### PR TITLE
refactor(core): split candidate datum, layout chrome, and smooth geometry

### DIFF
--- a/packages/core/src/pipeline/build-candidates-datum.ts
+++ b/packages/core/src/pipeline/build-candidates-datum.ts
@@ -2,16 +2,16 @@
  * Stat/annotation candidate datum resolver: reconstructs series, ranks, and
  * represented source-row lineages from layer frames + identity index.
  */
-import type { BarParams } from "@ggsvelte/spec";
-
 import type { CandidateBuildFacts, CandidateDatum } from "../candidate-store.js";
 import type { LineageStore } from "../identity.js";
 import type { Scene } from "../scene.js";
 import { bandKey } from "../scales/train.js";
 import type { CellValue } from "../table.js";
-import { cellToNumber, ColumnTable } from "../table.js";
+import type { ColumnTable } from "../table.js";
 
+import { resolveCandidateFrameRow } from "./build-candidates-frame-row.js";
 import type { CandidateIdentityIndex } from "./build-candidates-identity.js";
+import { filterRepresentedSourceRows } from "./build-candidates-lineage.js";
 import type { FacetPanelDef } from "./facets.js";
 import { candidateAutoMode } from "./frame.js";
 import type { MappedField } from "./types.js";
@@ -57,38 +57,13 @@ export function createIdentityCandidateDatumResolver(input: {
         ? null
         : (facetPanels[facts.panelIndex]?.sourceRows?.[outlierLocalRow] ?? outlierLocalRow);
     const orderedGroups = frameGroups.get(`${facts.panelIndex}:${facts.layerIndex}`) ?? [0];
-    let frameRow = Math.min(facts.primitiveIndex, Math.max(0, (frame?.n ?? 1) - 1));
-    let derivedGroup = frame?.groups[frameRow] ?? 0;
-    if (frame !== undefined && batch.kind === "paths") {
-      let subpath = 0;
-      while (
-        subpath + 1 < batch.pathOffsets.length &&
-        facts.primitiveIndex >= batch.pathOffsets[subpath + 1]!
-      )
-        subpath++;
-      derivedGroup = orderedGroups[Math.min(subpath, orderedGroups.length - 1)] ?? 0;
-      const rowsInGroup = frame.groups
-        .map((group, row) => ({ group, row }))
-        .filter((entry) => entry.group === derivedGroup)
-        .map((entry) => entry.row)
-        .toSorted((a, b) => (frame.xNumeric?.[a] ?? a) - (frame.xNumeric?.[b] ?? b));
-      const local = facts.primitiveIndex - (batch.pathOffsets[subpath] ?? 0);
-      const reflected =
-        local < rowsInGroup.length ? local : Math.max(0, rowsInGroup.length * 2 - 1 - local);
-      frameRow = rowsInGroup[Math.min(reflected, rowsInGroup.length - 1)] ?? frameRow;
-    } else if (frame !== undefined && batch.kind === "segments") {
-      if (frame.binding.layer.geom === "errorbar") frameRow = Math.floor(facts.primitiveIndex / 3);
-      else if (frame.binding.layer.geom === "boxplot" && batch.rowIndex.length >= frame.n * 2)
-        frameRow = Math.floor(facts.primitiveIndex / 2);
-      derivedGroup = frame.groups[Math.min(frameRow, frame.groups.length - 1)] ?? derivedGroup;
-    } else if (
-      frame?.box !== null &&
-      frame?.binding.layer.geom === "boxplot" &&
-      batch.kind === "points"
-    ) {
-      frameRow = frame.box.outlierBox[facts.primitiveIndex] ?? frameRow;
-      derivedGroup = frame.groups[frameRow] ?? derivedGroup;
-    }
+    const { frameRow, derivedGroup } = resolveCandidateFrameRow({
+      frame,
+      batch,
+      primitiveIndex: facts.primitiveIndex,
+      orderedGroups,
+      outlierLocalRow,
+    });
     const sourceValue = (field: string | undefined): CellValue =>
       sourceRow === null || field === undefined ? null : table.column(field)[sourceRow]!;
     const xField = fields.find((field) => field.channel === "x")?.field;
@@ -120,47 +95,12 @@ export function createIdentityCandidateDatumResolver(input: {
         ? (sourceRowsByGroup.get(`${facts.panelIndex}:${facts.layerIndex}:${group}`) ?? [])
         : [outlierSourceRow];
     if (sourceRow === null && frame !== undefined) {
-      const stat = frame.binding.layer.stat ?? "identity";
-      const aggregateXField = frame.binding.xField;
-      const outputX = frame.xValues?.[frameRow] ?? frame.xNumeric?.[frameRow] ?? null;
-      if (
-        aggregateXField !== null &&
-        outputX !== null &&
-        (stat === "count" || stat === "summary" || stat === "boxplot")
-      ) {
-        const outputKey = bandKey(outputX);
-        representedRows = representedRows.filter(
-          (row) => bandKey(table.column(aggregateXField)[row]) === outputKey,
-        );
-      } else if (
-        stat === "bin" &&
-        aggregateXField !== null &&
-        frame.xmin !== null &&
-        frame.xmax !== null
-      ) {
-        const hi = frame.xmax[frameRow]!;
-        const lo = frame.xmin[frameRow]!;
-        const closed = ((frame.binding.layer.params ?? {}) as BarParams).closed ?? "right";
-        const frameGroup = frame.groups[frameRow];
-        const firstInGroup = frameRow === 0 || frame.groups[frameRow - 1] !== frameGroup;
-        const lastInGroup = frameRow === frame.n - 1 || frame.groups[frameRow + 1] !== frameGroup;
-        representedRows = representedRows.filter((row) => {
-          const value = cellToNumber(table.column(aggregateXField)[row]!);
-          if (!Number.isFinite(value)) return false;
-          return closed === "right"
-            ? value <= hi && (value > lo || (firstInGroup && value >= lo))
-            : value >= lo && (value < hi || (lastInGroup && value <= hi));
-        });
-      }
-      const aggregateYField = frame.binding.yField;
-      if (
-        (stat === "smooth" || stat === "summary" || stat === "boxplot") &&
-        aggregateYField !== null
-      ) {
-        representedRows = representedRows.filter((row) =>
-          Number.isFinite(cellToNumber(table.column(aggregateYField)[row]!)),
-        );
-      }
+      representedRows = filterRepresentedSourceRows({
+        frame,
+        table,
+        frameRow,
+        baseRows: representedRows,
+      });
     }
     return {
       xValue: annotationRule

--- a/packages/core/src/pipeline/build-candidates-frame-row.ts
+++ b/packages/core/src/pipeline/build-candidates-frame-row.ts
@@ -1,0 +1,54 @@
+/**
+ * Map a scene primitive back to a post-stat frame row and series group.
+ */
+import type { GeometryBatch } from "../scene.js";
+
+import type { LayerFrame } from "./types.js";
+
+export function resolveCandidateFrameRow(input: {
+  frame: LayerFrame | undefined;
+  batch: GeometryBatch;
+  primitiveIndex: number;
+  orderedGroups: readonly number[];
+  outlierLocalRow: number | null;
+}): { frameRow: number; derivedGroup: number } {
+  const { frame, batch, primitiveIndex, orderedGroups, outlierLocalRow } = input;
+  let frameRow = Math.min(primitiveIndex, Math.max(0, (frame?.n ?? 1) - 1));
+  let derivedGroup = frame?.groups[frameRow] ?? 0;
+
+  if (frame !== undefined && batch.kind === "paths") {
+    let subpath = 0;
+    while (
+      subpath + 1 < batch.pathOffsets.length &&
+      primitiveIndex >= batch.pathOffsets[subpath + 1]!
+    )
+      subpath++;
+    derivedGroup = orderedGroups[Math.min(subpath, orderedGroups.length - 1)] ?? 0;
+    const rowsInGroup = frame.groups
+      .map((group, row) => ({ group, row }))
+      .filter((entry) => entry.group === derivedGroup)
+      .map((entry) => entry.row)
+      .toSorted((a, b) => (frame.xNumeric?.[a] ?? a) - (frame.xNumeric?.[b] ?? b));
+    const local = primitiveIndex - (batch.pathOffsets[subpath] ?? 0);
+    const reflected =
+      local < rowsInGroup.length ? local : Math.max(0, rowsInGroup.length * 2 - 1 - local);
+    frameRow = rowsInGroup[Math.min(reflected, rowsInGroup.length - 1)] ?? frameRow;
+  } else if (frame !== undefined && batch.kind === "segments") {
+    if (frame.binding.layer.geom === "errorbar") frameRow = Math.floor(primitiveIndex / 3);
+    else if (frame.binding.layer.geom === "boxplot" && batch.rowIndex.length >= frame.n * 2)
+      frameRow = Math.floor(primitiveIndex / 2);
+    derivedGroup = frame.groups[Math.min(frameRow, frame.groups.length - 1)] ?? derivedGroup;
+  } else if (
+    frame?.box !== null &&
+    frame?.binding.layer.geom === "boxplot" &&
+    batch.kind === "points"
+  ) {
+    frameRow = frame.box.outlierBox[primitiveIndex] ?? frameRow;
+    derivedGroup = frame.groups[frameRow] ?? derivedGroup;
+  } else if (outlierLocalRow !== null && frame !== undefined) {
+    // outlier points already resolved via outlierBox above when geom matches;
+    // keep default frameRow for other point batches.
+  }
+
+  return { frameRow, derivedGroup };
+}

--- a/packages/core/src/pipeline/build-candidates-lineage.ts
+++ b/packages/core/src/pipeline/build-candidates-lineage.ts
@@ -1,0 +1,61 @@
+/**
+ * Reconstruct represented source rows for aggregate (stat-synthesized) marks.
+ */
+import type { BarParams } from "@ggsvelte/spec";
+
+import { bandKey } from "../scales/train.js";
+import { cellToNumber, ColumnTable } from "../table.js";
+
+import type { LayerFrame } from "./types.js";
+
+export function filterRepresentedSourceRows(input: {
+  frame: LayerFrame;
+  table: ColumnTable;
+  frameRow: number;
+  baseRows: readonly number[];
+}): number[] {
+  const { frame, table, frameRow } = input;
+  let representedRows = [...input.baseRows];
+  const stat = frame.binding.layer.stat ?? "identity";
+  const aggregateXField = frame.binding.xField;
+  const outputX = frame.xValues?.[frameRow] ?? frame.xNumeric?.[frameRow] ?? null;
+
+  if (
+    aggregateXField !== null &&
+    outputX !== null &&
+    (stat === "count" || stat === "summary" || stat === "boxplot")
+  ) {
+    const outputKey = bandKey(outputX);
+    representedRows = representedRows.filter(
+      (row) => bandKey(table.column(aggregateXField)[row]) === outputKey,
+    );
+  } else if (
+    stat === "bin" &&
+    aggregateXField !== null &&
+    frame.xmin !== null &&
+    frame.xmax !== null
+  ) {
+    const hi = frame.xmax[frameRow]!;
+    const lo = frame.xmin[frameRow]!;
+    const closed = ((frame.binding.layer.params ?? {}) as BarParams).closed ?? "right";
+    const frameGroup = frame.groups[frameRow];
+    const firstInGroup = frameRow === 0 || frame.groups[frameRow - 1] !== frameGroup;
+    const lastInGroup = frameRow === frame.n - 1 || frame.groups[frameRow + 1] !== frameGroup;
+    representedRows = representedRows.filter((row) => {
+      const value = cellToNumber(table.column(aggregateXField)[row]!);
+      if (!Number.isFinite(value)) return false;
+      return closed === "right"
+        ? value <= hi && (value > lo || (firstInGroup && value >= lo))
+        : value >= lo && (value < hi || (lastInGroup && value <= hi));
+    });
+  }
+
+  const aggregateYField = frame.binding.yField;
+  if ((stat === "smooth" || stat === "summary" || stat === "boxplot") && aggregateYField !== null) {
+    representedRows = representedRows.filter((row) =>
+      Number.isFinite(cellToNumber(table.column(aggregateYField)[row]!)),
+    );
+  }
+
+  return representedRows;
+}

--- a/packages/core/src/pipeline/geometry-smooth-line.ts
+++ b/packages/core/src/pipeline/geometry-smooth-line.ts
@@ -1,0 +1,59 @@
+/**
+ * Smooth fitted-line path batch.
+ */
+import type { SmoothParams } from "@ggsvelte/spec";
+
+import type { GeometryBatch } from "../scene.js";
+
+import type { LayerFrame, ResolvedColorScale } from "./types.js";
+import type { Frame } from "./geometry-shared.js";
+import { positionOf } from "./geometry-shared.js";
+import { DEFAULT_SMOOTH_LINEWIDTH, groupColor } from "./geometry-smooth-shared.js";
+
+export function buildSmoothLineBatch(input: {
+  frame: LayerFrame;
+  fx: Frame;
+  color: ResolvedColorScale | null;
+  groupRows: readonly (readonly number[])[];
+}): GeometryBatch {
+  const { frame, fx, color, groupRows } = input;
+  const { binding } = frame;
+  const params = (binding.layer.params ?? {}) as SmoothParams;
+
+  let total = 0;
+  for (const rows of groupRows) total += rows.length;
+  const positions = new Float32Array(total * 2);
+  const rowIndex = new Uint32Array(total);
+  const pathOffsets = new Uint32Array(groupRows.length + 1);
+  const strokes: (string | null)[] = [];
+  let cursor = 0;
+  for (let s = 0; s < groupRows.length; s++) {
+    pathOffsets[s] = cursor;
+    const rows = groupRows[s]!;
+    for (const row of rows) {
+      const tx = positionOf(fx.xScale, frame.xNumeric, frame.xValues, row);
+      const ty = positionOf(fx.yScale, frame.yNumeric, null, row);
+      positions[cursor * 2] = tx * fx.innerWidth;
+      positions[cursor * 2 + 1] = fx.innerHeight - ty * fx.innerHeight;
+      rowIndex[cursor] = frame.rowIndex[row]!;
+      cursor++;
+    }
+    strokes.push(
+      groupColor(color, frame.colorValues, binding.color.scaledConstant, rows[0]!) ??
+        binding.color.constant,
+    );
+  }
+  pathOffsets[groupRows.length] = cursor;
+  return {
+    kind: "paths",
+    layerIndex: binding.index,
+    panelIndex: 0,
+    positions,
+    rowIndex,
+    pathOffsets,
+    strokes,
+    linewidth: params.linewidth ?? DEFAULT_SMOOTH_LINEWIDTH,
+    alpha: params.alpha ?? 1,
+    curve: "linear",
+  };
+}

--- a/packages/core/src/pipeline/geometry-smooth-ribbon.ts
+++ b/packages/core/src/pipeline/geometry-smooth-ribbon.ts
@@ -1,0 +1,85 @@
+/**
+ * Smooth confidence ribbon (closed path under the fitted line).
+ */
+import type { GeometryBatch } from "../scene.js";
+
+import type { LayerFrame, ResolvedColorScale } from "./types.js";
+import type { Frame } from "./geometry-shared.js";
+import { positionOf } from "./geometry-shared.js";
+import { groupColor, SMOOTH_RIBBON_ALPHA } from "./geometry-smooth-shared.js";
+
+export function buildSmoothRibbonBatch(input: {
+  frame: LayerFrame;
+  fx: Frame;
+  color: ResolvedColorScale | null;
+  fill: ResolvedColorScale | null;
+  groupRows: readonly (readonly number[])[];
+}): GeometryBatch | null {
+  const { frame, fx, color, fill, groupRows } = input;
+  const { binding } = frame;
+  if (!frame.smoothBand || frame.ymin === null || frame.ymax === null) return null;
+
+  const bandRows = groupRows
+    .map((rows) =>
+      rows.filter(
+        (row) => Number.isFinite(frame.ymin![row]!) && Number.isFinite(frame.ymax![row]!),
+      ),
+    )
+    .filter((rows) => rows.length > 1);
+  if (bandRows.length === 0) return null;
+
+  let total = 0;
+  for (const rows of bandRows) total += rows.length * 2;
+  const positions = new Float32Array(total * 2);
+  const rowIndex = new Uint32Array(total);
+  const pathOffsets = new Uint32Array(bandRows.length + 1);
+  const fills: (string | null)[] = [];
+  const strokes: (string | null)[] = [];
+  let cursor = 0;
+  for (let s = 0; s < bandRows.length; s++) {
+    pathOffsets[s] = cursor;
+    const rows = bandRows[s]!;
+    for (const row of rows) {
+      const tx = positionOf(fx.xScale, frame.xNumeric, frame.xValues, row);
+      const ty = fx.yScale.type === "band" ? NaN : fx.yScale.normalize(frame.ymax[row]!);
+      positions[cursor * 2] = tx * fx.innerWidth;
+      positions[cursor * 2 + 1] = fx.innerHeight - ty * fx.innerHeight;
+      rowIndex[cursor] = frame.rowIndex[row]!;
+      cursor++;
+    }
+    for (let i = rows.length - 1; i >= 0; i--) {
+      const row = rows[i]!;
+      const tx = positionOf(fx.xScale, frame.xNumeric, frame.xValues, row);
+      const ty = fx.yScale.type === "band" ? NaN : fx.yScale.normalize(frame.ymin[row]!);
+      positions[cursor * 2] = tx * fx.innerWidth;
+      positions[cursor * 2 + 1] = fx.innerHeight - ty * fx.innerHeight;
+      rowIndex[cursor] = frame.rowIndex[row]!;
+      cursor++;
+    }
+    const first = rows[0]!;
+    // Ribbon tint: fill channel, else the line's color (band matches
+    // its line in multi-series smooths), else theme accent.
+    const ribbonFill =
+      groupColor(fill, frame.fillValues, binding.fill.scaledConstant, first) ??
+      binding.fill.constant ??
+      groupColor(color, frame.colorValues, binding.color.scaledConstant, first) ??
+      binding.color.constant;
+    fills.push(ribbonFill);
+    strokes.push(null);
+  }
+  pathOffsets[bandRows.length] = cursor;
+  return {
+    kind: "paths",
+    layerIndex: binding.index,
+    panelIndex: 0,
+    positions,
+    rowIndex,
+    pathOffsets,
+    strokes,
+    fills,
+    closed: true,
+    linewidth: 0,
+    alpha: SMOOTH_RIBBON_ALPHA,
+    curve: "linear",
+  };
+}

--- a/packages/core/src/pipeline/geometry-smooth-shared.ts
+++ b/packages/core/src/pipeline/geometry-smooth-shared.ts
@@ -1,0 +1,24 @@
+/**
+ * Shared helpers for smooth geometry batches.
+ */
+import type { CellValue } from "../table.js";
+
+import type { ResolvedColorScale } from "./types.js";
+import { colorOf } from "./types.js";
+
+/** Ribbon fill opacity (ggplot2 uses 0.4 on grey60; 0.3 reads better over
+ *  theme-accent fills — decision 0010). */
+export const SMOOTH_RIBBON_ALPHA = 0.3;
+export const DEFAULT_SMOOTH_LINEWIDTH = 1;
+
+/** Per-subpath color resolution for grouped batches (first row decides). */
+export function groupColor(
+  resolved: ResolvedColorScale | null,
+  values: readonly CellValue[] | null,
+  scaledConstant: CellValue | null,
+  firstRow: number,
+): string | null {
+  if (resolved === null || (values === null && scaledConstant === null)) return null;
+  const value = values === null ? scaledConstant! : values[firstRow]!;
+  return colorOf(resolved, value);
+}

--- a/packages/core/src/pipeline/geometry-smooth.ts
+++ b/packages/core/src/pipeline/geometry-smooth.ts
@@ -1,32 +1,13 @@
 /**
  * Smooth geometry: optional confidence ribbon plus fitted line.
  */
-import type { SmoothParams } from "@ggsvelte/spec";
-
 import type { GeometryBatch } from "../scene.js";
-import type { CellValue } from "../table.js";
 
 import type { LayerFrame, PipelineWarning, ResolvedColorScale } from "./types.js";
-import { colorOf } from "./types.js";
 import type { Frame } from "./geometry-shared.js";
-import { bucketByGroup, positionOf, xSortKey } from "./geometry-shared.js";
-
-const DEFAULT_SMOOTH_LINEWIDTH = 1;
-/** Ribbon fill opacity (ggplot2 uses 0.4 on grey60; 0.3 reads better over
- *  theme-accent fills — decision 0010). */
-const SMOOTH_RIBBON_ALPHA = 0.3;
-
-/** Per-subpath color resolution for grouped batches (first row decides). */
-function groupColor(
-  resolved: ResolvedColorScale | null,
-  values: readonly CellValue[] | null,
-  scaledConstant: CellValue | null,
-  firstRow: number,
-): string | null {
-  if (resolved === null || (values === null && scaledConstant === null)) return null;
-  const value = values === null ? scaledConstant! : values[firstRow]!;
-  return colorOf(resolved, value);
-}
+import { bucketByGroup, xSortKey } from "./geometry-shared.js";
+import { buildSmoothLineBatch } from "./geometry-smooth-line.js";
+import { buildSmoothRibbonBatch } from "./geometry-smooth-ribbon.js";
 
 export function smoothBatches(
   frame: LayerFrame,
@@ -35,123 +16,15 @@ export function smoothBatches(
   fill: ResolvedColorScale | null,
   warnings: PipelineWarning[],
 ): GeometryBatch[] {
-  const { binding } = frame;
-  const params = (binding.layer.params ?? {}) as SmoothParams;
   const groupRows = bucketByGroup(frame, fx, null, warnings);
   if (groupRows.length === 0) return [];
   const sortKey = xSortKey(frame, fx);
   for (const rows of groupRows) rows.sort((a, b) => sortKey(a) - sortKey(b));
+
   const out: GeometryBatch[] = [];
-
-  // --- ribbon (drawn first, under the line) -----------------------------------
-  if (frame.smoothBand && frame.ymin !== null && frame.ymax !== null) {
-    const bandRows = groupRows
-      .map((rows) =>
-        rows.filter(
-          (row) => Number.isFinite(frame.ymin![row]!) && Number.isFinite(frame.ymax![row]!),
-        ),
-      )
-      .filter((rows) => rows.length > 1);
-    if (bandRows.length > 0) {
-      let total = 0;
-      for (const rows of bandRows) total += rows.length * 2;
-      const positions = new Float32Array(total * 2);
-      const rowIndex = new Uint32Array(total);
-      const pathOffsets = new Uint32Array(bandRows.length + 1);
-      const fills: (string | null)[] = [];
-      const strokes: (string | null)[] = [];
-      let cursor = 0;
-      for (let s = 0; s < bandRows.length; s++) {
-        pathOffsets[s] = cursor;
-        const rows = bandRows[s]!;
-        for (const row of rows) {
-          const tx = positionOf(fx.xScale, frame.xNumeric, frame.xValues, row);
-          const ty = fx.yScale.type === "band" ? NaN : fx.yScale.normalize(frame.ymax[row]!);
-          positions[cursor * 2] = tx * fx.innerWidth;
-          positions[cursor * 2 + 1] = fx.innerHeight - ty * fx.innerHeight;
-          rowIndex[cursor] = frame.rowIndex[row]!;
-          cursor++;
-        }
-        for (let i = rows.length - 1; i >= 0; i--) {
-          const row = rows[i]!;
-          const tx = positionOf(fx.xScale, frame.xNumeric, frame.xValues, row);
-          const ty = fx.yScale.type === "band" ? NaN : fx.yScale.normalize(frame.ymin[row]!);
-          positions[cursor * 2] = tx * fx.innerWidth;
-          positions[cursor * 2 + 1] = fx.innerHeight - ty * fx.innerHeight;
-          rowIndex[cursor] = frame.rowIndex[row]!;
-          cursor++;
-        }
-        const first = rows[0]!;
-        // Ribbon tint: fill channel, else the line's color (band matches
-        // its line in multi-series smooths), else theme accent.
-        const ribbonFill =
-          groupColor(fill, frame.fillValues, binding.fill.scaledConstant, first) ??
-          binding.fill.constant ??
-          groupColor(color, frame.colorValues, binding.color.scaledConstant, first) ??
-          binding.color.constant;
-        fills.push(ribbonFill);
-        strokes.push(null);
-      }
-      pathOffsets[bandRows.length] = cursor;
-      out.push({
-        kind: "paths",
-        layerIndex: binding.index,
-        panelIndex: 0,
-        positions,
-        rowIndex,
-        pathOffsets,
-        strokes,
-        fills,
-        closed: true,
-        linewidth: 0,
-        alpha: SMOOTH_RIBBON_ALPHA,
-        curve: "linear",
-      });
-    }
-  }
-
-  // --- fitted line --------------------------------------------------------------
-  let total = 0;
-  for (const rows of groupRows) total += rows.length;
-  const positions = new Float32Array(total * 2);
-  const rowIndex = new Uint32Array(total);
-  const pathOffsets = new Uint32Array(groupRows.length + 1);
-  const strokes: (string | null)[] = [];
-  let cursor = 0;
-  for (let s = 0; s < groupRows.length; s++) {
-    pathOffsets[s] = cursor;
-    const rows = groupRows[s]!;
-    for (const row of rows) {
-      const tx = positionOf(fx.xScale, frame.xNumeric, frame.xValues, row);
-      const ty = positionOf(fx.yScale, frame.yNumeric, null, row);
-      positions[cursor * 2] = tx * fx.innerWidth;
-      positions[cursor * 2 + 1] = fx.innerHeight - ty * fx.innerHeight;
-      rowIndex[cursor] = frame.rowIndex[row]!;
-      cursor++;
-    }
-    strokes.push(
-      groupColor(color, frame.colorValues, binding.color.scaledConstant, rows[0]!) ??
-        binding.color.constant,
-    );
-  }
-  pathOffsets[groupRows.length] = cursor;
-  out.push({
-    kind: "paths",
-    layerIndex: binding.index,
-    panelIndex: 0,
-    positions,
-    rowIndex,
-    pathOffsets,
-    strokes,
-    linewidth: params.linewidth ?? DEFAULT_SMOOTH_LINEWIDTH,
-    alpha: params.alpha ?? 1,
-    curve: "linear",
-  });
+  // Ribbon drawn first, under the line.
+  const ribbon = buildSmoothRibbonBatch({ frame, fx, color, fill, groupRows });
+  if (ribbon !== null) out.push(ribbon);
+  out.push(buildSmoothLineBatch({ frame, fx, color, groupRows }));
   return out;
 }
-
-/**
- * Boxplot composite geometry, composed from existing batch kinds: whisker
- * segments (under), box rects (ink outline; paper fill when unmapped),
- * median segments (2× linewidth), outlier points.
- */

--- a/packages/core/src/pipeline/panel-layout-chrome.ts
+++ b/packages/core/src/pipeline/panel-layout-chrome.ts
@@ -1,0 +1,158 @@
+/**
+ * Panel layout chrome: labs, axis titles (with coord flip), formatters, legends.
+ */
+import type { PortableSpec } from "@ggsvelte/spec";
+
+import { FONT_METRICS } from "../layout/font-metrics.js";
+import type { LayoutTheme, TickFormatter } from "../layout/layout.js";
+import { DEFAULT_LAYOUT_THEME } from "../layout/layout.js";
+import type { TextMeasurer } from "../layout/measure.js";
+import { MetricsTableMeasurer } from "../layout/measure.js";
+import type { LegendInput, LegendOrder } from "../legend.js";
+import { buildLegends } from "../legend.js";
+import type { PositionScale } from "../scales/train.js";
+import type { ThemeTokens } from "../theme.js";
+
+import {
+  AXIS_TITLE_BAND,
+  CAPTION_BAND,
+  SUBTITLE_BAND,
+  TITLE_BAND,
+  makeAxisFormatter,
+} from "./layout-helpers.js";
+import type { LayerFrame, PipelineWarning, RunOptions } from "./types.js";
+
+export interface PanelLayoutChrome {
+  title: string;
+  subtitle: string;
+  caption: string;
+  xTitle: string;
+  yTitle: string;
+  hTitle: string;
+  vTitle: string;
+  topBand: number;
+  bottomBand: number;
+  axisTitleBand: number;
+  layoutHeight: number;
+  formatX: TickFormatter | undefined;
+  formatY: TickFormatter | undefined;
+  formatH: TickFormatter | undefined;
+  formatV: TickFormatter | undefined;
+  hBreaks: readonly (number | string)[] | undefined;
+  vBreaks: readonly (number | string)[] | undefined;
+  freeH: boolean;
+  freeV: boolean;
+  displayScales: (p: number) => { h: PositionScale; v: PositionScale };
+  measurer: TextMeasurer;
+  layoutTheme: LayoutTheme;
+  legendBlock: ReturnType<typeof buildLegends>;
+}
+
+export function resolvePanelLayoutChrome(input: {
+  flip: boolean;
+  freeX: boolean;
+  freeY: boolean;
+  panelScales: readonly { x: PositionScale; y: PositionScale }[];
+  allFrames: readonly LayerFrame[];
+  labs: NonNullable<PortableSpec["labs"]>;
+  scalesConfig: NonNullable<PortableSpec["scales"]>;
+  xScale: PositionScale;
+  yScale: PositionScale;
+  colorLegend: LegendInput | null;
+  fillLegend: LegendInput | null;
+  legendOrder: LegendOrder;
+  theme: ThemeTokens;
+  options: Pick<RunOptions, "width" | "height" | "measureText">;
+  warnings: PipelineWarning[];
+}): PanelLayoutChrome {
+  const {
+    flip,
+    freeX,
+    freeY,
+    panelScales,
+    allFrames,
+    labs,
+    scalesConfig,
+    xScale,
+    yScale,
+    theme,
+    options,
+    warnings,
+  } = input;
+
+  const title = labs.title ?? "";
+  const subtitle = labs.subtitle ?? "";
+  const caption = labs.caption ?? "";
+  const xTitle = labs.x ?? allFrames.find((f) => f.binding.xField !== null)?.binding.xField ?? "";
+  const yTitle =
+    labs.y ??
+    allFrames.find((f) => f.binding.yField !== null)?.binding.yField ??
+    allFrames.find((f) => f.binding.yStatColumn !== null)?.binding.yStatColumn ??
+    "";
+  const titleBand = Math.max(TITLE_BAND, theme.titleSize + 7);
+  const subtitleBand = Math.max(SUBTITLE_BAND, theme.subtitleSize + 4);
+  const captionBand = Math.max(CAPTION_BAND, theme.captionSize + 5);
+  const axisTitleBand = Math.max(AXIS_TITLE_BAND, theme.axisTitleSize + 9);
+  const topBand = (title === "" ? 0 : titleBand) + (subtitle === "" ? 0 : subtitleBand);
+  const bottomBand = caption === "" ? 0 : captionBand;
+
+  const hTitle = flip ? yTitle : xTitle;
+  const vTitle = flip ? xTitle : yTitle;
+  const formatX = makeAxisFormatter("x", xScale, scalesConfig.x, warnings);
+  const formatY = makeAxisFormatter("y", yScale, scalesConfig.y, warnings);
+  const formatH = flip ? formatY : formatX;
+  const formatV = flip ? formatX : formatY;
+  const hBreaks = flip ? scalesConfig.y?.breaks : scalesConfig.x?.breaks;
+  const vBreaks = flip ? scalesConfig.x?.breaks : scalesConfig.y?.breaks;
+  const freeH = flip ? freeY : freeX;
+  const freeV = flip ? freeX : freeY;
+  const displayScales = (p: number): { h: PositionScale; v: PositionScale } => {
+    const s = panelScales[p]!;
+    return flip ? { h: s.y, v: s.x } : { h: s.x, v: s.y };
+  };
+
+  const measurer = options.measureText ?? new MetricsTableMeasurer(FONT_METRICS);
+  const layoutTheme = {
+    ...DEFAULT_LAYOUT_THEME,
+    fontSize: theme.axisTextSize,
+    tickLength: theme.ticksX || theme.ticksY ? theme.tickLength : 0,
+    tickLabelGap: theme.ticksX || theme.ticksY ? 3 : 5,
+  };
+  const legendInputs = [input.colorLegend, input.fillLegend].filter(
+    (l): l is LegendInput => l !== null,
+  );
+  const legendBlock = buildLegends(
+    legendInputs,
+    input.legendOrder,
+    measurer,
+    Math.max(48, options.width * 0.35),
+  );
+
+  const layoutHeight = Math.max(40, options.height - topBand - bottomBand);
+
+  return {
+    title,
+    subtitle,
+    caption,
+    xTitle,
+    yTitle,
+    hTitle,
+    vTitle,
+    topBand,
+    bottomBand,
+    axisTitleBand,
+    layoutHeight,
+    formatX,
+    formatY,
+    formatH,
+    formatV,
+    hBreaks,
+    vBreaks,
+    freeH,
+    freeV,
+    displayScales,
+    measurer,
+    layoutTheme,
+    legendBlock,
+  };
+}

--- a/packages/core/src/pipeline/panel-layout.ts
+++ b/packages/core/src/pipeline/panel-layout.ts
@@ -4,22 +4,12 @@
  */
 import type { PortableSpec } from "@ggsvelte/spec";
 
-import { FONT_METRICS } from "../layout/font-metrics.js";
-import { DEFAULT_LAYOUT_THEME } from "../layout/layout.js";
-import { MetricsTableMeasurer } from "../layout/measure.js";
 import type { LegendInput, LegendOrder } from "../legend.js";
-import { buildLegends } from "../legend.js";
 import type { PositionScale } from "../scales/train.js";
 import type { ThemeTokens } from "../theme.js";
 
 import type { FacetPanelDef } from "./facets.js";
-import {
-  AXIS_TITLE_BAND,
-  CAPTION_BAND,
-  SUBTITLE_BAND,
-  TITLE_BAND,
-  makeAxisFormatter,
-} from "./layout-helpers.js";
+import { resolvePanelLayoutChrome } from "./panel-layout-chrome.js";
 import { placeFacetPanels } from "./panel-layout-facet.js";
 import { placeSinglePanel } from "./panel-layout-single.js";
 import type { PanelLayoutResult, PanelPlacement } from "./panel-layout-types.js";
@@ -48,74 +38,9 @@ export function computePanelLayout(input: {
   options: Pick<RunOptions, "width" | "height" | "measureText">;
   warnings: PipelineWarning[];
 }): PanelLayoutResult {
-  const {
-    flip,
-    faceted,
-    freeX,
-    freeY,
-    nrow,
-    ncol,
-    facetPanels,
-    panelScales,
-    allFrames,
-    labs,
-    scalesConfig,
-    xScale,
-    yScale,
-    theme,
-    options,
-    warnings,
-  } = input;
+  const { faceted, nrow, ncol, facetPanels, options } = input;
 
-  const title = labs.title ?? "";
-  const subtitle = labs.subtitle ?? "";
-  const caption = labs.caption ?? "";
-  const xTitle = labs.x ?? allFrames.find((f) => f.binding.xField !== null)?.binding.xField ?? "";
-  const yTitle =
-    labs.y ??
-    allFrames.find((f) => f.binding.yField !== null)?.binding.yField ??
-    allFrames.find((f) => f.binding.yStatColumn !== null)?.binding.yStatColumn ??
-    "";
-  const titleBand = Math.max(TITLE_BAND, theme.titleSize + 7);
-  const subtitleBand = Math.max(SUBTITLE_BAND, theme.subtitleSize + 4);
-  const captionBand = Math.max(CAPTION_BAND, theme.captionSize + 5);
-  const axisTitleBand = Math.max(AXIS_TITLE_BAND, theme.axisTitleSize + 9);
-  const topBand = (title === "" ? 0 : titleBand) + (subtitle === "" ? 0 : subtitleBand);
-  const bottomBand = caption === "" ? 0 : captionBand;
-
-  const hTitle = flip ? yTitle : xTitle;
-  const vTitle = flip ? xTitle : yTitle;
-  const formatX = makeAxisFormatter("x", xScale, scalesConfig.x, warnings);
-  const formatY = makeAxisFormatter("y", yScale, scalesConfig.y, warnings);
-  const formatH = flip ? formatY : formatX;
-  const formatV = flip ? formatX : formatY;
-  const hBreaks = flip ? scalesConfig.y?.breaks : scalesConfig.x?.breaks;
-  const vBreaks = flip ? scalesConfig.x?.breaks : scalesConfig.y?.breaks;
-  const freeH = flip ? freeY : freeX;
-  const freeV = flip ? freeX : freeY;
-  const displayScales = (p: number): { h: PositionScale; v: PositionScale } => {
-    const s = panelScales[p]!;
-    return flip ? { h: s.y, v: s.x } : { h: s.x, v: s.y };
-  };
-
-  const measurer = options.measureText ?? new MetricsTableMeasurer(FONT_METRICS);
-  const layoutTheme = {
-    ...DEFAULT_LAYOUT_THEME,
-    fontSize: theme.axisTextSize,
-    tickLength: theme.ticksX || theme.ticksY ? theme.tickLength : 0,
-    tickLabelGap: theme.ticksX || theme.ticksY ? 3 : 5,
-  };
-  const legendInputs = [input.colorLegend, input.fillLegend].filter(
-    (l): l is LegendInput => l !== null,
-  );
-  const legendBlock = buildLegends(
-    legendInputs,
-    input.legendOrder,
-    measurer,
-    Math.max(48, options.width * 0.35),
-  );
-
-  const layoutHeight = Math.max(40, options.height - topBand - bottomBand);
+  const chrome = resolvePanelLayoutChrome(input);
   let placements: PanelPlacement[];
 
   if (faceted) {
@@ -123,59 +48,59 @@ export function computePanelLayout(input: {
       facetPanels,
       nrow,
       ncol,
-      freeH,
-      freeV,
-      outerLeftTitle: vTitle,
-      outerBottomTitle: hTitle,
-      axisTitleBand,
-      legendWidth: legendBlock.width,
+      freeH: chrome.freeH,
+      freeV: chrome.freeV,
+      outerLeftTitle: chrome.vTitle,
+      outerBottomTitle: chrome.hTitle,
+      axisTitleBand: chrome.axisTitleBand,
+      legendWidth: chrome.legendBlock.width,
       optionsWidth: options.width,
-      layoutHeight,
-      topBand,
-      displayScales,
-      hBreaks,
-      vBreaks,
-      formatH,
-      formatV,
-      measurer,
-      layoutTheme,
+      layoutHeight: chrome.layoutHeight,
+      topBand: chrome.topBand,
+      displayScales: chrome.displayScales,
+      hBreaks: chrome.hBreaks,
+      vBreaks: chrome.vBreaks,
+      formatH: chrome.formatH,
+      formatV: chrome.formatV,
+      measurer: chrome.measurer,
+      layoutTheme: chrome.layoutTheme,
     });
   } else {
-    const { h, v } = displayScales(0);
+    const { h, v } = chrome.displayScales(0);
     placements = [
       placeSinglePanel({
         h,
         v,
-        hTitle,
-        vTitle,
-        axisTitleBand,
-        legendWidth: legendBlock.width,
+        hTitle: chrome.hTitle,
+        vTitle: chrome.vTitle,
+        axisTitleBand: chrome.axisTitleBand,
+        legendWidth: chrome.legendBlock.width,
         optionsWidth: options.width,
-        layoutHeight,
-        topBand,
-        hBreaks,
-        vBreaks,
-        formatH,
-        formatV,
-        measurer,
-        layoutTheme,
+        layoutHeight: chrome.layoutHeight,
+        topBand: chrome.topBand,
+        hBreaks: chrome.hBreaks,
+        vBreaks: chrome.vBreaks,
+        formatH: chrome.formatH,
+        formatV: chrome.formatV,
+        measurer: chrome.measurer,
+        layoutTheme: chrome.layoutTheme,
       }),
     ];
   }
 
   return {
     placements,
-    title,
-    subtitle,
-    caption,
-    hTitle,
-    vTitle,
-    xTitle,
-    yTitle,
-    topBand,
-    formatX,
-    formatY,
-    displayScales,
-    legendBlock,
+    title: chrome.title,
+    subtitle: chrome.subtitle,
+    caption: chrome.caption,
+    hTitle: chrome.hTitle,
+    vTitle: chrome.vTitle,
+    xTitle: chrome.xTitle,
+    yTitle: chrome.yTitle,
+    topBand: chrome.topBand,
+    formatX: chrome.formatX,
+    formatY: chrome.formatY,
+    displayScales: chrome.displayScales,
+    legendBlock: chrome.legendBlock,
   };
 }

--- a/packages/core/tests/pipeline-build-candidates.test.ts
+++ b/packages/core/tests/pipeline-build-candidates.test.ts
@@ -50,6 +50,30 @@ describe("buildPipelineCandidates via runPipeline", () => {
     expect(sizes).toContain(1);
   });
 
+  it("bin layers intern source rows using closed bin edges", () => {
+    const model = runPipeline(
+      {
+        data: { values: [{ x: 0 }, { x: 1 }, { x: 2 }] },
+        layers: [
+          {
+            geom: "histogram",
+            aes: { x: { field: "x" } },
+            params: { binwidth: 1, boundary: 0, closed: "right" },
+          },
+        ],
+      },
+      size,
+    );
+    expect(model.candidates.size).toBeGreaterThanOrEqual(2);
+    const memberships = Array.from({ length: model.candidates.size }, (_, id) => {
+      const c = model.candidates.candidate(id)!;
+      return model.lineage.count(c.lineage);
+    });
+    // three source rows assigned across bins without empty lineages
+    expect(memberships.every((n) => n >= 1)).toBe(true);
+    expect(memberships.reduce((a, b) => a + b, 0)).toBe(3);
+  });
+
   it("annotation rules produce candidates with intercept values", () => {
     const model = runPipeline(
       gg(

--- a/packages/core/tests/pipeline-geometry.test.ts
+++ b/packages/core/tests/pipeline-geometry.test.ts
@@ -214,6 +214,30 @@ describe("buildBatch dispatch via runPipeline", () => {
     expect(col.scene.batches.some((b) => b.kind === "rects")).toBe(true);
   });
 
+  it("smooth with se ribbon emits closed ribbon path under the line", () => {
+    const model = runPipeline(
+      gg(
+        [
+          { x: 1, y: 2 },
+          { x: 2, y: 4 },
+          { x: 3, y: 5 },
+          { x: 4, y: 7 },
+          { x: 5, y: 8 },
+        ],
+        aes({ x: "x", y: "y" }),
+      )
+        .geomSmooth({ se: true, method: "lm" })
+        .spec(),
+      size,
+    );
+    const paths = model.scene.batches.filter((b) => b.kind === "paths");
+    expect(paths.length).toBeGreaterThanOrEqual(2);
+    const closed = paths.filter((b) => b.kind === "paths" && b.closed === true);
+    expect(closed.length).toBeGreaterThanOrEqual(1);
+    const line = paths.find((b) => b.kind === "paths" && b.closed !== true);
+    expect(line).toBeTruthy();
+  });
+
   it("area emits a closed filled path batch", () => {
     const area = runPipeline(
       gg(

--- a/packages/core/tests/pipeline-panel-layout.test.ts
+++ b/packages/core/tests/pipeline-panel-layout.test.ts
@@ -75,6 +75,25 @@ describe("panel layout via runPipeline", () => {
     expect(withY.length).toBeGreaterThanOrEqual(2);
   });
 
+  it("legend reserves right margin when fill is mapped", () => {
+    const model = runPipeline(
+      gg(
+        [
+          { g: "a", y: 1 },
+          { g: "b", y: 2 },
+        ],
+        aes({ x: "g", y: "y", fill: "g" }),
+      )
+        .geomCol()
+        .spec(),
+      size,
+    );
+    expect(model.scene.legends.length).toBeGreaterThan(0);
+    const panel = model.scene.panels[0]!;
+    // legend occupies right of the plot; panel should not span full width
+    expect(panel.x + panel.width).toBeLessThan(size.width - 8);
+  });
+
   it("labs and flip swap axis title orientation on the scene", () => {
     const model = runPipeline(
       gg(


### PR DESCRIPTION
## Summary

- Split identity candidate datum resolution into frame-row mapping and aggregate lineage filtering.
- Extract panel-layout chrome (labs, formatters, legends, flip axes) from placement dispatch.
- Split smooth geometry into shared helpers, SE ribbon, and fitted line.
- Characterization tests for bin lineage closedness, legend margin reservation, and smooth SE ribbon batches.

## Test plan

- [x] `bun run check`
- [x] `bun test packages/core` (484 pass)
- [x] `bun run knip`
- [x] `bun run lint:type-aware`
- [x] pre-push hooks on push