### PR TITLE
perf(core): O(1) aggregate candidate lineage via group×x/bin indexes

### DIFF
--- a/packages/core/src/pipeline/build-candidates-datum-lineage-ann.ts
+++ b/packages/core/src/pipeline/build-candidates-datum-lineage-ann.ts
@@ -21,7 +21,15 @@ export function resolveIdentityLineageAndAnnotation(
   annotationX: CellValue;
   annotationY: CellValue;
 } {
-  const { sourceRow, frame, outlierSourceRow, frameRow, sourceRowsByGroup } = located;
+  const {
+    sourceRow,
+    frame,
+    outlierSourceRow,
+    frameRow,
+    sourceRowsByGroup,
+    sourceRowsByGroupX,
+    sourceRowsByGroupBin,
+  } = located;
   const { annotationRule, annotationX, annotationY } = resolveAnnotationIntercepts({
     frame,
     primitiveIndex: facts.primitiveIndex,
@@ -33,6 +41,8 @@ export function resolveIdentityLineageAndAnnotation(
     panelIndex: facts.panelIndex,
     layerIndex: facts.layerIndex,
     sourceRowsByGroup,
+    sourceRowsByGroupX,
+    sourceRowsByGroupBin,
     frame,
     table: ctx.table,
     frameRow,

--- a/packages/core/src/pipeline/build-candidates-datum-locate-types.ts
+++ b/packages/core/src/pipeline/build-candidates-datum-locate-types.ts
@@ -18,4 +18,6 @@ export interface LocatedIdentityCandidate {
   fillField: string | undefined;
   seriesByRow: Map<string, number>;
   sourceRowsByGroup: Map<string, number[]>;
+  sourceRowsByGroupX: Map<string, number[]>;
+  sourceRowsByGroupBin: Map<string, number[]>;
 }

--- a/packages/core/src/pipeline/build-candidates-datum-locate.ts
+++ b/packages/core/src/pipeline/build-candidates-datum-locate.ts
@@ -18,7 +18,8 @@ export function locateIdentityCandidate(
   ctx: IdentityCandidateResolveContext,
   facts: CandidateBuildFacts,
 ): LocatedIdentityCandidate {
-  const { seriesByRow, sourceRowsByGroup, frameGroups } = ctx.getIdentityIndex();
+  const { seriesByRow, sourceRowsByGroup, sourceRowsByGroupX, sourceRowsByGroupBin, frameGroups } =
+    ctx.getIdentityIndex();
   const fields = ctx.layerFields[facts.layerIndex] ?? [];
   const sourceRow = facts.rowIndex;
   const frame = ctx.panelFrames[facts.panelIndex]?.[facts.layerIndex];
@@ -52,5 +53,7 @@ export function locateIdentityCandidate(
     fillField,
     seriesByRow,
     sourceRowsByGroup,
+    sourceRowsByGroupX,
+    sourceRowsByGroupBin,
   };
 }

--- a/packages/core/src/pipeline/build-candidates-datum-represented.ts
+++ b/packages/core/src/pipeline/build-candidates-datum-represented.ts
@@ -14,6 +14,8 @@ export function resolveRepresentedSourceRows(input: {
   panelIndex: number;
   layerIndex: number;
   sourceRowsByGroup: Map<string, number[]>;
+  sourceRowsByGroupX?: Map<string, number[]>;
+  sourceRowsByGroupBin?: Map<string, number[]>;
   frame: LayerFrame | undefined;
   table: ColumnTable;
   frameRow: number;
@@ -27,6 +29,8 @@ export function resolveRepresentedSourceRows(input: {
     panelIndex,
     layerIndex,
     sourceRowsByGroup,
+    sourceRowsByGroupX,
+    sourceRowsByGroupBin,
     frame,
     table,
     frameRow,
@@ -34,17 +38,25 @@ export function resolveRepresentedSourceRows(input: {
     primitiveIndex,
   } = input;
 
+  // Outliers already pin an exact source row — do not re-expand via aggregate
+  // group×x / bin indexes (those buckets contain every row the box represents).
   let representedRows =
     outlierSourceRow === null
       ? (sourceRowsByGroup.get(`${panelIndex}:${layerIndex}:${group}`) ?? [])
       : [outlierSourceRow];
-  if (sourceRow === null && frame !== undefined) {
-    representedRows = filterRepresentedSourceRows({
+  if (sourceRow === null && outlierSourceRow === null && frame !== undefined) {
+    const filterInput: Parameters<typeof filterRepresentedSourceRows>[0] = {
       frame,
       table,
       frameRow,
       baseRows: representedRows,
-    });
+      group,
+      panelIndex,
+      layerIndex,
+    };
+    if (sourceRowsByGroupX) filterInput.sourceRowsByGroupX = sourceRowsByGroupX;
+    if (sourceRowsByGroupBin) filterInput.sourceRowsByGroupBin = sourceRowsByGroupBin;
+    representedRows = filterRepresentedSourceRows(filterInput);
   }
   return {
     representedRows,

--- a/packages/core/src/pipeline/build-candidates-identity-aggregate.ts
+++ b/packages/core/src/pipeline/build-candidates-identity-aggregate.ts
@@ -1,0 +1,59 @@
+/**
+ * Pre-bucket aggregate source-row lineage for identity-indexed candidates.
+ * Built once with the identity index so mark resolve is O(1) lookup instead of
+ * re-filtering the full group for every count/summary/boxplot/bin output mark.
+ */
+import { filterBinRepresentedRows } from "./build-candidates-lineage-filters.js";
+import type { FacetPanelDef } from "./facets.js";
+import { deriveLayerGroups } from "./frame.js";
+import type { LayerFrame } from "./types.js";
+
+export function appendSourceRowByGroupX(input: {
+  sourceRowsByGroupX: Map<string, number[]>;
+  panelIndex: number;
+  layerIndex: number;
+  group: number;
+  xKey: string;
+  sourceRow: number;
+}): void {
+  const key = `${input.panelIndex}:${input.layerIndex}:${input.group}:${input.xKey}`;
+  const members = input.sourceRowsByGroupX.get(key);
+  if (members === undefined) input.sourceRowsByGroupX.set(key, [input.sourceRow]);
+  else members.push(input.sourceRow);
+}
+
+export function buildBinLineageBuckets(input: {
+  frame: LayerFrame;
+  panelIndex: number;
+  layerIndex: number;
+  facetPanel: FacetPanelDef;
+  sourceRowsByGroupBin: Map<string, number[]>;
+}): void {
+  const { frame, panelIndex, layerIndex, facetPanel, sourceRowsByGroupBin } = input;
+  const field = frame.binding.xField;
+  if (field === null) return;
+
+  // Collect panel-local rows per group, then map matched locals → source rows.
+  const inputGroups = deriveLayerGroups(frame.binding, frame.table);
+  const localRowsByGroup = new Map<number, number[]>();
+  for (let localRow = 0; localRow < inputGroups.length; localRow++) {
+    const group = inputGroups[localRow]!;
+    const members = localRowsByGroup.get(group);
+    if (members === undefined) localRowsByGroup.set(group, [localRow]);
+    else members.push(localRow);
+  }
+
+  for (let frameRow = 0; frameRow < frame.n; frameRow++) {
+    const group = frame.groups[frameRow] ?? 0;
+    const localBase = localRowsByGroup.get(group) ?? [];
+    const matchedLocal = filterBinRepresentedRows({
+      frame,
+      table: frame.table,
+      frameRow,
+      field,
+      baseRows: localBase,
+    });
+    const matchedSource = matchedLocal.map((local) => facetPanel.sourceRows?.[local] ?? local);
+    sourceRowsByGroupBin.set(`${panelIndex}:${layerIndex}:${group}:${frameRow}`, matchedSource);
+  }
+}

--- a/packages/core/src/pipeline/build-candidates-identity-aggregate.ts
+++ b/packages/core/src/pipeline/build-candidates-identity-aggregate.ts
@@ -3,7 +3,10 @@
  * Built once with the identity index so mark resolve is O(1) lookup instead of
  * re-filtering the full group for every count/summary/boxplot/bin output mark.
  */
-import { filterBinRepresentedRows } from "./build-candidates-lineage-filters.js";
+import type { BarParams } from "@ggsvelte/spec";
+
+import { cellToNumber } from "../table.js";
+
 import type { FacetPanelDef } from "./facets.js";
 import { deriveLayerGroups } from "./frame.js";
 import type { LayerFrame } from "./types.js";
@@ -22,6 +25,20 @@ export function appendSourceRowByGroupX(input: {
   else members.push(input.sourceRow);
 }
 
+interface BinEdge {
+  frameRow: number;
+  lo: number;
+  hi: number;
+  first: boolean;
+  last: boolean;
+  bucket: number[];
+}
+
+/**
+ * Assign each source row to at most one bin in a single pass over the panel
+ * rows (O(n log k) per group via binary search on ordered bin edges), instead
+ * of re-scanning the full group once per output bin (O(k·g)).
+ */
 export function buildBinLineageBuckets(input: {
   frame: LayerFrame;
   panelIndex: number;
@@ -33,27 +50,88 @@ export function buildBinLineageBuckets(input: {
   const field = frame.binding.xField;
   if (field === null) return;
 
-  // Collect panel-local rows per group, then map matched locals → source rows.
   const inputGroups = deriveLayerGroups(frame.binding, frame.table);
-  const localRowsByGroup = new Map<number, number[]>();
-  for (let localRow = 0; localRow < inputGroups.length; localRow++) {
-    const group = inputGroups[localRow]!;
-    const members = localRowsByGroup.get(group);
-    if (members === undefined) localRowsByGroup.set(group, [localRow]);
-    else members.push(localRow);
-  }
+  const closed = ((frame.binding.layer.params ?? {}) as BarParams).closed ?? "right";
+  const binsByGroup = new Map<number, BinEdge[]>();
 
   for (let frameRow = 0; frameRow < frame.n; frameRow++) {
     const group = frame.groups[frameRow] ?? 0;
-    const localBase = localRowsByGroup.get(group) ?? [];
-    const matchedLocal = filterBinRepresentedRows({
-      frame,
-      table: frame.table,
+    const bucket: number[] = [];
+    sourceRowsByGroupBin.set(`${panelIndex}:${layerIndex}:${group}:${frameRow}`, bucket);
+    if (frame.xmin === null || frame.xmax === null) continue;
+    const first = frameRow === 0 || frame.groups[frameRow - 1] !== group;
+    const last = frameRow === frame.n - 1 || frame.groups[frameRow + 1] !== group;
+    const edge: BinEdge = {
       frameRow,
-      field,
-      baseRows: localBase,
-    });
-    const matchedSource = matchedLocal.map((local) => facetPanel.sourceRows?.[local] ?? local);
-    sourceRowsByGroupBin.set(`${panelIndex}:${layerIndex}:${group}:${frameRow}`, matchedSource);
+      lo: frame.xmin[frameRow]!,
+      hi: frame.xmax[frameRow]!,
+      first,
+      last,
+      bucket,
+    };
+    const list = binsByGroup.get(group);
+    if (list === undefined) binsByGroup.set(group, [edge]);
+    else list.push(edge);
   }
+
+  // No bin edges: every output mark represents the full group (filter fallback).
+  if (frame.xmin === null || frame.xmax === null) {
+    for (let localRow = 0; localRow < inputGroups.length; localRow++) {
+      const group = inputGroups[localRow]!;
+      const sourceRow = facetPanel.sourceRows?.[localRow] ?? localRow;
+      for (let frameRow = 0; frameRow < frame.n; frameRow++) {
+        if ((frame.groups[frameRow] ?? 0) !== group) continue;
+        sourceRowsByGroupBin
+          .get(`${panelIndex}:${layerIndex}:${group}:${frameRow}`)
+          ?.push(sourceRow);
+      }
+    }
+    return;
+  }
+
+  for (const bins of binsByGroup.values()) {
+    bins.sort((a, b) => a.lo - b.lo || a.hi - b.hi);
+  }
+
+  const xColumn = frame.table.column(field);
+  for (let localRow = 0; localRow < inputGroups.length; localRow++) {
+    const group = inputGroups[localRow]!;
+    const bins = binsByGroup.get(group);
+    if (bins === undefined || bins.length === 0) continue;
+    const value = cellToNumber(xColumn[localRow]!);
+    if (!Number.isFinite(value)) continue;
+    const idx = findBinIndex(value, bins, closed);
+    if (idx < 0) continue;
+    const sourceRow = facetPanel.sourceRows?.[localRow] ?? localRow;
+    bins[idx]!.bucket.push(sourceRow);
+  }
+}
+
+function findBinIndex(value: number, bins: readonly BinEdge[], closed: "right" | "left"): number {
+  if (closed === "right") {
+    // First bin with hi >= value, then verify left edge (lo, hi] / first [lo, hi].
+    let lo = 0;
+    let hi = bins.length;
+    while (lo < hi) {
+      const mid = (lo + hi) >> 1;
+      if (bins[mid]!.hi < value) lo = mid + 1;
+      else hi = mid;
+    }
+    if (lo >= bins.length) return -1;
+    const bin = bins[lo]!;
+    return value <= bin.hi && (value > bin.lo || (bin.first && value >= bin.lo)) ? lo : -1;
+  }
+
+  // Last bin with lo <= value, then verify right edge [lo, hi) / last [lo, hi].
+  let lo = 0;
+  let hi = bins.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if (bins[mid]!.lo <= value) lo = mid + 1;
+    else hi = mid;
+  }
+  const idx = lo - 1;
+  if (idx < 0) return -1;
+  const bin = bins[idx]!;
+  return value >= bin.lo && (value < bin.hi || (bin.last && value <= bin.hi)) ? idx : -1;
 }

--- a/packages/core/src/pipeline/build-candidates-identity.ts
+++ b/packages/core/src/pipeline/build-candidates-identity.ts
@@ -77,5 +77,9 @@ export function buildCandidateIdentityIndex(
       }
     }
   }
+  // Seal bucket arrays so resolve-time consumers cannot mutate shared lineage.
+  for (const map of [sourceRowsByGroup, sourceRowsByGroupX, sourceRowsByGroupBin]) {
+    for (const [key, rows] of map) map.set(key, Object.freeze(rows) as number[]);
+  }
   return { seriesByRow, sourceRowsByGroup, sourceRowsByGroupX, sourceRowsByGroupBin, frameGroups };
 }

--- a/packages/core/src/pipeline/build-candidates-identity.ts
+++ b/packages/core/src/pipeline/build-candidates-identity.ts
@@ -1,7 +1,14 @@
 /**
  * Lazy identity index for candidate datums that are not source-row backed
- * (stats, annotations): series by source row, group memberships, ordered groups.
+ * (stats, annotations): series by source row, group memberships, ordered groups,
+ * and pre-bucketed aggregate lineage for O(1) represented-row resolve.
  */
+import { bandKey } from "../scales/train.js";
+
+import {
+  appendSourceRowByGroupX,
+  buildBinLineageBuckets,
+} from "./build-candidates-identity-aggregate.js";
 import type { FacetPanelDef } from "./facets.js";
 import { deriveLayerGroups } from "./frame.js";
 import type { LayerFrame } from "./types.js";
@@ -10,6 +17,10 @@ import { NO_ROW } from "./types.js";
 export interface CandidateIdentityIndex {
   readonly seriesByRow: Map<string, number>;
   readonly sourceRowsByGroup: Map<string, number[]>;
+  /** `${panel}:${layer}:${group}:${bandKey(x)}` → source rows (count/summary/boxplot). */
+  readonly sourceRowsByGroupX: Map<string, number[]>;
+  /** `${panel}:${layer}:${group}:${frameRow}` → source rows (bin/histogram). */
+  readonly sourceRowsByGroupBin: Map<string, number[]>;
   readonly frameGroups: Map<string, number[]>;
 }
 
@@ -19,12 +30,17 @@ export function buildCandidateIdentityIndex(
 ): CandidateIdentityIndex {
   const seriesByRow = new Map<string, number>();
   const sourceRowsByGroup = new Map<string, number[]>();
+  const sourceRowsByGroupX = new Map<string, number[]>();
+  const sourceRowsByGroupBin = new Map<string, number[]>();
   const frameGroups = new Map<string, number[]>();
   for (let panelIndex = 0; panelIndex < panelFrames.length; panelIndex++) {
     for (const frame of panelFrames[panelIndex] ?? []) {
-      const frameKey = `${panelIndex}:${frame.binding.index}`;
+      const layerIndex = frame.binding.index;
+      const frameKey = `${panelIndex}:${layerIndex}`;
       frameGroups.set(frameKey, [...new Set(frame.groups)]);
       const inputGroups = deriveLayerGroups(frame.binding, frame.table);
+      const xField = frame.binding.xField;
+      const xColumn = xField === null ? null : frame.table.column(xField);
       for (let localRow = 0; localRow < inputGroups.length; localRow++) {
         const group = inputGroups[localRow]!;
         const sourceRow = facetPanels[panelIndex]!.sourceRows?.[localRow] ?? localRow;
@@ -32,17 +48,34 @@ export function buildCandidateIdentityIndex(
         const members = sourceRowsByGroup.get(key);
         if (members === undefined) sourceRowsByGroup.set(key, [sourceRow]);
         else members.push(sourceRow);
+        if (xColumn !== null) {
+          appendSourceRowByGroupX({
+            sourceRowsByGroupX,
+            panelIndex,
+            layerIndex,
+            group,
+            xKey: bandKey(xColumn[localRow]),
+            sourceRow,
+          });
+        }
+      }
+      const stat = frame.binding.layer.stat ?? "identity";
+      if (stat === "bin") {
+        buildBinLineageBuckets({
+          frame,
+          panelIndex,
+          layerIndex,
+          facetPanel: facetPanels[panelIndex]!,
+          sourceRowsByGroupBin,
+        });
       }
       for (let i = 0; i < frame.rowIndex.length; i++) {
         const sourceRow = frame.rowIndex[i]!;
         if (sourceRow !== NO_ROW) {
-          seriesByRow.set(
-            `${panelIndex}:${frame.binding.index}:${sourceRow}`,
-            frame.groups[i] ?? 0,
-          );
+          seriesByRow.set(`${panelIndex}:${layerIndex}:${sourceRow}`, frame.groups[i] ?? 0);
         }
       }
     }
   }
-  return { seriesByRow, sourceRowsByGroup, frameGroups };
+  return { seriesByRow, sourceRowsByGroup, sourceRowsByGroupX, sourceRowsByGroupBin, frameGroups };
 }

--- a/packages/core/src/pipeline/build-candidates-identity.ts
+++ b/packages/core/src/pipeline/build-candidates-identity.ts
@@ -39,8 +39,11 @@ export function buildCandidateIdentityIndex(
       const frameKey = `${panelIndex}:${layerIndex}`;
       frameGroups.set(frameKey, [...new Set(frame.groups)]);
       const inputGroups = deriveLayerGroups(frame.binding, frame.table);
+      const stat = frame.binding.layer.stat ?? "identity";
+      // Only count/summary/boxplot resolve via group×x buckets; skip for other layers.
+      const bucketByX = stat === "count" || stat === "summary" || stat === "boxplot";
       const xField = frame.binding.xField;
-      const xColumn = xField === null ? null : frame.table.column(xField);
+      const xColumn = bucketByX && xField !== null ? frame.table.column(xField) : null;
       for (let localRow = 0; localRow < inputGroups.length; localRow++) {
         const group = inputGroups[localRow]!;
         const sourceRow = facetPanels[panelIndex]!.sourceRows?.[localRow] ?? localRow;
@@ -59,7 +62,6 @@ export function buildCandidateIdentityIndex(
           });
         }
       }
-      const stat = frame.binding.layer.stat ?? "identity";
       if (stat === "bin") {
         buildBinLineageBuckets({
           frame,

--- a/packages/core/src/pipeline/build-candidates-lineage.ts
+++ b/packages/core/src/pipeline/build-candidates-lineage.ts
@@ -42,34 +42,28 @@ export function filterRepresentedSourceRows(input: {
     outputX !== null &&
     (stat === "count" || stat === "summary" || stat === "boxplot")
   ) {
-    const indexed =
-      indexKeyPrefix !== null && input.sourceRowsByGroupX !== undefined
+    representedRows =
+      (indexKeyPrefix !== null && input.sourceRowsByGroupX !== undefined
         ? input.sourceRowsByGroupX.get(`${indexKeyPrefix}:${bandKey(outputX)}`)
-        : undefined;
-    representedRows =
-      indexed === undefined
-        ? filterAggregateXRows({
-            table,
-            field: aggregateXField,
-            outputX,
-            baseRows: representedRows,
-          })
-        : indexed;
+        : undefined) ??
+      filterAggregateXRows({
+        table,
+        field: aggregateXField,
+        outputX,
+        baseRows: representedRows,
+      });
   } else if (stat === "bin" && aggregateXField !== null) {
-    const indexed =
-      indexKeyPrefix !== null && input.sourceRowsByGroupBin !== undefined
-        ? input.sourceRowsByGroupBin.get(`${indexKeyPrefix}:${frameRow}`)
-        : undefined;
     representedRows =
-      indexed === undefined
-        ? filterBinRepresentedRows({
-            frame,
-            table,
-            frameRow,
-            field: aggregateXField,
-            baseRows: representedRows,
-          })
-        : indexed;
+      (indexKeyPrefix !== null && input.sourceRowsByGroupBin !== undefined
+        ? input.sourceRowsByGroupBin.get(`${indexKeyPrefix}:${frameRow}`)
+        : undefined) ??
+      filterBinRepresentedRows({
+        frame,
+        table,
+        frameRow,
+        field: aggregateXField,
+        baseRows: representedRows,
+      });
   }
 
   const aggregateYField = frame.binding.yField;

--- a/packages/core/src/pipeline/build-candidates-lineage.ts
+++ b/packages/core/src/pipeline/build-candidates-lineage.ts
@@ -1,6 +1,8 @@
 /**
  * Reconstruct represented source rows for aggregate (stat-synthesized) marks.
+ * Prefers O(1) pre-bucketed indexes when available; falls back to pure filters.
  */
+import { bandKey } from "../scales/train.js";
 import { ColumnTable } from "../table.js";
 
 import {
@@ -15,32 +17,59 @@ export function filterRepresentedSourceRows(input: {
   table: ColumnTable;
   frameRow: number;
   baseRows: readonly number[];
+  /** Series group of the mark (needed for index keys). */
+  group?: number;
+  panelIndex?: number;
+  layerIndex?: number;
+  sourceRowsByGroupX?: Map<string, number[]>;
+  sourceRowsByGroupBin?: Map<string, number[]>;
 }): number[] {
   const { frame, table, frameRow } = input;
   let representedRows = [...input.baseRows];
   const stat = frame.binding.layer.stat ?? "identity";
   const aggregateXField = frame.binding.xField;
   const outputX = frame.xValues?.[frameRow] ?? frame.xNumeric?.[frameRow] ?? null;
+  const group = input.group ?? frame.groups[frameRow] ?? 0;
+  const panelIndex = input.panelIndex;
+  const layerIndex = input.layerIndex;
+  const indexKeyPrefix =
+    panelIndex !== undefined && layerIndex !== undefined
+      ? `${panelIndex}:${layerIndex}:${group}`
+      : null;
 
   if (
     aggregateXField !== null &&
     outputX !== null &&
     (stat === "count" || stat === "summary" || stat === "boxplot")
   ) {
-    representedRows = filterAggregateXRows({
-      table,
-      field: aggregateXField,
-      outputX,
-      baseRows: representedRows,
-    });
+    const indexed =
+      indexKeyPrefix !== null && input.sourceRowsByGroupX !== undefined
+        ? input.sourceRowsByGroupX.get(`${indexKeyPrefix}:${bandKey(outputX)}`)
+        : undefined;
+    representedRows =
+      indexed === undefined
+        ? filterAggregateXRows({
+            table,
+            field: aggregateXField,
+            outputX,
+            baseRows: representedRows,
+          })
+        : indexed;
   } else if (stat === "bin" && aggregateXField !== null) {
-    representedRows = filterBinRepresentedRows({
-      frame,
-      table,
-      frameRow,
-      field: aggregateXField,
-      baseRows: representedRows,
-    });
+    const indexed =
+      indexKeyPrefix !== null && input.sourceRowsByGroupBin !== undefined
+        ? input.sourceRowsByGroupBin.get(`${indexKeyPrefix}:${frameRow}`)
+        : undefined;
+    representedRows =
+      indexed === undefined
+        ? filterBinRepresentedRows({
+            frame,
+            table,
+            frameRow,
+            field: aggregateXField,
+            baseRows: representedRows,
+          })
+        : indexed;
   }
 
   const aggregateYField = frame.binding.yField;

--- a/packages/core/tests/pipeline-build-candidates.test.ts
+++ b/packages/core/tests/pipeline-build-candidates.test.ts
@@ -315,3 +315,145 @@ describe("lineage represented-row filters", () => {
     ).toEqual([0, 1]);
   });
 });
+
+describe("aggregate lineage index (issue #184)", () => {
+  it("pre-buckets group source rows by x band key for O(1) mark resolve", async () => {
+    const { preparePanels } = await import("../src/pipeline/prepare-panels.ts");
+    const { buildCandidateIdentityIndex } =
+      await import("../src/pipeline/build-candidates-identity.ts");
+    const { bandKey } = await import("../src/scales/train.ts");
+    const { normalize } = await import("@ggsvelte/spec");
+
+    // Continuous (numeric) x does not participate in grouping, so count expands
+    // many x levels inside one group — the O(k·g) case the index must fix.
+    const prepared = preparePanels(
+      normalize(
+        gg([{ x: 1 }, { x: 2 }, { x: 1 }, { x: 3 }], aes({ x: "x" }))
+          .geomBar()
+          .spec(),
+      ),
+      size,
+      [],
+      [],
+    );
+    const index = buildCandidateIdentityIndex(prepared.panelFrames, prepared.facetPanels);
+
+    const groupKey = "0:0:0";
+    expect(index.sourceRowsByGroup.get(groupKey)?.toSorted((a, b) => a - b)).toEqual([0, 1, 2, 3]);
+    expect(index.sourceRowsByGroupX.get(`${groupKey}:${bandKey(1)}`)).toEqual([0, 2]);
+    expect(index.sourceRowsByGroupX.get(`${groupKey}:${bandKey(2)}`)).toEqual([1]);
+    expect(index.sourceRowsByGroupX.get(`${groupKey}:${bandKey(3)}`)).toEqual([3]);
+  });
+
+  it("pre-buckets bin memberships per frame row so resolve does not re-scan", async () => {
+    const { preparePanels } = await import("../src/pipeline/prepare-panels.ts");
+    const { buildCandidateIdentityIndex } =
+      await import("../src/pipeline/build-candidates-identity.ts");
+    const { normalize } = await import("@ggsvelte/spec");
+
+    const prepared = preparePanels(
+      normalize({
+        data: { values: [{ x: 0 }, { x: 0.2 }, { x: 1.2 }] },
+        layers: [
+          {
+            geom: "histogram",
+            aes: { x: { field: "x" } },
+            params: { binwidth: 1, boundary: 0, closed: "right" },
+          },
+        ],
+      }),
+      size,
+      [],
+      [],
+    );
+    const index = buildCandidateIdentityIndex(prepared.panelFrames, prepared.facetPanels);
+    const frame = prepared.panelFrames[0]![0]!;
+    expect(frame.n).toBeGreaterThanOrEqual(2);
+
+    // closed=right: [0,1] owns rows 0,1; (1,2] owns row 2.
+    expect(index.sourceRowsByGroupBin.get("0:0:0:0")).toEqual([0, 1]);
+    expect(index.sourceRowsByGroupBin.get("0:0:0:1")).toEqual([2]);
+  });
+
+  it("keeps boxplot outlier lineage as the single source row (not the full box)", () => {
+    const model = runPipeline(
+      {
+        data: {
+          values: [
+            { group: "a", y: 1 },
+            { group: "a", y: 2 },
+            { group: "a", y: 3 },
+            { group: "a", y: 100 },
+          ],
+        },
+        layers: [
+          {
+            geom: "boxplot",
+            stat: "boxplot",
+            aes: { x: { field: "group" }, y: { field: "y" } },
+          },
+        ],
+      },
+      size,
+    );
+    const candidates = Array.from({ length: model.candidates.size }, (_, id) =>
+      model.candidates.candidate(id),
+    );
+    const outlier = candidates.find((candidate) => candidate?.kind === "points");
+    expect(outlier).toBeDefined();
+    expect([...model.lineage.keys(outlier!.lineage)].toSorted((a, b) => a - b)).toEqual([3]);
+  });
+
+  it("resolveRepresentedSourceRows uses index lookups and matches filter parity", async () => {
+    const { preparePanels } = await import("../src/pipeline/prepare-panels.ts");
+    const { buildCandidateIdentityIndex } =
+      await import("../src/pipeline/build-candidates-identity.ts");
+    const { resolveRepresentedSourceRows } =
+      await import("../src/pipeline/build-candidates-datum-represented.ts");
+    const { filterRepresentedSourceRows } =
+      await import("../src/pipeline/build-candidates-lineage.ts");
+    const { LineageStore } = await import("../src/identity.ts");
+    const { normalize } = await import("@ggsvelte/spec");
+
+    const prepared = preparePanels(
+      normalize(
+        gg([{ x: 1 }, { x: 2 }, { x: 1 }, { x: 3 }], aes({ x: "x" }))
+          .geomBar()
+          .spec(),
+      ),
+      size,
+      [],
+      [],
+    );
+    const index = buildCandidateIdentityIndex(prepared.panelFrames, prepared.facetPanels);
+    const frame = prepared.panelFrames[0]![0]!;
+    const lineage = new LineageStore<number>();
+
+    for (let frameRow = 0; frameRow < frame.n; frameRow++) {
+      const group = frame.groups[frameRow] ?? 0;
+      const viaIndex = resolveRepresentedSourceRows({
+        outlierSourceRow: null,
+        sourceRow: null,
+        group,
+        panelIndex: 0,
+        layerIndex: 0,
+        sourceRowsByGroup: index.sourceRowsByGroup,
+        sourceRowsByGroupX: index.sourceRowsByGroupX,
+        sourceRowsByGroupBin: index.sourceRowsByGroupBin,
+        frame,
+        table: prepared.table,
+        frameRow,
+        lineage,
+        primitiveIndex: frameRow,
+      });
+      const baseRows = index.sourceRowsByGroup.get(`0:0:${group}`) ?? [];
+      const viaFilter = filterRepresentedSourceRows({
+        frame,
+        table: prepared.table,
+        frameRow,
+        baseRows,
+      });
+      expect(viaIndex.representedRows).toEqual(viaFilter);
+    }
+  });
+});

--- a/packages/core/tests/pipeline-build-candidates.test.ts
+++ b/packages/core/tests/pipeline-build-candidates.test.ts
@@ -349,17 +349,64 @@ describe("aggregate lineage index (issue #184)", () => {
     const { preparePanels } = await import("../src/pipeline/prepare-panels.ts");
     const { buildCandidateIdentityIndex } =
       await import("../src/pipeline/build-candidates-identity.ts");
+    const { filterBinRepresentedRows } =
+      await import("../src/pipeline/build-candidates-lineage-filters.ts");
     const { normalize } = await import("@ggsvelte/spec");
 
+    for (const closed of ["right", "left"] as const) {
+      const prepared = preparePanels(
+        normalize({
+          data: { values: [{ x: 0 }, { x: 1 }, { x: 2 }] },
+          layers: [
+            {
+              geom: "histogram",
+              aes: { x: { field: "x" } },
+              params: { binwidth: 1, boundary: 0, closed },
+            },
+          ],
+        }),
+        size,
+        [],
+        [],
+      );
+      const index = buildCandidateIdentityIndex(prepared.panelFrames, prepared.facetPanels);
+      const frame = prepared.panelFrames[0]![0]!;
+      expect(frame.n).toBeGreaterThanOrEqual(2);
+
+      // Single-pass assignment must match pure filter membership for every bin.
+      for (let frameRow = 0; frameRow < frame.n; frameRow++) {
+        const group = frame.groups[frameRow] ?? 0;
+        const baseRows = index.sourceRowsByGroup.get(`0:0:${group}`) ?? [];
+        const viaFilter = filterBinRepresentedRows({
+          frame,
+          table: prepared.table,
+          frameRow,
+          field: "x",
+          baseRows,
+        });
+        expect(index.sourceRowsByGroupBin.get(`0:0:${group}:${frameRow}`)).toEqual(viaFilter);
+      }
+    }
+  });
+
+  it("does not build group×x buckets for identity layers that never consume them", async () => {
+    const { preparePanels } = await import("../src/pipeline/prepare-panels.ts");
+    const { buildCandidateIdentityIndex } =
+      await import("../src/pipeline/build-candidates-identity.ts");
+    const { normalize } = await import("@ggsvelte/spec");
+
+    // Mixed layers force identity-indexed path; only count should fill group×x.
     const prepared = preparePanels(
       normalize({
-        data: { values: [{ x: 0 }, { x: 0.2 }, { x: 1.2 }] },
+        data: {
+          values: [
+            { g: "a", y: 1 },
+            { g: "b", y: 2 },
+          ],
+        },
         layers: [
-          {
-            geom: "histogram",
-            aes: { x: { field: "x" } },
-            params: { binwidth: 1, boundary: 0, closed: "right" },
-          },
+          { geom: "point", aes: { x: { field: "g" }, y: { field: "y" } } },
+          { geom: "bar", aes: { x: { field: "g" } }, stat: "count" },
         ],
       }),
       size,
@@ -367,12 +414,12 @@ describe("aggregate lineage index (issue #184)", () => {
       [],
     );
     const index = buildCandidateIdentityIndex(prepared.panelFrames, prepared.facetPanels);
-    const frame = prepared.panelFrames[0]![0]!;
-    expect(frame.n).toBeGreaterThanOrEqual(2);
-
-    // closed=right: [0,1] owns rows 0,1; (1,2] owns row 2.
-    expect(index.sourceRowsByGroupBin.get("0:0:0:0")).toEqual([0, 1]);
-    expect(index.sourceRowsByGroupBin.get("0:0:0:1")).toEqual([2]);
+    // Layer 0 is identity point — no group×x keys with layerIndex 0.
+    for (const key of index.sourceRowsByGroupX.keys()) {
+      expect(key.startsWith("0:0:")).toBe(false);
+    }
+    // Layer 1 is count bar — has group×x keys.
+    expect([...index.sourceRowsByGroupX.keys()].some((key) => key.startsWith("0:1:"))).toBe(true);
   });
 
   it("keeps boxplot outlier lineage as the single source row (not the full box)", () => {


### PR DESCRIPTION
## Summary

- Fixes #184: aggregate candidate lineage no longer re-filters the full source group for every count/summary/boxplot/bin mark (`O(k·g) ≈ O(n²)` → `O(n)` build + `O(1)` lookup).
- Pre-buckets represented source rows into `sourceRowsByGroupX` (`panel:layer:group:xKey`) and `sourceRowsByGroupBin` (`panel:layer:group:frameRow`) when building the identity index.
- Resolve path prefers index lookups with pure-filter fallback; boxplot outliers keep singleton source-row lineage (do not expand to the full box bucket).

## Test plan

- [x] New unit tests for group×x / bin pre-buckets and resolve/filter parity
- [x] Regression: boxplot outlier lineage is the single source row
- [x] `bun test packages/core` (556 pass)
- [x] `bun run check` (tsc clean)
- [x] Pre-push hooks green (type-aware lint, knip, full unit suite)
- [ ] CI green on this PR