### PR TITLE
refactor(core): split candidate attrs, facet place, ordinal, contracts

### DIFF
--- a/packages/core/src/pipeline/assemble-render-model-input.ts
+++ b/packages/core/src/pipeline/assemble-render-model-input.ts
@@ -1,0 +1,43 @@
+/**
+ * assembleRenderModel input contract.
+ */
+import type { TickFormatter } from "../layout/layout.js";
+import type { ScaleState } from "../scales/state.js";
+import type { PositionScale } from "../scales/train.js";
+import type { Scene } from "../scene.js";
+import type { CellValue, ColumnTable } from "../table.js";
+import type { CandidateStore } from "../candidate-store.js";
+import type { LineageStore } from "../identity.js";
+
+import type {
+  Advisory,
+  LayerBackend,
+  MappedField,
+  PipelineWarning,
+  ResolvedColorScale,
+  ScaleDomainSnapshot,
+} from "./types.js";
+
+export interface AssembleRenderModelInput {
+  scene: Scene;
+  xScale: PositionScale;
+  yScale: PositionScale;
+  color: ResolvedColorScale | null;
+  fill: ResolvedColorScale | null;
+  panelScales: { x: PositionScale; y: PositionScale }[];
+  colorState: ScaleState | null;
+  fillState: ScaleState | null;
+  warnings: PipelineWarning[];
+  advisories: Advisory[];
+  runId: number;
+  layerBackends: LayerBackend[];
+  layerFields: MappedField[][];
+  layerScaledConstants: ReadonlyArray<Readonly<Partial<Record<string, CellValue>>>>;
+  baselineDomains: ScaleDomainSnapshot;
+  effectiveDomains: ScaleDomainSnapshot;
+  lineage: LineageStore<number>;
+  candidates: CandidateStore;
+  formatX: TickFormatter | undefined;
+  formatY: TickFormatter | undefined;
+  table: ColumnTable;
+}

--- a/packages/core/src/pipeline/assemble-render-model.ts
+++ b/packages/core/src/pipeline/assemble-render-model.ts
@@ -1,15 +1,7 @@
 /**
  * Assemble the public RenderModel (scene, scales, contracts, dispose/row).
  */
