### PR TITLE
perf(core): O(log R+k) rect hit shortlist via size-class AABB trees

### DIFF
--- a/packages/core/src/dom/hit-index.ts
+++ b/packages/core/src/dom/hit-index.ts
@@ -167,18 +167,21 @@ interface PointsIndexEntry {
   ys: Float64Array;
 }
 
+/** One size class of rect AABB centers (plot px). */
+interface RectSizeClass {
+  readonly indices: readonly number[];
+  readonly maxHalfW: number;
+  readonly maxHalfH: number;
+  readonly spatial: StaticQuadtree;
+}
+
 /** Size-classed AABB-center trees for rect batches (plot px). */
 interface RectsIndexEntry {
   readonly minX: Float64Array;
   readonly minY: Float64Array;
   readonly maxX: Float64Array;
   readonly maxY: Float64Array;
-  readonly classes: readonly {
-    readonly indices: readonly number[];
-    readonly maxHalfW: number;
-    readonly maxHalfH: number;
-    readonly spatial: StaticQuadtree;
-  }[];
+  readonly classes: readonly RectSizeClass[];
 }
 
 function buildRectsIndex(
@@ -210,7 +213,7 @@ function buildRectsIndex(
     if (list === undefined) buckets.set(key, [j]);
     else list.push(j);
   }
-  const classes: RectsIndexEntry["classes"] = [];
+  const classes: RectSizeClass[] = [];
   for (const indices of buckets.values()) {
     const cxs = new Float64Array(indices.length);
     const cys = new Float64Array(indices.length);
@@ -233,6 +236,36 @@ function buildRectsIndex(
     });
   }
   return { minX, minY, maxX, maxY, classes };
+}
+
+/** Rect indices whose AABB intersects [loX,hiX]×[loY,hiY] (plot px). */
+function shortlistRectsIntersecting(
+  entry: RectsIndexEntry,
+  loX: number,
+  loY: number,
+  hiX: number,
+  hiY: number,
+): number[] {
+  const out: number[] = [];
+  for (const cls of entry.classes) {
+    for (const k of cls.spatial.queryRect(
+      loX - cls.maxHalfW,
+      loY - cls.maxHalfH,
+      hiX + cls.maxHalfW,
+      hiY + cls.maxHalfH,
+    )) {
+      const j = cls.indices[k]!;
+      if (
+        entry.maxX[j]! < loX ||
+        entry.minX[j]! > hiX ||
+        entry.maxY[j]! < loY ||
+        entry.minY[j]! > hiY
+      )
+        continue;
+      out.push(j);
+    }
+  }
+  return out;
 }
 
 /** Build the unified hit index for a committed scene. */
