### PR TITLE
refactor(svelte): extract interaction diagnostic catalog module

### DIFF
--- a/packages/svelte/src/lib/interaction/interaction-diagnostics.ts
+++ b/packages/svelte/src/lib/interaction/interaction-diagnostics.ts
@@ -1,0 +1,151 @@
+/**
+ * Agent-facing interaction diagnostic catalog — frozen codes, messages, and
+ * doc URLs for capability normalization and runtime key/lineage checks.
+ *
+ * Extracted from interaction.ts so pure catalog data is not mixed with event
+ * types and normalizeInteractionConfig.
+ */
+
+export type InteractionDiagnosticCode =
+  | "INTERACTION_INTERVAL_FACET_UNSUPPORTED"
+  | "INTERACTION_INVALID_MAX_DISTANCE"
+  | "INTERACTION_POINT_REQUIRES_KEY"
+  | "INTERACTION_INTERVAL_PRESET_REQUIRES_KEY"
+  | "INTERACTION_INVALID_KEY"
+  | "INTERACTION_DUPLICATE_KEY"
+  | "INTERACTION_UNSTABLE_KEY"
+  | "INTERACTION_MISSING_LINEAGE"
+  | "INTERACTION_LEGEND_REQUIRES_KEY"
+  | "INTERACTION_LEGEND_DISCRETE_ONLY"
+  | "INTERACTION_INTERVAL_SCALE_UNSUPPORTED"
+  | "INTERACTION_TOOL_UNAVAILABLE";
+
+export interface InteractionDiagnostic {
+  readonly severity: "error" | "warning" | "advisory";
+  readonly code: InteractionDiagnosticCode;
+  readonly message: string;
+  readonly prop: string;
+  readonly actual?: unknown;
+  readonly suggestions: ReadonlyArray<string>;
+  readonly docUrl: string;
+}
+
+export const INTERACTION_DIAGNOSTIC_CATALOG: Readonly<
+  Record<InteractionDiagnosticCode, Omit<InteractionDiagnostic, "actual">>
+> = Object.freeze({
+  INTERACTION_INTERVAL_FACET_UNSUPPORTED: {
+    severity: "warning",
+    code: "INTERACTION_INTERVAL_FACET_UNSUPPORTED",
+    message: "Brush zoom currently requires one unfaceted panel.",
+    prop: "zoom",
+    suggestions: [
+      "Remove the facet",
+      "Use faceted interval selection",
+      "Zoom a linked detail view",
+    ],
+    docUrl:
+      "https://ljodea.github.io/ggsvelte/guide/interaction-reference#interaction-interval-facet-unsupported",
+  },
+  INTERACTION_INVALID_MAX_DISTANCE: {
+    severity: "error",
+    code: "INTERACTION_INVALID_MAX_DISTANCE",
+    message: "inspect.maxDistance must be a finite non-negative CSS-pixel distance.",
+    prop: "inspect.maxDistance",
+    suggestions: ["Use a finite number greater than or equal to zero"],
+    docUrl:
+      "https://ljodea.github.io/ggsvelte/guide/interaction-reference#interaction-invalid-max-distance",
+  },
+  INTERACTION_POINT_REQUIRES_KEY: {
+    severity: "warning",
+    code: "INTERACTION_POINT_REQUIRES_KEY",
+    message: "Durable point selection requires a stable key field or accessor.",
+    prop: "key",
+    suggestions: ['Pass key="id"', "Pass a stable key accessor"],
+    docUrl:
+      "https://ljodea.github.io/ggsvelte/guide/interaction-reference#interaction-point-requires-key",
+  },
+  INTERACTION_INTERVAL_PRESET_REQUIRES_KEY: {
+    severity: "warning",
+    code: "INTERACTION_INTERVAL_PRESET_REQUIRES_KEY",
+    message:
+      "Coordinated interval presets (union, cross-panel) require a stable key field or accessor; without one they combine no rows.",
+    prop: "key",
+    suggestions: ['Pass key="id"', "Pass a stable key accessor"],
+    docUrl:
+      "https://ljodea.github.io/ggsvelte/guide/interaction-reference#interaction-interval-preset-requires-key",
+  },
+  INTERACTION_INVALID_KEY: {
+    severity: "error",
+    code: "INTERACTION_INVALID_KEY",
+    message: "A key accessor returned null, undefined, or a non-PropertyKey value.",
+    prop: "key",
+    suggestions: ["Return a stable string, number, or symbol for every row"],
+    docUrl: "https://ljodea.github.io/ggsvelte/guide/interaction-reference#interaction-invalid-key",
+  },
+  INTERACTION_DUPLICATE_KEY: {
+    severity: "error",
+    code: "INTERACTION_DUPLICATE_KEY",
+    message:
+      "The key accessor returned a duplicate value; durable interaction is disabled for that value.",
+    prop: "key",
+    suggestions: ["Use a field that uniquely identifies each source row"],
+    docUrl:
+      "https://ljodea.github.io/ggsvelte/guide/interaction-reference#interaction-duplicate-key",
+  },
+  INTERACTION_UNSTABLE_KEY: {
+    severity: "error",
+    code: "INTERACTION_UNSTABLE_KEY",
+    message: "The key accessor returned a different value for the same source row.",
+    prop: "key",
+    suggestions: ["Return an immutable field that uniquely identifies each row"],
+    docUrl:
+      "https://ljodea.github.io/ggsvelte/guide/interaction-reference#interaction-unstable-key",
+  },
+  INTERACTION_MISSING_LINEAGE: {
+    severity: "warning",
+    code: "INTERACTION_MISSING_LINEAGE",
+    message: "A synthetic or aggregate mark did not expose source-row lineage.",
+    prop: "layers",
+    suggestions: ["Use a stat that preserves source-row lineage"],
+    docUrl:
+      "https://ljodea.github.io/ggsvelte/guide/interaction-reference#interaction-missing-lineage",
+  },
+  INTERACTION_LEGEND_REQUIRES_KEY: {
+    severity: "warning",
+    code: "INTERACTION_LEGEND_REQUIRES_KEY",
+    message:
+      "Legend focus requires stable row keys so encoded legend values never become identities.",
+    prop: "key",
+    suggestions: ['Pass key="id"', "Pass a stable key accessor"],
+    docUrl:
+      "https://ljodea.github.io/ggsvelte/guide/interaction-reference#interaction-legend-requires-key",
+  },
+  INTERACTION_LEGEND_DISCRETE_ONLY: {
+    severity: "advisory",
+    code: "INTERACTION_LEGEND_DISCRETE_ONLY",
+    message:
+      "Legend focus currently applies to discrete color and fill legends; continuous ramps remain static.",
+    prop: "legendFocus",
+    suggestions: ["Use a discrete color or fill mapping", "Keep the continuous ramp static"],
+    docUrl:
+      "https://ljodea.github.io/ggsvelte/guide/interaction-reference#interaction-legend-discrete-only",
+  },
+  INTERACTION_INTERVAL_SCALE_UNSUPPORTED: {
+    severity: "warning",
+    code: "INTERACTION_INTERVAL_SCALE_UNSUPPORTED",
+    message: "Interval domains and brush zoom require continuous linear, log, or time scales.",
+    prop: "scales",
+    suggestions: ["Use a continuous positional scale", "Use point inspection for band data"],
+    docUrl:
+      "https://ljodea.github.io/ggsvelte/guide/interaction-reference#interaction-interval-scale-unsupported",
+  },
+  INTERACTION_TOOL_UNAVAILABLE: {
+    severity: "warning",
+    code: "INTERACTION_TOOL_UNAVAILABLE",
+    message: "The requested interaction tool is unavailable for the enabled capabilities.",
+    prop: "tool",
+    suggestions: ["Enable the matching capability", "Choose an available interaction tool"],
+    docUrl:
+      "https://ljodea.github.io/ggsvelte/guide/interaction-reference#interaction-tool-unavailable",
+  },
+});

