### PR TITLE
refactor(interaction): delegate keyboard navigation to CandidateStore

### DIFF
--- a/.changeset/deepen-candidate-navigation.md
+++ b/.changeset/deepen-candidate-navigation.md
@@ -1,0 +1,13 @@
+---
+"@ggsvelte/core": minor
+"@ggsvelte/svelte": patch
+---
+
+# Delegate keyboard navigation to CandidateStore
+
+Let `CandidateStore.traverse()` apply modular sequential steps and preserve
+paint order for directional ties. Svelte inspection now delegates sequential,
+directional, and coincident keyboard navigation to the model-owned store
+without materializing a second candidate traversal list.
+
+Migration: <https://ljodea.github.io/ggsvelte/guide/upgrading#0-2-to-0-3>

--- a/packages/core/src/candidate-geometry.ts
+++ b/packages/core/src/candidate-geometry.ts
@@ -257,8 +257,8 @@ export function closestOrthInRange(
  * Nearest candidate in one axis direction within a panel-sorted order.
  *
  * `order[panelStart, panelEnd)` must be sorted by ascending primary coordinate,
- * then id. Prefer min primary > 0 (strictly in-direction), then min orthogonal
- * distance, then lower id — matching a linear 0..n-1 scan.
+ * then paint order. Prefer min primary > 0 (strictly in-direction), then min
+ * orthogonal distance, then higher id so topmost/later-painted marks win.
  *
  * Non-finite seed primary → return seedId (linear never updates from NaN primary).
  * Complexity: O(log n + k) probes into `order` for a finite seed (k = equal-primary run).
@@ -315,7 +315,7 @@ export function directionalNearestInOrder(
       if (id === startId) continue;
       const o = Math.abs(orth[id]! - seedOrth);
       if (!Number.isFinite(o)) continue;
-      if (best < 0 || o < bestOrth || (o === bestOrth && id < best)) {
+      if (best < 0 || o < bestOrth || (o === bestOrth && id > best)) {
         best = id;
         bestOrth = o;
       }
@@ -328,7 +328,7 @@ export function directionalNearestInOrder(
       if (id === startId) continue;
       const o = Math.abs(orth[id]! - seedOrth);
       if (!Number.isFinite(o)) continue;
-      if (best < 0 || o < bestOrth || (o === bestOrth && id < best)) {
+      if (best < 0 || o < bestOrth || (o === bestOrth && id > best)) {
         best = id;
         bestOrth = o;
       }

--- a/packages/core/src/candidate-store-eager.ts
+++ b/packages/core/src/candidate-store-eager.ts
@@ -976,19 +976,26 @@ export function buildCandidateStoreEager(
         range: { axis, panelIndex: panel, start, end, permutation },
       };
     },
-    traverse(startId, direction = "next") {
+    traverse(startId, direction = "next", step) {
       if (n === 0) return null;
-      if (direction === "first" || startId === null) return traversal[0]!;
+      if (direction === "first") return traversal[0]!;
       if (direction === "last") return traversal[n - 1]!;
       if (direction === "next" || direction === "previous") {
-        if (!Number.isInteger(startId) || startId < 0 || startId >= n) return traversal[0]!;
-        const at = traversalRank[startId]!;
-        if (direction === "next") return traversal[(at + 1) % n]!;
-        return traversal[(at - 1 + n) % n]!;
+        if (startId !== null && (!Number.isInteger(startId) || startId < 0 || startId >= n))
+          return traversal[0]!;
+        // Preserve the original null-start contract when callers omit step.
+        if (startId === null && step === undefined) return traversal[0]!;
+        const resolvedStep = step ?? 1;
+        if (!Number.isInteger(resolvedStep) || !Number.isFinite(resolvedStep)) return startId;
+        const at = startId === null ? -1 : traversalRank[startId]!;
+        const delta = direction === "next" ? resolvedStep : -resolvedStep;
+        const next = (((at + delta) % n) + n) % n;
+        return traversal[next]!;
       }
+      if (startId === null) return traversal[0]!;
       if (!Number.isInteger(startId) || startId < 0 || startId >= n) return traversal[0]!;
       // left/right/up/down: O(log n + k) via panel-sorted primary axis indexes
-      // (not a full O(n) scan). Same panel; min primary > 0; min orth; lower id.
+      // (not a full O(n) scan). Same panel; min primary > 0; min orth; topmost id.
       const panel = panelIds[startId]!;
       if (direction === "left" || direction === "right") {
         const [panelStart, panelEnd] = panelRangeInOrder(orderByX, panelIds, panel);

--- a/packages/core/src/candidate-store-lazy.ts
+++ b/packages/core/src/candidate-store-lazy.ts
@@ -78,8 +78,8 @@ class LazyCandidateStore implements CandidateStore {
     return this.#ready()?.group(seedId, axis) ?? null;
   }
 
-  traverse(startId: number | null, direction?: TraversalDirection): number | null {
-    return this.#ready()?.traverse(startId, direction) ?? null;
+  traverse(startId: number | null, direction?: TraversalDirection, step?: number): number | null {
+    return this.#ready()?.traverse(startId, direction, step) ?? null;
   }
 
   cycle(seedId: number, step?: number): number | null {

--- a/packages/core/src/candidate-store-types.ts
+++ b/packages/core/src/candidate-store-types.ts
@@ -94,7 +94,8 @@ export interface CandidateStore {
     options: { mode: CandidateInspectMode; maxDistance: number; panelId?: string },
   ): CandidateMatch | null;
   group(seedId: number, axis: "x" | "y"): CandidateGroup | null;
-  traverse(startId: number | null, direction?: TraversalDirection): number | null;
+  /** Navigate traversal order; sequential directions apply step in O(1). */
+  traverse(startId: number | null, direction?: TraversalDirection, step?: number): number | null;
   cycle(seedId: number, step?: number): number | null;
   queryRect(x0: number, y0: number, x1: number, y1: number, panelId?: string): Uint32Array;
   /** Release epoch-local resolvers, scene references, and compact arrays. */

--- a/packages/core/tests/candidate-geometry.test.ts
+++ b/packages/core/tests/candidate-geometry.test.ts
@@ -178,7 +178,7 @@ describe("closestOrthInRange", () => {
 });
 
 describe("directionalNearestInOrder / panelRangeInOrder", () => {
-  it("finds nearest in-direction with lower id on full orth ties", () => {
+  it("finds nearest in-direction with topmost paint order on full orth ties", () => {
     // order by primary (x): ids at x=0,10,10,20
     const order = [0, 1, 2, 3];
     const primary = [0, 10, 10, 20];
@@ -187,8 +187,8 @@ describe("directionalNearestInOrder / panelRangeInOrder", () => {
     expect(directionalNearestInOrder(order, primary, orth, 0, 4, 0, 0, 0, true)).toBe(2);
     // left from id3: nearest is x=10 run; min orth id2
     expect(directionalNearestInOrder(order, primary, orth, 0, 4, 3, 20, 0, false)).toBe(2);
-    // full orth tie at x=10: both orth 5 → lower id
-    expect(directionalNearestInOrder(order, primary, [0, 5, 5, 0], 0, 4, 0, 0, 0, true)).toBe(1);
+    // full orth tie at x=10: both orth 5 → later-painted higher id
+    expect(directionalNearestInOrder(order, primary, [0, 5, 5, 0], 0, 4, 0, 0, 0, true)).toBe(2);
   });
 
   it("returns seed when nothing lies in-direction or seed primary is non-finite", () => {

--- a/packages/core/tests/candidate-store.test.ts
+++ b/packages/core/tests/candidate-store.test.ts
@@ -539,7 +539,7 @@ describe("CandidateStore", () => {
     expect(store.cycle(3, Number.NaN)).toBe(3);
     expect(store.cycle(3, Number.POSITIVE_INFINITY)).toBe(3);
     expect(store.cycle(3, 1.5)).toBe(3);
-    expect(store.traverse(0, "down")).toBe(3);
+    expect(store.traverse(0, "down")).toBe(4);
     expect(store.queryRect(5, 15, 15, 45)).toEqual(new Uint32Array([0, 3, 4, 1]));
   });
 
@@ -547,6 +547,7 @@ describe("CandidateStore", () => {
   // [0, 3, 4, 2, 1]
   it("walks next/previous with wrap-around and falls back for unknown start ids", () => {
     expect(store.traverse(null, "next")).toBe(0);
+    expect(store.traverse(null, "previous")).toBe(0);
     expect(store.traverse(0, "first")).toBe(0);
     expect(store.traverse(0, "last")).toBe(1);
     expect(store.traverse(0, "next")).toBe(3);
@@ -557,16 +558,21 @@ describe("CandidateStore", () => {
     expect(store.traverse(0, "previous")).toBe(1);
     expect(store.traverse(1, "previous")).toBe(2);
     expect(store.traverse(2, "previous")).toBe(4);
+    // CandidateStore owns modular keyboard jumps; callers do not materialize
+    // traversal order to calculate an index themselves.
+    expect(store.traverse(null, "next", 2)).toBe(3);
+    expect(store.traverse(0, "next", 3)).toBe(2);
+    expect(store.traverse(0, "previous", 2)).toBe(2);
     expect(store.traverse(999, "next")).toBe(0);
     expect(store.traverse(-1, "previous")).toBe(0);
   });
 
   it("keeps spatial directions independent of sequential rank", () => {
     // Spatial uses geometry, not traversal order.
-    expect(store.traverse(0, "down")).toBe(3);
+    expect(store.traverse(0, "down")).toBe(4);
     expect(store.traverse(0, "right")).toBe(2);
-    // From (50,30), nearest left is the coincident pair at x=10 (ids 3 then 4); lower id wins ties.
-    expect(store.traverse(2, "left")).toBe(3);
+    // From (50,30), nearest left is the coincident pair at x=10; topmost id 4 wins.
+    expect(store.traverse(2, "left")).toBe(4);
     expect(store.traverse(1, "up")).toBe(2);
   });
 });
@@ -672,9 +678,9 @@ describe("candidate traversal hot path", () => {
     expect(hot.traverse(n - 1, "right")).toBe(n - 1);
   });
 
-  it("directional traverse prefers lower id when primary and orth both tie", () => {
+  it("directional traverse prefers topmost paint order when primary and orth both tie", () => {
     // Three points at x=20 with y=0,10,0; seed at (0,0). Right nearest primary
-    // is x=20; among y=0 ties (orth 0), lower id wins.
+    // is x=20; among y=0 ties (orth 0), the later-painted higher id wins.
     const hot = buildCandidateStore(
       sceneWithPoints([
         [0, 0],
@@ -690,7 +696,7 @@ describe("candidate traversal hot path", () => {
       },
     );
     void hot.x;
-    expect(hot.traverse(0, "right")).toBe(1);
+    expect(hot.traverse(0, "right")).toBe(3);
   });
 });
 

--- a/packages/svelte/src/lib/inspection/frame.ts
+++ b/packages/svelte/src/lib/inspection/frame.ts
@@ -155,32 +155,10 @@ export function resolveQueuedInspectFrameAction(
 }
 
 /** Reducer inspect payload candidate (matches InteractionCandidateRef shape). */
-export type InspectionCandidateRef = {
+type InspectionCandidateRef = {
   readonly epoch: number;
   readonly id: number;
   readonly panelId: string | null;
   readonly x: number;
   readonly y: number;
 };
-
-/**
- * Build the inspect-dispatch candidate ref for setInspection apply.
- * `fallbackId` is a thunk so hosts can defer `traversalHits.indexOf(hit)`
- * until `candidateId` is actually missing (hot pointer path).
- */
-export function buildInspectionCandidateRef(input: {
-  readonly epoch: number;
-  readonly candidateId: number | undefined;
-  readonly fallbackId: () => number;
-  readonly panelId: string | null;
-  readonly x: number;
-  readonly y: number;
-}): InspectionCandidateRef {
-  return {
-    epoch: input.epoch,
-    id: input.candidateId ?? input.fallbackId(),
-    panelId: input.panelId,
-    x: input.x,
-    y: input.y,
-  };
-}

--- a/packages/svelte/src/lib/inspection/inspection-state.svelte.ts
+++ b/packages/svelte/src/lib/inspection/inspection-state.svelte.ts
@@ -2,15 +2,15 @@
  * Inspection controller extracted from GGPlot for S6.
  *
  * Owns inspection $state, inspectionSeed, lastInspectionFingerprint,
- * activeTraversalIndex, pointer-queue fields (queuedPointerToken,
+ * activeCandidateId, pointer-queue fields (queuedPointerToken,
  * queuedPointerInspection, pendingPinnedPointer), construction-time deriveds
  * (inspectionPanel, traversalHits), the coordinator, private resolve/emit
  * helpers, public set/toggle/dismiss/close/traversal/queue methods, and
  * phased effects (coordinator disposal + scene-reconcile).
  *
  * Factory sits at the original queue-vars position (before the component-held
- * reducer). Construction-time deriveds read inspection (own), model, and
- * surfaceInteractive only. Armed later-declared / handler-only deps for the
+ * reducer). Construction-time deriveds read inspection (own) and model only.
+ * Armed later-declared / handler-only deps for the
  * construction guard: reducer, captureSurface, tooltipHovered,
  * clearTooltipHovered, keyAt, inspectEnabled, chooseTool, clearBrush,
  * oninspect, oninteraction.
@@ -36,21 +36,8 @@ import type {
 import { inspectionLiveText as inspectionLiveTextFor } from "../assembly/labels.js";
 import { plotTooltipDomId } from "../assembly/layout.js";
 import { panelContainingAnchor } from "../scene/geometry.js";
-import {
-  bestDirectionalIndex,
-  buildTraversalEntries,
-  cycleCoincidentIndex,
-  hitFromCandidate,
-  nextTraversalIndex,
-  type SceneHit,
-  planCycleCoincident,
-  planDirectionalNavigate,
-} from "../surface/plot-px.js";
-import {
-  buildInspectionCandidateRef,
-  resolveQueuedInspectFrameAction,
-  type QueuedPointerInspection,
-} from "./frame.js";
+import { hitFromCandidate, type SceneHit } from "../surface/plot-px.js";
+import { resolveQueuedInspectFrameAction, type QueuedPointerInspection } from "./frame.js";
 import {
   resolveInspectionCompleteness,
   resolveInspectionMode,
@@ -85,7 +72,6 @@ export type InspectionStateDeps = {
    */
   reducer: () => InteractionReducer;
   inspectConfig: () => ResolvedInteractionConfig["inspect"];
-  surfaceInteractive: () => boolean;
   inspectEnabled: () => boolean;
   dataIdentityEpoch: () => string;
   /**
@@ -165,7 +151,7 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
   );
   let inspectionSeed: CandidateFacts | null = null;
   let lastInspectionFingerprint = "";
-  let activeTraversalIndex = $state(-1);
+  let activeCandidateId: number | null = null;
 
   let queuedPointerToken: {
     readonly epoch: number;
@@ -174,22 +160,11 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
   let queuedPointerInspection: QueuedPointerInspection | null = null;
   let pendingPinnedPointer: QueuedPointerInspection | null = null;
 
-  // Construction-safe: own state + earlier host model / surfaceInteractive.
+  // Construction-safe: own state + earlier host model.
   const inspectionPanel = $derived.by(() => {
     if (inspection === null || deps.model() === null) return null;
     return panelContainingAnchor(deps.model()!.scene.panels, inspection.focus.anchor);
   });
-
-  // Parallel hits + candidate ids: keyboard apply O(1)-fetches
-  // candidates.candidate(id) so resolveInspection does not re-scan the full
-  // store (O(C) matchCandidateFromHit). Ids only — not full CandidateFacts —
-  // so large charts do not retain every facts object for the model lifetime.
-  const traversal = $derived.by(() => {
-    if (!deps.surfaceInteractive() || deps.model() === null)
-      return { hits: [] as SceneHit[], candidateIds: [] as number[] };
-    return buildTraversalEntries(deps.model()!.candidates);
-  });
-  const traversalHits: SceneHit[] = $derived(traversal.hits);
 
   // Coordinator closes over keyAt — handler-only invocation (deferred).
   const inspectionCoordinator = createInspectionCoordinator<Record<string, CellValue>, PropertyKey>(
@@ -300,14 +275,13 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
           return;
         }
         const next = resolved.snapshot;
-        const candidateRef = buildInspectionCandidateRef({
+        const candidateRef = {
           epoch: deps.model()?.runId ?? 0,
-          candidateId: candidate?.id,
-          fallbackId: () => traversalHits.indexOf(hit!),
+          id: resolved.seed.id,
           panelId: next.panelId,
           x: hit!.x,
           y: hit!.y,
-        });
+        };
         deps.reducer().dispatch({ type: "inspect", candidate: candidateRef, source });
         if (state === "pinned") deps.reducer().dispatch({ type: "toggle-pin", source });
         if (
@@ -319,6 +293,7 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
           return;
         inspection = next;
         inspectionSeed = resolved.seed;
+        activeCandidateId = resolved.seed.id;
         if (resolved.semanticChanged) emitInspection(next, resolved.semanticFingerprint);
       }
     }
@@ -433,47 +408,44 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
     dismissInspection("close", source, { restoreFocus });
   }
 
-  /** Private — no remaining external consumer (codex r2 P2-3). */
-  function applyTraversalIndex(index: number): void {
-    activeTraversalIndex = index;
-    // O(1) id → facts for the selected index only (not full-store rematch).
-    const model = deps.model();
-    const id = traversal.candidateIds[index];
-    const candidate =
-      model === null || id === undefined
-        ? undefined
-        : (model.candidates.candidate(id) ?? undefined);
-    setInspection(traversal.hits[index]!, "keyboard", "transient", undefined, candidate);
+  function applyCandidateId(id: number | null): void {
+    if (id === null) return;
+    const candidate = deps.model()?.candidates.candidate(id);
+    if (candidate === null || candidate === undefined) return;
+    activeCandidateId = id;
+    setInspection(hitFromCandidate(candidate), "keyboard", "transient", undefined, candidate);
   }
 
   function navigate(delta: number): void {
-    if (traversalHits.length === 0) return;
-    applyTraversalIndex(nextTraversalIndex(activeTraversalIndex, delta, traversalHits.length));
+    const store = deps.model()?.candidates;
+    if (store === undefined || store.size === 0) return;
+    const direction = delta < 0 ? "previous" : "next";
+    applyCandidateId(store.traverse(activeCandidateId, direction, Math.abs(delta)));
   }
 
   function navigateDirection(dx: number, dy: number): void {
-    const plan = planDirectionalNavigate({
-      hitCount: traversalHits.length,
-      hasInspection: inspection !== null,
-      currentIndex: activeTraversalIndex,
-      bestIndex: () => bestDirectionalIndex(inspection!.focus.anchor, traversalHits, dx, dy),
-    });
-    if (plan.type === "set-index") applyTraversalIndex(plan.index);
+    const store = deps.model()?.candidates;
+    if (store === undefined || store.size === 0) return;
+    if (inspection === null || activeCandidateId === null) {
+      applyCandidateId(store.traverse(activeCandidateId, "next"));
+      return;
+    }
+    const direction = dx < 0 ? "left" : dx > 0 ? "right" : dy < 0 ? "up" : dy > 0 ? "down" : "next";
+    applyCandidateId(store.traverse(activeCandidateId, direction));
   }
 
   function cycleCoincident(delta: number): void {
-    const plan = planCycleCoincident({
-      hasInspection: inspection !== null,
-      hitCount: traversalHits.length,
-      currentIndex: activeTraversalIndex,
-      nextIndex: () =>
-        cycleCoincidentIndex(inspection!.focus.anchor, traversalHits, activeTraversalIndex, delta),
-    });
-    if (plan.type === "set-index") applyTraversalIndex(plan.index);
+    const store = deps.model()?.candidates;
+    if (store === undefined || store.size === 0) return;
+    if (inspection === null || activeCandidateId === null) {
+      applyCandidateId(store.traverse(activeCandidateId, "next"));
+      return;
+    }
+    applyCandidateId(store.cycle(activeCandidateId, delta));
   }
 
   function resetTraversalIndex(): void {
-    activeTraversalIndex = -1;
+    activeCandidateId = null;
   }
 
   function applyQueuedInspectFrame(action: InspectPointerFrameAction): void {
@@ -600,6 +572,7 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
           } else {
             inspection = reconciled.snapshot;
             inspectionSeed = reconciled.seed;
+            activeCandidateId = reconciled.seed.id;
             if (reconciled.semanticChanged)
               emitInspection(reconciled.snapshot, reconciled.semanticFingerprint);
           }

--- a/packages/svelte/src/lib/plot-orchestrator.svelte.ts
+++ b/packages/svelte/src/lib/plot-orchestrator.svelte.ts
@@ -447,8 +447,8 @@ export function createPlotOrchestrator<
   const surfaceInteractive = $derived(interactionConfig.availableTools.length > 0);
 
   // ------------------------------------------------- inspection
-  // Construction-time deriveds may read model / surfaceInteractive (both
-  // earlier). Phased effects register later via registerInspectionEffects().
+  // Construction-time deriveds may read the earlier model. Phased effects
+  // register later via registerInspectionEffects().
   // Reversed deps: reducer / clearBrush / chooseTool close over the later-
   // declared surfaceState (handler/effect-only; construction guard).
   const inspectionState = createInspectionState({
@@ -456,7 +456,6 @@ export function createPlotOrchestrator<
     // Deferred: surface owns the reducer (handler/effect only).
     reducer: () => surfaceState.reducer,
     inspectConfig: () => interactionConfig.inspect,
-    surfaceInteractive: () => surfaceInteractive,
     inspectEnabled: () => inspectEnabled,
     dataIdentityEpoch: () => dataIdentityEpoch,
     // Deferred: semantic-key service is declared later (handler only).

--- a/packages/svelte/src/lib/surface/plot-px.ts
+++ b/packages/svelte/src/lib/surface/plot-px.ts
@@ -23,8 +23,8 @@ export type SceneSize = {
 };
 
 /** Map a client pointer position into plot/scene coordinates. Zero-size
- *  targets return the origin; out-of-bounds clients are intentionally not
- *  clamped (callers may drag past the capture edge). */
+ * targets return the origin; out-of-bounds clients are intentionally not
+ * clamped (callers may drag past the capture edge). */
 export function plotPointFromClient(
   clientX: number,
   clientY: number,
@@ -38,7 +38,7 @@ export function plotPointFromClient(
   };
 }
 
-/** Project a candidate into the SceneHit shape used by hit indexes/overlays. */
+/** Project a candidate into the SceneHit shape used by overlays. */
 export function hitFromCandidate(candidate: CandidateFacts): SceneHit {
   return {
     layerIndex: candidate.layerIndex,
@@ -48,166 +48,4 @@ export function hitFromCandidate(candidate: CandidateFacts): SceneHit {
     y: candidate.y,
     kind: candidate.kind,
   };
-}
-
-/**
- * Narrow candidate-store surface for keyboard/inspection traversal.
- * Production walks id-ascending via traverse(null,"first") / traverse(id,"next").
- */
-export type TraversalCandidateStore = {
-  traverse(fromId: number | null, direction: "first" | "next"): number | null;
-  candidate(id: number): CandidateFacts | null;
-};
-
-/**
- * Ordered keyboard-traversal projection: SceneHits plus the candidate **ids**
- * that produced them (same length/order). Hosts O(1)-fetch
- * `store.candidate(ids[i])` on apply so keyboard navigation does not re-scan
- * the store O(C) via matchCandidateFromHit — without retaining every
- * CandidateFacts object for the model lifetime (compact id list only).
- *
- * Stops on cycle (duplicate id) or null terminator; skips missing candidates.
- */
-export function buildTraversalEntries(store: TraversalCandidateStore): {
-  readonly hits: SceneHit[];
-  readonly candidateIds: readonly number[];
-} {
-  const hits: SceneHit[] = [];
-  const candidateIds: number[] = [];
-  let id = store.traverse(null, "first");
-  const seen = new Set<number>();
-  while (id !== null && !seen.has(id)) {
-    seen.add(id);
-    const candidate = store.candidate(id);
-    if (candidate !== null) {
-      hits.push(hitFromCandidate(candidate));
-      candidateIds.push(id);
-    }
-    id = store.traverse(id, "next");
-  }
-  return { hits, candidateIds };
-}
-
-/**
- * Build the ordered SceneHit list used by keyboard navigation.
- * Prefer `buildTraversalEntries` when the host also needs candidate ids.
- */
-export function buildTraversalHits(store: TraversalCandidateStore): SceneHit[] {
-  return buildTraversalEntries(store).hits;
-}
-
-/** Modular wrap for keyboard traversal across a hit list. */
-export function nextTraversalIndex(current: number, delta: number, length: number): number {
-  if (length <= 0) return -1;
-  return (current + delta + length) % length;
-}
-
-/**
- * Pick the best hit in direction (dx, dy) from origin.
- * Score = primary + 2 * |orthogonal|; ties keep the later traversal index
- * (matches topmost/later paint order used by pointer hit testing).
- * Returns -1 when no forward candidate exists.
- */
-export function bestDirectionalIndex(
-  origin: Readonly<{ x: number; y: number }>,
-  hits: readonly Readonly<{ x: number; y: number }>[],
-  dx: number,
-  dy: number,
-): number {
-  let bestIndex = -1;
-  let bestScore = Number.POSITIVE_INFINITY;
-  for (let index = 0; index < hits.length; index++) {
-    const hit = hits[index]!;
-    const horizontal = hit.x - origin.x;
-    const vertical = hit.y - origin.y;
-    const primary = horizontal * dx + vertical * dy;
-    if (primary <= 0) continue;
-    const orthogonal = Math.abs(horizontal * dy - vertical * dx);
-    const score = primary + orthogonal * 2;
-    // Equal scores overwrite → later traversal order wins.
-    if (score > bestScore) continue;
-    bestScore = score;
-    bestIndex = index;
-  }
-  return bestIndex;
-}
-
-/**
- * Cycle among hits coincident with origin (within < 0.5 px on both axes).
- * When activeIndex is not among them, starts as if at the first coincident
- * entry (Math.max(0, -1) = 0). Returns -1 when fewer than two matches.
- */
-export function cycleCoincidentIndex(
-  origin: Readonly<{ x: number; y: number }>,
-  hits: readonly Readonly<{ x: number; y: number }>[],
-  activeIndex: number,
-  delta: number,
-): number {
-  const coincident = hits
-    .map((hit, index) => ({ hit, index }))
-    .filter(({ hit }) => Math.abs(hit.x - origin.x) < 0.5 && Math.abs(hit.y - origin.y) < 0.5);
-  if (coincident.length < 2) return -1;
-  const current = Math.max(
-    0,
-    coincident.findIndex(({ index }) => index === activeIndex),
-  );
-  const next = coincident[(current + delta + coincident.length) % coincident.length]!;
-  return next.index;
-}
-
-// ---- host traversal step plans ----
-
-export type TraversalStepPlan =
-  | { readonly type: "none" }
-  | { readonly type: "set-index"; readonly index: number };
-
-/**
- * Directional keyboard navigation (arrow keys).
- *
- * - empty hits → none
- * - no live inspection → advance from currentIndex by +1 (host `navigate(1)`)
- * - with inspection → `bestIndex()` (thunk so host skips anchor work when uninspected)
- *   and none when the thunk returns a negative index
- */
-export function planDirectionalNavigate(input: {
-  readonly hitCount: number;
-  readonly hasInspection: boolean;
-  readonly currentIndex: number;
-  /** Evaluated only when hasInspection. */
-  readonly bestIndex: () => number;
-}): TraversalStepPlan {
-  if (input.hitCount <= 0) return { type: "none" };
-  if (!input.hasInspection) {
-    const index = nextTraversalIndex(input.currentIndex, 1, input.hitCount);
-    return index < 0 ? { type: "none" } : { type: "set-index", index };
-  }
-  const best = input.bestIndex();
-  if (best < 0) return { type: "none" };
-  return { type: "set-index", index: best };
-}
-
-/**
- * Coincident cycle (`[` / `]`).
- *
- * - no live inspection → advance from currentIndex by +1 (same as navigate(1))
- * - with inspection → `nextIndex()` thunk; none when negative
- *
- * Host `cycleCoincident` has no empty-list guard; empty hits yield none via
- * nextTraversalIndex / negative nextIndex.
- */
-export function planCycleCoincident(input: {
-  readonly hasInspection: boolean;
-  readonly hitCount: number;
-  readonly currentIndex: number;
-  /** Evaluated only when hasInspection. */
-  readonly nextIndex: () => number;
-}): TraversalStepPlan {
-  if (!input.hasInspection) {
-    if (input.hitCount <= 0) return { type: "none" };
-    const index = nextTraversalIndex(input.currentIndex, 1, input.hitCount);
-    return index < 0 ? { type: "none" } : { type: "set-index", index };
-  }
-  const next = input.nextIndex();
-  if (next < 0) return { type: "none" };
-  return { type: "set-index", index: next };
 }

--- a/packages/svelte/tests/inspection/inspection-state.test.ts
+++ b/packages/svelte/tests/inspection/inspection-state.test.ts
@@ -156,7 +156,6 @@ function mountInspectionController(
     model?: () => RenderModel | null;
     reducer?: () => InteractionReducer;
     inspectConfig?: () => InspectConfig;
-    surfaceInteractive?: () => boolean;
     inspectEnabled?: () => boolean;
     dataIdentityEpoch?: () => string;
     keyAt?: (index: number) => PropertyKey | null;
@@ -192,7 +191,6 @@ function mountInspectionController(
       model: options.model ?? (() => defaultModel),
       reducer: getReducer,
       inspectConfig: options.inspectConfig ?? defaultInspect,
-      surfaceInteractive: options.surfaceInteractive ?? (() => true),
       inspectEnabled: options.inspectEnabled ?? (() => true),
       dataIdentityEpoch: options.dataIdentityEpoch ?? (() => "epoch-1"),
       keyAt:
@@ -245,7 +243,6 @@ describe("createInspectionState construction", () => {
           return reducer;
         },
         inspectConfig: defaultInspect,
-        surfaceInteractive: () => true,
         inspectEnabled: () => {
           inspectEnabledCalls++;
           return true;
@@ -854,22 +851,15 @@ describe("createInspectionState traversal", () => {
     destroy();
   });
 
-  it("keyboard navigate O(1)-fetches by retained id (no full-store rematch)", () => {
-    // applyTraversalIndex must use candidates.candidate(id) for the selected
-    // index only — not matchCandidateFromHit over iterateCandidates (O(C)).
-    // Count candidate() calls after the first navigate has built the traversal
-    // list: a second navigate should call candidate once (the selected id),
-    // not once per store entry.
+  it("keyboard navigate delegates to CandidateStore without materializing traversal hits", () => {
     const model = modelFor(continuousSpec());
     const realCandidate = model.candidates.candidate.bind(model.candidates);
     let candidateCalls = 0;
-    let countCalls = false;
     model.candidates.candidate = (id: number) => {
-      if (countCalls) candidateCalls += 1;
+      candidateCalls += 1;
       return realCandidate(id);
     };
-    const storeSize = model.candidates.size;
-    expect(storeSize).toBeGreaterThan(1);
+    expect(model.candidates.size).toBeGreaterThan(1);
 
     const { state, destroy } = mountInspectionController({
       model: () => model,
@@ -880,16 +870,46 @@ describe("createInspectionState traversal", () => {
     flushSync();
     expect(state.inspection).not.toBeNull();
     const firstKey = state.inspection!.focus.key;
+    // The store chooses one id and inspection fetches only that candidate.
+    expect(candidateCalls).toBe(1);
 
     candidateCalls = 0;
-    countCalls = true;
     state.navigate(1);
     flushSync();
     expect(state.inspection).not.toBeNull();
     expect(state.inspection!.focus.key).not.toEqual(firstKey);
-    // O(1) id fetch — not a full-store walk (would be ≥ storeSize).
-    expect(candidateCalls).toBeLessThan(storeSize);
-    expect(candidateCalls).toBeGreaterThan(0);
+    expect(candidateCalls).toBe(1);
+
+    destroy();
+  });
+
+  it("delegates directional navigation and coincident cycling to CandidateStore", () => {
+    const model = modelFor(continuousSpec());
+    const realTraverse = model.candidates.traverse.bind(model.candidates);
+    const realCycle = model.candidates.cycle.bind(model.candidates);
+    const traversals: string[] = [];
+    let cycleCalls = 0;
+    model.candidates.traverse = (id, direction, step) => {
+      traversals.push(direction ?? "next");
+      return realTraverse(id, direction, step);
+    };
+    model.candidates.cycle = (id, step) => {
+      cycleCalls += 1;
+      return realCycle(id, step);
+    };
+
+    const { state, destroy } = mountInspectionController({
+      model: () => model,
+      registerEffects: false,
+    });
+
+    state.navigate(1);
+    state.navigateDirection(1, 0);
+    state.cycleCoincident(1);
+    flushSync();
+
+    expect(traversals).toContain("right");
+    expect(cycleCalls).toBe(1);
 
     destroy();
   });
@@ -914,7 +934,6 @@ describe("createInspectionState setInspection(null) clear ordering", () => {
         model: () => model,
         reducer: () => wrapped,
         inspectConfig: defaultInspect,
-        surfaceInteractive: () => true,
         inspectEnabled: () => true,
         dataIdentityEpoch: () => "epoch-1",
         keyAt: keyAtForModel(model),

--- a/packages/svelte/tests/inspection/surface-inspection.test.ts
+++ b/packages/svelte/tests/inspection/surface-inspection.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  buildInspectionCandidateRef,
   buildQueuedInspectFrame,
   buildQueuedPointerInspection,
   resolveQueuedInspectFrameAction,
@@ -414,39 +413,6 @@ describe("buildQueuedInspectFrame", () => {
       x: 12,
       y: 24,
     });
-  });
-});
-
-describe("buildInspectionCandidateRef", () => {
-  it("prefers candidateId and does not call fallbackId when present", () => {
-    let fallbackCalls = 0;
-    expect(
-      buildInspectionCandidateRef({
-        epoch: 3,
-        candidateId: 7,
-        fallbackId: () => {
-          fallbackCalls += 1;
-          return -1;
-        },
-        panelId: "p0",
-        x: 1,
-        y: 2,
-      }),
-    ).toEqual({ epoch: 3, id: 7, panelId: "p0", x: 1, y: 2 });
-    expect(fallbackCalls).toBe(0);
-  });
-
-  it("uses lazy fallbackId when candidateId is missing (incl. -1)", () => {
-    expect(
-      buildInspectionCandidateRef({
-        epoch: 1,
-        candidateId: undefined,
-        fallbackId: () => -1,
-        panelId: null,
-        x: 10,
-        y: 20,
-      }),
-    ).toEqual({ epoch: 1, id: -1, panelId: null, x: 10, y: 20 });
   });
 });
 

--- a/packages/svelte/tests/surface/plot-px.test.ts
+++ b/packages/svelte/tests/surface/plot-px.test.ts
@@ -2,28 +2,7 @@ import { fromPartial } from "@total-typescript/shoehorn";
 import { describe, expect, it } from "vitest";
 
 import type { CandidateFacts } from "@ggsvelte/core";
-import {
-  bestDirectionalIndex,
-  buildTraversalEntries,
-  buildTraversalHits,
-  cycleCoincidentIndex,
-  hitFromCandidate,
-  nextTraversalIndex,
-  planCycleCoincident,
-  planDirectionalNavigate,
-  plotPointFromClient,
-  type SceneHit,
-} from "../../src/lib/surface/plot-px.js";
-
-const hit = (x: number, y: number, extras: Partial<SceneHit> = {}): SceneHit => ({
-  layerIndex: 0,
-  panelIndex: 0,
-  rowIndex: 0,
-  x,
-  y,
-  kind: "point",
-  ...extras,
-});
+import { hitFromCandidate, plotPointFromClient } from "../../src/lib/surface/plot-px.js";
 
 describe("plotPointFromClient", () => {
   it("maps client coordinates into scene space", () => {
@@ -32,10 +11,7 @@ describe("plotPointFromClient", () => {
         150,
         120,
         { left: 100, top: 100, width: 200, height: 100 },
-        {
-          width: 400,
-          height: 200,
-        },
+        { width: 400, height: 200 },
       ),
     ).toEqual({ x: 100, y: 40 });
   });
@@ -46,10 +22,7 @@ describe("plotPointFromClient", () => {
         10,
         10,
         { left: 0, top: 0, width: 0, height: 50 },
-        {
-          width: 400,
-          height: 200,
-        },
+        { width: 400, height: 200 },
       ),
     ).toEqual({ x: 0, y: 0 });
     expect(
@@ -57,10 +30,7 @@ describe("plotPointFromClient", () => {
         10,
         10,
         { left: 0, top: 0, width: 50, height: 0 },
-        {
-          width: 400,
-          height: 200,
-        },
+        { width: 400, height: 200 },
       ),
     ).toEqual({ x: 0, y: 0 });
   });
@@ -71,10 +41,7 @@ describe("plotPointFromClient", () => {
         50,
         50,
         { left: 100, top: 100, width: 100, height: 100 },
-        {
-          width: 100,
-          height: 100,
-        },
+        { width: 100, height: 100 },
       ),
     ).toEqual({ x: -50, y: -50 });
   });
@@ -98,286 +65,5 @@ describe("hitFromCandidate", () => {
       y: 44,
       kind: "line",
     });
-  });
-});
-
-describe("nextTraversalIndex", () => {
-  it("wraps modularly in both directions", () => {
-    expect(nextTraversalIndex(0, 1, 3)).toBe(1);
-    expect(nextTraversalIndex(2, 1, 3)).toBe(0);
-    expect(nextTraversalIndex(0, -1, 3)).toBe(2);
-    expect(nextTraversalIndex(1, -1, 3)).toBe(0);
-  });
-});
-
-describe("bestDirectionalIndex", () => {
-  const origin = { x: 50, y: 50 };
-  const hits = [
-    hit(40, 50), // left of origin
-    hit(70, 50), // right
-    hit(80, 50), // farther right
-    hit(70, 55), // right with orthogonal offset
-    hit(50, 50), // coincident with origin
-  ];
-
-  it("returns -1 for empty hits or no candidates in the direction", () => {
-    expect(bestDirectionalIndex(origin, [], 1, 0)).toBe(-1);
-    expect(bestDirectionalIndex(origin, hits, -1, 0)).toBe(0);
-    expect(bestDirectionalIndex(origin, [hit(40, 50)], 1, 0)).toBe(-1);
-  });
-
-  it("prefers the best score and breaks ties by later traversal order", () => {
-    // Both index 1 and a duplicate at same position: later wins on equal score.
-    const tied = [hit(70, 50), hit(70, 50)];
-    expect(bestDirectionalIndex(origin, tied, 1, 0)).toBe(1);
-    // Among rightward hits, nearer primary with zero orthogonal wins over farther.
-    expect(bestDirectionalIndex(origin, hits, 1, 0)).toBe(1);
-  });
-
-  it("applies orthogonal penalty so collinear-ish neighbors win", () => {
-    // index 1: primary=20, ortho=0 → score 20
-    // index 3: primary=20, ortho=5 → score 20+10=30
-    expect(bestDirectionalIndex(origin, hits, 1, 0)).toBe(1);
-  });
-
-  it("excludes origin-coincident and behind-direction hits (primary <= 0)", () => {
-    expect(bestDirectionalIndex(origin, [hit(50, 50), hit(60, 50)], 1, 0)).toBe(1);
-    expect(bestDirectionalIndex(origin, [hit(40, 50)], 1, 0)).toBe(-1);
-  });
-});
-
-describe("buildTraversalHits / buildTraversalEntries", () => {
-  const asCandidate = (id: number, partial: Partial<CandidateFacts> = {}): CandidateFacts =>
-    fromPartial<CandidateFacts>({
-      id,
-      layerIndex: 0,
-      panelIndex: 0,
-      rowIndex: id,
-      x: id * 10,
-      y: id * 10,
-      kind: "point",
-      autoMode: "exact",
-      lineage: id,
-      ...partial,
-    });
-
-  it("walks first/next order and projects candidates to hits", () => {
-    const order = [2, 0, 1];
-    const store = {
-      traverse(fromId: number | null, direction: "first" | "next"): number | null {
-        if (direction === "first") return order[0] ?? null;
-        if (fromId === null) return null;
-        const index = order.indexOf(fromId);
-        return index < 0 ? null : (order[index + 1] ?? null);
-      },
-      candidate(id: number): CandidateFacts | null {
-        return asCandidate(id);
-      },
-    };
-    expect(buildTraversalHits(store)).toEqual([
-      hitFromCandidate(asCandidate(2)),
-      hitFromCandidate(asCandidate(0)),
-      hitFromCandidate(asCandidate(1)),
-    ]);
-  });
-
-  it("stops on cycles and skips missing candidates", () => {
-    const store = {
-      traverse(fromId: number | null, direction: "first" | "next"): number | null {
-        if (direction === "first") return 0;
-        if (fromId === 0) return 1;
-        if (fromId === 1) return 0; // cycle
-        return null;
-      },
-      candidate(id: number): CandidateFacts | null {
-        return id === 1 ? null : asCandidate(id);
-      },
-    };
-    expect(buildTraversalHits(store)).toEqual([hitFromCandidate(asCandidate(0))]);
-  });
-
-  it("returns empty when traverse has no first candidate", () => {
-    expect(
-      buildTraversalHits({
-        traverse: () => null,
-        candidate: () => null,
-      }),
-    ).toEqual([]);
-  });
-
-  it("keeps parallel candidate ids so hosts avoid O(C) hit rematch", () => {
-    // Structural contract: entries.candidateIds[i] identifies hits[i]. Hosts
-    // O(1)-fetch store.candidate(id) on apply instead of matchCandidateFromHit
-    // (full scan). Ids only — do not retain every CandidateFacts object.
-    const order = [5, 1, 9];
-    const byId = new Map(order.map((id) => [id, asCandidate(id)]));
-    const store = {
-      traverse(fromId: number | null, direction: "first" | "next"): number | null {
-        if (direction === "first") return order[0] ?? null;
-        if (fromId === null) return null;
-        const index = order.indexOf(fromId);
-        return index < 0 ? null : (order[index + 1] ?? null);
-      },
-      candidate(id: number): CandidateFacts | null {
-        return byId.get(id) ?? null;
-      },
-    };
-    const entries = buildTraversalEntries(store);
-    expect(entries.hits).toEqual(buildTraversalHits(store));
-    expect(entries.candidateIds).toEqual(order);
-    expect(entries.hits).toHaveLength(entries.candidateIds.length);
-    for (const [i, id] of order.entries()) {
-      const facts = byId.get(id);
-      if (facts === undefined) throw new Error(`missing facts for id ${String(id)}`);
-      expect(entries.hits[i]).toEqual(hitFromCandidate(facts));
-    }
-  });
-
-  it("skips null candidates in both parallel arrays together", () => {
-    const store = {
-      traverse(fromId: number | null, direction: "first" | "next"): number | null {
-        if (direction === "first") return 0;
-        if (fromId === 0) return 1;
-        if (fromId === 1) return 2;
-        return null;
-      },
-      candidate(id: number): CandidateFacts | null {
-        return id === 1 ? null : asCandidate(id);
-      },
-    };
-    const entries = buildTraversalEntries(store);
-    expect(entries.candidateIds).toEqual([0, 2]);
-    expect(entries.hits).toHaveLength(2);
-  });
-});
-
-describe("cycleCoincidentIndex", () => {
-  const origin = { x: 10, y: 20 };
-  const hits = [
-    hit(10, 20), // 0 coincident
-    hit(50, 50), // 1 not
-    hit(10.4, 20.4), // 2 coincident (< 0.5)
-    hit(10.6, 20), // 3 not (>= 0.5 on x)
-    hit(10, 20), // 4 coincident
-  ];
-
-  it("returns -1 when fewer than two coincident hits", () => {
-    expect(cycleCoincidentIndex(origin, [hit(10, 20)], 0, 1)).toBe(-1);
-    expect(cycleCoincidentIndex(origin, [hit(0, 0), hit(1, 1)], 0, 1)).toBe(-1);
-  });
-
-  it("cycles forward and wraps", () => {
-    expect(cycleCoincidentIndex(origin, hits, 0, 1)).toBe(2);
-    expect(cycleCoincidentIndex(origin, hits, 2, 1)).toBe(4);
-    expect(cycleCoincidentIndex(origin, hits, 4, 1)).toBe(0);
-  });
-
-  it("cycles backward and wraps", () => {
-    expect(cycleCoincidentIndex(origin, hits, 0, -1)).toBe(4);
-  });
-
-  it("starts at first coincident when active index is not in the set", () => {
-    // activeIndex 1 is not coincident → Math.max(0, -1) = 0 → next from first
-    expect(cycleCoincidentIndex(origin, hits, 1, 1)).toBe(2);
-  });
-});
-
-describe("planDirectionalNavigate", () => {
-  it("returns none when there are no hits", () => {
-    expect(
-      planDirectionalNavigate({
-        hitCount: 0,
-        hasInspection: true,
-        currentIndex: 0,
-        bestIndex: () => 2,
-      }),
-    ).toEqual({ type: "none" });
-  });
-
-  it("advances by +1 from currentIndex when uninspected (not hard-coded first)", () => {
-    expect(
-      planDirectionalNavigate({
-        hitCount: 3,
-        hasInspection: false,
-        currentIndex: 1,
-        bestIndex: () => {
-          throw new Error("thunk must not run when uninspected");
-        },
-      }),
-    ).toEqual({ type: "set-index", index: 2 });
-  });
-
-  it("uses the bestIndex thunk when inspected", () => {
-    let called = false;
-    expect(
-      planDirectionalNavigate({
-        hitCount: 4,
-        hasInspection: true,
-        currentIndex: 0,
-        bestIndex: () => {
-          called = true;
-          return 3;
-        },
-      }),
-    ).toEqual({ type: "set-index", index: 3 });
-    expect(called).toBe(true);
-  });
-
-  it("returns none when the thunk reports no forward candidate", () => {
-    expect(
-      planDirectionalNavigate({
-        hitCount: 4,
-        hasInspection: true,
-        currentIndex: 0,
-        bestIndex: () => -1,
-      }),
-    ).toEqual({ type: "none" });
-  });
-});
-
-describe("planCycleCoincident", () => {
-  it("advances by +1 when uninspected, including empty → none", () => {
-    expect(
-      planCycleCoincident({
-        hasInspection: false,
-        hitCount: 0,
-        currentIndex: 0,
-        nextIndex: () => {
-          throw new Error("thunk must not run when uninspected");
-        },
-      }),
-    ).toEqual({ type: "none" });
-    expect(
-      planCycleCoincident({
-        hasInspection: false,
-        hitCount: 3,
-        currentIndex: 2,
-        nextIndex: () => {
-          throw new Error("thunk must not run when uninspected");
-        },
-      }),
-    ).toEqual({ type: "set-index", index: 0 });
-  });
-
-  it("uses the nextIndex thunk when inspected", () => {
-    expect(
-      planCycleCoincident({
-        hasInspection: true,
-        hitCount: 5,
-        currentIndex: 0,
-        nextIndex: () => 4,
-      }),
-    ).toEqual({ type: "set-index", index: 4 });
-  });
-
-  it("returns none when the thunk reports fewer than two coincident", () => {
-    expect(
-      planCycleCoincident({
-        hasInspection: true,
-        hitCount: 5,
-        currentIndex: 0,
-        nextIndex: () => -1,
-      }),
-    ).toEqual({ type: "none" });
   });
 });

--- a/packages/svelte/tests/surface/surface-state.test.ts
+++ b/packages/svelte/tests/surface/surface-state.test.ts
@@ -296,7 +296,6 @@ function mountSurfaceComposite(
       model: () => model,
       reducer: () => surface.reducer,
       inspectConfig: () => config.inspect,
-      surfaceInteractive: () => options.surfaceInteractive ?? true,
       inspectEnabled: () => config.inspect !== null,
       dataIdentityEpoch: () => "epoch-1",
       keyAt,


### PR DESCRIPTION
## Summary

- delegate sequential, directional, and coincident keyboard navigation to the model-owned `CandidateStore`
- add O(1) modular traversal steps and paint-ordered directional tie-breaking to the store interface
- remove the Svelte-side traversal projection and duplicate navigation helpers
- keep reconciled pinned inspection aligned with the current candidate id
- add a Changeset for `@ggsvelte/core` and `@ggsvelte/svelte`

## Test coverage

- CandidateStore modular steps, compatibility, directional ties, cycle behavior, and complexity guards
- inspection delegation without materializing candidate facts
- browser-level four-direction navigation and coincident cycling across Chromium, Firefox, and WebKit

## Verification

- `bun run test` — 1,016 passed
- `cd packages/svelte && bun run --bun test` — 2,852 passed (2,841 browser + 11 SSR)
- `bun run lint && bun run lint:type-aware`
- `bun run fmt:check`
- `bun run knip`
- `bun run check && bun run check:svelte`
- `bun run build`
- pre-push hooks: package builds, docs check, type-aware lint, Svelte check, examples check, knip, and core tests passed

## Review

Pre-landing review found no remaining correctness, security, maintainability, or performance issues. The refactor deletes 652 lines while preserving the public CandidateStore null-start behavior and browser navigation evidence.
