### PR TITLE
refactor(svelte): extract pure live-region and plot-root layout helpers

### DIFF
--- a/packages/svelte/src/lib/GGPlot.svelte
+++ b/packages/svelte/src/lib/GGPlot.svelte
@@ -128,10 +128,19 @@
     resolveLegendPointerUpAction,
   } from "./plot-legend-surface.js";
   import {
+    BRUSH_SECOND_CORNER_ANNOUNCEMENT,
     datumLabel as datumLabelFor,
     inspectionLiveText as inspectionLiveTextFor,
+    legendFocusAnnouncement,
     markLabel as markLabelFor,
+    selectionAnnouncement,
+    zoomAnnouncement,
   } from "./plot-labels.js";
+  import {
+    isDockedTooltipWidth,
+    isNarrowToolsWidth,
+    plotRootInlineStyle,
+  } from "./plot-layout.js";
   import {
     bestDirectionalIndex,
     buildTraversalHits,
@@ -760,8 +769,17 @@
     model === null ? "" : themeTokensToCss(model.scene.theme),
   );
   const rootStyle = $derived(
-    `${hasCanvas || interactive || effectiveEmphasisKeys.length > 0 || effectiveSelectedKeys.length > 0 ? `width:${width === undefined || width === "container" ? "100%" : `${model?.scene.width ?? resolvedWidth}px`};height:${model?.scene.height ?? resolvedHeight}px;` : ""}${themeStyle}` ||
-      undefined,
+    plotRootInlineStyle({
+      needsSizedBox:
+        hasCanvas ||
+        interactive ||
+        effectiveEmphasisKeys.length > 0 ||
+        effectiveSelectedKeys.length > 0,
+      containerWidth: width === undefined || width === "container",
+      sceneWidth: model?.scene.width ?? resolvedWidth,
+      sceneHeight: model?.scene.height ?? resolvedHeight,
+      themeStyle,
+    }),
   );
   function anchorsForKeys(keys: readonly PropertyKey[]): {
     x: number;
@@ -827,15 +845,8 @@
   }
 
   function emitSelection(event: PlotSelection): void {
-    if (event.phase === "end") {
-      const count =
-        event.mode === "point" ? event.keys.length : event.lineageCount;
-      announceInteraction(
-        `Selection complete, ${String(count)} ${count === 1 ? "datum" : "data"}.`,
-      );
-    } else if (event.phase === "clear") {
-      announceInteraction("Selection cleared.");
-    }
+    const message = selectionAnnouncement(event);
+    if (message !== null) announceInteraction(message);
     onselect?.(event as unknown as PlotSelection<PublicKey>);
     oninteraction?.(event as unknown as PlotInteractionEvent<Row, PublicKey>);
   }
@@ -996,13 +1007,7 @@
   }
 
   function emitLegendFocus(event: LegendFocusEvent<PropertyKey>): void {
-    if (event.phase === "change") {
-      announceInteraction(
-        `${event.label} ${event.state === "committed" ? "focused" : "previewed"}, ${String(event.keys.length)} ${event.keys.length === 1 ? "datum" : "data"}.`,
-      );
-    } else {
-      announceInteraction("Legend focus cleared.");
-    }
+    announceInteraction(legendFocusAnnouncement(event));
     onlegendfocus?.(event as LegendFocusEvent<PublicKey>);
     oninteraction?.(event as PlotInteractionEvent<Row, PublicKey>);
   }
@@ -1810,7 +1815,7 @@
         const ended = evaluatePointerBrushEnd(brushRect, plotPoint(event));
         if (ended.kind === "too-small") {
           brushRect = ended.corners;
-          announceInteraction("Choose opposite corner.");
+          announceInteraction(BRUSH_SECOND_CORNER_ANNOUNCEMENT);
           break;
         }
         brushRect = null;
@@ -1860,7 +1865,7 @@
       }
     }
     const event = buildZoomEvent(committed, source);
