### PR TITLE
refactor(svelte): carry keyboard complete-area finish payload

### DIFF
--- a/packages/svelte/src/lib/GGPlot.svelte
+++ b/packages/svelte/src/lib/GGPlot.svelte
@@ -128,11 +128,14 @@
     type QueuedPointerInspection,
   } from "./plot-surface-inspection.js";
   import {
+    resolveFinishBrushAction,
+    type FinishBrushAction,
+  } from "./plot-brush-finish.js";
+  import {
     resolveCaptureClickAction,
     advanceTouchInspectMoved,
     isAreaAwaitingSecond,
     isAreaBrushing,
-    resolveFinishBrushAction,
     resolveLostPointerCaptureAction,
     resolvePointerDownAction,
     resolvePointerMoveAction,
@@ -140,7 +143,6 @@
     shouldClearInspectionOnPointerLeave,
     POINT_SELECT_NEAREST_MAX_DISTANCE_PX,
     TOUCH_INSPECT_CLICK_SUPPRESS_MS,
-    type FinishBrushAction,
   } from "./plot-surface-pointer.js";
   import {
     resolveLegendClearControlSource,
@@ -2181,12 +2183,13 @@
 
   function onSurfaceKeyDown(event: KeyboardEvent): void {
     // Decision table is pure (plot-surface-keyboard); this switch owns side
-    // effects only. hasBrushDraft tracks brushRect, not reducer brushing.
+    // effects only. brushCorners is the draft source of truth (not reducer
+    // brushing); complete-area carries finish so host only applies.
     const { action, preventDefault } = resolveSurfaceKeyAction({
       key: event.key,
       shiftKey: event.shiftKey,
       activeTool,
-      hasBrushDraft: brushRect !== null,
+      brushCorners: brushRect,
       hasInspection: inspection !== null,
       pinEnabled,
       focusKey: inspection?.focus.key ?? null,
@@ -2197,6 +2200,7 @@
     if (preventDefault) event.preventDefault();
     switch (action.type) {
       case "nudge-brush": {
+        // Pure table emits only when brushCorners was non-null.
         const panel = inspectionPanel ?? model?.scene.panels[0];
         if (panel === undefined || brushRect === null) return;
         brushRect = nudgeBrushEnd(brushRect, action.dx, action.dy, panel);
@@ -2218,15 +2222,8 @@
         return;
       }
       case "complete-area": {
-        if (brushRect === null) return;
-        // Single pure owner with pointer finish-brush for select vs zoom.
-        applyFinishBrush(
-          resolveFinishBrushAction({
-            ended: { kind: "commit", rect: normalizedRect(brushRect) },
-            activeTool,
-          }),
-          "keyboard",
-        );
+        // finish payload is pure-owned (normalize + select/zoom/end routing).
+        applyFinishBrush(action.finish, "keyboard");
         return;
       }
       case "cycle-coincident":

--- a/packages/svelte/src/lib/plot-brush-finish.ts
+++ b/packages/svelte/src/lib/plot-brush-finish.ts
@@ -1,0 +1,53 @@
+import type { InteractionTool } from "./interaction.js";
+import type { PlotRect } from "./plot-geometry.js";
+
+/**
+ * Matches `PointerBrushEnd` from plot-area-brush without importing that module
+ * (local mirror; plot-area-brush does not import this file — no cycle risk,
+ * but keep the payload shape self-contained for pure finish routing).
+ */
+export type FinishBrushEnded =
+  | { readonly kind: "too-small"; readonly corners: PlotRect }
+  | { readonly kind: "commit"; readonly rect: PlotRect };
+
+export type FinishBrushAction =
+  | { readonly type: "keep-second-corner"; readonly corners: PlotRect }
+  | { readonly type: "select-end"; readonly rect: PlotRect }
+  | { readonly type: "zoom-end"; readonly rect: PlotRect }
+  | { readonly type: "end-area" };
+
+/**
+ * Pure routing after brush-end evaluation for pointer finish-brush and
+ * keyboard complete-area.
+ *
+ * Takes the full ended discriminant so actions carry rect/corners payloads —
+ * host must not re-narrow `ended.kind` for emit/apply.
+ *
+ * Priority:
+ *   1. keep-second-corner — too-small (wins for any tool); carries corners
+ *   2. select-end — commit + select-area; carries rect
+ *   3. zoom-end — commit + zoom-area; carries rect
+ *   4. end-area — commit + any other tool (clear draft + cancel-area, no emit)
+ *
+ * Host on keep-second-corner: brushRect = action.corners, announce, no cancel-area.
+ * Host on select-end/zoom-end/end-area: brushRect=null, cancel-area; emit/apply
+ * using action.rect when present.
+ *
+ * Keyboard complete-area always supplies `kind: "commit"` (no free-corner
+ * too-small evaluation); pointer uses `evaluatePointerBrushEnd` first.
+ */
+export function resolveFinishBrushAction(input: {
+  readonly ended: FinishBrushEnded;
+  readonly activeTool: InteractionTool;
+}): FinishBrushAction {
+  if (input.ended.kind === "too-small") {
+    return { type: "keep-second-corner", corners: input.ended.corners };
+  }
+  if (input.activeTool === "select-area") {
+    return { type: "select-end", rect: input.ended.rect };
+  }
+  if (input.activeTool === "zoom-area") {
+    return { type: "zoom-end", rect: input.ended.rect };
+  }
+  return { type: "end-area" };
+}

--- a/packages/svelte/src/lib/plot-surface-keyboard.ts
+++ b/packages/svelte/src/lib/plot-surface-keyboard.ts
@@ -1,18 +1,25 @@
 import { isAreaTool, type InteractionTool } from "./interaction.js";
-import { panelCenterAnchor, type PlotPoint } from "./plot-area-brush.js";
-import type { PanelBounds } from "./plot-geometry.js";
+import { panelCenterAnchor, type BrushCorners, type PlotPoint } from "./plot-area-brush.js";
+import { normalizedRect, type PanelBounds } from "./plot-geometry.js";
+import { resolveFinishBrushAction, type FinishBrushAction } from "./plot-brush-finish.js";
 
 /**
- * Capture-surface keyboard decision input. `hasBrushDraft` mirrors
- * `brushRect !== null` in GGPlot — distinct from reducer `brushing`, which can
- * diverge when the draft corners and area machine are out of sync.
+ * Capture-surface keyboard decision input.
+ *
+ * `brushCorners` is the sole draft source of truth (host: `brushRect`).
+ * Distinct from reducer `brushing`, which can diverge when the draft corners
+ * and area machine are out of sync. Null means no draft — no separate
+ * `hasBrushDraft` boolean so illegal combos are unrepresentable.
  */
 export type SurfaceKeyboardInput = {
   readonly key: string;
   readonly shiftKey: boolean;
   readonly activeTool: InteractionTool;
-  /** True when a brush draft corner exists (`brushRect !== null`). */
-  readonly hasBrushDraft: boolean;
+  /**
+   * Host: `brushRect`. Non-null when a draft free corner exists.
+   * Gates nudge-brush, complete-area, and Escape returnToInspect.
+   */
+  readonly brushCorners: BrushCorners | null;
   readonly hasInspection: boolean;
   readonly pinEnabled: boolean;
   /**
@@ -47,10 +54,12 @@ type SurfaceKeyAction =
     }
   | {
       /**
-       * Host: normalize brush rect, then `resolveFinishBrushAction` owns
-       * select-end vs zoom-end (single pure owner with pointer finish-brush).
+       * Pure table owns normalize + select/zoom/end routing (shared finish
+       * owner with pointer). Keyboard always commits the current draft
+       * (`kind: "commit"`) — no free-corner too-small evaluation.
        */
       readonly type: "complete-area";
+      readonly finish: FinishBrushAction;
     }
   | { readonly type: "cycle-coincident"; readonly delta: 1 | -1 }
   | {
@@ -83,7 +92,7 @@ export function resolveSurfaceKeyAction(input: SurfaceKeyboardInput): SurfaceKey
     key,
     shiftKey,
     activeTool,
-    hasBrushDraft,
+    brushCorners,
     hasInspection,
     pinEnabled,
     focusKey,
@@ -92,8 +101,9 @@ export function resolveSurfaceKeyAction(input: SurfaceKeyboardInput): SurfaceKey
     firstPanel,
   } = input;
   const area = isAreaTool(activeTool);
+  const hasDraft = brushCorners !== null;
 
-  if (area && key.startsWith("Arrow") && hasBrushDraft) {
+  if (area && key.startsWith("Arrow") && hasDraft) {
     const step = shiftKey ? 10 : 1;
     const dx = key === "ArrowLeft" ? -step : key === "ArrowRight" ? step : 0;
     const dy = key === "ArrowUp" ? -step : key === "ArrowDown" ? step : 0;
@@ -106,12 +116,21 @@ export function resolveSurfaceKeyAction(input: SurfaceKeyboardInput): SurfaceKey
   if (area && (key === "Enter" || key === " ")) {
     return {
       preventDefault: true,
-      action: hasBrushDraft
-        ? { type: "complete-area" }
-        : {
-            type: "begin-area",
-            anchor: inspectionAnchor ?? panelCenterAnchor(firstPanel),
-          },
+      action:
+        brushCorners !== null
+          ? {
+              type: "complete-area",
+              // Keyboard commits the live draft as-is (no free-corner update).
+              // Zero-size drafts still route as commit → select/zoom/end-area.
+              finish: resolveFinishBrushAction({
+                ended: { kind: "commit", rect: normalizedRect(brushCorners) },
+                activeTool,
+              }),
+            }
+          : {
+              type: "begin-area",
+              anchor: inspectionAnchor ?? panelCenterAnchor(firstPanel),
+            },
     };
   }
 
@@ -155,7 +174,7 @@ export function resolveSurfaceKeyAction(input: SurfaceKeyboardInput): SurfaceKey
       preventDefault: true,
       action: {
         type: "escape",
-        returnToInspect: !hasBrushDraft && area,
+        returnToInspect: !hasDraft && area,
       },
     };
   }

--- a/packages/svelte/src/lib/plot-surface-keyboard.ts
+++ b/packages/svelte/src/lib/plot-surface-keyboard.ts
@@ -117,8 +117,12 @@ export function resolveSurfaceKeyAction(input: SurfaceKeyboardInput): SurfaceKey
     return {
       preventDefault: true,
       action:
-        brushCorners !== null
+        brushCorners === null
           ? {
+              type: "begin-area",
+              anchor: inspectionAnchor ?? panelCenterAnchor(firstPanel),
+            }
+          : {
               type: "complete-area",
               // Keyboard commits the live draft as-is (no free-corner update).
               // Zero-size drafts still route as commit → select/zoom/end-area.
@@ -126,10 +130,6 @@ export function resolveSurfaceKeyAction(input: SurfaceKeyboardInput): SurfaceKey
                 ended: { kind: "commit", rect: normalizedRect(brushCorners) },
                 activeTool,
               }),
-            }
-          : {
-              type: "begin-area",
-              anchor: inspectionAnchor ?? panelCenterAnchor(firstPanel),
             },
     };
   }

--- a/packages/svelte/src/lib/plot-surface-pointer.ts
+++ b/packages/svelte/src/lib/plot-surface-pointer.ts
@@ -1,5 +1,4 @@
 import { isAreaTool, type InteractionTool } from "./interaction.js";
-import type { PlotRect } from "./plot-geometry.js";
 
 /**
  * Capture-surface pointer decision input for pointerdown.
@@ -273,53 +272,6 @@ export function shouldClearInspectionOnPointerLeave(input: {
   readonly tooltipHovered: boolean;
 }): boolean {
   return !input.brushing && !input.tooltipHovered;
-}
-
-/**
- * Matches `PointerBrushEnd` from plot-area-brush without importing that module
- * (local mirror; plot-area-brush does not import this file — no cycle risk,
- * but keep the payload shape self-contained for the pure pointer table).
- */
-export type FinishBrushEnded =
-  | { readonly kind: "too-small"; readonly corners: PlotRect }
-  | { readonly kind: "commit"; readonly rect: PlotRect };
-
-export type FinishBrushAction =
-  | { readonly type: "keep-second-corner"; readonly corners: PlotRect }
-  | { readonly type: "select-end"; readonly rect: PlotRect }
-  | { readonly type: "zoom-end"; readonly rect: PlotRect }
-  | { readonly type: "end-area" };
-
-/**
- * Pure routing after `evaluatePointerBrushEnd` for pointerup finish-brush.
- *
- * Takes the full ended discriminant so actions carry rect/corners payloads —
- * host must not re-narrow `ended.kind` for emit/apply.
- *
- * Priority:
- *   1. keep-second-corner — too-small (wins for any tool); carries corners
- *   2. select-end — commit + select-area; carries rect
- *   3. zoom-end — commit + zoom-area; carries rect
- *   4. end-area — commit + any other tool (clear draft + cancel-area, no emit)
- *
- * Host on keep-second-corner: brushRect = action.corners, announce, no cancel-area.
- * Host on select-end/zoom-end/end-area: brushRect=null, cancel-area; emit/apply
- * using action.rect when present. Host keeps `brushRect === null` defensive break.
- */
-export function resolveFinishBrushAction(input: {
-  readonly ended: FinishBrushEnded;
-  readonly activeTool: InteractionTool;
-}): FinishBrushAction {
-  if (input.ended.kind === "too-small") {
-    return { type: "keep-second-corner", corners: input.ended.corners };
-  }
-  if (input.activeTool === "select-area") {
-    return { type: "select-end", rect: input.ended.rect };
-  }
-  if (input.activeTool === "zoom-area") {
-    return { type: "zoom-end", rect: input.ended.rect };
-  }
-  return { type: "end-area" };
 }
 
 // ---- lost pointer capture ----

--- a/packages/svelte/tests/plot-brush-finish.test.ts
+++ b/packages/svelte/tests/plot-brush-finish.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import type { InteractionTool } from "../src/lib/interaction.js";
+import { resolveFinishBrushAction } from "../src/lib/plot-brush-finish.js";
+
+describe("resolveFinishBrushAction", () => {
+  const corners = { x0: 1, y0: 2, x1: 3, y1: 4 } as const;
+  const rect = { x0: 10, y0: 20, x1: 40, y1: 50 } as const;
+  const tooSmall = { kind: "too-small" as const, corners };
+  const commit = { kind: "commit" as const, rect };
+
+  it("keeps second corner with payload on too-small for any tool", () => {
+    for (const activeTool of [
+      "select-area",
+      "zoom-area",
+      "inspect",
+      "point",
+    ] as const satisfies readonly InteractionTool[]) {
+      expect(resolveFinishBrushAction({ ended: tooSmall, activeTool })).toEqual({
+        type: "keep-second-corner",
+        corners,
+      });
+    }
+  });
+
+  it("routes commit + select-area to select-end with rect payload", () => {
+    expect(resolveFinishBrushAction({ ended: commit, activeTool: "select-area" })).toEqual({
+      type: "select-end",
+      rect,
+    });
+  });
+
+  it("routes commit + zoom-area to zoom-end with rect payload", () => {
+    expect(resolveFinishBrushAction({ ended: commit, activeTool: "zoom-area" })).toEqual({
+      type: "zoom-end",
+      rect,
+    });
+  });
+
+  it("routes commit + non-area tools to end-area (clear draft, no emit)", () => {
+    expect(resolveFinishBrushAction({ ended: commit, activeTool: "inspect" })).toEqual({
+      type: "end-area",
+    });
+    expect(resolveFinishBrushAction({ ended: commit, activeTool: "point" })).toEqual({
+      type: "end-area",
+    });
+  });
+});

--- a/packages/svelte/tests/plot-surface-keyboard.test.ts
+++ b/packages/svelte/tests/plot-surface-keyboard.test.ts
@@ -1,16 +1,23 @@
 import { describe, expect, it } from "vitest";
 
 import type { InteractionTool } from "../src/lib/interaction.js";
+import type { BrushCorners } from "../src/lib/plot-area-brush.js";
 import {
   resolveSurfaceKeyAction,
   type SurfaceKeyboardInput,
 } from "../src/lib/plot-surface-keyboard.js";
 
+const draft: BrushCorners = { x0: 10, y0: 20, x1: 40, y1: 50 };
+/** Reversed corners — pure table must normalize before finish routing. */
+const reversedDraft: BrushCorners = { x0: 40, y0: 50, x1: 10, y1: 20 };
+/** Zero-size draft — keyboard still commits (no too-small evaluation). */
+const zeroDraft: BrushCorners = { x0: 5, y0: 5, x1: 5, y1: 5 };
+
 const base = (
   overrides: Partial<SurfaceKeyboardInput> & Pick<SurfaceKeyboardInput, "key" | "activeTool">,
 ): SurfaceKeyboardInput => ({
   shiftKey: false,
-  hasBrushDraft: false,
+  brushCorners: null,
   hasInspection: false,
   pinEnabled: false,
   // Meaningful only when hasInspection (toggle-point-keys); unused otherwise.
@@ -29,7 +36,7 @@ describe("resolveSurfaceKeyAction", () => {
       (tool) => {
         expect(
           resolveSurfaceKeyAction(
-            base({ key: "ArrowRight", activeTool: tool, hasBrushDraft: true }),
+            base({ key: "ArrowRight", activeTool: tool, brushCorners: draft }),
           ),
         ).toEqual({
           preventDefault: true,
@@ -41,7 +48,7 @@ describe("resolveSurfaceKeyAction", () => {
               key: "ArrowUp",
               shiftKey: true,
               activeTool: tool,
-              hasBrushDraft: true,
+              brushCorners: draft,
             }),
           ),
         ).toEqual({
@@ -57,7 +64,7 @@ describe("resolveSurfaceKeyAction", () => {
           base({
             key: "ArrowDiagonal",
             activeTool: "select-area",
-            hasBrushDraft: true,
+            brushCorners: draft,
           }),
         ),
       ).toEqual({
@@ -66,26 +73,83 @@ describe("resolveSurfaceKeyAction", () => {
       });
     });
 
-    it("area Enter/Space with draft completes the brush (finish owned by resolveFinishBrushAction)", () => {
+    it("select-area Enter completes with select-end finish (normalized rect)", () => {
       expect(
         resolveSurfaceKeyAction(
           base({
             key: "Enter",
             activeTool: "select-area",
-            hasBrushDraft: true,
+            brushCorners: draft,
             hasInspection: true,
             pinEnabled: true,
           }),
         ),
       ).toEqual({
         preventDefault: true,
-        action: { type: "complete-area" },
+        action: {
+          type: "complete-area",
+          finish: {
+            type: "select-end",
+            rect: { x0: 10, y0: 20, x1: 40, y1: 50 },
+          },
+        },
       });
+    });
+
+    it("zoom-area Space completes with zoom-end finish", () => {
       expect(
-        resolveSurfaceKeyAction(base({ key: " ", activeTool: "zoom-area", hasBrushDraft: true })),
+        resolveSurfaceKeyAction(base({ key: " ", activeTool: "zoom-area", brushCorners: draft })),
       ).toEqual({
         preventDefault: true,
-        action: { type: "complete-area" },
+        action: {
+          type: "complete-area",
+          finish: {
+            type: "zoom-end",
+            rect: { x0: 10, y0: 20, x1: 40, y1: 50 },
+          },
+        },
+      });
+    });
+
+    it("normalizes reversed corners before finish routing", () => {
+      expect(
+        resolveSurfaceKeyAction(
+          base({
+            key: "Enter",
+            activeTool: "select-area",
+            brushCorners: reversedDraft,
+          }),
+        ),
+      ).toEqual({
+        preventDefault: true,
+        action: {
+          type: "complete-area",
+          finish: {
+            type: "select-end",
+            rect: { x0: 10, y0: 20, x1: 40, y1: 50 },
+          },
+        },
+      });
+    });
+
+    it("keyboard commits zero-size drafts (no too-small evaluation)", () => {
+      expect(
+        resolveSurfaceKeyAction(
+          base({
+            key: "Enter",
+            activeTool: "select-area",
+            brushCorners: zeroDraft,
+          }),
+        ),
+      ).toEqual({
+        preventDefault: true,
+        action: {
+          type: "complete-area",
+          finish: {
+            type: "select-end",
+            rect: { x0: 5, y0: 5, x1: 5, y1: 5 },
+          },
+        },
       });
     });
   });
@@ -230,7 +294,7 @@ describe("resolveSurfaceKeyAction", () => {
           base({
             key: "Enter",
             activeTool: "select-area",
-            hasBrushDraft: false,
+            brushCorners: null,
             hasInspection: true,
             pinEnabled: true,
           }),
@@ -253,7 +317,7 @@ describe("resolveSurfaceKeyAction", () => {
           base({
             key: "Escape",
             activeTool: "zoom-area",
-            hasBrushDraft: true,
+            brushCorners: draft,
           }),
         ),
       ).toEqual({
@@ -291,7 +355,7 @@ describe("resolveSurfaceKeyAction", () => {
               base({
                 key,
                 activeTool,
-                hasBrushDraft: true,
+                brushCorners: draft,
                 hasInspection: true,
                 pinEnabled: true,
               }),

--- a/packages/svelte/tests/plot-surface-pointer.test.ts
+++ b/packages/svelte/tests/plot-surface-pointer.test.ts
@@ -8,7 +8,6 @@ import {
   advanceTouchInspectMoved,
   interactionSourceFromPointerType,
   resolveCaptureClickAction,
-  resolveFinishBrushAction,
   isAreaAwaitingSecond,
   isAreaBrushing,
   resolveLostPointerCaptureAction,
@@ -553,50 +552,6 @@ describe("shouldClearInspectionOnPointerLeave", () => {
     expect(shouldClearInspectionOnPointerLeave({ brushing: true, tooltipHovered: true })).toBe(
       false,
     );
-  });
-});
-
-describe("resolveFinishBrushAction", () => {
-  const corners = { x0: 1, y0: 2, x1: 3, y1: 4 } as const;
-  const rect = { x0: 10, y0: 20, x1: 40, y1: 50 } as const;
-  const tooSmall = { kind: "too-small" as const, corners };
-  const commit = { kind: "commit" as const, rect };
-
-  it("keeps second corner with payload on too-small for any tool", () => {
-    for (const activeTool of [
-      "select-area",
-      "zoom-area",
-      "inspect",
-      "point",
-    ] as const satisfies readonly InteractionTool[]) {
-      expect(resolveFinishBrushAction({ ended: tooSmall, activeTool })).toEqual({
-        type: "keep-second-corner",
-        corners,
-      });
-    }
-  });
-
-  it("routes commit + select-area to select-end with rect payload", () => {
-    expect(resolveFinishBrushAction({ ended: commit, activeTool: "select-area" })).toEqual({
-      type: "select-end",
-      rect,
-    });
-  });
-
-  it("routes commit + zoom-area to zoom-end with rect payload", () => {
-    expect(resolveFinishBrushAction({ ended: commit, activeTool: "zoom-area" })).toEqual({
-      type: "zoom-end",
-      rect,
-    });
-  });
-
-  it("routes commit + non-area tools to end-area (clear draft, no emit)", () => {
-    expect(resolveFinishBrushAction({ ended: commit, activeTool: "inspect" })).toEqual({
-      type: "end-area",
-    });
-    expect(resolveFinishBrushAction({ ended: commit, activeTool: "point" })).toEqual({
-      type: "end-area",
-    });
   });
 });
 


### PR DESCRIPTION
## Summary

- Collapse keyboard draft tracking from `hasBrushDraft` into `brushCorners: BrushCorners | null` so illegal draft combos are unrepresentable.
- Move `resolveFinishBrushAction` into shared `plot-brush-finish` (keyboard + pointer finish owner).
- Expand `complete-area` to carry a pure `finish` payload (normalize + select/zoom/end routing); GGPlot only applies via `applyFinishBrush`.
- Keyboard still commits the live draft without free-corner too-small evaluation (documented in tests).

## Test plan

- [x] `vitest run` plot-surface-keyboard / plot-brush-finish / plot-surface-pointer
- [x] svelte-check clean
- [x] Pre-push hooks (build, type-aware oxlint, knip, bun test)
- [ ] CI on PR