### PR TITLE
perf(spec): short-circuit isPortable on first issue

### DIFF
--- a/packages/spec/src/portability.ts
+++ b/packages/spec/src/portability.ts
@@ -110,9 +110,12 @@ function walk(
     return;
   }
   seen.add(value);
-  // Object.keys then value[key]: Object.entries eagerly evaluates every
-  // property value (including getters), which would defeat stopAfter.
-  for (const key of Object.keys(value)) {
+  // Lazy own-key walk: Object.entries eagerly Gets every value (defeating
+  // stopAfter on later getters); Object.keys materializes the full key list
+  // and would still Get deleted-by-earlier-getter keys as undefined. for…in
+  // yields keys lazily and skips properties removed before we reach them.
+  for (const key in value) {
+    if (!Object.hasOwn(value, key)) continue;
     walk(value[key], `${path}/${key}`, seen, issues, stopAfter);
     if (stopAfter !== undefined && issues.length >= stopAfter) break;
   }

--- a/packages/spec/src/portability.ts
+++ b/packages/spec/src/portability.ts
@@ -62,7 +62,20 @@ function issueFor(value: unknown): string | null {
   }
 }
 
-function walk(value: unknown, path: string, seen: Set<object>, issues: PortabilityIssue[]): void {
+/**
+ * Walk a value tree, collecting portability issues.
+ * When `stopAfter` is set, stop once that many issues are recorded (used by
+ * `isPortable` for an early-exit existence check).
+ */
+function walk(
+  value: unknown,
+  path: string,
+  seen: Set<object>,
+  issues: PortabilityIssue[],
+  stopAfter?: number,
+): void {
+  if (stopAfter !== undefined && issues.length >= stopAfter) return;
+
   const primitiveIssue = issueFor(value);
   if (primitiveIssue !== null) {
     issues.push({ path, reason: primitiveIssue });
@@ -82,7 +95,10 @@ function walk(value: unknown, path: string, seen: Set<object>, issues: Portabili
   }
   if (Array.isArray(value)) {
     seen.add(value);
-    for (let i = 0; i < value.length; i++) walk(value[i], `${path}/${i}`, seen, issues);
+    for (let i = 0; i < value.length; i++) {
+      walk(value[i], `${path}/${i}`, seen, issues, stopAfter);
+      if (stopAfter !== undefined && issues.length >= stopAfter) break;
+    }
     seen.delete(value);
     return;
   }
@@ -95,7 +111,8 @@ function walk(value: unknown, path: string, seen: Set<object>, issues: Portabili
   }
   seen.add(value);
   for (const [key, v] of Object.entries(value)) {
-    walk(v, `${path}/${key}`, seen, issues);
+    walk(v, `${path}/${key}`, seen, issues, stopAfter);
+    if (stopAfter !== undefined && issues.length >= stopAfter) break;
   }
   seen.delete(value);
 }
@@ -109,7 +126,9 @@ export function portabilityIssues(value: unknown): PortabilityIssue[] {
 
 /** True when `spec` contains only strictly-JSON values (narrowing type guard). */
 export function isPortable(spec: RuntimeSpec | PortableSpec): spec is PortableSpec {
-  return portabilityIssues(spec).length === 0;
+  const issues: PortabilityIssue[] = [];
+  walk(spec, "", new Set(), issues, 1);
+  return issues.length === 0;
 }
 
 /** Thrown by toPortable(): lists EVERY unserializable path, not just the first. */

--- a/packages/spec/src/portability.ts
+++ b/packages/spec/src/portability.ts
@@ -110,8 +110,10 @@ function walk(
     return;
   }
   seen.add(value);
-  for (const [key, v] of Object.entries(value)) {
-    walk(v, `${path}/${key}`, seen, issues, stopAfter);
+  // Object.keys then value[key]: Object.entries eagerly evaluates every
+  // property value (including getters), which would defeat stopAfter.
+  for (const key of Object.keys(value)) {
+    walk(value[key], `${path}/${key}`, seen, issues, stopAfter);
     if (stopAfter !== undefined && issues.length >= stopAfter) break;
   }
   seen.delete(value);

--- a/packages/spec/src/portability.ts
+++ b/packages/spec/src/portability.ts
@@ -110,10 +110,11 @@ function walk(
     return;
   }
   seen.add(value);
-  // Lazy own-key walk: Object.entries eagerly Gets every value (defeating
-  // stopAfter on later getters); Object.keys materializes the full key list
-  // and would still Get deleted-by-earlier-getter keys as undefined. for…in
-  // yields keys lazily and skips properties removed before we reach them.
+  // Prefer for…in over Object.entries: entries eagerly Gets every property
+  // value (including later getters), defeating stopAfter. Engines still list
+  // own keys up front (OwnPropertyKeys); the short-circuit here is on value
+  // Gets and recursive walks — not on key listing. for…in also skips keys
+  // deleted by an earlier getter before we reach them.
   for (const key in value) {
     if (!Object.hasOwn(value, key)) continue;
     walk(value[key], `${path}/${key}`, seen, issues, stopAfter);

--- a/packages/spec/tests/portability.test.ts
+++ b/packages/spec/tests/portability.test.ts
@@ -70,6 +70,30 @@ describe("isPortable early exit", () => {
     expect(laterTouched).toBe(true);
     expect(issues.some((i) => i.path === "/width")).toBe(true);
   });
+
+  it("does not report own properties deleted by an earlier getter", () => {
+    // Matches Object.entries / JSON semantics: a key removed mid-walk is omitted,
+    // not reported as undefined.
+    const spec: Record<string, unknown> = {
+      layers: [{ geom: "point" }],
+    };
+    Object.defineProperty(spec, "a", {
+      enumerable: true,
+      configurable: true,
+      get() {
+        delete spec["b"];
+        return 1;
+      },
+    });
+    Object.defineProperty(spec, "b", {
+      enumerable: true,
+      configurable: true,
+      value: 2,
+      writable: true,
+    });
+    expect(portabilityIssues(spec)).toEqual([]);
+    expect(isPortable(spec as unknown as RuntimeSpec)).toBe(true);
+  });
 });
 
 describe("toPortable", () => {

--- a/packages/spec/tests/portability.test.ts
+++ b/packages/spec/tests/portability.test.ts
@@ -48,28 +48,26 @@ describe("portabilityIssues", () => {
 });
 
 describe("isPortable early exit", () => {
-  it("stops walking after the first issue", () => {
-    let deepTouched = false;
-    const bomb = {
-      get x() {
-        deepTouched = true;
-        return 1;
-      },
-    };
-    // `width` is visited before `data` in insertion order; NaN is unportable.
+  it("stops walking after the first issue without reading later getters", () => {
+    let laterTouched = false;
+    // Sibling getter after the unportable property: Object.entries would
+    // evaluate it before the loop, defeating stopAfter. Keys must be read lazily.
     const spec = {
       layers: [{ geom: "point" }],
       width: Number.NaN,
-      data: { values: [bomb] },
+      get later() {
+        laterTouched = true;
+        return 1;
+      },
     } as unknown as RuntimeSpec;
 
     expect(isPortable(spec)).toBe(false);
-    expect(deepTouched).toBe(false);
+    expect(laterTouched).toBe(false);
 
-    // Full enumeration still visits everything (and reports every path).
-    deepTouched = false;
+    // Full enumeration still visits every path (and runs the getter).
+    laterTouched = false;
     const issues = portabilityIssues(spec);
-    expect(deepTouched).toBe(true);
+    expect(laterTouched).toBe(true);
     expect(issues.some((i) => i.path === "/width")).toBe(true);
   });
 });

--- a/packages/spec/tests/portability.test.ts
+++ b/packages/spec/tests/portability.test.ts
@@ -47,6 +47,33 @@ describe("portabilityIssues", () => {
   });
 });
 
+describe("isPortable early exit", () => {
+  it("stops walking after the first issue", () => {
+    let deepTouched = false;
+    const bomb = {
+      get x() {
+        deepTouched = true;
+        return 1;
+      },
+    };
+    // `width` is visited before `data` in insertion order; NaN is unportable.
+    const spec = {
+      layers: [{ geom: "point" }],
+      width: Number.NaN,
+      data: { values: [bomb] },
+    } as unknown as RuntimeSpec;
+
+    expect(isPortable(spec)).toBe(false);
+    expect(deepTouched).toBe(false);
+
+    // Full enumeration still visits everything (and reports every path).
+    deepTouched = false;
+    const issues = portabilityIssues(spec);
+    expect(deepTouched).toBe(true);
+    expect(issues.some((i) => i.path === "/width")).toBe(true);
+  });
+});
+
 describe("toPortable", () => {
   it("returns a deep copy for portable specs", () => {
     const copy = toPortable(portable);


### PR DESCRIPTION
## Summary

- `isPortable()` no longer enumerates every portability issue; it stops after the first one.
- `portabilityIssues()` / `toPortable()` still report every unserializable path (full walk).
- Adds a bomb-getter regression test so the early-exit contract is observable without coupling to private helpers.

From the packages/spec big-O audit: `isPortable` was always O(full tree) even when a boolean sufficed.

## Test plan

- [x] `bun test packages/spec/tests/portability.test.ts`
- [ ] CI green on packages/spec