### PR TITLE
fix: publish Svelte adapter under project scope

### DIFF
--- a/.changeset/bright-charts-arrive.md
+++ b/.changeset/bright-charts-arrive.md
@@ -1,7 +1,7 @@
 ---
 "@ggsvelte/spec": minor
 "@ggsvelte/core": minor
-"ggsvelte": minor
+"@ggsvelte/svelte": minor
 ---
 
 # First public release

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -3,7 +3,7 @@
   "changelog": "@changesets/cli/changelog",
   "commit": false,
   "fixed": [],
-  "linked": [["@ggsvelte/spec", "@ggsvelte/core", "ggsvelte"]],
+  "linked": [["@ggsvelte/spec", "@ggsvelte/core", "@ggsvelte/svelte"]],
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@
 #   1. A GitHub remote for this repo — until the repo is pushed to GitHub,
 #      this workflow never runs.
 #   2. npm "trusted publishing" configured on npmjs.com for EACH published
-#      package — @ggsvelte/spec, @ggsvelte/core, and ggsvelte — each pointing
+#      package — @ggsvelte/spec, @ggsvelte/core, and @ggsvelte/svelte — each pointing
 #      at this repository + this workflow file (release.yml). This requires
 #      the npm org/packages to exist and is maintainer-side setup.
 #

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -233,7 +233,7 @@ so the privileged path is dormant until then. Do not weaken these invariants.
 ## Lifecycle policy (Hadley lesson 13)
 
 Every public export of `@ggsvelte/spec`, `@ggsvelte/core` (both entries), and
