### PR TITLE
refactor(svelte): extract pure presentation and interval-scene adapters

### DIFF
--- a/packages/svelte/src/lib/GGPlot.svelte
+++ b/packages/svelte/src/lib/GGPlot.svelte
@@ -151,12 +151,14 @@
   import { clearIntervalSelectionEvent } from "./plot-interval.js";
   import {
     buildIntervalSelectionFromScene,
+    intervalQuerySceneFromModel,
     type IntervalQueryScene,
   } from "./plot-interval-query.js";
   import { createPaintLedger, isPlotReady } from "./plot-paint.js";
   import {
     anchorsFromCandidateKeys,
     buildPointSelectionEvent,
+    mergePresentationFocusKeys,
     nextPointSelectionKeys,
     rowIndexesForCandidate,
     sameOrderedPropertyKeys,
@@ -1095,17 +1097,17 @@
     });
   }
 
-  const presentationFocusKeys: readonly PropertyKey[] = $derived.by(() => {
-    if (effectiveEmphasisKeys.length === 0 || inspection === null)
-      return effectiveEmphasisKeys;
-    return Object.freeze([
-      ...new Set([
-        ...effectiveEmphasisKeys,
-        ...inspection.focus.sourceKeys,
-        ...(inspection.focus.key === null ? [] : [inspection.focus.key]),
-      ]),
-    ]);
-  });
+  const presentationFocusKeys: readonly PropertyKey[] = $derived(
+    mergePresentationFocusKeys(
+      effectiveEmphasisKeys,
+      inspection === null
+        ? null
+        : {
+            sourceKeys: inspection.focus.sourceKeys,
+            key: inspection.focus.key,
+          },
+    ),
+  );
 
   const semanticCandidateProjections = $derived.by(() => {
     if (model === null) return [];
@@ -1671,41 +1673,11 @@
 
   /** Map the live render model into the pure interval query scene adapter. */
   function intervalQueryScene(): IntervalQueryScene | null {
-    const current = model;
-    if (current === null) return null;
-    const panel = current.scene.panels[0];
-    return {
-      panel:
-        panel === undefined
-          ? null
-          : {
-              x: panel.x,
-              y: panel.y,
-              width: panel.width,
-              height: panel.height,
-              id: panel.id,
-            },
-      singlePanel: current.scene.panels.length === 1,
-      flip: assembled?.coord?.type === "flip",
-      scales: current.scales,
-      queryCandidates(expanded) {
-        return [
-          ...current.candidates.queryRect(
-            expanded.x0,
-            expanded.y0,
-            expanded.x1,
-            expanded.y1,
-          ),
-        ]
-          .map((id) => current.candidates.candidate(id))
-          .filter(
-            (candidate): candidate is CandidateFacts => candidate !== null,
-          );
-      },
-      lineageKeys(lineageId) {
-        return current.lineage.keys(lineageId);
-      },
-    };
+    if (model === null) return null;
+    return intervalQuerySceneFromModel(
+      model,
+      assembled?.coord?.type === "flip",
+    );
   }
 
   function onPointerLeave(): void {

--- a/packages/svelte/src/lib/plot-interval-query.ts
+++ b/packages/svelte/src/lib/plot-interval-query.ts
@@ -30,6 +30,60 @@ export type IntervalQueryScene = {
   lineageKeys(lineageId: number): Iterable<number>;
 };
 
+/**
+ * Structural port for building an IntervalQueryScene without requiring a full
+ * RenderModel (tests use plain objects; production passes the live model).
+ */
+export type IntervalQueryModelPort = {
+  readonly scene: {
+    readonly panels: readonly (PanelBounds & {
+      readonly id: string | null;
+    })[];
+  };
+  readonly scales: Pick<RenderModel["scales"], "x" | "y">;
+  readonly candidates: {
+    queryRect(x0: number, y0: number, x1: number, y1: number): Iterable<number>;
+    candidate(id: number): { readonly lineage: number } | null;
+  };
+  readonly lineage: {
+    keys(lineageId: number): Iterable<number>;
+  };
+};
+
+/**
+ * Map a model port + flip flag into the interval query scene adapter.
+ * Hosts keep the `model === null` gate; this helper assumes a live model.
+ */
+export function intervalQuerySceneFromModel(
+  model: IntervalQueryModelPort,
+  flip: boolean,
+): IntervalQueryScene {
+  const panel = model.scene.panels[0];
+  return {
+    panel:
+      panel === undefined
+        ? null
+        : {
+            x: panel.x,
+            y: panel.y,
+            width: panel.width,
+            height: panel.height,
+            id: panel.id,
+          },
+    singlePanel: model.scene.panels.length === 1,
+    flip,
+    scales: model.scales,
+    queryCandidates(expanded) {
+      return [...model.candidates.queryRect(expanded.x0, expanded.y0, expanded.x1, expanded.y1)]
+        .map((id) => model.candidates.candidate(id))
+        .filter((candidate): candidate is { readonly lineage: number } => candidate !== null);
+    },
+    lineageKeys(lineageId) {
+      return model.lineage.keys(lineageId);
+    },
+  };
+}
+
 export type ResolveIntervalQueryPartsInput = {
   readonly pixels: PlotRect;
   readonly mode: SelectAreaMode;

--- a/packages/svelte/src/lib/plot-selection.ts
+++ b/packages/svelte/src/lib/plot-selection.ts
@@ -112,3 +112,29 @@ export function anchorsFromCandidateKeys(
   }
   return anchors;
 }
+
+/** Inspection focus fields needed for interaction-mask presentation keys. */
+export type PresentationInspectionFocus = {
+  readonly sourceKeys: readonly PropertyKey[];
+  readonly key: PropertyKey | null;
+};
+
+/**
+ * Keys used for interaction mask presentation when emphasis is active.
+ * Short-circuit: if emphasis is empty OR inspection is null, return emphasis
+ * (same reference). Otherwise freeze the Set-union of emphasis, sourceKeys,
+ * and the optional focus key (insertion order: emphasis → sourceKeys → key).
+ */
+export function mergePresentationFocusKeys(
+  emphasisKeys: readonly PropertyKey[],
+  inspection: PresentationInspectionFocus | null,
+): readonly PropertyKey[] {
+  if (emphasisKeys.length === 0 || inspection === null) return emphasisKeys;
+  return Object.freeze([
+    ...new Set([
+      ...emphasisKeys,
+      ...inspection.sourceKeys,
+      ...(inspection.key === null ? [] : [inspection.key]),
+    ]),
+  ]);
+}

--- a/packages/svelte/tests/plot-interval-query.test.ts
+++ b/packages/svelte/tests/plot-interval-query.test.ts
@@ -161,6 +161,7 @@ describe("intervalQuerySceneFromModel", () => {
     panels?: IntervalQueryModelPort["scene"]["panels"];
     byId?: Record<number, { lineage: number } | null>;
     lineage?: Record<number, number[]>;
+    onQueryRect?: (x0: number, y0: number, x1: number, y1: number) => void;
   }): IntervalQueryModelPort {
     const byId = partial.byId ?? {
       0: { lineage: 1 },
@@ -174,7 +175,8 @@ describe("intervalQuerySceneFromModel", () => {
       },
       scales,
       candidates: {
-        queryRect() {
+        queryRect(x0, y0, x1, y1) {
+          partial.onQueryRect?.(x0, y0, x1, y1);
           return Object.keys(byId).map(Number);
         },
         candidate(id) {
@@ -216,12 +218,21 @@ describe("intervalQuerySceneFromModel", () => {
     expect(empty.singlePanel).toBe(false);
   });
 
-  it("queryCandidates filters null candidates and lineageKeys delegates", () => {
-    const adapted = intervalQuerySceneFromModel(port({}), false);
-    expect(adapted.queryCandidates({ x0: 0, y0: 0, x1: 1, y1: 1 })).toEqual([
+  it("queryCandidates forwards expanded bounds, filters nulls, and lineageKeys delegates", () => {
+    const seen: number[][] = [];
+    const adapted = intervalQuerySceneFromModel(
+      port({
+        onQueryRect(x0, y0, x1, y1) {
+          seen.push([x0, y0, x1, y1]);
+        },
+      }),
+      false,
+    );
+    expect(adapted.queryCandidates({ x0: 3, y0: 4, x1: 5, y1: 6 })).toEqual([
       { lineage: 1 },
       { lineage: 2 },
     ]);
+    expect(seen).toEqual([[3, 4, 5, 6]]);
     expect([...adapted.lineageKeys(2)]).toEqual([20, 21]);
     expect([...adapted.lineageKeys(99)]).toEqual([]);
   });

--- a/packages/svelte/tests/plot-interval-query.test.ts
+++ b/packages/svelte/tests/plot-interval-query.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from "vitest";
 
 import {
   buildIntervalSelectionFromScene,
+  intervalQuerySceneFromModel,
   resolveIntervalQueryParts,
+  type IntervalQueryModelPort,
   type IntervalQueryScene,
 } from "../src/lib/plot-interval-query.js";
 
@@ -146,5 +148,99 @@ describe("buildIntervalSelectionFromScene", () => {
       panelId: null,
       source: "keyboard",
     });
+  });
+});
+
+describe("intervalQuerySceneFromModel", () => {
+  const scales = {
+    x: { type: "linear", invert: (t: number) => t * 10 },
+    y: { type: "linear", invert: (t: number) => (1 - t) * 20 },
+  } as IntervalQueryScene["scales"];
+
+  function port(partial: {
+    panels?: IntervalQueryModelPort["scene"]["panels"];
+    byId?: Record<number, { lineage: number } | null>;
+    lineage?: Record<number, number[]>;
+  }): IntervalQueryModelPort {
+    const byId = partial.byId ?? {
+      0: { lineage: 1 },
+      1: null,
+      2: { lineage: 2 },
+    };
+    const lineage = partial.lineage ?? { 1: [10], 2: [20, 21] };
+    return {
+      scene: {
+        panels: partial.panels ?? [{ x: 1, y: 2, width: 30, height: 40, id: "p0" }],
+      },
+      scales,
+      candidates: {
+        queryRect() {
+          return Object.keys(byId).map(Number);
+        },
+        candidate(id) {
+          return byId[id] ?? null;
+        },
+      },
+      lineage: {
+        keys(lineageId) {
+          return lineage[lineageId] ?? [];
+        },
+      },
+    };
+  }
+
+  it("maps first panel geometry and singlePanel from panel count", () => {
+    const one = intervalQuerySceneFromModel(port({}), false);
+    expect(one.panel).toEqual({ x: 1, y: 2, width: 30, height: 40, id: "p0" });
+    expect(one.singlePanel).toBe(true);
+    expect(one.flip).toBe(false);
+    expect(one.scales).toBe(scales);
+
+    const multi = intervalQuerySceneFromModel(
+      port({
+        panels: [
+          { x: 0, y: 0, width: 10, height: 10, id: "a" },
+          { x: 10, y: 0, width: 10, height: 10, id: "b" },
+        ],
+      }),
+      true,
+    );
+    expect(multi.panel?.id).toBe("a");
+    expect(multi.singlePanel).toBe(false);
+    expect(multi.flip).toBe(true);
+  });
+
+  it("returns null panel when the model has no panels", () => {
+    const empty = intervalQuerySceneFromModel(port({ panels: [] }), false);
+    expect(empty.panel).toBeNull();
+    expect(empty.singlePanel).toBe(false);
+  });
+
+  it("queryCandidates filters null candidates and lineageKeys delegates", () => {
+    const adapted = intervalQuerySceneFromModel(port({}), false);
+    expect(adapted.queryCandidates({ x0: 0, y0: 0, x1: 1, y1: 1 })).toEqual([
+      { lineage: 1 },
+      { lineage: 2 },
+    ]);
+    expect([...adapted.lineageKeys(2)]).toEqual([20, 21]);
+    expect([...adapted.lineageKeys(99)]).toEqual([]);
+  });
+
+  it("wires through resolveIntervalQueryParts for lineage rows", () => {
+    const adapted = intervalQuerySceneFromModel(
+      port({
+        byId: { 0: { lineage: 1 } },
+        lineage: { 1: [5, 6] },
+      }),
+      false,
+    );
+    // queryRect returns all byId keys; expanded geometry unused by stub.
+    const parts = resolveIntervalQueryParts({
+      pixels: { x0: 0, y0: 0, x1: 50, y1: 50 },
+      mode: "xy",
+      scene: adapted,
+    });
+    expect([...parts.rowIndexes]).toEqual([5, 6]);
+    expect(parts.panelId).toBe("p0");
   });
 });

--- a/packages/svelte/tests/plot-selection.test.ts
+++ b/packages/svelte/tests/plot-selection.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   anchorsFromCandidateKeys,
   buildPointSelectionEvent,
+  mergePresentationFocusKeys,
   nextPointSelectionKeys,
   rowIndexesForCandidate,
   sameOrderedPropertyKeys,
@@ -131,5 +132,42 @@ describe("buildPointSelectionEvent", () => {
     expect(event.phase).toBe("clear");
     expect(event.keys).toEqual([]);
     expect(Object.isFrozen(event.keys)).toBe(true);
+  });
+});
+
+describe("mergePresentationFocusKeys", () => {
+  it("returns the same emphasis reference when emphasis is empty", () => {
+    const empty: PropertyKey[] = [];
+    expect(mergePresentationFocusKeys(empty, { sourceKeys: ["a"], key: null })).toBe(empty);
+  });
+
+  it("returns the same emphasis reference when inspection is null", () => {
+    const emphasis = ["a", "b"] as const;
+    expect(mergePresentationFocusKeys(emphasis, null)).toBe(emphasis);
+  });
+
+  it("unions emphasis then sourceKeys then optional key, dedupes, and freezes", () => {
+    const result = mergePresentationFocusKeys(["a"], {
+      sourceKeys: ["b", "a"],
+      key: "c",
+    });
+    expect(result).toEqual(["a", "b", "c"]);
+    expect(Object.isFrozen(result)).toBe(true);
+  });
+
+  it("omits null focus key and dedupes when key already present", () => {
+    expect(mergePresentationFocusKeys(["a"], { sourceKeys: ["b"], key: null })).toEqual(["a", "b"]);
+    expect(mergePresentationFocusKeys(["a"], { sourceKeys: ["b"], key: "a" })).toEqual(["a", "b"]);
+  });
+
+  it("uses Set/Object.is semantics for symbols", () => {
+    const a = Symbol("row");
+    const b = Symbol("row");
+    const result = mergePresentationFocusKeys([a], {
+      sourceKeys: [b, a],
+      key: b,
+    });
+    expect(result).toEqual([a, b]);
+    expect(Object.isFrozen(result)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- Extract `mergePresentationFocusKeys` from `GGPlot` into `plot-selection.ts` so interaction-mask key union (emphasis + inspection focus) is a unit-tested pure helper with identity/freeze/dedupe guarantees.
- Extract `intervalQuerySceneFromModel` into `plot-interval-query.ts` with a narrow `IntervalQueryModelPort`, so interval brush selection no longer builds the scene adapter inline in the component.
- Thin `GGPlot` wiring only; no intentional behavior change.

## Test plan

- [x] `bunx vitest run tests/plot-selection.test.ts tests/plot-interval-query.test.ts` (chromium/webkit/firefox)
- [x] `bun run check` in `packages/svelte`
- [ ] CI on PR