### PR TITLE
fix(svelte): deterministic forced-colors paint for disabled-at-SSR tool buttons

### DIFF
--- a/packages/svelte/src/lib/PlotStatusChrome.svelte
+++ b/packages/svelte/src/lib/PlotStatusChrome.svelte
@@ -80,10 +80,9 @@
     left: 50%;
     top: 50%;
     transform: translate(-50%, -50%);
-    color: var(
-      --gg-interactionMuted,
-      var(--gg-theme-interactionMuted, currentColor)
-    );
+    /* --gg-theme-interactionMuted is a numeric alpha token — invalid in a
+       color position (see ToolRail.svelte). */
+    color: var(--gg-interactionMuted, currentColor);
     font: 12px/1.4 var(--gg-font-family, sans-serif);
     pointer-events: none;
   }
@@ -93,10 +92,8 @@
     top: calc(100% + 4px);
     left: 0;
     margin: 0;
-    color: var(
-      --gg-interactionMuted,
-      var(--gg-theme-interactionMuted, currentColor)
-    );
+    /* Numeric alpha token — invalid in a color position (see ToolRail). */
+    color: var(--gg-interactionMuted, currentColor);
     font: 11px/1.4 var(--gg-font-family, sans-serif);
   }
 

--- a/packages/svelte/src/lib/ToolRail.svelte
+++ b/packages/svelte/src/lib/ToolRail.svelte
@@ -209,10 +209,11 @@
     border-radius: 0;
     padding: 0 10px;
     background: transparent;
-    color: var(
-      --gg-interactionMuted,
-      var(--gg-theme-interactionMuted, currentColor)
-    );
+    /* --gg-theme-interactionMuted is a NUMERIC alpha token (theme.ts
+       interactionMuted: 0.36) — substituting it here made this declaration
+       invalid at computed-value time, so only --gg-interactionMuted (a
+       consumer-supplied color) may appear in a color position. */
+    color: var(--gg-interactionMuted, currentColor);
     font: inherit;
     font-size: 14px;
     white-space: nowrap;
@@ -272,6 +273,19 @@
     .gg-tool-rail button.active {
       border-bottom-color: Highlight;
       color: ButtonText;
+    }
+
+    /* Chromium does not repaint a button's forced text/border color when
+       `disabled` is removed unless the COMPUTED value changes with the state
+       (these buttons render disabled during SSR and are enabled after
+       hydration, so without this rule they froze race-dependently on the
+       disabled GrayText paint — PR #160's vr flake). Both properties are
+       needed: the base rule's `transparent` border is also forced-painted.
+       Placed after `.active` so a disabled active tool still reads as
+       disabled. */
+    .gg-tool-rail button:disabled {
+      border-bottom-color: GrayText;
+      color: GrayText;
     }
   }
 </style>

--- a/packages/svelte/tests/plot-status-chrome.test.ts
+++ b/packages/svelte/tests/plot-status-chrome.test.ts
@@ -109,4 +109,26 @@ describe("PlotStatusChrome", () => {
     // CSSOM may serialize `animation: none` as expanded longhands / `auto`.
     expect(cssText).toMatch(/animation:\s*(none|auto)/i);
   });
+
+  it("keeps muted chrome color free of the numeric theme alpha token (#161)", () => {
+    render(PlotStatusChrome, {
+      plotId: "muted-color",
+      emptyPlot: true,
+      capabilityStatus: "status",
+    });
+    const cssText = [...document.styleSheets]
+      .flatMap((sheet) => {
+        try {
+          return [...sheet.cssRules].map((rule) => rule.cssText);
+        } catch {
+          return [] as string[];
+        }
+      })
+      .join("\n");
+    // --gg-theme-interactionMuted is a numeric alpha; invalid in color position.
+    expect(cssText).toMatch(/color:\s*var\(--gg-interactionMuted,\s*currentColor\)/i);
+    expect(cssText).not.toMatch(
+      /color:\s*var\(\s*--gg-interactionMuted\s*,\s*var\(\s*--gg-theme-interactionMuted/i,
+    );
+  });
 });

--- a/packages/svelte/tests/tool-rail.test.ts
+++ b/packages/svelte/tests/tool-rail.test.ts
@@ -3,30 +3,79 @@ import { describe, expect, it, vi } from "vitest";
 import ToolRail from "../src/lib/ToolRail.svelte";
 import { render } from "./helpers/render.js";
 