-    announceInteraction(committed === null ? "Zoom reset." : "Zoom complete.");
+    announceInteraction(zoomAnnouncement(committed));
     onzoom?.(event);
     oninteraction?.(event);
   }
@@ -2021,7 +2026,7 @@
           point: anchor,
           panelId: panelId(0),
         });
-        announceInteraction("Choose opposite corner.");
+        announceInteraction(BRUSH_SECOND_CORNER_ANNOUNCEMENT);
         return;
       }
       case "complete-area": {
@@ -2150,9 +2155,9 @@
   class:gg-with-tool-rail={showToolRail}
   class:gg-with-legend-clear={interactionConfig.legendFocus !== null &&
     effectiveLegendPressed !== null}
-  class:gg-narrow-tools={resolvedWidth < 560}
+  class:gg-narrow-tools={isNarrowToolsWidth(resolvedWidth)}
   class:gg-with-docked-tooltip={inspection?.state === "pinned" &&
-    resolvedWidth < 480}
+    isDockedTooltipWidth(resolvedWidth)}
   data-gg-ready={ready ? "true" : "false"}
   style={rootStyle}
 >
@@ -2163,7 +2168,7 @@
       {activeTool}
       {ready}
       {emptyPlot}
-      narrow={resolvedWidth < 560}
+      narrow={isNarrowToolsWidth(resolvedWidth)}
       zoomDomains={effectiveZoomDomains}
       hasPointSelection={canPublishPointSelection &&
         effectiveSelectedKeys.length > 0}
@@ -2403,7 +2408,8 @@
           )}
           content={interactionConfig.inspect?.content}
           interactive={interactionConfig.inspect?.contentMode === "interactive"}
