### PR TITLE
chore: add structured community feedback forms

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/ideas.yml
+++ b/.github/DISCUSSION_TEMPLATE/ideas.yml
@@ -1,0 +1,42 @@
+title: "[Design proposal] "
+body:
+  - type: dropdown
+    id: request_kind
+    attributes:
+      label: Proposal kind
+      options:
+        - Presentation, theme, palette, or default
+        - Grammar or PortableSpec semantics
+        - Interaction, event, identity, or linking semantics
+        - Renderer, performance, export, or picking
+        - Developer experience, packaging, or tooling
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: User problem
+      description: Describe the job to be done before choosing an API.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed direction
+      description: Include an API or spec sketch if useful, while leaving room for alternatives.
+    validations:
+      required: true
+  - type: textarea
+    id: semantics
+    attributes:
+      label: Meaning, state, and accessibility
+      description: Distinguish appearance from changes to data meaning, events, identity, focus, or assistive-technology behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: tradeoffs
+    attributes:
+      label: Tradeoffs and alternatives
+      description: Consider portability, SVG/canvas/headless behavior, performance, and composition.
+    validations:
+      required: true

--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -1,0 +1,28 @@
+title: "[Question] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Ask for help with the grammar, Svelte integration, or chart behavior. For a reproducible defect, use the bug or interaction issue form instead. Use synthetic or public data only.
+  - type: textarea
+    id: goal
+    attributes:
+      label: What are you trying to make?
+      description: Describe the chart, data meaning, and intended outcome.
+    validations:
+      required: true
+  - type: textarea
+    id: attempt
+    attributes:
+      label: Minimal attempt
+      description: Paste a small component, builder call, or PortableSpec using non-sensitive data.
+      render: typescript
+    validations:
+      required: true
+  - type: textarea
+    id: result
+    attributes:
+      label: What happened?
+      description: Include diagnostics and versions when relevant.
+    validations:
+      required: true

