### PR TITLE
docs+test: post-0.1 migration policy, upgrading guide, migration fixtures

### DIFF
--- a/.changeset/interactive-legend-focus.md
+++ b/.changeset/interactive-legend-focus.md
@@ -8,3 +8,5 @@
 Add opt-in pointer, touch, and keyboard legend controls; stable-key emphasis
 propagation; renderer-neutral focus masks with SVG/canvas parity; 24-pixel
 legend targets; typed events and diagnostics; and a three-view example.
+
+Migration: none — additive

--- a/.changeset/linked-interaction-controller.md
+++ b/.changeset/linked-interaction-controller.md
@@ -7,3 +7,5 @@
 Add `createPlotInteraction`, controlled selection and zoom, presentation-only
 emphasis, stable semantic scopes, explicit key reconciliation, and a complete
 linked plots-controls-table example.
+
+Migration: <https://ljodea.github.io/ggsvelte/guide/upgrading#0-1-to-0-2>

--- a/.changeset/precise-filtered-facets.md
+++ b/.changeset/precise-filtered-facets.md
@@ -9,3 +9,5 @@ Filter discrete legend groups without changing their color identity, coordinate
 durable interval selections across facets with independent, union, or
 cross-panel semantics, and enter exact accessible selection or zoom bounds for
 linear, log, time, reversed, and band scales.
+
+Migration: none — additive

--- a/.changeset/raise-svelte-floor.md
+++ b/.changeset/raise-svelte-floor.md
@@ -10,3 +10,5 @@ the library no longer carries wiring constraints for the 5.29 eager behavior.
 Only the eager-derived declaration constraint is removed — internal controller
 construction order and effect-registration order are unchanged. Consumers on
 Svelte 5.29.0–5.33.0 must upgrade Svelte to take this release.
+
+Migration: <https://ljodea.github.io/ggsvelte/guide/upgrading#0-1-to-0-2>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -337,7 +337,10 @@ staleness-tested). The docs lifecycle page and llms surfaces render from it.
 - **stable-intent** — the agent core path: `PortableSpec`, `normalize`,
   `validate` (+ `ValidateResult`/`SpecError` contracts), `renderToSVGString`,
   `GGPlot`. Not frozen pre-1.0, but changes are treated as breaking: they get
