### PR TITLE
refactor(svelte): extract pure queued-inspect frame decisions

### DIFF
--- a/packages/svelte/src/lib/GGPlot.svelte
+++ b/packages/svelte/src/lib/GGPlot.svelte
@@ -613,7 +613,7 @@
               pending.concreteMode,
               pending.candidate,
             );
-            return;
+            break;
         }
       }
     },

--- a/packages/svelte/src/lib/GGPlot.svelte
+++ b/packages/svelte/src/lib/GGPlot.svelte
@@ -114,6 +114,7 @@
   } from "./plot-area-brush.js";
   import { frozenZoomDomains, normalizedRect } from "./plot-geometry.js";
   import { resolveSurfaceKeyAction } from "./plot-surface-keyboard.js";
+  import { resolveQueuedInspectFrameAction } from "./plot-surface-inspection.js";
   import {
     resolveCaptureClickAction,
     advanceTouchInspectMoved,
@@ -579,28 +580,41 @@
       if (action.type === "move-area") {
         applyAreaMove(action.point, queuedAreaSource);
       } else {
+        // Snapshot then clear queues before pure routing (matches prior host).
         const pending = queuedPointerInspection;
         const token = queuedPointerToken;
         queuedPointerInspection = null;
         queuedPointerToken = null;
-        if (pending === null) return;
-        if (token !== null && !reducer.accepts(token)) return;
-        if (inspection?.state === "pinned") {
-          pendingPinnedPointer = pending;
-          return;
+        // Short-circuit tokenAccepted when no pending so accepts() is not
+        // called for empty frames (Codex plan review).
+        const frameAction = resolveQueuedInspectFrameAction({
+          hasPending: pending !== null,
+          tokenAccepted:
+            pending === null || token === null || reducer.accepts(token),
+          currentState: inspection?.state ?? "none",
+          candidateEpochMismatch:
+            action.candidate !== null &&
+            action.candidate.epoch !== model?.runId,
+        });
+        switch (frameAction.type) {
+          case "none":
+          case "drop":
+            return;
+          case "stash-pending":
+            if (pending === null) return;
+            pendingPinnedPointer = pending;
+            return;
+          case "apply-pending":
+            if (pending === null) return;
+            setInspection(
+              pending.hit,
+              pending.source,
+              "transient",
+              pending.concreteMode,
+              pending.candidate,
+            );
+            return;
         }
-        if (
-          action.candidate !== null &&
-          action.candidate.epoch !== model?.runId
-        )
-          return;
-        setInspection(
-          pending.hit,
-          pending.source,
-          "transient",
-          pending.concreteMode,
-          pending.candidate,
-        );
       }
     },
   });

--- a/packages/svelte/src/lib/plot-surface-inspection.ts
+++ b/packages/svelte/src/lib/plot-surface-inspection.ts
@@ -3,7 +3,7 @@
  * Callers own queue mutation, setInspection, and reducer side effects.
  */
 
