### PR TITLE
refactor(svelte): extract pure surface-dismiss and finish-brush decisions

### DIFF
--- a/packages/svelte/src/lib/GGPlot.svelte
+++ b/packages/svelte/src/lib/GGPlot.svelte
@@ -118,16 +118,20 @@
     resolveInspectionMode,
     resolveQueuedInspectFrameAction,
     resolveSetInspectionAction,
+    resolveSurfaceBlurAction,
     resolveToggleInspectionPinAction,
     shouldClearInspectionAnnouncement,
+    shouldClosePinnedOnOutsidePointer,
     shouldCommitInspection,
   } from "./plot-surface-inspection.js";
   import {
     resolveCaptureClickAction,
     advanceTouchInspectMoved,
+    resolveFinishBrushAction,
     resolvePointerDownAction,
     resolvePointerMoveAction,
     resolvePointerUpAction,
+    shouldClearInspectionOnPointerLeave,
   } from "./plot-surface-pointer.js";
   import {
     resolveLegendClearControlSource,
@@ -926,8 +930,10 @@
     if (!surfaceInteractive) return;
     const onOutsidePointer = (event: PointerEvent) => {
       if (
-        inspection?.state !== "pinned" ||
-        root?.contains(event.target as Node)
+        !shouldClosePinnedOnOutsidePointer({
+          isPinned: inspection?.state === "pinned",
+          targetInsideRoot: root?.contains(event.target as Node) === true,
+        })
       )
         return;
       closeInspection("pointer", false);
@@ -1796,13 +1802,20 @@
   }
 
   function onPointerLeave(): void {
+    // Evaluate leave clear **inside** the microtask so brushing/tooltip
+    // reflect post-flush state (not leave-time snapshots).
     queueMicrotask(() => {
-      if (!brushing && !tooltipHovered) {
-        queuedPointerInspection = null;
-        pendingPinnedPointer = null;
-        reducer.cancelScheduledPointer();
-        setInspection(null, "pointer");
-      }
+      if (
+        !shouldClearInspectionOnPointerLeave({
+          brushing,
+          tooltipHovered,
+        })
+      )
+        return;
+      queuedPointerInspection = null;
+      pendingPinnedPointer = null;
+      reducer.cancelScheduledPointer();
+      setInspection(null, "pointer");
     });
   }
 
@@ -1919,26 +1932,43 @@
       case "none":
         break;
       case "finish-brush": {
+        // Defensive: pure up-gate already requires hasBrushDraft.
         if (brushRect === null) break;
         reducer.cancelScheduledPointer();
         const source = event.pointerType === "touch" ? "touch" : "pointer";
         const ended = evaluatePointerBrushEnd(brushRect, plotPoint(event));
-        if (ended.kind === "too-small") {
-          brushRect = ended.corners;
-          announceInteraction(BRUSH_SECOND_CORNER_ANNOUNCEMENT);
-          break;
+        const finish = resolveFinishBrushAction({
+          endedKind: ended.kind,
+          activeTool,
+        });
+        switch (finish.type) {
+          case "keep-second-corner":
+            // ended.kind is too-small when pure returns keep-second-corner.
+            if (ended.kind === "too-small") brushRect = ended.corners;
+            announceInteraction(BRUSH_SECOND_CORNER_ANNOUNCEMENT);
+            break;
+          case "select-end":
+            brushRect = null;
+            if (ended.kind === "commit") {
+              const eventValue = selectionEvent("end", ended.rect, source);
+              committedInterval = interactionConfig.select?.persistent
+                ? eventValue
+                : null;
+              emitSelection(eventValue);
+            }
+            reducer.dispatch({ type: "cancel-area" });
+            break;
+          case "zoom-end":
+            brushRect = null;
+            if (ended.kind === "commit") applyBrushZoom(ended.rect, source);
+            reducer.dispatch({ type: "cancel-area" });
+            break;
+          case "end-area":
+            // Commit with non-area tool (e.g. tool changed mid-drag): clear only.
+            brushRect = null;
+            reducer.dispatch({ type: "cancel-area" });
+            break;
         }
-        brushRect = null;
-        if (activeTool === "select-area") {
-          const eventValue = selectionEvent("end", ended.rect, source);
-          committedInterval = interactionConfig.select?.persistent
-            ? eventValue
-            : null;
-          emitSelection(eventValue);
-        } else if (activeTool === "zoom-area") {
-          applyBrushZoom(ended.rect, source);
-        }
-        reducer.dispatch({ type: "cancel-area" });
         break;
       }
     }
@@ -2087,10 +2117,17 @@
   }
 
   function onSurfaceBlur(event: FocusEvent): void {
-    if (root?.contains(event.relatedTarget as Node | null)) return;
+    const blurAction = resolveSurfaceBlurAction({
+      relatedTargetInsideRoot:
+        root?.contains(event.relatedTarget as Node | null) === true,
+      inspectionState: inspection?.state ?? "none",
+    });
+    if (blurAction.type === "ignore") return;
+    // Shared for keep-pinned and clear-inspection (ordering is load-bearing).
     activeTraversalIndex = -1;
     reducer.dispatch({ type: "set-active", candidate: null });
-    if (inspection?.state !== "pinned") setInspection(null, "keyboard");
+    if (blurAction.type === "blur-clear-inspection")
+      setInspection(null, "keyboard");
   }
 
   function togglePointKeys(

--- a/packages/svelte/src/lib/plot-surface-inspection.ts
+++ b/packages/svelte/src/lib/plot-surface-inspection.ts
@@ -193,3 +193,43 @@ export function resolveInspectionMode(input: {
   if (input.requested === "auto") return input.seedAutoMode;
   return input.requested;
 }
+
+// ---- surface blur / outside pointer dismiss ----
+
+export type SurfaceBlurAction =
+  | { readonly type: "ignore" }
+  | { readonly type: "blur-keep-pinned" }
+  | { readonly type: "blur-clear-inspection" };
+
+/**
+ * Pure decision for capture-surface `blur`.
+ *
+ * Host on non-ignore (ordering is load-bearing):
+ *   1. activeTraversalIndex = -1
+ *   2. reducer.dispatch set-active null
+ *   3. only blur-clear-inspection → setInspection(null, "keyboard")
+ *
+ * Host must pass `relatedTargetInsideRoot: root?.contains(related) === true`.
+ * `"none"` and `"transient"` both clear inspection; `"pinned"` keeps it.
+ */
+export function resolveSurfaceBlurAction(input: {
+  readonly relatedTargetInsideRoot: boolean;
+  /** Host: `inspection === null ? "none" : inspection.state`. */
+  readonly inspectionState: InspectionHostState;
+}): SurfaceBlurAction {
+  if (input.relatedTargetInsideRoot) return { type: "ignore" };
+  if (input.inspectionState === "pinned") return { type: "blur-keep-pinned" };
+  return { type: "blur-clear-inspection" };
+}
+
+/**
+ * Whether a window pointerdown outside the plot should close a pinned
+ * inspection. Host: only when `surfaceInteractive` effect is installed.
+ * Host must pass `targetInsideRoot: root?.contains(target) === true`.
+ */
+export function shouldClosePinnedOnOutsidePointer(input: {
+  readonly isPinned: boolean;
+  readonly targetInsideRoot: boolean;
+}): boolean {
+  return input.isPinned && !input.targetInsideRoot;
+}

--- a/packages/svelte/src/lib/plot-surface-pointer.ts
+++ b/packages/svelte/src/lib/plot-surface-pointer.ts
@@ -219,3 +219,49 @@ export function resolvePointerMoveAction(input: SurfacePointerMoveInput): Surfac
 
   return { type: "none" };
 }
+
+// ---- pointer leave / finish-brush ----
+
+/**
+ * Whether pointerleave should clear inspection after its microtask flush.
+ * Host must call this **inside** `queueMicrotask` so `brushing` and
+ * `tooltipHovered` reflect post-flush state (not leave-time snapshots).
+ */
+export function shouldClearInspectionOnPointerLeave(input: {
+  readonly brushing: boolean;
+  readonly tooltipHovered: boolean;
+}): boolean {
+  return !input.brushing && !input.tooltipHovered;
+}
+
+/** Matches `PointerBrushEnd["kind"]` from plot-area-brush (no import cycle). */
+export type FinishBrushEndedKind = "too-small" | "commit";
+
+export type FinishBrushAction =
+  | { readonly type: "keep-second-corner" }
+  | { readonly type: "select-end" }
+  | { readonly type: "zoom-end" }
+  | { readonly type: "end-area" };
+
+/**
+ * Pure routing after `evaluatePointerBrushEnd` for pointerup finish-brush.
+ *
+ * Priority:
+ *   1. keep-second-corner — `endedKind === "too-small"` (wins for any tool)
+ *   2. select-end — commit + select-area
+ *   3. zoom-end — commit + zoom-area
+ *   4. end-area — commit + any other tool (clear draft + cancel-area, no emit)
+ *
+ * Host on keep-second-corner: retain corners, announce, do **not** cancel-area.
+ * Host on select-end/zoom-end/end-area: brushRect=null, cancel-area; emit only
+ * for select/zoom. Host keeps its `brushRect === null` defensive break.
+ */
+export function resolveFinishBrushAction(input: {
+  readonly endedKind: FinishBrushEndedKind;
+  readonly activeTool: InteractionTool;
+}): FinishBrushAction {
+  if (input.endedKind === "too-small") return { type: "keep-second-corner" };
+  if (input.activeTool === "select-area") return { type: "select-end" };
+  if (input.activeTool === "zoom-area") return { type: "zoom-end" };
+  return { type: "end-area" };
+}

--- a/packages/svelte/tests/plot-surface-inspection.test.ts
+++ b/packages/svelte/tests/plot-surface-inspection.test.ts
@@ -5,8 +5,10 @@ import {
   resolveInspectionMode,
   resolveQueuedInspectFrameAction,
   resolveSetInspectionAction,
+  resolveSurfaceBlurAction,
   resolveToggleInspectionPinAction,
   shouldClearInspectionAnnouncement,
+  shouldClosePinnedOnOutsidePointer,
   shouldCommitInspection,
   type QueuedInspectFrameInput,
   type SetInspectionInput,
@@ -420,5 +422,78 @@ describe("resolveInspectionMode", () => {
         seedAutoMode: "exact",
       }),
     ).toBe("xy");
+  });
+});
+
+describe("resolveSurfaceBlurAction", () => {
+  it("ignores when relatedTarget is inside the plot root", () => {
+    expect(
+      resolveSurfaceBlurAction({
+        relatedTargetInsideRoot: true,
+        inspectionState: "transient",
+      }),
+    ).toEqual({ type: "ignore" });
+    expect(
+      resolveSurfaceBlurAction({
+        relatedTargetInsideRoot: true,
+        inspectionState: "pinned",
+      }),
+    ).toEqual({ type: "ignore" });
+    expect(
+      resolveSurfaceBlurAction({
+        relatedTargetInsideRoot: true,
+        inspectionState: "none",
+      }),
+    ).toEqual({ type: "ignore" });
+  });
+
+  it("keeps pinned inspection when focus leaves the root", () => {
+    expect(
+      resolveSurfaceBlurAction({
+        relatedTargetInsideRoot: false,
+        inspectionState: "pinned",
+      }),
+    ).toEqual({ type: "blur-keep-pinned" });
+  });
+
+  it("clears inspection for transient and none when focus leaves the root", () => {
+    expect(
+      resolveSurfaceBlurAction({
+        relatedTargetInsideRoot: false,
+        inspectionState: "transient",
+      }),
+    ).toEqual({ type: "blur-clear-inspection" });
+    expect(
+      resolveSurfaceBlurAction({
+        relatedTargetInsideRoot: false,
+        inspectionState: "none",
+      }),
+    ).toEqual({ type: "blur-clear-inspection" });
+  });
+});
+
+describe("shouldClosePinnedOnOutsidePointer", () => {
+  it("closes only when pinned and target is outside the root", () => {
+    expect(shouldClosePinnedOnOutsidePointer({ isPinned: true, targetInsideRoot: false })).toBe(
+      true,
+    );
+  });
+
+  it("does not close when not pinned", () => {
+    expect(shouldClosePinnedOnOutsidePointer({ isPinned: false, targetInsideRoot: false })).toBe(
+      false,
+    );
+  });
+
+  it("does not close when target is inside the root", () => {
+    expect(shouldClosePinnedOnOutsidePointer({ isPinned: true, targetInsideRoot: true })).toBe(
+      false,
+    );
+  });
+
+  it("does not close when unpinned and inside", () => {
+    expect(shouldClosePinnedOnOutsidePointer({ isPinned: false, targetInsideRoot: true })).toBe(
+      false,
+    );
   });
 });

