### PR TITLE
fix(test): contention-tolerant timeout for the SSR hydration gate

### DIFF
--- a/packages/svelte/tests/release-matrix.test.ts
+++ b/packages/svelte/tests/release-matrix.test.ts
@@ -68,6 +68,13 @@ function drag(
 }
 
 describe("R-1/R0 release matrix", () => {
+  // 120s: the /__ggplot-ssr fetch transforms GGPlot's whole SSR module graph
+  // on the suite-shared Vite server, so under full-suite transform contention
+  // (three browsers, 150+ files) it can wait well past 30s on loaded runners.
+  // Its only observed failure mode is this timeout — the render itself is
+  // correct and takes ~10s in isolation. Eagerly warming the graph at server
+  // start is NOT safe: it races dep re-optimization and yields mixed Svelte
+  // server runtimes (lifecycle_outside_component).
   it("hydrates a real server-rendered GGPlot and attaches inspection events", async () => {
     const target = document.createElement("div");
     const response = await fetch("/__ggplot-ssr");
@@ -88,7 +95,7 @@ describe("R-1/R0 release matrix", () => {
 
     await cleanup();
     target.remove();
-  }, 30_000);
+  }, 120_000);
 
   it("keeps IDs and ARIA ownership unique across two interactive charts", async () => {
     const { container } = render(MultipleInteractivePlots);


### PR DESCRIPTION
The component check's SSR-hydration gate ("hydrates a real server-rendered GGPlot and attaches inspection events") times out intermittently at 30s — locally under full-suite load and on CI (it blocked PR #79 at 0f6fc96 until a rerun).

## Root cause
The /__ggplot-ssr fetch transforms GGPlot's **entire SSR module graph** on the suite-shared Vite dev server. Under full-suite transform contention (three browsers, 150+ test files, slower self-hosted runners since #150) that fetch can wait well past 30s. The render itself is correct and takes ~10s in isolation; the timeout is the only observed failure mode.

## Why not eager warm-up
Warming the SSR graph at server start was tried and is unsafe: it races Vite's lazy dep re-optimization and yields mixed Svelte server runtimes (dev-mode render throws `lifecycle_outside_component` / `context.function` null). The endpoint stays lazy and correct.

## Fix
Lift the per-test ceiling to 120s with a comment documenting the mechanism. Verified: 24/24 pass in isolation (10s); the timeout only bites when the shared server is saturated, which is exactly when the extra headroom is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
