### PR TITLE
refactor(core): extract categorical palettes from scales/train.ts

### DIFF
--- a/packages/core/src/scales/categorical-palettes.ts
+++ b/packages/core/src/scales/categorical-palettes.ts
@@ -1,0 +1,81 @@
+/**
+ * Named categorical color palettes and scheme registry for ordinal color
+ * scales. Pure data — training lives in train.ts.
+ */
+/**
+ * Default categorical palette: 10 colors in the Observable 10 family.
+ * The palette is a plain value — its fingerprint (not its identity) keys
+ * scale-state invalidation.
+ */
+export const CATEGORICAL_PALETTE_10: readonly string[] = [
+  "#4269d0",
+  "#efb118",
+  "#ff725c",
+  "#6cc5b0",
+  "#3ca951",
+  "#ff8ab7",
+  "#a463f2",
+  "#97bbf5",
+  "#9c6b4e",
+  "#9498a0",
+];
+
+/** hrbrthemes::ipsum_palette, in its published source order. */
+export const IPSUM_PALETTE: readonly string[] = [
+  "#d18975",
+  "#8fd175",
+  "#3f2d54",
+  "#75b8d1",
+  "#2d543d",
+  "#c9d175",
+  "#d1ab75",
+  "#d175b8",
+  "#758bd1",
+];
+
+/** hrbrthemes::flexoki_light, the light-background qualitative palette. */
+export const FLEXOKI_PALETTE: readonly string[] = [
+  "#D14D41",
+  "#DA702C",
+  "#D0A215",
+  "#879A39",
+  "#3AA99F",
+  "#4385BE",
+  "#8B7EC8",
+  "#CE5D97",
+];
+
+/** ggthemes' regular "Tableau 10" palette. */
+export const TABLEAU10_PALETTE: readonly string[] = [
+  "#4E79A7",
+  "#F28E2B",
+  "#E15759",
+  "#76B7B2",
+  "#59A14F",
+  "#EDC948",
+  "#B07AA1",
+  "#FF9DA7",
+  "#9C755F",
+  "#BAB0AC",
+];
+
+/** ggthemes' eight-color qualitative colorblind-safe palette. */
+export const COLORBLIND_PALETTE: readonly string[] = [
+  "#000000",
+  "#E69F00",
+  "#56B4E9",
+  "#009E73",
+  "#F0E442",
+  "#0072B2",
+  "#D55E00",
+  "#CC79A7",
+];
+
+/** Named categorical schemes accepted by the portable spec. */
+export const CATEGORICAL_SCHEMES = {
+  observable10: CATEGORICAL_PALETTE_10,
+  ipsum: IPSUM_PALETTE,
+  flexoki: FLEXOKI_PALETTE,
+  tableau10: TABLEAU10_PALETTE,
+  colorblind: COLORBLIND_PALETTE,
+} as const satisfies Readonly<Record<string, readonly string[]>>;

--- a/packages/core/src/scales/train.ts
+++ b/packages/core/src/scales/train.ts
@@ -22,83 +22,18 @@ import { VIRIDIS_RAMP_10 } from "./color.js";
 import type { ScaleState, ScaleWarning, TrainResult } from "./state.js";
 import { encodeKey, trainDiscrete } from "./state.js";
 
-/**
- * Default categorical palette: 10 colors in the Observable 10 family.
- * The palette is a plain value — its fingerprint (not its identity) keys
- * scale-state invalidation.
- */
-export const CATEGORICAL_PALETTE_10: readonly string[] = [
-  "#4269d0",
-  "#efb118",
-  "#ff725c",
-  "#6cc5b0",
-  "#3ca951",
-  "#ff8ab7",
-  "#a463f2",
-  "#97bbf5",
-  "#9c6b4e",
-  "#9498a0",
-];
+import { CATEGORICAL_PALETTE_10, CATEGORICAL_SCHEMES } from "./categorical-palettes.js";
 
-/** hrbrthemes::ipsum_palette, in its published source order. */
-export const IPSUM_PALETTE: readonly string[] = [
-  "#d18975",
-  "#8fd175",
-  "#3f2d54",
-  "#75b8d1",
-  "#2d543d",
-  "#c9d175",
-  "#d1ab75",
-  "#d175b8",
-  "#758bd1",
-];
-
-/** hrbrthemes::flexoki_light, the light-background qualitative palette. */
-export const FLEXOKI_PALETTE: readonly string[] = [
-  "#D14D41",
-  "#DA702C",
-  "#D0A215",
-  "#879A39",
-  "#3AA99F",
-  "#4385BE",
-  "#8B7EC8",
-  "#CE5D97",
-];
-
-/** ggthemes' regular "Tableau 10" palette. */
-export const TABLEAU10_PALETTE: readonly string[] = [
-  "#4E79A7",
-  "#F28E2B",
-  "#E15759",
-  "#76B7B2",
-  "#59A14F",
-  "#EDC948",
-  "#B07AA1",
-  "#FF9DA7",
-  "#9C755F",
-  "#BAB0AC",
-];
-
-/** ggthemes' eight-color qualitative colorblind-safe palette. */
-export const COLORBLIND_PALETTE: readonly string[] = [
-  "#000000",
-  "#E69F00",
-  "#56B4E9",
-  "#009E73",
-  "#F0E442",
-  "#0072B2",
-  "#D55E00",
-  "#CC79A7",
-];
-
-/** Named categorical schemes accepted by the portable spec. */
-export const CATEGORICAL_SCHEMES = {
-  observable10: CATEGORICAL_PALETTE_10,
-  ipsum: IPSUM_PALETTE,
-  flexoki: FLEXOKI_PALETTE,
-  tableau10: TABLEAU10_PALETTE,
-  colorblind: COLORBLIND_PALETTE,
-} as const satisfies Readonly<Record<string, readonly string[]>>;
+// Stable public path: re-export palettes so index/editions/tests keep
+// importing from ./scales/train.js (same ES binding for identity === checks).
+export {
+  CATEGORICAL_PALETTE_10,
+  CATEGORICAL_SCHEMES,
+  COLORBLIND_PALETTE,
+  FLEXOKI_PALETTE,
+  IPSUM_PALETTE,
+  TABLEAU10_PALETTE,
+} from "./categorical-palettes.js";
 
 function rangeForScheme(scheme: string | undefined): readonly string[] | undefined {
   if (scheme === "viridis") return VIRIDIS_RAMP_10;


### PR DESCRIPTION
## Summary

Astral maintain rotate target: **`packages/core/src`** (after svelte #271).

**Best candidate:** `scales/train.ts` mixed pure categorical palette tables with scale training algorithms.

### Split
| Module | Role |
|---|---|
| `scales/categorical-palettes.ts` | Named palettes + `CATEGORICAL_SCHEMES` (dependency-free leaf) |
| `scales/train.ts` | Scale types, train*, re-exports palettes |

Public `./scales/train.js` path unchanged — same ES bindings preserve
`editionDefaults.categoricalPalette === CATEGORICAL_PALETTE_10` identity checks.

### Deferred
- canvas points/paths extract
- hit-index (active perf surface)
- candidate-store-eager (cohesive builder)

## Test plan
- [x] `bun test packages/core` (655 pass)
- [x] knip / pre-push green