### PR TITLE
perf(core): Θ(runs) canvas segment strokes (mirror points batching)

### DIFF
--- a/packages/core/src/dom/canvas.ts
+++ b/packages/core/src/dom/canvas.ts
@@ -19,7 +19,7 @@
  * Glyph (text) batches are NOT drawn here: text always renders as SVG
  * (plan: "axes/grids/legends/text always SVG"); planStrata routes them.
  */
-import type { GeometryBatch, PathsBatch, PointsBatch, Scene } from "../scene.js";
+import type { GeometryBatch, PathsBatch, PointsBatch, Scene, SegmentsBatch } from "../scene.js";
 import type { BatchInteractionMask } from "../interaction-mask.js";
 import type { ThemeTokens } from "../theme.js";
 import { themeVar } from "../theme.js";
@@ -307,6 +307,80 @@ function drawPathsSubset(
   }
 }
 
+/**
+ * Trace one segment as a disconnected subpath (moveTo + lineTo).
+ * Multiple segments share one path + stroke when strokeStyle matches —
+ * same multi-subpath contract points use for mono/run fills (overlapping
+ * antialiasing / alpha compositing differs from per-primitive stroke()).
+ */
+function traceSegment(ctx: CanvasRenderingContext2D, batch: SegmentsBatch, j: number): void {
+  const o = j * 4;
+  ctx.moveTo(batch.segments[o]!, batch.segments[o + 1]!);
+  ctx.lineTo(batch.segments[o + 2]!, batch.segments[o + 3]!);
+}
+
+function segmentStrokeAt(
+  batch: SegmentsBatch,
+  j: number,
+  themeInk: string,
+  resolve: ColorResolver,
+): string {
+  const stroke = batch.strokes?.[j] ?? batch.stroke;
+  return stroke === null || stroke === undefined ? themeInk : resolve(stroke);
+}
+
+/**
+ * Draw segments with Θ(runs) stroke() calls: mono batches (no per-segment
+ * `strokes`) are one path; per-segment colors collapse contiguous same-color
+ * runs. Optional `includes` skips primitives for focus-mask subset passes.
+ */
+function drawSegments(
+  ctx: CanvasRenderingContext2D,
+  batch: SegmentsBatch,
+  theme: ThemeTokens,
+  resolve: ColorResolver,
+  includes?: (index: number) => boolean,
+): void {
+  const themeInk = resolve(themeVar("ink", theme));
+  ctx.lineWidth = batch.linewidth;
+  const n = batch.segments.length / 4;
+  if (n === 0) return;
+
+  if (batch.strokes === undefined) {
+    ctx.strokeStyle = segmentStrokeAt(batch, 0, themeInk, resolve);
+    ctx.beginPath();
+    let traced = false;
+    for (let j = 0; j < n; j++) {
+      if (includes !== undefined && !includes(j)) continue;
+      traceSegment(ctx, batch, j);
+      traced = true;
+    }
+    if (traced) ctx.stroke();
+    return;
+  }
+
+  let runStart = 0;
+  while (runStart < n) {
+    if (includes !== undefined && !includes(runStart)) {
+      runStart++;
+      continue;
+    }
+    const color = segmentStrokeAt(batch, runStart, themeInk, resolve);
+    let runEnd = runStart + 1;
+    while (runEnd < n && segmentStrokeAt(batch, runEnd, themeInk, resolve) === color) runEnd++;
+    ctx.strokeStyle = color;
+    ctx.beginPath();
+    let traced = false;
+    for (let j = runStart; j < runEnd; j++) {
+      if (includes !== undefined && !includes(j)) continue;
+      traceSegment(ctx, batch, j);
+      traced = true;
+    }
+    if (traced) ctx.stroke();
+    runStart = runEnd;
+  }
+}
+
 function drawBatchInner(
   ctx: CanvasRenderingContext2D,
   batch: GeometryBatch,
@@ -345,20 +419,9 @@ function drawBatchInner(
       }
       break;
     }
