### PR TITLE
refactor(svelte): carry pointer finish-brush finish payload

### DIFF
--- a/packages/svelte/src/lib/GGPlot.svelte
+++ b/packages/svelte/src/lib/GGPlot.svelte
@@ -98,7 +98,6 @@
   import {
     brushAtPoint,
     brushWithEnd,
-    evaluatePointerBrushEnd,
     initialBrushRect,
     nudgeBrushEnd,
   } from "./plot-area-brush.js";
@@ -127,10 +126,7 @@
     shouldFocusPinnedInteractiveTooltip,
     type QueuedPointerInspection,
   } from "./plot-surface-inspection.js";
-  import {
-    resolveFinishBrushAction,
-    type FinishBrushAction,
-  } from "./plot-brush-finish.js";
+  import { type FinishBrushAction } from "./plot-brush-finish.js";
   import {
     resolveCaptureClickAction,
     advanceTouchInspectMoved,
@@ -1957,6 +1953,8 @@
   }
 
   function onPointerUp(event: PointerEvent): void {
+    // endPoint always computed (pure finish-brush needs it; touch paths ignore).
+    const endPoint = plotPoint(event);
     const action = resolvePointerUpAction({
       pointerType: event.pointerType,
       activeTool,
@@ -1965,7 +1963,8 @@
       hasTouchInspectStart: touchInspectStart !== null,
       touchInspectMoved,
       brushing,
-      hasBrushDraft: brushRect !== null,
+      brushCorners: brushRect,
+      endPoint,
     });
     switch (action.type) {
       case "touch-inspect-drag-ignore":
@@ -1978,8 +1977,7 @@
         touchInspectMoved = false;
         const inspectConfig = interactionConfig.inspect;
         if (inspectConfig === null) break;
-        const p = plotPoint(event);
-        const match = model?.candidates.nearest(p.x, p.y, {
+        const match = model?.candidates.nearest(endPoint.x, endPoint.y, {
           mode: inspectConfig.mode,
           maxDistance: inspectConfig.maxDistance,
         });
@@ -1999,19 +1997,9 @@
       case "none":
         break;
       case "finish-brush": {
-        // Defensive: pure up-gate already requires hasBrushDraft.
-        if (brushRect === null) break;
-        // Pointer-only: cancel scheduled frames before shared finish effects.
+        // Pure table owns evaluate + select/zoom/end; host cancels then applies.
         reducer.cancelScheduledPointer();
-        const ended = evaluatePointerBrushEnd(brushRect, plotPoint(event));
-        // Pure table carries rect/corners — no host ended.kind re-narrow.
-        applyFinishBrush(
-          resolveFinishBrushAction({
-            ended,
-            activeTool,
-          }),
-          action.source,
-        );
+        applyFinishBrush(action.finish, action.source);
         break;
       }
     }

--- a/packages/svelte/src/lib/plot-brush-finish.ts
+++ b/packages/svelte/src/lib/plot-brush-finish.ts
@@ -1,14 +1,11 @@
 import type { InteractionTool } from "./interaction.js";
+import {
+  evaluatePointerBrushEnd,
+  type BrushCorners,
+  type PlotPoint,
+  type PointerBrushEnd,
+} from "./plot-area-brush.js";
 import type { PlotRect } from "./plot-geometry.js";
-
-/**
- * Matches `PointerBrushEnd` from plot-area-brush without importing that module
- * (local mirror; plot-area-brush does not import this file — no cycle risk,
- * but keep the payload shape self-contained for pure finish routing).
- */
-export type FinishBrushEnded =
-  | { readonly kind: "too-small"; readonly corners: PlotRect }
-  | { readonly kind: "commit"; readonly rect: PlotRect };
 
 export type FinishBrushAction =
   | { readonly type: "keep-second-corner"; readonly corners: PlotRect }
@@ -34,10 +31,10 @@ export type FinishBrushAction =
  * using action.rect when present.
  *
  * Keyboard complete-area always supplies `kind: "commit"` (no free-corner
- * too-small evaluation); pointer uses `evaluatePointerBrushEnd` first.
+ * too-small evaluation); pointer uses `resolvePointerFinishBrushAction`.
  */
 export function resolveFinishBrushAction(input: {
-  readonly ended: FinishBrushEnded;
+  readonly ended: PointerBrushEnd;
   readonly activeTool: InteractionTool;
 }): FinishBrushAction {
   if (input.ended.kind === "too-small") {
@@ -50,4 +47,20 @@ export function resolveFinishBrushAction(input: {
     return { type: "zoom-end", rect: input.ended.rect };
   }
   return { type: "end-area" };
+}
+
+/**
+ * Compose free-corner evaluation + finish routing for pointer finish-brush.
+ * Host supplies draft corners and the up event plot point; pure owns too-small
+ * vs commit and select/zoom/end payloads.
+ */
+export function resolvePointerFinishBrushAction(input: {
+  readonly brushCorners: BrushCorners;
+  readonly endPoint: PlotPoint;
+  readonly activeTool: InteractionTool;
+}): FinishBrushAction {
+  return resolveFinishBrushAction({
+    ended: evaluatePointerBrushEnd(input.brushCorners, input.endPoint),
+    activeTool: input.activeTool,
+  });
 }

--- a/packages/svelte/src/lib/plot-surface-pointer.ts
+++ b/packages/svelte/src/lib/plot-surface-pointer.ts
@@ -1,4 +1,6 @@
 import { isAreaTool, type InteractionTool } from "./interaction.js";
+import type { BrushCorners, PlotPoint } from "./plot-area-brush.js";
+import { resolvePointerFinishBrushAction, type FinishBrushAction } from "./plot-brush-finish.js";
 
 /**
  * Capture-surface pointer decision input for pointerdown.
@@ -52,6 +54,10 @@ export function resolvePointerDownAction(input: SurfacePointerDownInput): Surfac
 /**
  * Capture-surface pointerup decision input.
  * Touch-inspect fields only matter when tool is inspect + pointer is touch.
+ *
+ * `brushCorners` is the sole draft source of truth for finish-brush (host:
+ * `brushRect`). Distinct from reducer `brushing`, which can diverge.
+ * `endPoint` is always the up-event plot point (host always computes it).
  */
 export type SurfacePointerUpInput = {
   readonly pointerType: string;
@@ -62,8 +68,13 @@ export type SurfacePointerUpInput = {
   readonly touchInspectMoved: boolean;
   /** Reducer brushing flag — can diverge from draft. */
   readonly brushing: boolean;
-  /** True when `brushRect !== null`. */
-  readonly hasBrushDraft: boolean;
+  /**
+   * Host: `brushRect`. Non-null when a draft free corner exists.
+   * Finish-brush requires both brushing and non-null corners.
+   */
+  readonly brushCorners: BrushCorners | null;
+  /** Host: `plotPoint(event)` — always available on pointerup. */
+  readonly endPoint: PlotPoint;
 };
 
 export type SurfacePointerUpAction =
@@ -77,15 +88,21 @@ export type SurfacePointerUpAction =
       readonly type: "finish-brush";
       /** Interaction source for selection/zoom emission. */
       readonly source: "touch" | "pointer";
+      /**
+       * Pure-owned too-small/commit + select/zoom/end routing (shared with
+       * keyboard complete-area via plot-brush-finish).
+       */
+      readonly finish: FinishBrushAction;
     }
   | { readonly type: "none" };
 
 /**
  * Pure decision for the plot capture-surface `pointerup` handler.
  * Priority: touch-inspect tap/drag → finish-brush (both brushing and draft)
- * → none. Geometry (too-small) and emission stay with the host after
- * `finish-brush`. Host always clears touch-inspect start state for both
- * touch-inspect actions.
+ * → none. Finish-brush carries the complete finish payload (too-small vs
+ * commit, select/zoom/end). Host cancels scheduled pointer then
+ * `applyFinishBrush(action.finish, action.source)`. Host always clears
+ * touch-inspect start state for both touch-inspect actions.
  */
 export function resolvePointerUpAction(input: SurfacePointerUpInput): SurfacePointerUpAction {
   const {
@@ -96,7 +113,8 @@ export function resolvePointerUpAction(input: SurfacePointerUpInput): SurfacePoi
     hasTouchInspectStart,
     touchInspectMoved,
     brushing,
-    hasBrushDraft,
+    brushCorners,
+    endPoint,
   } = input;
 
   if (
@@ -112,10 +130,15 @@ export function resolvePointerUpAction(input: SurfacePointerUpInput): SurfacePoi
     };
   }
 
-  if (!brushing || !hasBrushDraft) return { type: "none" };
+  if (!brushing || brushCorners === null) return { type: "none" };
   return {
     type: "finish-brush",
     source: interactionSourceFromPointerType(pointerType),
+    finish: resolvePointerFinishBrushAction({
+      brushCorners,
+      endPoint,
+      activeTool,
+    }),
   };
 }
 

--- a/packages/svelte/tests/plot-brush-finish.test.ts
+++ b/packages/svelte/tests/plot-brush-finish.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 
 import type { InteractionTool } from "../src/lib/interaction.js";
-import { resolveFinishBrushAction } from "../src/lib/plot-brush-finish.js";
+import {
+  resolveFinishBrushAction,
+  resolvePointerFinishBrushAction,
+} from "../src/lib/plot-brush-finish.js";
 
 describe("resolveFinishBrushAction", () => {
   const corners = { x0: 1, y0: 2, x1: 3, y1: 4 } as const;
@@ -43,6 +46,34 @@ describe("resolveFinishBrushAction", () => {
     });
     expect(resolveFinishBrushAction({ ended: commit, activeTool: "point" })).toEqual({
       type: "end-area",
+    });
+  });
+});
+
+describe("resolvePointerFinishBrushAction", () => {
+  it("composes free-corner evaluation into select-end", () => {
+    expect(
+      resolvePointerFinishBrushAction({
+        brushCorners: { x0: 10, y0: 20, x1: 10, y1: 20 },
+        endPoint: { x: 40, y: 50 },
+        activeTool: "select-area",
+      }),
+    ).toEqual({
+      type: "select-end",
+      rect: { x0: 10, y0: 20, x1: 40, y1: 50 },
+    });
+  });
+
+  it("composes too-small free corner into keep-second-corner", () => {
+    expect(
+      resolvePointerFinishBrushAction({
+        brushCorners: { x0: 10, y0: 10, x1: 10, y1: 10 },
+        endPoint: { x: 12, y: 12 },
+        activeTool: "zoom-area",
+      }),
+    ).toEqual({
+      type: "keep-second-corner",
+      corners: { x0: 10, y0: 10, x1: 12, y1: 12 },
     });
   });
 });

--- a/packages/svelte/tests/plot-surface-pointer.test.ts
+++ b/packages/svelte/tests/plot-surface-pointer.test.ts
@@ -31,6 +31,9 @@ const down = (
   ...overrides,
 });
 
