### PR TITLE
perf(core): O(1) rank lookup for candidate-store next/previous traverse

### DIFF
--- a/packages/core/src/candidate-store.ts
+++ b/packages/core/src/candidate-store.ts
@@ -490,6 +490,9 @@ function buildCandidateStoreEager(
         primitiveIds[a]! - primitiveIds[b]!,
     ),
   );
+  // Dense inverse of `traversal`: candidate id → sequential rank (O(1) next/previous).
+  const traversalRank = new Uint32Array(n);
+  for (let i = 0; i < n; i++) traversalRank[traversal[i]!] = i;
   const permutations: Record<"x" | "y", Uint32Array> = {
     x: new Uint32Array(0),
     y: new Uint32Array(0),
@@ -777,10 +780,13 @@ function buildCandidateStoreEager(
       if (n === 0) return null;
       if (direction === "first" || startId === null) return traversal[0]!;
       if (direction === "last") return traversal[n - 1]!;
-      const at = traversal.indexOf(startId);
-      if (at < 0) return traversal[0]!;
-      if (direction === "next") return traversal[(at + 1) % n]!;
-      if (direction === "previous") return traversal[(at - 1 + n) % n]!;
+      if (direction === "next" || direction === "previous") {
+        if (!Number.isInteger(startId) || startId < 0 || startId >= n) return traversal[0]!;
+        const at = traversalRank[startId]!;
+        if (direction === "next") return traversal[(at + 1) % n]!;
+        return traversal[(at - 1 + n) % n]!;
+      }
+      if (!Number.isInteger(startId) || startId < 0 || startId >= n) return traversal[0]!;
       let best = -1;
       let primaryBest = Infinity;
       let orthBest = Infinity;

--- a/packages/core/tests/candidate-store.test.ts
+++ b/packages/core/tests/candidate-store.test.ts
@@ -282,6 +282,71 @@ describe("CandidateStore", () => {
     expect(store.traverse(0, "down")).toBe(3);
     expect(store.queryRect(5, 15, 15, 45)).toEqual(new Uint32Array([0, 3, 4, 1]));
   });
+
+  // Traversal order for this fixture (panel → y → x → batch → primitive):
+  // [0, 3, 4, 2, 1]
+  it("walks next/previous with wrap-around and falls back for unknown start ids", () => {
+    expect(store.traverse(null, "next")).toBe(0);
+    expect(store.traverse(0, "first")).toBe(0);
+    expect(store.traverse(0, "last")).toBe(1);
+    expect(store.traverse(0, "next")).toBe(3);
+    expect(store.traverse(3, "next")).toBe(4);
+    expect(store.traverse(4, "next")).toBe(2);
+    expect(store.traverse(2, "next")).toBe(1);
+    expect(store.traverse(1, "next")).toBe(0);
+    expect(store.traverse(0, "previous")).toBe(1);
+    expect(store.traverse(1, "previous")).toBe(2);
+    expect(store.traverse(2, "previous")).toBe(4);
+    expect(store.traverse(999, "next")).toBe(0);
+    expect(store.traverse(-1, "previous")).toBe(0);
+  });
+
+  it("keeps spatial directions independent of sequential rank", () => {
+    // Spatial uses geometry, not traversal order.
+    expect(store.traverse(0, "down")).toBe(3);
+    expect(store.traverse(0, "right")).toBe(2);
+    // From (50,30), nearest left is the coincident pair at x=10 (ids 3 then 4); lower id wins ties.
+    expect(store.traverse(2, "left")).toBe(3);
+    expect(store.traverse(1, "up")).toBe(2);
+  });
+});
+
+describe("candidate traversal hot path", () => {
+  it("uses O(1) rank lookup for next/previous without scanning traversal", () => {
+    const plotScene = sceneWithPoints([
+      [10, 10],
+      [20, 20],
+      [30, 30],
+      [40, 40],
+    ]);
+    const hot = buildCandidateStore(plotScene, {
+      datum: ({ primitiveIndex }) => ({
+        xValue: primitiveIndex,
+        yValue: primitiveIndex,
+      }),
+    });
+    // Force the lazy construction boundary before policing resolution.
+    void hot.x;
+    const indexOfSpy = spyOn(Uint32Array.prototype, "indexOf").mockImplementation(function (
+      this: Uint32Array,
+      ...args: Parameters<Uint32Array["indexOf"]>
+    ) {
+      throw new Error(`traverse used linear indexOf(${String(args[0])})`);
+    });
+    try {
+      expect(hot.traverse(0, "next")).toBe(1);
+      expect(hot.traverse(1, "previous")).toBe(0);
+      expect(hot.traverse(3, "next")).toBe(0);
+      expect(hot.traverse(0, "previous")).toBe(3);
+      expect(hot.traverse(null)).toBe(0);
+      expect(hot.traverse(0, "first")).toBe(0);
+      expect(hot.traverse(0, "last")).toBe(3);
+      // Spatial still allowed to scan candidates by id; only sequential rank is constrained.
+      expect(hot.traverse(0, "down")).toBe(1);
+    } finally {
+      indexOfSpy.mockRestore();
+    }
+  });
 });
 
 describe("candidate grouping hot path", () => {


### PR DESCRIPTION
## Summary

- Fixes #187: `CandidateStore.traverse` no longer uses `traversal.indexOf(startId)` for keyboard `next` / `previous` navigation (`O(n)` → `O(1)`).
- Builds a dense inverse rank array once when constructing the store (`candidate id → sequential rank`).
- Spatial directions (`left` / `right` / `up` / `down`) keep the existing geometry scan; sequential wrap-around and invalid-start fallbacks are covered by regression tests.

## Test plan

- [x] Red → green TDD: hot-path spy fails on linear `Uint32Array#indexOf` for next/previous, then passes with rank lookup
- [x] Behavior: next/previous wrap-around and unknown-start fallback
- [x] Spatial directions unchanged vs existing fixture geometry
- [x] `bun test packages/core` (571 pass)
- [x] `bun run check` (tsc clean)
- [ ] CI green on this PR