### PR TITLE
refactor(svelte): extract data-identity, legend-clear, and inspect-ref helpers

### DIFF
--- a/packages/svelte/src/lib/GGPlot.svelte
+++ b/packages/svelte/src/lib/GGPlot.svelte
@@ -112,6 +112,7 @@
   } from "./plot-geometry.js";
   import { resolveSurfaceKeyAction } from "./plot-surface-keyboard.js";
   import {
+    buildInspectionCandidateRef,
     resolveInspectionCompleteness,
     resolveInspectionEmitAction,
     resolveInspectionMode,
@@ -143,6 +144,7 @@
     resolveLegendPointerUpAction,
     resolveLegendPreviewDismissAction,
     shouldClearLegendPreviewOnBlur,
+    shouldEmitLegendFocusClear,
     shouldRenderInteractionLiveRegion,
   } from "./plot-legend-surface.js";
   import {
@@ -205,6 +207,7 @@
   } from "./plot-selection.js";
   import {
     createSourceIdentityTracker,
+    dataIdentityEpochToken,
     resolveSemanticKeys,
   } from "./plot-semantic-keys.js";
   import { themeTokensToCss } from "./plot-theme-css.js";
@@ -439,12 +442,11 @@
   // Tracker is owned for the component lifetime (never cleared).
   const { sourceIdentity } = createSourceIdentityTracker();
   const dataIdentityEpoch = $derived(
-    assembled === null
-      ? "no-data"
-      : `${sourceIdentity(data)}:${sourceIdentity(spec)}:${JSON.stringify([
-          assembled.data ?? null,
-          assembled.datasets ?? null,
-        ])}`,
+    dataIdentityEpochToken({
+      assembled,
+      dataToken: sourceIdentity(data),
+      specToken: sourceIdentity(spec),
+    }),
   );
 
   // ------------------------------------------------- container width (RO)
@@ -1063,15 +1065,16 @@
   }
 
   function clearLegendFocus(source: InteractionSource): void {
-    const hadFocus =
-      legendPreview !== null ||
-      legendCommitted !== null ||
-      effectiveEmphasisKeys.length > 0;
+    const emitClear = shouldEmitLegendFocusClear({
+      hasPreview: legendPreview !== null,
+      hasCommitted: legendCommitted !== null,
+      emphasisKeyCount: effectiveEmphasisKeys.length,
+    });
     legendPreview = null;
     legendCommitted = null;
     if (interaction === undefined) localEmphasisKeys = [];
     else interaction.clearEmphasis({ scope: resolvedInteractionScope, source });
-    if (hadFocus)
+    if (emitClear)
       emitLegendFocus({ type: "legend-focus", phase: "clear", source });
   }
 
@@ -1568,13 +1571,14 @@
           return;
         }
         const next = resolved.snapshot;
-        const candidateRef = {
+        const candidateRef = buildInspectionCandidateRef({
           epoch: model?.runId ?? 0,
-          id: candidate?.id ?? traversalHits.indexOf(hit!),
+          candidateId: candidate?.id,
+          fallbackId: () => traversalHits.indexOf(hit!),
           panelId: next.panelId,
           x: hit!.x,
           y: hit!.y,
-        };
+        });
         reducer.dispatch({ type: "inspect", candidate: candidateRef, source });
         if (state === "pinned")
           reducer.dispatch({ type: "toggle-pin", source });

