### PR TITLE
refactor(svelte): pass pin domain state into capture helpers

### DIFF
--- a/packages/svelte/src/lib/GGPlot.svelte
+++ b/packages/svelte/src/lib/GGPlot.svelte
@@ -911,7 +911,7 @@
     const onOutsidePointer = (event: PointerEvent) => {
       if (
         !shouldClosePinnedOnOutsidePointer({
-          isPinned: inspection?.state === "pinned",
+          inspectionState: inspection?.state,
           targetInsideRoot: root?.contains(event.target as Node) === true,
         })
       )
@@ -2432,9 +2432,8 @@
           assembled?.labs?.title ??
           sceneLabel(model.scene)}
         ariaControls={resolveCaptureAriaControls({
-          isPinned: inspection?.state === "pinned",
-          interactiveContent:
-            interactionConfig.inspect?.contentMode === "interactive",
+          inspectionState: inspection?.state,
+          contentMode: interactionConfig.inspect?.contentMode,
           plotId,
         })}
         onFocus={() => {

--- a/packages/svelte/src/lib/plot-layout.ts
+++ b/packages/svelte/src/lib/plot-layout.ts
@@ -71,13 +71,16 @@ export function plotTooltipDomId(plotId: string): string {
 /**
  * Capture-surface `aria-controls` when a pinned interactive tooltip is up.
  * Undefined otherwise (attribute omitted).
+ *
+ * Takes domain state (not pre-derived booleans) so hosts pass `inspection?.state`
+ * and inspect `contentMode` directly — same shape as `isTooltipDocked`.
  */
 export function resolveCaptureAriaControls(input: {
-  readonly isPinned: boolean;
-  readonly interactiveContent: boolean;
+  readonly inspectionState: "transient" | "pinned" | "none" | null | undefined;
+  readonly contentMode: "interactive" | "informational" | undefined;
   readonly plotId: string;
 }): string | undefined {
-  if (!input.isPinned || !input.interactiveContent) return undefined;
+  if (input.inspectionState !== "pinned" || input.contentMode !== "interactive") return undefined;
   return plotTooltipDomId(input.plotId);
 }
 

--- a/packages/svelte/src/lib/plot-surface-inspection.ts
+++ b/packages/svelte/src/lib/plot-surface-inspection.ts
@@ -354,12 +354,15 @@ export function resolveSurfaceBlurAction(input: {
  * Whether a window pointerdown outside the plot should close a pinned
  * inspection. Host: only when `surfaceInteractive` effect is installed.
  * Host must pass `targetInsideRoot: root?.contains(target) === true`.
+ *
+ * Takes domain `inspectionState` (not a pre-derived `isPinned` boolean) so
+ * hosts pass `inspection?.state` directly — same shape as `isTooltipDocked`.
  */
 export function shouldClosePinnedOnOutsidePointer(input: {
-  readonly isPinned: boolean;
+  readonly inspectionState: "transient" | "pinned" | "none" | null | undefined;
   readonly targetInsideRoot: boolean;
 }): boolean {
-  return input.isPinned && !input.targetInsideRoot;
+  return input.inspectionState === "pinned" && !input.targetInsideRoot;
 }
 
 // ---- scene-run inspection reconcile (host $effect) ----

--- a/packages/svelte/tests/plot-layout.test.ts
+++ b/packages/svelte/tests/plot-layout.test.ts
@@ -150,22 +150,37 @@ describe("resolveCaptureAriaControls", () => {
   it("returns plot-scoped tooltip id only when pinned and interactive", () => {
     expect(
       resolveCaptureAriaControls({
-        isPinned: true,
-        interactiveContent: true,
+        inspectionState: "pinned",
+        contentMode: "interactive",
         plotId: "plot-a",
       }),
     ).toBe(plotTooltipDomId("plot-a"));
+  });
+
+  it("is undefined for non-pinned states even when interactive", () => {
+    for (const inspectionState of ["transient", "none", null, undefined] as const) {
+      expect(
+        resolveCaptureAriaControls({
+          inspectionState,
+          contentMode: "interactive",
+          plotId: "plot-a",
+        }),
+      ).toBeUndefined();
+    }
+  });
+
+  it("is undefined when pinned but content is not interactive", () => {
     expect(
       resolveCaptureAriaControls({
-        isPinned: true,
-        interactiveContent: false,
+        inspectionState: "pinned",
+        contentMode: "informational",
         plotId: "plot-a",
       }),
     ).toBeUndefined();
     expect(
       resolveCaptureAriaControls({
-        isPinned: false,
-        interactiveContent: true,
+        inspectionState: "pinned",
+        contentMode: undefined,
         plotId: "plot-a",
       }),
     ).toBeUndefined();

--- a/packages/svelte/tests/plot-surface-inspection.test.ts
+++ b/packages/svelte/tests/plot-surface-inspection.test.ts
@@ -755,27 +755,41 @@ describe("shouldAnnounceUnpin / shouldFocusPinnedInteractiveTooltip", () => {
 
 describe("shouldClosePinnedOnOutsidePointer", () => {
   it("closes only when pinned and target is outside the root", () => {
-    expect(shouldClosePinnedOnOutsidePointer({ isPinned: true, targetInsideRoot: false })).toBe(
-      true,
-    );
+    expect(
+      shouldClosePinnedOnOutsidePointer({
+        inspectionState: "pinned",
+        targetInsideRoot: false,
+      }),
+    ).toBe(true);
   });
 
-  it("does not close when not pinned", () => {
-    expect(shouldClosePinnedOnOutsidePointer({ isPinned: false, targetInsideRoot: false })).toBe(
-      false,
-    );
+  it("does not close for non-pinned inspection states", () => {
+    for (const inspectionState of ["transient", "none", null, undefined] as const) {
+      expect(
+        shouldClosePinnedOnOutsidePointer({
+          inspectionState,
+          targetInsideRoot: false,
+        }),
+      ).toBe(false);
+    }
   });
 
   it("does not close when target is inside the root", () => {
-    expect(shouldClosePinnedOnOutsidePointer({ isPinned: true, targetInsideRoot: true })).toBe(
-      false,
-    );
+    expect(
+      shouldClosePinnedOnOutsidePointer({
+        inspectionState: "pinned",
+        targetInsideRoot: true,
+      }),
+    ).toBe(false);
   });
 
   it("does not close when unpinned and inside", () => {
-    expect(shouldClosePinnedOnOutsidePointer({ isPinned: false, targetInsideRoot: true })).toBe(
-      false,
-    );
+    expect(
+      shouldClosePinnedOnOutsidePointer({
+        inspectionState: "transient",
+        targetInsideRoot: true,
+      }),
+    ).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
- Expand `resolveCaptureAriaControls` to take `inspectionState` + `contentMode` instead of pre-derived booleans, matching `isTooltipDocked`.
- Expand `shouldClosePinnedOnOutsidePointer` to take `inspectionState` instead of `isPinned`.
- Wire `GGPlot` call sites to pass domain state directly so pin derivation lives in one place.

## Test plan
- [x] `vitest run tests/plot-layout.test.ts tests/plot-surface-inspection.test.ts` (all browsers)
- [x] `bun run check` / svelte-check --fail-on-warnings
- [x] Pre-push: package build, oxlint type-aware, knip, bun test
- [x] Codex pre-PR review: clean (no P1/P2)