### PR TITLE
refactor(svelte): extract scene-inspect reconcile plan and pin chrome gates

### DIFF
--- a/packages/svelte/src/lib/GGPlot.svelte
+++ b/packages/svelte/src/lib/GGPlot.svelte
@@ -115,6 +115,7 @@
   import {
     buildInspectionCandidateRef,
     buildQueuedPointerInspection,
+    planSceneInspectReconcile,
     resolveInspectionCompleteness,
     resolveInspectionEmitAction,
     resolveInspectionMode,
@@ -122,9 +123,11 @@
     resolveSetInspectionAction,
     resolveSurfaceBlurAction,
     resolveToggleInspectionPinAction,
+    shouldAnnounceUnpin,
     shouldClearInspectionAnnouncement,
     shouldClosePinnedOnOutsidePointer,
     shouldCommitInspection,
+    shouldFocusPinnedInteractiveTooltip,
     type QueuedPointerInspection,
   } from "./plot-surface-inspection.js";
   import {
@@ -164,6 +167,7 @@
     isNarrowToolsWidth,
     isTooltipDocked,
     plotRootInlineStyle,
+    plotTooltipDomId,
     resolveCaptureAriaControls,
     resolveClearLegendX,
     resolvePlotSize,
@@ -1438,9 +1442,17 @@
   let reconciledRun = -1;
   $effect(() => {
     const currentModel = model;
-    const inspectionEnabled = interactionConfig.inspect !== null;
-    if (!inspectionEnabled) {
-      if (inspection !== null) {
+    const plan = planSceneInspectReconcile({
+      inspectionEnabled: interactionConfig.inspect !== null,
+      inspectionState: inspection === null ? "none" : inspection.state,
+      modelRunId: currentModel?.runId ?? null,
+      reconciledRun,
+    });
+    switch (plan.type) {
+      case "noop":
+      case "skip":
+        return;
+      case "clear-disabled":
         inspectionCoordinator.invalidate();
         inspection = null;
         inspectionSeed = null;
@@ -1449,50 +1461,55 @@
           candidate: null,
           source: "programmatic",
         });
+        return;
+      case "invalidate-clear-transient":
+      case "invalidate-idle":
+      case "invalidate-reconcile-pinned": {
+        // currentModel is non-null for invalidate-* (plan requires run advance).
+        const runId = currentModel!.runId;
+        reducer.dispatch({ type: "invalidate", reason: "scene" });
+        queuedPointerInspection = null;
+        pendingPinnedPointer = null;
+        queuedPointerToken = null;
+        reducer.cancelScheduledPointer();
+        reconciledRun = runId;
+        if (plan.type === "invalidate-clear-transient") {
+          inspectionCoordinator.release("transient");
+          inspection = null;
+          inspectionSeed = null;
+          reducer.dispatch({
+            type: "inspect",
+            candidate: null,
+            source: "programmatic",
+          });
+          return;
+        }
+        if (plan.type === "invalidate-idle") return;
+        const reconciled = inspectionCoordinator.reconcilePinned({
+          model: currentModel!,
+          identityEpoch: dataIdentityEpoch,
+          layoutEpoch: runId,
+          source: "programmatic",
+          completeness: "complete",
+        });
+        if (reconciled === null) {
+          reducer.dispatch({ type: "escape", source: "programmatic" });
+          reducer.dispatch({ type: "set-active", candidate: null });
+          emitInspection({
+            type: "inspect",
+            phase: "clear",
+            source: "programmatic",
+          });
+          inspection = null;
+          inspectionSeed = null;
+        } else {
+          inspection = reconciled.snapshot;
+          inspectionSeed = reconciled.seed;
+          if (reconciled.semanticChanged)
+            emitInspection(reconciled.snapshot, reconciled.semanticFingerprint);
+        }
+        break;
       }
-      return;
-    }
-    if (currentModel === null || currentModel.runId === reconciledRun) return;
-    reducer.dispatch({ type: "invalidate", reason: "scene" });
-    queuedPointerInspection = null;
-    pendingPinnedPointer = null;
-    queuedPointerToken = null;
-    reducer.cancelScheduledPointer();
-    reconciledRun = currentModel.runId;
-    if (inspection?.state === "transient") {
-      inspectionCoordinator.release("transient");
-      inspection = null;
-      inspectionSeed = null;
-      reducer.dispatch({
-        type: "inspect",
-        candidate: null,
-        source: "programmatic",
-      });
-      return;
-    }
-    if (inspection?.state !== "pinned") return;
-    const reconciled = inspectionCoordinator.reconcilePinned({
-      model: currentModel,
-      identityEpoch: dataIdentityEpoch,
-      layoutEpoch: currentModel.runId,
-      source: "programmatic",
-      completeness: "complete",
-    });
-    if (reconciled === null) {
-      reducer.dispatch({ type: "escape", source: "programmatic" });
-      reducer.dispatch({ type: "set-active", candidate: null });
-      emitInspection({
-        type: "inspect",
-        phase: "clear",
-        source: "programmatic",
-      });
-      inspection = null;
-      inspectionSeed = null;
-    } else {
-      inspection = reconciled.snapshot;
-      inspectionSeed = reconciled.seed;
-      if (reconciled.semanticChanged)
-        emitInspection(reconciled.snapshot, reconciled.semanticFingerprint);
     }
   });
 
@@ -1652,22 +1669,23 @@
             source,
           });
         if (state === "transient") inspectionCoordinator.release("pinned");
