### PR TITLE
fix: keep actionlint load failures fatal in CI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,7 +127,7 @@ upstream, `.md`/`.yaml`/`.svelte` can fold back into oxfmt (`.oxfmtrc.json`
 | `Rscript packages/core/tests/fixtures/*/generate.R`   | regenerate the ggplot2-parity fixtures (grouping, stats/positions; needs R + ggplot2)                                                   |
 | `bun run knip`                                        | unused files/exports/dependencies                                                                                                       |
 | `bun run lint:package`                                | publint + attw (esm-only profile) over built packages — build first                                                                     |
-| `bun run lint:actions`                                | actionlint (wasm) over `.github/workflows` (also pre-push when `.github/**` changes; skips if wasm cannot load)                         |
+| `bun run lint:actions`                                | actionlint (wasm) over `.github/workflows` (also pre-push when `.github/**` changes; local soft-skip if wasm cannot load, fatal in CI)  |
 | `bun run lint:actions:security`                       | zizmor over `.github/workflows` (needs `uv tool install zizmor`; pre-push skips if missing)                                             |
 | `bun run test:spikes`                                 | retired M0a browser/ssr spike suites (vitest 4 browser mode)                                                                            |
 | `cd spikes/pure && bun test`                          | retired M0a pure spike suites                                                                                                           |

--- a/scripts/actionlint.test.ts
+++ b/scripts/actionlint.test.ts
@@ -51,6 +51,10 @@ labels:
     expect(parseYamlListScalar("'it''s fine'")).toBe("it's fine");
     expect(parseYamlListScalar("foo#notcomment")).toBe("foo#notcomment");
     expect(parseYamlListScalar('"a\\"b"')).toBe('a"b');
+    // Codex P2 on #157: double-quoted YAML escapes must decode, not strip `\`.
+    expect(parseYamlListScalar('"runner\\u002darm"')).toBe("runner-arm");
+    expect(parseYamlListScalar('"runner\\x2darm"')).toBe("runner-arm");
+    expect(parseYamlListScalar('"tab\\tsep"')).toBe("tab\tsep");
   });
 
   it("builds wasm suppressions from labels plus the vars gap", () => {

--- a/scripts/actionlint.test.ts
+++ b/scripts/actionlint.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { buildKnownFalsePositives, parseSelfHostedLabels } from "./actionlint.ts";
+import {
+  allowSoftSkipLoadFailure,
+  buildKnownFalsePositives,
+  parseSelfHostedLabels,
+  parseYamlListScalar,
+} from "./actionlint.ts";
 
 const root = join(import.meta.dir, "..");
 const read = (path: string) => readFileSync(join(root, path), "utf8");
@@ -29,6 +34,25 @@ labels:
     expect(parseSelfHostedLabels(yaml)).toEqual(["ggsvelte"]);
   });
 
+  it("strips unquoted inline comments from label values", () => {
+    // Codex P2: Go CLI reads `ggsvelte`; bare parser must not keep the comment.
+    const yaml = `self-hosted-runner:
+  labels:
+    - ggsvelte # primary pool
+    - "keep # hash"
+    - 'also # quoted'
+`;
+    expect(parseSelfHostedLabels(yaml)).toEqual(["ggsvelte", "keep # hash", "also # quoted"]);
+  });
+
+  it("parseYamlListScalar handles quotes, escapes, and plain comments", () => {
+    expect(parseYamlListScalar("ggsvelte # primary pool")).toBe("ggsvelte");
+    expect(parseYamlListScalar('"ggsvelte # literal"')).toBe("ggsvelte # literal");
+    expect(parseYamlListScalar("'it''s fine'")).toBe("it's fine");
+    expect(parseYamlListScalar("foo#notcomment")).toBe("foo#notcomment");
+    expect(parseYamlListScalar('"a\\"b"')).toBe('a"b');
+  });
+
   it("builds wasm suppressions from labels plus the vars gap", () => {
     const patterns = buildKnownFalsePositives(["ggsvelte"]);
     expect(patterns.some((re) => re.test('undefined variable "vars"'))).toBe(true);
@@ -49,6 +73,23 @@ labels:
     expect(runner).toContain(".github/actionlint.yaml");
     // Hard-coded label list would reintroduce the drift the issue filed.
     expect(runner).not.toMatch(/KNOWN_FALSE_POSITIVES\s*=\s*\[/);
+  });
+});
+
+describe("actionlint load-failure policy (Codex P1)", () => {
+  it("soft-skips only outside CI", () => {
+    expect(allowSoftSkipLoadFailure({})).toBe(true);
+    expect(allowSoftSkipLoadFailure({ CI: "true" })).toBe(false);
+    expect(allowSoftSkipLoadFailure({ GITHUB_ACTIONS: "true" })).toBe(false);
+    expect(allowSoftSkipLoadFailure({ CI: "true", GITHUB_ACTIONS: "true" })).toBe(false);
+    // Explicit non-true values (e.g. local shells exporting CI=) still allow skip.
+    expect(allowSoftSkipLoadFailure({ CI: "1" })).toBe(true);
+  });
+
+  it("documents fatal CI path in the runner source", () => {
+    const runner = read("scripts/actionlint.ts");
+    expect(runner).toContain("allowSoftSkipLoadFailure");
+    expect(runner).toContain("process.exit(1)");
   });
 });
 

