### PR TITLE
perf(svelte): early-exit before lineage join in reconcilePinned

### DIFF
--- a/packages/svelte/src/lib/inspection/resolver.ts
+++ b/packages/svelte/src/lib/inspection/resolver.ts
@@ -395,19 +395,17 @@ export function createInspectionCoordinator<
       const matches: CandidateFacts[] = [];
       for (let id = 0; id < input.model.candidates.size; id++) {
         const candidate = input.model.candidates.candidate(id);
-        const logicalIdentity =
-          candidate === null
-            ? ""
-            : `${axisToken(candidate.xToken)}|${axisToken(candidate.yToken)}|${input.model.lineage.keys(candidate.lineage).join(",")}`;
-        if (
-          candidate?.layerIndex === prior.layerIndex &&
-          candidate.rowIndex === prior.seedRow &&
-          candidate.kind === prior.seedKind &&
-          candidateBatchRole(input.model, candidate) === prior.seedBatchRole &&
-          candidate.primitiveIndex === prior.seedPrimitiveIndex &&
-          logicalIdentity === prior.seedLogicalIdentity
-        )
-          matches.push(candidate);
+        // Cheap filters first — lineage.keys join is O(L) and only needed for
+        // survivors that already match layer/row/kind/role/primitive (#229).
+        if (candidate === null) continue;
+        if (candidate.layerIndex !== prior.layerIndex) continue;
+        if (candidate.rowIndex !== prior.seedRow) continue;
+        if (candidate.kind !== prior.seedKind) continue;
+        if (candidate.primitiveIndex !== prior.seedPrimitiveIndex) continue;
+        if (candidateBatchRole(input.model, candidate) !== prior.seedBatchRole) continue;
+        const logicalIdentity = `${axisToken(candidate.xToken)}|${axisToken(candidate.yToken)}|${input.model.lineage.keys(candidate.lineage).join(",")}`;
+        if (logicalIdentity !== prior.seedLogicalIdentity) continue;
+        matches.push(candidate);
       }
       seed = matches.length === 1 ? matches[0]! : null;
     } else {

--- a/packages/svelte/tests/interaction/unit.test.ts
+++ b/packages/svelte/tests/interaction/unit.test.ts
@@ -812,6 +812,52 @@ describe("semantic inspection resolver", () => {
     model.dispose();
   });
 
+  // Keyless reconcilePinned must apply cheap layer/row/kind filters before
+  // materializing lineage identity joins (issue #229). Without early exit,
+  // every candidate pays O(L) join cost even when it cannot match.
+  it("skips lineage.keys for keyless pin candidates that fail cheap filters", () => {
+    const data = Array.from({ length: 40 }, (_, index) => ({
+      id: `r${index}`,
+      x: index,
+      y: (index % 7) + 1,
+    }));
+    const makeModel = (width: number) =>
+      runPipeline(
+        gg(data, aes({ x: "x", y: "y" }))
+          .geomPoint()
+          .spec(),
+        { width, height: 300 },
+      );
+    const first = makeModel(400);
+    const resized = makeModel(700);
+    expect(first.candidates.size).toBeGreaterThan(10);
+
+    const coordinator = createInspectionCoordinator(() => null);
+    const seed = first.candidates.candidate(0)!;
+    coordinator.resolve({
+      model: first,
+      seed,
+      mode: "exact",
+      state: "pinned",
+      source: "pointer",
+      identityEpoch: "same-data",
+      layoutEpoch: 1,
+    });
+
+    const keysSpy = vi.spyOn(resized.lineage, "keys");
+    const reconciled = coordinator.reconcilePinned({
+      model: resized,
+      identityEpoch: "same-data",
+      layoutEpoch: 2,
+    });
+    expect(reconciled).not.toBeNull();
+    // Cheap-filter survivors are O(matches); a full-store join walk is O(C).
+    // Materialization may call keys a few more times for the matched seed.
+    expect(keysSpy.mock.calls.length).toBeLessThan(resized.candidates.size);
+    first.dispose();
+    resized.dispose();
+  });
+
   // uniqueKeysFromRowIndexes builds one membership Set for the lineage walk
   // (issue #200). Array#includes-based first-seen would construct zero Sets.
   it("allocates a membership Set when materializing aggregate sourceKeys", () => {


### PR DESCRIPTION
## Summary

- On the null-`seedKey` path of `reconcilePinned`, apply cheap layer/row/kind/role/primitive filters **before** materializing `lineage.keys(...).join(",")` identity strings.
- Non-matching candidates no longer pay O(L) join cost on every store walk; complexity drops from O(C × L) to O(C) cheap filters + O(matches × L).
- Style matches the existing `seedKey !== null` early-`continue` branch.
- Adds a structural regression test that spies `lineage.keys` and asserts keyless reconcile does not call it once per candidate.

Closes #229

## Test plan

- [x] RED: new test failed under pre-fix code (`keys` calls ≥ candidate count)
- [x] GREEN: `bun run --bun test:browser -- tests/interaction/unit.test.ts -t "semantic inspection resolver"` passes (chromium/firefox/webkit)
- [ ] CI green on this PR