-        if (
-          state === "transient" &&
-          (source === "keyboard" || source === "touch")
-        )
+        if (shouldAnnounceUnpin({ state, source }))
           announceInteraction(
             `${inspectionLiveText(resolved.snapshot)}, unpinned`,
           );
         if (resolved.semanticChanged)
           emitInspection(resolved.snapshot, resolved.semanticFingerprint);
         if (
-          state === "pinned" &&
-          interactionConfig.inspect?.contentMode === "interactive"
+          shouldFocusPinnedInteractiveTooltip({
+            state,
+            contentMode: interactionConfig.inspect?.contentMode,
+          })
         )
           queueMicrotask(() =>
             root
-              ?.querySelector<HTMLElement>(`#${CSS.escape(plotId)}-tooltip`)
+              ?.querySelector<HTMLElement>(
+                `#${CSS.escape(plotTooltipDomId(plotId))}`,
+              )
               ?.focus(),
           );
       }
@@ -2428,7 +2446,7 @@
           clientHeight: root?.clientHeight,
         })}
         <Tooltip
-          id={`${plotId}-tooltip`}
+          id={plotTooltipDomId(plotId)}
           {inspection}
           width={tooltipSize.width}
           height={tooltipSize.height}

--- a/packages/svelte/src/lib/plot-layout.ts
+++ b/packages/svelte/src/lib/plot-layout.ts
@@ -63,6 +63,11 @@ export function isTooltipDocked(input: {
   return input.inspectionState === "pinned" && isDockedTooltipWidth(input.widthPx);
 }
 
+/** Stable DOM id for the plot's inspection tooltip element. */
+export function plotTooltipDomId(plotId: string): string {
+  return `${plotId}-tooltip`;
+}
+
 /**
  * Capture-surface `aria-controls` when a pinned interactive tooltip is up.
  * Undefined otherwise (attribute omitted).
@@ -73,7 +78,7 @@ export function resolveCaptureAriaControls(input: {
   readonly plotId: string;
 }): string | undefined {
   if (!input.isPinned || !input.interactiveContent) return undefined;
-  return `${input.plotId}-tooltip`;
+  return plotTooltipDomId(input.plotId);
 }
 
 export type TooltipViewportSizeInput = {

--- a/packages/svelte/src/lib/plot-surface-inspection.ts
+++ b/packages/svelte/src/lib/plot-surface-inspection.ts
@@ -299,6 +299,74 @@ export function shouldClosePinnedOnOutsidePointer(input: {
   return input.isPinned && !input.targetInsideRoot;
 }
 
+// ---- scene-run inspection reconcile (host $effect) ----
+
+export type SceneInspectReconcilePlan =
+  | { readonly type: "noop" }
+  | { readonly type: "clear-disabled" }
+  | { readonly type: "skip" }
+  | { readonly type: "invalidate-clear-transient" }
+  | { readonly type: "invalidate-idle" }
+  | { readonly type: "invalidate-reconcile-pinned" };
+
+/**
+ * Priority table for the model-run inspection reconcile effect.
+ *
+ *   1. inspect off → clear-disabled when live inspection exists, else noop
+ *   2. no model / same runId as reconciledRun → skip
+ *   3. run advanced + transient → invalidate-clear-transient
+ *   4. run advanced + pinned → invalidate-reconcile-pinned
+ *   5. run advanced + none → invalidate-idle
+ *
+ * Host on every invalidate-*: clear queues, cancel scheduled pointer, set
+ * reconciledRun to the new model runId, then branch-specific side effects.
+ */
+export function planSceneInspectReconcile(input: {
+  readonly inspectionEnabled: boolean;
+  /** Host: `inspection === null ? "none" : inspection.state`. */
+  readonly inspectionState: InspectionHostState;
+  readonly modelRunId: number | null;
+  readonly reconciledRun: number;
+}): SceneInspectReconcilePlan {
+  if (!input.inspectionEnabled) {
+    return input.inspectionState === "none" ? { type: "noop" } : { type: "clear-disabled" };
+  }
+  if (input.modelRunId === null || input.modelRunId === input.reconciledRun) {
+    return { type: "skip" };
+  }
+  if (input.inspectionState === "transient") {
+    return { type: "invalidate-clear-transient" };
+  }
+  if (input.inspectionState === "pinned") {
+    return { type: "invalidate-reconcile-pinned" };
+  }
+  return { type: "invalidate-idle" };
+}
+
+// ---- toggle-pin chrome gates ----
+
+/**
+ * Whether unpinning should announce for a11y (keyboard/touch only).
+ * Host: only after a successful flip-to-transient resolve.
+ */
+export function shouldAnnounceUnpin(input: {
+  readonly state: "transient" | "pinned";
+  readonly source: InteractionSource;
+}): boolean {
+  return input.state === "transient" && (input.source === "keyboard" || input.source === "touch");
+}
+
+/**
+ * Whether to move focus into the interactive pinned tooltip after pin.
+ * Host still runs the querySelector focus in a microtask.
+ */
+export function shouldFocusPinnedInteractiveTooltip(input: {
+  readonly state: "transient" | "pinned";
+  readonly contentMode: "interactive" | "informational" | undefined;
+}): boolean {
+  return input.state === "pinned" && input.contentMode === "interactive";
+}
+
 // ---- inspection emission fingerprint gate ----
 
 export type InspectionEmitAction =

--- a/packages/svelte/tests/plot-layout.test.ts
+++ b/packages/svelte/tests/plot-layout.test.ts
@@ -5,6 +5,7 @@ import {
   isNarrowToolsWidth,
   isTooltipDocked,
   plotRootInlineStyle,
+  plotTooltipDomId,
   resolveClearLegendX,
   resolveCaptureAriaControls,
   resolvePlotSize,
@@ -139,6 +140,12 @@ describe("plotRootInlineStyle", () => {
   });
 });
 
