### PR TITLE
refactor(spec): extract normalize-input types from normalize.ts

### DIFF
--- a/packages/spec/src/normalize-input.ts
+++ b/packages/spec/src/normalize-input.ts
@@ -1,0 +1,188 @@
+/**
+ * Builder-level SpecInput surface — bare-string channel shorthand and layer
+ * option forms accepted by normalize() / gg(). Canonical PortableSpec types
+ * live in schema.ts; this module is the convenience superset only.
+ */
+import type {
+  A11yMode,
+  AreaParams,
+  BarParams,
+  BoxplotParams,
+  ChannelValue,
+  ColParams,
+  CoordSpec,
+  DataRef,
+  DensityParams,
+  ErrorbarParams,
+  FacetScales,
+  InlineData,
+  Labs,
+  LegendSpec,
+  LineParams,
+  PointParams,
+  PointPosition,
+  PositionParams,
+  RenderBackend,
+  RuleParams,
+  Scales,
+  SmoothParams,
+  StackablePosition,
+  TextParams,
+  ThemeName,
+  ThemeSpec,
+} from "./schema.js";
+
+/** Channel form accepted at the TS/builder level: bare string = { field }. */
+export type ChannelInput = string | ChannelValue;
+
+/** Aes accepted at the TS/builder level (bare-string shorthand allowed). */
+export interface AesInput {
+  x?: ChannelInput;
+  y?: ChannelInput;
+  color?: ChannelInput;
+  fill?: ChannelInput;
+  size?: ChannelInput;
+  linewidth?: ChannelInput;
+  alpha?: ChannelInput;
+  group?: ChannelInput;
+  label?: ChannelInput;
+  weight?: ChannelInput;
+  ymin?: ChannelInput;
+  ymax?: ChannelInput;
+}
+
+interface LayerInputBase {
+  aes?: AesInput;
+  /** Rendering backend hint ("auto" is the default and canonicalizes away). */
+  render?: RenderBackend;
+}
+
+/** Facet accepted at the TS/builder level (bare-string field shorthand). */
+export interface FacetInput {
+  wrap?: string | { field: string };
+  rows?: string | { field: string };
+  cols?: string | { field: string };
+  ncol?: number;
+  scales?: FacetScales;
+}
+
+export interface PointLayerInput extends LayerInputBase {
+  geom: "point";
+  stat?: "identity";
+  position?: PointPosition;
+  positionParams?: PositionParams;
+  params?: PointParams;
+}
+
+export interface LineLayerInput extends LayerInputBase {
+  geom: "line";
+  stat?: "identity";
+  position?: "identity";
+  params?: LineParams;
+}
+
+export interface ColLayerInput extends LayerInputBase {
+  geom: "col";
+  stat?: "identity";
+  position?: StackablePosition;
+  params?: ColParams;
+}
+
+export interface BarLayerInput extends LayerInputBase {
+  geom: "bar";
+  stat?: "count" | "bin";
+  position?: StackablePosition;
+  params?: BarParams;
+}
+
+export interface HistogramLayerInput extends LayerInputBase {
+  geom: "histogram";
+  stat?: "bin";
+  position?: StackablePosition;
+  params?: BarParams;
+}
+
+export interface AreaLayerInput extends LayerInputBase {
+  geom: "area";
+  stat?: "identity";
+  position?: StackablePosition;
+  params?: AreaParams;
+}
+
+export interface RuleLayerInput extends LayerInputBase {
+  geom: "rule";
+  stat?: "identity";
+  position?: "identity";
+  params?: RuleParams;
+}
+
+export interface TextLayerInput extends LayerInputBase {
+  geom: "text";
+  stat?: "identity";
+  position?: "identity" | "nudge";
+  positionParams?: PositionParams;
+  params?: TextParams;
+}
+
+export interface SmoothLayerInput extends LayerInputBase {
+  geom: "smooth";
+  stat?: "smooth";
+  position?: "identity";
+  params?: SmoothParams;
+}
+
+export interface BoxplotLayerInput extends LayerInputBase {
+  geom: "boxplot";
+  stat?: "boxplot";
+  position?: "dodge" | "identity";
+  params?: BoxplotParams;
+}
+
+export interface DensityLayerInput extends LayerInputBase {
+  geom: "density";
+  stat?: "density";
+  position?: "identity";
+  params?: DensityParams;
+}
+
+export interface ErrorbarLayerInput extends LayerInputBase {
+  geom: "errorbar";
+  stat?: "identity" | "summary";
+  position?: "identity";
+  params?: ErrorbarParams;
+}
+
+/** Layer accepted at the TS/builder level. */
+export type LayerInput =
+  | PointLayerInput
+  | LineLayerInput
+  | ColLayerInput
+  | BarLayerInput
+  | HistogramLayerInput
+  | AreaLayerInput
+  | RuleLayerInput
+  | TextLayerInput
+  | SmoothLayerInput
+  | BoxplotLayerInput
+  | DensityLayerInput
+  | ErrorbarLayerInput;
+
+/** Spec accepted at the TS/builder level (superset of PortableSpec forms). */
+export interface SpecInput {
+  $schema?: string;
+  /** Defaults edition (Hadley lesson 13). Absent = current; normalize stamps it. */
+  edition?: number;
+  data?: DataRef;
+  datasets?: Record<string, InlineData>;
+  aes?: AesInput;
+  layers: LayerInput[];
+  facet?: FacetInput;
+  coord?: CoordSpec;
+  scales?: Scales;
+  legend?: LegendSpec;
+  labs?: Labs;
+  theme?: ThemeName | ThemeSpec;
+  width?: number;
+  height?: number;
+  a11y?: A11yMode;
+}

