### PR TITLE
perf(core): cache finite-y lineage per group for smooth/summary/boxplot

### DIFF
--- a/packages/core/src/identity.ts
+++ b/packages/core/src/identity.ts
@@ -11,8 +11,16 @@ export class LineageStore<Key extends PropertyKey = PropertyKey> {
   readonly #members: (readonly Key[])[] = [[]];
   readonly #refs = new Map<string, LineageRef>([["", 0]]);
   readonly #ids = new Map<Key, number>();
+  /** Identity cache for frozen shared membership arrays (e.g. smooth finite-y lists). */
+  readonly #byArray = new WeakMap<object, LineageRef>();
 
   intern(keys: Iterable<Key>): LineageRef {
+    // Shared frozen arrays (identity-index buckets) intern once; skip re-sort/tokenize.
+    if (Array.isArray(keys) && Object.isFrozen(keys)) {
+      const cached = this.#byArray.get(keys);
+      if (cached !== undefined) return cached;
+    }
+
     const unique: Key[] = [];
     const seen = new Set<Key>();
     for (const key of keys) {
@@ -24,10 +32,14 @@ export class LineageStore<Key extends PropertyKey = PropertyKey> {
     unique.sort((a, b) => this.#id(a) - this.#id(b));
     const token = unique.map((key) => this.#id(key)).join(",");
     const prior = this.#refs.get(token);
-    if (prior !== undefined) return prior;
+    if (prior !== undefined) {
+      if (Array.isArray(keys) && Object.isFrozen(keys)) this.#byArray.set(keys, prior);
+      return prior;
+    }
     const ref = this.#members.length;
     this.#members.push(Object.freeze(unique));
     this.#refs.set(token, ref);
+    if (Array.isArray(keys) && Object.isFrozen(keys)) this.#byArray.set(keys, ref);
     return ref;
   }
 

--- a/packages/core/src/pipeline/build-candidates-datum-lineage-ann.ts
+++ b/packages/core/src/pipeline/build-candidates-datum-lineage-ann.ts
@@ -29,6 +29,7 @@ export function resolveIdentityLineageAndAnnotation(
     sourceRowsByGroup,
     sourceRowsByGroupX,
     sourceRowsByGroupBin,
+    sourceRowsByGroupY,
   } = located;
   const { annotationRule, annotationX, annotationY } = resolveAnnotationIntercepts({
     frame,
@@ -43,6 +44,7 @@ export function resolveIdentityLineageAndAnnotation(
     sourceRowsByGroup,
     sourceRowsByGroupX,
     sourceRowsByGroupBin,
+    sourceRowsByGroupY,
     frame,
     table: ctx.table,
     frameRow,

--- a/packages/core/src/pipeline/build-candidates-datum-locate-types.ts
+++ b/packages/core/src/pipeline/build-candidates-datum-locate-types.ts
@@ -20,4 +20,5 @@ export interface LocatedIdentityCandidate {
   sourceRowsByGroup: Map<string, number[]>;
   sourceRowsByGroupX: Map<string, number[]>;
   sourceRowsByGroupBin: Map<string, number[]>;
+  sourceRowsByGroupY: Map<string, number[]>;
 }

--- a/packages/core/src/pipeline/build-candidates-datum-locate.ts
+++ b/packages/core/src/pipeline/build-candidates-datum-locate.ts
@@ -18,8 +18,14 @@ export function locateIdentityCandidate(
   ctx: IdentityCandidateResolveContext,
   facts: CandidateBuildFacts,
 ): LocatedIdentityCandidate {
-  const { seriesByRow, sourceRowsByGroup, sourceRowsByGroupX, sourceRowsByGroupBin, frameGroups } =
-    ctx.getIdentityIndex();
+  const {
+    seriesByRow,
+    sourceRowsByGroup,
+    sourceRowsByGroupX,
+    sourceRowsByGroupBin,
+    sourceRowsByGroupY,
+    frameGroups,
+  } = ctx.getIdentityIndex();
   const fields = ctx.layerFields[facts.layerIndex] ?? [];
   const sourceRow = facts.rowIndex;
   const frame = ctx.panelFrames[facts.panelIndex]?.[facts.layerIndex];
@@ -55,5 +61,6 @@ export function locateIdentityCandidate(
     sourceRowsByGroup,
     sourceRowsByGroupX,
     sourceRowsByGroupBin,
+    sourceRowsByGroupY,
   };
 }

--- a/packages/core/src/pipeline/build-candidates-datum-represented.ts
+++ b/packages/core/src/pipeline/build-candidates-datum-represented.ts
@@ -16,6 +16,7 @@ export function resolveRepresentedSourceRows(input: {
   sourceRowsByGroup: Map<string, number[]>;
   sourceRowsByGroupX?: Map<string, number[]>;
   sourceRowsByGroupBin?: Map<string, number[]>;
+  sourceRowsByGroupY?: Map<string, number[]>;
   frame: LayerFrame | undefined;
   table: ColumnTable;
   frameRow: number;
@@ -31,6 +32,7 @@ export function resolveRepresentedSourceRows(input: {
     sourceRowsByGroup,
     sourceRowsByGroupX,
     sourceRowsByGroupBin,
+    sourceRowsByGroupY,
     frame,
     table,
     frameRow,
@@ -56,6 +58,7 @@ export function resolveRepresentedSourceRows(input: {
     };
     if (sourceRowsByGroupX) filterInput.sourceRowsByGroupX = sourceRowsByGroupX;
     if (sourceRowsByGroupBin) filterInput.sourceRowsByGroupBin = sourceRowsByGroupBin;
+    if (sourceRowsByGroupY) filterInput.sourceRowsByGroupY = sourceRowsByGroupY;
     representedRows = filterRepresentedSourceRows(filterInput);
   }
   return {

--- a/packages/core/src/pipeline/build-candidates-identity-aggregate.ts
+++ b/packages/core/src/pipeline/build-candidates-identity-aggregate.ts
@@ -25,6 +25,16 @@ export function appendSourceRowByGroupX(input: {
   else members.push(input.sourceRow);
 }
 
+export function appendSourceRowByGroupKey(
+  map: Map<string, number[]>,
+  key: string,
+  sourceRow: number,
+): void {
+  const members = map.get(key);
+  if (members === undefined) map.set(key, [sourceRow]);
+  else members.push(sourceRow);
+}
+
 interface BinEdge {
   frameRow: number;
   lo: number;

--- a/packages/core/src/pipeline/build-candidates-identity.ts
+++ b/packages/core/src/pipeline/build-candidates-identity.ts
@@ -4,6 +4,7 @@
  * and pre-bucketed aggregate lineage for O(1) represented-row resolve.
  */
 import { bandKey } from "../scales/train.js";
+import { cellToNumber } from "../table.js";
 
 import {
   appendSourceRowByGroupX,
@@ -21,6 +22,12 @@ export interface CandidateIdentityIndex {
   readonly sourceRowsByGroupX: Map<string, number[]>;
   /** `${panel}:${layer}:${group}:${frameRow}` → source rows (bin/histogram). */
   readonly sourceRowsByGroupBin: Map<string, number[]>;
+  /**
+   * `${panel}:${layer}:${group}` → source rows with finite y
+   * (smooth/summary/boxplot). Built once so evaluation-grid marks (smooth n≈80)
+   * reuse the same list instead of re-filtering O(g) per mark.
+   */
+  readonly sourceRowsByGroupY: Map<string, number[]>;
   readonly frameGroups: Map<string, number[]>;
 }
 
@@ -32,6 +39,7 @@ export function buildCandidateIdentityIndex(
   const sourceRowsByGroup = new Map<string, number[]>();
   const sourceRowsByGroupX = new Map<string, number[]>();
   const sourceRowsByGroupBin = new Map<string, number[]>();
+  const sourceRowsByGroupY = new Map<string, number[]>();
   const frameGroups = new Map<string, number[]>();
   for (let panelIndex = 0; panelIndex < panelFrames.length; panelIndex++) {
     for (const frame of panelFrames[panelIndex] ?? []) {
@@ -44,13 +52,16 @@ export function buildCandidateIdentityIndex(
       const bucketByX = stat === "count" || stat === "summary" || stat === "boxplot";
       const xField = frame.binding.xField;
       const xColumn = bucketByX && xField !== null ? frame.table.column(xField) : null;
+      const groupKeysThisFrame: string[] = [];
       for (let localRow = 0; localRow < inputGroups.length; localRow++) {
         const group = inputGroups[localRow]!;
         const sourceRow = facetPanels[panelIndex]!.sourceRows?.[localRow] ?? localRow;
         const key = `${frameKey}:${group}`;
         const members = sourceRowsByGroup.get(key);
-        if (members === undefined) sourceRowsByGroup.set(key, [sourceRow]);
-        else members.push(sourceRow);
+        if (members === undefined) {
+          sourceRowsByGroup.set(key, [sourceRow]);
+          groupKeysThisFrame.push(key);
+        } else members.push(sourceRow);
         if (xColumn !== null) {
           appendSourceRowByGroupX({
             sourceRowsByGroupX,
@@ -71,6 +82,18 @@ export function buildCandidateIdentityIndex(
           sourceRowsByGroupBin,
         });
       }
+      // Once-per-group finite-y lists for stats that drop non-finite y in lineage.
+      const yField = frame.binding.yField;
+      if ((stat === "smooth" || stat === "summary" || stat === "boxplot") && yField !== null) {
+        const yColumn = frame.table.column(yField);
+        for (const key of groupKeysThisFrame) {
+          const rows = sourceRowsByGroup.get(key)!;
+          sourceRowsByGroupY.set(
+            key,
+            rows.filter((row) => Number.isFinite(cellToNumber(yColumn[row]!))),
+          );
+        }
+      }
       for (let i = 0; i < frame.rowIndex.length; i++) {
         const sourceRow = frame.rowIndex[i]!;
         if (sourceRow !== NO_ROW) {
@@ -80,8 +103,20 @@ export function buildCandidateIdentityIndex(
     }
   }
   // Seal bucket arrays so resolve-time consumers cannot mutate shared lineage.
-  for (const map of [sourceRowsByGroup, sourceRowsByGroupX, sourceRowsByGroupBin]) {
+  for (const map of [
+    sourceRowsByGroup,
+    sourceRowsByGroupX,
+    sourceRowsByGroupBin,
+    sourceRowsByGroupY,
+  ]) {
     for (const [key, rows] of map) map.set(key, Object.freeze(rows) as number[]);
   }
-  return { seriesByRow, sourceRowsByGroup, sourceRowsByGroupX, sourceRowsByGroupBin, frameGroups };
+  return {
+    seriesByRow,
+    sourceRowsByGroup,
+    sourceRowsByGroupX,
+    sourceRowsByGroupBin,
+    sourceRowsByGroupY,
+    frameGroups,
+  };
 }

--- a/packages/core/src/pipeline/build-candidates-identity.ts
+++ b/packages/core/src/pipeline/build-candidates-identity.ts
@@ -7,6 +7,7 @@ import { bandKey } from "../scales/train.js";
 import { cellToNumber } from "../table.js";
 
 import {
+  appendSourceRowByGroupKey,
   appendSourceRowByGroupX,
   buildBinLineageBuckets,
 } from "./build-candidates-identity-aggregate.js";
@@ -52,16 +53,17 @@ export function buildCandidateIdentityIndex(
       const bucketByX = stat === "count" || stat === "summary" || stat === "boxplot";
       const xField = frame.binding.xField;
       const xColumn = bucketByX && xField !== null ? frame.table.column(xField) : null;
-      const groupKeysThisFrame: string[] = [];
+      // Finite-y membership uses panel-local table indexes (localRow), then stores
+      // source-table rows — same mapping as sourceRowsByGroup itself.
+      const yField = frame.binding.yField;
+      const finiteY =
+        (stat === "smooth" || stat === "summary" || stat === "boxplot") && yField !== null;
+      const yColumn = finiteY ? frame.table.column(yField) : null;
       for (let localRow = 0; localRow < inputGroups.length; localRow++) {
         const group = inputGroups[localRow]!;
         const sourceRow = facetPanels[panelIndex]!.sourceRows?.[localRow] ?? localRow;
         const key = `${frameKey}:${group}`;
-        const members = sourceRowsByGroup.get(key);
-        if (members === undefined) {
-          sourceRowsByGroup.set(key, [sourceRow]);
-          groupKeysThisFrame.push(key);
-        } else members.push(sourceRow);
+        appendSourceRowByGroupKey(sourceRowsByGroup, key, sourceRow);
         if (xColumn !== null) {
           appendSourceRowByGroupX({
             sourceRowsByGroupX,
@@ -72,6 +74,9 @@ export function buildCandidateIdentityIndex(
             sourceRow,
           });
         }
+        if (yColumn !== null && Number.isFinite(cellToNumber(yColumn[localRow]!))) {
+          appendSourceRowByGroupKey(sourceRowsByGroupY, key, sourceRow);
+        }
       }
       if (stat === "bin") {
         buildBinLineageBuckets({
@@ -81,18 +86,6 @@ export function buildCandidateIdentityIndex(
           facetPanel: facetPanels[panelIndex]!,
           sourceRowsByGroupBin,
         });
-      }
-      // Once-per-group finite-y lists for stats that drop non-finite y in lineage.
-      const yField = frame.binding.yField;
-      if ((stat === "smooth" || stat === "summary" || stat === "boxplot") && yField !== null) {
-        const yColumn = frame.table.column(yField);
-        for (const key of groupKeysThisFrame) {
-          const rows = sourceRowsByGroup.get(key)!;
-          sourceRowsByGroupY.set(
-            key,
-            rows.filter((row) => Number.isFinite(cellToNumber(yColumn[row]!))),
-          );
-        }
       }
       for (let i = 0; i < frame.rowIndex.length; i++) {
         const sourceRow = frame.rowIndex[i]!;

--- a/packages/core/src/pipeline/build-candidates-lineage.ts
+++ b/packages/core/src/pipeline/build-candidates-lineage.ts
@@ -27,9 +27,9 @@ export function filterRepresentedSourceRows(input: {
   sourceRowsByGroupY?: Map<string, number[]>;
 }): number[] {
   const { frame, table, frameRow } = input;
-  let representedRows = [...input.baseRows];
   const stat = frame.binding.layer.stat ?? "identity";
   const aggregateXField = frame.binding.xField;
+  const aggregateYField = frame.binding.yField;
   const outputX = frame.xValues?.[frameRow] ?? frame.xNumeric?.[frameRow] ?? null;
   const group = input.group ?? frame.groups[frameRow] ?? 0;
   const panelIndex = input.panelIndex;
@@ -39,12 +39,23 @@ export function filterRepresentedSourceRows(input: {
       ? `${panelIndex}:${layerIndex}:${group}`
       : null;
 
-  let narrowedByXOrBin = false;
-  if (
+  const needsX =
     aggregateXField !== null &&
     outputX !== null &&
-    (stat === "count" || stat === "summary" || stat === "boxplot")
-  ) {
+    (stat === "count" || stat === "summary" || stat === "boxplot");
+  const needsBin = stat === "bin" && aggregateXField !== null;
+  const needsY =
+    (stat === "smooth" || stat === "summary" || stat === "boxplot") && aggregateYField !== null;
+
+  // Full-group finite-y path (smooth; summary/boxplot without x/bin): return the
+  // shared cached array before cloning baseRows — keeps resolve O(1) per mark.
+  if (needsY && !needsX && !needsBin && indexKeyPrefix !== null && input.sourceRowsByGroupY) {
+    const cachedY = input.sourceRowsByGroupY.get(indexKeyPrefix);
+    if (cachedY !== undefined) return cachedY;
+  }
+
+  let representedRows = [...input.baseRows];
+  if (needsX) {
     representedRows =
       (indexKeyPrefix !== null && input.sourceRowsByGroupX !== undefined
         ? input.sourceRowsByGroupX.get(`${indexKeyPrefix}:${bandKey(outputX)}`)
@@ -55,8 +66,7 @@ export function filterRepresentedSourceRows(input: {
         outputX,
         baseRows: representedRows,
       });
-    narrowedByXOrBin = true;
-  } else if (stat === "bin" && aggregateXField !== null) {
+  } else if (needsBin) {
     representedRows =
       (indexKeyPrefix !== null && input.sourceRowsByGroupBin !== undefined
         ? input.sourceRowsByGroupBin.get(`${indexKeyPrefix}:${frameRow}`)
@@ -68,24 +78,14 @@ export function filterRepresentedSourceRows(input: {
         field: aggregateXField,
         baseRows: representedRows,
       });
-    narrowedByXOrBin = true;
   }
 
-  const aggregateYField = frame.binding.yField;
-  if ((stat === "smooth" || stat === "summary" || stat === "boxplot") && aggregateYField !== null) {
-    // Full-group path (smooth, or summary/boxplot without x/bin narrowing): reuse
-    // the once-per-group finite-y list. After x/bin narrowing, filter the smaller set.
-    const cachedY =
-      !narrowedByXOrBin && indexKeyPrefix !== null && input.sourceRowsByGroupY !== undefined
-        ? input.sourceRowsByGroupY.get(indexKeyPrefix)
-        : undefined;
-    representedRows =
-      cachedY ??
-      filterAggregateYRows({
-        table,
-        field: aggregateYField,
-        baseRows: representedRows,
-      });
+  if (needsY) {
+    representedRows = filterAggregateYRows({
+      table,
+      field: aggregateYField,
+      baseRows: representedRows,
+    });
   }
 
   return representedRows;

--- a/packages/core/src/pipeline/build-candidates-lineage.ts
+++ b/packages/core/src/pipeline/build-candidates-lineage.ts
@@ -23,6 +23,8 @@ export function filterRepresentedSourceRows(input: {
   layerIndex?: number;
   sourceRowsByGroupX?: Map<string, number[]>;
   sourceRowsByGroupBin?: Map<string, number[]>;
+  /** Precomputed finite-y rows per `${panel}:${layer}:${group}` (smooth/summary/boxplot). */
+  sourceRowsByGroupY?: Map<string, number[]>;
 }): number[] {
   const { frame, table, frameRow } = input;
   let representedRows = [...input.baseRows];
@@ -37,6 +39,7 @@ export function filterRepresentedSourceRows(input: {
       ? `${panelIndex}:${layerIndex}:${group}`
       : null;
 
+  let narrowedByXOrBin = false;
   if (
     aggregateXField !== null &&
     outputX !== null &&
@@ -52,6 +55,7 @@ export function filterRepresentedSourceRows(input: {
         outputX,
         baseRows: representedRows,
       });
+    narrowedByXOrBin = true;
   } else if (stat === "bin" && aggregateXField !== null) {
     representedRows =
       (indexKeyPrefix !== null && input.sourceRowsByGroupBin !== undefined
@@ -64,15 +68,24 @@ export function filterRepresentedSourceRows(input: {
         field: aggregateXField,
         baseRows: representedRows,
       });
+    narrowedByXOrBin = true;
   }
 
   const aggregateYField = frame.binding.yField;
   if ((stat === "smooth" || stat === "summary" || stat === "boxplot") && aggregateYField !== null) {
-    representedRows = filterAggregateYRows({
-      table,
-      field: aggregateYField,
-      baseRows: representedRows,
-    });
+    // Full-group path (smooth, or summary/boxplot without x/bin narrowing): reuse
+    // the once-per-group finite-y list. After x/bin narrowing, filter the smaller set.
+    const cachedY =
+      !narrowedByXOrBin && indexKeyPrefix !== null && input.sourceRowsByGroupY !== undefined
+        ? input.sourceRowsByGroupY.get(indexKeyPrefix)
+        : undefined;
+    representedRows =
+      cachedY ??
+      filterAggregateYRows({
+        table,
+        field: aggregateYField,
+        baseRows: representedRows,
+      });
   }
 
   return representedRows;

--- a/packages/core/tests/pipeline-build-candidates.test.ts
+++ b/packages/core/tests/pipeline-build-candidates.test.ts
@@ -997,6 +997,67 @@ describe("finite-y lineage cache (issue #216)", () => {
     expect(keys).toEqual([0, 1, 3, 4]);
   });
 
+  it("finite-y cache uses panel-local y values under facet wrap", async () => {
+    const { preparePanels } = await import("../src/pipeline/prepare-panels.ts");
+    const { buildCandidateIdentityIndex } =
+      await import("../src/pipeline/build-candidates-identity.ts");
+    const { filterRepresentedSourceRows } =
+      await import("../src/pipeline/build-candidates-lineage.ts");
+    const { normalize } = await import("@ggsvelte/spec");
+
+    const prepared = preparePanels(
+      normalize(
+        gg(
+          [
+            { f: "A", x: 1, y: 10 },
+            { f: "A", x: 2, y: null },
+            { f: "A", x: 3, y: 30 },
+            { f: "B", x: 1, y: 100 },
+            { f: "B", x: 2, y: 200 },
+          ],
+          aes({ x: "x", y: "y" }),
+        )
+          .geomSmooth({ method: "lm", n: 4 })
+          .facet({ wrap: "f" })
+          .spec(),
+      ),
+      size,
+      [],
+      [],
+    );
+    const index = buildCandidateIdentityIndex(prepared.panelFrames, prepared.facetPanels);
+
+    // Panel B maps source rows 3,4 → panel-local 0,1. Cache must not index frame.table
+    // with source-table indexes (that empties or corrupts the finite-y list).
+    expect(index.sourceRowsByGroupY.get("0:0:0")).toEqual([0, 2]);
+    expect(index.sourceRowsByGroupY.get("1:0:0")).toEqual([3, 4]);
+
+    for (let panelIndex = 0; panelIndex < prepared.panelFrames.length; panelIndex++) {
+      const frame = prepared.panelFrames[panelIndex]![0]!;
+      const groupKey = `${panelIndex}:0:0`;
+      const baseRows = index.sourceRowsByGroup.get(groupKey) ?? [];
+      const viaFilter = filterRepresentedSourceRows({
+        frame,
+        table: prepared.table,
+        frameRow: 0,
+        baseRows,
+      });
+      expect(index.sourceRowsByGroupY.get(groupKey)).toEqual(viaFilter);
+      const viaIndex = filterRepresentedSourceRows({
+        frame,
+        table: prepared.table,
+        frameRow: 0,
+        baseRows,
+        group: 0,
+        panelIndex,
+        layerIndex: 0,
+        sourceRowsByGroupY: index.sourceRowsByGroupY,
+      });
+      expect(viaIndex).toEqual(viaFilter);
+      expect(viaIndex).toBe(index.sourceRowsByGroupY.get(groupKey));
+    }
+  });
+
   it("summary finite-y cache matches pure filter after group×x resolve", async () => {
     const { preparePanels } = await import("../src/pipeline/prepare-panels.ts");
     const { buildCandidateIdentityIndex } =

--- a/packages/core/tests/pipeline-build-candidates.test.ts
+++ b/packages/core/tests/pipeline-build-candidates.test.ts
@@ -739,6 +739,315 @@ describe("aggregate lineage index (issue #184)", () => {
         sourceRowsByGroup: index.sourceRowsByGroup,
         sourceRowsByGroupX: index.sourceRowsByGroupX,
         sourceRowsByGroupBin: index.sourceRowsByGroupBin,
+        sourceRowsByGroupY: index.sourceRowsByGroupY,
+        frame,
+        table: prepared.table,
+        frameRow,
+        lineage,
+        primitiveIndex: frameRow,
+      });
+      const baseRows = index.sourceRowsByGroup.get(`0:0:${group}`) ?? [];
+      const viaFilter = filterRepresentedSourceRows({
+        frame,
+        table: prepared.table,
+        frameRow,
+        baseRows,
+      });
+      expect(viaIndex.representedRows).toEqual(viaFilter);
+    }
+  });
+});
+
+describe("finite-y lineage cache (issue #216)", () => {
+  it("precomputes finite-y source rows once per group for smooth layers", async () => {
+    const { preparePanels } = await import("../src/pipeline/prepare-panels.ts");
+    const { buildCandidateIdentityIndex } =
+      await import("../src/pipeline/build-candidates-identity.ts");
+    const { filterAggregateYRows } =
+      await import("../src/pipeline/build-candidates-lineage-filters.ts");
+    const { normalize } = await import("@ggsvelte/spec");
+
+    const prepared = preparePanels(
+      normalize({
+        data: {
+          values: [
+            { x: 1, y: 10 },
+            { x: 2, y: 20 },
+            { x: 3, y: Number.NaN },
+            { x: 4, y: 40 },
+          ],
+        },
+        layers: [
+          {
+            geom: "smooth",
+            stat: "smooth",
+            aes: { x: { field: "x" }, y: { field: "y" } },
+            params: { method: "lm", n: 5 },
+          },
+        ],
+      }),
+      size,
+      [],
+      [],
+    );
+    const index = buildCandidateIdentityIndex(prepared.panelFrames, prepared.facetPanels);
+    const groupKey = "0:0:0";
+    const baseRows = index.sourceRowsByGroup.get(groupKey) ?? [];
+    expect(baseRows.toSorted((a, b) => a - b)).toEqual([0, 1, 2, 3]);
+
+    const viaFilter = filterAggregateYRows({
+      table: prepared.table,
+      field: "y",
+      baseRows,
+    });
+    // Non-finite y (row 2) must be excluded; cache must match pure filter.
+    expect(viaFilter).toEqual([0, 1, 3]);
+    expect(index.sourceRowsByGroupY.get(groupKey)).toEqual(viaFilter);
+  });
+
+  it("filterRepresentedSourceRows reuses finite-y cache for every smooth mark", async () => {
+    const { preparePanels } = await import("../src/pipeline/prepare-panels.ts");
+    const { buildCandidateIdentityIndex } =
+      await import("../src/pipeline/build-candidates-identity.ts");
+    const { filterRepresentedSourceRows } =
+      await import("../src/pipeline/build-candidates-lineage.ts");
+    const { normalize } = await import("@ggsvelte/spec");
+
+    const prepared = preparePanels(
+      normalize({
+        data: {
+          values: [
+            { x: 1, y: 10 },
+            { x: 2, y: 20 },
+            { x: 3, y: Number.NaN },
+            { x: 4, y: 40 },
+          ],
+        },
+        layers: [
+          {
+            geom: "smooth",
+            stat: "smooth",
+            aes: { x: { field: "x" }, y: { field: "y" } },
+            params: { method: "lm", n: 5 },
+          },
+        ],
+      }),
+      size,
+      [],
+      [],
+    );
+    const index = buildCandidateIdentityIndex(prepared.panelFrames, prepared.facetPanels);
+    const frame = prepared.panelFrames[0]![0]!;
+    const baseRows = index.sourceRowsByGroup.get("0:0:0") ?? [];
+    const expected = index.sourceRowsByGroupY.get("0:0:0");
+    expect(expected).toEqual([0, 1, 3]);
+
+    // Every evaluation-grid mark must resolve to the same finite-y list.
+    expect(frame.n).toBeGreaterThan(1);
+    for (let frameRow = 0; frameRow < frame.n; frameRow++) {
+      const viaIndex = filterRepresentedSourceRows({
+        frame,
+        table: prepared.table,
+        frameRow,
+        baseRows,
+        group: 0,
+        panelIndex: 0,
+        layerIndex: 0,
+        sourceRowsByGroupY: index.sourceRowsByGroupY,
+      });
+      const viaFilter = filterRepresentedSourceRows({
+        frame,
+        table: prepared.table,
+        frameRow,
+        baseRows,
+      });
+      expect(viaIndex).toEqual(viaFilter);
+      expect(viaIndex).toEqual(expected);
+      // Shared frozen array — no per-mark re-filter allocation.
+      expect(viaIndex).toBe(expected);
+    }
+  });
+
+  it("does not build finite-y buckets for identity or count layers", async () => {
+    const { preparePanels } = await import("../src/pipeline/prepare-panels.ts");
+    const { buildCandidateIdentityIndex } =
+      await import("../src/pipeline/build-candidates-identity.ts");
+    const { normalize } = await import("@ggsvelte/spec");
+
+    const prepared = preparePanels(
+      normalize({
+        data: {
+          values: [
+            { g: "a", y: 1 },
+            { g: "b", y: 2 },
+          ],
+        },
+        layers: [
+          { geom: "point", aes: { x: { field: "g" }, y: { field: "y" } } },
+          { geom: "bar", aes: { x: { field: "g" } }, stat: "count" },
+        ],
+      }),
+      size,
+      [],
+      [],
+    );
+    const index = buildCandidateIdentityIndex(prepared.panelFrames, prepared.facetPanels);
+    expect(index.sourceRowsByGroupY.size).toBe(0);
+  });
+
+  it("resolveRepresentedSourceRows matches pure filter and reuses lineage for smooth marks", async () => {
+    const { preparePanels } = await import("../src/pipeline/prepare-panels.ts");
+    const { buildCandidateIdentityIndex } =
+      await import("../src/pipeline/build-candidates-identity.ts");
+    const { resolveRepresentedSourceRows } =
+      await import("../src/pipeline/build-candidates-datum-represented.ts");
+    const { filterRepresentedSourceRows } =
+      await import("../src/pipeline/build-candidates-lineage.ts");
+    const { LineageStore } = await import("../src/identity.ts");
+    const { normalize } = await import("@ggsvelte/spec");
+
+    const prepared = preparePanels(
+      normalize({
+        data: {
+          values: [
+            { x: 1, y: 10 },
+            { x: 2, y: 20 },
+            { x: 3, y: Number.NaN },
+            { x: 4, y: 40 },
+          ],
+        },
+        layers: [
+          {
+            geom: "smooth",
+            stat: "smooth",
+            aes: { x: { field: "x" }, y: { field: "y" } },
+            params: { method: "lm", n: 8 },
+          },
+        ],
+      }),
+      size,
+      [],
+      [],
+    );
+    const index = buildCandidateIdentityIndex(prepared.panelFrames, prepared.facetPanels);
+    const frame = prepared.panelFrames[0]![0]!;
+    const lineage = new LineageStore<number>();
+    const baseRows = index.sourceRowsByGroup.get("0:0:0") ?? [];
+
+    const lineageKeys: number[] = [];
+    for (let frameRow = 0; frameRow < frame.n; frameRow++) {
+      const viaIndex = resolveRepresentedSourceRows({
+        outlierSourceRow: null,
+        sourceRow: null,
+        group: 0,
+        panelIndex: 0,
+        layerIndex: 0,
+        sourceRowsByGroup: index.sourceRowsByGroup,
+        sourceRowsByGroupX: index.sourceRowsByGroupX,
+        sourceRowsByGroupBin: index.sourceRowsByGroupBin,
+        sourceRowsByGroupY: index.sourceRowsByGroupY,
+        frame,
+        table: prepared.table,
+        frameRow,
+        lineage,
+        primitiveIndex: frameRow,
+      });
+      const viaFilter = filterRepresentedSourceRows({
+        frame,
+        table: prepared.table,
+        frameRow,
+        baseRows,
+      });
+      expect(viaIndex.representedRows).toEqual(viaFilter);
+      expect(viaIndex.representedRows).toEqual([0, 1, 3]);
+      lineageKeys.push(viaIndex.lineageKey);
+    }
+    expect(frame.n).toBeGreaterThan(1);
+    // All evaluation-grid marks share one interned lineage membership.
+    expect(new Set(lineageKeys).size).toBe(1);
+    expect([...lineage.keys(lineageKeys[0]!)].toSorted((a, b) => a - b)).toEqual([0, 1, 3]);
+  });
+
+  it("pipeline smooth candidates share one lineage membership per group", () => {
+    const model = runPipeline(
+      gg(
+        [
+          { x: 1, y: 10 },
+          { x: 2, y: 20 },
+          { x: 3, y: null },
+          { x: 4, y: 40 },
+          { x: 5, y: 50 },
+        ],
+        aes({ x: "x", y: "y" }),
+      )
+        .geomSmooth({ method: "lm", n: 10 })
+        .spec(),
+      size,
+    );
+    const candidates = Array.from({ length: model.candidates.size }, (_, id) =>
+      model.candidates.candidate(id),
+    ).flatMap((candidate) => (candidate === null ? [] : [candidate]));
+    expect(candidates.length).toBeGreaterThan(1);
+    const first = candidates[0];
+    if (first === undefined) throw new Error("expected at least one smooth candidate");
+    const lineageRefs = new Set(candidates.map((candidate) => candidate.lineage));
+    expect(lineageRefs.size).toBe(1);
+    const keys = [...model.lineage.keys(first.lineage)].toSorted((a, b) => a - b);
+    // Row 2 has null y and is not represented by the smooth fit lineage.
+    expect(keys).toEqual([0, 1, 3, 4]);
+  });
+
+  it("summary finite-y cache matches pure filter after group×x resolve", async () => {
+    const { preparePanels } = await import("../src/pipeline/prepare-panels.ts");
+    const { buildCandidateIdentityIndex } =
+      await import("../src/pipeline/build-candidates-identity.ts");
+    const { resolveRepresentedSourceRows } =
+      await import("../src/pipeline/build-candidates-datum-represented.ts");
+    const { filterRepresentedSourceRows } =
+      await import("../src/pipeline/build-candidates-lineage.ts");
+    const { LineageStore } = await import("../src/identity.ts");
+    const { normalize } = await import("@ggsvelte/spec");
+
+    const prepared = preparePanels(
+      normalize({
+        data: {
+          values: [
+            { g: "a", y: 1 },
+            { g: "a", y: Number.NaN },
+            { g: "a", y: 3 },
+            { g: "b", y: 4 },
+          ],
+        },
+        layers: [
+          {
+            geom: "pointrange",
+            stat: "summary",
+            aes: { x: { field: "g" }, y: { field: "y" } },
+          },
+        ],
+      }),
+      size,
+      [],
+      [],
+    );
+    const index = buildCandidateIdentityIndex(prepared.panelFrames, prepared.facetPanels);
+    expect(index.sourceRowsByGroupY.get("0:0:0")).toEqual([0, 2]);
+    expect(index.sourceRowsByGroupY.get("0:0:1")).toEqual([3]);
+
+    const frame = prepared.panelFrames[0]![0]!;
+    const lineage = new LineageStore<number>();
+    for (let frameRow = 0; frameRow < frame.n; frameRow++) {
+      const group = frame.groups[frameRow] ?? 0;
+      const viaIndex = resolveRepresentedSourceRows({
+        outlierSourceRow: null,
+        sourceRow: null,
+        group,
+        panelIndex: 0,
+        layerIndex: 0,
+        sourceRowsByGroup: index.sourceRowsByGroup,
+        sourceRowsByGroupX: index.sourceRowsByGroupX,
+        sourceRowsByGroupBin: index.sourceRowsByGroupBin,
+        sourceRowsByGroupY: index.sourceRowsByGroupY,
         frame,
         table: prepared.table,
         frameRow,


### PR DESCRIPTION
## Summary

- Fixes #216: when resolving represented source rows for `smooth` / `summary` / `boxplot`, finite-y filtering no longer re-scans the full group for every evaluation-grid mark.
- Precomputes `sourceRowsByGroupY` (`panel:layer:group` → finite-y source rows) once in `CandidateIdentityIndex`.
- `filterRepresentedSourceRows` reuses that list for the full-group path (smooth; summary/boxplot without x/bin narrowing); pure filters remain as fallback.
- `LineageStore.intern` short-circuits on shared frozen membership arrays so smooth marks that share identical represented rows intern lineage once.

**Complexity:** O(m · g) → O(g) per group for smooth (often ~80× less at default `params.n`).

## Test plan

- [x] Unit tests for finite-y precompute, filter cache identity, identity/count skip, resolve/filter parity, shared lineage, summary after group×x
- [x] Regression: existing aggregate lineage (#184) tests still pass
- [x] `bun test packages/core` (590 pass)
- [x] `bun run check` + type-aware lint clean
- [x] Pre-push hooks green
- [ ] CI green on this PR