### PR TITLE
fix: publish installable internal dependencies

### DIFF
--- a/.changeset/clean-registry-dependencies.md
+++ b/.changeset/clean-registry-dependencies.md
@@ -1,0 +1,9 @@
+---
+"@ggsvelte/spec": patch
+"@ggsvelte/core": patch
+"@ggsvelte/svelte": patch
+---
+
+# Installable registry dependencies
+
+Publish registry-compatible internal dependency ranges and verify release-shaped tarballs with npm, matching the actual Changesets publishing path.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -43,7 +43,7 @@
     "provenance": true
   },
   "dependencies": {
-    "@ggsvelte/spec": "workspace:*"
+    "@ggsvelte/spec": "^0.1.0"
   },
   "devDependencies": {
     "typescript": "^6.0.3"

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -51,8 +51,8 @@
     "test:ssr": "vitest run --config vitest.ssr.config.ts"
   },
   "dependencies": {
-    "@ggsvelte/core": "workspace:*",
-    "@ggsvelte/spec": "workspace:*"
+    "@ggsvelte/core": "^0.1.0",
+    "@ggsvelte/spec": "^0.1.0"
   },
   "devDependencies": {
     "@sveltejs/package": "^2.5.8",

--- a/scripts/consumer-compat.test.ts
+++ b/scripts/consumer-compat.test.ts
@@ -6,6 +6,7 @@ import {
   commandInvocation,
   commandPlan,
   fixtureManifest,
+  packagePackInvocation,
   packageTarballNames,
   resolveConsumerOptions,
 } from "./consumer-compat.js";
@@ -24,6 +25,14 @@ describe("packed consumer compatibility harness", () => {
     expect(commandExecutable("pnpm", "win32")).toBe("pnpm.cmd");
     expect(commandExecutable("bun", "win32")).toBe("bun");
     expect(commandExecutable("npm", "linux")).toBe("npm");
+  });
+
+  test("packs release-shaped artifacts with npm, matching changesets publish", () => {
+    expect(packagePackInvocation("/artifacts", "linux")).toEqual({
+      command: "npm",
+      args: ["pack", ".", "--pack-destination", "/artifacts", "--ignore-scripts", "--silent"],
+    });
+    expect(packagePackInvocation("C:\\artifacts", "win32").command).toBe("npm.cmd");
   });
 
   test("reads matrix options from the environment without shell-specific expansion", () => {

--- a/scripts/consumer-compat.ts
+++ b/scripts/consumer-compat.ts
@@ -64,6 +64,16 @@ export function commandInvocation(
   return { command: commandExecutable(command, platform), args };
 }
 
+export function packagePackInvocation(
+  artifacts: string,
+  platform = process.platform,
+): { command: string; args: string[] } {
+  return {
+    command: commandExecutable("npm", platform),
+    args: ["pack", ".", "--pack-destination", artifacts, "--ignore-scripts", "--silent"],
+  };
+}
+
 function runner(packageManager: PackageManager, binary: string, args: string[]): CommandStep {
   if (packageManager === "npm") {
     return { label: "", command: "npm", args: ["exec", "--", binary, ...args] };
@@ -305,15 +315,12 @@ function pack(root: string, artifacts: string): string[] {
     }
   ).version;
   for (const packageDirectory of ["spec", "core", "svelte"]) {
-    const result = spawnSync(
-      "bun",
-      ["pm", "pack", "--destination", artifacts, "--ignore-scripts", "--quiet"],
-      {
-        cwd: join(root, "packages", packageDirectory),
-        stdio: "inherit",
-        shell: false,
-      },
-    );
+    const invocation = packagePackInvocation(artifacts);
+    const result = spawnSync(invocation.command, invocation.args, {
+      cwd: join(root, "packages", packageDirectory),
+      stdio: "inherit",
+      shell: false,
+    });
     if (result.status !== 0) throw new Error(`packing packages/${packageDirectory} failed`);
   }
   const tarballs = packageTarballNames(version).map((name) => join(artifacts, name));

--- a/scripts/release-wiring.test.ts
+++ b/scripts/release-wiring.test.ts
@@ -59,6 +59,18 @@ describe("R0 release wiring", () => {
     expect(config.linked).toEqual([["@ggsvelte/spec", "@ggsvelte/core", "@ggsvelte/svelte"]]);
   });
 
+  it("keeps internal dependencies installable in npm-published manifests", () => {
+    for (const path of ["packages/core/package.json", "packages/svelte/package.json"]) {
+      const manifest = JSON.parse(read(path)) as { dependencies?: Record<string, string> };
+      for (const [name, range] of Object.entries(manifest.dependencies ?? {})) {
+        if (!name.startsWith("@ggsvelte/")) continue;
+        expect(range, `${path}: ${name} must be a registry semver range`).not.toStartWith(
+          "workspace:",
+        );
+      }
+    }
+  });
+
   it("ships the CLI bin without npm manifest normalization", () => {
     const manifest = JSON.parse(read("packages/svelte/package.json")) as {
       bin?: Record<string, string>;


### PR DESCRIPTION
## What changed
- replace publishable `workspace:*` dependencies with registry semver ranges
- pack compatibility fixtures with npm, matching Changesets publish
- add regression coverage that rejects workspace protocols in published manifests
- add a linked patch changeset for all three packages

## Root cause
The compatibility harness used `bun pm pack`, which rewrote workspace protocols, while Changesets publishes through npm, which preserved `workspace:*`. The registry artifacts therefore differed from the tested tarballs and could not be installed.

## Evidence
- regression test failed before the fix on `@ggsvelte/spec: workspace:*`
- `bun run fmt:check`
- `bun run build`
- `bun run lint:package`
- `bun test packages/spec packages/core benchmarks scripts tests/evals` (608 pass, 0 fail)
- `PACKAGE_MANAGER=npm SVELTE_VERSION=5.29.0 bun scripts/consumer-compat.ts`