### PR TITLE
ci: add Dependabot for Bun workspaces and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,125 @@
+# Dependabot for ggsvelte — Bun monorepo + GitHub Actions.
+#
+# Ecosystems in use:
+#   - bun: root workspace tooling + package/app/spike manifests (single bun.lock)
+#   - github-actions: workflows under .github/workflows and composite actions
+#
+# Not configured (no manifests / no value here):
+#   docker, docker-compose, gomod, cargo, uv
+#   pre-commit — hooks are repo-local `language: system` only (no remote revs)
+#
+# Playwright / @playwright/test are fully ignored: exact pins must stay in
+# lockstep with mcr.microsoft.com/playwright:vX.Y.Z-noble (asserted in CI and
+# documented in CONTRIBUTING.md). Bump them in a human-authored PR that updates
+# package pins + every container tag together.
+#
+# Majors for svelte / vite / @sveltejs/* / typescript / vitest / @types/* are
+# ignored so Dependabot does not open breaking migration PRs automatically.
+
+version: 2
+updates:
+  # Bun monorepo — Monday 09:00 UTC
+  # One multi-directory entry so the same dependency (e.g. typescript, svelte)
+  # lands as a single PR across every package.json that lists it.
+  - package-ecosystem: "bun"
+    directories:
+      - "/"
+      - "/packages/core"
+      - "/packages/spec"
+      - "/packages/svelte"
+      - "/apps/docs"
+      - "/examples"
+      - "/benchmarks"
+      - "/spikes/browser"
+      - "/spikes/pure"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 5
+    assignees:
+      - "ljodea"
+    commit-message:
+      prefix: "deps"
+      prefix-development: "deps-dev"
+      include: "scope"
+    cooldown:
+      default-days: 3
+      semver-major-days: 7
+    groups:
+      # Keep related toolchain bumps reviewable together (still one PR per
+      # dependency name across directories via group-by).
+      svelte-ecosystem:
+        patterns: ["svelte", "@sveltejs/*"]
+        group-by: dependency-name
+      vitest-ecosystem:
+        patterns: ["vitest", "@vitest/*", "vitest-browser-svelte"]
+        group-by: dependency-name
+      oxlint-ecosystem:
+        patterns: ["oxfmt", "oxlint", "oxlint-tsgolint"]
+        group-by: dependency-name
+      prettier-ecosystem:
+        patterns: ["prettier", "prettier-plugin-svelte"]
+        group-by: dependency-name
+      # Everything else: one PR per dependency, aligned across the monorepo.
+      other-dependencies:
+        patterns: ["*"]
+        exclude-patterns:
+          - "svelte"
+          - "@sveltejs/*"
+          - "vitest"
+          - "@vitest/*"
+          - "vitest-browser-svelte"
+          - "oxfmt"
+          - "oxlint"
+          - "oxlint-tsgolint"
+          - "prettier"
+          - "prettier-plugin-svelte"
+          - "playwright"
+          - "@playwright/test"
+        group-by: dependency-name
+    ignore:
+      - dependency-name: "svelte"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "vite"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@sveltejs/*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "vitest"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@vitest/*"
+        update-types: ["version-update:semver-major"]
+      # @types/node majors track the Node line we choose to support (engines >=22).
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
+      # @types/bun majors track packageManager / mise.toml bun pins.
+      - dependency-name: "@types/bun"
+        update-types: ["version-update:semver-major"]
+      # Container lockstep — see header comment and CONTRIBUTING.md tool roster.
+      - dependency-name: "playwright"
+      - dependency-name: "@playwright/test"
+
+  # GitHub Actions (workflows + .github/actions) — Tuesday 09:00 UTC
+  # Actions are SHA-pinned (zizmor-enforced). Dependabot updates the pin SHA
+  # and keeps the version comment current when present.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+      time: "09:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 3
+    assignees:
+      - "ljodea"
+    commit-message:
+      prefix: "deps-ci"
+    cooldown:
+      default-days: 3
+    groups:
+      # One weekly PR for all action bumps — keeps the review surface small.
+      github-actions:
+        patterns: ["*"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,16 +2,19 @@
 #
 # Ecosystems in use:
 #   - bun: root workspace tooling + package/app/spike manifests (single bun.lock)
-#   - github-actions: workflows under .github/workflows and composite actions
+#   - github-actions: workflows under .github/workflows and local composite actions
 #
 # Not configured (no manifests / no value here):
 #   docker, docker-compose, gomod, cargo, uv
 #   pre-commit — hooks are repo-local `language: system` only (no remote revs)
 #
-# Playwright / @playwright/test are fully ignored: exact pins must stay in
-# lockstep with mcr.microsoft.com/playwright:vX.Y.Z-noble (asserted in CI and
-# documented in CONTRIBUTING.md). Bump them in a human-authored PR that updates
-# package pins + every container tag together.
+# Human-authored locksteps (ignored here):
+#   - playwright / @playwright/test — must match mcr.microsoft.com/playwright:v…-noble
+#     (asserted in CI; see CONTRIBUTING.md tool roster)
+#   - pnpm — root pin must match support-matrix.json packageManagers.pnpm
+#     (asserted in scripts/support-matrix.test.ts)
+#   - @ggsvelte/* — publish-range deps in packages/* are owned by Changesets,
+#     not Dependabot registry bumps
 #
 # Majors for svelte / vite / @sveltejs/* / typescript / vitest / @types/* are
 # ignored so Dependabot does not open breaking migration PRs automatically.
@@ -78,6 +81,8 @@ updates:
           - "prettier-plugin-svelte"
           - "playwright"
           - "@playwright/test"
+          - "pnpm"
+          - "@ggsvelte/*"
         group-by: dependency-name
     ignore:
       - dependency-name: "svelte"
@@ -101,12 +106,22 @@ updates:
       # Container lockstep — see header comment and CONTRIBUTING.md tool roster.
       - dependency-name: "playwright"
       - dependency-name: "@playwright/test"
+      # support-matrix.json packageManagers.pnpm lockstep (support-matrix.test.ts).
+      - dependency-name: "pnpm"
+      # Internal publish ranges are Changesets-owned, not registry bumps.
+      - dependency-name: "@ggsvelte/*"
 
-  # GitHub Actions (workflows + .github/actions) — Tuesday 09:00 UTC
+  # GitHub Actions — Tuesday 09:00 UTC
+  # directory: "/" covers .github/workflows (+ root action.yml if present).
+  # Composite actions under .github/actions/* need their own directories —
+  # Dependabot does not walk them from "/".
   # Actions are SHA-pinned (zizmor-enforced). Dependabot updates the pin SHA
   # and keeps the version comment current when present.
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions/ci-content-hash-restore"
+      - "/.github/actions/ci-content-hash-write"
     schedule:
       interval: "weekly"
       day: "tuesday"
@@ -120,6 +135,7 @@ updates:
     cooldown:
       default-days: 3
     groups:
-      # One weekly PR for all action bumps — keeps the review surface small.
+      # One PR per action name, aligned across workflows + composite actions.
       github-actions:
         patterns: ["*"]
+        group-by: dependency-name

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,6 +98,23 @@ upstream, `.md`/`.yaml`/`.svelte` can fold back into oxfmt (`.oxfmtrc.json`
 | svelte / vite / @sveltejs/vite-plugin-svelte | 5.56.4 / 8.1.4 / 7.2.0 | spike + adapter toolchain                                                             |
 | pre-commit                                   | 4.6.0                  | hook framework (both stages)                                                          |
 
+## Dependency updates (Dependabot)
+
+[`.github/dependabot.yml`](.github/dependabot.yml) opens weekly PRs for:
+
+- **Bun** workspace manifests (root + packages/apps/examples/benchmarks/spikes)
+  on Mondays — grouped so one dependency update lands across every `package.json`
+  that lists it.
+- **GitHub Actions** (workflows + composite actions) on Tuesdays — batched into
+  a single PR because third-party actions are SHA-pinned (zizmor-enforced).
+
+Dependabot does **not** bump `playwright` / `@playwright/test`: those exact
+pins must stay aligned with every `mcr.microsoft.com/playwright:v…-noble`
+container tag (asserted in CI). Bump them in a human-authored PR that updates
+package pins and container tags together. Majors for `svelte`, `vite`,
+`@sveltejs/*`, `typescript`, and `vitest` are also ignored — land those as
+deliberate migrations.
+
 ## Running the checks
 
 | Command                                               | What it does                                                                                                                                      |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,15 +105,22 @@ upstream, `.md`/`.yaml`/`.svelte` can fold back into oxfmt (`.oxfmtrc.json`
 - **Bun** workspace manifests (root + packages/apps/examples/benchmarks/spikes)
   on Mondays — grouped so one dependency update lands across every `package.json`
   that lists it.
-- **GitHub Actions** (workflows + composite actions) on Tuesdays — batched into
-  a single PR because third-party actions are SHA-pinned (zizmor-enforced).
+- **GitHub Actions** on Tuesdays — workflows plus local composites under
+  `.github/actions/*` (Dependabot does not walk composites from `/` alone).
+  Third-party actions are SHA-pinned (zizmor-enforced); bumps group by action
+  name across every pin site.
 
-Dependabot does **not** bump `playwright` / `@playwright/test`: those exact
-pins must stay aligned with every `mcr.microsoft.com/playwright:v…-noble`
-container tag (asserted in CI). Bump them in a human-authored PR that updates
-package pins and container tags together. Majors for `svelte`, `vite`,
-`@sveltejs/*`, `typescript`, and `vitest` are also ignored — land those as
-deliberate migrations.
+Dependabot does **not** auto-bump these (human-authored locksteps / release flow):
+
+- `playwright` / `@playwright/test` — exact pins must match every
+  `mcr.microsoft.com/playwright:v…-noble` container tag (asserted in CI).
+- `pnpm` — root pin must match `support-matrix.json` `packageManagers.pnpm`
+  (asserted in `scripts/support-matrix.test.ts`).
+- `@ggsvelte/*` — internal publish ranges are owned by Changesets, not registry
+  bumps from Dependabot.
+
+Majors for `svelte`, `vite`, `@sveltejs/*`, `typescript`, and `vitest` are also
+ignored — land those as deliberate migrations.
 
 ## Running the checks
 

--- a/scripts/release-wiring.test.ts
+++ b/scripts/release-wiring.test.ts
@@ -258,6 +258,32 @@ describe("R0 release wiring", () => {
     expect(approvalJob).toContain("shell: bash");
   });
 
+  it("wires Dependabot for bun workspaces and GitHub Actions", () => {
+    const dependabot = read(".github/dependabot.yml");
+    expect(dependabot).toContain('package-ecosystem: "bun"');
+    expect(dependabot).toContain('package-ecosystem: "github-actions"');
+    // Monorepo manifests Dependabot should visit (single bun.lock at root).
+    for (const directory of [
+      '"/"',
+      '"/packages/core"',
+      '"/packages/spec"',
+      '"/packages/svelte"',
+      '"/apps/docs"',
+      '"/examples"',
+      '"/benchmarks"',
+      '"/spikes/browser"',
+      '"/spikes/pure"',
+    ]) {
+      expect(dependabot).toContain(directory);
+    }
+    // Playwright stays human-authored: package pins + container tag lockstep.
+    expect(dependabot).toContain('dependency-name: "playwright"');
+    expect(dependabot).toContain('dependency-name: "@playwright/test"');
+    // Action bumps batch into one weekly PR.
+    expect(dependabot).toContain("github-actions:");
+    expect(dependabot).toContain('patterns: ["*"]');
+  });
+
   it("versions only publishable packages", () => {
     const config = JSON.parse(read(".changeset/config.json")) as {
       linked?: string[][];

--- a/scripts/release-wiring.test.ts
+++ b/scripts/release-wiring.test.ts
@@ -276,12 +276,18 @@ describe("R0 release wiring", () => {
     ]) {
       expect(dependabot).toContain(directory);
     }
-    // Playwright stays human-authored: package pins + container tag lockstep.
+    // github-actions "/" only covers workflows; composites need their own dirs.
+    expect(dependabot).toContain('"/.github/actions/ci-content-hash-restore"');
+    expect(dependabot).toContain('"/.github/actions/ci-content-hash-write"');
+    // Human-authored locksteps / Changesets-owned internal ranges.
     expect(dependabot).toContain('dependency-name: "playwright"');
     expect(dependabot).toContain('dependency-name: "@playwright/test"');
-    // Action bumps batch into one weekly PR.
+    expect(dependabot).toContain('dependency-name: "pnpm"');
+    expect(dependabot).toContain('dependency-name: "@ggsvelte/*"');
+    // Action bumps group by dependency name across workflows + composites.
     expect(dependabot).toContain("github-actions:");
     expect(dependabot).toContain('patterns: ["*"]');
+    expect(dependabot).toContain("group-by: dependency-name");
   });
 
   it("versions only publishable packages", () => {


### PR DESCRIPTION
## Summary

- Add `.github/dependabot.yml` scoped to what ggsvelte actually uses:
  - **bun** — root + every workspace `package.json` (packages, apps/docs, examples, benchmarks, spikes), Monday weekly, multi-directory with `group-by: dependency-name` so one dep update lands across the monorepo
  - **github-actions** — workflows + composite actions, Tuesday weekly, single batched PR (SHA-pinned actions)
- Deliberately **not** configuring docker/compose/go/cargo/uv/pre-commit (no manifests / all hooks are local `language: system`)
- Ignore `playwright` / `@playwright/test` entirely (exact pins must match `mcr.microsoft.com/playwright:v…-noble`, asserted in CI)
- Ignore majors for `svelte`, `vite`, `@sveltejs/*`, `typescript`, `vitest`/`@vitest/*`, `@types/node`, `@types/bun`
- Cooldown (3d default / 7d major) + modest open-PR limits
- Wire a release-wiring test + CONTRIBUTING section documenting the policy

Reference: langscore’s Dependabot layout for Bun grouping patterns; tailored to ggsvelte’s smaller surface and Playwright container lockstep.

## Test plan

- [x] `bun test scripts/release-wiring.test.ts`
- [x] Prettier check on touched files
- [ ] Confirm Dependabot picks up the config after merge (GitHub → Insights → Dependency graph → Dependabot)
- [ ] First weekly run: bun PRs land grouped; Actions PR is one batch; no Playwright bumps