### PR TITLE
perf(svelte): O(C+R·c_panel) independent interval key consumption

### DIFF
--- a/packages/svelte/src/lib/interval/consumption.ts
+++ b/packages/svelte/src/lib/interval/consumption.ts
@@ -99,6 +99,15 @@ export function consumeIntervalKeys<Key extends PropertyKey>(
   const visiblePanels = new Set(input.panels.map((panel) => panel.id));
 
   if (preset === "independent") {
+    // Index candidates once by panelId so multi-record independent brushes
+    // scan only that panel's candidates (O(C + R·c_panel)), not the full
+    // store per record (O(R·C)).
+    const candidatesByPanel = new Map<string, IntervalConsumptionCandidate<Key>[]>();
+    for (const candidate of input.candidates) {
+      const list = candidatesByPanel.get(candidate.panelId);
+      if (list === undefined) candidatesByPanel.set(candidate.panelId, [candidate]);
+      else list.push(candidate);
+    }
     return uniqueKeys(
       input.records
         .filter((record) => record.preset === "independent" && visiblePanels.has(record.panelId))
@@ -106,9 +115,11 @@ export function consumeIntervalKeys<Key extends PropertyKey>(
           // Indexed lookup: a persistent brush can hold tens of thousands of
           // keys, and a linear includes() per candidate key is quadratic.
           const recordKeys = new Set<Key>(record.keys);
-          return input.candidates
-            .filter((candidate) => candidate.panelId === record.panelId)
-            .map((candidate) => candidate.keys.filter((key) => recordKeys.has(key)));
+          const panelCandidates = candidatesByPanel.get(record.panelId);
+          if (panelCandidates === undefined) return [];
+          return panelCandidates.map((candidate) =>
+            candidate.keys.filter((key) => recordKeys.has(key)),
+          );
         }),
     );
   }

--- a/packages/svelte/tests/interval/consumption.test.ts
+++ b/packages/svelte/tests/interval/consumption.test.ts
@@ -63,6 +63,49 @@ describe("facet interval consumption", () => {
     ).toEqual(["moved"]);
   });
 
+  // Independent consumption indexes candidates by panelId once (O(C + R·c_panel)),
+  // not re-filters the full candidate list per record (O(R·C)). Structural
+  // property of the implementation; perf-regression coverage lives in the
+  // bench-smoke job, not a wall-clock unit assertion (flakes under CI contention).
+  it("intersects independent keys only with same-panel candidates across many panels", () => {
+    const panelCount = 40;
+    const candidatesPerPanel = 80;
+    // Keep first 10 candidate keys per panel; also inject foreign keys that
+    // only exist on the next panel so a wrong-panel scan would leak them.
+    const keptPerPanel = 10;
+    const multiPanels = Array.from({ length: panelCount }, (_, p) => ({ id: `p${p}` }));
+    const multiCandidates: IntervalConsumptionCandidate<string>[] = multiPanels.flatMap(
+      (panel, p) =>
+        Array.from({ length: candidatesPerPanel }, (_, j) => ({
+          panelId: panel.id,
+          xValue: j,
+          keys: [`p${p}-c${j}`],
+        })),
+    );
+    const multiRecords = multiPanels.map((panel, p) => {
+      const ownKeys = Array.from({ length: keptPerPanel }, (_, j) => `p${p}-c${j}`);
+      const foreignKeys = Array.from({ length: 5 }, (_, j) => `p${(p + 1) % panelCount}-c${j}`);
+      return record(panel.id, "independent", [...ownKeys, ...foreignKeys]);
+    });
+    // Dormant panel brush must not contribute even if its keys exist elsewhere.
+    multiRecords.push(record("dormant", "independent", ["p0-c0", "ghost"]));
+
+    const keys = consumeIntervalKeys({
+      records: multiRecords,
+      panels: multiPanels,
+      candidates: multiCandidates,
+    });
+
+    // 40 panels × 10 same-panel keys each; foreign and dormant keys excluded.
+    const expected = multiPanels.flatMap((panel, p) =>
+      Array.from({ length: keptPerPanel }, (_, j) => `p${p}-c${j}`),
+    );
+    expect(keys).toEqual(expected);
+    expect(keys).toHaveLength(panelCount * keptPerPanel);
+    expect(keys).not.toContain("ghost");
+    expect(keys).not.toContain("p0-c10");
+  });
+
   it("atomically replaces chart-local records when the preset changes", () => {
     const independent = [
       record("north", "independent", ["n1"]),


### PR DESCRIPTION
## Summary

- Index candidates by `panelId` once in `consumeIntervalKeys` for the **independent** preset so multi-panel brushes scan only that panel’s candidates.
- Complexity: **O(R × C) → O(C + R × c_panel)** (issue #228 nested linear search).
- Key membership stays `Set`-based; behavior for visible-panel identity, cross-panel key isolation, and dormant panels is unchanged.

## Test plan

- [x] `bunx --bun vitest run tests/interval/consumption.test.ts` (all browsers)
- [x] `bunx --bun vitest run tests/interval/precise-bounds.test.ts`
- [x] New multi-panel fixture: 40 panels × 80 candidates, foreign + dormant keys excluded, exact expected key list

Closes #228