### PR TITLE
refactor(svelte): extract pure GGPlot interaction helpers

### DIFF
--- a/packages/svelte/src/lib/GGPlot.svelte
+++ b/packages/svelte/src/lib/GGPlot.svelte
@@ -93,6 +93,7 @@
   import InteractionOverlay from "./InteractionOverlay.svelte";
   import {
     clamp,
+    expandIntervalQuery,
     frozenZoomDomains,
     normalizedRect,
     panelDataDomains,
@@ -102,6 +103,23 @@
     inspectionLiveText as inspectionLiveTextFor,
     markLabel as markLabelFor,
   } from "./plot-labels.js";
+  import {
+    bestDirectionalIndex,
+    cycleCoincidentIndex,
+    hitFromCandidate,
+    nextTraversalIndex,
+    plotPointFromClient,
+  } from "./plot-pointer.js";
+  import {
+    anchorsFromCandidateKeys,
+    nextPointSelectionKeys,
+  } from "./plot-selection.js";
+  import { themeTokensToCss } from "./plot-theme-css.js";
+  import {
+    applyZoomToSpec,
+    resolveBrushZoomDomains,
+    sanitizePartialZoomDomains,
+  } from "./plot-zoom.js";
   import SceneView from "./SceneView.svelte";
   import Tooltip from "./Tooltip.svelte";
   import ToolRail from "./ToolRail.svelte";
@@ -318,26 +336,9 @@
       : (domains as ZoomDomains);
   });
 
-  const zoomScale = (config: Scales["x"], domain: [number, number]) => ({
-    ...config,
-    domain: [domain[0], domain[1]],
-    nice: false,
-  });
-
   const effectiveSpec: PortableSpec | null = $derived.by(() => {
     if (assembled === null || effectiveZoomDomains === null) return assembled;
-    return {
-      ...assembled,
-      scales: {
-        ...assembled.scales,
-        ...(effectiveZoomDomains.x !== undefined && {
-          x: zoomScale(assembled.scales?.x, effectiveZoomDomains.x),
-        }),
-        ...(effectiveZoomDomains.y !== undefined && {
-          y: zoomScale(assembled.scales?.y, effectiveZoomDomains.y),
-        }),
-      },
-    };
+    return applyZoomToSpec(assembled, effectiveZoomDomains);
   });
 
   // Source identity/order epoch: stable through responsive layout and zoom
@@ -676,24 +677,9 @@
       return "No inspectable marks";
     return null;
   });
-  const themeStyle = $derived.by(() => {
-    if (model === null) return "";
-    const tokens = model.scene.theme;
-    return [
-      ["interactionInk", tokens.interactionInk],
-      ["interactionMuted", tokens.interactionMuted],
-      ["focusRing", tokens.focusRing],
-      ["crosshair", tokens.crosshair],
-      ["selectionFill", tokens.selectionFill],
-      ["selectionStroke", tokens.selectionStroke],
-      ["tooltipPaper", tokens.tooltipPaper],
-      ["tooltipInk", tokens.tooltipInk],
-      ["tooltipBorder", tokens.tooltipBorder],
-      ["toolActive", tokens.toolActive],
-    ]
-      .map(([role, value]) => `--gg-theme-${role}:${value}`)
-      .join(";");
-  });
+  const themeStyle = $derived.by(() =>
+    model === null ? "" : themeTokensToCss(model.scene.theme),
+  );
   const rootStyle = $derived(
     `${hasCanvas || interactive || effectiveEmphasisKeys.length > 0 ? `width:${width === undefined || width === "container" ? "100%" : `${model?.scene.width ?? resolvedWidth}px`};height:${model?.scene.height ?? resolvedHeight}px;` : ""}${themeStyle}` ||
       undefined,
@@ -703,25 +689,21 @@
     y: number;
   }[] {
     if (model === null || keys.length === 0) return [];
-    const keySet = new Set(keys);
-    const anchors: { x: number; y: number }[] = [];
-    const seen = new Set<string>();
+    const candidates: {
+      x: number;
+      y: number;
+      keys: readonly PropertyKey[];
+    }[] = [];
     for (let id = 0; id < model.candidates.size; id++) {
       const candidate = model.candidates.candidate(id);
       if (candidate === null) continue;
-      let selected = false;
-      for (const key of candidateSemanticKeys(candidate)) {
-        if (!keySet.has(key)) continue;
-        selected = true;
-        break;
-      }
-      const identity = `${String(candidate.x)}:${String(candidate.y)}`;
-      if (selected && !seen.has(identity)) {
-        seen.add(identity);
-        anchors.push({ x: candidate.x, y: candidate.y });
-      }
+      candidates.push({
+        x: candidate.x,
+        y: candidate.y,
+        keys: candidateSemanticKeys(candidate),
+      });
     }
-    return anchors;
+    return anchorsFromCandidateKeys(candidates, keys);
   }
   const selectedAnchors = $derived(anchorsForKeys(effectiveSelectedKeys));
   const emphasizedAnchors = $derived(anchorsForKeys(effectiveEmphasisKeys));
