### PR TITLE
perf(core): O(log P+k) path hit shortlist via subpath AABB + vertex tree

### DIFF
--- a/packages/core/src/dom/hit-index.ts
+++ b/packages/core/src/dom/hit-index.ts
@@ -16,10 +16,11 @@
  *  - segments: size-classed AABB-center shortlist (endpoint box), then exact
  *    point-to-segment distance <= linewidth/2 + tolerance. Same size-class
  *    pattern as rects so one long rule cannot expand every short-segment query.
- *  - stroked paths (lines): per-edge point-to-segment distance, same rule
- *    (linear per subpath for now — follow-up shortlist).
- *  - filled paths (areas/ribbons): even-odd point-in-polygon containment;
- *    the reported row is the nearest subpath vertex's row.
+ *  - stroked paths (lines): size-classed subpath AABB shortlist, then per-edge
+ *    point-to-segment distance (pad by linewidth/2 + tolerance).
+ *  - filled paths (areas/ribbons): size-classed subpath AABB shortlist, then
+ *    even-odd point-in-polygon; the reported row is the nearest vertex's row.
+ *    queryRect uses a vertex StaticQuadtree (O(log V + k)).
  *  - glyphs (text): NOT hit targets in M2 (documented limitation — labels
  *    annotate marks; hovering the mark is the interaction).
  *
@@ -276,6 +277,62 @@ function buildSegmentsIndex(
   return buildAabbIndex(minX, minY, maxX, maxY);
 }
 
