### PR TITLE
refactor(core): split closed paths, candidates, boxplot, shared geometry

### DIFF
--- a/packages/core/src/pipeline/build-candidates-datum-represented.ts
+++ b/packages/core/src/pipeline/build-candidates-datum-represented.ts
@@ -1,0 +1,54 @@
+/**
+ * Represented source-row lineage for identity/stat candidates.
+ */
+import type { LineageStore } from "../identity.js";
+import type { ColumnTable } from "../table.js";
+
+import { filterRepresentedSourceRows } from "./build-candidates-lineage.js";
+import type { LayerFrame } from "./types.js";
+
+export function resolveRepresentedSourceRows(input: {
+  outlierSourceRow: number | null;
+  sourceRow: number | null;
+  group: number;
+  panelIndex: number;
+  layerIndex: number;
+  sourceRowsByGroup: Map<string, number[]>;
+  frame: LayerFrame | undefined;
+  table: ColumnTable;
+  frameRow: number;
+  lineage: LineageStore<number>;
+  primitiveIndex: number;
+}): { representedRows: number[]; sourceOrder: number; lineageKey: number } {
+  const {
+    outlierSourceRow,
+    sourceRow,
+    group,
+    panelIndex,
+    layerIndex,
+    sourceRowsByGroup,
+    frame,
+    table,
+    frameRow,
+    lineage,
+    primitiveIndex,
+  } = input;
+
+  let representedRows =
+    outlierSourceRow === null
+      ? (sourceRowsByGroup.get(`${panelIndex}:${layerIndex}:${group}`) ?? [])
+      : [outlierSourceRow];
+  if (sourceRow === null && frame !== undefined) {
+    representedRows = filterRepresentedSourceRows({
+      frame,
+      table,
+      frameRow,
+      baseRows: representedRows,
+    });
+  }
+  return {
+    representedRows,
+    sourceOrder: sourceRow ?? outlierSourceRow ?? primitiveIndex,
+    lineageKey: sourceRow === null ? lineage.intern(representedRows) : lineage.intern([sourceRow]),
+  };
+}

--- a/packages/core/src/pipeline/build-candidates-datum-resolve.ts
+++ b/packages/core/src/pipeline/build-candidates-datum-resolve.ts
@@ -1,0 +1,122 @@
+/**
+ * Resolve one identity-indexed candidate datum from scene/frame/index context.
+ */
+import type { CandidateBuildFacts, CandidateDatum } from "../candidate-store.js";
+import type { LineageStore } from "../identity.js";
+import type { Scene } from "../scene.js";
+import type { ColumnTable } from "../table.js";
+
+import {
+  resolveAnnotationIntercepts,
+  resolveOutlierContext,
+} from "./build-candidates-datum-context.js";
+import {
+  makeSourceValueLookup,
+  resolveCandidateFieldChannels,
+} from "./build-candidates-datum-fields.js";
+import {
+  resolveCandidateSeries,
+  resolveRepresentedSourceRows,
+} from "./build-candidates-datum-series.js";
+import { resolveCandidateLogicalValues } from "./build-candidates-datum-values.js";
+import { resolveCandidateFrameRow } from "./build-candidates-frame-row.js";
+import type { CandidateIdentityIndex } from "./build-candidates-identity.js";
+import type { FacetPanelDef } from "./facets.js";
+import { candidateAutoMode } from "./frame.js";
+import type { MappedField } from "./types.js";
+import type { LayerBinding, LayerFrame, ResolvedColorScale } from "./types.js";
+
+export interface IdentityCandidateResolveContext {
+  scene: Scene;
+  bindings: readonly LayerBinding[];
+  panelFrames: readonly (readonly LayerFrame[])[];
+  facetPanels: readonly FacetPanelDef[];
+  table: ColumnTable;
+  layerFields: readonly MappedField[][];
+  color: ResolvedColorScale | null;
+  fill: ResolvedColorScale | null;
+  lineage: LineageStore<number>;
+  getIdentityIndex: () => CandidateIdentityIndex;
+}
+
+export function resolveIdentityCandidateDatum(
+  ctx: IdentityCandidateResolveContext,
+  facts: CandidateBuildFacts,
+): CandidateDatum {
+  const { seriesByRow, sourceRowsByGroup, frameGroups } = ctx.getIdentityIndex();
+  const fields = ctx.layerFields[facts.layerIndex] ?? [];
+  const sourceRow = facts.rowIndex;
+  const frame = ctx.panelFrames[facts.panelIndex]?.[facts.layerIndex];
+  const batch = ctx.scene.batches[facts.batchIndex]!;
+  const { outlierLocalRow, outlierSourceRow } = resolveOutlierContext({
+    frame,
+    batch,
+    primitiveIndex: facts.primitiveIndex,
+    facetPanel: ctx.facetPanels[facts.panelIndex],
+  });
+  const orderedGroups = frameGroups.get(`${facts.panelIndex}:${facts.layerIndex}`) ?? [0];
+  const { frameRow, derivedGroup } = resolveCandidateFrameRow({
+    frame,
+    batch,
+    primitiveIndex: facts.primitiveIndex,
+    orderedGroups,
+    outlierLocalRow,
+  });
+  const sourceValue = makeSourceValueLookup(ctx.table, sourceRow);
+  const { xField, yField, colorField, fillField } = resolveCandidateFieldChannels(fields);
+  const { group, seriesRank } = resolveCandidateSeries({
+    sourceRow,
+    derivedGroup,
+    seriesByRow,
+    panelIndex: facts.panelIndex,
+    layerIndex: facts.layerIndex,
+    color: ctx.color,
+    fill: ctx.fill,
+    colorField,
+    fillField,
+    sourceValue,
+  });
+  const autoMode = candidateAutoMode(
+    frame?.binding ?? ctx.bindings[facts.layerIndex]!,
+    facts.primitiveIndex,
+  );
+  const { annotationRule, annotationX, annotationY } = resolveAnnotationIntercepts({
+    frame,
+    primitiveIndex: facts.primitiveIndex,
+  });
+  const { sourceOrder, lineageKey } = resolveRepresentedSourceRows({
+    outlierSourceRow,
+    sourceRow,
+    group,
+    panelIndex: facts.panelIndex,
+    layerIndex: facts.layerIndex,
+    sourceRowsByGroup,
+    frame,
+    table: ctx.table,
+    frameRow,
+    lineage: ctx.lineage,
+    primitiveIndex: facts.primitiveIndex,
+  });
+  const { xValue, yValue } = resolveCandidateLogicalValues({
+    annotationRule,
+    annotationX,
+    annotationY,
+    outlierSourceRow,
+    sourceRow,
+    frame,
+    frameRow,
+    primitiveIndex: facts.primitiveIndex,
+    sourceValue,
+    xField,
+    yField,
+  });
+  return {
+    xValue,
+    yValue,
+    seriesId: group,
+    seriesRank,
+    sourceOrder,
+    lineage: lineageKey,
+    autoMode,
+  };
+}

