### PR TITLE
chore: align svelte-check pins with 4.7.3

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,7 @@ upstream, `.md`/`.yaml`/`.svelte` can fold back into oxfmt (`.oxfmtrc.json`
 | oxfmt                                        | 0.58.0                 | formatter for ts/js/json/jsonc/css/toml                                               |
 | prettier + prettier-plugin-svelte            | 3.9.5 / 4.1.1          | formatter for .svelte/.md/.yaml (see quirk above)                                     |
 | markdownlint-cli2                            | 0.23.0                 | markdown lint (pre-commit stage; config `.markdownlint-cli2.jsonc`)                   |
-| svelte-check                                 | 4.7.2                  | Svelte template + type checking (packages/svelte)                                     |
+| svelte-check                                 | 4.7.3                  | Svelte template + type checking (packages/svelte)                                     |
 | knip                                         | 6.26.0                 | unused files/exports/deps (spikes ignored)                                            |
 | publint / @arethetypeswrong/cli              | 0.3.21 / 0.18.5        | package publish shape (skips unbuilt stubs)                                           |
 | actionlint (npm, wasm)                       | 2.0.6                  | workflow lint via `scripts/actionlint.ts` (no shellcheck integration — wasm build)    |

--- a/scripts/consumer-compat.ts
+++ b/scripts/consumer-compat.ts
@@ -18,7 +18,7 @@ const fixtureDependencies = [
   // Plugin 7 requires Svelte 5.46+, which would make the minimum row a test
   // of fixture peer resolution rather than a test of ggsvelte.
   "@sveltejs/vite-plugin-svelte@5.1.1",
-  "svelte-check@4.7.2",
+  "svelte-check@4.7.3",
   "typescript@6.0.3",
   "vite@6.4.3",
 ];


### PR DESCRIPTION
## Summary
- After #310 landed `svelte-check` **4.7.3** in `apps/docs` + `packages/svelte` + `bun.lock`, two leftover pins still said **4.7.2**.
- `.pre-commit-config.yaml` does **not** pin a version — pre-push hooks run `bun run check:docs` / `check:svelte` against the lockfile, so they already use 4.7.3.
- Bump the documented tool roster and the consumer-compat fixture dependency so they match.

## Test plan
- [x] Diff is only `CONTRIBUTING.md` + `scripts/consumer-compat.ts`
- [ ] CI green (no runtime change expected beyond fixture install pin)