--- a/.github/DISCUSSION_TEMPLATE/show-and-tell.yml
+++ b/.github/DISCUSSION_TEMPLATE/show-and-tell.yml
@@ -1,0 +1,31 @@
+title: "[Example] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Share a chart, technique, theme, integration, or public project. Include an accessible description and only data you are allowed to publish.
+  - type: textarea
+    id: example
+    attributes:
+      label: What did you make?
+      description: Explain the chart's question, encoding, and useful ggsvelte features.
+    validations:
+      required: true
+  - type: textarea
+    id: accessibility
+    attributes:
+      label: Accessible description
+      description: Summarize the visual and its main conclusion for someone who cannot see an image.
+    validations:
+      required: true
+  - type: input
+    id: link
+    attributes:
+      label: Public link
+      description: Link a repository, REPL, article, or deployed example if one is available.
+  - type: textarea
+    id: lessons
+    attributes:
+      label: What should others learn from it?
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,84 @@
+name: Bug report
+description: Report a reproducible rendering, grammar, packaging, or runtime defect.
+title: "[Bug]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve ggsvelte. Use synthetic or public data only; remove credentials, private records, and identifying information.
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Affected surface
+      options:
+        - Svelte components
+        - Fluent builder
+        - Portable JSON spec
+        - Headless SVG renderer
+        - ggsvelte-render CLI
+        - Documentation or examples
+        - Packaging or installation
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Minimal reproduction
+      description: Paste the smallest component, builder call, or PortableSpec that demonstrates the problem. A public repository or REPL is also welcome.
+      placeholder: |
+        const spec = {
+          data: { values: [{ x: 1, y: 2 }] },
+          layers: [{ geom: "point", aes: { x: { field: "x" }, y: { field: "y" } } }]
+        };
+      render: typescript
+    validations:
+      required: true
+  - type: dropdown
+    id: renderer
+    attributes:
+      label: Renderer
+      options:
+        - SVG in the browser
+        - Canvas marks with SVG chrome
+        - Headless or exported SVG
+        - Not sure or not applicable
+    validations:
+      required: true
+  - type: input
+    id: versions
+    attributes:
+      label: Versions
+      description: Include ggsvelte, Svelte, browser/runtime, and package-manager versions where relevant.
+      placeholder: ggsvelte 0.x, Svelte 5.x, Chromium 1xx, Node 24, pnpm 11
+    validations:
+      required: true
+  - type: input
+    id: environment
+    attributes:
+      label: Browser and operating system
+      placeholder: Firefox 1xx on Windows 11, or Node 24 on Ubuntu
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: Describe the chart or semantic result you expected.
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior and evidence
+      description: Include exact diagnostics and cropped screenshots or recordings when useful. Redact sensitive data.
+    validations:
+      required: true
+  - type: checkboxes
+    id: confirmations
+    attributes:
+      label: Checks
+      options:
+        - label: I reduced this to a minimal reproduction using non-sensitive data.
+          required: true
+        - label: I searched existing issues and Discussions for the same behavior.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Ask a usage question
+    url: https://github.com/ljodea/ggsvelte/discussions/categories/q-a
+    about: Get help with chart grammar, Svelte integration, or an unexpected result.
+  - name: Share a chart or example
+    url: https://github.com/ljodea/ggsvelte/discussions/categories/show-and-tell
+    about: Show what you made and help the community learn from it.
+  - name: Explore a design proposal
+    url: https://github.com/ljodea/ggsvelte/discussions/categories/ideas
+    about: Discuss an API, grammar, interaction, or presentation idea before scoping work.
+  - name: Report a security vulnerability privately
+    url: https://github.com/ljodea/ggsvelte/security/policy
+    about: Do not disclose vulnerabilities, credentials, private data, or exploit details publicly.

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,54 @@
+name: Documentation gap
+description: Report missing, misleading, inaccessible, or stale documentation.
+title: "[Docs]: "
+body:
+  - type: input
+    id: location
+    attributes:
+      label: Documentation location
+      description: Link the page, README section, example, error code, or source file.
+      placeholder: https://ljodea.github.io/ggsvelte/guide/interactions
+    validations:
+      required: true
+  - type: dropdown
+    id: gap_kind
+    attributes:
+      label: Kind of gap
+      options:
+        - Missing task or concept
+        - Incorrect or stale content
+        - Example does not demonstrate the claim
+        - Accessibility or readability problem
+        - Search, navigation, or discoverability problem
+        - Agent-facing schema, diagnostic, or llms.txt problem
+    validations:
+      required: true
+  - type: textarea
+    id: goal
+    attributes:
+      label: What were you trying to accomplish?
+    validations:
+      required: true
+  - type: textarea
+    id: observed
+    attributes:
+      label: What was unclear or incorrect?
+      description: Quote only the shortest relevant phrase; link to longer source material.
+    validations:
+      required: true
+  - type: textarea
+    id: proposed
+    attributes:
+      label: Suggested improvement
+      description: A correction, example outline, or expected destination is enough.
+    validations:
+      required: true
+  - type: checkboxes
+    id: confirmations
+    attributes:
+      label: Checks
+      options:
+        - label: I searched existing documentation issues and Discussions.
+          required: true
+        - label: This report contains no sensitive or private data.
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,71 @@
+name: Feature proposal
+description: Propose a scoped addition after considering its semantics and portability.
+title: "[Feature]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Early design exploration belongs in the Ideas Discussion category. Use this form when the problem and desired outcome are concrete enough to scope.
+  - type: dropdown
+    id: request_kind
+    attributes:
+      label: Request kind
+      description: Presentation changes affect appearance; semantic changes affect data meaning, events, state, or the grammar.
+      options:
+        - Presentation, theme, palette, or default
+        - Grammar, stat, geom, scale, coordinate, or PortableSpec
+        - Semantic interaction, event, identity, or linking
+        - Renderer, performance, export, or picking
+        - Developer experience, packaging, or tooling
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem to solve
+      description: Describe the user goal and why existing composition or configuration is insufficient.
+    validations:
+      required: true
+  - type: textarea
+    id: outcome
+    attributes:
+      label: Desired outcome
+      description: Show a concise API or spec sketch and the observable result.
+    validations:
+      required: true
+  - type: textarea
+    id: semantics
+    attributes:
+      label: Semantic and interaction contract
+      description: Which data, keys, domains, events, states, or accessibility behavior would change? Say “presentation only” when none change.
+    validations:
+      required: true
+  - type: textarea
+    id: portability
+    attributes:
+      label: Portability and rendering
+      description: Should this work in PortableSpec, headless SVG, browser SVG, and canvas? Explain intentional exceptions.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Include composition, explicit configuration, or another library where relevant.
+    validations:
+      required: true
+  - type: input
+    id: discussion
+    attributes:
+      label: Related Discussion
+      description: Link the Ideas thread if the proposal was explored there, or say “not discussed.”
+      placeholder: https://github.com/ljodea/ggsvelte/discussions/…
+  - type: checkboxes
+    id: confirmations
+    attributes:
+      label: Checks
+      options:
+        - label: I searched existing issues, Discussions, and the interaction reference.
+          required: true
+        - label: This report contains no sensitive or private data.
+          required: true

