### PR TITLE
test(svelte): S17 — coverage thresholds, gap closure, directory docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,6 +111,7 @@ upstream, `.md`/`.yaml`/`.svelte` can fold back into oxfmt (`.oxfmtrc.json`
 | `bun run fmt` / `bun run fmt:check`                   | oxfmt (ts/js/json/css/toml) + prettier (.svelte/.md/.yaml)                                                                              |
 | `bun run test`                                        | bun unit tests (spec + core + scripts + evals harness; needs `bun run check` first)                                                     |
 | `bun run test:components`                             | packages/svelte component tests (Chromium, Firefox, WebKit) followed by the Node SSR suite                                              |
+| `cd packages/svelte && bun run test:coverage`         | browser (chromium) + SSR coverage reports; browser config enforces thresholds (local/optional — not wired into CI yet)                  |
 | `bun run check:examples`                              | tsc over the examples corpus's .ts files (needs `bun run check` first: dist types)                                                      |
 | `bun run check:docs`                                  | svelte-kit sync + svelte-check for apps/docs (needs `bun run build` first)                                                              |
 | `bun run build:docs`                                  | static docs site → `apps/docs/build/` (needs `bun run build` first; the VR target)                                                      |
@@ -139,6 +140,70 @@ parity (both stages) plus unit / component / build / actions-security /
 bench-smoke jobs. **CI is the contract; the git hooks are a convenience
 mirror.** If pre-push ever feels too slow, checks move to CI-required — they
 are never disabled.
+
+## packages/svelte layout and coverage
+
+### `src/lib` map
+
+The Svelte package is organized by feature under `packages/svelte/src/lib/`:
+
+| Directory / file              | Role                                                                                                                             |
+| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `geoms/`                      | Declaration-only geom children (`GeomPoint`, …) and the geom factory/registry                                                    |
+| `assembly/`                   | Labels, layout helpers, chrome-adjacent pure assembly                                                                            |
+| `runtime/`                    | Runtime paint, announcer, semantic-key services                                                                                  |
+| `scene/`                      | SVG scene tree (`SceneView`, `Batch`, axes, legends paint, strata)                                                               |
+| `a11y/`                       | Canvas-stratum accessibility surface + row materialization                                                                       |
+| `interaction/`                | Tools, reducer, capability, controller                                                                                           |
+| `surface/`                    | Capture surface controller (pointer/keyboard/brush)                                                                              |
+| `inspection/`                 | Tooltip, inspection coordinator/resolver, inspection state                                                                       |
+| `selection/`                  | Point-selection state                                                                                                            |
+| `interval/`                   | Interval selection, bounds editor, query                                                                                         |
+| `zoom/`                       | Brush-zoom state                                                                                                                 |
+| `legend/`                     | Legend filter/focus controllers, targets, pure surface helpers                                                                   |
+| `chrome/`                     | Tool rail, status chrome, theme CSS, chrome state                                                                                |
+| `fonts/`                      | Packaged font assets (not TypeScript sources)                                                                                    |
+| `GGPlot.svelte`               | Public component shell                                                                                                           |
+| `plot-orchestrator.svelte.ts` | Controller wiring; owns the construction/effect-order DAG contract (read the file header before reordering factories or effects) |
+| `plot-props.ts`               | GGPlot's **internal** props contract — not re-exported from `index.ts`                                                           |
+| `index.ts`                    | The **only** public package entry                                                                                                |
+
+### No per-directory barrels
+
+Feature directories do **not** ship `index.ts` re-export barrels. Imports use
+direct relative specifiers with extensions
+(e.g. `../inspection/resolver.js`). Rationale: knip can flag dead exports
+without barrel noise; the published `dist/` shape stays flat and intentional;
+and hub-style barrels invite import cycles across feature controllers.
+
+### Tests mirror `src`
+
+- Feature suites live under `packages/svelte/tests/<feature>/` and track
+  `src/lib/<feature>/` (e.g. `tests/surface/` ↔ `src/lib/surface/`).
+- Cross-cutting suites (`component.test.ts`, harnesses, release matrix) sit
+  at `packages/svelte/tests/` root.
+- Shared helpers and fixtures: `tests/helpers/`, `tests/fixtures/`.
+
+### Coverage workflow
+
+```sh
+cd packages/svelte && bun run test:coverage
+```
+
+That runs:
+
+1. **Browser** coverage (`vitest --coverage --project chromium`) →
+   `packages/svelte/coverage/browser/`. Thresholds live in
+   `vitest.config.ts` (after the `coverageBase` spread): statements 90,
+   branches 80, functions 90, lines 90. They ratchet against regression on
+   the mature browser report; they are **not** in `coverageBase` so the SSR
+   config stays threshold-free.
+2. **SSR** coverage (`vitest.ssr.config.ts`) →
+   `packages/svelte/coverage/ssr/`. Numbers are structurally lower (SSR
+   paths only) — do not chase SSR-report gaps or put thresholds there.
+
+`test:coverage` is a local / optional gate today. Wiring it into CI is a
+follow-up decision (it is intentionally not part of the CI contract yet).
 
 ## Formatting policy
 

--- a/packages/svelte/tests/a11y/canvas-a11y-component.test.ts
+++ b/packages/svelte/tests/a11y/canvas-a11y-component.test.ts
@@ -126,4 +126,22 @@ describe("CanvasA11y", () => {
       `First ${String(A11Y_TABLE_CAP)} of ${String(A11Y_TABLE_CAP + 10)} rows.`,
     );
   });
