### PR TITLE
refactor(svelte): extract PlotSceneOverlays and capture aria helper

### DIFF
--- a/packages/svelte/src/lib/GGPlot.svelte
+++ b/packages/svelte/src/lib/GGPlot.svelte
@@ -92,7 +92,6 @@
   } from "./inspection-resolver.js";
   import { createInteractionReducer } from "./interaction-reducer.js";
   import { provideRegistry } from "./registry.svelte.js";
-  import InteractionOverlay from "./InteractionOverlay.svelte";
   import {
     assemblePortableSpec,
     isFacetedPlotIntent,
@@ -154,6 +153,7 @@
     isDockedTooltipWidth,
     isNarrowToolsWidth,
     plotRootInlineStyle,
+    resolveCaptureAriaControls,
     resolveClearLegendX,
     tooltipViewportSize,
   } from "./plot-layout.js";
@@ -228,6 +228,7 @@
   import PlotCaptureSurface from "./PlotCaptureSurface.svelte";
   import PlotLegendTargets from "./PlotLegendTargets.svelte";
   import PlotMarkStrata from "./PlotMarkStrata.svelte";
+  import PlotSceneOverlays from "./PlotSceneOverlays.svelte";
   import PlotStatusChrome from "./PlotStatusChrome.svelte";
   import Tooltip from "./Tooltip.svelte";
   import ToolRail from "./ToolRail.svelte";
@@ -2337,29 +2338,22 @@
       onClearPointerCancel={() => (legendClearPointerType = null)}
       onClearClick={clearLegendFromControl}
     />
