### PR TITLE
feat(ci): non-blocking changeset visibility comment on PRs

### DIFF
--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -1,0 +1,92 @@
+# Changeset visibility — non-blocking, in-repo changeset-bot equivalent.
+# All third-party actions pinned by full commit SHA (zizmor-enforced).
+#
+# Changesets only records PRs that add a .changeset/*.md file; every other PR
+# merges silently with no CHANGELOG entry and no version-bump influence
+# (release PR #45 shipped ~200 PRs with 4 entries). Decision logic and the
+# comment body live in scripts/changeset-check.ts (unit tested by
+# scripts/changeset-check.test.ts); this workflow only computes the PR diff
+# and syncs one sticky comment.
+#
+# Deliberately NOT a merge gate: internal-only changes are the common case in
+# this repo, and forcing contributors to commit empty changesets is worse
+# than an ignorable comment. The job succeeds on every verdict.
+name: Changeset check
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions: {}
+
+concurrency:
+  group: changeset-check-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  comment:
+    name: changeset visibility comment
+    # Skip the changesets bot's own Version Packages PR (its whole point is
+    # consuming changesets) and fork PRs (fork tokens are read-only, so the
+    # comment sync below could not write anyway).
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.head.ref != 'changeset-release/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.3.14
+      # No bun install: the script uses only bun/node builtins.
+      - id: decide
+        name: classify PR diff → changeset verdict
+        env:
+          # PR base SHA is trustworthy; github.sha is the merge commit that
+          # actions/checkout checked out (same protocol as ci.yml routing).
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Ensure the base object exists for the three-dot diff.
+          git fetch --no-tags --depth=1 origin "${BASE_SHA}" 2>/dev/null || true
+          git diff --name-only "${BASE_SHA}...${HEAD_SHA}" |
+            bun scripts/changeset-check.ts emit --stdin --body-out "${RUNNER_TEMP}/changeset-comment.md"
+      - name: sync sticky comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERDICT: ${{ steps.decide.outputs.verdict }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Keep in sync with COMMENT_MARKER in scripts/changeset-check.ts
+          # (asserted by scripts/changeset-check.test.ts).
+          existing_id=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate \
+            --jq '.[] | select(.body | contains("<!-- ggsvelte-changeset-check -->")) | .id' |
+            head -n1)
+          body_file="${RUNNER_TEMP}/changeset-comment.md"
+          if [ "${VERDICT}" = "missing" ]; then
+            if [ -n "${existing_id}" ]; then
+              gh api --method PATCH "repos/${REPO}/issues/comments/${existing_id}" -F "body=@${body_file}" > /dev/null
+            else
+              gh api --method POST "repos/${REPO}/issues/${PR_NUMBER}/comments" -F "body=@${body_file}" > /dev/null
+            fi
+            echo "verdict=missing — sticky comment synced"
+          elif [ -n "${existing_id}" ]; then
+            # A comment from an earlier push is stale — update it to the
+            # resolved wording instead of leaving a false warning.
+            gh api --method PATCH "repos/${REPO}/issues/comments/${existing_id}" -F "body=@${body_file}" > /dev/null
+            echo "verdict=${VERDICT} — stale comment updated"
+          else
+            echo "verdict=${VERDICT} — nothing to comment"
+          fi

