### PR TITLE
refactor(svelte): extract controller pure canonical helpers

### DIFF
--- a/packages/svelte/src/lib/interaction/controller-canonical.ts
+++ b/packages/svelte/src/lib/interaction/controller-canonical.ts
@@ -1,0 +1,172 @@
+/**
+ * Pure key / scope / domain / interval canonicalization and equality helpers
+ * for createPlotInteraction. No Svelte runes — safe to share and unit-test
+ * independently of the controller factory.
+ */
+import type {
+  PlotInteractionScope,
+  ReadonlyIntervalDomains,
+  ScopedInteractionDomain,
+  ScopedInteractionInterval,
+  ScopedInteractionKeys,
+} from "./interaction.js";
+
+/** Mutation scope: bare keys string or full PlotInteractionScope. */
+export type KeyScope = string | PlotInteractionScope;
+
+export function assertScope(value: string, channel: string): void {
+  if (value.length === 0)
+    throw new TypeError(`Interaction ${channel} scope must be a non-empty string.`);
+}
+
+export function normalizedScope(scope: KeyScope): PlotInteractionScope {
+  const value = typeof scope === "string" ? { keys: scope } : scope;
+  assertScope(value.keys, "keys");
+  if (value.x !== undefined) assertScope(value.x, "x");
+  if (value.y !== undefined) assertScope(value.y, "y");
+  if (value.intervals !== undefined) assertScope(value.intervals, "intervals");
+  return Object.freeze({
+    keys: value.keys,
+    ...(value.x !== undefined && { x: value.x }),
+    ...(value.y !== undefined && { y: value.y }),
+    ...(value.intervals !== undefined && { intervals: value.intervals }),
+  });
+}
+
+export function keyScope(scope: KeyScope): string {
+  return normalizedScope(scope).keys;
+}
+
+export function assertKey(value: unknown): asserts value is PropertyKey {
+  if (typeof value !== "string" && typeof value !== "number" && typeof value !== "symbol")
+    throw new TypeError("Interaction keys must be strings, numbers, or symbols.");
+}
+
+function keyRank(value: PropertyKey): number {
+  return typeof value === "number" ? 0 : typeof value === "string" ? 1 : 2;
+}
+
+function compareKeys(a: PropertyKey, b: PropertyKey): number {
+  const rankDelta = keyRank(a) - keyRank(b);
+  if (rankDelta !== 0) return rankDelta;
+  if (typeof a === "number" && typeof b === "number") {
+    if (Object.is(a, b)) return 0;
+    if (Number.isNaN(a)) return 1;
+    if (Number.isNaN(b)) return -1;
+    return a - b;
+  }
+  const left = typeof a === "symbol" ? (Symbol.keyFor(a) ?? a.description ?? "") : String(a);
+  const right = typeof b === "symbol" ? (Symbol.keyFor(b) ?? b.description ?? "") : String(b);
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+export function canonicalKeys<Key extends PropertyKey>(
+  keys: ReadonlyArray<Key>,
+): ReadonlyArray<Key> {
+  for (const key of keys) assertKey(key);
+  return Object.freeze([...new Set(keys)].toSorted(compareKeys));
+}
+
+export function equalKeys<Key extends PropertyKey>(
+  left: ReadonlyArray<Key>,
+  right: ReadonlyArray<Key>,
+): boolean {
+  if (left.length !== right.length) return false;
+  const values = new Set(right);
+  return left.every((key) => values.has(key));
+}
+
+export function canonicalDomain(domain: readonly [number, number]): readonly [number, number] {
+  const [first, second] = domain;
+  if (!Number.isFinite(first) || !Number.isFinite(second))
+    throw new TypeError("Interaction zoom domains must contain two finite numbers.");
+  return Object.freeze(first <= second ? [first, second] : [second, first]);
+}
+
+function canonicalIntervalAxis(axis: ReadonlyIntervalDomains["x"]): ReadonlyIntervalDomains["x"] {
+  if (axis === undefined) return undefined;
+  if (axis.kind === "band") {
+    if (!Array.isArray(axis.values) || axis.values.length === 0)
+      throw new TypeError("Interaction band intervals must contain at least one encoded value.");
+    for (const value of axis.values) {
+      if (typeof value !== "string")
+        throw new TypeError("Interaction band interval values must be encoded strings.");
+    }
+    return Object.freeze({ kind: "band", values: Object.freeze([...new Set(axis.values)]) });
+  }
+  const domain = canonicalDomain(axis.domain);
+  if (axis.kind === "log" && domain[0] <= 0)
+    throw new TypeError("Interaction log interval domains must contain positive values.");
+  return Object.freeze({ kind: axis.kind, domain });
+}
+
+export function canonicalIntervalDomains(
+  domains: ReadonlyIntervalDomains,
+): ReadonlyIntervalDomains {
+  const x = canonicalIntervalAxis(domains.x);
+  const y = canonicalIntervalAxis(domains.y);
+  if (x === undefined && y === undefined)
+    throw new TypeError("Interaction intervals must contain an x or y domain.");
+  return Object.freeze({ ...(x !== undefined && { x }), ...(y !== undefined && { y }) });
+}
+
+function equalIntervalAxis(
+  left: ReadonlyIntervalDomains["x"],
+  right: ReadonlyIntervalDomains["x"],
+): boolean {
+  if (left === right) return true;
+  if (left === undefined || right === undefined || left.kind !== right.kind) return false;
+  if (left.kind === "band" && right.kind === "band") {
+    return (
+      left.values.length === right.values.length &&
+      left.values.every((value, index) => value === right.values[index])
+    );
+  }
+  if (left.kind === "band" || right.kind === "band") return false;
+  return equalDomain(left.domain, right.domain);
+}
+
+export function equalInterval<Key extends PropertyKey>(
+  left: ScopedInteractionInterval<Key> | undefined,
+  right: ScopedInteractionInterval<Key>,
+): boolean {
+  return (
+    left !== undefined &&
+    left.panelId === right.panelId &&
+    left.preset === right.preset &&
+    equalIntervalAxis(left.domains.x, right.domains.x) &&
+    equalIntervalAxis(left.domains.y, right.domains.y) &&
+    equalKeys(left.keys, right.keys)
+  );
+}
+
+export function equalDomain(
+  left: readonly [number, number] | undefined,
+  right: readonly [number, number] | undefined,
+): boolean {
+  return (
+    left === right ||
+    (left !== undefined &&
+      right !== undefined &&
+      Object.is(left[0], right[0]) &&
+      Object.is(left[1], right[1]))
+  );
+}
+
+export function sortedScopes<T>(values: Map<string, T>): Array<[string, T]> {
+  return [...values].toSorted(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0));
+}
+
+export function scopedKeys<Key extends PropertyKey>(
+  values: Map<string, ReadonlyArray<Key>>,
+): ReadonlyArray<ScopedInteractionKeys<Key>> {
+  return Object.freeze(sortedScopes(values).map(([scope, keys]) => Object.freeze({ scope, keys })));
+}
+
+export function scopedDomains(
+  values: Map<string, readonly [number, number]>,
+): ReadonlyArray<ScopedInteractionDomain> {
+  return Object.freeze(
+    sortedScopes(values).map(([scope, domain]) => Object.freeze({ scope, domain })),
+  );
+}

