### PR TITLE
refactor(svelte): extract pure tool, lost-capture, and inspection-emit decisions

### DIFF
--- a/packages/svelte/src/lib/GGPlot.svelte
+++ b/packages/svelte/src/lib/GGPlot.svelte
@@ -984,7 +984,7 @@
         queuedPointerInspection = null;
         reducer.cancelScheduledPointer();
         ontoolchange?.(next);
-        return;
+        break;
     }
   }
 

--- a/packages/svelte/src/lib/GGPlot.svelte
+++ b/packages/svelte/src/lib/GGPlot.svelte
@@ -115,6 +115,7 @@
   import { resolveSurfaceKeyAction } from "./plot-surface-keyboard.js";
   import {
     resolveInspectionCompleteness,
+    resolveInspectionEmitAction,
     resolveInspectionMode,
     resolveQueuedInspectFrameAction,
     resolveSetInspectionAction,
@@ -128,6 +129,7 @@
     resolveCaptureClickAction,
     advanceTouchInspectMoved,
     resolveFinishBrushAction,
+    resolveLostPointerCaptureAction,
     resolvePointerDownAction,
     resolvePointerMoveAction,
     resolvePointerUpAction,
@@ -169,6 +171,8 @@
     capabilityStatusText,
     filterAvailableTools,
     legendFocusDiscreteOnlyDiagnostics,
+    resolveChooseToolAction,
+    resolveEffectiveTool,
     zoomScaleDiagnosticsFromChannels,
     zoomSupportsChannel,
   } from "./plot-capability.js";
@@ -954,24 +958,34 @@
   });
 
   $effect(() => {
-    const requested = tool ?? interactionConfig.initialTool;
-    const next = availableTools.includes(requested)
-      ? requested
-      : (availableTools[0] ?? "inspect");
+    const next = resolveEffectiveTool(
+      tool ?? interactionConfig.initialTool,
+      availableTools,
+    );
     reducer.dispatch({ type: "set-tool", tool: next });
   });
 
   function chooseTool(next: InteractionTool): void {
-    if (!availableTools.includes(next)) return;
-    if (tool !== undefined) {
-      ontoolchange?.(next);
-      return;
+    // Decision table is pure (plot-capability); this switch owns side effects.
+    const action = resolveChooseToolAction({
+      next,
+      available: availableTools,
+      isControlled: tool !== undefined,
+    });
+    switch (action.type) {
+      case "ignore":
+        return;
+      case "request":
+        ontoolchange?.(next);
+        return;
+      case "apply":
+        reducer.dispatch({ type: "set-tool", tool: next });
+        brushRect = null;
+        queuedPointerInspection = null;
+        reducer.cancelScheduledPointer();
+        ontoolchange?.(next);
+        return;
     }
-    reducer.dispatch({ type: "set-tool", tool: next });
-    brushRect = null;
-    queuedPointerInspection = null;
-    reducer.cancelScheduledPointer();
-    ontoolchange?.(next);
   }
 
   function plotPoint(event: PointerEvent | MouseEvent): {
@@ -1532,10 +1546,14 @@
       next.phase === "clear"
         ? clearInspectionFingerprint(next.source)
         : semanticFingerprint;
-    if (fingerprint !== undefined) {
-      if (fingerprint === lastInspectionFingerprint) return;
-      lastInspectionFingerprint = fingerprint;
-    }
+    // Decision table is pure (plot-surface-inspection); host owns last token.
+    const emit = resolveInspectionEmitAction({
+      fingerprint,
+      lastFingerprint: lastInspectionFingerprint,
+    });
+    if (emit.type === "skip") return;
+    if (emit.updateFingerprint !== null)
+      lastInspectionFingerprint = emit.updateFingerprint;
     oninspect?.(next as unknown as PlotInspection<Row, PublicKey>);
     oninteraction?.(next as unknown as PlotInteractionEvent<Row, PublicKey>);
   }
@@ -2452,9 +2470,19 @@
           reducer.dispatch({ type: "cancel-area" });
         }}
         onlostpointercapture={() => {
-          if (!brushing) return;
-          if (!areaAwaitingSecond) brushRect = null;
-          reducer.dispatch({ type: "cancel-area" });
+          // Decision table is pure (plot-surface-pointer); host owns draft + cancel.
+          const lost = resolveLostPointerCaptureAction(reducer.state.area.kind);
+          switch (lost.type) {
+            case "ignore":
+              return;
+            case "cancel-keep-draft":
+              reducer.dispatch({ type: "cancel-area" });
+              return;
+            case "cancel-clear-draft":
+              brushRect = null;
+              reducer.dispatch({ type: "cancel-area" });
+              return;
+          }
         }}
         onclick={onCaptureClick}
         onkeydown={onSurfaceKeyDown}

