### PR TITLE
perf(svelte): O(1) legend field lookup + one lineage Set per candidate

### DIFF
--- a/packages/svelte/src/lib/legend/entry-key-index.ts
+++ b/packages/svelte/src/lib/legend/entry-key-index.ts
@@ -76,6 +76,8 @@ export type LegendKeyIndexAdapter = {
  * - Skip null rows (field path) / null keys; constant path only needs keys.
  * - Match entry values via pre-built token→index maps (legendValueEqual
  *   semantics: NaN, Date, -0/0); O(E) prep + O(1) per row, not findIndex.
+ * - Layer field maps built once per layer (first non-stat channel → field);
+ *   lineage Sets once per candidate when any discrete legend applies.
  * - Final keys are first-seen unique order, frozen.
  */
 /** Row field value or scaled constant; `skip` when the row is missing. */
@@ -144,10 +146,29 @@ export function buildLegendEntryKeyIndexForPlot(input: {
   });
 }
 
+/**
+ * First non-stat field per channel for one layer — same selection as
+ * `fields.find(m => m.channel === scale && m.source !== "stat")`.
+ * Built once per layer so candidate×legend walks are O(1) field lookups.
+ */
+function indexLayerFieldsByChannel(
+  fields: readonly LegendMappedField[] | undefined,
+): ReadonlyMap<string, string> {
+  const byChannel = new Map<string, string>();
+  if (fields === undefined) return byChannel;
+  for (const mapped of fields) {
+    if (mapped.source === "stat") continue;
+    if (!byChannel.has(mapped.channel)) byChannel.set(mapped.channel, mapped.field);
+  }
+  return byChannel;
+}
+
 export function buildLegendEntryKeyIndex(
   adapter: LegendKeyIndexAdapter,
 ): ReadonlyMap<string, readonly PropertyKey[]> {
   const index = new Map<string, PropertyKey[]>();
+  /** Discrete legends only — ramp legends never contribute buckets. */
+  const discreteLegends: Extract<SceneLegend, { type: "discrete" }>[] = [];
   /** Per discrete legend: value-token → first matching entryIndex. */
   const entryLookupByLegend = new Map<
     Extract<SceneLegend, { type: "discrete" }>,
@@ -155,26 +176,44 @@ export function buildLegendEntryKeyIndex(
   >();
   for (const sceneLegend of adapter.legends) {
     if (sceneLegend.type !== "discrete") continue;
+    discreteLegends.push(sceneLegend);
     for (let entryIndex = 0; entryIndex < sceneLegend.entries.length; entryIndex++)
       index.set(legendIdentityKey({ scale: sceneLegend.scale, entryIndex }), []);
     entryLookupByLegend.set(sceneLegend, buildEntryIndexByToken(sceneLegend.entries));
   }
+  // Lazy: layerIndex → channel → first non-stat field (O(F) once per layer).
+  const fieldsByLayer = new Map<number, ReadonlyMap<string, string>>();
+  const fieldFor = (layerIndex: number, scale: string): string | undefined => {
+    let byChannel = fieldsByLayer.get(layerIndex);
+    if (byChannel === undefined) {
+      byChannel = indexLayerFieldsByChannel(adapter.layerFields(layerIndex));
+      fieldsByLayer.set(layerIndex, byChannel);
+    }
+    return byChannel.get(scale);
+  };
+
   const visited = new Set<string>();
   for (const candidate of adapter.candidates()) {
-    for (const sceneLegend of adapter.legends) {
-      if (sceneLegend.type !== "discrete") continue;
-      const field = adapter
-        .layerFields(candidate.layerIndex)
-        ?.find((mapped) => mapped.channel === sceneLegend.scale && mapped.source !== "stat")?.field;
+    // Lineage Set once per candidate when any discrete legend applies —
+    // not once per legend (was O(C·L·R) Set construction).
+    let sourceRows: Set<number> | null = null;
+    const rowsForCandidate = (): Set<number> => {
+      if (sourceRows === null) {
+        sourceRows = new Set(adapter.lineageKeys(candidate.lineage));
+        if (candidate.rowIndex !== null) sourceRows.add(candidate.rowIndex);
+      }
+      return sourceRows;
+    };
+
+    for (const sceneLegend of discreteLegends) {
+      const field = fieldFor(candidate.layerIndex, sceneLegend.scale);
       const scaledConstant =
         field === undefined
           ? adapter.layerScaledConstant?.(candidate.layerIndex, sceneLegend.scale)
           : undefined;
       if (field === undefined && scaledConstant === undefined) continue;
       const entryByToken = entryLookupByLegend.get(sceneLegend)!;
-      const sourceRows = new Set(adapter.lineageKeys(candidate.lineage));
-      if (candidate.rowIndex !== null) sourceRows.add(candidate.rowIndex);
-      for (const rowIndex of sourceRows) {
+      for (const rowIndex of rowsForCandidate()) {
         const visitField = field ?? `const:${String(scaledConstant)}`;
         const visit = `${sceneLegend.scale}:${String(candidate.layerIndex)}:${visitField}:${String(rowIndex)}`;
         if (visited.has(visit)) continue;

--- a/packages/svelte/tests/legend/focus.test.ts
+++ b/packages/svelte/tests/legend/focus.test.ts
@@ -718,6 +718,122 @@ describe("buildLegendEntryKeyIndex", () => {
       expect(index.get(`fill:${i}`)).toHaveLength(rowsPerEntry);
     }
   });
+
+  it("indexes first non-stat field per channel (skips leading stat, first non-stat wins)", () => {
+    const index = buildLegendEntryKeyIndex(
+      adapter({
+        candidates: [{ layerIndex: 0, lineage: 1, rowIndex: null }],
+        fields: {
+          0: [
+            { channel: "fill", field: "stat_fill", source: "stat" },
+            { channel: "fill", field: "real_fill" },
+            { channel: "fill", field: "second_fill" },
+          ],
+        },
+        lineages: { 1: [0] },
+        rows: { 0: { real_fill: "web", second_fill: "store", stat_fill: "ignored" } },
+        keys: { 0: "k" },
+      }),
+    );
+    // First non-stat mapping for fill is real_fill → "web" → entry 0.
+    expect(index.get("fill:0")).toEqual(["k"]);
+    expect(index.get("fill:1")).toEqual([]);
+  });
+
+  it("maps one candidate across field and scaled-constant discrete legends", () => {
+    const colorLegend: SceneLegend = {
+      type: "discrete",
+      scale: "color",
+      title: "Color",
+      x: 0,
+      y: 0,
+      width: 40,
+      height: 40,
+      swatchSize: 12,
+      entries: [
+        { label: "red", value: "red", color: "#f00" },
+        { label: "blue", value: "blue", color: "#00f" },
+      ],
+    };
+    const index = buildLegendEntryKeyIndex(
+      adapter({
+        legends: [discreteFill, colorLegend],
+        candidates: [{ layerIndex: 0, lineage: 1, rowIndex: null }],
+        fields: { 0: [{ channel: "fill", field: "channel" }] },
+        scaledConstants: { 0: { color: "blue" } },
+        lineages: { 1: [0, 1] },
+        rows: {
+          0: { channel: "web" },
+          1: { channel: "store" },
+        },
+        keys: { 0: "a", 1: "b" },
+      }),
+    );
+    expect(index.get("fill:0")).toEqual(["a"]);
+    expect(index.get("fill:1")).toEqual(["b"]);
+    // Scaled-constant color maps every lineage row to the same entry.
+    expect(index.get("color:1")).toEqual(["a", "b"]);
+    expect(index.get("color:0")).toEqual([]);
+  });
+
+  it("calls layerFields once per distinct layer and lineageKeys once per applicable candidate", () => {
+    let layerFieldsCalls = 0;
+    let lineageKeysCalls = 0;
+    const dualLegend: SceneLegend = {
+      type: "discrete",
+      scale: "color",
+      title: "C",
+      x: 0,
+      y: 0,
+      width: 40,
+      height: 40,
+      swatchSize: 12,
+      entries: [{ label: "x", value: "x", color: "#000" }],
+    };
+    const clean: LegendKeyIndexAdapter = {
+      legends: [discreteFill, dualLegend],
+      candidates: () => [
+        { layerIndex: 0, lineage: 1, rowIndex: null },
+        { layerIndex: 0, lineage: 2, rowIndex: null },
+        { layerIndex: 1, lineage: 3, rowIndex: null },
+      ],
+      layerFields() {
+        layerFieldsCalls += 1;
+        return [{ channel: "fill", field: "channel" }];
+      },
+      layerScaledConstant: (_layerIndex, channel) => (channel === "color" ? "x" : undefined),
+      lineageKeys(lineageId) {
+        lineageKeysCalls += 1;
+        return lineageId === 1 ? [0] : lineageId === 2 ? [1] : [2];
+      },
+      row: (rowIndex) => (rowIndex === 2 ? { channel: "store" } : { channel: "web" }),
+      semanticKey: (rowIndex) => (rowIndex === 0 ? "a" : rowIndex === 1 ? "b" : "c"),
+    };
+    const index = buildLegendEntryKeyIndex(clean);
+    expect(index.get("fill:0")).toEqual(["a", "b"]);
+    expect(index.get("color:0")).toEqual(["a", "b", "c"]);
+    // One layerFields call per distinct layerIndex (0 and 1), not per candidate×legend.
+    expect(layerFieldsCalls).toBe(2);
+    // One lineageKeys call per candidate (all three apply at least one legend).
+    expect(lineageKeysCalls).toBe(3);
+  });
+
+  it("does not call lineageKeys when no discrete legend applies to the candidate", () => {
+    let lineageKeysCalls = 0;
+    const index = buildLegendEntryKeyIndex({
+      legends: [discreteFill],
+      candidates: () => [{ layerIndex: 0, lineage: 99, rowIndex: null }],
+      layerFields: () => [{ channel: "color", field: "other" }], // fill legend only
+      lineageKeys: () => {
+        lineageKeysCalls += 1;
+        return [0];
+      },
+      row: () => ({ other: "x" }),
+      semanticKey: () => "k",
+    });
+    expect(index.get("fill:0")).toEqual([]);
+    expect(lineageKeysCalls).toBe(0);
+  });
 });
 
 describe("resolveLegendPreviewKeysDecision", () => {


### PR DESCRIPTION
## Summary

- **Audit target:** `packages/svelte/src` (bigo-maintain rotation)
- **Finding:** `buildLegendEntryKeyIndex` re-ran `layerFields(...).find(...)` for every candidate×discrete-legend pair and rebuilt lineage `Set`s per legend
- **Fix:** Index first non-stat field per channel once per layer; build lineage Set once per candidate when any discrete legend applies
- Codex plan review: reframed as constant-factor / allocation win (row walk still O(C·L·R) for visit keys); strengthened tests for first-non-stat field, multi-legend, and call counts

## Complexity

| Work | Before | After |
|------|--------|-------|
| Field resolve | O(C·L·F) linear find | O(U·F + C·L) — U = distinct layers |
| Lineage Set construction | O(C·L·R) | O(C·R) when legends apply |
| Per-row visit/match | O(C·L·R) | unchanged (visit keys include scale) |

**n = C** candidates (and R lineage rows) on legend-focus derived rebuilds.

## Test plan

- [x] Existing entry-key-index characterization suite
- [x] First non-stat field wins (stat skip + first of two non-stat)
- [x] Multi-legend field + scaled-constant on one candidate
- [x] `layerFields` once per layer; `lineageKeys` once per applicable candidate; zero when no legend applies
- [x] pre-push suite green

## Follow-ups

- Controller `isSelected` Set membership for large multi-selects
- Rare `matchCandidateFromHit` full-store path