### PR TITLE
fix(spec): honor options.limits in standalone lintSpec

### DIFF
--- a/packages/spec/src/lint.ts
+++ b/packages/spec/src/lint.ts
@@ -105,14 +105,16 @@ function isRecord(v: unknown): v is Record<string, unknown> {
 
 /**
  * Standalone evidence build (lintSpec without a shared map from validate).
- * Uses resolveFieldEvidence with default limits so behavior matches tier-2
- * when the same inline data is huge (data-aware rules skip over-limit).
+ * Merges options.limits into DEFAULT_VALIDATE_LIMITS the same way validate()
+ * does, so callers can raise or lower maxRows/maxBytes and data-aware rules
+ * honor the override (skip over-limit; never fabricate a complaint).
  */
 function buildEvidence(
   spec: Record<string, unknown>,
   options: ValidateOptions | undefined,
 ): FieldEvidenceMap | null {
-  const resolved = resolveFieldEvidence(spec, options ?? {}, DEFAULT_VALIDATE_LIMITS);
+  const limits = { ...DEFAULT_VALIDATE_LIMITS, ...options?.limits };
+  const resolved = resolveFieldEvidence(spec, options ?? {}, limits);
   return resolved.status === "ok" ? resolved.fields : null;
 }
 
@@ -125,8 +127,10 @@ const DISCRETE: ReadonlySet<ProfileFieldType> = new Set(["nominal", "ordinal"]);
 /**
  * Lint a spec for valid-but-questionable constructs. `options` mirrors
  * validate(): pass `{ profile }` to lint against out-of-band data, or let the
- * spec's inline data provide the evidence. Rules whose evidence is missing
- * skip silently — lint never fabricates a complaint.
+ * spec's inline data provide the evidence; `options.limits` merges over
+ * DEFAULT_VALIDATE_LIMITS the same way validate() does. Rules whose evidence
+ * is missing (including over-limit inline data) skip silently — lint never
+ * fabricates a complaint.
  *
  * When called from validate({ lint: true }), pass `sharedEvidence` so field
  * types/columns are not rebuilt after dataChecks already resolved them.

--- a/packages/spec/tests/lint.test.ts
+++ b/packages/spec/tests/lint.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it } from "bun:test";
 
 import { LINT_CATALOG, lintSpec } from "../src/lint.ts";
 import type { LintAdvisoryCode } from "../src/lint.ts";
+import { DEFAULT_VALIDATE_LIMITS } from "../src/validate-data.ts";
 import { validate } from "../src/validate.ts";
 
 const firedCodes = new Set<LintAdvisoryCode>();
@@ -147,6 +148,62 @@ describe("log-nonpositive-data", () => {
   it("silent for all-positive data or a linear scale", () => {
     expect(lintSpec(spec([1, 2, 3]))).toEqual([]);
     expect(lintSpec(spec([5, -1, 10], "linear"))).toEqual([]);
+  });
+});
+
+describe("lintSpec options.limits", () => {
+  /** Line-over-nominal-x fixture with `rows` nominal categories cycling a/b/c. */
+  const nominalLineSpec = (rows: number) => {
+    const cats = ["a", "b", "c"] as const;
+    return {
+      data: {
+        columns: {
+          x: Array.from({ length: rows }, (_, i) => cats[i % 3]!),
+          y: Array.from({ length: rows }, (_, i) => i),
+        },
+      },
+      aes: { x: { field: "x" }, y: { field: "y" } },
+      layers: [{ geom: "line" }],
+    };
+  };
+
+  it("raises maxRows so data above the default still yields data-backed advisories", () => {
+    // Default maxRows is 100_000; one past that is skipped under defaults.
+    const rows = DEFAULT_VALIDATE_LIMITS.maxRows + 1;
+    const spec = nominalLineSpec(rows);
+
+    expect(codesOf(lintSpec(spec))).not.toContain("line-over-nominal-x");
+
+    const raised = lintSpec(spec, { limits: { maxRows: rows } });
+    expect(codesOf(raised)).toContain("line-over-nominal-x");
+  });
+
+  it("lowers maxRows so over-limit inline data skips data-backed rules", () => {
+    const spec = nominalLineSpec(15);
+
+    // Under defaults (100k), the advisory fires.
+    expect(codesOf(lintSpec(spec))).toContain("line-over-nominal-x");
+
+    // Lowered limit: evidence is null, lint skips (never fabricates a complaint).
+    expect(lintSpec(spec, { limits: { maxRows: 10 } })).toEqual([]);
+  });
+
+  it("lowers maxBytes so oversized inline data skips data-backed rules", () => {
+    // Wide strings so a tiny maxBytes trips while row count stays small.
+    const big = "x".repeat(200);
+    const spec = {
+      data: {
+        columns: {
+          x: [big, big, big],
+          y: [1, 2, 3],
+        },
+      },
+      aes: { x: { field: "x" }, y: { field: "y" } },
+      layers: [{ geom: "line" }],
+    };
+
+    expect(codesOf(lintSpec(spec))).toContain("line-over-nominal-x");
+    expect(lintSpec(spec, { limits: { maxBytes: 50 } })).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Summary

- Standalone `lintSpec` always built field evidence with hard-coded `DEFAULT_VALIDATE_LIMITS`, ignoring `options.limits`.
- Merge `options.limits` the same way `validate()` does so raise/lower of `maxRows` / `maxBytes` is honored.
- Regression tests for raise (`maxRows` above default) and lower (`maxRows` / `maxBytes`) paths.

Fixes #208 (Codex P2 left open from #191).

## Test plan

- [x] `bun test` in `packages/spec` — 144 pass
- [x] New `lintSpec options.limits` suite covers raise maxRows, lower maxRows, lower maxBytes
- [ ] CI green on PR