### PR TITLE
refactor(svelte): extract plot size and area-kind pure helpers

### DIFF
--- a/packages/svelte/src/lib/GGPlot.svelte
+++ b/packages/svelte/src/lib/GGPlot.svelte
@@ -126,6 +126,8 @@
   import {
     resolveCaptureClickAction,
     advanceTouchInspectMoved,
+    isAreaAwaitingSecond,
+    isAreaBrushing,
     resolveFinishBrushAction,
     resolveLostPointerCaptureAction,
     resolvePointerDownAction,
@@ -159,6 +161,7 @@
     plotRootInlineStyle,
     resolveCaptureAriaControls,
     resolveClearLegendX,
+    resolvePlotSize,
     tooltipViewportSize,
   } from "./plot-layout.js";
   import {
@@ -470,12 +473,17 @@
     };
   });
 
-  const resolvedWidth: number = $derived(
-    width === undefined || width === "container"
-      ? (containerWidth ?? assembled?.width ?? 640)
-      : (width ?? assembled?.width ?? 640),
+  const resolvedSize = $derived(
+    resolvePlotSize({
+      width,
+      height,
+      containerWidth,
+      assembledWidth: assembled?.width,
+      assembledHeight: assembled?.height,
+    }),
   );
-  const resolvedHeight: number = $derived(height ?? assembled?.height ?? 400);
+  const resolvedWidth = $derived(resolvedSize.width);
+  const resolvedHeight = $derived(resolvedSize.height);
 
   // Authoritative committed scale state: a plain non-reactive box + run-id
   // gate. Committing only monotonically newer runs keeps stale results from
@@ -660,11 +668,11 @@
   } | null>(null);
   const brushing = $derived.by(() => {
     void reducerRevision;
-    return reducer.state.area.kind !== "idle";
+    return isAreaBrushing(reducer.state.area.kind);
   });
   const areaAwaitingSecond = $derived.by(() => {
     void reducerRevision;
-    return reducer.state.area.kind === "first-corner";
+    return isAreaAwaitingSecond(reducer.state.area.kind);
   });
   let lastInspectionFingerprint = "";
   let activeTraversalIndex = $state(-1);
@@ -2231,6 +2239,35 @@
     }
   }
 
+  /** Pointer-cancel always drops draft/queue/touch-inspect and cancels area. */
+  function onPointerCancel(): void {
+    queuedPointerInspection = null;
+    touchInspectStart = null;
+    touchInspectMoved = false;
+    reducer.cancelScheduledPointer();
+    brushRect = null;
+    reducer.dispatch({ type: "cancel-area" });
+  }
+
+  /**
+   * Lost capture: pure decision table owns keep vs clear draft; host mutates
+   * brushRect and always cancels area when not ignored.
+   */
+  function onLostPointerCapture(): void {
+    const lost = resolveLostPointerCaptureAction(reducer.state.area.kind);
+    switch (lost.type) {
+      case "ignore":
+        break;
+      case "cancel-keep-draft":
+        reducer.dispatch({ type: "cancel-area" });
+        break;
+      case "cancel-clear-draft":
+        brushRect = null;
+        reducer.dispatch({ type: "cancel-area" });
+        break;
+    }
+  }
+
   // Readiness signal for screenshot tooling (plan: VR waits on
   // `[data-gg-ready="true"]`). Split into:
   // - clientFlush via $effect: never runs during SSR → prerender stays
@@ -2373,29 +2410,8 @@
         {onPointerLeave}
         {onPointerDown}
         {onPointerUp}
-        onPointerCancel={() => {
-          queuedPointerInspection = null;
-          touchInspectStart = null;
-          touchInspectMoved = false;
-          reducer.cancelScheduledPointer();
-          brushRect = null;
-          reducer.dispatch({ type: "cancel-area" });
-        }}
-        onLostPointerCapture={() => {
-          // Decision table is pure (plot-surface-pointer); host owns draft + cancel.
-          const lost = resolveLostPointerCaptureAction(reducer.state.area.kind);
-          switch (lost.type) {
-            case "ignore":
-              return;
-            case "cancel-keep-draft":
-              reducer.dispatch({ type: "cancel-area" });
-              return;
-            case "cancel-clear-draft":
-              brushRect = null;
-              reducer.dispatch({ type: "cancel-area" });
-              return;
-          }
-        }}
+        {onPointerCancel}
+        {onLostPointerCapture}
         onClick={onCaptureClick}
         onKeyDown={onSurfaceKeyDown}
         {onDblClick}

--- a/packages/svelte/src/lib/plot-layout.ts
+++ b/packages/svelte/src/lib/plot-layout.ts
@@ -6,6 +6,38 @@
 
 const NARROW_TOOLS_MAX_WIDTH_PX = 560;
 const DOCKED_TOOLTIP_MAX_WIDTH_PX = 480;
