### PR TITLE
feat(docs): add safe interactive playground

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,8 +178,8 @@ jobs:
         run: bun run --bun test
       - name: build packaged interaction test target
         run: BASE_PATH=/ggsvelte bun run build:docs
-      - name: interaction accessibility, keyboard, and touch journeys
-        run: bun run test:visual -- interaction-accessibility.spec.ts
+      - name: interaction and safe-playground accessibility journeys
+        run: bun run test:visual -- interaction-accessibility.spec.ts playground.spec.ts
       - name: interaction performance p50/p95 gate
         run: bun run test:interaction-perf
       - name: upload browser traces, screenshots, and reports on failure

--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ tested with npm, pnpm, and Bun on Ubuntu and Windows; see the
 
 Try [inspection and pinning](https://ljodea.github.io/ggsvelte/examples/interaction/tooltip)
 or [interval selection and zoom](https://ljodea.github.io/ggsvelte/examples/interaction/brush-zoom),
-then read the [interaction guide and event reference](https://ljodea.github.io/ggsvelte/guide/interactions).
+bring [your own local JSON rows to the playground](https://ljodea.github.io/ggsvelte/playground),
+then read the [interaction guide](https://ljodea.github.io/ggsvelte/guide/interactions)
+or [searchable event reference](https://ljodea.github.io/ggsvelte/reference/interactions).
 
 ## One spec, three surfaces
 
@@ -129,6 +131,7 @@ CLI: `ggsvelte-render spec.json > chart.svg` (JSON-line diagnostics on stderr).
 
 - [Guide and examples](https://ljodea.github.io/ggsvelte/)
 - [Interactions and event reference](https://ljodea.github.io/ggsvelte/guide/interactions)
+- [Local data playground](https://ljodea.github.io/ggsvelte/playground)
 - [Pre-0.1 interaction migration](https://ljodea.github.io/ggsvelte/guide/migrating-pre-0-1)
 - [Lifecycle and editions](https://ljodea.github.io/ggsvelte/guide/lifecycle)
 

--- a/apps/docs/src/app.css
+++ b/apps/docs/src/app.css
@@ -96,8 +96,19 @@ pre {
   margin: 0 auto;
   padding: 0.75rem 1.5rem;
   display: flex;
+  flex-wrap: wrap;
   align-items: baseline;
   gap: 1.25rem;
+}
+
+@media (max-width: 32rem) {
+  .site-chrome nav {
+    gap: 0.55rem 1rem;
+  }
+
+  .site-chrome .brand {
+    flex-basis: 100%;
+  }
 }
 
 .site-chrome .brand {

--- a/apps/docs/src/lib/Playground.svelte
+++ b/apps/docs/src/lib/Playground.svelte
@@ -1,0 +1,544 @@
+<script lang="ts">
+  import { tick } from "svelte";
+
+  import { GGPlot } from "ggsvelte";
+  import type {
+    AesInput,
+    InteractionDiagnostic,
+    LayerInput,
+    PlotInteractionEvent,
+  } from "ggsvelte";
+
+  import {
+    inferPlaygroundFields,
+    parsePlaygroundData,
+    PlaygroundDataError,
+    recommendPlaygroundFields,
+    PLAYGROUND_MAX_BYTES,
+    PLAYGROUND_MAX_FIELDS,
+    PLAYGROUND_MAX_ROWS,
+    type PlaygroundField,
+    type PlaygroundRow,
+  } from "./playground-data";
+
+  type Mark = "point" | "line" | "col";
+
+  const sampleRows: PlaygroundRow[] = [
+    { id: "a1", species: "Adelie", flipper: 181, mass: 3750 },
+    { id: "a2", species: "Adelie", flipper: 186, mass: 3800 },
+    { id: "c1", species: "Chinstrap", flipper: 196, mass: 4050 },
+    { id: "c2", species: "Chinstrap", flipper: 201, mass: 4300 },
+    { id: "g1", species: "Gentoo", flipper: 211, mass: 5000 },
+    { id: "g2", species: "Gentoo", flipper: 221, mass: 5550 },
+  ];
+  const sampleSource = JSON.stringify(sampleRows, null, 2);
+
+  let draft = $state(sampleSource);
+  let rows = $state<PlaygroundRow[]>(sampleRows);
+  let fields = $state<PlaygroundField[]>(inferPlaygroundFields(sampleRows));
+  let xField = $state("flipper");
+  let yField = $state("mass");
+  let colorField = $state("species");
+  let keyField = $state("id");
+  let mark = $state<Mark>("point");
+  let inspectEnabled = $state(false);
+  let selectEnabled = $state(false);
+  let zoomEnabled = $state(false);
+  let revision = $state(0);
+  let errorMessage = $state("");
+  let errorFix = $state("");
+  let lastGoodPreviewShown = $state(true);
+  let status = $state(
+    "Sample data ready. Choose interaction options or paste your own rows.",
+  );
+  let eventLog = $state<string[]>([]);
+  let alertElement = $state<HTMLDivElement>();
+
+  const numericFields = $derived(
+    fields.filter((field) => field.kind === "number"),
+  );
+  const yFields = $derived(numericFields.length > 0 ? numericFields : fields);
+  const renderKey = $derived(
+    [
+      revision,
+      mark,
+      xField,
+      yField,
+      colorField,
+      keyField,
+      inspectEnabled,
+      selectEnabled,
+      zoomEnabled,
+    ].join("|"),
+  );
+  const aes = $derived.by(() => {
+    const mapping: Record<string, string> = { x: xField, y: yField };
+    if (colorField !== "") mapping.color = colorField;
+    return mapping as AesInput;
+  });
+  const layers = $derived.by(
+    () =>
+      [
+        mark === "point"
+          ? { geom: "point", params: { size: 4, alpha: 0.82 } }
+          : mark === "line"
+            ? { geom: "line", params: { linewidth: 1.6 } }
+            : { geom: "col" },
+      ] as LayerInput[],
+  );
+
+  function logEvent(
+    event: PlotInteractionEvent<PlaygroundRow, PropertyKey>,
+  ): void {
+    const detail =
+      event.type === "inspect" && event.phase !== "clear"
+        ? `${event.state}, ${String(event.members.length)} member${event.members.length === 1 ? "" : "s"}`
+        : event.type === "select" && event.phase !== "start"
+          ? `${String(event.keys.length)} key${event.keys.length === 1 ? "" : "s"}`
+          : event.type === "zoom" && event.phase === "end"
+            ? "domains updated"
+            : "";
+    const entry = `${event.type} · ${event.phase} · ${event.source}${detail === "" ? "" : ` · ${detail}`}`;
+    if (
+      event.type === "inspect" &&
+      event.phase === "change" &&
+      eventLog[0]?.startsWith("inspect · change")
+    ) {
+      eventLog = [entry, ...eventLog.slice(1)];
+    } else {
+      eventLog = [entry, ...eventLog].slice(0, 12);
+    }
+  }
+
+  function reportDiagnostic(diagnostic: InteractionDiagnostic): void {
+    status = `${diagnostic.code}: ${diagnostic.message} ${diagnostic.suggestions.join("; ")}`;
+  }
+
+  async function showError(error: unknown, preserved = true): Promise<void> {
+    errorMessage =
+      error instanceof Error ? error.message : "The data could not be applied.";
+    errorFix =
+      error instanceof PlaygroundDataError
+        ? error.fix
+        : "Keep the last working preview, adjust the data, and try again.";
+    lastGoodPreviewShown = preserved;
+    await tick();
+    alertElement?.focus();
+  }
+
+  async function applyData(): Promise<void> {
+    try {
+      const parsed = parsePlaygroundData(draft);
+      const nextFields = inferPlaygroundFields(parsed.rows);
+      if (nextFields.length < 2) {
+        throw new PlaygroundDataError(
+          "INVALID_ROW",
+          "The playground needs at least two named fields to draw a chart.",
+          "Add another field to each row, then apply the data again.",
+        );
+      }
+      const recommended = recommendPlaygroundFields(nextFields);
+      rows = parsed.rows;
+      fields = nextFields;
+      xField = recommended.x;
+      yField = recommended.y;
+      colorField = recommended.color;
+      keyField = recommended.key;
+      revision += 1;
+      eventLog = [];
+      errorMessage = "";
+      errorFix = "";
+      lastGoodPreviewShown = true;
+      status = `Applied ${String(rows.length)} local row${rows.length === 1 ? "" : "s"}. Nothing was uploaded.`;
+    } catch (error) {
+      await showError(error);
+    }
+  }
+
+  function resetSample(): void {
+    draft = sampleSource;
+    void applyData();
+  }
+
+  function rendererFailed(error: unknown): void {
+    void showError(error, false);
+  }
+</script>
+
+<section class="playground" aria-labelledby="playground-heading">
+  <div class="intro">
+    <p class="eyebrow">Local, bounded, no code execution</p>
+    <h1 id="playground-heading">Use my data</h1>
+    <p>
+      Paste a JSON array of ordinary row objects. The data stays in this browser
+      tab: ggsvelte does not upload it, store it, fetch remote URLs, or evaluate
+      JavaScript.
+    </p>
+  </div>
+
+  <div class="workspace">
+    <form
+      class="controls"
+      onsubmit={(event) => {
+        event.preventDefault();
+        void applyData();
+      }}
+    >
+      <label for="playground-data">JSON rows</label>
+      <textarea
+        id="playground-data"
+        aria-describedby="playground-limits"
+        bind:value={draft}
+        spellcheck="false"
+        rows="16"></textarea>
+      <p class="limits" id="playground-limits">
+        Up to {PLAYGROUND_MAX_ROWS.toLocaleString()} rows, {PLAYGROUND_MAX_FIELDS}
+        fields per row, and {PLAYGROUND_MAX_BYTES / 1024} KiB.
+      </p>
+      <div class="actions">
+        <button class="primary" type="submit">Apply data</button>
+        <button type="button" onclick={resetSample}>Reset sample</button>
+      </div>
+
+      {#if errorMessage !== ""}
+        <div class="error" role="alert" tabindex="-1" bind:this={alertElement}>
+          <strong>{errorMessage}</strong>
+          <span>{errorFix}</span>
+          <span>
+            {lastGoodPreviewShown
+              ? "The last working preview is still shown."
+              : "The renderer stopped safely. Reset the sample to restore the preview."}
+          </span>
+        </div>
+      {/if}
+    </form>
+
+    <section class="preview" aria-labelledby="preview-heading">
+      <div class="preview-heading">
+        <div>
+          <p class="eyebrow">Preview</p>
+          <h2 id="preview-heading">Build a chart</h2>
+        </div>
+        <p class="privacy-status" aria-live="polite">{status}</p>
+      </div>
+
+      <div class="field-controls">
+        <label>
+          Mark
+          <select bind:value={mark}>
+            <option value="point">Point</option>
+            <option value="line">Line</option>
+            <option value="col">Column</option>
+          </select>
+        </label>
+        <label>
+          X
+          <select bind:value={xField}>
+            {#each fields as field (field.name)}<option value={field.name}
+                >{field.name}</option
+              >{/each}
+          </select>
+        </label>
+        <label>
+          Y
+          <select bind:value={yField}>
+            {#each yFields as field (field.name)}<option value={field.name}
+                >{field.name}</option
+              >{/each}
+          </select>
+        </label>
+        <label>
+          Color
+          <select bind:value={colorField}>
+            <option value="">None</option>
+            {#each fields as field (field.name)}<option value={field.name}
+                >{field.name}</option
+              >{/each}
+          </select>
+        </label>
+        <label>
+          Stable key
+          <select bind:value={keyField}>
+            <option value="">None</option>
+            {#each fields as field (field.name)}<option value={field.name}
+                >{field.name}</option
+              >{/each}
+          </select>
+        </label>
+      </div>
+
+      <fieldset class="interaction-controls">
+        <legend>Interaction (opt in)</legend>
+        <label
+          ><input type="checkbox" bind:checked={inspectEnabled} /> Inspect + pin</label
+        >
+        <label
+          ><input type="checkbox" bind:checked={selectEnabled} /> Select area</label
+        >
+        <label
+          ><input type="checkbox" bind:checked={zoomEnabled} /> Zoom area</label
+        >
+      </fieldset>
+
+      <div class="chart-boundary">
+        {#key renderKey}
+          <svelte:boundary onerror={rendererFailed}>
+            <GGPlot
+              data={rows}
+              {aes}
+              {layers}
+              key={keyField === "" ? undefined : keyField}
+              inspect={inspectEnabled}
+              select={selectEnabled
+                ? { type: "interval", mode: "xy", persistent: true }
+                : false}
+              zoom={zoomEnabled ? { mode: "xy" } : false}
+              oninteraction={logEvent}
+              ondiagnostic={reportDiagnostic}
+              labs={{
+                title: "My local data",
+                x: xField,
+                y: yField,
+                color: colorField || undefined,
+              }}
+              width="container"
+              height={400}
+            />
+            {#snippet failed()}
+              <div class="render-error" role="status">
+                The new chart could not render. Adjust the field choices or
+                reset the sample.
+              </div>
+            {/snippet}
+          </svelte:boundary>
+        {/key}
+      </div>
+
+      <section class="event-log" aria-labelledby="event-log-heading">
+        <h3 id="event-log-heading">Semantic events</h3>
+        {#if eventLog.length === 0}
+          <p>
+            Opt into an interaction and use the plot. No raw rows are copied
+            into this log.
+          </p>
+        {:else}
+          <ol>
+            {#each eventLog as entry, index (`${entry}-${String(index)}`)}<li>
+                {entry}
+              </li>{/each}
+          </ol>
+        {/if}
+      </section>
+    </section>
+  </div>
+</section>
+
+<style>
+  .playground {
+    margin: 1rem 0 3rem;
+  }
+
+  .intro {
+    max-width: 48rem;
+  }
+
+  .intro h1,
+  .preview-heading h2 {
+    margin: 0.1rem 0 0.45rem;
+    line-height: 1.12;
+  }
+
+  .eyebrow {
+    margin: 0;
+    color: var(--muted);
+    font-size: 0.76rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .workspace {
+    display: grid;
+    grid-template-columns: minmax(16rem, 21rem) minmax(0, 1fr);
+    gap: 1.5rem;
+    margin-top: 1.5rem;
+    align-items: start;
+  }
+
+  .controls,
+  .preview {
+    min-width: 0;
+    border: 1px solid var(--border);
+    border-radius: 0.7rem;
+    background: var(--surface);
+    padding: 1rem;
+  }
+
+  .controls > label,
+  .field-controls label {
+    display: grid;
+    gap: 0.3rem;
+    font-weight: 650;
+  }
+
+  textarea,
+  select,
+  button {
+    min-height: 2.75rem;
+    border: 1px solid var(--border);
+    border-radius: 0.4rem;
+    background: var(--bg);
+    color: var(--fg);
+    font: inherit;
+  }
+
+  textarea {
+    width: 100%;
+    padding: 0.65rem;
+    resize: vertical;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 0.8rem;
+    line-height: 1.45;
+  }
+
+  select,
+  button {
+    padding: 0.45rem 0.65rem;
+  }
+
+  button {
+    cursor: pointer;
+    font-weight: 650;
+  }
+
+  button.primary {
+    border-color: var(--accent);
+    background: var(--accent);
+    color: white;
+  }
+
+  .limits,
+  .privacy-status,
+  .event-log p {
+    color: var(--muted);
+    font-size: 0.82rem;
+  }
+
+  .actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.55rem;
+  }
+
+  .error,
+  .render-error {
+    display: grid;
+    gap: 0.25rem;
+    margin-top: 0.85rem;
+    padding: 0.75rem;
+    border: 1px solid #b42318;
+    border-radius: 0.4rem;
+    background: color-mix(in srgb, #b42318 8%, var(--bg));
+  }
+
+  .preview-heading {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    align-items: start;
+  }
+
+  .privacy-status {
+    max-width: 22rem;
+    margin: 0;
+    text-align: right;
+  }
+
+  .field-controls {
+    display: grid;
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+    gap: 0.65rem;
+    margin: 1rem 0;
+  }
+
+  .field-controls select {
+    width: 100%;
+  }
+
+  .interaction-controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.65rem 1rem;
+    margin: 0 0 1rem;
+    border: 0;
+    padding: 0;
+  }
+
+  .interaction-controls legend {
+    width: 100%;
+    margin-bottom: 0.3rem;
+    font-weight: 700;
+  }
+
+  .interaction-controls label {
+    display: flex;
+    min-height: 2.75rem;
+    align-items: center;
+    gap: 0.45rem;
+  }
+
+  .interaction-controls input {
+    width: 1.15rem;
+    height: 1.15rem;
+  }
+
+  .chart-boundary {
+    min-height: 25rem;
+    overflow: hidden;
+    border-radius: 0.45rem;
+    background: var(--bg);
+  }
+
+  .event-log {
+    margin-top: 1rem;
+    border-top: 1px solid var(--border);
+    padding-top: 0.8rem;
+  }
+
+  .event-log h3 {
+    margin: 0;
+    font-size: 1rem;
+  }
+
+  .event-log ol {
+    margin: 0.5rem 0 0;
+    padding-left: 1.4rem;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 0.78rem;
+  }
+
+  @media (max-width: 58rem) {
+    .workspace {
+      grid-template-columns: 1fr;
+    }
+
+    .field-controls {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+
+  @media (max-width: 32rem) {
+    .preview-heading {
+      display: block;
+    }
+
+    .privacy-status {
+      margin-top: 0.5rem;
+      text-align: left;
+    }
+
+    .field-controls {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/apps/docs/src/lib/playground-data.ts
+++ b/apps/docs/src/lib/playground-data.ts
@@ -1,0 +1,256 @@
+export const PLAYGROUND_MAX_BYTES = 256 * 1024;
+export const PLAYGROUND_MAX_ROWS = 5_000;
+export const PLAYGROUND_MAX_FIELDS = 50;
+export const PLAYGROUND_MAX_FIELD_NAME_LENGTH = 128;
+export const PLAYGROUND_MAX_STRING_LENGTH = 10_000;
+
+const UNSAFE_FIELDS = new Set(["__proto__", "constructor", "prototype"]);
+
+export type PlaygroundCell = string | number | boolean | null;
+export type PlaygroundRow = Record<string, PlaygroundCell>;
+export type PlaygroundFieldKind = "number" | "text" | "boolean";
+
+export interface PlaygroundField {
+  name: string;
+  kind: PlaygroundFieldKind;
+}
+
+export interface RecommendedPlaygroundFields {
+  x: string;
+  y: string;
+  color: string;
+  key: string;
+}
+
+export interface ParsedPlaygroundData {
+  format: "json";
+  rows: PlaygroundRow[];
+}
+
+export type PlaygroundDataErrorCode =
+  | "EMPTY_INPUT"
+  | "INPUT_TOO_LARGE"
+  | "INVALID_JSON"
+  | "INVALID_ROOT"
+  | "EMPTY_DATA"
+  | "TOO_MANY_ROWS"
+  | "INVALID_ROW"
+  | "TOO_MANY_FIELDS"
+  | "INVALID_FIELD"
+  | "UNSAFE_FIELD"
+  | "INVALID_CELL"
+  | "STRING_TOO_LONG";
+
+export class PlaygroundDataError extends Error {
+  readonly code: PlaygroundDataErrorCode;
+  readonly fix: string;
+
+  constructor(code: PlaygroundDataErrorCode, message: string, fix: string) {
+    super(message);
+    this.name = "PlaygroundDataError";
+    this.code = code;
+    this.fix = fix;
+  }
+}
+
+function fail(code: PlaygroundDataErrorCode, message: string, fix: string): never {
+  throw new PlaygroundDataError(code, message, fix);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function copyRow(value: unknown, rowIndex: number): PlaygroundRow {
+  if (!isRecord(value)) {
+    fail(
+      "INVALID_ROW",
+      `Row ${String(rowIndex + 1)} must be a JSON object.`,
+      "Wrap each row in braces with named fields, then apply the data again.",
+    );
+  }
+
+  const entries = Object.entries(value);
+  if (entries.length > PLAYGROUND_MAX_FIELDS) {
+    fail(
+      "TOO_MANY_FIELDS",
+      `Row ${String(rowIndex + 1)} has too many fields; the playground limit is ${String(PLAYGROUND_MAX_FIELDS)}.`,
+      "Keep only the fields needed for this chart.",
+    );
+  }
+
+  const row: PlaygroundRow = {};
+  for (const [field, cell] of entries) {
+    if (field.length === 0) {
+      fail(
+        "INVALID_FIELD",
+        `Row ${String(rowIndex + 1)} field names cannot be empty.`,
+        "Give every field a short, visible name and apply the data again.",
+      );
+    }
+    if (field.length > PLAYGROUND_MAX_FIELD_NAME_LENGTH) {
+      fail(
+        "INVALID_FIELD",
+        `Row ${String(rowIndex + 1)} field name is too long; the playground limit is ${String(PLAYGROUND_MAX_FIELD_NAME_LENGTH)} characters.`,
+        "Shorten the field name and apply the data again.",
+      );
+    }
+    if (/\p{Cc}/u.test(field)) {
+      fail(
+        "INVALID_FIELD",
+        `Row ${String(rowIndex + 1)} field names cannot contain control characters.`,
+        "Remove line breaks and other control characters from field names.",
+      );
+    }
+    if (UNSAFE_FIELDS.has(field)) {
+      fail(
+        "UNSAFE_FIELD",
+        `Row ${String(rowIndex + 1)} uses the reserved field name ${JSON.stringify(field)}.`,
+        "Rename the field and apply the data again.",
+      );
+    }
+    if (
+      cell !== null &&
+      typeof cell !== "string" &&
+      typeof cell !== "number" &&
+      typeof cell !== "boolean"
+    ) {
+      fail(
+        "INVALID_CELL",
+        `Row ${String(rowIndex + 1)} field ${JSON.stringify(field)} must be a string, number, boolean, or null.`,
+        "Flatten nested values into ordinary fields before applying the data.",
+      );
+    }
+    if (typeof cell === "number" && !Number.isFinite(cell)) {
+      fail(
+        "INVALID_CELL",
+        `Row ${String(rowIndex + 1)} field ${JSON.stringify(field)} must be a finite number.`,
+        "Replace infinity or NaN with a finite number or null.",
+      );
+    }
+    if (typeof cell === "string" && cell.length > PLAYGROUND_MAX_STRING_LENGTH) {
+      fail(
+        "STRING_TOO_LONG",
+        `Row ${String(rowIndex + 1)} field ${JSON.stringify(field)} is too long.`,
+        `Shorten the value to ${String(PLAYGROUND_MAX_STRING_LENGTH)} characters or fewer.`,
+      );
+    }
+    row[field] = cell;
+  }
+  return row;
+}
+
+/** Parse bounded, local-only JSON rows. This function never evaluates code. */
+export function parsePlaygroundData(source: string): ParsedPlaygroundData {
+  // A UTF-16 code unit is never smaller than one UTF-8 byte. Reject obviously
+  // oversized strings before allocating a trimmed copy or encoded byte array.
+  if (source.length > PLAYGROUND_MAX_BYTES) {
+    fail(
+      "INPUT_TOO_LARGE",
+      `The pasted data is too large; the playground limit is ${String(PLAYGROUND_MAX_BYTES / 1024)} KiB.`,
+      "Use a smaller sample locally; the playground does not upload or stream data.",
+    );
+  }
+  const bytes = new TextEncoder().encode(source).byteLength;
+  if (bytes > PLAYGROUND_MAX_BYTES) {
+    fail(
+      "INPUT_TOO_LARGE",
+      `The pasted data is too large; the playground limit is ${String(PLAYGROUND_MAX_BYTES / 1024)} KiB.`,
+      "Use a smaller sample locally; the playground does not upload or stream data.",
+    );
+  }
+  const trimmed = source.trim();
+  if (trimmed === "") {
+    fail(
+      "EMPTY_INPUT",
+      "Paste a JSON array of rows before applying data.",
+      'Try the sample format: [{"x": 1, "y": 2}].',
+    );
+  }
+
+  let decoded: unknown;
+  try {
+    decoded = JSON.parse(trimmed) as unknown;
+  } catch (error) {
+    const detail =
+      error instanceof Error
+        ? error.message.replace(/^JSON Parse error:\s*/u, "").slice(0, 180)
+        : "";
+    fail(
+      "INVALID_JSON",
+      `The pasted data is not valid JSON${detail === "" ? "." : `: ${detail}`}`,
+      "Check quotes, commas, and brackets, then apply the data again.",
+    );
+  }
+
+  if (!Array.isArray(decoded)) {
+    fail(
+      "INVALID_ROOT",
+      "JSON data must be an array of row objects.",
+      'Wrap the rows in square brackets: [{"x": 1, "y": 2}].',
+    );
+  }
+  if (decoded.length === 0) {
+    fail("EMPTY_DATA", "JSON data needs at least one row.", "Add one or more row objects.");
+  }
+  if (decoded.length > PLAYGROUND_MAX_ROWS) {
+    fail(
+      "TOO_MANY_ROWS",
+      `The dataset has too many rows; the playground limit is ${String(PLAYGROUND_MAX_ROWS)}.`,
+      "Use a representative sample for the browser playground.",
+    );
+  }
+
+  return {
+    format: "json",
+    rows: decoded.map((row, index) => copyRow(row, index)),
+  };
+}
+
+/** Preserve first-seen field order and infer only the kinds needed by controls. */
+export function inferPlaygroundFields(rows: readonly PlaygroundRow[]): PlaygroundField[] {
+  const names: string[] = [];
+  const seen = new Set<string>();
+  for (const row of rows) {
+    for (const name of Object.keys(row)) {
+      if (!seen.has(name)) {
+        seen.add(name);
+        names.push(name);
+      }
+    }
+  }
+
+  return names.map((name) => {
+    const values = rows
+      .map((row) => row[name])
+      .filter((value) => value !== null && value !== undefined);
+    const kind: PlaygroundFieldKind =
+      values.length > 0 && values.every((value) => typeof value === "number")
+        ? "number"
+        : values.length > 0 && values.every((value) => typeof value === "boolean")
+          ? "boolean"
+          : "text";
+    return { name, kind };
+  });
+}
+
+export function recommendPlaygroundFields(
+  fields: readonly PlaygroundField[],
+): RecommendedPlaygroundFields {
+  const numbers = fields.filter((field) => field.kind === "number");
+  const categories = fields.filter((field) => field.kind !== "number");
+  const x =
+    numbers.length >= 2
+      ? (numbers[0]?.name ?? "")
+      : (categories.find((field) => field.name !== "id")?.name ?? fields[0]?.name ?? "");
+  const y =
+    numbers.length > 0
+      ? (numbers[Math.min(1, numbers.length - 1)]?.name ?? "")
+      : (fields[1]?.name ?? x);
+  return {
+    x,
+    y,
+    color: categories.find((field) => field.name !== "id")?.name ?? "",
+    key: fields.find((field) => field.name === "id")?.name ?? "",
+  };
+}

--- a/apps/docs/src/routes/+layout.svelte
+++ b/apps/docs/src/routes/+layout.svelte
@@ -16,6 +16,7 @@
     <a class="brand" href={`${base}/`}>ggsvelte</a>
     <a href={`${base}/guide/getting-started`}>Guide</a>
     <a href={`${base}/examples`}>Examples</a>
+    <a href={`${base}/playground`}>Playground</a>
     <a href="https://github.com/ljodea/ggsvelte" rel="external">GitHub</a>
   </nav>
 </header>

--- a/apps/docs/src/routes/+page.svelte
+++ b/apps/docs/src/routes/+page.svelte
@@ -26,7 +26,11 @@
     &nbsp;·&nbsp;
     <a href={`${base}/examples`}>Browse the example gallery →</a>
     &nbsp;·&nbsp;
-    <a href={`${base}/guide/interactions`}>Add interaction →</a>
+    <a href={`${base}/examples/interactions/inspection`}
+      >Inspect a live plot →</a
+    >
+    &nbsp;·&nbsp;
+    <a href={`${base}/playground`}>Use my data →</a>
   </p>
   <p>
     Agents: <a href={`${base}/schema/v0.json`}>JSON Schema</a> ·
@@ -34,6 +38,27 @@
     <a href={`${base}/llms-full.txt`}>llms-full.txt</a> ·
     <a href={`${base}/guide/errors`}>error catalog</a>
   </p>
+</section>
+
+<section class="next-steps" aria-labelledby="interactive-heading">
+  <div>
+    <p class="eyebrow">Interactive, only when you ask</p>
+    <h2 id="interactive-heading">Start static. Opt into useful behavior.</h2>
+    <p>
+      Add inspection, a clean HTML tooltip and crosshair, stable selection, or
+      brush zoom without changing the chart grammar. Events report data meaning,
+      not renderer indices.
+    </p>
+  </div>
+  <nav aria-label="Interactive starting points">
+    <a href={`${base}/examples/interactions/inspection`}
+      >Try inspection and pinning</a
+    >
+    <a href={`${base}/examples/interactions/interval-selection`}
+      >Try selection and zoom</a
+    >
+    <a href={`${base}/reference/interactions`}>Search the event reference</a>
+  </nav>
 </section>
 
 <section class="demo">
@@ -52,5 +77,46 @@
 
   .demo {
     margin: 2rem 0;
+  }
+
+  .next-steps {
+    display: grid;
+    grid-template-columns: minmax(0, 1.5fr) minmax(14rem, 1fr);
+    gap: 2rem;
+    margin: 2.5rem 0;
+    padding: 1.25rem;
+    border: 1px solid var(--border);
+    border-radius: 0.65rem;
+    background: var(--surface);
+  }
+
+  .next-steps h2 {
+    margin: 0.15rem 0 0.45rem;
+  }
+
+  .next-steps p:last-child {
+    margin-bottom: 0;
+  }
+
+  .next-steps nav {
+    display: grid;
+    align-content: center;
+    gap: 0.7rem;
+  }
+
+  .eyebrow {
+    margin: 0;
+    color: var(--muted);
+    font-size: 0.76rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  @media (max-width: 42rem) {
+    .next-steps {
+      grid-template-columns: 1fr;
+      gap: 1rem;
+    }
   }
 </style>

--- a/apps/docs/src/routes/playground/+page.svelte
+++ b/apps/docs/src/routes/playground/+page.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+  import Playground from "$lib/Playground.svelte";
+</script>
+
+<svelte:head>
+  <title>Use my data — ggsvelte playground</title>
+  <meta
+    name="description"
+    content="Build a local ggsvelte chart from bounded JSON rows, then opt into inspection, interval selection, and zoom."
+  />
+</svelte:head>
+
+<Playground />

--- a/apps/docs/src/routes/reference/interactions/+page.svelte
+++ b/apps/docs/src/routes/reference/interactions/+page.svelte
@@ -1,0 +1,152 @@
+<script lang="ts">
+  import { base } from "$app/paths";
+
+  import { INTERACTION_REFERENCE_INDEX } from "$scripts/gen-llms";
+
+  let query = $state("");
+  const normalizedQuery = $derived(query.trim().toLocaleLowerCase());
+  const results = $derived(
+    normalizedQuery === ""
+      ? INTERACTION_REFERENCE_INDEX
+      : INTERACTION_REFERENCE_INDEX.filter((entry) =>
+          [entry.name, entry.summary, ...entry.keywords]
+            .join(" ")
+            .toLocaleLowerCase()
+            .includes(normalizedQuery),
+        ),
+  );
+</script>
+
+<svelte:head>
+  <title>Search interaction reference — ggsvelte</title>
+  <meta
+    name="description"
+    content="Search ggsvelte interaction capabilities, events, diagnostics, and accessibility defaults."
+  />
+</svelte:head>
+
+<main class="reference-search" aria-labelledby="reference-heading">
+  <p class="eyebrow">v0.1 chart-local API</p>
+  <h1 id="reference-heading">Search interaction reference</h1>
+  <p class="intro">
+    Find the exact opt-in prop, callback, event phase, diagnostic, or keyboard
+    behavior. The linked-chart controller is planned for R1 and is not part of
+    this reference.
+  </p>
+
+  <label for="interaction-search">Search capabilities and events</label>
+  <input
+    id="interaction-search"
+    type="search"
+    bind:value={query}
+    placeholder="Try tooltip, brush, diagnostic, or keyboard"
+    autocomplete="off"
+  />
+
+  <p class="count" aria-live="polite">
+    {results.length}
+    {results.length === 1 ? "result" : "results"}
+  </p>
+
+  {#if results.length === 0}
+    <p class="empty">
+      No exact match. Try a capability, callback, or input method.
+    </p>
+  {:else}
+    <ul class="results">
+      {#each results as entry (entry.id)}
+        <li>
+          <a href={`${base}${entry.href}`}>
+            <strong>{entry.name}</strong>
+            <span>{entry.summary}</span>
+          </a>
+        </li>
+      {/each}
+    </ul>
+  {/if}
+</main>
+
+<style>
+  .reference-search {
+    max-width: 52rem;
+    margin: 2rem 0 4rem;
+  }
+
+  h1 {
+    margin: 0.15rem 0 0.6rem;
+  }
+
+  .intro {
+    max-width: 44rem;
+  }
+
+  .eyebrow {
+    margin: 0;
+    color: var(--muted);
+    font-size: 0.76rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  label {
+    display: block;
+    margin-top: 1.5rem;
+    font-weight: 650;
+  }
+
+  input {
+    width: min(100%, 40rem);
+    min-height: 44px;
+    margin-top: 0.4rem;
+    border: 1px solid var(--border);
+    border-radius: 0.45rem;
+    background: var(--surface);
+    color: inherit;
+    padding: 0.65rem 0.75rem;
+    font: inherit;
+  }
+
+  input:focus-visible {
+    outline: 3px solid color-mix(in srgb, var(--accent) 45%, transparent);
+    outline-offset: 2px;
+  }
+
+  .count {
+    color: var(--muted);
+  }
+
+  .results {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.75rem;
+    padding: 0;
+    list-style: none;
+  }
+
+  .results a {
+    display: grid;
+    gap: 0.3rem;
+    height: 100%;
+    border: 1px solid var(--border);
+    border-radius: 0.55rem;
+    padding: 0.9rem;
+    color: inherit;
+    text-decoration: none;
+  }
+
+  .results a:hover {
+    border-color: var(--accent);
+  }
+
+  .results span,
+  .empty {
+    color: var(--muted);
+  }
+
+  @media (max-width: 38rem) {
+    .results {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/packages/svelte/src/lib/interaction.ts
+++ b/packages/svelte/src/lib/interaction.ts
@@ -147,7 +147,8 @@ export const INTERACTION_DIAGNOSTIC_CATALOG: Readonly<
     message: "Interval selection and brush zoom currently require one unfaceted panel.",
     prop: "select",
     suggestions: ["Remove the facet", "Use point inspection", "Track facet intervals in issue #3"],
-    docUrl: "https://ljodea.github.io/ggsvelte/guide/interactions",
+    docUrl:
+      "https://ljodea.github.io/ggsvelte/guide/interaction-reference#interaction-interval-facet-unsupported",
   },
   INTERACTION_INVALID_MAX_DISTANCE: {
     severity: "error",
@@ -155,7 +156,8 @@ export const INTERACTION_DIAGNOSTIC_CATALOG: Readonly<
     message: "inspect.maxDistance must be a finite non-negative CSS-pixel distance.",
     prop: "inspect.maxDistance",
     suggestions: ["Use a finite number greater than or equal to zero"],
-    docUrl: "https://ljodea.github.io/ggsvelte/guide/interactions#inspection",
+    docUrl:
+      "https://ljodea.github.io/ggsvelte/guide/interaction-reference#interaction-invalid-max-distance",
   },
   INTERACTION_POINT_REQUIRES_KEY: {
     severity: "warning",
@@ -163,7 +165,8 @@ export const INTERACTION_DIAGNOSTIC_CATALOG: Readonly<
     message: "Durable point selection requires a stable key field or accessor.",
     prop: "key",
     suggestions: ['Pass key="id"', "Pass a stable key accessor"],
-    docUrl: "https://ljodea.github.io/ggsvelte/guide/interactions#identity",
+    docUrl:
+      "https://ljodea.github.io/ggsvelte/guide/interaction-reference#interaction-point-requires-key",
   },
   INTERACTION_INVALID_KEY: {
     severity: "error",
@@ -171,7 +174,7 @@ export const INTERACTION_DIAGNOSTIC_CATALOG: Readonly<
     message: "A key accessor returned null, undefined, or a non-PropertyKey value.",
     prop: "key",
     suggestions: ["Return a stable string, number, or symbol for every row"],
-    docUrl: "https://ljodea.github.io/ggsvelte/guide/interactions#identity",
+    docUrl: "https://ljodea.github.io/ggsvelte/guide/interaction-reference#interaction-invalid-key",
   },
   INTERACTION_DUPLICATE_KEY: {
     severity: "error",
@@ -180,7 +183,8 @@ export const INTERACTION_DIAGNOSTIC_CATALOG: Readonly<
       "The key accessor returned a duplicate value; durable interaction is disabled for that value.",
     prop: "key",
     suggestions: ["Use a field that uniquely identifies each source row"],
-    docUrl: "https://ljodea.github.io/ggsvelte/guide/interactions#identity",
+    docUrl:
+      "https://ljodea.github.io/ggsvelte/guide/interaction-reference#interaction-duplicate-key",
   },
   INTERACTION_UNSTABLE_KEY: {
     severity: "error",
@@ -188,7 +192,8 @@ export const INTERACTION_DIAGNOSTIC_CATALOG: Readonly<
     message: "The key accessor returned a different value for the same source row.",
     prop: "key",
     suggestions: ["Return an immutable field that uniquely identifies each row"],
-    docUrl: "https://ljodea.github.io/ggsvelte/guide/interactions#identity",
+    docUrl:
+      "https://ljodea.github.io/ggsvelte/guide/interaction-reference#interaction-unstable-key",
   },
   INTERACTION_MISSING_LINEAGE: {
     severity: "warning",
@@ -196,7 +201,8 @@ export const INTERACTION_DIAGNOSTIC_CATALOG: Readonly<
     message: "A synthetic or aggregate mark did not expose source-row lineage.",
     prop: "layers",
     suggestions: ["Use a stat that preserves source-row lineage"],
-    docUrl: "https://ljodea.github.io/ggsvelte/guide/interactions#identity",
+    docUrl:
+      "https://ljodea.github.io/ggsvelte/guide/interaction-reference#interaction-missing-lineage",
   },
   INTERACTION_INTERVAL_SCALE_UNSUPPORTED: {
     severity: "warning",
@@ -204,7 +210,8 @@ export const INTERACTION_DIAGNOSTIC_CATALOG: Readonly<
     message: "Interval domains and brush zoom require continuous linear, log, or time scales.",
     prop: "scales",
     suggestions: ["Use a continuous positional scale", "Use point inspection for band data"],
-    docUrl: "https://ljodea.github.io/ggsvelte/guide/interactions#intervals",
+    docUrl:
+      "https://ljodea.github.io/ggsvelte/guide/interaction-reference#interaction-interval-scale-unsupported",
   },
   INTERACTION_TOOL_UNAVAILABLE: {
     severity: "warning",
@@ -212,7 +219,8 @@ export const INTERACTION_DIAGNOSTIC_CATALOG: Readonly<
     message: "The requested interaction tool is unavailable for the enabled capabilities.",
     prop: "tool",
     suggestions: ["Enable the matching capability", "Choose an available interaction tool"],
-    docUrl: "https://ljodea.github.io/ggsvelte/guide/interactions#tools",
+    docUrl:
+      "https://ljodea.github.io/ggsvelte/guide/interaction-reference#interaction-tool-unavailable",
   },
 });
 

--- a/scripts/check-pages-links.test.ts
+++ b/scripts/check-pages-links.test.ts
@@ -3,13 +3,21 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
-import { checkPackedPages, findBrokenLinks, requiredPages } from "./check-pages-links.ts";
+import {
+  checkPackedPages,
+  findBrokenFragments,
+  findBrokenLinks,
+  requiredPages,
+} from "./check-pages-links.ts";
 
 describe("packed Pages link checks", () => {
   const files = new Set([
     "index.html",
     "guide/interactions.html",
+    "guide/interaction-reference.html",
     "guide/migrating-pre-0-1.html",
+    "playground.html",
+    "reference/interactions.html",
     "examples/interaction/tooltip.html",
     "examples/interaction/brush-zoom.html",
     "examples/interactions/inspection.html",
@@ -47,10 +55,28 @@ describe("packed Pages link checks", () => {
     ).toEqual(["../../guide/missing"]);
   });
 
-  it("requires both R0 examples, guides, and agent endpoints in the packed site", () => {
+  it("validates same-page and cross-page heading fragments", () => {
+    const anchors = new Map([
+      ["guide/interactions.html", new Set(["inspection", "brush-zoom"])],
+      ["guide/interaction-reference.html", new Set(["oninspect", "ondiagnostic"])],
+    ]);
+    expect(
+      findBrokenFragments(
+        "guide/interactions.html",
+        ["#inspection", "./interaction-reference#oninspect", "#missing"],
+        files,
+        anchors,
+      ),
+    ).toEqual(["#missing"]);
+  });
+
+  it("requires the playground, R0 examples, guides, and agent endpoints in the packed site", () => {
     for (const page of requiredPages) expect(files.has(page)).toBe(true);
     expect(requiredPages).toContain("examples/interactions/inspection.html");
     expect(requiredPages).toContain("examples/interactions/interval-selection.html");
+    expect(requiredPages).toContain("playground.html");
+    expect(requiredPages).toContain("reference/interactions.html");
+    expect(requiredPages).toContain("guide/interaction-reference.html");
   });
 
   it("reports a missing packed directory and every absent required page", () => {

--- a/scripts/check-pages-links.ts
+++ b/scripts/check-pages-links.ts
@@ -4,7 +4,10 @@ import { posix, resolve } from "node:path";
 
 export const requiredPages = [
   "guide/interactions.html",
+  "guide/interaction-reference.html",
   "guide/migrating-pre-0-1.html",
+  "playground.html",
+  "reference/interactions.html",
   "examples/interaction/tooltip.html",
   "examples/interaction/brush-zoom.html",
   "examples/interactions/inspection.html",
@@ -47,6 +50,33 @@ export function findBrokenLinks(
   });
 }
 
+/** Return internal hrefs whose target exists but whose fragment id does not. */
+export function findBrokenFragments(
+  sourcePath: string,
+  hrefs: readonly string[],
+  files: ReadonlySet<string>,
+  anchors: ReadonlyMap<string, ReadonlySet<string>>,
+): string[] {
+  return hrefs.filter((href) => {
+    const hashIndex = href.indexOf("#");
+    if (hashIndex < 0 || hashIndex === href.length - 1) return false;
+    const beforeHash = href.slice(0, hashIndex);
+    if (beforeHash.startsWith("//") || EXTERNAL_PROTOCOL.test(beforeHash)) return false;
+
+    let fragment: string;
+    try {
+      fragment = decodeURIComponent(href.slice(hashIndex + 1));
+    } catch {
+      return true;
+    }
+    const target = beforeHash === "" ? sourcePath : targetPath(sourcePath, beforeHash);
+    if (target === null) return false;
+    const page = candidates(target).find((candidate) => files.has(candidate));
+    if (page === undefined || !page.endsWith(".html")) return false;
+    return !(anchors.get(page)?.has(fragment) ?? false);
+  });
+}
+
 function listFiles(root: string, directory = root): string[] {
   return readdirSync(directory).flatMap((name) => {
     const absolute = resolve(directory, name);
@@ -59,18 +89,36 @@ function listFiles(root: string, directory = root): string[] {
 export function checkPackedPages(buildDirectory: string): string[] {
   if (!existsSync(buildDirectory)) return [`packed Pages directory is missing: ${buildDirectory}`];
   const files = new Set(listFiles(buildDirectory));
+  const htmlByPath = new Map<string, string>();
+  const anchors = new Map<string, ReadonlySet<string>>();
+  for (const path of files) {
+    if (!path.endsWith(".html")) continue;
+    const html = readFileSync(resolve(buildDirectory, path), "utf8");
+    htmlByPath.set(path, html);
+    anchors.set(
+      path,
+      new Set(
+        [...html.matchAll(/\bid=(?:"([^"]*)"|'([^']*)')/gi)].map(
+          (match) => match[1] ?? match[2] ?? "",
+        ),
+      ),
+    );
+  }
   const problems = requiredPages
     .filter((page) => !files.has(page))
     .map((page) => `missing required page: ${page}`);
 
   for (const sourcePath of files) {
     if (!sourcePath.endsWith(".html")) continue;
-    const html = readFileSync(resolve(buildDirectory, sourcePath), "utf8");
+    const html = htmlByPath.get(sourcePath) ?? "";
     const hrefs = [...html.matchAll(/\bhref=(?:"([^"]*)"|'([^']*)')/gi)].map(
       (match) => match[1] ?? match[2] ?? "",
     );
     for (const href of findBrokenLinks(sourcePath, hrefs, files)) {
       problems.push(`${sourcePath}: broken href ${JSON.stringify(href)}`);
+    }
+    for (const href of findBrokenFragments(sourcePath, hrefs, files, anchors)) {
+      problems.push(`${sourcePath}: broken fragment ${JSON.stringify(href)}`);
     }
   }
   return problems;

--- a/scripts/gen-llms.test.ts
+++ b/scripts/gen-llms.test.ts
@@ -10,6 +10,7 @@ import { join } from "node:path";
 
 import { ADVISORY_CATALOG, PIPELINE_ERROR_CATALOG, PIPELINE_WARNING_CATALOG } from "@ggsvelte/core";
 import { ERROR_CATALOG, LINT_CATALOG } from "@ggsvelte/spec";
+import { INTERACTION_DIAGNOSTIC_CATALOG } from "../packages/svelte/src/lib/interaction.ts";
 
 import { EXAMPLES } from "../examples/manifest.ts";
 import type { LifecycleDoc } from "./gen-llms.ts";
@@ -22,6 +23,8 @@ import {
   GETTING_STARTED_MD,
   COMPATIBILITY_MD,
   INTERACTIONS_MD,
+  INTERACTION_REFERENCE_MD,
+  INTERACTION_REFERENCE_INDEX,
   MIGRATING_PRE_0_1_MD,
   guidePages,
   pruneSpecData,
@@ -37,7 +40,7 @@ describe("renderMarkdown", () => {
     const html = renderMarkdown(
       "# T\n\npara with `code` and [x](/y)\n\n- a\n- b\n\n```ts\nconst a = 1 < 2;\n```\n",
     );
-    expect(html).toContain("<h1>T</h1>");
+    expect(html).toContain('<h1 id="t">T</h1>');
     expect(html).toContain('<p>para with <code>code</code> and <a href="/y">x</a></p>');
     expect(html).toContain("<ul><li>a</li><li>b</li></ul>");
     expect(html).toContain('<pre><code class="language-ts">const a = 1 &lt; 2;</code></pre>');
@@ -54,6 +57,13 @@ describe("renderMarkdown", () => {
     );
     expect(html).toContain('href="/ggsvelte/guide/errors"');
     expect(html).toContain('href="https://example.com"');
+  });
+
+  it("adds stable unique heading fragments", () => {
+    const html = renderMarkdown("# Events\n\n## `onselect` event\n\n## `onselect` event");
+    expect(html).toContain('<h1 id="events">Events</h1>');
+    expect(html).toContain('<h2 id="onselect-event"><code>onselect</code> event</h2>');
+    expect(html).toContain('<h2 id="onselect-event-2"><code>onselect</code> event</h2>');
   });
 });
 
@@ -96,6 +106,10 @@ describe("guide sections cover their catalogs", () => {
   });
 
   it("documents the complete interaction capability and event contracts", () => {
+    expect(INTERACTIONS_MD).toContain("chart-local callbacks");
+    expect(INTERACTIONS_MD).toContain("controller and linked-chart API is planned for R1");
+    expect(INTERACTIONS_MD).toContain("/examples/interactions/inspection");
+    expect(INTERACTIONS_MD).toContain("/playground");
     expect(INTERACTIONS_MD).toContain('inspect={{ mode: "x",');
     expect(INTERACTIONS_MD).toContain('select={{ type: "interval", mode: "xy",');
     expect(INTERACTIONS_MD).toContain('key="id"');
@@ -105,6 +119,50 @@ describe("guide sections cover their catalogs", () => {
     expect(INTERACTIONS_MD).toContain('phase: "clear"');
     expect(INTERACTIONS_MD).toContain('type: "zoom"');
     expect(INTERACTIONS_MD).toContain("INTERACTION_INTERVAL_FACET_UNSUPPORTED");
+  });
+
+  it("publishes a dedicated interaction capability and event reference", () => {
+    for (const term of [
+      "inspect",
+      "point selection",
+      "interval selection",
+      "zoom",
+      "tool",
+      "oninspect",
+      "onselect",
+      "onzoom",
+      "oninteraction",
+      "ondiagnostic",
+    ]) {
+      expect(INTERACTION_REFERENCE_MD.toLowerCase()).toContain(term);
+    }
+    expect(INTERACTION_REFERENCE_MD).toContain("INTERACTION_TOOL_UNAVAILABLE");
+    expect(INTERACTION_REFERENCE_MD).toContain("chart-local");
+    const html = renderMarkdown(INTERACTION_REFERENCE_MD);
+    for (const diagnostic of Object.values(INTERACTION_DIAGNOSTIC_CATALOG)) {
+      const fragment = diagnostic.docUrl.split("#")[1];
+      expect(diagnostic.docUrl).toContain("/guide/interaction-reference#");
+      expect(html).toContain(`id="${fragment}"`);
+    }
+  });
+
+  it("exposes an exact searchable interaction index", () => {
+    expect(INTERACTION_REFERENCE_INDEX.map((entry) => entry.id)).toEqual([
+      "static-default",
+      "inspect",
+      "point-selection",
+      "interval-selection",
+      "zoom",
+      "controlled-tool",
+      "identity",
+      "events",
+      "diagnostics",
+      "accessibility",
+    ]);
+    for (const entry of INTERACTION_REFERENCE_INDEX) {
+      expect(entry.summary.length).toBeGreaterThan(20);
+      expect(entry.href).toStartWith("/guide/interaction-reference#");
+    }
   });
 
   it("provides a pre-0.1 source migration for every superseded interaction prop", () => {
@@ -120,13 +178,21 @@ describe("guide sections cover their catalogs", () => {
 describe("pruneSpecData", () => {
   it("truncates values rows and column arrays, reporting the pruned count", () => {
     const values = pruneSpecData(
-      { data: { values: Array.from({ length: 50 }, (_, i) => ({ x: i })) }, layers: [] },
+      {
+        data: { values: Array.from({ length: 50 }, (_, i) => ({ x: i })) },
+        layers: [],
+      },
       20,
     );
     expect(values.prunedRows).toBe(30);
     expect((values.spec as { data: { values: unknown[] } }).data.values).toHaveLength(20);
     const columns = pruneSpecData(
-      { datasets: { d: { columns: { x: Array.from({ length: 25 }, (_, i) => i) } } }, layers: [] },
+      {
+        datasets: {
+          d: { columns: { x: Array.from({ length: 25 }, (_, i) => i) } },
+        },
+        layers: [],
+      },
       20,
     );
     expect(columns.prunedRows).toBe(5);
@@ -147,8 +213,11 @@ describe("llms surfaces", () => {
     expect(txt.startsWith("# ggsvelte\n")).toBe(true);
     for (const page of pages) expect(txt).toContain(`(/guide/${page.slug})`);
     expect(txt).toContain("(/schema/v0.json)");
+    expect(txt).toContain("(/playground)");
+    expect(txt).toContain("(/reference/interactions)");
     for (const ex of EXAMPLES) expect(txt).toContain(`(/examples/${ex.id})`);
     expect(pages.map((page) => page.slug)).toContain("interactions");
+    expect(pages.map((page) => page.slug)).toContain("interaction-reference");
     expect(pages.map((page) => page.slug)).toContain("migrating-pre-0-1");
     expect(pages.map((page) => page.slug)).toContain("compatibility");
   });

--- a/scripts/gen-llms.ts
+++ b/scripts/gen-llms.ts
@@ -23,6 +23,7 @@ import {
   PIPELINE_WARNING_CATALOG,
 } from "@ggsvelte/core";
 import { ERROR_CATALOG, LINT_CATALOG } from "@ggsvelte/spec";
+import { INTERACTION_DIAGNOSTIC_CATALOG } from "../packages/svelte/src/lib/interaction";
 import supportMatrix from "../support-matrix.json";
 
 // ---------------------------------------------------------------------------
@@ -58,6 +59,21 @@ export function renderMarkdown(md: string, base = ""): string {
   let list: string[] | null = null;
   let code: string[] | null = null;
   let codeLang = "";
+  const headingCounts = new Map<string, number>();
+
+  const headingId = (text: string): string => {
+    const stem =
+      text
+        .replaceAll(/`([^`]+)`/g, "$1")
+        .toLowerCase()
+        .normalize("NFKD")
+        .replaceAll(/[\u0300-\u036F]/g, "")
+        .replaceAll(/[^a-z0-9]+/g, "-")
+        .replaceAll(/^-|-$/g, "") || "section";
+    const count = (headingCounts.get(stem) ?? 0) + 1;
+    headingCounts.set(stem, count);
+    return count === 1 ? stem : `${stem}-${String(count)}`;
+  };
 
   const flushParagraph = () => {
     if (paragraph.length > 0) {
@@ -96,7 +112,9 @@ export function renderMarkdown(md: string, base = ""): string {
       flushParagraph();
       flushList();
       const level = heading[1]!.length;
-      html.push(`<h${level}>${inline(heading[2]!, base)}</h${level}>`);
+      html.push(
+        `<h${level} id="${headingId(heading[2]!)}">${inline(heading[2]!, base)}</h${level}>`,
+      );
       continue;
     }
     if (line.startsWith("- ")) {
@@ -221,6 +239,10 @@ and **the fix carries a machine-applicable example — apply it**. Pass
   the builder chain, and the canonical spec JSON side by side.
 - [Interactions](/guide/interactions) — inspection, selection, zoom, typed
   events, keyboard behavior, and stable identity.
+- [Local data playground](/playground) — paste bounded JSON rows without
+  uploads, remote fetches, or code execution.
+- [Interaction reference](/guide/interaction-reference) — props, callbacks,
+  event phases, diagnostics, and accessibility defaults.
 - [Compatibility](/guide/compatibility) — tested Node, Svelte, installer,
   browser, and operating-system boundaries.
 - [Pre-0.1 interaction migration](/guide/migrating-pre-0-1) — replace the old
@@ -263,6 +285,17 @@ ggsvelte keeps static charts static. Opt in to only the behaviors the chart
 needs with \`inspect\`, \`select\`, and \`zoom\`. Once more than one behavior is
 available, the chart renders an accessible tool rail so inspection, selection,
 and zoom never compete for the same drag or click.
+
+**v0.1 scope:** interaction props emit chart-local callbacks. The public
+controller and linked-chart API is planned for R1 and is not part of v0.1.
+Application code may consume a callback into its own Svelte state, but
+ggsvelte does not yet publish a coordination controller.
+
+Start with the runnable [inspection and pinning example](/examples/interactions/inspection),
+the [interval selection and zoom example](/examples/interactions/interval-selection),
+or [use your own local JSON rows in the playground](/playground). For exact
+props, callbacks, phases, and diagnostics, use the
+[interaction reference](/guide/interaction-reference).
 
 ## Inspection
 
@@ -309,7 +342,13 @@ Point selection is durable identity, not a renderer index. Supply a unique,
 stable string, number, or symbol for every source row:
 
 \`\`\`svelte
-<GGPlot key="id" select={{ type: "point", multiple: true }} />
+<GGPlot
+  key="id"
+  select={{ type: "point", multiple: true }}
+  onselect={(event) => {
+    if (event.mode === "point") selectedKeys = event.keys;
+  }}
+/>
 \`\`\`
 
 Use interval selection for brushing. The callback receives both the selected
@@ -341,8 +380,6 @@ domains; Reset zoom or double-click emits a clear event.
 
 \`\`\`svelte
 <GGPlot
-  inspect={true}
-  select={{ type: "interval", mode: "xy" }}
   zoom={{ mode: "xy" }}
   onzoom={(event) => console.log(event.domains)}
 />
@@ -403,6 +440,222 @@ updates. Invalid or duplicate keys emit structured diagnostics through
 \`ondiagnostic\`; they never silently fall back to array positions. Stable keys
 let pinned inspection and point selection follow a datum when data is updated.
 `;
+
+const interactionDiagnostics = Object.values(INTERACTION_DIAGNOSTIC_CATALOG)
+  .map(
+    (entry) => `### \`${entry.code}\`
+
+${entry.message}
+
+- Prop: \`${entry.prop}\`
+- Severity: \`${entry.severity}\`
+- Try: ${entry.suggestions.join("; ")}
+- More: [${entry.docUrl}](${entry.docUrl})`,
+  )
+  .join("\n\n");
+
+export const INTERACTION_REFERENCE_MD = `# Interaction reference
+
+This page is the searchable contract for v0.1 interaction. All outputs are
+chart-local callbacks. A public controller for linked charts is planned for
+R1 and is not shipped in v0.1.
+
+## Static default
+
+Charts have no capture layer, tooltip, selection state, or zoom behavior until
+the corresponding capability is enabled. This keeps ordinary charts light and
+prevents interaction gestures from competing with page scrolling.
+
+## Capability props
+
+### \`inspect\`
+
+Enables inspection, the default HTML tooltip, semantic crosshair, keyboard
+traversal, and optional pinning. Inputs are \`true\` or options with \`mode\`,
+\`pin\`, \`maxDistance\`, \`content\`, and \`contentMode\`.
+
+### Point selection
+
+\`select={{ type: "point", multiple: true }}\` stores stable semantic keys.
+Supply \`key\` for every row.
+
+### Interval selection
+
+\`select={{ type: "interval", mode: "x" | "y" | "xy", persistent: true }}\`
+enables an explicit Select area tool and emits domain and pixel bounds.
+
+### \`zoom\`
+
+\`zoom={{ mode: "x" | "y" | "xy" }}\` enables the explicit Zoom area tool.
+Reset zoom and double-click return to the natural domains.
+
+## Controlled tool
+
+\`tool\` and \`ontoolchange\` control the active Inspect, Select area, or Zoom
+area mode. Keep the value in Svelte state when application controls and the
+plot tool rail must stay synchronized:
+
+\`\`\`svelte
+<script lang="ts">
+  import type { InteractionTool } from "ggsvelte";
+
+  let activeTool = $state<InteractionTool>("inspect");
+</script>
+
+<GGPlot
+  inspect={true}
+  select={{ type: "interval" }}
+  tool={activeTool}
+  ontoolchange={(next) => (activeTool = next)}
+/>
+\`\`\`
+
+A controlled unavailable tool requests a change and emits a diagnostic; it
+does not silently arm a different drag behavior. This state remains local to
+one chart in v0.1; it is not the planned R1 linked-chart controller.
+
+## Identity
+
+\`key\` is a field name or accessor returning a unique stable \`PropertyKey\`. Public
+events expose semantic keys, aggregate \`sourceKeys\`, and \`lineageCount\`,
+never renderer indices.
+
+## Events
+
+### \`oninspect\`
+
+Receives \`PlotInspection\`: \`change\` with transient or pinned focus and
+members, or \`clear\`.
+
+### \`onselect\`
+
+Receives \`PlotSelection\`. Point selection emits \`end\` and \`clear\`.
+Interval selection emits \`start\`, \`change\`, \`end\`, and \`clear\`.
+
+### \`onzoom\`
+
+Receives \`ZoomEvent\`: \`end\` with explicit domains or \`clear\` with null
+domains.
+
+### \`oninteraction\`
+
+Receives the same discriminated \`PlotInteractionEvent\` union emitted by the
+focused callbacks. Narrow on \`type\` and \`phase\`.
+
+### \`ondiagnostic\`
+
+Receives structured \`InteractionDiagnostic\` objects with \`severity\`,
+\`code\`, \`message\`, \`prop\`, \`suggestions\`, and \`docUrl\`.
+
+\`\`\`svelte
+<GGPlot
+  ondiagnostic={(diagnostic) =>
+    console.warn(diagnostic.code, diagnostic.message, diagnostic.suggestions)}
+/>
+\`\`\`
+
+Every event has a \`source\`: \`pointer\`, \`keyboard\`, \`touch\`, or
+\`programmatic\`.
+
+## Diagnostics
+
+${interactionDiagnostics}
+
+## Accessibility
+
+The plot surface is named and keyboard focusable when interaction is enabled.
+Arrow keys or brackets traverse data; Enter or Space pins or commits the active
+tool; Escape dismisses. A polite live region announces concise state while
+pinned HTML remains labelled, navigable DOM. Area tools remain explicit so
+ordinary page scrolling is available until a user chooses a drag mode.
+`;
+
+export interface InteractionReferenceEntry {
+  id: string;
+  name: string;
+  summary: string;
+  href: string;
+  keywords: readonly string[];
+}
+
+/** Search data for the human-facing reference page, kept beside its prose. */
+export const INTERACTION_REFERENCE_INDEX: readonly InteractionReferenceEntry[] = [
+  {
+    id: "static-default",
+    name: "Static by default",
+    summary: "Keep capture layers and gestures out of charts until a capability is enabled.",
+    href: "/guide/interaction-reference#static-default",
+    keywords: ["opt in", "capture", "scroll"],
+  },
+  {
+    id: "inspect",
+    name: "Inspect and pin",
+    summary: "Show an HTML tooltip and semantic crosshair with pointer and keyboard traversal.",
+    href: "/guide/interaction-reference#inspect",
+    keywords: ["tooltip", "crosshair", "pin", "keyboard"],
+  },
+  {
+    id: "point-selection",
+    name: "Point selection",
+    summary:
+      "Select one or many data records using stable semantic keys instead of renderer indices.",
+    href: "/guide/interaction-reference#point-selection",
+    keywords: ["select", "multiple", "keys"],
+  },
+  {
+    id: "interval-selection",
+    name: "Interval selection",
+    summary:
+      "Brush an explicit rectangular area and receive domain, pixel, and semantic-key bounds.",
+    href: "/guide/interaction-reference#interval-selection",
+    keywords: ["brush", "rectangle", "domain"],
+  },
+  {
+    id: "zoom",
+    name: "Brush zoom",
+    summary: "Zoom one or both axes with an explicit area tool and a predictable reset path.",
+    href: "/guide/interaction-reference#zoom",
+    keywords: ["domain", "reset", "double click"],
+  },
+  {
+    id: "controlled-tool",
+    name: "Controlled tool",
+    summary: "Synchronize the active Inspect, Select area, or Zoom area mode with Svelte state.",
+    href: "/guide/interaction-reference#controlled-tool",
+    keywords: ["tool", "ontoolchange", "state"],
+  },
+  {
+    id: "identity",
+    name: "Stable identity",
+    summary: "Preserve inspection and selection across updates with unique application-level keys.",
+    href: "/guide/interaction-reference#identity",
+    keywords: ["key", "lineage", "sourceKeys"],
+  },
+  {
+    id: "events",
+    name: "Typed events",
+    summary:
+      "Handle focused callbacks or one discriminated interaction event union with explicit phases.",
+    href: "/guide/interaction-reference#events",
+    keywords: ["oninspect", "onselect", "onzoom", "oninteraction", "phase"],
+  },
+  {
+    id: "diagnostics",
+    name: "Diagnostics",
+    summary:
+      "Respond to structured codes, suggestions, affected props, and exact documentation links.",
+    href: "/guide/interaction-reference#diagnostics",
+    keywords: ["ondiagnostic", "warning", "error", "suggestions"],
+  },
+  {
+    id: "accessibility",
+    name: "Accessibility",
+    summary:
+      "Use keyboard traversal, concise announcements, labelled DOM, and explicit area tools.",
+    href: "/guide/interaction-reference#accessibility",
+    keywords: ["screen reader", "keyboard", "live region", "focus"],
+  },
+];
 
 export const MIGRATING_PRE_0_1_MD = `# Migrating pre-0.1 interactions
 
@@ -499,7 +752,9 @@ export function buildErrorsMd(): string {
     "Validation errors (@ggsvelte/spec)",
     "Returned by `validate()` as `{ code, path, message, allowed?, fix }`. Tier 1 = schema shape, no data needed; tier 2 runs when an options argument is passed (structural grammar rules + data-aware checks against inline data or a DataProfile). Instances carry a concrete `fix.example` — apply it.",
     ERROR_CATALOG,
-    { tierOf: (code) => `tier ${String(ERROR_CATALOG[code as keyof typeof ERROR_CATALOG].tier)}` },
+    {
+      tierOf: (code) => `tier ${String(ERROR_CATALOG[code as keyof typeof ERROR_CATALOG].tier)}`,
+    },
   );
   const pipeline = catalogSection(
     "Render-time errors (@ggsvelte/core)",
@@ -686,6 +941,12 @@ export function guidePages(lifecycle: LifecycleDoc): GuidePage[] {
       markdown: INTERACTIONS_MD,
     },
     {
+      slug: "interaction-reference",
+      title: "Interaction reference",
+      description: "Search interaction props, callbacks, event phases, and diagnostic codes.",
+      markdown: INTERACTION_REFERENCE_MD,
+    },
+    {
       slug: "migrating-pre-0-1",
       title: "Migrating pre-0.1 interactions",
       description: "Move from tooltip and brush props to semantic interaction capabilities.",
@@ -711,6 +972,8 @@ export function buildLlmsIndex(
     lines.push(`- [${page.title}](/guide/${page.slug}): ${page.description}`);
   }
   lines.push(
+    "- [Local data playground](/playground): safely try bounded JSON rows with static and interactive chart controls",
+    "- [Search interaction reference](/reference/interactions): filter interaction capabilities, events, diagnostics, and accessibility guidance",
     "- [JSON Schema v0](/schema/v0.json): the PortableSpec schema (unstable pre-0.1.0)",
     "- [llms-full.txt](/llms-full.txt): all docs prose plus every example (spec JSON + Svelte source)",
     "",

--- a/scripts/playground-data.test.ts
+++ b/scripts/playground-data.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  inferPlaygroundFields,
+  parsePlaygroundData,
+  PlaygroundDataError,
+  recommendPlaygroundFields,
+  PLAYGROUND_MAX_BYTES,
+  PLAYGROUND_MAX_FIELDS,
+  PLAYGROUND_MAX_FIELD_NAME_LENGTH,
+  PLAYGROUND_MAX_ROWS,
+} from "../apps/docs/src/lib/playground-data";
+
+describe("playground data parser", () => {
+  test("accepts a JSON array of flat records and reports its format", () => {
+    const parsed = parsePlaygroundData('[{"city":"Bogotá","value":12},{"city":"Cali","value":9}]');
+
+    expect(parsed).toEqual({
+      format: "json",
+      rows: [
+        { city: "Bogotá", value: 12 },
+        { city: "Cali", value: 9 },
+      ],
+    });
+  });
+
+  test("rejects executable, nested, malformed, and empty input with useful messages", () => {
+    expect(() => parsePlaygroundData("")).toThrow("Paste a JSON array of rows");
+    expect(() => parsePlaygroundData('{"x":1}')).toThrow("JSON data must be an array");
+    expect(() => parsePlaygroundData('[{"x":{"nested":true}}]')).toThrow(
+      'Row 1 field "x" must be a string, number, boolean, or null',
+    );
+    expect(() => parsePlaygroundData("alert(1)")).toThrow("is not valid JSON");
+    expect(() => parsePlaygroundData("[]")).toThrow("at least one row");
+  });
+
+  test("bounds input bytes and row count before the chart can consume it", () => {
+    expect(() => parsePlaygroundData("x".repeat(PLAYGROUND_MAX_BYTES + 1))).toThrow("is too large");
+    const rows = Array.from({ length: PLAYGROUND_MAX_ROWS + 1 }, (_, index) => ({ x: index }));
+    expect(() => parsePlaygroundData(JSON.stringify(rows))).toThrow("has too many rows");
+
+    const wideRow = Object.fromEntries(
+      Array.from({ length: PLAYGROUND_MAX_FIELDS + 1 }, (_, index) => [
+        `field_${String(index)}`,
+        index,
+      ]),
+    );
+    expect(() => parsePlaygroundData(JSON.stringify([wideRow]))).toThrow("has too many fields");
+  });
+
+  test("rejects unsafe keys and exposes a stable actionable error contract", () => {
+    let error: unknown;
+    try {
+      parsePlaygroundData('[{"constructor":"nope","value":1}]');
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(error).toBeInstanceOf(PlaygroundDataError);
+    expect(error).toMatchObject({
+      code: "UNSAFE_FIELD",
+      fix: "Rename the field and apply the data again.",
+    });
+  });
+
+  test("bounds field names and parse-error detail", () => {
+    expect(() => parsePlaygroundData('[{"":1,"y":2}]')).toThrow("field names cannot be empty");
+    expect(() => parsePlaygroundData('[{"bad\\nname":1,"y":2}]')).toThrow(
+      "field names cannot contain control characters",
+    );
+    const longName = "x".repeat(PLAYGROUND_MAX_FIELD_NAME_LENGTH + 1);
+    expect(() => parsePlaygroundData(JSON.stringify([{ [longName]: 1, y: 2 }]))).toThrow(
+      "field name is too long",
+    );
+
+    try {
+      parsePlaygroundData(`[${"{".repeat(1_000)}`);
+    } catch (error) {
+      expect((error as Error).message.length).toBeLessThan(300);
+    }
+  });
+
+  test("infers stable field choices and recommends numeric axes", () => {
+    const rows = [
+      { species: "Adelie", mass: 3700, flipper: 181, tagged: true },
+      { species: "Gentoo", mass: 5000, flipper: null, tagged: false },
+    ];
+
+    expect(inferPlaygroundFields(rows)).toEqual([
+      { name: "species", kind: "text" },
+      { name: "mass", kind: "number" },
+      { name: "flipper", kind: "number" },
+      { name: "tagged", kind: "boolean" },
+    ]);
+    expect(recommendPlaygroundFields(inferPlaygroundFields(rows))).toEqual({
+      x: "mass",
+      y: "flipper",
+      color: "species",
+      key: "",
+    });
+    expect(
+      recommendPlaygroundFields([
+        { name: "category", kind: "text" },
+        { name: "value", kind: "number" },
+      ]),
+    ).toEqual({ x: "category", y: "value", color: "category", key: "" });
+  });
+});

--- a/tests/visual/playground.spec.ts
+++ b/tests/visual/playground.spec.ts
@@ -1,0 +1,113 @@
+import { expect, test } from "@playwright/test";
+import axe from "axe-core";
+
+import { settleVisualState } from "./helpers/deterministic";
+
+test("landing page makes the interactive and local-data paths obvious", async ({ page }) => {
+  await page.goto("/");
+  await expect(page.getByRole("link", { name: "Inspect a live plot" })).toHaveAttribute(
+    "href",
+    /examples\/interactions\/inspection$/,
+  );
+  await page.getByRole("link", { name: "Use my data" }).click();
+  await expect(page).toHaveURL(/\/playground$/);
+  await expect(page.getByRole("heading", { name: "Use my data" })).toBeVisible();
+});
+
+test("interaction reference filters the exact v0.1 contract", async ({ page }) => {
+  await page.goto("/reference/interactions");
+  await page.getByLabel("Search capabilities and events").fill("diagnostic");
+
+  await expect(page.getByText("1 result")).toBeVisible();
+  await expect(page.getByRole("link", { name: /Diagnostics/ })).toBeVisible();
+  await expect(page.getByRole("link", { name: /Inspect and pin/ })).toHaveCount(0);
+});
+
+test("valid local JSON replaces the preview without network or code execution", async ({
+  page,
+}) => {
+  const unexpectedRequests: string[] = [];
+  const pageErrors: string[] = [];
+  await page.goto("/playground");
+  await settleVisualState(page);
+  page.on("pageerror", (error) => pageErrors.push(error.message));
+  page.on("request", (request) => {
+    if (!request.url().startsWith("http://127.0.0.1:4173")) unexpectedRequests.push(request.url());
+  });
+
+  await page.getByLabel("JSON rows").fill(
+    JSON.stringify([
+      { label: "<img src=x onerror=alert(1)>", x: 1, y: 4 },
+      { label: "safe", x: 2, y: 9 },
+    ]),
+  );
+  await page.getByRole("button", { name: "Apply data" }).click();
+
+  await expect(page.getByText("Applied 2 local rows. Nothing was uploaded.")).toBeVisible();
+  await expect(page.locator('.gg-plot-root[data-gg-ready="true"]')).toHaveCount(1);
+  await expect(page.locator("img")).toHaveCount(0);
+  expect(unexpectedRequests).toEqual([]);
+  expect(pageErrors).toEqual([]);
+});
+
+test("invalid data is actionable, takes focus, and preserves the last good chart", async ({
+  page,
+}) => {
+  await page.goto("/playground");
+  await settleVisualState(page);
+  const originalCircles = await page.locator(".gg-points circle").count();
+
+  await page.getByLabel("JSON rows").fill('[{"x":{"nested":true},"y":2}]');
+  await page.getByRole("button", { name: "Apply data" }).click();
+
+  const alert = page.getByRole("alert");
+  await expect(alert).toBeFocused();
+  await expect(alert).toContainText('field "x" must be a string, number, boolean, or null');
+  await expect(alert).toContainText("Flatten nested values");
+  await expect(alert).toContainText("last working preview is still shown");
+  await expect(page.locator(".gg-points circle")).toHaveCount(originalCircles);
+});
+
+test("interaction is static by default and emits bounded semantic events after opt-in", async ({
+  page,
+}) => {
+  await page.goto("/playground");
+  await settleVisualState(page);
+  await expect(page.locator(".gg-capture")).toHaveCount(0);
+
+  await page.getByLabel("Inspect + pin").check();
+  const capture = page.locator(".gg-capture");
+  await expect(capture).toBeVisible();
+  await capture.focus();
+  await capture.press("ArrowRight");
+  await expect(page.locator(".event-log li").first()).toContainText("inspect · change · keyboard");
+  await expect(page.locator(".event-log li")).toHaveCount(1);
+});
+
+test("playground stays operable and axe-clean at a touch-size viewport", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto("/playground");
+  await settleVisualState(page);
+
+  const horizontalOverflow = await page.evaluate(
+    () => document.documentElement.scrollWidth - document.documentElement.clientWidth,
+  );
+  expect(horizontalOverflow).toBeLessThanOrEqual(1);
+  for (const button of await page.getByRole("button").all()) {
+    const box = await button.boundingBox();
+    if (box !== null) expect(box.height).toBeGreaterThanOrEqual(44);
+  }
+
+  await page.addScriptTag({ content: axe.source });
+  const violations = await page.evaluate(async () => {
+    const runner = (globalThis as typeof globalThis & { axe: typeof axe }).axe;
+    return (await runner.run(document.querySelector(".playground")!)).violations.map(
+      ({ id, impact, nodes }) => ({
+        id,
+        impact,
+        targets: nodes.map((node) => node.target.join(" ")),
+      }),
+    );
+  });
+  expect(violations, JSON.stringify(violations, null, 2)).toEqual([]);
+});


### PR DESCRIPTION
## Summary

- add a local-only, bounded JSON playground that stays static by default and can opt into inspect, selection, and zoom
- add a searchable v0.1 interaction reference with exact capability, event, diagnostic, identity, and accessibility links
- make the interactive journeys discoverable from the README, docs home, navigation, and llms.txt
- enforce the playground/reference routes and fragments in the packed Pages artifact and CI browser suite

This is the v0.1/R0 docs-and-playground slice of #5. The R1 controller/linking chapters remain intentionally open for the later controller work.

No changeset is included because this PR is part of the ordered v0.1.0 release preparation; package versioning will be done in the dedicated publish step.

## Safety defaults

- no eval or arbitrary spec/code execution
- no uploads, remote URLs, persistence, or data fetches
- 256 KiB / 5,000-row / 50-field bounds, plus bounded fields and strings
- last-good preview preserved for input errors; renderer failures isolated by a recoverable Svelte boundary
- semantic event log only, capped at 12 entries with no raw rows

## Verification

- `bun run test` — 592 passed
- `bun run test:components` — 327 browser + 3 SSR passed
- built docs Playwright suite — 10 passed, including axe and 390px viewport coverage
- `bun run check`, `check:svelte`, `check:examples`, `check:docs`
- `bun run lint:type-aware`, `fmt:check`, `knip`
- `bun run build:docs`, `check:pages-links`
- `bun run lint:actions`, `lint:actions:security`
- manifest, lifecycle, and support-matrix checks

Refs #5
