### PR TITLE
fix(svelte): require role match on keyed seedId pin rebind

### DIFF
--- a/packages/svelte/src/lib/inspection/resolver.ts
+++ b/packages/svelte/src/lib/inspection/resolver.ts
@@ -412,6 +412,18 @@ export function createInspectionCoordinator<
     return row !== null && keyOf(row as Row, candidate.rowIndex) === prior.seedKey;
   };
 
+  /**
+   * Strict keyed rebind for the seedId fast path: key match plus kind / batch
+   * role / primitive (same filters as multi-match disambiguation). Same-epoch
+   * is not always pure layout — layer-prop swaps can keep the identity token
+   * while changing primitives that reuse an id (Codex #272 P2).
+   */
+  const keyedPinRoleMatch = (model: RenderModel, prior: Slot, candidate: CandidateFacts): boolean =>
+    keyedPinMatch(model, prior, candidate) &&
+    candidate.kind === prior.seedKind &&
+    candidate.primitiveIndex === prior.seedPrimitiveIndex &&
+    candidateBatchRole(model, candidate) === prior.seedBatchRole;
+
   const reconcilePinned = (
     input: Readonly<{
       model: RenderModel;
@@ -424,17 +436,17 @@ export function createInspectionCoordinator<
     const prior = pinned;
     if (prior === null) return null;
     let seed: CandidateFacts | null = null;
-    // Layout-only rebind (same data identity): candidate ids are stable for the
-    // same construction order. O(1) seedId revalidation avoids O(C) store walks.
-    // Uniqueness was proven at pin time; identityEpoch equality preserves it.
-    // On identity change, keyed path still full-scans (ambiguity may appear);
-    // keyless path clears immediately below.
+    // Same identityEpoch: O(1) seedId revalidation when id + role still match.
+    // Keyed path requires kind/batch/primitive (not only layer+key) so geom
+    // swaps that reuse seedId cannot pin the wrong primitive. Fall through to
+    // full scan on miss. Identity-change keyed still full-scans for ambiguity;
+    // keyless identity-change clears immediately below.
     if (prior.identityEpoch === input.identityEpoch) {
       const preferred = input.model.candidates.candidate(prior.seedId);
       if (preferred !== null) {
         if (prior.seedKey === null) {
           if (keylessPinMatch(input.model, prior, preferred)) seed = preferred;
-        } else if (keyedPinMatch(input.model, prior, preferred)) {
+        } else if (keyedPinRoleMatch(input.model, prior, preferred)) {
           seed = preferred;
         }
       }

--- a/packages/svelte/tests/interaction/unit.test.ts
+++ b/packages/svelte/tests/interaction/unit.test.ts
@@ -952,6 +952,49 @@ describe("semantic inspection resolver", () => {
     resized.dispose();
   });
 
+  // Same identityEpoch can still change primitives (layer-prop geom swap).
+  // Fast path must require kind/batch/primitive, not only layer+key (#272 P2).
+  it("rejects keyed seedId fast path when primitive role no longer matches", () => {
+    const data = [{ id: "a", x: 1, y: 2, ymin: 1, ymax: 3 }];
+    const points = runPipeline(
+      gg(data, aes({ x: "x", y: "y" }))
+        .geomPoint()
+        .spec(),
+      { width: 400, height: 300 },
+    );
+    const errorbars = runPipeline(
+      gg(data, aes({ x: "x", y: "y", ymin: "ymin", ymax: "ymax" }))
+        .geomErrorbar()
+        .spec(),
+      { width: 400, height: 300 },
+    );
+    const coordinator = createInspectionCoordinator((row) => (row as { id: string }).id);
+    const seed = points.candidates.candidate(0)!;
+    expect(seed.kind).toBe("points");
+    coordinator.resolve({
+      model: points,
+      seed,
+      mode: "exact",
+      state: "pinned",
+      source: "pointer",
+      identityEpoch: "same-epoch",
+      layoutEpoch: 1,
+    });
+    // Same epoch token, different geom at seedId — role mismatch must not pin.
+    const atSameId = errorbars.candidates.candidate(seed.id);
+    expect(atSameId).not.toBeNull();
+    expect(atSameId!.kind).not.toBe("points");
+    const reconciled = coordinator.reconcilePinned({
+      model: errorbars,
+      identityEpoch: "same-epoch",
+      layoutEpoch: 2,
+    });
+    // Full scan finds no points-role match for key "a" → clear pin.
+    expect(reconciled).toBeNull();
+    points.dispose();
+    errorbars.dispose();
+  });
+
   it("does not scan every candidate on layout-only keyless pin rebind", () => {
     const count = 2_000;
     const data = Array.from({ length: count }, (_, index) => ({


### PR DESCRIPTION
## Summary

Follow-up to #272 (Codex P2): keyed `seedId` fast path for `reconcilePinned` accepted a candidate when only layer + key matched. Same `identityEpoch` is not always pure layout — layer-prop geom swaps can keep the epoch token while changing primitives that reuse an id.

**Fix:** require kind / batch role / primitive (same filters as multi-match disambiguation) on the keyed O(1) path. Miss falls through to the full scan (may clear the pin).

## Test plan

- [x] New test: point → errorbar same epoch + key, different kind → pin clears
- [x] Existing layout-only O(1) complexity guards still green
- [x] `vitest run tests/interaction/unit.test.ts` — 93 pass
