### PR TITLE
fix(ci): hide hosted console during NVDA runs

### DIFF
--- a/scripts/manual-at/windows/ggsvelte_at.py
+++ b/scripts/manual-at/windows/ggsvelte_at.py
@@ -261,6 +261,7 @@ def _launch_browser(path: str, width: int = 1180, height: int = 760) -> None:
         )
         if not enabled:
             raise AssertionError("Windows High Contrast was off before browser launch.")
+    _hide_runner_infrastructure_windows()
     _browser_process = subprocess.Popen(args)
     _focus_browser_window()
     _record("launch browser", "", url=url, viewport={"width": width, "height": height})
@@ -302,6 +303,37 @@ def _focus_browser_window() -> None:
             return
         time.sleep(0.5)
     raise AssertionError(f"The headed {_browser_name} ggsvelte window did not appear.")
+
+
+def _hide_runner_infrastructure_windows() -> None:
+    """Hide GitHub's console so it cannot repeatedly steal AT test focus."""
+
+    user32 = ctypes.windll.user32
+    hidden_titles: list[str] = []
+
+    @ctypes.WINFUNCTYPE(wintypes.BOOL, wintypes.HWND, wintypes.LPARAM)
+    def hide(hwnd: int, _lparam: int) -> bool:
+        if not user32.IsWindowVisible(hwnd):
+            return True
+        length = user32.GetWindowTextLengthW(hwnd)
+        if length == 0:
+            return True
+        buffer = ctypes.create_unicode_buffer(length + 1)
+        user32.GetWindowTextW(hwnd, buffer, length + 1)
+        title = buffer.value
+        normalized = title.lower().replace("\\", "")
+        if "hosted-compute-agent" in normalized or "hostedcomputeagent" in normalized:
+            user32.ShowWindow(hwnd, 0)
+            hidden_titles.append(title)
+        return True
+
+    user32.EnumWindows(hide, 0)
+    _record(
+        "hide hosted runner infrastructure windows",
+        "",
+        hiddenCount=len(hidden_titles),
+        hiddenTitles=hidden_titles,
+    )
 
 
 def _ensure_browser_foreground() -> None:

--- a/scripts/manual-at/windows/ggsvelte_at.test.ts
+++ b/scripts/manual-at/windows/ggsvelte_at.test.ts
@@ -24,4 +24,15 @@ describe("NVDA headed-browser focus boundary", () => {
       helper.indexOf('_ensure_browser_foreground()\n        _send_key("control")'),
     ).toBeGreaterThan(-1);
   });
+
+  test("hides the hosted runner console before launching the browser", () => {
+    expect(source).toContain('"hosted-compute-agent"');
+    expect(source).toContain('"hostedcomputeagent"');
+    expect(source).toContain("user32.ShowWindow(hwnd, 0)");
+    expect(
+      source.indexOf(
+        "_hide_runner_infrastructure_windows()\n    _browser_process = subprocess.Popen(args)",
+      ),
+    ).toBeGreaterThan(-1);
+  });
 });


### PR DESCRIPTION
## Root cause

After browser-HWND verification was added, the rerun failed closed and proved Windows refused foreground activation. Retained screenshots identify the competing window as GitHub's `HostedComputeAgent/hosted-compute-agent` console, which remains visible and repeatedly steals focus.

## Fix

- enumerate visible top-level Win32 windows before each browser launch
- hide only titles identifying GitHub's hosted compute agent
- record the exact hidden titles/count in the evidence stream
- retain the existing browser-HWND verification and per-key focus guard
- add a regression test that the console is hidden before browser launch

## Verification

- `bun test scripts/manual-at/windows/ggsvelte_at.test.ts`
- `python3 -m py_compile scripts/manual-at/windows/ggsvelte_at.py`
- `bun run fmt:check`
- `bun test packages/spec packages/core benchmarks scripts tests/evals` (604 pass)
- full pre-push parity
