### PR TITLE
fix: gate workflow linting on pre-push when .github/ changes

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,5 +1,7 @@
-# actionlint config (Go CLI). The npm wasm runner in scripts/actionlint.ts
-# cannot load this file; it filters the same custom-label findings instead.
+# actionlint config (Go CLI). The npm wasm runner (scripts/actionlint.ts) cannot
+# load this file as config, but it *parses* self-hosted-runner.labels from here
+# and suppresses the matching "label is unknown" findings — single source of
+# truth for custom runner labels. Add/remove labels only in this file.
 self-hosted-runner:
   labels:
     - ggsvelte

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -128,3 +128,23 @@ repos:
         pass_filenames: false
         always_run: true
         stages: [pre-push]
+
+      # Workflow lint: only when .github/** is in the push set (or --all-files).
+      # actionlint uses the lockfile wasm build; skips gracefully if it cannot
+      # load. zizmor is an optional uv tool — skip if missing. CI still runs
+      # both in the dedicated actions-security job (contract, not optional).
+      - id: actionlint
+        name: actionlint (.github/workflows)
+        entry: bun run lint:actions
+        language: system
+        pass_filenames: false
+        files: ^\.github/
+        stages: [pre-push]
+
+      - id: zizmor
+        name: zizmor (.github/workflows security)
+        entry: scripts/guards/zizmor-or-skip.sh
+        language: system
+        pass_filenames: false
+        files: ^\.github/
+        stages: [pre-push]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,8 +127,8 @@ upstream, `.md`/`.yaml`/`.svelte` can fold back into oxfmt (`.oxfmtrc.json`
 | `Rscript packages/core/tests/fixtures/*/generate.R`   | regenerate the ggplot2-parity fixtures (grouping, stats/positions; needs R + ggplot2)                                                   |
 | `bun run knip`                                        | unused files/exports/dependencies                                                                                                       |
 | `bun run lint:package`                                | publint + attw (esm-only profile) over built packages — build first                                                                     |
-| `bun run lint:actions`                                | actionlint (wasm) over `.github/workflows`                                                                                              |
-| `bun run lint:actions:security`                       | zizmor over `.github/workflows` (needs `uv tool install zizmor`)                                                                        |
+| `bun run lint:actions`                                | actionlint (wasm) over `.github/workflows` (also pre-push when `.github/**` changes; skips if wasm cannot load)                         |
+| `bun run lint:actions:security`                       | zizmor over `.github/workflows` (needs `uv tool install zizmor`; pre-push skips if missing)                                             |
 | `bun run test:spikes`                                 | retired M0a browser/ssr spike suites (vitest 4 browser mode)                                                                            |
 | `cd spikes/pure && bun test`                          | retired M0a pure spike suites                                                                                                           |
 | `pre-commit run --all-files`                          | everything the pre-commit stage runs                                                                                                    |

--- a/scripts/actionlint.test.ts
+++ b/scripts/actionlint.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { buildKnownFalsePositives, parseSelfHostedLabels } from "./actionlint.ts";
+
+const root = join(import.meta.dir, "..");
+const read = (path: string) => readFileSync(join(root, path), "utf8");
+
+describe("actionlint self-hosted label config", () => {
+  it("parses labels from actionlint.yaml list form", () => {
+    const yaml = `self-hosted-runner:
+  labels:
+    - ggsvelte
+    - "linux-arm"
+`;
+    expect(parseSelfHostedLabels(yaml)).toEqual(["ggsvelte", "linux-arm"]);
+  });
+
+  it("ignores comments and stops at the next key", () => {
+    const yaml = `
+self-hosted-runner:
+  labels:
+    # primary label
+    - ggsvelte
+  other: true
+labels:
+  - not-under-self-hosted
+`;
+    expect(parseSelfHostedLabels(yaml)).toEqual(["ggsvelte"]);
+  });
+
+  it("builds wasm suppressions from labels plus the vars gap", () => {
+    const patterns = buildKnownFalsePositives(["ggsvelte"]);
+    expect(patterns.some((re) => re.test('undefined variable "vars"'))).toBe(true);
+    expect(patterns.some((re) => re.test('label "ggsvelte" is unknown'))).toBe(true);
+    expect(patterns.some((re) => re.test('label "other" is unknown'))).toBe(false);
+  });
+
+  it("keeps .github/actionlint.yaml labels wired into the wasm runner", () => {
+    // Drift guard: labels live only in the Go CLI config file; the wasm
+    // runner must derive suppressions from that file (not a parallel list).
+    const yaml = read(".github/actionlint.yaml");
+    const labels = parseSelfHostedLabels(yaml);
+    expect(labels.length).toBeGreaterThan(0);
+    expect(labels).toContain("ggsvelte");
+
+    const runner = read("scripts/actionlint.ts");
+    expect(runner).toContain("parseSelfHostedLabels");
+    expect(runner).toContain(".github/actionlint.yaml");
+    // Hard-coded label list would reintroduce the drift the issue filed.
+    expect(runner).not.toMatch(/KNOWN_FALSE_POSITIVES\s*=\s*\[/);
+  });
+});
+
+describe("workflow lint local gates (issue #155)", () => {
+  it("wires actionlint into the pre-push stage, gated on .github/", () => {
+    const hooks = read(".pre-commit-config.yaml");
+    expect(hooks).toMatch(/id:\s*actionlint/);
+    expect(hooks).toContain("bun run lint:actions");
+    expect(hooks).toMatch(/files:\s*\^\\.github\//);
+    // actionlint hook must be pre-push, not pre-commit (heavier, CI-parity).
+    const actionlintBlock = hooks.slice(hooks.indexOf("id: actionlint"));
+    const nextHook = actionlintBlock.indexOf("\n      - id:");
+    const block = nextHook === -1 ? actionlintBlock : actionlintBlock.slice(0, nextHook);
+    expect(block).toContain("stages: [pre-push]");
+  });
+
+  it("wires zizmor into the pre-push stage with a graceful skip wrapper", () => {
+    const hooks = read(".pre-commit-config.yaml");
+    expect(hooks).toMatch(/id:\s*zizmor/);
+    expect(hooks).toContain("scripts/guards/zizmor-or-skip.sh");
+    const zizmorBlock = hooks.slice(hooks.indexOf("id: zizmor"));
+    const nextHook = zizmorBlock.indexOf("\n      - id:");
+    const block = nextHook === -1 ? zizmorBlock : zizmorBlock.slice(0, nextHook);
+    expect(block).toContain("stages: [pre-push]");
+    expect(block).toMatch(/files:\s*\^\\.github\//);
+
+    const guard = read("scripts/guards/zizmor-or-skip.sh");
+    expect(guard).toContain("command -v zizmor");
+    expect(guard).toContain("skipping local gate");
+  });
+
+  it("keeps package scripts for actionlint and zizmor", () => {
+    const pkg = read("package.json");
+    expect(pkg).toContain('"lint:actions": "bun scripts/actionlint.ts"');
+    expect(pkg).toContain('"lint:actions:security": "zizmor .github/workflows"');
+  });
+});

--- a/scripts/actionlint.ts
+++ b/scripts/actionlint.ts
@@ -6,62 +6,161 @@
  * vs the Go binary: the wasm build cannot shell out to shellcheck/pyflakes,
  * so `run:` script contents get actionlint's own checks only.
  *
+ * Config parity with the Go CLI: self-hosted runner labels are read from
+ * `.github/actionlint.yaml` (the Go CLI loads that file; the wasm build has no
+ * config hook). Keep labels only in that yaml — this runner derives the
+ * "label is unknown" suppressions from it so the two cannot drift.
+ *
  * Usage: bun scripts/actionlint.ts [files...]
  */
 import { readFile, readdir } from "node:fs/promises";
 import { join } from "node:path";
-import { createLinter } from "actionlint";
 
-const explicit = process.argv.slice(2);
-let files = explicit;
-if (files.length === 0) {
-  const dir = ".github/workflows";
-  try {
-    files = (await readdir(dir))
-      .filter((f) => f.endsWith(".yml") || f.endsWith(".yaml"))
-      .map((f) => join(dir, f));
-  } catch {
-    console.log("actionlint: no .github/workflows directory — nothing to lint.");
-    process.exit(0);
-  }
-}
+const ACTIONLINT_YAML = ".github/actionlint.yaml";
 
-if (files.length === 0) {
-  console.log("actionlint: no workflow files found — nothing to lint.");
-  process.exit(0);
-}
-
-// The npm wasm build (2.0.6) lags the Go actionlint and does not know the
-// `vars` context (GitHub "configuration variables", valid since 2022; used by
-// release.yml's NPM_PUBLISH_ENABLED gate). Filter that one false positive.
-// Remove this when the npm package's checker recognizes `vars`.
-//
-// Custom self-hosted label `ggsvelte` is declared in .github/actionlint.yaml
-// for the Go CLI; the wasm package has no config hook, so filter the noise.
-const KNOWN_FALSE_POSITIVES = [/undefined variable "vars"/, /label "ggsvelte" is unknown/];
-
-const lint = await createLinter();
-let findings = 0;
-let suppressed = 0;
-for (const file of files) {
-  const source = await readFile(file, "utf8");
-  for (const r of lint(source, file)) {
-    if (KNOWN_FALSE_POSITIVES.some((re) => re.test(r.message))) {
-      suppressed += 1;
+/** Parse `self-hosted-runner.labels` from actionlint.yaml without a YAML dep. */
+export function parseSelfHostedLabels(yaml: string): string[] {
+  const labels: string[] = [];
+  let inSelfHosted = false;
+  let inLabels = false;
+  for (const raw of yaml.split("\n")) {
+    const line = raw.replace(/\r$/, "");
+    if (/^self-hosted-runner:\s*(#.*)?$/.test(line)) {
+      inSelfHosted = true;
+      inLabels = false;
       continue;
     }
-    findings += 1;
-    console.error(`${r.file}:${r.line}:${r.column}: ${r.message} [${r.kind}]`);
+    // A new top-level key ends the self-hosted-runner block.
+    if (inSelfHosted && /^\S/.test(line) && line.trim() !== "" && !line.startsWith("#")) {
+      inSelfHosted = false;
+      inLabels = false;
+    }
+    if (!inSelfHosted) continue;
+    if (/^\s+labels:\s*(#.*)?$/.test(line)) {
+      inLabels = true;
+      continue;
+    }
+    if (!inLabels) continue;
+    const item = line.match(/^\s+-\s+(.+?)\s*$/);
+    if (item) {
+      labels.push(item[1]!.replaceAll(/^['"]|['"]$/g, ""));
+      continue;
+    }
+    // Blank / comment lines stay inside the list; any other key ends it.
+    if (line.trim() === "" || /^\s*#/.test(line)) continue;
+    inLabels = false;
   }
-}
-if (suppressed > 0) {
-  console.log(
-    `actionlint: ${suppressed} known-false-positive finding(s) suppressed (see KNOWN_FALSE_POSITIVES).`,
-  );
+  return labels;
 }
 
-if (findings > 0) {
-  console.error(`actionlint: ${findings} finding(s) in ${files.length} file(s).`);
-  process.exit(1);
+/** Build the message-filter list used against wasm findings. */
+export function buildKnownFalsePositives(selfHostedLabels: string[]): RegExp[] {
+  // The npm wasm build (2.0.6) lags the Go actionlint and does not know the
+  // `vars` context (GitHub "configuration variables", valid since 2022; used by
+  // release.yml's NPM_PUBLISH_ENABLED gate). Filter that one false positive.
+  // Remove this when the npm package's checker recognizes `vars`.
+  const patterns: RegExp[] = [/undefined variable "vars"/];
+  for (const label of selfHostedLabels) {
+    // Escape regex metacharacters in labels so "ggsvelte" stays literal.
+    const escaped = label.replaceAll(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    patterns.push(new RegExp(`label "${escaped}" is unknown`));
+  }
+  return patterns;
 }
-console.log(`actionlint: ${files.length} workflow file(s) clean.`);
+
+async function loadSelfHostedLabels(): Promise<string[]> {
+  try {
+    const yaml = await readFile(ACTIONLINT_YAML, "utf8");
+    return parseSelfHostedLabels(yaml);
+  } catch {
+    console.warn(
+      `actionlint: could not read ${ACTIONLINT_YAML} — no self-hosted labels suppressed.`,
+    );
+    return [];
+  }
+}
+
+async function main(): Promise<void> {
+  const explicit = process.argv.slice(2);
+  let files = explicit;
+  if (files.length === 0) {
+    const dir = ".github/workflows";
+    try {
+      files = (await readdir(dir))
+        .filter((f) => f.endsWith(".yml") || f.endsWith(".yaml"))
+        .map((f) => join(dir, f));
+    } catch {
+      console.log("actionlint: no .github/workflows directory — nothing to lint.");
+      process.exit(0);
+    }
+  }
+
+  if (files.length === 0) {
+    console.log("actionlint: no workflow files found — nothing to lint.");
+    process.exit(0);
+  }
+
+  // Graceful skip when the wasm binding fails to load (arch mismatch, missing
+  // native bits, etc.). CI's actions-security job still enforces actionlint.
+  let createLinter: typeof import("actionlint").createLinter;
+  try {
+    ({ createLinter } = await import("actionlint"));
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(
+      `actionlint: wasm package failed to load — skipping local gate (${msg}). CI actions-security still enforces this.`,
+    );
+    process.exit(0);
+  }
+
+  let lint: (
+    source: string,
+    path: string,
+  ) => Iterable<{
+    file: string;
+    line: number;
+    column: number;
+    message: string;
+    kind: string;
+  }>;
+  try {
+    lint = await createLinter();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(
+      `actionlint: createLinter failed — skipping local gate (${msg}). CI actions-security still enforces this.`,
+    );
+    process.exit(0);
+  }
+
+  const knownFalsePositives = buildKnownFalsePositives(await loadSelfHostedLabels());
+
+  let findings = 0;
+  let suppressed = 0;
+  for (const file of files) {
+    const source = await readFile(file, "utf8");
+    for (const r of lint(source, file)) {
+      if (knownFalsePositives.some((re) => re.test(r.message))) {
+        suppressed += 1;
+        continue;
+      }
+      findings += 1;
+      console.error(`${r.file}:${r.line}:${r.column}: ${r.message} [${r.kind}]`);
+    }
+  }
+  if (suppressed > 0) {
+    console.log(
+      `actionlint: ${suppressed} known-false-positive finding(s) suppressed (from ${ACTIONLINT_YAML} labels + wasm gaps).`,
+    );
+  }
+
+  if (findings > 0) {
+    console.error(`actionlint: ${findings} finding(s) in ${files.length} file(s).`);
+    process.exit(1);
+  }
+  console.log(`actionlint: ${files.length} workflow file(s) clean.`);
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/scripts/guards/zizmor-or-skip.sh
+++ b/scripts/guards/zizmor-or-skip.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# pre-push guard: run zizmor over .github/workflows when installed; skip
+# gracefully when the binary is missing so developers without the uv tool
+# are not blocked. CI's actions-security job always runs a pinned zizmor.
+set -euo pipefail
+
+if ! command -v zizmor >/dev/null 2>&1; then
+  echo "zizmor: not on PATH — skipping local gate (install via \`uv tool install zizmor\`). CI actions-security still enforces this."
+  exit 0
+fi
+
+exec zizmor .github/workflows


### PR DESCRIPTION
## Summary

- Wire `actionlint` and `zizmor` into the pre-push stage, gated on `^\.github/` so only workflow-related pushes pay the cost.
- Graceful local skips: wasm load failure for actionlint; missing `zizmor` binary for the security audit. CI's `actions-security` job remains the hard contract.
- Single source of truth for self-hosted runner labels: `scripts/actionlint.ts` parses `.github/actionlint.yaml` instead of duplicating `ggsvelte` in a hard-coded filter list (fixes the config-drift risk from #155).

## Test plan

- [x] `bun test scripts/actionlint.test.ts` (label parser, drift guard, hook wiring)
- [x] `bun run lint:actions` clean
- [x] `pre-commit run actionlint --all-files --hook-stage pre-push` passes
- [x] `pre-commit run zizmor --all-files --hook-stage pre-push` passes (skip path when zizmor not installed)
- [ ] CI `checks` + `actions-security` green on this PR

Closes #155