--- a/packages/svelte/src/lib/plot-capability.ts
+++ b/packages/svelte/src/lib/plot-capability.ts
@@ -17,6 +17,45 @@ export function filterAvailableTools(
   return tools.filter((tool) => tool !== "zoom-area" || zoomHasSupportedChannel);
 }
 
+/**
+ * Resolve the tool the host should sync into the reducer.
+ * Priority: requested if available → first available → `"inspect"`.
+ *
+ * Note: empty `available` still yields `"inspect"` (even when inspect is not
+ * listed). That matches the host `$effect` and intentionally diverges from
+ * `resolveChooseToolAction`, which rejects unavailable tools.
+ */
+export function resolveEffectiveTool(
+  requested: InteractionTool,
+  available: readonly InteractionTool[],
+): InteractionTool {
+  if (available.includes(requested)) return requested;
+  return available[0] ?? "inspect";
+}
+
+export type ChooseToolAction =
+  | { readonly type: "ignore" }
+  | { readonly type: "request" }
+  | { readonly type: "apply" };
+
+/**
+ * Pure routing for host `chooseTool`.
+ *
+ * Priority:
+ *   1. ignore — `next` not in `available` (wins over controlled; no callback)
+ *   2. request — controlled prop (`tool !== undefined`): callback only
+ *   3. apply — local: dispatch + clear draft/queue + callback
+ */
+export function resolveChooseToolAction(input: {
+  readonly next: InteractionTool;
+  readonly available: readonly InteractionTool[];
+  readonly isControlled: boolean;
+}): ChooseToolAction {
+  if (!input.available.includes(input.next)) return { type: "ignore" };
+  if (input.isControlled) return { type: "request" };
+  return { type: "apply" };
+}
+
 export type ScaleTypeRef = {
   readonly x: { readonly type: string };
   readonly y: { readonly type: string };

--- a/packages/svelte/src/lib/plot-surface-inspection.ts
+++ b/packages/svelte/src/lib/plot-surface-inspection.ts
@@ -233,3 +233,37 @@ export function shouldClosePinnedOnOutsidePointer(input: {
 }): boolean {
   return input.isPinned && !input.targetInsideRoot;
 }
+
+// ---- inspection emission fingerprint gate ----
+
+export type InspectionEmitAction =
+  | { readonly type: "skip" }
+  | {
+      readonly type: "emit";
+      /**
+       * When non-null, host assigns `lastInspectionFingerprint = updateFingerprint`
+       * before callbacks. When null, host must not mutate the last fingerprint
+       * (undefined fingerprint path — always emit without update).
+       */
+      readonly updateFingerprint: string | null;
+    };
+
+/**
+ * Pure gate for host `emitInspection` after the fingerprint has been resolved
+ * (`clear:*` for clear phase via `clearInspectionFingerprint`, else the
+ * coordinator's semantic fingerprint).
+ *
+ *   undefined fingerprint → emit, do not update last
+ *   fingerprint === last  → skip (includes equal empty string; host inits last to "")
+ *   otherwise             → emit and update last to fingerprint
+ *
+ * Host still owns fingerprint production (clear token vs semantic).
+ */
+export function resolveInspectionEmitAction(input: {
+  readonly fingerprint: string | undefined;
+  readonly lastFingerprint: string;
+}): InspectionEmitAction {
+  if (input.fingerprint === undefined) return { type: "emit", updateFingerprint: null };
+  if (input.fingerprint === input.lastFingerprint) return { type: "skip" };
+  return { type: "emit", updateFingerprint: input.fingerprint };
+}

--- a/packages/svelte/src/lib/plot-surface-pointer.ts
+++ b/packages/svelte/src/lib/plot-surface-pointer.ts
@@ -265,3 +265,29 @@ export function resolveFinishBrushAction(input: {
   if (input.activeTool === "zoom-area") return { type: "zoom-end" };
   return { type: "end-area" };
 }
+
+// ---- lost pointer capture ----
+
+/** Reducer area.kind values that the host may observe on lostpointercapture. */
+export type AreaKind = "idle" | "first-corner" | "dragging";
+
+export type LostPointerCaptureAction =
+  | { readonly type: "ignore" }
+  | { readonly type: "cancel-keep-draft" }
+  | { readonly type: "cancel-clear-draft" };
+
+/**
+ * Pure routing for capture-surface `lostpointercapture`.
+ *
+ * Takes reducer `area.kind` (not derived booleans) so illegal combos like
+ * `!brushing && areaAwaitingSecond` are unrepresentable.
+ *
+ *   idle         → ignore (no cancel-area)
+ *   first-corner → cancel-keep-draft (dispatch cancel-area; retain brushRect)
+ *   dragging     → cancel-clear-draft (clear brushRect + dispatch cancel-area)
+ */
+export function resolveLostPointerCaptureAction(areaKind: AreaKind): LostPointerCaptureAction {
+  if (areaKind === "idle") return { type: "ignore" };
+  if (areaKind === "first-corner") return { type: "cancel-keep-draft" };
+  return { type: "cancel-clear-draft" };
+}

--- a/packages/svelte/tests/plot-capability.test.ts
+++ b/packages/svelte/tests/plot-capability.test.ts
@@ -5,6 +5,8 @@ import {
   capabilityStatusText,
   filterAvailableTools,
   legendFocusDiscreteOnlyDiagnostics,
+  resolveChooseToolAction,
+  resolveEffectiveTool,
   zoomScaleDiagnosticsFromChannels,
   zoomSupportsChannel,
 } from "../src/lib/plot-capability.js";
@@ -65,6 +67,65 @@ describe("filterAvailableTools", () => {
   it("leaves non-zoom tools untouched when zoom is unsupported", () => {
     expect(filterAvailableTools(["inspect", "point"], false)).toEqual(["inspect", "point"]);
     expect(filterAvailableTools(["zoom-area"], false)).toEqual([]);
+  });
+});
+
+describe("resolveEffectiveTool", () => {
+  it("keeps the requested tool when it is available", () => {
+    expect(resolveEffectiveTool("point", ["inspect", "point", "select-area"])).toBe("point");
+  });
+
+  it("falls back to the first available tool when requested is unavailable", () => {
+    expect(resolveEffectiveTool("zoom-area", ["inspect", "point"])).toBe("inspect");
+    expect(resolveEffectiveTool("inspect", ["point", "select-area"])).toBe("point");
+  });
+
+  it("falls back to inspect when available is empty (host asymmetry vs chooseTool)", () => {
+    // Host tool $effect dispatches "inspect" even when it is not in availableTools.
+    // chooseTool rejects tools not in availableTools — pin the split intentionally.
+    expect(resolveEffectiveTool("zoom-area", [])).toBe("inspect");
+    expect(resolveEffectiveTool("inspect", [])).toBe("inspect");
+  });
+});
+
+describe("resolveChooseToolAction", () => {
+  const available = ["inspect", "point", "select-area"] as const;
+
+  it("ignores unavailable tools before the controlled check (no callback)", () => {
+    expect(
+      resolveChooseToolAction({
+        next: "zoom-area",
+        available,
+        isControlled: true,
+      }),
+    ).toEqual({ type: "ignore" });
+    expect(
+      resolveChooseToolAction({
+        next: "zoom-area",
+        available,
+        isControlled: false,
+      }),
+    ).toEqual({ type: "ignore" });
+  });
+
+  it("requests only when controlled and available", () => {
+    expect(
+      resolveChooseToolAction({
+        next: "point",
+        available,
+        isControlled: true,
+      }),
+    ).toEqual({ type: "request" });
+  });
+
+  it("applies when local and available", () => {
+    expect(
+      resolveChooseToolAction({
+        next: "point",
+        available,
+        isControlled: false,
+      }),
+    ).toEqual({ type: "apply" });
   });
 });
 

--- a/packages/svelte/tests/plot-surface-inspection.test.ts
+++ b/packages/svelte/tests/plot-surface-inspection.test.ts
@@ -535,15 +535,15 @@ describe("resolveInspectionEmitAction", () => {
 
   it("characterizes a stateful sequence including clear tokens", () => {
     let last = "";
-    const step = (fingerprint: string | undefined) => {
+    const step = (fingerprint?: string) => {
       const action = resolveInspectionEmitAction({ fingerprint, lastFingerprint: last });
       if (action.type === "emit" && action.updateFingerprint !== null)
         last = action.updateFingerprint;
       return action;
     };
 
-    // undefined never mutates last
-    expect(step(undefined)).toEqual({ type: "emit", updateFingerprint: null });
+    // omitted fingerprint never mutates last
+    expect(step()).toEqual({ type: "emit", updateFingerprint: null });
     expect(last).toBe("");
 
     // empty fingerprint collides with initial last → skip

--- a/packages/svelte/tests/plot-surface-inspection.test.ts
+++ b/packages/svelte/tests/plot-surface-inspection.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   resolveInspectionCompleteness,
+  resolveInspectionEmitAction,
   resolveInspectionMode,
   resolveQueuedInspectFrameAction,
   resolveSetInspectionAction,
@@ -495,5 +496,77 @@ describe("shouldClosePinnedOnOutsidePointer", () => {
     expect(shouldClosePinnedOnOutsidePointer({ isPinned: false, targetInsideRoot: true })).toBe(
       false,
     );
+  });
+});
+
+describe("resolveInspectionEmitAction", () => {
+  it("emits without updating last when fingerprint is undefined", () => {
+    expect(
+      resolveInspectionEmitAction({
+        fingerprint: undefined,
+        lastFingerprint: "sem:a",
+      }),
+    ).toEqual({ type: "emit", updateFingerprint: null });
+  });
+
+  it("skips when fingerprint equals last, including empty string (host inits last to '')", () => {
+    expect(
+      resolveInspectionEmitAction({
+        fingerprint: "",
+        lastFingerprint: "",
+      }),
+    ).toEqual({ type: "skip" });
+    expect(
+      resolveInspectionEmitAction({
+        fingerprint: "sem:a",
+        lastFingerprint: "sem:a",
+      }),
+    ).toEqual({ type: "skip" });
+  });
+
+  it("emits and updates when fingerprint changes", () => {
+    expect(
+      resolveInspectionEmitAction({
+        fingerprint: "sem:b",
+        lastFingerprint: "sem:a",
+      }),
+    ).toEqual({ type: "emit", updateFingerprint: "sem:b" });
+  });
+
+  it("characterizes a stateful sequence including clear tokens", () => {
+    let last = "";
+    const step = (fingerprint: string | undefined) => {
+      const action = resolveInspectionEmitAction({ fingerprint, lastFingerprint: last });
+      if (action.type === "emit" && action.updateFingerprint !== null)
+        last = action.updateFingerprint;
+      return action;
+    };
+
+    // undefined never mutates last
+    expect(step(undefined)).toEqual({ type: "emit", updateFingerprint: null });
+    expect(last).toBe("");
+
+    // empty fingerprint collides with initial last → skip
+    expect(step("")).toEqual({ type: "skip" });
+    expect(last).toBe("");
+
+    // first real fingerprint updates
+    expect(step("sem:1")).toEqual({ type: "emit", updateFingerprint: "sem:1" });
+    expect(last).toBe("sem:1");
+
+    // equal suppresses
+    expect(step("sem:1")).toEqual({ type: "skip" });
+    expect(last).toBe("sem:1");
+
+    // clear token after semantic → emit and update
+    expect(step("clear:keyboard")).toEqual({
+      type: "emit",
+      updateFingerprint: "clear:keyboard",
+    });
+    expect(last).toBe("clear:keyboard");
+
+    // same clear token suppresses
+    expect(step("clear:keyboard")).toEqual({ type: "skip" });
+    expect(last).toBe("clear:keyboard");
   });
 });

--- a/packages/svelte/tests/plot-surface-pointer.test.ts
+++ b/packages/svelte/tests/plot-surface-pointer.test.ts
@@ -6,6 +6,7 @@ import {
   advanceTouchInspectMoved,
   resolveCaptureClickAction,
   resolveFinishBrushAction,
+  resolveLostPointerCaptureAction,
   resolvePointerDownAction,
   resolvePointerMoveAction,
   resolvePointerUpAction,
@@ -536,6 +537,24 @@ describe("resolveFinishBrushAction", () => {
     });
     expect(resolveFinishBrushAction({ endedKind: "commit", activeTool: "point" })).toEqual({
       type: "end-area",
+    });
+  });
+});
+
+describe("resolveLostPointerCaptureAction", () => {
+  it("ignores idle (not brushing)", () => {
+    expect(resolveLostPointerCaptureAction("idle")).toEqual({ type: "ignore" });
+  });
+
+  it("keeps draft and cancels area when awaiting second corner", () => {
+    expect(resolveLostPointerCaptureAction("first-corner")).toEqual({
+      type: "cancel-keep-draft",
+    });
+  });
+
+  it("clears draft and cancels area when dragging", () => {
+    expect(resolveLostPointerCaptureAction("dragging")).toEqual({
+      type: "cancel-clear-draft",
     });
   });
 });


### PR DESCRIPTION
## Summary

- Extract pure decision tables for tool sync/`chooseTool`, capture-surface `lostpointercapture`, and inspection emission fingerprint gating from `GGPlot.svelte`.
- Host handlers keep all side effects (reducer dispatch, callbacks, draft mutation); pure modules own priority/routing only.
- Add characterization unit tests for empty-available tool fallback, controlled+unavailable (no callback), area-kind lost-capture paths, and fingerprint emit/skip sequences including empty-string collision with initial last token.

## Test plan

- [x] `bun run test:browser -- tests/plot-capability.test.ts tests/plot-surface-pointer.test.ts tests/plot-surface-inspection.test.ts`
- [x] `bun run test:browser -- tests/interaction-regressions.test.ts`
- [x] `bun run check` in `packages/svelte`
- [ ] CI green