### PR TITLE
refactor(core): extract runPipeline layout, scene, contracts, candidates

### DIFF
--- a/packages/core/src/pipeline.ts
+++ b/packages/core/src/pipeline.ts
@@ -35,71 +35,50 @@
  * zero-variance domain -> symmetric padding; log scales drop non-positive
  * values with a warning and REFUSE non-positive explicit domains.
  */
-import type { BarParams, PortableSpec, SpecInput } from "@ggsvelte/spec";
+
+import type { PortableSpec, SpecInput } from "@ggsvelte/spec";
 import { normalize, SpecValidationError, validate } from "@ggsvelte/spec";
 
-import { FONT_METRICS } from "./layout/font-metrics.js";
-import type { LayoutResult, Margins, PassResult } from "./layout/layout.js";
-import { DEFAULT_LAYOUT_THEME, layout, layoutPass } from "./layout/layout.js";
-import { MetricsTableMeasurer } from "./layout/measure.js";
-import type { LegendInput, LegendOrder } from "./legend.js";
-import { buildLegends } from "./legend.js";
 import type { ScaleState } from "./scales/state.js";
 import type { PositionScale } from "./scales/train.js";
-import { bandKey, finiteExtent } from "./scales/train.js";
-import type { GeometryBatch, Scene, SceneAxis, SceneLegend, ScenePanel } from "./scene.js";
-import { PANEL_SPACING, STRIP_BAND } from "./scene.js";
+import { finiteExtent } from "./scales/train.js";
 import type { CellValue } from "./table.js";
-import { cellToNumber, ColumnTable } from "./table.js";
+import type { ColumnTable } from "./table.js";
 import { resolveEditionDefaults } from "./editions.js";
 import type { ThemeTokens } from "./theme.js";
 import { resolveTheme, UnknownThemeError } from "./theme.js";
 import { perfMark, perfMeasure } from "./perf.js";
-import { buildCandidateStore } from "./candidate-store.js";
 import { LineageStore } from "./identity.js";
 
 import type {
   Advisory,
-  LayerBackend,
   LayerBinding,
   LayerFrame,
-  MappedField,
   PipelineWarning,
   RenderModel,
-  ResolvedColorScale,
   RunOptions,
   ScaleDomainSnapshot,
 } from "./pipeline/types.js";
-import { CANVAS_AUTO_THRESHOLD, NO_ROW, PipelineError } from "./pipeline/types.js";
-import { batchMarkCount, buildBatch, flipBatchInPlace } from "./pipeline/geometry.js";
-import type { Frame } from "./pipeline/geometry.js";
+import { NO_ROW, PipelineError } from "./pipeline/types.js";
 import { resolveFacet, SINGLE_PANEL } from "./pipeline/facets.js";
 import { bindData, bindLayer } from "./pipeline/bind.js";
 import { collectAxisInputs, resolveColorScale, trainAxis } from "./pipeline/scale-training.js";
-import {
-  buildFrame,
-  createRawCandidateDatumResolver,
-  candidateAutoMode,
-  deriveLayerGroups,
-  remapSourceRows,
-} from "./pipeline/frame.js";
+import { buildFrame, remapSourceRows } from "./pipeline/frame.js";
 import { applyPosition } from "./pipeline/position.js";
 import {
-  AXIS_TITLE_BAND,
-  CAPTION_BAND,
-  LEGEND_EDGE_PAD,
-  LEGEND_GAP,
-  SUBTITLE_BAND,
-  TITLE_BAND,
-  axisTicks,
   dedupeAdvisories,
   dedupeWarnings,
-  elementwiseMaxMargins,
-  layoutDomain,
-  makeAxisFormatter,
   makeAxisValueFormatter,
   scaleDomainSnapshot,
 } from "./pipeline/layout-helpers.js";
