### PR TITLE
fix(ci): repair manual AT Python action pin

### DIFF
--- a/.github/workflows/manual-at-mobile.yml
+++ b/.github/workflows/manual-at-mobile.yml
@@ -45,7 +45,7 @@ jobs:
           bun install --frozen-lockfile
           bun run build
           bun run build:docs
-          python3 -m http.server 4173 --directory apps/docs/build > "${RUNNER_TEMP}/ggsvelte-docs.log" 2>&1 &
+          bun scripts/serve-docs.ts > "${RUNNER_TEMP}/ggsvelte-docs.log" 2>&1 &
           echo "$!" > "${RUNNER_TEMP}/ggsvelte-docs.pid"
           for attempt in {1..30}; do
             curl --fail --silent http://127.0.0.1:4173/examples/interactions/inspection >/dev/null && exit 0

--- a/.github/workflows/manual-at.yml
+++ b/.github/workflows/manual-at.yml
@@ -62,7 +62,7 @@ jobs:
           path: .manual-at/nvda
           persist-credentials: false
 
-      - uses: actions/setup-python@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           architecture: x64


### PR DESCRIPTION
The first real NVDA dispatches proved the prior `actions/setup-python` SHA did not exist. This pins the workflow to the verified immutable commit currently referenced by the official v6 tag.

Failed evidence runs: #29399861741 and #29399863315. No AT pass was claimed.