-          docked={inspection.state === "pinned" && resolvedWidth < 480}
+          docked={inspection.state === "pinned" &&
+            isDockedTooltipWidth(resolvedWidth)}
           onenter={() => (tooltipHovered = true)}
           onleave={() => {
             tooltipHovered = false;

--- a/packages/svelte/src/lib/plot-labels.ts
+++ b/packages/svelte/src/lib/plot-labels.ts
@@ -4,7 +4,7 @@ import type {
   LegendFocusEvent,
   PlotInspectionChange,
   PlotSelection,
-  ZoomDomains,
+  ReadonlyZoomDomains,
 } from "./interaction.js";
 
 /** Shared a11y count phrase: "1 datum" / "N data". */
@@ -38,7 +38,7 @@ export function legendFocusAnnouncement(event: LegendFocusEvent): string {
 }
 
 /** Live message after a zoom commit or reset (`null` domains → reset). */
-export function zoomAnnouncement(domains: ZoomDomains | null): string {
+export function zoomAnnouncement(domains: ReadonlyZoomDomains | null): string {
   return domains === null ? "Zoom reset." : "Zoom complete.";
 }
 

--- a/packages/svelte/src/lib/plot-labels.ts
+++ b/packages/svelte/src/lib/plot-labels.ts
@@ -1,6 +1,46 @@
 import type { CellValue, RenderModel } from "@ggsvelte/core";
 
-import type { PlotInspectionChange } from "./interaction.js";
+import type {
+  LegendFocusEvent,
+  PlotInspectionChange,
+  PlotSelection,
+  ZoomDomains,
+} from "./interaction.js";
+
+/** Shared a11y count phrase: "1 datum" / "N data". */
+export function countLabel(count: number): string {
+  return `${String(count)} ${count === 1 ? "datum" : "data"}`;
+}
+
+/** Live message when the brush needs a second corner (pointer or keyboard). */
+export const BRUSH_SECOND_CORNER_ANNOUNCEMENT = "Choose opposite corner." as const;
+
+/**
+ * Live message for selection emission, or null when the phase does not announce
+ * (interval start/change).
+ */
+export function selectionAnnouncement(event: PlotSelection): string | null {
+  if (event.phase === "end") {
+    const count = event.mode === "point" ? event.keys.length : event.lineageCount;
+    return `Selection complete, ${countLabel(count)}.`;
+  }
+  if (event.phase === "clear") return "Selection cleared.";
+  return null;
+}
+
+/** Live message for legend-focus change/clear events. */
+export function legendFocusAnnouncement(event: LegendFocusEvent): string {
+  if (event.phase === "change") {
+    const verb = event.state === "committed" ? "focused" : "previewed";
+    return `${event.label} ${verb}, ${countLabel(event.keys.length)}.`;
+  }
+  return "Legend focus cleared.";
+}
+
+/** Live message after a zoom commit or reset (`null` domains → reset). */
+export function zoomAnnouncement(domains: ZoomDomains | null): string {
+  return domains === null ? "Zoom reset." : "Zoom complete.";
+}
 
 /** Accessible per-mark label from the layer's mapped fields. */
 export function markLabel(model: RenderModel | null, row: number): string {
@@ -41,7 +81,7 @@ export function inspectionLiveText(
   const count = value.members.length;
   const state = value.state === "pinned" ? ", pinned" : "";
   if (value.mode !== "x" && value.mode !== "y")
-    return `${datumLabel(model, value.focus.row)}; ${String(count)} ${count === 1 ? "datum" : "data"}${state}`;
+    return `${datumLabel(model, value.focus.row)}; ${countLabel(count)}${state}`;
   const seen = new Set<string>();
   const focused = value.focus.fields
     .filter((field) => {
@@ -51,5 +91,5 @@ export function inspectionLiveText(
     })
     .map((field) => `${field.field} ${String(field.value ?? "")}`)
     .join(", ");
-  return `${value.mode} ${value.axisLabel}; ${String(count)} ${count === 1 ? "datum" : "data"}${focused ? `; focused ${focused}` : ""}${state}`;
+  return `${value.mode} ${value.axisLabel}; ${countLabel(count)}${focused ? `; focused ${focused}` : ""}${state}`;
 }

--- a/packages/svelte/src/lib/plot-layout.ts
+++ b/packages/svelte/src/lib/plot-layout.ts
@@ -1,0 +1,46 @@
+/**
+ * Pure plot-root layout chrome: inline size/theme style and responsive
+ * breakpoint helpers. Hosts own class bindings and tool-rail visibility.
+ */
+
+const NARROW_TOOLS_MAX_WIDTH_PX = 560;
+const DOCKED_TOOLTIP_MAX_WIDTH_PX = 480;
+
+/** True when the tool rail should use the narrow layout (width < 560). */
+export function isNarrowToolsWidth(widthPx: number): boolean {
+  return widthPx < NARROW_TOOLS_MAX_WIDTH_PX;
+}
+
+/**
+ * True when a pinned tooltip should dock (width < 480).
+ * Host still ANDs with pinned inspection state for the docked binding.
+ */
+export function isDockedTooltipWidth(widthPx: number): boolean {
+  return widthPx < DOCKED_TOOLTIP_MAX_WIDTH_PX;
+}
+
+export type PlotRootStyleInput = {
+  /**
+   * When true, emit width/height CSS before theme tokens.
+   * Host: hasCanvas || interactive || emphasis || selection.
+   */
+  readonly needsSizedBox: boolean;
+  /** True when the width prop is undefined or `"container"`. */
+  readonly containerWidth: boolean;
+  /** Fixed-width CSS uses scene dimensions (model scene with resolved fallback). */
+  readonly sceneWidth: number;
+  readonly sceneHeight: number;
+  readonly themeStyle: string;
+};
+
+/**
+ * Root `style` attribute value.
+ * Sized box: `width:…;height:…;` then raw `themeStyle` (no extra separator).
+ * Empty concatenation → `undefined` (matches host `… || undefined`).
+ */
+export function plotRootInlineStyle(input: PlotRootStyleInput): string | undefined {
+  const sizeCss = input.needsSizedBox
+    ? `width:${input.containerWidth ? "100%" : `${input.sceneWidth}px`};height:${input.sceneHeight}px;`
+    : "";
+  return `${sizeCss}${input.themeStyle}` || undefined;
+}

--- a/packages/svelte/tests/plot-labels.test.ts
+++ b/packages/svelte/tests/plot-labels.test.ts
@@ -2,8 +2,22 @@ import { describe, expect, it } from "vitest";
 
 import type { RenderModel } from "@ggsvelte/core";
 
-import type { PlotInspectionChange } from "../src/lib/interaction.js";
-import { datumLabel, inspectionLiveText, markLabel } from "../src/lib/plot-labels.js";
+import type {
+  IntervalSelection,
+  LegendFocusEvent,
+  PlotInspectionChange,
+  PointSelection,
+} from "../src/lib/interaction.js";
+import {
+  BRUSH_SECOND_CORNER_ANNOUNCEMENT,
+  countLabel,
+  datumLabel,
+  inspectionLiveText,
+  legendFocusAnnouncement,
+  markLabel,
+  selectionAnnouncement,
+  zoomAnnouncement,
+} from "../src/lib/plot-labels.js";
 
 function model(opts: {
   layerFields?: { field: string }[][];
@@ -155,5 +169,91 @@ describe("inspectionLiveText", () => {
       ],
     });
     expect(inspectionLiveText(m, value as never)).toBe("x 3.0; 1 datum; focused y 9, color blue");
+  });
+});
+
+describe("countLabel", () => {
+  it("uses singular datum and plural data", () => {
+    expect(countLabel(0)).toBe("0 data");
+    expect(countLabel(1)).toBe("1 datum");
+    expect(countLabel(2)).toBe("2 data");
+  });
+});
+
+describe("selectionAnnouncement", () => {
+  const pointEnd = (keys: PropertyKey[]): PointSelection =>
+    Object.freeze({
+      type: "select",
+      phase: "end",
+      mode: "point",
+      keys: Object.freeze([...keys]),
+      source: "pointer",
+    });
+
+  const interval = (phase: IntervalSelection["phase"], lineageCount: number): IntervalSelection =>
+    Object.freeze({
+      type: "select",
+      phase,
+      mode: "xy",
+      panelId: null,
+      domain: Object.freeze({}),
+      pixels: Object.freeze({ x0: 0, y0: 0, x1: 1, y1: 1 }),
+      keys: Object.freeze([]),
+      lineageCount,
+      source: "pointer",
+    });
+
+  it("announces end with point key count or interval lineage count", () => {
+    expect(selectionAnnouncement(pointEnd(["a"]))).toBe("Selection complete, 1 datum.");
+    expect(selectionAnnouncement(pointEnd(["a", "b"]))).toBe("Selection complete, 2 data.");
+    expect(selectionAnnouncement(interval("end", 3))).toBe("Selection complete, 3 data.");
+  });
+
+  it("announces clear and skips start/change", () => {
+    expect(selectionAnnouncement(interval("clear", 0))).toBe("Selection cleared.");
+    expect(selectionAnnouncement(interval("start", 0))).toBeNull();
+    expect(selectionAnnouncement(interval("change", 1))).toBeNull();
+  });
+});
+
+describe("legendFocusAnnouncement", () => {
+  it("announces committed/previewed change and clear", () => {
+    const committed: LegendFocusEvent = {
+      type: "legend-focus",
+      phase: "change",
+      state: "committed",
+      source: "pointer",
+      scale: "fill",
+      value: "web",
+      label: "Web",
+      keys: ["a"],
+    };
+    const preview: LegendFocusEvent = {
+      ...committed,
+      state: "transient",
+      keys: ["a", "b"],
+    };
+    expect(legendFocusAnnouncement(committed)).toBe("Web focused, 1 datum.");
+    expect(legendFocusAnnouncement(preview)).toBe("Web previewed, 2 data.");
+    expect(
+      legendFocusAnnouncement({
+        type: "legend-focus",
+        phase: "clear",
+        source: "keyboard",
+      }),
+    ).toBe("Legend focus cleared.");
+  });
+});
+
+describe("zoomAnnouncement", () => {
+  it("distinguishes reset from complete via domains nullability", () => {
+    expect(zoomAnnouncement(null)).toBe("Zoom reset.");
+    expect(zoomAnnouncement({ x: [0, 1] })).toBe("Zoom complete.");
+  });
+});
+
+describe("BRUSH_SECOND_CORNER_ANNOUNCEMENT", () => {
+  it("matches the host brush-instruction copy", () => {
+    expect(BRUSH_SECOND_CORNER_ANNOUNCEMENT).toBe("Choose opposite corner.");
   });
 });

--- a/packages/svelte/tests/plot-layout.test.ts
+++ b/packages/svelte/tests/plot-layout.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isDockedTooltipWidth,
+  isNarrowToolsWidth,
+  plotRootInlineStyle,
+} from "../src/lib/plot-layout.js";
+
+describe("breakpoint helpers", () => {
+  it("narrow tools is width < 560", () => {
+    expect(isNarrowToolsWidth(559)).toBe(true);
+    expect(isNarrowToolsWidth(560)).toBe(false);
+  });
+
+  it("docked tooltip is width < 480", () => {
+    expect(isDockedTooltipWidth(479)).toBe(true);
+    expect(isDockedTooltipWidth(480)).toBe(false);
+  });
+});
+
+describe("plotRootInlineStyle", () => {
+  it("returns undefined when there is no size box and empty theme", () => {
+    expect(
+      plotRootInlineStyle({
+        needsSizedBox: false,
+        containerWidth: true,
+        sceneWidth: 640,
+        sceneHeight: 400,
+        themeStyle: "",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("returns theme alone when no size box is needed", () => {
+    expect(
+      plotRootInlineStyle({
+        needsSizedBox: false,
+        containerWidth: false,
+        sceneWidth: 100,
+        sceneHeight: 50,
+        themeStyle: "--gg-theme-interactionInk:#111",
+      }),
+    ).toBe("--gg-theme-interactionInk:#111");
+  });
+
+  it("emits container width 100% and scene height when sized", () => {
+    expect(
+      plotRootInlineStyle({
+        needsSizedBox: true,
+        containerWidth: true,
+        sceneWidth: 999,
+        sceneHeight: 400,
+        themeStyle: "",
+      }),
+    ).toBe("width:100%;height:400px;");
+  });
+
+  it("emits fixed scene width/height when sized and not container", () => {
+    expect(
+      plotRootInlineStyle({
+        needsSizedBox: true,
+        containerWidth: false,
+        sceneWidth: 320,
+        sceneHeight: 200,
+        themeStyle: "",
+      }),
+    ).toBe("width:320px;height:200px;");
+  });
+
+  it("concatenates size CSS and theme with no extra separator", () => {
+    expect(
+      plotRootInlineStyle({
+        needsSizedBox: true,
+        containerWidth: true,
+        sceneWidth: 640,
+        sceneHeight: 400,
+        themeStyle: "--t:1",
+      }),
+    ).toBe("width:100%;height:400px;--t:1");
+  });
+});


### PR DESCRIPTION
## Summary

- Extract selection, legend-focus, and zoom live-region announcement strings into unit-tested pure helpers in `plot-labels.ts`, plus a shared `countLabel` used by inspection live text.
- Extract plot-root size/theme CSS serialization and responsive width helpers into `plot-layout.ts`, wiring root classes, ToolRail `narrow`, and Tooltip `docked` through the same breakpoints.
- Thin GGPlot host wiring only; no intentional behavior change.

## Test plan

- [x] `bunx vitest run tests/plot-labels.test.ts tests/plot-layout.test.ts` (chromium/webkit/firefox)
- [x] `bun run check` in `packages/svelte`
- [ ] CI on PR