### PR TITLE
refactor(core): split candidate resolve, segments, assemble, and finalize

### DIFF
--- a/packages/core/src/pipeline/assemble-render-model-scales.ts
+++ b/packages/core/src/pipeline/assemble-render-model-scales.ts
@@ -1,0 +1,50 @@
+/**
+ * Build RenderModel.scales and axisFormatters from trained state.
+ */
+import type { TickFormatter } from "../layout/layout.js";
+import type { ScaleState } from "../scales/state.js";
+import type { PositionScale } from "../scales/train.js";
+
+import { makeAxisValueFormatter } from "./layout-helpers.js";
+import type { RenderModel, ResolvedColorScale } from "./types.js";
+
+export function buildRenderModelScaleState(
+  colorState: ScaleState | null,
+  fillState: ScaleState | null,
+): Record<string, ScaleState> {
+  const state: Record<string, ScaleState> = {};
+  if (colorState !== null) state["color"] = colorState;
+  if (fillState !== null) state["fill"] = fillState;
+  return state;
+}
+
+export function buildRenderModelScales(input: {
+  xScale: PositionScale;
+  yScale: PositionScale;
+  color: ResolvedColorScale | null;
+  fill: ResolvedColorScale | null;
+  panelScales: { x: PositionScale; y: PositionScale }[];
+  colorState: ScaleState | null;
+  fillState: ScaleState | null;
+}): RenderModel["scales"] {
+  return {
+    x: input.xScale,
+    y: input.yScale,
+    color: input.color,
+    fill: input.fill,
+    panels: input.panelScales,
+    state: buildRenderModelScaleState(input.colorState, input.fillState),
+  };
+}
+
+export function buildRenderModelAxisFormatters(
+  xScale: PositionScale,
+  yScale: PositionScale,
+  formatX: TickFormatter | undefined,
+  formatY: TickFormatter | undefined,
+): RenderModel["axisFormatters"] {
+  return Object.freeze({
+    x: makeAxisValueFormatter(xScale, formatX),
+    y: makeAxisValueFormatter(yScale, formatY),
+  });
+}

--- a/packages/core/src/pipeline/assemble-render-model.ts
+++ b/packages/core/src/pipeline/assemble-render-model.ts
@@ -10,8 +10,11 @@ import type { ColumnTable } from "../table.js";
 import type { CandidateStore } from "../candidate-store.js";
 import type { LineageStore } from "../identity.js";
 
+import {
+  buildRenderModelAxisFormatters,
+  buildRenderModelScales,
+} from "./assemble-render-model-scales.js";
 import { createRenderModelLifecycle } from "./assemble-render-model-lifecycle.js";
