### PR TITLE
fix: keep JSDoc list/blockquote markers non-substantive after #72

### DIFF
--- a/packages/spec/tests/manual-at-alias-audit.test.ts
+++ b/packages/spec/tests/manual-at-alias-audit.test.ts
@@ -44,6 +44,11 @@ describe("manual AT alias commit audit", () => {
     // JSDoc/Markdown list and blockquote markers after `*` are documentation, not CSS.
     expect(isSkippableCommentLine(" * + positive values are kept")).toBe(true);
     expect(isSkippableCommentLine(" * > Note: domain is shared")).toBe(true);
+    expect(isSkippableCommentLine(" * > Note")).toBe(true);
+    // Bare lowercase type selectors (incl. multi-line CSS with `{` on the next line).
+    expect(isSkippableCommentLine(" * + p")).toBe(false);
+    expect(isSkippableCommentLine("* + section")).toBe(false);
+    expect(isSkippableCommentLine("* > div")).toBe(false);
     expect(
       diffTextIsSubstantive(`diff --git a/x.ts b/x.ts
 --- a/x.ts

--- a/packages/spec/tests/manual-at-alias-audit.test.ts
+++ b/packages/spec/tests/manual-at-alias-audit.test.ts
@@ -41,6 +41,20 @@ describe("manual AT alias commit audit", () => {
     expect(isSkippableCommentLine(" * + * { margin: 0; }")).toBe(false);
     expect(isSkippableCommentLine("* > .mark { opacity: 1; }")).toBe(false);
     expect(isSkippableCommentLine("* ~ * { display: none; }")).toBe(false);
+    // JSDoc/Markdown list and blockquote markers after `*` are documentation, not CSS.
+    expect(isSkippableCommentLine(" * + positive values are kept")).toBe(true);
+    expect(isSkippableCommentLine(" * > Note: domain is shared")).toBe(true);
+    expect(
+      diffTextIsSubstantive(`diff --git a/x.ts b/x.ts
+--- a/x.ts
++++ b/x.ts
+@@ -1,3 +1,3 @@
+ /**
+- * + old list item
++ * + positive values are kept
+  */
+`),
+    ).toBe(false);
     expect(
       diffTextIsSubstantive(`diff --git a/x.svelte b/x.svelte
 --- a/x.svelte

--- a/packages/spec/tests/manual-at-alias-audit.ts
+++ b/packages/spec/tests/manual-at-alias-audit.ts
@@ -40,9 +40,12 @@ function isCssSelectorAfterCombinator(rest: string): boolean {
   if (rest.length === 0) return false;
   // Universal, class, id, attribute, or pseudo.
   if (rest.startsWith("*") || /^[.#[]/.test(rest) || rest.startsWith(":")) return true;
-  // Type selector only when the same line continues with CSS structure.
+  // Type selector with CSS structure on the same line (`div{`, `div:hover`, …).
   // Require `::?ident` (no space after `:`) so JSDoc `Note: prose` stays docs.
-  return /^[A-Za-z_-][\w-]*\s*([{.#[]|::?[\w-]|[,>+~])/.test(rest);
+  if (/^[A-Za-z_-][\w-]*\s*([{.#[]|::?[\w-]|[,>+~])/.test(rest)) return true;
+  // Bare lowercase type selector (`* + p`, `* + section`) — common when `{` is
+  // on the next line. Capitalized / multi-word text is JSDoc/Markdown.
+  return /^[a-z][\w-]*$/.test(rest);
 }
 
 /** Lines that are blank or documentation-only (not CSS/code). */

--- a/packages/spec/tests/manual-at-alias-audit.ts
+++ b/packages/spec/tests/manual-at-alias-audit.ts
@@ -31,6 +31,20 @@ export function diffTextIsSubstantive(diff: string): boolean {
   return false;
 }
 
+/**
+ * After a CSS combinator (`+`, `>`, `~`), is the remainder a selector fragment?
+ * Distinguishes `* + * {…}` / `* > .mark` from JSDoc/Markdown `* + list item`
+ * and `* > Note`.
+ */
+function isCssSelectorAfterCombinator(rest: string): boolean {
+  if (rest.length === 0) return false;
+  // Universal, class, id, attribute, or pseudo.
+  if (rest.startsWith("*") || /^[.#[]/.test(rest) || rest.startsWith(":")) return true;
+  // Type selector only when the same line continues with CSS structure.
+  // Require `::?ident` (no space after `:`) so JSDoc `Note: prose` stays docs.
+  return /^[A-Za-z_-][\w-]*\s*([{.#[]|::?[\w-]|[,>+~])/.test(rest);
+}
+
 /** Lines that are blank or documentation-only (not CSS/code). */
 export function isSkippableCommentLine(body: string): boolean {
   const trimmed = body.trim();
@@ -42,11 +56,17 @@ export function isSkippableCommentLine(body: string): boolean {
 
   // JSDoc middle lines are `* text` / lone `*`. CSS universal selectors look like
   // `* {…}`, `*.class`, `*#id`, `*:hover`, `*, div`, `*[attr]`, and combinators
-  // `* + *`, `* > .x`, `* ~ *`.
+  // `* + *`, `* > .x`, `* ~ *`. Markdown list/blockquote markers (`* + …`,
+  // `* > Note`) stay documentation.
   const afterStar = trimmed.slice(1).trimStart();
   if (afterStar.length === 0) return true;
   if (afterStar.startsWith("/")) return true; // */
-  if (/^[{.,#:[\]+>~]/.test(afterStar)) return false;
+  // Unambiguous CSS after `*`.
+  if (/^[{.,#:[]/.test(afterStar)) return false;
+  // Combinators: only substantive when followed by a selector fragment.
+  if (/^[+>~]/.test(afterStar)) {
+    return !isCssSelectorAfterCombinator(afterStar.slice(1).trimStart());
+  }
   return true;
 }
 


### PR DESCRIPTION
## Summary

Follow-up for unrebutted pre-merge Codex P2 on #72.

### Valid → fixed
**Avoid treating JSDoc markers as runtime changes** — #72 marked any `* +` / `* >` / `* ~` line as CSS so combinator selectors were not skipped as JSDoc noise. That also classified Markdown list/blockquote comment lines (`* + positive values…`, `* > Note: …`) as runtime changes, so documentation-only alias ranges would fail the audit.

Combinators are substantive only when followed by a selector fragment (`*`, class/id/attr/pseudo, or type selector with CSS structure).

## Test plan
- [x] `bun test packages/spec/tests/manual-at-alias-audit.test.ts` (6)
- [x] pre-push full gate

Parent: #72
Codex thread: https://github.com/ljodea/ggsvelte/pull/72#discussion_r3593129105