### PR TITLE
refactor(svelte): extract GGPlot paint readiness and interaction pure seams

### DIFF
--- a/packages/svelte/src/lib/GGPlot.svelte
+++ b/packages/svelte/src/lib/GGPlot.svelte
@@ -84,7 +84,10 @@
     type ZoomInput,
   } from "./interaction.js";
   import type { PlotInteractionController } from "./interaction-controller.svelte.js";
-  import { createInspectionCoordinator } from "./inspection-resolver.js";
+  import {
+    clearInspectionFingerprint,
+    createInspectionCoordinator,
+  } from "./inspection-resolver.js";
   import { createInteractionReducer } from "./interaction-reducer.js";
   import { provideRegistry } from "./registry.svelte.js";
   import { a11yRows } from "./canvas-a11y.js";
@@ -108,6 +111,7 @@
   } from "./plot-labels.js";
   import {
     bestDirectionalIndex,
+    buildTraversalHits,
     cycleCoincidentIndex,
     hitFromCandidate,
     matchCandidateFromHit,
@@ -117,15 +121,17 @@
   import {
     bandChannelsForZoom,
     capabilityStatusText,
+    filterAvailableTools,
     zoomScaleDiagnosticsFromChannels,
     zoomSupportsChannel,
   } from "./plot-capability.js";
   import {
-    buildIntervalSelection,
     clearIntervalSelectionEvent,
-    filterDomainBySelectMode,
+    intervalSelectionFromRows,
     isBrushTooSmall,
+    lineageRowIndexesFromCandidates,
   } from "./plot-interval.js";
+  import { createPaintLedger, isPlotReady } from "./plot-paint.js";
   import {
     anchorsFromCandidateKeys,
     nextPointSelectionKeys,
@@ -420,17 +426,15 @@
   );
   const hasCanvas = $derived(canvasCount > 0);
 
-  // Canvas first-paint tracking: data-gg-ready waits for every canvas
-  // stratum of the CURRENT model to have painted at least once.
-  let paintedFor = $state(-1);
-  let paintedCount = $state(0);
-  function notifyPainted(runId: number): void {
-    if (paintedFor === runId) {
-      paintedCount += 1;
-    } else {
-      paintedFor = runId;
-      paintedCount = 1;
-    }
+  // Canvas first-paint tracking: data-gg-ready waits for every distinct
+  // canvas stratum of the CURRENT model to have painted at least once.
+  // paintEpoch bumps so readiness re-derives when the non-reactive ledger
+  // mutates (ledger itself must not be $state — set mutations are invisible).
+  const paintLedger = createPaintLedger();
+  let paintEpoch = $state(0);
+  function notifyPainted(runId: number, stratumKey: string): void {
+    paintLedger.notify(runId, stratumKey);
+    paintEpoch += 1;
   }
 
   // Redraw canvases when the host theme flips (canvas colors resolve from
@@ -449,7 +453,11 @@
   });
 
   /** Svelte attachment: size for DPR, draw the stratum, signal first paint. */