@@ -426,27 +459,12 @@ export function buildHitIndex(scene: Scene, options: HitIndexOptions = {}): Scen
           case "rects": {
             const entry = rectsIndex.get(batch);
             if (entry === undefined) break;
-            for (const cls of entry.classes) {
-              for (const k of cls.spatial.queryRect(
-                lo.x - cls.maxHalfW,
-                lo.y - cls.maxHalfH,
-                hi.x + cls.maxHalfW,
-                hi.y + cls.maxHalfH,
-              )) {
-                const j = cls.indices[k]!;
-                if (
-                  entry.maxX[j]! < lo.x ||
-                  entry.minX[j]! > hi.x ||
-                  entry.maxY[j]! < lo.y ||
-                  entry.minY[j]! > hi.y
-                )
-                  continue;
-                // Anchor matches hitTest / pre-index behavior: panel + raw origin.
-                const rx = batch.rects[j * 4]!;
-                const ry = batch.rects[j * 4 + 1]!;
-                const rw = batch.rects[j * 4 + 2]!;
-                push(batch, batch.rowIndex[j]!, panel.x + rx + rw / 2, panel.y + ry);
-              }
+            for (const j of shortlistRectsIntersecting(entry, lo.x, lo.y, hi.x, hi.y)) {
+              // Anchor matches hitTest / pre-index behavior: panel + raw origin.
+              const rx = batch.rects[j * 4]!;
+              const ry = batch.rects[j * 4 + 1]!;
+              const rw = batch.rects[j * 4 + 2]!;
+              push(batch, batch.rowIndex[j]!, panel.x + rx + rw / 2, panel.y + ry);
             }
             break;
           }

--- a/packages/core/src/dom/hit-index.ts
+++ b/packages/core/src/dom/hit-index.ts
@@ -9,7 +9,10 @@
  * Per-kind tests (plan round-2 fix — bbox alone cannot hit-test paths):
  *  - points: hand-rolled static quadtree (see quadtree.ts for why it is not
  *    a d3-quadtree port); hit radius = mark radius + tolerance, nearest wins.
- *  - rects: panel shortlist, then EXACT containment (no slop — bars abut).
+ *  - rects: size-classed AABB-center shortlist, then EXACT containment
+ *    (no slop — bars abut). Size classes prevent one giant bar from
+ *    expanding every small-bar query to O(R) — same pattern as CandidateStore
+ *    extended geometry (#264).
  *  - segments: exact point-to-segment distance <= linewidth/2 + tolerance.
  *  - stroked paths (lines): per-edge point-to-segment distance, same rule.
  *  - filled paths (areas/ribbons): even-odd point-in-polygon containment;
@@ -164,6 +167,74 @@ interface PointsIndexEntry {
   ys: Float64Array;
 }
 
+/** Size-classed AABB-center trees for rect batches (plot px). */
+interface RectsIndexEntry {
+  readonly minX: Float64Array;
+  readonly minY: Float64Array;
+  readonly maxX: Float64Array;
+  readonly maxY: Float64Array;
+  readonly classes: readonly {
+    readonly indices: readonly number[];
+    readonly maxHalfW: number;
+    readonly maxHalfH: number;
+    readonly spatial: StaticQuadtree;
+  }[];
+}
+
+function buildRectsIndex(
+  batch: Extract<GeometryBatch, { kind: "rects" }>,
+  panel: ScenePanel,
+): RectsIndexEntry {
+  const n = batch.rects.length / 4;
+  const minX = new Float64Array(n);
+  const minY = new Float64Array(n);
+  const maxX = new Float64Array(n);
+  const maxY = new Float64Array(n);
+  for (let j = 0; j < n; j++) {
+    const rx = panel.x + batch.rects[j * 4]!;
+    const ry = panel.y + batch.rects[j * 4 + 1]!;
+    const rw = batch.rects[j * 4 + 2]!;
+    const rh = batch.rects[j * 4 + 3]!;
+    minX[j] = Math.min(rx, rx + rw);
+    minY[j] = Math.min(ry, ry + rh);
+    maxX[j] = Math.max(rx, rx + rw);
+    maxY[j] = Math.max(ry, ry + rh);
+  }
+  // Size classes so one giant bar cannot expand every small-bar query to O(n).
+  const buckets = new Map<number, number[]>();
+  for (let j = 0; j < n; j++) {
+    const halfW = (maxX[j]! - minX[j]!) / 2;
+    const halfH = (maxY[j]! - minY[j]!) / 2;
+    const key = Math.min(31, Math.ceil(Math.log2(Math.max(halfW, halfH, 1e-9))));
+    const list = buckets.get(key);
+    if (list === undefined) buckets.set(key, [j]);
+    else list.push(j);
+  }
+  const classes: RectsIndexEntry["classes"] = [];
+  for (const indices of buckets.values()) {
+    const cxs = new Float64Array(indices.length);
+    const cys = new Float64Array(indices.length);
+    let maxHalfW = 0;
+    let maxHalfH = 0;
+    for (let k = 0; k < indices.length; k++) {
+      const j = indices[k]!;
+      const halfW = (maxX[j]! - minX[j]!) / 2;
+      const halfH = (maxY[j]! - minY[j]!) / 2;
+      cxs[k] = (minX[j]! + maxX[j]!) / 2;
+      cys[k] = (minY[j]! + maxY[j]!) / 2;
+      if (halfW > maxHalfW) maxHalfW = halfW;
+      if (halfH > maxHalfH) maxHalfH = halfH;
+    }
+    classes.push({
+      indices,
+      maxHalfW,
+      maxHalfH,
+      spatial: new StaticQuadtree(cxs, cys),
+    });
+  }
+  return { minX, minY, maxX, maxY, classes };
+}
+
 /** Build the unified hit index for a committed scene. */
 export function buildHitIndex(scene: Scene, options: HitIndexOptions = {}): SceneHitIndex {
   const tolerance = options.tolerance ?? DEFAULT_HIT_TOLERANCE;
@@ -171,18 +242,22 @@ export function buildHitIndex(scene: Scene, options: HitIndexOptions = {}): Scen
 
   // Per points-batch quadtrees over PLOT-px positions.
   const pointsIndex = new Map<GeometryBatch, PointsIndexEntry>();
+  const rectsIndex = new Map<GeometryBatch, RectsIndexEntry>();
   for (const batch of scene.batches) {
-    if (batch.kind !== "points") continue;
     const panel = panels[batch.panelIndex];
     if (panel === undefined) continue;
-    const n = batch.rowIndex.length;
-    const xs = new Float64Array(n);
-    const ys = new Float64Array(n);
-    for (let i = 0; i < n; i++) {
-      xs[i] = panel.x + batch.positions[i * 2]!;
-      ys[i] = panel.y + batch.positions[i * 2 + 1]!;
+    if (batch.kind === "points") {
+      const n = batch.rowIndex.length;
+      const xs = new Float64Array(n);
+      const ys = new Float64Array(n);
+      for (let i = 0; i < n; i++) {
+        xs[i] = panel.x + batch.positions[i * 2]!;
+        ys[i] = panel.y + batch.positions[i * 2 + 1]!;
+      }
+      pointsIndex.set(batch, { quadtree: new StaticQuadtree(xs, ys), xs, ys });
+    } else if (batch.kind === "rects") {
+      rectsIndex.set(batch, buildRectsIndex(batch, panel));
     }
-    pointsIndex.set(batch, { quadtree: new StaticQuadtree(xs, ys), xs, ys });
   }
 
   function hitBatch(batch: GeometryBatch, x: number, y: number): SceneHit | null {
@@ -209,24 +284,40 @@ export function buildHitIndex(scene: Scene, options: HitIndexOptions = {}): Scen
         };
       }
       case "rects": {
-        // Exact containment, topmost (= last drawn) rect first.
-        for (let j = batch.rects.length / 4 - 1; j >= 0; j--) {
-          const rx = batch.rects[j * 4]!;
-          const ry = batch.rects[j * 4 + 1]!;
-          const rw = batch.rects[j * 4 + 2]!;
-          const rh = batch.rects[j * 4 + 3]!;
-          if (lx >= rx && lx <= rx + rw && ly >= ry && ly <= ry + rh) {
-            return {
-              layerIndex: batch.layerIndex,
-              panelIndex: batch.panelIndex,
-              rowIndex: rowOf(batch.rowIndex[j]!),
-              x: panel.x + rx + rw / 2,
-              y: panel.y + ry,
-              kind: "rects",
-            };
+        // Size-class AABB shortlist, then exact containment; topmost = highest j.
+        const entry = rectsIndex.get(batch);
+        if (entry === undefined) return null;
+        let best = -1;
+        for (const cls of entry.classes) {
+          for (const k of cls.spatial.queryRect(
+            x - cls.maxHalfW,
+            y - cls.maxHalfH,
+            x + cls.maxHalfW,
+            y + cls.maxHalfH,
+          )) {
+            const j = cls.indices[k]!;
+            if (
+              x >= entry.minX[j]! &&
+              x <= entry.maxX[j]! &&
+              y >= entry.minY[j]! &&
+              y <= entry.maxY[j]! &&
+              j > best
+            )
+              best = j;
           }
         }
-        return null;
+        if (best < 0) return null;
+        const rx = batch.rects[best * 4]!;
+        const ry = batch.rects[best * 4 + 1]!;
+        const rw = batch.rects[best * 4 + 2]!;
+        return {
+          layerIndex: batch.layerIndex,
+          panelIndex: batch.panelIndex,
+          rowIndex: rowOf(batch.rowIndex[best]!),
+          x: panel.x + rx + rw / 2,
+          y: panel.y + ry,
+          kind: "rects",
+        };
       }
       case "segments": {
         const slop = batch.linewidth / 2 + tolerance;
@@ -333,13 +424,28 @@ export function buildHitIndex(scene: Scene, options: HitIndexOptions = {}): Scen
             break;
           }
           case "rects": {
-            for (let j = 0; j < batch.rects.length / 4; j++) {
-              const rx = panel.x + batch.rects[j * 4]!;
-              const ry = panel.y + batch.rects[j * 4 + 1]!;
-              const rw = batch.rects[j * 4 + 2]!;
-              const rh = batch.rects[j * 4 + 3]!;
-              if (rx <= hi.x && rx + rw >= lo.x && ry <= hi.y && ry + rh >= lo.y) {
-                push(batch, batch.rowIndex[j]!, rx + rw / 2, ry);
+            const entry = rectsIndex.get(batch);
+            if (entry === undefined) break;
+            for (const cls of entry.classes) {
+              for (const k of cls.spatial.queryRect(
+                lo.x - cls.maxHalfW,
+                lo.y - cls.maxHalfH,
+                hi.x + cls.maxHalfW,
+                hi.y + cls.maxHalfH,
+              )) {
+                const j = cls.indices[k]!;
+                if (
+                  entry.maxX[j]! < lo.x ||
+                  entry.minX[j]! > hi.x ||
+                  entry.maxY[j]! < lo.y ||
+                  entry.minY[j]! > hi.y
+                )
+                  continue;
+                // Anchor matches hitTest / pre-index behavior: panel + raw origin.
+                const rx = batch.rects[j * 4]!;
+                const ry = batch.rects[j * 4 + 1]!;
+                const rw = batch.rects[j * 4 + 2]!;
+                push(batch, batch.rowIndex[j]!, panel.x + rx + rw / 2, panel.y + ry);
               }
             }
             break;

--- a/packages/core/tests/hit-index.test.ts
+++ b/packages/core/tests/hit-index.test.ts
@@ -10,10 +10,81 @@ import { gg, aes } from "@ggsvelte/spec";
 import { buildHitIndex } from "../src/dom/hit-index.ts";
 import { StaticQuadtree } from "../src/dom/quadtree.ts";
 import { runPipeline } from "../src/pipeline.ts";
-import type { PointsBatch } from "../src/scene.ts";
+import type { PointsBatch, Scene } from "../src/scene.ts";
 import { planStrata } from "../src/strata.ts";
 
 const size = { width: 640, height: 400 };
+
+/** Minimal scene for synthetic rect batches (panel origin at 0,0). */
+function rectScene(rects: Float32Array, rowIndex?: Uint32Array): Scene {
+  const n = rects.length / 4;
+  return {
+    width: 640,
+    height: 400,
+    panels: [
+      {
+        id: "panel:all",
+        x: 0,
+        y: 0,
+        width: 640,
+        height: 400,
+        strip: "",
+        axisX: [],
+        axisY: [],
+        grid: { x: [], y: [] },
+      },
+    ],
+    batches: [
+      {
+        kind: "rects",
+        layerIndex: 0,
+        panelIndex: 0,
+        rects,
+        rowIndex: rowIndex ?? Uint32Array.from({ length: n }, (_, i) => i),
+        fill: null,
+        alpha: 1,
+      },
+    ],
+    axes: { x: { ticks: [], title: "" }, y: { ticks: [], title: "" } },
+    grid: { x: [], y: [] },
+    legends: [],
+    theme: {} as Scene["theme"],
+    title: "",
+    subtitle: "",
+    caption: "",
+  };
+}
+
+/** Count numeric index reads on a Float32Array (complexity guard). */
+function instrumentReads(source: Float32Array): {
+  view: Float32Array;
+  reads: () => number;
+  reset: () => void;
+} {
+  let reads = 0;
+  // TypedArray methods reject Proxy as `this`; forward length/methods to the
+  // underlying buffer and only trap numeric element gets for the guard.
+  const view = new Proxy(source, {
+    get(target, property): unknown {
+      if (typeof property === "string" && /^\d+$/.test(property)) {
+        reads++;
+        return target[Number(property)];
+      }
+      if (property === "length") return target.length;
+      const value = (target as unknown as Record<string | symbol, unknown>)[property];
+      return typeof value === "function"
+        ? (value as (...a: unknown[]) => unknown).bind(target)
+        : value;
+    },
+  }) as Float32Array;
+  return {
+    view,
+    reads: () => reads,
+    reset: () => {
+      reads = 0;
+    },
+  };
+}
 
 describe("StaticQuadtree", () => {
   it("nearestWithin finds the closest point inside the radius, exactly", () => {
@@ -209,6 +280,96 @@ describe("buildHitIndex", () => {
     expect(all.map((h) => h.rowIndex).toSorted((a, b) => a! - b!)).toEqual([0, 1, 2, 3]);
     const none = index.queryRect(0, 0, 5, 5);
     expect(none).toEqual([]);
+  });
+
+  it("queryRect includes rects that intersect the brush (anchor at raw origin)", () => {
+    // Two bars: one under the brush, one far away. Negative height still hits via AABB.
+    const rects = new Float32Array([
+      10,
+      50,
+      20,
+      -30, // covers y 20..50, x 10..30 — brush at 15..25, 30..40
+      200,
+      10,
+      10,
+      10, // far
+    ]);
+    const scene = rectScene(rects);
+    const index = buildHitIndex(scene);
+    const hits = index.queryRect(15, 30, 25, 40);
+    expect(hits.map((h) => h.rowIndex)).toEqual([0]);
+    expect(hits[0]!.x).toBe(20); // 10 + 20/2
+    expect(hits[0]!.y).toBe(50); // raw origin y (not minY)
+  });
+
+  it("hitTest does not scan every far rect on a dense bar field", () => {
+    // Complexity: linear rects walk was O(R); size-class AABB shortlist is O(log R + k).
+    const count = 4_000;
+    const raw = new Float32Array(count * 4);
+    for (let i = 0; i < count; i++) {
+      const col = i % 50;
+      const row = Math.floor(i / 50);
+      raw[i * 4] = 100 + col * 10;
+      raw[i * 4 + 1] = 100 + row * 10;
+      raw[i * 4 + 2] = 2;
+      raw[i * 4 + 3] = 2;
+    }
+    // One bar covering the probe at (10,10).
+    raw[0] = 0;
+    raw[1] = 0;
+    raw[2] = 20;
+    raw[3] = 20;
+    const instrumented = instrumentReads(raw);
+    const scene = rectScene(instrumented.view);
+    const index = buildHitIndex(scene);
+    instrumented.reset();
+
+    const hit = index.hitTest(10, 10);
+    expect(hit?.rowIndex).toBe(0);
+    // Winner reads 3 components of batch.rects (x,y,w); linear scan would read ~4*R.
+    expect(instrumented.reads()).toBeLessThan(32);
+    expect(instrumented.reads()).toBeLessThan(count / 50);
+
+    instrumented.reset();
+    // Empty pocket between the cover bar (0..20) and the far grid (≥100).
+    expect(index.hitTest(50, 50)).toBeNull();
+    // Miss must not walk every far bar via batch.rects.
+    expect(instrumented.reads()).toBe(0);
+  });
+
+  it("one giant rect does not force-scan every small far rect", () => {
+    // Size classes: a full-plot bar must not expand the small-bar class query.
+    const count = 2_000;
+    const raw = new Float32Array((count + 1) * 4);
+    raw[0] = 0;
+    raw[1] = 0;
+    raw[2] = 200;
+    raw[3] = 120;
+    for (let i = 0; i < count; i++) {
+      const col = i % 40;
+      const row = Math.floor(i / 40);
+      raw[(i + 1) * 4] = 300 + col * 8;
+      raw[(i + 1) * 4 + 1] = 300 + row * 8;
+      raw[(i + 1) * 4 + 2] = 2;
+      raw[(i + 1) * 4 + 3] = 2;
+    }
+    const instrumented = instrumentReads(raw);
+    const scene = rectScene(instrumented.view);
+    const index = buildHitIndex(scene);
+    instrumented.reset();
+
+    // Probe inside the giant only — small far bars must not be refined via batch.rects.
+    const hit = index.hitTest(50, 50);
+    expect(hit?.rowIndex).toBe(0);
+    expect(instrumented.reads()).toBeLessThan(32);
+
+    instrumented.reset();
+    // Tight brush over empty left corner of giant (still only giant class hits).
+    const brushed = index.queryRect(10, 10, 20, 20);
+    expect(brushed.map((h) => h.rowIndex)).toEqual([0]);
+    // queryRect only reads batch.rects for shortlisted hits (3 components each).
+    expect(instrumented.reads()).toBeLessThan(32);
+    expect(instrumented.reads()).toBeLessThan(count / 20);
   });
 });
 

--- a/packages/core/tests/hit-index.test.ts
+++ b/packages/core/tests/hit-index.test.ts
@@ -64,7 +64,7 @@ function instrumentReads(source: Float32Array): {
   let reads = 0;
   // TypedArray methods reject Proxy as `this`; forward length/methods to the
   // underlying buffer and only trap numeric element gets for the guard.
-  const view = new Proxy(source, {
+  const view: Float32Array = new Proxy(source, {
     get(target, property): unknown {
       if (typeof property === "string" && /^\d+$/.test(property)) {
         reads++;
@@ -76,7 +76,7 @@ function instrumentReads(source: Float32Array): {
         ? (value as (...a: unknown[]) => unknown).bind(target)
         : value;
     },
-  }) as Float32Array;
+  });
   return {
     view,
     reads: () => reads,


### PR DESCRIPTION
## Summary

- **Audit target:** `packages/core/src` (bigo-maintain rotation; nextIndex=0)
- **Finding:** `buildHitIndex` rect `hitTest` / `queryRect` scanned all rects linearly **O(R)** per probe (R = bar count). Points already use a quadtree; rects did not.
- **Fix:** Build per-rects-batch **size-classed AABB-center** `StaticQuadtree`s (same pattern as CandidateStore extended geometry #264). Shortlist by expanded query, then exact containment / AABB intersect. Topmost = highest index `j`. Query-rect anchors preserve raw rect origin (panel + x + w/2, y).
- **Complexity:** O(R) → **O(log R + k)** per probe (plus O(R log R) build once per scene commit). Size classes prevent one giant bar from expanding every small-bar query to O(R).
- **Out of scope:** segments / paths still linear (follow-up).

## Test plan

- [x] `bun test packages/core/tests/hit-index.test.ts` — 15 pass
- [x] Characterization: stacked `geomCol` topmost + exact containment
- [x] Negative-height rect brush still hits; anchor at raw origin
- [x] Complexity guards: dense far bars + giant+small size-class (Proxy on `batch.rects` element reads after build)
- [x] Pre-push: tsc, oxlint-type-aware, knip, full bun test suite

## Related

- Follow-up from #264 size-class AABB for CandidateStore extended geometry
- Segments/paths hit-index shortlist deferred
