### PR TITLE
perf(svelte): share candidate projection for anchors and masks

### DIFF
--- a/packages/svelte/src/lib/plot-orchestrator.svelte.ts
+++ b/packages/svelte/src/lib/plot-orchestrator.svelte.ts
@@ -574,10 +574,6 @@ export function createPlotOrchestrator<
     resolvedWidth: () => runtime.resolvedWidth,
     resolvedHeight: () => runtime.resolvedHeight,
   });
-  // Method-call deriveds (not pure aliases) — keep as intermediate memos.
-  const selectedAnchors = $derived(selectionState.computeSelectedAnchors());
-  const emphasizedAnchors = $derived(selectionState.computeEmphasizedAnchors());
-
   // Semantic diagnostics effects (before host diagnostic / surface effects).
   semanticKeys.registerEffects();
 
@@ -593,17 +589,30 @@ export function createPlotOrchestrator<
   // focus/inspection registrations).
   surfaceState.registerSurfaceEffects();
 
-  // Three separate host deriveds — intermediate memo boundaries live here
-  // (do NOT fold into one method).
+  // Focus keys first (no candidate walk) so shared projection can short-circuit
+  // when idle. One full-store projection feeds selected/emphasized anchors and
+  // interaction masks — was O(2–3C) separate collectCandidates walks.
   const presentationFocusKeys = $derived(selectionState.computePresentationFocusKeys());