-import { makeAxisValueFormatter } from "./layout-helpers.js";
 import type {
   Advisory,
   LayerBackend,
@@ -46,10 +49,6 @@ export function assembleRenderModel(input: {
   formatY: TickFormatter | undefined;
   table: ColumnTable;
 }): RenderModel {
-  const state: Record<string, ScaleState> = {};
-  if (input.colorState !== null) state["color"] = input.colorState;
-  if (input.fillState !== null) state["fill"] = input.fillState;
-
   const { scene, candidates } = input;
   const lifecycle = createRenderModelLifecycle({
     scene,
@@ -59,14 +58,7 @@ export function assembleRenderModel(input: {
 
   return {
     scene,
-    scales: {
-      x: input.xScale,
-      y: input.yScale,
-      color: input.color,
-      fill: input.fill,
-      panels: input.panelScales,
-      state,
-    },
+    scales: buildRenderModelScales(input),
     warnings: dedupeWarnings(input.warnings),
     advisories: dedupeAdvisories(input.advisories),
     runId: input.runId,
@@ -79,10 +71,12 @@ export function assembleRenderModel(input: {
     }),
     lineage: input.lineage,
     candidates,
-    axisFormatters: Object.freeze({
-      x: makeAxisValueFormatter(input.xScale, input.formatX),
-      y: makeAxisValueFormatter(input.yScale, input.formatY),
-    }),
+    axisFormatters: buildRenderModelAxisFormatters(
+      input.xScale,
+      input.yScale,
+      input.formatX,
+      input.formatY,
+    ),
     row: lifecycle.row,
     dispose: lifecycle.dispose,
   };

--- a/packages/core/src/pipeline/build-candidates-datum-ctx.ts
+++ b/packages/core/src/pipeline/build-candidates-datum-ctx.ts
@@ -1,0 +1,24 @@
+/**
+ * Shared context for identity-indexed candidate resolution.
+ */
+import type { LineageStore } from "../identity.js";
+import type { Scene } from "../scene.js";
+import type { ColumnTable } from "../table.js";
+
+import type { CandidateIdentityIndex } from "./build-candidates-identity.js";
+import type { FacetPanelDef } from "./facets.js";
+import type { MappedField } from "./types.js";
+import type { LayerBinding, LayerFrame, ResolvedColorScale } from "./types.js";
+
+export interface IdentityCandidateResolveContext {
+  scene: Scene;
+  bindings: readonly LayerBinding[];
+  panelFrames: readonly (readonly LayerFrame[])[];
+  facetPanels: readonly FacetPanelDef[];
+  table: ColumnTable;
+  layerFields: readonly MappedField[][];
+  color: ResolvedColorScale | null;
+  fill: ResolvedColorScale | null;
+  lineage: LineageStore<number>;
+  getIdentityIndex: () => CandidateIdentityIndex;
+}

--- a/packages/core/src/pipeline/build-candidates-datum-locate.ts
+++ b/packages/core/src/pipeline/build-candidates-datum-locate.ts
@@ -1,0 +1,70 @@
+/**
+ * Locate frame/batch context for one identity-indexed candidate fact.
+ */
+import type { CandidateBuildFacts } from "../candidate-store.js";
+import type { CellValue } from "../table.js";
+
+import type { IdentityCandidateResolveContext } from "./build-candidates-datum-ctx.js";
+import { resolveOutlierContext } from "./build-candidates-datum-context.js";
+import {
+  makeSourceValueLookup,
+  resolveCandidateFieldChannels,
+} from "./build-candidates-datum-fields.js";
+import { resolveCandidateFrameRow } from "./build-candidates-frame-row.js";
+import type { LayerFrame } from "./types.js";
+
+export interface LocatedIdentityCandidate {
+  sourceRow: number | null;
+  frame: LayerFrame | undefined;
+  outlierSourceRow: number | null;
+  frameRow: number;
+  derivedGroup: number;
+  sourceValue: (field: string | undefined) => CellValue;
+  xField: string | undefined;
+  yField: string | undefined;
+  colorField: string | undefined;
+  fillField: string | undefined;
+  seriesByRow: Map<string, number>;
+  sourceRowsByGroup: Map<string, number[]>;
+}
+
+export function locateIdentityCandidate(
+  ctx: IdentityCandidateResolveContext,
+  facts: CandidateBuildFacts,
+): LocatedIdentityCandidate {
+  const { seriesByRow, sourceRowsByGroup, frameGroups } = ctx.getIdentityIndex();
+  const fields = ctx.layerFields[facts.layerIndex] ?? [];
+  const sourceRow = facts.rowIndex;
+  const frame = ctx.panelFrames[facts.panelIndex]?.[facts.layerIndex];
+  const batch = ctx.scene.batches[facts.batchIndex]!;
+  const { outlierLocalRow, outlierSourceRow } = resolveOutlierContext({
+    frame,
+    batch,
+    primitiveIndex: facts.primitiveIndex,
+    facetPanel: ctx.facetPanels[facts.panelIndex],
+  });
+  const orderedGroups = frameGroups.get(`${facts.panelIndex}:${facts.layerIndex}`) ?? [0];
+  const { frameRow, derivedGroup } = resolveCandidateFrameRow({
+    frame,
+    batch,
+    primitiveIndex: facts.primitiveIndex,
+    orderedGroups,
+    outlierLocalRow,
+  });
+  const sourceValue = makeSourceValueLookup(ctx.table, sourceRow);
+  const { xField, yField, colorField, fillField } = resolveCandidateFieldChannels(fields);
+  return {
+    sourceRow,
+    frame,
+    outlierSourceRow,
+    frameRow,
+    derivedGroup,
+    sourceValue,
+    xField,
+    yField,
+    colorField,
+    fillField,
+    seriesByRow,
+    sourceRowsByGroup,
+  };
+}

--- a/packages/core/src/pipeline/build-candidates-datum-resolve.ts
+++ b/packages/core/src/pipeline/build-candidates-datum-resolve.ts
@@ -2,68 +2,39 @@
  * Resolve one identity-indexed candidate datum from scene/frame/index context.
  */
 import type { CandidateBuildFacts, CandidateDatum } from "../candidate-store.js";
-import type { LineageStore } from "../identity.js";
-import type { Scene } from "../scene.js";
-import type { ColumnTable } from "../table.js";
 
-import {
-  resolveAnnotationIntercepts,
-  resolveOutlierContext,
-} from "./build-candidates-datum-context.js";
-import {
-  makeSourceValueLookup,
-  resolveCandidateFieldChannels,
-} from "./build-candidates-datum-fields.js";
+import type { IdentityCandidateResolveContext } from "./build-candidates-datum-ctx.js";
+import { resolveAnnotationIntercepts } from "./build-candidates-datum-context.js";
+import { locateIdentityCandidate } from "./build-candidates-datum-locate.js";
 import {
   resolveCandidateSeries,
   resolveRepresentedSourceRows,
 } from "./build-candidates-datum-series.js";
 import { resolveCandidateLogicalValues } from "./build-candidates-datum-values.js";
-import { resolveCandidateFrameRow } from "./build-candidates-frame-row.js";
-import type { CandidateIdentityIndex } from "./build-candidates-identity.js";
-import type { FacetPanelDef } from "./facets.js";
 import { candidateAutoMode } from "./frame.js";
-import type { MappedField } from "./types.js";
-import type { LayerBinding, LayerFrame, ResolvedColorScale } from "./types.js";
 
-export interface IdentityCandidateResolveContext {
-  scene: Scene;
-  bindings: readonly LayerBinding[];
-  panelFrames: readonly (readonly LayerFrame[])[];
-  facetPanels: readonly FacetPanelDef[];
-  table: ColumnTable;
-  layerFields: readonly MappedField[][];
-  color: ResolvedColorScale | null;
-  fill: ResolvedColorScale | null;
-  lineage: LineageStore<number>;
-  getIdentityIndex: () => CandidateIdentityIndex;
-}
+export type { IdentityCandidateResolveContext } from "./build-candidates-datum-ctx.js";
 
 export function resolveIdentityCandidateDatum(
   ctx: IdentityCandidateResolveContext,
   facts: CandidateBuildFacts,
 ): CandidateDatum {
-  const { seriesByRow, sourceRowsByGroup, frameGroups } = ctx.getIdentityIndex();
-  const fields = ctx.layerFields[facts.layerIndex] ?? [];
-  const sourceRow = facts.rowIndex;
-  const frame = ctx.panelFrames[facts.panelIndex]?.[facts.layerIndex];
-  const batch = ctx.scene.batches[facts.batchIndex]!;
-  const { outlierLocalRow, outlierSourceRow } = resolveOutlierContext({
+  const located = locateIdentityCandidate(ctx, facts);
+  const {
+    sourceRow,
     frame,
-    batch,
-    primitiveIndex: facts.primitiveIndex,
-    facetPanel: ctx.facetPanels[facts.panelIndex],
-  });
-  const orderedGroups = frameGroups.get(`${facts.panelIndex}:${facts.layerIndex}`) ?? [0];
-  const { frameRow, derivedGroup } = resolveCandidateFrameRow({
-    frame,
-    batch,
-    primitiveIndex: facts.primitiveIndex,
-    orderedGroups,
-    outlierLocalRow,
-  });
-  const sourceValue = makeSourceValueLookup(ctx.table, sourceRow);
-  const { xField, yField, colorField, fillField } = resolveCandidateFieldChannels(fields);
+    outlierSourceRow,
+    frameRow,
+    derivedGroup,
+    sourceValue,
+    xField,
+    yField,
+    colorField,
+    fillField,
+    seriesByRow,
+    sourceRowsByGroup,
+  } = located;
+
   const { group, seriesRank } = resolveCandidateSeries({
     sourceRow,
     derivedGroup,

--- a/packages/core/src/pipeline/build-candidates-identity-store.ts
+++ b/packages/core/src/pipeline/build-candidates-identity-store.ts
@@ -1,0 +1,69 @@
+/**
+ * Identity-indexed candidate store (stat/annotation layers with lineage).
+ */
+import { buildCandidateStore } from "../candidate-store.js";
+import type { CandidateStore } from "../candidate-store.js";
+import type { LineageStore } from "../identity.js";
+import type { Scene } from "../scene.js";
+import type { ColumnTable } from "../table.js";
+
+import { createIdentityCandidateDatumResolver } from "./build-candidates-datum.js";
+import {
+  buildCandidateIdentityIndex,
+  type CandidateIdentityIndex,
+} from "./build-candidates-identity.js";
+import type { FacetPanelDef } from "./facets.js";
+import type { MappedField } from "./types.js";
+import type { LayerBinding, LayerFrame, ResolvedColorScale } from "./types.js";
+
+export function buildIdentityIndexedCandidates(input: {
+  scene: Scene;
+  runId: number;
+  flip: boolean;
+  bindings: readonly LayerBinding[];
+  panelFrames: readonly (readonly LayerFrame[])[];
+  facetPanels: readonly FacetPanelDef[];
+  table: ColumnTable;
+  layerFields: readonly MappedField[][];
+  color: ResolvedColorScale | null;
+  fill: ResolvedColorScale | null;
+  lineage: LineageStore<number>;
+}): CandidateStore {
+  const {
+    scene,
+    runId,
+    flip,
+    bindings,
+    panelFrames,
+    facetPanels,
+    table,
+    layerFields,
+    color,
+    fill,
+    lineage,
+  } = input;
+
+  let identityIndex: CandidateIdentityIndex | null = null;
+  const getIdentityIndex = () => {
+    if (identityIndex !== null) return identityIndex;
+    identityIndex = buildCandidateIdentityIndex(panelFrames, facetPanels);
+    return identityIndex;
+  };
+
+  return buildCandidateStore(scene, {
+    epoch: runId,
+    flip,
+    datum: createIdentityCandidateDatumResolver({
+      scene,
+      bindings,
+      panelFrames,
+      facetPanels,
+      table,
+      layerFields,
+      color,
+      fill,
+      lineage,
+      getIdentityIndex,
+    }),
+  });
+}

--- a/packages/core/src/pipeline/build-candidates.ts
+++ b/packages/core/src/pipeline/build-candidates.ts
@@ -3,17 +3,12 @@
  * Source-backed layers use the cheap raw resolver; stat/annotation layers use
  * the identity-indexed path that reconstructs represented source rows.
  */
-import { buildCandidateStore } from "../candidate-store.js";
 import type { CandidateStore } from "../candidate-store.js";
 import type { LineageStore } from "../identity.js";
 import type { Scene } from "../scene.js";
 import type { ColumnTable } from "../table.js";
 
-import { createIdentityCandidateDatumResolver } from "./build-candidates-datum.js";
-import {
-  buildCandidateIdentityIndex,
-  type CandidateIdentityIndex,
-} from "./build-candidates-identity.js";
+import { buildIdentityIndexedCandidates } from "./build-candidates-identity-store.js";
 import {
   buildSourceBackedCandidates,
   isAllSourceBacked,
@@ -35,54 +30,8 @@ export function buildPipelineCandidates(input: {
   fill: ResolvedColorScale | null;
   lineage: LineageStore<number>;
 }): CandidateStore {
-  const {
-    scene,
-    runId,
-    flip,
-    bindings,
-    panelFrames,
-    facetPanels,
-    table,
-    layerFields,
-    color,
-    fill,
-    lineage,
-  } = input;
-
-  if (isAllSourceBacked(bindings)) {
-    return buildSourceBackedCandidates({
-      scene,
-      runId,
-      flip,
-      bindings,
-      table,
-      color,
-      fill,
-      lineage,
-    });
+  if (isAllSourceBacked(input.bindings)) {
+    return buildSourceBackedCandidates(input);
   }
-
-  let identityIndex: CandidateIdentityIndex | null = null;
-  const getIdentityIndex = () => {
-    if (identityIndex !== null) return identityIndex;
-    identityIndex = buildCandidateIdentityIndex(panelFrames, facetPanels);
-    return identityIndex;
-  };
-
-  return buildCandidateStore(scene, {
-    epoch: runId,
-    flip,
-    datum: createIdentityCandidateDatumResolver({
-      scene,
-      bindings,
-      panelFrames,
-      facetPanels,
-      table,
-      layerFields,
-      color,
-      fill,
-      lineage,
-      getIdentityIndex,
-    }),
-  });
+  return buildIdentityIndexedCandidates(input);
 }

--- a/packages/core/src/pipeline/finalize-model-candidates.ts
+++ b/packages/core/src/pipeline/finalize-model-candidates.ts
@@ -1,0 +1,38 @@
+/**
+ * Build lineage store + interaction candidates during finalize.
+ */
+import { LineageStore } from "../identity.js";
+import type { Scene } from "../scene.js";
+import type { CandidateStore } from "../candidate-store.js";
+
+import { buildPipelineCandidates } from "./build-candidates.js";
+import type { PreparedPanels } from "./prepare-panels.js";
+import type { TrainedPipelineScales } from "./train-pipeline-scales.js";
+import type { LayerBinding, MappedField } from "./types.js";
+
+export function buildFinalizeCandidates(input: {
+  scene: Scene;
+  runId: number;
+  flip: boolean;
+  prepared: PreparedPanels;
+  trained: TrainedPipelineScales;
+  bindings: readonly LayerBinding[];
+  layerFields: MappedField[][];
+}): { lineage: LineageStore<number>; candidates: CandidateStore } {
+  const { scene, runId, flip, prepared, trained, bindings, layerFields } = input;
+  const lineage = new LineageStore<number>();
+  const candidates = buildPipelineCandidates({
+    scene,
+    runId,
+    flip,
+    bindings,
+    panelFrames: prepared.panelFrames,
+    facetPanels: prepared.facetPanels,
+    table: prepared.table,
+    layerFields,
+    color: trained.colorResolution.resolved,
+    fill: trained.fillResolution.resolved,
+    lineage,
+  });
+  return { lineage, candidates };
+}

--- a/packages/core/src/pipeline/finalize-model.ts
+++ b/packages/core/src/pipeline/finalize-model.ts
@@ -3,11 +3,10 @@
  */
 import type { PortableSpec } from "@ggsvelte/spec";
 
-import { LineageStore } from "../identity.js";
 import type { Scene } from "../scene.js";
 
 import { assembleRenderModel } from "./assemble-render-model.js";
-import { buildPipelineCandidates } from "./build-candidates.js";
+import { buildFinalizeCandidates } from "./finalize-model-candidates.js";
 import { resolveFinalizeContracts } from "./finalize-model-contracts.js";
 import type { PanelLayoutResult } from "./panel-layout.js";
 import type { PreparedPanels } from "./prepare-panels.js";
@@ -38,7 +37,6 @@ export function finalizeRenderModel(input: {
     warnings,
     advisories,
   } = input;
-  const { facetPanels, panelFrames, table } = prepared;
   const { xTraining, yTraining, panelScales, colorResolution, fillResolution } = trained;
 
   const contracts = resolveFinalizeContracts({
@@ -50,19 +48,14 @@ export function finalizeRenderModel(input: {
     advisories,
   });
 
-  const lineage = new LineageStore<number>();
-  const candidates = buildPipelineCandidates({
+  const { lineage, candidates } = buildFinalizeCandidates({
     scene,
     runId,
     flip,
+    prepared,
+    trained,
     bindings: contracts.bindings,
-    panelFrames,
-    facetPanels,
-    table,
     layerFields: contracts.layerFields,
-    color: colorResolution.resolved,
-    fill: fillResolution.resolved,
-    lineage,
   });
 
   return assembleRenderModel({
@@ -86,6 +79,6 @@ export function finalizeRenderModel(input: {
     candidates,
     formatX: panelLayout.formatX,
     formatY: panelLayout.formatY,
-    table,
+    table: prepared.table,
   });
 }

--- a/packages/core/src/pipeline/geometry-boxplot-body-batches-parts.ts
+++ b/packages/core/src/pipeline/geometry-boxplot-body-batches-parts.ts
@@ -1,0 +1,71 @@
+/**
+ * Boxplot body batch pieces: hinge rects, whiskers, and median segments.
+ */
+import type { GeometryBatch, RectsBatch } from "../scene.js";
+
+import type { LayerFrame, ResolvedColorScale } from "./types.js";
+import { colorOf } from "./types.js";
+import type { BoxplotBodyLayout } from "./geometry-boxplot-body-layout.js";
+
+/** Median line draws at 2× the box linewidth (ggplot2's fatten = 2). */
+export const BOX_MEDIAN_FATTEN = 2;
+
+export function makeBoxplotRectsBatch(
+  frame: LayerFrame,
+  layout: BoxplotBodyLayout,
+  fill: ResolvedColorScale | null,
+): RectsBatch {
+  const { binding } = frame;
+  const { linewidth, alpha } = layout;
+  const rectsBatchOut: RectsBatch = {
+    kind: "rects",
+    layerIndex: binding.index,
+    panelIndex: 0,
+    rects: Float32Array.from(layout.rects),
+    rowIndex: Uint32Array.from(layout.rectRows),
+    fill: binding.fill.constant,
+    fillRole: "paper",
+    stroke: null,
+    strokeWidth: linewidth,
+    alpha,
+  };
+  if (fill !== null && (frame.fillValues !== null || binding.fill.scaledConstant !== null)) {
+    rectsBatchOut.fills = layout.keptRows.map((row) =>
+      colorOf(
+        fill,
+        frame.fillValues === null ? binding.fill.scaledConstant! : frame.fillValues[row]!,
+      ),
+    );
+  }
+  return rectsBatchOut;
+}
+
+export function makeBoxplotWhiskerAndMedianBatches(
+  frame: LayerFrame,
+  layout: BoxplotBodyLayout,
+): GeometryBatch[] {
+  const { binding } = frame;
+  const { linewidth, alpha } = layout;
+  return [
+    {
+      kind: "segments",
+      layerIndex: binding.index,
+      panelIndex: 0,
+      segments: Float32Array.from(layout.whiskers),
+      rowIndex: Uint32Array.from(layout.whiskerRows),
+      stroke: null,
+      linewidth,
+      alpha,
+    },
+    {
+      kind: "segments",
+      layerIndex: binding.index,
+      panelIndex: 0,
+      segments: Float32Array.from(layout.medians),
+      rowIndex: Uint32Array.from(layout.medianRows),
+      stroke: null,
+      linewidth: linewidth * BOX_MEDIAN_FATTEN,
+      alpha,
+    },
+  ];
+}

--- a/packages/core/src/pipeline/geometry-boxplot-body-batches.ts
+++ b/packages/core/src/pipeline/geometry-boxplot-body-batches.ts
@@ -3,14 +3,14 @@
  */
 import type { BoxplotParams } from "@ggsvelte/spec";
 
-import type { GeometryBatch, RectsBatch } from "../scene.js";
+import type { GeometryBatch } from "../scene.js";
 
 import type { LayerFrame, ResolvedColorScale } from "./types.js";
-import { colorOf } from "./types.js";
 import type { BoxplotBodyLayout } from "./geometry-boxplot-body-layout.js";
-
-/** Median line draws at 2× the box linewidth (ggplot2's fatten = 2). */
-const BOX_MEDIAN_FATTEN = 2;
+import {
+  makeBoxplotRectsBatch,
+  makeBoxplotWhiskerAndMedianBatches,
+} from "./geometry-boxplot-body-batches-parts.js";
 
 export function batchesFromBoxplotBodyLayout(
   frame: LayerFrame,
@@ -23,56 +23,12 @@ export function batchesFromBoxplotBodyLayout(
   alpha: number;
   params: BoxplotParams;
 } {
-  const { binding } = frame;
   const { linewidth, alpha, params } = layout;
-
-  const rectsBatchOut: RectsBatch = {
-    kind: "rects",
-    layerIndex: binding.index,
-    panelIndex: 0,
-    rects: Float32Array.from(layout.rects),
-    rowIndex: Uint32Array.from(layout.rectRows),
-    fill: binding.fill.constant,
-    fillRole: "paper",
-    stroke: null,
-    strokeWidth: linewidth,
-    alpha,
-  };
-  if (fill !== null && (frame.fillValues !== null || binding.fill.scaledConstant !== null)) {
-    rectsBatchOut.fills = layout.keptRows.map((row) =>
-      colorOf(
-        fill,
-        frame.fillValues === null ? binding.fill.scaledConstant! : frame.fillValues[row]!,
-      ),
-    );
-  }
-
-  const batches: GeometryBatch[] = [
-    {
-      kind: "segments",
-      layerIndex: binding.index,
-      panelIndex: 0,
-      segments: Float32Array.from(layout.whiskers),
-      rowIndex: Uint32Array.from(layout.whiskerRows),
-      stroke: null,
-      linewidth,
-      alpha,
-    },
-    rectsBatchOut,
-    {
-      kind: "segments",
-      layerIndex: binding.index,
-      panelIndex: 0,
-      segments: Float32Array.from(layout.medians),
-      rowIndex: Uint32Array.from(layout.medianRows),
-      stroke: null,
-      linewidth: linewidth * BOX_MEDIAN_FATTEN,
-      alpha,
-    },
-  ];
+  const [whiskers, medians] = makeBoxplotWhiskerAndMedianBatches(frame, layout);
+  const rects = makeBoxplotRectsBatch(frame, layout, fill);
 
   return {
-    batches,
+    batches: [whiskers!, rects, medians!],
     centerPx: layout.centerPx,
     linewidth,
     alpha,

--- a/packages/core/src/pipeline/geometry-errorbar-rows.ts
+++ b/packages/core/src/pipeline/geometry-errorbar-rows.ts
@@ -1,0 +1,51 @@
+/**
+ * Per-row errorbar segment emission (stem + caps).
+ */
+import type { LayerFrame, ResolvedColorScale } from "./types.js";
+import { colorOf } from "./types.js";
+import type { Frame } from "./geometry-shared.js";
+import { positionOf } from "./geometry-shared.js";
+
+export function emitErrorbarRows(input: {
+  frame: LayerFrame;
+  fx: Frame;
+  color: ResolvedColorScale | null;
+  wantsColors: boolean;
+  halfOf: (row: number) => number;
+  segments: number[];
+  rowIndex: number[];
+  strokes: string[];
+}): number {
+  const { frame, fx, color, wantsColors, halfOf, segments, rowIndex, strokes } = input;
+  const { binding, n } = frame;
+  let removed = 0;
+  for (let row = 0; row < n; row++) {
+    const tx = positionOf(fx.xScale, frame.xNumeric, frame.xValues, row);
+    const t0 = fx.yScale.normalize(frame.ymin![row]!);
+    const t1 = fx.yScale.normalize(frame.ymax![row]!);
+    if (
+      Number.isNaN(tx) ||
+      t0 === undefined ||
+      t1 === undefined ||
+      Number.isNaN(t0) ||
+      Number.isNaN(t1)
+    ) {
+      removed++;
+      continue;
+    }
+    const cx = tx * fx.innerWidth;
+    const half = halfOf(row) * fx.innerWidth;
+    const y0 = fx.innerHeight - t0 * fx.innerHeight;
+    const y1 = fx.innerHeight - t1 * fx.innerHeight;
+    segments.push(cx, y0, cx, y1, cx - half, y0, cx + half, y0, cx - half, y1, cx + half, y1);
+    const src = frame.rowIndex[row]!;
+    rowIndex.push(src, src, src);
+    if (wantsColors && color !== null) {
+      const value =
+        frame.colorValues === null ? binding.color.scaledConstant! : frame.colorValues[row]!;
+      const c = colorOf(color, value);
+      strokes.push(c, c, c);
+    }
+  }
+  return removed;
+}

--- a/packages/core/src/pipeline/geometry-errorbar.ts
+++ b/packages/core/src/pipeline/geometry-errorbar.ts
@@ -6,9 +6,9 @@ import type { ErrorbarParams } from "@ggsvelte/spec";
 import type { SegmentsBatch } from "../scene.js";
 
 import type { LayerFrame, PipelineWarning, ResolvedColorScale } from "./types.js";
-import { colorOf } from "./types.js";
 import type { Frame } from "./geometry-shared.js";
-import { DEFAULT_RULE_LINEWIDTH, positionOf, removedWarning } from "./geometry-shared.js";
+import { DEFAULT_RULE_LINEWIDTH, removedWarning } from "./geometry-shared.js";
+import { emitErrorbarRows } from "./geometry-errorbar-rows.js";
 import { makeErrorbarHalfWidth } from "./geometry-errorbar-width.js";
 
 const DEFAULT_ERRORBAR_WIDTH = 0.9;
@@ -19,7 +19,7 @@ export function errorbarBatch(
   color: ResolvedColorScale | null,
   warnings: PipelineWarning[],
 ): SegmentsBatch | null {
-  const { binding, n } = frame;
+  const { binding } = frame;
   if (frame.ymin === null || frame.ymax === null || fx.yScale.type === "band") return null;
   const params = (binding.layer.params ?? {}) as ErrorbarParams;
   const widthParam = params.width ?? DEFAULT_ERRORBAR_WIDTH;
@@ -31,29 +31,16 @@ export function errorbarBatch(
   const segments: number[] = [];
   const rowIndex: number[] = [];
   const strokes: string[] = [];
-  let removed = 0;
-  for (let row = 0; row < n; row++) {
-    const tx = positionOf(fx.xScale, frame.xNumeric, frame.xValues, row);
-    const t0 = fx.yScale.normalize(frame.ymin[row]!);
-    const t1 = fx.yScale.normalize(frame.ymax[row]!);
-    if (Number.isNaN(tx) || Number.isNaN(t0) || Number.isNaN(t1)) {
-      removed++;
-      continue;
-    }
-    const cx = tx * fx.innerWidth;
-    const half = halfOf(row) * fx.innerWidth;
-    const y0 = fx.innerHeight - t0 * fx.innerHeight;
-    const y1 = fx.innerHeight - t1 * fx.innerHeight;
-    segments.push(cx, y0, cx, y1, cx - half, y0, cx + half, y0, cx - half, y1, cx + half, y1);
-    const src = frame.rowIndex[row]!;
-    rowIndex.push(src, src, src);
-    if (wantsColors) {
-      const value =
-        frame.colorValues === null ? binding.color.scaledConstant! : frame.colorValues[row]!;
-      const c = colorOf(color, value);
-      strokes.push(c, c, c);
-    }
-  }
+  const removed = emitErrorbarRows({
+    frame,
+    fx,
+    color,
+    wantsColors,
+    halfOf,
+    segments,
+    rowIndex,
+    strokes,
+  });
   removedWarning(removed, binding.index, warnings);
   if (rowIndex.length === 0) return null;
 

--- a/packages/core/src/pipeline/geometry-segments-annotation.ts
+++ b/packages/core/src/pipeline/geometry-segments-annotation.ts
@@ -1,0 +1,29 @@
+/**
+ * Emit annotation intercept rule segments (xintercept / yintercept).
+ */
+import { cellToNumber } from "../table.js";
+
+import type { LayerFrame } from "./types.js";
+import { NO_ROW } from "./types.js";
+import type { Frame } from "./geometry-shared.js";
+
+export function emitAnnotationSegments(input: {
+  frame: LayerFrame;
+  fx: Frame;
+  pushVertical: (t: number | undefined, row: number) => void;
+  pushHorizontal: (t: number | undefined, row: number) => void;
+}): void {
+  const { frame, fx, pushVertical, pushHorizontal } = input;
+  for (const v of frame.xIntercepts) {
+    pushVertical(
+      fx.xScale.type === "band" ? fx.xScale.normalize(v) : fx.xScale.normalize(cellToNumber(v)),
+      NO_ROW,
+    );
+  }
+  for (const v of frame.yIntercepts) {
+    pushHorizontal(
+      fx.yScale.type === "band" ? fx.yScale.normalize(v) : fx.yScale.normalize(cellToNumber(v)),
+      NO_ROW,
+    );
+  }
+}

--- a/packages/core/src/pipeline/geometry-segments-data.ts
+++ b/packages/core/src/pipeline/geometry-segments-data.ts
@@ -1,0 +1,44 @@
+/**
+ * Emit data-driven vertical/horizontal rule segments with optional colors.
+ */
+import type { LayerFrame, ResolvedColorScale } from "./types.js";
+import { colorOf } from "./types.js";
+import type { Frame } from "./geometry-shared.js";
+import { positionOf } from "./geometry-shared.js";
+
+export function emitDataSegments(input: {
+  frame: LayerFrame;
+  fx: Frame;
+  color: ResolvedColorScale | null;
+  wantsColors: boolean;
+  pushVertical: (t: number | undefined, row: number) => void;
+  pushHorizontal: (t: number | undefined, row: number) => void;
+  rowIndex: number[];
+  perSegmentColors: string[];
+}): void {
+  const {
+    frame,
+    fx,
+    color,
+    wantsColors,
+    pushVertical,
+    pushHorizontal,
+    rowIndex,
+    perSegmentColors,
+  } = input;
+  const { binding } = frame;
+
+  for (let row = 0; row < frame.n; row++) {
+    const before = rowIndex.length;
+    if (binding.ruleForm === "vertical") {
+      pushVertical(positionOf(fx.xScale, frame.xNumeric, frame.xValues, row), frame.rowIndex[row]!);
+    } else {
+      pushHorizontal(positionOf(fx.yScale, frame.yNumeric, null, row), frame.rowIndex[row]!);
+    }
+    if (wantsColors && color !== null && rowIndex.length > before) {
+      const value =
+        frame.colorValues === null ? binding.color.scaledConstant! : frame.colorValues[row]!;
+      perSegmentColors.push(colorOf(color, value));
+    }
+  }
+}

--- a/packages/core/src/pipeline/geometry-segments.ts
+++ b/packages/core/src/pipeline/geometry-segments.ts
@@ -2,12 +2,12 @@
  * Rule segment geometry batch builder (annotation intercepts + data-driven).
  */
 import type { SegmentsBatch } from "../scene.js";
-import { cellToNumber } from "../table.js";
 
 import type { LayerFrame, PipelineWarning, ResolvedColorScale } from "./types.js";
-import { colorOf, NO_ROW } from "./types.js";
 import type { Frame } from "./geometry-shared.js";
-import { DEFAULT_RULE_LINEWIDTH, positionOf, removedWarning } from "./geometry-shared.js";
+import { DEFAULT_RULE_LINEWIDTH, removedWarning } from "./geometry-shared.js";
+import { emitAnnotationSegments } from "./geometry-segments-annotation.js";
+import { emitDataSegments } from "./geometry-segments-data.js";
 import { createSegmentEmitters } from "./geometry-segments-emit.js";
 
 export function segmentsBatch(
@@ -35,35 +35,18 @@ export function segmentsBatch(
   });
 
   if (binding.ruleForm === "annotation") {
-    for (const v of frame.xIntercepts) {
-      pushVertical(
-        fx.xScale.type === "band" ? fx.xScale.normalize(v) : fx.xScale.normalize(cellToNumber(v)),
-        NO_ROW,
-      );
-    }
-    for (const v of frame.yIntercepts) {
-      pushHorizontal(
-        fx.yScale.type === "band" ? fx.yScale.normalize(v) : fx.yScale.normalize(cellToNumber(v)),
-        NO_ROW,
-      );
-    }
+    emitAnnotationSegments({ frame, fx, pushVertical, pushHorizontal });
   } else {
-    for (let row = 0; row < frame.n; row++) {
-      const before = rowIndex.length;
-      if (binding.ruleForm === "vertical") {
-        pushVertical(
-          positionOf(fx.xScale, frame.xNumeric, frame.xValues, row),
-          frame.rowIndex[row]!,
-        );
-      } else {
-        pushHorizontal(positionOf(fx.yScale, frame.yNumeric, null, row), frame.rowIndex[row]!);
-      }
-      if (wantsColors && rowIndex.length > before) {
-        const value =
-          frame.colorValues === null ? binding.color.scaledConstant! : frame.colorValues[row]!;
-        perSegmentColors.push(colorOf(color, value));
-      }
-    }
+    emitDataSegments({
+      frame,
+      fx,
+      color,
+      wantsColors,
+      pushVertical,
+      pushHorizontal,
+      rowIndex,
+      perSegmentColors,
+    });
   }
   removedWarning(removed, binding.index, warnings);
   if (rowIndex.length === 0) return null;

--- a/packages/core/src/pipeline/layer-fields.ts
+++ b/packages/core/src/pipeline/layer-fields.ts
@@ -1,9 +1,9 @@
 /**
- * Tooltip field maps and scaled-constant values per declared layer.
+ * Tooltip field maps per declared layer.
  */
-import type { CellValue } from "../table.js";
-
 import type { LayerBinding, MappedField } from "./types.js";
+
+export { resolveLayerScaledConstants } from "./layer-scaled-constants.js";
 
 /**
  * One entry per declared layer index. When bindings are shorter (empty data
@@ -46,23 +46,4 @@ export function resolveLayerFields(
     push("weight", binding.weightField);
     return fields;
   });
-}
-
-/**
- * One entry per declared layer index (same empty-data padding as fields).
- */
-export function resolveLayerScaledConstants(
-  layerCount: number,
-  bindings: readonly LayerBinding[],
-): ReadonlyArray<Readonly<Partial<Record<string, CellValue>>>> {
-  return Object.freeze(
-    Array.from({ length: layerCount }, (_, index) => {
-      const binding = bindings[index];
-      if (binding === undefined) return Object.freeze({});
-      const out: Partial<Record<string, CellValue>> = {};
-      if (binding.color.scaledConstant !== null) out["color"] = binding.color.scaledConstant;
-      if (binding.fill.scaledConstant !== null) out["fill"] = binding.fill.scaledConstant;
-      return Object.freeze(out);
-    }),
-  );
 }

--- a/packages/core/src/pipeline/layer-scaled-constants.ts
+++ b/packages/core/src/pipeline/layer-scaled-constants.ts
@@ -1,0 +1,25 @@
+/**
+ * Per-layer scaled constant color/fill values for legend-focus indexing.
+ */
+import type { CellValue } from "../table.js";
+
+import type { LayerBinding } from "./types.js";
+
+/**
+ * One entry per declared layer index (same empty-data padding as fields).
+ */
+export function resolveLayerScaledConstants(
+  layerCount: number,
+  bindings: readonly LayerBinding[],
+): ReadonlyArray<Readonly<Partial<Record<string, CellValue>>>> {
+  return Object.freeze(
+    Array.from({ length: layerCount }, (_, index) => {
+      const binding = bindings[index];
+      if (binding === undefined) return Object.freeze({});
+      const out: Partial<Record<string, CellValue>> = {};
+      if (binding.color.scaledConstant !== null) out["color"] = binding.color.scaledConstant;
+      if (binding.fill.scaledConstant !== null) out["fill"] = binding.fill.scaledConstant;
+      return Object.freeze(out);
+    }),
+  );
+}

--- a/packages/core/src/pipeline/scale-color-sequential-domain.ts
+++ b/packages/core/src/pipeline/scale-color-sequential-domain.ts
@@ -1,0 +1,29 @@
+/**
+ * Sequential color domain and range resolution (config vs edition defaults).
+ */
+import type { ColorScaleSpec } from "@ggsvelte/spec";
+
+import type { EditionDefaults } from "../editions.js";
+import { VIRIDIS_RAMP_10 } from "../scales/color.js";
+import type { CellValue } from "../table.js";
+import { cellToNumber } from "../table.js";
+
+export function resolveSequentialDomain(config?: ColorScaleSpec): [number, number] | undefined {
+  const domain = config?.domain;
+  if (domain === undefined || domain.length !== 2) return undefined;
+  return [cellToNumber(domain[0] as CellValue), cellToNumber(domain[1] as CellValue)];
+}
+
+/**
+ * Edition-keyed default ramp: identical to trainSequential built-in for
+ * edition 1 (undefined — keeps behavior byte-stable); other editions pass
+ * their ramp. Explicit config always wins at the call site.
+ */
+export function resolveSequentialRange(
+  config: ColorScaleSpec | undefined,
+  editionDefaults: EditionDefaults,
+): readonly string[] | undefined {
+  const editionRamp =
+    editionDefaults.sequentialRamp === VIRIDIS_RAMP_10 ? undefined : editionDefaults.sequentialRamp;
+  return config?.range ?? editionRamp;
+}

--- a/packages/core/src/pipeline/scale-color-sequential.ts
+++ b/packages/core/src/pipeline/scale-color-sequential.ts
@@ -4,11 +4,15 @@
 import type { ColorScaleSpec } from "@ggsvelte/spec";
 
 import type { EditionDefaults } from "../editions.js";
-import { trainSequential, VIRIDIS_RAMP_10 } from "../scales/color.js";
+import { trainSequential } from "../scales/color.js";
 import { finiteExtent } from "../scales/train.js";
 import type { CellValue } from "../table.js";
-import { cellsToNumeric, cellToNumber } from "../table.js";
+import { cellsToNumeric } from "../table.js";
 
+import {
+  resolveSequentialDomain,
+  resolveSequentialRange,
+} from "./scale-color-sequential-domain.js";
 import { resolveSequentialLegendFormat } from "./scale-color-sequential-format.js";
 import type { ColorResolution } from "./scale-color-types.js";
 import type { Advisory, PipelineWarning } from "./types.js";
@@ -42,20 +46,8 @@ export function resolveSequentialColorScale(input: {
   }
   const numeric = cellsToNumeric(values);
   const extent = finiteExtent([numeric]);
-  const domain = config?.domain;
-  const sequentialDomain =
-    domain !== undefined && domain.length === 2
-      ? ([cellToNumber(domain[0] as CellValue), cellToNumber(domain[1] as CellValue)] as [
-          number,
-          number,
-        ])
-      : undefined;
-  // Edition-keyed default ramp: identical to the trainSequential built-in
-  // for edition 1 (pass nothing — keeps behavior byte-stable); a different
-  // edition's ramp is passed explicitly. Explicit config always wins.
-  const editionRamp =
-    editionDefaults.sequentialRamp === VIRIDIS_RAMP_10 ? undefined : editionDefaults.sequentialRamp;
-  const range = config?.range ?? editionRamp;
+  const sequentialDomain = resolveSequentialDomain(config);
+  const range = resolveSequentialRange(config, editionDefaults);
   const scale = trainSequential(extent, {
     ...(sequentialDomain !== undefined && { domain: sequentialDomain }),
     ...(range !== undefined && { range }),

--- a/packages/core/tests/pipeline-build-candidates.test.ts
+++ b/packages/core/tests/pipeline-build-candidates.test.ts
@@ -192,3 +192,19 @@ describe("resolveCandidateSeries / resolveRepresentedSourceRows", () => {
     expect(result.group).toBe(4);
   });
 });
+
+describe("isAllSourceBacked", () => {
+  it("is true only when every layer is identity and non-annotation", async () => {
+    const { isAllSourceBacked } = await import("../src/pipeline/build-candidates-source-backed.ts");
+    expect(
+      isAllSourceBacked([
+        { layer: { stat: "identity" }, ruleForm: null },
+        { layer: {}, ruleForm: null },
+      ] as never),
+    ).toBe(true);
+    expect(isAllSourceBacked([{ layer: { stat: "count" }, ruleForm: null }] as never)).toBe(false);
+    expect(
+      isAllSourceBacked([{ layer: { stat: "identity" }, ruleForm: "annotation" }] as never),
+    ).toBe(false);
+  });
+});

--- a/packages/core/tests/pipeline-geometry.test.ts
+++ b/packages/core/tests/pipeline-geometry.test.ts
@@ -423,3 +423,31 @@ describe("layoutBoxplotBody — hinge/whisker collection", () => {
     expect(layoutBoxplotBody(frame, fx, [])).toBeNull();
   });
 });
+
+describe("buildRenderModelScaleState", () => {
+  it("includes only non-null color/fill state entries", async () => {
+    const { buildRenderModelScaleState } =
+      await import("../src/pipeline/assemble-render-model-scales.ts");
+    const colorState = { domain: ["a"], assigned: { a: 0 } } as never;
+    expect(buildRenderModelScaleState(colorState, null)).toEqual({ color: colorState });
+    expect(buildRenderModelScaleState(null, null)).toEqual({});
+  });
+});
+
+describe("resolveSequentialDomain", () => {
+  it("parses two-element domains and ignores incomplete ones", async () => {
+    const { resolveSequentialDomain } =
+      await import("../src/pipeline/scale-color-sequential-domain.ts");
+    expect(resolveSequentialDomain()).toBeUndefined();
+    expect(resolveSequentialDomain({ domain: [1] })).toBeUndefined();
+    expect(resolveSequentialDomain({ domain: [0, 10] })).toEqual([0, 10]);
+  });
+});
+
+describe("BOX_MEDIAN_FATTEN", () => {
+  it("matches ggplot2 fatten default of 2", async () => {
+    const { BOX_MEDIAN_FATTEN } =
+      await import("../src/pipeline/geometry-boxplot-body-batches-parts.ts");
+    expect(BOX_MEDIAN_FATTEN).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- Split identity candidate locate/context and identity-indexed store path behind stable facades.
- Extract annotation vs data-driven rule segment emitters; boxplot body batch parts; errorbar row emission.
- Extract render-model scale/axis-formatter assembly, finalize candidates builder, sequential domain/range, and layer scaled-constants.
- Add characterization tests for scale state, sequential domain, source-backed detection, and median fatten.

## Test plan
- [x] `bun test packages/core` (511 pass)
- [x] `bun run check`
- [x] `bun run knip`
- [x] `bun run lint:type-aware`
- [x] Codex pre-PR review (`gpt-5.6-terra`) — PASS (no P1)