--- a/.github/ISSUE_TEMPLATE/interaction-accessibility.yml
+++ b/.github/ISSUE_TEMPLATE/interaction-accessibility.yml
@@ -1,0 +1,100 @@
+name: Interaction or accessibility problem
+description: Report problems with inspection, selection, zoom, input, focus, or assistive technology.
+title: "[Interaction/a11y]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ggsvelte interaction is semantic and opt-in. Please describe the intended data behavior as well as the visual symptom. Never include private user data or assistive-technology logs containing personal information.
+  - type: dropdown
+    id: capability
+    attributes:
+      label: Interaction capability
+      options:
+        - Inspect, tooltip, crosshair, or pinning
+        - Point selection
+        - Interval selection or brushing
+        - Zoom or reset
+        - Tool rail or controlled tool
+        - Legend interaction
+        - Focus, announcements, or chart description
+        - Other accessibility behavior
+    validations:
+      required: true
+  - type: checkboxes
+    id: input_modalities
+    attributes:
+      label: Input modalities tested
+      description: Select every modality you exercised.
+      options:
+        - label: Keyboard
+        - label: Pointer or mouse
+        - label: Touch
+        - label: Switch, voice, or another alternative input
+        - label: Assistive technology
+    validations:
+      required: true
+  - type: input
+    id: assistive_technology
+    attributes:
+      label: Assistive technology
+      description: Name and version, or “not used.” Do not paste transcripts containing sensitive data.
+      placeholder: VoiceOver on macOS 15, NVDA 2026.1 with Firefox, or not used
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Minimal plot reproduction
+      description: Include synthetic data, stable key configuration, enabled interaction props, and callbacks.
+      render: svelte
+    validations:
+      required: true
+  - type: textarea
+    id: journey
+    attributes:
+      label: Exact interaction journey
+      description: List focus, key, gesture, or pointer steps in order and say where behavior diverges.
+      placeholder: 1. Tab to the plot. 2. Press ArrowRight. 3. Press Enter to pin.
+    validations:
+      required: true
+  - type: textarea
+    id: expected_semantics
+    attributes:
+      label: Expected semantic behavior
+      description: Describe the datum, keys, domains, event phases, focus, or announcement that should result.
+    validations:
+      required: true
+  - type: textarea
+    id: actual_behavior
+    attributes:
+      label: Actual behavior
+      description: Include the emitted event or diagnostic if available and attach redacted visual evidence when useful.
+    validations:
+      required: true
+  - type: dropdown
+    id: renderer
+    attributes:
+      label: Renderer
+      options:
+        - SVG in the browser
+        - Canvas marks with SVG chrome
+        - Not sure
+    validations:
+      required: true
+  - type: input
+    id: versions
+    attributes:
+      label: ggsvelte, Svelte, browser, and OS versions
+      placeholder: ggsvelte 0.x, Svelte 5.x, Safari 1x, macOS 15
+    validations:
+      required: true
+  - type: checkboxes
+    id: confirmations
+    attributes:
+      label: Checks
+      options:
+        - label: I used non-sensitive data and removed identifying information from evidence.
+          required: true
+        - label: I searched existing issues and Discussions for this journey.
+          required: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,28 @@
 # Contributing to ggsvelte
 
