### PR TITLE
perf(core): O(1) CandidateStore.cycle via prebuilt coincident stacks

### DIFF
--- a/packages/core/src/candidate-store.ts
+++ b/packages/core/src/candidate-store.ts
@@ -494,9 +494,10 @@ function buildCandidateStoreEager(
   const traversalRank = new Uint32Array(n);
   for (let i = 0; i < n; i++) traversalRank[traversal[i]!] = i;
 
-  // Coincident stacks by (panel, x, y) in paint/source order (ascending id), so
-  // `cycle` is modular arithmetic over a prebuilt stack instead of an O(n) rescan.
-  const coincidentStack: Uint32Array[] = Array.from({ length: n });
+  // Coincident multi-member stacks by (panel, x, y) in paint/source order (ascending id).
+  // Singletons are omitted so dense plots do not retain n one-element Uint32Arrays;
+  // `cycle` treats a missing stack as identity. Multi-member stacks make cycle O(1).
+  const coincidentStack: (Uint32Array | undefined)[] = Array.from({ length: n });
   const coincidentAt = new Uint32Array(n);
   {
     const groups = new Map<string, number[]>();
@@ -510,12 +511,14 @@ function buildCandidateStoreEager(
       members.push(id);
     }
     for (const members of groups.values()) {
-      // Typed arrays are not freezeable in all runtimes; treat as immutable by convention.
-      const stack = Uint32Array.from(members);
-      for (let i = 0; i < members.length; i++) {
-        const id = members[i]!;
-        coincidentStack[id] = stack;
-        coincidentAt[id] = i;
+      if (members.length >= 2) {
+        // Typed arrays are not freezeable in all runtimes; treat as immutable by convention.
+        const stack = Uint32Array.from(members);
+        for (let i = 0; i < members.length; i++) {
+          const id = members[i]!;
+          coincidentStack[id] = stack;
+          coincidentAt[id] = i;
+        }
       }
       members.length = 0;
     }
@@ -835,11 +838,14 @@ function buildCandidateStoreEager(
       return best < 0 ? startId : best;
     },
     cycle(seedId, step = 1) {
-      if (seedId < 0 || seedId >= n) return null;
-      const stack = coincidentStack[seedId]!;
+      if (!Number.isInteger(seedId) || seedId < 0 || seedId >= n) return null;
+      const stack = coincidentStack[seedId];
+      // No multi-member stack → singleton; step is a no-op.
+      if (stack === undefined) return seedId;
       const at = coincidentAt[seedId]!;
       const next = (((at + step) % stack.length) + stack.length) % stack.length;
-      return stack[next]!;
+      // Non-finite / non-integral step yields a non-element index; fall back to seed.
+      return stack[next] ?? seedId;
     },
     queryRect(x0, y0, x1, y1, panelId) {
       const loX = Math.min(x0, x1);

--- a/packages/core/src/candidate-store.ts
+++ b/packages/core/src/candidate-store.ts
@@ -493,6 +493,34 @@ function buildCandidateStoreEager(
   // Dense inverse of `traversal`: candidate id → sequential rank (O(1) next/previous).
   const traversalRank = new Uint32Array(n);
   for (let i = 0; i < n; i++) traversalRank[traversal[i]!] = i;
+
+  // Coincident stacks by (panel, x, y) in paint/source order (ascending id), so
+  // `cycle` is modular arithmetic over a prebuilt stack instead of an O(n) rescan.
+  const coincidentStack: Uint32Array[] = Array.from({ length: n });
+  const coincidentAt = new Uint32Array(n);
+  {
+    const groups = new Map<string, number[]>();
+    for (let id = 0; id < n; id++) {
+      const key = `${panelIds[id]!}|${xs[id]!}|${ys[id]!}`;
+      let members = groups.get(key);
+      if (members === undefined) {
+        members = [];
+        groups.set(key, members);
+      }
+      members.push(id);
+    }
+    for (const members of groups.values()) {
+      // Typed arrays are not freezeable in all runtimes; treat as immutable by convention.
+      const stack = Uint32Array.from(members);
+      for (let i = 0; i < members.length; i++) {
+        const id = members[i]!;
+        coincidentStack[id] = stack;
+        coincidentAt[id] = i;
+      }
+      members.length = 0;
+    }
+    groups.clear();
+  }
   const permutations: Record<"x" | "y", Uint32Array> = {
     x: new Uint32Array(0),
     y: new Uint32Array(0),
@@ -808,14 +836,10 @@ function buildCandidateStoreEager(
     },
     cycle(seedId, step = 1) {
       if (seedId < 0 || seedId >= n) return null;
-      const coincident: number[] = [];
-      for (let id = 0; id < n; id++) {
-        if (panelIds[id] === panelIds[seedId] && xs[id] === xs[seedId] && ys[id] === ys[seedId])
-          coincident.push(id);
-      }
-      const at = coincident.indexOf(seedId);
-      const next = (((at + step) % coincident.length) + coincident.length) % coincident.length;
-      return coincident[next] ?? seedId;
+      const stack = coincidentStack[seedId]!;
+      const at = coincidentAt[seedId]!;
+      const next = (((at + step) % stack.length) + stack.length) % stack.length;
+      return stack[next]!;
     },
     queryRect(x0, y0, x1, y1, panelId) {
       const loX = Math.min(x0, x1);

--- a/packages/core/tests/candidate-store.test.ts
+++ b/packages/core/tests/candidate-store.test.ts
@@ -284,12 +284,18 @@ describe("CandidateStore", () => {
     expect(store.cycle(4, -1)).toBe(3);
     expect(store.cycle(3, 2)).toBe(3);
     expect(store.cycle(3, 0)).toBe(3);
-    // Singleton stack: step is a no-op.
+    // Singleton stack: step is a no-op (no retained one-element stack required).
     expect(store.cycle(0, 1)).toBe(0);
     expect(store.cycle(0, -3)).toBe(0);
-    // Invalid seed returns null (bounds only; same contract as before).
+    // Invalid seed returns null (bounds + non-integer, matching other store entry points).
     expect(store.cycle(-1, 1)).toBeNull();
     expect(store.cycle(5, 1)).toBeNull();
+    expect(store.cycle(1.5, 1)).toBeNull();
+    expect(store.cycle(Number.NaN, 1)).toBeNull();
+    // Non-finite / non-integral step falls back to the seed (prior contract).
+    expect(store.cycle(3, Number.NaN)).toBe(3);
+    expect(store.cycle(3, Number.POSITIVE_INFINITY)).toBe(3);
+    expect(store.cycle(3, 1.5)).toBe(3);
     expect(store.traverse(0, "down")).toBe(3);
     expect(store.queryRect(5, 15, 15, 45)).toEqual(new Uint32Array([0, 3, 4, 1]));
   });

--- a/packages/core/tests/candidate-store.test.ts
+++ b/packages/core/tests/candidate-store.test.ts
@@ -277,8 +277,19 @@ describe("CandidateStore", () => {
   });
 
   it("cycles coincident marks, traverses deterministically, and returns integer rect ids", () => {
+    // Coincident pair at (10, 25): paint/source order is ids 3 then 4.
     expect(store.cycle(3, 1)).toBe(4);
     expect(store.cycle(4, 1)).toBe(3);
+    expect(store.cycle(3, -1)).toBe(4);
+    expect(store.cycle(4, -1)).toBe(3);
+    expect(store.cycle(3, 2)).toBe(3);
+    expect(store.cycle(3, 0)).toBe(3);
+    // Singleton stack: step is a no-op.
+    expect(store.cycle(0, 1)).toBe(0);
+    expect(store.cycle(0, -3)).toBe(0);
+    // Invalid seed returns null (bounds only; same contract as before).
+    expect(store.cycle(-1, 1)).toBeNull();
+    expect(store.cycle(5, 1)).toBeNull();
     expect(store.traverse(0, "down")).toBe(3);
     expect(store.queryRect(5, 15, 15, 45)).toEqual(new Uint32Array([0, 3, 4, 1]));
   });
@@ -308,6 +319,50 @@ describe("CandidateStore", () => {
     // From (50,30), nearest left is the coincident pair at x=10 (ids 3 then 4); lower id wins ties.
     expect(store.traverse(2, "left")).toBe(3);
     expect(store.traverse(1, "up")).toBe(2);
+  });
+});
+
+describe("candidate cycle hot path", () => {
+  it("uses prebuilt coincident stacks without scanning or indexOf on each step", () => {
+    // Three-way stack at (10, 10) plus a singleton — build order is paint/source (id asc).
+    const plotScene = sceneWithPoints([
+      [10, 10],
+      [20, 20],
+      [10, 10],
+      [10, 10],
+    ]);
+    const hot = buildCandidateStore(plotScene, {
+      datum: ({ primitiveIndex }) => ({
+        xValue: primitiveIndex,
+        yValue: primitiveIndex,
+      }),
+    });
+    // Force the lazy construction boundary before policing resolution.
+    void hot.x;
+    const arrayIndexOfSpy = spyOn(Array.prototype, "indexOf").mockImplementation(function (
+      this: unknown[],
+      ...args: Parameters<Array<unknown>["indexOf"]>
+    ) {
+      throw new Error(`cycle used Array.indexOf(${String(args[0])})`);
+    });
+    const typedIndexOfSpy = spyOn(Uint32Array.prototype, "indexOf").mockImplementation(function (
+      this: Uint32Array,
+      ...args: Parameters<Uint32Array["indexOf"]>
+    ) {
+      throw new Error(`cycle used Uint32Array.indexOf(${String(args[0])})`);
+    });
+    try {
+      expect(hot.cycle(0, 1)).toBe(2);
+      expect(hot.cycle(2, 1)).toBe(3);
+      expect(hot.cycle(3, 1)).toBe(0);
+      expect(hot.cycle(0, -1)).toBe(3);
+      expect(hot.cycle(1, 5)).toBe(1);
+      expect(hot.cycle(-1)).toBeNull();
+      expect(hot.cycle(99)).toBeNull();
+    } finally {
+      arrayIndexOfSpy.mockRestore();
+      typedIndexOfSpy.mockRestore();
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- Prebuild coincident stacks keyed by `(panel, x, y)` at `CandidateStore` construction (paint/source order preserved).
- Make `cycle(seedId, step)` modular arithmetic over the prebuilt stack — O(1) instead of O(n) scan + `indexOf` each step.
- Expand cycle contract tests and add a hot-path guard that fails if cycle reintroduces linear `indexOf`.

Fixes #219.

## Test plan
- [x] `bun test packages/core/tests/candidate-store.test.ts` (behavior + O(1) hot path)
- [x] `bun test packages/core` (full core suite green)
- [x] Pre-push hooks (typecheck, knip, full unit suite) passed on commit