### PR TITLE
fix(spec): honor options.limits in standalone lintSpec

### DIFF
--- a/packages/spec/src/lint.ts
+++ b/packages/spec/src/lint.ts
@@ -105,14 +105,16 @@ function isRecord(v: unknown): v is Record<string, unknown> {
 
 /**
  * Standalone evidence build (lintSpec without a shared map from validate).
- * Uses resolveFieldEvidence with default limits so behavior matches tier-2
- * when the same inline data is huge (data-aware rules skip over-limit).
+ * Merges options.limits the same way validate() does, then resolves field
+ * evidence so over-limit inline data still skips data-aware rules (never
+ * fabricates complaints) while raised limits keep advisories available.
  */
 function buildEvidence(
   spec: Record<string, unknown>,
   options: ValidateOptions | undefined,
 ): FieldEvidenceMap | null {
-  const resolved = resolveFieldEvidence(spec, options ?? {}, DEFAULT_VALIDATE_LIMITS);
+  const limits = { ...DEFAULT_VALIDATE_LIMITS, ...options?.limits };
+  const resolved = resolveFieldEvidence(spec, options ?? {}, limits);
   return resolved.status === "ok" ? resolved.fields : null;
 }
 
@@ -125,8 +127,9 @@ const DISCRETE: ReadonlySet<ProfileFieldType> = new Set(["nominal", "ordinal"]);
 /**
  * Lint a spec for valid-but-questionable constructs. `options` mirrors
  * validate(): pass `{ profile }` to lint against out-of-band data, or let the
- * spec's inline data provide the evidence. Rules whose evidence is missing
- * skip silently — lint never fabricates a complaint.
+ * spec's inline data provide the evidence; `options.limits` raises/lowers the
+ * same maxRows/maxBytes caps. Rules whose evidence is missing skip silently —
+ * lint never fabricates a complaint.
  *
  * When called from validate({ lint: true }), pass `sharedEvidence` so field
  * types/columns are not rebuilt after dataChecks already resolved them.

--- a/packages/spec/tests/lint.test.ts
+++ b/packages/spec/tests/lint.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it } from "bun:test";
 
 import { LINT_CATALOG, lintSpec } from "../src/lint.ts";
 import type { LintAdvisoryCode } from "../src/lint.ts";
+import { DEFAULT_VALIDATE_LIMITS } from "../src/validate-data.ts";
 import { validate } from "../src/validate.ts";
 
 const firedCodes = new Set<LintAdvisoryCode>();
@@ -147,6 +148,42 @@ describe("log-nonpositive-data", () => {
   it("silent for all-positive data or a linear scale", () => {
     expect(lintSpec(spec([1, 2, 3]))).toEqual([]);
     expect(lintSpec(spec([5, -1, 10], "linear"))).toEqual([]);
+  });
+});
+
+describe("lintSpec options.limits (standalone evidence)", () => {
+  /** Nominal-x line: data-backed advisory when evidence is available. */
+  const nominalLine = (rowCount: number) => ({
+    data: {
+      columns: {
+        x: Array.from({ length: rowCount }, (_, i) => `cat-${i % 5}`),
+        y: Array.from({ length: rowCount }, (_, i) => i),
+      },
+    },
+    aes: { x: { field: "x" }, y: { field: "y" } },
+    layers: [{ geom: "line" }],
+  });
+
+  it("honors a raised maxRows so data-backed advisories still fire", () => {
+    const n = DEFAULT_VALIDATE_LIMITS.maxRows + 1;
+    const spec = nominalLine(n);
+
+    // Default limits: over-limit evidence is dropped → silent skip.
+    expect(lintSpec(spec)).toEqual([]);
+
+    // Raised limits: same data yields the data-backed advisory.
+    const advisories = lintSpec(spec, { limits: { maxRows: n } });
+    expect(codesOf(advisories)).toContain("line-over-nominal-x");
+  });
+
+  it("honors a lowered maxRows by skipping data-backed rules (no fabricated complaints)", () => {
+    const spec = nominalLine(50);
+
+    // Under default limits, the advisory fires.
+    expect(codesOf(lintSpec(spec))).toContain("line-over-nominal-x");
+
+    // Lowered limit drops evidence the same way validate does — silent skip.
+    expect(lintSpec(spec, { limits: { maxRows: 10 } })).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Summary

- Standalone `lintSpec(spec, options)` now merges `options.limits` with `DEFAULT_VALIDATE_LIMITS` the same way `validate()` does before resolving field evidence.
- Raising `maxRows`/`maxBytes` keeps data-backed advisories available past the defaults; lowering them still skips silently (no fabricated complaints).
- Docs/comments no longer claim hard-coded default limits for standalone lint.

Fixes #208 (Codex P2 follow-up from #191).

## Test plan

- [x] TDD: failing tests first for raise and lower `maxRows` paths on public `lintSpec` seam
- [x] `bun test packages/spec/tests/lint.test.ts` — 19 pass
- [x] Pre-push package build + type-aware lint + knip + full bun test suite