### PR TITLE
perf(svelte): Set membership for legend filter visibility (O(E+V))

### DIFF
--- a/packages/svelte/src/lib/legend/filter-state.svelte.ts
+++ b/packages/svelte/src/lib/legend/filter-state.svelte.ts
@@ -11,7 +11,9 @@ import { encodeKey } from "@ggsvelte/core";
 import type { PortableSpec } from "@ggsvelte/spec";
 
 import {
+  isLegendValueKeyVisible,
   isLegendValueVisible,
+  legendFilterValueKeys,
   nextLegendFilterValues,
   reconcileLegendFilterValues,
   type LegendFilterClause,
@@ -183,13 +185,22 @@ export function createLegendFilterState(deps: LegendFilterStateDeps): LegendFilt
       const current = localLegendFilters.find(
         (clause) => clause.scale === sceneLegend.scale && clause.field === field,
       );
+      if (current === undefined) {
+        return sceneLegend.entries.map((entry) => ({
+          legend: sceneLegend,
+          entry,
+          field,
+          visible: true,
+        }));
+      }
+      // One Set per clause, then O(1) membership per entry (O(E+V) not O(E×V)).
+      const valueKeys = legendFilterValueKeys(current.values);
+      const mode = current.mode;
       return sceneLegend.entries.map((entry) => ({
         legend: sceneLegend,
         entry,
         field,
-        visible:
-          current === undefined ||
-          isLegendValueVisible(current.values, entry.value as CellValue, current.mode),
+        visible: isLegendValueKeyVisible(valueKeys, entry.value as CellValue, mode),
       }));
     });
   }

--- a/packages/svelte/src/lib/legend/filter.ts
+++ b/packages/svelte/src/lib/legend/filter.ts
@@ -24,24 +24,35 @@ export interface LegendFilterEvent {
   readonly clause: LegendFilterClause | null;
 }
 
