### PR TITLE
refactor(svelte): split GGPlot helpers and presentational UI

### DIFF
--- a/packages/svelte/src/lib/GGPlot.svelte
+++ b/packages/svelte/src/lib/GGPlot.svelte
@@ -89,8 +89,22 @@
   import { createInteractionReducer } from "./interaction-reducer.js";
   import type { LayerDescriptor } from "./registry.svelte.js";
   import { provideRegistry } from "./registry.svelte.js";
+  import { a11yRows } from "./canvas-a11y.js";
+  import InteractionOverlay from "./InteractionOverlay.svelte";
+  import {
+    clamp,
+    frozenZoomDomains,
+    normalizedRect,
+    panelDataDomains,
+  } from "./plot-geometry.js";
+  import {
+    datumLabel as datumLabelFor,
+    inspectionLiveText as inspectionLiveTextFor,
+    markLabel as markLabelFor,
+  } from "./plot-labels.js";
   import SceneView from "./SceneView.svelte";
   import Tooltip from "./Tooltip.svelte";
+  import ToolRail from "./ToolRail.svelte";
 
   type PublicKey = Identity extends keyof Row
     ? Extract<Row[Identity], PropertyKey>
@@ -186,33 +200,6 @@
   }: Props = $props();
 
   const registry = provideRegistry();
-
-  const clamp = (v: number, lo: number, hi: number) =>
-    Math.max(lo, Math.min(hi, v));
-
-  /** Invert a normalized [t0, t1] window through a positional scale (band
-   *  scales cannot zoom — documented M2 limitation). */
-  function invertedDomain(
-    scale: RenderModel["scales"]["x"],
-    t0: number,
-    t1: number,
-  ): [number, number] | undefined {
-    if (scale.type === "band") return undefined;
-    const a = scale.invert(t0);
-    const b = scale.invert(t1);
-    return a <= b ? [a, b] : [b, a];
-  }
-
-  function frozenZoomDomains(domains: ZoomDomains): ZoomDomains {
-    return Object.freeze({
-      ...(domains.x !== undefined && {
-        x: Object.freeze([...domains.x]) as unknown as [number, number],
-      }),
-      ...(domains.y !== undefined && {
-        y: Object.freeze([...domains.y]) as unknown as [number, number],
-      }),
-    });
-  }
 
   function toLayerInput(descriptor: LayerDescriptor): LayerInput {
     // Reading .aes/.position/.params here goes through the child's live
@@ -517,32 +504,6 @@
     };
   }
 
-  /** Rows referenced by a canvas stratum, capped for the a11y table. */
-  const A11Y_TABLE_CAP = 100;
-  function a11yRows(
-    m: RenderModel,
-    batches: GeometryBatch[],
-  ): { fields: string[]; rows: CellValue[][]; total: number } {
-    const rowSet = new Set<number>();
-    for (const batch of batches) {
-      for (const raw of batch.rowIndex) {
-        if (raw !== 0xffffffff) rowSet.add(raw);
-      }
-    }
-    const fieldSet = new Set<string>();
-    for (const batch of batches) {
-      for (const f of m.layerFields[batch.layerIndex] ?? [])
-        fieldSet.add(f.field);
-    }
-    const fields = [...fieldSet];
-    const rows: CellValue[][] = [];
-    for (const index of [...rowSet].toSorted((a, b) => a - b)) {
-      if (rows.length >= A11Y_TABLE_CAP) break;
-      const row = m.row(index);
-      if (row !== null) rows.push(fields.map((f) => row[f] ?? null));
-    }
-    return { fields, rows, total: rowSet.size };
-  }
   let a11yTableOpen = $state(false);
 
   // ---------------------------------------------------------- interaction
