### PR TITLE
fix: audit manual AT alias commit ranges for runtime edits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          # Full history: pre-push parity runs manual-AT alias commit-range audits.
+          fetch-depth: 0
           persist-credentials: false
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,8 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          # Full history: manual-AT alias records audit releaseCommit ranges.
+          fetch-depth: 0
           persist-credentials: false
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:

--- a/docs/accessibility/manual-at/README.md
+++ b/docs/accessibility/manual-at/README.md
@@ -32,6 +32,9 @@ For a patch release that changes only packaging, documentation, or release
 automation, `records/v<release>.json` may instead use
 `record-alias.schema.json` to inherit an earlier record in the same major/minor
 line. The alias must identify the release commit, declare that runtime behavior
-did not change, and explain why the inherited matrix remains applicable. Any
-runtime or interaction change requires a new complete record; an alias must
+did not change, and explain why the inherited matrix remains applicable. The
+schema test resolves that commit range against the inherited record's
+`testedCommit`, requires the base to be an ancestor of the release tip, and
+rejects substantive edits under `packages/svelte/src/` or `packages/core/src/`.
+Any runtime or interaction change requires a new complete record; an alias must
 never be used to represent unperformed manual testing as new evidence.

--- a/docs/accessibility/manual-at/README.md
+++ b/docs/accessibility/manual-at/README.md
@@ -34,7 +34,9 @@ automation, `records/v<release>.json` may instead use
 line. The alias must identify the release commit, declare that runtime behavior
 did not change, and explain why the inherited matrix remains applicable. The
 schema test resolves that commit range against the inherited record's
-`testedCommit`, requires the base to be an ancestor of the release tip, and
-rejects substantive edits under `packages/svelte/src/` or `packages/core/src/`.
-Any runtime or interaction change requires a new complete record; an alias must
-never be used to represent unperformed manual testing as new evidence.
+`testedCommit`, requires the base to be an ancestor of the release tip, checks
+that `@ggsvelte/svelte` at `releaseCommit` matches the alias release version,
+and rejects substantive (non-documentation) edits under `packages/svelte/src/`
+or `packages/core/src/`, including binary assets. Any runtime or interaction
+change requires a new complete record; an alias must never be used to represent
+unperformed manual testing as new evidence.

--- a/packages/spec/tests/manual-at-alias-audit.test.ts
+++ b/packages/spec/tests/manual-at-alias-audit.test.ts
@@ -32,9 +32,9 @@ describe("manual AT alias commit audit", () => {
     const base = "7f95673c2c72ddfd10329acc3195f62ef8ecea87";
     const head = "68f29f80b22b91d301378b4e6e17d2abd7b093ec";
     expect(findSubstantiveRuntimePaths(repoRoot, base, head)).toEqual([]);
-    expect(() =>
-      auditAliasCommitRange({ repoRoot, baseCommit: base, releaseCommit: head }),
-    ).not.toThrow();
+    expect(() => {
+      auditAliasCommitRange({ repoRoot, baseCommit: base, releaseCommit: head });
+    }).not.toThrow();
   });
 
   it("rejects a commit range that substantively edits runtime sources", () => {
@@ -43,12 +43,12 @@ describe("manual AT alias commit audit", () => {
     const withRuntime = "1fc7b4d0847b5c9664806b4dd40c7db8e306a2fa";
     const offenders = findSubstantiveRuntimePaths(repoRoot, packagingTip, withRuntime);
     expect(offenders.some((path) => path.includes("interaction"))).toBe(true);
-    expect(() =>
+    expect(() => {
       auditAliasCommitRange({
         repoRoot,
         baseCommit: packagingTip,
         releaseCommit: withRuntime,
-      }),
-    ).toThrow(/requires a complete record/);
+      });
+    }).toThrow(/requires a complete record/);
   });
 });

--- a/packages/spec/tests/manual-at-alias-audit.test.ts
+++ b/packages/spec/tests/manual-at-alias-audit.test.ts
@@ -3,8 +3,11 @@ import { join } from "node:path";
 
 import {
   auditAliasCommitRange,
+  diffTextIsSubstantive,
   findSubstantiveRuntimePaths,
   isRuntimeBehaviorPath,
+  isSkippableCommentLine,
+  packageVersionAtCommit,
   runtimeBehaviorPaths,
 } from "./manual-at-alias-audit.ts";
 