--- a/packages/svelte/src/lib/interaction/interaction.ts
+++ b/packages/svelte/src/lib/interaction/interaction.ts
@@ -2,6 +2,15 @@ import type { CellValue } from "@ggsvelte/core";
 import type { Snippet } from "svelte";
 
 import type { LegendFilterEvent } from "../legend/filter.js";
+import type { InteractionDiagnostic } from "./interaction-diagnostics.js";
+import { INTERACTION_DIAGNOSTIC_CATALOG } from "./interaction-diagnostics.js";
+
+// Diagnostic catalog (codes + frozen messages) lives in interaction-diagnostics.ts.
+export { INTERACTION_DIAGNOSTIC_CATALOG } from "./interaction-diagnostics.js";
+export type {
+  InteractionDiagnostic,
+  InteractionDiagnosticCode,
+} from "./interaction-diagnostics.js";
 
 export type InteractionSource = "pointer" | "keyboard" | "touch" | "programmatic";
 export type InspectMode = "auto" | "exact" | "x" | "y" | "xy";
@@ -154,150 +163,6 @@ export interface LegendFocusOptions {
   readonly preview?: boolean;
 }
 export type LegendFocusInput = boolean | LegendFocusOptions;
-
-export type InteractionDiagnosticCode =
-  | "INTERACTION_INTERVAL_FACET_UNSUPPORTED"
-  | "INTERACTION_INVALID_MAX_DISTANCE"
-  | "INTERACTION_POINT_REQUIRES_KEY"
-  | "INTERACTION_INTERVAL_PRESET_REQUIRES_KEY"
-  | "INTERACTION_INVALID_KEY"
-  | "INTERACTION_DUPLICATE_KEY"
-  | "INTERACTION_UNSTABLE_KEY"
-  | "INTERACTION_MISSING_LINEAGE"
-  | "INTERACTION_LEGEND_REQUIRES_KEY"
-  | "INTERACTION_LEGEND_DISCRETE_ONLY"
-  | "INTERACTION_INTERVAL_SCALE_UNSUPPORTED"
-  | "INTERACTION_TOOL_UNAVAILABLE";
-
-export interface InteractionDiagnostic {
-  readonly severity: "error" | "warning" | "advisory";
-  readonly code: InteractionDiagnosticCode;
-  readonly message: string;
-  readonly prop: string;
-  readonly actual?: unknown;
-  readonly suggestions: ReadonlyArray<string>;
-  readonly docUrl: string;
-}
-
-export const INTERACTION_DIAGNOSTIC_CATALOG: Readonly<
-  Record<InteractionDiagnosticCode, Omit<InteractionDiagnostic, "actual">>
-> = Object.freeze({
-  INTERACTION_INTERVAL_FACET_UNSUPPORTED: {
-    severity: "warning",
-    code: "INTERACTION_INTERVAL_FACET_UNSUPPORTED",
-    message: "Brush zoom currently requires one unfaceted panel.",
-    prop: "zoom",
-    suggestions: [
-      "Remove the facet",
-      "Use faceted interval selection",
-      "Zoom a linked detail view",
-    ],
-    docUrl:
-      "https://ljodea.github.io/ggsvelte/guide/interaction-reference#interaction-interval-facet-unsupported",
-  },
-  INTERACTION_INVALID_MAX_DISTANCE: {
-    severity: "error",
-    code: "INTERACTION_INVALID_MAX_DISTANCE",
-    message: "inspect.maxDistance must be a finite non-negative CSS-pixel distance.",
-    prop: "inspect.maxDistance",
-    suggestions: ["Use a finite number greater than or equal to zero"],
-    docUrl:
-      "https://ljodea.github.io/ggsvelte/guide/interaction-reference#interaction-invalid-max-distance",
-  },
-  INTERACTION_POINT_REQUIRES_KEY: {
-    severity: "warning",
-    code: "INTERACTION_POINT_REQUIRES_KEY",
-    message: "Durable point selection requires a stable key field or accessor.",
-    prop: "key",
-    suggestions: ['Pass key="id"', "Pass a stable key accessor"],
-    docUrl:
-      "https://ljodea.github.io/ggsvelte/guide/interaction-reference#interaction-point-requires-key",
-  },
-  INTERACTION_INTERVAL_PRESET_REQUIRES_KEY: {
-    severity: "warning",
-    code: "INTERACTION_INTERVAL_PRESET_REQUIRES_KEY",
-    message:
-      "Coordinated interval presets (union, cross-panel) require a stable key field or accessor; without one they combine no rows.",
-    prop: "key",
-    suggestions: ['Pass key="id"', "Pass a stable key accessor"],
-    docUrl:
-      "https://ljodea.github.io/ggsvelte/guide/interaction-reference#interaction-interval-preset-requires-key",
-  },
-  INTERACTION_INVALID_KEY: {
-    severity: "error",
-    code: "INTERACTION_INVALID_KEY",
-    message: "A key accessor returned null, undefined, or a non-PropertyKey value.",
-    prop: "key",
-    suggestions: ["Return a stable string, number, or symbol for every row"],
-    docUrl: "https://ljodea.github.io/ggsvelte/guide/interaction-reference#interaction-invalid-key",
-  },
-  INTERACTION_DUPLICATE_KEY: {
-    severity: "error",
-    code: "INTERACTION_DUPLICATE_KEY",
-    message:
-      "The key accessor returned a duplicate value; durable interaction is disabled for that value.",
-    prop: "key",
-    suggestions: ["Use a field that uniquely identifies each source row"],
-    docUrl:
-      "https://ljodea.github.io/ggsvelte/guide/interaction-reference#interaction-duplicate-key",
-  },
-  INTERACTION_UNSTABLE_KEY: {
-    severity: "error",
-    code: "INTERACTION_UNSTABLE_KEY",
-    message: "The key accessor returned a different value for the same source row.",
-    prop: "key",
-    suggestions: ["Return an immutable field that uniquely identifies each row"],
-    docUrl:
-      "https://ljodea.github.io/ggsvelte/guide/interaction-reference#interaction-unstable-key",
-  },
-  INTERACTION_MISSING_LINEAGE: {
-    severity: "warning",
-    code: "INTERACTION_MISSING_LINEAGE",
-    message: "A synthetic or aggregate mark did not expose source-row lineage.",
-    prop: "layers",
-    suggestions: ["Use a stat that preserves source-row lineage"],
-    docUrl:
-      "https://ljodea.github.io/ggsvelte/guide/interaction-reference#interaction-missing-lineage",
-  },
-  INTERACTION_LEGEND_REQUIRES_KEY: {
-    severity: "warning",
-    code: "INTERACTION_LEGEND_REQUIRES_KEY",
-    message:
-      "Legend focus requires stable row keys so encoded legend values never become identities.",
-    prop: "key",
-    suggestions: ['Pass key="id"', "Pass a stable key accessor"],
-    docUrl:
-      "https://ljodea.github.io/ggsvelte/guide/interaction-reference#interaction-legend-requires-key",
-  },
-  INTERACTION_LEGEND_DISCRETE_ONLY: {
-    severity: "advisory",
-    code: "INTERACTION_LEGEND_DISCRETE_ONLY",
-    message:
-      "Legend focus currently applies to discrete color and fill legends; continuous ramps remain static.",
-    prop: "legendFocus",
-    suggestions: ["Use a discrete color or fill mapping", "Keep the continuous ramp static"],
-    docUrl:
-      "https://ljodea.github.io/ggsvelte/guide/interaction-reference#interaction-legend-discrete-only",
-  },
-  INTERACTION_INTERVAL_SCALE_UNSUPPORTED: {
-    severity: "warning",
-    code: "INTERACTION_INTERVAL_SCALE_UNSUPPORTED",
-    message: "Interval domains and brush zoom require continuous linear, log, or time scales.",
-    prop: "scales",
-    suggestions: ["Use a continuous positional scale", "Use point inspection for band data"],
-    docUrl:
-      "https://ljodea.github.io/ggsvelte/guide/interaction-reference#interaction-interval-scale-unsupported",
-  },
-  INTERACTION_TOOL_UNAVAILABLE: {
-    severity: "warning",
-    code: "INTERACTION_TOOL_UNAVAILABLE",
-    message: "The requested interaction tool is unavailable for the enabled capabilities.",
-    prop: "tool",
-    suggestions: ["Enable the matching capability", "Choose an available interaction tool"],
-    docUrl:
-      "https://ljodea.github.io/ggsvelte/guide/interaction-reference#interaction-tool-unavailable",
-  },
-});
 
 export interface ResolvedInteractionConfig<Row = Record<string, CellValue>, Key = PropertyKey> {
   readonly interactive: boolean;

--- a/packages/svelte/tests/interaction/unit.test.ts
+++ b/packages/svelte/tests/interaction/unit.test.ts
@@ -161,6 +161,14 @@ describe("interaction capability normalization", () => {
       expect(INTERACTION_DIAGNOSTIC_CATALOG[diagnostic.code]).toBeDefined();
     }
   });
