### PR TITLE
test: migrate partial fixtures to @total-typescript/shoehorn

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -211,6 +211,11 @@ and hub-style barrels invite import cycles across feature controllers.
 - Cross-cutting suites (`component.test.ts`, harnesses, release matrix) sit
   at `packages/svelte/tests/` root.
 - Shared helpers and fixtures: `tests/helpers/`, `tests/fixtures/`.
+- Prefer `@total-typescript/shoehorn` for partial test fixtures instead of `as`
+  / `as unknown as` / `as never` on object literals:
+  - `fromPartial({ ... })` when the shape is a valid deep-partial of the target type
+  - `fromAny({ ... })` when the data is intentionally wrong or untyped for the test
+  - Keep `as const`, error/DOM narrowing, and post-pipeline batch narrowing as-is
 
 ### Coverage workflow
 

--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,7 @@
         "@ggsvelte/core": "workspace:*",
         "@ggsvelte/spec": "workspace:*",
         "@playwright/test": "1.61.1",
+        "@total-typescript/shoehorn": "^0.1.2",
         "@types/bun": "^1.3.14",
         "@types/node": "^26.1.1",
         "actionlint": "2.0.6",
@@ -476,6 +477,8 @@
     "@sveltejs/vite-plugin-svelte": ["@sveltejs/vite-plugin-svelte@7.2.0", "", { "dependencies": { "deepmerge": "^4.3.1", "magic-string": "^0.30.21", "obug": "^2.1.0", "vitefu": "^1.1.2" }, "peerDependencies": { "svelte": "^5.46.4", "vite": "^8.0.0-beta.7 || ^8.0.0" } }, "sha512-1SpkuMSRLfugrVX+IrKfE1RUegzo8AQzKQ6qQPfVzbcWi5IhuTPaKb5ZrLpucleFznkc4/RTeSPoRnGWFxX+EQ=="],
 
     "@testing-library/svelte-core": ["@testing-library/svelte-core@1.1.3", "", { "peerDependencies": { "svelte": "^3 || ^4 || ^5 || ^5.0.0-next.0" } }, "sha512-KkMAvXeWorxN2Yn0kdC1lfoAItxpoj4uOWzxK5leDrNxonLvS5nwBFvztrroyTszQ0Wf/EU6iLT8JhY5qcn22g=="],
+
+    "@total-typescript/shoehorn": ["@total-typescript/shoehorn@0.1.2", "", {}, "sha512-p7nNZbOZIofpDNyP0u1BctFbjxD44Qc+oO5jufgQdFdGIXJLc33QRloJpq7k5T59CTgLWfQSUxsuqLcmeurYRw=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
 

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@ggsvelte/core": "workspace:*",
     "@ggsvelte/spec": "workspace:*",
     "@playwright/test": "1.61.1",
+    "@total-typescript/shoehorn": "^0.1.2",
     "@types/bun": "^1.3.14",
     "@types/node": "^26.1.1",
     "actionlint": "2.0.6",

--- a/packages/core/tests/candidate-store.test.ts
+++ b/packages/core/tests/candidate-store.test.ts
@@ -1,3 +1,4 @@
+import { fromPartial } from "@total-typescript/shoehorn";
 import { describe, expect, it, spyOn } from "bun:test";
 
 import {
@@ -51,7 +52,7 @@ function scene(): Scene {
     axes: { x: { ticks: [], title: "" }, y: { ticks: [], title: "" } },
     grid: { x: [], y: [] },
     legends: [],
-    theme: {} as Scene["theme"],
+    theme: fromPartial<Scene["theme"]>({}),
     title: "",
     subtitle: "",
     caption: "",

--- a/packages/core/tests/canvas.test.ts
+++ b/packages/core/tests/canvas.test.ts
@@ -1,3 +1,4 @@
+import { fromPartial } from "@total-typescript/shoehorn";
 import { describe, expect, it } from "bun:test";
 
 import { drawStratum, groupBatchesByPanel } from "../src/dom/canvas.ts";
@@ -125,17 +126,17 @@ function scene(batches: readonly GeometryBatch[], panelCount = 1): Scene {
     axisY: null,
     grid: { x: [], y: [] },
   }));
-  return {
+  return fromPartial<Scene>({
     width: Math.max(20, panelCount * 30),
     height: 20,
     panels,
     batches: [...batches],
     legends: [],
-    theme: { ink: "black", accent: "blue", interactionMuted: 0.36 } as Scene["theme"],
+    theme: { ink: "black", accent: "blue", interactionMuted: 0.36 },
     title: "",
     subtitle: "",
     caption: "",
-  } as Scene;
+  });
 }
 
 const resolve = (color: string) => color;

--- a/packages/core/tests/hit-index.test.ts
+++ b/packages/core/tests/hit-index.test.ts
@@ -3,6 +3,7 @@
  * These are pure computations over Scene geometry — no DOM — so they run
  * under bun; the browser-level event wiring is covered by component tests.
  */
+import { fromPartial } from "@total-typescript/shoehorn";
 import { describe, expect, it } from "bun:test";
 
 import { gg, aes } from "@ggsvelte/spec";
