### PR TITLE
refactor(svelte): extract pure pointer-move surface decisions

### DIFF
--- a/packages/svelte/src/lib/GGPlot.svelte
+++ b/packages/svelte/src/lib/GGPlot.svelte
@@ -116,7 +116,9 @@
   import { resolveSurfaceKeyAction } from "./plot-surface-keyboard.js";
   import {
     resolveCaptureClickAction,
+    advanceTouchInspectMoved,
     resolvePointerDownAction,
+    resolvePointerMoveAction,
     resolvePointerUpAction,
   } from "./plot-surface-pointer.js";
   import {
@@ -1555,54 +1557,72 @@
 
   function onPointerMove(event: PointerEvent): void {
     const p = plotPoint(event);
+    // Sticky threshold is pure; host only advances on touch + start set.
     if (event.pointerType === "touch" && touchInspectStart !== null) {
-      touchInspectMoved ||=
-        Math.hypot(p.x - touchInspectStart.x, p.y - touchInspectStart.y) >= 4;
-      if (touchInspectMoved && activeTool === "inspect") {
+      touchInspectMoved = advanceTouchInspectMoved(
+        touchInspectMoved,
+        touchInspectStart,
+        p,
+      );
+    }
+    // Decision table is pure (plot-surface-pointer); this switch owns queues.
+    const action = resolvePointerMoveAction({
+      pointerType: event.pointerType,
+      activeTool,
+      touchInspectMoved,
+      hasTouchInspectStart: touchInspectStart !== null,
+      brushing,
+      hasBrushDraft: brushRect !== null,
+      inspectEnabled: interactionConfig.inspect !== null,
+    });
+    switch (action.type) {
+      case "touch-inspect-drag-cancel":
         queuedPointerInspection = null;
         reducer.cancelScheduledPointer();
         return;
-      }
-    }
-    if (brushing && brushRect !== null) {
-      queuedAreaSource = event.pointerType === "touch" ? "touch" : "pointer";
-      reducer.queuePointer({ type: "move-area", point: p });
-      return;
-    }
-    if (activeTool === "inspect" && interactionConfig.inspect !== null) {
-      const match =
-        model?.candidates.nearest(p.x, p.y, {
-          mode: interactionConfig.inspect.mode,
-          maxDistance: interactionConfig.inspect.maxDistance,
-        }) ?? null;
-      const resolvedHit =
-        match === null
-          ? (hitIndex?.hitTest(p.x, p.y) ?? null)
-          : hitFromCandidate(match);
-      const source = event.pointerType === "touch" ? "touch" : "pointer";
-      queuedPointerInspection = {
-        hit: resolvedHit,
-        source,
-        ...(match !== null && {
-          concreteMode: match.mode,
-          candidate: match,
-        }),
-      };
-      queuedPointerToken = reducer.frameToken();
-      reducer.queuePointer({
-        type: "inspect",
-        candidate:
+      case "queue-area-move":
+        queuedAreaSource = action.source;
+        reducer.queuePointer({ type: "move-area", point: p });
+        return;
+      case "queue-inspect": {
+        const inspectConfig = interactionConfig.inspect;
+        if (inspectConfig === null) return;
+        const match =
+          model?.candidates.nearest(p.x, p.y, {
+            mode: inspectConfig.mode,
+            maxDistance: inspectConfig.maxDistance,
+          }) ?? null;
+        const resolvedHit =
           match === null
-            ? null
-            : {
-                epoch: model?.runId ?? 0,
-                id: match.id,
-                panelId: panelId(match.panelIndex),
-                x: match.x,
-                y: match.y,
-              },
-        source,
-      });
+            ? (hitIndex?.hitTest(p.x, p.y) ?? null)
+            : hitFromCandidate(match);
+        queuedPointerInspection = {
+          hit: resolvedHit,
+          source: action.source,
+          ...(match !== null && {
+            concreteMode: match.mode,
+            candidate: match,
+          }),
+        };
+        queuedPointerToken = reducer.frameToken();
+        reducer.queuePointer({
+          type: "inspect",
+          candidate:
+            match === null
+              ? null
+              : {
+                  epoch: model?.runId ?? 0,
+                  id: match.id,
+                  panelId: panelId(match.panelIndex),
+                  x: match.x,
+                  y: match.y,
+                },
+          source: action.source,
+        });
+        return;
+      }
+      case "none":
+        return;
     }
   }
 

--- a/packages/svelte/src/lib/GGPlot.svelte
+++ b/packages/svelte/src/lib/GGPlot.svelte
@@ -1619,10 +1619,10 @@
                 },
           source: action.source,
         });
