### PR TITLE
feat(svelte): advise on silently-inert interaction wiring

### DIFF
--- a/.changeset/wiring-advisories.md
+++ b/.changeset/wiring-advisories.md
@@ -1,0 +1,15 @@
+---
+"@ggsvelte/svelte": patch
+---
+
+# Advise on silently-inert interaction wiring
+
+Two new advisory diagnostics (ADR 0013 ambiguity audit): `interactionScope`
+without an `interaction` controller is ignored and now says so, and an
+interaction handler (`oninspect`/`onselect`/`onzoom`/`onlegendfocus`/
+`onlegendfilter`) whose capability prop is not enabled never fires and now
+says so. Both are delivered once per prop per plot instance through the
+existing `ondiagnostic` channel (dev-only console fallback) and never change
+behavior. The passive controller-consumer pattern stays advisory-free.
+
+Migration: none — additive

--- a/docs/decisions/0013-post-0-1-migration-policy.md
+++ b/docs/decisions/0013-post-0-1-migration-policy.md
@@ -122,7 +122,34 @@ be added for pure-TS spec files if the transform demands it.
 | Unsupported transformations explain the manual change | N/A post-0.1 — none exist     | Required guide subsection per future migration                                  |
 | Release notes link migration guidance                 | Met for 0.2                   | `Migration:` markers in all pending minors; wiring test                         |
 
-## Ambiguity-audit candidates (verdicts land with the audit)
+## Ambiguity audit — verdicts
+
+Audited against `resolveInteractionScope` (`assembly/assemble.ts`),
+`normalizeInteractionConfig` (`interaction/interaction.ts`), the orchestrator
+wiring (`plot-orchestrator.svelte.ts`), and `legend/filter-state.svelte.ts`.
+Capabilities are strictly opt-in (`undefined`/`false` ⇒ off; `legendFilter`
+defaults to `false` in `GGPlot`).
+
+| Combination                                                                                             | Behavior                                            | Verdict                                                                                                                                                                                              |
+| ------------------------------------------------------------------------------------------------------- | --------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `interaction` without `interactionScope`                                                                | `TypeError` at render                               | Loud by design — no diagnostic                                                                                                                                                                       |
+| Controlled zoom without `interactionScope.x`/`.y`                                                       | `TypeError` at render                               | Loud by design — no diagnostic                                                                                                                                                                       |
+| `interactionScope` without `interaction`                                                                | Prop silently ignored; scope derived from `key`/aes | **`INTERACTION_SCOPE_WITHOUT_CONTROLLER` (advisory)**                                                                                                                                                |
+| Handler prop with its capability off (`oninspect`/`onselect`/`onzoom`/`onlegendfocus`/`onlegendfilter`) | Handler never fires, silently                       | **`INTERACTION_HANDLER_WITHOUT_CAPABILITY` (advisory)**, `prop` = handler, `actual` = capability to enable; keyed on capability _requested_, so requires-key/faceted degradations never advise twice |
+| Controller state + locally disabled capability                                                          | Documented passive-consumer linked-view pattern     | Intentional — no diagnostic                                                                                                                                                                          |
+| `oninteraction` with no capability and no controller                                                    | Unified stream is empty                             | Covered by the per-handler advisories above; no separate code                                                                                                                                        |
+| `ontoolchange` with no tools available                                                                  | No tool events                                      | Follows from capability opt-in; tool rail shows unavailability — no code                                                                                                                             |
+| `tool` naming an unavailable capability                                                                 | Tool not activated                                  | Already `INTERACTION_TOOL_UNAVAILABLE`                                                                                                                                                               |
+| `select` point / non-independent interval preset without `key`                                          | Selection not durable / combines nothing            | Already `INTERACTION_POINT_REQUIRES_KEY` / `INTERACTION_INTERVAL_PRESET_REQUIRES_KEY`                                                                                                                |
+| `legendFocus` without `key` / without discrete legends                                                  | Degraded                                            | Already `INTERACTION_LEGEND_REQUIRES_KEY` / `INTERACTION_LEGEND_DISCRETE_ONLY`                                                                                                                       |
+| `zoom` on faceted plots                                                                                 | Disabled                                            | Already `INTERACTION_INTERVAL_FACET_UNSUPPORTED`                                                                                                                                                     |
+
+The two new advisories are delivered through the ordinary diagnostic channel
+once per prop per plot instance (`wiringDiagnostics` in the orchestrator),
+and are component-tested in
+`packages/svelte/tests/interaction/wiring-diagnostics.test.ts`.
+
+## Ambiguity-audit candidates (superseded by the verdicts above)
 
 Checks for ambiguous capability combinations are added only where an audit
 confirms silently surprising behavior — diagnostics are conditional output,