+/** Subpath AABB shortlist + vertex tree for brush queries (plot px). */
+interface PathsIndexEntry {
+  readonly subpaths: AabbIndexEntry;
+  readonly vertices: PointsIndexEntry;
+}
+
+function buildPathsIndex(
+  batch: Extract<GeometryBatch, { kind: "paths" }>,
+  panel: ScenePanel,
+): PathsIndexEntry {
+  const nSub = Math.max(0, batch.pathOffsets.length - 1);
+  const minX = new Float64Array(nSub);
+  const minY = new Float64Array(nSub);
+  const maxX = new Float64Array(nSub);
+  const maxY = new Float64Array(nSub);
+  for (let s = 0; s < nSub; s++) {
+    const start = batch.pathOffsets[s]!;
+    const end = batch.pathOffsets[s + 1]!;
+    let sMinX = Infinity;
+    let sMinY = Infinity;
+    let sMaxX = -Infinity;
+    let sMaxY = -Infinity;
+    for (let i = start; i < end; i++) {
+      const vx = panel.x + batch.positions[i * 2]!;
+      const vy = panel.y + batch.positions[i * 2 + 1]!;
+      if (vx < sMinX) sMinX = vx;
+      if (vy < sMinY) sMinY = vy;
+      if (vx > sMaxX) sMaxX = vx;
+      if (vy > sMaxY) sMaxY = vy;
+    }
+    if (end <= start) {
+      // Empty subpath: degenerate AABB at origin (never matches finite queries).
+      minX[s] = 0;
+      minY[s] = 0;
+      maxX[s] = 0;
+      maxY[s] = 0;
+    } else {
+      minX[s] = sMinX;
+      minY[s] = sMinY;
+      maxX[s] = sMaxX;
+      maxY[s] = sMaxY;
+    }
+  }
+  const nVert = batch.rowIndex.length;
+  const xs = new Float64Array(nVert);
+  const ys = new Float64Array(nVert);
+  for (let i = 0; i < nVert; i++) {
+    xs[i] = panel.x + batch.positions[i * 2]!;
+    ys[i] = panel.y + batch.positions[i * 2 + 1]!;
+  }
+  return {
+    subpaths: buildAabbIndex(minX, minY, maxX, maxY),
+    vertices: { quadtree: new StaticQuadtree(xs, ys), xs, ys },
+  };
+}
+
 /**
  * Primitive indices whose AABB intersects [loX,hiX]×[loY,hiY] (plot px).
  * Optional pad expands the query (stroke slop around segments).
@@ -319,10 +376,11 @@ export function buildHitIndex(scene: Scene, options: HitIndexOptions = {}): Scen
   const tolerance = options.tolerance ?? DEFAULT_HIT_TOLERANCE;
   const panels = scene.panels;
 
-  // Per points-batch quadtrees; per rects/segments size-classed AABB trees.
+  // Per points-batch quadtrees; per rects/segments/paths size-classed AABB trees.
   const pointsIndex = new Map<GeometryBatch, PointsIndexEntry>();
   const rectsIndex = new Map<GeometryBatch, AabbIndexEntry>();
   const segmentsIndex = new Map<GeometryBatch, AabbIndexEntry>();
+  const pathsIndex = new Map<GeometryBatch, PathsIndexEntry>();
   for (const batch of scene.batches) {
     const panel = panels[batch.panelIndex];
     if (panel === undefined) continue;
@@ -339,6 +397,8 @@ export function buildHitIndex(scene: Scene, options: HitIndexOptions = {}): Scen
       rectsIndex.set(batch, buildRectsIndex(batch, panel));
     } else if (batch.kind === "segments") {
       segmentsIndex.set(batch, buildSegmentsIndex(batch, panel));
+    } else if (batch.kind === "paths") {
+      pathsIndex.set(batch, buildPathsIndex(batch, panel));
     }
   }
 
@@ -427,38 +487,50 @@ export function buildHitIndex(scene: Scene, options: HitIndexOptions = {}): Scen
         };
       }
       case "paths": {
+        // Size-class subpath AABB shortlist, then exact fill/stroke; topmost = highest s.
+        const entry = pathsIndex.get(batch);
+        if (entry === undefined) return null;
         const filled = batch.fills !== undefined;
-        for (let s = batch.pathOffsets.length - 2; s >= 0; s--) {
+        const pad = filled ? 0 : batch.linewidth / 2 + tolerance;
+        let bestS = -1;
+        let bestVertex = -1;
+        for (const s of shortlistAabbIntersecting(entry.subpaths, x, y, x, y, pad)) {
           const start = batch.pathOffsets[s]!;
           const end = batch.pathOffsets[s + 1]!;
           if (end <= start) continue;
           if (filled) {
             if (!pointInSubpath(batch, start, end, lx, ly)) continue;
-            // Nearest vertex's row anchors the hit (areas span many rows).
-            const best = nearestVertex(batch, start, end, lx, ly);
-            return {
-              layerIndex: batch.layerIndex,
-              panelIndex: batch.panelIndex,
-              rowIndex: rowOf(batch.rowIndex[best]!),
-              x: x,
-              y: y,
-              kind: "paths",
-            };
-          }
-          // Stroked line: per-edge proximity with the documented tolerance.
-          const at = nearestStrokeVertex(batch, start, end, lx, ly, tolerance);
-          if (at !== -1) {
-            return {
-              layerIndex: batch.layerIndex,
-              panelIndex: batch.panelIndex,
-              rowIndex: rowOf(batch.rowIndex[at]!),
-              x: panel.x + batch.positions[at * 2]!,
-              y: panel.y + batch.positions[at * 2 + 1]!,
-              kind: "paths",
-            };
+            if (s > bestS) {
+              bestS = s;
+              bestVertex = nearestVertex(batch, start, end, lx, ly);
+            }
+          } else {
+            const at = nearestStrokeVertex(batch, start, end, lx, ly, tolerance);
+            if (at !== -1 && s > bestS) {
+              bestS = s;
+              bestVertex = at;
+            }
           }
         }
-        return null;
+        if (bestS < 0 || bestVertex < 0) return null;
+        if (filled) {
+          return {
+            layerIndex: batch.layerIndex,
+            panelIndex: batch.panelIndex,
+            rowIndex: rowOf(batch.rowIndex[bestVertex]!),
+            x: x,
+            y: y,
+            kind: "paths",
+          };
+        }
+        return {
+          layerIndex: batch.layerIndex,
+          panelIndex: batch.panelIndex,
+          rowIndex: rowOf(batch.rowIndex[bestVertex]!),
+          x: panel.x + batch.positions[bestVertex * 2]!,
+          y: panel.y + batch.positions[bestVertex * 2 + 1]!,
+          kind: "paths",
+        };
       }
       case "glyphs":
         // Text marks are not hit targets in M2 (module docs).
@@ -539,12 +611,11 @@ export function buildHitIndex(scene: Scene, options: HitIndexOptions = {}): Scen
             break;
           }
           case "paths": {
-            for (let i = 0; i < batch.rowIndex.length; i++) {
-              const vx = panel.x + batch.positions[i * 2]!;
-              const vy = panel.y + batch.positions[i * 2 + 1]!;
-              if (vx >= lo.x && vx <= hi.x && vy >= lo.y && vy <= hi.y) {
-                push(batch, batch.rowIndex[i]!, vx, vy);
-              }
+            // Vertex quadtree shortlist (same brush membership as linear scan).
+            const entry = pathsIndex.get(batch);
+            if (entry === undefined) break;
+            for (const i of entry.vertices.quadtree.queryRect(lo.x, lo.y, hi.x, hi.y)) {
+              push(batch, batch.rowIndex[i]!, entry.vertices.xs[i]!, entry.vertices.ys[i]!);
             }
             break;
           }

--- a/packages/core/tests/hit-index.test.ts
+++ b/packages/core/tests/hit-index.test.ts
@@ -79,6 +79,37 @@ function segmentScene(
   ]);
 }
 
+/**
+ * Synthetic multi-subpath line batch. `pathOffsets` length = subpathCount + 1.
+ * Positions are panel-local interleaved x,y.
+ */
+function pathScene(
+  positions: Float32Array,
+  pathOffsets: Uint32Array,
+  options: {
+    linewidth?: number;
+    rowIndex?: Uint32Array;
+    fills?: (string | null)[];
+  } = {},
+): Scene {
+  const n = positions.length / 2;
+  return basePanelScene([
+    {
+      kind: "paths",
+      layerIndex: 0,
+      panelIndex: 0,
+      positions,
+      rowIndex: options.rowIndex ?? Uint32Array.from({ length: n }, (_, i) => i),
+      pathOffsets,
+      strokes: Array.from({ length: pathOffsets.length - 1 }, () => null),
+      ...(options.fills !== undefined && { fills: options.fills }),
+      linewidth: options.linewidth ?? 1,
+      alpha: 1,
+      curve: "linear",
+    },
+  ]);
+}
+
 /** Count numeric index reads on a Float32Array (complexity guard). */
 function instrumentReads(source: Float32Array): {
   view: Float32Array;
@@ -499,6 +530,125 @@ describe("buildHitIndex", () => {
     expect(brushed.map((h) => h.rowIndex)).toEqual([0]);
     expect(instrumented.reads()).toBeLessThan(32);
     expect(instrumented.reads()).toBeLessThan(count / 20);
+  });
+
+  it("paths topmost subpath wins when stacked strokes overlap", () => {
+    // Two horizontal strokes at the same y; later subpath is topmost.
+    const positions = new Float32Array([
+      10,
+      50,
+      100,
+      50, // subpath 0
+      10,
+      50,
+      100,
+      50, // subpath 1
+    ]);
+    const pathOffsets = new Uint32Array([0, 2, 4]);
+    const scene = pathScene(positions, pathOffsets, { linewidth: 2 });
+    const index = buildHitIndex(scene, { tolerance: 2 });
+    const hit = index.hitTest(50, 50);
+    expect(hit?.kind).toBe("paths");
+    expect(hit?.rowIndex).toBe(2); // first vertex of subpath 1
+    expect(index.hitTest(50, 60)).toBeNull();
+  });
+
+  it("queryRect returns path vertices inside the brush via vertex tree", () => {
+    const positions = new Float32Array([
+      10,
+      10,
+      20,
+      10, // in brush
+      200,
+      200,
+      210,
+      200, // far
+    ]);
+    const pathOffsets = new Uint32Array([0, 2, 4]);
+    const scene = pathScene(positions, pathOffsets);
+    const index = buildHitIndex(scene);
+    const hits = index.queryRect(0, 0, 25, 25);
+    expect(hits.map((h) => h.rowIndex).toSorted((a, b) => a! - b!)).toEqual([0, 1]);
+    expect(index.queryRect(50, 50, 60, 60)).toEqual([]);
+  });
+
+  it("hitTest does not refine every far path subpath on a dense multi-series field", () => {
+    // Many short horizontal subpaths far from the probe; one under (10, 10).
+    const subpaths = 2_000;
+    const positions = new Float32Array(subpaths * 4); // 2 verts each
+    const pathOffsets = new Uint32Array(subpaths + 1);
+    for (let s = 0; s < subpaths; s++) {
+      pathOffsets[s] = s * 2;
+      const col = s % 40;
+      const row = Math.floor(s / 40);
+      const x = 100 + col * 10;
+      const y = 100 + row * 10;
+      positions[s * 4] = x;
+      positions[s * 4 + 1] = y;
+      positions[s * 4 + 2] = x + 4;
+      positions[s * 4 + 3] = y;
+    }
+    pathOffsets[subpaths] = subpaths * 2;
+    // Subpath 0 under the probe.
+    positions[0] = 0;
+    positions[1] = 10;
+    positions[2] = 20;
+    positions[3] = 10;
+
+    const instrumented = instrumentReads(positions);
+    const scene = pathScene(instrumented.view, pathOffsets, { linewidth: 1 });
+    const index = buildHitIndex(scene, { tolerance: 2 });
+    instrumented.reset();
+
+    const hit = index.hitTest(10, 10);
+    expect(hit?.rowIndex).toBe(0);
+    // Exact stroke test only on shortlisted subpaths (not every far series).
+    expect(instrumented.reads()).toBeLessThan(64);
+    expect(instrumented.reads()).toBeLessThan(subpaths / 10);
+
+    instrumented.reset();
+    expect(index.hitTest(50, 50)).toBeNull();
+    expect(instrumented.reads()).toBe(0);
+  });
+
+  it("one giant path subpath does not force-scan every small far series", () => {
+    const far = 1_500;
+    // Subpath 0: long diagonal covering most of the left panel.
+    // Subpaths 1..far: short segments in the far corner.
+    const positions = new Float32Array((far + 1) * 4);
+    const pathOffsets = new Uint32Array(far + 2);
+    pathOffsets[0] = 0;
+    positions[0] = 0;
+    positions[1] = 0;
+    positions[2] = 200;
+    positions[3] = 120;
+    pathOffsets[1] = 2;
+    for (let s = 0; s < far; s++) {
+      pathOffsets[s + 1] = 2 + s * 2;
+      const col = s % 30;
+      const row = Math.floor(s / 30);
+      const x = 300 + col * 8;
+      const y = 300 + row * 8;
+      positions[(s + 1) * 4] = x;
+      positions[(s + 1) * 4 + 1] = y;
+      positions[(s + 1) * 4 + 2] = x + 2;
+      positions[(s + 1) * 4 + 3] = y;
+    }
+    pathOffsets[far + 1] = 2 + far * 2;
+
+    const instrumented = instrumentReads(positions);
+    const scene = pathScene(instrumented.view, pathOffsets, { linewidth: 1 });
+    const index = buildHitIndex(scene, { tolerance: 1 });
+    instrumented.reset();
+
+    const hit = index.hitTest(100, 60);
+    expect(hit?.rowIndex).toBe(0);
+    expect(instrumented.reads()).toBeLessThan(64);
+
+    instrumented.reset();
+    const brushed = index.queryRect(0, 0, 5, 5);
+    expect(brushed.some((h) => h.rowIndex === 0)).toBe(true);
+    expect(instrumented.reads()).toBe(0); // vertices come from index arrays, not batch.positions
   });
 });
 


### PR DESCRIPTION
## Summary

- **Audit target:** `packages/core/src` (bigo-maintain rotation; nextIndex=0)
- **Finding:** After #270 (rects) and #274 (segments), **paths** still walked every subpath / vertex linearly **O(P/V)** on `hitTest` / `queryRect` (P = subpath count, V = vertices).
- **Fix:**
  - **hitTest:** size-classed subpath AABB shortlist (pad stroke slop for lines), then exact fill containment or edge distance; topmost = highest subpath index among hits.
  - **queryRect:** vertex `StaticQuadtree` shortlist (same endpoint/vertex-in-brush semantics).
- **Complexity:** multi-series hitTest **O(P) → O(log P + k)**; queryRect **O(V) → O(log V + k)**. Completes spatial shortlist for all hit-target geometry kinds.

## Test plan

- [x] Characterization: stacked stroke topmost; vertex brush; existing line/area geom tests
- [x] Complexity: dense far multi-series + giant+small size class (Proxy on `batch.positions` reads)
- [x] Full hit-index suite: 23 pass
- [x] Pre-push suite green