-        return;
+        break;
       }
       case "none":
-        return;
+        break;
     }
   }
 

--- a/packages/svelte/src/lib/plot-surface-pointer.ts
+++ b/packages/svelte/src/lib/plot-surface-pointer.ts
@@ -133,3 +133,89 @@ export function resolveCaptureClickAction(input: SurfaceClickInput): SurfaceClic
 
   return { type: "none" };
 }
+
+// ---- pointer move ----
+
+/** Pixel threshold for sticky touch-inspect drag (plotPoint coordinates). */
+export const TOUCH_INSPECT_MOVE_PX = 4;
+
+/**
+ * Sticky OR of touch-inspect drag past threshold in plotPoint coordinates.
+ * Exactly `TOUCH_INSPECT_MOVE_PX` counts as moved (`>=`).
+ * Host calls only when `pointerType === "touch" && touchInspectStart !== null`.
+ */
+export function advanceTouchInspectMoved(
+  alreadyMoved: boolean,
+  start: Readonly<{ x: number; y: number }>,
+  point: Readonly<{ x: number; y: number }>,
+): boolean {
+  if (alreadyMoved) return true;
+  return Math.hypot(point.x - start.x, point.y - start.y) >= TOUCH_INSPECT_MOVE_PX;
+}
+
+export type SurfacePointerMoveInput = {
+  readonly pointerType: string;
+  readonly activeTool: InteractionTool;
+  /** Host sticky flag after `advanceTouchInspectMoved` (or false if no touch start). */
+  readonly touchInspectMoved: boolean;
+  /** True when `touchInspectStart !== null`. */
+  readonly hasTouchInspectStart: boolean;
+  /** Reducer brushing flag — can diverge from draft. */
+  readonly brushing: boolean;
+  /** True when `brushRect !== null`. */
+  readonly hasBrushDraft: boolean;
+  /** `interactionConfig.inspect !== null`. */
+  readonly inspectEnabled: boolean;
+};
+
+export type SurfacePointerMoveAction =
+  | { readonly type: "touch-inspect-drag-cancel" }
+  | { readonly type: "queue-area-move"; readonly source: "touch" | "pointer" }
+  | { readonly type: "queue-inspect"; readonly source: "touch" | "pointer" }
+  | { readonly type: "none" };
+
+const pointerSource = (pointerType: string): "touch" | "pointer" =>
+  pointerType === "touch" ? "touch" : "pointer";
+
+/**
+ * Pure decision for the plot capture-surface `pointermove` handler.
+ * Priority: touch-inspect drag cancel → queue area move → queue inspect → none.
+ *
+ * Cancel requires `pointerType === "touch"` (mouse/pen with residual start must
+ * not cancel). Cancel does **not** require `inspectEnabled` — only the inspect
+ * tool, matching the current host.
+ *
+ * Host advances `touchInspectMoved` separately on touch+start before calling.
+ * Host on cancel: clear `queuedPointerInspection`, cancel scheduled pointer
+ * (`queuedPointerToken` left untouched). Host on queue-*: use `action.source`.
+ */
+export function resolvePointerMoveAction(input: SurfacePointerMoveInput): SurfacePointerMoveAction {
+  const {
+    pointerType,
+    activeTool,
+    touchInspectMoved,
+    hasTouchInspectStart,
+    brushing,
+    hasBrushDraft,
+    inspectEnabled,
+  } = input;
+
+  if (
+    pointerType === "touch" &&
+    hasTouchInspectStart &&
+    touchInspectMoved &&
+    activeTool === "inspect"
+  ) {
+    return { type: "touch-inspect-drag-cancel" };
+  }
+
+  if (brushing && hasBrushDraft) {
+    return { type: "queue-area-move", source: pointerSource(pointerType) };
+  }
+
+  if (activeTool === "inspect" && inspectEnabled) {
+    return { type: "queue-inspect", source: pointerSource(pointerType) };
+  }
+
+  return { type: "none" };
+}

