### PR TITLE
perf(svelte): skip canvas a11y row materialisation while table closed

### DIFF
--- a/packages/svelte/src/lib/a11y/CanvasA11y.svelte
+++ b/packages/svelte/src/lib/a11y/CanvasA11y.svelte
@@ -5,7 +5,7 @@
    */
   import type { GeometryBatch, RenderModel } from "@ggsvelte/core";
 
-  import { a11yRows } from "./canvas-a11y.js";
+  import { a11yMarkCount, a11yRows } from "./canvas-a11y.js";
 
   const {
     model,
@@ -21,9 +21,13 @@
     onToggle: () => void;
   } = $props();
 
-  const table = $derived(a11yRows(model, batches));
+  // Closed: O(P) distinct-index count only (aria-label). Open: full sort +
+  // row materialisation for the capped table. Avoids O(R log R) + model.row
+  // work on every model update while the table stays closed.
+  const total = $derived(a11yMarkCount(batches));
+  const table = $derived(open ? a11yRows(model, batches) : null);
   const ariaLabel = $derived(
-    `${sceneLabelText} — ${String(table.total)} canvas-rendered marks. Canvas marks are not individually focusable; use the data table.`,
+    `${sceneLabelText} — ${String(total)} canvas-rendered marks. Canvas marks are not individually focusable; use the data table.`,
   );
 </script>
 
@@ -35,7 +39,7 @@
   onclick={() => onToggle()}
   >{open ? "Hide data table" : "Show data table"}</button
 >