--- a/packages/spec/src/normalize.ts
+++ b/packages/spec/src/normalize.ts
@@ -4,6 +4,7 @@
  * Input: a SpecInput, the TS/builder-level convenience form where channels may
  * be bare strings ('displ' means { field: 'displ' }). The JSON Schema does NOT
  * admit bare strings — the shorthand exists only here and in the Svelte props.
+ * Input types live in normalize-input.ts.
  *
  * Output: a canonical PortableSpec. Canonicalization performed:
  *  1. Bare-string channels -> { field } (in plot aes and layer aes).
@@ -25,193 +26,45 @@
  * valid PortableSpec, and normalize(normalize(s)) deep-equals normalize(s).
  */
 import type {
-  A11yMode,
   Aes,
-  AreaParams,
-  BarParams,
-  BoxplotParams,
   ChannelValue,
-  ColParams,
-  CoordSpec,
-  DataRef,
-  DensityParams,
-  ErrorbarParams,
-  FacetScales,
   FacetSpec,
-  InlineData,
-  Labs,
   LayerSpec,
-  LegendSpec,
-  LineParams,
-  PointParams,
-  PointPosition,
   PortableSpec,
-  PositionParams,
-  RenderBackend,
-  RuleParams,
   Scales,
-  SmoothParams,
-  StackablePosition,
-  TextParams,
   ThemeName,
   ThemeSpec,
 } from "./schema.js";
 import { CHANNELS, CURRENT_EDITION, GEOM_DEFAULTS } from "./schema.js";
+import type {
+  AesInput,
+  ChannelInput,
+  FacetInput,
+  LayerInput,
+  SpecInput,
+} from "./normalize-input.js";
 
