### PR TITLE
fix(ci): run the /approve-visuals gate on a GitHub-hosted runner

### DIFF
--- a/.github/workflows/vr-compare.yml
+++ b/.github/workflows/vr-compare.yml
@@ -144,7 +144,10 @@ jobs:
       github.event_name == 'issue_comment' &&
       github.event.issue.pull_request &&
       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
-    runs-on: [self-hosted, ggsvelte]
+    # GitHub-hosted: this 5s job needs the `gh` CLI (preinstalled on
+    # ubuntu-latest, absent on the self-hosted ggsvelte runners) and runs no
+    # checked-out code. vr-approve.yml already runs on ubuntu-latest.
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read # resolve the PR head via `gh api` (read-only)


### PR DESCRIPTION
Every real `/approve-visuals` command now fails at the parse gate with exit 127 — `gh: command not found` ([example run](https://github.com/ljodea/ggsvelte/actions/runs/29529511488)).

## Root cause
#150 routed the VR Compare workflow's jobs to the self-hosted `ggsvelte` runners, but the `approve-gate` job resolves the PR head via `gh api`, and the GitHub CLI is not installed on those runners. The other two jobs are unaffected: `compare` and `approve-regenerate` use only actions and checked-in tooling.

## Fix
Pin `approve-gate` back to `ubuntu-latest` (gh preinstalled). It is a 5-second read-only API lookup that runs no checked-out code, and `vr-approve.yml` — the trusted half of the same flow — already runs on `ubuntu-latest`.

Unblocks the baseline refresh for #79.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
