### PR TITLE
perf(svelte): O(R) data-identity epoch via row-ref order

### DIFF
--- a/packages/svelte/src/lib/plot-orchestrator.svelte.ts
+++ b/packages/svelte/src/lib/plot-orchestrator.svelte.ts
@@ -313,11 +313,10 @@ export function createPlotOrchestrator<
     // Ready without reading `assembled` so chrome-only respecs do not re-enter.
     const ready = spec !== undefined || layerCount > 0;
     const sourceIdentity = (value: unknown) => identityTracker.sourceIdentity(value);
+    // assemblePortableSpec: explicit `spec` wins and ignores the data prop —
+    // fingerprint the rendered source only (Codex P2).
     const contentData =
-      data ??
-      (spec !== undefined && typeof spec === "object"
-        ? (spec as { data?: unknown }).data
-        : undefined);
+      spec !== undefined && typeof spec === "object" ? (spec as { data?: unknown }).data : data;
     const contentDatasets =
       spec !== undefined && typeof spec === "object"
         ? (spec as { datasets?: unknown }).datasets

--- a/packages/svelte/src/lib/plot-orchestrator.svelte.ts
+++ b/packages/svelte/src/lib/plot-orchestrator.svelte.ts
@@ -300,17 +300,37 @@ export function createPlotOrchestrator<
     announce: announceSink,
   });
 
-  // Source identity/order epoch: stable through responsive layout and zoom
-  // respecs, different when normalized inline data or data references change.
+  // Source identity/order epoch: O(R) row-ref order over data/spec *props*
+  // (not assembled shells). Theme/labs/scales respecs do not re-walk cells;
+  // new prop references or in-place row-order changes still bump the epoch.
   // Tracker is owned for the component lifetime (never cleared).
   const identityTracker = createSourceIdentityTracker();
-  const dataIdentityEpoch = $derived(
-    dataIdentityEpochToken({
-      assembled,
-      dataToken: identityTracker.sourceIdentity(inputs.data()),
-      specToken: identityTracker.sourceIdentity(inputs.spec()),
-    }),
-  );
+  const dataIdentityEpoch = $derived.by(() => {
+    const data = inputs.data();
+    const spec = inputs.spec();
+    const layers = inputs.layers();
+    const layerCount = layers === undefined ? inputs.registry.layers.length : layers.length;
+    // Ready without reading `assembled` so chrome-only respecs do not re-enter.
+    const ready = spec !== undefined || layerCount > 0;
+    const sourceIdentity = (value: unknown) => identityTracker.sourceIdentity(value);
+    const contentData =
+      data ??
+      (spec !== undefined && typeof spec === "object"
+        ? (spec as { data?: unknown }).data
+        : undefined);
+    const contentDatasets =
+      spec !== undefined && typeof spec === "object"
+        ? (spec as { datasets?: unknown }).datasets
+        : undefined;
+    return dataIdentityEpochToken({
+      ready,
+      dataToken: sourceIdentity(data),
+      specToken: sourceIdentity(spec),
+      data: contentData ?? null,
+      datasets: contentDatasets ?? null,
+      sourceIdentity,
+    });
+  });
 
   // Live-region announcer (owned early so legend-reset effects can call it).
   const announcer = createPlotAnnouncer();