@@ -958,12 +940,8 @@
   } {
     const rect = (event.currentTarget as HTMLElement).getBoundingClientRect();
     const scene = model?.scene;
-    if (scene === undefined || rect.width === 0 || rect.height === 0)
-      return { x: 0, y: 0 };
-    return {
-      x: ((event.clientX - rect.left) / rect.width) * scene.width,
-      y: ((event.clientY - rect.top) / rect.height) * scene.height,
-    };
+    if (scene === undefined) return { x: 0, y: 0 };
+    return plotPointFromClient(event.clientX, event.clientY, rect, scene);
   }
 
   function panelId(index: number): string | null {
@@ -998,17 +976,6 @@
   >((_row, index) => semanticKeys.keys.get(index) ?? null);
 
   $effect(() => () => inspectionCoordinator.invalidate());
-
-  function hitFromCandidate(candidate: CandidateFacts): SceneHit {
-    return {
-      layerIndex: candidate.layerIndex,
-      panelIndex: candidate.panelIndex,
-      rowIndex: candidate.rowIndex,
-      x: candidate.x,
-      y: candidate.y,
-      kind: candidate.kind,
-    };
-  }
 
   function candidateFromHit(hit: SceneHit): CandidateFacts | null {
     if (model === null) return null;
@@ -1399,18 +1366,7 @@
     const mode = interactionConfig.select?.mode ?? "xy";
     const panel = model?.scene.panels[0];
     const flip = assembled?.coord?.type === "flip";
-    const query =
-      panel === undefined
-        ? rect
-        : mode === "x"
-          ? flip
-            ? { ...rect, x0: panel.x, x1: panel.x + panel.width }
-            : { ...rect, y0: panel.y, y1: panel.y + panel.height }
-          : mode === "y"
-            ? flip
-              ? { ...rect, y0: panel.y, y1: panel.y + panel.height }
-              : { ...rect, x0: panel.x, x1: panel.x + panel.width }
-            : rect;
+    const query = expandIntervalQuery(rect, panel, mode, flip);
     const candidates =
       model === null
         ? []
@@ -1575,20 +1531,12 @@
   /** Replace one or both continuous zoom domains without disturbing the
    *  other channel. This is the controlled linking/programmatic-zoom path. */
   export function setZoom(domains: Partial<ZoomDomains>): void {
-    const next: ZoomDomains = { ...effectiveZoomDomains };
-    for (const channel of ["x", "y"] as const) {
-      const domain = domains[channel];
-      if (domain === undefined) continue;
-      const scale = model?.scales[channel];
-      if (
-        scale?.type === "band" ||
-        domain.length !== 2 ||
-        !domain.every((value) => Number.isFinite(value))
-      )
-        continue;
-      next[channel] = [domain[0], domain[1]];
-    }
-    if (next.x === undefined && next.y === undefined) return;
+    const next = sanitizePartialZoomDomains(
+      domains,
+      model?.scales,
+      effectiveZoomDomains,
+    );
+    if (next === null) return;
     commitZoom(frozenZoomDomains(next), "programmatic");
   }
 
@@ -1614,17 +1562,15 @@
     if (model === null || model.scene.panels.length !== 1) return;
     const panel = model.scene.panels[0]!;
     const flip = assembled?.coord?.type === "flip";
-    const th0 = clamp((rect.x0 - panel.x) / panel.width, 0, 1);
-    const th1 = clamp((rect.x1 - panel.x) / panel.width, 0, 1);
-    const tv0 = clamp(1 - (rect.y1 - panel.y) / panel.height, 0, 1);
-    const tv1 = clamp(1 - (rect.y0 - panel.y) / panel.height, 0, 1);
-    if (th1 - th0 <= 0 && tv1 - tv0 <= 0) return;
-    const inverted = panelDataDomains(rect, panel, model.scales, flip);
-    const mode = interactionConfig.zoom?.mode ?? "xy";
-    const next: ZoomDomains = { ...effectiveZoomDomains };
-    if (mode !== "y" && inverted.x !== undefined) next.x = inverted.x;
-    if (mode !== "x" && inverted.y !== undefined) next.y = inverted.y;
-    if (next.x === undefined && next.y === undefined) return;
+    const next = resolveBrushZoomDomains(
+      rect,
+      panel,
+      model.scales,
+      flip,
+      interactionConfig.zoom?.mode ?? "xy",
+      effectiveZoomDomains,
+    );
+    if (next === null) return;
     commitZoom(frozenZoomDomains(next), source);
   }
 
@@ -1640,9 +1586,11 @@
 
   function navigate(delta: number): void {
     if (traversalHits.length === 0) return;
-    activeTraversalIndex =
-      (activeTraversalIndex + delta + traversalHits.length) %
-      traversalHits.length;
+    activeTraversalIndex = nextTraversalIndex(
+      activeTraversalIndex,
+      delta,
+      traversalHits.length,
+    );
     setInspection(traversalHits[activeTraversalIndex]!, "keyboard");
   }
 
@@ -1652,23 +1600,12 @@
       navigate(1);
       return;
     }
-    const origin = inspection.focus.anchor;
-    let bestIndex = -1;
-    let bestScore = Number.POSITIVE_INFINITY;
-    for (let index = 0; index < traversalHits.length; index++) {
-      const hit = traversalHits[index]!;
-      const horizontal = hit.x - origin.x;
-      const vertical = hit.y - origin.y;
-      const primary = horizontal * dx + vertical * dy;
-      if (primary <= 0) continue;
-      const orthogonal = Math.abs(horizontal * dy - vertical * dx);
-      const score = primary + orthogonal * 2;
-      // Equal geometric candidates resolve to the later paint/source order,
-      // matching the deterministic topmost representative used by pointer hit testing.
-      if (score > bestScore) continue;
-      bestScore = score;
-      bestIndex = index;
-    }
+    const bestIndex = bestDirectionalIndex(
+      inspection.focus.anchor,
+      traversalHits,
+      dx,
+      dy,
+    );
     if (bestIndex < 0) return;
     activeTraversalIndex = bestIndex;
     setInspection(traversalHits[bestIndex]!, "keyboard");
@@ -1679,22 +1616,15 @@
       navigate(1);
       return;
     }
