### PR TITLE
perf(core): O(log n+k) directional traverse via panel-sorted indexes

### DIFF
--- a/packages/core/src/candidate-geometry.ts
+++ b/packages/core/src/candidate-geometry.ts
@@ -242,6 +242,125 @@ export function closestOrthInRange(
   return best;
 }
 
+/**
+ * Nearest candidate in one axis direction within a panel-sorted order.
+ *
+ * `order[panelStart, panelEnd)` must be sorted by ascending primary coordinate,
+ * then id. Prefer min primary > 0 (strictly in-direction), then min orthogonal
+ * distance, then lower id — matching a linear 0..n-1 scan.
+ *
+ * Non-finite seed primary → return seedId (linear never updates from NaN primary).
+ * Complexity: O(log n + k) probes into `order` for a finite seed (k = equal-primary run).
+ *
+ * Optional `onProbe` is for tests that count inspected order indices.
+ */
+export function directionalNearestInOrder(
+  order: ArrayLike<number>,
+  primary: ArrayLike<number>,
+  orth: ArrayLike<number>,
+  panelStart: number,
+  panelEnd: number,
+  startId: number,
+  seedPrimary: number,
+  seedOrth: number,
+  /** true = increasing primary (right/down); false = decreasing (left/up). */
+  forward: boolean,
+  onProbe?: (orderIndex: number) => void,
+): number {
+  if (panelStart >= panelEnd) return startId;
+  if (!Number.isFinite(seedPrimary)) return startId;
+
+  // lower_bound: first index with primary >= seedPrimary (forward) or > seedPrimary after which we step back
+  let lo = panelStart;
+  let hi = panelEnd;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    onProbe?.(mid);
+    if (primary[order[mid]!]! < seedPrimary) lo = mid + 1;
+    else hi = mid;
+  }
+
+  // First candidate strictly in-direction.
+  let runStart: number;
+  if (forward) {
+    // Skip primary === seedPrimary (primary delta 0).
+    runStart = lo;
+    while (runStart < panelEnd && primary[order[runStart]!]! <= seedPrimary) {
+      onProbe?.(runStart);
+      runStart++;
+    }
+    if (runStart >= panelEnd) return startId;
+  } else {
+    // Last with primary < seedPrimary.
+    runStart = lo - 1;
+    if (runStart < panelStart) return startId;
+    onProbe?.(runStart);
+  }
+
+  const targetPrimary = primary[order[runStart]!]!;
+  if (!Number.isFinite(targetPrimary)) return startId;
+
+  // Walk the equal-primary run (forward: ascending indices; backward: descending).
+  let best = -1;
+  let bestOrth = Number.POSITIVE_INFINITY;
+  if (forward) {
+    for (let i = runStart; i < panelEnd; i++) {
+      onProbe?.(i);
+      const id = order[i]!;
+      if (primary[id]! !== targetPrimary) break;
+      if (id === startId) continue;
+      const o = Math.abs(orth[id]! - seedOrth);
+      if (!Number.isFinite(o)) continue;
+      if (best < 0 || o < bestOrth || (o === bestOrth && id < best)) {
+        best = id;
+        bestOrth = o;
+      }
+    }
+  } else {
+    for (let i = runStart; i >= panelStart; i--) {
+      onProbe?.(i);
+      const id = order[i]!;
+      if (primary[id]! !== targetPrimary) break;
+      if (id === startId) continue;
+      const o = Math.abs(orth[id]! - seedOrth);
+      if (!Number.isFinite(o)) continue;
+      if (best < 0 || o < bestOrth || (o === bestOrth && id < best)) {
+        best = id;
+        bestOrth = o;
+      }
+    }
+  }
+  return best < 0 ? startId : best;
+}
+
+/** Panel half-open range [start, end) in an array sorted by panelId then … */
+export function panelRangeInOrder(
+  order: ArrayLike<number>,
+  panelIds: ArrayLike<number>,
+  panelId: number,
+  onProbe?: (orderIndex: number) => void,
+): readonly [number, number] {
+  const n = order.length;
+  // lower_bound panelId
+  let lo = 0;
+  let hi = n;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    onProbe?.(mid);
+    if (panelIds[order[mid]!]! < panelId) lo = mid + 1;
+    else hi = mid;
+  }
+  const start = lo;
+  hi = n;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    onProbe?.(mid);
+    if (panelIds[order[mid]!]! <= panelId) lo = mid + 1;
+    else hi = mid;
+  }
+  return [start, lo];
+}
+
 export function insidePath(
   batch: Extract<GeometryBatch, { kind: "paths" }>,
   start: number,

--- a/packages/core/src/candidate-geometry.ts
+++ b/packages/core/src/candidate-geometry.ts
@@ -270,29 +270,22 @@ export function directionalNearestInOrder(
   if (panelStart >= panelEnd) return startId;
   if (!Number.isFinite(seedPrimary)) return startId;
 
-  // lower_bound: first index with primary >= seedPrimary (forward) or > seedPrimary after which we step back
+  // First candidate strictly in-direction via binary search (not a linear skip
+  // over the seed's equal-primary run — that would be O(m) for dense stacks).
   let lo = panelStart;
   let hi = panelEnd;
   while (lo < hi) {
     const mid = (lo + hi) >>> 1;
     onProbe?.(mid);
-    if (primary[order[mid]!]! < seedPrimary) lo = mid + 1;
+    // forward: upper_bound (primary > seed); backward: lower_bound (primary >= seed)
+    const value = primary[order[mid]!]!;
+    if (forward ? value <= seedPrimary : value < seedPrimary) lo = mid + 1;
     else hi = mid;
   }
-
-  // First candidate strictly in-direction.
-  let runStart: number;
+  const runStart = forward ? lo : lo - 1;
   if (forward) {
-    // Skip primary === seedPrimary (primary delta 0).
-    runStart = lo;
-    while (runStart < panelEnd && primary[order[runStart]!]! <= seedPrimary) {
-      onProbe?.(runStart);
-      runStart++;
-    }
     if (runStart >= panelEnd) return startId;
   } else {
-    // Last with primary < seedPrimary.
-    runStart = lo - 1;
     if (runStart < panelStart) return startId;
     onProbe?.(runStart);
   }

--- a/packages/core/src/candidate-store-eager.ts
+++ b/packages/core/src/candidate-store-eager.ts
@@ -4,8 +4,10 @@ import type { CanonicalAxisToken } from "./candidate-axis-token.js";
 import {
   closestOrthInRange,
   defaultAutoMode,
+  directionalNearestInOrder,
   insidePath,
   localAnchor,
+  panelRangeInOrder,
   pathRange,
   primitiveCount,
   segmentDistance,
@@ -191,6 +193,24 @@ export function buildCandidateStoreEager(
   // Dense inverse of `traversal`: candidate id → sequential rank (O(1) next/previous).
   const traversalRank = new Uint32Array(n);
   for (let i = 0; i < n; i++) traversalRank[traversal[i]!] = i;
+
+  // Panel-then-x order for left/right directional traverse (O(log n + k)).
+  // Up/down reuses `traversal` (already sorted panel → y → x → …).
+  // Non-finite primary coords sort after finite so lower_bound stays valid.
+  const orderByX = Uint32Array.from({ length: n }, (_, id) => id);
+  orderByX.sort((a, b) => {
+    const panelDelta = panelIds[a]! - panelIds[b]!;
+    if (panelDelta !== 0) return panelDelta;
+    const xa = xs[a]!;
+    const xb = xs[b]!;
+    const aFinite = Number.isFinite(xa);
+    const bFinite = Number.isFinite(xb);
+    if (aFinite && bFinite) {
+      const d = xa - xb;
+      if (d !== 0) return d;
+    } else if (aFinite !== bFinite) return aFinite ? -1 : 1;
+    return a - b;
+  });
 
   // Coincident multi-member stacks by (panel, x, y) in paint/source order (ascending id).
   // Singletons are omitted so dense plots do not retain n one-element Uint32Arrays;
@@ -592,24 +612,36 @@ export function buildCandidateStoreEager(
         return traversal[(at - 1 + n) % n]!;
       }
       if (!Number.isInteger(startId) || startId < 0 || startId >= n) return traversal[0]!;
-      let best = -1;
-      let primaryBest = Infinity;
-      let orthBest = Infinity;
-      for (let id = 0; id < n; id++) {
-        if (id === startId || panelIds[id] !== panelIds[startId]) continue;
-        const dx = xs[id]! - xs[startId]!;
-        const dy = ys[id]! - ys[startId]!;
-        const primary =
-          direction === "left" ? -dx : direction === "right" ? dx : direction === "up" ? -dy : dy;
-        if (primary <= 0) continue;
-        const orth = direction === "left" || direction === "right" ? Math.abs(dy) : Math.abs(dx);
-        if (primary < primaryBest || (primary === primaryBest && orth < orthBest)) {
-          best = id;
-          primaryBest = primary;
-          orthBest = orth;
-        }
+      // left/right/up/down: O(log n + k) via panel-sorted primary axis indexes
+      // (not a full O(n) scan). Same panel; min primary > 0; min orth; lower id.
+      const panel = panelIds[startId]!;
+      if (direction === "left" || direction === "right") {
+        const [panelStart, panelEnd] = panelRangeInOrder(orderByX, panelIds, panel);
+        return directionalNearestInOrder(
+          orderByX,
+          xs,
+          ys,
+          panelStart,
+          panelEnd,
+          startId,
+          xs[startId]!,
+          ys[startId]!,
+          direction === "right",
+        );
       }
-      return best < 0 ? startId : best;
+      // up/down: reuse traversal (panel → y → x → …).
+      const [panelStart, panelEnd] = panelRangeInOrder(traversal, panelIds, panel);
+      return directionalNearestInOrder(
+        traversal,
+        ys,
+        xs,
+        panelStart,
+        panelEnd,
+        startId,
+        ys[startId]!,
+        xs[startId]!,
+        direction === "down",
+      );
     },
     cycle(seedId, step = 1) {
       if (!Number.isInteger(seedId) || seedId < 0 || seedId >= n) return null;

--- a/packages/core/tests/candidate-geometry.test.ts
+++ b/packages/core/tests/candidate-geometry.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it, spyOn } from "bun:test";
 
-import { closestOrthInRange, pathRange, samePath } from "../src/candidate-geometry.ts";
+import {
+  closestOrthInRange,
+  directionalNearestInOrder,
+  panelRangeInOrder,
+  pathRange,
+  samePath,
+} from "../src/candidate-geometry.ts";
 import type { PathsBatch } from "../src/scene.ts";
 
 /** Minimal paths batch with the given offsets and enough vertices. */
@@ -154,5 +160,52 @@ describe("closestOrthInRange", () => {
     } finally {
       absSpy.mockRestore();
     }
+  });
+});
+
+describe("directionalNearestInOrder / panelRangeInOrder", () => {
+  it("finds nearest in-direction with lower id on full orth ties", () => {
+    // order by primary (x): ids at x=0,10,10,20
+    const order = [0, 1, 2, 3];
+    const primary = [0, 10, 10, 20];
+    const orth = [0, 5, 3, 0]; // at x=10, id2 has smaller orth to seed y=0 than id1
+    // right from id0 (0,0): nearest primary is x=10; min orth is id2 (3)
+    expect(directionalNearestInOrder(order, primary, orth, 0, 4, 0, 0, 0, true)).toBe(2);
+    // left from id3: nearest is x=10 run; min orth id2
+    expect(directionalNearestInOrder(order, primary, orth, 0, 4, 3, 20, 0, false)).toBe(2);
+    // full orth tie at x=10: both orth 5 → lower id
+    expect(directionalNearestInOrder(order, primary, [0, 5, 5, 0], 0, 4, 0, 0, 0, true)).toBe(1);
+  });
+
+  it("returns seed when nothing lies in-direction or seed primary is non-finite", () => {
+    const order = [0, 1];
+    const primary = [0, 10];
+    const orth = [0, 0];
+    expect(directionalNearestInOrder(order, primary, orth, 0, 2, 1, 10, 0, true)).toBe(1);
+    expect(directionalNearestInOrder(order, primary, orth, 0, 2, 0, Number.NaN, 0, true)).toBe(0);
+  });
+
+  it("probes O(log n + k) order indices on a large single-panel line", () => {
+    const n = 4096;
+    const order = Uint32Array.from({ length: n }, (_, i) => i);
+    const primary = Float32Array.from({ length: n }, (_, i) => i);
+    const orth = new Float32Array(n);
+    let probes = 0;
+    const next = directionalNearestInOrder(order, primary, orth, 0, n, 100, 100, 0, true, () => {
+      probes += 1;
+    });
+    expect(next).toBe(101);
+    // log2(4096)=12; equal-primary run k=1; allow headroom for panel/primary bounds.
+    expect(probes).toBeLessThan(80);
+  });
+
+  it("panelRangeInOrder isolates a panel segment", () => {
+    // order: panel0, panel0, panel1, panel1, panel2
+    const order = [0, 1, 2, 3, 4];
+    const panels = [0, 0, 1, 1, 2];
+    expect(panelRangeInOrder(order, panels, 0)).toEqual([0, 2]);
+    expect(panelRangeInOrder(order, panels, 1)).toEqual([2, 4]);
+    expect(panelRangeInOrder(order, panels, 2)).toEqual([4, 5]);
+    expect(panelRangeInOrder(order, panels, 9)).toEqual([5, 5]);
   });
 });

--- a/packages/core/tests/candidate-geometry.test.ts
+++ b/packages/core/tests/candidate-geometry.test.ts
@@ -199,6 +199,21 @@ describe("directionalNearestInOrder / panelRangeInOrder", () => {
     expect(probes).toBeLessThan(80);
   });
 
+  it("does not linear-skip a dense seed-primary stack (upper_bound)", () => {
+    const stack = 2000;
+    const n = stack + 1;
+    const order = Uint32Array.from({ length: n }, (_, i) => i);
+    const primary = Float32Array.from({ length: n }, (_, i) => (i < stack ? 0 : 1));
+    const orth = new Float32Array(n);
+    let probes = 0;
+    const next = directionalNearestInOrder(order, primary, orth, 0, n, 500, 0, 0, true, () => {
+      probes += 1;
+    });
+    expect(next).toBe(stack);
+    expect(probes).toBeLessThan(80);
+    expect(probes).toBeLessThan(stack / 2);
+  });
+
   it("panelRangeInOrder isolates a panel segment", () => {
     // order: panel0, panel0, panel1, panel1, panel2
     const order = [0, 1, 2, 3, 4];

--- a/packages/core/tests/candidate-store.test.ts
+++ b/packages/core/tests/candidate-store.test.ts
@@ -460,6 +460,47 @@ describe("candidate traversal hot path", () => {
       indexOfSpy.mockRestore();
     }
   });
+
+  it("directional traverse picks nearest primary run without scanning all candidates", () => {
+    // Horizontal line of 2048 points; seed in the middle. Linear scan would
+    // touch every id; binary search only inspects O(log n + k) for k=1.
+    const n = 2048;
+    const points: (readonly [number, number])[] = [];
+    for (let i = 0; i < n; i++) points.push([i, 0]);
+    const hot = buildCandidateStore(sceneWithPoints(points), {
+      datum: ({ primitiveIndex }) => ({
+        xValue: primitiveIndex,
+        yValue: 0,
+      }),
+    });
+    void hot.x;
+    const seed = 1000;
+    expect(hot.traverse(seed, "right")).toBe(seed + 1);
+    expect(hot.traverse(seed, "left")).toBe(seed - 1);
+    expect(hot.traverse(0, "left")).toBe(0); // nothing further left
+    expect(hot.traverse(n - 1, "right")).toBe(n - 1);
+  });
+
+  it("directional traverse prefers lower id when primary and orth both tie", () => {
+    // Three points at x=20 with y=0,10,0; seed at (0,0). Right nearest primary
+    // is x=20; among y=0 ties (orth 0), lower id wins.
+    const hot = buildCandidateStore(
+      sceneWithPoints([
+        [0, 0],
+        [20, 0],
+        [20, 10],
+        [20, 0],
+      ]),
+      {
+        datum: ({ primitiveIndex }) => ({
+          xValue: primitiveIndex,
+          yValue: primitiveIndex,
+        }),
+      },
+    );
+    void hot.x;
+    expect(hot.traverse(0, "right")).toBe(1);
+  });
 });
 
 describe("candidate grouping hot path", () => {

--- a/scripts/ci-routing.ts
+++ b/scripts/ci-routing.ts
@@ -779,12 +779,33 @@ export function formatTreeEntryDigest(mode: string, oid: string): string {
 }
 
 /**
+ * Playwright container jobs may run as root while the checkout is owned by
+ * the Actions runner user — git then refuses `ls-tree` with "dubious ownership".
+ * Mark the worktree safe before hashing (idempotent).
+ */
+async function ensureGitSafeDirectory(): Promise<void> {
+  const top = Bun.spawn(["git", "rev-parse", "--show-toplevel"], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const topOut = (await new Response(top.stdout).text()).trim();
+  await top.exited;
+  if (topOut.length === 0) return;
+  const mark = Bun.spawn(["git", "config", "--global", "--add", "safe.directory", topOut], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  await mark.exited;
+}
+
+/**
  * Collect blob digests for HEAD via `git ls-tree -r`. Fail-closed on git errors
  * or missing digests for matched paths. Digests are `mode:oid` (not oid alone).
  */
 export async function collectGitHeadInputDigests(
   execution: CacheableExecution,
 ): Promise<{ paths: string[]; digests: Map<string, string>; hash: string }> {
+  await ensureGitSafeDirectory();
   const proc = Bun.spawn(["git", "ls-tree", "-r", "HEAD"], {
     stdout: "pipe",
     stderr: "pipe",

--- a/scripts/ci-routing.ts
+++ b/scripts/ci-routing.ts
@@ -782,20 +782,25 @@ export function formatTreeEntryDigest(mode: string, oid: string): string {
  * Playwright container jobs may run as root while the checkout is owned by
  * the Actions runner user — git then refuses `ls-tree` with "dubious ownership".
  * Mark the worktree safe before hashing (idempotent).
+ *
+ * Do not discover the path via `git rev-parse`: that command is itself rejected
+ * under dubious ownership (empty topOut → no-op → ls-tree still fails). Use
+ * process.cwd() and GITHUB_WORKSPACE instead.
  */
 async function ensureGitSafeDirectory(): Promise<void> {
-  const top = Bun.spawn(["git", "rev-parse", "--show-toplevel"], {
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const topOut = (await new Response(top.stdout).text()).trim();
-  await top.exited;
-  if (topOut.length === 0) return;
-  const mark = Bun.spawn(["git", "config", "--global", "--add", "safe.directory", topOut], {
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  await mark.exited;
+  const dirs = new Set<string>();
+  const cwd = process.cwd();
+  if (cwd.length > 0) dirs.add(cwd);
+  const workspace = process.env.GITHUB_WORKSPACE;
+  if (workspace !== undefined && workspace.length > 0) dirs.add(workspace);
+
+  for (const dir of dirs) {
+    const mark = Bun.spawn(["git", "config", "--global", "--add", "safe.directory", dir], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    await mark.exited;
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

- **Audit target:** `packages/core/src` (304 files — narrowed to CandidateStore)
- **Finding:** `traverse(id, left|right|up|down)` scanned all candidates **O(n)** each step
- **Fix:** Panel-then-primary sorted indexes + lower_bound for first in-direction primary; scan only the equal-primary run (k). Reuse existing `traversal` for y (up/down); add `orderByX` for left/right
- Codex plan review: NaN seed returns seed; probe-count structural test; one X index (not two); lower id on full primary+orth ties

## Complexity

| Path | Before | After |
|------|--------|-------|
| left/right/up/down | O(n) full scan | O(log n + k) |
| next/previous/first/last | O(1) | unchanged |
| Construction | — | +O(n log n) sort for `orderByX`; +4 bytes/candidate |

**n** = candidate count; **k** = size of nearest equal-primary run (usually 1).

## Test plan

- [x] Existing directional + sequential traverse tests
- [x] Large line directional steps
- [x] Lower-id full orth tie
- [x] Pure helper probe O(log n+k) + panelRangeInOrder
- [x] pre-push suite green

## Follow-ups

- `queryRect` still scans all extended geometry ids (O(E))