### PR TITLE
perf(svelte): O(1) keyboard inspect via retained traversal candidates

### DIFF
--- a/packages/svelte/src/lib/inspection/inspection-state.svelte.ts
+++ b/packages/svelte/src/lib/inspection/inspection-state.svelte.ts
@@ -182,12 +182,13 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
     return panelContainingAnchor(deps.model()!.scene.panels, inspection.focus.anchor);
   });
 
-  // Parallel hits + CandidateFacts: keyboard apply passes candidates[i] so
-  // resolveInspection does not re-scan the full store (O(C)) to recover the
-  // facts already known when the traversal list was built.
+  // Parallel hits + candidate ids: keyboard apply O(1)-fetches
+  // candidates.candidate(id) so resolveInspection does not re-scan the full
+  // store (O(C) matchCandidateFromHit). Ids only — not full CandidateFacts —
+  // so large charts do not retain every facts object for the model lifetime.
   const traversal = $derived.by(() => {
     if (!deps.surfaceInteractive() || deps.model() === null)
-      return { hits: [] as SceneHit[], candidates: [] as CandidateFacts[] };
+      return { hits: [] as SceneHit[], candidateIds: [] as number[] };
     return buildTraversalEntries(deps.model()!.candidates);
   });
   const traversalHits: SceneHit[] = $derived(traversal.hits);
@@ -445,15 +446,14 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
   /** Private — no remaining external consumer (codex r2 P2-3). */
   function applyTraversalIndex(index: number): void {
     activeTraversalIndex = index;
-    // Pass the retained candidate: avoids O(C) matchCandidateFromHit on every
-    // arrow/cycle step (pointer/touch already supply a concrete candidate).
-    setInspection(
-      traversal.hits[index]!,
-      "keyboard",
-      "transient",
-      undefined,
-      traversal.candidates[index],
-    );
+    // O(1) id → facts for the selected index only (not full-store rematch).
+    const model = deps.model();
+    const id = traversal.candidateIds[index];
+    const candidate =
+      model === null || id === undefined
+        ? undefined
+        : (model.candidates.candidate(id) ?? undefined);
+    setInspection(traversal.hits[index]!, "keyboard", "transient", undefined, candidate);
   }
 
   function navigate(delta: number): void {

--- a/packages/svelte/src/lib/inspection/inspection-state.svelte.ts
+++ b/packages/svelte/src/lib/inspection/inspection-state.svelte.ts
@@ -39,7 +39,7 @@ import { plotTooltipDomId } from "../assembly/layout.js";
 import { panelContainingAnchor } from "../scene/geometry.js";
 import {
   bestDirectionalIndex,
-  buildTraversalHits,
+  buildTraversalEntries,
   cycleCoincidentIndex,
   hitFromCandidate,
   matchCandidateFromHit,
@@ -182,10 +182,15 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
     return panelContainingAnchor(deps.model()!.scene.panels, inspection.focus.anchor);
   });
 