--- a/packages/svelte/tests/plot-surface-pointer.test.ts
+++ b/packages/svelte/tests/plot-surface-pointer.test.ts
@@ -314,13 +314,21 @@ describe("advanceTouchInspectMoved", () => {
   const start = { x: 0, y: 0 };
 
   it("stays false under the threshold", () => {
-    expect(advanceTouchInspectMoved(false, start, { x: TOUCH_INSPECT_MOVE_PX - 1, y: 0 })).toBe(
-      false,
-    );
+    expect(
+      advanceTouchInspectMoved(false, start, {
+        x: TOUCH_INSPECT_MOVE_PX - 1,
+        y: 0,
+      }),
+    ).toBe(false);
   });
 
   it("becomes true at exactly the threshold (plotPoint coords)", () => {
-    expect(advanceTouchInspectMoved(false, start, { x: TOUCH_INSPECT_MOVE_PX, y: 0 })).toBe(true);
+    expect(
+      advanceTouchInspectMoved(false, start, {
+        x: TOUCH_INSPECT_MOVE_PX,
+        y: 0,
+      }),
+    ).toBe(true);
   });
 
   it("is sticky once true", () => {
@@ -462,6 +470,8 @@ describe("resolvePointerMoveAction", () => {
   });
 
   it("returns none for non-inspect tools without brush", () => {
-    expect(resolvePointerMoveAction(move({ activeTool: "point" }))).toEqual({ type: "none" });
+    expect(resolvePointerMoveAction(move({ activeTool: "point" }))).toEqual({
+      type: "none",
+    });
   });
 });

--- a/packages/svelte/tests/plot-surface-pointer.test.ts
+++ b/packages/svelte/tests/plot-surface-pointer.test.ts
@@ -2,11 +2,15 @@ import { describe, expect, it } from "vitest";
 
 import type { InteractionTool } from "../src/lib/interaction.js";
 import {
+  TOUCH_INSPECT_MOVE_PX,
+  advanceTouchInspectMoved,
   resolveCaptureClickAction,
   resolvePointerDownAction,
+  resolvePointerMoveAction,
   resolvePointerUpAction,
   type SurfaceClickInput,
   type SurfacePointerDownInput,
+  type SurfacePointerMoveInput,
   type SurfacePointerUpInput,
 } from "../src/lib/plot-surface-pointer.js";
 
@@ -41,6 +45,18 @@ const click = (
   inspectEnabled: true,
   pinEnabled: false,
   hasInspection: false,
+  ...overrides,
+});
+
+const move = (
+  overrides: Partial<SurfacePointerMoveInput> & Pick<SurfacePointerMoveInput, "activeTool">,
+): SurfacePointerMoveInput => ({
+  pointerType: "mouse",
+  touchInspectMoved: false,
+  hasTouchInspectStart: false,
+  brushing: false,
+  hasBrushDraft: false,
+  inspectEnabled: true,
   ...overrides,
 });
 
@@ -291,5 +307,161 @@ describe("resolveCaptureClickAction", () => {
         }),
       ),
     ).toEqual({ type: "none" });