+
+  it("opens an empty table without a truncation note when there are no canvas rows", async () => {
+    const emptyModel = model({ layerFields: { 0: [{ field: "x" }] }, rows: {} });
+    const { container } = render(CanvasA11y, {
+      model: emptyModel,
+      batches: [batch({ layerIndex: 0, rowIndex: [] })],
+      sceneLabelText: "Empty",
+      open: true,
+      onToggle: () => {},
+    });
+    await until(() => container.querySelector(".gg-a11y-table") !== null);
+    const table = container.querySelector(".gg-a11y-table");
+    expect(table?.querySelectorAll("tbody tr")).toHaveLength(0);
+    expect(table?.querySelector("p")).toBeNull();
+    expect(container.querySelector(".gg-canvas-a11y")?.getAttribute("aria-label")).toBe(
+      "Empty — 0 canvas-rendered marks. Canvas marks are not individually focusable; use the data table.",
+    );
+  });
 });

--- a/packages/svelte/tests/fixtures/BatchFocusHarness.svelte
+++ b/packages/svelte/tests/fixtures/BatchFocusHarness.svelte
@@ -10,14 +10,18 @@
   const {
     batch,
     theme,
-    focusMask,
+    focusMask = null,
+    focusable = false,
+    markLabel,
   }: {
     batch: GeometryBatch;
     theme: ThemeTokens;
-    focusMask: BatchInteractionMask;
+    focusMask?: BatchInteractionMask | null;
+    focusable?: boolean;
+    markLabel?: (row: number) => string;
   } = $props();
 </script>
 
 <svg width="100" height="100">
-  <Batch {batch} {theme} {focusMask} />
+  <Batch {batch} {theme} {focusMask} {focusable} {markLabel} />
 </svg>

--- a/packages/svelte/tests/interaction/unit.test.ts
+++ b/packages/svelte/tests/interaction/unit.test.ts
@@ -534,4 +534,150 @@ describe("semantic inspection resolver", () => {
       resized.dispose();
     }
   });
