### PR TITLE
fix: address post-merge Codex findings from #61

### DIFF
--- a/packages/svelte/src/lib/GGPlot.svelte
+++ b/packages/svelte/src/lib/GGPlot.svelte
@@ -193,6 +193,7 @@
     applyZoomToSpec,
     buildZoomEvent,
     continuousZoomDomainsFromScopes,
+    filterScopeChannelsByZoomMode,
     filterZoomDomainsByMode,
     resolveBrushZoomDomains,
     sanitizePartialZoomDomains,
@@ -339,12 +340,17 @@
     });
   });
 
+  // Facet intent comes from the raw prop — not assembled.facet — so declaration-
+  // only children still take the faceted diagnostic path before layers register
+  // and assembled becomes non-null on a later flush.
+  const facetedPlot = $derived(facet !== undefined);
+
   const resolvedInteractionScope: PlotInteractionScope = $derived(
     resolveInteractionScope({
       interaction,
       ...(interactionScope !== undefined && { interactionScope }),
       zoom,
-      faceted: assembled?.facet !== undefined,
+      faceted: facetedPlot,
       ...(datumKey !== undefined && { datumKey }),
       assembled,
     }),
@@ -360,7 +366,7 @@
         ...(tool !== undefined && { tool }),
       },
       {
-        faceted: assembled?.facet !== undefined,
+        faceted: facetedPlot,
         hasKey: datumKey !== undefined,
       },
     ),
@@ -491,7 +497,13 @@
     scaleBox.runId = -1;
     scaleBox.scales = undefined;
     if (interaction === undefined) localZoomDomains = null;
-    else interaction.resetZoom({ scope: resolvedInteractionScope });
+    else
+      interaction.resetZoom({
+        scope: filterScopeChannelsByZoomMode(
+          resolvedInteractionScope,
+          interactionConfig.zoom?.mode ?? null,
+        ),
+      });
     scaleEpoch++;
   }
 
@@ -1941,11 +1953,16 @@
       if (domains === null && localZoomDomains === null) return;
       localZoomDomains = domains;
     } else {
+      // Match filterZoomDomainsByMode: x-only plots must not mutate shared y.
+      const mutationScope = filterScopeChannelsByZoomMode(
+        resolvedInteractionScope,
+        interactionConfig.zoom?.mode ?? null,
+      );
       const transition =
         domains === null
-          ? interaction.resetZoom({ scope: resolvedInteractionScope, source })
+          ? interaction.resetZoom({ scope: mutationScope, source })
           : interaction.setZoom(domains, {
-              scope: resolvedInteractionScope,
+              scope: mutationScope,
               source,
             });
       if (transition === null) return;
@@ -1953,8 +1970,8 @@
         committed = frozenZoomDomains(
           continuousZoomDomainsFromScopes(
             transition.snapshot.zoom,
-            resolvedInteractionScope.x,
-            resolvedInteractionScope.y,
+            mutationScope.x,
+            mutationScope.y,
           ),
         );
       }

--- a/packages/svelte/src/lib/plot-zoom.ts
+++ b/packages/svelte/src/lib/plot-zoom.ts
@@ -1,7 +1,7 @@
 import type { RenderModel } from "@ggsvelte/core";
 import type { PortableSpec, Scales } from "@ggsvelte/spec";
 