--- a/packages/svelte/src/lib/runtime/semantic-keys.svelte.ts
+++ b/packages/svelte/src/lib/runtime/semantic-keys.svelte.ts
@@ -88,19 +88,82 @@ export type ResolveSemanticKeysResult = {
 };
 
 /**
+ * O(R) order fingerprint for plot data — row *references* and length, not
+ * deep cell values. In-place reverse bumps the token; in-place cell edits on
+ * the same row objects do not (hosts should replace rows/arrays for identity).
+ *
+ * Avoids the former O(R·F) `JSON.stringify` of every cell on each epoch read.
+ */
+export function dataContentOrderToken(
+  data: unknown,
+  sourceIdentity: (value: unknown) => string,
+): string {
+  if (data === null || data === undefined) return "null";
+  if (Array.isArray(data)) {
+    let token = `v:${data.length}`;
+    for (let index = 0; index < data.length; index++) token += `:${sourceIdentity(data[index])}`;
+    return token;
+  }
+  if (typeof data === "object") {
+    const record = data as Record<string, unknown>;
+    if (Array.isArray(record.values)) {
+      const rows = record.values;
+      let token = `v:${rows.length}`;
+      for (let index = 0; index < rows.length; index++) token += `:${sourceIdentity(rows[index])}`;
+      return token;
+    }
+    if (
+      record.columns !== null &&
+      typeof record.columns === "object" &&
+      !Array.isArray(record.columns)
+    )
+      return `c:${sourceIdentity(record.columns)}`;
+    if (typeof record.name === "string") {
+      const keys = Object.keys(record);
+      if (keys.length === 1 && keys[0] === "name") return `n:${record.name}`;
+    }
+    return `o:${sourceIdentity(data)}`;
+  }
+  return `p:${String(data)}`;
+}
+
+function datasetsOrderToken(datasets: unknown, sourceIdentity: (value: unknown) => string): string {
+  if (datasets === null || datasets === undefined) return "null";
+  if (typeof datasets !== "object") return sourceIdentity(datasets);
+  const keys = Object.keys(datasets as object).toSorted();
+  let token = `d:${keys.length}`;
+  for (const key of keys) {
+    token += `|${key}=${dataContentOrderToken(
+      (datasets as Record<string, unknown>)[key],
+      sourceIdentity,
+    )}`;
+  }
+  return token;
+}
+
+/**
  * Stable data/spec identity token for inspection reconcile epochs.
- * Host supplies sourceIdentity tokens for the raw `data` / `spec` props.
+ *
+ * Host supplies:
+ * - `dataToken` / `specToken` — WeakMap identity of the raw `data` / `spec` props
+ * - `data` / `datasets` — content to order-fingerprint (prefer **prop** values,
+ *   not a freshly assembled PortableSpec shell, so theme/labs respecs do not
+ *   force a re-walk)
+ * - `sourceIdentity` — stable object ids for the O(R) order fingerprint
+ *
+ * Ready=false (no plot yet) → `"no-data"`. Complexity: O(R) over row refs,
+ * not O(R·F) deep cell serialization.
  */
 export function dataIdentityEpochToken(input: {
-  readonly assembled: { readonly data?: unknown; readonly datasets?: unknown } | null;
+  readonly ready: boolean;
   readonly dataToken: string;
   readonly specToken: string;
+  readonly data: unknown;
+  readonly datasets: unknown;
+  readonly sourceIdentity: (value: unknown) => string;
 }): string {
-  if (input.assembled === null) return "no-data";
-  return `${input.dataToken}:${input.specToken}:${JSON.stringify([
-    input.assembled.data ?? null,
-    input.assembled.datasets ?? null,
-  ])}`;
+  if (!input.ready) return "no-data";
+  return `${input.dataToken}:${input.specToken}:${dataContentOrderToken(input.data, input.sourceIdentity)}:${datasetsOrderToken(input.datasets, input.sourceIdentity)}`;
 }
 
 /** Empty semantic-key bag when there is no render model. */