-    const anchor = inspection.focus.anchor;
-    const coincident = traversalHits
-      .map((hit, index) => ({ hit, index }))
-      .filter(
-        ({ hit }) =>
-          Math.abs(hit.x - anchor.x) < 0.5 && Math.abs(hit.y - anchor.y) < 0.5,
-      );
-    if (coincident.length < 2) return;
-    const current = Math.max(
-      0,
-      coincident.findIndex(({ index }) => index === activeTraversalIndex),
+    const nextIndex = cycleCoincidentIndex(
+      inspection.focus.anchor,
+      traversalHits,
+      activeTraversalIndex,
+      delta,
     );
-    const next =
-      coincident[(current + delta + coincident.length) % coincident.length]!;
-    activeTraversalIndex = next.index;
-    setInspection(next.hit, "keyboard");
+    if (nextIndex < 0) return;
+    activeTraversalIndex = nextIndex;
+    setInspection(traversalHits[nextIndex]!, "keyboard");
   }
 
   function onSurfaceBlur(event: FocusEvent): void {
@@ -1709,14 +1639,11 @@
     source: InteractionSource,
   ): void {
     if (keys.length === 0) return;
-    const allSelected = keys.every((key) =>
-      effectiveSelectedKeys.includes(key),
+    const next = nextPointSelectionKeys(
+      effectiveSelectedKeys,
+      keys,
+      interactionConfig.select?.multiple ?? false,
     );
-    const next = allSelected
-      ? effectiveSelectedKeys.filter((key) => !keys.includes(key))
-      : interactionConfig.select?.multiple
-        ? [...new Set([...effectiveSelectedKeys, ...keys])]
-        : [...keys];
     commitPointSelection(next, source);
   }
 

--- a/packages/svelte/src/lib/plot-geometry.ts
+++ b/packages/svelte/src/lib/plot-geometry.ts
@@ -79,3 +79,31 @@ export function panelDataDomains(
     ...(yDomain !== undefined && { y: yDomain }),
   };
 }
+
+export type IntervalSelectMode = "x" | "y" | "xy";
+
+/**
+ * Expand a brush rect to the free axis for interval selection.
+ * Under coord flip, x-mode expands the horizontal panel span and y-mode the
+ * vertical span (channels are swapped relative to unflipped). Absent panels
+ * leave the rect unchanged.
+ */
+export function expandIntervalQuery(
+  rect: PlotRect,
+  panel: PanelBounds | undefined,
+  mode: IntervalSelectMode,
+  flipped: boolean,
+): PlotRect {
+  if (panel === undefined) return rect;
+  if (mode === "x") {
+    return flipped
+      ? { ...rect, x0: panel.x, x1: panel.x + panel.width }
+      : { ...rect, y0: panel.y, y1: panel.y + panel.height };
+  }
+  if (mode === "y") {
+    return flipped
+      ? { ...rect, y0: panel.y, y1: panel.y + panel.height }
+      : { ...rect, x0: panel.x, x1: panel.x + panel.width };
+  }
+  return rect;
+}

--- a/packages/svelte/src/lib/plot-pointer.ts
+++ b/packages/svelte/src/lib/plot-pointer.ts
@@ -1,0 +1,101 @@
+import type { CandidateFacts } from "@ggsvelte/core";
+import type { SceneHit } from "@ggsvelte/core/dom";
+
+export type ClientRectSize = {
+  readonly left: number;
+  readonly top: number;
+  readonly width: number;
+  readonly height: number;
+};
+
+export type SceneSize = {
+  readonly width: number;
+  readonly height: number;
+};
+
+/** Map a client pointer position into plot/scene coordinates. Zero-size
+ *  targets return the origin; out-of-bounds clients are intentionally not
+ *  clamped (callers may drag past the capture edge). */
+export function plotPointFromClient(
+  clientX: number,
+  clientY: number,
+  rect: ClientRectSize,
+  scene: SceneSize,
+): { x: number; y: number } {
+  if (rect.width === 0 || rect.height === 0) return { x: 0, y: 0 };
+  return {
+    x: ((clientX - rect.left) / rect.width) * scene.width,
+    y: ((clientY - rect.top) / rect.height) * scene.height,
+  };
+}
+
+/** Project a candidate into the SceneHit shape used by hit indexes/overlays. */
+export function hitFromCandidate(candidate: CandidateFacts): SceneHit {
+  return {
+    layerIndex: candidate.layerIndex,
+    panelIndex: candidate.panelIndex,
+    rowIndex: candidate.rowIndex,
+    x: candidate.x,
+    y: candidate.y,
+    kind: candidate.kind,
+  };
+}
+
+/** Modular wrap for keyboard traversal across a hit list. */
+export function nextTraversalIndex(current: number, delta: number, length: number): number {
+  if (length <= 0) return -1;
+  return (current + delta + length) % length;
+}
+
+/**
+ * Pick the best hit in direction (dx, dy) from origin.
+ * Score = primary + 2 * |orthogonal|; ties keep the later traversal index
+ * (matches topmost/later paint order used by pointer hit testing).
+ * Returns -1 when no forward candidate exists.
+ */
+export function bestDirectionalIndex(
+  origin: Readonly<{ x: number; y: number }>,
+  hits: readonly Readonly<{ x: number; y: number }>[],
+  dx: number,
+  dy: number,
+): number {
+  let bestIndex = -1;
+  let bestScore = Number.POSITIVE_INFINITY;
+  for (let index = 0; index < hits.length; index++) {
+    const hit = hits[index]!;
+    const horizontal = hit.x - origin.x;
+    const vertical = hit.y - origin.y;
+    const primary = horizontal * dx + vertical * dy;
+    if (primary <= 0) continue;
+    const orthogonal = Math.abs(horizontal * dy - vertical * dx);
+    const score = primary + orthogonal * 2;
+    // Equal scores overwrite → later traversal order wins.
+    if (score > bestScore) continue;
+    bestScore = score;
+    bestIndex = index;
+  }
+  return bestIndex;
+}
+
+/**
+ * Cycle among hits coincident with origin (within < 0.5 px on both axes).
+ * When activeIndex is not among them, starts as if at the first coincident
+ * entry (Math.max(0, -1) = 0). Returns -1 when fewer than two matches.
+ */
+export function cycleCoincidentIndex(
+  origin: Readonly<{ x: number; y: number }>,
+  hits: readonly Readonly<{ x: number; y: number }>[],
+  activeIndex: number,
+  delta: number,
+): number {
+  const coincident = hits
+    .map((hit, index) => ({ hit, index }))
+    .filter(({ hit }) => Math.abs(hit.x - origin.x) < 0.5 && Math.abs(hit.y - origin.y) < 0.5);
+  if (coincident.length < 2) return -1;
+  const current = Math.max(
+    0,
+    coincident.findIndex(({ index }) => index === activeIndex),
+  );
+  const next = coincident[(current + delta + coincident.length) % coincident.length]!;
+  return next.index;
+}