-export type InspectionHostState = "none" | "transient" | "pinned";
+type InspectionHostState = "none" | "transient" | "pinned";
 
 export type QueuedInspectFrameInput = {
   /** True when a snapshotted `queuedPointerInspection` payload exists. */

--- a/packages/svelte/src/lib/plot-surface-inspection.ts
+++ b/packages/svelte/src/lib/plot-surface-inspection.ts
@@ -1,0 +1,58 @@
+/**
+ * Pure decision tables for capture-surface inspection host policy.
+ * Callers own queue mutation, setInspection, and reducer side effects.
+ */
+
+export type InspectionHostState = "none" | "transient" | "pinned";
+
+export type QueuedInspectFrameInput = {
+  /** True when a snapshotted `queuedPointerInspection` payload exists. */
+  readonly hasPending: boolean;
+  /**
+   * Host: `token === null || reducer.accepts(token)`.
+   * Compute only after confirming a pending payload exists (or short-circuit
+   * so `reducer.accepts` is not called when `hasPending` is false).
+   */
+  readonly tokenAccepted: boolean;
+  /** Current host inspection: null → `"none"`, else `inspection.state`. */
+  readonly currentState: InspectionHostState;
+  /**
+   * Host: `action.candidate !== null && action.candidate.epoch !== model?.runId`
+   * from the reducer frame action (not the queued candidate snapshot).
+   * When the frame action has no candidate, pass false.
+   */
+  readonly candidateEpochMismatch: boolean;
+};
+
+export type QueuedInspectFrameAction =
+  | { readonly type: "none" }
+  | { readonly type: "drop" }
+  | { readonly type: "stash-pending" }
+  | { readonly type: "apply-pending" };
+
+/**
+ * Pure decision for the inspect branch of `onPointerFrame` after the host
+ * has snapshotted and cleared queue fields.
+ *
+ * Priority (matches current host):
+ *   1. none — !hasPending
+ *   2. drop — !tokenAccepted (stale frame token)
+ *   3. stash-pending — currentState === "pinned"
+ *   4. drop — candidateEpochMismatch
+ *   5. apply-pending
+ *
+ * Host sequencing: snapshot pending + token, clear `queuedPointerInspection`
+ * and `queuedPointerToken`, then call this helper, then switch:
+ *   none/drop → return
+ *   stash-pending → `pendingPinnedPointer = pending`
+ *   apply-pending → `setInspection(pending…, "transient", …)`
+ */
+export function resolveQueuedInspectFrameAction(
+  input: QueuedInspectFrameInput,
+): QueuedInspectFrameAction {
+  if (!input.hasPending) return { type: "none" };
+  if (!input.tokenAccepted) return { type: "drop" };
+  if (input.currentState === "pinned") return { type: "stash-pending" };
+  if (input.candidateEpochMismatch) return { type: "drop" };
+  return { type: "apply-pending" };
+}

--- a/packages/svelte/tests/plot-surface-inspection.test.ts
+++ b/packages/svelte/tests/plot-surface-inspection.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  resolveQueuedInspectFrameAction,
+  type QueuedInspectFrameInput,
+} from "../src/lib/plot-surface-inspection.js";
+
+const frame = (overrides: Partial<QueuedInspectFrameInput> = {}): QueuedInspectFrameInput => ({
+  hasPending: true,
+  tokenAccepted: true,
+  currentState: "none",
+  candidateEpochMismatch: false,
+  ...overrides,
+});
+
+describe("resolveQueuedInspectFrameAction", () => {
+  it("returns none when there is no pending payload", () => {
+    expect(
+      resolveQueuedInspectFrameAction(
+        frame({
+          hasPending: false,
+          tokenAccepted: false,
+          currentState: "pinned",
+          candidateEpochMismatch: true,
+        }),
+      ),
+    ).toEqual({ type: "none" });
+  });
+
+  it("drops stale frame tokens before pinned stash or epoch checks", () => {
+    expect(
+      resolveQueuedInspectFrameAction(
+        frame({
+          tokenAccepted: false,
+          currentState: "pinned",
+          candidateEpochMismatch: false,
+        }),
+      ),
+    ).toEqual({ type: "drop" });
+  });
+
+  it("stashes pending while inspection is pinned (before epoch mismatch)", () => {
+    expect(
+      resolveQueuedInspectFrameAction(
+        frame({
+          currentState: "pinned",
+          candidateEpochMismatch: true,
+        }),
+      ),
+    ).toEqual({ type: "stash-pending" });
+  });
+
+  it("drops on candidate epoch mismatch for non-pinned host states", () => {
+    for (const currentState of ["none", "transient"] as const) {
+      expect(
+        resolveQueuedInspectFrameAction(frame({ currentState, candidateEpochMismatch: true })),
+      ).toEqual({ type: "drop" });
+    }
+  });
+
+  it("applies pending for none/transient when token ok and epoch matches", () => {
+    for (const currentState of ["none", "transient"] as const) {
+      expect(resolveQueuedInspectFrameAction(frame({ currentState }))).toEqual({
+        type: "apply-pending",
+      });
+    }
+  });
+
+  it("priority matrix: pending → token → stash → epoch → apply", () => {
+    // no pending wins over everything
+    expect(
+      resolveQueuedInspectFrameAction(
+        frame({
+          hasPending: false,
+          tokenAccepted: true,
+          currentState: "none",
+          candidateEpochMismatch: false,
+        }),
+      ),
+    ).toEqual({ type: "none" });
+
+    // rejected token beats pinned stash
+    expect(
+      resolveQueuedInspectFrameAction(frame({ tokenAccepted: false, currentState: "pinned" })),
+    ).toEqual({ type: "drop" });
+
+    // pinned stash beats epoch drop
+    expect(
+      resolveQueuedInspectFrameAction(
+        frame({ currentState: "pinned", candidateEpochMismatch: true }),
+      ),
+    ).toEqual({ type: "stash-pending" });
+
+    // epoch drop beats apply
+    expect(
+      resolveQueuedInspectFrameAction(
+        frame({ currentState: "transient", candidateEpochMismatch: true }),
+      ),
+    ).toEqual({ type: "drop" });
+  });
+});


### PR DESCRIPTION
## Summary

- Extract the rAF `onPointerFrame` inspect-queue routing from `GGPlot.svelte` into a pure decision table (`resolveQueuedInspectFrameAction` in `plot-surface-inspection.ts`).
- Priority is unit-tested: no pending → none; stale token → drop; pinned → stash-pending; candidate epoch mismatch → drop; else apply-pending.
- Host still snapshots/clears queue fields first, short-circuits `reducer.accepts` when there is no pending payload, and owns `setInspection` / stash side effects.

## Test plan

- [x] `pnpm exec vitest run tests/plot-surface-inspection.test.ts` (chromium/webkit/firefox)
- [x] `pnpm exec vitest run tests/r0-evidence.test.ts` — leave cancel, pin stash/reveal, stale epoch (chromium/webkit green; firefox axe timeout on unrelated dense-dialog test)
- [x] Pre-push: package build, svelte-check, oxlint type-aware, knip