### PR TITLE
fix: canonicalize published CLI bin path

### DIFF
--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -23,7 +23,7 @@
     "url": "git+https://github.com/ljodea/ggsvelte.git"
   },
   "bin": {
-    "ggsvelte-render": "./bin/ggsvelte-render.js"
+    "ggsvelte-render": "bin/ggsvelte-render.js"
   },
   "files": [
     "dist",

--- a/scripts/release-wiring.test.ts
+++ b/scripts/release-wiring.test.ts
@@ -56,4 +56,13 @@ describe("R0 release wiring", () => {
     };
     expect(config.privatePackages).toBe(false);
   });
+
+  it("ships the CLI bin without npm manifest normalization", () => {
+    const manifest = JSON.parse(read("packages/svelte/package.json")) as {
+      bin?: Record<string, string>;
+    };
+    expect(manifest.bin).toEqual({
+      "ggsvelte-render": "bin/ggsvelte-render.js",
+    });
+  });
 });


### PR DESCRIPTION
Removes npm's publish-time manifest normalization warning while retaining the `ggsvelte-render` executable.

- use npm's canonical bin target form
- add release-wiring regression coverage
- verify `npm publish --dry-run` is warning-free

Test: `bun test scripts/release-wiring.test.ts`