### PR TITLE
perf(svelte): fuse non-union interval walk with shared candidate projection

### DIFF
--- a/packages/svelte/src/lib/interval/interval-state.svelte.ts
+++ b/packages/svelte/src/lib/interval/interval-state.svelte.ts
@@ -77,6 +77,13 @@ export type IntervalStateDeps = {
   /** Semantic candidate projection, initialized before factory construction. */
   candidateSemanticKeys: (candidate: CandidateFacts) => PropertyKey[];
   /**
+   * Deferred host bag for non-union interval key consumption. When the host
+   * already walked the store for anchors/masks (shared projection), return that
+   * bag here so `effectiveIntervalKeys` does not re-walk O(C). `null`/omitted
+   * falls back to the local full-store projection (tests / non-orchestrator).
+   */
+  sharedConsumptionCandidates?: () => readonly IntervalConsumptionCandidate<PropertyKey>[] | null;
+  /**
    * Handler-only: `openBoundsEditor` select branch reads the host's inspection
    * panel as its fallback target. Host derived is earlier than the factory and
    * returns `ScenePanel | null`.
@@ -187,10 +194,19 @@ export function createIntervalState(deps: IntervalStateDeps): IntervalState {
     // every controller revision — skip the O(candidates) semantic projection
     // whenever the preset never reads it.
     const preset = effectiveIntervals[0]?.preset;
+    if (preset === "union")
+      return consumeIntervalKeys({
+        records: effectiveIntervals,
+        panels: model.scene.panels,
+        candidates: [],
+      });
+    // Prefer host shared bag (one store walk with anchors/masks) over a second
+    // local full-store projection when non-union intervals are live.
+    const shared = deps.sharedConsumptionCandidates?.() ?? null;
     return consumeIntervalKeys({
       records: effectiveIntervals,
       panels: model.scene.panels,
-      candidates: preset === "union" ? [] : intervalConsumptionCandidates(),
+      candidates: shared ?? intervalConsumptionCandidates(),
     });
   });
 

--- a/packages/svelte/src/lib/plot-orchestrator.svelte.ts
+++ b/packages/svelte/src/lib/plot-orchestrator.svelte.ts
@@ -548,6 +548,9 @@ export function createPlotOrchestrator<
     coordFlipped: () => coordFlipped,
     captureSurface: inputs.captureSurface,
     candidateSemanticKeys: (candidate) => candidateSemanticKeys(candidate),
+    // Deferred: fused projection is declared after this factory (method only).
+    // When non-null, non-union interval keys reuse the host's single store walk.
+    sharedConsumptionCandidates: () => fusedConsumptionCandidates,
     inspectionPanel: () => inspectionState.inspectionPanel,
     emitSelection: (...args: Parameters<SelectionState["emitSelection"]>) => {
       selectionState.emitSelection(...args);
@@ -590,19 +593,41 @@ export function createPlotOrchestrator<
   surfaceState.registerSurfaceEffects();
 
   // Focus keys first (no candidate walk) so shared projection can short-circuit
-  // when idle. One full-store projection feeds selected/emphasized anchors and
-  // interaction masks — was O(2–3C) separate collectCandidates walks.
+  // when idle. One full-store projection feeds selected/emphasized anchors,
+  // interaction masks, AND non-union interval key consumption — was O(2C) when
+  // a non-union interval was live (interval consumption walk + anchors walk).
   // Liveness uses *counts* (Object.is-stable when keys swap but stay non-empty)
   // so focus-only key changes rebuild masks/anchors without re-walking C (Codex P2).
   const presentationFocusKeys = $derived(selectionState.computePresentationFocusKeys());
   const selectedKeyCount = $derived(selectionState.effectiveSelectedKeys.length);
-  const intervalKeyCount = $derived(intervalState.effectiveIntervalKeys.length);
   const emphasisKeyCount = $derived(legendFocusState.effectiveEmphasisKeys.length);
   const presentationFocusKeyCount = $derived(presentationFocusKeys.length);
+  // Gate without reading effectiveIntervalKeys (those depend on the fused bag
+  // for non-union presets — reading keys here would circular-depend).
+  const needIntervalConsumptionWalk = $derived(
+    intervalState.effectiveIntervals.length > 0 &&
+      intervalState.effectiveIntervals[0]?.preset !== "union",
+  );
+  // Union interval keys come from stored records only (no walk). Safe to read
+  // for the selection/anchor gate after the non-union path is handled above.
+  const intervalKeyCount = $derived(intervalState.effectiveIntervalKeys.length);
   const sharedCandidateProjection = $derived.by(() => {
+    if (needIntervalConsumptionWalk) return selectionState.computeSharedCandidateProjection();
     if (selectedKeyCount + intervalKeyCount + emphasisKeyCount + presentationFocusKeyCount === 0)
       return [];
     return selectionState.computeSharedCandidateProjection();
+  });
+  // Map once for interval consumption; null when the bag was not built for
+  // interval (union / idle). Interval falls back to its local walk only when
+  // this is null AND non-union — which should not happen under the host gate.
+  const fusedConsumptionCandidates = $derived.by(() => {
+    if (!needIntervalConsumptionWalk) return null;
+    return sharedCandidateProjection.map((entry) => ({
+      panelId: entry.panelId,
+      keys: entry.keys,
+      ...(entry.xValue !== undefined && { xValue: entry.xValue }),
+      ...(entry.yValue !== undefined && { yValue: entry.yValue }),
+    }));
   });
   const selectedAnchors = $derived(
     selectionState.computeSelectedAnchors(sharedCandidateProjection),

--- a/packages/svelte/src/lib/selection/selection-state.svelte.ts
+++ b/packages/svelte/src/lib/selection/selection-state.svelte.ts
@@ -76,9 +76,10 @@ export type SelectionStateDeps = {
 };
 
 /**
- * One candidate projection for anchors + interaction masks.
- * Built once per reactive need so selected/emphasized/mask paths do not each
- * re-walk the store (was O(2–3C) when several are live).
+ * One candidate projection for anchors, interaction masks, and interval
+ * consumption. Built once per reactive need so those consumers do not each
+ * re-walk the store (was O(2–3C) when several are live; non-union intervals
+ * previously added a second full walk for panelId/xValue/yValue/keys).
  */
 type SharedCandidateProjection = {
   readonly x: number;
@@ -86,6 +87,10 @@ type SharedCandidateProjection = {
   readonly batchIndex: number;
   readonly primitiveIndex: number;
   readonly keys: readonly PropertyKey[];
+  /** Panel identity for interval consumption (independent / cross-panel). */
+  readonly panelId: string;
+  readonly xValue?: CellValue;
+  readonly yValue?: CellValue;
 };
 
 export type SelectionState = {
@@ -147,6 +152,9 @@ export function createSelectionState(deps: SelectionStateDeps): SelectionState {
       batchIndex: candidate.batchIndex,
       primitiveIndex: candidate.primitiveIndex,
       keys: deps.candidateSemanticKeys(candidate),
+      panelId: candidate.panelId,
+      ...(candidate.xValue !== undefined && { xValue: candidate.xValue }),
+      ...(candidate.yValue !== undefined && { yValue: candidate.yValue }),
     }));
   }
 

