### PR TITLE
fix: readable dark-theme linked-views controls (#44)

### DIFF
--- a/examples/interaction/legend-focus/Example.svelte
+++ b/examples/interaction/legend-focus/Example.svelte
@@ -95,7 +95,7 @@
   .status,
   .summary {
     margin: 0;
-    color: var(--text, #17202a);
+    color: var(--fg, #17202a);
     font: 0.86rem/1.4 var(--gg-font-family, system-ui, sans-serif);
   }
 

--- a/examples/interaction/linked-views/Example.svelte
+++ b/examples/interaction/linked-views/Example.svelte
@@ -178,7 +178,7 @@
     justify-content: space-between;
     gap: 1rem;
     padding: 1rem 1.1rem;
-    border: 1px solid color-mix(in srgb, var(--text, #17202a) 16%, transparent);
+    border: 1px solid color-mix(in srgb, var(--fg, #17202a) 16%, transparent);
     border-radius: 0.7rem;
     background: color-mix(in srgb, var(--surface, white) 94%, #287271 6%);
   }
@@ -189,7 +189,7 @@
   }
 
   .eyebrow {
-    color: var(--text, #17202a);
+    color: var(--fg, #17202a);
     font: 650 0.78rem/1.2 var(--gg-font-family, system-ui, sans-serif);
     letter-spacing: 0.05em;
     text-transform: uppercase;
@@ -211,10 +211,10 @@
   button {
     min-height: 2.25rem;
     padding: 0.42rem 0.72rem;
-    border: 1px solid color-mix(in srgb, var(--text, #17202a) 26%, transparent);
+    border: 1px solid color-mix(in srgb, var(--fg, #17202a) 26%, transparent);
     border-radius: 0.42rem;
     background: var(--surface, white);
-    color: var(--text, #17202a);
+    color: var(--fg, #17202a);
     font: 600 0.78rem/1.2 var(--gg-font-family, system-ui, sans-serif);
     cursor: pointer;
   }
@@ -238,7 +238,7 @@
   table {
     width: 100%;
     border-collapse: collapse;
-    color: var(--text, #17202a);
+    color: var(--fg, #17202a);
     font: 0.82rem/1.35 var(--gg-font-family, system-ui, sans-serif);
   }
 
@@ -252,7 +252,7 @@
   td {
     padding: 0.5rem 0.65rem;
     border-bottom: 1px solid
-      color-mix(in srgb, var(--text, #17202a) 12%, transparent);
+      color-mix(in srgb, var(--fg, #17202a) 12%, transparent);
     text-align: left;
   }
 

--- a/scripts/example-theme-tokens.test.ts
+++ b/scripts/example-theme-tokens.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Docs theme tokens live on :root as --fg / --bg / --surface / --muted
+ * (apps/docs/src/app.css). Example chrome that hard-codes var(--text, #17202a)
+ * never resolves --text, so buttons and tables stay near-black in dark theme.
+ *
+ * Regression for the post-merge finding on #44 (linked-views dark baseline).
+ */
+import { describe, expect, it } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOT = join(import.meta.dir, "..");
+const DOCS_CSS = join(ROOT, "apps/docs/src/app.css");
+const INTERACTION_EXAMPLES = join(ROOT, "examples/interaction");
+
+function exampleSvelteSources(): Array<{ id: string; source: string }> {
+  return readdirSync(INTERACTION_EXAMPLES, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => {
+      const path = join(INTERACTION_EXAMPLES, entry.name, "Example.svelte");
+      return { id: `interaction/${entry.name}`, source: readFileSync(path, "utf8") };
+    });
+}
+
+describe("docs theme tokens", () => {
+  it("defines --fg for light and dark themes (not --text)", () => {
+    const css = readFileSync(DOCS_CSS, "utf8");
+    expect(css).toMatch(/:root\s*\{[^}]*--fg\s*:/s);
+    expect(css).toMatch(/:root\[data-theme="dark"\]\s*\{[^}]*--fg\s*:/s);
+    expect(css).not.toMatch(/--text\s*:/);
+  });
+});
+
+describe("interaction example chrome", () => {
+  for (const { id, source } of exampleSvelteSources()) {
+    it(`${id} uses docs --fg (or inherit), never undefined --text`, () => {
+      expect(source).not.toMatch(/var\(\s*--text\b/);
+    });
+  }
+
+  it("linked-views body text and buttons track --fg so dark theme stays readable", () => {
+    const source = readFileSync(
+      join(INTERACTION_EXAMPLES, "linked-views", "Example.svelte"),
+      "utf8",
+    );
+    // Buttons and table inherit the docs foreground token (or inherit body color).
+    expect(source).toMatch(/color:\s*var\(\s*--fg\b/);
+    expect(source).not.toMatch(/color:\s*var\(\s*--text\b/);
+  });
+});

--- a/tests/visual/vr.spec.ts
+++ b/tests/visual/vr.spec.ts
@@ -57,6 +57,9 @@ test("interaction legend focus — committed linked state", async ({ page }) => 
   await firstLegendEntry.click();
   await expect(firstLegendEntry).toHaveAttribute("aria-pressed", "true");
   await expect(page.getByText("3 rows focused")).toBeVisible();
+  // Click can emit a transient preview event before the commit; wait for the
+  // committed status copy so the screenshot cannot race on "previewed here".
+  await expect(page.getByRole("status")).toContainText("pinned across three views");
   // Three SVG points in the first view, then one focused path plus three
   // focused point vertices in the mixed line view. Canvas shares the mask
   // semantics but intentionally exposes no SVG mark nodes to count here.


### PR DESCRIPTION
## Summary

Follow-up for unrebutted post-merge Codex findings on #44.

**Valid (fixed):** Dark linked-views external controls/table used `var(--text, #17202a)`, but docs theme tokens are `--fg` / `--bg` / `--surface` / `--muted` only (`apps/docs/src/app.css`). Undefined `--text` always fell back to near-black, so buttons and table text were unreadable on the dark baseline. Same token mistake fixed in `legend-focus` chrome for consistency.

**Invalid (rebutted on #44):**
- “Wire baselines into a visual test” — on current `main`, `interaction/linked-views` is in `examples/manifest.ts` and `tests/visual/vr.spec.ts` screenshots the full matrix.
- “Clipped point at domain max” — continuous `nice` domains end on the data max (flipper 230); panel clip of marks at domain edges is library scale-edge geometry, not a regression introduced by approving the VR PNGs.

## Test plan

- [x] RED→GREEN: `bun test scripts/example-theme-tokens.test.ts`
- [x] Full scripts suite via pre-push hook
- [ ] After merge / on this PR: maintainer `/approve-visuals` to regenerate `interaction-linked-views-dark.png` (and legend-focus dark if needed) via the pinned VR container — baselines are not hand-committed

## Verification evidence

- Command: `bun test scripts/example-theme-tokens.test.ts`
- Result: 6 pass / 0 fail
- Command: pre-push hook (build + type-aware lint + knip + bun test scripts/spec/core)
- Result: Passed

Parent disposition: #44