### PR TITLE
fix(ci): grant touch exploration before TalkBack bind

### DIFF
--- a/scripts/manual-at/mobile/run-talkback-chrome.sh
+++ b/scripts/manual-at/mobile/run-talkback-chrome.sh
@@ -45,11 +45,12 @@ adb shell wm density 420
 adb shell input keyevent KEYCODE_WAKEUP
 adb shell wm dismiss-keyguard
 
-adb shell settings put secure enabled_accessibility_services "${TALKBACK_SERVICE}"
-adb shell settings put secure accessibility_enabled 1
+adb shell settings put secure accessibility_enabled 0
 adb shell settings put secure touch_exploration_granted_accessibility_services \
   "${TALKBACK_SERVICE}"
 adb shell settings put secure touch_exploration_enabled 1
+adb shell settings put secure enabled_accessibility_services "${TALKBACK_SERVICE}"
+adb shell settings put secure accessibility_enabled 1
 sleep 8
 
 adb shell dumpsys accessibility > "${OUTPUT_DIR}/accessibility-dump.txt"


### PR DESCRIPTION
The real Android artifact proves TalkBack was installed, bound, and enabled, while `dumpsys accessibility` recorded `touchExplorationEnabled=false`. Grant touch exploration before binding/enabling the service so Android evaluates the capability at service startup.

Evidence: run 29401067963. No AT pass was claimed.