### PR TITLE
refactor(core): split public types, scale collect/train, and candidates

### DIFF
--- a/packages/core/src/pipeline/build-candidates-datum-values.ts
+++ b/packages/core/src/pipeline/build-candidates-datum-values.ts
@@ -1,0 +1,52 @@
+/**
+ * Resolve candidate logical x/y values from frame, annotation, or outlier paths.
+ */
+import type { CellValue } from "../table.js";
+
+import type { LayerFrame } from "./types.js";
+
+export function resolveCandidateLogicalValues(input: {
+  annotationRule: boolean;
+  annotationX: CellValue;
+  annotationY: CellValue;
+  outlierSourceRow: number | null;
+  sourceRow: number | null;
+  frame: LayerFrame | undefined;
+  frameRow: number;
+  primitiveIndex: number;
+  sourceValue: (field: string | undefined) => CellValue;
+  xField: string | undefined;
+  yField: string | undefined;
+}): { xValue: CellValue; yValue: CellValue } {
+  const {
+    annotationRule,
+    annotationX,
+    annotationY,
+    outlierSourceRow,
+    sourceRow,
+    frame,
+    frameRow,
+    primitiveIndex,
+    sourceValue,
+    xField,
+    yField,
+  } = input;
+
+  const xValue = annotationRule
+    ? annotationX
+    : outlierSourceRow === null
+      ? sourceRow === null
+        ? (frame?.xValues?.[frameRow] ?? frame?.xNumeric?.[frameRow] ?? null)
+        : sourceValue(xField)
+      : (frame?.box?.outlierX[primitiveIndex] ?? null);
+
+  const yValue = annotationRule
+    ? annotationY
+    : outlierSourceRow === null
+      ? sourceRow === null
+        ? (frame?.yNumeric?.[frameRow] ?? frame?.box?.middle[frameRow] ?? null)
+        : sourceValue(yField)
+      : (frame?.box?.outlierY[primitiveIndex] ?? null);
+
+  return { xValue, yValue };
+}

--- a/packages/core/src/pipeline/build-candidates-datum.ts
+++ b/packages/core/src/pipeline/build-candidates-datum.ts
@@ -9,6 +9,7 @@ import { bandKey } from "../scales/train.js";
 import type { CellValue } from "../table.js";
 import type { ColumnTable } from "../table.js";
 
+import { resolveCandidateLogicalValues } from "./build-candidates-datum-values.js";
 import { resolveCandidateFrameRow } from "./build-candidates-frame-row.js";
 import type { CandidateIdentityIndex } from "./build-candidates-identity.js";
 import { filterRepresentedSourceRows } from "./build-candidates-lineage.js";
@@ -102,21 +103,22 @@ export function createIdentityCandidateDatumResolver(input: {
         baseRows: representedRows,
       });
     }
