### PR TITLE
fix: address post-merge Codex findings from #43

### DIFF
--- a/packages/svelte/src/lib/GGPlot.svelte
+++ b/packages/svelte/src/lib/GGPlot.svelte
@@ -167,8 +167,10 @@
   import {
     applyZoomToSpec,
     buildZoomEvent,
+    filterZoomDomainsByMode,
     resolveBrushZoomDomains,
     sanitizePartialZoomDomains,
+    stableZoomDomains,
   } from "./plot-zoom.js";
   import {
     buildInteractiveLegendEntries,
@@ -311,6 +313,7 @@
       interaction,
       ...(interactionScope !== undefined && { interactionScope }),
       zoom,
+      faceted: assembled?.facet !== undefined,
       ...(datumKey !== undefined && { datumKey }),
       assembled,
     }),
@@ -348,14 +351,25 @@
 
   // ------------------------------------------------------------ zoom respec
   let localZoomDomains = $state<ZoomDomains | null>(null);
+  // Memoize prior bag so selection/emphasis revisions do not retrain zoom.
+  let previousEffectiveZoomDomains: ZoomDomains | null = null;
   const controllerRevision = $derived(interaction?.revision ?? 0);
   const effectiveZoomDomains: ZoomDomains | null = $derived.by(() => {
     void controllerRevision;
-    if (interaction === undefined) return localZoomDomains;
-    const domains = interaction.zoom(resolvedInteractionScope);
-    return domains.x === undefined && domains.y === undefined
-      ? null
-      : (domains as ZoomDomains);
+    let next: ZoomDomains | null;
+    if (interaction === undefined) {
+      next = localZoomDomains;
+    } else {
+      // Gate shared domains by this plot's resolved zoom mode (null when
+      // disabled / faceted-unsupported) so x-only plots ignore y domains.
+      next = filterZoomDomainsByMode(
+        interaction.zoom(resolvedInteractionScope),
+        interactionConfig.zoom?.mode ?? null,
+      );
+    }
+    next = stableZoomDomains(previousEffectiveZoomDomains, next);
+    previousEffectiveZoomDomains = next;
+    return next;
   });
 
   const effectiveSpec: PortableSpec | null = $derived.by(() => {
@@ -671,10 +685,13 @@
       zoomHasSupportedChannel,
     ),
   );
+  const canPublishPointSelection = $derived(
+    interactionConfig.select?.type === "point",
+  );
   const showToolRail = $derived(
     interactive &&
       (availableTools.length > 1 ||
-        effectiveSelectedKeys.length > 0 ||
+        (canPublishPointSelection && effectiveSelectedKeys.length > 0) ||
         committedInterval !== null ||
         effectiveZoomDomains !== null),
   );