+const draftCorners = { x0: 10, y0: 20, x1: 10, y1: 20 } as const;
+const endAt = { x: 40, y: 50 } as const;
+
 const up = (
   overrides: Partial<SurfacePointerUpInput> & Pick<SurfacePointerUpInput, "activeTool">,
 ): SurfacePointerUpInput => ({
@@ -40,7 +43,8 @@ const up = (
   hasTouchInspectStart: false,
   touchInspectMoved: false,
   brushing: false,
-  hasBrushDraft: false,
+  brushCorners: null,
+  endPoint: endAt,
   ...overrides,
 });
 
@@ -216,56 +220,99 @@ describe("resolvePointerUpAction", () => {
   });
 
   it("does not take touch-inspect path when inspect disabled or tool changed", () => {
-    expect(
-      resolvePointerUpAction(
-        up({
-          activeTool: "inspect",
-          pointerType: "touch",
-          inspectEnabled: false,
-          hasTouchInspectStart: true,
-          brushing: true,
-          hasBrushDraft: true,
-        }),
-      ),
-    ).toEqual({ type: "finish-brush", source: "touch" });
+    const finishTouch = resolvePointerUpAction(
+      up({
+        activeTool: "inspect",
+        pointerType: "touch",
+        inspectEnabled: false,
+        hasTouchInspectStart: true,
+        brushing: true,
+        brushCorners: draftCorners,
+      }),
+    );
+    expect(finishTouch.type).toBe("finish-brush");
+    if (finishTouch.type === "finish-brush") {
+      expect(finishTouch.source).toBe("touch");
+      expect(finishTouch.finish.type).toBe("end-area");
+    }
 
+    const finishSelect = resolvePointerUpAction(
+      up({
+        activeTool: "select-area",
+        pointerType: "touch",
+        inspectEnabled: true,
+        hasTouchInspectStart: true,
+        brushing: true,
+        brushCorners: draftCorners,
+      }),
+    );
+    expect(finishSelect).toEqual({
+      type: "finish-brush",
+      source: "touch",
+      finish: {
+        type: "select-end",
+        rect: { x0: 10, y0: 20, x1: 40, y1: 50 },
+      },
+    });
+  });
+
+  it("finishes brush only when both brushing and draft exist; carries finish payload", () => {
     expect(
       resolvePointerUpAction(
         up({
           activeTool: "select-area",
-          pointerType: "touch",
-          inspectEnabled: true,
-          hasTouchInspectStart: true,
           brushing: true,
-          hasBrushDraft: true,
+          brushCorners: draftCorners,
         }),
       ),
-    ).toEqual({ type: "finish-brush", source: "touch" });
+    ).toEqual({
+      type: "finish-brush",
+      source: "pointer",
+      finish: {
+        type: "select-end",
+        rect: { x0: 10, y0: 20, x1: 40, y1: 50 },
+      },
+    });
   });
 
