### PR TITLE
refactor(svelte): extract isContainerWidthProp for layout chrome

### DIFF
--- a/packages/svelte/src/lib/GGPlot.svelte
+++ b/packages/svelte/src/lib/GGPlot.svelte
@@ -164,6 +164,7 @@
     zoomAnnouncement,
   } from "./plot-labels.js";
   import {
+    isContainerWidthProp,
     isNarrowToolsWidth,
     isTooltipDocked,
     plotRootInlineStyle,
@@ -468,7 +469,7 @@
   let root = $state<HTMLDivElement | null>(null);
 
   $effect(() => {
-    if ((width !== undefined && width !== "container") || root === null) return;
+    if (!isContainerWidthProp(width) || root === null) return;
     const el = root;
     let frame = 0;
     const observer = new ResizeObserver((entries) => {
@@ -790,7 +791,7 @@
         interactive ||
         effectiveEmphasisKeys.length > 0 ||
         effectiveSelectedKeys.length > 0,
-      containerWidth: width === undefined || width === "container",
+      containerWidth: isContainerWidthProp(width),
       sceneWidth: model?.scene.width ?? resolvedWidth,
       sceneHeight: model?.scene.height ?? resolvedHeight,
       themeStyle,
@@ -2315,8 +2316,7 @@
     if (!clientFlush) return false;
     return isPlotReady({
       hasModel: model !== null,
-      widthMode:
-        width === undefined || width === "container" ? "container" : "fixed",
+      widthMode: isContainerWidthProp(width) ? "container" : "fixed",
       containerHasPositiveWidth,
       hasCanvas,
       paintComplete:
@@ -2335,7 +2335,7 @@
 <div
   bind:this={root}
   class="gg-plot-root"
-  class:gg-container-width={width === undefined || width === "container"}
+  class:gg-container-width={isContainerWidthProp(width)}
   class:gg-with-tool-rail={showToolRail}
   class:gg-with-legend-clear={interactionConfig.legendFocus !== null &&
     effectiveLegendPressed !== null}

--- a/packages/svelte/src/lib/plot-layout.ts
+++ b/packages/svelte/src/lib/plot-layout.ts
@@ -22,6 +22,18 @@ export type ResolvePlotSizeInput = {
 };
 
 /**
+ * True when the width prop is omitted or `"container"` (responsive layout).
+ * Shared by resolvePlotSize, paint readiness widthMode, root class, ResizeObserver
+ * install, and plotRootInlineStyle containerWidth flag.
+ * Type predicate so fixed-mode branches narrow to `number`.
+ */
+export function isContainerWidthProp(
+  width: number | "container" | undefined,
+): width is "container" | undefined {
+  return width === undefined || width === "container";
+}
+
+/**
  * Resolved plot pixel size for the pipeline and root style.
  * Container mode: measured container width, then assembled, then 640.
  * Fixed mode: the numeric width prop (assembled fallback is unused once fixed).
@@ -31,10 +43,9 @@ export function resolvePlotSize(input: ResolvePlotSizeInput): {
   readonly width: number;
   readonly height: number;
 } {
-  const width =
-    input.width === undefined || input.width === "container"
-      ? (input.containerWidth ?? input.assembledWidth ?? DEFAULT_PLOT_WIDTH_PX)
-      : input.width;
+  const width = isContainerWidthProp(input.width)
+    ? (input.containerWidth ?? input.assembledWidth ?? DEFAULT_PLOT_WIDTH_PX)
+    : input.width;
   const height = input.height ?? input.assembledHeight ?? DEFAULT_PLOT_HEIGHT_PX;
   return { width, height };
 }

--- a/packages/svelte/tests/plot-layout.test.ts
+++ b/packages/svelte/tests/plot-layout.test.ts
@@ -15,7 +15,9 @@ import {
 
 describe("isContainerWidthProp", () => {
   it("is true for omitted and container width props", () => {
-    expect(isContainerWidthProp(undefined)).toBe(true);
+    // Omitted optional prop (no undefined literal — oxlint unicorn/no-useless-undefined).
+    const props: { width?: number | "container" } = {};
+    expect(isContainerWidthProp(props.width)).toBe(true);
     expect(isContainerWidthProp("container")).toBe(true);
   });
 

--- a/packages/svelte/tests/plot-layout.test.ts
+++ b/packages/svelte/tests/plot-layout.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  isContainerWidthProp,
   isDockedTooltipWidth,
   isNarrowToolsWidth,
   isTooltipDocked,
@@ -11,6 +12,18 @@ import {
   resolvePlotSize,
   tooltipViewportSize,
 } from "../src/lib/plot-layout.js";
+
+describe("isContainerWidthProp", () => {
+  it("is true for omitted and container width props", () => {
+    expect(isContainerWidthProp(undefined)).toBe(true);
+    expect(isContainerWidthProp("container")).toBe(true);
+  });
+
+  it("is false for fixed numeric widths", () => {
+    expect(isContainerWidthProp(640)).toBe(false);
+    expect(isContainerWidthProp(0)).toBe(false);
+  });
+});
 
 describe("resolvePlotSize", () => {
   it("uses container measure then assembled then 640 in container mode", () => {


### PR DESCRIPTION
## Summary
- Extract `isContainerWidthProp` (type predicate) for container vs fixed width prop classification.
- Wire it into `resolvePlotSize`, paint readiness `widthMode`, root `gg-container-width` class, ResizeObserver install, and root inline style input.
- Unit coverage for omitted optional prop, `"container"`, and fixed numeric widths.

## Test plan
- [x] `vitest run tests/plot-layout.test.ts` (all browsers)
- [x] `bun run check` / svelte-check --fail-on-warnings
- [x] Pre-push: package build, oxlint type-aware, knip, bun test
- [x] Codex pre-PR: clean (no P1/P2)