### PR TITLE
refactor(svelte): carry keyboard nudge-brush corners payload

### DIFF
--- a/packages/svelte/src/lib/GGPlot.svelte
+++ b/packages/svelte/src/lib/GGPlot.svelte
@@ -95,11 +95,7 @@
     resolveInteractionScope,
     toLayerInput,
   } from "./plot-assemble.js";
-  import {
-    brushAtPoint,
-    brushWithEnd,
-    nudgeBrushEnd,
-  } from "./plot-area-brush.js";
+  import { brushAtPoint, brushWithEnd } from "./plot-area-brush.js";
   import {
     frozenZoomDomains,
     normalizedRect,
@@ -2170,7 +2166,7 @@
   function onSurfaceKeyDown(event: KeyboardEvent): void {
     // Decision table is pure (plot-surface-keyboard); this switch owns side
     // effects only. brushCorners is the draft source of truth (not reducer
-    // brushing); complete-area carries finish so host only applies.
+    // brushing); nudge/complete-area carry pure payloads so host only applies.
     const { action, preventDefault } = resolveSurfaceKeyAction({
       key: event.key,
       shiftKey: event.shiftKey,
@@ -2181,18 +2177,17 @@
       focusKey: inspection?.focus.key ?? null,
       sourceKeys: inspection?.focus.sourceKeys ?? [],
       inspectionAnchor: inspection?.focus.anchor ?? null,
+      inspectionPanel,
       firstPanel: model?.scene.panels[0],
     });
     if (preventDefault) event.preventDefault();
     switch (action.type) {
       case "nudge-brush": {
-        // Pure table emits only when brushCorners was non-null.
-        const panel = inspectionPanel ?? model?.scene.panels[0];
-        if (panel === undefined || brushRect === null) return;
-        brushRect = nudgeBrushEnd(brushRect, action.dx, action.dy, panel);
+        // Pure table owns clamp panel policy and free-corner nudge.
+        brushRect = action.corners;
         reducer.dispatch({
           type: "move-area",
-          point: { x: brushRect.x1, y: brushRect.y1 },
+          point: { x: action.corners.x1, y: action.corners.y1 },
         });
         return;
       }

--- a/packages/svelte/src/lib/plot-surface-keyboard.ts
+++ b/packages/svelte/src/lib/plot-surface-keyboard.ts
@@ -1,5 +1,10 @@
 import { isAreaTool, type InteractionTool } from "./interaction.js";
-import { panelCenterAnchor, type BrushCorners, type PlotPoint } from "./plot-area-brush.js";
+import {
+  nudgeBrushEnd,
+  panelCenterAnchor,
+  type BrushCorners,
+  type PlotPoint,
+} from "./plot-area-brush.js";
 import { normalizedRect, type PanelBounds } from "./plot-geometry.js";
 import { resolveFinishBrushAction, type FinishBrushAction } from "./plot-brush-finish.js";
 
@@ -38,15 +43,24 @@ export type SurfaceKeyboardInput = {
    */
   readonly inspectionAnchor: PlotPoint | null;
   /**
+   * Host: panel containing inspection focus anchor, or null.
+   * Preferred clamp panel for nudge-brush over `firstPanel`.
+   */
+  readonly inspectionPanel: PanelBounds | null;
+  /**
    * Host: `model?.scene.panels[0]`. Panel-center fallback for `begin-area`
-   * when no inspection anchor. Host still uses `panelId(0)` for dispatch
-   * (index-based, not derived from this panel reference).
+   * when no inspection anchor; also nudge clamp fallback after inspectionPanel.
+   * Host still uses `panelId(0)` for dispatch (index-based).
    */
   readonly firstPanel: PanelBounds | undefined;
 };
 
 type SurfaceKeyAction =
-  | { readonly type: "nudge-brush"; readonly dx: number; readonly dy: number }
+  | {
+      readonly type: "nudge-brush";
+      /** Clamped draft after free-corner nudge; host assigns brushRect. */
+      readonly corners: BrushCorners;
+    }
   | {
       readonly type: "begin-area";
       /** Inspection anchor if present, else panel center (or {0,0}). */
@@ -98,6 +112,7 @@ export function resolveSurfaceKeyAction(input: SurfaceKeyboardInput): SurfaceKey
     focusKey,
     sourceKeys,
     inspectionAnchor,
+    inspectionPanel,
     firstPanel,
   } = input;
   const area = isAreaTool(activeTool);
@@ -107,9 +122,18 @@ export function resolveSurfaceKeyAction(input: SurfaceKeyboardInput): SurfaceKey
     const step = shiftKey ? 10 : 1;
     const dx = key === "ArrowLeft" ? -step : key === "ArrowRight" ? step : 0;
     const dy = key === "ArrowUp" ? -step : key === "ArrowDown" ? step : 0;
+    // Prefer inspection panel, else first panel (host previously inspectionPanel ?? panels[0]).
+    const panel = inspectionPanel ?? firstPanel;
+    if (panel === undefined) {
+      // Draft without a panel: swallow the key (preventDefault) without mutating.
+      return { preventDefault: true, action: { type: "none" } };
+    }
     return {
       preventDefault: true,
-      action: { type: "nudge-brush", dx, dy },
+      action: {
+        type: "nudge-brush",
+        corners: nudgeBrushEnd(brushCorners, dx, dy, panel),
+      },
     };
   }
 

--- a/packages/svelte/tests/plot-surface-keyboard.test.ts
+++ b/packages/svelte/tests/plot-surface-keyboard.test.ts
@@ -13,6 +13,10 @@ const reversedDraft: BrushCorners = { x0: 40, y0: 50, x1: 10, y1: 20 };
 /** Zero-size draft — keyboard still commits (no too-small evaluation). */
 const zeroDraft: BrushCorners = { x0: 5, y0: 5, x1: 5, y1: 5 };
 
+const panel = { x: 0, y: 0, width: 100, height: 80 };
+/** Interior free corner so unclamped ±1/±10 steps stay in-bounds. */
+const draftInterior: BrushCorners = { x0: 10, y0: 20, x1: 50, y1: 40 };
+
 const base = (
   overrides: Partial<SurfaceKeyboardInput> & Pick<SurfaceKeyboardInput, "key" | "activeTool">,
 ): SurfaceKeyboardInput => ({
@@ -23,8 +27,9 @@ const base = (
   // Meaningful only when hasInspection (toggle-point-keys); unused otherwise.
   focusKey: null,
   sourceKeys: [],
-  // Meaningful for begin-area; unused otherwise.
+  // Meaningful for begin-area / nudge; unused otherwise.
   inspectionAnchor: null,
+  inspectionPanel: null,
   firstPanel: undefined,
   ...overrides,
 });
@@ -32,15 +37,23 @@ const base = (
 describe("resolveSurfaceKeyAction", () => {
   describe("area tools with brush draft", () => {
     it.each(["select-area", "zoom-area"] as const)(
-      "%s Arrow keys nudge the free corner (shift steps by 10)",
+      "%s Arrow keys nudge free corner with clamped corners payload (shift steps by 10)",
       (tool) => {
         expect(
           resolveSurfaceKeyAction(
-            base({ key: "ArrowRight", activeTool: tool, brushCorners: draft }),
+            base({
+              key: "ArrowRight",
+              activeTool: tool,
+              brushCorners: draftInterior,
+              firstPanel: panel,
+            }),
           ),
         ).toEqual({
           preventDefault: true,
-          action: { type: "nudge-brush", dx: 1, dy: 0 },
+          action: {
+            type: "nudge-brush",
+            corners: { x0: 10, y0: 20, x1: 51, y1: 40 },
+          },
         });
         expect(
           resolveSurfaceKeyAction(
@@ -48,29 +61,91 @@ describe("resolveSurfaceKeyAction", () => {
               key: "ArrowUp",
               shiftKey: true,
               activeTool: tool,
-              brushCorners: draft,
+              brushCorners: draftInterior,
+              firstPanel: panel,
             }),
           ),
         ).toEqual({
           preventDefault: true,
-          action: { type: "nudge-brush", dx: 0, dy: -10 },
+          action: {
+            type: "nudge-brush",
+            corners: { x0: 10, y0: 20, x1: 50, y1: 30 },
+          },
         });
       },
     );
 
-    it("preserves startsWith('Arrow') for nonstandard keys (zero deltas)", () => {
+    it("prefers inspectionPanel over firstPanel for nudge clamp", () => {
+      const inspectionOnly = { x: 0, y: 0, width: 20, height: 20 };
+      const firstOnly = { x: 0, y: 0, width: 1000, height: 1000 };
+      expect(
+        resolveSurfaceKeyAction(
+          base({
+            key: "ArrowRight",
+            activeTool: "select-area",
+            brushCorners: { x0: 5, y0: 5, x1: 10, y1: 10 },
+            inspectionPanel: inspectionOnly,
+            firstPanel: firstOnly,
+          }),
+        ),
+      ).toEqual({
+        preventDefault: true,
+        action: {
+          type: "nudge-brush",
+          // free corner clamps to inspection panel right edge (20), not 1000
+          corners: { x0: 5, y0: 5, x1: 11, y1: 10 },
+        },
+      });
+      // Prove first-only would not clamp at 20: large step hits inspection edge.
+      expect(
+        resolveSurfaceKeyAction(
+          base({
+            key: "ArrowRight",
+            shiftKey: true,
+            activeTool: "select-area",
+            brushCorners: { x0: 5, y0: 5, x1: 15, y1: 10 },
+            inspectionPanel: inspectionOnly,
+            firstPanel: firstOnly,
+          }),
+        ).action,
+      ).toEqual({
+        type: "nudge-brush",
+        corners: { x0: 5, y0: 5, x1: 20, y1: 10 },
+      });
+    });
+
+    it("preserves startsWith('Arrow') for nonstandard keys (zero deltas, same corners)", () => {
       expect(
         resolveSurfaceKeyAction(
           base({
             key: "ArrowDiagonal",
             activeTool: "select-area",
-            brushCorners: draft,
+            brushCorners: draftInterior,
+            firstPanel: panel,
           }),
         ),
       ).toEqual({
         preventDefault: true,
-        action: { type: "nudge-brush", dx: 0, dy: 0 },
+        action: {
+          type: "nudge-brush",
+          corners: draftInterior,
+        },
       });
+    });
+
+    it("swallows arrow when draft exists but no panel is available", () => {
+      // Keyboard begin-area with no model can leave a draft at {0,0} without panels.
+      expect(
+        resolveSurfaceKeyAction(
+          base({
+            key: "ArrowRight",
+            activeTool: "select-area",
+            brushCorners: draft,
+            inspectionPanel: null,
+            firstPanel: undefined,
+          }),
+        ),
+      ).toEqual({ preventDefault: true, action: { type: "none" } });
     });
 
     it("select-area Enter completes with select-end finish (normalized rect)", () => {


### PR DESCRIPTION
## Summary

- Expand keyboard `nudge-brush` to carry pure-owned clamped `corners` via `nudgeBrushEnd`.
- Pure prefers `inspectionPanel` over `firstPanel` for clamp bounds (matches prior host policy).
- Draft without any panel: `preventDefault` + `none` (swallow arrows without mutation).
- Host only assigns `brushRect = action.corners` and dispatches the free-corner point.

## Test plan

- [x] Arrow nudge corners payload (step 1 / shift 10)
- [x] inspectionPanel preferred over firstPanel
- [x] Nonstandard Arrow* zero-delta preserves corners
- [x] Draft without panel → preventDefault + none
- [x] svelte-check + pre-push hooks
- [ ] CI on PR