### PR TITLE
fix: avoid hover re-running scene-inspect reconcile after #101

### DIFF
--- a/packages/svelte/src/lib/GGPlot.svelte
+++ b/packages/svelte/src/lib/GGPlot.svelte
@@ -1459,7 +1459,10 @@
     const currentModel = model;
     const plan = planSceneInspectReconcile({
       inspectionEnabled: interactionConfig.inspect !== null,
-      inspectionState: inspection === null ? "none" : inspection.state,
+      // Thunk: do not read `inspection` on the same-run skip path so hover
+      // updates are not effect dependencies of scene-run reconcile.
+      getInspectionState: () =>
+        inspection === null ? "none" : inspection.state,
       modelRunId: currentModel?.runId ?? null,
       reconciledRun,
     });

--- a/packages/svelte/src/lib/plot-surface-inspection.ts
+++ b/packages/svelte/src/lib/plot-surface-inspection.ts
@@ -372,24 +372,29 @@ export type SceneInspectReconcilePlan =
  *
  * Host on every invalidate-*: clear queues, cancel scheduled pointer, set
  * reconciledRun to the new model runId, then branch-specific side effects.
+ *
+ * `getInspectionState` is a thunk so the host `$effect` can avoid reading
+ * hover `inspection` state on the skip path (same runId) — otherwise every
+ * transient pointer update would re-run this effect only to hit skip.
  */
 export function planSceneInspectReconcile(input: {
   readonly inspectionEnabled: boolean;
-  /** Host: `inspection === null ? "none" : inspection.state`. */
-  readonly inspectionState: InspectionHostState;
+  /** Host: `() => (inspection === null ? "none" : inspection.state)`. */
+  readonly getInspectionState: () => InspectionHostState;
   readonly modelRunId: number | null;
   readonly reconciledRun: number;
 }): SceneInspectReconcilePlan {
   if (!input.inspectionEnabled) {
-    return input.inspectionState === "none" ? { type: "noop" } : { type: "clear-disabled" };
+    return input.getInspectionState() === "none" ? { type: "noop" } : { type: "clear-disabled" };
   }
   if (input.modelRunId === null || input.modelRunId === input.reconciledRun) {
     return { type: "skip" };
   }
-  if (input.inspectionState === "transient") {
+  const inspectionState = input.getInspectionState();
+  if (inspectionState === "transient") {
     return { type: "invalidate-clear-transient" };
   }
-  if (input.inspectionState === "pinned") {
+  if (inspectionState === "pinned") {
     return { type: "invalidate-reconcile-pinned" };
   }
   return { type: "invalidate-idle" };

--- a/packages/svelte/tests/plot-surface-inspection.test.ts
+++ b/packages/svelte/tests/plot-surface-inspection.test.ts
@@ -654,7 +654,7 @@ describe("planSceneInspectReconcile", () => {
     expect(
       planSceneInspectReconcile({
         inspectionEnabled: false,
-        inspectionState: "none",
+        getInspectionState: () => "none",
         modelRunId: 1,
         reconciledRun: 0,
       }),
@@ -662,18 +662,23 @@ describe("planSceneInspectReconcile", () => {
     expect(
       planSceneInspectReconcile({
         inspectionEnabled: false,
-        inspectionState: "pinned",
+        getInspectionState: () => "pinned",
         modelRunId: 1,
         reconciledRun: 0,
       }),
     ).toEqual({ type: "clear-disabled" });
   });
 
-  it("skips when model is missing or run is already reconciled", () => {
+  it("skips when model is missing or run is already reconciled without reading inspection", () => {
+    let reads = 0;
+    const getInspectionState = (): "none" | "transient" | "pinned" => {
+      reads += 1;
+      return "transient";
+    };
     expect(
       planSceneInspectReconcile({
         inspectionEnabled: true,
-        inspectionState: "pinned",
+        getInspectionState,
         modelRunId: null,
         reconciledRun: 0,
       }),
@@ -681,18 +686,19 @@ describe("planSceneInspectReconcile", () => {
     expect(
       planSceneInspectReconcile({
         inspectionEnabled: true,
-        inspectionState: "transient",
+        getInspectionState,
         modelRunId: 3,
         reconciledRun: 3,
       }),
     ).toEqual({ type: "skip" });
+    expect(reads).toBe(0);
   });
 
   it("routes advanced runs by inspection state (enabled-off already handled)", () => {
     expect(
       planSceneInspectReconcile({
         inspectionEnabled: true,
-        inspectionState: "transient",
+        getInspectionState: () => "transient",
         modelRunId: 2,
         reconciledRun: 1,
       }),
@@ -700,7 +706,7 @@ describe("planSceneInspectReconcile", () => {
     expect(
       planSceneInspectReconcile({
         inspectionEnabled: true,
-        inspectionState: "pinned",
+        getInspectionState: () => "pinned",
         modelRunId: 2,
         reconciledRun: 1,
       }),
@@ -708,7 +714,7 @@ describe("planSceneInspectReconcile", () => {
     expect(
       planSceneInspectReconcile({
         inspectionEnabled: true,
-        inspectionState: "none",
+        getInspectionState: () => "none",
         modelRunId: 2,
         reconciledRun: 1,
       }),


### PR DESCRIPTION
## Summary

Follow-up for unrebutted post-merge Codex P2 on #101.

`planSceneInspectReconcile` was called with `inspectionState: inspection === null ? "none" : inspection.state`, so the host `$effect` tracked `inspection` even on the same-`runId` skip path. Every transient pointer hover re-ran scene reconcile only to return `skip`.

### Fix

- Change the pure plan API to `getInspectionState: () => InspectionHostState`.
- Call the thunk only when inspect is disabled (clear-disabled vs noop) or the model run has advanced.
- Same-run / missing-model skip path does not read inspection (covered by unit test `reads === 0`).

## Test plan

- [x] `vitest run tests/plot-surface-inspection.test.ts` (52 tests × 3 browsers)

## Verification evidence

```
$ bunx vitest run tests/plot-surface-inspection.test.ts
156 passed
```