### PR TITLE
refactor(svelte): extract pure inspection-host decisions from GGPlot

### DIFF
--- a/packages/svelte/src/lib/GGPlot.svelte
+++ b/packages/svelte/src/lib/GGPlot.svelte
@@ -113,7 +113,15 @@
   } from "./plot-area-brush.js";
   import { frozenZoomDomains, normalizedRect } from "./plot-geometry.js";
   import { resolveSurfaceKeyAction } from "./plot-surface-keyboard.js";
-  import { resolveQueuedInspectFrameAction } from "./plot-surface-inspection.js";
+  import {
+    resolveInspectionCompleteness,
+    resolveInspectionMode,
+    resolveQueuedInspectFrameAction,
+    resolveSetInspectionAction,
+    resolveToggleInspectionPinAction,
+    shouldClearInspectionAnnouncement,
+    shouldCommitInspection,
+  } from "./plot-surface-inspection.js";
   import {
     resolveCaptureClickAction,
     advanceTouchInspectMoved,
@@ -1408,8 +1416,11 @@
     if (seed === null)
       throw new Error("Inspection hit was not present in the candidate store");
     const requested = interactionConfig.inspect?.mode ?? "auto";
-    const mode =
-      concreteMode ?? (requested === "auto" ? seed.autoMode : requested);
+    const mode = resolveInspectionMode({
+      concreteMode,
+      requested,
+      seedAutoMode: seed.autoMode,
+    });
     return inspectionCoordinator.resolve({
       model,
       seed,
@@ -1418,13 +1429,12 @@
       source,
       identityEpoch: dataIdentityEpoch,
       layoutEpoch: model.runId,
-      completeness:
-        state === "pinned" ||
-        interactionConfig.inspect?.content !== undefined ||
-        oninspect !== undefined ||
-        oninteraction !== undefined
-          ? "complete"
-          : "transient",
+      completeness: resolveInspectionCompleteness({
+        state,
+        hasCustomContent: interactionConfig.inspect?.content !== undefined,
+        hasInspectCallback: oninspect !== undefined,
+        hasInteractionCallback: oninteraction !== undefined,
+      }),
     });
   }
 
