### PR TITLE
fix: keep data-gg-ready false during SSR after #51

### DIFF
--- a/packages/svelte/src/lib/GGPlot.svelte
+++ b/packages/svelte/src/lib/GGPlot.svelte
@@ -2138,14 +2138,21 @@
   }
 
   // Readiness signal for screenshot tooling (plan: VR waits on
-  // `[data-gg-ready="true"]`). Must use $effect (not pure $derived): effects
-  // never run during SSR, so prerendered HTML stays data-gg-ready="false"
-  // until the first client committed flush (decision 0009). Canvas strata
-  // additionally gate on first paint (decision 0006 / plan).
-  let ready = $state(false);
+  // `[data-gg-ready="true"]`). Split into:
+  // - clientFlush via $effect: never runs during SSR → prerender stays
+  //   data-gg-ready="false" until the first client committed flush (decision 0009)
+  // - derived isPlotReady: updates in the same render when prerequisites flip
+  //   (e.g. model cleared, canvas paint incomplete) so VR cannot accept a
+  //   stale ready=true mid-transition. Canvas strata gate on first paint
+  //   (decision 0006 / plan).
+  let clientFlush = $state(false);
   $effect(() => {
+    clientFlush = true;
+  });
+  const ready = $derived.by(() => {
     void paintEpoch;
-    ready = isPlotReady({
+    if (!clientFlush) return false;
+    return isPlotReady({
       hasModel: model !== null,
       widthMode:
         width === undefined || width === "container" ? "container" : "fixed",

--- a/packages/svelte/src/lib/GGPlot.svelte
+++ b/packages/svelte/src/lib/GGPlot.svelte
@@ -2138,11 +2138,14 @@
   }
 
   // Readiness signal for screenshot tooling (plan: VR waits on
-  // `[data-gg-ready="true"]`). Derived after flush-visible state updates;
-  // canvas strata additionally gate on first paint (decision 0006 / plan).
-  const ready = $derived.by(() => {
+  // `[data-gg-ready="true"]`). Must use $effect (not pure $derived): effects
+  // never run during SSR, so prerendered HTML stays data-gg-ready="false"
+  // until the first client committed flush (decision 0009). Canvas strata
+  // additionally gate on first paint (decision 0006 / plan).
+  let ready = $state(false);
+  $effect(() => {
     void paintEpoch;
-    return isPlotReady({
+    ready = isPlotReady({
       hasModel: model !== null,
       widthMode:
         width === undefined || width === "container" ? "container" : "fixed",

--- a/packages/svelte/tests/component.test.ts
+++ b/packages/svelte/tests/component.test.ts
@@ -291,6 +291,28 @@ describe("data-gg-ready readiness signal (M1 VR workstream)", () => {
     await Promise.resolve(); // a microtask later it is STILL not ready
     expect(root?.dataset.ggReady).toBe("false");
   });
+
+  it("clears data-gg-ready in the same update when the plot becomes unready", async () => {
+    const { container, rerender } = render(GGPlot, {
+      data: rows,
+      aes: { x: "x", y: "y" },
+      layers: [{ geom: "point" }],
+      width: 480,
+      height: 320,
+    });
+    const root = container.querySelector<HTMLElement>(".gg-plot-root");
+    await expect.poll(() => root?.dataset.ggReady).toBe("true");
+    // Explicit empty layers → no model → not ready. Derived predicate must
+    // clear the attribute in this commit (not wait for a post-flush $effect).
+    await rerender({
+      data: rows,
+      aes: { x: "x", y: "y" },
+      layers: [],
+      width: 480,
+      height: 320,
+    } as never);
+    expect(root?.dataset.ggReady).toBe("false");
+  });
 });
 
 describe("M2 statistical children components", () => {

--- a/packages/svelte/tests/ssr-harness.ssr.test.ts
+++ b/packages/svelte/tests/ssr-harness.ssr.test.ts
@@ -26,6 +26,21 @@ describe("SSR release fixture", () => {
     expect(fixture.html).toMatch(/^<!doctype html>/);
   });
 
+  it('keeps data-gg-ready="false" during SSR for fixed-width SVG plots (decision 0009)', () => {
+    // $effect never runs on the server; prerendered HTML must not claim ready
+    // so VR / screenshot tooling waits for the post-hydration committed flush.
+    const fixture = renderSsrFixture(GGPlot, {
+      data: rows,
+      aes: { x: "x", y: "y" },
+      layers: [{ geom: "point" }],
+      width: 480,
+      height: 320,
+    });
+
+    expect(fixture.body).toContain('data-gg-ready="false"');
+    expect(fixture.body).not.toContain('data-gg-ready="true"');
+  });
+
   it("renders the canonical browser hydration fixture", () => {
     const fixture = renderSsrFixture(HydrationFixture, { label: "Selected", count: 2 });
     expect(fixture.body).toContain('data-hydrated="false"');


### PR DESCRIPTION
## Summary
- Parent: unrebutted post-merge Codex finding on #51 (P2: gate readiness until client flush).
- #51 switched `data-gg-ready` from `$state`+`$effect` to `$derived.by`. For fixed-width SVG-only plots that evaluates during SSR and emits `data-gg-ready="true"` in prerendered HTML.
- Decision 0009 requires the signal to flip only after hydration's committed render (`$effect` never runs on the server), so VR screenshot waits can race.
- Restore the `$effect` gate while keeping the pure `isPlotReady` helper.

## Root cause
`$derived` runs during SSR; `$effect` does not. The pure predicate correctly returns ready for fixed-width SVG with a model, so SSR HTML claimed ready before client effects settled.

## Test plan
- [x] SSR: `data-gg-ready="false"` for fixed-width SVG plot (new assertion in `ssr-harness.ssr.test.ts`)
- [x] CSR: existing `data-gg-ready` component tests still flip to `"true"` after flush
- [x] `plot-paint` unit tests unchanged/pass

## Verification evidence
- `bun run test:ssr` in `packages/svelte` — pass (4 tests)
- `bunx vitest run tests/component.test.ts -t data-gg-ready` — pass
- `bunx vitest run tests/plot-paint.test.ts` — pass
- Pre-push: package build, svelte-check, oxlint type-aware, knip, bun test — pass