### PR TITLE
chore: ignore local pi settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ tests/visual/.local-baselines/
 /bench-results.json
 tests/evals/out/
 .gstack/
+/.pi/settings.json
 
 # CI content-hash skip markers / dist cache (issue #245)
 .ci-content-hash/


### PR DESCRIPTION
## Summary
- Ignore the repository-local `.pi/settings.json` so developers can customize Pi skill loading without committing machine-specific settings.

## Test plan
- [x] Confirmed `.pi/settings.json` is ignored with `git check-ignore`
- [x] Pre-push checks passed (package build, Svelte checks, type-aware lint, TypeScript examples, knip, and Bun tests)
