### PR TITLE
refactor(core): split pipeline entry, facet place, scene, boxplot batches

### DIFF
--- a/packages/core/src/pipeline.ts
+++ b/packages/core/src/pipeline.ts
@@ -41,6 +41,7 @@ import type { SpecInput, PortableSpec } from "@ggsvelte/spec";
 import { perfMark, perfMeasure } from "./perf.js";
 
 import type { Advisory, PipelineWarning, RenderModel, RunOptions } from "./pipeline/types.js";
+import { allocatePipelineRunId } from "./pipeline/run-id.js";
 import { setupPipelineRun } from "./pipeline/setup-run.js";
 import { preparePanels } from "./pipeline/prepare-panels.js";
 import { trainPipelineScales } from "./pipeline/train-pipeline-scales.js";
@@ -59,18 +60,15 @@ export type {
   RunOptions,
   ScaleDomainSnapshot,
   TrainedScales,
-} from "./pipeline/types.js";
-export { CANVAS_AUTO_THRESHOLD, PipelineError } from "./pipeline/types.js";
-export { batchMarkCount } from "./pipeline/geometry.js";
+} from "./pipeline/public-api.js";
+export { CANVAS_AUTO_THRESHOLD, PipelineError, batchMarkCount } from "./pipeline/public-api.js";
 
 // ---------------------------------------------------------------------------
 // runPipeline
 // ---------------------------------------------------------------------------
 
