### PR TITLE
docs(svelte): teach agent skill v0.2 interactions

### DIFF
--- a/.changeset/bright-charts-teach.md
+++ b/.changeset/bright-charts-teach.md
@@ -1,0 +1,8 @@
+---
+"@ggsvelte/svelte": patch
+---
+
+# Update the packaged agent skill for v0.2
+
+Document linked interaction controllers, legend focus and filtering, faceted
+intervals, exact bounds, and the current Svelte peer requirement.

--- a/packages/svelte/skills/ggsvelte/SKILL.md
+++ b/packages/svelte/skills/ggsvelte/SKILL.md
@@ -45,6 +45,51 @@ ndensity`; density→`density, scaled`; smooth→`y, ymin, ymax, se`;
   `renderToSVGString(spec, {width, height})` (headless, Node-safe),
   `ggsvelte-render spec.json > out.svg` (CLI; JSON-line diagnostics on stderr).
 
+## Svelte interactions (v0.2+)
+
+`@ggsvelte/svelte` requires Svelte `^5.33.1`. Interactions are opt-in props on
+`<GGPlot>`; always provide a stable `key` field when selection or linked views
+must survive filtering, reordering, or data refreshes.
+
+```svelte
+<script lang="ts">
+  import { createPlotInteraction, GGPlot } from "@ggsvelte/svelte";
+
+  const interaction = createPlotInteraction<number>();
+  const scope = { keys: "sales-rows", intervals: "sales-range" } as const;
+</script>
+
+<GGPlot
+  data={rows}
+  aes={{ x: "date", y: "value", color: "series" }}
+  layers={[{ geom: "point" }]}
+  facet={{ wrap: "region", ncol: 3 }}
+  key="id"
+  select={{ type: "interval", mode: "x", preset: "cross-panel" }}
+  legendFocus
+  legendFilter
+  {interaction}
+  interactionScope={scope}
+  oninteraction={(event) => console.log(event)}
+/>
+```
+
+- `inspect` adds tooltip, crosshair, keyboard traversal, and pinning; `select`
+  supports point or interval selection; `zoom` enables brush zoom.
+- Faceted interval presets are `independent`, `union`, and `cross-panel`.
+  After an interval or zoom commit, accessible controls accept exact bounds.
+- `legendFocus` only emphasizes a discrete group. `legendFilter` changes the
+  included rows and reruns the grammar while preserving stable color identity.
+- Share one `createPlotInteraction()` controller between plots to link semantic
+  selection, emphasis, interval, and zoom state. Give plots matching
+  `interactionScope` channels only when they should coordinate.
+- Use controlled controller methods such as `setSelection`, `setInterval`, and
+  `setZoom` for external controls. Observe all interaction kinds through
+  `oninteraction`, or use capability-specific handlers such as `onselect`,
+  `onzoom`, `onlegendfocus`, and `onlegendfilter`.
+- A handler without its matching capability prop, or `interactionScope` without
+  an `interaction` controller, is inert and emits a development advisory.
+
 ## The validation contract (use it!)
 
 `validate(spec)` = schema shape. `validate(spec, { profile })` adds

--- a/skills/ggsvelte/SKILL.md
+++ b/skills/ggsvelte/SKILL.md
@@ -45,6 +45,51 @@ ndensity`; density→`density, scaled`; smooth→`y, ymin, ymax, se`;
   `renderToSVGString(spec, {width, height})` (headless, Node-safe),
   `ggsvelte-render spec.json > out.svg` (CLI; JSON-line diagnostics on stderr).
 
+## Svelte interactions (v0.2+)
+
+`@ggsvelte/svelte` requires Svelte `^5.33.1`. Interactions are opt-in props on
+`<GGPlot>`; always provide a stable `key` field when selection or linked views
+must survive filtering, reordering, or data refreshes.
+
+```svelte
+<script lang="ts">
+  import { createPlotInteraction, GGPlot } from "@ggsvelte/svelte";
+
+  const interaction = createPlotInteraction<number>();
+  const scope = { keys: "sales-rows", intervals: "sales-range" } as const;
+</script>
+
+<GGPlot
+  data={rows}
+  aes={{ x: "date", y: "value", color: "series" }}
+  layers={[{ geom: "point" }]}
+  facet={{ wrap: "region", ncol: 3 }}
+  key="id"
+  select={{ type: "interval", mode: "x", preset: "cross-panel" }}
+  legendFocus
+  legendFilter
+  {interaction}
+  interactionScope={scope}
+  oninteraction={(event) => console.log(event)}
+/>
+```
+
+- `inspect` adds tooltip, crosshair, keyboard traversal, and pinning; `select`
+  supports point or interval selection; `zoom` enables brush zoom.
+- Faceted interval presets are `independent`, `union`, and `cross-panel`.
+  After an interval or zoom commit, accessible controls accept exact bounds.
+- `legendFocus` only emphasizes a discrete group. `legendFilter` changes the
+  included rows and reruns the grammar while preserving stable color identity.
+- Share one `createPlotInteraction()` controller between plots to link semantic
+  selection, emphasis, interval, and zoom state. Give plots matching
+  `interactionScope` channels only when they should coordinate.
+- Use controlled controller methods such as `setSelection`, `setInterval`, and
+  `setZoom` for external controls. Observe all interaction kinds through
+  `oninteraction`, or use capability-specific handlers such as `onselect`,
+  `onzoom`, `onlegendfocus`, and `onlegendfilter`.
+- A handler without its matching capability prop, or `interactionScope` without
+  an `interaction` controller, is inert and emits a development advisory.
+
 ## The validation contract (use it!)
 
 `validate(spec)` = schema shape. `validate(spec, { profile })` adds


### PR DESCRIPTION
## Summary

- document the v0.2 Svelte interaction surface in the canonical ggsvelte agent skill
- sync the byte-identical skill copy shipped inside `@ggsvelte/svelte`
- add a Changesets patch entry for `@ggsvelte/svelte@0.2.1`

## Release path

This intentionally uses Changesets. After this PR merges, Changesets will open/update the Version Packages PR; merging that release PR publishes `@ggsvelte/svelte@0.2.1`.

## Verification

- `bun test packages/spec packages/core benchmarks scripts tests/evals` (1,027 passed)
- `bun test scripts/skill-sync.test.ts scripts/changeset-check.test.ts scripts/ci-routing.test.ts` (60 passed)
- `pre-commit run --all-files`
- `bun run build`
- `bun run lint:package`
- `bunx changeset status` resolves `@ggsvelte/svelte` 0.2.0 → 0.2.1
- `npm pack --dry-run` includes `skills/ggsvelte/SKILL.md`