--- a/packages/svelte/tests/interval/interval-state.test.ts
+++ b/packages/svelte/tests/interval/interval-state.test.ts
@@ -156,6 +156,7 @@ function mountIntervalController(
     coordFlipped?: () => boolean;
     captureSurface?: () => HTMLDivElement | null;
     candidateSemanticKeys?: (candidate: CandidateFacts) => PropertyKey[];
+    sharedConsumptionCandidates?: IntervalStateDeps["sharedConsumptionCandidates"];
     inspectionPanel?: () => ScenePanel | null;
     emitSelection?: (event: PlotSelection) => void;
     announce?: (message: string) => void;
@@ -174,6 +175,9 @@ function mountIntervalController(
       coordFlipped: options.coordFlipped ?? (() => false),
       captureSurface: options.captureSurface ?? (() => null),
       candidateSemanticKeys: options.candidateSemanticKeys ?? identityCandidateKeys,
+      ...(options.sharedConsumptionCandidates !== undefined && {
+        sharedConsumptionCandidates: options.sharedConsumptionCandidates,
+      }),
       inspectionPanel: options.inspectionPanel ?? (() => null),
       emitSelection: options.emitSelection ?? (() => {}),
       announce: options.announce ?? (() => {}),
@@ -249,6 +253,70 @@ describe("createIntervalState construction", () => {
     expect(announceCalls).toBe(0);
     expect(inspectionPanelCalls).toBe(0);
     expect(candidateSemanticKeysCalls).toBe(0);
+    destroy();
+  });
+});
+
+describe("createIntervalState shared consumption bag", () => {
+  it("uses sharedConsumptionCandidates and skips candidateSemanticKeys walk for non-union keys", () => {
+    const model = modelFor(continuousSpec());
+    const panelId = model.scene.panels[0]?.id;
+    if (panelId === undefined) throw new Error("expected panel");
+    let keyCalls = 0;
+    const sharedBag = [
+      {
+        panelId,
+        xValue: 1 as const,
+        yValue: 1 as const,
+        keys: ["0"] as const,
+      },
+      {
+        panelId,
+        xValue: 10 as const,
+        yValue: 20 as const,
+        keys: ["1"] as const,
+      },
+    ];
+    const { state, destroy } = mountIntervalController({
+      model: () => model,
+      selectConfig: persistentSelect,
+      candidateSemanticKeys: (candidate) => {
+        keyCalls++;
+        return identityCandidateKeys(candidate);
+      },
+      sharedConsumptionCandidates: () => sharedBag,
+    });
+
+    state.applyBrushSelectEnd(brushEvent(model, { keys: ["0", "1"] }), "pointer");
+    flushSync();
+    keyCalls = 0;
+    const keys = state.effectiveIntervalKeys;
+    expect(keys.length).toBeGreaterThan(0);
+    // Shared bag supplied all candidates — no local full-store key walk.
+    expect(keyCalls).toBe(0);
+
+    destroy();
+  });
+
+  it("falls back to local walk when shared bag is null", () => {
+    const model = modelFor(continuousSpec());
+    let keyCalls = 0;
+    const { state, destroy } = mountIntervalController({
+      model: () => model,
+      selectConfig: persistentSelect,
+      candidateSemanticKeys: (candidate) => {
+        keyCalls++;
+        return identityCandidateKeys(candidate);
+      },
+      sharedConsumptionCandidates: () => null,
+    });
+
+    state.applyBrushSelectEnd(brushEvent(model), "pointer");
+    flushSync();
+    keyCalls = 0;
+    expect(state.effectiveIntervalKeys.length).toBeGreaterThan(0);
+    expect(keyCalls).toBeGreaterThan(0);
+
     destroy();
   });
 });

