### PR TITLE
fix(ci): include NVDA harness workspaces

### DIFF
--- a/.github/workflows/manual-at.yml
+++ b/.github/workflows/manual-at.yml
@@ -60,6 +60,7 @@ jobs:
           repository: nvaccess/nvda
           ref: ${{ env.NVDA_HARNESS_COMMIT }}
           path: .manual-at/nvda
+          submodules: recursive
           persist-credentials: false
 
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6


### PR DESCRIPTION
The real NVDA runs reached the upstream Robot harness, then failed because the pinned NVDA checkout omitted its `nvda-misc-deps` workspace. Recursively checking out the pinned commit’s submodules restores the official harness dependency graph.

Evidence: run 29400296466. No AT pass was claimed.