@@ -725,7 +742,7 @@
     model === null ? "" : themeTokensToCss(model.scene.theme),
   );
   const rootStyle = $derived(
-    `${hasCanvas || interactive || effectiveEmphasisKeys.length > 0 ? `width:${width === undefined || width === "container" ? "100%" : `${model?.scene.width ?? resolvedWidth}px`};height:${model?.scene.height ?? resolvedHeight}px;` : ""}${themeStyle}` ||
+    `${hasCanvas || interactive || effectiveEmphasisKeys.length > 0 || effectiveSelectedKeys.length > 0 ? `width:${width === undefined || width === "container" ? "100%" : `${model?.scene.width ?? resolvedWidth}px`};height:${model?.scene.height ?? resolvedHeight}px;` : ""}${themeStyle}` ||
       undefined,
   );
   function anchorsForKeys(keys: readonly PropertyKey[]): {
@@ -2132,11 +2149,14 @@
       {emptyPlot}
       narrow={resolvedWidth < 560}
       zoomDomains={effectiveZoomDomains}
-      hasPointSelection={effectiveSelectedKeys.length > 0}
+      hasPointSelection={canPublishPointSelection &&
+        effectiveSelectedKeys.length > 0}
       hasIntervalSelection={committedInterval !== null}
       onChooseTool={chooseTool}
       onResetZoom={() => resetZoom("pointer")}
-      onClearPointSelection={() => clearPointSelection("pointer")}
+      onClearPointSelection={() => {
+        if (canPublishPointSelection) clearPointSelection("pointer");
+      }}
       onClearIntervalSelection={() => clearIntervalSelection("pointer")}
     />
   {/if}
@@ -2263,11 +2283,12 @@
         >
       {/if}
     {/if}
-    {#if !interactive && emphasizedAnchors.length > 0}
+    {#if !interactive && (emphasizedAnchors.length > 0 || selectedAnchors.length > 0)}
       <InteractionOverlay
         width={model.scene.width}
         height={model.scene.height}
         interactive={false}
+        {selectedAnchors}
         {emphasizedAnchors}
       />
     {/if}

--- a/packages/svelte/src/lib/InteractionOverlay.svelte
+++ b/packages/svelte/src/lib/InteractionOverlay.svelte
@@ -107,17 +107,17 @@
       fill="none"
     />
   {/if}
-  {#if interactive}
-    {#each selectedAnchors as anchor, index (index)}
-      <circle
-        class="gg-selected-ring"
-        cx={anchor.x}
-        cy={anchor.y}
-        r="8"
-        fill="none"
-      />
-    {/each}
-  {/if}
+  <!-- Selection rings are presentation of shared controller state; passive
+       consumers (interactive=false) must still show them. -->
+  {#each selectedAnchors as anchor, index (index)}
+    <circle
+      class="gg-selected-ring"
+      cx={anchor.x}
+      cy={anchor.y}
+      r="8"
+      fill="none"
+    />
+  {/each}
   {#each emphasizedAnchors as anchor, index (index)}
     <circle
       class="gg-emphasized-ring"

--- a/packages/svelte/src/lib/plot-assemble.ts
+++ b/packages/svelte/src/lib/plot-assemble.ts
@@ -107,6 +107,11 @@ export type ResolveInteractionScopeInput = {
   readonly interaction: object | null | undefined;
   readonly interactionScope?: PlotInteractionScope;
   readonly zoom?: ZoomInput;
+  /**
+   * When true, zoom is unsupported (same as normalizeInteractionConfig) and
+   * must not force domain scopes — faceted plots use a diagnostic/no-op path.
+   */
+  readonly faceted?: boolean;
   readonly datumKey?: string | number | symbol | ((...args: never[]) => PropertyKey);
   readonly assembled: PortableSpec | null;
 };
@@ -121,8 +126,16 @@ export function resolveInteractionScope(input: ResolveInteractionScopeInput): Pl
       throw new TypeError(
         "GGPlot requires interactionScope when interaction is supplied so unrelated charts cannot share semantic keys or domains accidentally.",
       );
+    // Mirror normalizeInteractionConfig: faceted zoom is disabled with a
+    // diagnostic, so missing x/y scopes must not hard-fail render.
     const zoomMode =
-      input.zoom === true ? "xy" : typeof input.zoom === "object" ? input.zoom.mode : null;
+      input.faceted === true
+        ? null
+        : input.zoom === true
+          ? "xy"
+          : typeof input.zoom === "object"
+            ? input.zoom.mode
+            : null;
     if (zoomMode !== null) {
       if (zoomMode !== "y" && input.interactionScope.x === undefined)
         throw new TypeError(

--- a/packages/svelte/src/lib/plot-zoom.ts
+++ b/packages/svelte/src/lib/plot-zoom.ts
@@ -22,6 +22,76 @@ const zoomScale = (
 });
 
 /**
+ * Restrict controller/shared zoom domains to channels this plot opted into.
+ *
+ * - `mode === null`: plot has no local zoom tool; still apply every controller
+ *   domain present (linked display without publishing zoom tools).
+ * - `mode === "x" | "y" | "xy"`: drop channels the plot did not opt into so an
+ *   x-only plot cannot be rescaled by a shared y domain.
+ *
+ * Returns null when nothing remains to apply.
+ */
+export function filterZoomDomainsByMode(
+  domains:
+    | ContinuousZoomDomains
+    | null
+    | Readonly<{
+        x?: readonly [number, number];
+        y?: readonly [number, number];
+      }>,
+  mode: ZoomMode | null,
+): ContinuousZoomDomains | null {
+  if (domains === null) return null;
+  const takeX = mode === null || mode !== "y";
+  const takeY = mode === null || mode !== "x";
+  const next: ContinuousZoomDomains = {
+    ...(takeX &&
+      domains.x !== undefined && {
+        x: [domains.x[0], domains.x[1]] as [number, number],
+      }),
+    ...(takeY &&
+      domains.y !== undefined && {
+        y: [domains.y[0], domains.y[1]] as [number, number],
+      }),
+  };
+  if (next.x === undefined && next.y === undefined) return null;
+  return next;
+}
+
+function sameZoomChannel(
+  a: readonly [number, number] | undefined,
+  b: readonly [number, number] | undefined,
+): boolean {
+  return (
+    a === b ||
+    (a !== undefined && b !== undefined && Object.is(a[0], b[0]) && Object.is(a[1], b[1]))
+  );
+}
+
+/** Value equality for continuous zoom domain bags (Object.is per endpoint). */
+export function sameZoomDomains(
+  left: ContinuousZoomDomains | null | undefined,
+  right: ContinuousZoomDomains | null | undefined,
+): boolean {
+  if (left === right) return true;
+  if (left === null || left === undefined || right === null || right === undefined) {
+    return (left === null || left === undefined) && (right === null || right === undefined);
+  }
+  return sameZoomChannel(left.x, right.x) && sameZoomChannel(left.y, right.y);
+}
+
+/**
+ * Prefer the previous domain bag when values match so `$derived` identity stays
+ * stable across controller revisions that only change selection/emphasis.
+ */
+export function stableZoomDomains(
+  previous: ContinuousZoomDomains | null,
+  next: ContinuousZoomDomains | null,
+): ContinuousZoomDomains | null {
+  return sameZoomDomains(previous, next) ? previous : next;
+}
+
+/**
  * Merge continuous zoom domains into a portable spec's scales.
  * Returns `spec` by reference when domains are null/empty so callers can
  * keep `$derived` identity stable and avoid pipeline re-runs.

--- a/packages/svelte/tests/controller-integration.test.ts
+++ b/packages/svelte/tests/controller-integration.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import LinkedControllerPlot from "./fixtures/LinkedControllerPlot.svelte";
 import MissingControllerScopePlot from "./fixtures/MissingControllerScopePlot.svelte";
+import PassiveControllerConsumerPlot from "./fixtures/PassiveControllerConsumerPlot.svelte";
 import { expectAccessible } from "./helpers/accessibility.js";
 import { render } from "./helpers/render.js";
 
@@ -110,5 +111,42 @@ describe("linked semantic interaction controller", () => {
     expect(state(container)["rendersOther"]).toBe(beforeRendersOther);
     expect(state(container)["callbacksA"]).toBe("0");
     expect(state(container)["callbacksB"]).toBe("0");
+  });
+
+  it("renders selection rings for passive consumers without Clear selection", async () => {
+    const { container } = render(PassiveControllerConsumerPlot);
+    container.querySelector<HTMLButtonElement>("[data-select-a]")!.click();
+    await until(
+      () => container.querySelectorAll("[data-plot-passive] .gg-selected-ring").length === 1,
+    );
+
+    expect(container.querySelectorAll("[data-plot-publisher] .gg-selected-ring")).toHaveLength(1);
+    expect(container.querySelectorAll("[data-plot-passive] .gg-selected-ring")).toHaveLength(1);
+    // Inspect-only / passive plots must not expose Clear selection for shared state.
+    const clearButtons = [...container.querySelectorAll("button")].filter((button) =>
+      /Clear selection/i.test(button.textContent ?? ""),
+    );
+    expect(clearButtons).toHaveLength(1); // publisher only
+    expect(clearButtons[0]?.closest("[data-plot-publisher]")).not.toBeNull();
+    expect(container.querySelector("[data-plot-passive] .gg-tool-rail")).toBeNull();
+    expect(container.querySelector("[data-plot-inspect-only] .gg-tool-rail")).toBeNull();
+  });
+
+  it("does not retrain zoomed plots when only selection changes", async () => {
+    const { container } = render(PassiveControllerConsumerPlot);
+    const passiveState = () =>
+      container.querySelector<HTMLElement>("[data-passive-state]")!.dataset;
+
+    // Shared zoom respecs the passive consumer once (linked display).
+    container.querySelector<HTMLButtonElement>("[data-zoom-xy]")!.click();
+    await until(() => Number(passiveState()["rendersPassive"]) >= 1);
+    const afterZoomRenders = Number(passiveState()["rendersPassive"]);
+    expect(passiveState()["transitions"]).toBe("1");
+
+    // Selection must not re-trigger the zoom pipeline (stable domain identity).
+    container.querySelector<HTMLButtonElement>("[data-select-after-zoom]")!.click();
+    await until(() => passiveState()["transitions"] === "2");
+    expect(Number(passiveState()["rendersPassive"])).toBe(afterZoomRenders);
+    expect(container.querySelectorAll("[data-plot-passive] .gg-selected-ring")).toHaveLength(1);
   });
 });

--- a/packages/svelte/tests/fixtures/PassiveControllerConsumerPlot.svelte
+++ b/packages/svelte/tests/fixtures/PassiveControllerConsumerPlot.svelte
@@ -1,0 +1,112 @@
+<script lang="ts">
+  import { createPlotInteraction, GGPlot } from "../../src/lib/index.js";
+
+  const scope = { keys: "row-id", x: "x-value", y: "y-value" } as const;
+  const xy = { x: "x", y: "y" } as const;
+  const pointLayers = [{ geom: "point" as const }];
+  const rows = [
+    { id: "a", x: 1, y: 4 },
+    { id: "b", x: 2, y: 2 },
+    { id: "c", x: 3, y: 3 },
+  ];
+  let transitions = $state(0);
+  let rendersPassive = $state(0);
+  const interaction = createPlotInteraction<string>({
+    onchange: () => {
+      transitions += 1;
+    },
+  });
+</script>
+
+<div
+  data-passive-state
+  data-transitions={transitions}
+  data-renders-passive={rendersPassive}
+>
+  <button
+    type="button"
+    data-select-a
+    onclick={() => interaction.setSelection(["a"], { scope })}>Select A</button
+  >
+  <button
+    type="button"
+    data-zoom-xy
+    onclick={() =>
+      interaction.setZoom({ x: [1.2, 2.8], y: [1.5, 3.5] }, { scope })}
+    >Zoom xy</button
+  >
+  <button
+    type="button"
+    data-select-after-zoom
+    onclick={() => interaction.setSelection(["b"], { scope })}
+    >Select B after zoom</button
+  >
+
+  <!-- Publisher: can select points and zoom on both axes. -->
+  <div data-plot-publisher>
+    <GGPlot
+      data={rows}
+      aes={xy}
+      layers={pointLayers}
+      key="id"
+      select="point"
+      zoom={true}
+      {interaction}
+      interactionScope={scope}
+      width={360}
+      height={260}
+      ariaLabel="Publisher plot"
+    />
+  </div>
+
+  <!-- Passive consumer: linked selection only; no select/inspect tools. -->
+  <div data-plot-passive>
+    <GGPlot
+      data={rows}
+      aes={xy}
+      layers={pointLayers}
+      key="id"
+      {interaction}
+      interactionScope={scope}
+      width={360}
+      height={260}
+      ariaLabel="Passive controller consumer"
+      onrender={() => {
+        rendersPassive += 1;
+      }}
+    />
+  </div>
+
+  <!-- X-only zoom consumer: must not adopt shared y domains. -->
+  <div data-plot-x-only>
+    <GGPlot
+      data={rows}
+      aes={xy}
+      layers={pointLayers}
+      key="id"
+      inspect={true}
+      zoom={{ mode: "x" }}
+      {interaction}
+      interactionScope={scope}
+      width={360}
+      height={260}
+      ariaLabel="X-only zoom consumer"
+    />
+  </div>
+
+  <!-- Interactive inspect-only: must not offer Clear selection. -->
+  <div data-plot-inspect-only>
+    <GGPlot
+      data={rows}
+      aes={xy}
+      layers={pointLayers}
+      key="id"
+      inspect={true}
+      {interaction}
+      interactionScope={scope}
+      width={360}
+      height={260}
+      ariaLabel="Inspect-only linked plot"
+    />
+  </div>
+</div>

--- a/packages/svelte/tests/plot-assemble.test.ts
+++ b/packages/svelte/tests/plot-assemble.test.ts
@@ -23,7 +23,10 @@ describe("toLayerInput", () => {
         return aes;
       },
     };
-    expect(toLayerInput(descriptor)).toEqual({ geom: "point", aes: { x: "a" } });
+    expect(toLayerInput(descriptor)).toEqual({
+      geom: "point",
+      aes: { x: "a" },
+    });
     geom = "line";
     aes = undefined;
     expect(toLayerInput(descriptor)).toEqual({ geom: "line" });
@@ -223,6 +226,29 @@ describe("resolveInteractionScope", () => {
         assembled,
       }),
     ).toThrow(/Controlled x zoom requires interactionScope\.x/);
+  });
+
+  it("does not require domain scopes for faceted zoom (unsupported → diagnostic/no-op)", () => {
+    // Faceted interval/zoom is cleared by normalizeInteractionConfig; scope
+    // resolution must not turn that path into a hard render failure.
+    expect(
+      resolveInteractionScope({
+        interaction: {},
+        interactionScope: { keys: "id" },
+        zoom: true,
+        faceted: true,
+        assembled,
+      }),
+    ).toEqual({ keys: "id" });
+    expect(
+      resolveInteractionScope({
+        interaction: {},
+        interactionScope: { keys: "id" },
+        zoom: { mode: "xy" },
+        faceted: true,
+        assembled,
+      }),
+    ).toEqual({ keys: "id" });
   });
 
   it("requires y scope for controlled y zoom", () => {

--- a/packages/svelte/tests/plot-zoom.test.ts
+++ b/packages/svelte/tests/plot-zoom.test.ts
@@ -5,8 +5,11 @@ import type { PortableSpec } from "@ggsvelte/spec";
 import {
   applyZoomToSpec,
   buildZoomEvent,
+  filterZoomDomainsByMode,
   resolveBrushZoomDomains,
+  sameZoomDomains,
   sanitizePartialZoomDomains,
+  stableZoomDomains,
 } from "../src/lib/plot-zoom.js";
 
 const continuousScale = (domain: [number, number]) => {
@@ -24,6 +27,55 @@ const bandScale = {
 };
 
 const panel = { x: 0, y: 0, width: 100, height: 100 };
+
+describe("filterZoomDomainsByMode", () => {
+  const domains = {
+    x: [1, 2] as [number, number],
+    y: [3, 4] as [number, number],
+  };
+
+  it("returns null for empty domains and keeps all channels when mode is null", () => {
+    expect(filterZoomDomainsByMode(null, "xy")).toBeNull();
+    expect(filterZoomDomainsByMode({}, "xy")).toBeNull();
+    // No local zoom tool still displays shared controller domains.
+    expect(filterZoomDomainsByMode(domains, null)).toEqual({
+      x: [1, 2],
+      y: [3, 4],
+    });
+  });
+
+  it("keeps only channels the plot opted into", () => {
+    expect(filterZoomDomainsByMode(domains, "x")).toEqual({ x: [1, 2] });
+    expect(filterZoomDomainsByMode(domains, "y")).toEqual({ y: [3, 4] });
+    expect(filterZoomDomainsByMode(domains, "xy")).toEqual({
+      x: [1, 2],
+      y: [3, 4],
+    });
+  });
+
+  it("drops a mode when the matching channel is absent", () => {
+    expect(filterZoomDomainsByMode({ y: [3, 4] }, "x")).toBeNull();
+    expect(filterZoomDomainsByMode({ x: [1, 2] }, "y")).toBeNull();
+  });
+});
+
+describe("sameZoomDomains / stableZoomDomains", () => {
+  it("compares channel endpoints with Object.is", () => {
+    expect(sameZoomDomains({ x: [1, 2] }, { x: [1, 2] })).toBe(true);
+    expect(sameZoomDomains({ x: [1, 2] }, { x: [1, 3] })).toBe(false);
+    expect(sameZoomDomains(null, null)).toBe(true);
+    expect(sameZoomDomains({ x: [1, 2] }, null)).toBe(false);
+    expect(sameZoomDomains({ x: [-0, 1] }, { x: [0, 1] })).toBe(false);
+  });
+
+  it("reuses the previous bag when values match", () => {
+    const previous = { x: [1, 2] as [number, number] };
+    const next = { x: [1, 2] as [number, number] };
+    expect(stableZoomDomains(previous, next)).toBe(previous);
+    expect(stableZoomDomains(previous, { x: [1, 3] })).toEqual({ x: [1, 3] });
+    expect(stableZoomDomains(previous, null)).toBeNull();
+  });
+});
 
 describe("applyZoomToSpec", () => {
   const base = {


### PR DESCRIPTION
## Summary

Follow-up for unrebutted post-merge Codex findings on #43 (linked interaction controller).

| Finding | Verdict | Fix |
|---------|---------|-----|
| Faceted zoom + controller throws on missing domain scopes | **Valid** | `resolveInteractionScope` treats faceted zoom like `normalizeInteractionConfig` (no domain-scope hard fail) |
| Passive controller consumers draw no selection rings | **Valid** | Selection rings always paint; passive overlay includes `selectedAnchors` |
| Zoom retrains on selection/emphasis revisions | **Valid** | `stableZoomDomains` keeps domain bag identity across non-zoom revisions |
| x-only zoom still applies shared y domains | **Valid** | `filterZoomDomainsByMode` drops non-opted channels (`mode: null` still accepts all for linked display without tools) |
| Inspect-only plots expose Clear selection | **Valid** | Gate Clear / tool-rail selection recovery on `select.type === "point"` |

## Test plan

- [x] `packages/svelte` vitest: plot-assemble, plot-zoom, controller-integration, interaction-* (222 tests green across chromium/firefox/webkit)
- [x] Pre-push: package build, svelte-check, oxlint type-aware, knip, bun unit tests

Parent disposition: comment on #43 after open.