### PR TITLE
refactor(svelte): extract pure legend surface event decisions

### DIFF
--- a/packages/svelte/src/lib/GGPlot.svelte
+++ b/packages/svelte/src/lib/GGPlot.svelte
@@ -120,6 +120,11 @@
     resolvePointerUpAction,
   } from "./plot-surface-pointer.js";
   import {
+    resolveLegendClickAction,
+    resolveLegendKeyAction,
+    resolveLegendPointerUpAction,
+  } from "./plot-legend-surface.js";
+  import {
     datumLabel as datumLabelFor,
     inspectionLiveText as inspectionLiveTextFor,
     markLabel as markLabelFor,
@@ -1205,23 +1210,26 @@
   }
 
   function onLegendKeydown(event: KeyboardEvent, index: number): void {
-    if (
-      event.key === "ArrowRight" ||
-      event.key === "ArrowDown" ||
-      event.key === "ArrowLeft" ||
-      event.key === "ArrowUp" ||
-      event.key === "Home" ||
-      event.key === "End"
-    ) {
-      event.preventDefault();
-      moveLegendFocus(index, event.key);
-    } else if (event.key === "Enter" || event.key === " ") {
-      event.preventDefault();
-      const action = legendAction(index, "keyboard");
-      if (action !== null) commitLegend(action);
-    } else if (event.key === "Escape") {
-      event.preventDefault();
-      clearLegendFocus("keyboard");
+    // Decision table is pure (plot-legend-surface); this switch owns side
+    // effects only. Roving move, commit, and clear stay host-owned.
+    const { action, preventDefault } = resolveLegendKeyAction({
+      key: event.key,
+    });
+    if (preventDefault) event.preventDefault();
+    switch (action.type) {
+      case "move":
+        moveLegendFocus(index, action.key);
+        break;
+      case "commit": {
+        const next = legendAction(index, "keyboard");
+        if (next !== null) commitLegend(next);
+        break;
+      }
+      case "clear":
+        clearLegendFocus("keyboard");
+        break;
+      case "none":
+        break;
     }
   }
 
@@ -1230,23 +1238,44 @@
   }
 
   function onLegendPointerUp(event: PointerEvent, index: number): void {
-    if (event.pointerType !== "touch" || legendTouchIndex !== index) return;
-    legendTouchIndex = -1;
-    suppressLegendClick = true;
-    const action = legendAction(index, "touch");
-    if (action !== null) commitLegend(action);
+    // Pure gate: touch + matching legendTouchIndex. Host always clears the
+    // index and sets suppressLegendClick on touch-commit (exact-once with the
+    // synthetic click). pointercancel clears the index in the template.
+    const resolved = resolveLegendPointerUpAction({
+      pointerType: event.pointerType,
+      index,
+      touchIndex: legendTouchIndex,
+    });
+    switch (resolved.type) {
+      case "touch-commit": {
+        legendTouchIndex = -1;
+        suppressLegendClick = true;
+        const next = legendAction(index, "touch");
+        if (next !== null) commitLegend(next);
+        break;
+      }
+      case "none":
+        break;
+    }
   }
 
   function onLegendClick(event: MouseEvent, index: number): void {
-    if (suppressLegendClick) {
-      suppressLegendClick = false;
-      return;
+    // Pure priority: suppress (after touch) outranks detail-classified commit.
+    // detail === 0 is current source classification (not an a11y guarantee).
+    const resolved = resolveLegendClickAction({
+      suppressClick: suppressLegendClick,
+      detail: event.detail,
+    });
+    switch (resolved.type) {
+      case "suppress":
+        suppressLegendClick = false;
+        break;
+      case "commit": {
+        const next = legendAction(index, resolved.source);
+        if (next !== null) commitLegend(next);
+        break;
+      }
     }
-    const action = legendAction(
-      index,
-      event.detail === 0 ? "keyboard" : "pointer",
-    );
-    if (action !== null) commitLegend(action);
   }
 
   function onLegendBlur(event: FocusEvent): void {

--- a/packages/svelte/src/lib/plot-legend-surface.ts
+++ b/packages/svelte/src/lib/plot-legend-surface.ts
@@ -12,7 +12,7 @@ export type LegendKeyInput = {
   readonly key: string;
 };
 
-export type LegendKeyAction =
+type LegendKeyAction =
   | { readonly type: "move"; readonly key: string }
   | { readonly type: "commit" }
   | { readonly type: "clear" }

--- a/packages/svelte/src/lib/plot-legend-surface.ts
+++ b/packages/svelte/src/lib/plot-legend-surface.ts
@@ -1,0 +1,112 @@
+/**
+ * Pure legend surface event decisions for GGPlot.
+ *
+ * Hosts own DOM handlers, suppress/touch index lifecycle, focus moves,
+ * commitLegend side effects, and announcements. This module owns only
+ * key routing and touch/click coordination priority.
+ */
+
+// ---- keydown ----
+
+export type LegendKeyInput = {
+  readonly key: string;
+};
+
+export type LegendKeyAction =
+  | { readonly type: "move"; readonly key: string }
+  | { readonly type: "commit" }
+  | { readonly type: "clear" }
+  | { readonly type: "none" };
+
+export type LegendKeyResolution = {
+  readonly action: LegendKeyAction;
+  readonly preventDefault: boolean;
+};
+
+const isRovingKey = (key: string): boolean =>
+  key === "ArrowRight" ||
+  key === "ArrowDown" ||
+  key === "ArrowLeft" ||
+  key === "ArrowUp" ||
+  key === "Home" ||
+  key === "End";
+
+/**
+ * Pure decision for a legend target `keydown` handler.
+ * Priority: roving arrows/Home/End → Enter/Space commit → Escape clear → none.
+ * Callers own preventDefault, focus move, commitLegend, and clearLegendFocus.
+ */
+export function resolveLegendKeyAction(input: LegendKeyInput): LegendKeyResolution {
+  const { key } = input;
+
+  if (isRovingKey(key)) {
+    return { preventDefault: true, action: { type: "move", key } };
+  }
+
+  if (key === "Enter" || key === " ") {
+    return { preventDefault: true, action: { type: "commit" } };
+  }
+
+  if (key === "Escape") {
+    return { preventDefault: true, action: { type: "clear" } };
+  }
+
+  return { preventDefault: false, action: { type: "none" } };
+}
+
+// ---- pointer up (touch commit gate) ----
+
+export type LegendPointerUpInput = {
+  readonly pointerType: string;
+  readonly index: number;
+  /** Host `legendTouchIndex` from pointerdown; -1 if none/cancelled. */
+  readonly touchIndex: number;
+};
+
+export type LegendPointerUpAction = { readonly type: "touch-commit" } | { readonly type: "none" };
+
+/**
+ * Pure decision for legend target `pointerup`.
+ * Touch-commit only when pointerType is touch and touchIndex matches index.
+ * Host on touch-commit: clear touchIndex, set suppressLegendClick, then commit.
+ * Host on none: no suppress flag change (mismatched up after cancel stays quiet).
+ *
+ * `legendTouchIndex` is a single host slot (not pointerId-keyed). Multi-touch
+ * is not modeled; cancel resets the slot before this resolver runs.
+ */
+export function resolveLegendPointerUpAction(input: LegendPointerUpInput): LegendPointerUpAction {
+  if (input.pointerType !== "touch") return { type: "none" };
+  if (input.touchIndex !== input.index) return { type: "none" };
+  return { type: "touch-commit" };
+}
+
+// ---- click ----
+
+export type LegendClickInput = {
+  /** Host `suppressLegendClick` after a touch commit. */
+  readonly suppressClick: boolean;
+  /**
+   * MouseEvent.detail classification used by the host today.
+   * detail === 0 → source "keyboard" (also true for some programmatic clicks —
+   * this is current source classification, not an a11y guarantee).
+   */
+  readonly detail: number;
+};
+
+export type LegendClickAction =
+  | { readonly type: "suppress" }
+  | { readonly type: "commit"; readonly source: "keyboard" | "pointer" };
+
+/**
+ * Pure decision for legend target `click`.
+ * Priority: suppressClick → suppress; else commit with detail-classified source.
+ * Host on suppress: clear suppressLegendClick and return (exact-once touch).
+ * Host on commit: legendAction(index, source) + commitLegend when non-null.
+ */
+export function resolveLegendClickAction(input: LegendClickInput): LegendClickAction {
+  if (input.suppressClick) return { type: "suppress" };
+  return {
+    type: "commit",
+    source: input.detail === 0 ? "keyboard" : "pointer",
+  };
+}

--- a/packages/svelte/tests/legend-focus.test.ts
+++ b/packages/svelte/tests/legend-focus.test.ts
@@ -143,9 +143,10 @@ describe("linked legend focus", () => {
   it("commits one touch activation and suppresses its compatibility click", async () => {
     const { container } = render(LinkedLegendFocusPlot);
     await until(() => container.querySelectorAll("[data-plot-a] .gg-legend-target").length === 2);
-    const south = container.querySelectorAll<HTMLButtonElement>(
-      "[data-plot-a] .gg-legend-target",
-    )[1];
+    const targets = [
+      ...container.querySelectorAll<HTMLButtonElement>("[data-plot-a] .gg-legend-target"),
+    ];
+    const [north, south] = targets as [HTMLButtonElement, HTMLButtonElement];
 
     south.dispatchEvent(
       new PointerEvent("pointerdown", { bubbles: true, pointerId: 7, pointerType: "touch" }),
@@ -158,6 +159,12 @@ describe("linked legend focus", () => {
     await until(() => state(container)["emphasized"] === "b");
     expect(state(container)["transitions"]).toBe("1");
     expect(south.getAttribute("aria-pressed")).toBe("true");
+
+    // Suppress must clear: a subsequent real click must still activate.
+    north.dispatchEvent(new MouseEvent("click", { bubbles: true, detail: 1 }));
+    await until(() => state(container)["emphasized"] === "a,c");
+    expect(state(container)["transitions"]).toBe("2");
+    expect(north.getAttribute("aria-pressed")).toBe("true");
   });
 
   it("cancels a touch sequence without committing emphasis", async () => {

--- a/packages/svelte/tests/plot-legend-surface.test.ts
+++ b/packages/svelte/tests/plot-legend-surface.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  resolveLegendClickAction,
+  resolveLegendKeyAction,
+  resolveLegendPointerUpAction,
+  type LegendClickInput,
+  type LegendKeyInput,
+  type LegendPointerUpInput,
+} from "../src/lib/plot-legend-surface.js";
+
+const key = (overrides: Partial<LegendKeyInput> = {}): LegendKeyInput => ({
+  key: "a",
+  ...overrides,
+});
+
+const pointerUp = (overrides: Partial<LegendPointerUpInput> = {}): LegendPointerUpInput => ({
+  pointerType: "touch",
+  index: 1,
+  touchIndex: 1,
+  ...overrides,
+});
+
+const click = (overrides: Partial<LegendClickInput> = {}): LegendClickInput => ({
+  suppressClick: false,
+  detail: 1,
+  ...overrides,
+});
+
+describe("resolveLegendKeyAction", () => {
+  it.each(["ArrowRight", "ArrowDown", "ArrowLeft", "ArrowUp", "Home", "End"] as const)(
+    "routes %s to move with preventDefault",
+    (rovingKey) => {
+      expect(resolveLegendKeyAction(key({ key: rovingKey }))).toEqual({
+        preventDefault: true,
+        action: { type: "move", key: rovingKey },
+      });
+    },
+  );
+
+  it.each(["Enter", " "] as const)("routes %s to commit with preventDefault", (commitKey) => {
+    expect(resolveLegendKeyAction(key({ key: commitKey }))).toEqual({
+      preventDefault: true,
+      action: { type: "commit" },
+    });
+  });
+
+  it("routes Escape to clear with preventDefault", () => {
+    expect(resolveLegendKeyAction(key({ key: "Escape" }))).toEqual({
+      preventDefault: true,
+      action: { type: "clear" },
+    });
+  });
+
+  it("ignores unrelated keys without preventDefault", () => {
+    expect(resolveLegendKeyAction(key({ key: "Tab" }))).toEqual({
+      preventDefault: false,
+      action: { type: "none" },
+    });
+    expect(resolveLegendKeyAction(key({ key: "a" }))).toEqual({
+      preventDefault: false,
+      action: { type: "none" },
+    });
+  });
+});
+
+describe("resolveLegendPointerUpAction", () => {
+  it("commits when touch pointerup matches recorded touch index", () => {
+    expect(resolveLegendPointerUpAction(pointerUp())).toEqual({ type: "touch-commit" });
+  });
+
+  it("returns none when touch index mismatches (stale / other target)", () => {
+    expect(resolveLegendPointerUpAction(pointerUp({ index: 2, touchIndex: 1 }))).toEqual({
+      type: "none",
+    });
+  });
+
+  it("returns none when touch index was cancelled or never set (-1)", () => {
+    expect(resolveLegendPointerUpAction(pointerUp({ touchIndex: -1 }))).toEqual({
+      type: "none",
+    });
+  });
+
+  it("returns none for non-touch pointer types even when index matches", () => {
+    expect(
+      resolveLegendPointerUpAction(pointerUp({ pointerType: "mouse", index: 0, touchIndex: 0 })),
+    ).toEqual({ type: "none" });
+    expect(
+      resolveLegendPointerUpAction(pointerUp({ pointerType: "pen", index: 0, touchIndex: 0 })),
+    ).toEqual({ type: "none" });
+  });
+});
+
+describe("resolveLegendClickAction", () => {
+  it("suppress outranks commit (touch compatibility click)", () => {
+    expect(resolveLegendClickAction(click({ suppressClick: true, detail: 1 }))).toEqual({
+      type: "suppress",
+    });
+    // detail 0 still suppressed — classification does not matter when suppress is set
+    expect(resolveLegendClickAction(click({ suppressClick: true, detail: 0 }))).toEqual({
+      type: "suppress",
+    });
+  });
+
+  it("classifies detail === 0 as keyboard source (current host classification)", () => {
+    expect(resolveLegendClickAction(click({ detail: 0 }))).toEqual({
+      type: "commit",
+      source: "keyboard",
+    });
+  });
+
+  it("classifies detail > 0 as pointer source", () => {
+    expect(resolveLegendClickAction(click({ detail: 1 }))).toEqual({
+      type: "commit",
+      source: "pointer",
+    });
+    expect(resolveLegendClickAction(click({ detail: 2 }))).toEqual({
+      type: "commit",
+      source: "pointer",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Extract pure legend keydown / pointerup / click routing from `GGPlot.svelte` into `plot-legend-surface.ts` so priority can be unit-tested without mounting the plot host.
- Keep host-owned lifecycle: `legendTouchIndex`, `suppressLegendClick`, template `pointercancel`, `legendAction` null no-ops, and `commitLegend` / focus side effects.
- Extend the legend touch browser test to prove the suppress flag clears so a subsequent real click still activates.

## Scope notes

- Does **not** extract commit toggle, clear-control source mapping, or blur (trivial or tightly coupled; blur relatedTarget remains the existing global `[data-gg-legend-target]` match).
- `detail === 0` remains current source classification (keyboard), not an a11y guarantee.

## Test plan

- [x] `bun run test:browser -- tests/plot-legend-surface.test.ts`
- [x] `bun run test:browser -- tests/plot-legend-focus.test.ts tests/legend-focus.test.ts`
- [x] `bun run check` / `bun run test:ssr` in `packages/svelte`
- [x] pre-push knip + package checks