### PR TITLE
perf(core): hoist table.column() out of lineage filter row callbacks

### DIFF
--- a/packages/core/src/pipeline/build-candidates-lineage-filters.ts
+++ b/packages/core/src/pipeline/build-candidates-lineage-filters.ts
@@ -15,9 +15,8 @@ export function filterAggregateXRows(input: {
   baseRows: readonly number[];
 }): number[] {
   const outputKey = bandKey(input.outputX);
-  return input.baseRows.filter(
-    (row) => bandKey(input.table.column(input.field)[row]) === outputKey,
-  );
+  const col = input.table.column(input.field);
+  return input.baseRows.filter((row) => bandKey(col[row]) === outputKey);
 }
 
 export function filterBinRepresentedRows(input: {
@@ -35,8 +34,9 @@ export function filterBinRepresentedRows(input: {
   const frameGroup = frame.groups[frameRow];
   const firstInGroup = frameRow === 0 || frame.groups[frameRow - 1] !== frameGroup;
   const lastInGroup = frameRow === frame.n - 1 || frame.groups[frameRow + 1] !== frameGroup;
+  const col = table.column(field);
   return baseRows.filter((row) => {
-    const value = cellToNumber(table.column(field)[row]!);
+    const value = cellToNumber(col[row]!);
     if (!Number.isFinite(value)) return false;
     return closed === "right"
       ? value <= hi && (value > lo || (firstInGroup && value >= lo))
@@ -49,7 +49,6 @@ export function filterAggregateYRows(input: {
   field: string;
   baseRows: readonly number[];
 }): number[] {
-  return input.baseRows.filter((row) =>
-    Number.isFinite(cellToNumber(input.table.column(input.field)[row]!)),
-  );
+  const col = input.table.column(input.field);
+  return input.baseRows.filter((row) => Number.isFinite(cellToNumber(col[row]!)));
 }

--- a/packages/core/tests/pipeline-build-candidates.test.ts
+++ b/packages/core/tests/pipeline-build-candidates.test.ts
@@ -1,16 +1,45 @@
 /**
  * Characterization tests for pipeline candidate construction paths:
  * source-backed (identity layers) vs identity-indexed (stats/annotations).
+ *
+ * Seams under test (issue #220):
+ * - filterAggregateXRows / filterBinRepresentedRows / filterAggregateYRows
+ *   public row-filter contracts
+ * - complexity: each filter reads table.column(field) once, not per base row
  */
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, spyOn } from "bun:test";
 
 import { aes, gg } from "@ggsvelte/spec";
 
 import { ordinalSeriesRank } from "../src/pipeline/build-candidates-datum-context.ts";
 import { resolveCandidateLogicalValues } from "../src/pipeline/build-candidates-datum-values.ts";
 import { runPipeline } from "../src/pipeline.ts";
+import { ColumnTable } from "../src/table.ts";
 
 const size = { width: 640, height: 400 };
+
+/** Count ColumnTable.column(field) calls during fn (restored after). */
+function countColumnReads(field: string, fn: () => void): number {
+  let reads = 0;
+  const desc = Object.getOwnPropertyDescriptor(ColumnTable.prototype, "column");
+  if (desc?.value === undefined) {
+    throw new Error("ColumnTable.prototype.column is not a data property");
+  }
+  const impl = desc.value as (this: ColumnTable, name: string) => readonly unknown[];
+  const spy = spyOn(ColumnTable.prototype, "column").mockImplementation(function (
+    this: ColumnTable,
+    name: string,
+  ) {
+    if (name === field) reads += 1;
+    return impl.call(this, name);
+  });
+  try {
+    fn();
+    return reads;
+  } finally {
+    spy.mockRestore();
+  }
+}
 
 describe("ordinalSeriesRank", () => {
   it("falls back to group when no ordinal color/fill mapping applies", () => {
@@ -430,7 +459,6 @@ describe("lineage represented-row filters", () => {
   it("keeps rows whose band key matches the aggregate x output", async () => {
     const { filterAggregateXRows } =
       await import("../src/pipeline/build-candidates-lineage-filters.ts");
-    const { ColumnTable } = await import("../src/table.ts");
     const table = ColumnTable.fromRows([
       { g: "a", y: 1 },
       { g: "b", y: 2 },
@@ -449,7 +477,6 @@ describe("lineage represented-row filters", () => {
   it("filters bin membership with closed=right half-open intervals", async () => {
     const { filterBinRepresentedRows } =
       await import("../src/pipeline/build-candidates-lineage-filters.ts");
-    const { ColumnTable } = await import("../src/table.ts");
     const table = ColumnTable.fromRows([{ x: 0.5 }, { x: 1.5 }, { x: 2.5 }, { x: 3.5 }]);
     const frame = {
       xmin: new Float64Array([0, 2]),
@@ -467,6 +494,77 @@ describe("lineage represented-row filters", () => {
         baseRows: [0, 1, 2, 3],
       }),
     ).toEqual([0, 1]);
+  });
+
+  it("keeps rows with finite y values for aggregate y lineage", async () => {
+    const { filterAggregateYRows } =
+      await import("../src/pipeline/build-candidates-lineage-filters.ts");
+    const table = ColumnTable.fromRows([
+      { y: 1 },
+      { y: Number.NaN },
+      { y: 3 },
+      { y: null },
+      { y: Infinity },
+    ]);
+    expect(
+      filterAggregateYRows({
+        table,
+        field: "y",
+        baseRows: [0, 1, 2, 3, 4],
+      }),
+    ).toEqual([0, 2]);
+  });
+});
+
+describe("lineage filter column hoist (issue #220)", () => {
+  it("filterAggregateXRows reads the field column once for many base rows", async () => {
+    const { filterAggregateXRows } =
+      await import("../src/pipeline/build-candidates-lineage-filters.ts");
+    const table = ColumnTable.fromRows(
+      Array.from({ length: 40 }, (_, i) => ({ g: i % 2 === 0 ? "a" : "b", y: i })),
+    );
+    const baseRows = Array.from({ length: 40 }, (_, i) => i);
+    const reads = countColumnReads("g", () => {
+      filterAggregateXRows({ table, field: "g", outputX: "a", baseRows });
+    });
+    expect(reads).toBe(1);
+  });
+
+  it("filterBinRepresentedRows reads the field column once for many base rows", async () => {
+    const { filterBinRepresentedRows } =
+      await import("../src/pipeline/build-candidates-lineage-filters.ts");
+    const table = ColumnTable.fromRows(Array.from({ length: 40 }, (_, i) => ({ x: i * 0.1 })));
+    const frame = {
+      xmin: new Float64Array([0]),
+      xmax: new Float64Array([2]),
+      groups: new Uint32Array([0]),
+      n: 1,
+      binding: { layer: { params: { closed: "right" } } },
+    } as never;
+    const baseRows = Array.from({ length: 40 }, (_, i) => i);
+    const reads = countColumnReads("x", () => {
+      filterBinRepresentedRows({
+        frame,
+        table,
+        frameRow: 0,
+        field: "x",
+        baseRows,
+      });
+    });
+    expect(reads).toBe(1);
+  });
+
+  it("filterAggregateYRows reads the field column once for many base rows", async () => {
+    const { filterAggregateYRows } =
+      await import("../src/pipeline/build-candidates-lineage-filters.ts");
+    const table = ColumnTable.fromRows(
+      Array.from({ length: 40 }, (_, i) => ({ y: i % 5 === 0 ? Number.NaN : i })),
+    );
+    const baseRows = Array.from({ length: 40 }, (_, i) => i);
+    const reads = countColumnReads("y", () => {
+      filterAggregateYRows({ table, field: "y", baseRows });
+    });
+    expect(reads).toBe(1);
   });
 });
 


### PR DESCRIPTION
## Summary
- Hoist `table.column(field)` once before the row loop in `filterAggregateXRows`, `filterBinRepresentedRows`, and `filterAggregateYRows` (issue #220).
- Filter predicates are unchanged; same big-O with lower constant cost on fallback / y filters.
- TDD: characterization tests assert each filter reads the field column exactly once for multi-row base sets, plus a finite-y behavioral case for `filterAggregateYRows`.

## Test plan
- [x] `bun test tests/pipeline-build-candidates.test.ts -t lineage` (red to green on hoist assertions)
- [x] Pre-commit suite (package build, oxlint type-aware, bun test, knip)

Closes #220
