### PR TITLE
fix: address post-merge Codex findings from #54

### DIFF
--- a/packages/spec/tests/manual-at-alias-audit.test.ts
+++ b/packages/spec/tests/manual-at-alias-audit.test.ts
@@ -7,6 +7,7 @@ import {
   findSubstantiveRuntimePaths,
   isRuntimeBehaviorPath,
   isSkippableCommentLine,
+  listChangedFilesFromNameStatus,
   packageVersionAtCommit,
   runtimeBehaviorPaths,
 } from "./manual-at-alias-audit.ts";
@@ -36,6 +37,10 @@ describe("manual AT alias commit audit", () => {
     expect(isSkippableCommentLine(" // re-export surface")).toBe(true);
     expect(isSkippableCommentLine(" * { pointer-events: none; }")).toBe(false);
     expect(isSkippableCommentLine("*.mark { opacity: 0.4; }")).toBe(false);
+    // Combinators after `*` must stay substantive (not JSDoc).
+    expect(isSkippableCommentLine(" * + * { margin: 0; }")).toBe(false);
+    expect(isSkippableCommentLine("* > .mark { opacity: 1; }")).toBe(false);
+    expect(isSkippableCommentLine("* ~ * { display: none; }")).toBe(false);
     expect(
       diffTextIsSubstantive(`diff --git a/x.svelte b/x.svelte
 --- a/x.svelte
@@ -43,6 +48,15 @@ describe("manual AT alias commit audit", () => {
 @@ -1 +1 @@
 -* { pointer-events: auto; }
 +* { pointer-events: none; }
+`),
+    ).toBe(true);
+    expect(
+      diffTextIsSubstantive(`diff --git a/x.svelte b/x.svelte
+--- a/x.svelte
++++ b/x.svelte
+@@ -1 +1 @@
+-* + * { margin: 0; }
++* + * { margin: 4px; }
 `),
     ).toBe(true);
     expect(
@@ -108,5 +122,27 @@ describe("manual AT alias commit audit", () => {
         releaseVersion: packageVersionAtCommit(repoRoot, withRuntime),
       });
     }).toThrow(/requires a complete record/);
+  });
+
+  it("lists both sides of renames when collecting changed paths", () => {
+    // Rename out of packages/svelte/src must still surface the source path.
+    expect(
+      listChangedFilesFromNameStatus(
+        [
+          "M\tpackages/spec/src/artifact.ts",
+          "R100\tpackages/svelte/src/lib/Old.svelte\tpackages/docs/Old.svelte",
+          "A\tpackages/core/src/new.ts",
+          "D\tpackages/core/src/gone.ts",
+        ].join("\n"),
+      ).toSorted(),
+    ).toEqual(
+      [
+        "packages/spec/src/artifact.ts",
+        "packages/svelte/src/lib/Old.svelte",
+        "packages/docs/Old.svelte",
+        "packages/core/src/new.ts",
+        "packages/core/src/gone.ts",
+      ].toSorted(),
+    );
   });
 });

--- a/packages/spec/tests/manual-at-alias-audit.ts
+++ b/packages/spec/tests/manual-at-alias-audit.ts
@@ -41,11 +41,12 @@ export function isSkippableCommentLine(body: string): boolean {
   if (!trimmed.startsWith("*")) return false;
 
   // JSDoc middle lines are `* text` / lone `*`. CSS universal selectors look like
-  // `* {…}`, `*.class`, `*#id`, `*:hover`, `*, div`, `*[attr]`.
+  // `* {…}`, `*.class`, `*#id`, `*:hover`, `*, div`, `*[attr]`, and combinators
+  // `* + *`, `* > .x`, `* ~ *`.
   const afterStar = trimmed.slice(1).trimStart();
   if (afterStar.length === 0) return true;
   if (afterStar.startsWith("/")) return true; // */
-  if (/^[{.,#:[\]]/.test(afterStar)) return false;
+  if (/^[{.,#:[\]+>~]/.test(afterStar)) return false;
   return true;
 }
 
@@ -81,17 +82,41 @@ function assertAncestor(repoRoot: string, ancestor: string, descendant: string):
   }
 }
 
+/**
+ * Parse `git diff --name-status` stdout into every path involved, including
+ * both sides of renames/copies so moves out of runtime trees stay visible.
+ */
+export function listChangedFilesFromNameStatus(stdout: string): string[] {
+  const paths: string[] = [];
+  for (const line of stdout.split("\n")) {
+    const trimmed = line.trimEnd();
+    if (trimmed.length === 0) continue;
+    // status\tpath  OR  R100\told\tnew  OR  C100\told\tnew
+    const parts = trimmed.split("\t");
+    if (parts.length < 2) continue;
+    const status = parts[0] ?? "";
+    if (status.startsWith("R") || status.startsWith("C")) {
+      const from = parts[1];
+      const to = parts[2];
+      if (from !== undefined && from.length > 0) paths.push(from);
+      if (to !== undefined && to.length > 0) paths.push(to);
+      continue;
+    }
+    const path = parts[1];
+    if (path !== undefined && path.length > 0) paths.push(path);
+  }
+  return [...new Set(paths)];
+}
+
 function listChangedFiles(repoRoot: string, base: string, head: string): string[] {
-  const result = git(repoRoot, ["diff", "--name-only", `${base}..${head}`]);
+  // --name-status (not --name-only) so renames keep both source and destination.
+  const result = git(repoRoot, ["diff", "--name-status", `${base}..${head}`]);
   if (result.status !== 0) {
     throw new Error(
       `git diff ${base}..${head} failed: ${result.stderr.trim() || result.stdout.trim()}`,
     );
   }
-  return result.stdout
-    .split("\n")
-    .map((line) => line.trim())
-    .filter((line) => line.length > 0);
+  return listChangedFilesFromNameStatus(result.stdout);
 }
 
 /** True when the unified diff has non-comment, non-blank added/removed lines. */


### PR DESCRIPTION
## Summary

Follow-up for unrebutted post-merge Codex findings on #54 (manual AT alias commit-range audit).

### Valid → fixed
1. **Star-combinator selectors as code** — `isSkippableCommentLine` now treats `* +`, `* >`, `* ~` (after the star) as substantive CSS, not JSDoc.
2. **Rename source paths** — changed-file listing uses `git diff --name-status` and `listChangedFilesFromNameStatus` so both sides of renames/copies are audited.

### Invalid / by design
- **Bind aliases to the checked release commit (HEAD tip)** — alias evidence documents a **specific packaging `releaseCommit` artifact**, already bound via `packageVersionAtCommit`. Auditing `releaseCommit..HEAD` for same-version runtime would invalidate continuous development at the published version between releases. Not the intended contract.

## Test plan
- [x] `bun test packages/spec/tests/manual-at-alias-audit.test.ts packages/spec/tests/manual-at-schema.test.ts`

Parent: #54