### PR TITLE
refactor(svelte): extract tool-rail and tooltip viewport pure helpers

### DIFF
--- a/packages/svelte/src/lib/GGPlot.svelte
+++ b/packages/svelte/src/lib/GGPlot.svelte
@@ -155,6 +155,7 @@
     isNarrowToolsWidth,
     plotRootInlineStyle,
     resolveClearLegendX,
+    tooltipViewportSize,
   } from "./plot-layout.js";
   import {
     bestDirectionalIndex,
@@ -172,6 +173,7 @@
     legendFocusDiscreteOnlyDiagnostics,
     resolveChooseToolAction,
     resolveEffectiveTool,
+    shouldShowToolRail,
     zoomScaleDiagnosticsFromChannels,
     zoomSupportsChannel,
   } from "./plot-capability.js";
@@ -714,12 +716,21 @@
   const canPublishPointSelection = $derived(
     interactionConfig.select?.type === "point",
   );
+  // Shared by tool-rail visibility and ToolRail recovery props (avoid dual calc).
+  const hasPointSelection = $derived(
+    canPublishPointSelection && effectiveSelectedKeys.length > 0,
+  );
+  const hasIntervalSelection = $derived(committedInterval !== null);
+  const hasZoomDomains = $derived(effectiveZoomDomains !== null);
   const showToolRail = $derived(
-    interactive &&
-      (availableTools.length > 1 ||
-        (canPublishPointSelection && effectiveSelectedKeys.length > 0) ||
-        committedInterval !== null ||
-        effectiveZoomDomains !== null),
+    shouldShowToolRail({
+      interactive,
+      availableToolCount: availableTools.length,
+      canPublishPointSelection,
+      selectedKeyCount: effectiveSelectedKeys.length,
+      hasIntervalSelection,
+      hasZoomDomains,
+    }),
   );
   const emptyPlot = $derived(
     model !== null &&
@@ -2280,9 +2291,8 @@
       {emptyPlot}
       narrow={isNarrowToolsWidth(resolvedWidth)}
       zoomDomains={effectiveZoomDomains}
-      hasPointSelection={canPublishPointSelection &&
-        effectiveSelectedKeys.length > 0}
-      hasIntervalSelection={committedInterval !== null}
+      {hasPointSelection}
+      {hasIntervalSelection}
       onChooseTool={chooseTool}
       onResetZoom={() => resetZoom("pointer")}
       onClearPointSelection={() => {
@@ -2398,17 +2408,17 @@
         {onDblClick}
       />
       {#if inspection !== null}
+        {@const tooltipSize = tooltipViewportSize({
+          sceneWidth: model.scene.width,
+          sceneHeight: model.scene.height,
+          clientWidth: root?.clientWidth,
+          clientHeight: root?.clientHeight,
+        })}
         <Tooltip
           id={`${plotId}-tooltip`}
           {inspection}
-          width={Math.min(
-            model.scene.width,
-            root?.clientWidth ?? model.scene.width,
-          )}
-          height={Math.min(
-            model.scene.height,
-            root?.clientHeight ?? model.scene.height,
-          )}
+          width={tooltipSize.width}
+          height={tooltipSize.height}
           content={interactionConfig.inspect?.content}
           interactive={interactionConfig.inspect?.contentMode === "interactive"}
           docked={inspection.state === "pinned" &&

--- a/packages/svelte/src/lib/plot-capability.ts
+++ b/packages/svelte/src/lib/plot-capability.ts
@@ -38,6 +38,30 @@ export type ChooseToolAction =
   | { readonly type: "request" }
   | { readonly type: "apply" };
 
+export type ShowToolRailInput = {
+  readonly interactive: boolean;
+  readonly availableToolCount: number;
+  /** Host: `interactionConfig.select?.type === "point"`. */
+  readonly canPublishPointSelection: boolean;
+  readonly selectedKeyCount: number;
+  readonly hasIntervalSelection: boolean;
+  readonly hasZoomDomains: boolean;
+};
+
+/**
+ * Whether the tool rail chrome should mount.
+ * Multi-tool mode, or any recovery control (point clear / interval clear / zoom reset).
+ */
+export function shouldShowToolRail(input: ShowToolRailInput): boolean {
+  return (
+    input.interactive &&
+    (input.availableToolCount > 1 ||
+      (input.canPublishPointSelection && input.selectedKeyCount > 0) ||
+      input.hasIntervalSelection ||
+      input.hasZoomDomains)
+  );
+}
+
 /**
  * Pure routing for host `chooseTool`.
  *

--- a/packages/svelte/src/lib/plot-layout.ts
+++ b/packages/svelte/src/lib/plot-layout.ts
@@ -1,7 +1,7 @@
 /**
  * Pure plot-root layout chrome: inline size/theme style, responsive
- * breakpoint helpers, and legend clear-control anchor lookup.
- * Hosts own class bindings and tool-rail visibility.
+ * breakpoint helpers, tooltip viewport clamp, and legend clear-control
+ * anchor lookup. Hosts own class bindings and tool-rail visibility.
  */
 
 const NARROW_TOOLS_MAX_WIDTH_PX = 560;
@@ -18,6 +18,30 @@ export function isNarrowToolsWidth(widthPx: number): boolean {
  */
 export function isDockedTooltipWidth(widthPx: number): boolean {
   return widthPx < DOCKED_TOOLTIP_MAX_WIDTH_PX;
+}
+
+export type TooltipViewportSizeInput = {
+  readonly sceneWidth: number;
+  readonly sceneHeight: number;
+  /** Host: `root?.clientWidth` — nullish falls back to scene; 0 is kept. */
+  readonly clientWidth: number | null | undefined;
+  /** Host: `root?.clientHeight` — nullish falls back to scene; 0 is kept. */
+  readonly clientHeight: number | null | undefined;
+};
+
+/**
+ * Tooltip layout box: min(scene, client) per axis.
+ * Uses nullish coalesce so a laid-out zero client size does not fall back
+ * to the scene (matches historical `root?.clientWidth ?? sceneWidth`).
+ */
+export function tooltipViewportSize(input: TooltipViewportSizeInput): {
+  readonly width: number;
+  readonly height: number;
+} {
+  return {
+    width: Math.min(input.sceneWidth, input.clientWidth ?? input.sceneWidth),
+    height: Math.min(input.sceneHeight, input.clientHeight ?? input.sceneHeight),
+  };
 }
 
 export type PlotRootStyleInput = {

--- a/packages/svelte/tests/plot-capability.test.ts
+++ b/packages/svelte/tests/plot-capability.test.ts
@@ -7,6 +7,7 @@ import {
   legendFocusDiscreteOnlyDiagnostics,
   resolveChooseToolAction,
   resolveEffectiveTool,
+  shouldShowToolRail,
   zoomScaleDiagnosticsFromChannels,
   zoomSupportsChannel,
 } from "../src/lib/plot-capability.js";
@@ -209,6 +210,66 @@ describe("capabilityStatusText", () => {
         candidateCount: 0,
       }),
     ).toBeNull();
+  });
+});
+
+describe("shouldShowToolRail", () => {
+  const base = {
+    interactive: true,
+    availableToolCount: 1,
+    canPublishPointSelection: false,
+    selectedKeyCount: 0,
+    hasIntervalSelection: false,
+    hasZoomDomains: false,
+  } as const;
+
+  it("is false when interaction is disabled regardless of recovery state", () => {
+    expect(
+      shouldShowToolRail({
+        ...base,
+        interactive: false,
+        availableToolCount: 4,
+        hasIntervalSelection: true,
+        hasZoomDomains: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("is false for a single tool with no selection or zoom recovery", () => {
+    expect(shouldShowToolRail(base)).toBe(false);
+  });
+
+  it("is true when more than one tool is available", () => {
+    expect(shouldShowToolRail({ ...base, availableToolCount: 2 })).toBe(true);
+  });
+
+  it("is true only when point selection is publishable and non-empty", () => {
+    expect(
+      shouldShowToolRail({
+        ...base,
+        canPublishPointSelection: true,
+        selectedKeyCount: 1,
+      }),
+    ).toBe(true);
+    expect(
+      shouldShowToolRail({
+        ...base,
+        canPublishPointSelection: true,
+        selectedKeyCount: 0,
+      }),
+    ).toBe(false);
+    expect(
+      shouldShowToolRail({
+        ...base,
+        canPublishPointSelection: false,
+        selectedKeyCount: 3,
+      }),
+    ).toBe(false);
+  });
+
+  it("is true when an interval selection or zoom domains are present", () => {
+    expect(shouldShowToolRail({ ...base, hasIntervalSelection: true })).toBe(true);
+    expect(shouldShowToolRail({ ...base, hasZoomDomains: true })).toBe(true);
   });
 });
 

--- a/packages/svelte/tests/plot-layout.test.ts
+++ b/packages/svelte/tests/plot-layout.test.ts
@@ -5,6 +5,7 @@ import {
   isNarrowToolsWidth,
   plotRootInlineStyle,
   resolveClearLegendX,
+  tooltipViewportSize,
 } from "../src/lib/plot-layout.js";
 
 describe("breakpoint helpers", () => {
@@ -78,6 +79,42 @@ describe("plotRootInlineStyle", () => {
         themeStyle: "--t:1",
       }),
     ).toBe("width:100%;height:400px;--t:1");
+  });
+});
+
+describe("tooltipViewportSize", () => {
+  it("falls back to scene dims when client dims are nullish", () => {
+    expect(
+      tooltipViewportSize({
+        sceneWidth: 640,
+        sceneHeight: 400,
+        clientWidth: undefined,
+        clientHeight: null,
+      }),
+    ).toEqual({ width: 640, height: 400 });
+  });
+
+  it("clamps to the smaller of scene and client per axis", () => {
+    expect(
+      tooltipViewportSize({
+        sceneWidth: 640,
+        sceneHeight: 400,
+        clientWidth: 320,
+        clientHeight: 500,
+      }),
+    ).toEqual({ width: 320, height: 400 });
+  });
+
+  it("preserves zero client dims via nullish coalesce (not ||)", () => {
+    // root?.clientWidth ?? scene — laid-out zero must not fall back to scene.
+    expect(
+      tooltipViewportSize({
+        sceneWidth: 640,
+        sceneHeight: 400,
+        clientWidth: 0,
+        clientHeight: 0,
+      }),
+    ).toEqual({ width: 0, height: 0 });
   });
 });
 


### PR DESCRIPTION
## Summary

- Extract `shouldShowToolRail` into `plot-capability.ts` so tool-rail mount logic is unit-tested without host state.
- Extract `tooltipViewportSize` into `plot-layout.ts`, preserving `??` semantics so a laid-out zero client size does not fall back to the scene.
- Hoist shared `hasPointSelection` / `hasIntervalSelection` / `hasZoomDomains` deriveds in GGPlot so ToolRail recovery props and rail visibility no longer recompute the same predicates.

## Test plan

- [x] `vitest run tests/plot-capability.test.ts tests/plot-layout.test.ts` (chromium/webkit/firefox)
- [x] Type-aware oxlint clean
- [x] Pre-push package build / svelte-check / knip / bun test