-  const semanticCandidateProjections = $derived(
-    selectionState.computeSemanticCandidateProjections(),
+  const sharedCandidateProjection = $derived.by(() => {
+    const needAnchors =
+      selectionState.effectiveSelectedKeys.length > 0 ||
+      intervalState.effectiveIntervalKeys.length > 0 ||
+      legendFocusState.effectiveEmphasisKeys.length > 0;
+    const needMasks = presentationFocusKeys.length > 0;
+    if (!needAnchors && !needMasks) return [];
+    return selectionState.computeSharedCandidateProjection();
+  });
+  const selectedAnchors = $derived(
+    selectionState.computeSelectedAnchors(sharedCandidateProjection),
+  );
+  const emphasizedAnchors = $derived(
+    selectionState.computeEmphasizedAnchors(sharedCandidateProjection),
   );
   const interactionMasks = $derived(
     selectionState.computeInteractionMasks(
       presentationFocusKeys,
-      // Thunk: with empty focus (idle), the projections derived is never read.
-      () => semanticCandidateProjections,
+      // Thunk: with empty focus (idle), shared projection is never forced for masks.
+      () => sharedCandidateProjection,
     ),
   );
 

--- a/packages/svelte/src/lib/plot-orchestrator.svelte.ts
+++ b/packages/svelte/src/lib/plot-orchestrator.svelte.ts
@@ -592,14 +592,16 @@ export function createPlotOrchestrator<
   // Focus keys first (no candidate walk) so shared projection can short-circuit
   // when idle. One full-store projection feeds selected/emphasized anchors and
   // interaction masks — was O(2–3C) separate collectCandidates walks.
+  // Liveness uses *counts* (Object.is-stable when keys swap but stay non-empty)
+  // so focus-only key changes rebuild masks/anchors without re-walking C (Codex P2).
   const presentationFocusKeys = $derived(selectionState.computePresentationFocusKeys());
+  const selectedKeyCount = $derived(selectionState.effectiveSelectedKeys.length);
+  const intervalKeyCount = $derived(intervalState.effectiveIntervalKeys.length);
+  const emphasisKeyCount = $derived(legendFocusState.effectiveEmphasisKeys.length);
+  const presentationFocusKeyCount = $derived(presentationFocusKeys.length);
   const sharedCandidateProjection = $derived.by(() => {
-    const needAnchors =
-      selectionState.effectiveSelectedKeys.length > 0 ||
-      intervalState.effectiveIntervalKeys.length > 0 ||
-      legendFocusState.effectiveEmphasisKeys.length > 0;
-    const needMasks = presentationFocusKeys.length > 0;
-    if (!needAnchors && !needMasks) return [];
+    if (selectedKeyCount + intervalKeyCount + emphasisKeyCount + presentationFocusKeyCount === 0)
+      return [];
     return selectionState.computeSharedCandidateProjection();
   });
   const selectedAnchors = $derived(

--- a/packages/svelte/src/lib/selection/selection-state.svelte.ts
+++ b/packages/svelte/src/lib/selection/selection-state.svelte.ts
@@ -80,7 +80,7 @@ export type SelectionStateDeps = {
  * Built once per reactive need so selected/emphasized/mask paths do not each
  * re-walk the store (was O(2–3C) when several are live).
  */
-export type SharedCandidateProjection = {
+type SharedCandidateProjection = {
   readonly x: number;
   readonly y: number;
   readonly batchIndex: number;
@@ -96,7 +96,7 @@ export type SelectionState = {
   /**
    * Full-store projection (x/y + mask fields + keys). Host should `$derived`
    * this once when any anchor or mask consumer is live, then pass the array
-   * into the From-shared helpers below.
+   * into the shared-projection overloads below.
    */
   computeSharedCandidateProjection(): SharedCandidateProjection[];
   computeSelectedAnchors(
@@ -106,7 +106,7 @@ export type SelectionState = {
     sharedProjection?: readonly SharedCandidateProjection[],
   ): { x: number; y: number }[];
   computePresentationFocusKeys(): readonly PropertyKey[];
-  /** @deprecated Prefer computeSharedCandidateProjection + masks From shared. */
+  /** Alias of computeSharedCandidateProjection (tests / masks). */
   computeSemanticCandidateProjections(): SharedCandidateProjection[];
   /**
    * Takes BOTH upstream values as parameters so the host's three separate

--- a/packages/svelte/src/lib/selection/selection-state.svelte.ts
+++ b/packages/svelte/src/lib/selection/selection-state.svelte.ts
@@ -75,7 +75,14 @@ export type SelectionStateDeps = {
   announce: (message: string) => void;
 };
 
-type SemanticCandidateProjection = {
+/**
+ * One candidate projection for anchors + interaction masks.
+ * Built once per reactive need so selected/emphasized/mask paths do not each
+ * re-walk the store (was O(2–3C) when several are live).
+ */
+export type SharedCandidateProjection = {
+  readonly x: number;
+  readonly y: number;
   readonly batchIndex: number;
   readonly primitiveIndex: number;
   readonly keys: readonly PropertyKey[];
@@ -86,10 +93,21 @@ export type SelectionState = {
   clearPointSelection(source: InteractionSource): void;
   togglePointKeys(keys: readonly PropertyKey[], source: InteractionSource): void;
   emitSelection(event: PlotSelection): void;
-  computeSelectedAnchors(): { x: number; y: number }[];
-  computeEmphasizedAnchors(): { x: number; y: number }[];
+  /**
+   * Full-store projection (x/y + mask fields + keys). Host should `$derived`
+   * this once when any anchor or mask consumer is live, then pass the array
+   * into the From-shared helpers below.
+   */
+  computeSharedCandidateProjection(): SharedCandidateProjection[];
+  computeSelectedAnchors(
+    sharedProjection?: readonly SharedCandidateProjection[],
+  ): { x: number; y: number }[];
+  computeEmphasizedAnchors(
+    sharedProjection?: readonly SharedCandidateProjection[],
+  ): { x: number; y: number }[];
   computePresentationFocusKeys(): readonly PropertyKey[];
-  computeSemanticCandidateProjections(): SemanticCandidateProjection[];
+  /** @deprecated Prefer computeSharedCandidateProjection + masks From shared. */
+  computeSemanticCandidateProjections(): SharedCandidateProjection[];
   /**
    * Takes BOTH upstream values as parameters so the host's three separate
    * derived aliases preserve independent memo boundaries (focus-only changes
@@ -97,7 +115,7 @@ export type SelectionState = {
    */
   computeInteractionMasks(
     presentationFocusKeys: readonly PropertyKey[],
-    getSemanticCandidateProjections: () => readonly SemanticCandidateProjection[],
+    getSemanticCandidateProjections: () => readonly SharedCandidateProjection[],
   ): readonly (BatchInteractionMask | null)[];
 };
 
@@ -120,18 +138,27 @@ export function createSelectionState(deps: SelectionStateDeps): SelectionState {
     return deps.interaction()?.selected(deps.resolvedInteractionScope()) ?? localSelectedKeys;
   });
 
-  function anchorsForKeys(keys: readonly PropertyKey[]): { x: number; y: number }[] {
-    // Empty filter short-circuits before walking (keysFor can be expensive).
+  function projectCandidates(): SharedCandidateProjection[] {
     const model = deps.model();
-    if (model === null || keys.length === 0) return [];
-    return anchorsFromCandidateKeys(
-      collectCandidates(model.candidates, (candidate) => ({
-        x: candidate.x,
-        y: candidate.y,
-        keys: deps.candidateSemanticKeys(candidate),
-      })),
-      keys,
-    );
+    if (model === null) return [];
+    return collectCandidates(model.candidates, (candidate) => ({
+      x: candidate.x,
+      y: candidate.y,
+      batchIndex: candidate.batchIndex,
+      primitiveIndex: candidate.primitiveIndex,
+      keys: deps.candidateSemanticKeys(candidate),
+    }));
+  }
+
+  function anchorsForKeys(
+    keys: readonly PropertyKey[],
+    sharedProjection?: readonly SharedCandidateProjection[],
+  ): { x: number; y: number }[] {
+    // Empty filter short-circuits before walking (keysFor can be expensive).
+    if (keys.length === 0) return [];
+    if (deps.model() === null) return [];
+    const candidates = sharedProjection ?? projectCandidates();
+    return anchorsFromCandidateKeys(candidates, keys);
   }
 
   /** Private — only clear/toggle call this; no external caller (P2-7). */
@@ -179,28 +206,31 @@ export function createSelectionState(deps: SelectionStateDeps): SelectionState {
     commitPointSelection(next, source);
   }
 
-  function computeSelectedAnchors(): { x: number; y: number }[] {
-    return anchorsForKeys([
-      ...new Set([...effectiveSelectedKeys, ...deps.effectiveIntervalKeys()]),
-    ]);
+  function computeSharedCandidateProjection(): SharedCandidateProjection[] {
+    return projectCandidates();
   }
 
-  function computeEmphasizedAnchors(): { x: number; y: number }[] {
-    return anchorsForKeys(deps.effectiveEmphasisKeys());
+  function computeSelectedAnchors(
+    sharedProjection?: readonly SharedCandidateProjection[],
+  ): { x: number; y: number }[] {
+    return anchorsForKeys(
+      [...new Set([...effectiveSelectedKeys, ...deps.effectiveIntervalKeys()])],
+      sharedProjection,
+    );
+  }
+
+  function computeEmphasizedAnchors(
+    sharedProjection?: readonly SharedCandidateProjection[],
+  ): { x: number; y: number }[] {
+    return anchorsForKeys(deps.effectiveEmphasisKeys(), sharedProjection);
   }
 
   function computePresentationFocusKeys(): readonly PropertyKey[] {
     return mergePresentationFocusKeys(deps.effectiveEmphasisKeys(), deps.inspectionFocus());
   }
 
-  function computeSemanticCandidateProjections(): SemanticCandidateProjection[] {
-    const model = deps.model();
-    if (model === null) return [];
-    return collectCandidates(model.candidates, (candidate) => ({
-      batchIndex: candidate.batchIndex,
-      primitiveIndex: candidate.primitiveIndex,
-      keys: deps.candidateSemanticKeys(candidate),
-    }));
+  function computeSemanticCandidateProjections(): SharedCandidateProjection[] {
+    return projectCandidates();
   }
 
   function computeInteractionMasks(
@@ -209,7 +239,7 @@ export function createSelectionState(deps: SelectionStateDeps): SelectionState {
     // BEFORE the projections derived is read, exactly as the base host did —
     // an eager parameter would run the O(candidates) semantic-key walk on
     // every model update (and every SSR render) in the idle no-focus state.
-    getSemanticCandidateProjections: () => readonly SemanticCandidateProjection[],
+    getSemanticCandidateProjections: () => readonly SharedCandidateProjection[],
   ): readonly (BatchInteractionMask | null)[] {
     const model = deps.model();
     if (model === null || presentationFocusKeys.length === 0) return [];
@@ -227,6 +257,7 @@ export function createSelectionState(deps: SelectionStateDeps): SelectionState {
     clearPointSelection,
     togglePointKeys,
     emitSelection,
+    computeSharedCandidateProjection,
     computeSelectedAnchors,
     computeEmphasizedAnchors,
     computePresentationFocusKeys,

--- a/packages/svelte/tests/selection/selection-state.test.ts
+++ b/packages/svelte/tests/selection/selection-state.test.ts
@@ -404,6 +404,42 @@ describe("createSelectionState anchors", () => {
     empty.destroy();
     destroy();
   });
+
+  it("shared projection serves selected + emphasized anchors with one key walk", () => {
+    const model = modelFor(continuousSpec());
+    let candidateCalls = 0;
+    const { state, destroy } = mountSelectionController({
+      model: () => model,
+      selectConfig: pointSelectMultiple,
+      effectiveEmphasisKeys: () => ["1"],
+      candidateSemanticKeys: (candidate) => {
+        candidateCalls++;
+        return identityCandidateKeys(candidate);
+      },
+    });
+    state.togglePointKeys(["0"], "pointer");
+    flushSync();
+
+    candidateCalls = 0;
+    const shared = state.computeSharedCandidateProjection();
+    const once = candidateCalls;
+    expect(once).toBeGreaterThan(0);
+
+    const selected = state.computeSelectedAnchors(shared);
+    const emphasized = state.computeEmphasizedAnchors(shared);
+    // No second store walk: key resolver not invoked again for anchors.
+    expect(candidateCalls).toBe(once);
+    expect(selected.length).toBeGreaterThan(0);
+    expect(emphasized.length).toBeGreaterThan(0);
+
+    // Without sharing, two independent calls would double the key work.
+    candidateCalls = 0;
+    state.computeSelectedAnchors();
+    state.computeEmphasizedAnchors();
+    expect(candidateCalls).toBeGreaterThanOrEqual(once * 2);
+
+    destroy();
+  });
 });
 
 describe("createSelectionState masks", () => {


### PR DESCRIPTION
## Summary
Big-O maintain (rotation: packages/svelte/src after core #268).

**Finding:** Selected/emphasized anchors and interaction masks each did full `collectCandidates` walks — **O(2–3C)** when live.

**Fix:** One shared projection when any consumer is live; idle short-circuits.

## Complexity
| Before | After |
|--------|-------|
| O(2–3C) | O(C) shared |

## Test plan
- [x] selection-state tests including shared-projection guard
- [ ] CI
