### PR TITLE
perf(core): O(log M) group() closest orth via binary search

### DIFF
--- a/packages/core/src/candidate-geometry.ts
+++ b/packages/core/src/candidate-geometry.ts
@@ -110,17 +110,63 @@ export function samePath(batch: GeometryBatch, a: number, b: number): boolean {
 }
 
 /**
+ * Whether `id` beats `bestId` for group() representative selection.
+ * Matches the historical linear scan: min |orth-seed|, then higher batchId,
+ * then lower source; full equality keeps the earlier (left) member.
+ */
+function betterOrthCandidate(
+  id: number,
+  bestId: number,
+  orth: ArrayLike<number>,
+  batchIds: ArrayLike<number>,
+  sources: ArrayLike<number>,
+  seedOrth: number,
+): boolean {
+  const distance = Math.abs(orth[id]! - seedOrth);
+  const prior = Math.abs(orth[bestId]! - seedOrth);
+  // NaN never improves (matches `distance < prior` being false for NaN).
+  // ±Infinity distances compare equal and fall through to batch/source ties.
+  if (Number.isNaN(distance)) return false;
+  if (Number.isNaN(prior)) return true;
+  if (distance < prior) return true;
+  if (distance > prior) return false;
+  if (batchIds[id]! > batchIds[bestId]!) return true;
+  if (batchIds[id]! < batchIds[bestId]!) return false;
+  return sources[id]! < sources[bestId]!;
+}
+
+/** Linear closest — used for non-finite seedOrth and as the full-tie contract. */
+function closestOrthLinear(
+  permutation: ArrayLike<number>,
+  orth: ArrayLike<number>,
+  batchIds: ArrayLike<number>,
+  sources: ArrayLike<number>,
+  start: number,
+  end: number,
+  seedOrth: number,
+): number {
+  let best = permutation[start]!;
+  for (let cursor = start + 1; cursor < end; cursor++) {
+    const id = permutation[cursor]!;
+    if (betterOrthCandidate(id, best, orth, batchIds, sources, seedOrth)) best = id;
+  }
+  return best;
+}
+
+/**
  * Closest candidate in a series range already sorted by ascending orth, then
- * batchId, then source (CandidateStore group-bucket contract).
+ * batchId, then source (CandidateStore group-bucket contract: constant rank /
+ * layer / series within the range).
  *
  * Preference matches the historical linear scan:
  * 1. minimize |orth[id] - seedOrth|
  * 2. on equal distance: higher batchId wins
  * 3. still tied: lower source wins
+ * 4. still tied: earlier index in the range (first duplicate)
  *
- * Complexity: O(log M + T) for finite seedOrth (lower_bound + expand the
- * equal-distance run of size T). Non-finite seedOrth falls back to the first
- * id — same as the linear scan when every |Δ| is NaN and never improves.
+ * Complexity: O(log M + T) for finite seedOrth (lower_bound + equal-distance
+ * run of size T). Non-finite seedOrth uses a linear pass so Infinity seeds
+ * still apply batch/source ties among finite members.
  */
 export function closestOrthInRange(
   permutation: ArrayLike<number>,
@@ -130,58 +176,70 @@ export function closestOrthInRange(
   start: number,
   end: number,
   seedOrth: number,
+  /** False when ranks (or other pre-orth keys) vary — range is not orth-sorted. */
+  orthSorted: boolean = true,
 ): number {
   if (start >= end) {
     throw new RangeError("closestOrthInRange: empty range");
   }
-  if (end - start === 1 || !Number.isFinite(seedOrth)) return permutation[start]!;
+  if (end - start === 1) return permutation[start]!;
+  // NaN / ± seed, or rank-blocked range: linear scan (batch/source ties).
+  if (!Number.isFinite(seedOrth) || !orthSorted) {
+    return closestOrthLinear(permutation, orth, batchIds, sources, start, end, seedOrth);
+  }
 
-  // lower_bound: first index with finite orth >= seedOrth (non-finite orth
-  // sorts as "less than" so the bound still lands among usable values).
+  // lower_bound: first index with orth >= seedOrth (JS: NaN/∞ comparisons
+  // match Array sort used to build the range).
   let lo = start;
   let hi = end;
   while (lo < hi) {
     const mid = (lo + hi) >>> 1;
-    const value = orth[permutation[mid]!]!;
-    if (!Number.isFinite(value) || value < seedOrth) lo = mid + 1;
+    if (orth[permutation[mid]!]! < seedOrth) lo = mid + 1;
     else hi = mid;
   }
 
+  // Probe the two candidates that straddle seedOrth to learn min distance.
   let bestId = -1;
   let bestDist = Number.POSITIVE_INFINITY;
-  const consider = (id: number): void => {
+  const note = (id: number): void => {
     const distance = Math.abs(orth[id]! - seedOrth);
     if (!Number.isFinite(distance)) return;
-    if (
-      bestId < 0 ||
-      distance < bestDist ||
-      (distance === bestDist &&
-        (batchIds[id]! > batchIds[bestId]! ||
-          (batchIds[id] === batchIds[bestId] && sources[id]! < sources[bestId]!)))
-    ) {
+    if (bestId < 0 || distance < bestDist) {
       bestId = id;
       bestDist = distance;
     }
   };
+  if (lo > start) note(permutation[lo - 1]!);
+  if (lo < end) note(permutation[lo]!);
+  if (bestId < 0) {
+    return closestOrthLinear(permutation, orth, batchIds, sources, start, end, seedOrth);
+  }
 
-  if (lo > start) consider(permutation[lo - 1]!);
-  if (lo < end) consider(permutation[lo]!);
-  if (bestId < 0) return permutation[start]!;
+  // Left edge of the equal-distance run (scan L→R so full ties keep first).
+  let left =
+    lo > start && Math.abs(orth[permutation[lo - 1]!]! - seedOrth) === bestDist
+      ? lo - 1
+      : lo < end
+        ? lo
+        : lo - 1;
+  while (left > start) {
+    const distance = Math.abs(orth[permutation[left - 1]!]! - seedOrth);
+    if (distance !== bestDist) break;
+    left--;
+  }
 
-  // Expand equal-distance runs left of lo-1 and right of lo (sorted orth).
-  for (let i = lo - 2; i >= start; i--) {
+  let best = permutation[left]!;
+  for (let i = left + 1; i < end; i++) {
     const id = permutation[i]!;
     const distance = Math.abs(orth[id]! - seedOrth);
-    if (!Number.isFinite(distance) || distance > bestDist) break;
-    consider(id);
+    if (distance !== bestDist) {
+      // Sorted orth: once distance exceeds bestDist we are past the run.
+      if (!Number.isFinite(distance) || distance > bestDist) break;
+      continue;
+    }
+    if (betterOrthCandidate(id, best, orth, batchIds, sources, seedOrth)) best = id;
   }
-  for (let i = lo + 1; i < end; i++) {
-    const id = permutation[i]!;
-    const distance = Math.abs(orth[id]! - seedOrth);
-    if (!Number.isFinite(distance) || distance > bestDist) break;
-    consider(id);
-  }
-  return bestId;
+  return best;
 }
 
 export function insidePath(

--- a/packages/core/src/candidate-geometry.ts
+++ b/packages/core/src/candidate-geometry.ts
@@ -109,6 +109,81 @@ export function samePath(batch: GeometryBatch, a: number, b: number): boolean {
   return range !== null && b >= range[0] && b < range[1];
 }
 
+/**
+ * Closest candidate in a series range already sorted by ascending orth, then
+ * batchId, then source (CandidateStore group-bucket contract).
+ *
+ * Preference matches the historical linear scan:
+ * 1. minimize |orth[id] - seedOrth|
+ * 2. on equal distance: higher batchId wins
+ * 3. still tied: lower source wins
+ *
+ * Complexity: O(log M + T) for finite seedOrth (lower_bound + expand the
+ * equal-distance run of size T). Non-finite seedOrth falls back to the first
+ * id — same as the linear scan when every |Δ| is NaN and never improves.
+ */
+export function closestOrthInRange(
+  permutation: ArrayLike<number>,
+  orth: ArrayLike<number>,
+  batchIds: ArrayLike<number>,
+  sources: ArrayLike<number>,
+  start: number,
+  end: number,
+  seedOrth: number,
+): number {
+  if (start >= end) {
+    throw new RangeError("closestOrthInRange: empty range");
+  }
+  if (end - start === 1 || !Number.isFinite(seedOrth)) return permutation[start]!;
+
+  // lower_bound: first index with finite orth >= seedOrth (non-finite orth
+  // sorts as "less than" so the bound still lands among usable values).
+  let lo = start;
+  let hi = end;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    const value = orth[permutation[mid]!]!;
+    if (!Number.isFinite(value) || value < seedOrth) lo = mid + 1;
+    else hi = mid;
+  }
+
+  let bestId = -1;
+  let bestDist = Number.POSITIVE_INFINITY;
+  const consider = (id: number): void => {
+    const distance = Math.abs(orth[id]! - seedOrth);
+    if (!Number.isFinite(distance)) return;
+    if (
+      bestId < 0 ||
+      distance < bestDist ||
+      (distance === bestDist &&
+        (batchIds[id]! > batchIds[bestId]! ||
+          (batchIds[id] === batchIds[bestId] && sources[id]! < sources[bestId]!)))
+    ) {
+      bestId = id;
+      bestDist = distance;
+    }
+  };
+
+  if (lo > start) consider(permutation[lo - 1]!);
+  if (lo < end) consider(permutation[lo]!);
+  if (bestId < 0) return permutation[start]!;
+
+  // Expand equal-distance runs left of lo-1 and right of lo (sorted orth).
+  for (let i = lo - 2; i >= start; i--) {
+    const id = permutation[i]!;
+    const distance = Math.abs(orth[id]! - seedOrth);
+    if (!Number.isFinite(distance) || distance > bestDist) break;
+    consider(id);
+  }
+  for (let i = lo + 1; i < end; i++) {
+    const id = permutation[i]!;
+    const distance = Math.abs(orth[id]! - seedOrth);
+    if (!Number.isFinite(distance) || distance > bestDist) break;
+    consider(id);
+  }
+  return bestId;
+}
+
 export function insidePath(
   batch: Extract<GeometryBatch, { kind: "paths" }>,
   start: number,

--- a/packages/core/src/candidate-store-eager.ts
+++ b/packages/core/src/candidate-store-eager.ts
@@ -555,7 +555,12 @@ export function buildCandidateStoreEager(
           memberIds[boundaryIndex] = seedId;
           continue;
         }
-        // Series ranges are sorted by orth — O(log M + T) closest, not O(M).
+        // Bucket sort orders ranks before orth. A single layer/series boundary
+        // is orth-sorted only when rank is constant across the range; otherwise
+        // fall back to linear closest (preserves prior group() semantics).
+        const firstId = permutation[boundary.start]!;
+        const lastId = permutation[boundary.end - 1]!;
+        const orthSorted = ranks[firstId] === ranks[lastId];
         memberIds[boundaryIndex] = closestOrthInRange(
           permutation,
           orth,
@@ -564,6 +569,7 @@ export function buildCandidateStoreEager(
           boundary.start,
           boundary.end,
           seedOrth,
+          orthSorted,
         );
       }
       return {

--- a/packages/core/src/candidate-store-eager.ts
+++ b/packages/core/src/candidate-store-eager.ts
@@ -2,6 +2,7 @@ import { StaticQuadtree } from "./dom/quadtree.js";
 import { canonicalAxisToken, compareTokens, tokenKey } from "./candidate-axis-token.js";
 import type { CanonicalAxisToken } from "./candidate-axis-token.js";
 import {
+  closestOrthInRange,
   defaultAutoMode,
   insidePath,
   localAnchor,
@@ -547,26 +548,23 @@ export function buildCandidateStoreEager(
       const orth = axis === "x" ? (flip ? xs : ys) : flip ? ys : xs;
       const seedLayer = scene.batches[batchIds[seedId]!]!.layerIndex;
       const memberIds = new Uint32Array(tuple.series.length);
+      const seedOrth = orth[seedId]!;
       for (let boundaryIndex = 0; boundaryIndex < tuple.series.length; boundaryIndex++) {
         const boundary: SeriesBoundary = tuple.series[boundaryIndex]!;
         if (boundary.layerIndex === seedLayer && boundary.seriesId === series[seedId]) {
           memberIds[boundaryIndex] = seedId;
           continue;
         }
-        let chosen = permutation[boundary.start]!;
-        for (let cursor = boundary.start + 1; cursor < boundary.end; cursor++) {
-          const id = permutation[cursor]!;
-          const distance = Math.abs(orth[id]! - orth[seedId]!);
-          const priorDistance = Math.abs(orth[chosen]! - orth[seedId]!);
-          if (
-            distance < priorDistance ||
-            (distance === priorDistance &&
-              (batchIds[id]! > batchIds[chosen]! ||
-                (batchIds[id] === batchIds[chosen] && sources[id]! < sources[chosen]!)))
-          )
-            chosen = id;
-        }
-        memberIds[boundaryIndex] = chosen;
+        // Series ranges are sorted by orth — O(log M + T) closest, not O(M).
+        memberIds[boundaryIndex] = closestOrthInRange(
+          permutation,
+          orth,
+          batchIds,
+          sources,
+          boundary.start,
+          boundary.end,
+          seedOrth,
+        );
       }
       return {
         axis,

--- a/packages/core/tests/candidate-geometry.test.ts
+++ b/packages/core/tests/candidate-geometry.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, spyOn } from "bun:test";
 
-import { pathRange, samePath } from "../src/candidate-geometry.ts";
+import { closestOrthInRange, pathRange, samePath } from "../src/candidate-geometry.ts";
 import type { PathsBatch } from "../src/scene.ts";
 
 /** Minimal paths batch with the given offsets and enough vertices. */
@@ -71,5 +71,64 @@ describe("samePath", () => {
     // Vertex 3 is last of first path; vertex 4 is first of second — not samePath.
     expect(samePath(batch, 3, 4)).toBe(false);
     expect(samePath(batch, 4, 3)).toBe(false);
+  });
+});
+
+describe("closestOrthInRange", () => {
+  // permutation is identity; orth/batch/source are per id.
+  const ids = (n: number) => Uint32Array.from({ length: n }, (_, i) => i);
+
+  it("returns the only member of a singleton range", () => {
+    expect(closestOrthInRange(ids(1), [10], [0], [0], 0, 1, 99)).toBe(0);
+  });
+
+  it("picks an exact orth match and the closer of two neighbors", () => {
+    const orth = [1, 3, 5, 9];
+    const batch = [0, 0, 0, 0];
+    const source = [0, 1, 2, 3];
+    const perm = ids(4);
+    expect(closestOrthInRange(perm, orth, batch, source, 0, 4, 5)).toBe(2);
+    // Strictly closer to one neighbor (midpoints are equidistant and use ties).
+    expect(closestOrthInRange(perm, orth, batch, source, 0, 4, 4.1)).toBe(2);
+    expect(closestOrthInRange(perm, orth, batch, source, 0, 4, 2.1)).toBe(1);
+    expect(closestOrthInRange(perm, orth, batch, source, 0, 4, 0)).toBe(0);
+    expect(closestOrthInRange(perm, orth, batch, source, 0, 4, 100)).toBe(3);
+  });
+
+  it("breaks equidistant orth ties by higher batchId then lower source", () => {
+    // target 5: id0 orth=4 (dist1) batch0; id1 orth=6 (dist1) batch2 → batch wins
+    expect(closestOrthInRange(ids(2), [4, 6], [0, 2], [0, 0], 0, 2, 5)).toBe(1);
+    // same batch: lower source wins
+    expect(closestOrthInRange(ids(2), [4, 6], [1, 1], [3, 1], 0, 2, 5)).toBe(1);
+    // equal orth run: scan the whole run for best batch/source
+    expect(closestOrthInRange(ids(3), [2, 2, 2], [1, 3, 2], [0, 5, 1], 0, 3, 2)).toBe(1);
+  });
+
+  it("returns the first id when seedOrth is non-finite (linear-scan NaN contract)", () => {
+    // Linear scan started at start and never improved when every |Δ| is NaN.
+    expect(closestOrthInRange(ids(3), [1, 2, 3], [0, 9, 8], [0, 0, 0], 0, 3, Number.NaN)).toBe(0);
+    expect(
+      closestOrthInRange(ids(3), [1, 2, 3], [0, 9, 8], [0, 0, 0], 0, 3, Number.POSITIVE_INFINITY),
+    ).toBe(0);
+  });
+
+  it("uses O(log M + T) Math.abs probes on a large sorted series", () => {
+    // Structural complexity guard: linear scan would call Math.abs ~2*(M-1) times
+    // per series (distance + priorDistance). Binary search + tie expand is O(log M).
+    const M = 4096;
+    const orth = Float32Array.from({ length: M }, (_, i) => i);
+    const batch = new Uint32Array(M);
+    const source = Uint32Array.from({ length: M }, (_, i) => i);
+    const perm = ids(M);
+    const absSpy = spyOn(Math, "abs");
+    try {
+      // Seed orth at the middle of the range (id 2048).
+      expect(closestOrthInRange(perm, orth, batch, source, 0, M, 2048)).toBe(2048);
+      // log2(4096)=12; allow generous headroom for bound probes + expand.
+      expect(absSpy.mock.calls.length).toBeLessThan(64);
+      expect(absSpy.mock.calls.length).toBeGreaterThan(0);
+    } finally {
+      absSpy.mockRestore();
+    }
   });
 });

--- a/packages/core/tests/candidate-geometry.test.ts
+++ b/packages/core/tests/candidate-geometry.test.ts
@@ -104,12 +104,36 @@ describe("closestOrthInRange", () => {
     expect(closestOrthInRange(ids(3), [2, 2, 2], [1, 3, 2], [0, 5, 1], 0, 3, 2)).toBe(1);
   });
 
-  it("returns the first id when seedOrth is non-finite (linear-scan NaN contract)", () => {
-    // Linear scan started at start and never improved when every |Δ| is NaN.
+  it("handles non-finite seedOrth like the linear scan", () => {
+    // NaN distances never improve → keep the first member.
     expect(closestOrthInRange(ids(3), [1, 2, 3], [0, 9, 8], [0, 0, 0], 0, 3, Number.NaN)).toBe(0);
+    // ±Infinity seed: every finite member has distance Infinity; batch/source ties apply.
     expect(
       closestOrthInRange(ids(3), [1, 2, 3], [0, 9, 8], [0, 0, 0], 0, 3, Number.POSITIVE_INFINITY),
-    ).toBe(0);
+    ).toBe(1); // highest batchId among equal Infinity distances
+    expect(
+      closestOrthInRange(ids(3), [1, 2, 3], [1, 1, 1], [5, 1, 3], 0, 3, Number.NEGATIVE_INFINITY),
+    ).toBe(1); // same batch → lowest source
+  });
+
+  it("keeps the first full-tie member on the lower-side equal-orth run", () => {
+    // seed 10: both orth 0 have dist 10; identical batch/source → first id wins.
+    expect(closestOrthInRange(ids(3), [0, 0, 20], [1, 1, 1], [0, 0, 0], 0, 3, 10)).toBe(0);
+  });
+
+  it("picks the largest finite orth when +Infinity follows in the series", () => {
+    // seed 50: finite 40 is closer than +Infinity; must not skip past 40.
+    expect(
+      closestOrthInRange(
+        ids(3),
+        [10, 40, Number.POSITIVE_INFINITY],
+        [0, 0, 0],
+        [0, 0, 0],
+        0,
+        3,
+        50,
+      ),
+    ).toBe(1);
   });
 
   it("uses O(log M + T) Math.abs probes on a large sorted series", () => {

--- a/packages/core/tests/candidate-store.test.ts
+++ b/packages/core/tests/candidate-store.test.ts
@@ -497,6 +497,58 @@ describe("candidate grouping hot path", () => {
     expect(store.group(0, "x")).toBeNull();
     expect(store.nearest(10, 10, { mode: "x", maxDistance: 100 })).toBeNull();
   });
+
+  it("keeps the seed as its own series representative", () => {
+    const plotScene = sceneWithPoints([
+      [10, 10],
+      [10, 50],
+      [10, 30],
+    ]);
+    // Two series at the same x: seed series 0 has two points; series 1 has one.
+    const store = buildCandidateStore(plotScene, {
+      datum: ({ primitiveIndex }) => ({
+        xValue: "a",
+        yValue: primitiveIndex * 10,
+        seriesId: primitiveIndex === 1 ? 1 : 0,
+        seriesRank: primitiveIndex === 1 ? 1 : 0,
+      }),
+    });
+    const grouped = store.group(2, "x");
+    expect(grouped).not.toBeNull();
+    // Seed id 2 is series 0; that series' member must stay the seed (not the
+    // orth-closest sibling id 0 at y=10).
+    expect(grouped!.focusId).toBe(2);
+    expect([...grouped!.memberIds]).toContain(2);
+  });
+
+  it("resolves a large non-seed series with O(log M) orth probes", () => {
+    // Seed series is a singleton; other series has M points at the same x
+    // with increasing y. group(seed) must binary-search the large series —
+    // a linear scan would call Math.abs ~2*(M-1) times on that series alone.
+    const M = 2048;
+    const points: (readonly [number, number])[] = [[0, 0]]; // seed series
+    for (let i = 0; i < M; i++) points.push([0, i]); // other series
+    const plotScene = sceneWithPoints(points);
+    const store = buildCandidateStore(plotScene, {
+      datum: ({ primitiveIndex }) => ({
+        xValue: 1,
+        yValue: primitiveIndex,
+        seriesId: primitiveIndex === 0 ? 0 : 1,
+        seriesRank: primitiveIndex === 0 ? 0 : 1,
+      }),
+    });
+    void store.x;
+    const absSpy = spyOn(Math, "abs");
+    try {
+      const grouped = store.group(0, "x");
+      expect(grouped).not.toBeNull();
+      // Closest in the large series to seed y=0 is the first member (y=0).
+      expect([...grouped!.memberIds]).toContain(1);
+      expect(absSpy.mock.calls.length).toBeLessThan(80);
+    } finally {
+      absSpy.mockRestore();
+    }
+  });
 });
 
 describe("candidate spatial query hot path (issue #214)", () => {


### PR DESCRIPTION
## Summary

- **Audit target:** `packages/core/src` (304 files — narrowed to CandidateStore hot path)
- **Finding:** `CandidateStore.group()` linear-scanned every member of each non-seed series to pick the nearest orthogonal coordinate (**O(M)** per series)
- **Fix:** `closestOrthInRange` — lower_bound on the pre-sorted orth range + expand equal-distance runs; same batchId/source tie-break as before
- Codex plan review: revised for non-finite seedOrth (first-member contract) and complexity claim (win is large *other* series, not seed’s own short-circuit)

## Complexity

| Path | Before | After |
|------|--------|-------|
| `group()` per non-seed series | O(M) linear scan | O(log M + T) (T = equal-distance run) |
| Seed’s own series | O(1) short-circuit | unchanged |
| Non-finite seedOrth | first member (NaN never improves) | same |

**n = M** = members in a non-seed series within the seed’s panel+axis token bucket (inspection x/y mode, interaction-perf, benchmarks).

## Test plan

- [x] `bun test packages/core/tests/candidate-geometry.test.ts` — unit + Math.abs op-count on M=4096
- [x] `bun test packages/core/tests/candidate-store.test.ts` — seed retention, large non-seed series op-count, existing group tests
- [x] pre-push suite green

## Follow-ups

- Directional `traverse` left/right/up/down remains O(C) (svelte uses plot-px directional helpers today)