--- a/packages/svelte/src/lib/plot-selection.ts
+++ b/packages/svelte/src/lib/plot-selection.ts
@@ -1,0 +1,50 @@
+export type CandidateAnchorKeys = {
+  readonly x: number;
+  readonly y: number;
+  readonly keys: readonly PropertyKey[];
+};
+
+/**
+ * Point-selection set algebra for toggle-on-click/keyboard.
+ * Empty toggled keys leave the current selection unchanged.
+ */
+export function nextPointSelectionKeys(
+  current: readonly PropertyKey[],
+  toggled: readonly PropertyKey[],
+  multiple: boolean,
+): PropertyKey[] {
+  if (toggled.length === 0) return [...current];
+  const allSelected = toggled.every((key) => current.includes(key));
+  if (allSelected) return current.filter((key) => !toggled.includes(key));
+  if (multiple) return [...new Set([...current, ...toggled])];
+  return [...toggled];
+}
+
+/**
+ * Collect unique pixel anchors for selected semantic keys.
+ * Candidates must already be in id-ascending order; key resolution stays with
+ * the caller. Dedup identity is `${String(x)}:${String(y)}`.
+ */
+export function anchorsFromCandidateKeys(
+  candidates: Iterable<CandidateAnchorKeys>,
+  selectedKeys: readonly PropertyKey[],
+): { x: number; y: number }[] {
+  if (selectedKeys.length === 0) return [];
+  const keySet = new Set(selectedKeys);
+  const anchors: { x: number; y: number }[] = [];
+  const seen = new Set<string>();
+  for (const candidate of candidates) {
+    let selected = false;
+    for (const key of candidate.keys) {
+      if (!keySet.has(key)) continue;
+      selected = true;
+      break;
+    }
+    const identity = `${String(candidate.x)}:${String(candidate.y)}`;
+    if (selected && !seen.has(identity)) {
+      seen.add(identity);
+      anchors.push({ x: candidate.x, y: candidate.y });
+    }
+  }
+  return anchors;
+}

--- a/packages/svelte/src/lib/plot-theme-css.ts
+++ b/packages/svelte/src/lib/plot-theme-css.ts
@@ -1,0 +1,32 @@
+/** Interaction theme roles exposed as CSS custom properties on the plot root.
+ *  Values may be color strings or numeric opacities (e.g. interactionMuted). */
+export type PlotThemeCssTokens = {
+  readonly interactionInk: string | number;
+  readonly interactionMuted: string | number;
+  readonly focusRing: string | number;
+  readonly crosshair: string | number;
+  readonly selectionFill: string | number;
+  readonly selectionStroke: string | number;
+  readonly tooltipPaper: string | number;
+  readonly tooltipInk: string | number;
+  readonly tooltipBorder: string | number;
+  readonly toolActive: string | number;
+};
+
+const THEME_ROLES = [
+  "interactionInk",
+  "interactionMuted",
+  "focusRing",
+  "crosshair",
+  "selectionFill",
+  "selectionStroke",
+  "tooltipPaper",
+  "tooltipInk",
+  "tooltipBorder",
+  "toolActive",
+] as const satisfies readonly (keyof PlotThemeCssTokens)[];
+
+/** Stable role-order CSS custom property string for interaction chrome. */
+export function themeTokensToCss(tokens: PlotThemeCssTokens): string {
+  return THEME_ROLES.map((role) => `--gg-theme-${role}:${tokens[role]}`).join(";");
+}