@@ -148,8 +175,9 @@ skipped.
 ## References
 
 - Issue #7 (scope + acceptance criteria for this record).
-- Follow-up issues (filed with this record): runtime deprecation diagnostics
-  (triggered by the first runtime-observable deprecation); codemod runner +
-  fixture harness (triggered by the first migration meeting the bar).
+- Follow-up issues (filed with this record): #289 runtime deprecation
+  diagnostics (triggered by the first runtime-observable deprecation);
+  #290 codemod runner + fixture harness (triggered by the first migration
+  meeting the bar).
 - CONTRIBUTING.md "Deprecation policy"; `lifecycle.json` lifecycle tags;
   ADR 0011/0012 for the interaction and release-automation background.

--- a/packages/svelte/src/lib/interaction/interaction-diagnostics.ts
+++ b/packages/svelte/src/lib/interaction/interaction-diagnostics.ts
@@ -18,7 +18,9 @@ export type InteractionDiagnosticCode =
   | "INTERACTION_LEGEND_REQUIRES_KEY"
   | "INTERACTION_LEGEND_DISCRETE_ONLY"
   | "INTERACTION_INTERVAL_SCALE_UNSUPPORTED"
-  | "INTERACTION_TOOL_UNAVAILABLE";
+  | "INTERACTION_TOOL_UNAVAILABLE"
+  | "INTERACTION_SCOPE_WITHOUT_CONTROLLER"
+  | "INTERACTION_HANDLER_WITHOUT_CAPABILITY";
 
 export interface InteractionDiagnostic {
   readonly severity: "error" | "warning" | "advisory";
@@ -147,5 +149,33 @@ export const INTERACTION_DIAGNOSTIC_CATALOG: Readonly<
     suggestions: ["Enable the matching capability", "Choose an available interaction tool"],
     docUrl:
       "https://ljodea.github.io/ggsvelte/guide/interaction-reference#interaction-tool-unavailable",
+  },
+  INTERACTION_SCOPE_WITHOUT_CONTROLLER: {
+    severity: "advisory",
+    code: "INTERACTION_SCOPE_WITHOUT_CONTROLLER",
+    message:
+      "interactionScope is ignored without an interaction controller; chart-local scope is derived from key and aes.",
+    prop: "interactionScope",
+    suggestions: [
+      "Pass interaction={createPlotInteraction()} to control this plot",
+      "Remove interactionScope from uncontrolled plots",
+    ],
+    docUrl:
+      "https://ljodea.github.io/ggsvelte/guide/interaction-reference#interaction-scope-without-controller",
+  },
+  INTERACTION_HANDLER_WITHOUT_CAPABILITY: {
+    severity: "advisory",
+    code: "INTERACTION_HANDLER_WITHOUT_CAPABILITY",
+    // Emitted with `prop` overridden to the concrete handler name and
+    // `actual` naming the capability prop that would enable it.
+    message:
+      "An interaction handler is set but its capability prop is not enabled, so the handler never fires.",
+    prop: "oninspect / onselect / onzoom / onlegendfocus / onlegendfilter",
+    suggestions: [
+      "Enable the matching capability prop (for example select for onselect)",
+      "Remove the unused handler",
+    ],
+    docUrl:
+      "https://ljodea.github.io/ggsvelte/guide/interaction-reference#interaction-handler-without-capability",
   },
 });