+
+  it("fingerprints null/Date/-0 cells and symbol keys in coordinated snapshots", () => {
+    const data = [
+      { id: "a", x: 1, y: 2 },
+      { id: "b", x: 1, y: 3 },
+    ];
+    const model = runPipeline(
+      gg(data, aes({ x: "x", y: "y", color: "id" }))
+        .geomPoint()
+        .spec(),
+      { width: 400, height: 300 },
+    );
+    // Inject cell shapes cellToken handles specially (null / Date / -0) without
+    // going through PortableSpec validation, which rejects Date/null payloads.
+    const originalRow = model.row.bind(model);
+    vi.spyOn(model, "row").mockImplementation((index: number) => {
+      const base = originalRow(index);
+      if (base === null) return null;
+      return {
+        ...base,
+        note: index === 0 ? null : "ok",
+        when: new Date("2020-01-01T00:00:00Z"),
+        y: index === 1 ? -0 : base["y"],
+      };
+    });
+    const symbols = new Map<string, symbol>([
+      ["a", Symbol("a")],
+      ["b", Symbol("b")],
+    ]);
+    const coordinator = createInspectionCoordinator((row) => {
+      const id = String(row.id);
+      return symbols.get(id) ?? null;
+    });
+    const epoch = Symbol("layout");
+    const resolved = coordinator.resolve({
+      model,
+      seed: model.candidates.candidate(0)!,
+      mode: "x",
+      state: "transient",
+      source: "pointer",
+      identityEpoch: 1,
+      layoutEpoch: epoch,
+    });
+    expect(resolved).not.toBeNull();
+    expect(resolved!.snapshot.members.length).toBeGreaterThanOrEqual(1);
+    // Symbol keys must stay distinct across the same string identity.
+    expect(resolved!.semanticFingerprint).toContain("symbol:");
+    // null/Date/-0 all contribute typed cell tokens to the fingerprint payload.
+    expect(resolved!.semanticFingerprint).toMatch(/null|date:|number:/);
+    // Re-resolve with the same symbol layout epoch must hit the memo slot.
+    expect(
+      coordinator.resolve({
+        model,
+        seed: model.candidates.candidate(0)!,
+        mode: "x",
+        state: "transient",
+        source: "pointer",
+        identityEpoch: 1,
+        layoutEpoch: epoch,
+      }),
+    ).toBe(resolved);
+    model.dispose();
+  });
+
+  it("falls back to a single-member snapshot when axis grouping has no bucket", () => {
+    const model = runPipeline(
+      gg([{ id: "a", x: 1, y: 2 }], aes({ x: "x", y: "y" }))
+        .geomPoint()
+        .spec(),
+      { width: 300, height: 200 },
+    );
+    const seed = model.candidates.candidate(0)!;
+    // group() owns bucket validity; force a null group so resolveInspection's
+    // total fallback materializes a single-member axis snapshot.
+    vi.spyOn(model.candidates, "group").mockReturnValue(null);
+    const inspection = resolveInspection({
+      model,
+      seed: { ...seed, xValue: null, yValue: null },
+      mode: "x",
+      state: "pinned",
+      source: "keyboard",
+      keyOf: (row) => row.id as string,
+    });
+    expect(inspection.mode).toBe("x");
+    expect(inspection.members).toHaveLength(1);
+    expect(inspection.focus.key).toBe("a");
+    expect(inspection.axisValue).toBeNull();
+    expect(inspection.axisLabel).toBe("–");
+    model.dispose();
+  });
+
+  it("returns null from reconcilePinned when no pin is active", () => {
+    const model = runPipeline(
+      gg([{ id: "a", x: 1, y: 2 }], aes({ x: "x", y: "y" }))
+        .geomPoint()
+        .spec(),
+      { width: 300, height: 200 },
+    );
+    const coordinator = createInspectionCoordinator((row) => row.id as string);
+    expect(
+      coordinator.reconcilePinned({
+        model,
+        identityEpoch: 1,
+        layoutEpoch: 1,
+      }),
+    ).toBeNull();
+    model.dispose();
+  });
+
+  it("disambiguates multi-match pins that share one source row via batch role", () => {
+    const smoothSpec = gg(
+      [
+        { x: 0, y: 1 },
+        { x: 1, y: 3 },
+        { x: 2, y: 5 },
+      ],
+      aes({ x: "x", y: "y" }),
+    )
+      .geomSmooth({ method: "lm" })
+      .spec();
+    const first = runPipeline(smoothSpec, { width: 400, height: 300 });
+    const resized = runPipeline(smoothSpec, { width: 700, height: 300 });
+    // Keyed coordinator with a constant key so every candidate maps to the same key —
+    // reconcile then uses seedKind/batchRole/primitiveIndex to pick one match.
+    const coordinator = createInspectionCoordinator(() => "smooth");
+    const seed = first.candidates.candidate(0)!;
+    coordinator.resolve({
+      model: first,
+      seed,
+      mode: "exact",
+      state: "pinned",
+      source: "pointer",
+      identityEpoch: "same-data",
+      layoutEpoch: first.runId,
+    });
+    const reconciled = coordinator.reconcilePinned({
+      model: resized,
+      identityEpoch: "same-data",
+      layoutEpoch: resized.runId,
+    });
+    expect(reconciled).not.toBeNull();
+    expect(reconciled!.seed.kind).toBe(seed.kind);
+    expect(reconciled!.seed.primitiveIndex).toBe(seed.primitiveIndex);
+    first.dispose();
+    resized.dispose();
+  });
 });