--- a/packages/svelte/src/lib/interaction/controller.svelte.ts
+++ b/packages/svelte/src/lib/interaction/controller.svelte.ts
@@ -5,14 +5,25 @@ import type {
   PlotInteractionScope,
   PlotInteractionSnapshot,
   PlotInteractionTransition,
-  ReadonlyIntervalDomains,
   ReadonlyZoomDomains,
   ScopedInteractionInterval,
-  ScopedInteractionDomain,
-  ScopedInteractionKeys,
 } from "./interaction.js";
-
-type KeyScope = string | PlotInteractionScope;
+import {
+  assertKey,
+  assertScope,
+  canonicalDomain,
+  canonicalIntervalDomains,
+  canonicalKeys,
+  equalDomain,
+  equalInterval,
+  equalKeys,
+  keyScope,
+  normalizedScope,
+  scopedDomains,
+  scopedKeys,
+  sortedScopes,
+  type KeyScope,
+} from "./controller-canonical.js";
 
 export interface PlotInteractionMutationOptions {
   readonly scope: KeyScope;
@@ -72,145 +83,6 @@ export interface PlotInteractionController<Key extends PropertyKey> {
 
 const EMPTY_KEYS = Object.freeze([]) as readonly never[];
 
-function assertScope(value: string, channel: string): void {
-  if (value.length === 0)
-    throw new TypeError(`Interaction ${channel} scope must be a non-empty string.`);
-}
-
-function normalizedScope(scope: KeyScope): PlotInteractionScope {
-  const value = typeof scope === "string" ? { keys: scope } : scope;
-  assertScope(value.keys, "keys");
-  if (value.x !== undefined) assertScope(value.x, "x");
-  if (value.y !== undefined) assertScope(value.y, "y");
-  if (value.intervals !== undefined) assertScope(value.intervals, "intervals");
-  return Object.freeze({
-    keys: value.keys,
-    ...(value.x !== undefined && { x: value.x }),
-    ...(value.y !== undefined && { y: value.y }),
-    ...(value.intervals !== undefined && { intervals: value.intervals }),
-  });
-}
-
-function keyScope(scope: KeyScope): string {
-  return normalizedScope(scope).keys;
-}
-
-function assertKey(value: unknown): asserts value is PropertyKey {
-  if (typeof value !== "string" && typeof value !== "number" && typeof value !== "symbol")
-    throw new TypeError("Interaction keys must be strings, numbers, or symbols.");
-}
-
-function keyRank(value: PropertyKey): number {
-  return typeof value === "number" ? 0 : typeof value === "string" ? 1 : 2;
-}
-
-function compareKeys(a: PropertyKey, b: PropertyKey): number {
-  const rankDelta = keyRank(a) - keyRank(b);
-  if (rankDelta !== 0) return rankDelta;
-  if (typeof a === "number" && typeof b === "number") {
-    if (Object.is(a, b)) return 0;
-    if (Number.isNaN(a)) return 1;
-    if (Number.isNaN(b)) return -1;
-    return a - b;
-  }
-  const left = typeof a === "symbol" ? (Symbol.keyFor(a) ?? a.description ?? "") : String(a);
-  const right = typeof b === "symbol" ? (Symbol.keyFor(b) ?? b.description ?? "") : String(b);
-  return left < right ? -1 : left > right ? 1 : 0;
-}
-
-function canonicalKeys<Key extends PropertyKey>(keys: ReadonlyArray<Key>): ReadonlyArray<Key> {
-  for (const key of keys) assertKey(key);
-  return Object.freeze([...new Set(keys)].toSorted(compareKeys));
-}
-
-function equalKeys<Key extends PropertyKey>(
-  left: ReadonlyArray<Key>,
-  right: ReadonlyArray<Key>,
-): boolean {
-  if (left.length !== right.length) return false;
-  const values = new Set(right);
-  return left.every((key) => values.has(key));
-}
-
-function canonicalDomain(domain: readonly [number, number]): readonly [number, number] {
-  const [first, second] = domain;
-  if (!Number.isFinite(first) || !Number.isFinite(second))
-    throw new TypeError("Interaction zoom domains must contain two finite numbers.");
-  return Object.freeze(first <= second ? [first, second] : [second, first]);
-}
-
-function canonicalIntervalAxis(axis: ReadonlyIntervalDomains["x"]): ReadonlyIntervalDomains["x"] {
-  if (axis === undefined) return undefined;
-  if (axis.kind === "band") {
-    if (!Array.isArray(axis.values) || axis.values.length === 0)
-      throw new TypeError("Interaction band intervals must contain at least one encoded value.");
-    for (const value of axis.values) {
-      if (typeof value !== "string")
-        throw new TypeError("Interaction band interval values must be encoded strings.");
-    }
-    return Object.freeze({ kind: "band", values: Object.freeze([...new Set(axis.values)]) });
-  }
-  const domain = canonicalDomain(axis.domain);
-  if (axis.kind === "log" && domain[0] <= 0)
-    throw new TypeError("Interaction log interval domains must contain positive values.");
-  return Object.freeze({ kind: axis.kind, domain });
-}
-
-function canonicalIntervalDomains(domains: ReadonlyIntervalDomains): ReadonlyIntervalDomains {
-  const x = canonicalIntervalAxis(domains.x);
-  const y = canonicalIntervalAxis(domains.y);
-  if (x === undefined && y === undefined)
-    throw new TypeError("Interaction intervals must contain an x or y domain.");
-  return Object.freeze({ ...(x !== undefined && { x }), ...(y !== undefined && { y }) });
-}
-
-function equalIntervalAxis(
-  left: ReadonlyIntervalDomains["x"],
-  right: ReadonlyIntervalDomains["x"],
-): boolean {
-  if (left === right) return true;
-  if (left === undefined || right === undefined || left.kind !== right.kind) return false;
-  if (left.kind === "band" && right.kind === "band") {
-    return (
-      left.values.length === right.values.length &&
-      left.values.every((value, index) => value === right.values[index])
-    );
-  }
-  if (left.kind === "band" || right.kind === "band") return false;
-  return equalDomain(left.domain, right.domain);
-}
-
-function equalInterval<Key extends PropertyKey>(
-  left: ScopedInteractionInterval<Key> | undefined,
-  right: ScopedInteractionInterval<Key>,
-): boolean {
-  return (
-    left !== undefined &&
-    left.panelId === right.panelId &&
-    left.preset === right.preset &&
-    equalIntervalAxis(left.domains.x, right.domains.x) &&
-    equalIntervalAxis(left.domains.y, right.domains.y) &&
-    equalKeys(left.keys, right.keys)
-  );
-}
-
-function equalDomain(
-  left: readonly [number, number] | undefined,
-  right: readonly [number, number] | undefined,
-): boolean {
-  return (
-    left === right ||
-    (left !== undefined &&
-      right !== undefined &&
-      Object.is(left[0], right[0]) &&
-      Object.is(left[1], right[1]))
-  );
-}
-
-function sortedScopes<T>(values: Map<string, T>): Array<[string, T]> {
-  return [...values].toSorted(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0));
-}
-
 /** Create chart-independent, semantic interaction state for Svelte 5.
  *
  * The controller owns stable keys and scoped data domains only. A chart is
@@ -234,16 +106,6 @@ export function createPlotInteraction<Key extends PropertyKey = PropertyKey>(
         "PlotInteractionController must not be mutated from its onchange callback. Schedule a later application update instead.",
       );
   };
-
-  const scopedKeys = (
-    values: Map<string, ReadonlyArray<Key>>,
-  ): ReadonlyArray<ScopedInteractionKeys<Key>> =>
-    Object.freeze(sortedScopes(values).map(([scope, keys]) => Object.freeze({ scope, keys })));
-
-  const scopedDomains = (
-    values: Map<string, readonly [number, number]>,
-  ): ReadonlyArray<ScopedInteractionDomain> =>
-    Object.freeze(sortedScopes(values).map(([scope, domain]) => Object.freeze({ scope, domain })));
 
   const scopedIntervals = (): ReadonlyArray<ScopedInteractionInterval<Key>> =>
     Object.freeze(


### PR DESCRIPTION
## Summary

Astral maintain rotate target: **`packages/svelte/src`** (after spec #267).

**Best candidate:** `interaction/controller.svelte.ts` mixed pure key/scope/domain/interval helpers with `createPlotInteraction`.

### Split
| Module | Role |
|---|---|
| `controller-canonical.ts` | `KeyScope`, asserts, canonicalize, equality, scopedKeys/Domains |
| `controller.svelte.ts` | Public controller types + factory; imports pure helpers |

Public `createPlotInteraction` path unchanged (package index + deep import).

### Deferred
- surface/inspection/interval state factories (rune lifecycle)
- inspection/resolver coordinator split

## Test plan
- [x] `bunx vitest run tests/interaction/controller.test.ts tests/interaction/interaction.test.ts` (144 pass)
- [x] knip / pre-push green (svelte-check, type-aware oxlint)
- [ ] Codex timed out after 5.5m; local verification green