### PR TITLE
chore: backfill changesets for spec fix/perf and 0.2.0 changelog

### DIFF
--- a/.changeset/perf-hardening-backfill.md
+++ b/.changeset/perf-hardening-backfill.md
@@ -1,0 +1,33 @@
+---
+"@ggsvelte/core": patch
+"@ggsvelte/svelte": patch
+---
+
+# Performance and hardening backfill
+
+Changelog backfill for the performance, bug-fix, and internal-architecture work
+merged between v0.1.1 and this release that did not carry individual
+changesets.
+
+Performance:
+
+- Stroked-path hit-testing resolves candidates through an edge AABB shortlist
+  (O(log E + k) instead of scanning every edge).
+- Canvas segment strokes batch mirror points and render in Θ(runs); canvas
+  accessibility rows are not materialised while the data table is closed.
+- Selection membership checks use parallel `Set`s (O(1) per key), and
+  non-union interval walks fuse with a shared candidate projection.
+- Many further allocation and traversal reductions across scales, legends,
+  facets, tooltips, and interaction controllers.
+
+Fixes:
+
+- Keyed `seedId` pin rebinds require a role match.
+- Legend filter chrome honors `--gg-tooltip-background` and preserves
+  contrast; forced-colors paint is deterministic for disabled-at-SSR tool
+  buttons.
+- Restored interval selections no longer hit an SSR temporal-dead-zone error.
+- Annotation frames stay rowless for `inputGroups`.
+
+Internals: source modules were split into smaller single-concern units
+(validate, normalize, error catalog, controllers) with no public API change.

--- a/.changeset/spec-lint-limits-and-perf.md
+++ b/.changeset/spec-lint-limits-and-perf.md
@@ -1,0 +1,12 @@
+---
+"@ggsvelte/spec": patch
+---
+
+# Honor options.limits in standalone lintSpec, plus lint performance
+
+Standalone `lintSpec` previously always passed the default validate limits to
+field-evidence resolution, so raising or lowering `maxRows`/`maxBytes` via
+`options.limits` had no effect; it now merges `options.limits` the same way
+`validate()` does. Linting also short-circuits `isPortable` on the first issue
+and shares field evidence between data checks and lint instead of resolving it
+twice.


### PR DESCRIPTION
## Why

Release PR #45 only knows about the 4 PRs that added `.changeset/*.md` files. Two gaps found while investigating it:

1. **`@ggsvelte/spec` was not going to be republished at all.** It has 7 unreleased `src` commits since `@ggsvelte/spec@0.1.1` — including the behavioral fix `fix(spec): honor options.limits in standalone lintSpec` (#210) and lint perf work (#190, #191) — but no changeset, so `changeset publish` would leave npm at 0.1.1 and the fix would silently never ship.
2. **The 0.2.0 CHANGELOG omits the ~200 perf/fix/refactor PRs** merged without changesets. Once #45 merges the pending changesets are consumed, so this is the last chance to backfill.

## What

- `.changeset/spec-lint-limits-and-perf.md` — patch for `@ggsvelte/spec` (limits fix + lint perf). Via the linked group, spec releases as **0.2.0** alongside core and svelte, and `updateInternalDependencies` bumps core/svelte's `@ggsvelte/spec` ranges to `^0.2.0`.
- `.changeset/perf-hardening-backfill.md` — patch-level summary for `@ggsvelte/core` + `@ggsvelte/svelte` covering the perf overhaul, user-visible fixes, and internal module splits since v0.1.1.

Verified locally: `changeset status` now reports all three packages bumping minor together.

After merge, the changesets bot will force-push #45 to include these entries; #45 remains the release trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)