### PR TITLE
fix: address post-merge Codex findings from #50

### DIFF
--- a/packages/core/src/pipeline.ts
+++ b/packages/core/src/pipeline.ts
@@ -210,6 +210,11 @@ export interface RenderModel {
   layerBackends: LayerBackend[];
   /** Field-mapped channels per layer (drives default tooltip content). */
   layerFields: MappedField[][];
+  /**
+   * Scaled constant aes values per layer (`{ value, scale: true }` on color/fill).
+   * Used by legend-focus key indexing when no field mapping exists for a scale.
+   */
+  layerScaledConstants: ReadonlyArray<Readonly<Partial<Record<string, CellValue>>>>;
   /** Stable baseline plus the domains actually used for this render. */
   domains: Readonly<{ baseline: ScaleDomainSnapshot; effective: ScaleDomainSnapshot }>;
   /** Interned source-row memberships. Public adapters resolve these through keys. */
@@ -3435,6 +3440,19 @@ export function runPipeline(spec: SpecInput | PortableSpec, options: RunOptions)
     return fields;
   });
 
+  // Legend-focus contract: scaled constant channels with no field mapping.
+  const layerScaledConstants: ReadonlyArray<Readonly<Partial<Record<string, CellValue>>>> =
+    Object.freeze(
+      normalized.layers.map((_layer, index) => {
+        const binding = bindings[index];
+        if (binding === undefined) return Object.freeze({});
+        const out: Partial<Record<string, CellValue>> = {};
+        if (binding.color.scaledConstant !== null) out["color"] = binding.color.scaledConstant;
+        if (binding.fill.scaledConstant !== null) out["fill"] = binding.fill.scaledConstant;
+        return Object.freeze(out);
+      }),
+    );
+
   const state: Record<string, ScaleState> = {};
   if (colorResolution.state !== null) state["color"] = colorResolution.state;
   if (fillResolution.state !== null) state["fill"] = fillResolution.state;
@@ -3720,6 +3738,7 @@ export function runPipeline(spec: SpecInput | PortableSpec, options: RunOptions)
     runId,
     layerBackends,
     layerFields,
+    layerScaledConstants,
     domains: Object.freeze({ baseline: baselineDomains, effective: effectiveDomains }),
     lineage,
     candidates,

--- a/packages/svelte/src/lib/GGPlot.svelte
+++ b/packages/svelte/src/lib/GGPlot.svelte
@@ -126,6 +126,8 @@
     resolveLegendClickAction,
     resolveLegendKeyAction,
     resolveLegendPointerUpAction,
+    shouldClearLegendPreviewOnBlur,
+    shouldRenderInteractionLiveRegion,
   } from "./plot-legend-surface.js";
   import {
     BRUSH_SECOND_CORNER_ANNOUNCEMENT,
@@ -196,6 +198,9 @@
     keysForLegendEntry,
     legendInteractionSource,
     moveLegendRovingIndex,
+    reconcileLegendPreview,
+    resolveLegendEmphasisKeys,
+    resolveLegendPreviewKeysDecision,
     samePropertyKeySet,
     type LegendEntryAction,
     type LegendEntryIdentity,
@@ -697,11 +702,15 @@
   });
   const effectiveEmphasisKeys: readonly PropertyKey[] = $derived.by(() => {
     void controllerRevision;
-    return (
-      legendPreview?.keys ??
-      interaction?.emphasized(resolvedInteractionScope) ??
-      localEmphasisKeys
-    );
+    return resolveLegendEmphasisKeys({
+      legendFocusEnabled: interactionConfig.legendFocus !== null,
+      previewKeys: legendPreview?.keys ?? null,
+      controllerKeys:
+        interaction === undefined
+          ? null
+          : interaction.emphasized(resolvedInteractionScope),
+      localKeys: localEmphasisKeys,
+    });
   });
   let committedInterval = $state<IntervalSelection | null>(null);
   const zoomHasSupportedChannel = $derived.by(() => {
@@ -990,6 +999,8 @@
           }
         },
         layerFields: (layerIndex) => current.layerFields[layerIndex],
+        layerScaledConstant: (layerIndex, channel) =>
+          current.layerScaledConstants[layerIndex]?.[channel],
         lineageKeys: (lineageId) => current.lineage.keys(lineageId),
         row: (rowIndex) => current.row(rowIndex),
         semanticKey: (rowIndex) => semanticKeys.keys.get(rowIndex),
