### PR TITLE
fix(ci): stop interaction-perf wall-clock flakes from blocking merges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,8 +191,6 @@ jobs:
         run: BASE_PATH=/ggsvelte bun run build:docs
       - name: interaction and safe-playground accessibility journeys
         run: bun run test:visual -- interaction-accessibility.spec.ts playground.spec.ts
-      - name: interaction performance p50/p95 gate
-        run: bun run test:interaction-perf
       - name: upload browser traces, screenshots, and reports on failure
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -203,7 +201,52 @@ jobs:
             spikes/browser/test-results/
             tests/visual/test-results/
             tests/visual/playwright-report/
-            tests/performance/test-results/
+          if-no-files-found: ignore
+          retention-days: 7
+
+  # Informational only — not a required status check.
+  # Absolute wall-clock p50/p95 budgets are noisy on the shared self-hosted
+  # host (4 concurrent runners on 8 vCPU). Keeping them out of `component`
+  # stops timing flakes from blocking merges while still surfacing regressions
+  # as a dedicated red check. Hard gate remains on `run-bench` PRs via bench.yml.
+  interaction-perf:
+    name: interaction-perf (p50/p95, informational)
+    needs: [component]
+    runs-on: [self-hosted, ggsvelte]
+    env:
+      HOME: /root
+    container:
+      image: mcr.microsoft.com/playwright:v1.61.1-noble
+    defaults:
+      run:
+        shell: bash
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: install unzip (playwright image lacks it; setup-bun needs it)
+        run: apt-get update && apt-get install -y --no-install-recommends unzip
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.3.14
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.bun/install/cache
+          key: bun-container-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: bun-container-${{ runner.os }}-
+      - run: bun install --frozen-lockfile
+      - name: build packages and docs for interaction performance fixtures
+        run: bun run build && BASE_PATH=/ggsvelte bun run build:docs
+      - name: interaction performance p50/p95 gate
+        run: bun run test:interaction-perf
+      - name: upload interaction-perf failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: interaction-perf-failure-artifacts
+          path: tests/performance/test-results/
           if-no-files-found: ignore
           retention-days: 7
 