--- a/packages/core/src/pipeline/build-candidates-datum-series.ts
+++ b/packages/core/src/pipeline/build-candidates-datum-series.ts
@@ -1,13 +1,13 @@
 /**
- * Series identity, rank, and represented-row lineage for identity candidates.
+ * Series identity and ordinal rank for identity candidates.
+ * Represented-row lineage lives in build-candidates-datum-represented.
  */
-import type { LineageStore } from "../identity.js";
 import type { CellValue } from "../table.js";
-import type { ColumnTable } from "../table.js";
 
 import { ordinalSeriesRank } from "./build-candidates-datum-context.js";
-import { filterRepresentedSourceRows } from "./build-candidates-lineage.js";
-import type { LayerFrame, ResolvedColorScale } from "./types.js";
+import type { ResolvedColorScale } from "./types.js";
+
+export { resolveRepresentedSourceRows } from "./build-candidates-datum-represented.js";
 
 export function resolveCandidateSeries(input: {
   sourceRow: number | null;
@@ -47,50 +47,4 @@ export function resolveCandidateSeries(input: {
     group,
   });
   return { group, seriesRank };
-}
-
-export function resolveRepresentedSourceRows(input: {
-  outlierSourceRow: number | null;
-  sourceRow: number | null;
-  group: number;
-  panelIndex: number;
-  layerIndex: number;
-  sourceRowsByGroup: Map<string, number[]>;
-  frame: LayerFrame | undefined;
-  table: ColumnTable;
-  frameRow: number;
-  lineage: LineageStore<number>;
-  primitiveIndex: number;
-}): { representedRows: number[]; sourceOrder: number; lineageKey: number } {
-  const {
-    outlierSourceRow,
-    sourceRow,
-    group,
-    panelIndex,
-    layerIndex,
-    sourceRowsByGroup,
-    frame,
-    table,
-    frameRow,
-    lineage,
-    primitiveIndex,
-  } = input;
-
-  let representedRows =
-    outlierSourceRow === null
-      ? (sourceRowsByGroup.get(`${panelIndex}:${layerIndex}:${group}`) ?? [])
-      : [outlierSourceRow];
-  if (sourceRow === null && frame !== undefined) {
-    representedRows = filterRepresentedSourceRows({
-      frame,
-      table,
-      frameRow,
-      baseRows: representedRows,
-    });
-  }
-  return {
-    representedRows,
-    sourceOrder: sourceRow ?? outlierSourceRow ?? primitiveIndex,
-    lineageKey: sourceRow === null ? lineage.intern(representedRows) : lineage.intern([sourceRow]),
-  };
 }

--- a/packages/core/src/pipeline/build-candidates-datum.ts
+++ b/packages/core/src/pipeline/build-candidates-datum.ts
@@ -8,22 +8,11 @@ import type { Scene } from "../scene.js";
 import type { ColumnTable } from "../table.js";
 
 import {
-  resolveAnnotationIntercepts,
-  resolveOutlierContext,
-} from "./build-candidates-datum-context.js";
-import {
-  makeSourceValueLookup,
-  resolveCandidateFieldChannels,
-} from "./build-candidates-datum-fields.js";
-import {
-  resolveCandidateSeries,
-  resolveRepresentedSourceRows,
-} from "./build-candidates-datum-series.js";
-import { resolveCandidateLogicalValues } from "./build-candidates-datum-values.js";
-import { resolveCandidateFrameRow } from "./build-candidates-frame-row.js";
+  resolveIdentityCandidateDatum,
+  type IdentityCandidateResolveContext,
+} from "./build-candidates-datum-resolve.js";
 import type { CandidateIdentityIndex } from "./build-candidates-identity.js";
 import type { FacetPanelDef } from "./facets.js";
-import { candidateAutoMode } from "./frame.js";
 import type { MappedField } from "./types.js";
 import type { LayerBinding, LayerFrame, ResolvedColorScale } from "./types.js";
 