--- a/packages/svelte/src/lib/plot-zoom.ts
+++ b/packages/svelte/src/lib/plot-zoom.ts
@@ -13,12 +13,11 @@ export type ZoomMode = "x" | "y" | "xy";
 const zoomScale = (
   config: Scales["x"] | undefined,
   domain: [number, number],
-): NonNullable<Scales["x"]> =>
-  ({
-    ...config,
-    domain: [domain[0], domain[1]],
-    nice: false,
-  }) as NonNullable<Scales["x"]>;
+): NonNullable<Scales["x"]> => ({
+  ...config,
+  domain: [domain[0], domain[1]],
+  nice: false,
+});
 
 /**
  * Merge continuous zoom domains into a portable spec's scales.

--- a/packages/svelte/src/lib/plot-zoom.ts
+++ b/packages/svelte/src/lib/plot-zoom.ts
@@ -1,0 +1,99 @@
+import type { RenderModel } from "@ggsvelte/core";
+import type { PortableSpec, Scales } from "@ggsvelte/spec";
+
+import {
+  panelDataDomains,
+  type ContinuousZoomDomains,
+  type PanelBounds,
+  type PlotRect,
+} from "./plot-geometry.js";
+
+export type ZoomMode = "x" | "y" | "xy";
+
+const zoomScale = (
+  config: Scales["x"] | undefined,
+  domain: [number, number],
+): NonNullable<Scales["x"]> =>
+  ({
+    ...config,
+    domain: [domain[0], domain[1]],
+    nice: false,
+  }) as NonNullable<Scales["x"]>;
+
+/**
+ * Merge continuous zoom domains into a portable spec's scales.
+ * Returns `spec` by reference when domains are null/empty so callers can
+ * keep `$derived` identity stable and avoid pipeline re-runs.
+ */
+export function applyZoomToSpec(
+  spec: PortableSpec,
+  domains: ContinuousZoomDomains | null,
+): PortableSpec {
+  if (domains === null || (domains.x === undefined && domains.y === undefined)) return spec;
+  return {
+    ...spec,
+    scales: {
+      ...spec.scales,
+      ...(domains.x !== undefined && {
+        x: zoomScale(spec.scales?.x, domains.x),
+      }),
+      ...(domains.y !== undefined && {
+        y: zoomScale(spec.scales?.y, domains.y),
+      }),
+    },
+  };
+}
+
+/**
+ * Apply a partial programmatic zoom update, dropping band/non-finite channels.
+ * Returns null when no valid domain remains (callers emit no zoom event).
+ */
+export function sanitizePartialZoomDomains(
+  partial: Partial<ContinuousZoomDomains>,
+  scales: Pick<RenderModel["scales"], "x" | "y"> | undefined,
+  current: ContinuousZoomDomains | null,
+): ContinuousZoomDomains | null {
+  const next: ContinuousZoomDomains = { ...current };
+  for (const channel of ["x", "y"] as const) {
+    const domain = partial[channel];
+    if (domain === undefined) continue;
+    const scale = scales?.[channel];
+    if (
+      scale?.type === "band" ||
+      domain.length !== 2 ||
+      !domain.every((value) => Number.isFinite(value))
+    )
+      continue;
+    next[channel] = [domain[0], domain[1]];
+  }
+  if (next.x === undefined && next.y === undefined) return null;
+  return next;
+}
+
+/**
+ * Invert a brush rect into continuous zoom domains for the given mode.
+ * Degeneracy uses *raw* (pre-flip) normalized pixel spans and rejects only
+ * when both spans are non-positive — single-axis-thin brushes still produce
+ * a domain on the remaining axis (existing M2 behavior).
+ */
+export function resolveBrushZoomDomains(
+  rect: PlotRect,
+  panel: PanelBounds,
+  scales: Pick<RenderModel["scales"], "x" | "y">,
+  flipped: boolean,
+  mode: ZoomMode,
+  current: ContinuousZoomDomains | null,
+): ContinuousZoomDomains | null {
+  const th0 = Math.max(0, Math.min(1, (rect.x0 - panel.x) / panel.width));
+  const th1 = Math.max(0, Math.min(1, (rect.x1 - panel.x) / panel.width));
+  const tv0 = Math.max(0, Math.min(1, 1 - (rect.y1 - panel.y) / panel.height));
+  const tv1 = Math.max(0, Math.min(1, 1 - (rect.y0 - panel.y) / panel.height));
+  // Guard uses raw screen fractions, not flip-remapped domains.
+  if (th1 - th0 <= 0 && tv1 - tv0 <= 0) return null;
+  const inverted = panelDataDomains(rect, panel, scales, flipped);
+  const next: ContinuousZoomDomains = { ...current };
+  if (mode !== "y" && inverted.x !== undefined) next.x = inverted.x;
+  if (mode !== "x" && inverted.y !== undefined) next.y = inverted.y;
+  if (next.x === undefined && next.y === undefined) return null;
+  return next;
+}

--- a/packages/svelte/tests/plot-geometry.test.ts
+++ b/packages/svelte/tests/plot-geometry.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   clamp,
+  expandIntervalQuery,
   frozenZoomDomains,
   invertedDomain,
   normalizedRect,
@@ -126,5 +127,43 @@ describe("panelDataDomains", () => {
     expect(domains.x).toBeUndefined();
     expect(domains.y?.[0]).toBeCloseTo(0);
     expect(domains.y?.[1]).toBeCloseTo(50);
+  });
+});
+
+describe("expandIntervalQuery", () => {
+  const panel = { x: 10, y: 20, width: 100, height: 50 };
+  const rect = { x0: 30, y0: 25, x1: 70, y1: 55 };
+
+  it("returns the rect unchanged when panel is absent", () => {
+    expect(expandIntervalQuery(rect, undefined, "x", false)).toEqual(rect);
+  });
+
+  it("expands the free axis for x/y modes and swaps under flip", () => {
+    expect(expandIntervalQuery(rect, panel, "x", false)).toEqual({
+      ...rect,
+      y0: 20,
+      y1: 70,
+    });
+    expect(expandIntervalQuery(rect, panel, "y", false)).toEqual({
+      ...rect,
+      x0: 10,
+      x1: 110,
+    });
+    // Flipped: x-mode expands horizontal (panel x span); y-mode expands vertical.
+    expect(expandIntervalQuery(rect, panel, "x", true)).toEqual({
+      ...rect,
+      x0: 10,
+      x1: 110,
+    });
+    expect(expandIntervalQuery(rect, panel, "y", true)).toEqual({
+      ...rect,
+      y0: 20,
+      y1: 70,
+    });
+  });
+
+  it("leaves xy mode unexpanded", () => {
+    expect(expandIntervalQuery(rect, panel, "xy", false)).toEqual(rect);
+    expect(expandIntervalQuery(rect, panel, "xy", true)).toEqual(rect);
   });
 });