-    case "segments": {
-      const themeInk = resolve(themeVar("ink", theme));
-      ctx.lineWidth = batch.linewidth;
-      const n = batch.segments.length / 4;
-      for (let j = 0; j < n; j++) {
-        const stroke = batch.strokes?.[j] ?? batch.stroke;
-        ctx.strokeStyle = stroke === null || stroke === undefined ? themeInk : resolve(stroke);
-        ctx.beginPath();
-        ctx.moveTo(batch.segments[j * 4]!, batch.segments[j * 4 + 1]!);
-        ctx.lineTo(batch.segments[j * 4 + 2]!, batch.segments[j * 4 + 3]!);
-        ctx.stroke();
-      }
+    case "segments":
+      drawSegments(ctx, batch, theme, resolve);
       break;
-    }
     case "glyphs":
       // Text always renders as SVG (module docs); nothing to draw.
       break;
@@ -407,21 +470,9 @@ function drawBatchSubsetInner(
       }
       break;
     }
-    case "segments": {
-      const themeInk = resolve(themeVar("ink", theme));
-      ctx.lineWidth = batch.linewidth;
-      const n = batch.segments.length / 4;
-      for (let j = 0; j < n; j++) {
-        if (!includes(j)) continue;
-        const stroke = batch.strokes?.[j] ?? batch.stroke;
-        ctx.strokeStyle = stroke === null || stroke === undefined ? themeInk : resolve(stroke);
-        ctx.beginPath();
-        ctx.moveTo(batch.segments[j * 4]!, batch.segments[j * 4 + 1]!);
-        ctx.lineTo(batch.segments[j * 4 + 2]!, batch.segments[j * 4 + 3]!);
-        ctx.stroke();
-      }
+    case "segments":
+      drawSegments(ctx, batch, theme, resolve, includes);
       break;
-    }
     case "glyphs":
       // Text always renders as SVG; the mask still addresses glyph primitives
       // so SVG and canvas callers can share one renderer-neutral mask shape.

