### PR TITLE
refactor(svelte): extract PlotCanvasA11y from GGPlot

### DIFF
--- a/packages/svelte/src/lib/GGPlot.svelte
+++ b/packages/svelte/src/lib/GGPlot.svelte
@@ -98,7 +98,6 @@
   } from "./inspection-resolver.js";
   import { createInteractionReducer } from "./interaction-reducer.js";
   import { provideRegistry } from "./registry.svelte.js";
-  import { a11yRows } from "./canvas-a11y.js";
   import InteractionOverlay from "./InteractionOverlay.svelte";
   import {
     assemblePortableSpec,
@@ -206,6 +205,7 @@
     type LegendEntryAction,
     type LegendEntryIdentity,
   } from "./plot-legend-focus.js";
+  import PlotCanvasA11y from "./PlotCanvasA11y.svelte";
   import PlotLegendTargets from "./PlotLegendTargets.svelte";
   import SceneView from "./SceneView.svelte";
   import Tooltip from "./Tooltip.svelte";
@@ -2232,40 +2232,13 @@
             class="gg-stratum gg-canvas"
             {@attach canvasAttachment(model, stratum.batches, `canvas:${si}`)}
           ></canvas>
-          {@const table = a11yRows(model, stratum.batches)}
-          <div
-            class="gg-canvas-a11y"
-            role="img"
-            aria-label={`${sceneLabel(model.scene)} — ${String(table.total)} canvas-rendered marks. Canvas marks are not individually focusable; use the data table.`}
-          ></div>
-          <button
-            type="button"
-            class="gg-a11y-toggle"
-            aria-expanded={a11yTableOpen}
-            onclick={() => (a11yTableOpen = !a11yTableOpen)}
-            >{a11yTableOpen ? "Hide data table" : "Show data table"}</button
-          >
-          {#if a11yTableOpen}
-            <div class="gg-a11y-table">
-              <table>
-                <thead>
-                  <tr>
-                    {#each table.fields as field (field)}<th>{field}</th>{/each}
-                  </tr>
-                </thead>
-                <tbody>
-                  {#each table.rows as row, ri (ri)}
-                    <tr>
-                      {#each row as cell, ci (ci)}<td>{cell}</td>{/each}
-                    </tr>
-                  {/each}
-                </tbody>
-              </table>
-              {#if table.total > table.rows.length}
-                <p>First {table.rows.length} of {table.total} rows.</p>
-              {/if}
-            </div>
-          {/if}
+          <PlotCanvasA11y
+            {model}
+            batches={stratum.batches}
+            sceneLabelText={sceneLabel(model.scene)}
+            open={a11yTableOpen}
+            onToggle={() => (a11yTableOpen = !a11yTableOpen)}
+          />
         {:else}
           <SceneView
             scene={model.scene}
@@ -2471,8 +2444,7 @@
      (no z-index anywhere — decision 0006). All inert; the capture layer
      owns pointer events. Parent-owned so extracted overlay SVGs with
      class gg-stratum stay absolutely positioned. */
-  .gg-plot-root :global(.gg-stratum),
-  .gg-canvas-a11y {
+  .gg-plot-root :global(.gg-stratum) {
     position: absolute;
     inset: 0;
     pointer-events: none;
@@ -2480,51 +2452,6 @@
 
   canvas.gg-stratum {
     display: block;
-  }
-
-  /* sr-only pattern (NOT display:none — must stay in the a11y tree). */
-  .gg-canvas-a11y,
-  .gg-a11y-toggle:not(:focus) {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    margin: -1px;
-    padding: 0;
-    overflow: hidden;
-    clip-path: inset(50%);
-    white-space: nowrap;
-    border: 0;
-  }
-
-  .gg-a11y-toggle {
-    pointer-events: auto;
-    position: absolute;
-    top: 2px;
-    left: 2px;
-    font-size: 11px;
-    line-height: 1.2;
-  }
-
-  .gg-a11y-table {
-    position: absolute;
-    inset: 0;
-    overflow: auto;
-    background: var(--gg-paper, #fff);
-    color: var(--gg-ink, #1f2328);
-    font-size: 11px;
-    line-height: 1.4;
-    pointer-events: auto;
-  }
-
-  .gg-a11y-table table {
-    border-collapse: collapse;
-  }
-
-  .gg-a11y-table th,
-  .gg-a11y-table td {
-    border: 1px solid var(--gg-grid, rgba(128, 128, 128, 0.4));
-    padding: 2px 6px;
-    text-align: left;
   }
 
   .gg-capture {

--- a/packages/svelte/src/lib/PlotCanvasA11y.svelte
+++ b/packages/svelte/src/lib/PlotCanvasA11y.svelte
@@ -1,0 +1,112 @@
+<script lang="ts">
+  /**
+   * Canvas-stratum accessibility surface for GGPlot.
+   * Host owns shared open state (plot-scoped across canvas strata).
+   */
+  import type { GeometryBatch, RenderModel } from "@ggsvelte/core";
+
+  import { a11yRows } from "./canvas-a11y.js";
+
+  const {
+    model,
+    batches,
+    sceneLabelText,
+    open,
+    onToggle,
+  }: {
+    model: RenderModel;
+    batches: GeometryBatch[];
+    sceneLabelText: string;
+    open: boolean;
+    onToggle: () => void;
+  } = $props();
+
+  const table = $derived(a11yRows(model, batches));
+  const ariaLabel = $derived(
+    `${sceneLabelText} — ${String(table.total)} canvas-rendered marks. Canvas marks are not individually focusable; use the data table.`,
+  );
+</script>
+
+<div class="gg-canvas-a11y" role="img" aria-label={ariaLabel}></div>
+<button
+  type="button"
+  class="gg-a11y-toggle"
+  aria-expanded={open}
+  onclick={() => onToggle()}
+  >{open ? "Hide data table" : "Show data table"}</button
+>
+{#if open}
+  <div class="gg-a11y-table">
+    <table>
+      <thead>
+        <tr>
+          {#each table.fields as field (field)}<th>{field}</th>{/each}
+        </tr>
+      </thead>
+      <tbody>
+        {#each table.rows as row, ri (ri)}
+          <tr>
+            {#each row as cell, ci (ci)}<td>{cell}</td>{/each}
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+    {#if table.total > table.rows.length}
+      <p>First {table.rows.length} of {table.total} rows.</p>
+    {/if}
+  </div>
+{/if}
+
+<style>
+  /* Full-size inert layer base; sr-only clip below keeps it in the a11y tree. */
+  .gg-canvas-a11y {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+  }
+
+  /* sr-only pattern (NOT display:none — must stay in the a11y tree). */
+  .gg-canvas-a11y,
+  .gg-a11y-toggle:not(:focus) {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  .gg-a11y-toggle {
+    pointer-events: auto;
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    font-size: 11px;
+    line-height: 1.2;
+  }
+
+  .gg-a11y-table {
+    position: absolute;
+    inset: 0;
+    overflow: auto;
+    background: var(--gg-paper, #fff);
+    color: var(--gg-ink, #1f2328);
+    font-size: 11px;
+    line-height: 1.4;
+    pointer-events: auto;
+  }
+
+  .gg-a11y-table table {
+    border-collapse: collapse;
+  }
+
+  .gg-a11y-table th,
+  .gg-a11y-table td {
+    border: 1px solid var(--gg-grid, rgba(128, 128, 128, 0.4));
+    padding: 2px 6px;
+    text-align: left;
+  }
+</style>

--- a/packages/svelte/tests/interaction.test.ts
+++ b/packages/svelte/tests/interaction.test.ts
@@ -144,6 +144,32 @@ describe("canvas strata (decision 0006 graduated)", () => {
     expect([...table.querySelectorAll("th")].map((t) => t.textContent)).toEqual(["x", "y"]);
   });
 
+  it("canvas a11y open state is shared across interleaved canvas strata", async () => {
+    // canvas → svg → canvas yields two canvas strata (contiguous same-backend merges).
+    const { container } = render(GGPlot, {
+      data: rows,
+      aes: { x: "x", y: "y" },
+      layers: [
+        { geom: "point" as const, render: "canvas" as const, params: { size: 6 } },
+        { geom: "line" as const },
+        { geom: "point" as const, render: "canvas" as const, params: { size: 4 } },
+      ],
+      theme: "light" as const,
+      ...size,
+    });
+    const toggles = [...container.querySelectorAll<HTMLButtonElement>(".gg-a11y-toggle")];
+    expect(toggles).toHaveLength(2);
+    expect(toggles.every((t) => t.getAttribute("aria-expanded") === "false")).toBe(true);
+    expect(container.querySelectorAll(".gg-a11y-table")).toHaveLength(0);
+    toggles[0]?.click();
+    await until(() => container.querySelectorAll(".gg-a11y-table").length === 2);
+    expect(
+      [...container.querySelectorAll(".gg-a11y-toggle")].every(
+        (t) => t.getAttribute("aria-expanded") === "true",
+      ),
+    ).toBe(true);
+  });
+
   it('a11y "force-svg" keeps marks in SVG with one virtual-navigation surface', () => {
     const { container } = render(GGPlot, { ...canvasProps, a11y: "force-svg", inspect: true });
     expect(container.querySelector("canvas")).toBeNull();

--- a/packages/svelte/tests/plot-canvas-a11y.test.ts
+++ b/packages/svelte/tests/plot-canvas-a11y.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { GeometryBatch, RenderModel } from "@ggsvelte/core";
+
+import { A11Y_TABLE_CAP, a11yRows } from "../src/lib/canvas-a11y.js";
+import PlotCanvasA11y from "../src/lib/PlotCanvasA11y.svelte";
+import { render } from "./helpers/render.js";
+
+function batch(partial: { layerIndex: number; rowIndex: number[] }): GeometryBatch {
+  return {
+    layerIndex: partial.layerIndex,
+    geom: "point",
+    rowIndex: new Uint32Array(partial.rowIndex),
+  } as unknown as GeometryBatch;
+}
+
+function model(opts: {
+  layerFields: Record<number, { field: string }[]>;
+  rows: Record<number, Record<string, unknown> | null>;
+}): RenderModel {
+  return {
+    layerFields: opts.layerFields,
+    row: (index: number) => opts.rows[index] ?? null,
+  } as unknown as RenderModel;
+}
+
+const sampleModel = model({
+  layerFields: { 0: [{ field: "x" }, { field: "y" }] },
+  rows: {
+    0: { x: 1, y: 10 },
+    1: { x: 2, y: 20 },
+    2: { x: 3, y: 15 },
+    3: { x: 4, y: 25 },
+  },
+});
+const sampleBatches = [batch({ layerIndex: 0, rowIndex: [0, 1, 2, 3] })];
+
+function until(predicate: () => boolean, timeout = 2000): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const started = performance.now();
+    const tick = () => {
+      if (predicate()) {
+        resolve();
+        return;
+      }
+      if (performance.now() - started > timeout) {
+        reject(new Error("until() timed out"));
+        return;
+      }
+      requestAnimationFrame(tick);
+    };
+    tick();
+  });
+}
+
+describe("PlotCanvasA11y", () => {
+  it("renders role=img summary with scene label and canvas mark total", () => {
+    const { container } = render(PlotCanvasA11y, {
+      model: sampleModel,
+      batches: sampleBatches,
+      sceneLabelText: "Scatter plot",
+      open: false,
+      onToggle: () => {},
+    });
+    const block = container.querySelector(".gg-canvas-a11y");
+    expect(block).not.toBeNull();
+    expect(block?.getAttribute("role")).toBe("img");
+    expect(block?.getAttribute("aria-label")).toBe(
+      "Scatter plot — 4 canvas-rendered marks. Canvas marks are not individually focusable; use the data table.",
+    );
+  });
+
+  it("starts closed; toggle reports expanded and label text from open prop", async () => {
+    const onToggle = vi.fn();
+    const closed = render(PlotCanvasA11y, {
+      model: sampleModel,
+      batches: sampleBatches,
+      sceneLabelText: "Plot",
+      open: false,
+      onToggle,
+    });
+    const toggle = closed.container.querySelector<HTMLButtonElement>(".gg-a11y-toggle");
+    expect(toggle?.getAttribute("aria-expanded")).toBe("false");
+    expect(toggle?.textContent).toBe("Show data table");
+    expect(closed.container.querySelector(".gg-a11y-table")).toBeNull();
+
+    toggle?.click();
+    expect(onToggle).toHaveBeenCalledTimes(1);
+
+    const opened = render(PlotCanvasA11y, {
+      model: sampleModel,
+      batches: sampleBatches,
+      sceneLabelText: "Plot",
+      open: true,
+      onToggle: () => {},
+    });
+    await until(() => opened.container.querySelector(".gg-a11y-table") !== null);
+    const openToggle = opened.container.querySelector<HTMLButtonElement>(".gg-a11y-toggle");
+    expect(openToggle?.getAttribute("aria-expanded")).toBe("true");
+    expect(openToggle?.textContent).toBe("Hide data table");
+  });
+
+  it("renders field headers and body rows from a11yRows", async () => {
+    const { container } = render(PlotCanvasA11y, {
+      model: sampleModel,
+      batches: sampleBatches,
+      sceneLabelText: "Plot",
+      open: true,
+      onToggle: () => {},
+    });
+    await until(() => container.querySelector(".gg-a11y-table") !== null);
+    const table = container.querySelector(".gg-a11y-table");
+    const expected = a11yRows(sampleModel, sampleBatches);
+    expect([...(table?.querySelectorAll("th") ?? [])].map((t) => t.textContent)).toEqual(
+      expected.fields,
+    );
+    expect(table?.querySelectorAll("tbody tr")).toHaveLength(expected.rows.length);
+    expect(table?.querySelector("p")).toBeNull();
+  });
+
+  it("shows truncation note when total exceeds materialised rows", async () => {
+    const rows: Record<number, Record<string, unknown>> = {};
+    const indices: number[] = [];
+    for (let i = 0; i < A11Y_TABLE_CAP + 10; i++) {
+      rows[i] = { x: i };
+      indices.push(i);
+    }
+    const largeModel = model({
+      layerFields: { 0: [{ field: "x" }] },
+      rows,
+    });
+    const largeBatches = [batch({ layerIndex: 0, rowIndex: indices })];
+    const { container } = render(PlotCanvasA11y, {
+      model: largeModel,
+      batches: largeBatches,
+      sceneLabelText: "Large",
+      open: true,
+      onToggle: () => {},
+    });
+    await until(() => container.querySelector(".gg-a11y-table p") !== null);
+    const note = container.querySelector(".gg-a11y-table p");
+    expect(note?.textContent).toBe(
+      `First ${String(A11Y_TABLE_CAP)} of ${String(A11Y_TABLE_CAP + 10)} rows.`,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Extract canvas-stratum accessibility UI (role=img summary, data-table toggle, table markup, and styles) from `GGPlot.svelte` into `PlotCanvasA11y.svelte`.
- Host keeps plot-scoped `a11yTableOpen` so interleaved canvas strata continue to share open state; child receives `open` + `onToggle` and owns `a11yRows` derivation.
- GGPlot drops ~70 lines of presentation surface while preserving the existing a11y contract.

## Test plan
- [x] Characterization: `tests/plot-canvas-a11y.test.ts` (summary aria-label, toggle wiring, fields/rows, truncation note)
- [x] Integration: existing canvas a11y block test in `interaction.test.ts`
- [x] Multi-canvas shared open: open one toggle → both canvas strata expanded/tables present
- [x] Pure `a11yRows` unit tests unchanged
- [x] Pre-push suite green (build, svelte-check, oxlint type-aware, knip, bun test)