### PR TITLE
refactor(core): split position, facet grid, bind, and finalize helpers

### DIFF
--- a/packages/core/src/pipeline/bind-layer-extras.ts
+++ b/packages/core/src/pipeline/bind-layer-extras.ts
@@ -1,0 +1,56 @@
+/**
+ * Label, weight, and color/fill resolution after required-channel checks.
+ */
+import type { Aes, LayerSpec } from "@ggsvelte/spec";
+
+import type { ColumnTable } from "../table.js";
+
+import { checkField, colorBinding } from "./bind-layer-helpers.js";
+import { applyColorOnFillGeomWarning } from "./bind-layer-validate.js";
+import type { ColorBinding, PipelineWarning } from "./types.js";
+import { PipelineError } from "./types.js";
+
+export function resolveLabelWeightColorFill(input: {
+  aes: Aes;
+  geom: LayerSpec["geom"];
+  stat: string;
+  index: number;
+  table: ColumnTable;
+  warnings: PipelineWarning[];
+}): {
+  labelField: string | null;
+  labelConstant: string | null;
+  weightField: string | null;
+  color: ColorBinding;
+  fill: ColorBinding;
+} {
+  const { aes, geom, stat, index, table, warnings } = input;
+
+  let labelField: string | null = null;
+  let labelConstant: string | null = null;
+  const label = aes.label;
+  if (label !== undefined && label !== null) {
+    if ("field" in label) labelField = checkField(label, "label", index, table, warnings);
+    else if ("value" in label) labelConstant = String(label.value);
+  }
+  if (geom === "text" && labelField === null && labelConstant === null) {
+    throw new PipelineError(
+      "missing-channel",
+      `/layers/${index}/aes/label`,
+      'The text geom requires a "label" channel (map it with aes).',
+    );
+  }
+  const weightField = checkField(aes.weight, "weight", index, table, warnings);
+
+  const color = colorBinding(aes.color, "color", index, table, warnings);
+  const fill = colorBinding(aes.fill, "fill", index, table, warnings);
+  applyColorOnFillGeomWarning(geom, index, color, warnings);
+  if (weightField !== null && (stat === "boxplot" || stat === "smooth" || stat === "summary")) {
+    warnings.push({
+      code: "weight-unsupported",
+      message: `Layer ${index}: the ${stat} stat does not support aes.weight; the weight mapping is ignored.`,
+    });
+  }
+
+  return { labelField, labelConstant, weightField, color, fill };
+}

--- a/packages/core/src/pipeline/bind-layer-y.ts
+++ b/packages/core/src/pipeline/bind-layer-y.ts
@@ -1,0 +1,33 @@
+/**
+ * Resolve y field vs stat-column mapping for bindLayer.
+ */
+import type { Aes } from "@ggsvelte/spec";
+
+import type { ColumnTable } from "../table.js";
+
+import { STAT_Y_COLUMNS, checkField } from "./bind-layer-helpers.js";
+import type { PipelineWarning } from "./types.js";
+import { PipelineError } from "./types.js";
+
+export function resolveYChannel(input: {
+  aes: Aes;
+  stat: string;
+  index: number;
+  table: ColumnTable;
+  warnings: PipelineWarning[];
+}): { yField: string | null; yStatColumn: string | null } {
+  const { aes, stat, index, table, warnings } = input;
+  const y = aes.y;
+  if (y !== undefined && y !== null && "stat" in y) {
+    const generated = STAT_Y_COLUMNS[stat] ?? [];
+    if (!generated.includes(y.stat)) {
+      throw new PipelineError(
+        "unknown-stat-column",
+        `/layers/${index}/aes/y`,
+        `Channel "y" maps stat column "${y.stat}", but this layer's stat ("${stat}") ${generated.length > 0 ? `generates: ${generated.join(", ")}` : "generates no y-mappable columns"}.`,
+      );
+    }
+    return { yField: null, yStatColumn: y.stat };
+  }
+  return { yField: checkField(y, "y", index, table, warnings), yStatColumn: null };
+}

--- a/packages/core/src/pipeline/bind-layer.ts
+++ b/packages/core/src/pipeline/bind-layer.ts
@@ -5,15 +5,15 @@ import type { Aes, LayerSpec } from "@ggsvelte/spec";
 
 import type { ColumnTable } from "../table.js";
 
-import { STAT_Y_COLUMNS, checkField, colorBinding } from "./bind-layer-helpers.js";
+import { checkField } from "./bind-layer-helpers.js";
+import { resolveLabelWeightColorFill } from "./bind-layer-extras.js";
 import {
-  applyColorOnFillGeomWarning,
   assertRequiredChannels,
   resolveRuleForm,
   validateGeomStatContracts,
 } from "./bind-layer-validate.js";
+import { resolveYChannel } from "./bind-layer-y.js";
 import type { LayerBinding, PipelineWarning } from "./types.js";
