### PR TITLE
fix: accept custom/SVG/anchor bare type chains after #96

### DIFF
--- a/packages/spec/tests/manual-at-alias-audit.test.ts
+++ b/packages/spec/tests/manual-at-alias-audit.test.ts
@@ -59,16 +59,21 @@ describe("manual AT alias commit audit", () => {
     // Multi-word English / tag-word prose after combinators stays documentation.
     expect(isSkippableCommentLine("* + positive values, if any")).toBe(true);
     expect(isSkippableCommentLine("* + positive values. Kept")).toBe(true);
-    expect(isSkippableCommentLine("* + a button")).toBe(true);
+    // "a button" is valid CSS (`a button` descendant); prefer AT false-positive on docs.
+    expect(isSkippableCommentLine("* + a button")).toBe(false);
     expect(isSkippableCommentLine("* + data table")).toBe(true);
     expect(isSkippableCommentLine("* + source code")).toBe(true);
-    // Arbitrary lowercase prose (not HTML/SVG tags) is documentation.
+    // Arbitrary lowercase prose (not HTML/SVG/custom tags) is documentation.
     expect(isSkippableCommentLine("* + minimum latency")).toBe(true);
     expect(isSkippableCommentLine("* > fallback content")).toBe(true);
-    // Real bare HTML/SVG tag chains (incl. camelCase SVG) stay CSS.
+    // Real bare HTML/SVG/custom tag chains stay CSS (incl. anchor-led, missing SVG, CE).
     expect(isSkippableCommentLine("* + section a")).toBe(false);
     expect(isSkippableCommentLine("* > main nav")).toBe(false);
     expect(isSkippableCommentLine("* > svg linearGradient")).toBe(false);
+    expect(isSkippableCommentLine("* > svg polygon")).toBe(false);
+    expect(isSkippableCommentLine("* > my-widget path")).toBe(false);
+    expect(isSkippableCommentLine("* + a span")).toBe(false);
+    expect(isSkippableCommentLine("* > a img")).toBe(false);
     // Continuations after multi-token chains (comma / nested combinators).
     expect(isSkippableCommentLine("* > ul li, ol li { margin: 0; }")).toBe(false);
     expect(isSkippableCommentLine("* > ul li > a { color: red; }")).toBe(false);

--- a/packages/spec/tests/manual-at-alias-audit.ts
+++ b/packages/spec/tests/manual-at-alias-audit.ts
@@ -34,7 +34,7 @@ export function diffTextIsSubstantive(diff: string): boolean {
 /**
  * Known HTML/SVG type selectors. Used for bare multi-token chains after a
  * combinator so arbitrary English (`minimum latency`) stays documentation while
- * real tag chains (`ul li`, `section a`, `svg linearGradient`) stay CSS.
+ * real tag chains (`ul li`, `a span`, `svg polygon`, `my-widget path`) stay CSS.
  * camelCase SVG names are stored as authored.
  */
 const CSS_TYPE_TOKEN = new Set(
@@ -49,35 +49,39 @@ const CSS_TYPE_TOKEN = new Set(
     "sub summary sup svg table tbody td template text textarea tfoot th thead " +
     "time title tr track u ul var video wbr use defs clipPath linearGradient " +
     "radialGradient stop tspan foreignObject pattern marker symbol switch " +
-    "animate animateTransform set image"
-  ).split(/\s+/),
-);
-
-/**
- * Leading tokens that make a bare multi-word chain read as English even when
- * later tokens are valid tag names (`* + a button`, `* + the table`).
- */
-const BARE_CHAIN_LEAD_BLOCK = new Set(
-  (
-    "a an the and or not is are was were be been being for with from that this " +
-    "these those of to in on at by as if any all each every"
+    "animate animateTransform set image polygon polyline ellipse textPath " +
+    "mask view feBlend feColorMatrix feComponentTransfer feComposite " +
+    "feConvolveMatrix feDiffuseLighting feDisplacementMap feDistantLight " +
+    "feDropShadow feFlood feFuncA feFuncB feFuncG feFuncR feGaussianBlur feImage " +
+    "feMerge feMergeNode feMorphology feOffset fePointLight feSpecularLighting " +
+    "feSpotLight feTile feTurbulence filter"
   ).split(/\s+/),
 );
 
 /**
  * English-first collocations that are HTML tag names but common in JSDoc lists
- * (`* + data table`, `* + source code`).
+ * (`* + data table`, `* + source code`). Not CSS `a span` / `a img`.
  */
 const BARE_CHAIN_PROSE_PAIR = new Set(["data table", "source code", "mark time", "object video"]);
 
+/** HTML custom elements must contain a hyphen (HTML living standard). */
+function isCustomElementToken(token: string): boolean {
+  return /^[a-z][\w]*-[\w-]+$/.test(token);
+}
+
 function isCssTypeToken(token: string): boolean {
-  return token === "*" || CSS_TYPE_TOKEN.has(token) || CSS_TYPE_TOKEN.has(token.toLowerCase());
+  return (
+    token === "*" ||
+    CSS_TYPE_TOKEN.has(token) ||
+    CSS_TYPE_TOKEN.has(token.toLowerCase()) ||
+    isCustomElementToken(token)
+  );
 }
 
 /**
  * After a CSS combinator (`+`, `>`, `~`), is the remainder a selector fragment?
  * Distinguishes `* + * {…}` / `* > .mark` / `* > ul li {…}` / `* > ul *` from
- * JSDoc/Markdown `* + list item`, `* + a button`, and `* > Note`.
+ * JSDoc/Markdown `* + list item` and `* > Note`.
  */
 function isCssSelectorAfterCombinator(rest: string): boolean {
   if (rest.length === 0) return false;
@@ -102,10 +106,8 @@ function isCssSelectorAfterCombinator(rest: string): boolean {
       const only = tokens[0]!;
       return only === "*" || /^[a-z][\w-]*$/.test(only);
     }
-    // Bare multi-token: known HTML/SVG types only (not arbitrary lowercase prose).
-    // Block article-led English and a few tag-word collocations.
-    const leadToken = tokens[0]!.toLowerCase();
-    if (BARE_CHAIN_LEAD_BLOCK.has(leadToken)) return false;
+    // Bare multi-token: HTML/SVG/custom-element types only (not English prose).
+    // Anchor-led chains (`a span`) are real CSS — do not blanket-skip lead `a`.
     if (BARE_CHAIN_PROSE_PAIR.has(tokens.map((t) => t.toLowerCase()).join(" "))) return false;
     return tokens.every((t) => isCssTypeToken(t));
   }


### PR DESCRIPTION
## Summary

Follow-up for unrebutted post-merge Codex P2s on #96:

1. Bare multi-token chains missed unlisted SVG types (`svg polygon`) and custom elements (`my-widget path`).
2. `BARE_CHAIN_LEAD_BLOCK` treated every `a`-led chain as prose, so real CSS (`a span`, `a img`) was skippable.

### Fix

- Expand HTML/SVG type allowlist; accept hyphenated custom elements.
- Remove blanket `a` lead block; keep only known JSDoc collocations (`data table`, `source code`).

## Test plan

- [x] `bun test packages/spec/tests/manual-at-alias-audit.test.ts` (6 pass)

## Verification evidence

```
$ bun test packages/spec/tests/manual-at-alias-audit.test.ts
6 pass, 0 fail
```