### PR TITLE
perf(core): index drawStratum batches by panel in one O(B) pass

### DIFF
--- a/packages/core/src/dom/canvas.ts
+++ b/packages/core/src/dom/canvas.ts
@@ -482,6 +482,36 @@ export function drawBatch(
 }
 
 /**
+ * Group geometry batches by panel once (issue #185): O(B) instead of
+ * re-filtering the full list per panel (O(P·B)). Within each panel bucket,
+ * order matches the original batch list so paint order is preserved.
+ * When `withIndices` is true, also record each batch's original list index
+ * for focus-mask alignment on the presentation path.
+ *
+ * Exported for unit tests that lock the single-pass complexity contract.
+ */
+export function groupBatchesByPanel(
+  panelCount: number,
+  batches: readonly GeometryBatch[],
+  withIndices: boolean,
+): { byPanel: GeometryBatch[][]; indices: number[][] | null } {
+  const byPanel: GeometryBatch[][] = Array.from({ length: panelCount }, () => []);
+  const indices: number[][] | null = withIndices
+    ? Array.from({ length: panelCount }, () => [])
+    : null;
+  for (let i = 0; i < batches.length; i++) {
+    const batch = batches[i]!;
+    const p = batch.panelIndex;
+    // Out-of-range panelIndex is a pipeline bug; skip rather than throw so a
+    // bad batch cannot take down the whole stratum draw.
+    if (p < 0 || p >= panelCount) continue;
+    byPanel[p]!.push(batch);
+    indices?.[p]!.push(i);
+  }
+  return { byPanel, indices };
+}
+
+/**
  * Draw a canvas stratum's batches, clipped per panel (one canvas per
  * stratum; panels are clipped regions inside it — decision 0006). The ctx
  * must already carry the dpr transform (sizeCanvasForDpr); this clears the
@@ -495,12 +525,14 @@ export function drawStratum(
   presentation?: CanvasFocusPresentation,
 ): void {
   ctx.clearRect(0, 0, scene.width, scene.height);
+  const needIndices = presentation !== undefined;
+  const { byPanel, indices } = groupBatchesByPanel(scene.panels.length, batches, needIndices);
   if (presentation === undefined) {
     // Preserve the original high-volume path completely when focus
     // presentation is not requested.
     for (let p = 0; p < scene.panels.length; p++) {
       const panel = scene.panels[p]!;
-      const panelBatches = batches.filter((batch) => batch.panelIndex === p);
+      const panelBatches = byPanel[p]!;
       if (panelBatches.length === 0) continue;
       drawClippedToPanel(ctx, panel, () => {
         ctx.save();
@@ -513,9 +545,8 @@ export function drawStratum(
   }
   for (let p = 0; p < scene.panels.length; p++) {
     const panel = scene.panels[p]!;
-    const panelBatches = batches
-      .map((batch, index) => ({ batch, index }))
-      .filter(({ batch }) => batch.panelIndex === p);
+    const panelBatches = byPanel[p]!;
+    const panelIndices = indices![p]!;
     if (panelBatches.length === 0) continue;
     drawClippedToPanel(ctx, panel, () => {
       ctx.save();
@@ -523,7 +554,9 @@ export function drawStratum(
       const mutedAlpha = presentation.mutedAlpha ?? scene.theme.interactionMuted;
       // Paint all unaffected/muted primitives first across the stratum, then
       // focused primitives so coincident focused marks remain visible.
-      for (const { batch, index } of panelBatches) {
+      for (let k = 0; k < panelBatches.length; k++) {
+        const batch = panelBatches[k]!;
+        const index = panelIndices[k]!;
         const mask = presentation.focusMasks[index];
         if (mask === undefined || mask === null) {
           drawBatch(ctx, batch, scene.theme, resolve);
@@ -531,7 +564,9 @@ export function drawStratum(
           drawBatchSubset(ctx, batch, scene.theme, resolve, mask, false, mutedAlpha);
         }
       }
-      for (const { batch, index } of panelBatches) {
+      for (let k = 0; k < panelBatches.length; k++) {
+        const batch = panelBatches[k]!;
+        const index = panelIndices[k]!;
         const mask = presentation.focusMasks[index];
         if (mask === undefined || mask === null) continue;
         if (maskIsAllFocused(mask, batchPrimitiveCount(batch))) {

--- a/packages/core/src/dom/canvas.ts
+++ b/packages/core/src/dom/canvas.ts
@@ -502,9 +502,11 @@ export function groupBatchesByPanel(
   for (let i = 0; i < batches.length; i++) {
     const batch = batches[i]!;
     const p = batch.panelIndex;
-    // Out-of-range panelIndex is a pipeline bug; skip rather than throw so a
-    // bad batch cannot take down the whole stratum draw.
-    if (p < 0 || p >= panelCount) continue;
+    // Malformed panelIndex (NaN, non-integer, out of range) is a pipeline bug;
+    // skip rather than throw so a bad batch cannot take down the whole stratum
+    // draw. Integer check matters: `byPanel[1.5]` / `byPanel[NaN]` are not
+    // real buckets, and the old filter path silently dropped those too.
+    if (!Number.isInteger(p) || p < 0 || p >= panelCount) continue;
     byPanel[p]!.push(batch);
     indices?.[p]!.push(i);
   }

--- a/packages/core/tests/canvas.test.ts
+++ b/packages/core/tests/canvas.test.ts
@@ -362,6 +362,18 @@ describe("drawStratum multi-panel batch routing", () => {
     expect(byPanel[1]).toHaveLength(0);
     expect(indices![0]).toEqual([0]);
   });
+
+  it("groupBatchesByPanel skips NaN and non-integer panelIndex without throwing", () => {
+    // Regression for Codex P2 on #192: bounds-only guards let NaN/1.5 through
+    // to `byPanel[p]!.push`, which throws because those keys are not buckets.
+    const nan: PointsBatch = { ...points, panelIndex: Number.NaN };
+    const frac: PointsBatch = { ...points, layerIndex: 1, panelIndex: 1.5 };
+    const { byPanel, indices } = groupBatchesByPanel(2, [points, nan, frac], true);
+    expect(byPanel[0]).toHaveLength(1);
+    expect(byPanel[1]).toHaveLength(0);
+    expect(indices![0]).toEqual([0]);
+    expect(Object.keys(byPanel).filter((k) => k !== "0" && k !== "1")).toEqual([]);
+  });
 });
 
 describe("drawStratum focus presentation", () => {

--- a/packages/core/tests/canvas.test.ts
+++ b/packages/core/tests/canvas.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 
-import { drawStratum } from "../src/dom/canvas.ts";
+import { drawStratum, groupBatchesByPanel } from "../src/dom/canvas.ts";
 import type {
   GeometryBatch,
   PathsBatch,
@@ -105,23 +105,22 @@ const paths: PathsBatch = {
   curve: "linear",
 };
 
-function scene(batches: readonly GeometryBatch[]): Scene {
-  return {
+function scene(batches: readonly GeometryBatch[], panelCount = 1): Scene {
+  const panels = Array.from({ length: panelCount }, (_, i) => ({
+    id: `panel-${i}`,
+    x: i * 30,
+    y: 0,
     width: 20,
     height: 20,
-    panels: [
-      {
-        id: "panel",
-        x: 0,
-        y: 0,
-        width: 20,
-        height: 20,
-        strip: "",
-        axisX: null,
-        axisY: null,
-        grid: { x: [], y: [] },
-      },
-    ],
+    strip: "",
+    axisX: null,
+    axisY: null,
+    grid: { x: [], y: [] },
+  }));
+  return {
+    width: Math.max(20, panelCount * 30),
+    height: 20,
+    panels,
     batches: [...batches],
     legends: [],
     theme: { ink: "black", accent: "blue", interactionMuted: 0.36 } as Scene["theme"],
@@ -132,6 +131,238 @@ function scene(batches: readonly GeometryBatch[]): Scene {
 }
 
 const resolve = (color: string) => color;
+
+/**
+ * Arc x-positions drawn after each panel translate. Panel origin is
+ * `panelIndex * 30` (see `scene()`), so we group draws by the latest
+ * translate x. Used to lock multi-panel routing without coupling to the
+ * internal by-panel index structure.
+ */
+function arcsByPanelTranslate(calls: readonly RecordedCall[]): Map<number, number[]> {
+  const byPanel = new Map<number, number[]>();
+  let currentX = 0;
+  for (const call of calls) {
+    if (call.name === "translate") {
+      currentX = call.args[0]!;
+      if (!byPanel.has(currentX)) byPanel.set(currentX, []);
+      continue;
+    }
+    if (call.name === "arc") {
+      const list = byPanel.get(currentX) ?? [];
+      list.push(call.args[0]!);
+      byPanel.set(currentX, list);
+    }
+  }
+  return byPanel;
+}
+
+describe("drawStratum multi-panel batch routing", () => {
+  const panel0Points: PointsBatch = {
+    ...points,
+    panelIndex: 0,
+    positions: Float32Array.from([10, 1]),
+    rowIndex: Uint32Array.from([0]),
+  };
+  const panel1Points: PointsBatch = {
+    ...points,
+    layerIndex: 1,
+    panelIndex: 1,
+    positions: Float32Array.from([20, 2]),
+    rowIndex: Uint32Array.from([1]),
+  };
+  const panel2Points: PointsBatch = {
+    ...points,
+    layerIndex: 2,
+    panelIndex: 2,
+    positions: Float32Array.from([30, 3]),
+    rowIndex: Uint32Array.from([2]),
+  };
+
+  it("draws each batch only inside its own panel (interleaved panel indices)", () => {
+    // Batches arrive out of panel order — grouping must not reorder across panels
+    // and must not skip or double-draw when panelIndex is non-monotonic.
+    const batches = [panel1Points, panel0Points, panel2Points];
+    const { ctx, calls } = recordingContext();
+    drawStratum(ctx, scene(batches, 3), batches, resolve);
+
+    const arcs = arcsByPanelTranslate(calls);
+    expect(arcs.get(0)).toEqual([10]);
+    expect(arcs.get(30)).toEqual([20]);
+    expect(arcs.get(60)).toEqual([30]);
+    expect(calls.filter((c) => c.name === "arc")).toHaveLength(3);
+  });
+
+  it("preserves within-panel paint order when multiple batches share a panel", () => {
+    const first: PointsBatch = {
+      ...points,
+      panelIndex: 1,
+      positions: Float32Array.from([1, 1]),
+      rowIndex: Uint32Array.from([0]),
+    };
+    const second: PointsBatch = {
+      ...points,
+      layerIndex: 1,
+      panelIndex: 1,
+      positions: Float32Array.from([2, 2]),
+      rowIndex: Uint32Array.from([1]),
+    };
+    // A batch for panel 0 sits between them in the input list — it must not
+    // reorder the two panel-1 batches relative to each other.
+    const other: PointsBatch = {
+      ...points,
+      layerIndex: 2,
+      panelIndex: 0,
+      positions: Float32Array.from([9, 9]),
+      rowIndex: Uint32Array.from([2]),
+    };
+    const batches = [first, other, second];
+    const { ctx, calls } = recordingContext();
+    drawStratum(ctx, scene(batches, 2), batches, resolve);
+
+    const arcs = arcsByPanelTranslate(calls);
+    expect(arcs.get(0)).toEqual([9]);
+    expect(arcs.get(30)).toEqual([1, 2]);
+  });
+
+  it("skips empty panels without drawing and still covers all populated ones", () => {
+    // Panels 0 and 2 empty; only panel 1 has work. Empty panels must not
+    // produce translate/clip work beyond clearRect setup, and panel 1 must still draw.
+    const batches = [panel1Points];
+    const { ctx, calls } = recordingContext();
+    drawStratum(ctx, scene(batches, 3), batches, resolve);
+
+    const arcs = arcsByPanelTranslate(calls);
+    expect(arcs.get(30)).toEqual([20]);
+    expect(arcs.has(0)).toBe(false);
+    expect(arcs.has(60)).toBe(false);
+    expect(calls.filter((c) => c.name === "arc")).toHaveLength(1);
+  });
+
+  it("focus masks index by original batch list, not per-panel reindex", () => {
+    // focusMasks[i] must address batches[i] in the full list. If implementation
+    // reindexes masks per panel, the second batch's mask would be read as the
+    // first panel-local entry and the focus/muted split would flip.
+    const a: PointsBatch = {
+      ...points,
+      panelIndex: 0,
+      positions: Float32Array.from([1, 1, 2, 2]),
+      rowIndex: Uint32Array.from([0, 1]),
+    };
+    const b: PointsBatch = {
+      ...points,
+      layerIndex: 1,
+      panelIndex: 1,
+      positions: Float32Array.from([10, 10, 20, 20]),
+      rowIndex: Uint32Array.from([2, 3]),
+    };
+    const batches = [a, b];
+    const { ctx, calls } = recordingContext();
+    drawStratum(ctx, scene(batches, 2), batches, resolve, {
+      // mask for a: focus first point only; mask for b: focus second point only
+      focusMasks: [Uint8Array.from([1, 0]), Uint8Array.from([0, 1])],
+      mutedAlpha: 0.25,
+    });
+
+    const arcs = arcsByPanelTranslate(calls);
+    // Panel 0: muted point x=2 first, then focused x=1
+    expect(arcs.get(0)).toEqual([2, 1]);
+    // Panel 1: muted point x=10 first, then focused x=20
+    expect(arcs.get(30)).toEqual([10, 20]);
+  });
+
+  it("paints muted then focused across batches within the same panel only", () => {
+    const a: PointsBatch = {
+      ...points,
+      panelIndex: 0,
+      positions: Float32Array.from([1, 1]),
+      rowIndex: Uint32Array.from([0]),
+    };
+    const b: PointsBatch = {
+      ...points,
+      layerIndex: 1,
+      panelIndex: 0,
+      positions: Float32Array.from([2, 2]),
+      rowIndex: Uint32Array.from([1]),
+    };
+    const otherPanel: PointsBatch = {
+      ...points,
+      layerIndex: 2,
+      panelIndex: 1,
+      positions: Float32Array.from([99, 99]),
+      rowIndex: Uint32Array.from([2]),
+    };
+    const batches = [a, otherPanel, b];
+    const { ctx, calls } = recordingContext();
+    drawStratum(ctx, scene(batches, 2), batches, resolve, {
+      focusMasks: [
+        Uint8Array.from([1]), // a focused
+        Uint8Array.from([0]), // otherPanel muted
+        Uint8Array.from([0]), // b muted
+      ],
+      mutedAlpha: 0.25,
+    });
+
+    const arcs = arcsByPanelTranslate(calls);
+    // Within panel 0: muted b (x=2) before focused a (x=1)
+    expect(arcs.get(0)).toEqual([2, 1]);
+    // Panel 1: only its own muted point
+    expect(arcs.get(30)).toEqual([99]);
+  });
+
+  function manyPanelBatches(panelCount: number, batchesPerPanel: number): GeometryBatch[] {
+    const out: GeometryBatch[] = [];
+    for (let p = 0; p < panelCount; p++) {
+      for (let b = 0; b < batchesPerPanel; b++) {
+        out.push({
+          ...points,
+          layerIndex: p * batchesPerPanel + b,
+          panelIndex: p,
+          positions: Float32Array.from([p + b, 1]),
+          rowIndex: Uint32Array.from([0]),
+        });
+      }
+    }
+    return out;
+  }
+
+  /**
+   * Complexity guard for #185: groupBatchesByPanel must index each batch
+   * exactly once (O(B)), independent of panel count. A Proxy counts numeric
+   * index reads without patching Array.prototype (oxlint no-extend-native).
+   */
+  it("groupBatchesByPanel reads each batch once regardless of panel count", () => {
+    const panelCount = 12;
+    const raw = manyPanelBatches(panelCount, 3);
+    let indexReads = 0;
+    const batches = new Proxy(raw, {
+      get(target, property, receiver): unknown {
+        if (typeof property === "string" && /^\d+$/.test(property)) indexReads++;
+        return Reflect.get(target, property, receiver) as unknown;
+      },
+    });
+
+    const withoutIdx = groupBatchesByPanel(panelCount, batches, false);
+    expect(indexReads).toBe(raw.length);
+    expect(withoutIdx.indices).toBeNull();
+    expect(withoutIdx.byPanel).toHaveLength(panelCount);
+    expect(withoutIdx.byPanel.reduce((n, bucket) => n + bucket.length, 0)).toBe(raw.length);
+
+    indexReads = 0;
+    const withIdx = groupBatchesByPanel(panelCount, batches, true);
+    expect(indexReads).toBe(raw.length);
+    // Original indices align with the full list, not a per-panel reindex.
+    expect(withIdx.indices![1]).toEqual([3, 4, 5]);
+    expect(withIdx.byPanel[1]!.map((b) => b.layerIndex)).toEqual([3, 4, 5]);
+  });
+
+  it("groupBatchesByPanel skips out-of-range panelIndex without throwing", () => {
+    const bad: PointsBatch = { ...points, panelIndex: 99 };
+    const { byPanel, indices } = groupBatchesByPanel(2, [points, bad], true);
+    expect(byPanel[0]).toHaveLength(1);
+    expect(byPanel[1]).toHaveLength(0);
+    expect(indices![0]).toEqual([0]);
+  });
+});
 
 describe("drawStratum focus presentation", () => {
   it("keeps the unpresented point fast path as one fill", () => {


### PR DESCRIPTION
## Summary

Fixes #185: `drawStratum` no longer re-filters the full batch list once per panel.

- Add `groupBatchesByPanel` — single O(B) pass grouping batches (and optional original indices) by `panelIndex`
- Fast path and focus-presentation path both walk pre-indexed panel buckets → **O(B + P)** instead of **O(P · B)**
- Focus masks stay aligned to the original batch list; within-panel paint order preserved
- Out-of-range `panelIndex` is skipped (pipeline bug) rather than throwing mid-draw

## Test plan (TDD)

- [x] RED → GREEN multi-panel routing (interleaved indices, empty panels, within-panel order)
- [x] Focus mask alignment across panels (global batch index, not per-panel reindex)
- [x] Muted-then-focused paint order scoped per panel
- [x] Complexity: `groupBatchesByPanel` reads each batch once regardless of panel count
- [x] Existing focus-presentation canvas suite green
- [x] Full `@ggsvelte/core` suite + typecheck + type-aware oxlint (pre-push)

## Complexity

| Path | Before | After |
|------|--------|-------|
| Unfocused draw | O(P · B) filter | O(B + P) |
| Focus presentation | O(P · B) map+filter | O(B + P) |

Closes #185