-  it("finishes brush only when both brushing and draft exist", () => {
-    expect(
-      resolvePointerUpAction(
-        up({
-          activeTool: "select-area",
-          brushing: true,
-          hasBrushDraft: true,
-        }),
-      ),
-    ).toEqual({ type: "finish-brush", source: "pointer" });
-  });
-
-  it("maps finish-brush source from pointerType", () => {
+  it("maps finish-brush source from pointerType and zoom-end finish", () => {
     expect(
       resolvePointerUpAction(
         up({
           activeTool: "zoom-area",
           pointerType: "touch",
           brushing: true,
-          hasBrushDraft: true,
+          brushCorners: draftCorners,
         }),
       ),
-    ).toEqual({ type: "finish-brush", source: "touch" });
+    ).toEqual({
+      type: "finish-brush",
+      source: "touch",
+      finish: {
+        type: "zoom-end",
+        rect: { x0: 10, y0: 20, x1: 40, y1: 50 },
+      },
+    });
+  });
+
+  it("finish-brush keep-second-corner when free corner is too-small", () => {
+    expect(
+      resolvePointerUpAction(
+        up({
+          activeTool: "select-area",
+          brushing: true,
+          brushCorners: { x0: 10, y0: 10, x1: 10, y1: 10 },
+          endPoint: { x: 12, y: 12 },
+        }),
+      ),
+    ).toEqual({
+      type: "finish-brush",
+      source: "pointer",
+      finish: {
+        type: "keep-second-corner",
+        corners: { x0: 10, y0: 10, x1: 12, y1: 12 },
+      },
+    });
   });
 
   it("returns none when brushing/draft state diverges", () => {
@@ -274,7 +321,7 @@ describe("resolvePointerUpAction", () => {
         up({
           activeTool: "zoom-area",
           brushing: true,
-          hasBrushDraft: false,
+          brushCorners: null,
         }),
       ),
     ).toEqual({ type: "none" });
@@ -284,7 +331,7 @@ describe("resolvePointerUpAction", () => {
         up({
           activeTool: "zoom-area",
           brushing: false,
-          hasBrushDraft: true,
+          brushCorners: draftCorners,
         }),
       ),
     ).toEqual({ type: "none" });


### PR DESCRIPTION
## Summary

- Expand pointer-up `finish-brush` to carry a pure `FinishBrushAction` (too-small keep-second-corner vs select/zoom/end), matching keyboard complete-area ownership.
- Replace pointer-up `hasBrushDraft` with `brushCorners: BrushCorners | null` as the sole draft source of truth for finish routing.
- Compose free-corner evaluation in `resolvePointerFinishBrushAction` (`plot-brush-finish`); drop the mirrored `FinishBrushEnded` type in favor of `PointerBrushEnd`.
- GGPlot `onPointerUp` finish path only cancels scheduled pointer and applies the finish payload.

## Test plan

- [x] Vitest: plot-surface-pointer finish-brush payloads (select-end, zoom-end, keep-second-corner, none divergences)
- [x] Vitest: plot-brush-finish composition tests
- [x] Keyboard suite still green
- [x] svelte-check + pre-push hooks
- [ ] CI on PR