+  });
+});
+
+describe("advanceTouchInspectMoved", () => {
+  const start = { x: 0, y: 0 };
+
+  it("stays false under the threshold", () => {
+    expect(advanceTouchInspectMoved(false, start, { x: TOUCH_INSPECT_MOVE_PX - 1, y: 0 })).toBe(
+      false,
+    );
+  });
+
+  it("becomes true at exactly the threshold (plotPoint coords)", () => {
+    expect(advanceTouchInspectMoved(false, start, { x: TOUCH_INSPECT_MOVE_PX, y: 0 })).toBe(true);
+  });
+
+  it("is sticky once true", () => {
+    expect(advanceTouchInspectMoved(true, start, { x: 0, y: 0 })).toBe(true);
+  });
+});
+
+describe("resolvePointerMoveAction", () => {
+  it("cancels touch-inspect drag only for touch + start + moved + inspect tool", () => {
+    expect(
+      resolvePointerMoveAction(
+        move({
+          activeTool: "inspect",
+          pointerType: "touch",
+          hasTouchInspectStart: true,
+          touchInspectMoved: true,
+          brushing: true,
+          hasBrushDraft: true,
+          inspectEnabled: true,
+        }),
+      ),
+    ).toEqual({ type: "touch-inspect-drag-cancel" });
+  });
+
+  it("cancels even when inspect config is disabled (tool-only gate)", () => {
+    expect(
+      resolvePointerMoveAction(
+        move({
+          activeTool: "inspect",
+          pointerType: "touch",
+          hasTouchInspectStart: true,
+          touchInspectMoved: true,
+          inspectEnabled: false,
+        }),
+      ),
+    ).toEqual({ type: "touch-inspect-drag-cancel" });
+  });
+
+  it("does not cancel when pointerType is mouse/pen with residual touch-start state", () => {
+    for (const pointerType of ["mouse", "pen"] as const) {
+      expect(
+        resolvePointerMoveAction(
+          move({
+            activeTool: "inspect",
+            pointerType,
+            hasTouchInspectStart: true,
+            touchInspectMoved: true,
+            inspectEnabled: true,
+          }),
+        ),
+      ).toEqual({ type: "queue-inspect", source: "pointer" });
+    }
+  });
+
+  it("does not cancel when unmoved — falls through to queue-inspect", () => {
+    expect(
+      resolvePointerMoveAction(
+        move({
+          activeTool: "inspect",
+          pointerType: "touch",
+          hasTouchInspectStart: true,
+          touchInspectMoved: false,
+          inspectEnabled: true,
+        }),
+      ),
+    ).toEqual({ type: "queue-inspect", source: "touch" });
+  });
+
+  it("does not cancel when tool is no longer inspect (area wins if brushing)", () => {
+    expect(
+      resolvePointerMoveAction(
+        move({
+          activeTool: "select-area",
+          pointerType: "touch",
+          hasTouchInspectStart: true,
+          touchInspectMoved: true,
+          brushing: true,
+          hasBrushDraft: true,
+        }),
+      ),
+    ).toEqual({ type: "queue-area-move", source: "touch" });
+  });
+
+  it("queues area move when brushing and draft both present", () => {
+    expect(
+      resolvePointerMoveAction(
+        move({
+          activeTool: "zoom-area",
+          brushing: true,
+          hasBrushDraft: true,
+        }),
+      ),
+    ).toEqual({ type: "queue-area-move", source: "pointer" });
+  });
+
+  it("returns none when brushing/draft diverge", () => {
+    expect(
+      resolvePointerMoveAction(
+        move({
+          activeTool: "select-area",
+          brushing: true,
+          hasBrushDraft: false,
+        }),
+      ),
+    ).toEqual({ type: "none" });
+
+    expect(
+      resolvePointerMoveAction(
+        move({
+          activeTool: "select-area",
+          brushing: false,
+          hasBrushDraft: true,
+        }),
+      ),
+    ).toEqual({ type: "none" });
+  });
+
+  it("queues inspect for mouse with pointer source", () => {
+    expect(
+      resolvePointerMoveAction(
+        move({
+          activeTool: "inspect",
+          pointerType: "mouse",
+          inspectEnabled: true,
+        }),
+      ),
+    ).toEqual({ type: "queue-inspect", source: "pointer" });
+  });
+
+  it("returns none for inspect tool when inspect disabled", () => {
+    expect(
+      resolvePointerMoveAction(
+        move({
+          activeTool: "inspect",
+          inspectEnabled: false,
+        }),
+      ),
+    ).toEqual({ type: "none" });
+  });
+
+  it("returns none for non-inspect tools without brush", () => {
+    expect(resolvePointerMoveAction(move({ activeTool: "point" }))).toEqual({ type: "none" });
   });
 });

