### PR TITLE
perf(core): O(log P) path subpath index for candidate frame rows

### DIFF
--- a/packages/core/src/candidate-geometry.ts
+++ b/packages/core/src/candidate-geometry.ts
@@ -78,6 +78,26 @@ export function segmentIntersectsRect(
 }
 
 /**
+ * Subpath index in `pathOffsets` for a vertex (0 .. subpathCount-1), or null.
+ * Binary search on monotonic half-open spans — O(log P) vs linear O(P).
+ * Fractional vertices allowed; zero-length spans never match.
+ */
+export function pathSubpathIndex(offsets: ArrayLike<number>, vertex: number): number | null {
+  if (offsets.length < 2) return null;
+  let low = 0;
+  let high = offsets.length - 2;
+  while (low <= high) {
+    const mid = (low + high) >>> 1;
+    const start = offsets[mid]!;
+    const end = offsets[mid + 1]!;
+    if (vertex < start) high = mid - 1;
+    else if (vertex >= end) low = mid + 1;
+    else return mid;
+  }
+  return null;
+}
+
+/**
  * Half-open subpath range [start, end) containing `vertex`, or null.
  * Binary search on monotonic pathOffsets — O(log P) vs linear O(P).
  * Preserves the linear-scan contract: fractional vertices are allowed;
@@ -88,18 +108,9 @@ export function pathRange(
   vertex: number,
 ): readonly [number, number] | null {
   const offsets = batch.pathOffsets;
-  if (offsets.length < 2) return null;
-  let low = 0;
-  let high = offsets.length - 2;
-  while (low <= high) {
-    const mid = (low + high) >>> 1;
-    const start = offsets[mid]!;
-    const end = offsets[mid + 1]!;
-    if (vertex < start) high = mid - 1;
-    else if (vertex >= end) low = mid + 1;
-    else return [start, end] as const;
-  }
-  return null;
+  const mid = pathSubpathIndex(offsets, vertex);
+  if (mid === null) return null;
+  return [offsets[mid]!, offsets[mid + 1]!] as const;
 }
 
 /** True when a and b lie in the same half-open pathOffsets subpath. */

--- a/packages/core/src/interaction-mask.ts
+++ b/packages/core/src/interaction-mask.ts
@@ -1,3 +1,4 @@
+import { pathSubpathIndex } from "./candidate-geometry.js";
 import type { GeometryBatch } from "./scene.js";
 
 /** Semantic source-row keys associated with one renderer candidate. */
@@ -34,18 +35,7 @@ function pathForVertex(offsets: Uint32Array, vertexIndex: number): number | null
     vertexIndex >= offsets.at(-1)!
   )
     return null;