-import type { InteractionSource, ZoomEvent } from "./interaction.js";
+import type { InteractionSource, PlotInteractionScope, ZoomEvent } from "./interaction.js";
 import {
   frozenZoomDomains,
   panelDataDomains,
@@ -87,6 +87,29 @@ export function filterZoomDomainsByMode(
   };
   if (next.x === undefined && next.y === undefined) return null;
   return next;
+}
+
+/**
+ * Restrict controller mutation scopes to zoom channels this plot opted into.
+ *
+ * Linked plots often share `{ keys, x, y }` while an individual chart uses
+ * `zoom={{ mode: "x" }}`. Reading already filters domains by mode; resets and
+ * writes must too, or Reset on an x-only plot would clear the shared y domain.
+ *
+ * - `mode === null | "xy"`: keep every defined channel on `scope`
+ * - `mode === "x" | "y"`: drop the other positional channel
+ */
+export function filterScopeChannelsByZoomMode(
+  scope: PlotInteractionScope,
+  mode: ZoomMode | null,
+): PlotInteractionScope {
+  const takeX = mode === null || mode !== "y";
+  const takeY = mode === null || mode !== "x";
+  return Object.freeze({
+    keys: scope.keys,
+    ...(takeX && scope.x !== undefined && { x: scope.x }),
+    ...(takeY && scope.y !== undefined && { y: scope.y }),
+  });
 }
 
 function sameZoomChannel(

--- a/packages/svelte/tests/plot-assemble.test.ts
+++ b/packages/svelte/tests/plot-assemble.test.ts
@@ -249,6 +249,17 @@ describe("resolveInteractionScope", () => {
         assembled,
       }),
     ).toEqual({ keys: "id" });
+    // Hosts must pass faceted from the raw facet prop (not assembled.facet)
+    // so declaration-only children still take this path before layers register.
+    expect(
+      resolveInteractionScope({
+        interaction: {},
+        interactionScope: { keys: "id" },
+        zoom: true,
+        faceted: true,
+        assembled: null,
+      }),
+    ).toEqual({ keys: "id" });
   });
 
   it("requires y scope for controlled y zoom", () => {

--- a/packages/svelte/tests/plot-zoom.test.ts
+++ b/packages/svelte/tests/plot-zoom.test.ts
@@ -6,6 +6,7 @@ import {
   applyZoomToSpec,
   buildZoomEvent,
   continuousZoomDomainsFromScopes,
+  filterScopeChannelsByZoomMode,
   filterZoomDomainsByMode,
   resolveBrushZoomDomains,
   sameZoomDomains,
@@ -57,6 +58,30 @@ describe("filterZoomDomainsByMode", () => {
   it("drops a mode when the matching channel is absent", () => {
     expect(filterZoomDomainsByMode({ y: [3, 4] }, "x")).toBeNull();
     expect(filterZoomDomainsByMode({ x: [1, 2] }, "y")).toBeNull();
+  });
+});
+
+describe("filterScopeChannelsByZoomMode", () => {
+  const linked = { keys: "id", x: "x-mm", y: "y-mm" };
+
+  it("keeps both channels for xy or null mode", () => {
+    expect(filterScopeChannelsByZoomMode(linked, "xy")).toEqual(linked);
+    expect(filterScopeChannelsByZoomMode(linked, null)).toEqual(linked);
+  });
+
+  it("drops the non-opted channel for single-axis zoom", () => {
+    expect(filterScopeChannelsByZoomMode(linked, "x")).toEqual({
+      keys: "id",
+      x: "x-mm",
+    });
+    expect(filterScopeChannelsByZoomMode(linked, "y")).toEqual({
+      keys: "id",
+      y: "y-mm",
+    });
+  });
+
+  it("freezes the result", () => {
+    expect(Object.isFrozen(filterScopeChannelsByZoomMode(linked, "x"))).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

Follow-up for unrebutted post-merge Codex findings on #61 (controller zoom from #43).

### Valid → fixed
1. **Limit reset to opted-in zoom channels** — `filterScopeChannelsByZoomMode` strips non-opted channels from controller mutation scopes. Reset/set zoom on `zoom={{ mode: \"x\" }}` no longer clears a shared y domain from a common `{ x, y }` interactionScope.
2. **Detect facet props before child layers register** — faceted intent uses the raw `facet` prop, not `assembled?.facet`, so controlled faceted plots with declaration-only children take the diagnostic/no-op path on the first pass.

## Test plan
- [x] `vitest run tests/plot-zoom.test.ts tests/plot-assemble.test.ts` (126)

Parent: #61