### PR TITLE
refactor(svelte): own semantic Candidate projection

### DIFF
--- a/.changeset/own-semantic-candidate-projection.md
+++ b/.changeset/own-semantic-candidate-projection.md
@@ -1,0 +1,7 @@
+---
+"@ggsvelte/svelte": patch
+---
+
+# Own semantic Candidate projection once
+
+Move semantic Candidate traversal, liveness gating, anchor projection, interaction masks, and interval-consumption shaping behind one runtime module seam.

--- a/packages/svelte/src/lib/interval/interval-state.svelte.ts
+++ b/packages/svelte/src/lib/interval/interval-state.svelte.ts
@@ -72,15 +72,13 @@ export type IntervalStateDeps = {
   commitZoom: (domains: ContinuousZoomDomains | null, source: InteractionSource) => void;
   coordFlipped: () => boolean;
   captureSurface: () => HTMLDivElement | null;
-  /** Semantic candidate projection, initialized before factory construction. */
+  /** Used by the precise-bounds lineage projection. */
   candidateSemanticKeys: (candidate: CandidateFacts) => PropertyKey[];
   /**
-   * Deferred host bag for non-union interval key consumption. When the host
-   * already walked the store for anchors/masks (shared projection), return that
-   * bag here so `effectiveIntervalKeys` does not re-walk O(C). `null`/omitted
-   * falls back to the local full-store projection (tests / non-orchestrator).
+   * Deferred semantic Candidate view for non-union interval consumption.
+   * Projection ownership stays outside interval behavior.
    */
-  sharedConsumptionCandidates?: () => readonly IntervalConsumptionCandidate<PropertyKey>[] | null;
+  consumptionCandidates: () => readonly IntervalConsumptionCandidate<PropertyKey>[];
   /**
    * Handler-only: `openBoundsEditor` select branch reads the host's inspection
    * panel as its fallback target. Host derived is earlier than the factory and
@@ -168,23 +166,6 @@ export function createIntervalState(deps: IntervalStateDeps): IntervalState {
     );
   });
 
-  function intervalConsumptionCandidates(): IntervalConsumptionCandidate<PropertyKey>[] {
-    const model = deps.model();
-    if (model === null) return [];
-    const candidates: IntervalConsumptionCandidate<PropertyKey>[] = [];
-    for (let id = 0; id < model.candidates.size; id++) {
-      const candidate = model.candidates.candidate(id);
-      if (candidate === null) continue;
-      candidates.push({
-        panelId: candidate.panelId,
-        xValue: candidate.xValue,
-        yValue: candidate.yValue,
-        keys: deps.candidateSemanticKeys(candidate),
-      });
-    }
-    return candidates;
-  }
-
   const effectiveIntervalKeys: readonly PropertyKey[] = $derived.by(() => {
     const model = deps.model();
     if (model === null || effectiveIntervals.length === 0) return [];
@@ -198,13 +179,10 @@ export function createIntervalState(deps: IntervalStateDeps): IntervalState {
         panels: model.scene.panels,
         candidates: [],
       });
-    // Prefer host shared bag (one store walk with anchors/masks) over a second
-    // local full-store projection when non-union intervals are live.
-    const shared = deps.sharedConsumptionCandidates?.() ?? null;
     return consumeIntervalKeys({
       records: effectiveIntervals,
       panels: model.scene.panels,
-      candidates: shared ?? intervalConsumptionCandidates(),
+      candidates: deps.consumptionCandidates(),
     });
   });
 

--- a/packages/svelte/src/lib/plot-interaction-assembly.svelte.ts
+++ b/packages/svelte/src/lib/plot-interaction-assembly.svelte.ts
@@ -23,6 +23,7 @@ import {
   type SemanticKeyService,
 } from "./runtime/semantic-keys.svelte.js";
 import { createPlotRuntime } from "./runtime/runtime.svelte.js";
+import { createSemanticCandidateProjection } from "./runtime/semantic-candidate-projection.svelte.js";
 import type { LegendEntryIdentity } from "./legend/focus.js";
 import { createLegendFilterState } from "./legend/filter-state.svelte.js";
 import { createLegendEntryKeyIndex } from "./legend/entry-key-index.svelte.js";
@@ -313,28 +314,11 @@ export function createPlotInteractionAssembly<
   let tooltipHovered = $state(false);
   // ------------------------------------------------- selection
   // Construction-time effectiveSelectedKeys reads earlier interaction/scope
-  // only. Anchors and masks are methods (later-declared inputs).
+  // only. The later runtime projection module owns anchors and masks.
   const selectionState = createSelectionState({
-    model: () => runtime.model,
     interaction: inputs.interaction,
     resolvedInteractionScope: () => resolvedInteractionScope,
     selectConfig: () => interactionConfig.select,
-    // Deferred: interval is declared after this factory (method only).
-    effectiveIntervalKeys: () => intervalState.effectiveIntervalKeys,
-    // Deferred: legend-focus is declared after this factory (method only).
-    effectiveEmphasisKeys: () => legendFocusState.effectiveEmphasisKeys,
-    // Deferred method-only projection of inspection focus for presentation masks.
-    inspectionFocus: () => {
-      const current = inspectionState.inspection;
-      return current === null
-        ? null
-        : {
-            sourceKeys: current.focus.sourceKeys,
-            key: current.focus.key,
-          };
-    },
-    // Deferred: semantic-key service initializes later (#165).
-    candidateSemanticKeys: (candidate) => candidateSemanticKeys(candidate),
     onselect: inputs.onselect,
     oninteraction: inputs.oninteraction,
     announce: announceSink,
@@ -377,14 +361,30 @@ export function createPlotInteractionAssembly<
     coordFlipped: () => coordFlipped,
     captureSurface: inputs.captureSurface,
     candidateSemanticKeys: (candidate) => candidateSemanticKeys(candidate),
-    // Deferred: fused projection is declared after this factory (method only).
-    // When non-null, non-union interval keys reuse the host's single store walk.
-    sharedConsumptionCandidates: () => fusedConsumptionCandidates,
+    // Deferred: the projection module is constructed immediately after interval.
+    consumptionCandidates: () => semanticCandidateProjection.intervalConsumptionCandidates,
     inspectionPanel: () => inspectionState.inspectionPanel,
     emitSelection: (...args: Parameters<SelectionState["emitSelection"]>) => {
       selectionState.emitSelection(...args);
     },
     announce: announceSink,
+  });
+  const semanticCandidateProjection = createSemanticCandidateProjection({
+    model: () => runtime.model,
+    candidateSemanticKeys: (candidate) => candidateSemanticKeys(candidate),
+    selectedKeys: () => selectionState.effectiveSelectedKeys,
+    intervalKeys: () => intervalState.effectiveIntervalKeys,
+    intervals: () => intervalState.effectiveIntervals,
+    emphasisKeys: () => legendFocusState.effectiveEmphasisKeys,
+    inspectionFocus: () => {
+      const current = inspectionState.inspection;
+      return current === null
+        ? null
+        : {
+            sourceKeys: current.focus.sourceKeys,
+            key: current.focus.key,
+          };
+    },
   });
   // ------------------------------------------------- plot chrome
   // All inputs earlier-declared. Pure construction-time deriveds —
@@ -420,57 +420,6 @@ export function createPlotInteractionAssembly<
   // Surface window-teardown + tool-sync (after diagnostics, before catalog/
   // focus/inspection registrations).
   surfaceState.registerSurfaceEffects();
-
-  // Focus keys first (no candidate walk) so shared projection can short-circuit
-  // when idle. One full-store projection feeds selected/emphasized anchors,
-  // interaction masks, AND non-union interval key consumption — was O(2C) when
-  // a non-union interval was live (interval consumption walk + anchors walk).
-  // Liveness uses *counts* (Object.is-stable when keys swap but stay non-empty)
-  // so focus-only key changes rebuild masks/anchors without re-walking C (Codex P2).
-  const presentationFocusKeys = $derived(selectionState.computePresentationFocusKeys());
-  const selectedKeyCount = $derived(selectionState.effectiveSelectedKeys.length);
-  const emphasisKeyCount = $derived(legendFocusState.effectiveEmphasisKeys.length);
-  const presentationFocusKeyCount = $derived(presentationFocusKeys.length);
-  // Gate without reading effectiveIntervalKeys (those depend on the fused bag
-  // for non-union presets — reading keys here would circular-depend).
-  const needIntervalConsumptionWalk = $derived(
-    intervalState.effectiveIntervals.length > 0 &&
-      intervalState.effectiveIntervals[0]?.preset !== "union",
-  );
-  // Union interval keys come from stored records only (no walk). Safe to read
-  // for the selection/anchor gate after the non-union path is handled above.
-  const intervalKeyCount = $derived(intervalState.effectiveIntervalKeys.length);
-  const sharedCandidateProjection = $derived.by(() => {
-    if (needIntervalConsumptionWalk) return selectionState.computeSharedCandidateProjection();
-    if (selectedKeyCount + intervalKeyCount + emphasisKeyCount + presentationFocusKeyCount === 0)
-      return [];
-    return selectionState.computeSharedCandidateProjection();
-  });
-  // Map once for interval consumption; null when the bag was not built for
-  // interval (union / idle). Interval falls back to its local walk only when
-  // this is null AND non-union — which should not happen under the host gate.
-  const fusedConsumptionCandidates = $derived.by(() => {
-    if (!needIntervalConsumptionWalk) return null;
-    return sharedCandidateProjection.map((entry) => ({
-      panelId: entry.panelId,
-      keys: entry.keys,
-      ...(entry.xValue !== undefined && { xValue: entry.xValue }),
-      ...(entry.yValue !== undefined && { yValue: entry.yValue }),
-    }));
-  });
-  const selectedAnchors = $derived(
-    selectionState.computeSelectedAnchors(sharedCandidateProjection),
-  );
-  const emphasizedAnchors = $derived(
-    selectionState.computeEmphasizedAnchors(sharedCandidateProjection),
-  );
-  const interactionMasks = $derived(
-    selectionState.computeInteractionMasks(
-      presentationFocusKeys,
-      // Thunk: with empty focus (idle), shared projection is never forced for masks.
-      () => sharedCandidateProjection,
-    ),
-  );
 
   // Host-side deriveds kept outside the factory (construction-time free of
   // the model read).
@@ -531,13 +480,13 @@ export function createPlotInteractionAssembly<
       return legendFocusEnabled;
     },
     get selectedAnchors() {
-      return selectedAnchors;
+      return semanticCandidateProjection.selectedAnchors;
     },
     get emphasizedAnchors() {
-      return emphasizedAnchors;
+      return semanticCandidateProjection.emphasizedAnchors;
     },
     get interactionMasks() {
-      return interactionMasks;
+      return semanticCandidateProjection.interactionMasks;
     },
     get interactiveLegendEntries() {
       return interactiveLegendEntries;

--- a/packages/svelte/src/lib/runtime/semantic-candidate-projection.svelte.ts
+++ b/packages/svelte/src/lib/runtime/semantic-candidate-projection.svelte.ts
@@ -1,0 +1,118 @@
+import {
+  buildInteractionMasks,
+  type BatchInteractionMask,
+  type CandidateFacts,
+  type RenderModel,
+} from "@ggsvelte/core";
+
+import type { PlotInteractionInterval } from "../interaction/interaction.js";
+import type { IntervalConsumptionCandidate } from "../interval/consumption.js";
+import {
+  anchorsFromCandidateKeys,
+  collectCandidates,
+  mergePresentationFocusKeys,
+  type PresentationInspectionFocus,
+} from "../selection/selection.js";
+
+type SemanticCandidate = IntervalConsumptionCandidate<PropertyKey> & {
+  readonly x: number;
+  readonly y: number;
+  readonly batchIndex: number;
+  readonly primitiveIndex: number;
+};
+
+export type SemanticCandidateProjectionDeps = {
+  model: () => RenderModel | null;
+  candidateSemanticKeys: (candidate: CandidateFacts) => readonly PropertyKey[];
+  selectedKeys: () => readonly PropertyKey[];
+  intervalKeys: () => readonly PropertyKey[];
+  intervals: () => readonly PlotInteractionInterval<PropertyKey>[];
+  emphasisKeys: () => readonly PropertyKey[];
+  inspectionFocus: () => PresentationInspectionFocus | null;
+};
+
+export type SemanticCandidateProjection = {
+  readonly selectedAnchors: { x: number; y: number }[];
+  readonly emphasizedAnchors: { x: number; y: number }[];
+  readonly interactionMasks: readonly (BatchInteractionMask | null)[];
+  readonly intervalConsumptionCandidates: readonly IntervalConsumptionCandidate<PropertyKey>[];
+};
+
+/**
+ * Own the one semantic walk over CandidateStore and all presentation shapes
+ * derived from it. Counts gate the walk so key-only changes reuse projection.
+ */
+export function createSemanticCandidateProjection(
+  deps: SemanticCandidateProjectionDeps,
+): SemanticCandidateProjection {
+  const presentationFocusKeys = $derived(
+    mergePresentationFocusKeys(deps.emphasisKeys(), deps.inspectionFocus()),
+  );
+  const selectedKeyCount = $derived(deps.selectedKeys().length);
+  const emphasisKeyCount = $derived(deps.emphasisKeys().length);
+  const presentationFocusKeyCount = $derived(presentationFocusKeys.length);
+  const needIntervalConsumptionWalk = $derived(
+    deps.intervals().length > 0 && deps.intervals()[0]?.preset !== "union",
+  );
+  // Non-union interval keys consume this projection, so do not read them until
+  // the non-union gate has been handled.
+  const intervalKeyCount = $derived(deps.intervalKeys().length);
+
+  const sharedCandidateProjection = $derived.by((): SemanticCandidate[] => {
+    if (
+      !needIntervalConsumptionWalk &&
+      selectedKeyCount + intervalKeyCount + emphasisKeyCount + presentationFocusKeyCount === 0
+    ) {
+      return [];
+    }
+    const model = deps.model();
+    if (model === null) return [];
+    return collectCandidates(model.candidates, (candidate) => ({
+      x: candidate.x,
+      y: candidate.y,
+      batchIndex: candidate.batchIndex,
+      primitiveIndex: candidate.primitiveIndex,
+      panelId: candidate.panelId,
+      keys: deps.candidateSemanticKeys(candidate),
+      ...(candidate.xValue !== undefined && { xValue: candidate.xValue }),
+      ...(candidate.yValue !== undefined && { yValue: candidate.yValue }),
+    }));
+  });
+
+  const intervalConsumptionCandidates = $derived.by(
+    (): readonly IntervalConsumptionCandidate<PropertyKey>[] =>
+      needIntervalConsumptionWalk ? sharedCandidateProjection : [],
+  );
+  const selectedAnchors = $derived(
+    anchorsFromCandidateKeys(sharedCandidateProjection, [
+      ...new Set([...deps.selectedKeys(), ...deps.intervalKeys()]),
+    ]),
+  );
+  const emphasizedAnchors = $derived(
+    anchorsFromCandidateKeys(sharedCandidateProjection, deps.emphasisKeys()),
+  );
+  const interactionMasks = $derived.by((): readonly (BatchInteractionMask | null)[] => {
+    const model = deps.model();
+    if (model === null || presentationFocusKeys.length === 0) return [];
+    return buildInteractionMasks(
+      model.scene.batches,
+      presentationFocusKeys,
+      sharedCandidateProjection,
+    );
+  });
+
+  return {
+    get selectedAnchors() {
+      return selectedAnchors;
+    },
+    get emphasizedAnchors() {
+      return emphasizedAnchors;
+    },
+    get interactionMasks() {
+      return interactionMasks;
+    },
+    get intervalConsumptionCandidates() {
+      return intervalConsumptionCandidates;
+    },
+  };
+}

--- a/packages/svelte/src/lib/selection/selection-state.svelte.ts
+++ b/packages/svelte/src/lib/selection/selection-state.svelte.ts
@@ -2,20 +2,13 @@
  * Point-selection controller extracted from GGPlot for S8.
  *
  * Owns local selection state, the construction-time `effectiveSelectedKeys`
- * derived (inputs are all earlier-declared), commit/clear/toggle/emit
- * handlers, and the later-input anchor / presentation-mask methods.
- *
- * Construction topology (host): factory sits at the original localSelectedKeys
- * position (after surface, before legend-focus / interval). Construction-time
- * derived reads only earlier bindings (interaction, scope). Anchors and masks
- * are methods because they close over later-declared effectiveIntervalKeys,
- * effectiveEmphasisKeys, candidateSemanticKeys, and inspection focus.
+ * derived, and commit/clear/toggle/emit handlers. Semantic Candidate
+ * projection and presentation shaping belong to the runtime projection module.
  *
  * `commitPointSelection` is PRIVATE (no external caller — toggle/clear only).
  * Public API speaks PropertyKey; PublicKey casts stay at the host boundary.
  */
-import type { BatchInteractionMask, CandidateFacts, CellValue, RenderModel } from "@ggsvelte/core";
-import { buildInteractionMasks } from "@ggsvelte/core";
+import type { CellValue } from "@ggsvelte/core";
 
 import type { PlotInteractionController } from "../interaction/controller.svelte.js";
 import type {
@@ -27,13 +20,9 @@ import type {
 } from "../interaction/interaction.js";
 import { selectionAnnouncement } from "../assembly/labels.js";
 import {
-  anchorsFromCandidateKeys,
   buildPointSelectionEvent,
-  collectCandidates,
-  mergePresentationFocusKeys,
   nextPointSelectionKeys,
   sameOrderedPropertyKeys,
-  type PresentationInspectionFocus,
 } from "./selection.js";
 
 // ---------------------------------------------------------------------------
@@ -41,31 +30,10 @@ import {
 // ---------------------------------------------------------------------------
 
 export type SelectionStateDeps = {
-  model: () => RenderModel | null;
   interaction: () => PlotInteractionController<PropertyKey> | undefined;
   resolvedInteractionScope: () => PlotInteractionScope;
   /** Narrow getter over `interactionConfig.select`. */
   selectConfig: () => ResolvedInteractionConfig["select"];
-  /**
-   * Deferred: host interval alias is declared after this factory. Method-only
-   * (computeSelectedAnchors).
-   */
-  effectiveIntervalKeys: () => readonly PropertyKey[];
-  /**
-   * Deferred: host legend-focus alias is declared after this factory.
-   * Method-only (computeEmphasizedAnchors / presentation focus).
-   */
-  effectiveEmphasisKeys: () => readonly PropertyKey[];
-  /**
-   * Deferred method-only projection of inspection focus for presentation
-   * masks. Host may supply a Pick of the inspection derived.
-   */
-  inspectionFocus: () => PresentationInspectionFocus | null;
-  /**
-   * Deferred: host alias initializes after the semantic-key service (#165).
-   * Method-only (anchors / candidate projections).
-   */
-  candidateSemanticKeys: (candidate: CandidateFacts) => PropertyKey[];
   /** Deferred callback getters (handler-only; never construction). */
   onselect: () => ((event: PlotSelection) => void) | undefined;
   oninteraction: () =>
@@ -75,53 +43,11 @@ export type SelectionStateDeps = {
   announce: (message: string) => void;
 };
 
-/**
- * One candidate projection for anchors, interaction masks, and interval
- * consumption. Built once per reactive need so those consumers do not each
- * re-walk the store (was O(2–3C) when several are live; non-union intervals
- * previously added a second full walk for panelId/xValue/yValue/keys).
- */
-type SharedCandidateProjection = {
-  readonly x: number;
-  readonly y: number;
-  readonly batchIndex: number;
-  readonly primitiveIndex: number;
-  readonly keys: readonly PropertyKey[];
-  /** Panel identity for interval consumption (independent / cross-panel). */
-  readonly panelId: string;
-  readonly xValue?: CellValue;
-  readonly yValue?: CellValue;
-};
-
 export type SelectionState = {
   readonly effectiveSelectedKeys: readonly PropertyKey[];
   clearPointSelection(source: InteractionSource): void;
   togglePointKeys(keys: readonly PropertyKey[], source: InteractionSource): void;
   emitSelection(event: PlotSelection): void;
-  /**
-   * Full-store projection (x/y + mask fields + keys). Host should `$derived`
-   * this once when any anchor or mask consumer is live, then pass the array
-   * into the shared-projection overloads below.
-   */
-  computeSharedCandidateProjection(): SharedCandidateProjection[];
-  computeSelectedAnchors(
-    sharedProjection?: readonly SharedCandidateProjection[],
-  ): { x: number; y: number }[];
-  computeEmphasizedAnchors(
-    sharedProjection?: readonly SharedCandidateProjection[],
-  ): { x: number; y: number }[];
-  computePresentationFocusKeys(): readonly PropertyKey[];
-  /** Alias of computeSharedCandidateProjection (tests / masks). */
-  computeSemanticCandidateProjections(): SharedCandidateProjection[];
-  /**
-   * Takes BOTH upstream values as parameters so the host's three separate
-   * derived aliases preserve independent memo boundaries (focus-only changes
-   * must not re-walk candidates).
-   */
-  computeInteractionMasks(
-    presentationFocusKeys: readonly PropertyKey[],
-    getSemanticCandidateProjections: () => readonly SharedCandidateProjection[],
-  ): readonly (BatchInteractionMask | null)[];
 };
 
 // ---------------------------------------------------------------------------
@@ -130,8 +56,7 @@ export type SelectionState = {
 
 /**
  * Create the point-selection controller. Construction registers only the
- * `effectiveSelectedKeys` derived (over earlier host bindings). Anchors and
- * masks are methods that may read later-declared deps via deferred getters.
+ * `effectiveSelectedKeys` derived over interaction and scope.
  */
 export function createSelectionState(deps: SelectionStateDeps): SelectionState {
   let localSelectedKeys = $state<PropertyKey[]>([]);
@@ -142,32 +67,6 @@ export function createSelectionState(deps: SelectionStateDeps): SelectionState {
     void (deps.interaction()?.revision ?? 0);
     return deps.interaction()?.selected(deps.resolvedInteractionScope()) ?? localSelectedKeys;
   });
-
-  function projectCandidates(): SharedCandidateProjection[] {
-    const model = deps.model();
-    if (model === null) return [];
-    return collectCandidates(model.candidates, (candidate) => ({
-      x: candidate.x,
-      y: candidate.y,
-      batchIndex: candidate.batchIndex,
-      primitiveIndex: candidate.primitiveIndex,
-      keys: deps.candidateSemanticKeys(candidate),
-      panelId: candidate.panelId,
-      ...(candidate.xValue !== undefined && { xValue: candidate.xValue }),
-      ...(candidate.yValue !== undefined && { yValue: candidate.yValue }),
-    }));
-  }
-
-  function anchorsForKeys(
-    keys: readonly PropertyKey[],
-    sharedProjection?: readonly SharedCandidateProjection[],
-  ): { x: number; y: number }[] {
-    // Empty filter short-circuits before walking (keysFor can be expensive).
-    if (keys.length === 0) return [];
-    if (deps.model() === null) return [];
-    const candidates = sharedProjection ?? projectCandidates();
-    return anchorsFromCandidateKeys(candidates, keys);
-  }
 
   /** Private — only clear/toggle call this; no external caller (P2-7). */
   function commitPointSelection(keys: readonly PropertyKey[], source: InteractionSource): void {
@@ -214,50 +113,6 @@ export function createSelectionState(deps: SelectionStateDeps): SelectionState {
     commitPointSelection(next, source);
   }
 
-  function computeSharedCandidateProjection(): SharedCandidateProjection[] {
-    return projectCandidates();
-  }
-
-  function computeSelectedAnchors(
-    sharedProjection?: readonly SharedCandidateProjection[],
-  ): { x: number; y: number }[] {
-    return anchorsForKeys(
-      [...new Set([...effectiveSelectedKeys, ...deps.effectiveIntervalKeys()])],
-      sharedProjection,
-    );
-  }
-
-  function computeEmphasizedAnchors(
-    sharedProjection?: readonly SharedCandidateProjection[],
-  ): { x: number; y: number }[] {
-    return anchorsForKeys(deps.effectiveEmphasisKeys(), sharedProjection);
-  }
-
-  function computePresentationFocusKeys(): readonly PropertyKey[] {
-    return mergePresentationFocusKeys(deps.effectiveEmphasisKeys(), deps.inspectionFocus());
-  }
-
-  function computeSemanticCandidateProjections(): SharedCandidateProjection[] {
-    return projectCandidates();
-  }
-
-  function computeInteractionMasks(
-    presentationFocusKeys: readonly PropertyKey[],
-    // THUNK, not a value: the empty-focus guard below must short-circuit
-    // BEFORE the projections derived is read, exactly as the base host did —
-    // an eager parameter would run the O(candidates) semantic-key walk on
-    // every model update (and every SSR render) in the idle no-focus state.
-    getSemanticCandidateProjections: () => readonly SharedCandidateProjection[],
-  ): readonly (BatchInteractionMask | null)[] {
-    const model = deps.model();
-    if (model === null || presentationFocusKeys.length === 0) return [];
-    return buildInteractionMasks(
-      model.scene.batches,
-      presentationFocusKeys,
-      getSemanticCandidateProjections(),
-    );
-  }
-
   return {
     get effectiveSelectedKeys() {
       return effectiveSelectedKeys;
@@ -265,11 +120,5 @@ export function createSelectionState(deps: SelectionStateDeps): SelectionState {
     clearPointSelection,
     togglePointKeys,
     emitSelection,
-    computeSharedCandidateProjection,
-    computeSelectedAnchors,
-    computeEmphasizedAnchors,
-    computePresentationFocusKeys,
-    computeSemanticCandidateProjections,
-    computeInteractionMasks,
   };
 }

--- a/packages/svelte/tests/helpers/reactive-box.svelte.ts
+++ b/packages/svelte/tests/helpers/reactive-box.svelte.ts
@@ -19,17 +19,3 @@ export function reactiveBox<T>(initial: T): ReactiveBox<T> {
     },
   };
 }
-
-/**
- * Rune-backed memo for `.test.ts` files (runes are unavailable there).
- * Mirrors a host `$derived` boundary: `fn` re-runs only when its reactive
- * inputs change, regardless of how often `.value` is read.
- */
-export function derivedBox<T>(fn: () => T): { readonly value: T } {
-  const value = $derived.by(fn);
-  return {
-    get value() {
-      return value;
-    },
-  };
-}

--- a/packages/svelte/tests/interval/interval-state.test.ts
+++ b/packages/svelte/tests/interval/interval-state.test.ts
@@ -157,7 +157,7 @@ function mountIntervalController(
     coordFlipped?: () => boolean;
     captureSurface?: () => HTMLDivElement | null;
     candidateSemanticKeys?: (candidate: CandidateFacts) => PropertyKey[];
-    sharedConsumptionCandidates?: IntervalStateDeps["sharedConsumptionCandidates"];
+    consumptionCandidates?: IntervalStateDeps["consumptionCandidates"];
     inspectionPanel?: () => ScenePanel | null;
     emitSelection?: (event: PlotSelection) => void;
     announce?: (message: string) => void;
@@ -176,9 +176,23 @@ function mountIntervalController(
       coordFlipped: options.coordFlipped ?? (() => false),
       captureSurface: options.captureSurface ?? (() => null),
       candidateSemanticKeys: options.candidateSemanticKeys ?? identityCandidateKeys,
-      ...(options.sharedConsumptionCandidates !== undefined && {
-        sharedConsumptionCandidates: options.sharedConsumptionCandidates,
-      }),
+      consumptionCandidates:
+        options.consumptionCandidates ??
+        (() => {
+          const currentModel = options.model?.() ?? defaultModel;
+          const candidates = [];
+          for (let id = 0; id < currentModel.candidates.size; id++) {
+            const candidate = currentModel.candidates.candidate(id);
+            if (candidate === null) continue;
+            candidates.push({
+              panelId: candidate.panelId,
+              xValue: candidate.xValue,
+              yValue: candidate.yValue,
+              keys: identityCandidateKeys(candidate),
+            });
+          }
+          return candidates;
+        }),
       inspectionPanel: options.inspectionPanel ?? (() => null),
       emitSelection: options.emitSelection ?? (() => {}),
       announce: options.announce ?? (() => {}),
@@ -219,6 +233,9 @@ describe("createIntervalState construction", () => {
           candidateSemanticKeysCalls++;
           return identityCandidateKeys(candidate);
         },
+        consumptionCandidates: () => {
+          throw new Error("consumptionCandidates must remain lazy for empty intervals");
+        },
         inspectionPanel: () => {
           inspectionPanelCalls++;
           return null;
@@ -258,8 +275,8 @@ describe("createIntervalState construction", () => {
   });
 });
 
-describe("createIntervalState shared consumption bag", () => {
-  it("uses sharedConsumptionCandidates and skips candidateSemanticKeys walk for non-union keys", () => {
+describe("createIntervalState semantic Candidate consumption", () => {
+  it("consumes the supplied projection without resolving Candidate keys", () => {
     const model = modelFor(continuousSpec());
     const panelId = model.scene.panels[0]?.id;
     if (panelId === undefined) throw new Error("expected panel");
@@ -285,7 +302,7 @@ describe("createIntervalState shared consumption bag", () => {
         keyCalls++;
         return identityCandidateKeys(candidate);
       },
-      sharedConsumptionCandidates: () => sharedBag,
+      consumptionCandidates: () => sharedBag,
     });
 
     state.applyBrushSelectEnd(brushEvent(model, { keys: ["0", "1"] }), "pointer");
@@ -293,30 +310,7 @@ describe("createIntervalState shared consumption bag", () => {
     keyCalls = 0;
     const keys = state.effectiveIntervalKeys;
     expect(keys.length).toBeGreaterThan(0);
-    // Shared bag supplied all candidates — no local full-store key walk.
     expect(keyCalls).toBe(0);
-
-    destroy();
-  });
-
-  it("falls back to local walk when shared bag is null", () => {
-    const model = modelFor(continuousSpec());
-    let keyCalls = 0;
-    const { state, destroy } = mountIntervalController({
-      model: () => model,
-      selectConfig: persistentSelect,
-      candidateSemanticKeys: (candidate) => {
-        keyCalls++;
-        return identityCandidateKeys(candidate);
-      },
-      sharedConsumptionCandidates: () => null,
-    });
-
-    state.applyBrushSelectEnd(brushEvent(model), "pointer");
-    flushSync();
-    keyCalls = 0;
-    expect(state.effectiveIntervalKeys.length).toBeGreaterThan(0);
-    expect(keyCalls).toBeGreaterThan(0);
 
     destroy();
   });

--- a/packages/svelte/tests/plot-orchestrator-contract.ssr.test.ts
+++ b/packages/svelte/tests/plot-orchestrator-contract.ssr.test.ts
@@ -39,6 +39,7 @@ describe("plot interaction assembly lifecycle contract", () => {
       "createSelectionState(",
       "createLegendFocusState(",
       "createIntervalState(",
+      "createSemanticCandidateProjection(",
       "createPlotChromeState(",
     ]) {
       expect(orchestratorSource).not.toContain(factory);
@@ -57,6 +58,7 @@ describe("plot interaction assembly lifecycle contract", () => {
       "const selectionState = createSelectionState(",
       "const legendFocusState = createLegendFocusState(",
       "const intervalState = createIntervalState(",
+      "const semanticCandidateProjection = createSemanticCandidateProjection(",
       "const chromeState = createPlotChromeState(",
     ]);
   });
@@ -64,6 +66,17 @@ describe("plot interaction assembly lifecycle contract", () => {
   it("uses the model-owned CandidateStore without constructing a second hit index", () => {
     expect(assemblySource).not.toContain("buildHitIndex");
     expect(assemblySource).not.toContain("SceneHitIndex");
+  });
+
+  it("keeps semantic Candidate projection knowledge behind one module seam", () => {
+    expect(assemblySource).toContain("createSemanticCandidateProjection(");
+    for (const implementationDetail of [
+      "needIntervalConsumptionWalk",
+      "sharedCandidateProjection",
+      "fusedConsumptionCandidates",
+    ]) {
+      expect(assemblySource).not.toContain(implementationDetail);
+    }
   });
 
   it("keeps phased effects in registration order", () => {

--- a/packages/svelte/tests/runtime/semantic-candidate-projection.test.ts
+++ b/packages/svelte/tests/runtime/semantic-candidate-projection.test.ts
@@ -1,0 +1,180 @@
+import { flushSync } from "svelte";
+import { describe, expect, it } from "vitest";
+
+import type { CandidateFacts } from "@ggsvelte/core";
+import { aes, gg } from "@ggsvelte/spec";
+
+import type { PlotInteractionInterval } from "../../src/lib/interaction/interaction.js";
+import { createSemanticCandidateProjection } from "../../src/lib/runtime/semantic-candidate-projection.svelte.js";
+import { withFlushedEffectRoot } from "../helpers/effect-root.svelte.js";
+import { modelFor } from "../helpers/model.js";
+import { reactiveBox } from "../helpers/reactive-box.svelte.js";
+
+const model = modelFor(
+  gg(
+    [
+      { id: "a", x: 1, y: 1 },
+      { id: "b", x: 10, y: 20 },
+      { id: "c", x: 5, y: 8 },
+    ],
+    aes({ x: "x", y: "y" }),
+  )
+    .geomPoint()
+    .spec(),
+);
+
+function keysFor(candidate: CandidateFacts): PropertyKey[] {
+  return candidate.rowIndex === null ? [] : [String(candidate.rowIndex)];
+}
+
+function candidateForRow(rowIndex: number): CandidateFacts {
+  for (let id = 0; id < model.candidates.size; id++) {
+    const candidate = model.candidates.candidate(id);
+    if (candidate?.rowIndex === rowIndex) return candidate;
+  }
+  throw new Error(`missing Candidate for row ${String(rowIndex)}`);
+}
+
+describe("createSemanticCandidateProjection", () => {
+  it("keeps the CandidateStore idle when no semantic presentation is active", () => {
+    let keyCalls = 0;
+    const { value, destroy } = withFlushedEffectRoot(() =>
+      createSemanticCandidateProjection({
+        model: () => model,
+        candidateSemanticKeys: (candidate) => {
+          keyCalls++;
+          return keysFor(candidate);
+        },
+        selectedKeys: () => [],
+        intervalKeys: () => [],
+        intervals: () => [],
+        emphasisKeys: () => [],
+        inspectionFocus: () => null,
+      }),
+    );
+
+    expect(value.selectedAnchors).toEqual([]);
+    expect(value.emphasizedAnchors).toEqual([]);
+    expect(value.interactionMasks).toEqual([]);
+    expect(value.intervalConsumptionCandidates).toEqual([]);
+    expect(keyCalls).toBe(0);
+    destroy();
+  });
+
+  it("serves anchors and masks from one semantic Candidate walk", () => {
+    let keyCalls = 0;
+    const first = candidateForRow(0);
+    const second = candidateForRow(1);
+    const { value, destroy } = withFlushedEffectRoot(() =>
+      createSemanticCandidateProjection({
+        model: () => model,
+        candidateSemanticKeys: (candidate) => {
+          keyCalls++;
+          return keysFor(candidate);
+        },
+        selectedKeys: () => ["0"],
+        intervalKeys: () => [],
+        intervals: () => [],
+        emphasisKeys: () => ["1"],
+        inspectionFocus: () => ({ sourceKeys: ["2"], key: null }),
+      }),
+    );
+
+    expect(value.selectedAnchors).toContainEqual({ x: first.x, y: first.y });
+    expect(value.emphasizedAnchors).toContainEqual({ x: second.x, y: second.y });
+    expect(value.interactionMasks.some((mask) => mask !== null)).toBe(true);
+    const callsAfterAllConsumers = keyCalls;
+    expect(callsAfterAllConsumers).toBeGreaterThan(0);
+    void value.selectedAnchors;
+    void value.emphasizedAnchors;
+    void value.interactionMasks;
+    expect(keyCalls).toBe(callsAfterAllConsumers);
+    destroy();
+  });
+
+  it("skips semantic Candidate consumption for union intervals", () => {
+    let keyCalls = 0;
+    const intervals: readonly PlotInteractionInterval<PropertyKey>[] = [
+      {
+        panelId: model.scene.panels[0].id,
+        preset: "union",
+        domains: {},
+        keys: ["0"],
+      },
+    ];
+    const { value, destroy } = withFlushedEffectRoot(() =>
+      createSemanticCandidateProjection({
+        model: () => model,
+        candidateSemanticKeys: (candidate) => {
+          keyCalls++;
+          return keysFor(candidate);
+        },
+        selectedKeys: () => [],
+        intervalKeys: () => [],
+        intervals: () => intervals,
+        emphasisKeys: () => [],
+        inspectionFocus: () => null,
+      }),
+    );
+
+    expect(value.intervalConsumptionCandidates).toEqual([]);
+    expect(keyCalls).toBe(0);
+    destroy();
+  });
+
+  it("supplies non-union interval consumption without a fallback walk", () => {
+    let keyCalls = 0;
+    const intervals: readonly PlotInteractionInterval<PropertyKey>[] = [
+      { panelId: model.scene.panels[0].id, preset: "independent", domains: {}, keys: [] },
+    ];
+    const { value, destroy } = withFlushedEffectRoot(() =>
+      createSemanticCandidateProjection({
+        model: () => model,
+        candidateSemanticKeys: (candidate) => {
+          keyCalls++;
+          return keysFor(candidate);
+        },
+        selectedKeys: () => [],
+        intervalKeys: () => [],
+        intervals: () => intervals,
+        emphasisKeys: () => [],
+        inspectionFocus: () => null,
+      }),
+    );
+
+    expect(value.intervalConsumptionCandidates.length).toBeGreaterThan(0);
+    expect(value.intervalConsumptionCandidates[0]).toMatchObject({
+      panelId: model.scene.panels[0].id,
+      keys: ["0"],
+    });
+    expect(keyCalls).toBe(value.intervalConsumptionCandidates.length);
+    destroy();
+  });
+
+  it("reuses its semantic view when focus keys change but liveness does not", () => {
+    const emphasis = reactiveBox<readonly PropertyKey[]>(["0"]);
+    let keyCalls = 0;
+    const { value, destroy } = withFlushedEffectRoot(() =>
+      createSemanticCandidateProjection({
+        model: () => model,
+        candidateSemanticKeys: (candidate) => {
+          keyCalls++;
+          return keysFor(candidate);
+        },
+        selectedKeys: () => [],
+        intervalKeys: () => [],
+        intervals: () => [],
+        emphasisKeys: () => emphasis.value,
+        inspectionFocus: () => null,
+      }),
+    );
+
+    void value.interactionMasks;
+    const initialCalls = keyCalls;
+    emphasis.set(["1"]);
+    flushSync();
+    void value.interactionMasks;
+    expect(keyCalls).toBe(initialCalls);
+    destroy();
+  });
+});

--- a/packages/svelte/tests/selection/selection-state.test.ts
+++ b/packages/svelte/tests/selection/selection-state.test.ts
@@ -5,8 +5,7 @@
 import { flushSync } from "svelte";
 import { describe, expect, it } from "vitest";
 
-import type { CellValue, CandidateFacts, RenderModel } from "@ggsvelte/core";
-import { aes, gg, type PortableSpec } from "@ggsvelte/spec";
+import type { CellValue } from "@ggsvelte/core";
 
 import type {
   PlotInteractionEvent,
@@ -16,19 +15,9 @@ import type {
 } from "../../src/lib/interaction/interaction.js";
 import { createPlotInteraction } from "../../src/lib/interaction/controller.svelte.js";
 import { buildPointSelectionEvent } from "../../src/lib/selection/selection.js";
-import {
-  createSelectionState,
-  type SelectionStateDeps,
-} from "../../src/lib/selection/selection-state.svelte.js";
+import { createSelectionState } from "../../src/lib/selection/selection-state.svelte.js";
 import { withEffectRoot, withFlushedEffectRoot } from "../helpers/effect-root.svelte.js";
-import { modelFor } from "../helpers/model.js";
-import { derivedBox, reactiveBox } from "../helpers/reactive-box.svelte.js";
-
-const continuousRows = [
-  { id: "a", x: 1, y: 1 },
-  { id: "b", x: 10, y: 20 },
-  { id: "c", x: 5, y: 8 },
-];
+import { reactiveBox } from "../helpers/reactive-box.svelte.js";
 
 type SelectConfig = ResolvedInteractionConfig["select"];
 type MaybeController = ReturnType<typeof createPlotInteraction> | undefined;
@@ -66,20 +55,6 @@ const pointSelectMultiple = (): SelectConfig =>
     preset: "independent" as const,
   });
 
-function continuousSpec(
-  data: readonly { id: string; x: number; y: number }[] = continuousRows,
-): PortableSpec {
-  return gg([...data], aes({ x: "x", y: "y" }))
-    .geomPoint()
-    .spec();
-}
-
-/** Identity semantic keys from rowIndex — stable for anchor/mask tests. */
-function identityCandidateKeys(candidate: CandidateFacts): PropertyKey[] {
-  if (candidate.rowIndex === null) return [];
-  return [String(candidate.rowIndex)];
-}
-
 type SelectionHarness = {
   state: ReturnType<typeof createSelectionState>;
   destroy: () => void;
@@ -87,30 +62,19 @@ type SelectionHarness = {
 
 function mountSelectionController(
   options: {
-    model?: () => RenderModel | null;
     interaction?: () => MaybeController;
     resolvedInteractionScope?: () => PlotInteractionScope;
     selectConfig?: () => SelectConfig;
-    effectiveIntervalKeys?: () => readonly PropertyKey[];
-    effectiveEmphasisKeys?: () => readonly PropertyKey[];
-    inspectionFocus?: SelectionStateDeps["inspectionFocus"];
-    candidateSemanticKeys?: SelectionStateDeps["candidateSemanticKeys"];
     onselect?: () => SelectCb;
     oninteraction?: () => InteractionCb;
     announce?: (message: string) => void;
   } = {},
 ): SelectionHarness {
-  const defaultModel = modelFor(continuousSpec());
   const { value: state, destroy } = withFlushedEffectRoot(() =>
     createSelectionState({
-      model: options.model ?? (() => defaultModel),
       interaction: options.interaction ?? noController,
       resolvedInteractionScope: options.resolvedInteractionScope ?? (() => defaultScope),
       selectConfig: options.selectConfig ?? pointSelectSingle,
-      effectiveIntervalKeys: options.effectiveIntervalKeys ?? (() => []),
-      effectiveEmphasisKeys: options.effectiveEmphasisKeys ?? (() => []),
-      inspectionFocus: options.inspectionFocus ?? (() => null),
-      candidateSemanticKeys: options.candidateSemanticKeys ?? identityCandidateKeys,
       onselect: options.onselect ?? noSelectCb,
       oninteraction: options.oninteraction ?? noInteractionCb,
       announce: options.announce ?? (() => {}),
@@ -120,38 +84,16 @@ function mountSelectionController(
 }
 
 describe("createSelectionState construction", () => {
-  it("does not invoke armed later-declared getters during construction (before first flush)", () => {
-    const model = modelFor(continuousSpec());
-    let intervalKeysCalls = 0;
-    let emphasisKeysCalls = 0;
-    let inspectionFocusCalls = 0;
-    let candidateSemanticKeysCalls = 0;
+  it("does not invoke callback getters during construction", () => {
     let onselectCalls = 0;
     let oninteractionCalls = 0;
     let announceCalls = 0;
 
     const { value: state, destroy } = withEffectRoot(() =>
       createSelectionState({
-        model: () => model,
         interaction: noController,
         resolvedInteractionScope: () => defaultScope,
         selectConfig: pointSelectSingle,
-        effectiveIntervalKeys: () => {
-          intervalKeysCalls++;
-          return [];
-        },
-        effectiveEmphasisKeys: () => {
-          emphasisKeysCalls++;
-          return [];
-        },
-        inspectionFocus: () => {
-          inspectionFocusCalls++;
-          return null;
-        },
-        candidateSemanticKeys: (candidate) => {
-          candidateSemanticKeysCalls++;
-          return identityCandidateKeys(candidate);
-        },
         onselect: (): SelectCb => {
           onselectCalls++;
           return noSelectCb();
@@ -166,21 +108,8 @@ describe("createSelectionState construction", () => {
       }),
     );
 
-    expect(intervalKeysCalls).toBe(0);
-    expect(emphasisKeysCalls).toBe(0);
-    expect(inspectionFocusCalls).toBe(0);
-    expect(candidateSemanticKeysCalls).toBe(0);
-    expect(onselectCalls).toBe(0);
-    expect(oninteractionCalls).toBe(0);
-    expect(announceCalls).toBe(0);
-    // Accessor + flush must not reach armed deps (construction-time derived
-    // only reads interaction/scope).
     expect(state.effectiveSelectedKeys).toEqual([]);
     flushSync();
-    expect(intervalKeysCalls).toBe(0);
-    expect(emphasisKeysCalls).toBe(0);
-    expect(inspectionFocusCalls).toBe(0);
-    expect(candidateSemanticKeysCalls).toBe(0);
     expect(onselectCalls).toBe(0);
     expect(oninteractionCalls).toBe(0);
     expect(announceCalls).toBe(0);
@@ -339,219 +268,6 @@ describe("createSelectionState controller mode", () => {
     state.togglePointKeys([], "pointer");
     flushSync();
     expect(events).toHaveLength(2);
-
-    destroy();
-  });
-});
-
-describe("createSelectionState anchors", () => {
-  it("computeSelectedAnchors unions selected + interval keys with literal coords", () => {
-    const model = modelFor(continuousSpec());
-    // Find anchors for row indexes "0" and "1"
-    const expected: { x: number; y: number }[] = [];
-    for (let id = 0; id < model.candidates.size; id++) {
-      const c = model.candidates.candidate(id);
-      if (c === null || c.rowIndex === null) continue;
-      if (c.rowIndex === 0 || c.rowIndex === 1) {
-        const identity = `${String(c.x)}:${String(c.y)}`;
-        if (!expected.some((a) => `${a.x}:${a.y}` === identity)) {
-          expected.push({ x: c.x, y: c.y });
-        }
-      }
-    }
-    expect(expected.length).toBeGreaterThan(0);
-
-    const { state, destroy } = mountSelectionController({
-      model: () => model,
-      selectConfig: pointSelectMultiple,
-      effectiveIntervalKeys: () => ["1"],
-    });
-
-    state.togglePointKeys(["0"], "pointer");
-    flushSync();
-    expect(state.computeSelectedAnchors()).toEqual(expected);
-
-    destroy();
-  });
-
-  it("computeEmphasizedAnchors reads emphasis keys; empty keys skip candidate walk", () => {
-    const model = modelFor(continuousSpec());
-    let candidateCalls = 0;
-    const { state, destroy } = mountSelectionController({
-      model: () => model,
-      effectiveEmphasisKeys: () => ["0"],
-      candidateSemanticKeys: (candidate) => {
-        candidateCalls++;
-        return identityCandidateKeys(candidate);
-      },
-    });
-
-    const anchors = state.computeEmphasizedAnchors();
-    expect(anchors.length).toBeGreaterThan(0);
-    expect(candidateCalls).toBeGreaterThan(0);
-
-    candidateCalls = 0;
-    const empty = mountSelectionController({
-      model: () => model,
-      effectiveEmphasisKeys: () => [],
-      candidateSemanticKeys: (candidate) => {
-        candidateCalls++;
-        return identityCandidateKeys(candidate);
-      },
-    });
-    expect(empty.state.computeEmphasizedAnchors()).toEqual([]);
-    expect(candidateCalls).toBe(0);
-    empty.destroy();
-    destroy();
-  });
-
-  it("shared projection serves selected + emphasized anchors with one key walk", () => {
-    const model = modelFor(continuousSpec());
-    let candidateCalls = 0;
-    const { state, destroy } = mountSelectionController({
-      model: () => model,
-      selectConfig: pointSelectMultiple,
-      effectiveEmphasisKeys: () => ["1"],
-      candidateSemanticKeys: (candidate) => {
-        candidateCalls++;
-        return identityCandidateKeys(candidate);
-      },
-    });
-    state.togglePointKeys(["0"], "pointer");
-    flushSync();
-
-    candidateCalls = 0;
-    const shared = state.computeSharedCandidateProjection();
-    const once = candidateCalls;
-    expect(once).toBeGreaterThan(0);
-    // Interval consumption fields travel on the same bag (host fuses walks).
-    expect(shared.every((entry) => typeof entry.panelId === "string")).toBe(true);
-
-    const selected = state.computeSelectedAnchors(shared);
-    const emphasized = state.computeEmphasizedAnchors(shared);
-    // No second store walk: key resolver not invoked again for anchors.
-    expect(candidateCalls).toBe(once);
-    expect(selected.length).toBeGreaterThan(0);
-    expect(emphasized.length).toBeGreaterThan(0);
-
-    // Without sharing, two independent calls would double the key work.
-    candidateCalls = 0;
-    state.computeSelectedAnchors();
-    state.computeEmphasizedAnchors();
-    expect(candidateCalls).toBeGreaterThanOrEqual(once * 2);
-
-    destroy();
-  });
-});
-
-describe("createSelectionState masks", () => {
-  it("computeInteractionMasks non-empty only when focus keys exist; inspection contributes", () => {
-    const model = modelFor(continuousSpec());
-    const emphasisBox = reactiveBox<readonly PropertyKey[]>([]);
-    const focusBox = reactiveBox<{
-      sourceKeys: readonly PropertyKey[];
-      key: PropertyKey | null;
-    } | null>(null);
-
-    const { state, destroy } = mountSelectionController({
-      model: () => model,
-      effectiveEmphasisKeys: () => emphasisBox.value,
-      inspectionFocus: () => focusBox.value,
-    });
-
-    // No focus keys → empty masks
-    expect(state.computePresentationFocusKeys()).toEqual([]);
-    const projections = state.computeSemanticCandidateProjections();
-    expect(projections.length).toBeGreaterThan(0);
-    expect(state.computeInteractionMasks([], () => projections)).toEqual([]);
-
-    // Emphasis alone
-    emphasisBox.set(["0"]);
-    flushSync();
-    const focusKeys = state.computePresentationFocusKeys();
-    expect(focusKeys).toEqual(["0"]);
-    const masks = state.computeInteractionMasks(focusKeys, () => projections);
-    expect(masks.length).toBeGreaterThan(0);
-    expect(masks.some((m) => m !== null)).toBe(true);
-
-    // Inspection focus merges when emphasis non-empty
-    focusBox.set({ sourceKeys: ["1"], key: "2" });
-    flushSync();
-    const merged = state.computePresentationFocusKeys();
-    expect(merged).toEqual(["0", "1", "2"]);
-
-    destroy();
-  });
-
-  it("focus-only change does not recompute candidate projections (host memo boundary)", () => {
-    const model = modelFor(continuousSpec());
-    const emphasisBox = reactiveBox<readonly PropertyKey[]>(["0"]);
-    let candidateCalls = 0;
-
-    const { value, destroy } = withFlushedEffectRoot(() => {
-      const state = createSelectionState({
-        model: () => model,
-        interaction: noController,
-        resolvedInteractionScope: () => defaultScope,
-        selectConfig: pointSelectSingle,
-        effectiveIntervalKeys: () => [],
-        effectiveEmphasisKeys: () => emphasisBox.value,
-        inspectionFocus: () => null,
-        candidateSemanticKeys: (candidate) => {
-          candidateCalls++;
-          return identityCandidateKeys(candidate);
-        },
-        onselect: noSelectCb,
-        oninteraction: noInteractionCb,
-        announce: () => {},
-      });
-      // Host-shaped independent memo boundaries (three separate deriveds,
-      // via the rune-backed helper — runes are unavailable in .test.ts).
-      const focus = derivedBox(() => state.computePresentationFocusKeys());
-      const projections = derivedBox(() => state.computeSemanticCandidateProjections());
-      const masks = derivedBox(() =>
-        state.computeInteractionMasks(focus.value, () => projections.value),
-      );
-      return {
-        state,
-        get focus() {
-          return focus.value;
-        },
-        get masks() {
-          return masks.value;
-        },
-        get projections() {
-          return projections.value;
-        },
-      };
-    });
-
-    // IDLE REGRESSION GUARD: with empty focus, reading masks must NOT
-    // materialize the projections walk (the thunk stays uninvoked).
-    emphasisBox.set([]);
-    flushSync();
-    expect(value.masks).toEqual([]);
-    expect(candidateCalls).toBe(0);
-    emphasisBox.set(["0"]);
-    flushSync();
-
-    // Initial focused read materializes projections
-    void value.focus;
-    void value.projections;
-    void value.masks;
-    flushSync();
-    const callsAfterInit = candidateCalls;
-    expect(callsAfterInit).toBeGreaterThan(0);
-
-    // Focus-only flip: change emphasis keys, re-read focus + masks
-    emphasisBox.set(["0", "1"]);
-    flushSync();
-    void value.focus;
-    void value.masks;
-    // Projections derived should NOT re-run candidateSemanticKeys
-    expect(candidateCalls).toBe(callsAfterInit);
-    expect(value.focus).toEqual(["0", "1"]);
-    expect(value.masks.length).toBeGreaterThan(0);
 
     destroy();
   });

--- a/packages/svelte/tests/surface/surface-state.test.ts
+++ b/packages/svelte/tests/surface/surface-state.test.ts
@@ -365,6 +365,20 @@ function mountSurfaceComposite(
       coordFlipped: () => false,
       captureSurface: () => capture,
       candidateSemanticKeys: identityCandidateKeys,
+      consumptionCandidates: () => {
+        const candidates = [];
+        for (let id = 0; id < model.candidates.size; id++) {
+          const candidate = model.candidates.candidate(id);
+          if (candidate === null) continue;
+          candidates.push({
+            panelId: candidate.panelId,
+            xValue: candidate.xValue,
+            yValue: candidate.yValue,
+            keys: identityCandidateKeys(candidate),
+          });
+        }
+        return candidates;
+      },
       inspectionPanel: () => inspection.inspectionPanel,
       emitSelection: (event) => {
         selectionEvents.push(event);


### PR DESCRIPTION
## Summary

- add a deep runtime module that owns semantic Candidate traversal, liveness gating, anchor projection, interaction masks, and interval-consumption shaping
- reduce `SelectionState` to selection behavior and remove interval's fallback CandidateStore traversal
- preserve idle and union short-circuits, one-walk sharing, and focus-only memoization with behavior and lifecycle contract tests

## Architecture

`createPlotInteractionAssembly()` remains the host interface. It now delegates the semantic Candidate view to `createSemanticCandidateProjection()`, giving selection, interval consumption, anchors, and masks one locality point. `CandidateStore` remains model-owned and DOM-independent per ADR 0011.

## Validation

- `bun run fmt:check`
- `bun run lint`
- `bun run lint:type-aware`
- `bun run check`
- `bun run check:svelte`
- `bun run check:examples`
- `bun run knip`
- `bun run build`
- `bun run --cwd packages/svelte test:ssr` (13 tests)
- `bun run --cwd packages/svelte test:browser` (2,835 tests)
- `bun test packages/spec packages/core benchmarks scripts tests/evals` (1,016 tests)
- pre-commit and pre-push hooks
