### PR TITLE
refactor(core): split candidate assemble, color collect, geometry, frames

### DIFF
--- a/packages/core/src/pipeline/assemble-scene-build.ts
+++ b/packages/core/src/pipeline/assemble-scene-build.ts
@@ -5,9 +5,9 @@ import type { GeometryBatch, Scene, SceneLegend } from "../scene.js";
 import type { ThemeTokens } from "../theme.js";
 import type { PositionScale } from "../scales/train.js";
 
+import { placeSceneLegends } from "./assemble-scene-legends.js";
 import { assembleScenePanels } from "./assemble-scene-panels.js";
 import type { FacetPanelDef } from "./facets.js";
-import { LEGEND_EDGE_PAD } from "./layout-helpers.js";
 import type { PanelPlacement } from "./panel-layout.js";
 
 export function assembleScene(input: {
@@ -51,11 +51,12 @@ export function assembleScene(input: {
     vTitle,
   });
 
-  const legends: SceneLegend[] = legendBlock.legends.map((legend) => ({
-    ...legend,
-    x: legend.x + width - legendBlock.width - LEGEND_EDGE_PAD,
-    y: legend.y + (scenePanels[0]?.y ?? topBand),
-  }));
+  const legends = placeSceneLegends({
+    legends: legendBlock.legends,
+    legendWidth: legendBlock.width,
+    sceneWidth: width,
+    panelY: scenePanels[0]?.y ?? topBand,
+  });
 
   return {
     width,

--- a/packages/core/src/pipeline/assemble-scene-legends.ts
+++ b/packages/core/src/pipeline/assemble-scene-legends.ts
@@ -1,0 +1,20 @@
+/**
+ * Position scene legends relative to panel/chrome layout.
+ */
+import type { SceneLegend } from "../scene.js";
+
+import { LEGEND_EDGE_PAD } from "./layout-helpers.js";
+
+export function placeSceneLegends(input: {
+  legends: readonly SceneLegend[];
+  legendWidth: number;
+  sceneWidth: number;
+  panelY: number;
+}): SceneLegend[] {
+  const { legends, legendWidth, sceneWidth, panelY } = input;
+  return legends.map((legend) => ({
+    ...legend,
+    x: legend.x + sceneWidth - legendWidth - LEGEND_EDGE_PAD,
+    y: legend.y + panelY,
+  }));
+}

--- a/packages/core/src/pipeline/build-candidates-datum-assemble.ts
+++ b/packages/core/src/pipeline/build-candidates-datum-assemble.ts
@@ -1,0 +1,91 @@
+/**
+ * Assemble CandidateDatum from located identity context + series/lineage/values.
+ */
+import type { CandidateBuildFacts, CandidateDatum } from "../candidate-store.js";
+
+import type { IdentityCandidateResolveContext } from "./build-candidates-datum-ctx.js";
+import { resolveAnnotationIntercepts } from "./build-candidates-datum-context.js";
+import type { LocatedIdentityCandidate } from "./build-candidates-datum-locate.js";
+import {
+  resolveCandidateSeries,
+  resolveRepresentedSourceRows,
+} from "./build-candidates-datum-series.js";
+import { resolveCandidateLogicalValues } from "./build-candidates-datum-values.js";
+import { candidateAutoMode } from "./frame.js";
+
+export function assembleIdentityCandidateDatum(
+  ctx: IdentityCandidateResolveContext,
+  facts: CandidateBuildFacts,
+  located: LocatedIdentityCandidate,
+): CandidateDatum {
+  const {
+    sourceRow,
+    frame,
+    outlierSourceRow,
+    frameRow,
+    derivedGroup,
+    sourceValue,
+    xField,
+    yField,
+    colorField,
+    fillField,
+    seriesByRow,
+    sourceRowsByGroup,
+  } = located;
+
+  const { group, seriesRank } = resolveCandidateSeries({
+    sourceRow,
+    derivedGroup,
+    seriesByRow,
+    panelIndex: facts.panelIndex,
+    layerIndex: facts.layerIndex,
+    color: ctx.color,
+    fill: ctx.fill,
+    colorField,
+    fillField,
+    sourceValue,
+  });
+  const autoMode = candidateAutoMode(
+    frame?.binding ?? ctx.bindings[facts.layerIndex]!,
+    facts.primitiveIndex,
+  );
+  const { annotationRule, annotationX, annotationY } = resolveAnnotationIntercepts({
+    frame,
+    primitiveIndex: facts.primitiveIndex,
+  });
+  const { sourceOrder, lineageKey } = resolveRepresentedSourceRows({
+    outlierSourceRow,
+    sourceRow,
+    group,
+    panelIndex: facts.panelIndex,
+    layerIndex: facts.layerIndex,
+    sourceRowsByGroup,
+    frame,
+    table: ctx.table,
+    frameRow,
+    lineage: ctx.lineage,
+    primitiveIndex: facts.primitiveIndex,
+  });
+  const { xValue, yValue } = resolveCandidateLogicalValues({
+    annotationRule,
+    annotationX,
+    annotationY,
+    outlierSourceRow,
+    sourceRow,
+    frame,
+    frameRow,
+    primitiveIndex: facts.primitiveIndex,
+    sourceValue,
+    xField,
+    yField,
+  });
+  return {
+    xValue,
+    yValue,
+    seriesId: group,
+    seriesRank,
+    sourceOrder,
+    lineage: lineageKey,
+    autoMode,
+  };
+}

--- a/packages/core/src/pipeline/build-candidates-datum-resolve.ts
+++ b/packages/core/src/pipeline/build-candidates-datum-resolve.ts
@@ -4,14 +4,8 @@
 import type { CandidateBuildFacts, CandidateDatum } from "../candidate-store.js";
 
 import type { IdentityCandidateResolveContext } from "./build-candidates-datum-ctx.js";
-import { resolveAnnotationIntercepts } from "./build-candidates-datum-context.js";
+import { assembleIdentityCandidateDatum } from "./build-candidates-datum-assemble.js";
 import { locateIdentityCandidate } from "./build-candidates-datum-locate.js";
-import {
-  resolveCandidateSeries,
-  resolveRepresentedSourceRows,
-} from "./build-candidates-datum-series.js";
-import { resolveCandidateLogicalValues } from "./build-candidates-datum-values.js";
-import { candidateAutoMode } from "./frame.js";
 
 export type { IdentityCandidateResolveContext } from "./build-candidates-datum-ctx.js";
 
@@ -20,74 +14,5 @@ export function resolveIdentityCandidateDatum(
   facts: CandidateBuildFacts,
 ): CandidateDatum {
   const located = locateIdentityCandidate(ctx, facts);
-  const {
-    sourceRow,
-    frame,
-    outlierSourceRow,
-    frameRow,
-    derivedGroup,
-    sourceValue,
-    xField,
-    yField,
-    colorField,
-    fillField,
-    seriesByRow,
-    sourceRowsByGroup,
-  } = located;
-
-  const { group, seriesRank } = resolveCandidateSeries({
-    sourceRow,
-    derivedGroup,
-    seriesByRow,
-    panelIndex: facts.panelIndex,
-    layerIndex: facts.layerIndex,
-    color: ctx.color,
-    fill: ctx.fill,
-    colorField,
-    fillField,
-    sourceValue,
-  });
-  const autoMode = candidateAutoMode(
-    frame?.binding ?? ctx.bindings[facts.layerIndex]!,
-    facts.primitiveIndex,
-  );
-  const { annotationRule, annotationX, annotationY } = resolveAnnotationIntercepts({
-    frame,
-    primitiveIndex: facts.primitiveIndex,
-  });
-  const { sourceOrder, lineageKey } = resolveRepresentedSourceRows({
-    outlierSourceRow,
-    sourceRow,
-    group,
-    panelIndex: facts.panelIndex,
-    layerIndex: facts.layerIndex,
-    sourceRowsByGroup,
-    frame,
-    table: ctx.table,
-    frameRow,
-    lineage: ctx.lineage,
-    primitiveIndex: facts.primitiveIndex,
-  });
-  const { xValue, yValue } = resolveCandidateLogicalValues({
-    annotationRule,
-    annotationX,
-    annotationY,
-    outlierSourceRow,
-    sourceRow,
-    frame,
-    frameRow,
-    primitiveIndex: facts.primitiveIndex,
-    sourceValue,
-    xField,
-    yField,
-  });
-  return {
-    xValue,
-    yValue,
-    seriesId: group,
-    seriesRank,
-    sourceOrder,
-    lineage: lineageKey,
-    autoMode,
-  };
+  return assembleIdentityCandidateDatum(ctx, facts, located);
 }

--- a/packages/core/src/pipeline/facets-helpers.ts
+++ b/packages/core/src/pipeline/facets-helpers.ts
@@ -9,6 +9,8 @@ import { cellToNumber, ColumnTable } from "../table.js";
 
 import { PipelineError } from "./types.js";
 
+export { panelComponentToken, panelValueToken, rowsMatching } from "./facets-tokens.js";
+
 export function facetField(
   ref: { field: string } | undefined,
   key: "wrap" | "rows" | "cols",
@@ -49,27 +51,4 @@ export function facetValues(table: ColumnTable, field: string): CellValue[] {
     return ka < kb ? -1 : ka > kb ? 1 : 0;
   });
   return values;
-}
-
-export function panelValueToken(value: CellValue): string {
-  if (value instanceof Date) return `d:${value.getTime()}`;
-  if (value === null) return "null";
-  if (typeof value === "string") return `s:${value}`;
-  if (typeof value === "number") return `n:${Object.is(value, -0) ? 0 : value}`;
-  return `b:${value}`;
-}
-
-export function panelComponentToken(field: string, value: CellValue): string {
-  const token = panelValueToken(value);
-  return `${field.length}:${field}=${token.length}:${token}`;
-}
-
-export function rowsMatching(table: ColumnTable, field: string, value: CellValue): number[] {
-  const key = bandKey(value);
-  const column = table.column(field);
-  const rows: number[] = [];
-  for (let i = 0; i < column.length; i++) {
-    if (bandKey(column[i]!) === key) rows.push(i);
-  }
-  return rows;
 }

--- a/packages/core/src/pipeline/facets-tokens.ts
+++ b/packages/core/src/pipeline/facets-tokens.ts
@@ -1,0 +1,29 @@
+/**
+ * Facet panel identity tokens and row matching.
+ */
+import { bandKey } from "../scales/train.js";
+import type { CellValue } from "../table.js";
+import type { ColumnTable } from "../table.js";
+
+export function panelValueToken(value: CellValue): string {
+  if (value instanceof Date) return `d:${value.getTime()}`;
+  if (value === null) return "null";
+  if (typeof value === "string") return `s:${value}`;
+  if (typeof value === "number") return `n:${Object.is(value, -0) ? 0 : value}`;
+  return `b:${value}`;
+}
+
+export function panelComponentToken(field: string, value: CellValue): string {
+  const token = panelValueToken(value);
+  return `${field.length}:${field}=${token.length}:${token}`;
+}
+
+export function rowsMatching(table: ColumnTable, field: string, value: CellValue): number[] {
+  const key = bandKey(value);
+  const column = table.column(field);
+  const rows: number[] = [];
+  for (let i = 0; i < column.length; i++) {
+    if (bandKey(column[i]!) === key) rows.push(i);
+  }
+  return rows;
+}

--- a/packages/core/src/pipeline/finalize-model-assemble.ts
+++ b/packages/core/src/pipeline/finalize-model-assemble.ts
@@ -1,0 +1,63 @@
+/**
+ * Pack trained scales + contracts into assembleRenderModel input.
+ */
+import type { Scene } from "../scene.js";
+import type { CandidateStore } from "../candidate-store.js";
+import type { LineageStore } from "../identity.js";
+
+import { assembleRenderModel } from "./assemble-render-model.js";
+import type { PanelLayoutResult } from "./panel-layout.js";
+import type { PreparedPanels } from "./prepare-panels.js";
+import type { TrainedPipelineScales } from "./train-pipeline-scales.js";
+import type {
+  Advisory,
+  LayerBackend,
+  MappedField,
+  PipelineWarning,
+  RenderModel,
+  ScaleDomainSnapshot,
+} from "./types.js";
+import type { CellValue } from "../table.js";
+
+export function assembleFinalizeRenderModel(input: {
+  scene: Scene;
+  trained: TrainedPipelineScales;
+  prepared: PreparedPanels;
+  panelLayout: PanelLayoutResult;
+  runId: number;
+  warnings: PipelineWarning[];
+  advisories: Advisory[];
+  layerBackends: LayerBackend[];
+  layerFields: MappedField[][];
+  layerScaledConstants: ReadonlyArray<Readonly<Partial<Record<string, CellValue>>>>;
+  baselineDomains: ScaleDomainSnapshot;
+  effectiveDomains: ScaleDomainSnapshot;
+  lineage: LineageStore<number>;
+  candidates: CandidateStore;
+}): RenderModel {
+  const { scene, trained, prepared, panelLayout } = input;
+  const { xTraining, yTraining, panelScales, colorResolution, fillResolution } = trained;
+  return assembleRenderModel({
+    scene,
+    xScale: xTraining.scale,
+    yScale: yTraining.scale,
+    color: colorResolution.resolved,
+    fill: fillResolution.resolved,
+    panelScales,
+    colorState: colorResolution.state,
+    fillState: fillResolution.state,
+    warnings: input.warnings,
+    advisories: input.advisories,
+    runId: input.runId,
+    layerBackends: input.layerBackends,
+    layerFields: input.layerFields,
+    layerScaledConstants: input.layerScaledConstants,
+    baselineDomains: input.baselineDomains,
+    effectiveDomains: input.effectiveDomains,
+    lineage: input.lineage,
+    candidates: input.candidates,
+    formatX: panelLayout.formatX,
+    formatY: panelLayout.formatY,
+    table: prepared.table,
+  });
+}

--- a/packages/core/src/pipeline/finalize-model.ts
+++ b/packages/core/src/pipeline/finalize-model.ts
@@ -5,7 +5,7 @@ import type { PortableSpec } from "@ggsvelte/spec";
 
 import type { Scene } from "../scene.js";
 
-import { assembleRenderModel } from "./assemble-render-model.js";
+import { assembleFinalizeRenderModel } from "./finalize-model-assemble.js";
 import { buildFinalizeCandidates } from "./finalize-model-candidates.js";
 import { resolveFinalizeContracts } from "./finalize-model-contracts.js";
 import type { PanelLayoutResult } from "./panel-layout.js";
@@ -37,7 +37,6 @@ export function finalizeRenderModel(input: {
     warnings,
     advisories,
   } = input;
-  const { xTraining, yTraining, panelScales, colorResolution, fillResolution } = trained;
 
   const contracts = resolveFinalizeContracts({
     normalized,
@@ -58,18 +57,14 @@ export function finalizeRenderModel(input: {
     layerFields: contracts.layerFields,
   });
 
-  return assembleRenderModel({
+  return assembleFinalizeRenderModel({
     scene,
-    xScale: xTraining.scale,
-    yScale: yTraining.scale,
-    color: colorResolution.resolved,
-    fill: fillResolution.resolved,
-    panelScales,
-    colorState: colorResolution.state,
-    fillState: fillResolution.state,
+    trained,
+    prepared,
+    panelLayout,
+    runId,
     warnings,
     advisories,
-    runId,
     layerBackends: contracts.layerBackends,
     layerFields: contracts.layerFields,
     layerScaledConstants: contracts.layerScaledConstants,
@@ -77,8 +72,5 @@ export function finalizeRenderModel(input: {
     effectiveDomains: contracts.effectiveDomains,
     lineage,
     candidates,
-    formatX: panelLayout.formatX,
-    formatY: panelLayout.formatY,
-    table: prepared.table,
   });
 }

--- a/packages/core/src/pipeline/frame-annotation.ts
+++ b/packages/core/src/pipeline/frame-annotation.ts
@@ -1,0 +1,27 @@
+/**
+ * Annotation-rule LayerFrame (intercept lists, zero data rows).
+ */
+import type { ColumnTable } from "../table.js";
+
+import { emptyFrameExtras, interceptList } from "./frame-helpers.js";
+import type { LayerBinding, LayerFrame } from "./types.js";
+
+export function buildAnnotationFrame(binding: LayerBinding, table: ColumnTable): LayerFrame {
+  const params = (binding.layer.params ?? {}) as { xintercept?: unknown; yintercept?: unknown };
+  return {
+    binding,
+    table,
+    n: 0,
+    xValues: null,
+    xNumeric: null,
+    yNumeric: null,
+    groups: [],
+    rowIndex: new Uint32Array(0),
+    colorValues: null,
+    fillValues: null,
+    labelValues: null,
+    ...emptyFrameExtras(),
+    xIntercepts: interceptList(params.xintercept),
+    yIntercepts: interceptList(params.yintercept),
+  };
+}

--- a/packages/core/src/pipeline/frame-identity.ts
+++ b/packages/core/src/pipeline/frame-identity.ts
@@ -1,0 +1,31 @@
+/**
+ * Identity-stat LayerFrame (source columns, optional ymin/ymax).
+ */
+import type { ColumnTable } from "../table.js";
+
+import { emptyFrameExtras } from "./frame-helpers.js";
+import type { LayerBinding, LayerFrame } from "./types.js";
+
+export function buildIdentityFrame(
+  binding: LayerBinding,
+  table: ColumnTable,
+  groups: number[],
+): LayerFrame {
+  const n = table.rowCount;
+  return {
+    binding,
+    table,
+    n,
+    xValues: binding.xField === null ? null : table.column(binding.xField),
+    xNumeric: binding.xField === null ? null : table.numeric(binding.xField),
+    yNumeric: binding.yField === null ? null : table.numeric(binding.yField),
+    groups,
+    rowIndex: Uint32Array.from({ length: n }, (_, i) => i),
+    colorValues: binding.color.field === null ? null : table.column(binding.color.field),
+    fillValues: binding.fill.field === null ? null : table.column(binding.fill.field),
+    labelValues: binding.labelField === null ? null : table.column(binding.labelField),
+    ...emptyFrameExtras(),
+    ymin: binding.yminField === null ? null : table.numeric(binding.yminField),
+    ymax: binding.ymaxField === null ? null : table.numeric(binding.ymaxField),
+  };
+}

--- a/packages/core/src/pipeline/frame.ts
+++ b/packages/core/src/pipeline/frame.ts
@@ -6,7 +6,9 @@ import type { ColumnTable } from "../table.js";
 
 import type { Advisory, LayerBinding, LayerFrame, PipelineWarning } from "./types.js";
 import { NO_ROW } from "./types.js";
-import { deriveLayerGroups, emptyFrameExtras, interceptList } from "./frame-helpers.js";
+import { buildAnnotationFrame } from "./frame-annotation.js";
+import { deriveLayerGroups } from "./frame-helpers.js";
+import { buildIdentityFrame } from "./frame-identity.js";
 import { buildNonIdentityFrame } from "./frame-stats.js";
 
 export { deriveLayerGroups } from "./frame-helpers.js";
@@ -19,49 +21,15 @@ export function buildFrame(
   advisories: Advisory[],
   binRange?: [number, number],
 ): LayerFrame {
-  const n = table.rowCount;
-
   if (binding.ruleForm === "annotation") {
-    const params = (binding.layer.params ?? {}) as { xintercept?: unknown; yintercept?: unknown };
-    return {
-      binding,
-      table,
-      n: 0,
-      xValues: null,
-      xNumeric: null,
-      yNumeric: null,
-      groups: [],
-      rowIndex: new Uint32Array(0),
-      colorValues: null,
-      fillValues: null,
-      labelValues: null,
-      ...emptyFrameExtras(),
-      xIntercepts: interceptList(params.xintercept),
-      yIntercepts: interceptList(params.yintercept),
-    };
+    return buildAnnotationFrame(binding, table);
   }
 
   const groups = deriveLayerGroups(binding, table);
   const nonIdentity = buildNonIdentityFrame(binding, table, groups, warnings, advisories, binRange);
   if (nonIdentity !== null) return nonIdentity;
 
-  // --- identity ----------------------------------------------------------------
-  return {
-    binding,
-    table,
-    n,
-    xValues: binding.xField === null ? null : table.column(binding.xField),
-    xNumeric: binding.xField === null ? null : table.numeric(binding.xField),
-    yNumeric: binding.yField === null ? null : table.numeric(binding.yField),
-    groups,
-    rowIndex: Uint32Array.from({ length: n }, (_, i) => i),
-    colorValues: binding.color.field === null ? null : table.column(binding.color.field),
-    fillValues: binding.fill.field === null ? null : table.column(binding.fill.field),
-    labelValues: binding.labelField === null ? null : table.column(binding.labelField),
-    ...emptyFrameExtras(),
-    ymin: binding.yminField === null ? null : table.numeric(binding.yminField),
-    ymax: binding.ymaxField === null ? null : table.numeric(binding.ymaxField),
-  };
+  return buildIdentityFrame(binding, table, groups);
 }
 
 /**

--- a/packages/core/src/pipeline/geometry-glyphs-rows.ts
+++ b/packages/core/src/pipeline/geometry-glyphs-rows.ts
@@ -1,0 +1,45 @@
+/**
+ * Per-row text glyph emission into mutable geometry buffers.
+ */
+import { bandKey } from "../scales/train.js";
+
+import type { LayerFrame, ResolvedColorScale } from "./types.js";
+import { colorOf } from "./types.js";
+import type { Frame } from "./geometry-shared.js";
+import { positionOf } from "./geometry-shared.js";
+
+export function emitGlyphRows(input: {
+  frame: LayerFrame;
+  fx: Frame;
+  color: ResolvedColorScale | null;
+  wantsColors: boolean;
+  dx: number;
+  dy: number;
+  positions: number[];
+  rowIndex: number[];
+  texts: string[];
+  colors: string[];
+}): number {
+  const { frame, fx, color, wantsColors, dx, dy, positions, rowIndex, texts, colors } = input;
+  const { binding, n } = frame;
+  let removed = 0;
+  for (let row = 0; row < n; row++) {
+    const tx = positionOf(fx.xScale, frame.xNumeric, frame.xValues, row, frame.offsetX);
+    const ty = positionOf(fx.yScale, frame.yNumeric, null, row, frame.offsetY);
+    const label =
+      binding.labelConstant ?? (frame.labelValues === null ? null : frame.labelValues[row]);
+    if (Number.isNaN(tx) || Number.isNaN(ty) || label === null) {
+      removed++;
+      continue;
+    }
+    positions.push(tx * fx.innerWidth + dx, fx.innerHeight - ty * fx.innerHeight + dy);
+    rowIndex.push(frame.rowIndex[row]!);
+    texts.push(bandKey(label));
+    if (wantsColors && color !== null) {
+      const value =
+        frame.colorValues === null ? binding.color.scaledConstant! : frame.colorValues[row]!;
+      colors.push(colorOf(color, value));
+    }
+  }
+  return removed;
+}

--- a/packages/core/src/pipeline/geometry-glyphs.ts
+++ b/packages/core/src/pipeline/geometry-glyphs.ts
@@ -2,12 +2,11 @@
  * Text glyph geometry batch builder.
  */
 import type { GlyphsBatch } from "../scene.js";
-import { bandKey } from "../scales/train.js";
 
 import type { LayerFrame, PipelineWarning, ResolvedColorScale } from "./types.js";
-import { colorOf } from "./types.js";
 import type { Frame } from "./geometry-shared.js";
-import { DEFAULT_TEXT_SIZE, positionOf, removedWarning } from "./geometry-shared.js";
+import { DEFAULT_TEXT_SIZE, removedWarning } from "./geometry-shared.js";
+import { emitGlyphRows } from "./geometry-glyphs-rows.js";
 
 export function glyphsBatch(
   frame: LayerFrame,
@@ -15,7 +14,7 @@ export function glyphsBatch(
   color: ResolvedColorScale | null,
   warnings: PipelineWarning[],
 ): GlyphsBatch | null {
-  const { binding, n } = frame;
+  const { binding } = frame;
   const params = (binding.layer.params ?? {}) as {
     anchor?: "start" | "middle" | "end";
     size?: number;
@@ -23,33 +22,24 @@ export function glyphsBatch(
     dy?: number;
     alpha?: number;
   };
-  const dx = params.dx ?? 0;
-  const dy = params.dy ?? 0;
   const positions: number[] = [];
   const rowIndex: number[] = [];
   const texts: string[] = [];
   const colors: string[] = [];
   const wantsColors =
     color !== null && (frame.colorValues !== null || binding.color.scaledConstant !== null);
-  let removed = 0;
-  for (let row = 0; row < n; row++) {
-    const tx = positionOf(fx.xScale, frame.xNumeric, frame.xValues, row, frame.offsetX);
-    const ty = positionOf(fx.yScale, frame.yNumeric, null, row, frame.offsetY);
-    const label =
-      binding.labelConstant ?? (frame.labelValues === null ? null : frame.labelValues[row]);
-    if (Number.isNaN(tx) || Number.isNaN(ty) || label === null) {
-      removed++;
-      continue;
-    }
-    positions.push(tx * fx.innerWidth + dx, fx.innerHeight - ty * fx.innerHeight + dy);
-    rowIndex.push(frame.rowIndex[row]!);
-    texts.push(bandKey(label));
-    if (wantsColors) {
-      const value =
-        frame.colorValues === null ? binding.color.scaledConstant! : frame.colorValues[row]!;
-      colors.push(colorOf(color, value));
-    }
-  }
+  const removed = emitGlyphRows({
+    frame,
+    fx,
+    color,
+    wantsColors,
+    dx: params.dx ?? 0,
+    dy: params.dy ?? 0,
+    positions,
+    rowIndex,
+    texts,
+    colors,
+  });
   removedWarning(removed, binding.index, warnings);
   if (texts.length === 0) return null;
 

--- a/packages/core/src/pipeline/geometry-paths-line-write.ts
+++ b/packages/core/src/pipeline/geometry-paths-line-write.ts
@@ -1,0 +1,52 @@
+/**
+ * Write sorted line subpaths into path buffers.
+ */
+import type { LayerFrame, ResolvedColorScale } from "./types.js";
+import { colorOf } from "./types.js";
+import type { Frame } from "./geometry-shared.js";
+import { positionOf } from "./geometry-shared.js";
+
+export function writeLineSubpaths(input: {
+  frame: LayerFrame;
+  fx: Frame;
+  color: ResolvedColorScale | null;
+  subpaths: readonly (readonly number[])[];
+}): {
+  positions: Float32Array;
+  rowIndex: Uint32Array;
+  pathOffsets: Uint32Array;
+  strokes: (string | null)[];
+} {
+  const { frame, fx, color, subpaths } = input;
+  const { binding } = frame;
+
+  let total = 0;
+  for (const rows of subpaths) total += rows.length;
+  const positions = new Float32Array(total * 2);
+  const rowIndex = new Uint32Array(total);
+  const pathOffsets = new Uint32Array(subpaths.length + 1);
+  const strokes: (string | null)[] = [];
+  let cursor = 0;
+  for (let s = 0; s < subpaths.length; s++) {
+    pathOffsets[s] = cursor;
+    const rows = subpaths[s]!;
+    for (const row of rows) {
+      const tx = positionOf(fx.xScale, frame.xNumeric, frame.xValues, row);
+      const ty = positionOf(fx.yScale, frame.yNumeric, null, row);
+      positions[cursor * 2] = tx * fx.innerWidth;
+      positions[cursor * 2 + 1] = fx.innerHeight - ty * fx.innerHeight;
+      rowIndex[cursor] = frame.rowIndex[row]!;
+      cursor++;
+    }
+    let stroke: string | null = binding.color.constant;
+    if (color !== null && (frame.colorValues !== null || binding.color.scaledConstant !== null)) {
+      const first = rows[0]!;
+      const value =
+        frame.colorValues === null ? binding.color.scaledConstant! : frame.colorValues[first]!;
+      stroke = colorOf(color, value);
+    }
+    strokes.push(stroke);
+  }
+  pathOffsets[subpaths.length] = cursor;
+  return { positions, rowIndex, pathOffsets, strokes };
+}

--- a/packages/core/src/pipeline/geometry-paths-line.ts
+++ b/packages/core/src/pipeline/geometry-paths-line.ts
@@ -4,9 +4,9 @@
 import type { PathsBatch } from "../scene.js";
 
 import type { LayerFrame, PipelineWarning, ResolvedColorScale } from "./types.js";
-import { colorOf } from "./types.js";
 import type { Frame } from "./geometry-shared.js";
-import { DEFAULT_LINEWIDTH, bucketByGroup, positionOf, xSortKey } from "./geometry-shared.js";
+import { DEFAULT_LINEWIDTH, bucketByGroup, xSortKey } from "./geometry-shared.js";
+import { writeLineSubpaths } from "./geometry-paths-line-write.js";
 
 export function lineBatch(
   frame: LayerFrame,
@@ -20,34 +20,12 @@ export function lineBatch(
   const sortKey = xSortKey(frame, fx);
   for (const rows of subpaths) rows.sort((a, b) => sortKey(a) - sortKey(b));
 
-  let total = 0;
-  for (const rows of subpaths) total += rows.length;
-  const positions = new Float32Array(total * 2);
-  const rowIndex = new Uint32Array(total);
-  const pathOffsets = new Uint32Array(subpaths.length + 1);
-  const strokes: (string | null)[] = [];
-  let cursor = 0;
-  for (let s = 0; s < subpaths.length; s++) {
-    pathOffsets[s] = cursor;
-    const rows = subpaths[s]!;
-    for (const row of rows) {
-      const tx = positionOf(fx.xScale, frame.xNumeric, frame.xValues, row);
-      const ty = positionOf(fx.yScale, frame.yNumeric, null, row);
-      positions[cursor * 2] = tx * fx.innerWidth;
-      positions[cursor * 2 + 1] = fx.innerHeight - ty * fx.innerHeight;
-      rowIndex[cursor] = frame.rowIndex[row]!;
-      cursor++;
-    }
-    let stroke: string | null = binding.color.constant;
-    if (color !== null && (frame.colorValues !== null || binding.color.scaledConstant !== null)) {
-      const first = rows[0]!;
-      const value =
-        frame.colorValues === null ? binding.color.scaledConstant! : frame.colorValues[first]!;
-      stroke = colorOf(color, value);
-    }
-    strokes.push(stroke);
-  }
-  pathOffsets[subpaths.length] = cursor;
+  const { positions, rowIndex, pathOffsets, strokes } = writeLineSubpaths({
+    frame,
+    fx,
+    color,
+    subpaths,
+  });
 
   const params = binding.layer.geom === "line" ? (binding.layer.params ?? {}) : {};
   return {

--- a/packages/core/src/pipeline/geometry-points-collect.ts
+++ b/packages/core/src/pipeline/geometry-points-collect.ts
@@ -1,0 +1,47 @@
+/**
+ * Collect finite point positions (normalized) before pixel packing.
+ */
+import type { LayerFrame } from "./types.js";
+import type { Frame } from "./geometry-shared.js";
+import { positionOf } from "./geometry-shared.js";
+
+export interface CollectedPointPositions {
+  xs: Float64Array;
+  ys: Float64Array;
+  keptRows: Uint32Array;
+  kept: number;
+}
+
+export function collectPointPositions(frame: LayerFrame, fx: Frame): CollectedPointPositions {
+  const { n } = frame;
+  const xs = new Float64Array(n);
+  const ys = new Float64Array(n);
+  const keptRows = new Uint32Array(n);
+  let kept = 0;
+  for (let row = 0; row < n; row++) {
+    const tx = positionOf(fx.xScale, frame.xNumeric, frame.xValues, row, frame.offsetX);
+    const ty = positionOf(fx.yScale, frame.yNumeric, null, row, frame.offsetY);
+    if (Number.isNaN(tx) || Number.isNaN(ty)) continue;
+    xs[kept] = tx;
+    ys[kept] = ty;
+    keptRows[kept] = row;
+    kept++;
+  }
+  return { xs, ys, keptRows, kept };
+}
+
+export function packPointPixels(
+  collected: CollectedPointPositions,
+  frame: LayerFrame,
+  fx: Frame,
+): { positions: Float32Array; rowIndex: Uint32Array } {
+  const { xs, ys, keptRows, kept } = collected;
+  const positions = new Float32Array(kept * 2);
+  const rowIndex = new Uint32Array(kept);
+  for (let j = 0; j < kept; j++) {
+    positions[j * 2] = xs[j]! * fx.innerWidth;
+    positions[j * 2 + 1] = fx.innerHeight - ys[j]! * fx.innerHeight;
+    rowIndex[j] = frame.rowIndex[keptRows[j]!]!;
+  }
+  return { positions, rowIndex };
+}

--- a/packages/core/src/pipeline/geometry-points.ts
+++ b/packages/core/src/pipeline/geometry-points.ts
@@ -6,7 +6,8 @@ import type { PointsBatch } from "../scene.js";
 import type { LayerFrame, PipelineWarning, ResolvedColorScale } from "./types.js";
 import { colorOf } from "./types.js";
 import type { Frame } from "./geometry-shared.js";
-import { DEFAULT_POINT_SIZE, positionOf, removedWarning } from "./geometry-shared.js";
+import { DEFAULT_POINT_SIZE, removedWarning } from "./geometry-shared.js";
+import { collectPointPositions, packPointPixels } from "./geometry-points-collect.js";
 
 export function pointsBatch(
   frame: LayerFrame,
@@ -15,30 +16,11 @@ export function pointsBatch(
   warnings: PipelineWarning[],
 ): PointsBatch | null {
   const { binding, n } = frame;
-  const xs = new Float64Array(n);
-  const ys = new Float64Array(n);
-  const keptRows = new Uint32Array(n);
-  let kept = 0;
-  for (let row = 0; row < n; row++) {
-    const tx = positionOf(fx.xScale, frame.xNumeric, frame.xValues, row, frame.offsetX);
-    const ty = positionOf(fx.yScale, frame.yNumeric, null, row, frame.offsetY);
-    if (Number.isNaN(tx) || Number.isNaN(ty)) continue;
-    xs[kept] = tx;
-    ys[kept] = ty;
-    keptRows[kept] = row;
-    kept++;
-  }
-  removedWarning(n - kept, binding.index, warnings);
-  if (kept === 0) return null;
+  const collected = collectPointPositions(frame, fx);
+  removedWarning(n - collected.kept, binding.index, warnings);
+  if (collected.kept === 0) return null;
 
-  const positions = new Float32Array(kept * 2);
-  const rowIndex = new Uint32Array(kept);
-  for (let j = 0; j < kept; j++) {
-    positions[j * 2] = xs[j]! * fx.innerWidth;
-    positions[j * 2 + 1] = fx.innerHeight - ys[j]! * fx.innerHeight;
-    rowIndex[j] = frame.rowIndex[keptRows[j]!]!;
-  }
-
+  const { positions, rowIndex } = packPointPixels(collected, frame, fx);
   const params = binding.layer.geom === "point" ? (binding.layer.params ?? {}) : {};
   const batch: PointsBatch = {
     kind: "points",
@@ -52,9 +34,9 @@ export function pointsBatch(
     fill: binding.color.constant,
   };
   if (color !== null && (frame.colorValues !== null || binding.color.scaledConstant !== null)) {
-    const colors = Array.from<string>({ length: kept });
-    for (let j = 0; j < kept; j++) {
-      const row = keptRows[j]!;
+    const colors = Array.from<string>({ length: collected.kept });
+    for (let j = 0; j < collected.kept; j++) {
+      const row = collected.keptRows[j]!;
       const value =
         frame.colorValues === null ? binding.color.scaledConstant! : frame.colorValues[row]!;
       colors[j] = colorOf(color, value);

--- a/packages/core/src/pipeline/panel-layout-chrome-types.ts
+++ b/packages/core/src/pipeline/panel-layout-chrome-types.ts
@@ -1,0 +1,33 @@
+/**
+ * Panel layout chrome public shape (labs + display + legends).
+ */
+import type { LayoutTheme, TickFormatter } from "../layout/layout.js";
+import type { TextMeasurer } from "../layout/measure.js";
+import type { buildLegends } from "../legend.js";
+import type { PositionScale } from "../scales/train.js";
+
+export interface PanelLayoutChrome {
+  title: string;
+  subtitle: string;
+  caption: string;
+  xTitle: string;
+  yTitle: string;
+  hTitle: string;
+  vTitle: string;
+  topBand: number;
+  bottomBand: number;
+  axisTitleBand: number;
+  layoutHeight: number;
+  formatX: TickFormatter | undefined;
+  formatY: TickFormatter | undefined;
+  formatH: TickFormatter | undefined;
+  formatV: TickFormatter | undefined;
+  hBreaks: readonly (number | string)[] | undefined;
+  vBreaks: readonly (number | string)[] | undefined;
+  freeH: boolean;
+  freeV: boolean;
+  displayScales: (p: number) => { h: PositionScale; v: PositionScale };
+  measurer: TextMeasurer;
+  layoutTheme: LayoutTheme;
+  legendBlock: ReturnType<typeof buildLegends>;
+}

--- a/packages/core/src/pipeline/panel-layout-chrome.ts
+++ b/packages/core/src/pipeline/panel-layout-chrome.ts
@@ -3,43 +3,17 @@
  */
 import type { PortableSpec } from "@ggsvelte/spec";
 
-import type { LayoutTheme, TickFormatter } from "../layout/layout.js";
-import type { TextMeasurer } from "../layout/measure.js";
 import type { LegendInput, LegendOrder } from "../legend.js";
-import type { buildLegends } from "../legend.js";
 import type { PositionScale } from "../scales/train.js";
 import type { ThemeTokens } from "../theme.js";
 
 import { resolvePanelLayoutDisplay } from "./panel-layout-chrome-display.js";
 import { resolvePanelLayoutLabs } from "./panel-layout-chrome-labs.js";
 import { resolvePanelLayoutLegends } from "./panel-layout-chrome-legends.js";
+import type { PanelLayoutChrome } from "./panel-layout-chrome-types.js";
 import type { LayerFrame, PipelineWarning, RunOptions } from "./types.js";
 
-export interface PanelLayoutChrome {
-  title: string;
-  subtitle: string;
-  caption: string;
-  xTitle: string;
-  yTitle: string;
-  hTitle: string;
-  vTitle: string;
-  topBand: number;
-  bottomBand: number;
-  axisTitleBand: number;
-  layoutHeight: number;
-  formatX: TickFormatter | undefined;
-  formatY: TickFormatter | undefined;
-  formatH: TickFormatter | undefined;
-  formatV: TickFormatter | undefined;
-  hBreaks: readonly (number | string)[] | undefined;
-  vBreaks: readonly (number | string)[] | undefined;
-  freeH: boolean;
-  freeV: boolean;
-  displayScales: (p: number) => { h: PositionScale; v: PositionScale };
-  measurer: TextMeasurer;
-  layoutTheme: LayoutTheme;
-  legendBlock: ReturnType<typeof buildLegends>;
-}
+export type { PanelLayoutChrome } from "./panel-layout-chrome-types.js";
 
 export function resolvePanelLayoutChrome(input: {
   flip: boolean;

--- a/packages/core/src/pipeline/scale-color-collect.ts
+++ b/packages/core/src/pipeline/scale-color-collect.ts
@@ -1,0 +1,40 @@
+/**
+ * Collect color/fill channel values across panel frames for scale training.
+ */
+import type { CellValue } from "../table.js";
+import type { ColumnTable } from "../table.js";
+
+import type { LayerFrame } from "./types.js";
+
+export interface CollectedColorChannel {
+  values: CellValue[];
+  anyDiscreteField: boolean;
+  anyField: boolean;
+}
+
+export function collectColorChannelValues(
+  name: "color" | "fill",
+  frames: readonly LayerFrame[],
+  table: ColumnTable,
+): CollectedColorChannel {
+  const values: CellValue[] = [];
+  let anyDiscreteField = false;
+  let anyField = false;
+  for (const frame of frames) {
+    const channel = name === "color" ? frame.binding.color : frame.binding.fill;
+    const frameValues = name === "color" ? frame.colorValues : frame.fillValues;
+    if (channel.field !== null && frameValues !== null) {
+      anyField = true;
+      if (table.has(channel.field) && table.discreteness(channel.field) === "discrete") {
+        anyDiscreteField = true;
+      }
+      for (const v of frameValues) values.push(v);
+    }
+    if (channel.scaledConstant !== null) {
+      anyDiscreteField = true;
+      anyField = true;
+      values.push(channel.scaledConstant);
+    }
+  }
+  return { values, anyDiscreteField, anyField };
+}

--- a/packages/core/src/pipeline/scale-color-ordinal-range.ts
+++ b/packages/core/src/pipeline/scale-color-ordinal-range.ts
@@ -1,0 +1,26 @@
+/**
+ * Resolve ordinal color range from explicit config vs edition defaults.
+ */
+import type { ColorScaleSpec } from "@ggsvelte/spec";
+
+import type { EditionDefaults } from "../editions.js";
+import { CATEGORICAL_PALETTE_10 } from "../scales/train.js";
+
+/**
+ * Edition-keyed default palette: for edition 1 nothing is passed (trainColor
+ * keeps its "observable10" scheme fingerprint — byte-stable with pre-edition
+ * state); other editions pass their palette as an explicit range.
+ * Named schemes resolve inside trainColor; edition defaults only apply when
+ * the caller supplied neither a scheme nor an explicit range.
+ */
+export function resolveOrdinalColorRange(
+  config: ColorScaleSpec | undefined,
+  editionDefaults: EditionDefaults,
+): readonly string[] | undefined {
+  const scheme = config?.scheme;
+  const editionPalette =
+    editionDefaults.categoricalPalette === CATEGORICAL_PALETTE_10
+      ? undefined
+      : editionDefaults.categoricalPalette;
+  return config?.range ?? (scheme === undefined ? editionPalette : undefined);
+}

--- a/packages/core/src/pipeline/scale-color-ordinal.ts
+++ b/packages/core/src/pipeline/scale-color-ordinal.ts
@@ -7,9 +7,10 @@ import type { EditionDefaults } from "../editions.js";
 import type { ScaleState } from "../scales/state.js";
 import { PaletteExhaustedError } from "../scales/state.js";
 import type { ColorScale } from "../scales/train.js";
-import { CATEGORICAL_PALETTE_10, trainColor } from "../scales/train.js";
+import { trainColor } from "../scales/train.js";
 import type { CellValue } from "../table.js";
 
+import { resolveOrdinalColorRange } from "./scale-color-ordinal-range.js";
 import type { ColorResolution } from "./scale-color-types.js";
 import type { Advisory, PipelineWarning } from "./types.js";
 import { PipelineError } from "./types.js";
@@ -28,16 +29,7 @@ export function resolveOrdinalColorScale(input: {
     input;
 
   const scheme = config?.scheme;
-  // Edition-keyed default palette: for edition 1 nothing is passed (trainColor
-  // keeps its "observable10" scheme fingerprint — byte-stable with pre-edition
-  // state); other editions pass their palette as an explicit range.
-  const editionPalette =
-    editionDefaults.categoricalPalette === CATEGORICAL_PALETTE_10
-      ? undefined
-      : editionDefaults.categoricalPalette;
-  // A named scheme resolves inside trainColor. Edition defaults only apply
-  // when the caller supplied neither a scheme nor an explicit range.
-  const range = config?.range ?? (scheme === undefined ? editionPalette : undefined);
+  const range = resolveOrdinalColorRange(config, editionDefaults);
   let scale: ColorScale;
   try {
     scale = trainColor(values, prevState, {

--- a/packages/core/src/pipeline/scale-color.ts
+++ b/packages/core/src/pipeline/scale-color.ts
@@ -4,10 +4,10 @@
 import type { ColorScaleSpec } from "@ggsvelte/spec";
 
 import type { ScaleState } from "../scales/state.js";
-import type { CellValue } from "../table.js";
 import type { ColumnTable } from "../table.js";
 import type { EditionDefaults } from "../editions.js";
 
+import { collectColorChannelValues } from "./scale-color-collect.js";
 import { resolveOrdinalColorScale } from "./scale-color-ordinal.js";
 import { resolveSequentialColorScale } from "./scale-color-sequential.js";
 import type { ColorResolution } from "./scale-color-types.js";
@@ -26,25 +26,7 @@ export function resolveColorScale(
   advisories: Advisory[],
   editionDefaults: EditionDefaults,
 ): ColorResolution {
-  const values: CellValue[] = [];
-  let anyDiscreteField = false;
-  let anyField = false;
-  for (const frame of frames) {
-    const channel = name === "color" ? frame.binding.color : frame.binding.fill;
-    const frameValues = name === "color" ? frame.colorValues : frame.fillValues;
-    if (channel.field !== null && frameValues !== null) {
-      anyField = true;
-      if (table.has(channel.field) && table.discreteness(channel.field) === "discrete") {
-        anyDiscreteField = true;
-      }
-      for (const v of frameValues) values.push(v);
-    }
-    if (channel.scaledConstant !== null) {
-      anyDiscreteField = true;
-      anyField = true;
-      values.push(channel.scaledConstant);
-    }
-  }
+  const { values, anyDiscreteField, anyField } = collectColorChannelValues(name, frames, table);
   if (!anyField) return { resolved: null, legendInput: null, state: null };
 
   const type = config?.type ?? (anyDiscreteField ? "ordinal" : "sequential");

--- a/packages/core/tests/pipeline-build-candidates.test.ts
+++ b/packages/core/tests/pipeline-build-candidates.test.ts
@@ -208,3 +208,35 @@ describe("isAllSourceBacked", () => {
     ).toBe(false);
   });
 });
+
+describe("collectColorChannelValues", () => {
+  it("returns empty when no color mapping is present", async () => {
+    const { collectColorChannelValues } = await import("../src/pipeline/scale-color-collect.ts");
+    const table = { has: () => false, discreteness: () => "continuous" } as never;
+    const frames = [
+      {
+        binding: {
+          color: { field: null, scaledConstant: null },
+          fill: { field: null, scaledConstant: null },
+        },
+        colorValues: null,
+        fillValues: null,
+      },
+    ] as never;
+    expect(collectColorChannelValues("color", frames, table)).toEqual({
+      values: [],
+      anyDiscreteField: false,
+      anyField: false,
+    });
+  });
+});
+
+describe("panelValueToken", () => {
+  it("prefixes values by type and treats -0 as 0", async () => {
+    const { panelValueToken } = await import("../src/pipeline/facets-tokens.ts");
+    expect(panelValueToken(null)).toBe("null");
+    expect(panelValueToken("a")).toBe("s:a");
+    expect(panelValueToken(-0)).toBe("n:0");
+    expect(panelValueToken(true)).toBe("b:true");
+  });
+});

--- a/packages/core/tests/pipeline-geometry.test.ts
+++ b/packages/core/tests/pipeline-geometry.test.ts
@@ -451,3 +451,42 @@ describe("BOX_MEDIAN_FATTEN", () => {
     expect(BOX_MEDIAN_FATTEN).toBe(2);
   });
 });
+
+describe("collectPointPositions", () => {
+  it("drops NaN positions and keeps finite points", async () => {
+    const { collectPointPositions } = await import("../src/pipeline/geometry-points-collect.ts");
+    const frame = {
+      n: 3,
+      xNumeric: new Float64Array([0, NaN, 1]),
+      yNumeric: new Float64Array([0.5, 0.5, 0.25]),
+      xValues: null,
+      offsetX: null,
+      offsetY: null,
+      rowIndex: new Uint32Array([0, 1, 2]),
+    } as never;
+    const fx = {
+      innerWidth: 100,
+      innerHeight: 200,
+      xScale: { type: "linear", normalize: (v: number) => v },
+      yScale: { type: "linear", normalize: (v: number) => v },
+    } as never;
+    const collected = collectPointPositions(frame, fx);
+    expect(collected.kept).toBe(2);
+    expect([...collected.keptRows.subarray(0, 2)]).toEqual([0, 2]);
+  });
+});
+
+describe("placeSceneLegends", () => {
+  it("offsets legend x by scene width minus block width and edge pad", async () => {
+    const { placeSceneLegends } = await import("../src/pipeline/assemble-scene-legends.ts");
+    const { LEGEND_EDGE_PAD } = await import("../src/pipeline/layout-helpers.ts");
+    const legends = placeSceneLegends({
+      legends: [{ x: 0, y: 5, width: 10, height: 10, title: "", items: [] } as never],
+      legendWidth: 40,
+      sceneWidth: 200,
+      panelY: 12,
+    });
+    expect(legends[0]!.x).toBe(200 - 40 - LEGEND_EDGE_PAD);
+    expect(legends[0]!.y).toBe(5 + 12);
+  });
+});


### PR DESCRIPTION
## Summary
- Extract identity candidate assemble after locate; panel chrome types; color channel collect and ordinal range helpers.
- Split glyph/point/line geometry helpers; annotation and identity frame builders; finalize assemble packing.
- Extract facet identity tokens and scene legend placement behind stable facades.
- Add characterization tests for point collection, legend placement, color collect, and facet value tokens.

## Test plan
- [x] `bun test packages/core` (515 pass)
- [x] `bun run check`
- [x] `bun run knip`
- [x] `bun run lint:type-aware`
- [x] Codex pre-PR review (`gpt-5.6-terra`) — PASS (no P1)