+## Start in the right place
+
+- Reproducible rendering, runtime, packaging, and grammar defects use the
+  [bug form](https://github.com/ljodea/ggsvelte/issues/new?template=bug.yml).
+- Inspection, selection, zoom, keyboard, touch, focus, and assistive-technology
+  problems use the
+  [interaction and accessibility form](https://github.com/ljodea/ggsvelte/issues/new?template=interaction-accessibility.yml).
+- Scoped additions use the
+  [feature form](https://github.com/ljodea/ggsvelte/issues/new?template=feature.yml);
+  explore early API and design ideas in
+  [Ideas](https://github.com/ljodea/ggsvelte/discussions/categories/ideas).
+- Documentation gaps use the
+  [documentation form](https://github.com/ljodea/ggsvelte/issues/new?template=documentation.yml).
+- Usage questions belong in
+  [Q&A](https://github.com/ljodea/ggsvelte/discussions/categories/q-a), and
+  reusable examples belong in
+  [Show and tell](https://github.com/ljodea/ggsvelte/discussions/categories/show-and-tell).
+- Suspected vulnerabilities must follow the [private security policy](SECURITY.md),
+  not a public issue or Discussion.
+
+The project has no guaranteed response times. See [SUPPORT.md](SUPPORT.md) for
+tested support boundaries and what information helps the community respond.
+
 ## Setup
 
 1. **bun** — the package manager, script runner, and unit-test runner.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,25 @@
+# Security policy
+
+## Report a vulnerability privately
+
+Do not open a public issue or Discussion for a suspected vulnerability. Use
+[GitHub's private vulnerability reporting form](https://github.com/ljodea/ggsvelte/security/advisories/new).
+Include the affected version or commit, impact, minimal reproduction, and any
+known mitigations. Remove credentials, private datasets, personal information,
+and unrelated exploit material.
+
+If private vulnerability reporting is unavailable, contact the repository
+owner through the email address on their GitHub profile and ask for a private
+reporting channel. Do not send exploit details until a private channel is
+confirmed.
+
+## Supported versions
+
+Before the first stable release, security fixes target the latest published
+0.x release and `main`. Older pre-release builds may require upgrading. The
+project does not promise response or remediation times, but reports will be
+triaged according to reproducibility, impact, and the safety of disclosure.
+
+Public rendering bugs, accessibility problems, and non-sensitive denial-of-
+service cases should use the structured issue forms. When in doubt, report
+privately first.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,22 @@
+# Support
+
+ggsvelte is an open-source project without guaranteed response times or service
+levels. Clear, minimal reports are easier for maintainers and contributors to
+answer.
+
+- Ask usage questions in
+  [Q&A](https://github.com/ljodea/ggsvelte/discussions/categories/q-a).
+- Share charts in
+  [Show and tell](https://github.com/ljodea/ggsvelte/discussions/categories/show-and-tell).
+- Explore API and design directions in
+  [Ideas](https://github.com/ljodea/ggsvelte/discussions/categories/ideas).
+- Report reproducible defects through the
+  [issue chooser](https://github.com/ljodea/ggsvelte/issues/new/choose).
+- Report suspected vulnerabilities through the
+  [private security route](SECURITY.md).
+
+Supported runtime, Svelte, installer, browser, and operating-system boundaries
+are published in the
+[compatibility guide](https://ljodea.github.io/ggsvelte/guide/compatibility).
+Questions outside those tested boundaries are welcome, but may be answered by
+another community member or require a reproduction on a supported setup.

--- a/scripts/community-forms.test.ts
+++ b/scripts/community-forms.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import { basename, join } from "node:path";
+
+const root = join(import.meta.dir, "..");
+const issueDirectory = join(root, ".github", "ISSUE_TEMPLATE");
+const discussionDirectory = join(root, ".github", "DISCUSSION_TEMPLATE");
+
+interface FormField {
+  type?: string;
+  id?: string;
+  attributes?: Record<string, unknown>;
+  validations?: { required?: boolean };
+}
+
+interface Form {
+  name?: string;
+  description?: string;
+  title?: string;
+  body?: FormField[];
+}
+
+function parseYaml(path: string): Record<string, unknown> {
+  return Bun.YAML.parse(readFileSync(path, "utf8")) as Record<string, unknown>;
+}
+
+function formFiles(directory: string): string[] {
+  return readdirSync(directory)
+    .filter((name) => name.endsWith(".yml"))
+    .map((name) => join(directory, name));
+}
+
+function validateForm(path: string, issue: boolean): void {
+  const form = parseYaml(path) as Form;
+  if (issue) {
+    expect(form.name, path).toBeString();
+    expect(form.description, path).toBeString();
+  }
+  expect(form.title, path).toBeString();
+  expect(form.body, path).toBeArray();
+  expect(form.body!.length, path).toBeGreaterThan(2);
+
+  const ids = form.body!.flatMap((field) => (field.id === undefined ? [] : [field.id]));
+  expect(new Set(ids).size, `${path} has duplicate field ids`).toBe(ids.length);
+  for (const field of form.body!) {
+    expect(["markdown", "textarea", "input", "dropdown", "checkboxes"], path).toContain(field.type);
+    expect(field.attributes, path).toBeObject();
+    if (field.type !== "markdown") expect(field.id, path).toMatch(/^[a-z0-9_-]+$/);
+    if (field.type === "dropdown") {
+      expect(field.attributes?.["options"], path).toBeArray();
+    }
+  }
+}
+
+describe("GitHub community forms", () => {
+  test("parses and validates every issue and Discussion form", () => {
+    const issueFiles = formFiles(issueDirectory).filter((path) => basename(path) !== "config.yml");
+    expect(issueFiles.map((path) => basename(path)).toSorted()).toEqual([
+      "bug.yml",
+      "documentation.yml",
+      "feature.yml",
+      "interaction-accessibility.yml",
+    ]);
+    for (const path of issueFiles) validateForm(path, true);
+
+    const discussionFiles = formFiles(discussionDirectory);
+    expect(discussionFiles.map((path) => basename(path)).toSorted()).toEqual([
+      "ideas.yml",
+      "q-a.yml",
+      "show-and-tell.yml",
+    ]);
+    for (const path of discussionFiles) validateForm(path, false);
+  });
+
+  test("routes questions, examples, proposals, and security without blank issues", () => {
+    const config = parseYaml(join(issueDirectory, "config.yml"));
+    expect(config["blank_issues_enabled"]).toBe(false);
+    const links = config["contact_links"] as { name: string; url: string }[];
+    const urls = links.map((link) => link.url);
+    expect(urls).toContain("https://github.com/ljodea/ggsvelte/discussions/categories/q-a");
+    expect(urls).toContain(
+      "https://github.com/ljodea/ggsvelte/discussions/categories/show-and-tell",
+    );
+    expect(urls).toContain("https://github.com/ljodea/ggsvelte/discussions/categories/ideas");
+    expect(urls).toContain("https://github.com/ljodea/ggsvelte/security/policy");
+  });
+
+  test("collects the interaction and accessibility reproduction contract", () => {
+    const form = parseYaml(join(issueDirectory, "interaction-accessibility.yml")) as Form;
+    const ids = new Set(form.body?.map((field) => field.id));
+    for (const id of [
+      "capability",
+      "input_modalities",
+      "assistive_technology",
+      "reproduction",
+      "journey",
+      "expected_semantics",
+      "actual_behavior",
+      "renderer",
+      "versions",
+    ]) {
+      expect(ids.has(id), `missing ${id}`).toBe(true);
+    }
+  });
+
+  test("distinguishes presentation requests from semantic interaction changes", () => {
+    const form = parseYaml(join(issueDirectory, "feature.yml")) as Form;
+    const kind = form.body?.find((field) => field.id === "request_kind");
+    const options = kind?.attributes?.["options"] as string[];
+    expect(options.some((option) => option.startsWith("Presentation"))).toBe(true);
+    expect(options.some((option) => option.startsWith("Semantic interaction"))).toBe(true);
+    expect(form.body?.some((field) => field.id === "semantics")).toBe(true);
+    expect(form.body?.some((field) => field.id === "portability")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- add structured issue forms for bugs, interaction/accessibility problems, scoped features, and documentation gaps
- add category-matched Discussion forms for Q&A, Show and tell, and Ideas
- route security reports to private vulnerability reporting and document support boundaries without service-level promises
- update contributing guidance so questions, examples, design exploration, defects, and security reports reach the right surface
- validate every YAML form, unique field ID, category slug, and required interaction contract in the standard test suite

## Repository settings completed

- GitHub Discussions enabled
- private vulnerability reporting enabled
- standard Q&A, Show and tell, and Ideas categories selected for the requested community journeys

The welcome discussions will be seeded after merge so they can link the committed default-branch forms.

## Verification

- `bun run test` — 596 passed
- `bun test scripts/community-forms.test.ts` — 4 tests / 205 assertions passed
- `bun run lint:type-aware`
- `bun run lint:md`
- `bun run fmt:check`
- TypeScript, Svelte, examples, and docs checks
- actionlint, zizmor, and knip

Closes #8
