### PR TITLE
refactor(svelte): extract pure legend-focus helpers from GGPlot

### DIFF
--- a/packages/svelte/src/lib/GGPlot.svelte
+++ b/packages/svelte/src/lib/GGPlot.svelte
@@ -59,7 +59,6 @@
   } from "@ggsvelte/core";
   import {
     buildInteractionMasks,
-    legendValueEqual,
     planStrata,
     runPipeline,
     sceneLabel,
@@ -157,8 +156,19 @@
     resolveBrushZoomDomains,
     sanitizePartialZoomDomains,
   } from "./plot-zoom.js";
+  import {
+    buildInteractiveLegendEntries,
+    buildLegendEntryKeyIndex,
+    clampLegendRovingIndex,
+    findLegendPressedIdentity,
+    keysForLegendEntry,
+    legendInteractionSource,
+    moveLegendRovingIndex,
+    samePropertyKeySet,
+    type LegendEntryAction,
+    type LegendEntryIdentity,
+  } from "./plot-legend-focus.js";
   import SceneView from "./SceneView.svelte";
-  import type { LegendEntryAction, LegendEntryIdentity } from "./Legend.svelte";
   import Tooltip from "./Tooltip.svelte";
   import ToolRail from "./ToolRail.svelte";
 
@@ -922,66 +932,30 @@
 
   const legendEntryKeyIndex: ReadonlyMap<string, readonly PropertyKey[]> =
     $derived.by(() => {
-      const index = new Map<string, PropertyKey[]>();
-      if (model === null) return index;
-      for (const sceneLegend of model.scene.legends) {
-        if (sceneLegend.type !== "discrete") continue;
-        for (
-          let entryIndex = 0;
-          entryIndex < sceneLegend.entries.length;
-          entryIndex++
-        )
-          index.set(`${sceneLegend.scale}:${String(entryIndex)}`, []);
-      }
-      const visited = new Set<string>();
-      for (let id = 0; id < model.candidates.size; id++) {
-        const candidate = model.candidates.candidate(id);
-        if (candidate === null) continue;
-        for (const sceneLegend of model.scene.legends) {
-          if (sceneLegend.type !== "discrete") continue;
-          const field = model.layerFields[candidate.layerIndex]?.find(
-            (mapped) =>
-              mapped.channel === sceneLegend.scale && mapped.source !== "stat",
-          )?.field;
-          if (field === undefined) continue;
-          const sourceRows = new Set(model.lineage.keys(candidate.lineage));
-          if (candidate.rowIndex !== null) sourceRows.add(candidate.rowIndex);
-          for (const rowIndex of sourceRows) {
-            const visit = `${sceneLegend.scale}:${String(candidate.layerIndex)}:${field}:${String(rowIndex)}`;
-            if (visited.has(visit)) continue;
-            visited.add(visit);
-            const row = model.row(rowIndex);
-            const key = semanticKeys.keys.get(rowIndex);
-            if (row === null || key === null || key === undefined) continue;
-            const entryIndex = sceneLegend.entries.findIndex((entry) =>
-              legendValueEqual(entry.value, row[field]),
-            );
-            if (entryIndex < 0) continue;
-            index.get(`${sceneLegend.scale}:${String(entryIndex)}`)?.push(key);
+      if (model === null) return new Map<string, readonly PropertyKey[]>();
+      const current = model;
+      return buildLegendEntryKeyIndex({
+        legends: current.scene.legends,
+        candidates: function* () {
+          for (let id = 0; id < current.candidates.size; id++) {
+            const candidate = current.candidates.candidate(id);
+            if (candidate === null) continue;
+            yield {
+              layerIndex: candidate.layerIndex,
+              lineage: candidate.lineage,
+              rowIndex: candidate.rowIndex,
+            };
           }
-        }
-      }
-      return new Map(
-        [...index].map(([identity, keys]) => [
-          identity,
-          Object.freeze([...new Set(keys)]),
-        ]),
-      );
+        },
+        layerFields: (layerIndex) => current.layerFields[layerIndex],
+        lineageKeys: (lineageId) => current.lineage.keys(lineageId),
+        row: (rowIndex) => current.row(rowIndex),
+        semanticKey: (rowIndex) => semanticKeys.keys.get(rowIndex),
+      });
     });
 
   function keysForLegend(action: LegendEntryAction): readonly PropertyKey[] {
-    return (
-      legendEntryKeyIndex.get(
-        `${action.identity.scale}:${String(action.identity.entryIndex)}`,
-      ) ?? []
-    );
-  }
-
-  function legendSource(
-    source: LegendEntryAction["source"],
-  ): InteractionSource {
-    if (source === "pointer" || source === "touch") return source;
-    return "keyboard";
+    return keysForLegendEntry(legendEntryKeyIndex, action.identity);
   }
 
   function emitLegendFocus(event: LegendFocusEvent<PropertyKey>): void {
@@ -999,7 +973,7 @@
   function previewLegend(action: LegendEntryAction | null): void {
     if (action === null) {
       if (legendPreview === null) return;
-      const source = legendSource(legendPreview.action.source);
+      const source = legendInteractionSource(legendPreview.action.source);
       legendPreview = null;
       const committed =
         interaction?.emphasized(resolvedInteractionScope) ?? localEmphasisKeys;
@@ -1014,7 +988,7 @@
       type: "legend-focus",
       phase: "change",
       state: "transient",
-      source: legendSource(action.source),
+      source: legendInteractionSource(action.source),
       scale: action.identity.scale as "color" | "fill",
       value: action.entry.value as CellValue,
       label: action.entry.label,
@@ -1056,7 +1030,7 @@
   }
 
   function commitLegend(action: LegendEntryAction): void {
-    const source = legendSource(action.source);
+    const source = legendInteractionSource(action.source);
     if (
       effectiveLegendPressed?.scale === action.identity.scale &&
       effectiveLegendPressed.entryIndex === action.identity.entryIndex
@@ -1131,58 +1105,27 @@
     });
   }
 
-  function sameKeySet(
-    left: readonly PropertyKey[],
-    right: readonly PropertyKey[],
-  ): boolean {
-    if (left.length !== right.length) return false;
-    const values = new Set(right);
-    return left.every((key) => values.has(key));
-  }
+  const interactiveLegendEntries = $derived.by(() => {
+    if (model === null || interactionConfig.legendFocus === null) return [];
+    return buildInteractiveLegendEntries(model.scene.legends);
+  });
 
   const effectiveLegendPressed: LegendEntryIdentity | null = $derived.by(() => {
     const keys =
       interaction?.emphasized(resolvedInteractionScope) ?? localEmphasisKeys;
     if (keys.length === 0 || model === null) return null;
-    if (legendCommitted !== null && sameKeySet(legendCommitted.keys, keys))
-      return legendCommitted.identity;
-    const matches: LegendEntryIdentity[] = [];
-    for (const sceneLegend of model.scene.legends) {
-      if (sceneLegend.type !== "discrete") continue;
-      for (
-        let entryIndex = 0;
-        entryIndex < sceneLegend.entries.length;
-        entryIndex++
-      ) {
-        const entry = sceneLegend.entries[entryIndex]!;
-        const entryKeys = keysForLegend({
-          identity: { scale: sceneLegend.scale, entryIndex },
-          entry,
-          source: "keyboard",
-        });
-        if (sameKeySet(entryKeys, keys))
-          matches.push({ scale: sceneLegend.scale, entryIndex });
-      }
-    }
-    return matches.length === 1 ? matches[0]! : null;
-  });
-
-  const interactiveLegendEntries = $derived.by(() => {
-    if (model === null || interactionConfig.legendFocus === null) return [];
-    return model.scene.legends.flatMap((sceneLegend) =>
-      sceneLegend.type === "discrete"
-        ? sceneLegend.entries.map((entry, entryIndex) => ({
-            legend: sceneLegend,
-            entry,
-            identity: { scale: sceneLegend.scale, entryIndex },
-          }))
-        : [],
-    );
+    // Match against all discrete scene legends (not only interactive targets).
+    return findLegendPressedIdentity({
+      keys,
+      entries: buildInteractiveLegendEntries(model.scene.legends),
+      keyIndex: legendEntryKeyIndex,
+      committed: legendCommitted,
+    });
   });
 
   $effect.pre(() => {
     const count = interactiveLegendEntries.length;
-    const nextIndex = count === 0 ? 0 : Math.min(legendRovingIndex, count - 1);
+    const nextIndex = clampLegendRovingIndex(legendRovingIndex, count);
     const active = document.activeElement;
     const focusedIndex =
       active instanceof HTMLElement &&
@@ -1192,7 +1135,7 @@
         : null;
     if (nextIndex !== legendRovingIndex) legendRovingIndex = nextIndex;
     if (focusedIndex === null || count === 0) return;
-    const returnIndex = Math.min(focusedIndex, count - 1);
+    const returnIndex = clampLegendRovingIndex(focusedIndex, count);
     queueMicrotask(() => {
       root
         ?.querySelector<HTMLElement>(
@@ -1213,12 +1156,8 @@
     const currentKeys =
       current === undefined
         ? []
-        : keysForLegend({
-            identity: current.identity,
-            entry: current.entry,
-            source: "keyboard",
-          });
-    if (sameKeySet(currentKeys, committed.keys)) return;
+        : keysForLegendEntry(legendEntryKeyIndex, current.identity);
+    if (samePropertyKeySet(currentKeys, committed.keys)) return;
 
     legendCommitted = null;
     if (interaction === undefined && localEmphasisKeys.length > 0) {
@@ -1255,14 +1194,11 @@
   }
 
   function moveLegendFocus(index: number, key: string): void {
-    const last = interactiveLegendEntries.length - 1;
-    let next = index;
-    if (key === "ArrowRight" || key === "ArrowDown")
-      next = Math.min(last, index + 1);
-    else if (key === "ArrowLeft" || key === "ArrowUp")
-      next = Math.max(0, index - 1);
-    else if (key === "Home") next = 0;
-    else if (key === "End") next = last;
+    const next = moveLegendRovingIndex(
+      index,
+      key,
+      interactiveLegendEntries.length,
+    );
     legendRovingIndex = next;
     root
       ?.querySelector<HTMLElement>(

--- a/packages/svelte/src/lib/Legend.svelte
+++ b/packages/svelte/src/lib/Legend.svelte
@@ -1,28 +1,12 @@
-<script module lang="ts">
-  import type { SceneLegendEntry } from "@ggsvelte/core";
-
-  /** Stable renderer identity for one entry in one discrete legend. */
-  export interface LegendEntryIdentity {
-    scale: string;
-    entryIndex: number;
-  }
-
-  export type LegendInteractionSource =
-    "pointer" | "touch" | "focus" | "keyboard";
-
-  export interface LegendEntryAction {
-    identity: LegendEntryIdentity;
-    entry: SceneLegendEntry;
-    source: LegendInteractionSource;
-  }
-</script>
-
 <script lang="ts">
   /**
    * One SceneLegend (discrete swatches or continuous ramp), already placed by
    * the layout in plot px. Mirrors renderToSVGString's legend structure (same
    * class names); the gradient id uses $props.id() so several plots on one
    * page never collide.
+   *
+   * Legend interaction types live in plot-legend-focus.ts (pure helpers used
+   * by GGPlot). This component only paints static SVG chrome.
    */
   import type { SceneLegend, ThemeTokens } from "@ggsvelte/core";
   import { LEGEND_ROW_HEIGHT, themeVar } from "@ggsvelte/core";

--- a/packages/svelte/src/lib/plot-legend-focus.ts
+++ b/packages/svelte/src/lib/plot-legend-focus.ts
@@ -1,0 +1,218 @@
+/**
+ * Pure legend-focus helpers for GGPlot.
+ *
+ * Hosts own local/controller emphasis state, DOM handlers, announcements,
+ * and event emission. This module owns identity keying, entry listing,
+ * semantic key indexing, pressed-state resolution, and roving-index math.
+ */
+import type { CellValue, SceneLegend, SceneLegendEntry } from "@ggsvelte/core";
+import { legendValueEqual } from "@ggsvelte/core";
+
+import type { InteractionSource } from "./interaction.js";
+
+/** Stable renderer identity for one entry in one discrete legend. */
+export interface LegendEntryIdentity {
+  scale: string;
+  entryIndex: number;
+}
+
+export type LegendInteractionSource = "pointer" | "touch" | "focus" | "keyboard";
+
+export interface LegendEntryAction {
+  identity: LegendEntryIdentity;
+  entry: SceneLegendEntry;
+  source: LegendInteractionSource;
+}
+
+/** One discrete legend entry flattened for hit targets / roving focus. */
+export interface InteractiveLegendEntry {
+  readonly legend: Extract<SceneLegend, { type: "discrete" }>;
+  readonly entry: SceneLegendEntry;
+  readonly identity: LegendEntryIdentity;
+}
+
+export type LegendMappedField = {
+  readonly channel: string;
+  readonly field: string;
+  readonly source?: "stat";
+};
+
+export type LegendKeyCandidate = {
+  readonly layerIndex: number;
+  readonly lineage: number;
+  readonly rowIndex: number | null;
+};
+
+/**
+ * Narrow adapter for buildLegendEntryKeyIndex.
+ * Hosts map RenderModel + semantic keys into this surface.
+ */
+export type LegendKeyIndexAdapter = {
+  readonly legends: readonly SceneLegend[];
+  /** Candidates in id-ascending order (null candidates already filtered). */
+  candidates(): Iterable<LegendKeyCandidate>;
+  layerFields(layerIndex: number): readonly LegendMappedField[] | undefined;
+  lineageKeys(lineageId: number): Iterable<number>;
+  row(rowIndex: number): Record<string, CellValue> | null;
+  /** Semantic key for a source row; null/undefined rows are skipped. */
+  semanticKey(rowIndex: number): PropertyKey | null | undefined;
+};
+
+/** Map identity to the stable index key used by the entry-key map. */
+export function legendIdentityKey(identity: LegendEntryIdentity): string {
+  return `${identity.scale}:${String(identity.entryIndex)}`;
+}
+
+/**
+ * Flatten discrete scene legends into interactive targets.
+ * Ramp legends are excluded. Order is legend order, then entryIndex order.
+ */
+export function buildInteractiveLegendEntries(
+  legends: readonly SceneLegend[],
+): InteractiveLegendEntry[] {
+  return legends.flatMap((sceneLegend) =>
+    sceneLegend.type === "discrete"
+      ? sceneLegend.entries.map((entry, entryIndex) => ({
+          legend: sceneLegend,
+          entry,
+          identity: { scale: sceneLegend.scale, entryIndex },
+        }))
+      : [],
+  );
+}
+
+/**
+ * Set equality for PropertyKey collections (order-insensitive, duplicate-tolerant).
+ * Distinct Symbols never equal even when descriptions match.
+ */
+export function samePropertyKeySet(
+  left: readonly PropertyKey[],
+  right: readonly PropertyKey[],
+): boolean {
+  const leftSet = new Set(left);
+  const rightSet = new Set(right);
+  if (leftSet.size !== rightSet.size) return false;
+  for (const key of leftSet) if (!rightSet.has(key)) return false;
+  return true;
+}
+
+/** Map a legend interaction source to the public InteractionSource surface. */
+export function legendInteractionSource(source: LegendInteractionSource): InteractionSource {
+  if (source === "pointer" || source === "touch") return source;
+  return "keyboard";
+}
+
+/** Look up frozen semantic keys for a legend entry identity. */
+export function keysForLegendEntry(
+  index: ReadonlyMap<string, readonly PropertyKey[]>,
+  identity: LegendEntryIdentity,
+): readonly PropertyKey[] {
+  return index.get(legendIdentityKey(identity)) ?? [];
+}
+
+/**
+ * Clamp a roving tabindex index into [0, count).
+ * Empty lists return 0 so hosts can store a stable default.
+ */
+export function clampLegendRovingIndex(current: number, count: number): number {
+  if (count <= 0) return 0;
+  if (!Number.isFinite(current)) return 0;
+  return Math.min(Math.max(0, Math.trunc(current)), count - 1);
+}
+
+/**
+ * Non-wrapping roving navigation for Arrow/Home/End.
+ * Unknown keys return the clamped current index. Empty lists return 0.
+ */
+export function moveLegendRovingIndex(current: number, key: string, count: number): number {
+  if (count <= 0) return 0;
+  const last = count - 1;
+  const index = clampLegendRovingIndex(current, count);
+  if (key === "ArrowRight" || key === "ArrowDown") return Math.min(last, index + 1);
+  if (key === "ArrowLeft" || key === "ArrowUp") return Math.max(0, index - 1);
+  if (key === "Home") return 0;
+  if (key === "End") return last;
+  return index;
+}
+
+export type FindLegendPressedIdentityInput = {
+  readonly keys: readonly PropertyKey[];
+  readonly entries: readonly InteractiveLegendEntry[];
+  readonly keyIndex: ReadonlyMap<string, readonly PropertyKey[]>;
+  readonly committed: {
+    readonly identity: LegendEntryIdentity;
+    readonly keys: readonly PropertyKey[];
+  } | null;
+};
+
+/**
+ * Resolve which legend entry should appear pressed.
+ * Committed identity wins when its key set still matches (even if multiple
+ * entries share the same keys). Otherwise require exactly one matching entry.
+ */
+export function findLegendPressedIdentity(
+  input: FindLegendPressedIdentityInput,
+): LegendEntryIdentity | null {
+  if (input.keys.length === 0) return null;
+  if (input.committed !== null && samePropertyKeySet(input.committed.keys, input.keys))
+    return input.committed.identity;
+  const matches: LegendEntryIdentity[] = [];
+  for (const entry of input.entries) {
+    const entryKeys = keysForLegendEntry(input.keyIndex, entry.identity);
+    if (samePropertyKeySet(entryKeys, input.keys)) matches.push(entry.identity);
+  }
+  return matches.length === 1 ? matches[0]! : null;
+}
+
+/**
+ * Build the discrete legend entry → semantic key index.
+ *
+ * Contract (characterizes GGPlot host behavior):
+ * - Pre-seed empty buckets for every discrete entry (unmatched stay []).
+ * - Skip ramp legends and null candidates.
+ * - Map only non-stat fields whose channel equals the legend scale.
+ * - Row membership = lineage row indexes (insertion order) then candidate
+ *   rowIndex if not already present.
+ * - Visit key is scale:layerIndex:field:rowIndex (dedupe repeated candidates).
+ * - Skip null rows and null/undefined semantic keys.
+ * - Match entry values with legendValueEqual (NaN, Date, -0/0).
+ * - Final keys are first-seen unique order, frozen.
+ */
+export function buildLegendEntryKeyIndex(
+  adapter: LegendKeyIndexAdapter,
+): ReadonlyMap<string, readonly PropertyKey[]> {
+  const index = new Map<string, PropertyKey[]>();
+  for (const sceneLegend of adapter.legends) {
+    if (sceneLegend.type !== "discrete") continue;
+    for (let entryIndex = 0; entryIndex < sceneLegend.entries.length; entryIndex++)
+      index.set(legendIdentityKey({ scale: sceneLegend.scale, entryIndex }), []);
+  }
+  const visited = new Set<string>();
+  for (const candidate of adapter.candidates()) {
+    for (const sceneLegend of adapter.legends) {
+      if (sceneLegend.type !== "discrete") continue;
+      const field = adapter
+        .layerFields(candidate.layerIndex)
+        ?.find((mapped) => mapped.channel === sceneLegend.scale && mapped.source !== "stat")?.field;
+      if (field === undefined) continue;
+      const sourceRows = new Set(adapter.lineageKeys(candidate.lineage));
+      if (candidate.rowIndex !== null) sourceRows.add(candidate.rowIndex);
+      for (const rowIndex of sourceRows) {
+        const visit = `${sceneLegend.scale}:${String(candidate.layerIndex)}:${field}:${String(rowIndex)}`;
+        if (visited.has(visit)) continue;
+        visited.add(visit);
+        const row = adapter.row(rowIndex);
+        const key = adapter.semanticKey(rowIndex);
+        if (row === null || key === null || key === undefined) continue;
+        const entryIndex = sceneLegend.entries.findIndex((entry) =>
+          legendValueEqual(entry.value, row[field]),
+        );
+        if (entryIndex < 0) continue;
+        index.get(legendIdentityKey({ scale: sceneLegend.scale, entryIndex }))?.push(key);
+      }
+    }
+  }
+  return new Map(
+    [...index].map(([identity, keys]) => [identity, Object.freeze([...new Set(keys)])]),
+  );
+}

--- a/packages/svelte/src/lib/plot-legend-focus.ts
+++ b/packages/svelte/src/lib/plot-legend-focus.ts
@@ -31,13 +31,13 @@ export interface InteractiveLegendEntry {
   readonly identity: LegendEntryIdentity;
 }
 
-export type LegendMappedField = {
+type LegendMappedField = {
   readonly channel: string;
   readonly field: string;
   readonly source?: "stat";
 };
 
-export type LegendKeyCandidate = {
+type LegendKeyCandidate = {
   readonly layerIndex: number;
   readonly lineage: number;
   readonly rowIndex: number | null;

--- a/packages/svelte/tests/plot-legend-focus.test.ts
+++ b/packages/svelte/tests/plot-legend-focus.test.ts
@@ -1,0 +1,449 @@
+import { describe, expect, it } from "vitest";
+
+import type { SceneLegend } from "@ggsvelte/core";
+
+import {
+  buildInteractiveLegendEntries,
+  buildLegendEntryKeyIndex,
+  clampLegendRovingIndex,
+  findLegendPressedIdentity,
+  keysForLegendEntry,
+  legendIdentityKey,
+  legendInteractionSource,
+  moveLegendRovingIndex,
+  samePropertyKeySet,
+  type InteractiveLegendEntry,
+  type LegendKeyIndexAdapter,
+} from "../src/lib/plot-legend-focus.js";
+
+const discreteFill: SceneLegend = {
+  type: "discrete",
+  scale: "fill",
+  title: "Channel",
+  x: 10,
+  y: 12,
+  width: 124,
+  height: 72,
+  swatchSize: 12,
+  entries: [
+    { value: "web", label: "Web", color: "#123456", y: 18 },
+    { value: "store", label: "Store", color: "#654321", y: 42 },
+  ],
+};
+
+const discreteColor: SceneLegend = {
+  type: "discrete",
+  scale: "color",
+  title: "Tone",
+  x: 200,
+  y: 12,
+  width: 100,
+  height: 48,
+  swatchSize: 12,
+  entries: [{ value: "a", label: "A", color: "#000", y: 18 }],
+};
+
+const ramp: SceneLegend = {
+  type: "ramp",
+  scale: "color",
+  title: "Score",
+  x: 10,
+  y: 12,
+  width: 80,
+  height: 120,
+  rampWidth: 12,
+  rampHeight: 80,
+  stops: [
+    [0, "#000"],
+    [1, "#fff"],
+  ],
+  ticks: [{ y: 0, label: "10" }],
+};
+
+describe("legendIdentityKey", () => {
+  it("joins scale and entryIndex", () => {
+    expect(legendIdentityKey({ scale: "fill", entryIndex: 2 })).toBe("fill:2");
+  });
+});
+
+describe("samePropertyKeySet", () => {
+  it("treats equal membership as equal regardless of order", () => {
+    expect(samePropertyKeySet(["a", "b"], ["b", "a"])).toBe(true);
+  });
+
+  it("treats duplicate-tolerant sets as equal", () => {
+    expect(samePropertyKeySet(["a", "a"], ["a"])).toBe(true);
+    expect(samePropertyKeySet(["a", "a"], ["a", "b"])).toBe(false);
+  });
+
+  it("distinguishes symbols with the same description", () => {
+    const left = Symbol("row");
+    const right = Symbol("row");
+    expect(samePropertyKeySet([left], [right])).toBe(false);
+    expect(samePropertyKeySet([left], [left])).toBe(true);
+  });
+
+  it("returns false for different lengths of unique keys", () => {
+    expect(samePropertyKeySet(["a"], ["a", "b"])).toBe(false);
+  });
+});
+
+describe("legendInteractionSource", () => {
+  it("keeps pointer and touch", () => {
+    expect(legendInteractionSource("pointer")).toBe("pointer");
+    expect(legendInteractionSource("touch")).toBe("touch");
+  });
+
+  it("maps focus and keyboard to keyboard", () => {
+    expect(legendInteractionSource("focus")).toBe("keyboard");
+    expect(legendInteractionSource("keyboard")).toBe("keyboard");
+  });
+});
+
+describe("buildInteractiveLegendEntries", () => {
+  it("lists only discrete entries in legend then entry order", () => {
+    const entries = buildInteractiveLegendEntries([discreteFill, ramp, discreteColor]);
+    expect(entries.map((entry) => legendIdentityKey(entry.identity))).toEqual([
+      "fill:0",
+      "fill:1",
+      "color:0",
+    ]);
+    expect(entries[0]?.entry.label).toBe("Web");
+    expect(entries[2]?.entry.label).toBe("A");
+  });
+
+  it("returns empty for ramp-only legends", () => {
+    expect(buildInteractiveLegendEntries([ramp])).toEqual([]);
+  });
+});
+
+describe("keysForLegendEntry", () => {
+  it("returns frozen keys or empty for missing identities", () => {
+    const index = new Map<string, readonly PropertyKey[]>([["fill:0", Object.freeze(["a", "c"])]]);
+    expect(keysForLegendEntry(index, { scale: "fill", entryIndex: 0 })).toEqual(["a", "c"]);
+    expect(keysForLegendEntry(index, { scale: "fill", entryIndex: 1 })).toEqual([]);
+  });
+});
+
+describe("clampLegendRovingIndex", () => {
+  it("returns 0 for empty lists and non-finite input", () => {
+    expect(clampLegendRovingIndex(3, 0)).toBe(0);
+    expect(clampLegendRovingIndex(Number.NaN, 4)).toBe(0);
+  });
+
+  it("clamps into [0, count)", () => {
+    expect(clampLegendRovingIndex(-2, 4)).toBe(0);
+    expect(clampLegendRovingIndex(1, 4)).toBe(1);
+    expect(clampLegendRovingIndex(99, 4)).toBe(3);
+  });
+});
+
+describe("moveLegendRovingIndex", () => {
+  it("returns 0 for empty lists", () => {
+    expect(moveLegendRovingIndex(0, "ArrowRight", 0)).toBe(0);
+  });
+
+  it("moves without wrapping", () => {
+    expect(moveLegendRovingIndex(0, "ArrowRight", 3)).toBe(1);
+    expect(moveLegendRovingIndex(2, "ArrowRight", 3)).toBe(2);
+    expect(moveLegendRovingIndex(0, "ArrowLeft", 3)).toBe(0);
+    expect(moveLegendRovingIndex(2, "ArrowUp", 3)).toBe(1);
+    expect(moveLegendRovingIndex(1, "ArrowDown", 3)).toBe(2);
+  });
+
+  it("handles Home, End, and unknown keys", () => {
+    expect(moveLegendRovingIndex(2, "Home", 4)).toBe(0);
+    expect(moveLegendRovingIndex(0, "End", 4)).toBe(3);
+    expect(moveLegendRovingIndex(1, "Tab", 4)).toBe(1);
+    expect(moveLegendRovingIndex(99, "Tab", 4)).toBe(3);
+  });
+});
+
+describe("findLegendPressedIdentity", () => {
+  const entries = buildInteractiveLegendEntries([discreteFill, discreteColor]);
+  const keyIndex = new Map<string, readonly PropertyKey[]>([
+    ["fill:0", Object.freeze(["a", "c"])],
+    ["fill:1", Object.freeze(["b"])],
+    ["color:0", Object.freeze(["a", "c"])], // identical key set to fill:0
+  ]);
+
+  it("returns null for empty emphasis", () => {
+    expect(
+      findLegendPressedIdentity({
+        keys: [],
+        entries,
+        keyIndex,
+        committed: null,
+      }),
+    ).toBeNull();
+  });
+
+  it("prefers committed identity when its keys still match", () => {
+    expect(
+      findLegendPressedIdentity({
+        keys: ["c", "a"],
+        entries,
+        keyIndex,
+        committed: {
+          identity: { scale: "fill", entryIndex: 0 },
+          keys: ["a", "c"],
+        },
+      }),
+    ).toEqual({ scale: "fill", entryIndex: 0 });
+  });
+
+  it("returns null when multiple entries match without a committed identity", () => {
+    expect(
+      findLegendPressedIdentity({
+        keys: ["a", "c"],
+        entries,
+        keyIndex,
+        committed: null,
+      }),
+    ).toBeNull();
+  });
+
+  it("returns the unique matching entry for external emphasis", () => {
+    expect(
+      findLegendPressedIdentity({
+        keys: ["b"],
+        entries,
+        keyIndex,
+        committed: null,
+      }),
+    ).toEqual({ scale: "fill", entryIndex: 1 });
+  });
+
+  it("ignores committed identity when its keys no longer match", () => {
+    expect(
+      findLegendPressedIdentity({
+        keys: ["b"],
+        entries,
+        keyIndex,
+        committed: {
+          identity: { scale: "fill", entryIndex: 0 },
+          keys: ["a", "c"],
+        },
+      }),
+    ).toEqual({ scale: "fill", entryIndex: 1 });
+  });
+});
+
+function adapter(partial: {
+  legends?: readonly SceneLegend[];
+  candidates?: readonly {
+    layerIndex: number;
+    lineage: number;
+    rowIndex: number | null;
+  }[];
+  fields?: Record<number, readonly { channel: string; field: string; source?: "stat" }[]>;
+  lineages?: Record<number, readonly number[]>;
+  rows?: Record<number, Record<string, unknown> | null>;
+  keys?: Record<number, PropertyKey | null | undefined>;
+}): LegendKeyIndexAdapter {
+  const candidates = partial.candidates ?? [];
+  const fields = partial.fields ?? {};
+  const lineages = partial.lineages ?? {};
+  const rows = partial.rows ?? {};
+  const keys = partial.keys ?? {};
+  return {
+    legends: partial.legends ?? [discreteFill],
+    candidates: () => candidates,
+    layerFields: (layerIndex) => fields[layerIndex],
+    lineageKeys: (lineageId) => lineages[lineageId] ?? [],
+    row: (rowIndex) => (rows[rowIndex] as Record<string, never> | null) ?? null,
+    semanticKey: (rowIndex) => keys[rowIndex],
+  };
+}
+
+describe("buildLegendEntryKeyIndex", () => {
+  it("pre-seeds empty buckets for discrete entries and ignores ramps", () => {
+    const index = buildLegendEntryKeyIndex(
+      adapter({ legends: [discreteFill, ramp], candidates: [] }),
+    );
+    expect([...index.keys()]).toEqual(["fill:0", "fill:1"]);
+    expect(index.get("fill:0")).toEqual([]);
+    expect(index.get("fill:1")).toEqual([]);
+  });
+
+  it("maps encoded values to first-seen unique semantic keys in lineage order", () => {
+    const index = buildLegendEntryKeyIndex(
+      adapter({
+        candidates: [{ layerIndex: 0, lineage: 1, rowIndex: null }],
+        fields: { 0: [{ channel: "fill", field: "channel" }] },
+        lineages: { 1: [2, 0, 2] },
+        rows: {
+          0: { channel: "web" },
+          2: { channel: "web" },
+        },
+        keys: { 0: "c", 2: "a" },
+      }),
+    );
+    // Set insertion from lineage: 2 then 0; first-seen unique keys preserve that order
+    expect(index.get("fill:0")).toEqual(["a", "c"]);
+    expect(index.get("fill:1")).toEqual([]);
+  });
+
+  it("appends candidate rowIndex after lineage rows when missing", () => {
+    const index = buildLegendEntryKeyIndex(
+      adapter({
+        candidates: [{ layerIndex: 0, lineage: 1, rowIndex: 5 }],
+        fields: { 0: [{ channel: "fill", field: "channel" }] },
+        lineages: { 1: [0] },
+        rows: {
+          0: { channel: "web" },
+          5: { channel: "web" },
+        },
+        keys: { 0: "first", 5: "appended" },
+      }),
+    );
+    expect(index.get("fill:0")).toEqual(["first", "appended"]);
+  });
+
+  it("skips stat mappings, null rows, and null keys", () => {
+    const index = buildLegendEntryKeyIndex(
+      adapter({
+        candidates: [
+          { layerIndex: 0, lineage: 1, rowIndex: null },
+          { layerIndex: 1, lineage: 2, rowIndex: null },
+        ],
+        fields: {
+          0: [{ channel: "fill", field: "channel", source: "stat" }],
+          1: [{ channel: "fill", field: "channel" }],
+        },
+        lineages: { 1: [0], 2: [1, 2, 3] },
+        rows: {
+          1: null,
+          2: { channel: "web" },
+          3: { channel: "web" },
+        },
+        keys: { 1: "x", 2: null, 3: "kept" },
+      }),
+    );
+    expect(index.get("fill:0")).toEqual(["kept"]);
+  });
+
+  it("dedupes repeated candidates for the same scale/layer/field/row", () => {
+    const index = buildLegendEntryKeyIndex(
+      adapter({
+        candidates: [
+          { layerIndex: 0, lineage: 1, rowIndex: 0 },
+          { layerIndex: 0, lineage: 1, rowIndex: 0 },
+        ],
+        fields: { 0: [{ channel: "fill", field: "channel" }] },
+        lineages: { 1: [0] },
+        rows: { 0: { channel: "store" } },
+        keys: { 0: "b" },
+      }),
+    );
+    expect(index.get("fill:1")).toEqual(["b"]);
+    expect(index.get("fill:0")).toEqual([]);
+  });
+
+  it("matches Date, NaN, and -0 via legendValueEqual and isolates scales", () => {
+    const dateLegend: SceneLegend = {
+      type: "discrete",
+      scale: "color",
+      title: "When",
+      x: 0,
+      y: 0,
+      width: 40,
+      height: 40,
+      swatchSize: 12,
+      entries: [
+        { value: new Date("2020-01-01T00:00:00.000Z"), label: "d", color: "#0", y: 0 },
+        { value: Number.NaN, label: "nan", color: "#1", y: 12 },
+        { value: 0, label: "zero", color: "#2", y: 24 },
+      ],
+    };
+    const index = buildLegendEntryKeyIndex(
+      adapter({
+        legends: [discreteFill, dateLegend],
+        candidates: [
+          { layerIndex: 0, lineage: 1, rowIndex: null },
+          { layerIndex: 1, lineage: 2, rowIndex: null },
+        ],
+        fields: {
+          0: [{ channel: "fill", field: "channel" }],
+          1: [{ channel: "color", field: "when" }],
+        },
+        lineages: { 1: [0], 2: [10, 11, 12] },
+        rows: {
+          0: { channel: "store" },
+          10: { when: new Date("2020-01-01T00:00:00.000Z") },
+          11: { when: Number.NaN },
+          12: { when: -0 },
+        },
+        keys: { 0: "fill-store", 10: "date-k", 11: "nan-k", 12: "zero-k" },
+      }),
+    );
+    expect(index.get("fill:1")).toEqual(["fill-store"]);
+    expect(index.get("color:0")).toEqual(["date-k"]);
+    expect(index.get("color:1")).toEqual(["nan-k"]);
+    expect(index.get("color:2")).toEqual(["zero-k"]);
+    // fill scale must not absorb color keys
+    expect(index.get("fill:0")).toEqual([]);
+  });
+
+  it("leaves unmatched entry values empty", () => {
+    const index = buildLegendEntryKeyIndex(
+      adapter({
+        candidates: [{ layerIndex: 0, lineage: 1, rowIndex: null }],
+        fields: { 0: [{ channel: "fill", field: "channel" }] },
+        lineages: { 1: [0] },
+        rows: { 0: { channel: "unknown" } },
+        keys: { 0: "orphan" },
+      }),
+    );
+    expect(index.get("fill:0")).toEqual([]);
+    expect(index.get("fill:1")).toEqual([]);
+  });
+
+  it("supports multi-layer membership on the same scale", () => {
+    const index = buildLegendEntryKeyIndex(
+      adapter({
+        candidates: [
+          { layerIndex: 0, lineage: 1, rowIndex: null },
+          { layerIndex: 1, lineage: 2, rowIndex: null },
+        ],
+        fields: {
+          0: [{ channel: "fill", field: "channel" }],
+          1: [{ channel: "fill", field: "channel" }],
+        },
+        lineages: { 1: [0], 2: [1] },
+        rows: {
+          0: { channel: "web" },
+          1: { channel: "web" },
+        },
+        keys: { 0: "layer0", 1: "layer1" },
+      }),
+    );
+    expect(index.get("fill:0")).toEqual(["layer0", "layer1"]);
+  });
+
+  it("preserves Symbol semantic keys", () => {
+    const sym = Symbol("row-a");
+    const index = buildLegendEntryKeyIndex(
+      adapter({
+        candidates: [{ layerIndex: 0, lineage: 1, rowIndex: null }],
+        fields: { 0: [{ channel: "fill", field: "channel" }] },
+        lineages: { 1: [0] },
+        rows: { 0: { channel: "web" } },
+        keys: { 0: sym },
+      }),
+    );
+    expect(index.get("fill:0")).toEqual([sym]);
+  });
+});
+
+describe("InteractiveLegendEntry typing smoke", () => {
+  it("exposes identity and entry for host action builders", () => {
+    const entries: InteractiveLegendEntry[] = buildInteractiveLegendEntries([discreteFill]);
+    const action = {
+      identity: entries[0]!.identity,
+      entry: entries[0]!.entry,
+      source: "keyboard" as const,
+    };
+    expect(action.entry.label).toBe("Web");
+  });
+});

--- a/packages/svelte/tests/plot-legend-focus.test.ts
+++ b/packages/svelte/tests/plot-legend-focus.test.ts
@@ -439,9 +439,12 @@ describe("buildLegendEntryKeyIndex", () => {
 describe("InteractiveLegendEntry typing smoke", () => {
   it("exposes identity and entry for host action builders", () => {
     const entries: InteractiveLegendEntry[] = buildInteractiveLegendEntries([discreteFill]);
+    const first = entries[0];
+    expect(first).toBeDefined();
+    if (first === undefined) return;
     const action = {
-      identity: entries[0]!.identity,
-      entry: entries[0]!.entry,
+      identity: first.identity,
+      entry: first.entry,
       source: "keyboard" as const,
     };
     expect(action.entry.label).toBe("Web");


### PR DESCRIPTION
## Summary

- Extract discrete legend key indexing, pressed-identity resolution, roving navigation, and entry listing from `GGPlot.svelte` into internal `plot-legend-focus.ts`.
- Move legend interaction types out of the static `Legend.svelte` renderer so types live with the pure helpers that own them.
- Keep host state, controller dual-path, DOM handlers, announcements, and event construction in `GGPlot` (behavior-preserving thin wiring).
- Public package surface (`index.ts`) is unchanged.

## Test plan

- [x] Unit tests for pure helpers (`tests/plot-legend-focus.test.ts`): set equality, source mapping, entry listing, roving index, pressed identity precedence, key index ordering/dedupe/nulls/Date/NaN/symbols/multi-scale/multi-layer
- [x] Integration: `legend-focus`, `legend-renderer-mask`, `legend-interaction` (156 tests across chromium/firefox/webkit)
- [x] `bun run check` (svelte-check, 0 errors/warnings)
- [x] Pre-push: type-aware oxlint, knip, package build, bun test
- [ ] CI green on PR

## Notes

Follows the existing pure `plot-*.ts` extraction pattern. DOM-coupled legend handlers (touch/click suppression, focus restoration) intentionally remain in `GGPlot`.