### PR TITLE
perf(core): cache pre-stat inputGroups once per frame

### DIFF
--- a/packages/core/src/pipeline/build-candidates-identity-aggregate.ts
+++ b/packages/core/src/pipeline/build-candidates-identity-aggregate.ts
@@ -8,7 +8,6 @@ import type { BarParams } from "@ggsvelte/spec";
 import { cellToNumber } from "../table.js";
 
 import type { FacetPanelDef } from "./facets.js";
-import { deriveLayerGroups } from "./frame.js";
 import type { LayerFrame } from "./types.js";
 
 export function appendSourceRowByGroupX(input: {
@@ -50,7 +49,8 @@ export function buildBinLineageBuckets(input: {
   const field = frame.binding.xField;
   if (field === null) return;
 
-  const inputGroups = deriveLayerGroups(frame.binding, frame.table);
+  // Pre-stat groups cached on the frame during buildFrame (issue #217).
+  const inputGroups = frame.inputGroups;
   const closed = ((frame.binding.layer.params ?? {}) as BarParams).closed ?? "right";
   const binsByGroup = new Map<number, BinEdge[]>();
 

--- a/packages/core/src/pipeline/build-candidates-identity.ts
+++ b/packages/core/src/pipeline/build-candidates-identity.ts
@@ -10,7 +10,6 @@ import {
   buildBinLineageBuckets,
 } from "./build-candidates-identity-aggregate.js";
 import type { FacetPanelDef } from "./facets.js";
-import { deriveLayerGroups } from "./frame.js";
 import type { LayerFrame } from "./types.js";
 import { NO_ROW } from "./types.js";
 
@@ -38,7 +37,8 @@ export function buildCandidateIdentityIndex(
       const layerIndex = frame.binding.index;
       const frameKey = `${panelIndex}:${layerIndex}`;
       frameGroups.set(frameKey, [...new Set(frame.groups)]);
-      const inputGroups = deriveLayerGroups(frame.binding, frame.table);
+      // Pre-stat groups cached on the frame during buildFrame (issue #217).
+      const inputGroups = frame.inputGroups;
       const stat = frame.binding.layer.stat ?? "identity";
       // Only count/summary/boxplot resolve via group×x buckets; skip for other layers.
       const bucketByX = stat === "count" || stat === "summary" || stat === "boxplot";

--- a/packages/core/src/pipeline/frame-annotation.ts
+++ b/packages/core/src/pipeline/frame-annotation.ts
@@ -16,6 +16,7 @@ export function buildAnnotationFrame(binding: LayerBinding, table: ColumnTable):
     xNumeric: null,
     yNumeric: null,
     groups: [],
+    inputGroups: [],
     rowIndex: new Uint32Array(0),
     colorValues: null,
     fillValues: null,

--- a/packages/core/src/pipeline/frame-identity.ts
+++ b/packages/core/src/pipeline/frame-identity.ts
@@ -9,7 +9,7 @@ import type { LayerBinding, LayerFrame } from "./types.js";
 export function buildIdentityFrame(
   binding: LayerBinding,
   table: ColumnTable,
-  groups: number[],
+  groups: readonly number[],
 ): LayerFrame {
   const n = table.rowCount;
   return {
@@ -20,6 +20,7 @@ export function buildIdentityFrame(
     xNumeric: binding.xField === null ? null : table.numeric(binding.xField),
     yNumeric: binding.yField === null ? null : table.numeric(binding.yField),
     groups,
+    inputGroups: groups,
     rowIndex: Uint32Array.from({ length: n }, (_, i) => i),
     colorValues: binding.color.field === null ? null : table.column(binding.color.field),
     fillValues: binding.fill.field === null ? null : table.column(binding.fill.field),

--- a/packages/core/src/pipeline/frame-stats-bin-frame.ts
+++ b/packages/core/src/pipeline/frame-stats-bin-frame.ts
@@ -25,6 +25,7 @@ export function packBinLayerFrame(
   table: ColumnTable,
   result: BinResult,
   columnOf: ReturnType<typeof makeColumnOf>,
+  inputGroups: readonly number[],
 ): LayerFrame {
   const columns: Record<string, Float64Array> = {
     count: result.count,
@@ -41,6 +42,7 @@ export function packBinLayerFrame(
     xNumeric: result.x,
     yNumeric: columns[binding.yStatColumn ?? "count"] ?? result.count,
     groups: result.groups,
+    inputGroups,
     rowIndex: Uint32Array.from({ length: result.x.length }, () => NO_ROW),
     colorValues: col(binding.color.field),
     fillValues: col(binding.fill.field),

--- a/packages/core/src/pipeline/frame-stats-bin.ts
+++ b/packages/core/src/pipeline/frame-stats-bin.ts
@@ -43,5 +43,5 @@ export function buildBinFrame(
       howToOverride: `Set params.binwidth (preferred — a width meaningful for the data) or params.bins on layer ${index}.`,
     });
   }
-  return packBinLayerFrame(binding, table, result, columnOf);
+  return packBinLayerFrame(binding, table, result, columnOf, groups);
 }

--- a/packages/core/src/pipeline/frame-stats-boxplot.ts
+++ b/packages/core/src/pipeline/frame-stats-boxplot.ts
@@ -38,6 +38,7 @@ export function buildBoxplotFrame(
     xNumeric: null,
     yNumeric: null,
     groups: result.groups,
+    inputGroups: groups,
     rowIndex: Uint32Array.from({ length: result.x.length }, () => NO_ROW),
     colorValues: col(binding.color.field),
     fillValues: col(binding.fill.field),

--- a/packages/core/src/pipeline/frame-stats-count.ts
+++ b/packages/core/src/pipeline/frame-stats-count.ts
@@ -40,6 +40,7 @@ export function buildCountFrame(
     xNumeric: cellsToNumeric(result.x),
     yNumeric: binding.yStatColumn === "count" ? result.count : null,
     groups: result.groups,
+    inputGroups: groups,
     rowIndex: Uint32Array.from({ length: result.x.length }, () => NO_ROW),
     colorValues: col(binding.color.field),
     fillValues: col(binding.fill.field),

--- a/packages/core/src/pipeline/frame-stats-density.ts
+++ b/packages/core/src/pipeline/frame-stats-density.ts
@@ -49,6 +49,7 @@ export function buildDensityFrame(
     xNumeric: result.x,
     yNumeric,
     groups: result.groups,
+    inputGroups: groups,
     rowIndex: Uint32Array.from({ length: outN }, () => NO_ROW),
     colorValues: col(binding.color.field),
     fillValues: col(binding.fill.field),

--- a/packages/core/src/pipeline/frame-stats-smooth-frame.ts
+++ b/packages/core/src/pipeline/frame-stats-smooth-frame.ts
@@ -24,6 +24,7 @@ export function packSmoothLayerFrame(
   table: ColumnTable,
   result: SmoothResult,
   columnOf: CarriedColumnOf,
+  inputGroups: readonly number[],
 ): LayerFrame {
   const col = columnOf(result, null);
   return {
@@ -34,6 +35,7 @@ export function packSmoothLayerFrame(
     xNumeric: result.x,
     yNumeric: result.y,
     groups: result.groups,
+    inputGroups,
     rowIndex: Uint32Array.from({ length: result.x.length }, () => NO_ROW),
     colorValues: col(binding.color.field),
     fillValues: col(binding.fill.field),

--- a/packages/core/src/pipeline/frame-stats-smooth.ts
+++ b/packages/core/src/pipeline/frame-stats-smooth.ts
@@ -44,5 +44,5 @@ export function buildSmoothFrame(
       howToOverride: `Set params.method ("lm" | "loess") on layer ${index}.`,
     });
   }
-  return packSmoothLayerFrame(binding, table, result, columnOf);
+  return packSmoothLayerFrame(binding, table, result, columnOf, groups);
 }

--- a/packages/core/src/pipeline/frame-stats-summary.ts
+++ b/packages/core/src/pipeline/frame-stats-summary.ts
@@ -40,6 +40,7 @@ export function buildSummaryFrame(
     xNumeric: cellsToNumeric(result.x),
     yNumeric: result.y,
     groups: result.groups,
+    inputGroups: groups,
     rowIndex: Uint32Array.from({ length: result.x.length }, () => NO_ROW),
     colorValues: col(binding.color.field),
     fillValues: col(binding.fill.field),

--- a/packages/core/src/pipeline/frame.ts
+++ b/packages/core/src/pipeline/frame.ts
@@ -21,15 +21,24 @@ export function buildFrame(
   advisories: Advisory[],
   binRange?: [number, number],
 ): LayerFrame {
+  // Derive once per frame; identity index + bin lineage consume frame.inputGroups.
+  const inputGroups = deriveLayerGroups(binding, table);
+
   if (binding.ruleForm === "annotation") {
-    return buildAnnotationFrame(binding, table);
+    return { ...buildAnnotationFrame(binding, table), inputGroups };
   }
 
-  const groups = deriveLayerGroups(binding, table);
-  const nonIdentity = buildNonIdentityFrame(binding, table, groups, warnings, advisories, binRange);
-  if (nonIdentity !== null) return nonIdentity;
+  const nonIdentity = buildNonIdentityFrame(
+    binding,
+    table,
+    inputGroups,
+    warnings,
+    advisories,
+    binRange,
+  );
+  if (nonIdentity !== null) return { ...nonIdentity, inputGroups };
 
-  return buildIdentityFrame(binding, table, groups);
+  return { ...buildIdentityFrame(binding, table, inputGroups), inputGroups };
 }
 
 /**

--- a/packages/core/src/pipeline/types-layer-frame.ts
+++ b/packages/core/src/pipeline/types-layer-frame.ts
@@ -27,6 +27,12 @@ export interface LayerFrame {
   xNumeric: Float64Array | null;
   yNumeric: Float64Array | null;
   groups: readonly number[];
+  /**
+   * Pre-stat group id per input table row (canonical first-seen order).
+   * Identity index and bin lineage reuse this instead of re-deriving.
+   * Length is always `table.rowCount` (empty for annotation frames with no rows).
+   */
+  inputGroups: readonly number[];
   /** Source row per post-stat row (NO_ROW for synthesized rows). */
   rowIndex: Uint32Array;
   colorValues: readonly CellValue[] | null;

--- a/packages/core/tests/pipeline-build-candidates.test.ts
+++ b/packages/core/tests/pipeline-build-candidates.test.ts
@@ -658,3 +658,72 @@ describe("aggregate lineage index (issue #184)", () => {
     }
   });
 });
+
+describe("pre-stat inputGroups cache (issue #217)", () => {
+  it("identity index buckets source rows from frame.inputGroups (not re-derived)", async () => {
+    const { preparePanels } = await import("../src/pipeline/prepare-panels.ts");
+    const { buildCandidateIdentityIndex } =
+      await import("../src/pipeline/build-candidates-identity.ts");
+    const { normalize } = await import("@ggsvelte/spec");
+
+    const prepared = preparePanels(
+      normalize(
+        gg(
+          [
+            { g: "a", c: "x" },
+            { g: "a", c: "y" },
+            { g: "b", c: "x" },
+          ],
+          aes({ x: "g", fill: "c" }),
+        )
+          .geomBar()
+          .spec(),
+      ),
+      size,
+      [],
+      [],
+    );
+    const frame = prepared.panelFrames[0]![0]!;
+    // Replace cached pre-stat groups with a distinctive assignment; the index
+    // must follow the cache (proves no second deriveLayerGroups pass).
+    const forced = [7, 7, 8] as const;
+    (frame as { inputGroups: readonly number[] }).inputGroups = forced;
+
+    const index = buildCandidateIdentityIndex(prepared.panelFrames, prepared.facetPanels);
+    expect(index.sourceRowsByGroup.get("0:0:7")?.toSorted((a, b) => a - b)).toEqual([0, 1]);
+    expect(index.sourceRowsByGroup.get("0:0:8")).toEqual([2]);
+    // Natural group ids from derive must not appear if cache is honored.
+    expect(index.sourceRowsByGroup.has("0:0:0")).toBe(false);
+  });
+
+  it("bin lineage assign uses frame.inputGroups for source-row membership", async () => {
+    const { preparePanels } = await import("../src/pipeline/prepare-panels.ts");
+    const { buildCandidateIdentityIndex } =
+      await import("../src/pipeline/build-candidates-identity.ts");
+    const { normalize } = await import("@ggsvelte/spec");
+
+    const prepared = preparePanels(
+      normalize({
+        data: { values: [{ x: 0 }, { x: 1 }, { x: 2 }] },
+        layers: [
+          {
+            geom: "histogram",
+            aes: { x: { field: "x" } },
+            params: { binwidth: 1, boundary: 0, closed: "right" },
+          },
+        ],
+      }),
+      size,
+      [],
+      [],
+    );
+    const frame = prepared.panelFrames[0]![0]!;
+    expect(frame.inputGroups).toHaveLength(3);
+    // Single group for continuous x with no discrete aesthetics.
+    expect([...new Set(frame.inputGroups)]).toEqual([0]);
+
+    const index = buildCandidateIdentityIndex(prepared.panelFrames, prepared.facetPanels);
+    const allBinRows = [...index.sourceRowsByGroupBin.values()].flat();
+    expect(allBinRows.toSorted((a, b) => a - b)).toEqual([0, 1, 2]);
+  });
+});

--- a/packages/core/tests/pipeline-frame.test.ts
+++ b/packages/core/tests/pipeline-frame.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it } from "bun:test";
 import { aes, gg } from "@ggsvelte/spec";
 
 import { bindLayer } from "../src/pipeline/bind.ts";
-import { buildFrame, remapSourceRows } from "../src/pipeline/frame.ts";
+import { buildFrame, deriveLayerGroups, remapSourceRows } from "../src/pipeline/frame.ts";
 import { runPipeline } from "../src/pipeline.ts";
 import { NO_ROW } from "../src/pipeline/types.ts";
 import { ColumnTable } from "../src/table.ts";
@@ -247,5 +247,59 @@ describe("buildFrame via runPipeline (regression)", () => {
     );
     const rects = model.scene.batches.filter((b) => b.kind === "rects");
     expect(rects.length).toBeGreaterThan(0);
+  });
+});
+
+describe("buildFrame — pre-stat inputGroups (issue #217)", () => {
+  it("retains pre-stat groups on identity frames (same as post-stat groups)", () => {
+    const table = ColumnTable.fromRows([
+      { x: "a", c: "red", y: 1 },
+      { x: "b", c: "blue", y: 2 },
+      { x: "a", c: "red", y: 3 },
+    ]);
+    const binding = bindLayer(
+      {
+        geom: "point",
+        aes: { x: { field: "x" }, y: { field: "y" }, color: { field: "c" } },
+      },
+      0,
+      table,
+      [],
+    );
+    const frame = buildFrame(binding, table, [], []);
+    const expected = deriveLayerGroups(binding, table);
+    // Known first-seen group ids for discrete x × color (decision 0005).
+    expect(expected).toEqual([0, 1, 0]);
+    expect([...frame.inputGroups]).toEqual([0, 1, 0]);
+    expect([...frame.groups]).toEqual([0, 1, 0]);
+  });
+
+  it("retains pre-stat groups on count frames (distinct from post-stat groups)", () => {
+    // Two source rows share (g, fill) so count collapses 4 rows → 3 marks.
+    const table = ColumnTable.fromRows([
+      { g: "a", fill: "x" },
+      { g: "a", fill: "x" },
+      { g: "a", fill: "y" },
+      { g: "b", fill: "x" },
+    ]);
+    const binding = bindLayer(
+      {
+        geom: "bar",
+        aes: { x: { field: "g" }, fill: { field: "fill" }, y: { stat: "count" } },
+        stat: "count",
+      },
+      0,
+      table,
+      [],
+    );
+    const frame = buildFrame(binding, table, [], []);
+    // Pre-stat: one id per source row; post-stat: one id per aggregated mark.
+    expect(frame.inputGroups).toHaveLength(table.rowCount);
+    expect(frame.groups).toHaveLength(frame.n);
+    expect(frame.n).toBe(3);
+    expect(frame.n).toBeLessThan(table.rowCount);
+    expect([...frame.inputGroups]).toEqual(deriveLayerGroups(binding, table));
+    // First-seen interaction of discrete x × fill: a|x=0, a|y=1, b|x=2.
+    expect([...frame.inputGroups]).toEqual([0, 0, 1, 2]);
   });
 });

--- a/packages/core/tests/pipeline-scale-training.test.ts
+++ b/packages/core/tests/pipeline-scale-training.test.ts
@@ -66,6 +66,7 @@ function pointFrame(table: ColumnTable): LayerFrame {
     weightField: null,
     ruleForm: null,
   };
+  const groups = Array.from({ length: table.rowCount }, () => 0);
   return {
     binding,
     table,
@@ -73,7 +74,8 @@ function pointFrame(table: ColumnTable): LayerFrame {
     xValues: null,
     xNumeric: table.numeric("x"),
     yNumeric: table.numeric("y"),
-    groups: Array.from({ length: table.rowCount }, () => 0),
+    groups,
+    inputGroups: groups,
     rowIndex: Uint32Array.from({ length: table.rowCount }, (_, i) => i),
     colorValues: null,
     fillValues: null,
@@ -299,6 +301,7 @@ describe("collectAxisInputs — evidence collection", () => {
       xNumeric: null,
       yNumeric: table.numeric("y"),
       groups: [0, 1],
+      inputGroups: [0, 1],
       rowIndex: new Uint32Array([0, 1]),
       colorValues: null,
       fillValues: null,
@@ -340,6 +343,7 @@ describe("collectAxisInputs — evidence collection", () => {
       xNumeric: null,
       yNumeric: Float64Array.of(1, 1),
       groups: [0, 0],
+      inputGroups: [0, 0, 0],
       rowIndex: new Uint32Array([0xffffffff, 0xffffffff]),
       colorValues: null,
       fillValues: null,


### PR DESCRIPTION
## Summary

- Cache pre-stat group assignment on `LayerFrame.inputGroups` during `buildFrame` so identity index and bin lineage no longer re-run `deriveLayerGroups` (2–3× → 1× per layer/panel).
- First-seen group ids and source-row lineage stay identical; only the redundant pre-stat grouping passes are removed.
- Tests cover identity vs count `inputGroups` retention and prove the identity index / bin path consume the frame cache.

Fixes #217

## Test plan

- [x] `bun test packages/core` (588 pass)
- [x] Pre-commit full suite (tsc, svelte-check, knip, bun test, type-aware lint)
- [ ] CI green on PR
- [ ] Confirm bin/count lineage still matches filter parity (covered by existing + new tests)