### PR TITLE
fix(core): keep annotation frames rowless for inputGroups

### DIFF
--- a/packages/core/src/pipeline/frame.ts
+++ b/packages/core/src/pipeline/frame.ts
@@ -21,12 +21,15 @@ export function buildFrame(
   advisories: Advisory[],
   binRange?: [number, number],
 ): LayerFrame {
+  // Annotation frames are rowless (n=0, empty inputGroups). Do not derive or
+  // overwrite pre-stat groups — identity index would otherwise retain O(n)
+  // source memberships for a layer with no source rows.
+  if (binding.ruleForm === "annotation") {
+    return buildAnnotationFrame(binding, table);
+  }
+
   // Derive once per frame; identity index + bin lineage consume frame.inputGroups.
   const inputGroups = deriveLayerGroups(binding, table);
-
-  if (binding.ruleForm === "annotation") {
-    return { ...buildAnnotationFrame(binding, table), inputGroups };
-  }
 
   const nonIdentity = buildNonIdentityFrame(
     binding,

--- a/packages/core/tests/pipeline-frame.test.ts
+++ b/packages/core/tests/pipeline-frame.test.ts
@@ -74,6 +74,26 @@ describe("buildFrame — annotation rules", () => {
     expect(frame.yIntercepts).toEqual([1, 2]);
     expect(frame.xIntercepts).toEqual([0.5]);
   });
+
+  it("keeps inputGroups empty over a non-empty source table", () => {
+    // Annotation frames are rowless (n=0); pre-stat groups must stay empty so
+    // the identity index does not retain O(source rows) memberships for them.
+    const table = ColumnTable.fromRows([
+      { x: 1, y: 2, g: "a" },
+      { x: 2, y: 3, g: "b" },
+      { x: 3, y: 4, g: "a" },
+    ]);
+    const binding = bindLayer(
+      { geom: "rule", params: { yintercept: 1 }, aes: { color: { field: "g" } } },
+      0,
+      table,
+      [],
+    );
+    expect(binding.ruleForm).toBe("annotation");
+    const frame = buildFrame(binding, table, [], []);
+    expect(frame.n).toBe(0);
+    expect(frame.inputGroups).toEqual([]);
+  });
 });
 
 describe("buildFrame — bin default advisory", () => {


### PR DESCRIPTION
## Summary

- Follow-up for unrebutted post-merge Codex finding on #223 (P2: Keep annotation frames rowless).
- Root cause: `buildFrame` derived pre-stat `inputGroups` for the full table, then spread them over `buildAnnotationFrame`'s intentionally empty `inputGroups`. Annotation layers have `n = 0` and no source rows.
- Effect: O(source rows) retained memberships per annotation layer/facet, and identity-index lineage incorrectly attributed source rows to a rowless layer.
- Fix: return annotation frames before `deriveLayerGroups`.

## Test plan

- [x] RED→GREEN: `keeps inputGroups empty over a non-empty source table` in `pipeline-frame.test.ts`
- [x] `bun test packages/core` (615 pass)

## Verification evidence

- Local: `bun test packages/core` — 615 pass / 0 fail
- Parent finding: https://github.com/ljodea/ggsvelte/pull/223#discussion_r3607511487