### PR TITLE
perf(svelte): cap transient inspect fingerprint at member limit

### DIFF
--- a/packages/svelte/src/lib/inspection/resolver.ts
+++ b/packages/svelte/src/lib/inspection/resolver.ts
@@ -80,6 +80,19 @@ function cellToken(value: CellValue): string {
   return `${typeof value}:${String(value)}`;
 }
 
+/**
+ * Stable cell payload for semantic fingerprints. Insertion order of Object.keys
+ * is used (no O(F log F) sort): same row object is stable; content-equal clones
+ * with different key order may re-emit (safe over-emit, not under-emit).
+ */
+function rowCellPayload(row: Record<string, CellValue>): string {
+  const parts: string[] = [];
+  for (const field of Object.keys(row)) {
+    parts.push(`${field}=${cellToken(row[field] ?? null)}`);
+  }
+  return parts.join(",");
+}
+
 function resolvedTarget(
   model: RenderModel,
   seed: CandidateFacts,
@@ -291,7 +304,13 @@ export function createInspectionCoordinator<
     if (target === null) return null;
     const completeness =
       input.state === "pinned" ? "complete" : (input.completeness ?? "transient");
-    const semanticMembers = target.members.map((candidate) => {
+    // Pin/complete fingerprints the full group; transient matches materialize's
+    // TRANSIENT_MEMBER_LIMIT so pointer inspect is O(min(M,8)·F), not O(M·F log F).
+    const fingerprintMembers =
+      completeness === "complete"
+        ? target.members
+        : target.members.slice(0, TRANSIENT_MEMBER_LIMIT);
+    const semanticMembers = fingerprintMembers.map((candidate) => {
       const row = candidate.rowIndex === null ? null : input.model.row(candidate.rowIndex);
       const key =
         row === null || candidate.rowIndex === null ? null : keyOf(row as Row, candidate.rowIndex);
@@ -299,10 +318,7 @@ export function createInspectionCoordinator<
       const payload =
         row === null
           ? `${axisToken(candidate.xToken)},${axisToken(candidate.yToken)}`
-          : Object.keys(row)
-              .toSorted()
-              .map((field) => `${field}=${cellToken(row[field] ?? null)}`)
-              .join(",");
+          : rowCellPayload(row as Record<string, CellValue>);
       return `${semanticKeyToken(key, fallback)}{${payload}}`;
     });
     const focusRow = input.seed.rowIndex === null ? null : input.model.row(input.seed.rowIndex);
@@ -329,13 +345,18 @@ export function createInspectionCoordinator<
       input.state,
     ].join("|");
     const range = target.group?.range;
+    // Mirror fingerprintMembers: transient pinches presentation id to the same
+    // member window as materialize (layoutEpoch + range already cover the bucket).
+    const presentationMembers = fingerprintMembers;
     const presentationIdentity = [
       epochToken(input.layoutEpoch),
       PRESENTATION_ORDERING_VERSION,
       range === undefined
         ? `candidate:${input.seed.id}`
         : `${range.axis}:${range.start}:${range.end}`,
-      target.members.map((candidate) => `${candidate.id}@${candidate.x},${candidate.y}`).join(";"),
+      presentationMembers
+        .map((candidate) => `${candidate.id}@${candidate.x},${candidate.y}`)
+        .join(";"),
     ].join("|");
     const cacheKey = `${epochToken(input.layoutEpoch)}|${presentationIdentity}|${semanticFingerprint}|${completeness}|${input.source}`;
     const current = input.state === "pinned" ? pinned : transient;

--- a/packages/svelte/src/lib/inspection/resolver.ts
+++ b/packages/svelte/src/lib/inspection/resolver.ts
@@ -318,7 +318,7 @@ export function createInspectionCoordinator<
       const payload =
         row === null
           ? `${axisToken(candidate.xToken)},${axisToken(candidate.yToken)}`
-          : rowCellPayload(row as Record<string, CellValue>);
+          : rowCellPayload(row);
       return `${semanticKeyToken(key, fallback)}{${payload}}`;
     });
     const focusRow = input.seed.rowIndex === null ? null : input.model.row(input.seed.rowIndex);

--- a/packages/svelte/tests/interaction/unit.test.ts
+++ b/packages/svelte/tests/interaction/unit.test.ts
@@ -603,7 +603,7 @@ describe("semantic inspection resolver", () => {
       rowReads++;
       return originalRow(index);
     });
-    const coordinator = createInspectionCoordinator((row) => String((row as { id: string }).id));
+    const coordinator = createInspectionCoordinator((row) => (row as { id: string }).id);
     rowReads = 0;
     const resolved = coordinator.resolve({
       model,

--- a/packages/svelte/tests/interaction/unit.test.ts
+++ b/packages/svelte/tests/interaction/unit.test.ts
@@ -582,6 +582,46 @@ describe("semantic inspection resolver", () => {
     }
   });
 
+  it("transient fingerprint does not read every row in a large axis group", () => {
+    // Complexity: fingerprint used to walk all M members (Object.keys each row)
+    // before the slot cache check. Transient now caps at TRANSIENT_MEMBER_LIMIT (8).
+    const n = 400;
+    const data = Array.from({ length: n }, (_, i) => ({
+      id: `r${i}`,
+      x: 1,
+      y: i,
+    }));
+    const model = runPipeline(
+      gg(data, aes({ x: "x", y: "y", color: "id" }))
+        .geomPoint()
+        .spec(),
+      { width: 400, height: 300 },
+    );
+    const originalRow = model.row.bind(model);
+    let rowReads = 0;
+    vi.spyOn(model, "row").mockImplementation((index: number) => {
+      rowReads++;
+      return originalRow(index);
+    });
+    const coordinator = createInspectionCoordinator((row) => String((row as { id: string }).id));
+    rowReads = 0;
+    const resolved = coordinator.resolve({
+      model,
+      seed: model.candidates.candidate(0)!,
+      mode: "x",
+      state: "transient",
+      source: "pointer",
+      identityEpoch: 1,
+      layoutEpoch: "layout-1",
+      completeness: "transient",
+    });
+    expect(resolved).not.toBeNull();
+    // Full-group fingerprint would read ~n member rows (+ focus). Cap ≈ 8 members + focus + materialize.
+    expect(rowReads).toBeLessThan(40);
+    expect(rowReads).toBeLessThan(n / 5);
+    model.dispose();
+  });
+
   it("fingerprints null/Date/-0 cells and symbol keys in coordinated snapshots", () => {
     const data = [
       { id: "a", x: 1, y: 2 },


### PR DESCRIPTION
## Summary
Big-O maintain (rotation: packages/svelte/src after core #264).

**Finding:** `createInspectionCoordinator.resolve` built semantic fingerprints over **all** axis-group members with `Object.keys(row).toSorted()` **before** the slot cache check — **O(M·(F log F))** on every pointer inspect.

**Fix:** Transient fingerprints use `TRANSIENT_MEMBER_LIMIT` (same as materialize); pins stay complete; drop per-row key sort.

## Complexity
| Before | After |
|--------|-------|
| O(M·F log F) every transient resolve | O(min(M,8)·F) transient |

## Test plan
- [x] packages/svelte browser vitest
- [ ] CI