--- a/packages/svelte/tests/plot-pointer.test.ts
+++ b/packages/svelte/tests/plot-pointer.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from "vitest";
+
+import type { CandidateFacts } from "@ggsvelte/core";
+import type { SceneHit } from "@ggsvelte/core/dom";
+
+import {
+  bestDirectionalIndex,
+  cycleCoincidentIndex,
+  hitFromCandidate,
+  nextTraversalIndex,
+  plotPointFromClient,
+} from "../src/lib/plot-pointer.js";
+
+const hit = (x: number, y: number, extras: Partial<SceneHit> = {}): SceneHit => ({
+  layerIndex: 0,
+  panelIndex: 0,
+  rowIndex: 0,
+  x,
+  y,
+  kind: "point",
+  ...extras,
+});
+
+describe("plotPointFromClient", () => {
+  it("maps client coordinates into scene space", () => {
+    expect(
+      plotPointFromClient(
+        150,
+        120,
+        { left: 100, top: 100, width: 200, height: 100 },
+        {
+          width: 400,
+          height: 200,
+        },
+      ),
+    ).toEqual({ x: 100, y: 40 });
+  });
+
+  it("returns origin when the element has zero size", () => {
+    expect(
+      plotPointFromClient(
+        10,
+        10,
+        { left: 0, top: 0, width: 0, height: 50 },
+        {
+          width: 400,
+          height: 200,
+        },
+      ),
+    ).toEqual({ x: 0, y: 0 });
+    expect(
+      plotPointFromClient(
+        10,
+        10,
+        { left: 0, top: 0, width: 50, height: 0 },
+        {
+          width: 400,
+          height: 200,
+        },
+      ),
+    ).toEqual({ x: 0, y: 0 });
+  });
+
+  it("does not clamp out-of-bounds client coordinates", () => {
+    expect(
+      plotPointFromClient(
+        50,
+        50,
+        { left: 100, top: 100, width: 100, height: 100 },
+        {
+          width: 100,
+          height: 100,
+        },
+      ),
+    ).toEqual({ x: -50, y: -50 });
+  });
+});
+
+describe("hitFromCandidate", () => {
+  it("copies hit fields from a candidate", () => {
+    const candidate = {
+      layerIndex: 2,
+      panelIndex: 1,
+      rowIndex: 7,
+      x: 12.5,
+      y: 44,
+      kind: "line",
+    } as CandidateFacts;
+    expect(hitFromCandidate(candidate)).toEqual({
+      layerIndex: 2,
+      panelIndex: 1,
+      rowIndex: 7,
+      x: 12.5,
+      y: 44,
+      kind: "line",
+    });
+  });
+});
+
+describe("nextTraversalIndex", () => {
+  it("wraps modularly in both directions", () => {
+    expect(nextTraversalIndex(0, 1, 3)).toBe(1);
+    expect(nextTraversalIndex(2, 1, 3)).toBe(0);
+    expect(nextTraversalIndex(0, -1, 3)).toBe(2);
+    expect(nextTraversalIndex(1, -1, 3)).toBe(0);
+  });
+});
+
+describe("bestDirectionalIndex", () => {
+  const origin = { x: 50, y: 50 };
+  const hits = [
+    hit(40, 50), // left of origin
+    hit(70, 50), // right
+    hit(80, 50), // farther right
+    hit(70, 55), // right with orthogonal offset
+    hit(50, 50), // coincident with origin
+  ];
+
+  it("returns -1 for empty hits or no candidates in the direction", () => {
+    expect(bestDirectionalIndex(origin, [], 1, 0)).toBe(-1);
+    expect(bestDirectionalIndex(origin, hits, -1, 0)).toBe(0);
+    expect(bestDirectionalIndex(origin, [hit(40, 50)], 1, 0)).toBe(-1);
+  });
+
+  it("prefers the best score and breaks ties by later traversal order", () => {
+    // Both index 1 and a duplicate at same position: later wins on equal score.
+    const tied = [hit(70, 50), hit(70, 50)];
+    expect(bestDirectionalIndex(origin, tied, 1, 0)).toBe(1);
+    // Among rightward hits, nearer primary with zero orthogonal wins over farther.
+    expect(bestDirectionalIndex(origin, hits, 1, 0)).toBe(1);
+  });
+
+  it("applies orthogonal penalty so collinear-ish neighbors win", () => {
+    // index 1: primary=20, ortho=0 → score 20
+    // index 3: primary=20, ortho=5 → score 20+10=30
+    expect(bestDirectionalIndex(origin, hits, 1, 0)).toBe(1);
+  });
+
+  it("excludes origin-coincident and behind-direction hits (primary <= 0)", () => {
+    expect(bestDirectionalIndex(origin, [hit(50, 50), hit(60, 50)], 1, 0)).toBe(1);
+    expect(bestDirectionalIndex(origin, [hit(40, 50)], 1, 0)).toBe(-1);
+  });
+});
+
+describe("cycleCoincidentIndex", () => {
+  const origin = { x: 10, y: 20 };
+  const hits = [
+    hit(10, 20), // 0 coincident
+    hit(50, 50), // 1 not
+    hit(10.4, 20.4), // 2 coincident (< 0.5)
+    hit(10.6, 20), // 3 not (>= 0.5 on x)
+    hit(10, 20), // 4 coincident
+  ];
+
+  it("returns -1 when fewer than two coincident hits", () => {
+    expect(cycleCoincidentIndex(origin, [hit(10, 20)], 0, 1)).toBe(-1);
+    expect(cycleCoincidentIndex(origin, [hit(0, 0), hit(1, 1)], 0, 1)).toBe(-1);
+  });
+
+  it("cycles forward and wraps", () => {
+    expect(cycleCoincidentIndex(origin, hits, 0, 1)).toBe(2);
+    expect(cycleCoincidentIndex(origin, hits, 2, 1)).toBe(4);
+    expect(cycleCoincidentIndex(origin, hits, 4, 1)).toBe(0);
+  });
+
+  it("cycles backward and wraps", () => {
+    expect(cycleCoincidentIndex(origin, hits, 0, -1)).toBe(4);
+  });
+
+  it("starts at first coincident when active index is not in the set", () => {
+    // activeIndex 1 is not coincident → Math.max(0, -1) = 0 → next from first
+    expect(cycleCoincidentIndex(origin, hits, 1, 1)).toBe(2);
+  });
+});