-function sameValue(left: CellValue, right: CellValue): boolean {
-  return encodeKey(left) === encodeKey(right);
+/** Build encodeKey membership once per clause for O(1) visibility checks. */
+export function legendFilterValueKeys(values: readonly CellValue[]): ReadonlySet<string> {
+  return new Set(values.map((value) => encodeKey(value)));
 }
 
+/** O(1) membership against a prebuilt clause key set. */
+export function isLegendValueKeyVisible(
+  valueKeys: ReadonlySet<string>,
+  value: CellValue,
+  mode: "exclude" | "include",
+): boolean {
+  const present = valueKeys.has(encodeKey(value));
+  return mode === "include" ? present : !present;
+}
+
+/** Single-shot visibility (builds a Set). Prefer `isLegendValueKeyVisible` in loops. */
 export function isLegendValueVisible(
   values: readonly CellValue[],
   value: CellValue,
   mode: "exclude" | "include",
 ): boolean {
-  const present = values.some((candidate) => sameValue(candidate, value));
-  return mode === "include" ? present : !present;
+  return isLegendValueKeyVisible(legendFilterValueKeys(values), value, mode);
 }
 
 export function reconcileLegendFilterValues(
   values: readonly CellValue[],
   catalog: readonly CellValue[],
 ): readonly CellValue[] {
-  const catalogKeys = new Set(catalog.map((value) => encodeKey(value)));
+  const catalogKeys = legendFilterValueKeys(catalog);
   return Object.freeze(values.filter((value) => catalogKeys.has(encodeKey(value))));
 }
 
@@ -53,15 +64,16 @@ export function nextLegendFilterValues(
   mode: "exclude" | "include",
   multiple: boolean,
 ): readonly CellValue[] {
+  const key = encodeKey(value);
   if (!multiple) {
     return Object.freeze(
-      mode === "include" ? [value] : catalog.filter((candidate) => !sameValue(candidate, value)),
+      mode === "include" ? [value] : catalog.filter((candidate) => encodeKey(candidate) !== key),
     );
   }
 
   const baseline = current;
-  const found = baseline.some((candidate) => sameValue(candidate, value));
+  const found = baseline.some((candidate) => encodeKey(candidate) === key);
   return Object.freeze(
-    found ? baseline.filter((candidate) => !sameValue(candidate, value)) : [...baseline, value],
+    found ? baseline.filter((candidate) => encodeKey(candidate) !== key) : [...baseline, value],
   );
 }

--- a/packages/svelte/tests/legend/filter.test.ts
+++ b/packages/svelte/tests/legend/filter.test.ts
@@ -1,7 +1,10 @@
+import { encodeKey } from "@ggsvelte/core";
 import { describe, expect, test } from "vitest";
 
 import {
+  isLegendValueKeyVisible,
   isLegendValueVisible,
+  legendFilterValueKeys,
   nextLegendFilterValues,
   reconcileLegendFilterValues,
 } from "../../src/lib/legend/filter.ts";
@@ -38,5 +41,45 @@ describe("legend filter state", () => {
 
   test("reconciliation drops values no longer present in the stable catalog", () => {
     expect(reconcileLegendFilterValues(["west", "gone"], catalog)).toEqual(["west"]);
+  });
+
+  // clause→Set once, then O(1) membership per entry (O(E+V) not O(E×V)).
+  // Structural: high-cardinality visibility must match encodeKey identity for
+  // every entry against a prebuilt key set; array and Set paths agree.
+  test("Set membership visibility matches encodeKey identity across many values", () => {
+    const entries = Array.from({ length: 200 }, (_, i) => `cat-${i}`);
+    const clauseValues = ["cat-0", "cat-50", "cat-199", "cat-missing"];
+    const valueKeys = legendFilterValueKeys(clauseValues);
+
+    expect(valueKeys).toEqual(new Set(clauseValues.map((value) => encodeKey(value))));
+
+    for (const entry of entries) {
+      const inClause = entry === "cat-0" || entry === "cat-50" || entry === "cat-199";
+      expect(isLegendValueKeyVisible(valueKeys, entry, "exclude")).toBe(!inClause);
+      expect(isLegendValueKeyVisible(valueKeys, entry, "include")).toBe(inClause);
+      expect(isLegendValueVisible(clauseValues, entry, "exclude")).toBe(!inClause);
+      expect(isLegendValueVisible(clauseValues, entry, "include")).toBe(inClause);
+    }
+  });
+
+  test("typed distinct values stay distinct under Set membership", () => {
+    // "1" (string) and 1 (number) are different encodeKey identities.
+    const valueKeys = legendFilterValueKeys(["1"]);
+    expect(isLegendValueKeyVisible(valueKeys, "1", "exclude")).toBe(false);
+    expect(isLegendValueKeyVisible(valueKeys, 1, "exclude")).toBe(true);
+    expect(isLegendValueKeyVisible(valueKeys, "1", "include")).toBe(true);
+    expect(isLegendValueKeyVisible(valueKeys, 1, "include")).toBe(false);
+  });
+
+  test("multi toggle over a large baseline preserves every other value", () => {
+    const large = Array.from({ length: 150 }, (_, i) => `v${i}`);
+    const withoutMid = nextLegendFilterValues(large, "v75", large, "exclude", true);
+    expect(withoutMid).toHaveLength(149);
+    expect(withoutMid).not.toContain("v75");
+    expect(withoutMid[0]).toBe("v0");
+    expect(withoutMid.at(-1)).toBe("v149");
+
+    const restored = nextLegendFilterValues(withoutMid, "v75", large, "exclude", true);
+    expect(restored).toEqual([...withoutMid, "v75"]);
   });
 });


### PR DESCRIPTION
## Summary

- Build one `encodeKey` `Set` per active legend filter clause in `computeEntries`, then O(1) membership per entry (`isLegendValueKeyVisible`).
- Complexity: **O(E × V) → O(E + V)** (issue #231 nested linear search).
- `nextLegendFilterValues` encodes the toggled value once; high-cardinality fixtures lock encodeKey identity for exclude/include and typed distinct values.

## Test plan

- [x] `bunx --bun vitest run tests/legend/filter.test.ts tests/legend/filter-state.test.ts` (all browsers)
- [x] New high-cardinality fixture: 200 entries × small clause, Set/array paths agree; string `"1"` vs number `1` remain distinct
- [x] Multi toggle over 150-value baseline preserves every other value
- [x] Pre-commit: package build, svelte-check, type-aware lint, knip, bun test

Closes #231