+import { computePanelLayout } from "./pipeline/panel-layout.js";
+import { assembleScene, buildGeometryBatches } from "./pipeline/assemble-scene.js";
+import {
+  resolveLayerBackends,
+  resolveLayerFields,
+  resolveLayerScaledConstants,
+} from "./pipeline/layer-contracts.js";
+import { buildPipelineCandidates } from "./pipeline/build-candidates.js";
 
 // Re-export the public pipeline contract (import path stability).
 export type {
@@ -283,196 +262,27 @@ export function runPipeline(spec: SpecInput | PortableSpec, options: RunOptions)
 
   // layout (bounded two-pass; facet grids run the per-panel mirror of it)
   perfMark("ggsvelte:layout:start");
-  const title = labs.title ?? "";
-  const subtitle = labs.subtitle ?? "";
-  const caption = labs.caption ?? "";
-  const xTitle = labs.x ?? allFrames.find((f) => f.binding.xField !== null)?.binding.xField ?? "";
-  const yTitle =
-    labs.y ??
-    allFrames.find((f) => f.binding.yField !== null)?.binding.yField ??
-    allFrames.find((f) => f.binding.yStatColumn !== null)?.binding.yStatColumn ??
-    "";
-  const titleBand = Math.max(TITLE_BAND, theme.titleSize + 7);
-  const subtitleBand = Math.max(SUBTITLE_BAND, theme.subtitleSize + 4);
-  const captionBand = Math.max(CAPTION_BAND, theme.captionSize + 5);
-  const axisTitleBand = Math.max(AXIS_TITLE_BAND, theme.axisTitleSize + 9);
-  const topBand = (title === "" ? 0 : titleBand) + (subtitle === "" ? 0 : subtitleBand);
-  const bottomBand = caption === "" ? 0 : captionBand;
-
-  // Display sides: under coord flip the BOTTOM axis shows the y channel and
-  // the LEFT axis shows the x channel — titles, formatters, domains, and
-  // free-scale behavior all follow the displayed scale.
-  const hTitle = flip ? yTitle : xTitle;
-  const vTitle = flip ? xTitle : yTitle;
-  const formatX = makeAxisFormatter("x", xTraining.scale, scalesConfig.x, warnings);
-  const formatY = makeAxisFormatter("y", yTraining.scale, scalesConfig.y, warnings);
-  const formatH = flip ? formatY : formatX;
-  const formatV = flip ? formatX : formatY;
-  const hBreaks = flip ? scalesConfig.y?.breaks : scalesConfig.x?.breaks;
-  const vBreaks = flip ? scalesConfig.x?.breaks : scalesConfig.y?.breaks;
-  const freeH = flip ? freeY : freeX;
-  const freeV = flip ? freeX : freeY;
-  const displayScales = (p: number): { h: PositionScale; v: PositionScale } => {
-    const s = panelScales[p]!;
-    return flip ? { h: s.y, v: s.x } : { h: s.x, v: s.y };
-  };
-
-  const measurer = options.measureText ?? new MetricsTableMeasurer(FONT_METRICS);
-  const layoutTheme = {
-    ...DEFAULT_LAYOUT_THEME,
-    fontSize: theme.axisTextSize,
-    tickLength: theme.ticksX || theme.ticksY ? theme.tickLength : 0,
-    tickLabelGap: theme.ticksX || theme.ticksY ? 3 : 5,
-  };
-  const legendOrder: LegendOrder = normalized.legend?.order ?? "stable-domain";
-  const legendInputs = [colorResolution.legendInput, fillResolution.legendInput].filter(
-    (l): l is LegendInput => l !== null,
-  );
-  const legendBlock = buildLegends(
-    legendInputs,
-    legendOrder,
-    measurer,
-    Math.max(48, options.width * 0.35),
-  );
-
-  const layoutHeight = Math.max(40, options.height - topBand - bottomBand);
-
-  interface PanelPlacement {
-    x: number;
-    y: number;
-    width: number;
-    height: number;
-    ticksH: LayoutResult["x"]["ticks"];
-    ticksV: LayoutResult["y"]["ticks"];
-    showAxisX: boolean;
-    showAxisY: boolean;
-  }
-  const placements: PanelPlacement[] = [];
-
-  if (faceted) {
-    // --- facet grid layout -------------------------------------------------
-    // Outer chrome first (axis-title bands + legend column), then per-panel
-    // margins measured over every panel's domains (elementwise max keeps the
-    // grid regular), then a second tick pass at the true panel size.
-    const spacing = PANEL_SPACING;
-    const strip = STRIP_BAND;
-    const outerLeft = vTitle === "" ? 0 : axisTitleBand;
-    const outerBottom = hTitle === "" ? 0 : axisTitleBand;
-    const outerRight = legendBlock.width > 0 ? legendBlock.width + LEGEND_GAP + LEGEND_EDGE_PAD : 0;
-    const gridW = Math.max(40, options.width - outerLeft - outerRight);
-    const gridH = Math.max(40, layoutHeight - outerBottom);
-
-    const approxW = Math.max(40, (gridW - (ncol - 1) * spacing) / ncol);
-    const approxH = Math.max(40, (gridH - nrow * strip - (nrow - 1) * spacing) / nrow);
-    let mMax: Margins = { top: 0, right: 0, bottom: 0, left: 0 };
-    for (let p = 0; p < facetPanels.length; p++) {
-      const { h, v } = displayScales(p);
-      const run = layout({
-        width: approxW,
-        height: approxH,
-        x: layoutDomain(h, hBreaks),
-        y: layoutDomain(v, vBreaks),
-        ...(formatH !== undefined && { formatX: formatH }),
-        ...(formatV !== undefined && { formatY: formatV }),
-        measurer,
-        theme: layoutTheme,
-      });
-      mMax = elementwiseMaxMargins(mMax, run.margins);
-    }
-
-    const leftCount = freeV ? ncol : 1;
-    const bottomCount = freeH ? nrow : 1;
-    const panelW = Math.max(
-      1,
-      (gridW - leftCount * mMax.left - mMax.right - (ncol - 1) * spacing) / ncol,
-    );
-    const panelH = Math.max(
-      1,
-      (gridH - mMax.top - bottomCount * mMax.bottom - nrow * strip - (nrow - 1) * spacing) / nrow,
-    );
-
-    // Column x positions and row y positions.
-    const colX: number[] = [];
-    let xCursor = outerLeft;
-    for (let c = 0; c < ncol; c++) {
-      if (c === 0 || freeV) xCursor += mMax.left;
-      colX.push(xCursor);
-      xCursor += panelW + spacing;
-    }
-    const rowY: number[] = [];
-    let yCursor = topBand + mMax.top;
-    for (let r = 0; r < nrow; r++) {
-      yCursor += strip;
-      rowY.push(yCursor);
-      yCursor += panelH;
-      if (r === nrow - 1 || freeH) yCursor += mMax.bottom;
-      yCursor += spacing;
-    }
-
-    // Bottom-most occupied row per column (wrap's last row may be partial):
-    // with fixed scales the x axis draws there and nowhere else.
-    const bottomMostRow: number[] = Array.from({ length: ncol }, () => 0);
-    for (const def of facetPanels) {
-      if (def.row > bottomMostRow[def.col]!) bottomMostRow[def.col] = def.row;
-    }
-
-    for (let p = 0; p < facetPanels.length; p++) {
-      const def = facetPanels[p]!;
-      const { h, v } = displayScales(p);
-      const ticksRun: PassResult = layoutPass(
-        mMax,
-        {
-          width: panelW + mMax.left + mMax.right,
-          height: panelH + mMax.top + mMax.bottom,
-          x: layoutDomain(h, hBreaks),
-          y: layoutDomain(v, vBreaks),
-          ...(formatH !== undefined && { formatX: formatH }),
-          ...(formatV !== undefined && { formatY: formatV }),
-          measurer,
-        },
-        layoutTheme,
-      );
-      placements.push({
-        x: colX[def.col]!,
-        y: rowY[def.row]!,
-        width: panelW,
-        height: panelH,
-        ticksH: ticksRun.x.ticks,
-        ticksV: ticksRun.y.ticks,
-        showAxisX: freeH || def.row === bottomMostRow[def.col]!,
-        showAxisY: freeV || def.col === 0,
-      });
-    }
-  } else {
-    const { h, v } = displayScales(0);
-    const reserve: Partial<Margins> = {
-      ...(hTitle !== "" && { bottom: axisTitleBand }),
-      ...(vTitle !== "" && { left: axisTitleBand }),
-      ...(legendBlock.width > 0 && { right: legendBlock.width + LEGEND_GAP + LEGEND_EDGE_PAD }),
-    };
-    const layoutResult = layout({
-      width: options.width,
-      height: layoutHeight,
-      x: layoutDomain(h, hBreaks),
-      y: layoutDomain(v, vBreaks),
-      ...(formatH !== undefined && { formatX: formatH }),
-      ...(formatV !== undefined && { formatY: formatV }),
-      measurer,
-      reserve,
-      theme: layoutTheme,
-    });
-    const margins = layoutResult.margins;
-    placements.push({
-      x: margins.left,
-      y: topBand + margins.top,
-      width: Math.max(1, options.width - margins.left - margins.right),
-      height: Math.max(1, layoutHeight - margins.top - margins.bottom),
-      ticksH: layoutResult.x.ticks,
-      ticksV: layoutResult.y.ticks,
-      showAxisX: true,
-      showAxisY: true,
-    });
-  }
+  const panelLayout = computePanelLayout({
+    flip,
+    faceted,
+    freeX,
+    freeY,
+    nrow,
+    ncol,
+    facetPanels,
+    panelScales,
+    allFrames,
+    labs,
+    scalesConfig,
+    xScale: xTraining.scale,
+    yScale: yTraining.scale,
+    colorLegend: colorResolution.legendInput,
+    fillLegend: fillResolution.legendInput,
+    legendOrder: normalized.legend?.order ?? "stable-domain",
+    theme,
+    options,
+    warnings,
+  });
   perfMark("ggsvelte:layout:end");
   perfMeasure("ggsvelte:layout", "ggsvelte:layout:start", "ggsvelte:layout:end");
 
@@ -481,159 +291,46 @@ export function runPipeline(spec: SpecInput | PortableSpec, options: RunOptions)
   // it keeps each layer's batches contiguous so strata planning (contiguous
   // same-backend batches share a stratum) never fragments on facet panels.
   perfMark("ggsvelte:geometry:start");
-  const batches: GeometryBatch[] = [];
-  const panelFrame = (p: number): Frame => {
-    const placement = placements[p]!;
-    const scales = panelScales[p]!;
-    return flip
-      ? {
-          innerWidth: placement.height,
-          innerHeight: placement.width,
-          xScale: scales.x,
-          yScale: scales.y,
-        }
-      : {
-          innerWidth: placement.width,
-          innerHeight: placement.height,
-          xScale: scales.x,
-          yScale: scales.y,
-        };
-  };
-  for (let index = 0; index < normalized.layers.length; index++) {
-    for (let p = 0; p < facetPanels.length; p++) {
-      const frame = panelFrames[p]?.[index];
-      if (frame === undefined) continue;
-      const placement = placements[p]!;
-      const built = buildBatch(
-        frame,
-        panelFrame(p),
-        colorResolution.resolved,
-        fillResolution.resolved,
-        warnings,
-      );
-      for (const batch of built) {
-        if (flip) flipBatchInPlace(batch, placement.width, placement.height);
-        batch.panelIndex = p;
-        batches.push(batch);
-      }
-    }
-  }
+  const batches = buildGeometryBatches({
+    layerCount: normalized.layers.length,
+    facetPanels,
+    panelFrames,
+    placements: panelLayout.placements,
+    panelScales,
+    color: colorResolution.resolved,
+    fill: fillResolution.resolved,
+    flip,
+    warnings,
+  });
   perfMark("ggsvelte:geometry:end");
   perfMeasure("ggsvelte:geometry", "ggsvelte:geometry:start", "ggsvelte:geometry:end");
 
-  // scene panels: per-panel axes/grid/strips
-  const scenePanels: ScenePanel[] = placements.map((placement, p) => {
-    const { h, v } = displayScales(p);
-    const bottom = axisTicks(h, placement.ticksH, placement.width, false);
-    const left = axisTicks(v, placement.ticksV, placement.height, true);
-    return {
-      id: facetPanels[p]!.id,
-      x: placement.x,
-      y: placement.y,
-      width: placement.width,
-      height: placement.height,
-      strip: facetPanels[p]!.label,
-      axisX: placement.showAxisX ? bottom : null,
-      axisY: placement.showAxisY ? left : null,
-      grid: { x: bottom.map((t) => t.pos), y: left.map((t) => t.pos) },
-    };
-  });
-
-  const firstX = scenePanels.find((p) => p.axisX !== null);
-  const firstY = scenePanels.find((p) => p.axisY !== null);
-  const xAxis: SceneAxis = { ticks: firstX?.axisX ?? [], title: hTitle };
-  const yAxis: SceneAxis = { ticks: firstY?.axisY ?? [], title: vTitle };
-
-  // place legends: right column, top-aligned with the first panel
-  const legends: SceneLegend[] = legendBlock.legends.map((legend) => ({
-    ...legend,
-    x: legend.x + options.width - legendBlock.width - LEGEND_EDGE_PAD,
-    y: legend.y + (scenePanels[0]?.y ?? topBand),
-  }));
-
-  const scene: Scene = {
+  const scene = assembleScene({
     width: options.width,
     height: options.height,
-    panels: scenePanels,
+    placements: panelLayout.placements,
+    facetPanels,
+    displayScales: panelLayout.displayScales,
+    hTitle: panelLayout.hTitle,
+    vTitle: panelLayout.vTitle,
     batches,
-    axes: { x: xAxis, y: yAxis },
-    grid: scenePanels[0]?.grid ?? { x: [], y: [] },
-    legends,
+    legendBlock: panelLayout.legendBlock,
+    topBand: panelLayout.topBand,
     theme,
-    title,
-    subtitle,
-    caption,
-  };
-
-  // Resolve per-layer rendering backends (advisory when 'auto' switches).
-  const threshold = options.canvasThreshold ?? CANVAS_AUTO_THRESHOLD;
-  const marksPerLayer: number[] = normalized.layers.map(() => 0);
-  for (const batch of batches) {
-    marksPerLayer[batch.layerIndex] =
-      (marksPerLayer[batch.layerIndex] ?? 0) + batchMarkCount(batch);
-  }
-  const layerBackends: LayerBackend[] = normalized.layers.map((layer, index) => {
-    if (normalized.a11y === "force-svg") return "svg";
-    const hint = ("render" in layer ? layer.render : undefined) ?? "auto";
-    if (hint === "svg" || hint === "canvas") return hint;
-    if ((marksPerLayer[index] ?? 0) > threshold) {
-      advisories.push({
-        code: "canvas-auto",
-        path: `layers.${index}`,
-        chosen: `canvas backend (${marksPerLayer[index]} marks > threshold ${threshold}; canvas marks do not expose per-mark accessibility or "copy SVG")`,
-        howToOverride: `Set layers[${index}].render to "svg" (or "canvas" to silence this), or set a11y: "force-svg" on the plot.`,
-      });
-      return "canvas";
-    }
-    return "svg";
+    title: panelLayout.title,
+    subtitle: panelLayout.subtitle,
+    caption: panelLayout.caption,
   });
 
-  // Tooltip contract: field-mapped channels per layer + source-row lookup.
-  const layerFields: MappedField[][] = normalized.layers.map((_layer, index) => {
-    const binding = bindings[index];
-    if (binding === undefined) return [];
-    const fields: MappedField[] = [];
-    const push = (channel: string, field: string | null, source?: "stat") => {
-      if (field !== null)
-        fields.push(source === undefined ? { channel, field } : { channel, field, source });
-    };
-    const stat = binding.layer.stat ?? "identity";
-    if (stat === "identity") {
-      push("x", binding.xField);
-      push("y", binding.yField);
-    } else {
-      // Synthesized stat rows have no source row. Advertise only semantic
-      // generated channels that CandidateFacts can resolve truthfully.
-      if (binding.xField !== null) push("x", "x", "stat");
-      if (stat === "count" || stat === "bin" || stat === "density") {
-        push("y", binding.yStatColumn ?? (stat === "density" ? "density" : "count"), "stat");
-      } else if (stat === "boxplot") {
-        push("y", "middle", "stat");
-      } else if (stat === "smooth" || stat === "summary") {
-        push("y", "y", "stat");
-      }
-    }
-    push("ymin", binding.yminField);
-    push("ymax", binding.ymaxField);
-    push("color", binding.color.field);
-    push("fill", binding.fill.field);
-    push("label", binding.labelField);
-    push("weight", binding.weightField);
-    return fields;
-  });
-
-  // Legend-focus contract: scaled constant channels with no field mapping.
-  const layerScaledConstants: ReadonlyArray<Readonly<Partial<Record<string, CellValue>>>> =
-    Object.freeze(
-      normalized.layers.map((_layer, index) => {
-        const binding = bindings[index];
-        if (binding === undefined) return Object.freeze({});
-        const out: Partial<Record<string, CellValue>> = {};
-        if (binding.color.scaledConstant !== null) out["color"] = binding.color.scaledConstant;
-        if (binding.fill.scaledConstant !== null) out["fill"] = binding.fill.scaledConstant;
-        return Object.freeze(out);
-      }),
-    );
+  const layerBackends = resolveLayerBackends(
+    normalized.layers,
+    batches,
+    normalized.a11y,
+    options.canvasThreshold,
+    advisories,
+  );
+  const layerFields = resolveLayerFields(bindings);
+  const layerScaledConstants = resolveLayerScaledConstants(bindings);
 
   const state: Record<string, ScaleState> = {};
   if (colorResolution.state !== null) state["color"] = colorResolution.state;
@@ -691,214 +388,19 @@ export function runPipeline(spec: SpecInput | PortableSpec, options: RunOptions)
   baselineDomains ??= effectiveDomains;
 
   const lineage = new LineageStore<number>();
-  let identityIndex: Readonly<{
-    seriesByRow: Map<string, number>;
-    sourceRowsByGroup: Map<string, number[]>;
-    frameGroups: Map<string, number[]>;
-  }> | null = null;
-  const getIdentityIndex = () => {
-    if (identityIndex !== null) return identityIndex;
-    const seriesByRow = new Map<string, number>();
-    const sourceRowsByGroup = new Map<string, number[]>();
-    const frameGroups = new Map<string, number[]>();
-    for (let panelIndex = 0; panelIndex < panelFrames.length; panelIndex++) {
-      for (const frame of panelFrames[panelIndex] ?? []) {
-        const frameKey = `${panelIndex}:${frame.binding.index}`;
-        frameGroups.set(frameKey, [...new Set(frame.groups)]);
-        const inputGroups = deriveLayerGroups(frame.binding, frame.table);
-        for (let localRow = 0; localRow < inputGroups.length; localRow++) {
-          const group = inputGroups[localRow]!;
-          const sourceRow = facetPanels[panelIndex]!.sourceRows?.[localRow] ?? localRow;
-          const key = `${frameKey}:${group}`;
-          const members = sourceRowsByGroup.get(key);
-          if (members === undefined) sourceRowsByGroup.set(key, [sourceRow]);
-          else members.push(sourceRow);
-        }
-        for (let i = 0; i < frame.rowIndex.length; i++) {
-          const sourceRow = frame.rowIndex[i]!;
-          if (sourceRow !== NO_ROW) {
-            seriesByRow.set(
-              `${panelIndex}:${frame.binding.index}:${sourceRow}`,
-              frame.groups[i] ?? 0,
-            );
-          }
-        }
-      }
-    }
-    identityIndex = { seriesByRow, sourceRowsByGroup, frameGroups };
-    return identityIndex;
-  };
-  const allSourceBacked = bindings.every(
-    (binding) =>
-      (binding.layer.stat ?? "identity") === "identity" && binding.ruleForm !== "annotation",
-  );
-  const candidates = allSourceBacked
-    ? buildCandidateStore(scene, {
-        epoch: runId,
-        flip,
-        datum: createRawCandidateDatumResolver(
-          bindings,
-          table,
-          colorResolution.resolved,
-          fillResolution.resolved,
-          lineage,
-        ),
-      })
-    : buildCandidateStore(scene, {
-        epoch: runId,
-        flip,
-        datum(facts) {
-          const { seriesByRow, sourceRowsByGroup, frameGroups } = getIdentityIndex();
-          const fields = layerFields[facts.layerIndex] ?? [];
-          const sourceRow = facts.rowIndex;
-          const frame = panelFrames[facts.panelIndex]?.[facts.layerIndex];
-          const batch = scene.batches[facts.batchIndex]!;
-          const outlierLocalRow =
-            frame?.box !== null &&
-            frame?.binding.layer.geom === "boxplot" &&
-            batch.kind === "points"
-              ? (frame?.box.outlierRow[facts.primitiveIndex] ?? null)
-              : null;
-          const outlierSourceRow =
-            outlierLocalRow === null
-              ? null
-              : (facetPanels[facts.panelIndex]?.sourceRows?.[outlierLocalRow] ?? outlierLocalRow);
-          const orderedGroups = frameGroups.get(`${facts.panelIndex}:${facts.layerIndex}`) ?? [0];
-          let frameRow = Math.min(facts.primitiveIndex, Math.max(0, (frame?.n ?? 1) - 1));
-          let derivedGroup = frame?.groups[frameRow] ?? 0;
-          if (frame !== undefined && batch.kind === "paths") {
-            let subpath = 0;
-            while (
-              subpath + 1 < batch.pathOffsets.length &&
-              facts.primitiveIndex >= batch.pathOffsets[subpath + 1]!
-            )
-              subpath++;
-            derivedGroup = orderedGroups[Math.min(subpath, orderedGroups.length - 1)] ?? 0;
-            const rowsInGroup = frame.groups
-              .map((group, row) => ({ group, row }))
-              .filter((entry) => entry.group === derivedGroup)
-              .map((entry) => entry.row)
-              .toSorted((a, b) => (frame.xNumeric?.[a] ?? a) - (frame.xNumeric?.[b] ?? b));
-            const local = facts.primitiveIndex - (batch.pathOffsets[subpath] ?? 0);
-            const reflected =
-              local < rowsInGroup.length ? local : Math.max(0, rowsInGroup.length * 2 - 1 - local);
-            frameRow = rowsInGroup[Math.min(reflected, rowsInGroup.length - 1)] ?? frameRow;
-          } else if (frame !== undefined && batch.kind === "segments") {
-            if (frame.binding.layer.geom === "errorbar")
-              frameRow = Math.floor(facts.primitiveIndex / 3);
-            else if (frame.binding.layer.geom === "boxplot" && batch.rowIndex.length >= frame.n * 2)
-              frameRow = Math.floor(facts.primitiveIndex / 2);
-            derivedGroup =
-              frame.groups[Math.min(frameRow, frame.groups.length - 1)] ?? derivedGroup;
-          } else if (
-            frame?.box !== null &&
-            frame?.binding.layer.geom === "boxplot" &&
-            batch.kind === "points"
-          ) {
-            frameRow = frame.box.outlierBox[facts.primitiveIndex] ?? frameRow;
-            derivedGroup = frame.groups[frameRow] ?? derivedGroup;
-          }
-          const sourceValue = (field: string | undefined): CellValue =>
-            sourceRow === null || field === undefined ? null : table.column(field)[sourceRow]!;
-          const xField = fields.find((field) => field.channel === "x")?.field;
-          const yField = fields.find((field) => field.channel === "y")?.field;
-          const colorField = fields.find((field) => field.channel === "color")?.field;
-          const fillField = fields.find((field) => field.channel === "fill")?.field;
-          const group =
-            sourceRow === null
-              ? derivedGroup
-              : (seriesByRow.get(`${facts.panelIndex}:${facts.layerIndex}:${sourceRow}`) ?? 0);
-          const ordinalRank = (resolved: ResolvedColorScale | null, field: string | undefined) => {
-            if (resolved?.kind !== "ordinal" || field === undefined || sourceRow === null)
-              return -1;
-            const key = bandKey(sourceValue(field));
-            return resolved.scale.domain.findIndex((value) => bandKey(value) === key);
-          };
-          const colorRank = ordinalRank(colorResolution.resolved, colorField);
-          const fillRank = ordinalRank(fillResolution.resolved, fillField);
-          const autoMode = candidateAutoMode(
-            frame?.binding ?? bindings[facts.layerIndex]!,
-            facts.primitiveIndex,
-          );
-          const annotationRule = frame?.binding.ruleForm === "annotation";
-          const annotationX = annotationRule
-            ? (frame.xIntercepts[facts.primitiveIndex] ?? null)
-            : null;
-          const annotationY = annotationRule
-            ? (frame.yIntercepts[facts.primitiveIndex - frame.xIntercepts.length] ?? null)
-            : null;
-          let representedRows =
-            outlierSourceRow === null
-              ? (sourceRowsByGroup.get(`${facts.panelIndex}:${facts.layerIndex}:${group}`) ?? [])
-              : [outlierSourceRow];
-          if (sourceRow === null && frame !== undefined) {
-            const stat = frame.binding.layer.stat ?? "identity";
-            const aggregateXField = frame.binding.xField;
-            const outputX = frame.xValues?.[frameRow] ?? frame.xNumeric?.[frameRow] ?? null;
-            if (
-              aggregateXField !== null &&
-              outputX !== null &&
-              (stat === "count" || stat === "summary" || stat === "boxplot")
-            ) {
-              const outputKey = bandKey(outputX);
-              representedRows = representedRows.filter(
-                (row) => bandKey(table.column(aggregateXField)[row]) === outputKey,
-              );
-            } else if (
-              stat === "bin" &&
-              aggregateXField !== null &&
-              frame.xmin !== null &&
-              frame.xmax !== null
-            ) {
-              const hi = frame.xmax[frameRow]!;
-              const lo = frame.xmin[frameRow]!;
-              const closed = ((frame.binding.layer.params ?? {}) as BarParams).closed ?? "right";
-              const frameGroup = frame.groups[frameRow];
-              const firstInGroup = frameRow === 0 || frame.groups[frameRow - 1] !== frameGroup;
-              const lastInGroup =
-                frameRow === frame.n - 1 || frame.groups[frameRow + 1] !== frameGroup;
-              representedRows = representedRows.filter((row) => {
-                const value = cellToNumber(table.column(aggregateXField)[row]!);
-                if (!Number.isFinite(value)) return false;
-                return closed === "right"
-                  ? value <= hi && (value > lo || (firstInGroup && value >= lo))
-                  : value >= lo && (value < hi || (lastInGroup && value <= hi));
-              });
-            }
-            const aggregateYField = frame.binding.yField;
-            if (
-              (stat === "smooth" || stat === "summary" || stat === "boxplot") &&
-              aggregateYField !== null
-            ) {
-              representedRows = representedRows.filter((row) =>
-                Number.isFinite(cellToNumber(table.column(aggregateYField)[row]!)),
-              );
-            }
-          }
-          return {
-            xValue: annotationRule
-              ? annotationX
-              : outlierSourceRow === null
-                ? sourceRow === null
-                  ? (frame?.xValues?.[frameRow] ?? frame?.xNumeric?.[frameRow] ?? null)
-                  : sourceValue(xField)
-                : (frame?.box?.outlierX[facts.primitiveIndex] ?? null),
-            yValue: annotationRule
-              ? annotationY
-              : outlierSourceRow === null
-                ? sourceRow === null
-                  ? (frame?.yNumeric?.[frameRow] ?? frame?.box?.middle[frameRow] ?? null)
-                  : sourceValue(yField)
-                : (frame?.box?.outlierY[facts.primitiveIndex] ?? null),
-            seriesId: group,
-            seriesRank: colorRank >= 0 ? colorRank : fillRank >= 0 ? fillRank : group,
-            sourceOrder: sourceRow ?? outlierSourceRow ?? facts.primitiveIndex,
-            lineage:
-              sourceRow === null ? lineage.intern(representedRows) : lineage.intern([sourceRow]),
-            autoMode,
-          };
-        },
-      });
+  const candidates = buildPipelineCandidates({
+    scene,
+    runId,
+    flip,
+    bindings,
+    panelFrames,
+    facetPanels,
+    table,
+    layerFields,
+    color: colorResolution.resolved,
+    fill: fillResolution.resolved,
+    lineage,
+  });
 
   perfMark("ggsvelte:pipeline:end");
   perfMeasure("ggsvelte:pipeline", "ggsvelte:pipeline:start", "ggsvelte:pipeline:end");
@@ -925,8 +427,8 @@ export function runPipeline(spec: SpecInput | PortableSpec, options: RunOptions)
     lineage,
     candidates,
     axisFormatters: Object.freeze({
-      x: makeAxisValueFormatter(xTraining.scale, formatX),
-      y: makeAxisValueFormatter(yTraining.scale, formatY),
+      x: makeAxisValueFormatter(xTraining.scale, panelLayout.formatX),
+      y: makeAxisValueFormatter(yTraining.scale, panelLayout.formatY),
     }),
     row(index: number): Record<string, CellValue> | null {
       const source = retainedTable;

--- a/packages/core/src/pipeline.ts
+++ b/packages/core/src/pipeline.ts
@@ -329,8 +329,8 @@ export function runPipeline(spec: SpecInput | PortableSpec, options: RunOptions)
     options.canvasThreshold,
     advisories,
   );
-  const layerFields = resolveLayerFields(bindings);
-  const layerScaledConstants = resolveLayerScaledConstants(bindings);
+  const layerFields = resolveLayerFields(normalized.layers.length, bindings);
+  const layerScaledConstants = resolveLayerScaledConstants(normalized.layers.length, bindings);
 
   const state: Record<string, ScaleState> = {};
   if (colorResolution.state !== null) state["color"] = colorResolution.state;

--- a/packages/core/src/pipeline/assemble-scene.ts
+++ b/packages/core/src/pipeline/assemble-scene.ts
@@ -1,0 +1,145 @@
+/**
+ * Geometry batch construction and Scene assembly from panel placements.
+ */
+import type { GeometryBatch, Scene, SceneAxis, SceneLegend, ScenePanel } from "../scene.js";
+import type { ThemeTokens } from "../theme.js";
+import type { PositionScale } from "../scales/train.js";
+
+import type { FacetPanelDef } from "./facets.js";
+import { buildBatch, flipBatchInPlace } from "./geometry.js";
+import type { Frame } from "./geometry.js";
+import { axisTicks, LEGEND_EDGE_PAD } from "./layout-helpers.js";
+import type { PanelPlacement } from "./panel-layout.js";
+import type { LayerFrame, PipelineWarning, ResolvedColorScale } from "./types.js";
+
+export function buildGeometryBatches(input: {
+  layerCount: number;
+  facetPanels: readonly FacetPanelDef[];
+  panelFrames: readonly (readonly LayerFrame[])[];
+  placements: readonly PanelPlacement[];
+  panelScales: readonly { x: PositionScale; y: PositionScale }[];
+  color: ResolvedColorScale | null;
+  fill: ResolvedColorScale | null;
+  flip: boolean;
+  warnings: PipelineWarning[];
+}): GeometryBatch[] {
+  const {
+    layerCount,
+    facetPanels,
+    panelFrames,
+    placements,
+    panelScales,
+    color,
+    fill,
+    flip,
+    warnings,
+  } = input;
+  const batches: GeometryBatch[] = [];
+  const panelFrame = (p: number): Frame => {
+    const placement = placements[p]!;
+    const scales = panelScales[p]!;
+    return flip
+      ? {
+          innerWidth: placement.height,
+          innerHeight: placement.width,
+          xScale: scales.x,
+          yScale: scales.y,
+        }
+      : {
+          innerWidth: placement.width,
+          innerHeight: placement.height,
+          xScale: scales.x,
+          yScale: scales.y,
+        };
+  };
+  for (let index = 0; index < layerCount; index++) {
+    for (let p = 0; p < facetPanels.length; p++) {
+      const frame = panelFrames[p]?.[index];
+      if (frame === undefined) continue;
+      const placement = placements[p]!;
+      const built = buildBatch(frame, panelFrame(p), color, fill, warnings);
+      for (const batch of built) {
+        if (flip) flipBatchInPlace(batch, placement.width, placement.height);
+        batch.panelIndex = p;
+        batches.push(batch);
+      }
+    }
+  }
+  return batches;
+}
+
+export function assembleScene(input: {
+  width: number;
+  height: number;
+  placements: readonly PanelPlacement[];
+  facetPanels: readonly FacetPanelDef[];
+  displayScales: (p: number) => { h: PositionScale; v: PositionScale };
+  hTitle: string;
+  vTitle: string;
+  batches: GeometryBatch[];
+  legendBlock: { legends: SceneLegend[]; width: number };
+  topBand: number;
+  theme: ThemeTokens;
+  title: string;
+  subtitle: string;
+  caption: string;
+}): Scene {
+  const {
+    width,
+    height,
+    placements,
+    facetPanels,
+    displayScales,
+    hTitle,
+    vTitle,
+    batches,
+    legendBlock,
+    topBand,
+    theme,
+    title,
+    subtitle,
+    caption,
+  } = input;
+
+  const scenePanels: ScenePanel[] = placements.map((placement, p) => {
+    const { h, v } = displayScales(p);
+    const bottom = axisTicks(h, placement.ticksH, placement.width, false);
+    const left = axisTicks(v, placement.ticksV, placement.height, true);
+    return {
+      id: facetPanels[p]!.id,
+      x: placement.x,
+      y: placement.y,
+      width: placement.width,
+      height: placement.height,
+      strip: facetPanels[p]!.label,
+      axisX: placement.showAxisX ? bottom : null,
+      axisY: placement.showAxisY ? left : null,
+      grid: { x: bottom.map((t) => t.pos), y: left.map((t) => t.pos) },
+    };
+  });
+
+  const firstX = scenePanels.find((p) => p.axisX !== null);
+  const firstY = scenePanels.find((p) => p.axisY !== null);
+  const xAxis: SceneAxis = { ticks: firstX?.axisX ?? [], title: hTitle };
+  const yAxis: SceneAxis = { ticks: firstY?.axisY ?? [], title: vTitle };
+
+  const legends: SceneLegend[] = legendBlock.legends.map((legend) => ({
+    ...legend,
+    x: legend.x + width - legendBlock.width - LEGEND_EDGE_PAD,
+    y: legend.y + (scenePanels[0]?.y ?? topBand),
+  }));
+
+  return {
+    width,
+    height,
+    panels: scenePanels,
+    batches,
+    axes: { x: xAxis, y: yAxis },
+    grid: scenePanels[0]?.grid ?? { x: [], y: [] },
+    legends,
+    theme,
+    title,
+    subtitle,
+    caption,
+  };
+}

--- a/packages/core/src/pipeline/build-candidates.ts
+++ b/packages/core/src/pipeline/build-candidates.ts
@@ -1,0 +1,247 @@
+/**
+ * Interaction candidate store construction for a completed pipeline scene.
+ * Source-backed layers use the cheap raw resolver; stat/annotation layers use
+ * the identity-indexed path that reconstructs represented source rows.
+ */
+import type { BarParams } from "@ggsvelte/spec";
+
+import { buildCandidateStore } from "../candidate-store.js";
+import type { CandidateStore } from "../candidate-store.js";
+import { LineageStore } from "../identity.js";
+import type { Scene } from "../scene.js";
+import { bandKey } from "../scales/train.js";
+import type { CellValue } from "../table.js";
+import { cellToNumber, ColumnTable } from "../table.js";
+
+import type { FacetPanelDef } from "./facets.js";
+import { candidateAutoMode, createRawCandidateDatumResolver, deriveLayerGroups } from "./frame.js";
+import type { MappedField } from "./types.js";
+import type { LayerBinding, LayerFrame, ResolvedColorScale } from "./types.js";
+import { NO_ROW } from "./types.js";
+
+export function buildPipelineCandidates(input: {
+  scene: Scene;
+  runId: number;
+  flip: boolean;
+  bindings: readonly LayerBinding[];
+  panelFrames: readonly (readonly LayerFrame[])[];
+  facetPanels: readonly FacetPanelDef[];
+  table: ColumnTable;
+  layerFields: readonly MappedField[][];
+  color: ResolvedColorScale | null;
+  fill: ResolvedColorScale | null;
+  lineage: LineageStore<number>;
+}): CandidateStore {
+  const {
+    scene,
+    runId,
+    flip,
+    bindings,
+    panelFrames,
+    facetPanels,
+    table,
+    layerFields,
+    color,
+    fill,
+    lineage,
+  } = input;
+
+  let identityIndex: Readonly<{
+    seriesByRow: Map<string, number>;
+    sourceRowsByGroup: Map<string, number[]>;
+    frameGroups: Map<string, number[]>;
+  }> | null = null;
+  const getIdentityIndex = () => {
+    if (identityIndex !== null) return identityIndex;
+    const seriesByRow = new Map<string, number>();
+    const sourceRowsByGroup = new Map<string, number[]>();
+    const frameGroups = new Map<string, number[]>();
+    for (let panelIndex = 0; panelIndex < panelFrames.length; panelIndex++) {
+      for (const frame of panelFrames[panelIndex] ?? []) {
+        const frameKey = `${panelIndex}:${frame.binding.index}`;
+        frameGroups.set(frameKey, [...new Set(frame.groups)]);
+        const inputGroups = deriveLayerGroups(frame.binding, frame.table);
+        for (let localRow = 0; localRow < inputGroups.length; localRow++) {
+          const group = inputGroups[localRow]!;
+          const sourceRow = facetPanels[panelIndex]!.sourceRows?.[localRow] ?? localRow;
+          const key = `${frameKey}:${group}`;
+          const members = sourceRowsByGroup.get(key);
+          if (members === undefined) sourceRowsByGroup.set(key, [sourceRow]);
+          else members.push(sourceRow);
+        }
+        for (let i = 0; i < frame.rowIndex.length; i++) {
+          const sourceRow = frame.rowIndex[i]!;
+          if (sourceRow !== NO_ROW) {
+            seriesByRow.set(
+              `${panelIndex}:${frame.binding.index}:${sourceRow}`,
+              frame.groups[i] ?? 0,
+            );
+          }
+        }
+      }
+    }
+    identityIndex = { seriesByRow, sourceRowsByGroup, frameGroups };
+    return identityIndex;
+  };
+
+  const allSourceBacked = bindings.every(
+    (binding) =>
+      (binding.layer.stat ?? "identity") === "identity" && binding.ruleForm !== "annotation",
+  );
+
+  if (allSourceBacked) {
+    return buildCandidateStore(scene, {
+      epoch: runId,
+      flip,
+      datum: createRawCandidateDatumResolver(bindings, table, color, fill, lineage),
+    });
+  }
+
+  return buildCandidateStore(scene, {
+    epoch: runId,
+    flip,
+    datum(facts) {
+      const { seriesByRow, sourceRowsByGroup, frameGroups } = getIdentityIndex();
+      const fields = layerFields[facts.layerIndex] ?? [];
+      const sourceRow = facts.rowIndex;
+      const frame = panelFrames[facts.panelIndex]?.[facts.layerIndex];
+      const batch = scene.batches[facts.batchIndex]!;
+      const outlierLocalRow =
+        frame?.box !== null && frame?.binding.layer.geom === "boxplot" && batch.kind === "points"
+          ? (frame?.box.outlierRow[facts.primitiveIndex] ?? null)
+          : null;
+      const outlierSourceRow =
+        outlierLocalRow === null
+          ? null
+          : (facetPanels[facts.panelIndex]?.sourceRows?.[outlierLocalRow] ?? outlierLocalRow);
+      const orderedGroups = frameGroups.get(`${facts.panelIndex}:${facts.layerIndex}`) ?? [0];
+      let frameRow = Math.min(facts.primitiveIndex, Math.max(0, (frame?.n ?? 1) - 1));
+      let derivedGroup = frame?.groups[frameRow] ?? 0;
+      if (frame !== undefined && batch.kind === "paths") {
+        let subpath = 0;
+        while (
+          subpath + 1 < batch.pathOffsets.length &&
+          facts.primitiveIndex >= batch.pathOffsets[subpath + 1]!
+        )
+          subpath++;
+        derivedGroup = orderedGroups[Math.min(subpath, orderedGroups.length - 1)] ?? 0;
+        const rowsInGroup = frame.groups
+          .map((group, row) => ({ group, row }))
+          .filter((entry) => entry.group === derivedGroup)
+          .map((entry) => entry.row)
+          .toSorted((a, b) => (frame.xNumeric?.[a] ?? a) - (frame.xNumeric?.[b] ?? b));
+        const local = facts.primitiveIndex - (batch.pathOffsets[subpath] ?? 0);
+        const reflected =
+          local < rowsInGroup.length ? local : Math.max(0, rowsInGroup.length * 2 - 1 - local);
+        frameRow = rowsInGroup[Math.min(reflected, rowsInGroup.length - 1)] ?? frameRow;
+      } else if (frame !== undefined && batch.kind === "segments") {
+        if (frame.binding.layer.geom === "errorbar")
+          frameRow = Math.floor(facts.primitiveIndex / 3);
+        else if (frame.binding.layer.geom === "boxplot" && batch.rowIndex.length >= frame.n * 2)
+          frameRow = Math.floor(facts.primitiveIndex / 2);
+        derivedGroup = frame.groups[Math.min(frameRow, frame.groups.length - 1)] ?? derivedGroup;
+      } else if (
+        frame?.box !== null &&
+        frame?.binding.layer.geom === "boxplot" &&
+        batch.kind === "points"
+      ) {
+        frameRow = frame.box.outlierBox[facts.primitiveIndex] ?? frameRow;
+        derivedGroup = frame.groups[frameRow] ?? derivedGroup;
+      }
+      const sourceValue = (field: string | undefined): CellValue =>
+        sourceRow === null || field === undefined ? null : table.column(field)[sourceRow]!;
+      const xField = fields.find((field) => field.channel === "x")?.field;
+      const yField = fields.find((field) => field.channel === "y")?.field;
+      const colorField = fields.find((field) => field.channel === "color")?.field;
+      const fillField = fields.find((field) => field.channel === "fill")?.field;
+      const group =
+        sourceRow === null
+          ? derivedGroup
+          : (seriesByRow.get(`${facts.panelIndex}:${facts.layerIndex}:${sourceRow}`) ?? 0);
+      const ordinalRank = (resolved: ResolvedColorScale | null, field: string | undefined) => {
+        if (resolved?.kind !== "ordinal" || field === undefined || sourceRow === null) return -1;
+        const key = bandKey(sourceValue(field));
+        return resolved.scale.domain.findIndex((value) => bandKey(value) === key);
+      };
+      const colorRank = ordinalRank(color, colorField);
+      const fillRank = ordinalRank(fill, fillField);
+      const autoMode = candidateAutoMode(
+        frame?.binding ?? bindings[facts.layerIndex]!,
+        facts.primitiveIndex,
+      );
+      const annotationRule = frame?.binding.ruleForm === "annotation";
+      const annotationX = annotationRule ? (frame.xIntercepts[facts.primitiveIndex] ?? null) : null;
+      const annotationY = annotationRule
+        ? (frame.yIntercepts[facts.primitiveIndex - frame.xIntercepts.length] ?? null)
+        : null;
+      let representedRows =
+        outlierSourceRow === null
+          ? (sourceRowsByGroup.get(`${facts.panelIndex}:${facts.layerIndex}:${group}`) ?? [])
+          : [outlierSourceRow];
+      if (sourceRow === null && frame !== undefined) {
+        const stat = frame.binding.layer.stat ?? "identity";
+        const aggregateXField = frame.binding.xField;
+        const outputX = frame.xValues?.[frameRow] ?? frame.xNumeric?.[frameRow] ?? null;
+        if (
+          aggregateXField !== null &&
+          outputX !== null &&
+          (stat === "count" || stat === "summary" || stat === "boxplot")
+        ) {
+          const outputKey = bandKey(outputX);
+          representedRows = representedRows.filter(
+            (row) => bandKey(table.column(aggregateXField)[row]) === outputKey,
+          );
+        } else if (
+          stat === "bin" &&
+          aggregateXField !== null &&
+          frame.xmin !== null &&
+          frame.xmax !== null
+        ) {
+          const hi = frame.xmax[frameRow]!;
+          const lo = frame.xmin[frameRow]!;
+          const closed = ((frame.binding.layer.params ?? {}) as BarParams).closed ?? "right";
+          const frameGroup = frame.groups[frameRow];
+          const firstInGroup = frameRow === 0 || frame.groups[frameRow - 1] !== frameGroup;
+          const lastInGroup = frameRow === frame.n - 1 || frame.groups[frameRow + 1] !== frameGroup;
+          representedRows = representedRows.filter((row) => {
+            const value = cellToNumber(table.column(aggregateXField)[row]!);
+            if (!Number.isFinite(value)) return false;
+            return closed === "right"
+              ? value <= hi && (value > lo || (firstInGroup && value >= lo))
+              : value >= lo && (value < hi || (lastInGroup && value <= hi));
+          });
+        }
+        const aggregateYField = frame.binding.yField;
+        if (
+          (stat === "smooth" || stat === "summary" || stat === "boxplot") &&
+          aggregateYField !== null
+        ) {
+          representedRows = representedRows.filter((row) =>
+            Number.isFinite(cellToNumber(table.column(aggregateYField)[row]!)),
+          );
+        }
+      }
+      return {
+        xValue: annotationRule
+          ? annotationX
+          : outlierSourceRow === null
+            ? sourceRow === null
+              ? (frame?.xValues?.[frameRow] ?? frame?.xNumeric?.[frameRow] ?? null)
+              : sourceValue(xField)
+            : (frame?.box?.outlierX[facts.primitiveIndex] ?? null),
+        yValue: annotationRule
+          ? annotationY
+          : outlierSourceRow === null
+            ? sourceRow === null
+              ? (frame?.yNumeric?.[frameRow] ?? frame?.box?.middle[frameRow] ?? null)
+              : sourceValue(yField)
+            : (frame?.box?.outlierY[facts.primitiveIndex] ?? null),
+        seriesId: group,
+        seriesRank: colorRank >= 0 ? colorRank : fillRank >= 0 ? fillRank : group,
+        sourceOrder: sourceRow ?? outlierSourceRow ?? facts.primitiveIndex,
+        lineage: sourceRow === null ? lineage.intern(representedRows) : lineage.intern([sourceRow]),
+        autoMode,
+      };
+    },
+  });
+}

--- a/packages/core/src/pipeline/facets.ts
+++ b/packages/core/src/pipeline/facets.ts
@@ -15,7 +15,7 @@ import { PipelineError } from "./types.js";
 // Facet partition (BEFORE stats/positions — plan round-2 consensus)
 // ---------------------------------------------------------------------------
 
-interface FacetPanelDef {
+export interface FacetPanelDef {
   /** Stable facet field/value identity; independent of display position. */
   id: string;
   /** Strip label ("" = no strip; the unfaceted single panel). */

--- a/packages/core/src/pipeline/layer-contracts.ts
+++ b/packages/core/src/pipeline/layer-contracts.ts
@@ -1,0 +1,88 @@
+/**
+ * Per-layer pipeline contracts: render backends, tooltip field maps, and
+ * scaled-constant values used by legend-focus indexing.
+ */
+import type { LayerSpec } from "@ggsvelte/spec";
+
+import type { GeometryBatch } from "../scene.js";
+import type { CellValue } from "../table.js";
+
+import { batchMarkCount } from "./geometry.js";
+import type { Advisory, LayerBackend, LayerBinding, MappedField } from "./types.js";
+import { CANVAS_AUTO_THRESHOLD } from "./types.js";
+
+export function resolveLayerBackends(
+  layers: readonly LayerSpec[],
+  batches: readonly GeometryBatch[],
+  a11y: "auto" | "force-svg" | undefined,
+  canvasThreshold: number | undefined,
+  advisories: Advisory[],
+): LayerBackend[] {
+  const threshold = canvasThreshold ?? CANVAS_AUTO_THRESHOLD;
+  const marksPerLayer: number[] = layers.map(() => 0);
+  for (const batch of batches) {
+    marksPerLayer[batch.layerIndex] =
+      (marksPerLayer[batch.layerIndex] ?? 0) + batchMarkCount(batch);
+  }
+  return layers.map((layer, index) => {
+    if (a11y === "force-svg") return "svg";
+    const hint = ("render" in layer ? layer.render : undefined) ?? "auto";
+    if (hint === "svg" || hint === "canvas") return hint;
+    if ((marksPerLayer[index] ?? 0) > threshold) {
+      advisories.push({
+        code: "canvas-auto",
+        path: `layers.${index}`,
+        chosen: `canvas backend (${marksPerLayer[index]} marks > threshold ${threshold}; canvas marks do not expose per-mark accessibility or "copy SVG")`,
+        howToOverride: `Set layers[${index}].render to "svg" (or "canvas" to silence this), or set a11y: "force-svg" on the plot.`,
+      });
+      return "canvas";
+    }
+    return "svg";
+  });
+}
+
+export function resolveLayerFields(bindings: readonly LayerBinding[]): MappedField[][] {
+  return bindings.map((binding) => {
+    const fields: MappedField[] = [];
+    const push = (channel: string, field: string | null, source?: "stat") => {
+      if (field !== null)
+        fields.push(source === undefined ? { channel, field } : { channel, field, source });
+    };
+    const stat = binding.layer.stat ?? "identity";
+    if (stat === "identity") {
+      push("x", binding.xField);
+      push("y", binding.yField);
+    } else {
+      // Synthesized stat rows have no source row. Advertise only semantic
+      // generated channels that CandidateFacts can resolve truthfully.
+      if (binding.xField !== null) push("x", "x", "stat");
+      if (stat === "count" || stat === "bin" || stat === "density") {
+        push("y", binding.yStatColumn ?? (stat === "density" ? "density" : "count"), "stat");
+      } else if (stat === "boxplot") {
+        push("y", "middle", "stat");
+      } else if (stat === "smooth" || stat === "summary") {
+        push("y", "y", "stat");
+      }
+    }
+    push("ymin", binding.yminField);
+    push("ymax", binding.ymaxField);
+    push("color", binding.color.field);
+    push("fill", binding.fill.field);
+    push("label", binding.labelField);
+    push("weight", binding.weightField);
+    return fields;
+  });
+}
+
+export function resolveLayerScaledConstants(
+  bindings: readonly LayerBinding[],
+): ReadonlyArray<Readonly<Partial<Record<string, CellValue>>>> {
+  return Object.freeze(
+    bindings.map((binding) => {
+      const out: Partial<Record<string, CellValue>> = {};
+      if (binding.color.scaledConstant !== null) out["color"] = binding.color.scaledConstant;
+      if (binding.fill.scaledConstant !== null) out["fill"] = binding.fill.scaledConstant;
+      return Object.freeze(out);
+    }),
+  );
+}

--- a/packages/core/src/pipeline/layer-contracts.ts
+++ b/packages/core/src/pipeline/layer-contracts.ts
@@ -41,8 +41,18 @@ export function resolveLayerBackends(
   });
 }
 
-export function resolveLayerFields(bindings: readonly LayerBinding[]): MappedField[][] {
-  return bindings.map((binding) => {
+/**
+ * One entry per declared layer index. When bindings are shorter (empty data
+ * skips bindLayer), missing indices yield empty field maps so layer-indexed
+ * consumers stay aligned with `normalized.layers` / `layerBackends`.
+ */
+export function resolveLayerFields(
+  layerCount: number,
+  bindings: readonly LayerBinding[],
+): MappedField[][] {
+  return Array.from({ length: layerCount }, (_, index) => {
+    const binding = bindings[index];
+    if (binding === undefined) return [];
     const fields: MappedField[] = [];
     const push = (channel: string, field: string | null, source?: "stat") => {
       if (field !== null)
@@ -74,11 +84,17 @@ export function resolveLayerFields(bindings: readonly LayerBinding[]): MappedFie
   });
 }
 
+/**
+ * One entry per declared layer index (same empty-data padding as fields).
+ */
 export function resolveLayerScaledConstants(
+  layerCount: number,
   bindings: readonly LayerBinding[],
 ): ReadonlyArray<Readonly<Partial<Record<string, CellValue>>>> {
   return Object.freeze(
-    bindings.map((binding) => {
+    Array.from({ length: layerCount }, (_, index) => {
+      const binding = bindings[index];
+      if (binding === undefined) return Object.freeze({});
       const out: Partial<Record<string, CellValue>> = {};
       if (binding.color.scaledConstant !== null) out["color"] = binding.color.scaledConstant;
       if (binding.fill.scaledConstant !== null) out["fill"] = binding.fill.scaledConstant;

--- a/packages/core/src/pipeline/panel-layout.ts
+++ b/packages/core/src/pipeline/panel-layout.ts
@@ -1,0 +1,282 @@
+/**
+ * Two-pass panel layout: facet grids and single-panel plots, including
+ * axis-title/legend chrome and free-scale edge axes.
+ */
+import type { PortableSpec } from "@ggsvelte/spec";
+
+import { FONT_METRICS } from "../layout/font-metrics.js";
+import type { LayoutResult, Margins, PassResult, TickFormatter } from "../layout/layout.js";
+import { DEFAULT_LAYOUT_THEME, layout, layoutPass } from "../layout/layout.js";
+import { MetricsTableMeasurer } from "../layout/measure.js";
+import type { LegendInput, LegendOrder } from "../legend.js";
+import { buildLegends } from "../legend.js";
+import type { PositionScale } from "../scales/train.js";
+import { PANEL_SPACING, STRIP_BAND } from "../scene.js";
+import type { ThemeTokens } from "../theme.js";
+
+import type { FacetPanelDef } from "./facets.js";
+import {
+  AXIS_TITLE_BAND,
+  CAPTION_BAND,
+  LEGEND_EDGE_PAD,
+  LEGEND_GAP,
+  SUBTITLE_BAND,
+  TITLE_BAND,
+  elementwiseMaxMargins,
+  layoutDomain,
+  makeAxisFormatter,
+} from "./layout-helpers.js";
+import type { LayerFrame, PipelineWarning, RunOptions } from "./types.js";
+
+export interface PanelPlacement {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  ticksH: LayoutResult["x"]["ticks"];
+  ticksV: LayoutResult["y"]["ticks"];
+  showAxisX: boolean;
+  showAxisY: boolean;
+}
+
+export interface PanelLayoutResult {
+  placements: PanelPlacement[];
+  title: string;
+  subtitle: string;
+  caption: string;
+  hTitle: string;
+  vTitle: string;
+  xTitle: string;
+  yTitle: string;
+  topBand: number;
+  formatX: TickFormatter | undefined;
+  formatY: TickFormatter | undefined;
+  displayScales: (p: number) => { h: PositionScale; v: PositionScale };
+  legendBlock: ReturnType<typeof buildLegends>;
+}
+
+export function computePanelLayout(input: {
+  flip: boolean;
+  faceted: boolean;
+  freeX: boolean;
+  freeY: boolean;
+  nrow: number;
+  ncol: number;
+  facetPanels: readonly FacetPanelDef[];
+  panelScales: readonly { x: PositionScale; y: PositionScale }[];
+  allFrames: readonly LayerFrame[];
+  labs: NonNullable<PortableSpec["labs"]>;
+  scalesConfig: NonNullable<PortableSpec["scales"]>;
+  xScale: PositionScale;
+  yScale: PositionScale;
+  colorLegend: LegendInput | null;
+  fillLegend: LegendInput | null;
+  legendOrder: LegendOrder;
+  theme: ThemeTokens;
+  options: Pick<RunOptions, "width" | "height" | "measureText">;
+  warnings: PipelineWarning[];
+}): PanelLayoutResult {
+  const {
+    flip,
+    faceted,
+    freeX,
+    freeY,
+    nrow,
+    ncol,
+    facetPanels,
+    panelScales,
+    allFrames,
+    labs,
+    scalesConfig,
+    xScale,
+    yScale,
+    theme,
+    options,
+    warnings,
+  } = input;
+
+  const title = labs.title ?? "";
+  const subtitle = labs.subtitle ?? "";
+  const caption = labs.caption ?? "";
+  const xTitle = labs.x ?? allFrames.find((f) => f.binding.xField !== null)?.binding.xField ?? "";
+  const yTitle =
+    labs.y ??
+    allFrames.find((f) => f.binding.yField !== null)?.binding.yField ??
+    allFrames.find((f) => f.binding.yStatColumn !== null)?.binding.yStatColumn ??
+    "";
+  const titleBand = Math.max(TITLE_BAND, theme.titleSize + 7);
+  const subtitleBand = Math.max(SUBTITLE_BAND, theme.subtitleSize + 4);
+  const captionBand = Math.max(CAPTION_BAND, theme.captionSize + 5);
+  const axisTitleBand = Math.max(AXIS_TITLE_BAND, theme.axisTitleSize + 9);
+  const topBand = (title === "" ? 0 : titleBand) + (subtitle === "" ? 0 : subtitleBand);
+  const bottomBand = caption === "" ? 0 : captionBand;
+
+  const hTitle = flip ? yTitle : xTitle;
+  const vTitle = flip ? xTitle : yTitle;
+  const formatX = makeAxisFormatter("x", xScale, scalesConfig.x, warnings);
+  const formatY = makeAxisFormatter("y", yScale, scalesConfig.y, warnings);
+  const formatH = flip ? formatY : formatX;
+  const formatV = flip ? formatX : formatY;
+  const hBreaks = flip ? scalesConfig.y?.breaks : scalesConfig.x?.breaks;
+  const vBreaks = flip ? scalesConfig.x?.breaks : scalesConfig.y?.breaks;
+  const freeH = flip ? freeY : freeX;
+  const freeV = flip ? freeX : freeY;
+  const displayScales = (p: number): { h: PositionScale; v: PositionScale } => {
+    const s = panelScales[p]!;
+    return flip ? { h: s.y, v: s.x } : { h: s.x, v: s.y };
+  };
+
+  const measurer = options.measureText ?? new MetricsTableMeasurer(FONT_METRICS);
+  const layoutTheme = {
+    ...DEFAULT_LAYOUT_THEME,
+    fontSize: theme.axisTextSize,
+    tickLength: theme.ticksX || theme.ticksY ? theme.tickLength : 0,
+    tickLabelGap: theme.ticksX || theme.ticksY ? 3 : 5,
+  };
+  const legendInputs = [input.colorLegend, input.fillLegend].filter(
+    (l): l is LegendInput => l !== null,
+  );
+  const legendBlock = buildLegends(
+    legendInputs,
+    input.legendOrder,
+    measurer,
+    Math.max(48, options.width * 0.35),
+  );
+
+  const layoutHeight = Math.max(40, options.height - topBand - bottomBand);
+  const placements: PanelPlacement[] = [];
+
+  if (faceted) {
+    const spacing = PANEL_SPACING;
+    const strip = STRIP_BAND;
+    const outerLeft = vTitle === "" ? 0 : axisTitleBand;
+    const outerBottom = hTitle === "" ? 0 : axisTitleBand;
+    const outerRight = legendBlock.width > 0 ? legendBlock.width + LEGEND_GAP + LEGEND_EDGE_PAD : 0;
+    const gridW = Math.max(40, options.width - outerLeft - outerRight);
+    const gridH = Math.max(40, layoutHeight - outerBottom);
+
+    const approxW = Math.max(40, (gridW - (ncol - 1) * spacing) / ncol);
+    const approxH = Math.max(40, (gridH - nrow * strip - (nrow - 1) * spacing) / nrow);
+    let mMax: Margins = { top: 0, right: 0, bottom: 0, left: 0 };
+    for (let p = 0; p < facetPanels.length; p++) {
+      const { h, v } = displayScales(p);
+      const run = layout({
+        width: approxW,
+        height: approxH,
+        x: layoutDomain(h, hBreaks),
+        y: layoutDomain(v, vBreaks),
+        ...(formatH !== undefined && { formatX: formatH }),
+        ...(formatV !== undefined && { formatY: formatV }),
+        measurer,
+        theme: layoutTheme,
+      });
+      mMax = elementwiseMaxMargins(mMax, run.margins);
+    }
+
+    const leftCount = freeV ? ncol : 1;
+    const bottomCount = freeH ? nrow : 1;
+    const panelW = Math.max(
+      1,
+      (gridW - leftCount * mMax.left - mMax.right - (ncol - 1) * spacing) / ncol,
+    );
+    const panelH = Math.max(
+      1,
+      (gridH - mMax.top - bottomCount * mMax.bottom - nrow * strip - (nrow - 1) * spacing) / nrow,
+    );
+
+    const colX: number[] = [];
+    let xCursor = outerLeft;
+    for (let c = 0; c < ncol; c++) {
+      if (c === 0 || freeV) xCursor += mMax.left;
+      colX.push(xCursor);
+      xCursor += panelW + spacing;
+    }
+    const rowY: number[] = [];
+    let yCursor = topBand + mMax.top;
+    for (let r = 0; r < nrow; r++) {
+      yCursor += strip;
+      rowY.push(yCursor);
+      yCursor += panelH;
+      if (r === nrow - 1 || freeH) yCursor += mMax.bottom;
+      yCursor += spacing;
+    }
+
+    const bottomMostRow: number[] = Array.from({ length: ncol }, () => 0);
+    for (const def of facetPanels) {
+      if (def.row > bottomMostRow[def.col]!) bottomMostRow[def.col] = def.row;
+    }
+
+    for (let p = 0; p < facetPanels.length; p++) {
+      const def = facetPanels[p]!;
+      const { h, v } = displayScales(p);
+      const ticksRun: PassResult = layoutPass(
+        mMax,
+        {
+          width: panelW + mMax.left + mMax.right,
+          height: panelH + mMax.top + mMax.bottom,
+          x: layoutDomain(h, hBreaks),
+          y: layoutDomain(v, vBreaks),
+          ...(formatH !== undefined && { formatX: formatH }),
+          ...(formatV !== undefined && { formatY: formatV }),
+          measurer,
+        },
+        layoutTheme,
+      );
+      placements.push({
+        x: colX[def.col]!,
+        y: rowY[def.row]!,
+        width: panelW,
+        height: panelH,
+        ticksH: ticksRun.x.ticks,
+        ticksV: ticksRun.y.ticks,
+        showAxisX: freeH || def.row === bottomMostRow[def.col]!,
+        showAxisY: freeV || def.col === 0,
+      });
+    }
+  } else {
+    const { h, v } = displayScales(0);
+    const reserve: Partial<Margins> = {
+      ...(hTitle !== "" && { bottom: axisTitleBand }),
+      ...(vTitle !== "" && { left: axisTitleBand }),
+      ...(legendBlock.width > 0 && { right: legendBlock.width + LEGEND_GAP + LEGEND_EDGE_PAD }),
+    };
+    const layoutResult = layout({
+      width: options.width,
+      height: layoutHeight,
+      x: layoutDomain(h, hBreaks),
+      y: layoutDomain(v, vBreaks),
+      ...(formatH !== undefined && { formatX: formatH }),
+      ...(formatV !== undefined && { formatY: formatV }),
+      measurer,
+      reserve,
+      theme: layoutTheme,
+    });
+    const margins = layoutResult.margins;
+    placements.push({
+      x: margins.left,
+      y: topBand + margins.top,
+      width: Math.max(1, options.width - margins.left - margins.right),
+      height: Math.max(1, layoutHeight - margins.top - margins.bottom),
+      ticksH: layoutResult.x.ticks,
+      ticksV: layoutResult.y.ticks,
+      showAxisX: true,
+      showAxisY: true,
+    });
+  }
+
+  return {
+    placements,
+    title,
+    subtitle,
+    caption,
+    hTitle,
+    vTitle,
+    xTitle,
+    yTitle,
+    topBand,
+    formatX,
+    formatY,
+    displayScales,
+    legendBlock,
+  };
+}

--- a/packages/core/tests/pipeline-layer-contracts.test.ts
+++ b/packages/core/tests/pipeline-layer-contracts.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Characterization tests for per-layer pipeline contracts: backends,
+ * tooltip field maps, and scaled-constant legend-focus values.
+ */
+import { describe, expect, it } from "bun:test";
+
+import {
+  resolveLayerBackends,
+  resolveLayerFields,
+  resolveLayerScaledConstants,
+} from "../src/pipeline/layer-contracts.ts";
+import { bindLayer } from "../src/pipeline/bind.ts";
+import type { Advisory } from "../src/pipeline/types.ts";
+import { ColumnTable } from "../src/table.ts";
+import type { GeometryBatch } from "../src/scene.ts";
+import type { LayerSpec } from "@ggsvelte/spec";
+
+const table = ColumnTable.fromRows([
+  { x: 1, y: 10, g: "a" },
+  { x: 2, y: 20, g: "b" },
+]);
+
+function pointLayers(): LayerSpec[] {
+  return [{ geom: "point", aes: { x: { field: "x" }, y: { field: "y" } } }];
+}
+
+function emptyPoints(n: number, layerIndex = 0): GeometryBatch {
+  return {
+    kind: "points",
+    layerIndex,
+    panelIndex: 0,
+    positions: new Float32Array(n * 2),
+    rowIndex: new Uint32Array(n),
+    size: 2,
+    alpha: 1,
+    shape: "circle",
+    fill: null,
+  };
+}
+
+describe("resolveLayerBackends", () => {
+  it("defaults auto layers under threshold to svg", () => {
+    const advisories: Advisory[] = [];
+    const backends = resolveLayerBackends(
+      pointLayers(),
+      [emptyPoints(10)],
+      undefined,
+      2000,
+      advisories,
+    );
+    expect(backends).toEqual(["svg"]);
+    expect(advisories).toHaveLength(0);
+  });
+
+  it("auto-switches to canvas above threshold with advisory", () => {
+    const advisories: Advisory[] = [];
+    const backends = resolveLayerBackends(
+      pointLayers(),
+      [emptyPoints(50)],
+      undefined,
+      10,
+      advisories,
+    );
+    expect(backends).toEqual(["canvas"]);
+    expect(advisories.some((a) => a.code === "canvas-auto")).toBe(true);
+  });
+
+  it("force-svg overrides canvas auto", () => {
+    const advisories: Advisory[] = [];
+    const backends = resolveLayerBackends(
+      pointLayers(),
+      [emptyPoints(50)],
+      "force-svg",
+      10,
+      advisories,
+    );
+    expect(backends).toEqual(["svg"]);
+    expect(advisories).toHaveLength(0);
+  });
+
+  it("honors explicit render hints", () => {
+    const layers: LayerSpec[] = [
+      { geom: "point", aes: { x: { field: "x" }, y: { field: "y" } }, render: "canvas" },
+    ];
+    expect(resolveLayerBackends(layers, [emptyPoints(1)], undefined, 2000, [])).toEqual(["canvas"]);
+  });
+});
+
+describe("resolveLayerFields", () => {
+  it("maps identity field channels for tooltips", () => {
+    const binding = bindLayer(
+      { geom: "point", aes: { x: { field: "x" }, y: { field: "y" }, color: { field: "g" } } },
+      0,
+      table,
+      [],
+    );
+    const fields = resolveLayerFields([binding]);
+    expect(fields[0]!.map((f) => `${f.channel}:${f.field}`)).toEqual(
+      expect.arrayContaining(["x:x", "y:y", "color:g"]),
+    );
+  });
+
+  it("marks count-stat y as stat source", () => {
+    const binding = bindLayer(
+      {
+        geom: "bar",
+        aes: { x: { field: "g" }, y: { stat: "count" } },
+        stat: "count",
+      },
+      0,
+      table,
+      [],
+    );
+    const fields = resolveLayerFields([binding])[0]!;
+    const y = fields.find((f) => f.channel === "y");
+    expect(y?.field).toBe("count");
+    expect(y?.source).toBe("stat");
+  });
+});
+
+describe("resolveLayerScaledConstants", () => {
+  it("captures scaled constant color/fill values", () => {
+    const binding = bindLayer(
+      {
+        geom: "point",
+        aes: {
+          x: { field: "x" },
+          y: { field: "y" },
+          color: { value: "steelblue", scale: true },
+        },
+      },
+      0,
+      table,
+      [],
+    );
+    const constants = resolveLayerScaledConstants([binding]);
+    expect(constants[0]?.["color"]).toBe("steelblue");
+  });
+});

--- a/packages/core/tests/pipeline-layer-contracts.test.ts
+++ b/packages/core/tests/pipeline-layer-contracts.test.ts
@@ -94,7 +94,7 @@ describe("resolveLayerFields", () => {
       table,
       [],
     );
-    const fields = resolveLayerFields([binding]);
+    const fields = resolveLayerFields(1, [binding]);
     expect(fields[0]!.map((f) => `${f.channel}:${f.field}`)).toEqual(
       expect.arrayContaining(["x:x", "y:y", "color:g"]),
     );
@@ -111,10 +111,17 @@ describe("resolveLayerFields", () => {
       table,
       [],
     );
-    const fields = resolveLayerFields([binding])[0]!;
+    const fields = resolveLayerFields(1, [binding])[0]!;
     const y = fields.find((f) => f.channel === "y");
     expect(y?.field).toBe("count");
     expect(y?.source).toBe("stat");
+  });
+
+  it("pads empty bindings to declared layer count (empty-data contract)", () => {
+    const fields = resolveLayerFields(2, []);
+    expect(fields).toHaveLength(2);
+    expect(fields[0]).toEqual([]);
+    expect(fields[1]).toEqual([]);
   });
 });
 
@@ -133,7 +140,14 @@ describe("resolveLayerScaledConstants", () => {
       table,
       [],
     );
-    const constants = resolveLayerScaledConstants([binding]);
+    const constants = resolveLayerScaledConstants(1, [binding]);
     expect(constants[0]?.["color"]).toBe("steelblue");
+  });
+
+  it("pads empty bindings to declared layer count (empty-data contract)", () => {
+    const constants = resolveLayerScaledConstants(2, []);
+    expect(constants).toHaveLength(2);
+    expect(constants[0]).toEqual({});
+    expect(constants[1]).toEqual({});
   });
 });

--- a/packages/core/tests/pipeline-layer-contracts.test.ts
+++ b/packages/core/tests/pipeline-layer-contracts.test.ts
@@ -95,9 +95,10 @@ describe("resolveLayerFields", () => {
       [],
     );
     const fields = resolveLayerFields(1, [binding]);
-    expect(fields[0]!.map((f) => `${f.channel}:${f.field}`)).toEqual(
-      expect.arrayContaining(["x:x", "y:y", "color:g"]),
-    );
+    const labels = fields[0]!.map((f) => `${f.channel}:${f.field}`);
+    expect(labels).toContain("x:x");
+    expect(labels).toContain("y:y");
+    expect(labels).toContain("color:g");
   });
 
   it("marks count-stat y as stat source", () => {

--- a/packages/core/tests/pipeline-panel-layout.test.ts
+++ b/packages/core/tests/pipeline-panel-layout.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Characterization tests for panel layout placement contracts.
+ */
+import { describe, expect, it } from "bun:test";
+
+import { aes, gg } from "@ggsvelte/spec";
+
+import { runPipeline } from "../src/pipeline.ts";
+import { STRIP_BAND } from "../src/scene.ts";
+
+const size = { width: 640, height: 400 };
+
+describe("panel layout via runPipeline", () => {
+  it("single panel fills the plot interior with both axes", () => {
+    const model = runPipeline(
+      gg(
+        [
+          { x: 1, y: 10 },
+          { x: 2, y: 20 },
+        ],
+        aes({ x: "x", y: "y" }),
+      )
+        .geomPoint()
+        .spec(),
+      size,
+    );
+    expect(model.scene.panels).toHaveLength(1);
+    const p = model.scene.panels[0]!;
+    expect(p.width).toBeGreaterThan(200);
+    expect(p.height).toBeGreaterThan(150);
+    expect(p.axisX).not.toBeNull();
+    expect(p.axisY).not.toBeNull();
+  });
+
+  it("facet wrap places panels on a grid with strips", () => {
+    const model = runPipeline(
+      gg(
+        [
+          { x: 1, y: 1, g: "a" },
+          { x: 2, y: 2, g: "b" },
+          { x: 3, y: 3, g: "c" },
+        ],
+        aes({ x: "x", y: "y" }),
+      )
+        .geomPoint()
+        .facet({ wrap: "g" })
+        .spec(),
+      size,
+    );
+    expect(model.scene.panels).toHaveLength(3);
+    expect(model.scene.panels.map((p) => p.strip).toSorted()).toEqual(["a", "b", "c"]);
+    // strips reserve a band above panels
+    expect(model.scene.panels[0]!.y).toBeGreaterThanOrEqual(STRIP_BAND);
+  });
+});


### PR DESCRIPTION
## Summary

After earlier modularization, `pipeline.ts` was still a ~950-line `runPipeline` with large inlined phases. This PR peels the remaining heavy stages into focused modules:

- `pipeline/panel-layout.ts` — two-pass facet/single-panel layout + legend chrome
- `pipeline/assemble-scene.ts` — geometry batches + Scene assembly
- `pipeline/layer-contracts.ts` — backends, tooltip fields, scaled constants
- `pipeline/build-candidates.ts` — interaction candidate store construction

`pipeline.ts` is now a thin orchestrator (~450 lines). Public re-exports are unchanged.

## Test plan

- [x] Characterization tests for backends / fields / scaled constants (including empty-data layer-index padding)
- [x] Layout placement regression via `runPipeline` (single + facet wrap)
- [x] `bun run check` + `bun test packages/core` (436 pass)
- [x] Pre-push gate (knip, type-aware oxlint, svelte-check, monorepo tests)

## Notes

Behavior-preserving extract. One empty-data layer-index contract regression was caught in pre-PR review and fixed with tests.