### PR TITLE
refactor(core): split bind-layer validation and panel layout paths

### DIFF
--- a/packages/core/src/pipeline/bind-layer-helpers.ts
+++ b/packages/core/src/pipeline/bind-layer-helpers.ts
@@ -1,0 +1,96 @@
+/**
+ * Field-resolution helpers shared by bindLayer validation and assembly.
+ */
+import type { ChannelValue } from "@ggsvelte/spec";
+import { didYouMean } from "@ggsvelte/spec";
+
+import type { CellValue } from "../table.js";
+import type { ColumnTable } from "../table.js";
+
+import type { ColorBinding, PipelineWarning } from "./types.js";
+import { PipelineError } from "./types.js";
+
+/** y-channel { stat } columns each stat exposes (module-header contracts). */
+export const STAT_Y_COLUMNS: Record<string, readonly string[]> = {
+  identity: [],
+  count: ["count"],
+  bin: ["count", "density", "ncount", "ndensity"],
+  density: ["density", "count", "scaled", "ndensity"],
+  smooth: [],
+  boxplot: [],
+  summary: [],
+};
+
+export function checkField(
+  channel: ChannelValue | undefined,
+  channelName: string,
+  layerIndex: number,
+  table: ColumnTable,
+  warnings: PipelineWarning[],
+): string | null {
+  if (channel === undefined || channel === null) return null;
+  if (!("field" in channel)) return null;
+  if (!table.has(channel.field)) {
+    const suggestion = didYouMean(channel.field, table.fields);
+    throw new PipelineError(
+      "unknown-field",
+      `/layers/${layerIndex}/aes/${channelName}`,
+      `Unknown field "${channel.field}" (available: ${table.fields.join(", ") || "none"}).` +
+        (suggestion === undefined ? "" : ` Did you mean "${suggestion}"?`),
+    );
+  }
+  if (allNull(table.column(channel.field))) {
+    throw new PipelineError(
+      "all-null-column",
+      `/layers/${layerIndex}/aes/${channelName}`,
+      `Field "${channel.field}" contains only null values; the "${channelName}" channel cannot be drawn from it.`,
+    );
+  }
+  void warnings;
+  return channel.field;
+}
+
+function allNull(column: readonly CellValue[]): boolean {
+  if (column.length === 0) return false;
+  for (const v of column) if (v !== null) return false;
+  return true;
+}
+
+export function requireField(
+  field: string | null,
+  channelName: string,
+  layerIndex: number,
+  geom: string,
+): string {
+  if (field === null) {
+    throw new PipelineError(
+      "missing-channel",
+      `/layers/${layerIndex}/aes/${channelName}`,
+      `The ${geom} geom requires a "${channelName}" channel (map it with aes).`,
+    );
+  }
+  return field;
+}
+
+export function colorBinding(
+  channel: ChannelValue | undefined,
+  channelName: string,
+  layerIndex: number,
+  table: ColumnTable,
+  warnings: PipelineWarning[],
+): ColorBinding {
+  const out: ColorBinding = { field: null, constant: null, scaledConstant: null };
+  if (channel === undefined || channel === null) return out;
+  if ("field" in channel) {
+    out.field = checkField(channel, channelName, layerIndex, table, warnings);
+  } else if ("value" in channel) {
+    if (channel.scale === true) out.scaledConstant = channel.value;
+    else out.constant = String(channel.value);
+  } else {
+    warnings.push({
+      code: "stat-channel-unsupported",
+      message: `Layer ${layerIndex}: { stat } mappings on the "${channelName}" channel are not supported yet; the mapping is ignored.`,
+    });
+  }
+  return out;
+}