--- a/scripts/actionlint.ts
+++ b/scripts/actionlint.ts
@@ -44,13 +44,65 @@ export function parseYamlListScalar(raw: string): string {
     let out = "";
     for (let i = 1; i < s.length; i++) {
       const ch = s[i]!;
-      if (ch === "\\" && i + 1 < s.length) {
-        out += s[i + 1]!;
+      if (ch === '"') return out;
+      if (ch !== "\\" || i + 1 >= s.length) {
+        out += ch;
+        continue;
+      }
+      // YAML double-quoted escapes (subset sufficient for label scalars).
+      const next = s[i + 1]!;
+      const simple: Record<string, string> = {
+        "0": "\0",
+        a: "\u0007",
+        b: "\b",
+        t: "\t",
+        n: "\n",
+        v: "\v",
+        f: "\f",
+        r: "\r",
+        e: "\u001B",
+        " ": " ",
+        '"': '"',
+        "/": "/",
+        "\\": "\\",
+        N: "\u0085",
+        _: "\u00A0",
+        L: "\u2028",
+        P: "\u2029",
+      };
+      if (next in simple) {
+        out += simple[next]!;
         i += 1;
         continue;
       }
-      if (ch === '"') return out;
-      out += ch;
+      if (next === "x" && i + 3 < s.length) {
+        const hex = s.slice(i + 2, i + 4);
+        if (/^[0-9a-fA-F]{2}$/.test(hex)) {
+          out += String.fromCodePoint(Number.parseInt(hex, 16));
+          i += 3;
+          continue;
+        }
+      }
+      if (next === "u" && i + 5 < s.length) {
+        const hex = s.slice(i + 2, i + 6);
+        if (/^[0-9a-fA-F]{4}$/.test(hex)) {
+          out += String.fromCodePoint(Number.parseInt(hex, 16));
+          i += 5;
+          continue;
+        }
+      }
+      if (next === "U" && i + 9 < s.length) {
+        const hex = s.slice(i + 2, i + 10);
+        if (/^[0-9a-fA-F]{8}$/.test(hex)) {
+          out += String.fromCodePoint(Number.parseInt(hex, 16));
+          i += 9;
+          continue;
+        }
+      }
+      // Unknown escape: keep the escapee literally (YAML rejects these; we
+      // stay permissive so a bad config still yields a stable suppression).
+      out += next;
+      i += 1;
     }
     return out;
   }

--- a/scripts/actionlint.ts
+++ b/scripts/actionlint.ts
@@ -11,12 +11,76 @@
  * config hook). Keep labels only in that yaml — this runner derives the
  * "label is unknown" suppressions from it so the two cannot drift.
  *
+ * Load/init failures: fatal under CI (`CI` / `GITHUB_ACTIONS`), soft-skip only
+ * on local machines (arch mismatch, missing wasm). The pre-push hook and the
+ * required `actions-security` job both call this script; CI must never green
+ * on a silent skip.
+ *
  * Usage: bun scripts/actionlint.ts [files...]
  */
 import { readFile, readdir } from "node:fs/promises";
 import { join } from "node:path";
 
 const ACTIONLINT_YAML = ".github/actionlint.yaml";
