### PR TITLE
perf(core): O(log P) pathRange/samePath via binary search

### DIFF
--- a/packages/core/src/candidate-geometry.ts
+++ b/packages/core/src/candidate-geometry.ts
@@ -77,21 +77,36 @@ export function segmentIntersectsRect(
   return true;
 }
 
-export function samePath(batch: GeometryBatch, a: number, b: number): boolean {
-  if (batch.kind !== "paths") return false;
-  for (let p = 0; p < batch.pathOffsets.length - 1; p++)
-    if (a >= batch.pathOffsets[p]! && a < batch.pathOffsets[p + 1]!)
-      return b >= batch.pathOffsets[p]! && b < batch.pathOffsets[p + 1]!;
-  return false;
-}
-
-export function pathRange(batch: Extract<GeometryBatch, { kind: "paths" }>, vertex: number) {
-  for (let p = 0; p < batch.pathOffsets.length - 1; p++) {
-    const start = batch.pathOffsets[p]!;
-    const end = batch.pathOffsets[p + 1]!;
-    if (vertex >= start && vertex < end) return [start, end] as const;
+/**
+ * Half-open subpath range [start, end) containing `vertex`, or null.
+ * Binary search on monotonic pathOffsets — O(log P) vs linear O(P).
+ * Preserves the linear-scan contract: fractional vertices are allowed;
+ * zero-length spans never match.
+ */
+export function pathRange(
+  batch: Extract<GeometryBatch, { kind: "paths" }>,
+  vertex: number,
+): readonly [number, number] | null {
+  const offsets = batch.pathOffsets;
+  if (offsets.length < 2) return null;
+  let low = 0;
+  let high = offsets.length - 2;
+  while (low <= high) {
+    const mid = (low + high) >>> 1;
+    const start = offsets[mid]!;
+    const end = offsets[mid + 1]!;
+    if (vertex < start) high = mid - 1;
+    else if (vertex >= end) low = mid + 1;
+    else return [start, end] as const;
   }
   return null;
+}
+
+/** True when a and b lie in the same half-open pathOffsets subpath. */
+export function samePath(batch: GeometryBatch, a: number, b: number): boolean {
+  if (batch.kind !== "paths") return false;
+  const range = pathRange(batch, a);
+  return range !== null && b >= range[0] && b < range[1];
 }
 
 export function insidePath(

--- a/packages/core/src/candidate-store-eager.ts
+++ b/packages/core/src/candidate-store-eager.ts
@@ -7,7 +7,6 @@ import {
   localAnchor,
   pathRange,
   primitiveCount,
-  samePath,
   segmentDistance,
   segmentIntersectsRect,
 } from "./candidate-geometry.js";
@@ -369,6 +368,7 @@ export function buildCandidateStoreEager(
       return d <= batch.linewidth / 2 + 3 ? d : null;
     }
     if (batch.kind === "paths") {
+      // One O(log P) range lookup; reuse for fill containment and stroke neighbors.
       const range = pathRange(batch, i);
       if (batch.fills !== undefined && range !== null) {
         const containmentKey = `${batchIds[id]}:${range[0]}:${range[1]}`;
@@ -380,8 +380,9 @@ export function buildCandidateStoreEager(
         if (contained) return Math.hypot(px - xs[id]!, py - ys[id]!);
       }
       let d = Infinity;
-      for (const other of [i - 1, i + 1])
-        if (other >= 0 && other < batch.rowIndex.length && samePath(batch, i, other))
+      if (range !== null) {
+        for (const other of [i - 1, i + 1]) {
+          if (other < range[0] || other >= range[1]) continue;
           d = Math.min(
             d,
             segmentDistance(
@@ -393,6 +394,8 @@ export function buildCandidateStoreEager(
               batch.positions[other * 2 + 1]!,
             ),
           );
+        }
+      }
       return d <= batch.linewidth / 2 + 3 ? d : null;
     }
     return null;
@@ -417,17 +420,19 @@ export function buildCandidateStoreEager(
     }
     if (batch.kind === "paths") {
       if (xs[id]! >= loX && xs[id]! <= hiX && ys[id]! >= loY && ys[id]! <= hiY) return true;
-      for (const other of [i - 1, i + 1])
-        if (other >= 0 && other < batch.rowIndex.length && samePath(batch, i, other)) {
+      const range = pathRange(batch, i);
+      if (range !== null) {
+        for (const other of [i - 1, i + 1]) {
+          if (other < range[0] || other >= range[1]) continue;
           const ox = panel.x + batch.positions[other * 2]!;
           const oy = panel.y + batch.positions[other * 2 + 1]!;
           if (segmentIntersectsRect(xs[id]!, ys[id]!, ox, oy, loX, loY, hiX, hiY)) return true;
         }
-      const range = pathRange(batch, i);
-      if (batch.fills !== undefined && range !== null) {
-        const centerX = (loX + hiX) / 2 - panel.x;
-        const centerY = (loY + hiY) / 2 - panel.y;
-        if (insidePath(batch, range[0], range[1], centerX, centerY)) return true;
+        if (batch.fills !== undefined) {
+          const centerX = (loX + hiX) / 2 - panel.x;
+          const centerY = (loY + hiY) / 2 - panel.y;
+          if (insidePath(batch, range[0], range[1], centerX, centerY)) return true;
+        }
       }
       return false;
     }

--- a/packages/core/tests/candidate-geometry.test.ts
+++ b/packages/core/tests/candidate-geometry.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "bun:test";
+
+import { pathRange, samePath } from "../src/candidate-geometry.ts";
+import type { PathsBatch } from "../src/scene.ts";
+
+/** Minimal paths batch with the given offsets and enough vertices. */
+function pathsBatch(pathOffsets: readonly number[]): PathsBatch {
+  const last = pathOffsets.at(-1) ?? 0;
+  return {
+    kind: "paths",
+    layerIndex: 0,
+    panelIndex: 0,
+    positions: new Float32Array(Math.max(last, 1) * 2),
+    rowIndex: new Uint32Array(Math.max(last, 1)),
+    pathOffsets: Uint32Array.from(pathOffsets),
+    strokes: Array.from({ length: Math.max(0, pathOffsets.length - 1) }, () => null),
+    linewidth: 1,
+    alpha: 1,
+    curve: "linear",
+  };
+}
+
+describe("pathRange", () => {
+  const offsets = [0, 3, 5, 9] as const;
+  const batch = pathsBatch(offsets);
+
+  it("returns first, middle, and last subpath ranges", () => {
+    expect(pathRange(batch, 0)).toEqual([0, 3]);
+    expect(pathRange(batch, 2)).toEqual([0, 3]);
+    expect(pathRange(batch, 3)).toEqual([3, 5]);
+    expect(pathRange(batch, 4)).toEqual([3, 5]);
+    expect(pathRange(batch, 5)).toEqual([5, 9]);
+    expect(pathRange(batch, 8)).toEqual([5, 9]);
+  });
+
+  it("returns null for out-of-range vertices and empty offsets", () => {
+    expect(pathRange(batch, -1)).toBeNull();
+    expect(pathRange(batch, 9)).toBeNull();
+    expect(pathRange(batch, 100)).toBeNull();
+    expect(pathRange(pathsBatch([]), 0)).toBeNull();
+    expect(pathRange(pathsBatch([0]), 0)).toBeNull();
+  });
+
+  it("skips zero-length spans and accepts fractional vertices like the linear scan", () => {
+    const withEmpty = pathsBatch([0, 2, 2, 5]);
+    expect(pathRange(withEmpty, 1)).toEqual([0, 2]);
+    // vertex 2 falls in the third span [2, 5) because [2, 2) is empty.
+    expect(pathRange(withEmpty, 2)).toEqual([2, 5]);
+    expect(pathRange(withEmpty, 1.5)).toEqual([0, 2]);
+    expect(pathRange(withEmpty, 2.25)).toEqual([2, 5]);
+  });
+});
+
+describe("samePath", () => {
+  const batch = pathsBatch([0, 4, 7]);
+
+  it("is true for vertices in the same subpath, including ends of the half-open range", () => {
+    expect(samePath(batch, 0, 3)).toBe(true);
+    expect(samePath(batch, 3, 1)).toBe(true);
+    expect(samePath(batch, 4, 6)).toBe(true);
+  });
+
+  it("is false across subpath boundaries and for out-of-range seeds", () => {
+    expect(samePath(batch, 3, 4)).toBe(false);
+    expect(samePath(batch, 0, 4)).toBe(false);
+    expect(samePath(batch, -1, 0)).toBe(false);
+    expect(samePath(batch, 7, 6)).toBe(false);
+  });
+
+  it("treats adjacent vertices on a shared boundary as different subpaths", () => {
+    // Vertex 3 is last of first path; vertex 4 is first of second — not samePath.
+    expect(samePath(batch, 3, 4)).toBe(false);
+    expect(samePath(batch, 4, 3)).toBe(false);
+  });
+});

--- a/packages/core/tests/candidate-store.test.ts
+++ b/packages/core/tests/candidate-store.test.ts
@@ -200,6 +200,49 @@ describe("CandidateStore", () => {
     expect(areaStore.nearest(25, 25, { mode: "exact", maxDistance: 0 })?.id).toBe(0);
   });
 
+  it("does not form stroke segments across multi-subpath boundaries", () => {
+    // Two disjoint horizontal strokes. The last vertex of path 0 is (20,0);
+    // the first of path 1 is (0,50). A false edge between them would pass near (10,25).
+    const multi = scene();
+    multi.batches = [
+      {
+        kind: "paths",
+        layerIndex: 0,
+        panelIndex: 0,
+        positions: new Float32Array([0, 0, 10, 0, 20, 0, 0, 50, 10, 50, 20, 50]),
+        rowIndex: new Uint32Array([0, 1, 2, 3, 4, 5]),
+        pathOffsets: new Uint32Array([0, 3, 6]),
+        strokes: [null, null],
+        linewidth: 2,
+        alpha: 1,
+        curve: "linear",
+      },
+    ];
+    const multiStore = buildCandidateStore(multi, {
+      datum: ({ primitiveIndex }) => ({
+        xValue: primitiveIndex,
+        yValue: primitiveIndex < 3 ? 0 : 50,
+        // Force exact geometry so pathRange/samePath are on the refine path.
+        autoMode: "exact",
+      }),
+    });
+    // Midpoint of the false cross-boundary edge must not hit.
+    expect(multiStore.nearest(10, 25, { mode: "exact", maxDistance: 3 })).toBeNull();
+    // Real stroke on path 0 (probe near the middle vertex of the first subpath).
+    const onPath0 = multiStore.nearest(10, 1, { mode: "exact", maxDistance: 3 });
+    expect(onPath0).not.toBeNull();
+    expect(onPath0!.id).toBeLessThan(3);
+    // Real stroke on path 1.
+    const onPath1 = multiStore.nearest(10, 51, { mode: "exact", maxDistance: 3 });
+    expect(onPath1).not.toBeNull();
+    expect(onPath1!.id).toBeGreaterThanOrEqual(3);
+    // Brush covering only the false edge should be empty; covering a real edge is not.
+    expect(multiStore.queryRect(8, 20, 12, 30)).toEqual(new Uint32Array());
+    const brushed = multiStore.queryRect(8, -2, 12, 2);
+    expect([...brushed].every((id) => id < 3)).toBe(true);
+    expect(brushed.length).toBeGreaterThan(0);
+  });
+
   it("rejects segment bounding boxes that do not geometrically intersect a brush", () => {
     const segmentScene = scene();
     segmentScene.batches = [


### PR DESCRIPTION
## Summary

- **Audit target:** `packages/core/src` (narrowed from 304 files to data-scale hot paths: candidate store/geometry, hit-index, stats, scales, grouping, positions)
- **Chosen finding:** `pathRange` / `samePath` walked `pathOffsets` linearly (O(P) per call). On exact `nearest` / `queryRect`, every path vertex is refined, so offset lookups were **O(E·P)** worst case (E = path vertices, P = subpaths / series count).
- **Fix:** Binary search on monotonic `pathOffsets` → **O(log P)** per lookup; reuse one resolved range per candidate for stroke-neighbor checks (no second search via `samePath`). Semantics preserved (half-open ranges, fractional vertices, zero-length spans skipped).
- **Not claimed:** Ordinary auto-mode paths default to `autoMode: "x"` and usually skip `exactDistance`; filled-path `insidePath` cost is separate.

## Complexity

| | Before | After |
|---|--------|--------|
| Offset lookup per candidate | O(P) | O(log P) |
| Exact path refine (worst case) | O(E·P) | O(E log P) |

**n:** E grows with plotted path vertices; P grows with multi-series / multi-subpath line and area batches.

## Test plan

- [x] Unit tests: `pathRange` / `samePath` edges (first/middle/last, empty offsets, zero-length spans, fractional vertices, cross-boundary)
- [x] Integration: multi-subpath exact nearest does not form false stroke across subpath boundary; brush respects real edges only
- [x] Existing candidate-store + full core suite via pre-push hooks

## Other audit findings (follow-up)

- `group()` linear scan over sorted orth within series boundaries
- Directional `traverse` (L/R/U/D) full O(n) scan
- `deriveGroups` `Math.max(...groups)` stack risk at large n