### PR TITLE
fix(ci): close path-routing coverage gaps from Codex #242

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,8 @@ jobs:
             bun scripts/ci-routing.ts emit-github-output --force-all
             exit 0
           fi
-          mapfile -t files < <(git diff --name-only "${BASE_SHA}...${HEAD_SHA}" || true)
+          # --name-status keeps rename/copy source paths for classification.
+          mapfile -t files < <(git diff --name-status "${BASE_SHA}...${HEAD_SHA}" || true)
           if [ "${#files[@]}" -eq 0 ]; then
             # Empty diff (empty commit / metadata-only): still run cheap checks.
             echo "empty changed-file set — checks-only routing"
@@ -129,6 +130,9 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          # Full history: packages/spec manual-AT alias audit tests git-show
+          # hard-coded historical commits (shallow clone would fail unit).
+          fetch-depth: 0
           persist-credentials: false
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -11,12 +11,10 @@ on:
 
 permissions: {}
 
-concurrency:
-  group: pages
-  # Do not cancel in-flight deploys: a later path-routed skip would otherwise
-  # cancel a docs/package Pages build and then skip build/deploy itself,
-  # leaving GitHub Pages stale until another routed push.
-  cancel-in-progress: false
+# Concurrency is intentionally NOT workflow-level. A path-routed `pages=false`
+# run that only executes detect-changes must not enter the deploy group and
+# displace a pending real deploy (GitHub keeps only one pending run per group).
+# Serialize production deploys on the deploy job alone (see below).
 
 jobs:
   detect-changes:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -113,6 +113,11 @@ jobs:
     name: deploy GitHub Pages
     needs: [detect-changes, build]
     if: needs.detect-changes.outputs.pages == 'true' && needs.build.result == 'success'
+    # Serialize production deploys only — skip-only runs never reach this job,
+    # so they cannot cancel or displace a pending deploy of a docs/package push.
+    concurrency:
+      group: pages-deploy
+      cancel-in-progress: false
     # GitHub-hosted: pages write + OIDC; keep privileged deploys off self-hosted.
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -13,7 +13,10 @@ permissions: {}
 
 concurrency:
   group: pages
-  cancel-in-progress: true
+  # Do not cancel in-flight deploys: a later path-routed skip would otherwise
+  # cancel a docs/package Pages build and then skip build/deploy itself,
+  # leaving GitHub Pages stale until another routed push.
+  cancel-in-progress: false
 
 jobs:
   detect-changes:
@@ -55,7 +58,8 @@ jobs:
             bun scripts/ci-routing.ts emit-github-output --force-all
             exit 0
           fi
-          mapfile -t files < <(git diff --name-only "${BASE_SHA}...${HEAD_SHA}" || true)
+          # --name-status keeps rename/copy source paths for classification.
+          mapfile -t files < <(git diff --name-status "${BASE_SHA}...${HEAD_SHA}" || true)
           if [ "${#files[@]}" -eq 0 ]; then
             printf '' | bun scripts/ci-routing.ts emit-github-output --stdin
           else

--- a/.github/workflows/vr-compare.yml
+++ b/.github/workflows/vr-compare.yml
@@ -79,7 +79,8 @@ jobs:
             bun scripts/ci-routing.ts emit-github-output --force-all
             exit 0
           fi
-          mapfile -t files < <(git diff --name-only "${BASE_SHA}...${HEAD_SHA}" || true)
+          # --name-status keeps rename/copy source paths for classification.
+          mapfile -t files < <(git diff --name-status "${BASE_SHA}...${HEAD_SHA}" || true)
           if [ "${#files[@]}" -eq 0 ]; then
             printf '' | bun scripts/ci-routing.ts emit-github-output --stdin
           else

--- a/scripts/ci-routing.test.ts
+++ b/scripts/ci-routing.test.ts
@@ -5,6 +5,7 @@ import {
   evaluateGate,
   formatGithubOutputs,
   matchPathPattern,
+  parseNameStatusList,
   planJobs,
   type JobName,
 } from "./ci-routing.ts";
@@ -67,11 +68,40 @@ describe("classifyChangedPaths", () => {
   });
 });
 
