### PR TITLE
refactor(ci): extract content-hash marker protocol into composite actions

### DIFF
--- a/.github/actions/ci-content-hash-restore/action.yml
+++ b/.github/actions/ci-content-hash-restore/action.yml
@@ -1,0 +1,131 @@
+# Success-marker content-hash restore (issue #245).
+# Compute hash → restore exact-key marker cache → validate marker.
+# Callers gate work on steps.<id>.outputs.hit != 'true' and write via
+# ci-content-hash-write when hit is false and bypass is false.
+name: CI content-hash restore
+description: >
+  Bypass-aware content-hash for a cacheable execution: hash inputs, restore
+  the success-marker cache (exact key only), and validate the marker.
+
+inputs:
+  execution:
+    description: CacheableExecution name (unit, build, component_svelte, consumer, …)
+    required: true
+  bypass:
+    description: detect-changes.outputs.bypass_content_cache
+    required: true
+  disable:
+    description: vars.CI_DISABLE_CONTENT_HASH (set to 1 to force full run)
+    required: false
+    default: ""
+  container_tag:
+    description: Optional Playwright container tag for component shards
+    required: false
+    default: ""
+  matrix_node:
+    description: Optional consumer matrix node major (with other matrix_* inputs)
+    required: false
+    default: ""
+  matrix_pm:
+    description: Optional consumer matrix package manager
+    required: false
+    default: ""
+  matrix_pm_version:
+    description: Optional consumer matrix package manager version
+    required: false
+    default: ""
+  matrix_svelte:
+    description: Optional consumer matrix Svelte version
+    required: false
+    default: ""
+  runtime_node_version:
+    description: Optional resolved node -v (consumer; resolve in the job)
+    required: false
+    default: ""
+  runtime_pm_version:
+    description: Optional resolved package-manager -v (consumer; resolve in the job)
+    required: false
+    default: ""
+
+outputs:
+  bypass:
+    description: true when content-hash short-circuit is disabled for this run
+    value: ${{ steps.compute.outputs.bypass }}
+  hit:
+    description: true when a validated success marker matches the content hash
+    # Prefer validate output; fall back to compute (sets hit=false on bypass).
+    value: ${{ steps.validate.outputs.hit || steps.compute.outputs.hit }}
+  hash:
+    description: Content hash hex (empty when bypassed)
+    value: ${{ steps.compute.outputs.hash }}
+
+runs:
+  using: composite
+  steps:
+    - id: compute
+      name: compute content-hash (${{ inputs.execution }})
+      shell: bash
+      env:
+        # env-indirection: inputs must not expand into the script body (zizmor).
+        BYPASS: ${{ inputs.bypass }}
+        DISABLE: ${{ inputs.disable }}
+        EXECUTION: ${{ inputs.execution }}
+        CONTAINER_TAG: ${{ inputs.container_tag }}
+        MATRIX_NODE: ${{ inputs.matrix_node }}
+        MATRIX_PM: ${{ inputs.matrix_pm }}
+        MATRIX_PM_VERSION: ${{ inputs.matrix_pm_version }}
+        MATRIX_SVELTE: ${{ inputs.matrix_svelte }}
+        RUNTIME_NODE_VERSION: ${{ inputs.runtime_node_version }}
+        RUNTIME_PM_VERSION: ${{ inputs.runtime_pm_version }}
+      run: |
+        set -euo pipefail
+        if [ "${BYPASS:-}" = "true" ] || [ "${DISABLE:-}" = "1" ]; then
+          {
+            echo "bypass=true"
+            echo "hit=false"
+          } >> "$GITHUB_OUTPUT"
+          echo "content-hash bypassed for ${EXECUTION}"
+          exit 0
+        fi
+        echo "bypass=false" >> "$GITHUB_OUTPUT"
+        args=(--execution "${EXECUTION}" --os "${RUNNER_OS}")
+        if [ -n "${CONTAINER_TAG}" ]; then
+          args+=(--container-tag "${CONTAINER_TAG}")
+        fi
+        if [ -n "${MATRIX_NODE}" ]; then
+          args+=(
+            --matrix-node "${MATRIX_NODE}"
+            --matrix-pm "${MATRIX_PM}"
+            --matrix-pm-version "${MATRIX_PM_VERSION}"
+            --matrix-svelte "${MATRIX_SVELTE}"
+          )
+        fi
+        if [ -n "${RUNTIME_NODE_VERSION}" ]; then
+          args+=(
+            --runtime-node-version "${RUNTIME_NODE_VERSION}"
+            --runtime-pm-version "${RUNTIME_PM_VERSION}"
+          )
+        fi
+        bun scripts/ci-routing.ts hash-inputs "${args[@]}"
+
+    - id: marker_cache
+      name: restore ${{ inputs.execution }} success-marker cache
+      if: steps.compute.outputs.bypass != 'true'
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: .ci-content-hash/${{ inputs.execution }}.ok
+        # Exact key only (no restore-keys) — incomplete or wrong-tree hits are unsafe.
+        key: ${{ steps.compute.outputs.cache_key }}
+
+    - id: validate
+      name: validate ${{ inputs.execution }} success marker
+      if: steps.compute.outputs.bypass != 'true' && steps.marker_cache.outputs.cache-hit == 'true'
+      shell: bash
+      env:
+        # env-indirection: step outputs must not expand into the script body (zizmor).
+        CONTENT_HASH: ${{ steps.compute.outputs.hash }}
+        EXECUTION: ${{ inputs.execution }}
+      run: |
+        set -euo pipefail
+        bun scripts/ci-routing.ts validate-success-marker \
+          --execution "${EXECUTION}" --hash "${CONTENT_HASH}"

--- a/.github/actions/ci-content-hash-write/action.yml
+++ b/.github/actions/ci-content-hash-write/action.yml
@@ -1,0 +1,28 @@
+# Write success marker after a cacheable job body succeeds (issue #245).
+# Call only when restore outputs.hit != 'true' and outputs.bypass != 'true'.
+name: CI content-hash write
+description: >
+  Write a validated success marker for a cacheable execution so subsequent
+  runs with the same content hash can short-circuit.
+
+inputs:
+  execution:
+    description: CacheableExecution name (unit, build, component_svelte, consumer, …)
+    required: true
+  hash:
+    description: Content hash from ci-content-hash-restore
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: write ${{ inputs.execution }} success marker
+      shell: bash
+      env:
+        # env-indirection: inputs must not expand into the script body (zizmor).
+        CONTENT_HASH: ${{ inputs.hash }}
+        EXECUTION: ${{ inputs.execution }}
+      run: |
+        set -euo pipefail
+        bun scripts/ci-routing.ts write-success-marker \
+          --execution "${EXECUTION}" --hash "${CONTENT_HASH}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,14 @@
 # Content-hash skip (issue #245): when a job is still scheduled, it may
 # early-exit success if a validated success marker / packages-dist cache
 # exists for the same physical execution identity (content hash of
-# JOB_CONTENT_INPUTS + recipe). bypass_content_cache disables short-circuit
-# under force-all / lockfile / ci.yml / ci-routing changes. Invalidate by
-# bumping CONTENT_HASH_SCHEMA, editing a matched input, or setting repo
-# variable CI_DISABLE_CONTENT_HASH=1. GHA cache is ref-scoped (not a cross-PR
-# registry). Exact cache keys only — no restore-keys fallback for job markers.
+# JOB_CONTENT_INPUTS + recipe). Success-marker jobs use local composites
+# (.github/actions/ci-content-hash-restore|write); packages-dist keeps its
+# specialized dist-payload path. bypass_content_cache disables short-circuit
+# under force-all / lockfile / ci.yml / ci-routing / .github/actions changes.
+# Invalidate by bumping CONTENT_HASH_SCHEMA, editing a matched input, or
+# setting repo variable CI_DISABLE_CONTENT_HASH=1. GHA cache is ref-scoped
+# (not a cross-PR registry). Exact cache keys only — no restore-keys for
+# job markers.
 name: CI
 
 on:
@@ -318,65 +321,30 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.3.14
-      - id: content_hash
-        name: compute content-hash (unit)
-        env:
-          BYPASS: ${{ needs.detect-changes.outputs.bypass_content_cache }}
-          DISABLE: ${{ vars.CI_DISABLE_CONTENT_HASH }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [ "${BYPASS:-}" = "true" ] || [ "${DISABLE:-}" = "1" ]; then
-            {
-              echo "bypass=true"
-              echo "hit=false"
-            } >> "$GITHUB_OUTPUT"
-            echo "content-hash bypassed for unit"
-            exit 0
-          fi
-          echo "bypass=false" >> "$GITHUB_OUTPUT"
-          bun scripts/ci-routing.ts hash-inputs --execution unit --os "${RUNNER_OS}"
-      - id: marker_cache
-        name: restore unit success-marker cache
-        if: steps.content_hash.outputs.bypass != 'true'
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - uses: ./.github/actions/ci-content-hash-restore
+        id: content_hash
         with:
-          path: .ci-content-hash/unit.ok
-          key: ${{ steps.content_hash.outputs.cache_key }}
-      - id: validate_marker
-        name: validate unit success marker
-        if: steps.content_hash.outputs.bypass != 'true' && steps.marker_cache.outputs.cache-hit == 'true'
-        shell: bash
-        env:
-          # env-indirection: step outputs must not expand into the script body (zizmor).
-          CONTENT_HASH: ${{ steps.content_hash.outputs.hash }}
-        run: |
-          set -euo pipefail
-          bun scripts/ci-routing.ts validate-success-marker \
-            --execution unit --hash "${CONTENT_HASH}"
+          execution: unit
+          bypass: ${{ needs.detect-changes.outputs.bypass_content_cache }}
+          disable: ${{ vars.CI_DISABLE_CONTENT_HASH }}
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        if: steps.validate_marker.outputs.hit != 'true'
+        if: steps.content_hash.outputs.hit != 'true'
         with:
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
           restore-keys: bun-${{ runner.os }}-
-      - if: steps.validate_marker.outputs.hit != 'true'
+      - if: steps.content_hash.outputs.hit != 'true'
         run: bun install --frozen-lockfile
       - name: build spec/core dist (package exports point at dist/)
-        if: steps.validate_marker.outputs.hit != 'true'
+        if: steps.content_hash.outputs.hit != 'true'
         run: bun run check
-      - if: steps.validate_marker.outputs.hit != 'true'
+      - if: steps.content_hash.outputs.hit != 'true'
         run: bun test packages/spec packages/core benchmarks scripts tests/evals
-      - name: write unit success marker
-        if: steps.validate_marker.outputs.hit != 'true' && steps.content_hash.outputs.bypass != 'true'
-        shell: bash
-        env:
-          # env-indirection: step outputs must not expand into the script body (zizmor).
-          CONTENT_HASH: ${{ steps.content_hash.outputs.hash }}
-        run: |
-          set -euo pipefail
-          bun scripts/ci-routing.ts write-success-marker \
-            --execution unit --hash "${CONTENT_HASH}"
+      - uses: ./.github/actions/ci-content-hash-write
+        if: steps.content_hash.outputs.hit != 'true' && steps.content_hash.outputs.bypass != 'true'
+        with:
+          execution: unit
+          hash: ${{ steps.content_hash.outputs.hash }}
 
   compatibility-matrix:
     name: compatibility matrix (machine-checked source)
@@ -448,30 +416,18 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.3.14
-      - id: content_hash
-        name: compute content-hash (consumer)
+      # Resolved toolchain versions (not matrix majors alone) — Node/npm patch
+      # bumps must miss the consumer success-marker cache (Codex P2 on #245).
+      # Keep resolution in the job so the content-hash composite stays protocol-only.
+      - id: consumer_runtime
+        name: resolve consumer runtime toolchain versions
+        shell: bash
         env:
-          BYPASS: ${{ needs.detect-changes.outputs.bypass_content_cache }}
-          DISABLE: ${{ vars.CI_DISABLE_CONTENT_HASH }}
           # env-indirection: matrix values must not expand into the script body (zizmor).
-          MATRIX_NODE: ${{ matrix.node }}
           MATRIX_PM: ${{ matrix.packageManager }}
           MATRIX_PM_VERSION: ${{ matrix.packageManagerVersion }}
-          MATRIX_SVELTE: ${{ matrix.svelte }}
-        shell: bash
         run: |
           set -euo pipefail
-          if [ "${BYPASS:-}" = "true" ] || [ "${DISABLE:-}" = "1" ]; then
-            {
-              echo "bypass=true"
-              echo "hit=false"
-            } >> "$GITHUB_OUTPUT"
-            echo "content-hash bypassed for consumer"
-            exit 0
-          fi
-          echo "bypass=false" >> "$GITHUB_OUTPUT"
-          # Resolved toolchain versions (not matrix majors alone) — Node/npm patch
-          # bumps must miss the consumer success-marker cache (Codex P2 on #245).
           RUNTIME_NODE="$(node -v)"
           case "${MATRIX_PM}" in
             npm) RUNTIME_PM_VER="$(npm -v)" ;;
@@ -485,42 +441,33 @@ jobs:
               ;;
             *) RUNTIME_PM_VER="${MATRIX_PM_VERSION}" ;;
           esac
-          bun scripts/ci-routing.ts hash-inputs --execution consumer --os "${RUNNER_OS}" \
-            --matrix-node "${MATRIX_NODE}" \
-            --matrix-pm "${MATRIX_PM}" \
-            --matrix-pm-version "${MATRIX_PM_VERSION}" \
-            --matrix-svelte "${MATRIX_SVELTE}" \
-            --runtime-node-version "${RUNTIME_NODE}" \
-            --runtime-pm-version "${RUNTIME_PM_VER}"
-      - id: marker_cache
-        name: restore consumer success-marker cache
-        if: steps.content_hash.outputs.bypass != 'true'
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+          {
+            echo "runtime_node=${RUNTIME_NODE}"
+            echo "runtime_pm_ver=${RUNTIME_PM_VER}"
+          } >> "$GITHUB_OUTPUT"
+      - uses: ./.github/actions/ci-content-hash-restore
+        id: content_hash
         with:
