### PR TITLE
refactor(svelte): pass inspect domain config on pointer move and up

### DIFF
--- a/packages/svelte/src/lib/GGPlot.svelte
+++ b/packages/svelte/src/lib/GGPlot.svelte
@@ -1763,7 +1763,7 @@
       hasTouchInspectStart: touchInspectStart !== null,
       brushing,
       hasBrushDraft: brushRect !== null,
-      inspectEnabled,
+      inspect: interactionConfig.inspect,
     });
     switch (action.type) {
       case "touch-inspect-drag-cancel":
@@ -1775,12 +1775,11 @@
         reducer.queuePointer({ type: "move-area", point: p });
         return;
       case "queue-inspect": {
-        const inspectConfig = interactionConfig.inspect;
-        if (inspectConfig === null) return;
+        // mode/maxDistance from pure snapshot — no inspect config re-gate.
         const match =
           model?.candidates.nearest(p.x, p.y, {
-            mode: inspectConfig.mode,
-            maxDistance: inspectConfig.maxDistance,
+            mode: action.mode,
+            maxDistance: action.maxDistance,
           }) ?? null;
         // One null branch for hit + reducer candidate (lazy hitTest / panelId).
         const frame = buildQueuedInspectFrame({
@@ -1952,8 +1951,7 @@
     const action = resolvePointerUpAction({
       pointerType: event.pointerType,
       activeTool,
-      inspectEnabled,
-      pinEnabled,
+      inspect: interactionConfig.inspect,
       hasTouchInspectStart: touchInspectStart !== null,
       touchInspectMoved,
       brushing,
@@ -1969,11 +1967,10 @@
       case "touch-inspect-tap": {
         touchInspectStart = null;
         touchInspectMoved = false;
-        const inspectConfig = interactionConfig.inspect;
-        if (inspectConfig === null) break;
+        // mode/maxDistance/state from pure inspect snapshot — no re-gate.
         const match = model?.candidates.nearest(endPoint.x, endPoint.y, {
-          mode: inspectConfig.mode,
-          maxDistance: inspectConfig.maxDistance,
+          mode: action.mode,
+          maxDistance: action.maxDistance,
         });
         if (match !== null && match !== undefined) {
           setInspection(

--- a/packages/svelte/src/lib/plot-surface-pointer.ts
+++ b/packages/svelte/src/lib/plot-surface-pointer.ts
@@ -68,6 +68,17 @@ export function resolvePointerDownAction(input: SurfacePointerDownInput): Surfac
 }
 
 /**
+ * Domain inspect snapshot for pointer move/up (host: resolved
+ * `interactionConfig.inspect`). Pass the domain object, not a pre-derived
+ * `inspectEnabled` boolean — matches inspection-state domain convention.
+ */
+export type SurfaceInspectConfig = {
+  readonly mode: "auto" | "exact" | "x" | "y" | "xy";
+  readonly maxDistance: number;
+  readonly pin: boolean;
+} | null;
+
+/**
  * Capture-surface pointerup decision input.
  * Touch-inspect fields only matter when tool is inspect + pointer is touch.
  *
@@ -78,8 +89,8 @@ export function resolvePointerDownAction(input: SurfacePointerDownInput): Surfac
 export type SurfacePointerUpInput = {
   readonly pointerType: string;
   readonly activeTool: InteractionTool;
-  readonly inspectEnabled: boolean;
-  readonly pinEnabled: boolean;
+  /** Host: resolved `interactionConfig.inspect`. */
+  readonly inspect: SurfaceInspectConfig;
   readonly hasTouchInspectStart: boolean;
   readonly touchInspectMoved: boolean;
   /** Reducer brushing flag — can diverge from draft. */
@@ -96,8 +107,11 @@ export type SurfacePointerUpInput = {
 export type SurfacePointerUpAction =
   | {
       readonly type: "touch-inspect-tap";
-      /** Inspection state for setInspection (from pinEnabled). */
+      /** Inspection state for setInspection (from inspect.pin). */
       readonly state: "pinned" | "transient";
+      /** Nearest-query params from inspect snapshot at decision time. */
+      readonly mode: "auto" | "exact" | "x" | "y" | "xy";
+      readonly maxDistance: number;
     }
   | { readonly type: "touch-inspect-drag-ignore" }
   | {
@@ -124,8 +138,7 @@ export function resolvePointerUpAction(input: SurfacePointerUpInput): SurfacePoi
   const {
     pointerType,
     activeTool,
-    inspectEnabled,
-    pinEnabled,
+    inspect,
     hasTouchInspectStart,
     touchInspectMoved,
     brushing,
@@ -136,13 +149,15 @@ export function resolvePointerUpAction(input: SurfacePointerUpInput): SurfacePoi
   if (
     activeTool === "inspect" &&
     pointerType === "touch" &&
-    inspectEnabled &&
+    inspect !== null &&
     hasTouchInspectStart
   ) {
     if (touchInspectMoved) return { type: "touch-inspect-drag-ignore" };
     return {
       type: "touch-inspect-tap",
-      state: pinEnabled ? "pinned" : "transient",
+      state: inspect.pin ? "pinned" : "transient",
+      mode: inspect.mode,
+      maxDistance: inspect.maxDistance,
     };
   }
 
@@ -238,14 +253,20 @@ export type SurfacePointerMoveInput = {
   readonly brushing: boolean;
   /** True when `brushRect !== null`. */
   readonly hasBrushDraft: boolean;
-  /** `interactionConfig.inspect !== null`. */
-  readonly inspectEnabled: boolean;
+  /** Host: resolved `interactionConfig.inspect` (domain object, not a boolean). */
+  readonly inspect: SurfaceInspectConfig;
 };
 
 export type SurfacePointerMoveAction =
   | { readonly type: "touch-inspect-drag-cancel" }
   | { readonly type: "queue-area-move"; readonly source: "touch" | "pointer" }
-  | { readonly type: "queue-inspect"; readonly source: "touch" | "pointer" }
+  | {
+      readonly type: "queue-inspect";
+      readonly source: "touch" | "pointer";
+      /** Nearest-query params from inspect snapshot at decision time. */
+      readonly mode: "auto" | "exact" | "x" | "y" | "xy";
+      readonly maxDistance: number;
+    }
   | { readonly type: "none" };
 
 /** Map a PointerEvent.pointerType string to InteractionSource surface values. */
@@ -261,12 +282,13 @@ const pointerSource = (pointerType: string): "touch" | "pointer" =>
  * Priority: touch-inspect drag cancel → queue area move → queue inspect → none.
  *
  * Cancel requires `pointerType === "touch"` (mouse/pen with residual start must
- * not cancel). Cancel does **not** require `inspectEnabled` — only the inspect
+ * not cancel). Cancel does **not** require inspect config — only the inspect
  * tool, matching the current host.
  *
  * Host advances `touchInspectMoved` separately on touch+start before calling.
  * Host on cancel: clear `queuedPointerInspection`, cancel scheduled pointer
- * (`queuedPointerToken` left untouched). Host on queue-*: use `action.source`.
+ * (`queuedPointerToken` left untouched). Host on queue-inspect: nearest with
+ * action.mode / action.maxDistance (no config re-read).
  */
 export function resolvePointerMoveAction(input: SurfacePointerMoveInput): SurfacePointerMoveAction {
   const {
@@ -276,7 +298,7 @@ export function resolvePointerMoveAction(input: SurfacePointerMoveInput): Surfac
     hasTouchInspectStart,
     brushing,
     hasBrushDraft,
-    inspectEnabled,
+    inspect,
   } = input;
 
   if (
@@ -292,8 +314,13 @@ export function resolvePointerMoveAction(input: SurfacePointerMoveInput): Surfac
     return { type: "queue-area-move", source: pointerSource(pointerType) };
   }
 
-  if (activeTool === "inspect" && inspectEnabled) {
-    return { type: "queue-inspect", source: pointerSource(pointerType) };
+  if (activeTool === "inspect" && inspect !== null) {
+    return {
+      type: "queue-inspect",
+      source: pointerSource(pointerType),
+      mode: inspect.mode,
+      maxDistance: inspect.maxDistance,
+    };
   }
 
   return { type: "none" };

--- a/packages/svelte/src/lib/plot-surface-pointer.ts
+++ b/packages/svelte/src/lib/plot-surface-pointer.ts
@@ -72,7 +72,7 @@ export function resolvePointerDownAction(input: SurfacePointerDownInput): Surfac
  * `interactionConfig.inspect`). Pass the domain object, not a pre-derived
  * `inspectEnabled` boolean — matches inspection-state domain convention.
  */
-export type SurfaceInspectConfig = {
+type SurfaceInspectConfig = {
   readonly mode: "auto" | "exact" | "x" | "y" | "xy";
   readonly maxDistance: number;
   readonly pin: boolean;

--- a/packages/svelte/tests/plot-surface-pointer.test.ts
+++ b/packages/svelte/tests/plot-surface-pointer.test.ts
@@ -36,12 +36,17 @@ const down = (
   ...overrides,
 });
 
+const defaultInspect = {
+  mode: "auto" as const,
+  maxDistance: 24,
+  pin: false,
+};
+
 const up = (
   overrides: Partial<SurfacePointerUpInput> & Pick<SurfacePointerUpInput, "activeTool">,
 ): SurfacePointerUpInput => ({
   pointerType: "mouse",
-  inspectEnabled: true,
-  pinEnabled: false,
+  inspect: defaultInspect,
   hasTouchInspectStart: false,
   touchInspectMoved: false,
   brushing: false,
@@ -69,7 +74,7 @@ const move = (
   hasTouchInspectStart: false,
   brushing: false,
   hasBrushDraft: false,
-  inspectEnabled: true,
+  inspect: defaultInspect,
   ...overrides,
 });
 
@@ -183,32 +188,40 @@ describe("resolvePointerDownAction", () => {
 });
 
 describe("resolvePointerUpAction", () => {
-  it("resolves touch inspect tap with inspection state from pinEnabled", () => {
+  it("resolves touch inspect tap with state/mode/maxDistance from inspect snapshot", () => {
     expect(
       resolvePointerUpAction(
         up({
           activeTool: "inspect",
           pointerType: "touch",
-          inspectEnabled: true,
+          inspect: { mode: "xy", maxDistance: 16, pin: true },
           hasTouchInspectStart: true,
           touchInspectMoved: false,
-          pinEnabled: true,
         }),
       ),
-    ).toEqual({ type: "touch-inspect-tap", state: "pinned" });
+    ).toEqual({
+      type: "touch-inspect-tap",
+      state: "pinned",
+      mode: "xy",
+      maxDistance: 16,
+    });
 
     expect(
       resolvePointerUpAction(
         up({
           activeTool: "inspect",
           pointerType: "touch",
-          inspectEnabled: true,
+          inspect: { mode: "auto", maxDistance: 24, pin: false },
           hasTouchInspectStart: true,
           touchInspectMoved: false,
-          pinEnabled: false,
         }),
       ),
-    ).toEqual({ type: "touch-inspect-tap", state: "transient" });
+    ).toEqual({
+      type: "touch-inspect-tap",
+      state: "transient",
+      mode: "auto",
+      maxDistance: 24,
+    });
   });
 
   it("ignores touch inspect drag (moved past threshold)", () => {
@@ -217,7 +230,7 @@ describe("resolvePointerUpAction", () => {
         up({
           activeTool: "inspect",
           pointerType: "touch",
-          inspectEnabled: true,
+          inspect: defaultInspect,
           hasTouchInspectStart: true,
           touchInspectMoved: true,
         }),
@@ -225,12 +238,12 @@ describe("resolvePointerUpAction", () => {
     ).toEqual({ type: "touch-inspect-drag-ignore" });
   });
 
-  it("does not take touch-inspect path when inspect disabled or tool changed", () => {
+  it("does not take touch-inspect path when inspect null or tool changed", () => {
     const finishTouch = resolvePointerUpAction(
       up({
         activeTool: "inspect",
         pointerType: "touch",
-        inspectEnabled: false,
+        inspect: null,
         hasTouchInspectStart: true,
         brushing: true,
         brushCorners: draftCorners,
@@ -246,7 +259,7 @@ describe("resolvePointerUpAction", () => {
       up({
         activeTool: "select-area",
         pointerType: "touch",
-        inspectEnabled: true,
+        inspect: defaultInspect,
         hasTouchInspectStart: true,
         brushing: true,
         brushCorners: draftCorners,
@@ -453,13 +466,13 @@ describe("resolvePointerMoveAction", () => {
           touchInspectMoved: true,
           brushing: true,
           hasBrushDraft: true,
-          inspectEnabled: true,
+          inspect: defaultInspect,
         }),
       ),
     ).toEqual({ type: "touch-inspect-drag-cancel" });
   });
 
-  it("cancels even when inspect config is disabled (tool-only gate)", () => {
+  it("cancels even when inspect config is null (tool-only gate)", () => {
     expect(
       resolvePointerMoveAction(
         move({
@@ -467,7 +480,7 @@ describe("resolvePointerMoveAction", () => {
           pointerType: "touch",
           hasTouchInspectStart: true,
           touchInspectMoved: true,
-          inspectEnabled: false,
+          inspect: null,
         }),
       ),
     ).toEqual({ type: "touch-inspect-drag-cancel" });
@@ -482,14 +495,19 @@ describe("resolvePointerMoveAction", () => {
             pointerType,
             hasTouchInspectStart: true,
             touchInspectMoved: true,
-            inspectEnabled: true,
+            inspect: { mode: "x", maxDistance: 12, pin: true },
           }),
         ),
-      ).toEqual({ type: "queue-inspect", source: "pointer" });
+      ).toEqual({
+        type: "queue-inspect",
+        source: "pointer",
+        mode: "x",
+        maxDistance: 12,
+      });
     }
   });
 
-  it("does not cancel when unmoved — falls through to queue-inspect", () => {
+  it("does not cancel when unmoved — falls through to queue-inspect with payload", () => {
     expect(
       resolvePointerMoveAction(
         move({
@@ -497,10 +515,15 @@ describe("resolvePointerMoveAction", () => {
           pointerType: "touch",
           hasTouchInspectStart: true,
           touchInspectMoved: false,
-          inspectEnabled: true,
+          inspect: { mode: "auto", maxDistance: 24, pin: false },
         }),
       ),
-    ).toEqual({ type: "queue-inspect", source: "touch" });
+    ).toEqual({
+      type: "queue-inspect",
+      source: "touch",
+      mode: "auto",
+      maxDistance: 24,
+    });
   });
 
   it("does not cancel when tool is no longer inspect (area wins if brushing)", () => {
@@ -552,24 +575,29 @@ describe("resolvePointerMoveAction", () => {
     ).toEqual({ type: "none" });
   });
 
-  it("queues inspect for mouse with pointer source", () => {
+  it("queues inspect for mouse with pointer source and inspect snapshot fields", () => {
     expect(
       resolvePointerMoveAction(
         move({
           activeTool: "inspect",
           pointerType: "mouse",
-          inspectEnabled: true,
+          inspect: { mode: "xy", maxDistance: 8, pin: true },
         }),
       ),
-    ).toEqual({ type: "queue-inspect", source: "pointer" });
+    ).toEqual({
+      type: "queue-inspect",
+      source: "pointer",
+      mode: "xy",
+      maxDistance: 8,
+    });
   });
 
-  it("returns none for inspect tool when inspect disabled", () => {
+  it("returns none for inspect tool when inspect config is null", () => {
     expect(
       resolvePointerMoveAction(
         move({
           activeTool: "inspect",
-          inspectEnabled: false,
+          inspect: null,
         }),
       ),
     ).toEqual({ type: "none" });


### PR DESCRIPTION
## Summary

- Replace `inspectEnabled` / `pinEnabled` booleans on pointer-move and pointer-up tables with the resolved inspect domain object (`interactionConfig.inspect`).
- `queue-inspect` and `touch-inspect-tap` carry `mode`, `maxDistance`, and pin-derived state so GGPlot nearest-query paths do not re-gate or re-read config.
- Touch-inspect drag cancel remains tool-only (still fires when inspect is null).
- Capture click path unchanged (hardcoded point-select radius).

## Test plan

- [x] Pointer move/up pure tests updated for domain inspect + payload fields
- [x] svelte-check + knip + pre-push hooks
- [ ] CI on PR