--- a/scripts/changeset-check.test.ts
+++ b/scripts/changeset-check.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "bun:test";
+
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  COMMENT_MARKER,
+  decideChangesetComment,
+  discoverPublishedPackages,
+  renderComment,
+} from "./changeset-check";
+
+const root = join(import.meta.dir, "..");
+
+/** Fixture mirroring the real published workspace shape (see discovery test). */
+const PACKAGES = [
+  { dir: "packages/core", name: "@ggsvelte/core", shipped: ["dist", "src"] },
+  { dir: "packages/spec", name: "@ggsvelte/spec", shipped: ["dist", "schema", "src"] },
+  { dir: "packages/svelte", name: "@ggsvelte/svelte", shipped: ["dist", "bin", "skills"] },
+];
+
+describe("decideChangesetComment", () => {
+  it("reports changeset-present when the PR adds a changeset file", () => {
+    const decision = decideChangesetComment(
+      [".changeset/my-change.md", "packages/core/src/scales.ts"],
+      PACKAGES,
+    );
+    expect(decision.verdict).toBe("changeset-present");
+  });
+
+  it("reports missing when shipped package code changes without a changeset", () => {
+    const decision = decideChangesetComment(
+      ["packages/core/src/scales.ts", "packages/svelte/bin/ggsvelte-render.js", "README.md"],
+      PACKAGES,
+    );
+    expect(decision.verdict).toBe("missing");
+    expect(decision.touched).toEqual([
+      "packages/core/src/scales.ts",
+      "packages/svelte/bin/ggsvelte-render.js",
+    ]);
+  });
+
+  it("treats a published package.json change as shipped surface", () => {
+    const decision = decideChangesetComment(["packages/svelte/package.json"], PACKAGES);
+    expect(decision.verdict).toBe("missing");
+    expect(decision.touched).toEqual(["packages/svelte/package.json"]);
+  });
+
+  it("stays quiet for changes outside shipped package surfaces", () => {
+    const decision = decideChangesetComment(
+      [
+        "apps/docs/src/routes/+page.svelte",
+        "packages/core/tests/scales.test.ts",
+        "packages/svelte/vitest.config.ts",
+        "packages/spec/README.md",
+        "packages/spec/CHANGELOG.md",
+        ".github/workflows/ci.yml",
+        "scripts/ci-routing.ts",
+      ],
+      PACKAGES,
+    );
+    expect(decision.verdict).toBe("not-needed");
+  });
+
+  it("stays quiet for test files colocated inside shipped dirs", () => {
+    const decision = decideChangesetComment(
+      ["packages/core/src/scales.test.ts", "packages/spec/src/lint.spec.ts"],
+      PACKAGES,
+    );
+    expect(decision.verdict).toBe("not-needed");
+  });
+
+  it("does not count .changeset/README.md as a changeset", () => {
+    const decision = decideChangesetComment(
+      [".changeset/README.md", "packages/core/src/scales.ts"],
+      PACKAGES,
+    );
+    expect(decision.verdict).toBe("missing");
+  });
+});
+
+describe("changeset-check workflow wiring", () => {
+  const workflow = readFileSync(join(root, ".github/workflows/changeset-check.yml"), "utf8");
+
+  it("routes the PR diff through the tested script", () => {
+    expect(workflow).toContain("bun scripts/changeset-check.ts emit --stdin");
+  });
+
+  it("can write PR comments but nothing else", () => {
+    expect(workflow).toContain("permissions: {}");
+    expect(workflow).toContain("pull-requests: write");
+    expect(workflow).toContain("persist-credentials: false");
+  });
+
+  it("skips the bot's own Version Packages PR and fork PRs", () => {
+    expect(workflow).toContain("changeset-release/main");
+    expect(workflow).toContain(
+      "github.event.pull_request.head.repo.full_name == github.repository",
+    );
+  });
+
+  it("stays non-blocking and syncs one sticky comment via the shared marker", () => {
+    expect(workflow).not.toContain("exit 1");
+    expect(workflow).toContain(COMMENT_MARKER);
+  });
+});
+
+describe("emit CLI", () => {
+  it("writes the verdict to GITHUB_OUTPUT and the comment body to --body-out", () => {
+    const dir = mkdtempSync(join(tmpdir(), "changeset-check-"));
+    const outputFile = join(dir, "github-output");
+    const bodyFile = join(dir, "comment.md");
+    writeFileSync(outputFile, "");
+    const result = Bun.spawnSync({
+      cmd: [
+        "bun",
+        join(root, "scripts/changeset-check.ts"),
+        "emit",
+        "--stdin",
+        "--body-out",
+        bodyFile,
+      ],
+      stdin: Buffer.from("packages/core/src/scales.ts\n"),
+      env: { ...process.env, GITHUB_OUTPUT: outputFile },
+    });
+    expect(result.exitCode).toBe(0);
+    expect(readFileSync(outputFile, "utf8")).toContain("verdict=missing");
+    expect(readFileSync(bodyFile, "utf8")).toContain("packages/core/src/scales.ts");
+  });
+});
+
+describe("discoverPublishedPackages", () => {
+  it("finds exactly the npm-published workspace packages with their shipped dirs", () => {
+    // Real-repo fixture: if a package is added, made private, or reshapes its
+    // npm `files`, this test is the reminder to reconfirm the check's scope.
+    expect(discoverPublishedPackages(root)).toEqual(PACKAGES);
+  });
+});
+
+describe("renderComment", () => {
+  it("explains a missing changeset without blocking, and lists touched files", () => {
+    const body = renderComment({
+      verdict: "missing",
+      touched: ["packages/core/src/scales.ts", "packages/core/src/theme.ts"],
+    });
+    expect(body).toContain(COMMENT_MARKER);
+    expect(body).toContain("bun changeset");
+    expect(body).toContain("packages/core/src/scales.ts");
+    expect(body).toContain("not block");
+  });
+
+  it("caps the touched-file listing at 10 and reports the remainder", () => {
+    const touched = Array.from({ length: 14 }, (_, i) => `packages/core/src/mod-${i}.ts`);
+    const body = renderComment({ verdict: "missing", touched });
+    expect(body).toContain("packages/core/src/mod-9.ts");
+    expect(body).not.toContain("packages/core/src/mod-10.ts");
+    expect(body).toContain("4 more");
+  });
+
+  it("acknowledges a changeset once one is added", () => {
+    const body = renderComment({ verdict: "changeset-present", touched: [] });
+    expect(body).toContain(COMMENT_MARKER);
+    expect(body).toContain("Changeset detected");
+  });
+
+  it("marks internal-only PRs as needing nothing", () => {
+    const body = renderComment({ verdict: "not-needed", touched: [] });
+    expect(body).toContain(COMMENT_MARKER);
+    expect(body).toContain("No changeset needed");
+  });
+});