-          path: .ci-content-hash/consumer.ok
-          key: ${{ steps.content_hash.outputs.cache_key }}
-      - id: validate_marker
-        name: validate consumer success marker
-        if: steps.content_hash.outputs.bypass != 'true' && steps.marker_cache.outputs.cache-hit == 'true'
-        shell: bash
-        env:
-          # env-indirection: step outputs must not expand into the script body (zizmor).
-          CONTENT_HASH: ${{ steps.content_hash.outputs.hash }}
-        run: |
-          set -euo pipefail
-          bun scripts/ci-routing.ts validate-success-marker \
-            --execution consumer --hash "${CONTENT_HASH}"
-      - if: steps.validate_marker.outputs.hit != 'true'
+          execution: consumer
+          bypass: ${{ needs.detect-changes.outputs.bypass_content_cache }}
+          disable: ${{ vars.CI_DISABLE_CONTENT_HASH }}
+          matrix_node: ${{ matrix.node }}
+          matrix_pm: ${{ matrix.packageManager }}
+          matrix_pm_version: ${{ matrix.packageManagerVersion }}
+          matrix_svelte: ${{ matrix.svelte }}
+          runtime_node_version: ${{ steps.consumer_runtime.outputs.runtime_node }}
+          runtime_pm_version: ${{ steps.consumer_runtime.outputs.runtime_pm_ver }}
+      - if: steps.content_hash.outputs.hit != 'true'
         run: bun install --frozen-lockfile
       - name: download shared packages/*/dist
-        if: steps.validate_marker.outputs.hit != 'true'
+        if: steps.content_hash.outputs.hit != 'true'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: packages-dist
           # Producer uploads .packages-dist-upload/packages → extract as packages/.
           path: packages
       - name: verify downloaded package dist entrypoints
-        if: steps.validate_marker.outputs.hit != 'true'
+        if: steps.content_hash.outputs.hit != 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -535,10 +482,10 @@ jobs:
             fi
           done
       - name: type-check Svelte package source
-        if: steps.validate_marker.outputs.hit != 'true'
+        if: steps.content_hash.outputs.hit != 'true'
         run: bun run check:svelte
       - name: install tarballs in a clean consumer and exercise types, build, SSR, Node, and CLI
-        if: steps.validate_marker.outputs.hit != 'true'
+        if: steps.content_hash.outputs.hit != 'true'
         env:
           PACKAGE_MANAGER: ${{ matrix.packageManager }}
           PACKAGE_MANAGER_VERSION: ${{ matrix.packageManagerVersion }}
@@ -547,16 +494,11 @@ jobs:
 
       # Component surface is split for wall-clock (issue #243). All three schedule
       # when routing sets component=true; ci-gate requires every shard to succeed.
-      - name: write consumer success marker
-        if: steps.validate_marker.outputs.hit != 'true' && steps.content_hash.outputs.bypass != 'true'
-        shell: bash
-        env:
-          # env-indirection: step outputs must not expand into the script body (zizmor).
-          CONTENT_HASH: ${{ steps.content_hash.outputs.hash }}
-        run: |
-          set -euo pipefail
-          bun scripts/ci-routing.ts write-success-marker \
-            --execution consumer --hash "${CONTENT_HASH}"
+      - uses: ./.github/actions/ci-content-hash-write
+        if: steps.content_hash.outputs.hit != 'true' && steps.content_hash.outputs.bypass != 'true'
+        with:
+          execution: consumer
+          hash: ${{ steps.content_hash.outputs.hash }}
 
   component-svelte:
     name: component-svelte (packages/svelte vitest browser + ssr)
@@ -593,59 +535,30 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.3.14
-      - id: content_hash
-        name: compute content-hash (component_svelte)
-        env:
-          BYPASS: ${{ needs.detect-changes.outputs.bypass_content_cache }}
-          DISABLE: ${{ vars.CI_DISABLE_CONTENT_HASH }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [ "${BYPASS:-}" = "true" ] || [ "${DISABLE:-}" = "1" ]; then
-            {
-              echo "bypass=true"
-              echo "hit=false"
-            } >> "$GITHUB_OUTPUT"
-            echo "content-hash bypassed for component_svelte"
-            exit 0
-          fi
-          echo "bypass=false" >> "$GITHUB_OUTPUT"
-          bun scripts/ci-routing.ts hash-inputs --execution component_svelte --os "${RUNNER_OS}" --container-tag "${PLAYWRIGHT_CONTAINER_TAG}"
-      - id: marker_cache
-        name: restore component_svelte success-marker cache
-        if: steps.content_hash.outputs.bypass != 'true'
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - uses: ./.github/actions/ci-content-hash-restore
+        id: content_hash
         with:
-          path: .ci-content-hash/component_svelte.ok
-          key: ${{ steps.content_hash.outputs.cache_key }}
-      - id: validate_marker
-        name: validate component_svelte success marker
-        if: steps.content_hash.outputs.bypass != 'true' && steps.marker_cache.outputs.cache-hit == 'true'
-        shell: bash
-        env:
-          # env-indirection: step outputs must not expand into the script body (zizmor).
-          CONTENT_HASH: ${{ steps.content_hash.outputs.hash }}
-        run: |
-          set -euo pipefail
-          bun scripts/ci-routing.ts validate-success-marker \
-            --execution component_svelte --hash "${CONTENT_HASH}"
+          execution: component_svelte
+          bypass: ${{ needs.detect-changes.outputs.bypass_content_cache }}
+          disable: ${{ vars.CI_DISABLE_CONTENT_HASH }}
+          container_tag: ${{ env.PLAYWRIGHT_CONTAINER_TAG }}
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        if: steps.validate_marker.outputs.hit != 'true'
+        if: steps.content_hash.outputs.hit != 'true'
         with:
           path: ~/.bun/install/cache
           key: bun-container-${{ runner.os }}-${{ hashFiles('bun.lock') }}
           restore-keys: bun-container-${{ runner.os }}-
-      - if: steps.validate_marker.outputs.hit != 'true'
+      - if: steps.content_hash.outputs.hit != 'true'
         run: bun install --frozen-lockfile
       - name: download shared packages/*/dist
-        if: steps.validate_marker.outputs.hit != 'true'
+        if: steps.content_hash.outputs.hit != 'true'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: packages-dist
           # Producer uploads .packages-dist-upload/packages → extract as packages/.
           path: packages
       - name: verify downloaded package dist entrypoints
-        if: steps.validate_marker.outputs.hit != 'true'
+        if: steps.content_hash.outputs.hit != 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -660,7 +573,7 @@ jobs:
             fi
           done
       - name: assert playwright npm/container version sync (packages/svelte)
-        if: steps.validate_marker.outputs.hit != 'true'
+        if: steps.content_hash.outputs.hit != 'true'
         run: |
           set -euo pipefail
           npm_version="$(cd packages/svelte && bun -e 'console.log(require("playwright/package.json").version)')"
@@ -671,19 +584,14 @@ jobs:
             exit 1
           fi
       - name: component tests (packages/svelte, vitest browser mode + ssr)
-        if: steps.validate_marker.outputs.hit != 'true'
+        if: steps.content_hash.outputs.hit != 'true'
         working-directory: packages/svelte
         run: bun run --bun test