@@ -36,7 +37,7 @@ function basePanelScene(batches: Scene["batches"]): Scene {
     axes: { x: { ticks: [], title: "" }, y: { ticks: [], title: "" } },
     grid: { x: [], y: [] },
     legends: [],
-    theme: {} as Scene["theme"],
+    theme: fromPartial<Scene["theme"]>({}),
     title: "",
     subtitle: "",
     caption: "",

--- a/packages/core/tests/pipeline-build-candidates.test.ts
+++ b/packages/core/tests/pipeline-build-candidates.test.ts
@@ -7,6 +7,7 @@
  *   public row-filter contracts
  * - complexity: each filter reads table.column(field) once, not per base row
  */
+import { fromAny } from "@total-typescript/shoehorn";
 import { describe, expect, it, spyOn } from "bun:test";
 
 import { aes, gg } from "@ggsvelte/spec";
@@ -419,14 +420,16 @@ describe("isAllSourceBacked", () => {
   it("is true only when every layer is identity and non-annotation", async () => {
     const { isAllSourceBacked } = await import("../src/pipeline/build-candidates-source-backed.ts");
     expect(
-      isAllSourceBacked([
-        { layer: { stat: "identity" }, ruleForm: null },
-        { layer: {}, ruleForm: null },
-      ] as never),
+      isAllSourceBacked(
+        fromAny([
+          { layer: { stat: "identity" }, ruleForm: null },
+          { layer: {}, ruleForm: null },
+        ]),
+      ),
     ).toBe(true);
-    expect(isAllSourceBacked([{ layer: { stat: "count" }, ruleForm: null }] as never)).toBe(false);
+    expect(isAllSourceBacked(fromAny([{ layer: { stat: "count" }, ruleForm: null }]))).toBe(false);
     expect(
-      isAllSourceBacked([{ layer: { stat: "identity" }, ruleForm: "annotation" }] as never),
+      isAllSourceBacked(fromAny([{ layer: { stat: "identity" }, ruleForm: "annotation" }])),
     ).toBe(false);
   });
 });
@@ -434,8 +437,8 @@ describe("isAllSourceBacked", () => {
 describe("collectColorChannelValues", () => {
   it("returns empty when no color mapping is present", async () => {
     const { collectColorChannelValues } = await import("../src/pipeline/scale-color-collect.ts");
-    const table = { has: () => false, discreteness: () => "continuous" } as never;
-    const frames = [
+    const table = fromAny({ has: () => false, discreteness: () => "continuous" });
+    const frames = fromAny([
       {
         binding: {
           color: { field: null, scaledConstant: null },
@@ -444,7 +447,7 @@ describe("collectColorChannelValues", () => {
         colorValues: null,
         fillValues: null,
       },
-    ] as never;
+    ]);
     expect(collectColorChannelValues("color", frames, table)).toEqual({
       values: [],
       anyDiscreteField: false,
@@ -475,10 +478,10 @@ describe("buildPathGroupSortedRows", () => {
       await import("../src/pipeline/build-candidates-frame-row.ts");
     // rows: group 1 at x=3, group 0 at x=2, group 1 at x=1, group 0 at x=0
     // → group 0 sorted [3, 1]; group 1 sorted [2, 0]
-    const frame = {
+    const frame = fromAny({
       groups: [1, 0, 1, 0],
       xNumeric: new Float64Array([3, 2, 1, 0]),
-    } as never;
+    });
     const byGroup = buildPathGroupSortedRows(frame);
     expect([...byGroup.get(0)!]).toEqual([3, 1]);
     expect([...byGroup.get(1)!]).toEqual([2, 0]);
@@ -487,7 +490,7 @@ describe("buildPathGroupSortedRows", () => {
   it("falls back to row index order when xNumeric is null", async () => {
     const { buildPathGroupSortedRows } =
       await import("../src/pipeline/build-candidates-frame-row.ts");
-    const frame = { groups: [0, 0, 0], xNumeric: null } as never;
+    const frame = fromAny({ groups: [0, 0, 0], xNumeric: null });
     expect([...buildPathGroupSortedRows(frame).get(0)!]).toEqual([0, 1, 2]);
   });
 });
@@ -496,10 +499,10 @@ describe("getPathGroupSortedRows", () => {
   it("returns the same Map for the same frame (precomputed once)", async () => {
     const { getPathGroupSortedRows } =
       await import("../src/pipeline/build-candidates-frame-row.ts");
-    const frame = {
+    const frame = fromAny({
       groups: [0, 0, 1],
       xNumeric: new Float64Array([0, 1, 2]),
-    } as never;
+    });
     const a = getPathGroupSortedRows(frame);
     const b = getPathGroupSortedRows(frame);
     expect(a).toBe(b);
@@ -514,18 +517,18 @@ describe("resolveCandidateFrameRow paths", () => {
       await import("../src/pipeline/build-candidates-frame-row.ts");
     // Two groups interleaved: g0 rows {0,2} with x 2,0 → sorted [2,0];
     // g1 rows {1,3} with x 3,1 → sorted [3,1]
-    const frame = {
+    const frame = fromAny({
       n: 4,
       groups: [0, 1, 0, 1],
       xNumeric: new Float64Array([2, 3, 0, 1]),
       binding: { layer: { geom: "area" } },
-    } as never;
+    });
     // Two subpaths, each 4 vertices (forward + reverse for closed area):
     // subpath 0: offsets [0, 4), subpath 1: [4, 8)
-    const batch = {
+    const batch = fromAny({
       kind: "paths",
       pathOffsets: new Uint32Array([0, 4, 8]),
-    } as never;
+    });
     const orderedGroups = [0, 1];
 
     // Forward: local 0 → first sorted row of group 0 = 2
@@ -595,13 +598,13 @@ describe("resolveCandidateFrameRow paths", () => {
       xNumeric[s * 2] = 0;
       xNumeric[s * 2 + 1] = 1;
     }
-    const frame = {
+    const frame = fromAny({
       n: P * 2,
       groups,
       xNumeric,
       binding: { layer: { geom: "line" } },
-    } as never;
-    const batch = { kind: "paths", pathOffsets: offsets } as never;
+    });
+    const batch = fromAny({ kind: "paths", pathOffsets: offsets });
     const orderedGroups = Array.from({ length: P }, (_, s) => s);
 
     // Binary search correctness on first / mid / last subpath
@@ -641,7 +644,7 @@ describe("resolveOutlierContext", () => {
     expect(
       resolveOutlierContext({
         frame: undefined,
-        batch: { kind: "points" } as never,
+        batch: fromAny({ kind: "points" }),
         primitiveIndex: 0,
         facetPanel: undefined,
       }),
@@ -672,13 +675,13 @@ describe("lineage represented-row filters", () => {
     const { filterBinRepresentedRows } =
       await import("../src/pipeline/build-candidates-lineage-filters.ts");
     const table = ColumnTable.fromRows([{ x: 0.5 }, { x: 1.5 }, { x: 2.5 }, { x: 3.5 }]);
-    const frame = {
+    const frame = fromAny({
       xmin: new Float64Array([0, 2]),
       xmax: new Float64Array([2, 4]),
       groups: new Uint32Array([0, 0]),
       n: 2,
       binding: { layer: { params: { closed: "right" } } },
-    } as never;
+    });
     expect(
       filterBinRepresentedRows({
         frame,
@@ -728,13 +731,13 @@ describe("lineage filter column hoist (issue #220)", () => {
     const { filterBinRepresentedRows } =
       await import("../src/pipeline/build-candidates-lineage-filters.ts");
     const table = ColumnTable.fromRows(Array.from({ length: 40 }, (_, i) => ({ x: i * 0.1 })));
-    const frame = {
+    const frame = fromAny({
       xmin: new Float64Array([0]),
       xmax: new Float64Array([2]),
       groups: new Uint32Array([0]),
       n: 1,
       binding: { layer: { params: { closed: "right" } } },
-    } as never;
+    });
     const baseRows = Array.from({ length: 40 }, (_, i) => i);
     const reads = countColumnReads("x", () => {
       filterBinRepresentedRows({
@@ -1003,7 +1006,7 @@ describe("buildBinLineageBuckets missing-edges fallback (issue #218)", () => {
     const inputGroups = [0, 1, 0, 1, 0];
     // Two empty-edge output marks per group (0=a, 1=b).
     const groups = [0, 0, 1, 1];
-    const frame = {
+    const frame = fromAny({
       binding: binBinding("g"),
       table,
       n: groups.length,
@@ -1011,13 +1014,13 @@ describe("buildBinLineageBuckets missing-edges fallback (issue #218)", () => {
       inputGroups,
       xmin: null,
       xmax: null,
-    } as never;
+    });
     const sourceRowsByGroupBin = new Map<string, number[]>();
     buildBinLineageBuckets({
       frame,
       panelIndex: 0,
       layerIndex: 0,
-      facetPanel: { sourceRows: null } as never,
+      facetPanel: fromAny({ sourceRows: null }),
       sourceRowsByGroupBin,
     });
 
@@ -1036,7 +1039,7 @@ describe("buildBinLineageBuckets missing-edges fallback (issue #218)", () => {
     ]);
     const inputGroups = [0, 0, 1];
     const groups = [0, 1];
-    const frame = {
+    const frame = fromAny({
       binding: binBinding("g"),
       table,
       n: groups.length,
@@ -1044,13 +1047,13 @@ describe("buildBinLineageBuckets missing-edges fallback (issue #218)", () => {
       inputGroups,
       xmin: null,
       xmax: null,
-    } as never;
+    });
     const sourceRowsByGroupBin = new Map<string, number[]>();
     buildBinLineageBuckets({
       frame,
       panelIndex: 2,
       layerIndex: 1,
-      facetPanel: { sourceRows: [10, 20, 30] } as never,
+      facetPanel: fromAny({ sourceRows: [10, 20, 30] }),
       sourceRowsByGroupBin,
     });
 
@@ -1072,7 +1075,7 @@ describe("buildBinLineageBuckets missing-edges fallback (issue #218)", () => {
         return Reflect.get(target, property, receiver) as unknown;
       },
     });
-    const frame = {
+    const frame = fromAny({
       binding: binBinding(null),
       table,
       n: k,
@@ -1080,13 +1083,13 @@ describe("buildBinLineageBuckets missing-edges fallback (issue #218)", () => {
       inputGroups,
       xmin: null,
       xmax: null,
-    } as never;
+    });
     const sourceRowsByGroupBin = new Map<string, number[]>();
     buildBinLineageBuckets({
       frame,
       panelIndex: 0,
       layerIndex: 0,
-      facetPanel: { sourceRows: null } as never,
+      facetPanel: fromAny({ sourceRows: null }),
       sourceRowsByGroupBin,
     });
 

--- a/packages/core/tests/pipeline-geometry.test.ts
+++ b/packages/core/tests/pipeline-geometry.test.ts
@@ -3,6 +3,7 @@
  * Public/observable contracts only — batch mark counts and coord-flip vertex
  * mapping — so the split can move freely without rewriting these specs.
  */
+import { fromAny, fromPartial } from "@total-typescript/shoehorn";
 import { describe, expect, it } from "bun:test";
 
 import { gg, aes } from "@ggsvelte/spec";
@@ -18,13 +19,13 @@ const size = { width: 640, height: 400 };
 
 describe("makeErrorbarHalfWidth", () => {
   it("uses half band-step for discrete x", () => {
-    const frame = { xNumeric: null } as LayerFrame;
-    const fx = {
+    const frame = fromPartial<LayerFrame>({ xNumeric: null });
+    const fx = fromPartial<Frame>({
       xScale: { type: "band", step: 0.4, normalize: () => 0 },
       yScale: { type: "linear", normalize: (v: number) => v },
       innerWidth: 100,
       innerHeight: 100,
-    } as Frame;
+    });
     const halfOf = makeErrorbarHalfWidth(frame, fx, 0.5);
     expect(halfOf(0)).toBeCloseTo(0.1);
   });
@@ -360,14 +361,14 @@ describe("appendClosedBandEdges — shared closed ribbon vertices", () => {
     const { appendClosedBandEdges } = await import("../src/pipeline/geometry-paths-closed.ts");
     const positions = new Float32Array(16);
     const rowIndex = new Uint32Array(8);
-    const frame = {
+    const frame = fromAny<LayerFrame>({
       xNumeric: new Float64Array([0, 1]),
       xValues: null,
       rowIndex: new Uint32Array([10, 11]),
       ymin: new Float64Array([0.2, 0.3]),
       ymax: new Float64Array([0.8, 0.9]),
-    } as unknown as LayerFrame;
-    const fx = {
+    });
+    const fx = fromPartial<Frame>({
       innerWidth: 100,
       innerHeight: 200,
       xScale: {
@@ -378,7 +379,7 @@ describe("appendClosedBandEdges — shared closed ribbon vertices", () => {
         type: "linear",
         normalize: (v: number) => v,
       },
-    } as Frame;
+    });
     const cursor = appendClosedBandEdges({
       positions,
       rowIndex,
@@ -407,19 +408,19 @@ describe("appendClosedBandEdges — shared closed ribbon vertices", () => {
 describe("layoutBoxplotBody — hinge/whisker collection", () => {
   it("returns null when box extras or scales are unsuitable", async () => {
     const { layoutBoxplotBody } = await import("../src/pipeline/geometry-boxplot-body-layout.ts");
-    const frame = {
+    const frame = fromAny<LayerFrame>({
       binding: { index: 0, layer: { params: {} } },
       n: 1,
       box: null,
       ymin: null,
       ymax: null,
-    } as unknown as LayerFrame;
-    const fx = {
+    });
+    const fx = fromPartial<Frame>({
       xScale: { type: "linear" },
       yScale: { type: "linear" },
       innerWidth: 100,
       innerHeight: 100,
-    } as Frame;
+    });
     expect(layoutBoxplotBody(frame, fx, [])).toBeNull();
   });
 });
@@ -428,7 +429,7 @@ describe("buildRenderModelScaleState", () => {
   it("includes only non-null color/fill state entries", async () => {
     const { buildRenderModelScaleState } =
       await import("../src/pipeline/assemble-render-model-scales.ts");
-    const colorState = { domain: ["a"], assigned: { a: 0 } } as never;
+    const colorState = fromAny({ domain: ["a"], assigned: { a: 0 } });
     expect(buildRenderModelScaleState(colorState, null)).toEqual({ color: colorState });
     expect(buildRenderModelScaleState(null, null)).toEqual({});
   });
@@ -455,7 +456,7 @@ describe("BOX_MEDIAN_FATTEN", () => {
 describe("collectPointPositions", () => {
   it("drops NaN positions and keeps finite points", async () => {
     const { collectPointPositions } = await import("../src/pipeline/geometry-points-collect.ts");
-    const frame = {
+    const frame = fromAny({
       n: 3,
       xNumeric: new Float64Array([0, NaN, 1]),
       yNumeric: new Float64Array([0.5, 0.5, 0.25]),
@@ -463,13 +464,13 @@ describe("collectPointPositions", () => {
       offsetX: null,
       offsetY: null,
       rowIndex: new Uint32Array([0, 1, 2]),
-    } as never;
-    const fx = {
+    });
+    const fx = fromAny({
       innerWidth: 100,
       innerHeight: 200,
       xScale: { type: "linear", normalize: (v: number) => v },
       yScale: { type: "linear", normalize: (v: number) => v },
-    } as never;
+    });
     const collected = collectPointPositions(frame, fx);
     expect(collected.kept).toBe(2);
     expect([...collected.keptRows.subarray(0, 2)]).toEqual([0, 2]);
@@ -481,7 +482,7 @@ describe("placeSceneLegends", () => {
     const { placeSceneLegends } = await import("../src/pipeline/assemble-scene-legends.ts");
     const { LEGEND_EDGE_PAD } = await import("../src/pipeline/layout-helpers.ts");
     const legends = placeSceneLegends({
-      legends: [{ x: 0, y: 5, width: 10, height: 10, title: "", items: [] } as never],
+      legends: [fromAny({ x: 0, y: 5, width: 10, height: 10, title: "", items: [] })],
       legendWidth: 40,
       sceneWidth: 200,
       panelY: 12,
@@ -557,14 +558,14 @@ describe("geometryPanelFrame", () => {
 describe("packSegmentsBatch", () => {
   it("returns null for empty rowIndex and builds a segments batch otherwise", async () => {
     const { packSegmentsBatch } = await import("../src/pipeline/geometry-segments-pack.ts");
-    const frame = {
+    const frame = fromAny({
       binding: {
         index: 0,
         color: { constant: "#111" },
         layer: { params: {} },
         ruleForm: "vertical",
       },
-    } as never;
+    });
     expect(
       packSegmentsBatch({
         frame,
@@ -592,7 +593,7 @@ describe("packFacetPanelPlacement", () => {
     const { packFacetPanelPlacement } =
       await import("../src/pipeline/panel-layout-facet-place-pack.ts");
     const placement = packFacetPanelPlacement({
-      def: { col: 1, row: 0 } as never,
+      def: fromAny({ col: 1, row: 0 }),
       colX: 20,
       rowY: 10,
       panelW: 100,
@@ -600,7 +601,7 @@ describe("packFacetPanelPlacement", () => {
       freeH: false,
       freeV: false,
       bottomMostRow: 0,
-      ticksRun: { x: { ticks: [1] }, y: { ticks: [2] } } as never,
+      ticksRun: fromAny({ x: { ticks: [1] }, y: { ticks: [2] } }),
     });
     expect(placement.showAxisX).toBe(true);
     expect(placement.showAxisY).toBe(false);
@@ -612,20 +613,20 @@ describe("writeSmoothLineGeometry", () => {
   it("writes one path offset per group and maps y into panel px", async () => {
     const { writeSmoothLineGeometry } =
       await import("../src/pipeline/geometry-smooth-line-write.ts");
-    const frame = {
+    const frame = fromAny({
       binding: { color: { constant: "#abc", scaledConstant: null } },
       xNumeric: new Float64Array([0, 1]),
       yNumeric: new Float64Array([0, 1]),
       xValues: null,
       colorValues: null,
       rowIndex: new Uint32Array([10, 11]),
-    } as never;
-    const fx = {
+    });
+    const fx = fromAny({
       xScale: { type: "linear", normalize: (v: number) => v },
       yScale: { type: "linear", normalize: (v: number) => v },
       innerWidth: 100,
       innerHeight: 50,
-    } as never;
+    });
     const geom = writeSmoothLineGeometry({
       frame,
       fx,
@@ -645,10 +646,10 @@ describe("writeSmoothLineGeometry", () => {
 describe("areaGroupFillOf", () => {
   it("uses the constant fill when no scaled fill is mapped", async () => {
     const { areaGroupFillOf } = await import("../src/pipeline/geometry-paths-area-fill.ts");
-    const frame = {
+    const frame = fromAny({
       binding: { fill: { constant: "#cde", scaledConstant: null } },
       fillValues: null,
-    } as never;
+    });
     expect(areaGroupFillOf(frame, null, [0])).toBe("#cde");
   });
 });

--- a/packages/core/tests/pipeline-m1.test.ts
+++ b/packages/core/tests/pipeline-m1.test.ts
@@ -3,6 +3,7 @@
  * config surface (types, domains, zero forcing, breaks, labels), color/fill
  * legends (incl. the order option), theme wiring, and the failure policy.
  */
+import { fromAny } from "@total-typescript/shoehorn";
 import { describe, expect, it } from "bun:test";
 
 import { aes, gg } from "@ggsvelte/spec";
@@ -598,11 +599,11 @@ describe("theme wiring", () => {
   it("unknown theme names throw a structured tier-1 error", () => {
     try {
       runPipeline(
-        {
+        fromAny({
           data: { values: salesRows },
           theme: "darkk",
           layers: [{ geom: "point", aes: { x: { field: "city" }, y: { field: "sales" } } }],
-        } as never,
+        }),
         size,
       );
       throw new Error("should have thrown");

--- a/packages/core/tests/pipeline-position.test.ts
+++ b/packages/core/tests/pipeline-position.test.ts
@@ -1,6 +1,7 @@
 /**
  * Characterization tests for data-space position adjustments on LayerFrames.
  */
+import { fromPartial } from "@total-typescript/shoehorn";
 import { describe, expect, it } from "bun:test";
 
 import { aes, gg } from "@ggsvelte/spec";
@@ -21,14 +22,20 @@ describe("barSlotKeys", () => {
       xValues: null as CellValue[] | null,
       xNumeric: null as Float64Array | null,
     };
-    expect(barSlotKeys(base as LayerFrame)).toBeNull();
-    expect(barSlotKeys({ ...base, xValues: ["a", "b"] } as LayerFrame)).toEqual(["a", "b"]);
+    expect(barSlotKeys(fromPartial<LayerFrame>(base))).toBeNull();
+    expect(barSlotKeys(fromPartial<LayerFrame>({ ...base, xValues: ["a", "b"] }))).toEqual([
+      "a",
+      "b",
+    ]);
     // Typed categories with colliding labels occupy distinct slots, matching
     // the band scale's typed identity (encodeKey: strings pass through).
-    expect(barSlotKeys({ ...base, xValues: [1, "1"] } as LayerFrame)).toEqual(["@n:1", "1"]);
-    expect(barSlotKeys({ ...base, xNumeric: Float64Array.of(1.5, 2.5) } as LayerFrame)).toEqual([
-      1.5, 2.5,
+    expect(barSlotKeys(fromPartial<LayerFrame>({ ...base, xValues: [1, "1"] }))).toEqual([
+      "@n:1",
+      "1",
     ]);
+    expect(
+      barSlotKeys(fromPartial<LayerFrame>({ ...base, xNumeric: Float64Array.of(1.5, 2.5) })),
+    ).toEqual([1.5, 2.5]);
   });
 });
 

--- a/packages/core/tests/pipeline-scale-training.test.ts
+++ b/packages/core/tests/pipeline-scale-training.test.ts
@@ -1,6 +1,7 @@
 /**
  * Characterization tests for axis/color scale training extracted from the pipeline.
  */
+import { fromAny } from "@total-typescript/shoehorn";
 import { describe, expect, it } from "bun:test";
 
 import { aes, gg } from "@ggsvelte/spec";
@@ -125,7 +126,7 @@ describe("trainAxis", () => {
     ]);
     const inputs = collectAxisInputs("x", [pointFrame(table)], "linear", []);
     try {
-      trainAxis("x", inputs, { type: "linear", domain: [1] as unknown as [number, number] });
+      trainAxis("x", inputs, { type: "linear", domain: fromAny<[number, number]>([1]) });
       expect.unreachable("should throw");
     } catch (e) {
       expect((e as { code: string }).code).toBe("invalid-scale-domain");
@@ -146,7 +147,7 @@ describe("continuousDomainOf", () => {
 
   it("throws invalid-scale-domain for wrong arity or non-finite values", () => {
     try {
-      continuousDomainOf({ domain: [1] as unknown as [number, number] }, "x");
+      continuousDomainOf({ domain: fromAny<[number, number]>([1]) }, "x");
       expect.unreachable("should throw");
     } catch (e) {
       expect(e).toBeInstanceOf(PipelineError);

--- a/packages/core/tests/pipeline-setup-run.test.ts
+++ b/packages/core/tests/pipeline-setup-run.test.ts
@@ -1,6 +1,7 @@
 /**
  * Characterization tests for pipeline run setup (normalize/edition/theme/flip).
  */
+import { fromAny } from "@total-typescript/shoehorn";
 import { describe, expect, it } from "bun:test";
 
 import { aes, gg } from "@ggsvelte/spec";
@@ -40,11 +41,11 @@ describe("setupPipelineRun", () => {
   it("rejects unknown theme names as tier-1 structured errors", () => {
     try {
       runPipeline(
-        {
+        fromAny({
           data: { values: [{ x: 1, y: 2 }] },
           layers: [{ geom: "point", aes: { x: { field: "x" }, y: { field: "y" } } }],
           theme: "definitely-not-a-real-theme",
-        } as never,
+        }),
         { width: 100, height: 100 },
       );
       expect.unreachable("should throw");

--- a/packages/core/tests/scale-state.test.ts
+++ b/packages/core/tests/scale-state.test.ts
@@ -1,3 +1,4 @@
+import { fromAny } from "@total-typescript/shoehorn";
 import { describe, expect, test } from "bun:test";
 import {
   adoptScaleState,
@@ -129,7 +130,7 @@ describe("persistence round-trip", () => {
 
   test("a future-version state degrades to fresh with a version-mismatch warning", () => {
     const r1 = trainDiscrete(["a"], spec());
-    const future = { ...r1.state, version: 99 } as unknown as ScaleState;
+    const future = fromAny<ScaleState>({ ...r1.state, version: 99 });
     const r2 = trainDiscrete(["a"], spec(), future);
     expect(r2.warnings.map((w) => w.code)).toEqual(["version-mismatch"]);
     expect(r2.indexOf("a")).toBe(0);

--- a/packages/core/tests/scales-m1.test.ts
+++ b/packages/core/tests/scales-m1.test.ts
@@ -3,6 +3,7 @@
  * pinning, nice, zero, reverse), time/log tick generation, label format
  * strings, sequential color ramps, and the theme registry.
  */
+import { fromAny } from "@total-typescript/shoehorn";
 import { describe, expect, it } from "bun:test";
 
 import { formatTime, numberFormatter } from "../src/layout/format.ts";
@@ -257,7 +258,7 @@ describe("theme registry", () => {
   });
 
   it("unknown names throw (tier-1 error) and themeVar wraps --gg-* vars", () => {
-    expect(() => resolveTheme("darkk" as never)).toThrow(UnknownThemeError);
+    expect(() => resolveTheme(fromAny("darkk"))).toThrow(UnknownThemeError);
     expect(themeVar("ink", BUILTIN_THEMES.default)).toBe("var(--gg-ink, #262626)");
   });
 

--- a/packages/core/tests/stats-parity.test.ts
+++ b/packages/core/tests/stats-parity.test.ts
@@ -15,6 +15,7 @@
  *    5e-4 relative. Bandwidth (bw.nrd0) and grid endpoints are exact (1e-9).
  *  - bin / boxplot / summary: exact algorithms — 1e-9.
  */
+import { fromAny } from "@total-typescript/shoehorn";
 import { describe, expect, it } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
@@ -281,9 +282,7 @@ describe("boxplot stat — ggplot2 parity (R fixtures)", () => {
           .filter((o) => o.boxRow === i)
           .map((o) => o.y)
           .toSorted((a, b) => a - b);
-        const want = Array.isArray(row.outliers)
-          ? row.outliers
-          : [row.outliers as unknown as number];
+        const want = Array.isArray(row.outliers) ? row.outliers : [fromAny<number>(row.outliers)];
         expect(got.length).toBe(want.length);
         for (let j = 0; j < want.length; j++) expect(got[j]!).toBeCloseTo(want[j]!, 9);
       }

--- a/packages/spec/tests/catalog-coverage.test.ts
+++ b/packages/spec/tests/catalog-coverage.test.ts
@@ -4,6 +4,7 @@
  * one place. Adding a catalog code without a trigger — or a trigger whose
  * code silently changes — fails this test.
  */
+import { fromAny } from "@total-typescript/shoehorn";
 import { describe, expect, it } from "bun:test";
 
 import { ERROR_CATALOG, ERROR_CODES } from "../src/errors.ts";
@@ -101,7 +102,8 @@ const TRIGGERS: Record<SpecErrorCode, Trigger> = {
   },
   "invalid-data-profile": {
     spec: { layers: [point] },
-    options: { profile: { fields: [{ name: "x", type: "numeric" }] } as never },
+    // Intentionally malformed profile type (not a valid DataProfile field type).
+    options: { profile: fromAny({ fields: [{ name: "x", type: "numeric" }] }) },
   },
   "validation-limit": {
     spec: { data: { values: [{ x: 1 }, { x: 2 }] }, layers: [point] },

--- a/packages/spec/tests/portability.test.ts
+++ b/packages/spec/tests/portability.test.ts
@@ -1,3 +1,4 @@
+import { fromAny } from "@total-typescript/shoehorn";
 import { describe, expect, it } from "bun:test";
 
 import {
@@ -21,7 +22,8 @@ describe("portabilityIssues", () => {
   });
 
   it("reports every offending path with a reason", () => {
-    const spec = {
+    // Intentionally unportable values (fn, Date, bigint, NaN, undefined).
+    const spec = fromAny<RuntimeSpec>({
       layers: [
         {
           geom: "point",
@@ -32,7 +34,7 @@ describe("portabilityIssues", () => {
       when: new Date(0),
       big: 1n,
       gone: undefined,
-    } as unknown as RuntimeSpec;
+    });
     const issues = portabilityIssues(spec);
     const paths = issues.map((i) => i.path).toSorted();
     expect(paths).toEqual(["/big", "/gone", "/layers/0/aes/x/fn", "/when", "/width"]);
@@ -52,14 +54,14 @@ describe("isPortable early exit", () => {
     let laterTouched = false;
     // Sibling getter after the unportable property: Object.entries would
     // evaluate it before the loop, defeating stopAfter. Keys must be read lazily.
-    const spec = {
+    const spec = fromAny<RuntimeSpec>({
       layers: [{ geom: "point" }],
       width: Number.NaN,
       get later() {
         laterTouched = true;
         return 1;
       },
-    } as unknown as RuntimeSpec;
+    });
 
     expect(isPortable(spec)).toBe(false);
     expect(laterTouched).toBe(false);
@@ -92,23 +94,23 @@ describe("isPortable early exit", () => {
       writable: true,
     });
     expect(portabilityIssues(spec)).toEqual([]);
-    expect(isPortable(spec as unknown as RuntimeSpec)).toBe(true);
+    expect(isPortable(fromAny(spec))).toBe(true);
   });
 });
 
 describe("toPortable", () => {
   it("returns a deep copy for portable specs", () => {
     const copy = toPortable(portable);
-    expect(copy).toEqual(portable as never);
-    expect(copy).not.toBe(portable as never);
-    expect(copy.layers).not.toBe(portable.layers as never);
+    expect(copy).toEqual(portable);
+    expect(copy).not.toBe(portable);
+    expect(copy.layers).not.toBe(portable.layers);
   });
 
   it("REJECTS with every unserializable path (never strips)", () => {
-    const spec = {
+    const spec = fromAny<RuntimeSpec>({
       layers: [{ geom: "point", aes: { x: { fn: () => 1 } } }],
       width: Infinity,
-    } as unknown as RuntimeSpec;
+    });
     let error: UnportableSpecError | undefined;
     try {
       toPortable(spec);
@@ -123,20 +125,20 @@ describe("toPortable", () => {
 
 describe("toPortableLossy", () => {
   it("strips fn accessors and reports dropped paths", () => {
-    const spec = {
+    const spec = fromAny<RuntimeSpec>({
       layers: [{ geom: "point", aes: { x: { fn: () => 1 }, y: { field: "y" } } }],
-    } as unknown as RuntimeSpec;
+    });
     const { spec: out, dropped } = toPortableLossy(spec);
     expect(dropped).toEqual(["/layers/0/aes/x/fn"]);
     // the fn key is gone; the (now empty) channel object remains
-    expect(out.layers[0]).toEqual({ geom: "point", aes: { x: {}, y: { field: "y" } } } as never);
+    expect(out.layers[0]).toEqual({ geom: "point", aes: { x: {}, y: { field: "y" } } });
   });
 
   it("coerces dates to ISO strings and non-finite numbers to null (not drops)", () => {
-    const spec = {
+    const spec = fromAny<RuntimeSpec>({
       data: { values: [{ t: new Date("2026-07-10T00:00:00Z"), v: NaN }] },
       layers: [{ geom: "point" }],
-    } as unknown as RuntimeSpec;
+    });
     const { spec: out, dropped } = toPortableLossy(spec);
     expect(dropped).toEqual([]);
     expect(out.data).toEqual({

--- a/packages/spec/tests/validate-tier2.test.ts
+++ b/packages/spec/tests/validate-tier2.test.ts
@@ -4,6 +4,7 @@
  * all-null columns, stat columns, scale/type compatibility) against inline
  * data or a DataProfile, under documented input limits.
  */
+import { fromAny } from "@total-typescript/shoehorn";
 import { describe, expect, it } from "bun:test";
 
 import type { DataProfile } from "../src/validate-data.ts";
@@ -213,7 +214,7 @@ describe("tier 2 — DataProfile", () => {
     expect(
       codesOf(
         { layers: [{ geom: "point", aes: { x: { field: "a" }, y: { field: "b" } } }] },
-        { profile: { fields: [{ name: "a", type: "numeric" }] } as never },
+        { profile: fromAny({ fields: [{ name: "a", type: "numeric" }] }) },
       ),
     ).toEqual(["invalid-data-profile"]);
   });
@@ -304,7 +305,7 @@ describe("tier 2 — cross-stage error ordering (characterization)", () => {
         layers: [{ geom: "point", aes: { x: { field: "xx" } } }],
         facet: { wrap: { field: "g" }, rows: { field: "h" } },
       },
-      { profile: { fields: [{ name: "a", type: "numeric" }] } as never },
+      { profile: fromAny({ fields: [{ name: "a", type: "numeric" }] }) },
     );
     expect(errors.map((e) => e.code)).toEqual([
       "missing-required-channel",

--- a/packages/svelte/tests/a11y/canvas-a11y-component.test.ts
+++ b/packages/svelte/tests/a11y/canvas-a11y-component.test.ts
@@ -1,3 +1,4 @@
+import { fromAny } from "@total-typescript/shoehorn";
 import { describe, expect, it, vi } from "vitest";
 
 import type { GeometryBatch, RenderModel } from "@ggsvelte/core";
@@ -8,21 +9,21 @@ import { render } from "../helpers/render.js";
 import { until } from "../helpers/until.js";
 
 function batch(partial: { layerIndex: number; rowIndex: number[] }): GeometryBatch {
-  return {
+  return fromAny<GeometryBatch>({
     layerIndex: partial.layerIndex,
     geom: "point",
     rowIndex: new Uint32Array(partial.rowIndex),
-  } as unknown as GeometryBatch;
+  });
 }
 
 function model(opts: {
   layerFields: Record<number, { field: string }[]>;
   rows: Record<number, Record<string, unknown> | null>;
 }): RenderModel {
-  return {
+  return fromAny<RenderModel>({
     layerFields: opts.layerFields,
     row: (index: number) => opts.rows[index] ?? null,
-  } as unknown as RenderModel;
+  });
 }
 
 const sampleModel = model({
@@ -85,15 +86,15 @@ describe("CanvasA11y", () => {
 
   it("closed→open on the same mount materialises rows only after open becomes true", async () => {
     const row = vi.fn((index: number) => {
-      const body = (sampleModel as { row: (i: number) => Record<string, unknown> | null }).row(
+      const body = fromAny<{ row: (i: number) => Record<string, unknown> | null }>(sampleModel).row(
         index,
       );
       return body;
     });
-    const spyModel = {
-      layerFields: (sampleModel as { layerFields: unknown }).layerFields,
+    const spyModel = fromAny<RenderModel>({
+      layerFields: fromAny<{ layerFields: unknown }>(sampleModel).layerFields,
       row,
-    } as unknown as RenderModel;
+    });
 
     const props = {
       model: spyModel,

--- a/packages/svelte/tests/a11y/canvas-a11y.test.ts
+++ b/packages/svelte/tests/a11y/canvas-a11y.test.ts
@@ -1,3 +1,4 @@
+import { fromAny } from "@total-typescript/shoehorn";
 import { describe, expect, it, vi } from "vitest";
 
 import type { GeometryBatch, RenderModel } from "@ggsvelte/core";
@@ -10,21 +11,21 @@ import {
 } from "../../src/lib/a11y/canvas-a11y.js";
 
 function batch(partial: { layerIndex: number; rowIndex: number[] }): GeometryBatch {
-  return {
+  return fromAny<GeometryBatch>({
     layerIndex: partial.layerIndex,
     geom: "point",
     rowIndex: new Uint32Array(partial.rowIndex),
-  } as unknown as GeometryBatch;
+  });
 }
 
 function model(opts: {
   layerFields: Record<number, { field: string }[]>;
   rows: Record<number, Record<string, unknown> | null>;
 }): RenderModel {
-  return {
+  return fromAny<RenderModel>({
     layerFields: opts.layerFields,
     row: (index: number) => opts.rows[index] ?? null,
-  } as unknown as RenderModel;
+  });
 }
 
 describe("a11yRows", () => {
@@ -158,10 +159,10 @@ describe("a11yRows", () => {
 
   it("a11yMarkCount never calls model.row", () => {
     const row = vi.fn(() => ({ x: 1 }));
-    const m = {
+    const m = fromAny<RenderModel>({
       layerFields: { 0: [{ field: "x" }] },
       row,
-    } as unknown as RenderModel;
+    });
     const batches = [batch({ layerIndex: 0, rowIndex: [0, 1, 2, 0xffffffff, 1] })];
     expect(a11yMarkCount(batches)).toBe(3);
     expect(row).not.toHaveBeenCalled();

--- a/packages/svelte/tests/assembly/assemble.test.ts
+++ b/packages/svelte/tests/assembly/assemble.test.ts
@@ -1,3 +1,4 @@
+import { fromAny } from "@total-typescript/shoehorn";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -149,8 +150,8 @@ describe("mappedChannelField", () => {
         },
       ],
     };
-    expect(mappedChannelField(assembled as never, "x")).toBe("a");
-    expect(mappedChannelField(assembled as never, "y")).toBe("b");
+    expect(mappedChannelField(fromAny(assembled), "x")).toBe("a");
+    expect(mappedChannelField(fromAny(assembled), "y")).toBe("b");
   });
 
   it("falls through to the first layer with a non-null channel field", () => {

--- a/packages/svelte/tests/assembly/labels.test.ts
+++ b/packages/svelte/tests/assembly/labels.test.ts
@@ -1,3 +1,4 @@
+import { fromAny, fromPartial } from "@total-typescript/shoehorn";
 import { describe, expect, it } from "vitest";
 
 import type { RenderModel } from "@ggsvelte/core";
@@ -24,10 +25,10 @@ function model(opts: {
   layerFields?: { field: string }[][];
   rows?: Record<number, Record<string, unknown> | null>;
 }): RenderModel {
-  return {
+  return fromAny<RenderModel>({
     layerFields: opts.layerFields ?? [[{ field: "x" }, { field: "y" }]],
     row: (index: number) => opts.rows?.[index] ?? null,
-  } as unknown as RenderModel;
+  });
 }
 
 describe("markLabel", () => {
@@ -81,13 +82,13 @@ describe("inspectionLiveText", () => {
         "mode" | "focus" | "members" | "state"
       >,
   ): PlotInspectionChange<Record<string, unknown>, PropertyKey> {
-    return {
+    return fromPartial<PlotInspectionChange<Record<string, unknown>, PropertyKey>>({
       type: "inspect",
       phase: "change",
       source: "keyboard",
       panelId: null,
       ...partial,
-    } as PlotInspectionChange<Record<string, unknown>, PropertyKey>;
+    });
   }
 
   it("uses singular/plural and optional pinned suffix for exact mode", () => {
@@ -123,14 +124,14 @@ describe("inspectionLiveText", () => {
         },
       ],
     });
-    expect(inspectionLiveText(m, one as never)).toBe("x 1, y 2; 1 datum");
+    expect(inspectionLiveText(m, fromAny(one))).toBe("x 1, y 2; 1 datum");
 
     const pinned = {
       ...one,
       state: "pinned" as const,
       members: [one.members[0], one.members[0]],
     };
-    expect(inspectionLiveText(m, pinned as never)).toBe("x 1, y 2; 2 data, pinned");
+    expect(inspectionLiveText(m, fromAny(pinned))).toBe("x 1, y 2; 2 data, pinned");
   });
 
   it("excludes the axis channel from focused fields for x/y modes", () => {
@@ -169,7 +170,7 @@ describe("inspectionLiveText", () => {
         },
       ],
     });
-    expect(inspectionLiveText(m, value as never)).toBe("x 3.0; 1 datum; focused y 9, color blue");
+    expect(inspectionLiveText(m, fromAny(value))).toBe("x 3.0; 1 datum; focused y 9, color blue");
   });
 });
 
@@ -202,7 +203,9 @@ describe("resolveInteractionLiveText", () => {
       anchor: { x: 0, y: 0 },
     },
   ];
-  const keyboardInspection = {
+  const keyboardInspection = fromPartial<
+    PlotInspectionChange<Record<string, unknown>, PropertyKey>
+  >({
     type: "inspect",
     phase: "change",
     source: "keyboard",
@@ -211,14 +214,14 @@ describe("resolveInteractionLiveText", () => {
     state: "transient",
     focus,
     members,
-  } as PlotInspectionChange<Record<string, unknown>, PropertyKey>;
+  });
 
   it("prefers non-empty sticky announcement over inspection text", () => {
     expect(
       resolveInteractionLiveText({
         announcement: "Zoom complete.",
         model: m,
-        inspection: keyboardInspection as never,
+        inspection: fromAny(keyboardInspection),
       }),
     ).toBe("Zoom complete.");
   });
@@ -228,32 +231,32 @@ describe("resolveInteractionLiveText", () => {
       resolveInteractionLiveText({
         announcement: "",
         model: m,
-        inspection: keyboardInspection as never,
+        inspection: fromAny(keyboardInspection),
       }),
-    ).toBe(inspectionLiveText(m, keyboardInspection as never));
+    ).toBe(inspectionLiveText(m, fromAny(keyboardInspection)));
   });
 
   it("uses inspection live text for keyboard and touch sources only", () => {
-    const expected = inspectionLiveText(m, keyboardInspection as never);
+    const expected = inspectionLiveText(m, fromAny(keyboardInspection));
     expect(
       resolveInteractionLiveText({
         announcement: "",
         model: m,
-        inspection: keyboardInspection as never,
+        inspection: fromAny(keyboardInspection),
       }),
     ).toBe(expected);
     expect(
       resolveInteractionLiveText({
         announcement: "",
         model: m,
-        inspection: { ...keyboardInspection, source: "touch" } as never,
+        inspection: fromAny({ ...keyboardInspection, source: "touch" }),
       }),
     ).toBe(expected);
     expect(
       resolveInteractionLiveText({
         announcement: "",
         model: m,
-        inspection: { ...keyboardInspection, source: "pointer" } as never,
+        inspection: fromAny({ ...keyboardInspection, source: "pointer" }),
       }),
     ).toBe("");
   });

--- a/packages/svelte/tests/component.test.ts
+++ b/packages/svelte/tests/component.test.ts
@@ -8,6 +8,7 @@
  *  - equivalence gate (a): children-assembled spec === builder output ===
  *    hand-written PortableSpec after normalize
  */
+import { fromPartial } from "@total-typescript/shoehorn";
 import { describe, expect, it } from "vitest";
 
 import { aes, gg, normalize } from "@ggsvelte/spec";
@@ -83,11 +84,11 @@ describe("scale stability through the component (THE flagship behavior)", () => 
     expect(initial.a).not.toBe(initial.b);
 
     // remove series "a" -> "b" keeps its color (SveltePlot's flagship defect, fixed)
-    await rerender({ data: rows.filter((r) => r.cls === "b") } as never);
+    await rerender(fromPartial({ data: rows.filter((r) => r.cls === "b") }));
     expect(circleFills(container)).toEqual([initial.b, initial.b]);
 
     // re-add "a" -> it gets its ORIGINAL color back
-    await rerender({ data: rows } as never);
+    await rerender(fromPartial({ data: rows }));
     expect(byClass()).toEqual(initial);
   });
 });
@@ -142,11 +143,11 @@ describe("stacked bars + legend (M1)", () => {
     expect(initial.web).not.toBe(initial.store);
 
     // remove the "web" series -> "store" keeps its color
-    await rerender({ data: salesRows.filter((r) => r.kind === "store") } as never);
+    await rerender(fromPartial({ data: salesRows.filter((r) => r.kind === "store") }));
     expect(rectFills(container)).toEqual([initial.store, initial.store]);
 
     // re-add "web" -> its ORIGINAL color returns
-    await rerender({ data: salesRows } as never);
+    await rerender(fromPartial({ data: salesRows }));
     expect(byKind()).toEqual(initial);
   });
 
@@ -304,13 +305,15 @@ describe("data-gg-ready readiness signal (M1 VR workstream)", () => {
     await expect.poll(() => root?.dataset.ggReady).toBe("true");
     // Explicit empty layers → no model → not ready. Derived predicate must
     // clear the attribute in this commit (not wait for a post-flush $effect).
-    await rerender({
-      data: rows,
-      aes: { x: "x", y: "y" },
-      layers: [],
-      width: 480,
-      height: 320,
-    } as never);
+    await rerender(
+      fromPartial({
+        data: rows,
+        aes: { x: "x", y: "y" },
+        layers: [],
+        width: 480,
+        height: 320,
+      }),
+    );
     expect(root?.dataset.ggReady).toBe("false");
   });
 });

--- a/packages/svelte/tests/final-evidence.test.ts
+++ b/packages/svelte/tests/final-evidence.test.ts
@@ -1,3 +1,4 @@
+import { fromAny, fromPartial } from "@total-typescript/shoehorn";
 import { tick } from "svelte";
 import { describe, expect, it, vi } from "vitest";
 
@@ -195,10 +196,10 @@ describe("final R-1/R0 evidence locks", () => {
     await expect.poll(() => view.container.querySelector(".gg-tooltip")).not.toBeNull();
     expect(view.container.querySelector(".gg-tooltip")?.classList).toContain("gg-tooltip-pinned");
 
-    await view.rerender({ height: 360 } as never);
+    await view.rerender(fromPartial({ height: 360 }));
     expect(view.container.querySelector(".gg-tooltip")?.classList).toContain("gg-tooltip-pinned");
 
-    await view.rerender({ data: data.map((row) => ({ ...row })) } as never);
+    await view.rerender(fromPartial({ data: data.map((row) => ({ ...row })) }));
     await expect.poll(() => view.container.querySelector(".gg-tooltip")).toBeNull();
 
     const reorderData = [
@@ -217,7 +218,7 @@ describe("final R-1/R0 evidence locks", () => {
     keydown(reorderSurface, "Enter");
     await expect.poll(() => reorderView.container.querySelector(".gg-tooltip")).not.toBeNull();
     reorderData.reverse();
-    await reorderView.rerender({ data: reorderData } as never);
+    await reorderView.rerender(fromPartial({ data: reorderData }));
     await expect.poll(() => reorderView.container.querySelector(".gg-tooltip")).toBeNull();
   });
 
@@ -233,7 +234,7 @@ describe("final R-1/R0 evidence locks", () => {
       ondiagnostic: (diagnostic: InteractionDiagnostic) => diagnostics.push(diagnostic),
       ...size,
     });
-    await unstable.rerender({ key: () => "row-2" } as never);
+    await unstable.rerender(fromPartial({ key: () => "row-2" }));
     await expect
       .poll(() => diagnostics.map((diagnostic) => diagnostic.code))
       .toContain("INTERACTION_UNSTABLE_KEY");
@@ -269,7 +270,7 @@ describe("final R-1/R0 evidence locks", () => {
     render(GGPlot, {
       data: [row],
       layers: [{ geom: "point", aes: { x: "x", y: "y" } }],
-      key: (() => null) as never,
+      key: fromAny(() => null),
       inspect: true,
       ...size,
     });

--- a/packages/svelte/tests/interaction/controller.test.ts
+++ b/packages/svelte/tests/interaction/controller.test.ts
@@ -1,3 +1,4 @@
+import { fromAny } from "@total-typescript/shoehorn";
 import { describe, expect, it, vi } from "vitest";
 
 import { createPlotInteraction } from "../../src/lib/interaction/controller.svelte.js";
@@ -366,7 +367,7 @@ describe("createPlotInteraction", () => {
 
   it("rejects invalid runtime keys and non-finite domains without transitions", () => {
     const controller = createPlotInteraction();
-    expect(() => controller.setSelection([{} as unknown as PropertyKey], { scope: "id" })).toThrow(
+    expect(() => controller.setSelection([fromAny<PropertyKey>({})], { scope: "id" })).toThrow(
       TypeError,
     );
     expect(() =>

--- a/packages/svelte/tests/interaction/interaction.test.ts
+++ b/packages/svelte/tests/interaction/interaction.test.ts
@@ -4,6 +4,7 @@
  * color stability, a11y attributes, container resize through run ids, and
  * model disposal.
  */
+import { fromPartial } from "@total-typescript/shoehorn";
 import { describe, expect, it, vi } from "vitest";
 
 import type { RenderModel } from "@ggsvelte/core";
@@ -1224,14 +1225,17 @@ describe("brush + brush-to-zoom", () => {
     ];
 
     for (const fixture of fixtures) {
-      const view = render(GGPlot, {
-        data: fixture.data,
-        aes: { x: "x", y: "y" },
-        layers: [{ geom: "point" }],
-        scales: fixture.scales,
-        select: { type: "interval", mode: "x" },
-        ...size,
-      } as never);
+      const view = render(
+        GGPlot,
+        fromPartial({
+          data: fixture.data,
+          aes: { x: "x", y: "y" },
+          layers: [{ geom: "point" }],
+          scales: fixture.scales,
+          select: { type: "interval", mode: "x" },
+          ...size,
+        }),
+      );
       const setBounds = [
         ...view.container.querySelectorAll<HTMLButtonElement>(".gg-tool-rail button"),
       ].find((button) => button.textContent?.trim() === "Set x selection bounds");
@@ -1511,7 +1515,7 @@ describe("container width + run ids + disposal", () => {
       onrender: (m: RenderModel) => models.push(m),
       ...size,
     });
-    await second.rerender({ data: rows.slice(0, 2) } as never);
+    await second.rerender(fromPartial({ data: rows.slice(0, 2) }));
     await until(() => models.length >= 2);
     const [first, latest] = [models[0], models.at(-1)];
     expect(latest).not.toBe(first);

--- a/packages/svelte/tests/interval/bounds-editor-unit.test.ts
+++ b/packages/svelte/tests/interval/bounds-editor-unit.test.ts
@@ -1,3 +1,4 @@
+import { fromPartial } from "@total-typescript/shoehorn";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -7,13 +8,13 @@ import {
 } from "../../src/lib/interval/bounds-editor.js";
 
 const input = (overrides: Partial<BoundsEditorInput> = {}): BoundsEditorInput =>
-  ({
+  fromPartial<BoundsEditorInput>({
     axis: "x",
     action: "select",
     scale: "linear",
     bounds: [2, 8],
     ...overrides,
-  }) as BoundsEditorInput;
+  });
 
 describe("precise bounds drafts", () => {
   it("formats continuous and time values without local-time conversion", () => {

--- a/packages/svelte/tests/interval/interval-state.test.ts
+++ b/packages/svelte/tests/interval/interval-state.test.ts
@@ -2,6 +2,7 @@
  * Interval-selection + bounds-editor controller tests (S5 extraction).
  * Factories own deriveds + effects — instantiate under `$effect.root` and destroy.
  */
+import { fromAny, fromPartial } from "@total-typescript/shoehorn";
 import { flushSync } from "svelte";
 import { describe, expect, it } from "vitest";
 
@@ -724,7 +725,7 @@ describe("createIntervalState bounds editor select path", () => {
     let keyCalls = 0;
     let candidateReads = 0;
     const rawCandidates = model.candidates;
-    const spyModel = {
+    const spyModel = fromPartial<RenderModel>({
       ...model,
       candidates: {
         get size() {
@@ -735,7 +736,7 @@ describe("createIntervalState bounds editor select path", () => {
           return rawCandidates.candidate(id);
         },
       },
-    } as RenderModel;
+    });
     const events: PlotSelection[] = [];
     const { state, destroy } = mountIntervalController({
       model: () => spyModel,
@@ -985,7 +986,7 @@ describe("createIntervalState bounds-cancel effect", () => {
 describe("createIntervalState write-before-emit", () => {
   it("clearIntervalSelection: committedInterval is already null when emitSelection runs", () => {
     const model = modelFor(continuousSpec());
-    let observedAtEmit: IntervalSelection | null | undefined = "unset" as never;
+    let observedAtEmit: IntervalSelection | null | undefined = fromAny("unset");
     const { state, destroy } = mountIntervalController({
       model: () => model,
       selectConfig: persistentSelect,

--- a/packages/svelte/tests/interval/precise-bounds.test.ts
+++ b/packages/svelte/tests/interval/precise-bounds.test.ts
@@ -1,3 +1,4 @@
+import { fromPartial } from "@total-typescript/shoehorn";
 import { describe, expect, it } from "vitest";
 
 import { trainBand, type PositionScale } from "@ggsvelte/core";
@@ -18,7 +19,7 @@ describe("precise plot bounds adapters", () => {
       const input = boundsEditorInputForScale({
         axis: "x",
         action: "select",
-        scale: { type, domain: [1, 100] } as PositionScale,
+        scale: fromPartial<PositionScale>({ type, domain: [1, 100] }),
         bounds: [90, 10],
         reversed: true,
       });
@@ -36,12 +37,12 @@ describe("precise plot bounds adapters", () => {
     const input = boundsEditorInputForScale({
       axis: "y",
       action: "select",
-      scale: {
+      scale: fromPartial<PositionScale>({
         type: "band",
         domain: ["north", "south"],
         rawDomain: ["north", "south"],
         step: 0.5,
-      } as PositionScale,
+      }),
     });
     expect(input).toMatchObject({
       scale: "band",

--- a/packages/svelte/tests/interval/query.test.ts
+++ b/packages/svelte/tests/interval/query.test.ts
@@ -1,3 +1,4 @@
+import { fromPartial } from "@total-typescript/shoehorn";
 import { describe, expect, it } from "vitest";
 
 import { encodeKey } from "@ggsvelte/core";
@@ -34,7 +35,7 @@ function scene(partial: {
     panel,
     singlePanel: partial.singlePanel ?? true,
     flip,
-    scales: {
+    scales: fromPartial<IntervalQueryScene["scales"]>({
       x: {
         type: "linear",
         invert: (t: number) => (flip ? 1 - t : t) * 10,
@@ -43,7 +44,7 @@ function scene(partial: {
         type: "linear",
         invert: (t: number) => (flip ? t : 1 - t) * 20,
       },
-    } as IntervalQueryScene["scales"],
+    }),
     queryCandidates(expanded) {
       // Production uses the hit index; tests approximate with axis-aligned bounds.
       return candidates
@@ -142,10 +143,10 @@ describe("resolveIntervalQueryParts", () => {
             width: 100,
             height: 100,
             id: "panel:east",
-            scales: {
+            scales: fromPartial<IntervalQueryScene["scales"]>({
               x: { type: "linear", invert: (t: number) => 100 + t * 100 },
               y: { type: "linear", invert: (t: number) => 1000 - t * 1000 },
-            } as IntervalQueryScene["scales"],
+            }),
           },
         ],
       },
@@ -239,10 +240,10 @@ describe("resolveIntervalQueryParts", () => {
 
 describe("intervalPixelsFromDomains", () => {
   const panel = { x: 10, y: 20, width: 100, height: 200 };
-  const linearScales = {
+  const linearScales = fromPartial<IntervalQueryScene["scales"]>({
     x: { type: "linear", normalize: (v: number) => v / 10 },
     y: { type: "linear", normalize: (v: number) => v / 20 },
-  } as IntervalQueryScene["scales"];
+  });
   const bandRaw = ["a", "b", "c", "d"] as const;
   const bandScale = {
     type: "band",
@@ -289,7 +290,7 @@ describe("intervalPixelsFromDomains", () => {
       intervalPixelsFromDomains({
         domains: { x: { kind: "band", values: ["b", "c"] } },
         panel,
-        scales: { ...linearScales, x: bandScale } as IntervalQueryScene["scales"],
+        scales: fromPartial<IntervalQueryScene["scales"]>({ ...linearScales, x: bandScale }),
         flipped: false,
       }),
     ).toEqual({ x0: 35, y0: 20, x1: 85, y1: 220 });
@@ -307,7 +308,7 @@ describe("intervalPixelsFromDomains", () => {
       intervalPixelsFromDomains({
         domains: { x: { kind: "band", values: ["a"] } },
         panel,
-        scales: { ...linearScales, x: reversed } as IntervalQueryScene["scales"],
+        scales: fromPartial<IntervalQueryScene["scales"]>({ ...linearScales, x: reversed }),
         flipped: false,
       }),
     ).toEqual({ x0: 85, y0: 20, x1: 110, y1: 220 });
@@ -332,7 +333,7 @@ describe("intervalPixelsFromDomains", () => {
       intervalPixelsFromDomains({
         domains: { x: { kind: "band", values: ["missing"] } },
         panel,
-        scales: { ...linearScales, x: bandScale } as IntervalQueryScene["scales"],
+        scales: fromPartial<IntervalQueryScene["scales"]>({ ...linearScales, x: bandScale }),
         flipped: false,
       }),
     ).toEqual({ x0: 10, y0: 20, x1: 110, y1: 220 });
@@ -371,7 +372,7 @@ describe("intervalPixelsFromDomains", () => {
           x: { kind: "band", values: [encodeKey(1), encodeKey(true)] },
         },
         panel,
-        scales: { ...linearScales, x: typedScale } as IntervalQueryScene["scales"],
+        scales: fromPartial<IntervalQueryScene["scales"]>({ ...linearScales, x: typedScale }),
         flipped: false,
       }),
     ).toEqual({ x0: 10, y0: 20, x1: 110, y1: 220 });
@@ -382,7 +383,7 @@ describe("intervalPixelsFromDomains", () => {
       intervalPixelsFromDomains({
         domains: { x: { kind: "band", values: [encodeKey("1")] } },
         panel,
-        scales: { ...linearScales, x: typedScale } as IntervalQueryScene["scales"],
+        scales: fromPartial<IntervalQueryScene["scales"]>({ ...linearScales, x: typedScale }),
         flipped: false,
       }),
     ).toEqual({
@@ -425,7 +426,7 @@ describe("intervalPixelsFromDomains", () => {
       intervalPixelsFromDomains({
         domains: { x: { kind: "band", values: selected } },
         panel,
-        scales: { ...linearScales, x: largeScale } as IntervalQueryScene["scales"],
+        scales: fromPartial<IntervalQueryScene["scales"]>({ ...linearScales, x: largeScale }),
         flipped: false,
       }),
     ).toEqual({ x0: 10, y0: 20, x1: 110, y1: 220 });
@@ -504,10 +505,10 @@ describe("buildIntervalSelectionFromScene", () => {
 });
 
 describe("intervalQuerySceneFromModel", () => {
-  const scales = {
+  const scales = fromPartial<IntervalQueryScene["scales"]>({
     x: { type: "linear", invert: (t: number) => t * 10 },
     y: { type: "linear", invert: (t: number) => (1 - t) * 20 },
-  } as IntervalQueryScene["scales"];
+  });
 
   function port(partial: {
     panels?: IntervalQueryModelPort["scene"]["panels"];

--- a/packages/svelte/tests/legend/filter-reconciliation.test.ts
+++ b/packages/svelte/tests/legend/filter-reconciliation.test.ts
@@ -1,3 +1,4 @@
+import { fromAny } from "@total-typescript/shoehorn";
 import { expect, test } from "vitest";
 
 import GGPlot from "../../src/lib/GGPlot.svelte";
@@ -37,7 +38,7 @@ test("disappeared filter values return visible while resetScales keeps active fi
 
   view.container.querySelector<HTMLInputElement>("input[aria-label='Show south']")!.click();
   await until(() => candidates === 1);
-  (view as unknown as { component: { resetScales(): void } }).component.resetScales();
+  fromAny<{ component: { resetScales(): void } }>(view).component.resetScales();
   await until(() => candidates === 1);
   expect(
     view.container.querySelector<HTMLInputElement>("input[aria-label='Show south']")!.checked,

--- a/packages/svelte/tests/legend/interaction.test.ts
+++ b/packages/svelte/tests/legend/interaction.test.ts
@@ -1,3 +1,4 @@
+import { fromPartial } from "@total-typescript/shoehorn";
 import { describe, expect, it } from "vitest";
 
 import type { SceneLegend, ThemeTokens } from "@ggsvelte/core";
@@ -5,7 +6,7 @@ import type { SceneLegend, ThemeTokens } from "@ggsvelte/core";
 import LegendHarness from "../fixtures/LegendHarness.svelte";
 import { render } from "../helpers/render.js";
 
-const theme = {} as ThemeTokens;
+const theme = fromPartial<ThemeTokens>({});
 const discrete = {
   type: "discrete",
   scale: "fill",

--- a/packages/svelte/tests/legend/renderer-mask.test.ts
+++ b/packages/svelte/tests/legend/renderer-mask.test.ts
@@ -1,3 +1,4 @@
+import { fromPartial } from "@total-typescript/shoehorn";
 import { describe, expect, it } from "vitest";
 
 import type { BatchInteractionMask, GeometryBatch, ThemeTokens } from "@ggsvelte/core";
@@ -5,13 +6,13 @@ import type { BatchInteractionMask, GeometryBatch, ThemeTokens } from "@ggsvelte
 import BatchFocusHarness from "../fixtures/BatchFocusHarness.svelte";
 import { render } from "../helpers/render.js";
 
-const theme = {
+const theme = fromPartial<ThemeTokens>({
   ink: "#111111",
   accent: "#3366ff",
   paper: "#ffffff",
   interactionMuted: 0.25,
   fontFamily: "sans-serif",
-} as ThemeTokens;
+});
 
 const focusFirst: BatchInteractionMask = {
   primitiveCount: 2,

--- a/packages/svelte/tests/r0-evidence.test.ts
+++ b/packages/svelte/tests/r0-evidence.test.ts
@@ -1,3 +1,4 @@
+import { fromPartial } from "@total-typescript/shoehorn";
 import { describe, expect, it } from "vitest";
 
 import type { RenderModel } from "@ggsvelte/core";
@@ -814,12 +815,14 @@ describe("R0 interaction evidence", () => {
       candidate.x,
       candidate.y,
     );
-    await view.rerender({
-      data: [
-        { id: "new-a", x: 100, y: 1 },
-        { id: "new-b", x: 200, y: 2 },
-      ],
-    } as never);
+    await view.rerender(
+      fromPartial({
+        data: [
+          { id: "new-a", x: 100, y: 1 },
+          { id: "new-b", x: 200, y: 2 },
+        ],
+      }),
+    );
     await expect.poll(() => model?.runId).not.toBe(staleModel.runId);
     await nextFrame();
     expect(changes).toHaveLength(0);
@@ -847,7 +850,7 @@ describe("R0 interaction evidence", () => {
       )
       .toBe(true);
 
-    await view.rerender({ data: rows.map((row) => ({ ...row })) } as never);
+    await view.rerender(fromPartial({ data: rows.map((row) => ({ ...row })) }));
     await expect.poll(() => view.container.querySelector(".gg-tooltip")).toBeNull();
     const second = model!.candidates.candidate(1)!;
     pointEvent(capture, "pointermove", second.x, second.y);
@@ -1009,7 +1012,7 @@ describe("R0 interaction evidence", () => {
       { id: "n2", x: 200, y: 2 },
       { id: "n3", x: 400, y: 3 },
     ];
-    await view.rerender({ data: replacement } as never);
+    await view.rerender(fromPartial({ data: replacement }));
     await expect.poll(() => model?.runId).not.toBe(zoomed.runId);
     expect(model!.domains.baseline.x.at(-1)).toBeGreaterThanOrEqual(400);
     const reset = tool(view.container, "Reset zoom");
@@ -1061,7 +1064,7 @@ describe("R0 interaction evidence", () => {
     close.focus();
     expect(document.activeElement).toBe(close);
     await expectAccessible(view.container);
-    await view.rerender({ height: 360 } as never);
+    await view.rerender(fromPartial({ height: 360 }));
     await expect
       .poll(() => view.container.querySelector("svg.gg-plot")?.getAttribute("height"))
       .toBe("360");

--- a/packages/svelte/tests/runtime/semantic-keys.test.ts
+++ b/packages/svelte/tests/runtime/semantic-keys.test.ts
@@ -2,6 +2,7 @@
  * Unit tests for semantic-key pure helpers + reactive service.
  * Factories own effects — instantiate under `$effect.root` and destroy.
  */
+import { fromAny } from "@total-typescript/shoehorn";
 import { flushSync } from "svelte";
 import { describe, expect, it, vi } from "vitest";
 
@@ -361,7 +362,7 @@ describe("resolveSemanticKeys", () => {
         ]),
       }),
       datumKey: (row: Record<string, CellValue>, index: number) =>
-        index === 0 ? String(row.n) : ({ bad: true } as unknown as PropertyKey),
+        index === 0 ? String(row.n) : fromAny<PropertyKey>({ bad: true }),
       priorKeys: new Map(),
       rowIdentity: (rowIndex) => `r:${rowIndex}`,
     });

--- a/packages/svelte/tests/scene/geometry.test.ts
+++ b/packages/svelte/tests/scene/geometry.test.ts
@@ -1,3 +1,4 @@
+import { fromAny } from "@total-typescript/shoehorn";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -54,18 +55,18 @@ describe("panelContainingAnchor", () => {
 
 describe("invertedDomain", () => {
   it("returns undefined for band scales", () => {
-    expect(invertedDomain(bandScale as never, 0.2, 0.8)).toBeUndefined();
+    expect(invertedDomain(fromAny(bandScale), 0.2, 0.8)).toBeUndefined();
   });
 
   it("inverts continuous domains and sorts endpoints", () => {
     const scale = continuousScale([0, 100]);
-    expect(invertedDomain(scale as never, 0.2, 0.8)).toEqual([20, 80]);
-    expect(invertedDomain(scale as never, 0.8, 0.2)).toEqual([20, 80]);
+    expect(invertedDomain(fromAny(scale), 0.2, 0.8)).toEqual([20, 80]);
+    expect(invertedDomain(fromAny(scale), 0.8, 0.2)).toEqual([20, 80]);
   });
 
   it("handles reversed continuous domains", () => {
     const scale = continuousScale([100, 0]);
-    expect(invertedDomain(scale as never, 0.25, 0.75)).toEqual([25, 75]);
+    expect(invertedDomain(fromAny(scale), 0.25, 0.75)).toEqual([25, 75]);
   });
 });
 
@@ -108,8 +109,8 @@ describe("normalizedRect", () => {
 describe("panelDataDomains", () => {
   const panel = { x: 40, y: 20, width: 200, height: 100 };
   const scales = {
-    x: continuousScale([0, 10]) as never,
-    y: continuousScale([0, 50]) as never,
+    x: fromAny(continuousScale([0, 10])),
+    y: fromAny(continuousScale([0, 50])),
   };
 
   it("maps a full panel rect to full scale domains", () => {
@@ -141,8 +142,8 @@ describe("panelDataDomains", () => {
 
   it("omits band-scale channels", () => {
     const mixed = {
-      x: bandScale as never,
-      y: continuousScale([0, 50]) as never,
+      x: fromAny(bandScale),
+      y: fromAny(continuousScale([0, 50])),
     };
     const domains = panelDataDomains({ x0: 40, y0: 20, x1: 240, y1: 120 }, panel, mixed, false);
     expect(domains.x).toBeUndefined();

--- a/packages/svelte/tests/scene/mark-strata.test.ts
+++ b/packages/svelte/tests/scene/mark-strata.test.ts
@@ -1,3 +1,4 @@
+import { fromAny } from "@total-typescript/shoehorn";
 import { describe, expect, it, vi } from "vitest";
 
 import type { GeometryBatch, RenderModel, Stratum } from "@ggsvelte/core";
@@ -11,7 +12,7 @@ function model(partial: {
   height?: number;
   batches?: GeometryBatch[];
 }): RenderModel {
-  return {
+  return fromAny<RenderModel>({
     runId: partial.runId ?? 1,
     scene: {
       width: partial.width ?? 80,
@@ -36,7 +37,7 @@ function model(partial: {
     },
     layerBackends: [],
     candidates: { size: 0, candidate: () => null },
-  } as unknown as RenderModel;
+  });
 }
 
 const emptySvgStratum: Stratum = {

--- a/packages/svelte/tests/scene/stratum-paint.test.ts
+++ b/packages/svelte/tests/scene/stratum-paint.test.ts
@@ -1,3 +1,4 @@
+import { fromAny, fromPartial } from "@total-typescript/shoehorn";
 import { describe, expect, it, vi } from "vitest";
 
 import type { GeometryBatch } from "@ggsvelte/core";
@@ -5,9 +6,9 @@ import type { GeometryBatch } from "@ggsvelte/core";
 import { paintCanvasStratum, resolveBatchFocusMasks } from "../../src/lib/scene/stratum-paint.js";
 
 describe("resolveBatchFocusMasks", () => {
-  const a = { id: "a" } as unknown as GeometryBatch;
-  const b = { id: "b" } as unknown as GeometryBatch;
-  const c = { id: "c" } as unknown as GeometryBatch;
+  const a = fromAny<GeometryBatch>({ id: "a" });
+  const b = fromAny<GeometryBatch>({ id: "b" });
+  const c = fromAny<GeometryBatch>({ id: "c" });
   const sceneBatches = [a, b, c];
   const masks = [{ primitives: new Set([0]) }, null, { primitives: new Set([1]) }] as const;
 
@@ -16,20 +17,20 @@ describe("resolveBatchFocusMasks", () => {
   });
 
   it("maps subset batches by scene identity, not subset index", () => {
-    expect(resolveBatchFocusMasks(sceneBatches, [c, a], masks as never)).toEqual([
+    expect(resolveBatchFocusMasks(sceneBatches, [c, a], fromAny(masks))).toEqual([
       masks[2],
       masks[0],
     ]);
   });
 
   it("returns null for batches absent from the scene list", () => {
-    const orphan = { id: "orphan" } as unknown as GeometryBatch;
-    expect(resolveBatchFocusMasks(sceneBatches, [orphan], masks as never)).toEqual([null]);
+    const orphan = fromAny<GeometryBatch>({ id: "orphan" });
+    expect(resolveBatchFocusMasks(sceneBatches, [orphan], fromAny(masks))).toEqual([null]);
   });
 
   it("treats missing mask slots as null when masks are shorter than the scene", () => {
     // Scene index 2 has no corresponding mask entry.
-    expect(resolveBatchFocusMasks(sceneBatches, [c, a], [masks[0]] as never)).toEqual([
+    expect(resolveBatchFocusMasks(sceneBatches, [c, a], fromAny([masks[0]]))).toEqual([
       null,
       masks[0],
     ]);
@@ -41,9 +42,9 @@ describe("resolveBatchFocusMasks", () => {
   // public contract instead.
   it("projects a large subset by scene identity in reverse order", () => {
     const n = 2_000;
-    const scene = Array.from({ length: n }, (_, i) => ({ id: i }) as unknown as GeometryBatch);
+    const scene = Array.from({ length: n }, (_, i) => fromAny<GeometryBatch>({ id: i }));
     const interactionMasks = scene.map((_, i) =>
-      i % 3 === 0 ? ({ primitives: new Set([i]) } as never) : null,
+      i % 3 === 0 ? fromAny({ primitives: new Set([i]) }) : null,
     );
     // Known scene indices (every 7th, reversed) — expected masks come from that
     // construction, not from re-deriving indices via indexOf.
@@ -62,12 +63,12 @@ describe("paintCanvasStratum", () => {
     const getContext = vi.spyOn(canvas, "getContext").mockReturnValue(null);
     const ok = paintCanvasStratum({
       canvas,
-      scene: {
+      scene: fromPartial({
         width: 100,
         height: 50,
         theme: { interactionMuted: 0.35 },
         batches: [],
-      } as never,
+      }),
       batches: [],
       focusMasks: [],
     });
@@ -80,7 +81,7 @@ describe("paintCanvasStratum", () => {
     // Real browser 2d context — sizing/drawing exercise the core path.
     const ok = paintCanvasStratum({
       canvas,
-      scene: {
+      scene: fromPartial({
         width: 40,
         height: 20,
         theme: { interactionMuted: 0.4 },
@@ -93,7 +94,7 @@ describe("paintCanvasStratum", () => {
         title: null,
         subtitle: null,
         caption: null,
-      } as never,
+      }),
       batches: [],
       focusMasks: [],
     });

--- a/packages/svelte/tests/surface/plot-px.test.ts
+++ b/packages/svelte/tests/surface/plot-px.test.ts
@@ -1,3 +1,4 @@
+import { fromAny, fromPartial } from "@total-typescript/shoehorn";
 import { describe, expect, it } from "vitest";
 
 import type { CandidateFacts } from "@ggsvelte/core";
@@ -84,14 +85,14 @@ describe("plotPointFromClient", () => {
 
 describe("hitFromCandidate", () => {
   it("copies hit fields from a candidate", () => {
-    const candidate = {
+    const candidate = fromPartial<CandidateFacts>({
       layerIndex: 2,
       panelIndex: 1,
       rowIndex: 7,
       x: 12.5,
       y: 44,
       kind: "line",
-    } as CandidateFacts;
+    });
     expect(hitFromCandidate(candidate)).toEqual({
       layerIndex: 2,
       panelIndex: 1,
@@ -150,7 +151,7 @@ describe("bestDirectionalIndex", () => {
 
 describe("buildTraversalHits / buildTraversalEntries", () => {
   const asCandidate = (id: number, partial: Partial<CandidateFacts> = {}): CandidateFacts =>
-    ({
+    fromPartial<CandidateFacts>({
       id,
       layerIndex: 0,
       panelIndex: 0,
@@ -161,7 +162,7 @@ describe("buildTraversalHits / buildTraversalEntries", () => {
       autoMode: "exact",
       lineage: id,
       ...partial,
-    }) as CandidateFacts;
+    });
 
   it("walks first/next order and projects candidates to hits", () => {
     const order = [2, 0, 1];
@@ -398,10 +399,10 @@ describe("matchCandidateFromHit", () => {
   };
 
   const asCandidate = (partial: Partial<typeof base> & { id: number }): CandidateFacts =>
-    ({
+    fromPartial<CandidateFacts>({
       ...base,
       ...partial,
-    }) as CandidateFacts;
+    });
 
   it("matches on layer/panel/row/kind within exclusive 0.5 tolerance", () => {
     const candidates = [
@@ -424,7 +425,7 @@ describe("matchCandidateFromHit", () => {
   });
 
   it("requires kind and row identity", () => {
-    const candidates = [asCandidate({ id: 0, kind: "line" as never })];
+    const candidates = [asCandidate({ id: 0, kind: fromAny("line") })];
     expect(
       matchCandidateFromHit(candidates, hit(10, 20, { rowIndex: 1, kind: "point" })),
     ).toBeNull();

--- a/packages/svelte/tests/surface/surface-state.test.ts
+++ b/packages/svelte/tests/surface/surface-state.test.ts
@@ -7,6 +7,7 @@
  *   zoom → inspection → surface → interval → registerSurfaceEffects
  *   → registerInspectionEffects
  */
+import { fromAny } from "@total-typescript/shoehorn";
 import { flushSync } from "svelte";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -465,7 +466,9 @@ describe("createSurfaceState construction", () => {
     let surfaceInteractiveCalls = 0;
 
     // Minimal stubs so construction can close the cycle without real siblings.
-    const stubInspection = {
+    const stubInspection = fromAny<
+      SurfaceStateDeps["inspection"] extends () => infer R ? R : never
+    >({
       get inspection() {
         inspectionCalls++;
         return null;
@@ -507,9 +510,9 @@ describe("createSurfaceState construction", () => {
       resetTraversalIndex: () => {
         inspectionCalls++;
       },
-    } as unknown as SurfaceStateDeps["inspection"] extends () => infer R ? R : never;
+    });
 
-    const stubInterval = {
+    const stubInterval = fromAny<SurfaceStateDeps["interval"] extends () => infer R ? R : never>({
       get committedInterval() {
         intervalCalls++;
         return null;
@@ -517,13 +520,13 @@ describe("createSurfaceState construction", () => {
       applyBrushSelectEnd: () => {
         intervalCalls++;
       },
-    } as unknown as SurfaceStateDeps["interval"] extends () => infer R ? R : never;
+    });
 
-    const stubZoom = {
+    const stubZoom = fromAny<SurfaceStateDeps["zoom"] extends () => infer R ? R : never>({
       applyBrushZoom: () => {
         zoomCalls++;
       },
-    } as unknown as SurfaceStateDeps["zoom"] extends () => infer R ? R : never;
+    });
 
     const { value: state, destroy } = withEffectRoot(() =>
       createSurfaceState({

--- a/packages/svelte/tests/zoom/zoom.test.ts
+++ b/packages/svelte/tests/zoom/zoom.test.ts
@@ -1,3 +1,4 @@
+import { fromAny } from "@total-typescript/shoehorn";
 import { describe, expect, it } from "vitest";
 
 import type { PortableSpec } from "@ggsvelte/spec";
@@ -105,14 +106,14 @@ describe("sameZoomDomains / stableZoomDomains", () => {
 });
 
 describe("applyZoomToSpec", () => {
-  const base = {
+  const base = fromAny<PortableSpec>({
     aes: {},
     layers: [{ geom: "point" }],
     scales: {
       x: { type: "continuous", nice: true },
       y: { type: "continuous", nice: true },
     },
-  } as unknown as PortableSpec;
+  });
 
   it("returns the same reference when domains are null or empty", () => {
     expect(applyZoomToSpec(base, null)).toBe(base);
@@ -136,10 +137,10 @@ describe("applyZoomToSpec", () => {
   });
 
   it("handles absent scale configs via spread of undefined", () => {
-    const bare = {
+    const bare = fromAny<PortableSpec>({
       aes: {},
       layers: [{ geom: "point" }],
-    } as unknown as PortableSpec;
+    });
     const next = applyZoomToSpec(bare, { y: [0, 1] });
     expect(next.scales?.y).toEqual({ domain: [0, 1], nice: false });
     expect(next.scales?.x).toBeUndefined();
@@ -153,7 +154,7 @@ describe("sanitizePartialZoomDomains", () => {
   };
 
   it("keeps finite continuous channels and drops band/non-finite", () => {
-    expect(sanitizePartialZoomDomains({ x: [5, 15], y: [0, 1] }, scales as never, null)).toEqual({
+    expect(sanitizePartialZoomDomains({ x: [5, 15], y: [0, 1] }, fromAny(scales), null)).toEqual({
       x: [5, 15],
     });
   });
@@ -162,10 +163,10 @@ describe("sanitizePartialZoomDomains", () => {
     expect(
       sanitizePartialZoomDomains(
         { x: [1, 2] },
-        {
+        fromAny({
           x: continuousScale([0, 10]),
           y: continuousScale([0, 10]),
-        } as never,
+        }),
         { y: [3, 4] },
       ),
     ).toEqual({ x: [1, 2], y: [3, 4] });
@@ -175,15 +176,15 @@ describe("sanitizePartialZoomDomains", () => {
     expect(
       sanitizePartialZoomDomains(
         { x: [Number.NaN, 1], y: [0, Number.POSITIVE_INFINITY] },
-        {
+        fromAny({
           x: continuousScale([0, 1]),
           y: continuousScale([0, 1]),
-        } as never,
+        }),
         null,
       ),
     ).toBeNull();
     expect(
-      sanitizePartialZoomDomains({ x: [0, 1] }, { x: bandScale, y: bandScale } as never, null),
+      sanitizePartialZoomDomains({ x: [0, 1] }, fromAny({ x: bandScale, y: bandScale }), null),
     ).toBeNull();
   });
 });
@@ -199,7 +200,7 @@ describe("resolveBrushZoomDomains", () => {
       resolveBrushZoomDomains(
         { x0: 10, y0: 10, x1: 10, y1: 10 },
         panel,
-        scales as never,
+        fromAny(scales),
         false,
         "xy",
         null,
@@ -211,7 +212,7 @@ describe("resolveBrushZoomDomains", () => {
     const domains = resolveBrushZoomDomains(
       { x0: 10, y0: 20, x1: 10, y1: 80 },
       panel,
-      scales as never,
+      fromAny(scales),
       false,
       "xy",
       null,
@@ -224,7 +225,7 @@ describe("resolveBrushZoomDomains", () => {
     const xOnly = resolveBrushZoomDomains(
       { x0: 10, y0: 10, x1: 90, y1: 90 },
       panel,
-      scales as never,
+      fromAny(scales),
       false,
       "x",
       { y: [1, 2] },
@@ -235,7 +236,7 @@ describe("resolveBrushZoomDomains", () => {
     const yOnly = resolveBrushZoomDomains(
       { x0: 10, y0: 10, x1: 90, y1: 90 },
       panel,
-      scales as never,
+      fromAny(scales),
       false,
       "y",
       null,
@@ -249,7 +250,7 @@ describe("resolveBrushZoomDomains", () => {
     const domains = resolveBrushZoomDomains(
       { x0: 0, y0: 0, x1: 100, y1: 100 },
       panel,
-      scales as never,
+      fromAny(scales),
       true,
       "xy",
       null,
@@ -266,7 +267,7 @@ describe("resolveBrushZoomFromModel", () => {
   };
   const single = {
     scene: { panels: [panel] },
-    scales: scales as never,
+    scales: fromAny(scales),
   };
   const rect = { x0: 10, y0: 10, x1: 90, y1: 90 };
 
@@ -287,7 +288,7 @@ describe("resolveBrushZoomFromModel", () => {
       resolveBrushZoomFromModel({
         model: {
           scene: { panels: [panel, { x: 100, y: 0, width: 100, height: 100 }] },
-          scales: scales as never,
+          scales: fromAny(scales),
         },
         rect,
         flipped: false,
@@ -300,7 +301,7 @@ describe("resolveBrushZoomFromModel", () => {
   it("returns null when there are zero panels", () => {
     expect(
       resolveBrushZoomFromModel({
-        model: { scene: { panels: [] }, scales: scales as never },
+        model: { scene: { panels: [] }, scales: fromAny(scales) },
         rect,
         flipped: false,
         mode: "xy",


### PR DESCRIPTION
## Summary

Installs `@total-typescript/shoehorn` and migrates partial test fixtures across `@ggsvelte/spec`, `@ggsvelte/core`, and `@ggsvelte/svelte` off object-literal type assertions.

| Helper | Use |
|--------|-----|
| `fromPartial({ ... })` | Deep-partial of a real type (still type-checks) |
| `fromAny({ ... })` | Intentionally wrong / untyped data for error paths |

Also documents the convention in `CONTRIBUTING.md`.

### Scope by package

- **Root:** `@total-typescript/shoehorn` devDependency + CONTRIBUTING note
- **`packages/spec`:** portability unportable specs, invalid data-profile triggers
- **`packages/core`:** pipeline geometry/candidates/position partials, scale-state, theme stubs
- **`packages/svelte`:** `rerender` partials, RenderModel/GeometryBatch stubs, zoom/interval/surface/a11y fixtures

### Intentionally not migrated

- `as const`
- Error narrowing (`e as PipelineError`)
- DOM casts / post-pipeline batch narrowing (`batches[0] as RectsBatch`)
- Non-fixture workarounds (`CanvasRenderingContext2D` proxy, `apply` arity, Reflect get target)

This is one PR rather than a package stack because the dep + convention + migrations are one reviewable pattern. Happy to split by package if preferred.

## Test plan

- [x] `bun test packages/spec packages/core` (819 pass)
- [x] `cd packages/svelte && bun run test:browser` (2898 pass)
- [x] `bun run check` (tsc -b)
- [x] Pre-push hooks (oxlint type-aware, knip, svelte-check, package build)