### PR TITLE
deps-dev: bump @sveltejs/kit 2.69.2 → 2.69.3 (rebased)

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@sveltejs/adapter-static": "^3.0.10",
-    "@sveltejs/kit": "^2.69.2",
+    "@sveltejs/kit": "^2.69.3",
     "@sveltejs/vite-plugin-svelte": "^7.2.0",
     "svelte": "^5.56.5",
     "svelte-check": "^4.7.2",

--- a/bun.lock
+++ b/bun.lock
@@ -4,9 +4,6 @@
   "workspaces": {
     "": {
       "name": "ggsvelte-monorepo",
-      "dependencies": {
-        "svelte": "^5.56.6",
-      },
       "devDependencies": {
         "@arethetypeswrong/cli": "0.18.5",
         "@changesets/cli": "2.31.1",
@@ -40,9 +37,9 @@
       },
       "devDependencies": {
         "@sveltejs/adapter-static": "^3.0.10",
-        "@sveltejs/kit": "^2.69.2",
+        "@sveltejs/kit": "^2.69.3",
         "@sveltejs/vite-plugin-svelte": "^7.2.0",
-        "svelte": "^5.46.4",
+        "svelte": "^5.56.5",
         "svelte-check": "^4.7.2",
         "typescript": "^6.0.3",
         "vite": "^8.0.0",
@@ -67,7 +64,7 @@
         "@ggsvelte/svelte": "workspace:*",
       },
       "devDependencies": {
-        "svelte": "^5.46.4",
+        "svelte": "^5.56.5",
         "typescript": "^6.0.3",
       },
     },
@@ -110,7 +107,7 @@
         "@vitest/coverage-v8": "^4.1.10",
         "axe-core": "^4.11.1",
         "playwright": "1.61.1",
-        "svelte": "^5.46.4",
+        "svelte": "^5.56.5",
         "svelte-check": "^4.7.2",
         "typescript": "^6.0.3",
         "vite": "^8.0.0",
@@ -128,7 +125,7 @@
         "@testing-library/svelte-core": "^1.1.3",
         "@vitest/browser-playwright": "^4.1.10",
         "playwright": "1.61.1",
-        "svelte": "^5.46.4",
+        "svelte": "^5.56.5",
         "typescript": "^6.0.3",
         "vite": "^8.0.0",
         "vitest": "^4.1.10",
@@ -471,7 +468,7 @@
 
     "@sveltejs/adapter-static": ["@sveltejs/adapter-static@3.0.10", "", { "peerDependencies": { "@sveltejs/kit": "^2.0.0" } }, "sha512-7D9lYFWJmB7zxZyTE/qxjksvMqzMuYrrsyh1f4AlZqeZeACPRySjbC3aFiY55wb1tWUaKOQG9PVbm74JcN2Iew=="],
 
-    "@sveltejs/kit": ["@sveltejs/kit@2.69.2", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@sveltejs/acorn-typescript": "^1.0.9", "@types/cookie": "^0.6.0", "acorn": "^8.16.0", "cookie": "^0.6.0", "devalue": "^5.8.1", "esm-env": "^1.2.2", "kleur": "^4.1.5", "magic-string": "^0.30.5", "mrmime": "^2.0.0", "set-cookie-parser": "^3.0.0", "sirv": "^3.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.0.0", "@sveltejs/vite-plugin-svelte": "^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0 || ^7.0.0", "svelte": "^4.0.0 || ^5.0.0-next.0", "typescript": "^5.3.3 || ^6.0.0", "vite": "^5.0.3 || ^6.0.0 || ^7.0.0-beta.0 || ^8.0.0" }, "optionalPeers": ["@opentelemetry/api", "typescript"], "bin": { "svelte-kit": "svelte-kit.js" } }, "sha512-CMdPDbYjRwRu4KXTxBVMuOpFPCt1i/v0ANennotec+K9Cmb2e3w2yYzJiC6Vh/WSvm9Khi5sJMZa0rJPqfHlDw=="],
+    "@sveltejs/kit": ["@sveltejs/kit@2.69.3", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@sveltejs/acorn-typescript": "^1.0.9", "@types/cookie": "^0.6.0", "acorn": "^8.16.0", "cookie": "^0.6.0", "devalue": "^5.8.1", "esm-env": "^1.2.2", "kleur": "^4.1.5", "magic-string": "^0.30.5", "mrmime": "^2.0.0", "set-cookie-parser": "^3.0.0", "sirv": "^3.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.0.0", "@sveltejs/vite-plugin-svelte": "^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0 || ^7.0.0", "svelte": "^4.0.0 || ^5.0.0-next.0", "typescript": "^5.3.3 || ^6.0.0", "vite": "^5.0.3 || ^6.0.0 || ^7.0.0-beta.0 || ^8.0.0" }, "optionalPeers": ["@opentelemetry/api", "typescript"], "bin": { "svelte-kit": "svelte-kit.js" } }, "sha512-cphwqMRcE19/9VkrIPr5qZhQ0SptSSDfDzRUpYHu9OJDFGuYBFyJzK+KQA27wB4YG32O/yF2QjBkDmTyo0vtCw=="],
 
     "@sveltejs/load-config": ["@sveltejs/load-config@0.2.0", "", {}, "sha512-1LgZ/qUqSoq+QorD83lk2hka79Px0wXNW2q5V1nZlxGhQgw1jrsIbVz5YiCeucVLo4XvFLjXukUaQjIiqowkcg=="],
 


### PR DESCRIPTION
## Summary

- Replaces conflicted Dependabot PR #300 (`DIRTY` against current `main`; update-branch returned 422).
- Same safe patch: `@sveltejs/kit` `^2.69.2` → `^2.69.3` in `apps/docs/package.json`, lock resolved to `@sveltejs/kit@2.69.3`.
- No force-push of the Dependabot branch; recreated cleanly from `main`.

Lockfile also drops a phantom root `svelte` workspace dep entry and syncs workspace package `svelte` ranges to match existing package.json pins (no intentional package bumps beyond kit).

## Test plan

- [x] `bun install --frozen-lockfile`
- [x] Pre-commit: package build, svelte-check (docs + packages/svelte), type-aware lint, knip, unit tests
- [ ] CI green on this PR

Closes the conflicted bot PR: #300