--- a/packages/svelte/tests/selection/selection-state.test.ts
+++ b/packages/svelte/tests/selection/selection-state.test.ts
@@ -424,6 +424,8 @@ describe("createSelectionState anchors", () => {
     const shared = state.computeSharedCandidateProjection();
     const once = candidateCalls;
     expect(once).toBeGreaterThan(0);
+    // Interval consumption fields travel on the same bag (host fuses walks).
+    expect(shared.every((entry) => typeof entry.panelId === "string")).toBe(true);
 
     const selected = state.computeSelectedAnchors(shared);
     const emphasized = state.computeEmphasizedAnchors(shared);


### PR DESCRIPTION
## Summary

**Audit target:** `packages/svelte/src` (rotation after core #282)

**Finding:** Non-union interval key consumption walked the full candidate store, then `sharedCandidateProjection` walked again for anchors/masks — **O(2C)** per reactive turn when a brush is live.

**n:** C = candidate-store size (dense plots).

**Fix:**
- Shared projection carries `panelId` / `xValue` / `yValue` alongside mask/anchor fields
- Orchestrator builds one fused bag when non-union intervals are live (or selection/emphasis/focus needs it)
- `effectiveIntervalKeys` reuses `sharedConsumptionCandidates` when provided; falls back to local walk for tests
- Union preset still skips the consumption walk entirely

## Complexity

| Path | Before | After |
|------|--------|-------|
| Non-union interval + anchors | O(2C) walks | **O(C)** one walk |
| Union interval + anchors | O(C) anchors only | same |
| Idle (no keys) | O(1) short-circuit | same |

## Test plan

- [x] `vitest` selection-state + interval-state (shared bag skips key walk; null bag falls back)
- [x] Shared projection includes `panelId`
- [x] Pre-push suite (knip, svelte-check, bun test)

## Out of scope

- Precise-bounds apply dual walk + lineage count (user gesture, same module)
- Panel-indexed shortlist inside a single walk
