### PR TITLE
perf(svelte): O(1) layout-only pin rebind via stored seedId

### DIFF
--- a/packages/svelte/src/lib/inspection/resolver.ts
+++ b/packages/svelte/src/lib/inspection/resolver.ts
@@ -258,6 +258,8 @@ export function createInspectionCoordinator<
   type Slot = Readonly<{
     key: string;
     value: CoordinatedInspection<Row, Key>;
+    /** Candidate id at pin time — O(1) rebind when identityEpoch is unchanged. */
+    seedId: number;
     seedKey: Key | null;
     seedRow: number | null;
     seedKind: CandidateFacts["kind"];
@@ -373,6 +375,7 @@ export function createInspectionCoordinator<
     const slot: Slot = {
       key: cacheKey,
       value,
+      seedId: input.seed.id,
       seedKey: focusKey,
       seedRow: input.seed.rowIndex,
       seedKind: input.seed.kind,
@@ -391,6 +394,24 @@ export function createInspectionCoordinator<
     return value;
   };
 
+  /** Keyless pin match: cheap filters then O(L) logical identity (#229). */
+  const keylessPinMatch = (model: RenderModel, prior: Slot, candidate: CandidateFacts): boolean => {
+    if (candidate.layerIndex !== prior.layerIndex) return false;
+    if (candidate.rowIndex !== prior.seedRow) return false;
+    if (candidate.kind !== prior.seedKind) return false;
+    if (candidate.primitiveIndex !== prior.seedPrimitiveIndex) return false;
+    if (candidateBatchRole(model, candidate) !== prior.seedBatchRole) return false;
+    const logicalIdentity = `${axisToken(candidate.xToken)}|${axisToken(candidate.yToken)}|${model.lineage.keys(candidate.lineage).join(",")}`;
+    return logicalIdentity === prior.seedLogicalIdentity;
+  };
+
+  /** Keyed pin match: layer + non-null row whose keyOf equals the pinned key. */
+  const keyedPinMatch = (model: RenderModel, prior: Slot, candidate: CandidateFacts): boolean => {
+    if (candidate.layerIndex !== prior.layerIndex || candidate.rowIndex === null) return false;
+    const row = model.row(candidate.rowIndex);
+    return row !== null && keyOf(row as Row, candidate.rowIndex) === prior.seedKey;
+  };
+
   const reconcilePinned = (
     input: Readonly<{
       model: RenderModel;
@@ -403,7 +424,22 @@ export function createInspectionCoordinator<
     const prior = pinned;
     if (prior === null) return null;
     let seed: CandidateFacts | null = null;
-    if (prior.seedKey === null) {
+    // Layout-only rebind (same data identity): candidate ids are stable for the
+    // same construction order. O(1) seedId revalidation avoids O(C) store walks.
+    // Uniqueness was proven at pin time; identityEpoch equality preserves it.
+    // On identity change, keyed path still full-scans (ambiguity may appear);
+    // keyless path clears immediately below.
+    if (prior.identityEpoch === input.identityEpoch) {
+      const preferred = input.model.candidates.candidate(prior.seedId);
+      if (preferred !== null) {
+        if (prior.seedKey === null) {
+          if (keylessPinMatch(input.model, prior, preferred)) seed = preferred;
+        } else if (keyedPinMatch(input.model, prior, preferred)) {
+          seed = preferred;
+        }
+      }
+    }
+    if (seed === null && prior.seedKey === null) {
       if (prior.identityEpoch !== input.identityEpoch) {
         pinned = null;
         if (lastSlot === "pinned") {
@@ -416,27 +452,18 @@ export function createInspectionCoordinator<
       const matches: CandidateFacts[] = [];
       for (let id = 0; id < input.model.candidates.size; id++) {
         const candidate = input.model.candidates.candidate(id);
-        // Cheap filters first — lineage.keys join is O(L) and only needed for
-        // survivors that already match layer/row/kind/role/primitive (#229).
         if (candidate === null) continue;
-        if (candidate.layerIndex !== prior.layerIndex) continue;
-        if (candidate.rowIndex !== prior.seedRow) continue;
-        if (candidate.kind !== prior.seedKind) continue;
-        if (candidate.primitiveIndex !== prior.seedPrimitiveIndex) continue;
-        if (candidateBatchRole(input.model, candidate) !== prior.seedBatchRole) continue;
-        const logicalIdentity = `${axisToken(candidate.xToken)}|${axisToken(candidate.yToken)}|${input.model.lineage.keys(candidate.lineage).join(",")}`;
-        if (logicalIdentity !== prior.seedLogicalIdentity) continue;
+        if (!keylessPinMatch(input.model, prior, candidate)) continue;
         matches.push(candidate);
       }
       seed = matches.length === 1 ? matches[0]! : null;
-    } else {
+    } else if (seed === null) {
       const matches: CandidateFacts[] = [];
       for (let id = 0; id < input.model.candidates.size; id++) {
         const candidate = input.model.candidates.candidate(id);
-        if (candidate?.layerIndex !== prior.layerIndex || candidate.rowIndex === null) continue;
-        const row = input.model.row(candidate.rowIndex);
-        if (row !== null && keyOf(row as Row, candidate.rowIndex) === prior.seedKey)
-          matches.push(candidate);
+        if (candidate === null) continue;
+        if (!keyedPinMatch(input.model, prior, candidate)) continue;
+        matches.push(candidate);
       }
       if (matches.length === 1) seed = matches[0]!;
       else if (matches.length > 1) {

--- a/packages/svelte/tests/interaction/unit.test.ts
+++ b/packages/svelte/tests/interaction/unit.test.ts
@@ -906,6 +906,93 @@ describe("semantic inspection resolver", () => {
     resized.dispose();
   });
 
+  // Layout-only rebind (same identityEpoch) must revalidate via stored seedId
+  // instead of scanning every candidate (O(C) keyOf / cheap-filter walk).
+  it("does not scan every candidate on layout-only keyed pin rebind", () => {
+    const count = 2_000;
+    const data = Array.from({ length: count }, (_, index) => ({
+      id: `r${index}`,
+      x: index,
+      y: (index % 11) + 1,
+    }));
+    const makeModel = (width: number) =>
+      runPipeline(
+        gg(data, aes({ x: "x", y: "y" }))
+          .geomPoint()
+          .spec(),
+        { width, height: 300 },
+      );
+    const first = makeModel(400);
+    const resized = makeModel(700);
+    expect(resized.candidates.size).toBe(count);
+
+    const coordinator = createInspectionCoordinator((row) => (row as { id: string }).id);
+    coordinator.resolve({
+      model: first,
+      seed: first.candidates.candidate(0)!,
+      mode: "exact",
+      state: "pinned",
+      source: "pointer",
+      identityEpoch: "layout-stable",
+      layoutEpoch: 1,
+    });
+
+    const candidateSpy = vi.spyOn(resized.candidates, "candidate");
+    const reconciled = coordinator.reconcilePinned({
+      model: resized,
+      identityEpoch: "layout-stable",
+      layoutEpoch: 2,
+    });
+    expect(reconciled).not.toBeNull();
+    expect(reconciled!.snapshot.focus.key).toBe("r0");
+    // seedId O(1) + materialize; a full rebind walk is ~C candidate() lookups.
+    expect(candidateSpy.mock.calls.length).toBeLessThan(32);
+    expect(candidateSpy.mock.calls.length).toBeLessThan(count / 20);
+    first.dispose();
+    resized.dispose();
+  });
+
+  it("does not scan every candidate on layout-only keyless pin rebind", () => {
+    const count = 2_000;
+    const data = Array.from({ length: count }, (_, index) => ({
+      id: `r${index}`,
+      x: index,
+      y: (index % 11) + 1,
+    }));
+    const makeModel = (width: number) =>
+      runPipeline(
+        gg(data, aes({ x: "x", y: "y" }))
+          .geomPoint()
+          .spec(),
+        { width, height: 300 },
+      );
+    const first = makeModel(400);
+    const resized = makeModel(700);
+
+    const coordinator = createInspectionCoordinator(() => null);
+    coordinator.resolve({
+      model: first,
+      seed: first.candidates.candidate(7)!,
+      mode: "exact",
+      state: "pinned",
+      source: "pointer",
+      identityEpoch: "layout-stable",
+      layoutEpoch: 1,
+    });
+
+    const candidateSpy = vi.spyOn(resized.candidates, "candidate");
+    const reconciled = coordinator.reconcilePinned({
+      model: resized,
+      identityEpoch: "layout-stable",
+      layoutEpoch: 2,
+    });
+    expect(reconciled).not.toBeNull();
+    expect(candidateSpy.mock.calls.length).toBeLessThan(32);
+    expect(candidateSpy.mock.calls.length).toBeLessThan(count / 20);
+    first.dispose();
+    resized.dispose();
+  });
+
   // uniqueKeysFromRowIndexes builds one membership Set for the lineage walk
   // (issue #200). Array#includes-based first-seen would construct zero Sets.
   it("allocates a membership Set when materializing aggregate sourceKeys", () => {


### PR DESCRIPTION
## Summary

- **Audit target:** `packages/svelte/src` (bigo-maintain rotation; nextIndex=1)
- **Finding:** `createInspectionCoordinator.reconcilePinned` scanned every candidate **O(C)** on each scene rebind (layout resize and data change). C = mark count.
- **Fix:** Store `seedId` on the pinned slot. When `identityEpoch` is unchanged (layout-only), revalidate with a single `candidate(seedId)` lookup — O(1). Fall back to the existing full scan when the id misses or for keyed identity changes that may introduce key ambiguity. Keyless identity changes still clear the pin immediately.
- **Complexity:** Layout-only rebind **O(C) → O(1)**; identity-change keyed rebind still O(C) for uniqueness (correctness).

## Test plan

- [x] `vitest run tests/interaction/unit.test.ts` — 90 pass (incl. existing reconcile characterization)
- [x] Complexity guards: layout-only keyed + keyless with C=2000 spy `candidates.candidate` call count ≪ C
- [x] Pre-push suite green

## Related

- Follow-up from bigo-maintain notes (reconcilePinned keyed scan)
- Keyless cheap filters before lineage join (#229) preserved via shared match helpers