-/** Channel form accepted at the TS/builder level: bare string = { field }. */
-export type ChannelInput = string | ChannelValue;
-
-/** Aes accepted at the TS/builder level (bare-string shorthand allowed). */
-export interface AesInput {
-  x?: ChannelInput;
-  y?: ChannelInput;
-  color?: ChannelInput;
-  fill?: ChannelInput;
-  size?: ChannelInput;
-  linewidth?: ChannelInput;
-  alpha?: ChannelInput;
-  group?: ChannelInput;
-  label?: ChannelInput;
-  weight?: ChannelInput;
-  ymin?: ChannelInput;
-  ymax?: ChannelInput;
-}
-
-interface LayerInputBase {
-  aes?: AesInput;
-  /** Rendering backend hint ("auto" is the default and canonicalizes away). */
-  render?: RenderBackend;
-}
-
-/** Facet accepted at the TS/builder level (bare-string field shorthand). */
-export interface FacetInput {
-  wrap?: string | { field: string };
-  rows?: string | { field: string };
-  cols?: string | { field: string };
-  ncol?: number;
-  scales?: FacetScales;
-}
-
-export interface PointLayerInput extends LayerInputBase {
-  geom: "point";
-  stat?: "identity";
-  position?: PointPosition;
-  positionParams?: PositionParams;
-  params?: PointParams;
-}
-
-export interface LineLayerInput extends LayerInputBase {
-  geom: "line";
-  stat?: "identity";
-  position?: "identity";
-  params?: LineParams;
-}
-
-export interface ColLayerInput extends LayerInputBase {
-  geom: "col";
-  stat?: "identity";
-  position?: StackablePosition;
-  params?: ColParams;
-}
-
-export interface BarLayerInput extends LayerInputBase {
-  geom: "bar";
-  stat?: "count" | "bin";
-  position?: StackablePosition;
-  params?: BarParams;
-}
-
-export interface HistogramLayerInput extends LayerInputBase {
-  geom: "histogram";
-  stat?: "bin";
-  position?: StackablePosition;
-  params?: BarParams;
-}
-
-export interface AreaLayerInput extends LayerInputBase {
-  geom: "area";
-  stat?: "identity";
-  position?: StackablePosition;
-  params?: AreaParams;
-}
-
-export interface RuleLayerInput extends LayerInputBase {
-  geom: "rule";
-  stat?: "identity";
-  position?: "identity";
-  params?: RuleParams;
-}
-
-export interface TextLayerInput extends LayerInputBase {
-  geom: "text";
-  stat?: "identity";
-  position?: "identity" | "nudge";
-  positionParams?: PositionParams;
-  params?: TextParams;
-}
-
-export interface SmoothLayerInput extends LayerInputBase {
-  geom: "smooth";
-  stat?: "smooth";
-  position?: "identity";
-  params?: SmoothParams;
-}
-
-export interface BoxplotLayerInput extends LayerInputBase {
-  geom: "boxplot";
-  stat?: "boxplot";
-  position?: "dodge" | "identity";
-  params?: BoxplotParams;
-}
-
-export interface DensityLayerInput extends LayerInputBase {
-  geom: "density";
-  stat?: "density";
-  position?: "identity";
-  params?: DensityParams;
-}
-
-export interface ErrorbarLayerInput extends LayerInputBase {
-  geom: "errorbar";
-  stat?: "identity" | "summary";
-  position?: "identity";
-  params?: ErrorbarParams;
-}
-
-/** Layer accepted at the TS/builder level. */
-export type LayerInput =
-  | PointLayerInput
-  | LineLayerInput
-  | ColLayerInput
-  | BarLayerInput
-  | HistogramLayerInput
-  | AreaLayerInput
-  | RuleLayerInput
-  | TextLayerInput
-  | SmoothLayerInput
-  | BoxplotLayerInput
-  | DensityLayerInput
-  | ErrorbarLayerInput;
-
-/** Spec accepted at the TS/builder level (superset of PortableSpec forms). */
-export interface SpecInput {
-  $schema?: string;
-  /** Defaults edition (Hadley lesson 13). Absent = current; normalize stamps it. */
-  edition?: number;
-  data?: DataRef;
-  datasets?: Record<string, InlineData>;
-  aes?: AesInput;
-  layers: LayerInput[];
-  facet?: FacetInput;
-  coord?: CoordSpec;
-  scales?: Scales;
-  legend?: LegendSpec;
-  labs?: Labs;
-  theme?: ThemeName | ThemeSpec;
-  width?: number;
-  height?: number;
-  a11y?: A11yMode;
-}
+// Stable public path: re-export input types so index/builder/tests keep
+// importing from ./normalize.js (type-only dependency on normalize-input).
+export type {
+  AesInput,
+  AreaLayerInput,
+  BarLayerInput,
+  BoxplotLayerInput,
+  ChannelInput,
+  ColLayerInput,
+  DensityLayerInput,
+  ErrorbarLayerInput,
+  FacetInput,
+  HistogramLayerInput,
+  LayerInput,
+  LineLayerInput,
+  PointLayerInput,
+  RuleLayerInput,
+  SmoothLayerInput,
+  SpecInput,
+  TextLayerInput,
+} from "./normalize-input.js";
 
 /** Canonicalize one channel: bare string -> { field }; clone canonical forms. */
 export function normalizeChannel(input: ChannelInput): ChannelValue {


### PR DESCRIPTION
## Summary

Astral maintain rotate target: **`packages/spec/src`** (after core #265, svelte #263).

**Best candidate:** `normalize.ts` (362 lines) mixed builder-level `*Input` types with canonicalize logic.

### Split
| Module | Role |
|---|---|
| `normalize-input.ts` | `ChannelInput`, `AesInput`, `*LayerInput`, `LayerInput`, `SpecInput` (`LayerInputBase` stays private) |
| `normalize.ts` | `normalizeChannel`, `normalize`, helpers; re-exports input types |

Public `./normalize.js` path unchanged — `index.ts`, `builder.ts`, and tests need no import edits.

### Deferred
- `schema.ts` Type.Module (keep)
- `builder.ts` Geom*Options extract
- `errors.ts` / `lint.ts` catalog extracts
- validate-* (already split #238/#262)

## Test plan
- [x] `bun test packages/spec` (148 pass)
- [x] knip / pre-push green
- [x] Codex review: clean