### PR TITLE
fix(ci): dismiss Chrome onboarding before TalkBack

### DIFF
--- a/scripts/manual-at/mobile/run-talkback-chrome.sh
+++ b/scripts/manual-at/mobile/run-talkback-chrome.sh
@@ -45,6 +45,41 @@ adb shell wm density 420
 adb shell input keyevent KEYCODE_WAKEUP
 adb shell wm dismiss-keyguard
 
+# Skip Chrome's first-run UI without replacing Chrome or its accessibility
+# stack. Chrome can still show a separate notifications education modal after
+# these flags, so dismiss that while ordinary touch input is active, before
+# TalkBack owns the touchscreen.
+adb shell settings put secure accessibility_enabled 0
+adb shell am set-debug-app --persistent "${CHROME_PACKAGE}"
+adb shell 'echo "chrome --no-first-run --disable-fre --disable-default-apps" > /data/local/tmp/chrome-command-line'
+
+dump_chrome_ui() {
+  adb shell uiautomator dump /sdcard/ggsvelte-chrome-ui.xml >/dev/null
+  adb shell cat /sdcard/ggsvelte-chrome-ui.xml | tr -d '\r' > "${OUTPUT_DIR}/chrome-ui.xml"
+}
+
+dismiss_chrome_onboarding() {
+  adb shell am force-stop "${CHROME_PACKAGE}"
+  adb shell am start -W -a android.intent.action.VIEW -d "${TEST_URL}" "${CHROME_PACKAGE}" > \
+    "${OUTPUT_DIR}/chrome-preload.txt" || fail "Chrome could not preload the test fixture"
+  sleep 8
+  dump_chrome_ui
+  if grep -F 'text="Chrome notifications make things easier"' \
+    "${OUTPUT_DIR}/chrome-ui.xml" >/dev/null; then
+    # "No thanks" is stable at the lower-left action position on the pinned
+    # Pixel 7 / 1080x1920 fixture. TalkBack is deliberately still disabled.
+    adb shell input tap 610 1500
+    sleep 3
+    dump_chrome_ui
+  fi
+  if grep -F 'text="Chrome notifications make things easier"' \
+    "${OUTPUT_DIR}/chrome-ui.xml" >/dev/null; then
+    fail "Chrome onboarding still obscures the test fixture"
+  fi
+}
+
+dismiss_chrome_onboarding
+
 accessibility_ready=false
 for attempt in 1 2 3; do
   adb shell settings put secure accessibility_enabled 0
@@ -67,14 +102,15 @@ done
 [[ "${accessibility_ready}" == "true" ]] || \
   fail "TalkBack and touch exploration did not become ready together"
 
-# Skip Chrome's first-run UI without replacing Chrome or its accessibility
-# stack. This flag only removes account/onboarding screens from the fixture.
-adb shell am set-debug-app --persistent "${CHROME_PACKAGE}"
-adb shell 'echo "chrome --no-first-run --disable-fre --disable-default-apps" > /data/local/tmp/chrome-command-line'
 adb shell am force-stop "${CHROME_PACKAGE}"
 adb shell am start -W -a android.intent.action.VIEW -d "${TEST_URL}" "${CHROME_PACKAGE}" > \
   "${OUTPUT_DIR}/chrome-start.txt" || fail "Chrome could not open the test fixture"
 sleep 12
+dump_chrome_ui
+if grep -F 'text="Chrome notifications make things easier"' \
+  "${OUTPUT_DIR}/chrome-ui.xml" >/dev/null; then
+  fail "Chrome onboarding still obscures the test fixture"
+fi
 adb exec-out screencap -p > "${OUTPUT_DIR}/screenshots/00-loaded.png"
 
 # Clear setup chatter. Every later swipe and tap is injected through Android's

--- a/scripts/manual-at/mobile/run-talkback-chrome.test.ts
+++ b/scripts/manual-at/mobile/run-talkback-chrome.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test";
+
+const script = await Bun.file(new URL("./run-talkback-chrome.sh", import.meta.url)).text();
+
+describe("TalkBack Chrome evidence harness", () => {
+  test("dismisses Chrome onboarding before enabling TalkBack", () => {
+    const preload = script.indexOf("dismiss_chrome_onboarding");
+    const enable = script.indexOf("accessibility_ready=false");
+
+    expect(preload).toBeGreaterThan(-1);
+    expect(enable).toBeGreaterThan(preload);
+  });
+
+  test("refuses to explore while Chrome onboarding obscures the fixture", () => {
+    expect(script).toContain('fail "Chrome onboarding still obscures the test fixture"');
+    expect(script).toContain('text="Chrome notifications make things easier"');
+  });
+});


### PR DESCRIPTION
## Root cause\n\nThe retained Android artifact showed Chrome's notifications education modal covering the chart for the entire run. TalkBack correctly navigated that modal, so chart focus was impossible.\n\n## Fix\n\n- preload Chrome while TalkBack is disabled\n- dismiss the pinned notifications education modal with ordinary touch\n- fail closed if the modal remains before or after TalkBack starts\n- add regression tests for ordering and the fail-closed guard\n\n## Verification\n\n- bun test v1.3.14 (0d9b296a)\n- \n- Checking formatting...

All matched files use the correct format.
Finished in 337ms on 379 files using 10 threads.\n- bun test v1.3.14 (0d9b296a)
[two-pass sweep] N=500 A→B converged=492 (98.4%) C-moved=2 (0.4%) maxCDelta=48px (600 pass)