### PR TITLE
chore(svelte): S9 — raise Svelte peer floor to 5.33.1

### DIFF
--- a/.changeset/raise-svelte-floor.md
+++ b/.changeset/raise-svelte-floor.md
@@ -1,0 +1,12 @@
+---
+"@ggsvelte/svelte": minor
+---
+
+# Raise the Svelte peer floor to 5.33.1
+
+The `svelte` peer range narrows from `^5.29.0` to `^5.33.1`. Svelte 5.33.1
+restored lazy server-side `$derived` evaluation (sveltejs/svelte#15964), so
+the library no longer carries wiring constraints for the 5.29 eager behavior.
+Only the eager-derived declaration constraint is removed — internal controller
+construction order and effect-registration order are unchanged. Consumers on
+Svelte 5.29.0–5.33.0 must upgrade Svelte to take this release.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ bun add @ggsvelte/svelte        # or: npm install @ggsvelte/svelte
 `@ggsvelte/svelte` pulls in `@ggsvelte/spec` (spec types, validation, builder) and
 `@ggsvelte/core` (pipeline + renderers) and re-exports the whole surface.
 
-Requires Node.js 22+ and Svelte 5.29+. Clean packed-artifact installs are
+Requires Node.js 22+ and Svelte 5.33.1+. Clean packed-artifact installs are
 tested with npm, pnpm, and Bun on Ubuntu and Windows; see the
 [compatibility matrix](https://ljodea.github.io/ggsvelte/guide/compatibility).
 

--- a/bun.lock
+++ b/bun.lock
@@ -69,9 +69,9 @@
     },
     "packages/core": {
       "name": "@ggsvelte/core",
-      "version": "0.0.0",
+      "version": "0.1.1",
       "dependencies": {
-        "@ggsvelte/spec": "workspace:*",
+        "@ggsvelte/spec": "^0.1.1",
       },
       "devDependencies": {
         "typescript": "^6.0.3",
@@ -79,7 +79,7 @@
     },
     "packages/spec": {
       "name": "@ggsvelte/spec",
-      "version": "0.0.0",
+      "version": "0.1.1",
       "dependencies": {
         "@sinclair/typebox": "^0.34.0",
       },
@@ -90,13 +90,13 @@
     },
     "packages/svelte": {
       "name": "@ggsvelte/svelte",
-      "version": "0.0.0",
+      "version": "0.1.1",
       "bin": {
-        "ggsvelte-render": "./bin/ggsvelte-render.js",
+        "ggsvelte-render": "bin/ggsvelte-render.js",
       },
       "dependencies": {
-        "@ggsvelte/core": "workspace:*",
-        "@ggsvelte/spec": "workspace:*",
+        "@ggsvelte/core": "^0.1.1",
+        "@ggsvelte/spec": "^0.1.1",
       },
       "devDependencies": {
         "@sveltejs/package": "^2.5.8",
@@ -112,7 +112,7 @@
         "vitest": "^4.1.10",
       },
       "peerDependencies": {
-        "svelte": "^5.29.0",
+        "svelte": "^5.33.1",
       },
     },
     "spikes/browser": {

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -68,7 +68,7 @@
     "vitest": "^4.1.10"
   },
   "peerDependencies": {
-    "svelte": "^5.29.0"
+    "svelte": "^5.33.1"
   },
   "engines": {
     "node": ">=22"

--- a/packages/svelte/src/lib/GGPlot.svelte
+++ b/packages/svelte/src/lib/GGPlot.svelte
@@ -378,7 +378,7 @@
   // ------------------------------------------------- plot runtime (S1)
   // The factory call sits AFTER the zoom-respec and legend-filter blocks:
   // every binding a dep getter closes over must already be initialized here
-  // (construction-order DAG; consumer-compat SSR smoke enforces this).
+  // (construction-order DAG; direct construction-time reads TDZ).
   // Client-side, the ResizeObserver effect now registers after the
   // legend-reset effects — safe: the observer callback is async and shares
   // no state with them.

--- a/packages/svelte/src/lib/GGPlot.svelte
+++ b/packages/svelte/src/lib/GGPlot.svelte
@@ -316,8 +316,8 @@
   // ------------------------------------------------------------ zoom respec (S4)
   // Factory sits at the original zoom-respec region (before announcer /
   // runtime). Construction-time deriveds read interaction/scope/zoomConfig/
-  // assembled only — never model/coordFlipped/announce (Svelte 5.29 server
-  // evaluates $derived eagerly at construction).
+  // assembled only — never model/coordFlipped/announce (those are later-
+  // declared; construction-order DAG keeps them as deferred getters).
   // controllerRevision deleted in S8 (selection reads revision directly).
   const zoomState = createPlotZoomState({
     interaction: () => factoryInteraction,
@@ -331,7 +331,7 @@
     oninteraction: () => factoryOninteraction,
     announce: announceSink,
   });
-  // One-line host aliases at original positions (server-eager order).
+  // One-line host aliases at original positions (construction-order DAG).
   const effectiveZoomDomains = $derived(zoomState.effectiveZoomDomains);
   const effectiveSpec = $derived(zoomState.effectiveSpec);
 
@@ -354,7 +354,7 @@
   // ------------------------------------------------- legend filter (S2)
   // Factory sits at the original legend-filter region (before the runtime).
   // Construction-time deriveds read legendFilter/effectiveSpec only — never
-  // model (Svelte 5.29 server evaluates $derived eagerly at construction).
+  // model (model is declared after the runtime; construction-order DAG).
   const legendFilterState = createLegendFilterState({
     effectiveSpec: () => effectiveSpec,
     legendFilterProp: () => legendFilter,
@@ -377,11 +377,11 @@
 
   // ------------------------------------------------- plot runtime (S1)
   // The factory call sits AFTER the zoom-respec and legend-filter blocks:
-  // on the oldest supported Svelte, SERVER deriveds evaluate eagerly at
-  // construction, so every binding a dep getter closes over must already be
-  // initialized here (consumer-compat SSR smoke enforces this). Client-side,
-  // the ResizeObserver effect now registers after the legend-reset effects —
-  // safe: the observer callback is async and shares no state with them.
+  // every binding a dep getter closes over must already be initialized here
+  // (construction-order DAG; consumer-compat SSR smoke enforces this).
+  // Client-side, the ResizeObserver effect now registers after the
+  // legend-reset effects — safe: the observer callback is async and shares
+  // no state with them.
   const runtime = createPlotRuntime({
     widthProp: () => width,
     heightProp: () => height,
@@ -404,8 +404,8 @@
 
   // Construct semantic resolution as soon as the runtime model exists. The
   // diagnostics effect is still registered at its original later position.
-  // This ordering makes server-eager interval projection safe when a shared
-  // controller arrives with pre-populated non-union intervals (#165).
+  // This ordering makes interval projection safe when a shared controller
+  // arrives with pre-populated non-union intervals (#165).
   const semanticKeys = createSemanticKeyService({
     model: () => model,
     assembled: () => assembled,
@@ -545,8 +545,8 @@
   const legendFocusEnabled = $derived(interactionConfig.legendFocus !== null);
   // ------------------------------------------------- legend focus (S3)
   // Factory sits AFTER the enablement cluster: construction-time
-  // effectiveEmphasisKeys closes over earlier bindings only (Svelte 5.29
-  // server evaluates $derived eagerly at construction).
+  // effectiveEmphasisKeys closes over earlier bindings only
+  // (construction-order DAG).
   const legendFocusState = createLegendFocusState({
     interaction: () => factoryInteraction,
     resolvedInteractionScope: () => resolvedInteractionScope,
@@ -564,7 +564,7 @@
     oninteraction: () => factoryOninteraction,
     announce: announceSink,
   });
-  // Host one-liner: downstream server-eager deriveds (capability gate,
+  // Host one-liner: downstream deriveds (capability gate,
   // emphasizedAnchors, presentationFocusKeys) read this at original sites.
   const effectiveEmphasisKeys = $derived(
     legendFocusState.effectiveEmphasisKeys,
@@ -630,7 +630,7 @@
   const capabilityStatus = $derived(chromeState.capabilityStatus);
   const rootStyle = $derived(chromeState.rootStyle);
   // Anchors: methods with host one-liner deriveds at original positions
-  // (server-eager order preserved; later-declared inputs).
+  // (construction-order DAG; later-declared inputs).
   const selectedAnchors = $derived(selectionState.computeSelectedAnchors());
   const emphasizedAnchors = $derived(selectionState.computeEmphasizedAnchors());
 
@@ -667,7 +667,8 @@
     ),
   );
 
-  // Host-side deriveds: must not live in the factory (server-eager model TDZ).
+  // Host-side deriveds: must not live in the factory (model is later-
+  // declared; keep construction-time factory free of that read).
   const interactiveLegendEntries = $derived(
     legendFocusState.computeInteractiveEntries(model),
   );
@@ -683,7 +684,8 @@
     legendFocusEnabled && effectiveLegendPressed !== null,
   );
 
-  // Host-side derived: must not live in the factory (server-eager model TDZ).
+  // Host-side derived: must not live in the factory (model is later-
+  // declared; keep construction-time factory free of that read).
   const filterableLegendEntries = $derived(
     legendFilterState.computeEntries(model),
   );

--- a/packages/svelte/src/lib/inspection-state.svelte.ts
+++ b/packages/svelte/src/lib/inspection-state.svelte.ts
@@ -16,7 +16,7 @@
  * oninspect, oninteraction.
  *
  * Effects register via registerInspectionEffects() at the original coordinator
- * site (after legend-focus reconcile), matching Svelte 5.29 server-eager rules.
+ * site (after legend-focus reconcile); effect-registration order is load-bearing.
  */
 import type { CandidateFacts, CellValue, RenderModel, ScenePanel } from "@ggsvelte/core";
 import type { SceneHit } from "@ggsvelte/core/dom";
@@ -158,9 +158,8 @@ export type InspectionState = {
  * `registerInspectionEffects` at the original coordinator position after
  * legend-focus reconcile effects.
  *
- * Client-lazy note: on the client, $derived evaluation is lazy until first
- * read; Svelte 5.29 SSR evaluates construction-time deriveds eagerly. Armed
- * deps must not be reached from construction-time deriveds (compat:consumer).
+ * Construction-order note: armed deps must not be reached from
+ * construction-time deriveds (construction-order DAG; compat:consumer).
  */
 export function createInspectionState(deps: InspectionStateDeps): InspectionState {
   let inspection = $state<PlotInspectionChange<Record<string, CellValue>, PropertyKey> | null>(

--- a/packages/svelte/src/lib/inspection-state.svelte.ts
+++ b/packages/svelte/src/lib/inspection-state.svelte.ts
@@ -158,8 +158,8 @@ export type InspectionState = {
  * `registerInspectionEffects` at the original coordinator position after
  * legend-focus reconcile effects.
  *
- * Construction-order note: armed deps must not be reached from
- * construction-time deriveds (construction-order DAG; compat:consumer).
+ * Construction-order note: deps must not be invoked during construction —
+ * construction-read discipline enforced by the armed-getter suite.
  */
 export function createInspectionState(deps: InspectionStateDeps): InspectionState {
   let inspection = $state<PlotInspectionChange<Record<string, CellValue>, PropertyKey> | null>(

--- a/packages/svelte/src/lib/interval-state.svelte.ts
+++ b/packages/svelte/src/lib/interval-state.svelte.ts
@@ -12,8 +12,9 @@
  * for the construction guard: emitSelection, commitZoom, announce,
  * inspectionPanel, candidateSemanticKeys.
  *
- * The host constructs semantic-key resolution before this factory so
- * pre-populated non-union intervals can project safely at construction.
+ * The host constructs semantic-key resolution before this factory
+ * (construction-order convention; deriveds are lazy at the 5.33.1 floor, so
+ * interval projection evaluates on first read, not at construction).
  * Semantic diagnostics retain their later effect-registration position
  * through the service's phased `registerEffects()` API (#165).
  */

--- a/packages/svelte/src/lib/interval-state.svelte.ts
+++ b/packages/svelte/src/lib/interval-state.svelte.ts
@@ -12,10 +12,10 @@
  * for the construction guard: emitSelection, commitZoom, announce,
  * inspectionPanel, candidateSemanticKeys.
  *
- * The host constructs semantic-key resolution before this factory so Svelte
- * 5.29's eager server evaluation can safely project pre-populated non-union
- * intervals. Semantic diagnostics retain their later effect-registration
- * position through the service's phased `registerEffects()` API (#165).
+ * The host constructs semantic-key resolution before this factory so
+ * pre-populated non-union intervals can project safely at construction.
+ * Semantic diagnostics retain their later effect-registration position
+ * through the service's phased `registerEffects()` API (#165).
  */
 import {
   decodeKey,

--- a/packages/svelte/src/lib/legend-filter-state.svelte.ts
+++ b/packages/svelte/src/lib/legend-filter-state.svelte.ts
@@ -3,8 +3,8 @@
  *
  * Owns chart-local filter clauses, mode/capability reset effects, catalog
  * reconciliation (phased registration), and toggle/reset side effects.
- * Construction-time deriveds must NOT read `model` — on Svelte 5.29 the
- * server evaluates $derived eagerly at factory construction (SSR TDZ).
+ * Construction-time deriveds must NOT read `model` (declared later;
+ * construction-order DAG — model is used only from late catalog effects).
  */
 import type { CellValue, RenderModel, SceneDiscreteLegend, SceneLegendEntry } from "@ggsvelte/core";
 import { encodeKey } from "@ggsvelte/core";
@@ -44,7 +44,7 @@ export type LegendFilterStateDeps = {
   announce: (message: string) => void;
   /**
    * Used ONLY inside late catalog effects (never at construction). Armed-getter
-   * construction tests enforce this for Svelte 5.29 server-eager deriveds.
+   * construction tests enforce this construction-order DAG contract.
    */
   model: () => RenderModel | null;
 };

--- a/packages/svelte/src/lib/legend-focus-state.svelte.ts
+++ b/packages/svelte/src/lib/legend-focus-state.svelte.ts
@@ -3,9 +3,9 @@
  *
  * Owns chart-local emphasis, preview/commit state, roving/touch suppress flags,
  * interaction handlers, and phased reconcile effects. Construction-time
- * deriveds must NOT read model/semanticKeys/entries (Svelte 5.29 server-eager
- * $derived TDZ). Those are methods/effects registered after the host declares
- * the later bindings.
+ * deriveds must NOT read model/semanticKeys/entries (construction-order DAG).
+ * Those are methods/effects registered after the host declares the later
+ * bindings.
  */
 import type { CellValue, RenderModel } from "@ggsvelte/core";
 

--- a/packages/svelte/src/lib/plot-runtime.svelte.ts
+++ b/packages/svelte/src/lib/plot-runtime.svelte.ts
@@ -59,7 +59,7 @@ export type PlotRuntime = {
  * original host positions. Dep getters must not be invoked during construction
  * for construction-time deriveds; the host must declare every binding a dep
  * getter closes over BEFORE calling this factory (declaration order is the
- * topological order; the consumer-compat SSR smoke enforces it).
+ * topological order; direct construction-time reads of later bindings TDZ).
  */
 export function createPlotRuntime(deps: PlotRuntimeDeps): PlotRuntime {
   // ------------------------------------------------- container width (RO)

--- a/packages/svelte/src/lib/plot-runtime.svelte.ts
+++ b/packages/svelte/src/lib/plot-runtime.svelte.ts
@@ -57,9 +57,8 @@ export type PlotRuntime = {
  * Create the plot runtime. Construction registers ONLY the ResizeObserver
  * effect. Call `registerModelEffects` and `registerLateEffects` at their
  * original host positions. Dep getters must not be invoked during construction
- * ON THE CLIENT — but on the oldest supported Svelte the SERVER evaluates
- * deriveds eagerly at construction, so the host must declare every binding a
- * dep getter closes over BEFORE calling this factory (declaration order is the
+ * for construction-time deriveds; the host must declare every binding a dep
+ * getter closes over BEFORE calling this factory (declaration order is the
  * topological order; the consumer-compat SSR smoke enforces it).
  */
 export function createPlotRuntime(deps: PlotRuntimeDeps): PlotRuntime {

--- a/packages/svelte/src/lib/plot-zoom-state.svelte.ts
+++ b/packages/svelte/src/lib/plot-zoom-state.svelte.ts
@@ -3,8 +3,8 @@
  *
  * Owns chart-local zoom domains, effective-domain / effective-spec deriveds,
  * and zoom commit/reset/brush/set handlers. Construction-time deriveds must
- * NOT read model/coordFlipped/announce (Svelte 5.29 server-eager $derived TDZ).
- * Those are handler-only deferred getters.
+ * NOT read model/coordFlipped/announce (later-declared / handler-only;
+ * construction-order DAG). Those are handler-only deferred getters.
  */
 import type { CellValue, RenderModel } from "@ggsvelte/core";
 import type { PortableSpec } from "@ggsvelte/spec";

--- a/packages/svelte/src/lib/surface-state.svelte.ts
+++ b/packages/svelte/src/lib/surface-state.svelte.ts
@@ -153,8 +153,8 @@ export type SurfaceState = {
  * construction-time deriveds. Call `registerSurfaceEffects` at the original
  * line-810 position (after diagnostics, before catalog/focus/inspection).
  *
- * Construction-order note: armed deps must not be reached from
- * construction-time deriveds (construction-order DAG; compat:consumer).
+ * Construction-order note: deps must not be invoked during construction —
+ * construction-read discipline enforced by the armed-getter suite.
  */
 export function createSurfaceState(deps: SurfaceStateDeps): SurfaceState {
   let reducerRevision = $state(0);

--- a/packages/svelte/src/lib/surface-state.svelte.ts
+++ b/packages/svelte/src/lib/surface-state.svelte.ts
@@ -153,9 +153,8 @@ export type SurfaceState = {
  * construction-time deriveds. Call `registerSurfaceEffects` at the original
  * line-810 position (after diagnostics, before catalog/focus/inspection).
  *
- * Client-lazy note: on the client, $derived evaluation is lazy until first
- * read; Svelte 5.29 SSR evaluates construction-time deriveds eagerly. Armed
- * deps must not be reached from construction-time deriveds (compat:consumer).
+ * Construction-order note: armed deps must not be reached from
+ * construction-time deriveds (construction-order DAG; compat:consumer).
  */
 export function createSurfaceState(deps: SurfaceStateDeps): SurfaceState {
   let reducerRevision = $state(0);

--- a/packages/svelte/tests/inspection-state.test.ts
+++ b/packages/svelte/tests/inspection-state.test.ts
@@ -302,7 +302,8 @@ describe("createInspectionState construction", () => {
     expect(oninteractionCalls).toBe(0);
     expect(plotIdCalls).toBe(0);
     // Client-lazy: accessors + one flush must not reach armed getters.
-    // SSR-eager deriveds are gated by .ssr suites and compat:consumer.
+    // Construction-order DAG regressions are gated by .ssr suites and
+    // compat:consumer.
     expect(state.inspection).toBeNull();
     expect(state.inspectionPanel).toBeNull();
     flushSync();

--- a/packages/svelte/tests/inspection-state.test.ts
+++ b/packages/svelte/tests/inspection-state.test.ts
@@ -301,9 +301,9 @@ describe("createInspectionState construction", () => {
     expect(oninspectCalls).toBe(0);
     expect(oninteractionCalls).toBe(0);
     expect(plotIdCalls).toBe(0);
-    // Client-lazy: accessors + one flush must not reach armed getters.
-    // Construction-order DAG regressions are gated by .ssr suites and
-    // compat:consumer.
+    // Accessors + one flush must not reach armed getters (construction-read
+    // discipline). Direct construction-time reads of armed deps would throw
+    // right here.
     expect(state.inspection).toBeNull();
     expect(state.inspectionPanel).toBeNull();
     flushSync();

--- a/packages/svelte/tests/interval-state.test.ts
+++ b/packages/svelte/tests/interval-state.test.ts
@@ -203,10 +203,10 @@ describe("createIntervalState construction", () => {
         },
         coordFlipped: () => false,
         captureSurface: () => null,
-        // Known hazard (issue #165): pre-populated non-union controller +
-        // non-null model can reach this at construction and TDZ if semantic
-        // keys are not yet declared. This guard pins the common empty-
-        // intervals construction path only.
+        // Issue #165 history: under the retired eager-SSR floor, a
+        // pre-populated non-union controller + non-null model reached this
+        // at construction. Deriveds are lazy at the 5.33.1 floor, so this
+        // guard pins the common empty-intervals construction path only.
         candidateSemanticKeys: (candidate) => {
           candidateSemanticKeysCalls++;
           return identityCandidateKeys(candidate);
@@ -229,12 +229,10 @@ describe("createIntervalState construction", () => {
     expect(announceCalls).toBe(0);
     expect(inspectionPanelCalls).toBe(0);
     expect(candidateSemanticKeysCalls).toBe(0);
-    // Client deriveds are lazy, so this guard only proves the exposed
-    // accessors reach no armed getter (reads + one flush below). A
-    // construction-time $derived that reads an armed dep WITHOUT being
-    // reachable from an accessor would pass here yet still violate the
-    // construction-order DAG — the .ssr suites and compat:consumer are the
-    // gate for that case.
+    // Deriveds are lazy on client and server at the 5.33.1 floor, so this
+    // guard proves the exposed accessors reach no armed getter (reads + one
+    // flush below) — the construction-read discipline. Direct (non-derived)
+    // construction-time reads of armed deps would throw right here.
     expect(state.committedInterval).toBeNull();
     expect(state.effectiveIntervals).toEqual([]);
     expect(state.effectiveIntervalKeys).toEqual([]);

--- a/packages/svelte/tests/interval-state.test.ts
+++ b/packages/svelte/tests/interval-state.test.ts
@@ -204,9 +204,9 @@ describe("createIntervalState construction", () => {
         coordFlipped: () => false,
         captureSurface: () => null,
         // Known hazard (issue #165): pre-populated non-union controller +
-        // non-null model DOES reach this at construction on Svelte 5.29 SSR
-        // and TDZs identically on the base branch. This guard pins the common
-        // empty-intervals construction path only.
+        // non-null model can reach this at construction and TDZ if semantic
+        // keys are not yet declared. This guard pins the common empty-
+        // intervals construction path only.
         candidateSemanticKeys: (candidate) => {
           candidateSemanticKeysCalls++;
           return identityCandidateKeys(candidate);
@@ -232,9 +232,9 @@ describe("createIntervalState construction", () => {
     // Client deriveds are lazy, so this guard only proves the exposed
     // accessors reach no armed getter (reads + one flush below). A
     // construction-time $derived that reads an armed dep WITHOUT being
-    // reachable from an accessor would pass here yet still crash Svelte 5.29
-    // SSR, where deriveds evaluate eagerly at construction (TDZ) — the .ssr
-    // suites and compat:consumer are the gate for that case.
+    // reachable from an accessor would pass here yet still violate the
+    // construction-order DAG — the .ssr suites and compat:consumer are the
+    // gate for that case.
     expect(state.committedInterval).toBeNull();
     expect(state.effectiveIntervals).toEqual([]);
     expect(state.effectiveIntervalKeys).toEqual([]);

--- a/packages/svelte/tests/legend-filter-state.test.ts
+++ b/packages/svelte/tests/legend-filter-state.test.ts
@@ -60,8 +60,8 @@ describe("createLegendFilterState construction", () => {
     // Client deriveds are lazy, so the construction-time assertion alone
     // cannot catch a model-reading $derived added to the factory. Force
     // every exposed accessor and one effect flush, then re-assert — that is
-    // the closest client-side stand-in for Svelte 5.29's SSR behavior,
-    // where such a derived evaluates eagerly at construction (TDZ hazard).
+    // the closest client-side stand-in for the construction-order DAG
+    // contract (model must not be read at construction).
     expect(state.options).not.toBeNull();
     expect(state.filters).toEqual([]);
     expect(state.hasActiveFilters).toBe(false);

--- a/packages/svelte/tests/legend-focus-state.test.ts
+++ b/packages/svelte/tests/legend-focus-state.test.ts
@@ -162,9 +162,9 @@ describe("createLegendFocusState construction", () => {
     // Client deriveds are lazy, so this guard only proves the exposed
     // accessors reach no armed getter (reads + one flush below). A
     // construction-time $derived that reads an armed dep WITHOUT being
-    // reachable from an accessor would pass here yet still crash Svelte 5.29
-    // SSR, where deriveds evaluate eagerly at construction (TDZ) — the .ssr
-    // suites and compat:consumer are the gate for that case.
+    // reachable from an accessor would pass here yet still violate the
+    // construction-order DAG — the .ssr suites and compat:consumer are the
+    // gate for that case.
     expect(state.effectiveEmphasisKeys).toEqual([]);
     expect(state.previewIdentity).toBeNull();
     expect(state.rovingIndex).toBe(0);

--- a/packages/svelte/tests/legend-focus-state.test.ts
+++ b/packages/svelte/tests/legend-focus-state.test.ts
@@ -159,12 +159,10 @@ describe("createLegendFocusState construction", () => {
     expect(semanticCalls).toBe(0);
     expect(entriesCalls).toBe(0);
     expect(pressedCalls).toBe(0);
-    // Client deriveds are lazy, so this guard only proves the exposed
-    // accessors reach no armed getter (reads + one flush below). A
-    // construction-time $derived that reads an armed dep WITHOUT being
-    // reachable from an accessor would pass here yet still violate the
-    // construction-order DAG — the .ssr suites and compat:consumer are the
-    // gate for that case.
+    // Deriveds are lazy on client and server at the 5.33.1 floor, so this
+    // guard proves the exposed accessors reach no armed getter (reads + one
+    // flush below) — the construction-read discipline. Direct (non-derived)
+    // construction-time reads of armed deps would throw right here.
     expect(state.effectiveEmphasisKeys).toEqual([]);
     expect(state.previewIdentity).toBeNull();
     expect(state.rovingIndex).toBe(0);

--- a/packages/svelte/tests/plot-zoom-state.test.ts
+++ b/packages/svelte/tests/plot-zoom-state.test.ts
@@ -163,12 +163,10 @@ describe("createPlotZoomState construction", () => {
     expect(modelCalls).toBe(0);
     expect(coordFlippedCalls).toBe(0);
     expect(announceCalls).toBe(0);
-    // Client deriveds are lazy, so this guard only proves the exposed
-    // accessors reach no armed getter (reads + one flush below). A
-    // construction-time $derived that reads an armed dep WITHOUT being
-    // reachable from an accessor would pass here yet still violate the
-    // construction-order DAG — the .ssr suites and compat:consumer are the
-    // gate for that case.
+    // Deriveds are lazy on client and server at the 5.33.1 floor, so this
+    // guard proves the exposed accessors reach no armed getter (reads + one
+    // flush below) — the construction-read discipline. Direct (non-derived)
+    // construction-time reads of armed deps would throw right here.
     expect(state.effectiveZoomDomains).toBeNull();
     expect(state.effectiveSpec).not.toBeNull();
     flushSync();

--- a/packages/svelte/tests/plot-zoom-state.test.ts
+++ b/packages/svelte/tests/plot-zoom-state.test.ts
@@ -166,9 +166,9 @@ describe("createPlotZoomState construction", () => {
     // Client deriveds are lazy, so this guard only proves the exposed
     // accessors reach no armed getter (reads + one flush below). A
     // construction-time $derived that reads an armed dep WITHOUT being
-    // reachable from an accessor would pass here yet still crash Svelte 5.29
-    // SSR, where deriveds evaluate eagerly at construction (TDZ) — the .ssr
-    // suites and compat:consumer are the gate for that case.
+    // reachable from an accessor would pass here yet still violate the
+    // construction-order DAG — the .ssr suites and compat:consumer are the
+    // gate for that case.
     expect(state.effectiveZoomDomains).toBeNull();
     expect(state.effectiveSpec).not.toBeNull();
     flushSync();
@@ -605,7 +605,7 @@ describe("runtime + zoom real cycle", () => {
         oninteraction: noInteractionCallback,
         announce: () => {},
       });
-      // Host aliases (server-eager order).
+      // Host aliases (construction-order DAG).
       const effectiveZoomDomains = () => zoom.effectiveZoomDomains;
       const effectiveSpec = () => zoom.effectiveSpec;
       const runtimeDeps = createReactiveRuntimeDeps({

--- a/scripts/consumer-compat.test.ts
+++ b/scripts/consumer-compat.test.ts
@@ -79,7 +79,7 @@ describe("packed consumer compatibility harness", () => {
 
   test("names every local tarball in the consumer manifest", () => {
     const manifest = fixtureManifest(
-      "5.29.0",
+      "0.0.0-fixture",
       [
         join("artifacts", "ggsvelte-spec-0.0.0.tgz"),
         join("artifacts", "ggsvelte-core-0.0.0.tgz"),
@@ -87,7 +87,7 @@ describe("packed consumer compatibility harness", () => {
       ],
       "/consumer",
     );
-    expect(manifest.dependencies.svelte).toBe("5.29.0");
+    expect(manifest.dependencies.svelte).toBe("0.0.0-fixture");
     expect(manifest.dependencies["@ggsvelte/spec"]).toContain("ggsvelte-spec-0.0.0.tgz");
     expect(manifest.dependencies["@ggsvelte/core"]).toContain("ggsvelte-core-0.0.0.tgz");
     expect(manifest.dependencies["@ggsvelte/svelte"]).toContain("ggsvelte-svelte-0.0.0.tgz");

--- a/scripts/consumer-compat.test.ts
+++ b/scripts/consumer-compat.test.ts
@@ -10,6 +10,7 @@ import {
   packageTarballNames,
   resolveConsumerOptions,
 } from "./consumer-compat.js";
+import { loadSupportMatrix } from "./support-matrix.js";
 
 describe("packed consumer compatibility harness", () => {
   test("installs every publishable tarball rather than workspace source", () => {
@@ -47,6 +48,10 @@ describe("packed consumer compatibility harness", () => {
       packageManagerVersion: "11.13.0",
       svelteVersion: "5.56.5",
     });
+  });
+
+  test("default Svelte version matches the support-matrix floor", () => {
+    expect(resolveConsumerOptions([], {}).svelteVersion).toBe(loadSupportMatrix().svelte.minimum);
   });
 
   test("invokes the pinned pnpm CLI without relying on an installer-generated shim", () => {

--- a/scripts/consumer-compat.ts
+++ b/scripts/consumer-compat.ts
@@ -14,7 +14,7 @@ interface CommandStep {
 }
 
 const fixtureDependencies = [
-  // The compatibility fixture must itself support the Svelte 5.29 floor.
+  // The compatibility fixture must itself support the Svelte 5.33.1 floor.
   // Plugin 7 requires Svelte 5.46+, which would make the minimum row a test
   // of fixture peer resolution rather than a test of ggsvelte.
   "@sveltejs/vite-plugin-svelte@5.1.1",
@@ -44,7 +44,7 @@ export function resolveConsumerOptions(
 ) {
   return {
     packageManager: (args[0] ?? environment.PACKAGE_MANAGER ?? "npm") as PackageManager,
-    svelteVersion: args[1] ?? environment.SVELTE_VERSION ?? "5.29.0",
+    svelteVersion: args[1] ?? environment.SVELTE_VERSION ?? "5.33.1",
     packageManagerVersion: args[2] ?? environment.PACKAGE_MANAGER_VERSION,
   };
 }

--- a/scripts/consumer-compat.ts
+++ b/scripts/consumer-compat.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { basename, join, relative, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
 
-import type { PackageManager } from "./support-matrix.js";
+import { loadSupportMatrix, type PackageManager } from "./support-matrix.js";
 
 interface CommandStep {
   label: string;
@@ -44,7 +44,8 @@ export function resolveConsumerOptions(
 ) {
   return {
     packageManager: (args[0] ?? environment.PACKAGE_MANAGER ?? "npm") as PackageManager,
-    svelteVersion: args[1] ?? environment.SVELTE_VERSION ?? "5.33.1",
+    // Single-sourced from support-matrix.json — the floor lives in one place.
+    svelteVersion: args[1] ?? environment.SVELTE_VERSION ?? loadSupportMatrix().svelte.minimum,
     packageManagerVersion: args[2] ?? environment.PACKAGE_MANAGER_VERSION,
   };
 }

--- a/scripts/gen-llms.test.ts
+++ b/scripts/gen-llms.test.ts
@@ -98,7 +98,7 @@ describe("guide sections cover their catalogs", () => {
 
   it("documents the machine-checked packed-consumer support contract", () => {
     expect(COMPATIBILITY_MD).toContain("Node.js 22");
-    expect(COMPATIBILITY_MD).toContain("Svelte 5.29.0");
+    expect(COMPATIBILITY_MD).toContain("Svelte 5.33.1");
     expect(COMPATIBILITY_MD).toContain("npm bundled with Node");
     expect(COMPATIBILITY_MD).toContain("pnpm 11.13.0");
     expect(COMPATIBILITY_MD).toContain("Bun 1.3.14");

--- a/support-matrix.json
+++ b/support-matrix.json
@@ -6,8 +6,8 @@
     "canary": "26"
   },
   "svelte": {
-    "range": "^5.29.0",
-    "minimum": "5.29.0",
+    "range": "^5.33.1",
+    "minimum": "5.33.1",
     "current": "5.56.5"
   },
   "packageManagers": {
@@ -21,16 +21,16 @@
     "engines": ["chromium", "firefox", "webkit"]
   },
   "required": [
-    { "os": "ubuntu-latest", "node": "22", "packageManager": "npm", "svelte": "5.29.0" },
+    { "os": "ubuntu-latest", "node": "22", "packageManager": "npm", "svelte": "5.33.1" },
     { "os": "ubuntu-latest", "node": "24", "packageManager": "pnpm", "svelte": "5.56.5" },
     { "os": "ubuntu-latest", "node": "24", "packageManager": "bun", "svelte": "5.56.5" },
     { "os": "windows-latest", "node": "24", "packageManager": "npm", "svelte": "5.56.5" }
   ],
   "nightly": [
     { "os": "ubuntu-latest", "node": "26", "packageManager": "bun", "svelte": "5.56.5" },
-    { "os": "windows-latest", "node": "22", "packageManager": "pnpm", "svelte": "5.29.0" },
+    { "os": "windows-latest", "node": "22", "packageManager": "pnpm", "svelte": "5.33.1" },
     { "os": "windows-latest", "node": "24", "packageManager": "bun", "svelte": "5.56.5" },
-    { "os": "macos-latest", "node": "22", "packageManager": "npm", "svelte": "5.29.0" },
+    { "os": "macos-latest", "node": "22", "packageManager": "npm", "svelte": "5.33.1" },
     { "os": "macos-latest", "node": "24", "packageManager": "pnpm", "svelte": "5.56.5" }
   ]
 }


### PR DESCRIPTION
## Summary

First slice of the S9–S17 lib-restructure program. Raises the Svelte peer floor from `^5.29.0` to `^5.33.1` — Svelte 5.33.1 restored lazy server-side `$derived` evaluation (sveltejs/svelte#15964), which removes the eager-derived declaration-order hazard that shaped GGPlot's controller wiring. Later slices (S10/S11) delete that scaffolding.

- **Floor data**: peer range, `support-matrix.json` (`range`/`minimum` + the three floor-pinned CI rows; the data-driven matrix means zero workflow YAML changes), README.
- **Single-sourced floor**: `scripts/consumer-compat.ts` now derives its default Svelte version from `support-matrix.json`'s `svelte.minimum` instead of a duplicated literal, with a floor-consistency test.
- **Comment rewrites** (zero logic changes): obsolete "Svelte 5.29 server evaluates `$derived` eagerly" claims removed across GGPlot and the six controller state modules + their construction-guard tests. Still-true contracts preserved and reworded: deps are getter thunks, direct construction-time reads of later-declared controllers TDZ, effect-registration order is load-bearing.
- **Changeset**: minor for `@ggsvelte/svelte`; consumers on Svelte 5.29.0–5.33.0 must upgrade Svelte to take this release.

## Verification

- `bun run --bun test` (packages/svelte): 183 files / 2553 browser tests + 8 SSR tests pass across chromium/firefox/webkit
- `bun run compat:consumer`: PASS (npm, Svelte 5.33.1) — packed-consumer install, typecheck, build, runtime/SSR/CLI smoke
- `bun run check`, `bun run check:svelte` (0 errors/warnings), `bun run lint`, script suites 34/34
- `bun scripts/support-matrix.ts required|nightly`: valid rows
- Repo sweep: zero remaining `5.29` references in source/tests/docs
- Reviewed by codex (gpt-5.6-sol) at plan stage and multi-agent verify pass on the diff; all findings addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)