+    const { xValue, yValue } = resolveCandidateLogicalValues({
+      annotationRule,
+      annotationX,
+      annotationY,
+      outlierSourceRow,
+      sourceRow,
+      frame,
+      frameRow,
+      primitiveIndex: facts.primitiveIndex,
+      sourceValue,
+      xField,
+      yField,
+    });
     return {
-      xValue: annotationRule
-        ? annotationX
-        : outlierSourceRow === null
-          ? sourceRow === null
-            ? (frame?.xValues?.[frameRow] ?? frame?.xNumeric?.[frameRow] ?? null)
-            : sourceValue(xField)
-          : (frame?.box?.outlierX[facts.primitiveIndex] ?? null),
-      yValue: annotationRule
-        ? annotationY
-        : outlierSourceRow === null
-          ? sourceRow === null
-            ? (frame?.yNumeric?.[frameRow] ?? frame?.box?.middle[frameRow] ?? null)
-            : sourceValue(yField)
-          : (frame?.box?.outlierY[facts.primitiveIndex] ?? null),
+      xValue,
+      yValue,
       seriesId: group,
       seriesRank: colorRank >= 0 ? colorRank : fillRank >= 0 ? fillRank : group,
       sourceOrder: sourceRow ?? outlierSourceRow ?? facts.primitiveIndex,

--- a/packages/core/src/pipeline/geometry-boxplot-body-batches.ts
+++ b/packages/core/src/pipeline/geometry-boxplot-body-batches.ts
@@ -1,0 +1,81 @@
+/**
+ * Assemble boxplot body GeometryBatches from precomputed pixel layout.
+ */
+import type { BoxplotParams } from "@ggsvelte/spec";
+
+import type { GeometryBatch, RectsBatch } from "../scene.js";
+
+import type { LayerFrame, ResolvedColorScale } from "./types.js";
+import { colorOf } from "./types.js";
+import type { BoxplotBodyLayout } from "./geometry-boxplot-body-layout.js";
+
+/** Median line draws at 2× the box linewidth (ggplot2's fatten = 2). */
+const BOX_MEDIAN_FATTEN = 2;
+
+export function batchesFromBoxplotBodyLayout(
+  frame: LayerFrame,
+  layout: BoxplotBodyLayout,
+  fill: ResolvedColorScale | null,
+): {
+  batches: GeometryBatch[];
+  centerPx: number[];
+  linewidth: number;
+  alpha: number;
+  params: BoxplotParams;
+} {
+  const { binding } = frame;
+  const { linewidth, alpha, params } = layout;
+
+  const rectsBatchOut: RectsBatch = {
+    kind: "rects",
+    layerIndex: binding.index,
+    panelIndex: 0,
+    rects: Float32Array.from(layout.rects),
+    rowIndex: Uint32Array.from(layout.rectRows),
+    fill: binding.fill.constant,
+    fillRole: "paper",
+    stroke: null,
+    strokeWidth: linewidth,
+    alpha,
+  };
+  if (fill !== null && (frame.fillValues !== null || binding.fill.scaledConstant !== null)) {
+    rectsBatchOut.fills = layout.keptRows.map((row) =>
+      colorOf(
+        fill,
+        frame.fillValues === null ? binding.fill.scaledConstant! : frame.fillValues[row]!,
+      ),
+    );
+  }
+
+  const batches: GeometryBatch[] = [
+    {
+      kind: "segments",
+      layerIndex: binding.index,
+      panelIndex: 0,
+      segments: Float32Array.from(layout.whiskers),
+      rowIndex: Uint32Array.from(layout.whiskerRows),
+      stroke: null,
+      linewidth,
+      alpha,
+    },
+    rectsBatchOut,
+    {
+      kind: "segments",
+      layerIndex: binding.index,
+      panelIndex: 0,
+      segments: Float32Array.from(layout.medians),
+      rowIndex: Uint32Array.from(layout.medianRows),
+      stroke: null,
+      linewidth: linewidth * BOX_MEDIAN_FATTEN,
+      alpha,
+    },
+  ];
+
+  return {
+    batches,
+    centerPx: layout.centerPx,
+    linewidth,
+    alpha,
+    params,
+  };
+}

--- a/packages/core/src/pipeline/geometry-boxplot-body-layout.ts
+++ b/packages/core/src/pipeline/geometry-boxplot-body-layout.ts
@@ -1,0 +1,117 @@
+/**
+ * Boxplot body pixel layout: centers, hinge rects, whiskers, and median lines.
+ */
+import type { BoxplotParams } from "@ggsvelte/spec";
+
+import type { LayerFrame, PipelineWarning } from "./types.js";
+import type { Frame } from "./geometry-shared.js";
+import { DEFAULT_BAR_WIDTH, removedWarning } from "./geometry-shared.js";
+
+const DEFAULT_BOX_LINEWIDTH = 1;
+
+export interface BoxplotBodyLayout {
+  centerPx: number[];
+  halfPx: number[];
+  rects: number[];
+  rectRows: number[];
+  keptRows: number[];
+  whiskers: number[];
+  whiskerRows: number[];
+  medians: number[];
+  medianRows: number[];
+  linewidth: number;
+  alpha: number;
+  params: BoxplotParams;
+}
+
+export function layoutBoxplotBody(
+  frame: LayerFrame,
+  fx: Frame,
+  warnings: PipelineWarning[],
+): BoxplotBodyLayout | null {
+  const { binding, n } = frame;
+  const box = frame.box;
+  if (
+    box === null ||
+    frame.ymin === null ||
+    frame.ymax === null ||
+    fx.xScale.type !== "band" ||
+    fx.yScale.type === "band"
+  ) {
+    return null;
+  }
+  const params = (binding.layer.params ?? {}) as BoxplotParams;
+  const widthFrac = (params.width ?? DEFAULT_BAR_WIDTH) * fx.xScale.step;
+  const linewidth = params.linewidth ?? DEFAULT_BOX_LINEWIDTH;
+  const alpha = params.alpha ?? 1;
+  const yScale = fx.yScale;
+
+  const centerPx: number[] = [];
+  const halfPx: number[] = [];
+  const rects: number[] = [];
+  const rectRows: number[] = [];
+  const keptRows: number[] = [];
+  const whiskers: number[] = [];
+  const whiskerRows: number[] = [];
+  const medians: number[] = [];
+  const medianRows: number[] = [];
+  let removed = 0;
+
+  const yPx = (v: number) => fx.innerHeight - yScale.normalize(v) * fx.innerHeight;
+
+  for (let row = 0; row < n; row++) {
+    const tc = fx.xScale.normalize(frame.xValues?.[row] ?? null);
+    const lo = frame.ymin[row]!;
+    const q1 = box.lower[row]!;
+    const q2 = box.middle[row]!;
+    const q3 = box.upper[row]!;
+    const hi = frame.ymax[row]!;
+    if (
+      tc === undefined ||
+      ![lo, q1, q2, q3, hi].every((v) => Number.isFinite(yScale.normalize(v)))
+    ) {
+      removed++;
+      centerPx.push(NaN);
+      halfPx.push(NaN);
+      continue;
+    }
+    let center = tc;
+    let w = widthFrac;
+    if (frame.dodgeSlot !== null && frame.dodgeSlotCounts !== null) {
+      const slotCount = Math.max(1, frame.dodgeSlotCounts[row]!);
+      w = widthFrac / slotCount;
+      center = tc + widthFrac * ((frame.dodgeSlot[row]! + 0.5) / slotCount - 0.5);
+    }
+    const cx = center * fx.innerWidth;
+    const half = (w / 2) * fx.innerWidth;
+    centerPx.push(cx);
+    halfPx.push(half);
+    // Box: lower..upper hinges.
+    rects.push(cx - half, Math.min(yPx(q3), yPx(q1)), half * 2, Math.abs(yPx(q1) - yPx(q3)));
+    rectRows.push(frame.rowIndex[row]!);
+    keptRows.push(row);
+    // Whiskers: hinge -> whisker end, both directions.
+    whiskers.push(cx, yPx(q3), cx, yPx(hi), cx, yPx(q1), cx, yPx(lo));
+    whiskerRows.push(frame.rowIndex[row]!, frame.rowIndex[row]!);
+    // Median line across the box.
+    medians.push(cx - half, yPx(q2), cx + half, yPx(q2));
+    medianRows.push(frame.rowIndex[row]!);
+  }
+  removedWarning(removed, binding.index, warnings);
+  if (keptRows.length === 0) return null;
+
+  return {
+    centerPx,
+    halfPx,
+    rects,
+    rectRows,
+    keptRows,
+    whiskers,
+    whiskerRows,
+    medians,
+    medianRows,
+    linewidth,
+    alpha,
+    params,
+  };
+}

--- a/packages/core/src/pipeline/geometry-boxplot-body.ts
+++ b/packages/core/src/pipeline/geometry-boxplot-body.ts
@@ -3,16 +3,12 @@
  */
 import type { BoxplotParams } from "@ggsvelte/spec";
 
-import type { GeometryBatch, RectsBatch } from "../scene.js";
+import type { GeometryBatch } from "../scene.js";
 
 import type { LayerFrame, PipelineWarning, ResolvedColorScale } from "./types.js";
-import { colorOf } from "./types.js";
 import type { Frame } from "./geometry-shared.js";
-import { DEFAULT_BAR_WIDTH, removedWarning } from "./geometry-shared.js";
-
-const DEFAULT_BOX_LINEWIDTH = 1;
-/** Median line draws at 2× the box linewidth (ggplot2's fatten = 2). */
-const BOX_MEDIAN_FATTEN = 2;
+import { batchesFromBoxplotBodyLayout } from "./geometry-boxplot-body-batches.js";
+import { layoutBoxplotBody } from "./geometry-boxplot-body-layout.js";
 
 export interface BoxplotBodyResult {
   batches: GeometryBatch[];
@@ -29,121 +25,7 @@ export function buildBoxplotBody(
   fill: ResolvedColorScale | null,
   warnings: PipelineWarning[],
 ): BoxplotBodyResult | null {
-  const { binding, n } = frame;
-  const box = frame.box;
-  if (
-    box === null ||
-    frame.ymin === null ||
-    frame.ymax === null ||
-    fx.xScale.type !== "band" ||
-    fx.yScale.type === "band"
-  ) {
-    return null;
-  }
-  const params = (binding.layer.params ?? {}) as BoxplotParams;
-  const widthFrac = (params.width ?? DEFAULT_BAR_WIDTH) * fx.xScale.step;
-  const linewidth = params.linewidth ?? DEFAULT_BOX_LINEWIDTH;
-  const alpha = params.alpha ?? 1;
-  const yScale = fx.yScale;
-
-  const centerPx: number[] = [];
-  const halfPx: number[] = [];
-  const rects: number[] = [];
-  const rectRows: number[] = [];
-  const keptRows: number[] = [];
-  const whiskers: number[] = [];
-  const whiskerRows: number[] = [];
-  const medians: number[] = [];
-  const medianRows: number[] = [];
-  let removed = 0;
-
-  const yPx = (v: number) => fx.innerHeight - yScale.normalize(v) * fx.innerHeight;
-
-  for (let row = 0; row < n; row++) {
-    const tc = fx.xScale.normalize(frame.xValues?.[row] ?? null);
-    const lo = frame.ymin[row]!;
-    const q1 = box.lower[row]!;
-    const q2 = box.middle[row]!;
-    const q3 = box.upper[row]!;
-    const hi = frame.ymax[row]!;
-    if (
-      tc === undefined ||
-      ![lo, q1, q2, q3, hi].every((v) => Number.isFinite(yScale.normalize(v)))
-    ) {
-      removed++;
-      centerPx.push(NaN);
-      halfPx.push(NaN);
-      continue;
-    }
-    let center = tc;
-    let w = widthFrac;
-    if (frame.dodgeSlot !== null && frame.dodgeSlotCounts !== null) {
-      const slotCount = Math.max(1, frame.dodgeSlotCounts[row]!);
-      w = widthFrac / slotCount;
-      center = tc + widthFrac * ((frame.dodgeSlot[row]! + 0.5) / slotCount - 0.5);
-    }
-    const cx = center * fx.innerWidth;
-    const half = (w / 2) * fx.innerWidth;
-    centerPx.push(cx);
-    halfPx.push(half);
-    // Box: lower..upper hinges.
-    rects.push(cx - half, Math.min(yPx(q3), yPx(q1)), half * 2, Math.abs(yPx(q1) - yPx(q3)));
-    rectRows.push(frame.rowIndex[row]!);
-    keptRows.push(row);
-    // Whiskers: hinge -> whisker end, both directions.
-    whiskers.push(cx, yPx(q3), cx, yPx(hi), cx, yPx(q1), cx, yPx(lo));
-    whiskerRows.push(frame.rowIndex[row]!, frame.rowIndex[row]!);
-    // Median line across the box.
-    medians.push(cx - half, yPx(q2), cx + half, yPx(q2));
-    medianRows.push(frame.rowIndex[row]!);
-  }
-  removedWarning(removed, binding.index, warnings);
-  if (keptRows.length === 0) return null;
-
-  const rectsBatchOut: RectsBatch = {
-    kind: "rects",
-    layerIndex: binding.index,
-    panelIndex: 0,
-    rects: Float32Array.from(rects),
-    rowIndex: Uint32Array.from(rectRows),
-    fill: binding.fill.constant,
-    fillRole: "paper",
-    stroke: null,
-    strokeWidth: linewidth,
-    alpha,
-  };
-  if (fill !== null && (frame.fillValues !== null || binding.fill.scaledConstant !== null)) {
-    rectsBatchOut.fills = keptRows.map((row) =>
-      colorOf(
-        fill,
-        frame.fillValues === null ? binding.fill.scaledConstant! : frame.fillValues[row]!,
-      ),
-    );
-  }
-
-  const batches: GeometryBatch[] = [
-    {
-      kind: "segments",
-      layerIndex: binding.index,
-      panelIndex: 0,
-      segments: Float32Array.from(whiskers),
-      rowIndex: Uint32Array.from(whiskerRows),
-      stroke: null,
-      linewidth,
-      alpha,
-    },
-    rectsBatchOut,
-    {
-      kind: "segments",
-      layerIndex: binding.index,
-      panelIndex: 0,
-      segments: Float32Array.from(medians),
-      rowIndex: Uint32Array.from(medianRows),
-      stroke: null,
-      linewidth: linewidth * BOX_MEDIAN_FATTEN,
-      alpha,
-    },
-  ];
-
-  return { batches, centerPx, linewidth, alpha, params };
+  const layout = layoutBoxplotBody(frame, fx, warnings);
+  if (layout === null) return null;
+  return batchesFromBoxplotBodyLayout(frame, layout, fill);
 }

--- a/packages/core/src/pipeline/scale-axis-collect-x.ts
+++ b/packages/core/src/pipeline/scale-axis-collect-x.ts
@@ -1,0 +1,66 @@
+/**
+ * Collect x-axis training evidence from a single layer frame.
+ */
+import type { PositionScaleSpec } from "@ggsvelte/spec";
+
+import type { CellValue } from "../table.js";
+import { cellToNumber } from "../table.js";
+
+import type { Advisory, LayerFrame } from "./types.js";
+
+export interface AxisCollectAcc {
+  columns: (readonly CellValue[])[];
+  numeric: Float64Array[];
+  anyDiscrete: boolean;
+  allTemporal: boolean;
+  sawContinuousEvidence: boolean;
+  barMeasure: boolean;
+  typeParts: Set<string>;
+}
+
+export function collectAxisInputsX(
+  frame: LayerFrame,
+  configType: PositionScaleSpec["type"] | undefined,
+  advisories: Advisory[],
+  acc: AxisCollectAcc,
+): void {
+  const { binding } = frame;
+  const geom = binding.layer.geom;
+
+  if (frame.xmin !== null && frame.xmax !== null) {
+    // Binned bars: the x domain is the union of bin edges (continuous).
+    acc.numeric.push(frame.xmin, frame.xmax);
+    const field = binding.xField!;
+    const fieldType = frame.table.has(field) ? frame.table.fieldType(field) : "quantitative";
+    acc.typeParts.add(`binned ${fieldType}`);
+    if (fieldType !== "temporal") acc.allTemporal = false;
+    acc.sawContinuousEvidence = true;
+  } else if (frame.xValues !== null || frame.xNumeric !== null) {
+    if (frame.xValues !== null) acc.columns.push(frame.xValues);
+    if (frame.xNumeric !== null) acc.numeric.push(frame.xNumeric);
+    const field = binding.xField!;
+    const fieldType = frame.table.has(field) ? frame.table.fieldType(field) : "quantitative";
+    acc.typeParts.add(fieldType);
+    const barX = (geom === "bar" || geom === "col") && binding.layer.stat !== "bin";
+    if (barX && fieldType !== "nominal" && configType === undefined) {
+      advisories.push({
+        code: "bar-x-discretized",
+        path: `layers.${binding.index}`,
+        chosen: `x treated as discrete bands (${geom} geom)`,
+        howToOverride: "Use point/line/area for continuous x, or set scales.x.type explicitly.",
+      });
+    }
+    if (barX || fieldType === "nominal") acc.anyDiscrete = true;
+    if (fieldType !== "temporal") acc.allTemporal = false;
+    acc.sawContinuousEvidence = true;
+  }
+  if (frame.box !== null && frame.box.outlierX.length > 0) {
+    acc.columns.push(frame.box.outlierX);
+  }
+  for (const v of frame.xIntercepts) {
+    acc.columns.push([v]);
+    acc.numeric.push(Float64Array.of(cellToNumber(v)));
+    if (typeof v === "string" && !Number.isFinite(cellToNumber(v))) acc.anyDiscrete = true;
+    acc.sawContinuousEvidence = true;
+  }
+}

--- a/packages/core/src/pipeline/scale-axis-collect-y.ts
+++ b/packages/core/src/pipeline/scale-axis-collect-y.ts
@@ -1,0 +1,47 @@
+/**
+ * Collect y-axis training evidence from a single layer frame.
+ */
+import { cellToNumber } from "../table.js";
+
+import { isBarLike } from "./scale-axis-train.js";
+import type { AxisCollectAcc } from "./scale-axis-collect-x.js";
+import type { LayerFrame } from "./types.js";
+
+export function collectAxisInputsY(frame: LayerFrame, acc: AxisCollectAcc): void {
+  const { binding } = frame;
+  const geom = binding.layer.geom;
+
+  if (isBarLike(geom) || geom === "density") acc.barMeasure = true;
+  if (frame.ymin !== null && frame.ymax !== null) {
+    acc.numeric.push(frame.ymin, frame.ymax);
+    // Bands need not cover the center line (se: false smooths have
+    // NaN bands; the summary center can escape min/max bounds).
+    if ((geom === "smooth" || geom === "errorbar") && frame.yNumeric !== null) {
+      acc.numeric.push(frame.yNumeric);
+    }
+    if (frame.box !== null) acc.numeric.push(frame.box.outlierY);
+    acc.typeParts.add("quantitative");
+    acc.allTemporal = false;
+    acc.sawContinuousEvidence = true;
+  } else if (binding.yStatColumn !== null && frame.yNumeric !== null) {
+    acc.numeric.push(frame.yNumeric);
+    acc.typeParts.add(binding.yStatColumn);
+    acc.allTemporal = false;
+    acc.sawContinuousEvidence = true;
+  } else if (binding.yField !== null) {
+    // Panel-local data: free-y facets train each panel on ITS rows.
+    const column = frame.table.column(binding.yField);
+    acc.columns.push(column);
+    acc.numeric.push(frame.table.numeric(binding.yField));
+    const fieldType = frame.table.fieldType(binding.yField);
+    acc.typeParts.add(fieldType);
+    if (fieldType === "nominal") acc.anyDiscrete = true;
+    if (fieldType !== "temporal") acc.allTemporal = false;
+    acc.sawContinuousEvidence = true;
+  }
+  for (const v of frame.yIntercepts) {
+    acc.columns.push([v]);
+    acc.numeric.push(Float64Array.of(cellToNumber(v)));
+    acc.sawContinuousEvidence = true;
+  }
+}

--- a/packages/core/src/pipeline/scale-axis-collect.ts
+++ b/packages/core/src/pipeline/scale-axis-collect.ts
@@ -3,11 +3,9 @@
  */
 import type { PositionScaleSpec } from "@ggsvelte/spec";
 
-import type { CellValue } from "../table.js";
-import { cellToNumber } from "../table.js";
-
 import type { AxisInputs } from "./scale-axis-train.js";
-import { isBarLike } from "./scale-axis-train.js";
+import { collectAxisInputsX, type AxisCollectAcc } from "./scale-axis-collect-x.js";
+import { collectAxisInputsY } from "./scale-axis-collect-y.js";
 import type { Advisory, LayerFrame } from "./types.js";
 
 /** Collect per-axis training evidence across layers. */
@@ -17,98 +15,27 @@ export function collectAxisInputs(
   configType: PositionScaleSpec["type"] | undefined,
   advisories: Advisory[],
 ): AxisInputs {
-  const columns: (readonly CellValue[])[] = [];
-  const numeric: Float64Array[] = [];
-  let anyDiscrete = false;
-  let allTemporal = true;
-  let sawContinuousEvidence = false;
-  let barMeasure = false;
-  const typeParts = new Set<string>();
+  const acc: AxisCollectAcc = {
+    columns: [],
+    numeric: [],
+    anyDiscrete: false,
+    allTemporal: true,
+    sawContinuousEvidence: false,
+    barMeasure: false,
+    typeParts: new Set<string>(),
+  };
 
   for (const frame of frames) {
-    const { binding } = frame;
-    const geom = binding.layer.geom;
-
-    if (axis === "x") {
-      if (frame.xmin !== null && frame.xmax !== null) {
-        // Binned bars: the x domain is the union of bin edges (continuous).
-        numeric.push(frame.xmin, frame.xmax);
-        const field = binding.xField!;
-        const fieldType = frame.table.has(field) ? frame.table.fieldType(field) : "quantitative";
-        typeParts.add(`binned ${fieldType}`);
-        if (fieldType !== "temporal") allTemporal = false;
-        sawContinuousEvidence = true;
-      } else if (frame.xValues !== null || frame.xNumeric !== null) {
-        if (frame.xValues !== null) columns.push(frame.xValues);
-        if (frame.xNumeric !== null) numeric.push(frame.xNumeric);
-        const field = binding.xField!;
-        const fieldType = frame.table.has(field) ? frame.table.fieldType(field) : "quantitative";
-        typeParts.add(fieldType);
-        const barX = (geom === "bar" || geom === "col") && binding.layer.stat !== "bin";
-        if (barX && fieldType !== "nominal" && configType === undefined) {
-          advisories.push({
-            code: "bar-x-discretized",
-            path: `layers.${binding.index}`,
-            chosen: `x treated as discrete bands (${geom} geom)`,
-            howToOverride: "Use point/line/area for continuous x, or set scales.x.type explicitly.",
-          });
-        }
-        if (barX || fieldType === "nominal") anyDiscrete = true;
-        if (fieldType !== "temporal") allTemporal = false;
-        sawContinuousEvidence = true;
-      }
-      if (frame.box !== null && frame.box.outlierX.length > 0) {
-        columns.push(frame.box.outlierX);
-      }
-      for (const v of frame.xIntercepts) {
-        columns.push([v]);
-        numeric.push(Float64Array.of(cellToNumber(v)));
-        if (typeof v === "string" && !Number.isFinite(cellToNumber(v))) anyDiscrete = true;
-        sawContinuousEvidence = true;
-      }
-    } else {
-      if (isBarLike(geom) || geom === "density") barMeasure = true;
-      if (frame.ymin !== null && frame.ymax !== null) {
-        numeric.push(frame.ymin, frame.ymax);
-        // Bands need not cover the center line (se: false smooths have
-        // NaN bands; the summary center can escape min/max bounds).
-        if ((geom === "smooth" || geom === "errorbar") && frame.yNumeric !== null) {
-          numeric.push(frame.yNumeric);
-        }
-        if (frame.box !== null) numeric.push(frame.box.outlierY);
-        typeParts.add("quantitative");
-        allTemporal = false;
-        sawContinuousEvidence = true;
-      } else if (binding.yStatColumn !== null && frame.yNumeric !== null) {
-        numeric.push(frame.yNumeric);
-        typeParts.add(binding.yStatColumn);
-        allTemporal = false;
-        sawContinuousEvidence = true;
-      } else if (binding.yField !== null) {
-        // Panel-local data: free-y facets train each panel on ITS rows.
-        const column = frame.table.column(binding.yField);
-        columns.push(column);
-        numeric.push(frame.table.numeric(binding.yField));
-        const fieldType = frame.table.fieldType(binding.yField);
-        typeParts.add(fieldType);
-        if (fieldType === "nominal") anyDiscrete = true;
-        if (fieldType !== "temporal") allTemporal = false;
-        sawContinuousEvidence = true;
-      }
-      for (const v of frame.yIntercepts) {
-        columns.push([v]);
-        numeric.push(Float64Array.of(cellToNumber(v)));
-        sawContinuousEvidence = true;
-      }
-    }
+    if (axis === "x") collectAxisInputsX(frame, configType, advisories, acc);
+    else collectAxisInputsY(frame, acc);
   }
 
   return {
-    columns,
-    numeric,
-    anyDiscrete,
-    allTemporal: allTemporal && sawContinuousEvidence,
-    barMeasure,
-    evidence: `field type: ${[...typeParts].join("+") || "none"}`,
+    columns: acc.columns,
+    numeric: acc.numeric,
+    anyDiscrete: acc.anyDiscrete,
+    allTemporal: acc.allTemporal && acc.sawContinuousEvidence,
+    barMeasure: acc.barMeasure,
+    evidence: `field type: ${[...acc.typeParts].join("+") || "none"}`,
   };
 }

--- a/packages/core/src/pipeline/train-pipeline-scales-color.ts
+++ b/packages/core/src/pipeline/train-pipeline-scales-color.ts
@@ -1,0 +1,55 @@
+/**
+ * Resolve global color and fill scales for a pipeline run.
+ */
+import type { PortableSpec } from "@ggsvelte/spec";
+
+import type { EditionDefaults } from "../editions.js";
+import type { ColumnTable } from "../table.js";
+
+import { resolveColorScale } from "./scale-training.js";
+import type { Advisory, LayerFrame, PipelineWarning, RunOptions } from "./types.js";
+
+export function trainPipelineColorScales(input: {
+  scalesConfig: NonNullable<PortableSpec["scales"]>;
+  labs: NonNullable<PortableSpec["labs"]>;
+  allFrames: readonly LayerFrame[];
+  table: ColumnTable;
+  options: Pick<RunOptions, "prevScales">;
+  editionDefaults: EditionDefaults;
+  warnings: PipelineWarning[];
+  advisories: Advisory[];
+}): {
+  colorResolution: ReturnType<typeof resolveColorScale>;
+  fillResolution: ReturnType<typeof resolveColorScale>;
+} {
+  const { scalesConfig, labs, allFrames, table, options, editionDefaults, warnings, advisories } =
+    input;
+
+  const firstColorField = allFrames.find((f) => f.binding.color.field !== null)?.binding.color
+    .field;
+  const firstFillField = allFrames.find((f) => f.binding.fill.field !== null)?.binding.fill.field;
+  const colorResolution = resolveColorScale(
+    "color",
+    allFrames,
+    table,
+    scalesConfig.color,
+    options.prevScales?.["color"] ?? null,
+    labs.color ?? firstColorField ?? "",
+    warnings,
+    advisories,
+    editionDefaults,
+  );
+  const fillResolution = resolveColorScale(
+    "fill",
+    allFrames,
+    table,
+    scalesConfig.fill,
+    options.prevScales?.["fill"] ?? null,
+    labs.fill ?? firstFillField ?? "",
+    warnings,
+    advisories,
+    editionDefaults,
+  );
+
+  return { colorResolution, fillResolution };
+}

--- a/packages/core/src/pipeline/train-pipeline-scales-position.ts
+++ b/packages/core/src/pipeline/train-pipeline-scales-position.ts
@@ -1,0 +1,60 @@
+/**
+ * Train fixed and free positional scales for a pipeline run.
+ */
+import type { PortableSpec } from "@ggsvelte/spec";
+
+import type { PositionScale } from "../scales/train.js";
+
+import type { FacetPanelDef } from "./facets.js";
+import { collectAxisInputs, trainAxis } from "./scale-training.js";
+import type { Advisory, LayerFrame, PipelineWarning } from "./types.js";
+
+export interface TrainedPositionScales {
+  xTraining: ReturnType<typeof trainAxis>;
+  yTraining: ReturnType<typeof trainAxis>;
+  panelScales: { x: PositionScale; y: PositionScale }[];
+  xInputs: ReturnType<typeof collectAxisInputs>;
+  yInputs: ReturnType<typeof collectAxisInputs>;
+  allFrames: LayerFrame[];
+}
+
+export function trainPipelinePositionScales(input: {
+  scalesConfig: NonNullable<PortableSpec["scales"]>;
+  facetPanels: readonly FacetPanelDef[];
+  panelFrames: readonly (readonly LayerFrame[])[];
+  freeX: boolean;
+  freeY: boolean;
+  warnings: PipelineWarning[];
+  advisories: Advisory[];
+}): TrainedPositionScales {
+  const { scalesConfig, facetPanels, panelFrames, freeX, freeY, warnings, advisories } = input;
+
+  const allFrames = panelFrames.flat();
+  const xInputs = collectAxisInputs("x", allFrames, scalesConfig.x?.type, advisories);
+  const yInputs = collectAxisInputs("y", allFrames, scalesConfig.y?.type, advisories);
+  const xTraining = trainAxis("x", xInputs, scalesConfig.x);
+  const yTraining = trainAxis("y", yInputs, scalesConfig.y);
+  advisories.push(...xTraining.advisories, ...yTraining.advisories);
+  warnings.push(...xTraining.warnings, ...yTraining.warnings);
+
+  const panelScales: { x: PositionScale; y: PositionScale }[] = facetPanels.map((_, p) => {
+    let px = xTraining.scale;
+    let py = yTraining.scale;
+    const scratch: Advisory[] = [];
+    if (freeX) {
+      const inputs = collectAxisInputs("x", panelFrames[p]!, scalesConfig.x?.type, scratch);
+      const training = trainAxis("x", inputs, { ...scalesConfig.x, type: xTraining.scale.type });
+      warnings.push(...training.warnings);
+      px = training.scale;
+    }
+    if (freeY) {
+      const inputs = collectAxisInputs("y", panelFrames[p]!, scalesConfig.y?.type, scratch);
+      const training = trainAxis("y", inputs, { ...scalesConfig.y, type: yTraining.scale.type });
+      warnings.push(...training.warnings);
+      py = training.scale;
+    }
+    return { x: px, y: py };
+  });
+
+  return { xTraining, yTraining, panelScales, xInputs, yInputs, allFrames };
+}

--- a/packages/core/src/pipeline/train-pipeline-scales.ts
+++ b/packages/core/src/pipeline/train-pipeline-scales.ts
@@ -9,6 +9,8 @@ import type { ColumnTable } from "../table.js";
 
 import type { FacetPanelDef } from "./facets.js";
 import { collectAxisInputs, resolveColorScale, trainAxis } from "./scale-training.js";
+import { trainPipelineColorScales } from "./train-pipeline-scales-color.js";
+import { trainPipelinePositionScales } from "./train-pipeline-scales-position.js";
 import type { Advisory, LayerFrame, PipelineWarning, RunOptions } from "./types.js";
 
 export interface TrainedPipelineScales {
@@ -49,69 +51,29 @@ export function trainPipelineScales(input: {
   } = input;
 
   const scalesConfig = normalized.scales ?? {};
-  const allFrames = panelFrames.flat();
-  const xInputs = collectAxisInputs("x", allFrames, scalesConfig.x?.type, advisories);
-  const yInputs = collectAxisInputs("y", allFrames, scalesConfig.y?.type, advisories);
-  const xTraining = trainAxis("x", xInputs, scalesConfig.x);
-  const yTraining = trainAxis("y", yInputs, scalesConfig.y);
-  advisories.push(...xTraining.advisories, ...yTraining.advisories);
-  warnings.push(...xTraining.warnings, ...yTraining.warnings);
-
-  const panelScales: { x: PositionScale; y: PositionScale }[] = facetPanels.map((_, p) => {
-    let px = xTraining.scale;
-    let py = yTraining.scale;
-    const scratch: Advisory[] = [];
-    if (freeX) {
-      const inputs = collectAxisInputs("x", panelFrames[p]!, scalesConfig.x?.type, scratch);
-      const training = trainAxis("x", inputs, { ...scalesConfig.x, type: xTraining.scale.type });
-      warnings.push(...training.warnings);
-      px = training.scale;
-    }
-    if (freeY) {
-      const inputs = collectAxisInputs("y", panelFrames[p]!, scalesConfig.y?.type, scratch);
-      const training = trainAxis("y", inputs, { ...scalesConfig.y, type: yTraining.scale.type });
-      warnings.push(...training.warnings);
-      py = training.scale;
-    }
-    return { x: px, y: py };
+  const position = trainPipelinePositionScales({
+    scalesConfig,
+    facetPanels,
+    panelFrames,
+    freeX,
+    freeY,
+    warnings,
+    advisories,
+  });
+  const color = trainPipelineColorScales({
+    scalesConfig,
+    labs: normalized.labs ?? {},
+    allFrames: position.allFrames,
+    table,
+    options,
+    editionDefaults,
+    warnings,
+    advisories,
   });
 
-  const labs = normalized.labs ?? {};
-  const firstColorField = allFrames.find((f) => f.binding.color.field !== null)?.binding.color
-    .field;
-  const firstFillField = allFrames.find((f) => f.binding.fill.field !== null)?.binding.fill.field;
-  const colorResolution = resolveColorScale(
-    "color",
-    allFrames,
-    table,
-    scalesConfig.color,
-    options.prevScales?.["color"] ?? null,
-    labs.color ?? firstColorField ?? "",
-    warnings,
-    advisories,
-    editionDefaults,
-  );
-  const fillResolution = resolveColorScale(
-    "fill",
-    allFrames,
-    table,
-    scalesConfig.fill,
-    options.prevScales?.["fill"] ?? null,
-    labs.fill ?? firstFillField ?? "",
-    warnings,
-    advisories,
-    editionDefaults,
-  );
-
   return {
-    xTraining,
-    yTraining,
-    panelScales,
-    colorResolution,
-    fillResolution,
-    xInputs,
-    yInputs,
+    ...position,
+    ...color,
     scalesConfig,
-    allFrames,
   };
 }

--- a/packages/core/src/pipeline/types-advisory.ts
+++ b/packages/core/src/pipeline/types-advisory.ts
@@ -1,0 +1,35 @@
+/**
+ * Pipeline diagnostics: advisories, warnings, structured errors, and canvas threshold.
+ */
+
+export interface Advisory {
+  code: string;
+  /** Where the decision applies (e.g. "scales.x"). */
+  path: string;
+  /** What was chosen. */
+  chosen: string;
+  /** How to override the heuristic. */
+  howToOverride: string;
+}
+
+/** A data-level problem that did not stop the render. */
+export interface PipelineWarning {
+  code: string;
+  message: string;
+}
+
+/** A spec- or input-level problem that stops the render (structured). */
+export class PipelineError extends Error {
+  readonly code: string;
+  readonly path: string;
+
+  constructor(code: string, path: string, message: string) {
+    super(message);
+    this.name = "PipelineError";
+    this.code = code;
+    this.path = path;
+  }
+}
+
+/** Default `render: "auto"` mark-count threshold for the canvas backend. */
+export const CANVAS_AUTO_THRESHOLD = 2000;

--- a/packages/core/src/pipeline/types-model.ts
+++ b/packages/core/src/pipeline/types-model.ts
@@ -1,0 +1,96 @@
+/**
+ * Pipeline model types: trained scales, domain snapshots, and RenderModel.
+ */
+import type { SequentialColorScale } from "../scales/color.js";
+import type { ScaleState } from "../scales/state.js";
+import type { ColorScale, PositionScale } from "../scales/train.js";
+import type { Scene } from "../scene.js";
+import type { CellValue } from "../table.js";
+import type { CandidateStore } from "../candidate-store.js";
+import type { LineageStore } from "../identity.js";
+
+import type { Advisory, PipelineWarning } from "./types-advisory.js";
+
+/** A resolved color-ish scale: value-stable ordinal or sequential ramp. */
+export type ResolvedColorScale =
+  | { kind: "ordinal"; scale: ColorScale }
+  | { kind: "sequential"; scale: SequentialColorScale };
+
+export interface TrainedScales {
+  /** The shared x scale (union-trained). Free-x facets ALSO train per panel
+   *  — see `panels`. */
+  x: PositionScale;
+  y: PositionScale;
+  color: ResolvedColorScale | null;
+  fill: ResolvedColorScale | null;
+  /** Per-panel positional scales (facets; equal to x/y when fixed). */
+  panels: { x: PositionScale; y: PositionScale }[];
+  /** Serializable per-scale-name state (plain JSON). Commit only when this
+   *  model's runId is still the latest — that is the transactionality rule. */
+  state: Record<string, ScaleState>;
+}
+
+export interface ScaleDomainSnapshot {
+  readonly x: readonly CellValue[];
+  readonly y: readonly CellValue[];
+  readonly panels: readonly Readonly<{
+    x: readonly CellValue[];
+    y: readonly CellValue[];
+  }>[];
+}
+
+/** Format a logical value using its trained semantic positional axis. */
+export type AxisValueFormatter = (value: CellValue) => string;
+
+/** Resolved rendering backend per layer (after hints/threshold/a11y). */
+export type LayerBackend = "svg" | "canvas";
+
+/** A field-mapped channel of one layer (tooltip content contract). */
+export interface MappedField {
+  channel: string;
+  field: string;
+  /** Stat output rather than a source-table column. Its semantic x/y value
+   *  is available directly on CandidateFacts for synthesized marks. */
+  source?: "stat";
+}
+
+export interface RenderModel {
+  scene: Scene;
+  scales: TrainedScales;
+  warnings: PipelineWarning[];
+  advisories: Advisory[];
+  /** Monotonic run identity (module-global, increases every runPipeline call). */
+  runId: number;
+  /**
+   * Resolved rendering backend per layer: the layer's `render` hint, with
+   * "auto" resolving to canvas above the mark-count threshold (advisory
+   * `canvas-auto`), and `a11y: "force-svg"` forcing every layer to "svg".
+   * renderToSVGString ignores this (always all-SVG).
+   */
+  layerBackends: LayerBackend[];
+  /** Field-mapped channels per layer (drives default tooltip content). */
+  layerFields: MappedField[][];
+  /**
+   * Scaled constant aes values per layer (`{ value, scale: true }` on color/fill).
+   * Used by legend-focus key indexing when no field mapping exists for a scale.
+   */
+  layerScaledConstants: ReadonlyArray<Readonly<Partial<Record<string, CellValue>>>>;
+  /** Stable baseline plus the domains actually used for this render. */
+  domains: Readonly<{ baseline: ScaleDomainSnapshot; effective: ScaleDomainSnapshot }>;
+  /** Interned source-row memberships. Public adapters resolve these through keys. */
+  lineage: LineageStore<number>;
+  /** Shared epoch-scoped interaction candidate storage. */
+  candidates: CandidateStore;
+  /** Trained semantic formatters. Coord transforms never swap x and y here. */
+  axisFormatters: Readonly<{ x: AxisValueFormatter; y: AxisValueFormatter }>;
+  /** The source data row behind a hit-index rowIndex (null for synthesized
+   *  stat rows). Reads the bound table — do not call after dispose(). */
+  row(index: number): Record<string, CellValue> | null;
+  /**
+   * Release this model's geometry and caches (plan: memory ownership). The
+   * Svelte adapter disposes the previous model on commit and the current one
+   * on unmount. After dispose() the scene's batches are empty and row()
+   * returns null; rendering a disposed model is a caller bug.
+   */
+  dispose(): void;
+}

--- a/packages/core/src/pipeline/types-options.ts
+++ b/packages/core/src/pipeline/types-options.ts
@@ -1,0 +1,47 @@
+/**
+ * Pipeline run options and named data contract.
+ */
+import type { PositionScaleSpec } from "@ggsvelte/spec";
+
+import type { ScaleState } from "../scales/state.js";
+import type { Columns, Rows } from "../table.js";
+import type { TextMeasurer } from "../layout/measure.js";
+import type { EditionDefaults } from "../editions.js";
+
+import type { ScaleDomainSnapshot } from "./types-model.js";
+
+/** Named data acceptable at run time: rows, columns, or the inline forms. */
+export type NamedData = Rows | Columns | { values: Rows } | { columns: Columns };
+
+export interface RunOptions {
+  /** Plot width in px (required — container sizing is the adapter's job). */
+  width: number;
+  /** Plot height in px. */
+  height: number;
+  /** Named datasets resolvable by { name } data refs. */
+  data?: Record<string, NamedData>;
+  /** Allow RunOptions.data to shadow spec.datasets on name collision. */
+  allowOverride?: boolean;
+  /** Text measurer; defaults to the canonical deterministic metrics table. */
+  measureText?: TextMeasurer;
+  /** Previously committed scale state (value-stable color assignments). */
+  prevScales?: Record<string, ScaleState>;
+  /** Mark-count threshold above which `render: "auto"` layers resolve to
+   *  canvas (default 2000, benchmark-tuned; advisory `canvas-auto`). */
+  canvasThreshold?: number;
+  /** Defaults-edition table override (editions.ts). Run-scoped — no global
+   *  registry; used by tests proving edition stability and by future
+   *  edition rollouts. Defaults to EDITION_DEFAULTS. */
+  editions?: Readonly<Record<number, EditionDefaults>>;
+  /** Latest data-derived domains retained by an interaction controller while
+   * an explicit zoom domain is effective. Omit for an unzoomed render. */
+  baselineDomains?: ScaleDomainSnapshot;
+  /** Unzoomed positional scale configuration. When supplied, the pipeline
+   * trains the latest natural baseline from this run's data while rendering
+   * with the spec's effective (typically explicit zoom) domains. Missing
+   * axes mean natural default scale configuration. `baselineDomains` wins. */
+  baselineScales?: Readonly<{
+    x?: PositionScaleSpec;
+    y?: PositionScaleSpec;
+  }>;
+}

--- a/packages/core/src/pipeline/types-public.ts
+++ b/packages/core/src/pipeline/types-public.ts
@@ -1,166 +1,19 @@
 /**
  * Pipeline public contract: errors, model, run options, scale snapshots.
+ * Split into types-advisory / types-model / types-options; re-exported here
+ * for import-path stability.
  */
-import type { PositionScaleSpec } from "@ggsvelte/spec";
+export type { Advisory, PipelineWarning } from "./types-advisory.js";
+export { CANVAS_AUTO_THRESHOLD, PipelineError } from "./types-advisory.js";
 
-import type { SequentialColorScale } from "../scales/color.js";
-import type { ScaleState } from "../scales/state.js";
-import type { ColorScale, PositionScale } from "../scales/train.js";
-import type { Scene } from "../scene.js";
-import type { CellValue, Columns, Rows } from "../table.js";
-import type { TextMeasurer } from "../layout/measure.js";
-import type { EditionDefaults } from "../editions.js";
-import type { CandidateStore } from "../candidate-store.js";
-import type { LineageStore } from "../identity.js";
+export type {
+  AxisValueFormatter,
+  LayerBackend,
+  MappedField,
+  RenderModel,
+  ResolvedColorScale,
+  ScaleDomainSnapshot,
+  TrainedScales,
+} from "./types-model.js";
 
-export interface Advisory {
-  code: string;
-  /** Where the decision applies (e.g. "scales.x"). */
-  path: string;
-  /** What was chosen. */
-  chosen: string;
-  /** How to override the heuristic. */
-  howToOverride: string;
-}
-
-/** A data-level problem that did not stop the render. */
-export interface PipelineWarning {
-  code: string;
-  message: string;
-}
-
-/** A spec- or input-level problem that stops the render (structured). */
-export class PipelineError extends Error {
-  readonly code: string;
-  readonly path: string;
-
-  constructor(code: string, path: string, message: string) {
-    super(message);
-    this.name = "PipelineError";
-    this.code = code;
-    this.path = path;
-  }
-}
-
-/** A resolved color-ish scale: value-stable ordinal or sequential ramp. */
-export type ResolvedColorScale =
-  | { kind: "ordinal"; scale: ColorScale }
-  | { kind: "sequential"; scale: SequentialColorScale };
-
-export interface TrainedScales {
-  /** The shared x scale (union-trained). Free-x facets ALSO train per panel
-   *  — see `panels`. */
-  x: PositionScale;
-  y: PositionScale;
-  color: ResolvedColorScale | null;
-  fill: ResolvedColorScale | null;
-  /** Per-panel positional scales (facets; equal to x/y when fixed). */
-  panels: { x: PositionScale; y: PositionScale }[];
-  /** Serializable per-scale-name state (plain JSON). Commit only when this
-   *  model's runId is still the latest — that is the transactionality rule. */
-  state: Record<string, ScaleState>;
-}
-
-export interface ScaleDomainSnapshot {
-  readonly x: readonly CellValue[];
-  readonly y: readonly CellValue[];
-  readonly panels: readonly Readonly<{
-    x: readonly CellValue[];
-    y: readonly CellValue[];
-  }>[];
-}
-
-/** Format a logical value using its trained semantic positional axis. */
-export type AxisValueFormatter = (value: CellValue) => string;
-
-/** Resolved rendering backend per layer (after hints/threshold/a11y). */
-export type LayerBackend = "svg" | "canvas";
-
-/** A field-mapped channel of one layer (tooltip content contract). */
-export interface MappedField {
-  channel: string;
-  field: string;
-  /** Stat output rather than a source-table column. Its semantic x/y value
-   *  is available directly on CandidateFacts for synthesized marks. */
-  source?: "stat";
-}
-
-export interface RenderModel {
-  scene: Scene;
-  scales: TrainedScales;
-  warnings: PipelineWarning[];
-  advisories: Advisory[];
-  /** Monotonic run identity (module-global, increases every runPipeline call). */
-  runId: number;
-  /**
-   * Resolved rendering backend per layer: the layer's `render` hint, with
-   * "auto" resolving to canvas above the mark-count threshold (advisory
-   * `canvas-auto`), and `a11y: "force-svg"` forcing every layer to "svg".
-   * renderToSVGString ignores this (always all-SVG).
-   */
-  layerBackends: LayerBackend[];
-  /** Field-mapped channels per layer (drives default tooltip content). */
-  layerFields: MappedField[][];
-  /**
-   * Scaled constant aes values per layer (`{ value, scale: true }` on color/fill).
-   * Used by legend-focus key indexing when no field mapping exists for a scale.
-   */
-  layerScaledConstants: ReadonlyArray<Readonly<Partial<Record<string, CellValue>>>>;
-  /** Stable baseline plus the domains actually used for this render. */
-  domains: Readonly<{ baseline: ScaleDomainSnapshot; effective: ScaleDomainSnapshot }>;
-  /** Interned source-row memberships. Public adapters resolve these through keys. */
-  lineage: LineageStore<number>;
-  /** Shared epoch-scoped interaction candidate storage. */
-  candidates: CandidateStore;
-  /** Trained semantic formatters. Coord transforms never swap x and y here. */
-  axisFormatters: Readonly<{ x: AxisValueFormatter; y: AxisValueFormatter }>;
-  /** The source data row behind a hit-index rowIndex (null for synthesized
-   *  stat rows). Reads the bound table — do not call after dispose(). */
-  row(index: number): Record<string, CellValue> | null;
-  /**
-   * Release this model's geometry and caches (plan: memory ownership). The
-   * Svelte adapter disposes the previous model on commit and the current one
-   * on unmount. After dispose() the scene's batches are empty and row()
-   * returns null; rendering a disposed model is a caller bug.
-   */
-  dispose(): void;
-}
-
-/** Named data acceptable at run time: rows, columns, or the inline forms. */
-export type NamedData = Rows | Columns | { values: Rows } | { columns: Columns };
-
-export interface RunOptions {
-  /** Plot width in px (required — container sizing is the adapter's job). */
-  width: number;
-  /** Plot height in px. */
-  height: number;
-  /** Named datasets resolvable by { name } data refs. */
-  data?: Record<string, NamedData>;
-  /** Allow RunOptions.data to shadow spec.datasets on name collision. */
-  allowOverride?: boolean;
-  /** Text measurer; defaults to the canonical deterministic metrics table. */
-  measureText?: TextMeasurer;
-  /** Previously committed scale state (value-stable color assignments). */
-  prevScales?: Record<string, ScaleState>;
-  /** Mark-count threshold above which `render: "auto"` layers resolve to
-   *  canvas (default 2000, benchmark-tuned; advisory `canvas-auto`). */
-  canvasThreshold?: number;
-  /** Defaults-edition table override (editions.ts). Run-scoped — no global
-   *  registry; used by tests proving edition stability and by future
-   *  edition rollouts. Defaults to EDITION_DEFAULTS. */
-  editions?: Readonly<Record<number, EditionDefaults>>;
-  /** Latest data-derived domains retained by an interaction controller while
-   * an explicit zoom domain is effective. Omit for an unzoomed render. */
-  baselineDomains?: ScaleDomainSnapshot;
-  /** Unzoomed positional scale configuration. When supplied, the pipeline
-   * trains the latest natural baseline from this run's data while rendering
-   * with the spec's effective (typically explicit zoom) domains. Missing
-   * axes mean natural default scale configuration. `baselineDomains` wins. */
-  baselineScales?: Readonly<{
-    x?: PositionScaleSpec;
-    y?: PositionScaleSpec;
-  }>;
-}
-
-/** Default `render: "auto"` mark-count threshold for the canvas backend. */
-export const CANVAS_AUTO_THRESHOLD = 2000;
+export type { NamedData, RunOptions } from "./types-options.js";

--- a/packages/core/tests/pipeline-build-candidates.test.ts
+++ b/packages/core/tests/pipeline-build-candidates.test.ts
@@ -6,9 +6,48 @@ import { describe, expect, it } from "bun:test";
 
 import { aes, gg } from "@ggsvelte/spec";
 
+import { resolveCandidateLogicalValues } from "../src/pipeline/build-candidates-datum-values.ts";
 import { runPipeline } from "../src/pipeline.ts";
 
 const size = { width: 640, height: 400 };
+
+describe("resolveCandidateLogicalValues", () => {
+  it("prefers annotation intercepts when the layer is an annotation rule", () => {
+    expect(
+      resolveCandidateLogicalValues({
+        annotationRule: true,
+        annotationX: 3,
+        annotationY: null,
+        outlierSourceRow: null,
+        sourceRow: 0,
+        frame: undefined,
+        frameRow: 0,
+        primitiveIndex: 0,
+        sourceValue: () => "ignored",
+        xField: "x",
+        yField: "y",
+      }),
+    ).toEqual({ xValue: 3, yValue: null });
+  });
+
+  it("reads source fields for identity rows and outliers when present", () => {
+    expect(
+      resolveCandidateLogicalValues({
+        annotationRule: false,
+        annotationX: null,
+        annotationY: null,
+        outlierSourceRow: null,
+        sourceRow: 2,
+        frame: undefined,
+        frameRow: 0,
+        primitiveIndex: 0,
+        sourceValue: (field) => (field === "x" ? 11 : field === "y" ? 22 : null),
+        xField: "x",
+        yField: "y",
+      }),
+    ).toEqual({ xValue: 11, yValue: 22 });
+  });
+});
 
 describe("buildPipelineCandidates via runPipeline", () => {
   it("source-backed point layers expose one candidate per mark with lineage", () => {


### PR DESCRIPTION
## Summary
- Split `types-public` into advisory/errors, model, and run-options modules (facade re-exports).
- Split `scale-axis-collect` into x/y evidence collectors.
- Split `trainPipelineScales` into position training and color/fill resolution.
- Split boxplot body into pixel layout vs batch assembly.
- Extract pure `resolveCandidateLogicalValues` from candidate datum resolution.
- Add characterization tests for the candidate value helper; existing types/scale/geometry/runPipeline coverage for facades.

## Test plan
- [x] `bun test packages/core` (499 pass)
- [x] `bun run check`
- [x] `bun run knip`
- [x] `bun run lint:type-aware`
- [x] Codex pre-PR review (PASS, no P1/P2)