--- a/packages/svelte/src/lib/runtime/semantic-keys.svelte.ts
+++ b/packages/svelte/src/lib/runtime/semantic-keys.svelte.ts
@@ -106,24 +106,29 @@ export function dataContentOrderToken(
   }
   if (typeof data === "object") {
     const record = data as Record<string, unknown>;
-    const values = record["values"];
-    if (Array.isArray(values)) {
+    const fieldKeys = Object.keys(record);
+    // DataRef shapes only when single-key (matches packages/spec isDataRef).
+    // A bare column map may own a field named `values`/`columns` alongside
+    // other arrays and must not short-circuit (Codex P2).
+    if (fieldKeys.length === 1 && fieldKeys[0] === "values" && Array.isArray(record["values"])) {
+      const values = record["values"] as unknown[];
       let token = `v:${values.length}`;
       for (let index = 0; index < values.length; index++)
         token += `:${sourceIdentity(values[index])}`;
       return token;
     }
-    const columns = record["columns"];
-    if (columns !== null && typeof columns === "object" && !Array.isArray(columns))
-      return `c:${columnMapOrderToken(columns as Record<string, unknown>, sourceIdentity)}`;
-    const name = record["name"];
-    if (typeof name === "string") {
-      const keys = Object.keys(record);
-      if (keys.length === 1 && keys[0] === "name") return `n:${name}`;
-    }
+    if (
+      fieldKeys.length === 1 &&
+      fieldKeys[0] === "columns" &&
+      record["columns"] !== null &&
+      typeof record["columns"] === "object" &&
+      !Array.isArray(record["columns"])
+    )
+      return `c:${columnMapOrderToken(record["columns"] as Record<string, unknown>, sourceIdentity)}`;
+    if (fieldKeys.length === 1 && fieldKeys[0] === "name" && typeof record["name"] === "string")
+      return `n:${record["name"]}`;
     // Bare column-oriented object (gg() wraps as { columns }) — fingerprint
     // each field's array identity so in-place column replacement bumps epoch.
-    const fieldKeys = Object.keys(record);
     if (fieldKeys.length > 0 && fieldKeys.every((key) => Array.isArray(record[key])))
       return `c:${columnMapOrderToken(record, sourceIdentity)}`;
     return `o:${sourceIdentity(data)}`;

--- a/packages/svelte/src/lib/runtime/semantic-keys.svelte.ts
+++ b/packages/svelte/src/lib/runtime/semantic-keys.svelte.ts
@@ -115,18 +115,38 @@ export function dataContentOrderToken(
     }
     const columns = record["columns"];
     if (columns !== null && typeof columns === "object" && !Array.isArray(columns))
-      return `c:${sourceIdentity(columns)}`;
+      return `c:${columnMapOrderToken(columns as Record<string, unknown>, sourceIdentity)}`;
     const name = record["name"];
     if (typeof name === "string") {
       const keys = Object.keys(record);
       if (keys.length === 1 && keys[0] === "name") return `n:${name}`;
     }
+    // Bare column-oriented object (gg() wraps as { columns }) — fingerprint
+    // each field's array identity so in-place column replacement bumps epoch.
+    const fieldKeys = Object.keys(record);
+    if (fieldKeys.length > 0 && fieldKeys.every((key) => Array.isArray(record[key])))
+      return `c:${columnMapOrderToken(record, sourceIdentity)}`;
     return `o:${sourceIdentity(data)}`;
   }
   if (typeof data === "string" || typeof data === "number" || typeof data === "boolean")
     return `p:${String(data)}`;
   if (typeof data === "bigint") return `p:${data.toString()}`;
   return `p:${sourceIdentity(data)}`;
+}
+
+/** O(fields) fingerprint: each column array's identity (+ length), not cells. */
+function columnMapOrderToken(
+  columns: Record<string, unknown>,
+  sourceIdentity: (value: unknown) => string,
+): string {
+  const keys = Object.keys(columns).toSorted();
+  let token = `${keys.length}`;
+  for (const key of keys) {
+    const column = columns[key];
+    token += `|${key}=${sourceIdentity(column)}`;
+    if (Array.isArray(column)) token += `@${column.length}`;
+  }
+  return token;
 }
 
 function datasetsOrderToken(datasets: unknown, sourceIdentity: (value: unknown) => string): string {

--- a/packages/svelte/src/lib/runtime/semantic-keys.svelte.ts
+++ b/packages/svelte/src/lib/runtime/semantic-keys.svelte.ts
@@ -106,31 +106,33 @@ export function dataContentOrderToken(
   }
   if (typeof data === "object") {
     const record = data as Record<string, unknown>;
-    if (Array.isArray(record.values)) {
-      const rows = record.values;
-      let token = `v:${rows.length}`;
-      for (let index = 0; index < rows.length; index++) token += `:${sourceIdentity(rows[index])}`;
+    const values = record["values"];
+    if (Array.isArray(values)) {
+      let token = `v:${values.length}`;
+      for (let index = 0; index < values.length; index++)
+        token += `:${sourceIdentity(values[index])}`;
       return token;
     }
-    if (
-      record.columns !== null &&
-      typeof record.columns === "object" &&
-      !Array.isArray(record.columns)
-    )
-      return `c:${sourceIdentity(record.columns)}`;
-    if (typeof record.name === "string") {
+    const columns = record["columns"];
+    if (columns !== null && typeof columns === "object" && !Array.isArray(columns))
+      return `c:${sourceIdentity(columns)}`;
+    const name = record["name"];
+    if (typeof name === "string") {
       const keys = Object.keys(record);
-      if (keys.length === 1 && keys[0] === "name") return `n:${record.name}`;
+      if (keys.length === 1 && keys[0] === "name") return `n:${name}`;
     }
     return `o:${sourceIdentity(data)}`;
   }
-  return `p:${String(data)}`;
+  if (typeof data === "string" || typeof data === "number" || typeof data === "boolean")
+    return `p:${String(data)}`;
+  if (typeof data === "bigint") return `p:${data.toString()}`;
+  return `p:${sourceIdentity(data)}`;
 }
 
 function datasetsOrderToken(datasets: unknown, sourceIdentity: (value: unknown) => string): string {
   if (datasets === null || datasets === undefined) return "null";
   if (typeof datasets !== "object") return sourceIdentity(datasets);
-  const keys = Object.keys(datasets as object).toSorted();
+  const keys = Object.keys(datasets).toSorted();
   let token = `d:${keys.length}`;
   for (const key of keys) {
     token += `|${key}=${dataContentOrderToken(

--- a/packages/svelte/tests/runtime/semantic-keys.test.ts
+++ b/packages/svelte/tests/runtime/semantic-keys.test.ts
@@ -143,6 +143,24 @@ describe("dataIdentityEpochToken", () => {
     );
   });
 
+  it("fingerprints column-array identities (not only the columns wrapper)", () => {
+    const tracker = createSourceIdentityTracker();
+    const id = (value: unknown) => tracker.sourceIdentity(value);
+    const x = [1, 2];
+    const y = [3, 4];
+    const columns = { x, y };
+    const bare = dataContentOrderToken(columns, id);
+    const wrapped = dataContentOrderToken({ columns }, id);
+    // Both forms include each column array's identity (Codex P2).
+    expect(bare).toContain(id(x));
+    expect(bare).toContain(id(y));
+    expect(wrapped).toContain(id(x));
+    expect(wrapped).toContain(id(y));
+    // Replace one column array on the map → content token changes.
+    columns.y = [5, 6];
+    expect(dataContentOrderToken(columns, id)).not.toBe(bare);
+  });
+
   it("does not deep-serialize large row payloads (no JSON.stringify of cells)", () => {
     const tracker = createSourceIdentityTracker();
     const id = (value: unknown) => tracker.sourceIdentity(value);

--- a/packages/svelte/tests/runtime/semantic-keys.test.ts
+++ b/packages/svelte/tests/runtime/semantic-keys.test.ts
@@ -11,6 +11,7 @@ import { INTERACTION_DIAGNOSTIC_CATALOG } from "../../src/lib/interaction/intera
 import {
   createSourceIdentityTracker,
   createSemanticKeyService,
+  dataContentOrderToken,
   dataIdentityEpochToken,
   resolveSemanticKeys,
   resolveSemanticKeysForPlot,
@@ -156,6 +157,8 @@ describe("dataIdentityEpochToken", () => {
       sourceIdentity: id,
     });
     expect(token.startsWith("d:s:")).toBe(true);
+    // Content order is O(R) row refs — same helper used standalone.
+    expect(dataContentOrderToken(largeRows, id).startsWith("v:2000:")).toBe(true);
     // May stringify nothing, or only incidental non-data uses — never the full row array.
     for (const call of spy.mock.calls) {
       expect(call[0]).not.toBe(largeRows);

--- a/packages/svelte/tests/runtime/semantic-keys.test.ts
+++ b/packages/svelte/tests/runtime/semantic-keys.test.ts
@@ -58,31 +58,112 @@ function modelView(options: {
 // ---------------------------------------------------------------------------
 
 describe("dataIdentityEpochToken", () => {
-  it("returns no-data when assembled is null", () => {
+  it("returns no-data when not ready", () => {
+    const tracker = createSourceIdentityTracker();
     expect(
       dataIdentityEpochToken({
-        assembled: null,
+        ready: false,
         dataToken: "1",
         specToken: "2",
+        data: null,
+        datasets: null,
+        sourceIdentity: (value) => tracker.sourceIdentity(value),
       }),
     ).toBe("no-data");
   });
 
-  it("joins source tokens with JSON of data and datasets (nullish → null)", () => {
+  it("joins prop tokens with O(R) row-reference order, not deep JSON of cells", () => {
+    const tracker = createSourceIdentityTracker();
+    const id = (value: unknown) => tracker.sourceIdentity(value);
+    const rowA = { a: 1 };
+    const rowB = { a: 2 };
+    const data = [rowA, rowB];
+    const first = dataIdentityEpochToken({
+      ready: true,
+      dataToken: "d",
+      specToken: "s",
+      data,
+      datasets: null,
+      sourceIdentity: id,
+    });
+    // Same row references / order → same epoch (theme-style respecs keep prop identity).
     expect(
       dataIdentityEpochToken({
-        assembled: { data: [{ a: 1 }], datasets: undefined },
+        ready: true,
         dataToken: "d",
         specToken: "s",
+        data,
+        datasets: null,
+        sourceIdentity: id,
       }),
-    ).toBe(`d:s:${JSON.stringify([[{ a: 1 }], null])}`);
+    ).toBe(first);
+    // In-place reverse of the same row objects bumps the order fingerprint.
+    data.reverse();
+    const reversed = dataIdentityEpochToken({
+      ready: true,
+      dataToken: "d",
+      specToken: "s",
+      data,
+      datasets: null,
+      sourceIdentity: id,
+    });
+    expect(reversed).not.toBe(first);
+    // Deep cell edits on the same row objects do not walk cells — token stays put.
+    rowA.a = 99;
     expect(
       dataIdentityEpochToken({
-        assembled: {},
+        ready: true,
         dataToken: "d",
         specToken: "s",
+        data,
+        datasets: null,
+        sourceIdentity: id,
       }),
-    ).toBe(`d:s:${JSON.stringify([null, null])}`);
+    ).toBe(reversed);
+    // New dataToken (new prop reference) changes the epoch even with empty content.
+    expect(
+      dataIdentityEpochToken({
+        ready: true,
+        dataToken: "d2",
+        specToken: "s",
+        data: null,
+        datasets: null,
+        sourceIdentity: id,
+      }),
+    ).not.toBe(
+      dataIdentityEpochToken({
+        ready: true,
+        dataToken: "d",
+        specToken: "s",
+        data: null,
+        datasets: null,
+        sourceIdentity: id,
+      }),
+    );
+  });
+
+  it("does not deep-serialize large row payloads (no JSON.stringify of cells)", () => {
+    const tracker = createSourceIdentityTracker();
+    const id = (value: unknown) => tracker.sourceIdentity(value);
+    const largeRows = Array.from({ length: 2000 }, (_, i) => ({ i, pad: "x".repeat(64) }));
+    const spy = vi.spyOn(JSON, "stringify");
+    const token = dataIdentityEpochToken({
+      ready: true,
+      dataToken: "d",
+      specToken: "s",
+      data: largeRows,
+      datasets: null,
+      sourceIdentity: id,
+    });
+    expect(token.startsWith("d:s:")).toBe(true);
+    // May stringify nothing, or only incidental non-data uses — never the full row array.
+    for (const call of spy.mock.calls) {
+      expect(call[0]).not.toBe(largeRows);
+      if (Array.isArray(call[0])) {
+        expect(call[0]).not.toContain(largeRows[0]);
+      }
+    }
+    spy.mockRestore();
   });
 });
 

--- a/packages/svelte/tests/runtime/semantic-keys.test.ts
+++ b/packages/svelte/tests/runtime/semantic-keys.test.ts
@@ -161,6 +161,20 @@ describe("dataIdentityEpochToken", () => {
     expect(dataContentOrderToken(columns, id)).not.toBe(bare);
   });
 
+  it("does not treat a multi-field map with a values column as a DataRef", () => {
+    const tracker = createSourceIdentityTracker();
+    const id = (value: unknown) => tracker.sourceIdentity(value);
+    const values = [1, 2];
+    const y = [3, 4];
+    const bare = { values, y };
+    const first = dataContentOrderToken(bare, id);
+    expect(first.startsWith("c:")).toBe(true);
+    expect(first).toContain(id(values));
+    expect(first).toContain(id(y));
+    bare.y = [9, 9];
+    expect(dataContentOrderToken(bare, id)).not.toBe(first);
+  });
+
   it("does not deep-serialize large row payloads (no JSON.stringify of cells)", () => {
     const tracker = createSourceIdentityTracker();
     const id = (value: unknown) => tracker.sourceIdentity(value);


### PR DESCRIPTION
## Summary
Big-O maintain (rotation: packages/svelte/src after core #259).

**Finding:** `dataIdentityEpochToken` deep-`JSON.stringify`ed `assembled.data` / `datasets` on every PortableSpec recompute (theme, labs, scales, …), costing **O(R·F)** cells even when data/spec prop identity was unchanged.

**Fix:** Epoch is now `dataToken:specToken` (WeakMap prop identity) plus an **O(R)** row-reference order fingerprint (`dataContentOrderToken`). Host derives content from **props**, not assembled shells, so chrome-only respecs do not re-enter the walk.

## Complexity
| Before | After |
|--------|-------|
| O(R·F) stringify per assembled recompute | O(R) row-ref walk only when data/spec props invalidate; O(1) skip when derived deps unchanged |

## Behavior notes (codex plan review)
- In-place **row reorder** still bumps epoch (order of row object ids).
- In-place **cell mutation** on the same row objects does not (replace rows/arrays for identity changes).
- Keyless pin invalidation for axis-differing reorders still works via `reconcilePinned` logical identity.

## Test plan
- [x] packages/svelte browser vitest (semantic-keys + full suite green locally)
- [ ] CI unit/component/ci-gate

## Audit
- Target: packages/svelte/src
- Chosen: #5 repeated expensive computation (data identity epoch)
- Other: inspection member full-row fingerprint (follow-up); selection multi-walk (follow-up)
