### PR TITLE
refactor(svelte): extract pure legend discrete-only diagnostics

### DIFF
--- a/packages/svelte/src/lib/GGPlot.svelte
+++ b/packages/svelte/src/lib/GGPlot.svelte
@@ -154,6 +154,7 @@
     bandChannelsForZoom,
     capabilityStatusText,
     filterAvailableTools,
+    legendFocusDiscreteOnlyDiagnostics,
     zoomScaleDiagnosticsFromChannels,
     zoomSupportsChannel,
   } from "./plot-capability.js";
@@ -735,19 +736,11 @@
     );
   });
   const legendDiagnostics = $derived.by(() => {
-    if (
-      interactionConfig.legendFocus === null ||
-      model === null ||
-      model.scene.legends.length === 0 ||
-      model.scene.legends.some((candidate) => candidate.type === "discrete")
-    )
-      return [] as InteractionDiagnostic[];
-    return [
-      {
-        ...INTERACTION_DIAGNOSTIC_CATALOG.INTERACTION_LEGEND_DISCRETE_ONLY,
-        actual: model.scene.legends.map((candidate) => candidate.type),
-      },
-    ];
+    if (model === null) return [] as InteractionDiagnostic[];
+    return legendFocusDiscreteOnlyDiagnostics(
+      interactionConfig.legendFocus !== null,
+      model.scene.legends,
+    );
   });
   const capabilityStatus = $derived.by(() => {
     const unavailable = interactionConfig.diagnostics.find(

--- a/packages/svelte/src/lib/plot-capability.ts
+++ b/packages/svelte/src/lib/plot-capability.ts
@@ -1,4 +1,8 @@
-import type { InteractionDiagnostic, InteractionTool } from "./interaction.js";
+import {
+  INTERACTION_DIAGNOSTIC_CATALOG,
+  type InteractionDiagnostic,
+  type InteractionTool,
+} from "./interaction.js";
 
 export type ZoomAreaMode = "x" | "y" | "xy";
 
@@ -74,4 +78,29 @@ export function capabilityStatusText(input: CapabilityStatusInput): string | nul
   )
     return "No inspectable marks";
   return null;
+}
+
+/** Legend type surface for discrete-only advisory (host maps scene legends). */
+export type LegendTypeRef = {
+  readonly type: string;
+};
+
+/**
+ * When legend focus is enabled and the scene has legends but none are discrete,
+ * return the INTERACTION_LEGEND_DISCRETE_ONLY advisory with `actual` legend types.
+ * Empty when disabled, no legends, or any discrete legend is present.
+ * Contract is "not discrete" (ramps, unknown types, etc.), not ramp-only.
+ */
+export function legendFocusDiscreteOnlyDiagnostics(
+  legendFocusEnabled: boolean,
+  legends: readonly LegendTypeRef[],
+): InteractionDiagnostic[] {
+  if (!legendFocusEnabled || legends.length === 0) return [];
+  if (legends.some((legend) => legend.type === "discrete")) return [];
+  return [
+    {
+      ...INTERACTION_DIAGNOSTIC_CATALOG.INTERACTION_LEGEND_DISCRETE_ONLY,
+      actual: legends.map((legend) => legend.type),
+    },
+  ];
 }

--- a/packages/svelte/tests/plot-capability.test.ts
+++ b/packages/svelte/tests/plot-capability.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
 
+import { INTERACTION_DIAGNOSTIC_CATALOG } from "../src/lib/interaction.js";
 import {
   bandChannelsForZoom,
   capabilityStatusText,
   filterAvailableTools,
+  legendFocusDiscreteOnlyDiagnostics,
   zoomScaleDiagnosticsFromChannels,
   zoomSupportsChannel,
 } from "../src/lib/plot-capability.js";
@@ -147,5 +149,30 @@ describe("capabilityStatusText", () => {
         candidateCount: 0,
       }),
     ).toBeNull();
