### PR TITLE
perf(core): O(n+k) bin lineage fill when edges are missing

### DIFF
--- a/packages/core/src/pipeline/build-candidates-identity-aggregate.ts
+++ b/packages/core/src/pipeline/build-candidates-identity-aggregate.ts
@@ -38,6 +38,8 @@ interface BinEdge {
  * Assign each source row to at most one bin in a single pass over the panel
  * rows (O(n log k) per group via binary search on ordered bin edges), instead
  * of re-scanning the full group once per output bin (O(k·g)).
+ * When bin edges are absent, every mark represents the full group: members are
+ * collected once per group and shared across that group's frame rows (O(n+k)).
  */
 export function buildBinLineageBuckets(input: {
   frame: LayerFrame;
@@ -53,18 +55,26 @@ export function buildBinLineageBuckets(input: {
   const inputGroups = deriveLayerGroups(frame.binding, frame.table);
   const closed = ((frame.binding.layer.params ?? {}) as BarParams).closed ?? "right";
   const binsByGroup = new Map<number, BinEdge[]>();
+  const missingEdges = frame.xmin === null || frame.xmax === null;
+  /** group → frame rows (missing-edges path only; enables O(n+k) fill). */
+  const frameRowsByGroup = missingEdges ? new Map<number, number[]>() : null;
 
   for (let frameRow = 0; frameRow < frame.n; frameRow++) {
     const group = frame.groups[frameRow] ?? 0;
+    if (frameRowsByGroup !== null) {
+      const rows = frameRowsByGroup.get(group);
+      if (rows === undefined) frameRowsByGroup.set(group, [frameRow]);
+      else rows.push(frameRow);
+      continue;
+    }
     const bucket: number[] = [];
     sourceRowsByGroupBin.set(`${panelIndex}:${layerIndex}:${group}:${frameRow}`, bucket);
-    if (frame.xmin === null || frame.xmax === null) continue;
     const first = frameRow === 0 || frame.groups[frameRow - 1] !== group;
     const last = frameRow === frame.n - 1 || frame.groups[frameRow + 1] !== group;
     const edge: BinEdge = {
       frameRow,
-      lo: frame.xmin[frameRow]!,
-      hi: frame.xmax[frameRow]!,
+      lo: frame.xmin![frameRow]!,
+      hi: frame.xmax![frameRow]!,
       first,
       last,
       bucket,
@@ -75,15 +85,20 @@ export function buildBinLineageBuckets(input: {
   }
 
   // No bin edges: every output mark represents the full group (filter fallback).
-  if (frame.xmin === null || frame.xmax === null) {
+  // Pre-index group → frame rows, collect members O(n), share one array per group O(k).
+  if (frameRowsByGroup !== null) {
+    const membersByGroup = new Map<number, number[]>();
     for (let localRow = 0; localRow < inputGroups.length; localRow++) {
       const group = inputGroups[localRow]!;
       const sourceRow = facetPanel.sourceRows?.[localRow] ?? localRow;
-      for (let frameRow = 0; frameRow < frame.n; frameRow++) {
-        if ((frame.groups[frameRow] ?? 0) !== group) continue;
-        sourceRowsByGroupBin
-          .get(`${panelIndex}:${layerIndex}:${group}:${frameRow}`)
-          ?.push(sourceRow);
+      const members = membersByGroup.get(group);
+      if (members === undefined) membersByGroup.set(group, [sourceRow]);
+      else members.push(sourceRow);
+    }
+    for (const [group, frameRows] of frameRowsByGroup) {
+      const members = membersByGroup.get(group) ?? [];
+      for (const frameRow of frameRows) {
+        sourceRowsByGroupBin.set(`${panelIndex}:${layerIndex}:${group}:${frameRow}`, members);
       }
     }
     return;

--- a/packages/core/tests/pipeline-build-candidates.test.ts
+++ b/packages/core/tests/pipeline-build-candidates.test.ts
@@ -764,11 +764,10 @@ describe("aggregate lineage index (issue #184)", () => {
  * - complexity: frame.groups index reads stay O(k), not O(n·k)
  */
 describe("buildBinLineageBuckets missing-edges fallback (issue #218)", () => {
-  async function load() {
+  async function loadBuildBinLineageBuckets() {
     const { buildBinLineageBuckets } =
       await import("../src/pipeline/build-candidates-identity-aggregate.ts");
-    const { ColumnTable } = await import("../src/table.ts");
-    return { buildBinLineageBuckets, ColumnTable };
+    return buildBinLineageBuckets;
   }
 
   function binBinding(colorField: string | null = null) {
@@ -797,7 +796,7 @@ describe("buildBinLineageBuckets missing-edges fallback (issue #218)", () => {
   }
 
   it("assigns every source row of a group into each of that group's frame rows", async () => {
-    const { buildBinLineageBuckets, ColumnTable } = await load();
+    const buildBinLineageBuckets = await loadBuildBinLineageBuckets();
     const table = ColumnTable.fromRows([
       { g: "a", x: 1 },
       { g: "b", x: 2 },
@@ -831,7 +830,7 @@ describe("buildBinLineageBuckets missing-edges fallback (issue #218)", () => {
   });
 
   it("remaps through facetPanel.sourceRows in first-seen order", async () => {
-    const { buildBinLineageBuckets, ColumnTable } = await load();
+    const buildBinLineageBuckets = await loadBuildBinLineageBuckets();
     const table = ColumnTable.fromRows([
       { g: "a", x: 1 },
       { g: "a", x: 2 },
@@ -860,7 +859,7 @@ describe("buildBinLineageBuckets missing-edges fallback (issue #218)", () => {
   });
 
   it("reads frame.groups O(k) times, not O(n·k), when edges are missing", async () => {
-    const { buildBinLineageBuckets, ColumnTable } = await load();
+    const buildBinLineageBuckets = await loadBuildBinLineageBuckets();
     const n = 40;
     const k = 40;
     const table = ColumnTable.fromRows(Array.from({ length: n }, (_, i) => ({ x: i })));

--- a/packages/core/tests/pipeline-build-candidates.test.ts
+++ b/packages/core/tests/pipeline-build-candidates.test.ts
@@ -658,3 +658,145 @@ describe("aggregate lineage index (issue #184)", () => {
     }
   });
 });
+
+/**
+ * Seams under test (issue #218):
+ * - buildBinLineageBuckets missing-edges path: full-group membership per frame row
+ * - multi-group isolation + first-seen source-row order + facet sourceRows remap
+ * - complexity: frame.groups index reads stay O(k), not O(n·k)
+ */
+describe("buildBinLineageBuckets missing-edges fallback (issue #218)", () => {
+  async function load() {
+    const { buildBinLineageBuckets } =
+      await import("../src/pipeline/build-candidates-identity-aggregate.ts");
+    const { ColumnTable } = await import("../src/table.ts");
+    return { buildBinLineageBuckets, ColumnTable };
+  }
+
+  function binBinding(colorField: string | null = null) {
+    return {
+      layer: {
+        geom: "histogram",
+        stat: "bin",
+        aes: {
+          x: { field: "x" },
+          ...(colorField === null ? {} : { color: { field: colorField } }),
+        },
+      },
+      index: 0,
+      xField: "x",
+      yField: null,
+      yStatColumn: null,
+      yminField: null,
+      ymaxField: null,
+      color: { field: colorField, constant: null, scaledConstant: null },
+      fill: { field: null, constant: null, scaledConstant: null },
+      labelField: null,
+      labelConstant: null,
+      weightField: null,
+      ruleForm: null,
+    };
+  }
+
+  it("assigns every source row of a group into each of that group's frame rows", async () => {
+    const { buildBinLineageBuckets, ColumnTable } = await load();
+    const table = ColumnTable.fromRows([
+      { g: "a", x: 1 },
+      { g: "b", x: 2 },
+      { g: "a", x: 3 },
+      { g: "b", x: 4 },
+      { g: "a", x: 5 },
+    ]);
+    // Two empty-edge output marks per group (0=a, 1=b).
+    const groups = [0, 0, 1, 1];
+    const frame = {
+      binding: binBinding("g"),
+      table,
+      n: groups.length,
+      groups,
+      xmin: null,
+      xmax: null,
+    } as never;
+    const sourceRowsByGroupBin = new Map<string, number[]>();
+    buildBinLineageBuckets({
+      frame,
+      panelIndex: 0,
+      layerIndex: 0,
+      facetPanel: { sourceRows: null } as never,
+      sourceRowsByGroupBin,
+    });
+
+    expect(sourceRowsByGroupBin.get("0:0:0:0")).toEqual([0, 2, 4]);
+    expect(sourceRowsByGroupBin.get("0:0:0:1")).toEqual([0, 2, 4]);
+    expect(sourceRowsByGroupBin.get("0:0:1:2")).toEqual([1, 3]);
+    expect(sourceRowsByGroupBin.get("0:0:1:3")).toEqual([1, 3]);
+  });
+
+  it("remaps through facetPanel.sourceRows in first-seen order", async () => {
+    const { buildBinLineageBuckets, ColumnTable } = await load();
+    const table = ColumnTable.fromRows([
+      { g: "a", x: 1 },
+      { g: "a", x: 2 },
+      { g: "b", x: 3 },
+    ]);
+    const groups = [0, 1];
+    const frame = {
+      binding: binBinding("g"),
+      table,
+      n: groups.length,
+      groups,
+      xmin: null,
+      xmax: null,
+    } as never;
+    const sourceRowsByGroupBin = new Map<string, number[]>();
+    buildBinLineageBuckets({
+      frame,
+      panelIndex: 2,
+      layerIndex: 1,
+      facetPanel: { sourceRows: [10, 20, 30] } as never,
+      sourceRowsByGroupBin,
+    });
+
+    expect(sourceRowsByGroupBin.get("2:1:0:0")).toEqual([10, 20]);
+    expect(sourceRowsByGroupBin.get("2:1:1:1")).toEqual([30]);
+  });
+
+  it("reads frame.groups O(k) times, not O(n·k), when edges are missing", async () => {
+    const { buildBinLineageBuckets, ColumnTable } = await load();
+    const n = 40;
+    const k = 40;
+    const table = ColumnTable.fromRows(Array.from({ length: n }, (_, i) => ({ x: i })));
+    const rawGroups = Array.from({ length: k }, () => 0);
+    let groupIndexReads = 0;
+    const groups = new Proxy(rawGroups, {
+      get(target, property, receiver): unknown {
+        if (typeof property === "string" && /^\d+$/.test(property)) groupIndexReads += 1;
+        return Reflect.get(target, property, receiver) as unknown;
+      },
+    });
+    const frame = {
+      binding: binBinding(null),
+      table,
+      n: k,
+      groups,
+      xmin: null,
+      xmax: null,
+    } as never;
+    const sourceRowsByGroupBin = new Map<string, number[]>();
+    buildBinLineageBuckets({
+      frame,
+      panelIndex: 0,
+      layerIndex: 0,
+      facetPanel: { sourceRows: null } as never,
+      sourceRowsByGroupBin,
+    });
+
+    // Setup walk over k frame rows is enough; nested O(n·k) would read ~n·k times.
+    expect(groupIndexReads).toBeLessThanOrEqual(k * 2);
+    expect(groupIndexReads).toBeLessThan((n * k) / 2);
+    expect(sourceRowsByGroupBin.get("0:0:0:0")).toEqual(Array.from({ length: n }, (_, i) => i));
+    expect(sourceRowsByGroupBin.get(`0:0:0:${k - 1}`)).toEqual(
+      Array.from({ length: n }, (_, i) => i),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- `buildBinLineageBuckets` missing-edges fallback (`xmin`/`xmax` null) scanned every frame row for every source row: **O(n·k)**.
- Pre-index `group → frame rows`, collect members once per group (**O(n)**), and share one full-group array across that group's output marks (**O(k)**).
- Semantics unchanged: each mark still represents the full group; first-seen order preserved; facet `sourceRows` remapping still applies.

Fixes #218

## Test plan

- [x] TDD: multi-group membership + facet remapping characterization
- [x] TDD: Proxy-counted `frame.groups` reads stay O(k), not O(n·k) (was 1640 → ≤80 for n=k=40)
- [x] Existing bin lineage + aggregate index tests still green
- [x] `bun test packages/core` (587 pass)
- [x] Pre-commit: typecheck, knip, lint, full unit suite
