### PR TITLE
refactor(svelte): extract pure scoped zoom domain projection

### DIFF
--- a/packages/svelte/src/lib/GGPlot.svelte
+++ b/packages/svelte/src/lib/GGPlot.svelte
@@ -182,6 +182,7 @@
   import {
     applyZoomToSpec,
     buildZoomEvent,
+    continuousZoomDomainsFromScopes,
     filterZoomDomainsByMode,
     resolveBrushZoomDomains,
     sanitizePartialZoomDomains,
@@ -1845,16 +1846,13 @@
             });
       if (transition === null) return;
       if (domains !== null) {
-        const x = transition.snapshot.zoom.x.find(
-          (domain) => domain.scope === resolvedInteractionScope.x,
-        )?.domain;
-        const y = transition.snapshot.zoom.y.find(
-          (domain) => domain.scope === resolvedInteractionScope.y,
-        )?.domain;
-        committed = frozenZoomDomains({
-          ...(x !== undefined && { x: [...x] }),
-          ...(y !== undefined && { y: [...y] }),
-        });
+        committed = frozenZoomDomains(
+          continuousZoomDomainsFromScopes(
+            transition.snapshot.zoom,
+            resolvedInteractionScope.x,
+            resolvedInteractionScope.y,
+          ),
+        );
       }
     }
     const event = buildZoomEvent(committed, source);

--- a/packages/svelte/src/lib/plot-zoom.ts
+++ b/packages/svelte/src/lib/plot-zoom.ts
@@ -12,6 +12,37 @@ import {
 
 export type ZoomMode = "x" | "y" | "xy";
 
+/** One controller/shared zoom channel entry keyed by interaction scope. */
+export type ScopedZoomChannel = {
+  readonly scope: string;
+  readonly domain: readonly [number, number];
+};
+
+/**
+ * Project controller zoom channel lists into a continuous domain bag for this
+ * plot's interaction scopes. Clones matching domain tuples. Omits missing
+ * channels. Undefined scopes never match (same as PlotInteractionScope.x/y).
+ * May return `{}` when neither scope matches (host freezes via
+ * `frozenZoomDomains`, matching commitZoom after a successful setZoom).
+ */
+export function continuousZoomDomainsFromScopes(
+  channels: {
+    readonly x: readonly ScopedZoomChannel[];
+    readonly y: readonly ScopedZoomChannel[];
+  },
+  scopeX: string | undefined,
+  scopeY: string | undefined,
+): ContinuousZoomDomains {
+  const x =
+    scopeX === undefined ? undefined : channels.x.find((domain) => domain.scope === scopeX)?.domain;
+  const y =
+    scopeY === undefined ? undefined : channels.y.find((domain) => domain.scope === scopeY)?.domain;
+  return {
+    ...(x !== undefined && { x: [x[0], x[1]] as [number, number] }),
+    ...(y !== undefined && { y: [y[0], y[1]] as [number, number] }),
+  };
+}
+
 const zoomScale = (
   config: Scales["x"] | undefined,
   domain: [number, number],

--- a/packages/svelte/tests/plot-zoom.test.ts
+++ b/packages/svelte/tests/plot-zoom.test.ts
@@ -5,6 +5,7 @@ import type { PortableSpec } from "@ggsvelte/spec";
 import {
   applyZoomToSpec,
   buildZoomEvent,
+  continuousZoomDomainsFromScopes,
   filterZoomDomainsByMode,
   resolveBrushZoomDomains,
   sameZoomDomains,
@@ -256,5 +257,73 @@ describe("buildZoomEvent", () => {
       domains: null,
     });
     expect(Object.isFrozen(event)).toBe(true);
+  });
+});
+
+describe("continuousZoomDomainsFromScopes", () => {
+  it("picks x and y by scope and clones domain tuples", () => {
+    const xDomain: [number, number] = [0, 1];
+    const yDomain: [number, number] = [2, 3];
+    const result = continuousZoomDomainsFromScopes(
+      {
+        x: [
+          { scope: "plot-a", domain: xDomain },
+          { scope: "other", domain: [9, 10] },
+        ],
+        y: [{ scope: "plot-a", domain: yDomain }],
+      },
+      "plot-a",
+      "plot-a",
+    );
+    expect(result).toEqual({ x: [0, 1], y: [2, 3] });
+    xDomain[0] = 99;
+    yDomain[1] = 88;
+    expect(result).toEqual({ x: [0, 1], y: [2, 3] });
+  });
+
+  it("omits missing channels and returns empty bag when neither matches", () => {
+    expect(
+      continuousZoomDomainsFromScopes(
+        {
+          x: [{ scope: "plot-a", domain: [0, 1] }],
+          y: [],
+        },
+        "plot-a",
+        "plot-b",
+      ),
+    ).toEqual({ x: [0, 1] });
+
+    expect(
+      continuousZoomDomainsFromScopes(
+        {
+          x: [],
+          y: [{ scope: "plot-b", domain: [4, 5] }],
+        },
+        "plot-a",
+        "plot-b",
+      ),
+    ).toEqual({ y: [4, 5] });
+
+    expect(
+      continuousZoomDomainsFromScopes(
+        {
+          x: [{ scope: "other", domain: [0, 1] }],
+          y: [{ scope: "other", domain: [2, 3] }],
+        },
+        "plot-a",
+        "plot-b",
+      ),
+    ).toEqual({});
+
+    expect(
+      continuousZoomDomainsFromScopes(
+        {
+          x: [{ scope: "plot-a", domain: [0, 1] }],
+          y: [{ scope: "plot-b", domain: [2, 3] }],
+        },
+        undefined,
+        undefined,
+      ),
+    ).toEqual({});
   });
 });

--- a/packages/svelte/tests/plot-zoom.test.ts
+++ b/packages/svelte/tests/plot-zoom.test.ts
@@ -315,14 +315,15 @@ describe("continuousZoomDomainsFromScopes", () => {
       ),
     ).toEqual({});
 
+    const unsetScope: string | undefined = void 0;
     expect(
       continuousZoomDomainsFromScopes(
         {
           x: [{ scope: "plot-a", domain: [0, 1] }],
           y: [{ scope: "plot-b", domain: [2, 3] }],
         },
-        undefined,
-        undefined,
+        unsetScope,
+        unsetScope,
       ),
     ).toEqual({});
   });


### PR DESCRIPTION
## Summary

- Extract `continuousZoomDomainsFromScopes` from `GGPlot` `commitZoom` into `plot-zoom.ts`.
- Project controller zoom channel lists into a continuous domain bag by interaction scope, cloning domain tuples and treating undefined scopes as non-matching.
- Thin host wiring freezes the result with `frozenZoomDomains` as before; no intentional behavior change.

## Test plan

- [x] `bunx vitest run tests/plot-zoom.test.ts` (chromium/webkit/firefox)
- [x] `bun run check` in `packages/svelte`
- [ ] CI on PR