### PR TITLE
perf(svelte): single-pass precise-bounds keys + lineageCount

### DIFF
--- a/packages/svelte/src/lib/interval/consumption.ts
+++ b/packages/svelte/src/lib/interval/consumption.ts
@@ -31,6 +31,21 @@ export interface RecomputePanelIntervalKeysInput<Key extends PropertyKey> {
   readonly candidates: readonly IntervalConsumptionCandidate<Key>[];
 }
 
+/**
+ * Candidate bag for a single-pass panel recompute: consumption fields plus
+ * optional source-row indexes (lineage ∪ rowIndex) for lineageCount.
+ */
+type PanelIntervalProjectionCandidate<Key extends PropertyKey> =
+  IntervalConsumptionCandidate<Key> & {
+    readonly sourceRows?: Iterable<number>;
+  };
+
+export interface RecomputePanelIntervalProjectionInput<Key extends PropertyKey> {
+  readonly panelId: string;
+  readonly domains: ReadonlyIntervalDomains;
+  readonly candidates: readonly PanelIntervalProjectionCandidate<Key>[];
+}
+
 function numericAxisContains(axis: SemanticIntervalAxis, value: CellValue): boolean {
   if (axis.kind === "band") return false;
   const numeric = cellToNumber(value);
@@ -195,14 +210,35 @@ export function nextLocalIntervalRecords<Key extends PropertyKey>(
   return Object.freeze([...rest, next]);
 }
 
+/**
+ * Single-pass panel recompute after an exact bounds edit: unique semantic keys
+ * and optional lineage row count. Callers that need both keys and lineageCount
+ * must supply `sourceRows` on each candidate so the store is not scanned twice
+ * (interval-state precise-bounds path).
+ */
+export function recomputePanelIntervalProjection<Key extends PropertyKey>(
+  input: RecomputePanelIntervalProjectionInput<Key>,
+): { readonly keys: readonly Key[]; readonly lineageCount: number } {
+  const inInterval = prepareCandidateInInterval(input.domains);
+  const keys = new Set<Key>();
+  const rows = new Set<number>();
+  let trackRows = false;
+  for (const candidate of input.candidates) {
+    if (candidate.panelId !== input.panelId || !inInterval(candidate)) continue;
+    for (const key of candidate.keys) keys.add(key);
+    if (candidate.sourceRows === undefined) continue;
+    trackRows = true;
+    for (const rowIndex of candidate.sourceRows) rows.add(rowIndex);
+  }
+  return {
+    keys: Object.freeze([...keys]),
+    lineageCount: trackRows ? rows.size : 0,
+  };
+}
+
 /** Recompute one panel's committed keys after an exact bounds edit. */
 export function recomputePanelIntervalKeys<Key extends PropertyKey>(
   input: RecomputePanelIntervalKeysInput<Key>,
 ): readonly Key[] {
-  const inInterval = prepareCandidateInInterval(input.domains);
-  return uniqueKeys(
-    input.candidates
-      .filter((candidate) => candidate.panelId === input.panelId && inInterval(candidate))
-      .map((candidate) => candidate.keys),
-  );
+  return recomputePanelIntervalProjection(input).keys;
 }

--- a/packages/svelte/src/lib/interval/interval-state.svelte.ts
+++ b/packages/svelte/src/lib/interval/interval-state.svelte.ts
@@ -50,13 +50,11 @@ import {
   consumeIntervalKeys,
   nextLocalIntervalRecords,
   prepareCandidateInInterval,
-  recomputePanelIntervalKeys,
   sameIntervalRecord,
   type IntervalConsumptionCandidate,
 } from "./consumption.js";
 import { bandDomainValuesFromKeys, intervalPixelsFromDomains } from "./query.js";
 import { boundsEditorInputForScale, semanticAxisFromBounds } from "./precise-bounds.js";
-import { rowIndexesForCandidate } from "../selection/selection.js";
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -430,23 +428,29 @@ export function createIntervalState(deps: IntervalStateDeps): IntervalState {
     };
   }
 