--- a/packages/core/src/pipeline/bind-layer-validate.ts
+++ b/packages/core/src/pipeline/bind-layer-validate.ts
@@ -1,0 +1,188 @@
+/**
+ * Geom/stat structural validation for bindLayer (rule forms, type mismatches,
+ * required channels, color-on-fill warnings).
+ */
+import type { Aes, BarParams, LayerSpec } from "@ggsvelte/spec";
+
+import type { ColumnTable } from "../table.js";
+
+import { requireField } from "./bind-layer-helpers.js";
+import type { ColorBinding, PipelineWarning, RuleForm } from "./types.js";
+import { PipelineError } from "./types.js";
+
+export function resolveRuleForm(layer: LayerSpec, index: number): RuleForm | null {
+  if (layer.geom !== "rule") return null;
+  const aes: Aes = layer.aes ?? {};
+  const params = layer.params ?? {};
+  const p = params as { xintercept?: unknown; yintercept?: unknown };
+  const hasIntercepts = p.xintercept !== undefined || p.yintercept !== undefined;
+  const xMapped = aes.x !== undefined && aes.x !== null;
+  const yMapped = aes.y !== undefined && aes.y !== null;
+  if (hasIntercepts && (xMapped || yMapped)) {
+    throw new PipelineError(
+      "rule-form-ambiguous",
+      `/layers/${index}`,
+      "This rule layer mixes the annotation form (params.xintercept/yintercept) with mapped aes.x/aes.y. Use fixed intercepts OR a data mapping, never both.",
+    );
+  }
+  if (!hasIntercepts && !xMapped && !yMapped) {
+    throw new PipelineError(
+      "rule-form-missing",
+      `/layers/${index}`,
+      "This rule layer has neither fixed intercepts (params.xintercept/yintercept) nor a mapped aes.x/aes.y — nothing to draw.",
+    );
+  }
+  if (!hasIntercepts && xMapped && yMapped) {
+    throw new PipelineError(
+      "rule-both-axes",
+      `/layers/${index}`,
+      "This rule layer maps BOTH aes.x and aes.y; a data-driven rule is either vertical (map x) or horizontal (map y). Unset the other channel with null.",
+    );
+  }
+  return hasIntercepts ? "annotation" : xMapped ? "vertical" : "horizontal";
+}
+
+export function validateGeomStatContracts(input: {
+  layer: LayerSpec;
+  index: number;
+  table: ColumnTable;
+  xField: string | null;
+  yField: string | null;
+}): void {
+  const { layer, index, table, xField, yField } = input;
+  const geom = layer.geom;
+  const stat = layer.stat ?? "identity";
+  const params = layer.params ?? {};
+
+  if (geom === "bar" && yField !== null) {
+    throw new PipelineError(
+      "computed-y-mapped",
+      `/layers/${index}/aes/y`,
+      `The bar geom computes y with the ${stat} stat, so aes.y must not map data. Use geom "col" for pre-computed heights.`,
+    );
+  }
+  if (geom === "density" && yField !== null) {
+    throw new PipelineError(
+      "computed-y-mapped",
+      `/layers/${index}/aes/y`,
+      "The density geom computes y with the density stat, so aes.y must not map data. Map only x.",
+    );
+  }
+  if (stat === "bin") {
+    const p = params as BarParams;
+    if (p.center !== undefined && p.boundary !== undefined) {
+      throw new PipelineError(
+        "bin-center-and-boundary",
+        `/layers/${index}/params`,
+        "The bin stat accepts params.center OR params.boundary (both align the bin grid), never both.",
+      );
+    }
+    if (xField !== null && table.fieldType(xField) === "nominal") {
+      throw new PipelineError(
+        "channel-type-mismatch",
+        `/layers/${index}/aes/x`,
+        `The bin stat needs a continuous x, but field "${xField}" is nominal. Use geom "bar" (the count stat) to count categories instead.`,
+      );
+    }
+  }
+  if (geom === "density" && xField !== null && table.fieldType(xField) === "nominal") {
+    throw new PipelineError(
+      "channel-type-mismatch",
+      `/layers/${index}/aes/x`,
+      `The density stat needs a continuous x, but field "${xField}" is nominal. Use geom "bar" (the count stat) to count categories instead.`,
+    );
+  }
+  if (geom === "smooth") {
+    for (const [channel, field] of [
+      ["x", xField],
+      ["y", yField],
+    ] as const) {
+      if (field !== null && table.fieldType(field) === "nominal") {
+        throw new PipelineError(
+          "channel-type-mismatch",
+          `/layers/${index}/aes/${channel}`,
+          `The smooth stat needs quantitative x and y, but field "${field}" (${channel}) is nominal.`,
+        );
+      }
+    }
+  }
+  if (geom === "boxplot") {
+    if (xField !== null && table.fieldType(xField) !== "nominal") {
+      throw new PipelineError(
+        "channel-type-mismatch",
+        `/layers/${index}/aes/x`,
+        `The boxplot geom needs a DISCRETE x this milestone, but field "${xField}" is ${table.fieldType(xField)}. Map x to a categorical field.`,
+      );
+    }
+    if (yField !== null && table.fieldType(yField) === "nominal") {
+      throw new PipelineError(
+        "channel-type-mismatch",
+        `/layers/${index}/aes/y`,
+        `The boxplot stat needs a quantitative y, but field "${yField}" is nominal.`,
+      );
+    }
+  }
+}
+
+export function assertRequiredChannels(input: {
+  geom: string;
+  stat: string;
+  index: number;
+  ruleForm: RuleForm | null;
+  xField: string | null;
+  yField: string | null;
+  yStatColumn: string | null;
+  yminField: string | null;
+  ymaxField: string | null;
+}): void {
+  const { geom, stat, index, ruleForm, xField, yField, yStatColumn, yminField, ymaxField } = input;
+
+  if (
+    geom === "point" ||
+    geom === "line" ||
+    geom === "col" ||
+    geom === "area" ||
+    geom === "text" ||
+    geom === "smooth" ||
+    geom === "boxplot"
+  ) {
+    requireField(xField, "x", index, geom);
+    if (yStatColumn === null) requireField(yField, "y", index, geom);
+  }
+  if (geom === "bar" || geom === "density") requireField(xField, "x", index, geom);
+  if (geom === "errorbar") {
+    requireField(xField, "x", index, geom);
+    if (stat === "summary") {
+      requireField(yField, "y", index, geom);
+    } else {
+      requireField(yminField, "ymin", index, geom);
+      requireField(ymaxField, "ymax", index, geom);
+    }
+  }
+  if (geom === "rule" && ruleForm === "vertical") requireField(xField, "x", index, geom);
+  if (geom === "rule" && ruleForm === "horizontal") requireField(yField, "y", index, geom);
+}
+
+export function applyColorOnFillGeomWarning(
+  geom: string,
+  index: number,
+  color: ColorBinding,
+  warnings: PipelineWarning[],
+): void {
+  if (
+    (geom === "bar" ||
+      geom === "col" ||
+      geom === "area" ||
+      geom === "boxplot" ||
+      geom === "density") &&
+    (color.field !== null || color.constant !== null || color.scaledConstant !== null)
+  ) {
+    warnings.push({
+      code: "color-on-fill-geom",
+      message: `Layer ${index} (${geom}): the color channel styles OUTLINES, which this geom does not support as a data channel yet — map "fill" instead. The color mapping is ignored.`,
+    });
+    color.field = null;
+    color.constant = null;
+    color.scaledConstant = null;
+  }
+}

--- a/packages/core/src/pipeline/bind-layer.ts
+++ b/packages/core/src/pipeline/bind-layer.ts
@@ -1,99 +1,19 @@
 /**
  * Per-layer aes channel resolution and structural geom/stat validation.
  */
-import type { Aes, BarParams, ChannelValue, LayerSpec } from "@ggsvelte/spec";
-import { didYouMean } from "@ggsvelte/spec";
+import type { Aes, LayerSpec } from "@ggsvelte/spec";
 
-import type { CellValue } from "../table.js";
 import type { ColumnTable } from "../table.js";
 
