### PR TITLE
refactor(svelte): extract legend host effect decision plans

### DIFF
--- a/packages/svelte/src/lib/GGPlot.svelte
+++ b/packages/svelte/src/lib/GGPlot.svelte
@@ -234,11 +234,13 @@
   import {
     buildInteractiveLegendEntries,
     buildLegendEntryKeyIndexForPlot,
-    clampLegendRovingIndex,
     findLegendPressedIdentity,
     keysForLegendEntry,
     legendInteractionSource,
     moveLegendRovingIndex,
+    planLegendCommittedReconcile,
+    planLegendFocusDisabledClear,
+    planLegendRovingFocusSync,
     reconcileLegendPreview,
     resolveLegendEmphasisKeys,
     resolveLegendPreviewKeysDecision,
@@ -1180,17 +1182,23 @@
 
   $effect.pre(() => {
     const count = interactiveLegendEntries.length;
-    const nextIndex = clampLegendRovingIndex(legendRovingIndex, count);
     const active = document.activeElement;
+    // Number(dataset.index) may be NaN — pure plan maps non-finite → 0.
     const focusedIndex =
       active instanceof HTMLElement &&
       active.matches("[data-gg-legend-target]") &&
       root?.contains(active)
         ? Number(active.dataset["index"])
         : null;
-    if (nextIndex !== legendRovingIndex) legendRovingIndex = nextIndex;
-    if (focusedIndex === null || count === 0) return;
-    const returnIndex = clampLegendRovingIndex(focusedIndex, count);
+    const plan = planLegendRovingFocusSync({
+      currentRoving: legendRovingIndex,
+      entryCount: count,
+      focusedIndex,
+    });
+    if (plan.nextIndex !== legendRovingIndex)
+      legendRovingIndex = plan.nextIndex;
+    if (plan.type !== "refocus") return;
+    const returnIndex = plan.returnIndex;
     queueMicrotask(() => {
       root
         ?.querySelector<HTMLElement>(
@@ -1201,27 +1209,28 @@
   });
 
   $effect(() => {
-    const committed = legendCommitted;
-    if (committed === null) return;
-    const current = interactiveLegendEntries.find(
-      ({ identity }) =>
-        identity.scale === committed.identity.scale &&
-        identity.entryIndex === committed.identity.entryIndex,
-    );
-    const currentKeys =
-      current === undefined
-        ? []
-        : keysForLegendEntry(legendEntryKeyIndex, current.identity);
-    if (samePropertyKeySet(currentKeys, committed.keys)) return;
-
-    legendCommitted = null;
-    if (interaction === undefined && localEmphasisKeys.length > 0) {
-      localEmphasisKeys = [];
-      emitLegendFocus({
-        type: "legend-focus",
-        phase: "clear",
-        source: "programmatic",
-      });
+    const plan = planLegendCommittedReconcile({
+      committed: legendCommitted,
+      entries: interactiveLegendEntries,
+      keyIndex: legendEntryKeyIndex,
+      usesLocalEmphasis: interaction === undefined,
+      localEmphasisCount: localEmphasisKeys.length,
+    });
+    switch (plan.type) {
+      case "noop":
+        return;
+      case "clear-committed":
+        legendCommitted = null;
+        break;
+      case "clear-committed-local-emit":
+        legendCommitted = null;
+        localEmphasisKeys = [];
+        emitLegendFocus({
+          type: "legend-focus",
+          phase: "clear",
+          source: "programmatic",
+        });
+        break;
     }
   });
 
@@ -1247,16 +1256,26 @@
 
   // Drop chart-local emphasis when legend focus is turned off at runtime.
   $effect(() => {
-    if (interactionConfig.legendFocus !== null) return;
-    if (
-      legendPreview === null &&
-      localEmphasisKeys.length === 0 &&
-      legendCommitted === null
-    )
-      return;
-    legendPreview = null;
-    legendCommitted = null;
-    if (interaction === undefined) localEmphasisKeys = [];
+    const plan = planLegendFocusDisabledClear({
+      legendFocusEnabled: interactionConfig.legendFocus !== null,
+      hasPreview: legendPreview !== null,
+      hasCommitted: legendCommitted !== null,
+      hasLocalEmphasis: localEmphasisKeys.length > 0,
+      usesLocalEmphasis: interaction === undefined,
+    });
+    switch (plan.type) {
+      case "noop":
+        return;
+      case "clear-host":
+        legendPreview = null;
+        legendCommitted = null;
+        break;
+      case "clear-host-local":
+        legendPreview = null;
+        legendCommitted = null;
+        localEmphasisKeys = [];
+        break;
+    }
   });
 
   function legendAction(

--- a/packages/svelte/src/lib/plot-legend-focus.ts
+++ b/packages/svelte/src/lib/plot-legend-focus.ts
@@ -351,3 +351,117 @@ export function reconcileLegendPreview(input: {
   if (samePropertyKeySet(keys, input.preview.keys)) return input.preview;
   return { identity: current.identity, keys };
 }
+
+// ---- host legend $effect plans ----
+
+export type LegendCommittedState = {
+  readonly identity: LegendEntryIdentity;
+  readonly keys: readonly PropertyKey[];
+};
+
+export type LegendCommittedReconcilePlan =
+  | { readonly type: "noop" }
+  | { readonly type: "clear-committed" }
+  | { readonly type: "clear-committed-local-emit" };
+
+/**
+ * Pure plan for the committed-legend reconcile effect after data reshuffle.
+ *
+ * Owns entry lookup + key compare (same shape as `reconcileLegendPreview`).
+ * Host on non-noop: always nulls `legendCommitted`. On local-emit also clears
+ * chart-local emphasis keys and emits legend-focus clear.
+ *
+ *   1. no commit → noop
+ *   2. live keys still match → noop
+ *   3. mismatch + local emphasis active → clear-committed-local-emit
+ *   4. mismatch otherwise → clear-committed
+ */
+export function planLegendCommittedReconcile(input: {
+  readonly committed: LegendCommittedState | null;
+  readonly entries: readonly InteractiveLegendEntry[];
+  readonly keyIndex: ReadonlyMap<string, readonly PropertyKey[]>;
+  /** Host: `interaction === undefined`. */
+  readonly usesLocalEmphasis: boolean;
+  readonly localEmphasisCount: number;
+}): LegendCommittedReconcilePlan {
+  if (input.committed === null) return { type: "noop" };
+  const current = input.entries.find(
+    ({ identity }) =>
+      identity.scale === input.committed!.identity.scale &&
+      identity.entryIndex === input.committed!.identity.entryIndex,
+  );
+  const currentKeys =
+    current === undefined ? [] : keysForLegendEntry(input.keyIndex, current.identity);
+  if (samePropertyKeySet(currentKeys, input.committed.keys)) return { type: "noop" };
+  if (input.usesLocalEmphasis && input.localEmphasisCount > 0) {
+    return { type: "clear-committed-local-emit" };
+  }
+  return { type: "clear-committed" };
+}
+
+export type LegendFocusDisabledClearPlan =
+  | { readonly type: "noop" }
+  | { readonly type: "clear-host" }
+  | { readonly type: "clear-host-local" };
+
+/**
+ * Pure plan when legend focus is turned off at runtime.
+ *
+ *   1. still enabled → noop
+ *   2. host legend state already empty → noop
+ *   3. chart-local mode → clear preview+committed+localEmphasisKeys
+ *   4. controller mode → clear preview+committed only (controller emphasis stays)
+ */
+export function planLegendFocusDisabledClear(input: {
+  readonly legendFocusEnabled: boolean;
+  readonly hasPreview: boolean;
+  readonly hasCommitted: boolean;
+  readonly hasLocalEmphasis: boolean;
+  /** Host: `interaction === undefined`. */
+  readonly usesLocalEmphasis: boolean;
+}): LegendFocusDisabledClearPlan {
+  if (input.legendFocusEnabled) return { type: "noop" };
+  if (!input.hasPreview && !input.hasCommitted && !input.hasLocalEmphasis) {
+    return { type: "noop" };
+  }
+  return input.usesLocalEmphasis ? { type: "clear-host-local" } : { type: "clear-host" };
+}
+
+export type LegendRovingFocusSyncPlan =
+  | { readonly type: "noop"; readonly nextIndex: number }
+  | { readonly type: "clamp-roving"; readonly nextIndex: number }
+  | {
+      readonly type: "refocus";
+      readonly nextIndex: number;
+      readonly returnIndex: number;
+    };
+
+/**
+ * Pure plan for the legend roving-index `$effect.pre`.
+ *
+ * Host owns `document.activeElement` / dataset parse for `focusedIndex`.
+ * `Number(dataset.index)` yields NaN when missing — pass that through so
+ * `clampLegendRovingIndex` maps non-finite → 0 (refocus first entry).
+ *
+ *   - focusedIndex === null OR entryCount === 0 → no DOM refocus
+ *     (clamp-roving when nextIndex differs from current, else noop)
+ *   - otherwise → refocus with returnIndex = clamp(focusedIndex, count)
+ */
+export function planLegendRovingFocusSync(input: {
+  readonly currentRoving: number;
+  readonly entryCount: number;
+  /** null = focus not on a legend target inside root; may be NaN. */
+  readonly focusedIndex: number | null;
+}): LegendRovingFocusSyncPlan {
+  const nextIndex = clampLegendRovingIndex(input.currentRoving, input.entryCount);
+  if (input.focusedIndex === null || input.entryCount === 0) {
+    return nextIndex === input.currentRoving
+      ? { type: "noop", nextIndex }
+      : { type: "clamp-roving", nextIndex };
+  }
+  return {
+    type: "refocus",
+    nextIndex,
+    returnIndex: clampLegendRovingIndex(input.focusedIndex, input.entryCount),
+  };
+}

--- a/packages/svelte/tests/plot-legend-focus.test.ts
+++ b/packages/svelte/tests/plot-legend-focus.test.ts
@@ -12,6 +12,9 @@ import {
   legendIdentityKey,
   legendInteractionSource,
   moveLegendRovingIndex,
+  planLegendCommittedReconcile,
+  planLegendFocusDisabledClear,
+  planLegendRovingFocusSync,
   reconcileLegendPreview,
   resolveLegendEmphasisKeys,
   resolveLegendPreviewKeysDecision,
@@ -603,5 +606,207 @@ describe("InteractiveLegendEntry typing smoke", () => {
       source: "keyboard" as const,
     };
     expect(action.entry.label).toBe("Web");
+  });
+});
+
+describe("planLegendCommittedReconcile", () => {
+  const entries = buildInteractiveLegendEntries([discreteFill]);
+  const keyIndex = new Map<string, readonly PropertyKey[]>([
+    ["fill:0", Object.freeze(["a", "c"])],
+    ["fill:1", Object.freeze(["b"])],
+  ]);
+
+  it("noops when nothing is committed", () => {
+    expect(
+      planLegendCommittedReconcile({
+        committed: null,
+        entries,
+        keyIndex,
+        usesLocalEmphasis: true,
+        localEmphasisCount: 2,
+      }),
+    ).toEqual({ type: "noop" });
+  });
+
+  it("noops when live entry keys still match the commit", () => {
+    expect(
+      planLegendCommittedReconcile({
+        committed: { identity: { scale: "fill", entryIndex: 0 }, keys: ["a", "c"] },
+        entries,
+        keyIndex,
+        usesLocalEmphasis: true,
+        localEmphasisCount: 2,
+      }),
+    ).toEqual({ type: "noop" });
+  });
+
+  it("clears commit only on controller path when keys reshuffle", () => {
+    expect(
+      planLegendCommittedReconcile({
+        committed: { identity: { scale: "fill", entryIndex: 0 }, keys: ["stale"] },
+        entries,
+        keyIndex,
+        usesLocalEmphasis: false,
+        localEmphasisCount: 0,
+      }),
+    ).toEqual({ type: "clear-committed" });
+  });
+
+  it("clears commit only when local emphasis is already empty", () => {
+    expect(
+      planLegendCommittedReconcile({
+        committed: { identity: { scale: "fill", entryIndex: 0 }, keys: ["stale"] },
+        entries,
+        keyIndex,
+        usesLocalEmphasis: true,
+        localEmphasisCount: 0,
+      }),
+    ).toEqual({ type: "clear-committed" });
+  });
+
+  it("clears commit and local-emits when local emphasis is active", () => {
+    expect(
+      planLegendCommittedReconcile({
+        committed: { identity: { scale: "fill", entryIndex: 0 }, keys: ["stale"] },
+        entries,
+        keyIndex,
+        usesLocalEmphasis: true,
+        localEmphasisCount: 2,
+      }),
+    ).toEqual({ type: "clear-committed-local-emit" });
+  });
+
+  it("treats a missing entry as key mismatch (empty keys)", () => {
+    expect(
+      planLegendCommittedReconcile({
+        committed: { identity: { scale: "fill", entryIndex: 9 }, keys: ["x"] },
+        entries,
+        keyIndex,
+        usesLocalEmphasis: false,
+        localEmphasisCount: 0,
+      }),
+    ).toEqual({ type: "clear-committed" });
+  });
+});
+
+describe("planLegendFocusDisabledClear", () => {
+  it("noops while legend focus remains enabled", () => {
+    expect(
+      planLegendFocusDisabledClear({
+        legendFocusEnabled: true,
+        hasPreview: true,
+        hasCommitted: true,
+        hasLocalEmphasis: true,
+        usesLocalEmphasis: true,
+      }),
+    ).toEqual({ type: "noop" });
+  });
+
+  it("noops when focus is disabled but host legend state is already empty", () => {
+    expect(
+      planLegendFocusDisabledClear({
+        legendFocusEnabled: false,
+        hasPreview: false,
+        hasCommitted: false,
+        hasLocalEmphasis: false,
+        usesLocalEmphasis: true,
+      }),
+    ).toEqual({ type: "noop" });
+  });
+
+  it("clears host state without local keys on the controller path", () => {
+    expect(
+      planLegendFocusDisabledClear({
+        legendFocusEnabled: false,
+        hasPreview: true,
+        hasCommitted: false,
+        hasLocalEmphasis: false,
+        usesLocalEmphasis: false,
+      }),
+    ).toEqual({ type: "clear-host" });
+  });
+
+  it("clears host state and local emphasis when chart-local", () => {
+    expect(
+      planLegendFocusDisabledClear({
+        legendFocusEnabled: false,
+        hasPreview: false,
+        hasCommitted: true,
+        hasLocalEmphasis: true,
+        usesLocalEmphasis: true,
+      }),
+    ).toEqual({ type: "clear-host-local" });
+  });
+});
+
+describe("planLegendRovingFocusSync", () => {
+  it("noops when the roving index is already clamped and nothing is focused", () => {
+    expect(
+      planLegendRovingFocusSync({
+        currentRoving: 1,
+        entryCount: 3,
+        focusedIndex: null,
+      }),
+    ).toEqual({ type: "noop", nextIndex: 1 });
+  });
+
+  it("clamps roving without refocus when focus is outside the legend", () => {
+    expect(
+      planLegendRovingFocusSync({
+        currentRoving: 9,
+        entryCount: 3,
+        focusedIndex: null,
+      }),
+    ).toEqual({ type: "clamp-roving", nextIndex: 2 });
+  });
+
+  it("clamps without refocus when the entry list is empty", () => {
+    // count === 0 still clamps roving to 0, but skips DOM refocus even if
+    // focusedIndex is set (host returns before the focus microtask).
+    expect(
+      planLegendRovingFocusSync({
+        currentRoving: 2,
+        entryCount: 0,
+        focusedIndex: 1,
+      }),
+    ).toEqual({ type: "clamp-roving", nextIndex: 0 });
+    expect(
+      planLegendRovingFocusSync({
+        currentRoving: 0,
+        entryCount: 0,
+        focusedIndex: 1,
+      }),
+    ).toEqual({ type: "noop", nextIndex: 0 });
+  });
+
+  it("refocuses the clamped focused index when a target is focused", () => {
+    expect(
+      planLegendRovingFocusSync({
+        currentRoving: 0,
+        entryCount: 3,
+        focusedIndex: 5,
+      }),
+    ).toEqual({ type: "refocus", nextIndex: 0, returnIndex: 2 });
+  });
+
+  it("characterizes NaN focusedIndex as refocus entry 0 (dataset parse miss)", () => {
+    // Host does Number(dataset.index); missing/non-numeric yields NaN, not null.
+    expect(
+      planLegendRovingFocusSync({
+        currentRoving: 1,
+        entryCount: 3,
+        focusedIndex: Number.NaN,
+      }),
+    ).toEqual({ type: "refocus", nextIndex: 1, returnIndex: 0 });
+  });
+
+  it("refocuses and clamps roving together when both are out of range", () => {
+    expect(
+      planLegendRovingFocusSync({
+        currentRoving: 8,
+        entryCount: 2,
+        focusedIndex: 1,
+      }),
+    ).toEqual({ type: "refocus", nextIndex: 1, returnIndex: 1 });
   });
 });


### PR DESCRIPTION
## Summary
- Extract pure `planLegendCommittedReconcile`, `planLegendFocusDisabledClear`, and `planLegendRovingFocusSync` helpers from GGPlot legend `$effect` / `$effect.pre` host policy into `plot-legend-focus.ts`.
- Wire GGPlot to switch on the pure plans; host still owns DOM focus, mutation, and emit side effects.
- Add characterization tests (including `NaN` dataset-index → refocus entry 0).

## Test plan
- [x] `vitest run tests/plot-legend-focus.test.ts` (165 tests across chromium/webkit/firefox)
- [x] `svelte-check` clean for package
- [x] oxfmt/oxlint clean on touched files
- [x] Codex pre-PR review: no P1/P2 findings