### PR TITLE
perf(core): precompute path group sorted rows for candidate resolve

### DIFF
--- a/packages/core/src/pipeline/build-candidates-frame-row.ts
+++ b/packages/core/src/pipeline/build-candidates-frame-row.ts
@@ -5,6 +5,43 @@ import type { GeometryBatch } from "../scene.js";
 
 import type { LayerFrame } from "./types.js";
 
+/**
+ * Build per-group frame-row indices sorted by xNumeric (fallback: row index).
+ * Path candidate resolution looks up local vertex → frame row from this index.
+ */
+export function buildPathGroupSortedRows(
+  frame: Pick<LayerFrame, "groups" | "xNumeric">,
+): Map<number, number[]> {
+  const byGroup = new Map<number, number[]>();
+  for (let row = 0; row < frame.groups.length; row++) {
+    const group = frame.groups[row]!;
+    const rows = byGroup.get(group);
+    if (rows === undefined) byGroup.set(group, [row]);
+    else rows.push(row);
+  }
+  for (const rows of byGroup.values()) {
+    rows.sort((a, b) => (frame.xNumeric?.[a] ?? a) - (frame.xNumeric?.[b] ?? b));
+  }
+  return byGroup;
+}
+
+/** One sorted-row index per LayerFrame for the duration of candidate construction. */
+const pathGroupSortedRowsCache = new WeakMap<
+  Pick<LayerFrame, "groups" | "xNumeric">,
+  Map<number, number[]>
+>();
+
+/** Return the cached per-group sorted rows for `frame`, building once if needed. */
+export function getPathGroupSortedRows(
+  frame: Pick<LayerFrame, "groups" | "xNumeric">,
+): Map<number, number[]> {
+  let cached = pathGroupSortedRowsCache.get(frame);
+  if (cached !== undefined) return cached;
+  cached = buildPathGroupSortedRows(frame);
+  pathGroupSortedRowsCache.set(frame, cached);
+  return cached;
+}
+
 export function resolveCandidateFrameRow(input: {
   frame: LayerFrame | undefined;
   batch: GeometryBatch;
@@ -24,11 +61,7 @@ export function resolveCandidateFrameRow(input: {
     )
       subpath++;
     derivedGroup = orderedGroups[Math.min(subpath, orderedGroups.length - 1)] ?? 0;
-    const rowsInGroup = frame.groups
-      .map((group, row) => ({ group, row }))
-      .filter((entry) => entry.group === derivedGroup)
-      .map((entry) => entry.row)
-      .toSorted((a, b) => (frame.xNumeric?.[a] ?? a) - (frame.xNumeric?.[b] ?? b));
+    const rowsInGroup = getPathGroupSortedRows(frame).get(derivedGroup) ?? [];
     const local = primitiveIndex - (batch.pathOffsets[subpath] ?? 0);
     const reflected =
       local < rowsInGroup.length ? local : Math.max(0, rowsInGroup.length * 2 - 1 - local);

--- a/packages/core/tests/pipeline-build-candidates.test.ts
+++ b/packages/core/tests/pipeline-build-candidates.test.ts
@@ -181,7 +181,12 @@ describe("buildPipelineCandidates via runPipeline", () => {
     ]);
     expect(new Set(linePoints.map((c) => c.seriesId)).size).toBe(2);
     // Within each series, vertices are ordered by x (sorted group rows).
-    const bySeries = Map.groupBy(linePoints, (c) => c.seriesId);
+    const bySeries = new Map<number, typeof linePoints>();
+    for (const c of linePoints) {
+      const series = bySeries.get(c.seriesId);
+      if (series === undefined) bySeries.set(c.seriesId, [c]);
+      else series.push(c);
+    }
     for (const seriesPoints of bySeries.values()) {
       const xs = seriesPoints.map((c) => Number(c.xValue));
       expect(xs).toEqual([...xs].toSorted((a, b) => a - b));

--- a/packages/core/tests/pipeline-build-candidates.test.ts
+++ b/packages/core/tests/pipeline-build-candidates.test.ts
@@ -151,6 +151,42 @@ describe("buildPipelineCandidates via runPipeline", () => {
     );
     expect(modes.some((m) => m === "x" || m === "y")).toBe(true);
   });
+
+  it("identity-indexed multi-series lines map path vertices via precomputed group rows", () => {
+    // Annotation layer forces the identity-indexed candidate path (not
+    // source-backed). Path vertices must resolve to x-sorted frame rows per
+    // series without rebuilding the group index on every call.
+    const model = runPipeline(
+      gg(
+        [
+          { x: 2, y: 10, s: "a" },
+          { x: 1, y: 20, s: "b" },
+          { x: 1, y: 30, s: "a" },
+          { x: 2, y: 40, s: "b" },
+        ],
+        aes({ x: "x", y: "y", color: "s" }),
+      )
+        .geomLine()
+        .geomRule({ yintercept: 25 })
+        .spec(),
+      size,
+    );
+    const linePoints = Array.from(
+      { length: model.candidates.size },
+      (_, id) => model.candidates.candidate(id)!,
+    ).filter((c) => c.kind === "paths");
+    expect(linePoints).toHaveLength(4);
+    expect(linePoints.map((c) => c.yValue).toSorted((a, b) => Number(a) - Number(b))).toEqual([
+      10, 20, 30, 40,
+    ]);
+    expect(new Set(linePoints.map((c) => c.seriesId)).size).toBe(2);
+    // Within each series, vertices are ordered by x (sorted group rows).
+    const bySeries = Map.groupBy(linePoints, (c) => c.seriesId);
+    for (const seriesPoints of bySeries.values()) {
+      const xs = seriesPoints.map((c) => Number(c.xValue));
+      expect(xs).toEqual([...xs].toSorted((a, b) => a - b));
+    }
+  });
 });
 
 describe("resolveCandidateSeries / resolveRepresentedSourceRows", () => {
@@ -244,6 +280,119 @@ describe("createLazyIdentityIndex", () => {
     expect(a).toBe(b);
     // silence unused
     expect(calls).toBe(0);
+  });
+});
+
+describe("buildPathGroupSortedRows", () => {
+  it("groups frame rows and sorts each group by xNumeric (fallback row index)", async () => {
+    const { buildPathGroupSortedRows } =
+      await import("../src/pipeline/build-candidates-frame-row.ts");
+    // rows: group 1 at x=3, group 0 at x=2, group 1 at x=1, group 0 at x=0
+    // → group 0 sorted [3, 1]; group 1 sorted [2, 0]
+    const frame = {
+      groups: [1, 0, 1, 0],
+      xNumeric: new Float64Array([3, 2, 1, 0]),
+    } as never;
+    const byGroup = buildPathGroupSortedRows(frame);
+    expect([...byGroup.get(0)!]).toEqual([3, 1]);
+    expect([...byGroup.get(1)!]).toEqual([2, 0]);
+  });
+
+  it("falls back to row index order when xNumeric is null", async () => {
+    const { buildPathGroupSortedRows } =
+      await import("../src/pipeline/build-candidates-frame-row.ts");
+    const frame = { groups: [0, 0, 0], xNumeric: null } as never;
+    expect([...buildPathGroupSortedRows(frame).get(0)!]).toEqual([0, 1, 2]);
+  });
+});
+
+describe("getPathGroupSortedRows", () => {
+  it("returns the same Map for the same frame (precomputed once)", async () => {
+    const { getPathGroupSortedRows } =
+      await import("../src/pipeline/build-candidates-frame-row.ts");
+    const frame = {
+      groups: [0, 0, 1],
+      xNumeric: new Float64Array([0, 1, 2]),
+    } as never;
+    const a = getPathGroupSortedRows(frame);
+    const b = getPathGroupSortedRows(frame);
+    expect(a).toBe(b);
+    expect([...a.get(0)!]).toEqual([0, 1]);
+    expect([...a.get(1)!]).toEqual([2]);
+  });
+});
+
+describe("resolveCandidateFrameRow paths", () => {
+  it("maps path vertices to x-sorted frame rows and reflects closed-path reverse legs", async () => {
+    const { resolveCandidateFrameRow } =
+      await import("../src/pipeline/build-candidates-frame-row.ts");
+    // Two groups interleaved: g0 rows {0,2} with x 2,0 → sorted [2,0];
+    // g1 rows {1,3} with x 3,1 → sorted [3,1]
+    const frame = {
+      n: 4,
+      groups: [0, 1, 0, 1],
+      xNumeric: new Float64Array([2, 3, 0, 1]),
+      binding: { layer: { geom: "area" } },
+    } as never;
+    // Two subpaths, each 4 vertices (forward + reverse for closed area):
+    // subpath 0: offsets [0, 4), subpath 1: [4, 8)
+    const batch = {
+      kind: "paths",
+      pathOffsets: new Uint32Array([0, 4, 8]),
+    } as never;
+    const orderedGroups = [0, 1];
+
+    // Forward: local 0 → first sorted row of group 0 = 2
+    expect(
+      resolveCandidateFrameRow({
+        frame,
+        batch,
+        primitiveIndex: 0,
+        orderedGroups,
+        outlierLocalRow: null,
+      }),
+    ).toEqual({ frameRow: 2, derivedGroup: 0 });
+    // Forward: local 1 → second sorted row of group 0 = 0
+    expect(
+      resolveCandidateFrameRow({
+        frame,
+        batch,
+        primitiveIndex: 1,
+        orderedGroups,
+        outlierLocalRow: null,
+      }),
+    ).toEqual({ frameRow: 0, derivedGroup: 0 });
+    // Reverse leg: local 2 → reflected 2*2-1-2 = 1 → same as local 1 = 0
+    expect(
+      resolveCandidateFrameRow({
+        frame,
+        batch,
+        primitiveIndex: 2,
+        orderedGroups,
+        outlierLocalRow: null,
+      }),
+    ).toEqual({ frameRow: 0, derivedGroup: 0 });
+    // Reverse leg: local 3 → reflected 0 → row 2
+    expect(
+      resolveCandidateFrameRow({
+        frame,
+        batch,
+        primitiveIndex: 3,
+        orderedGroups,
+        outlierLocalRow: null,
+      }),
+    ).toEqual({ frameRow: 2, derivedGroup: 0 });
+
+    // Second subpath (group 1): local 0 → first sorted = 3
+    expect(
+      resolveCandidateFrameRow({
+        frame,
+        batch,
+        primitiveIndex: 4,
+        orderedGroups,
+        outlierLocalRow: null,
+      }),
+    ).toEqual({ frameRow: 3, derivedGroup: 1 });
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes #186: `resolveCandidateFrameRow` no longer rebuilds and sorts all path-group frame rows on every call.

- Add `buildPathGroupSortedRows` — one O(n log n) pass grouping frame rows by group and sorting by `xNumeric` (row-index fallback)
- Cache per `LayerFrame` via WeakMap (`getPathGroupSortedRows`) so identity-indexed store construction pays once, then O(1) lookup per path vertex
- Path subpath → derived group → local/reflected index mapping for lines/areas/smooth is unchanged

## Complexity

| Path | Before | After |
|------|--------|-------|
| Per path-vertex resolve | O(n + g log g) scan+sort | O(1) map lookup |
| Store build with G subpaths | O(G · n log n) | O(n log n + G) |

## Test plan (TDD)

- [x] RED → GREEN `buildPathGroupSortedRows` groups + xNumeric sort
- [x] Null `xNumeric` falls back to row-index order
- [x] `getPathGroupSortedRows` reuses the same Map per frame
- [x] Characterization: path vertex → frame row + closed-path reflection
- [x] Integration: identity-indexed multi-series line (+ annotation) keeps series ids and x-order
- [x] `bun test packages/core` (568 pass)
- [x] `bun run check` + type-aware lint + pre-push green

Closes #186