@@ -39,95 +28,6 @@ export function createIdentityCandidateDatumResolver(input: {
   lineage: LineageStore<number>;
   getIdentityIndex: () => CandidateIdentityIndex;
 }): (facts: CandidateBuildFacts) => CandidateDatum {
-  const {
-    scene,
-    bindings,
-    panelFrames,
-    facetPanels,
-    table,
-    layerFields,
-    color,
-    fill,
-    lineage,
-    getIdentityIndex,
-  } = input;
-
-  return (facts) => {
-    const { seriesByRow, sourceRowsByGroup, frameGroups } = getIdentityIndex();
-    const fields = layerFields[facts.layerIndex] ?? [];
-    const sourceRow = facts.rowIndex;
-    const frame = panelFrames[facts.panelIndex]?.[facts.layerIndex];
-    const batch = scene.batches[facts.batchIndex]!;
-    const { outlierLocalRow, outlierSourceRow } = resolveOutlierContext({
-      frame,
-      batch,
-      primitiveIndex: facts.primitiveIndex,
-      facetPanel: facetPanels[facts.panelIndex],
-    });
-    const orderedGroups = frameGroups.get(`${facts.panelIndex}:${facts.layerIndex}`) ?? [0];
-    const { frameRow, derivedGroup } = resolveCandidateFrameRow({
-      frame,
-      batch,
-      primitiveIndex: facts.primitiveIndex,
-      orderedGroups,
-      outlierLocalRow,
-    });
-    const sourceValue = makeSourceValueLookup(table, sourceRow);
-    const { xField, yField, colorField, fillField } = resolveCandidateFieldChannels(fields);
-    const { group, seriesRank } = resolveCandidateSeries({
-      sourceRow,
-      derivedGroup,
-      seriesByRow,
-      panelIndex: facts.panelIndex,
-      layerIndex: facts.layerIndex,
-      color,
-      fill,
-      colorField,
-      fillField,
-      sourceValue,
-    });
-    const autoMode = candidateAutoMode(
-      frame?.binding ?? bindings[facts.layerIndex]!,
-      facts.primitiveIndex,
-    );
-    const { annotationRule, annotationX, annotationY } = resolveAnnotationIntercepts({
-      frame,
-      primitiveIndex: facts.primitiveIndex,
-    });
-    const { sourceOrder, lineageKey } = resolveRepresentedSourceRows({
-      outlierSourceRow,
-      sourceRow,
-      group,
-      panelIndex: facts.panelIndex,
-      layerIndex: facts.layerIndex,
-      sourceRowsByGroup,
-      frame,
-      table,
-      frameRow,
-      lineage,
-      primitiveIndex: facts.primitiveIndex,
-    });
-    const { xValue, yValue } = resolveCandidateLogicalValues({
-      annotationRule,
-      annotationX,
-      annotationY,
-      outlierSourceRow,
-      sourceRow,
-      frame,
-      frameRow,
-      primitiveIndex: facts.primitiveIndex,
-      sourceValue,
-      xField,
-      yField,
-    });
-    return {
-      xValue,
-      yValue,
-      seriesId: group,
-      seriesRank,
-      sourceOrder,
-      lineage: lineageKey,
-      autoMode,
-    };
-  };
+  const ctx: IdentityCandidateResolveContext = input;
+  return (facts) => resolveIdentityCandidateDatum(ctx, facts);
 }

--- a/packages/core/src/pipeline/build-candidates-source-backed.ts
+++ b/packages/core/src/pipeline/build-candidates-source-backed.ts
@@ -1,0 +1,36 @@
+/**
+ * Source-backed candidate store path (identity layers, no annotations).
+ */
+import { buildCandidateStore } from "../candidate-store.js";
+import type { CandidateStore } from "../candidate-store.js";
+import type { LineageStore } from "../identity.js";
+import type { Scene } from "../scene.js";
+import type { ColumnTable } from "../table.js";
+
+import { createRawCandidateDatumResolver } from "./frame.js";
+import type { LayerBinding, ResolvedColorScale } from "./types.js";
+
+export function isAllSourceBacked(bindings: readonly LayerBinding[]): boolean {
+  return bindings.every(
+    (binding) =>
+      (binding.layer.stat ?? "identity") === "identity" && binding.ruleForm !== "annotation",
+  );
+}
+
+export function buildSourceBackedCandidates(input: {
+  scene: Scene;
+  runId: number;
+  flip: boolean;
+  bindings: readonly LayerBinding[];
+  table: ColumnTable;
+  color: ResolvedColorScale | null;
+  fill: ResolvedColorScale | null;
+  lineage: LineageStore<number>;
+}): CandidateStore {
+  const { scene, runId, flip, bindings, table, color, fill, lineage } = input;
+  return buildCandidateStore(scene, {
+    epoch: runId,
+    flip,
+    datum: createRawCandidateDatumResolver(bindings, table, color, fill, lineage),
+  });
+}

--- a/packages/core/src/pipeline/build-candidates.ts
+++ b/packages/core/src/pipeline/build-candidates.ts
@@ -14,8 +14,11 @@ import {
   buildCandidateIdentityIndex,
   type CandidateIdentityIndex,
 } from "./build-candidates-identity.js";
+import {
+  buildSourceBackedCandidates,
+  isAllSourceBacked,
+} from "./build-candidates-source-backed.js";
 import type { FacetPanelDef } from "./facets.js";
-import { createRawCandidateDatumResolver } from "./frame.js";
 import type { MappedField } from "./types.js";
 import type { LayerBinding, LayerFrame, ResolvedColorScale } from "./types.js";
 
