### PR TITLE
refactor(core): split free scales, facet form, smooth/area lineage helpers

### DIFF
--- a/packages/core/src/pipeline/build-candidates-lineage-filters.ts
+++ b/packages/core/src/pipeline/build-candidates-lineage-filters.ts
@@ -1,0 +1,55 @@
+/**
+ * Pure filters for reconstructing source rows represented by aggregate marks.
+ */
+import type { BarParams } from "@ggsvelte/spec";
+
+import { bandKey } from "../scales/train.js";
+import { cellToNumber, ColumnTable } from "../table.js";
+
+import type { LayerFrame } from "./types.js";
+
+export function filterAggregateXRows(input: {
+  table: ColumnTable;
+  field: string;
+  outputX: unknown;
+  baseRows: readonly number[];
+}): number[] {
+  const outputKey = bandKey(input.outputX);
+  return input.baseRows.filter(
+    (row) => bandKey(input.table.column(input.field)[row]) === outputKey,
+  );
+}
+
+export function filterBinRepresentedRows(input: {
+  frame: LayerFrame;
+  table: ColumnTable;
+  frameRow: number;
+  field: string;
+  baseRows: readonly number[];
+}): number[] {
+  const { frame, table, frameRow, field, baseRows } = input;
+  if (frame.xmin === null || frame.xmax === null) return [...baseRows];
+  const hi = frame.xmax[frameRow]!;
+  const lo = frame.xmin[frameRow]!;
+  const closed = ((frame.binding.layer.params ?? {}) as BarParams).closed ?? "right";
+  const frameGroup = frame.groups[frameRow];
+  const firstInGroup = frameRow === 0 || frame.groups[frameRow - 1] !== frameGroup;
+  const lastInGroup = frameRow === frame.n - 1 || frame.groups[frameRow + 1] !== frameGroup;
+  return baseRows.filter((row) => {
+    const value = cellToNumber(table.column(field)[row]!);
+    if (!Number.isFinite(value)) return false;
+    return closed === "right"
+      ? value <= hi && (value > lo || (firstInGroup && value >= lo))
+      : value >= lo && (value < hi || (lastInGroup && value <= hi));
+  });
+}
+
+export function filterAggregateYRows(input: {
+  table: ColumnTable;
+  field: string;
+  baseRows: readonly number[];
+}): number[] {
+  return input.baseRows.filter((row) =>
+    Number.isFinite(cellToNumber(input.table.column(input.field)[row]!)),
+  );
+}

--- a/packages/core/src/pipeline/build-candidates-lineage.ts
+++ b/packages/core/src/pipeline/build-candidates-lineage.ts
@@ -1,11 +1,13 @@
 /**
  * Reconstruct represented source rows for aggregate (stat-synthesized) marks.
  */
-import type { BarParams } from "@ggsvelte/spec";
+import { ColumnTable } from "../table.js";
 
