### PR TITLE
refactor(svelte): S11 — extract plot orchestrator

### DIFF
--- a/packages/svelte/src/lib/GGPlot.svelte
+++ b/packages/svelte/src/lib/GGPlot.svelte
@@ -10,7 +10,7 @@
    * `layers` props win over children when both are present.
    *
    * Reactivity: spec assembly is $derived; model production runs in the plot
-   * runtime (`createPlotRuntime`) with run-id gating; the committed scale
+   * runtime with run-id gating; the committed scale
    * state lives in a NON-reactive box (never read-modify-write shared reactive
    * state across init/teardown — decision 0001, finding 3). That box is what
    * makes discrete colors value-stable across data changes AND across
@@ -32,31 +32,22 @@
    * Memory (plan: "Memory ownership"): the previous RenderModel is disposed
    * on commit ($effect cleanup — runs after the DOM has moved to the new
    * model) and the last one on unmount.
+   *
+   * Controller wiring lives in `plot-orchestrator.svelte.ts` (construction /
+   * effect-order contract documented there).
    */
   import type { CellValue } from "@ggsvelte/core";
   import { sceneLabel } from "@ggsvelte/core";
-  import type { SceneHitIndex } from "@ggsvelte/core/dom";
-  import { buildHitIndex } from "@ggsvelte/core/dom";
-  import type { DataInput, PortableSpec } from "@ggsvelte/spec";
 