+  });
+});
+
+describe("legendFocusDiscreteOnlyDiagnostics", () => {
+  const catalog = INTERACTION_DIAGNOSTIC_CATALOG.INTERACTION_LEGEND_DISCRETE_ONLY;
+
+  it("returns empty when disabled or there are no legends", () => {
+    expect(legendFocusDiscreteOnlyDiagnostics(false, [{ type: "ramp" }])).toEqual([]);
+    expect(legendFocusDiscreteOnlyDiagnostics(true, [])).toEqual([]);
+  });
+
+  it("returns empty when any legend is discrete", () => {
+    expect(legendFocusDiscreteOnlyDiagnostics(true, [{ type: "discrete" }])).toEqual([]);
+    expect(
+      legendFocusDiscreteOnlyDiagnostics(true, [{ type: "discrete" }, { type: "ramp" }]),
+    ).toEqual([]);
+  });
+
+  it("advises when every legend is non-discrete (ramp or unknown)", () => {
+    expect(legendFocusDiscreteOnlyDiagnostics(true, [{ type: "ramp" }])).toEqual([
+      { ...catalog, actual: ["ramp"] },
+    ]);
+    expect(
+      legendFocusDiscreteOnlyDiagnostics(true, [{ type: "ramp" }, { type: "continuous" }]),
+    ).toEqual([{ ...catalog, actual: ["ramp", "continuous"] }]);
   });
 });

--- a/packages/svelte/tests/plot-capability.test.ts
+++ b/packages/svelte/tests/plot-capability.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vitest";
 
-import { INTERACTION_DIAGNOSTIC_CATALOG } from "../src/lib/interaction.js";
 import {
   bandChannelsForZoom,
   capabilityStatusText,
@@ -153,8 +152,6 @@ describe("capabilityStatusText", () => {
 });
 
 describe("legendFocusDiscreteOnlyDiagnostics", () => {
-  const catalog = INTERACTION_DIAGNOSTIC_CATALOG.INTERACTION_LEGEND_DISCRETE_ONLY;
-
   it("returns empty when disabled or there are no legends", () => {
     expect(legendFocusDiscreteOnlyDiagnostics(false, [{ type: "ramp" }])).toEqual([]);
     expect(legendFocusDiscreteOnlyDiagnostics(true, [])).toEqual([]);
@@ -168,11 +165,25 @@ describe("legendFocusDiscreteOnlyDiagnostics", () => {
   });
 
   it("advises when every legend is non-discrete (ramp or unknown)", () => {
-    expect(legendFocusDiscreteOnlyDiagnostics(true, [{ type: "ramp" }])).toEqual([
-      { ...catalog, actual: ["ramp"] },
+    const rampOnly = legendFocusDiscreteOnlyDiagnostics(true, [{ type: "ramp" }]);
+    expect(rampOnly).toHaveLength(1);
+    const rampDiag = rampOnly[0];
+    expect(rampDiag).toMatchObject({
+      code: "INTERACTION_LEGEND_DISCRETE_ONLY",
+      severity: "advisory",
+      prop: "legendFocus",
+      actual: ["ramp"],
+    });
+    expect(typeof rampDiag.message).toBe("string");
+    expect(rampDiag.message.length).toBeGreaterThan(0);
+
+    const mixed = legendFocusDiscreteOnlyDiagnostics(true, [
+      { type: "ramp" },
+      { type: "continuous" },
     ]);
-    expect(
-      legendFocusDiscreteOnlyDiagnostics(true, [{ type: "ramp" }, { type: "continuous" }]),
-    ).toEqual([{ ...catalog, actual: ["ramp", "continuous"] }]);
+    expect(mixed[0]).toMatchObject({
+      code: "INTERACTION_LEGEND_DISCRETE_ONLY",
+      actual: ["ramp", "continuous"],
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Extract the inverted legend-focus discrete-only advisory gate from `GGPlot` into `legendFocusDiscreteOnlyDiagnostics` in `plot-capability.ts`.
- Bake the fixed `INTERACTION_LEGEND_DISCRETE_ONLY` catalog entry into the helper (contract is “no discrete legends,” not ramp-only).
- Thin host wiring keeps the null-model gate; existing legend-focus component coverage remains.

## Test plan

- [x] `bunx vitest run tests/plot-capability.test.ts tests/legend-focus.test.ts`
- [x] `bun run check` in `packages/svelte`
- [ ] CI on PR