--- a/packages/svelte/tests/plot-surface-pointer.test.ts
+++ b/packages/svelte/tests/plot-surface-pointer.test.ts
@@ -5,9 +5,11 @@ import {
   TOUCH_INSPECT_MOVE_PX,
   advanceTouchInspectMoved,
   resolveCaptureClickAction,
+  resolveFinishBrushAction,
   resolvePointerDownAction,
   resolvePointerMoveAction,
   resolvePointerUpAction,
+  shouldClearInspectionOnPointerLeave,
   type SurfaceClickInput,
   type SurfacePointerDownInput,
   type SurfacePointerMoveInput,
@@ -472,6 +474,68 @@ describe("resolvePointerMoveAction", () => {
   it("returns none for non-inspect tools without brush", () => {
     expect(resolvePointerMoveAction(move({ activeTool: "point" }))).toEqual({
       type: "none",
+    });
+  });
+});
+
+describe("shouldClearInspectionOnPointerLeave", () => {
+  it("clears only when idle brush and tooltip not hovered", () => {
+    expect(shouldClearInspectionOnPointerLeave({ brushing: false, tooltipHovered: false })).toBe(
+      true,
+    );
+  });
+
+  it("holds while brushing", () => {
+    expect(shouldClearInspectionOnPointerLeave({ brushing: true, tooltipHovered: false })).toBe(
+      false,
+    );
+  });
+
+  it("holds while tooltip is hovered", () => {
+    expect(shouldClearInspectionOnPointerLeave({ brushing: false, tooltipHovered: true })).toBe(
+      false,
+    );
+  });
+
+  it("holds when both brushing and tooltip hovered", () => {
+    expect(shouldClearInspectionOnPointerLeave({ brushing: true, tooltipHovered: true })).toBe(
+      false,
+    );
+  });
+});
+
+describe("resolveFinishBrushAction", () => {
+  it("keeps second corner on too-small for any tool", () => {
+    for (const activeTool of [
+      "select-area",
+      "zoom-area",
+      "inspect",
+      "point",
+    ] as const satisfies readonly InteractionTool[]) {
+      expect(resolveFinishBrushAction({ endedKind: "too-small", activeTool })).toEqual({
+        type: "keep-second-corner",
+      });
+    }
+  });
+
+  it("routes commit + select-area to select-end", () => {
+    expect(resolveFinishBrushAction({ endedKind: "commit", activeTool: "select-area" })).toEqual({
+      type: "select-end",
+    });
+  });
+
+  it("routes commit + zoom-area to zoom-end", () => {
+    expect(resolveFinishBrushAction({ endedKind: "commit", activeTool: "zoom-area" })).toEqual({
+      type: "zoom-end",
+    });
+  });
+
+  it("routes commit + non-area tools to end-area (clear draft, no emit)", () => {
+    expect(resolveFinishBrushAction({ endedKind: "commit", activeTool: "inspect" })).toEqual({
+      type: "end-area",
+    });
+    expect(resolveFinishBrushAction({ endedKind: "commit", activeTool: "point" })).toEqual({
+      type: "end-area",
     });
   });
 });


### PR DESCRIPTION
## Summary
- Extract pure decision tables for capture-surface pointer leave, blur, outside-pointer dismiss, and finish-brush tool routing from `GGPlot.svelte`.
- Host handlers keep side effects only (queue clear, reducer dispatch, selection/zoom emit, announcements).
- Characterization tests cover leave gates, blur pinned/transient/none, outside-pointer pin close, and finish-brush too-small / select / zoom / end-area paths.

## Test plan
- [x] `bun run test:browser -- tests/plot-surface-pointer.test.ts tests/plot-surface-inspection.test.ts`
- [x] `bun run test:browser -- tests/interaction-unit.test.ts tests/interaction-regressions.test.ts tests/plot-area-brush.test.ts`
- [x] `bun run check` (packages/svelte)
- [x] Pre-push hooks (build, oxlint, knip, package tests)
- [ ] CI green on this PR