### PR TITLE
perf(core): O(1) ordinal seriesRank via ColorScale.indexOf

### DIFF
--- a/packages/core/src/pipeline/build-candidates-datum-ordinal-rank.ts
+++ b/packages/core/src/pipeline/build-candidates-datum-ordinal-rank.ts
@@ -1,10 +1,24 @@
 /**
  * Ordinal color/fill series rank for identity candidates.
+ *
+ * Uses ColorScale.indexOf (encodeKey Map from training) — O(1) per candidate,
+ * not domain.findIndex with bandKey (O(d) and type-collapsing). Ranks match
+ * color assignment (including value-stable gaps when series drop out of grow
+ * state), not dense presentation-domain positions.
  */
-import { bandKey } from "../scales/train.js";
 import type { CellValue } from "../table.js";
 
 import type { ResolvedColorScale } from "./types.js";
+
+/** O(1) assignment rank, or -1 when scale/field does not apply. */
+export function ordinalColorRank(
+  resolved: ResolvedColorScale | null,
+  field: string | null | undefined,
+  value: CellValue,
+): number {
+  if (resolved?.kind !== "ordinal" || field === null || field === undefined) return -1;
+  return resolved.scale.indexOf(value) ?? -1;
+}
 
 export function ordinalSeriesRank(input: {
   color: ResolvedColorScale | null;
@@ -16,12 +30,8 @@ export function ordinalSeriesRank(input: {
   group: number;
 }): number {
   const { color, fill, colorField, fillField, sourceRow, sourceValue, group } = input;
-  const ordinalRank = (resolved: ResolvedColorScale | null, field: string | undefined) => {
-    if (resolved?.kind !== "ordinal" || field === undefined || sourceRow === null) return -1;
-    const key = bandKey(sourceValue(field));
-    return resolved.scale.domain.findIndex((value) => bandKey(value) === key);
-  };
-  const colorRank = ordinalRank(color, colorField);
-  const fillRank = ordinalRank(fill, fillField);
+  if (sourceRow === null) return group;
+  const colorRank = ordinalColorRank(color, colorField, sourceValue(colorField));
+  const fillRank = ordinalColorRank(fill, fillField, sourceValue(fillField));
   return colorRank >= 0 ? colorRank : fillRank >= 0 ? fillRank : group;
 }

--- a/packages/core/src/pipeline/build-candidates-datum-ordinal-rank.ts
+++ b/packages/core/src/pipeline/build-candidates-datum-ordinal-rank.ts
@@ -10,14 +10,17 @@ import type { CellValue } from "../table.js";
 
 import type { ResolvedColorScale } from "./types.js";
 
-/** O(1) assignment rank, or -1 when scale/field does not apply. */
+/**
+ * O(1) assignment rank, or -1 when scale/field does not apply.
+ * `readValue` is a thunk so sequential/null scales never force a cell read.
+ */
 export function ordinalColorRank(
   resolved: ResolvedColorScale | null,
   field: string | null | undefined,
-  value: CellValue,
+  readValue: () => CellValue,
 ): number {
   if (resolved?.kind !== "ordinal" || field === null || field === undefined) return -1;
-  return resolved.scale.indexOf(value) ?? -1;
+  return resolved.scale.indexOf(readValue()) ?? -1;
 }
 
 export function ordinalSeriesRank(input: {
@@ -31,7 +34,7 @@ export function ordinalSeriesRank(input: {
 }): number {
   const { color, fill, colorField, fillField, sourceRow, sourceValue, group } = input;
   if (sourceRow === null) return group;
-  const colorRank = ordinalColorRank(color, colorField, sourceValue(colorField));
-  const fillRank = ordinalColorRank(fill, fillField, sourceValue(fillField));
+  const colorRank = ordinalColorRank(color, colorField, () => sourceValue(colorField));
+  const fillRank = ordinalColorRank(fill, fillField, () => sourceValue(fillField));
   return colorRank >= 0 ? colorRank : fillRank >= 0 ? fillRank : group;
 }

--- a/packages/core/src/pipeline/frame-candidates.ts
+++ b/packages/core/src/pipeline/frame-candidates.ts
@@ -1,12 +1,12 @@
 /**
  * Candidate-store datum factories derived from bound layers.
  */
-import { bandKey } from "../scales/train.js";
 import type { CellValue } from "../table.js";
 import type { ColumnTable } from "../table.js";
 import type { CandidateBuildFacts, CandidateDatum } from "../candidate-store.js";
 import type { LineageStore } from "../identity.js";
 
+import { ordinalColorRank } from "./build-candidates-datum-ordinal-rank.js";
 import { candidateAutoMode } from "./frame-candidates-auto-mode.js";
 import type { LayerBinding, ResolvedColorScale } from "./types.js";
 import { deriveLayerGroups } from "./frame-helpers.js";
@@ -37,13 +37,8 @@ export function createRawCandidateDatumResolver(
     const value = (field: string | null): CellValue =>
       field === null ? null : table.column(field)[sourceRow]!;
     const group = groupsFor(facts.layerIndex)[sourceRow] ?? 0;
-    const ordinalRank = (resolved: ResolvedColorScale | null, field: string | null) => {
-      if (resolved?.kind !== "ordinal" || field === null) return -1;
-      const key = bandKey(value(field));
-      return resolved.scale.domain.findIndex((domainValue) => bandKey(domainValue) === key);
-    };
-    const colorRank = ordinalRank(color, binding.color.field);
-    const fillRank = ordinalRank(fill, binding.fill.field);
+    const colorRank = ordinalColorRank(color, binding.color.field, value(binding.color.field));
+    const fillRank = ordinalColorRank(fill, binding.fill.field, value(binding.fill.field));
     return {
       xValue: value(binding.xField),
       yValue: value(binding.yField),

--- a/packages/core/src/pipeline/frame-candidates.ts
+++ b/packages/core/src/pipeline/frame-candidates.ts
@@ -37,8 +37,10 @@ export function createRawCandidateDatumResolver(
     const value = (field: string | null): CellValue =>
       field === null ? null : table.column(field)[sourceRow]!;
     const group = groupsFor(facts.layerIndex)[sourceRow] ?? 0;
-    const colorRank = ordinalColorRank(color, binding.color.field, value(binding.color.field));
-    const fillRank = ordinalColorRank(fill, binding.fill.field, value(binding.fill.field));
+    const colorRank = ordinalColorRank(color, binding.color.field, () =>
+      value(binding.color.field),
+    );
+    const fillRank = ordinalColorRank(fill, binding.fill.field, () => value(binding.fill.field));
     return {
       xValue: value(binding.xField),
       yValue: value(binding.yField),

--- a/packages/core/src/scales/train.ts
+++ b/packages/core/src/scales/train.ts
@@ -433,7 +433,7 @@ export function trainColor(
   return {
     type: "ordinal",
     domain: result.domain,
-    indexOf: result.indexOf,
+    indexOf: (value: unknown) => result.indexOf(value),
     colorOf: (value: unknown) => result.rangeValueOf(value) as string | undefined,
     state: result.state,
     warnings: result.warnings,

--- a/packages/core/src/scales/train.ts
+++ b/packages/core/src/scales/train.ts
@@ -149,6 +149,11 @@ export interface ColorScale {
   type: "ordinal";
   /** Present domain values in stable assignment order. */
   domain: readonly unknown[];
+  /**
+   * Assignment rank of a value (undefined = unknown). O(1) via the training
+   * encodeKey map — same keying as `colorOf`, not presentation `bandKey`.
+   */
+  indexOf(value: unknown): number | undefined;
   /** Resolved color for a value (undefined = unknown). */
   colorOf(value: unknown): string | undefined;
   /** Serializable value-stable state — commit only for the latest run. */
@@ -428,6 +433,7 @@ export function trainColor(
   return {
     type: "ordinal",
     domain: result.domain,
+    indexOf: result.indexOf,
     colorOf: (value: unknown) => result.rangeValueOf(value) as string | undefined,
     state: result.state,
     warnings: result.warnings,

--- a/packages/core/tests/pipeline-build-candidates.test.ts
+++ b/packages/core/tests/pipeline-build-candidates.test.ts
@@ -57,6 +57,31 @@ describe("ordinalSeriesRank", () => {
     ).toBe(3);
   });
 
+  it("does not read source cells when color/fill are non-ordinal", () => {
+    // Sequential/null scales must not force table.column / sourceValue lookups
+    // for seriesRank (eager arg evaluation would regress continuous color paths).
+    let reads = 0;
+    const sequential = {
+      kind: "sequential" as const,
+      scale: { domain: [0, 1] as [number, number], colorOf: () => "#000" },
+    };
+    expect(
+      ordinalSeriesRank({
+        color: sequential,
+        fill: sequential,
+        colorField: "c",
+        fillField: "f",
+        sourceRow: 0,
+        sourceValue: () => {
+          reads += 1;
+          return "x";
+        },
+        group: 4,
+      }),
+    ).toBe(4);
+    expect(reads).toBe(0);
+  });
+
   it("returns encodeKey assignment ranks from the ordinal color scale", () => {
     // 1 vs "1" must not collapse under presentation bandKey.
     const scale = trainColor([1, "1", "b"]);

--- a/packages/core/tests/pipeline-build-candidates.test.ts
+++ b/packages/core/tests/pipeline-build-candidates.test.ts
@@ -14,6 +14,7 @@ import { aes, gg } from "@ggsvelte/spec";
 import { ordinalSeriesRank } from "../src/pipeline/build-candidates-datum-context.ts";
 import { resolveCandidateLogicalValues } from "../src/pipeline/build-candidates-datum-values.ts";
 import { runPipeline } from "../src/pipeline.ts";
+import { trainColor } from "../src/scales/train.ts";
 import { ColumnTable } from "../src/table.ts";
 
 const size = { width: 640, height: 400 };
@@ -54,6 +55,104 @@ describe("ordinalSeriesRank", () => {
         group: 3,
       }),
     ).toBe(3);
+  });
+
+  it("returns encodeKey assignment ranks from the ordinal color scale", () => {
+    // 1 vs "1" must not collapse under presentation bandKey.
+    const scale = trainColor([1, "1", "b"]);
+    expect(
+      ordinalSeriesRank({
+        color: { kind: "ordinal", scale },
+        fill: null,
+        colorField: "c",
+        fillField: undefined,
+        sourceRow: 0,
+        sourceValue: (field) => (field === "c" ? "1" : null),
+        group: 99,
+      }),
+    ).toBe(1);
+    expect(
+      ordinalSeriesRank({
+        color: { kind: "ordinal", scale },
+        fill: null,
+        colorField: "c",
+        fillField: undefined,
+        sourceRow: 0,
+        sourceValue: (field) => (field === "c" ? 1 : null),
+        group: 99,
+      }),
+    ).toBe(0);
+  });
+
+  it("prefers color rank over fill; falls back to fill then group", () => {
+    const color = trainColor(["red-series"]);
+    const fill = trainColor(["a", "b", "c"]);
+    expect(
+      ordinalSeriesRank({
+        color: { kind: "ordinal", scale: color },
+        fill: { kind: "ordinal", scale: fill },
+        colorField: "color",
+        fillField: "fill",
+        sourceRow: 0,
+        sourceValue: (field) => (field === "color" ? "red-series" : "c"),
+        group: 5,
+      }),
+    ).toBe(0);
+    expect(
+      ordinalSeriesRank({
+        color: null,
+        fill: { kind: "ordinal", scale: fill },
+        colorField: undefined,
+        fillField: "fill",
+        sourceRow: 0,
+        sourceValue: (field) => (field === "fill" ? "c" : null),
+        group: 5,
+      }),
+    ).toBe(2);
+    expect(
+      ordinalSeriesRank({
+        color: { kind: "ordinal", scale: color },
+        fill: { kind: "ordinal", scale: fill },
+        colorField: "color",
+        fillField: "fill",
+        sourceRow: 0,
+        sourceValue: () => "unknown",
+        group: 5,
+      }),
+    ).toBe(5);
+  });
+
+  it("does not linear-scan the ordinal domain per candidate", () => {
+    const domain = Array.from({ length: 50 }, (_, i) => `s${i}`);
+    const scale = trainColor(domain);
+    const findIndexSpy = spyOn(Array.prototype, "findIndex").mockImplementation(function (
+      this: unknown[],
+      ...args: Parameters<Array<unknown>["findIndex"]>
+    ) {
+      // Only fail if the scan targets the scale domain (the O(n·d) path).
+      if (this === scale.domain || this === domain) {
+        throw new Error(`ordinalSeriesRank used domain.findIndex(${String(args[0])})`);
+      }
+      return Array.prototype.findIndex.apply(this, args as never);
+    });
+    try {
+      for (let i = 0; i < domain.length; i++) {
+        const value = domain[i]!;
+        expect(
+          ordinalSeriesRank({
+            color: { kind: "ordinal", scale },
+            fill: null,
+            colorField: "c",
+            fillField: undefined,
+            sourceRow: i,
+            sourceValue: () => value,
+            group: 0,
+          }),
+        ).toBe(i);
+      }
+    } finally {
+      findIndexSpy.mockRestore();
+    }
   });
 });
 
@@ -116,6 +215,34 @@ describe("buildPipelineCandidates via runPipeline", () => {
     expect(c0!.xValue).toBe(1);
     expect(c0!.yValue).toBe(10);
     expect(model.lineage.count(c0!.lineage)).toBe(1);
+  });
+
+  it("ordinal color seriesRank matches encodeKey assignment order (1 vs '1')", () => {
+    const model = runPipeline(
+      gg(
+        [
+          { x: 0, y: 1, c: 1 },
+          { x: 1, y: 2, c: "1" },
+          { x: 2, y: 3, c: "b" },
+        ],
+        aes({ x: "x", y: "y", color: "c" }),
+      )
+        .geomPoint()
+        .spec(),
+      size,
+    );
+    const ranks = Array.from({ length: model.candidates.size }, (_, id) => {
+      const c = model.candidates.candidate(id)!;
+      return { c: c.xValue, rank: c.seriesRank };
+    }).toSorted((a, b) => Number(a.c) - Number(b.c));
+    // First-seen color values: 1 → rank 0, "1" → rank 1, "b" → rank 2
+    expect(ranks.map((r) => r.rank)).toEqual([0, 1, 2]);
+    expect(model.scales.color?.kind).toBe("ordinal");
+    if (model.scales.color?.kind === "ordinal") {
+      expect(model.scales.color.scale.indexOf(1)).toBe(0);
+      expect(model.scales.color.scale.indexOf("1")).toBe(1);
+      expect(model.scales.color.scale.indexOf("b")).toBe(2);
+    }
   });
 
   it("count bars reconstruct aggregate lineages for represented source rows", () => {

--- a/packages/core/tests/pipeline-types.test.ts
+++ b/packages/core/tests/pipeline-types.test.ts
@@ -25,9 +25,17 @@ describe("pipeline types contract", () => {
     const resolved: ResolvedColorScale = {
       kind: "ordinal",
       scale: {
+        type: "ordinal",
         domain: ["a"],
+        indexOf: (v: unknown) => (v === "a" ? 0 : undefined),
         colorOf: (v: unknown) => (v === "a" ? "#111111" : undefined),
-        state: { domain: ["a"], assignments: { a: 0 }, scheme: "test", reverse: false },
+        state: {
+          version: 1,
+          fingerprint: "test",
+          assignments: [["a", 0]],
+          nextIndex: 1,
+          exhaustWarned: false,
+        },
         warnings: [],
       },
     };

--- a/packages/core/tests/scales-train.test.ts
+++ b/packages/core/tests/scales-train.test.ts
@@ -161,4 +161,19 @@ describe("trainColor (value-stable, decision 0002)", () => {
     const second = trainColor(["y", "z"], revived);
     expect(second.colorOf("y")).toBe(first.colorOf("y"));
   });
+
+  it("exposes O(1) indexOf keyed like color assignment (encodeKey)", () => {
+    // Rank must match palette assignment: 1 and "1" are distinct categories.
+    const scale = trainColor([1, "1", true, "true"]);
+    expect(scale.indexOf(1)).toBe(0);
+    expect(scale.indexOf("1")).toBe(1);
+    expect(scale.indexOf(true)).toBe(2);
+    expect(scale.indexOf("true")).toBe(3);
+    expect(scale.indexOf("missing")).toBeUndefined();
+    // Value-stable: removed series keep assignment ranks for survivors.
+    const afterDrop = trainColor([1, true], scale.state);
+    expect(afterDrop.indexOf(1)).toBe(0);
+    expect(afterDrop.indexOf(true)).toBe(2);
+    expect(afterDrop.indexOf("1")).toBe(1); // still in assignment map
+  });
 });


### PR DESCRIPTION
## Summary

- Expose `ColorScale.indexOf` from the existing `encodeKey` assignment map built during ordinal color training.
- Resolve candidate `seriesRank` with O(1) lookups instead of `domain.findIndex` + `bandKey` (O(n·d), type-collapsing).
- Share `ordinalColorRank` between identity and source-backed candidate paths so ranks match color assignment (e.g. `1` vs `"1"` stay distinct).

Closes #215.

## Test plan

- [x] Unit: `trainColor` exposes encodeKey-stable `indexOf` (including value-stable ranks after series drop).
- [x] Unit: `ordinalSeriesRank` returns correct ranks for typed collisions, color/fill priority, and group fallback.
- [x] Unit: spies confirm no `domain.findIndex` on the ordinal domain during rank resolution.
- [x] Integration: `runPipeline` point layer with ordinal color yields seriesRanks matching first-seen assignment order for `1` / `"1"` / `"b"`.
- [x] Full `@ggsvelte/core` suite (589 tests) + pre-push typecheck/knip/lint.