### PR TITLE
perf(svelte): O(log C+k) hit-to-candidate rematch via spatial shortlist

### DIFF
--- a/packages/svelte/src/lib/inspection/inspection-state.svelte.ts
+++ b/packages/svelte/src/lib/inspection/inspection-state.svelte.ts
@@ -47,7 +47,6 @@ import {
   planCycleCoincident,
   planDirectionalNavigate,
 } from "../surface/plot-px.js";
-import { iterateCandidates } from "../selection/selection.js";
 import {
   buildInspectionCandidateRef,
   resolveQueuedInspectFrameAction,
@@ -203,7 +202,10 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
   function candidateFromHit(hit: SceneHit): CandidateFacts | null {
     const model = deps.model();
     if (model === null) return null;
-    return matchCandidateFromHit(iterateCandidates(model.candidates), hit);
+    // Spatial shortlist via CandidateStore.queryRect (O(log C + k)); do not
+    // walk iterateCandidates O(C) on large charts.
+    const panelId = model.scene.panels[hit.panelIndex]?.id;
+    return matchCandidateFromHit(model.candidates, hit, undefined, panelId);
   }
 
   function resolveInspection(

--- a/packages/svelte/src/lib/surface/plot-px.ts
+++ b/packages/svelte/src/lib/surface/plot-px.ts
@@ -45,25 +45,73 @@ export function hitFromCandidate(candidate: CandidateFacts): SceneHit {
 export const CANDIDATE_HIT_TOLERANCE = 0.5;
 
 /**
+ * Spatial candidate store surface for hit→facts rematch.
+ * `queryRect` shortlists by anchor/extended AABB (O(log C + k)); `candidate`
+ * materializes facts. Production uses the real CandidateStore.
+ */
+export type SpatialCandidateSource = {
+  queryRect(
+    x0: number,
+    y0: number,
+    x1: number,
+    y1: number,
+    panelId?: string,
+  ): Uint32Array | readonly number[];
+  candidate(id: number): CandidateFacts | null;
+};
+
+function isSpatialCandidateSource(
+  value: Iterable<CandidateFacts> | SpatialCandidateSource,
+): value is SpatialCandidateSource {
+  if (typeof value !== "object" || value === null) return false;
+  const record = value as Record<string, unknown>;
+  return typeof record["queryRect"] === "function" && typeof record["candidate"] === "function";
+}
+
+function candidateMatchesHit(candidate: CandidateFacts, hit: SceneHit, tolerance: number): boolean {
+  return (
+    candidate.layerIndex === hit.layerIndex &&
+    candidate.panelIndex === hit.panelIndex &&
+    candidate.rowIndex === hit.rowIndex &&
+    candidate.kind === hit.kind &&
+    Math.abs(candidate.x - hit.x) < tolerance &&
+    Math.abs(candidate.y - hit.y) < tolerance
+  );
+}
+
+/**
  * Find the first candidate matching a SceneHit identity + proximity.
- * Iteration order is caller-owned (production walks id-ascending).
+ *
+ * - **Iterable:** caller-owned order (production used id-ascending walks).
+ * - **Spatial store:** `queryRect` shortlist around the hit, then exact filters
+ *   — O(log C + k) instead of O(C). Prefer this on large charts.
+ *
  * Tolerance is exclusive: |Δ| < tol matches; |Δ| === tol does not.
+ * Optional `panelId` scopes the spatial shortlist (store panel filter).
  */
 export function matchCandidateFromHit(
-  candidates: Iterable<CandidateFacts>,
+  candidates: Iterable<CandidateFacts> | SpatialCandidateSource,
   hit: SceneHit,
   tolerance: number = CANDIDATE_HIT_TOLERANCE,
+  panelId?: string,
 ): CandidateFacts | null {
+  if (isSpatialCandidateSource(candidates)) {
+    const ids = candidates.queryRect(
+      hit.x - tolerance,
+      hit.y - tolerance,
+      hit.x + tolerance,
+      hit.y + tolerance,
+      panelId,
+    );
+    // Store queryRect orders by traversal rank (id-ascending among hits).
+    for (const id of ids) {
+      const candidate = candidates.candidate(id);
+      if (candidate !== null && candidateMatchesHit(candidate, hit, tolerance)) return candidate;
+    }
+    return null;
+  }
   for (const candidate of candidates) {
-    if (
-      candidate.layerIndex === hit.layerIndex &&
-      candidate.panelIndex === hit.panelIndex &&
-      candidate.rowIndex === hit.rowIndex &&
-      candidate.kind === hit.kind &&
-      Math.abs(candidate.x - hit.x) < tolerance &&
-      Math.abs(candidate.y - hit.y) < tolerance
-    )
-      return candidate;
+    if (candidateMatchesHit(candidate, hit, tolerance)) return candidate;
   }
   return null;
 }

--- a/packages/svelte/tests/surface/plot-px.test.ts
+++ b/packages/svelte/tests/surface/plot-px.test.ts
@@ -429,4 +429,54 @@ describe("matchCandidateFromHit", () => {
       matchCandidateFromHit(candidates, hit(10, 20, { rowIndex: 1, kind: "point" })),
     ).toBeNull();
   });
+
+  it("spatial shortlist does not materialize every far candidate", () => {
+    // Complexity: linear Iterable walk is O(C); SpatialCandidateSource uses
+    // queryRect shortlist then O(k) candidate() materializations.
+    const count = 4_000;
+    const xs = new Float64Array(count);
+    const ys = new Float64Array(count);
+    const facts: CandidateFacts[] = [];
+    for (let i = 0; i < count; i++) {
+      const col = i % 50;
+      const row = Math.floor(i / 50);
+      const x = 100 + col * 10;
+      const y = 100 + row * 10;
+      xs[i] = x;
+      ys[i] = y;
+      facts.push(asCandidate({ id: i, x, y, rowIndex: i }));
+    }
+    // One candidate under the probe at (10, 20).
+    xs[0] = 10;
+    ys[0] = 20;
+    facts[0] = asCandidate({ id: 0, x: 10, y: 20, rowIndex: 1 });
+
+    let candidateCalls = 0;
+    const spatial = {
+      queryRect(x0: number, y0: number, x1: number, y1: number): number[] {
+        const out: number[] = [];
+        for (let i = 0; i < count; i++) {
+          const x = xs[i];
+          const y = ys[i];
+          if (x >= x0 && x <= x1 && y >= y0 && y <= y1) out.push(i);
+        }
+        return out;
+      },
+      candidate(id: number): CandidateFacts | null {
+        candidateCalls++;
+        return facts[id] ?? null;
+      },
+    };
+
+    candidateCalls = 0;
+    const matched = matchCandidateFromHit(spatial, hit(10, 20, { rowIndex: 1 }));
+    expect(matched?.id).toBe(0);
+    // Shortlist is tiny; linear walk would call candidate() ~count times.
+    expect(candidateCalls).toBeLessThan(16);
+    expect(candidateCalls).toBeLessThan(count / 50);
+
+    candidateCalls = 0;
+    expect(matchCandidateFromHit(spatial, hit(50, 50, { rowIndex: 1 }))).toBeNull();
+    expect(candidateCalls).toBe(0);
+  });
 });


### PR DESCRIPTION
## Summary

- **Audit target:** `packages/svelte/src` (bigo-maintain rotation; nextIndex=1)
- **Finding:** `matchCandidateFromHit` walked every candidate **O(C)** when rematching a SceneHit to CandidateFacts (inspection fallback without a pre-resolved candidate).
- **Fix:** Accept either an `Iterable` (existing tests) or a **spatial store** (`queryRect` + `candidate`). Spatial path shortlists with `queryRect` around the hit, then exact identity/proximity filters — **O(log C + k)**. `inspection-state.candidateFromHit` now passes `model.candidates` + panel id (no `iterateCandidates` walk).
- **Complexity:** O(C) → **O(log C + k)** on the production rematch path.

## Test plan

- [x] Existing matchCandidateFromHit characterization tests green
- [x] Complexity: spatial shortlist spy — `candidate()` calls ≪ C on dense far field
- [x] inspection-state tests green
- [x] Pre-push suite green
