### PR TITLE
refactor(svelte): extract pure legend commit, preview-dismiss, and live-text decisions

### DIFF
--- a/packages/svelte/src/lib/GGPlot.svelte
+++ b/packages/svelte/src/lib/GGPlot.svelte
@@ -1143,9 +1143,9 @@
     switch (commit.type) {
       case "toggle-clear":
         clearLegendFocus(source);
-        return;
+        break;
       case "ignore":
-        return;
+        break;
       case "commit":
         legendPreview = null;
         legendCommitted = { identity: action.identity, keys };
@@ -1165,7 +1165,7 @@
           label: action.entry.label,
           keys,
         });
-        return;
+        break;
     }
   }
 

--- a/packages/svelte/src/lib/GGPlot.svelte
+++ b/packages/svelte/src/lib/GGPlot.svelte
@@ -139,8 +139,10 @@
   import {
     resolveLegendClearControlSource,
     resolveLegendClickAction,
+    resolveLegendCommitAction,
     resolveLegendKeyAction,
     resolveLegendPointerUpAction,
+    resolveLegendPreviewDismissAction,
     shouldClearLegendPreviewOnBlur,
     shouldRenderInteractionLiveRegion,
   } from "./plot-legend-surface.js";
@@ -150,6 +152,7 @@
     inspectionLiveText as inspectionLiveTextFor,
     legendFocusAnnouncement,
     markLabel as markLabelFor,
+    resolveInteractionLiveText,
     selectionAnnouncement,
     zoomAnnouncement,
   } from "./plot-labels.js";