-  a changeset, a migration note, and a deprecation window where feasible.
+  a changeset with a `Migration:` marker, an upgrading-guide section, and a
+  deprecation window of at least one full minor release. The precise rules
+  (windows, fixtures, runtime checks, codemod bar) are decision 0013
+  (`docs/decisions/0013-post-0-1-migration-policy.md`).
 - **stable** — committed API under semver. Nothing is `stable` pre-0.1.0.
 - **superseded** — keeps working but stops being recommended; docs point at
   the replacement. This tag exists to protect agent-generated code from

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ CLI: `ggsvelte-render spec.json > chart.svg` (JSON-line diagnostics on stderr).
 - [Guide and examples](https://ljodea.github.io/ggsvelte/)
 - [Interactions and event reference](https://ljodea.github.io/ggsvelte/guide/interactions)
 - [Local data playground](https://ljodea.github.io/ggsvelte/playground)
+- [Upgrading between releases](https://ljodea.github.io/ggsvelte/guide/upgrading)
 - [Pre-0.1 interaction migration](https://ljodea.github.io/ggsvelte/guide/migrating-pre-0-1)
 - [Lifecycle and editions](https://ljodea.github.io/ggsvelte/guide/lifecycle)
 

--- a/docs/decisions/0013-post-0-1-migration-policy.md
+++ b/docs/decisions/0013-post-0-1-migration-policy.md
@@ -1,0 +1,155 @@
+# 0013 — Post-0.1 migration policy: upgrade checks, migrations, codemods
+
+- **Status:** accepted
+- **Date:** 2026-07-18
+- **Scope:** issue #7 — versioned migration policy, deprecated-surface and
+  ambiguous-capability checks, codemod evaluation, migration docs wiring.
+- **Artifacts:** `/guide/upgrading` (rolling upgrade page, `UPGRADING_MD` in
+  `scripts/gen-llms.ts`), `packages/svelte/tests/migrations/` (type-checked
+  fixtures), `scripts/migration-fixtures.test.ts`,
+  `scripts/deprecation-wiring.test.ts`.
+
+## Context
+
+Before 0.1, interaction API changes could delete surfaces outright (the
+pre-0.1 rename is a one-shot manual guide, `/guide/migrating-pre-0-1`, with
+"no runtime compatibility shim"). 0.1.x is published on npm; upgrades are now
+real events that need deliberate support. 0.1 → 0.2 itself is **additive** —
+every 0.1 prop, callback, and export survives; the controller API
+(`createPlotInteraction`) arrives alongside, not instead of, chart-local
+props — so this record establishes the policy and the smallest set of live
+artifacts, and defers machinery that has no real case yet to trigger-bound
+follow-up issues rather than shipping it dormant.
+
+## Versioning and support windows
+
+- Pre-1.0, breaking changes ride **minor** releases. The linked changeset
+  group (`spec`/`core`/`svelte`) versions together.
+- `stable-intent` surfaces (per `lifecycle.json`) get a deprecation window of
+  at least **one full minor release**: deprecated in 0.N means removable in
+  0.N+2 at the earliest. "Deprecated in 0.2, removed in 0.3" does NOT satisfy
+  the window.
+- `superseded` surfaces survive until a **major** release (restates the
+  stronger rule in CONTRIBUTING.md "Deprecation policy").
+- `experimental` surfaces may change in any minor with a migration note only.
+- Migration guidance is maintained for **adjacent-minor** transitions; older
+  starting points chain through the per-transition sections of
+  `/guide/upgrading` (rolling page, one stable anchor per transition; an
+  outsized transition may get its own page, linked from its section, as the
+  pre-0.1 page already is).
+
+## Per-migration requirements (same PR as the change)
+
+Every PR that deprecates, reshapes, or removes a published surface ships:
+
+1. A changeset whose body carries an explicit `Migration:` marker — an
+   absolute `/guide/upgrading` anchor URL, or the literal
+   `Migration: none — additive`. Enforced for every minor/major changeset by
+   `scripts/deprecation-wiring.test.ts` (markers, not prose sniffing, so
+   additive minors must say so and non-additive ones cannot forget the link).
+2. An upgrading-guide section with **before/after real Svelte source**. Guide
+   code blocks are verbatim embeds of fixtures under
+   `packages/svelte/tests/migrations/` (modulo the public import specifier),
+   which svelte-check type-checks — enforced by
+   `scripts/migration-fixtures.test.ts`. Examples cannot drift from the
+   compiler's idea of the API.
+3. `@deprecated` JSDoc carrying `since <version>` and an absolute guide URL
+   whose page and anchor resolve (enforced by the wiring test; anchors are
+   computed by the docs renderer itself, never a re-derived slug algorithm).
+4. If the deprecation is **runtime-observable** (a prop or option, not a
+   type): a runtime deprecation diagnostic (requirements below).
+5. If the migration meets the codemod bar (below): a codemod with fixtures.
+   Otherwise the guide section documents the manual change explicitly.
+
+**Invariant: checks never rewrite code.** Checks are diagnostics or CI
+assertions only. Future codemods are separate, opt-in commands: dry-run/diff
+by default, writes only behind an explicit `--write`.
+
+## Runtime deprecation checks — requirements (deferred until triggered)
+
+There is nothing runtime-deprecated today (the three pre-0.1 aliases are
+type-only), so no runtime machinery ships now; a permanently empty frozen
+catalog would be dead code. The **first PR that deprecates a
+runtime-observable surface** must implement, in the same PR:
+
+- Advisory-severity diagnostics carrying `since` and removal-target metadata,
+  plus the existing `{ message, prop, suggestions, docUrl }` shape.
+- Delivery through the existing channel (`ondiagnostic`, else dev-only
+  `console.warn`), fired **once per prop per plot instance** — no spam across
+  reactive updates; silent in production builds.
+- Never a behavior change: deprecated inputs keep working through the window.
+- The concrete type design is decided then, not here: extending the closed
+  `InteractionDiagnosticCode` union vs a broader plot-level diagnostic union
+  vs separate delivery — deprecated props may not be interaction-scoped, so
+  prescribing the interaction catalog now would prejudge the wrong home.
+
+Tracked by a standing issue (see References).
+
+## Codemods — evaluation outcome (deferred until triggered)
+
+Zero mechanical post-0.1 migrations exist, so no runner ships now. Whether a
+future migration **requires** a codemod is decided by these factors — not a
+numeric prop-count threshold:
+
+- **Syntactic detectability** — can every rewrite site be found from parse
+  trees alone?
+- **Semantic confidence** — is the rewrite meaning-preserving without human
+  judgment? (The pre-0.1 `onzoom` payload narrowing is the canonical
+  counter-example: judgment required, codemod prohibited, manual guide
+  section instead.)
+- **Expected prevalence** in real consumer code.
+- **Blast radius** of a wrong rewrite.
+- **Precise identifiability of skipped cases** — anything the tool does not
+  rewrite must be reported with the guide anchor for the manual change,
+  never silently half-migrated.
+
+Acceptance criteria for any codemod, enforced by its fixtures
+(`fixtures/migrations/<from>-<to>/<case>/{input,expected}.svelte`): idempotent
+(second run is a no-op), formatting untouched outside edited ranges,
+unrecognized shapes left untouched with a printed manual-change pointer.
+Starting-point stack (revisit against the first real transformation):
+`svelte/compiler` `parse()` + `magic-string` for `.svelte` positional edits
+(jscodeshift/ts-morph cannot parse Svelte templates); a script-AST tool may
+be added for pure-TS spec files if the transform demands it.
+
+## Acceptance-criteria applicability (issue #7, honest status)
+
+| Criterion                                             | Status                        | Mechanism                                                                       |
+| ----------------------------------------------------- | ----------------------------- | ------------------------------------------------------------------------------- |
+| Real-Svelte fixture per supported migration           | Met                           | `packages/svelte/tests/migrations/` + sync test; fixtures in svelte-check scope |
+| Checks never rewrite code silently                    | Met                           | Diagnostics/CI-assertions only; dry-run-default rule above                      |
+| Codemods idempotent / format-preserving               | N/A — zero codemod candidates | ACs recorded above; enforced by the first codemod's fixtures                    |
+| Unsupported transformations explain the manual change | N/A post-0.1 — none exist     | Required guide subsection per future migration                                  |
+| Release notes link migration guidance                 | Met for 0.2                   | `Migration:` markers in all pending minors; wiring test                         |
+
+## Ambiguity-audit candidates (verdicts land with the audit)
+
+Checks for ambiguous capability combinations are added only where an audit
+confirms silently surprising behavior — diagnostics are conditional output,
+not presumed deliverables. Candidates and pre-seeded evidence:
+
+- Controller state while local props leave the capability disabled:
+  **intentional** passive-consumer pattern
+  (`packages/svelte/tests/fixtures/PassiveControllerConsumerPlot.svelte`) —
+  expected verdict: no diagnostic.
+- `interactionScope` provided without an `interaction` controller: silently
+  ignored — advisory candidate.
+- Handler prop present while its capability is off (`onselect` without
+  `select`, `onzoom` without `zoom`, `onlegendfocus`/`onlegendfilter`
+  likewise): advisory candidate; verify intentional reusable-handler and
+  spread patterns first.
+- `tool` naming an unavailable capability: already covered by
+  `INTERACTION_TOOL_UNAVAILABLE` — no new code.
+
+The audit's full combo × behavior × verdict table is appended to this record
+when it lands, so combos judged fine are recorded rather than silently
+skipped.
+
+## References
+
+- Issue #7 (scope + acceptance criteria for this record).
+- Follow-up issues (filed with this record): runtime deprecation diagnostics
+  (triggered by the first runtime-observable deprecation); codemod runner +
+  fixture harness (triggered by the first migration meeting the bar).
+- CONTRIBUTING.md "Deprecation policy"; `lifecycle.json` lifecycle tags;
+  ADR 0011/0012 for the interaction and release-automation background.

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -28,7 +28,10 @@
       "project": ["src/**", "tests/**"],
     },
     "packages/svelte": {
-      "entry": ["tests/**/*.test.ts"],
+      // tests/migrations are upgrade-guide fixtures: read by
+      // scripts/migration-fixtures.test.ts via the filesystem (not imports)
+      // and type-checked by svelte-check — invisible to knip's graph.
+      "entry": ["tests/**/*.test.ts", "tests/migrations/**"],
       "project": ["src/**", "tests/**"],
     },
     "benchmarks": {

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -86,6 +86,7 @@ ggsvelte-render spec.json --width 640 --height 400 > chart.svg
 
 - Docs + examples: <https://ljodea.github.io/ggsvelte/>
 - Repository: <https://github.com/ljodea/ggsvelte>
+- Upgrading between releases: <https://ljodea.github.io/ggsvelte/guide/upgrading>
 - Pre-0.1 interaction migration: <https://ljodea.github.io/ggsvelte/guide/migrating-pre-0-1>
 - Spec package: [`@ggsvelte/spec`](https://www.npmjs.com/package/@ggsvelte/spec)
 - Core package: [`@ggsvelte/core`](https://www.npmjs.com/package/@ggsvelte/core)

--- a/packages/svelte/src/lib/interaction/interaction.ts
+++ b/packages/svelte/src/lib/interaction/interaction.ts
@@ -381,12 +381,21 @@ export interface PlotInteractionTransition<Key extends PropertyKey> {
   readonly snapshot: PlotInteractionSnapshot<Key>;
 }
 
-/** @deprecated Use IntervalSelection. Kept as a source migration alias only. */
+/**
+ * @deprecated since 0.1.0 — use IntervalSelection. Kept as a source migration
+ * alias only: https://ljodea.github.io/ggsvelte/guide/migrating-pre-0-1#migrate-custom-tooltip-snippets
+ */
 export type BrushSelection = IntervalSelection;
-/** @deprecated Use PlotInspectionChange. */
+/**
+ * @deprecated since 0.1.0 — use PlotInspectionChange. Kept as a source
+ * migration alias only: https://ljodea.github.io/ggsvelte/guide/migrating-pre-0-1#migrate-custom-tooltip-snippets
+ */
 export type TooltipContext<
   Row = Record<string, CellValue>,
   Key = PropertyKey,
 > = PlotInspectionChange<Row, Key>;
-/** @deprecated Use ReadonlyZoomDomains. */
+/**
+ * @deprecated since 0.1.0 — use ReadonlyZoomDomains. Kept as a source
+ * migration alias only: https://ljodea.github.io/ggsvelte/guide/migrating-pre-0-1#migrate-custom-tooltip-snippets
+ */
 export type ZoomDomains = { x?: [number, number]; y?: [number, number] };

--- a/packages/svelte/tests/migrations/chart-local-selection.svelte
+++ b/packages/svelte/tests/migrations/chart-local-selection.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  import {
+    GeomPoint,
+    GGPlot,
+    type PlotSelection,
+  } from "../../src/lib/index.js";
+
+  const rows = [
+    { id: "a", flipper: 181, mass: 3750, species: "Adelie" },
+    { id: "b", flipper: 195, mass: 3800, species: "Chinstrap" },
+    { id: "c", flipper: 217, mass: 4500, species: "Gentoo" },
+  ];
+  let selection = $state<PlotSelection<string> | null>(null);
+</script>
+
+<GGPlot
+  data={rows}
+  aes={{ x: "flipper", y: "mass", color: "species" }}
+  key="id"
+  select={{ type: "point", multiple: true }}
+  onselect={(event) => (selection = event)}
+>
+  <GeomPoint />
+</GGPlot>
+
+<p>{selection === null ? 0 : selection.keys.length} selected</p>

--- a/packages/svelte/tests/migrations/deprecated-type-aliases.ts
+++ b/packages/svelte/tests/migrations/deprecated-type-aliases.ts
@@ -1,0 +1,24 @@
+/**
+ * Migration fixture: the pre-0.1 type aliases (deprecated since 0.1.0) must
+ * keep compiling — and staying assignable to their replacements — until their
+ * removal release per the migration policy (ADR 0013).
+ */
+/* oxlint-disable typescript/no-deprecated -- exercising the deprecated aliases is the point */
+import type {
+  BrushSelection,
+  IntervalSelection,
+  PlotInspectionChange,
+  ReadonlyZoomDomains,
+  TooltipContext,
+  ZoomDomains,
+} from "../../src/lib/index.js";
+
+type Row = { id: string; value: number };
+
+// Each `before` name must remain assignable to its `after` replacement while
+// the alias survives; a failed assignability turns into a compile error here.
+export const intervalCompat: BrushSelection extends IntervalSelection ? true : never = true;
+export const inspectionCompat: TooltipContext<Row, string> extends PlotInspectionChange<Row, string>
+  ? true
+  : never = true;
+export const zoomCompat: ZoomDomains extends ReadonlyZoomDomains ? true : never = true;

--- a/packages/svelte/tests/migrations/shared-controller-selection.svelte
+++ b/packages/svelte/tests/migrations/shared-controller-selection.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+  import {
+    createPlotInteraction,
+    GeomPoint,
+    GGPlot,
+  } from "../../src/lib/index.js";
+
+  const rows = [
+    { id: "a", flipper: 181, mass: 3750, species: "Adelie" },
+    { id: "b", flipper: 195, mass: 3800, species: "Chinstrap" },
+    { id: "c", flipper: 217, mass: 4500, species: "Gentoo" },
+  ];
+  const scope = { keys: "row-id", x: "flipper-mm", y: "mass-g" } as const;
+  const interaction = createPlotInteraction<string>();
+  const selected = $derived(interaction.selected(scope));
+</script>
+
+<GGPlot
+  data={rows}
+  aes={{ x: "flipper", y: "mass", color: "species" }}
+  key="id"
+  select={{ type: "point", multiple: true }}
+  {interaction}
+  interactionScope={scope}
+>
+  <GeomPoint />
+</GGPlot>
+
+<p>{selected.length} selected</p>

--- a/packages/svelte/tsconfig.json
+++ b/packages/svelte/tsconfig.json
@@ -6,5 +6,5 @@
     "noEmit": true,
     "lib": ["es2023", "dom", "dom.iterable"]
   },
-  "include": ["src/**/*", "svelte.config.js"]
+  "include": ["src/**/*", "svelte.config.js", "tests/migrations/**/*"]
 }

--- a/scripts/check-pages-links.test.ts
+++ b/scripts/check-pages-links.test.ts
@@ -16,6 +16,7 @@ describe("packed Pages link checks", () => {
     "guide/interactions.html",
     "guide/interaction-reference.html",
     "guide/migrating-pre-0-1.html",
+    "guide/upgrading.html",
     "playground.html",
     "reference/interactions.html",
     "examples/interaction/tooltip.html",

--- a/scripts/check-pages-links.ts
+++ b/scripts/check-pages-links.ts
@@ -6,6 +6,7 @@ export const requiredPages = [
   "guide/interactions.html",
   "guide/interaction-reference.html",
   "guide/migrating-pre-0-1.html",
+  "guide/upgrading.html",
   "playground.html",
   "reference/interactions.html",
   "examples/interaction/tooltip.html",

--- a/scripts/deprecation-wiring.test.ts
+++ b/scripts/deprecation-wiring.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Deprecation/release-notes wiring (ADR 0013): deprecations and
+ * version-bumping changesets must link users to migration guidance.
+ *
+ * - Every `@deprecated` JSDoc in published package sources carries
+ *   "since <version>" and an absolute upgrade-guide URL whose page and
+ *   anchor really exist (anchors come from the same renderer the docs site
+ *   uses — never a re-derived slug algorithm).
+ * - Every pending changeset with a minor or major bump for a published
+ *   package carries an explicit `Migration:` line — either a resolving
+ *   guide URL or the literal "none — additive". An explicit marker, not
+ *   prose keyword sniffing: additive minors must say so.
+ */
+import { describe, expect, it } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { LifecycleDoc } from "./gen-llms.ts";
+import { guidePages, renderMarkdown } from "./gen-llms.ts";
+
+const ROOT = join(import.meta.dir, "..");
+const GUIDE_URL_BASE = "https://ljodea.github.io/ggsvelte/guide/";
+
+const lifecycle = JSON.parse(readFileSync(join(ROOT, "lifecycle.json"), "utf8")) as LifecycleDoc;
+
+/** slug → set of heading anchors rendered by the docs site. */
+function guideAnchors(): Map<string, Set<string>> {
+  const anchors = new Map<string, Set<string>>();
+  for (const page of guidePages(lifecycle)) {
+    const ids = [...renderMarkdown(page.markdown).matchAll(/<h\d id="([^"]+)"/g)].map(
+      (match) => match[1]!,
+    );
+    anchors.set(page.slug, new Set(ids));
+  }
+  return anchors;
+}
+
+function assertGuideUrlResolves(url: string, context: string): void {
+  const anchors = guideAnchors();
+  expect(url, `${context}: migration links must use ${GUIDE_URL_BASE}`).toStartWith(GUIDE_URL_BASE);
+  const [slug = "", fragment] = url.slice(GUIDE_URL_BASE.length).split("#");
+  expect([...anchors.keys()], `${context}: unknown guide page "${slug}"`).toContain(slug);
+  if (fragment !== undefined) {
+    expect(
+      [...(anchors.get(slug) ?? [])],
+      `${context}: anchor #${fragment} missing from guide/${slug}`,
+    ).toContain(fragment);
+  }
+}
+
+function* walkSources(dir: string): Generator<string> {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) yield* walkSources(path);
+    else if (/\.(ts|svelte)$/.test(entry.name) && !entry.name.includes(".test.")) yield path;
+  }
+}
+
+/** The full JSDoc block around each `@deprecated` occurrence in a file. */
+function deprecatedBlocks(source: string): string[] {
+  const blocks: string[] = [];
+  for (const match of source.matchAll(/@deprecated/g)) {
+    const start = source.lastIndexOf("/**", match.index);
+    const end = source.indexOf("*/", match.index);
+    blocks.push(start === -1 || end === -1 ? "" : source.slice(start, end + 2));
+  }
+  return blocks;
+}
+
+describe("deprecated surfaces link migration guidance", () => {
+  const packages = ["spec", "core", "svelte"];
+
+  it("every @deprecated tag carries since-version and a resolving guide link", () => {
+    for (const pkg of packages) {
+      for (const file of walkSources(join(ROOT, "packages", pkg, "src"))) {
+        for (const block of deprecatedBlocks(readFileSync(file, "utf8"))) {
+          const context = `${file} deprecated block`;
+          expect(block, `${context}: needs "since <version>"`).toMatch(/since \d+\.\d+\.\d+/i);
+          const url = /https:\/\/\S+/.exec(block)?.[0];
+          expect(url, `${context}: needs an absolute guide URL`).toBeDefined();
+          assertGuideUrlResolves(url!, context);
+        }
+      }
+    }
+  });
+});
+
+describe("version-bumping changesets carry an explicit migration marker", () => {
+  const changesetDir = join(ROOT, ".changeset");
+  const changesets = readdirSync(changesetDir).filter(
+    (name) => name.endsWith(".md") && name !== "README.md",
+  );
+
+  it("every minor/major changeset states its migration story", () => {
+    for (const name of changesets) {
+      const body = readFileSync(join(changesetDir, name), "utf8");
+      const frontmatter = /^---\n([\s\S]*?)\n---/.exec(body)?.[1] ?? "";
+      const bumps = [...frontmatter.matchAll(/"@ggsvelte\/[^"]+":\s*(minor|major)/g)];
+      if (bumps.length === 0) continue;
+      const context = `.changeset/${name}`;
+      const marker = /Migration: (\S[^\n]*)/.exec(body)?.[1];
+      expect(
+        marker,
+        `${context}: minor/major changesets need "Migration: <guide URL>" or "Migration: none — additive"`,
+      ).toBeDefined();
+      if (marker! !== "none — additive") {
+        // Changeset URLs use markdown autolink form (<https://…>) — MD034.
+        assertGuideUrlResolves(marker!.trim().replaceAll(/^<|>$/g, ""), context);
+      }
+    }
+  });
+});

--- a/scripts/gen-llms.test.ts
+++ b/scripts/gen-llms.test.ts
@@ -26,6 +26,7 @@ import {
   INTERACTION_REFERENCE_MD,
   INTERACTION_REFERENCE_INDEX,
   MIGRATING_PRE_0_1_MD,
+  UPGRADING_MD,
   guidePages,
   pruneSpecData,
   renderMarkdown,
@@ -188,6 +189,26 @@ describe("guide sections cover their catalogs", () => {
     expect(MIGRATING_PRE_0_1_MD).toContain("`TooltipContext` → `PlotInspectionChange`");
     expect(MIGRATING_PRE_0_1_MD).toContain("`BrushSelection` → `IntervalSelection`");
   });
+
+  it("provides a rolling upgrading guide with a stable per-transition anchor", () => {
+    // One section per release transition; changesets link these anchors, so
+    // heading ids must come from the same renderer the docs site uses.
+    expect(UPGRADING_MD).toContain("## 0.1 to 0.2");
+    expect(renderMarkdown(UPGRADING_MD)).toContain('id="0-1-to-0-2"');
+  });
+
+  it("states the 0.1→0.2 upgrade contract: additive, controller optional", () => {
+    expect(UPGRADING_MD).toContain("No source changes are required");
+    // Controller adoption is optional — both APIs remain supported.
+    expect(UPGRADING_MD).toContain("createPlotInteraction");
+    expect(UPGRADING_MD).toContain("optional");
+    // Deprecated aliases predate 0.2 and point at their own migration page.
+    expect(UPGRADING_MD).toContain("`BrushSelection` → `IntervalSelection`");
+    expect(UPGRADING_MD).toContain("`TooltipContext` → `PlotInspectionChange`");
+    expect(UPGRADING_MD).toContain("`ZoomDomains` → `ReadonlyZoomDomains`");
+    expect(UPGRADING_MD).toContain("deprecated since 0.1.0");
+    expect(UPGRADING_MD).toContain("/guide/migrating-pre-0-1");
+  });
 });
 
 describe("pruneSpecData", () => {
@@ -234,6 +255,7 @@ describe("llms surfaces", () => {
     expect(pages.map((page) => page.slug)).toContain("interactions");
     expect(pages.map((page) => page.slug)).toContain("interaction-reference");
     expect(pages.map((page) => page.slug)).toContain("migrating-pre-0-1");
+    expect(pages.map((page) => page.slug)).toContain("upgrading");
     expect(pages.map((page) => page.slug)).toContain("compatibility");
   });
 

--- a/scripts/gen-llms.ts
+++ b/scripts/gen-llms.ts
@@ -954,6 +954,109 @@ See [Interactions](/guide/interactions) for current options, event shapes,
 keyboard behavior, and identity requirements.
 `;
 
+export const UPGRADING_MD = `# Upgrading ggsvelte
+
+One section per released 0.x transition, newest first. Each heading is a
+stable anchor that changesets and release notes link to. Pre-1.0, breaking
+changes ride minor releases; every deprecation or removal ships with a
+migration note here. The pre-release API has its own page:
+[Migrating pre-0.1 interactions](/guide/migrating-pre-0-1).
+
+## 0.1 to 0.2
+
+No source changes are required: every 0.1 prop, callback, and export keeps
+working in 0.2. One environment requirement changed: the \`svelte\` peer
+dependency floor rose from \`^5.29.0\` to \`^5.33.1\`, so upgrade Svelte first.
+The additions below are optional to adopt.
+
+### Optional: shared interaction state with a controller
+
+0.2 adds \`createPlotInteraction\` for linked views: selection, emphasis, and
+zoom state shared across plots, controls, and tables. Chart-local props and
+callbacks remain fully supported — reach for a controller only when more than
+one surface consumes the same interaction state.
+
+Chart-local (unchanged from 0.1):
+
+\`\`\`svelte
+<script lang="ts">
+  import {
+    GeomPoint,
+    GGPlot,
+    type PlotSelection,
+  } from "@ggsvelte/svelte";
+
+  const rows = [
+    { id: "a", flipper: 181, mass: 3750, species: "Adelie" },
+    { id: "b", flipper: 195, mass: 3800, species: "Chinstrap" },
+    { id: "c", flipper: 217, mass: 4500, species: "Gentoo" },
+  ];
+  let selection = $state<PlotSelection<string> | null>(null);
+</script>
+
+<GGPlot
+  data={rows}
+  aes={{ x: "flipper", y: "mass", color: "species" }}
+  key="id"
+  select={{ type: "point", multiple: true }}
+  onselect={(event) => (selection = event)}
+>
+  <GeomPoint />
+</GGPlot>
+
+<p>{selection === null ? 0 : selection.keys.length} selected</p>
+\`\`\`
+
+Shared controller (new in 0.2, optional):
+
+\`\`\`svelte
+<script lang="ts">
+  import {
+    createPlotInteraction,
+    GeomPoint,
+    GGPlot,
+  } from "@ggsvelte/svelte";
+
+  const rows = [
+    { id: "a", flipper: 181, mass: 3750, species: "Adelie" },
+    { id: "b", flipper: 195, mass: 3800, species: "Chinstrap" },
+    { id: "c", flipper: 217, mass: 4500, species: "Gentoo" },
+  ];
+  const scope = { keys: "row-id", x: "flipper-mm", y: "mass-g" } as const;
+  const interaction = createPlotInteraction<string>();
+  const selected = $derived(interaction.selected(scope));
+</script>
+
+<GGPlot
+  data={rows}
+  aes={{ x: "flipper", y: "mass", color: "species" }}
+  key="id"
+  select={{ type: "point", multiple: true }}
+  {interaction}
+  interactionScope={scope}
+>
+  <GeomPoint />
+</GGPlot>
+
+<p>{selected.length} selected</p>
+\`\`\`
+
+See the [linked views example](/examples/interaction/linked-views) and
+[Interactions](/guide/interactions) for the full controller contract.
+
+### Deprecated type aliases
+
+Unchanged in 0.2: these pre-0.1 names have been deprecated since 0.1.0 and
+still compile. Replace them when convenient:
+
+- \`BrushSelection\` → \`IntervalSelection\`
+- \`TooltipContext\` → \`PlotInspectionChange\`
+- \`ZoomDomains\` → \`ReadonlyZoomDomains\`
+
+The payload changes behind these renames are documented in
+[Migrating pre-0.1 interactions](/guide/migrating-pre-0-1#migrate-custom-tooltip-snippets).
+`;
+
 function catalogSection(
   title: string,
   intro: string,
@@ -1173,6 +1276,12 @@ export function guidePages(lifecycle: LifecycleDoc): GuidePage[] {
       title: "Migrating pre-0.1 interactions",
       description: "Move from tooltip and brush props to semantic interaction capabilities.",
       markdown: MIGRATING_PRE_0_1_MD,
+    },
+    {
+      slug: "upgrading",
+      title: "Upgrading ggsvelte",
+      description: "Per-release upgrade notes: what changed, what is optional, what to replace.",
+      markdown: UPGRADING_MD,
     },
   ];
 }

--- a/scripts/migration-fixtures.test.ts
+++ b/scripts/migration-fixtures.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Migration-fixture sync: every fenced svelte block in the upgrading guide is
+ * a real, type-checked fixture file (ADR 0013 — migration examples must be
+ * real Svelte source, not prose). Fixtures under
+ * packages/svelte/tests/migrations/ are the source of truth; the guide embeds
+ * them verbatim modulo one normalization (the public import specifier
+ * "@ggsvelte/svelte" — fixtures import "../../src/lib/index.js" because the
+ * workspace has no self-link for the package name).
+ */
+import { describe, expect, it } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { UPGRADING_MD } from "./gen-llms.ts";
+
+const MIGRATIONS_DIR = join(import.meta.dir, "..", "packages", "svelte", "tests", "migrations");
+
+function guideSvelteBlocks(md: string): string[] {
+  return [...md.matchAll(/```svelte\n([\s\S]*?)```/g)].map((match) => match[1]!.trim());
+}
+
+function fixtureFiles(extension: string): Map<string, string> {
+  const files = new Map<string, string>();
+  for (const name of readdirSync(MIGRATIONS_DIR)) {
+    if (!name.endsWith(extension)) continue;
+    files.set(name, readFileSync(join(MIGRATIONS_DIR, name), "utf8").trim());
+  }
+  return files;
+}
+
+describe("upgrading-guide migration fixtures", () => {
+  const blocks = guideSvelteBlocks(UPGRADING_MD);
+  const svelteFixtures = fixtureFiles(".svelte");
+
+  it("has at least one svelte example per guide, and no orphan fixtures", () => {
+    expect(blocks.length).toBeGreaterThan(0);
+    expect(svelteFixtures.size).toBe(blocks.length);
+  });
+
+  it("embeds each fixture verbatim in the guide (modulo the public import specifier)", () => {
+    const normalized = blocks.map((block) =>
+      block.replaceAll('"@ggsvelte/svelte"', '"../../src/lib/index.js"'),
+    );
+    for (const [name, content] of svelteFixtures) {
+      expect(normalized, `fixture ${name} must appear as a guide code block`).toContain(content);
+    }
+  });
+
+  it("guide examples show the public import specifier, never repo-relative paths", () => {
+    for (const block of blocks) {
+      expect(block).toContain('from "@ggsvelte/svelte"');
+      expect(block).not.toContain("src/lib");
+    }
+  });
+
+  it("keeps a compile-time fixture for every deprecated type alias", () => {
+    const aliases = fixtureFiles(".ts");
+    const combined = [...aliases.values()].join("\n");
+    for (const name of [
+      "BrushSelection",
+      "IntervalSelection",
+      "TooltipContext",
+      "PlotInspectionChange",
+      "ZoomDomains",
+      "ReadonlyZoomDomains",
+    ]) {
+      expect(combined, `alias fixture must exercise ${name}`).toContain(name);
+    }
+  });
+
+  it("fixtures are inside the svelte-check type-checking scope", () => {
+    // Without this include, the fixtures would parse in tests but never be
+    // type-checked — exactly the drift this suite exists to prevent.
+    const tsconfig = readFileSync(
+      join(import.meta.dir, "..", "packages", "svelte", "tsconfig.json"),
+      "utf8",
+    );
+    expect(tsconfig).toContain('"tests/migrations/**/*"');
+  });
+});


### PR DESCRIPTION
Part 1 of 2 for #7 ("Design post-0.1 upgrade checks, migrations, and codemods"). Establishes the versioned migration policy and the live artifacts that enforce it today; a follow-up PR adds the ambiguous-capability audit.

## What

- **ADR 0013** (`docs/decisions/0013-post-0-1-migration-policy.md`): pre-1.0 support windows (`stable-intent` ⇒ ≥1 full minor deprecation window; `superseded` ⇒ survives to a major), per-migration requirements shipped in the same PR as the change, the checks-never-rewrite invariant, codemod decision factors + acceptance criteria (deferred until the first mechanical migration exists), and an honest applicability matrix for #7's acceptance criteria.
- **`/guide/upgrading`** — rolling per-transition upgrade page generated from `scripts/gen-llms.ts`. The `0.1 to 0.2` section states the contract: no source changes; Svelte peer floor `^5.29.0` → `^5.33.1`; controller adoption optional; deprecated alias table. Linked from both READMEs, required by the packed-pages check.
- **Real migration fixtures** (`packages/svelte/tests/migrations/`): guide code blocks are verbatim embeds of fixture files (sync-tested both directions) that svelte-check type-checks via a new tsconfig include — examples cannot drift from the compiler's idea of the API. Includes a compile-time assignability fixture for the three deprecated type aliases.
- **`scripts/deprecation-wiring.test.ts`**: every `@deprecated` JSDoc must carry `since <version>` + a guide URL whose page/anchor resolve (anchors computed by the docs renderer itself); every minor/major changeset must carry an explicit `Migration:` marker (URL or `none — additive`). Written red→green against the previously non-compliant state.
- All four pending 0.2 minors now comply: `linked-interaction-controller` and `raise-svelte-floor` link the upgrading guide (the floor raise is *not* additive — consumers on Svelte 5.29–5.33.0 must upgrade), the other two declare `none — additive`. The regenerated Version Packages PR (#45) will carry these links into the 0.2 changelogs.
- Alias `@deprecated` metadata corrected to `since 0.1.0` — they shipped deprecated in 0.1.0; stamping 0.2.0 would falsify release history.

## Verification

`bun test scripts` (184 pass, incl. 7 new), `bun run check`, `bun run check:svelte` (423 files, fixtures included), `bun run build:docs` + `check:pages-links`, oxlint + `lint:type-aware`, knip, oxfmt/prettier, markdownlint, `lifecycle:check`, `manifest:check` — all green.

Refs #7 (closed by the follow-up audit PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)