--- a/packages/svelte/src/lib/plot-legend-surface.ts
+++ b/packages/svelte/src/lib/plot-legend-surface.ts
@@ -233,3 +233,19 @@ export function resolveLegendPreviewDismissAction(input: {
   if (input.committedEmphasisEmpty) return { type: "clear-and-emit" };
   return { type: "clear-only" };
 }
+
+/**
+ * Whether `clearLegendFocus` should emit a legend-focus clear event.
+ *
+ * Unlike `resolveLegendPreviewDismissAction` (preview dismiss), this gate ORs
+ * active preview, committed legend entry, and **effective** emphasis key count
+ * (preview keys included when present). That matches the host clearing all
+ * focus surfaces, not only a transient preview leave.
+ */
+export function shouldEmitLegendFocusClear(input: {
+  readonly hasPreview: boolean;
+  readonly hasCommitted: boolean;
+  readonly emphasisKeyCount: number;
+}): boolean {
+  return input.hasPreview || input.hasCommitted || input.emphasisKeyCount > 0;
+}

--- a/packages/svelte/src/lib/plot-semantic-keys.ts
+++ b/packages/svelte/src/lib/plot-semantic-keys.ts
@@ -72,6 +72,22 @@ export type ResolveSemanticKeysResult = {
 };
 
 /**
+ * Stable data/spec identity token for inspection reconcile epochs.
+ * Host supplies sourceIdentity tokens for the raw `data` / `spec` props.
+ */
+export function dataIdentityEpochToken(input: {
+  readonly assembled: { readonly data?: unknown; readonly datasets?: unknown } | null;
+  readonly dataToken: string;
+  readonly specToken: string;
+}): string {
+  if (input.assembled === null) return "no-data";
+  return `${input.dataToken}:${input.specToken}:${JSON.stringify([
+    input.assembled.data ?? null,
+    input.assembled.datasets ?? null,
+  ])}`;
+}
+
+/**
  * Resolve durable semantic keys for interaction, emitting diagnostics in
  * encounter order: synthetic-rule missing lineage, per-candidate missing
  * lineage, then per-row invalid / unstable / duplicate key diagnostics.

--- a/packages/svelte/src/lib/plot-surface-inspection.ts
+++ b/packages/svelte/src/lib/plot-surface-inspection.ts
@@ -126,6 +126,37 @@ export function shouldCommitInspection(input: {
   return true;
 }
 
+/** Reducer inspect payload candidate (matches InteractionCandidateRef shape). */
+export type InspectionCandidateRef = {
+  readonly epoch: number;
+  readonly id: number;
+  readonly panelId: string | null;
+  readonly x: number;
+  readonly y: number;
+};
+
+/**
+ * Build the inspect-dispatch candidate ref for setInspection apply.
+ * `fallbackId` is a thunk so hosts can defer `traversalHits.indexOf(hit)`
+ * until `candidateId` is actually missing (hot pointer path).
+ */
+export function buildInspectionCandidateRef(input: {
+  readonly epoch: number;
+  readonly candidateId: number | undefined;
+  readonly fallbackId: () => number;
+  readonly panelId: string | null;
+  readonly x: number;
+  readonly y: number;
+}): InspectionCandidateRef {
+  return {
+    epoch: input.epoch,
+    id: input.candidateId ?? input.fallbackId(),
+    panelId: input.panelId,
+    x: input.x,
+    y: input.y,
+  };
+}
+
 export type ToggleInspectionPinInput = {
   readonly hasInspection: boolean;
   readonly hasSeed: boolean;

--- a/packages/svelte/tests/plot-legend-surface.test.ts
+++ b/packages/svelte/tests/plot-legend-surface.test.ts
@@ -8,6 +8,7 @@ import {
   resolveLegendPointerUpAction,
   resolveLegendPreviewDismissAction,
   shouldClearLegendPreviewOnBlur,
+  shouldEmitLegendFocusClear,
   shouldRenderInteractionLiveRegion,
   type LegendClearControlInput,
   type LegendClickInput,
@@ -295,5 +296,41 @@ describe("resolveLegendPreviewDismissAction", () => {
         committedEmphasisEmpty: false,
       }),
     ).toEqual({ type: "clear-only" });
+  });
+});
+
+describe("shouldEmitLegendFocusClear", () => {
+  it("is false only when preview, committed, and effective emphasis are all empty", () => {
+    expect(
+      shouldEmitLegendFocusClear({
+        hasPreview: false,
+        hasCommitted: false,
+        emphasisKeyCount: 0,
+      }),
+    ).toBe(false);
+  });
+
+  it("is true when any focus surface is present (incl. effective emphasis alone)", () => {
+    expect(
+      shouldEmitLegendFocusClear({
+        hasPreview: true,
+        hasCommitted: false,
+        emphasisKeyCount: 0,
+      }),
+    ).toBe(true);
+    expect(
+      shouldEmitLegendFocusClear({
+        hasPreview: false,
+        hasCommitted: true,
+        emphasisKeyCount: 0,
+      }),
+    ).toBe(true);
+    expect(
+      shouldEmitLegendFocusClear({
+        hasPreview: false,
+        hasCommitted: false,
+        emphasisKeyCount: 2,
+      }),
+    ).toBe(true);
   });
 });