-{#if open}
+{#if open && table !== null}
   <div class="gg-a11y-table">
     <table>
       <thead>

--- a/packages/svelte/src/lib/a11y/canvas-a11y.ts
+++ b/packages/svelte/src/lib/a11y/canvas-a11y.ts
@@ -3,22 +3,55 @@ import type { CellValue, GeometryBatch, RenderModel } from "@ggsvelte/core";
 /** Rows referenced by a canvas stratum, capped for the a11y table. */
 export const A11Y_TABLE_CAP = 100;
 
-export function a11yRows(
-  model: RenderModel,
-  batches: GeometryBatch[],
-): { fields: string[]; rows: CellValue[][]; total: number } {
+/**
+ * Distinct source-row indexes referenced by canvas batches.
+ * Skips the `0xffffffff` missing-row sentinel. Shared by count-only and
+ * materialise paths so sentinel / dedupe semantics cannot drift.
+ *
+ * Cost: O(P) time over primitive `rowIndex` entries, O(R) memory for the set
+ * (R = distinct indexes). Does not sort or call `model.row`.
+ */
+export function collectCanvasRowIndexes(batches: readonly GeometryBatch[]): Set<number> {
   const rowSet = new Set<number>();
   for (const batch of batches) {
     for (const raw of batch.rowIndex) {
       if (raw !== 0xffffffff) rowSet.add(raw);
     }
   }
+  return rowSet;
+}
+
+/**
+ * Distinct canvas mark count for aria labels (source-row indexes, not
+ * geometry primitives). O(P) scan, O(R) set — no sort, no row materialisation.
+ */
+export function a11yMarkCount(batches: readonly GeometryBatch[]): number {
+  return collectCanvasRowIndexes(batches).size;
+}
+
+/**
+ * Build the capped a11y data table for an open canvas stratum.
+ *
+ * - `total` = distinct source-row indexes (matches `a11yMarkCount`).
+ * - `rows` = up to {@link A11Y_TABLE_CAP} materialised rows in ascending
+ *   source-row index order; null `model.row` entries are skipped and do not
+ *   count toward the cap.
+ * - Sort cost O(R log R) only when materialising (open table); closed UIs
+ *   should call {@link a11yMarkCount} instead.
+ */
+export function a11yRows(
+  model: RenderModel,
+  batches: GeometryBatch[],
+): { fields: string[]; rows: CellValue[][]; total: number } {
+  const rowSet = collectCanvasRowIndexes(batches);
   const fieldSet = new Set<string>();
   for (const batch of batches) {
     for (const f of model.layerFields[batch.layerIndex] ?? []) fieldSet.add(f.field);
   }
   const fields = [...fieldSet];
   const rows: CellValue[][] = [];
+  // Full ascending sort of distinct indexes so null rows mid-stream still
+  // advance to later indexes (CAP counts successful materialisations only).
   for (const index of [...rowSet].toSorted((a, b) => a - b)) {
     if (rows.length >= A11Y_TABLE_CAP) break;
     const row = model.row(index);

--- a/packages/svelte/tests/a11y/canvas-a11y-component.test.ts
+++ b/packages/svelte/tests/a11y/canvas-a11y-component.test.ts
@@ -83,6 +83,39 @@ describe("CanvasA11y", () => {
     expect(openToggle?.textContent).toBe("Hide data table");
   });
 
+  it("closed→open on the same mount materialises rows only after open becomes true", async () => {
+    const row = vi.fn((index: number) => {
+      const body = (sampleModel as { row: (i: number) => Record<string, unknown> | null }).row(
+        index,
+      );
+      return body;
+    });
+    const spyModel = {
+      layerFields: (sampleModel as { layerFields: unknown }).layerFields,
+      row,
+    } as unknown as RenderModel;
+
+    const props = {
+      model: spyModel,
+      batches: sampleBatches,
+      sceneLabelText: "Plot",
+      open: false,
+      onToggle: () => {},
+    };
+    const view = render(CanvasA11y, props);
+
+    expect(view.container.querySelector(".gg-a11y-table")).toBeNull();
+    expect(row).not.toHaveBeenCalled();
+    expect(view.container.querySelector(".gg-canvas-a11y")?.getAttribute("aria-label")).toContain(
+      "4 canvas-rendered marks",
+    );
+
+    await view.rerender({ ...props, open: true });
+    await until(() => view.container.querySelector(".gg-a11y-table") !== null);
+    expect(row).toHaveBeenCalled();
+    expect(view.container.querySelectorAll(".gg-a11y-table tbody tr").length).toBe(4);
+  });
+
   it("renders field headers and body rows from a11yRows", async () => {
     const { container } = render(CanvasA11y, {
       model: sampleModel,

--- a/packages/svelte/tests/a11y/canvas-a11y.test.ts
+++ b/packages/svelte/tests/a11y/canvas-a11y.test.ts
@@ -1,8 +1,13 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import type { GeometryBatch, RenderModel } from "@ggsvelte/core";
 
-import { A11Y_TABLE_CAP, a11yRows } from "../../src/lib/a11y/canvas-a11y.js";
+import {
+  A11Y_TABLE_CAP,
+  a11yMarkCount,
+  a11yRows,
+  collectCanvasRowIndexes,
+} from "../../src/lib/a11y/canvas-a11y.js";
 
 function batch(partial: { layerIndex: number; rowIndex: number[] }): GeometryBatch {
   return {
@@ -86,5 +91,81 @@ describe("a11yRows", () => {
     expect(table.rows).toHaveLength(A11Y_TABLE_CAP);
     expect(table.rows[0]).toEqual([0]);
     expect(table.rows[A11Y_TABLE_CAP - 1]).toEqual([A11Y_TABLE_CAP - 1]);
+  });
+
+  it("collectCanvasRowIndexes / a11yMarkCount share sentinel + dedupe semantics with a11yRows.total", () => {
+    const indices = [7, 0xffffffff, 3, 7, 1, 0xffffffff, 3];
+    const batches = [batch({ layerIndex: 0, rowIndex: indices })];
+    const set = collectCanvasRowIndexes(batches);
+    expect(set.size).toBe(3);
+    expect(set.has(1)).toBe(true);
+    expect(set.has(3)).toBe(true);
+    expect(set.has(7)).toBe(true);
+    expect(a11yMarkCount(batches)).toBe(3);
+    const m = model({
+      layerFields: { 0: [{ field: "x" }] },
+      rows: { 1: { x: 1 }, 3: { x: 3 }, 7: { x: 7 } },
+    });
+    expect(a11yRows(m, batches).total).toBe(3);
+  });
+
+  it("materialises first CAP rows by ascending index even when batch indexes are shuffled", () => {
+    const rows: Record<number, Record<string, unknown>> = {};
+    const n = A11Y_TABLE_CAP + 40;
+    const indices: number[] = [];
+    for (let i = 0; i < n; i++) {
+      rows[i] = { x: i };
+      indices.push(i);
+    }
+    // Fisher–Yates-ish reverse + mid swap so order is not ascending.
+    indices.reverse();
+    const mid = Math.floor(indices.length / 2);
+    const head = indices[0] ?? 0;
+    const midVal = indices[mid] ?? 0;
+    indices[0] = midVal;
+    indices[mid] = head;
+    const sample = indices[3] ?? 0;
+    indices.push(0xffffffff, sample, 0xffffffff);
+
+    const m = model({
+      layerFields: { 0: [{ field: "x" }] },
+      rows,
+    });
+    const table = a11yRows(m, [batch({ layerIndex: 0, rowIndex: indices })]);
+    expect(table.total).toBe(n);
+    expect(table.rows).toHaveLength(A11Y_TABLE_CAP);
+    expect(table.rows[0]).toEqual([0]);
+    expect(table.rows[A11Y_TABLE_CAP - 1]).toEqual([A11Y_TABLE_CAP - 1]);
+  });
+
+  it("skips null rows among the smallest indexes and continues until CAP successes", () => {
+    const rows: Record<number, Record<string, unknown> | null> = {};
+    // Smallest indexes 0..4 are null; valid rows start at 5.
+    for (let i = 0; i < 5; i++) rows[i] = null;
+    for (let i = 5; i < A11Y_TABLE_CAP + 10; i++) rows[i] = { x: i };
+    const indices = Object.keys(rows).map(Number);
+    indices.reverse();
+    const m = model({
+      layerFields: { 0: [{ field: "x" }] },
+      rows,
+    });
+    const table = a11yRows(m, [batch({ layerIndex: 0, rowIndex: indices })]);
+    expect(table.total).toBe(A11Y_TABLE_CAP + 10);
+    expect(table.rows).toHaveLength(A11Y_TABLE_CAP);
+    expect(table.rows[0]).toEqual([5]);
+    expect(table.rows[A11Y_TABLE_CAP - 1]).toEqual([A11Y_TABLE_CAP + 4]);
+  });
+
+  it("a11yMarkCount never calls model.row", () => {
+    const row = vi.fn(() => ({ x: 1 }));
+    const m = {
+      layerFields: { 0: [{ field: "x" }] },
+      row,
+    } as unknown as RenderModel;
+    const batches = [batch({ layerIndex: 0, rowIndex: [0, 1, 2, 0xffffffff, 1] })];
+    expect(a11yMarkCount(batches)).toBe(3);
+    expect(row).not.toHaveBeenCalled();
+    // materialize still works with the same batches
+    void m;
   });
 });


### PR DESCRIPTION
## Summary

**Audit target:** `packages/svelte/src` (rotation after core #280)

**Finding:** `CanvasA11y` always `$derived(a11yRows(...))`, so every model/batch update paid **O(R log R)** full sort of distinct canvas row indexes plus up to **CAP** `model.row` materialisations — even when the data table was **closed** and only `table.total` fed the aria-label.

**n:** R = distinct source-row indexes on canvas strata; P = primitive `rowIndex` entries; k = `A11Y_TABLE_CAP` (100).

**Fix:**
- Shared `collectCanvasRowIndexes` (sentinel + dedupe) used by both paths
- `a11yMarkCount` for closed aria-label — O(P) scan, no sort / no `model.row`
- Open table still runs full ascending sort + materialisation (correct null-skip / CAP semantics; Codex plan review: do not claim false O(R log k) with null fallback)

## Complexity

| Path | Before | After |
|------|--------|-------|
| Closed (aria-label only) | O(P + R log R + k·F) | O(P) time, O(R) set |
| Open (table visible) | O(P + R log R + k·F) | same (unchanged correctness) |

## Test plan

- [x] `bunx vitest run tests/a11y/` (unit + component, chromium/webkit/firefox)
- [x] Shared count/dedupe/sentinel characterization
- [x] Shuffled indexes + nulls among smallest indexes
- [x] Closed→open same-mount: `model.row` only after open

## Out of scope / follow-ups

- Interval dual full-store walk when non-union keys live (medium; same class as #269)
