### PR TITLE
refactor(svelte): extract interval brush geometry and scene query

### DIFF
--- a/packages/svelte/src/lib/GGPlot.svelte
+++ b/packages/svelte/src/lib/GGPlot.svelte
@@ -98,12 +98,13 @@
     toLayerInput,
   } from "./plot-assemble.js";
   import {
-    clamp,
-    expandIntervalQuery,
-    frozenZoomDomains,
-    normalizedRect,
-    panelDataDomains,
-  } from "./plot-geometry.js";
+    brushAtPoint,
+    brushWithEnd,
+    evaluatePointerBrushEnd,
+    nudgeBrushEnd,
+    panelCenterAnchor,
+  } from "./plot-area-brush.js";
+  import { frozenZoomDomains, normalizedRect } from "./plot-geometry.js";
   import {
     datumLabel as datumLabelFor,
     inspectionLiveText as inspectionLiveTextFor,
@@ -125,12 +126,11 @@
     zoomScaleDiagnosticsFromChannels,
     zoomSupportsChannel,
   } from "./plot-capability.js";
+  import { clearIntervalSelectionEvent } from "./plot-interval.js";
   import {
-    clearIntervalSelectionEvent,
-    intervalSelectionFromRows,
-    isBrushTooSmall,
-    lineageRowIndexesFromCandidates,
-  } from "./plot-interval.js";
+    buildIntervalSelectionFromScene,
+    type IntervalQueryScene,
+  } from "./plot-interval-query.js";
   import { createPaintLedger, isPlotReady } from "./plot-paint.js";
   import {
     anchorsFromCandidateKeys,
@@ -1174,11 +1174,50 @@
     source: InteractionSource,
   ): void {
     if (!brushing || brushRect === null) return;
-    brushRect = { ...brushRect, x1: point.x, y1: point.y };
+    brushRect = brushWithEnd(brushRect, point);
     if (activeTool === "select-area")
       emitSelection(
         selectionEvent("change", normalizedRect(brushRect), source),
       );
+  }
+
+  /** Map the live render model into the pure interval query scene adapter. */
+  function intervalQueryScene(): IntervalQueryScene | null {
+    const current = model;
+    if (current === null) return null;
+    const panel = current.scene.panels[0];
+    return {
+      panel:
+        panel === undefined
+          ? null
+          : {
+              x: panel.x,
+              y: panel.y,
+              width: panel.width,
+              height: panel.height,
+              id: panel.id,
+            },
+      singlePanel: current.scene.panels.length === 1,
+      flip: assembled?.coord?.type === "flip",
+      scales: current.scales,
+      queryCandidates(expanded) {
+        return [
+          ...current.candidates.queryRect(
+            expanded.x0,
+            expanded.y0,
+            expanded.x1,
+            expanded.y1,
+          ),
+        ]
+          .map((id) => current.candidates.candidate(id))
+          .filter(
+            (candidate): candidate is CandidateFacts => candidate !== null,
+          );
+      },
+      lineageKeys(lineageId) {
+        return current.lineage.keys(lineageId);
+      },
+    };
   }
 
   function onPointerLeave(): void {
@@ -1208,8 +1247,8 @@
     const p = plotPoint(event);
     brushRect =
       areaAwaitingSecond && brushRect !== null
-        ? { ...brushRect, x1: p.x, y1: p.y }
-        : { x0: p.x, y0: p.y, x1: p.x, y1: p.y };
+        ? brushWithEnd(brushRect, p)
+        : brushAtPoint(p);
     setInspection(null, event.pointerType === "touch" ? "touch" : "pointer");
     reducer.dispatch({ type: "begin-area", point: p, panelId: panelId(0) });
     if (activeTool === "select-area" && !areaAwaitingSecond) {
@@ -1233,43 +1272,14 @@
     rect: ReturnType<typeof normalizedRect>,
     source: InteractionSource,
   ): IntervalSelection {
-    const mode = interactionConfig.select?.mode ?? "xy";
-    const panel = model?.scene.panels[0];
-    const flip = assembled?.coord?.type === "flip";
-    const query = expandIntervalQuery(rect, panel, mode, flip);
-    const candidates =
-      model === null
-        ? []
-        : [
-            ...model.candidates.queryRect(
-              query.x0,
-              query.y0,
-              query.x1,
-              query.y1,
-            ),
-          ]
-            .map((id) => model!.candidates.candidate(id))
-            .filter(
-              (candidate): candidate is CandidateFacts => candidate !== null,
-            );
-    const sourceRows = lineageRowIndexesFromCandidates(
-      candidates,
-      (lineageId) => model?.lineage.keys(lineageId) ?? [],
-    );
-    const inverted =
-      model !== null && model.scene.panels.length === 1
-        ? panelDataDomains(rect, model.scene.panels[0]!, model.scales, flip)
-        : {};
-    return intervalSelectionFromRows({
+    return buildIntervalSelectionFromScene({
       phase,
-      mode,
-      panelId: panelId(0),
-      pixels: rect,
+      mode: interactionConfig.select?.mode ?? "xy",
       source,
-      rowIndexes: sourceRows,
+      pixels: rect,
+      scene: intervalQueryScene(),
       keyForRow: (rowIndex) =>
         semanticKey(model?.row(rowIndex) ?? null, rowIndex),
-      invertedDomain: inverted,
     });
   }
 
@@ -1304,29 +1314,21 @@
     if (!brushing || brushRect === null) return;
     reducer.cancelScheduledPointer();
     const source = event.pointerType === "touch" ? "touch" : "pointer";
-    const rect = normalizedRect({
-      ...brushRect,
-      ...Object.fromEntries(
-        Object.entries(plotPoint(event)).map(([k, v]) => [
-          k === "x" ? "x1" : "y1",
-          v,
-        ]),
-      ),
-    } as { x0: number; y0: number; x1: number; y1: number });
-    if (isBrushTooSmall(rect)) {
-      brushRect = rect;
+    const ended = evaluatePointerBrushEnd(brushRect, plotPoint(event));
+    if (ended.kind === "too-small") {
+      brushRect = ended.corners;
       announceInteraction("Choose opposite corner.");
       return;
     }
     brushRect = null;
     if (activeTool === "select-area") {
-      const eventValue = selectionEvent("end", rect, source);
+      const eventValue = selectionEvent("end", ended.rect, source);
       committedInterval = interactionConfig.select?.persistent
         ? eventValue
         : null;
       emitSelection(eventValue);
     } else if (activeTool === "zoom-area") {
-      applyBrushZoom(rect, source);
+      applyBrushZoom(ended.rect, source);
     }
     reducer.dispatch({ type: "cancel-area" });
   }
@@ -1514,11 +1516,7 @@
             : 0;
       const dy =
         event.key === "ArrowUp" ? -step : event.key === "ArrowDown" ? step : 0;
-      brushRect = {
-        ...brushRect,
-        x1: clamp(brushRect.x1 + dx, panel.x, panel.x + panel.width),
-        y1: clamp(brushRect.y1 + dy, panel.y, panel.y + panel.height),
-      };
+      brushRect = nudgeBrushEnd(brushRect, dx, dy, panel);
       reducer.dispatch({
         type: "move-area",
         point: { x: brushRect.x1, y: brushRect.y1 },
@@ -1531,15 +1529,9 @@
     ) {
       event.preventDefault();
       const anchor =
-        inspection?.focus.anchor ??
-        (() => {
-          const panel = model?.scene.panels[0];
-          return panel === undefined
-            ? { x: 0, y: 0 }
-            : { x: panel.x + panel.width / 2, y: panel.y + panel.height / 2 };
-        })();
+        inspection?.focus.anchor ?? panelCenterAnchor(model?.scene.panels[0]);
       if (brushRect === null) {
-        brushRect = { x0: anchor.x, y0: anchor.y, x1: anchor.x, y1: anchor.y };
+        brushRect = brushAtPoint(anchor);
         reducer.dispatch({
           type: "begin-area",
           point: anchor,

--- a/packages/svelte/src/lib/plot-area-brush.ts
+++ b/packages/svelte/src/lib/plot-area-brush.ts
@@ -1,0 +1,64 @@
+import { clamp, normalizedRect, type PanelBounds, type PlotRect } from "./plot-geometry.js";
+import { isBrushTooSmall } from "./plot-interval.js";
+
+/** Live brush corners; may be denormalized while dragging (x0>x1 or y0>y1). */
+export type BrushCorners = {
+  x0: number;
+  y0: number;
+  x1: number;
+  y1: number;
+};
+
+export type PlotPoint = Readonly<{ x: number; y: number }>;
+
+/** Degenerate brush at a single point (pointer-down / first keyboard corner). */
+export function brushAtPoint(point: PlotPoint): BrushCorners {
+  return { x0: point.x, y0: point.y, x1: point.x, y1: point.y };
+}
+
+/** Update the free corner of a brush (pointer move / second-corner down). */
+export function brushWithEnd(corners: BrushCorners, point: PlotPoint): BrushCorners {
+  return { ...corners, x1: point.x, y1: point.y };
+}
+
+/**
+ * Keyboard arrow nudge of the free corner, clamped to panel bounds.
+ * Does not normalize; callers keep denormalized corners until commit.
+ */
+export function nudgeBrushEnd(
+  corners: BrushCorners,
+  dx: number,
+  dy: number,
+  panel: PanelBounds,
+): BrushCorners {
+  return {
+    ...corners,
+    x1: clamp(corners.x1 + dx, panel.x, panel.x + panel.width),
+    y1: clamp(corners.y1 + dy, panel.y, panel.y + panel.height),
+  };
+}
+
+/**
+ * Pointer brush-end evaluation.
+ * Too-small: BOTH spans &lt; min (see isBrushTooSmall); returns normalized corners
+ * for the retained draft (matches existing GGPlot behavior).
+ * Otherwise returns a normalized commit rect.
+ */
+export type PointerBrushEnd =
+  | { readonly kind: "too-small"; readonly corners: PlotRect }
+  | { readonly kind: "commit"; readonly rect: PlotRect };
+
+export function evaluatePointerBrushEnd(
+  corners: BrushCorners,
+  endPoint: PlotPoint,
+): PointerBrushEnd {
+  const rect = normalizedRect(brushWithEnd(corners, endPoint));
+  if (isBrushTooSmall(rect)) return { kind: "too-small", corners: rect };
+  return { kind: "commit", rect };
+}
+
+/** Panel center for keyboard first-corner placement when no inspection anchor. */
+export function panelCenterAnchor(panel: PanelBounds | undefined): PlotPoint {
+  if (panel === undefined) return { x: 0, y: 0 };
+  return { x: panel.x + panel.width / 2, y: panel.y + panel.height / 2 };
+}

--- a/packages/svelte/src/lib/plot-interval-query.ts
+++ b/packages/svelte/src/lib/plot-interval-query.ts
@@ -1,0 +1,97 @@
+import type { RenderModel } from "@ggsvelte/core";
+
+import type { InteractionSource, IntervalSelection } from "./interaction.js";
+import {
+  expandIntervalQuery,
+  panelDataDomains,
+  type PanelBounds,
+  type PlotRect,
+} from "./plot-geometry.js";
+import {
+  intervalSelectionFromRows,
+  lineageRowIndexesFromCandidates,
+  type IntervalDomain,
+  type SelectAreaMode,
+} from "./plot-interval.js";
+
+/**
+ * Narrow scene surface for interval query: one panel's geometry/scales plus
+ * candidate → lineage → row resolution. Hosts map RenderModel into this view.
+ */
+export type IntervalQueryScene = {
+  /** First panel, or null when the plot has no panels. */
+  readonly panel: (PanelBounds & { readonly id: string | null }) | null;
+  /** True when the plot has exactly one panel (domain invert is allowed). */
+  readonly singlePanel: boolean;
+  readonly flip: boolean;
+  readonly scales: Pick<RenderModel["scales"], "x" | "y">;
+  /** Candidates intersecting an already-expanded plot-px query rect. */
+  queryCandidates(expanded: PlotRect): readonly { readonly lineage: number }[];
+  lineageKeys(lineageId: number): Iterable<number>;
+};
+
+export type ResolveIntervalQueryPartsInput = {
+  readonly pixels: PlotRect;
+  readonly mode: SelectAreaMode;
+  readonly scene: IntervalQueryScene | null;
+};
+
+/**
+ * Expand the brush by select mode, collect lineage rows, invert domains when
+ * a single panel is present. Empty/null scene yields empty keys and domain.
+ */
+export function resolveIntervalQueryParts(input: ResolveIntervalQueryPartsInput): {
+  readonly rowIndexes: Set<number>;
+  readonly panelId: string | null;
+  readonly invertedDomain: IntervalDomain;
+} {
+  const scene = input.scene;
+  if (scene === null || scene.panel === null) {
+    return {
+      rowIndexes: new Set(),
+      panelId: null,
+      invertedDomain: {},
+    };
+  }
+  const expanded = expandIntervalQuery(input.pixels, scene.panel, input.mode, scene.flip);
+  const candidates = scene.queryCandidates(expanded);
+  const rowIndexes = lineageRowIndexesFromCandidates(candidates, (id) => scene.lineageKeys(id));
+  const invertedDomain = scene.singlePanel
+    ? panelDataDomains(input.pixels, scene.panel, scene.scales, scene.flip)
+    : {};
+  return {
+    rowIndexes,
+    panelId: scene.panel.id,
+    invertedDomain,
+  };
+}
+
+export type BuildIntervalSelectionFromSceneInput = {
+  readonly phase: IntervalSelection["phase"];
+  readonly mode: SelectAreaMode;
+  readonly source: InteractionSource;
+  readonly pixels: PlotRect;
+  readonly scene: IntervalQueryScene | null;
+  readonly keyForRow: (rowIndex: number) => PropertyKey | null;
+};
+
+/** Full interval selection event from normalized pixels + scene adapter. */
+export function buildIntervalSelectionFromScene(
+  input: BuildIntervalSelectionFromSceneInput,
+): IntervalSelection {
+  const parts = resolveIntervalQueryParts({
+    pixels: input.pixels,
+    mode: input.mode,
+    scene: input.scene,
+  });
+  return intervalSelectionFromRows({
+    phase: input.phase,
+    mode: input.mode,
+    panelId: parts.panelId,
+    pixels: input.pixels,
+    source: input.source,
+    rowIndexes: parts.rowIndexes,
+    keyForRow: input.keyForRow,
+    invertedDomain: parts.invertedDomain,
+  });
+}

--- a/packages/svelte/tests/plot-area-brush.test.ts
+++ b/packages/svelte/tests/plot-area-brush.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  brushAtPoint,
+  brushWithEnd,
+  evaluatePointerBrushEnd,
+  nudgeBrushEnd,
+  panelCenterAnchor,
+} from "../src/lib/plot-area-brush.js";
+
+const panel = { x: 10, y: 20, width: 100, height: 50 };
+
+describe("brushAtPoint", () => {
+  it("creates a degenerate brush", () => {
+    expect(brushAtPoint({ x: 3, y: 4 })).toEqual({ x0: 3, y0: 4, x1: 3, y1: 4 });
+  });
+});
+
+describe("brushWithEnd", () => {
+  it("updates only the free corner", () => {
+    expect(brushWithEnd({ x0: 1, y0: 2, x1: 1, y1: 2 }, { x: 9, y: 8 })).toEqual({
+      x0: 1,
+      y0: 2,
+      x1: 9,
+      y1: 8,
+    });
+  });
+});
+
+describe("nudgeBrushEnd", () => {
+  it("clamps the free corner to the panel", () => {
+    const corners = { x0: 50, y0: 40, x1: 50, y1: 40 };
+    expect(nudgeBrushEnd(corners, 1000, 0, panel)).toEqual({
+      x0: 50,
+      y0: 40,
+      x1: 110,
+      y1: 40,
+    });
+    expect(nudgeBrushEnd(corners, 0, -1000, panel)).toEqual({
+      x0: 50,
+      y0: 40,
+      x1: 50,
+      y1: 20,
+    });
+  });
+
+  it("applies finite steps without normalizing", () => {
+    // reverse-direction free corner stays denormalized
+    expect(nudgeBrushEnd({ x0: 50, y0: 40, x1: 50, y1: 40 }, -5, 3, panel)).toEqual({
+      x0: 50,
+      y0: 40,
+      x1: 45,
+      y1: 43,
+    });
+  });
+});
+
+describe("evaluatePointerBrushEnd", () => {
+  it("keeps a normalized draft when both spans are under the min", () => {
+    const result = evaluatePointerBrushEnd({ x0: 10, y0: 10, x1: 10, y1: 10 }, { x: 12, y: 12 });
+    expect(result).toEqual({
+      kind: "too-small",
+      corners: { x0: 10, y0: 10, x1: 12, y1: 12 },
+    });
+  });
+
+  it("normalizes reverse brushes on commit", () => {
+    const result = evaluatePointerBrushEnd({ x0: 20, y0: 30, x1: 20, y1: 30 }, { x: 5, y: 8 });
+    expect(result).toEqual({
+      kind: "commit",
+      rect: { x0: 5, y0: 8, x1: 20, y1: 30 },
+    });
+  });
+
+  it("commits when only one axis is thin (existing min-size rule)", () => {
+    const result = evaluatePointerBrushEnd({ x0: 0, y0: 0, x1: 0, y1: 0 }, { x: 10, y: 1 });
+    expect(result.kind).toBe("commit");
+  });
+});
+
+describe("panelCenterAnchor", () => {
+  it("uses panel center or origin when missing", () => {
+    const missing: Parameters<typeof panelCenterAnchor>[0] = undefined;
+    expect(panelCenterAnchor(missing)).toEqual({ x: 0, y: 0 });
+    expect(panelCenterAnchor(panel)).toEqual({ x: 60, y: 45 });
+  });
+});

--- a/packages/svelte/tests/plot-interval-query.test.ts
+++ b/packages/svelte/tests/plot-interval-query.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildIntervalSelectionFromScene,
+  resolveIntervalQueryParts,
+  type IntervalQueryScene,
+} from "../src/lib/plot-interval-query.js";
+
+function scene(partial: {
+  panel?: IntervalQueryScene["panel"];
+  singlePanel?: boolean;
+  flip?: boolean;
+  candidates?: readonly { lineage: number; x0: number; y0: number; x1: number; y1: number }[];
+  lineage?: Record<number, number[]>;
+}): IntervalQueryScene {
+  const panel =
+    partial.panel === undefined ? { x: 0, y: 0, width: 100, height: 100, id: "p0" } : partial.panel;
+  const candidates = partial.candidates ?? [];
+  const lineage = partial.lineage ?? { 1: [10, 11], 2: [11, 12] };
+  const flip = partial.flip ?? false;
+  return {
+    panel,
+    singlePanel: partial.singlePanel ?? true,
+    flip,
+    scales: {
+      x: {
+        type: "linear",
+        invert: (t: number) => (flip ? 1 - t : t) * 10,
+      },
+      y: {
+        type: "linear",
+        invert: (t: number) => (flip ? t : 1 - t) * 20,
+      },
+    } as IntervalQueryScene["scales"],
+    queryCandidates(expanded) {
+      // Production uses the hit index; tests approximate with axis-aligned bounds.
+      return candidates
+        .filter(
+          (c) =>
+            c.x1 >= expanded.x0 &&
+            c.x0 <= expanded.x1 &&
+            c.y1 >= expanded.y0 &&
+            c.y0 <= expanded.y1,
+        )
+        .map((c) => ({ lineage: c.lineage }));
+    },
+    lineageKeys(id) {
+      return lineage[id] ?? [];
+    },
+  };
+}
+
+describe("resolveIntervalQueryParts", () => {
+  it("returns empty parts when scene or panel is missing", () => {
+    expect(
+      resolveIntervalQueryParts({
+        pixels: { x0: 0, y0: 0, x1: 10, y1: 10 },
+        mode: "xy",
+        scene: null,
+      }),
+    ).toEqual({ rowIndexes: new Set(), panelId: null, invertedDomain: {} });
+
+    expect(
+      resolveIntervalQueryParts({
+        pixels: { x0: 0, y0: 0, x1: 10, y1: 10 },
+        mode: "xy",
+        scene: scene({ panel: null }),
+      }),
+    ).toEqual({ rowIndexes: new Set(), panelId: null, invertedDomain: {} });
+  });
+
+  it("unions lineage rows for candidates in the expanded query", () => {
+    const parts = resolveIntervalQueryParts({
+      pixels: { x0: 10, y0: 10, x1: 40, y1: 40 },
+      mode: "xy",
+      scene: scene({
+        candidates: [
+          { lineage: 1, x0: 15, y0: 15, x1: 16, y1: 16 },
+          { lineage: 2, x0: 20, y0: 20, x1: 21, y1: 21 },
+          { lineage: 1, x0: 90, y0: 90, x1: 91, y1: 91 }, // outside
+        ],
+      }),
+    });
+    expect([...parts.rowIndexes]).toEqual(expect.arrayContaining([10, 11, 12]));
+    expect(parts.rowIndexes.size).toBe(3);
+    expect(parts.panelId).toBe("p0");
+  });
+
+  it("x-mode expands the orthogonal axis so y-position is ignored", () => {
+    // Candidate far in y but inside x span of a thin brush should still match in x-mode.
+    const parts = resolveIntervalQueryParts({
+      pixels: { x0: 10, y0: 50, x1: 30, y1: 51 },
+      mode: "x",
+      scene: scene({
+        candidates: [{ lineage: 1, x0: 20, y0: 5, x1: 21, y1: 6 }],
+      }),
+    });
+    expect([...parts.rowIndexes]).toEqual([10, 11]);
+  });
+
+  it("skips domain invert when not single-panel", () => {
+    const parts = resolveIntervalQueryParts({
+      pixels: { x0: 0, y0: 0, x1: 50, y1: 50 },
+      mode: "xy",
+      scene: scene({ singlePanel: false }),
+    });
+    expect(parts.invertedDomain).toEqual({});
+  });
+});
+
+describe("buildIntervalSelectionFromScene", () => {
+  it("builds a frozen end event with mode-filtered domain and keys", () => {
+    const event = buildIntervalSelectionFromScene({
+      phase: "end",
+      mode: "x",
+      source: "pointer",
+      pixels: { x0: 0, y0: 0, x1: 50, y1: 50 },
+      scene: scene({
+        candidates: [{ lineage: 1, x0: 10, y0: 10, x1: 11, y1: 11 }],
+      }),
+      keyForRow: (rowIndex) => (rowIndex === 11 ? null : `r${String(rowIndex)}`),
+    });
+    expect(event.phase).toBe("end");
+    expect(event.mode).toBe("x");
+    expect(event.panelId).toBe("p0");
+    expect(event.keys).toEqual(["r10"]);
+    expect(event.lineageCount).toBe(2);
+    expect(event.domain.x).toBeDefined();
+    expect(event.domain.y).toBeUndefined();
+    expect(Object.isFrozen(event)).toBe(true);
+  });
+
+  it("preserves start phase with empty scene", () => {
+    const event = buildIntervalSelectionFromScene({
+      phase: "start",
+      mode: "xy",
+      source: "keyboard",
+      pixels: { x0: 1, y0: 2, x1: 3, y1: 4 },
+      scene: null,
+      keyForRow: () => "k",
+    });
+    expect(event).toMatchObject({
+      phase: "start",
+      keys: [],
+      lineageCount: 0,
+      panelId: null,
+      source: "keyboard",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Extract brush corner geometry into `plot-area-brush.ts` (`brushAtPoint`, `brushWithEnd`, `nudgeBrushEnd`, `evaluatePointerBrushEnd`, `panelCenterAnchor`) with unit tests.
- Extract interval selection scene query into `plot-interval-query.ts` (`resolveIntervalQueryParts`, `buildIntervalSelectionFromScene`) — expand → lineage rows → domain invert — with mocked scene characterization tests.
- Wire `GGPlot` area pointer/keyboard paths through those helpers; **keep** `brushRect` / `committedInterval` and the reducer area FSM in the component (single host owner — no dual session/reducer draft state).

## Why

Follow-up to #51. Interval pure assembly was still mixed into GGPlot gesture handlers. A full area-session factory was considered and rejected after review: the reducer already owns discrete area lifecycle, so a second brush authority would diverge. This PR extracts the pure geometry + query seams with test coverage and leaves lifecycle ownership where it is today.

## Test plan

- [x] `plot-area-brush` unit tests
- [x] `plot-interval-query` unit tests
- [x] Full `packages/svelte` browser suite (804) + SSR (3)
- [x] `bun run check` / `check:svelte`
- [x] `bun run lint:type-aware`
- [x] `bun run knip`
- [x] Independent Codex pre-PR review: no P1/P2 findings