--- a/benchmarks/interaction-budgets.json
+++ b/benchmarks/interaction-budgets.json
@@ -1,6 +1,6 @@
 {
-  "$comment": "Pinned Chromium interaction gates. R0 inspection retains its 50/500 x 5 dispatch gate; R2 measures 100k legend navigation and linked propagation; R3 measures filter-to-pipeline and precise-bounds apply latency while independently asserting exact commit counts.",
-  "version": 3,
+  "$comment": "Pinned Chromium interaction gates. R0 inspection retains its 50/500 x 5 dispatch gate; R2 measures 100k legend navigation and linked propagation; R3 measures filter-to-pipeline and precise-bounds apply latency while independently asserting exact commit counts. R3 filter ops use warmup + n>=20 so p95 is a real percentile (n=8 made p95 == max and failed under multi-runner host load).",
+  "version": 4,
   "warmupOperations": 50,
   "operationsPerSample": 500,
   "samples": 5,
@@ -10,7 +10,8 @@
   "legendSamples": 3,
   "legendNavigationP95Ms": 8,
   "threeViewPropagationP95Ms": 50,
-  "r3LegendFilterOperations": 8,
+  "r3LegendFilterWarmupOperations": 3,
+  "r3LegendFilterOperations": 20,
   "r3LegendFilterCommitP95Ms": 320,
   "r3SelectionApplyMs": 100,
   "r3ZoomApplyMs": 100

--- a/scripts/release-wiring.test.ts
+++ b/scripts/release-wiring.test.ts
@@ -23,13 +23,22 @@ describe("R0 release wiring", () => {
   it("runs the Playwright interaction performance gate with benchmark budgets", () => {
     const ci = read(".github/workflows/ci.yml");
     const bench = read(".github/workflows/bench.yml");
-    const componentJob = ci.slice(ci.indexOf("  component:"), ci.indexOf("\n  build:"));
+    const componentJob = ci.slice(ci.indexOf("  component:"), ci.indexOf("\n  interaction-perf:"));
+    const interactionPerfJob = ci.slice(
+      ci.indexOf("  interaction-perf:"),
+      ci.indexOf("\n  build:"),
+    );
     expect(ci).toContain("mcr.microsoft.com/playwright:v1.61.1-noble");
     expect(ci).toContain("HOME: /root");
     expect(componentJob).toContain("name: build all packages for browser and docs targets");
     expect(componentJob).toContain("run: bun run build");
-    expect(ci).toContain("bun run test:interaction-perf");
-    expect(ci).toContain("interaction-accessibility.spec.ts");
+    // Absolute wall-clock gates stay out of the required `component` check
+    // so multi-runner host noise cannot block merges (issue #154).
+    expect(componentJob).not.toContain("bun run test:interaction-perf");
+    expect(componentJob).toContain("interaction-accessibility.spec.ts");
+    expect(interactionPerfJob).toContain("bun run test:interaction-perf");
+    expect(interactionPerfJob).toContain("needs: [component]");
+    expect(interactionPerfJob).toContain("informational");
     expect(bench).toContain("mcr.microsoft.com/playwright:v1.61.1-noble");
     expect(bench).toContain("bun run test:interaction-perf");
     expect(read("package.json")).toContain('"test:interaction-perf"');

--- a/tests/performance/interaction.spec.ts
+++ b/tests/performance/interaction.spec.ts
@@ -3,7 +3,7 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
 interface InteractionBudgets {
-  version: 3;
+  version: 4;
   warmupOperations: number;
   operationsPerSample: number;
   samples: number;
@@ -13,6 +13,7 @@ interface InteractionBudgets {
   legendSamples: number;
   legendNavigationP95Ms: number;
   threeViewPropagationP95Ms: number;
+  r3LegendFilterWarmupOperations: number;
   r3LegendFilterOperations: number;
   r3LegendFilterCommitP95Ms: number;
   r3SelectionApplyMs: number;
@@ -203,51 +204,60 @@ test("R3 filter, cross-panel interval, and precise bounds commits meet separate 
   await expect(fixture).toHaveAttribute("data-zoom-pipeline-commits", "1");
   await expect(fixture).toHaveAttribute("data-zoom-interaction-commits", "0");
 
-  const filterTimings = await page.evaluate(async (operations) => {
-    const fixtureElement = document.querySelector<HTMLElement>("[data-r3-perf-fixture]");
-    const checkbox = document.querySelector<HTMLInputElement>(
-      '[data-perf-plot="filter"] .gg-legend-filters input[type="checkbox"]',
-    );
-    if (!fixtureElement || !checkbox)
-      throw new Error("R3 legend-filter performance fixture is incomplete");
+  expect(budgets.r3LegendFilterWarmupOperations).toBeGreaterThanOrEqual(1);
+  expect(budgets.r3LegendFilterOperations).toBeGreaterThanOrEqual(20);
+  const filterTimings = await page.evaluate(
+    async (config: { warmupOperations: number; operations: number }) => {
+      const fixtureElement = document.querySelector<HTMLElement>("[data-r3-perf-fixture]");
+      const checkbox = document.querySelector<HTMLInputElement>(
+        '[data-perf-plot="filter"] .gg-legend-filters input[type="checkbox"]',
+      );
+      if (!fixtureElement || !checkbox)
+        throw new Error("R3 legend-filter performance fixture is incomplete");
 
-    const commit = async (): Promise<number> => {
-      const before = Number(fixtureElement.dataset["filterPipelineCommits"]);
-      const expected = String(before + 1);
-      const completed = new Promise<void>((resolve) => {
-        const observer = new MutationObserver(() => {
-          if (fixtureElement.dataset["filterPipelineCommits"] !== expected) return;
-          observer.disconnect();
-          resolve();
+      const commit = async (): Promise<number> => {
+        const before = Number(fixtureElement.dataset["filterPipelineCommits"]);
+        const expected = String(before + 1);
+        const completed = new Promise<void>((resolve) => {
+          const observer = new MutationObserver(() => {
+            if (fixtureElement.dataset["filterPipelineCommits"] !== expected) return;
+            observer.disconnect();
+            resolve();
+          });
+          observer.observe(fixtureElement, {
+            attributes: true,
+            attributeFilter: ["data-filter-pipeline-commits"],
+          });
         });
-        observer.observe(fixtureElement, {
-          attributes: true,
-          attributeFilter: ["data-filter-pipeline-commits"],
+        const started = performance.now();
+        checkbox.click();
+        await completed;
+        await new Promise<void>((resolve) => {
+          requestAnimationFrame(() => {
+            resolve();
+          });
         });
-      });
-      const started = performance.now();
-      checkbox.click();
-      await completed;
-      await new Promise<void>((resolve) => {
-        requestAnimationFrame(() => {
-          resolve();
-        });
-      });
-      const after = Number(fixtureElement.dataset["filterPipelineCommits"]);
-      if (after !== before + 1)
-        throw new Error(`Legend filter produced ${String(after - before)} pipeline commits`);
-      return performance.now() - started;
-    };
+        const after = Number(fixtureElement.dataset["filterPipelineCommits"]);
+        if (after !== before + 1)
+          throw new Error(`Legend filter produced ${String(after - before)} pipeline commits`);
+        return performance.now() - started;
+      };
 
-    const timings: number[] = [];
-    for (let index = 0; index < operations; index++) timings.push(await commit());
-    return timings.toSorted((a, b) => a - b);
-  }, budgets.r3LegendFilterOperations);
+      for (let index = 0; index < config.warmupOperations; index++) await commit();
+      const timings: number[] = [];
+      for (let index = 0; index < config.operations; index++) timings.push(await commit());
+      return timings.toSorted((a, b) => a - b);
+    },
+    {
+      warmupOperations: budgets.r3LegendFilterWarmupOperations,
+      operations: budgets.r3LegendFilterOperations,
+    },
+  );
   const filterP95 = filterTimings[Math.floor(filterTimings.length * 0.95)]!;
   expect(filterP95).toBeLessThan(budgets.r3LegendFilterCommitP95Ms);
   await expect(fixture).toHaveAttribute(
     "data-filter-pipeline-commits",
-    String(1 + budgets.r3LegendFilterOperations),
+    String(1 + budgets.r3LegendFilterWarmupOperations + budgets.r3LegendFilterOperations),
   );
 
   const facetPlot = page.locator('[data-perf-plot="facet"]');

--- a/tests/performance/playwright.config.ts
+++ b/tests/performance/playwright.config.ts
@@ -4,7 +4,9 @@ export default defineConfig({
   testDir: ".",
   outputDir: "./test-results",
   fullyParallel: false,
-  retries: 0,
+  // One in-process retry under CI absorbs single-sample host noise on the
+  // shared self-hosted runners without hiding persistent regressions.
+  retries: process.env["CI"] === undefined ? 0 : 1,
   forbidOnly: process.env["CI"] !== undefined,
   reporter: "list",
   timeout: 120_000,


### PR DESCRIPTION
## Summary

Fixes #154. The required `component` check was flaking on the R3 filter commit wall-clock budget (e.g. 347ms vs 320ms) when the shared cx43 host was busy (load ~14 on 8 vCPU with 4 concurrent runners).

### Changes
- **Split gate:** `test:interaction-perf` moves from required `component` into a new informational job `interaction-perf (p50/p95, informational)` that `needs: [component]` and is **not** in the branch ruleset required checks.
- **Measurement:** R3 legend-filter path now warms up (3 ops) and samples 20 commits so p95 is not `max(n=8)`. Playwright gets one CI retry for residual host noise.
- **Still gated hard** on `run-bench` labeled PRs via `bench.yml`.

### Runner ops (applied live + cloud-init)
In `ggsvelte-ci-infra`: pin `DOCKER_CONFIG=/home/runner/.docker` so container jobs with `HOME=/root` no longer emit:
`WARNING: Error loading config file: open /root/.docker/config.json: permission denied`.

## Test plan
- [x] `bun test scripts/release-wiring.test.ts`
- [x] `bun run lint:actions`
- [ ] CI green: required `component` no longer runs interaction-perf
- [ ] Informational `interaction-perf` job still runs after component