-  function canvasAttachment(m: RenderModel, batches: GeometryBatch[]) {
+  function canvasAttachment(
+    m: RenderModel,
+    batches: GeometryBatch[],
+    stratumKey: string,
+  ) {
     void themeEpoch;
     return (canvas: HTMLCanvasElement) => {
       const ctx = canvas.getContext("2d");
@@ -459,7 +467,7 @@
       drawStratum(ctx, m.scene, batches, cssColorResolver(canvas));
       // untrack: the attachment must WRITE paint state without SUBSCRIBING
       // to it (a tracked read here would re-trigger the attachment -> loop).
-      untrack(() => notifyPainted(m.runId));
+      untrack(() => notifyPainted(m.runId, stratumKey));
     };
   }
 
@@ -583,8 +591,9 @@
     return zoomSupportsChannel(interactionConfig.zoom.mode, model.scales);
   });
   const availableTools = $derived(
-    interactionConfig.availableTools.filter(
-      (available) => available !== "zoom-area" || zoomHasSupportedChannel,
+    filterAvailableTools(
+      interactionConfig.availableTools,
+      zoomHasSupportedChannel,
     ),
   );
   const showToolRail = $derived(
@@ -899,16 +908,7 @@
 
   const traversalHits: SceneHit[] = $derived.by(() => {
     if (model === null) return [];
-    const hits: SceneHit[] = [];
-    let id = model.candidates.traverse(null, "first");
-    const seen = new Set<number>();
-    while (id !== null && !seen.has(id)) {
-      seen.add(id);
-      const candidate = model.candidates.candidate(id);
-      if (candidate !== null) hits.push(hitFromCandidate(candidate));
-      id = model.candidates.traverse(id, "next");
-    }
-    return hits;
+    return buildTraversalHits(model.candidates);
   });
   let reconciledRun = -1;
   $effect(() => {
@@ -975,13 +975,17 @@
     next: PlotInspection<Record<string, CellValue>>,
     semanticFingerprint?: string,
   ): void {
+    // Clear tokens come from the inspection-resolver helper. Non-clear
+    // emissions must carry the coordinator's type-aware semanticFingerprint —
+    // never a host-side String(key) fallback (collides symbols / delimiters).
     const fingerprint =
-      semanticFingerprint ??
-      (next.phase === "clear"
-        ? `clear:${next.source}`
-        : `${next.mode}:${next.state}:${next.panelId}:${String(next.focus.key)}:${next.members.map((m) => `${m.layerIndex}:${String(m.key)}`).join(",")}`);
-    if (fingerprint === lastInspectionFingerprint) return;
-    lastInspectionFingerprint = fingerprint;
+      next.phase === "clear"
+        ? clearInspectionFingerprint(next.source)
+        : semanticFingerprint;
+    if (fingerprint !== undefined) {
+      if (fingerprint === lastInspectionFingerprint) return;
+      lastInspectionFingerprint = fingerprint;
+    }
     oninspect?.(next as unknown as PlotInspection<Row, PublicKey>);
     oninteraction?.(next as unknown as PlotInteractionEvent<Row, PublicKey>);
   }
@@ -1248,27 +1252,24 @@
             .filter(
               (candidate): candidate is CandidateFacts => candidate !== null,
             );
-    const sourceRows = new Set<number>();
-    for (const candidate of candidates)
-      for (const rowIndex of model?.lineage.keys(candidate.lineage) ?? [])
-        sourceRows.add(rowIndex);
-    const keys = uniqueKeysFromRowIndexes(sourceRows, (rowIndex) =>
-      semanticKey(model?.row(rowIndex) ?? null, rowIndex),
+    const sourceRows = lineageRowIndexesFromCandidates(
+      candidates,
+      (lineageId) => model?.lineage.keys(lineageId) ?? [],
     );
     const inverted =
       model !== null && model.scene.panels.length === 1
         ? panelDataDomains(rect, model.scene.panels[0]!, model.scales, flip)
         : {};
-    const domain = filterDomainBySelectMode(inverted, mode);
-    return buildIntervalSelection({
+    return intervalSelectionFromRows({
       phase,
       mode,
       panelId: panelId(0),
-      domain,
       pixels: rect,
-      keys,
-      lineageCount: sourceRows.size,
       source,
+      rowIndexes: sourceRows,
+      keyForRow: (rowIndex) =>
+        semanticKey(model?.row(rowIndex) ?? null, rowIndex),
+      invertedDomain: inverted,
     });
   }
 
@@ -1629,16 +1630,19 @@
   }
 
   // Readiness signal for screenshot tooling (plan: VR waits on
-  // `[data-gg-ready="true"]`). Effects run after the render flush; canvas
-  // strata additionally gate on their first paint (decision 0006 / plan).
-  let ready = $state(false);
-  $effect(() => {
-    ready =
-      model !== null &&
-      ((width !== undefined && width !== "container") ||
-        containerHasPositiveWidth) &&
-      (!hasCanvas ||
-        (paintedFor === model.runId && paintedCount >= canvasCount));
+  // `[data-gg-ready="true"]`). Derived after flush-visible state updates;
+  // canvas strata additionally gate on first paint (decision 0006 / plan).
+  const ready = $derived.by(() => {
+    void paintEpoch;
+    return isPlotReady({
+      hasModel: model !== null,
+      widthMode:
+        width === undefined || width === "container" ? "container" : "fixed",
+      containerHasPositiveWidth,
+      hasCanvas,
+      paintComplete:
+        model !== null && paintLedger.isComplete(model.runId, canvasCount),
+    });
   });
 </script>
 
@@ -1684,7 +1688,7 @@
         {#if stratum.backend === "canvas"}
           <canvas
             class="gg-stratum gg-canvas"
-            {@attach canvasAttachment(model, stratum.batches)}
+            {@attach canvasAttachment(model, stratum.batches, `canvas:${si}`)}
           ></canvas>
           {@const table = a11yRows(model, stratum.batches)}
           <div

--- a/packages/svelte/src/lib/inspection-resolver.ts
+++ b/packages/svelte/src/lib/inspection-resolver.ts
@@ -49,6 +49,15 @@ export interface CoordinatedInspection<Row, Key> {
   readonly presentationChanged: boolean;
 }
 
+/**
+ * Stable emit-dedupe token for inspection clear events.
+ * Non-clear emissions must use the coordinator's `semanticFingerprint`
+ * (type-aware key identity); hosts must not invent a second fingerprint.
+ */
+export function clearInspectionFingerprint(source: InteractionSource): string {
+  return `clear:${source}`;
+}
+
 interface ResolvedTarget {
   readonly seed: CandidateFacts;
   readonly members: readonly CandidateFacts[];

--- a/packages/svelte/src/lib/plot-capability.ts
+++ b/packages/svelte/src/lib/plot-capability.ts
@@ -1,6 +1,17 @@
-import type { InteractionDiagnostic } from "./interaction.js";
+import type { InteractionDiagnostic, InteractionTool } from "./interaction.js";
 
 export type ZoomAreaMode = "x" | "y" | "xy";
+
+/**
+ * Drop zoom-area when no continuous channel supports brush zoom.
+ * Other tools pass through unchanged.
+ */
+export function filterAvailableTools(
+  tools: readonly InteractionTool[],
+  zoomHasSupportedChannel: boolean,
+): InteractionTool[] {
+  return tools.filter((tool) => tool !== "zoom-area" || zoomHasSupportedChannel);
+}
 
 export type ScaleTypeRef = {
   readonly x: { readonly type: string };

--- a/packages/svelte/src/lib/plot-interval.ts
+++ b/packages/svelte/src/lib/plot-interval.ts
@@ -2,6 +2,7 @@ import type { CellValue } from "@ggsvelte/core";
 
 import type { InteractionSource, IntervalSelection } from "./interaction.js";
 import type { PlotRect } from "./plot-geometry.js";
+import { uniqueKeysFromRowIndexes } from "./plot-selection.js";
 
 /** Pointer brush-end gate only. Keyboard Enter/Space commits any size. */
 export const BRUSH_MIN_SPAN_PX = 4;
@@ -88,5 +89,59 @@ export function clearIntervalSelectionEvent(
     keys: Object.freeze([]),
     lineageCount: 0,
     source,
+  });
+}
+
+export type LineageCandidate = {
+  readonly lineage: number;
+};
+
+/**
+ * Collect source row indexes covered by interval candidates via lineage.
+ * Order is insertion order (first candidate, then lineage key order).
+ */
+export function lineageRowIndexesFromCandidates(
+  candidates: Iterable<LineageCandidate>,
+  lineageKeys: (lineageId: number) => Iterable<number>,
+): Set<number> {
+  const sourceRows = new Set<number>();
+  for (const candidate of candidates) {
+    for (const rowIndex of lineageKeys(candidate.lineage)) sourceRows.add(rowIndex);
+  }
+  return sourceRows;
+}
+
+export type IntervalSelectionFromRowsInput = {
+  readonly phase: IntervalSelection["phase"];
+  readonly mode: SelectAreaMode;
+  readonly panelId: string | null;
+  readonly pixels: PlotRect;
+  readonly source: InteractionSource;
+  /** Source row indexes (typically from lineageRowIndexesFromCandidates). */
+  readonly rowIndexes: Iterable<number>;
+  readonly keyForRow: (rowIndex: number) => PropertyKey | null;
+  /** Pre-inverted panel domains; mode filtering is applied here. */
+  readonly invertedDomain: IntervalDomain;
+};
+
+/**
+ * Pure interval-selection assembly after candidate query + domain inversion.
+ * Resolves keys from row indexes, filters domain by select mode, freezes payload.
+ */
+export function intervalSelectionFromRows(
+  input: IntervalSelectionFromRowsInput,
+): IntervalSelection {
+  const sourceRows = input.rowIndexes instanceof Set ? input.rowIndexes : new Set(input.rowIndexes);
+  const keys = uniqueKeysFromRowIndexes(sourceRows, input.keyForRow);
+  const domain = filterDomainBySelectMode(input.invertedDomain, input.mode);
+  return buildIntervalSelection({
+    phase: input.phase,
+    mode: input.mode,
+    panelId: input.panelId,
+    domain,
+    pixels: input.pixels,
+    keys,
+    lineageCount: sourceRows.size,
+    source: input.source,
   });
 }

--- a/packages/svelte/src/lib/plot-paint.ts
+++ b/packages/svelte/src/lib/plot-paint.ts
@@ -1,0 +1,68 @@
+/**
+ * Canvas first-paint readiness for GGPlot compositing.
+ *
+ * Readiness waits until every canvas stratum of the current model run has
+ * painted at least once. Tracking is by distinct stratum key (not raw
+ * notification count) so a re-attached canvas cannot mark the plot ready
+ * before sibling strata paint.
+ */
+
+export type PlotReadyInput = {
+  readonly hasModel: boolean;
+  readonly widthMode: "fixed" | "container";
+  readonly containerHasPositiveWidth: boolean;
+  readonly hasCanvas: boolean;
+  /** True when every canvas stratum of the current model run has painted. */
+  readonly paintComplete: boolean;
+};
+
+/**
+ * VR / screenshot readiness predicate for `[data-gg-ready]`.
+ * Container width must be positive only when width is container-responsive.
+ * Canvas plots additionally require paintComplete.
+ */
+export function isPlotReady(input: PlotReadyInput): boolean {
+  if (!input.hasModel) return false;
+  if (input.widthMode === "container" && !input.containerHasPositiveWidth) return false;
+  if (input.hasCanvas && !input.paintComplete) return false;
+  return true;
+}
+
+export type PaintLedger = {
+  /** Record that a canvas stratum painted for `runId`. */
+  notify(runId: number, stratumKey: string): void;
+  /** Distinct strata painted for the current run. */
+  readonly paintedCount: number;
+  /** Run id of the current paint set, or -1 before any notify. */
+  readonly paintedRunId: number;
+  /**
+   * True when `runId` matches the ledger run and at least `canvasCount`
+   * distinct stratum keys have notified. `canvasCount === 0` is complete
+   * only when the ledger run already matches (including the initial -1 run).
+   */
+  isComplete(runId: number, canvasCount: number): boolean;
+};
+
+/** Mutable paint ledger owned by one GGPlot instance. */
+export function createPaintLedger(): PaintLedger {
+  let paintedRunId = -1;
+  const paintedKeys = new Set<string>();
+  return {
+    notify(runId: number, stratumKey: string): void {
+      if (paintedRunId !== runId) {
+        paintedRunId = runId;
+        paintedKeys.clear();
+      }
+      paintedKeys.add(stratumKey);
+    },
+    get paintedCount(): number {
+      return paintedKeys.size;
+    },
+    get paintedRunId(): number {
+      return paintedRunId;
+    },
+    isComplete(runId: number, canvasCount: number): boolean {
+      return paintedRunId === runId && paintedKeys.size >= canvasCount;
+    },
+  };
+}

--- a/packages/svelte/src/lib/plot-pointer.ts
+++ b/packages/svelte/src/lib/plot-pointer.ts
@@ -68,6 +68,32 @@ export function matchCandidateFromHit(
   return null;
 }
 
+/**
+ * Narrow candidate-store surface for keyboard/inspection traversal.
+ * Production walks id-ascending via traverse(null,"first") / traverse(id,"next").
+ */
+export type TraversalCandidateStore = {
+  traverse(fromId: number | null, direction: "first" | "next"): number | null;
+  candidate(id: number): CandidateFacts | null;
+};
+
+/**
+ * Build the ordered SceneHit list used by keyboard navigation.
+ * Stops on cycle (duplicate id) or null terminator; skips missing candidates.
+ */
+export function buildTraversalHits(store: TraversalCandidateStore): SceneHit[] {
+  const hits: SceneHit[] = [];
+  let id = store.traverse(null, "first");
+  const seen = new Set<number>();
+  while (id !== null && !seen.has(id)) {
+    seen.add(id);
+    const candidate = store.candidate(id);
+    if (candidate !== null) hits.push(hitFromCandidate(candidate));
+    id = store.traverse(id, "next");
+  }
+  return hits;
+}
+
 /** Modular wrap for keyboard traversal across a hit list. */
 export function nextTraversalIndex(current: number, delta: number, length: number): number {
   if (length <= 0) return -1;

--- a/packages/svelte/tests/interaction-unit.test.ts
+++ b/packages/svelte/tests/interaction-unit.test.ts
@@ -11,7 +11,11 @@ import {
   createInteractionReducer,
   type InteractionCandidateRef,
 } from "../src/lib/interaction-reducer.js";
-import { createInspectionCoordinator, resolveInspection } from "../src/lib/inspection-resolver.js";
+import {
+  clearInspectionFingerprint,
+  createInspectionCoordinator,
+  resolveInspection,
+} from "../src/lib/inspection-resolver.js";
 
 const candidate = (id: number): InteractionCandidateRef => ({
   epoch: 1,
@@ -149,6 +153,15 @@ describe("chart-local interaction reducer", () => {
     reducer.dispatch({ type: "set-tool", tool: "zoom-area" });
     expect(frame).toBeNull();
     expect(reducer.state.inspection.candidate?.id).toBe(2);
+  });
+});
+
+describe("clearInspectionFingerprint", () => {
+  it("scopes clear dedupe tokens by interaction source", () => {
+    expect(clearInspectionFingerprint("pointer")).toBe("clear:pointer");
+    expect(clearInspectionFingerprint("keyboard")).toBe("clear:keyboard");
+    expect(clearInspectionFingerprint("programmatic")).toBe("clear:programmatic");
+    expect(clearInspectionFingerprint("pointer")).not.toBe(clearInspectionFingerprint("touch"));
   });
 });
 

--- a/packages/svelte/tests/plot-capability.test.ts
+++ b/packages/svelte/tests/plot-capability.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   bandChannelsForZoom,
   capabilityStatusText,
+  filterAvailableTools,
   zoomScaleDiagnosticsFromChannels,
   zoomSupportsChannel,
 } from "../src/lib/plot-capability.js";
@@ -49,6 +50,20 @@ describe("zoomScaleDiagnosticsFromChannels", () => {
         actual: "band",
       },
     ]);
+  });
+});
+
+describe("filterAvailableTools", () => {
+  const all = ["inspect", "point", "select-area", "zoom-area"] as const;
+
+  it("keeps zoom-area only when a continuous channel supports it", () => {
+    expect(filterAvailableTools(all, true)).toEqual([...all]);
+    expect(filterAvailableTools(all, false)).toEqual(["inspect", "point", "select-area"]);
+  });
+
+  it("leaves non-zoom tools untouched when zoom is unsupported", () => {
+    expect(filterAvailableTools(["inspect", "point"], false)).toEqual(["inspect", "point"]);
+    expect(filterAvailableTools(["zoom-area"], false)).toEqual([]);
   });
 });
 

--- a/packages/svelte/tests/plot-interval.test.ts
+++ b/packages/svelte/tests/plot-interval.test.ts
@@ -6,7 +6,9 @@ import {
   clearIntervalSelectionEvent,
   filterDomainBySelectMode,
   freezeIntervalDomain,
+  intervalSelectionFromRows,
   isBrushTooSmall,
+  lineageRowIndexesFromCandidates,
 } from "../src/lib/plot-interval.js";
 
 describe("isBrushTooSmall (pointer brush-end gate)", () => {
@@ -104,6 +106,62 @@ describe("buildIntervalSelection", () => {
     expect(Object.isFrozen(event.domain)).toBe(true);
     expect(Object.isFrozen(event.domain.x)).toBe(true);
     expect(Object.isFrozen(event.domain.y)).toBe(true);
+  });
+});
+
+describe("lineageRowIndexesFromCandidates", () => {
+  it("unions lineage keys across candidates without duplicating rows", () => {
+    const lineage = new Map<number, number[]>([
+      [10, [1, 2]],
+      [20, [2, 3]],
+    ]);
+    const rows = lineageRowIndexesFromCandidates(
+      [{ lineage: 10 }, { lineage: 20 }, { lineage: 10 }],
+      (id) => lineage.get(id) ?? [],
+    );
+    expect([...rows]).toEqual([1, 2, 3]);
+  });
+
+  it("returns empty set when there are no candidates", () => {
+    expect([...lineageRowIndexesFromCandidates([], () => [1])]).toEqual([]);
+  });
+});
+
+describe("intervalSelectionFromRows", () => {
+  it("resolves keys, filters domain by mode, and freezes the payload", () => {
+    const event = intervalSelectionFromRows({
+      phase: "end",
+      mode: "x",
+      panelId: "p0",
+      pixels: { x0: 0, y0: 0, x1: 10, y1: 10 },
+      source: "pointer",
+      rowIndexes: [0, 1, 0, 2],
+      keyForRow: (rowIndex) => (rowIndex === 1 ? null : `k${String(rowIndex)}`),
+      invertedDomain: { x: [0, 5], y: [1, 9] },
+    });
+    expect(event.mode).toBe("x");
+    expect(event.domain).toEqual({ x: [0, 5] });
+    expect(event.keys).toEqual(["k0", "k2"]);
+    expect(event.lineageCount).toBe(3); // unique row indexes before null-key drop
+    expect(Object.isFrozen(event)).toBe(true);
+    expect(Object.isFrozen(event.keys)).toBe(true);
+  });
+
+  it("preserves start/change phases and empty key sets", () => {
+    const start = intervalSelectionFromRows({
+      phase: "start",
+      mode: "xy",
+      panelId: null,
+      pixels: { x0: 1, y0: 2, x1: 3, y1: 4 },
+      source: "keyboard",
+      rowIndexes: [],
+      keyForRow: () => "x",
+      invertedDomain: {},
+    });
+    expect(start.phase).toBe("start");
+    expect(start.keys).toEqual([]);
+    expect(start.lineageCount).toBe(0);
+    expect(start.source).toBe("keyboard");
   });
 });
 

--- a/packages/svelte/tests/plot-paint.test.ts
+++ b/packages/svelte/tests/plot-paint.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+
+import { createPaintLedger, isPlotReady } from "../src/lib/plot-paint.js";
+
+describe("isPlotReady", () => {
+  const readyBase = {
+    hasModel: true,
+    widthMode: "fixed" as const,
+    containerHasPositiveWidth: false,
+    hasCanvas: false,
+    paintComplete: false,
+  };
+
+  it("is false without a model", () => {
+    expect(isPlotReady({ ...readyBase, hasModel: false })).toBe(false);
+  });
+
+  it("requires positive container width only in container mode", () => {
+    expect(
+      isPlotReady({
+        ...readyBase,
+        widthMode: "container",
+        containerHasPositiveWidth: false,
+      }),
+    ).toBe(false);
+    expect(
+      isPlotReady({
+        ...readyBase,
+        widthMode: "container",
+        containerHasPositiveWidth: true,
+      }),
+    ).toBe(true);
+    expect(
+      isPlotReady({
+        ...readyBase,
+        widthMode: "fixed",
+        containerHasPositiveWidth: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("gates canvas plots on paintComplete", () => {
+    expect(
+      isPlotReady({
+        ...readyBase,
+        hasCanvas: true,
+        paintComplete: false,
+      }),
+    ).toBe(false);
+    expect(
+      isPlotReady({
+        ...readyBase,
+        hasCanvas: true,
+        paintComplete: true,
+      }),
+    ).toBe(true);
+    // SVG-only plots do not wait on paint ledger.
+    expect(
+      isPlotReady({
+        ...readyBase,
+        hasCanvas: false,
+        paintComplete: false,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("createPaintLedger", () => {
+  it("is incomplete until each distinct stratum key paints for the run", () => {
+    const ledger = createPaintLedger();
+    expect(ledger.isComplete(1, 2)).toBe(false);
+    ledger.notify(1, "0");
+    expect(ledger.isComplete(1, 2)).toBe(false);
+    expect(ledger.paintedCount).toBe(1);
+    expect(ledger.paintedRunId).toBe(1);
+    ledger.notify(1, "1");
+    expect(ledger.isComplete(1, 2)).toBe(true);
+    expect(ledger.paintedCount).toBe(2);
+  });
+
+  it("ignores duplicate notifications for the same stratum key", () => {
+    const ledger = createPaintLedger();
+    ledger.notify(7, "canvas-0");
+    ledger.notify(7, "canvas-0");
+    ledger.notify(7, "canvas-0");
+    expect(ledger.paintedCount).toBe(1);
+    expect(ledger.isComplete(7, 2)).toBe(false);
+    ledger.notify(7, "canvas-1");
+    expect(ledger.isComplete(7, 2)).toBe(true);
+  });
+
+  it("resets when the run id changes (model replacement)", () => {
+    const ledger = createPaintLedger();
+    ledger.notify(1, "0");
+    ledger.notify(1, "1");
+    expect(ledger.isComplete(1, 2)).toBe(true);
+    ledger.notify(2, "0");
+    expect(ledger.paintedRunId).toBe(2);
+    expect(ledger.paintedCount).toBe(1);
+    expect(ledger.isComplete(1, 2)).toBe(false);
+    expect(ledger.isComplete(2, 2)).toBe(false);
+    ledger.notify(2, "1");
+    expect(ledger.isComplete(2, 2)).toBe(true);
+  });
+
+  it("treats canvasCount 0 as complete for the matching run only when empty", () => {
+    const ledger = createPaintLedger();
+    // No paints yet, run id still sentinel -1.
+    expect(ledger.isComplete(5, 0)).toBe(false);
+    // After any notify establishes the run, zero canvases means complete.
+    ledger.notify(5, "unused");
+    // With canvasCount 0 we should not require strata; complete when run matches.
+    const empty = createPaintLedger();
+    // Explicit: zero canvas strata → complete iff we consider the run current.
+    // Host only asks isComplete when hasCanvas; still define: count 0 ⇒ paintedCount >= 0
+    // only when paintedRunId matches. Fresh ledger paintedRunId is -1.
+    expect(empty.isComplete(-1, 0)).toBe(true);
+    expect(empty.isComplete(1, 0)).toBe(false);
+  });
+});

--- a/packages/svelte/tests/plot-pointer.test.ts
+++ b/packages/svelte/tests/plot-pointer.test.ts
@@ -5,6 +5,7 @@ import type { SceneHit } from "@ggsvelte/core/dom";
 
 import {
   bestDirectionalIndex,
+  buildTraversalHits,
   CANDIDATE_HIT_TOLERANCE,
   cycleCoincidentIndex,
   hitFromCandidate,
@@ -141,6 +142,66 @@ describe("bestDirectionalIndex", () => {
   it("excludes origin-coincident and behind-direction hits (primary <= 0)", () => {
     expect(bestDirectionalIndex(origin, [hit(50, 50), hit(60, 50)], 1, 0)).toBe(1);
     expect(bestDirectionalIndex(origin, [hit(40, 50)], 1, 0)).toBe(-1);
+  });
+});
+
+describe("buildTraversalHits", () => {
+  const asCandidate = (id: number, partial: Partial<CandidateFacts> = {}): CandidateFacts =>
+    ({
+      id,
+      layerIndex: 0,
+      panelIndex: 0,
+      rowIndex: id,
+      x: id * 10,
+      y: id * 10,
+      kind: "point",
+      autoMode: "exact",
+      lineage: id,
+      ...partial,
+    }) as CandidateFacts;
+
+  it("walks first/next order and projects candidates to hits", () => {
+    const order = [2, 0, 1];
+    const store = {
+      traverse(fromId: number | null, direction: "first" | "next"): number | null {
+        if (direction === "first") return order[0] ?? null;
+        if (fromId === null) return null;
+        const index = order.indexOf(fromId);
+        return index < 0 ? null : (order[index + 1] ?? null);
+      },
+      candidate(id: number): CandidateFacts | null {
+        return asCandidate(id);
+      },
+    };
+    expect(buildTraversalHits(store)).toEqual([
+      hitFromCandidate(asCandidate(2)),
+      hitFromCandidate(asCandidate(0)),
+      hitFromCandidate(asCandidate(1)),
+    ]);
+  });
+
+  it("stops on cycles and skips missing candidates", () => {
+    const store = {
+      traverse(fromId: number | null, direction: "first" | "next"): number | null {
+        if (direction === "first") return 0;
+        if (fromId === 0) return 1;
+        if (fromId === 1) return 0; // cycle
+        return null;
+      },
+      candidate(id: number): CandidateFacts | null {
+        return id === 1 ? null : asCandidate(id);
+      },
+    };
+    expect(buildTraversalHits(store)).toEqual([hitFromCandidate(asCandidate(0))]);
+  });
+
+  it("returns empty when traverse has no first candidate", () => {
+    expect(
+      buildTraversalHits({
+        traverse: () => null,
+        candidate: () => null,
+      }),
+    ).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Summary

- Extract canvas first-paint readiness into `plot-paint.ts` (`createPaintLedger`, `isPlotReady`) and derive `[data-gg-ready]` instead of effect-syncing it.
- Fix paint tracking so readiness requires each **distinct** canvas stratum of the current model run (re-attachment of one canvas can no longer satisfy the count alone).
- Move tool filtering, traversal hit building, interval selection assembly, and clear-inspection fingerprint ownership into focused pure modules with characterization unit tests.
- Keep `GGPlot` as the Svelte orchestrator; public API (`GGPlot`, `resetScales`, `setZoom`, props/events) is unchanged.

## Why

`GGPlot.svelte` still mixes pipeline/compositing readiness with interaction pure assembly after earlier helper extracts. These seams have clear unit-test surfaces and fix a real multi-canvas readiness edge case without touching the gesture state machine wholesale (a larger interval-interaction host extract remains a follow-up).

## Test plan

- [x] Unit tests: `plot-paint`, `plot-capability` (filterAvailableTools), `plot-interval` (lineage + intervalSelectionFromRows), `plot-pointer` (buildTraversalHits), clearInspectionFingerprint
- [x] Full `packages/svelte` browser suite (761 passed; one webkit hydration timeout flaked once and passed on re-run)
- [x] SSR harness (3 passed)
- [x] `bun run check:svelte`
- [x] `bun run lint:type-aware`
- [x] `bun run knip`
- [x] Independent Codex pre-PR review: no P1/P2 findings