### PR TITLE
fix(svelte): honor --gg-tooltip-background on legend filter chrome

### DIFF
--- a/packages/svelte/src/lib/legend/LegendFilters.svelte
+++ b/packages/svelte/src/lib/legend/LegendFilters.svelte
@@ -117,7 +117,13 @@
     border: 1px solid
       var(--gg-tooltipBorder, var(--gg-theme-tooltipBorder, currentColor));
     border-radius: 3px;
-    background: var(--gg-tooltipPaper, var(--gg-theme-tooltipPaper, white));
+    background: var(
+      --gg-tooltipPaper,
+      var(
+        --gg-tooltip-background,
+        var(--gg-theme-tooltipPaper, var(--gg-paper, #fff))
+      )
+    );
     color: var(
       --gg-tooltipInk,
       var(

--- a/packages/svelte/src/lib/legend/LegendTargets.svelte
+++ b/packages/svelte/src/lib/legend/LegendTargets.svelte
@@ -124,8 +124,20 @@
       var(--gg-tooltipBorder, var(--gg-theme-tooltipBorder, currentColor));
     border-radius: 3px;
     padding: 2px 6px;
-    background: var(--gg-tooltipPaper, var(--gg-theme-tooltipPaper, white));
-    color: var(--gg-tooltipInk, var(--gg-theme-tooltipInk, currentColor));
+    background: var(
+      --gg-tooltipPaper,
+      var(
+        --gg-tooltip-background,
+        var(--gg-theme-tooltipPaper, var(--gg-paper, #fff))
+      )
+    );
+    color: var(
+      --gg-tooltipInk,
+      var(
+        --gg-tooltip-foreground,
+        var(--gg-theme-tooltipInk, var(--gg-ink, #1f2328))
+      )
+    );
     font: 11px/1.2 var(--gg-font-family, sans-serif);
     white-space: nowrap;
     pointer-events: auto;

--- a/packages/svelte/tests/legend/filter-component.test.ts
+++ b/packages/svelte/tests/legend/filter-component.test.ts
@@ -106,6 +106,43 @@ describe("explicit legend filtering", () => {
     expect(getComputedStyle(label).backgroundColor).toBe("rgb(255, 255, 255)");
   });
 
+  it("honors kebab-case tooltip background/foreground aliases on filter chips", async () => {
+    // Consumer path from #207: only the kebab pair is set (no camelCase tokens).
+    // Without --gg-tooltip-background in the CSS chain, white text on a white
+    // fallback surface becomes unreadable.
+    const { container } = render(LegendFilterPlot);
+    container.style.setProperty("--gg-tooltip-background", "#111111");
+    container.style.setProperty("--gg-tooltip-foreground", "#ffffff");
+    await until(() => container.querySelector(".gg-legend-filters label") !== null);
+
+    const label = container.querySelector<HTMLElement>(".gg-legend-filters label")!;
+    expect(getComputedStyle(label).backgroundColor).toBe("rgb(17, 17, 17)");
+    expect(getComputedStyle(label).color).toBe("rgb(255, 255, 255)");
+
+    container.querySelector<HTMLInputElement>("input[aria-label='Show north']")!.click();
+    await until(
+      () => container.querySelector("button[aria-label='Reset legend filters']") !== null,
+    );
+    const reset = container.querySelector<HTMLButtonElement>(
+      "button[aria-label='Reset legend filters']",
+    )!;
+    expect(getComputedStyle(reset).backgroundColor).toBe("rgb(17, 17, 17)");
+    expect(getComputedStyle(reset).color).toBe("rgb(255, 255, 255)");
+  });
+
+  it("prefers camelCase tooltip tokens over kebab-case aliases on filter chips", async () => {
+    const { container } = render(LegendFilterPlot);
+    container.style.setProperty("--gg-tooltipPaper", "#ffffff");
+    container.style.setProperty("--gg-tooltipInk", "#262626");
+    container.style.setProperty("--gg-tooltip-background", "#111111");
+    container.style.setProperty("--gg-tooltip-foreground", "#ffffff");
+    await until(() => container.querySelector(".gg-legend-filters label") !== null);
+
+    const label = container.querySelector<HTMLElement>(".gg-legend-filters label")!;
+    expect(getComputedStyle(label).backgroundColor).toBe("rgb(255, 255, 255)");
+    expect(getComputedStyle(label).color).toBe("rgb(38, 38, 38)");
+  });
+
   it("resets old clauses when the controlled filter mode changes", async () => {
     const view = render(LegendFilterPlot, { mode: "exclude" });
     await until(() => view.container.querySelectorAll(".gg-legend-filters input").length === 2);

--- a/packages/svelte/tests/legend/targets.test.ts
+++ b/packages/svelte/tests/legend/targets.test.ts
@@ -75,6 +75,44 @@ describe("LegendTargets", () => {
     expect(clear?.style.top).toBe("304px");
   });
 
+  it("honors kebab-case tooltip background/foreground aliases on clear control", () => {
+    // Same chrome family as filter chips (#207): kebab-only theme path must
+    // not fall through to a white surface under light text.
+    const { container } = render(LegendTargets, {
+      entries,
+      sceneWidth: 400,
+      sceneHeight: 300,
+      clearLegendX: 100,
+      pressedIdentity: { scale: "fill", entryIndex: 0 },
+      ...noopHandlers,
+    });
+    container.style.setProperty("--gg-tooltip-background", "#111111");
+    container.style.setProperty("--gg-tooltip-foreground", "#ffffff");
+
+    const clear = container.querySelector<HTMLButtonElement>(".gg-legend-clear")!;
+    expect(getComputedStyle(clear).backgroundColor).toBe("rgb(17, 17, 17)");
+    expect(getComputedStyle(clear).color).toBe("rgb(255, 255, 255)");
+  });
+
+  it("prefers camelCase tooltip tokens over kebab-case aliases on clear control", () => {
+    const { container } = render(LegendTargets, {
+      entries,
+      sceneWidth: 400,
+      sceneHeight: 300,
+      clearLegendX: 100,
+      pressedIdentity: { scale: "fill", entryIndex: 0 },
+      ...noopHandlers,
+    });
+    container.style.setProperty("--gg-tooltipPaper", "#ffffff");
+    container.style.setProperty("--gg-tooltipInk", "#262626");
+    container.style.setProperty("--gg-tooltip-background", "#111111");
+    container.style.setProperty("--gg-tooltip-foreground", "#ffffff");
+
+    const clear = container.querySelector<HTMLButtonElement>(".gg-legend-clear")!;
+    expect(getComputedStyle(clear).backgroundColor).toBe("rgb(255, 255, 255)");
+    expect(getComputedStyle(clear).color).toBe("rgb(38, 38, 38)");
+  });
+
   it("clamps clear left into [4, sceneWidth-52]", () => {
     const low = render(LegendTargets, {
       entries,


### PR DESCRIPTION
## Summary

- Mirror `Tooltip.svelte`'s background fallback chain (`--gg-tooltipPaper` → `--gg-tooltip-background` → `--gg-theme-tooltipPaper` → `--gg-paper`/`#fff`) on legend filter chips and the legend-focus Clear control.
- Align Clear control ink with the same kebab foreground alias path as filter chips/tooltips.
- Add browser regression coverage for kebab-only theming and camelCase precedence.

Fixes white-on-white filter labels when consumers theme tooltips with only the kebab-case pair.

Closes #207

## Test plan

- [x] Red: kebab-only background assertion failed with white fallback
- [x] Green: `vitest run tests/legend/filter-component.test.ts tests/legend/targets.test.ts` (all browsers)
- [x] Existing camelCase tooltip color coverage still passes
- [ ] CI green on PR