+describe("parseNameStatusList", () => {
+  test("includes both sides of renames and copies", () => {
+    const paths = parseNameStatusList(
+      [
+        "M\tpackages/core/src/x.ts",
+        "R100\tpackages/svelte/src/lib/Old.svelte\tapps/docs/src/lib/Old.svelte",
+        "C050\tscripts/a.ts\tscripts/b.ts",
+        "A\tscripts/new.ts",
+      ].join("\n"),
+    );
+    expect(paths).toContain("packages/core/src/x.ts");
+    expect(paths).toContain("packages/svelte/src/lib/Old.svelte");
+    expect(paths).toContain("apps/docs/src/lib/Old.svelte");
+    expect(paths).toContain("scripts/a.ts");
+    expect(paths).toContain("scripts/b.ts");
+    expect(paths).toContain("scripts/new.ts");
+  });
+
+  test("rename source keeps package surface when destination alone would not", () => {
+    const files = parseNameStatusList(
+      "R100\tpackages/svelte/src/lib/X.svelte\tdocs/notes/X.svelte\n",
+    );
+    const plan = planJobs(classifyChangedPaths(files));
+    expect(plan.component).toBe(true);
+    expect(plan.consumer).toBe(true);
+    expect(plan.build).toBe(true);
+  });
+});
+
 describe("planJobs", () => {
-  test("docs-site-only changes skip unit/component/consumer/bench but keep build+vr+pages", () => {
+  test("docs-site changes run unit+build+vr+pages (script tests cover docs behavior)", () => {
     const plan = planJobs(classifyChangedPaths(["apps/docs/src/routes/guide/+page.svelte"]));
     expect(plan.checks).toBe(true);
-    expect(plan.unit).toBe(false);
+    expect(plan.unit).toBe(true);
     expect(plan.component).toBe(false);
     expect(plan.consumer).toBe(false);
     expect(plan.bench_smoke).toBe(false);
@@ -80,6 +110,21 @@ describe("planJobs", () => {
     expect(plan.vr).toBe(true);
     expect(plan.pages).toBe(true);
     expect(plan.interaction_perf).toBe(false);
+  });
+
+  test("docs generators schedule pages/vr (not scripts-only)", () => {
+    const plan = planJobs(classifyChangedPaths(["scripts/gen-llms.ts"]));
+    expect(plan.unit).toBe(true);
+    expect(plan.pages).toBe(true);
+    expect(plan.vr).toBe(true);
+    expect(plan.component).toBe(false);
+  });
+
+  test("lifecycle.json schedules pages/vr via docs surface", () => {
+    const plan = planJobs(classifyChangedPaths(["lifecycle.json"]));
+    expect(plan.pages).toBe(true);
+    expect(plan.vr).toBe(true);
+    expect(plan.unit).toBe(true);
   });
 
   test("spec changes pull core unit, component, consumer, build, bench, and vr", () => {
@@ -94,15 +139,21 @@ describe("planJobs", () => {
     expect(plan.actions_security).toBe(false);
   });
 
-  test("workflow-only changes run actions-security and checks, not the full suite", () => {
+  test("workflow-only changes run actions-security + unit (release-wiring) without full suite", () => {
     const plan = planJobs(classifyChangedPaths([".github/workflows/pages.yml"]));
     expect(plan.actions_security).toBe(true);
     expect(plan.checks).toBe(true);
-    expect(plan.unit).toBe(false);
+    expect(plan.unit).toBe(true);
     expect(plan.component).toBe(false);
     expect(plan.consumer).toBe(false);
     expect(plan.vr).toBe(false);
     expect(plan.pages).toBe(false);
+  });
+
+  test("actionlint runner changes schedule actions-security", () => {
+    const plan = planJobs(classifyChangedPaths(["scripts/actionlint.ts"]));
+    expect(plan.actions_security).toBe(true);
+    expect(plan.unit).toBe(true);
   });
 
   test("ci.yml self-changes force the full CI surface so routing cannot silently shrink", () => {
@@ -126,11 +177,44 @@ describe("planJobs", () => {
     expect(plan.vr).toBe(true);
   });
 
-  test("root skill source changes schedule the svelte package surface", () => {
+  test("root skill source changes schedule unit (skill-sync) and svelte package surface", () => {
     const plan = planJobs(classifyChangedPaths(["skills/ggsvelte/SKILL.md"]));
+    expect(plan.unit).toBe(true);
     expect(plan.component).toBe(true);
     expect(plan.build).toBe(true);
     expect(plan.consumer).toBe(true);
+  });
+
+  test("svelte-only changes run unit (lifecycle) and bench_smoke (retained-memory)", () => {
+    const plan = planJobs(classifyChangedPaths(["packages/svelte/src/lib/index.ts"]));
+    expect(plan.unit).toBe(true);
+    expect(plan.bench_smoke).toBe(true);
+    expect(plan.component).toBe(true);
+    expect(plan.consumer).toBe(true);
+  });
+
+  test("consumer harness scripts schedule the packed-consumer matrix", () => {
+    const plan = planJobs(classifyChangedPaths(["scripts/consumer-compat.ts"]));
+    expect(plan.consumer).toBe(true);
+    expect(plan.unit).toBe(true);
+  });
+
+  test("manual-AT evidence and community forms schedule unit", () => {
+    expect(
+      planJobs(classifyChangedPaths(["docs/accessibility/manual-at/procedures.json"])).unit,
+    ).toBe(true);
+    expect(planJobs(classifyChangedPaths([".github/ISSUE_TEMPLATE/bug.yml"])).unit).toBe(true);
+    expect(planJobs(classifyChangedPaths([".changeset/config.json"])).unit).toBe(true);
+  });
+
+  test("interaction budgets and docs perf fixtures schedule interaction_perf", () => {
+    expect(
+      planJobs(classifyChangedPaths(["benchmarks/interaction-budgets.json"])).interaction_perf,
+    ).toBe(true);
+    expect(
+      planJobs(classifyChangedPaths(["apps/docs/src/routes/__perf/interaction-100k/+page.svelte"]))
+        .interaction_perf,
+    ).toBe(true);
   });
 
   test("lockfile changes force package-touching jobs", () => {
@@ -171,10 +255,11 @@ describe("planJobs", () => {
 
 describe("evaluateGate", () => {
   test("passes when required jobs succeed and others are skipped", () => {
+    // Docs-site change: unit+build+vr+pages required; browser/consumer skipped.
     const required = planJobs(classifyChangedPaths(["apps/docs/src/app.css"]));
     const results: Record<JobName, string> = {
       checks: "success",
-      unit: "skipped",
+      unit: "success",
       component: "skipped",
       consumer: "skipped",
       build: "success",
@@ -227,7 +312,7 @@ describe("formatGithubOutputs", () => {
     const text = formatGithubOutputs(plan);
     expect(text).toContain("checks=true\n");
     expect(text).toContain("actions_security=true\n");
-    expect(text).toContain("unit=false\n");
+    expect(text).toContain("unit=true\n");
     expect(text).toContain("component=false\n");
   });
 });

--- a/scripts/ci-routing.ts
+++ b/scripts/ci-routing.ts
@@ -29,7 +29,8 @@ export type ChangeLane =
   | "spikes"
   | "lockfile"
   | "markdown"
-  | "performance";
+  | "performance"
+  | "consumer_tools";
 
 export type ChangeFlags = Record<ChangeLane, boolean>;
 
@@ -54,17 +55,49 @@ export const LANE_PATTERNS: Record<ChangeLane, readonly string[]> = {
   spec: ["packages/spec/**"],
   core: ["packages/core/**"],
   svelte: ["packages/svelte/**", "skills/ggsvelte/**"],
-  docs: ["apps/docs/**"],
+  docs: [
+    "apps/docs/**",
+    // Docs app imports `$scripts/gen-llms` and ships lifecycle-driven guide content.
+    "scripts/gen-llms.ts",
+    "scripts/gen-llms.test.ts",
+    "lifecycle.json",
+  ],
   examples: ["examples/**"],
   benchmarks: ["benchmarks/**"],
-  scripts: ["scripts/**", "lifecycle.json"],
+  scripts: [
+    "scripts/**",
+    "lifecycle.json",
+    // Unit suite validates manual-AT evidence + community forms + Changesets config.
+    "docs/accessibility/manual-at/**",
+    ".github/ISSUE_TEMPLATE/**",
+    ".github/DISCUSSION_TEMPLATE/**",
+    ".changeset/**",
+  ],
   evals: ["tests/evals/**"],
-  workflows: [".github/workflows/**", ".github/actionlint.yaml"],
+  workflows: [
+    ".github/workflows/**",
+    ".github/actionlint.yaml",
+    // Only the actions-security job runs the real actionlint runner against workflows.
+    "scripts/actionlint.ts",
+    "scripts/actionlint.test.ts",
+  ],
   ci_workflow: [".github/workflows/ci.yml"],
   ci_routing: ["scripts/ci-routing.ts", "scripts/ci-routing.test.ts"],
   visual: ["tests/visual/**"],
-  performance: ["tests/performance/**"],
+  performance: [
+    "tests/performance/**",
+    // Direct inputs to the Playwright interaction-perf job.
+    "apps/docs/src/routes/__perf/**",
+    "benchmarks/interaction-budgets.json",
+  ],
   spikes: ["spikes/**"],
+  // Packed-consumer harness (not the whole scripts/ tree — matrix is expensive).
+  consumer_tools: [
+    "scripts/consumer-compat.ts",
+    "scripts/consumer-compat.test.ts",
+    "scripts/support-matrix.ts",
+    "scripts/support-matrix.test.ts",
+  ],
   lockfile: [
     "bun.lock",
     "package.json",
@@ -176,6 +209,12 @@ export type PlanOptions = {
 /**
  * Map change lanes → jobs, including monorepo dependency edges:
  * spec → core consumers; core → svelte; packages → VR/pages/build/consumer.
+ *
+ * Coverage edges restored after path-routing (Codex review on #242):
+ * - unit also covers docs/examples/workflows/svelte (script tests live only there)
+ * - consumer follows consumer harness scripts as well as packages
+ * - bench_smoke follows svelte (retained-memory imports inspection)
+ * - docs generators (gen-llms / lifecycle.json) sit on the docs lane → pages/vr
  */
 export function planJobs(changes: ChangeFlags, options: PlanOptions = {}): JobPlan {
   if (options.forceAll === true) {
@@ -200,15 +239,20 @@ export function planJobs(changes: ChangeFlags, options: PlanOptions = {}): JobPl
     unit:
       changes.spec ||
       changes.core ||
+      changes.svelte ||
       changes.scripts ||
       changes.benchmarks ||
       changes.evals ||
+      changes.docs ||
+      changes.examples ||
+      changes.workflows ||
       force,
     component: browserSurface,
-    consumer: packageSurface,
+    consumer: packageSurface || changes.consumer_tools || force,
     build: staticAnalysisSurface,
     actions_security: changes.workflows || force,
-    bench_smoke: changes.benchmarks || changes.spec || changes.core || force,
+    // retained-memory imports packages/svelte inspection coordinator.
+    bench_smoke: changes.benchmarks || changes.spec || changes.core || changes.svelte || force,
     // Informational only; path-gated and independent of the component job.
     interaction_perf: browserSurface,
     vr: packageSurface || docsSurface || changes.visual || force,
@@ -266,6 +310,34 @@ export function parseFileList(text: string): string[] {
     .split(/\r?\n/)
     .map((line) => line.trim())
     .filter((line) => line.length > 0 && !line.startsWith("#"));
+}
+
+/**
+ * Parse `git diff --name-status` stdout into every path involved, including
+ * both sides of renames/copies. `--name-only` drops the source path of a
+ * rename, so a move out of `packages/svelte/**` into docs could skip package
+ * jobs while the package file was effectively removed.
+ */
+export function parseNameStatusList(text: string): string[] {
+  const paths: string[] = [];
+  for (const line of text.split(/\r?\n/)) {
+    const trimmed = line.trimEnd();
+    if (trimmed.length === 0 || trimmed.startsWith("#")) continue;
+    // status\tpath  OR  R100\told\tnew  OR  C100\told\tnew
+    const parts = trimmed.split("\t");
+    if (parts.length < 2) continue;
+    const status = parts[0] ?? "";
+    if (status.startsWith("R") || status.startsWith("C")) {
+      const from = parts[1];
+      const to = parts[2];
+      if (from !== undefined && from.length > 0) paths.push(from);
+      if (to !== undefined && to.length > 0) paths.push(to);
+      continue;
+    }
+    const path = parts[1];
+    if (path !== undefined && path.length > 0) paths.push(path);
+  }
+  return [...new Set(paths)];
 }
 
 export function jobNames(): readonly JobName[] {
@@ -339,6 +411,9 @@ function printHelp(): void {
   bun scripts/ci-routing.ts plan [--files ... | --from-git --base <ref> | --stdin] [--force-all]
   bun scripts/ci-routing.ts emit-github-output [--files ... | --from-git --base <ref> | --stdin] [--force-all]
   bun scripts/ci-routing.ts gate --required <file|-> --results <file|->
+
+  --from-git uses git diff --name-status (rename source + dest).
+  --stdin accepts plain paths or name-status lines (tab-separated).
 `);
 }
 
@@ -351,6 +426,11 @@ async function resolvePlanArgs(args: string[]): Promise<{ files: string[]; force
 async function resolveFiles(args: string[]): Promise<string[]> {
   if (args.includes("--stdin")) {
     const text = await new Response(Bun.stdin.stream()).text();
+    // Workflows pass `git diff --name-status` lines so renames keep both paths.
+    // Plain path lists (one path per line, no tabs) still work via parseFileList.
+    if (text.includes("\t") || /^[AMDCRT?]+\d*\t/m.test(text)) {
+      return parseNameStatusList(text);
+    }
     return parseFileList(text);
   }
 
@@ -364,7 +444,8 @@ async function resolveFiles(args: string[]): Promise<string[]> {
     if (base === undefined || base === "") {
       throw new Error("--from-git requires --base <ref>");
     }
-    const proc = Bun.spawn(["git", "diff", "--name-only", `${base}...HEAD`], {
+    // --name-status keeps rename/copy source paths for classification.
+    const proc = Bun.spawn(["git", "diff", "--name-status", `${base}...HEAD`], {
       stdout: "pipe",
       stderr: "pipe",
     });
@@ -374,7 +455,7 @@ async function resolveFiles(args: string[]): Promise<string[]> {
     if (code !== 0) {
       throw new Error(`git diff failed (exit ${code}): ${stderr.trim()}`);
     }
-    return parseFileList(stdout);
+    return parseNameStatusList(stdout);
   }
 
   // Default: empty list (caller should pass --force-all when appropriate).


### PR DESCRIPTION
## Summary

Follow-up to merged #242 path routing. Codex raised 1×P1 + 14×P2 coverage gaps; all were **valid** and **unimplemented**. This PR fixes them.

### Fixes (Codex #242)

| Severity | Finding | Fix |
|----------|---------|-----|
| P1 | Unit checkout shallow → manual-AT alias audit needs history | `fetch-depth: 0` on unit job |
| P2 | `git diff --name-only` drops rename sources | `--name-status` + `parseNameStatusList` |
| P2 | gen-llms / lifecycle.json skip pages/vr | docs lane includes generators |
| P2 | svelte-only skips bench_smoke | bench_smoke includes svelte |
| P2 | consumer harness skips consumer matrix | `consumer_tools` lane |
| P2 | manual-AT evidence unclassified | scripts lane |
| P2 | docs/examples skip unit script tests | unit includes docs/examples |
| P2 | ISSUE/DISCUSSION templates skip unit | scripts lane |
| P2 | skill edits skip skill-sync unit test | unit includes svelte |
| P2 | interaction budgets skip interaction_perf | performance lane inputs |
| P2 | actionlint.ts skips actions-security | workflows lane |
| P2 | Changesets config unclassified | scripts lane |
| P2 | workflow edits skip release-wiring unit | unit includes workflows |
| P2 | Pages cancel + skip leaves site stale | `cancel-in-progress: false` |
| P2 | svelte index skips lifecycle unit | unit includes svelte |

## Test plan

- [x] `bun test scripts/ci-routing.test.ts scripts/release-wiring.test.ts`
- [x] `bun scripts/actionlint.ts` clean
- [x] `bun run lint:type-aware` clean
- [ ] PR CI (touches `ci.yml` + router → force-all self-test)