### PR TITLE
fix(ci): prevent fixture server stealing AT focus

### DIFF
--- a/.github/workflows/manual-at.yml
+++ b/.github/workflows/manual-at.yml
@@ -156,6 +156,7 @@ jobs:
                 -WorkingDirectory $env:GITHUB_WORKSPACE `
                 -ArgumentList @('scripts/serve-docs.ts') `
                 -PassThru `
+                -WindowStyle Hidden `
                 -RedirectStandardOutput "$env:EVIDENCE_DIR\fixture-server.stdout.log" `
                 -RedirectStandardError "$env:EVIDENCE_DIR\fixture-server.stderr.log"
               for ($attempt = 0; $attempt -lt 60; $attempt++) {


### PR DESCRIPTION
Retained Windows screenshots show the live chart behind a foreground Bun fixture-server console. The real Tab input therefore targeted the console and produced no browser speech. Hide only the infrastructure server window; the tested browser stays genuinely headed and foreground.

Evidence: run 29402803529. No AT pass was claimed.