@@ -1482,24 +1443,9 @@
       {};
     if (model !== null && model.scene.panels.length === 1) {
       const solePanel = model.scene.panels[0]!;
-      const tx0 = clamp((rect.x0 - solePanel.x) / solePanel.width, 0, 1);
-      const tx1 = clamp((rect.x1 - solePanel.x) / solePanel.width, 0, 1);
-      const ty0 = clamp(1 - (rect.y1 - solePanel.y) / solePanel.height, 0, 1);
-      const ty1 = clamp(1 - (rect.y0 - solePanel.y) / solePanel.height, 0, 1);
-      const horizontalDomain = invertedDomain(
-        flip ? model.scales.y : model.scales.x,
-        tx0,
-        tx1,
-      );
-      const verticalDomain = invertedDomain(
-        flip ? model.scales.x : model.scales.y,
-        ty0,
-        ty1,
-      );
-      const xDomain = flip ? verticalDomain : horizontalDomain;
-      const yDomain = flip ? horizontalDomain : verticalDomain;
-      if (mode !== "y" && xDomain !== undefined) domain.x = xDomain;
-      if (mode !== "x" && yDomain !== undefined) domain.y = yDomain;
+      const inverted = panelDataDomains(rect, solePanel, model.scales, flip);
+      if (mode !== "y" && inverted.x !== undefined) domain.x = inverted.x;
+      if (mode !== "x" && inverted.y !== undefined) domain.y = inverted.y;
     }
     const frozenDomain = Object.freeze({
       ...(domain.x !== undefined && {
@@ -1651,20 +1597,6 @@
     resetZoom("pointer");
   }
 
-  function normalizedRect(r: {
-    x0: number;
-    y0: number;
-    x1: number;
-    y1: number;
-  }) {
-    return {
-      x0: Math.min(r.x0, r.x1),
-      y0: Math.min(r.y0, r.y1),
-      x1: Math.max(r.x0, r.x1),
-      y1: Math.max(r.y0, r.y1),
-    };
-  }
-
   /**
    * Brush-to-zoom = an intentional respec: invert the brushed plot-px rect
    * through the trained scales into explicit continuous domains. Band axes
@@ -1687,70 +1619,24 @@
     const tv0 = clamp(1 - (rect.y1 - panel.y) / panel.height, 0, 1);
     const tv1 = clamp(1 - (rect.y0 - panel.y) / panel.height, 0, 1);
     if (th1 - th0 <= 0 && tv1 - tv0 <= 0) return;
-    const hScale = flip ? model.scales.y : model.scales.x;
-    const vScale = flip ? model.scales.x : model.scales.y;
-    const next: ZoomDomains = { ...effectiveZoomDomains };
-    const hDomain = invertedDomain(hScale, th0, th1);
-    const vDomain = invertedDomain(vScale, tv0, tv1);
+    const inverted = panelDataDomains(rect, panel, model.scales, flip);
     const mode = interactionConfig.zoom?.mode ?? "xy";
-    const horizontalChannel = flip ? "y" : "x";
-    const verticalChannel = flip ? "x" : "y";
-    if (hDomain !== undefined && mode !== verticalChannel)
-      next[horizontalChannel] = hDomain;
-    if (vDomain !== undefined && mode !== horizontalChannel)
-      next[verticalChannel] = vDomain;
+    const next: ZoomDomains = { ...effectiveZoomDomains };
+    if (mode !== "y" && inverted.x !== undefined) next.x = inverted.x;
+    if (mode !== "x" && inverted.y !== undefined) next.y = inverted.y;
     if (next.x === undefined && next.y === undefined) return;
     commitZoom(frozenZoomDomains(next), source);
   }
 
-  /** Accessible per-mark label from the layer's mapped fields. */
-  function markLabel(row: number): string {
-    if (model === null) return `data point ${row + 1}`;
-    const values = model.row(row);
-    if (values === null) return `data point ${row + 1}`;
-    const fields = model.layerFields.flat();
-    const seen = new Set<string>();
-    const parts: string[] = [];
-    for (const f of fields) {
-      if (seen.has(f.field)) continue;
-      seen.add(f.field);
-      parts.push(`${f.field} ${String(values[f.field] ?? "")}`);
-    }
-    return parts.join(", ") || `data point ${row + 1}`;
-  }
-
-  function datumLabel(values: Record<string, CellValue> | null): string {
-    if (values === null) return "No active datum";
-    const fields = model?.layerFields.flat() ?? [];
-    const seen = new Set<string>();
-    const parts: string[] = [];
-    for (const field of fields) {
-      if (seen.has(field.field)) continue;
-      seen.add(field.field);
-      parts.push(`${field.field} ${String(values[field.field] ?? "")}`);
-    }
-    return parts.join(", ") || "Active datum";
-  }
-
-  function inspectionLiveText(
+  // Stable SceneView callback identity when model is unchanged.
+  const markLabel = $derived.by(
+    () => (row: number) => markLabelFor(model, row),
+  );
+  const datumLabel = (values: Record<string, CellValue> | null) =>
+    datumLabelFor(model, values);
+  const inspectionLiveText = (
     value: PlotInspectionChange<Record<string, CellValue>, PropertyKey>,
-  ): string {
-    const count = value.members.length;
-    const state = value.state === "pinned" ? ", pinned" : "";
-    if (value.mode !== "x" && value.mode !== "y")
-      return `${datumLabel(value.focus.row)}; ${String(count)} ${count === 1 ? "datum" : "data"}${state}`;
-    const seen = new Set<string>();
-    const focused = value.focus.fields
-      .filter(
-        (field) =>
-          field.channel !== value.mode &&
-          !seen.has(field.field) &&
-          seen.add(field.field),
-      )
-      .map((field) => `${field.field} ${String(field.value ?? "")}`)
-      .join(", ");
-    return `${value.mode} ${value.axisLabel}; ${String(count)} ${count === 1 ? "datum" : "data"}${focused ? `; focused ${focused}` : ""}${state}`;
-  }
+  ) => inspectionLiveTextFor(model, value);
 
   function navigate(delta: number): void {
     if (traversalHits.length === 0) return;
@@ -2001,52 +1887,20 @@
 >
   {@render children?.()}
   {#if showToolRail}
-    <div
-      class="gg-tool-rail"
-      role="toolbar"
-      aria-label="Chart interaction tools"
-      aria-busy={!ready}
-    >
-      <div class="gg-tool-modes">
-        {#each availableTools as available (available)}
-          <button
-            type="button"
-            disabled={!ready ||
-              (emptyPlot &&
-                (available === "select-area" || available === "zoom-area"))}
-            class:active={activeTool === available}
-            aria-pressed={activeTool === available}
-            onclick={() => chooseTool(available)}
-            >{available === "select-area"
-              ? "Select area"
-              : available === "zoom-area"
-                ? "Zoom area"
-                : available === "point"
-                  ? "Select point"
-                  : "Inspect"}</button
-          >
-        {/each}
-      </div>
-      <div class="gg-tool-recovery-actions">
-        {#if effectiveZoomDomains !== null}
-          <button type="button" onclick={() => resetZoom("pointer")}
-            >Reset zoom</button
-          >
-        {/if}
-        {#if effectiveSelectedKeys.length > 0}
-          <button type="button" onclick={() => clearPointSelection("pointer")}
-            >Clear selection</button
-          >
-        {/if}
-        {#if committedInterval !== null}
-          <button
-            type="button"
-            onclick={() => clearIntervalSelection("pointer")}
-            >Clear selection</button
-          >
-        {/if}
-      </div>
-    </div>
+    <ToolRail
+      {availableTools}
+      {activeTool}
+      {ready}
+      {emptyPlot}
+      narrow={resolvedWidth < 560}
+      zoomDomains={effectiveZoomDomains}
+      hasPointSelection={effectiveSelectedKeys.length > 0}
+      hasIntervalSelection={committedInterval !== null}
+      onChooseTool={chooseTool}
+      onResetZoom={() => resetZoom("pointer")}
+      onClearPointSelection={() => clearPointSelection("pointer")}
+      onClearIntervalSelection={() => clearIntervalSelection("pointer")}
+    />
   {/if}
   {#if model !== null}
     {#if hasCanvas}
@@ -2106,138 +1960,27 @@
       <SceneView scene={model.scene} focusable={false} {markLabel} />
     {/if}
     {#if !interactive && emphasizedAnchors.length > 0}
-      <svg
-        class="gg-stratum gg-interaction-overlay"
+      <InteractionOverlay
         width={model.scene.width}
         height={model.scene.height}
-        viewBox={`0 0 ${model.scene.width} ${model.scene.height}`}
-        aria-hidden="true"
-      >
-        {#each emphasizedAnchors as anchor, index (index)}
-          <circle
-            class="gg-emphasized-ring"
-            cx={anchor.x}
-            cy={anchor.y}
-            r="11"
-            fill="none"
-          />
-        {/each}
-      </svg>
+        interactive={false}
+        {emphasizedAnchors}
+      />
     {/if}
     {#if interactive}
-      <svg
-        class="gg-stratum gg-interaction-overlay"
+      <InteractionOverlay
         width={model.scene.width}
         height={model.scene.height}
-        viewBox={`0 0 ${model.scene.width} ${model.scene.height}`}
-        aria-hidden="true"
-      >
-        {#if inspection !== null}
-          {#if inspection.mode === "xy" || (inspection.mode === "x" && !coordFlipped) || (inspection.mode === "y" && coordFlipped)}
-            {#if inspectionPanel}
-              <line
-                class="gg-crosshair"
-                x1={inspection.focus.anchor.x}
-                x2={inspection.focus.anchor.x}
-                y1={inspectionPanel.y}
-                y2={inspectionPanel.y + inspectionPanel.height}
-              />
-              {#if "axisLabel" in inspection}
-                <text
-                  class={`gg-crosshair-axis-label gg-crosshair-axis-label-${inspection.mode}`}
-                  x={inspection.focus.anchor.x}
-                  y={inspectionPanel.y + inspectionPanel.height - 4}
-                  text-anchor="middle">{inspection.axisLabel}</text
-                >
-              {/if}
-            {/if}
-          {/if}
-          {#if inspection.mode === "xy" || (inspection.mode === "y" && !coordFlipped) || (inspection.mode === "x" && coordFlipped)}
-            {#if inspectionPanel}
-              <line
-                class="gg-crosshair"
-                x1={inspectionPanel.x}
-                x2={inspectionPanel.x + inspectionPanel.width}
-                y1={inspection.focus.anchor.y}
-                y2={inspection.focus.anchor.y}
-              />
-              {#if "axisLabel" in inspection}
-                <text
-                  class={`gg-crosshair-axis-label gg-crosshair-axis-label-${inspection.mode}`}
-                  x={inspectionPanel.x + 4}
-                  y={inspection.focus.anchor.y - 4}>{inspection.axisLabel}</text
-                >
-              {/if}
-            {/if}
-          {/if}
-          <circle
-            class="gg-hover-ring"
-            cx={inspection.focus.anchor.x}
-            cy={inspection.focus.anchor.y}
-            r="6"
-            fill="none"
-          />
-        {/if}
-        {#each selectedAnchors as anchor, index (index)}
-          <circle
-            class="gg-selected-ring"
-            cx={anchor.x}
-            cy={anchor.y}
-            r="8"
-            fill="none"
-          />
-        {/each}
-        {#each emphasizedAnchors as anchor, index (index)}
-          <circle
-            class="gg-emphasized-ring"
-            cx={anchor.x}
-            cy={anchor.y}
-            r="11"
-            fill="none"
-          />
-        {/each}
-        {#if brushRect !== null}
-          {@const r = normalizedRect(brushRect)}
-          <rect
-            class="gg-area-draft"
-            class:gg-area-draft-select={activeTool === "select-area"}
-            class:gg-area-draft-zoom={activeTool === "zoom-area"}
-            x={r.x0}
-            y={r.y0}
-            width={r.x1 - r.x0}
-            height={r.y1 - r.y0}
-            fill={activeTool === "zoom-area"
-              ? "none"
-              : "var(--gg-selectionFill, var(--gg-theme-selectionFill, currentColor))"}
-            fill-opacity={activeTool === "zoom-area" ? undefined : "0.12"}
-            stroke="var(--gg-selectionStroke, var(--gg-theme-selectionStroke, currentColor))"
-          />
-          {#if activeTool === "zoom-area"}
-            <text class="gg-zoom-label" x={r.x0 + 5} y={r.y0 + 15}>Zoom</text>
-          {/if}
-          {#if areaAwaitingSecond}
-            <circle
-              class="gg-first-corner"
-              cx={brushRect.x0}
-              cy={brushRect.y0}
-              r="4"
-              fill="var(--gg-selectionStroke, var(--gg-theme-selectionStroke, currentColor))"
-            />
-          {/if}
-        {/if}
-        {#if committedInterval !== null}
-          <rect
-            class="gg-selection"
-            x={committedInterval.pixels.x0}
-            y={committedInterval.pixels.y0}
-            width={committedInterval.pixels.x1 - committedInterval.pixels.x0}
-            height={committedInterval.pixels.y1 - committedInterval.pixels.y0}
-            fill="var(--gg-selectionFill, var(--gg-theme-selectionFill, currentColor))"
-            fill-opacity="0.08"
-            stroke="var(--gg-selectionStroke, var(--gg-theme-selectionStroke, currentColor))"
-          />
-        {/if}
-      </svg>
+        {inspection}
+        {inspectionPanel}
+        {coordFlipped}
+        {selectedAnchors}
+        {emphasizedAnchors}
+        {brushRect}
+        {activeTool}
+        {areaAwaitingSecond}
+        {committedInterval}
+      />
       <!-- The capture layer is a pointer-only surface; the accessible
            interaction paths are focusable marks and the data table. -->
       <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
@@ -2364,7 +2107,8 @@
 
   /* Strata: full-size positioned siblings; document order = paint order
      (no z-index anywhere — decision 0006). All inert; the capture layer
-     owns pointer events. */
+     owns pointer events. Parent-owned so extracted overlay SVGs with
+     class gg-stratum stay absolutely positioned. */
   .gg-plot-root :global(.gg-stratum),
   .gg-canvas-a11y {
     position: absolute;
@@ -2434,100 +2178,9 @@
     cursor: crosshair;
   }
 
-  .gg-capture:focus-visible,
-  .gg-tool-rail button:focus-visible {
+  .gg-capture:focus-visible {
     outline: 2px solid var(--gg-focusRing, var(--gg-theme-focusRing, Highlight));
     outline-offset: 2px;
-  }
-
-  .gg-crosshair {
-    stroke: var(--gg-crosshair, var(--gg-theme-crosshair, currentColor));
-    stroke-width: 1;
-    vector-effect: non-scaling-stroke;
-    opacity: 0.55;
-  }
-
-  .gg-crosshair-axis-label {
-    fill: var(
-      --gg-interactionInk,
-      var(--gg-theme-interactionInk, currentColor)
-    );
-    font: 11px/1 var(--gg-font-family, sans-serif);
-    paint-order: stroke;
-    stroke: var(--gg-tooltipPaper, var(--gg-theme-tooltipPaper, white));
-    stroke-width: 3px;
-    stroke-linejoin: round;
-  }
-
-  .gg-hover-ring {
-    stroke: var(
-      --gg-interactionInk,
-      var(--gg-theme-interactionInk, currentColor)
-    );
-    stroke-width: 1.5;
-    vector-effect: non-scaling-stroke;
-  }
-
-  .gg-selected-ring {
-    stroke: var(
-      --gg-selectionStroke,
-      var(--gg-theme-selectionStroke, currentColor)
-    );
-    stroke-width: 2.5;
-    vector-effect: non-scaling-stroke;
-  }
-
-  .gg-emphasized-ring {
-    stroke: var(
-      --gg-interactionInk,
-      var(--gg-theme-interactionInk, currentColor)
-    );
-    stroke-width: 2;
-    stroke-dasharray: 3 2;
-    vector-effect: non-scaling-stroke;
-  }
-
-  @media (forced-colors: active) {
-    .gg-emphasized-ring {
-      stroke: Highlight;
-    }
-  }
-
-  .gg-tool-rail {
-    position: absolute;
-    left: 8px;
-    right: 8px;
-    top: -48px;
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) auto;
-    gap: 4px;
-    align-items: center;
-    z-index: 1;
-    line-height: 1.2;
-    pointer-events: auto;
-  }
-
-  .gg-tool-modes,
-  .gg-tool-recovery-actions {
-    display: flex;
-    align-items: center;
-    gap: 4px;
-  }
-
-  .gg-tool-rail button {
-    min-height: 44px;
-    min-width: 44px;
-    border: 0;
-    border-bottom: 2px solid transparent;
-    border-radius: 0;
-    padding: 0 10px;
-    background: transparent;
-    color: var(
-      --gg-interactionMuted,
-      var(--gg-theme-interactionMuted, currentColor)
-    );
-    font: inherit;
-    font-size: 14px;
   }
 
   .gg-area-instruction {
@@ -2543,35 +2196,6 @@
     font-size: 13px;
     line-height: 1.25;
     pointer-events: none;
-  }
-
-  .gg-tool-rail button.active {
-    border-bottom-color: var(
-      --gg-toolActive,
-      var(--gg-theme-toolActive, currentColor)
-    );
-    color: var(--gg-toolActive, var(--gg-theme-toolActive, currentColor));
-  }
-
-  .gg-tool-recovery-actions:empty {
-    display: none;
-  }
-
-  .gg-area-draft,
-  .gg-selection {
-    stroke-width: 1;
-    vector-effect: non-scaling-stroke;
-  }
-
-  .gg-zoom-label {
-    fill: var(
-      --gg-interactionInk,
-      var(--gg-theme-interactionInk, currentColor)
-    );
-    font: 10px/1 var(--gg-font-family, sans-serif);
-    paint-order: stroke;
-    stroke: var(--gg-tooltipPaper, var(--gg-theme-tooltipPaper, white));
-    stroke-width: 3px;
   }
 
   .gg-empty-state {
@@ -2603,34 +2227,12 @@
     .gg-with-tool-rail {
       margin-top: 96px;
     }
-
-    .gg-tool-rail {
-      top: -92px;
-      grid-template-columns: 1fr;
-      grid-template-rows: auto auto;
-    }
-
-    .gg-tool-modes,
-    .gg-tool-recovery-actions {
-      width: 100%;
-    }
   }
 
   /* ResizeObserver-backed fallback for engines that do not apply a query to
      descendants of a component-owned named container during hydration. */
   .gg-narrow-tools.gg-with-tool-rail {
     margin-top: 96px;
-  }
-
-  .gg-narrow-tools .gg-tool-rail {
-    top: -92px;
-    grid-template-columns: 1fr;
-    grid-template-rows: auto auto;
-  }
-
-  .gg-narrow-tools .gg-tool-modes,
-  .gg-narrow-tools .gg-tool-recovery-actions {
-    width: 100%;
   }
 
   .gg-sr-only {
@@ -2654,37 +2256,8 @@
   }
 
   @media (forced-colors: active) {
-    .gg-capture:focus-visible,
-    .gg-tool-rail button:focus-visible {
+    .gg-capture:focus-visible {
       outline-color: Highlight;
-    }
-
-    .gg-tool-rail button.active {
-      border-bottom-color: Highlight;
-      color: ButtonText;
-    }
-
-    .gg-area-draft-select,
-    .gg-selection {
-      fill: none;
-      stroke: Highlight;
-    }
-
-    .gg-area-draft-zoom {
-      fill: none;
-      stroke: CanvasText;
-      stroke-width: 2;
-    }
-
-    .gg-crosshair,
-    .gg-hover-ring,
-    .gg-selected-ring {
-      stroke: Highlight;
-    }
-
-    .gg-zoom-label {
-      fill: CanvasText;
-      stroke: Canvas;
     }
   }
 </style>

--- a/packages/svelte/src/lib/InteractionOverlay.svelte
+++ b/packages/svelte/src/lib/InteractionOverlay.svelte
@@ -1,0 +1,266 @@
+<script lang="ts">
+  import type { CellValue } from "@ggsvelte/core";
+
+  import type {
+    InteractionTool,
+    IntervalSelection,
+    PlotInspectionChange,
+  } from "./interaction.js";
+  import { normalizedRect } from "./plot-geometry.js";
+
+  type Anchor = { readonly x: number; readonly y: number };
+  type Panel = {
+    readonly x: number;
+    readonly y: number;
+    readonly width: number;
+    readonly height: number;
+  };
+  type BrushRect = {
+    readonly x0: number;
+    readonly y0: number;
+    readonly x1: number;
+    readonly y1: number;
+  };
+
+  const {
+    width,
+    height,
+    interactive = true,
+    inspection = null,
+    inspectionPanel = null,
+    coordFlipped = false,
+    selectedAnchors = [],
+    emphasizedAnchors = [],
+    brushRect = null,
+    activeTool = "inspect",
+    areaAwaitingSecond = false,
+    committedInterval = null,
+  }: {
+    width: number;
+    height: number;
+    interactive?: boolean;
+    inspection?: PlotInspectionChange<
+      Record<string, CellValue>,
+      PropertyKey
+    > | null;
+    inspectionPanel?: Panel | null;
+    coordFlipped?: boolean;
+    selectedAnchors?: readonly Anchor[];
+    emphasizedAnchors?: readonly Anchor[];
+    brushRect?: BrushRect | null;
+    activeTool?: InteractionTool;
+    areaAwaitingSecond?: boolean;
+    committedInterval?: IntervalSelection | null;
+  } = $props();
+</script>
+
+<svg
+  class="gg-stratum gg-interaction-overlay"
+  {width}
+  {height}
+  viewBox={`0 0 ${width} ${height}`}
+  aria-hidden="true"
+>
+  {#if interactive && inspection !== null}
+    {#if inspection.mode === "xy" || (inspection.mode === "x" && !coordFlipped) || (inspection.mode === "y" && coordFlipped)}
+      {#if inspectionPanel}
+        <line
+          class="gg-crosshair"
+          x1={inspection.focus.anchor.x}
+          x2={inspection.focus.anchor.x}
+          y1={inspectionPanel.y}
+          y2={inspectionPanel.y + inspectionPanel.height}
+        />
+        {#if "axisLabel" in inspection}
+          <text
+            class={`gg-crosshair-axis-label gg-crosshair-axis-label-${inspection.mode}`}
+            x={inspection.focus.anchor.x}
+            y={inspectionPanel.y + inspectionPanel.height - 4}
+            text-anchor="middle">{inspection.axisLabel}</text
+          >
+        {/if}
+      {/if}
+    {/if}
+    {#if inspection.mode === "xy" || (inspection.mode === "y" && !coordFlipped) || (inspection.mode === "x" && coordFlipped)}
+      {#if inspectionPanel}
+        <line
+          class="gg-crosshair"
+          x1={inspectionPanel.x}
+          x2={inspectionPanel.x + inspectionPanel.width}
+          y1={inspection.focus.anchor.y}
+          y2={inspection.focus.anchor.y}
+        />
+        {#if "axisLabel" in inspection}
+          <text
+            class={`gg-crosshair-axis-label gg-crosshair-axis-label-${inspection.mode}`}
+            x={inspectionPanel.x + 4}
+            y={inspection.focus.anchor.y - 4}>{inspection.axisLabel}</text
+          >
+        {/if}
+      {/if}
+    {/if}
+    <circle
+      class="gg-hover-ring"
+      cx={inspection.focus.anchor.x}
+      cy={inspection.focus.anchor.y}
+      r="6"
+      fill="none"
+    />
+  {/if}
+  {#if interactive}
+    {#each selectedAnchors as anchor, index (index)}
+      <circle
+        class="gg-selected-ring"
+        cx={anchor.x}
+        cy={anchor.y}
+        r="8"
+        fill="none"
+      />
+    {/each}
+  {/if}
+  {#each emphasizedAnchors as anchor, index (index)}
+    <circle
+      class="gg-emphasized-ring"
+      cx={anchor.x}
+      cy={anchor.y}
+      r="11"
+      fill="none"
+    />
+  {/each}
+  {#if interactive && brushRect !== null}
+    {@const r = normalizedRect(brushRect)}
+    <rect
+      class="gg-area-draft"
+      class:gg-area-draft-select={activeTool === "select-area"}
+      class:gg-area-draft-zoom={activeTool === "zoom-area"}
+      x={r.x0}
+      y={r.y0}
+      width={r.x1 - r.x0}
+      height={r.y1 - r.y0}
+      fill={activeTool === "zoom-area"
+        ? "none"
+        : "var(--gg-selectionFill, var(--gg-theme-selectionFill, currentColor))"}
+      fill-opacity={activeTool === "zoom-area" ? undefined : "0.12"}
+      stroke="var(--gg-selectionStroke, var(--gg-theme-selectionStroke, currentColor))"
+    />
+    {#if activeTool === "zoom-area"}
+      <text class="gg-zoom-label" x={r.x0 + 5} y={r.y0 + 15}>Zoom</text>
+    {/if}
+    {#if areaAwaitingSecond}
+      <circle
+        class="gg-first-corner"
+        cx={brushRect.x0}
+        cy={brushRect.y0}
+        r="4"
+        fill="var(--gg-selectionStroke, var(--gg-theme-selectionStroke, currentColor))"
+      />
+    {/if}
+  {/if}
+  {#if interactive && committedInterval !== null}
+    <rect
+      class="gg-selection"
+      x={committedInterval.pixels.x0}
+      y={committedInterval.pixels.y0}
+      width={committedInterval.pixels.x1 - committedInterval.pixels.x0}
+      height={committedInterval.pixels.y1 - committedInterval.pixels.y0}
+      fill="var(--gg-selectionFill, var(--gg-theme-selectionFill, currentColor))"
+      fill-opacity="0.08"
+      stroke="var(--gg-selectionStroke, var(--gg-theme-selectionStroke, currentColor))"
+    />
+  {/if}
+</svg>
+
+<style>
+  .gg-crosshair {
+    stroke: var(--gg-crosshair, var(--gg-theme-crosshair, currentColor));
+    stroke-width: 1;
+    vector-effect: non-scaling-stroke;
+    opacity: 0.55;
+  }
+
+  .gg-crosshair-axis-label {
+    fill: var(
+      --gg-interactionInk,
+      var(--gg-theme-interactionInk, currentColor)
+    );
+    font: 11px/1 var(--gg-font-family, sans-serif);
+    paint-order: stroke;
+    stroke: var(--gg-tooltipPaper, var(--gg-theme-tooltipPaper, white));
+    stroke-width: 3px;
+    stroke-linejoin: round;
+  }
+
+  .gg-hover-ring {
+    stroke: var(
+      --gg-interactionInk,
+      var(--gg-theme-interactionInk, currentColor)
+    );
+    stroke-width: 1.5;
+    vector-effect: non-scaling-stroke;
+  }
+
+  .gg-selected-ring {
+    stroke: var(
+      --gg-selectionStroke,
+      var(--gg-theme-selectionStroke, currentColor)
+    );
+    stroke-width: 2.5;
+    vector-effect: non-scaling-stroke;
+  }
+
+  .gg-emphasized-ring {
+    stroke: var(
+      --gg-interactionInk,
+      var(--gg-theme-interactionInk, currentColor)
+    );
+    stroke-width: 2;
+    stroke-dasharray: 3 2;
+    vector-effect: non-scaling-stroke;
+  }
+
+  .gg-area-draft,
+  .gg-selection {
+    stroke-width: 1;
+    vector-effect: non-scaling-stroke;
+  }
+
+  .gg-zoom-label {
+    fill: var(
+      --gg-interactionInk,
+      var(--gg-theme-interactionInk, currentColor)
+    );
+    font: 10px/1 var(--gg-font-family, sans-serif);
+    paint-order: stroke;
+    stroke: var(--gg-tooltipPaper, var(--gg-theme-tooltipPaper, white));
+    stroke-width: 3px;
+  }
+
+  @media (forced-colors: active) {
+    .gg-emphasized-ring {
+      stroke: Highlight;
+    }
+
+    .gg-area-draft-select,
+    .gg-selection {
+      fill: none;
+      stroke: Highlight;
+    }
+
+    .gg-area-draft-zoom {
+      fill: none;
+      stroke: CanvasText;
+      stroke-width: 2;
+    }
+
+    .gg-crosshair,
+    .gg-hover-ring,
+    .gg-selected-ring {
+      stroke: Highlight;
+    }
+
+    .gg-zoom-label {
+      fill: CanvasText;
+      stroke: Canvas;
+    }
+  }
+</style>

--- a/packages/svelte/src/lib/ToolRail.svelte
+++ b/packages/svelte/src/lib/ToolRail.svelte
@@ -37,7 +37,13 @@
   }
 </script>
 
-<div class="gg-tool-rail" class:gg-tool-rail-narrow={narrow} role="toolbar" aria-label="Chart interaction tools" aria-busy={!ready}>
+<div
+  class="gg-tool-rail"
+  class:gg-tool-rail-narrow={narrow}
+  role="toolbar"
+  aria-label="Chart interaction tools"
+  aria-busy={!ready}
+>
   <div class="gg-tool-modes">
     {#each availableTools as available (available)}
       <button

--- a/packages/svelte/src/lib/ToolRail.svelte
+++ b/packages/svelte/src/lib/ToolRail.svelte
@@ -1,0 +1,164 @@
+<script lang="ts">
+  import type { InteractionTool, ZoomDomains } from "./interaction.js";
+
+  const {
+    availableTools,
+    activeTool,
+    ready,
+    emptyPlot,
+    narrow = false,
+    zoomDomains = null,
+    hasPointSelection = false,
+    hasIntervalSelection = false,
+    onChooseTool,
+    onResetZoom,
+    onClearPointSelection,
+    onClearIntervalSelection,
+  }: {
+    availableTools: readonly InteractionTool[];
+    activeTool: InteractionTool;
+    ready: boolean;
+    emptyPlot: boolean;
+    narrow?: boolean;
+    zoomDomains?: ZoomDomains | null;
+    hasPointSelection?: boolean;
+    hasIntervalSelection?: boolean;
+    onChooseTool: (tool: InteractionTool) => void;
+    onResetZoom: () => void;
+    onClearPointSelection: () => void;
+    onClearIntervalSelection: () => void;
+  } = $props();
+
+  function labelFor(tool: InteractionTool): string {
+    if (tool === "select-area") return "Select area";
+    if (tool === "zoom-area") return "Zoom area";
+    if (tool === "point") return "Select point";
+    return "Inspect";
+  }
+</script>
+
+<div class="gg-tool-rail" class:gg-tool-rail-narrow={narrow} role="toolbar" aria-label="Chart interaction tools" aria-busy={!ready}>
+  <div class="gg-tool-modes">
+    {#each availableTools as available (available)}
+      <button
+        type="button"
+        disabled={!ready ||
+          (emptyPlot &&
+            (available === "select-area" || available === "zoom-area"))}
+        class:active={activeTool === available}
+        aria-pressed={activeTool === available}
+        onclick={() => onChooseTool(available)}>{labelFor(available)}</button
+      >
+    {/each}
+  </div>
+  <div class="gg-tool-recovery-actions">
+    {#if zoomDomains !== null}
+      <button type="button" onclick={onResetZoom}>Reset zoom</button>
+    {/if}
+    {#if hasPointSelection}
+      <button type="button" onclick={onClearPointSelection}
+        >Clear selection</button
+      >
+    {/if}
+    {#if hasIntervalSelection}
+      <button type="button" onclick={onClearIntervalSelection}
+        >Clear selection</button
+      >
+    {/if}
+  </div>
+</div>
+
+<style>
+  .gg-tool-rail {
+    position: absolute;
+    left: 8px;
+    right: 8px;
+    top: -48px;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 4px;
+    align-items: center;
+    z-index: 1;
+    line-height: 1.2;
+    pointer-events: auto;
+  }
+
+  .gg-tool-modes,
+  .gg-tool-recovery-actions {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+
+  .gg-tool-rail button {
+    min-height: 44px;
+    min-width: 44px;
+    border: 0;
+    border-bottom: 2px solid transparent;
+    border-radius: 0;
+    padding: 0 10px;
+    background: transparent;
+    color: var(
+      --gg-interactionMuted,
+      var(--gg-theme-interactionMuted, currentColor)
+    );
+    font: inherit;
+    font-size: 14px;
+  }
+
+  .gg-tool-rail button:focus-visible {
+    outline: 2px solid var(--gg-focusRing, var(--gg-theme-focusRing, Highlight));
+    outline-offset: 2px;
+  }
+
+  .gg-tool-rail button.active {
+    border-bottom-color: var(
+      --gg-toolActive,
+      var(--gg-theme-toolActive, currentColor)
+    );
+    color: var(--gg-toolActive, var(--gg-theme-toolActive, currentColor));
+  }
+
+  .gg-tool-recovery-actions:empty {
+    display: none;
+  }
+
+  /* Container queries cascade across component boundaries; keep the
+     responsive narrow layout for engines that honour named containers. */
+  @container gg-plot (max-width: 559px) {
+    .gg-tool-rail {
+      top: -92px;
+      grid-template-columns: 1fr;
+      grid-template-rows: auto auto;
+    }
+
+    .gg-tool-modes,
+    .gg-tool-recovery-actions {
+      width: 100%;
+    }
+  }
+
+  /* Prop-driven fallback for engines that do not apply a query to
+     descendants of a component-owned named container during hydration. */
+  .gg-tool-rail-narrow {
+    top: -92px;
+    grid-template-columns: 1fr;
+    grid-template-rows: auto auto;
+  }
+
+  .gg-tool-rail-narrow .gg-tool-modes,
+  .gg-tool-rail-narrow .gg-tool-recovery-actions {
+    width: 100%;
+  }
+
+  @media (forced-colors: active) {
+    .gg-tool-rail button:focus-visible {
+      outline-color: Highlight;
+    }
+
+    .gg-tool-rail button.active {
+      border-bottom-color: Highlight;
+      color: ButtonText;
+    }
+  }
+</style>

--- a/packages/svelte/src/lib/canvas-a11y.ts
+++ b/packages/svelte/src/lib/canvas-a11y.ts
@@ -15,8 +15,7 @@ export function a11yRows(
   }
   const fieldSet = new Set<string>();
   for (const batch of batches) {
-    for (const f of model.layerFields[batch.layerIndex] ?? [])
-      fieldSet.add(f.field);
+    for (const f of model.layerFields[batch.layerIndex] ?? []) fieldSet.add(f.field);
   }
   const fields = [...fieldSet];
   const rows: CellValue[][] = [];

--- a/packages/svelte/src/lib/canvas-a11y.ts
+++ b/packages/svelte/src/lib/canvas-a11y.ts
@@ -1,0 +1,29 @@
+import type { CellValue, GeometryBatch, RenderModel } from "@ggsvelte/core";
+
+/** Rows referenced by a canvas stratum, capped for the a11y table. */
+export const A11Y_TABLE_CAP = 100;
+
+export function a11yRows(
+  model: RenderModel,
+  batches: GeometryBatch[],
+): { fields: string[]; rows: CellValue[][]; total: number } {
+  const rowSet = new Set<number>();
+  for (const batch of batches) {
+    for (const raw of batch.rowIndex) {
+      if (raw !== 0xffffffff) rowSet.add(raw);
+    }
+  }
+  const fieldSet = new Set<string>();
+  for (const batch of batches) {
+    for (const f of model.layerFields[batch.layerIndex] ?? [])
+      fieldSet.add(f.field);
+  }
+  const fields = [...fieldSet];
+  const rows: CellValue[][] = [];
+  for (const index of [...rowSet].toSorted((a, b) => a - b)) {
+    if (rows.length >= A11Y_TABLE_CAP) break;
+    const row = model.row(index);
+    if (row !== null) rows.push(fields.map((f) => row[f] ?? null));
+  }
+  return { fields, rows, total: rowSet.size };
+}

--- a/packages/svelte/src/lib/plot-geometry.ts
+++ b/packages/svelte/src/lib/plot-geometry.ts
@@ -16,8 +16,7 @@ export type PanelBounds = {
   readonly height: number;
 };
 
-export const clamp = (v: number, lo: number, hi: number): number =>
-  Math.max(lo, Math.min(hi, v));
+export const clamp = (v: number, lo: number, hi: number): number => Math.max(lo, Math.min(hi, v));
 
 /** Invert a normalized [t0, t1] window through a positional scale (band
  *  scales cannot zoom — documented M2 limitation). */
@@ -67,16 +66,8 @@ export function panelDataDomains(
   const tx1 = clamp((rect.x1 - panel.x) / panel.width, 0, 1);
   const ty0 = clamp(1 - (rect.y1 - panel.y) / panel.height, 0, 1);
   const ty1 = clamp(1 - (rect.y0 - panel.y) / panel.height, 0, 1);
-  const horizontalDomain = invertedDomain(
-    flipped ? scales.y : scales.x,
-    tx0,
-    tx1,
-  );
-  const verticalDomain = invertedDomain(
-    flipped ? scales.x : scales.y,
-    ty0,
-    ty1,
-  );
+  const horizontalDomain = invertedDomain(flipped ? scales.y : scales.x, tx0, tx1);
+  const verticalDomain = invertedDomain(flipped ? scales.x : scales.y, ty0, ty1);
   const xDomain = flipped ? verticalDomain : horizontalDomain;
   const yDomain = flipped ? horizontalDomain : verticalDomain;
   return {

--- a/packages/svelte/src/lib/plot-geometry.ts
+++ b/packages/svelte/src/lib/plot-geometry.ts
@@ -1,0 +1,86 @@
+import type { RenderModel } from "@ggsvelte/core";
+
+import type { ZoomDomains } from "./interaction.js";
+
+export type PlotRect = {
+  readonly x0: number;
+  readonly y0: number;
+  readonly x1: number;
+  readonly y1: number;
+};
+
+export type PanelBounds = {
+  readonly x: number;
+  readonly y: number;
+  readonly width: number;
+  readonly height: number;
+};
+
+export const clamp = (v: number, lo: number, hi: number): number =>
+  Math.max(lo, Math.min(hi, v));
+
+/** Invert a normalized [t0, t1] window through a positional scale (band
+ *  scales cannot zoom — documented M2 limitation). */
+export function invertedDomain(
+  scale: RenderModel["scales"]["x"],
+  t0: number,
+  t1: number,
+): [number, number] | undefined {
+  if (scale.type === "band") return undefined;
+  const a = scale.invert(t0);
+  const b = scale.invert(t1);
+  return a <= b ? [a, b] : [b, a];
+}
+
+export function frozenZoomDomains(domains: ZoomDomains): ZoomDomains {
+  return Object.freeze({
+    ...(domains.x !== undefined && {
+      x: Object.freeze([...domains.x]) as unknown as [number, number],
+    }),
+    ...(domains.y !== undefined && {
+      y: Object.freeze([...domains.y]) as unknown as [number, number],
+    }),
+  });
+}
+
+export function normalizedRect(r: PlotRect): PlotRect {
+  return {
+    x0: Math.min(r.x0, r.x1),
+    y0: Math.min(r.y0, r.y1),
+    x1: Math.max(r.x0, r.x1),
+    y1: Math.max(r.y0, r.y1),
+  };
+}
+
+/**
+ * Shared pixel→data domain inversion used by brush-zoom and interval selection.
+ * Returns unfiltered x/y domains in data space (no mode guards, no panel-count
+ * guards). Callers apply mode filters and single-panel checks.
+ */
+export function panelDataDomains(
+  rect: PlotRect,
+  panel: PanelBounds,
+  scales: Pick<RenderModel["scales"], "x" | "y">,
+  flipped: boolean,
+): { x?: [number, number]; y?: [number, number] } {
+  const tx0 = clamp((rect.x0 - panel.x) / panel.width, 0, 1);
+  const tx1 = clamp((rect.x1 - panel.x) / panel.width, 0, 1);
+  const ty0 = clamp(1 - (rect.y1 - panel.y) / panel.height, 0, 1);
+  const ty1 = clamp(1 - (rect.y0 - panel.y) / panel.height, 0, 1);
+  const horizontalDomain = invertedDomain(
+    flipped ? scales.y : scales.x,
+    tx0,
+    tx1,
+  );
+  const verticalDomain = invertedDomain(
+    flipped ? scales.x : scales.y,
+    ty0,
+    ty1,
+  );
+  const xDomain = flipped ? verticalDomain : horizontalDomain;
+  const yDomain = flipped ? horizontalDomain : verticalDomain;
+  return {
+    ...(xDomain !== undefined && { x: xDomain }),
+    ...(yDomain !== undefined && { y: yDomain }),
+  };
+}

--- a/packages/svelte/src/lib/plot-geometry.ts
+++ b/packages/svelte/src/lib/plot-geometry.ts
@@ -1,7 +1,5 @@
 import type { RenderModel } from "@ggsvelte/core";
 
-import type { ZoomDomains } from "./interaction.js";
-
 export type PlotRect = {
   readonly x0: number;
   readonly y0: number;
@@ -14,6 +12,12 @@ export type PanelBounds = {
   readonly y: number;
   readonly width: number;
   readonly height: number;
+};
+
+/** Continuous zoom domain bag used by brush-to-zoom commit paths. */
+export type ContinuousZoomDomains = {
+  x?: [number, number];
+  y?: [number, number];
 };
 
 export const clamp = (v: number, lo: number, hi: number): number => Math.max(lo, Math.min(hi, v));
@@ -31,7 +35,7 @@ export function invertedDomain(
   return a <= b ? [a, b] : [b, a];
 }
 
-export function frozenZoomDomains(domains: ZoomDomains): ZoomDomains {
+export function frozenZoomDomains(domains: ContinuousZoomDomains): ContinuousZoomDomains {
   return Object.freeze({
     ...(domains.x !== undefined && {
       x: Object.freeze([...domains.x]) as unknown as [number, number],

--- a/packages/svelte/src/lib/plot-labels.ts
+++ b/packages/svelte/src/lib/plot-labels.ts
@@ -3,10 +3,7 @@ import type { CellValue, RenderModel } from "@ggsvelte/core";
 import type { PlotInspectionChange } from "./interaction.js";
 
 /** Accessible per-mark label from the layer's mapped fields. */
-export function markLabel(
-  model: RenderModel | null,
-  row: number,
-): string {
+export function markLabel(model: RenderModel | null, row: number): string {
   if (model === null) return `data point ${row + 1}`;
   const values = model.row(row);
   if (values === null) return `data point ${row + 1}`;
@@ -48,10 +45,7 @@ export function inspectionLiveText(
   const seen = new Set<string>();
   const focused = value.focus.fields
     .filter(
-      (field) =>
-        field.channel !== value.mode &&
-        !seen.has(field.field) &&
-        seen.add(field.field),
+      (field) => field.channel !== value.mode && !seen.has(field.field) && seen.add(field.field),
     )
     .map((field) => `${field.field} ${String(field.value ?? "")}`)
     .join(", ");

--- a/packages/svelte/src/lib/plot-labels.ts
+++ b/packages/svelte/src/lib/plot-labels.ts
@@ -44,9 +44,11 @@ export function inspectionLiveText(
     return `${datumLabel(model, value.focus.row)}; ${String(count)} ${count === 1 ? "datum" : "data"}${state}`;
   const seen = new Set<string>();
   const focused = value.focus.fields
-    .filter(
-      (field) => field.channel !== value.mode && !seen.has(field.field) && seen.add(field.field),
-    )
+    .filter((field) => {
+      if (field.channel === value.mode || seen.has(field.field)) return false;
+      seen.add(field.field);
+      return true;
+    })
     .map((field) => `${field.field} ${String(field.value ?? "")}`)
     .join(", ");
   return `${value.mode} ${value.axisLabel}; ${String(count)} ${count === 1 ? "datum" : "data"}${focused ? `; focused ${focused}` : ""}${state}`;

--- a/packages/svelte/src/lib/plot-labels.ts
+++ b/packages/svelte/src/lib/plot-labels.ts
@@ -1,0 +1,59 @@
+import type { CellValue, RenderModel } from "@ggsvelte/core";
+
+import type { PlotInspectionChange } from "./interaction.js";
+
+/** Accessible per-mark label from the layer's mapped fields. */
+export function markLabel(
+  model: RenderModel | null,
+  row: number,
+): string {
+  if (model === null) return `data point ${row + 1}`;
+  const values = model.row(row);
+  if (values === null) return `data point ${row + 1}`;
+  const fields = model.layerFields.flat();
+  const seen = new Set<string>();
+  const parts: string[] = [];
+  for (const f of fields) {
+    if (seen.has(f.field)) continue;
+    seen.add(f.field);
+    parts.push(`${f.field} ${String(values[f.field] ?? "")}`);
+  }
+  return parts.join(", ") || `data point ${row + 1}`;
+}
+
+export function datumLabel(
+  model: RenderModel | null,
+  values: Record<string, CellValue> | null,
+): string {
+  if (values === null) return "No active datum";
+  const fields = model?.layerFields.flat() ?? [];
+  const seen = new Set<string>();
+  const parts: string[] = [];
+  for (const field of fields) {
+    if (seen.has(field.field)) continue;
+    seen.add(field.field);
+    parts.push(`${field.field} ${String(values[field.field] ?? "")}`);
+  }
+  return parts.join(", ") || "Active datum";
+}
+
+export function inspectionLiveText(
+  model: RenderModel | null,
+  value: PlotInspectionChange<Record<string, CellValue>, PropertyKey>,
+): string {
+  const count = value.members.length;
+  const state = value.state === "pinned" ? ", pinned" : "";
+  if (value.mode !== "x" && value.mode !== "y")
+    return `${datumLabel(model, value.focus.row)}; ${String(count)} ${count === 1 ? "datum" : "data"}${state}`;
+  const seen = new Set<string>();
+  const focused = value.focus.fields
+    .filter(
+      (field) =>
+        field.channel !== value.mode &&
+        !seen.has(field.field) &&
+        seen.add(field.field),
+    )
+    .map((field) => `${field.field} ${String(field.value ?? "")}`)
+    .join(", ");
+  return `${value.mode} ${value.axisLabel}; ${String(count)} ${count === 1 ? "datum" : "data"}${focused ? `; focused ${focused}` : ""}${state}`;
+}

--- a/packages/svelte/tests/canvas-a11y.test.ts
+++ b/packages/svelte/tests/canvas-a11y.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+
+import type { GeometryBatch, RenderModel } from "@ggsvelte/core";
+
+import { A11Y_TABLE_CAP, a11yRows } from "../src/lib/canvas-a11y.js";
+
+function batch(partial: {
+  layerIndex: number;
+  rowIndex: number[];
+}): GeometryBatch {
+  return {
+    layerIndex: partial.layerIndex,
+    geom: "point",
+    rowIndex: new Uint32Array(partial.rowIndex),
+  } as unknown as GeometryBatch;
+}
+
+function model(opts: {
+  layerFields: Record<number, { field: string }[]>;
+  rows: Record<number, Record<string, unknown> | null>;
+}): RenderModel {
+  return {
+    layerFields: opts.layerFields,
+    row: (index: number) => opts.rows[index] ?? null,
+  } as unknown as RenderModel;
+}
+
+describe("a11yRows", () => {
+  it("collects unique fields in first-seen order and sorted row indices", () => {
+    const m = model({
+      layerFields: {
+        0: [{ field: "x" }, { field: "y" }],
+        1: [{ field: "y" }, { field: "color" }],
+      },
+      rows: {
+        2: { x: 1, y: 2, color: "a" },
+        0: { x: 0, y: 0, color: "b" },
+        5: { x: 5, y: 5, color: "c" },
+      },
+    });
+    const table = a11yRows(m, [
+      batch({ layerIndex: 0, rowIndex: [2, 0xffffffff, 2] }),
+      batch({ layerIndex: 1, rowIndex: [5, 0] }),
+    ]);
+    expect(table.fields).toEqual(["x", "y", "color"]);
+    expect(table.total).toBe(3);
+    expect(table.rows).toEqual([
+      [0, 0, "b"],
+      [1, 2, "a"],
+      [5, 5, "c"],
+    ]);
+  });
+
+  it("skips 0xffffffff sentinels and null rows but counts total pre-filter", () => {
+    const m = model({
+      layerFields: { 0: [{ field: "x" }] },
+      rows: {
+        1: { x: 1 },
+        3: null,
+      },
+    });
+    const table = a11yRows(m, [
+      batch({ layerIndex: 0, rowIndex: [1, 0xffffffff, 3, 1] }),
+    ]);
+    expect(table.total).toBe(2);
+    expect(table.rows).toEqual([[1]]);
+  });
+
+  it("maps undefined cell values to null", () => {
+    const m = model({
+      layerFields: { 0: [{ field: "x" }, { field: "y" }] },
+      rows: { 0: { x: 1 } },
+    });
+    const table = a11yRows(m, [batch({ layerIndex: 0, rowIndex: [0] })]);
+    expect(table.rows).toEqual([[1, null]]);
+  });
+
+  it(`caps materialised rows at ${String(A11Y_TABLE_CAP)} while reporting full total`, () => {
+    const rows: Record<number, Record<string, unknown>> = {};
+    const indices: number[] = [];
+    for (let i = 0; i < A11Y_TABLE_CAP + 25; i++) {
+      rows[i] = { x: i };
+      indices.push(i);
+    }
+    const m = model({
+      layerFields: { 0: [{ field: "x" }] },
+      rows,
+    });
+    const table = a11yRows(m, [batch({ layerIndex: 0, rowIndex: indices })]);
+    expect(table.total).toBe(A11Y_TABLE_CAP + 25);
+    expect(table.rows).toHaveLength(A11Y_TABLE_CAP);
+    expect(table.rows[0]).toEqual([0]);
+    expect(table.rows[A11Y_TABLE_CAP - 1]).toEqual([A11Y_TABLE_CAP - 1]);
+  });
+});

--- a/packages/svelte/tests/canvas-a11y.test.ts
+++ b/packages/svelte/tests/canvas-a11y.test.ts
@@ -4,10 +4,7 @@ import type { GeometryBatch, RenderModel } from "@ggsvelte/core";
 
 import { A11Y_TABLE_CAP, a11yRows } from "../src/lib/canvas-a11y.js";
 
-function batch(partial: {
-  layerIndex: number;
-  rowIndex: number[];
-}): GeometryBatch {
+function batch(partial: { layerIndex: number; rowIndex: number[] }): GeometryBatch {
   return {
     layerIndex: partial.layerIndex,
     geom: "point",
@@ -59,9 +56,7 @@ describe("a11yRows", () => {
         3: null,
       },
     });
-    const table = a11yRows(m, [
-      batch({ layerIndex: 0, rowIndex: [1, 0xffffffff, 3, 1] }),
-    ]);
+    const table = a11yRows(m, [batch({ layerIndex: 0, rowIndex: [1, 0xffffffff, 3, 1] })]);
     expect(table.total).toBe(2);
     expect(table.rows).toEqual([[1]]);
   });

--- a/packages/svelte/tests/plot-geometry.test.ts
+++ b/packages/svelte/tests/plot-geometry.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  clamp,
+  frozenZoomDomains,
+  invertedDomain,
+  normalizedRect,
+  panelDataDomains,
+} from "../src/lib/plot-geometry.js";
+
+const continuousScale = (domain: [number, number]) => {
+  const [d0, d1] = domain;
+  const span = d1 - d0;
+  return {
+    type: "continuous" as const,
+    invert: (t: number) => d0 + t * span,
+  };
+};
+
+const bandScale = {
+  type: "band" as const,
+  invert: (_t: number) => 0,
+};
+
+describe("clamp", () => {
+  it("bounds values inclusively", () => {
+    expect(clamp(5, 0, 10)).toBe(5);
+    expect(clamp(-1, 0, 10)).toBe(0);
+    expect(clamp(11, 0, 10)).toBe(10);
+  });
+});
+
+describe("invertedDomain", () => {
+  it("returns undefined for band scales", () => {
+    expect(invertedDomain(bandScale as never, 0.2, 0.8)).toBeUndefined();
+  });
+
+  it("inverts continuous domains and sorts endpoints", () => {
+    const scale = continuousScale([0, 100]);
+    expect(invertedDomain(scale as never, 0.2, 0.8)).toEqual([20, 80]);
+    expect(invertedDomain(scale as never, 0.8, 0.2)).toEqual([20, 80]);
+  });
+
+  it("handles reversed continuous domains", () => {
+    const scale = continuousScale([100, 0]);
+    expect(invertedDomain(scale as never, 0.25, 0.75)).toEqual([25, 75]);
+  });
+});
+
+describe("frozenZoomDomains", () => {
+  it("freezes the object and clones input arrays", () => {
+    const x: [number, number] = [1, 2];
+    const y: [number, number] = [3, 4];
+    const frozen = frozenZoomDomains({ x, y });
+    expect(Object.isFrozen(frozen)).toBe(true);
+    expect(Object.isFrozen(frozen.x)).toBe(true);
+    expect(Object.isFrozen(frozen.y)).toBe(true);
+    expect(frozen.x).toEqual([1, 2]);
+    expect(frozen.y).toEqual([3, 4]);
+    expect(frozen.x).not.toBe(x);
+    expect(frozen.y).not.toBe(y);
+    x[0] = 99;
+    y[0] = 99;
+    expect(frozen.x).toEqual([1, 2]);
+    expect(frozen.y).toEqual([3, 4]);
+  });
+
+  it("omits missing channels", () => {
+    const frozen = frozenZoomDomains({ x: [0, 1] });
+    expect(frozen.x).toEqual([0, 1]);
+    expect(frozen.y).toBeUndefined();
+  });
+});
+
+describe("normalizedRect", () => {
+  it("orders corners independently of drag direction", () => {
+    expect(normalizedRect({ x0: 10, y0: 20, x1: 5, y1: 8 })).toEqual({
+      x0: 5,
+      y0: 8,
+      x1: 10,
+      y1: 20,
+    });
+  });
+});
+
+describe("panelDataDomains", () => {
+  const panel = { x: 40, y: 20, width: 200, height: 100 };
+  const scales = {
+    x: continuousScale([0, 10]) as never,
+    y: continuousScale([0, 50]) as never,
+  };
+
+  it("maps a full panel rect to full scale domains", () => {
+    const domains = panelDataDomains(
+      { x0: 40, y0: 20, x1: 240, y1: 120 },
+      panel,
+      scales,
+      false,
+    );
+    expect(domains.x?.[0]).toBeCloseTo(0);
+    expect(domains.x?.[1]).toBeCloseTo(10);
+    expect(domains.y?.[0]).toBeCloseTo(0);
+    expect(domains.y?.[1]).toBeCloseTo(50);
+  });
+
+  it("clips out-of-panel coordinates", () => {
+    const domains = panelDataDomains(
+      { x0: -100, y0: -50, x1: 400, y1: 400 },
+      panel,
+      scales,
+      false,
+    );
+    expect(domains.x?.[0]).toBeCloseTo(0);
+    expect(domains.x?.[1]).toBeCloseTo(10);
+    expect(domains.y?.[0]).toBeCloseTo(0);
+    expect(domains.y?.[1]).toBeCloseTo(50);
+  });
+
+  it("remaps channels when flipped", () => {
+    // Left half of panel, full vertical → horizontal half of y scale when flipped.
+    const domains = panelDataDomains(
+      { x0: 40, y0: 20, x1: 140, y1: 120 },
+      panel,
+      scales,
+      true,
+    );
+    // Screen-x half → y data domain (scale y inverted with tx)
+    expect(domains.y?.[0]).toBeCloseTo(0);
+    expect(domains.y?.[1]).toBeCloseTo(25);
+    // Screen-y full → x data domain (scale x inverted with ty)
+    expect(domains.x?.[0]).toBeCloseTo(0);
+    expect(domains.x?.[1]).toBeCloseTo(10);
+  });
+
+  it("omits band-scale channels", () => {
+    const mixed = {
+      x: bandScale as never,
+      y: continuousScale([0, 50]) as never,
+    };
+    const domains = panelDataDomains(
+      { x0: 40, y0: 20, x1: 240, y1: 120 },
+      panel,
+      mixed,
+      false,
+    );
+    expect(domains.x).toBeUndefined();
+    expect(domains.y?.[0]).toBeCloseTo(0);
+    expect(domains.y?.[1]).toBeCloseTo(50);
+  });
+});

--- a/packages/svelte/tests/plot-geometry.test.ts
+++ b/packages/svelte/tests/plot-geometry.test.ts
@@ -91,12 +91,7 @@ describe("panelDataDomains", () => {
   };
 
   it("maps a full panel rect to full scale domains", () => {
-    const domains = panelDataDomains(
-      { x0: 40, y0: 20, x1: 240, y1: 120 },
-      panel,
-      scales,
-      false,
-    );
+    const domains = panelDataDomains({ x0: 40, y0: 20, x1: 240, y1: 120 }, panel, scales, false);
     expect(domains.x?.[0]).toBeCloseTo(0);
     expect(domains.x?.[1]).toBeCloseTo(10);
     expect(domains.y?.[0]).toBeCloseTo(0);
@@ -104,12 +99,7 @@ describe("panelDataDomains", () => {
   });
 
   it("clips out-of-panel coordinates", () => {
-    const domains = panelDataDomains(
-      { x0: -100, y0: -50, x1: 400, y1: 400 },
-      panel,
-      scales,
-      false,
-    );
+    const domains = panelDataDomains({ x0: -100, y0: -50, x1: 400, y1: 400 }, panel, scales, false);
     expect(domains.x?.[0]).toBeCloseTo(0);
     expect(domains.x?.[1]).toBeCloseTo(10);
     expect(domains.y?.[0]).toBeCloseTo(0);
@@ -118,12 +108,7 @@ describe("panelDataDomains", () => {
 
   it("remaps channels when flipped", () => {
     // Left half of panel, full vertical → horizontal half of y scale when flipped.
-    const domains = panelDataDomains(
-      { x0: 40, y0: 20, x1: 140, y1: 120 },
-      panel,
-      scales,
-      true,
-    );
+    const domains = panelDataDomains({ x0: 40, y0: 20, x1: 140, y1: 120 }, panel, scales, true);
     // Screen-x half → y data domain (scale y inverted with tx)
     expect(domains.y?.[0]).toBeCloseTo(0);
     expect(domains.y?.[1]).toBeCloseTo(25);
@@ -137,12 +122,7 @@ describe("panelDataDomains", () => {
       x: bandScale as never,
       y: continuousScale([0, 50]) as never,
     };
-    const domains = panelDataDomains(
-      { x0: 40, y0: 20, x1: 240, y1: 120 },
-      panel,
-      mixed,
-      false,
-    );
+    const domains = panelDataDomains({ x0: 40, y0: 20, x1: 240, y1: 120 }, panel, mixed, false);
     expect(domains.x).toBeUndefined();
     expect(domains.y?.[0]).toBeCloseTo(0);
     expect(domains.y?.[1]).toBeCloseTo(50);

--- a/packages/svelte/tests/plot-labels.test.ts
+++ b/packages/svelte/tests/plot-labels.test.ts
@@ -113,7 +113,7 @@ describe("inspectionLiveText", () => {
     const pinned = {
       ...one,
       state: "pinned" as const,
-      members: [one.members[0]!, one.members[0]!],
+      members: [one.members[0], one.members[0]],
     };
     expect(inspectionLiveText(m, pinned as never)).toBe("x 1, y 2; 2 data, pinned");
   });

--- a/packages/svelte/tests/plot-labels.test.ts
+++ b/packages/svelte/tests/plot-labels.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "vitest";
+
+import type { RenderModel } from "@ggsvelte/core";
+
+import type { PlotInspectionChange } from "../src/lib/interaction.js";
+import {
+  datumLabel,
+  inspectionLiveText,
+  markLabel,
+} from "../src/lib/plot-labels.js";
+
+function model(opts: {
+  layerFields?: { field: string }[][];
+  rows?: Record<number, Record<string, unknown> | null>;
+}): RenderModel {
+  return {
+    layerFields: opts.layerFields ?? [[{ field: "x" }, { field: "y" }]],
+    row: (index: number) => opts.rows?.[index] ?? null,
+  } as unknown as RenderModel;
+}
+
+describe("markLabel", () => {
+  it("falls back when model or row is missing", () => {
+    expect(markLabel(null, 2)).toBe("data point 3");
+    expect(markLabel(model({ rows: {} }), 4)).toBe("data point 5");
+  });
+
+  it("joins unique fields and de-duplicates across layers", () => {
+    const m = model({
+      layerFields: [
+        [{ field: "x" }, { field: "y" }],
+        [{ field: "y" }, { field: "color" }],
+      ],
+      rows: { 0: { x: 1, y: 2, color: "red" } },
+    });
+    expect(markLabel(m, 0)).toBe("x 1, y 2, color red");
+  });
+
+  it("falls back when fields produce an empty label", () => {
+    const m = model({
+      layerFields: [[]],
+      rows: { 0: { x: 1 } },
+    });
+    expect(markLabel(m, 0)).toBe("data point 1");
+  });
+});
+
+describe("datumLabel", () => {
+  it("returns the no-active-datum fallback", () => {
+    expect(datumLabel(model({}), null)).toBe("No active datum");
+  });
+
+  it("returns Active datum when there are no mapped fields", () => {
+    expect(datumLabel(model({ layerFields: [[]] }), { x: 1 })).toBe(
+      "Active datum",
+    );
+  });
+
+  it("stringifies missing values as empty", () => {
+    const m = model({
+      layerFields: [[{ field: "x" }, { field: "y" }]],
+    });
+    expect(datumLabel(m, { x: 3 })).toBe("x 3, y ");
+  });
+});
+
+describe("inspectionLiveText", () => {
+  function inspection(
+    partial: Partial<PlotInspectionChange<Record<string, unknown>, PropertyKey>> &
+      Pick<
+        PlotInspectionChange<Record<string, unknown>, PropertyKey>,
+        "mode" | "focus" | "members" | "state"
+      >,
+  ): PlotInspectionChange<Record<string, unknown>, PropertyKey> {
+    return {
+      type: "inspect",
+      phase: "change",
+      source: "keyboard",
+      panelId: null,
+      ...partial,
+    } as PlotInspectionChange<Record<string, unknown>, PropertyKey>;
+  }
+
+  it("uses singular/plural and optional pinned suffix for exact mode", () => {
+    const m = model({
+      layerFields: [[{ field: "x" }, { field: "y" }]],
+    });
+    const one = inspection({
+      mode: "exact",
+      state: "transient",
+      focus: {
+        key: "a",
+        row: { x: 1, y: 2 },
+        sourceKeys: ["a"],
+        lineageCount: 1,
+        layerIndex: 0,
+        panelId: null,
+        fields: [
+          { channel: "x", field: "x", value: 1 },
+          { channel: "y", field: "y", value: 2 },
+        ],
+        anchor: { x: 0, y: 0 },
+      },
+      members: [
+        {
+          key: "a",
+          row: { x: 1, y: 2 },
+          sourceKeys: ["a"],
+          lineageCount: 1,
+          layerIndex: 0,
+          panelId: null,
+          fields: [],
+          anchor: { x: 0, y: 0 },
+        },
+      ],
+    });
+    expect(inspectionLiveText(m, one as never)).toBe("x 1, y 2; 1 datum");
+
+    const pinned = {
+      ...one,
+      state: "pinned" as const,
+      members: [one.members[0]!, one.members[0]!],
+    };
+    expect(inspectionLiveText(m, pinned as never)).toBe(
+      "x 1, y 2; 2 data, pinned",
+    );
+  });
+
+  it("excludes the axis channel from focused fields for x/y modes", () => {
+    const m = model({
+      layerFields: [[{ field: "x" }, { field: "y" }, { field: "color" }]],
+    });
+    const value = inspection({
+      mode: "x",
+      state: "transient",
+      axisValue: 3,
+      axisLabel: "3.0",
+      focus: {
+        key: "a",
+        row: { x: 3, y: 9, color: "blue" },
+        sourceKeys: ["a"],
+        lineageCount: 1,
+        layerIndex: 0,
+        panelId: null,
+        fields: [
+          { channel: "x", field: "x", value: 3 },
+          { channel: "y", field: "y", value: 9 },
+          { channel: "colour", field: "color", value: "blue" },
+        ],
+        anchor: { x: 0, y: 0 },
+      },
+      members: [
+        {
+          key: "a",
+          row: { x: 3, y: 9, color: "blue" },
+          sourceKeys: ["a"],
+          lineageCount: 1,
+          layerIndex: 0,
+          panelId: null,
+          fields: [],
+          anchor: { x: 0, y: 0 },
+        },
+      ],
+    });
+    expect(inspectionLiveText(m, value as never)).toBe(
+      "x 3.0; 1 datum; focused y 9, color blue",
+    );
+  });
+});

--- a/packages/svelte/tests/plot-labels.test.ts
+++ b/packages/svelte/tests/plot-labels.test.ts
@@ -3,11 +3,7 @@ import { describe, expect, it } from "vitest";
 import type { RenderModel } from "@ggsvelte/core";
 
 import type { PlotInspectionChange } from "../src/lib/interaction.js";
-import {
-  datumLabel,
-  inspectionLiveText,
-  markLabel,
-} from "../src/lib/plot-labels.js";
+import { datumLabel, inspectionLiveText, markLabel } from "../src/lib/plot-labels.js";
 
 function model(opts: {
   layerFields?: { field: string }[][];
@@ -51,9 +47,7 @@ describe("datumLabel", () => {
   });
 
   it("returns Active datum when there are no mapped fields", () => {
-    expect(datumLabel(model({ layerFields: [[]] }), { x: 1 })).toBe(
-      "Active datum",
-    );
+    expect(datumLabel(model({ layerFields: [[]] }), { x: 1 })).toBe("Active datum");
   });
 
   it("stringifies missing values as empty", () => {
@@ -121,9 +115,7 @@ describe("inspectionLiveText", () => {
       state: "pinned" as const,
       members: [one.members[0]!, one.members[0]!],
     };
-    expect(inspectionLiveText(m, pinned as never)).toBe(
-      "x 1, y 2; 2 data, pinned",
-    );
+    expect(inspectionLiveText(m, pinned as never)).toBe("x 1, y 2; 2 data, pinned");
   });
 
   it("excludes the axis channel from focused fields for x/y modes", () => {
@@ -162,8 +154,6 @@ describe("inspectionLiveText", () => {
         },
       ],
     });
-    expect(inspectionLiveText(m, value as never)).toBe(
-      "x 3.0; 1 datum; focused y 9, color blue",
-    );
+    expect(inspectionLiveText(m, value as never)).toBe("x 3.0; 1 datum; focused y 9, color blue");
   });
 });

--- a/packages/svelte/tests/presentation.test.ts
+++ b/packages/svelte/tests/presentation.test.ts
@@ -128,10 +128,9 @@ describe("DESIGN.md interaction presentation", () => {
     expect(getComputedStyle(overlay).position).toBe("absolute");
     expect(getComputedStyle(overlay).pointerEvents).toBe("none");
     // Capture remains the last interactive sibling after the overlay.
-    expect(
-      [...wideRoot.children].indexOf(overlay) <
-        [...wideRoot.children].indexOf(capture),
-    ).toBe(true);
+    expect([...wideRoot.children].indexOf(overlay) < [...wideRoot.children].indexOf(capture)).toBe(
+      true,
+    );
   });
 
   it("preserves chart chrome and reports empty and unavailable states", () => {

--- a/packages/svelte/tests/presentation.test.ts
+++ b/packages/svelte/tests/presentation.test.ts
@@ -92,6 +92,48 @@ describe("DESIGN.md interaction presentation", () => {
     expect(container.querySelector(".gg-crosshair")?.getAttribute("stroke-dasharray")).toBeNull();
   });
 
+  it("keeps extracted tool rail and overlay positioned as plot-root siblings", async () => {
+    const narrow = render(GGPlot, {
+      data: rows,
+      aes: { x: "x", y: "y" },
+      layers: [{ geom: "point" }],
+      key: "id",
+      inspect: true,
+      select: "interval",
+      zoom: true,
+      width: 400,
+      height: 280,
+    });
+    const narrowRoot = narrow.container.querySelector(".gg-plot-root")!;
+    const rail = narrow.container.querySelector<HTMLElement>(".gg-tool-rail")!;
+    expect(rail.parentElement).toBe(narrowRoot);
+    expect(rail.classList.contains("gg-tool-rail-narrow")).toBe(true);
+    expect(getComputedStyle(rail).position).toBe("absolute");
+
+    const wide = render(GGPlot, {
+      data: rows,
+      aes: { x: "x", y: "y" },
+      layers: [{ geom: "point" }],
+      inspect: { mode: "xy" },
+      width: 640,
+      height: 360,
+    });
+    const wideRoot = wide.container.querySelector(".gg-plot-root")!;
+    const capture = wide.container.querySelector<HTMLElement>(".gg-capture")!;
+    capture.focus();
+    capture.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }));
+    await expect.poll(() => wide.container.querySelector(".gg-interaction-overlay")).not.toBeNull();
+    const overlay = wide.container.querySelector<SVGElement>(".gg-interaction-overlay")!;
+    expect(overlay.parentElement).toBe(wideRoot);
+    expect(getComputedStyle(overlay).position).toBe("absolute");
+    expect(getComputedStyle(overlay).pointerEvents).toBe("none");
+    // Capture remains the last interactive sibling after the overlay.
+    expect(
+      [...wideRoot.children].indexOf(overlay) <
+        [...wideRoot.children].indexOf(capture),
+    ).toBe(true);
+  });
+
   it("preserves chart chrome and reports empty and unavailable states", () => {
     const empty = render(GGPlot, {
       data: [],


### PR DESCRIPTION
## Summary
`GGPlot.svelte` had grown past 2,600 lines and mixed pure helpers, interaction orchestration, and presentation. This PR peels off well-bounded pieces so the component stays an orchestrator:

- **Pure modules** (with unit tests):
  - `plot-geometry.ts` — clamp, domain invert, rect normalize, shared brush/panel inversion
  - `canvas-a11y.ts` — canvas a11y table row extraction
  - `plot-labels.ts` — mark/datum/live-region label text
- **Presentational components** (styles moved with markup):
  - `ToolRail.svelte` — tool modes + recovery actions (narrow layout via prop + container query)
  - `InteractionOverlay.svelte` — crosshairs, selection rings, brush draft, committed interval

Public API is unchanged (`GGPlot` default export, `resetScales` / `setZoom`). New modules are internal-only (not re-exported from `index.ts`), matching `interaction-reducer` / `inspection-resolver`.

`GGPlot.svelte` is ~2,690 → ~2,263 lines.

## Verification
- `bun run check` / `packages/svelte` `svelte-check`: clean
- Focused pure helper tests: pass (3 browsers)
- Presentation + interaction + component + controller suites: pass
- Full `packages/svelte` suite: 437 pass; one chromium hydration timeout under concurrent load, passed on re-run for all browsers
- New layout regression: tool rail + overlay positioning

## Test plan
- [ ] `cd packages/svelte && bun run check`
- [ ] `cd packages/svelte && bun run test`
- [ ] Smoke an interactive docs example (tool rail, brush, tooltip) if reviewing in browser