--- a/packages/svelte/tests/plot-semantic-keys.test.ts
+++ b/packages/svelte/tests/plot-semantic-keys.test.ts
@@ -5,6 +5,7 @@ import type { CellValue } from "@ggsvelte/core";
 import { INTERACTION_DIAGNOSTIC_CATALOG } from "../src/lib/interaction.js";
 import {
   createSourceIdentityTracker,
+  dataIdentityEpochToken,
   resolveSemanticKeys,
   type SemanticKeyCandidate,
   type SemanticKeyModelView,
@@ -36,6 +37,35 @@ function modelView(options: {
     layers: options.layers ?? [],
   };
 }
+
+describe("dataIdentityEpochToken", () => {
+  it("returns no-data when assembled is null", () => {
+    expect(
+      dataIdentityEpochToken({
+        assembled: null,
+        dataToken: "1",
+        specToken: "2",
+      }),
+    ).toBe("no-data");
+  });
+
+  it("joins source tokens with JSON of data and datasets (nullish → null)", () => {
+    expect(
+      dataIdentityEpochToken({
+        assembled: { data: [{ a: 1 }], datasets: undefined },
+        dataToken: "d",
+        specToken: "s",
+      }),
+    ).toBe(`d:s:${JSON.stringify([[{ a: 1 }], null])}`);
+    expect(
+      dataIdentityEpochToken({
+        assembled: {},
+        dataToken: "d",
+        specToken: "s",
+      }),
+    ).toBe(`d:s:${JSON.stringify([null, null])}`);
+  });
+});
 
 describe("createSourceIdentityTracker", () => {
   it("assigns stable ids to the same object and distinct ids to different objects", () => {

--- a/packages/svelte/tests/plot-surface-inspection.test.ts
+++ b/packages/svelte/tests/plot-surface-inspection.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  buildInspectionCandidateRef,
   resolveInspectionCompleteness,
   resolveInspectionEmitAction,
   resolveInspectionMode,
@@ -235,6 +236,39 @@ describe("resolveSetInspectionAction", () => {
         }),
       ),
     ).toEqual({ type: "ignore" });
+  });
+});
+
+describe("buildInspectionCandidateRef", () => {
+  it("prefers candidateId and does not call fallbackId when present", () => {
+    let fallbackCalls = 0;
+    expect(
+      buildInspectionCandidateRef({
+        epoch: 3,
+        candidateId: 7,
+        fallbackId: () => {
+          fallbackCalls += 1;
+          return -1;
+        },
+        panelId: "p0",
+        x: 1,
+        y: 2,
+      }),
+    ).toEqual({ epoch: 3, id: 7, panelId: "p0", x: 1, y: 2 });
+    expect(fallbackCalls).toBe(0);
+  });
+
+  it("uses lazy fallbackId when candidateId is missing (incl. -1)", () => {
+    expect(
+      buildInspectionCandidateRef({
+        epoch: 1,
+        candidateId: undefined,
+        fallbackId: () => -1,
+        panelId: null,
+        x: 10,
+        y: 20,
+      }),
+    ).toEqual({ epoch: 1, id: -1, panelId: null, x: 10, y: 20 });
   });
 });
 


### PR DESCRIPTION
## Summary

- Extract `dataIdentityEpochToken` for inspection reconcile identity epochs.
- Extract `shouldEmitLegendFocusClear` next to preview-dismiss, documenting the intentional effective-vs-committed emphasis divergence.
- Extract `buildInspectionCandidateRef` with a lazy `fallbackId` thunk so pointer-hot paths skip `indexOf` when a candidate id is present.

## Test plan

- [x] `vitest run tests/plot-semantic-keys.test.ts tests/plot-legend-surface.test.ts tests/plot-surface-inspection.test.ts`
- [x] Lazy fallback not invoked when `candidateId` is set
- [x] Type-aware oxlint clean; pre-push package build / svelte-check / knip / bun test