@@ -1017,9 +1028,13 @@
         emitLegendFocus({ type: "legend-focus", phase: "clear", source });
       return;
     }
-    const keys = keysForLegend(action);
-    if (keys.length === 0) return;
-    legendPreview = { action, keys };
+    const decision = resolveLegendPreviewKeysDecision(keysForLegend(action));
+    if (decision.type === "clear") {
+      // Empty domain entry: do not leave the previous entry's preview active.
+      previewLegend(null);
+      return;
+    }
+    legendPreview = { action, keys: decision.keys };
     emitLegendFocus({
       type: "legend-focus",
       phase: "change",
@@ -1028,7 +1043,7 @@
       scale: action.identity.scale as "color" | "fill",
       value: action.entry.value as CellValue,
       label: action.entry.label,
-      keys,
+      keys: decision.keys,
     });
   }
 
@@ -1206,6 +1221,40 @@
     }
   });
 
+  // Reconcile transient preview when data/domain reshuffles entry membership.
+  $effect(() => {
+    const preview = legendPreview;
+    if (preview === null) return;
+    const next = reconcileLegendPreview({
+      preview: { identity: preview.action.identity, keys: preview.keys },
+      entries: interactiveLegendEntries,
+      keyIndex: legendEntryKeyIndex,
+    });
+    if (next === null) {
+      previewLegend(null);
+      return;
+    }
+    if (samePropertyKeySet(next.keys, preview.keys)) return;
+    legendPreview = {
+      action: { ...preview.action, identity: next.identity },
+      keys: next.keys,
+    };
+  });
+
+  // Drop chart-local emphasis when legend focus is turned off at runtime.
+  $effect(() => {
+    if (interactionConfig.legendFocus !== null) return;
+    if (
+      legendPreview === null &&
+      localEmphasisKeys.length === 0 &&
+      legendCommitted === null
+    )
+      return;
+    legendPreview = null;
+    legendCommitted = null;
+    if (interaction === undefined) localEmphasisKeys = [];
+  });
+
   function legendAction(
     index: number,
     source: LegendEntryAction["source"],
@@ -1314,8 +1363,10 @@
 
   function onLegendBlur(event: FocusEvent): void {
     if (
-      event.relatedTarget instanceof Element &&
-      event.relatedTarget.matches("[data-gg-legend-target]")
+      !shouldClearLegendPreviewOnBlur({
+        relatedTarget: event.relatedTarget,
+        root,
+      })
     )
       return;
     previewLegend(null);
@@ -2371,17 +2422,6 @@
           ? "No active datum"
           : datumLabel(inspection.focus.row)}
       </p>
-      <div
-        id={`${plotId}-live`}
-        class="gg-sr-only"
-        aria-live="polite"
-        aria-atomic="true"
-      >
-        {interactionAnnouncement ||
-          (inspection?.source === "keyboard" || inspection?.source === "touch"
-            ? inspectionLiveText(inspection)
-            : "")}
-      </div>
       {#if areaAwaitingSecond}
         <p class="gg-area-instruction">Choose opposite corner</p>
       {/if}
@@ -2409,6 +2449,19 @@
           onclose={(source) => closeInspection(source, true)}
         />
       {/if}
+    {/if}
+    {#if shouldRenderInteractionLiveRegion( { surfaceInteractive, legendFocusEnabled: interactionConfig.legendFocus !== null } )}
+      <div
+        id={`${plotId}-live`}
+        class="gg-sr-only"
+        aria-live="polite"
+        aria-atomic="true"
+      >
+        {interactionAnnouncement ||
+          (inspection?.source === "keyboard" || inspection?.source === "touch"
+            ? inspectionLiveText(inspection)
+            : "")}
+      </div>
     {/if}
     {#if emptyPlot}
       <div class="gg-empty-state" role="status">No data to display</div>

--- a/packages/svelte/src/lib/plot-legend-focus.ts
+++ b/packages/svelte/src/lib/plot-legend-focus.ts
@@ -52,6 +52,12 @@ export type LegendKeyIndexAdapter = {
   /** Candidates in id-ascending order (null candidates already filtered). */
   candidates(): Iterable<LegendKeyCandidate>;
   layerFields(layerIndex: number): readonly LegendMappedField[] | undefined;
+  /**
+   * Scaled constant for a layer channel (`aes: { color: { value, scale: true } }`).
+   * When present and no field mapping exists, every row of the layer matches
+   * the legend entry equal to this value.
+   */
+  layerScaledConstant?(layerIndex: number, channel: string): unknown;
   lineageKeys(lineageId: number): Iterable<number>;
   row(rowIndex: number): Record<string, CellValue> | null;
   /** Semantic key for a source row; null/undefined rows are skipped. */
@@ -171,13 +177,28 @@ export function findLegendPressedIdentity(
  * - Pre-seed empty buckets for every discrete entry (unmatched stay []).
  * - Skip ramp legends and null candidates.
  * - Map only non-stat fields whose channel equals the legend scale.
+ * - When no field mapping exists, fall back to layerScaledConstant for that
+ *   channel (scaled constant aes) and match the constant against entries.
  * - Row membership = lineage row indexes (insertion order) then candidate
  *   rowIndex if not already present.
- * - Visit key is scale:layerIndex:field:rowIndex (dedupe repeated candidates).
- * - Skip null rows and null/undefined semantic keys.
+ * - Visit key is scale:layerIndex:field|const:rowIndex (dedupe repeated candidates).
+ * - Skip null rows (field path) / null keys; constant path only needs keys.
  * - Match entry values with legendValueEqual (NaN, Date, -0/0).
  * - Final keys are first-seen unique order, frozen.
  */
+/** Row field value or scaled constant; `skip` when the row is missing. */
+function resolveLegendMatchValue(
+  adapter: LegendKeyIndexAdapter,
+  field: string | undefined,
+  scaledConstant: unknown,
+  rowIndex: number,
+): { readonly skip: true } | { readonly skip: false; readonly value: unknown } {
+  if (field === undefined) return { skip: false, value: scaledConstant };
+  const row = adapter.row(rowIndex);
+  if (row === null) return { skip: true };
+  return { skip: false, value: row[field] };
+}
+
 export function buildLegendEntryKeyIndex(
   adapter: LegendKeyIndexAdapter,
 ): ReadonlyMap<string, readonly PropertyKey[]> {
@@ -194,18 +215,24 @@ export function buildLegendEntryKeyIndex(
       const field = adapter
         .layerFields(candidate.layerIndex)
         ?.find((mapped) => mapped.channel === sceneLegend.scale && mapped.source !== "stat")?.field;
-      if (field === undefined) continue;
+      const scaledConstant =
+        field === undefined
+          ? adapter.layerScaledConstant?.(candidate.layerIndex, sceneLegend.scale)
+          : undefined;
+      if (field === undefined && scaledConstant === undefined) continue;
       const sourceRows = new Set(adapter.lineageKeys(candidate.lineage));
       if (candidate.rowIndex !== null) sourceRows.add(candidate.rowIndex);
       for (const rowIndex of sourceRows) {
-        const visit = `${sceneLegend.scale}:${String(candidate.layerIndex)}:${field}:${String(rowIndex)}`;
+        const visitField = field ?? `const:${String(scaledConstant)}`;
+        const visit = `${sceneLegend.scale}:${String(candidate.layerIndex)}:${visitField}:${String(rowIndex)}`;
         if (visited.has(visit)) continue;
         visited.add(visit);
-        const row = adapter.row(rowIndex);
         const key = adapter.semanticKey(rowIndex);
-        if (row === null || key === null || key === undefined) continue;
+        if (key === null || key === undefined) continue;
+        const matched = resolveLegendMatchValue(adapter, field, scaledConstant, rowIndex);
+        if (matched.skip) continue;
         const entryIndex = sceneLegend.entries.findIndex((entry) =>
-          legendValueEqual(entry.value, row[field]),
+          legendValueEqual(entry.value, matched.value),
         );
         if (entryIndex < 0) continue;
         index.get(legendIdentityKey({ scale: sceneLegend.scale, entryIndex }))?.push(key);
@@ -215,4 +242,58 @@ export function buildLegendEntryKeyIndex(
   return new Map(
     [...index].map(([identity, keys]) => [identity, Object.freeze([...new Set(keys)])]),
   );
+}
+
+/**
+ * Decide what a legend preview attempt should do with resolved keys.
+ * Empty key sets clear any active preview (empty domain entry / stale target)
+ * rather than leaving the previous entry highlighted.
+ */
+export function resolveLegendPreviewKeysDecision(
+  keys: readonly PropertyKey[],
+): { readonly type: "set"; readonly keys: readonly PropertyKey[] } | { readonly type: "clear" } {
+  return keys.length === 0 ? { type: "clear" } : { type: "set", keys };
+}
+
+/**
+ * Emphasis keys shown while legend focus is enabled vs disabled.
+ * When disabled, chart-local preview and local commits must not mute the plot
+ * (controls are gone). Controller emphasis still flows through when present.
+ */
+export function resolveLegendEmphasisKeys(input: {
+  readonly legendFocusEnabled: boolean;
+  readonly previewKeys: readonly PropertyKey[] | null;
+  readonly controllerKeys: readonly PropertyKey[] | null;
+  readonly localKeys: readonly PropertyKey[];
+}): readonly PropertyKey[] {
+  if (!input.legendFocusEnabled) return input.controllerKeys ?? [];
+  return input.previewKeys ?? input.controllerKeys ?? input.localKeys;
+}
+
+export type LegendPreviewState = {
+  readonly identity: LegendEntryIdentity;
+  readonly keys: readonly PropertyKey[];
+};
+
+/**
+ * Reconcile a transient preview against the current entry list / key index.
+ * Clears when the identity disappears or its keys empty; refreshes keys when
+ * membership changes for the same identity.
+ */
+export function reconcileLegendPreview(input: {
+  readonly preview: LegendPreviewState | null;
+  readonly entries: readonly InteractiveLegendEntry[];
+  readonly keyIndex: ReadonlyMap<string, readonly PropertyKey[]>;
+}): LegendPreviewState | null {
+  if (input.preview === null) return null;
+  const current = input.entries.find(
+    ({ identity }) =>
+      identity.scale === input.preview!.identity.scale &&
+      identity.entryIndex === input.preview!.identity.entryIndex,
+  );
+  if (current === undefined) return null;
+  const keys = keysForLegendEntry(input.keyIndex, current.identity);
+  if (keys.length === 0) return null;
+  if (samePropertyKeySet(keys, input.preview.keys)) return input.preview;
+  return { identity: current.identity, keys };
 }

--- a/packages/svelte/src/lib/plot-legend-surface.ts
+++ b/packages/svelte/src/lib/plot-legend-surface.ts
@@ -110,3 +110,40 @@ export function resolveLegendClickAction(input: LegendClickInput): LegendClickAc
     source: input.detail === 0 ? "keyboard" : "pointer",
   };
 }
+
+// ---- blur (preview clear gate) ----
+
+export type LegendBlurInput = {
+  readonly relatedTarget: EventTarget | null;
+  /** Host plot root; null when unmounted. */
+  readonly root: ParentNode | null;
+};
+
+/**
+ * Whether blur should clear transient legend preview.
+ *
+ * Retain preview only when focus moves to another legend target **inside this
+ * plot's root**. Cross-plot moves to another `[data-gg-legend-target]` must
+ * clear, or the previous plot stays muted with a stale preview.
+ */
+export function shouldClearLegendPreviewOnBlur(input: LegendBlurInput): boolean {
+  if (!(input.relatedTarget instanceof Element)) return true;
+  if (!input.relatedTarget.matches("[data-gg-legend-target]")) return true;
+  if (input.root === null) return true;
+  return !input.root.contains(input.relatedTarget);
+}
+
+// ---- live region gate ----
+
+export type InteractionLiveRegionInput = {
+  readonly surfaceInteractive: boolean;
+  readonly legendFocusEnabled: boolean;
+};
+
+/**
+ * Live region is required for surface tools **or** legend-only focus so
+ * keyboard commits/clears still announce when inspect/select/zoom are off.
+ */
+export function shouldRenderInteractionLiveRegion(input: InteractionLiveRegionInput): boolean {
+  return input.surfaceInteractive || input.legendFocusEnabled;
+}

--- a/packages/svelte/tests/plot-legend-focus.test.ts
+++ b/packages/svelte/tests/plot-legend-focus.test.ts
@@ -11,6 +11,9 @@ import {
   legendIdentityKey,
   legendInteractionSource,
   moveLegendRovingIndex,
+  reconcileLegendPreview,
+  resolveLegendEmphasisKeys,
+  resolveLegendPreviewKeysDecision,
   samePropertyKeySet,
   type InteractiveLegendEntry,
   type LegendKeyIndexAdapter,
@@ -237,12 +240,14 @@ function adapter(partial: {
     rowIndex: number | null;
   }[];
   fields?: Record<number, readonly { channel: string; field: string; source?: "stat" }[]>;
+  scaledConstants?: Record<number, Record<string, unknown>>;
   lineages?: Record<number, readonly number[]>;
   rows?: Record<number, Record<string, unknown> | null>;
   keys?: Record<number, PropertyKey | null | undefined>;
 }): LegendKeyIndexAdapter {
   const candidates = partial.candidates ?? [];
   const fields = partial.fields ?? {};
+  const scaledConstants = partial.scaledConstants ?? {};
   const lineages = partial.lineages ?? {};
   const rows = partial.rows ?? {};
   const keys = partial.keys ?? {};
@@ -250,6 +255,7 @@ function adapter(partial: {
     legends: partial.legends ?? [discreteFill],
     candidates: () => candidates,
     layerFields: (layerIndex) => fields[layerIndex],
+    layerScaledConstant: (layerIndex, channel) => scaledConstants[layerIndex]?.[channel],
     lineageKeys: (lineageId) => lineages[lineageId] ?? [],
     row: (rowIndex) => (rows[rowIndex] as Record<string, never> | null) ?? null,
     semanticKey: (rowIndex) => keys[rowIndex],
@@ -433,6 +439,117 @@ describe("buildLegendEntryKeyIndex", () => {
       }),
     );
     expect(index.get("fill:0")).toEqual([sym]);
+  });
+
+  it("maps scaled-constant layers onto the matching legend entry", () => {
+    const index = buildLegendEntryKeyIndex(
+      adapter({
+        candidates: [
+          { layerIndex: 0, lineage: 1, rowIndex: null },
+          { layerIndex: 0, lineage: 2, rowIndex: null },
+        ],
+        // No field mapping — constant-only layer.
+        scaledConstants: { 0: { fill: "web" } },
+        lineages: { 1: [0], 2: [1] },
+        rows: { 0: {}, 1: {} },
+        keys: { 0: "const-a", 1: "const-b" },
+      }),
+    );
+    expect(index.get("fill:0")).toEqual(["const-a", "const-b"]);
+    expect(index.get("fill:1")).toEqual([]);
+  });
+});
+
+describe("resolveLegendPreviewKeysDecision", () => {
+  it("clears when the entry has no keys and sets otherwise", () => {
+    expect(resolveLegendPreviewKeysDecision([])).toEqual({ type: "clear" });
+    expect(resolveLegendPreviewKeysDecision(["a"])).toEqual({ type: "set", keys: ["a"] });
+  });
+});
+
+describe("resolveLegendEmphasisKeys", () => {
+  it("drops local/preview emphasis when legend focus is disabled", () => {
+    expect(
+      resolveLegendEmphasisKeys({
+        legendFocusEnabled: false,
+        previewKeys: ["p"],
+        controllerKeys: null,
+        localKeys: ["l"],
+      }),
+    ).toEqual([]);
+    expect(
+      resolveLegendEmphasisKeys({
+        legendFocusEnabled: false,
+        previewKeys: ["p"],
+        controllerKeys: ["c"],
+        localKeys: ["l"],
+      }),
+    ).toEqual(["c"]);
+  });
+
+  it("prefers preview then controller then local when enabled", () => {
+    expect(
+      resolveLegendEmphasisKeys({
+        legendFocusEnabled: true,
+        previewKeys: ["p"],
+        controllerKeys: ["c"],
+        localKeys: ["l"],
+      }),
+    ).toEqual(["p"]);
+    expect(
+      resolveLegendEmphasisKeys({
+        legendFocusEnabled: true,
+        previewKeys: null,
+        controllerKeys: null,
+        localKeys: ["l"],
+      }),
+    ).toEqual(["l"]);
+  });
+});
+
+describe("reconcileLegendPreview", () => {
+  const entries = buildInteractiveLegendEntries([discreteFill]);
+  const keyIndex = new Map<string, readonly PropertyKey[]>([
+    ["fill:0", Object.freeze(["a", "c"])],
+    ["fill:1", Object.freeze(["b"])],
+  ]);
+
+  it("clears when the entry disappears or has empty keys", () => {
+    expect(
+      reconcileLegendPreview({
+        preview: { identity: { scale: "fill", entryIndex: 9 }, keys: ["x"] },
+        entries,
+        keyIndex,
+      }),
+    ).toBeNull();
+    const emptyIndex = new Map<string, readonly PropertyKey[]>([["fill:0", Object.freeze([])]]);
+    expect(
+      reconcileLegendPreview({
+        preview: { identity: { scale: "fill", entryIndex: 0 }, keys: ["a"] },
+        entries,
+        keyIndex: emptyIndex,
+      }),
+    ).toBeNull();
+  });
+
+  it("refreshes keys when membership changes for the same identity", () => {
+    const next = reconcileLegendPreview({
+      preview: { identity: { scale: "fill", entryIndex: 0 }, keys: ["stale"] },
+      entries,
+      keyIndex,
+    });
+    expect(next).toEqual({ identity: { scale: "fill", entryIndex: 0 }, keys: ["a", "c"] });
+  });
+
+  it("keeps the same object when keys still match", () => {
+    const preview = { identity: { scale: "fill", entryIndex: 0 }, keys: ["a", "c"] as const };
+    expect(
+      reconcileLegendPreview({
+        preview,
+        entries,
+        keyIndex,
+      }),
+    ).toBe(preview);
   });
 });
 

--- a/packages/svelte/tests/plot-legend-surface.test.ts
+++ b/packages/svelte/tests/plot-legend-surface.test.ts
@@ -4,6 +4,8 @@ import {
   resolveLegendClickAction,
   resolveLegendKeyAction,
   resolveLegendPointerUpAction,
+  shouldClearLegendPreviewOnBlur,
+  shouldRenderInteractionLiveRegion,
   type LegendClickInput,
   type LegendKeyInput,
   type LegendPointerUpInput,
@@ -118,5 +120,50 @@ describe("resolveLegendClickAction", () => {
       type: "commit",
       source: "pointer",
     });
+  });
+});
+
+describe("shouldClearLegendPreviewOnBlur", () => {
+  it("clears when relatedTarget is null or not a legend target", () => {
+    const root = document.createElement("div");
+    expect(shouldClearLegendPreviewOnBlur({ relatedTarget: null, root })).toBe(true);
+    const other = document.createElement("button");
+    expect(shouldClearLegendPreviewOnBlur({ relatedTarget: other, root })).toBe(true);
+  });
+
+  it("retains only when the next legend target is inside this plot root", () => {
+    const root = document.createElement("div");
+    const inside = document.createElement("button");
+    inside.dataset.ggLegendTarget = "";
+    root.append(inside);
+    const outside = document.createElement("button");
+    outside.dataset.ggLegendTarget = "";
+    document.body.append(outside);
+    expect(shouldClearLegendPreviewOnBlur({ relatedTarget: inside, root })).toBe(false);
+    expect(shouldClearLegendPreviewOnBlur({ relatedTarget: outside, root })).toBe(true);
+    outside.remove();
+  });
+});
+
+describe("shouldRenderInteractionLiveRegion", () => {
+  it("renders for surface tools or legend-only focus", () => {
+    expect(
+      shouldRenderInteractionLiveRegion({
+        surfaceInteractive: false,
+        legendFocusEnabled: true,
+      }),
+    ).toBe(true);
+    expect(
+      shouldRenderInteractionLiveRegion({
+        surfaceInteractive: true,
+        legendFocusEnabled: false,
+      }),
+    ).toBe(true);
+    expect(
+      shouldRenderInteractionLiveRegion({
+        surfaceInteractive: false,
+        legendFocusEnabled: false,
+      }),
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Follow-up for unrebutted post-merge/pre-merge-async Codex findings on #50 (linked interactive legend focus).

### Valid → fixed
1. **Clear preview when focus leaves this plot** — blur retained preview for any `[data-gg-legend-target]`; now requires the target inside this plot root.
2. **Clear stale previews for empty legend entries** — empty key sets clear the active preview instead of no-op.
3. **Include scaled constants in legend focus keys** — `RenderModel.layerScaledConstants` + key-index fallback when no field mapping exists.
4. **Drop local emphasis when legend focus is disabled** — local preview/commit ignored and cleared when capability is off; controller emphasis still flows.
5. **Clear stale previews when legend entries change** — reconcile transient preview against current entries/key index.
6. **Render the live region for legend-only focus** — live region gates on surface tools **or** legend focus.

### Invalid / deferred (rebutted on parent)
- **Preserve signed-zero legend membership** — intentional: `legendValueEqual(-0, 0)` is true and covered by tests; scale `encodeKey` keeps `-0` for other uses.
- **Draw focused SVG marks above later batches** — valid product gap vs canvas panel-wide passes, but a dual muted/focused SVG pass destroys stable mark node identity that inspect/tooltip tests and keyboard focus rely on. Deferred to a dedicated renderer pass.

## Test plan
- [x] `bun run test:components` (1332 browser + 4 SSR)
- [x] `bun test packages/core`
- [x] `bun run check` + `packages/svelte` svelte-check
- Pure unit coverage in `plot-legend-focus.test.ts` / `plot-legend-surface.test.ts`

Parent: #50