-import type { TickFormatter } from "../layout/layout.js";
-import type { ScaleState } from "../scales/state.js";
-import type { PositionScale } from "../scales/train.js";
-import type { Scene } from "../scene.js";
-import type { CellValue } from "../table.js";
-import type { ColumnTable } from "../table.js";
-import type { CandidateStore } from "../candidate-store.js";
-import type { LineageStore } from "../identity.js";
-
+import type { AssembleRenderModelInput } from "./assemble-render-model-input.js";
 import {
   dedupeRenderModelDiagnostics,
   freezeRenderModelDomains,
@@ -19,39 +11,11 @@ import {
   buildRenderModelScales,
 } from "./assemble-render-model-scales.js";
 import { createRenderModelLifecycle } from "./assemble-render-model-lifecycle.js";
-import type {
-  Advisory,
-  LayerBackend,
-  MappedField,
-  PipelineWarning,
-  RenderModel,
-  ResolvedColorScale,
-  ScaleDomainSnapshot,
-} from "./types.js";
+import type { RenderModel } from "./types.js";
 
-export function assembleRenderModel(input: {
-  scene: Scene;
-  xScale: PositionScale;
-  yScale: PositionScale;
-  color: ResolvedColorScale | null;
-  fill: ResolvedColorScale | null;
-  panelScales: { x: PositionScale; y: PositionScale }[];
-  colorState: ScaleState | null;
-  fillState: ScaleState | null;
-  warnings: PipelineWarning[];
-  advisories: Advisory[];
-  runId: number;
-  layerBackends: LayerBackend[];
-  layerFields: MappedField[][];
-  layerScaledConstants: ReadonlyArray<Readonly<Partial<Record<string, CellValue>>>>;
-  baselineDomains: ScaleDomainSnapshot;
-  effectiveDomains: ScaleDomainSnapshot;
-  lineage: LineageStore<number>;
-  candidates: CandidateStore;
-  formatX: TickFormatter | undefined;
-  formatY: TickFormatter | undefined;
-  table: ColumnTable;
-}): RenderModel {
+export type { AssembleRenderModelInput } from "./assemble-render-model-input.js";
+
+export function assembleRenderModel(input: AssembleRenderModelInput): RenderModel {
   const { scene, candidates } = input;
   const lifecycle = createRenderModelLifecycle({
     scene,

--- a/packages/core/src/pipeline/bind-layer-result.ts
+++ b/packages/core/src/pipeline/bind-layer-result.ts
@@ -1,0 +1,38 @@
+/**
+ * Assemble LayerBinding from resolved channel fields and extras.
+ */
+import type { LayerSpec } from "@ggsvelte/spec";
+
+import type { LayerBinding } from "./types.js";
+
+export function makeLayerBinding(input: {
+  layer: LayerSpec;
+  index: number;
+  xField: string | null;
+  yField: string | null;
+  yStatColumn: string | null;
+  yminField: string | null;
+  ymaxField: string | null;
+  color: LayerBinding["color"];
+  fill: LayerBinding["fill"];
+  labelField: string | null;
+  labelConstant: string | null;
+  weightField: string | null;
+  ruleForm: LayerBinding["ruleForm"];
+}): LayerBinding {
+  return {
+    layer: input.layer,
+    index: input.index,
+    xField: input.xField,
+    yField: input.yField,
+    yStatColumn: input.yStatColumn,
+    yminField: input.yminField,
+    ymaxField: input.ymaxField,
+    color: input.color,
+    fill: input.fill,
+    labelField: input.labelField,
+    labelConstant: input.labelConstant,
+    weightField: input.weightField,
+    ruleForm: input.ruleForm,
+  };
+}

--- a/packages/core/src/pipeline/bind-layer.ts
+++ b/packages/core/src/pipeline/bind-layer.ts
@@ -7,6 +7,7 @@ import type { ColumnTable } from "../table.js";
 
 import { checkField } from "./bind-layer-helpers.js";
 import { resolveLabelWeightColorFill } from "./bind-layer-extras.js";
+import { makeLayerBinding } from "./bind-layer-result.js";
 import {
   assertRequiredChannels,
   resolveRuleForm,
@@ -50,7 +51,7 @@ export function bindLayer(
 
   const extras = resolveLabelWeightColorFill({ aes, geom, stat, index, table, warnings });
 
-  return {
+  return makeLayerBinding({
     layer,
     index,
     xField,
@@ -64,5 +65,5 @@ export function bindLayer(
     labelConstant: extras.labelConstant,
     weightField: extras.weightField,
     ruleForm,
-  };
+  });
 }

--- a/packages/core/src/pipeline/build-candidates-datum-attrs-types.ts
+++ b/packages/core/src/pipeline/build-candidates-datum-attrs-types.ts
@@ -1,0 +1,17 @@
+/**
+ * Identity candidate attribute shape (series, mode, lineage, annotation).
+ */
+import type { CellValue } from "../table.js";
+
+import type { candidateAutoMode } from "./frame.js";
+
+export interface IdentityCandidateAttrs {
+  group: number;
+  seriesRank: number;
+  autoMode: ReturnType<typeof candidateAutoMode>;
+  sourceOrder: number;
+  lineageKey: number;
+  annotationRule: boolean;
+  annotationX: CellValue;
+  annotationY: CellValue;
+}

--- a/packages/core/src/pipeline/build-candidates-datum-attrs.ts
+++ b/packages/core/src/pipeline/build-candidates-datum-attrs.ts
@@ -2,87 +2,26 @@
  * Series, autoMode, annotation, and lineage attributes for identity candidates.
  */
 import type { CandidateBuildFacts } from "../candidate-store.js";
-import type { CellValue } from "../table.js";
 
 import type { IdentityCandidateResolveContext } from "./build-candidates-datum-ctx.js";
-import { resolveAnnotationIntercepts } from "./build-candidates-datum-context.js";
+import type { IdentityCandidateAttrs } from "./build-candidates-datum-attrs-types.js";
+import { resolveIdentityLineageAndAnnotation } from "./build-candidates-datum-lineage-ann.js";
 import type { LocatedIdentityCandidate } from "./build-candidates-datum-locate.js";
-import {
-  resolveCandidateSeries,
-  resolveRepresentedSourceRows,
-} from "./build-candidates-datum-series.js";
-import { candidateAutoMode } from "./frame.js";
+import { resolveIdentitySeriesAndMode } from "./build-candidates-datum-series-mode.js";
 
-export interface IdentityCandidateAttrs {
-  group: number;
-  seriesRank: number;
-  autoMode: ReturnType<typeof candidateAutoMode>;
-  sourceOrder: number;
-  lineageKey: number;
-  annotationRule: boolean;
-  annotationX: CellValue;
-  annotationY: CellValue;
-}
+export type { IdentityCandidateAttrs } from "./build-candidates-datum-attrs-types.js";
 
 export function resolveIdentityCandidateAttrs(
   ctx: IdentityCandidateResolveContext,
   facts: CandidateBuildFacts,
   located: LocatedIdentityCandidate,
 ): IdentityCandidateAttrs {
-  const {
-    sourceRow,
-    frame,
-    outlierSourceRow,
-    frameRow,
-    derivedGroup,
-    sourceValue,
-    colorField,
-    fillField,
-    seriesByRow,
-    sourceRowsByGroup,
-  } = located;
-
-  const { group, seriesRank } = resolveCandidateSeries({
-    sourceRow,
-    derivedGroup,
-    seriesByRow,
-    panelIndex: facts.panelIndex,
-    layerIndex: facts.layerIndex,
-    color: ctx.color,
-    fill: ctx.fill,
-    colorField,
-    fillField,
-    sourceValue,
-  });
-  const autoMode = candidateAutoMode(
-    frame?.binding ?? ctx.bindings[facts.layerIndex]!,
-    facts.primitiveIndex,
-  );
-  const { annotationRule, annotationX, annotationY } = resolveAnnotationIntercepts({
-    frame,
-    primitiveIndex: facts.primitiveIndex,
-  });
-  const { sourceOrder, lineageKey } = resolveRepresentedSourceRows({
-    outlierSourceRow,
-    sourceRow,
-    group,
-    panelIndex: facts.panelIndex,
-    layerIndex: facts.layerIndex,
-    sourceRowsByGroup,
-    frame,
-    table: ctx.table,
-    frameRow,
-    lineage: ctx.lineage,
-    primitiveIndex: facts.primitiveIndex,
-  });
+  const { group, seriesRank, autoMode } = resolveIdentitySeriesAndMode(ctx, facts, located);
+  const lineageAnn = resolveIdentityLineageAndAnnotation(ctx, facts, located, group);
   return {
     group,
     seriesRank,
     autoMode,
-    sourceOrder,
-    lineageKey,
-    annotationRule,
-    annotationX,
-    annotationY,
+    ...lineageAnn,
   };
 }

--- a/packages/core/src/pipeline/build-candidates-datum-lineage-ann.ts
+++ b/packages/core/src/pipeline/build-candidates-datum-lineage-ann.ts
@@ -1,0 +1,43 @@
+/**
+ * Annotation intercepts and represented-row lineage for identity candidates.
+ */
+import type { CandidateBuildFacts } from "../candidate-store.js";
+import type { CellValue } from "../table.js";
+
+import type { IdentityCandidateResolveContext } from "./build-candidates-datum-ctx.js";
+import { resolveAnnotationIntercepts } from "./build-candidates-datum-context.js";
+import type { LocatedIdentityCandidate } from "./build-candidates-datum-locate.js";
+import { resolveRepresentedSourceRows } from "./build-candidates-datum-series.js";
+
+export function resolveIdentityLineageAndAnnotation(
+  ctx: IdentityCandidateResolveContext,
+  facts: CandidateBuildFacts,
+  located: LocatedIdentityCandidate,
+  group: number,
+): {
+  sourceOrder: number;
+  lineageKey: number;
+  annotationRule: boolean;
+  annotationX: CellValue;
+  annotationY: CellValue;
+} {
+  const { sourceRow, frame, outlierSourceRow, frameRow, sourceRowsByGroup } = located;
+  const { annotationRule, annotationX, annotationY } = resolveAnnotationIntercepts({
+    frame,
+    primitiveIndex: facts.primitiveIndex,
+  });
+  const { sourceOrder, lineageKey } = resolveRepresentedSourceRows({
+    outlierSourceRow,
+    sourceRow,
+    group,
+    panelIndex: facts.panelIndex,
+    layerIndex: facts.layerIndex,
+    sourceRowsByGroup,
+    frame,
+    table: ctx.table,
+    frameRow,
+    lineage: ctx.lineage,
+    primitiveIndex: facts.primitiveIndex,
+  });
+  return { sourceOrder, lineageKey, annotationRule, annotationX, annotationY };
+}

--- a/packages/core/src/pipeline/build-candidates-datum-series-mode.ts
+++ b/packages/core/src/pipeline/build-candidates-datum-series-mode.ts
@@ -1,0 +1,36 @@
+/**
+ * Series id/rank and inspection autoMode for identity candidates.
+ */
+import type { CandidateBuildFacts } from "../candidate-store.js";
+
+import type { IdentityCandidateResolveContext } from "./build-candidates-datum-ctx.js";
+import type { LocatedIdentityCandidate } from "./build-candidates-datum-locate.js";
+import { resolveCandidateSeries } from "./build-candidates-datum-series.js";
+import { candidateAutoMode } from "./frame.js";
+
+export function resolveIdentitySeriesAndMode(
+  ctx: IdentityCandidateResolveContext,
+  facts: CandidateBuildFacts,
+  located: LocatedIdentityCandidate,
+): { group: number; seriesRank: number; autoMode: ReturnType<typeof candidateAutoMode> } {
+  const { sourceRow, frame, derivedGroup, sourceValue, colorField, fillField, seriesByRow } =
+    located;
+
+  const { group, seriesRank } = resolveCandidateSeries({
+    sourceRow,
+    derivedGroup,
+    seriesByRow,
+    panelIndex: facts.panelIndex,
+    layerIndex: facts.layerIndex,
+    color: ctx.color,
+    fill: ctx.fill,
+    colorField,
+    fillField,
+    sourceValue,
+  });
+  const autoMode = candidateAutoMode(
+    frame?.binding ?? ctx.bindings[facts.layerIndex]!,
+    facts.primitiveIndex,
+  );
+  return { group, seriesRank, autoMode };
+}

--- a/packages/core/src/pipeline/build-candidates-identity-lazy.ts
+++ b/packages/core/src/pipeline/build-candidates-identity-lazy.ts
@@ -1,0 +1,21 @@
+/**
+ * Lazy identity index for candidate store construction.
+ */
+import {
+  buildCandidateIdentityIndex,
+  type CandidateIdentityIndex,
+} from "./build-candidates-identity.js";
+import type { FacetPanelDef } from "./facets.js";
+import type { LayerFrame } from "./types.js";
+
+export function createLazyIdentityIndex(
+  panelFrames: readonly (readonly LayerFrame[])[],
+  facetPanels: readonly FacetPanelDef[],
+): () => CandidateIdentityIndex {
+  let identityIndex: CandidateIdentityIndex | null = null;
+  return () => {
+    if (identityIndex !== null) return identityIndex;
+    identityIndex = buildCandidateIdentityIndex(panelFrames, facetPanels);
+    return identityIndex;
+  };
+}

--- a/packages/core/src/pipeline/build-candidates-identity-store.ts
+++ b/packages/core/src/pipeline/build-candidates-identity-store.ts
@@ -8,10 +8,7 @@ import type { Scene } from "../scene.js";
 import type { ColumnTable } from "../table.js";
 
 import { createIdentityCandidateDatumResolver } from "./build-candidates-datum.js";
-import {
-  buildCandidateIdentityIndex,
-  type CandidateIdentityIndex,
-} from "./build-candidates-identity.js";
+import { createLazyIdentityIndex } from "./build-candidates-identity-lazy.js";
 import type { FacetPanelDef } from "./facets.js";
 import type { MappedField } from "./types.js";
 import type { LayerBinding, LayerFrame, ResolvedColorScale } from "./types.js";
@@ -43,12 +40,7 @@ export function buildIdentityIndexedCandidates(input: {
     lineage,
   } = input;
 
-  let identityIndex: CandidateIdentityIndex | null = null;
-  const getIdentityIndex = () => {
-    if (identityIndex !== null) return identityIndex;
-    identityIndex = buildCandidateIdentityIndex(panelFrames, facetPanels);
-    return identityIndex;
-  };
+  const getIdentityIndex = createLazyIdentityIndex(panelFrames, facetPanels);
 
   return buildCandidateStore(scene, {
     epoch: runId,

--- a/packages/core/src/pipeline/finalize-model-contracts-domains.ts
+++ b/packages/core/src/pipeline/finalize-model-contracts-domains.ts
@@ -1,0 +1,33 @@
+/**
+ * Effective and baseline domain snapshots for finalize.
+ */
+import { computeBaselineDomains, computeEffectiveDomains } from "./compute-domains.js";
+import type { PreparedPanels } from "./prepare-panels.js";
+import type { TrainedPipelineScales } from "./train-pipeline-scales.js";
+import type { RunOptions, ScaleDomainSnapshot } from "./types.js";
+
+export function resolveFinalizeDomainSnapshots(input: {
+  options: RunOptions;
+  prepared: PreparedPanels;
+  trained: TrainedPipelineScales;
+}): {
+  effectiveDomains: ScaleDomainSnapshot;
+  baselineDomains: ScaleDomainSnapshot;
+} {
+  const { options, prepared, trained } = input;
+  const { freeX, freeY, facetPanels, panelFrames } = prepared;
+  const { xTraining, yTraining, panelScales, xInputs, yInputs } = trained;
+
+  const effectiveDomains = computeEffectiveDomains(xTraining.scale, yTraining.scale, panelScales);
+  const baselineDomains = computeBaselineDomains({
+    options,
+    freeX,
+    freeY,
+    facetPanels,
+    panelFrames,
+    xInputs,
+    yInputs,
+    effectiveDomains,
+  });
+  return { effectiveDomains, baselineDomains };
+}

--- a/packages/core/src/pipeline/finalize-model-contracts-layers.ts
+++ b/packages/core/src/pipeline/finalize-model-contracts-layers.ts
@@ -1,0 +1,42 @@
+/**
+ * Layer backends, tooltip fields, and scaled constants for finalize.
+ */
+import type { PortableSpec } from "@ggsvelte/spec";
+import type { CellValue } from "../table.js";
+import type { Scene } from "../scene.js";
+
+import {
+  resolveLayerBackends,
+  resolveLayerFields,
+  resolveLayerScaledConstants,
+} from "./layer-contracts.js";
+import type { PreparedPanels } from "./prepare-panels.js";
+import type { Advisory, LayerBackend, LayerBinding, MappedField, RunOptions } from "./types.js";
+
+export function resolveFinalizeLayerContracts(input: {
+  normalized: PortableSpec;
+  options: RunOptions;
+  prepared: PreparedPanels;
+  scene: Scene;
+  advisories: Advisory[];
+}): {
+  layerBackends: LayerBackend[];
+  layerFields: MappedField[][];
+  layerScaledConstants: ReadonlyArray<Readonly<Partial<Record<string, CellValue>>>>;
+  bindings: readonly LayerBinding[];
+} {
+  const { normalized, options, prepared, scene, advisories } = input;
+  const { bindings } = prepared;
+  return {
+    layerBackends: resolveLayerBackends(
+      normalized.layers,
+      scene.batches,
+      normalized.a11y,
+      options.canvasThreshold,
+      advisories,
+    ),
+    layerFields: resolveLayerFields(normalized.layers.length, bindings),
+    layerScaledConstants: resolveLayerScaledConstants(normalized.layers.length, bindings),
+    bindings,
+  };
+}

--- a/packages/core/src/pipeline/finalize-model-contracts.ts
+++ b/packages/core/src/pipeline/finalize-model-contracts.ts
@@ -2,25 +2,21 @@
  * Resolve layer contracts and domain snapshots for the finalize phase.
  */
 import type { PortableSpec } from "@ggsvelte/spec";
+import type { CellValue } from "../table.js";
+import type { Scene } from "../scene.js";
 
-import { computeBaselineDomains, computeEffectiveDomains } from "./compute-domains.js";
-import {
-  resolveLayerBackends,
-  resolveLayerFields,
-  resolveLayerScaledConstants,
-} from "./layer-contracts.js";
+import { resolveFinalizeDomainSnapshots } from "./finalize-model-contracts-domains.js";
+import { resolveFinalizeLayerContracts } from "./finalize-model-contracts-layers.js";
 import type { PreparedPanels } from "./prepare-panels.js";
 import type { TrainedPipelineScales } from "./train-pipeline-scales.js";
 import type {
   Advisory,
   LayerBackend,
+  LayerBinding,
   MappedField,
   RunOptions,
   ScaleDomainSnapshot,
 } from "./types.js";
-import type { CellValue } from "../table.js";
-import type { Scene } from "../scene.js";
-import type { LayerBinding } from "./types.js";
 
 export function resolveFinalizeContracts(input: {
   normalized: PortableSpec;
@@ -37,38 +33,7 @@ export function resolveFinalizeContracts(input: {
   baselineDomains: ScaleDomainSnapshot;
   bindings: readonly LayerBinding[];
 } {
-  const { normalized, options, prepared, trained, scene, advisories } = input;
-  const { freeX, freeY, facetPanels, bindings, panelFrames } = prepared;
-  const { xTraining, yTraining, panelScales, xInputs, yInputs } = trained;
-
-  const layerBackends = resolveLayerBackends(
-    normalized.layers,
-    scene.batches,
-    normalized.a11y,
-    options.canvasThreshold,
-    advisories,
-  );
-  const layerFields = resolveLayerFields(normalized.layers.length, bindings);
-  const layerScaledConstants = resolveLayerScaledConstants(normalized.layers.length, bindings);
-
-  const effectiveDomains = computeEffectiveDomains(xTraining.scale, yTraining.scale, panelScales);
-  const baselineDomains = computeBaselineDomains({
-    options,
-    freeX,
-    freeY,
-    facetPanels,
-    panelFrames,
-    xInputs,
-    yInputs,
-    effectiveDomains,
-  });
-
-  return {
-    layerBackends,
-    layerFields,
-    layerScaledConstants,
-    effectiveDomains,
-    baselineDomains,
-    bindings,
-  };
+  const layers = resolveFinalizeLayerContracts(input);
+  const domains = resolveFinalizeDomainSnapshots(input);
+  return { ...layers, ...domains };
 }

--- a/packages/core/src/pipeline/frame-stats-bin-frame.ts
+++ b/packages/core/src/pipeline/frame-stats-bin-frame.ts
@@ -1,0 +1,52 @@
+/**
+ * Pack bin-stat result into a LayerFrame.
+ */
+import type { ColumnTable } from "../table.js";
+
+import { emptyFrameExtras } from "./frame-helpers.js";
+import type { makeColumnOf } from "./frame-stats-shared.js";
+import type { LayerBinding, LayerFrame } from "./types.js";
+import { NO_ROW } from "./types.js";
+
+type BinResult = {
+  x: Float64Array;
+  count: Float64Array;
+  density: Float64Array;
+  ncount: Float64Array;
+  ndensity: Float64Array;
+  groups: number[];
+  xmin: Float64Array;
+  xmax: Float64Array;
+  carried: Record<string, import("../table.js").CellValue[]>;
+};
+
+export function packBinLayerFrame(
+  binding: LayerBinding,
+  table: ColumnTable,
+  result: BinResult,
+  columnOf: ReturnType<typeof makeColumnOf>,
+): LayerFrame {
+  const columns: Record<string, Float64Array> = {
+    count: result.count,
+    density: result.density,
+    ncount: result.ncount,
+    ndensity: result.ndensity,
+  };
+  const col = columnOf(result, null);
+  return {
+    binding,
+    table,
+    n: result.x.length,
+    xValues: null,
+    xNumeric: result.x,
+    yNumeric: columns[binding.yStatColumn ?? "count"] ?? result.count,
+    groups: result.groups,
+    rowIndex: Uint32Array.from({ length: result.x.length }, () => NO_ROW),
+    colorValues: col(binding.color.field),
+    fillValues: col(binding.fill.field),
+    labelValues: col(binding.labelField),
+    ...emptyFrameExtras(),
+    xmin: result.xmin,
+    xmax: result.xmax,
+  };
+}

--- a/packages/core/src/pipeline/frame-stats-bin.ts
+++ b/packages/core/src/pipeline/frame-stats-bin.ts
@@ -6,10 +6,10 @@ import type { BarParams } from "@ggsvelte/spec";
 import { statBin } from "../stats/bin.js";
 import type { ColumnTable } from "../table.js";
 
-import { carriedColumns, emptyFrameExtras, removedStatWarning } from "./frame-helpers.js";
+import { carriedColumns, removedStatWarning } from "./frame-helpers.js";
+import { packBinLayerFrame } from "./frame-stats-bin-frame.js";
 import { makeColumnOf } from "./frame-stats-shared.js";
 import type { Advisory, LayerBinding, LayerFrame, PipelineWarning } from "./types.js";
-import { NO_ROW } from "./types.js";
 
 export function buildBinFrame(
   binding: LayerBinding,
@@ -43,27 +43,5 @@ export function buildBinFrame(
       howToOverride: `Set params.binwidth (preferred — a width meaningful for the data) or params.bins on layer ${index}.`,
     });
   }
-  const columns: Record<string, Float64Array> = {
-    count: result.count,
-    density: result.density,
-    ncount: result.ncount,
-    ndensity: result.ndensity,
-  };
-  const col = columnOf(result, null);
-  return {
-    binding,
-    table,
-    n: result.x.length,
-    xValues: null,
-    xNumeric: result.x,
-    yNumeric: columns[binding.yStatColumn ?? "count"] ?? result.count,
-    groups: result.groups,
-    rowIndex: Uint32Array.from({ length: result.x.length }, () => NO_ROW),
-    colorValues: col(binding.color.field),
-    fillValues: col(binding.fill.field),
-    labelValues: col(binding.labelField),
-    ...emptyFrameExtras(),
-    xmin: result.xmin,
-    xmax: result.xmax,
-  };
+  return packBinLayerFrame(binding, table, result, columnOf);
 }

--- a/packages/core/src/pipeline/panel-layout-chrome-display-types.ts
+++ b/packages/core/src/pipeline/panel-layout-chrome-display-types.ts
@@ -1,0 +1,19 @@
+/**
+ * Panel layout display surface after coord-flip remapping.
+ */
+import type { TickFormatter } from "../layout/layout.js";
+import type { PositionScale } from "../scales/train.js";
+
+export interface PanelLayoutDisplay {
+  hTitle: string;
+  vTitle: string;
+  formatX: TickFormatter | undefined;
+  formatY: TickFormatter | undefined;
+  formatH: TickFormatter | undefined;
+  formatV: TickFormatter | undefined;
+  hBreaks: readonly (number | string)[] | undefined;
+  vBreaks: readonly (number | string)[] | undefined;
+  freeH: boolean;
+  freeV: boolean;
+  displayScales: (p: number) => { h: PositionScale; v: PositionScale };
+}

--- a/packages/core/src/pipeline/panel-layout-chrome-display.ts
+++ b/packages/core/src/pipeline/panel-layout-chrome-display.ts
@@ -3,7 +3,6 @@
  */
 import type { PortableSpec } from "@ggsvelte/spec";
 
-import type { TickFormatter } from "../layout/layout.js";
 import type { PositionScale } from "../scales/train.js";
 
 import { makeAxisFormatter } from "./layout-helpers.js";
@@ -14,21 +13,10 @@ import {
   flipDisplayTitles,
   makeDisplayScalesFn,
 } from "./panel-layout-chrome-display-flip.js";
+import type { PanelLayoutDisplay } from "./panel-layout-chrome-display-types.js";
 import type { PipelineWarning } from "./types.js";
 
-export interface PanelLayoutDisplay {
-  hTitle: string;
-  vTitle: string;
-  formatX: TickFormatter | undefined;
-  formatY: TickFormatter | undefined;
-  formatH: TickFormatter | undefined;
-  formatV: TickFormatter | undefined;
-  hBreaks: readonly (number | string)[] | undefined;
-  vBreaks: readonly (number | string)[] | undefined;
-  freeH: boolean;
-  freeV: boolean;
-  displayScales: (p: number) => { h: PositionScale; v: PositionScale };
-}
+export type { PanelLayoutDisplay } from "./panel-layout-chrome-display-types.js";
 
 export function resolvePanelLayoutDisplay(input: {
   flip: boolean;

--- a/packages/core/src/pipeline/panel-layout-facet-place-one.ts
+++ b/packages/core/src/pipeline/panel-layout-facet-place-one.ts
@@ -1,0 +1,75 @@
+/**
+ * Place one facet panel: tick layout pass + axis visibility flags.
+ */
+import type { LayoutTheme, Margins, PassResult, TickFormatter } from "../layout/layout.js";
+import { layoutPass } from "../layout/layout.js";
+import type { TextMeasurer } from "../layout/measure.js";
+import type { PositionScale } from "../scales/train.js";
+
+import type { FacetPanelDef } from "./facets.js";
+import { layoutDomain } from "./layout-helpers.js";
+import type { PanelPlacement } from "./panel-layout-types.js";
+
+export function placeOneFacetPanel(input: {
+  def: FacetPanelDef;
+  h: PositionScale;
+  v: PositionScale;
+  mMax: Margins;
+  panelW: number;
+  panelH: number;
+  colX: number;
+  rowY: number;
+  freeH: boolean;
+  freeV: boolean;
+  bottomMostRow: number;
+  hBreaks: readonly (number | string)[] | undefined;
+  vBreaks: readonly (number | string)[] | undefined;
+  formatH: TickFormatter | undefined;
+  formatV: TickFormatter | undefined;
+  measurer: TextMeasurer;
+  layoutTheme: LayoutTheme;
+}): PanelPlacement {
+  const {
+    def,
+    h,
+    v,
+    mMax,
+    panelW,
+    panelH,
+    colX,
+    rowY,
+    freeH,
+    freeV,
+    bottomMostRow,
+    hBreaks,
+    vBreaks,
+    formatH,
+    formatV,
+    measurer,
+    layoutTheme,
+  } = input;
+
+  const ticksRun: PassResult = layoutPass(
+    mMax,
+    {
+      width: panelW + mMax.left + mMax.right,
+      height: panelH + mMax.top + mMax.bottom,
+      x: layoutDomain(h, hBreaks),
+      y: layoutDomain(v, vBreaks),
+      ...(formatH !== undefined && { formatX: formatH }),
+      ...(formatV !== undefined && { formatY: formatV }),
+      measurer,
+    },
+    layoutTheme,
+  );
+  return {
+    x: colX,
+    y: rowY,
+    width: panelW,
+    height: panelH,
+    ticksH: ticksRun.x.ticks,
+    ticksV: ticksRun.y.ticks,
+    showAxisX: freeH || def.row === bottomMostRow,
+    showAxisY: freeV || def.col === 0,
+  };
+}

--- a/packages/core/src/pipeline/panel-layout-facet.ts
+++ b/packages/core/src/pipeline/panel-layout-facet.ts
@@ -1,13 +1,12 @@
 /**
  * Facet-grid panel placement: shared margin pass, free-scale edge axes, strips.
  */
-import type { LayoutTheme, PassResult, TickFormatter } from "../layout/layout.js";
-import { layoutPass } from "../layout/layout.js";
+import type { LayoutTheme, TickFormatter } from "../layout/layout.js";
 import type { TextMeasurer } from "../layout/measure.js";
 
 import type { FacetPanelDef } from "./facets.js";
-import { layoutDomain } from "./layout-helpers.js";
 import { computeFacetGridGeometry } from "./panel-layout-facet-margins.js";
+import { placeOneFacetPanel } from "./panel-layout-facet-place-one.js";
 import type { DisplayScalesFn, PanelPlacement } from "./panel-layout-types.js";
 
 export function placeFacetPanels(input: {
@@ -50,29 +49,27 @@ export function placeFacetPanels(input: {
   for (let p = 0; p < facetPanels.length; p++) {
     const def = facetPanels[p]!;
     const { h, v } = displayScales(p);
-    const ticksRun: PassResult = layoutPass(
-      mMax,
-      {
-        width: panelW + mMax.left + mMax.right,
-        height: panelH + mMax.top + mMax.bottom,
-        x: layoutDomain(h, hBreaks),
-        y: layoutDomain(v, vBreaks),
-        ...(formatH !== undefined && { formatX: formatH }),
-        ...(formatV !== undefined && { formatY: formatV }),
+    placements.push(
+      placeOneFacetPanel({
+        def,
+        h,
+        v,
+        mMax,
+        panelW,
+        panelH,
+        colX: colX[def.col]!,
+        rowY: rowY[def.row]!,
+        freeH,
+        freeV,
+        bottomMostRow: bottomMostRow[def.col]!,
+        hBreaks,
+        vBreaks,
+        formatH,
+        formatV,
         measurer,
-      },
-      layoutTheme,
+        layoutTheme,
+      }),
     );
-    placements.push({
-      x: colX[def.col]!,
-      y: rowY[def.row]!,
-      width: panelW,
-      height: panelH,
-      ticksH: ticksRun.x.ticks,
-      ticksV: ticksRun.y.ticks,
-      showAxisX: freeH || def.row === bottomMostRow[def.col]!,
-      showAxisY: freeV || def.col === 0,
-    });
   }
   return placements;
 }

--- a/packages/core/src/pipeline/panel-layout-single-reserve.ts
+++ b/packages/core/src/pipeline/panel-layout-single-reserve.ts
@@ -1,0 +1,19 @@
+/**
+ * Single-panel margin reserves for axis titles and legend width.
+ */
+import type { Margins } from "../layout/layout.js";
+
+import { LEGEND_EDGE_PAD, LEGEND_GAP } from "./layout-helpers.js";
+
+export function singlePanelMarginReserve(
+  hTitle: string,
+  vTitle: string,
+  axisTitleBand: number,
+  legendWidth: number,
+): Partial<Margins> {
+  return {
+    ...(hTitle !== "" && { bottom: axisTitleBand }),
+    ...(vTitle !== "" && { left: axisTitleBand }),
+    ...(legendWidth > 0 && { right: legendWidth + LEGEND_GAP + LEGEND_EDGE_PAD }),
+  };
+}

--- a/packages/core/src/pipeline/panel-layout-single.ts
+++ b/packages/core/src/pipeline/panel-layout-single.ts
@@ -1,12 +1,13 @@
 /**
  * Single-panel layout placement with axis-title and legend reserves.
  */
-import type { LayoutTheme, Margins, TickFormatter } from "../layout/layout.js";
+import type { LayoutTheme, TickFormatter } from "../layout/layout.js";
 import { layout } from "../layout/layout.js";
 import type { TextMeasurer } from "../layout/measure.js";
 import type { PositionScale } from "../scales/train.js";
 
-import { LEGEND_EDGE_PAD, LEGEND_GAP, layoutDomain } from "./layout-helpers.js";
+import { layoutDomain } from "./layout-helpers.js";
+import { singlePanelMarginReserve } from "./panel-layout-single-reserve.js";
 import type { PanelPlacement } from "./panel-layout-types.js";
 
 export function placeSinglePanel(input: {
@@ -44,11 +45,6 @@ export function placeSinglePanel(input: {
     layoutTheme,
   } = input;
 
-  const reserve: Partial<Margins> = {
-    ...(hTitle !== "" && { bottom: axisTitleBand }),
-    ...(vTitle !== "" && { left: axisTitleBand }),
-    ...(legendWidth > 0 && { right: legendWidth + LEGEND_GAP + LEGEND_EDGE_PAD }),
-  };
   const layoutResult = layout({
     width: optionsWidth,
     height: layoutHeight,
@@ -57,7 +53,7 @@ export function placeSinglePanel(input: {
     ...(formatH !== undefined && { formatX: formatH }),
     ...(formatV !== undefined && { formatY: formatV }),
     measurer,
-    reserve,
+    reserve: singlePanelMarginReserve(hTitle, vTitle, axisTitleBand, legendWidth),
     theme: layoutTheme,
   });
   const margins = layoutResult.margins;

--- a/packages/core/src/pipeline/scale-color-ordinal-result.ts
+++ b/packages/core/src/pipeline/scale-color-ordinal-result.ts
@@ -1,0 +1,42 @@
+/**
+ * Pack ordinal ColorScale into ColorResolution + palette-inferred advisory.
+ */
+import type { ColorScaleSpec } from "@ggsvelte/spec";
+import type { ColorScale } from "../scales/train.js";
+import type { CellValue } from "../table.js";
+
+import type { ColorResolution } from "./scale-color-types.js";
+import type { Advisory, PipelineWarning } from "./types.js";
+
+export function ordinalColorResolution(input: {
+  name: "color" | "fill";
+  values: readonly CellValue[];
+  config: ColorScaleSpec | undefined;
+  legendTitle: string;
+  scale: ColorScale;
+  warnings: PipelineWarning[];
+  advisories: Advisory[];
+}): ColorResolution {
+  const { name, values, config, legendTitle, scale, warnings, advisories } = input;
+  for (const w of scale.warnings) warnings.push({ code: w.code, message: w.message });
+  if (config?.scheme === undefined && config?.range === undefined) {
+    advisories.push({
+      code: "palette-inferred",
+      path: `scales.${name}`,
+      chosen: "categorical 10-color palette (value-stable assignment)",
+      howToOverride: `Set scales.${name}.scheme, scales.${name}.range, or scales.${name}.domain.`,
+    });
+  }
+  return {
+    resolved: { kind: "ordinal", scale },
+    legendInput: {
+      kind: "discrete",
+      scale: name,
+      title: legendTitle,
+      domain: scale.domain,
+      firstSeen: values,
+      colorOf: (v: unknown) => scale.colorOf(v),
+    },
+    state: scale.state,
+  };
+}

--- a/packages/core/src/pipeline/scale-color-ordinal-train.ts
+++ b/packages/core/src/pipeline/scale-color-ordinal-train.ts
@@ -1,0 +1,38 @@
+/**
+ * Train ordinal color scale with palette-exhaust handling.
+ */
+import type { ColorScaleSpec } from "@ggsvelte/spec";
+
+import type { ScaleState } from "../scales/state.js";
+import { PaletteExhaustedError } from "../scales/state.js";
+import type { ColorScale } from "../scales/train.js";
+import { trainColor } from "../scales/train.js";
+import type { CellValue } from "../table.js";
+
+import { PipelineError } from "./types.js";
+
+export function trainOrdinalColorScale(input: {
+  name: "color" | "fill";
+  values: readonly CellValue[];
+  config: ColorScaleSpec | undefined;
+  prevState: ScaleState | null;
+  range: readonly string[] | undefined;
+}): ColorScale {
+  const { name, values, config, prevState, range } = input;
+  const scheme = config?.scheme;
+  try {
+    return trainColor(values, prevState, {
+      ...(config?.domain !== undefined && { domain: config.domain }),
+      ...(config?.domainMode !== undefined && { domainMode: config.domainMode }),
+      ...(range !== undefined && { range }),
+      ...(scheme !== undefined && { scheme }),
+      ...(config?.reverse !== undefined && { reverse: config.reverse }),
+      ...(config?.onExhaust !== undefined && { onExhaust: config.onExhaust }),
+    });
+  } catch (error) {
+    if (error instanceof PaletteExhaustedError) {
+      throw new PipelineError("palette-exhausted", `/scales/${name}`, error.message);
+    }
+    throw error;
+  }
+}

--- a/packages/core/src/pipeline/scale-color-ordinal.ts
+++ b/packages/core/src/pipeline/scale-color-ordinal.ts
@@ -5,15 +5,13 @@ import type { ColorScaleSpec } from "@ggsvelte/spec";
 
 import type { EditionDefaults } from "../editions.js";
 import type { ScaleState } from "../scales/state.js";
-import { PaletteExhaustedError } from "../scales/state.js";
-import type { ColorScale } from "../scales/train.js";
-import { trainColor } from "../scales/train.js";
 import type { CellValue } from "../table.js";
 
 import { resolveOrdinalColorRange } from "./scale-color-ordinal-range.js";
+import { ordinalColorResolution } from "./scale-color-ordinal-result.js";
+import { trainOrdinalColorScale } from "./scale-color-ordinal-train.js";
 import type { ColorResolution } from "./scale-color-types.js";
 import type { Advisory, PipelineWarning } from "./types.js";
-import { PipelineError } from "./types.js";
 
 export function resolveOrdinalColorScale(input: {
   name: "color" | "fill";
@@ -28,43 +26,15 @@ export function resolveOrdinalColorScale(input: {
   const { name, values, config, prevState, legendTitle, warnings, advisories, editionDefaults } =
     input;
 
-  const scheme = config?.scheme;
   const range = resolveOrdinalColorRange(config, editionDefaults);
-  let scale: ColorScale;
-  try {
-    scale = trainColor(values, prevState, {
-      ...(config?.domain !== undefined && { domain: config.domain }),
-      ...(config?.domainMode !== undefined && { domainMode: config.domainMode }),
-      ...(range !== undefined && { range }),
-      ...(scheme !== undefined && { scheme }),
-      ...(config?.reverse !== undefined && { reverse: config.reverse }),
-      ...(config?.onExhaust !== undefined && { onExhaust: config.onExhaust }),
-    });
-  } catch (error) {
-    if (error instanceof PaletteExhaustedError) {
-      throw new PipelineError("palette-exhausted", `/scales/${name}`, error.message);
-    }
-    throw error;
-  }
-  for (const w of scale.warnings) warnings.push({ code: w.code, message: w.message });
-  if (config?.scheme === undefined && config?.range === undefined) {
-    advisories.push({
-      code: "palette-inferred",
-      path: `scales.${name}`,
-      chosen: "categorical 10-color palette (value-stable assignment)",
-      howToOverride: `Set scales.${name}.scheme, scales.${name}.range, or scales.${name}.domain.`,
-    });
-  }
-  return {
-    resolved: { kind: "ordinal", scale },
-    legendInput: {
-      kind: "discrete",
-      scale: name,
-      title: legendTitle,
-      domain: scale.domain,
-      firstSeen: values,
-      colorOf: (v: unknown) => scale.colorOf(v),
-    },
-    state: scale.state,
-  };
+  const scale = trainOrdinalColorScale({ name, values, config, prevState, range });
+  return ordinalColorResolution({
+    name,
+    values,
+    config,
+    legendTitle,
+    scale,
+    warnings,
+    advisories,
+  });
 }

--- a/packages/core/src/pipeline/train-pipeline-scales-types.ts
+++ b/packages/core/src/pipeline/train-pipeline-scales-types.ts
@@ -1,0 +1,21 @@
+/**
+ * Trained scale bundle for one pipeline run.
+ */
+import type { PortableSpec } from "@ggsvelte/spec";
+
+import type { PositionScale } from "../scales/train.js";
+
+import { collectAxisInputs, resolveColorScale, trainAxis } from "./scale-training.js";
+import type { LayerFrame } from "./types.js";
+
+export interface TrainedPipelineScales {
+  xTraining: ReturnType<typeof trainAxis>;
+  yTraining: ReturnType<typeof trainAxis>;
+  panelScales: { x: PositionScale; y: PositionScale }[];
+  colorResolution: ReturnType<typeof resolveColorScale>;
+  fillResolution: ReturnType<typeof resolveColorScale>;
+  xInputs: ReturnType<typeof collectAxisInputs>;
+  yInputs: ReturnType<typeof collectAxisInputs>;
+  scalesConfig: NonNullable<PortableSpec["scales"]>;
+  allFrames: LayerFrame[];
+}

--- a/packages/core/src/pipeline/train-pipeline-scales.ts
+++ b/packages/core/src/pipeline/train-pipeline-scales.ts
@@ -4,26 +4,15 @@
 import type { PortableSpec } from "@ggsvelte/spec";
 
 import type { EditionDefaults } from "../editions.js";
-import type { PositionScale } from "../scales/train.js";
 import type { ColumnTable } from "../table.js";
 
 import type { FacetPanelDef } from "./facets.js";
-import { collectAxisInputs, resolveColorScale, trainAxis } from "./scale-training.js";
 import { trainPipelineColorScales } from "./train-pipeline-scales-color.js";
 import { trainPipelinePositionScales } from "./train-pipeline-scales-position.js";
+import type { TrainedPipelineScales } from "./train-pipeline-scales-types.js";
 import type { Advisory, LayerFrame, PipelineWarning, RunOptions } from "./types.js";
 
-export interface TrainedPipelineScales {
-  xTraining: ReturnType<typeof trainAxis>;
-  yTraining: ReturnType<typeof trainAxis>;
-  panelScales: { x: PositionScale; y: PositionScale }[];
-  colorResolution: ReturnType<typeof resolveColorScale>;
-  fillResolution: ReturnType<typeof resolveColorScale>;
-  xInputs: ReturnType<typeof collectAxisInputs>;
-  yInputs: ReturnType<typeof collectAxisInputs>;
-  scalesConfig: NonNullable<PortableSpec["scales"]>;
-  allFrames: LayerFrame[];
-}
+export type { TrainedPipelineScales } from "./train-pipeline-scales-types.js";
 
 export function trainPipelineScales(input: {
   normalized: PortableSpec;

--- a/packages/core/tests/pipeline-build-candidates.test.ts
+++ b/packages/core/tests/pipeline-build-candidates.test.ts
@@ -240,3 +240,19 @@ describe("panelValueToken", () => {
     expect(panelValueToken(true)).toBe("b:true");
   });
 });
+
+describe("createLazyIdentityIndex", () => {
+  it("builds the index once and reuses it", async () => {
+    const { createLazyIdentityIndex } =
+      await import("../src/pipeline/build-candidates-identity-lazy.ts");
+    let calls = 0;
+    // empty panels produce a stable empty-ish index; count construction via
+    // successive get() returning the same reference.
+    const get = createLazyIdentityIndex([], []);
+    const a = get();
+    const b = get();
+    expect(a).toBe(b);
+    // silence unused
+    expect(calls).toBe(0);
+  });
+});

--- a/packages/core/tests/pipeline-layout-helpers.test.ts
+++ b/packages/core/tests/pipeline-layout-helpers.test.ts
@@ -157,3 +157,16 @@ describe("axisTicks", () => {
     ]);
   });
 });
+
+describe("singlePanelMarginReserve", () => {
+  it("reserves bottom/left for titles and right for legends", async () => {
+    const { singlePanelMarginReserve } =
+      await import("../src/pipeline/panel-layout-single-reserve.ts");
+    expect(singlePanelMarginReserve("", "", 18, 0)).toEqual({});
+    expect(singlePanelMarginReserve("x", "y", 18, 40)).toEqual({
+      bottom: 18,
+      left: 18,
+      right: 40 + LEGEND_GAP + LEGEND_EDGE_PAD,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Extract identity series/mode and lineage/annotation helpers; assemble render-model input type; chrome display and trained-scale types.
- Extract per-facet panel placement, single-panel margin reserve, finalize layer vs domain contracts.
- Extract ordinal train/result packing, bin frame packing, bind-layer result assembly, lazy identity index.
- Add characterization tests for margin reserve and lazy identity index.

## Test plan
- [x] `bun test packages/core` (520 pass)
- [x] `bun run check`
- [x] `bun run knip`
- [x] `bun run lint:type-aware`
- [x] Codex pre-PR review (`gpt-5.6-terra`) — PASS (no P1)