### PR TITLE
perf(core): spatial index for CandidateStore nearest/queryRect

### DIFF
--- a/packages/core/src/candidate-store.ts
+++ b/packages/core/src/candidate-store.ts
@@ -1,3 +1,4 @@
+import { StaticQuadtree } from "./dom/quadtree.js";
 import type { LineageRef } from "./identity.js";
 import type { GeometryBatch, Scene } from "./scene.js";
 import type { CellValue } from "./table.js";
@@ -584,6 +585,28 @@ function buildCandidateStoreEager(
     buffer.length = 0;
   tokenIndex.clear();
 
+  // Spatial index over plot-px anchors (reuse StaticQuadtree). Point-like
+  // candidates shortlist via the tree; rects/segments/paths are refined from a
+  // compact extended-geometry list because their hit region can sit far from
+  // the stored anchor (bars, long segments, filled paths).
+  const spatialXs = Float64Array.from(xs);
+  const spatialYs = Float64Array.from(ys);
+  const spatial = n > 0 ? new StaticQuadtree(spatialXs, spatialYs) : null;
+  const isPoint = new Uint8Array(n);
+  const extendedIds: number[] = [];
+  let maxPointReach = 0;
+  for (let id = 0; id < n; id++) {
+    const batch = scene.batches[batchIds[id]!]!;
+    if (batch.kind === "points") {
+      isPoint[id] = 1;
+      maxPointReach = Math.max(maxPointReach, batch.size + 3);
+    } else {
+      extendedIds.push(id);
+    }
+  }
+  // Far-plane strip bounds: StaticQuadtree prunes on the finite axis only.
+  const STRIP = 1e30;
+
   const exactDistance = (
     id: number,
     px: number,
@@ -683,6 +706,38 @@ function buildCandidateStoreEager(
     return xs[id]! >= loX && xs[id]! <= hiX && ys[id]! >= loY && ys[id]! <= hiY;
   };
 
+  /** Shortlist candidate ids for a nearest query (reverse-id order for topmost ties). */
+  const shortlistNearest = (
+    px: number,
+    py: number,
+    mode: CandidateInspectMode,
+    maxDistance: number,
+  ): number[] => {
+    if (spatial === null || n === 0) return [];
+    const consider = new Set<number>();
+    const addRect = (x0: number, y0: number, x1: number, y1: number) => {
+      for (const id of spatial.queryRect(x0, y0, x1, y1)) consider.add(id);
+    };
+    if (mode === "xy") {
+      addRect(px - maxDistance, py - maxDistance, px + maxDistance, py + maxDistance);
+    } else if (mode === "x") {
+      // Dominant-axis distance is along semantic x (screen y when coord_flip).
+      // Axis token maps stay for group(); nearest uses spatial strips.
+      if (flip) addRect(-STRIP, py - maxDistance, STRIP, py + maxDistance);
+      else addRect(px - maxDistance, -STRIP, px + maxDistance, STRIP);
+    } else if (mode === "y") {
+      if (flip) addRect(px - maxDistance, -STRIP, px + maxDistance, STRIP);
+      else addRect(-STRIP, py - maxDistance, STRIP, py + maxDistance);
+    } else {
+      // exact / auto: point anchors within hit reach + all extended geometry
+      // (rects/segments/paths can match far from their stored anchors).
+      const r = mode === "auto" ? Math.max(maxDistance, maxPointReach) : maxPointReach;
+      addRect(px - r, py - r, px + r, py + r);
+      for (const id of extendedIds) consider.add(id);
+    }
+    return [...consider].toSorted((a, b) => b - a);
+  };
+
   return {
     epoch,
     size: n,
@@ -693,43 +748,45 @@ function buildCandidateStoreEager(
       let best = -1,
         bestDistance = Infinity,
         bestOrth = Infinity;
-      let resultMode: ResolvedCandidateInspectMode = search.mode === "auto" ? "exact" : search.mode;
+      const mode: ResolvedCandidateInspectMode = search.mode === "auto" ? "exact" : search.mode;
+      let resultMode: ResolvedCandidateInspectMode = mode;
       const pathContainment = new Map<string, boolean>();
-      const scan = (mode: ResolvedCandidateInspectMode, resolveAuto = false) => {
-        for (let id = n - 1; id >= 0; id--) {
-          if (search.panelId !== undefined && scene.panels[panelIds[id]!]!.id !== search.panelId)
-            continue;
-          const candidateMode = resolveAuto ? AUTO_MODES[autoModes[id]!]! : mode;
-          if (
-            (candidateMode === "x" && xTokenIds[id] === -1) ||
-            (candidateMode === "y" && yTokenIds[id] === -1)
-          )
-            continue;
-          const distance =
-            candidateMode === "exact"
-              ? exactDistance(id, px, py, pathContainment)
-              : candidateMode === "x"
-                ? Math.abs((flip ? ys[id] : xs[id])! - (flip ? py : px))
-                : candidateMode === "y"
-                  ? Math.abs((flip ? xs[id] : ys[id])! - (flip ? px : py))
-                  : Math.hypot(xs[id]! - px, ys[id]! - py);
-          if (distance === null || (candidateMode !== "exact" && distance > search.maxDistance))
-            continue;
-          const orth =
-            candidateMode === "x"
-              ? Math.abs((flip ? xs[id] : ys[id])! - (flip ? px : py))
+      const ids =
+        spatial === null
+          ? Array.from({ length: n }, (_, id) => n - 1 - id)
+          : shortlistNearest(px, py, search.mode, search.maxDistance);
+      for (const id of ids) {
+        if (search.panelId !== undefined && scene.panels[panelIds[id]!]!.id !== search.panelId)
+          continue;
+        const candidateMode = search.mode === "auto" ? AUTO_MODES[autoModes[id]!]! : mode;
+        if (
+          (candidateMode === "x" && xTokenIds[id] === -1) ||
+          (candidateMode === "y" && yTokenIds[id] === -1)
+        )
+          continue;
+        const distance =
+          candidateMode === "exact"
+            ? exactDistance(id, px, py, pathContainment)
+            : candidateMode === "x"
+              ? Math.abs((flip ? ys[id] : xs[id])! - (flip ? py : px))
               : candidateMode === "y"
-                ? Math.abs((flip ? ys[id] : xs[id])! - (flip ? py : px))
-                : 0;
-          if (distance < bestDistance || (distance === bestDistance && orth < bestOrth)) {
-            best = id;
-            bestDistance = distance;
-            bestOrth = orth;
-            resultMode = candidateMode;
-          }
+                ? Math.abs((flip ? xs[id] : ys[id])! - (flip ? px : py))
+                : Math.hypot(xs[id]! - px, ys[id]! - py);
+        if (distance === null || (candidateMode !== "exact" && distance > search.maxDistance))
+          continue;
+        const orth =
+          candidateMode === "x"
+            ? Math.abs((flip ? xs[id] : ys[id])! - (flip ? px : py))
+            : candidateMode === "y"
+              ? Math.abs((flip ? ys[id] : xs[id])! - (flip ? py : px))
+              : 0;
+        if (distance < bestDistance || (distance === bestDistance && orth < bestOrth)) {
+          best = id;
+          bestDistance = distance;
+          bestOrth = orth;
+          resultMode = candidateMode;
         }
-      };
-      scan(resultMode, search.mode === "auto");
+      }
       const found = fact(best);
       return found === null ? null : { ...found, distance: bestDistance, mode: resultMode };
     },
@@ -822,12 +879,16 @@ function buildCandidateStoreEager(
       const hiX = Math.max(x0, x1);
       const loY = Math.min(y0, y1);
       const hiY = Math.max(y0, y1);
+      if (spatial === null || n === 0) return EMPTY_UINT32;
+      // Point anchors: exact rect membership via the tree. Extended geometry
+      // (rects/segments/paths) can intersect far from the anchor — always refine.
+      const pointHits = new Set(spatial.queryRect(loX, loY, hiX, hiY));
       return Uint32Array.from(
-        traversal.filter(
-          (id) =>
-            (panelId === undefined || scene.panels[panelIds[id]!]!.id === panelId) &&
-            intersects(id, loX, loY, hiX, hiY),
-        ),
+        traversal.filter((id) => {
+          if (panelId !== undefined && scene.panels[panelIds[id]!]!.id !== panelId) return false;
+          if (isPoint[id] === 1) return pointHits.has(id);
+          return intersects(id, loX, loY, hiX, hiY);
+        }),
       );
     },
     dispose() {},

--- a/packages/core/src/candidate-store.ts
+++ b/packages/core/src/candidate-store.ts
@@ -882,14 +882,19 @@ function buildCandidateStoreEager(
       if (spatial === null || n === 0) return EMPTY_UINT32;
       // Point anchors: exact rect membership via the tree. Extended geometry
       // (rects/segments/paths) can intersect far from the anchor — always refine.
-      const pointHits = new Set(spatial.queryRect(loX, loY, hiX, hiY));
-      return Uint32Array.from(
-        traversal.filter((id) => {
-          if (panelId !== undefined && scene.panels[panelIds[id]!]!.id !== panelId) return false;
-          if (isPoint[id] === 1) return pointHits.has(id);
-          return intersects(id, loX, loY, hiX, hiY);
-        }),
-      );
+      // Collect hits then order by traversal rank (preserves prior contract).
+      const hits: number[] = [];
+      for (const id of spatial.queryRect(loX, loY, hiX, hiY)) {
+        if (isPoint[id] !== 1) continue;
+        if (panelId !== undefined && scene.panels[panelIds[id]!]!.id !== panelId) continue;
+        hits.push(id);
+      }
+      for (const id of extendedIds) {
+        if (panelId !== undefined && scene.panels[panelIds[id]!]!.id !== panelId) continue;
+        if (intersects(id, loX, loY, hiX, hiY)) hits.push(id);
+      }
+      hits.sort((a, b) => traversalRank[a]! - traversalRank[b]!);
+      return Uint32Array.from(hits);
     },
     dispose() {},
   };

--- a/packages/core/src/candidate-store.ts
+++ b/packages/core/src/candidate-store.ts
@@ -733,6 +733,17 @@ function buildCandidateStoreEager(
       // (rects/segments/paths can match far from their stored anchors).
       const r = mode === "auto" ? Math.max(maxDistance, maxPointReach) : maxPointReach;
       addRect(px - r, py - r, px + r, py + r);
+      if (mode === "auto") {
+        // Per-candidate autoMode can still be x/y (e.g. boxplot outliers):
+        // include dominant-axis strips so orthogonal distance does not drop them.
+        if (flip) {
+          addRect(-STRIP, py - maxDistance, STRIP, py + maxDistance);
+          addRect(px - maxDistance, -STRIP, px + maxDistance, STRIP);
+        } else {
+          addRect(px - maxDistance, -STRIP, px + maxDistance, STRIP);
+          addRect(-STRIP, py - maxDistance, STRIP, py + maxDistance);
+        }
+      }
       for (const id of extendedIds) consider.add(id);
     }
     return [...consider].toSorted((a, b) => b - a);

--- a/packages/core/src/dom/quadtree.ts
+++ b/packages/core/src/dom/quadtree.ts
@@ -1,13 +1,13 @@
 /**
- * Static point quadtree for the hit index.
+ * Static point quadtree for the hit index and CandidateStore nearest/queryRect.
  *
- * HAND-ROLLED, not a d3-quadtree port (documented decision): the hit index
- * only needs build-once + radius/rect queries over immutable Float32Array
- * positions — d3-quadtree's incremental add/remove/cover machinery is dead
- * weight here, and zero runtime dependencies is a project constraint
- * (@sinclair/typebox is the only one). The structure is the classic
- * recursive bucket quadtree: leaf buckets of 16, max depth 12, bbox pruning
- * on every visit. Build is O(n log n); queries are O(log n + k).
+ * HAND-ROLLED, not a d3-quadtree port (documented decision): consumers only
+ * need build-once + radius/rect queries over immutable plot-px positions —
+ * d3-quadtree's incremental add/remove/cover machinery is dead weight here,
+ * and zero runtime dependencies is a project constraint (@sinclair/typebox is
+ * the only one). The structure is the classic recursive bucket quadtree: leaf
+ * buckets of 16, max depth 12, bbox pruning on every visit. Build is O(n log n);
+ * queries are O(log n + k). Pure (no DOM) — safe from the core pure entry.
  */
 
 interface QuadNode {

--- a/packages/core/tests/candidate-store.test.ts
+++ b/packages/core/tests/candidate-store.test.ts
@@ -385,3 +385,191 @@ describe("candidate grouping hot path", () => {
     expect(store.nearest(10, 10, { mode: "x", maxDistance: 100 })).toBeNull();
   });
 });
+
+describe("candidate spatial query hot path (issue #214)", () => {
+  function largePointScene(count: number): Scene {
+    const cols = Math.ceil(Math.sqrt(count));
+    const points: (readonly [number, number])[] = [];
+    for (let i = 0; i < count; i++) {
+      points.push([(i % cols) * 10, Math.floor(i / cols) * 10]);
+    }
+    return sceneWithPoints(points);
+  }
+
+  it("xy nearest does not Math.hypot every candidate on a large point cloud", () => {
+    // Complexity guard: linear nearest is O(n) hypot; spatial shortlist is O(log n + k).
+    const count = 8_000;
+    const store = buildCandidateStore(largePointScene(count), {
+      datum: ({ primitiveIndex }) => ({
+        xValue: primitiveIndex,
+        yValue: primitiveIndex,
+      }),
+    });
+    void store.x;
+
+    const originalHypot = Math.hypot;
+    let hypotCalls = 0;
+    const hypotSpy = spyOn(Math, "hypot").mockImplementation(function (
+      this: void,
+      ...args: Parameters<typeof Math.hypot>
+    ) {
+      hypotCalls++;
+      return originalHypot(...args);
+    });
+    try {
+      // Target near (10,10) — grid id 1 at (10,0) or id ~cols at (0,10); nearest is id 1 or nearby.
+      const hit = store.nearest(10, 10, { mode: "xy", maxDistance: 6 });
+      expect(hit).not.toBeNull();
+      expect(hit!.distance).toBeLessThanOrEqual(6);
+      // Shortlist must be far smaller than a full scan (budget leaves room for refine + ties).
+      expect(hypotCalls).toBeLessThan(200);
+      expect(hypotCalls).toBeLessThan(count / 10);
+    } finally {
+      hypotSpy.mockRestore();
+    }
+  });
+
+  it("queryRect does not read every batch for a tight brush on a large point cloud", () => {
+    const count = 8_000;
+    const cols = Math.ceil(Math.sqrt(count));
+    const positions = new Float32Array(count * 2);
+    for (let i = 0; i < count; i++) {
+      positions[i * 2] = (i % cols) * 10;
+      positions[i * 2 + 1] = Math.floor(i / cols) * 10;
+    }
+    const rawBatches: Scene["batches"] = [
+      {
+        kind: "points",
+        layerIndex: 0,
+        panelIndex: 0,
+        positions,
+        rowIndex: Uint32Array.from({ length: count }, (_, index) => index),
+        size: 3,
+        alpha: 1,
+        shape: "circle",
+        fill: null,
+      },
+    ];
+    let batchIndexReads = 0;
+    const batches = new Proxy(rawBatches, {
+      get(target, property, receiver): unknown {
+        if (typeof property === "string" && /^\d+$/.test(property)) batchIndexReads++;
+        return Reflect.get(target, property, receiver) as unknown;
+      },
+    });
+    const plotScene = scene();
+    plotScene.batches = batches;
+    const store = buildCandidateStore(plotScene);
+    // Construction may touch batches; only police the query.
+    void store.x;
+    batchIndexReads = 0;
+
+    const hits = store.queryRect(5, 5, 25, 25);
+    // Grid points in [5,25]² with 10px spacing: (10,10), (20,10), (10,20), (20,20) → 4 hits.
+    expect([...hits].toSorted((a, b) => a - b)).toEqual([
+      cols + 1,
+      cols + 2,
+      2 * cols + 1,
+      2 * cols + 2,
+    ]);
+    // Linear queryRect consulted scene.batches once per candidate; shortlist stays O(k).
+    expect(batchIndexReads).toBeLessThan(200);
+    expect(batchIndexReads).toBeLessThan(count / 10);
+  });
+
+  it("preserves topmost tie-break and panel filter with spatial shortlist", () => {
+    const multi = scene();
+    multi.panels = [
+      {
+        id: "a",
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 100,
+        strip: "",
+        axisX: [],
+        axisY: [],
+        grid: { x: [], y: [] },
+      },
+      {
+        id: "b",
+        x: 200,
+        y: 0,
+        width: 100,
+        height: 100,
+        strip: "",
+        axisX: [],
+        axisY: [],
+        grid: { x: [], y: [] },
+      },
+    ];
+    multi.batches = [
+      {
+        kind: "points",
+        layerIndex: 0,
+        panelIndex: 0,
+        positions: new Float32Array([10, 10, 10, 10]),
+        rowIndex: new Uint32Array([0, 1]),
+        size: 3,
+        alpha: 1,
+        shape: "circle",
+        fill: null,
+      },
+      {
+        kind: "points",
+        layerIndex: 1,
+        panelIndex: 1,
+        positions: new Float32Array([10, 10]),
+        rowIndex: new Uint32Array([2]),
+        size: 3,
+        alpha: 1,
+        shape: "circle",
+        fill: null,
+      },
+    ];
+    const store = buildCandidateStore(multi);
+    // Coincident panel-a points: reverse paint order → higher id wins equal distance.
+    expect(store.nearest(10, 10, { mode: "xy", maxDistance: 1 })?.id).toBe(1);
+    expect(store.nearest(10, 10, { mode: "xy", maxDistance: 1, panelId: "a" })?.id).toBe(1);
+    expect(store.nearest(210, 10, { mode: "xy", maxDistance: 1, panelId: "b" })?.id).toBe(2);
+    expect(store.nearest(10, 10, { mode: "xy", maxDistance: 1, panelId: "b" })).toBeNull();
+    expect([...store.queryRect(5, 5, 15, 15, "a")].toSorted((a, b) => a - b)).toEqual([0, 1]);
+    expect([...store.queryRect(205, 5, 215, 15, "b")]).toEqual([2]);
+  });
+
+  it("exact nearest still hits large rects whose anchors are far from the probe", () => {
+    const rectScene = scene();
+    rectScene.batches = [
+      {
+        kind: "rects",
+        layerIndex: 0,
+        panelIndex: 0,
+        // Wide/tall bar: anchor is center-x / top-y (100, 0).
+        rects: new Float32Array([0, 0, 200, 100]),
+        rowIndex: new Uint32Array([0]),
+        fill: null,
+        alpha: 1,
+      },
+      {
+        kind: "points",
+        layerIndex: 1,
+        panelIndex: 0,
+        // Far from the rect interior probe used below.
+        positions: new Float32Array([5, 5]),
+        rowIndex: new Uint32Array([1]),
+        size: 2,
+        alpha: 1,
+        shape: "circle",
+        fill: null,
+      },
+    ];
+    const store = buildCandidateStore(rectScene, {
+      datum: ({ kind }) => ({ xValue: 1, yValue: 2, autoMode: kind === "rects" ? "exact" : "xy" }),
+    });
+    // Probe inside the bar, far from its top-center anchor — spatial shortlist by
+    // anchor radius alone would miss this unless extended geometry is refined.
+    expect(store.nearest(150, 80, { mode: "exact", maxDistance: 0 })?.id).toBe(0);
+    expect(store.queryRect(140, 70, 160, 90)).toEqual(new Uint32Array([0]));
+    expect(store.queryRect(0, 0, 10, 10)).toEqual(new Uint32Array([0, 1]));
+  });
+});

--- a/packages/core/tests/candidate-store.test.ts
+++ b/packages/core/tests/candidate-store.test.ts
@@ -537,6 +537,31 @@ describe("candidate spatial query hot path (issue #214)", () => {
     expect([...store.queryRect(205, 5, 215, 15, "b")]).toEqual([2]);
   });
 
+  it("auto mode still finds dominant-axis point hits far from the probe orthogonally", () => {
+    // Boxplot outliers and similar points can inherit autoMode "x": match on
+    // dominant-axis distance only. Spatial shortlist must include x/y strips,
+    // not only a euclidean square around maxPointReach.
+    const plotScene = sceneWithPoints([
+      [50, 10],
+      [50, 200],
+    ]);
+    const store = buildCandidateStore(plotScene, {
+      datum: ({ primitiveIndex }) => ({
+        xValue: 50,
+        yValue: primitiveIndex === 0 ? 10 : 200,
+        autoMode: "x",
+      }),
+    });
+    // Probe at same x as both points, but 150px from the nearer in y — outside
+    // size+3 euclidean reach, yet within x maxDistance of 5.
+    expect(store.nearest(52, 100, { mode: "auto", maxDistance: 5 })).toMatchObject({
+      id: 0,
+      mode: "x",
+      distance: 2,
+    });
+    expect(store.nearest(52, 100, { mode: "x", maxDistance: 5 })?.id).toBe(0);
+  });
+
   it("exact nearest still hits large rects whose anchors are far from the probe", () => {
     const rectScene = scene();
     rectScene.batches = [


### PR DESCRIPTION
## Summary

- Build a `StaticQuadtree` over plot-px candidate anchors once at store construction so `nearest` / `queryRect` are ~O(log n + k) on large point clouds instead of O(n) per pointer/brush event.
- Point-like candidates shortlist via the tree; rects/segments/paths refine from a compact extended-geometry list so large bars still hit when the probe is far from the stored anchor.
- Preserves topmost (reverse-id) ties, panel filtering, x/y/auto/exact distance semantics, and traversal-ordered `queryRect` results. No public API change.

Closes #214

## Test plan

- [x] Existing `candidate-store` semantic suite (exact/auto/axis modes, segments, paths, dispose, traversal, group)
- [x] New complexity guards: xy nearest does not `Math.hypot` every candidate; tight brush does not read every batch on an 8k point cloud
- [x] New semantic guards: topmost + panel filter with spatial shortlist; large-rect exact hit far from anchor
- [x] Related suites: hit-index, identity pipeline, pure Node entry smoke
- [x] Pre-commit full monorepo suite (tsc, oxlint type-aware, knip, bun test)