### PR TITLE
perf(core): O(log E+k) extended-geometry shortlist via AABB index

### DIFF
--- a/packages/core/src/candidate-store-eager.ts
+++ b/packages/core/src/candidate-store-eager.ts
@@ -334,16 +334,15 @@ export function buildCandidateStoreEager(
   tokenIndex.clear();
 
   // Spatial index over plot-px anchors (reuse StaticQuadtree). Point-like
-  // candidates shortlist via the tree; rects/segments/paths use a second
-  // index over AABB *centers* expanded by max half-extents so hit regions
-  // far from anchors (tall bars, long segments, filled paths) still shortlist
-  // in O(log E + k) instead of force-adding every extended id.
+  // candidates shortlist via the tree; rects/segments/paths/glyphs use
+  // size-classed AABB-center trees so hit regions far from anchors still
+  // shortlist without force-adding every extended id. Classes bucket by
+  // log2(max half-extent) so one giant AABB cannot expand every query to O(E).
   const spatialXs = Float64Array.from(xs);
   const spatialYs = Float64Array.from(ys);
   const spatial = n > 0 ? new StaticQuadtree(spatialXs, spatialYs) : null;
   const isPoint = new Uint8Array(n);
   const extendedIds: number[] = [];
-  // Per-extended-id plot-space AABB (filled after the classify pass).
   const extMinXBuild: number[] = [];
   const extMinYBuild: number[] = [];
   const extMaxXBuild: number[] = [];
@@ -384,8 +383,8 @@ export function buildCandidateStoreEager(
       minY = Math.min(y1, y2) - pad;
       maxX = Math.max(x1, x2) + pad;
       maxY = Math.max(y1, y2) + pad;
-    } else {
-      // paths: subpath AABB (fill + stroke can sit far from one vertex anchor).
+    } else if (batch.kind === "paths") {
+      // Subpath AABB (fill + stroke can sit far from one vertex anchor).
       const range = pathRange(batch, i);
       if (range === null) {
         minX = xs[id]!;
@@ -428,6 +427,14 @@ export function buildCandidateStoreEager(
         maxX = box[2];
         maxY = box[3];
       }
+    } else {
+      // glyphs: text is not a hit target (hit-index), but still needs a finite
+      // AABB so store init never pathRange()'s a non-path batch (Codex P1).
+      const pad = batch.size + 3;
+      minX = xs[id]! - pad;
+      minY = ys[id]! - pad;
+      maxX = xs[id]! + pad;
+      maxY = ys[id]! + pad;
     }
     extMinXBuild.push(minX);
     extMinYBuild.push(minY);
@@ -441,23 +448,51 @@ export function buildCandidateStoreEager(
   const extMinY = Float64Array.from(extMinYBuild);
   const extMaxX = Float64Array.from(extMaxXBuild);
   const extMaxY = Float64Array.from(extMaxYBuild);
-  const extCx = new Float64Array(extN);
-  const extCy = new Float64Array(extN);
-  let maxHalfW = 0;
-  let maxHalfH = 0;
-  for (let ei = 0; ei < extN; ei++) {
-    const halfW = (extMaxX[ei]! - extMinX[ei]!) / 2;
-    const halfH = (extMaxY[ei]! - extMinY[ei]!) / 2;
-    extCx[ei] = (extMinX[ei]! + extMaxX[ei]!) / 2;
-    extCy[ei] = (extMinY[ei]! + extMaxY[ei]!) / 2;
-    if (halfW > maxHalfW) maxHalfW = halfW;
-    if (halfH > maxHalfH) maxHalfH = halfH;
-  }
-  const extendedSpatial = extN > 0 ? new StaticQuadtree(extCx, extCy) : null;
   extMinXBuild.length = 0;
   extMinYBuild.length = 0;
   extMaxXBuild.length = 0;
   extMaxYBuild.length = 0;
+
+  // Size-class trees: class key = ceil(log2(max half-extent)).
+  type ExtendedClass = {
+    readonly eis: readonly number[];
+    readonly maxHalfW: number;
+    readonly maxHalfH: number;
+    readonly spatial: StaticQuadtree;
+  };
+  const classBuckets = new Map<number, number[]>();
+  for (let ei = 0; ei < extN; ei++) {
+    const halfW = (extMaxX[ei]! - extMinX[ei]!) / 2;
+    const halfH = (extMaxY[ei]! - extMinY[ei]!) / 2;
+    const m = Math.max(halfW, halfH, 1e-9);
+    const key = Math.min(31, Math.ceil(Math.log2(m)));
+    const bucket = classBuckets.get(key);
+    if (bucket === undefined) classBuckets.set(key, [ei]);
+    else bucket.push(ei);
+  }
+  const extendedClasses: ExtendedClass[] = [];
+  for (const eis of classBuckets.values()) {
+    const cxs = new Float64Array(eis.length);
+    const cys = new Float64Array(eis.length);
+    let maxHalfW = 0;
+    let maxHalfH = 0;
+    for (let j = 0; j < eis.length; j++) {
+      const ei = eis[j]!;
+      const halfW = (extMaxX[ei]! - extMinX[ei]!) / 2;
+      const halfH = (extMaxY[ei]! - extMinY[ei]!) / 2;
+      cxs[j] = (extMinX[ei]! + extMaxX[ei]!) / 2;
+      cys[j] = (extMinY[ei]! + extMaxY[ei]!) / 2;
+      if (halfW > maxHalfW) maxHalfW = halfW;
+      if (halfH > maxHalfH) maxHalfH = halfH;
+    }
+    extendedClasses.push({
+      eis,
+      maxHalfW,
+      maxHalfH,
+      spatial: new StaticQuadtree(cxs, cys),
+    });
+  }
+  classBuckets.clear();
 
   /** Add extended ids whose AABB intersects the axis-aligned query box. */
   const addExtendedIntersecting = (
@@ -467,19 +502,22 @@ export function buildCandidateStoreEager(
     hiY: number,
     into: Set<number> | number[],
   ): void => {
-    if (extendedSpatial === null) return;
-    // Any AABB that intersects [lo,hi] has its center within the query expanded
-    // by that AABB's half-extents; expand by the global max for one tree query.
-    const qx0 = loX - maxHalfW;
-    const qy0 = loY - maxHalfH;
-    const qx1 = hiX + maxHalfW;
-    const qy1 = hiY + maxHalfH;
-    for (const ei of extendedSpatial.queryRect(qx0, qy0, qx1, qy1)) {
-      if (extMaxX[ei]! < loX || extMinX[ei]! > hiX || extMaxY[ei]! < loY || extMinY[ei]! > hiY)
-        continue;
-      const id = extendedIds[ei]!;
-      if (Array.isArray(into)) into.push(id);
-      else into.add(id);
+    for (const cls of extendedClasses) {
+      // Intersecting AABBs have centers inside query expanded by *this class's*
+      // half-extents — not the global max (avoids one giant bar scanning all E).
+      for (const j of cls.spatial.queryRect(
+        loX - cls.maxHalfW,
+        loY - cls.maxHalfH,
+        hiX + cls.maxHalfW,
+        hiY + cls.maxHalfH,
+      )) {
+        const ei = cls.eis[j]!;
+        if (extMaxX[ei]! < loX || extMinX[ei]! > hiX || extMaxY[ei]! < loY || extMinY[ei]! > hiY)
+          continue;
+        const id = extendedIds[ei]!;
+        if (Array.isArray(into)) into.push(id);
+        else into.add(id);
+      }
     }
   };
 

--- a/packages/core/src/candidate-store-eager.ts
+++ b/packages/core/src/candidate-store-eager.ts
@@ -21,7 +21,7 @@ import type {
   CandidateStoreOptions,
   ResolvedCandidateInspectMode,
 } from "./candidate-store-types.js";
-import type { Scene } from "./scene.js";
+import type { GeometryBatch, Scene } from "./scene.js";
 import type { CellValue } from "./table.js";
 
 const NO_ROW = 0xffffffff;
@@ -37,6 +37,33 @@ const AUTO_MODES = [
   "y",
   "xy",
 ] as const satisfies readonly ResolvedCandidateInspectMode[];
+
+/** Plot-space AABB for a path subpath range, padded by stroke half-width + hit tol. */
+function pathSubpathAabb(
+  batch: Extract<GeometryBatch, { kind: "paths" }>,
+  panelX: number,
+  panelY: number,
+  start: number,
+  end: number,
+  fallbackX: number,
+  fallbackY: number,
+): readonly [number, number, number, number] {
+  const pad = batch.linewidth / 2 + 3;
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  for (let v = start; v < end; v++) {
+    const px = panelX + batch.positions[v * 2]!;
+    const py = panelY + batch.positions[v * 2 + 1]!;
+    if (px < minX) minX = px;
+    if (py < minY) minY = py;
+    if (px > maxX) maxX = px;
+    if (py > maxY) maxY = py;
+  }
+  if (minX > maxX) return [fallbackX, fallbackY, fallbackX, fallbackY];
+  return [minX - pad, minY - pad, maxX + pad, maxY + pad];
+}
 
 export function buildCandidateStoreEager(
   scene: Scene,
@@ -395,31 +422,7 @@ export function buildCandidateStoreEager(
         const cacheKey = `${batchIds[id]}:${range[0]}:${range[1]}`;
         let box = pathAabbCache.get(cacheKey);
         if (box === undefined) {
-          const pad = batch.linewidth / 2 + 3;
-          let pMinX = Infinity;
-          let pMinY = Infinity;
-          let pMaxX = -Infinity;
-          let pMaxY = -Infinity;
-          for (let v = range[0]; v < range[1]; v++) {
-            const px = panel.x + batch.positions[v * 2]!;
-            const py = panel.y + batch.positions[v * 2 + 1]!;
-            if (px < pMinX) pMinX = px;
-            if (py < pMinY) pMinY = py;
-            if (px > pMaxX) pMaxX = px;
-            if (py > pMaxY) pMaxY = py;
-          }
-          if (pMinX > pMaxX) {
-            pMinX = xs[id]!;
-            pMinY = ys[id]!;
-            pMaxX = pMinX;
-            pMaxY = pMinY;
-          } else {
-            pMinX -= pad;
-            pMinY -= pad;
-            pMaxX += pad;
-            pMaxY += pad;
-          }
-          box = [pMinX, pMinY, pMaxX, pMaxY];
+          box = pathSubpathAabb(batch, panel.x, panel.y, range[0], range[1], xs[id]!, ys[id]!);
           pathAabbCache.set(cacheKey, box);
         }
         minX = box[0];

--- a/packages/core/src/candidate-store-eager.ts
+++ b/packages/core/src/candidate-store-eager.ts
@@ -334,24 +334,155 @@ export function buildCandidateStoreEager(
   tokenIndex.clear();
 
   // Spatial index over plot-px anchors (reuse StaticQuadtree). Point-like
-  // candidates shortlist via the tree; rects/segments/paths are refined from a
-  // compact extended-geometry list because their hit region can sit far from
-  // the stored anchor (bars, long segments, filled paths).
+  // candidates shortlist via the tree; rects/segments/paths use a second
+  // index over AABB *centers* expanded by max half-extents so hit regions
+  // far from anchors (tall bars, long segments, filled paths) still shortlist
+  // in O(log E + k) instead of force-adding every extended id.
   const spatialXs = Float64Array.from(xs);
   const spatialYs = Float64Array.from(ys);
   const spatial = n > 0 ? new StaticQuadtree(spatialXs, spatialYs) : null;
   const isPoint = new Uint8Array(n);
   const extendedIds: number[] = [];
+  // Per-extended-id plot-space AABB (filled after the classify pass).
+  const extMinXBuild: number[] = [];
+  const extMinYBuild: number[] = [];
+  const extMaxXBuild: number[] = [];
+  const extMaxYBuild: number[] = [];
+  // Subpath AABB cache: `${batchIndex}:${start}:${end}` → box (plot px).
+  const pathAabbCache = new Map<string, readonly [number, number, number, number]>();
   let maxPointReach = 0;
   for (let id = 0; id < n; id++) {
     const batch = scene.batches[batchIds[id]!]!;
     if (batch.kind === "points") {
       isPoint[id] = 1;
       maxPointReach = Math.max(maxPointReach, batch.size + 3);
-    } else {
-      extendedIds.push(id);
+      continue;
     }
+    extendedIds.push(id);
+    const panel = scene.panels[panelIds[id]!]!;
+    const i = primitiveIds[id]!;
+    let minX: number;
+    let minY: number;
+    let maxX: number;
+    let maxY: number;
+    if (batch.kind === "rects") {
+      const rx = panel.x + batch.rects[i * 4]!;
+      const ry = panel.y + batch.rects[i * 4 + 1]!;
+      const rw = batch.rects[i * 4 + 2]!;
+      const rh = batch.rects[i * 4 + 3]!;
+      minX = Math.min(rx, rx + rw);
+      minY = Math.min(ry, ry + rh);
+      maxX = Math.max(rx, rx + rw);
+      maxY = Math.max(ry, ry + rh);
+    } else if (batch.kind === "segments") {
+      const pad = batch.linewidth / 2 + 3;
+      const x1 = panel.x + batch.segments[i * 4]!;
+      const y1 = panel.y + batch.segments[i * 4 + 1]!;
+      const x2 = panel.x + batch.segments[i * 4 + 2]!;
+      const y2 = panel.y + batch.segments[i * 4 + 3]!;
+      minX = Math.min(x1, x2) - pad;
+      minY = Math.min(y1, y2) - pad;
+      maxX = Math.max(x1, x2) + pad;
+      maxY = Math.max(y1, y2) + pad;
+    } else {
+      // paths: subpath AABB (fill + stroke can sit far from one vertex anchor).
+      const range = pathRange(batch, i);
+      if (range === null) {
+        minX = xs[id]!;
+        minY = ys[id]!;
+        maxX = minX;
+        maxY = minY;
+      } else {
+        const cacheKey = `${batchIds[id]}:${range[0]}:${range[1]}`;
+        let box = pathAabbCache.get(cacheKey);
+        if (box === undefined) {
+          const pad = batch.linewidth / 2 + 3;
+          let pMinX = Infinity;
+          let pMinY = Infinity;
+          let pMaxX = -Infinity;
+          let pMaxY = -Infinity;
+          for (let v = range[0]; v < range[1]; v++) {
+            const px = panel.x + batch.positions[v * 2]!;
+            const py = panel.y + batch.positions[v * 2 + 1]!;
+            if (px < pMinX) pMinX = px;
+            if (py < pMinY) pMinY = py;
+            if (px > pMaxX) pMaxX = px;
+            if (py > pMaxY) pMaxY = py;
+          }
+          if (pMinX > pMaxX) {
+            pMinX = xs[id]!;
+            pMinY = ys[id]!;
+            pMaxX = pMinX;
+            pMaxY = pMinY;
+          } else {
+            pMinX -= pad;
+            pMinY -= pad;
+            pMaxX += pad;
+            pMaxY += pad;
+          }
+          box = [pMinX, pMinY, pMaxX, pMaxY];
+          pathAabbCache.set(cacheKey, box);
+        }
+        minX = box[0];
+        minY = box[1];
+        maxX = box[2];
+        maxY = box[3];
+      }
+    }
+    extMinXBuild.push(minX);
+    extMinYBuild.push(minY);
+    extMaxXBuild.push(maxX);
+    extMaxYBuild.push(maxY);
   }
+  pathAabbCache.clear();
+
+  const extN = extendedIds.length;
+  const extMinX = Float64Array.from(extMinXBuild);
+  const extMinY = Float64Array.from(extMinYBuild);
+  const extMaxX = Float64Array.from(extMaxXBuild);
+  const extMaxY = Float64Array.from(extMaxYBuild);
+  const extCx = new Float64Array(extN);
+  const extCy = new Float64Array(extN);
+  let maxHalfW = 0;
+  let maxHalfH = 0;
+  for (let ei = 0; ei < extN; ei++) {
+    const halfW = (extMaxX[ei]! - extMinX[ei]!) / 2;
+    const halfH = (extMaxY[ei]! - extMinY[ei]!) / 2;
+    extCx[ei] = (extMinX[ei]! + extMaxX[ei]!) / 2;
+    extCy[ei] = (extMinY[ei]! + extMaxY[ei]!) / 2;
+    if (halfW > maxHalfW) maxHalfW = halfW;
+    if (halfH > maxHalfH) maxHalfH = halfH;
+  }
+  const extendedSpatial = extN > 0 ? new StaticQuadtree(extCx, extCy) : null;
+  extMinXBuild.length = 0;
+  extMinYBuild.length = 0;
+  extMaxXBuild.length = 0;
+  extMaxYBuild.length = 0;
+
+  /** Add extended ids whose AABB intersects the axis-aligned query box. */
+  const addExtendedIntersecting = (
+    loX: number,
+    loY: number,
+    hiX: number,
+    hiY: number,
+    into: Set<number> | number[],
+  ): void => {
+    if (extendedSpatial === null) return;
+    // Any AABB that intersects [lo,hi] has its center within the query expanded
+    // by that AABB's half-extents; expand by the global max for one tree query.
+    const qx0 = loX - maxHalfW;
+    const qy0 = loY - maxHalfH;
+    const qx1 = hiX + maxHalfW;
+    const qy1 = hiY + maxHalfH;
+    for (const ei of extendedSpatial.queryRect(qx0, qy0, qx1, qy1)) {
+      if (extMaxX[ei]! < loX || extMinX[ei]! > hiX || extMaxY[ei]! < loY || extMinY[ei]! > hiY)
+        continue;
+      const id = extendedIds[ei]!;
+      if (Array.isArray(into)) into.push(id);
+      else into.add(id);
+    }
+  };
+
   // Far-plane strip bounds: StaticQuadtree prunes on the finite axis only.
   const STRIP = 1e30;
 
@@ -483,8 +614,8 @@ export function buildCandidateStoreEager(
       if (flip) addRect(px - maxDistance, -STRIP, px + maxDistance, STRIP);
       else addRect(-STRIP, py - maxDistance, STRIP, py + maxDistance);
     } else {
-      // exact / auto: point anchors within hit reach + all extended geometry
-      // (rects/segments/paths can match far from their stored anchors).
+      // exact / auto: point anchors within hit reach + extended geometry whose
+      // AABB meets the probe (rects/segments/paths can sit far from anchors).
       const r = mode === "auto" ? Math.max(maxDistance, maxPointReach) : maxPointReach;
       addRect(px - r, py - r, px + r, py + r);
       if (mode === "auto") {
@@ -498,7 +629,10 @@ export function buildCandidateStoreEager(
           addRect(-STRIP, py - maxDistance, STRIP, py + maxDistance);
         }
       }
-      for (const id of extendedIds) consider.add(id);
+      // exact containment uses the point AABB; auto still needs maxDistance pad
+      // for dominant-axis extended matches that refine after shortlist.
+      const pad = mode === "auto" ? maxDistance : 0;
+      addExtendedIntersecting(px - pad, py - pad, px + pad, py + pad, consider);
     }
     return [...consider].toSorted((a, b) => b - a);
   };
@@ -668,7 +802,9 @@ export function buildCandidateStoreEager(
         if (panelId !== undefined && scene.panels[panelIds[id]!]!.id !== panelId) continue;
         hits.push(id);
       }
-      for (const id of extendedIds) {
+      const extendedHits: number[] = [];
+      addExtendedIntersecting(loX, loY, hiX, hiY, extendedHits);
+      for (const id of extendedHits) {
         if (panelId !== undefined && scene.panels[panelIds[id]!]!.id !== panelId) continue;
         if (intersects(id, loX, loY, hiX, hiY)) hits.push(id);
       }

--- a/packages/core/tests/candidate-store.test.ts
+++ b/packages/core/tests/candidate-store.test.ts
@@ -803,4 +803,56 @@ describe("candidate spatial query hot path (issue #214)", () => {
     expect(store.queryRect(140, 70, 160, 90)).toEqual(new Uint32Array([0]));
     expect(store.queryRect(0, 0, 10, 10)).toEqual(new Uint32Array([0, 1]));
   });
+
+  it("exact nearest does not refine every far rect on a large bar field", () => {
+    // Complexity guard: extended geometry used to force-add all E rects into the
+    // shortlist. AABB spatial shortlist must keep refine O(log E + k).
+    const count = 4_000;
+    const rects = new Float32Array(count * 4);
+    for (let i = 0; i < count; i++) {
+      // 2×2 bars spaced on a grid far from the probe at (5,5).
+      const col = i % 50;
+      const row = Math.floor(i / 50);
+      rects[i * 4] = 100 + col * 10;
+      rects[i * 4 + 1] = 100 + row * 10;
+      rects[i * 4 + 2] = 2;
+      rects[i * 4 + 3] = 2;
+    }
+    // One bar covering the probe, anchor far from (10,10).
+    rects[0] = 0;
+    rects[1] = 0;
+    rects[2] = 20;
+    rects[3] = 20;
+    const plotScene = scene();
+    plotScene.batches = [
+      {
+        kind: "rects",
+        layerIndex: 0,
+        panelIndex: 0,
+        rects,
+        rowIndex: Uint32Array.from({ length: count }, (_, index) => index),
+        fill: null,
+        alpha: 1,
+      },
+    ];
+    let batchIndexReads = 0;
+    const batches = new Proxy(plotScene.batches, {
+      get(target, property, receiver): unknown {
+        if (typeof property === "string" && /^\d+$/.test(property)) batchIndexReads++;
+        return Reflect.get(target, property, receiver) as unknown;
+      },
+    });
+    plotScene.batches = batches;
+    const store = buildCandidateStore(plotScene, {
+      datum: () => ({ xValue: 1, yValue: 2, autoMode: "exact" }),
+    });
+    void store.x;
+    batchIndexReads = 0;
+
+    const hit = store.nearest(10, 10, { mode: "exact", maxDistance: 0 });
+    expect(hit?.id).toBe(0);
+    // Linear extended scan would touch batches once per rect (~count).
+    expect(batchIndexReads).toBeLessThan(200);
+    expect(batchIndexReads).toBeLessThan(count / 10);
+  });
 });

--- a/packages/core/tests/candidate-store.test.ts
+++ b/packages/core/tests/candidate-store.test.ts
@@ -855,4 +855,74 @@ describe("candidate spatial query hot path (issue #214)", () => {
     expect(batchIndexReads).toBeLessThan(200);
     expect(batchIndexReads).toBeLessThan(count / 10);
   });
+
+  it("one giant rect does not force-refine every small far rect", () => {
+    // Size-classed AABB trees: a full-plot bar must not expand the small-bar class.
+    const count = 2_000;
+    const rects = new Float32Array((count + 1) * 4);
+    // Giant bar covering most of the panel (own size class).
+    rects[0] = 0;
+    rects[1] = 0;
+    rects[2] = 200;
+    rects[3] = 120;
+    for (let i = 0; i < count; i++) {
+      const col = i % 40;
+      const row = Math.floor(i / 40);
+      rects[(i + 1) * 4] = 300 + col * 8;
+      rects[(i + 1) * 4 + 1] = 300 + row * 8;
+      rects[(i + 1) * 4 + 2] = 2;
+      rects[(i + 1) * 4 + 3] = 2;
+    }
+    const plotScene = scene();
+    plotScene.batches = [
+      {
+        kind: "rects",
+        layerIndex: 0,
+        panelIndex: 0,
+        rects,
+        rowIndex: Uint32Array.from({ length: count + 1 }, (_, index) => index),
+        fill: null,
+        alpha: 1,
+      },
+    ];
+    let batchIndexReads = 0;
+    plotScene.batches = new Proxy(plotScene.batches, {
+      get(target, property, receiver): unknown {
+        if (typeof property === "string" && /^\d+$/.test(property)) batchIndexReads++;
+        return Reflect.get(target, property, receiver) as unknown;
+      },
+    });
+    const store = buildCandidateStore(plotScene, {
+      datum: () => ({ xValue: 1, yValue: 2, autoMode: "exact" }),
+    });
+    void store.x;
+    batchIndexReads = 0;
+    // Probe on the giant bar; far small rects must stay out of refine.
+    expect(store.nearest(100, 60, { mode: "exact", maxDistance: 0 })?.id).toBe(0);
+    expect(batchIndexReads).toBeLessThan(50);
+    expect(batchIndexReads).toBeLessThan(count / 20);
+  });
+
+  it("builds stores that include glyph batches without throwing", () => {
+    const plotScene = scene();
+    plotScene.batches = [
+      {
+        kind: "glyphs",
+        layerIndex: 0,
+        panelIndex: 0,
+        positions: new Float32Array([10, 20, 30, 40]),
+        rowIndex: new Uint32Array([0, 1]),
+        texts: ["a", "b"],
+        color: null,
+        size: 12,
+        anchor: "start",
+        alpha: 1,
+      },
+    ];
+    const store = buildCandidateStore(plotScene, {
+      datum: () => ({ xValue: 1, yValue: 2 }),
+    });
+    expect(store.size).toBe(2);
+    expect(store.nearest(10, 20, { mode: "exact", maxDistance: 0 })).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary
Big-O maintain (rotation: packages/core/src after svelte #261).

**Finding:** `shortlistNearest` (exact/auto) and `queryRect` force-added **every** non-point candidate (`extendedIds`) — **O(E)** refine on every hover/brush.

**Fix:** Plot-space AABBs for rects/segments/path-subpaths/glyphs; size-classed `StaticQuadtree` on AABB centers (`ceil(log2(max half-extent))`); per-class query expansion; refine intersecting k.

## Complexity
| Before | After |
|--------|-------|
| O(E) force-add all extended | O(log E + k) per size class |

## Test plan
- [x] `bun test packages/core/tests/candidate-store.test.ts` (32 pass)
- [ ] CI
