### PR TITLE
refactor(core): extract runPipeline body, layout packs, segments, bind

### DIFF
--- a/packages/core/src/pipeline.ts
+++ b/packages/core/src/pipeline.ts
@@ -36,17 +36,6 @@
  * values with a warning and REFUSE non-positive explicit domains.
  */
 
-import type { SpecInput, PortableSpec } from "@ggsvelte/spec";
-
-import { perfMark, perfMeasure } from "./perf.js";
-
-import type { Advisory, PipelineWarning, RenderModel, RunOptions } from "./pipeline/types.js";
-import { allocatePipelineRunId } from "./pipeline/run-id.js";
-import { setupPipelineRun } from "./pipeline/setup-run.js";
-import { preparePanels } from "./pipeline/prepare-panels.js";
-import { trainPipelineScales } from "./pipeline/train-pipeline-scales.js";
-import { finalizePipelineRun } from "./pipeline/finalize-run.js";
-
 // Re-export the public pipeline contract (import path stability).
 export type {
   Advisory,
@@ -63,60 +52,4 @@ export type {
 } from "./pipeline/public-api.js";
 export { CANVAS_AUTO_THRESHOLD, PipelineError, batchMarkCount } from "./pipeline/public-api.js";
 
-// ---------------------------------------------------------------------------
-// runPipeline
-// ---------------------------------------------------------------------------
-
-export function runPipeline(spec: SpecInput | PortableSpec, options: RunOptions): RenderModel {
-  const runId = allocatePipelineRunId();
-  perfMark("ggsvelte:pipeline:start");
-
-  const warnings: PipelineWarning[] = [];
-  const advisories: Advisory[] = [];
-
-  const { normalized, editionDefaults, theme, flip } = setupPipelineRun(
-    spec,
-    options.editions,
-    warnings,
-  );
-
-  // bind + facet partition + per-panel frames
-  perfMark("ggsvelte:bind:start");
-  const prepared = preparePanels(normalized, options, warnings, advisories);
-  perfMark("ggsvelte:bind:end");
-  perfMeasure("ggsvelte:bind", "ggsvelte:bind:start", "ggsvelte:bind:end");
-
-  // train scales — fixed: union across panels; free: positional domains per
-  // panel; discrete color/fill assignment ALWAYS global (one legend).
-  perfMark("ggsvelte:scales:start");
-  const trained = trainPipelineScales({
-    normalized,
-    options,
-    table: prepared.table,
-    facetPanels: prepared.facetPanels,
-    panelFrames: prepared.panelFrames,
-    freeX: prepared.freeX,
-    freeY: prepared.freeY,
-    editionDefaults,
-    warnings,
-    advisories,
-  });
-  perfMark("ggsvelte:scales:end");
-  perfMeasure("ggsvelte:scales", "ggsvelte:scales:start", "ggsvelte:scales:end");
-
-  const model = finalizePipelineRun({
-    runId,
-    normalized,
-    options,
-    theme,
-    flip,
-    prepared,
-    trained,
-    warnings,
-    advisories,
-  });
-
-  perfMark("ggsvelte:pipeline:end");
-  perfMeasure("ggsvelte:pipeline", "ggsvelte:pipeline:start", "ggsvelte:pipeline:end");
-  return model;
-}
+export { runPipeline } from "./pipeline/run-pipeline.js";

--- a/packages/core/src/pipeline/bind-layer-position.ts
+++ b/packages/core/src/pipeline/bind-layer-position.ts
@@ -1,0 +1,56 @@
+/**
+ * Resolve positional channels (x/y/ymin/ymax) and validate geom/stat contracts.
+ */
+import type { Aes, LayerSpec } from "@ggsvelte/spec";
+
+import type { ColumnTable } from "../table.js";
+
+import { checkField } from "./bind-layer-helpers.js";
+import {
+  assertRequiredChannels,
+  resolveRuleForm,
+  validateGeomStatContracts,
+} from "./bind-layer-validate.js";
+import { resolveYChannel } from "./bind-layer-y.js";
+import type { LayerBinding, PipelineWarning } from "./types.js";
+
+export function resolveLayerPositionChannels(input: {
+  layer: LayerSpec;
+  aes: Aes;
+  index: number;
+  table: ColumnTable;
+  warnings: PipelineWarning[];
+}): {
+  ruleForm: LayerBinding["ruleForm"];
+  xField: string | null;
+  yField: string | null;
+  yStatColumn: string | null;
+  yminField: string | null;
+  ymaxField: string | null;
+} {
+  const { layer, aes, index, table, warnings } = input;
+  const geom = layer.geom;
+  const ruleForm = resolveRuleForm(layer, index);
+  const stat = layer.stat ?? "identity";
+  const xField = checkField(aes.x, "x", index, table, warnings);
+  const { yField, yStatColumn } = resolveYChannel({ aes, stat, index, table, warnings });
+
+  validateGeomStatContracts({ layer, index, table, xField, yField });
+
+  const yminField = checkField(aes.ymin, "ymin", index, table, warnings);
+  const ymaxField = checkField(aes.ymax, "ymax", index, table, warnings);
+
+  assertRequiredChannels({
+    geom,
+    stat,
+    index,
+    ruleForm,
+    xField,
+    yField,
+    yStatColumn,
+    yminField,
+    ymaxField,
+  });
+
+  return { ruleForm, xField, yField, yStatColumn, yminField, ymaxField };
+}

--- a/packages/core/src/pipeline/bind-layer.ts
+++ b/packages/core/src/pipeline/bind-layer.ts
@@ -5,15 +5,9 @@ import type { Aes, LayerSpec } from "@ggsvelte/spec";
 
 import type { ColumnTable } from "../table.js";
 
-import { checkField } from "./bind-layer-helpers.js";
 import { resolveLabelWeightColorFill } from "./bind-layer-extras.js";
+import { resolveLayerPositionChannels } from "./bind-layer-position.js";
 import { makeLayerBinding } from "./bind-layer-result.js";
-import {
-  assertRequiredChannels,
-  resolveRuleForm,
-  validateGeomStatContracts,
-} from "./bind-layer-validate.js";
-import { resolveYChannel } from "./bind-layer-y.js";
 import type { LayerBinding, PipelineWarning } from "./types.js";
 
 export function bindLayer(
@@ -23,47 +17,29 @@ export function bindLayer(
   warnings: PipelineWarning[],
 ): LayerBinding {
   const aes: Aes = layer.aes ?? {};
-  const geom = layer.geom;
-
-  const ruleForm = resolveRuleForm(layer, index);
-
-  const stat = layer.stat ?? "identity";
-  const xField = checkField(aes.x, "x", index, table, warnings);
-  const { yField, yStatColumn } = resolveYChannel({ aes, stat, index, table, warnings });
-
-  validateGeomStatContracts({ layer, index, table, xField, yField });
-
-  // --- ymin/ymax (errorbar identity form) --------------------------------------
-  const yminField = checkField(aes.ymin, "ymin", index, table, warnings);
-  const ymaxField = checkField(aes.ymax, "ymax", index, table, warnings);
-
-  assertRequiredChannels({
-    geom,
-    stat,
+  const position = resolveLayerPositionChannels({ layer, aes, index, table, warnings });
+  const extras = resolveLabelWeightColorFill({
+    aes,
+    geom: layer.geom,
+    stat: layer.stat ?? "identity",
     index,
-    ruleForm,
-    xField,
-    yField,
-    yStatColumn,
-    yminField,
-    ymaxField,
+    table,
+    warnings,
   });
-
-  const extras = resolveLabelWeightColorFill({ aes, geom, stat, index, table, warnings });
 
   return makeLayerBinding({
     layer,
     index,
-    xField,
-    yField,
-    yStatColumn,
-    yminField,
-    ymaxField,
+    xField: position.xField,
+    yField: position.yField,
+    yStatColumn: position.yStatColumn,
+    yminField: position.yminField,
+    ymaxField: position.ymaxField,
     color: extras.color,
     fill: extras.fill,
     labelField: extras.labelField,
     labelConstant: extras.labelConstant,
     weightField: extras.weightField,
-    ruleForm,
+    ruleForm: position.ruleForm,
   });
 }

--- a/packages/core/src/pipeline/geometry-dispatch.ts
+++ b/packages/core/src/pipeline/geometry-dispatch.ts
@@ -1,0 +1,53 @@
+/**
+ * Per-geom geometry batch dispatch for a single layer frame.
+ */
+import type { GeometryBatch } from "../scene.js";
+
+import type { LayerFrame, PipelineWarning, ResolvedColorScale } from "./types.js";
+import type { Frame } from "./geometry-shared.js";
+import {
+  areaBatch,
+  glyphsBatch,
+  lineBatch,
+  pointsBatch,
+  rectsBatch,
+  segmentsBatch,
+} from "./geometry-marks.js";
+import { boxplotBatches, errorbarBatch, smoothBatches } from "./geometry-composites.js";
+
+function single(batch: GeometryBatch | null): GeometryBatch[] {
+  return batch === null ? [] : [batch];
+}
+
+export function dispatchGeometryBatch(
+  frame: LayerFrame,
+  fx: Frame,
+  color: ResolvedColorScale | null,
+  fill: ResolvedColorScale | null,
+  warnings: PipelineWarning[],
+): GeometryBatch[] {
+  switch (frame.binding.layer.geom) {
+    case "point":
+      return single(pointsBatch(frame, fx, color, warnings));
+    case "line":
+      return single(lineBatch(frame, fx, color, warnings));
+    case "col":
+    case "bar":
+      return single(rectsBatch(frame, fx, fill, warnings));
+    case "area":
+    case "density":
+      return single(areaBatch(frame, fx, fill, warnings));
+    case "rule":
+      return single(segmentsBatch(frame, fx, color, warnings));
+    case "text":
+      return single(glyphsBatch(frame, fx, color, warnings));
+    case "smooth":
+      return smoothBatches(frame, fx, color, fill, warnings);
+    case "boxplot":
+      return boxplotBatches(frame, fx, fill, warnings);
+    case "errorbar":
+      return single(errorbarBatch(frame, fx, color, warnings));
+    default:
+      return [];
+  }
+}

--- a/packages/core/src/pipeline/geometry-glyphs-pack.ts
+++ b/packages/core/src/pipeline/geometry-glyphs-pack.ts
@@ -1,0 +1,39 @@
+/**
+ * Pack glyph buffers into a GlyphsBatch.
+ */
+import type { GlyphsBatch } from "../scene.js";
+
+import type { LayerFrame } from "./types.js";
+import { DEFAULT_TEXT_SIZE } from "./geometry-shared.js";
+
+export function packGlyphsBatch(input: {
+  frame: LayerFrame;
+  positions: number[];
+  rowIndex: number[];
+  texts: string[];
+  colors: string[];
+  wantsColors: boolean;
+  params: {
+    anchor?: "start" | "middle" | "end";
+    size?: number;
+    alpha?: number;
+  };
+}): GlyphsBatch | null {
+  const { frame, positions, rowIndex, texts, colors, wantsColors, params } = input;
+  if (texts.length === 0) return null;
+  const { binding } = frame;
+  const batch: GlyphsBatch = {
+    kind: "glyphs",
+    layerIndex: binding.index,
+    panelIndex: 0,
+    positions: Float32Array.from(positions),
+    rowIndex: Uint32Array.from(rowIndex),
+    texts,
+    color: binding.color.constant,
+    size: params.size ?? DEFAULT_TEXT_SIZE,
+    anchor: params.anchor ?? "middle",
+    alpha: params.alpha ?? 1,
+  };
+  if (wantsColors) batch.colors = colors;
+  return batch;
+}

--- a/packages/core/src/pipeline/geometry-glyphs.ts
+++ b/packages/core/src/pipeline/geometry-glyphs.ts
@@ -5,7 +5,8 @@ import type { GlyphsBatch } from "../scene.js";
 
 import type { LayerFrame, PipelineWarning, ResolvedColorScale } from "./types.js";
 import type { Frame } from "./geometry-shared.js";
-import { DEFAULT_TEXT_SIZE, removedWarning } from "./geometry-shared.js";
+import { removedWarning } from "./geometry-shared.js";
+import { packGlyphsBatch } from "./geometry-glyphs-pack.js";
 import { emitGlyphRows } from "./geometry-glyphs-rows.js";
 
 export function glyphsBatch(
@@ -41,20 +42,5 @@ export function glyphsBatch(
     colors,
   });
   removedWarning(removed, binding.index, warnings);
-  if (texts.length === 0) return null;
-
-  const batch: GlyphsBatch = {
-    kind: "glyphs",
-    layerIndex: binding.index,
-    panelIndex: 0,
-    positions: Float32Array.from(positions),
-    rowIndex: Uint32Array.from(rowIndex),
-    texts,
-    color: binding.color.constant,
-    size: params.size ?? DEFAULT_TEXT_SIZE,
-    anchor: params.anchor ?? "middle",
-    alpha: params.alpha ?? 1,
-  };
-  if (wantsColors) batch.colors = colors;
-  return batch;
+  return packGlyphsBatch({ frame, positions, rowIndex, texts, colors, wantsColors, params });
 }

--- a/packages/core/src/pipeline/geometry-segments-pack.ts
+++ b/packages/core/src/pipeline/geometry-segments-pack.ts
@@ -1,0 +1,32 @@
+/**
+ * Pack mutable segment buffers into a SegmentsBatch.
+ */
+import type { SegmentsBatch } from "../scene.js";
+
+import type { LayerFrame } from "./types.js";
+import { DEFAULT_RULE_LINEWIDTH } from "./geometry-shared.js";
+
+export function packSegmentsBatch(input: {
+  frame: LayerFrame;
+  segments: number[];
+  rowIndex: number[];
+  perSegmentColors: string[];
+  wantsColors: boolean;
+}): SegmentsBatch | null {
+  const { frame, segments, rowIndex, perSegmentColors, wantsColors } = input;
+  if (rowIndex.length === 0) return null;
+  const { binding } = frame;
+  const params = (binding.layer.params ?? {}) as { linewidth?: number; alpha?: number };
+  const batch: SegmentsBatch = {
+    kind: "segments",
+    layerIndex: binding.index,
+    panelIndex: 0,
+    segments: Float32Array.from(segments),
+    rowIndex: Uint32Array.from(rowIndex),
+    stroke: binding.color.constant,
+    linewidth: params.linewidth ?? DEFAULT_RULE_LINEWIDTH,
+    alpha: params.alpha ?? 1,
+  };
+  if (wantsColors && binding.ruleForm !== "annotation") batch.strokes = perSegmentColors;
+  return batch;
+}

--- a/packages/core/src/pipeline/geometry-segments.ts
+++ b/packages/core/src/pipeline/geometry-segments.ts
@@ -5,10 +5,11 @@ import type { SegmentsBatch } from "../scene.js";
 
 import type { LayerFrame, PipelineWarning, ResolvedColorScale } from "./types.js";
 import type { Frame } from "./geometry-shared.js";
-import { DEFAULT_RULE_LINEWIDTH, removedWarning } from "./geometry-shared.js";
+import { removedWarning } from "./geometry-shared.js";
 import { emitAnnotationSegments } from "./geometry-segments-annotation.js";
 import { emitDataSegments } from "./geometry-segments-data.js";
 import { createSegmentEmitters } from "./geometry-segments-emit.js";
+import { packSegmentsBatch } from "./geometry-segments-pack.js";
 
 export function segmentsBatch(
   frame: LayerFrame,
@@ -17,7 +18,6 @@ export function segmentsBatch(
   warnings: PipelineWarning[],
 ): SegmentsBatch | null {
   const { binding } = frame;
-  const params = (binding.layer.params ?? {}) as { linewidth?: number; alpha?: number };
   const segments: number[] = [];
   const rowIndex: number[] = [];
   const perSegmentColors: string[] = [];
@@ -49,18 +49,5 @@ export function segmentsBatch(
     });
   }
   removedWarning(removed, binding.index, warnings);
-  if (rowIndex.length === 0) return null;
-
-  const batch: SegmentsBatch = {
-    kind: "segments",
-    layerIndex: binding.index,
-    panelIndex: 0,
-    segments: Float32Array.from(segments),
-    rowIndex: Uint32Array.from(rowIndex),
-    stroke: binding.color.constant,
-    linewidth: params.linewidth ?? DEFAULT_RULE_LINEWIDTH,
-    alpha: params.alpha ?? 1,
-  };
-  if (wantsColors && binding.ruleForm !== "annotation") batch.strokes = perSegmentColors;
-  return batch;
+  return packSegmentsBatch({ frame, segments, rowIndex, perSegmentColors, wantsColors });
 }

--- a/packages/core/src/pipeline/geometry.ts
+++ b/packages/core/src/pipeline/geometry.ts
@@ -7,23 +7,11 @@ import type { GeometryBatch } from "../scene.js";
 
 import type { LayerFrame, PipelineWarning, ResolvedColorScale } from "./types.js";
 import type { Frame } from "./geometry-shared.js";
-import {
-  areaBatch,
-  glyphsBatch,
-  lineBatch,
-  pointsBatch,
-  rectsBatch,
-  segmentsBatch,
-} from "./geometry-marks.js";
-import { boxplotBatches, errorbarBatch, smoothBatches } from "./geometry-composites.js";
+import { dispatchGeometryBatch } from "./geometry-dispatch.js";
 
 export type { Frame } from "./geometry-shared.js";
 export { flipBatchInPlace } from "./geometry-flip.js";
 export { batchMarkCount } from "./geometry-mark-count.js";
-
-function single(batch: GeometryBatch | null): GeometryBatch[] {
-  return batch === null ? [] : [batch];
-}
 
 export function buildBatch(
   frame: LayerFrame,
@@ -32,28 +20,5 @@ export function buildBatch(
   fill: ResolvedColorScale | null,
   warnings: PipelineWarning[],
 ): GeometryBatch[] {
-  switch (frame.binding.layer.geom) {
-    case "point":
-      return single(pointsBatch(frame, fx, color, warnings));
-    case "line":
-      return single(lineBatch(frame, fx, color, warnings));
-    case "col":
-    case "bar":
-      return single(rectsBatch(frame, fx, fill, warnings));
-    case "area":
-    case "density":
-      return single(areaBatch(frame, fx, fill, warnings));
-    case "rule":
-      return single(segmentsBatch(frame, fx, color, warnings));
-    case "text":
-      return single(glyphsBatch(frame, fx, color, warnings));
-    case "smooth":
-      return smoothBatches(frame, fx, color, fill, warnings);
-    case "boxplot":
-      return boxplotBatches(frame, fx, fill, warnings);
-    case "errorbar":
-      return single(errorbarBatch(frame, fx, color, warnings));
-    default:
-      return [];
-  }
+  return dispatchGeometryBatch(frame, fx, color, fill, warnings);
 }

--- a/packages/core/src/pipeline/panel-layout-chrome-display-input.ts
+++ b/packages/core/src/pipeline/panel-layout-chrome-display-input.ts
@@ -1,0 +1,21 @@
+/**
+ * Input for coord-flip-aware panel layout display resolution.
+ */
+import type { PortableSpec } from "@ggsvelte/spec";
+
+import type { PositionScale } from "../scales/train.js";
+
+import type { PipelineWarning } from "./types.js";
+
+export interface PanelLayoutDisplayInput {
+  flip: boolean;
+  freeX: boolean;
+  freeY: boolean;
+  panelScales: readonly { x: PositionScale; y: PositionScale }[];
+  scalesConfig: NonNullable<PortableSpec["scales"]>;
+  xScale: PositionScale;
+  yScale: PositionScale;
+  xTitle: string;
+  yTitle: string;
+  warnings: PipelineWarning[];
+}

--- a/packages/core/src/pipeline/panel-layout-chrome-display.ts
+++ b/packages/core/src/pipeline/panel-layout-chrome-display.ts
@@ -1,10 +1,6 @@
 /**
  * Coord-flip-aware display titles, formatters, free scales, and panel scale view.
  */
-import type { PortableSpec } from "@ggsvelte/spec";
-
-import type { PositionScale } from "../scales/train.js";
-
 import { makeAxisFormatter } from "./layout-helpers.js";
 import {
   flipDisplayBreaks,
@@ -13,23 +9,13 @@ import {
   flipDisplayTitles,
   makeDisplayScalesFn,
 } from "./panel-layout-chrome-display-flip.js";
+import type { PanelLayoutDisplayInput } from "./panel-layout-chrome-display-input.js";
 import type { PanelLayoutDisplay } from "./panel-layout-chrome-display-types.js";
-import type { PipelineWarning } from "./types.js";
 
 export type { PanelLayoutDisplay } from "./panel-layout-chrome-display-types.js";
+export type { PanelLayoutDisplayInput } from "./panel-layout-chrome-display-input.js";
 
-export function resolvePanelLayoutDisplay(input: {
-  flip: boolean;
-  freeX: boolean;
-  freeY: boolean;
-  panelScales: readonly { x: PositionScale; y: PositionScale }[];
-  scalesConfig: NonNullable<PortableSpec["scales"]>;
-  xScale: PositionScale;
-  yScale: PositionScale;
-  xTitle: string;
-  yTitle: string;
-  warnings: PipelineWarning[];
-}): PanelLayoutDisplay {
+export function resolvePanelLayoutDisplay(input: PanelLayoutDisplayInput): PanelLayoutDisplay {
   const {
     flip,
     freeX,

--- a/packages/core/src/pipeline/panel-layout-chrome-input.ts
+++ b/packages/core/src/pipeline/panel-layout-chrome-input.ts
@@ -1,0 +1,28 @@
+/**
+ * resolvePanelLayoutChrome input contract.
+ */
+import type { PortableSpec } from "@ggsvelte/spec";
+
+import type { LegendInput, LegendOrder } from "../legend.js";
+import type { PositionScale } from "../scales/train.js";
+import type { ThemeTokens } from "../theme.js";
+
+import type { LayerFrame, PipelineWarning, RunOptions } from "./types.js";
+
+export interface PanelLayoutChromeInput {
+  flip: boolean;
+  freeX: boolean;
+  freeY: boolean;
+  panelScales: readonly { x: PositionScale; y: PositionScale }[];
+  allFrames: readonly LayerFrame[];
+  labs: NonNullable<PortableSpec["labs"]>;
+  scalesConfig: NonNullable<PortableSpec["scales"]>;
+  xScale: PositionScale;
+  yScale: PositionScale;
+  colorLegend: LegendInput | null;
+  fillLegend: LegendInput | null;
+  legendOrder: LegendOrder;
+  theme: ThemeTokens;
+  options: Pick<RunOptions, "width" | "height" | "measureText">;
+  warnings: PipelineWarning[];
+}

--- a/packages/core/src/pipeline/panel-layout-chrome.ts
+++ b/packages/core/src/pipeline/panel-layout-chrome.ts
@@ -1,37 +1,16 @@
 /**
  * Panel layout chrome: labs, axis titles (with coord flip), formatters, legends.
  */
-import type { PortableSpec } from "@ggsvelte/spec";
-
-import type { LegendInput, LegendOrder } from "../legend.js";
-import type { PositionScale } from "../scales/train.js";
-import type { ThemeTokens } from "../theme.js";
-
 import { resolvePanelLayoutDisplay } from "./panel-layout-chrome-display.js";
+import type { PanelLayoutChromeInput } from "./panel-layout-chrome-input.js";
 import { resolvePanelLayoutLabs } from "./panel-layout-chrome-labs.js";
 import { resolvePanelLayoutLegends } from "./panel-layout-chrome-legends.js";
 import type { PanelLayoutChrome } from "./panel-layout-chrome-types.js";
-import type { LayerFrame, PipelineWarning, RunOptions } from "./types.js";
 
 export type { PanelLayoutChrome } from "./panel-layout-chrome-types.js";
+export type { PanelLayoutChromeInput } from "./panel-layout-chrome-input.js";
 
-export function resolvePanelLayoutChrome(input: {
-  flip: boolean;
-  freeX: boolean;
-  freeY: boolean;
-  panelScales: readonly { x: PositionScale; y: PositionScale }[];
-  allFrames: readonly LayerFrame[];
-  labs: NonNullable<PortableSpec["labs"]>;
-  scalesConfig: NonNullable<PortableSpec["scales"]>;
-  xScale: PositionScale;
-  yScale: PositionScale;
-  colorLegend: LegendInput | null;
-  fillLegend: LegendInput | null;
-  legendOrder: LegendOrder;
-  theme: ThemeTokens;
-  options: Pick<RunOptions, "width" | "height" | "measureText">;
-  warnings: PipelineWarning[];
-}): PanelLayoutChrome {
+export function resolvePanelLayoutChrome(input: PanelLayoutChromeInput): PanelLayoutChrome {
   const labsChrome = resolvePanelLayoutLabs({
     allFrames: input.allFrames,
     labs: input.labs,

--- a/packages/core/src/pipeline/panel-layout-facet-map-input.ts
+++ b/packages/core/src/pipeline/panel-layout-facet-map-input.ts
@@ -1,0 +1,27 @@
+/**
+ * Input for mapping facet panel defs into placements.
+ */
+import type { LayoutTheme, Margins, TickFormatter } from "../layout/layout.js";
+import type { TextMeasurer } from "../layout/measure.js";
+
+import type { FacetPanelDef } from "./facets.js";
+import type { DisplayScalesFn } from "./panel-layout-types.js";
+
+export interface MapFacetPanelPlacementsInput {
+  facetPanels: readonly FacetPanelDef[];
+  freeH: boolean;
+  freeV: boolean;
+  displayScales: DisplayScalesFn;
+  mMax: Margins;
+  panelW: number;
+  panelH: number;
+  colX: number[];
+  rowY: number[];
+  bottomMostRow: number[];
+  hBreaks: readonly (number | string)[] | undefined;
+  vBreaks: readonly (number | string)[] | undefined;
+  formatH: TickFormatter | undefined;
+  formatV: TickFormatter | undefined;
+  measurer: TextMeasurer;
+  layoutTheme: LayoutTheme;
+}

--- a/packages/core/src/pipeline/panel-layout-facet-map.ts
+++ b/packages/core/src/pipeline/panel-layout-facet-map.ts
@@ -1,31 +1,13 @@
 /**
  * Map facet panel defs through geometry into placements.
  */
-import type { LayoutTheme, Margins, TickFormatter } from "../layout/layout.js";
-import type { TextMeasurer } from "../layout/measure.js";
-
-import type { FacetPanelDef } from "./facets.js";
 import { placeOneFacetPanel } from "./panel-layout-facet-place-one.js";
-import type { DisplayScalesFn, PanelPlacement } from "./panel-layout-types.js";
+import type { MapFacetPanelPlacementsInput } from "./panel-layout-facet-map-input.js";
+import type { PanelPlacement } from "./panel-layout-types.js";
 
-export function mapFacetPanelPlacements(input: {
-  facetPanels: readonly FacetPanelDef[];
-  freeH: boolean;
-  freeV: boolean;
-  displayScales: DisplayScalesFn;
-  mMax: Margins;
-  panelW: number;
-  panelH: number;
-  colX: number[];
-  rowY: number[];
-  bottomMostRow: number[];
-  hBreaks: readonly (number | string)[] | undefined;
-  vBreaks: readonly (number | string)[] | undefined;
-  formatH: TickFormatter | undefined;
-  formatV: TickFormatter | undefined;
-  measurer: TextMeasurer;
-  layoutTheme: LayoutTheme;
-}): PanelPlacement[] {
+export type { MapFacetPanelPlacementsInput } from "./panel-layout-facet-map-input.js";
+
+export function mapFacetPanelPlacements(input: MapFacetPanelPlacementsInput): PanelPlacement[] {
   const {
     facetPanels,
     freeH,

--- a/packages/core/src/pipeline/panel-layout-facet-place-pack.ts
+++ b/packages/core/src/pipeline/panel-layout-facet-place-pack.ts
@@ -1,0 +1,31 @@
+/**
+ * Pack a PanelPlacement from tick-pass results and facet geometry.
+ */
+import type { PassResult } from "../layout/layout.js";
+
+import type { FacetPanelDef } from "./facets.js";
+import type { PanelPlacement } from "./panel-layout-types.js";
+
+export function packFacetPanelPlacement(input: {
+  def: FacetPanelDef;
+  colX: number;
+  rowY: number;
+  panelW: number;
+  panelH: number;
+  freeH: boolean;
+  freeV: boolean;
+  bottomMostRow: number;
+  ticksRun: PassResult;
+}): PanelPlacement {
+  const { def, colX, rowY, panelW, panelH, freeH, freeV, bottomMostRow, ticksRun } = input;
+  return {
+    x: colX,
+    y: rowY,
+    width: panelW,
+    height: panelH,
+    ticksH: ticksRun.x.ticks,
+    ticksV: ticksRun.y.ticks,
+    showAxisX: freeH || def.row === bottomMostRow,
+    showAxisY: freeV || def.col === 0,
+  };
+}

--- a/packages/core/src/pipeline/panel-layout-facet-place-ticks-input.ts
+++ b/packages/core/src/pipeline/panel-layout-facet-place-ticks-input.ts
@@ -1,0 +1,28 @@
+/**
+ * Input for facet panel tick layout + placement packing.
+ */
+import type { LayoutTheme, Margins, TickFormatter } from "../layout/layout.js";
+import type { TextMeasurer } from "../layout/measure.js";
+import type { PositionScale } from "../scales/train.js";
+
+import type { FacetPanelDef } from "./facets.js";
+
+export interface FacetPanelTicksInput {
+  def: FacetPanelDef;
+  h: PositionScale;
+  v: PositionScale;
+  mMax: Margins;
+  panelW: number;
+  panelH: number;
+  colX: number;
+  rowY: number;
+  freeH: boolean;
+  freeV: boolean;
+  bottomMostRow: number;
+  hBreaks: readonly (number | string)[] | undefined;
+  vBreaks: readonly (number | string)[] | undefined;
+  formatH: TickFormatter | undefined;
+  formatV: TickFormatter | undefined;
+  measurer: TextMeasurer;
+  layoutTheme: LayoutTheme;
+}

--- a/packages/core/src/pipeline/panel-layout-facet-place-ticks.ts
+++ b/packages/core/src/pipeline/panel-layout-facet-place-ticks.ts
@@ -1,34 +1,16 @@
 /**
  * Facet panel tick layout pass and placement packing.
  */
-import type { LayoutTheme, Margins, TickFormatter } from "../layout/layout.js";
 import { layoutPass } from "../layout/layout.js";
-import type { TextMeasurer } from "../layout/measure.js";
-import type { PositionScale } from "../scales/train.js";
 
-import type { FacetPanelDef } from "./facets.js";
 import { layoutDomain } from "./layout-helpers.js";
+import { packFacetPanelPlacement } from "./panel-layout-facet-place-pack.js";
+import type { FacetPanelTicksInput } from "./panel-layout-facet-place-ticks-input.js";
 import type { PanelPlacement } from "./panel-layout-types.js";
 
-export function placeFacetPanelFromTicks(input: {
-  def: FacetPanelDef;
-  h: PositionScale;
-  v: PositionScale;
-  mMax: Margins;
-  panelW: number;
-  panelH: number;
-  colX: number;
-  rowY: number;
-  freeH: boolean;
-  freeV: boolean;
-  bottomMostRow: number;
-  hBreaks: readonly (number | string)[] | undefined;
-  vBreaks: readonly (number | string)[] | undefined;
-  formatH: TickFormatter | undefined;
-  formatV: TickFormatter | undefined;
-  measurer: TextMeasurer;
-  layoutTheme: LayoutTheme;
-}): PanelPlacement {
+export type { FacetPanelTicksInput } from "./panel-layout-facet-place-ticks-input.js";
+
+export function placeFacetPanelFromTicks(input: FacetPanelTicksInput): PanelPlacement {
   const {
     def,
     h,
@@ -62,14 +44,15 @@ export function placeFacetPanelFromTicks(input: {
     },
     layoutTheme,
   );
-  return {
-    x: colX,
-    y: rowY,
-    width: panelW,
-    height: panelH,
-    ticksH: ticksRun.x.ticks,
-    ticksV: ticksRun.y.ticks,
-    showAxisX: freeH || def.row === bottomMostRow,
-    showAxisY: freeV || def.col === 0,
-  };
+  return packFacetPanelPlacement({
+    def,
+    colX,
+    rowY,
+    panelW,
+    panelH,
+    freeH,
+    freeV,
+    bottomMostRow,
+    ticksRun,
+  });
 }

--- a/packages/core/src/pipeline/panel-layout-placements-facet.ts
+++ b/packages/core/src/pipeline/panel-layout-placements-facet.ts
@@ -1,0 +1,39 @@
+/**
+ * Facet-grid panel placements from layout chrome.
+ */
+import type { PanelLayoutChrome } from "./panel-layout-chrome.js";
+import { placeFacetPanels } from "./panel-layout-facet.js";
+import type { PanelPlacement } from "./panel-layout-types.js";
+import type { FacetPanelDef } from "./facets.js";
+import type { RunOptions } from "./types.js";
+
+export function placeFacetPanelsFromChrome(input: {
+  nrow: number;
+  ncol: number;
+  facetPanels: readonly FacetPanelDef[];
+  chrome: PanelLayoutChrome;
+  options: Pick<RunOptions, "width">;
+}): PanelPlacement[] {
+  const { nrow, ncol, facetPanels, chrome, options } = input;
+  return placeFacetPanels({
+    facetPanels,
+    nrow,
+    ncol,
+    freeH: chrome.freeH,
+    freeV: chrome.freeV,
+    outerLeftTitle: chrome.vTitle,
+    outerBottomTitle: chrome.hTitle,
+    axisTitleBand: chrome.axisTitleBand,
+    legendWidth: chrome.legendBlock.width,
+    optionsWidth: options.width,
+    layoutHeight: chrome.layoutHeight,
+    topBand: chrome.topBand,
+    displayScales: chrome.displayScales,
+    hBreaks: chrome.hBreaks,
+    vBreaks: chrome.vBreaks,
+    formatH: chrome.formatH,
+    formatV: chrome.formatV,
+    measurer: chrome.measurer,
+    layoutTheme: chrome.layoutTheme,
+  });
+}

--- a/packages/core/src/pipeline/panel-layout-placements-single.ts
+++ b/packages/core/src/pipeline/panel-layout-placements-single.ts
@@ -1,0 +1,31 @@
+/**
+ * Single-panel placement from layout chrome.
+ */
+import type { PanelLayoutChrome } from "./panel-layout-chrome.js";
+import { placeSinglePanel } from "./panel-layout-single.js";
+import type { PanelPlacement } from "./panel-layout-types.js";
+import type { RunOptions } from "./types.js";
+
+export function placeSinglePanelFromChrome(
+  chrome: PanelLayoutChrome,
+  options: Pick<RunOptions, "width">,
+): PanelPlacement {
+  const { h, v } = chrome.displayScales(0);
+  return placeSinglePanel({
+    h,
+    v,
+    hTitle: chrome.hTitle,
+    vTitle: chrome.vTitle,
+    axisTitleBand: chrome.axisTitleBand,
+    legendWidth: chrome.legendBlock.width,
+    optionsWidth: options.width,
+    layoutHeight: chrome.layoutHeight,
+    topBand: chrome.topBand,
+    hBreaks: chrome.hBreaks,
+    vBreaks: chrome.vBreaks,
+    formatH: chrome.formatH,
+    formatV: chrome.formatV,
+    measurer: chrome.measurer,
+    layoutTheme: chrome.layoutTheme,
+  });
+}

--- a/packages/core/src/pipeline/panel-layout-placements.ts
+++ b/packages/core/src/pipeline/panel-layout-placements.ts
@@ -2,8 +2,8 @@
  * Build panel placements for facet grids or a single panel.
  */
 import type { PanelLayoutChrome } from "./panel-layout-chrome.js";
-import { placeFacetPanels } from "./panel-layout-facet.js";
-import { placeSinglePanel } from "./panel-layout-single.js";
+import { placeFacetPanelsFromChrome } from "./panel-layout-placements-facet.js";
+import { placeSinglePanelFromChrome } from "./panel-layout-placements-single.js";
 import type { PanelPlacement } from "./panel-layout-types.js";
 import type { FacetPanelDef } from "./facets.js";
 import type { RunOptions } from "./types.js";
@@ -17,49 +17,8 @@ export function buildPanelPlacements(input: {
   options: Pick<RunOptions, "width">;
 }): PanelPlacement[] {
   const { faceted, nrow, ncol, facetPanels, chrome, options } = input;
-
   if (faceted) {
-    return placeFacetPanels({
-      facetPanels,
-      nrow,
-      ncol,
-      freeH: chrome.freeH,
-      freeV: chrome.freeV,
-      outerLeftTitle: chrome.vTitle,
-      outerBottomTitle: chrome.hTitle,
-      axisTitleBand: chrome.axisTitleBand,
-      legendWidth: chrome.legendBlock.width,
-      optionsWidth: options.width,
-      layoutHeight: chrome.layoutHeight,
-      topBand: chrome.topBand,
-      displayScales: chrome.displayScales,
-      hBreaks: chrome.hBreaks,
-      vBreaks: chrome.vBreaks,
-      formatH: chrome.formatH,
-      formatV: chrome.formatV,
-      measurer: chrome.measurer,
-      layoutTheme: chrome.layoutTheme,
-    });
+    return placeFacetPanelsFromChrome({ nrow, ncol, facetPanels, chrome, options });
   }
-
-  const { h, v } = chrome.displayScales(0);
-  return [
-    placeSinglePanel({
-      h,
-      v,
-      hTitle: chrome.hTitle,
-      vTitle: chrome.vTitle,
-      axisTitleBand: chrome.axisTitleBand,
-      legendWidth: chrome.legendBlock.width,
-      optionsWidth: options.width,
-      layoutHeight: chrome.layoutHeight,
-      topBand: chrome.topBand,
-      hBreaks: chrome.hBreaks,
-      vBreaks: chrome.vBreaks,
-      formatH: chrome.formatH,
-      formatV: chrome.formatV,
-      measurer: chrome.measurer,
-      layoutTheme: chrome.layoutTheme,
-    }),
-  ];
+  return [placeSinglePanelFromChrome(chrome, options)];
 }

--- a/packages/core/src/pipeline/prepare-panels-empty.ts
+++ b/packages/core/src/pipeline/prepare-panels-empty.ts
@@ -1,0 +1,11 @@
+/**
+ * Empty-data warning for preparePanels.
+ */
+import type { PipelineWarning } from "./types.js";
+
+export function warnEmptyData(warnings: PipelineWarning[]): void {
+  warnings.push({
+    code: "empty-data",
+    message: "The data has no rows; rendering the frame and axes as a placeholder.",
+  });
+}

--- a/packages/core/src/pipeline/prepare-panels.ts
+++ b/packages/core/src/pipeline/prepare-panels.ts
@@ -6,6 +6,7 @@ import type { PortableSpec } from "@ggsvelte/spec";
 import { bindData } from "./bind.js";
 import type { FacetLayout } from "./facets.js";
 import { resolveFacet, SINGLE_PANEL } from "./facets.js";
+import { warnEmptyData } from "./prepare-panels-empty.js";
 import { buildPanelFrames } from "./prepare-panels-frames.js";
 import type { PreparedPanels } from "./prepare-panels-types.js";
 import type { Advisory, LayerBinding, LayerFrame, PipelineWarning, RunOptions } from "./types.js";
@@ -20,12 +21,7 @@ export function preparePanels(
 ): PreparedPanels {
   const table = bindData(normalized, options);
   const emptyData = table.rowCount === 0;
-  if (emptyData) {
-    warnings.push({
-      code: "empty-data",
-      message: "The data has no rows; rendering the frame and axes as a placeholder.",
-    });
-  }
+  if (emptyData) warnEmptyData(warnings);
 
   const facetLayout: FacetLayout = emptyData
     ? SINGLE_PANEL(table)

--- a/packages/core/src/pipeline/run-pipeline.ts
+++ b/packages/core/src/pipeline/run-pipeline.ts
@@ -1,0 +1,67 @@
+/**
+ * Core runPipeline orchestration: setup → prepare → train → finalize.
+ */
+import type { SpecInput, PortableSpec } from "@ggsvelte/spec";
+
+import { perfMark, perfMeasure } from "../perf.js";
+
+import type { Advisory, PipelineWarning, RenderModel, RunOptions } from "./types.js";
+import { allocatePipelineRunId } from "./run-id.js";
+import { setupPipelineRun } from "./setup-run.js";
+import { preparePanels } from "./prepare-panels.js";
+import { trainPipelineScales } from "./train-pipeline-scales.js";
+import { finalizePipelineRun } from "./finalize-run.js";
+
+export function runPipeline(spec: SpecInput | PortableSpec, options: RunOptions): RenderModel {
+  const runId = allocatePipelineRunId();
+  perfMark("ggsvelte:pipeline:start");
+
+  const warnings: PipelineWarning[] = [];
+  const advisories: Advisory[] = [];
+
+  const { normalized, editionDefaults, theme, flip } = setupPipelineRun(
+    spec,
+    options.editions,
+    warnings,
+  );
+
+  // bind + facet partition + per-panel frames
+  perfMark("ggsvelte:bind:start");
+  const prepared = preparePanels(normalized, options, warnings, advisories);
+  perfMark("ggsvelte:bind:end");
+  perfMeasure("ggsvelte:bind", "ggsvelte:bind:start", "ggsvelte:bind:end");
+
+  // train scales — fixed: union across panels; free: positional domains per
+  // panel; discrete color/fill assignment ALWAYS global (one legend).
+  perfMark("ggsvelte:scales:start");
+  const trained = trainPipelineScales({
+    normalized,
+    options,
+    table: prepared.table,
+    facetPanels: prepared.facetPanels,
+    panelFrames: prepared.panelFrames,
+    freeX: prepared.freeX,
+    freeY: prepared.freeY,
+    editionDefaults,
+    warnings,
+    advisories,
+  });
+  perfMark("ggsvelte:scales:end");
+  perfMeasure("ggsvelte:scales", "ggsvelte:scales:start", "ggsvelte:scales:end");
+
+  const model = finalizePipelineRun({
+    runId,
+    normalized,
+    options,
+    theme,
+    flip,
+    prepared,
+    trained,
+    warnings,
+    advisories,
+  });
+
+  perfMark("ggsvelte:pipeline:end");
+  perfMeasure("ggsvelte:pipeline", "ggsvelte:pipeline:start", "ggsvelte:pipeline:end");
+  return model;
+}

--- a/packages/core/src/pipeline/scale-axis-collect-acc.ts
+++ b/packages/core/src/pipeline/scale-axis-collect-acc.ts
@@ -1,0 +1,14 @@
+/**
+ * Shared accumulator for axis evidence collection.
+ */
+import type { CellValue } from "../table.js";
+
+export interface AxisCollectAcc {
+  columns: (readonly CellValue[])[];
+  numeric: Float64Array[];
+  anyDiscrete: boolean;
+  allTemporal: boolean;
+  sawContinuousEvidence: boolean;
+  barMeasure: boolean;
+  typeParts: Set<string>;
+}

--- a/packages/core/src/pipeline/scale-axis-collect-x-binned.ts
+++ b/packages/core/src/pipeline/scale-axis-collect-x-binned.ts
@@ -1,0 +1,15 @@
+/**
+ * Collect continuous x evidence from binned xmin/xmax edges.
+ */
+import type { AxisCollectAcc } from "./scale-axis-collect-acc.js";
+import type { LayerFrame } from "./types.js";
+
+export function collectBinnedXEvidence(frame: LayerFrame, acc: AxisCollectAcc): void {
+  if (frame.xmin === null || frame.xmax === null) return;
+  acc.numeric.push(frame.xmin, frame.xmax);
+  const field = frame.binding.xField!;
+  const fieldType = frame.table.has(field) ? frame.table.fieldType(field) : "quantitative";
+  acc.typeParts.add(`binned ${fieldType}`);
+  if (fieldType !== "temporal") acc.allTemporal = false;
+  acc.sawContinuousEvidence = true;
+}

--- a/packages/core/src/pipeline/scale-axis-collect-x-extras.ts
+++ b/packages/core/src/pipeline/scale-axis-collect-x-extras.ts
@@ -1,0 +1,19 @@
+/**
+ * Collect x evidence from boxplot outliers and annotation intercepts.
+ */
+import { cellToNumber } from "../table.js";
+
+import type { AxisCollectAcc } from "./scale-axis-collect-acc.js";
+import type { LayerFrame } from "./types.js";
+
+export function collectXOutliersAndIntercepts(frame: LayerFrame, acc: AxisCollectAcc): void {
+  if (frame.box !== null && frame.box.outlierX.length > 0) {
+    acc.columns.push(frame.box.outlierX);
+  }
+  for (const v of frame.xIntercepts) {
+    acc.columns.push([v]);
+    acc.numeric.push(Float64Array.of(cellToNumber(v)));
+    if (typeof v === "string" && !Number.isFinite(cellToNumber(v))) acc.anyDiscrete = true;
+    acc.sawContinuousEvidence = true;
+  }
+}

--- a/packages/core/src/pipeline/scale-axis-collect-x-mapped.ts
+++ b/packages/core/src/pipeline/scale-axis-collect-x-mapped.ts
@@ -1,0 +1,35 @@
+/**
+ * Collect x evidence from mapped xValues/xNumeric (including bar discretization).
+ */
+import type { PositionScaleSpec } from "@ggsvelte/spec";
+
+import type { AxisCollectAcc } from "./scale-axis-collect-acc.js";
+import type { Advisory, LayerFrame } from "./types.js";
+
+export function collectMappedXEvidence(
+  frame: LayerFrame,
+  configType: PositionScaleSpec["type"] | undefined,
+  advisories: Advisory[],
+  acc: AxisCollectAcc,
+): void {
+  if (frame.xValues === null && frame.xNumeric === null) return;
+  if (frame.xValues !== null) acc.columns.push(frame.xValues);
+  if (frame.xNumeric !== null) acc.numeric.push(frame.xNumeric);
+  const { binding } = frame;
+  const geom = binding.layer.geom;
+  const field = binding.xField!;
+  const fieldType = frame.table.has(field) ? frame.table.fieldType(field) : "quantitative";
+  acc.typeParts.add(fieldType);
+  const barX = (geom === "bar" || geom === "col") && binding.layer.stat !== "bin";
+  if (barX && fieldType !== "nominal" && configType === undefined) {
+    advisories.push({
+      code: "bar-x-discretized",
+      path: `layers.${binding.index}`,
+      chosen: `x treated as discrete bands (${geom} geom)`,
+      howToOverride: "Use point/line/area for continuous x, or set scales.x.type explicitly.",
+    });
+  }
+  if (barX || fieldType === "nominal") acc.anyDiscrete = true;
+  if (fieldType !== "temporal") acc.allTemporal = false;
+  acc.sawContinuousEvidence = true;
+}

--- a/packages/core/src/pipeline/scale-axis-collect-x.ts
+++ b/packages/core/src/pipeline/scale-axis-collect-x.ts
@@ -3,20 +3,13 @@
  */
 import type { PositionScaleSpec } from "@ggsvelte/spec";
 
-import type { CellValue } from "../table.js";
-import { cellToNumber } from "../table.js";
-
+import type { AxisCollectAcc } from "./scale-axis-collect-acc.js";
+import { collectBinnedXEvidence } from "./scale-axis-collect-x-binned.js";
+import { collectXOutliersAndIntercepts } from "./scale-axis-collect-x-extras.js";
+import { collectMappedXEvidence } from "./scale-axis-collect-x-mapped.js";
 import type { Advisory, LayerFrame } from "./types.js";
 
-export interface AxisCollectAcc {
-  columns: (readonly CellValue[])[];
-  numeric: Float64Array[];
-  anyDiscrete: boolean;
-  allTemporal: boolean;
-  sawContinuousEvidence: boolean;
-  barMeasure: boolean;
-  typeParts: Set<string>;
-}
+export type { AxisCollectAcc } from "./scale-axis-collect-acc.js";
 
 export function collectAxisInputsX(
   frame: LayerFrame,
@@ -24,43 +17,10 @@ export function collectAxisInputsX(
   advisories: Advisory[],
   acc: AxisCollectAcc,
 ): void {
-  const { binding } = frame;
-  const geom = binding.layer.geom;
-
   if (frame.xmin !== null && frame.xmax !== null) {
-    // Binned bars: the x domain is the union of bin edges (continuous).
-    acc.numeric.push(frame.xmin, frame.xmax);
-    const field = binding.xField!;
-    const fieldType = frame.table.has(field) ? frame.table.fieldType(field) : "quantitative";
-    acc.typeParts.add(`binned ${fieldType}`);
-    if (fieldType !== "temporal") acc.allTemporal = false;
-    acc.sawContinuousEvidence = true;
-  } else if (frame.xValues !== null || frame.xNumeric !== null) {
-    if (frame.xValues !== null) acc.columns.push(frame.xValues);
-    if (frame.xNumeric !== null) acc.numeric.push(frame.xNumeric);
-    const field = binding.xField!;
-    const fieldType = frame.table.has(field) ? frame.table.fieldType(field) : "quantitative";
-    acc.typeParts.add(fieldType);
-    const barX = (geom === "bar" || geom === "col") && binding.layer.stat !== "bin";
-    if (barX && fieldType !== "nominal" && configType === undefined) {
-      advisories.push({
-        code: "bar-x-discretized",
-        path: `layers.${binding.index}`,
-        chosen: `x treated as discrete bands (${geom} geom)`,
-        howToOverride: "Use point/line/area for continuous x, or set scales.x.type explicitly.",
-      });
-    }
-    if (barX || fieldType === "nominal") acc.anyDiscrete = true;
-    if (fieldType !== "temporal") acc.allTemporal = false;
-    acc.sawContinuousEvidence = true;
+    collectBinnedXEvidence(frame, acc);
+  } else {
+    collectMappedXEvidence(frame, configType, advisories, acc);
   }
-  if (frame.box !== null && frame.box.outlierX.length > 0) {
-    acc.columns.push(frame.box.outlierX);
-  }
-  for (const v of frame.xIntercepts) {
-    acc.columns.push([v]);
-    acc.numeric.push(Float64Array.of(cellToNumber(v)));
-    if (typeof v === "string" && !Number.isFinite(cellToNumber(v))) acc.anyDiscrete = true;
-    acc.sawContinuousEvidence = true;
-  }
+  collectXOutliersAndIntercepts(frame, acc);
 }

--- a/packages/core/src/pipeline/scale-color-sequential-train.ts
+++ b/packages/core/src/pipeline/scale-color-sequential-train.ts
@@ -1,0 +1,53 @@
+/**
+ * Train a sequential color scale from values + config/edition range.
+ */
+import type { ColorScaleSpec } from "@ggsvelte/spec";
+
+import type { EditionDefaults } from "../editions.js";
+import { trainSequential, type SequentialColorScale } from "../scales/color.js";
+import { finiteExtent } from "../scales/train.js";
+import type { CellValue } from "../table.js";
+import { cellsToNumeric } from "../table.js";
+
+import {
+  resolveSequentialDomain,
+  resolveSequentialRange,
+} from "./scale-color-sequential-domain.js";
+import type { Advisory, PipelineWarning } from "./types.js";
+
+export function trainSequentialColorScale(input: {
+  name: "color" | "fill";
+  values: readonly CellValue[];
+  anyDiscreteField: boolean;
+  config: ColorScaleSpec | undefined;
+  editionDefaults: EditionDefaults;
+  warnings: PipelineWarning[];
+  advisories: Advisory[];
+}): SequentialColorScale {
+  const { name, values, anyDiscreteField, config, editionDefaults, warnings, advisories } = input;
+
+  if (anyDiscreteField) {
+    warnings.push({
+      code: "sequential-discrete-field",
+      message: `The ${name} scale is sequential but a mapped field is discrete; values that do not parse as numbers render the unknown color.`,
+    });
+  }
+  const numeric = cellsToNumeric(values);
+  const extent = finiteExtent([numeric]);
+  const sequentialDomain = resolveSequentialDomain(config);
+  const range = resolveSequentialRange(config, editionDefaults);
+  const scale = trainSequential(extent, {
+    ...(sequentialDomain !== undefined && { domain: sequentialDomain }),
+    ...(range !== undefined && { range }),
+    ...(config?.reverse !== undefined && { reverse: config.reverse }),
+  });
+  if (config?.scheme === undefined && config?.range === undefined) {
+    advisories.push({
+      code: "palette-inferred",
+      path: `scales.${name}`,
+      chosen: "sequential viridis ramp",
+      howToOverride: `Set scales.${name}.range (ramp stops) or scales.${name}.domain.`,
+    });
+  }
+  return scale;
+}

--- a/packages/core/src/pipeline/scale-color-sequential.ts
+++ b/packages/core/src/pipeline/scale-color-sequential.ts
@@ -4,17 +4,11 @@
 import type { ColorScaleSpec } from "@ggsvelte/spec";
 
 import type { EditionDefaults } from "../editions.js";
-import { trainSequential } from "../scales/color.js";
-import { finiteExtent } from "../scales/train.js";
 import type { CellValue } from "../table.js";
-import { cellsToNumeric } from "../table.js";
 
-import {
-  resolveSequentialDomain,
-  resolveSequentialRange,
-} from "./scale-color-sequential-domain.js";
 import { resolveSequentialLegendFormat } from "./scale-color-sequential-format.js";
 import { sequentialColorResolution } from "./scale-color-sequential-result.js";
+import { trainSequentialColorScale } from "./scale-color-sequential-train.js";
 import type { ColorResolution } from "./scale-color-types.js";
 import type { Advisory, PipelineWarning } from "./types.js";
 
@@ -28,40 +22,8 @@ export function resolveSequentialColorScale(input: {
   advisories: Advisory[];
   editionDefaults: EditionDefaults;
 }): ColorResolution {
-  const {
-    name,
-    values,
-    anyDiscreteField,
-    config,
-    legendTitle,
-    warnings,
-    advisories,
-    editionDefaults,
-  } = input;
-
-  if (anyDiscreteField) {
-    warnings.push({
-      code: "sequential-discrete-field",
-      message: `The ${name} scale is sequential but a mapped field is discrete; values that do not parse as numbers render the unknown color.`,
-    });
-  }
-  const numeric = cellsToNumeric(values);
-  const extent = finiteExtent([numeric]);
-  const sequentialDomain = resolveSequentialDomain(config);
-  const range = resolveSequentialRange(config, editionDefaults);
-  const scale = trainSequential(extent, {
-    ...(sequentialDomain !== undefined && { domain: sequentialDomain }),
-    ...(range !== undefined && { range }),
-    ...(config?.reverse !== undefined && { reverse: config.reverse }),
-  });
-  if (config?.scheme === undefined && config?.range === undefined) {
-    advisories.push({
-      code: "palette-inferred",
-      path: `scales.${name}`,
-      chosen: "sequential viridis ramp",
-      howToOverride: `Set scales.${name}.range (ramp stops) or scales.${name}.domain.`,
-    });
-  }
+  const { name, legendTitle, config, warnings } = input;
+  const scale = trainSequentialColorScale(input);
   const format = resolveSequentialLegendFormat(scale, config, name, warnings);
   return sequentialColorResolution(name, legendTitle, scale, format);
 }

--- a/packages/core/src/pipeline/train-pipeline-scales-input.ts
+++ b/packages/core/src/pipeline/train-pipeline-scales-input.ts
@@ -1,0 +1,23 @@
+/**
+ * trainPipelineScales input contract.
+ */
+import type { PortableSpec } from "@ggsvelte/spec";
+
+import type { EditionDefaults } from "../editions.js";
+import type { ColumnTable } from "../table.js";
+
+import type { FacetPanelDef } from "./facets.js";
+import type { Advisory, LayerFrame, PipelineWarning, RunOptions } from "./types.js";
+
+export interface TrainPipelineScalesInput {
+  normalized: PortableSpec;
+  options: RunOptions;
+  table: ColumnTable;
+  facetPanels: readonly FacetPanelDef[];
+  panelFrames: readonly (readonly LayerFrame[])[];
+  freeX: boolean;
+  freeY: boolean;
+  editionDefaults: EditionDefaults;
+  warnings: PipelineWarning[];
+  advisories: Advisory[];
+}

--- a/packages/core/src/pipeline/train-pipeline-scales.ts
+++ b/packages/core/src/pipeline/train-pipeline-scales.ts
@@ -1,31 +1,15 @@
 /**
  * Train fixed/free positional scales and global color/fill scales for a run.
  */
-import type { PortableSpec } from "@ggsvelte/spec";
-
-import type { EditionDefaults } from "../editions.js";
-import type { ColumnTable } from "../table.js";
-
-import type { FacetPanelDef } from "./facets.js";
 import { trainPipelineColorScales } from "./train-pipeline-scales-color.js";
+import type { TrainPipelineScalesInput } from "./train-pipeline-scales-input.js";
 import { trainPipelinePositionScales } from "./train-pipeline-scales-position.js";
 import type { TrainedPipelineScales } from "./train-pipeline-scales-types.js";
-import type { Advisory, LayerFrame, PipelineWarning, RunOptions } from "./types.js";
 
 export type { TrainedPipelineScales } from "./train-pipeline-scales-types.js";
+export type { TrainPipelineScalesInput } from "./train-pipeline-scales-input.js";
 
-export function trainPipelineScales(input: {
-  normalized: PortableSpec;
-  options: RunOptions;
-  table: ColumnTable;
-  facetPanels: readonly FacetPanelDef[];
-  panelFrames: readonly (readonly LayerFrame[])[];
-  freeX: boolean;
-  freeY: boolean;
-  editionDefaults: EditionDefaults;
-  warnings: PipelineWarning[];
-  advisories: Advisory[];
-}): TrainedPipelineScales {
+export function trainPipelineScales(input: TrainPipelineScalesInput): TrainedPipelineScales {
   const {
     normalized,
     options,

--- a/packages/core/src/pipeline/types-model.ts
+++ b/packages/core/src/pipeline/types-model.ts
@@ -1,20 +1,6 @@
 /**
  * Pipeline model types: trained scales, domain snapshots, and RenderModel.
  */
-import type { Scene } from "../scene.js";
-import type { CellValue } from "../table.js";
-import type { CandidateStore } from "../candidate-store.js";
-import type { LineageStore } from "../identity.js";
-
-import type { Advisory, PipelineWarning } from "./types-advisory.js";
-import type {
-  AxisValueFormatter,
-  LayerBackend,
-  MappedField,
-  ScaleDomainSnapshot,
-  TrainedScales,
-} from "./types-model-scales.js";
-
 export type {
   AxisValueFormatter,
   LayerBackend,
@@ -24,43 +10,4 @@ export type {
   TrainedScales,
 } from "./types-model-scales.js";
 
-export interface RenderModel {
-  scene: Scene;
-  scales: TrainedScales;
-  warnings: PipelineWarning[];
-  advisories: Advisory[];
-  /** Monotonic run identity (module-global, increases every runPipeline call). */
-  runId: number;
-  /**
-   * Resolved rendering backend per layer: the layer's `render` hint, with
-   * "auto" resolving to canvas above the mark-count threshold (advisory
-   * `canvas-auto`), and `a11y: "force-svg"` forcing every layer to "svg".
-   * renderToSVGString ignores this (always all-SVG).
-   */
-  layerBackends: LayerBackend[];
-  /** Field-mapped channels per layer (drives default tooltip content). */
-  layerFields: MappedField[][];
-  /**
-   * Scaled constant aes values per layer (`{ value, scale: true }` on color/fill).
-   * Used by legend-focus key indexing when no field mapping exists for a scale.
-   */
-  layerScaledConstants: ReadonlyArray<Readonly<Partial<Record<string, CellValue>>>>;
-  /** Stable baseline plus the domains actually used for this render. */
-  domains: Readonly<{ baseline: ScaleDomainSnapshot; effective: ScaleDomainSnapshot }>;
-  /** Interned source-row memberships. Public adapters resolve these through keys. */
-  lineage: LineageStore<number>;
-  /** Shared epoch-scoped interaction candidate storage. */
-  candidates: CandidateStore;
-  /** Trained semantic formatters. Coord transforms never swap x and y here. */
-  axisFormatters: Readonly<{ x: AxisValueFormatter; y: AxisValueFormatter }>;
-  /** The source data row behind a hit-index rowIndex (null for synthesized
-   *  stat rows). Reads the bound table — do not call after dispose(). */
-  row(index: number): Record<string, CellValue> | null;
-  /**
-   * Release this model's geometry and caches (plan: memory ownership). The
-   * Svelte adapter disposes the previous model on commit and the current one
-   * on unmount. After dispose() the scene's batches are empty and row()
-   * returns null; rendering a disposed model is a caller bug.
-   */
-  dispose(): void;
-}
+export type { RenderModel } from "./types-render-model.js";

--- a/packages/core/src/pipeline/types-render-model.ts
+++ b/packages/core/src/pipeline/types-render-model.ts
@@ -1,0 +1,57 @@
+/**
+ * Public RenderModel surface returned by runPipeline.
+ */
+import type { Scene } from "../scene.js";
+import type { CellValue } from "../table.js";
+import type { CandidateStore } from "../candidate-store.js";
+import type { LineageStore } from "../identity.js";
+
+import type { Advisory, PipelineWarning } from "./types-advisory.js";
+import type {
+  AxisValueFormatter,
+  LayerBackend,
+  MappedField,
+  ScaleDomainSnapshot,
+  TrainedScales,
+} from "./types-model-scales.js";
+
+export interface RenderModel {
+  scene: Scene;
+  scales: TrainedScales;
+  warnings: PipelineWarning[];
+  advisories: Advisory[];
+  /** Monotonic run identity (module-global, increases every runPipeline call). */
+  runId: number;
+  /**
+   * Resolved rendering backend per layer: the layer's `render` hint, with
+   * "auto" resolving to canvas above the mark-count threshold (advisory
+   * `canvas-auto`), and `a11y: "force-svg"` forcing every layer to "svg".
+   * renderToSVGString ignores this (always all-SVG).
+   */
+  layerBackends: LayerBackend[];
+  /** Field-mapped channels per layer (drives default tooltip content). */
+  layerFields: MappedField[][];
+  /**
+   * Scaled constant aes values per layer (`{ value, scale: true }` on color/fill).
+   * Used by legend-focus key indexing when no field mapping exists for a scale.
+   */
+  layerScaledConstants: ReadonlyArray<Readonly<Partial<Record<string, CellValue>>>>;
+  /** Stable baseline plus the domains actually used for this render. */
+  domains: Readonly<{ baseline: ScaleDomainSnapshot; effective: ScaleDomainSnapshot }>;
+  /** Interned source-row memberships. Public adapters resolve these through keys. */
+  lineage: LineageStore<number>;
+  /** Shared epoch-scoped interaction candidate storage. */
+  candidates: CandidateStore;
+  /** Trained semantic formatters. Coord transforms never swap x and y here. */
+  axisFormatters: Readonly<{ x: AxisValueFormatter; y: AxisValueFormatter }>;
+  /** The source data row behind a hit-index rowIndex (null for synthesized
+   *  stat rows). Reads the bound table — do not call after dispose(). */
+  row(index: number): Record<string, CellValue> | null;
+  /**
+   * Release this model's geometry and caches (plan: memory ownership). The
+   * Svelte adapter disposes the previous model on commit and the current one
+   * on unmount. After dispose() the scene's batches are empty and row()
+   * returns null; rendering a disposed model is a caller bug.
+   */
+  dispose(): void;
+}

--- a/packages/core/tests/pipeline-geometry.test.ts
+++ b/packages/core/tests/pipeline-geometry.test.ts
@@ -553,3 +553,57 @@ describe("geometryPanelFrame", () => {
     expect(flipped.xScale).toBe(xScale);
   });
 });
+
+describe("packSegmentsBatch", () => {
+  it("returns null for empty rowIndex and builds a segments batch otherwise", async () => {
+    const { packSegmentsBatch } = await import("../src/pipeline/geometry-segments-pack.ts");
+    const frame = {
+      binding: {
+        index: 0,
+        color: { constant: "#111" },
+        layer: { params: {} },
+        ruleForm: "vertical",
+      },
+    } as never;
+    expect(
+      packSegmentsBatch({
+        frame,
+        segments: [],
+        rowIndex: [],
+        perSegmentColors: [],
+        wantsColors: false,
+      }),
+    ).toBeNull();
+    const batch = packSegmentsBatch({
+      frame,
+      segments: [0, 0, 10, 10],
+      rowIndex: [3],
+      perSegmentColors: [],
+      wantsColors: false,
+    });
+    expect(batch?.kind).toBe("segments");
+    expect([...batch!.rowIndex]).toEqual([3]);
+    expect(batch!.stroke).toBe("#111");
+  });
+});
+
+describe("packFacetPanelPlacement", () => {
+  it("shows y-axis only for column 0 when freeV is false", async () => {
+    const { packFacetPanelPlacement } =
+      await import("../src/pipeline/panel-layout-facet-place-pack.ts");
+    const placement = packFacetPanelPlacement({
+      def: { col: 1, row: 0 } as never,
+      colX: 20,
+      rowY: 10,
+      panelW: 100,
+      panelH: 50,
+      freeH: false,
+      freeV: false,
+      bottomMostRow: 0,
+      ticksRun: { x: { ticks: [1] }, y: { ticks: [2] } } as never,
+    });
+    expect(placement.showAxisX).toBe(true);
+    expect(placement.showAxisY).toBe(false);
+    expect(placement.x).toBe(20);
+  });
+});


### PR DESCRIPTION
## Summary
- Move `runPipeline` orchestration into `run-pipeline.ts` so the public entry stays documentation + re-exports.
- Split layout chrome/facet/placement, bind-layer position, scale-axis collect/sequential train, and geometry dispatch/segments/glyphs helpers behind stable facades.
- Add characterization tests for segment packing and facet panel placement.

## Test plan
- [x] `bun test packages/core` (524 pass)
- [x] `bun run check`
- [x] `bun run knip`
- [x] `bun run lint:type-aware`
- [x] Codex review (`gpt-5.6-terra`) — PASS, no P1