--- a/packages/svelte/src/lib/plot-orchestrator.svelte.ts
+++ b/packages/svelte/src/lib/plot-orchestrator.svelte.ts
@@ -87,7 +87,10 @@ import { createSelectionState, type SelectionState } from "./selection/selection
 import { createPlotChromeState, type PlotChromeState } from "./chrome/chrome-state.svelte.js";
 import type { LegendFilterEvent, LegendFilterInput } from "./legend/filter.js";
 import type { LayerRegistry } from "./geoms/registry.svelte.js";
-import { normalizeInteractionConfig } from "./interaction/interaction.js";
+import {
+  INTERACTION_DIAGNOSTIC_CATALOG,
+  normalizeInteractionConfig,
+} from "./interaction/interaction.js";
 
 // ---------------------------------------------------------------------------
 // Inputs / return type
@@ -269,6 +272,46 @@ export function createPlotOrchestrator<
 
   $effect(() => {
     for (const diagnostic of interactionConfig.diagnostics) deliverDiagnostic(diagnostic);
+  });
+
+  // Wiring advisories (ADR 0013 audit): prop combinations that silently do
+  // nothing. Unlike config diagnostics (re-delivered per recompute), these
+  // fire once per prop per plot instance — a later capability toggle must
+  // not re-advise.
+  const wiringDiagnostics = $derived.by((): InteractionDiagnostic[] => {
+    const list: InteractionDiagnostic[] = [];
+    if (inputs.interactionScope() !== undefined && inputs.interaction() === undefined)
+      list.push({ ...INTERACTION_DIAGNOSTIC_CATALOG.INTERACTION_SCOPE_WITHOUT_CONTROLLER });
+    const handlerCapabilityPairs = [
+      ["oninspect", "inspect", inputs.oninspect(), inputs.inspect()],
+      ["onselect", "select", inputs.onselect(), inputs.select()],
+      ["onzoom", "zoom", inputs.onzoom(), inputs.zoom()],
+      ["onlegendfocus", "legendFocus", inputs.onlegendfocus(), inputs.legendFocus()],
+      ["onlegendfilter", "legendFilter", inputs.onlegendfilter(), inputs.legendFilter()],
+    ] as const;
+    for (const [handler, capability, handlerValue, capabilityValue] of handlerCapabilityPairs) {
+      if (handlerValue === undefined) continue;
+      // Capability "requested" (any value but undefined/false) is enough:
+      // requested-but-degraded configs already get their own diagnostics
+      // (requires-key, faceted zoom, ...) — never advise twice for one
+      // mistake.
+      if (capabilityValue !== undefined && capabilityValue !== false) continue;
+      list.push({
+        ...INTERACTION_DIAGNOSTIC_CATALOG.INTERACTION_HANDLER_WITHOUT_CAPABILITY,
+        prop: handler,
+        actual: capability,
+      });
+    }
+    return list;
+  });
+  const deliveredWiring = new Set<string>();
+  $effect(() => {
+    for (const diagnostic of wiringDiagnostics) {
+      const dedupKey = `${diagnostic.code}:${diagnostic.prop}`;
+      if (deliveredWiring.has(dedupKey)) continue;
+      deliveredWiring.add(dedupKey);
+      deliverDiagnostic(diagnostic);
+    }
   });
 
   // The PublicKey → PropertyKey widening casts live at the GGPlot call site;

