### PR TITLE
refactor(svelte): extract interval selection and capability helpers

### DIFF
--- a/packages/svelte/src/lib/GGPlot.svelte
+++ b/packages/svelte/src/lib/GGPlot.svelte
@@ -107,12 +107,27 @@
     bestDirectionalIndex,
     cycleCoincidentIndex,
     hitFromCandidate,
+    matchCandidateFromHit,
     nextTraversalIndex,
     plotPointFromClient,
   } from "./plot-pointer.js";
   import {
+    bandChannelsForZoom,
+    capabilityStatusText,
+    zoomScaleDiagnosticsFromChannels,
+    zoomSupportsChannel,
+  } from "./plot-capability.js";
+  import {
+    buildIntervalSelection,
+    clearIntervalSelectionEvent,
+    filterDomainBySelectMode,
+    isBrushTooSmall,
+  } from "./plot-interval.js";
+  import {
     anchorsFromCandidateKeys,
     nextPointSelectionKeys,
+    rowIndexesForCandidate,
+    uniqueKeysFromRowIndexes,
   } from "./plot-selection.js";
   import { themeTokensToCss } from "./plot-theme-css.js";
   import {
@@ -622,11 +637,7 @@
   let committedInterval = $state<IntervalSelection | null>(null);
   const zoomHasSupportedChannel = $derived.by(() => {
     if (interactionConfig.zoom === null || model === null) return true;
-    const mode = interactionConfig.zoom.mode;
-    return (
-      (mode !== "y" && model.scales.x.type !== "band") ||
-      (mode !== "x" && model.scales.y.type !== "band")
-    );
+    return zoomSupportsChannel(interactionConfig.zoom.mode, model.scales);
   });
   const availableTools = $derived(
     interactionConfig.availableTools.filter(
@@ -645,37 +656,28 @@
       model.scene.batches.every((batch) => batch.rowIndex.length === 0),
   );
   const areaScaleDiagnostics = $derived.by(() => {
-    if (model === null) return [] as InteractionDiagnostic[];
-    const modes =
-      interactionConfig.zoom === null ? [] : [interactionConfig.zoom.mode];
-    const channels = new Set<"x" | "y">();
-    for (const mode of modes) {
-      if (mode !== "y" && model.scales.x.type === "band") channels.add("x");
-      if (mode !== "x" && model.scales.y.type === "band") channels.add("y");
-    }
-    return [...channels].map((channel) => ({
-      ...INTERACTION_DIAGNOSTIC_CATALOG.INTERACTION_INTERVAL_SCALE_UNSUPPORTED,
-      prop: `scales.${channel}`,
-      actual: "band",
-    }));
+    if (model === null || interactionConfig.zoom === null)
+      return [] as InteractionDiagnostic[];
+    return zoomScaleDiagnosticsFromChannels(
+      bandChannelsForZoom(interactionConfig.zoom.mode, model.scales),
+      INTERACTION_DIAGNOSTIC_CATALOG.INTERACTION_INTERVAL_SCALE_UNSUPPORTED,
+    );
   });
   const capabilityStatus = $derived.by(() => {
     const unavailable = interactionConfig.diagnostics.find(
       (diagnostic) =>
         diagnostic.code === "INTERACTION_INTERVAL_FACET_UNSUPPORTED",
     );
-    if (unavailable !== undefined)
-      return `Area interaction unavailable: ${unavailable.message}`;
-    if (areaScaleDiagnostics.length > 0)
-      return `Zoom ${zoomHasSupportedChannel ? "limited" : "unavailable"}: ${areaScaleDiagnostics[0]!.message}`;
-    if (
-      interactive &&
-      !emptyPlot &&
-      model !== null &&
-      model.candidates.size === 0
-    )
-      return "No inspectable marks";
-    return null;
+    return capabilityStatusText({
+      ...(unavailable !== undefined && {
+        facetUnavailableMessage: unavailable.message,
+      }),
+      areaDiagnostics: areaScaleDiagnostics,
+      zoomSupported: zoomHasSupportedChannel,
+      interactive,
+      emptyPlot,
+      candidateCount: model === null ? null : model.candidates.size,
+    });
   });
   const themeStyle = $derived.by(() =>
     model === null ? "" : themeTokensToCss(model.scene.theme),
@@ -754,17 +756,7 @@
 
   function clearIntervalSelection(source: InteractionSource): void {
     if (committedInterval === null) return;
-    const event: IntervalSelection = Object.freeze({
-      type: "select",
-      phase: "clear",
-      mode: committedInterval.mode,
-      panelId: committedInterval.panelId,
-      domain: Object.freeze({}),
-      pixels: Object.freeze({ ...committedInterval.pixels }),
-      keys: Object.freeze([]),
-      lineageCount: 0,
-      source,
-    });
+    const event = clearIntervalSelectionEvent(committedInterval, source);
     committedInterval = null;
     emitSelection(event);
   }
@@ -960,14 +952,13 @@
 
   function candidateSemanticKeys(candidate: CandidateFacts): PropertyKey[] {
     if (model === null) return [];
-    const keys: PropertyKey[] = [];
-    const rows = new Set(model.lineage.keys(candidate.lineage));
-    if (candidate.rowIndex !== null) rows.add(candidate.rowIndex);
-    for (const rowIndex of rows) {
-      const key = semanticKey(model.row(rowIndex), rowIndex);
-      if (key !== null && !keys.includes(key)) keys.push(key);
-    }
-    return keys;
+    const rows = rowIndexesForCandidate(
+      candidate,
+      model.lineage.keys(candidate.lineage),
+    );
+    return uniqueKeysFromRowIndexes(rows, (rowIndex) =>
+      semanticKey(model.row(rowIndex), rowIndex),
+    );
   }
 
   const inspectionCoordinator = createInspectionCoordinator<
@@ -979,20 +970,15 @@
 
   function candidateFromHit(hit: SceneHit): CandidateFacts | null {
     if (model === null) return null;
-    for (let id = 0; id < model.candidates.size; id++) {
-      const candidate = model.candidates.candidate(id);
-      if (
-        candidate !== null &&
-        candidate.layerIndex === hit.layerIndex &&
-        candidate.panelIndex === hit.panelIndex &&
-        candidate.rowIndex === hit.rowIndex &&
-        candidate.kind === hit.kind &&
-        Math.abs(candidate.x - hit.x) < 0.5 &&
-        Math.abs(candidate.y - hit.y) < 0.5
-      )
-        return candidate;
-    }
-    return null;
+    return matchCandidateFromHit(
+      (function* () {
+        for (let id = 0; id < model.candidates.size; id++) {
+          const candidate = model.candidates.candidate(id);
+          if (candidate !== null) yield candidate;
+        }
+      })(),
+      hit,
+    );
   }
 
   function resolveInspection(
@@ -1386,39 +1372,21 @@
     for (const candidate of candidates)
       for (const rowIndex of model?.lineage.keys(candidate.lineage) ?? [])
         sourceRows.add(rowIndex);
-    const keys = [
-      ...new Set(
-        [...sourceRows]
-          .map((rowIndex) =>
-            semanticKey(model?.row(rowIndex) ?? null, rowIndex),
-          )
-          .filter((key): key is PropertyKey => key !== null),
-      ),
-    ];
-    const domain: { x?: [CellValue, CellValue]; y?: [CellValue, CellValue] } =
-      {};
-    if (model !== null && model.scene.panels.length === 1) {
-      const solePanel = model.scene.panels[0]!;
-      const inverted = panelDataDomains(rect, solePanel, model.scales, flip);
-      if (mode !== "y" && inverted.x !== undefined) domain.x = inverted.x;
-      if (mode !== "x" && inverted.y !== undefined) domain.y = inverted.y;
-    }
-    const frozenDomain = Object.freeze({
-      ...(domain.x !== undefined && {
-        x: Object.freeze([...domain.x]) as [CellValue, CellValue],
-      }),
-      ...(domain.y !== undefined && {
-        y: Object.freeze([...domain.y]) as [CellValue, CellValue],
-      }),
-    });
-    return Object.freeze({
-      type: "select",
+    const keys = uniqueKeysFromRowIndexes(sourceRows, (rowIndex) =>
+      semanticKey(model?.row(rowIndex) ?? null, rowIndex),
+    );
+    const inverted =
+      model !== null && model.scene.panels.length === 1
+        ? panelDataDomains(rect, model.scene.panels[0]!, model.scales, flip)
+        : {};
+    const domain = filterDomainBySelectMode(inverted, mode);
+    return buildIntervalSelection({
       phase,
-      mode: interactionConfig.select?.mode ?? "xy",
+      mode,
       panelId: panelId(0),
-      domain: frozenDomain,
-      pixels: Object.freeze({ ...rect }),
-      keys: Object.freeze([...keys]),
+      domain,
+      pixels: rect,
+      keys,
       lineageCount: sourceRows.size,
       source,
     });
@@ -1464,7 +1432,7 @@
         ]),
       ),
     } as { x0: number; y0: number; x1: number; y1: number });
-    if (rect.x1 - rect.x0 < 4 && rect.y1 - rect.y0 < 4) {
+    if (isBrushTooSmall(rect)) {
       brushRect = rect;
       announceInteraction("Choose opposite corner.");
       return;

--- a/packages/svelte/src/lib/plot-capability.ts
+++ b/packages/svelte/src/lib/plot-capability.ts
@@ -1,0 +1,75 @@
+import type { InteractionDiagnostic } from "./interaction.js";
+
+export type ZoomAreaMode = "x" | "y" | "xy";
+
+export type ScaleTypeRef = {
+  readonly x: { readonly type: string };
+  readonly y: { readonly type: string };
+};
+
+/** True when at least one channel requested by mode is non-band. */
+export function zoomSupportsChannel(
+  mode: ZoomAreaMode,
+  scales: ScaleTypeRef,
+): boolean {
+  return (
+    (mode !== "y" && scales.x.type !== "band") ||
+    (mode !== "x" && scales.y.type !== "band")
+  );
+}
+
+/** Band channels that block zoom under the given mode. */
+export function bandChannelsForZoom(
+  mode: ZoomAreaMode,
+  scales: ScaleTypeRef,
+): Array<"x" | "y"> {
+  const channels: Array<"x" | "y"> = [];
+  if (mode !== "y" && scales.x.type === "band") channels.push("x");
+  if (mode !== "x" && scales.y.type === "band") channels.push("y");
+  return channels;
+}
+
+/**
+ * Zoom-only band-scale diagnostics (not interval-select).
+ * `catalogEntry` is spread into each diagnostic with prop/actual filled.
+ */
+export function zoomScaleDiagnosticsFromChannels(
+  channels: readonly ("x" | "y")[],
+  catalogEntry: Omit<InteractionDiagnostic, "prop" | "actual"> &
+    Partial<Pick<InteractionDiagnostic, "prop" | "actual">>,
+): InteractionDiagnostic[] {
+  return channels.map((channel) => ({
+    ...catalogEntry,
+    prop: `scales.${channel}`,
+    actual: "band",
+  }));
+}
+
+export type CapabilityStatusInput = {
+  readonly facetUnavailableMessage?: string;
+  readonly areaDiagnostics: readonly InteractionDiagnostic[];
+  readonly zoomSupported: boolean;
+  readonly interactive: boolean;
+  readonly emptyPlot: boolean;
+  /** Null when no render model (preserves host `model !== null` guard). */
+  readonly candidateCount: number | null;
+};
+
+/**
+ * User-facing capability status under the plot.
+ * Order: facet unavailable → zoom limited/unavailable → no inspectable marks → null.
+ */
+export function capabilityStatusText(input: CapabilityStatusInput): string | null {
+  if (input.facetUnavailableMessage !== undefined)
+    return `Area interaction unavailable: ${input.facetUnavailableMessage}`;
+  if (input.areaDiagnostics.length > 0)
+    return `Zoom ${input.zoomSupported ? "limited" : "unavailable"}: ${input.areaDiagnostics[0]!.message}`;
+  if (
+    input.interactive &&
+    !input.emptyPlot &&
+    input.candidateCount !== null &&
+    input.candidateCount === 0
+  )
+    return "No inspectable marks";
+  return null;
+}

--- a/packages/svelte/src/lib/plot-capability.ts
+++ b/packages/svelte/src/lib/plot-capability.ts
@@ -8,21 +8,12 @@ export type ScaleTypeRef = {
 };
 
 /** True when at least one channel requested by mode is non-band. */
-export function zoomSupportsChannel(
-  mode: ZoomAreaMode,
-  scales: ScaleTypeRef,
-): boolean {
-  return (
-    (mode !== "y" && scales.x.type !== "band") ||
-    (mode !== "x" && scales.y.type !== "band")
-  );
+export function zoomSupportsChannel(mode: ZoomAreaMode, scales: ScaleTypeRef): boolean {
+  return (mode !== "y" && scales.x.type !== "band") || (mode !== "x" && scales.y.type !== "band");
 }
 
 /** Band channels that block zoom under the given mode. */
-export function bandChannelsForZoom(
-  mode: ZoomAreaMode,
-  scales: ScaleTypeRef,
-): Array<"x" | "y"> {
+export function bandChannelsForZoom(mode: ZoomAreaMode, scales: ScaleTypeRef): Array<"x" | "y"> {
   const channels: Array<"x" | "y"> = [];
   if (mode !== "y" && scales.x.type === "band") channels.push("x");
   if (mode !== "x" && scales.y.type === "band") channels.push("y");

--- a/packages/svelte/src/lib/plot-interval.ts
+++ b/packages/svelte/src/lib/plot-interval.ts
@@ -1,9 +1,6 @@
 import type { CellValue } from "@ggsvelte/core";
 
-import type {
-  InteractionSource,
-  IntervalSelection,
-} from "./interaction.js";
+import type { InteractionSource, IntervalSelection } from "./interaction.js";
 import type { PlotRect } from "./plot-geometry.js";
 
 /** Pointer brush-end gate only. Keyboard Enter/Space commits any size. */
@@ -20,10 +17,7 @@ export type IntervalDomain = {
  * Pointer brush-end degeneracy: BOTH spans must be strictly less than min.
  * Input must already be normalized (x0≤x1, y0≤y1); this does not take abs.
  */
-export function isBrushTooSmall(
-  rect: PlotRect,
-  minPx: number = BRUSH_MIN_SPAN_PX,
-): boolean {
+export function isBrushTooSmall(rect: PlotRect, minPx: number = BRUSH_MIN_SPAN_PX): boolean {
   return rect.x1 - rect.x0 < minPx && rect.y1 - rect.y0 < minPx;
 }
 
@@ -39,9 +33,7 @@ export function filterDomainBySelectMode(
 }
 
 /** Freeze an interval domain bag (nested tuples when present). */
-export function freezeIntervalDomain(
-  domain: IntervalDomain,
-): IntervalSelection["domain"] {
+export function freezeIntervalDomain(domain: IntervalDomain): IntervalSelection["domain"] {
   return Object.freeze({
     ...(domain.x !== undefined && {
       x: Object.freeze([...domain.x]) as [CellValue, CellValue],
@@ -64,9 +56,7 @@ export type BuildIntervalSelectionInput = {
 };
 
 /** Build a frozen IntervalSelection event payload. */
-export function buildIntervalSelection(
-  input: BuildIntervalSelectionInput,
-): IntervalSelection {
+export function buildIntervalSelection(input: BuildIntervalSelectionInput): IntervalSelection {
   return Object.freeze({
     type: "select",
     phase: input.phase,

--- a/packages/svelte/src/lib/plot-interval.ts
+++ b/packages/svelte/src/lib/plot-interval.ts
@@ -1,0 +1,102 @@
+import type { CellValue } from "@ggsvelte/core";
+
+import type {
+  InteractionSource,
+  IntervalSelection,
+} from "./interaction.js";
+import type { PlotRect } from "./plot-geometry.js";
+
+/** Pointer brush-end gate only. Keyboard Enter/Space commits any size. */
+export const BRUSH_MIN_SPAN_PX = 4;
+
+export type SelectAreaMode = "x" | "y" | "xy";
+
+export type IntervalDomain = {
+  readonly x?: readonly [CellValue, CellValue];
+  readonly y?: readonly [CellValue, CellValue];
+};
+
+/**
+ * Pointer brush-end degeneracy: BOTH spans must be strictly less than min.
+ * Input must already be normalized (x0≤x1, y0≤y1); this does not take abs.
+ */
+export function isBrushTooSmall(
+  rect: PlotRect,
+  minPx: number = BRUSH_MIN_SPAN_PX,
+): boolean {
+  return rect.x1 - rect.x0 < minPx && rect.y1 - rect.y0 < minPx;
+}
+
+/** Drop domain axes not requested by the interval select mode. */
+export function filterDomainBySelectMode(
+  domain: IntervalDomain,
+  mode: SelectAreaMode,
+): IntervalDomain {
+  return {
+    ...(mode !== "y" && domain.x !== undefined && { x: domain.x }),
+    ...(mode !== "x" && domain.y !== undefined && { y: domain.y }),
+  };
+}
+
+/** Freeze an interval domain bag (nested tuples when present). */
+export function freezeIntervalDomain(
+  domain: IntervalDomain,
+): IntervalSelection["domain"] {
+  return Object.freeze({
+    ...(domain.x !== undefined && {
+      x: Object.freeze([...domain.x]) as [CellValue, CellValue],
+    }),
+    ...(domain.y !== undefined && {
+      y: Object.freeze([...domain.y]) as [CellValue, CellValue],
+    }),
+  });
+}
+
+export type BuildIntervalSelectionInput = {
+  readonly phase: IntervalSelection["phase"];
+  readonly mode: SelectAreaMode;
+  readonly panelId: string | null;
+  readonly domain: IntervalDomain;
+  readonly pixels: PlotRect;
+  readonly keys: readonly PropertyKey[];
+  readonly lineageCount: number;
+  readonly source: InteractionSource;
+};
+
+/** Build a frozen IntervalSelection event payload. */
+export function buildIntervalSelection(
+  input: BuildIntervalSelectionInput,
+): IntervalSelection {
+  return Object.freeze({
+    type: "select",
+    phase: input.phase,
+    mode: input.mode,
+    panelId: input.panelId,
+    domain: freezeIntervalDomain(input.domain),
+    pixels: Object.freeze({ ...input.pixels }),
+    keys: Object.freeze([...input.keys]),
+    lineageCount: input.lineageCount,
+    source: input.source,
+  });
+}
+
+/**
+ * Clear event for a committed interval: preserves mode/panelId/pixels,
+ * empties domain/keys, lineageCount 0.
+ */
+export function clearIntervalSelectionEvent(
+  previous: Pick<IntervalSelection, "mode" | "panelId" | "pixels">,
+  source: InteractionSource,
+): IntervalSelection {
+  return Object.freeze({
+    type: "select",
+    phase: "clear",
+    mode: previous.mode,
+    panelId: previous.panelId,
+    domain: Object.freeze({}),
+    pixels: Object.freeze({ ...previous.pixels }),
+    keys: Object.freeze([]),
+    lineageCount: 0,
+    source,
+  });
+}

--- a/packages/svelte/src/lib/plot-pointer.ts
+++ b/packages/svelte/src/lib/plot-pointer.ts
@@ -41,6 +41,33 @@ export function hitFromCandidate(candidate: CandidateFacts): SceneHit {
   };
 }
 
+/** Pixel tolerance for matching a hit back to a stored candidate (both axes). */
+export const CANDIDATE_HIT_TOLERANCE = 0.5;
+
+/**
+ * Find the first candidate matching a SceneHit identity + proximity.
+ * Iteration order is caller-owned (production walks id-ascending).
+ * Tolerance is exclusive: |Δ| < tol matches; |Δ| === tol does not.
+ */
+export function matchCandidateFromHit(
+  candidates: Iterable<CandidateFacts>,
+  hit: SceneHit,
+  tolerance: number = CANDIDATE_HIT_TOLERANCE,
+): CandidateFacts | null {
+  for (const candidate of candidates) {
+    if (
+      candidate.layerIndex === hit.layerIndex &&
+      candidate.panelIndex === hit.panelIndex &&
+      candidate.rowIndex === hit.rowIndex &&
+      candidate.kind === hit.kind &&
+      Math.abs(candidate.x - hit.x) < tolerance &&
+      Math.abs(candidate.y - hit.y) < tolerance
+    )
+      return candidate;
+  }
+  return null;
+}
+
 /** Modular wrap for keyboard traversal across a hit list. */
 export function nextTraversalIndex(current: number, delta: number, length: number): number {
   if (length <= 0) return -1;

--- a/packages/svelte/src/lib/plot-selection.ts
+++ b/packages/svelte/src/lib/plot-selection.ts
@@ -4,6 +4,39 @@ export type CandidateAnchorKeys = {
   readonly keys: readonly PropertyKey[];
 };
 
+export type CandidateRowRef = {
+  readonly rowIndex: number | null;
+};
+
+/**
+ * Union lineage row indexes with the candidate's own rowIndex when set.
+ * Lineage order is preserved; the candidate row is appended only if absent.
+ */
+export function rowIndexesForCandidate(
+  candidate: CandidateRowRef,
+  lineageRowIndexes: Iterable<number>,
+): number[] {
+  const rows = [...lineageRowIndexes];
+  if (candidate.rowIndex !== null && !rows.includes(candidate.rowIndex))
+    rows.push(candidate.rowIndex);
+  return rows;
+}
+
+/**
+ * Map row indexes through a key resolver, keeping first-seen unique non-null keys.
+ */
+export function uniqueKeysFromRowIndexes(
+  rowIndexes: Iterable<number>,
+  keyForRow: (rowIndex: number) => PropertyKey | null,
+): PropertyKey[] {
+  const keys: PropertyKey[] = [];
+  for (const rowIndex of rowIndexes) {
+    const key = keyForRow(rowIndex);
+    if (key !== null && !keys.includes(key)) keys.push(key);
+  }
+  return keys;
+}
+
 /**
  * Point-selection set algebra for toggle-on-click/keyboard.
  * Empty toggled keys leave the current selection unchanged.

--- a/packages/svelte/tests/plot-capability.test.ts
+++ b/packages/svelte/tests/plot-capability.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  bandChannelsForZoom,
+  capabilityStatusText,
+  zoomScaleDiagnosticsFromChannels,
+  zoomSupportsChannel,
+} from "../src/lib/plot-capability.js";
+
+const continuous = { x: { type: "linear" }, y: { type: "linear" } };
+const bandX = { x: { type: "band" }, y: { type: "linear" } };
+const bandBoth = { x: { type: "band" }, y: { type: "band" } };
+
+describe("zoomSupportsChannel", () => {
+  it("is true when any requested channel is continuous", () => {
+    expect(zoomSupportsChannel("xy", continuous)).toBe(true);
+    expect(zoomSupportsChannel("xy", bandX)).toBe(true); // y continuous
+    expect(zoomSupportsChannel("x", bandX)).toBe(false);
+    expect(zoomSupportsChannel("y", bandX)).toBe(true);
+    expect(zoomSupportsChannel("xy", bandBoth)).toBe(false);
+  });
+});
+
+describe("bandChannelsForZoom", () => {
+  it("lists only band channels required by mode", () => {
+    expect(bandChannelsForZoom("xy", bandX)).toEqual(["x"]);
+    expect(bandChannelsForZoom("y", bandX)).toEqual([]);
+    expect(bandChannelsForZoom("xy", bandBoth)).toEqual(["x", "y"]);
+    expect(bandChannelsForZoom("x", bandBoth)).toEqual(["x"]);
+  });
+});
+
+describe("zoomScaleDiagnosticsFromChannels", () => {
+  it("maps channels to catalog diagnostics with prop/actual", () => {
+    const entry = {
+      code: "INTERACTION_INTERVAL_SCALE_UNSUPPORTED" as const,
+      message: "Band scales cannot zoom",
+      severity: "warning" as const,
+    };
+    expect(zoomScaleDiagnosticsFromChannels(["x", "y"], entry)).toEqual([
+      {
+        ...entry,
+        prop: "scales.x",
+        actual: "band",
+      },
+      {
+        ...entry,
+        prop: "scales.y",
+        actual: "band",
+      },
+    ]);
+  });
+});
+
+describe("capabilityStatusText", () => {
+  const diag = {
+    code: "INTERACTION_INTERVAL_SCALE_UNSUPPORTED" as const,
+    message: "Band scales cannot zoom",
+    severity: "warning" as const,
+    prop: "scales.x",
+    actual: "band",
+  };
+
+  it("prefers facet unavailability over zoom messages", () => {
+    expect(
+      capabilityStatusText({
+        facetUnavailableMessage: "facets unsupported",
+        areaDiagnostics: [diag],
+        zoomSupported: false,
+        interactive: true,
+        emptyPlot: false,
+        candidateCount: 0,
+      }),
+    ).toBe("Area interaction unavailable: facets unsupported");
+  });
+
+  it("reports zoom limited vs unavailable from zoomSupported", () => {
+    expect(
+      capabilityStatusText({
+        areaDiagnostics: [diag],
+        zoomSupported: true,
+        interactive: true,
+        emptyPlot: false,
+        candidateCount: 5,
+      }),
+    ).toBe("Zoom limited: Band scales cannot zoom");
+    expect(
+      capabilityStatusText({
+        areaDiagnostics: [diag],
+        zoomSupported: false,
+        interactive: true,
+        emptyPlot: false,
+        candidateCount: 5,
+      }),
+    ).toBe("Zoom unavailable: Band scales cannot zoom");
+  });
+
+  it("reports no inspectable marks only when model exists (candidateCount not null)", () => {
+    expect(
+      capabilityStatusText({
+        areaDiagnostics: [],
+        zoomSupported: true,
+        interactive: true,
+        emptyPlot: false,
+        candidateCount: 0,
+      }),
+    ).toBe("No inspectable marks");
+    expect(
+      capabilityStatusText({
+        areaDiagnostics: [],
+        zoomSupported: true,
+        interactive: true,
+        emptyPlot: false,
+        candidateCount: null,
+      }),
+    ).toBeNull();
+    expect(
+      capabilityStatusText({
+        areaDiagnostics: [],
+        zoomSupported: true,
+        interactive: true,
+        emptyPlot: true,
+        candidateCount: 0,
+      }),
+    ).toBeNull();
+    expect(
+      capabilityStatusText({
+        areaDiagnostics: [],
+        zoomSupported: true,
+        interactive: false,
+        emptyPlot: false,
+        candidateCount: 0,
+      }),
+    ).toBeNull();
+  });
+});

--- a/packages/svelte/tests/plot-interval.test.ts
+++ b/packages/svelte/tests/plot-interval.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  BRUSH_MIN_SPAN_PX,
+  buildIntervalSelection,
+  clearIntervalSelectionEvent,
+  filterDomainBySelectMode,
+  freezeIntervalDomain,
+  isBrushTooSmall,
+} from "../src/lib/plot-interval.js";
+
+describe("isBrushTooSmall (pointer brush-end gate)", () => {
+  it("defaults min span to 4", () => {
+    expect(BRUSH_MIN_SPAN_PX).toBe(4);
+  });
+
+  it("requires BOTH width and height strictly less than min (&&)", () => {
+    // 3×3 — both under min
+    expect(isBrushTooSmall({ x0: 0, y0: 0, x1: 3, y1: 3 })).toBe(true);
+    // one axis meets min → not too small
+    expect(isBrushTooSmall({ x0: 0, y0: 0, x1: 5, y1: 3 })).toBe(false);
+    expect(isBrushTooSmall({ x0: 0, y0: 0, x1: 3, y1: 5 })).toBe(false);
+    // exactly min on both is NOT < min
+    expect(isBrushTooSmall({ x0: 0, y0: 0, x1: 4, y1: 4 })).toBe(false);
+    expect(isBrushTooSmall({ x0: 0, y0: 0, x1: 0, y1: 0 })).toBe(true);
+  });
+
+  it("uses raw x1-x0/y1-y0 (callers must normalize first)", () => {
+    // Negative spans are also < min; production always normalizes before this gate.
+    expect(isBrushTooSmall({ x0: 10, y0: 10, x1: 0, y1: 0 })).toBe(true);
+    expect(isBrushTooSmall({ x0: 0, y0: 0, x1: 10, y1: 1 })).toBe(false);
+  });
+
+  it("honors an explicit minPx", () => {
+    expect(isBrushTooSmall({ x0: 0, y0: 0, x1: 8, y1: 8 }, 10)).toBe(true);
+    expect(isBrushTooSmall({ x0: 0, y0: 0, x1: 10, y1: 10 }, 10)).toBe(false);
+  });
+});
+
+describe("filterDomainBySelectMode", () => {
+  const domain = {
+    x: [0, 1] as [number, number],
+    y: [2, 3] as [number, number],
+  };
+
+  it("drops y for x-mode and x for y-mode", () => {
+    expect(filterDomainBySelectMode(domain, "x")).toEqual({ x: [0, 1] });
+    expect(filterDomainBySelectMode(domain, "y")).toEqual({ y: [2, 3] });
+  });
+
+  it("keeps both for xy-mode", () => {
+    expect(filterDomainBySelectMode(domain, "xy")).toEqual(domain);
+  });
+
+  it("omits missing axes", () => {
+    expect(filterDomainBySelectMode({ x: [0, 1] }, "xy")).toEqual({ x: [0, 1] });
+    expect(filterDomainBySelectMode({}, "x")).toEqual({});
+  });
+});
+
+describe("freezeIntervalDomain", () => {
+  it("freezes outer object and nested tuples", () => {
+    const frozen = freezeIntervalDomain({
+      x: [1, 2],
+      y: [3, 4],
+    });
+    expect(Object.isFrozen(frozen)).toBe(true);
+    expect(Object.isFrozen(frozen.x)).toBe(true);
+    expect(Object.isFrozen(frozen.y)).toBe(true);
+    expect(frozen).toEqual({ x: [1, 2], y: [3, 4] });
+  });
+
+  it("returns frozen empty object when no axes", () => {
+    const frozen = freezeIntervalDomain({});
+    expect(Object.isFrozen(frozen)).toBe(true);
+    expect(frozen).toEqual({});
+  });
+});
+
+describe("buildIntervalSelection", () => {
+  it("returns a deeply frozen IntervalSelection payload", () => {
+    const event = buildIntervalSelection({
+      phase: "end",
+      mode: "xy",
+      panelId: "p0",
+      domain: { x: [0, 10], y: [1, 2] },
+      pixels: { x0: 1, y0: 2, x1: 3, y1: 4 },
+      keys: ["a", "b"],
+      lineageCount: 2,
+      source: "pointer",
+    });
+    expect(event.type).toBe("select");
+    expect(event.phase).toBe("end");
+    expect(event.mode).toBe("xy");
+    expect(event.panelId).toBe("p0");
+    expect(event.lineageCount).toBe(2);
+    expect(event.source).toBe("pointer");
+    expect(event.keys).toEqual(["a", "b"]);
+    expect(event.pixels).toEqual({ x0: 1, y0: 2, x1: 3, y1: 4 });
+    expect(event.domain).toEqual({ x: [0, 10], y: [1, 2] });
+    expect(Object.isFrozen(event)).toBe(true);
+    expect(Object.isFrozen(event.keys)).toBe(true);
+    expect(Object.isFrozen(event.pixels)).toBe(true);
+    expect(Object.isFrozen(event.domain)).toBe(true);
+    expect(Object.isFrozen(event.domain.x)).toBe(true);
+    expect(Object.isFrozen(event.domain.y)).toBe(true);
+  });
+});
+
+describe("clearIntervalSelectionEvent", () => {
+  it("preserves mode/panelId/pixels and clears domain/keys/lineage", () => {
+    const previous = buildIntervalSelection({
+      phase: "end",
+      mode: "x",
+      panelId: "panel-1",
+      domain: { x: [0, 1] },
+      pixels: { x0: 5, y0: 6, x1: 15, y1: 16 },
+      keys: ["k"],
+      lineageCount: 3,
+      source: "pointer",
+    });
+    const cleared = clearIntervalSelectionEvent(previous, "keyboard");
+    expect(cleared).toEqual({
+      type: "select",
+      phase: "clear",
+      mode: "x",
+      panelId: "panel-1",
+      domain: {},
+      pixels: { x0: 5, y0: 6, x1: 15, y1: 16 },
+      keys: [],
+      lineageCount: 0,
+      source: "keyboard",
+    });
+    expect(Object.isFrozen(cleared)).toBe(true);
+    expect(Object.isFrozen(cleared.domain)).toBe(true);
+    expect(Object.isFrozen(cleared.keys)).toBe(true);
+    expect(Object.isFrozen(cleared.pixels)).toBe(true);
+    // pixels is a copy, not the same reference
+    expect(cleared.pixels).not.toBe(previous.pixels);
+  });
+});

--- a/packages/svelte/tests/plot-pointer.test.ts
+++ b/packages/svelte/tests/plot-pointer.test.ts
@@ -7,6 +7,7 @@ import {
   bestDirectionalIndex,
   cycleCoincidentIndex,
   hitFromCandidate,
+  matchCandidateFromHit,
   nextTraversalIndex,
   plotPointFromClient,
 } from "../src/lib/plot-pointer.js";
@@ -170,5 +171,54 @@ describe("cycleCoincidentIndex", () => {
   it("starts at first coincident when active index is not in the set", () => {
     // activeIndex 1 is not coincident → Math.max(0, -1) = 0 → next from first
     expect(cycleCoincidentIndex(origin, hits, 1, 1)).toBe(2);
+  });
+});
+
+describe("matchCandidateFromHit", () => {
+  const base = {
+    id: 0,
+    layerIndex: 0,
+    panelIndex: 0,
+    rowIndex: 1 as number | null,
+    x: 10,
+    y: 20,
+    kind: "point" as const,
+    autoMode: "exact" as const,
+    lineage: 0,
+  };
+
+  const asCandidate = (partial: Partial<typeof base> & { id: number }): CandidateFacts =>
+    ({
+      ...base,
+      ...partial,
+    }) as CandidateFacts;
+
+  it("matches on layer/panel/row/kind within exclusive 0.5 tolerance", () => {
+    const candidates = [
+      asCandidate({ id: 0, x: 10.49, y: 20.49 }),
+      asCandidate({ id: 1, x: 10, y: 20, rowIndex: 2 }),
+    ];
+    const matched = matchCandidateFromHit(candidates, hit(10, 20, { rowIndex: 1 }));
+    expect(matched?.id).toBe(0);
+  });
+
+  it("rejects |Δ| === 0.5 (exclusive bound)", () => {
+    const candidates = [asCandidate({ id: 0, x: 10.5, y: 20 })];
+    expect(matchCandidateFromHit(candidates, hit(10, 20, { rowIndex: 1 }))).toBeNull();
+  });
+
+  it("returns the first match in iteration order", () => {
+    const candidates = [
+      asCandidate({ id: 0, x: 10, y: 20 }),
+      asCandidate({ id: 1, x: 10, y: 20 }),
+    ];
+    expect(matchCandidateFromHit(candidates, hit(10, 20, { rowIndex: 1 }))?.id).toBe(0);
+  });
+
+  it("requires kind and row identity", () => {
+    const candidates = [asCandidate({ id: 0, kind: "line" as never })];
+    expect(
+      matchCandidateFromHit(candidates, hit(10, 20, { rowIndex: 1, kind: "point" })),
+    ).toBeNull();
   });
 });

--- a/packages/svelte/tests/plot-pointer.test.ts
+++ b/packages/svelte/tests/plot-pointer.test.ts
@@ -5,6 +5,7 @@ import type { SceneHit } from "@ggsvelte/core/dom";
 
 import {
   bestDirectionalIndex,
+  CANDIDATE_HIT_TOLERANCE,
   cycleCoincidentIndex,
   hitFromCandidate,
   matchCandidateFromHit,
@@ -202,8 +203,9 @@ describe("matchCandidateFromHit", () => {
     expect(matched?.id).toBe(0);
   });
 
-  it("rejects |Δ| === 0.5 (exclusive bound)", () => {
-    const candidates = [asCandidate({ id: 0, x: 10.5, y: 20 })];
+  it("rejects |Δ| === CANDIDATE_HIT_TOLERANCE (exclusive bound)", () => {
+    expect(CANDIDATE_HIT_TOLERANCE).toBe(0.5);
+    const candidates = [asCandidate({ id: 0, x: 10 + CANDIDATE_HIT_TOLERANCE, y: 20 })];
     expect(matchCandidateFromHit(candidates, hit(10, 20, { rowIndex: 1 }))).toBeNull();
   });
 

--- a/packages/svelte/tests/plot-pointer.test.ts
+++ b/packages/svelte/tests/plot-pointer.test.ts
@@ -208,10 +208,7 @@ describe("matchCandidateFromHit", () => {
   });
 
   it("returns the first match in iteration order", () => {
-    const candidates = [
-      asCandidate({ id: 0, x: 10, y: 20 }),
-      asCandidate({ id: 1, x: 10, y: 20 }),
-    ];
+    const candidates = [asCandidate({ id: 0, x: 10, y: 20 }), asCandidate({ id: 1, x: 10, y: 20 })];
     expect(matchCandidateFromHit(candidates, hit(10, 20, { rowIndex: 1 }))?.id).toBe(0);
   });
 

--- a/packages/svelte/tests/plot-selection.test.ts
+++ b/packages/svelte/tests/plot-selection.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { anchorsFromCandidateKeys, nextPointSelectionKeys } from "../src/lib/plot-selection.js";
+import {
+  anchorsFromCandidateKeys,
+  nextPointSelectionKeys,
+  rowIndexesForCandidate,
+  uniqueKeysFromRowIndexes,
+} from "../src/lib/plot-selection.js";
 
 describe("nextPointSelectionKeys", () => {
   it("no-ops on empty toggle input", () => {
@@ -54,5 +59,30 @@ describe("anchorsFromCandidateKeys", () => {
       { x: 1, y: 2, keys: ["a"] },
     ];
     expect(anchorsFromCandidateKeys(dupes, ["a"])).toEqual([{ x: 1, y: 2 }]);
+  });
+});
+
+describe("rowIndexesForCandidate", () => {
+  it("preserves lineage order and appends rowIndex only if absent", () => {
+    expect(rowIndexesForCandidate({ rowIndex: 9 }, [3, 1, 4])).toEqual([3, 1, 4, 9]);
+    expect(rowIndexesForCandidate({ rowIndex: 1 }, [3, 1, 4])).toEqual([3, 1, 4]);
+    expect(rowIndexesForCandidate({ rowIndex: null }, [3, 1])).toEqual([3, 1]);
+  });
+});
+
+describe("uniqueKeysFromRowIndexes", () => {
+  it("keeps first-seen non-null keys and skips nulls", () => {
+    const keyForRow = (rowIndex: number): PropertyKey | null => {
+      if (rowIndex === 1) return "a";
+      if (rowIndex === 2) return null;
+      if (rowIndex === 3) return "b";
+      if (rowIndex === 4) return "a";
+      return "c";
+    };
+    expect(uniqueKeysFromRowIndexes([1, 2, 3, 4, 5], keyForRow)).toEqual(["a", "b", "c"]);
+  });
+
+  it("returns empty for empty input", () => {
+    expect(uniqueKeysFromRowIndexes([], () => "x")).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

- Extract pure, testable helpers from `GGPlot.svelte` so interval selection and zoom capability logic is no longer host-only:
  - `plot-interval.ts` — pointer brush-end gate (`&&` both spans), domain mode filter, frozen interval selection build/clear
  - `plot-capability.ts` — zoom band-channel support, zoom scale diagnostics, capability status copy (with null-model guard)
  - `plot-pointer.ts` — `matchCandidateFromHit` (exclusive 0.5 px tolerance, first match wins)
  - `plot-selection.ts` — `rowIndexesForCandidate` / `uniqueKeysFromRowIndexes`
- Wire `GGPlot` through the helpers with no public API change (`resetScales` / `setZoom` / props / event shapes).
- Characterization unit tests for load-bearing contracts (brush gate, freeze depth, capability ordering, candidate match bounds).

Keyboard intent extraction and capture-surface host extraction are intentionally deferred.

## Test plan

- [x] `bun run check` (svelte-check) — 0 errors
- [x] Unit: plot-interval / plot-capability / plot-pointer / plot-selection
- [x] interaction-unit + interaction-controller
- [x] interaction + interaction-regressions (chromium/firefox/webkit)
- [x] `bun run lint`
- [ ] CI green on this PR