### PR TITLE
refactor(svelte): carry pending payload and preview-set source

### DIFF
--- a/packages/svelte/src/lib/GGPlot.svelte
+++ b/packages/svelte/src/lib/GGPlot.svelte
@@ -238,7 +238,6 @@
     buildLegendEntryKeyIndexForPlot,
     findLegendPressedIdentity,
     keysForLegendEntry,
-    legendInteractionSource,
     moveLegendRovingIndex,
     planLegendCommittedReconcile,
     planLegendFocusDisabledClear,
@@ -1048,7 +1047,10 @@
         });
       return;
     }
-    const decision = resolveLegendPreviewKeysDecision(keysForLegend(action));
+    const decision = resolveLegendPreviewKeysDecision({
+      keys: keysForLegend(action),
+      entrySource: action.source,
+    });
     if (decision.type === "clear") {
       // Empty domain entry: do not leave the previous entry's preview active.
       previewLegend(null);
@@ -1059,7 +1061,7 @@
       type: "legend-focus",
       phase: "change",
       state: "transient",
-      source: legendInteractionSource(action.source),
+      source: decision.source,
       scale: action.identity.scale as "color" | "fill",
       value: action.entry.value as CellValue,
       label: action.entry.label,
@@ -1634,7 +1636,7 @@
       hasInspection: inspection !== null,
       hasSeed: inspectionSeed !== null,
       currentState: inspection?.state ?? "transient",
-      hasPendingPinned: pendingPinnedPointer !== null,
+      pending: pendingPinnedPointer,
     });
     if (pinAction.type === "ignore") return;
     // toggle-pin always runs before restore/flip side effects; if flip