-let nextRunId = 0;
-
 export function runPipeline(spec: SpecInput | PortableSpec, options: RunOptions): RenderModel {
-  const runId = ++nextRunId;
+  const runId = allocatePipelineRunId();
   perfMark("ggsvelte:pipeline:start");
 
   const warnings: PipelineWarning[] = [];

--- a/packages/core/src/pipeline/assemble-scene-build.ts
+++ b/packages/core/src/pipeline/assemble-scene-build.ts
@@ -1,31 +1,15 @@
 /**
  * Scene assembly from panel placements, axes, and legends.
  */
-import type { GeometryBatch, Scene, SceneLegend } from "../scene.js";
-import type { ThemeTokens } from "../theme.js";
-import type { PositionScale } from "../scales/train.js";
+import type { Scene } from "../scene.js";
 
+import type { AssembleSceneInput } from "./assemble-scene-input.js";
 import { placeSceneLegends } from "./assemble-scene-legends.js";
 import { assembleScenePanels } from "./assemble-scene-panels.js";
-import type { FacetPanelDef } from "./facets.js";
-import type { PanelPlacement } from "./panel-layout.js";
 
-export function assembleScene(input: {
-  width: number;
-  height: number;
-  placements: readonly PanelPlacement[];
-  facetPanels: readonly FacetPanelDef[];
-  displayScales: (p: number) => { h: PositionScale; v: PositionScale };
-  hTitle: string;
-  vTitle: string;
-  batches: GeometryBatch[];
-  legendBlock: { legends: SceneLegend[]; width: number };
-  topBand: number;
-  theme: ThemeTokens;
-  title: string;
-  subtitle: string;
-  caption: string;
-}): Scene {
+export type { AssembleSceneInput } from "./assemble-scene-input.js";
+
+export function assembleScene(input: AssembleSceneInput): Scene {
   const {
     width,
     height,

--- a/packages/core/src/pipeline/assemble-scene-input.ts
+++ b/packages/core/src/pipeline/assemble-scene-input.ts
@@ -1,0 +1,26 @@
+/**
+ * assembleScene input contract.
+ */
+import type { GeometryBatch, SceneLegend } from "../scene.js";
+import type { ThemeTokens } from "../theme.js";
+import type { PositionScale } from "../scales/train.js";
+
+import type { FacetPanelDef } from "./facets.js";
+import type { PanelPlacement } from "./panel-layout.js";
+
+export interface AssembleSceneInput {
+  width: number;
+  height: number;
+  placements: readonly PanelPlacement[];
+  facetPanels: readonly FacetPanelDef[];
+  displayScales: (p: number) => { h: PositionScale; v: PositionScale };
+  hTitle: string;
+  vTitle: string;
+  batches: GeometryBatch[];
+  legendBlock: { legends: SceneLegend[]; width: number };
+  topBand: number;
+  theme: ThemeTokens;
+  title: string;
+  subtitle: string;
+  caption: string;
+}

--- a/packages/core/src/pipeline/build-candidates-datum-annotation.ts
+++ b/packages/core/src/pipeline/build-candidates-datum-annotation.ts
@@ -1,0 +1,25 @@
+/**
+ * Annotation-rule intercept values for identity candidates.
+ */
+import type { CellValue } from "../table.js";
+
+import type { LayerFrame } from "./types.js";
+
+export function resolveAnnotationIntercepts(input: {
+  frame: LayerFrame | undefined;
+  primitiveIndex: number;
+}): {
+  annotationRule: boolean;
+  annotationX: CellValue;
+  annotationY: CellValue;
+} {
+  const { frame, primitiveIndex } = input;
+  if (frame?.binding.ruleForm !== "annotation") {
+    return { annotationRule: false, annotationX: null, annotationY: null };
+  }
+  return {
+    annotationRule: true,
+    annotationX: frame.xIntercepts[primitiveIndex] ?? null,
+    annotationY: frame.yIntercepts[primitiveIndex - frame.xIntercepts.length] ?? null,
+  };
+}

--- a/packages/core/src/pipeline/build-candidates-datum-context.ts
+++ b/packages/core/src/pipeline/build-candidates-datum-context.ts
@@ -1,66 +1,7 @@
 /**
  * Resolve outlier/annotation context and series rank for identity candidates.
+ * Implementations live in sibling modules; this facade keeps import paths stable.
  */
-import type { GeometryBatch } from "../scene.js";
-import { bandKey } from "../scales/train.js";
-import type { CellValue } from "../table.js";
-
-import type { FacetPanelDef } from "./facets.js";
-import type { LayerFrame, ResolvedColorScale } from "./types.js";
-
-export function resolveOutlierContext(input: {
-  frame: LayerFrame | undefined;
-  batch: GeometryBatch;
-  primitiveIndex: number;
-  facetPanel: FacetPanelDef | undefined;
-}): { outlierLocalRow: number | null; outlierSourceRow: number | null } {
-  const { frame, batch, primitiveIndex, facetPanel } = input;
-  const outlierLocalRow =
-    frame?.box !== null && frame?.binding.layer.geom === "boxplot" && batch.kind === "points"
-      ? (frame?.box.outlierRow[primitiveIndex] ?? null)
-      : null;
-  const outlierSourceRow =
-    outlierLocalRow === null
-      ? null
-      : (facetPanel?.sourceRows?.[outlierLocalRow] ?? outlierLocalRow);
-  return { outlierLocalRow, outlierSourceRow };
-}
-
-export function resolveAnnotationIntercepts(input: {
-  frame: LayerFrame | undefined;
-  primitiveIndex: number;
-}): {
-  annotationRule: boolean;
-  annotationX: CellValue;
-  annotationY: CellValue;
-} {
-  const { frame, primitiveIndex } = input;
-  if (frame?.binding.ruleForm !== "annotation") {
-    return { annotationRule: false, annotationX: null, annotationY: null };
-  }
-  return {
-    annotationRule: true,
-    annotationX: frame.xIntercepts[primitiveIndex] ?? null,
-    annotationY: frame.yIntercepts[primitiveIndex - frame.xIntercepts.length] ?? null,
-  };
-}
-
-export function ordinalSeriesRank(input: {
-  color: ResolvedColorScale | null;
-  fill: ResolvedColorScale | null;
-  colorField: string | undefined;
-  fillField: string | undefined;
-  sourceRow: number | null;
-  sourceValue: (field: string | undefined) => CellValue;
-  group: number;
-}): number {
-  const { color, fill, colorField, fillField, sourceRow, sourceValue, group } = input;
-  const ordinalRank = (resolved: ResolvedColorScale | null, field: string | undefined) => {
-    if (resolved?.kind !== "ordinal" || field === undefined || sourceRow === null) return -1;
-    const key = bandKey(sourceValue(field));
-    return resolved.scale.domain.findIndex((value) => bandKey(value) === key);
-  };
-  const colorRank = ordinalRank(color, colorField);
-  const fillRank = ordinalRank(fill, fillField);
-  return colorRank >= 0 ? colorRank : fillRank >= 0 ? fillRank : group;
-}
+export { resolveAnnotationIntercepts } from "./build-candidates-datum-annotation.js";
+export { ordinalSeriesRank } from "./build-candidates-datum-ordinal-rank.js";
+export { resolveOutlierContext } from "./build-candidates-datum-outlier.js";

--- a/packages/core/src/pipeline/build-candidates-datum-locate-types.ts
+++ b/packages/core/src/pipeline/build-candidates-datum-locate-types.ts
@@ -1,0 +1,21 @@
+/**
+ * Located identity candidate frame/batch context.
+ */
+import type { CellValue } from "../table.js";
+
+import type { LayerFrame } from "./types.js";
+
+export interface LocatedIdentityCandidate {
+  sourceRow: number | null;
+  frame: LayerFrame | undefined;
+  outlierSourceRow: number | null;
+  frameRow: number;
+  derivedGroup: number;
+  sourceValue: (field: string | undefined) => CellValue;
+  xField: string | undefined;
+  yField: string | undefined;
+  colorField: string | undefined;
+  fillField: string | undefined;
+  seriesByRow: Map<string, number>;
+  sourceRowsByGroup: Map<string, number[]>;
+}

--- a/packages/core/src/pipeline/build-candidates-datum-locate.ts
+++ b/packages/core/src/pipeline/build-candidates-datum-locate.ts
@@ -2,7 +2,6 @@
  * Locate frame/batch context for one identity-indexed candidate fact.
  */
 import type { CandidateBuildFacts } from "../candidate-store.js";
-import type { CellValue } from "../table.js";
 
 import type { IdentityCandidateResolveContext } from "./build-candidates-datum-ctx.js";
 import { resolveOutlierContext } from "./build-candidates-datum-context.js";
@@ -10,23 +9,10 @@ import {
   makeSourceValueLookup,
   resolveCandidateFieldChannels,
 } from "./build-candidates-datum-fields.js";
+import type { LocatedIdentityCandidate } from "./build-candidates-datum-locate-types.js";
 import { resolveCandidateFrameRow } from "./build-candidates-frame-row.js";
-import type { LayerFrame } from "./types.js";
 
-export interface LocatedIdentityCandidate {
-  sourceRow: number | null;
-  frame: LayerFrame | undefined;
-  outlierSourceRow: number | null;
-  frameRow: number;
-  derivedGroup: number;
-  sourceValue: (field: string | undefined) => CellValue;
-  xField: string | undefined;
-  yField: string | undefined;
-  colorField: string | undefined;
-  fillField: string | undefined;
-  seriesByRow: Map<string, number>;
-  sourceRowsByGroup: Map<string, number[]>;
-}
+export type { LocatedIdentityCandidate } from "./build-candidates-datum-locate-types.js";
 
 export function locateIdentityCandidate(
   ctx: IdentityCandidateResolveContext,

--- a/packages/core/src/pipeline/build-candidates-datum-ordinal-rank.ts
+++ b/packages/core/src/pipeline/build-candidates-datum-ordinal-rank.ts
@@ -1,0 +1,27 @@
+/**
+ * Ordinal color/fill series rank for identity candidates.
+ */
+import { bandKey } from "../scales/train.js";
+import type { CellValue } from "../table.js";
+
+import type { ResolvedColorScale } from "./types.js";
+
+export function ordinalSeriesRank(input: {
+  color: ResolvedColorScale | null;
+  fill: ResolvedColorScale | null;
+  colorField: string | undefined;
+  fillField: string | undefined;
+  sourceRow: number | null;
+  sourceValue: (field: string | undefined) => CellValue;
+  group: number;
+}): number {
+  const { color, fill, colorField, fillField, sourceRow, sourceValue, group } = input;
+  const ordinalRank = (resolved: ResolvedColorScale | null, field: string | undefined) => {
+    if (resolved?.kind !== "ordinal" || field === undefined || sourceRow === null) return -1;
+    const key = bandKey(sourceValue(field));
+    return resolved.scale.domain.findIndex((value) => bandKey(value) === key);
+  };
+  const colorRank = ordinalRank(color, colorField);
+  const fillRank = ordinalRank(fill, fillField);
+  return colorRank >= 0 ? colorRank : fillRank >= 0 ? fillRank : group;
+}

--- a/packages/core/src/pipeline/build-candidates-datum-outlier.ts
+++ b/packages/core/src/pipeline/build-candidates-datum-outlier.ts
@@ -1,0 +1,25 @@
+/**
+ * Boxplot outlier row context for identity candidates.
+ */
+import type { GeometryBatch } from "../scene.js";
+
+import type { FacetPanelDef } from "./facets.js";
+import type { LayerFrame } from "./types.js";
+
+export function resolveOutlierContext(input: {
+  frame: LayerFrame | undefined;
+  batch: GeometryBatch;
+  primitiveIndex: number;
+  facetPanel: FacetPanelDef | undefined;
+}): { outlierLocalRow: number | null; outlierSourceRow: number | null } {
+  const { frame, batch, primitiveIndex, facetPanel } = input;
+  const outlierLocalRow =
+    frame?.box !== null && frame?.binding.layer.geom === "boxplot" && batch.kind === "points"
+      ? (frame?.box.outlierRow[primitiveIndex] ?? null)
+      : null;
+  const outlierSourceRow =
+    outlierLocalRow === null
+      ? null
+      : (facetPanel?.sourceRows?.[outlierLocalRow] ?? outlierLocalRow);
+  return { outlierLocalRow, outlierSourceRow };
+}

--- a/packages/core/src/pipeline/finalize-model-input.ts
+++ b/packages/core/src/pipeline/finalize-model-input.ts
@@ -1,0 +1,23 @@
+/**
+ * finalizeRenderModel input contract.
+ */
+import type { PortableSpec } from "@ggsvelte/spec";
+import type { Scene } from "../scene.js";
+
+import type { PanelLayoutResult } from "./panel-layout.js";
+import type { PreparedPanels } from "./prepare-panels.js";
+import type { TrainedPipelineScales } from "./train-pipeline-scales.js";
+import type { Advisory, PipelineWarning, RunOptions } from "./types.js";
+
+export interface FinalizeRenderModelInput {
+  runId: number;
+  normalized: PortableSpec;
+  options: RunOptions;
+  flip: boolean;
+  prepared: PreparedPanels;
+  trained: TrainedPipelineScales;
+  panelLayout: PanelLayoutResult;
+  scene: Scene;
+  warnings: PipelineWarning[];
+  advisories: Advisory[];
+}

--- a/packages/core/src/pipeline/finalize-model.ts
+++ b/packages/core/src/pipeline/finalize-model.ts
@@ -1,30 +1,15 @@
 /**
  * Finalize phase: layer contracts, domains, candidates, and RenderModel.
  */
-import type { PortableSpec } from "@ggsvelte/spec";
-
-import type { Scene } from "../scene.js";
-
 import { assembleFinalizeRenderModel } from "./finalize-model-assemble.js";
 import { buildFinalizeCandidates } from "./finalize-model-candidates.js";
 import { resolveFinalizeContracts } from "./finalize-model-contracts.js";
-import type { PanelLayoutResult } from "./panel-layout.js";
-import type { PreparedPanels } from "./prepare-panels.js";
-import type { TrainedPipelineScales } from "./train-pipeline-scales.js";
-import type { Advisory, PipelineWarning, RenderModel, RunOptions } from "./types.js";
+import type { FinalizeRenderModelInput } from "./finalize-model-input.js";
+import type { RenderModel } from "./types.js";
 
-export function finalizeRenderModel(input: {
-  runId: number;
-  normalized: PortableSpec;
-  options: RunOptions;
-  flip: boolean;
-  prepared: PreparedPanels;
-  trained: TrainedPipelineScales;
-  panelLayout: PanelLayoutResult;
-  scene: Scene;
-  warnings: PipelineWarning[];
-  advisories: Advisory[];
-}): RenderModel {
+export type { FinalizeRenderModelInput } from "./finalize-model-input.js";
+
+export function finalizeRenderModel(input: FinalizeRenderModelInput): RenderModel {
   const {
     runId,
     normalized,

--- a/packages/core/src/pipeline/frame-stats-smooth-frame.ts
+++ b/packages/core/src/pipeline/frame-stats-smooth-frame.ts
@@ -1,0 +1,46 @@
+/**
+ * Pack smooth-stat result into a LayerFrame.
+ */
+import type { ColumnTable } from "../table.js";
+import type { CellValue } from "../table.js";
+
+import { emptyFrameExtras } from "./frame-helpers.js";
+import type { CarriedColumnOf } from "./frame-stats-shared.js";
+import type { LayerBinding, LayerFrame } from "./types.js";
+import { NO_ROW } from "./types.js";
+
+type SmoothResult = {
+  x: Float64Array;
+  y: Float64Array;
+  ymin: Float64Array | null;
+  ymax: Float64Array | null;
+  groups: number[];
+  hasBand: boolean;
+  carried: Record<string, CellValue[]>;
+};
+
+export function packSmoothLayerFrame(
+  binding: LayerBinding,
+  table: ColumnTable,
+  result: SmoothResult,
+  columnOf: CarriedColumnOf,
+): LayerFrame {
+  const col = columnOf(result, null);
+  return {
+    binding,
+    table,
+    n: result.x.length,
+    xValues: null,
+    xNumeric: result.x,
+    yNumeric: result.y,
+    groups: result.groups,
+    rowIndex: Uint32Array.from({ length: result.x.length }, () => NO_ROW),
+    colorValues: col(binding.color.field),
+    fillValues: col(binding.fill.field),
+    labelValues: col(binding.labelField),
+    ...emptyFrameExtras(),
+    ymin: result.ymin,
+    ymax: result.ymax,
+    smoothBand: result.hasBand,
+  };
+}

--- a/packages/core/src/pipeline/frame-stats-smooth.ts
+++ b/packages/core/src/pipeline/frame-stats-smooth.ts
@@ -6,10 +6,10 @@ import type { SmoothParams } from "@ggsvelte/spec";
 import { statSmooth } from "../stats/smooth.js";
 import type { ColumnTable } from "../table.js";
 
-import { carriedColumns, emptyFrameExtras, removedStatWarning } from "./frame-helpers.js";
+import { carriedColumns, removedStatWarning } from "./frame-helpers.js";
+import { packSmoothLayerFrame } from "./frame-stats-smooth-frame.js";
 import { makeColumnOf } from "./frame-stats-shared.js";
 import type { Advisory, LayerBinding, LayerFrame, PipelineWarning } from "./types.js";
-import { NO_ROW } from "./types.js";
 
 export function buildSmoothFrame(
   binding: LayerBinding,
@@ -44,22 +44,5 @@ export function buildSmoothFrame(
       howToOverride: `Set params.method ("lm" | "loess") on layer ${index}.`,
     });
   }
-  const col = columnOf(result, null);
-  return {
-    binding,
-    table,
-    n: result.x.length,
-    xValues: null,
-    xNumeric: result.x,
-    yNumeric: result.y,
-    groups: result.groups,
-    rowIndex: Uint32Array.from({ length: result.x.length }, () => NO_ROW),
-    colorValues: col(binding.color.field),
-    fillValues: col(binding.fill.field),
-    labelValues: col(binding.labelField),
-    ...emptyFrameExtras(),
-    ymin: result.ymin,
-    ymax: result.ymax,
-    smoothBand: result.hasBand,
-  };
+  return packSmoothLayerFrame(binding, table, result, columnOf);
 }

--- a/packages/core/src/pipeline/geometry-boxplot-body-batches-parts.ts
+++ b/packages/core/src/pipeline/geometry-boxplot-body-batches-parts.ts
@@ -1,71 +1,9 @@
 /**
  * Boxplot body batch pieces: hinge rects, whiskers, and median segments.
+ * Implementation lives in geometry-boxplot-body-rects / -segments.
  */
-import type { GeometryBatch, RectsBatch } from "../scene.js";
-
-import type { LayerFrame, ResolvedColorScale } from "./types.js";
-import { colorOf } from "./types.js";
-import type { BoxplotBodyLayout } from "./geometry-boxplot-body-layout.js";
-
-/** Median line draws at 2× the box linewidth (ggplot2's fatten = 2). */
-export const BOX_MEDIAN_FATTEN = 2;
-
-export function makeBoxplotRectsBatch(
-  frame: LayerFrame,
-  layout: BoxplotBodyLayout,
-  fill: ResolvedColorScale | null,
-): RectsBatch {
-  const { binding } = frame;
-  const { linewidth, alpha } = layout;
-  const rectsBatchOut: RectsBatch = {
-    kind: "rects",
-    layerIndex: binding.index,
-    panelIndex: 0,
-    rects: Float32Array.from(layout.rects),
-    rowIndex: Uint32Array.from(layout.rectRows),
-    fill: binding.fill.constant,
-    fillRole: "paper",
-    stroke: null,
-    strokeWidth: linewidth,
-    alpha,
-  };
-  if (fill !== null && (frame.fillValues !== null || binding.fill.scaledConstant !== null)) {
-    rectsBatchOut.fills = layout.keptRows.map((row) =>
-      colorOf(
-        fill,
-        frame.fillValues === null ? binding.fill.scaledConstant! : frame.fillValues[row]!,
-      ),
-    );
-  }
-  return rectsBatchOut;
-}
-
-export function makeBoxplotWhiskerAndMedianBatches(
-  frame: LayerFrame,
-  layout: BoxplotBodyLayout,
-): GeometryBatch[] {
-  const { binding } = frame;
-  const { linewidth, alpha } = layout;
-  return [
-    {
-      kind: "segments",
-      layerIndex: binding.index,
-      panelIndex: 0,
-      segments: Float32Array.from(layout.whiskers),
-      rowIndex: Uint32Array.from(layout.whiskerRows),
-      stroke: null,
-      linewidth,
-      alpha,
-    },
-    {
-      kind: "segments",
-      layerIndex: binding.index,
-      panelIndex: 0,
-      segments: Float32Array.from(layout.medians),
-      rowIndex: Uint32Array.from(layout.medianRows),
-      stroke: null,
-      linewidth: linewidth * BOX_MEDIAN_FATTEN,
-      alpha,
-    },
-  ];
-}
+export { makeBoxplotRectsBatch } from "./geometry-boxplot-body-rects.js";
+export {
+  BOX_MEDIAN_FATTEN,
+  makeBoxplotWhiskerAndMedianBatches,
+} from "./geometry-boxplot-body-segments.js";

--- a/packages/core/src/pipeline/geometry-boxplot-body-rects.ts
+++ b/packages/core/src/pipeline/geometry-boxplot-body-rects.ts
@@ -1,0 +1,38 @@
+/**
+ * Boxplot hinge rect batch from precomputed body layout.
+ */
+import type { RectsBatch } from "../scene.js";
+
+import type { LayerFrame, ResolvedColorScale } from "./types.js";
+import { colorOf } from "./types.js";
+import type { BoxplotBodyLayout } from "./geometry-boxplot-body-layout.js";
+
+export function makeBoxplotRectsBatch(
+  frame: LayerFrame,
+  layout: BoxplotBodyLayout,
+  fill: ResolvedColorScale | null,
+): RectsBatch {
+  const { binding } = frame;
+  const { linewidth, alpha } = layout;
+  const rectsBatchOut: RectsBatch = {
+    kind: "rects",
+    layerIndex: binding.index,
+    panelIndex: 0,
+    rects: Float32Array.from(layout.rects),
+    rowIndex: Uint32Array.from(layout.rectRows),
+    fill: binding.fill.constant,
+    fillRole: "paper",
+    stroke: null,
+    strokeWidth: linewidth,
+    alpha,
+  };
+  if (fill !== null && (frame.fillValues !== null || binding.fill.scaledConstant !== null)) {
+    rectsBatchOut.fills = layout.keptRows.map((row) =>
+      colorOf(
+        fill,
+        frame.fillValues === null ? binding.fill.scaledConstant! : frame.fillValues[row]!,
+      ),
+    );
+  }
+  return rectsBatchOut;
+}

--- a/packages/core/src/pipeline/geometry-boxplot-body-segments.ts
+++ b/packages/core/src/pipeline/geometry-boxplot-body-segments.ts
@@ -1,0 +1,40 @@
+/**
+ * Boxplot whisker and median segment batches from body layout.
+ */
+import type { GeometryBatch } from "../scene.js";
+
+import type { LayerFrame } from "./types.js";
+import type { BoxplotBodyLayout } from "./geometry-boxplot-body-layout.js";
+
+/** Median line draws at 2× the box linewidth (ggplot2's fatten = 2). */
+export const BOX_MEDIAN_FATTEN = 2;
+
+export function makeBoxplotWhiskerAndMedianBatches(
+  frame: LayerFrame,
+  layout: BoxplotBodyLayout,
+): GeometryBatch[] {
+  const { binding } = frame;
+  const { linewidth, alpha } = layout;
+  return [
+    {
+      kind: "segments",
+      layerIndex: binding.index,
+      panelIndex: 0,
+      segments: Float32Array.from(layout.whiskers),
+      rowIndex: Uint32Array.from(layout.whiskerRows),
+      stroke: null,
+      linewidth,
+      alpha,
+    },
+    {
+      kind: "segments",
+      layerIndex: binding.index,
+      panelIndex: 0,
+      segments: Float32Array.from(layout.medians),
+      rowIndex: Uint32Array.from(layout.medianRows),
+      stroke: null,
+      linewidth: linewidth * BOX_MEDIAN_FATTEN,
+      alpha,
+    },
+  ];
+}

--- a/packages/core/src/pipeline/panel-layout-facet-map.ts
+++ b/packages/core/src/pipeline/panel-layout-facet-map.ts
@@ -1,0 +1,70 @@
+/**
+ * Map facet panel defs through geometry into placements.
+ */
+import type { LayoutTheme, Margins, TickFormatter } from "../layout/layout.js";
+import type { TextMeasurer } from "../layout/measure.js";
+
+import type { FacetPanelDef } from "./facets.js";
+import { placeOneFacetPanel } from "./panel-layout-facet-place-one.js";
+import type { DisplayScalesFn, PanelPlacement } from "./panel-layout-types.js";
+
+export function mapFacetPanelPlacements(input: {
+  facetPanels: readonly FacetPanelDef[];
+  freeH: boolean;
+  freeV: boolean;
+  displayScales: DisplayScalesFn;
+  mMax: Margins;
+  panelW: number;
+  panelH: number;
+  colX: number[];
+  rowY: number[];
+  bottomMostRow: number[];
+  hBreaks: readonly (number | string)[] | undefined;
+  vBreaks: readonly (number | string)[] | undefined;
+  formatH: TickFormatter | undefined;
+  formatV: TickFormatter | undefined;
+  measurer: TextMeasurer;
+  layoutTheme: LayoutTheme;
+}): PanelPlacement[] {
+  const {
+    facetPanels,
+    freeH,
+    freeV,
+    displayScales,
+    mMax,
+    panelW,
+    panelH,
+    colX,
+    rowY,
+    bottomMostRow,
+    hBreaks,
+    vBreaks,
+    formatH,
+    formatV,
+    measurer,
+    layoutTheme,
+  } = input;
+
+  return facetPanels.map((def, p) => {
+    const { h, v } = displayScales(p);
+    return placeOneFacetPanel({
+      def,
+      h,
+      v,
+      mMax,
+      panelW,
+      panelH,
+      colX: colX[def.col]!,
+      rowY: rowY[def.row]!,
+      freeH,
+      freeV,
+      bottomMostRow: bottomMostRow[def.col]!,
+      hBreaks,
+      vBreaks,
+      formatH,
+      formatV,
+      measurer,
+      layoutTheme,
+    });
+  });
+}

--- a/packages/core/src/pipeline/panel-layout-facet-margins-input.ts
+++ b/packages/core/src/pipeline/panel-layout-facet-margins-input.ts
@@ -1,0 +1,30 @@
+/**
+ * Input contract for facet grid geometry computation.
+ */
+import type { LayoutTheme, TickFormatter } from "../layout/layout.js";
+import type { TextMeasurer } from "../layout/measure.js";
+
+import type { FacetPanelDef } from "./facets.js";
+import type { DisplayScalesFn } from "./panel-layout-types.js";
+
+export interface FacetGridGeometryInput {
+  facetPanels: readonly FacetPanelDef[];
+  nrow: number;
+  ncol: number;
+  freeH: boolean;
+  freeV: boolean;
+  outerLeftTitle: string;
+  outerBottomTitle: string;
+  axisTitleBand: number;
+  legendWidth: number;
+  optionsWidth: number;
+  layoutHeight: number;
+  topBand: number;
+  displayScales: DisplayScalesFn;
+  hBreaks: readonly (number | string)[] | undefined;
+  vBreaks: readonly (number | string)[] | undefined;
+  formatH: TickFormatter | undefined;
+  formatV: TickFormatter | undefined;
+  measurer: TextMeasurer;
+  layoutTheme: LayoutTheme;
+}

--- a/packages/core/src/pipeline/panel-layout-facet-margins.ts
+++ b/packages/core/src/pipeline/panel-layout-facet-margins.ts
@@ -1,39 +1,16 @@
 /**
  * Facet grid: outer chrome, shared margin pass, and panel cell geometry.
  */
-import type { LayoutTheme, TickFormatter } from "../layout/layout.js";
-import type { TextMeasurer } from "../layout/measure.js";
-
-import type { FacetPanelDef } from "./facets.js";
 import { computeFacetCellGeometry } from "./panel-layout-facet-cells.js";
+import type { FacetGridGeometryInput } from "./panel-layout-facet-margins-input.js";
 import { computeFacetSharedMargins } from "./panel-layout-facet-margins-pass.js";
 import type { FacetGridGeometry } from "./panel-layout-facet-margins-types.js";
 import { computeFacetOuterChrome } from "./panel-layout-facet-outer.js";
-import type { DisplayScalesFn } from "./panel-layout-types.js";
 
 export type { FacetGridGeometry } from "./panel-layout-facet-margins-types.js";
+export type { FacetGridGeometryInput } from "./panel-layout-facet-margins-input.js";
 
-export function computeFacetGridGeometry(input: {
-  facetPanels: readonly FacetPanelDef[];
-  nrow: number;
-  ncol: number;
-  freeH: boolean;
-  freeV: boolean;
-  outerLeftTitle: string;
-  outerBottomTitle: string;
-  axisTitleBand: number;
-  legendWidth: number;
-  optionsWidth: number;
-  layoutHeight: number;
-  topBand: number;
-  displayScales: DisplayScalesFn;
-  hBreaks: readonly (number | string)[] | undefined;
-  vBreaks: readonly (number | string)[] | undefined;
-  formatH: TickFormatter | undefined;
-  formatV: TickFormatter | undefined;
-  measurer: TextMeasurer;
-  layoutTheme: LayoutTheme;
-}): FacetGridGeometry {
+export function computeFacetGridGeometry(input: FacetGridGeometryInput): FacetGridGeometry {
   const outer = computeFacetOuterChrome({
     nrow: input.nrow,
     ncol: input.ncol,

--- a/packages/core/src/pipeline/panel-layout-facet-place-one.ts
+++ b/packages/core/src/pipeline/panel-layout-facet-place-one.ts
@@ -1,13 +1,12 @@
 /**
  * Place one facet panel: tick layout pass + axis visibility flags.
  */
-import type { LayoutTheme, Margins, PassResult, TickFormatter } from "../layout/layout.js";
-import { layoutPass } from "../layout/layout.js";
+import type { LayoutTheme, Margins, TickFormatter } from "../layout/layout.js";
 import type { TextMeasurer } from "../layout/measure.js";
 import type { PositionScale } from "../scales/train.js";
 
 import type { FacetPanelDef } from "./facets.js";
-import { layoutDomain } from "./layout-helpers.js";
+import { placeFacetPanelFromTicks } from "./panel-layout-facet-place-ticks.js";
 import type { PanelPlacement } from "./panel-layout-types.js";
 
 export function placeOneFacetPanel(input: {
@@ -29,47 +28,5 @@ export function placeOneFacetPanel(input: {
   measurer: TextMeasurer;
   layoutTheme: LayoutTheme;
 }): PanelPlacement {
-  const {
-    def,
-    h,
-    v,
-    mMax,
-    panelW,
-    panelH,
-    colX,
-    rowY,
-    freeH,
-    freeV,
-    bottomMostRow,
-    hBreaks,
-    vBreaks,
-    formatH,
-    formatV,
-    measurer,
-    layoutTheme,
-  } = input;
-
-  const ticksRun: PassResult = layoutPass(
-    mMax,
-    {
-      width: panelW + mMax.left + mMax.right,
-      height: panelH + mMax.top + mMax.bottom,
-      x: layoutDomain(h, hBreaks),
-      y: layoutDomain(v, vBreaks),
-      ...(formatH !== undefined && { formatX: formatH }),
-      ...(formatV !== undefined && { formatY: formatV }),
-      measurer,
-    },
-    layoutTheme,
-  );
-  return {
-    x: colX,
-    y: rowY,
-    width: panelW,
-    height: panelH,
-    ticksH: ticksRun.x.ticks,
-    ticksV: ticksRun.y.ticks,
-    showAxisX: freeH || def.row === bottomMostRow,
-    showAxisY: freeV || def.col === 0,
-  };
+  return placeFacetPanelFromTicks(input);
 }

--- a/packages/core/src/pipeline/panel-layout-facet-place-ticks.ts
+++ b/packages/core/src/pipeline/panel-layout-facet-place-ticks.ts
@@ -1,0 +1,75 @@
+/**
+ * Facet panel tick layout pass and placement packing.
+ */
+import type { LayoutTheme, Margins, TickFormatter } from "../layout/layout.js";
+import { layoutPass } from "../layout/layout.js";
+import type { TextMeasurer } from "../layout/measure.js";
+import type { PositionScale } from "../scales/train.js";
+
+import type { FacetPanelDef } from "./facets.js";
+import { layoutDomain } from "./layout-helpers.js";
+import type { PanelPlacement } from "./panel-layout-types.js";
+
+export function placeFacetPanelFromTicks(input: {
+  def: FacetPanelDef;
+  h: PositionScale;
+  v: PositionScale;
+  mMax: Margins;
+  panelW: number;
+  panelH: number;
+  colX: number;
+  rowY: number;
+  freeH: boolean;
+  freeV: boolean;
+  bottomMostRow: number;
+  hBreaks: readonly (number | string)[] | undefined;
+  vBreaks: readonly (number | string)[] | undefined;
+  formatH: TickFormatter | undefined;
+  formatV: TickFormatter | undefined;
+  measurer: TextMeasurer;
+  layoutTheme: LayoutTheme;
+}): PanelPlacement {
+  const {
+    def,
+    h,
+    v,
+    mMax,
+    panelW,
+    panelH,
+    colX,
+    rowY,
+    freeH,
+    freeV,
+    bottomMostRow,
+    hBreaks,
+    vBreaks,
+    formatH,
+    formatV,
+    measurer,
+    layoutTheme,
+  } = input;
+
+  const ticksRun = layoutPass(
+    mMax,
+    {
+      width: panelW + mMax.left + mMax.right,
+      height: panelH + mMax.top + mMax.bottom,
+      x: layoutDomain(h, hBreaks),
+      y: layoutDomain(v, vBreaks),
+      ...(formatH !== undefined && { formatX: formatH }),
+      ...(formatV !== undefined && { formatY: formatV }),
+      measurer,
+    },
+    layoutTheme,
+  );
+  return {
+    x: colX,
+    y: rowY,
+    width: panelW,
+    height: panelH,
+    ticksH: ticksRun.x.ticks,
+    ticksV: ticksRun.y.ticks,
+    showAxisX: freeH || def.row === bottomMostRow,
+    showAxisY: freeV || def.col === 0,
+  };
+}

--- a/packages/core/src/pipeline/panel-layout-facet.ts
+++ b/packages/core/src/pipeline/panel-layout-facet.ts
@@ -5,8 +5,8 @@ import type { LayoutTheme, TickFormatter } from "../layout/layout.js";
 import type { TextMeasurer } from "../layout/measure.js";
 
 import type { FacetPanelDef } from "./facets.js";
+import { mapFacetPanelPlacements } from "./panel-layout-facet-map.js";
 import { computeFacetGridGeometry } from "./panel-layout-facet-margins.js";
-import { placeOneFacetPanel } from "./panel-layout-facet-place-one.js";
 import type { DisplayScalesFn, PanelPlacement } from "./panel-layout-types.js";
 
 export function placeFacetPanels(input: {
@@ -30,46 +30,23 @@ export function placeFacetPanels(input: {
   measurer: TextMeasurer;
   layoutTheme: LayoutTheme;
 }): PanelPlacement[] {
-  const {
-    facetPanels,
-    freeH,
-    freeV,
-    displayScales,
-    hBreaks,
-    vBreaks,
-    formatH,
-    formatV,
-    measurer,
-    layoutTheme,
-  } = input;
-
-  const { mMax, panelW, panelH, colX, rowY, bottomMostRow } = computeFacetGridGeometry(input);
-
-  const placements: PanelPlacement[] = [];
-  for (let p = 0; p < facetPanels.length; p++) {
-    const def = facetPanels[p]!;
-    const { h, v } = displayScales(p);
-    placements.push(
-      placeOneFacetPanel({
-        def,
-        h,
-        v,
-        mMax,
-        panelW,
-        panelH,
-        colX: colX[def.col]!,
-        rowY: rowY[def.row]!,
-        freeH,
-        freeV,
-        bottomMostRow: bottomMostRow[def.col]!,
-        hBreaks,
-        vBreaks,
-        formatH,
-        formatV,
-        measurer,
-        layoutTheme,
-      }),
-    );
-  }
-  return placements;
+  const geometry = computeFacetGridGeometry(input);
+  return mapFacetPanelPlacements({
+    facetPanels: input.facetPanels,
+    freeH: input.freeH,
+    freeV: input.freeV,
+    displayScales: input.displayScales,
+    mMax: geometry.mMax,
+    panelW: geometry.panelW,
+    panelH: geometry.panelH,
+    colX: geometry.colX,
+    rowY: geometry.rowY,
+    bottomMostRow: geometry.bottomMostRow,
+    hBreaks: input.hBreaks,
+    vBreaks: input.vBreaks,
+    formatH: input.formatH,
+    formatV: input.formatV,
+    measurer: input.measurer,
+    layoutTheme: input.layoutTheme,
+  });
 }

--- a/packages/core/src/pipeline/panel-layout-result.ts
+++ b/packages/core/src/pipeline/panel-layout-result.ts
@@ -1,0 +1,26 @@
+/**
+ * Pack chrome + placements into PanelLayoutResult.
+ */
+import type { PanelLayoutChrome } from "./panel-layout-chrome.js";
+import type { PanelLayoutResult, PanelPlacement } from "./panel-layout-types.js";
+
+export function panelLayoutResultFromChrome(
+  chrome: PanelLayoutChrome,
+  placements: PanelPlacement[],
+): PanelLayoutResult {
+  return {
+    placements,
+    title: chrome.title,
+    subtitle: chrome.subtitle,
+    caption: chrome.caption,
+    hTitle: chrome.hTitle,
+    vTitle: chrome.vTitle,
+    xTitle: chrome.xTitle,
+    yTitle: chrome.yTitle,
+    topBand: chrome.topBand,
+    formatX: chrome.formatX,
+    formatY: chrome.formatY,
+    displayScales: chrome.displayScales,
+    legendBlock: chrome.legendBlock,
+  };
+}

--- a/packages/core/src/pipeline/panel-layout-single-from-layout.ts
+++ b/packages/core/src/pipeline/panel-layout-single-from-layout.ts
@@ -1,0 +1,25 @@
+/**
+ * Pack single-panel placement from a layout() result.
+ */
+import type { LayoutResult } from "../layout/layout.js";
+
+import type { PanelPlacement } from "./panel-layout-types.js";
+
+export function singlePanelPlacementFromLayout(
+  layoutResult: LayoutResult,
+  optionsWidth: number,
+  layoutHeight: number,
+  topBand: number,
+): PanelPlacement {
+  const margins = layoutResult.margins;
+  return {
+    x: margins.left,
+    y: topBand + margins.top,
+    width: Math.max(1, optionsWidth - margins.left - margins.right),
+    height: Math.max(1, layoutHeight - margins.top - margins.bottom),
+    ticksH: layoutResult.x.ticks,
+    ticksV: layoutResult.y.ticks,
+    showAxisX: true,
+    showAxisY: true,
+  };
+}

--- a/packages/core/src/pipeline/panel-layout-single.ts
+++ b/packages/core/src/pipeline/panel-layout-single.ts
@@ -7,6 +7,7 @@ import type { TextMeasurer } from "../layout/measure.js";
 import type { PositionScale } from "../scales/train.js";
 
 import { layoutDomain } from "./layout-helpers.js";
+import { singlePanelPlacementFromLayout } from "./panel-layout-single-from-layout.js";
 import { singlePanelMarginReserve } from "./panel-layout-single-reserve.js";
 import type { PanelPlacement } from "./panel-layout-types.js";
 
@@ -56,15 +57,5 @@ export function placeSinglePanel(input: {
     reserve: singlePanelMarginReserve(hTitle, vTitle, axisTitleBand, legendWidth),
     theme: layoutTheme,
   });
-  const margins = layoutResult.margins;
-  return {
-    x: margins.left,
-    y: topBand + margins.top,
-    width: Math.max(1, optionsWidth - margins.left - margins.right),
-    height: Math.max(1, layoutHeight - margins.top - margins.bottom),
-    ticksH: layoutResult.x.ticks,
-    ticksV: layoutResult.y.ticks,
-    showAxisX: true,
-    showAxisY: true,
-  };
+  return singlePanelPlacementFromLayout(layoutResult, optionsWidth, layoutHeight, topBand);
 }

--- a/packages/core/src/pipeline/panel-layout.ts
+++ b/packages/core/src/pipeline/panel-layout.ts
@@ -11,6 +11,7 @@ import type { ThemeTokens } from "../theme.js";
 import type { FacetPanelDef } from "./facets.js";
 import { resolvePanelLayoutChrome } from "./panel-layout-chrome.js";
 import { buildPanelPlacements } from "./panel-layout-placements.js";
+import { panelLayoutResultFromChrome } from "./panel-layout-result.js";
 import type { PanelLayoutResult } from "./panel-layout-types.js";
 import type { LayerFrame, PipelineWarning, RunOptions } from "./types.js";
 
@@ -49,19 +50,5 @@ export function computePanelLayout(input: {
     options,
   });
 
-  return {
-    placements,
-    title: chrome.title,
-    subtitle: chrome.subtitle,
-    caption: chrome.caption,
-    hTitle: chrome.hTitle,
-    vTitle: chrome.vTitle,
-    xTitle: chrome.xTitle,
-    yTitle: chrome.yTitle,
-    topBand: chrome.topBand,
-    formatX: chrome.formatX,
-    formatY: chrome.formatY,
-    displayScales: chrome.displayScales,
-    legendBlock: chrome.legendBlock,
-  };
+  return panelLayoutResultFromChrome(chrome, placements);
 }

--- a/packages/core/src/pipeline/prepare-panels-bin-ranges.ts
+++ b/packages/core/src/pipeline/prepare-panels-bin-ranges.ts
@@ -1,0 +1,20 @@
+/**
+ * Shared bin break grids across facet panels when the x scale is fixed.
+ */
+import { finiteExtent } from "../scales/train.js";
+import type { ColumnTable } from "../table.js";
+
+import type { LayerBinding } from "./types.js";
+
+export function computePanelBinRanges(
+  bindings: readonly LayerBinding[],
+  table: ColumnTable,
+  faceted: boolean,
+  freeX: boolean,
+): Array<[number, number] | undefined> {
+  return bindings.map((binding) => {
+    const stat = binding.layer.stat ?? "identity";
+    if (stat !== "bin" || !faceted || freeX || binding.xField === null) return void 0;
+    return finiteExtent([table.numeric(binding.xField)]) ?? void 0;
+  });
+}

--- a/packages/core/src/pipeline/prepare-panels-empty-layers.ts
+++ b/packages/core/src/pipeline/prepare-panels-empty-layers.ts
@@ -1,0 +1,20 @@
+/**
+ * Warn when every panel leaves a non-annotation layer empty after stats.
+ */
+import type { LayerBinding, LayerFrame, PipelineWarning } from "./types.js";
+
+export function warnEmptyLayers(
+  bindings: readonly LayerBinding[],
+  panelFrames: readonly (readonly LayerFrame[])[],
+  warnings: PipelineWarning[],
+): void {
+  for (let index = 0; index < bindings.length; index++) {
+    const allEmpty = panelFrames.every((frames) => frames[index]!.n === 0);
+    if (allEmpty && bindings[index]!.ruleForm !== "annotation") {
+      warnings.push({
+        code: "empty-layer",
+        message: `Layer ${index} (${bindings[index]!.layer.geom}) has no drawable rows after its stat; skipping it.`,
+      });
+    }
+  }
+}

--- a/packages/core/src/pipeline/prepare-panels-frames.ts
+++ b/packages/core/src/pipeline/prepare-panels-frames.ts
@@ -3,13 +3,14 @@
  */
 import type { PortableSpec } from "@ggsvelte/spec";
 
-import { finiteExtent } from "../scales/train.js";
 import type { ColumnTable } from "../table.js";
 
 import { bindLayer } from "./bind.js";
 import type { FacetPanelDef } from "./facets.js";
 import { buildFrame, remapSourceRows } from "./frame.js";
 import { applyPosition } from "./position.js";
+import { computePanelBinRanges } from "./prepare-panels-bin-ranges.js";
+import { warnEmptyLayers } from "./prepare-panels-empty-layers.js";
 import type { Advisory, LayerBinding, LayerFrame, PipelineWarning } from "./types.js";
 
 export function buildPanelFrames(input: {
@@ -29,12 +30,7 @@ export function buildPanelFrames(input: {
   for (let index = 0; index < normalized.layers.length; index++) {
     bindings.push(bindLayer(normalized.layers[index]!, index, table, warnings));
   }
-  // Shared bin break grids across panels when the x scale is fixed.
-  const binRanges = bindings.map((binding) => {
-    const stat = binding.layer.stat ?? "identity";
-    if (stat !== "bin" || !faceted || freeX || binding.xField === null) return void 0;
-    return finiteExtent([table.numeric(binding.xField)]) ?? void 0;
-  });
+  const binRanges = computePanelBinRanges(bindings, table, faceted, freeX);
   for (let p = 0; p < facetPanels.length; p++) {
     const panelTable = facetPanels[p]!.table;
     for (let index = 0; index < bindings.length; index++) {
@@ -50,15 +46,7 @@ export function buildPanelFrames(input: {
       panelFrames[p]!.push(frame);
     }
   }
-  for (let index = 0; index < bindings.length; index++) {
-    const allEmpty = panelFrames.every((frames) => frames[index]!.n === 0);
-    if (allEmpty && bindings[index]!.ruleForm !== "annotation") {
-      warnings.push({
-        code: "empty-layer",
-        message: `Layer ${index} (${bindings[index]!.layer.geom}) has no drawable rows after its stat; skipping it.`,
-      });
-    }
-  }
+  warnEmptyLayers(bindings, panelFrames, warnings);
 
   return { bindings, panelFrames };
 }

--- a/packages/core/src/pipeline/public-api.ts
+++ b/packages/core/src/pipeline/public-api.ts
@@ -1,0 +1,19 @@
+/**
+ * Public pipeline contract re-exports (import path stability for consumers
+ * of @ggsvelte/core via ./pipeline.ts).
+ */
+export type {
+  Advisory,
+  AxisValueFormatter,
+  LayerBackend,
+  MappedField,
+  NamedData,
+  PipelineWarning,
+  RenderModel,
+  ResolvedColorScale,
+  RunOptions,
+  ScaleDomainSnapshot,
+  TrainedScales,
+} from "./types.js";
+export { CANVAS_AUTO_THRESHOLD, PipelineError } from "./types.js";
+export { batchMarkCount } from "./geometry.js";

--- a/packages/core/src/pipeline/run-id.ts
+++ b/packages/core/src/pipeline/run-id.ts
@@ -1,0 +1,8 @@
+/**
+ * Monotonic pipeline run identity (module-global).
+ */
+let nextRunId = 0;
+
+export function allocatePipelineRunId(): number {
+  return ++nextRunId;
+}

--- a/packages/core/src/pipeline/setup-run-edition.ts
+++ b/packages/core/src/pipeline/setup-run-edition.ts
@@ -1,0 +1,26 @@
+/**
+ * Resolve defaults edition for a pipeline run (with unknown-edition warning).
+ */
+import type { PortableSpec } from "@ggsvelte/spec";
+
+import type { EditionDefaults } from "../editions.js";
+import { resolveEditionDefaults } from "../editions.js";
+
+import type { PipelineWarning, RunOptions } from "./types.js";
+
+export function resolvePipelineEditionDefaults(
+  edition: PortableSpec["edition"],
+  editions: RunOptions["editions"],
+  warnings: PipelineWarning[],
+): EditionDefaults {
+  const editionResolution = resolveEditionDefaults(edition, editions);
+  if (editionResolution.unknownRequested !== null) {
+    warnings.push({
+      code: "unknown-edition",
+      message:
+        `The spec targets defaults edition ${editionResolution.unknownRequested}, which this ` +
+        `version of ggsvelte does not know; falling back to edition ${editionResolution.edition} defaults.`,
+    });
+  }
+  return editionResolution.defaults;
+}

--- a/packages/core/src/pipeline/setup-run-normalize.ts
+++ b/packages/core/src/pipeline/setup-run-normalize.ts
@@ -1,0 +1,12 @@
+/**
+ * Normalize + validate a pipeline spec entry.
+ */
+import type { PortableSpec, SpecInput } from "@ggsvelte/spec";
+import { normalize, SpecValidationError, validate } from "@ggsvelte/spec";
+
+export function normalizeAndValidateSpec(spec: SpecInput | PortableSpec): PortableSpec {
+  const normalized = normalize(spec);
+  const result = validate(normalized);
+  if (!result.ok) throw new SpecValidationError(result.errors);
+  return normalized;
+}

--- a/packages/core/src/pipeline/setup-run-theme.ts
+++ b/packages/core/src/pipeline/setup-run-theme.ts
@@ -1,0 +1,24 @@
+/**
+ * Resolve theme tokens for a pipeline run (structured unknown-theme errors).
+ */
+import type { PortableSpec } from "@ggsvelte/spec";
+
+import type { EditionDefaults } from "../editions.js";
+import type { ThemeTokens } from "../theme.js";
+import { resolveTheme, UnknownThemeError } from "../theme.js";
+
+import { PipelineError } from "./types.js";
+
+export function resolvePipelineTheme(
+  themeSpec: PortableSpec["theme"],
+  editionDefaults: EditionDefaults,
+): ThemeTokens {
+  try {
+    return resolveTheme(themeSpec, editionDefaults.themes);
+  } catch (error) {
+    if (error instanceof UnknownThemeError) {
+      throw new PipelineError("unknown-theme", "/theme", error.message);
+    }
+    throw error;
+  }
+}

--- a/packages/core/src/pipeline/setup-run.ts
+++ b/packages/core/src/pipeline/setup-run.ts
@@ -2,15 +2,14 @@
  * Pipeline run setup: normalize + validate, edition defaults, theme, coord flip.
  */
 import type { PortableSpec, SpecInput } from "@ggsvelte/spec";
-import { normalize, SpecValidationError, validate } from "@ggsvelte/spec";
 
 import type { EditionDefaults } from "../editions.js";
-import { resolveEditionDefaults } from "../editions.js";
 import type { ThemeTokens } from "../theme.js";
-import { resolveTheme, UnknownThemeError } from "../theme.js";
 
+import { resolvePipelineEditionDefaults } from "./setup-run-edition.js";
+import { normalizeAndValidateSpec } from "./setup-run-normalize.js";
+import { resolvePipelineTheme } from "./setup-run-theme.js";
 import type { PipelineWarning, RunOptions } from "./types.js";
-import { PipelineError } from "./types.js";
 
 export interface PipelineRunSetup {
   normalized: PortableSpec;
@@ -24,34 +23,9 @@ export function setupPipelineRun(
   editions: RunOptions["editions"],
   warnings: PipelineWarning[],
 ): PipelineRunSetup {
-  // normalize + validate (normalize is idempotent; validation is cheap and
-  // makes every entry point honor the agent error contract)
-  const normalized = normalize(spec);
-  const result = validate(normalized);
-  if (!result.ok) throw new SpecValidationError(result.errors);
-
-  // Defaults edition (Hadley lesson 13): the spec's stamped edition selects
-  // the default theme table + palettes; explicit settings still win.
-  const editionResolution = resolveEditionDefaults(normalized.edition, editions);
-  if (editionResolution.unknownRequested !== null) {
-    warnings.push({
-      code: "unknown-edition",
-      message:
-        `The spec targets defaults edition ${editionResolution.unknownRequested}, which this ` +
-        `version of ggsvelte does not know; falling back to edition ${editionResolution.edition} defaults.`,
-    });
-  }
-  const editionDefaults = editionResolution.defaults;
-
-  let theme: ThemeTokens;
-  try {
-    theme = resolveTheme(normalized.theme, editionDefaults.themes);
-  } catch (error) {
-    if (error instanceof UnknownThemeError) {
-      throw new PipelineError("unknown-theme", "/theme", error.message);
-    }
-    throw error;
-  }
+  const normalized = normalizeAndValidateSpec(spec);
+  const editionDefaults = resolvePipelineEditionDefaults(normalized.edition, editions, warnings);
+  const theme = resolvePipelineTheme(normalized.theme, editionDefaults);
 
   return {
     normalized,

--- a/packages/core/tests/pipeline-build-candidates.test.ts
+++ b/packages/core/tests/pipeline-build-candidates.test.ts
@@ -256,3 +256,28 @@ describe("createLazyIdentityIndex", () => {
     expect(calls).toBe(0);
   });
 });
+
+describe("allocatePipelineRunId", () => {
+  it("returns increasing positive integers", async () => {
+    const { allocatePipelineRunId } = await import("../src/pipeline/run-id.ts");
+    const a = allocatePipelineRunId();
+    const b = allocatePipelineRunId();
+    expect(a).toBeGreaterThan(0);
+    expect(b).toBe(a + 1);
+  });
+});
+
+describe("resolveOutlierContext", () => {
+  it("returns nulls for non-boxplot point batches", async () => {
+    const { resolveOutlierContext } =
+      await import("../src/pipeline/build-candidates-datum-outlier.ts");
+    expect(
+      resolveOutlierContext({
+        frame: undefined,
+        batch: { kind: "points" } as never,
+        primitiveIndex: 0,
+        facetPanel: undefined,
+      }),
+    ).toEqual({ outlierLocalRow: null, outlierSourceRow: null });
+  });
+});


### PR DESCRIPTION
## Summary
- Extract public API re-exports and run-id allocation from the pipeline entrypoint.
- Extract facet grid input/map/place helpers; scene and finalize input types; boxplot rects vs segments.
- Extract candidate locate types and outlier/annotation/ordinal-rank modules; setup normalize/edition/theme.
- Extract prepare-panels bin ranges and empty-layer warnings; smooth frame packing; panel layout result packing.
- Add characterization tests for run ids and outlier context.

## Test plan
- [x] `bun test packages/core` (522 pass)
- [x] `bun run check`
- [x] `bun run knip`
- [x] `bun run lint:type-aware`
- [x] Codex pre-PR review (`gpt-5.6-terra`) — PASS (no P1)