-  function intervalLineageCount(targetPanelId: string, domains: ReadonlyIntervalDomains): number {
+  /**
+   * One full-store pass for precise-bounds apply: semantic keys + lineage row
+   * count for the target panel/domains. Was two walks (consumption bag then
+   * intervalLineageCount) with intermediate rowIndexesForCandidate arrays.
+   */
+  function recomputePanelIntervalSelection(
+    targetPanelId: string,
+    domains: ReadonlyIntervalDomains,
+  ): { readonly keys: readonly PropertyKey[]; readonly lineageCount: number } {
     const model = deps.model();
-    if (model === null) return 0;
-    // Band Sets once for the scan — not includes() per candidate.
+    if (model === null) return { keys: Object.freeze([]), lineageCount: 0 };
     const inInterval = prepareCandidateInInterval(domains);
+    const keys = new Set<PropertyKey>();
     const rows = new Set<number>();
     for (let id = 0; id < model.candidates.size; id++) {
       const candidate = model.candidates.candidate(id);
       if (candidate === null || candidate.panelId !== targetPanelId || !inInterval(candidate))
         continue;
-      for (const rowIndex of rowIndexesForCandidate(
-        candidate,
-        model.lineage.keys(candidate.lineage),
-      ))
-        rows.add(rowIndex);
+      for (const key of deps.candidateSemanticKeys(candidate)) keys.add(key);
+      for (const rowIndex of model.lineage.keys(candidate.lineage)) rows.add(rowIndex);
+      if (candidate.rowIndex !== null) rows.add(candidate.rowIndex);
     }
-    return rows.size;
+    return { keys: Object.freeze([...keys]), lineageCount: rows.size };
   }
 
   /** Private — no remaining external consumer (codex P2-7). */
@@ -541,11 +545,9 @@ export function createIntervalState(deps: IntervalStateDeps): IntervalState {
       ...prior?.domains,
       [event.axis]: axis,
     });
-    const keys = recomputePanelIntervalKeys({
-      panelId: targetPanelId,
-      domains,
-      candidates: intervalConsumptionCandidates(),
-    });
+    // Keys + lineageCount from one candidate-store pass (not consumption then
+    // a second lineage scan).
+    const { keys, lineageCount } = recomputePanelIntervalSelection(targetPanelId, domains);
     const next: PlotInteractionInterval<PropertyKey> = Object.freeze({
       panelId: targetPanelId,
       preset: prior?.preset ?? deps.selectConfig()?.preset ?? "independent",
@@ -583,7 +585,7 @@ export function createIntervalState(deps: IntervalStateDeps): IntervalState {
         flipped: deps.coordFlipped(),
       }),
       keys,
-      lineageCount: intervalLineageCount(targetPanelId, domains),
+      lineageCount,
       source: event.inputSource,
     });
     committedInterval = persistentSelectionOrNull(deps.selectConfig()?.persistent, eventValue);

--- a/packages/svelte/tests/interval/consumption.test.ts
+++ b/packages/svelte/tests/interval/consumption.test.ts
@@ -5,6 +5,7 @@ import {
   consumeIntervalKeys,
   nextLocalIntervalRecords,
   recomputePanelIntervalKeys,
+  recomputePanelIntervalProjection,
   sameIntervalRecord,
   type IntervalConsumptionCandidate,
 } from "../../src/lib/interval/consumption.js";
@@ -354,6 +355,55 @@ describe("facet interval consumption", () => {
         candidates,
       }),
     ).toEqual(["s2", "shared"]);
