### PR TITLE
perf(svelte): O(1) selection membership via parallel Sets

### DIFF
--- a/packages/svelte/src/lib/interaction/controller.svelte.ts
+++ b/packages/svelte/src/lib/interaction/controller.svelte.ts
@@ -83,6 +83,22 @@ export interface PlotInteractionController<Key extends PropertyKey> {
 
 const EMPTY_KEYS = Object.freeze([]) as readonly never[];
 
+/** Keep ordered key lists and parallel membership Sets in sync. */
+function writeKeyList<Key extends PropertyKey>(
+  values: Map<string, ReadonlyArray<Key>>,
+  sets: Map<string, Set<Key>>,
+  scopeKeys: string,
+  next: ReadonlyArray<Key>,
+): void {
+  if (next.length === 0) {
+    values.delete(scopeKeys);
+    sets.delete(scopeKeys);
+  } else {
+    values.set(scopeKeys, next);
+    sets.set(scopeKeys, new Set(next));
+  }
+}
+
 /** Create chart-independent, semantic interaction state for Svelte 5.
  *
  * The controller owns stable keys and scoped data domains only. A chart is
@@ -95,6 +111,11 @@ export function createPlotInteraction<Key extends PropertyKey = PropertyKey>(
   let revision = $state(0);
   const selections = new Map<string, ReadonlyArray<Key>>();
   const emphases = new Map<string, ReadonlyArray<Key>>();
+  // Parallel membership sets for O(1) isSelected / toggleSelection (not O(K)
+  // Array#includes). Set uses SameValueZero so NaN keys work without the
+  // Number.isNaN special-case used when filtering arrays.
+  const selectionSets = new Map<string, Set<Key>>();
+  const emphasisSets = new Map<string, Set<Key>>();
   const intervals = new Map<string, Map<string, ScopedInteractionInterval<Key>>>();
   const zoomX = new Map<string, readonly [number, number]>();
   const zoomY = new Map<string, readonly [number, number]>();
@@ -154,6 +175,7 @@ export function createPlotInteraction<Key extends PropertyKey = PropertyKey>(
 
   const replaceKeys = (
     values: Map<string, ReadonlyArray<Key>>,
+    sets: Map<string, Set<Key>>,
     nextKeys: ReadonlyArray<Key>,
     mutation: PlotInteractionMutationOptions,
     kind: "selection" | "emphasis",
@@ -162,8 +184,7 @@ export function createPlotInteraction<Key extends PropertyKey = PropertyKey>(
     const next = canonicalKeys(nextKeys);
     const prior = values.get(scope.keys) ?? EMPTY_KEYS;
     if (equalKeys(prior, next)) return null;
-    if (next.length === 0) values.delete(scope.keys);
-    else values.set(scope.keys, next);
+    writeKeyList(values, sets, scope.keys, next);
     return commit(kind, [kind], scope, mutation.source ?? "programmatic");
   };
 
@@ -184,17 +205,19 @@ export function createPlotInteraction<Key extends PropertyKey = PropertyKey>(
     },
     isSelected(key, scope) {
       assertKey(key);
-      return controller.selected(scope).includes(key);
+      return selectionSets.get(keyScope(scope))?.has(key) ?? false;
     },
     setSelection(keys, mutation) {
       assertMutationAllowed();
-      return replaceKeys(selections, keys, mutation, "selection");
+      return replaceKeys(selections, selectionSets, keys, mutation, "selection");
     },
     toggleSelection(key, mutation) {
       assertKey(key);
+      const scopeKey = keyScope(mutation.scope);
       const current = controller.selected(mutation.scope);
+      const selected = selectionSets.get(scopeKey)?.has(key) ?? false;
       return controller.setSelection(
-        current.includes(key)
+        selected
           ? current.filter((value) => value !== key && !(Number.isNaN(value) && Number.isNaN(key)))
           : [...current, key],
         mutation,
@@ -205,7 +228,7 @@ export function createPlotInteraction<Key extends PropertyKey = PropertyKey>(
     },
     setEmphasis(keys, mutation) {
       assertMutationAllowed();
-      return replaceKeys(emphases, keys, mutation, "emphasis");
+      return replaceKeys(emphases, emphasisSets, keys, mutation, "emphasis");
     },
     clearEmphasis(mutation) {
       return controller.setEmphasis([], mutation);
@@ -333,14 +356,8 @@ export function createPlotInteraction<Key extends PropertyKey = PropertyKey>(
         }
       }
       if (!selectionChanged && !emphasisChanged && !intervalChanged) return null;
-      if (selectionChanged) {
-        if (nextSelection.length === 0) selections.delete(scope.keys);
-        else selections.set(scope.keys, nextSelection);
-      }
-      if (emphasisChanged) {
-        if (nextEmphasis.length === 0) emphases.delete(scope.keys);
-        else emphases.set(scope.keys, nextEmphasis);
-      }
+      if (selectionChanged) writeKeyList(selections, selectionSets, scope.keys, nextSelection);
+      if (emphasisChanged) writeKeyList(emphases, emphasisSets, scope.keys, nextEmphasis);
       const changes = Object.freeze([
         ...(selectionChanged ? (["selection"] as const) : []),
         ...(emphasisChanged ? (["emphasis"] as const) : []),

--- a/packages/svelte/src/lib/interaction/controller.svelte.ts
+++ b/packages/svelte/src/lib/interaction/controller.svelte.ts
@@ -205,6 +205,9 @@ export function createPlotInteraction<Key extends PropertyKey = PropertyKey>(
     },
     isSelected(key, scope) {
       assertKey(key);
+      // Track revision so $derived/template consumers invalidate on mutation
+      // (selectionSets itself is not $state — Codex #278 P2).
+      void revision;
       return selectionSets.get(keyScope(scope))?.has(key) ?? false;
     },
     setSelection(keys, mutation) {

--- a/packages/svelte/tests/interaction/controller.test.ts
+++ b/packages/svelte/tests/interaction/controller.test.ts
@@ -231,6 +231,35 @@ describe("createPlotInteraction", () => {
     expect(controller.revision).toBe(3);
   });
 
+  // Membership Sets keep isSelected / toggleSelection O(1) in K, not O(K)
+  // Array#includes. Large multi-selects (brush) must stay correct without
+  // rescanning the ordered list on every probe.
+  it("isSelected and toggle membership handle large multi-selects", () => {
+    const controller = createPlotInteraction<number>();
+    const count = 5_000;
+    const keys = Array.from({ length: count }, (_, i) => i);
+    controller.setSelection(keys, { scope: "row-id" });
+    expect(controller.isSelected(count - 1, "row-id")).toBe(true);
+    expect(controller.isSelected(count, "row-id")).toBe(false);
+    controller.toggleSelection(0, { scope: "row-id" });
+    expect(controller.isSelected(0, "row-id")).toBe(false);
+    expect(controller.selected("row-id")).toHaveLength(count - 1);
+    // Reconcile must keep the membership set in sync with the ordered list.
+    controller.reconcileKeys(keys.slice(1, 100), { scope: "row-id" });
+    expect(controller.isSelected(50, "row-id")).toBe(true);
+    expect(controller.isSelected(0, "row-id")).toBe(false);
+    expect(controller.isSelected(200, "row-id")).toBe(false);
+  });
+
+  it("isSelected treats NaN as a single membership key", () => {
+    const controller = createPlotInteraction<number>();
+    controller.setSelection([Number.NaN, 1], { scope: "row-id" });
+    expect(controller.isSelected(Number.NaN, "row-id")).toBe(true);
+    controller.toggleSelection(Number.NaN, { scope: "row-id" });
+    expect(controller.isSelected(Number.NaN, "row-id")).toBe(false);
+    expect(controller.selected("row-id")).toEqual([1]);
+  });
+
   it("treats PropertyKey collections as sets even for opaque symbols", () => {
     const first = Symbol("same-description");
     const second = Symbol("same-description");


### PR DESCRIPTION
## Summary

- **Audit target:** `packages/svelte/src` (bigo-maintain rotation; nextIndex=1)
- **Finding:** `PlotInteractionController.isSelected` / `toggleSelection` used `Array#includes` over the ordered selection list **O(K)** (K = selected key count). Large multi-select brushes make membership probes quadratic with selection size.
- **Fix:** Keep ordered frozen arrays for `selected()` / snapshots, but maintain parallel per-scope `Set`s for membership. `isSelected` and toggle membership are **O(1)**; sets stay in sync on `setSelection`, `setEmphasis`, and `reconcileKeys`.
- **Complexity:** membership **O(K) → O(1)**; list rebuild on toggle/set still O(K) as before.

## Test plan

- [x] Existing controller characterization tests green
- [x] Large multi-select (5k keys) isSelected / toggle / reconcileKeys
- [x] NaN key membership (SameValueZero via Set)
- [x] Pre-push suite green
