### PR TITLE
perf(svelte): skip Set alloc when no discrete legend entries

### DIFF
--- a/packages/svelte/src/lib/legend/focus.ts
+++ b/packages/svelte/src/lib/legend/focus.ts
@@ -193,12 +193,15 @@ export type FindLegendPressedIdentityInput = {
  *
  * Complexity: O(K + E) — one Set for the emphasis keys, then per-entry size
  * short-circuit + membership (no Set rebuild per entry). Multi-match returns
- * null as soon as a second hit is found.
+ * null as soon as a second hit is found. Empty keys, or empty entries with no
+ * committed identity, return before allocating the Set.
  */
 export function findLegendPressedIdentity(
   input: FindLegendPressedIdentityInput,
 ): LegendEntryIdentity | null {
   if (input.keys.length === 0) return null;
+  // Ramp-only / no discrete legends and no commit: nothing to match (issue #209).
+  if (input.entries.length === 0 && input.committed === null) return null;
   const inputSet = new Set(input.keys);
   if (input.committed !== null && uniqueKeysMatchSet(input.committed.keys, inputSet))
     return input.committed.identity;

--- a/packages/svelte/tests/legend/focus.test.ts
+++ b/packages/svelte/tests/legend/focus.test.ts
@@ -222,6 +222,23 @@ describe("findLegendPressedIdentity", () => {
     ).toBeNull();
   });
 
+  // Ramp-only / no discrete legends: nothing to match, so skip Set allocation
+  // even when emphasis keys are large (issue #209).
+  it("does not allocate a Set when entries are empty and committed is null", () => {
+    const largeKeys = Array.from({ length: 5_000 }, (_, i) => `k${i}`);
+    withCountingSet((constructions) => {
+      expect(
+        findLegendPressedIdentity({
+          keys: largeKeys,
+          entries: [],
+          keyIndex: new Map(),
+          committed: null,
+        }),
+      ).toBeNull();
+      expect(constructions()).toBe(0);
+    });
+  });
+
   it("prefers committed identity when its keys still match", () => {
     expect(
       findLegendPressedIdentity({
@@ -347,15 +364,7 @@ describe("findLegendPressedIdentity", () => {
       Object.freeze(matchingKeys),
     );
 
-    const RealSet = globalThis.Set;
-    let constructions = 0;
-    globalThis.Set = class CountingSet<T> extends RealSet<T> {
-      constructor(iterable?: Iterable<T>) {
-        super(iterable);
-        constructions += 1;
-      }
-    } as SetConstructor;
-    try {
+    withCountingSet((constructions) => {
       const result = findLegendPressedIdentity({
         keys: matchingKeys,
         entries: largeEntries,
@@ -364,13 +373,28 @@ describe("findLegendPressedIdentity", () => {
       });
       expect(result).toEqual({ scale: "fill", entryIndex: E - 1 });
       // One Set for input.keys (plus at most a small constant). Not 2×E.
-      expect(constructions).toBeLessThanOrEqual(2);
-      expect(constructions).toBeLessThan(E);
-    } finally {
-      globalThis.Set = RealSet;
-    }
+      expect(constructions()).toBeLessThanOrEqual(2);
+      expect(constructions()).toBeLessThan(E);
+    });
   });
 });
+
+/** Spy `globalThis.Set` constructions for allocation-path tests (single class for max-classes-per-file). */
+function withCountingSet(run: (constructions: () => number) => void): void {
+  const RealSet = globalThis.Set;
+  let constructions = 0;
+  globalThis.Set = class CountingSet<T> extends RealSet<T> {
+    constructor(iterable?: Iterable<T>) {
+      super(iterable);
+      constructions += 1;
+    }
+  } as SetConstructor;
+  try {
+    run(() => constructions);
+  } finally {
+    globalThis.Set = RealSet;
+  }
+}
 
 function adapter(partial: {
   legends?: readonly SceneLegend[];


### PR DESCRIPTION
## Summary

- `findLegendPressedIdentity` always allocated `new Set(input.keys)` whenever emphasis keys were non-empty, even with **no discrete legend entries** and **no committed identity** (ramp-only / no legends).
- Early-return before Set allocation on that path so reactive recomputes of `effectiveLegendPressed` stay free when there is nothing to match.
- Behavior unchanged: still returns `null`.
- Shared `withCountingSet` helper in tests so max-classes-per-file stays green.

Closes #209

## Test plan

- [x] TDD RED: CountingSet spy fails with 1 construction on empty entries + null committed + large keys
- [x] TDD GREEN: early-return → 0 constructions, still returns null
- [x] Existing pressed-identity cases (committed, unique match, multi-match, size short-circuit, O(1) Sets vs E)
- [x] `vitest run tests/legend/focus.test.ts` (chromium/firefox/webkit) — 183 passed
- [ ] CI green on this PR