+
+/**
+ * Soft-skip wasm load failures only outside CI. GitHub Actions sets both
+ * `CI=true` and `GITHUB_ACTIONS=true`; local pre-push has neither.
+ */
+export function allowSoftSkipLoadFailure(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env.CI !== "true" && env.GITHUB_ACTIONS !== "true";
+}
+
+/**
+ * Parse a YAML list-item scalar value (the part after `- `).
+ * Strips unquoted inline comments (`ggsvelte # pool` → `ggsvelte`) while
+ * keeping `#` inside quotes (`"ggsvelte # literal"` → `ggsvelte # literal`).
+ */
+export function parseYamlListScalar(raw: string): string {
+  const s = raw.trim();
+  if (s.length === 0) return "";
+
+  if (s.startsWith('"')) {
+    let out = "";
+    for (let i = 1; i < s.length; i++) {
+      const ch = s[i]!;
+      if (ch === "\\" && i + 1 < s.length) {
+        out += s[i + 1]!;
+        i += 1;
+        continue;
+      }
+      if (ch === '"') return out;
+      out += ch;
+    }
+    return out;
+  }
+
+  if (s.startsWith("'")) {
+    // YAML single-quoted: '' is an escaped single quote.
+    let out = "";
+    for (let i = 1; i < s.length; i++) {
+      const ch = s[i]!;
+      if (ch === "'") {
+        if (s[i + 1] === "'") {
+          out += "'";
+          i += 1;
+          continue;
+        }
+        return out;
+      }
+      out += ch;
+    }
+    return out;
+  }
+
+  // Plain scalar: `#` starts a comment only when preceded by whitespace.
+  for (let i = 0; i < s.length; i++) {
+    if (s[i] === "#" && (i === 0 || /\s/.test(s[i - 1]!))) {
+      return s.slice(0, i).trimEnd();
+    }
+  }
+  return s;
+}
 
 /** Parse `self-hosted-runner.labels` from actionlint.yaml without a YAML dep. */
 export function parseSelfHostedLabels(yaml: string): string[] {
@@ -43,7 +107,8 @@ export function parseSelfHostedLabels(yaml: string): string[] {
     if (!inLabels) continue;
     const item = line.match(/^\s+-\s+(.+?)\s*$/);
     if (item) {
-      labels.push(item[1]!.replaceAll(/^['"]|['"]$/g, ""));
+      const label = parseYamlListScalar(item[1]!);
+      if (label.length > 0) labels.push(label);
       continue;
     }
     // Blank / comment lines stay inside the list; any other key ends it.
@@ -100,17 +165,21 @@ async function main(): Promise<void> {
     process.exit(0);
   }
 
-  // Graceful skip when the wasm binding fails to load (arch mismatch, missing
-  // native bits, etc.). CI's actions-security job still enforces actionlint.
+  // Local-only soft-skip when the wasm binding fails to load (arch mismatch,
+  // missing native bits). Under CI the same failure is fatal so the required
+  // actions-security job cannot green without running the linter.
+  const softSkip = allowSoftSkipLoadFailure();
   let createLinter: typeof import("actionlint").createLinter;
   try {
     ({ createLinter } = await import("actionlint"));
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    console.warn(
-      `actionlint: wasm package failed to load — skipping local gate (${msg}). CI actions-security still enforces this.`,
-    );
-    process.exit(0);
+    if (softSkip) {
+      console.warn(`actionlint: wasm package failed to load — skipping local gate (${msg}).`);
+      process.exit(0);
+    }
+    console.error(`actionlint: wasm package failed to load (${msg}).`);
+    process.exit(1);
   }
 
   let lint: (
@@ -127,10 +196,12 @@ async function main(): Promise<void> {
     lint = await createLinter();
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    console.warn(
-      `actionlint: createLinter failed — skipping local gate (${msg}). CI actions-security still enforces this.`,
-    );
-    process.exit(0);
+    if (softSkip) {
+      console.warn(`actionlint: createLinter failed — skipping local gate (${msg}).`);
+      process.exit(0);
+    }
+    console.error(`actionlint: createLinter failed (${msg}).`);
+    process.exit(1);
   }
 
   const knownFalsePositives = buildKnownFalsePositives(await loadSelfHostedLabels());


### PR DESCRIPTION
## Summary

Follow-up to post-merge Codex review on #156:

- **P1 (valid):** wasm load/init failures soft-skipped everywhere, including CI's `actions-security` job which calls the same `bun run lint:actions`. Soft-skip now only when neither `CI` nor `GITHUB_ACTIONS` is `true`.
- **P2 (valid):** unquoted inline comments on labels (`- ggsvelte # pool`) were kept in the suppression pattern. Parser now matches YAML plain-scalar comment rules and quoted `#` literals.

## Test plan

- [x] `bun test scripts/actionlint.test.ts`
- [x] `bun run lint:actions`
- [x] `bun run lint:type-aware`