@@ -1642,17 +1644,17 @@
     reducer.dispatch({ type: "toggle-pin", source });
     switch (pinAction.type) {
       case "restore-pending": {
-        const pending = pendingPinnedPointer!;
+        // Pure gate carries pending payload — no host non-null assert.
         pendingPinnedPointer = null;
         inspectionCoordinator.release("pinned");
         inspection = null;
         inspectionSeed = null;
         setInspection(
-          pending.hit,
-          pending.source,
+          pinAction.pending.hit,
+          pinAction.pending.source,
           "transient",
-          pending.concreteMode,
-          pending.candidate,
+          pinAction.pending.concreteMode,
+          pinAction.pending.candidate,
         );
         return;
       }

--- a/packages/svelte/src/lib/plot-legend-focus.ts
+++ b/packages/svelte/src/lib/plot-legend-focus.ts
@@ -302,11 +302,27 @@ export function buildLegendEntryKeyIndex(
  * Decide what a legend preview attempt should do with resolved keys.
  * Empty key sets clear any active preview (empty domain entry / stale target)
  * rather than leaving the previous entry highlighted.
+ *
+ * Non-empty `set` carries mapped InteractionSource via `legendInteractionSource`
+ * so the host does not re-map `action.source` after the pure decision.
  */
-export function resolveLegendPreviewKeysDecision(
-  keys: readonly PropertyKey[],
-): { readonly type: "set"; readonly keys: readonly PropertyKey[] } | { readonly type: "clear" } {
-  return keys.length === 0 ? { type: "clear" } : { type: "set", keys };
+export function resolveLegendPreviewKeysDecision(input: {
+  readonly keys: readonly PropertyKey[];
+  /** Host: `action.source` (legend entry interaction source). */
+  readonly entrySource: LegendInteractionSource;
+}):
+  | { readonly type: "clear" }
+  | {
+      readonly type: "set";
+      readonly keys: readonly PropertyKey[];
+      readonly source: InteractionSource;
+    } {
+  if (input.keys.length === 0) return { type: "clear" };
+  return {
+    type: "set",
+    keys: input.keys,
+    source: legendInteractionSource(input.entrySource),
+  };
 }
 
 /**

--- a/packages/svelte/src/lib/plot-surface-inspection.ts
+++ b/packages/svelte/src/lib/plot-surface-inspection.ts
@@ -256,12 +256,17 @@ export type ToggleInspectionPinInput = {
   readonly hasSeed: boolean;
   /** Host: current inspection.state when hasInspection. */
   readonly currentState: "transient" | "pinned";
-  readonly hasPendingPinned: boolean;
+  /** Host: `pendingPinnedPointer` (null when none). */
+  readonly pending: QueuedPointerInspection | null;
 };
 
 export type ToggleInspectionPinAction =
   | { readonly type: "ignore" }
-  | { readonly type: "restore-pending" }
+  | {
+      readonly type: "restore-pending";
+      /** Pending queue payload to restore as transient inspection. */
+      readonly pending: QueuedPointerInspection;
+    }
   | {
       readonly type: "flip";
       /** Target inspection state after toggle-pin dispatch + re-resolve. */
@@ -274,15 +279,19 @@ export type ToggleInspectionPinAction =
  * Host sequencing (preserve exactly):
  *   1. if ignore → return (no reducer dispatch)
  *   2. always `reducer.dispatch({ type: "toggle-pin", source })` first
- *   3. restore-pending → release pinned, clear fields, setInspection(pending…)
+ *   3. restore-pending → release pinned, clear fields, setInspection(action.pending…, "transient")
  *   4. flip → resolveInspection with action.state; if null return with reducer
  *      already toggled (host does not roll back reducer state)
+ *
+ * `pending` replaces a separate `hasPendingPinned` boolean so restore cannot
+ * race a null payload and the host does not non-null-assert after the gate.
  */
 export function resolveToggleInspectionPinAction(
   input: ToggleInspectionPinInput,
 ): ToggleInspectionPinAction {
   if (!input.hasInspection || !input.hasSeed) return { type: "ignore" };
-  if (input.currentState === "pinned" && input.hasPendingPinned) return { type: "restore-pending" };
+  if (input.currentState === "pinned" && input.pending !== null)
+    return { type: "restore-pending", pending: input.pending };
   return {
     type: "flip",
     state: input.currentState === "pinned" ? "transient" : "pinned",

--- a/packages/svelte/tests/plot-legend-focus.test.ts
+++ b/packages/svelte/tests/plot-legend-focus.test.ts
@@ -502,9 +502,23 @@ describe("buildLegendEntryKeyIndex", () => {
 });
 
 describe("resolveLegendPreviewKeysDecision", () => {
-  it("clears when the entry has no keys and sets otherwise", () => {
-    expect(resolveLegendPreviewKeysDecision([])).toEqual({ type: "clear" });
-    expect(resolveLegendPreviewKeysDecision(["a"])).toEqual({ type: "set", keys: ["a"] });
+  it("clears when the entry has no keys", () => {
+    expect(resolveLegendPreviewKeysDecision({ keys: [], entrySource: "pointer" })).toEqual({
+      type: "clear",
+    });
+  });
+
+  it("sets keys and maps entrySource to InteractionSource", () => {
+    expect(resolveLegendPreviewKeysDecision({ keys: ["a"], entrySource: "pointer" })).toEqual({
+      type: "set",
+      keys: ["a"],
+      source: "pointer",
+    });
+    expect(resolveLegendPreviewKeysDecision({ keys: ["a", "b"], entrySource: "focus" })).toEqual({
+      type: "set",
+      keys: ["a", "b"],
+      source: "keyboard",
+    });
   });
 });
 

--- a/packages/svelte/tests/plot-surface-inspection.test.ts
+++ b/packages/svelte/tests/plot-surface-inspection.test.ts
@@ -452,13 +452,19 @@ describe("shouldCommitInspection", () => {
   });
 });
 
+const samplePending = {
+  hit: null,
+  source: "pointer" as const,
+  concreteMode: "exact" as const,
+};
+
 const toggleInput = (
   overrides: Partial<ToggleInspectionPinInput> = {},
 ): ToggleInspectionPinInput => ({
   hasInspection: true,
   hasSeed: true,
   currentState: "transient",
-  hasPendingPinned: false,
+  pending: null,
   ...overrides,
 });
 
@@ -472,15 +478,15 @@ describe("resolveToggleInspectionPinAction", () => {
     ).toEqual({ type: "ignore" });
   });
 
-  it("restores pending only when pinned with a pending payload", () => {
+  it("restores pending only when pinned with a non-null pending payload", () => {
     expect(
       resolveToggleInspectionPinAction(
         toggleInput({
           currentState: "pinned",
-          hasPendingPinned: true,
+          pending: samplePending,
         }),
       ),
-    ).toEqual({ type: "restore-pending" });
+    ).toEqual({ type: "restore-pending", pending: samplePending });
   });
 
   it("does not restore pending while transient even if pending exists", () => {
@@ -488,18 +494,18 @@ describe("resolveToggleInspectionPinAction", () => {
       resolveToggleInspectionPinAction(
         toggleInput({
           currentState: "transient",
-          hasPendingPinned: true,
+          pending: samplePending,
         }),
       ),
     ).toEqual({ type: "flip", state: "pinned" });
   });
 
-  it("flips pinned → transient when no pending", () => {
+  it("flips pinned → transient when pending is null", () => {
     expect(
       resolveToggleInspectionPinAction(
         toggleInput({
           currentState: "pinned",
-          hasPendingPinned: false,
+          pending: null,
         }),
       ),
     ).toEqual({ type: "flip", state: "transient" });


### PR DESCRIPTION
## Summary
- Expand `resolveToggleInspectionPinAction` so `restore-pending` carries the pending queue payload (replacing `hasPendingPinned`), removing the host non-null assert on `pendingPinnedPointer`.
- Expand `resolveLegendPreviewKeysDecision` to take `entrySource` and return mapped `source` on `set`, finishing legend source mapping for the preview-set path.
- Remove unused `legendInteractionSource` import from `GGPlot`.

## Test plan
- [x] `vitest run` plot-surface-inspection + plot-legend-focus (all browsers)
- [x] `bun run check` / svelte-check --fail-on-warnings
- [x] Pre-push: package build, oxlint type-aware, knip, bun test
- [x] Codex pre-PR: clean (no P1/P2)