-    {#if !interactive && (emphasizedAnchors.length > 0 || selectedAnchors.length > 0)}
-      <InteractionOverlay
-        width={model.scene.width}
-        height={model.scene.height}
-        interactive={false}
-        {selectedAnchors}
-        {emphasizedAnchors}
-      />
-    {/if}
+    <PlotSceneOverlays
+      width={model.scene.width}
+      height={model.scene.height}
+      {interactive}
+      {surfaceInteractive}
+      {inspection}
+      {inspectionPanel}
+      {coordFlipped}
+      {selectedAnchors}
+      {emphasizedAnchors}
+      {brushRect}
+      {activeTool}
+      {areaAwaitingSecond}
+      {committedInterval}
+    />
     {#if surfaceInteractive}
-      <InteractionOverlay
-        width={model.scene.width}
-        height={model.scene.height}
-        {inspection}
-        {inspectionPanel}
-        {coordFlipped}
-        {selectedAnchors}
-        {emphasizedAnchors}
-        {brushRect}
-        {activeTool}
-        {areaAwaitingSecond}
-        {committedInterval}
-      />
       <!-- Order (document = paint): overlay → capture → Tooltip → status chrome. -->
       <PlotCaptureSurface
         bind:element={captureSurface}
@@ -2368,10 +2362,12 @@
         ariaLabel={ariaLabel ??
           assembled?.labs?.title ??
           sceneLabel(model.scene)}
-        ariaControls={inspection?.state === "pinned" &&
-        interactionConfig.inspect?.contentMode === "interactive"
-          ? `${plotId}-tooltip`
-          : undefined}
+        ariaControls={resolveCaptureAriaControls({
+          isPinned: inspection?.state === "pinned",
+          interactiveContent:
+            interactionConfig.inspect?.contentMode === "interactive",
+          plotId,
+        })}
         onFocus={() => {
           if (inspection === null) navigate(1);
         }}

--- a/packages/svelte/src/lib/PlotSceneOverlays.svelte
+++ b/packages/svelte/src/lib/PlotSceneOverlays.svelte
@@ -1,0 +1,99 @@
+<script lang="ts">
+  /**
+   * Selection / inspection overlay strata for GGPlot (decision 0006 paint order).
+   * Host owns anchors, inspection state, brush draft, and tools.
+   *
+   * Surface-interactive and inert selection overlays are mutually exclusive
+   * via `{:else if}` so both never mount even if host props are inconsistent.
+   */
+  import type { CellValue } from "@ggsvelte/core";
+
+  import type {
+    InteractionTool,
+    IntervalSelection,
+    PlotInspectionChange,
+  } from "./interaction.js";
+  import InteractionOverlay from "./InteractionOverlay.svelte";
+  import { shouldShowInertSelectionOverlay } from "./plot-capability.js";
+
+  type Anchor = { readonly x: number; readonly y: number };
+  type Panel = {
+    readonly x: number;
+    readonly y: number;
+    readonly width: number;
+    readonly height: number;
+  };
+  type BrushRect = {
+    readonly x0: number;
+    readonly y0: number;
+    readonly x1: number;
+    readonly y1: number;
+  };
+
+  let {
+    width,
+    height,
+    interactive,
+    surfaceInteractive,
+    inspection = null,
+    inspectionPanel = null,
+    coordFlipped = false,
+    selectedAnchors = [],
+    emphasizedAnchors = [],
+    brushRect = null,
+    activeTool = "inspect",
+    areaAwaitingSecond = false,
+    committedInterval = null,
+  }: {
+    width: number;
+    height: number;
+    /** Chart-local interactive (tools or legend focus). */
+    interactive: boolean;
+    /** Capture + full overlay (available tools). */
+    surfaceInteractive: boolean;
+    inspection?: PlotInspectionChange<
+      Record<string, CellValue>,
+      PropertyKey
+    > | null;
+    inspectionPanel?: Panel | null;
+    coordFlipped?: boolean;
+    selectedAnchors?: readonly Anchor[];
+    emphasizedAnchors?: readonly Anchor[];
+    brushRect?: BrushRect | null;
+    activeTool?: InteractionTool;
+    areaAwaitingSecond?: boolean;
+    committedInterval?: IntervalSelection | null;
+  } = $props();
+
+  const showInert = $derived(
+    shouldShowInertSelectionOverlay({
+      interactive,
+      selectedAnchorCount: selectedAnchors.length,
+      emphasizedAnchorCount: emphasizedAnchors.length,
+    }),
+  );
+</script>
+
+{#if surfaceInteractive}
+  <InteractionOverlay
+    {width}
+    {height}
+    {inspection}
+    {inspectionPanel}
+    {coordFlipped}
+    {selectedAnchors}
+    {emphasizedAnchors}
+    {brushRect}
+    {activeTool}
+    {areaAwaitingSecond}
+    {committedInterval}
+  />
+{:else if showInert}
+  <InteractionOverlay
+    {width}
+    {height}
+    interactive={false}
+    {selectedAnchors}
+    {emphasizedAnchors}
+  />
+{/if}

--- a/packages/svelte/src/lib/plot-capability.ts
+++ b/packages/svelte/src/lib/plot-capability.ts
@@ -62,6 +62,25 @@ export function shouldShowToolRail(input: ShowToolRailInput): boolean {
   );
 }
 
+export type InertSelectionOverlayInput = {
+  /**
+   * Host chart-local `interactive` (tools or legend focus).
+   * Inert overlay is only for non-interactive emphasis/selection paint.
+   */
+  readonly interactive: boolean;
+  readonly selectedAnchorCount: number;
+  readonly emphasizedAnchorCount: number;
+};
+
+/**
+ * Whether to paint the non-interactive selection/emphasis overlay.
+ * Host also must not be in surface-interactive mode; PlotSceneOverlays
+ * enforces that with `{:else if}` so both never mount together.
+ */
+export function shouldShowInertSelectionOverlay(input: InertSelectionOverlayInput): boolean {
+  return !input.interactive && (input.selectedAnchorCount > 0 || input.emphasizedAnchorCount > 0);
+}
+
 /**
  * Pure routing for host `chooseTool`.
  *

--- a/packages/svelte/src/lib/plot-layout.ts
+++ b/packages/svelte/src/lib/plot-layout.ts
@@ -20,6 +20,19 @@ export function isDockedTooltipWidth(widthPx: number): boolean {
   return widthPx < DOCKED_TOOLTIP_MAX_WIDTH_PX;
 }
 
+/**
+ * Capture-surface `aria-controls` when a pinned interactive tooltip is up.
+ * Undefined otherwise (attribute omitted).
+ */
+export function resolveCaptureAriaControls(input: {
+  readonly isPinned: boolean;
+  readonly interactiveContent: boolean;
+  readonly plotId: string;
+}): string | undefined {
+  if (!input.isPinned || !input.interactiveContent) return undefined;
+  return `${input.plotId}-tooltip`;
+}
+
 export type TooltipViewportSizeInput = {
   readonly sceneWidth: number;
   readonly sceneHeight: number;

--- a/packages/svelte/tests/plot-capability.test.ts
+++ b/packages/svelte/tests/plot-capability.test.ts
@@ -7,6 +7,7 @@ import {
   legendFocusDiscreteOnlyDiagnostics,
   resolveChooseToolAction,
   resolveEffectiveTool,
+  shouldShowInertSelectionOverlay,
   shouldShowToolRail,
   zoomScaleDiagnosticsFromChannels,
   zoomSupportsChannel,
@@ -270,6 +271,42 @@ describe("shouldShowToolRail", () => {
   it("is true when an interval selection or zoom domains are present", () => {
     expect(shouldShowToolRail({ ...base, hasIntervalSelection: true })).toBe(true);
     expect(shouldShowToolRail({ ...base, hasZoomDomains: true })).toBe(true);
+  });
+});
+
+describe("shouldShowInertSelectionOverlay", () => {
+  it("is false when the chart is interactive even with anchors", () => {
+    expect(
+      shouldShowInertSelectionOverlay({
+        interactive: true,
+        selectedAnchorCount: 2,
+        emphasizedAnchorCount: 3,
+      }),
+    ).toBe(false);
+  });
+
+  it("is true only when non-interactive and at least one anchor set is non-empty", () => {
+    expect(
+      shouldShowInertSelectionOverlay({
+        interactive: false,
+        selectedAnchorCount: 1,
+        emphasizedAnchorCount: 0,
+      }),
+    ).toBe(true);
+    expect(
+      shouldShowInertSelectionOverlay({
+        interactive: false,
+        selectedAnchorCount: 0,
+        emphasizedAnchorCount: 2,
+      }),
+    ).toBe(true);
+    expect(
+      shouldShowInertSelectionOverlay({
+        interactive: false,
+        selectedAnchorCount: 0,
+        emphasizedAnchorCount: 0,
+      }),
+    ).toBe(false);
   });
 });
 

--- a/packages/svelte/tests/plot-layout.test.ts
+++ b/packages/svelte/tests/plot-layout.test.ts
@@ -5,6 +5,7 @@ import {
   isNarrowToolsWidth,
   plotRootInlineStyle,
   resolveClearLegendX,
+  resolveCaptureAriaControls,
   tooltipViewportSize,
 } from "../src/lib/plot-layout.js";
 
@@ -79,6 +80,32 @@ describe("plotRootInlineStyle", () => {
         themeStyle: "--t:1",
       }),
     ).toBe("width:100%;height:400px;--t:1");
+  });
+});
+
+describe("resolveCaptureAriaControls", () => {
+  it("returns plot-scoped tooltip id only when pinned and interactive", () => {
+    expect(
+      resolveCaptureAriaControls({
+        isPinned: true,
+        interactiveContent: true,
+        plotId: "plot-a",
+      }),
+    ).toBe("plot-a-tooltip");
+    expect(
+      resolveCaptureAriaControls({
+        isPinned: true,
+        interactiveContent: false,
+        plotId: "plot-a",
+      }),
+    ).toBeUndefined();
+    expect(
+      resolveCaptureAriaControls({
+        isPinned: false,
+        interactiveContent: true,
+        plotId: "plot-a",
+      }),
+    ).toBeUndefined();
   });
 });
 

