### PR TITLE
release: prepare linked v0.1.0 packages

### DIFF
--- a/.changeset/bright-charts-arrive.md
+++ b/.changeset/bright-charts-arrive.md
@@ -1,0 +1,9 @@
+---
+"@ggsvelte/spec": minor
+"@ggsvelte/core": minor
+"ggsvelte": minor
+---
+
+# First public release
+
+Publish the first public ggsvelte release: a Svelte 5 grammar of graphics with strong defaults, ggplot2-inspired themes and palettes, responsive bounded rendering, agent-friendly portable specs and diagnostics, hybrid SVG/canvas output, accessible opt-in inspection and brushing, complete interaction documentation, and a release-gated compatibility and quality matrix.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,6 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
+  "privatePackages": false,
   "ignore": ["@ggsvelte-spike/*"]
 }

--- a/scripts/release-wiring.test.ts
+++ b/scripts/release-wiring.test.ts
@@ -49,4 +49,11 @@ describe("R0 release wiring", () => {
     expect(approvalJob).toContain("defaults:");
     expect(approvalJob).toContain("shell: bash");
   });
+
+  it("versions only publishable packages", () => {
+    const config = JSON.parse(read(".changeset/config.json")) as {
+      privatePackages?: boolean | { version?: boolean; tag?: boolean };
+    };
+    expect(config.privatePackages).toBe(false);
+  });
 });


### PR DESCRIPTION
## Release preparation

- adds a linked minor changeset for `@ggsvelte/spec`, `@ggsvelte/core`, and `ggsvelte`
- resolves each public package from `0.0.0` to `0.1.0`
- disables Changesets versioning/tagging for private workspace packages
- adds a regression test for that release boundary

`changeset status` reports the three public packages at 0.1.0 and every private workspace package at release type `none`.

## Verification

- `bun test scripts/release-wiring.test.ts`
- `bun node_modules/.bin/changeset status`
- `bun run fmt:check`
- full pre-push parity