--- a/packages/core/tests/canvas.test.ts
+++ b/packages/core/tests/canvas.test.ts
@@ -14,6 +14,8 @@ interface RecordedCall {
   name: string;
   args: number[];
   alpha: number;
+  strokeStyle: string;
+  lineWidth: number;
 }
 
 function recordingContext(): { ctx: CanvasRenderingContext2D; calls: RecordedCall[] } {
@@ -47,7 +49,13 @@ function recordingContext(): { ctx: CanvasRenderingContext2D; calls: RecordedCal
     get(object, property): unknown {
       if (typeof property === "string" && methods.has(property)) {
         return (...args: number[]) => {
-          calls.push({ name: property, args, alpha: object.globalAlpha });
+          calls.push({
+            name: property,
+            args,
+            alpha: object.globalAlpha,
+            strokeStyle: object.strokeStyle,
+            lineWidth: object.lineWidth,
+          });
         };
       }
       return Reflect.get(object, property);
@@ -538,5 +546,147 @@ describe("drawStratum focus presentation", () => {
       (call) => call.name === "fillRect" && call.args[0] === 1 && call.alpha === 0.25,
     );
     expect(focusedPoint).toBeGreaterThan(mutedRect);
+  });
+});
+
+describe("drawStratum segment stroke batching", () => {
+  const denseMono: SegmentsBatch = {
+    kind: "segments",
+    layerIndex: 0,
+    panelIndex: 0,
+    // 6 segments, mono stroke (no per-segment strokes array)
+    segments: Float32Array.from([
+      0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11,
+    ]),
+    rowIndex: Uint32Array.from([0, 1, 2, 3, 4, 5]),
+    stroke: "black",
+    linewidth: 2,
+    alpha: 1,
+  };
+
+  it("mono stroke: one stroke() for all segments (not one per edge)", () => {
+    const { ctx, calls } = recordingContext();
+    drawStratum(ctx, scene([denseMono]), [denseMono], resolve);
+    // Panel clip also begins a path; count only paint strokes (with strokeStyle set).
+    const strokes = calls.filter((c) => c.name === "stroke" && c.strokeStyle !== "");
+    expect(strokes).toHaveLength(1);
+    expect(strokes[0]?.strokeStyle).toBe("black");
+    expect(strokes[0]?.lineWidth).toBe(2);
+    expect(calls.filter((c) => c.name === "moveTo")).toHaveLength(6);
+    expect(calls.filter((c) => c.name === "lineTo")).toHaveLength(6);
+  });
+
+  it("null stroke falls back to theme ink once for the mono path", () => {
+    const themed: SegmentsBatch = { ...denseMono, stroke: null };
+    const { ctx, calls } = recordingContext();
+    drawStratum(ctx, scene([themed]), [themed], resolve);
+    const strokes = calls.filter((c) => c.name === "stroke" && c.strokeStyle !== "");
+    expect(strokes).toHaveLength(1);
+    // Identity resolve leaves themeVar() expressions intact (cssColorResolver peels them in prod).
+    expect(strokes[0]?.strokeStyle).toBe("var(--gg-ink, black)");
+  });
+
+  it("empty segments issue no stroke()", () => {
+    const empty: SegmentsBatch = {
+      ...denseMono,
+      segments: new Float32Array(0),
+      rowIndex: new Uint32Array(0),
+    };
+    const { ctx, calls } = recordingContext();
+    drawStratum(ctx, scene([empty]), [empty], resolve);
+    expect(calls.filter((c) => c.name === "stroke")).toHaveLength(0);
+    expect(calls.filter((c) => c.name === "moveTo")).toHaveLength(0);
+  });
+
+  it("contiguous same-color runs collapse to one stroke per run", () => {
+    const runBatch: SegmentsBatch = {
+      kind: "segments",
+      layerIndex: 0,
+      panelIndex: 0,
+      segments: Float32Array.from([0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7]),
+      rowIndex: Uint32Array.from([0, 1, 2, 3]),
+      stroke: null,
+      strokes: ["red", "red", "blue", "blue"],
+      linewidth: 1,
+      alpha: 1,
+    };
+    const { ctx, calls } = recordingContext();
+    drawStratum(ctx, scene([runBatch]), [runBatch], resolve);
+    const strokes = calls.filter((c) => c.name === "stroke");
+    expect(strokes).toHaveLength(2);
+    expect(strokes.map((c) => c.strokeStyle)).toEqual(["red", "blue"]);
+    expect(calls.filter((c) => c.name === "moveTo")).toHaveLength(4);
+  });
+
+  it("alternating per-segment strokes keep one stroke per run (n runs)", () => {
+    const alt: SegmentsBatch = {
+      kind: "segments",
+      layerIndex: 0,
+      panelIndex: 0,
+      segments: Float32Array.from([0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5]),
+      rowIndex: Uint32Array.from([0, 1, 2]),
+      stroke: null,
+      strokes: ["red", "blue", "red"],
+      linewidth: 1,
+      alpha: 1,
+    };
+    const { ctx, calls } = recordingContext();
+    drawStratum(ctx, scene([alt]), [alt], resolve);
+    const strokes = calls.filter((c) => c.name === "stroke");
+    expect(strokes).toHaveLength(3);
+    expect(strokes.map((c) => c.strokeStyle)).toEqual(["red", "blue", "red"]);
+  });
+
+  it("mixed focus mask: mono batch strokes once per pass (muted then focused)", () => {
+    const { ctx, calls } = recordingContext();
+    drawStratum(ctx, scene([denseMono]), [denseMono], resolve, {
+      focusMasks: [Uint8Array.from([1, 0, 1, 0, 1, 0])],
+      mutedAlpha: 0.3,
+    });
+    const strokes = calls.filter((c) => c.name === "stroke");
+    // muted pass + focused pass
+    expect(strokes).toHaveLength(2);
+    expect(strokes.map((c) => c.alpha).toSorted((a, b) => a - b)).toEqual([0.3, 1]);
+    // 3 muted + 3 focused endpoints
+    expect(calls.filter((c) => c.name === "moveTo")).toHaveLength(6);
+  });
+
+  it("all-focused mask: single mono stroke; empty-inclusion pass issues no stroke", () => {
+    const { ctx, calls } = recordingContext();
+    drawStratum(ctx, scene([denseMono]), [denseMono], resolve, {
+      focusMasks: [Uint8Array.from([1, 1, 1, 1, 1, 1])],
+      mutedAlpha: 0.3,
+    });
+    const strokes = calls.filter((c) => c.name === "stroke");
+    expect(strokes).toHaveLength(1);
+    expect(strokes[0]?.alpha).toBe(1);
+    expect(calls.filter((c) => c.name === "moveTo")).toHaveLength(6);
+  });
+
+  it("masked multi-color runs skip excluded mid-run without empty stroke", () => {
+    // red, blue, red — exclude blue: contiguous reds stay separate runs (not merged)
+    const batch: SegmentsBatch = {
+      kind: "segments",
+      layerIndex: 0,
+      panelIndex: 0,
+      segments: Float32Array.from([0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5]),
+      rowIndex: Uint32Array.from([0, 1, 2]),
+      stroke: null,
+      strokes: ["red", "blue", "red"],
+      linewidth: 1,
+      alpha: 1,
+    };
+    const { ctx, calls } = recordingContext();
+    drawStratum(ctx, scene([batch]), [batch], resolve, {
+      focusMasks: [Uint8Array.from([1, 0, 1])],
+      mutedAlpha: 0.25,
+    });
+    // muted: blue only → 1 stroke; focused: red, red as two runs → 2 strokes
+    const strokes = calls.filter((c) => c.name === "stroke");
+    expect(strokes).toHaveLength(3);
+    const muted = strokes.filter((c) => c.alpha === 0.25);
+    const focused = strokes.filter((c) => c.alpha === 1);
+    expect(muted.map((c) => c.strokeStyle)).toEqual(["blue"]);
+    expect(focused.map((c) => c.strokeStyle)).toEqual(["red", "red"]);
   });
 });