--- a/packages/svelte/tests/plot-scene-overlays.test.ts
+++ b/packages/svelte/tests/plot-scene-overlays.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import PlotSceneOverlays from "../src/lib/PlotSceneOverlays.svelte";
+import { render } from "./helpers/render.js";
+
+const anchors = [{ x: 10, y: 20 }];
+
+describe("PlotSceneOverlays", () => {
+  it("renders the interactive overlay when surfaceInteractive", () => {
+    const { container } = render(PlotSceneOverlays, {
+      width: 100,
+      height: 80,
+      interactive: true,
+      surfaceInteractive: true,
+      selectedAnchors: anchors,
+      emphasizedAnchors: [],
+    });
+    const overlays = container.querySelectorAll(".gg-interaction-overlay");
+    expect(overlays).toHaveLength(1);
+  });
+
+  it("renders the inert overlay when non-interactive with anchors", () => {
+    const { container } = render(PlotSceneOverlays, {
+      width: 100,
+      height: 80,
+      interactive: false,
+      surfaceInteractive: false,
+      selectedAnchors: anchors,
+      emphasizedAnchors: [],
+    });
+    expect(container.querySelectorAll(".gg-interaction-overlay")).toHaveLength(1);
+  });
+
+  it("renders nothing when non-interactive with empty anchors", () => {
+    const { container } = render(PlotSceneOverlays, {
+      width: 100,
+      height: 80,
+      interactive: false,
+      surfaceInteractive: false,
+      selectedAnchors: [],
+      emphasizedAnchors: [],
+    });
+    expect(container.querySelector(".gg-interaction-overlay")).toBeNull();
+  });
+
+  it("never mounts both overlays when surfaceInteractive even with inert-looking flags", () => {
+    // Structural exclusivity: surface branch wins over inert eligibility.
+    const { container } = render(PlotSceneOverlays, {
+      width: 100,
+      height: 80,
+      interactive: false,
+      surfaceInteractive: true,
+      selectedAnchors: anchors,
+      emphasizedAnchors: anchors,
+    });
+    expect(container.querySelectorAll(".gg-interaction-overlay")).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Extract `PlotSceneOverlays.svelte` to compose the inert vs surface `InteractionOverlay` strata with a structural `{:else if}` so both never mount together.
- Add pure `shouldShowInertSelectionOverlay` (capability) and `resolveCaptureAriaControls` (layout) with unit coverage.
- Wire GGPlot capture `aria-controls` through the pure helper; drop the unused `InteractionOverlay` import from the host.

## Test plan

- [x] `vitest run tests/plot-scene-overlays.test.ts tests/plot-capability.test.ts tests/plot-layout.test.ts`
- [x] Pre-push: package build, svelte-check, type-aware oxlint, knip, bun test
- [x] Characterization: inert-only, surface-only, neither, surface wins over inert-looking flags