### PR TITLE
refactor(core): split candidate attrs, facet cells, closed paths, rects

### DIFF
--- a/packages/core/src/pipeline/assemble-geometry-batches.ts
+++ b/packages/core/src/pipeline/assemble-geometry-batches.ts
@@ -4,9 +4,9 @@
 import type { GeometryBatch } from "../scene.js";
 import type { PositionScale } from "../scales/train.js";
 
+import { geometryPanelFrame } from "./assemble-geometry-panel-frame.js";
 import type { FacetPanelDef } from "./facets.js";
 import { buildBatch, flipBatchInPlace } from "./geometry.js";
-import type { Frame } from "./geometry.js";
 import type { PanelPlacement } from "./panel-layout.js";
 import type { LayerFrame, PipelineWarning, ResolvedColorScale } from "./types.js";
 
@@ -33,29 +33,18 @@ export function buildGeometryBatches(input: {
     warnings,
   } = input;
   const batches: GeometryBatch[] = [];
-  const panelFrame = (p: number): Frame => {
-    const placement = placements[p]!;
-    const scales = panelScales[p]!;
-    return flip
-      ? {
-          innerWidth: placement.height,
-          innerHeight: placement.width,
-          xScale: scales.x,
-          yScale: scales.y,
-        }
-      : {
-          innerWidth: placement.width,
-          innerHeight: placement.height,
-          xScale: scales.x,
-          yScale: scales.y,
-        };
-  };
   for (let index = 0; index < layerCount; index++) {
     for (let p = 0; p < facetPanels.length; p++) {
       const frame = panelFrames[p]?.[index];
       if (frame === undefined) continue;
       const placement = placements[p]!;
-      const built = buildBatch(frame, panelFrame(p), color, fill, warnings);
+      const built = buildBatch(
+        frame,
+        geometryPanelFrame(placement, panelScales[p]!, flip),
+        color,
+        fill,
+        warnings,
+      );
       for (const batch of built) {
         if (flip) flipBatchInPlace(batch, placement.width, placement.height);
         batch.panelIndex = p;

--- a/packages/core/src/pipeline/assemble-geometry-panel-frame.ts
+++ b/packages/core/src/pipeline/assemble-geometry-panel-frame.ts
@@ -1,0 +1,27 @@
+/**
+ * Build the geometry Frame for one facet panel (optional coord flip extents).
+ */
+import type { PositionScale } from "../scales/train.js";
+
+import type { Frame } from "./geometry.js";
+import type { PanelPlacement } from "./panel-layout.js";
+
+export function geometryPanelFrame(
+  placement: PanelPlacement,
+  scales: { x: PositionScale; y: PositionScale },
+  flip: boolean,
+): Frame {
+  return flip
+    ? {
+        innerWidth: placement.height,
+        innerHeight: placement.width,
+        xScale: scales.x,
+        yScale: scales.y,
+      }
+    : {
+        innerWidth: placement.width,
+        innerHeight: placement.height,
+        xScale: scales.x,
+        yScale: scales.y,
+      };
+}

--- a/packages/core/src/pipeline/assemble-render-model-domains.ts
+++ b/packages/core/src/pipeline/assemble-render-model-domains.ts
@@ -1,0 +1,22 @@
+/**
+ * Freeze RenderModel domain and warning/advisory surfaces.
+ */
+import type { Advisory, PipelineWarning, RenderModel, ScaleDomainSnapshot } from "./types.js";
+import { dedupeAdvisories, dedupeWarnings } from "./layout-helpers.js";
+
+export function freezeRenderModelDomains(
+  baseline: ScaleDomainSnapshot,
+  effective: ScaleDomainSnapshot,
+): RenderModel["domains"] {
+  return Object.freeze({ baseline, effective });
+}
+
+export function dedupeRenderModelDiagnostics(
+  warnings: PipelineWarning[],
+  advisories: Advisory[],
+): { warnings: PipelineWarning[]; advisories: Advisory[] } {
+  return {
+    warnings: dedupeWarnings(warnings),
+    advisories: dedupeAdvisories(advisories),
+  };
+}

--- a/packages/core/src/pipeline/assemble-render-model.ts
+++ b/packages/core/src/pipeline/assemble-render-model.ts
@@ -11,6 +11,10 @@ import type { CandidateStore } from "../candidate-store.js";
 import type { LineageStore } from "../identity.js";
 
 import {
+  dedupeRenderModelDiagnostics,
+  freezeRenderModelDomains,
+} from "./assemble-render-model-domains.js";
+import {
   buildRenderModelAxisFormatters,
   buildRenderModelScales,
 } from "./assemble-render-model-scales.js";
@@ -24,7 +28,6 @@ import type {
   ResolvedColorScale,
   ScaleDomainSnapshot,
 } from "./types.js";
-import { dedupeAdvisories, dedupeWarnings } from "./layout-helpers.js";
 
 export function assembleRenderModel(input: {
   scene: Scene;
@@ -55,20 +58,18 @@ export function assembleRenderModel(input: {
     candidates,
     table: input.table,
   });
+  const diagnostics = dedupeRenderModelDiagnostics(input.warnings, input.advisories);
 
   return {
     scene,
     scales: buildRenderModelScales(input),
-    warnings: dedupeWarnings(input.warnings),
-    advisories: dedupeAdvisories(input.advisories),
+    warnings: diagnostics.warnings,
+    advisories: diagnostics.advisories,
     runId: input.runId,
     layerBackends: input.layerBackends,
     layerFields: input.layerFields,
     layerScaledConstants: input.layerScaledConstants,
-    domains: Object.freeze({
-      baseline: input.baselineDomains,
-      effective: input.effectiveDomains,
-    }),
+    domains: freezeRenderModelDomains(input.baselineDomains, input.effectiveDomains),
     lineage: input.lineage,
     candidates,
     axisFormatters: buildRenderModelAxisFormatters(

--- a/packages/core/src/pipeline/build-candidates-datum-assemble.ts
+++ b/packages/core/src/pipeline/build-candidates-datum-assemble.ts
@@ -4,88 +4,36 @@
 import type { CandidateBuildFacts, CandidateDatum } from "../candidate-store.js";
 
 import type { IdentityCandidateResolveContext } from "./build-candidates-datum-ctx.js";
-import { resolveAnnotationIntercepts } from "./build-candidates-datum-context.js";
+import { resolveIdentityCandidateAttrs } from "./build-candidates-datum-attrs.js";
 import type { LocatedIdentityCandidate } from "./build-candidates-datum-locate.js";
-import {
-  resolveCandidateSeries,
-  resolveRepresentedSourceRows,
-} from "./build-candidates-datum-series.js";
 import { resolveCandidateLogicalValues } from "./build-candidates-datum-values.js";
-import { candidateAutoMode } from "./frame.js";
 
 export function assembleIdentityCandidateDatum(
   ctx: IdentityCandidateResolveContext,
   facts: CandidateBuildFacts,
   located: LocatedIdentityCandidate,
 ): CandidateDatum {
-  const {
-    sourceRow,
-    frame,
-    outlierSourceRow,
-    frameRow,
-    derivedGroup,
-    sourceValue,
-    xField,
-    yField,
-    colorField,
-    fillField,
-    seriesByRow,
-    sourceRowsByGroup,
-  } = located;
-
-  const { group, seriesRank } = resolveCandidateSeries({
-    sourceRow,
-    derivedGroup,
-    seriesByRow,
-    panelIndex: facts.panelIndex,
-    layerIndex: facts.layerIndex,
-    color: ctx.color,
-    fill: ctx.fill,
-    colorField,
-    fillField,
-    sourceValue,
-  });
-  const autoMode = candidateAutoMode(
-    frame?.binding ?? ctx.bindings[facts.layerIndex]!,
-    facts.primitiveIndex,
-  );
-  const { annotationRule, annotationX, annotationY } = resolveAnnotationIntercepts({
-    frame,
-    primitiveIndex: facts.primitiveIndex,
-  });
-  const { sourceOrder, lineageKey } = resolveRepresentedSourceRows({
-    outlierSourceRow,
-    sourceRow,
-    group,
-    panelIndex: facts.panelIndex,
-    layerIndex: facts.layerIndex,
-    sourceRowsByGroup,
-    frame,
-    table: ctx.table,
-    frameRow,
-    lineage: ctx.lineage,
-    primitiveIndex: facts.primitiveIndex,
-  });
+  const attrs = resolveIdentityCandidateAttrs(ctx, facts, located);
   const { xValue, yValue } = resolveCandidateLogicalValues({
-    annotationRule,
-    annotationX,
-    annotationY,
-    outlierSourceRow,
-    sourceRow,
-    frame,
-    frameRow,
+    annotationRule: attrs.annotationRule,
+    annotationX: attrs.annotationX,
+    annotationY: attrs.annotationY,
+    outlierSourceRow: located.outlierSourceRow,
+    sourceRow: located.sourceRow,
+    frame: located.frame,
+    frameRow: located.frameRow,
     primitiveIndex: facts.primitiveIndex,
-    sourceValue,
-    xField,
-    yField,
+    sourceValue: located.sourceValue,
+    xField: located.xField,
+    yField: located.yField,
   });
   return {
     xValue,
     yValue,
-    seriesId: group,
-    seriesRank,
-    sourceOrder,
-    lineage: lineageKey,
-    autoMode,
+    seriesId: attrs.group,
+    seriesRank: attrs.seriesRank,
+    sourceOrder: attrs.sourceOrder,
+    lineage: attrs.lineageKey,
+    autoMode: attrs.autoMode,
   };
 }

--- a/packages/core/src/pipeline/build-candidates-datum-attrs.ts
+++ b/packages/core/src/pipeline/build-candidates-datum-attrs.ts
@@ -1,0 +1,88 @@
+/**
+ * Series, autoMode, annotation, and lineage attributes for identity candidates.
+ */
+import type { CandidateBuildFacts } from "../candidate-store.js";
+import type { CellValue } from "../table.js";
+
+import type { IdentityCandidateResolveContext } from "./build-candidates-datum-ctx.js";
+import { resolveAnnotationIntercepts } from "./build-candidates-datum-context.js";
+import type { LocatedIdentityCandidate } from "./build-candidates-datum-locate.js";
+import {
+  resolveCandidateSeries,
+  resolveRepresentedSourceRows,
+} from "./build-candidates-datum-series.js";
+import { candidateAutoMode } from "./frame.js";
+
+export interface IdentityCandidateAttrs {
+  group: number;
+  seriesRank: number;
+  autoMode: ReturnType<typeof candidateAutoMode>;
+  sourceOrder: number;
+  lineageKey: number;
+  annotationRule: boolean;
+  annotationX: CellValue;
+  annotationY: CellValue;
+}
+
+export function resolveIdentityCandidateAttrs(
+  ctx: IdentityCandidateResolveContext,
+  facts: CandidateBuildFacts,
+  located: LocatedIdentityCandidate,
+): IdentityCandidateAttrs {
+  const {
+    sourceRow,
+    frame,
+    outlierSourceRow,
+    frameRow,
+    derivedGroup,
+    sourceValue,
+    colorField,
+    fillField,
+    seriesByRow,
+    sourceRowsByGroup,
+  } = located;
+
+  const { group, seriesRank } = resolveCandidateSeries({
+    sourceRow,
+    derivedGroup,
+    seriesByRow,
+    panelIndex: facts.panelIndex,
+    layerIndex: facts.layerIndex,
+    color: ctx.color,
+    fill: ctx.fill,
+    colorField,
+    fillField,
+    sourceValue,
+  });
+  const autoMode = candidateAutoMode(
+    frame?.binding ?? ctx.bindings[facts.layerIndex]!,
+    facts.primitiveIndex,
+  );
+  const { annotationRule, annotationX, annotationY } = resolveAnnotationIntercepts({
+    frame,
+    primitiveIndex: facts.primitiveIndex,
+  });
+  const { sourceOrder, lineageKey } = resolveRepresentedSourceRows({
+    outlierSourceRow,
+    sourceRow,
+    group,
+    panelIndex: facts.panelIndex,
+    layerIndex: facts.layerIndex,
+    sourceRowsByGroup,
+    frame,
+    table: ctx.table,
+    frameRow,
+    lineage: ctx.lineage,
+    primitiveIndex: facts.primitiveIndex,
+  });
+  return {
+    group,
+    seriesRank,
+    autoMode,
+    sourceOrder,
+    lineageKey,
+    annotationRule,
+    annotationX,
+    annotationY,
+  };
+}

--- a/packages/core/src/pipeline/geometry-boxplot-body-layout-finalize.ts
+++ b/packages/core/src/pipeline/geometry-boxplot-body-layout-finalize.ts
@@ -1,0 +1,30 @@
+/**
+ * Finalize boxplot body buffers into a public layout result.
+ */
+import type { BoxplotParams } from "@ggsvelte/spec";
+
+import type { BoxplotBodyBuffers } from "./geometry-boxplot-body-layout-collect.js";
+import type { BoxplotBodyLayout } from "./geometry-boxplot-body-layout-types.js";
+
+export function finalizeBoxplotBodyLayout(
+  buffers: BoxplotBodyBuffers,
+  linewidth: number,
+  alpha: number,
+  params: BoxplotParams,
+): BoxplotBodyLayout | null {
+  if (buffers.keptRows.length === 0) return null;
+  return {
+    centerPx: buffers.centerPx,
+    halfPx: buffers.halfPx,
+    rects: buffers.rects,
+    rectRows: buffers.rectRows,
+    keptRows: buffers.keptRows,
+    whiskers: buffers.whiskers,
+    whiskerRows: buffers.whiskerRows,
+    medians: buffers.medians,
+    medianRows: buffers.medianRows,
+    linewidth,
+    alpha,
+    params,
+  };
+}

--- a/packages/core/src/pipeline/geometry-boxplot-body-layout-types.ts
+++ b/packages/core/src/pipeline/geometry-boxplot-body-layout-types.ts
@@ -1,0 +1,19 @@
+/**
+ * Boxplot body layout result shape.
+ */
+import type { BoxplotParams } from "@ggsvelte/spec";
+
+export interface BoxplotBodyLayout {
+  centerPx: number[];
+  halfPx: number[];
+  rects: number[];
+  rectRows: number[];
+  keptRows: number[];
+  whiskers: number[];
+  whiskerRows: number[];
+  medians: number[];
+  medianRows: number[];
+  linewidth: number;
+  alpha: number;
+  params: BoxplotParams;
+}

--- a/packages/core/src/pipeline/geometry-boxplot-body-layout.ts
+++ b/packages/core/src/pipeline/geometry-boxplot-body-layout.ts
@@ -11,24 +11,13 @@ import {
   pushKeptBoxplotRow,
   pushRemovedBoxplotRow,
 } from "./geometry-boxplot-body-layout-collect.js";
+import { finalizeBoxplotBodyLayout } from "./geometry-boxplot-body-layout-finalize.js";
+import type { BoxplotBodyLayout } from "./geometry-boxplot-body-layout-types.js";
 import { layoutBoxplotBodyRow } from "./geometry-boxplot-body-row.js";
 
-const DEFAULT_BOX_LINEWIDTH = 1;
+export type { BoxplotBodyLayout } from "./geometry-boxplot-body-layout-types.js";
 
-export interface BoxplotBodyLayout {
-  centerPx: number[];
-  halfPx: number[];
-  rects: number[];
-  rectRows: number[];
-  keptRows: number[];
-  whiskers: number[];
-  whiskerRows: number[];
-  medians: number[];
-  medianRows: number[];
-  linewidth: number;
-  alpha: number;
-  params: BoxplotParams;
-}
+const DEFAULT_BOX_LINEWIDTH = 1;
 
 export function layoutBoxplotBody(
   frame: LayerFrame,
@@ -64,20 +53,5 @@ export function layoutBoxplotBody(
     pushKeptBoxplotRow(buffers, geom, row);
   }
   removedWarning(buffers.removed, binding.index, warnings);
-  if (buffers.keptRows.length === 0) return null;
-
-  return {
-    centerPx: buffers.centerPx,
-    halfPx: buffers.halfPx,
-    rects: buffers.rects,
-    rectRows: buffers.rectRows,
-    keptRows: buffers.keptRows,
-    whiskers: buffers.whiskers,
-    whiskerRows: buffers.whiskerRows,
-    medians: buffers.medians,
-    medianRows: buffers.medianRows,
-    linewidth,
-    alpha,
-    params,
-  };
+  return finalizeBoxplotBodyLayout(buffers, linewidth, alpha, params);
 }

--- a/packages/core/src/pipeline/geometry-paths-area.ts
+++ b/packages/core/src/pipeline/geometry-paths-area.ts
@@ -7,7 +7,7 @@ import type { LayerFrame, PipelineWarning, ResolvedColorScale } from "./types.js
 import { colorOf } from "./types.js";
 import type { Frame } from "./geometry-shared.js";
 import { bucketByGroup, xSortKey } from "./geometry-shared.js";
-import { appendClosedBandEdges } from "./geometry-paths-closed.js";
+import { writeClosedPathGroups } from "./geometry-paths-closed-batch.js";
 
 export function areaBatch(
   frame: LayerFrame,
@@ -23,38 +23,23 @@ export function areaBatch(
   for (const rows of groupRows) rows.sort((a, b) => sortKey(a) - sortKey(b));
 
   // Draw later-stacked groups first so the first-seen group paints on top.
-  let total = 0;
-  for (const rows of groupRows) total += rows.length * 2;
-  const positions = new Float32Array(total * 2);
-  const rowIndex = new Uint32Array(total);
-  const pathOffsets = new Uint32Array(groupRows.length + 1);
-  const fills: (string | null)[] = [];
-  const strokes: (string | null)[] = [];
-  let cursor = 0;
-  for (let s = 0; s < groupRows.length; s++) {
-    pathOffsets[s] = cursor;
-    const rows = groupRows[s]!;
-    cursor = appendClosedBandEdges({
-      positions,
-      rowIndex,
-      cursor,
-      rows,
-      frame,
-      fx,
-      yTop: frame.ymax,
-      yBottom: frame.ymin,
-    });
-    let fillColor: string | null = binding.fill.constant;
-    if (fill !== null && (frame.fillValues !== null || binding.fill.scaledConstant !== null)) {
-      const first = rows[0]!;
-      const value =
-        frame.fillValues === null ? binding.fill.scaledConstant! : frame.fillValues[first]!;
-      fillColor = colorOf(fill, value);
-    }
-    fills.push(fillColor);
-    strokes.push(null);
-  }
-  pathOffsets[groupRows.length] = cursor;
+  const { positions, rowIndex, pathOffsets, fills, strokes } = writeClosedPathGroups({
+    frame,
+    fx,
+    groupRows,
+    yTop: frame.ymax,
+    yBottom: frame.ymin,
+    fillOf: (rows) => {
+      let fillColor: string | null = binding.fill.constant;
+      if (fill !== null && (frame.fillValues !== null || binding.fill.scaledConstant !== null)) {
+        const first = rows[0]!;
+        const value =
+          frame.fillValues === null ? binding.fill.scaledConstant! : frame.fillValues[first]!;
+        fillColor = colorOf(fill, value);
+      }
+      return fillColor;
+    },
+  });
 
   const params: { alpha?: number } =
     binding.layer.geom === "area" || binding.layer.geom === "density"

--- a/packages/core/src/pipeline/geometry-paths-closed-batch.ts
+++ b/packages/core/src/pipeline/geometry-paths-closed-batch.ts
@@ -1,0 +1,49 @@
+/**
+ * Allocate and fill multi-group closed path buffers with per-group fills.
+ */
+import type { LayerFrame } from "./types.js";
+import type { Frame } from "./geometry-shared.js";
+import { appendClosedBandEdges } from "./geometry-paths-closed.js";
+
+export function writeClosedPathGroups(input: {
+  frame: LayerFrame;
+  fx: Frame;
+  groupRows: readonly (readonly number[])[];
+  yTop: Float64Array;
+  yBottom: Float64Array;
+  fillOf: (rows: readonly number[]) => string | null;
+}): {
+  positions: Float32Array;
+  rowIndex: Uint32Array;
+  pathOffsets: Uint32Array;
+  fills: (string | null)[];
+  strokes: (string | null)[];
+} {
+  const { frame, fx, groupRows, yTop, yBottom, fillOf } = input;
+  let total = 0;
+  for (const rows of groupRows) total += rows.length * 2;
+  const positions = new Float32Array(total * 2);
+  const rowIndex = new Uint32Array(total);
+  const pathOffsets = new Uint32Array(groupRows.length + 1);
+  const fills: (string | null)[] = [];
+  const strokes: (string | null)[] = [];
+  let cursor = 0;
+  for (let s = 0; s < groupRows.length; s++) {
+    pathOffsets[s] = cursor;
+    const rows = groupRows[s]!;
+    cursor = appendClosedBandEdges({
+      positions,
+      rowIndex,
+      cursor,
+      rows,
+      frame,
+      fx,
+      yTop,
+      yBottom,
+    });
+    fills.push(fillOf(rows));
+    strokes.push(null);
+  }
+  pathOffsets[groupRows.length] = cursor;
+  return { positions, rowIndex, pathOffsets, fills, strokes };
+}

--- a/packages/core/src/pipeline/geometry-rects-emit.ts
+++ b/packages/core/src/pipeline/geometry-rects-emit.ts
@@ -1,0 +1,40 @@
+/**
+ * Emit bar/col rect pixels from resolved slots.
+ */
+import type { LayerFrame } from "./types.js";
+import type { Frame } from "./geometry-shared.js";
+import { resolveRectSlot } from "./geometry-rects-slot.js";
+
+export function emitRectRows(input: {
+  frame: LayerFrame;
+  fx: Frame;
+  binned: boolean;
+  widthFrac: number;
+}): {
+  rects: number[];
+  rowIndexKept: number[];
+  keptRows: number[];
+  removed: number;
+} {
+  const { frame, fx, binned, widthFrac } = input;
+  const { n } = frame;
+  const rects: number[] = [];
+  const rowIndexKept: number[] = [];
+  const keptRows: number[] = [];
+  let removed = 0;
+  for (let row = 0; row < n; row++) {
+    const slot = resolveRectSlot({ frame, fx, row, binned, widthFrac });
+    if (slot === null) {
+      removed++;
+      continue;
+    }
+    const xPx = (slot.center - slot.w / 2) * fx.innerWidth;
+    const wPx = slot.w * fx.innerWidth;
+    const y0 = fx.innerHeight - slot.t0 * fx.innerHeight;
+    const y1 = fx.innerHeight - slot.t1 * fx.innerHeight;
+    rects.push(xPx, Math.min(y0, y1), wPx, Math.abs(y1 - y0));
+    rowIndexKept.push(frame.rowIndex[row]!);
+    keptRows.push(row);
+  }
+  return { rects, rowIndexKept, keptRows, removed };
+}

--- a/packages/core/src/pipeline/geometry-rects.ts
+++ b/packages/core/src/pipeline/geometry-rects.ts
@@ -7,7 +7,7 @@ import type { LayerFrame, PipelineWarning, ResolvedColorScale } from "./types.js
 import { colorOf } from "./types.js";
 import type { Frame } from "./geometry-shared.js";
 import { DEFAULT_BAR_WIDTH, removedWarning } from "./geometry-shared.js";
-import { resolveRectSlot } from "./geometry-rects-slot.js";
+import { emitRectRows } from "./geometry-rects-emit.js";
 
 export function rectsBatch(
   frame: LayerFrame,
@@ -15,7 +15,7 @@ export function rectsBatch(
   fill: ResolvedColorScale | null,
   warnings: PipelineWarning[],
 ): RectsBatch | null {
-  const { binding, n } = frame;
+  const { binding } = frame;
   if (frame.ymin === null || frame.ymax === null) return null;
   const binned = frame.xmin !== null && frame.xmax !== null;
   if (!binned && fx.xScale.type !== "band") return null;
@@ -23,24 +23,12 @@ export function rectsBatch(
   const widthFrac =
     fx.xScale.type === "band" ? (params.width ?? DEFAULT_BAR_WIDTH) * fx.xScale.step : 0;
 
-  const rects: number[] = [];
-  const rowIndexKept: number[] = [];
-  const keptRows: number[] = [];
-  let removed = 0;
-  for (let row = 0; row < n; row++) {
-    const slot = resolveRectSlot({ frame, fx, row, binned, widthFrac });
-    if (slot === null) {
-      removed++;
-      continue;
-    }
-    const xPx = (slot.center - slot.w / 2) * fx.innerWidth;
-    const wPx = slot.w * fx.innerWidth;
-    const y0 = fx.innerHeight - slot.t0 * fx.innerHeight;
-    const y1 = fx.innerHeight - slot.t1 * fx.innerHeight;
-    rects.push(xPx, Math.min(y0, y1), wPx, Math.abs(y1 - y0));
-    rowIndexKept.push(frame.rowIndex[row]!);
-    keptRows.push(row);
-  }
+  const { rects, rowIndexKept, keptRows, removed } = emitRectRows({
+    frame,
+    fx,
+    binned,
+    widthFrac,
+  });
   removedWarning(removed, binding.index, warnings);
   if (keptRows.length === 0) return null;
 

--- a/packages/core/src/pipeline/geometry-smooth-ribbon.ts
+++ b/packages/core/src/pipeline/geometry-smooth-ribbon.ts
@@ -5,7 +5,7 @@ import type { GeometryBatch } from "../scene.js";
 
 import type { LayerFrame, ResolvedColorScale } from "./types.js";
 import type { Frame } from "./geometry-shared.js";
-import { appendClosedBandEdges } from "./geometry-paths-closed.js";
+import { writeClosedPathGroups } from "./geometry-paths-closed-batch.js";
 import { groupColor, SMOOTH_RIBBON_ALPHA } from "./geometry-smooth-shared.js";
 
 export function buildSmoothRibbonBatch(input: {
@@ -28,39 +28,25 @@ export function buildSmoothRibbonBatch(input: {
     .filter((rows) => rows.length > 1);
   if (bandRows.length === 0) return null;
 
-  let total = 0;
-  for (const rows of bandRows) total += rows.length * 2;
-  const positions = new Float32Array(total * 2);
-  const rowIndex = new Uint32Array(total);
-  const pathOffsets = new Uint32Array(bandRows.length + 1);
-  const fills: (string | null)[] = [];
-  const strokes: (string | null)[] = [];
-  let cursor = 0;
-  for (let s = 0; s < bandRows.length; s++) {
-    pathOffsets[s] = cursor;
-    const rows = bandRows[s]!;
-    cursor = appendClosedBandEdges({
-      positions,
-      rowIndex,
-      cursor,
-      rows,
-      frame,
-      fx,
-      yTop: frame.ymax,
-      yBottom: frame.ymin,
-    });
-    const first = rows[0]!;
-    // Ribbon tint: fill channel, else the line's color (band matches
-    // its line in multi-series smooths), else theme accent.
-    const ribbonFill =
-      groupColor(fill, frame.fillValues, binding.fill.scaledConstant, first) ??
-      binding.fill.constant ??
-      groupColor(color, frame.colorValues, binding.color.scaledConstant, first) ??
-      binding.color.constant;
-    fills.push(ribbonFill);
-    strokes.push(null);
-  }
-  pathOffsets[bandRows.length] = cursor;
+  const { positions, rowIndex, pathOffsets, fills, strokes } = writeClosedPathGroups({
+    frame,
+    fx,
+    groupRows: bandRows,
+    yTop: frame.ymax,
+    yBottom: frame.ymin,
+    fillOf: (rows) => {
+      const first = rows[0]!;
+      // Ribbon tint: fill channel, else the line's color (band matches
+      // its line in multi-series smooths), else theme accent.
+      return (
+        groupColor(fill, frame.fillValues, binding.fill.scaledConstant, first) ??
+        binding.fill.constant ??
+        groupColor(color, frame.colorValues, binding.color.scaledConstant, first) ??
+        binding.color.constant
+      );
+    },
+  });
+
   return {
     kind: "paths",
     layerIndex: binding.index,

--- a/packages/core/src/pipeline/panel-layout-chrome-display-flip.ts
+++ b/packages/core/src/pipeline/panel-layout-chrome-display-flip.ts
@@ -1,0 +1,50 @@
+/**
+ * Coord-flip remapping for display titles, formatters, breaks, and free flags.
+ */
+import type { TickFormatter } from "../layout/layout.js";
+import type { PositionScale } from "../scales/train.js";
+
+export function flipDisplayTitles(
+  flip: boolean,
+  xTitle: string,
+  yTitle: string,
+): { hTitle: string; vTitle: string } {
+  return flip ? { hTitle: yTitle, vTitle: xTitle } : { hTitle: xTitle, vTitle: yTitle };
+}
+
+export function flipDisplayFormatters(
+  flip: boolean,
+  formatX: TickFormatter | undefined,
+  formatY: TickFormatter | undefined,
+): { formatH: TickFormatter | undefined; formatV: TickFormatter | undefined } {
+  return flip ? { formatH: formatY, formatV: formatX } : { formatH: formatX, formatV: formatY };
+}
+
+export function flipDisplayBreaks(
+  flip: boolean,
+  xBreaks: readonly (number | string)[] | undefined,
+  yBreaks: readonly (number | string)[] | undefined,
+): {
+  hBreaks: readonly (number | string)[] | undefined;
+  vBreaks: readonly (number | string)[] | undefined;
+} {
+  return flip ? { hBreaks: yBreaks, vBreaks: xBreaks } : { hBreaks: xBreaks, vBreaks: yBreaks };
+}
+
+export function flipDisplayFreeFlags(
+  flip: boolean,
+  freeX: boolean,
+  freeY: boolean,
+): { freeH: boolean; freeV: boolean } {
+  return flip ? { freeH: freeY, freeV: freeX } : { freeH: freeX, freeV: freeY };
+}
+
+export function makeDisplayScalesFn(
+  flip: boolean,
+  panelScales: readonly { x: PositionScale; y: PositionScale }[],
+): (p: number) => { h: PositionScale; v: PositionScale } {
+  return (p: number) => {
+    const s = panelScales[p]!;
+    return flip ? { h: s.y, v: s.x } : { h: s.x, v: s.y };
+  };
+}

--- a/packages/core/src/pipeline/panel-layout-chrome-display.ts
+++ b/packages/core/src/pipeline/panel-layout-chrome-display.ts
@@ -7,6 +7,13 @@ import type { TickFormatter } from "../layout/layout.js";
 import type { PositionScale } from "../scales/train.js";
 
 import { makeAxisFormatter } from "./layout-helpers.js";
+import {
+  flipDisplayBreaks,
+  flipDisplayFormatters,
+  flipDisplayFreeFlags,
+  flipDisplayTitles,
+  makeDisplayScalesFn,
+} from "./panel-layout-chrome-display-flip.js";
 import type { PipelineWarning } from "./types.js";
 
 export interface PanelLayoutDisplay {
@@ -48,20 +55,16 @@ export function resolvePanelLayoutDisplay(input: {
     warnings,
   } = input;
 
-  const hTitle = flip ? yTitle : xTitle;
-  const vTitle = flip ? xTitle : yTitle;
   const formatX = makeAxisFormatter("x", xScale, scalesConfig.x, warnings);
   const formatY = makeAxisFormatter("y", yScale, scalesConfig.y, warnings);
-  const formatH = flip ? formatY : formatX;
-  const formatV = flip ? formatX : formatY;
-  const hBreaks = flip ? scalesConfig.y?.breaks : scalesConfig.x?.breaks;
-  const vBreaks = flip ? scalesConfig.x?.breaks : scalesConfig.y?.breaks;
-  const freeH = flip ? freeY : freeX;
-  const freeV = flip ? freeX : freeY;
-  const displayScales = (p: number): { h: PositionScale; v: PositionScale } => {
-    const s = panelScales[p]!;
-    return flip ? { h: s.y, v: s.x } : { h: s.x, v: s.y };
-  };
+  const { hTitle, vTitle } = flipDisplayTitles(flip, xTitle, yTitle);
+  const { formatH, formatV } = flipDisplayFormatters(flip, formatX, formatY);
+  const { hBreaks, vBreaks } = flipDisplayBreaks(
+    flip,
+    scalesConfig.x?.breaks,
+    scalesConfig.y?.breaks,
+  );
+  const { freeH, freeV } = flipDisplayFreeFlags(flip, freeX, freeY);
 
   return {
     hTitle,
@@ -74,6 +77,6 @@ export function resolvePanelLayoutDisplay(input: {
     vBreaks,
     freeH,
     freeV,
-    displayScales,
+    displayScales: makeDisplayScalesFn(flip, panelScales),
   };
 }

--- a/packages/core/src/pipeline/panel-layout-facet-cells-place.ts
+++ b/packages/core/src/pipeline/panel-layout-facet-cells-place.ts
@@ -1,0 +1,60 @@
+/**
+ * Facet col/row cursor placements and bottom-most-row index per column.
+ */
+import type { Margins } from "../layout/layout.js";
+
+import type { FacetPanelDef } from "./facets.js";
+
+export function computeFacetColRowPlacements(input: {
+  facetPanels: readonly FacetPanelDef[];
+  nrow: number;
+  ncol: number;
+  freeH: boolean;
+  freeV: boolean;
+  mMax: Margins;
+  outerLeft: number;
+  topBand: number;
+  spacing: number;
+  strip: number;
+  panelW: number;
+  panelH: number;
+}): { colX: number[]; rowY: number[]; bottomMostRow: number[] } {
+  const {
+    facetPanels,
+    nrow,
+    ncol,
+    freeH,
+    freeV,
+    mMax,
+    outerLeft,
+    topBand,
+    spacing,
+    strip,
+    panelW,
+    panelH,
+  } = input;
+
+  const colX: number[] = [];
+  let xCursor = outerLeft;
+  for (let c = 0; c < ncol; c++) {
+    if (c === 0 || freeV) xCursor += mMax.left;
+    colX.push(xCursor);
+    xCursor += panelW + spacing;
+  }
+  const rowY: number[] = [];
+  let yCursor = topBand + mMax.top;
+  for (let r = 0; r < nrow; r++) {
+    yCursor += strip;
+    rowY.push(yCursor);
+    yCursor += panelH;
+    if (r === nrow - 1 || freeH) yCursor += mMax.bottom;
+    yCursor += spacing;
+  }
+
+  const bottomMostRow: number[] = Array.from({ length: ncol }, () => 0);
+  for (const def of facetPanels) {
+    if (def.row > bottomMostRow[def.col]!) bottomMostRow[def.col] = def.row;
+  }
+
+  return { colX, rowY, bottomMostRow };
+}

--- a/packages/core/src/pipeline/panel-layout-facet-cells-size.ts
+++ b/packages/core/src/pipeline/panel-layout-facet-cells-size.ts
@@ -1,0 +1,29 @@
+/**
+ * Facet panel width/height from grid extents and shared margins.
+ */
+import type { Margins } from "../layout/layout.js";
+
+export function computeFacetPanelSize(input: {
+  nrow: number;
+  ncol: number;
+  freeH: boolean;
+  freeV: boolean;
+  mMax: Margins;
+  spacing: number;
+  strip: number;
+  gridW: number;
+  gridH: number;
+}): { panelW: number; panelH: number } {
+  const { nrow, ncol, freeH, freeV, mMax, spacing, strip, gridW, gridH } = input;
+  const leftCount = freeV ? ncol : 1;
+  const bottomCount = freeH ? nrow : 1;
+  const panelW = Math.max(
+    1,
+    (gridW - leftCount * mMax.left - mMax.right - (ncol - 1) * spacing) / ncol,
+  );
+  const panelH = Math.max(
+    1,
+    (gridH - mMax.top - bottomCount * mMax.bottom - nrow * strip - (nrow - 1) * spacing) / nrow,
+  );
+  return { panelW, panelH };
+}

--- a/packages/core/src/pipeline/panel-layout-facet-cells.ts
+++ b/packages/core/src/pipeline/panel-layout-facet-cells.ts
@@ -4,6 +4,8 @@
 import type { Margins } from "../layout/layout.js";
 
 import type { FacetPanelDef } from "./facets.js";
+import { computeFacetColRowPlacements } from "./panel-layout-facet-cells-place.js";
+import { computeFacetPanelSize } from "./panel-layout-facet-cells-size.js";
 
 export interface FacetCellGeometry {
   panelW: number;
@@ -27,53 +29,11 @@ export function computeFacetCellGeometry(input: {
   gridW: number;
   gridH: number;
 }): FacetCellGeometry {
-  const {
-    facetPanels,
-    nrow,
-    ncol,
-    freeH,
-    freeV,
-    mMax,
-    outerLeft,
-    topBand,
-    spacing,
-    strip,
-    gridW,
-    gridH,
-  } = input;
-
-  const leftCount = freeV ? ncol : 1;
-  const bottomCount = freeH ? nrow : 1;
-  const panelW = Math.max(
-    1,
-    (gridW - leftCount * mMax.left - mMax.right - (ncol - 1) * spacing) / ncol,
-  );
-  const panelH = Math.max(
-    1,
-    (gridH - mMax.top - bottomCount * mMax.bottom - nrow * strip - (nrow - 1) * spacing) / nrow,
-  );
-
-  const colX: number[] = [];
-  let xCursor = outerLeft;
-  for (let c = 0; c < ncol; c++) {
-    if (c === 0 || freeV) xCursor += mMax.left;
-    colX.push(xCursor);
-    xCursor += panelW + spacing;
-  }
-  const rowY: number[] = [];
-  let yCursor = topBand + mMax.top;
-  for (let r = 0; r < nrow; r++) {
-    yCursor += strip;
-    rowY.push(yCursor);
-    yCursor += panelH;
-    if (r === nrow - 1 || freeH) yCursor += mMax.bottom;
-    yCursor += spacing;
-  }
-
-  const bottomMostRow: number[] = Array.from({ length: ncol }, () => 0);
-  for (const def of facetPanels) {
-    if (def.row > bottomMostRow[def.col]!) bottomMostRow[def.col] = def.row;
-  }
-
+  const { panelW, panelH } = computeFacetPanelSize(input);
+  const { colX, rowY, bottomMostRow } = computeFacetColRowPlacements({
+    ...input,
+    panelW,
+    panelH,
+  });
   return { panelW, panelH, colX, rowY, bottomMostRow };
 }

--- a/packages/core/src/pipeline/panel-layout-facet-margins-types.ts
+++ b/packages/core/src/pipeline/panel-layout-facet-margins-types.ts
@@ -1,0 +1,13 @@
+/**
+ * Facet grid geometry result (margins + cell placement).
+ */
+import type { Margins } from "../layout/layout.js";
+
+export interface FacetGridGeometry {
+  mMax: Margins;
+  panelW: number;
+  panelH: number;
+  colX: number[];
+  rowY: number[];
+  bottomMostRow: number[];
+}

--- a/packages/core/src/pipeline/panel-layout-facet-margins.ts
+++ b/packages/core/src/pipeline/panel-layout-facet-margins.ts
@@ -1,23 +1,17 @@
 /**
  * Facet grid: outer chrome, shared margin pass, and panel cell geometry.
  */
-import type { LayoutTheme, Margins, TickFormatter } from "../layout/layout.js";
+import type { LayoutTheme, TickFormatter } from "../layout/layout.js";
 import type { TextMeasurer } from "../layout/measure.js";
 
 import type { FacetPanelDef } from "./facets.js";
 import { computeFacetCellGeometry } from "./panel-layout-facet-cells.js";
 import { computeFacetSharedMargins } from "./panel-layout-facet-margins-pass.js";
+import type { FacetGridGeometry } from "./panel-layout-facet-margins-types.js";
 import { computeFacetOuterChrome } from "./panel-layout-facet-outer.js";
 import type { DisplayScalesFn } from "./panel-layout-types.js";
 
-export interface FacetGridGeometry {
-  mMax: Margins;
-  panelW: number;
-  panelH: number;
-  colX: number[];
-  rowY: number[];
-  bottomMostRow: number[];
-}
+export type { FacetGridGeometry } from "./panel-layout-facet-margins-types.js";
 
 export function computeFacetGridGeometry(input: {
   facetPanels: readonly FacetPanelDef[];

--- a/packages/core/src/pipeline/prepare-panels-types.ts
+++ b/packages/core/src/pipeline/prepare-panels-types.ts
@@ -1,0 +1,20 @@
+/**
+ * Prepared panel partition result for the pipeline bind phase.
+ */
+import type { ColumnTable } from "../table.js";
+
+import type { FacetPanelDef } from "./facets.js";
+import type { LayerBinding, LayerFrame } from "./types.js";
+
+export interface PreparedPanels {
+  table: ColumnTable;
+  emptyData: boolean;
+  faceted: boolean;
+  freeX: boolean;
+  freeY: boolean;
+  nrow: number;
+  ncol: number;
+  facetPanels: FacetPanelDef[];
+  bindings: LayerBinding[];
+  panelFrames: LayerFrame[][];
+}

--- a/packages/core/src/pipeline/prepare-panels.ts
+++ b/packages/core/src/pipeline/prepare-panels.ts
@@ -3,26 +3,14 @@
  */
 import type { PortableSpec } from "@ggsvelte/spec";
 
-import type { ColumnTable } from "../table.js";
-
 import { bindData } from "./bind.js";
-import type { FacetLayout, FacetPanelDef } from "./facets.js";
+import type { FacetLayout } from "./facets.js";
 import { resolveFacet, SINGLE_PANEL } from "./facets.js";
 import { buildPanelFrames } from "./prepare-panels-frames.js";
+import type { PreparedPanels } from "./prepare-panels-types.js";
 import type { Advisory, LayerBinding, LayerFrame, PipelineWarning, RunOptions } from "./types.js";
 
-export interface PreparedPanels {
-  table: ColumnTable;
-  emptyData: boolean;
-  faceted: boolean;
-  freeX: boolean;
-  freeY: boolean;
-  nrow: number;
-  ncol: number;
-  facetPanels: FacetPanelDef[];
-  bindings: LayerBinding[];
-  panelFrames: LayerFrame[][];
-}
+export type { PreparedPanels } from "./prepare-panels-types.js";
 
 export function preparePanels(
   normalized: PortableSpec,

--- a/packages/core/src/pipeline/scale-color-sequential-result.ts
+++ b/packages/core/src/pipeline/scale-color-sequential-result.ts
@@ -1,0 +1,26 @@
+/**
+ * Pack sequential scale resolution into ColorResolution legend input.
+ */
+import type { SequentialColorScale } from "../scales/color.js";
+
+import type { ColorResolution } from "./scale-color-types.js";
+
+export function sequentialColorResolution(
+  name: "color" | "fill",
+  legendTitle: string,
+  scale: SequentialColorScale,
+  format: (v: number) => string,
+): ColorResolution {
+  return {
+    resolved: { kind: "sequential", scale },
+    legendInput: {
+      kind: "ramp",
+      scale: name,
+      title: legendTitle,
+      domain: scale.domain,
+      at: (t: number) => scale.at(t),
+      format,
+    },
+    state: null,
+  };
+}

--- a/packages/core/src/pipeline/scale-color-sequential.ts
+++ b/packages/core/src/pipeline/scale-color-sequential.ts
@@ -14,6 +14,7 @@ import {
   resolveSequentialRange,
 } from "./scale-color-sequential-domain.js";
 import { resolveSequentialLegendFormat } from "./scale-color-sequential-format.js";
+import { sequentialColorResolution } from "./scale-color-sequential-result.js";
 import type { ColorResolution } from "./scale-color-types.js";
 import type { Advisory, PipelineWarning } from "./types.js";
 
@@ -62,16 +63,5 @@ export function resolveSequentialColorScale(input: {
     });
   }
   const format = resolveSequentialLegendFormat(scale, config, name, warnings);
-  return {
-    resolved: { kind: "sequential", scale },
-    legendInput: {
-      kind: "ramp",
-      scale: name,
-      title: legendTitle,
-      domain: scale.domain,
-      at: (t: number) => scale.at(t),
-      format,
-    },
-    state: null,
-  };
+  return sequentialColorResolution(name, legendTitle, scale, format);
 }

--- a/packages/core/tests/pipeline-geometry.test.ts
+++ b/packages/core/tests/pipeline-geometry.test.ts
@@ -490,3 +490,66 @@ describe("placeSceneLegends", () => {
     expect(legends[0]!.y).toBe(5 + 12);
   });
 });
+
+describe("flipDisplayTitles / flipDisplayFreeFlags", () => {
+  it("swaps titles and free flags under coord flip", async () => {
+    const { flipDisplayTitles, flipDisplayFreeFlags } =
+      await import("../src/pipeline/panel-layout-chrome-display-flip.ts");
+    expect(flipDisplayTitles(true, "X", "Y")).toEqual({ hTitle: "Y", vTitle: "X" });
+    expect(flipDisplayTitles(false, "X", "Y")).toEqual({ hTitle: "X", vTitle: "Y" });
+    expect(flipDisplayFreeFlags(true, true, false)).toEqual({ freeH: false, freeV: true });
+  });
+});
+
+describe("computeFacetPanelSize", () => {
+  it("divides remaining grid width across columns", async () => {
+    const { computeFacetPanelSize } =
+      await import("../src/pipeline/panel-layout-facet-cells-size.ts");
+    const panels = computeFacetPanelSize({
+      nrow: 1,
+      ncol: 2,
+      freeH: false,
+      freeV: false,
+      mMax: { top: 0, right: 0, bottom: 0, left: 10 },
+      spacing: 0,
+      strip: 0,
+      gridW: 210,
+      gridH: 100,
+    });
+    // leftCount=1 so left margin once: (210 - 10) / 2 = 100
+    expect(panels.panelW).toBe(100);
+    expect(panels.panelH).toBe(100);
+  });
+});
+
+describe("geometryPanelFrame", () => {
+  it("swaps extents under coord flip", async () => {
+    const { geometryPanelFrame } = await import("../src/pipeline/assemble-geometry-panel-frame.ts");
+    const placement = {
+      x: 0,
+      y: 0,
+      width: 80,
+      height: 40,
+      ticksH: [],
+      ticksV: [],
+      showAxisX: true,
+      showAxisY: true,
+    };
+    const xScale = {
+      type: "linear" as const,
+      domain: [0, 1] as [number, number],
+      range: [0, 1] as [number, number],
+      normalize: (v: number) => v,
+    };
+    const yScale = {
+      type: "linear" as const,
+      domain: [0, 1] as [number, number],
+      range: [0, 1] as [number, number],
+      normalize: (v: number) => v,
+    };
+    const flipped = geometryPanelFrame(placement, { x: xScale, y: yScale }, true);
+    expect(flipped.innerWidth).toBe(40);
+    expect(flipped.innerHeight).toBe(80);
+    expect(flipped.xScale).toBe(xScale);
+  });
+});


### PR DESCRIPTION
## Summary
- Extract identity candidate attrs after locate; boxplot layout types/finalize; facet panel size and col/row placement.
- Extract chrome display flip helpers; shared closed-path multi-group writer for area/smooth ribbons; rect emission.
- Extract geometry panel frames; prepare-panels types; render-model domain freeze; sequential color result packing.
- Add characterization tests for flip helpers, facet panel size, and geometry panel frames.

## Test plan
- [x] `bun test packages/core` (518 pass)
- [x] `bun run check`
- [x] `bun run knip`
- [x] `bun run lint:type-aware`
- [x] Codex pre-PR review (`gpt-5.6-terra`) — PASS (no P1)