+describe("plotTooltipDomId", () => {
+  it("builds the stable tooltip element id", () => {
+    expect(plotTooltipDomId("plot-a")).toBe("plot-a-tooltip");
+  });
+});
+
 describe("resolveCaptureAriaControls", () => {
   it("returns plot-scoped tooltip id only when pinned and interactive", () => {
     expect(
@@ -147,7 +154,7 @@ describe("resolveCaptureAriaControls", () => {
         interactiveContent: true,
         plotId: "plot-a",
       }),
-    ).toBe("plot-a-tooltip");
+    ).toBe(plotTooltipDomId("plot-a"));
     expect(
       resolveCaptureAriaControls({
         isPinned: true,

--- a/packages/svelte/tests/plot-surface-inspection.test.ts
+++ b/packages/svelte/tests/plot-surface-inspection.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildInspectionCandidateRef,
   buildQueuedPointerInspection,
+  planSceneInspectReconcile,
   resolveInspectionCompleteness,
   resolveInspectionEmitAction,
   resolveInspectionMode,
@@ -10,9 +11,11 @@ import {
   resolveSetInspectionAction,
   resolveSurfaceBlurAction,
   resolveToggleInspectionPinAction,
+  shouldAnnounceUnpin,
   shouldClearInspectionAnnouncement,
   shouldClosePinnedOnOutsidePointer,
   shouldCommitInspection,
+  shouldFocusPinnedInteractiveTooltip,
   type QueuedInspectFrameInput,
   type SetInspectionInput,
   type ToggleInspectionPinInput,
@@ -553,6 +556,103 @@ describe("resolveSurfaceBlurAction", () => {
         inspectionState: "none",
       }),
     ).toEqual({ type: "blur-clear-inspection" });
+  });
+});
+
+describe("planSceneInspectReconcile", () => {
+  it("clears when inspect is disabled only if inspection is live", () => {
+    expect(
+      planSceneInspectReconcile({
+        inspectionEnabled: false,
+        inspectionState: "none",
+        modelRunId: 1,
+        reconciledRun: 0,
+      }),
+    ).toEqual({ type: "noop" });
+    expect(
+      planSceneInspectReconcile({
+        inspectionEnabled: false,
+        inspectionState: "pinned",
+        modelRunId: 1,
+        reconciledRun: 0,
+      }),
+    ).toEqual({ type: "clear-disabled" });
+  });
+
+  it("skips when model is missing or run is already reconciled", () => {
+    expect(
+      planSceneInspectReconcile({
+        inspectionEnabled: true,
+        inspectionState: "pinned",
+        modelRunId: null,
+        reconciledRun: 0,
+      }),
+    ).toEqual({ type: "skip" });
+    expect(
+      planSceneInspectReconcile({
+        inspectionEnabled: true,
+        inspectionState: "transient",
+        modelRunId: 3,
+        reconciledRun: 3,
+      }),
+    ).toEqual({ type: "skip" });
+  });
+
+  it("routes advanced runs by inspection state (enabled-off already handled)", () => {
+    expect(
+      planSceneInspectReconcile({
+        inspectionEnabled: true,
+        inspectionState: "transient",
+        modelRunId: 2,
+        reconciledRun: 1,
+      }),
+    ).toEqual({ type: "invalidate-clear-transient" });
+    expect(
+      planSceneInspectReconcile({
+        inspectionEnabled: true,
+        inspectionState: "pinned",
+        modelRunId: 2,
+        reconciledRun: 1,
+      }),
+    ).toEqual({ type: "invalidate-reconcile-pinned" });
+    expect(
+      planSceneInspectReconcile({
+        inspectionEnabled: true,
+        inspectionState: "none",
+        modelRunId: 2,
+        reconciledRun: 1,
+      }),
+    ).toEqual({ type: "invalidate-idle" });
+  });
+});
+
+describe("shouldAnnounceUnpin / shouldFocusPinnedInteractiveTooltip", () => {
+  it("announces unpin only for transient keyboard/touch", () => {
+    expect(shouldAnnounceUnpin({ state: "transient", source: "keyboard" })).toBe(true);
+    expect(shouldAnnounceUnpin({ state: "transient", source: "touch" })).toBe(true);
+    expect(shouldAnnounceUnpin({ state: "transient", source: "pointer" })).toBe(false);
+    expect(shouldAnnounceUnpin({ state: "pinned", source: "keyboard" })).toBe(false);
+  });
+
+  it("focuses tooltip only when pinned with interactive content", () => {
+    expect(
+      shouldFocusPinnedInteractiveTooltip({
+        state: "pinned",
+        contentMode: "interactive",
+      }),
+    ).toBe(true);
+    expect(
+      shouldFocusPinnedInteractiveTooltip({
+        state: "pinned",
+        contentMode: "informational",
+      }),
+    ).toBe(false);
+    expect(
+      shouldFocusPinnedInteractiveTooltip({
+        state: "transient",
+        contentMode: "interactive",
+      }),
+    ).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

- Extract `planSceneInspectReconcile` for the model-run inspection effect priority table (disabled clear, skip, invalidate transient/idle/pinned).
- Extract `shouldAnnounceUnpin` and `shouldFocusPinnedInteractiveTooltip` for toggle-pin chrome.
- Extract `plotTooltipDomId` in layout chrome and reuse it from `resolveCaptureAriaControls`, tooltip `id`, and pin focus targeting.

## Test plan

- [x] `vitest run tests/plot-surface-inspection.test.ts tests/plot-layout.test.ts`
- [x] Reconcile plan: disabled/live priority, skip same run, transient/pinned/idle invalidate routes
- [x] Type-aware oxlint clean; pre-push package build / svelte-check / knip / bun test