+
+  it("keeps each catalog entry's code equal to its key (characterization)", () => {
+    // Locks the catalog object shape so extract refactors cannot drift entry.code
+    // away from the Record key (agents and docs look up by both).
+    for (const [key, entry] of Object.entries(INTERACTION_DIAGNOSTIC_CATALOG)) {
+      expect(entry.code).toBe(key);
+    }
+  });
 });
 
 describe("chart-local interaction reducer", () => {


### PR DESCRIPTION
## Summary

Astral maintain rotate target: **`packages/svelte/src`** (after core #240, spec #262).

**Best candidate:** `interaction/interaction.ts` (527 lines) mixed event/API types, the frozen agent diagnostic catalog, and `normalizeInteractionConfig`.

### Split (plan-review revised: diagnostics only)
| Module | Role |
|---|---|
| `interaction-diagnostics.ts` | `InteractionDiagnosticCode`, `InteractionDiagnostic`, `INTERACTION_DIAGNOSTIC_CATALOG` |
| `interaction.ts` | Event/API types, tools, normalize, re-exports diagnostics |

Full 3-file (config extract) was rejected in plan review as a type-only cycle with soft boundaries; catalog isolation is the high-value, acyclic win.

Public package exports and deep imports via `interaction/interaction.js` unchanged.

### Characterization
- Catalog entry `.code ===` Record key for every entry

### Deferred
- `surface-state` / `inspection-state` / `interval-state` rune factories (lifecycle risk)
- `controller.svelte.ts` pure equality helpers (opportunistic)

## Test plan
- [x] `bunx vitest run tests/interaction/unit.test.ts` (27 tests × 3 browsers)
- [x] knip / pre-push green
- [x] Codex review: no P1/P2