-import { bandKey } from "../scales/train.js";
-import { cellToNumber, ColumnTable } from "../table.js";
-
+import {
+  filterAggregateXRows,
+  filterAggregateYRows,
+  filterBinRepresentedRows,
+} from "./build-candidates-lineage-filters.js";
 import type { LayerFrame } from "./types.js";
 
 export function filterRepresentedSourceRows(input: {
@@ -25,36 +27,29 @@ export function filterRepresentedSourceRows(input: {
     outputX !== null &&
     (stat === "count" || stat === "summary" || stat === "boxplot")
   ) {
-    const outputKey = bandKey(outputX);
-    representedRows = representedRows.filter(
-      (row) => bandKey(table.column(aggregateXField)[row]) === outputKey,
-    );
-  } else if (
-    stat === "bin" &&
-    aggregateXField !== null &&
-    frame.xmin !== null &&
-    frame.xmax !== null
-  ) {
-    const hi = frame.xmax[frameRow]!;
-    const lo = frame.xmin[frameRow]!;
-    const closed = ((frame.binding.layer.params ?? {}) as BarParams).closed ?? "right";
-    const frameGroup = frame.groups[frameRow];
-    const firstInGroup = frameRow === 0 || frame.groups[frameRow - 1] !== frameGroup;
-    const lastInGroup = frameRow === frame.n - 1 || frame.groups[frameRow + 1] !== frameGroup;
-    representedRows = representedRows.filter((row) => {
-      const value = cellToNumber(table.column(aggregateXField)[row]!);
-      if (!Number.isFinite(value)) return false;
-      return closed === "right"
-        ? value <= hi && (value > lo || (firstInGroup && value >= lo))
-        : value >= lo && (value < hi || (lastInGroup && value <= hi));
+    representedRows = filterAggregateXRows({
+      table,
+      field: aggregateXField,
+      outputX,
+      baseRows: representedRows,
+    });
+  } else if (stat === "bin" && aggregateXField !== null) {
+    representedRows = filterBinRepresentedRows({
+      frame,
+      table,
+      frameRow,
+      field: aggregateXField,
+      baseRows: representedRows,
     });
   }
 
   const aggregateYField = frame.binding.yField;
   if ((stat === "smooth" || stat === "summary" || stat === "boxplot") && aggregateYField !== null) {
-    representedRows = representedRows.filter((row) =>
-      Number.isFinite(cellToNumber(table.column(aggregateYField)[row]!)),
-    );
+    representedRows = filterAggregateYRows({
+      table,
+      field: aggregateYField,
+      baseRows: representedRows,
+    });
   }
 
   return representedRows;

--- a/packages/core/src/pipeline/facets-form.ts
+++ b/packages/core/src/pipeline/facets-form.ts
@@ -1,0 +1,39 @@
+/**
+ * Facet form validation and free-scale flag derivation.
+ */
+import type { FacetSpec } from "@ggsvelte/spec";
+
+import { PipelineError } from "./types.js";
+
+export function facetFreeFlags(scales: FacetSpec["scales"] | undefined): {
+  freeX: boolean;
+  freeY: boolean;
+} {
+  const resolved = scales ?? "fixed";
+  return {
+    freeX: resolved === "free" || resolved === "free_x",
+    freeY: resolved === "free" || resolved === "free_y",
+  };
+}
+
+export function assertFacetForm(input: {
+  wrapField: string | null;
+  rowsField: string | null;
+  colsField: string | null;
+}): void {
+  const { wrapField, rowsField, colsField } = input;
+  if (wrapField !== null && (rowsField !== null || colsField !== null)) {
+    throw new PipelineError(
+      "facet-form-ambiguous",
+      "/facet",
+      "This facet mixes the wrap form (facet.wrap) with the grid form (facet.rows/facet.cols). Use wrap OR rows/cols, never both.",
+    );
+  }
+  if (wrapField === null && rowsField === null && colsField === null) {
+    throw new PipelineError(
+      "facet-form-missing",
+      "/facet",
+      "This facet sets neither wrap nor rows/cols — there is no field to partition panels by.",
+    );
+  }
+}

--- a/packages/core/src/pipeline/facets.ts
+++ b/packages/core/src/pipeline/facets.ts
@@ -10,8 +10,8 @@ import { facetField } from "./facets-helpers.js";
 import { resolveFacetGrid } from "./facets-grid.js";
 import type { FacetLayout } from "./facets-types.js";
 import { SINGLE_PANEL } from "./facets-types.js";
+import { assertFacetForm, facetFreeFlags } from "./facets-form.js";
 import { resolveFacetWrap } from "./facets-wrap.js";
-import { PipelineError } from "./types.js";
 
 export type { FacetPanelDef, FacetLayout } from "./facets-types.js";
 export { SINGLE_PANEL } from "./facets-types.js";
@@ -21,23 +21,8 @@ export function resolveFacet(facet: FacetSpec | undefined, table: ColumnTable): 
   const wrapField = facetField(facet.wrap, "wrap", table);
   const rowsField = facetField(facet.rows, "rows", table);
   const colsField = facetField(facet.cols, "cols", table);
-  if (wrapField !== null && (rowsField !== null || colsField !== null)) {
-    throw new PipelineError(
-      "facet-form-ambiguous",
-      "/facet",
-      "This facet mixes the wrap form (facet.wrap) with the grid form (facet.rows/facet.cols). Use wrap OR rows/cols, never both.",
-    );
-  }
-  if (wrapField === null && rowsField === null && colsField === null) {
-    throw new PipelineError(
-      "facet-form-missing",
-      "/facet",
-      "This facet sets neither wrap nor rows/cols — there is no field to partition panels by.",
-    );
-  }
-  const scales = facet.scales ?? "fixed";
-  const freeX = scales === "free" || scales === "free_x";
-  const freeY = scales === "free" || scales === "free_y";
+  assertFacetForm({ wrapField, rowsField, colsField });
+  const { freeX, freeY } = facetFreeFlags(facet.scales);
 
   if (wrapField !== null) {
     return resolveFacetWrap({

--- a/packages/core/src/pipeline/geometry-paths-area-fill.ts
+++ b/packages/core/src/pipeline/geometry-paths-area-fill.ts
@@ -1,0 +1,21 @@
+/**
+ * Area/density group fill color resolution.
+ */
+import type { LayerFrame, ResolvedColorScale } from "./types.js";
+import { colorOf } from "./types.js";
+
+export function areaGroupFillOf(
+  frame: LayerFrame,
+  fill: ResolvedColorScale | null,
+  rows: readonly number[],
+): string | null {
+  const { binding } = frame;
+  let fillColor: string | null = binding.fill.constant;
+  if (fill !== null && (frame.fillValues !== null || binding.fill.scaledConstant !== null)) {
+    const first = rows[0]!;
+    const value =
+      frame.fillValues === null ? binding.fill.scaledConstant! : frame.fillValues[first]!;
+    fillColor = colorOf(fill, value);
+  }
+  return fillColor;
+}

--- a/packages/core/src/pipeline/geometry-paths-area.ts
+++ b/packages/core/src/pipeline/geometry-paths-area.ts
@@ -4,10 +4,10 @@
 import type { PathsBatch } from "../scene.js";
 
 import type { LayerFrame, PipelineWarning, ResolvedColorScale } from "./types.js";
-import { colorOf } from "./types.js";
 import type { Frame } from "./geometry-shared.js";
 import { bucketByGroup, xSortKey } from "./geometry-shared.js";
 import { writeClosedPathGroups } from "./geometry-paths-closed-batch.js";
+import { areaGroupFillOf } from "./geometry-paths-area-fill.js";
 
 export function areaBatch(
   frame: LayerFrame,
@@ -29,16 +29,7 @@ export function areaBatch(
     groupRows,
     yTop: frame.ymax,
     yBottom: frame.ymin,
-    fillOf: (rows) => {
-      let fillColor: string | null = binding.fill.constant;
-      if (fill !== null && (frame.fillValues !== null || binding.fill.scaledConstant !== null)) {
-        const first = rows[0]!;
-        const value =
-          frame.fillValues === null ? binding.fill.scaledConstant! : frame.fillValues[first]!;
-        fillColor = colorOf(fill, value);
-      }
-      return fillColor;
-    },
+    fillOf: (rows) => areaGroupFillOf(frame, fill, rows),
   });
 
   const params: { alpha?: number } =

--- a/packages/core/src/pipeline/geometry-smooth-line-write.ts
+++ b/packages/core/src/pipeline/geometry-smooth-line-write.ts
@@ -1,0 +1,48 @@
+/**
+ * Write smooth fitted-line vertices into typed arrays.
+ */
+import type { LayerFrame, ResolvedColorScale } from "./types.js";
+import type { Frame } from "./geometry-shared.js";
+import { positionOf } from "./geometry-shared.js";
+import { groupColor } from "./geometry-smooth-shared.js";
+
+export function writeSmoothLineGeometry(input: {
+  frame: LayerFrame;
+  fx: Frame;
+  color: ResolvedColorScale | null;
+  groupRows: readonly (readonly number[])[];
+}): {
+  positions: Float32Array;
+  rowIndex: Uint32Array;
+  pathOffsets: Uint32Array;
+  strokes: (string | null)[];
+} {
+  const { frame, fx, color, groupRows } = input;
+  const { binding } = frame;
+
+  let total = 0;
+  for (const rows of groupRows) total += rows.length;
+  const positions = new Float32Array(total * 2);
+  const rowIndex = new Uint32Array(total);
+  const pathOffsets = new Uint32Array(groupRows.length + 1);
+  const strokes: (string | null)[] = [];
+  let cursor = 0;
+  for (let s = 0; s < groupRows.length; s++) {
+    pathOffsets[s] = cursor;
+    const rows = groupRows[s]!;
+    for (const row of rows) {
+      const tx = positionOf(fx.xScale, frame.xNumeric, frame.xValues, row);
+      const ty = positionOf(fx.yScale, frame.yNumeric, null, row);
+      positions[cursor * 2] = tx * fx.innerWidth;
+      positions[cursor * 2 + 1] = fx.innerHeight - ty * fx.innerHeight;
+      rowIndex[cursor] = frame.rowIndex[row]!;
+      cursor++;
+    }
+    strokes.push(
+      groupColor(color, frame.colorValues, binding.color.scaledConstant, rows[0]!) ??
+        binding.color.constant,
+    );
+  }
+  pathOffsets[groupRows.length] = cursor;
+  return { positions, rowIndex, pathOffsets, strokes };
+}

--- a/packages/core/src/pipeline/geometry-smooth-line.ts
+++ b/packages/core/src/pipeline/geometry-smooth-line.ts
@@ -7,8 +7,8 @@ import type { GeometryBatch } from "../scene.js";
 
 import type { LayerFrame, ResolvedColorScale } from "./types.js";
 import type { Frame } from "./geometry-shared.js";
-import { positionOf } from "./geometry-shared.js";
-import { DEFAULT_SMOOTH_LINEWIDTH, groupColor } from "./geometry-smooth-shared.js";
+import { DEFAULT_SMOOTH_LINEWIDTH } from "./geometry-smooth-shared.js";
+import { writeSmoothLineGeometry } from "./geometry-smooth-line-write.js";
 
 export function buildSmoothLineBatch(input: {
   frame: LayerFrame;
@@ -19,31 +19,12 @@ export function buildSmoothLineBatch(input: {
   const { frame, fx, color, groupRows } = input;
   const { binding } = frame;
   const params = (binding.layer.params ?? {}) as SmoothParams;
-
-  let total = 0;
-  for (const rows of groupRows) total += rows.length;
-  const positions = new Float32Array(total * 2);
-  const rowIndex = new Uint32Array(total);
-  const pathOffsets = new Uint32Array(groupRows.length + 1);
-  const strokes: (string | null)[] = [];
-  let cursor = 0;
-  for (let s = 0; s < groupRows.length; s++) {
-    pathOffsets[s] = cursor;
-    const rows = groupRows[s]!;
-    for (const row of rows) {
-      const tx = positionOf(fx.xScale, frame.xNumeric, frame.xValues, row);
-      const ty = positionOf(fx.yScale, frame.yNumeric, null, row);
-      positions[cursor * 2] = tx * fx.innerWidth;
-      positions[cursor * 2 + 1] = fx.innerHeight - ty * fx.innerHeight;
-      rowIndex[cursor] = frame.rowIndex[row]!;
-      cursor++;
-    }
-    strokes.push(
-      groupColor(color, frame.colorValues, binding.color.scaledConstant, rows[0]!) ??
-        binding.color.constant,
-    );
-  }
-  pathOffsets[groupRows.length] = cursor;
+  const { positions, rowIndex, pathOffsets, strokes } = writeSmoothLineGeometry({
+    frame,
+    fx,
+    color,
+    groupRows,
+  });
   return {
     kind: "paths",
     layerIndex: binding.index,

--- a/packages/core/src/pipeline/scale-axis-train-continuous-warn.ts
+++ b/packages/core/src/pipeline/scale-axis-train-continuous-warn.ts
@@ -1,0 +1,24 @@
+/**
+ * Empty-domain and log-nonpositive warnings after continuous training.
+ */
+import type { PipelineWarning } from "./types.js";
+
+export function pushContinuousTrainingWarnings(
+  axis: "x" | "y",
+  type: "linear" | "log" | "time",
+  training: { empty: boolean; nonPositive: number },
+  warnings: PipelineWarning[],
+): void {
+  if (training.empty) {
+    warnings.push({
+      code: "empty-domain",
+      message: `The ${axis} scale has no finite${type === "log" ? " positive" : ""} values; using a default domain.`,
+    });
+  }
+  if (training.nonPositive > 0) {
+    warnings.push({
+      code: "log-nonpositive",
+      message: `Removed ${training.nonPositive} non-positive value(s) from the ${axis} log scale (log10 is undefined at or below zero).`,
+    });
+  }
+}

--- a/packages/core/src/pipeline/scale-axis-train-continuous-zero.ts
+++ b/packages/core/src/pipeline/scale-axis-train-continuous-zero.ts
@@ -1,0 +1,27 @@
+/**
+ * Bar/area zero-baseline advisory for continuous positional axes.
+ */
+import type { PositionScaleSpec } from "@ggsvelte/spec";
+
+import type { AxisInputs } from "./scale-axis-types.js";
+import type { Advisory } from "./types.js";
+
+export function maybeForceZeroForBars(
+  axis: "x" | "y",
+  inputs: AxisInputs,
+  config: PositionScaleSpec | undefined,
+  type: "linear" | "log" | "time",
+  advisories: Advisory[],
+): boolean | undefined {
+  let zero = config?.zero;
+  if (inputs.barMeasure && type !== "time" && zero === undefined && config?.domain === undefined) {
+    zero = true;
+    advisories.push({
+      code: "zero-forced",
+      path: `scales.${axis}`,
+      chosen: "domain extended to include 0 (bars/areas measure from a zero baseline)",
+      howToOverride: `Set scales.${axis}.zero to false, or pin scales.${axis}.domain.`,
+    });
+  }
+  return zero;
+}

--- a/packages/core/src/pipeline/scale-axis-train-continuous.ts
+++ b/packages/core/src/pipeline/scale-axis-train-continuous.ts
@@ -10,6 +10,8 @@ import { continuousDomainOf } from "./scale-axis-domain.js";
 import type { AxisInputs, AxisTraining } from "./scale-axis-types.js";
 import type { Advisory, PipelineWarning } from "./types.js";
 import { PipelineError } from "./types.js";
+import { maybeForceZeroForBars } from "./scale-axis-train-continuous-zero.js";
+import { pushContinuousTrainingWarnings } from "./scale-axis-train-continuous-warn.js";
 
 export function trainContinuousAxis(
   axis: "x" | "y",
@@ -19,16 +21,7 @@ export function trainContinuousAxis(
   advisories: Advisory[],
   warnings: PipelineWarning[],
 ): AxisTraining {
-  let zero = config?.zero;
-  if (inputs.barMeasure && type !== "time" && zero === undefined && config?.domain === undefined) {
-    zero = true;
-    advisories.push({
-      code: "zero-forced",
-      path: `scales.${axis}`,
-      chosen: "domain extended to include 0 (bars/areas measure from a zero baseline)",
-      howToOverride: `Set scales.${axis}.zero to false, or pin scales.${axis}.domain.`,
-    });
-  }
+  const zero = maybeForceZeroForBars(axis, inputs, config, type, advisories);
 
   const domain = continuousDomainOf(config, axis);
   const continuousConfig: ContinuousConfig = {
@@ -47,17 +40,6 @@ export function trainContinuousAxis(
     }
     throw error;
   }
-  if (training.empty) {
-    warnings.push({
-      code: "empty-domain",
-      message: `The ${axis} scale has no finite${type === "log" ? " positive" : ""} values; using a default domain.`,
-    });
-  }
-  if (training.nonPositive > 0) {
-    warnings.push({
-      code: "log-nonpositive",
-      message: `Removed ${training.nonPositive} non-positive value(s) from the ${axis} log scale (log10 is undefined at or below zero).`,
-    });
-  }
+  pushContinuousTrainingWarnings(axis, type, training, warnings);
   return { scale: training.scale, advisories, warnings };
 }

--- a/packages/core/src/pipeline/train-pipeline-scales-position-free.ts
+++ b/packages/core/src/pipeline/train-pipeline-scales-position-free.ts
@@ -1,0 +1,41 @@
+/**
+ * Per-panel free_x / free_y positional scale training.
+ */
+import type { PortableSpec } from "@ggsvelte/spec";
+
+import type { PositionScale } from "../scales/train.js";
+
+import { collectAxisInputs, trainAxis } from "./scale-training.js";
+import type { Advisory, LayerFrame, PipelineWarning } from "./types.js";
+
+export function trainFreePanelScales(input: {
+  scalesConfig: NonNullable<PortableSpec["scales"]>;
+  panelFrames: readonly (readonly LayerFrame[])[];
+  panelCount: number;
+  freeX: boolean;
+  freeY: boolean;
+  fixedX: PositionScale;
+  fixedY: PositionScale;
+  warnings: PipelineWarning[];
+}): { x: PositionScale; y: PositionScale }[] {
+  const { scalesConfig, panelFrames, panelCount, freeX, freeY, fixedX, fixedY, warnings } = input;
+
+  return Array.from({ length: panelCount }, (_, p) => {
+    let px = fixedX;
+    let py = fixedY;
+    const scratch: Advisory[] = [];
+    if (freeX) {
+      const inputs = collectAxisInputs("x", panelFrames[p]!, scalesConfig.x?.type, scratch);
+      const training = trainAxis("x", inputs, { ...scalesConfig.x, type: fixedX.type });
+      warnings.push(...training.warnings);
+      px = training.scale;
+    }
+    if (freeY) {
+      const inputs = collectAxisInputs("y", panelFrames[p]!, scalesConfig.y?.type, scratch);
+      const training = trainAxis("y", inputs, { ...scalesConfig.y, type: fixedY.type });
+      warnings.push(...training.warnings);
+      py = training.scale;
+    }
+    return { x: px, y: py };
+  });
+}

--- a/packages/core/src/pipeline/train-pipeline-scales-position.ts
+++ b/packages/core/src/pipeline/train-pipeline-scales-position.ts
@@ -8,6 +8,7 @@ import type { PositionScale } from "../scales/train.js";
 import type { FacetPanelDef } from "./facets.js";
 import { collectAxisInputs, trainAxis } from "./scale-training.js";
 import type { Advisory, LayerFrame, PipelineWarning } from "./types.js";
+import { trainFreePanelScales } from "./train-pipeline-scales-position-free.js";
 
 export interface TrainedPositionScales {
   xTraining: ReturnType<typeof trainAxis>;
@@ -37,23 +38,15 @@ export function trainPipelinePositionScales(input: {
   advisories.push(...xTraining.advisories, ...yTraining.advisories);
   warnings.push(...xTraining.warnings, ...yTraining.warnings);
 
-  const panelScales: { x: PositionScale; y: PositionScale }[] = facetPanels.map((_, p) => {
-    let px = xTraining.scale;
-    let py = yTraining.scale;
-    const scratch: Advisory[] = [];
-    if (freeX) {
-      const inputs = collectAxisInputs("x", panelFrames[p]!, scalesConfig.x?.type, scratch);
-      const training = trainAxis("x", inputs, { ...scalesConfig.x, type: xTraining.scale.type });
-      warnings.push(...training.warnings);
-      px = training.scale;
-    }
-    if (freeY) {
-      const inputs = collectAxisInputs("y", panelFrames[p]!, scalesConfig.y?.type, scratch);
-      const training = trainAxis("y", inputs, { ...scalesConfig.y, type: yTraining.scale.type });
-      warnings.push(...training.warnings);
-      py = training.scale;
-    }
-    return { x: px, y: py };
+  const panelScales = trainFreePanelScales({
+    scalesConfig,
+    panelFrames,
+    panelCount: facetPanels.length,
+    freeX,
+    freeY,
+    fixedX: xTraining.scale,
+    fixedY: yTraining.scale,
+    warnings,
   });
 
   return { xTraining, yTraining, panelScales, xInputs, yInputs, allFrames };

--- a/packages/core/tests/pipeline-build-candidates.test.ts
+++ b/packages/core/tests/pipeline-build-candidates.test.ts
@@ -281,3 +281,47 @@ describe("resolveOutlierContext", () => {
     ).toEqual({ outlierLocalRow: null, outlierSourceRow: null });
   });
 });
+
+describe("lineage represented-row filters", () => {
+  it("keeps rows whose band key matches the aggregate x output", async () => {
+    const { filterAggregateXRows } =
+      await import("../src/pipeline/build-candidates-lineage-filters.ts");
+    const { ColumnTable } = await import("../src/table.ts");
+    const table = ColumnTable.fromRows([
+      { g: "a", y: 1 },
+      { g: "b", y: 2 },
+      { g: "a", y: 3 },
+    ]);
+    expect(
+      filterAggregateXRows({
+        table,
+        field: "g",
+        outputX: "a",
+        baseRows: [0, 1, 2],
+      }),
+    ).toEqual([0, 2]);
+  });
+
+  it("filters bin membership with closed=right half-open intervals", async () => {
+    const { filterBinRepresentedRows } =
+      await import("../src/pipeline/build-candidates-lineage-filters.ts");
+    const { ColumnTable } = await import("../src/table.ts");
+    const table = ColumnTable.fromRows([{ x: 0.5 }, { x: 1.5 }, { x: 2.5 }, { x: 3.5 }]);
+    const frame = {
+      xmin: new Float64Array([0, 2]),
+      xmax: new Float64Array([2, 4]),
+      groups: new Uint32Array([0, 0]),
+      n: 2,
+      binding: { layer: { params: { closed: "right" } } },
+    } as never;
+    expect(
+      filterBinRepresentedRows({
+        frame,
+        table,
+        frameRow: 0,
+        field: "x",
+        baseRows: [0, 1, 2, 3],
+      }),
+    ).toEqual([0, 1]);
+  });
+});

--- a/packages/core/tests/pipeline-facets-unit.test.ts
+++ b/packages/core/tests/pipeline-facets-unit.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from "bun:test";
 
 import { PipelineError } from "../src/pipeline.ts";
 import { resolveFacet, SINGLE_PANEL } from "../src/pipeline/facets.ts";
+import { assertFacetForm, facetFreeFlags } from "../src/pipeline/facets-form.ts";
 import { ColumnTable } from "../src/table.ts";
 
 const table = ColumnTable.fromRows([
@@ -123,6 +124,25 @@ describe("resolveFacet — grid", () => {
     } catch (e) {
       expect(e).toBeInstanceOf(PipelineError);
       expect((e as PipelineError).code).toBe("facet-form-missing");
+    }
+  });
+});
+
+describe("facetFreeFlags / assertFacetForm", () => {
+  it("derives free_x and free_y from scales modes", () => {
+    expect(facetFreeFlags()).toEqual({ freeX: false, freeY: false });
+    expect(facetFreeFlags("free")).toEqual({ freeX: true, freeY: true });
+    expect(facetFreeFlags("free_x")).toEqual({ freeX: true, freeY: false });
+    expect(facetFreeFlags("free_y")).toEqual({ freeX: false, freeY: true });
+  });
+
+  it("throws facet-form-ambiguous when wrap mixes with grid fields", () => {
+    try {
+      assertFacetForm({ wrapField: "g", rowsField: "r", colsField: null });
+      expect.unreachable("should throw");
+    } catch (e) {
+      expect(e).toBeInstanceOf(PipelineError);
+      expect((e as PipelineError).code).toBe("facet-form-ambiguous");
     }
   });
 });

--- a/packages/core/tests/pipeline-geometry.test.ts
+++ b/packages/core/tests/pipeline-geometry.test.ts
@@ -607,3 +607,48 @@ describe("packFacetPanelPlacement", () => {
     expect(placement.x).toBe(20);
   });
 });
+
+describe("writeSmoothLineGeometry", () => {
+  it("writes one path offset per group and maps y into panel px", async () => {
+    const { writeSmoothLineGeometry } =
+      await import("../src/pipeline/geometry-smooth-line-write.ts");
+    const frame = {
+      binding: { color: { constant: "#abc", scaledConstant: null } },
+      xNumeric: new Float64Array([0, 1]),
+      yNumeric: new Float64Array([0, 1]),
+      xValues: null,
+      colorValues: null,
+      rowIndex: new Uint32Array([10, 11]),
+    } as never;
+    const fx = {
+      xScale: { type: "linear", normalize: (v: number) => v },
+      yScale: { type: "linear", normalize: (v: number) => v },
+      innerWidth: 100,
+      innerHeight: 50,
+    } as never;
+    const geom = writeSmoothLineGeometry({
+      frame,
+      fx,
+      color: null,
+      groupRows: [[0, 1]],
+    });
+    expect([...geom.pathOffsets]).toEqual([0, 2]);
+    expect([...geom.rowIndex]).toEqual([10, 11]);
+    expect(geom.positions[0]).toBe(0);
+    expect(geom.positions[1]).toBe(50);
+    expect(geom.positions[2]).toBe(100);
+    expect(geom.positions[3]).toBe(0);
+    expect(geom.strokes).toEqual(["#abc"]);
+  });
+});
+
+describe("areaGroupFillOf", () => {
+  it("uses the constant fill when no scaled fill is mapped", async () => {
+    const { areaGroupFillOf } = await import("../src/pipeline/geometry-paths-area-fill.ts");
+    const frame = {
+      binding: { fill: { constant: "#cde", scaledConstant: null } },
+      fillValues: null,
+    } as never;
+    expect(areaGroupFillOf(frame, null, [0])).toBe("#cde");
+  });
+});

--- a/packages/core/tests/pipeline-scale-training.test.ts
+++ b/packages/core/tests/pipeline-scale-training.test.ts
@@ -383,3 +383,31 @@ describe("scale training via runPipeline (regression anchors)", () => {
     }
   });
 });
+
+describe("maybeForceZeroForBars / pushContinuousTrainingWarnings", () => {
+  it("forces zero only for bar measures without an explicit domain", async () => {
+    const { maybeForceZeroForBars } =
+      await import("../src/pipeline/scale-axis-train-continuous-zero.ts");
+    const advisories: { code: string; path: string; chosen: string; howToOverride: string }[] = [];
+    const inputs = {
+      columns: [] as const,
+      numeric: [new Float64Array([1, 2])],
+      anyDiscrete: false,
+      allTemporal: false,
+      barMeasure: true,
+      evidence: "test",
+    };
+    const forced = maybeForceZeroForBars("y", inputs, undefined, "linear", advisories);
+    expect(forced).toBe(true);
+    expect(advisories.map((a) => a.code)).toContain("zero-forced");
+    expect(maybeForceZeroForBars("y", inputs, { domain: [0, 10] }, "linear", [])).toBeUndefined();
+  });
+
+  it("emits empty-domain and log-nonpositive warnings", async () => {
+    const { pushContinuousTrainingWarnings } =
+      await import("../src/pipeline/scale-axis-train-continuous-warn.ts");
+    const warnings: { code: string; message: string }[] = [];
+    pushContinuousTrainingWarnings("x", "log", { empty: true, nonPositive: 2 }, warnings);
+    expect(warnings.map((w) => w.code)).toEqual(["empty-domain", "log-nonpositive"]);
+  });
+});


### PR DESCRIPTION
## Summary
- Extract free-panel positional scale training, continuous zero-forcing and training warnings, and facet form validation/free-scale flags behind stable facades.
- Split smooth-line vertex write, area fill resolution, and aggregate/bin lineage row filters into pure helpers.
- Add characterization tests for the new seams (smooth geometry, area fill, facet free flags, zero force, lineage filters).

## Test plan
- [x] `bun test packages/core` (532 pass)
- [x] `bun run check`
- [x] `bun run knip`
- [x] `bun run lint:type-aware`
- [x] Codex review (`gpt-5.6-terra`) — PASS, no P1