--- a/packages/svelte/tests/plot-selection.test.ts
+++ b/packages/svelte/tests/plot-selection.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { anchorsFromCandidateKeys, nextPointSelectionKeys } from "../src/lib/plot-selection.js";
+
+describe("nextPointSelectionKeys", () => {
+  it("no-ops on empty toggle input", () => {
+    expect(nextPointSelectionKeys(["a"], [], true)).toEqual(["a"]);
+  });
+
+  it("removes keys when every toggled key is already selected", () => {
+    expect(nextPointSelectionKeys(["a", "b", "c"], ["a", "c"], true)).toEqual(["b"]);
+  });
+
+  it("unions keys in multiple mode when not all are selected", () => {
+    expect(nextPointSelectionKeys(["a"], ["a", "b"], true)).toEqual(["a", "b"]);
+    expect(nextPointSelectionKeys(["a"], ["b"], true)).toEqual(["a", "b"]);
+  });
+
+  it("replaces selection in single mode", () => {
+    expect(nextPointSelectionKeys(["a", "b"], ["c"], false)).toEqual(["c"]);
+    // partial overlap still not "all selected"
+    expect(nextPointSelectionKeys(["a", "b"], ["a", "c"], false)).toEqual(["a", "c"]);
+  });
+
+  it("deduplicates union results", () => {
+    expect(nextPointSelectionKeys(["a", "a"], ["b", "b"], true)).toEqual(["a", "b"]);
+  });
+});
+
+describe("anchorsFromCandidateKeys", () => {
+  const candidates = [
+    { x: 1, y: 2, keys: ["a"] },
+    { x: 3, y: 4, keys: ["b"] },
+    { x: 1, y: 2, keys: ["c"] }, // same anchor as first
+    { x: 5, y: 6, keys: ["a", "d"] },
+    { x: 7, y: 8, keys: [] },
+  ];
+
+  it("returns empty when nothing is selected", () => {
+    expect(anchorsFromCandidateKeys(candidates, [])).toEqual([]);
+  });
+
+  it("collects anchors in id-ascending order and dedups by coordinate identity", () => {
+    expect(anchorsFromCandidateKeys(candidates, ["a", "b"])).toEqual([
+      { x: 1, y: 2 },
+      { x: 3, y: 4 },
+      { x: 5, y: 6 },
+    ]);
+  });
+
+  it("uses String(x):String(y) identity for dedup", () => {
+    const dupes = [
+      { x: 1, y: 2, keys: ["a"] },
+      { x: 1, y: 2, keys: ["a"] },
+    ];
+    expect(anchorsFromCandidateKeys(dupes, ["a"])).toEqual([{ x: 1, y: 2 }]);
+  });
+});

--- a/packages/svelte/tests/plot-theme-css.test.ts
+++ b/packages/svelte/tests/plot-theme-css.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { themeTokensToCss } from "../src/lib/plot-theme-css.js";
+
+describe("themeTokensToCss", () => {
+  it("emits custom properties in the stable role order", () => {
+    const css = themeTokensToCss({
+      interactionInk: "#111",
+      interactionMuted: 0.35,
+      focusRing: "#333",
+      crosshair: "#444",
+      selectionFill: "#555",
+      selectionStroke: "#666",
+      tooltipPaper: "#777",
+      tooltipInk: "#888",
+      tooltipBorder: "#999",
+      toolActive: "#aaa",
+    });
+    expect(css).toBe(
+      [
+        "--gg-theme-interactionInk:#111",
+        "--gg-theme-interactionMuted:0.35",
+        "--gg-theme-focusRing:#333",
+        "--gg-theme-crosshair:#444",
+        "--gg-theme-selectionFill:#555",
+        "--gg-theme-selectionStroke:#666",
+        "--gg-theme-tooltipPaper:#777",
+        "--gg-theme-tooltipInk:#888",
+        "--gg-theme-tooltipBorder:#999",
+        "--gg-theme-toolActive:#aaa",
+      ].join(";"),
+    );
+  });
+});

