### PR TITLE
refactor(svelte): extract PlotStatusChrome from GGPlot

### DIFF
--- a/packages/svelte/src/lib/GGPlot.svelte
+++ b/packages/svelte/src/lib/GGPlot.svelte
@@ -160,6 +160,7 @@
     isDockedTooltipWidth,
     isNarrowToolsWidth,
     plotRootInlineStyle,
+    resolveClearLegendX,
   } from "./plot-layout.js";
   import {
     bestDirectionalIndex,
@@ -228,6 +229,7 @@
   } from "./plot-legend-focus.js";
   import PlotCanvasA11y from "./PlotCanvasA11y.svelte";
   import PlotLegendTargets from "./PlotLegendTargets.svelte";
+  import PlotStatusChrome from "./PlotStatusChrome.svelte";
   import SceneView from "./SceneView.svelte";
   import Tooltip from "./Tooltip.svelte";
   import ToolRail from "./ToolRail.svelte";
@@ -2409,12 +2411,11 @@
       rovingIndex={legendRovingIndex}
       sceneWidth={model.scene.width}
       sceneHeight={model.scene.height}
-      clearLegendX={interactionConfig.legendFocus !== null &&
-      effectiveLegendPressed !== null
-        ? (model.scene.legends.find(
-            (candidate) => candidate.scale === effectiveLegendPressed.scale,
-          )?.x ?? null)
-        : null}
+      clearLegendX={resolveClearLegendX({
+        legendFocusEnabled: interactionConfig.legendFocus !== null,
+        pressedScale: effectiveLegendPressed?.scale ?? null,
+        legends: model.scene.legends,
+      })}
       onPreviewIndex={(index) => previewLegendIndex(index, "pointer")}
       onPreviewClear={() => previewLegend(null)}
       onPointerDown={onLegendPointerDown}
@@ -2506,18 +2507,6 @@
         onkeydown={onSurfaceKeyDown}
         ondblclick={onDblClick}
       ></div>
