### PR TITLE
fix(spec): restore large-inline validation performance

### DIFF
--- a/.changeset/compile-typebox-validation.md
+++ b/.changeset/compile-typebox-validation.md
@@ -1,0 +1,7 @@
+---
+"@ggsvelte/spec": patch
+---
+
+# Compile plot schema validation
+
+Compile and reuse the plot schema validator so large inline datasets no longer block rendering during validation.

--- a/packages/spec/src/validate.ts
+++ b/packages/spec/src/validate.ts
@@ -2,8 +2,9 @@
  * Spec validation orchestrator — tier 1 (schema shape) plus opt-in tier 2
  * (structural grammar, data-aware checks, optional lint).
  *
- * Tier-1 mechanism (decision 0004): TypeBox 1.x `Value.Check`/`Value.Errors`
- * over the same schemas that emit `schema/v0.json` — one artifact, no drift.
+ * Tier-1 mechanism (decision 0004): TypeBox 1.x compiled checks plus
+ * `Value.Errors` over the same schemas that emit `schema/v0.json` — one
+ * artifact, no drift.
  * Raw TypeBox union noise is mapped to the agent error contract in
  * validate-map-errors.ts. Data-free grammar rules live in
  * validate-structure.ts. Data-aware checks live in validate-data*.ts
@@ -12,6 +13,7 @@
  * Output: `{ ok: true, spec }` or `{ ok: false, errors: SpecError[] }` with
  * the agent error contract from errors.ts. Messages are snapshot-tested.
  */
+import Compile from "typebox/compile";
 import { Settings } from "typebox/system";
 import { Value } from "typebox/value";
 
@@ -47,6 +49,16 @@ import { facetStructuralErrors, layerStructuralErrors } from "./validate-structu
 export type ValidateResult =
   | { ok: true; spec: PortableSpec; advisories?: SpecAdvisory[] }
   | { ok: false; errors: SpecError[]; advisories?: SpecAdvisory[] };
+
+const PLOT_SPEC_VALIDATOR = (() => {
+  const previousExactOptional = Settings.Get().exactOptionalPropertyTypes;
+  Settings.Set({ exactOptionalPropertyTypes: true });
+  try {
+    return Compile(PlotSpecSchema);
+  } finally {
+    Settings.Set({ exactOptionalPropertyTypes: previousExactOptional });
+  }
+})();
 
 const GEOM_BRANCHES = {
   point: PointLayerSchema,
@@ -176,9 +188,10 @@ export function validate(input: unknown, options?: ValidateOptions): ValidateRes
     exactOptionalPropertyTypes: true,
   });
   try {
-    // SpecImportSchema is a structural Cyclic root; Static<> on it is not useful
-    // for control-flow (collapses), so treat Check as a plain boolean.
-    const schemaValid: boolean = Value.Check(PlotSpecSchema, input);
+    // TypeBox's interpreted Value.Check walks the cyclic schema graph repeatedly
+    // for every inline row. Reuse its compiled validator so large plots remain
+    // interactive while preserving Value.Errors for detailed invalid diagnostics.
+    const schemaValid: boolean = PLOT_SPEC_VALIDATOR.Check(input);
 
     if (!schemaValid) {
       if (!isRecord(input)) {

--- a/packages/spec/tests/validate.test.ts
+++ b/packages/spec/tests/validate.test.ts
@@ -12,6 +12,25 @@ function errorsOf(input: unknown) {
   return result.errors;
 }
 
+describe("validate — performance", () => {
+  it("validates a 10,000-row inline dataset without blocking interactive rendering", () => {
+    const values = Array.from({ length: 10_000 }, (_, index) => ({
+      x: index,
+      y: index % 100,
+    }));
+    const startedAt = performance.now();
+
+    const result = validate({
+      data: { values },
+      aes: { x: { field: "x" }, y: { field: "y" } },
+      layers: [{ geom: "point" }],
+    });
+
+    expect(result.ok).toBe(true);
+    expect(performance.now() - startedAt).toBeLessThan(2_000);
+  });
+});
+
 describe("validate — accepts", () => {
   it("a minimal valid spec", () => {
     const result = validate({ layers: [{ geom: "point" }] });


### PR DESCRIPTION
## Summary

- compile the TypeBox plot schema once and reuse its validator
- preserve `exactOptionalPropertyTypes` behavior and interpreted `Value.Errors` diagnostics
- add a 10,000-row public-interface performance regression test

## Root cause

The TypeBox 1.x migration changed the hot plot-schema check to interpreted `Value.Check`. On a 10,000-row inline dataset this took 6–9 seconds per validation. The visual suite runs the light and dark canvas-scatter cases concurrently, so both browser main threads exceeded Playwright's 30-second timeout. PR #316 and exact `origin/main` reproduced the same failures before this branch.

## Evidence

- Regression test before fix: **6,243 ms** and failed the 2,000 ms budget
- Regression test after fix: **5–83 ms** across focused/full runs
- Canvas-scatter visual cases now reach stable screenshots in **1.7 seconds** under two parallel workers instead of timing out; local screenshot comparison has environment-specific text antialiasing differences
- `bun test packages/spec/tests`: 160 passed
- full pre-push suite passed: package build, docs/Svelte checks, type-aware lint, examples, Knip, and spec/core/benchmark/script/eval tests
- `bun run build` and `bun run build:docs` passed

## Risk control

Invalid-spec diagnostics continue through `Value.Errors`; the compiled validator only replaces the initial boolean shape check. Compilation happens with exact optional-property semantics, covered by the existing explicit-`undefined` regression test.