-import type { ColorBinding, LayerBinding, PipelineWarning, RuleForm } from "./types.js";
+import { STAT_Y_COLUMNS, checkField, colorBinding } from "./bind-layer-helpers.js";
+import {
+  applyColorOnFillGeomWarning,
+  assertRequiredChannels,
+  resolveRuleForm,
+  validateGeomStatContracts,
+} from "./bind-layer-validate.js";
+import type { LayerBinding, PipelineWarning } from "./types.js";
 import { PipelineError } from "./types.js";
-
-/** y-channel { stat } columns each stat exposes (module-header contracts). */
-const STAT_Y_COLUMNS: Record<string, readonly string[]> = {
-  identity: [],
-  count: ["count"],
-  bin: ["count", "density", "ncount", "ndensity"],
-  density: ["density", "count", "scaled", "ndensity"],
-  smooth: [],
-  boxplot: [],
-  summary: [],
-};
-
-function checkField(
-  channel: ChannelValue | undefined,
-  channelName: string,
-  layerIndex: number,
-  table: ColumnTable,
-  warnings: PipelineWarning[],
-): string | null {
-  if (channel === undefined || channel === null) return null;
-  if (!("field" in channel)) return null;
-  if (!table.has(channel.field)) {
-    const suggestion = didYouMean(channel.field, table.fields);
-    throw new PipelineError(
-      "unknown-field",
-      `/layers/${layerIndex}/aes/${channelName}`,
-      `Unknown field "${channel.field}" (available: ${table.fields.join(", ") || "none"}).` +
-        (suggestion === undefined ? "" : ` Did you mean "${suggestion}"?`),
-    );
-  }
-  if (allNull(table.column(channel.field))) {
-    throw new PipelineError(
-      "all-null-column",
-      `/layers/${layerIndex}/aes/${channelName}`,
-      `Field "${channel.field}" contains only null values; the "${channelName}" channel cannot be drawn from it.`,
-    );
-  }
-  void warnings;
-  return channel.field;
-}
-
-function allNull(column: readonly CellValue[]): boolean {
-  if (column.length === 0) return false;
-  for (const v of column) if (v !== null) return false;
-  return true;
-}
-
-function requireField(
-  field: string | null,
-  channelName: string,
-  layerIndex: number,
-  geom: string,
-): string {
-  if (field === null) {
-    throw new PipelineError(
-      "missing-channel",
-      `/layers/${layerIndex}/aes/${channelName}`,
-      `The ${geom} geom requires a "${channelName}" channel (map it with aes).`,
-    );
-  }
-  return field;
-}
-
-function colorBinding(
-  channel: ChannelValue | undefined,
-  channelName: string,
-  layerIndex: number,
-  table: ColumnTable,
-  warnings: PipelineWarning[],
-): ColorBinding {
-  const out: ColorBinding = { field: null, constant: null, scaledConstant: null };
-  if (channel === undefined || channel === null) return out;
-  if ("field" in channel) {
-    out.field = checkField(channel, channelName, layerIndex, table, warnings);
-  } else if ("value" in channel) {
-    if (channel.scale === true) out.scaledConstant = channel.value;
-    else out.constant = String(channel.value);
-  } else {
-    warnings.push({
-      code: "stat-channel-unsupported",
-      message: `Layer ${layerIndex}: { stat } mappings on the "${channelName}" channel are not supported yet; the mapping is ignored.`,
-    });
-  }
-  return out;
-}
 
 export function bindLayer(
   layer: LayerSpec,
@@ -103,38 +23,8 @@ export function bindLayer(
 ): LayerBinding {
   const aes: Aes = layer.aes ?? {};
   const geom = layer.geom;
-  const params = layer.params ?? {};
 
-  // --- rule: two honest forms ------------------------------------------------
-  let ruleForm: RuleForm | null = null;
-  if (geom === "rule") {
-    const p = params as { xintercept?: unknown; yintercept?: unknown };
-    const hasIntercepts = p.xintercept !== undefined || p.yintercept !== undefined;
-    const xMapped = aes.x !== undefined && aes.x !== null;
-    const yMapped = aes.y !== undefined && aes.y !== null;
-    if (hasIntercepts && (xMapped || yMapped)) {
-      throw new PipelineError(
-        "rule-form-ambiguous",
-        `/layers/${index}`,
-        "This rule layer mixes the annotation form (params.xintercept/yintercept) with mapped aes.x/aes.y. Use fixed intercepts OR a data mapping, never both.",
-      );
-    }
-    if (!hasIntercepts && !xMapped && !yMapped) {
-      throw new PipelineError(
-        "rule-form-missing",
-        `/layers/${index}`,
-        "This rule layer has neither fixed intercepts (params.xintercept/yintercept) nor a mapped aes.x/aes.y — nothing to draw.",
-      );
-    }
-    if (!hasIntercepts && xMapped && yMapped) {
-      throw new PipelineError(
-        "rule-both-axes",
-        `/layers/${index}`,
-        "This rule layer maps BOTH aes.x and aes.y; a data-driven rule is either vertical (map x) or horizontal (map y). Unset the other channel with null.",
-      );
-    }
-    ruleForm = hasIntercepts ? "annotation" : xMapped ? "vertical" : "horizontal";
-  }
+  const ruleForm = resolveRuleForm(layer, index);
 
   const stat = layer.stat ?? "identity";
   const xField = checkField(aes.x, "x", index, table, warnings);
@@ -155,104 +45,23 @@ export function bindLayer(
     yField = checkField(y, "y", index, table, warnings);
   }
 
-  if (geom === "bar" && yField !== null) {
-    throw new PipelineError(
-      "computed-y-mapped",
-      `/layers/${index}/aes/y`,
-      `The bar geom computes y with the ${stat} stat, so aes.y must not map data. Use geom "col" for pre-computed heights.`,
-    );
-  }
-  if (geom === "density" && yField !== null) {
-    throw new PipelineError(
-      "computed-y-mapped",
-      `/layers/${index}/aes/y`,
-      "The density geom computes y with the density stat, so aes.y must not map data. Map only x.",
-    );
-  }
-  if (stat === "bin") {
-    const p = params as BarParams;
-    if (p.center !== undefined && p.boundary !== undefined) {
-      throw new PipelineError(
-        "bin-center-and-boundary",
-        `/layers/${index}/params`,
-        "The bin stat accepts params.center OR params.boundary (both align the bin grid), never both.",
-      );
-    }
-    if (xField !== null && table.fieldType(xField) === "nominal") {
-      throw new PipelineError(
-        "channel-type-mismatch",
-        `/layers/${index}/aes/x`,
-        `The bin stat needs a continuous x, but field "${xField}" is nominal. Use geom "bar" (the count stat) to count categories instead.`,
-      );
-    }
-  }
-  if (geom === "density" && xField !== null && table.fieldType(xField) === "nominal") {
-    throw new PipelineError(
-      "channel-type-mismatch",
-      `/layers/${index}/aes/x`,
-      `The density stat needs a continuous x, but field "${xField}" is nominal. Use geom "bar" (the count stat) to count categories instead.`,
-    );
-  }
-  if (geom === "smooth") {
-    for (const [channel, field] of [
-      ["x", xField],
-      ["y", yField],
-    ] as const) {
-      if (field !== null && table.fieldType(field) === "nominal") {
-        throw new PipelineError(
-          "channel-type-mismatch",
-          `/layers/${index}/aes/${channel}`,
-          `The smooth stat needs quantitative x and y, but field "${field}" (${channel}) is nominal.`,
-        );
-      }
-    }
-  }
-  if (geom === "boxplot") {
-    if (xField !== null && table.fieldType(xField) !== "nominal") {
-      throw new PipelineError(
-        "channel-type-mismatch",
-        `/layers/${index}/aes/x`,
-        `The boxplot geom needs a DISCRETE x this milestone, but field "${xField}" is ${table.fieldType(xField)}. Map x to a categorical field.`,
-      );
-    }
-    if (yField !== null && table.fieldType(yField) === "nominal") {
-      throw new PipelineError(
-        "channel-type-mismatch",
-        `/layers/${index}/aes/y`,
-        `The boxplot stat needs a quantitative y, but field "${yField}" is nominal.`,
-      );
-    }
-  }
+  validateGeomStatContracts({ layer, index, table, xField, yField });
 
   // --- ymin/ymax (errorbar identity form) --------------------------------------
   const yminField = checkField(aes.ymin, "ymin", index, table, warnings);
   const ymaxField = checkField(aes.ymax, "ymax", index, table, warnings);
 
-  // --- required channels ------------------------------------------------------
-  if (
-    geom === "point" ||
-    geom === "line" ||
-    geom === "col" ||
-    geom === "area" ||
-    geom === "text" ||
-    geom === "smooth" ||
-    geom === "boxplot"
-  ) {
-    requireField(xField, "x", index, geom);
-    if (yStatColumn === null) requireField(yField, "y", index, geom);
-  }
-  if (geom === "bar" || geom === "density") requireField(xField, "x", index, geom);
-  if (geom === "errorbar") {
-    requireField(xField, "x", index, geom);
-    if (stat === "summary") {
-      requireField(yField, "y", index, geom);
-    } else {
-      requireField(yminField, "ymin", index, geom);
-      requireField(ymaxField, "ymax", index, geom);
-    }
-  }
-  if (geom === "rule" && ruleForm === "vertical") requireField(xField, "x", index, geom);
-  if (geom === "rule" && ruleForm === "horizontal") requireField(yField, "y", index, geom);
+  assertRequiredChannels({
+    geom,
+    stat,
+    index,
+    ruleForm,
+    xField,
+    yField,
+    yStatColumn,
+    yminField,
+    ymaxField,
+  });
 
   // --- label / weight ----------------------------------------------------------
   let labelField: string | null = null;
@@ -273,22 +82,7 @@ export function bindLayer(
 
   const color = colorBinding(aes.color, "color", index, table, warnings);
   const fill = colorBinding(aes.fill, "fill", index, table, warnings);
-  if (
-    (geom === "bar" ||
-      geom === "col" ||
-      geom === "area" ||
-      geom === "boxplot" ||
-      geom === "density") &&
-    (color.field !== null || color.constant !== null || color.scaledConstant !== null)
-  ) {
-    warnings.push({
-      code: "color-on-fill-geom",
-      message: `Layer ${index} (${geom}): the color channel styles OUTLINES, which this geom does not support as a data channel yet — map "fill" instead. The color mapping is ignored.`,
-    });
-    color.field = null;
-    color.constant = null;
-    color.scaledConstant = null;
-  }
+  applyColorOnFillGeomWarning(geom, index, color, warnings);
   if (weightField !== null && (stat === "boxplot" || stat === "smooth" || stat === "summary")) {
     warnings.push({
       code: "weight-unsupported",

--- a/packages/core/src/pipeline/panel-layout-facet.ts
+++ b/packages/core/src/pipeline/panel-layout-facet.ts
@@ -1,0 +1,149 @@
+/**
+ * Facet-grid panel placement: shared margin pass, free-scale edge axes, strips.
+ */
+import type { LayoutTheme, Margins, PassResult, TickFormatter } from "../layout/layout.js";
+import { layout, layoutPass } from "../layout/layout.js";
+import type { TextMeasurer } from "../layout/measure.js";
+import { PANEL_SPACING, STRIP_BAND } from "../scene.js";
+
+import type { FacetPanelDef } from "./facets.js";
+import {
+  LEGEND_EDGE_PAD,
+  LEGEND_GAP,
+  elementwiseMaxMargins,
+  layoutDomain,
+} from "./layout-helpers.js";
+import type { DisplayScalesFn, PanelPlacement } from "./panel-layout-types.js";
+
+export function placeFacetPanels(input: {
+  facetPanels: readonly FacetPanelDef[];
+  nrow: number;
+  ncol: number;
+  freeH: boolean;
+  freeV: boolean;
+  outerLeftTitle: string;
+  outerBottomTitle: string;
+  axisTitleBand: number;
+  legendWidth: number;
+  optionsWidth: number;
+  layoutHeight: number;
+  topBand: number;
+  displayScales: DisplayScalesFn;
+  hBreaks: readonly (number | string)[] | undefined;
+  vBreaks: readonly (number | string)[] | undefined;
+  formatH: TickFormatter | undefined;
+  formatV: TickFormatter | undefined;
+  measurer: TextMeasurer;
+  layoutTheme: LayoutTheme;
+}): PanelPlacement[] {
+  const {
+    facetPanels,
+    nrow,
+    ncol,
+    freeH,
+    freeV,
+    outerLeftTitle,
+    outerBottomTitle,
+    axisTitleBand,
+    legendWidth,
+    optionsWidth,
+    layoutHeight,
+    topBand,
+    displayScales,
+    hBreaks,
+    vBreaks,
+    formatH,
+    formatV,
+    measurer,
+    layoutTheme,
+  } = input;
+
+  const spacing = PANEL_SPACING;
+  const strip = STRIP_BAND;
+  const outerLeft = outerLeftTitle === "" ? 0 : axisTitleBand;
+  const outerBottom = outerBottomTitle === "" ? 0 : axisTitleBand;
+  const outerRight = legendWidth > 0 ? legendWidth + LEGEND_GAP + LEGEND_EDGE_PAD : 0;
+  const gridW = Math.max(40, optionsWidth - outerLeft - outerRight);
+  const gridH = Math.max(40, layoutHeight - outerBottom);
+
+  const approxW = Math.max(40, (gridW - (ncol - 1) * spacing) / ncol);
+  const approxH = Math.max(40, (gridH - nrow * strip - (nrow - 1) * spacing) / nrow);
+  let mMax: Margins = { top: 0, right: 0, bottom: 0, left: 0 };
+  for (let p = 0; p < facetPanels.length; p++) {
+    const { h, v } = displayScales(p);
+    const run = layout({
+      width: approxW,
+      height: approxH,
+      x: layoutDomain(h, hBreaks),
+      y: layoutDomain(v, vBreaks),
+      ...(formatH !== undefined && { formatX: formatH }),
+      ...(formatV !== undefined && { formatY: formatV }),
+      measurer,
+      theme: layoutTheme,
+    });
+    mMax = elementwiseMaxMargins(mMax, run.margins);
+  }
+
+  const leftCount = freeV ? ncol : 1;
+  const bottomCount = freeH ? nrow : 1;
+  const panelW = Math.max(
+    1,
+    (gridW - leftCount * mMax.left - mMax.right - (ncol - 1) * spacing) / ncol,
+  );
+  const panelH = Math.max(
+    1,
+    (gridH - mMax.top - bottomCount * mMax.bottom - nrow * strip - (nrow - 1) * spacing) / nrow,
+  );
+
+  const colX: number[] = [];
+  let xCursor = outerLeft;
+  for (let c = 0; c < ncol; c++) {
+    if (c === 0 || freeV) xCursor += mMax.left;
+    colX.push(xCursor);
+    xCursor += panelW + spacing;
+  }
+  const rowY: number[] = [];
+  let yCursor = topBand + mMax.top;
+  for (let r = 0; r < nrow; r++) {
+    yCursor += strip;
+    rowY.push(yCursor);
+    yCursor += panelH;
+    if (r === nrow - 1 || freeH) yCursor += mMax.bottom;
+    yCursor += spacing;
+  }
+
+  const bottomMostRow: number[] = Array.from({ length: ncol }, () => 0);
+  for (const def of facetPanels) {
+    if (def.row > bottomMostRow[def.col]!) bottomMostRow[def.col] = def.row;
+  }
+
+  const placements: PanelPlacement[] = [];
+  for (let p = 0; p < facetPanels.length; p++) {
+    const def = facetPanels[p]!;
+    const { h, v } = displayScales(p);
+    const ticksRun: PassResult = layoutPass(
+      mMax,
+      {
+        width: panelW + mMax.left + mMax.right,
+        height: panelH + mMax.top + mMax.bottom,
+        x: layoutDomain(h, hBreaks),
+        y: layoutDomain(v, vBreaks),
+        ...(formatH !== undefined && { formatX: formatH }),
+        ...(formatV !== undefined && { formatY: formatV }),
+        measurer,
+      },
+      layoutTheme,
+    );
+    placements.push({
+      x: colX[def.col]!,
+      y: rowY[def.row]!,
+      width: panelW,
+      height: panelH,
+      ticksH: ticksRun.x.ticks,
+      ticksV: ticksRun.y.ticks,
+      showAxisX: freeH || def.row === bottomMostRow[def.col]!,
+      showAxisY: freeV || def.col === 0,
+    });
+  }
+  return placements;
+}

--- a/packages/core/src/pipeline/panel-layout-single.ts
+++ b/packages/core/src/pipeline/panel-layout-single.ts
@@ -1,0 +1,74 @@
+/**
+ * Single-panel layout placement with axis-title and legend reserves.
+ */
+import type { LayoutTheme, Margins, TickFormatter } from "../layout/layout.js";
+import { layout } from "../layout/layout.js";
+import type { TextMeasurer } from "../layout/measure.js";
+import type { PositionScale } from "../scales/train.js";
+
+import { LEGEND_EDGE_PAD, LEGEND_GAP, layoutDomain } from "./layout-helpers.js";
+import type { PanelPlacement } from "./panel-layout-types.js";
+
+export function placeSinglePanel(input: {
+  h: PositionScale;
+  v: PositionScale;
+  hTitle: string;
+  vTitle: string;
+  axisTitleBand: number;
+  legendWidth: number;
+  optionsWidth: number;
+  layoutHeight: number;
+  topBand: number;
+  hBreaks: readonly (number | string)[] | undefined;
+  vBreaks: readonly (number | string)[] | undefined;
+  formatH: TickFormatter | undefined;
+  formatV: TickFormatter | undefined;
+  measurer: TextMeasurer;
+  layoutTheme: LayoutTheme;
+}): PanelPlacement {
+  const {
+    h,
+    v,
+    hTitle,
+    vTitle,
+    axisTitleBand,
+    legendWidth,
+    optionsWidth,
+    layoutHeight,
+    topBand,
+    hBreaks,
+    vBreaks,
+    formatH,
+    formatV,
+    measurer,
+    layoutTheme,
+  } = input;
+
+  const reserve: Partial<Margins> = {
+    ...(hTitle !== "" && { bottom: axisTitleBand }),
+    ...(vTitle !== "" && { left: axisTitleBand }),
+    ...(legendWidth > 0 && { right: legendWidth + LEGEND_GAP + LEGEND_EDGE_PAD }),
+  };
+  const layoutResult = layout({
+    width: optionsWidth,
+    height: layoutHeight,
+    x: layoutDomain(h, hBreaks),
+    y: layoutDomain(v, vBreaks),
+    ...(formatH !== undefined && { formatX: formatH }),
+    ...(formatV !== undefined && { formatY: formatV }),
+    measurer,
+    reserve,
+    theme: layoutTheme,
+  });
+  const margins = layoutResult.margins;
+  return {
+    x: margins.left,
+    y: topBand + margins.top,
+    width: Math.max(1, optionsWidth - margins.left - margins.right),
+    height: Math.max(1, layoutHeight - margins.top - margins.bottom),
+    ticksH: layoutResult.x.ticks,
+    ticksV: layoutResult.y.ticks,
+    showAxisX: true,
+    showAxisY: true,
+  };
+}

--- a/packages/core/src/pipeline/panel-layout-types.ts
+++ b/packages/core/src/pipeline/panel-layout-types.ts
@@ -1,0 +1,35 @@
+/**
+ * Shared panel layout result types.
+ */
+import type { LayoutResult, TickFormatter } from "../layout/layout.js";
+import type { PositionScale } from "../scales/train.js";
+import { buildLegends } from "../legend.js";
+
+export interface PanelPlacement {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  ticksH: LayoutResult["x"]["ticks"];
+  ticksV: LayoutResult["y"]["ticks"];
+  showAxisX: boolean;
+  showAxisY: boolean;
+}
+
+export interface PanelLayoutResult {
+  placements: PanelPlacement[];
+  title: string;
+  subtitle: string;
+  caption: string;
+  hTitle: string;
+  vTitle: string;
+  xTitle: string;
+  yTitle: string;
+  topBand: number;
+  formatX: TickFormatter | undefined;
+  formatY: TickFormatter | undefined;
+  displayScales: (p: number) => { h: PositionScale; v: PositionScale };
+  legendBlock: ReturnType<typeof buildLegends>;
+}
+
+export type DisplayScalesFn = (p: number) => { h: PositionScale; v: PositionScale };

--- a/packages/core/src/pipeline/panel-layout.ts
+++ b/packages/core/src/pipeline/panel-layout.ts
@@ -5,55 +5,27 @@
 import type { PortableSpec } from "@ggsvelte/spec";
 
 import { FONT_METRICS } from "../layout/font-metrics.js";
-import type { LayoutResult, Margins, PassResult, TickFormatter } from "../layout/layout.js";
-import { DEFAULT_LAYOUT_THEME, layout, layoutPass } from "../layout/layout.js";
+import { DEFAULT_LAYOUT_THEME } from "../layout/layout.js";
 import { MetricsTableMeasurer } from "../layout/measure.js";
 import type { LegendInput, LegendOrder } from "../legend.js";
 import { buildLegends } from "../legend.js";
 import type { PositionScale } from "../scales/train.js";
-import { PANEL_SPACING, STRIP_BAND } from "../scene.js";
 import type { ThemeTokens } from "../theme.js";
 
 import type { FacetPanelDef } from "./facets.js";
 import {
   AXIS_TITLE_BAND,
   CAPTION_BAND,
-  LEGEND_EDGE_PAD,
-  LEGEND_GAP,
   SUBTITLE_BAND,
   TITLE_BAND,
-  elementwiseMaxMargins,
-  layoutDomain,
   makeAxisFormatter,
 } from "./layout-helpers.js";
+import { placeFacetPanels } from "./panel-layout-facet.js";
+import { placeSinglePanel } from "./panel-layout-single.js";
+import type { PanelLayoutResult, PanelPlacement } from "./panel-layout-types.js";
 import type { LayerFrame, PipelineWarning, RunOptions } from "./types.js";
 
-export interface PanelPlacement {
-  x: number;
-  y: number;
-  width: number;
-  height: number;
-  ticksH: LayoutResult["x"]["ticks"];
-  ticksV: LayoutResult["y"]["ticks"];
-  showAxisX: boolean;
-  showAxisY: boolean;
-}
-
-export interface PanelLayoutResult {
-  placements: PanelPlacement[];
-  title: string;
-  subtitle: string;
-  caption: string;
-  hTitle: string;
-  vTitle: string;
-  xTitle: string;
-  yTitle: string;
-  topBand: number;
-  formatX: TickFormatter | undefined;
-  formatY: TickFormatter | undefined;
-  displayScales: (p: number) => { h: PositionScale; v: PositionScale };
-  legendBlock: ReturnType<typeof buildLegends>;
-}
+export type { PanelPlacement, PanelLayoutResult } from "./panel-layout-types.js";
 
 export function computePanelLayout(input: {
   flip: boolean;
@@ -144,124 +116,51 @@ export function computePanelLayout(input: {
   );
 
   const layoutHeight = Math.max(40, options.height - topBand - bottomBand);
-  const placements: PanelPlacement[] = [];
+  let placements: PanelPlacement[];
 
   if (faceted) {
-    const spacing = PANEL_SPACING;
-    const strip = STRIP_BAND;
-    const outerLeft = vTitle === "" ? 0 : axisTitleBand;
-    const outerBottom = hTitle === "" ? 0 : axisTitleBand;
-    const outerRight = legendBlock.width > 0 ? legendBlock.width + LEGEND_GAP + LEGEND_EDGE_PAD : 0;
-    const gridW = Math.max(40, options.width - outerLeft - outerRight);
-    const gridH = Math.max(40, layoutHeight - outerBottom);
-
-    const approxW = Math.max(40, (gridW - (ncol - 1) * spacing) / ncol);
-    const approxH = Math.max(40, (gridH - nrow * strip - (nrow - 1) * spacing) / nrow);
-    let mMax: Margins = { top: 0, right: 0, bottom: 0, left: 0 };
-    for (let p = 0; p < facetPanels.length; p++) {
-      const { h, v } = displayScales(p);
-      const run = layout({
-        width: approxW,
-        height: approxH,
-        x: layoutDomain(h, hBreaks),
-        y: layoutDomain(v, vBreaks),
-        ...(formatH !== undefined && { formatX: formatH }),
-        ...(formatV !== undefined && { formatY: formatV }),
-        measurer,
-        theme: layoutTheme,
-      });
-      mMax = elementwiseMaxMargins(mMax, run.margins);
-    }
-
-    const leftCount = freeV ? ncol : 1;
-    const bottomCount = freeH ? nrow : 1;
-    const panelW = Math.max(
-      1,
-      (gridW - leftCount * mMax.left - mMax.right - (ncol - 1) * spacing) / ncol,
-    );
-    const panelH = Math.max(
-      1,
-      (gridH - mMax.top - bottomCount * mMax.bottom - nrow * strip - (nrow - 1) * spacing) / nrow,
-    );
-
-    const colX: number[] = [];
-    let xCursor = outerLeft;
-    for (let c = 0; c < ncol; c++) {
-      if (c === 0 || freeV) xCursor += mMax.left;
-      colX.push(xCursor);
-      xCursor += panelW + spacing;
-    }
-    const rowY: number[] = [];
-    let yCursor = topBand + mMax.top;
-    for (let r = 0; r < nrow; r++) {
-      yCursor += strip;
-      rowY.push(yCursor);
-      yCursor += panelH;
-      if (r === nrow - 1 || freeH) yCursor += mMax.bottom;
-      yCursor += spacing;
-    }
-
-    const bottomMostRow: number[] = Array.from({ length: ncol }, () => 0);
-    for (const def of facetPanels) {
-      if (def.row > bottomMostRow[def.col]!) bottomMostRow[def.col] = def.row;
-    }
-
-    for (let p = 0; p < facetPanels.length; p++) {
-      const def = facetPanels[p]!;
-      const { h, v } = displayScales(p);
-      const ticksRun: PassResult = layoutPass(
-        mMax,
-        {
-          width: panelW + mMax.left + mMax.right,
-          height: panelH + mMax.top + mMax.bottom,
-          x: layoutDomain(h, hBreaks),
-          y: layoutDomain(v, vBreaks),
-          ...(formatH !== undefined && { formatX: formatH }),
-          ...(formatV !== undefined && { formatY: formatV }),
-          measurer,
-        },
-        layoutTheme,
-      );
-      placements.push({
-        x: colX[def.col]!,
-        y: rowY[def.row]!,
-        width: panelW,
-        height: panelH,
-        ticksH: ticksRun.x.ticks,
-        ticksV: ticksRun.y.ticks,
-        showAxisX: freeH || def.row === bottomMostRow[def.col]!,
-        showAxisY: freeV || def.col === 0,
-      });
-    }
+    placements = placeFacetPanels({
+      facetPanels,
+      nrow,
+      ncol,
+      freeH,
+      freeV,
+      outerLeftTitle: vTitle,
+      outerBottomTitle: hTitle,
+      axisTitleBand,
+      legendWidth: legendBlock.width,
+      optionsWidth: options.width,
+      layoutHeight,
+      topBand,
+      displayScales,
+      hBreaks,
+      vBreaks,
+      formatH,
+      formatV,
+      measurer,
+      layoutTheme,
+    });
   } else {
     const { h, v } = displayScales(0);
-    const reserve: Partial<Margins> = {
-      ...(hTitle !== "" && { bottom: axisTitleBand }),
-      ...(vTitle !== "" && { left: axisTitleBand }),
-      ...(legendBlock.width > 0 && { right: legendBlock.width + LEGEND_GAP + LEGEND_EDGE_PAD }),
-    };
-    const layoutResult = layout({
-      width: options.width,
-      height: layoutHeight,
-      x: layoutDomain(h, hBreaks),
-      y: layoutDomain(v, vBreaks),
-      ...(formatH !== undefined && { formatX: formatH }),
-      ...(formatV !== undefined && { formatY: formatV }),
-      measurer,
-      reserve,
-      theme: layoutTheme,
-    });
-    const margins = layoutResult.margins;
-    placements.push({
-      x: margins.left,
-      y: topBand + margins.top,
-      width: Math.max(1, options.width - margins.left - margins.right),
-      height: Math.max(1, layoutHeight - margins.top - margins.bottom),
-      ticksH: layoutResult.x.ticks,
-      ticksV: layoutResult.y.ticks,
-      showAxisX: true,
-      showAxisY: true,
-    });
+    placements = [
+      placeSinglePanel({
+        h,
+        v,
+        hTitle,
+        vTitle,
+        axisTitleBand,
+        legendWidth: legendBlock.width,
+        optionsWidth: options.width,
+        layoutHeight,
+        topBand,
+        hBreaks,
+        vBreaks,
+        formatH,
+        formatV,
+        measurer,
+        layoutTheme,
+      }),
+    ];
   }
 
   return {

--- a/packages/core/tests/pipeline-bind.test.ts
+++ b/packages/core/tests/pipeline-bind.test.ts
@@ -130,6 +130,86 @@ describe("bindLayer", () => {
 
     const vert = bindLayer({ geom: "rule", aes: { x: { field: "x" } } }, 0, table, []);
     expect(vert.ruleForm).toBe("vertical");
+
+    const horiz = bindLayer({ geom: "rule", aes: { y: { field: "y" } } }, 0, table, []);
+    expect(horiz.ruleForm).toBe("horizontal");
+  });
+
+  it("rejects rule form that maps both axes", () => {
+    try {
+      bindLayer({ geom: "rule", aes: { x: { field: "x" }, y: { field: "y" } } }, 0, table, []);
+      expect.unreachable("should throw");
+    } catch (e) {
+      expect(e).toBeInstanceOf(PipelineError);
+      expect((e as PipelineError).code).toBe("rule-both-axes");
+    }
+  });
+
+  it("rejects rule that mixes intercepts with mapped channels", () => {
+    try {
+      bindLayer(
+        { geom: "rule", params: { yintercept: 1 }, aes: { x: { field: "x" } } },
+        0,
+        table,
+        [],
+      );
+      expect.unreachable("should throw");
+    } catch (e) {
+      expect(e).toBeInstanceOf(PipelineError);
+      expect((e as PipelineError).code).toBe("rule-form-ambiguous");
+    }
+  });
+
+  it("requires text label channel", () => {
+    try {
+      bindLayer({ geom: "text", aes: { x: { field: "x" }, y: { field: "y" } } }, 0, table, []);
+      expect.unreachable("should throw");
+    } catch (e) {
+      expect(e).toBeInstanceOf(PipelineError);
+      expect((e as PipelineError).code).toBe("missing-channel");
+      expect((e as PipelineError).path).toContain("label");
+    }
+  });
+
+  it("warns color-on-fill-geom and clears color for bar-like geoms", () => {
+    const warnings: { code: string; message: string }[] = [];
+    const binding = bindLayer(
+      {
+        geom: "col",
+        aes: { x: { field: "g" }, y: { field: "y" }, color: { field: "g" }, fill: { field: "g" } },
+      },
+      0,
+      table,
+      warnings,
+    );
+    expect(warnings.some((w) => w.code === "color-on-fill-geom")).toBe(true);
+    expect(binding.color.field).toBeNull();
+    expect(binding.fill.field).toBe("g");
+  });
+
+  it("binds errorbar ymin/ymax identity form", () => {
+    const binding = bindLayer(
+      {
+        geom: "errorbar",
+        aes: { x: { field: "g" }, ymin: { field: "x" }, ymax: { field: "y" } },
+      },
+      0,
+      table,
+      [],
+    );
+    expect(binding.yminField).toBe("x");
+    expect(binding.ymaxField).toBe("y");
+    expect(binding.xField).toBe("g");
+  });
+
+  it("rejects smooth on nominal channels", () => {
+    try {
+      bindLayer({ geom: "smooth", aes: { x: { field: "g" }, y: { field: "y" } } }, 0, table, []);
+      expect.unreachable("should throw");
+    } catch (e) {
+      expect(e).toBeInstanceOf(PipelineError);
+      expect((e as PipelineError).code).toBe("channel-type-mismatch");
+    }
   });
 });
 

--- a/packages/core/tests/pipeline-panel-layout.test.ts
+++ b/packages/core/tests/pipeline-panel-layout.test.ts
@@ -52,4 +52,47 @@ describe("panel layout via runPipeline", () => {
     // strips reserve a band above panels
     expect(model.scene.panels[0]!.y).toBeGreaterThanOrEqual(STRIP_BAND);
   });
+
+  it("facet free_y shows y axes on every column (not only the left edge)", () => {
+    const model = runPipeline(
+      gg(
+        [
+          { x: 1, y: 1, g: "a" },
+          { x: 2, y: 10, g: "b" },
+          { x: 3, y: 100, g: "c" },
+          { x: 4, y: 2, g: "d" },
+        ],
+        aes({ x: "x", y: "y" }),
+      )
+        .geomPoint()
+        .facet({ wrap: "g", scales: "free_y", ncol: 2 })
+        .spec(),
+      size,
+    );
+    expect(model.scene.panels).toHaveLength(4);
+    // free_y: each column gets its own y axis chrome
+    const withY = model.scene.panels.filter((p) => p.axisY !== null);
+    expect(withY.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("labs and flip swap axis title orientation on the scene", () => {
+    const model = runPipeline(
+      gg(
+        [
+          { x: 1, y: 10 },
+          { x: 2, y: 20 },
+        ],
+        aes({ x: "x", y: "y" }),
+      )
+        .geomPoint()
+        .labs({ x: "Miles", y: "Gallons", title: "Mileage" })
+        .coord({ type: "flip" })
+        .spec(),
+      size,
+    );
+    expect(model.scene.title).toBe("Mileage");
+    // under flip, semantic x title renders on the vertical axis
+    expect(model.scene.axes.y.title).toBe("Miles");
+    expect(model.scene.axes.x.title).toBe("Gallons");
+  });
 });


### PR DESCRIPTION
## Summary

- Split `bind-layer` into field helpers (`bind-layer-helpers`) and geom/stat contracts (`bind-layer-validate`), keeping `bindLayer` as a thin assembler.
- Split `computePanelLayout` into facet-grid (`panel-layout-facet`) and single-panel (`panel-layout-single`) placement with shared types; public API unchanged.
- Expand characterization tests for rule forms, color-on-fill warnings, errorbar channels, free_y axes, and coord-flip labs.

## Test plan

- [x] `bun run check`
- [x] `bun test packages/core` (460 pass)
- [x] `bun run knip`
- [x] `bun run lint:type-aware`
- [x] pre-push hooks on push