@@ -27,14 +30,66 @@ describe("manual AT alias commit audit", () => {
     ).toEqual(["packages/svelte/src/lib/interaction.ts", "packages/core/src/theme.ts"]);
   });
 
+  it("does not treat CSS universal-selector edits as JSDoc noise", () => {
+    expect(isSkippableCommentLine(" * inherited matrix remains applicable")).toBe(true);
+    expect(isSkippableCommentLine(" *")).toBe(true);
+    expect(isSkippableCommentLine(" // re-export surface")).toBe(true);
+    expect(isSkippableCommentLine(" * { pointer-events: none; }")).toBe(false);
+    expect(isSkippableCommentLine("*.mark { opacity: 0.4; }")).toBe(false);
+    expect(
+      diffTextIsSubstantive(`diff --git a/x.svelte b/x.svelte
+--- a/x.svelte
++++ b/x.svelte
+@@ -1 +1 @@
+-* { pointer-events: auto; }
++* { pointer-events: none; }
+`),
+    ).toBe(true);
+    expect(
+      diffTextIsSubstantive(`diff --git a/cli.ts b/cli.ts
+--- a/cli.ts
++++ b/cli.ts
+@@ -1,3 +1,3 @@
+ /**
+- * old package name
++ * new package name
+  */
+`),
+    ).toBe(false);
+    expect(
+      diffTextIsSubstantive(
+        "Binary files a/packages/svelte/src/lib/icon.png and b/packages/svelte/src/lib/icon.png differ\n",
+      ),
+    ).toBe(true);
+  });
+
   it("accepts the packaging-only v0.1.0→v0.1.1 alias range", () => {
     // Inherited testedCommit (v0.1.0) .. releaseCommit (v0.1.1).
     const base = "7f95673c2c72ddfd10329acc3195f62ef8ecea87";
     const head = "68f29f80b22b91d301378b4e6e17d2abd7b093ec";
+    expect(packageVersionAtCommit(repoRoot, head)).toBe("0.1.1");
     expect(findSubstantiveRuntimePaths(repoRoot, base, head)).toEqual([]);
     expect(() => {
-      auditAliasCommitRange({ repoRoot, baseCommit: base, releaseCommit: head });
+      auditAliasCommitRange({
+        repoRoot,
+        baseCommit: base,
+        releaseCommit: head,
+        releaseVersion: "0.1.1",
+      });
     }).not.toThrow();
+  });
+
+  it("rejects a releaseCommit that does not publish the claimed release version", () => {
+    const packagingTip = "68f29f80b22b91d301378b4e6e17d2abd7b093ec";
+    const base = "7f95673c2c72ddfd10329acc3195f62ef8ecea87";
+    expect(() => {
+      auditAliasCommitRange({
+        repoRoot,
+        baseCommit: base,
+        releaseCommit: packagingTip,
+        releaseVersion: "0.1.2",
+      });
+    }).toThrow(/@ggsvelte\/svelte is 0\.1\.1/);
   });
 
   it("rejects a commit range that substantively edits runtime sources", () => {
@@ -43,11 +98,14 @@ describe("manual AT alias commit audit", () => {
     const withRuntime = "1fc7b4d0847b5c9664806b4dd40c7db8e306a2fa";
     const offenders = findSubstantiveRuntimePaths(repoRoot, packagingTip, withRuntime);
     expect(offenders.some((path) => path.includes("interaction"))).toBe(true);
+    // Interaction commit still reports package version 0.1.1, so bind a matching
+    // version and still fail on the runtime path audit.
     expect(() => {
       auditAliasCommitRange({
         repoRoot,
         baseCommit: packagingTip,
         releaseCommit: withRuntime,
+        releaseVersion: packageVersionAtCommit(repoRoot, withRuntime),
       });
     }).toThrow(/requires a complete record/);
   });

--- a/packages/spec/tests/manual-at-alias-audit.test.ts
+++ b/packages/spec/tests/manual-at-alias-audit.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "bun:test";
+import { join } from "node:path";
+
+import {
+  auditAliasCommitRange,
+  findSubstantiveRuntimePaths,
+  isRuntimeBehaviorPath,
+  runtimeBehaviorPaths,
+} from "./manual-at-alias-audit.ts";
+
+const repoRoot = join(import.meta.dir, "..", "..", "..");
+
+describe("manual AT alias commit audit", () => {
+  it("classifies chart and core sources as runtime behavior paths", () => {
+    expect(isRuntimeBehaviorPath("packages/svelte/src/lib/GGPlot.svelte")).toBe(true);
+    expect(isRuntimeBehaviorPath("packages/core/src/pipeline.ts")).toBe(true);
+    expect(isRuntimeBehaviorPath("packages/spec/src/artifact.ts")).toBe(false);
+    expect(isRuntimeBehaviorPath("packages/svelte/package.json")).toBe(false);
+    expect(isRuntimeBehaviorPath("docs/accessibility/manual-at/README.md")).toBe(false);
+    expect(
+      runtimeBehaviorPaths([
+        "packages/svelte/package.json",
+        "packages/svelte/src/lib/interaction.ts",
+        "packages/core/CHANGELOG.md",
+        "packages/core/src/theme.ts",
+      ]),
+    ).toEqual(["packages/svelte/src/lib/interaction.ts", "packages/core/src/theme.ts"]);
+  });
+
+  it("accepts the packaging-only v0.1.0→v0.1.1 alias range", () => {
+    // Inherited testedCommit (v0.1.0) .. releaseCommit (v0.1.1).
+    const base = "7f95673c2c72ddfd10329acc3195f62ef8ecea87";
+    const head = "68f29f80b22b91d301378b4e6e17d2abd7b093ec";
+    expect(findSubstantiveRuntimePaths(repoRoot, base, head)).toEqual([]);
+    expect(() =>
+      auditAliasCommitRange({ repoRoot, baseCommit: base, releaseCommit: head }),
+    ).not.toThrow();
+  });
+
+  it("rejects a commit range that substantively edits runtime sources", () => {
+    // v0.1.1 packaging tip .. linked interaction controller (#43).
+    const packagingTip = "68f29f80b22b91d301378b4e6e17d2abd7b093ec";
+    const withRuntime = "1fc7b4d0847b5c9664806b4dd40c7db8e306a2fa";
+    const offenders = findSubstantiveRuntimePaths(repoRoot, packagingTip, withRuntime);
+    expect(offenders.some((path) => path.includes("interaction"))).toBe(true);
+    expect(() =>
+      auditAliasCommitRange({
+        repoRoot,
+        baseCommit: packagingTip,
+        releaseCommit: withRuntime,
+      }),
+    ).toThrow(/requires a complete record/);
+  });
+});

--- a/packages/spec/tests/manual-at-alias-audit.ts
+++ b/packages/spec/tests/manual-at-alias-audit.ts
@@ -1,0 +1,115 @@
+/**
+ * Audit helpers for manual-AT release evidence aliases.
+ *
+ * An alias may ship without a new AT matrix only when the release commit range
+ * does not touch chart/interaction runtime sources. The boolean
+ * `runtimeBehaviorChanged: false` is necessary but not sufficient.
+ */
+import { spawnSync } from "node:child_process";
+
+/** Paths whose substantive edits require a complete manual AT record. */
+export function isRuntimeBehaviorPath(path: string): boolean {
+  return path.startsWith("packages/svelte/src/") || path.startsWith("packages/core/src/");
+}
+
+export function runtimeBehaviorPaths(paths: readonly string[]): string[] {
+  return paths.filter(isRuntimeBehaviorPath);
+}
+
+function git(
+  repoRoot: string,
+  args: readonly string[],
+): { status: number; stdout: string; stderr: string } {
+  const result = spawnSync("git", args, {
+    cwd: repoRoot,
+    encoding: "utf8",
+    maxBuffer: 16 * 1024 * 1024,
+  });
+  return {
+    status: result.status ?? 1,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+  };
+}
+
+export function assertGitObjectExists(repoRoot: string, sha: string, label: string): void {
+  const result = git(repoRoot, ["cat-file", "-e", `${sha}^{commit}`]);
+  if (result.status !== 0) {
+    throw new Error(`${label} commit ${sha} is not present in this repository`);
+  }
+}
+
+export function assertAncestor(repoRoot: string, ancestor: string, descendant: string): void {
+  const result = git(repoRoot, ["merge-base", "--is-ancestor", ancestor, descendant]);
+  if (result.status !== 0) {
+    throw new Error(
+      `alias base commit ${ancestor} is not an ancestor of release commit ${descendant}`,
+    );
+  }
+}
+
+export function listChangedFiles(repoRoot: string, base: string, head: string): string[] {
+  const result = git(repoRoot, ["diff", "--name-only", `${base}..${head}`]);
+  if (result.status !== 0) {
+    throw new Error(
+      `git diff ${base}..${head} failed: ${result.stderr.trim() || result.stdout.trim()}`,
+    );
+  }
+  return result.stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+
+/** True when the unified diff has non-comment, non-blank added/removed lines. */
+export function hasSubstantiveDiff(
+  repoRoot: string,
+  base: string,
+  head: string,
+  path: string,
+): boolean {
+  const result = git(repoRoot, ["diff", `${base}..${head}`, "--", path]);
+  if (result.status !== 0) {
+    throw new Error(
+      `git diff ${base}..${head} -- ${path} failed: ${result.stderr.trim() || result.stdout.trim()}`,
+    );
+  }
+  for (const line of result.stdout.split("\n")) {
+    if (!(line.startsWith("+") || line.startsWith("-"))) continue;
+    if (line.startsWith("+++") || line.startsWith("---")) continue;
+    const body = line.slice(1).trim();
+    if (body.length === 0) continue;
+    if (body.startsWith("//")) continue;
+    if (body.startsWith("/*") || body.startsWith("*") || body.startsWith("*/")) continue;
+    return true;
+  }
+  return false;
+}
+
+export function findSubstantiveRuntimePaths(
+  repoRoot: string,
+  base: string,
+  head: string,
+  paths: readonly string[] = listChangedFiles(repoRoot, base, head),
+): string[] {
+  return runtimeBehaviorPaths(paths).filter((path) =>
+    hasSubstantiveDiff(repoRoot, base, head, path),
+  );
+}
+
+export function auditAliasCommitRange(input: {
+  repoRoot: string;
+  baseCommit: string;
+  releaseCommit: string;
+}): void {
+  const { repoRoot, baseCommit, releaseCommit } = input;
+  assertGitObjectExists(repoRoot, baseCommit, "inherited tested");
+  assertGitObjectExists(repoRoot, releaseCommit, "alias release");
+  assertAncestor(repoRoot, baseCommit, releaseCommit);
+  const offenders = findSubstantiveRuntimePaths(repoRoot, baseCommit, releaseCommit);
+  if (offenders.length > 0) {
+    throw new Error(
+      `manual AT alias ${releaseCommit} changes runtime sources and requires a complete record: ${offenders.join(", ")}`,
+    );
+  }
+}

--- a/packages/spec/tests/manual-at-alias-audit.ts
+++ b/packages/spec/tests/manual-at-alias-audit.ts
@@ -13,7 +13,7 @@ export function isRuntimeBehaviorPath(path: string): boolean {
 }
 
 export function runtimeBehaviorPaths(paths: readonly string[]): string[] {
-  return paths.filter(isRuntimeBehaviorPath);
+  return paths.filter((path) => isRuntimeBehaviorPath(path));
 }
 
 function git(
@@ -32,14 +32,14 @@ function git(
   };
 }
 
-export function assertGitObjectExists(repoRoot: string, sha: string, label: string): void {
+function assertGitObjectExists(repoRoot: string, sha: string, label: string): void {
   const result = git(repoRoot, ["cat-file", "-e", `${sha}^{commit}`]);
   if (result.status !== 0) {
     throw new Error(`${label} commit ${sha} is not present in this repository`);
   }
 }
 
-export function assertAncestor(repoRoot: string, ancestor: string, descendant: string): void {
+function assertAncestor(repoRoot: string, ancestor: string, descendant: string): void {
   const result = git(repoRoot, ["merge-base", "--is-ancestor", ancestor, descendant]);
   if (result.status !== 0) {
     throw new Error(
@@ -48,7 +48,7 @@ export function assertAncestor(repoRoot: string, ancestor: string, descendant: s
   }
 }
 
-export function listChangedFiles(repoRoot: string, base: string, head: string): string[] {
+function listChangedFiles(repoRoot: string, base: string, head: string): string[] {
   const result = git(repoRoot, ["diff", "--name-only", `${base}..${head}`]);
   if (result.status !== 0) {
     throw new Error(
@@ -62,12 +62,7 @@ export function listChangedFiles(repoRoot: string, base: string, head: string): 
 }
 
 /** True when the unified diff has non-comment, non-blank added/removed lines. */
-export function hasSubstantiveDiff(
-  repoRoot: string,
-  base: string,
-  head: string,
-  path: string,
-): boolean {
+function hasSubstantiveDiff(repoRoot: string, base: string, head: string, path: string): boolean {
   const result = git(repoRoot, ["diff", `${base}..${head}`, "--", path]);
   if (result.status !== 0) {
     throw new Error(

--- a/packages/spec/tests/manual-at-alias-audit.ts
+++ b/packages/spec/tests/manual-at-alias-audit.ts
@@ -16,6 +16,39 @@ export function runtimeBehaviorPaths(paths: readonly string[]): string[] {
   return paths.filter((path) => isRuntimeBehaviorPath(path));
 }
 
+/**
+ * True when a unified (or binary) diff contains non-comment behavior changes.
+ * JSDoc/block-comment noise is ignored; CSS universal selectors and code are not.
+ */
+export function diffTextIsSubstantive(diff: string): boolean {
+  if (diff.includes("Binary files ") || diff.includes("GIT binary patch")) return true;
+
+  for (const line of diff.split("\n")) {
+    if (!(line.startsWith("+") || line.startsWith("-"))) continue;
+    if (line.startsWith("+++") || line.startsWith("---")) continue;
+    if (!isSkippableCommentLine(line.slice(1))) return true;
+  }
+  return false;
+}
+
+/** Lines that are blank or documentation-only (not CSS/code). */
+export function isSkippableCommentLine(body: string): boolean {
+  const trimmed = body.trim();
+  if (trimmed.length === 0) return true;
+  if (trimmed.startsWith("//")) return true;
+  if (trimmed.startsWith("/*")) return true;
+  if (trimmed === "*/" || trimmed.startsWith("*/")) return true;
+  if (!trimmed.startsWith("*")) return false;
+
+  // JSDoc middle lines are `* text` / lone `*`. CSS universal selectors look like
+  // `* {…}`, `*.class`, `*#id`, `*:hover`, `*, div`, `*[attr]`.
+  const afterStar = trimmed.slice(1).trimStart();
+  if (afterStar.length === 0) return true;
+  if (afterStar.startsWith("/")) return true; // */
+  if (/^[{.,#:[\]]/.test(afterStar)) return false;
+  return true;
+}
+
 function git(
   repoRoot: string,
   args: readonly string[],
@@ -69,16 +102,25 @@ function hasSubstantiveDiff(repoRoot: string, base: string, head: string, path: 
       `git diff ${base}..${head} -- ${path} failed: ${result.stderr.trim() || result.stdout.trim()}`,
     );
   }
-  for (const line of result.stdout.split("\n")) {
-    if (!(line.startsWith("+") || line.startsWith("-"))) continue;
-    if (line.startsWith("+++") || line.startsWith("---")) continue;
-    const body = line.slice(1).trim();
-    if (body.length === 0) continue;
-    if (body.startsWith("//")) continue;
-    if (body.startsWith("/*") || body.startsWith("*") || body.startsWith("*/")) continue;
-    return true;
+  return diffTextIsSubstantive(result.stdout);
+}
+
+export function packageVersionAtCommit(
+  repoRoot: string,
+  commit: string,
+  packageJsonPath = "packages/svelte/package.json",
+): string {
+  const result = git(repoRoot, ["show", `${commit}:${packageJsonPath}`]);
+  if (result.status !== 0) {
+    throw new Error(
+      `cannot read ${packageJsonPath} at ${commit}: ${result.stderr.trim() || result.stdout.trim()}`,
+    );
   }
-  return false;
+  const parsed = JSON.parse(result.stdout) as { version?: unknown };
+  if (typeof parsed.version !== "string" || parsed.version.length === 0) {
+    throw new Error(`${packageJsonPath} at ${commit} has no version field`);
+  }
+  return parsed.version;
 }
 
 export function findSubstantiveRuntimePaths(
@@ -96,11 +138,20 @@ export function auditAliasCommitRange(input: {
   repoRoot: string;
   baseCommit: string;
   releaseCommit: string;
+  releaseVersion: string;
 }): void {
-  const { repoRoot, baseCommit, releaseCommit } = input;
+  const { repoRoot, baseCommit, releaseCommit, releaseVersion } = input;
   assertGitObjectExists(repoRoot, baseCommit, "inherited tested");
   assertGitObjectExists(repoRoot, releaseCommit, "alias release");
   assertAncestor(repoRoot, baseCommit, releaseCommit);
+
+  const versionAtTip = packageVersionAtCommit(repoRoot, releaseCommit);
+  if (versionAtTip !== releaseVersion) {
+    throw new Error(
+      `alias release ${releaseVersion} points at commit ${releaseCommit} where @ggsvelte/svelte is ${versionAtTip}`,
+    );
+  }
+
   const offenders = findSubstantiveRuntimePaths(repoRoot, baseCommit, releaseCommit);
   if (offenders.length > 0) {
     throw new Error(

--- a/packages/spec/tests/manual-at-schema.test.ts
+++ b/packages/spec/tests/manual-at-schema.test.ts
@@ -4,6 +4,8 @@ import { basename, join } from "node:path";
 
 import { Ajv2020 } from "ajv/dist/2020.js";
 
+import { auditAliasCommitRange } from "./manual-at-alias-audit.ts";
+
 interface Observation {
   id: string;
   observed: string;
@@ -42,6 +44,7 @@ interface AcceptedIssue {
 
 interface ReleaseRecord {
   release: string;
+  testedCommit: string;
   acceptedIssues: AcceptedIssue[];
   runs: Run[];
 }
@@ -387,7 +390,14 @@ function validateReleaseEvidence(
   ).toBe(true);
   const nextResolving = new Set(resolving).add(evidence.release);
   const inherited = JSON.parse(readFileSync(inheritedFile, "utf8")) as ReleaseRecord | ReleaseAlias;
-  return validateReleaseEvidence(inheritedFile, inherited, nextResolving);
+  const resolved = validateReleaseEvidence(inheritedFile, inherited, nextResolving);
+  const repoRoot = join(manualAtDirectory, "..", "..", "..");
+  auditAliasCommitRange({
+    repoRoot,
+    baseCommit: resolved.testedCommit,
+    releaseCommit: evidence.releaseCommit,
+  });
+  return resolved;
 }
 
 describe("manual assistive-technology evidence schema", () => {

--- a/packages/spec/tests/manual-at-schema.test.ts
+++ b/packages/spec/tests/manual-at-schema.test.ts
@@ -396,6 +396,7 @@ function validateReleaseEvidence(
     repoRoot,
     baseCommit: resolved.testedCommit,
     releaseCommit: evidence.releaseCommit,
+    releaseVersion: evidence.release,
   });
   return resolved;
 }


### PR DESCRIPTION
## Summary

Follow-up for unrebutted post-merge Codex finding on #42 (P2: audit alias diffs before accepting inherited AT evidence).

Aliases only required `runtimeBehaviorChanged: false` and version shape; `releaseCommit` was never resolved or compared to the inherited `testedCommit`. A false packaging-only claim would still pass the release gate.

### Changes
- Resolve alias `releaseCommit` and inherited `testedCommit` in git
- Require the base commit to be an ancestor of the release tip
- Reject substantive (non-comment) diffs under `packages/svelte/src/` or `packages/core/src/`
- CI `unit` job uses `fetch-depth: 0` so history is available
- Document the automated check in the manual-AT README

### Tests
- `bun test packages/spec/tests/manual-at-alias-audit.test.ts packages/spec/tests/manual-at-schema.test.ts` (8 pass)

## Parent finding
Codex on #42: *Audit alias diffs before accepting inherited AT evidence* — when a patch claims no runtime change but edits interaction/runtime code, CI still accepted the alias.

## Verification evidence
- Unit: local `bun test` on the new audit helpers + existing schema gate (packaging-only v0.1.1 still passes; interaction controller range is rejected)
- Pre-push: type-aware lint, knip, package tests green