### PR TITLE
fix: detect facet intent from raw prop or assembled spec after #76

### DIFF
--- a/packages/svelte/src/lib/GGPlot.svelte
+++ b/packages/svelte/src/lib/GGPlot.svelte
@@ -101,6 +101,7 @@
   import InteractionOverlay from "./InteractionOverlay.svelte";
   import {
     assemblePortableSpec,
+    isFacetedPlotIntent,
     resolveInteractionScope,
     toLayerInput,
   } from "./plot-assemble.js";
@@ -344,10 +345,9 @@
     });
   });
 
-  // Facet intent comes from the raw prop — not assembled.facet — so declaration-
-  // only children still take the faceted diagnostic path before layers register
-  // and assembled becomes non-null on a later flush.
-  const facetedPlot = $derived(facet !== undefined);
+  // Facet intent: raw prop (declaration-only children before layers register)
+  // OR assembled.facet (portable-spec plots that embed facet without a prop).
+  const facetedPlot = $derived(isFacetedPlotIntent({ facet, assembled }));
 
   const resolvedInteractionScope: PlotInteractionScope = $derived(
     resolveInteractionScope({

--- a/packages/svelte/src/lib/plot-assemble.ts
+++ b/packages/svelte/src/lib/plot-assemble.ts
@@ -69,6 +69,23 @@ export type AssemblePortableSpecInput = {
 };
 
 /**
+ * Whether this plot instance should take the faceted interaction path
+ * (disable brush zoom / interval select with a diagnostic).
+ *
+ * True when either:
+ * - the raw `facet` prop is set (covers declaration-only children before layers
+ *   register and `assembled` is still null), or
+ * - `assembled.facet` is set (covers portable-`spec` plots that embed facet
+ *   without a separate prop).
+ */
+export function isFacetedPlotIntent(input: {
+  readonly facet?: FacetInput | undefined;
+  readonly assembled: PortableSpec | null;
+}): boolean {
+  return input.facet !== undefined || input.assembled?.facet !== undefined;
+}
+
+/**
  * Build the normalized PortableSpec for GGPlot.
  * Explicit `spec` wins; empty `layers` yields null (no plot).
  */

--- a/packages/svelte/tests/plot-assemble.test.ts
+++ b/packages/svelte/tests/plot-assemble.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   assemblePortableSpec,
+  isFacetedPlotIntent,
   mappedChannelField,
   resolveInteractionScope,
   toLayerInput,
@@ -178,6 +179,50 @@ describe("mappedChannelField", () => {
   });
 });
 
+describe("isFacetedPlotIntent", () => {
+  it("is true from the raw facet prop before layers assemble (declaration-only children)", () => {
+    // Hosts must treat a raw facet prop as intent even when assembled is still
+    // null — declaration-only children register on a later flush.
+    expect(
+      isFacetedPlotIntent({
+        facet: { rows: "g" },
+        assembled: null,
+      }),
+    ).toBe(true);
+  });
+
+  it("is true from assembled.facet when the plot is driven by a portable spec", () => {
+    // Spec-based plots put facet on the normalized spec, not a separate prop.
+    const assembled = assemblePortableSpec({
+      spec: {
+        data: [{ x: 1, y: 2, g: "a" }],
+        layers: [{ geom: "point", aes: { x: "x", y: "y" } }],
+        facet: { rows: "g" },
+      },
+      layers: [],
+    });
+    expect(assembled?.facet).toBeDefined();
+    expect(
+      isFacetedPlotIntent({
+        assembled,
+      }),
+    ).toBe(true);
+  });
+
+  it("is false when neither the prop nor the assembled spec is faceted", () => {
+    const assembled = assemblePortableSpec({
+      data: [{ x: 1, y: 2 }],
+      layers: [{ geom: "point", aes: { x: "x", y: "y" } }],
+    });
+    expect(
+      isFacetedPlotIntent({
+        assembled,
+      }),
+    ).toBe(false);
+    expect(isFacetedPlotIntent({ assembled: null })).toBe(false);
+  });
+});
+
 describe("resolveInteractionScope", () => {
   const assembled = assemblePortableSpec({
     data: [{ foo: 1, bar: 2 }],
@@ -249,8 +294,8 @@ describe("resolveInteractionScope", () => {
         assembled,
       }),
     ).toEqual({ keys: "id" });
-    // Hosts must pass faceted from the raw facet prop (not assembled.facet)
-    // so declaration-only children still take this path before layers register.
+    // Hosts must pass faceted via isFacetedPlotIntent (raw prop OR assembled.facet)
+    // so declaration-only children and spec-embedded facets both take this path.
     expect(
       resolveInteractionScope({
         interaction: {},


### PR DESCRIPTION
## Summary

Follow-up for unrebutted post-merge Codex P2 on #76.

### Valid → fixed
**Preserve facet detection for spec-based plots** — #76 gated faceted interaction on the raw `facet` prop so declaration-only children take the diagnostic/no-op path before layers register. That regressed portable-`spec` plots that embed `facet` without a separate prop: `normalizeInteractionConfig` no longer disabled brush zoom/interval select, and controlled plots with `interactionScope={{ keys: ... }}` + `zoom` threw for missing x/y scopes.

`isFacetedPlotIntent` unions both sources (`facet` prop **or** `assembled?.facet`).

## Test plan
- [x] `vitest run tests/plot-assemble.test.ts tests/plot-zoom.test.ts` (135)
- [x] pre-push full gate (build, svelte-check, oxlint, knip, bun test)

Parent: #76
Codex thread: https://github.com/ljodea/ggsvelte/pull/76#discussion_r3593805366