-  import {
-    normalizeInteractionConfig,
-    type InteractionDiagnostic,
-    type LegendFocusEvent,
-    type PlotInspection,
-    type PlotInteractionEvent,
-    type PlotInteractionScope,
-    type PlotSelection,
-    type ZoomDomains,
+  import type {
+    LegendFocusEvent,
+    PlotInspection,
+    PlotInteractionEvent,
+    PlotSelection,
+    ZoomDomains,
   } from "./interaction.js";
   import type { PlotInteractionController } from "./interaction-controller.svelte.js";
   import { provideRegistry } from "./registry.svelte.js";
-  import {
-    assemblePortableSpec,
-    isFacetedPlotIntent,
-    resolveInteractionScope,
-    toLayerInput,
-  } from "./plot-assemble.js";
   import { shouldRenderInteractionLiveRegion } from "./plot-legend-surface.js";
   import { resolveInteractionLiveText } from "./plot-labels.js";
   import {
@@ -69,17 +60,8 @@
     tooltipViewportSize,
   } from "./plot-layout.js";
   import BoundsEditor from "./BoundsEditor.svelte";
-  import {
-    createSourceIdentityTracker,
-    dataIdentityEpochToken,
-  } from "./plot-semantic-keys.js";
-  import {
-    createPlotAnnouncer,
-    createSemanticKeyService,
-  } from "./plot-shared-services.svelte.js";
-  import { createPlotRuntime } from "./plot-runtime.svelte.js";
-  import type { LegendEntryIdentity } from "./plot-legend-focus.js";
   import type { GGPlotProps } from "./plot-props.js";
+  import { createPlotOrchestrator } from "./plot-orchestrator.svelte.js";
   import PlotCaptureSurface from "./PlotCaptureSurface.svelte";
   import PlotLegendFilters from "./PlotLegendFilters.svelte";
   import PlotLegendTargets from "./PlotLegendTargets.svelte";
@@ -88,14 +70,6 @@
   import PlotStatusChrome from "./PlotStatusChrome.svelte";
   import Tooltip from "./Tooltip.svelte";
   import ToolRail from "./ToolRail.svelte";
-  import { createLegendFilterState } from "./legend-filter-state.svelte.js";
-  import { createLegendFocusState } from "./legend-focus-state.svelte.js";
-  import { createPlotZoomState } from "./plot-zoom-state.svelte.js";
-  import { createIntervalState } from "./interval-state.svelte.js";
-  import { createInspectionState } from "./inspection-state.svelte.js";
-  import { createSurfaceState } from "./surface-state.svelte.js";
-  import { createSelectionState } from "./selection-state.svelte.js";
-  import { createPlotChromeState } from "./plot-chrome-state.svelte.js";
 
   const {
     spec,
@@ -134,142 +108,75 @@
   }: GGPlotProps<Row, Identity> = $props();
 
   const registry = provideRegistry();
-
-  // Reading descriptors through toLayerInput goes through live getters, so
-  // geom prop changes flow into this $derived without re-registration.
-  // Explicit `spec` short-circuits before registry/children so ignored props
-  // do not become reactive dependencies of the assembled plot.
-  const assembled: PortableSpec | null = $derived.by(() => {
-    if (spec !== undefined) return assemblePortableSpec({ spec, layers: [] });
-    return assemblePortableSpec({
-      ...(data !== undefined && { data: data as DataInput | readonly Row[] }),
-      ...(mapping !== undefined && { aes: mapping }),
-      layers: layers ?? registry.layers.map(toLayerInput),
-      ...(facet !== undefined && { facet }),
-      ...(coord !== undefined && { coord }),
-      ...(scales !== undefined && { scales }),
-      ...(legend !== undefined && { legend }),
-      ...(theme !== undefined && { theme }),
-      ...(labs !== undefined && { labs }),
-      ...(a11y !== undefined && { a11y }),
-    });
-  });
-
-  // Facet intent: raw prop (declaration-only children before layers register)
-  // OR assembled.facet (portable-spec plots that embed facet without a prop).
-  const facetedPlot = $derived(isFacetedPlotIntent({ facet, assembled }));
-
-  const resolvedInteractionScope: PlotInteractionScope = $derived(
-    resolveInteractionScope({
-      interaction,
-      ...(interactionScope !== undefined && { interactionScope }),
-      zoom,
-      faceted: facetedPlot,
-      ...(datumKey !== undefined && { datumKey }),
-      assembled,
-    }),
-  );
-
-  const interactionConfig = $derived(
-    normalizeInteractionConfig(
-      {
-        inspect,
-        select,
-        zoom,
-        legendFocus,
-        ...(tool !== undefined && { tool }),
-      },
-      {
-        faceted: facetedPlot,
-        hasKey: datumKey !== undefined,
-      },
-    ),
-  );
-
-  function deliverDiagnostic(diagnostic: InteractionDiagnostic): void {
-    ondiagnostic?.(diagnostic);
-    const nodeEnvironment = (
-      globalThis as { process?: { env?: { NODE_ENV?: string } } }
-    ).process?.env?.NODE_ENV;
-    if (nodeEnvironment !== "production" && ondiagnostic === undefined)
-      console.warn(`[ggsvelte:${diagnostic.code}] ${diagnostic.message}`);
-  }
-
-  $effect(() => {
-    for (const diagnostic of interactionConfig.diagnostics)
-      deliverDiagnostic(diagnostic);
-  });
-
-  // Shared controller-factory dep aliases: ONE place for the PublicKey →
-  // PropertyKey widening casts every extracted controller (S2–S8) wires.
-  const factoryInteraction = $derived(
-    interaction as PlotInteractionController<PropertyKey> | undefined,
-  );
-  const factoryOninteraction = $derived(
-    oninteraction as
-      | ((
-          event: PlotInteractionEvent<Record<string, CellValue>, PropertyKey>,
-        ) => void)
-      | undefined,
-  );
-  const factoryOninspect = $derived(
-    oninspect as
-      ((event: PlotInspection<Record<string, CellValue>>) => void) | undefined,
-  );
-  // Announcer is declared later; the sink is handler-only (never construction).
-  const announceSink = (message: string): void => {
-    announcer.announce(message);
-  };
-
-  // Construction order is the topological order of direct construction-time
-  // reads; effect registration sequence is load-bearing. Deferred thunks break
-  // the runtime cycles (surface ↔ inspection ↔ interval ↔ selection).
-
-  // ------------------------------------------------------------ zoom respec
-  // Construction-time deriveds read interaction/scope/zoomConfig/assembled
-  // only — model/coordFlipped/announce are deferred getters (later-declared).
-  const zoomState = createPlotZoomState({
-    interaction: () => factoryInteraction,
-    resolvedInteractionScope: () => resolvedInteractionScope,
-    zoomConfig: () => interactionConfig.zoom,
-    assembled: () => assembled,
-    // model / coordFlipped declared after the runtime; handlers only.
-    model: () => runtime.model,
-    coordFlipped: () => coordFlipped,
-    onzoom: () => onzoom,
-    oninteraction: () => factoryOninteraction,
-    announce: announceSink,
-  });
-
-  // Source identity/order epoch: stable through responsive layout and zoom
-  // respecs, different when normalized inline data or data references change.
-  // Tracker is owned for the component lifetime (never cleared).
-  const { sourceIdentity } = createSourceIdentityTracker();
-  const dataIdentityEpoch = $derived(
-    dataIdentityEpochToken({
-      assembled,
-      dataToken: sourceIdentity(data),
-      specToken: sourceIdentity(spec),
-    }),
-  );
-
   let root = $state<HTMLDivElement | null>(null);
-  // Live-region announcer (owned early so legend-reset effects can call it).
-  const announcer = createPlotAnnouncer();
+  let captureSurface = $state<HTMLDivElement | null>(null);
+  let a11yTableOpen = $state(false);
+  const plotId = $props.id();
 
-  // ------------------------------------------------- legend filter
-  // Construction-time deriveds read legendFilter/effectiveSpec only —
-  // model is deferred (declared after the runtime).
-  const legendFilterState = createLegendFilterState({
-    effectiveSpec: () => zoomState.effectiveSpec,
-    legendFilterProp: () => legendFilter,
+  const engine = createPlotOrchestrator<Row, Identity>({
+    registry,
+    plotId,
+    root: () => root,
+    captureSurface: () => captureSurface,
+    spec: () => spec,
+    data: () => data,
+    mapping: () => mapping,
+    layers: () => layers,
+    facet: () => facet,
+    coord: () => coord,
+    scales: () => scales,
+    legend: () => legend,
+    theme: () => theme,
+    labs: () => labs,
+    a11y: () => a11y,
+    width: () => width,
+    height: () => height,
+    datumKey: () => datumKey,
+    inspect: () => inspect,
+    select: () => select,
+    zoom: () => zoom,
+    legendFocus: () => legendFocus,
+    legendFilter: () => legendFilter,
+    tool: () => tool,
+    interaction: () =>
+      interaction as PlotInteractionController<PropertyKey> | undefined,
+    interactionScope: () => interactionScope,
+    oninspect: () =>
+      oninspect as
+        | ((
+            event: PlotInspection<Record<string, CellValue>, PropertyKey>,
+          ) => void)
+        | undefined,
+    onselect: () =>
+      onselect as ((event: PlotSelection<PropertyKey>) => void) | undefined,
+    onzoom: () => onzoom,
+    onlegendfocus: () =>
+      onlegendfocus as
+        ((event: LegendFocusEvent<PropertyKey>) => void) | undefined,
     onlegendfilter: () => onlegendfilter,
-    oninteraction: () => oninteraction,
-    announce: announceSink,
-    // model is declared after the runtime; the getter is only invoked from
-    // late catalog effects (never at construction).
-    model: () => runtime.model,
+    oninteraction: () =>
+      oninteraction as
+        | ((
+            event: PlotInteractionEvent<Record<string, CellValue>, PropertyKey>,
+          ) => void)
+        | undefined,
+    ondiagnostic: () => ondiagnostic,
+    ontoolchange: () => ontoolchange,
+    onrender: () => onrender,
   });
+
+  const {
+    zoomState,
+    legendFilterState,
+    runtime,
+    inspectionState,
+    surfaceState,
+    selectionState,
+    legendFocusState,
+    intervalState,
+    chromeState,
+    announcer,
+  } = engine;
 
   /**
    * Clear committed grow-mode scale state and any brush zoom so the next
@@ -277,297 +184,14 @@
    * that drop categories whose reserved colors should not persist.
    */
   export function resetScales(): void {
-    runtime.resetScales();
+    engine.runtime.resetScales();
   }
-
-  // ------------------------------------------------- plot runtime
-  // Factory sits after zoom-respec and legend-filter so every direct
-  // construction-time dep is already initialized (TDZ).
-  // Effect registration: model dispose/onrender effects register here;
-  // ResizeObserver registers later via registerLateEffects (after legend
-  // reconcile) — safe because the observer callback is async.
-  const runtime = createPlotRuntime({
-    widthProp: () => width,
-    heightProp: () => height,
-    assembled: () => assembled,
-    effectiveSpec: () => zoomState.effectiveSpec,
-    effectiveZoomDomains: () => zoomState.effectiveZoomDomains,
-    effectiveLegendFilters: () => legendFilterState.filters,
-    root: () => root,
-    resetZoom: () => zoomState.resetForScales(),
-    onrender: () => onrender,
-  });
-  // Model dispose + onrender effects (after the legend-reset effects that
-  // registered during legendFilterState construction; before late effects).
-  runtime.registerModelEffects();
-
-  // Semantic resolution as soon as the runtime model exists. Diagnostics
-  // effects register later; early construction makes interval projection
-  // safe when a shared controller arrives with pre-populated non-union
-  // intervals (#165).
-  const semanticKeys = createSemanticKeyService({
-    model: () => runtime.model,
-    assembled: () => assembled,
-    datumKey: () =>
-      datumKey as
-        string | ((row: never, index: number) => PropertyKey) | undefined,
-    data: () => data,
-    spec: () => spec,
-    sourceIdentity,
-    deliverDiagnostic,
-  });
-  const semanticKey = semanticKeys.semanticKey;
-  const candidateSemanticKeys = semanticKeys.candidateSemanticKeys;
-
-  let a11yTableOpen = $state(false);
-
-  // ---------------------------------------------------------- interaction
-  // source rows/spec -> pipeline/scene -> hit index -> semantic resolver ->
-  // chart-local reducer -> tooltip/crosshair/tools/callbacks. Presentation
-  // consumes one resolved inspection and never reconstructs grouping itself.
-  const interactive = $derived(interactionConfig.interactive);
-  const surfaceInteractive = $derived(
-    interactionConfig.availableTools.length > 0,
-  );
-  const hitIndex: SceneHitIndex | null = $derived.by(() =>
-    surfaceInteractive && runtime.model !== null
-      ? buildHitIndex(runtime.model.scene)
-      : null,
-  );
-
-  // ------------------------------------------------- inspection
-  // Construction-time deriveds may read model / surfaceInteractive (both
-  // earlier). Phased effects register later via registerInspectionEffects().
-  // Reversed deps: reducer / clearBrush / chooseTool close over the later-
-  // declared surfaceState (handler/effect-only; construction guard).
-  const inspectionState = createInspectionState({
-    model: () => runtime.model,
-    // Deferred: surface owns the reducer (handler/effect only).
-    reducer: () => surfaceState.reducer,
-    inspectConfig: () => interactionConfig.inspect,
-    surfaceInteractive: () => surfaceInteractive,
-    inspectEnabled: () => inspectEnabled,
-    dataIdentityEpoch: () => dataIdentityEpoch,
-    // Deferred: semantic-key service is declared later (handler only).
-    keyAt: (index) => semanticKeys.keyAt(index),
-    root: () => root,
-    captureSurface: () => captureSurface,
-    plotId: () => plotId,
-    tooltipHovered: () => tooltipHovered,
-    clearTooltipHovered: () => {
-      tooltipHovered = false;
-    },
-    clearBrush: () => surfaceState.clearBrush(),
-    chooseTool: (next) => surfaceState.chooseTool(next),
-    oninspect: () => factoryOninspect,
-    oninteraction: () => factoryOninteraction,
-    announce: announceSink,
-    clearAnnouncement: () => announcer.clear(),
-  });
-  // ------------------------------------------------- surface
-  // Construction-time deriveds read module-internal state + inspectConfig.
-  // Sibling controllers, sinks, and chrome getters are handler/effect-only.
-  // Phased effects register later via registerSurfaceEffects().
-  const surfaceState = createSurfaceState({
-    model: () => runtime.model,
-    coordFlipped: () => coordFlipped,
-    root: () => root,
-    toolProp: () => tool,
-    initialTool: () => interactionConfig.initialTool,
-    // Deferred: chrome availableTools (handler/effect only).
-    availableTools: () => chromeState.availableTools,
-    inspectConfig: () => interactionConfig.inspect,
-    selectConfig: () => interactionConfig.select,
-    // Deferred: chrome canPublishPointSelection (handler only).
-    pointSelectEnabled: () => chromeState.canPublishPointSelection,
-    ontoolchange: () => ontoolchange,
-    surfaceInteractive: () => surfaceInteractive,
-    hitIndex: () => hitIndex,
-    // Deferred: semantic-key service initializes later (issue #165).
-    candidateSemanticKeys: (candidate) => candidateSemanticKeys(candidate),
-    inspection: () => inspectionState,
-    // Deferred: interval is declared after surface (handler only).
-    interval: () => intervalState,
-    zoom: () => zoomState,
-    // Deferred: selection controller is declared after surface (handler only).
-    emitSelection: (event) => selectionState.emitSelection(event),
-    // Deferred: semantic-key service is declared later (handler only).
-    semanticKey: (row, index) => semanticKey(row, index),
-    // Deferred: selection controller is declared after surface (handler only).
-    togglePointKeys: (keys, source) =>
-      selectionState.togglePointKeys(keys, source),
-    tooltipHovered: () => tooltipHovered,
-    announce: announceSink,
-  });
-  const coordFlipped = $derived(assembled?.coord?.type === "flip");
-  let tooltipHovered = $state(false);
-  let captureSurface = $state<HTMLDivElement | null>(null);
-  // ------------------------------------------------- selection
-  // Construction-time effectiveSelectedKeys reads earlier interaction/scope
-  // only. Anchors and masks are methods (later-declared inputs).
-  const selectionState = createSelectionState({
-    model: () => runtime.model,
-    interaction: () => factoryInteraction,
-    resolvedInteractionScope: () => resolvedInteractionScope,
-    selectConfig: () => interactionConfig.select,
-    // Deferred: interval is declared after this factory (method only).
-    effectiveIntervalKeys: () => intervalState.effectiveIntervalKeys,
-    // Deferred: legend-focus is declared after this factory (method only).
-    effectiveEmphasisKeys: () => legendFocusState.effectiveEmphasisKeys,
-    // Deferred method-only projection of inspection focus for presentation masks.
-    inspectionFocus: () => {
-      const current = inspectionState.inspection;
-      return current === null
-        ? null
-        : {
-            sourceKeys: current.focus.sourceKeys,
-            key: current.focus.key,
-          };
-    },
-    // Deferred: semantic-key service initializes later (#165).
-    candidateSemanticKeys: (candidate) => candidateSemanticKeys(candidate),
-    onselect: () => onselect as ((event: PlotSelection) => void) | undefined,
-    oninteraction: () => factoryOninteraction,
-    announce: announceSink,
-  });
-  // Shared enablement predicates (avoid re-typing the same config gates).
-  const inspectEnabled = $derived(interactionConfig.inspect !== null);
-  const legendFocusEnabled = $derived(interactionConfig.legendFocus !== null);
-  // ------------------------------------------------- legend focus
-  // Factory sits after the enablement cluster so construction-time
-  // effectiveEmphasisKeys closes over earlier bindings only.
-  const legendFocusState = createLegendFocusState({
-    interaction: () => factoryInteraction,
-    resolvedInteractionScope: () => resolvedInteractionScope,
-    legendFocusEnabled: () => legendFocusEnabled,
-    legendFocusPreviewEnabled: () =>
-      interactionConfig.legendFocus?.preview === true,
-    root: () => root,
-    semanticKeys: () => semanticKeys,
-    entries: () => interactiveLegendEntries,
-    // Deferred read of the later-declared cached derived (handlers only).
-    pressed: () => effectiveLegendPressed,
-    onlegendfocus: () =>
-      onlegendfocus as
-        ((event: LegendFocusEvent<PropertyKey>) => void) | undefined,
-    oninteraction: () => factoryOninteraction,
-    announce: announceSink,
-  });
-  // ------------------------------------------------- interval selection
-  // Construction-time deriveds may read model/effectiveZoomDomains (both
-  // earlier-declared). Effects register here — relative order is runtime
-  // model effects < interval effects < semantic diagnostics.
-  const intervalState = createIntervalState({
-    model: () => runtime.model,
-    interaction: () => factoryInteraction,
-    resolvedInteractionScope: () => resolvedInteractionScope,
-    selectConfig: () => interactionConfig.select,
-    effectiveZoomDomains: () => zoomState.effectiveZoomDomains,
-    // Direct construction edges (not deferred thunks): zoom + selection
-    // are already constructed when interval is built.
-    commitZoom: zoomState.commitZoom,
-    coordFlipped: () => coordFlipped,
-    captureSurface: () => captureSurface,
-    candidateSemanticKeys: (candidate) => candidateSemanticKeys(candidate),
-    inspectionPanel: () => inspectionState.inspectionPanel,
-    emitSelection: selectionState.emitSelection,
-    announce: announceSink,
-  });
-  // ------------------------------------------------- plot chrome
-  // All inputs earlier-declared. Pure construction-time deriveds —
-  // no $state/handlers/effects.
-  const chromeState = createPlotChromeState({
-    model: () => runtime.model,
-    zoomConfig: () => interactionConfig.zoom,
-    selectConfig: () => interactionConfig.select,
-    configuredAvailableTools: () => interactionConfig.availableTools,
-    interactionDiagnostics: () => interactionConfig.diagnostics,
-    interactive: () => interactive,
-    effectiveZoomDomains: () => zoomState.effectiveZoomDomains,
-    effectiveIntervals: () => intervalState.effectiveIntervals,
-    effectiveSelectedKeys: () => selectionState.effectiveSelectedKeys,
-    effectiveEmphasisKeys: () => legendFocusState.effectiveEmphasisKeys,
-    legendFocusEnabled: () => legendFocusEnabled,
-    hasCanvas: () => runtime.hasCanvas,
-    width: () => width,
-    resolvedWidth: () => runtime.resolvedWidth,
-    resolvedHeight: () => runtime.resolvedHeight,
-  });
-  // Method-call deriveds (not pure aliases) — keep as intermediate memos.
-  const selectedAnchors = $derived(selectionState.computeSelectedAnchors());
-  const emphasizedAnchors = $derived(selectionState.computeEmphasizedAnchors());
-
-  const plotId = $props.id();
-  // Semantic diagnostics effects (before host diagnostic / surface effects).
-  semanticKeys.registerEffects();
-
-  $effect(() => {
-    for (const diagnostic of chromeState.areaScaleDiagnostics)
-      deliverDiagnostic(diagnostic);
-  });
-
-  $effect(() => {
-    for (const diagnostic of chromeState.legendDiagnostics)
-      deliverDiagnostic(diagnostic);
-  });
-
-  // Surface window-teardown + tool-sync (after diagnostics, before catalog/
-  // focus/inspection registrations).
-  surfaceState.registerSurfaceEffects();
-
-  // Three separate host deriveds — intermediate memo boundaries live here
-  // (do NOT fold into one method).
-  const presentationFocusKeys = $derived(
-    selectionState.computePresentationFocusKeys(),
-  );
-  const semanticCandidateProjections = $derived(
-    selectionState.computeSemanticCandidateProjections(),
-  );
-  const interactionMasks = $derived(
-    selectionState.computeInteractionMasks(
-      presentationFocusKeys,
-      // Thunk: with empty focus (idle), the projections derived is never read.
-      () => semanticCandidateProjections,
-    ),
-  );
-
-  // Host-side deriveds kept outside the factory (construction-time free of
-  // the model read).
-  const interactiveLegendEntries = $derived(
-    legendFocusState.computeInteractiveEntries(runtime.model),
-  );
-
-  const effectiveLegendPressed: LegendEntryIdentity | null = $derived(
-    legendFocusState.computeLegendPressed(runtime.model),
-  );
-
-  // Single source for "the legend clear row is shown": the root class and
-  // the filter fieldset's below-clear offset must flip together (the legend
-  // layout test pins their combined geometry).
-  const legendClearActive = $derived(
-    legendFocusEnabled && effectiveLegendPressed !== null,
-  );
-
-  // Host-side derived kept outside the factory (construction-time free of
-  // the model read).
-  const filterableLegendEntries = $derived(
-    legendFilterState.computeEntries(runtime.model),
-  );
-  // Catalog reconcile after model effects.
-  legendFilterState.registerCatalogEffects(() => filterableLegendEntries);
-  // Legend-focus reconcile after catalog.
-  legendFocusState.registerReconcileEffects();
-  // Inspection disposal + scene reconcile after legend-focus.
-  inspectionState.registerInspectionEffects();
 
   /** Replace one or both continuous zoom domains without disturbing the
    *  other channel. This is the controlled linking/programmatic-zoom path. */
   export function setZoom(domains: Partial<ZoomDomains>): void {
-    zoomState.setZoomDomains(domains);
+    engine.zoomState.setZoomDomains(domains);
   }
-
-  // clientFlush/ready effect at end of script (late registration).
-  runtime.registerLateEffects();
 </script>
 
 <!-- Children MUST render before any registry-consuming markup: SSR evaluates
@@ -582,8 +206,8 @@
   class="gg-plot-root"
   class:gg-container-width={isContainerWidthProp(width)}
   class:gg-with-tool-rail={chromeState.showToolRail}
-  class:gg-with-legend-clear={legendClearActive}
-  class:gg-with-legend-filters={filterableLegendEntries.length > 0}
+  class:gg-with-legend-clear={engine.legendClearActive}
+  class:gg-with-legend-filters={engine.filterableLegendEntries.length > 0}
   class:gg-narrow-tools={isNarrowToolsWidth(runtime.resolvedWidth)}
   class:gg-with-docked-tooltip={isTooltipDocked({
     inspectionState: inspectionState.inspection?.state,
@@ -635,21 +259,21 @@
       model={currentModel}
       strata={runtime.strata}
       markLabel={chromeState.markLabel}
-      {interactionMasks}
+      interactionMasks={engine.interactionMasks}
       {a11yTableOpen}
       onA11yToggle={() => (a11yTableOpen = !a11yTableOpen)}
       onPainted={runtime.notifyPainted}
     />
     <PlotLegendTargets
-      entries={interactiveLegendEntries}
+      entries={engine.interactiveLegendEntries}
       previewIdentity={legendFocusState.previewIdentity}
-      pressedIdentity={effectiveLegendPressed}
+      pressedIdentity={engine.effectiveLegendPressed}
       rovingIndex={legendFocusState.rovingIndex}
       sceneWidth={currentModel.scene.width}
       sceneHeight={currentModel.scene.height}
       clearLegendX={resolveClearLegendX({
-        legendFocusEnabled,
-        pressedScale: effectiveLegendPressed?.scale ?? null,
+        legendFocusEnabled: engine.legendFocusEnabled,
+        pressedScale: engine.effectiveLegendPressed?.scale ?? null,
         legends: currentModel.scene.legends,
       })}
       onPreviewIndex={legendFocusState.onPreviewIndex}
@@ -667,36 +291,36 @@
     />
     <PlotLegendFilters
       controller={legendFilterState}
-      entries={filterableLegendEntries}
-      belowClearFocus={legendClearActive}
+      entries={engine.filterableLegendEntries}
+      belowClearFocus={engine.legendClearActive}
     />
     <PlotSceneOverlays
       width={currentModel.scene.width}
       height={currentModel.scene.height}
-      {interactive}
-      {surfaceInteractive}
+      interactive={engine.interactive}
+      surfaceInteractive={engine.surfaceInteractive}
       inspection={inspectionState.inspection}
       inspectionPanel={inspectionState.inspectionPanel}
-      {coordFlipped}
-      {selectedAnchors}
-      {emphasizedAnchors}
+      coordFlipped={engine.coordFlipped}
+      selectedAnchors={engine.selectedAnchors}
+      emphasizedAnchors={engine.emphasizedAnchors}
       brushRect={surfaceState.brushRect}
       activeTool={surfaceState.activeTool}
       areaAwaitingSecond={surfaceState.areaAwaitingSecond}
       committedInterval={intervalState.committedInterval}
     />
-    {#if surfaceInteractive}
+    {#if engine.surfaceInteractive}
       <!-- Order (document = paint): overlay → capture → Tooltip → status chrome. -->
       <PlotCaptureSurface
         bind:element={captureSurface}
         {plotId}
         activeTool={surfaceState.activeTool}
         ariaLabel={ariaLabel ??
-          assembled?.labs?.title ??
+          engine.assembled?.labs?.title ??
           sceneLabel(currentModel.scene)}
         ariaControls={resolveCaptureAriaControls({
           inspectionState: inspectionState.inspection?.state,
-          contentMode: interactionConfig.inspect?.contentMode,
+          contentMode: engine.interactionConfig.inspect?.contentMode,
           plotId,
         })}
         onFocus={() => {
@@ -726,15 +350,16 @@
           inspection={currentInspection}
           width={tooltipSize.width}
           height={tooltipSize.height}
-          content={interactionConfig.inspect?.content}
-          interactive={interactionConfig.inspect?.contentMode === "interactive"}
+          content={engine.interactionConfig.inspect?.content}
+          interactive={engine.interactionConfig.inspect?.contentMode ===
+            "interactive"}
           docked={isTooltipDocked({
             inspectionState: currentInspection.state,
             widthPx: runtime.resolvedWidth,
           })}
-          onenter={() => (tooltipHovered = true)}
+          onenter={() => (engine.tooltipHovered = true)}
           onleave={() => {
-            tooltipHovered = false;
+            engine.tooltipHovered = false;
             if (inspectionState.inspection?.state !== "pinned")
               inspectionState.setInspection(null, "pointer");
           }}
@@ -747,16 +372,16 @@
          nodes (chrome has no transitions — intentional no-op). -->
     <PlotStatusChrome
       {plotId}
-      showInstructions={surfaceInteractive}
+      showInstructions={engine.surfaceInteractive}
       description={surfaceState.surfaceDescription}
       activeDatumLabel={chromeState.datumLabel(
         inspectionState.inspection?.focus.row ?? null,
       )}
-      showAreaInstruction={surfaceInteractive &&
+      showAreaInstruction={engine.surfaceInteractive &&
         surfaceState.areaAwaitingSecond}
       showLiveRegion={shouldRenderInteractionLiveRegion({
-        surfaceInteractive,
-        legendFocusEnabled,
+        surfaceInteractive: engine.surfaceInteractive,
+        legendFocusEnabled: engine.legendFocusEnabled,
         legendFilterEnabled: legendFilterState.options !== null,
       })}
       liveText={resolveInteractionLiveText({

--- a/packages/svelte/src/lib/GGPlot.svelte
+++ b/packages/svelte/src/lib/GGPlot.svelte
@@ -33,43 +33,21 @@
    * on commit ($effect cleanup — runs after the DOM has moved to the new
    * model) and the last one on unmount.
    */
-  import type { Snippet } from "svelte";
-
-  import type {
-    A11yMode,
-    AesInput,
-    CoordSpec,
-    DataInput,
-    FacetInput,
-    Labs,
-    LayerInput,
-    LegendSpec,
-    PortableSpec,
-    Scales,
-    SpecInput,
-    ThemeName,
-    ThemeSpec,
-  } from "@ggsvelte/spec";
-  import type { CellValue, RenderModel } from "@ggsvelte/core";
+  import type { CellValue } from "@ggsvelte/core";
   import { sceneLabel } from "@ggsvelte/core";
   import type { SceneHitIndex } from "@ggsvelte/core/dom";
   import { buildHitIndex } from "@ggsvelte/core/dom";
+  import type { DataInput, PortableSpec } from "@ggsvelte/spec";
 
   import {
     normalizeInteractionConfig,
-    type InspectInput,
     type InteractionDiagnostic,
-    type InteractionTool,
     type LegendFocusEvent,
-    type LegendFocusInput,
     type PlotInspection,
     type PlotInteractionEvent,
     type PlotInteractionScope,
     type PlotSelection,
-    type SelectInput,
     type ZoomDomains,
-    type ZoomEvent,
-    type ZoomInput,
   } from "./interaction.js";
   import type { PlotInteractionController } from "./interaction-controller.svelte.js";
   import { provideRegistry } from "./registry.svelte.js";
@@ -101,6 +79,7 @@
   } from "./plot-shared-services.svelte.js";
   import { createPlotRuntime } from "./plot-runtime.svelte.js";
   import type { LegendEntryIdentity } from "./plot-legend-focus.js";
+  import type { GGPlotProps } from "./plot-props.js";
   import PlotCaptureSurface from "./PlotCaptureSurface.svelte";
   import PlotLegendFilters from "./PlotLegendFilters.svelte";
   import PlotLegendTargets from "./PlotLegendTargets.svelte";
@@ -117,77 +96,6 @@
   import { createSurfaceState } from "./surface-state.svelte.js";
   import { createSelectionState } from "./selection-state.svelte.js";
   import { createPlotChromeState } from "./plot-chrome-state.svelte.js";
-  import {
-    type LegendFilterEvent,
-    type LegendFilterInput,
-  } from "./legend-filter.js";
-
-  type PublicKey = Identity extends keyof Row
-    ? Extract<Row[Identity], PropertyKey>
-    : Identity extends (row: Row, index: number) => infer Key
-      ? Extract<Key, PropertyKey>
-      : never;
-
-  interface Props {
-    /** A complete spec (bare-string channel shorthand allowed). Wins over the other props. */
-    spec?: SpecInput;
-    /** Data rows, columns, or a DataRef ({values}/{columns}/{name}). */
-    data?: DataInput | readonly Row[];
-    /** Plot-level aesthetic mapping (inherited by every layer). */
-    aes?: AesInput;
-    /** Layers (props-first canonical form). Wins over declaration-only children. */
-    layers?: LayerInput[];
-    /** Facet into small multiples (wrap or rows/cols grid). */
-    facet?: FacetInput;
-    /** Coordinate system ("flip" shorthand accepted). */
-    coord?: CoordSpec | "flip";
-    /** Per-scale configuration (types, domains, schemes, breaks, labels). */
-    scales?: Scales;
-    /** Legend options (order). */
-    legend?: LegendSpec;
-    /** Theme: a registered name or an object with role overrides. */
-    theme?: ThemeName | ThemeSpec;
-    /** Titles and axis labels. */
-    labs?: Labs;
-    /** Accessibility mode ("force-svg" keeps every layer as SVG marks). */
-    a11y?: A11yMode;
-    /** Plot width in px. Omitted is container-responsive. */
-    width?: number | "container";
-    /** Plot height in px (falls back to spec.height, then 400). */
-    height?: number;
-    /** Stable semantic identity used by public interaction payloads. */
-    key?: Identity;
-    /** Opt into inspection, its semantic crosshair, tooltip, and pinning. */
-    inspect?: InspectInput;
-    /** Opt into point or interval selection. */
-    select?: SelectInput;
-    /** Opt into brush zoom. */
-    zoom?: ZoomInput;
-    /** Opt into discrete legend preview, focus, and linked emphasis. */
-    legendFocus?: LegendFocusInput;
-    /** Opt into data-changing filtering through discrete legend controls. */
-    legendFilter?: LegendFilterInput;
-    /** Controlled initial/active tool. */
-    tool?: InteractionTool;
-    /** Optional durable semantic state shared with other plots and Svelte UI. */
-    interaction?: PlotInteractionController<PublicKey>;
-    /** Semantic identity for linked keys and positional domains. */
-    interactionScope?: PlotInteractionScope;
-    /** Accessible chart name; falls back to the plot title/generated label. */
-    ariaLabel?: string;
-    oninspect?: (event: PlotInspection<Row, PublicKey>) => void;
-    onselect?: (event: PlotSelection<PublicKey>) => void;
-    onzoom?: (event: ZoomEvent) => void;
-    onlegendfocus?: (event: LegendFocusEvent<PublicKey>) => void;
-    onlegendfilter?: (event: LegendFilterEvent) => void;
-    oninteraction?: (event: PlotInteractionEvent<Row, PublicKey>) => void;
-    ondiagnostic?: (diagnostic: InteractionDiagnostic) => void;
-    ontoolchange?: (tool: InteractionTool) => void;
-    /** Called after each committed render with the model (warnings,
-     *  advisories, scales) and the normalized PortableSpec. */
-    onrender?: (model: RenderModel, spec: PortableSpec) => void;
-    children?: Snippet;
-  }
 
   const {
     spec,
@@ -223,7 +131,7 @@
     ontoolchange,
     onrender,
     children,
-  }: Props = $props();
+  }: GGPlotProps<Row, Identity> = $props();
 
   const registry = provideRegistry();
 

--- a/packages/svelte/src/lib/GGPlot.svelte
+++ b/packages/svelte/src/lib/GGPlot.svelte
@@ -138,6 +138,9 @@
     legendFocus: () => legendFocus,
     legendFilter: () => legendFilter,
     tool: () => tool,
+    // The PublicKey → PropertyKey widening casts live HERE (component-local
+    // generic erased at the orchestrator boundary; same widening the pre-S11
+    // factory* aliases performed).
     interaction: () =>
       interaction as PlotInteractionController<PropertyKey> | undefined,
     interactionScope: () => interactionScope,
@@ -184,13 +187,13 @@
    * that drop categories whose reserved colors should not persist.
    */
   export function resetScales(): void {
-    engine.runtime.resetScales();
+    runtime.resetScales();
   }
 
   /** Replace one or both continuous zoom domains without disturbing the
    *  other channel. This is the controlled linking/programmatic-zoom path. */
   export function setZoom(domains: Partial<ZoomDomains>): void {
-    engine.zoomState.setZoomDomains(domains);
+    zoomState.setZoomDomains(domains);
   }
 </script>
 

--- a/packages/svelte/src/lib/plot-orchestrator.svelte.ts
+++ b/packages/svelte/src/lib/plot-orchestrator.svelte.ts
@@ -1,0 +1,664 @@
+/**
+ * Plot orchestrator — controller wiring + host-level deriveds for <GGPlot>.
+ *
+ * Ownership
+ * ---------
+ * GGPlot owns: root, captureSurface, a11yTableOpen, plotId (component runes /
+ *   bind:this / $props.id / markup-only state). Context (`provideRegistry`) and
+ *   `$props()` also stay in the component.
+ * Orchestrator owns: tooltipHovered and all controller construction, host
+ *   deriveds, and phased effect registration.
+ *
+ * Construction / effect-order contract
+ * ------------------------------------
+ * Construction order is the topological order of direct construction-time
+ * reads; effect registration sequence is load-bearing. Deferred thunks break
+ * the runtime cycles (surface ↔ inspection ↔ interval ↔ selection). This
+ * module preserves the pre-S11 top-to-bottom declaration order from GGPlot.
+ *
+ * Call `createPlotOrchestrator` once during component init so every `$effect`
+ * registers in the component effect tree. No `$props`, `$props.id()`, or
+ * context calls live here.
+ */
+import type { BatchInteractionMask, CellValue } from "@ggsvelte/core";
+import { buildHitIndex, type SceneHitIndex } from "@ggsvelte/core/dom";
+import type {
+  A11yMode,
+  AesInput,
+  CoordSpec,
+  DataInput,
+  FacetInput,
+  Labs,
+  LayerInput,
+  LegendSpec,
+  PortableSpec,
+  Scales,
+  SpecInput,
+  ThemeName,
+  ThemeSpec,
+} from "@ggsvelte/spec";
+
+import type {
+  InspectInput,
+  InteractionDiagnostic,
+  InteractionTool,
+  LegendFocusEvent,
+  LegendFocusInput,
+  PlotInspection,
+  PlotInteractionEvent,
+  PlotInteractionScope,
+  PlotSelection,
+  ResolvedInteractionConfig,
+  SelectInput,
+  ZoomEvent,
+  ZoomInput,
+} from "./interaction.js";
+import type { PlotInteractionController } from "./interaction-controller.svelte.js";
+import {
+  assemblePortableSpec,
+  isFacetedPlotIntent,
+  resolveInteractionScope,
+  toLayerInput,
+} from "./plot-assemble.js";
+import { createSourceIdentityTracker, dataIdentityEpochToken } from "./plot-semantic-keys.js";
+import {
+  createPlotAnnouncer,
+  createSemanticKeyService,
+  type PlotAnnouncer,
+  type SemanticKeyService,
+} from "./plot-shared-services.svelte.js";
+import { createPlotRuntime, type PlotRuntime } from "./plot-runtime.svelte.js";
+import { type InteractiveLegendEntry, type LegendEntryIdentity } from "./plot-legend-focus.js";
+import {
+  createLegendFilterState,
+  type FilterableLegendEntry,
+  type LegendFilterState,
+} from "./legend-filter-state.svelte.js";
+import { createLegendFocusState, type LegendFocusState } from "./legend-focus-state.svelte.js";
+import { createPlotZoomState, type PlotZoomState } from "./plot-zoom-state.svelte.js";
+import { createIntervalState, type IntervalState } from "./interval-state.svelte.js";
+import { createInspectionState, type InspectionState } from "./inspection-state.svelte.js";
+import { createSurfaceState, type SurfaceState } from "./surface-state.svelte.js";
+import { createSelectionState, type SelectionState } from "./selection-state.svelte.js";
+import { createPlotChromeState, type PlotChromeState } from "./plot-chrome-state.svelte.js";
+import type { LegendFilterEvent, LegendFilterInput } from "./legend-filter.js";
+import type { LayerRegistry } from "./registry.svelte.js";
+import { normalizeInteractionConfig } from "./interaction.js";
+
+// ---------------------------------------------------------------------------
+// Inputs / return type
+// ---------------------------------------------------------------------------
+
+export type OrchestratorInputs<
+  Row extends Record<string, CellValue> = Record<string, CellValue>,
+  Identity extends keyof Row | ((row: Row, index: number) => PropertyKey) = keyof Row,
+> = {
+  /** Value — created by `provideRegistry()` in GGPlot (context stays there). */
+  registry: LayerRegistry;
+  /** Plain string from `$props.id()` in GGPlot. */
+  plotId: string;
+  root: () => HTMLDivElement | null;
+  captureSurface: () => HTMLDivElement | null;
+
+  // Reactive props / callbacks as getter thunks (post-destructure names).
+  spec: () => SpecInput | undefined;
+  data: () => DataInput | readonly Row[] | undefined;
+  mapping: () => AesInput | undefined;
+  layers: () => LayerInput[] | undefined;
+  facet: () => FacetInput | undefined;
+  coord: () => CoordSpec | "flip" | undefined;
+  scales: () => Scales | undefined;
+  legend: () => LegendSpec | undefined;
+  theme: () => ThemeName | ThemeSpec | undefined;
+  labs: () => Labs | undefined;
+  a11y: () => A11yMode | undefined;
+  width: () => number | "container" | undefined;
+  height: () => number | undefined;
+  datumKey: () => Identity | undefined;
+  /** Defaulted non-optional after destructure. */
+  inspect: () => InspectInput;
+  select: () => SelectInput;
+  zoom: () => ZoomInput;
+  legendFocus: () => LegendFocusInput;
+  legendFilter: () => LegendFilterInput;
+  tool: () => InteractionTool | undefined;
+  // Widened to PropertyKey at the boundary — PublicKey is component-local.
+  interaction: () => PlotInteractionController<PropertyKey> | undefined;
+  interactionScope: () => PlotInteractionScope | undefined;
+  oninspect: () =>
+    | ((event: PlotInspection<Record<string, CellValue>, PropertyKey>) => void)
+    | undefined;
+  onselect: () => ((event: PlotSelection<PropertyKey>) => void) | undefined;
+  onzoom: () => ((event: ZoomEvent) => void) | undefined;
+  onlegendfocus: () => ((event: LegendFocusEvent<PropertyKey>) => void) | undefined;
+  onlegendfilter: () => ((event: LegendFilterEvent) => void) | undefined;
+  oninteraction: () =>
+    | ((event: PlotInteractionEvent<Record<string, CellValue>, PropertyKey>) => void)
+    | undefined;
+  ondiagnostic: () => ((diagnostic: InteractionDiagnostic) => void) | undefined;
+  ontoolchange: () => ((tool: InteractionTool) => void) | undefined;
+  onrender: () =>
+    | ((model: import("@ggsvelte/core").RenderModel, spec: PortableSpec) => void)
+    | undefined;
+};
+
+/**
+ * Non-generic return surface. Controllers are stable object refs; deriveds
+ * that markup reads are `get` accessors. Internal wiring (deliverDiagnostic,
+ * inspectEnabled, facetedPlot, factory* casts, …) is not exposed.
+ */
+export type PlotOrchestrator = {
+  // Controllers (stable object references)
+  readonly zoomState: PlotZoomState;
+  readonly legendFilterState: LegendFilterState;
+  readonly runtime: PlotRuntime;
+  readonly semanticKeys: SemanticKeyService;
+  readonly inspectionState: InspectionState;
+  readonly surfaceState: SurfaceState;
+  readonly selectionState: SelectionState;
+  readonly legendFocusState: LegendFocusState;
+  readonly intervalState: IntervalState;
+  readonly chromeState: PlotChromeState;
+  readonly announcer: PlotAnnouncer;
+
+  // Engine getter accessors — deriveds markup consumes
+  readonly assembled: PortableSpec | null;
+  readonly interactionConfig: ResolvedInteractionConfig;
+  readonly interactive: boolean;
+  readonly surfaceInteractive: boolean;
+  readonly coordFlipped: boolean;
+  readonly legendFocusEnabled: boolean;
+  readonly selectedAnchors: { x: number; y: number }[];
+  readonly emphasizedAnchors: { x: number; y: number }[];
+  readonly interactionMasks: readonly (BatchInteractionMask | null)[];
+  readonly interactiveLegendEntries: InteractiveLegendEntry[];
+  readonly effectiveLegendPressed: LegendEntryIdentity | null;
+  readonly legendClearActive: boolean;
+  readonly filterableLegendEntries: FilterableLegendEntry[];
+
+  // get/set tooltipHovered (owned here; markup handlers write via engine)
+  tooltipHovered: boolean;
+};
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export function createPlotOrchestrator<
+  Row extends Record<string, CellValue> = Record<string, CellValue>,
+  Identity extends keyof Row | ((row: Row, index: number) => PropertyKey) = keyof Row,
+>(inputs: OrchestratorInputs<Row, Identity>): PlotOrchestrator {
+  // Reading descriptors through toLayerInput goes through live getters, so
+  // geom prop changes flow into this $derived without re-registration.
+  // Explicit `spec` short-circuits before registry/children so ignored props
+  // do not become reactive dependencies of the assembled plot.
+  const assembled: PortableSpec | null = $derived.by(() => {
+    const spec = inputs.spec();
+    if (spec !== undefined) return assemblePortableSpec({ spec, layers: [] });
+    const data = inputs.data();
+    const mapping = inputs.mapping();
+    const layers = inputs.layers();
+    const facet = inputs.facet();
+    const coord = inputs.coord();
+    const scales = inputs.scales();
+    const legend = inputs.legend();
+    const theme = inputs.theme();
+    const labs = inputs.labs();
+    const a11y = inputs.a11y();
+    return assemblePortableSpec({
+      ...(data !== undefined && { data: data as DataInput | readonly Row[] }),
+      ...(mapping !== undefined && { aes: mapping }),
+      layers: layers ?? inputs.registry.layers.map(toLayerInput),
+      ...(facet !== undefined && { facet }),
+      ...(coord !== undefined && { coord }),
+      ...(scales !== undefined && { scales }),
+      ...(legend !== undefined && { legend }),
+      ...(theme !== undefined && { theme }),
+      ...(labs !== undefined && { labs }),
+      ...(a11y !== undefined && { a11y }),
+    });
+  });
+
+  // Facet intent: raw prop (declaration-only children before layers register)
+  // OR assembled.facet (portable-spec plots that embed facet without a prop).
+  const facetedPlot = $derived(isFacetedPlotIntent({ facet: inputs.facet(), assembled }));
+
+  const resolvedInteractionScope: PlotInteractionScope = $derived(
+    (() => {
+      const interaction = inputs.interaction();
+      const interactionScope = inputs.interactionScope();
+      const zoom = inputs.zoom();
+      const datumKey = inputs.datumKey();
+      return resolveInteractionScope({
+        interaction,
+        ...(interactionScope !== undefined && { interactionScope }),
+        zoom,
+        faceted: facetedPlot,
+        ...(datumKey !== undefined && { datumKey }),
+        assembled,
+      });
+    })(),
+  );
+
+  const interactionConfig = $derived(
+    (() => {
+      const tool = inputs.tool();
+      return normalizeInteractionConfig(
+        {
+          inspect: inputs.inspect(),
+          select: inputs.select(),
+          zoom: inputs.zoom(),
+          legendFocus: inputs.legendFocus(),
+          ...(tool !== undefined && { tool }),
+        },
+        {
+          faceted: facetedPlot,
+          hasKey: inputs.datumKey() !== undefined,
+        },
+      );
+    })(),
+  );
+
+  function deliverDiagnostic(diagnostic: InteractionDiagnostic): void {
+    const ondiagnostic = inputs.ondiagnostic();
+    ondiagnostic?.(diagnostic);
+    const nodeEnvironment = (globalThis as { process?: { env?: { NODE_ENV?: string } } }).process
+      ?.env?.NODE_ENV;
+    if (nodeEnvironment !== "production" && ondiagnostic === undefined)
+      console.warn(`[ggsvelte:${diagnostic.code}] ${diagnostic.message}`);
+  }
+
+  $effect(() => {
+    for (const diagnostic of interactionConfig.diagnostics) deliverDiagnostic(diagnostic);
+  });
+
+  // Shared controller-factory dep aliases: ONE place for the PublicKey →
+  // PropertyKey widening casts every extracted controller (S2–S8) wires.
+  const factoryInteraction = $derived(
+    inputs.interaction() as PlotInteractionController<PropertyKey> | undefined,
+  );
+  const factoryOninteraction = $derived(
+    inputs.oninteraction() as
+      | ((event: PlotInteractionEvent<Record<string, CellValue>, PropertyKey>) => void)
+      | undefined,
+  );
+  const factoryOninspect = $derived(
+    inputs.oninspect() as ((event: PlotInspection<Record<string, CellValue>>) => void) | undefined,
+  );
+  // Announcer is declared later; the sink is handler-only (never construction).
+  const announceSink = (message: string): void => {
+    announcer.announce(message);
+  };
+
+  // Construction order is the topological order of direct construction-time
+  // reads; effect registration sequence is load-bearing. Deferred thunks break
+  // the runtime cycles (surface ↔ inspection ↔ interval ↔ selection).
+
+  // ------------------------------------------------------------ zoom respec
+  // Construction-time deriveds read interaction/scope/zoomConfig/assembled
+  // only — model/coordFlipped/announce are deferred getters (later-declared).
+  const zoomState = createPlotZoomState({
+    interaction: () => factoryInteraction,
+    resolvedInteractionScope: () => resolvedInteractionScope,
+    zoomConfig: () => interactionConfig.zoom,
+    assembled: () => assembled,
+    // model / coordFlipped declared after the runtime; handlers only.
+    model: () => runtime.model,
+    coordFlipped: () => coordFlipped,
+    onzoom: () => inputs.onzoom(),
+    oninteraction: () => factoryOninteraction,
+    announce: announceSink,
+  });
+
+  // Source identity/order epoch: stable through responsive layout and zoom
+  // respecs, different when normalized inline data or data references change.
+  // Tracker is owned for the component lifetime (never cleared).
+  const { sourceIdentity } = createSourceIdentityTracker();
+  const dataIdentityEpoch = $derived(
+    dataIdentityEpochToken({
+      assembled,
+      dataToken: sourceIdentity(inputs.data()),
+      specToken: sourceIdentity(inputs.spec()),
+    }),
+  );
+
+  // Live-region announcer (owned early so legend-reset effects can call it).
+  const announcer = createPlotAnnouncer();
+
+  // ------------------------------------------------- legend filter
+  // Construction-time deriveds read legendFilter/effectiveSpec only —
+  // model is deferred (declared after the runtime).
+  const legendFilterState = createLegendFilterState({
+    effectiveSpec: () => zoomState.effectiveSpec,
+    legendFilterProp: () => inputs.legendFilter(),
+    onlegendfilter: () => inputs.onlegendfilter(),
+    oninteraction: () => inputs.oninteraction() as ((event: LegendFilterEvent) => void) | undefined,
+    announce: announceSink,
+    // model is declared after the runtime; the getter is only invoked from
+    // late catalog effects (never at construction).
+    model: () => runtime.model,
+  });
+
+  // ------------------------------------------------- plot runtime
+  // Factory sits after zoom-respec and legend-filter so every direct
+  // construction-time dep is already initialized (TDZ).
+  // Effect registration: model dispose/onrender effects register here;
+  // ResizeObserver registers later via registerLateEffects (after legend
+  // reconcile) — safe because the observer callback is async.
+  const runtime = createPlotRuntime({
+    widthProp: () => inputs.width(),
+    heightProp: () => inputs.height(),
+    assembled: () => assembled,
+    effectiveSpec: () => zoomState.effectiveSpec,
+    effectiveZoomDomains: () => zoomState.effectiveZoomDomains,
+    effectiveLegendFilters: () => legendFilterState.filters,
+    root: inputs.root,
+    resetZoom: () => zoomState.resetForScales(),
+    onrender: () => inputs.onrender(),
+  });
+  // Model dispose + onrender effects (after the legend-reset effects that
+  // registered during legendFilterState construction; before late effects).
+  runtime.registerModelEffects();
+
+  // Semantic resolution as soon as the runtime model exists. Diagnostics
+  // effects register later; early construction makes interval projection
+  // safe when a shared controller arrives with pre-populated non-union
+  // intervals (#165).
+  const semanticKeys = createSemanticKeyService({
+    model: () => runtime.model,
+    assembled: () => assembled,
+    datumKey: () =>
+      inputs.datumKey() as string | ((row: never, index: number) => PropertyKey) | undefined,
+    data: () => inputs.data(),
+    spec: () => inputs.spec(),
+    sourceIdentity,
+    deliverDiagnostic,
+  });
+  const semanticKey = semanticKeys.semanticKey;
+  const candidateSemanticKeys = semanticKeys.candidateSemanticKeys;
+
+  // ---------------------------------------------------------- interaction
+  // source rows/spec -> pipeline/scene -> hit index -> semantic resolver ->
+  // chart-local reducer -> tooltip/crosshair/tools/callbacks. Presentation
+  // consumes one resolved inspection and never reconstructs grouping itself.
+  const interactive = $derived(interactionConfig.interactive);
+  const surfaceInteractive = $derived(interactionConfig.availableTools.length > 0);
+  const hitIndex: SceneHitIndex | null = $derived.by(() =>
+    surfaceInteractive && runtime.model !== null ? buildHitIndex(runtime.model.scene) : null,
+  );
+
+  // ------------------------------------------------- inspection
+  // Construction-time deriveds may read model / surfaceInteractive (both
+  // earlier). Phased effects register later via registerInspectionEffects().
+  // Reversed deps: reducer / clearBrush / chooseTool close over the later-
+  // declared surfaceState (handler/effect-only; construction guard).
+  const inspectionState = createInspectionState({
+    model: () => runtime.model,
+    // Deferred: surface owns the reducer (handler/effect only).
+    reducer: () => surfaceState.reducer,
+    inspectConfig: () => interactionConfig.inspect,
+    surfaceInteractive: () => surfaceInteractive,
+    inspectEnabled: () => inspectEnabled,
+    dataIdentityEpoch: () => dataIdentityEpoch,
+    // Deferred: semantic-key service is declared later (handler only).
+    keyAt: (index) => semanticKeys.keyAt(index),
+    root: inputs.root,
+    captureSurface: inputs.captureSurface,
+    plotId: () => inputs.plotId,
+    tooltipHovered: () => tooltipHovered,
+    clearTooltipHovered: () => {
+      tooltipHovered = false;
+    },
+    clearBrush: () => surfaceState.clearBrush(),
+    chooseTool: (next) => surfaceState.chooseTool(next),
+    oninspect: () => factoryOninspect,
+    oninteraction: () => factoryOninteraction,
+    announce: announceSink,
+    clearAnnouncement: () => announcer.clear(),
+  });
+  // ------------------------------------------------- surface
+  // Construction-time deriveds read module-internal state + inspectConfig.
+  // Sibling controllers, sinks, and chrome getters are handler/effect-only.
+  // Phased effects register later via registerSurfaceEffects().
+  const surfaceState = createSurfaceState({
+    model: () => runtime.model,
+    coordFlipped: () => coordFlipped,
+    root: inputs.root,
+    toolProp: () => inputs.tool(),
+    initialTool: () => interactionConfig.initialTool,
+    // Deferred: chrome availableTools (handler/effect only).
+    availableTools: () => chromeState.availableTools,
+    inspectConfig: () => interactionConfig.inspect,
+    selectConfig: () => interactionConfig.select,
+    // Deferred: chrome canPublishPointSelection (handler only).
+    pointSelectEnabled: () => chromeState.canPublishPointSelection,
+    ontoolchange: () => inputs.ontoolchange(),
+    surfaceInteractive: () => surfaceInteractive,
+    hitIndex: () => hitIndex,
+    // Deferred: semantic-key service initializes later (issue #165).
+    candidateSemanticKeys: (candidate) => candidateSemanticKeys(candidate),
+    inspection: () => inspectionState,
+    // Deferred: interval is declared after surface (handler only).
+    interval: () => intervalState,
+    zoom: () => zoomState,
+    // Deferred: selection controller is declared after surface (handler only).
+    emitSelection: (event) => selectionState.emitSelection(event),
+    // Deferred: semantic-key service is declared later (handler only).
+    semanticKey: (row, index) => semanticKey(row, index),
+    // Deferred: selection controller is declared after surface (handler only).
+    togglePointKeys: (keys, source) => selectionState.togglePointKeys(keys, source),
+    tooltipHovered: () => tooltipHovered,
+    announce: announceSink,
+  });
+  const coordFlipped = $derived(assembled?.coord?.type === "flip");
+  let tooltipHovered = $state(false);
+  // ------------------------------------------------- selection
+  // Construction-time effectiveSelectedKeys reads earlier interaction/scope
+  // only. Anchors and masks are methods (later-declared inputs).
+  const selectionState = createSelectionState({
+    model: () => runtime.model,
+    interaction: () => factoryInteraction,
+    resolvedInteractionScope: () => resolvedInteractionScope,
+    selectConfig: () => interactionConfig.select,
+    // Deferred: interval is declared after this factory (method only).
+    effectiveIntervalKeys: () => intervalState.effectiveIntervalKeys,
+    // Deferred: legend-focus is declared after this factory (method only).
+    effectiveEmphasisKeys: () => legendFocusState.effectiveEmphasisKeys,
+    // Deferred method-only projection of inspection focus for presentation masks.
+    inspectionFocus: () => {
+      const current = inspectionState.inspection;
+      return current === null
+        ? null
+        : {
+            sourceKeys: current.focus.sourceKeys,
+            key: current.focus.key,
+          };
+    },
+    // Deferred: semantic-key service initializes later (#165).
+    candidateSemanticKeys: (candidate) => candidateSemanticKeys(candidate),
+    onselect: () => inputs.onselect() as ((event: PlotSelection) => void) | undefined,
+    oninteraction: () => factoryOninteraction,
+    announce: announceSink,
+  });
+  // Shared enablement predicates (avoid re-typing the same config gates).
+  const inspectEnabled = $derived(interactionConfig.inspect !== null);
+  const legendFocusEnabled = $derived(interactionConfig.legendFocus !== null);
+  // ------------------------------------------------- legend focus
+  // Factory sits after the enablement cluster so construction-time
+  // effectiveEmphasisKeys closes over earlier bindings only.
+  const legendFocusState = createLegendFocusState({
+    interaction: () => factoryInteraction,
+    resolvedInteractionScope: () => resolvedInteractionScope,
+    legendFocusEnabled: () => legendFocusEnabled,
+    legendFocusPreviewEnabled: () => interactionConfig.legendFocus?.preview === true,
+    root: inputs.root,
+    semanticKeys: () => semanticKeys,
+    entries: () => interactiveLegendEntries,
+    // Deferred read of the later-declared cached derived (handlers only).
+    pressed: () => effectiveLegendPressed,
+    onlegendfocus: () =>
+      inputs.onlegendfocus() as ((event: LegendFocusEvent<PropertyKey>) => void) | undefined,
+    oninteraction: () => factoryOninteraction,
+    announce: announceSink,
+  });
+  // ------------------------------------------------- interval selection
+  // Construction-time deriveds may read model/effectiveZoomDomains (both
+  // earlier-declared). Effects register here — relative order is runtime
+  // model effects < interval effects < semantic diagnostics.
+  const intervalState = createIntervalState({
+    model: () => runtime.model,
+    interaction: () => factoryInteraction,
+    resolvedInteractionScope: () => resolvedInteractionScope,
+    selectConfig: () => interactionConfig.select,
+    effectiveZoomDomains: () => zoomState.effectiveZoomDomains,
+    // Direct construction edges (not deferred thunks): zoom + selection
+    // are already constructed when interval is built.
+    commitZoom: zoomState.commitZoom,
+    coordFlipped: () => coordFlipped,
+    captureSurface: inputs.captureSurface,
+    candidateSemanticKeys: (candidate) => candidateSemanticKeys(candidate),
+    inspectionPanel: () => inspectionState.inspectionPanel,
+    emitSelection: selectionState.emitSelection,
+    announce: announceSink,
+  });
+  // ------------------------------------------------- plot chrome
+  // All inputs earlier-declared. Pure construction-time deriveds —
+  // no $state/handlers/effects.
+  const chromeState = createPlotChromeState({
+    model: () => runtime.model,
+    zoomConfig: () => interactionConfig.zoom,
+    selectConfig: () => interactionConfig.select,
+    configuredAvailableTools: () => interactionConfig.availableTools,
+    interactionDiagnostics: () => interactionConfig.diagnostics,
+    interactive: () => interactive,
+    effectiveZoomDomains: () => zoomState.effectiveZoomDomains,
+    effectiveIntervals: () => intervalState.effectiveIntervals,
+    effectiveSelectedKeys: () => selectionState.effectiveSelectedKeys,
+    effectiveEmphasisKeys: () => legendFocusState.effectiveEmphasisKeys,
+    legendFocusEnabled: () => legendFocusEnabled,
+    hasCanvas: () => runtime.hasCanvas,
+    width: () => inputs.width(),
+    resolvedWidth: () => runtime.resolvedWidth,
+    resolvedHeight: () => runtime.resolvedHeight,
+  });
+  // Method-call deriveds (not pure aliases) — keep as intermediate memos.
+  const selectedAnchors = $derived(selectionState.computeSelectedAnchors());
+  const emphasizedAnchors = $derived(selectionState.computeEmphasizedAnchors());
+
+  // Semantic diagnostics effects (before host diagnostic / surface effects).
+  semanticKeys.registerEffects();
+
+  $effect(() => {
+    for (const diagnostic of chromeState.areaScaleDiagnostics) deliverDiagnostic(diagnostic);
+  });
+
+  $effect(() => {
+    for (const diagnostic of chromeState.legendDiagnostics) deliverDiagnostic(diagnostic);
+  });
+
+  // Surface window-teardown + tool-sync (after diagnostics, before catalog/
+  // focus/inspection registrations).
+  surfaceState.registerSurfaceEffects();
+
+  // Three separate host deriveds — intermediate memo boundaries live here
+  // (do NOT fold into one method).
+  const presentationFocusKeys = $derived(selectionState.computePresentationFocusKeys());
+  const semanticCandidateProjections = $derived(
+    selectionState.computeSemanticCandidateProjections(),
+  );
+  const interactionMasks = $derived(
+    selectionState.computeInteractionMasks(
+      presentationFocusKeys,
+      // Thunk: with empty focus (idle), the projections derived is never read.
+      () => semanticCandidateProjections,
+    ),
+  );
+
+  // Host-side deriveds kept outside the factory (construction-time free of
+  // the model read).
+  const interactiveLegendEntries = $derived(
+    legendFocusState.computeInteractiveEntries(runtime.model),
+  );
+
+  const effectiveLegendPressed: LegendEntryIdentity | null = $derived(
+    legendFocusState.computeLegendPressed(runtime.model),
+  );
+
+  // Single source for "the legend clear row is shown": the root class and
+  // the filter fieldset's below-clear offset must flip together (the legend
+  // layout test pins their combined geometry).
+  const legendClearActive = $derived(legendFocusEnabled && effectiveLegendPressed !== null);
+
+  // Host-side derived kept outside the factory (construction-time free of
+  // the model read).
+  const filterableLegendEntries = $derived(legendFilterState.computeEntries(runtime.model));
+  // Catalog reconcile after model effects.
+  legendFilterState.registerCatalogEffects(() => filterableLegendEntries);
+  // Legend-focus reconcile after catalog.
+  legendFocusState.registerReconcileEffects();
+  // Inspection disposal + scene reconcile after legend-focus.
+  inspectionState.registerInspectionEffects();
+
+  // clientFlush/ready effect at end of script (late registration).
+  runtime.registerLateEffects();
+
+  return {
+    zoomState,
+    legendFilterState,
+    runtime,
+    semanticKeys,
+    inspectionState,
+    surfaceState,
+    selectionState,
+    legendFocusState,
+    intervalState,
+    chromeState,
+    announcer,
+
+    get assembled() {
+      return assembled;
+    },
+    get interactionConfig() {
+      return interactionConfig;
+    },
+    get interactive() {
+      return interactive;
+    },
+    get surfaceInteractive() {
+      return surfaceInteractive;
+    },
+    get coordFlipped() {
+      return coordFlipped;
+    },
+    get legendFocusEnabled() {
+      return legendFocusEnabled;
+    },
+    get selectedAnchors() {
+      return selectedAnchors;
+    },
+    get emphasizedAnchors() {
+      return emphasizedAnchors;
+    },
+    get interactionMasks() {
+      return interactionMasks;
+    },
+    get interactiveLegendEntries() {
+      return interactiveLegendEntries;
+    },
+    get effectiveLegendPressed() {
+      return effectiveLegendPressed;
+    },
+    get legendClearActive() {
+      return legendClearActive;
+    },
+    get filterableLegendEntries() {
+      return filterableLegendEntries;
+    },
+    get tooltipHovered() {
+      return tooltipHovered;
+    },
+    set tooltipHovered(value: boolean) {
+      tooltipHovered = value;
+    },
+  };
+}

--- a/packages/svelte/src/lib/plot-orchestrator.svelte.ts
+++ b/packages/svelte/src/lib/plot-orchestrator.svelte.ts
@@ -20,7 +20,7 @@
  * registers in the component effect tree. No `$props`, `$props.id()`, or
  * context calls live here.
  */
-import type { BatchInteractionMask, CellValue } from "@ggsvelte/core";
+import type { BatchInteractionMask, CellValue, RenderModel } from "@ggsvelte/core";
 import { buildHitIndex, type SceneHitIndex } from "@ggsvelte/core/dom";
 import type {
   A11yMode,
@@ -125,21 +125,17 @@ export type OrchestratorInputs<
   // Widened to PropertyKey at the boundary — PublicKey is component-local.
   interaction: () => PlotInteractionController<PropertyKey> | undefined;
   interactionScope: () => PlotInteractionScope | undefined;
-  oninspect: () =>
-    | ((event: PlotInspection<Record<string, CellValue>, PropertyKey>) => void)
-    | undefined;
-  onselect: () => ((event: PlotSelection<PropertyKey>) => void) | undefined;
+  oninspect: () => ((event: PlotInspection<Record<string, CellValue>>) => void) | undefined;
+  onselect: () => ((event: PlotSelection) => void) | undefined;
   onzoom: () => ((event: ZoomEvent) => void) | undefined;
-  onlegendfocus: () => ((event: LegendFocusEvent<PropertyKey>) => void) | undefined;
+  onlegendfocus: () => ((event: LegendFocusEvent) => void) | undefined;
   onlegendfilter: () => ((event: LegendFilterEvent) => void) | undefined;
   oninteraction: () =>
-    | ((event: PlotInteractionEvent<Record<string, CellValue>, PropertyKey>) => void)
+    | ((event: PlotInteractionEvent<Record<string, CellValue>>) => void)
     | undefined;
   ondiagnostic: () => ((diagnostic: InteractionDiagnostic) => void) | undefined;
   ontoolchange: () => ((tool: InteractionTool) => void) | undefined;
-  onrender: () =>
-    | ((model: import("@ggsvelte/core").RenderModel, spec: PortableSpec) => void)
-    | undefined;
+  onrender: () => ((model: RenderModel, spec: PortableSpec) => void) | undefined;
 };
 
 /**
@@ -152,7 +148,6 @@ export type PlotOrchestrator = {
   readonly zoomState: PlotZoomState;
   readonly legendFilterState: LegendFilterState;
   readonly runtime: PlotRuntime;
-  readonly semanticKeys: SemanticKeyService;
   readonly inspectionState: InspectionState;
   readonly surfaceState: SurfaceState;
   readonly selectionState: SelectionState;
@@ -206,7 +201,7 @@ export function createPlotOrchestrator<
     const labs = inputs.labs();
     const a11y = inputs.a11y();
     return assemblePortableSpec({
-      ...(data !== undefined && { data: data as DataInput | readonly Row[] }),
+      ...(data !== undefined && { data }),
       ...(mapping !== undefined && { aes: mapping }),
       layers: layers ?? inputs.registry.layers.map(toLayerInput),
       ...(facet !== undefined && { facet }),
@@ -272,19 +267,10 @@ export function createPlotOrchestrator<
     for (const diagnostic of interactionConfig.diagnostics) deliverDiagnostic(diagnostic);
   });
 
-  // Shared controller-factory dep aliases: ONE place for the PublicKey →
-  // PropertyKey widening casts every extracted controller (S2–S8) wires.
-  const factoryInteraction = $derived(
-    inputs.interaction() as PlotInteractionController<PropertyKey> | undefined,
-  );
-  const factoryOninteraction = $derived(
-    inputs.oninteraction() as
-      | ((event: PlotInteractionEvent<Record<string, CellValue>, PropertyKey>) => void)
-      | undefined,
-  );
-  const factoryOninspect = $derived(
-    inputs.oninspect() as ((event: PlotInspection<Record<string, CellValue>>) => void) | undefined,
-  );
+  // The PublicKey → PropertyKey widening casts live at the GGPlot call site;
+  // OrchestratorInputs is already declared in the widened form, so controller
+  // deps consume inputs.interaction / inputs.oninteraction / inputs.oninspect
+  // directly (handler contravariance covers the narrower per-event deps).
   // Announcer is declared later; the sink is handler-only (never construction).
   const announceSink = (message: string): void => {
     announcer.announce(message);
@@ -298,7 +284,7 @@ export function createPlotOrchestrator<
   // Construction-time deriveds read interaction/scope/zoomConfig/assembled
   // only — model/coordFlipped/announce are deferred getters (later-declared).
   const zoomState = createPlotZoomState({
-    interaction: () => factoryInteraction,
+    interaction: inputs.interaction,
     resolvedInteractionScope: () => resolvedInteractionScope,
     zoomConfig: () => interactionConfig.zoom,
     assembled: () => assembled,
@@ -306,19 +292,19 @@ export function createPlotOrchestrator<
     model: () => runtime.model,
     coordFlipped: () => coordFlipped,
     onzoom: () => inputs.onzoom(),
-    oninteraction: () => factoryOninteraction,
+    oninteraction: inputs.oninteraction,
     announce: announceSink,
   });
 
   // Source identity/order epoch: stable through responsive layout and zoom
   // respecs, different when normalized inline data or data references change.
   // Tracker is owned for the component lifetime (never cleared).
-  const { sourceIdentity } = createSourceIdentityTracker();
+  const identityTracker = createSourceIdentityTracker();
   const dataIdentityEpoch = $derived(
     dataIdentityEpochToken({
       assembled,
-      dataToken: sourceIdentity(inputs.data()),
-      specToken: sourceIdentity(inputs.spec()),
+      dataToken: identityTracker.sourceIdentity(inputs.data()),
+      specToken: identityTracker.sourceIdentity(inputs.spec()),
     }),
   );
 
@@ -332,7 +318,7 @@ export function createPlotOrchestrator<
     effectiveSpec: () => zoomState.effectiveSpec,
     legendFilterProp: () => inputs.legendFilter(),
     onlegendfilter: () => inputs.onlegendfilter(),
-    oninteraction: () => inputs.oninteraction() as ((event: LegendFilterEvent) => void) | undefined,
+    oninteraction: inputs.oninteraction,
     announce: announceSink,
     // model is declared after the runtime; the getter is only invoked from
     // late catalog effects (never at construction).
@@ -353,7 +339,9 @@ export function createPlotOrchestrator<
     effectiveZoomDomains: () => zoomState.effectiveZoomDomains,
     effectiveLegendFilters: () => legendFilterState.filters,
     root: inputs.root,
-    resetZoom: () => zoomState.resetForScales(),
+    resetZoom: () => {
+      zoomState.resetForScales();
+    },
     onrender: () => inputs.onrender(),
   });
   // Model dispose + onrender effects (after the legend-reset effects that
@@ -367,15 +355,16 @@ export function createPlotOrchestrator<
   const semanticKeys = createSemanticKeyService({
     model: () => runtime.model,
     assembled: () => assembled,
-    datumKey: () =>
-      inputs.datumKey() as string | ((row: never, index: number) => PropertyKey) | undefined,
+    datumKey: () => inputs.datumKey(),
     data: () => inputs.data(),
     spec: () => inputs.spec(),
-    sourceIdentity,
+    sourceIdentity: (value: unknown) => identityTracker.sourceIdentity(value),
     deliverDiagnostic,
   });
-  const semanticKey = semanticKeys.semanticKey;
-  const candidateSemanticKeys = semanticKeys.candidateSemanticKeys;
+  const semanticKey: SemanticKeyService["semanticKey"] = (...args) =>
+    semanticKeys.semanticKey(...args);
+  const candidateSemanticKeys: SemanticKeyService["candidateSemanticKeys"] = (...args) =>
+    semanticKeys.candidateSemanticKeys(...args);
 
   // ---------------------------------------------------------- interaction
   // source rows/spec -> pipeline/scene -> hit index -> semantic resolver ->
@@ -409,12 +398,18 @@ export function createPlotOrchestrator<
     clearTooltipHovered: () => {
       tooltipHovered = false;
     },
-    clearBrush: () => surfaceState.clearBrush(),
-    chooseTool: (next) => surfaceState.chooseTool(next),
-    oninspect: () => factoryOninspect,
-    oninteraction: () => factoryOninteraction,
+    clearBrush: () => {
+      surfaceState.clearBrush();
+    },
+    chooseTool: (next) => {
+      surfaceState.chooseTool(next);
+    },
+    oninspect: inputs.oninspect,
+    oninteraction: inputs.oninteraction,
     announce: announceSink,
-    clearAnnouncement: () => announcer.clear(),
+    clearAnnouncement: () => {
+      announcer.clear();
+    },
   });
   // ------------------------------------------------- surface
   // Construction-time deriveds read module-internal state + inspectConfig.
@@ -442,11 +437,15 @@ export function createPlotOrchestrator<
     interval: () => intervalState,
     zoom: () => zoomState,
     // Deferred: selection controller is declared after surface (handler only).
-    emitSelection: (event) => selectionState.emitSelection(event),
+    emitSelection: (event) => {
+      selectionState.emitSelection(event);
+    },
     // Deferred: semantic-key service is declared later (handler only).
     semanticKey: (row, index) => semanticKey(row, index),
     // Deferred: selection controller is declared after surface (handler only).
-    togglePointKeys: (keys, source) => selectionState.togglePointKeys(keys, source),
+    togglePointKeys: (keys, source) => {
+      selectionState.togglePointKeys(keys, source);
+    },
     tooltipHovered: () => tooltipHovered,
     announce: announceSink,
   });
@@ -457,7 +456,7 @@ export function createPlotOrchestrator<
   // only. Anchors and masks are methods (later-declared inputs).
   const selectionState = createSelectionState({
     model: () => runtime.model,
-    interaction: () => factoryInteraction,
+    interaction: inputs.interaction,
     resolvedInteractionScope: () => resolvedInteractionScope,
     selectConfig: () => interactionConfig.select,
     // Deferred: interval is declared after this factory (method only).
@@ -476,8 +475,8 @@ export function createPlotOrchestrator<
     },
     // Deferred: semantic-key service initializes later (#165).
     candidateSemanticKeys: (candidate) => candidateSemanticKeys(candidate),
-    onselect: () => inputs.onselect() as ((event: PlotSelection) => void) | undefined,
-    oninteraction: () => factoryOninteraction,
+    onselect: inputs.onselect,
+    oninteraction: inputs.oninteraction,
     announce: announceSink,
   });
   // Shared enablement predicates (avoid re-typing the same config gates).
@@ -487,7 +486,7 @@ export function createPlotOrchestrator<
   // Factory sits after the enablement cluster so construction-time
   // effectiveEmphasisKeys closes over earlier bindings only.
   const legendFocusState = createLegendFocusState({
-    interaction: () => factoryInteraction,
+    interaction: inputs.interaction,
     resolvedInteractionScope: () => resolvedInteractionScope,
     legendFocusEnabled: () => legendFocusEnabled,
     legendFocusPreviewEnabled: () => interactionConfig.legendFocus?.preview === true,
@@ -496,9 +495,8 @@ export function createPlotOrchestrator<
     entries: () => interactiveLegendEntries,
     // Deferred read of the later-declared cached derived (handlers only).
     pressed: () => effectiveLegendPressed,
-    onlegendfocus: () =>
-      inputs.onlegendfocus() as ((event: LegendFocusEvent<PropertyKey>) => void) | undefined,
-    oninteraction: () => factoryOninteraction,
+    onlegendfocus: inputs.onlegendfocus,
+    oninteraction: inputs.oninteraction,
     announce: announceSink,
   });
   // ------------------------------------------------- interval selection
@@ -507,18 +505,22 @@ export function createPlotOrchestrator<
   // model effects < interval effects < semantic diagnostics.
   const intervalState = createIntervalState({
     model: () => runtime.model,
-    interaction: () => factoryInteraction,
+    interaction: inputs.interaction,
     resolvedInteractionScope: () => resolvedInteractionScope,
     selectConfig: () => interactionConfig.select,
     effectiveZoomDomains: () => zoomState.effectiveZoomDomains,
     // Direct construction edges (not deferred thunks): zoom + selection
     // are already constructed when interval is built.
-    commitZoom: zoomState.commitZoom,
+    commitZoom: (...args: Parameters<PlotZoomState["commitZoom"]>) => {
+      zoomState.commitZoom(...args);
+    },
     coordFlipped: () => coordFlipped,
     captureSurface: inputs.captureSurface,
     candidateSemanticKeys: (candidate) => candidateSemanticKeys(candidate),
     inspectionPanel: () => inspectionState.inspectionPanel,
-    emitSelection: selectionState.emitSelection,
+    emitSelection: (...args: Parameters<SelectionState["emitSelection"]>) => {
+      selectionState.emitSelection(...args);
+    },
     announce: announceSink,
   });
   // ------------------------------------------------- plot chrome
@@ -606,7 +608,6 @@ export function createPlotOrchestrator<
     zoomState,
     legendFilterState,
     runtime,
-    semanticKeys,
     inspectionState,
     surfaceState,
     selectionState,

--- a/packages/svelte/src/lib/plot-props.ts
+++ b/packages/svelte/src/lib/plot-props.ts
@@ -1,0 +1,112 @@
+/**
+ * Internal props type for <GGPlot>. Not part of the public package surface —
+ * the component never exported this type before S11; keep it module-local.
+ */
+import type { Snippet } from "svelte";
+
+import type {
+  A11yMode,
+  AesInput,
+  CoordSpec,
+  DataInput,
+  FacetInput,
+  Labs,
+  LayerInput,
+  LegendSpec,
+  PortableSpec,
+  Scales,
+  SpecInput,
+  ThemeName,
+  ThemeSpec,
+} from "@ggsvelte/spec";
+import type { CellValue, RenderModel } from "@ggsvelte/core";
+
+import type {
+  InspectInput,
+  InteractionDiagnostic,
+  InteractionTool,
+  LegendFocusEvent,
+  LegendFocusInput,
+  PlotInspection,
+  PlotInteractionEvent,
+  PlotInteractionScope,
+  PlotSelection,
+  SelectInput,
+  ZoomEvent,
+  ZoomInput,
+} from "./interaction.js";
+import type { PlotInteractionController } from "./interaction-controller.svelte.js";
+import type { LegendFilterEvent, LegendFilterInput } from "./legend-filter.js";
+
+type PublicKey<
+  Row extends Record<string, CellValue>,
+  Identity extends keyof Row | ((row: Row, index: number) => PropertyKey),
+> = Identity extends keyof Row
+  ? Extract<Row[Identity], PropertyKey>
+  : Identity extends (row: Row, index: number) => infer Key
+    ? Extract<Key, PropertyKey>
+    : never;
+
+export interface GGPlotProps<
+  Row extends Record<string, CellValue> = Record<string, CellValue>,
+  Identity extends keyof Row | ((row: Row, index: number) => PropertyKey) = keyof Row,
+> {
+  /** A complete spec (bare-string channel shorthand allowed). Wins over the other props. */
+  spec?: SpecInput;
+  /** Data rows, columns, or a DataRef ({values}/{columns}/{name}). */
+  data?: DataInput | readonly Row[];
+  /** Plot-level aesthetic mapping (inherited by every layer). */
+  aes?: AesInput;
+  /** Layers (props-first canonical form). Wins over declaration-only children. */
+  layers?: LayerInput[];
+  /** Facet into small multiples (wrap or rows/cols grid). */
+  facet?: FacetInput;
+  /** Coordinate system ("flip" shorthand accepted). */
+  coord?: CoordSpec | "flip";
+  /** Per-scale configuration (types, domains, schemes, breaks, labels). */
+  scales?: Scales;
+  /** Legend options (order). */
+  legend?: LegendSpec;
+  /** Theme: a registered name or an object with role overrides. */
+  theme?: ThemeName | ThemeSpec;
+  /** Titles and axis labels. */
+  labs?: Labs;
+  /** Accessibility mode ("force-svg" keeps every layer as SVG marks). */
+  a11y?: A11yMode;
+  /** Plot width in px. Omitted is container-responsive. */
+  width?: number | "container";
+  /** Plot height in px (falls back to spec.height, then 400). */
+  height?: number;
+  /** Stable semantic identity used by public interaction payloads. */
+  key?: Identity;
+  /** Opt into inspection, its semantic crosshair, tooltip, and pinning. */
+  inspect?: InspectInput;
+  /** Opt into point or interval selection. */
+  select?: SelectInput;
+  /** Opt into brush zoom. */
+  zoom?: ZoomInput;
+  /** Opt into discrete legend preview, focus, and linked emphasis. */
+  legendFocus?: LegendFocusInput;
+  /** Opt into data-changing filtering through discrete legend controls. */
+  legendFilter?: LegendFilterInput;
+  /** Controlled initial/active tool. */
+  tool?: InteractionTool;
+  /** Optional durable semantic state shared with other plots and Svelte UI. */
+  interaction?: PlotInteractionController<PublicKey<Row, Identity>>;
+  /** Semantic identity for linked keys and positional domains. */
+  interactionScope?: PlotInteractionScope;
+  /** Accessible chart name; falls back to the plot title/generated label. */
+  ariaLabel?: string;
+  oninspect?: (event: PlotInspection<Row, PublicKey<Row, Identity>>) => void;
+  onselect?: (event: PlotSelection<PublicKey<Row, Identity>>) => void;
+  onzoom?: (event: ZoomEvent) => void;
+  onlegendfocus?: (event: LegendFocusEvent<PublicKey<Row, Identity>>) => void;
+  onlegendfilter?: (event: LegendFilterEvent) => void;
+  oninteraction?: (event: PlotInteractionEvent<Row, PublicKey<Row, Identity>>) => void;
+  ondiagnostic?: (diagnostic: InteractionDiagnostic) => void;
+  ontoolchange?: (tool: InteractionTool) => void;
+  /** Called after each committed render with the model (warnings,
+   *  advisories, scales) and the normalized PortableSpec. */
+  onrender?: (model: RenderModel, spec: PortableSpec) => void;
+  children?: Snippet;
+}

--- a/packages/svelte/tests/ggplot-loc-ratchet.ssr.test.ts
+++ b/packages/svelte/tests/ggplot-loc-ratchet.ssr.test.ts
@@ -32,6 +32,8 @@ const CEILINGS: readonly { readonly slice: string; readonly ceiling: number }[] 
   { slice: "s8-final", ceiling: 999 },
   // S10 dissolve alias scaffolding: actual 951 + 20.
   { slice: "s10-descaffold", ceiling: 971 },
+  // S11 extract plot orchestrator: actual 485 + 20.
+  { slice: "s11-orchestrator", ceiling: 505 },
 ];
 
 // Resolve via import.meta (never CWD). Node SSR suite only — uses node:fs.

--- a/packages/svelte/tests/plot-orchestrator-contract.ssr.test.ts
+++ b/packages/svelte/tests/plot-orchestrator-contract.ssr.test.ts
@@ -1,0 +1,50 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const orchestratorPath = join(import.meta.dirname, "../src/lib/plot-orchestrator.svelte.ts");
+
+function expectOrdered(source: string, tokens: readonly string[]): void {
+  let previousIndex = -1;
+  for (const token of tokens) {
+    const index = source.indexOf(token);
+    expect(index, `missing orchestrator contract token: ${token}`).toBeGreaterThanOrEqual(0);
+    expect(
+      index,
+      `${token} must remain after ${tokens[tokens.indexOf(token) - 1]}`,
+    ).toBeGreaterThan(previousIndex);
+    previousIndex = index;
+  }
+}
+
+describe("plot orchestrator lifecycle contract", () => {
+  const source = readFileSync(orchestratorPath, "utf8");
+
+  it("keeps controller construction in dependency order", () => {
+    expectOrdered(source, [
+      "const zoomState = createPlotZoomState(",
+      "const legendFilterState = createLegendFilterState(",
+      "const runtime = createPlotRuntime(",
+      "const semanticKeys = createSemanticKeyService(",
+      "const inspectionState = createInspectionState(",
+      "const surfaceState = createSurfaceState(",
+      "const selectionState = createSelectionState(",
+      "const legendFocusState = createLegendFocusState(",
+      "const intervalState = createIntervalState(",
+      "const chromeState = createPlotChromeState(",
+    ]);
+  });
+
+  it("keeps phased effects in registration order", () => {
+    expectOrdered(source, [
+      "runtime.registerModelEffects();",
+      "semanticKeys.registerEffects();",
+      "surfaceState.registerSurfaceEffects();",
+      "legendFilterState.registerCatalogEffects(",
+      "legendFocusState.registerReconcileEffects();",
+      "inspectionState.registerInspectionEffects();",
+      "runtime.registerLateEffects();",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Third slice of the S9–S17 program (follows #172, #173; based on main per squash-merge flow). All controller wiring leaves `GGPlot.svelte` (951 → ~490 lines) into two new internal modules:

- **`plot-orchestrator.svelte.ts`** — generic factory `createPlotOrchestrator<Row, Identity>(inputs)`. Inputs are getter thunks for every reactive prop/callback (exact post-destructure names; raw values would snapshot reactivity), plus `registry`/`plotId` as values and `root`/`captureSurface` element getters. The wiring moved verbatim in its pre-S11 declaration order — 10 factory constructions, interleaved declarations, and the full phased effect-registration sequence ending in `registerLateEffects()`. Module header documents the ownership split and the construction/effect-order contract. `tooltipHovered` is now orchestrator-owned (get/set); markup routes through `engine.tooltipHovered`.
- **`plot-props.ts`** — the generic `GGPlotProps` interface (type-only, internal; public API untouched — index.ts unmodified, publint + attw clean).

GGPlot keeps what must stay component-side: `$props()`, `provideRegistry()` context, `$props.id()`, `bind:this` element state, markup-only `a11yTableOpen`, and the exported `resetScales()`/`setZoom()` delegates.

Post-review boundary tightening (final commit): vestigial no-op casts deleted (the `PublicKey→PropertyKey` widening lives at the GGPlot call site; handler contravariance covers the narrower per-event dep types), dead `semanticKeys` member dropped from the public orchestrator surface, `RenderModel` imported top-level, unbound-method/void-expression lint satisfied — the orchestrator is the first wiring code type-aware lint analyzes (GGPlot.svelte was exempt as a `.svelte` file).

Ratchet ceiling appended: `s11-orchestrator: 505`.

## Verification

- Full `packages/svelte` suite: 183 files / 2553 browser tests + 10 SSR pass (run after every fix round)
- `bun run compat:consumer`: PASS (npm, Svelte 5.33.1)
- `check:svelte` 0/0, oxlint, **type-aware oxlint**, `bun run check`, `bun run build` + `lint:package` (publint/attw)
- Factory/effect call order verified byte-identical to base; all dep thunks preserved
- VR: failing-test identities on this branch are the identical 19 pre-existing local-noise tests recorded on the S10 tip (plot pixels byte-identical; container `vr-compare` in CI is authoritative)
- Multi-agent review verify pass: no correctness findings; 4 cleanup findings all applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)