-
-  let low = 0;
-  let high = offsets.length - 2;
-  while (low <= high) {
-    const middle = (low + high) >>> 1;
-    const start = offsets[middle]!;
-    const end = offsets[middle + 1]!;
-    if (vertexIndex < start) high = middle - 1;
-    else if (vertexIndex >= end) low = middle + 1;
-    else return middle;
-  }
-  return null;
+  return pathSubpathIndex(offsets, vertexIndex);
 }
 
 function rendererPrimitive(batch: GeometryBatch, candidateIndex: number): number | null {

--- a/packages/core/src/pipeline/build-candidates-frame-row.ts
+++ b/packages/core/src/pipeline/build-candidates-frame-row.ts
@@ -1,6 +1,7 @@
 /**
  * Map a scene primitive back to a post-stat frame row and series group.
  */
+import { pathSubpathIndex } from "../candidate-geometry.js";
 import type { GeometryBatch } from "../scene.js";
 
 import type { LayerFrame } from "./types.js";
@@ -54,18 +55,17 @@ export function resolveCandidateFrameRow(input: {
   let derivedGroup = frame?.groups[frameRow] ?? 0;
 
   if (frame !== undefined && batch.kind === "paths") {
-    let subpath = 0;
-    while (
-      subpath + 1 < batch.pathOffsets.length &&
-      primitiveIndex >= batch.pathOffsets[subpath + 1]!
-    )
-      subpath++;
-    derivedGroup = orderedGroups[Math.min(subpath, orderedGroups.length - 1)] ?? 0;
-    const rowsInGroup = getPathGroupSortedRows(frame).get(derivedGroup) ?? [];
-    const local = primitiveIndex - (batch.pathOffsets[subpath] ?? 0);
-    const reflected =
-      local < rowsInGroup.length ? local : Math.max(0, rowsInGroup.length * 2 - 1 - local);
-    frameRow = rowsInGroup[Math.min(reflected, rowsInGroup.length - 1)] ?? frameRow;
+    // O(log P) subpath lookup (was linear O(P) per vertex → O(V·P) at build).
+    // Null = OOB / empty offsets: keep default frameRow/derivedGroup (codex P1).
+    const subpath = pathSubpathIndex(batch.pathOffsets, primitiveIndex);
+    if (subpath !== null) {
+      derivedGroup = orderedGroups[Math.min(subpath, orderedGroups.length - 1)] ?? 0;
+      const rowsInGroup = getPathGroupSortedRows(frame).get(derivedGroup) ?? [];
+      const local = primitiveIndex - (batch.pathOffsets[subpath] ?? 0);
+      const reflected =
+        local < rowsInGroup.length ? local : Math.max(0, rowsInGroup.length * 2 - 1 - local);
+      frameRow = rowsInGroup[Math.min(reflected, rowsInGroup.length - 1)] ?? frameRow;
+    }
   } else if (frame !== undefined && batch.kind === "segments") {
     if (frame.binding.layer.geom === "errorbar") frameRow = Math.floor(primitiveIndex / 3);
     else if (frame.binding.layer.geom === "boxplot" && batch.rowIndex.length >= frame.n * 2)

--- a/packages/core/tests/candidate-geometry.test.ts
+++ b/packages/core/tests/candidate-geometry.test.ts
@@ -5,6 +5,7 @@ import {
   directionalNearestInOrder,
   panelRangeInOrder,
   pathRange,
+  pathSubpathIndex,
   samePath,
 } from "../src/candidate-geometry.ts";
 import type { PathsBatch } from "../src/scene.ts";
@@ -26,11 +27,17 @@ function pathsBatch(pathOffsets: readonly number[]): PathsBatch {
   };
 }
 
-describe("pathRange", () => {
+describe("pathSubpathIndex / pathRange", () => {
   const offsets = [0, 3, 5, 9] as const;
   const batch = pathsBatch(offsets);
 
-  it("returns first, middle, and last subpath ranges", () => {
+  it("returns first, middle, and last subpath indexes and ranges", () => {
+    expect(pathSubpathIndex(offsets, 0)).toBe(0);
+    expect(pathSubpathIndex(offsets, 2)).toBe(0);
+    expect(pathSubpathIndex(offsets, 3)).toBe(1);
+    expect(pathSubpathIndex(offsets, 4)).toBe(1);
+    expect(pathSubpathIndex(offsets, 5)).toBe(2);
+    expect(pathSubpathIndex(offsets, 8)).toBe(2);
     expect(pathRange(batch, 0)).toEqual([0, 3]);
     expect(pathRange(batch, 2)).toEqual([0, 3]);
     expect(pathRange(batch, 3)).toEqual([3, 5]);
@@ -40,6 +47,11 @@ describe("pathRange", () => {
   });
 
   it("returns null for out-of-range vertices and empty offsets", () => {
+    expect(pathSubpathIndex(offsets, -1)).toBeNull();
+    expect(pathSubpathIndex(offsets, 9)).toBeNull();
+    expect(pathSubpathIndex(offsets, 100)).toBeNull();
+    expect(pathSubpathIndex([], 0)).toBeNull();
+    expect(pathSubpathIndex([0], 0)).toBeNull();
     expect(pathRange(batch, -1)).toBeNull();
     expect(pathRange(batch, 9)).toBeNull();
     expect(pathRange(batch, 100)).toBeNull();
@@ -49,6 +61,8 @@ describe("pathRange", () => {
 
   it("skips zero-length spans and accepts fractional vertices like the linear scan", () => {
     const withEmpty = pathsBatch([0, 2, 2, 5]);
+    expect(pathSubpathIndex(withEmpty.pathOffsets, 1)).toBe(0);
+    expect(pathSubpathIndex(withEmpty.pathOffsets, 2)).toBe(2);
     expect(pathRange(withEmpty, 1)).toEqual([0, 2]);
     // vertex 2 falls in the third span [2, 5) because [2, 2) is empty.
     expect(pathRange(withEmpty, 2)).toEqual([2, 5]);

--- a/packages/core/tests/pipeline-build-candidates.test.ts
+++ b/packages/core/tests/pipeline-build-candidates.test.ts
@@ -580,6 +580,48 @@ describe("resolveCandidateFrameRow paths", () => {
       }),
     ).toEqual({ frameRow: 3, derivedGroup: 1 });
   });
+
+  it("resolves many subpaths without linear pathOffsets scans (O(log P))", async () => {
+    const { resolveCandidateFrameRow } =
+      await import("../src/pipeline/build-candidates-frame-row.ts");
+    const { pathSubpathIndex } = await import("../src/candidate-geometry.ts");
+    // P subpaths × 2 vertices each; offsets [0,2,4,...,2P]
+    const P = 2_000;
+    const offsets = new Uint32Array(P + 1);
+    for (let s = 0; s <= P; s++) offsets[s] = s * 2;
+    const groups = Array.from({ length: P * 2 }, (_, i) => Math.floor(i / 2));
+    const xNumeric = new Float64Array(P * 2);
+    for (let s = 0; s < P; s++) {
+      xNumeric[s * 2] = 0;
+      xNumeric[s * 2 + 1] = 1;
+    }
+    const frame = {
+      n: P * 2,
+      groups,
+      xNumeric,
+      binding: { layer: { geom: "line" } },
+    } as never;
+    const batch = { kind: "paths", pathOffsets: offsets } as never;
+    const orderedGroups = Array.from({ length: P }, (_, s) => s);
+
+    // Binary search correctness on first / mid / last subpath
+    expect(pathSubpathIndex(offsets, 0)).toBe(0);
+    expect(pathSubpathIndex(offsets, 2 * Math.floor(P / 2))).toBe(Math.floor(P / 2));
+    expect(pathSubpathIndex(offsets, 2 * P - 1)).toBe(P - 1);
+
+    // Full build-style walk: each vertex once. Linear would be O(V·P) comparisons;
+    // we only check results stay correct for endpoints of a few subpaths.
+    for (const s of [0, 1, Math.floor(P / 2), P - 2, P - 1]) {
+      const resolved = resolveCandidateFrameRow({
+        frame,
+        batch,
+        primitiveIndex: s * 2,
+        orderedGroups,
+        outlierLocalRow: null,
+      });
+      expect(resolved.derivedGroup).toBe(s);
+    }
+  });
 });
 
 describe("allocatePipelineRunId", () => {


### PR DESCRIPTION
## Summary
Big-O maintain (rotation: packages/core/src after svelte #266).

**Finding:** `resolveCandidateFrameRow` linear-scanned `pathOffsets` per path vertex → **O(V·P)** multi-series line/area candidate build.

**Fix:** Export `pathSubpathIndex` (binary search); use in frame-row; share with `pathRange` and `interaction-mask` `pathForVertex`.

## Complexity
| Before | After |
|--------|-------|
| O(V·P) | O(V log P) |

## Test plan
- [x] bun test candidate-geometry + pipeline-build-candidates + interaction-mask
- [ ] CI

## Follow-ups
- hit-index non-point shortlist (rects/segments/paths still O(n) per hover)
- canvas segment stroke batching