--- a/packages/svelte/tests/interaction/wiring-diagnostics.test.ts
+++ b/packages/svelte/tests/interaction/wiring-diagnostics.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Ambiguous-wiring advisories (ADR 0013 audit): combos that silently do
+ * nothing must advise once, through the ordinary diagnostic channel, without
+ * disturbing intentional patterns (passive controller consumers, clean
+ * handler/capability pairs).
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import GGPlot from "../../src/lib/GGPlot.svelte";
+import { createPlotInteraction } from "../../src/lib/interaction/controller.svelte.js";
+import type { InteractionDiagnostic } from "../../src/lib/interaction/interaction.js";
+import { render } from "../helpers/render.js";
+
+const rows = [
+  { id: "a", x: 1, y: 10 },
+  { id: "b", x: 2, y: 20 },
+  { id: "c", x: 3, y: 15 },
+];
+const size = { width: 480, height: 320 };
+const base = {
+  data: rows,
+  aes: { x: "x", y: "y" },
+  layers: [{ geom: "point" as const }],
+  key: "id",
+  ...size,
+};
+
+function collect(): {
+  diagnostics: InteractionDiagnostic[];
+  ondiagnostic: (diagnostic: InteractionDiagnostic) => void;
+} {
+  const diagnostics: InteractionDiagnostic[] = [];
+  return {
+    diagnostics,
+    ondiagnostic: (diagnostic) => {
+      diagnostics.push(diagnostic);
+    },
+  };
+}
+
+async function settled(container: Element): Promise<void> {
+  await expect.poll(() => container.querySelector("svg") !== null).toBe(true);
+  // One extra macrotask drain so pending $effect flushes cannot race the
+  // absence assertions below.
+  await new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
+}
+
+describe("scope-without-controller advisory", () => {
+  it("advises when interactionScope is supplied without a controller", async () => {
+    const { diagnostics, ondiagnostic } = collect();
+    render(GGPlot, { ...base, interactionScope: { keys: "row-id" }, ondiagnostic });
+    await expect
+      .poll(() => diagnostics.find((d) => d.code === "INTERACTION_SCOPE_WITHOUT_CONTROLLER"))
+      .toMatchObject({ severity: "advisory", prop: "interactionScope" });
+  });
+
+  it("stays silent when the scope accompanies a controller", async () => {
+    const { diagnostics, ondiagnostic } = collect();
+    const interaction = createPlotInteraction<string>();
+    const { container } = render(GGPlot, {
+      ...base,
+      interaction,
+      interactionScope: { keys: "row-id" },
+      ondiagnostic,
+    });
+    await settled(container);
+    expect(diagnostics.map((d) => d.code)).not.toContain("INTERACTION_SCOPE_WITHOUT_CONTROLLER");
+  });
+});
+
+describe("handler-without-capability advisory", () => {
+  it("advises per dead handler, naming the capability prop to enable", async () => {
+    const { diagnostics, ondiagnostic } = collect();
+    render(GGPlot, {
+      ...base,
+      onselect: vi.fn(),
+      onzoom: vi.fn(),
+      ondiagnostic,
+    });
+    await expect
+      .poll(
+        () => diagnostics.filter((d) => d.code === "INTERACTION_HANDLER_WITHOUT_CAPABILITY").length,
+      )
+      .toBe(2);
+    const dead = diagnostics.filter((d) => d.code === "INTERACTION_HANDLER_WITHOUT_CAPABILITY");
+    expect(new Set(dead.map((d) => d.prop))).toEqual(new Set(["onselect", "onzoom"]));
+    expect(new Set(dead.map((d) => d.actual))).toEqual(new Set(["select", "zoom"]));
+    for (const diagnostic of dead) expect(diagnostic.severity).toBe("advisory");
+  });
+
+  it("stays silent when every handler has its capability enabled", async () => {
+    const { diagnostics, ondiagnostic } = collect();
+    const { container } = render(GGPlot, {
+      ...base,
+      inspect: true,
+      select: { type: "point" as const },
+      zoom: true,
+      oninspect: vi.fn(),
+      onselect: vi.fn(),
+      onzoom: vi.fn(),
+      ondiagnostic,
+    });
+    await settled(container);
+    expect(diagnostics.map((d) => d.code)).not.toContain("INTERACTION_HANDLER_WITHOUT_CAPABILITY");
+  });
+
+  it("does not advise about handlers that were never passed", async () => {
+    const { diagnostics, ondiagnostic } = collect();
+    const { container } = render(GGPlot, { ...base, ondiagnostic });
+    await settled(container);
+    expect(diagnostics.map((d) => d.code)).not.toContain("INTERACTION_HANDLER_WITHOUT_CAPABILITY");
+  });
+
+  it("keeps the passive controller-consumer pattern advisory-free", async () => {
+    // Controller state with locally-disabled capabilities is the documented
+    // linked-view pattern (PassiveControllerConsumerPlot) — never advised.
+    const { diagnostics, ondiagnostic } = collect();
+    const interaction = createPlotInteraction<string>();
+    const { container } = render(GGPlot, {
+      ...base,
+      interaction,
+      interactionScope: { keys: "row-id" },
+      ondiagnostic,
+    });
+    await settled(container);
+    expect(diagnostics.map((d) => d.code)).not.toContain("INTERACTION_HANDLER_WITHOUT_CAPABILITY");
+  });
+
+  it("advises once per plot instance, not once per reactive update", async () => {
+    const { diagnostics, ondiagnostic } = collect();
+    const view = render(GGPlot, { ...base, onselect: vi.fn(), ondiagnostic });
+    await expect
+      .poll(
+        () => diagnostics.filter((d) => d.code === "INTERACTION_HANDLER_WITHOUT_CAPABILITY").length,
+      )
+      .toBe(1);
+    await view.rerender({ height: 340 });
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
+    expect(
+      diagnostics.filter((d) => d.code === "INTERACTION_HANDLER_WITHOUT_CAPABILITY"),
+    ).toHaveLength(1);
+  });
+
+  it("falls back to a dev console warning when no ondiagnostic handler is set", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {
+      /* swallow the dev fallback while asserting on it */
+    });
+    try {
+      render(GGPlot, { ...base, onselect: () => {} });
+      await expect
+        .poll(() =>
+          warn.mock.calls.some((call) =>
+            String(call[0]).includes("INTERACTION_HANDLER_WITHOUT_CAPABILITY"),
+          ),
+        )
+        .toBe(true);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
Part 2 of 2 for #7, completing the plan started in #288 (ADR 0013). **Closes #7.**

## What

The ADR 0013 ambiguity audit is now recorded as a full combo × behavior × verdict table in the decision record. Of everything audited, exactly two combinations silently do nothing today; both now emit **advisory** diagnostics through the existing `ondiagnostic` channel (dev-only console fallback, silent in production):

- **`INTERACTION_SCOPE_WITHOUT_CONTROLLER`** — `interactionScope` without an `interaction` controller is ignored (`resolveInteractionScope` derives chart-local scope from `key`/aes) and now says so.
- **`INTERACTION_HANDLER_WITHOUT_CAPABILITY`** — a handler prop (`oninspect`/`onselect`/`onzoom`/`onlegendfocus`/`onlegendfilter`) whose capability prop is not enabled never fires and now says so, with `prop` = the handler and `actual` = the capability to enable. Keyed on capability *requested*, so requested-but-degraded configs (requires-key, faceted zoom) are never advised twice for one mistake.

Deliberately **not** diagnosed, per the audit: controller state with locally disabled capabilities (the documented passive-consumer linked-view pattern), and the loud-by-design `TypeError`s (`interaction` without `interactionScope`). Wiring advisories deliver **once per prop per plot instance** — reactive updates cannot spam consumers — unlike config diagnostics, which re-deliver per recompute.

The interaction-reference guide sections for both codes regenerate from the catalog. Patch changeset included with the ADR-mandated `Migration: none — additive` marker. ADR references follow-ups #289 (runtime deprecation diagnostics) and #290 (codemod runner), both trigger-bound.

## Acceptance criteria for #7 (per ADR 0013 applicability matrix)

Fixtures, non-rewriting checks, and release-note linkage: delivered in #288. Ambiguous-combination checks: this PR. Codemods and runtime deprecation checks: N/A today (zero candidates exist); requirements recorded in ADR 0013 and tracked by #290/#289 with explicit triggers.

## Verification

TDD red→green per behavior. `vitest` component tests (8 new: delivery shape, clean/passive silence, once-per-instance dedup across rerenders, dev console fallback); full `bun run test:components` (browser + SSR) green; `bun test scripts` 184 pass; `bun run check` + `check:svelte` clean; oxlint, `lint:type-aware`, knip, oxfmt/prettier, markdownlint all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)