-import { PipelineError } from "./types.js";
 
 export function bindLayer(
   layer: LayerSpec,
@@ -28,22 +28,7 @@ export function bindLayer(
 
   const stat = layer.stat ?? "identity";
   const xField = checkField(aes.x, "x", index, table, warnings);
-  let yField: string | null = null;
-  let yStatColumn: string | null = null;
-  const y = aes.y;
-  if (y !== undefined && y !== null && "stat" in y) {
-    const generated = STAT_Y_COLUMNS[stat] ?? [];
-    if (!generated.includes(y.stat)) {
-      throw new PipelineError(
-        "unknown-stat-column",
-        `/layers/${index}/aes/y`,
-        `Channel "y" maps stat column "${y.stat}", but this layer's stat ("${stat}") ${generated.length > 0 ? `generates: ${generated.join(", ")}` : "generates no y-mappable columns"}.`,
-      );
-    }
-    yStatColumn = y.stat;
-  } else {
-    yField = checkField(y, "y", index, table, warnings);
-  }
+  const { yField, yStatColumn } = resolveYChannel({ aes, stat, index, table, warnings });
 
   validateGeomStatContracts({ layer, index, table, xField, yField });
 
@@ -63,32 +48,7 @@ export function bindLayer(
     ymaxField,
   });
 
-  // --- label / weight ----------------------------------------------------------
-  let labelField: string | null = null;
-  let labelConstant: string | null = null;
-  const label = aes.label;
-  if (label !== undefined && label !== null) {
-    if ("field" in label) labelField = checkField(label, "label", index, table, warnings);
-    else if ("value" in label) labelConstant = String(label.value);
-  }
-  if (geom === "text" && labelField === null && labelConstant === null) {
-    throw new PipelineError(
-      "missing-channel",
-      `/layers/${index}/aes/label`,
-      'The text geom requires a "label" channel (map it with aes).',
-    );
-  }
-  const weightField = checkField(aes.weight, "weight", index, table, warnings);
-
-  const color = colorBinding(aes.color, "color", index, table, warnings);
-  const fill = colorBinding(aes.fill, "fill", index, table, warnings);
-  applyColorOnFillGeomWarning(geom, index, color, warnings);
-  if (weightField !== null && (stat === "boxplot" || stat === "smooth" || stat === "summary")) {
-    warnings.push({
-      code: "weight-unsupported",
-      message: `Layer ${index}: the ${stat} stat does not support aes.weight; the weight mapping is ignored.`,
-    });
-  }
+  const extras = resolveLabelWeightColorFill({ aes, geom, stat, index, table, warnings });
 
   return {
     layer,
@@ -98,11 +58,11 @@ export function bindLayer(
     yStatColumn,
     yminField,
     ymaxField,
-    color,
-    fill,
-    labelField,
-    labelConstant,
-    weightField,
+    color: extras.color,
+    fill: extras.fill,
+    labelField: extras.labelField,
+    labelConstant: extras.labelConstant,
+    weightField: extras.weightField,
     ruleForm,
   };
 }

--- a/packages/core/src/pipeline/build-candidates-datum-context.ts
+++ b/packages/core/src/pipeline/build-candidates-datum-context.ts
@@ -1,0 +1,66 @@
+/**
+ * Resolve outlier/annotation context and series rank for identity candidates.
+ */
+import type { GeometryBatch } from "../scene.js";
+import { bandKey } from "../scales/train.js";
+import type { CellValue } from "../table.js";
+
+import type { FacetPanelDef } from "./facets.js";
+import type { LayerFrame, ResolvedColorScale } from "./types.js";
+
+export function resolveOutlierContext(input: {
+  frame: LayerFrame | undefined;
+  batch: GeometryBatch;
+  primitiveIndex: number;
+  facetPanel: FacetPanelDef | undefined;
+}): { outlierLocalRow: number | null; outlierSourceRow: number | null } {
+  const { frame, batch, primitiveIndex, facetPanel } = input;
+  const outlierLocalRow =
+    frame?.box !== null && frame?.binding.layer.geom === "boxplot" && batch.kind === "points"
+      ? (frame?.box.outlierRow[primitiveIndex] ?? null)
+      : null;
+  const outlierSourceRow =
+    outlierLocalRow === null
+      ? null
+      : (facetPanel?.sourceRows?.[outlierLocalRow] ?? outlierLocalRow);
+  return { outlierLocalRow, outlierSourceRow };
+}
+
+export function resolveAnnotationIntercepts(input: {
+  frame: LayerFrame | undefined;
+  primitiveIndex: number;
+}): {
+  annotationRule: boolean;
+  annotationX: CellValue;
+  annotationY: CellValue;
+} {
+  const { frame, primitiveIndex } = input;
+  if (frame?.binding.ruleForm !== "annotation") {
+    return { annotationRule: false, annotationX: null, annotationY: null };
+  }
+  return {
+    annotationRule: true,
+    annotationX: frame.xIntercepts[primitiveIndex] ?? null,
+    annotationY: frame.yIntercepts[primitiveIndex - frame.xIntercepts.length] ?? null,
+  };
+}
+
+export function ordinalSeriesRank(input: {
+  color: ResolvedColorScale | null;
+  fill: ResolvedColorScale | null;
+  colorField: string | undefined;
+  fillField: string | undefined;
+  sourceRow: number | null;
+  sourceValue: (field: string | undefined) => CellValue;
+  group: number;
+}): number {
+  const { color, fill, colorField, fillField, sourceRow, sourceValue, group } = input;
+  const ordinalRank = (resolved: ResolvedColorScale | null, field: string | undefined) => {
+    if (resolved?.kind !== "ordinal" || field === undefined || sourceRow === null) return -1;
+    const key = bandKey(sourceValue(field));
+    return resolved.scale.domain.findIndex((value) => bandKey(value) === key);
+  };
+  const colorRank = ordinalRank(color, colorField);
+  const fillRank = ordinalRank(fill, fillField);
+  return colorRank >= 0 ? colorRank : fillRank >= 0 ? fillRank : group;
+}

--- a/packages/core/src/pipeline/build-candidates-datum.ts
+++ b/packages/core/src/pipeline/build-candidates-datum.ts
@@ -5,10 +5,14 @@
 import type { CandidateBuildFacts, CandidateDatum } from "../candidate-store.js";
 import type { LineageStore } from "../identity.js";
 import type { Scene } from "../scene.js";
-import { bandKey } from "../scales/train.js";
 import type { CellValue } from "../table.js";
 import type { ColumnTable } from "../table.js";
 
+import {
+  ordinalSeriesRank,
+  resolveAnnotationIntercepts,
+  resolveOutlierContext,
+} from "./build-candidates-datum-context.js";
 import { resolveCandidateLogicalValues } from "./build-candidates-datum-values.js";
 import { resolveCandidateFrameRow } from "./build-candidates-frame-row.js";
 import type { CandidateIdentityIndex } from "./build-candidates-identity.js";
@@ -49,14 +53,12 @@ export function createIdentityCandidateDatumResolver(input: {
     const sourceRow = facts.rowIndex;
     const frame = panelFrames[facts.panelIndex]?.[facts.layerIndex];
     const batch = scene.batches[facts.batchIndex]!;
-    const outlierLocalRow =
-      frame?.box !== null && frame?.binding.layer.geom === "boxplot" && batch.kind === "points"
-        ? (frame?.box.outlierRow[facts.primitiveIndex] ?? null)
-        : null;
-    const outlierSourceRow =
-      outlierLocalRow === null
-        ? null
-        : (facetPanels[facts.panelIndex]?.sourceRows?.[outlierLocalRow] ?? outlierLocalRow);
+    const { outlierLocalRow, outlierSourceRow } = resolveOutlierContext({
+      frame,
+      batch,
+      primitiveIndex: facts.primitiveIndex,
+      facetPanel: facetPanels[facts.panelIndex],
+    });
     const orderedGroups = frameGroups.get(`${facts.panelIndex}:${facts.layerIndex}`) ?? [0];
     const { frameRow, derivedGroup } = resolveCandidateFrameRow({
       frame,
@@ -75,22 +77,23 @@ export function createIdentityCandidateDatumResolver(input: {
       sourceRow === null
         ? derivedGroup
         : (seriesByRow.get(`${facts.panelIndex}:${facts.layerIndex}:${sourceRow}`) ?? 0);
-    const ordinalRank = (resolved: ResolvedColorScale | null, field: string | undefined) => {
-      if (resolved?.kind !== "ordinal" || field === undefined || sourceRow === null) return -1;
-      const key = bandKey(sourceValue(field));
-      return resolved.scale.domain.findIndex((value) => bandKey(value) === key);
-    };
-    const colorRank = ordinalRank(color, colorField);
-    const fillRank = ordinalRank(fill, fillField);
+    const seriesRank = ordinalSeriesRank({
+      color,
+      fill,
+      colorField,
+      fillField,
+      sourceRow,
+      sourceValue,
+      group,
+    });
     const autoMode = candidateAutoMode(
       frame?.binding ?? bindings[facts.layerIndex]!,
       facts.primitiveIndex,
     );
-    const annotationRule = frame?.binding.ruleForm === "annotation";
-    const annotationX = annotationRule ? (frame.xIntercepts[facts.primitiveIndex] ?? null) : null;
-    const annotationY = annotationRule
-      ? (frame.yIntercepts[facts.primitiveIndex - frame.xIntercepts.length] ?? null)
-      : null;
+    const { annotationRule, annotationX, annotationY } = resolveAnnotationIntercepts({
+      frame,
+      primitiveIndex: facts.primitiveIndex,
+    });
     let representedRows =
       outlierSourceRow === null
         ? (sourceRowsByGroup.get(`${facts.panelIndex}:${facts.layerIndex}:${group}`) ?? [])
@@ -120,7 +123,7 @@ export function createIdentityCandidateDatumResolver(input: {
       xValue,
       yValue,
       seriesId: group,
-      seriesRank: colorRank >= 0 ? colorRank : fillRank >= 0 ? fillRank : group,
+      seriesRank,
       sourceOrder: sourceRow ?? outlierSourceRow ?? facts.primitiveIndex,
       lineage: sourceRow === null ? lineage.intern(representedRows) : lineage.intern([sourceRow]),
       autoMode,

--- a/packages/core/src/pipeline/finalize-model-contracts.ts
+++ b/packages/core/src/pipeline/finalize-model-contracts.ts
@@ -1,0 +1,74 @@
+/**
+ * Resolve layer contracts and domain snapshots for the finalize phase.
+ */
+import type { PortableSpec } from "@ggsvelte/spec";
+
+import { computeBaselineDomains, computeEffectiveDomains } from "./compute-domains.js";
+import {
+  resolveLayerBackends,
+  resolveLayerFields,
+  resolveLayerScaledConstants,
+} from "./layer-contracts.js";
+import type { PreparedPanels } from "./prepare-panels.js";
+import type { TrainedPipelineScales } from "./train-pipeline-scales.js";
+import type {
+  Advisory,
+  LayerBackend,
+  MappedField,
+  RunOptions,
+  ScaleDomainSnapshot,
+} from "./types.js";
+import type { CellValue } from "../table.js";
+import type { Scene } from "../scene.js";
+import type { LayerBinding } from "./types.js";
+
+export function resolveFinalizeContracts(input: {
+  normalized: PortableSpec;
+  options: RunOptions;
+  prepared: PreparedPanels;
+  trained: TrainedPipelineScales;
+  scene: Scene;
+  advisories: Advisory[];
+}): {
+  layerBackends: LayerBackend[];
+  layerFields: MappedField[][];
+  layerScaledConstants: ReadonlyArray<Readonly<Partial<Record<string, CellValue>>>>;
+  effectiveDomains: ScaleDomainSnapshot;
+  baselineDomains: ScaleDomainSnapshot;
+  bindings: readonly LayerBinding[];
+} {
+  const { normalized, options, prepared, trained, scene, advisories } = input;
+  const { freeX, freeY, facetPanels, bindings, panelFrames } = prepared;
+  const { xTraining, yTraining, panelScales, xInputs, yInputs } = trained;
+
+  const layerBackends = resolveLayerBackends(
+    normalized.layers,
+    scene.batches,
+    normalized.a11y,
+    options.canvasThreshold,
+    advisories,
+  );
+  const layerFields = resolveLayerFields(normalized.layers.length, bindings);
+  const layerScaledConstants = resolveLayerScaledConstants(normalized.layers.length, bindings);
+
+  const effectiveDomains = computeEffectiveDomains(xTraining.scale, yTraining.scale, panelScales);
+  const baselineDomains = computeBaselineDomains({
+    options,
+    freeX,
+    freeY,
+    facetPanels,
+    panelFrames,
+    xInputs,
+    yInputs,
+    effectiveDomains,
+  });
+
+  return {
+    layerBackends,
+    layerFields,
+    layerScaledConstants,
+    effectiveDomains,
+    baselineDomains,
+    bindings,
+  };
+}

--- a/packages/core/src/pipeline/finalize-model.ts
+++ b/packages/core/src/pipeline/finalize-model.ts
@@ -8,12 +8,7 @@ import type { Scene } from "../scene.js";
 
 import { assembleRenderModel } from "./assemble-render-model.js";
 import { buildPipelineCandidates } from "./build-candidates.js";
-import { computeBaselineDomains, computeEffectiveDomains } from "./compute-domains.js";
-import {
-  resolveLayerBackends,
-  resolveLayerFields,
-  resolveLayerScaledConstants,
-} from "./layer-contracts.js";
+import { resolveFinalizeContracts } from "./finalize-model-contracts.js";
 import type { PanelLayoutResult } from "./panel-layout.js";
 import type { PreparedPanels } from "./prepare-panels.js";
 import type { TrainedPipelineScales } from "./train-pipeline-scales.js";
@@ -43,30 +38,16 @@ export function finalizeRenderModel(input: {
     warnings,
     advisories,
   } = input;
-  const { freeX, freeY, facetPanels, bindings, panelFrames, table } = prepared;
-  const { xTraining, yTraining, panelScales, colorResolution, fillResolution, xInputs, yInputs } =
-    trained;
+  const { facetPanels, panelFrames, table } = prepared;
+  const { xTraining, yTraining, panelScales, colorResolution, fillResolution } = trained;
 
-  const layerBackends = resolveLayerBackends(
-    normalized.layers,
-    scene.batches,
-    normalized.a11y,
-    options.canvasThreshold,
-    advisories,
-  );
-  const layerFields = resolveLayerFields(normalized.layers.length, bindings);
-  const layerScaledConstants = resolveLayerScaledConstants(normalized.layers.length, bindings);
-
-  const effectiveDomains = computeEffectiveDomains(xTraining.scale, yTraining.scale, panelScales);
-  const baselineDomains = computeBaselineDomains({
+  const contracts = resolveFinalizeContracts({
+    normalized,
     options,
-    freeX,
-    freeY,
-    facetPanels,
-    panelFrames,
-    xInputs,
-    yInputs,
-    effectiveDomains,
+    prepared,
+    trained,
+    scene,
+    advisories,
   });
 
   const lineage = new LineageStore<number>();
@@ -74,11 +55,11 @@ export function finalizeRenderModel(input: {
     scene,
     runId,
     flip,
-    bindings,
+    bindings: contracts.bindings,
     panelFrames,
     facetPanels,
     table,
-    layerFields,
+    layerFields: contracts.layerFields,
     color: colorResolution.resolved,
     fill: fillResolution.resolved,
     lineage,
@@ -96,11 +77,11 @@ export function finalizeRenderModel(input: {
     warnings,
     advisories,
     runId,
-    layerBackends,
-    layerFields,
-    layerScaledConstants,
-    baselineDomains,
-    effectiveDomains,
+    layerBackends: contracts.layerBackends,
+    layerFields: contracts.layerFields,
+    layerScaledConstants: contracts.layerScaledConstants,
+    baselineDomains: contracts.baselineDomains,
+    effectiveDomains: contracts.effectiveDomains,
     lineage,
     candidates,
     formatX: panelLayout.formatX,

--- a/packages/core/src/pipeline/panel-layout-facet-cells.ts
+++ b/packages/core/src/pipeline/panel-layout-facet-cells.ts
@@ -1,0 +1,79 @@
+/**
+ * Facet grid cell sizes and absolute col/row placements.
+ */
+import type { Margins } from "../layout/layout.js";
+
+import type { FacetPanelDef } from "./facets.js";
+
+export interface FacetCellGeometry {
+  panelW: number;
+  panelH: number;
+  colX: number[];
+  rowY: number[];
+  bottomMostRow: number[];
+}
+
+export function computeFacetCellGeometry(input: {
+  facetPanels: readonly FacetPanelDef[];
+  nrow: number;
+  ncol: number;
+  freeH: boolean;
+  freeV: boolean;
+  mMax: Margins;
+  outerLeft: number;
+  topBand: number;
+  spacing: number;
+  strip: number;
+  gridW: number;
+  gridH: number;
+}): FacetCellGeometry {
+  const {
+    facetPanels,
+    nrow,
+    ncol,
+    freeH,
+    freeV,
+    mMax,
+    outerLeft,
+    topBand,
+    spacing,
+    strip,
+    gridW,
+    gridH,
+  } = input;
+
+  const leftCount = freeV ? ncol : 1;
+  const bottomCount = freeH ? nrow : 1;
+  const panelW = Math.max(
+    1,
+    (gridW - leftCount * mMax.left - mMax.right - (ncol - 1) * spacing) / ncol,
+  );
+  const panelH = Math.max(
+    1,
+    (gridH - mMax.top - bottomCount * mMax.bottom - nrow * strip - (nrow - 1) * spacing) / nrow,
+  );
+
+  const colX: number[] = [];
+  let xCursor = outerLeft;
+  for (let c = 0; c < ncol; c++) {
+    if (c === 0 || freeV) xCursor += mMax.left;
+    colX.push(xCursor);
+    xCursor += panelW + spacing;
+  }
+  const rowY: number[] = [];
+  let yCursor = topBand + mMax.top;
+  for (let r = 0; r < nrow; r++) {
+    yCursor += strip;
+    rowY.push(yCursor);
+    yCursor += panelH;
+    if (r === nrow - 1 || freeH) yCursor += mMax.bottom;
+    yCursor += spacing;
+  }
+
+  const bottomMostRow: number[] = Array.from({ length: ncol }, () => 0);
+  for (const def of facetPanels) {
+    if (def.row > bottomMostRow[def.col]!) bottomMostRow[def.col] = def.row;
+  }
+
+  return { panelW, panelH, colX, rowY, bottomMostRow };
+}

--- a/packages/core/src/pipeline/panel-layout-facet-margins-pass.ts
+++ b/packages/core/src/pipeline/panel-layout-facet-margins-pass.ts
@@ -1,0 +1,53 @@
+/**
+ * Shared max-margins pass across facet panels (union of per-panel layout).
+ */
+import type { LayoutTheme, Margins, TickFormatter } from "../layout/layout.js";
+import { layout } from "../layout/layout.js";
+import type { TextMeasurer } from "../layout/measure.js";
+
+import type { FacetPanelDef } from "./facets.js";
+import { elementwiseMaxMargins, layoutDomain } from "./layout-helpers.js";
+import type { DisplayScalesFn } from "./panel-layout-types.js";
+
+export function computeFacetSharedMargins(input: {
+  facetPanels: readonly FacetPanelDef[];
+  approxW: number;
+  approxH: number;
+  displayScales: DisplayScalesFn;
+  hBreaks: readonly (number | string)[] | undefined;
+  vBreaks: readonly (number | string)[] | undefined;
+  formatH: TickFormatter | undefined;
+  formatV: TickFormatter | undefined;
+  measurer: TextMeasurer;
+  layoutTheme: LayoutTheme;
+}): Margins {
+  const {
+    facetPanels,
+    approxW,
+    approxH,
+    displayScales,
+    hBreaks,
+    vBreaks,
+    formatH,
+    formatV,
+    measurer,
+    layoutTheme,
+  } = input;
+
+  let mMax: Margins = { top: 0, right: 0, bottom: 0, left: 0 };
+  for (let p = 0; p < facetPanels.length; p++) {
+    const { h, v } = displayScales(p);
+    const run = layout({
+      width: approxW,
+      height: approxH,
+      x: layoutDomain(h, hBreaks),
+      y: layoutDomain(v, vBreaks),
+      ...(formatH !== undefined && { formatX: formatH }),
+      ...(formatV !== undefined && { formatY: formatV }),
+      measurer,
+      theme: layoutTheme,
+    });
+    mMax = elementwiseMaxMargins(mMax, run.margins);
+  }
+  return mMax;
+}

--- a/packages/core/src/pipeline/panel-layout-facet-margins.ts
+++ b/packages/core/src/pipeline/panel-layout-facet-margins.ts
@@ -2,17 +2,12 @@
  * Facet grid: outer chrome, shared margin pass, and panel cell geometry.
  */
 import type { LayoutTheme, Margins, TickFormatter } from "../layout/layout.js";
-import { layout } from "../layout/layout.js";
 import type { TextMeasurer } from "../layout/measure.js";
-import { PANEL_SPACING, STRIP_BAND } from "../scene.js";
 
 import type { FacetPanelDef } from "./facets.js";
-import {
-  LEGEND_EDGE_PAD,
-  LEGEND_GAP,
-  elementwiseMaxMargins,
-  layoutDomain,
-} from "./layout-helpers.js";
+import { computeFacetCellGeometry } from "./panel-layout-facet-cells.js";
+import { computeFacetSharedMargins } from "./panel-layout-facet-margins-pass.js";
+import { computeFacetOuterChrome } from "./panel-layout-facet-outer.js";
 import type { DisplayScalesFn } from "./panel-layout-types.js";
 
 export interface FacetGridGeometry {
@@ -45,86 +40,44 @@ export function computeFacetGridGeometry(input: {
   measurer: TextMeasurer;
   layoutTheme: LayoutTheme;
 }): FacetGridGeometry {
-  const {
-    facetPanels,
-    nrow,
-    ncol,
-    freeH,
-    freeV,
-    outerLeftTitle,
-    outerBottomTitle,
-    axisTitleBand,
-    legendWidth,
-    optionsWidth,
-    layoutHeight,
-    topBand,
-    displayScales,
-    hBreaks,
-    vBreaks,
-    formatH,
-    formatV,
-    measurer,
-    layoutTheme,
-  } = input;
+  const outer = computeFacetOuterChrome({
+    nrow: input.nrow,
+    ncol: input.ncol,
+    outerLeftTitle: input.outerLeftTitle,
+    outerBottomTitle: input.outerBottomTitle,
+    axisTitleBand: input.axisTitleBand,
+    legendWidth: input.legendWidth,
+    optionsWidth: input.optionsWidth,
+    layoutHeight: input.layoutHeight,
+  });
 
-  const spacing = PANEL_SPACING;
-  const strip = STRIP_BAND;
-  const outerLeft = outerLeftTitle === "" ? 0 : axisTitleBand;
-  const outerBottom = outerBottomTitle === "" ? 0 : axisTitleBand;
-  const outerRight = legendWidth > 0 ? legendWidth + LEGEND_GAP + LEGEND_EDGE_PAD : 0;
-  const gridW = Math.max(40, optionsWidth - outerLeft - outerRight);
-  const gridH = Math.max(40, layoutHeight - outerBottom);
+  const mMax = computeFacetSharedMargins({
+    facetPanels: input.facetPanels,
+    approxW: outer.approxW,
+    approxH: outer.approxH,
+    displayScales: input.displayScales,
+    hBreaks: input.hBreaks,
+    vBreaks: input.vBreaks,
+    formatH: input.formatH,
+    formatV: input.formatV,
+    measurer: input.measurer,
+    layoutTheme: input.layoutTheme,
+  });
 
-  const approxW = Math.max(40, (gridW - (ncol - 1) * spacing) / ncol);
-  const approxH = Math.max(40, (gridH - nrow * strip - (nrow - 1) * spacing) / nrow);
-  let mMax: Margins = { top: 0, right: 0, bottom: 0, left: 0 };
-  for (let p = 0; p < facetPanels.length; p++) {
-    const { h, v } = displayScales(p);
-    const run = layout({
-      width: approxW,
-      height: approxH,
-      x: layoutDomain(h, hBreaks),
-      y: layoutDomain(v, vBreaks),
-      ...(formatH !== undefined && { formatX: formatH }),
-      ...(formatV !== undefined && { formatY: formatV }),
-      measurer,
-      theme: layoutTheme,
-    });
-    mMax = elementwiseMaxMargins(mMax, run.margins);
-  }
+  const cells = computeFacetCellGeometry({
+    facetPanels: input.facetPanels,
+    nrow: input.nrow,
+    ncol: input.ncol,
+    freeH: input.freeH,
+    freeV: input.freeV,
+    mMax,
+    outerLeft: outer.outerLeft,
+    topBand: input.topBand,
+    spacing: outer.spacing,
+    strip: outer.strip,
+    gridW: outer.gridW,
+    gridH: outer.gridH,
+  });
 
-  const leftCount = freeV ? ncol : 1;
-  const bottomCount = freeH ? nrow : 1;
-  const panelW = Math.max(
-    1,
-    (gridW - leftCount * mMax.left - mMax.right - (ncol - 1) * spacing) / ncol,
-  );
-  const panelH = Math.max(
-    1,
-    (gridH - mMax.top - bottomCount * mMax.bottom - nrow * strip - (nrow - 1) * spacing) / nrow,
-  );
-
-  const colX: number[] = [];
-  let xCursor = outerLeft;
-  for (let c = 0; c < ncol; c++) {
-    if (c === 0 || freeV) xCursor += mMax.left;
-    colX.push(xCursor);
-    xCursor += panelW + spacing;
-  }
-  const rowY: number[] = [];
-  let yCursor = topBand + mMax.top;
-  for (let r = 0; r < nrow; r++) {
-    yCursor += strip;
-    rowY.push(yCursor);
-    yCursor += panelH;
-    if (r === nrow - 1 || freeH) yCursor += mMax.bottom;
-    yCursor += spacing;
-  }
-
-  const bottomMostRow: number[] = Array.from({ length: ncol }, () => 0);
-  for (const def of facetPanels) {
-    if (def.row > bottomMostRow[def.col]!) bottomMostRow[def.col] = def.row;
-  }
-
-  return { mMax, panelW, panelH, colX, rowY, bottomMostRow };
+  return { mMax, ...cells };
 }

--- a/packages/core/src/pipeline/panel-layout-facet-outer.ts
+++ b/packages/core/src/pipeline/panel-layout-facet-outer.ts
@@ -1,0 +1,62 @@
+/**
+ * Facet grid outer chrome: reserved title/legend bands and approximate cell size.
+ */
+import { PANEL_SPACING, STRIP_BAND } from "../scene.js";
+
+import { LEGEND_EDGE_PAD, LEGEND_GAP } from "./layout-helpers.js";
+
+export interface FacetOuterChrome {
+  spacing: number;
+  strip: number;
+  outerLeft: number;
+  outerBottom: number;
+  outerRight: number;
+  gridW: number;
+  gridH: number;
+  approxW: number;
+  approxH: number;
+}
+
+export function computeFacetOuterChrome(input: {
+  nrow: number;
+  ncol: number;
+  outerLeftTitle: string;
+  outerBottomTitle: string;
+  axisTitleBand: number;
+  legendWidth: number;
+  optionsWidth: number;
+  layoutHeight: number;
+}): FacetOuterChrome {
+  const {
+    nrow,
+    ncol,
+    outerLeftTitle,
+    outerBottomTitle,
+    axisTitleBand,
+    legendWidth,
+    optionsWidth,
+    layoutHeight,
+  } = input;
+
+  const spacing = PANEL_SPACING;
+  const strip = STRIP_BAND;
+  const outerLeft = outerLeftTitle === "" ? 0 : axisTitleBand;
+  const outerBottom = outerBottomTitle === "" ? 0 : axisTitleBand;
+  const outerRight = legendWidth > 0 ? legendWidth + LEGEND_GAP + LEGEND_EDGE_PAD : 0;
+  const gridW = Math.max(40, optionsWidth - outerLeft - outerRight);
+  const gridH = Math.max(40, layoutHeight - outerBottom);
+  const approxW = Math.max(40, (gridW - (ncol - 1) * spacing) / ncol);
+  const approxH = Math.max(40, (gridH - nrow * strip - (nrow - 1) * spacing) / nrow);
+
+  return {
+    spacing,
+    strip,
+    outerLeft,
+    outerBottom,
+    outerRight,
+    gridW,
+    gridH,
+    approxW,
+    approxH,
+  };
+}

--- a/packages/core/src/pipeline/position-bar.ts
+++ b/packages/core/src/pipeline/position-bar.ts
@@ -1,0 +1,49 @@
+/**
+ * Bar-like stack/fill/dodge position adjustments (from zero baseline).
+ */
+import { positionDodge, positionStack } from "../positions/positions.js";
+import { bandKey } from "../scales/train.js";
+
+import { isBarLike } from "./scale-training.js";
+import type { LayerFrame } from "./types.js";
+
+/** Per-row slot keys: band categories, or bin centers for binned bars. */
+export function barSlotKeys(frame: LayerFrame): (number | string)[] | null {
+  if (frame.xValues !== null) return frame.xValues.map((v) => bandKey(v));
+  if (frame.xNumeric !== null) return Array.from(frame.xNumeric);
+  return null;
+}
+
+/** Apply stack/fill/dodge for bar-like geoms. Returns true when handled. */
+export function applyBarLikePosition(frame: LayerFrame): boolean {
+  const { binding } = frame;
+  const geom = binding.layer.geom;
+  if (!isBarLike(geom) || frame.yNumeric === null) return false;
+  const slots = barSlotKeys(frame);
+  if (slots === null) return true;
+  const position = binding.layer.position ?? "identity";
+  const y = frame.yNumeric;
+
+  if (position === "stack" || position === "fill") {
+    const { ymin, ymax } = positionStack({ slots, groups: frame.groups, y, mode: position });
+    frame.ymin = ymin;
+    frame.ymax = ymax;
+    return true;
+  }
+  // identity / dodge: bars grow from the zero baseline.
+  const ymin = new Float64Array(frame.n);
+  const ymax = new Float64Array(frame.n);
+  for (let i = 0; i < frame.n; i++) {
+    const v = Number.isFinite(y[i]!) ? y[i]! : 0;
+    ymin[i] = Math.min(0, v);
+    ymax[i] = Math.max(0, v);
+  }
+  frame.ymin = ymin;
+  frame.ymax = ymax;
+  if (position === "dodge") {
+    const dodge = positionDodge({ slots, groups: frame.groups });
+    frame.dodgeSlot = dodge.slot;
+    frame.dodgeSlotCounts = dodge.slotCount;
+  }
+  return true;
+}

--- a/packages/core/src/pipeline/position-boxplot.ts
+++ b/packages/core/src/pipeline/position-boxplot.ts
@@ -1,0 +1,21 @@
+/**
+ * Boxplot dodge position adjustment (panel-local slots).
+ */
+import { positionDodge } from "../positions/positions.js";
+import { bandKey } from "../scales/train.js";
+
+import type { LayerFrame } from "./types.js";
+
+/** Apply boxplot dodge. Returns true when handled (including no-op cases). */
+export function applyBoxplotPosition(frame: LayerFrame): boolean {
+  if (frame.binding.layer.geom !== "boxplot") return false;
+  const layer = frame.binding.layer;
+  if ((layer.position ?? "dodge") !== "dodge" || frame.xValues === null) return true;
+  const dodge = positionDodge({
+    slots: frame.xValues.map((v) => bandKey(v)),
+    groups: frame.groups,
+  });
+  frame.dodgeSlot = dodge.slot;
+  frame.dodgeSlotCounts = dodge.slotCount;
+  return true;
+}

--- a/packages/core/src/pipeline/position-jitter.ts
+++ b/packages/core/src/pipeline/position-jitter.ts
@@ -1,0 +1,54 @@
+/**
+ * Point/text position adjustments: identity, nudge, and seeded jitter.
+ */
+import type { PositionParams } from "@ggsvelte/spec";
+
+import { DEFAULT_JITTER_SEED, jitterOffsets, nudgeOffsets } from "../positions/jitter.js";
+import type { ColumnTable } from "../table.js";
+
+import type { Advisory, LayerFrame } from "./types.js";
+
+/** Apply jitter/nudge for point and text layers. Returns true when handled. */
+export function applyPointTextPosition(
+  frame: LayerFrame,
+  advisories: Advisory[],
+  table: ColumnTable,
+): boolean {
+  const { binding } = frame;
+  const layer = binding.layer;
+  const geom = layer.geom;
+  if (geom !== "point" && geom !== "text") return false;
+
+  const position = layer.position ?? "identity";
+  if (position === "identity") return true;
+  const params: PositionParams = "positionParams" in layer ? (layer.positionParams ?? {}) : {};
+  // Offsets are band-step fractions on discrete axes (resolution 1),
+  // data units on continuous axes.
+  const xDiscrete = binding.xField !== null && table.discreteness(binding.xField) === "discrete";
+  const yDiscrete = binding.yField !== null && table.discreteness(binding.yField) === "discrete";
+  if (position === "nudge") {
+    const { dx, dy } = nudgeOffsets(frame.n, params.x ?? 0, params.y ?? 0);
+    frame.offsetX = dx;
+    frame.offsetY = dy;
+    return true;
+  }
+  // jitter (point only, schema-enforced): seeded — deliberate divergence
+  // from ggplot2's random jitter (decision 0010), always surfaced.
+  const { dx, dy } = jitterOffsets({
+    n: frame.n,
+    width: params.width,
+    height: params.height,
+    seed: params.seed,
+    xNumeric: xDiscrete ? null : frame.xNumeric,
+    yNumeric: yDiscrete ? null : frame.yNumeric,
+  });
+  frame.offsetX = dx;
+  frame.offsetY = dy;
+  advisories.push({
+    code: "jitter-seeded",
+    path: `layers.${binding.index}`,
+    chosen: `deterministic seeded jitter (seed ${params.seed ?? DEFAULT_JITTER_SEED}) — ggplot2 draws new random offsets every render; ggsvelte seeds for reproducibility`,
+    howToOverride: `Set positionParams.seed (and width/height) on layer ${binding.index}.`,
+  });
+  return true;
+}

--- a/packages/core/src/pipeline/position.ts
+++ b/packages/core/src/pipeline/position.ts
@@ -3,102 +3,15 @@
  * to LayerFrames after stats and before scale training — panel-local, like
  * ggplot2.
  */
-import type { PositionParams } from "@ggsvelte/spec";
-
-import { DEFAULT_JITTER_SEED, jitterOffsets, nudgeOffsets } from "../positions/jitter.js";
-import { positionDodge, positionStack } from "../positions/positions.js";
-import { bandKey } from "../scales/train.js";
 import type { ColumnTable } from "../table.js";
 
-import { isBarLike } from "./scale-training.js";
+import { applyBarLikePosition } from "./position-bar.js";
+import { applyBoxplotPosition } from "./position-boxplot.js";
+import { applyPointTextPosition } from "./position-jitter.js";
 import type { Advisory, LayerFrame } from "./types.js";
 
-/** Per-row slot keys: band categories, or bin centers for binned bars. */
-function slotKeys(frame: LayerFrame): (number | string)[] | null {
-  if (frame.xValues !== null) return frame.xValues.map((v) => bandKey(v));
-  if (frame.xNumeric !== null) return Array.from(frame.xNumeric);
-  return null;
-}
-
 export function applyPosition(frame: LayerFrame, advisories: Advisory[], table: ColumnTable): void {
-  const { binding } = frame;
-  const layer = binding.layer;
-  const geom = layer.geom;
-
-  // --- jitter / nudge (point + text layers) -----------------------------------
-  if (geom === "point" || geom === "text") {
-    const position = layer.position ?? "identity";
-    if (position === "identity") return;
-    const params: PositionParams = "positionParams" in layer ? (layer.positionParams ?? {}) : {};
-    // Offsets are band-step fractions on discrete axes (resolution 1),
-    // data units on continuous axes.
-    const xDiscrete = binding.xField !== null && table.discreteness(binding.xField) === "discrete";
-    const yDiscrete = binding.yField !== null && table.discreteness(binding.yField) === "discrete";
-    if (position === "nudge") {
-      const { dx, dy } = nudgeOffsets(frame.n, params.x ?? 0, params.y ?? 0);
-      frame.offsetX = dx;
-      frame.offsetY = dy;
-      return;
-    }
-    // jitter (point only, schema-enforced): seeded — deliberate divergence
-    // from ggplot2's random jitter (decision 0010), always surfaced.
-    const { dx, dy } = jitterOffsets({
-      n: frame.n,
-      width: params.width,
-      height: params.height,
-      seed: params.seed,
-      xNumeric: xDiscrete ? null : frame.xNumeric,
-      yNumeric: yDiscrete ? null : frame.yNumeric,
-    });
-    frame.offsetX = dx;
-    frame.offsetY = dy;
-    advisories.push({
-      code: "jitter-seeded",
-      path: `layers.${binding.index}`,
-      chosen: `deterministic seeded jitter (seed ${params.seed ?? DEFAULT_JITTER_SEED}) — ggplot2 draws new random offsets every render; ggsvelte seeds for reproducibility`,
-      howToOverride: `Set positionParams.seed (and width/height) on layer ${binding.index}.`,
-    });
-    return;
-  }
-
-  // --- boxplot dodge -----------------------------------------------------------
-  if (geom === "boxplot") {
-    if ((layer.position ?? "dodge") !== "dodge" || frame.xValues === null) return;
-    const dodge = positionDodge({
-      slots: frame.xValues.map((v) => bandKey(v)),
-      groups: frame.groups,
-    });
-    frame.dodgeSlot = dodge.slot;
-    frame.dodgeSlotCounts = dodge.slotCount;
-    return;
-  }
-
-  // --- bar-like stack/fill/dodge ------------------------------------------------
-  if (!isBarLike(geom) || frame.yNumeric === null) return;
-  const slots = slotKeys(frame);
-  if (slots === null) return;
-  const position = layer.position ?? "identity";
-  const y = frame.yNumeric;
-
-  if (position === "stack" || position === "fill") {
-    const { ymin, ymax } = positionStack({ slots, groups: frame.groups, y, mode: position });
-    frame.ymin = ymin;
-    frame.ymax = ymax;
-    return;
-  }
-  // identity / dodge: bars grow from the zero baseline.
-  const ymin = new Float64Array(frame.n);
-  const ymax = new Float64Array(frame.n);
-  for (let i = 0; i < frame.n; i++) {
-    const v = Number.isFinite(y[i]!) ? y[i]! : 0;
-    ymin[i] = Math.min(0, v);
-    ymax[i] = Math.max(0, v);
-  }
-  frame.ymin = ymin;
-  frame.ymax = ymax;
-  if (position === "dodge") {
-    const dodge = positionDodge({ slots, groups: frame.groups });
-    frame.dodgeSlot = dodge.slot;
-    frame.dodgeSlotCounts = dodge.slotCount;
-  }
+  if (applyPointTextPosition(frame, advisories, table)) return;
+  if (applyBoxplotPosition(frame)) return;
+  applyBarLikePosition(frame);
 }

--- a/packages/core/src/pipeline/prepare-panels-frames.ts
+++ b/packages/core/src/pipeline/prepare-panels-frames.ts
@@ -1,0 +1,64 @@
+/**
+ * Build per-panel LayerFrames: bind layers, stats, position, remap source rows.
+ */
+import type { PortableSpec } from "@ggsvelte/spec";
+
+import { finiteExtent } from "../scales/train.js";
+import type { ColumnTable } from "../table.js";
+
+import { bindLayer } from "./bind.js";
+import type { FacetPanelDef } from "./facets.js";
+import { buildFrame, remapSourceRows } from "./frame.js";
+import { applyPosition } from "./position.js";
+import type { Advisory, LayerBinding, LayerFrame, PipelineWarning } from "./types.js";
+
+export function buildPanelFrames(input: {
+  normalized: PortableSpec;
+  table: ColumnTable;
+  facetPanels: readonly FacetPanelDef[];
+  faceted: boolean;
+  freeX: boolean;
+  warnings: PipelineWarning[];
+  advisories: Advisory[];
+}): { bindings: LayerBinding[]; panelFrames: LayerFrame[][] } {
+  const { normalized, table, facetPanels, faceted, freeX, warnings, advisories } = input;
+
+  const bindings: LayerBinding[] = [];
+  const panelFrames: LayerFrame[][] = facetPanels.map(() => []);
+
+  for (let index = 0; index < normalized.layers.length; index++) {
+    bindings.push(bindLayer(normalized.layers[index]!, index, table, warnings));
+  }
+  // Shared bin break grids across panels when the x scale is fixed.
+  const binRanges = bindings.map((binding) => {
+    const stat = binding.layer.stat ?? "identity";
+    if (stat !== "bin" || !faceted || freeX || binding.xField === null) return void 0;
+    return finiteExtent([table.numeric(binding.xField)]) ?? void 0;
+  });
+  for (let p = 0; p < facetPanels.length; p++) {
+    const panelTable = facetPanels[p]!.table;
+    for (let index = 0; index < bindings.length; index++) {
+      const frame = buildFrame(
+        bindings[index]!,
+        panelTable,
+        warnings,
+        advisories,
+        binRanges[index],
+      );
+      applyPosition(frame, advisories, panelTable);
+      remapSourceRows(frame, facetPanels[p]!.sourceRows);
+      panelFrames[p]!.push(frame);
+    }
+  }
+  for (let index = 0; index < bindings.length; index++) {
+    const allEmpty = panelFrames.every((frames) => frames[index]!.n === 0);
+    if (allEmpty && bindings[index]!.ruleForm !== "annotation") {
+      warnings.push({
+        code: "empty-layer",
+        message: `Layer ${index} (${bindings[index]!.layer.geom}) has no drawable rows after its stat; skipping it.`,
+      });
+    }
+  }
+
+  return { bindings, panelFrames };
+}

--- a/packages/core/src/pipeline/prepare-panels.ts
+++ b/packages/core/src/pipeline/prepare-panels.ts
@@ -3,14 +3,12 @@
  */
 import type { PortableSpec } from "@ggsvelte/spec";
 
-import { finiteExtent } from "../scales/train.js";
 import type { ColumnTable } from "../table.js";
 
-import { bindData, bindLayer } from "./bind.js";
+import { bindData } from "./bind.js";
 import type { FacetLayout, FacetPanelDef } from "./facets.js";
 import { resolveFacet, SINGLE_PANEL } from "./facets.js";
-import { buildFrame, remapSourceRows } from "./frame.js";
-import { applyPosition } from "./position.js";
+import { buildPanelFrames } from "./prepare-panels-frames.js";
 import type { Advisory, LayerBinding, LayerFrame, PipelineWarning, RunOptions } from "./types.js";
 
 export interface PreparedPanels {
@@ -49,42 +47,20 @@ export function preparePanels(
   const freeX = faceted && facetLayout.freeX;
   const freeY = faceted && facetLayout.freeY;
 
-  const bindings: LayerBinding[] = [];
-  const panelFrames: LayerFrame[][] = facetPanels.map(() => []);
+  let bindings: LayerBinding[] = [];
+  let panelFrames: LayerFrame[][] = facetPanels.map(() => []);
   if (!emptyData) {
-    for (let index = 0; index < normalized.layers.length; index++) {
-      bindings.push(bindLayer(normalized.layers[index]!, index, table, warnings));
-    }
-    // Shared bin break grids across panels when the x scale is fixed.
-    const binRanges = bindings.map((binding) => {
-      const stat = binding.layer.stat ?? "identity";
-      if (stat !== "bin" || !faceted || freeX || binding.xField === null) return void 0;
-      return finiteExtent([table.numeric(binding.xField)]) ?? void 0;
+    const built = buildPanelFrames({
+      normalized,
+      table,
+      facetPanels,
+      faceted,
+      freeX,
+      warnings,
+      advisories,
     });
-    for (let p = 0; p < facetPanels.length; p++) {
-      const panelTable = facetPanels[p]!.table;
-      for (let index = 0; index < bindings.length; index++) {
-        const frame = buildFrame(
-          bindings[index]!,
-          panelTable,
-          warnings,
-          advisories,
-          binRanges[index],
-        );
-        applyPosition(frame, advisories, panelTable);
-        remapSourceRows(frame, facetPanels[p]!.sourceRows);
-        panelFrames[p]!.push(frame);
-      }
-    }
-    for (let index = 0; index < bindings.length; index++) {
-      const allEmpty = panelFrames.every((frames) => frames[index]!.n === 0);
-      if (allEmpty && bindings[index]!.ruleForm !== "annotation") {
-        warnings.push({
-          code: "empty-layer",
-          message: `Layer ${index} (${bindings[index]!.layer.geom}) has no drawable rows after its stat; skipping it.`,
-        });
-      }
-    }
+    bindings = built.bindings;
+    panelFrames = built.panelFrames;
   }
 
   return {

--- a/packages/core/tests/pipeline-build-candidates.test.ts
+++ b/packages/core/tests/pipeline-build-candidates.test.ts
@@ -6,10 +6,27 @@ import { describe, expect, it } from "bun:test";
 
 import { aes, gg } from "@ggsvelte/spec";
 
+import { ordinalSeriesRank } from "../src/pipeline/build-candidates-datum-context.ts";
 import { resolveCandidateLogicalValues } from "../src/pipeline/build-candidates-datum-values.ts";
 import { runPipeline } from "../src/pipeline.ts";
 
 const size = { width: 640, height: 400 };
+
+describe("ordinalSeriesRank", () => {
+  it("falls back to group when no ordinal color/fill mapping applies", () => {
+    expect(
+      ordinalSeriesRank({
+        color: null,
+        fill: null,
+        colorField: undefined,
+        fillField: undefined,
+        sourceRow: 0,
+        sourceValue: () => "a",
+        group: 3,
+      }),
+    ).toBe(3);
+  });
+});
 
 describe("resolveCandidateLogicalValues", () => {
   it("prefers annotation intercepts when the layer is an annotation rule", () => {

--- a/packages/core/tests/pipeline-position.test.ts
+++ b/packages/core/tests/pipeline-position.test.ts
@@ -7,12 +7,27 @@ import { aes, gg } from "@ggsvelte/spec";
 
 import { bindLayer } from "../src/pipeline/bind.ts";
 import { buildFrame } from "../src/pipeline/frame.ts";
+import { barSlotKeys } from "../src/pipeline/position-bar.ts";
 import { applyPosition } from "../src/pipeline/position.ts";
 import { runPipeline } from "../src/pipeline.ts";
 import { ColumnTable } from "../src/table.ts";
-import type { Advisory } from "../src/pipeline/types.ts";
+import type { Advisory, LayerFrame } from "../src/pipeline/types.ts";
 
 const size = { width: 640, height: 400 };
+
+describe("barSlotKeys", () => {
+  it("prefers band categories, then numeric centers, else null", () => {
+    const base = {
+      xValues: null as string[] | null,
+      xNumeric: null as Float64Array | null,
+    };
+    expect(barSlotKeys(base as LayerFrame)).toBeNull();
+    expect(barSlotKeys({ ...base, xValues: ["a", "b"] } as LayerFrame)).toEqual(["a", "b"]);
+    expect(barSlotKeys({ ...base, xNumeric: Float64Array.of(1.5, 2.5) } as LayerFrame)).toEqual([
+      1.5, 2.5,
+    ]);
+  });
+});
 
 describe("applyPosition — stack/fill/dodge on bars", () => {
   it("stacks grouped cols from zero baseline into ymin/ymax", () => {


### PR DESCRIPTION
## Summary
- Split position adjustments into jitter/nudge, boxplot dodge, and bar stack/fill/dodge modules.
- Split facet grid geometry into outer chrome, shared margin pass, and cell placement.
- Split bindLayer into y-channel resolution and label/weight/color extras.
- Extract candidate datum context helpers (outliers, annotations, series rank).
- Split finalize contracts and preparePanels frame building behind facades.
- Add characterization tests for `barSlotKeys` and `ordinalSeriesRank`.

## Test plan
- [x] `bun test packages/core` (501 pass)
- [x] `bun run check`
- [x] `bun run knip`
- [x] `bun run lint:type-aware`
- [x] Codex pre-PR review (PASS, no P1/P2)