### PR TITLE
refactor(svelte): extract plot assemble and semantic key helpers

### DIFF
--- a/packages/svelte/src/lib/GGPlot.svelte
+++ b/packages/svelte/src/lib/GGPlot.svelte
@@ -49,7 +49,6 @@
     ThemeName,
     ThemeSpec,
   } from "@ggsvelte/spec";
-  import { gg, normalize } from "@ggsvelte/spec";
   import type {
     CandidateFacts,
     CellValue,
@@ -87,10 +86,14 @@
   import type { PlotInteractionController } from "./interaction-controller.svelte.js";
   import { createInspectionCoordinator } from "./inspection-resolver.js";
   import { createInteractionReducer } from "./interaction-reducer.js";
-  import type { LayerDescriptor } from "./registry.svelte.js";
   import { provideRegistry } from "./registry.svelte.js";
   import { a11yRows } from "./canvas-a11y.js";
   import InteractionOverlay from "./InteractionOverlay.svelte";
+  import {
+    assemblePortableSpec,
+    resolveInteractionScope,
+    toLayerInput,
+  } from "./plot-assemble.js";
   import {
     clamp,
     expandIntervalQuery,
@@ -129,6 +132,10 @@
     rowIndexesForCandidate,
     uniqueKeysFromRowIndexes,
   } from "./plot-selection.js";
+  import {
+    createSourceIdentityTracker,
+    resolveSemanticKeys,
+  } from "./plot-semantic-keys.js";
   import { themeTokensToCss } from "./plot-theme-css.js";
   import {
     applyZoomToSpec,
@@ -234,86 +241,33 @@
 
   const registry = provideRegistry();
 
-  function toLayerInput(descriptor: LayerDescriptor): LayerInput {
-    // Reading .aes/.position/.params here goes through the child's live
-    // getters, so geom prop changes flow into this $derived without
-    // re-registration.
-    return {
-      geom: descriptor.geom,
-      ...(descriptor.stat !== undefined && { stat: descriptor.stat }),
-      ...(descriptor.position !== undefined && {
-        position: descriptor.position,
-      }),
-      ...(descriptor.positionParams !== undefined && {
-        positionParams: descriptor.positionParams,
-      }),
-      ...(descriptor.render !== undefined && { render: descriptor.render }),
-      ...(descriptor.aes !== undefined && { aes: descriptor.aes }),
-      ...(descriptor.params !== undefined && { params: descriptor.params }),
-    } as LayerInput;
-  }
+  // Reading descriptors through toLayerInput goes through live getters, so
+  // geom prop changes flow into this $derived without re-registration.
+  const assembled: PortableSpec | null = $derived.by(() =>
+    assemblePortableSpec({
+      ...(spec !== undefined && { spec }),
+      ...(data !== undefined && { data: data as DataInput | readonly Row[] }),
+      ...(mapping !== undefined && { aes: mapping }),
+      layers: layers ?? registry.layers.map(toLayerInput),
+      ...(facet !== undefined && { facet }),
+      ...(coord !== undefined && { coord }),
+      ...(scales !== undefined && { scales }),
+      ...(legend !== undefined && { legend }),
+      ...(theme !== undefined && { theme }),
+      ...(labs !== undefined && { labs }),
+      ...(a11y !== undefined && { a11y }),
+    }),
+  );
 
-  const assembled: PortableSpec | null = $derived.by(() => {
-    if (spec !== undefined) return normalize(spec);
-    const layerInputs: LayerInput[] =
-      layers ?? registry.layers.map(toLayerInput);
-    if (layerInputs.length === 0) return null;
-    let builder = gg(data as DataInput, mapping);
-    for (const layer of layerInputs) builder = builder.layer(layer);
-    if (facet !== undefined) builder = builder.facet(facet);
-    if (coord !== undefined) builder = builder.coord(coord);
-    if (a11y !== undefined) builder = builder.a11y(a11y);
-    if (scales !== undefined) builder = builder.scales(scales);
-    if (legend !== undefined) builder = builder.legend(legend);
-    if (theme !== undefined) builder = builder.theme(theme);
-    if (labs !== undefined) builder = builder.labs(labs);
-    return builder.spec();
-  });
-
-  function mappedScope(channel: "x" | "y"): string {
-    const channelValue =
-      assembled?.aes?.[channel] ??
-      assembled?.layers.find(
-        (layer) =>
-          layer.aes?.[channel] !== undefined && layer.aes[channel] !== null,
-      )?.aes?.[channel];
-    return channelValue !== undefined &&
-      channelValue !== null &&
-      "field" in channelValue
-      ? channelValue.field
-      : channel;
-  }
-
-  const resolvedInteractionScope: PlotInteractionScope = $derived.by(() => {
-    if (interaction !== undefined) {
-      if (interactionScope === undefined)
-        throw new TypeError(
-          "GGPlot requires interactionScope when interaction is supplied so unrelated charts cannot share semantic keys or domains accidentally.",
-        );
-      const zoomMode =
-        zoom === true ? "xy" : typeof zoom === "object" ? zoom.mode : null;
-      if (zoomMode !== null) {
-        if (zoomMode !== "y" && interactionScope.x === undefined)
-          throw new TypeError(
-            "Controlled x zoom requires interactionScope.x; controlled plots never infer domain scopes.",
-          );
-        if (zoomMode !== "x" && interactionScope.y === undefined)
-          throw new TypeError(
-            "Controlled y zoom requires interactionScope.y; controlled plots never infer domain scopes.",
-          );
-      }
-      return Object.freeze({
-        keys: interactionScope.keys,
-        ...(interactionScope.x !== undefined && { x: interactionScope.x }),
-        ...(interactionScope.y !== undefined && { y: interactionScope.y }),
-      });
-    }
-    return Object.freeze({
-      keys: typeof datumKey === "string" ? String(datumKey) : "default",
-      x: mappedScope("x"),
-      y: mappedScope("y"),
-    });
-  });
+  const resolvedInteractionScope: PlotInteractionScope = $derived(
+    resolveInteractionScope({
+      interaction,
+      ...(interactionScope !== undefined && { interactionScope }),
+      zoom,
+      ...(datumKey !== undefined && { datumKey }),
+      assembled,
+    }),
+  );
 
   const interactionConfig = $derived(
     normalizeInteractionConfig(
@@ -358,21 +312,8 @@
 
   // Source identity/order epoch: stable through responsive layout and zoom
   // respecs, different when normalized inline data or data references change.
-  const sourceIdentities = new WeakMap<object, number>();
-  let nextSourceIdentity = 1;
-  function sourceIdentity(value: unknown): string {
-    if (
-      (typeof value !== "object" && typeof value !== "function") ||
-      value === null
-    )
-      return String(value);
-    let identity = sourceIdentities.get(value);
-    if (identity === undefined) {
-      identity = nextSourceIdentity++;
-      sourceIdentities.set(value, identity);
-    }
-    return String(identity);
-  }
+  // Tracker is owned for the component lifetime (never cleared).
+  const { sourceIdentity } = createSourceIdentityTracker();
   const dataIdentityEpoch = $derived(
     assembled === null
       ? "no-data"
@@ -782,92 +723,29 @@
     });
   }
   const plotId = $props.id();
+  // Owned for the component lifetime; resolveSemanticKeys mutates in place.
   const priorKeys = new Map<string, PropertyKey>();
 
   const semanticKeys = $derived.by(() => {
-    const keys = new Map<number, PropertyKey | null>();
-    const diagnostics: InteractionDiagnostic[] = [];
-    if (model === null || datumKey === undefined) return { keys, diagnostics };
-    const owners = new Map<PropertyKey, number>();
-    const sourceRows = new Set<number>();
-    if (
-      model.candidates.size === 0 &&
-      assembled?.layers.some(
-        (layer) =>
-          layer.geom === "rule" &&
-          (layer.params?.["xintercept"] !== undefined ||
-            layer.params?.["yintercept"] !== undefined),
-      )
-    )
-      diagnostics.push({
-        ...INTERACTION_DIAGNOSTIC_CATALOG.INTERACTION_MISSING_LINEAGE,
-        actual: "synthetic rule has no source rows",
-      });
-    for (let id = 0; id < model.candidates.size; id++) {
-      const candidate = model.candidates.candidate(id);
-      if (candidate === null) continue;
-      if (candidate.rowIndex !== null) sourceRows.add(candidate.rowIndex);
-      const lineageRows = [...model.lineage.keys(candidate.lineage)];
-      if (candidate.rowIndex === null && lineageRows.length === 0)
-        diagnostics.push({
-          ...INTERACTION_DIAGNOSTIC_CATALOG.INTERACTION_MISSING_LINEAGE,
-          actual: {
-            layerIndex: candidate.layerIndex,
-            candidateId: candidate.id,
-          },
-        });
-      for (const rowIndex of lineageRows) sourceRows.add(rowIndex);
-    }
-    for (const rowIndex of sourceRows) {
-      const row = model.row(rowIndex);
-      const value =
-        row === null
-          ? null
-          : typeof datumKey === "function"
-            ? (datumKey as (row: Row, index: number) => PropertyKey)(
-                row as Row,
-                rowIndex,
-              )
-            : row[datumKey as string];
-      if (
-        typeof value !== "string" &&
-        typeof value !== "number" &&
-        typeof value !== "symbol"
-      ) {
-        keys.set(rowIndex, null);
-        diagnostics.push({
-          ...INTERACTION_DIAGNOSTIC_CATALOG.INTERACTION_INVALID_KEY,
-          actual: value,
-        });
-        continue;
-      }
-      if (row !== null) {
-        const rowIdentity = `${sourceIdentity(data)}:${sourceIdentity(spec)}:${rowIndex}`;
-        const priorKey = priorKeys.get(rowIdentity);
-        if (priorKey !== undefined && priorKey !== value) {
-          keys.set(rowIndex, null);
-          diagnostics.push({
-            ...INTERACTION_DIAGNOSTIC_CATALOG.INTERACTION_UNSTABLE_KEY,
-            actual: { previous: priorKey, current: value },
-          });
-          continue;
-        }
-        priorKeys.set(rowIdentity, value);
-      }
-      const prior = owners.get(value);
-      if (prior !== undefined && prior !== rowIndex) {
-        keys.set(prior, null);
-        keys.set(rowIndex, null);
-        diagnostics.push({
-          ...INTERACTION_DIAGNOSTIC_CATALOG.INTERACTION_DUPLICATE_KEY,
-          actual: value,
-        });
-      } else {
-        owners.set(value, rowIndex);
-        keys.set(rowIndex, value);
-      }
-    }
-    return { keys, diagnostics };
+    if (model === null)
+      return {
+        keys: new Map<number, PropertyKey | null>(),
+        diagnostics: [] as InteractionDiagnostic[],
+      };
+    return resolveSemanticKeys({
+      model: {
+        candidateCount: model.candidates.size,
+        candidate: (id) => model.candidates.candidate(id),
+        lineageKeys: (lineageId) => model.lineage.keys(lineageId),
+        row: (rowIndex) => model.row(rowIndex),
+        layers: assembled?.layers ?? [],
+      },
+      datumKey: datumKey as
+        string | ((row: never, index: number) => PropertyKey) | undefined,
+      priorKeys,
+      rowIdentity: (rowIndex) =>
+        `${sourceIdentity(data)}:${sourceIdentity(spec)}:${rowIndex}`,
+    });
   });
 
   $effect(() => {

--- a/packages/svelte/src/lib/GGPlot.svelte
+++ b/packages/svelte/src/lib/GGPlot.svelte
@@ -243,9 +243,11 @@
 
   // Reading descriptors through toLayerInput goes through live getters, so
   // geom prop changes flow into this $derived without re-registration.
-  const assembled: PortableSpec | null = $derived.by(() =>
-    assemblePortableSpec({
-      ...(spec !== undefined && { spec }),
+  // Explicit `spec` short-circuits before registry/children so ignored props
+  // do not become reactive dependencies of the assembled plot.
+  const assembled: PortableSpec | null = $derived.by(() => {
+    if (spec !== undefined) return assemblePortableSpec({ spec, layers: [] });
+    return assemblePortableSpec({
       ...(data !== undefined && { data: data as DataInput | readonly Row[] }),
       ...(mapping !== undefined && { aes: mapping }),
       layers: layers ?? registry.layers.map(toLayerInput),
@@ -256,8 +258,8 @@
       ...(theme !== undefined && { theme }),
       ...(labs !== undefined && { labs }),
       ...(a11y !== undefined && { a11y }),
-    }),
-  );
+    });
+  });
 
   const resolvedInteractionScope: PlotInteractionScope = $derived(
     resolveInteractionScope({

--- a/packages/svelte/src/lib/plot-assemble.ts
+++ b/packages/svelte/src/lib/plot-assemble.ts
@@ -1,0 +1,151 @@
+import type {
+  A11yMode,
+  AesInput,
+  CoordSpec,
+  DataInput,
+  FacetInput,
+  GeomName,
+  Labs,
+  LayerInput,
+  LegendSpec,
+  PortableSpec,
+  PositionName,
+  PositionParams,
+  RenderBackend,
+  Scales,
+  SpecInput,
+  StatName,
+  ThemeName,
+  ThemeSpec,
+} from "@ggsvelte/spec";
+import { gg, normalize } from "@ggsvelte/spec";
+
+import type { PlotInteractionScope, ZoomInput } from "./interaction.js";
+
+/**
+ * Structural registry descriptor (live getters allowed). Kept local so this
+ * module does not import `registry.svelte.ts`.
+ */
+export type LayerDescriptorLike = {
+  readonly geom: GeomName;
+  readonly stat?: StatName | undefined;
+  readonly aes?: AesInput | undefined;
+  readonly position?: PositionName | undefined;
+  readonly positionParams?: PositionParams | undefined;
+  readonly render?: RenderBackend | undefined;
+  readonly params?: Record<string, unknown> | undefined;
+};
+
+/** Convert a registry descriptor into a LayerInput (reads live getters). */
+export function toLayerInput(descriptor: LayerDescriptorLike): LayerInput {
+  return {
+    geom: descriptor.geom,
+    ...(descriptor.stat !== undefined && { stat: descriptor.stat }),
+    ...(descriptor.position !== undefined && {
+      position: descriptor.position,
+    }),
+    ...(descriptor.positionParams !== undefined && {
+      positionParams: descriptor.positionParams,
+    }),
+    ...(descriptor.render !== undefined && { render: descriptor.render }),
+    ...(descriptor.aes !== undefined && { aes: descriptor.aes }),
+    ...(descriptor.params !== undefined && { params: descriptor.params }),
+  } as LayerInput;
+}
+
+export type AssemblePortableSpecInput = {
+  readonly spec?: SpecInput;
+  readonly data?: DataInput | readonly Record<string, unknown>[];
+  readonly aes?: AesInput;
+  /** Already-resolved layers (caller maps registry descriptors if needed). */
+  readonly layers: LayerInput[];
+  readonly facet?: FacetInput;
+  readonly coord?: CoordSpec | "flip";
+  readonly scales?: Scales;
+  readonly legend?: LegendSpec;
+  readonly theme?: ThemeName | ThemeSpec;
+  readonly labs?: Labs;
+  readonly a11y?: A11yMode;
+};
+
+/**
+ * Build the normalized PortableSpec for GGPlot.
+ * Explicit `spec` wins; empty `layers` yields null (no plot).
+ */
+export function assemblePortableSpec(input: AssemblePortableSpecInput): PortableSpec | null {
+  if (input.spec !== undefined) return normalize(input.spec);
+  if (input.layers.length === 0) return null;
+  let builder = gg(input.data as DataInput, input.aes);
+  for (const layer of input.layers) builder = builder.layer(layer);
+  if (input.facet !== undefined) builder = builder.facet(input.facet);
+  if (input.coord !== undefined) builder = builder.coord(input.coord);
+  if (input.a11y !== undefined) builder = builder.a11y(input.a11y);
+  if (input.scales !== undefined) builder = builder.scales(input.scales);
+  if (input.legend !== undefined) builder = builder.legend(input.legend);
+  if (input.theme !== undefined) builder = builder.theme(input.theme);
+  if (input.labs !== undefined) builder = builder.labs(input.labs);
+  return builder.spec();
+}
+
+/**
+ * Field name for a positional channel from plot/layer aes, else the channel
+ * itself (constants / missing mappings).
+ */
+export function mappedChannelField(assembled: PortableSpec | null, channel: "x" | "y"): string {
+  const channelValue =
+    assembled?.aes?.[channel] ??
+    assembled?.layers.find(
+      (layer) => layer.aes?.[channel] !== undefined && layer.aes[channel] !== null,
+    )?.aes?.[channel];
+  return channelValue !== undefined && channelValue !== null && "field" in channelValue
+    ? channelValue.field
+    : channel;
+}
+
+export type ResolveInteractionScopeInput = {
+  /** Presence-only: any defined controller forces controlled scope rules. */
+  readonly interaction: object | null | undefined;
+  readonly interactionScope?: PlotInteractionScope;
+  readonly zoom?: ZoomInput;
+  readonly datumKey?: string | number | symbol | ((...args: never[]) => PropertyKey);
+  readonly assembled: PortableSpec | null;
+};
+
+/**
+ * Resolve the semantic interaction scope for a plot instance.
+ * Controlled plots never infer domain scopes; uncontrolled plots do.
+ */
+export function resolveInteractionScope(input: ResolveInteractionScopeInput): PlotInteractionScope {
+  if (input.interaction !== undefined) {
+    if (input.interactionScope === undefined)
+      throw new TypeError(
+        "GGPlot requires interactionScope when interaction is supplied so unrelated charts cannot share semantic keys or domains accidentally.",
+      );
+    const zoomMode =
+      input.zoom === true ? "xy" : typeof input.zoom === "object" ? input.zoom.mode : null;
+    if (zoomMode !== null) {
+      if (zoomMode !== "y" && input.interactionScope.x === undefined)
+        throw new TypeError(
+          "Controlled x zoom requires interactionScope.x; controlled plots never infer domain scopes.",
+        );
+      if (zoomMode !== "x" && input.interactionScope.y === undefined)
+        throw new TypeError(
+          "Controlled y zoom requires interactionScope.y; controlled plots never infer domain scopes.",
+        );
+    }
+    return Object.freeze({
+      keys: input.interactionScope.keys,
+      ...(input.interactionScope.x !== undefined && {
+        x: input.interactionScope.x,
+      }),
+      ...(input.interactionScope.y !== undefined && {
+        y: input.interactionScope.y,
+      }),
+    });
+  }
+  return Object.freeze({
+    keys: typeof input.datumKey === "string" ? input.datumKey : "default",
+    x: mappedChannelField(input.assembled, "x"),
+    y: mappedChannelField(input.assembled, "y"),
+  });
+}

--- a/packages/svelte/src/lib/plot-semantic-keys.ts
+++ b/packages/svelte/src/lib/plot-semantic-keys.ts
@@ -1,0 +1,162 @@
+import type { CellValue } from "@ggsvelte/core";
+
+import { INTERACTION_DIAGNOSTIC_CATALOG, type InteractionDiagnostic } from "./interaction.js";
+
+/**
+ * Source-identity tracker owned by one GGPlot instance for the component
+ * lifetime. Do not clear: clearing would silently reset dataIdentityEpoch and
+ * break unstable-key detection across respecs.
+ */
+export type SourceIdentityTracker = {
+  sourceIdentity(value: unknown): string;
+};
+
+export function createSourceIdentityTracker(): SourceIdentityTracker {
+  const sourceIdentities = new WeakMap<object, number>();
+  let nextSourceIdentity = 1;
+  return {
+    sourceIdentity(value: unknown): string {
+      if ((typeof value !== "object" && typeof value !== "function") || value === null)
+        return String(value);
+      let identity = sourceIdentities.get(value);
+      if (identity === undefined) {
+        identity = nextSourceIdentity++;
+        sourceIdentities.set(value, identity);
+      }
+      return String(identity);
+    },
+  };
+}
+
+export type SemanticKeyCandidate = {
+  readonly id: number;
+  readonly rowIndex: number | null;
+  readonly layerIndex: number;
+  readonly lineage: number;
+};
+
+type SemanticKeyLayer = {
+  readonly geom: string;
+  readonly params?: Record<string, unknown> | undefined;
+};
+
+/** Narrow model surface needed for key resolution (no RenderModel import). */
+export type SemanticKeyModelView = {
+  readonly candidateCount: number;
+  candidate(id: number): SemanticKeyCandidate | null;
+  lineageKeys(lineageId: number): Iterable<number>;
+  row(rowIndex: number): Record<string, CellValue> | null;
+  readonly layers: readonly SemanticKeyLayer[];
+};
+
+export type ResolveSemanticKeysInput = {
+  readonly model: SemanticKeyModelView;
+  readonly datumKey:
+    | string
+    | number
+    | symbol
+    | ((row: never, index: number) => PropertyKey)
+    | undefined;
+  /**
+   * Mutable per-component map of rowIdentity → last key. Caller owns lifetime;
+   * this function mutates it in place (same as GGPlot historically).
+   */
+  readonly priorKeys: Map<string, PropertyKey>;
+  /** Stable identity for a source row within the current data/spec epoch. */
+  readonly rowIdentity: (rowIndex: number) => string;
+};
+
+export type ResolveSemanticKeysResult = {
+  readonly keys: Map<number, PropertyKey | null>;
+  readonly diagnostics: InteractionDiagnostic[];
+};
+
+/**
+ * Resolve durable semantic keys for interaction, emitting diagnostics in
+ * encounter order: synthetic-rule missing lineage, per-candidate missing
+ * lineage, then per-row invalid / unstable / duplicate key diagnostics.
+ */
+export function resolveSemanticKeys(input: ResolveSemanticKeysInput): ResolveSemanticKeysResult {
+  const keys = new Map<number, PropertyKey | null>();
+  const diagnostics: InteractionDiagnostic[] = [];
+  const { model, datumKey, priorKeys, rowIdentity } = input;
+  if (datumKey === undefined) return { keys, diagnostics };
+
+  const owners = new Map<PropertyKey, number>();
+  const sourceRows = new Set<number>();
+  if (
+    model.candidateCount === 0 &&
+    model.layers.some(
+      (layer) =>
+        layer.geom === "rule" &&
+        (layer.params?.["xintercept"] !== undefined || layer.params?.["yintercept"] !== undefined),
+    )
+  )
+    diagnostics.push({
+      ...INTERACTION_DIAGNOSTIC_CATALOG.INTERACTION_MISSING_LINEAGE,
+      actual: "synthetic rule has no source rows",
+    });
+
+  for (let id = 0; id < model.candidateCount; id++) {
+    const candidate = model.candidate(id);
+    if (candidate === null) continue;
+    if (candidate.rowIndex !== null) sourceRows.add(candidate.rowIndex);
+    const lineageRows = [...model.lineageKeys(candidate.lineage)];
+    if (candidate.rowIndex === null && lineageRows.length === 0)
+      diagnostics.push({
+        ...INTERACTION_DIAGNOSTIC_CATALOG.INTERACTION_MISSING_LINEAGE,
+        actual: {
+          layerIndex: candidate.layerIndex,
+          candidateId: candidate.id,
+        },
+      });
+    for (const rowIndex of lineageRows) sourceRows.add(rowIndex);
+  }
+
+  for (const rowIndex of sourceRows) {
+    const row = model.row(rowIndex);
+    const value =
+      row === null
+        ? null
+        : typeof datumKey === "function"
+          ? (datumKey as (row: Record<string, CellValue>, index: number) => PropertyKey)(
+              row,
+              rowIndex,
+            )
+          : row[datumKey as string];
+    if (typeof value !== "string" && typeof value !== "number" && typeof value !== "symbol") {
+      keys.set(rowIndex, null);
+      diagnostics.push({
+        ...INTERACTION_DIAGNOSTIC_CATALOG.INTERACTION_INVALID_KEY,
+        actual: value,
+      });
+      continue;
+    }
+    if (row !== null) {
+      const identity = rowIdentity(rowIndex);
+      const priorKey = priorKeys.get(identity);
+      if (priorKey !== undefined && priorKey !== value) {
+        keys.set(rowIndex, null);
+        diagnostics.push({
+          ...INTERACTION_DIAGNOSTIC_CATALOG.INTERACTION_UNSTABLE_KEY,
+          actual: { previous: priorKey, current: value },
+        });
+        continue;
+      }
+      priorKeys.set(identity, value);
+    }
+    const prior = owners.get(value);
+    if (prior !== undefined && prior !== rowIndex) {
+      keys.set(prior, null);
+      keys.set(rowIndex, null);
+      diagnostics.push({
+        ...INTERACTION_DIAGNOSTIC_CATALOG.INTERACTION_DUPLICATE_KEY,
+        actual: value,
+      });
+    } else {
+      owners.set(value, rowIndex);
+      keys.set(rowIndex, value);
+    }
+  }
+  return { keys, diagnostics };
+}

--- a/packages/svelte/tests/plot-assemble.test.ts
+++ b/packages/svelte/tests/plot-assemble.test.ts
@@ -1,0 +1,273 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  assemblePortableSpec,
+  mappedChannelField,
+  resolveInteractionScope,
+  toLayerInput,
+} from "../src/lib/plot-assemble.js";
+
+describe("toLayerInput", () => {
+  it("copies geom and omits undefined optional fields", () => {
+    expect(toLayerInput({ geom: "point" })).toEqual({ geom: "point" });
+  });
+
+  it("reads live getters on every invocation (registry contract)", () => {
+    let geom: "point" | "line" = "point";
+    let aes: { x: string } | undefined = { x: "a" };
+    const descriptor = {
+      get geom() {
+        return geom;
+      },
+      get aes() {
+        return aes;
+      },
+    };
+    expect(toLayerInput(descriptor)).toEqual({ geom: "point", aes: { x: "a" } });
+    geom = "line";
+    aes = undefined;
+    expect(toLayerInput(descriptor)).toEqual({ geom: "line" });
+  });
+
+  it("forwards all optional descriptor fields when present", () => {
+    expect(
+      toLayerInput({
+        geom: "smooth",
+        stat: "smooth",
+        position: "identity",
+        positionParams: { width: 0.5 },
+        render: "canvas",
+        aes: { x: "x", y: "y" },
+        params: { method: "lm" },
+      }),
+    ).toEqual({
+      geom: "smooth",
+      stat: "smooth",
+      position: "identity",
+      positionParams: { width: 0.5 },
+      render: "canvas",
+      aes: { x: "x", y: "y" },
+      params: { method: "lm" },
+    });
+  });
+});
+
+describe("assemblePortableSpec", () => {
+  const rows = [
+    { x: 1, y: 2 },
+    { x: 3, y: 4 },
+  ];
+
+  it("returns normalize(spec) when an explicit spec is provided", () => {
+    const assembled = assemblePortableSpec({
+      spec: {
+        data: { values: rows },
+        layers: [{ geom: "point", aes: { x: "x", y: "y" } }],
+      },
+      layers: [],
+    });
+    expect(assembled).not.toBeNull();
+    expect(assembled!.layers).toHaveLength(1);
+    expect(assembled!.layers[0].geom).toBe("point");
+  });
+
+  it("returns null when there are no layers", () => {
+    expect(
+      assemblePortableSpec({
+        data: rows,
+        aes: { x: "x", y: "y" },
+        layers: [],
+      }),
+    ).toBeNull();
+  });
+
+  it("builds from data/aes/layers without a top-level spec", () => {
+    const assembled = assemblePortableSpec({
+      data: rows,
+      aes: { x: "x", y: "y" },
+      layers: [{ geom: "point" }],
+      theme: "light",
+      labs: { title: "T" },
+      a11y: "force-svg",
+      scales: { x: { type: "linear" } },
+      legend: { order: "stable-domain" },
+      facet: { wrap: "g" },
+      coord: "flip",
+    });
+    expect(assembled).not.toBeNull();
+    expect(assembled!.labs?.title).toBe("T");
+    expect(assembled!.a11y).toBe("force-svg");
+    expect(assembled!.coord?.type).toBe("flip");
+    expect(assembled!.facet).toBeDefined();
+    expect(assembled!.scales?.x).toBeDefined();
+    expect(assembled!.legend?.order).toBe("stable-domain");
+  });
+
+  it("lets empty layers array win over hypothetical registry content", () => {
+    // Caller converts registry → LayerInput[] before assemble; empty wins.
+    expect(
+      assemblePortableSpec({
+        data: rows,
+        aes: { x: "x", y: "y" },
+        layers: [],
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("mappedChannelField", () => {
+  it("prefers plot-level aes field when present on the portable spec", () => {
+    // normalize/builder usually merge plot aes into layers; the plot-level
+    // branch still wins when aes remains on the assembled object.
+    const assembled = {
+      aes: { x: { field: "a" }, y: { field: "b" } },
+      layers: [
+        {
+          geom: "point" as const,
+          aes: { x: { field: "c" }, y: { field: "b" } },
+        },
+      ],
+    };
+    expect(mappedChannelField(assembled as never, "x")).toBe("a");
+    expect(mappedChannelField(assembled as never, "y")).toBe("b");
+  });
+
+  it("falls through to the first layer with a non-null channel field", () => {
+    const assembled = assemblePortableSpec({
+      data: [{ a: 1, b: 2 }],
+      layers: [
+        { geom: "point", aes: { x: null } },
+        { geom: "point", aes: { x: "a", y: "b" } },
+      ],
+    })!;
+    expect(mappedChannelField(assembled, "x")).toBe("a");
+  });
+
+  it("returns the channel name when mapping is a constant value or absent", () => {
+    const assembled = assemblePortableSpec({
+      data: [{ x: 1, y: 2 }],
+      layers: [{ geom: "point", aes: { x: { value: 1 }, y: "y" } }],
+    })!;
+    expect(mappedChannelField(assembled, "x")).toBe("x");
+    expect(mappedChannelField(assembled, "y")).toBe("y");
+  });
+
+  it("returns the channel name when assembled is null", () => {
+    expect(mappedChannelField(null, "x")).toBe("x");
+    expect(mappedChannelField(null, "y")).toBe("y");
+  });
+});
+
+describe("resolveInteractionScope", () => {
+  const assembled = assemblePortableSpec({
+    data: [{ foo: 1, bar: 2 }],
+    aes: { x: "foo", y: "bar" },
+    layers: [{ geom: "point" }],
+  });
+
+  it("throws when interaction is set without interactionScope", () => {
+    expect(() =>
+      resolveInteractionScope({
+        interaction: {},
+        interactionScope: undefined,
+        zoom: false,
+        datumKey: "id",
+        assembled,
+      }),
+    ).toThrow(
+      /GGPlot requires interactionScope when interaction is supplied so unrelated charts cannot share semantic keys or domains accidentally/,
+    );
+  });
+
+  it("requires x scope for controlled x zoom (including xy and zoom:true)", () => {
+    expect(() =>
+      resolveInteractionScope({
+        interaction: {},
+        interactionScope: { keys: "id", y: "y" },
+        zoom: true,
+        assembled,
+      }),
+    ).toThrow(
+      /Controlled x zoom requires interactionScope\.x; controlled plots never infer domain scopes/,
+    );
+    expect(() =>
+      resolveInteractionScope({
+        interaction: {},
+        interactionScope: { keys: "id", y: "y" },
+        zoom: { mode: "x" },
+        assembled,
+      }),
+    ).toThrow(/Controlled x zoom requires interactionScope\.x/);
+    expect(() =>
+      resolveInteractionScope({
+        interaction: {},
+        interactionScope: { keys: "id", y: "y" },
+        zoom: { mode: "xy" },
+        assembled,
+      }),
+    ).toThrow(/Controlled x zoom requires interactionScope\.x/);
+  });
+
+  it("requires y scope for controlled y zoom", () => {
+    expect(() =>
+      resolveInteractionScope({
+        interaction: {},
+        interactionScope: { keys: "id", x: "x" },
+        zoom: { mode: "y" },
+        assembled,
+      }),
+    ).toThrow(
+      /Controlled y zoom requires interactionScope\.y; controlled plots never infer domain scopes/,
+    );
+  });
+
+  it("returns a shallow-frozen controlled scope without inferring missing channels when zoom is off", () => {
+    const scope = resolveInteractionScope({
+      interaction: {},
+      interactionScope: { keys: "id" },
+      zoom: false,
+      assembled,
+    });
+    expect(scope).toEqual({ keys: "id" });
+    expect(Object.isFrozen(scope)).toBe(true);
+  });
+
+  it("accepts empty-string x/y scopes as defined (does not throw)", () => {
+    const scope = resolveInteractionScope({
+      interaction: {},
+      interactionScope: { keys: "id", x: "", y: "" },
+      zoom: true,
+      assembled,
+    });
+    expect(scope).toEqual({ keys: "id", x: "", y: "" });
+  });
+
+  it("infers uncontrolled scopes from string key and aes fields", () => {
+    expect(
+      resolveInteractionScope({
+        interaction: undefined,
+        datumKey: "id",
+        zoom: false,
+        assembled,
+      }),
+    ).toEqual({ keys: "id", x: "foo", y: "bar" });
+  });
+
+  it("uses keys default when datumKey is a function or absent", () => {
+    expect(
+      resolveInteractionScope({
+        interaction: undefined,
+        datumKey: (row: { id: number }) => row.id,
+        zoom: false,
+        assembled,
+      }),
+    ).toEqual({ keys: "default", x: "foo", y: "bar" });
+    expect(
+      resolveInteractionScope({
+        interaction: undefined,
+        zoom: false,
+        assembled: null,
+      }),
+    ).toEqual({ keys: "default", x: "x", y: "y" });
+  });
+});

--- a/packages/svelte/tests/plot-assemble.test.ts
+++ b/packages/svelte/tests/plot-assemble.test.ts
@@ -71,6 +71,23 @@ describe("assemblePortableSpec", () => {
     expect(assembled!.layers[0].geom).toBe("point");
   });
 
+  it("ignores sibling inputs when an explicit spec is provided", () => {
+    const assembled = assemblePortableSpec({
+      spec: {
+        data: { values: rows },
+        layers: [{ geom: "point", aes: { x: "x", y: "y" } }],
+        labs: { title: "from-spec" },
+      },
+      data: [{ x: 9, y: 9 }],
+      aes: { x: "nope", y: "nope" },
+      layers: [{ geom: "line", aes: { x: "x", y: "y" } }],
+      labs: { title: "ignored" },
+    });
+    expect(assembled!.labs?.title).toBe("from-spec");
+    expect(assembled!.layers).toHaveLength(1);
+    expect(assembled!.layers[0].geom).toBe("point");
+  });
+
   it("returns null when there are no layers", () => {
     expect(
       assemblePortableSpec({

--- a/packages/svelte/tests/plot-semantic-keys.test.ts
+++ b/packages/svelte/tests/plot-semantic-keys.test.ts
@@ -1,0 +1,291 @@
+import { describe, expect, it } from "vitest";
+
+import type { CellValue } from "@ggsvelte/core";
+
+import { INTERACTION_DIAGNOSTIC_CATALOG } from "../src/lib/interaction.js";
+import {
+  createSourceIdentityTracker,
+  resolveSemanticKeys,
+  type SemanticKeyCandidate,
+  type SemanticKeyModelView,
+} from "../src/lib/plot-semantic-keys.js";
+
+function modelView(options: {
+  candidates?: SemanticKeyCandidate[];
+  rows?: Array<Record<string, CellValue> | null>;
+  lineage?: Map<number, readonly number[]>;
+  layers?: ReadonlyArray<{
+    geom: string;
+    params?: Record<string, unknown>;
+  }>;
+}): SemanticKeyModelView {
+  const candidates = options.candidates ?? [];
+  const rows = options.rows ?? [];
+  const lineage = options.lineage ?? new Map<number, readonly number[]>();
+  return {
+    candidateCount: candidates.length,
+    candidate(id: number) {
+      return candidates[id] ?? null;
+    },
+    lineageKeys(lineageId: number) {
+      return lineage.get(lineageId) ?? [];
+    },
+    row(rowIndex: number) {
+      return rows[rowIndex] ?? null;
+    },
+    layers: options.layers ?? [],
+  };
+}
+
+describe("createSourceIdentityTracker", () => {
+  it("assigns stable ids to the same object and distinct ids to different objects", () => {
+    const tracker = createSourceIdentityTracker();
+    const a = { v: 1 };
+    const b = { v: 1 };
+    expect(tracker.sourceIdentity(a)).toBe(tracker.sourceIdentity(a));
+    expect(tracker.sourceIdentity(a)).not.toBe(tracker.sourceIdentity(b));
+    expect(tracker.sourceIdentity(42)).toBe("42");
+    expect(tracker.sourceIdentity(null)).toBe("null");
+    expect(tracker.sourceIdentity("x")).toBe("x");
+  });
+
+  it("does not expose a clear operation (identity epochs must stay stable)", () => {
+    const tracker = createSourceIdentityTracker();
+    expect("clear" in tracker).toBe(false);
+  });
+});
+
+describe("resolveSemanticKeys", () => {
+  it("returns empty maps and no diagnostics when datumKey is undefined", () => {
+    const priorKeys = new Map<string, PropertyKey>();
+    const result = resolveSemanticKeys({
+      model: modelView({
+        candidates: [{ id: 0, rowIndex: 0, layerIndex: 0, lineage: 0 }],
+        rows: [{ id: 1 }],
+        lineage: new Map([[0, [0]]]),
+      }),
+      datumKey: undefined,
+      priorKeys,
+      rowIdentity: (rowIndex) => `r:${rowIndex}`,
+    });
+    expect(result.keys.size).toBe(0);
+    expect(result.diagnostics).toEqual([]);
+    expect(priorKeys.size).toBe(0);
+  });
+
+  it("emits synthetic-rule missing-lineage first when candidates are empty", () => {
+    const result = resolveSemanticKeys({
+      model: modelView({
+        candidates: [],
+        layers: [{ geom: "rule", params: { xintercept: 1 } }],
+      }),
+      datumKey: "id",
+      priorKeys: new Map(),
+      rowIdentity: (rowIndex) => `r:${rowIndex}`,
+    });
+    expect(result.diagnostics).toEqual([
+      {
+        ...INTERACTION_DIAGNOSTIC_CATALOG.INTERACTION_MISSING_LINEAGE,
+        actual: "synthetic rule has no source rows",
+      },
+    ]);
+  });
+
+  it("emits candidate missing-lineage before row key diagnostics", () => {
+    const result = resolveSemanticKeys({
+      model: modelView({
+        candidates: [
+          { id: 0, rowIndex: null, layerIndex: 3, lineage: 0 },
+          { id: 1, rowIndex: 0, layerIndex: 0, lineage: 1 },
+        ],
+        rows: [{ id: null }],
+        lineage: new Map([
+          [0, []],
+          [1, [0]],
+        ]),
+      }),
+      datumKey: "id",
+      priorKeys: new Map(),
+      rowIdentity: (rowIndex) => `r:${rowIndex}`,
+    });
+    expect(result.diagnostics.map((d) => d.code)).toEqual([
+      "INTERACTION_MISSING_LINEAGE",
+      "INTERACTION_INVALID_KEY",
+    ]);
+    expect(result.diagnostics[0].actual).toEqual({
+      layerIndex: 3,
+      candidateId: 0,
+    });
+    expect(result.keys.get(0)).toBeNull();
+  });
+
+  it("records field keys and treats symbols as valid", () => {
+    const sym = Symbol("s");
+    const priorKeys = new Map<string, PropertyKey>();
+    const result = resolveSemanticKeys({
+      model: modelView({
+        candidates: [
+          { id: 0, rowIndex: 0, layerIndex: 0, lineage: 0 },
+          { id: 1, rowIndex: 1, layerIndex: 0, lineage: 1 },
+        ],
+        rows: [{ id: "a" }, { id: sym }],
+        lineage: new Map([
+          [0, [0]],
+          [1, [1]],
+        ]),
+      }),
+      datumKey: "id",
+      priorKeys,
+      rowIdentity: (rowIndex) => `r:${rowIndex}`,
+    });
+    expect(result.keys.get(0)).toBe("a");
+    expect(result.keys.get(1)).toBe(sym);
+    expect(result.diagnostics).toEqual([]);
+    expect(priorKeys.get("r:0")).toBe("a");
+    expect(priorKeys.get("r:1")).toBe(sym);
+  });
+
+  it("supports function accessors and invalid key types", () => {
+    const result = resolveSemanticKeys({
+      model: modelView({
+        candidates: [
+          { id: 0, rowIndex: 0, layerIndex: 0, lineage: 0 },
+          { id: 1, rowIndex: 1, layerIndex: 0, lineage: 1 },
+        ],
+        rows: [{ n: 1 }, { n: 2 }],
+        lineage: new Map([
+          [0, [0]],
+          [1, [1]],
+        ]),
+      }),
+      datumKey: (row: Record<string, CellValue>, index: number) =>
+        index === 0 ? String(row.n) : ({ bad: true } as unknown as PropertyKey),
+      priorKeys: new Map(),
+      rowIdentity: (rowIndex) => `r:${rowIndex}`,
+    });
+    expect(result.keys.get(0)).toBe("1");
+    expect(result.keys.get(1)).toBeNull();
+    expect(result.diagnostics).toEqual([
+      {
+        ...INTERACTION_DIAGNOSTIC_CATALOG.INTERACTION_INVALID_KEY,
+        actual: { bad: true },
+      },
+    ]);
+  });
+
+  it("detects unstable keys against priorKeys and does not update the prior entry", () => {
+    const priorKeys = new Map<string, PropertyKey>([["r:0", "old"]]);
+    const result = resolveSemanticKeys({
+      model: modelView({
+        candidates: [{ id: 0, rowIndex: 0, layerIndex: 0, lineage: 0 }],
+        rows: [{ id: "new" }],
+        lineage: new Map([[0, [0]]]),
+      }),
+      datumKey: "id",
+      priorKeys,
+      rowIdentity: (rowIndex) => `r:${rowIndex}`,
+    });
+    expect(result.keys.get(0)).toBeNull();
+    expect(result.diagnostics).toEqual([
+      {
+        ...INTERACTION_DIAGNOSTIC_CATALOG.INTERACTION_UNSTABLE_KEY,
+        actual: { previous: "old", current: "new" },
+      },
+    ]);
+    expect(priorKeys.get("r:0")).toBe("old");
+  });
+
+  it("nulls both owners on duplicate keys and records one diagnostic with actual value", () => {
+    const priorKeys = new Map<string, PropertyKey>();
+    const result = resolveSemanticKeys({
+      model: modelView({
+        candidates: [
+          { id: 0, rowIndex: 0, layerIndex: 0, lineage: 0 },
+          { id: 1, rowIndex: 1, layerIndex: 0, lineage: 1 },
+          { id: 2, rowIndex: 2, layerIndex: 0, lineage: 2 },
+        ],
+        rows: [{ id: "dup" }, { id: "dup" }, { id: "dup" }],
+        lineage: new Map([
+          [0, [0]],
+          [1, [1]],
+          [2, [2]],
+        ]),
+      }),
+      datumKey: "id",
+      priorKeys,
+      rowIdentity: (rowIndex) => `r:${rowIndex}`,
+    });
+    expect(result.keys.get(0)).toBeNull();
+    expect(result.keys.get(1)).toBeNull();
+    expect(result.keys.get(2)).toBeNull();
+    expect(result.diagnostics.map((d) => d.code)).toEqual([
+      "INTERACTION_DUPLICATE_KEY",
+      "INTERACTION_DUPLICATE_KEY",
+    ]);
+    expect(result.diagnostics[0].actual).toBe("dup");
+    // first owner was set before the first duplicate; later owners also mark prior null
+    expect(priorKeys.get("r:0")).toBe("dup");
+    expect(priorKeys.get("r:1")).toBe("dup");
+    expect(priorKeys.get("r:2")).toBe("dup");
+  });
+
+  it("collects lineage rows and candidate rowIndex into sourceRows in encounter order", () => {
+    const result = resolveSemanticKeys({
+      model: modelView({
+        candidates: [
+          { id: 0, rowIndex: 9, layerIndex: 0, lineage: 0 },
+          { id: 1, rowIndex: null, layerIndex: 0, lineage: 1 },
+        ],
+        rows: Array.from({ length: 10 }, (_, i) => ({ id: `k${i}` })),
+        lineage: new Map([
+          [0, [3, 1]],
+          [1, [4]],
+        ]),
+      }),
+      datumKey: "id",
+      priorKeys: new Map(),
+      rowIdentity: (rowIndex) => `r:${rowIndex}`,
+    });
+    // encounter order: 9 (rowIndex), 3,1 (lineage), 4 (lineage of second)
+    expect([...result.keys.keys()]).toEqual([9, 3, 1, 4]);
+    expect(result.keys.get(9)).toBe("k9");
+    expect(result.keys.get(3)).toBe("k3");
+  });
+
+  it("skips priorKeys mutation when the row is null", () => {
+    const priorKeys = new Map<string, PropertyKey>();
+    const result = resolveSemanticKeys({
+      model: modelView({
+        candidates: [{ id: 0, rowIndex: 0, layerIndex: 0, lineage: 0 }],
+        rows: [null],
+        lineage: new Map([[0, [0]]]),
+      }),
+      datumKey: "id",
+      priorKeys,
+      rowIdentity: (rowIndex) => `r:${rowIndex}`,
+    });
+    expect(result.keys.get(0)).toBeNull();
+    expect(result.diagnostics[0].code).toBe("INTERACTION_INVALID_KEY");
+    expect(priorKeys.size).toBe(0);
+  });
+
+  it("uses a fresh priorKeys map when data/spec identity changes (caller responsibility)", () => {
+    // Component keeps one priorKeys Map for the instance; replacement data is
+    // a different rowIdentity namespace so instability does not fire.
+    const priorKeys = new Map<string, PropertyKey>([["dataA:0", "a"]]);
+    const result = resolveSemanticKeys({
+      model: modelView({
+        candidates: [{ id: 0, rowIndex: 0, layerIndex: 0, lineage: 0 }],
+        rows: [{ id: "b" }],
+        lineage: new Map([[0, [0]]]),
+      }),
+      datumKey: "id",
+      priorKeys,
+      rowIdentity: (rowIndex) => `dataB:${rowIndex}`,
+    });
+    expect(result.keys.get(0)).toBe("b");
+    expect(result.diagnostics).toEqual([]);
+    expect(priorKeys.get("dataB:0")).toBe("b");
+    expect(priorKeys.get("dataA:0")).toBe("a");
+  });
+});


### PR DESCRIPTION
## Summary

- Extract PortableSpec assembly, interaction-scope resolution, source-identity tracking, and semantic-key diagnostics from `GGPlot.svelte` into pure modules (`plot-assemble.ts`, `plot-semantic-keys.ts`).
- Keep GGPlot as the Svelte orchestrator; public API (`GGPlot`, `resetScales`, `setZoom`, props/events) is unchanged.
- Add characterization unit tests for the extracted contracts (scope throw messages, diagnostic order, live registry getters, explicit-spec short-circuit).

## Why

`GGPlot.svelte` is still large after earlier pure-helper extracts. Assembly and semantic-key resolution are cohesive pure concerns with clear test surfaces; pulling them out shrinks the component (~120 net script lines) without touching the inspection/pointer state machine.

## Test plan

- [x] `packages/svelte` unit tests for `plot-assemble` and `plot-semantic-keys`
- [x] Full `packages/svelte` browser + SSR suite (708 + 3)
- [x] `bun run check:svelte`
- [x] `bun run lint:type-aware`
- [x] `bun run knip` (no new unused exports)