--- a/packages/svelte/tests/r0-evidence.test.ts
+++ b/packages/svelte/tests/r0-evidence.test.ts
@@ -179,6 +179,37 @@ describe("R0 interaction evidence", () => {
     expect(changes.at(-1)?.state).toBe("pinned");
   });
 
+  it("drops a queued touch-inspect hover once drag crosses the move threshold", async () => {
+    let model: RenderModel | null = null;
+    const changes: Array<{ phase: string; state?: string }> = [];
+    const { container } = render(GGPlot, {
+      data: rows,
+      aes: { x: "x", y: "y" },
+      layers: [{ geom: "point" }],
+      key: "id",
+      inspect: true,
+      onrender: (next: RenderModel) => (model = next),
+      oninspect: (event: { phase: string; state?: string }) => {
+        if (event.phase === "change") changes.push(event);
+      },
+      ...size,
+    });
+    const capture = container.querySelector<HTMLElement>(".gg-capture")!;
+    const candidate = model!.candidates.candidate(1)!;
+    // Host cleanup under test: unmoved move schedules inspect; drag cancel must
+    // clear the queue and cancel the scheduled frame before it can fire.
+    pointEvent(capture, "pointerdown", candidate.x, candidate.y, "touch", 12);
+    pointEvent(capture, "pointermove", candidate.x, candidate.y, "touch", 12);
+    pointEvent(capture, "pointermove", candidate.x + 40, candidate.y + 40, "touch", 12);
+    await nextFrame();
+    await nextFrame();
+    expect(changes).toHaveLength(0);
+    // pointerup after drag must also not pin (touch-inspect-drag-ignore path).
+    pointEvent(capture, "pointerup", candidate.x + 40, candidate.y + 40, "touch", 12);
+    await nextFrame();
+    expect(changes).toHaveLength(0);
+  });
+
   it("completes touch-drag selection with touch provenance and no JavaScript cancellation", async () => {
     const events: Array<{ phase: string; source: string }> = [];
     const { container } = render(GGPlot, {


### PR DESCRIPTION
## Summary

- Extract capture-surface `pointermove` routing (touch-inspect drag cancel, area queue, inspect queue) and the sticky 4px threshold into `plot-surface-pointer`.
- Rewire `GGPlot.onPointerMove` as a thin host switch that advances the sticky moved flag, then dispatches pure actions (uses `action.source` for both queue paths).
- Unit tests lock priority, source mapping, threshold stickiness, and cancel-requires-touch; browser evidence locks host cleanup so a queued hover cannot fire after drag cancel.

## Test plan

- [x] `bun run test:browser -- tests/plot-surface-pointer.test.ts`
- [x] `bun run test:browser -- tests/interaction.test.ts tests/interaction-regressions.test.ts`
- [x] `bun run test:browser -- tests/r0-evidence.test.ts -t "drops a queued touch-inspect"`
- [x] `bun run check` / `bun run test:ssr` in packages/svelte
- [ ] CI green on PR