### PR TITLE
perf(core): partition facet panels in one O(n) pass

### DIFF
--- a/packages/core/src/pipeline/facets-grid.ts
+++ b/packages/core/src/pipeline/facets-grid.ts
@@ -7,30 +7,9 @@ import { bandKey } from "../scales/train.js";
 import type { ColumnTable } from "../table.js";
 
 import { facetValues } from "./facets-helpers.js";
-import { partitionByField } from "./facets-tokens.js";
+import { partitionByField, partitionByFields } from "./facets-tokens.js";
 import type { FacetLayout, FacetPanelDef } from "./facets-types.js";
 import { SINGLE_PANEL } from "./facets-types.js";
-
-/** Intersect two ascending row-index lists (table order is ascending within buckets). */
-function intersectSorted(a: readonly number[], b: readonly number[]): number[] {
-  const out: number[] = [];
-  let i = 0;
-  let j = 0;
-  while (i < a.length && j < b.length) {
-    const av = a[i]!;
-    const bv = b[j]!;
-    if (av === bv) {
-      out.push(av);
-      i += 1;
-      j += 1;
-    } else if (av < bv) {
-      i += 1;
-    } else {
-      j += 1;
-    }
-  }
-  return out;
-}
 
 export function resolveFacetGrid(input: {
   table: ColumnTable;
@@ -51,22 +30,36 @@ export function resolveFacetGrid(input: {
   ) {
     return SINGLE_PANEL(table, baseSourceRows);
   }
-  // Pre-partition once per dimension — O(n) each, then per-cell intersection
-  // over bucket sizes (issue #183). Avoids O(R·C·n) full-table re-scans.
-  const rowBuckets = rowsField === null ? null : partitionByField(table, rowsField);
-  const colBuckets = colsField === null ? null : partitionByField(table, colsField);
+  // Partition rows once (issue #183): a full grid by the composite (row, col)
+  // key, or a single dimension when only one field is set — O(n), then O(R·C)
+  // bucket reads. Every rowValue/colValue comes from facetValues() over the
+  // same column, so its bucket always exists; a missing one is a broken
+  // contract and asserts loudly rather than silently emptying a panel. In the
+  // full grid, an absent inner bucket is a genuine empty combination (`?? []`).
+  const grid =
+    rowsField !== null && colsField !== null
+      ? partitionByFields(table, rowsField, colsField)
+      : null;
+  const rowBuckets =
+    rowsField !== null && colsField === null ? partitionByField(table, rowsField) : null;
+  const colBuckets =
+    colsField !== null && rowsField === null ? partitionByField(table, colsField) : null;
   const panels: FacetPanelDef[] = [];
   for (let r = 0; r < rowValues.length; r++) {
+    // Row-dimension lookup is loop-invariant across the col loop — hoist it.
+    const rowInner = grid === null ? null : grid.get(encodeKey(rowValues[r]!))!;
+    const rowOnly = rowBuckets === null ? null : rowBuckets.get(encodeKey(rowValues[r]!))!;
     for (let c = 0; c < colValues.length; c++) {
-      let rows: number[] = [];
-      if (rowBuckets !== null && colBuckets !== null) {
-        const rb = rowBuckets.get(encodeKey(rowValues[r]!)) ?? [];
-        const cb = colBuckets.get(encodeKey(colValues[c]!)) ?? [];
-        rows = intersectSorted(rb, cb);
-      } else if (rowBuckets !== null) {
-        rows = rowBuckets.get(encodeKey(rowValues[r]!)) ?? [];
-      } else if (colBuckets !== null) {
-        rows = colBuckets.get(encodeKey(colValues[c]!)) ?? [];
+      let rows: number[];
+      if (rowInner !== null) {
+        rows = rowInner.get(encodeKey(colValues[c]!)) ?? [];
+      } else if (rowOnly !== null) {
+        rows = rowOnly;
+      } else if (colBuckets === null) {
+        // Unreachable: assertFacetForm guarantees ≥1 grid field once wrap is null.
+        throw new Error("facet grid resolved with neither rows nor cols field");
+      } else {
+        rows = colBuckets.get(encodeKey(colValues[c]!))!;
       }
       const parts: string[] = [];
       if (rowsField !== null) parts.push(bandKey(rowValues[r]!));

--- a/packages/core/src/pipeline/facets-grid.ts
+++ b/packages/core/src/pipeline/facets-grid.ts
@@ -2,12 +2,35 @@
  * Facet grid partition: rows × cols combinations (empty combos kept).
  */
 import { createFacetPanelIdentity } from "../facet-identity.js";
+import { encodeKey } from "../scales/state.js";
 import { bandKey } from "../scales/train.js";
 import type { ColumnTable } from "../table.js";
 
-import { facetValues, rowsMatching } from "./facets-helpers.js";
+import { facetValues } from "./facets-helpers.js";
+import { partitionByField } from "./facets-tokens.js";
 import type { FacetLayout, FacetPanelDef } from "./facets-types.js";
 import { SINGLE_PANEL } from "./facets-types.js";
+
+/** Intersect two ascending row-index lists (table order is ascending within buckets). */
+function intersectSorted(a: readonly number[], b: readonly number[]): number[] {
+  const out: number[] = [];
+  let i = 0;
+  let j = 0;
+  while (i < a.length && j < b.length) {
+    const av = a[i]!;
+    const bv = b[j]!;
+    if (av === bv) {
+      out.push(av);
+      i += 1;
+      j += 1;
+    } else if (av < bv) {
+      i += 1;
+    } else {
+      j += 1;
+    }
+  }
+  return out;
+}
 
 export function resolveFacetGrid(input: {
   table: ColumnTable;
@@ -28,17 +51,22 @@ export function resolveFacetGrid(input: {
   ) {
     return SINGLE_PANEL(table, baseSourceRows);
   }
+  // Pre-partition once per dimension — O(n) each, then per-cell intersection
+  // over bucket sizes (issue #183). Avoids O(R·C·n) full-table re-scans.
+  const rowBuckets = rowsField === null ? null : partitionByField(table, rowsField);
+  const colBuckets = colsField === null ? null : partitionByField(table, colsField);
   const panels: FacetPanelDef[] = [];
   for (let r = 0; r < rowValues.length; r++) {
     for (let c = 0; c < colValues.length; c++) {
-      let rows: number[] | null = null;
-      if (rowsField !== null) rows = rowsMatching(table, rowsField, rowValues[r]!);
-      if (colsField !== null) {
-        const colRows = new Set(rowsMatching(table, colsField, colValues[c]!));
-        rows =
-          rows === null
-            ? [...colRows].toSorted((a, b) => a - b)
-            : rows.filter((i) => colRows.has(i));
+      let rows: number[] = [];
+      if (rowBuckets !== null && colBuckets !== null) {
+        const rb = rowBuckets.get(encodeKey(rowValues[r]!)) ?? [];
+        const cb = colBuckets.get(encodeKey(colValues[c]!)) ?? [];
+        rows = intersectSorted(rb, cb);
+      } else if (rowBuckets !== null) {
+        rows = rowBuckets.get(encodeKey(rowValues[r]!)) ?? [];
+      } else if (colBuckets !== null) {
+        rows = colBuckets.get(encodeKey(colValues[c]!)) ?? [];
       }
       const parts: string[] = [];
       if (rowsField !== null) parts.push(bandKey(rowValues[r]!));
@@ -57,8 +85,8 @@ export function resolveFacetGrid(input: {
         label: parts.join(" / "),
         row: r,
         col: c,
-        table: table.subset(rows ?? []),
-        sourceRows: (rows ?? []).map((row) => baseSourceRows?.[row] ?? row),
+        table: table.subset(rows),
+        sourceRows: rows.map((row) => baseSourceRows?.[row] ?? row),
       });
     }
   }

--- a/packages/core/src/pipeline/facets-helpers.ts
+++ b/packages/core/src/pipeline/facets-helpers.ts
@@ -10,8 +10,6 @@ import { cellToNumber, ColumnTable } from "../table.js";
 
 import { PipelineError } from "./types.js";
 
-export { partitionByField, rowsMatching } from "./facets-tokens.js";
-
 export function facetField(
   ref: { field: string } | undefined,
   key: "wrap" | "rows" | "cols",

--- a/packages/core/src/pipeline/facets-helpers.ts
+++ b/packages/core/src/pipeline/facets-helpers.ts
@@ -10,7 +10,7 @@ import { cellToNumber, ColumnTable } from "../table.js";
 
 import { PipelineError } from "./types.js";
 
-export { rowsMatching } from "./facets-tokens.js";
+export { partitionByField, rowsMatching } from "./facets-tokens.js";
 
 export function facetField(
   ref: { field: string } | undefined,

--- a/packages/core/src/pipeline/facets-tokens.ts
+++ b/packages/core/src/pipeline/facets-tokens.ts
@@ -22,3 +22,30 @@ export function partitionByField(table: ColumnTable, field: string): Map<string,
   }
   return map;
 }
+
+/**
+ * Single-pass partition of table rows by the composite encodeKey of two facet
+ * fields (grid rows × cols). Outer map keyed by `fieldA`, inner by `fieldB`;
+ * row indices within each bucket preserve table order. Empty (a, b)
+ * combinations are simply absent — a missing bucket is the caller's empty panel.
+ * O(n), replacing per-cell bucket intersection over R·C cells (issue #183).
+ */
+export function partitionByFields(
+  table: ColumnTable,
+  fieldA: string,
+  fieldB: string,
+): Map<string, Map<string, number[]>> {
+  const map = new Map<string, Map<string, number[]>>();
+  const colA = table.column(fieldA);
+  const colB = table.column(fieldB);
+  for (let i = 0; i < colA.length; i++) {
+    const ka = encodeKey(colA[i]!);
+    const kb = encodeKey(colB[i]!);
+    let inner = map.get(ka);
+    if (inner === undefined) map.set(ka, (inner = new Map<string, number[]>()));
+    let bucket = inner.get(kb);
+    if (bucket === undefined) inner.set(kb, (bucket = []));
+    bucket.push(i);
+  }
+  return map;
+}

--- a/packages/core/src/pipeline/facets-tokens.ts
+++ b/packages/core/src/pipeline/facets-tokens.ts
@@ -1,10 +1,30 @@
 /**
  * Facet panel row matching (encodeKey preserves `"1"`/`1` and `0`/`-0`).
+ *
+ * Prefer `partitionByField` for multi-panel builds: one O(n) scan instead of
+ * re-scanning the column once per distinct value / grid cell (issue #183).
  */
 import { encodeKey } from "../scales/state.js";
 import type { CellValue } from "../table.js";
 import type { ColumnTable } from "../table.js";
 
+/**
+ * Single-pass partition of table rows by a facet field's encodeKey.
+ * Row indices within each bucket preserve table order.
+ */
+export function partitionByField(table: ColumnTable, field: string): Map<string, number[]> {
+  const map = new Map<string, number[]>();
+  const column = table.column(field);
+  for (let i = 0; i < column.length; i++) {
+    const k = encodeKey(column[i]!);
+    let bucket = map.get(k);
+    if (bucket === undefined) map.set(k, (bucket = []));
+    bucket.push(i);
+  }
+  return map;
+}
+
+/** Rows whose field equals value (encodeKey equality). Prefer partitionByField for multi-value builds. */
 export function rowsMatching(table: ColumnTable, field: string, value: CellValue): number[] {
   const key = encodeKey(value);
   const column = table.column(field);

--- a/packages/core/src/pipeline/facets-tokens.ts
+++ b/packages/core/src/pipeline/facets-tokens.ts
@@ -1,11 +1,10 @@
 /**
- * Facet panel row matching (encodeKey preserves `"1"`/`1` and `0`/`-0`).
+ * Facet panel row partition (encodeKey preserves `"1"`/`1` and `0`/`-0`).
  *
- * Prefer `partitionByField` for multi-panel builds: one O(n) scan instead of
- * re-scanning the column once per distinct value / grid cell (issue #183).
+ * One O(n) scan groups row indices by field value — wrap/grid assemble panels
+ * from these buckets instead of re-scanning once per value/cell (issue #183).
  */
 import { encodeKey } from "../scales/state.js";
-import type { CellValue } from "../table.js";
 import type { ColumnTable } from "../table.js";
 
 /**
@@ -22,15 +21,4 @@ export function partitionByField(table: ColumnTable, field: string): Map<string,
     bucket.push(i);
   }
   return map;
-}
-
-/** Rows whose field equals value (encodeKey equality). Prefer partitionByField for multi-value builds. */
-export function rowsMatching(table: ColumnTable, field: string, value: CellValue): number[] {
-  const key = encodeKey(value);
-  const column = table.column(field);
-  const rows: number[] = [];
-  for (let i = 0; i < column.length; i++) {
-    if (encodeKey(column[i]!) === key) rows.push(i);
-  }
-  return rows;
 }

--- a/packages/core/src/pipeline/facets-wrap.ts
+++ b/packages/core/src/pipeline/facets-wrap.ts
@@ -2,10 +2,12 @@
  * Facet wrap partition: one panel per distinct value, near-square ncol default.
  */
 import { createFacetPanelIdentity } from "../facet-identity.js";
+import { encodeKey } from "../scales/state.js";
 import { bandKey } from "../scales/train.js";
 import type { ColumnTable } from "../table.js";
 
-import { facetValues, rowsMatching } from "./facets-helpers.js";
+import { facetValues } from "./facets-helpers.js";
+import { partitionByField } from "./facets-tokens.js";
 import type { FacetLayout } from "./facets-types.js";
 import { SINGLE_PANEL } from "./facets-types.js";
 
@@ -22,8 +24,10 @@ export function resolveFacetWrap(input: {
   if (values.length === 0) return SINGLE_PANEL(table, baseSourceRows);
   const ncol = Math.min(values.length, input.ncol ?? Math.ceil(Math.sqrt(values.length)));
   const nrow = Math.ceil(values.length / ncol);
+  // One O(n) partition, then O(v) panel assembly (issue #183).
+  const buckets = partitionByField(table, wrapField);
   const panels = values.map((value, i) => {
-    const rows = rowsMatching(table, wrapField, value);
+    const rows = buckets.get(encodeKey(value)) ?? [];
     const identity = createFacetPanelIdentity([{ role: "wrap", field: wrapField, value }]);
     return {
       identity,

--- a/packages/core/src/pipeline/facets-wrap.ts
+++ b/packages/core/src/pipeline/facets-wrap.ts
@@ -27,7 +27,9 @@ export function resolveFacetWrap(input: {
   // One O(n) partition, then O(v) panel assembly (issue #183).
   const buckets = partitionByField(table, wrapField);
   const panels = values.map((value, i) => {
-    const rows = buckets.get(encodeKey(value)) ?? [];
+    // Every value came from facetValues() over this column, so its bucket
+    // exists; a missing one is a broken contract and asserts loudly.
+    const rows = buckets.get(encodeKey(value))!;
     const identity = createFacetPanelIdentity([{ role: "wrap", field: wrapField, value }]);
     return {
       identity,

--- a/packages/core/tests/pipeline-facets-unit.test.ts
+++ b/packages/core/tests/pipeline-facets-unit.test.ts
@@ -14,7 +14,7 @@ import { encodeKey } from "../src/scales/state.ts";
 import { PipelineError } from "../src/pipeline.ts";
 import { resolveFacet, SINGLE_PANEL } from "../src/pipeline/facets.ts";
 import { assertFacetForm, facetFreeFlags } from "../src/pipeline/facets-form.ts";
-import { partitionByField } from "../src/pipeline/facets-tokens.ts";
+import { partitionByField, partitionByFields } from "../src/pipeline/facets-tokens.ts";
 import { ColumnTable } from "../src/table.ts";
 
 const table = ColumnTable.fromRows([
@@ -206,6 +206,49 @@ describe("partitionByField — single-pass buckets", () => {
       partitionByField(t, "g");
     });
     expect(reads).toBe(1);
+  });
+});
+
+describe("partitionByFields — single-pass composite buckets", () => {
+  it("groups row indices by (a, b) encodeKey in table order", () => {
+    const t = ColumnTable.fromRows([
+      { r: "a", c: "1", x: 0 },
+      { r: "a", c: "2", x: 1 },
+      { r: "b", c: "1", x: 2 },
+      { r: "a", c: "1", x: 3 },
+      { r: "b", c: "1", x: 4 },
+    ]);
+    const grid = partitionByFields(t, "r", "c");
+    expect(grid.get(encodeKey("a"))?.get(encodeKey("1"))).toEqual([0, 3]);
+    expect(grid.get(encodeKey("a"))?.get(encodeKey("2"))).toEqual([1]);
+    expect(grid.get(encodeKey("b"))?.get(encodeKey("1"))).toEqual([2, 4]);
+    // absent (b, 2) combination — no bucket at all
+    expect(grid.get(encodeKey("b"))?.get(encodeKey("2"))).toBeUndefined();
+  });
+
+  it("keeps number/string keys distinct on both axes", () => {
+    const t = ColumnTable.fromRows([
+      { r: 1, c: "1", x: 0 },
+      { r: "1", c: 1, x: 1 },
+    ]);
+    const grid = partitionByFields(t, "r", "c");
+    expect(grid.get(encodeKey(1))?.get(encodeKey("1"))).toEqual([0]);
+    expect(grid.get(encodeKey("1"))?.get(encodeKey(1))).toEqual([1]);
+    expect(grid.get(encodeKey(1))?.get(encodeKey(1))).toBeUndefined();
+  });
+
+  it("reads each facet column once", () => {
+    const t = ColumnTable.fromRows(
+      Array.from({ length: 40 }, (_, i) => ({ r: `r${i % 5}`, c: `c${i % 8}`, x: i })),
+    );
+    const rReads = countColumnReads("r", () => {
+      partitionByFields(t, "r", "c");
+    });
+    const cReads = countColumnReads("c", () => {
+      partitionByFields(t, "r", "c");
+    });
+    expect(rReads).toBe(1);
+    expect(cReads).toBe(1);
   });
 });
 

--- a/packages/core/tests/pipeline-facets-unit.test.ts
+++ b/packages/core/tests/pipeline-facets-unit.test.ts
@@ -267,4 +267,32 @@ describe("resolveFacet — O(n) partition (issue #183)", () => {
     expect(byLabel["a / 2"]).toEqual([]);
     expect(byLabel["b / 1"]).toEqual([]);
   });
+
+  it("grid rows-only partitions by row field in ascending table order", () => {
+    const t = ColumnTable.fromRows([
+      { r: "b", x: 1 },
+      { r: "a", x: 2 },
+      { r: "b", x: 3 },
+    ]);
+    const layout = resolveFacet({ rows: { field: "r" } }, t);
+    expect(layout.nrow).toBe(2);
+    expect(layout.ncol).toBe(1);
+    expect(layout.panels.map((p) => p.label)).toEqual(["a", "b"]);
+    expect(layout.panels[0]!.sourceRows).toEqual([1]);
+    expect(layout.panels[1]!.sourceRows).toEqual([0, 2]);
+  });
+
+  it("grid cols-only partitions by col field in ascending table order", () => {
+    const t = ColumnTable.fromRows([
+      { c: "2", x: 1 },
+      { c: "1", x: 2 },
+      { c: "2", x: 3 },
+    ]);
+    const layout = resolveFacet({ cols: { field: "c" } }, t);
+    expect(layout.nrow).toBe(1);
+    expect(layout.ncol).toBe(2);
+    expect(layout.panels.map((p) => p.label)).toEqual(["1", "2"]);
+    expect(layout.panels[0]!.sourceRows).toEqual([1]);
+    expect(layout.panels[1]!.sourceRows).toEqual([0, 2]);
+  });
 });

--- a/packages/core/tests/pipeline-facets-unit.test.ts
+++ b/packages/core/tests/pipeline-facets-unit.test.ts
@@ -26,14 +26,18 @@ const table = ColumnTable.fromRows([
 
 /** Count ColumnTable.column(field) calls during fn (restored after). */
 function countColumnReads(field: string, fn: () => void): number {
-  const original = ColumnTable.prototype.column;
   let reads = 0;
+  const desc = Object.getOwnPropertyDescriptor(ColumnTable.prototype, "column");
+  if (desc?.value === undefined) {
+    throw new Error("ColumnTable.prototype.column is not a data property");
+  }
+  const impl = desc.value as (this: ColumnTable, name: string) => readonly unknown[];
   const spy = spyOn(ColumnTable.prototype, "column").mockImplementation(function (
     this: ColumnTable,
     name: string,
   ) {
     if (name === field) reads += 1;
-    return original.call(this, name);
+    return impl.call(this, name);
   });
   try {
     fn();

--- a/packages/core/tests/pipeline-facets-unit.test.ts
+++ b/packages/core/tests/pipeline-facets-unit.test.ts
@@ -2,12 +2,19 @@
  * Characterization tests for the facet partition module.
  * Exercises resolveFacet / SINGLE_PANEL directly so the extraction stays
  * pinned to ggplot2 panel order and free-scale contracts.
+ *
+ * Seams under test (issue #183):
+ * - partitionByField: single O(n) pass → Map<encodeKey, row indices>
+ * - resolveFacet wrap/grid: panel membership + empty-grid parity
+ * - complexity: facet-field column() reads stay O(1) in distinct levels
  */
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, spyOn } from "bun:test";
 
+import { encodeKey } from "../src/scales/state.ts";
 import { PipelineError } from "../src/pipeline.ts";
 import { resolveFacet, SINGLE_PANEL } from "../src/pipeline/facets.ts";
 import { assertFacetForm, facetFreeFlags } from "../src/pipeline/facets-form.ts";
+import { partitionByField } from "../src/pipeline/facets-tokens.ts";
 import { ColumnTable } from "../src/table.ts";
 
 const table = ColumnTable.fromRows([
@@ -16,6 +23,25 @@ const table = ColumnTable.fromRows([
   { g: "c", r: "x", c: "1", x: 3 },
   { g: "a", r: "x", c: "2", x: 4 },
 ]);
+
+/** Count ColumnTable.column(field) calls during fn (restored after). */
+function countColumnReads(field: string, fn: () => void): number {
+  const original = ColumnTable.prototype.column;
+  let reads = 0;
+  const spy = spyOn(ColumnTable.prototype, "column").mockImplementation(function (
+    this: ColumnTable,
+    name: string,
+  ) {
+    if (name === field) reads += 1;
+    return original.call(this, name);
+  });
+  try {
+    fn();
+    return reads;
+  } finally {
+    spy.mockRestore();
+  }
+}
 
 describe("SINGLE_PANEL", () => {
   it("returns one unfaceted panel with identity sourceRows", () => {
@@ -144,5 +170,97 @@ describe("facetFreeFlags / assertFacetForm", () => {
       expect(e).toBeInstanceOf(PipelineError);
       expect((e as PipelineError).code).toBe("facet-form-ambiguous");
     }
+  });
+});
+
+describe("partitionByField — single-pass buckets", () => {
+  it("groups row indices by encodeKey in table order", () => {
+    const t = ColumnTable.fromRows([
+      { g: "b", x: 0 },
+      { g: "a", x: 1 },
+      { g: "b", x: 2 },
+      { g: "a", x: 3 },
+      { g: null, x: 4 },
+      { g: 1, x: 5 },
+      { g: "1", x: 6 },
+    ]);
+    const buckets = partitionByField(t, "g");
+    expect(buckets.get(encodeKey("b"))).toEqual([0, 2]);
+    expect(buckets.get(encodeKey("a"))).toEqual([1, 3]);
+    expect(buckets.get(encodeKey(null))).toEqual([4]);
+    // number 1 and string "1" stay distinct panels
+    expect(buckets.get(encodeKey(1))).toEqual([5]);
+    expect(buckets.get(encodeKey("1"))).toEqual([6]);
+    expect(buckets.size).toBe(5);
+  });
+
+  it("reads the facet column once", () => {
+    const t = ColumnTable.fromRows(
+      Array.from({ length: 40 }, (_, i) => ({ g: `v${i % 10}`, x: i })),
+    );
+    const reads = countColumnReads("g", () => {
+      partitionByField(t, "g");
+    });
+    expect(reads).toBe(1);
+  });
+});
+
+describe("resolveFacet — O(n) partition (issue #183)", () => {
+  it("wrap: column reads stay bounded as distinct levels grow", () => {
+    const levels = 40;
+    const rows = Array.from({ length: levels * 5 }, (_, i) => ({
+      g: `g${i % levels}`,
+      x: i,
+    }));
+    const t = ColumnTable.fromRows(rows);
+    const reads = countColumnReads("g", () => {
+      resolveFacet({ wrap: { field: "g" } }, t);
+    });
+    // facetValues + partitionByField (+ optional fieldType via column) — not per level
+    expect(reads).toBeLessThanOrEqual(4);
+    expect(reads).toBeLessThan(levels);
+  });
+
+  it("grid: row/col column reads stay bounded as the cartesian grid grows", () => {
+    const R = 12;
+    const C = 12;
+    const rows = Array.from({ length: R * C }, (_, i) => ({
+      r: `r${i % R}`,
+      c: `c${Math.floor(i / R) % C}`,
+      x: i,
+    }));
+    const t = ColumnTable.fromRows(rows);
+    const rowReads = countColumnReads("r", () => {
+      resolveFacet({ rows: { field: "r" }, cols: { field: "c" } }, t);
+    });
+    const colReads = countColumnReads("c", () => {
+      resolveFacet({ rows: { field: "r" }, cols: { field: "c" } }, t);
+    });
+    // Not one scan per row-level / col-level / cell
+    expect(rowReads).toBeLessThanOrEqual(4);
+    expect(colReads).toBeLessThanOrEqual(4);
+    expect(rowReads).toBeLessThan(R);
+    expect(colReads).toBeLessThan(C);
+  });
+
+  it("wrap still assigns every source row to exactly one panel", () => {
+    const layout = resolveFacet({ wrap: { field: "g" } }, table);
+    const assigned = layout.panels.flatMap((p) => p.sourceRows ?? []);
+    expect(assigned.toSorted((a, b) => a - b)).toEqual([0, 1, 2, 3]);
+  });
+
+  it("grid still intersects row/col buckets and keeps empty combos", () => {
+    const sparse = ColumnTable.fromRows([
+      { r: "a", c: "1", x: 1 },
+      { r: "a", c: "1", x: 2 },
+      { r: "b", c: "2", x: 3 },
+    ]);
+    const layout = resolveFacet({ rows: { field: "r" }, cols: { field: "c" } }, sparse);
+    expect(layout.panels).toHaveLength(4);
+    const byLabel = Object.fromEntries(layout.panels.map((p) => [p.label, p.sourceRows]));
+    expect(byLabel["a / 1"]).toEqual([0, 1]);
+    expect(byLabel["b / 2"]).toEqual([2]);
+    expect(byLabel["a / 2"]).toEqual([]);
+    expect(byLabel["b / 1"]).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

Fixes #183: facet wrap/grid no longer re-scan the full table once per panel (or twice per grid cell).

- Add `partitionByField` — single O(n) pass grouping row indices by `encodeKey`
- **facet_wrap:** partition once, then assemble panels from buckets → **O(n + v)**
- **facet_grid:** pre-partition rows/cols fields, intersect sorted buckets per cell → **O(n + R·C intersection)** instead of **O(R · C · n)**
- Empty grid combinations and encodeKey parity (`"1"` vs `1`, null last, etc.) preserved

## Test plan (TDD)

- [x] RED → GREEN on `partitionByField` unit tests (bucket membership, single column read)
- [x] Complexity guards: wrap/grid `column()` reads stay O(1) in distinct levels
- [x] Membership parity: every wrap row assigned once; grid empty combos kept
- [x] Existing facet unit + R parity suites green
- [x] Pre-push: typecheck, type-aware lint, knip, full bun test suite

## Complexity

| Layout | Before | After |
|--------|--------|-------|
| `facet_wrap` | O(v · n) | O(n + v) |
| `facet_grid` | O(R · C · n) | O(n + R · C · intersection) |