+function toolRailProps(
+  overrides: Partial<{
+    availableTools: readonly ("inspect" | "select-area" | "zoom-area" | "point")[];
+    activeTool: "inspect" | "select-area" | "zoom-area" | "point";
+    ready: boolean;
+    emptyPlot: boolean;
+    zoomDomains: { x: [number, number] } | null;
+    hasPointSelection: boolean;
+    hasIntervalSelection: boolean;
+    intervalTargetLabel: string;
+    canSetIntervalBounds: boolean;
+    intervalAxes: readonly ("x" | "y")[];
+    onChooseTool: ReturnType<typeof vi.fn>;
+    onResetZoom: ReturnType<typeof vi.fn>;
+    onClearPointSelection: ReturnType<typeof vi.fn>;
+    onClearIntervalSelection: ReturnType<typeof vi.fn>;
+    onClearCurrentInterval: ReturnType<typeof vi.fn>;
+    onEditBounds: ReturnType<typeof vi.fn>;
+  }> = {},
+) {
+  return {
+    availableTools: ["inspect"] as const,
+    activeTool: "inspect" as const,
+    ready: true,
+    emptyPlot: false,
+    zoomDomains: null,
+    hasPointSelection: false,
+    hasIntervalSelection: false,
+    canSetIntervalBounds: false,
+    intervalAxes: [] as const,
+    onChooseTool: vi.fn(),
+    onResetZoom: vi.fn(),
+    onClearPointSelection: vi.fn(),
+    onClearIntervalSelection: vi.fn(),
+    onClearCurrentInterval: vi.fn(),
+    onEditBounds: vi.fn(),
+    ...overrides,
+  };
+}
+
+function documentCssText(): string {
+  return [...document.styleSheets]
+    .flatMap((sheet) => {
+      try {
+        return [...sheet.cssRules].map((rule) => rule.cssText);
+      } catch {
+        return [] as string[];
+      }
+    })
+    .join("\n");
+}
+
 describe("<ToolRail> recovery input sources", () => {
   it("distinguishes keyboard, pointer, and touch activation", () => {
     const reset = vi.fn();
     const clearPoint = vi.fn();
     const clearPanel = vi.fn();
     const clearAll = vi.fn();
-    const { container } = render(ToolRail, {
-      availableTools: ["inspect"],
-      activeTool: "inspect",
-      ready: true,
-      emptyPlot: false,
-      zoomDomains: { x: [1, 2] },
-      hasPointSelection: true,
-      hasIntervalSelection: true,
-      intervalTargetLabel: "North",
-      canSetIntervalBounds: true,
-      intervalAxes: ["x"],
-      onChooseTool: vi.fn(),
-      onResetZoom: reset,
-      onClearPointSelection: clearPoint,
-      onClearIntervalSelection: clearAll,
-      onClearCurrentInterval: clearPanel,
-      onEditBounds: vi.fn(),
-    });
+    const { container } = render(
+      ToolRail,
+      toolRailProps({
+        zoomDomains: { x: [1, 2] },
+        hasPointSelection: true,
+        hasIntervalSelection: true,
+        intervalTargetLabel: "North",
+        canSetIntervalBounds: true,
+        intervalAxes: ["x"],
+        onResetZoom: reset,
+        onClearPointSelection: clearPoint,
+        onClearIntervalSelection: clearAll,
+        onClearCurrentInterval: clearPanel,
+      }),
+    );
     const button = (label: string) =>
       [...container.querySelectorAll<HTMLButtonElement>("button")].find(
         (candidate) => candidate.textContent?.trim() === label,
@@ -59,5 +108,46 @@ describe("<ToolRail> recovery input sources", () => {
     expect(clearAll).toHaveBeenCalledWith("keyboard");
 
     expect(button("Edit x selection bounds: North")).not.toBeUndefined();
+  });
+});
+
+describe("<ToolRail> forced-colors disabled→enabled paint contract (#161)", () => {
+  it("disables all buttons while ready is false (SSR / pre-hydration state)", () => {
+    const { container } = render(
+      ToolRail,
+      toolRailProps({
+        availableTools: ["inspect", "select-area", "zoom-area"],
+        ready: false,
+        zoomDomains: { x: [0, 1] },
+      }),
+    );
+    const buttons = [...container.querySelectorAll<HTMLButtonElement>("button")];
+    expect(buttons.length).toBeGreaterThan(0);
+    expect(buttons.every((button) => button.disabled)).toBe(true);
+  });
+
+  it("keeps button color free of the numeric theme alpha token", () => {
+    render(ToolRail, toolRailProps());
+    const cssText = documentCssText();
+    // --gg-theme-interactionMuted is a number (0.36); invalid in `color:`.
+    // Only the consumer color override may appear in the color chain.
+    expect(cssText).toMatch(/color:\s*var\(--gg-interactionMuted,\s*currentColor\)/i);
+    expect(cssText).not.toMatch(
+      /color:\s*var\(\s*--gg-interactionMuted\s*,\s*var\(\s*--gg-theme-interactionMuted/i,
+    );
+  });
+
+  it("declares forced-colors :disabled GrayText for color and border-bottom", () => {
+    render(ToolRail, toolRailProps());
+    const cssText = documentCssText();
+    // Chromium freezes forced-colors paint across disabled→enabled unless the
+    // computed author values change; these rules supply the state delta.
+    // CSSOM may expand `button:disabled` to `button:where(...):disabled` and
+    // lowercase system colors (`graytext`).
+    expect(cssText).toMatch(/forced-colors:\s*active/i);
+    expect(cssText).toMatch(/button(?::where\([^)]*\))?:disabled[^}]*\bcolor:\s*graytext\b/i);
+    expect(cssText).toMatch(
+      /button(?::where\([^)]*\))?:disabled[^}]*\bborder-bottom-color:\s*graytext\b/i,
+    );
   });
 });


### PR DESCRIPTION
Fixes the one remaining red check on #160 (the `interaction-zoom-draft-forced-colors` vr screenshot), which turned out to be a real rendering bug, not a stale baseline.

## Diagnosis

The committed baseline (regenerated via `/approve-visuals` on #159) renders the idle "Select area" tool button in `GrayText` `#600000` — Chromium's forced-colors *disabled* palette color — while #160's compare run rendered it `ButtonText` black. The same GrayText anomaly exists in the PR #79-era regen (`vr-update/pr-79`), so it predates the refactor stack entirely. Reproduced and bisected locally against the pinned Playwright 1.61.1 Chromium:

1. **ToolRail buttons are `disabled` in the SSR HTML** (`ready` stays false until hydration's client flush) and are enabled shortly after hydration.
2. **Chromium does not repaint a control's forced-colors text/border color when `disabled` is removed** unless the *computed author value* changes with the state. The buttons' author color computed identically in both states, so whichever paint won the race (pre-hydration disabled GrayText vs post-hydration ButtonText) **stuck for the life of the page** — hence byte-stable screenshots per machine that disagree across machines/runs. A minimal reduction (button with author color, `disabled` at first paint, then enabled) reproduces the stale paint 100%; a control button without author color repaints correctly.
3. The author color computed identically in both states because of a second latent bug: ToolRail and PlotStatusChrome consume `--gg-theme-interactionMuted` in a **color position**, but that token is a *numeric alpha* (`theme.ts` `interactionMuted: 0.36`, correctly used as `mutedAlpha` in stratum paint). `color: 0.36` is invalid-at-computed-value-time and silently resolves to the inherited color.

## Fix

- `ToolRail.svelte`: add `button:disabled { color: GrayText; border-bottom-color: GrayText }` inside the existing `@media (forced-colors: active)` block (after `.active`, so a disabled active tool reads disabled). The computed values now genuinely change on the disabled→enabled flip, so invalidation fires and the final paint is deterministic (`ButtonText` / `ButtonBorder`). Both properties are required — the base rule's `transparent` border-bottom is also forced-painted and staled independently (that was the residual 182-pixel bar after fixing `color` alone).
- `ToolRail.svelte` + `PlotStatusChrome.svelte` (2 spots): drop the numeric theme token from the color chains — `color: var(--gg-interactionMuted, currentColor)`. Pixel-identical to the shipped rendering (both resolve to the inherited ink); the consumer color-override hook is preserved.

## Verification

- 8 consecutive local `--update-snapshots` runs of the forced-colors test: **0 GrayText pixels**, byte-stable (pre-fix: race-dependent 205/182/0).
- Full 82-shot vr suite: update → compare cycle passes byte-identically.
- `check:svelte` 0/0, `lint`, `lint:type-aware`, `fmt:check` clean; svelte suite 153 files / 2214 browser tests + SSR suite pass; `svelte-autofixer` clean on both files.

## Expected CI state & follow-up

- This PR's own **vr-compare will fail against the stale pre-R3 committed baselines** — the known #153 state, ignore it here.
- Once this merges to main: rebase `ggr/s1-runtime`, re-comment `/approve-visuals` on #159 → `vr-update/pr-159` regenerates deterministically → #160 goes green (only the forced-colors PNG changes; idle buttons become ButtonText black — the a11y-correct rendering, since GrayText falsely signaled "disabled" to high-contrast users).

🤖 Generated with [Claude Code](https://claude.com/claude-code)