-      <p id={`${plotId}-description`} class="gg-sr-only">
-        Use arrow keys to inspect data. Press Enter to pin. Press Escape to
-        dismiss.
-      </p>
-      <p id={`${plotId}-active`} class="gg-sr-only">
-        {inspection === null
-          ? "No active datum"
-          : datumLabel(inspection.focus.row)}
-      </p>
-      {#if areaAwaitingSecond}
-        <p class="gg-area-instruction">Choose opposite corner</p>
-      {/if}
       {#if inspection !== null}
         <Tooltip
           id={`${plotId}-tooltip`}
@@ -2543,26 +2532,26 @@
         />
       {/if}
     {/if}
-    {#if shouldRenderInteractionLiveRegion( { surfaceInteractive, legendFocusEnabled: interactionConfig.legendFocus !== null } )}
-      <div
-        id={`${plotId}-live`}
-        class="gg-sr-only"
-        aria-live="polite"
-        aria-atomic="true"
-      >
-        {resolveInteractionLiveText({
-          announcement: interactionAnnouncement,
-          model,
-          inspection,
-        })}
-      </div>
-    {/if}
-    {#if emptyPlot}
-      <div class="gg-empty-state" role="status">No data to display</div>
-    {/if}
-    {#if capabilityStatus !== null}
-      <p class="gg-capability-status" role="status">{capabilityStatus}</p>
-    {/if}
+    <!-- Status chrome after capture/tooltip; ids stay plot-scoped for
+         aria-describedby. Parent reduced-motion rule does not match child
+         nodes (chrome has no transitions — intentional no-op). -->
+    <PlotStatusChrome
+      {plotId}
+      showInstructions={surfaceInteractive}
+      activeDatumLabel={datumLabel(inspection?.focus.row ?? null)}
+      showAreaInstruction={surfaceInteractive && areaAwaitingSecond}
+      showLiveRegion={shouldRenderInteractionLiveRegion({
+        surfaceInteractive,
+        legendFocusEnabled: interactionConfig.legendFocus !== null,
+      })}
+      liveText={resolveInteractionLiveText({
+        announcement: interactionAnnouncement,
+        model,
+        inspection,
+      })}
+      {emptyPlot}
+      {capabilityStatus}
+    />
   {/if}
 </div>
 
@@ -2626,46 +2615,6 @@
     outline-offset: 2px;
   }
 
-  .gg-area-instruction {
-    position: absolute;
-    right: 8px;
-    bottom: 8px;
-    z-index: 2;
-    margin: 0;
-    border-radius: 3px;
-    padding: 4px 7px;
-    background: var(--gg-tooltipBg, var(--gg-theme-tooltipBg, #fff));
-    color: var(--gg-foreground, var(--gg-theme-foreground, currentColor));
-    font-size: 13px;
-    line-height: 1.25;
-    pointer-events: none;
-  }
-
-  .gg-empty-state {
-    position: absolute;
-    left: 50%;
-    top: 50%;
-    transform: translate(-50%, -50%);
-    color: var(
-      --gg-interactionMuted,
-      var(--gg-theme-interactionMuted, currentColor)
-    );
-    font: 12px/1.4 var(--gg-font-family, sans-serif);
-    pointer-events: none;
-  }
-
-  .gg-capability-status {
-    position: absolute;
-    top: calc(100% + 4px);
-    left: 0;
-    margin: 0;
-    color: var(
-      --gg-interactionMuted,
-      var(--gg-theme-interactionMuted, currentColor)
-    );
-    font: 11px/1.4 var(--gg-font-family, sans-serif);
-  }
-
   @container gg-plot (max-width: 559px) {
     .gg-with-tool-rail {
       margin-top: 96px;
@@ -2678,19 +2627,9 @@
     margin-top: 96px;
   }
 
-  .gg-sr-only {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    clip-path: inset(50%);
-    white-space: nowrap;
-    border: 0;
-  }
-
   @media (prefers-reduced-motion: reduce) {
+    /* Parent-scoped: does not match PlotStatusChrome nodes. Chrome has no
+       transitions/animations, so this is a no-op for extracted status UI. */
     .gg-plot-root * {
       scroll-behavior: auto;
       transition: none !important;

--- a/packages/svelte/src/lib/PlotStatusChrome.svelte
+++ b/packages/svelte/src/lib/PlotStatusChrome.svelte
@@ -109,4 +109,17 @@
     white-space: nowrap;
     border: 0;
   }
+
+  /* Mirrors GGPlot root reduced-motion policy for this component scope
+     (parent `.gg-plot-root *` cannot cross Svelte style boundaries). */
+  @media (prefers-reduced-motion: reduce) {
+    .gg-area-instruction,
+    .gg-empty-state,
+    .gg-capability-status,
+    .gg-sr-only {
+      scroll-behavior: auto;
+      transition: none !important;
+      animation: none !important;
+    }
+  }
 </style>

--- a/packages/svelte/src/lib/PlotStatusChrome.svelte
+++ b/packages/svelte/src/lib/PlotStatusChrome.svelte
@@ -1,0 +1,112 @@
+<script lang="ts">
+  /**
+   * Status / a11y chrome for GGPlot (sr-only instructions, live region,
+   * empty state, capability status). Host owns interaction state and text.
+   *
+   * Element ids stay plot-scoped so capture `aria-describedby` and live
+   * region wiring remain stable across extraction.
+   */
+  const {
+    plotId,
+    showInstructions = false,
+    activeDatumLabel = "No active datum",
+    showAreaInstruction = false,
+    showLiveRegion = false,
+    liveText = "",
+    emptyPlot = false,
+    capabilityStatus = null,
+  }: {
+    plotId: string;
+    /** When true, render description + active datum sr-only pair. */
+    showInstructions?: boolean;
+    activeDatumLabel?: string;
+    showAreaInstruction?: boolean;
+    showLiveRegion?: boolean;
+    liveText?: string;
+    emptyPlot?: boolean;
+    capabilityStatus?: string | null;
+  } = $props();
+</script>
+
+{#if showInstructions}
+  <p id={`${plotId}-description`} class="gg-sr-only">
+    Use arrow keys to inspect data. Press Enter to pin. Press Escape to dismiss.
+  </p>
+  <p id={`${plotId}-active`} class="gg-sr-only">
+    {activeDatumLabel}
+  </p>
+{/if}
+{#if showAreaInstruction}
+  <p class="gg-area-instruction">Choose opposite corner</p>
+{/if}
+{#if showLiveRegion}
+  <div
+    id={`${plotId}-live`}
+    class="gg-sr-only"
+    aria-live="polite"
+    aria-atomic="true"
+  >
+    {liveText}
+  </div>
+{/if}
+{#if emptyPlot}
+  <div class="gg-empty-state" role="status">No data to display</div>
+{/if}
+{#if capabilityStatus !== null}
+  <p class="gg-capability-status" role="status">{capabilityStatus}</p>
+{/if}
+
+<style>
+  .gg-area-instruction {
+    position: absolute;
+    right: 8px;
+    bottom: 8px;
+    z-index: 2;
+    margin: 0;
+    border-radius: 3px;
+    padding: 4px 7px;
+    background: var(--gg-tooltipBg, var(--gg-theme-tooltipBg, #fff));
+    color: var(--gg-foreground, var(--gg-theme-foreground, currentColor));
+    font-size: 13px;
+    line-height: 1.25;
+    pointer-events: none;
+  }
+
+  .gg-empty-state {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    color: var(
+      --gg-interactionMuted,
+      var(--gg-theme-interactionMuted, currentColor)
+    );
+    font: 12px/1.4 var(--gg-font-family, sans-serif);
+    pointer-events: none;
+  }
+
+  .gg-capability-status {
+    position: absolute;
+    top: calc(100% + 4px);
+    left: 0;
+    margin: 0;
+    color: var(
+      --gg-interactionMuted,
+      var(--gg-theme-interactionMuted, currentColor)
+    );
+    font: 11px/1.4 var(--gg-font-family, sans-serif);
+  }
+
+  /* sr-only pattern (NOT display:none — must stay in the a11y tree). */
+  .gg-sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap;
+    border: 0;
+  }
+</style>

--- a/packages/svelte/src/lib/plot-layout.ts
+++ b/packages/svelte/src/lib/plot-layout.ts
@@ -1,6 +1,7 @@
 /**
- * Pure plot-root layout chrome: inline size/theme style and responsive
- * breakpoint helpers. Hosts own class bindings and tool-rail visibility.
+ * Pure plot-root layout chrome: inline size/theme style, responsive
+ * breakpoint helpers, and legend clear-control anchor lookup.
+ * Hosts own class bindings and tool-rail visibility.
  */
 
 const NARROW_TOOLS_MAX_WIDTH_PX = 560;
@@ -43,4 +44,27 @@ export function plotRootInlineStyle(input: PlotRootStyleInput): string | undefin
     ? `width:${input.containerWidth ? "100%" : `${input.sceneWidth}px`};height:${input.sceneHeight}px;`
     : "";
   return `${sizeCss}${input.themeStyle}` || undefined;
+}
+
+export type ClearLegendXInput = {
+  /**
+   * Host: `interactionConfig.legendFocus !== null`.
+   * Must stay even when `pressedScale` is non-null: controller emphasis can
+   * briefly leave a pressed scale after legend focus is disabled; Clear is
+   * intentionally suppressed then.
+   */
+  readonly legendFocusEnabled: boolean;
+  /** Host: `effectiveLegendPressed?.scale ?? null`. */
+  readonly pressedScale: string | null;
+  /** Scene legends (need scale + x for the clear control anchor). */
+  readonly legends: readonly { readonly scale: string; readonly x: number }[];
+};
+
+/**
+ * X position for the legend clear control, or null to hide it.
+ * null when legend focus is off, nothing is pressed, or no legend matches.
+ */
+export function resolveClearLegendX(input: ClearLegendXInput): number | null {
+  if (!input.legendFocusEnabled || input.pressedScale === null) return null;
+  return input.legends.find((legend) => legend.scale === input.pressedScale)?.x ?? null;
 }

--- a/packages/svelte/tests/plot-layout.test.ts
+++ b/packages/svelte/tests/plot-layout.test.ts
@@ -4,6 +4,7 @@ import {
   isDockedTooltipWidth,
   isNarrowToolsWidth,
   plotRootInlineStyle,
+  resolveClearLegendX,
 } from "../src/lib/plot-layout.js";
 
 describe("breakpoint helpers", () => {
@@ -77,5 +78,50 @@ describe("plotRootInlineStyle", () => {
         themeStyle: "--t:1",
       }),
     ).toBe("width:100%;height:400px;--t:1");
+  });
+});
+
+describe("resolveClearLegendX", () => {
+  const legends = [
+    { scale: "fill", x: 12 },
+    { scale: "color", x: 40 },
+  ];
+
+  it("returns the matching legend x when focus is enabled and pressed", () => {
+    expect(
+      resolveClearLegendX({
+        legendFocusEnabled: true,
+        pressedScale: "color",
+        legends,
+      }),
+    ).toBe(40);
+  });
+
+  it("returns null when legend focus is disabled even if a scale is pressed", () => {
+    // Runtime-disable: controller emphasis can leave a pressed scale briefly.
+    expect(
+      resolveClearLegendX({
+        legendFocusEnabled: false,
+        pressedScale: "fill",
+        legends,
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when nothing is pressed or no legend matches", () => {
+    expect(
+      resolveClearLegendX({
+        legendFocusEnabled: true,
+        pressedScale: null,
+        legends,
+      }),
+    ).toBeNull();
+    expect(
+      resolveClearLegendX({
+        legendFocusEnabled: true,
+        pressedScale: "size",
+        legends,
+      }),
+    ).toBeNull();
   });
 });

--- a/packages/svelte/tests/plot-status-chrome.test.ts
+++ b/packages/svelte/tests/plot-status-chrome.test.ts
@@ -87,4 +87,26 @@ describe("PlotStatusChrome", () => {
     expect(container.querySelector("#legend-only-description")).toBeNull();
     expect(container.querySelector("#legend-only-live")?.textContent).toBe("Web focused, 1 datum.");
   });
+
+  it("includes component-scoped reduced-motion resets for chrome classes", () => {
+    render(PlotStatusChrome, {
+      plotId: "rm",
+      showAreaInstruction: true,
+      emptyPlot: true,
+      capabilityStatus: "status",
+    });
+    const cssText = [...document.styleSheets]
+      .flatMap((sheet) => {
+        try {
+          return [...sheet.cssRules].map((rule) => rule.cssText);
+        } catch {
+          return [] as string[];
+        }
+      })
+      .join("\n");
+    expect(cssText).toMatch(/prefers-reduced-motion:\s*reduce/i);
+    expect(cssText).toMatch(/transition:\s*none/i);
+    // CSSOM may serialize `animation: none` as expanded longhands / `auto`.
+    expect(cssText).toMatch(/animation:\s*(none|auto)/i);
+  });
 });

--- a/packages/svelte/tests/plot-status-chrome.test.ts
+++ b/packages/svelte/tests/plot-status-chrome.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+
+import PlotStatusChrome from "../src/lib/PlotStatusChrome.svelte";
+import { render } from "./helpers/render.js";
+
+describe("PlotStatusChrome", () => {
+  it("renders plot-scoped instruction ids only when showInstructions", () => {
+    const off = render(PlotStatusChrome, {
+      plotId: "plot-a",
+      showInstructions: false,
+      activeDatumLabel: "x 1",
+    });
+    expect(off.container.querySelector("#plot-a-description")).toBeNull();
+    expect(off.container.querySelector("#plot-a-active")).toBeNull();
+
+    const on = render(PlotStatusChrome, {
+      plotId: "plot-a",
+      showInstructions: true,
+      activeDatumLabel: "x 1, y 2",
+    });
+    const description = on.container.querySelector("#plot-a-description");
+    const active = on.container.querySelector("#plot-a-active");
+    expect(description?.textContent).toContain("Use arrow keys to inspect data");
+    expect(active?.textContent?.trim()).toBe("x 1, y 2");
+  });
+
+  it("keeps instruction ids unique across two plot instances", () => {
+    const first = render(PlotStatusChrome, {
+      plotId: "p1",
+      showInstructions: true,
+      activeDatumLabel: "a",
+    });
+    const second = render(PlotStatusChrome, {
+      plotId: "p2",
+      showInstructions: true,
+      activeDatumLabel: "b",
+    });
+    expect(first.container.querySelector("#p1-description")).not.toBeNull();
+    expect(first.container.querySelector("#p1-active")?.textContent?.trim()).toBe("a");
+    expect(second.container.querySelector("#p2-description")).not.toBeNull();
+    expect(second.container.querySelector("#p2-active")?.textContent?.trim()).toBe("b");
+    expect(document.querySelectorAll("#p1-description").length).toBe(1);
+    expect(document.querySelectorAll("#p2-description").length).toBe(1);
+  });
+
+  it("renders area instruction, live region, empty, and capability gates", () => {
+    const empty = render(PlotStatusChrome, {
+      plotId: "plot-b",
+      showAreaInstruction: false,
+      showLiveRegion: false,
+      emptyPlot: false,
+      capabilityStatus: null,
+    });
+    expect(empty.container.querySelector(".gg-area-instruction")).toBeNull();
+    expect(empty.container.querySelector("#plot-b-live")).toBeNull();
+    expect(empty.container.querySelector(".gg-empty-state")).toBeNull();
+    expect(empty.container.querySelector(".gg-capability-status")).toBeNull();
+
+    const full = render(PlotStatusChrome, {
+      plotId: "plot-b",
+      showAreaInstruction: true,
+      showLiveRegion: true,
+      liveText: "Zoom complete.",
+      emptyPlot: true,
+      capabilityStatus: "No inspectable marks",
+    });
+    expect(full.container.querySelector(".gg-area-instruction")?.textContent).toContain(
+      "Choose opposite corner",
+    );
+    const live = full.container.querySelector("#plot-b-live");
+    expect(live?.getAttribute("aria-live")).toBe("polite");
+    expect(live?.getAttribute("aria-atomic")).toBe("true");
+    expect(live?.textContent).toBe("Zoom complete.");
+    expect(full.container.querySelector(".gg-empty-state")?.textContent).toBe("No data to display");
+    expect(full.container.querySelector(".gg-capability-status")?.textContent).toBe(
+      "No inspectable marks",
+    );
+  });
+
+  it("can render live region without surface instructions (legend-only focus)", () => {
+    const { container } = render(PlotStatusChrome, {
+      plotId: "legend-only",
+      showInstructions: false,
+      showLiveRegion: true,
+      liveText: "Web focused, 1 datum.",
+    });
+    expect(container.querySelector("#legend-only-description")).toBeNull();
+    expect(container.querySelector("#legend-only-live")?.textContent).toBe("Web focused, 1 datum.");
+  });
+});


### PR DESCRIPTION
## Summary

- Extract status/a11y chrome markup and styles into `PlotStatusChrome` (sr-only instructions, live region, empty state, capability status).
- Extract pure `resolveClearLegendX` for legend clear-control anchoring, including the legend-focus runtime-disable suppress path.
- Preserve plot-scoped element ids for capture `aria-describedby`; mirror reduced-motion resets inside the child component.

## Test plan

- [x] `bun run test:browser -- tests/plot-layout.test.ts tests/plot-status-chrome.test.ts tests/presentation.test.ts`
- [x] `bun run test:browser -- tests/interaction-regressions.test.ts tests/r0-evidence.test.ts`
- [x] `bun run check` in `packages/svelte`
- [ ] CI green