-`ggsvelte` carries a lifecycle tag, annotated in the package index files
+`@ggsvelte/svelte` carries a lifecycle tag, annotated in the package index files
 (file default `// @lifecycle-default`, statement-level one-line
 `@lifecycle` JSDoc markers, per-name trailing `// @lifecycle` comments) and
 collected into the generated `lifecycle.json` (`bun run lifecycle:gen`;
@@ -286,7 +286,7 @@ Consequences:
   value-stable scale state (decision 0002), two-pass layout (decision 0003),
   `runPipeline()`, `renderToSVGString()`. No DOM globals — enforced by the
   Node smoke test. `/dom` stays a stub until M2 canvas work.
-- `ggsvelte`: props-first `<GGPlot>`, declaration-only `<GeomPoint>`/
+- `@ggsvelte/svelte`: props-first `<GGPlot>`, declaration-only `<GeomPoint>`/
   `<GeomLine>` sugar (decision 0001, mechanism A), vitest-4 browser-mode
   component tests (`bun run test:components`).
 - Benchmarks live in `benchmarks/` (mitata; `bench-smoke` CI job runs the 1k
@@ -301,7 +301,7 @@ adapter-static site, `<GGPlot>`'s `data-gg-ready` readiness signal, the
 `tests/visual` Playwright suite, and a real (un-guarded) `vr-compare.yml`.
 Pre-push consequence: the first hook is now **package-build**
 (`bun run build`, not just `tsc -b`) because docs/examples checks import the
-built `ggsvelte` package.
+built `@ggsvelte/svelte` package.
 
 ## Milestone context (M2 — statistical layer)
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Build polished charts from Svelte components, a fluent builder, or portable
 JSON. ggsvelte gives you readable scales, stable colors, contained responsive
 rendering, and publication-ready themes before you tune anything.
 
-> **Status: pre-0.1.0, explicitly unstable.** Every export carries a
+> **Status: v0.1 is the first public release and intentionally early.** Every export carries a
 > lifecycle tag (see `lifecycle.json` and the docs lifecycle page); the
 > agent core path (`PortableSpec` / `normalize` / `validate` /
 > `renderToSVGString` / `GGPlot`) is `stable-intent`, everything else
@@ -25,10 +25,10 @@ rendering, and publication-ready themes before you tune anything.
 ## Install
 
 ```sh
-bun add ggsvelte        # or: npm install ggsvelte
+bun add @ggsvelte/svelte        # or: npm install @ggsvelte/svelte
 ```
 
-`ggsvelte` pulls in `@ggsvelte/spec` (spec types, validation, builder) and
+`@ggsvelte/svelte` pulls in `@ggsvelte/spec` (spec types, validation, builder) and
 `@ggsvelte/core` (pipeline + renderers) and re-exports the whole surface.
 
 Requires Node.js 22+ and Svelte 5.29+. Clean packed-artifact installs are
@@ -67,7 +67,7 @@ or [searchable event reference](https://ljodea.github.io/ggsvelte/reference/inte
 
 ```svelte
 <script>
-  import { GGPlot } from "ggsvelte";
+  import { GGPlot } from "@ggsvelte/svelte";
 
   const spec = {
     data: {
@@ -88,7 +88,7 @@ or [searchable event reference](https://ljodea.github.io/ggsvelte/reference/inte
 **Fluent builder**:
 
 ```ts
-import { aes, gg } from "ggsvelte";
+import { aes, gg } from "@ggsvelte/svelte";
 
 const spec = gg(rows, aes({ x: "displ", y: "hwy" }))
   .geomPoint()
@@ -114,16 +114,16 @@ CLI: `ggsvelte-render spec.json > chart.svg` (JSON-line diagnostics on stderr).
 
 ## Packages
 
-| Package                           | What                                                                                            |
-| --------------------------------- | ----------------------------------------------------------------------------------------------- |
-| [`ggsvelte`](packages/svelte)     | Svelte 5 components + everything re-exported + the CLI                                          |
-| [`@ggsvelte/spec`](packages/spec) | Spec types, JSON Schema, `normalize()`, `validate()`, `lintSpec()`, builder — zero DOM, zero d3 |
-| [`@ggsvelte/core`](packages/core) | Framework-agnostic pipeline + SVG renderer (pure entry) and canvas/hit-index (`/dom` entry)     |
+| Package                               | What                                                                                            |
+| ------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| [`@ggsvelte/svelte`](packages/svelte) | Svelte 5 components + everything re-exported + the CLI                                          |
+| [`@ggsvelte/spec`](packages/spec)     | Spec types, JSON Schema, `normalize()`, `validate()`, `lintSpec()`, builder — zero DOM, zero d3 |
+| [`@ggsvelte/core`](packages/core)     | Framework-agnostic pipeline + SVG renderer (pure entry) and canvas/hit-index (`/dom` entry)     |
 
 ## Agents
 
 - Skill: [`skills/ggsvelte/SKILL.md`](skills/ggsvelte/SKILL.md) (also shipped
-  inside the `ggsvelte` package).
+  inside the `@ggsvelte/svelte` package).
 - Docs site endpoints: `/llms.txt`, `/llms-full.txt`, `/schema/v0.json`.
 - Held-out eval harness: `tests/evals/` (`bun run evals`, dry-run without a key).
 

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@ggsvelte/examples": "workspace:*",
     "@ggsvelte/spec": "workspace:*",
-    "ggsvelte": "workspace:*"
+    "@ggsvelte/svelte": "workspace:*"
   },
   "devDependencies": {
     "@sveltejs/adapter-static": "^3.0.10",

--- a/apps/docs/src/lib/Playground.svelte
+++ b/apps/docs/src/lib/Playground.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
   import { tick } from "svelte";
 
-  import { GGPlot } from "ggsvelte";
+  import { GGPlot } from "@ggsvelte/svelte";
   import type {
     AesInput,
     InteractionDiagnostic,
     LayerInput,
     PlotInteractionEvent,
-  } from "ggsvelte";
+  } from "@ggsvelte/svelte";
 
   import {
     inferPlaygroundFields,

--- a/apps/docs/src/routes/+page.svelte
+++ b/apps/docs/src/routes/+page.svelte
@@ -20,7 +20,7 @@
     compose Svelte components — all three compile to the same canonical
     <code>PortableSpec</code>.
   </p>
-  <pre><code>bun add ggsvelte</code></pre>
+  <pre><code>bun add @ggsvelte/svelte</code></pre>
   <p>
     <a href={`${base}/guide/getting-started`}>Get started →</a>
     &nbsp;·&nbsp;

--- a/apps/docs/src/routes/__perf/interaction-100k/+page.svelte
+++ b/apps/docs/src/routes/__perf/interaction-100k/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { RenderModel } from "@ggsvelte/core";
-  import { GGPlot } from "ggsvelte";
+  import { GGPlot } from "@ggsvelte/svelte";
 
   type Row = Readonly<{
     id: number;

--- a/bun.lock
+++ b/bun.lock
@@ -32,7 +32,7 @@
       "dependencies": {
         "@ggsvelte/examples": "workspace:*",
         "@ggsvelte/spec": "workspace:*",
-        "ggsvelte": "workspace:*",
+        "@ggsvelte/svelte": "workspace:*",
       },
       "devDependencies": {
         "@sveltejs/adapter-static": "^3.0.10",
@@ -60,7 +60,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@ggsvelte/spec": "workspace:*",
-        "ggsvelte": "workspace:*",
+        "@ggsvelte/svelte": "workspace:*",
       },
       "devDependencies": {
         "svelte": "^5.46.4",
@@ -89,7 +89,7 @@
       },
     },
     "packages/svelte": {
-      "name": "ggsvelte",
+      "name": "@ggsvelte/svelte",
       "version": "0.0.0",
       "bin": {
         "ggsvelte-render": "./bin/ggsvelte-render.js",
@@ -209,6 +209,8 @@
     "@ggsvelte/examples": ["@ggsvelte/examples@workspace:examples"],
 
     "@ggsvelte/spec": ["@ggsvelte/spec@workspace:packages/spec"],
+
+    "@ggsvelte/svelte": ["@ggsvelte/svelte@workspace:packages/svelte"],
 
     "@inquirer/external-editor": ["@inquirer/external-editor@1.0.3", "", { "dependencies": { "chardet": "^2.1.1", "iconv-lite": "^0.7.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA=="],
 
@@ -653,8 +655,6 @@
     "get-east-asian-width": ["get-east-asian-width@1.6.0", "", {}, "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA=="],
 
     "get-tsconfig": ["get-tsconfig@4.14.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA=="],
-
-    "ggsvelte": ["ggsvelte@workspace:packages/svelte"],
 
     "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 

--- a/docs/decisions/0007-walking-skeleton-notes.md
+++ b/docs/decisions/0007-walking-skeleton-notes.md
@@ -14,7 +14,7 @@
 | `measure.ts` / `font-metrics.ts`  | `src/layout/measure.ts` / `layout/font-metrics.ts`  | Verbatim. The metrics table is still the macOS-Chromium/Helvetica one from the spike — regeneration in the pinned container is an M1 follow-up (see below).    |
 | `ticks.ts` / `layout.ts` (M0a-3)  | `src/layout/ticks.ts` / `layout/layout.ts`          | Verbatim algorithmically; two `if/else` branches restructured to hoist shared trailing code (behavior-identical, sweep still 98.4% converged).                 |
 | spike tests (6 suites)            | `packages/core/tests/*` + `tests/fixtures/grouping` | Ported nearly verbatim (paths/imports; `Columns` type rename). All 87 pass.                                                                                    |
-| `spikes/browser` registry (M0a-1) | `ggsvelte` `src/lib/registry.svelte.ts`             | Rewritten to the production shape but mechanism-identical: non-reactive Map + monotonic version `$state`, init-time registration, live getter descriptors.     |
+| `spikes/browser` registry (M0a-1) | `@ggsvelte/svelte` `src/lib/registry.svelte.ts`     | Rewritten to the production shape but mechanism-identical: non-reactive Map + monotonic version `$state`, init-time registration, live getter descriptors.     |
 
 Everything else (schema, normalize, validate, builder, portability,
 ColumnTable, pipeline, renderers, components) is new M0c code built on the
@@ -58,7 +58,7 @@ packages stay dependency-free apart from `@sinclair/typebox`:
    bottom/left margins). Safe direction: the panel shrinks, measured labels
    still fit; only tick density drifts marginally. Folding titles into the
    layout measurement loop is the clean fix — M1, together with legends.
-5. **attw runs `--profile esm-only`**, and the `ggsvelte` package is checked
+5. **attw runs `--profile esm-only`**, and the `@ggsvelte/svelte` package is checked
    by publint only: its d.ts files import `./*.svelte` modules, which no
    node16 resolution mode can resolve — Svelte packages are consumed through
    bundlers via the `svelte` condition. Documented in `scripts/package-lint.ts`.
@@ -116,7 +116,7 @@ packages stay dependency-free apart from `@sinclair/typebox`:
 3. Fold axis titles (and legends) into the two-pass layout measurement.
 4. Wire `aes` channels beyond x/y/color/group into geometry (size, alpha,
    linewidth as data channels — with the sqrt/linear dimensional split).
-5. `ggsvelte-render` CLI bin on the `ggsvelte` package (plan M1) — the pure
+5. `ggsvelte-render` CLI bin on the `@ggsvelte/svelte` package (plan M1) — the pure
    entry is ready for it.
 6. SvelteKit-real SSR/hydration round-trip for `<GGPlot>` + SSR scale-state
    adoption (`adoptScaleState` is exported and tested at the core level).

--- a/docs/decisions/0008-m1-core-notes.md
+++ b/docs/decisions/0008-m1-core-notes.md
@@ -101,7 +101,7 @@
     can collide ids (documented caveat). The Svelte adapter uses
     `$props.id()` and is collision-free.
 16. **CLI**: logic lives in `@ggsvelte/core` (`runCLI`, injectable IO,
-    testable without spawning); the `ggsvelte-render` bin on the `ggsvelte`
+    testable without spawning); the `ggsvelte-render` bin on the `@ggsvelte/svelte`
     package is a ~35-line wrapper. Exit codes: 0 rendered / 1 render failed
     / 2 usage error / 3 invalid spec. stdout carries ONLY SVG; diagnostics
     are stderr JSON lines ({kind: error|warning|advisory, ...}).

--- a/docs/decisions/0009-vr-examples-notes.md
+++ b/docs/decisions/0009-vr-examples-notes.md
@@ -116,7 +116,7 @@ and consequences:
 - **`bun run test` now includes `scripts/`** (the manifest generator's unit
   tests) — the pre-push hook and CI unit job were updated to match.
 - **Pre-push tsc-build hook became package-build** (`bun run build`): the
-  docs app and examples corpus import the BUILT `ggsvelte` package, so
+  docs app and examples corpus import the BUILT `@ggsvelte/svelte` package, so
   svelte-package must run before docs/examples checks. Adds ~1s.
 - The docs header's GitHub link points at a placeholder org URL (repo not
   published yet).

--- a/docs/decisions/0012-m3-notes.md
+++ b/docs/decisions/0012-m3-notes.md
@@ -98,7 +98,7 @@ mental model, the validation-error contract ("errors include fix.example —
 apply it"), the DataProfile→geom recommendation table, 20 recipes as
 canonical spec JSON (every explicit recipe machine-validated during
 authoring), links to schema + llms-full. A byte-identical copy ships inside
-the `ggsvelte` package (`files: ["dist","bin","skills"]`),
+the `@ggsvelte/svelte` package (`files: ["dist","bin","skills"]`),
 `scripts/skill-sync.test.ts` enforces sync.
 
 ## Held-out eval harness (tests/evals)
@@ -197,8 +197,8 @@ LICENSE (MIT, Liam O'Dea) at root + copied into each package; READMEs (root
    history is still uncommitted by instruction). Update `repository`/
    `homepage`/`bugs` in all three package.jsons + README/CONTRIBUTING links
    if the org/name differs from `ggsvelte/ggsvelte`.
-2. **npm**: reserve the `ggsvelte` name and the `@ggsvelte` org; configure
-   **trusted publishing** (OIDC) for `ggsvelte`, `@ggsvelte/spec`,
+2. **npm**: reserve the `@ggsvelte/svelte` name and the `@ggsvelte` org; configure
+   **trusted publishing** (OIDC) for `@ggsvelte/svelte`, `@ggsvelte/spec`,
    `@ggsvelte/core` pointing at `.github/workflows/release.yml`.
 3. **Secrets**: `ANTHROPIC_API_KEY` (evals.yml). No NPM_TOKEN — trusted
    publishing only.
@@ -242,3 +242,11 @@ Same date, user-blocked item 1 partially resolved: the real repository is
 three package.jsons and the placeholder `github.com/ggsvelte/ggsvelte` links
 (package READMEs, docs-site layout) now point there. npm scope names
 (`@ggsvelte/*`, `ggsvelte`) are unchanged.
+
+## Amendment (2026-07-15): Svelte adapter uses the organization scope
+
+npm rejected the unscoped `ggsvelte` name under its anti-typosquatting rule
+because it is too similar to `svelte`. The public adapter is therefore
+`@ggsvelte/svelte`; `@ggsvelte/spec` and `@ggsvelte/core` retain their planned
+names. This keeps all public packages under the project-owned scope and leaves
+room for future framework adapters.

--- a/examples/area/basic/Example.svelte
+++ b/examples/area/basic/Example.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { GeomArea, GeomLine, GGPlot } from "ggsvelte";
+  import { GeomArea, GeomLine, GGPlot } from "@ggsvelte/svelte";
 
   import { rainfall } from "./data.js";
 </script>

--- a/examples/area/stacked/Example.svelte
+++ b/examples/area/stacked/Example.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { GeomArea, GGPlot } from "ggsvelte";
+  import { GeomArea, GGPlot } from "@ggsvelte/svelte";
 
   import { generation } from "./data.js";
 </script>

--- a/examples/bar/dodged/Example.svelte
+++ b/examples/bar/dodged/Example.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { GeomBar, GGPlot } from "ggsvelte";
+  import { GeomBar, GGPlot } from "@ggsvelte/svelte";
 
   import { attendees } from "./data.js";
 </script>

--- a/examples/bar/horizontal/Example.svelte
+++ b/examples/bar/horizontal/Example.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { GeomCol, GGPlot } from "ggsvelte";
+  import { GeomCol, GGPlot } from "@ggsvelte/svelte";
 
   import { languages } from "./data.js";
 </script>

--- a/examples/bar/proportions/Example.svelte
+++ b/examples/bar/proportions/Example.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { GeomBar, GGPlot } from "ggsvelte";
+  import { GeomBar, GGPlot } from "@ggsvelte/svelte";
 
   import { sessions } from "./data.js";
 </script>

--- a/examples/bar/stacked/Example.svelte
+++ b/examples/bar/stacked/Example.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { GeomBar, GGPlot } from "ggsvelte";
+  import { GeomBar, GGPlot } from "@ggsvelte/svelte";
 
   import { tickets } from "./data.js";
 </script>

--- a/examples/boxplot/by-category/Example.svelte
+++ b/examples/boxplot/by-category/Example.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { GeomBoxplot, GGPlot } from "ggsvelte";
+  import { GeomBoxplot, GGPlot } from "@ggsvelte/svelte";
 
   import { readings } from "./data.js";
 </script>

--- a/examples/col/basic/Example.svelte
+++ b/examples/col/basic/Example.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { GeomCol, GGPlot } from "ggsvelte";
+  import { GeomCol, GGPlot } from "@ggsvelte/svelte";
 
   import { languages } from "./data.js";
 </script>

--- a/examples/col/value-labels/Example.svelte
+++ b/examples/col/value-labels/Example.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { GeomCol, GeomText, GGPlot } from "ggsvelte";
+  import { GeomCol, GeomText, GGPlot } from "@ggsvelte/svelte";
 
   import { revenue } from "./data.js";
 </script>

--- a/examples/color/continuous/Example.svelte
+++ b/examples/color/continuous/Example.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { GeomPoint, GGPlot } from "ggsvelte";
+  import { GeomPoint, GGPlot } from "@ggsvelte/svelte";
 
   import { stations } from "./data.js";
 </script>

--- a/examples/density/overlay/Example.svelte
+++ b/examples/density/overlay/Example.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { GeomDensity, GGPlot } from "ggsvelte";
+  import { GeomDensity, GGPlot } from "@ggsvelte/svelte";
 
   import { sessions } from "./data.js";
 </script>

--- a/examples/errorbar/mean-se/Example.svelte
+++ b/examples/errorbar/mean-se/Example.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { GeomErrorbar, GeomPoint, GGPlot } from "ggsvelte";
+  import { GeomErrorbar, GeomPoint, GGPlot } from "@ggsvelte/svelte";
 
   import { yields } from "./data.js";
 </script>

--- a/examples/facet/wrap-free-y/Example.svelte
+++ b/examples/facet/wrap-free-y/Example.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { GeomLine, GeomPoint, GGPlot } from "ggsvelte";
+  import { GeomLine, GeomPoint, GGPlot } from "@ggsvelte/svelte";
 
   import { metrics } from "./data.js";
 </script>

--- a/examples/facet/wrap/Example.svelte
+++ b/examples/facet/wrap/Example.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { GeomHistogram, GGPlot } from "ggsvelte";
+  import { GeomHistogram, GGPlot } from "@ggsvelte/svelte";
 
   import { samples } from "./data.js";
 </script>

--- a/examples/histogram/basic/Example.svelte
+++ b/examples/histogram/basic/Example.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { GeomHistogram, GGPlot } from "ggsvelte";
+  import { GeomHistogram, GGPlot } from "@ggsvelte/svelte";
 
   import { responses } from "./data.js";
 </script>

--- a/examples/interaction/brush-zoom/Example.svelte
+++ b/examples/interaction/brush-zoom/Example.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { GeomPoint, GGPlot } from "ggsvelte";
+  import { GeomPoint, GGPlot } from "@ggsvelte/svelte";
 
   import { field } from "./data.js";
 

--- a/examples/interaction/tooltip/Example.svelte
+++ b/examples/interaction/tooltip/Example.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { GeomPoint, GGPlot } from "ggsvelte";
+  import { GeomPoint, GGPlot } from "@ggsvelte/svelte";
 
   import { penguins } from "./data.js";
 

--- a/examples/line/multi-series/Example.svelte
+++ b/examples/line/multi-series/Example.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { GeomLine, GeomPoint, GGPlot } from "ggsvelte";
+  import { GeomLine, GeomPoint, GGPlot } from "@ggsvelte/svelte";
 
   import { temperatures } from "./data.js";
 </script>

--- a/examples/line/time-axis/Example.svelte
+++ b/examples/line/time-axis/Example.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { GeomLine, GGPlot } from "ggsvelte";
+  import { GeomLine, GGPlot } from "@ggsvelte/svelte";
 
   import { traffic } from "./data.js";
 </script>

--- a/examples/package.json
+++ b/examples/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "dependencies": {
     "@ggsvelte/spec": "workspace:*",
-    "ggsvelte": "workspace:*"
+    "@ggsvelte/svelte": "workspace:*"
   },
   "devDependencies": {
     "svelte": "^5.46.4",

--- a/examples/point/canvas-scatter/Example.svelte
+++ b/examples/point/canvas-scatter/Example.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { GeomPoint, GGPlot } from "ggsvelte";
+  import { GeomPoint, GGPlot } from "@ggsvelte/svelte";
 
   import { cloud } from "./data.js";
 </script>

--- a/examples/point/jitter/Example.svelte
+++ b/examples/point/jitter/Example.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { GeomPoint, GGPlot } from "ggsvelte";
+  import { GeomPoint, GGPlot } from "@ggsvelte/svelte";
 
   import { ratings } from "./data.js";
 </script>

--- a/examples/point/log-scale/Example.svelte
+++ b/examples/point/log-scale/Example.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { GeomPoint, GGPlot } from "ggsvelte";
+  import { GeomPoint, GGPlot } from "@ggsvelte/svelte";
 
   import { countries } from "./data.js";
 </script>

--- a/examples/point/scatter-color/Example.svelte
+++ b/examples/point/scatter-color/Example.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { GeomPoint, GGPlot } from "ggsvelte";
+  import { GeomPoint, GGPlot } from "@ggsvelte/svelte";
 
   import { penguins } from "./data.js";
 </script>

--- a/examples/rule/annotation/Example.svelte
+++ b/examples/rule/annotation/Example.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { GeomLine, GeomPoint, GeomRule, GGPlot } from "ggsvelte";
+  import { GeomLine, GeomPoint, GeomRule, GGPlot } from "@ggsvelte/svelte";
 
   import { signups, target } from "./data.js";
 </script>

--- a/examples/rule/data-driven/Example.svelte
+++ b/examples/rule/data-driven/Example.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { GeomRule, GGPlot } from "ggsvelte";
+  import { GeomRule, GGPlot } from "@ggsvelte/svelte";
 
   import { eruptions } from "./data.js";
 </script>

--- a/examples/smooth/loess-scatter/Example.svelte
+++ b/examples/smooth/loess-scatter/Example.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { GeomPoint, GeomSmooth, GGPlot } from "ggsvelte";
+  import { GeomPoint, GeomSmooth, GGPlot } from "@ggsvelte/svelte";
 
   import { trend } from "./data.js";
 </script>

--- a/examples/text/labels/Example.svelte
+++ b/examples/text/labels/Example.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { GeomPoint, GeomText, GGPlot } from "ggsvelte";
+  import { GeomPoint, GeomText, GGPlot } from "@ggsvelte/svelte";
 
   import { cities } from "./data.js";
 </script>

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -48,7 +48,7 @@
       "project": ["src/**/*.ts", "*.{js,ts}"],
       // Imported only from .svelte files / the $examples alias, which knip
       // does not trace.
-      "ignoreDependencies": ["ggsvelte", "@ggsvelte/examples"],
+      "ignoreDependencies": ["@ggsvelte/svelte", "@ggsvelte/examples"],
     },
   },
 }

--- a/lifecycle.json
+++ b/lifecycle.json
@@ -1477,7 +1477,7 @@
       }
     },
     {
-      "package": "ggsvelte",
+      "package": "@ggsvelte/svelte",
       "entry": ".",
       "source": "packages/svelte/src/lib/index.ts",
       "exports": {

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -4,13 +4,13 @@ The framework-agnostic ggsvelte engine: the grammar-of-graphics pipeline
 (stats, positions, panel-aware facets, value-stable scales, two-pass layout)
 and the pure SVG-string renderer. The main entry has no DOM dependency —
 safe in Node, edge runtimes, and workers; canvas rendering and the hit index
-live behind `@ggsvelte/core/dom`. Pre-0.1.0, explicitly unstable.
+live behind `@ggsvelte/core/dom`. The v0.1 API is intentionally early.
 
 ```sh
 bun add @ggsvelte/core     # or: npm install @ggsvelte/core
 ```
 
-Most apps want the [`ggsvelte`](https://www.npmjs.com/package/ggsvelte)
+Most apps want the [`@ggsvelte/svelte`](https://www.npmjs.com/package/@ggsvelte/svelte)
 package instead — Svelte 5 components over this engine. Use `@ggsvelte/core`
 directly for server/CLI/agent rendering.
 

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -1,5 +1,5 @@
 /**
- * `ggsvelte-render` CLI implementation (plan: the bin lives on the `ggsvelte`
+ * `ggsvelte-render` CLI implementation (plan: the bin lives on the `@ggsvelte/svelte`
  * package — packages/svelte/bin/ggsvelte-render.js is a thin wrapper around
  * this pure-entry module, so the logic is testable without spawning).
  *

--- a/packages/spec/README.md
+++ b/packages/spec/README.md
@@ -5,13 +5,13 @@ Schema (`schema/v0.json`), the `normalize()` canonicalizer, two-tier
 `validate()` with the agent error contract (`{ code, path, message,
 allowed?, fix }` — every fix carries a machine-applicable example),
 `lintSpec()` advisories, portability helpers, and the fluent `gg()/aes()`
-builder. Zero DOM, zero d3. Pre-0.1.0, explicitly unstable.
+builder. Zero DOM, zero d3. The v0.1 API is intentionally early.
 
 ```sh
 bun add @ggsvelte/spec     # or: npm install @ggsvelte/spec
 ```
 
-Most apps want the [`ggsvelte`](https://www.npmjs.com/package/ggsvelte)
+Most apps want the [`@ggsvelte/svelte`](https://www.npmjs.com/package/@ggsvelte/svelte)
 package instead — it re-exports all of this. Install `@ggsvelte/spec` alone
 for validation/authoring tooling with no renderer.
 
@@ -39,7 +39,7 @@ import schema from "@ggsvelte/spec/schema/v0.json";
 ```
 
 Render the spec with [`@ggsvelte/core`](https://www.npmjs.com/package/@ggsvelte/core)
-(headless SVG) or [`ggsvelte`](https://www.npmjs.com/package/ggsvelte)
+(headless SVG) or [`@ggsvelte/svelte`](https://www.npmjs.com/package/@ggsvelte/svelte)
 (Svelte 5 components).
 
 Repo + docs: <https://github.com/ljodea/ggsvelte> · MIT © Liam O'Dea

--- a/packages/spec/schema/v0.json
+++ b/packages/spec/schema/v0.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "ggsvelte PortableSpec",
-  "description": "A ggsvelte plot specification (schema v0 — UNSTABLE, pre-0.1.0; served from the repo until schema hosting exists).",
+  "description": "A ggsvelte plot specification (schema v0 — UNSTABLE; served from the repo until schema hosting exists).",
   "$defs": {
     "CellValue": {
       "description": "A single data cell: string, number, boolean, or null. Dates travel as ISO 8601 strings (e.g. \"2026-07-10\"); non-finite numbers travel as null.",

--- a/packages/spec/src/artifact.ts
+++ b/packages/spec/src/artifact.ts
@@ -51,7 +51,7 @@ export const SCHEMA_VERSION = "v0";
 
 /**
  * Build the publishable JSON Schema document (plain data, deterministic).
- * Explicitly UNSTABLE pre-0.1.0 per the plan; served from the repo until
+ * The v0 schema remains explicitly unstable; served from the repo until
  * hosting infrastructure exists (no $id URL is claimed yet).
  */
 export function buildSchemaArtifact(): Record<string, unknown> {
@@ -66,7 +66,7 @@ export function buildSchemaArtifact(): Record<string, unknown> {
     $schema: "https://json-schema.org/draft/2020-12/schema",
     title: "ggsvelte PortableSpec",
     description:
-      "A ggsvelte plot specification (schema v0 — UNSTABLE, pre-0.1.0; served from the repo until schema hosting exists).",
+      "A ggsvelte plot specification (schema v0 — UNSTABLE; served from the repo until schema hosting exists).",
     ...transformed,
   };
 }

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -2,18 +2,18 @@
 
 Svelte 5 adapter for the ggsvelte layered grammar of graphics — plus the
 whole `@ggsvelte/spec` + `@ggsvelte/core` surface re-exported, and the
-`ggsvelte-render` CLI. Pre-0.1.0, explicitly unstable (lifecycle tags in the
+`ggsvelte-render` CLI. The v0.1 API is intentionally early (lifecycle tags in the
 repo's `lifecycle.json`).
 
 ```sh
-bun add ggsvelte        # or: npm install ggsvelte
+bun add @ggsvelte/svelte        # or: npm install @ggsvelte/svelte
 ```
 
 ## Quick example — three surfaces, one spec
 
 ```svelte
 <script>
-  import { GGPlot, GeomPoint, gg, aes } from "ggsvelte";
+  import { GGPlot, GeomPoint, gg, aes } from "@ggsvelte/svelte";
 
   const rows = [
     { displ: 1.8, hwy: 29 },
@@ -66,7 +66,7 @@ enabled. See the [interaction guide and typed event reference](https://ljodea.gi
 ## Headless + CLI
 
 ```ts
-import { renderToSVGString } from "ggsvelte";
+import { renderToSVGString } from "@ggsvelte/svelte";
 const svg = renderToSVGString(spec, { width: 640, height: 400 });
 ```
 

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ggsvelte",
+  "name": "@ggsvelte/svelte",
   "version": "0.0.0",
   "description": "ggsvelte: a layered grammar of graphics for Svelte 5 — ggplot2 semantics, JSON-serializable specs, agent-friendly validation, hybrid SVG/canvas rendering, and the ggsvelte-render CLI.",
   "keywords": [

--- a/packages/svelte/skills/ggsvelte/SKILL.md
+++ b/packages/svelte/skills/ggsvelte/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ggsvelte
-description: Build data visualizations with ggsvelte, a grammar-of-graphics charting library (ggplot2 semantics, JSON specs, Svelte 5 components, headless SVG rendering). Use whenever creating, editing, validating, or debugging charts, plots, graphs, scatter plots, bar charts, histograms, line charts, boxplots, density plots, faceted/small-multiple charts, or data visualization in a JavaScript/TypeScript/Svelte project; when code imports from "ggsvelte", "@ggsvelte/spec", or "@ggsvelte/core"; when emitting a ggsvelte plot spec JSON; or when rendering charts server-side/headless to SVG.
+description: Build data visualizations with ggsvelte, a grammar-of-graphics charting library (ggplot2 semantics, JSON specs, Svelte 5 components, headless SVG rendering). Use whenever creating, editing, validating, or debugging charts, plots, graphs, scatter plots, bar charts, histograms, line charts, boxplots, density plots, faceted/small-multiple charts, or data visualization in a JavaScript/TypeScript/Svelte project; when code imports from "@ggsvelte/svelte", "@ggsvelte/spec", or "@ggsvelte/core"; when emitting a ggsvelte plot spec JSON; or when rendering charts server-side/headless to SVG.
 ---
 
 # ggsvelte

--- a/packages/svelte/src/lib/index.ts
+++ b/packages/svelte/src/lib/index.ts
@@ -1,7 +1,7 @@
 // ggsvelte — Svelte 5 adapter. Props-first API (<GGPlot spec/props>);
 // declaration-only children (<GeomPoint>/<GeomBar>/...) are optional sugar
 // (decision 0001, mechanism A). Re-exports the spec/core surface so
-// `bun add ggsvelte` gets everything. Owns the `ggsvelte-render` CLI bin
+// `bun add @ggsvelte/svelte` gets everything. Owns the `ggsvelte-render` CLI bin
 // (bin/ggsvelte-render.js, wrapping @ggsvelte/core's runCLI).
 //
 // Lifecycle (Hadley lesson 13; meanings in CONTRIBUTING.md): tags collected

--- a/scripts/consumer-compat.test.ts
+++ b/scripts/consumer-compat.test.ts
@@ -15,7 +15,7 @@ describe("packed consumer compatibility harness", () => {
     expect(packageTarballNames("0.1.0")).toEqual([
       "ggsvelte-spec-0.1.0.tgz",
       "ggsvelte-core-0.1.0.tgz",
-      "ggsvelte-0.1.0.tgz",
+      "ggsvelte-svelte-0.1.0.tgz",
     ]);
   });
 
@@ -69,13 +69,13 @@ describe("packed consumer compatibility harness", () => {
       [
         join("artifacts", "ggsvelte-spec-0.0.0.tgz"),
         join("artifacts", "ggsvelte-core-0.0.0.tgz"),
-        join("artifacts", "ggsvelte-0.0.0.tgz"),
+        join("artifacts", "ggsvelte-svelte-0.0.0.tgz"),
       ],
       "/consumer",
     );
     expect(manifest.dependencies.svelte).toBe("5.29.0");
     expect(manifest.dependencies["@ggsvelte/spec"]).toContain("ggsvelte-spec-0.0.0.tgz");
     expect(manifest.dependencies["@ggsvelte/core"]).toContain("ggsvelte-core-0.0.0.tgz");
-    expect(manifest.dependencies.ggsvelte).toContain("ggsvelte-0.0.0.tgz");
+    expect(manifest.dependencies["@ggsvelte/svelte"]).toContain("ggsvelte-svelte-0.0.0.tgz");
   });
 });

--- a/scripts/consumer-compat.ts
+++ b/scripts/consumer-compat.ts
@@ -27,7 +27,7 @@ export function packageTarballNames(version: string): string[] {
   return [
     `ggsvelte-spec-${version}.tgz`,
     `ggsvelte-core-${version}.tgz`,
-    `ggsvelte-${version}.tgz`,
+    `ggsvelte-svelte-${version}.tgz`,
   ];
 }
 
@@ -143,7 +143,7 @@ export function fixtureManifest(
   const localPackages = {
     "@ggsvelte/spec": file(tarballs[0]!),
     "@ggsvelte/core": file(tarballs[1]!),
-    ggsvelte: file(tarballs[2]!),
+    "@ggsvelte/svelte": file(tarballs[2]!),
   };
   return {
     name: "ggsvelte-packed-consumer",
@@ -175,7 +175,7 @@ function writeFixture(
   if (packageManager === "pnpm") {
     writeFileSync(
       join(directory, "pnpm-workspace.yaml"),
-      `packages: []\noverrides:\n  '@ggsvelte/spec': ${JSON.stringify(manifest.dependencies["@ggsvelte/spec"])}\n  '@ggsvelte/core': ${JSON.stringify(manifest.dependencies["@ggsvelte/core"])}\n  'ggsvelte': ${JSON.stringify(manifest.dependencies.ggsvelte)}\n`,
+      `packages: []\noverrides:\n  '@ggsvelte/spec': ${JSON.stringify(manifest.dependencies["@ggsvelte/spec"])}\n  '@ggsvelte/core': ${JSON.stringify(manifest.dependencies["@ggsvelte/core"])}\n  '@ggsvelte/svelte': ${JSON.stringify(manifest.dependencies["@ggsvelte/svelte"])}\n`,
     );
   }
   writeFileSync(
@@ -203,7 +203,7 @@ function writeFixture(
   writeFileSync(
     join(directory, "src", "App.svelte"),
     `<script lang="ts">
-  import { GGPlot, type PortableSpec } from "ggsvelte";
+  import { GGPlot, type PortableSpec } from "@ggsvelte/svelte";
   const spec: PortableSpec = ${JSON.stringify(plotSpec)};
 </script>
 <GGPlot {spec} width={480} height={320} inspect={true} />
@@ -222,14 +222,14 @@ await build({
   configFile: false,
   plugins: [svelte()],
   build: { ssr: "src/ssr.ts", outDir: "dist-ssr" },
-  ssr: { noExternal: ["ggsvelte"] },
+  ssr: { noExternal: ["@ggsvelte/svelte"] },
 });
 `,
   );
   writeFileSync(
     join(directory, "src", "ssr.ts"),
     `import { render } from "svelte/server";
-import { GGPlot, type PortableSpec } from "ggsvelte";
+import { GGPlot, type PortableSpec } from "@ggsvelte/svelte";
 const spec: PortableSpec = ${JSON.stringify(plotSpec)};
 export const html = render(GGPlot, { props: { spec, width: 480, height: 320 } }).body;
 `,

--- a/scripts/gen-lifecycle.test.ts
+++ b/scripts/gen-lifecycle.test.ts
@@ -104,7 +104,7 @@ describe("lifecycle.json", () => {
       expect(spec).toContain(name);
     }
     expect(stableIntent("@ggsvelte/core", ".")).toContain("renderToSVGString");
-    const svelte = stableIntent("ggsvelte", ".");
+    const svelte = stableIntent("@ggsvelte/svelte", ".");
     for (const name of ["GGPlot", "PortableSpec", "normalize", "validate", "renderToSVGString"]) {
       expect(svelte).toContain(name);
     }

--- a/scripts/gen-lifecycle.ts
+++ b/scripts/gen-lifecycle.ts
@@ -32,7 +32,7 @@ export const SURFACES: readonly { pkg: string; entry: string; file: string }[] =
   { pkg: "@ggsvelte/spec", entry: ".", file: "packages/spec/src/index.ts" },
   { pkg: "@ggsvelte/core", entry: ".", file: "packages/core/src/index.ts" },
   { pkg: "@ggsvelte/core", entry: "./dom", file: "packages/core/src/dom/index.ts" },
-  { pkg: "ggsvelte", entry: ".", file: "packages/svelte/src/lib/index.ts" },
+  { pkg: "@ggsvelte/svelte", entry: ".", file: "packages/svelte/src/lib/index.ts" },
 ];
 
 export class LifecycleError extends Error {

--- a/scripts/gen-llms.ts
+++ b/scripts/gen-llms.ts
@@ -154,7 +154,7 @@ canonical spec — JSON for agents, a fluent builder, and Svelte 5 components.
 ## Install
 
 \`\`\`sh
-bun add ggsvelte        # or: npm install ggsvelte
+bun add @ggsvelte/svelte        # or: npm install @ggsvelte/svelte
 \`\`\`
 
 The \`ggsvelte\` package re-exports the whole surface (\`@ggsvelte/spec\` and
@@ -171,7 +171,7 @@ same canonical PortableSpec.
 
 \`\`\`svelte
 <script>
-  import { GGPlot } from "ggsvelte";
+  import { GGPlot } from "@ggsvelte/svelte";
 
   const spec = {
     data: { values: [{ displ: 1.8, hwy: 29 }, { displ: 5.7, hwy: 16 }] },
@@ -191,7 +191,7 @@ same canonical PortableSpec.
 the canonical PortableSpec:
 
 \`\`\`ts
-import { aes, gg } from "ggsvelte";
+import { aes, gg } from "@ggsvelte/svelte";
 
 const spec = gg(rows, aes({ x: "displ", y: "hwy" })).geomPoint().spec();
 \`\`\`
@@ -200,7 +200,7 @@ const spec = gg(rows, aes({ x: "displ", y: "hwy" })).geomPoint().spec();
 
 \`\`\`svelte
 <script>
-  import { GGPlot, GeomPoint } from "ggsvelte";
+  import { GGPlot, GeomPoint } from "@ggsvelte/svelte";
   import { rows } from "./data.js";
 </script>
 
@@ -497,7 +497,7 @@ plot tool rail must stay synchronized:
 
 \`\`\`svelte
 <script lang="ts">
-  import type { InteractionTool } from "ggsvelte";
+  import type { InteractionTool } from "@ggsvelte/svelte";
 
   let activeTool = $state<InteractionTool>("inspect");
 </script>
@@ -851,12 +851,12 @@ Every public export carries a lifecycle tag (generated into
 \`bun run lifecycle:gen\`):
 
 - **experimental** — may change or disappear in any 0.x release. The default
-  for everything pre-0.1.0.
+  for APIs not explicitly promoted.
 - **stable-intent** — the agent core path (PortableSpec, normalize, validate,
   renderToSVGString, GGPlot and their direct result contracts). Not frozen
   pre-1.0, but changes here are treated as breaking: they get a changeset, a
   migration note, and a deprecation window where feasible.
-- **stable** — committed API under semver (none pre-0.1.0).
+- **stable** — committed API under semver (none in v0.1).
 - **superseded** — keeps working but stops being recommended; docs point to
   the replacement. Protects agent-generated code from silent breakage.
 
@@ -974,7 +974,7 @@ export function buildLlmsIndex(
   lines.push(
     "- [Local data playground](/playground): safely try bounded JSON rows with static and interactive chart controls",
     "- [Search interaction reference](/reference/interactions): filter interaction capabilities, events, diagnostics, and accessibility guidance",
-    "- [JSON Schema v0](/schema/v0.json): the PortableSpec schema (unstable pre-0.1.0)",
+    "- [JSON Schema v0](/schema/v0.json): the PortableSpec schema (unstable in v0.1)",
     "- [llms-full.txt](/llms-full.txt): all docs prose plus every example (spec JSON + Svelte source)",
     "",
     "## Examples",

--- a/scripts/package-lint.ts
+++ b/scripts/package-lint.ts
@@ -6,7 +6,7 @@
  * SKIPPED (reported, exit 0) so this script stays safe on fresh checkouts.
  *
  * attw runs with `--profile esm-only`: the workspace is ESM-only by plan
- * (no CJS artifacts, node10 resolution out of scope). The `ggsvelte` package
+ * (no CJS artifacts, node10 resolution out of scope). The `@ggsvelte/svelte` package
  * is checked by publint ONLY: its d.ts files import `./*.svelte` modules,
  * which no node16 TS resolution mode can resolve — Svelte packages are
  * consumed through bundlers via the `svelte`/`import` conditions (svelte-kit

--- a/scripts/release-wiring.test.ts
+++ b/scripts/release-wiring.test.ts
@@ -52,9 +52,11 @@ describe("R0 release wiring", () => {
 
   it("versions only publishable packages", () => {
     const config = JSON.parse(read(".changeset/config.json")) as {
+      linked?: string[][];
       privatePackages?: boolean | { version?: boolean; tag?: boolean };
     };
     expect(config.privatePackages).toBe(false);
+    expect(config.linked).toEqual([["@ggsvelte/spec", "@ggsvelte/core", "@ggsvelte/svelte"]]);
   });
 
   it("ships the CLI bin without npm manifest normalization", () => {

--- a/skills/ggsvelte/SKILL.md
+++ b/skills/ggsvelte/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ggsvelte
-description: Build data visualizations with ggsvelte, a grammar-of-graphics charting library (ggplot2 semantics, JSON specs, Svelte 5 components, headless SVG rendering). Use whenever creating, editing, validating, or debugging charts, plots, graphs, scatter plots, bar charts, histograms, line charts, boxplots, density plots, faceted/small-multiple charts, or data visualization in a JavaScript/TypeScript/Svelte project; when code imports from "ggsvelte", "@ggsvelte/spec", or "@ggsvelte/core"; when emitting a ggsvelte plot spec JSON; or when rendering charts server-side/headless to SVG.
+description: Build data visualizations with ggsvelte, a grammar-of-graphics charting library (ggplot2 semantics, JSON specs, Svelte 5 components, headless SVG rendering). Use whenever creating, editing, validating, or debugging charts, plots, graphs, scatter plots, bar charts, histograms, line charts, boxplots, density plots, faceted/small-multiple charts, or data visualization in a JavaScript/TypeScript/Svelte project; when code imports from "@ggsvelte/svelte", "@ggsvelte/spec", or "@ggsvelte/core"; when emitting a ggsvelte plot spec JSON; or when rendering charts server-side/headless to SVG.
 ---
 
 # ggsvelte


### PR DESCRIPTION
npm rejects the unscoped `ggsvelte` name under its anti-typosquatting policy because it is too similar to `svelte`. Publish the adapter as `@ggsvelte/svelte` instead.

- migrate package identity, imports, install docs, lockfile, lifecycle metadata, and Changesets config
- update packed-consumer fixtures and expected scoped tarball name
- update v0.1 status/schema language
- retain the `ggsvelte-render` CLI

Verification:
- 606 focused/release tests pass
- build and package lint pass
- scoped npm publish dry-run is warning-free
- full pre-push parity suite passes