### PR TITLE
refactor(svelte): extract PlotLegendTargets from GGPlot

### DIFF
--- a/packages/svelte/src/lib/GGPlot.svelte
+++ b/packages/svelte/src/lib/GGPlot.svelte
@@ -206,6 +206,7 @@
     type LegendEntryAction,
     type LegendEntryIdentity,
   } from "./plot-legend-focus.js";
+  import PlotLegendTargets from "./PlotLegendTargets.svelte";
   import SceneView from "./SceneView.svelte";
   import Tooltip from "./Tooltip.svelte";
   import ToolRail from "./ToolRail.svelte";
@@ -2285,66 +2286,33 @@
         focusMasks={interactionMasks}
       />
     {/if}
-    {#if interactiveLegendEntries.length > 0}
-      <div
-        class="gg-legend-targets"
-        role="group"
-        aria-label="Interactive legends"
-      >
-        {#each interactiveLegendEntries as target, index (`${target.identity.scale}:${target.identity.entryIndex}`)}
-          <button
-            type="button"
-            class="gg-legend-target"
-            class:gg-legend-target-active={legendPreview?.action.identity
-              .scale === target.identity.scale &&
-              legendPreview?.action.identity.entryIndex ===
-                target.identity.entryIndex}
-            aria-label={`${target.legend.title || target.identity.scale}: ${target.entry.label} (${target.identity.scale} legend)`}
-            aria-pressed={effectiveLegendPressed?.scale ===
-              target.identity.scale &&
-              effectiveLegendPressed.entryIndex === target.identity.entryIndex}
-            tabindex={index === legendRovingIndex ? 0 : -1}
-            data-gg-legend-target
-            data-index={index}
-            style:left={`${target.legend.x}px`}
-            style:top={`${target.legend.y + target.entry.y}px`}
-            style:width={`${Math.max(24, target.legend.width)}px`}
-            onpointerenter={(event) => {
-              if (event.pointerType !== "touch")
-                previewLegendIndex(index, "pointer");
-            }}
-            onpointerleave={() => previewLegend(null)}
-            onpointerdown={(event) => onLegendPointerDown(event, index)}
-            onpointerup={(event) => onLegendPointerUp(event, index)}
-            onpointercancel={() => (legendTouchIndex = -1)}
-            onfocus={() => onLegendFocus(index)}
-            onblur={onLegendBlur}
-            onclick={(event) => onLegendClick(event, index)}
-            onkeydown={(event) => onLegendKeydown(event, index)}
-          >
-            <span class="gg-sr-only">{target.entry.label}</span>
-          </button>
-        {/each}
-      </div>
-    {/if}
-    {#if interactionConfig.legendFocus !== null && effectiveLegendPressed !== null}
-      {@const focusedLegend = model.scene.legends.find(
-        (candidate) => candidate.scale === effectiveLegendPressed?.scale,
-      )}
-      {#if focusedLegend !== undefined}
-        <button
-          type="button"
-          class="gg-legend-clear"
-          aria-label="Clear legend focus"
-          style:left={`${Math.max(4, Math.min(focusedLegend.x, model.scene.width - 52))}px`}
-          style:top={`${model.scene.height + 4}px`}
-          onpointerdown={(event) =>
-            (legendClearPointerType = event.pointerType)}
-          onpointercancel={() => (legendClearPointerType = null)}
-          onclick={(event) => clearLegendFromControl(event)}>Clear</button
-        >
-      {/if}
-    {/if}
+    <PlotLegendTargets
+      entries={interactiveLegendEntries}
+      previewIdentity={legendPreview?.action.identity ?? null}
+      pressedIdentity={effectiveLegendPressed}
+      rovingIndex={legendRovingIndex}
+      sceneWidth={model.scene.width}
+      sceneHeight={model.scene.height}
+      clearLegendX={interactionConfig.legendFocus !== null &&
+      effectiveLegendPressed !== null
+        ? (model.scene.legends.find(
+            (candidate) => candidate.scale === effectiveLegendPressed.scale,
+          )?.x ?? null)
+        : null}
+      onPreviewIndex={(index) => previewLegendIndex(index, "pointer")}
+      onPreviewClear={() => previewLegend(null)}
+      onPointerDown={onLegendPointerDown}
+      onPointerUp={onLegendPointerUp}
+      onPointerCancel={() => (legendTouchIndex = -1)}
+      onFocus={onLegendFocus}
+      onBlur={onLegendBlur}
+      onClick={onLegendClick}
+      onKeyDown={onLegendKeydown}
+      onClearPointerDown={(pointerType) =>
+        (legendClearPointerType = pointerType)}
+      onClearPointerCancel={() => (legendClearPointerType = null)}
+      onClearClick={clearLegendFromControl}
+    />
     {#if !interactive && (emphasizedAnchors.length > 0 || selectedAnchors.length > 0)}
       <InteractionOverlay
         width={model.scene.width}
@@ -2535,63 +2503,6 @@
     left: 2px;
     font-size: 11px;
     line-height: 1.2;
-  }
-
-  .gg-legend-clear {
-    position: absolute;
-    z-index: 5;
-    min-width: 44px;
-    min-height: 44px;
-    border: 1px solid
-      var(--gg-tooltipBorder, var(--gg-theme-tooltipBorder, currentColor));
-    border-radius: 3px;
-    padding: 2px 6px;
-    background: var(--gg-tooltipPaper, var(--gg-theme-tooltipPaper, white));
-    color: var(--gg-tooltipInk, var(--gg-theme-tooltipInk, currentColor));
-    font: 11px/1.2 var(--gg-font-family, sans-serif);
-    white-space: nowrap;
-    pointer-events: auto;
-  }
-
-  .gg-legend-targets {
-    position: absolute;
-    inset: 0;
-    z-index: 5;
-    pointer-events: none;
-  }
-
-  .gg-legend-target {
-    position: absolute;
-    min-width: 24px;
-    min-height: 24px;
-    margin: 0;
-    border: 1px solid transparent;
-    border-radius: 3px;
-    padding: 0;
-    background: transparent;
-    color: transparent;
-    pointer-events: auto;
-    touch-action: manipulation;
-  }
-
-  .gg-legend-target:hover,
-  .gg-legend-target-active,
-  .gg-legend-target[aria-pressed="true"] {
-    border-color: var(
-      --gg-interactionInk,
-      var(--gg-theme-interactionInk, currentColor)
-    );
-    background: color-mix(in srgb, currentColor 7%, transparent);
-  }
-
-  .gg-legend-target:focus-visible {
-    outline: 2px solid var(--gg-focusRing, var(--gg-theme-focusRing, Highlight));
-    outline-offset: -2px;
-  }
-
-  .gg-legend-clear:focus-visible {
-    outline: 2px solid var(--gg-focusRing, var(--gg-theme-focusRing, Highlight));
-    outline-offset: 2px;
   }
 
   .gg-a11y-table {

--- a/packages/svelte/src/lib/PlotLegendTargets.svelte
+++ b/packages/svelte/src/lib/PlotLegendTargets.svelte
@@ -1,0 +1,190 @@
+<script lang="ts">
+  /**
+   * Interactive legend hit targets + clear control for GGPlot.
+   * Host owns focus state machine, key index, and commit/preview side effects.
+   */
+  import type {
+    InteractiveLegendEntry,
+    LegendEntryIdentity,
+  } from "./plot-legend-focus.js";
+
+  const {
+    entries,
+    previewIdentity = null,
+    pressedIdentity = null,
+    rovingIndex = 0,
+    sceneWidth,
+    sceneHeight,
+    /** Anchor x for clear control; null hides the clear button. */
+    clearLegendX = null,
+    onPreviewIndex,
+    onPreviewClear,
+    onPointerDown,
+    onPointerUp,
+    onPointerCancel,
+    onFocus,
+    onBlur,
+    onClick,
+    onKeyDown,
+    onClearPointerDown,
+    onClearPointerCancel,
+    onClearClick,
+  }: {
+    entries: readonly InteractiveLegendEntry[];
+    previewIdentity?: LegendEntryIdentity | null;
+    pressedIdentity?: LegendEntryIdentity | null;
+    rovingIndex?: number;
+    sceneWidth: number;
+    sceneHeight: number;
+    clearLegendX?: number | null;
+    onPreviewIndex: (index: number, source: "pointer") => void;
+    onPreviewClear: () => void;
+    onPointerDown: (event: PointerEvent, index: number) => void;
+    onPointerUp: (event: PointerEvent, index: number) => void;
+    onPointerCancel: () => void;
+    onFocus: (index: number) => void;
+    onBlur: (event: FocusEvent) => void;
+    onClick: (event: MouseEvent, index: number) => void;
+    onKeyDown: (event: KeyboardEvent, index: number) => void;
+    onClearPointerDown: (pointerType: string) => void;
+    onClearPointerCancel: () => void;
+    onClearClick: (event: MouseEvent) => void;
+  } = $props();
+
+  function sameIdentity(
+    left: LegendEntryIdentity | null | undefined,
+    right: LegendEntryIdentity,
+  ): boolean {
+    return (
+      left !== null &&
+      left !== undefined &&
+      left.scale === right.scale &&
+      left.entryIndex === right.entryIndex
+    );
+  }
+
+  function targetAriaLabel(target: InteractiveLegendEntry): string {
+    const scale = target.identity.scale;
+    return `${target.legend.title || scale}: ${target.entry.label} (${scale} legend)`;
+  }
+</script>
+
+{#if entries.length > 0}
+  <div class="gg-legend-targets" role="group" aria-label="Interactive legends">
+    {#each entries as target, index (`${target.identity.scale}:${target.identity.entryIndex}`)}
+      <button
+        type="button"
+        class="gg-legend-target"
+        class:gg-legend-target-active={sameIdentity(
+          previewIdentity,
+          target.identity,
+        )}
+        aria-label={targetAriaLabel(target)}
+        aria-pressed={sameIdentity(pressedIdentity, target.identity)}
+        tabindex={index === rovingIndex ? 0 : -1}
+        data-gg-legend-target
+        data-index={index}
+        style:left={`${target.legend.x}px`}
+        style:top={`${target.legend.y + target.entry.y}px`}
+        style:width={`${Math.max(24, target.legend.width)}px`}
+        onpointerenter={(event) => {
+          if (event.pointerType !== "touch") onPreviewIndex(index, "pointer");
+        }}
+        onpointerleave={() => onPreviewClear()}
+        onpointerdown={(event) => onPointerDown(event, index)}
+        onpointerup={(event) => onPointerUp(event, index)}
+        onpointercancel={() => onPointerCancel()}
+        onfocus={() => onFocus(index)}
+        onblur={onBlur}
+        onclick={(event) => onClick(event, index)}
+        onkeydown={(event) => onKeyDown(event, index)}
+      >
+        <span class="gg-legend-target-label">{target.entry.label}</span>
+      </button>
+    {/each}
+  </div>
+{/if}
+{#if clearLegendX !== null}
+  <button
+    type="button"
+    class="gg-legend-clear"
+    aria-label="Clear legend focus"
+    style:left={`${Math.max(4, Math.min(clearLegendX, sceneWidth - 52))}px`}
+    style:top={`${sceneHeight + 4}px`}
+    onpointerdown={(event) => onClearPointerDown(event.pointerType)}
+    onpointercancel={() => onClearPointerCancel()}
+    onclick={(event) => onClearClick(event)}>Clear</button
+  >
+{/if}
+
+<style>
+  .gg-legend-clear {
+    position: absolute;
+    z-index: 5;
+    min-width: 44px;
+    min-height: 44px;
+    border: 1px solid
+      var(--gg-tooltipBorder, var(--gg-theme-tooltipBorder, currentColor));
+    border-radius: 3px;
+    padding: 2px 6px;
+    background: var(--gg-tooltipPaper, var(--gg-theme-tooltipPaper, white));
+    color: var(--gg-tooltipInk, var(--gg-theme-tooltipInk, currentColor));
+    font: 11px/1.2 var(--gg-font-family, sans-serif);
+    white-space: nowrap;
+    pointer-events: auto;
+  }
+
+  .gg-legend-targets {
+    position: absolute;
+    inset: 0;
+    z-index: 5;
+    pointer-events: none;
+  }
+
+  .gg-legend-target {
+    position: absolute;
+    min-width: 24px;
+    min-height: 24px;
+    margin: 0;
+    border: 1px solid transparent;
+    border-radius: 3px;
+    padding: 0;
+    background: transparent;
+    color: transparent;
+    pointer-events: auto;
+    touch-action: manipulation;
+  }
+
+  .gg-legend-target:hover,
+  .gg-legend-target-active,
+  .gg-legend-target[aria-pressed="true"] {
+    border-color: var(
+      --gg-interactionInk,
+      var(--gg-theme-interactionInk, currentColor)
+    );
+    background: color-mix(in srgb, currentColor 7%, transparent);
+  }
+
+  .gg-legend-target:focus-visible {
+    outline: 2px solid var(--gg-focusRing, var(--gg-theme-focusRing, Highlight));
+    outline-offset: -2px;
+  }
+
+  .gg-legend-clear:focus-visible {
+    outline: 2px solid var(--gg-focusRing, var(--gg-theme-focusRing, Highlight));
+    outline-offset: 2px;
+  }
+
+  /* Local sr-only for target labels (GGPlot keeps its own .gg-sr-only for other chrome). */
+  .gg-legend-target-label {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap;
+    border: 0;
+  }
+</style>

--- a/packages/svelte/tests/plot-legend-targets.test.ts
+++ b/packages/svelte/tests/plot-legend-targets.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { InteractiveLegendEntry } from "../src/lib/plot-legend-focus.js";
+import PlotLegendTargets from "../src/lib/PlotLegendTargets.svelte";
+import { render } from "./helpers/render.js";
+
+const discreteFill = {
+  type: "discrete" as const,
+  scale: "fill",
+  title: "Channel",
+  x: 100,
+  y: 12,
+  width: 10,
+  height: 72,
+  swatchSize: 12,
+  entries: [
+    { value: "web", label: "Web", color: "#123456", y: 18 },
+    { value: "store", label: "Store", color: "#654321", y: 42 },
+  ],
+};
+
+const entries: InteractiveLegendEntry[] = [
+  {
+    legend: discreteFill,
+    entry: discreteFill.entries[0]!,
+    identity: { scale: "fill", entryIndex: 0 },
+  },
+  {
+    legend: discreteFill,
+    entry: discreteFill.entries[1]!,
+    identity: { scale: "fill", entryIndex: 1 },
+  },
+];
+
+const noopHandlers = {
+  onPreviewIndex: () => {},
+  onPreviewClear: () => {},
+  onPointerDown: () => {},
+  onPointerUp: () => {},
+  onPointerCancel: () => {},
+  onFocus: () => {},
+  onBlur: () => {},
+  onClick: () => {},
+  onKeyDown: () => {},
+  onClearPointerDown: () => {},
+  onClearPointerCancel: () => {},
+  onClearClick: () => {},
+};
+
+describe("PlotLegendTargets", () => {
+  it("renders one hit target per entry and hides clear when clearLegendX is null", () => {
+    const { container } = render(PlotLegendTargets, {
+      entries,
+      sceneWidth: 400,
+      sceneHeight: 300,
+      clearLegendX: null,
+      ...noopHandlers,
+    });
+    expect(container.querySelectorAll("[data-gg-legend-target]")).toHaveLength(2);
+    expect(container.querySelector(".gg-legend-clear")).toBeNull();
+  });
+
+  it("shows clear control at clamped left and sceneHeight+4 top", () => {
+    const { container } = render(PlotLegendTargets, {
+      entries,
+      sceneWidth: 400,
+      sceneHeight: 300,
+      clearLegendX: 100,
+      pressedIdentity: { scale: "fill", entryIndex: 0 },
+      ...noopHandlers,
+    });
+    const clear = container.querySelector<HTMLButtonElement>(".gg-legend-clear");
+    expect(clear).not.toBeNull();
+    expect(clear!.style.left).toBe("100px");
+    expect(clear!.style.top).toBe("304px");
+  });
+
+  it("clamps clear left into [4, sceneWidth-52]", () => {
+    const low = render(PlotLegendTargets, {
+      entries,
+      sceneWidth: 400,
+      sceneHeight: 200,
+      clearLegendX: 0,
+      ...noopHandlers,
+    });
+    expect(low.container.querySelector<HTMLButtonElement>(".gg-legend-clear")!.style.left).toBe(
+      "4px",
+    );
+
+    const high = render(PlotLegendTargets, {
+      entries,
+      sceneWidth: 400,
+      sceneHeight: 200,
+      clearLegendX: 500,
+      ...noopHandlers,
+    });
+    expect(high.container.querySelector<HTMLButtonElement>(".gg-legend-clear")!.style.left).toBe(
+      "348px",
+    );
+  });
+
+  it("applies min target width of 24 when legend width is smaller", () => {
+    const { container } = render(PlotLegendTargets, {
+      entries,
+      sceneWidth: 400,
+      sceneHeight: 300,
+      clearLegendX: null,
+      ...noopHandlers,
+    });
+    const first = container.querySelectorAll<HTMLButtonElement>("[data-gg-legend-target]")[0]!;
+    // legend width is 10 → max(24, 10) = 24
+    expect(first.style.width).toBe("24px");
+  });
+
+  it("wires preview enter for non-touch pointers", () => {
+    const onPreviewIndex = vi.fn();
+    const { container } = render(PlotLegendTargets, {
+      entries,
+      sceneWidth: 400,
+      sceneHeight: 300,
+      clearLegendX: null,
+      ...noopHandlers,
+      onPreviewIndex,
+    });
+    const first = container.querySelectorAll<HTMLButtonElement>("[data-gg-legend-target]")[0]!;
+    first.dispatchEvent(new PointerEvent("pointerenter", { bubbles: true, pointerType: "mouse" }));
+    expect(onPreviewIndex).toHaveBeenCalledWith(0, "pointer");
+  });
+});

--- a/packages/svelte/tests/plot-legend-targets.test.ts
+++ b/packages/svelte/tests/plot-legend-targets.test.ts
@@ -4,6 +4,9 @@ import type { InteractiveLegendEntry } from "../src/lib/plot-legend-focus.js";
 import PlotLegendTargets from "../src/lib/PlotLegendTargets.svelte";
 import { render } from "./helpers/render.js";
 
+const webEntry = { value: "web", label: "Web", color: "#123456", y: 18 };
+const storeEntry = { value: "store", label: "Store", color: "#654321", y: 42 };
+
 const discreteFill = {
   type: "discrete" as const,
   scale: "fill",
@@ -13,21 +16,18 @@ const discreteFill = {
   width: 10,
   height: 72,
   swatchSize: 12,
-  entries: [
-    { value: "web", label: "Web", color: "#123456", y: 18 },
-    { value: "store", label: "Store", color: "#654321", y: 42 },
-  ],
+  entries: [webEntry, storeEntry],
 };
 
 const entries: InteractiveLegendEntry[] = [
   {
     legend: discreteFill,
-    entry: discreteFill.entries[0]!,
+    entry: webEntry,
     identity: { scale: "fill", entryIndex: 0 },
   },
   {
     legend: discreteFill,
-    entry: discreteFill.entries[1]!,
+    entry: storeEntry,
     identity: { scale: "fill", entryIndex: 1 },
   },
 ];
@@ -71,8 +71,8 @@ describe("PlotLegendTargets", () => {
     });
     const clear = container.querySelector<HTMLButtonElement>(".gg-legend-clear");
     expect(clear).not.toBeNull();
-    expect(clear!.style.left).toBe("100px");
-    expect(clear!.style.top).toBe("304px");
+    expect(clear?.style.left).toBe("100px");
+    expect(clear?.style.top).toBe("304px");
   });
 
   it("clamps clear left into [4, sceneWidth-52]", () => {
@@ -83,9 +83,8 @@ describe("PlotLegendTargets", () => {
       clearLegendX: 0,
       ...noopHandlers,
     });
-    expect(low.container.querySelector<HTMLButtonElement>(".gg-legend-clear")!.style.left).toBe(
-      "4px",
-    );
+    const lowClear = low.container.querySelector<HTMLButtonElement>(".gg-legend-clear");
+    expect(lowClear?.style.left).toBe("4px");
 
     const high = render(PlotLegendTargets, {
       entries,
@@ -94,9 +93,8 @@ describe("PlotLegendTargets", () => {
       clearLegendX: 500,
       ...noopHandlers,
     });
-    expect(high.container.querySelector<HTMLButtonElement>(".gg-legend-clear")!.style.left).toBe(
-      "348px",
-    );
+    const highClear = high.container.querySelector<HTMLButtonElement>(".gg-legend-clear");
+    expect(highClear?.style.left).toBe("348px");
   });
 
   it("applies min target width of 24 when legend width is smaller", () => {
@@ -107,9 +105,10 @@ describe("PlotLegendTargets", () => {
       clearLegendX: null,
       ...noopHandlers,
     });
-    const first = container.querySelectorAll<HTMLButtonElement>("[data-gg-legend-target]")[0]!;
+    const targets = container.querySelectorAll<HTMLButtonElement>("[data-gg-legend-target]");
+    expect(targets.length).toBeGreaterThan(0);
     // legend width is 10 → max(24, 10) = 24
-    expect(first.style.width).toBe("24px");
+    expect(targets.item(0)?.style.width).toBe("24px");
   });
 
   it("wires preview enter for non-touch pointers", () => {
@@ -122,8 +121,10 @@ describe("PlotLegendTargets", () => {
       ...noopHandlers,
       onPreviewIndex,
     });
-    const first = container.querySelectorAll<HTMLButtonElement>("[data-gg-legend-target]")[0]!;
-    first.dispatchEvent(new PointerEvent("pointerenter", { bubbles: true, pointerType: "mouse" }));
+    const targets = container.querySelectorAll<HTMLButtonElement>("[data-gg-legend-target]");
+    const first = targets.item(0);
+    expect(first).not.toBeNull();
+    first?.dispatchEvent(new PointerEvent("pointerenter", { bubbles: true, pointerType: "mouse" }));
     expect(onPreviewIndex).toHaveBeenCalledWith(0, "pointer");
   });
 });


### PR DESCRIPTION
## Summary

- Extract interactive legend hit targets and the clear-focus control into an internal `PlotLegendTargets` child component.
- GGPlot keeps legend focus state, key index, and side-effect handlers; the child owns markup, layout, and legend-target styles.
- Add focused component tests for target count, clear visibility/position clamp, and preview wiring.

## Test plan

- [x] `bunx vitest run tests/plot-legend-targets.test.ts tests/legend-focus.test.ts`
- [x] `bun run check` in `packages/svelte`
- [ ] CI on PR