@@ -1519,108 +1529,151 @@
     concreteMode?: "exact" | "x" | "y" | "xy",
     candidate?: CandidateFacts,
   ): void {
-    if (hit !== null && (source === "keyboard" || source === "touch"))
-      interactionAnnouncement = "";
-    if (inspection?.state === "pinned" && state === "transient") return;
-    if (hit === null) {
-      if (tooltipHovered || inspection?.state === "pinned") return;
-      reducer.dispatch({ type: "inspect", candidate: null, source });
-      if (inspection !== null)
-        emitInspection({ type: "inspect", phase: "clear", source });
-      inspection = null;
-      inspectionSeed = null;
-      inspectionCoordinator.release("transient");
-      reducer.dispatch({ type: "inspect", candidate: null, source });
-      return;
-    }
-    const resolved = resolveInspection(
-      hit,
-      source,
-      state,
-      concreteMode,
-      candidate,
-    );
-    if (resolved === null) {
-      setInspection(null, source);
-      return;
-    }
-    const next = resolved.snapshot;
-    const candidateRef = {
-      epoch: model?.runId ?? 0,
-      id: candidate?.id ?? traversalHits.indexOf(hit),
-      panelId: next.panelId,
-      x: hit.x,
-      y: hit.y,
-    };
-    reducer.dispatch({ type: "inspect", candidate: candidateRef, source });
-    if (state === "pinned") reducer.dispatch({ type: "toggle-pin", source });
+    // Announcement clear runs before priority gates (including ignored
+    // keyboard/touch requests while pinned).
     if (
-      (state === "transient" &&
-        reducer.state.inspection.kind !== "transient") ||
-      (state === "pinned" && reducer.state.inspection.kind !== "pinned")
+      shouldClearInspectionAnnouncement({
+        hasHit: hit !== null,
+        source,
+      })
     )
-      return;
-    inspection = next;
-    inspectionSeed = resolved.seed;
-    if (resolved.semanticChanged)
-      emitInspection(next, resolved.semanticFingerprint);
+      interactionAnnouncement = "";
+    const action = resolveSetInspectionAction({
+      hasHit: hit !== null,
+      requestedState: state,
+      currentState: inspection?.state ?? "none",
+      tooltipHovered,
+    });
+    switch (action.type) {
+      case "ignore":
+        return;
+      case "clear": {
+        // Preserve both dispatches (before emit/release and after) — do not
+        // dedupe; may be load-bearing for reducer revision counting.
+        reducer.dispatch({ type: "inspect", candidate: null, source });
+        if (inspection !== null)
+          emitInspection({ type: "inspect", phase: "clear", source });
+        inspection = null;
+        inspectionSeed = null;
+        inspectionCoordinator.release("transient");
+        reducer.dispatch({ type: "inspect", candidate: null, source });
+        return;
+      }
+      case "apply": {
+        // hit is non-null when action is apply (pure gate).
+        const resolved = resolveInspection(
+          hit!,
+          source,
+          state,
+          concreteMode,
+          candidate,
+        );
+        // Null resolve re-enters clear gates via setInspection(null, source).
+        if (resolved === null) {
+          setInspection(null, source);
+          return;
+        }
+        const next = resolved.snapshot;
+        const candidateRef = {
+          epoch: model?.runId ?? 0,
+          id: candidate?.id ?? traversalHits.indexOf(hit!),
+          panelId: next.panelId,
+          x: hit!.x,
+          y: hit!.y,
+        };
+        reducer.dispatch({ type: "inspect", candidate: candidateRef, source });
+        if (state === "pinned")
+          reducer.dispatch({ type: "toggle-pin", source });
+        if (
+          !shouldCommitInspection({
+            requestedState: state,
+            reducerKind: reducer.state.inspection.kind,
+          })
+        )
+          return;
+        inspection = next;
+        inspectionSeed = resolved.seed;
+        if (resolved.semanticChanged)
+          emitInspection(next, resolved.semanticFingerprint);
+      }
+    }
   }
 
   function toggleInspectionPin(source: InteractionSource): void {
-    if (inspection === null || inspectionSeed === null) return;
+    const pinAction = resolveToggleInspectionPinAction({
+      hasInspection: inspection !== null,
+      hasSeed: inspectionSeed !== null,
+      currentState: inspection?.state ?? "transient",
+      hasPendingPinned: pendingPinnedPointer !== null,
+    });
+    if (pinAction.type === "ignore") return;
+    // toggle-pin always runs before restore/flip side effects; if flip
+    // resolve returns null the reducer stays toggled (no rollback).
     reducer.dispatch({ type: "toggle-pin", source });
-    if (inspection.state === "pinned" && pendingPinnedPointer !== null) {
-      const pending = pendingPinnedPointer;
-      pendingPinnedPointer = null;
-      inspectionCoordinator.release("pinned");
-      inspection = null;
-      inspectionSeed = null;
-      setInspection(
-        pending.hit,
-        pending.source,
-        "transient",
-        pending.concreteMode,
-        pending.candidate,
-      );
-      return;
+    switch (pinAction.type) {
+      case "restore-pending": {
+        const pending = pendingPinnedPointer!;
+        pendingPinnedPointer = null;
+        inspectionCoordinator.release("pinned");
+        inspection = null;
+        inspectionSeed = null;
+        setInspection(
+          pending.hit,
+          pending.source,
+          "transient",
+          pending.concreteMode,
+          pending.candidate,
+        );
+        return;
+      }
+      case "flip-to-transient":
+      case "flip-to-pinned": {
+        // inspection + seed non-null after non-ignore (pure gate).
+        const state =
+          pinAction.type === "flip-to-transient" ? "transient" : "pinned";
+        const resolved = resolveInspection(
+          hitFromCandidate(inspectionSeed!),
+          source,
+          state,
+          inspection!.mode,
+          inspectionSeed!,
+        );
+        if (resolved === null) return;
+        inspection = resolved.snapshot;
+        inspectionSeed = resolved.seed;
+        if (state === "transient")
+          reducer.dispatch({
+            type: "inspect",
+            candidate: {
+              epoch: model?.runId ?? 0,
+              id: inspectionSeed.id,
+              panelId: resolved.snapshot.panelId,
+              x: inspectionSeed.x,
+              y: inspectionSeed.y,
+            },
+            source,
+          });
+        if (state === "transient") inspectionCoordinator.release("pinned");
+        if (
+          state === "transient" &&
+          (source === "keyboard" || source === "touch")
+        )
+          announceInteraction(
+            `${inspectionLiveText(resolved.snapshot)}, unpinned`,
+          );
+        if (resolved.semanticChanged)
+          emitInspection(resolved.snapshot, resolved.semanticFingerprint);
+        if (
+          state === "pinned" &&
+          interactionConfig.inspect?.contentMode === "interactive"
+        )
+          queueMicrotask(() =>
+            root
+              ?.querySelector<HTMLElement>(`#${CSS.escape(plotId)}-tooltip`)
+              ?.focus(),
+          );
+      }
     }
-    const state = inspection.state === "pinned" ? "transient" : "pinned";
-    const resolved = resolveInspection(
-      hitFromCandidate(inspectionSeed),
-      source,
-      state,
-      inspection.mode,
-      inspectionSeed,
-    );
-    if (resolved === null) return;
-    inspection = resolved.snapshot;
-    inspectionSeed = resolved.seed;
-    if (state === "transient")
-      reducer.dispatch({
-        type: "inspect",
-        candidate: {
-          epoch: model?.runId ?? 0,
-          id: inspectionSeed.id,
-          panelId: resolved.snapshot.panelId,
-          x: inspectionSeed.x,
-          y: inspectionSeed.y,
-        },
-        source,
-      });
-    if (state === "transient") inspectionCoordinator.release("pinned");
-    if (state === "transient" && (source === "keyboard" || source === "touch"))
-      announceInteraction(`${inspectionLiveText(resolved.snapshot)}, unpinned`);
-    if (resolved.semanticChanged)
-      emitInspection(resolved.snapshot, resolved.semanticFingerprint);
-    if (
-      state === "pinned" &&
-      interactionConfig.inspect?.contentMode === "interactive"
-    )
-      queueMicrotask(() =>
-        root
-          ?.querySelector<HTMLElement>(`#${CSS.escape(plotId)}-tooltip`)
-          ?.focus(),
-      );
   }
 
   function closeInspection(

--- a/packages/svelte/src/lib/plot-surface-inspection.ts
+++ b/packages/svelte/src/lib/plot-surface-inspection.ts
@@ -3,6 +3,8 @@
  * Callers own queue mutation, setInspection, and reducer side effects.
  */
 
+import type { InteractionSource } from "./interaction.js";
+
 type InspectionHostState = "none" | "transient" | "pinned";
 
 export type QueuedInspectFrameInput = {
@@ -55,4 +57,139 @@ export function resolveQueuedInspectFrameAction(
   if (input.currentState === "pinned") return { type: "stash-pending" };
   if (input.candidateEpochMismatch) return { type: "drop" };
   return { type: "apply-pending" };
+}
+
+/**
+ * Whether the host should clear the sticky live-region announcement text
+ * before routing a setInspection request.
+ *
+ * Host calls this **unconditionally before** `resolveSetInspectionAction`,
+ * including when the later action is `ignore` (e.g. keyboard transient
+ * while pinned still clears the announcement).
+ */
+export function shouldClearInspectionAnnouncement(input: {
+  readonly hasHit: boolean;
+  readonly source: InteractionSource;
+}): boolean {
+  return input.hasHit && (input.source === "keyboard" || input.source === "touch");
+}
+
+export type SetInspectionInput = {
+  readonly hasHit: boolean;
+  readonly requestedState: "transient" | "pinned";
+  /** Host: `inspection === null ? "none" : inspection.state`. */
+  readonly currentState: InspectionHostState;
+  readonly tooltipHovered: boolean;
+};
+
+export type SetInspectionAction =
+  | { readonly type: "ignore" }
+  | { readonly type: "clear" }
+  | { readonly type: "apply" };
+
+/**
+ * Pure decision for the start of host `setInspection`.
+ *
+ * Priority (matches current host):
+ *   1. ignore — current pinned + requested transient
+ *   2. ignore — !hasHit && (tooltipHovered || current pinned)
+ *   3. clear — !hasHit
+ *   4. apply — hasHit
+ *
+ * Host note: `apply` is not terminal. After resolve, a null coordinator
+ * result re-enters via `setInspection(null, source)` (default transient),
+ * re-running these gates. Host still owns resolve, reducer, emit, and
+ * the post-dispatch `shouldCommitInspection` gate.
+ */
+export function resolveSetInspectionAction(input: SetInspectionInput): SetInspectionAction {
+  if (input.currentState === "pinned" && input.requestedState === "transient")
+    return { type: "ignore" };
+  if (!input.hasHit) {
+    if (input.tooltipHovered || input.currentState === "pinned") return { type: "ignore" };
+    return { type: "clear" };
+  }
+  return { type: "apply" };
+}
+
+/**
+ * After reducer inspect (+ optional toggle-pin) dispatch for an apply path,
+ * whether the host should commit the resolved snapshot into inspection state.
+ * Host: when false, return without mutating inspection / seed / emit.
+ */
+export function shouldCommitInspection(input: {
+  readonly requestedState: "transient" | "pinned";
+  /** Host: `reducer.state.inspection.kind` after dispatch. */
+  readonly reducerKind: string;
+}): boolean {
+  if (input.requestedState === "transient" && input.reducerKind !== "transient") return false;
+  if (input.requestedState === "pinned" && input.reducerKind !== "pinned") return false;
+  return true;
+}
+
+export type ToggleInspectionPinInput = {
+  readonly hasInspection: boolean;
+  readonly hasSeed: boolean;
+  /** Host: current inspection.state when hasInspection. */
+  readonly currentState: "transient" | "pinned";
+  readonly hasPendingPinned: boolean;
+};
+
+export type ToggleInspectionPinAction =
+  | { readonly type: "ignore" }
+  | { readonly type: "restore-pending" }
+  | { readonly type: "flip-to-transient" }
+  | { readonly type: "flip-to-pinned" };
+
+/**
+ * Pure decision for host `toggleInspectionPin` after the null-seed guard.
+ *
+ * Host sequencing (preserve exactly):
+ *   1. if ignore → return (no reducer dispatch)
+ *   2. always `reducer.dispatch({ type: "toggle-pin", source })` first
+ *   3. restore-pending → release pinned, clear fields, setInspection(pending…)
+ *   4. flip → resolveInspection; if null return with reducer already toggled
+ *      (host does not roll back reducer state)
+ */
+export function resolveToggleInspectionPinAction(
+  input: ToggleInspectionPinInput,
+): ToggleInspectionPinAction {
+  if (!input.hasInspection || !input.hasSeed) return { type: "ignore" };
+  if (input.currentState === "pinned" && input.hasPendingPinned) return { type: "restore-pending" };
+  return input.currentState === "pinned"
+    ? { type: "flip-to-transient" }
+    : { type: "flip-to-pinned" };
+}
+
+/**
+ * Coordinator completeness for resolveInspection.
+ * Uses `!== undefined` (not truthiness): defined falsy content is complete.
+ */
+export function resolveInspectionCompleteness(input: {
+  readonly state: "transient" | "pinned";
+  readonly hasCustomContent: boolean;
+  readonly hasInspectCallback: boolean;
+  readonly hasInteractionCallback: boolean;
+}): "complete" | "transient" {
+  if (
+    input.state === "pinned" ||
+    input.hasCustomContent ||
+    input.hasInspectCallback ||
+    input.hasInteractionCallback
+  )
+    return "complete";
+  return "transient";
+}
+
+/**
+ * Resolve effective inspect mode from optional concrete mode + config request.
+ * Host: `concreteMode ?? (requested === "auto" ? seed.autoMode : requested)`.
+ */
+export function resolveInspectionMode(input: {
+  readonly concreteMode: "exact" | "x" | "y" | "xy" | undefined;
+  readonly requested: "auto" | "exact" | "x" | "y" | "xy";
+  readonly seedAutoMode: "exact" | "x" | "y" | "xy";
+}): "exact" | "x" | "y" | "xy" {
+  if (input.concreteMode !== undefined) return input.concreteMode;
+  if (input.requested === "auto") return input.seedAutoMode;
+  return input.requested;
 }

--- a/packages/svelte/tests/plot-surface-inspection.test.ts
+++ b/packages/svelte/tests/plot-surface-inspection.test.ts
@@ -1,8 +1,16 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  resolveInspectionCompleteness,
+  resolveInspectionMode,
   resolveQueuedInspectFrameAction,
+  resolveSetInspectionAction,
+  resolveToggleInspectionPinAction,
+  shouldClearInspectionAnnouncement,
+  shouldCommitInspection,
   type QueuedInspectFrameInput,
+  type SetInspectionInput,
+  type ToggleInspectionPinInput,
 } from "../src/lib/plot-surface-inspection.js";
 
 const frame = (overrides: Partial<QueuedInspectFrameInput> = {}): QueuedInspectFrameInput => ({
@@ -97,5 +105,320 @@ describe("resolveQueuedInspectFrameAction", () => {
         frame({ currentState: "transient", candidateEpochMismatch: true }),
       ),
     ).toEqual({ type: "drop" });
+  });
+});
+
+const setInput = (overrides: Partial<SetInspectionInput> = {}): SetInspectionInput => ({
+  hasHit: true,
+  requestedState: "transient",
+  currentState: "none",
+  tooltipHovered: false,
+  ...overrides,
+});
+
+describe("shouldClearInspectionAnnouncement", () => {
+  it("clears only for non-null hit from keyboard or touch", () => {
+    expect(shouldClearInspectionAnnouncement({ hasHit: true, source: "keyboard" })).toBe(true);
+    expect(shouldClearInspectionAnnouncement({ hasHit: true, source: "touch" })).toBe(true);
+  });
+
+  it("does not clear for pointer or programmatic even with a hit", () => {
+    expect(shouldClearInspectionAnnouncement({ hasHit: true, source: "pointer" })).toBe(false);
+    expect(
+      shouldClearInspectionAnnouncement({
+        hasHit: true,
+        source: "programmatic",
+      }),
+    ).toBe(false);
+  });
+
+  it("does not clear when there is no hit (even keyboard)", () => {
+    expect(shouldClearInspectionAnnouncement({ hasHit: false, source: "keyboard" })).toBe(false);
+    expect(shouldClearInspectionAnnouncement({ hasHit: false, source: "touch" })).toBe(false);
+  });
+});
+
+describe("resolveSetInspectionAction", () => {
+  it("ignores transient requests while pinned (even with a hit)", () => {
+    expect(
+      resolveSetInspectionAction(
+        setInput({
+          hasHit: true,
+          requestedState: "transient",
+          currentState: "pinned",
+        }),
+      ),
+    ).toEqual({ type: "ignore" });
+  });
+
+  it("ignores clear when tooltip is hovered", () => {
+    expect(
+      resolveSetInspectionAction(
+        setInput({
+          hasHit: false,
+          requestedState: "transient",
+          currentState: "transient",
+          tooltipHovered: true,
+        }),
+      ),
+    ).toEqual({ type: "ignore" });
+  });
+
+  it("ignores clear while pinned even for pinned requests", () => {
+    expect(
+      resolveSetInspectionAction(
+        setInput({
+          hasHit: false,
+          requestedState: "pinned",
+          currentState: "pinned",
+          tooltipHovered: false,
+        }),
+      ),
+    ).toEqual({ type: "ignore" });
+  });
+
+  it("clears when no hit and not blocked (including pinned request)", () => {
+    expect(
+      resolveSetInspectionAction(
+        setInput({
+          hasHit: false,
+          requestedState: "pinned",
+          currentState: "none",
+          tooltipHovered: false,
+        }),
+      ),
+    ).toEqual({ type: "clear" });
+    expect(
+      resolveSetInspectionAction(
+        setInput({
+          hasHit: false,
+          requestedState: "transient",
+          currentState: "transient",
+        }),
+      ),
+    ).toEqual({ type: "clear" });
+  });
+
+  it("applies when there is a hit and not pinned-blocking-transient", () => {
+    expect(
+      resolveSetInspectionAction(
+        setInput({
+          hasHit: true,
+          requestedState: "pinned",
+          currentState: "pinned",
+        }),
+      ),
+    ).toEqual({ type: "apply" });
+    expect(
+      resolveSetInspectionAction(
+        setInput({
+          hasHit: true,
+          requestedState: "transient",
+          currentState: "none",
+        }),
+      ),
+    ).toEqual({ type: "apply" });
+  });
+
+  it("priority: pinned+transient ignore beats clear and apply", () => {
+    // no hit + pinned + transient → ignore (gate 1), not clear
+    expect(
+      resolveSetInspectionAction(
+        setInput({
+          hasHit: false,
+          requestedState: "transient",
+          currentState: "pinned",
+          tooltipHovered: false,
+        }),
+      ),
+    ).toEqual({ type: "ignore" });
+  });
+});
+
+describe("shouldCommitInspection", () => {
+  it("commits when reducer kind matches requested state", () => {
+    expect(
+      shouldCommitInspection({
+        requestedState: "transient",
+        reducerKind: "transient",
+      }),
+    ).toBe(true);
+    expect(
+      shouldCommitInspection({
+        requestedState: "pinned",
+        reducerKind: "pinned",
+      }),
+    ).toBe(true);
+  });
+
+  it("abandons when reducer kind does not match requested state", () => {
+    expect(
+      shouldCommitInspection({
+        requestedState: "transient",
+        reducerKind: "pinned",
+      }),
+    ).toBe(false);
+    expect(
+      shouldCommitInspection({
+        requestedState: "pinned",
+        reducerKind: "transient",
+      }),
+    ).toBe(false);
+    expect(
+      shouldCommitInspection({
+        requestedState: "transient",
+        reducerKind: "none",
+      }),
+    ).toBe(false);
+  });
+});
+
+const toggleInput = (
+  overrides: Partial<ToggleInspectionPinInput> = {},
+): ToggleInspectionPinInput => ({
+  hasInspection: true,
+  hasSeed: true,
+  currentState: "transient",
+  hasPendingPinned: false,
+  ...overrides,
+});
+
+describe("resolveToggleInspectionPinAction", () => {
+  it("ignores without inspection or seed", () => {
+    expect(
+      resolveToggleInspectionPinAction(toggleInput({ hasInspection: false, hasSeed: true })),
+    ).toEqual({ type: "ignore" });
+    expect(
+      resolveToggleInspectionPinAction(toggleInput({ hasInspection: true, hasSeed: false })),
+    ).toEqual({ type: "ignore" });
+  });
+
+  it("restores pending only when pinned with a pending payload", () => {
+    expect(
+      resolveToggleInspectionPinAction(
+        toggleInput({
+          currentState: "pinned",
+          hasPendingPinned: true,
+        }),
+      ),
+    ).toEqual({ type: "restore-pending" });
+  });
+
+  it("does not restore pending while transient even if pending exists", () => {
+    expect(
+      resolveToggleInspectionPinAction(
+        toggleInput({
+          currentState: "transient",
+          hasPendingPinned: true,
+        }),
+      ),
+    ).toEqual({ type: "flip-to-pinned" });
+  });
+
+  it("flips pinned → transient when no pending", () => {
+    expect(
+      resolveToggleInspectionPinAction(
+        toggleInput({
+          currentState: "pinned",
+          hasPendingPinned: false,
+        }),
+      ),
+    ).toEqual({ type: "flip-to-transient" });
+  });
+
+  it("flips transient → pinned", () => {
+    expect(resolveToggleInspectionPinAction(toggleInput({ currentState: "transient" }))).toEqual({
+      type: "flip-to-pinned",
+    });
+  });
+});
+
+describe("resolveInspectionCompleteness", () => {
+  it("is complete when pinned regardless of callbacks", () => {
+    expect(
+      resolveInspectionCompleteness({
+        state: "pinned",
+        hasCustomContent: false,
+        hasInspectCallback: false,
+        hasInteractionCallback: false,
+      }),
+    ).toBe("complete");
+  });
+
+  it("is complete when any content/callback flag is true", () => {
+    expect(
+      resolveInspectionCompleteness({
+        state: "transient",
+        hasCustomContent: true,
+        hasInspectCallback: false,
+        hasInteractionCallback: false,
+      }),
+    ).toBe("complete");
+    expect(
+      resolveInspectionCompleteness({
+        state: "transient",
+        hasCustomContent: false,
+        hasInspectCallback: true,
+        hasInteractionCallback: false,
+      }),
+    ).toBe("complete");
+    expect(
+      resolveInspectionCompleteness({
+        state: "transient",
+        hasCustomContent: false,
+        hasInspectCallback: false,
+        hasInteractionCallback: true,
+      }),
+    ).toBe("complete");
+  });
+
+  it("is transient only when unpinned and all flags false", () => {
+    expect(
+      resolveInspectionCompleteness({
+        state: "transient",
+        hasCustomContent: false,
+        hasInspectCallback: false,
+        hasInteractionCallback: false,
+      }),
+    ).toBe("transient");
+  });
+});
+
+describe("resolveInspectionMode", () => {
+  it("prefers concreteMode when provided", () => {
+    expect(
+      resolveInspectionMode({
+        concreteMode: "x",
+        requested: "auto",
+        seedAutoMode: "xy",
+      }),
+    ).toBe("x");
+    expect(
+      resolveInspectionMode({
+        concreteMode: "exact",
+        requested: "y",
+        seedAutoMode: "xy",
+      }),
+    ).toBe("exact");
+  });
+
+  it("uses seed autoMode when requested is auto", () => {
+    expect(
+      resolveInspectionMode({
+        concreteMode: undefined,
+        requested: "auto",
+        seedAutoMode: "y",
+      }),
+    ).toBe("y");
+  });
+
+  it("uses requested mode when not auto and no concrete", () => {
+    expect(
+      resolveInspectionMode({
+        concreteMode: undefined,
+        requested: "xy",
+        seedAutoMode: "exact",
+      }),
+    ).toBe("xy");
   });
 });


### PR DESCRIPTION
## Summary

- Extract pure decision helpers for inspection host policy from `GGPlot.svelte` into `plot-surface-inspection.ts`: announcement clear, setInspection gates, post-dispatch commit check, toggle-pin routing, completeness, and mode resolution.
- Wire the host to switch on pure actions while preserving side-effect order (announcement before gates, dual clear dispatches, toggle-pin before restore/flip, recursive null→clear).
- Add characterization unit tests covering priority matrices and named edge cases.

## Test plan

- [x] `bun run test:browser -- tests/plot-surface-inspection.test.ts` (all browsers)
- [x] `bun run check` (0 errors/warnings)
- [x] `bun run test:browser -- tests/interaction.test.ts tests/interaction-unit.test.ts tests/interaction-regressions.test.ts`
- [x] Pre-push hooks (oxlint type-aware, knip, package build)
- [ ] CI green on PR