### PR TITLE
refactor(svelte): own brush-zoom M2 gate in resolveBrushZoomFromModel

### DIFF
--- a/packages/svelte/src/lib/GGPlot.svelte
+++ b/packages/svelte/src/lib/GGPlot.svelte
@@ -223,7 +223,7 @@
     continuousZoomDomainsFromScopes,
     filterScopeChannelsByZoomMode,
     filterZoomDomainsByMode,
-    resolveBrushZoomDomains,
+    resolveBrushZoomFromModel,
     sanitizePartialZoomDomains,
     stableZoomDomains,
   } from "./plot-zoom.js";
@@ -2062,7 +2062,8 @@
   /**
    * Brush-to-zoom = an intentional respec: invert the brushed plot-px rect
    * through the trained scales into explicit continuous domains. Band axes
-   * and faceted plots are skipped (documented M2 limitation).
+   * and faceted plots are skipped (documented M2 limitation) inside
+   * `resolveBrushZoomFromModel`.
    */
   function applyBrushZoom(
     rect: {
@@ -2073,18 +2074,16 @@
     },
     source: InteractionSource,
   ): void {
-    if (model === null || model.scene.panels.length !== 1) return;
-    const panel = model.scene.panels[0]!;
-    const next = resolveBrushZoomDomains(
+    // Pure owns null/multi-panel gate, invert, and freeze for commit.
+    const next = resolveBrushZoomFromModel({
+      model,
       rect,
-      panel,
-      model.scales,
-      coordFlipped,
-      interactionConfig.zoom?.mode ?? "xy",
-      effectiveZoomDomains,
-    );
+      flipped: coordFlipped,
+      mode: interactionConfig.zoom?.mode ?? "xy",
+      current: effectiveZoomDomains,
+    });
     if (next === null) return;
-    commitZoom(frozenZoomDomains(next), source);
+    commitZoom(next, source);
   }
 
   // Stable SceneView callback identity when model is unchanged.

--- a/packages/svelte/src/lib/plot-zoom.ts
+++ b/packages/svelte/src/lib/plot-zoom.ts
@@ -239,3 +239,42 @@ export function resolveBrushZoomDomains(
   if (next.x === undefined && next.y === undefined) return null;
   return next;
 }
+
+/**
+ * Minimal model surface for brush-to-zoom commit (M2 single-panel only).
+ * Accepts full `RenderModel` structurally.
+ */
+export type BrushZoomModel = {
+  readonly scene: { readonly panels: readonly PanelBounds[] };
+  readonly scales: Pick<RenderModel["scales"], "x" | "y">;
+};
+
+/**
+ * Commit-ready domains for brush-to-zoom from a live model.
+ *
+ * Owns the M2 single-panel gate (`panels.length === 1`), domain invert via
+ * `resolveBrushZoomDomains`, and deep freeze for host `commitZoom`.
+ * Returns null when model is missing, multi-panel/faceted, or domains cannot
+ * be inverted. Mode is caller-supplied (`interactionConfig.zoom?.mode ?? "xy"`).
+ */
+export function resolveBrushZoomFromModel(input: {
+  readonly model: BrushZoomModel | null;
+  readonly rect: PlotRect;
+  readonly flipped: boolean;
+  readonly mode: ZoomMode;
+  readonly current: ContinuousZoomDomains | null;
+}): ContinuousZoomDomains | null {
+  if (input.model === null) return null;
+  if (input.model.scene.panels.length !== 1) return null;
+  const panel = input.model.scene.panels[0]!;
+  const next = resolveBrushZoomDomains(
+    input.rect,
+    panel,
+    input.model.scales,
+    input.flipped,
+    input.mode,
+    input.current,
+  );
+  if (next === null) return null;
+  return frozenZoomDomains(next);
+}

--- a/packages/svelte/tests/plot-zoom.test.ts
+++ b/packages/svelte/tests/plot-zoom.test.ts
@@ -9,6 +9,7 @@ import {
   filterScopeChannelsByZoomMode,
   filterZoomDomainsByMode,
   resolveBrushZoomDomains,
+  resolveBrushZoomFromModel,
   sameZoomDomains,
   sanitizePartialZoomDomains,
   stableZoomDomains,
@@ -255,6 +256,90 @@ describe("resolveBrushZoomDomains", () => {
     );
     expect(domains?.x).toEqual([0, 100]);
     expect(domains?.y).toEqual([0, 50]);
+  });
+});
+
+describe("resolveBrushZoomFromModel", () => {
+  const scales = {
+    x: continuousScale([0, 100]),
+    y: continuousScale([0, 50]),
+  };
+  const single = {
+    scene: { panels: [panel] },
+    scales: scales as never,
+  };
+  const rect = { x0: 10, y0: 10, x1: 90, y1: 90 };
+
+  it("returns null when model is null", () => {
+    expect(
+      resolveBrushZoomFromModel({
+        model: null,
+        rect,
+        flipped: false,
+        mode: "xy",
+        current: null,
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null for multi-panel (M2 faceted skip)", () => {
+    expect(
+      resolveBrushZoomFromModel({
+        model: {
+          scene: { panels: [panel, { x: 100, y: 0, width: 100, height: 100 }] },
+          scales: scales as never,
+        },
+        rect,
+        flipped: false,
+        mode: "xy",
+        current: null,
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when there are zero panels", () => {
+    expect(
+      resolveBrushZoomFromModel({
+        model: { scene: { panels: [] }, scales: scales as never },
+        rect,
+        flipped: false,
+        mode: "xy",
+        current: null,
+      }),
+    ).toBeNull();
+  });
+
+  it("returns frozen commit-ready domains for a single panel", () => {
+    const domains = resolveBrushZoomFromModel({
+      model: single,
+      rect,
+      flipped: false,
+      mode: "xy",
+      current: null,
+    });
+    expect(domains).not.toBeNull();
+    expect(domains!.x).toBeDefined();
+    expect(domains!.y).toBeDefined();
+    expect(Object.isFrozen(domains)).toBe(true);
+    expect(Object.isFrozen(domains!.x)).toBe(true);
+    expect(Object.isFrozen(domains!.y)).toBe(true);
+    // Deep clone: frozen tuples are not the same references as a mutable source.
+    const mutable: [number, number] = [domains!.x![0], domains!.x![1]];
+    expect(domains!.x).not.toBe(mutable);
+    mutable[0] = 999;
+    expect(domains!.x![0]).not.toBe(999);
+  });
+
+  it("returns null when domain invert degenerates", () => {
+    expect(
+      resolveBrushZoomFromModel({
+        model: single,
+        rect: { x0: 10, y0: 10, x1: 10, y1: 10 },
+        flipped: false,
+        mode: "xy",
+        current: null,
+      }),
+    ).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary

- Add `resolveBrushZoomFromModel` in `plot-zoom` that owns null-model and single-panel (M2) gating, domain invert via `resolveBrushZoomDomains`, and deep freeze of commit-ready domains.
- GGPlot `applyBrushZoom` only commits when pure returns domains (mode still host-supplied from config).
- Characterization tests: null model, multi-panel, zero panels, freeze, degenerate invert.

## Test plan

- [x] `vitest run tests/plot-zoom.test.ts`
- [x] svelte-check + pre-push hooks
- [ ] CI on PR