--- a/scripts/changeset-check.ts
+++ b/scripts/changeset-check.ts
@@ -1,0 +1,154 @@
+/**
+ * Changeset visibility check — non-blocking changeset-bot equivalent.
+ *
+ * Changesets only records PRs that add a `.changeset/*.md` file; a PR without
+ * one merges silently and never reaches the CHANGELOG or a version bump
+ * (release PR #45 shipped ~200 PRs with 4 changelog entries). This script
+ * decides whether a PR touches npm-published code without declaring a
+ * changeset so the workflow can leave a sticky informational comment.
+ *
+ * Deliberately NOT a merge gate: internal-only changes are the common case in
+ * this repo and forcing empty changesets is worse than an ignorable comment.
+ */
+
+import { appendFileSync, existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+export type PublishedPackage = {
+  /** Repo-relative package dir, e.g. "packages/core". */
+  dir: string;
+  name: string;
+  /** npm `files` entries — the dirs that ship in the tarball. */
+  shipped: string[];
+};
+
+export type Verdict = "changeset-present" | "not-needed" | "missing";
+
+export type Decision = {
+  verdict: Verdict;
+  /** Published files the PR touches (empty unless verdict is "missing"). */
+  touched: string[];
+};
+
+/**
+ * Read the npm-published workspace packages from packages/*. Published means
+ * no `"private": true`; `shipped` mirrors the npm `files` field (the dirs
+ * that actually reach the tarball).
+ */
+export function discoverPublishedPackages(root: string): PublishedPackage[] {
+  const packages: PublishedPackage[] = [];
+  for (const entry of readdirSync(join(root, "packages"), { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const manifestPath = join(root, "packages", entry.name, "package.json");
+    if (!existsSync(manifestPath)) continue;
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf8")) as {
+      name?: string;
+      private?: boolean;
+      files?: string[];
+    };
+    if (manifest.private === true || typeof manifest.name !== "string") continue;
+    packages.push({
+      dir: `packages/${entry.name}`,
+      name: manifest.name,
+      shipped: manifest.files ?? [],
+    });
+  }
+  return packages.toSorted((a, b) => a.dir.localeCompare(b.dir));
+}
+
+/** Hidden marker the workflow greps for to find/update its own comment. */
+export const COMMENT_MARKER = "<!-- ggsvelte-changeset-check -->";
+
+const LISTING_CAP = 10;
+
+export function renderComment(decision: Decision): string {
+  if (decision.verdict === "changeset-present") {
+    return `${COMMENT_MARKER}\n✅ **Changeset detected.** This PR's changes will appear in the next Version Packages PR and CHANGELOG.\n`;
+  }
+  if (decision.verdict === "not-needed") {
+    return `${COMMENT_MARKER}\n**No changeset needed.** This PR does not touch npm-published package code.\n`;
+  }
+  const shown = decision.touched.slice(0, LISTING_CAP).map((f) => `- \`${f}\``);
+  const rest = decision.touched.length - LISTING_CAP;
+  if (rest > 0) {
+    shown.push(`- …and ${rest} more`);
+  }
+  return [
+    COMMENT_MARKER,
+    "⚠️ **No changeset found**, but this PR changes npm-published code:",
+    "",
+    ...shown,
+    "",
+    "Without a changeset this PR will publish silently: no CHANGELOG entry, no",
+    "version-bump influence (see how release PR #45 covered ~200 PRs with 4",
+    "entries). If consumers should hear about this change, add one:",
+    "",
+    "```sh",
+    "bun changeset",
+    "```",
+    "",
+    "This check does **not block** merging — internal-only or",
+    "not-worth-announcing changes can ignore it.",
+    "",
+  ].join("\n");
+}
+
+function isChangesetFile(path: string): boolean {
+  return /^\.changeset\/(?!README\.md$)[^/]+\.md$/.test(path);
+}
+
+function isShippedPath(path: string, pkg: PublishedPackage): boolean {
+  if (path === `${pkg.dir}/package.json`) return true;
+  // Colocated test files live under src/ but are not part of the consumer
+  // surface a changelog entry describes.
+  if (/\.(test|spec)\.[jt]sx?$/.test(path)) return false;
+  return pkg.shipped.some((dir) => path.startsWith(`${pkg.dir}/${dir}/`));
+}
+
+export function decideChangesetComment(
+  changedFiles: string[],
+  packages: PublishedPackage[],
+): Decision {
+  if (changedFiles.some((path) => isChangesetFile(path))) {
+    return { verdict: "changeset-present", touched: [] };
+  }
+  const touched = changedFiles.filter((path) => packages.some((pkg) => isShippedPath(path, pkg)));
+  if (touched.length > 0) {
+    return { verdict: "missing", touched };
+  }
+  return { verdict: "not-needed", touched: [] };
+}
+
+async function readStdinPaths(): Promise<string[]> {
+  const text = await new Response(Bun.stdin.stream()).text();
+  return text
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+
+async function runEmitCli(args: string[]): Promise<void> {
+  const bodyOutIndex = args.indexOf("--body-out");
+  const bodyOut = bodyOutIndex === -1 ? undefined : args[bodyOutIndex + 1];
+  if (!args.includes("--stdin") || bodyOut === undefined) {
+    throw new Error("usage: changeset-check.ts emit --stdin --body-out <path>");
+  }
+  const files = await readStdinPaths();
+  const decision = decideChangesetComment(files, discoverPublishedPackages(process.cwd()));
+  writeFileSync(bodyOut, renderComment(decision));
+  const outputs = `verdict=${decision.verdict}\n`;
+  const githubOutput = process.env.GITHUB_OUTPUT;
+  if (typeof githubOutput === "string" && githubOutput.length > 0) {
+    appendFileSync(githubOutput, outputs);
+  }
+  process.stdout.write(outputs);
+}
+
+if (import.meta.main) {
+  const [cmd, ...rest] = process.argv.slice(2);
+  if (cmd !== "emit") {
+    console.error("usage: changeset-check.ts emit --stdin --body-out <path>");
+    process.exit(1);
+  }
+  await runEmitCli(rest);
+}


### PR DESCRIPTION
## Why

Changesets only ever sees PRs that add a `.changeset/*.md` file — release PR #45 shipped ~200 PRs with 4 changelog entries, and nothing in CI ever surfaced that. The official changeset-bot GitHub App would comment on every PR, but an in-repo check can be tested, scoped to npm-published surfaces, and stays silent on internal-only PRs. **Explicitly not a merge gate**: no forced empty changesets, the job succeeds on every verdict.

## What

- **`scripts/changeset-check.ts`** — pure decision logic. Verdicts:
  - `changeset-present` — PR adds a changeset (`.changeset/README.md` doesn't count)
  - `missing` — PR touches published surfaces without one: `packages/*` npm `files` dirs + `package.json`, minus colocated `*.test.ts`/`*.spec.ts`
  - `not-needed` — everything else (docs, tests, CI, apps, spikes) → **no comment, no noise**
  - Published packages discovered from `packages/*/package.json` (`private`/`files`), so scope follows the workspace.
- **`scripts/changeset-check.test.ts`** — TDD'd unit tests, a real-subprocess CLI test, a real-repo discovery drift alarm, and release-wiring-style assertions on the workflow (non-blocking, marker sync, fork + `changeset-release/main` skip). Runs in the existing `bun test scripts` lane.
- **`.github/workflows/changeset-check.yml`** — computes the PR diff from event SHAs (same protocol as ci.yml routing), pipes it to the script, syncs one sticky marker comment via `gh api` (creates on `missing`, updates to ✅ once a changeset lands, stays silent otherwise). All interpolations env-quoted; actions SHA-pinned; `permissions: {}` + job-scoped `contents: read` / `pull-requests: write`.

## Verification

- `bun test scripts` — 175 pass (16 new)
- `uvx zizmor==1.26.1` on the new workflow — no findings
- `bun run lint:actions`, `bun run knip`, `bun run lint:type-aware`, oxfmt/prettier — clean
- Dogfood: piping this branch's own diff through the CLI yields `not-needed` (scripts + workflow only — correctly silent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)