+  });
+
+  it("recomputePanelIntervalProjection returns keys and lineageCount in one pass", () => {
+    const projection = recomputePanelIntervalProjection({
+      panelId: "south",
+      domains: {
+        x: { kind: "linear", domain: [1, 3] },
+        y: { kind: "band", values: ["low"] },
+      },
+      candidates: [
+        {
+          panelId: "south",
+          xValue: 2,
+          yValue: "low",
+          keys: ["s2", "shared"],
+          sourceRows: [10, 11, 10],
+        },
+        {
+          panelId: "south",
+          xValue: 2,
+          yValue: "low",
+          keys: ["s3"],
+          sourceRows: [11, 12],
+        },
+        {
+          panelId: "north",
+          xValue: 2,
+          yValue: "low",
+          keys: ["n1"],
+          sourceRows: [99],
+        },
+      ],
+    });
+    expect(projection.keys).toEqual(["s2", "shared", "s3"]);
+    // Unique source rows on south only: 10, 11, 12
+    expect(projection.lineageCount).toBe(3);
+  });
+
+  it("recomputePanelIntervalProjection lineageCount is 0 when sourceRows omitted", () => {
+    const projection = recomputePanelIntervalProjection({
+      panelId: "south",
+      domains: {
+        x: { kind: "linear", domain: [1, 3] },
+        y: { kind: "band", values: ["low"] },
+      },
+      candidates,
+    });
+    expect(projection.keys).toEqual(["s2", "shared"]);
+    expect(projection.lineageCount).toBe(0);
   });
 
   it("recomputes panel keys against a large band domain via Set membership", () => {

--- a/packages/svelte/tests/interval/interval-state.test.ts
+++ b/packages/svelte/tests/interval/interval-state.test.ts
@@ -718,6 +718,76 @@ describe("createIntervalState bounds editor select path", () => {
     destroy();
   });
 
+  it("applyPreciseBounds resolves keys and lineageCount with one candidate key walk", () => {
+    const model = modelFor(continuousSpec());
+    const trigger = document.createElement("button");
+    let keyCalls = 0;
+    let candidateReads = 0;
+    const rawCandidates = model.candidates;
+    const spyModel = {
+      ...model,
+      candidates: {
+        get size() {
+          return rawCandidates.size;
+        },
+        candidate(id: number) {
+          candidateReads++;
+          return rawCandidates.candidate(id);
+        },
+      },
+    } as RenderModel;
+    const events: PlotSelection[] = [];
+    const { state, destroy } = mountIntervalController({
+      model: () => spyModel,
+      selectConfig: persistentSelect,
+      candidateSemanticKeys: (candidate) => {
+        keyCalls++;
+        return identityCandidateKeys(candidate);
+      },
+      emitSelection: (event) => {
+        events.push(event);
+      },
+    });
+
+    // Wide domain so both continuous points remain in-interval after the edit.
+    state.applyBrushSelectEnd(
+      brushEvent(spyModel, {
+        domain: { x: [0, 20], y: [0, 30] },
+        keys: ["0", "1"],
+      }),
+      "pointer",
+    );
+    flushSync();
+    state.openBoundsEditor("select", "x", trigger);
+    flushSync();
+
+    keyCalls = 0;
+    candidateReads = 0;
+    events.length = 0;
+    state.applyPreciseBounds({
+      source: "precise-bounds",
+      inputSource: "keyboard",
+      action: "select",
+      axis: "x",
+      reversed: false,
+      scale: "linear",
+      bounds: [0, 15],
+    });
+    flushSync();
+
+    // One store pass for keys+lineage (was consumption bag + lineage scan).
+    expect(candidateReads).toBe(rawCandidates.size);
+    expect(keyCalls).toBeGreaterThan(0);
+    expect(keyCalls).toBeLessThanOrEqual(rawCandidates.size);
+    expect(events).toHaveLength(1);
+    const end = events[0];
+    expect(
+      end !== undefined && "lineageCount" in end ? end.lineageCount : -1,
+    ).toBeGreaterThanOrEqual(0);
+
+    destroy();
+  });
+
   it("open → input; apply updates record (persistent) and emits once; non-persistent emits without record", () => {
     const model = modelFor(continuousSpec());
     const events: PlotSelection[] = [];


### PR DESCRIPTION
## Summary

**Audit target:** `packages/svelte/src` (rotation after core #284)

**Finding:** `applyPreciseBounds` walked the candidate store twice — once to build a consumption bag for keys (`intervalConsumptionCandidates` → `recomputePanelIntervalKeys`), then again in `intervalLineageCount` for `lineageCount`. Brush path already fused keys+count; precise bounds was the outlier.

**n:** C = candidate-store size on bounds Apply.

**Fix:**
- One private pass `recomputePanelIntervalSelection` collects semantic keys + lineage row set
- Pure `recomputePanelIntervalProjection` for unit tests (optional `sourceRows`)
- `recomputePanelIntervalKeys` remains as keys-only wrapper
- Drop intermediate `rowIndexesForCandidate` array/`includes` on this path

## Complexity

| Path | Before | After |
|------|--------|-------|
| Precise-bounds apply | O(2C) store walks | **O(C)** one walk |

## Test plan

- [x] consumption: projection keys + lineageCount; keys-only lineageCount 0
- [x] interval-state: one `candidate()` pass per apply (spy)
- [x] Existing precise-bounds / interval-state suite

## Out of scope

- LOESS / geometry / canvas rect batching (core)