--- a/packages/svelte/tests/interaction/unit.test.ts
+++ b/packages/svelte/tests/interaction/unit.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { runPipeline } from "@ggsvelte/core";
+import { runPipeline, type CandidateFacts, type RenderModel } from "@ggsvelte/core";
 import { aes, gg } from "@ggsvelte/spec";
 
 import {
@@ -25,6 +25,15 @@ const candidate = (id: number): InteractionCandidateRef => ({
   x: 10 + id,
   y: 20 + id,
 });
+
+function sameKindBatchOrdinal(model: RenderModel, seed: CandidateFacts): number {
+  return (
+    model.scene.batches
+      .slice(0, seed.batchIndex + 1)
+      .filter((batch) => batch.layerIndex === seed.layerIndex && batch.kind === seed.kind).length -
+    1
+  );
+}
 
 describe("isAreaTool", () => {
   it("is true only for select-area and zoom-area", () => {
@@ -142,7 +151,10 @@ describe("interaction capability normalization", () => {
 
   it("catalogues every emitted diagnostic", () => {
     const result = normalizeInteractionConfig(
-      { select: { type: "interval", mode: "xy" }, zoom: { mode: "xy", trigger: "brush" } },
+      {
+        select: { type: "interval", mode: "xy" },
+        zoom: { mode: "xy", trigger: "brush" },
+      },
       { faceted: true },
     );
     for (const diagnostic of result.diagnostics) {
@@ -159,14 +171,26 @@ describe("chart-local interaction reducer", () => {
         onChange();
       },
     });
-    reducer.dispatch({ type: "inspect", candidate: candidate(1), source: "pointer" });
-    reducer.dispatch({ type: "inspect", candidate: candidate(1), source: "pointer" });
+    reducer.dispatch({
+      type: "inspect",
+      candidate: candidate(1),
+      source: "pointer",
+    });
+    reducer.dispatch({
+      type: "inspect",
+      candidate: candidate(1),
+      source: "pointer",
+    });
     expect(onChange).toHaveBeenCalledTimes(1);
     expect(reducer.state.inspection.kind).toBe("transient");
 
     reducer.dispatch({ type: "toggle-pin", source: "pointer" });
     expect(reducer.state.inspection.kind).toBe("pinned");
-    reducer.dispatch({ type: "inspect", candidate: candidate(2), source: "pointer" });
+    reducer.dispatch({
+      type: "inspect",
+      candidate: candidate(2),
+      source: "pointer",
+    });
     expect(reducer.state.inspection.candidate?.id).toBe(1);
     reducer.dispatch({ type: "escape", source: "keyboard" });
     expect(reducer.state.inspection.kind).toBe("idle");
@@ -175,9 +199,16 @@ describe("chart-local interaction reducer", () => {
   it("keeps Select area and Zoom area mutually exclusive", () => {
     const reducer = createInteractionReducer();
     reducer.dispatch({ type: "set-tool", tool: "select-area" });
-    reducer.dispatch({ type: "begin-area", point: { x: 10, y: 10 }, panelId: "panel:all" });
+    reducer.dispatch({
+      type: "begin-area",
+      point: { x: 10, y: 10 },
+      panelId: "panel:all",
+    });
     reducer.dispatch({ type: "move-area", point: { x: 40, y: 50 } });
-    expect(reducer.state.area).toMatchObject({ kind: "dragging", tool: "select-area" });
+    expect(reducer.state.area).toMatchObject({
+      kind: "dragging",
+      tool: "select-area",
+    });
 
     reducer.dispatch({ type: "set-tool", tool: "zoom-area" });
     expect(reducer.state.area.kind).toBe("idle");
@@ -210,14 +241,26 @@ describe("chart-local interaction reducer", () => {
         changes.push(state.revision);
       },
     });
-    reducer.queuePointer({ type: "inspect", candidate: candidate(1), source: "pointer" });
-    reducer.queuePointer({ type: "inspect", candidate: candidate(2), source: "pointer" });
+    reducer.queuePointer({
+      type: "inspect",
+      candidate: candidate(1),
+      source: "pointer",
+    });
+    reducer.queuePointer({
+      type: "inspect",
+      candidate: candidate(2),
+      source: "pointer",
+    });
     expect(changes).toHaveLength(0);
     (frame as (() => void) | null)?.();
     expect(reducer.state.inspection.candidate?.id).toBe(2);
     expect(changes).toHaveLength(1);
 
-    reducer.queuePointer({ type: "inspect", candidate: candidate(3), source: "pointer" });
+    reducer.queuePointer({
+      type: "inspect",
+      candidate: candidate(3),
+      source: "pointer",
+    });
     reducer.dispatch({ type: "set-tool", tool: "zoom-area" });
     expect(frame).toBeNull();
     expect(reducer.state.inspection.candidate?.id).toBe(2);
@@ -505,12 +548,6 @@ describe("semantic inspection resolver", () => {
       );
       expect(collidingSeeds.length).toBeGreaterThanOrEqual(2);
 
-      const batchRole = (model: typeof first, seed: (typeof collidingSeeds)[number]) =>
-        model.scene.batches
-          .slice(0, seed.batchIndex + 1)
-          .filter((batch) => batch.layerIndex === seed.layerIndex && batch.kind === seed.kind)
-          .length - 1;
-
       for (const seed of collidingSeeds) {
         const coordinator = createInspectionCoordinator(() => null);
         coordinator.resolve({
@@ -528,7 +565,9 @@ describe("semantic inspection resolver", () => {
           layoutEpoch: resized.runId,
         });
         expect(reconciled).not.toBeNull();
-        expect(batchRole(resized, reconciled!.seed)).toBe(batchRole(first, seed));
+        expect(sameKindBatchOrdinal(resized, reconciled!.seed)).toBe(
+          sameKindBatchOrdinal(first, seed),
+        );
       }
       first.dispose();
       resized.dispose();
@@ -580,9 +619,14 @@ describe("semantic inspection resolver", () => {
     expect(resolved).not.toBeNull();
     expect(resolved!.snapshot.members.length).toBeGreaterThanOrEqual(1);
     // Symbol keys must stay distinct across the same string identity.
-    expect(resolved!.semanticFingerprint).toContain("symbol:");
+    expect([...new Set(resolved!.semanticFingerprint.match(/symbol:\d+/g) ?? [])]).toEqual([
+      "symbol:0",
+      "symbol:1",
+    ]);
     // null/Date/-0 all contribute typed cell tokens to the fingerprint payload.
-    expect(resolved!.semanticFingerprint).toMatch(/null|date:|number:/);
+    expect(resolved!.semanticFingerprint).toContain("note=null");
+    expect(resolved!.semanticFingerprint).toContain("when=date:1577836800000");
+    expect(resolved!.semanticFingerprint).toContain("y=number:0");
     // Re-resolve with the same symbol layout epoch must hit the memo slot.
     expect(
       coordinator.resolve({
@@ -677,6 +721,7 @@ describe("semantic inspection resolver", () => {
     expect(reconciled).not.toBeNull();
     expect(reconciled!.seed.kind).toBe(seed.kind);
     expect(reconciled!.seed.primitiveIndex).toBe(seed.primitiveIndex);
+    expect(sameKindBatchOrdinal(resized, reconciled!.seed)).toBe(sameKindBatchOrdinal(first, seed));
     first.dispose();
     resized.dispose();
   });

--- a/packages/svelte/tests/legend/interaction.test.ts
+++ b/packages/svelte/tests/legend/interaction.test.ts
@@ -67,4 +67,15 @@ describe("static Legend", () => {
     ).toEqual(["10", "0"]);
     expect(container.querySelector("foreignObject, button")).toBeNull();
   });
+
+  it("omits the title node and pins the ramp at y=0 when title is empty", () => {
+    const untitled = { ...ramp, title: "" } satisfies SceneLegend;
+    const { container } = render(LegendHarness, { legend: untitled, theme });
+    expect(container.querySelector(".gg-legend-title")).toBeNull();
+    const bar = container.querySelector(".gg-legend-ramp");
+    expect(bar?.getAttribute("y")).toBe("0");
+    // Tick labels are placed relative to rampTop=0 (not the titled offset of 18).
+    const labels = [...container.querySelectorAll(".gg-legend-label")];
+    expect(labels.map((label) => label.getAttribute("y"))).toEqual(["0", "80"]);
+  });
 });

--- a/packages/svelte/tests/legend/renderer-mask.test.ts
+++ b/packages/svelte/tests/legend/renderer-mask.test.ts
@@ -19,8 +19,21 @@ const focusFirst: BatchInteractionMask = {
   isFocused: (index) => index === 0,
 };
 
-function renderBatch(batch: GeometryBatch): SVGElement[] {
-  const { container } = render(BatchFocusHarness, { batch, theme, focusMask: focusFirst });
+function renderBatch(
+  batch: GeometryBatch,
+  opts?: {
+    focusMask?: BatchInteractionMask | null;
+    focusable?: boolean;
+    markLabel?: (row: number) => string;
+  },
+): SVGElement[] {
+  const { container } = render(BatchFocusHarness, {
+    batch,
+    theme,
+    focusMask: opts?.focusMask === undefined ? focusFirst : opts.focusMask,
+    focusable: opts?.focusable ?? false,
+    markLabel: opts?.markLabel,
+  });
   return [...container.querySelectorAll<SVGElement>(".gg-batch > *")];
 }
 
@@ -76,5 +89,177 @@ describe("SVG batch focus masks", () => {
     expect(elements.map((element) => element.textContent)).toEqual(["muted", "focused"]);
     expect(elements.map((element) => element.dataset["ggFocused"])).toEqual(["false", "true"]);
     expect(elements[0].getAttribute("opacity")).toBe("0.25");
+  });
+
+  it("reorders and mutes path primitives under a focus mask", () => {
+    const elements = renderBatch({
+      kind: "paths",
+      layerIndex: 0,
+      panelIndex: 0,
+      positions: Float32Array.from([0, 0, 10, 10, 20, 0, 30, 10]),
+      rowIndex: Uint32Array.from([0, 0, 1, 1]),
+      pathOffsets: Uint32Array.from([0, 2, 4]),
+      strokes: ["#111111", "#222222"],
+      linewidth: 1.5,
+      alpha: 1,
+      curve: "linear",
+    });
+
+    expect(elements).toHaveLength(2);
+    expect(elements.map((element) => element.dataset["ggFocused"])).toEqual(["false", "true"]);
+    expect(elements[0].getAttribute("opacity")).toBe("0.25");
+    expect(elements[0].getAttribute("stroke-width")).toBe("1.5");
+    expect(elements[1].getAttribute("opacity")).toBeNull();
+  });
+});
+
+describe("SVG batch mark variants", () => {
+  it("renders square and triangle point shapes with the expected SVG tags", () => {
+    const square = renderBatch(
+      {
+        kind: "points",
+        layerIndex: 0,
+        panelIndex: 0,
+        positions: Float32Array.from([10, 20]),
+        rowIndex: Uint32Array.from([0]),
+        size: 4,
+        alpha: 1,
+        shape: "square",
+        fill: "#ff0000",
+      },
+      { focusMask: null },
+    );
+    expect(square).toHaveLength(1);
+    expect(square[0].tagName.toLowerCase()).toBe("rect");
+    expect(square[0].getAttribute("width")).toBe("8");
+    expect(square[0].getAttribute("height")).toBe("8");
+    expect(square[0].getAttribute("fill")).toBe("#ff0000");
+    expect(Object.hasOwn(square[0].dataset, "ggFocused")).toBe(false);
+
+    const triangle = renderBatch(
+      {
+        kind: "points",
+        layerIndex: 0,
+        panelIndex: 0,
+        positions: Float32Array.from([15, 25]),
+        rowIndex: Uint32Array.from([0]),
+        size: 5,
+        alpha: 1,
+        shape: "triangle",
+        fill: "#00ff00",
+      },
+      { focusMask: null },
+    );
+    expect(triangle).toHaveLength(1);
+    expect(triangle[0].tagName.toLowerCase()).toBe("path");
+    expect(triangle[0].getAttribute("d")).toMatch(/^M/);
+    expect(triangle[0].getAttribute("fill")).toBe("#00ff00");
+  });
+
+  it("makes point marks keyboard-focusable with custom or default aria labels", () => {
+    const labeled = renderBatch(
+      {
+        kind: "points",
+        layerIndex: 2,
+        panelIndex: 0,
+        positions: Float32Array.from([1, 2, 3, 4]),
+        rowIndex: Uint32Array.from([3, 7]),
+        size: 3,
+        alpha: 1,
+        shape: "circle",
+        fill: null,
+        colors: ["#aaa", "#bbb"],
+      },
+      {
+        focusMask: null,
+        focusable: true,
+        markLabel: (row) => `row-${row}`,
+      },
+    );
+    expect(labeled).toHaveLength(2);
+    expect(labeled[0].getAttribute("tabindex")).toBe("0");
+    expect(labeled[0].getAttribute("role")).toBe("img");
+    expect(labeled[0].getAttribute("aria-label")).toBe("row-3");
+    expect(labeled[0].dataset["ggLayer"]).toBe("2");
+    expect(labeled[0].dataset["ggRow"]).toBe("3");
+    expect(labeled[1].getAttribute("aria-label")).toBe("row-7");
+
+    const defaultLabel = renderBatch(
+      {
+        kind: "points",
+        layerIndex: 0,
+        panelIndex: 0,
+        positions: Float32Array.from([5, 6]),
+        rowIndex: Uint32Array.from([4]),
+        size: 2,
+        alpha: 1,
+        shape: "circle",
+        fill: "#111",
+      },
+      { focusMask: null, focusable: true },
+    );
+    expect(defaultLabel[0].getAttribute("aria-label")).toBe("data point 5");
+  });
+
+  it("skips focus attrs for synthetic NO_ROW marks even when focusable", () => {
+    const elements = renderBatch(
+      {
+        kind: "points",
+        layerIndex: 0,
+        panelIndex: 0,
+        positions: Float32Array.from([1, 1, 2, 2]),
+        rowIndex: Uint32Array.from([0xffffffff, 1]),
+        size: 2,
+        alpha: 1,
+        shape: "circle",
+        fill: "#111",
+      },
+      { focusMask: null, focusable: true },
+    );
+    expect(elements[0].hasAttribute("tabindex")).toBe(false);
+    expect(elements[0].hasAttribute("aria-label")).toBe(false);
+    expect(elements[1].getAttribute("tabindex")).toBe("0");
+    expect(elements[1].getAttribute("aria-label")).toBe("data point 2");
+  });
+
+  it("omits empty path subpaths and strokes rects with default stroke width", () => {
+    const paths = renderBatch(
+      {
+        kind: "paths",
+        layerIndex: 0,
+        panelIndex: 0,
+        // Empty first subpath (offsets 0..0), real second subpath (0..2 points).
+        positions: Float32Array.from([0, 0, 10, 10]),
+        rowIndex: Uint32Array.from([0, 0]),
+        pathOffsets: Uint32Array.from([0, 0, 2]),
+        strokes: [null, "#abcdef"],
+        linewidth: 2,
+        alpha: 0.5,
+        curve: "linear",
+      },
+      { focusMask: null },
+    );
+    expect(paths).toHaveLength(1);
+    expect(paths[0].getAttribute("stroke")).toBe("#abcdef");
+    expect(paths[0].getAttribute("d")).toMatch(/^M/);
+    expect(paths[0].closest(".gg-batch")?.getAttribute("opacity")).toBe("0.5");
+
+    const rects = renderBatch(
+      {
+        kind: "rects",
+        layerIndex: 0,
+        panelIndex: 0,
+        rects: Float32Array.from([1, 2, 3, 4]),
+        rowIndex: Uint32Array.from([0]),
+        fill: null,
+        stroke: "#333333",
+        // strokeWidth omitted → Batch defaults to 1 when stroke is present.
+        alpha: 1,
+      },
+      { focusMask: null },
+    );
+    expect(rects).toHaveLength(1);
+    expect(rects[0].getAttribute("stroke")).toBe("#333333");
+    expect(rects[0].getAttribute("stroke-width")).toBe("1");
   });
 });

--- a/packages/svelte/tests/surface/surface-state.test.ts
+++ b/packages/svelte/tests/surface/surface-state.test.ts
@@ -648,6 +648,17 @@ describe("createSurfaceState tool cycle", () => {
     h.destroy();
   });
 
+  it("ignores chooseTool for tools not in availableTools", () => {
+    // Default harness enables inspect + interval + zoom — not point selection.
+    const h = mountSurfaceComposite({ registerEffects: false });
+    expect(h.surface.activeTool).toBe("inspect");
+    h.surface.chooseTool("point");
+    flushSync();
+    expect(h.surface.activeTool).toBe("inspect");
+    expect(h.toolChanges).toEqual([]);
+    h.destroy();
+  });
+
   it("tool-sync effect resolves initial tool into the reducer", () => {
     const config = normalizeInteractionConfig({
       inspect: { pin: true },
@@ -1280,6 +1291,75 @@ describe("createSurfaceState pointer cancel vs lost capture", () => {
       y: second.y,
     });
 
+    h.destroy();
+  });
+
+  it("lost capture while idle is a no-op (ignore branch)", () => {
+    const h = mountSurfaceComposite({ registerEffects: false });
+    expect(h.surface.reducer.state.area.kind).toBe("idle");
+    expect(h.surface.brushRect).toBeNull();
+    h.surface.onLostPointerCapture();
+    flushSync();
+    expect(h.surface.reducer.state.area.kind).toBe("idle");
+    expect(h.surface.brushRect).toBeNull();
+    h.destroy();
+  });
+
+  it("non-primary pointerdown and non-inspect move take the none action paths", () => {
+    const h = mountSurfaceComposite({ registerEffects: false });
+    h.surface.chooseTool("select-area");
+    flushSync();
+    const start = panelCenterClient(h.model);
+
+    // Right-click must not begin a brush.
+    h.surface.onPointerDown(
+      pointerEvent("pointerdown", h.capture, {
+        clientX: start.x,
+        clientY: start.y,
+        button: 2,
+      }),
+    );
+    flushSync();
+    expect(h.surface.brushRect).toBeNull();
+    expect(h.surface.reducer.state.area.kind).toBe("idle");
+
+    // Move while select-area (not brushing) queues nothing.
+    h.surface.onPointerMove(
+      pointerEvent("pointermove", h.capture, {
+        clientX: start.x + 5,
+        clientY: start.y + 5,
+      }),
+    );
+    suitePump.flush();
+    flushSync();
+    expect(h.surface.brushRect).toBeNull();
+    expect(h.inspection.inspection).toBeNull();
+    h.destroy();
+  });
+
+  it("capture click on point tool with no nearby candidate is a no-op", () => {
+    const config = normalizeInteractionConfig({
+      inspect: true,
+      select: { type: "point" },
+    });
+    const h = mountSurfaceComposite({
+      interactionConfig: config,
+      registerEffects: false,
+    });
+    h.surface.chooseTool("point");
+    flushSync();
+    expect(h.surface.activeTool).toBe("point");
+    // Far outside the plot — nearest lookup must miss.
+    const click = new MouseEvent("click", {
+      bubbles: true,
+      cancelable: true,
+      clientX: -1000,
+      clientY: -1000,
+    });
+    Object.defineProperty(click, "currentTarget", { value: h.capture, configurable: true });
+    h.surface.onCaptureClick(click);
+    flushSync();
+    expect(h.toggleCalls).toEqual([]);
     h.destroy();
   });
 });

--- a/packages/svelte/vitest.config.ts
+++ b/packages/svelte/vitest.config.ts
@@ -25,6 +25,16 @@ export default defineConfig({
     coverage: {
       ...coverageBase,
       reportsDirectory: "coverage/browser",
+      // Browser-only gate: keep thresholds on this config (not coverageBase)
+      // so the structurally-low SSR report is not blocked. Values sit ≥5pp
+      // under current mature browser totals to ratchet regressions without
+      // flake. CI adoption of test:coverage is a follow-up decision.
+      thresholds: {
+        statements: 90,
+        branches: 80,
+        functions: 90,
+        lines: 90,
+      },
     },
     browser: {
       enabled: true,


### PR DESCRIPTION
## Summary

Final slice of the S9–S17 program, rebased directly onto `main`. It closes the remaining report-driven browser coverage gaps, enables regression thresholds, and documents the feature-directory layout.

- **Branch-gap closure:** extends existing behavioral suites for untitled legends, path/point/rect rendering variants, mark accessibility, canvas empty-state accessibility, inspection fingerprints and pin reconciliation, and surface no-op paths.
- **Coverage thresholds:** browser-only thresholds of 90% statements, 80% branches, 90% functions, and 90% lines. The SSR report remains intentionally ungated. Current browser totals are **96.62 / 91.78 / 98.48 / 98**.
- **Review follow-through:** asserts every null/Date/-0 fingerprint token and both distinct symbol identities; keyed and keyless pin reconciliation now both verify the same-kind batch ordinal.
- **Documentation:** maps `packages/svelte/src/lib`, records the no-per-directory-barrels rule, explains the tests-mirror-source convention, and documents the optional coverage workflow.

## Verification

- `bun run test`: **823 passed**
- `bun run test:components`: **2,691 browser + 10 SSR passed**
- `cd packages/svelte && bun run test:coverage`: **897 browser + 10 SSR passed**; thresholds pass at **96.62 / 91.78 / 98.48 / 98**
- Targeted inspection suite: **66 passed** across Chromium, Firefox, and WebKit
- Build, svelte-check, type-aware lint, knip, formatting, and pre-push checks pass

## Program complete (S9–S17)

`packages/svelte/src/lib` moved from a flat 73-file directory to 13 feature directories plus four root files. `GGPlot.svelte` is now the component shell, `plot-orchestrator.svelte.ts` owns controller wiring and construction/effect ordering, `plot-props.ts` owns the internal props contract, and `index.ts` remains the sole public entry.