@@ -46,16 +49,16 @@ export function buildPipelineCandidates(input: {
     lineage,
   } = input;
 
-  const allSourceBacked = bindings.every(
-    (binding) =>
-      (binding.layer.stat ?? "identity") === "identity" && binding.ruleForm !== "annotation",
-  );
-
-  if (allSourceBacked) {
-    return buildCandidateStore(scene, {
-      epoch: runId,
+  if (isAllSourceBacked(bindings)) {
+    return buildSourceBackedCandidates({
+      scene,
+      runId,
       flip,
-      datum: createRawCandidateDatumResolver(bindings, table, color, fill, lineage),
+      bindings,
+      table,
+      color,
+      fill,
+      lineage,
     });
   }
 

--- a/packages/core/src/pipeline/frame-group-columns.ts
+++ b/packages/core/src/pipeline/frame-group-columns.ts
@@ -1,0 +1,36 @@
+/**
+ * Layer grouping and carried discrete columns for stats/identity frames.
+ */
+import { deriveGroups } from "../grouping.js";
+import type { CellValue, Discreteness } from "../table.js";
+import type { ColumnTable } from "../table.js";
+
+import type { LayerBinding } from "./types.js";
+
+export function deriveLayerGroups(binding: LayerBinding, table: ColumnTable): number[] {
+  const aes = binding.layer.aes ?? {};
+  const declared: Record<string, Discreteness> = {};
+  for (const mapping of Object.values(aes)) {
+    if (
+      mapping !== null &&
+      mapping !== undefined &&
+      "field" in mapping &&
+      table.has(mapping.field)
+    ) {
+      declared[mapping.field] = table.discreteness(mapping.field);
+    }
+  }
+  return [...deriveGroups(table.columns(), aes, declared).groups];
+}
+
+/** Carried discrete columns for stats (color/fill/label, minus the x field). */
+export function carriedColumns(
+  binding: LayerBinding,
+  table: ColumnTable,
+): Record<string, readonly CellValue[]> {
+  const carried: Record<string, readonly CellValue[]> = {};
+  for (const field of [binding.color.field, binding.fill.field, binding.labelField]) {
+    if (field !== null && field !== binding.xField) carried[field] = table.column(field);
+  }
+  return carried;
+}

--- a/packages/core/src/pipeline/frame-helpers.ts
+++ b/packages/core/src/pipeline/frame-helpers.ts
@@ -1,12 +1,13 @@
 /**
  * Shared frame-building helpers: empty extras, intercept lists, grouping,
- * carried columns, and stat drop warnings.
+ * carried columns, and stat drop warnings. Group/carried live in
+ * frame-group-columns; this file re-exports them for import-path stability.
  */
-import { deriveGroups } from "../grouping.js";
-import type { CellValue, Discreteness } from "../table.js";
-import type { ColumnTable } from "../table.js";
+import type { CellValue } from "../table.js";
 
-import type { LayerBinding, LayerFrame, PipelineWarning } from "./types.js";
+import type { LayerFrame, PipelineWarning } from "./types.js";
+
+export { carriedColumns, deriveLayerGroups } from "./frame-group-columns.js";
 
 /** Fresh all-null frame extras (each stat branch fills what it uses). */
 export function emptyFrameExtras(): Pick<
@@ -44,34 +45,6 @@ export function interceptList(value: unknown): CellValue[] {
   if (value === undefined) return [];
   if (Array.isArray(value)) return value as CellValue[];
   return [value as CellValue];
-}
-
-export function deriveLayerGroups(binding: LayerBinding, table: ColumnTable): number[] {
-  const aes = binding.layer.aes ?? {};
-  const declared: Record<string, Discreteness> = {};
-  for (const mapping of Object.values(aes)) {
-    if (
-      mapping !== null &&
-      mapping !== undefined &&
-      "field" in mapping &&
-      table.has(mapping.field)
-    ) {
-      declared[mapping.field] = table.discreteness(mapping.field);
-    }
-  }
-  return [...deriveGroups(table.columns(), aes, declared).groups];
-}
-
-/** Carried discrete columns for stats (color/fill/label, minus the x field). */
-export function carriedColumns(
-  binding: LayerBinding,
-  table: ColumnTable,
-): Record<string, readonly CellValue[]> {
-  const carried: Record<string, readonly CellValue[]> = {};
-  for (const field of [binding.color.field, binding.fill.field, binding.labelField]) {
-    if (field !== null && field !== binding.xField) carried[field] = table.column(field);
-  }
-  return carried;
 }
 
 export function removedStatWarning(

--- a/packages/core/src/pipeline/geometry-boxplot-body-layout-collect.ts
+++ b/packages/core/src/pipeline/geometry-boxplot-body-layout-collect.ts
@@ -1,0 +1,54 @@
+/**
+ * Accumulate per-row boxplot body geometry into layout buffers.
+ */
+import type { BoxplotRowGeometry } from "./geometry-boxplot-body-row.js";
+
+export interface BoxplotBodyBuffers {
+  centerPx: number[];
+  halfPx: number[];
+  rects: number[];
+  rectRows: number[];
+  keptRows: number[];
+  whiskers: number[];
+  whiskerRows: number[];
+  medians: number[];
+  medianRows: number[];
+  removed: number;
+}
+
+export function createBoxplotBodyBuffers(): BoxplotBodyBuffers {
+  return {
+    centerPx: [],
+    halfPx: [],
+    rects: [],
+    rectRows: [],
+    keptRows: [],
+    whiskers: [],
+    whiskerRows: [],
+    medians: [],
+    medianRows: [],
+    removed: 0,
+  };
+}
+
+export function pushRemovedBoxplotRow(buffers: BoxplotBodyBuffers): void {
+  buffers.removed++;
+  buffers.centerPx.push(NaN);
+  buffers.halfPx.push(NaN);
+}
+
+export function pushKeptBoxplotRow(
+  buffers: BoxplotBodyBuffers,
+  geom: BoxplotRowGeometry,
+  row: number,
+): void {
+  buffers.centerPx.push(geom.centerPx);
+  buffers.halfPx.push(geom.halfPx);
+  buffers.rects.push(...geom.rect);
+  buffers.rectRows.push(geom.sourceRow);
+  buffers.keptRows.push(row);
+  buffers.whiskers.push(...geom.whiskers);
+  buffers.whiskerRows.push(geom.sourceRow, geom.sourceRow);
+  buffers.medians.push(...geom.median);
+  buffers.medianRows.push(geom.sourceRow);
+}

--- a/packages/core/src/pipeline/geometry-boxplot-body-layout.ts
+++ b/packages/core/src/pipeline/geometry-boxplot-body-layout.ts
@@ -6,6 +6,11 @@ import type { BoxplotParams } from "@ggsvelte/spec";
 import type { LayerFrame, PipelineWarning } from "./types.js";
 import type { Frame } from "./geometry-shared.js";
 import { DEFAULT_BAR_WIDTH, removedWarning } from "./geometry-shared.js";
+import {
+  createBoxplotBodyBuffers,
+  pushKeptBoxplotRow,
+  pushRemovedBoxplotRow,
+} from "./geometry-boxplot-body-layout-collect.js";
 import { layoutBoxplotBodyRow } from "./geometry-boxplot-body-row.js";
 
 const DEFAULT_BOX_LINEWIDTH = 1;
@@ -47,50 +52,30 @@ export function layoutBoxplotBody(
   const alpha = params.alpha ?? 1;
   const yScale = fx.yScale;
 
-  const centerPx: number[] = [];
-  const halfPx: number[] = [];
-  const rects: number[] = [];
-  const rectRows: number[] = [];
-  const keptRows: number[] = [];
-  const whiskers: number[] = [];
-  const whiskerRows: number[] = [];
-  const medians: number[] = [];
-  const medianRows: number[] = [];
-  let removed = 0;
-
+  const buffers = createBoxplotBodyBuffers();
   const yPx = (v: number) => fx.innerHeight - yScale.normalize(v) * fx.innerHeight;
 
   for (let row = 0; row < n; row++) {
     const geom = layoutBoxplotBodyRow({ frame, fx, row, widthFrac, yPx });
     if (geom === null) {
-      removed++;
-      centerPx.push(NaN);
-      halfPx.push(NaN);
+      pushRemovedBoxplotRow(buffers);
       continue;
     }
-    centerPx.push(geom.centerPx);
-    halfPx.push(geom.halfPx);
-    rects.push(...geom.rect);
-    rectRows.push(geom.sourceRow);
-    keptRows.push(row);
-    whiskers.push(...geom.whiskers);
-    whiskerRows.push(geom.sourceRow, geom.sourceRow);
-    medians.push(...geom.median);
-    medianRows.push(geom.sourceRow);
+    pushKeptBoxplotRow(buffers, geom, row);
   }
-  removedWarning(removed, binding.index, warnings);
-  if (keptRows.length === 0) return null;
+  removedWarning(buffers.removed, binding.index, warnings);
+  if (buffers.keptRows.length === 0) return null;
 
   return {
-    centerPx,
-    halfPx,
-    rects,
-    rectRows,
-    keptRows,
-    whiskers,
-    whiskerRows,
-    medians,
-    medianRows,
+    centerPx: buffers.centerPx,
+    halfPx: buffers.halfPx,
+    rects: buffers.rects,
+    rectRows: buffers.rectRows,
+    keptRows: buffers.keptRows,
+    whiskers: buffers.whiskers,
+    whiskerRows: buffers.whiskerRows,
+    medians: buffers.medians,
+    medianRows: buffers.medianRows,
     linewidth,
     alpha,
     params,

--- a/packages/core/src/pipeline/geometry-paths-area.ts
+++ b/packages/core/src/pipeline/geometry-paths-area.ts
@@ -6,7 +6,8 @@ import type { PathsBatch } from "../scene.js";
 import type { LayerFrame, PipelineWarning, ResolvedColorScale } from "./types.js";
 import { colorOf } from "./types.js";
 import type { Frame } from "./geometry-shared.js";
-import { bucketByGroup, positionOf, xSortKey } from "./geometry-shared.js";
+import { bucketByGroup, xSortKey } from "./geometry-shared.js";
+import { appendClosedBandEdges } from "./geometry-paths-closed.js";
 
 export function areaBatch(
   frame: LayerFrame,
@@ -33,25 +34,16 @@ export function areaBatch(
   for (let s = 0; s < groupRows.length; s++) {
     pathOffsets[s] = cursor;
     const rows = groupRows[s]!;
-    // Upper edge (ymax), x ascending.
-    for (const row of rows) {
-      const tx = positionOf(fx.xScale, frame.xNumeric, frame.xValues, row);
-      const ty = fx.yScale.type === "band" ? NaN : fx.yScale.normalize(frame.ymax[row]!);
-      positions[cursor * 2] = tx * fx.innerWidth;
-      positions[cursor * 2 + 1] = fx.innerHeight - ty * fx.innerHeight;
-      rowIndex[cursor] = frame.rowIndex[row]!;
-      cursor++;
-    }
-    // Lower edge (ymin), x descending.
-    for (let i = rows.length - 1; i >= 0; i--) {
-      const row = rows[i]!;
-      const tx = positionOf(fx.xScale, frame.xNumeric, frame.xValues, row);
-      const ty = fx.yScale.type === "band" ? NaN : fx.yScale.normalize(frame.ymin[row]!);
-      positions[cursor * 2] = tx * fx.innerWidth;
-      positions[cursor * 2 + 1] = fx.innerHeight - ty * fx.innerHeight;
-      rowIndex[cursor] = frame.rowIndex[row]!;
-      cursor++;
-    }
+    cursor = appendClosedBandEdges({
+      positions,
+      rowIndex,
+      cursor,
+      rows,
+      frame,
+      fx,
+      yTop: frame.ymax,
+      yBottom: frame.ymin,
+    });
     let fillColor: string | null = binding.fill.constant;
     if (fill !== null && (frame.fillValues !== null || binding.fill.scaledConstant !== null)) {
       const first = rows[0]!;

--- a/packages/core/src/pipeline/geometry-paths-closed.ts
+++ b/packages/core/src/pipeline/geometry-paths-closed.ts
@@ -1,0 +1,44 @@
+/**
+ * Shared closed-band path edges: upper ascending, lower descending.
+ * Used by area/density ribbons and smooth confidence bands.
+ */
+import type { LayerFrame } from "./types.js";
+import type { Frame } from "./geometry-shared.js";
+import { positionOf } from "./geometry-shared.js";
+
+/**
+ * Append upper-then-reversed-lower vertices for one closed band subpath.
+ * Returns the advanced cursor.
+ */
+export function appendClosedBandEdges(input: {
+  positions: Float32Array;
+  rowIndex: Uint32Array;
+  cursor: number;
+  rows: readonly number[];
+  frame: LayerFrame;
+  fx: Frame;
+  yTop: Float64Array;
+  yBottom: Float64Array;
+}): number {
+  const { positions, rowIndex, rows, frame, fx, yTop, yBottom } = input;
+  let cursor = input.cursor;
+
+  for (const row of rows) {
+    const tx = positionOf(fx.xScale, frame.xNumeric, frame.xValues, row);
+    const ty = fx.yScale.type === "band" ? NaN : fx.yScale.normalize(yTop[row]!);
+    positions[cursor * 2] = tx * fx.innerWidth;
+    positions[cursor * 2 + 1] = fx.innerHeight - ty * fx.innerHeight;
+    rowIndex[cursor] = frame.rowIndex[row]!;
+    cursor++;
+  }
+  for (let i = rows.length - 1; i >= 0; i--) {
+    const row = rows[i]!;
+    const tx = positionOf(fx.xScale, frame.xNumeric, frame.xValues, row);
+    const ty = fx.yScale.type === "band" ? NaN : fx.yScale.normalize(yBottom[row]!);
+    positions[cursor * 2] = tx * fx.innerWidth;
+    positions[cursor * 2 + 1] = fx.innerHeight - ty * fx.innerHeight;
+    rowIndex[cursor] = frame.rowIndex[row]!;
+    cursor++;
+  }
+  return cursor;
+}

--- a/packages/core/src/pipeline/geometry-shared-bucket.ts
+++ b/packages/core/src/pipeline/geometry-shared-bucket.ts
@@ -1,0 +1,35 @@
+/**
+ * Group-bucket and x-sort helpers for path/line geometry builders.
+ */
+import type { LayerFrame, PipelineWarning } from "./types.js";
+import type { Frame } from "./geometry-shared-position.js";
+import { positionOf, removedWarning } from "./geometry-shared-position.js";
+
+export function bucketByGroup(
+  frame: LayerFrame,
+  fx: Frame,
+  yNumericOverride: Float64Array | null,
+  warnings: PipelineWarning[],
+): number[][] {
+  const groupRows: number[][] = [];
+  let removed = 0;
+  for (let row = 0; row < frame.n; row++) {
+    const tx = positionOf(fx.xScale, frame.xNumeric, frame.xValues, row);
+    const ty = positionOf(fx.yScale, yNumericOverride ?? frame.yNumeric, null, row);
+    if (Number.isNaN(tx) || Number.isNaN(ty)) {
+      removed++;
+      continue;
+    }
+    const g = frame.groups[row]!;
+    (groupRows[g] ??= []).push(row);
+  }
+  removedWarning(removed, frame.binding.index, warnings);
+  return groupRows.filter((rows) => rows !== undefined && rows.length > 0);
+}
+
+export function xSortKey(frame: LayerFrame, fx: Frame): (row: number) => number {
+  return (row: number) =>
+    fx.xScale.type === "band"
+      ? (fx.xScale.indexOf(frame.xValues?.[row] ?? null) ?? Number.MAX_SAFE_INTEGER)
+      : frame.xNumeric![row]!;
+}

--- a/packages/core/src/pipeline/geometry-shared-position.ts
+++ b/packages/core/src/pipeline/geometry-shared-position.ts
@@ -1,0 +1,49 @@
+/**
+ * Panel Frame type, position mapping, removed-row warnings, and mark defaults.
+ */
+import type { PositionScale } from "../scales/train.js";
+import type { CellValue } from "../table.js";
+
+import type { PipelineWarning } from "./types.js";
+
+export const DEFAULT_POINT_SIZE = 2.5;
+export const DEFAULT_LINEWIDTH = 1.5;
+export const DEFAULT_RULE_LINEWIDTH = 1;
+export const DEFAULT_BAR_WIDTH = 0.9;
+export const DEFAULT_TEXT_SIZE = 11;
+
+/** Panel-local frame extents + trained positional scales for batch builders. */
+export interface Frame {
+  innerWidth: number;
+  innerHeight: number;
+  xScale: PositionScale;
+  yScale: PositionScale;
+}
+
+export function positionOf(
+  scale: PositionScale,
+  numeric: Float64Array | null,
+  column: readonly CellValue[] | null,
+  row: number,
+  offsets: Float64Array | null = null,
+): number {
+  if (scale.type === "band") {
+    const t = scale.normalize(column?.[row] ?? null);
+    if (t === undefined) return NaN;
+    // Offsets on discrete axes are band-step fractions.
+    return offsets === null ? t : t + offsets[row]! * scale.step;
+  }
+  const v = numeric?.[row];
+  if (v === undefined || !Number.isFinite(v)) return NaN;
+  // Offsets on continuous axes are data units.
+  return scale.normalize(offsets === null ? v : v + offsets[row]!);
+}
+
+export function removedWarning(removed: number, index: number, warnings: PipelineWarning[]): void {
+  if (removed > 0) {
+    warnings.push({
+      code: "removed-missing",
+      message: `Removed ${removed} row(s) with missing or non-finite positions (layer ${index}).`,
+    });
+  }
+}

--- a/packages/core/src/pipeline/geometry-shared.ts
+++ b/packages/core/src/pipeline/geometry-shared.ts
@@ -1,79 +1,15 @@
 /**
  * Shared geometry primitives: panel Frame, position mapping, grouping buckets,
- * and common mark defaults.
+ * and common mark defaults. Facade re-exports keep import paths stable.
  */
-import type { PositionScale } from "../scales/train.js";
-import type { CellValue } from "../table.js";
-
-import type { LayerFrame, PipelineWarning } from "./types.js";
-
-export const DEFAULT_POINT_SIZE = 2.5;
-export const DEFAULT_LINEWIDTH = 1.5;
-export const DEFAULT_RULE_LINEWIDTH = 1;
-export const DEFAULT_BAR_WIDTH = 0.9;
-export const DEFAULT_TEXT_SIZE = 11;
-
-/** Panel-local frame extents + trained positional scales for batch builders. */
-export interface Frame {
-  innerWidth: number;
-  innerHeight: number;
-  xScale: PositionScale;
-  yScale: PositionScale;
-}
-
-export function positionOf(
-  scale: PositionScale,
-  numeric: Float64Array | null,
-  column: readonly CellValue[] | null,
-  row: number,
-  offsets: Float64Array | null = null,
-): number {
-  if (scale.type === "band") {
-    const t = scale.normalize(column?.[row] ?? null);
-    if (t === undefined) return NaN;
-    // Offsets on discrete axes are band-step fractions.
-    return offsets === null ? t : t + offsets[row]! * scale.step;
-  }
-  const v = numeric?.[row];
-  if (v === undefined || !Number.isFinite(v)) return NaN;
-  // Offsets on continuous axes are data units.
-  return scale.normalize(offsets === null ? v : v + offsets[row]!);
-}
-
-export function removedWarning(removed: number, index: number, warnings: PipelineWarning[]): void {
-  if (removed > 0) {
-    warnings.push({
-      code: "removed-missing",
-      message: `Removed ${removed} row(s) with missing or non-finite positions (layer ${index}).`,
-    });
-  }
-}
-
-export function bucketByGroup(
-  frame: LayerFrame,
-  fx: Frame,
-  yNumericOverride: Float64Array | null,
-  warnings: PipelineWarning[],
-): number[][] {
-  const groupRows: number[][] = [];
-  let removed = 0;
-  for (let row = 0; row < frame.n; row++) {
-    const tx = positionOf(fx.xScale, frame.xNumeric, frame.xValues, row);
-    const ty = positionOf(fx.yScale, yNumericOverride ?? frame.yNumeric, null, row);
-    if (Number.isNaN(tx) || Number.isNaN(ty)) {
-      removed++;
-      continue;
-    }
-    const g = frame.groups[row]!;
-    (groupRows[g] ??= []).push(row);
-  }
-  removedWarning(removed, frame.binding.index, warnings);
-  return groupRows.filter((rows) => rows !== undefined && rows.length > 0);
-}
-
-export function xSortKey(frame: LayerFrame, fx: Frame): (row: number) => number {
-  return (row: number) =>
-    fx.xScale.type === "band"
-      ? (fx.xScale.indexOf(frame.xValues?.[row] ?? null) ?? Number.MAX_SAFE_INTEGER)
-      : frame.xNumeric![row]!;
-}
+export {
+  DEFAULT_BAR_WIDTH,
+  DEFAULT_LINEWIDTH,
+  DEFAULT_POINT_SIZE,
+  DEFAULT_RULE_LINEWIDTH,
+  DEFAULT_TEXT_SIZE,
+  positionOf,
+  removedWarning,
+  type Frame,
+} from "./geometry-shared-position.js";
+export { bucketByGroup, xSortKey } from "./geometry-shared-bucket.js";

--- a/packages/core/src/pipeline/geometry-smooth-ribbon.ts
+++ b/packages/core/src/pipeline/geometry-smooth-ribbon.ts
@@ -5,7 +5,7 @@ import type { GeometryBatch } from "../scene.js";
 
 import type { LayerFrame, ResolvedColorScale } from "./types.js";
 import type { Frame } from "./geometry-shared.js";
-import { positionOf } from "./geometry-shared.js";
+import { appendClosedBandEdges } from "./geometry-paths-closed.js";
 import { groupColor, SMOOTH_RIBBON_ALPHA } from "./geometry-smooth-shared.js";
 
 export function buildSmoothRibbonBatch(input: {
@@ -39,23 +39,16 @@ export function buildSmoothRibbonBatch(input: {
   for (let s = 0; s < bandRows.length; s++) {
     pathOffsets[s] = cursor;
     const rows = bandRows[s]!;
-    for (const row of rows) {
-      const tx = positionOf(fx.xScale, frame.xNumeric, frame.xValues, row);
-      const ty = fx.yScale.type === "band" ? NaN : fx.yScale.normalize(frame.ymax[row]!);
-      positions[cursor * 2] = tx * fx.innerWidth;
-      positions[cursor * 2 + 1] = fx.innerHeight - ty * fx.innerHeight;
-      rowIndex[cursor] = frame.rowIndex[row]!;
-      cursor++;
-    }
-    for (let i = rows.length - 1; i >= 0; i--) {
-      const row = rows[i]!;
-      const tx = positionOf(fx.xScale, frame.xNumeric, frame.xValues, row);
-      const ty = fx.yScale.type === "band" ? NaN : fx.yScale.normalize(frame.ymin[row]!);
-      positions[cursor * 2] = tx * fx.innerWidth;
-      positions[cursor * 2 + 1] = fx.innerHeight - ty * fx.innerHeight;
-      rowIndex[cursor] = frame.rowIndex[row]!;
-      cursor++;
-    }
+    cursor = appendClosedBandEdges({
+      positions,
+      rowIndex,
+      cursor,
+      rows,
+      frame,
+      fx,
+      yTop: frame.ymax,
+      yBottom: frame.ymin,
+    });
     const first = rows[0]!;
     // Ribbon tint: fill channel, else the line's color (band matches
     // its line in multi-series smooths), else theme accent.

--- a/packages/core/tests/pipeline-build-candidates.test.ts
+++ b/packages/core/tests/pipeline-build-candidates.test.ts
@@ -152,3 +152,43 @@ describe("buildPipelineCandidates via runPipeline", () => {
     expect(modes.some((m) => m === "x" || m === "y")).toBe(true);
   });
 });
+
+describe("resolveCandidateSeries / resolveRepresentedSourceRows", () => {
+  it("uses derived group when sourceRow is null", async () => {
+    const { resolveCandidateSeries } =
+      await import("../src/pipeline/build-candidates-datum-series.ts");
+    const result = resolveCandidateSeries({
+      sourceRow: null,
+      derivedGroup: 7,
+      seriesByRow: new Map(),
+      panelIndex: 0,
+      layerIndex: 0,
+      color: null,
+      fill: null,
+      colorField: undefined,
+      fillField: undefined,
+      sourceValue: () => null,
+    });
+    expect(result.group).toBe(7);
+    expect(result.seriesRank).toBe(7);
+  });
+
+  it("maps seriesByRow for identity source rows", async () => {
+    const { resolveCandidateSeries } =
+      await import("../src/pipeline/build-candidates-datum-series.ts");
+    const seriesByRow = new Map([["0:0:2", 4]]);
+    const result = resolveCandidateSeries({
+      sourceRow: 2,
+      derivedGroup: 0,
+      seriesByRow,
+      panelIndex: 0,
+      layerIndex: 0,
+      color: null,
+      fill: null,
+      colorField: undefined,
+      fillField: undefined,
+      sourceValue: () => null,
+    });
+    expect(result.group).toBe(4);
+  });
+});

--- a/packages/core/tests/pipeline-geometry.test.ts
+++ b/packages/core/tests/pipeline-geometry.test.ts
@@ -354,3 +354,72 @@ describe("buildBatch dispatch via runPipeline", () => {
     expect(err.scene.batches.every((b) => b.kind === "segments")).toBe(true);
   });
 });
+
+describe("appendClosedBandEdges — shared closed ribbon vertices", () => {
+  it("writes upper edge ascending then lower edge descending", async () => {
+    const { appendClosedBandEdges } = await import("../src/pipeline/geometry-paths-closed.ts");
+    const positions = new Float32Array(16);
+    const rowIndex = new Uint32Array(8);
+    const frame = {
+      xNumeric: new Float64Array([0, 1]),
+      xValues: null,
+      rowIndex: new Uint32Array([10, 11]),
+      ymin: new Float64Array([0.2, 0.3]),
+      ymax: new Float64Array([0.8, 0.9]),
+    } as unknown as LayerFrame;
+    const fx = {
+      innerWidth: 100,
+      innerHeight: 200,
+      xScale: {
+        type: "linear",
+        normalize: (v: number) => v,
+      },
+      yScale: {
+        type: "linear",
+        normalize: (v: number) => v,
+      },
+    } as Frame;
+    const cursor = appendClosedBandEdges({
+      positions,
+      rowIndex,
+      cursor: 0,
+      rows: [0, 1],
+      frame,
+      fx,
+      yTop: frame.ymax!,
+      yBottom: frame.ymin!,
+    });
+    expect(cursor).toBe(4);
+    // upper: row0 (0, 0.8) -> px (0, 200-160)=(0,40); row1 (1,0.9)->(100,20)
+    expect(positions[0]).toBeCloseTo(0);
+    expect(positions[1]).toBeCloseTo(40);
+    expect(positions[2]).toBeCloseTo(100);
+    expect(positions[3]).toBeCloseTo(20);
+    // lower reverse: row1 (1,0.3)->(100,140); row0 (0,0.2)->(0,160)
+    expect(positions[4]).toBeCloseTo(100);
+    expect(positions[5]).toBeCloseTo(140);
+    expect(positions[6]).toBeCloseTo(0);
+    expect(positions[7]).toBeCloseTo(160);
+    expect([...rowIndex.subarray(0, 4)]).toEqual([10, 11, 11, 10]);
+  });
+});
+
+describe("layoutBoxplotBody — hinge/whisker collection", () => {
+  it("returns null when box extras or scales are unsuitable", async () => {
+    const { layoutBoxplotBody } = await import("../src/pipeline/geometry-boxplot-body-layout.ts");
+    const frame = {
+      binding: { index: 0, layer: { params: {} } },
+      n: 1,
+      box: null,
+      ymin: null,
+      ymax: null,
+    } as unknown as LayerFrame;
+    const fx = {
+      xScale: { type: "linear" },
+      yScale: { type: "linear" },
+      innerWidth: 100,
+      innerHeight: 100,
+    } as Frame;
+    expect(layoutBoxplotBody(frame, fx, [])).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Extract shared closed-band edge writing used by area/density and smooth ribbons.
- Split identity candidate resolve, source-backed candidate path, and represented-row lineage behind stable facades.
- Extract boxplot body buffer accumulation; split geometry shared position/bucket helpers and frame group/carried columns.
- Add characterization tests for `appendClosedBandEdges`, boxplot layout null-guard, and series resolution.

## Test plan
- [x] `bun test packages/core`
- [x] `bun run check`
- [x] `bun run knip`
- [x] `bun run lint:type-aware`
- [x] Codex pre-PR review (`gpt-5.6-terra`) — PASS (no P1)