### PR TITLE
perf(core): edge AABB shortlist for stroked path candidates

### DIFF
--- a/packages/core/src/candidate-store-eager.ts
+++ b/packages/core/src/candidate-store-eager.ts
@@ -65,6 +65,37 @@ function pathSubpathAabb(
   return [minX - pad, minY - pad, maxX + pad, maxY + pad];
 }
 
+/**
+ * Plot-space AABB for the stroke segments incident on vertex `i` within
+ * half-open subpath [start, end). Used for stroked (non-fill) path candidates
+ * so one long series does not land every vertex in a plot-sized size class
+ * (hit-index edge shortlist pattern). Pad = linewidth/2 + hit tol.
+ */
+function pathVertexStrokeAabb(
+  batch: Extract<GeometryBatch, { kind: "paths" }>,
+  panelX: number,
+  panelY: number,
+  i: number,
+  start: number,
+  end: number,
+): readonly [number, number, number, number] {
+  const pad = batch.linewidth / 2 + 3;
+  let minX = panelX + batch.positions[i * 2]!;
+  let minY = panelY + batch.positions[i * 2 + 1]!;
+  let maxX = minX;
+  let maxY = minY;
+  for (const other of [i - 1, i + 1]) {
+    if (other < start || other >= end) continue;
+    const ox = panelX + batch.positions[other * 2]!;
+    const oy = panelY + batch.positions[other * 2 + 1]!;
+    if (ox < minX) minX = ox;
+    if (oy < minY) minY = oy;
+    if (ox > maxX) maxX = ox;
+    if (oy > maxY) maxY = oy;
+  }
+  return [minX - pad, minY - pad, maxX + pad, maxY + pad];
+}
+
 export function buildCandidateStoreEager(
   scene: Scene,
   options: CandidateStoreOptions = {},
@@ -411,13 +442,22 @@ export function buildCandidateStoreEager(
       maxX = Math.max(x1, x2) + pad;
       maxY = Math.max(y1, y2) + pad;
     } else if (batch.kind === "paths") {
-      // Subpath AABB (fill + stroke can sit far from one vertex anchor).
+      // Filled paths: full subpath AABB (containment far from any vertex).
+      // Stroked paths: AABB of incident edges only — a plot-spanning series
+      // used to tag every vertex with the same giant box, forcing Θ(V) refine
+      // on nearest/exact (hit-index already edge-shortlists strokes).
       const range = pathRange(batch, i);
       if (range === null) {
         minX = xs[id]!;
         minY = ys[id]!;
         maxX = minX;
         maxY = minY;
+      } else if (batch.fills === undefined) {
+        const box = pathVertexStrokeAabb(batch, panel.x, panel.y, i, range[0], range[1]);
+        minX = box[0];
+        minY = box[1];
+        maxX = box[2];
+        maxY = box[3];
       } else {
         const cacheKey = `${batchIds[id]}:${range[0]}:${range[1]}`;
         let box = pathAabbCache.get(cacheKey);

--- a/packages/core/tests/candidate-store.test.ts
+++ b/packages/core/tests/candidate-store.test.ts
@@ -903,6 +903,116 @@ describe("candidate spatial query hot path (issue #214)", () => {
     expect(batchIndexReads).toBeLessThan(count / 20);
   });
 
+  it("exact nearest hits a stroked path mid-edge via incident-edge AABB", () => {
+    // Long horizontal polyline: probe near the middle of an interior edge.
+    const n = 20;
+    const positions = new Float32Array(n * 2);
+    for (let i = 0; i < n; i++) {
+      positions[i * 2] = i * 10;
+      positions[i * 2 + 1] = 50;
+    }
+    const plotScene = scene();
+    plotScene.batches = [
+      {
+        kind: "paths",
+        layerIndex: 0,
+        panelIndex: 0,
+        positions,
+        rowIndex: Uint32Array.from({ length: n }, (_, index) => index),
+        pathOffsets: new Uint32Array([0, n]),
+        strokes: [null],
+        linewidth: 2,
+        alpha: 1,
+        curve: "linear",
+      },
+    ];
+    const store = buildCandidateStore(plotScene, {
+      datum: () => ({ xValue: 1, yValue: 2, autoMode: "exact" }),
+    });
+    // Midpoint of edge between vertices 5 (50,50) and 6 (60,50).
+    const hit = store.nearest(55, 51, { mode: "exact", maxDistance: 3 });
+    expect(hit).not.toBeNull();
+    expect(hit!.id === 5 || hit!.id === 6).toBe(true);
+  });
+
+  it("exact nearest does not refine every vertex of a far dense stroked polyline", () => {
+    // Complexity guard: full-subpath AABB tagged every vertex of a long series
+    // into one giant size class → Θ(V) refine. Incident-edge AABB keeps shortlist
+    // O(log V + k) for a distant probe.
+    const count = 4_000;
+    const positions = new Float32Array(count * 2);
+    for (let i = 0; i < count; i++) {
+      // Dense polyline far from the origin probe.
+      positions[i * 2] = 200 + (i % 100);
+      positions[i * 2 + 1] = 200 + Math.floor(i / 100);
+    }
+    // Short local stroke near (10,10) so nearest still hits something real.
+    positions[0] = 0;
+    positions[1] = 10;
+    positions[2] = 20;
+    positions[3] = 10;
+    const plotScene = scene();
+    plotScene.batches = [
+      {
+        kind: "paths",
+        layerIndex: 0,
+        panelIndex: 0,
+        positions,
+        rowIndex: Uint32Array.from({ length: count }, (_, index) => index),
+        pathOffsets: new Uint32Array([0, count]),
+        strokes: [null],
+        linewidth: 2,
+        alpha: 1,
+        curve: "linear",
+      },
+    ];
+    let batchIndexReads = 0;
+    plotScene.batches = new Proxy(plotScene.batches, {
+      get(target, property, receiver): unknown {
+        if (typeof property === "string" && /^\d+$/.test(property)) batchIndexReads++;
+        return Reflect.get(target, property, receiver) as unknown;
+      },
+    });
+    const store = buildCandidateStore(plotScene, {
+      datum: () => ({ xValue: 1, yValue: 2, autoMode: "exact" }),
+    });
+    void store.x;
+    batchIndexReads = 0;
+
+    const hit = store.nearest(10, 10, { mode: "exact", maxDistance: 3 });
+    expect(hit).not.toBeNull();
+    expect(hit!.id).toBeLessThan(4);
+    // Linear extended scan would touch the batch once per far vertex (~count).
+    expect(batchIndexReads).toBeLessThan(200);
+    expect(batchIndexReads).toBeLessThan(count / 10);
+  });
+
+  it("filled path still uses subpath AABB so interior probes hit", () => {
+    // Regression: stroke edge boxes must not replace fill containment shortlist.
+    const areaScene = scene();
+    areaScene.batches = [
+      {
+        kind: "paths",
+        layerIndex: 0,
+        panelIndex: 0,
+        // Large triangle; probe deep inside, far from all vertices.
+        positions: new Float32Array([0, 0, 200, 0, 100, 200]),
+        rowIndex: new Uint32Array([0, 1, 2]),
+        pathOffsets: new Uint32Array([0, 3]),
+        strokes: [null],
+        fills: [null],
+        closed: true,
+        linewidth: 0,
+        alpha: 1,
+        curve: "linear",
+      },
+    ];
+    const areaStore = buildCandidateStore(areaScene, {
+      datum: () => ({ xValue: 1, yValue: 2, autoMode: "exact" }),
+    });
+    expect(areaStore.nearest(100, 50, { mode: "exact", maxDistance: 0 })?.id).toBeDefined();
+  });
+
   it("builds stores that include glyph batches without throwing", () => {
     const plotScene = scene();
     plotScene.batches = [


### PR DESCRIPTION
## Summary

**Audit target:** `packages/core/src` (rotation after svelte #283)

**Finding:** CandidateStore tagged every stroked path vertex with the **full subpath AABB**. A plot-spanning `geom_line` put all V vertices in one giant size class, so `nearest`/`exact` shortlist refined **Θ(V)** candidates. Hit-index already uses edge shortlists for strokes (#280); the store did not.

**n:** V = vertices on a stroked subpath (≈ series length for dense lines).

**Fix:**
- Stroked paths (`fills === undefined`): extended AABB = incident edges only (vertex ± neighbors in subpath), pad linewidth/2 + hit tol
- Filled paths: keep full subpath AABB (containment far from vertices)
- Complexity tests: mid-edge hit, dense far polyline shortlist, fill interior regression

## Complexity

| Path | Before | After |
|------|--------|-------|
| Stroked path nearest shortlist | Θ(V) on long series | **O(log V + k)** size-classed edge boxes |
| Filled path containment | subpath AABB | unchanged |

## Test plan

- [x] `bun test packages/core/tests/candidate-store.test.ts` (35 pass)
- [x] Pre-push suite

## Out of scope

- LOESS buffer reuse (GC/constant-factor)
- geometry `positionOf` recompute (~2–3×)
- canvas rect/path run batching