@@ -1061,12 +1064,20 @@
 
   function previewLegend(action: LegendEntryAction | null): void {
     if (action === null) {
-      if (legendPreview === null) return;
-      const source = legendInteractionSource(legendPreview.action.source);
+      // Decision table is pure (plot-legend-surface); host owns emit + mutation.
+      // Emit gate uses committed emphasis, not effectiveEmphasisKeys (preview).
+      const dismiss = resolveLegendPreviewDismissAction({
+        hasActivePreview: legendPreview !== null,
+        committedEmphasisEmpty:
+          (
+            interaction?.emphasized(resolvedInteractionScope) ??
+            localEmphasisKeys
+          ).length === 0,
+      });
+      if (dismiss.type === "none") return;
+      const source = legendInteractionSource(legendPreview!.action.source);
       legendPreview = null;
-      const committed =
-        interaction?.emphasized(resolvedInteractionScope) ?? localEmphasisKeys;
-      if (committed.length === 0)
+      if (dismiss.type === "clear-and-emit")
         emitLegendFocus({ type: "legend-focus", phase: "clear", source });
       return;
     }
@@ -1122,33 +1133,40 @@
 
   function commitLegend(action: LegendEntryAction): void {
     const source = legendInteractionSource(action.source);
-    if (
-      effectiveLegendPressed?.scale === action.identity.scale &&
-      effectiveLegendPressed.entryIndex === action.identity.entryIndex
-    ) {
-      clearLegendFocus(source);
-      return;
-    }
+    // Eager key lookup (O(1) Map.get) before pure routing; unused on toggle-clear.
     const keys = keysForLegend(action);
-    if (keys.length === 0) return;
-    legendPreview = null;
-    legendCommitted = { identity: action.identity, keys };
-    if (interaction === undefined) localEmphasisKeys = [...keys];
-    else
-      interaction.setEmphasis(keys as readonly PublicKey[], {
-        scope: resolvedInteractionScope,
-        source,
-      });
-    emitLegendFocus({
-      type: "legend-focus",
-      phase: "change",
-      state: "committed",
-      source,
-      scale: action.identity.scale as "color" | "fill",
-      value: action.entry.value as CellValue,
-      label: action.entry.label,
-      keys,
+    const commit = resolveLegendCommitAction({
+      pressed: effectiveLegendPressed,
+      identity: action.identity,
+      keyCount: keys.length,
     });
+    switch (commit.type) {
+      case "toggle-clear":
+        clearLegendFocus(source);
+        return;
+      case "ignore":
+        return;
+      case "commit":
+        legendPreview = null;
+        legendCommitted = { identity: action.identity, keys };
+        if (interaction === undefined) localEmphasisKeys = [...keys];
+        else
+          interaction.setEmphasis(keys as readonly PublicKey[], {
+            scope: resolvedInteractionScope,
+            source,
+          });
+        emitLegendFocus({
+          type: "legend-focus",
+          phase: "change",
+          state: "committed",
+          source,
+          scale: action.identity.scale as "color" | "fill",
+          value: action.entry.value as CellValue,
+          label: action.entry.label,
+          keys,
+        });
+        return;
+    }
   }
 
   const presentationFocusKeys: readonly PropertyKey[] = $derived(
@@ -2532,10 +2550,11 @@
         aria-live="polite"
         aria-atomic="true"
       >
-        {interactionAnnouncement ||
-          (inspection?.source === "keyboard" || inspection?.source === "touch"
-            ? inspectionLiveText(inspection)
-            : "")}
+        {resolveInteractionLiveText({
+          announcement: interactionAnnouncement,
+          model,
+          inspection,
+        })}
       </div>
     {/if}
     {#if emptyPlot}

--- a/packages/svelte/src/lib/plot-labels.ts
+++ b/packages/svelte/src/lib/plot-labels.ts
@@ -93,3 +93,26 @@ export function inspectionLiveText(
     .join(", ");
   return `${value.mode} ${value.axisLabel}; ${countLabel(count)}${focused ? `; focused ${focused}` : ""}${state}`;
 }
+
+/**
+ * Capture live-region text for the interaction ARIA live region.
+ *
+ * Priority (matches host `announcement || fallback`):
+ *   1. non-empty sticky `announcement` (including after microtask fill)
+ *   2. keyboard/touch inspection → `inspectionLiveText` (short-circuited)
+ *   3. otherwise empty string
+ *
+ * Empty-string announcement is falsy and falls through — host
+ * `announceInteraction` briefly sets `""` before the microtask message.
+ */
+export function resolveInteractionLiveText(input: {
+  readonly announcement: string;
+  readonly model: RenderModel | null;
+  readonly inspection: PlotInspectionChange<Record<string, CellValue>, PropertyKey> | null;
+}): string {
+  if (input.announcement) return input.announcement;
+  if (input.inspection === null) return "";
+  if (input.inspection.source === "keyboard" || input.inspection.source === "touch")
+    return inspectionLiveText(input.model, input.inspection);
+  return "";
+}

--- a/packages/svelte/src/lib/plot-legend-surface.ts
+++ b/packages/svelte/src/lib/plot-legend-surface.ts
@@ -3,10 +3,11 @@
  *
  * Hosts own DOM handlers, suppress/touch index lifecycle, focus moves,
  * commitLegend side effects, and announcements. This module owns only
- * key routing and touch/click coordination priority.
+ * key routing, touch/click coordination, and commit/preview-dismiss priority.
  */
 
 import type { InteractionSource } from "./interaction.js";
+import type { LegendEntryIdentity } from "./plot-legend-focus.js";
 
 // ---- keydown ----
 
@@ -171,4 +172,64 @@ export type InteractionLiveRegionInput = {
  */
 export function shouldRenderInteractionLiveRegion(input: InteractionLiveRegionInput): boolean {
   return input.surfaceInteractive || input.legendFocusEnabled;
+}
+
+// ---- commit / preview dismiss ----
+
+export type LegendCommitAction =
+  | { readonly type: "toggle-clear" }
+  | { readonly type: "ignore" }
+  | { readonly type: "commit" };
+
+/**
+ * Pure routing for host `commitLegend` after identity + key lookup.
+ *
+ * Priority (load-bearing):
+ *   1. toggle-clear — pressed identity matches action identity
+ *   2. ignore — keyCount === 0
+ *   3. commit
+ *
+ * Host may compute `keysForLegend(action)` before this call (eager Map.get);
+ * keys are unused on toggle-clear but O(1). A pressed entry whose domain keys
+ * reshuffled empty still toggles clear (does not fall into ignore).
+ */
+export function resolveLegendCommitAction(input: {
+  readonly pressed: LegendEntryIdentity | null;
+  readonly identity: LegendEntryIdentity;
+  readonly keyCount: number;
+}): LegendCommitAction {
+  if (
+    input.pressed !== null &&
+    input.pressed.scale === input.identity.scale &&
+    input.pressed.entryIndex === input.identity.entryIndex
+  )
+    return { type: "toggle-clear" };
+  if (input.keyCount === 0) return { type: "ignore" };
+  return { type: "commit" };
+}
+
+export type LegendPreviewDismissAction =
+  | { readonly type: "none" }
+  | { readonly type: "clear-only" }
+  | { readonly type: "clear-and-emit" };
+
+/**
+ * Pure routing for host `previewLegend(null)` (dismiss path only).
+ *
+ *   none           — no active preview (host returns without mutation)
+ *   clear-only     — drop preview, no clear event
+ *   clear-and-emit — drop preview and emit legend-focus clear
+ *
+ * Emit gate uses **committed** emphasis (`interaction?.emphasized(scope) ??
+ * localEmphasisKeys`), not `effectiveEmphasisKeys` (which includes preview).
+ * That differs intentionally from `clearLegendFocus`, which ORs preview /
+ * committed / effective emphasis before emit.
+ */
+export function resolveLegendPreviewDismissAction(input: {
+  readonly hasActivePreview: boolean;
+  readonly committedEmphasisEmpty: boolean;
+}): LegendPreviewDismissAction {
+  if (!input.hasActivePreview) return { type: "none" };
+  if (input.committedEmphasisEmpty) return { type: "clear-and-emit" };
+  return { type: "clear-only" };
 }

--- a/packages/svelte/tests/plot-labels.test.ts
+++ b/packages/svelte/tests/plot-labels.test.ts
@@ -15,6 +15,7 @@ import {
   inspectionLiveText,
   legendFocusAnnouncement,
   markLabel,
+  resolveInteractionLiveText,
   selectionAnnouncement,
   zoomAnnouncement,
 } from "../src/lib/plot-labels.js";
@@ -169,6 +170,102 @@ describe("inspectionLiveText", () => {
       ],
     });
     expect(inspectionLiveText(m, value as never)).toBe("x 3.0; 1 datum; focused y 9, color blue");
+  });
+});
+
+describe("resolveInteractionLiveText", () => {
+  const m = model({
+    layerFields: [[{ field: "x" }, { field: "y" }]],
+  });
+  const focus = {
+    key: "a",
+    row: { x: 1, y: 2 },
+    sourceKeys: ["a"],
+    lineageCount: 1,
+    layerIndex: 0,
+    panelId: null,
+    fields: [
+      { channel: "x", field: "x", value: 1 },
+      { channel: "y", field: "y", value: 2 },
+    ],
+    anchor: { x: 0, y: 0 },
+  };
+  const members = [
+    {
+      key: "a",
+      row: { x: 1, y: 2 },
+      sourceKeys: ["a"],
+      lineageCount: 1,
+      layerIndex: 0,
+      panelId: null,
+      fields: focus.fields,
+      anchor: { x: 0, y: 0 },
+    },
+  ];
+  const keyboardInspection = {
+    type: "inspect",
+    phase: "change",
+    source: "keyboard",
+    panelId: null,
+    mode: "exact",
+    state: "transient",
+    focus,
+    members,
+  } as PlotInspectionChange<Record<string, unknown>, PropertyKey>;
+
+  it("prefers non-empty sticky announcement over inspection text", () => {
+    expect(
+      resolveInteractionLiveText({
+        announcement: "Zoom complete.",
+        model: m,
+        inspection: keyboardInspection as never,
+      }),
+    ).toBe("Zoom complete.");
+  });
+
+  it("falls through empty announcement (host microtask clear-then-fill)", () => {
+    expect(
+      resolveInteractionLiveText({
+        announcement: "",
+        model: m,
+        inspection: keyboardInspection as never,
+      }),
+    ).toBe(inspectionLiveText(m, keyboardInspection as never));
+  });
+
+  it("uses inspection live text for keyboard and touch sources only", () => {
+    const expected = inspectionLiveText(m, keyboardInspection as never);
+    expect(
+      resolveInteractionLiveText({
+        announcement: "",
+        model: m,
+        inspection: keyboardInspection as never,
+      }),
+    ).toBe(expected);
+    expect(
+      resolveInteractionLiveText({
+        announcement: "",
+        model: m,
+        inspection: { ...keyboardInspection, source: "touch" } as never,
+      }),
+    ).toBe(expected);
+    expect(
+      resolveInteractionLiveText({
+        announcement: "",
+        model: m,
+        inspection: { ...keyboardInspection, source: "pointer" } as never,
+      }),
+    ).toBe("");
+  });
+
+  it("returns empty when inspection is null and announcement is empty", () => {
+    expect(
+      resolveInteractionLiveText({
+        announcement: "",
+        model: m,
+        inspection: null,
+      }),
+    ).toBe("");
   });
 });
 

--- a/packages/svelte/tests/plot-legend-surface.test.ts
+++ b/packages/svelte/tests/plot-legend-surface.test.ts
@@ -3,8 +3,10 @@ import { describe, expect, it } from "vitest";
 import {
   resolveLegendClearControlSource,
   resolveLegendClickAction,
+  resolveLegendCommitAction,
   resolveLegendKeyAction,
   resolveLegendPointerUpAction,
+  resolveLegendPreviewDismissAction,
   shouldClearLegendPreviewOnBlur,
   shouldRenderInteractionLiveRegion,
   type LegendClearControlInput,
@@ -202,5 +204,96 @@ describe("resolveLegendClearControlSource", () => {
     expect(resolveLegendClearControlSource(clear({ detail: 1, pointerType: null }))).toBe(
       "pointer",
     );
+  });
+});
+
+describe("resolveLegendCommitAction", () => {
+  const identity = { scale: "fill", entryIndex: 1 };
+
+  it("toggles clear when pressed identity matches, even with empty keys", () => {
+    // Load-bearing: empty keys after domain reshuffle must not fall into ignore.
+    expect(
+      resolveLegendCommitAction({
+        pressed: { scale: "fill", entryIndex: 1 },
+        identity,
+        keyCount: 0,
+      }),
+    ).toEqual({ type: "toggle-clear" });
+    expect(
+      resolveLegendCommitAction({
+        pressed: { scale: "fill", entryIndex: 1 },
+        identity,
+        keyCount: 3,
+      }),
+    ).toEqual({ type: "toggle-clear" });
+  });
+
+  it("ignores empty keys only when not toggling the pressed entry", () => {
+    expect(
+      resolveLegendCommitAction({
+        pressed: null,
+        identity,
+        keyCount: 0,
+      }),
+    ).toEqual({ type: "ignore" });
+    expect(
+      resolveLegendCommitAction({
+        pressed: { scale: "color", entryIndex: 1 },
+        identity,
+        keyCount: 0,
+      }),
+    ).toEqual({ type: "ignore" });
+    expect(
+      resolveLegendCommitAction({
+        pressed: { scale: "fill", entryIndex: 0 },
+        identity,
+        keyCount: 0,
+      }),
+    ).toEqual({ type: "ignore" });
+  });
+
+  it("commits when keys exist and identity is not already pressed", () => {
+    expect(
+      resolveLegendCommitAction({
+        pressed: null,
+        identity,
+        keyCount: 2,
+      }),
+    ).toEqual({ type: "commit" });
+  });
+});
+
+describe("resolveLegendPreviewDismissAction", () => {
+  it("returns none when there is no active preview", () => {
+    expect(
+      resolveLegendPreviewDismissAction({
+        hasActivePreview: false,
+        committedEmphasisEmpty: true,
+      }),
+    ).toEqual({ type: "none" });
+    expect(
+      resolveLegendPreviewDismissAction({
+        hasActivePreview: false,
+        committedEmphasisEmpty: false,
+      }),
+    ).toEqual({ type: "none" });
+  });
+
+  it("emits clear only when committed emphasis is empty (not effective/preview)", () => {
+    expect(
+      resolveLegendPreviewDismissAction({
+        hasActivePreview: true,
+        committedEmphasisEmpty: true,
+      }),
+    ).toEqual({ type: "clear-and-emit" });
+  });
+
+  it("clears preview without emit when committed emphasis remains", () => {
+    expect(
+      resolveLegendPreviewDismissAction({
+        hasActivePreview: true,
+        committedEmphasisEmpty: false,
+      }),
+    ).toEqual({ type: "clear-only" });
   });
 });


### PR DESCRIPTION
## Summary

- Extract pure decision tables for `commitLegend` (toggle-clear before empty-keys ignore), `previewLegend(null)` dismiss policy (committed emphasis, not effective/preview), and interaction live-region text precedence.
- Host keeps side effects (emphasis mutation, focus events, sticky announcement lifecycle).
- Characterization unit tests pin load-bearing priorities; existing legend/interaction regressions remain green.

## Test plan

- [x] `bun run test:browser -- tests/plot-legend-surface.test.ts tests/plot-labels.test.ts tests/legend-interaction.test.ts tests/interaction-regressions.test.ts`
- [x] `bun run check` in `packages/svelte`
- [ ] CI green