### PR DESCRIPTION
## Summary

**Audit target:** `packages/core/src` (rotation after svelte #281)

**Finding:** Canvas `segments` always issued `beginPath` + `stroke` per edge (Θ(E)), while points already mono-path + contiguous color-run batch. Dense mono-stroke batches (rules, boxplot whiskers/medians, errorbars) paid needless canvas state ops.

**n:** E = segment count (≈ 3R errorbars, 2G+G boxplot segments, R rules).

**Fix:**
- `drawSegments` helper: mono (`strokes` undefined) → one multi-subpath stroke; per-segment colors → contiguous same-color runs
- Focus-mask subset reuses the same helper with an includes predicate
- Multi-subpath compositing matches the existing points mono/run contract (Codex plan note: overlapping AA/alpha can differ from per-edge `stroke()` — accepted, same as points)

## Complexity

| Path | Before | After |
|------|--------|-------|
| Mono segments | Θ(E) stroke() | Θ(1) stroke() |
| Per-segment colors | Θ(E) stroke() | Θ(runs) stroke() |
| Masked mono | Θ(included) stroke() | Θ(1) per focus pass |

## Test plan

- [x] `bun test packages/core/tests/canvas.test.ts` (26 pass)
- [x] Mono / null-theme / empty / run collapse / alternating
- [x] Mixed focus (2 strokes) / all-focused (1) / masked multi-color runs

## Out of scope

- LOESS hot-loop Float64Array alloc (M)
- geometry positionOf recompute constant factor (M)
