### PR TITLE
ci: tier PR consumer matrix (pr default vs run-compat) (#246)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ on:
   push:
     branches: [main]
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
 
 permissions: {}
 
@@ -243,9 +244,25 @@ jobs:
         with:
           bun-version: 1.3.14
       - id: matrix
-        name: emit required packed-consumer rows
+        name: emit packed-consumer matrix (PR default vs full required)
+        # Issue #246: PRs run one Linux consumer row by default; full required
+        # matrix when labeled run-compat (or on push/main). Nightly workflow
+        # still covers the expanded set including Windows/macOS extras.
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
         shell: bash
-        run: echo "matrix=$(bun scripts/support-matrix.ts required)" >> "$GITHUB_OUTPUT"
+        run: |
+          set -euo pipefail
+          flavor=required
+          if [ "${EVENT_NAME}" = "pull_request" ]; then
+            flavor=pr
+            if printf '%s' "${PR_LABELS}" | tr ',' '\n' | grep -qx 'run-compat'; then
+              flavor=required
+            fi
+          fi
+          echo "support-matrix flavor=${flavor} labels=${PR_LABELS:-}"
+          echo "matrix=$(bun scripts/support-matrix.ts "${flavor}")" >> "$GITHUB_OUTPUT"
 
   consumer-compat:
     name: packed consumer (${{ matrix.os }}, Node ${{ matrix.node }}, ${{ matrix.packageManager }}, Svelte ${{ matrix.svelte }})

--- a/scripts/release-wiring.test.ts
+++ b/scripts/release-wiring.test.ts
@@ -172,3 +172,9 @@ it("thins expensive jobs on main push (issue #244)", () => {
   expect(ci).toContain("main push: thinned expensive jobs (issue #244)");
   expect(ci).toContain("packages_dist=false");
 });
+
+it("tiers the PR consumer matrix (issue #246)", () => {
+  const ci = read(".github/workflows/ci.yml");
+  expect(ci).toContain("run-compat");
+  expect(ci).toContain("flavor=pr");
+});

--- a/scripts/support-matrix.test.ts
+++ b/scripts/support-matrix.test.ts
@@ -6,12 +6,21 @@ import {
   loadSupportMatrix,
   requiredConsumerRows,
   nightlyConsumerRows,
+  prDefaultConsumerRows,
   validateSupportMatrix,
 } from "./support-matrix.js";
 
 const root = join(import.meta.dir, "..");
 
 describe("consumer support matrix", () => {
+  test("PR default tier is a single Linux required row (issue #246)", () => {
+    const matrix = loadSupportMatrix();
+    const pr = prDefaultConsumerRows(matrix);
+    expect(pr).toHaveLength(1);
+    expect(pr[0]?.os).toBe("ubuntu-latest");
+    expect(requiredConsumerRows(matrix).some((r) => r.os === "ubuntu-latest")).toBe(true);
+  });
+
   test("is valid and has a bounded required/full nightly split", () => {
     const matrix = loadSupportMatrix(root);
     expect(validateSupportMatrix(matrix)).toEqual([]);

--- a/scripts/support-matrix.ts
+++ b/scripts/support-matrix.ts
@@ -33,6 +33,15 @@ export function nightlyConsumerRows(matrix: SupportMatrix): ConsumerRow[] {
   return matrix.nightly;
 }
 
+/** PR default tier (issue #246): one Linux required row — full required via run-compat / nightly. */
+export function prDefaultConsumerRows(matrix: SupportMatrix): ConsumerRow[] {
+  const linux = matrix.required.find((row) => row.os === "ubuntu-latest");
+  if (linux === undefined) {
+    throw new Error("support-matrix required rows must include at least one ubuntu-latest row");
+  }
+  return [linux];
+}
+
 export function validateSupportMatrix(matrix: SupportMatrix): string[] {
   const errors: string[] = [];
   if (matrix.schemaVersion !== 1) errors.push("schemaVersion must be 1");
@@ -114,7 +123,9 @@ if (import.meta.main) {
     }));
   if (flavor === "required")
     console.log(JSON.stringify({ include: withVersions(matrix.required) }));
-  else if (flavor === "nightly") {
+  else if (flavor === "pr") {
+    console.log(JSON.stringify({ include: withVersions(prDefaultConsumerRows(matrix)) }));
+  } else if (flavor === "nightly") {
     console.log(JSON.stringify({ include: withVersions([...matrix.required, ...matrix.nightly]) }));
   } else console.log("support-matrix: valid");
 }


### PR DESCRIPTION
## Summary

Implements #246 consumer tiering:

| Event | Matrix |
|-------|--------|
| PR (default) | 1× Linux required row (`support-matrix.ts pr`) |
| PR labeled `run-compat` | Full required matrix (incl. Windows); also forces `consumer` + `packages_dist` even when path routing would skip |
| push to main | Thinned per #244 (consumer/component/bench stay PR-primary) |
| Nightly workflow | required + nightly extras |

Windows remains on the required/nightly tier deliberately (documented in workflow comments). Re-runs on `labeled`/`unlabeled` so adding `run-compat` expands coverage without a new commit.

Closes #246

## Test plan

- [x] `bun test scripts/support-matrix.test.ts scripts/release-wiring.test.ts`
- [ ] PR CI: one packed-consumer row by default
- [ ] Label `run-compat` expands to full required matrix (including docs-only PRs)