-      - name: write component_svelte success marker
-        if: steps.validate_marker.outputs.hit != 'true' && steps.content_hash.outputs.bypass != 'true'
-        shell: bash
-        env:
-          # env-indirection: step outputs must not expand into the script body (zizmor).
-          CONTENT_HASH: ${{ steps.content_hash.outputs.hash }}
-        run: |
-          set -euo pipefail
-          bun scripts/ci-routing.ts write-success-marker \
-            --execution component_svelte --hash "${CONTENT_HASH}"
+      - uses: ./.github/actions/ci-content-hash-write
+        if: steps.content_hash.outputs.hit != 'true' && steps.content_hash.outputs.bypass != 'true'
+        with:
+          execution: component_svelte
+          hash: ${{ steps.content_hash.outputs.hash }}
       - name: upload packages/svelte failure artifacts
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -728,59 +636,30 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.3.14
-      - id: content_hash
-        name: compute content-hash (component_spikes)
-        env:
-          BYPASS: ${{ needs.detect-changes.outputs.bypass_content_cache }}
-          DISABLE: ${{ vars.CI_DISABLE_CONTENT_HASH }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [ "${BYPASS:-}" = "true" ] || [ "${DISABLE:-}" = "1" ]; then
-            {
-              echo "bypass=true"
-              echo "hit=false"
-            } >> "$GITHUB_OUTPUT"
-            echo "content-hash bypassed for component_spikes"
-            exit 0
-          fi
-          echo "bypass=false" >> "$GITHUB_OUTPUT"
-          bun scripts/ci-routing.ts hash-inputs --execution component_spikes --os "${RUNNER_OS}" --container-tag "${PLAYWRIGHT_CONTAINER_TAG}"
-      - id: marker_cache
-        name: restore component_spikes success-marker cache
-        if: steps.content_hash.outputs.bypass != 'true'
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - uses: ./.github/actions/ci-content-hash-restore
+        id: content_hash
         with:
-          path: .ci-content-hash/component_spikes.ok
-          key: ${{ steps.content_hash.outputs.cache_key }}
-      - id: validate_marker
-        name: validate component_spikes success marker
-        if: steps.content_hash.outputs.bypass != 'true' && steps.marker_cache.outputs.cache-hit == 'true'
-        shell: bash
-        env:
-          # env-indirection: step outputs must not expand into the script body (zizmor).
-          CONTENT_HASH: ${{ steps.content_hash.outputs.hash }}
-        run: |
-          set -euo pipefail
-          bun scripts/ci-routing.ts validate-success-marker \
-            --execution component_spikes --hash "${CONTENT_HASH}"
+          execution: component_spikes
+          bypass: ${{ needs.detect-changes.outputs.bypass_content_cache }}
+          disable: ${{ vars.CI_DISABLE_CONTENT_HASH }}
+          container_tag: ${{ env.PLAYWRIGHT_CONTAINER_TAG }}
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        if: steps.validate_marker.outputs.hit != 'true'
+        if: steps.content_hash.outputs.hit != 'true'
         with:
           path: ~/.bun/install/cache
           key: bun-container-${{ runner.os }}-${{ hashFiles('bun.lock') }}
           restore-keys: bun-container-${{ runner.os }}-
-      - if: steps.validate_marker.outputs.hit != 'true'
+      - if: steps.content_hash.outputs.hit != 'true'
         run: bun install --frozen-lockfile
       - name: download shared packages/*/dist
-        if: steps.validate_marker.outputs.hit != 'true'
+        if: steps.content_hash.outputs.hit != 'true'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: packages-dist
           # Producer uploads .packages-dist-upload/packages → extract as packages/.
           path: packages
       - name: verify downloaded package dist entrypoints
-        if: steps.validate_marker.outputs.hit != 'true'
+        if: steps.content_hash.outputs.hit != 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -795,7 +674,7 @@ jobs:
             fi
           done
       - name: assert playwright npm/container version sync (spikes/browser)
-        if: steps.validate_marker.outputs.hit != 'true'
+        if: steps.content_hash.outputs.hit != 'true'
         run: |
           set -euo pipefail
           npm_version="$(cd spikes/browser && bun -e 'console.log(require("playwright/package.json").version)')"
@@ -806,19 +685,14 @@ jobs:
             exit 1
           fi
       - name: retired spike suites (browser + ssr projects)
-        if: steps.validate_marker.outputs.hit != 'true'
+        if: steps.content_hash.outputs.hit != 'true'
         working-directory: spikes/browser
         run: bun run --bun test
-      - name: write component_spikes success marker
-        if: steps.validate_marker.outputs.hit != 'true' && steps.content_hash.outputs.bypass != 'true'
-        shell: bash
-        env:
-          # env-indirection: step outputs must not expand into the script body (zizmor).
-          CONTENT_HASH: ${{ steps.content_hash.outputs.hash }}
-        run: |
-          set -euo pipefail
-          bun scripts/ci-routing.ts write-success-marker \
-            --execution component_spikes --hash "${CONTENT_HASH}"
+      - uses: ./.github/actions/ci-content-hash-write
+        if: steps.content_hash.outputs.hit != 'true' && steps.content_hash.outputs.bypass != 'true'
+        with:
+          execution: component_spikes
+          hash: ${{ steps.content_hash.outputs.hash }}
       - name: upload spikes failure artifacts
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -863,59 +737,30 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.3.14
-      - id: content_hash
-        name: compute content-hash (component_journeys)
-        env:
-          BYPASS: ${{ needs.detect-changes.outputs.bypass_content_cache }}
-          DISABLE: ${{ vars.CI_DISABLE_CONTENT_HASH }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [ "${BYPASS:-}" = "true" ] || [ "${DISABLE:-}" = "1" ]; then
-            {
-              echo "bypass=true"
-              echo "hit=false"
-            } >> "$GITHUB_OUTPUT"
-            echo "content-hash bypassed for component_journeys"
-            exit 0
-          fi
-          echo "bypass=false" >> "$GITHUB_OUTPUT"
-          bun scripts/ci-routing.ts hash-inputs --execution component_journeys --os "${RUNNER_OS}" --container-tag "${PLAYWRIGHT_CONTAINER_TAG}"
-      - id: marker_cache
-        name: restore component_journeys success-marker cache
-        if: steps.content_hash.outputs.bypass != 'true'
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - uses: ./.github/actions/ci-content-hash-restore
+        id: content_hash
         with:
-          path: .ci-content-hash/component_journeys.ok
-          key: ${{ steps.content_hash.outputs.cache_key }}
-      - id: validate_marker
-        name: validate component_journeys success marker
-        if: steps.content_hash.outputs.bypass != 'true' && steps.marker_cache.outputs.cache-hit == 'true'
-        shell: bash
-        env:
-          # env-indirection: step outputs must not expand into the script body (zizmor).
-          CONTENT_HASH: ${{ steps.content_hash.outputs.hash }}
-        run: |
-          set -euo pipefail
-          bun scripts/ci-routing.ts validate-success-marker \
-            --execution component_journeys --hash "${CONTENT_HASH}"
+          execution: component_journeys
+          bypass: ${{ needs.detect-changes.outputs.bypass_content_cache }}
+          disable: ${{ vars.CI_DISABLE_CONTENT_HASH }}
+          container_tag: ${{ env.PLAYWRIGHT_CONTAINER_TAG }}
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        if: steps.validate_marker.outputs.hit != 'true'
+        if: steps.content_hash.outputs.hit != 'true'
         with:
           path: ~/.bun/install/cache
           key: bun-container-${{ runner.os }}-${{ hashFiles('bun.lock') }}
           restore-keys: bun-container-${{ runner.os }}-
-      - if: steps.validate_marker.outputs.hit != 'true'
+      - if: steps.content_hash.outputs.hit != 'true'
         run: bun install --frozen-lockfile
       - name: download shared packages/*/dist
-        if: steps.validate_marker.outputs.hit != 'true'
+        if: steps.content_hash.outputs.hit != 'true'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: packages-dist
           # Producer uploads .packages-dist-upload/packages → extract as packages/.
           path: packages
       - name: verify downloaded package dist entrypoints
-        if: steps.validate_marker.outputs.hit != 'true'
+        if: steps.content_hash.outputs.hit != 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -930,7 +775,7 @@ jobs:
             fi
           done
       - name: assert playwright npm/container version sync (root @playwright/test)
-        if: steps.validate_marker.outputs.hit != 'true'
+        if: steps.content_hash.outputs.hit != 'true'
         run: |
           set -euo pipefail
           vr_version="$(bun -e 'console.log(require("@playwright/test/package.json").version)')"
@@ -940,21 +785,16 @@ jobs:
             exit 1
           fi
       - name: build packaged interaction test target
-        if: steps.validate_marker.outputs.hit != 'true'
+        if: steps.content_hash.outputs.hit != 'true'
         run: BASE_PATH=/ggsvelte bun run build:docs
       - name: interaction and safe-playground accessibility journeys
-        if: steps.validate_marker.outputs.hit != 'true'
+        if: steps.content_hash.outputs.hit != 'true'
         run: bun run test:visual -- interaction-accessibility.spec.ts playground.spec.ts
-      - name: write component_journeys success marker
-        if: steps.validate_marker.outputs.hit != 'true' && steps.content_hash.outputs.bypass != 'true'
-        shell: bash
-        env:
-          # env-indirection: step outputs must not expand into the script body (zizmor).
-          CONTENT_HASH: ${{ steps.content_hash.outputs.hash }}
-        run: |
-          set -euo pipefail
-          bun scripts/ci-routing.ts write-success-marker \
-            --execution component_journeys --hash "${CONTENT_HASH}"
+      - uses: ./.github/actions/ci-content-hash-write
+        if: steps.content_hash.outputs.hit != 'true' && steps.content_hash.outputs.bypass != 'true'
+        with:
+          execution: component_journeys
+          hash: ${{ steps.content_hash.outputs.hash }}
       - name: upload journey failure artifacts
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -1066,88 +906,53 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.3.14
-      - id: content_hash
-        name: compute content-hash (build)
-        env:
-          BYPASS: ${{ needs.detect-changes.outputs.bypass_content_cache }}
-          DISABLE: ${{ vars.CI_DISABLE_CONTENT_HASH }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [ "${BYPASS:-}" = "true" ] || [ "${DISABLE:-}" = "1" ]; then
-            {
-              echo "bypass=true"
-              echo "hit=false"
-            } >> "$GITHUB_OUTPUT"
-            echo "content-hash bypassed for build"
-            exit 0
-          fi
-          echo "bypass=false" >> "$GITHUB_OUTPUT"
-          bun scripts/ci-routing.ts hash-inputs --execution build --os "${RUNNER_OS}"
-      - id: marker_cache
-        name: restore build success-marker cache
-        if: steps.content_hash.outputs.bypass != 'true'
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - uses: ./.github/actions/ci-content-hash-restore
+        id: content_hash
         with:
-          path: .ci-content-hash/build.ok
-          key: ${{ steps.content_hash.outputs.cache_key }}
-      - id: validate_marker
-        name: validate build success marker
-        if: steps.content_hash.outputs.bypass != 'true' && steps.marker_cache.outputs.cache-hit == 'true'
-        shell: bash
-        env:
-          # env-indirection: step outputs must not expand into the script body (zizmor).
-          CONTENT_HASH: ${{ steps.content_hash.outputs.hash }}
-        run: |
-          set -euo pipefail
-          bun scripts/ci-routing.ts validate-success-marker \
-            --execution build --hash "${CONTENT_HASH}"
+          execution: build
+          bypass: ${{ needs.detect-changes.outputs.bypass_content_cache }}
+          disable: ${{ vars.CI_DISABLE_CONTENT_HASH }}
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        if: steps.validate_marker.outputs.hit != 'true'
+        if: steps.content_hash.outputs.hit != 'true'
         with:
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
           restore-keys: bun-${{ runner.os }}-
-      - if: steps.validate_marker.outputs.hit != 'true'
+      - if: steps.content_hash.outputs.hit != 'true'
         run: bun install --frozen-lockfile
       - name: build packages (tsc -b + svelte-package)
-        if: steps.validate_marker.outputs.hit != 'true'
+        if: steps.content_hash.outputs.hit != 'true'
         run: bun run build
       # Former pre-push hooks that are not duplicated by unit/component jobs.
       - name: svelte-check (packages/svelte)
-        if: steps.validate_marker.outputs.hit != 'true'
+        if: steps.content_hash.outputs.hit != 'true'
         run: bun run check:svelte
       - name: svelte-check (apps/docs)
-        if: steps.validate_marker.outputs.hit != 'true'
+        if: steps.content_hash.outputs.hit != 'true'
         run: bun run check:docs
       - name: tsc examples corpus
-        if: steps.validate_marker.outputs.hit != 'true'
+        if: steps.content_hash.outputs.hit != 'true'
         run: bun run check:examples
       - name: oxlint --type-aware
-        if: steps.validate_marker.outputs.hit != 'true'
+        if: steps.content_hash.outputs.hit != 'true'
         run: bun run lint:type-aware
       - name: knip
-        if: steps.validate_marker.outputs.hit != 'true'
+        if: steps.content_hash.outputs.hit != 'true'
         run: bun run knip
       - name: publint + attw (real gate — exports point at dist/)
-        if: steps.validate_marker.outputs.hit != 'true'
+        if: steps.content_hash.outputs.hit != 'true'
         run: bun run lint:package
       - name: build static docs site (adapter-static; the deployable/VR target)
-        if: steps.validate_marker.outputs.hit != 'true'
+        if: steps.content_hash.outputs.hit != 'true'
         run: bun run build:docs
       - name: verify packed Pages links and required R0 journeys
-        if: steps.validate_marker.outputs.hit != 'true'
+        if: steps.content_hash.outputs.hit != 'true'
         run: bun run check:pages-links
-      - name: write build success marker
-        if: steps.validate_marker.outputs.hit != 'true' && steps.content_hash.outputs.bypass != 'true'
-        shell: bash
-        env:
-          # env-indirection: step outputs must not expand into the script body (zizmor).
-          CONTENT_HASH: ${{ steps.content_hash.outputs.hash }}
-        run: |
-          set -euo pipefail
-          bun scripts/ci-routing.ts write-success-marker \
-            --execution build --hash "${CONTENT_HASH}"
+      - uses: ./.github/actions/ci-content-hash-write
+        if: steps.content_hash.outputs.hit != 'true' && steps.content_hash.outputs.bypass != 'true'
+        with:
+          execution: build
+          hash: ${{ steps.content_hash.outputs.hash }}
       # packages/*/dist for consumers is produced by packages-dist (issue #241).
       # This job keeps an independent build so publint/attw always re-validate
       # a fresh tree alongside knip/type-aware analysis.
@@ -1166,68 +971,33 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.3.14
-      - id: content_hash
-        name: compute content-hash (actions_security)
-        env:
-          BYPASS: ${{ needs.detect-changes.outputs.bypass_content_cache }}
-          DISABLE: ${{ vars.CI_DISABLE_CONTENT_HASH }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [ "${BYPASS:-}" = "true" ] || [ "${DISABLE:-}" = "1" ]; then
-            {
-              echo "bypass=true"
-              echo "hit=false"
-            } >> "$GITHUB_OUTPUT"
-            echo "content-hash bypassed for actions_security"
-            exit 0
-          fi
-          echo "bypass=false" >> "$GITHUB_OUTPUT"
-          bun scripts/ci-routing.ts hash-inputs --execution actions_security --os "${RUNNER_OS}"
-      - id: marker_cache
-        name: restore actions_security success-marker cache
-        if: steps.content_hash.outputs.bypass != 'true'
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - uses: ./.github/actions/ci-content-hash-restore
+        id: content_hash
         with:
-          path: .ci-content-hash/actions_security.ok
-          key: ${{ steps.content_hash.outputs.cache_key }}
-      - id: validate_marker
-        name: validate actions_security success marker
-        if: steps.content_hash.outputs.bypass != 'true' && steps.marker_cache.outputs.cache-hit == 'true'
-        shell: bash
-        env:
-          # env-indirection: step outputs must not expand into the script body (zizmor).
-          CONTENT_HASH: ${{ steps.content_hash.outputs.hash }}
-        run: |
-          set -euo pipefail
-          bun scripts/ci-routing.ts validate-success-marker \
-            --execution actions_security --hash "${CONTENT_HASH}"
+          execution: actions_security
+          bypass: ${{ needs.detect-changes.outputs.bypass_content_cache }}
+          disable: ${{ vars.CI_DISABLE_CONTENT_HASH }}
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        if: steps.validate_marker.outputs.hit != 'true'
+        if: steps.content_hash.outputs.hit != 'true'
         with:
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
           restore-keys: bun-${{ runner.os }}-
-      - if: steps.validate_marker.outputs.hit != 'true'
+      - if: steps.content_hash.outputs.hit != 'true'
         run: bun install --frozen-lockfile
       - name: actionlint (lockfile-installed wasm build)
-        if: steps.validate_marker.outputs.hit != 'true'
+        if: steps.content_hash.outputs.hit != 'true'
         run: bun run lint:actions
       - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
-        if: steps.validate_marker.outputs.hit != 'true'
+        if: steps.content_hash.outputs.hit != 'true'
       - name: zizmor
-        if: steps.validate_marker.outputs.hit != 'true'
-        run: uvx zizmor==1.26.1 .github/workflows
-      - name: write actions_security success marker
-        if: steps.validate_marker.outputs.hit != 'true' && steps.content_hash.outputs.bypass != 'true'
-        shell: bash
-        env:
-          # env-indirection: step outputs must not expand into the script body (zizmor).
-          CONTENT_HASH: ${{ steps.content_hash.outputs.hash }}
-        run: |
-          set -euo pipefail
-          bun scripts/ci-routing.ts write-success-marker \
-            --execution actions_security --hash "${CONTENT_HASH}"
+        if: steps.content_hash.outputs.hit != 'true'
+        run: uvx zizmor==1.26.1 .github/workflows .github/actions
+      - uses: ./.github/actions/ci-content-hash-write
+        if: steps.content_hash.outputs.hit != 'true' && steps.content_hash.outputs.bypass != 'true'
+        with:
+          execution: actions_security
+          hash: ${{ steps.content_hash.outputs.hash }}
 
   bench-smoke:
     name: bench-smoke (mitata, 1k workload)
@@ -1243,69 +1013,34 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.3.14
-      - id: content_hash
-        name: compute content-hash (bench_smoke)
-        env:
-          BYPASS: ${{ needs.detect-changes.outputs.bypass_content_cache }}
-          DISABLE: ${{ vars.CI_DISABLE_CONTENT_HASH }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [ "${BYPASS:-}" = "true" ] || [ "${DISABLE:-}" = "1" ]; then
-            {
-              echo "bypass=true"
-              echo "hit=false"
-            } >> "$GITHUB_OUTPUT"
-            echo "content-hash bypassed for bench_smoke"
-            exit 0
-          fi
-          echo "bypass=false" >> "$GITHUB_OUTPUT"
-          bun scripts/ci-routing.ts hash-inputs --execution bench_smoke --os "${RUNNER_OS}"
-      - id: marker_cache
-        name: restore bench_smoke success-marker cache
-        if: steps.content_hash.outputs.bypass != 'true'
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - uses: ./.github/actions/ci-content-hash-restore
+        id: content_hash
         with:
-          path: .ci-content-hash/bench_smoke.ok
-          key: ${{ steps.content_hash.outputs.cache_key }}
-      - id: validate_marker
-        name: validate bench_smoke success marker
-        if: steps.content_hash.outputs.bypass != 'true' && steps.marker_cache.outputs.cache-hit == 'true'
-        shell: bash
-        env:
-          # env-indirection: step outputs must not expand into the script body (zizmor).
-          CONTENT_HASH: ${{ steps.content_hash.outputs.hash }}
-        run: |
-          set -euo pipefail
-          bun scripts/ci-routing.ts validate-success-marker \
-            --execution bench_smoke --hash "${CONTENT_HASH}"
+          execution: bench_smoke
+          bypass: ${{ needs.detect-changes.outputs.bypass_content_cache }}
+          disable: ${{ vars.CI_DISABLE_CONTENT_HASH }}
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        if: steps.validate_marker.outputs.hit != 'true'
+        if: steps.content_hash.outputs.hit != 'true'
         with:
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
           restore-keys: bun-${{ runner.os }}-
-      - if: steps.validate_marker.outputs.hit != 'true'
+      - if: steps.content_hash.outputs.hit != 'true'
         run: bun install --frozen-lockfile
       - name: build spec/core dist (benchmarks import the packages)
-        if: steps.validate_marker.outputs.hit != 'true'
+        if: steps.content_hash.outputs.hit != 'true'
         run: bun run check
       - name: bench smoke (1k points; informal numbers, not a gate on values)
-        if: steps.validate_marker.outputs.hit != 'true'
+        if: steps.content_hash.outputs.hit != 'true'
         run: bun run bench:smoke
       - name: retained-memory absolute and 20% regression gate
-        if: steps.validate_marker.outputs.hit != 'true'
+        if: steps.content_hash.outputs.hit != 'true'
         run: bun run bench:memory:check
-      - name: write bench_smoke success marker
-        if: steps.validate_marker.outputs.hit != 'true' && steps.content_hash.outputs.bypass != 'true'
-        shell: bash
-        env:
-          # env-indirection: step outputs must not expand into the script body (zizmor).
-          CONTENT_HASH: ${{ steps.content_hash.outputs.hash }}
-        run: |
-          set -euo pipefail
-          bun scripts/ci-routing.ts write-success-marker \
-            --execution bench_smoke --hash "${CONTENT_HASH}"
+      - uses: ./.github/actions/ci-content-hash-write
+        if: steps.content_hash.outputs.hit != 'true' && steps.content_hash.outputs.bypass != 'true'
+        with:
+          execution: bench_smoke
+          hash: ${{ steps.content_hash.outputs.hash }}
 
   vr-baseline-guard:
     # Container-only baseline policy (decision 0009): committed baselines may

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,15 +147,21 @@ Path routing (`scripts/ci-routing.ts`) schedules jobs from the changed-file
 set. Content-hash skip (issue #245) is a second layer: when a job is still
 scheduled, it may early-exit success if a validated success marker (or
 `packages-dist` cache) exists for the same **physical execution identity**
-(content hash of `JOB_CONTENT_INPUTS` + recipe files including `ci.yml`).
+(content hash of `JOB_CONTENT_INPUTS` + recipe files including `ci.yml` and
+`.github/actions/**`).
 
-| Control                                                  | Effect                                         |
-| -------------------------------------------------------- | ---------------------------------------------- |
-| Change any path in that execution’s `JOB_CONTENT_INPUTS` | New hash → cache miss → full run               |
-| Expand/edit `JOB_CONTENT_INPUTS` patterns                | Patterns are inside the digest → miss          |
-| Bump `CONTENT_HASH_SCHEMA` in `scripts/ci-routing.ts`    | Global bust of all content-hash caches         |
-| force-all, lockfile, `ci.yml`, or `ci-routing` change    | `bypass_content_cache=true` → no short-circuit |
-| Repo variable `CI_DISABLE_CONTENT_HASH=1`                | Disable short-circuit for all jobs             |
+The success-marker protocol is implemented once in local composite actions
+(`.github/actions/ci-content-hash-restore`, `ci-content-hash-write`); `ci.yml`
+jobs call those instead of pasting the steps. The `packages-dist` producer keeps
+its specialized dist-payload cache path.
+
+| Control                                                    | Effect                                         |
+| ---------------------------------------------------------- | ---------------------------------------------- |
+| Change any path in that execution’s `JOB_CONTENT_INPUTS`   | New hash → cache miss → full run               |
+| Expand/edit `JOB_CONTENT_INPUTS` patterns                  | Patterns are inside the digest → miss          |
+| Bump `CONTENT_HASH_SCHEMA` in `scripts/ci-routing.ts`      | Global bust of all content-hash caches         |
+| force-all, lockfile, `ci.yml`, `ci-routing`, or composites | `bypass_content_cache=true` → no short-circuit |
+| Repo variable `CI_DISABLE_CONTENT_HASH=1`                  | Disable short-circuit for all jobs             |
 
 Hashes are fail-closed (missing digests abort). Component shards and each
 consumer matrix cell have distinct cache keys. GHA cache is ref-scoped —

--- a/scripts/ci-routing.test.ts
+++ b/scripts/ci-routing.test.ts
@@ -169,6 +169,19 @@ describe("planJobs", () => {
     expect(plan.unit).toBe(true);
   });
 
+  test("composite action changes force the full CI surface (no false-green on recipe-only edits)", () => {
+    const plan = planJobs(
+      classifyChangedPaths([".github/actions/ci-content-hash-restore/action.yml"]),
+    );
+    expect(plan.unit).toBe(true);
+    expect(plan.component).toBe(true);
+    expect(plan.consumer).toBe(true);
+    expect(plan.build).toBe(true);
+    expect(plan.bench_smoke).toBe(true);
+    expect(plan.actions_security).toBe(true);
+    expect(plan.packages_dist).toBe(true);
+  });
+
   test("ci.yml self-changes force the full CI surface so routing cannot silently shrink", () => {
     const plan = planJobs(classifyChangedPaths([".github/workflows/ci.yml"]));
     expect(plan.unit).toBe(true);
@@ -352,12 +365,14 @@ describe("content-hash inputs", () => {
       "package.json",
       ".github/workflows/ci.yml",
       "scripts/ci-routing.ts",
+      ".github/actions/ci-content-hash-restore/action.yml",
     ]);
     expect(paths).toContain("packages/core/src/x.ts");
     expect(paths).toContain("packages/svelte/src/lib/Plot.svelte");
     expect(paths).toContain("bun.lock");
     expect(paths).toContain(".github/workflows/ci.yml");
     expect(paths).toContain("scripts/ci-routing.ts");
+    expect(paths).toContain(".github/actions/ci-content-hash-restore/action.yml");
     expect(paths).not.toContain("spikes/browser/foo.ts");
     expect(paths).not.toContain("tests/visual/vr.spec.ts");
     expect(paths).not.toContain("README.md");
@@ -452,11 +467,16 @@ describe("hashJobInputs (fail-closed)", () => {
 });
 
 describe("shouldBypassContentCache", () => {
-  test("true for forceAll, lockfile, ci.yml, and ci-routing changes", () => {
+  test("true for forceAll, lockfile, ci.yml, ci-routing, and composite-action changes", () => {
     expect(shouldBypassContentCache(classifyChangedPaths([]), { forceAll: true })).toBe(true);
     expect(shouldBypassContentCache(classifyChangedPaths(["bun.lock"]))).toBe(true);
     expect(shouldBypassContentCache(classifyChangedPaths([".github/workflows/ci.yml"]))).toBe(true);
     expect(shouldBypassContentCache(classifyChangedPaths(["scripts/ci-routing.ts"]))).toBe(true);
+    expect(
+      shouldBypassContentCache(
+        classifyChangedPaths([".github/actions/ci-content-hash-restore/action.yml"]),
+      ),
+    ).toBe(true);
     expect(shouldBypassContentCache(classifyChangedPaths(["packages/core/src/x.ts"]))).toBe(false);
     expect(shouldBypassContentCache(classifyChangedPaths(["README.md"]))).toBe(false);
   });

--- a/scripts/ci-routing.ts
+++ b/scripts/ci-routing.ts
@@ -44,6 +44,7 @@ export type ChangeLane =
   | "workflows"
   | "ci_workflow"
   | "ci_routing"
+  | "ci_actions"
   | "visual"
   | "spikes"
   | "lockfile"
@@ -103,6 +104,9 @@ export const LANE_PATTERNS: Record<ChangeLane, readonly string[]> = {
   ],
   ci_workflow: [".github/workflows/ci.yml"],
   ci_routing: ["scripts/ci-routing.ts", "scripts/ci-routing.test.ts"],
+  // Local composite actions used by ci.yml (content-hash restore/write). A change
+  // here is a CI recipe change and must force the full surface + bypass cache.
+  ci_actions: [".github/actions/**"],
   visual: ["tests/visual/**"],
   performance: [
     "tests/performance/**",
@@ -244,7 +248,7 @@ export function planJobs(changes: ChangeFlags, options: PlanOptions = {}): JobPl
     return all;
   }
 
-  const force = changes.lockfile || changes.ci_workflow || changes.ci_routing;
+  const force = changes.lockfile || changes.ci_workflow || changes.ci_routing || changes.ci_actions;
   const packageSurface = changes.spec || changes.core || changes.svelte || force;
   const docsSurface = changes.docs || changes.examples || force;
   const browserSurface =
@@ -425,6 +429,8 @@ export const CACHEABLE_EXECUTIONS: readonly CacheableExecution[] = [
  */
 const UNIVERSAL_CONTENT_INPUTS: readonly string[] = [
   ".github/workflows/ci.yml",
+  // Composite actions hold the success-marker protocol after extraction from ci.yml.
+  ".github/actions/**",
   "scripts/ci-routing.ts",
   "scripts/ci-routing.test.ts",
   "bun.lock",
@@ -639,7 +645,7 @@ export function requireJobInputDigests(
 
 export function shouldBypassContentCache(changes: ChangeFlags, options: PlanOptions = {}): boolean {
   if (options.forceAll === true) return true;
-  return changes.lockfile || changes.ci_workflow || changes.ci_routing;
+  return changes.lockfile || changes.ci_workflow || changes.ci_routing || changes.ci_actions;
 }
 
 export type FormatGithubOutputOptions = {

--- a/scripts/release-wiring.test.ts
+++ b/scripts/release-wiring.test.ts
@@ -106,11 +106,30 @@ describe("R0 release wiring", () => {
 
   it("content-hash skips scheduled jobs via physical execution keys (issue #245)", () => {
     const ci = read(".github/workflows/ci.yml");
-    // detect-changes exports bypass covering force-all / lockfile / ci.yml / router.
+    const restore = read(".github/actions/ci-content-hash-restore/action.yml");
+    const write = read(".github/actions/ci-content-hash-write/action.yml");
+
+    // Protocol lives in composites (single source of truth).
+    expect(restore).toContain("hash-inputs");
+    expect(restore).toContain("validate-success-marker");
+    expect(restore).toContain(".ci-content-hash/");
+    expect(restore).toContain("shell: bash");
+    // Exact key only — no restore-keys on the success-marker cache step.
+    const markerCache = restore.slice(
+      restore.indexOf("path: .ci-content-hash/"),
+      restore.indexOf("validate-success-marker"),
+    );
+    expect(markerCache).toContain("key:");
+    expect(markerCache).not.toContain("restore-keys:");
+    expect(write).toContain("write-success-marker");
+    expect(write).toContain("shell: bash");
+
+    // detect-changes exports bypass covering force-all / lockfile / ci.yml / router / actions.
     const detect = ci.slice(ci.indexOf("  detect-changes:"), ci.indexOf("  packages-dist:"));
     expect(detect).toContain("bypass_content_cache:");
     expect(detect).toContain("emit-github-output");
 
+    // packages-dist keeps its specialized dist-payload protocol (not the marker composite).
     const producerJob = ci.slice(
       ci.indexOf("  packages-dist:\n    name: packages-dist"),
       ci.indexOf("  checks:\n    name: checks"),
@@ -119,23 +138,22 @@ describe("R0 release wiring", () => {
     expect(producerJob).toContain(".packages-dist-cache");
     expect(producerJob).toContain("steps.restore_dist.outputs.hit != 'true'");
     expect(producerJob).toContain("stage content-hash cache payload");
-    // Exact key only — no restore-keys on the content-hash cache step.
     const distCacheStep = producerJob.slice(
       producerJob.indexOf("restore packages-dist content-hash cache"),
       producerJob.indexOf("materialize packages/*/dist from content-hash cache"),
     );
     expect(distCacheStep).toContain("key: ${{ steps.content_hash.outputs.cache_key }}");
     expect(distCacheStep).not.toContain("restore-keys:");
+    expect(producerJob).not.toContain("ci-content-hash-restore");
 
     const unitJob = ci.slice(
       ci.indexOf("  unit:\n    name: unit"),
       ci.indexOf("  compatibility-matrix:\n    name: compatibility matrix"),
     );
-    expect(unitJob).toContain("hash-inputs --execution unit");
-    expect(unitJob).toContain("write-success-marker");
-    expect(unitJob).toContain("validate-success-marker");
-    expect(unitJob).toContain(".ci-content-hash/unit.ok");
-    expect(unitJob).toContain("steps.validate_marker.outputs.hit != 'true'");
+    expect(unitJob).toContain("uses: ./.github/actions/ci-content-hash-restore");
+    expect(unitJob).toContain("uses: ./.github/actions/ci-content-hash-write");
+    expect(unitJob).toContain("execution: unit");
+    expect(unitJob).toContain("steps.content_hash.outputs.hit != 'true'");
     expect(unitJob).toContain("bypass_content_cache");
     expect(unitJob).toContain("CI_DISABLE_CONTENT_HASH");
 
@@ -148,31 +166,55 @@ describe("R0 release wiring", () => {
       const start = ci.indexOf(`  ${job}:\n`);
       expect(start).toBeGreaterThan(-1);
       const slice = ci.slice(start, start + 4500);
-      expect(slice).toContain(`hash-inputs --execution ${execution}`);
-      expect(slice).toContain(`.ci-content-hash/${execution}.ok`);
-      expect(slice).toContain("--container-tag");
+      expect(slice).toContain("uses: ./.github/actions/ci-content-hash-restore");
+      expect(slice).toContain(`execution: ${execution}`);
+      expect(slice).toContain("container_tag:");
+      expect(slice).toContain("uses: ./.github/actions/ci-content-hash-write");
     }
 
-    // Consumer matrix dimensions are part of the cache key (Codex P1).
+    // Consumer: runtime resolution stays in the job; matrix dims pass into restore composite.
     const consumerJob = ci.slice(
       ci.indexOf("  consumer-compat:\n    name: packed consumer"),
       ci.indexOf("  component-svelte:\n    name: component-svelte"),
     );
-    expect(consumerJob).toContain("hash-inputs --execution consumer");
-    expect(consumerJob).toContain("--matrix-node");
-    expect(consumerJob).toContain("--matrix-pm");
-    expect(consumerJob).toContain("--matrix-svelte");
-    expect(consumerJob).toContain("--runtime-node-version");
-    expect(consumerJob).toContain("--runtime-pm-version");
+    expect(consumerJob).toContain("uses: ./.github/actions/ci-content-hash-restore");
+    expect(consumerJob).toContain("execution: consumer");
+    expect(consumerJob).toContain("matrix_node:");
+    expect(consumerJob).toContain("matrix_pm:");
+    expect(consumerJob).toContain("matrix_svelte:");
+    expect(consumerJob).toContain("runtime_node_version:");
+    expect(consumerJob).toContain("runtime_pm_version:");
     expect(consumerJob).toContain("node -v");
-    expect(consumerJob).toContain(".ci-content-hash/consumer.ok");
+    expect(consumerJob).toContain("uses: ./.github/actions/ci-content-hash-write");
 
-    // Router module documents invalidation + schema.
+    // Marker jobs share the composite (not only unit).
+    for (const jobMarker of [
+      "  build:\n    name: build",
+      "  actions-security:\n    name: actions-security",
+      "  bench-smoke:\n    name: bench-smoke",
+    ]) {
+      const start = ci.indexOf(jobMarker);
+      expect(start).toBeGreaterThan(-1);
+      const slice = ci.slice(start, start + 3500);
+      expect(slice).toContain("uses: ./.github/actions/ci-content-hash-restore");
+      expect(slice).toContain("uses: ./.github/actions/ci-content-hash-write");
+    }
+
+    // actions-security scans composites after extraction (zizmor path scope).
+    const actionsSecurity = ci.slice(
+      ci.indexOf("  actions-security:\n    name: actions-security"),
+      ci.indexOf("  bench-smoke:\n    name: bench-smoke"),
+    );
+    expect(actionsSecurity).toMatch(/zizmor==1\.26\.1 \.github\/workflows \.github\/actions/);
+
+    // Router module documents invalidation + schema + composite recipe inputs.
     const routing = read("scripts/ci-routing.ts");
     expect(routing).toContain("CONTENT_HASH_SCHEMA");
     expect(routing).toContain("JOB_CONTENT_INPUTS");
     expect(routing).toContain("bypass_content_cache");
     expect(routing).toContain("CI_DISABLE_CONTENT_HASH");
+    expect(routing).toContain(".github/actions/**");
+    expect(routing).toContain("ci_actions");
     expect(read("CONTRIBUTING.md")).toContain("content-hash");
   });
 


### PR DESCRIPTION
## Summary

- **Audit target:** `.github/workflows/ci.yml` (~1470 lines). Best candidate: 8× duplicated success-marker content-hash protocol (issue #245).
- **Extract** `.github/actions/ci-content-hash-restore` + `ci-content-hash-write`; rewire unit/build/actions-security/bench-smoke/component shards/consumer.
- **Keep** `packages-dist` on its specialized dist-payload path; keep three separate component jobs for ci-gate/#243.
- **Correctness (plan review C1/C2/C3):** `.github/actions/**` is a force lane + `UNIVERSAL_CONTENT_INPUTS`; zizmor scans `.github/actions`; consumer runtime resolution stays in the job.

Net: **ci.yml ~1470 → ~1200 lines**, single source of truth for marker protocol.

## Test plan

- [x] `bun test scripts/release-wiring.test.ts scripts/ci-routing.test.ts` (57 pass)
- [x] `bun run lint:actions` (clean)
- [x] `uvx zizmor==1.26.1 .github/workflows .github/actions` (no findings)
- [x] Codex code review: GATE PASS

## Side findings (not in this PR)

- `scripts/ci-routing.ts` (~1095 lines) still mixes path-routing + content-hash + CLI — good follow-up `/astral-maintain scripts/ci-routing.ts` (or split helpers).
- Optional: `download-packages-dist` composite for repeated artifact download+verify.