--- a/packages/svelte/tests/plot-zoom.test.ts
+++ b/packages/svelte/tests/plot-zoom.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from "vitest";
+
+import type { PortableSpec } from "@ggsvelte/spec";
+
+import {
+  applyZoomToSpec,
+  resolveBrushZoomDomains,
+  sanitizePartialZoomDomains,
+} from "../src/lib/plot-zoom.js";
+
+const continuousScale = (domain: [number, number]) => {
+  const [d0, d1] = domain;
+  const span = d1 - d0;
+  return {
+    type: "continuous" as const,
+    invert: (t: number) => d0 + t * span,
+  };
+};
+
+const bandScale = {
+  type: "band" as const,
+  invert: (_t: number) => 0,
+};
+
+const panel = { x: 0, y: 0, width: 100, height: 100 };
+
+describe("applyZoomToSpec", () => {
+  const base = {
+    aes: {},
+    layers: [{ geom: "point" }],
+    scales: {
+      x: { type: "continuous", nice: true },
+      y: { type: "continuous", nice: true },
+    },
+  } as unknown as PortableSpec;
+
+  it("returns the same reference when domains are null or empty", () => {
+    expect(applyZoomToSpec(base, null)).toBe(base);
+    expect(applyZoomToSpec(base, {})).toBe(base);
+    expect(applyZoomToSpec(base, { x: undefined, y: undefined })).toBe(base);
+  });
+
+  it("merges continuous domains with nice:false and clones tuples", () => {
+    const x: [number, number] = [10, 20];
+    const next = applyZoomToSpec(base, { x });
+    expect(next).not.toBe(base);
+    expect(next.scales?.x).toEqual({
+      type: "continuous",
+      nice: false,
+      domain: [10, 20],
+    });
+    expect(next.scales?.x?.domain).not.toBe(x);
+    expect(next.scales?.y).toEqual(base.scales?.y);
+    x[0] = 99;
+    expect(next.scales?.x?.domain).toEqual([10, 20]);
+  });
+
+  it("handles absent scale configs via spread of undefined", () => {
+    const bare = {
+      aes: {},
+      layers: [{ geom: "point" }],
+    } as unknown as PortableSpec;
+    const next = applyZoomToSpec(bare, { y: [0, 1] });
+    expect(next.scales?.y).toEqual({ domain: [0, 1], nice: false });
+    expect(next.scales?.x).toBeUndefined();
+  });
+});
+
+describe("sanitizePartialZoomDomains", () => {
+  const scales = {
+    x: continuousScale([0, 100]),
+    y: bandScale,
+  };
+
+  it("keeps finite continuous channels and drops band/non-finite", () => {
+    expect(sanitizePartialZoomDomains({ x: [5, 15], y: [0, 1] }, scales as never, null)).toEqual({
+      x: [5, 15],
+    });
+  });
+
+  it("retains the other channel from current domains", () => {
+    expect(
+      sanitizePartialZoomDomains(
+        { x: [1, 2] },
+        {
+          x: continuousScale([0, 10]),
+          y: continuousScale([0, 10]),
+        } as never,
+        { y: [3, 4] },
+      ),
+    ).toEqual({ x: [1, 2], y: [3, 4] });
+  });
+
+  it("returns null when nothing valid remains", () => {
+    expect(
+      sanitizePartialZoomDomains(
+        { x: [Number.NaN, 1], y: [0, Number.POSITIVE_INFINITY] },
+        {
+          x: continuousScale([0, 1]),
+          y: continuousScale([0, 1]),
+        } as never,
+        null,
+      ),
+    ).toBeNull();
+    expect(
+      sanitizePartialZoomDomains({ x: [0, 1] }, { x: bandScale, y: bandScale } as never, null),
+    ).toBeNull();
+  });
+});
+
+describe("resolveBrushZoomDomains", () => {
+  const scales = {
+    x: continuousScale([0, 100]),
+    y: continuousScale([0, 50]),
+  };
+
+  it("rejects only when both normalized pixel spans are non-positive", () => {
+    expect(
+      resolveBrushZoomDomains(
+        { x0: 10, y0: 10, x1: 10, y1: 10 },
+        panel,
+        scales as never,
+        false,
+        "xy",
+        null,
+      ),
+    ).toBeNull();
+  });
+
+  it("allows a single-axis-thin brush (existing behavior)", () => {
+    const domains = resolveBrushZoomDomains(
+      { x0: 10, y0: 20, x1: 10, y1: 80 },
+      panel,
+      scales as never,
+      false,
+      "xy",
+      null,
+    );
+    expect(domains).not.toBeNull();
+    expect(domains!.y).toBeDefined();
+  });
+
+  it("filters by mode and merges with current domains", () => {
+    const xOnly = resolveBrushZoomDomains(
+      { x0: 10, y0: 10, x1: 90, y1: 90 },
+      panel,
+      scales as never,
+      false,
+      "x",
+      { y: [1, 2] },
+    );
+    expect(xOnly?.x).toEqual([10, 90]);
+    expect(xOnly?.y).toEqual([1, 2]);
+
+    const yOnly = resolveBrushZoomDomains(
+      { x0: 10, y0: 10, x1: 90, y1: 90 },
+      panel,
+      scales as never,
+      false,
+      "y",
+      null,
+    );
+    expect(yOnly?.x).toBeUndefined();
+    expect(yOnly?.y).toBeDefined();
+  });
+
+  it("inverts through flipped coordinates", () => {
+    // Flipped: screen-x → y scale [0,50], screen-y → x scale [0,100].
+    const domains = resolveBrushZoomDomains(
+      { x0: 0, y0: 0, x1: 100, y1: 100 },
+      panel,
+      scales as never,
+      true,
+      "xy",
+      null,
+    );
+    expect(domains?.x).toEqual([0, 100]);
+    expect(domains?.y).toEqual([0, 50]);
+  });
+});


### PR DESCRIPTION
## Summary

- Extract pure, testable helpers from `GGPlot.svelte` into focused modules so interaction math no longer lives only inside a 2k-line orchestrator:
  - `plot-pointer.ts` — client→scene mapping, hit projection, traversal, directional nav, coincident cycling
  - `plot-zoom.ts` — zoom→spec merge (referential identity when empty), brush domain resolution, partial zoom sanitization
  - `plot-selection.ts` — point-selection set algebra and anchor collection
  - `plot-theme-css.ts` — stable theme CSS custom-property string
  - `plot-geometry.ts` — `expandIntervalQuery` for interval selection panel expansion (incl. coord flip)
- Wire `GGPlot` through the helpers without changing public API (`resetScales` / `setZoom` / props) or interaction event shapes.
- Add characterization unit tests for load-bearing contracts (nav ties later-wins, brush degeneracy `&&`, zoom identity, flip modes, selection algebra).

## Test plan

- [x] `bun run check` (svelte-check) — 0 errors
- [x] Unit characterization: plot-pointer / plot-geometry / plot-zoom / plot-selection / plot-theme-css
- [x] Interaction + component regression suite (chromium/firefox/webkit)
- [x] Full `packages/svelte` browser suite (one flaky chromium SSR hydration timeout re-ran green)
- [x] `bun run lint`
- [ ] CI green on this PR