### PR TITLE
refactor(svelte): extract pure capture-surface keyboard decisions

### DIFF
--- a/packages/svelte/src/lib/GGPlot.svelte
+++ b/packages/svelte/src/lib/GGPlot.svelte
@@ -1992,10 +1992,10 @@
         inspectionCoordinator.invalidate();
         brushRect = null;
         if (action.returnToInspect) chooseTool("inspect");
-        return;
+        break;
       }
       case "none":
-        return;
+        break;
     }
   }
 

--- a/packages/svelte/src/lib/GGPlot.svelte
+++ b/packages/svelte/src/lib/GGPlot.svelte
@@ -113,6 +113,7 @@
     panelCenterAnchor,
   } from "./plot-area-brush.js";
   import { frozenZoomDomains, normalizedRect } from "./plot-geometry.js";
+  import { resolveSurfaceKeyAction } from "./plot-surface-keyboard.js";
   import {
     datumLabel as datumLabelFor,
     inspectionLiveText as inspectionLiveTextFor,
@@ -1910,38 +1911,31 @@
   }
 
   function onSurfaceKeyDown(event: KeyboardEvent): void {
-    if (
-      (activeTool === "select-area" || activeTool === "zoom-area") &&
-      event.key.startsWith("Arrow") &&
-      brushRect !== null
-    ) {
-      event.preventDefault();
-      const step = event.shiftKey ? 10 : 1;
-      const panel = inspectionPanel ?? model?.scene.panels[0];
-      if (panel === undefined) return;
-      const dx =
-        event.key === "ArrowLeft"
-          ? -step
-          : event.key === "ArrowRight"
-            ? step
-            : 0;
-      const dy =
-        event.key === "ArrowUp" ? -step : event.key === "ArrowDown" ? step : 0;
-      brushRect = nudgeBrushEnd(brushRect, dx, dy, panel);
-      reducer.dispatch({
-        type: "move-area",
-        point: { x: brushRect.x1, y: brushRect.y1 },
-      });
-      return;
-    }
-    if (
-      (activeTool === "select-area" || activeTool === "zoom-area") &&
-      (event.key === "Enter" || event.key === " ")
-    ) {
-      event.preventDefault();
-      const anchor =
-        inspection?.focus.anchor ?? panelCenterAnchor(model?.scene.panels[0]);
-      if (brushRect === null) {
+    // Decision table is pure (plot-surface-keyboard); this switch owns side
+    // effects only. hasBrushDraft tracks brushRect, not reducer brushing.
+    const { action, preventDefault } = resolveSurfaceKeyAction({
+      key: event.key,
+      shiftKey: event.shiftKey,
+      activeTool,
+      hasBrushDraft: brushRect !== null,
+      hasInspection: inspection !== null,
+      pinEnabled: interactionConfig.inspect?.pin === true,
+    });
+    if (preventDefault) event.preventDefault();
+    switch (action.type) {
+      case "nudge-brush": {
+        const panel = inspectionPanel ?? model?.scene.panels[0];
+        if (panel === undefined || brushRect === null) return;
+        brushRect = nudgeBrushEnd(brushRect, action.dx, action.dy, panel);
+        reducer.dispatch({
+          type: "move-area",
+          point: { x: brushRect.x1, y: brushRect.y1 },
+        });
+        return;
+      }
+      case "begin-area": {
+        const anchor =
+          inspection?.focus.anchor ?? panelCenterAnchor(model?.scene.panels[0]);
         brushRect = brushAtPoint(anchor);
         reducer.dispatch({
           type: "begin-area",
@@ -1949,7 +1943,10 @@
           panelId: panelId(0),
         });
         announceInteraction("Choose opposite corner.");
-      } else {
+        return;
+      }
+      case "complete-area": {
+        if (brushRect === null) return;
         const rect = normalizedRect(brushRect);
         brushRect = null;
         if (activeTool === "select-area") {
@@ -1960,51 +1957,45 @@
           emitSelection(selection);
         } else applyBrushZoom(rect, "keyboard");
         reducer.dispatch({ type: "cancel-area" });
+        return;
       }
-      return;
-    }
-    if (event.key === "]" || event.key === "[") {
-      event.preventDefault();
-      cycleCoincident(event.key === "]" ? 1 : -1);
-    } else if (event.key.startsWith("Arrow")) {
-      event.preventDefault();
-      navigateDirection(
-        event.key === "ArrowRight" ? 1 : event.key === "ArrowLeft" ? -1 : 0,
-        event.key === "ArrowDown" ? 1 : event.key === "ArrowUp" ? -1 : 0,
-      );
-    } else if (
-      (event.key === "Enter" || event.key === " ") &&
-      activeTool === "point" &&
-      inspection !== null
-    ) {
-      event.preventDefault();
-      togglePointKeys(
-        inspection.focus.key === null
-          ? inspection.focus.sourceKeys
-          : [inspection.focus.key],
-        "keyboard",
-      );
-    } else if (
-      (event.key === "Enter" || event.key === " ") &&
-      inspection !== null &&
-      interactionConfig.inspect?.pin
-    ) {
-      event.preventDefault();
-      toggleInspectionPin("keyboard");
-    } else if (event.key === "Escape") {
-      event.preventDefault();
-      const returnToInspect =
-        brushRect === null &&
-        (activeTool === "select-area" || activeTool === "zoom-area");
-      reducer.dispatch({ type: "escape", source: "keyboard" });
-      if (inspection !== null)
-        emitInspection({ type: "inspect", phase: "clear", source: "keyboard" });
-      inspection = null;
-      inspectionSeed = null;
-      tooltipHovered = false;
-      inspectionCoordinator.invalidate();
-      brushRect = null;
-      if (returnToInspect) chooseTool("inspect");
+      case "cycle-coincident":
+        cycleCoincident(action.delta);
+        return;
+      case "navigate-direction":
+        navigateDirection(action.dx, action.dy);
+        return;
+      case "toggle-point-keys": {
+        if (inspection === null) return;
+        togglePointKeys(
+          inspection.focus.key === null
+            ? inspection.focus.sourceKeys
+            : [inspection.focus.key],
+          "keyboard",
+        );
+        return;
+      }
+      case "toggle-pin":
+        toggleInspectionPin("keyboard");
+        return;
+      case "escape": {
+        reducer.dispatch({ type: "escape", source: "keyboard" });
+        if (inspection !== null)
+          emitInspection({
+            type: "inspect",
+            phase: "clear",
+            source: "keyboard",
+          });
+        inspection = null;
+        inspectionSeed = null;
+        tooltipHovered = false;
+        inspectionCoordinator.invalidate();
+        brushRect = null;
+        if (action.returnToInspect) chooseTool("inspect");
+        return;
+      }
+      case "none":
+        return;
     }
   }
 

--- a/packages/svelte/src/lib/plot-surface-keyboard.ts
+++ b/packages/svelte/src/lib/plot-surface-keyboard.ts
@@ -1,0 +1,108 @@
+import type { InteractionTool } from "./interaction.js";
+
+/**
+ * Capture-surface keyboard decision input. `hasBrushDraft` mirrors
+ * `brushRect !== null` in GGPlot — distinct from reducer `brushing`, which can
+ * diverge when the draft corners and area machine are out of sync.
+ */
+export type SurfaceKeyboardInput = {
+  readonly key: string;
+  readonly shiftKey: boolean;
+  readonly activeTool: InteractionTool;
+  /** True when a brush draft corner exists (`brushRect !== null`). */
+  readonly hasBrushDraft: boolean;
+  readonly hasInspection: boolean;
+  readonly pinEnabled: boolean;
+};
+
+export type SurfaceKeyAction =
+  | { readonly type: "nudge-brush"; readonly dx: number; readonly dy: number }
+  | { readonly type: "begin-area" }
+  | { readonly type: "complete-area" }
+  | { readonly type: "cycle-coincident"; readonly delta: 1 | -1 }
+  | {
+      readonly type: "navigate-direction";
+      readonly dx: number;
+      readonly dy: number;
+    }
+  | { readonly type: "toggle-point-keys" }
+  | { readonly type: "toggle-pin" }
+  | { readonly type: "escape"; readonly returnToInspect: boolean }
+  | { readonly type: "none" };
+
+export type SurfaceKeyResolution = {
+  readonly action: SurfaceKeyAction;
+  readonly preventDefault: boolean;
+};
+
+const isAreaTool = (tool: InteractionTool): tool is "select-area" | "zoom-area" =>
+  tool === "select-area" || tool === "zoom-area";
+
+/**
+ * Pure decision table for the plot capture-surface `keydown` handler.
+ * Preserves existing priority: area draft arrows → area Enter/Space →
+ * coincident cycle → inspect arrows → point toggle → pin → Escape.
+ * Callers own side effects (brush mutation, inspection, tool changes).
+ */
+export function resolveSurfaceKeyAction(input: SurfaceKeyboardInput): SurfaceKeyResolution {
+  const { key, shiftKey, activeTool, hasBrushDraft, hasInspection, pinEnabled } = input;
+  const area = isAreaTool(activeTool);
+
+  if (area && key.startsWith("Arrow") && hasBrushDraft) {
+    const step = shiftKey ? 10 : 1;
+    const dx = key === "ArrowLeft" ? -step : key === "ArrowRight" ? step : 0;
+    const dy = key === "ArrowUp" ? -step : key === "ArrowDown" ? step : 0;
+    return {
+      preventDefault: true,
+      action: { type: "nudge-brush", dx, dy },
+    };
+  }
+
+  if (area && (key === "Enter" || key === " ")) {
+    return {
+      preventDefault: true,
+      action: { type: hasBrushDraft ? "complete-area" : "begin-area" },
+    };
+  }
+
+  if (key === "]" || key === "[") {
+    return {
+      preventDefault: true,
+      action: {
+        type: "cycle-coincident",
+        delta: key === "]" ? 1 : -1,
+      },
+    };
+  }
+
+  if (key.startsWith("Arrow")) {
+    return {
+      preventDefault: true,
+      action: {
+        type: "navigate-direction",
+        dx: key === "ArrowRight" ? 1 : key === "ArrowLeft" ? -1 : 0,
+        dy: key === "ArrowDown" ? 1 : key === "ArrowUp" ? -1 : 0,
+      },
+    };
+  }
+
+  if ((key === "Enter" || key === " ") && activeTool === "point" && hasInspection) {
+    return { preventDefault: true, action: { type: "toggle-point-keys" } };
+  }
+
+  if ((key === "Enter" || key === " ") && hasInspection && pinEnabled) {
+    return { preventDefault: true, action: { type: "toggle-pin" } };
+  }
+
+  if (key === "Escape") {
+    return {
+      preventDefault: true,
+      action: {
+        type: "escape",
+        returnToInspect: !hasBrushDraft && area,
+      },
+    };
+  }
+
+  return { preventDefault: false, action: { type: "none" } };
+}

--- a/packages/svelte/src/lib/plot-surface-keyboard.ts
+++ b/packages/svelte/src/lib/plot-surface-keyboard.ts
@@ -15,7 +15,7 @@ export type SurfaceKeyboardInput = {
   readonly pinEnabled: boolean;
 };
 
-export type SurfaceKeyAction =
+type SurfaceKeyAction =
   | { readonly type: "nudge-brush"; readonly dx: number; readonly dy: number }
   | { readonly type: "begin-area" }
   | { readonly type: "complete-area" }
@@ -30,7 +30,7 @@ export type SurfaceKeyAction =
   | { readonly type: "escape"; readonly returnToInspect: boolean }
   | { readonly type: "none" };
 
-export type SurfaceKeyResolution = {
+type SurfaceKeyResolution = {
   readonly action: SurfaceKeyAction;
   readonly preventDefault: boolean;
 };

--- a/packages/svelte/tests/plot-surface-keyboard.test.ts
+++ b/packages/svelte/tests/plot-surface-keyboard.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it } from "vitest";
+
+import type { InteractionTool } from "../src/lib/interaction.js";
+import {
+  resolveSurfaceKeyAction,
+  type SurfaceKeyboardInput,
+} from "../src/lib/plot-surface-keyboard.js";
+
+const base = (
+  overrides: Partial<SurfaceKeyboardInput> & Pick<SurfaceKeyboardInput, "key" | "activeTool">,
+): SurfaceKeyboardInput => ({
+  shiftKey: false,
+  hasBrushDraft: false,
+  hasInspection: false,
+  pinEnabled: false,
+  ...overrides,
+});
+
+describe("resolveSurfaceKeyAction", () => {
+  describe("area tools with brush draft", () => {
+    it.each(["select-area", "zoom-area"] as const)(
+      "%s Arrow keys nudge the free corner (shift steps by 10)",
+      (tool) => {
+        expect(
+          resolveSurfaceKeyAction(
+            base({ key: "ArrowRight", activeTool: tool, hasBrushDraft: true }),
+          ),
+        ).toEqual({
+          preventDefault: true,
+          action: { type: "nudge-brush", dx: 1, dy: 0 },
+        });
+        expect(
+          resolveSurfaceKeyAction(
+            base({
+              key: "ArrowUp",
+              shiftKey: true,
+              activeTool: tool,
+              hasBrushDraft: true,
+            }),
+          ),
+        ).toEqual({
+          preventDefault: true,
+          action: { type: "nudge-brush", dx: 0, dy: -10 },
+        });
+      },
+    );
+
+    it("preserves startsWith('Arrow') for nonstandard keys (zero deltas)", () => {
+      expect(
+        resolveSurfaceKeyAction(
+          base({
+            key: "ArrowDiagonal",
+            activeTool: "select-area",
+            hasBrushDraft: true,
+          }),
+        ),
+      ).toEqual({
+        preventDefault: true,
+        action: { type: "nudge-brush", dx: 0, dy: 0 },
+      });
+    });
+
+    it("area Enter/Space with draft completes the brush", () => {
+      expect(
+        resolveSurfaceKeyAction(
+          base({
+            key: "Enter",
+            activeTool: "select-area",
+            hasBrushDraft: true,
+            hasInspection: true,
+            pinEnabled: true,
+          }),
+        ),
+      ).toEqual({
+        preventDefault: true,
+        action: { type: "complete-area" },
+      });
+      expect(
+        resolveSurfaceKeyAction(base({ key: " ", activeTool: "zoom-area", hasBrushDraft: true })),
+      ).toEqual({
+        preventDefault: true,
+        action: { type: "complete-area" },
+      });
+    });
+  });
+
+  describe("area tools without draft", () => {
+    it("Enter/Space begins an area brush", () => {
+      expect(resolveSurfaceKeyAction(base({ key: "Enter", activeTool: "select-area" }))).toEqual({
+        preventDefault: true,
+        action: { type: "begin-area" },
+      });
+    });
+
+    it("Arrow without draft falls through to inspection navigation", () => {
+      expect(resolveSurfaceKeyAction(base({ key: "ArrowLeft", activeTool: "zoom-area" }))).toEqual({
+        preventDefault: true,
+        action: { type: "navigate-direction", dx: -1, dy: 0 },
+      });
+    });
+  });
+
+  describe("inspection navigation", () => {
+    it("cycles coincident hits with [ and ]", () => {
+      expect(resolveSurfaceKeyAction(base({ key: "]", activeTool: "inspect" }))).toEqual({
+        preventDefault: true,
+        action: { type: "cycle-coincident", delta: 1 },
+      });
+      expect(resolveSurfaceKeyAction(base({ key: "[", activeTool: "point" }))).toEqual({
+        preventDefault: true,
+        action: { type: "cycle-coincident", delta: -1 },
+      });
+    });
+
+    it("maps Arrow keys to navigation deltas", () => {
+      expect(resolveSurfaceKeyAction(base({ key: "ArrowDown", activeTool: "inspect" }))).toEqual({
+        preventDefault: true,
+        action: { type: "navigate-direction", dx: 0, dy: 1 },
+      });
+    });
+  });
+
+  describe("Enter / Space priority", () => {
+    it("point tool + inspection toggles point keys (wins over pin)", () => {
+      expect(
+        resolveSurfaceKeyAction(
+          base({
+            key: "Enter",
+            activeTool: "point",
+            hasInspection: true,
+            pinEnabled: true,
+          }),
+        ),
+      ).toEqual({
+        preventDefault: true,
+        action: { type: "toggle-point-keys" },
+      });
+    });
+
+    it("inspect tool + pin toggles pin when inspection is active", () => {
+      expect(
+        resolveSurfaceKeyAction(
+          base({
+            key: " ",
+            activeTool: "inspect",
+            hasInspection: true,
+            pinEnabled: true,
+          }),
+        ),
+      ).toEqual({
+        preventDefault: true,
+        action: { type: "toggle-pin" },
+      });
+    });
+
+    it("Enter without inspection is a no-op even when pin is enabled", () => {
+      expect(
+        resolveSurfaceKeyAction(
+          base({
+            key: "Enter",
+            activeTool: "inspect",
+            hasInspection: false,
+            pinEnabled: true,
+          }),
+        ),
+      ).toEqual({ preventDefault: false, action: { type: "none" } });
+    });
+
+    it("area Enter wins over point/pin semantics", () => {
+      // activeTool is area; hasInspection/pin would not matter
+      expect(
+        resolveSurfaceKeyAction(
+          base({
+            key: "Enter",
+            activeTool: "select-area",
+            hasBrushDraft: false,
+            hasInspection: true,
+            pinEnabled: true,
+          }),
+        ).action.type,
+      ).toBe("begin-area");
+    });
+  });
+
+  describe("Escape", () => {
+    it("returns to inspect when area tool has no draft", () => {
+      expect(resolveSurfaceKeyAction(base({ key: "Escape", activeTool: "select-area" }))).toEqual({
+        preventDefault: true,
+        action: { type: "escape", returnToInspect: true },
+      });
+    });
+
+    it("does not return to inspect when a brush draft is active", () => {
+      expect(
+        resolveSurfaceKeyAction(
+          base({
+            key: "Escape",
+            activeTool: "zoom-area",
+            hasBrushDraft: true,
+          }),
+        ),
+      ).toEqual({
+        preventDefault: true,
+        action: { type: "escape", returnToInspect: false },
+      });
+    });
+
+    it("does not return to inspect for non-area tools", () => {
+      expect(resolveSurfaceKeyAction(base({ key: "Escape", activeTool: "inspect" }))).toEqual({
+        preventDefault: true,
+        action: { type: "escape", returnToInspect: false },
+      });
+    });
+  });
+
+  describe("unrelated keys", () => {
+    it("leaves non-interaction keys unhandled", () => {
+      for (const key of ["a", "Tab", "F1", "Meta"] as const) {
+        expect(resolveSurfaceKeyAction(base({ key, activeTool: "inspect" }))).toEqual({
+          preventDefault: false,
+          action: { type: "none" },
+        });
+      }
+    });
+  });
+
+  describe("tools matrix smoke", () => {
+    const tools: InteractionTool[] = ["inspect", "point", "select-area", "zoom-area"];
+    it("never throws for common keys across tools", () => {
+      for (const activeTool of tools) {
+        for (const key of ["ArrowLeft", "Enter", " ", "Escape", "[", "]", "x"]) {
+          expect(() =>
+            resolveSurfaceKeyAction(
+              base({
+                key,
+                activeTool,
+                hasBrushDraft: true,
+                hasInspection: true,
+                pinEnabled: true,
+              }),
+            ),
+          ).not.toThrow();
+        }
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Extract GGPlot's capture-surface `keydown` decision table into `plot-surface-keyboard.ts` (`resolveSurfaceKeyAction`).
- GGPlot's handler now only executes side effects for the resolved action (brush, inspect, pin, Escape).
- Add unit coverage for action priority: area draft arrows, begin/complete area, point vs pin Enter, Escape return-to-inspect, and `startsWith("Arrow")` quirks.

This continues the pure-helper extraction pattern used for pointer, zoom, legend-focus, and interval modules. Public GGPlot API is unchanged.

## Test plan

- [x] `bun run test:browser -- tests/plot-surface-keyboard.test.ts` (17 tests × 3 browsers)
- [x] Interaction/keyboard suites: `interaction`, `interaction-regressions`, `r0-evidence`, `final-evidence`, `presentation`, `plot-interval`, `release-matrix`
- [x] `bun run test:ssr`
- [x] `bun run check` in `packages/svelte`
- [x] Pre-push gates (oxlint type-aware, knip, package build)