+const DEFAULT_PLOT_WIDTH_PX = 640;
+const DEFAULT_PLOT_HEIGHT_PX = 400;
+
+export type ResolvePlotSizeInput = {
+  /** Host width prop: fixed px, `"container"`, or omitted (container mode). */
+  readonly width: number | "container" | undefined;
+  readonly height: number | undefined;
+  /** ResizeObserver content width when in container mode; null before first measure. */
+  readonly containerWidth: number | null;
+  /** Assembled spec width fallback. */
+  readonly assembledWidth: number | undefined;
+  /** Assembled spec height fallback. */
+  readonly assembledHeight: number | undefined;
+};
+
+/**
+ * Resolved plot pixel size for the pipeline and root style.
+ * Container mode: measured container width, then assembled, then 640.
+ * Fixed mode: the numeric width prop (assembled fallback is unused once fixed).
+ * Height: height prop, then assembled, then 400.
+ */
+export function resolvePlotSize(input: ResolvePlotSizeInput): {
+  readonly width: number;
+  readonly height: number;
+} {
+  const width =
+    input.width === undefined || input.width === "container"
+      ? (input.containerWidth ?? input.assembledWidth ?? DEFAULT_PLOT_WIDTH_PX)
+      : input.width;
+  const height = input.height ?? input.assembledHeight ?? DEFAULT_PLOT_HEIGHT_PX;
+  return { width, height };
+}
 
 /** True when the tool rail should use the narrow layout (width < 560). */
 export function isNarrowToolsWidth(widthPx: number): boolean {

--- a/packages/svelte/src/lib/plot-surface-pointer.ts
+++ b/packages/svelte/src/lib/plot-surface-pointer.ts
@@ -271,6 +271,16 @@ export function resolveFinishBrushAction(input: {
 /** Reducer area.kind values that the host may observe on lostpointercapture. */
 export type AreaKind = "idle" | "first-corner" | "dragging";
 
+/** True while an area brush session is active (not idle). */
+export function isAreaBrushing(areaKind: AreaKind): boolean {
+  return areaKind !== "idle";
+}
+
+/** True while waiting for the second brush corner (keyboard / too-small path). */
+export function isAreaAwaitingSecond(areaKind: AreaKind): boolean {
+  return areaKind === "first-corner";
+}
+
 export type LostPointerCaptureAction =
   | { readonly type: "ignore" }
   | { readonly type: "cancel-keep-draft" }

--- a/packages/svelte/tests/plot-layout.test.ts
+++ b/packages/svelte/tests/plot-layout.test.ts
@@ -7,8 +7,53 @@ import {
   plotRootInlineStyle,
   resolveClearLegendX,
   resolveCaptureAriaControls,
+  resolvePlotSize,
   tooltipViewportSize,
 } from "../src/lib/plot-layout.js";
+
+describe("resolvePlotSize", () => {
+  it("uses container measure then assembled then 640 in container mode", () => {
+    expect(
+      resolvePlotSize({
+        width: "container",
+        height: undefined,
+        containerWidth: 500,
+        assembledWidth: 320,
+        assembledHeight: 200,
+      }),
+    ).toEqual({ width: 500, height: 200 });
+    expect(
+      resolvePlotSize({
+        width: undefined,
+        height: undefined,
+        containerWidth: null,
+        assembledWidth: 320,
+        assembledHeight: undefined,
+      }),
+    ).toEqual({ width: 320, height: 400 });
+    expect(
+      resolvePlotSize({
+        width: "container",
+        height: undefined,
+        containerWidth: null,
+        assembledWidth: undefined,
+        assembledHeight: undefined,
+      }),
+    ).toEqual({ width: 640, height: 400 });
+  });
+
+  it("uses the fixed width prop without assembled fallback", () => {
+    expect(
+      resolvePlotSize({
+        width: 800,
+        height: 300,
+        containerWidth: 100,
+        assembledWidth: 320,
+        assembledHeight: 200,
+      }),
+    ).toEqual({ width: 800, height: 300 });
+  });
+});
 
 describe("breakpoint helpers", () => {
   it("narrow tools is width < 560", () => {

--- a/packages/svelte/tests/plot-surface-pointer.test.ts
+++ b/packages/svelte/tests/plot-surface-pointer.test.ts
@@ -6,6 +6,8 @@ import {
   advanceTouchInspectMoved,
   resolveCaptureClickAction,
   resolveFinishBrushAction,
+  isAreaAwaitingSecond,
+  isAreaBrushing,
   resolveLostPointerCaptureAction,
   resolvePointerDownAction,
   resolvePointerMoveAction,
@@ -538,6 +540,17 @@ describe("resolveFinishBrushAction", () => {
     expect(resolveFinishBrushAction({ endedKind: "commit", activeTool: "point" })).toEqual({
       type: "end-area",
     });
+  });
+});
+
+describe("isAreaBrushing / isAreaAwaitingSecond", () => {
+  it("classifies area.kind for host deriveds", () => {
+    expect(isAreaBrushing("idle")).toBe(false);
+    expect(isAreaBrushing("first-corner")).toBe(true);
+    expect(isAreaBrushing("dragging")).toBe(true);
+    expect(isAreaAwaitingSecond("idle")).toBe(false);
+    expect(isAreaAwaitingSecond("first-corner")).toBe(true);
+    expect(isAreaAwaitingSecond("dragging")).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

- Extract `resolvePlotSize` for container/fixed width resolution and height fallbacks (drops dead fixed-width assembled coalesce).
- Extract `isAreaBrushing` / `isAreaAwaitingSecond` next to `AreaKind` for host brush deriveds.
- Move capture `onPointerCancel` / `onLostPointerCapture` from template inlines into named host handlers.

## Test plan

- [x] `vitest run tests/plot-layout.test.ts tests/plot-surface-pointer.test.ts`
- [x] Type-aware oxlint clean
- [x] Pre-push package build / svelte-check / knip / bun test