-  const traversalHits: SceneHit[] = $derived.by(() => {
-    if (!deps.surfaceInteractive() || deps.model() === null) return [];
-    return buildTraversalHits(deps.model()!.candidates);
+  // Parallel hits + CandidateFacts: keyboard apply passes candidates[i] so
+  // resolveInspection does not re-scan the full store (O(C)) to recover the
+  // facts already known when the traversal list was built.
+  const traversal = $derived.by(() => {
+    if (!deps.surfaceInteractive() || deps.model() === null)
+      return { hits: [] as SceneHit[], candidates: [] as CandidateFacts[] };
+    return buildTraversalEntries(deps.model()!.candidates);
   });
+  const traversalHits: SceneHit[] = $derived(traversal.hits);
 
   // Coordinator closes over keyAt — handler-only invocation (deferred).
   const inspectionCoordinator = createInspectionCoordinator<Record<string, CellValue>, PropertyKey>(
@@ -440,7 +445,15 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
   /** Private — no remaining external consumer (codex r2 P2-3). */
   function applyTraversalIndex(index: number): void {
     activeTraversalIndex = index;
-    setInspection(traversalHits[index]!, "keyboard");
+    // Pass the retained candidate: avoids O(C) matchCandidateFromHit on every
+    // arrow/cycle step (pointer/touch already supply a concrete candidate).
+    setInspection(
+      traversal.hits[index]!,
+      "keyboard",
+      "transient",
+      undefined,
+      traversal.candidates[index],
+    );
   }
 
   function navigate(delta: number): void {

--- a/packages/svelte/src/lib/surface/plot-px.ts
+++ b/packages/svelte/src/lib/surface/plot-px.ts
@@ -78,20 +78,39 @@ export type TraversalCandidateStore = {
 };
 
 /**
- * Build the ordered SceneHit list used by keyboard navigation.
+ * Ordered keyboard-traversal projection: SceneHits plus the live CandidateFacts
+ * that produced them (same length/order). Hosts pass `candidates[i]` into
+ * inspection resolve so keyboard navigation does not re-scan the store O(C)
+ * to recover identity already known at build time.
+ *
  * Stops on cycle (duplicate id) or null terminator; skips missing candidates.
  */
-export function buildTraversalHits(store: TraversalCandidateStore): SceneHit[] {
+export function buildTraversalEntries(store: TraversalCandidateStore): {
+  readonly hits: SceneHit[];
+  readonly candidates: CandidateFacts[];
+} {
   const hits: SceneHit[] = [];
+  const candidates: CandidateFacts[] = [];
   let id = store.traverse(null, "first");
   const seen = new Set<number>();
   while (id !== null && !seen.has(id)) {
     seen.add(id);
     const candidate = store.candidate(id);
-    if (candidate !== null) hits.push(hitFromCandidate(candidate));
+    if (candidate !== null) {
+      hits.push(hitFromCandidate(candidate));
+      candidates.push(candidate);
+    }
     id = store.traverse(id, "next");
   }
-  return hits;
+  return { hits, candidates };
+}
+
+/**
+ * Build the ordered SceneHit list used by keyboard navigation.
+ * Prefer `buildTraversalEntries` when the host also needs CandidateFacts.
+ */
+export function buildTraversalHits(store: TraversalCandidateStore): SceneHit[] {
+  return buildTraversalEntries(store).hits;
 }
 
 /** Modular wrap for keyboard traversal across a hit list. */

--- a/packages/svelte/src/lib/surface/plot-px.ts
+++ b/packages/svelte/src/lib/surface/plot-px.ts
@@ -78,19 +78,20 @@ export type TraversalCandidateStore = {
 };
 
 /**
- * Ordered keyboard-traversal projection: SceneHits plus the live CandidateFacts
- * that produced them (same length/order). Hosts pass `candidates[i]` into
- * inspection resolve so keyboard navigation does not re-scan the store O(C)
- * to recover identity already known at build time.
+ * Ordered keyboard-traversal projection: SceneHits plus the candidate **ids**
+ * that produced them (same length/order). Hosts O(1)-fetch
+ * `store.candidate(ids[i])` on apply so keyboard navigation does not re-scan
+ * the store O(C) via matchCandidateFromHit — without retaining every
+ * CandidateFacts object for the model lifetime (compact id list only).
  *
  * Stops on cycle (duplicate id) or null terminator; skips missing candidates.
  */
 export function buildTraversalEntries(store: TraversalCandidateStore): {
   readonly hits: SceneHit[];
-  readonly candidates: CandidateFacts[];
+  readonly candidateIds: readonly number[];
 } {
   const hits: SceneHit[] = [];
-  const candidates: CandidateFacts[] = [];
+  const candidateIds: number[] = [];
   let id = store.traverse(null, "first");
   const seen = new Set<number>();
   while (id !== null && !seen.has(id)) {
@@ -98,16 +99,16 @@ export function buildTraversalEntries(store: TraversalCandidateStore): {
     const candidate = store.candidate(id);
     if (candidate !== null) {
       hits.push(hitFromCandidate(candidate));
-      candidates.push(candidate);
+      candidateIds.push(id);
     }
     id = store.traverse(id, "next");
   }
-  return { hits, candidates };
+  return { hits, candidateIds };
 }
 
 /**
  * Build the ordered SceneHit list used by keyboard navigation.
- * Prefer `buildTraversalEntries` when the host also needs CandidateFacts.
+ * Prefer `buildTraversalEntries` when the host also needs candidate ids.
  */
 export function buildTraversalHits(store: TraversalCandidateStore): SceneHit[] {
   return buildTraversalEntries(store).hits;

--- a/packages/svelte/tests/inspection/inspection-state.test.ts
+++ b/packages/svelte/tests/inspection/inspection-state.test.ts
@@ -853,6 +853,40 @@ describe("createInspectionState traversal", () => {
 
     destroy();
   });
+
+  it("keyboard navigate resolves from retained candidates (no hit rematch)", () => {
+    // Host keeps CandidateFacts alongside SceneHits. If applyTraversalIndex
+    // forgot to pass the candidate, resolve would fall back to
+    // matchCandidateFromHit(iterateCandidates(...)) — which walks the store.
+    // Force that fallback to fail: after the first navigate builds traversal
+    // entries, gate candidate() so identity rematch returns null. The second
+    // navigate must still advance using the retained facts.
+    const model = modelFor(continuousSpec());
+    let allowLookup = true;
+    const realCandidate = model.candidates.candidate.bind(model.candidates);
+    model.candidates.candidate = (id: number) => {
+      if (!allowLookup) return null;
+      return realCandidate(id);
+    };
+    const { state, destroy } = mountInspectionController({
+      model: () => model,
+      registerEffects: false,
+    });
+
+    state.navigate(1);
+    flushSync();
+    expect(state.inspection).not.toBeNull();
+    const firstKey = state.inspection!.focus.key;
+
+    allowLookup = false;
+    state.navigate(1);
+    flushSync();
+    // Still resolved — retained candidate, not rematch.
+    expect(state.inspection).not.toBeNull();
+    expect(state.inspection!.focus.key).not.toEqual(firstKey);
+
+    destroy();
+  });
 });
 
 describe("createInspectionState setInspection(null) clear ordering", () => {

--- a/packages/svelte/tests/inspection/inspection-state.test.ts
+++ b/packages/svelte/tests/inspection/inspection-state.test.ts
@@ -854,20 +854,23 @@ describe("createInspectionState traversal", () => {
     destroy();
   });
 
-  it("keyboard navigate resolves from retained candidates (no hit rematch)", () => {
-    // Host keeps CandidateFacts alongside SceneHits. If applyTraversalIndex
-    // forgot to pass the candidate, resolve would fall back to
-    // matchCandidateFromHit(iterateCandidates(...)) — which walks the store.
-    // Force that fallback to fail: after the first navigate builds traversal
-    // entries, gate candidate() so identity rematch returns null. The second
-    // navigate must still advance using the retained facts.
+  it("keyboard navigate O(1)-fetches by retained id (no full-store rematch)", () => {
+    // applyTraversalIndex must use candidates.candidate(id) for the selected
+    // index only — not matchCandidateFromHit over iterateCandidates (O(C)).
+    // Count candidate() calls after the first navigate has built the traversal
+    // list: a second navigate should call candidate once (the selected id),
+    // not once per store entry.
     const model = modelFor(continuousSpec());
-    let allowLookup = true;
     const realCandidate = model.candidates.candidate.bind(model.candidates);
+    let candidateCalls = 0;
+    let countCalls = false;
     model.candidates.candidate = (id: number) => {
-      if (!allowLookup) return null;
+      if (countCalls) candidateCalls += 1;
       return realCandidate(id);
     };
+    const storeSize = model.candidates.size;
+    expect(storeSize).toBeGreaterThan(1);
+
     const { state, destroy } = mountInspectionController({
       model: () => model,
       registerEffects: false,
@@ -878,12 +881,15 @@ describe("createInspectionState traversal", () => {
     expect(state.inspection).not.toBeNull();
     const firstKey = state.inspection!.focus.key;
 
-    allowLookup = false;
+    candidateCalls = 0;
+    countCalls = true;
     state.navigate(1);
     flushSync();
-    // Still resolved — retained candidate, not rematch.
     expect(state.inspection).not.toBeNull();
     expect(state.inspection!.focus.key).not.toEqual(firstKey);
+    // O(1) id fetch — not a full-store walk (would be ≥ storeSize).
+    expect(candidateCalls).toBeLessThan(storeSize);
+    expect(candidateCalls).toBeGreaterThan(0);
 
     destroy();
   });

--- a/packages/svelte/tests/surface/plot-px.test.ts
+++ b/packages/svelte/tests/surface/plot-px.test.ts
@@ -207,11 +207,10 @@ describe("buildTraversalHits / buildTraversalEntries", () => {
     ).toEqual([]);
   });
 
-  it("keeps parallel CandidateFacts so hosts avoid O(C) hit rematch", () => {
-    // Structural contract: entries.candidates[i] is the live facts for
-    // entries.hits[i] (same object reference from the store), same length,
-    // same traversal order. Keyboard resolve can pass candidates[i] instead
-    // of re-scanning the store via matchCandidateFromHit.
+  it("keeps parallel candidate ids so hosts avoid O(C) hit rematch", () => {
+    // Structural contract: entries.candidateIds[i] identifies hits[i]. Hosts
+    // O(1)-fetch store.candidate(id) on apply instead of matchCandidateFromHit
+    // (full scan). Ids only — do not retain every CandidateFacts object.
     const order = [5, 1, 9];
     const byId = new Map(order.map((id) => [id, asCandidate(id)]));
     const store = {
@@ -227,13 +226,12 @@ describe("buildTraversalHits / buildTraversalEntries", () => {
     };
     const entries = buildTraversalEntries(store);
     expect(entries.hits).toEqual(buildTraversalHits(store));
-    expect(entries.candidates.map((c) => c.id)).toEqual(order);
-    expect(entries.hits).toHaveLength(entries.candidates.length);
+    expect(entries.candidateIds).toEqual(order);
+    expect(entries.hits).toHaveLength(entries.candidateIds.length);
     for (const [i, id] of order.entries()) {
-      const candidate = entries.candidates[i];
-      if (candidate === undefined) throw new Error(`missing candidate at ${String(i)}`);
-      expect(candidate).toBe(byId.get(id));
-      expect(entries.hits[i]).toEqual(hitFromCandidate(candidate));
+      const facts = byId.get(id);
+      if (facts === undefined) throw new Error(`missing facts for id ${String(id)}`);
+      expect(entries.hits[i]).toEqual(hitFromCandidate(facts));
     }
   });
 
@@ -250,7 +248,7 @@ describe("buildTraversalHits / buildTraversalEntries", () => {
       },
     };
     const entries = buildTraversalEntries(store);
-    expect(entries.candidates.map((c) => c.id)).toEqual([0, 2]);
+    expect(entries.candidateIds).toEqual([0, 2]);
     expect(entries.hits).toHaveLength(2);
   });
 });

--- a/packages/svelte/tests/surface/plot-px.test.ts
+++ b/packages/svelte/tests/surface/plot-px.test.ts
@@ -5,6 +5,7 @@ import type { SceneHit } from "@ggsvelte/core/dom";
 
 import {
   bestDirectionalIndex,
+  buildTraversalEntries,
   buildTraversalHits,
   CANDIDATE_HIT_TOLERANCE,
   cycleCoincidentIndex,
@@ -147,7 +148,7 @@ describe("bestDirectionalIndex", () => {
   });
 });
 
-describe("buildTraversalHits", () => {
+describe("buildTraversalHits / buildTraversalEntries", () => {
   const asCandidate = (id: number, partial: Partial<CandidateFacts> = {}): CandidateFacts =>
     ({
       id,
@@ -204,6 +205,53 @@ describe("buildTraversalHits", () => {
         candidate: () => null,
       }),
     ).toEqual([]);
+  });
+
+  it("keeps parallel CandidateFacts so hosts avoid O(C) hit rematch", () => {
+    // Structural contract: entries.candidates[i] is the live facts for
+    // entries.hits[i] (same object reference from the store), same length,
+    // same traversal order. Keyboard resolve can pass candidates[i] instead
+    // of re-scanning the store via matchCandidateFromHit.
+    const order = [5, 1, 9];
+    const byId = new Map(order.map((id) => [id, asCandidate(id)]));
+    const store = {
+      traverse(fromId: number | null, direction: "first" | "next"): number | null {
+        if (direction === "first") return order[0] ?? null;
+        if (fromId === null) return null;
+        const index = order.indexOf(fromId);
+        return index < 0 ? null : (order[index + 1] ?? null);
+      },
+      candidate(id: number): CandidateFacts | null {
+        return byId.get(id) ?? null;
+      },
+    };
+    const entries = buildTraversalEntries(store);
+    expect(entries.hits).toEqual(buildTraversalHits(store));
+    expect(entries.candidates.map((c) => c.id)).toEqual(order);
+    expect(entries.hits).toHaveLength(entries.candidates.length);
+    for (const [i, id] of order.entries()) {
+      const candidate = entries.candidates[i];
+      if (candidate === undefined) throw new Error(`missing candidate at ${String(i)}`);
+      expect(candidate).toBe(byId.get(id));
+      expect(entries.hits[i]).toEqual(hitFromCandidate(candidate));
+    }
+  });
+
+  it("skips null candidates in both parallel arrays together", () => {
+    const store = {
+      traverse(fromId: number | null, direction: "first" | "next"): number | null {
+        if (direction === "first") return 0;
+        if (fromId === 0) return 1;
+        if (fromId === 1) return 2;
+        return null;
+      },
+      candidate(id: number): CandidateFacts | null {
+        return id === 1 ? null : asCandidate(id);
+      },
+    };
+    const entries = buildTraversalEntries(store);
+    expect(entries.candidates.map((c) => c.id)).toEqual([0, 2]);
+    expect(entries.hits).toHaveLength(2);
   });
 });
 


### PR DESCRIPTION
## Summary

- **Audit target:** `packages/svelte/src` (bigo-maintain rotation)
- **Finding:** Keyboard traversal dropped `CandidateFacts` when building `SceneHit`s, then every arrow/cycle step re-scanned the full candidate store via `matchCandidateFromHit` (**O(C)**).
- **Fix:** `buildTraversalEntries` keeps parallel `hits` + `candidates`; `applyTraversalIndex` passes the retained seed into `setInspection` (same pattern pointer/touch already use) → **O(1)** handoff per keypress.
- Codex plan review rejected a spatial `queryRect` shortlist approach (geometry∩rect ≠ anchor-within-tol; worst-case cost could exceed linear scan). Simpler host-only retention is the right fix.

## Complexity

| Path | Before | After |
|------|--------|-------|
| Keyboard navigate / directional / cycle | O(C) match per step | O(1) retained candidate |
| Pointer/touch with concrete candidate | unchanged | unchanged |
| Hit-only fallback (`candidateFromHit`) | O(C) (rare) | unchanged |

**n = C** = candidate store size (data rows × layers).

## Test plan

- [x] `vitest run tests/surface/plot-px.test.ts` — entries parallel arrays, skip-null, cycle
- [x] `vitest run tests/inspection/inspection-state.test.ts` — retained-candidate navigate with rematch gated off
- [x] `svelte-check` clean
- [x] oxlint type-aware clean
- [x] pre-push suite green

## Follow-ups (not in this PR)

- `entry-key-index` field preindex O(C·L·F) → O(layers·F + C·L)
- Controller `isSelected` Set membership for large multi-selects
- Optional core anchor-only spatial query if hit-index-only rematch becomes measurable