### PR TITLE
refactor(svelte): extract pure legend clear-control source resolver

### DIFF
--- a/packages/svelte/src/lib/GGPlot.svelte
+++ b/packages/svelte/src/lib/GGPlot.svelte
@@ -123,6 +123,7 @@
     resolvePointerUpAction,
   } from "./plot-surface-pointer.js";
   import {
+    resolveLegendClearControlSource,
     resolveLegendClickAction,
     resolveLegendKeyAction,
     resolveLegendPointerUpAction,
@@ -1049,12 +1050,10 @@
     const returnTarget = root?.querySelector<HTMLElement>(
       ".gg-legend-target[aria-pressed='true']",
     );
-    const source: InteractionSource =
-      event.detail === 0
-        ? "keyboard"
-        : legendClearPointerType === "touch"
-          ? "touch"
-          : "pointer";
+    const source = resolveLegendClearControlSource({
+      detail: event.detail,
+      pointerType: legendClearPointerType,
+    });
     legendClearPointerType = null;
     clearLegendFocus(source);
     queueMicrotask(() => {

--- a/packages/svelte/src/lib/plot-legend-surface.ts
+++ b/packages/svelte/src/lib/plot-legend-surface.ts
@@ -6,6 +6,8 @@
  * key routing and touch/click coordination priority.
  */
 
+import type { InteractionSource } from "./interaction.js";
+
 // ---- keydown ----
 
 export type LegendKeyInput = {
@@ -109,4 +111,27 @@ export function resolveLegendClickAction(input: LegendClickInput): LegendClickAc
     type: "commit",
     source: input.detail === 0 ? "keyboard" : "pointer",
   };
+}
+
+// ---- clear control click ----
+
+export type LegendClearControlInput = {
+  /** MouseEvent.detail from the clear control click. */
+  readonly detail: number;
+  /**
+   * Host `legendClearPointerType` from pointerdown on the clear control
+   * (null when never set / after cancel).
+   */
+  readonly pointerType: string | null;
+};
+
+/**
+ * Pure InteractionSource for the legend clear control `click`.
+ * Priority: detail === 0 → keyboard; pointerType === "touch" → touch; else pointer.
+ * Host still clears `legendClearPointerType` after classification.
+ */
+export function resolveLegendClearControlSource(input: LegendClearControlInput): InteractionSource {
+  if (input.detail === 0) return "keyboard";
+  if (input.pointerType === "touch") return "touch";
+  return "pointer";
 }

--- a/packages/svelte/tests/plot-legend-surface.test.ts
+++ b/packages/svelte/tests/plot-legend-surface.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  resolveLegendClearControlSource,
   resolveLegendClickAction,
   resolveLegendKeyAction,
   resolveLegendPointerUpAction,
+  type LegendClearControlInput,
   type LegendClickInput,
   type LegendKeyInput,
   type LegendPointerUpInput,
@@ -118,5 +120,40 @@ describe("resolveLegendClickAction", () => {
       type: "commit",
       source: "pointer",
     });
+  });
+});
+
+describe("resolveLegendClearControlSource", () => {
+  const clear = (overrides: Partial<LegendClearControlInput> = {}): LegendClearControlInput => ({
+    detail: 1,
+    pointerType: null,
+    ...overrides,
+  });
+
+  it("classifies detail === 0 as keyboard even when pointerType is touch", () => {
+    expect(resolveLegendClearControlSource(clear({ detail: 0, pointerType: null }))).toBe(
+      "keyboard",
+    );
+    expect(resolveLegendClearControlSource(clear({ detail: 0, pointerType: "touch" }))).toBe(
+      "keyboard",
+    );
+  });
+
+  it("classifies touch pointerType when detail > 0", () => {
+    expect(resolveLegendClearControlSource(clear({ detail: 1, pointerType: "touch" }))).toBe(
+      "touch",
+    );
+  });
+
+  it("classifies non-touch detail > 0 as pointer", () => {
+    expect(resolveLegendClearControlSource(clear({ detail: 1, pointerType: "mouse" }))).toBe(
+      "pointer",
+    );
+    expect(resolveLegendClearControlSource(clear({ detail: 2, pointerType: "pen" }))).toBe(
+      "pointer",
+    );
+    expect(resolveLegendClearControlSource(clear({ detail: 1, pointerType: null }))).toBe(
+      "pointer",
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Extract `resolveLegendClearControlSource` from `GGPlot` `clearLegendFromControl` into `plot-legend-surface.ts`.
- Classify clear-control clicks with the existing priority: `detail === 0` → keyboard, stored touch pointer type → touch, otherwise pointer.
- Host still clears `legendClearPointerType` after classification; no intentional behavior change.

## Test plan

- [x] `bunx vitest run tests/plot-legend-surface.test.ts` (chromium/webkit/firefox)
- [x] `bun run check` in `packages/svelte`
- [ ] CI on PR