### PR TITLE
refactor(svelte): carry pointer begin-area corners payload

### DIFF
--- a/packages/svelte/src/lib/GGPlot.svelte
+++ b/packages/svelte/src/lib/GGPlot.svelte
@@ -98,7 +98,6 @@
   import {
     brushAtPoint,
     brushWithEnd,
-    initialBrushRect,
     nudgeBrushEnd,
   } from "./plot-area-brush.js";
   import {
@@ -1887,27 +1886,26 @@
     // Always cancel queued inspection before pure routing (host cleanup).
     queuedPointerInspection = null;
     reducer.cancelScheduledPointer();
+    // point always computed (pure begin-area needs it; touch/none ignore).
+    const p = plotPoint(event);
     const action = resolvePointerDownAction({
       pointerType: event.pointerType,
       button: event.button,
       activeTool,
       areaAwaitingSecond,
-      hasBrushDraft: brushRect !== null,
+      brushCorners: brushRect,
+      point: p,
     });
     switch (action.type) {
       case "touch-inspect-start":
-        touchInspectStart = plotPoint(event);
+        touchInspectStart = p;
         touchInspectMoved = false;
         break;
       case "none":
         break;
       case "begin-area": {
-        const p = plotPoint(event);
-        brushRect = initialBrushRect({
-          extendExisting: action.extendExisting,
-          existing: brushRect,
-          point: p,
-        });
+        // Pure table owns fresh vs extend corner policy.
+        brushRect = action.corners;
         setInspection(null, action.source);
         reducer.dispatch({
           type: "begin-area",
@@ -1917,7 +1915,7 @@
         if (action.emitSelectStart) {
           const startEvent = selectionEvent(
             "start",
-            normalizedRect(brushRect),
+            normalizedRect(action.corners),
             action.source,
           );
           emitSelection(startEvent);

--- a/packages/svelte/src/lib/plot-area-brush.ts
+++ b/packages/svelte/src/lib/plot-area-brush.ts
@@ -22,15 +22,17 @@ export function brushWithEnd(corners: BrushCorners, point: PlotPoint): BrushCorn
 }
 
 /**
- * Pointer-down begin-area corners: extend the free corner of an existing draft
- * when `extendExisting`, otherwise start a degenerate brush at `point`.
+ * Pointer-down begin-area corners.
+ * Extend free corner only when reducer is awaiting second AND draft exists;
+ * otherwise start a degenerate brush at `point`. Both conditions are required
+ * so a surviving draft without first-corner state restarts fresh (not extend).
  */
 export function initialBrushRect(input: {
-  readonly extendExisting: boolean;
+  readonly areaAwaitingSecond: boolean;
   readonly existing: BrushCorners | null;
   readonly point: PlotPoint;
 }): BrushCorners {
-  return input.extendExisting && input.existing !== null
+  return input.areaAwaitingSecond && input.existing !== null
     ? brushWithEnd(input.existing, input.point)
     : brushAtPoint(input.point);
 }

--- a/packages/svelte/src/lib/plot-surface-pointer.ts
+++ b/packages/svelte/src/lib/plot-surface-pointer.ts
@@ -1,11 +1,13 @@
 import { isAreaTool, type InteractionTool } from "./interaction.js";
-import type { BrushCorners, PlotPoint } from "./plot-area-brush.js";
+import { initialBrushRect, type BrushCorners, type PlotPoint } from "./plot-area-brush.js";
 import { resolvePointerFinishBrushAction, type FinishBrushAction } from "./plot-brush-finish.js";
 
 /**
  * Capture-surface pointer decision input for pointerdown.
- * `hasBrushDraft` mirrors `brushRect !== null` and can diverge from
- * reducer `areaAwaitingSecond` (same draft/reducer split as keyboard).
+ *
+ * `brushCorners` is the sole draft source of truth (host: `brushRect`).
+ * Distinct from reducer `areaAwaitingSecond` — both must hold to extend.
+ * `point` is the down-event plot point (host always computes it).
  */
 export type SurfacePointerDownInput = {
   readonly pointerType: string;
@@ -13,15 +15,24 @@ export type SurfacePointerDownInput = {
   readonly activeTool: InteractionTool;
   /** Reducer "awaiting second corner" flag. */
   readonly areaAwaitingSecond: boolean;
-  /** True when a brush draft corner exists (`brushRect !== null`). */
-  readonly hasBrushDraft: boolean;
+  /**
+   * Host: `brushRect`. Non-null when a draft free corner exists.
+   * Extend only when combined with `areaAwaitingSecond`.
+   */
+  readonly brushCorners: BrushCorners | null;
+  /** Host: `plotPoint(event)` — always available on pointerdown. */
+  readonly point: PlotPoint;
 };
 
 export type SurfacePointerDownAction =
   | { readonly type: "touch-inspect-start" }
   | {
       readonly type: "begin-area";
-      readonly extendExisting: boolean;
+      /**
+       * Pure-owned draft corners (fresh degenerate or extended free corner).
+       * Host assigns `brushRect = action.corners` without re-deriving policy.
+       */
+      readonly corners: BrushCorners;
       /** Emit select-area start event (not zoom; not second-corner await). */
       readonly emitSelectStart: boolean;
       /** Interaction source for setInspection clear + select-start emission. */
@@ -32,11 +43,12 @@ export type SurfacePointerDownAction =
 /**
  * Pure decision for the plot capture-surface `pointerdown` handler.
  * Priority: touch-inspect start (before button/tool checks) → primary-button
- * area begin/extend → none. Callers own queued-inspection cancel, draft
- * mutation, reducer dispatch, selection start emission, and capture.
+ * area begin/extend → none. Owns extend-vs-fresh corner policy via
+ * `initialBrushRect`. Callers own queued-inspection cancel, draft mutation,
+ * reducer dispatch, selection start emission, and capture.
  */
 export function resolvePointerDownAction(input: SurfacePointerDownInput): SurfacePointerDownAction {
-  const { pointerType, button, activeTool, areaAwaitingSecond, hasBrushDraft } = input;
+  const { pointerType, button, activeTool, areaAwaitingSecond, brushCorners, point } = input;
 
   if (activeTool === "inspect" && pointerType === "touch") return { type: "touch-inspect-start" };
 
@@ -45,7 +57,11 @@ export function resolvePointerDownAction(input: SurfacePointerDownInput): Surfac
 
   return {
     type: "begin-area",
-    extendExisting: areaAwaitingSecond && hasBrushDraft,
+    corners: initialBrushRect({
+      areaAwaitingSecond,
+      existing: brushCorners,
+      point,
+    }),
     emitSelectStart: activeTool === "select-area" && !areaAwaitingSecond,
     source: interactionSourceFromPointerType(pointerType),
   };

--- a/packages/svelte/tests/plot-area-brush.test.ts
+++ b/packages/svelte/tests/plot-area-brush.test.ts
@@ -18,31 +18,41 @@ describe("brushAtPoint", () => {
 });
 
 describe("initialBrushRect", () => {
-  it("starts a degenerate brush when not extending or existing is null", () => {
+  it("starts a degenerate brush when not awaiting second or existing is null", () => {
     expect(
       initialBrushRect({
-        extendExisting: false,
+        areaAwaitingSecond: false,
         existing: { x0: 1, y0: 2, x1: 3, y1: 4 },
         point: { x: 9, y: 8 },
       }),
     ).toEqual({ x0: 9, y0: 8, x1: 9, y1: 8 });
     expect(
       initialBrushRect({
-        extendExisting: true,
+        areaAwaitingSecond: true,
         existing: null,
         point: { x: 5, y: 6 },
       }),
     ).toEqual({ x0: 5, y0: 6, x1: 5, y1: 6 });
   });
 
-  it("extends the free corner of an existing draft", () => {
+  it("extends the free corner only when awaiting second AND draft exists", () => {
     expect(
       initialBrushRect({
-        extendExisting: true,
+        areaAwaitingSecond: true,
         existing: { x0: 1, y0: 2, x1: 3, y1: 4 },
         point: { x: 9, y: 8 },
       }),
     ).toEqual({ x0: 1, y0: 2, x1: 9, y1: 8 });
+  });
+
+  it("restarts fresh when draft exists but reducer is not awaiting second", () => {
+    expect(
+      initialBrushRect({
+        areaAwaitingSecond: false,
+        existing: { x0: 1, y0: 2, x1: 3, y1: 4 },
+        point: { x: 9, y: 8 },
+      }),
+    ).toEqual({ x0: 9, y0: 8, x1: 9, y1: 8 });
   });
 });
 

--- a/packages/svelte/tests/plot-surface-pointer.test.ts
+++ b/packages/svelte/tests/plot-surface-pointer.test.ts
@@ -21,18 +21,20 @@ import {
   type SurfacePointerUpInput,
 } from "../src/lib/plot-surface-pointer.js";
 
+const downPoint = { x: 9, y: 8 } as const;
+const draftCorners = { x0: 10, y0: 20, x1: 10, y1: 20 } as const;
+const endAt = { x: 40, y: 50 } as const;
+
 const down = (
   overrides: Partial<SurfacePointerDownInput> & Pick<SurfacePointerDownInput, "activeTool">,
 ): SurfacePointerDownInput => ({
   pointerType: "mouse",
   button: 0,
   areaAwaitingSecond: false,
-  hasBrushDraft: false,
+  brushCorners: null,
+  point: downPoint,
   ...overrides,
 });
-
-const draftCorners = { x0: 10, y0: 20, x1: 10, y1: 20 } as const;
-const endAt = { x: 40, y: 50 } as const;
 
 const up = (
   overrides: Partial<SurfacePointerUpInput> & Pick<SurfacePointerUpInput, "activeTool">,
@@ -97,63 +99,67 @@ describe("resolvePointerDownAction", () => {
   });
 
   it.each(["select-area", "zoom-area"] as const)(
-    "%s begins a new area draft when not extending",
+    "%s begins a new area draft with degenerate corners when not extending",
     (tool: InteractionTool) => {
       expect(resolvePointerDownAction(down({ activeTool: tool }))).toEqual({
         type: "begin-area",
-        extendExisting: false,
+        corners: { x0: 9, y0: 8, x1: 9, y1: 8 },
         emitSelectStart: tool === "select-area",
         source: "pointer",
       });
     },
   );
 
-  it("extends only when awaiting second corner AND draft exists", () => {
+  it("extends free corner when awaiting second AND draft exists", () => {
     expect(
       resolvePointerDownAction(
         down({
           activeTool: "select-area",
           areaAwaitingSecond: true,
-          hasBrushDraft: true,
+          brushCorners: { x0: 1, y0: 2, x1: 3, y1: 4 },
+          point: { x: 9, y: 8 },
         }),
       ),
     ).toEqual({
       type: "begin-area",
-      extendExisting: true,
+      corners: { x0: 1, y0: 2, x1: 9, y1: 8 },
       emitSelectStart: false,
       source: "pointer",
     });
   });
 
-  it("does not extend when awaiting second corner but draft is missing", () => {
+  it("starts fresh when awaiting second but draft is missing", () => {
     expect(
       resolvePointerDownAction(
         down({
           activeTool: "zoom-area",
           areaAwaitingSecond: true,
-          hasBrushDraft: false,
+          brushCorners: null,
+          point: { x: 5, y: 6 },
         }),
       ),
     ).toEqual({
       type: "begin-area",
-      extendExisting: false,
+      corners: { x0: 5, y0: 6, x1: 5, y1: 6 },
       emitSelectStart: false,
       source: "pointer",
     });
   });
 
-  it("does not extend when draft exists but reducer is not awaiting second", () => {
+  it("restarts fresh when draft exists but reducer is not awaiting second", () => {
+    // Regression: draft alone must not extend — both gates required.
     expect(
       resolvePointerDownAction(
         down({
           activeTool: "select-area",
           areaAwaitingSecond: false,
-          hasBrushDraft: true,
+          brushCorners: { x0: 1, y0: 2, x1: 3, y1: 4 },
+          point: { x: 9, y: 8 },
         }),
       ),
     ).toEqual({
       type: "begin-area",
-      extendExisting: false,
+      corners: { x0: 9, y0: 8, x1: 9, y1: 8 },
       emitSelectStart: true,
       source: "pointer",
     });
@@ -169,7 +175,7 @@ describe("resolvePointerDownAction", () => {
       ),
     ).toEqual({
       type: "begin-area",
-      extendExisting: false,
+      corners: { x0: 9, y0: 8, x1: 9, y1: 8 },
       emitSelectStart: true,
       source: "touch",
     });


### PR DESCRIPTION
## Summary

- Expand pointer-down `begin-area` to carry pure-owned `corners` from `initialBrushRect` (fresh degenerate vs extend free corner).
- Replace `hasBrushDraft` / `extendExisting` with `brushCorners` + `areaAwaitingSecond` gates so `{extend: true, existing: null}` is unrepresentable.
- `initialBrushRect` takes `areaAwaitingSecond` + `existing` (both required to extend).
- Host assigns `brushRect = action.corners` and emits select-start from `action.corners` only.

## Test plan

- [x] Fresh begin corners payload (select-area / zoom-area)
- [x] Extend when awaiting second AND draft exists
- [x] Fresh when awaiting second but draft missing
- [x] Fresh when draft exists without awaiting second (regression)
- [x] svelte-check + pre-push hooks
- [ ] CI on PR