### PR TITLE
fix(spec): keep runtime types aligned with portable specs

### DIFF
--- a/.changeset/fix-runtime-spec-parity.md
+++ b/.changeset/fix-runtime-spec-parity.md
@@ -1,0 +1,11 @@
+---
+"@ggsvelte/spec": patch
+---
+
+# Keep RuntimeSpec aligned with PortableSpec
+
+Project the runtime plot and layer types from their portable counterparts so
+portable fields such as `edition`, `facet`, `coord`, `a11y`, and layer `render`
+are visible through `RuntimeSpec`. Runtime-only `{ fn }` channel accessors remain
+type-level and conversion features; the rendering pipeline does not execute
+them.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   ],
   "type": "module",
   "scripts": {
-    "check": "tsc -b packages/spec packages/core",
+    "check": "tsc -b packages/spec packages/core && bun run check:type-contracts",
+    "check:type-contracts": "tsc -p packages/spec/type-tests/tsconfig.json",
     "check:svelte": "cd packages/svelte && bun run --bun check",
     "check:examples": "bun node_modules/.bin/tsc -p examples --noEmit",
     "check:docs": "cd apps/docs && bun run --bun check",

--- a/packages/spec/src/runtime.ts
+++ b/packages/spec/src/runtime.ts
@@ -6,34 +6,31 @@
  * Narrow with `isPortable()`; convert with `toPortable()` (rejecting) or
  * `toPortableLossy()` (explicit tooling path) from `portability.ts`.
  *
- * M0c note: the pipeline consumes PortableSpec; `{ fn }` accessor EXECUTION
- * is an M1 concern. The type + conversion contract lands now so the split is
- * part of the public API from the start.
+ * The runtime types are projected from their portable counterparts rather
+ * than duplicating the public surface. New portable plot or layer fields are
+ * therefore inherited automatically; only `aes` is widened for accessors.
+ *
+ * The pipeline still consumes PortableSpec. `{ fn }` accessor execution is
+ * future work: this module defines the in-memory type and conversion boundary,
+ * not an execution promise.
  */
 import type {
-  AreaParams,
-  BarParams,
-  BoxplotParams,
+  Aes,
+  AreaLayer,
+  BarLayer,
+  BoxplotLayer,
   ChannelValue,
-  ColParams,
-  DataRef,
-  DensityParams,
-  ErrorbarParams,
-  GeomName,
-  InlineData,
-  Labs,
-  LegendSpec,
-  LineParams,
-  PointParams,
-  PointPosition,
-  PositionParams,
-  RuleParams,
-  Scales,
-  SmoothParams,
-  StackablePosition,
-  TextParams,
-  ThemeName,
-  ThemeSpec,
+  ColLayer,
+  DensityLayer,
+  ErrorbarLayer,
+  HistogramLayer,
+  LayerSpec,
+  LineLayer,
+  PointLayer,
+  PortableSpec,
+  RuleLayer,
+  SmoothLayer,
+  TextLayer,
 } from "./schema.js";
 
 /** A function channel accessor: computes the channel value per row. */
@@ -45,111 +42,27 @@ export interface ChannelFn {
 export type RuntimeChannelValue = ChannelValue | ChannelFn;
 
 /** Aes whose channels may be function accessors. */
-export interface RuntimeAes {
-  x?: RuntimeChannelValue;
-  y?: RuntimeChannelValue;
-  color?: RuntimeChannelValue;
-  fill?: RuntimeChannelValue;
-  size?: RuntimeChannelValue;
-  linewidth?: RuntimeChannelValue;
-  alpha?: RuntimeChannelValue;
-  group?: RuntimeChannelValue;
-  label?: RuntimeChannelValue;
-  weight?: RuntimeChannelValue;
-  ymin?: RuntimeChannelValue;
-  ymax?: RuntimeChannelValue;
-}
+type RuntimeAesFields = {
+  [Channel in keyof Aes]: Exclude<Aes[Channel], undefined> | ChannelFn;
+};
+export interface RuntimeAes extends RuntimeAesFields {}
 
-interface RuntimeLayerBase {
-  geom: GeomName;
+type WithRuntimeAes<Layer extends LayerSpec> = Omit<Layer, "aes"> & {
   aes?: RuntimeAes;
-}
+};
 
-export interface RuntimePointLayer extends RuntimeLayerBase {
-  geom: "point";
-  stat?: "identity";
-  position?: PointPosition;
-  positionParams?: PositionParams;
-  params?: PointParams;
-}
-
-export interface RuntimeLineLayer extends RuntimeLayerBase {
-  geom: "line";
-  stat?: "identity";
-  position?: "identity";
-  params?: LineParams;
-}
-
-export interface RuntimeColLayer extends RuntimeLayerBase {
-  geom: "col";
-  stat?: "identity";
-  position?: StackablePosition;
-  params?: ColParams;
-}
-
-export interface RuntimeBarLayer extends RuntimeLayerBase {
-  geom: "bar";
-  stat?: "count" | "bin";
-  position?: StackablePosition;
-  params?: BarParams;
-}
-
-export interface RuntimeHistogramLayer extends RuntimeLayerBase {
-  geom: "histogram";
-  stat?: "bin";
-  position?: StackablePosition;
-  params?: BarParams;
-}
-
-export interface RuntimeAreaLayer extends RuntimeLayerBase {
-  geom: "area";
-  stat?: "identity";
-  position?: StackablePosition;
-  params?: AreaParams;
-}
-
-export interface RuntimeRuleLayer extends RuntimeLayerBase {
-  geom: "rule";
-  stat?: "identity";
-  position?: "identity";
-  params?: RuleParams;
-}
-
-export interface RuntimeTextLayer extends RuntimeLayerBase {
-  geom: "text";
-  stat?: "identity";
-  position?: "identity" | "nudge";
-  positionParams?: PositionParams;
-  params?: TextParams;
-}
-
-export interface RuntimeSmoothLayer extends RuntimeLayerBase {
-  geom: "smooth";
-  stat?: "smooth";
-  position?: "identity";
-  params?: SmoothParams;
-}
-
-export interface RuntimeBoxplotLayer extends RuntimeLayerBase {
-  geom: "boxplot";
-  stat?: "boxplot";
-  position?: "dodge" | "identity";
-  params?: BoxplotParams;
-}
-
-export interface RuntimeDensityLayer extends RuntimeLayerBase {
-  geom: "density";
-  stat?: "density";
-  position?: "identity";
-  params?: DensityParams;
-}
-
-export interface RuntimeErrorbarLayer extends RuntimeLayerBase {
-  geom: "errorbar";
-  stat?: "identity" | "summary";
-  position?: "identity";
-  params?: ErrorbarParams;
-}
+export interface RuntimePointLayer extends WithRuntimeAes<PointLayer> {}
+export interface RuntimeLineLayer extends WithRuntimeAes<LineLayer> {}
+export interface RuntimeColLayer extends WithRuntimeAes<ColLayer> {}
+export interface RuntimeBarLayer extends WithRuntimeAes<BarLayer> {}
+export interface RuntimeHistogramLayer extends WithRuntimeAes<HistogramLayer> {}
+export interface RuntimeAreaLayer extends WithRuntimeAes<AreaLayer> {}
+export interface RuntimeRuleLayer extends WithRuntimeAes<RuleLayer> {}
+export interface RuntimeTextLayer extends WithRuntimeAes<TextLayer> {}
+export interface RuntimeSmoothLayer extends WithRuntimeAes<SmoothLayer> {}
+export interface RuntimeBoxplotLayer extends WithRuntimeAes<BoxplotLayer> {}
+export interface RuntimeDensityLayer extends WithRuntimeAes<DensityLayer> {}
+export interface RuntimeErrorbarLayer extends WithRuntimeAes<ErrorbarLayer> {}
 
 export type RuntimeLayerSpec =
   | RuntimePointLayer
@@ -166,16 +79,8 @@ export type RuntimeLayerSpec =
   | RuntimeErrorbarLayer;
 
 /** The in-memory spec superset ({ fn } channel accessors allowed). */
-export interface RuntimeSpec {
-  $schema?: string;
-  data?: DataRef;
-  datasets?: Record<string, InlineData>;
+type RuntimeSpecPortableFields = Omit<PortableSpec, "aes" | "layers">;
+export interface RuntimeSpec extends RuntimeSpecPortableFields {
   aes?: RuntimeAes;
   layers: RuntimeLayerSpec[];
-  scales?: Scales;
-  legend?: LegendSpec;
-  labs?: Labs;
-  theme?: ThemeName | ThemeSpec;
-  width?: number;
-  height?: number;
 }

--- a/packages/spec/type-tests/runtime-spec-parity.ts
+++ b/packages/spec/type-tests/runtime-spec-parity.ts
@@ -1,0 +1,47 @@
+import type { Aes, LayerSpec, PortableSpec } from "../src/schema.js";
+import type { RuntimeAes, RuntimeLayerSpec, RuntimeSpec } from "../src/runtime.js";
+
+type KeysOfUnion<Value> = Value extends Value ? keyof Value : never;
+type Assert<Condition extends true> = Condition;
+
+export type PortableRuntimeKeyParity = Assert<
+  Exclude<keyof PortableSpec, keyof RuntimeSpec> extends never ? true : false
+>;
+export type PortableRuntimeLayerKeyParity = Assert<
+  Exclude<KeysOfUnion<LayerSpec>, KeysOfUnion<RuntimeLayerSpec>> extends never ? true : false
+>;
+export type PortableRuntimeAesKeyParity = Assert<
+  Exclude<keyof Aes, keyof RuntimeAes> extends never ? true : false
+>;
+
+function acceptRuntimeSpec(_spec: RuntimeSpec): void {}
+function acceptRuntimeLayer(_layer: RuntimeLayerSpec): void {}
+function acceptRuntimeAes(_aes: RuntimeAes): void {}
+
+declare const everyPortableSpec: PortableSpec;
+declare const everyPortableLayer: LayerSpec;
+declare const everyPortableAes: Aes;
+
+// Public contract: portable values are assignable without a cast or conversion.
+acceptRuntimeSpec(everyPortableSpec);
+acceptRuntimeLayer(everyPortableLayer);
+acceptRuntimeAes(everyPortableAes);
+
+// Keep the fields that previously drifted visible in the proof fixture so a
+// future reviewer can see the intended superset boundary at a glance.
+const currentPortableSurface = {
+  edition: 1,
+  data: { values: [{ group: "a", x: 1, y: 2 }] },
+  facet: { wrap: { field: "group" }, ncol: 2 },
+  coord: { type: "flip" },
+  a11y: "force-svg",
+  layers: [
+    {
+      geom: "point",
+      aes: { x: { field: "x" }, y: { field: "y" } },
+      render: "canvas",
+    },
+  ],
+} satisfies PortableSpec;
+
+acceptRuntimeSpec(currentPortableSurface);

--- a/packages/spec/type-tests/tsconfig.json
+++ b/packages/spec/type-tests/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": []
+  },
+  "include": ["./**/*.ts"]
+}


### PR DESCRIPTION
## Summary

- derive runtime plot and layer surfaces from their portable counterparts, widening only aesthetic channels for `{ fn }` accessors
- expose current portable fields such as `edition`, `facet`, `coord`, `a11y`, and per-layer `render` through `RuntimeSpec`
- preserve the existing public interfaces while preventing future portable/runtime key drift
- make the compile-time parity proof part of the standard `check` and `build` paths
- keep the execution boundary explicit: runtime accessors remain conversion/type features and are not executed by the rendering pipeline

## TDD evidence

The proof gate failed on unmodified `main` because `RuntimeSpec` omitted portable plot keys and every runtime layer omitted `render`. Implementation began only after that expected failure.

- compile-time whole-surface, layer-union, aesthetic, and current-field fixture proofs: passed
- `bun test packages/spec packages/core scripts tests/evals`: 1,049 passed
- portability regressions: 9 passed
- package/core/Svelte/docs/examples type checks: passed
- formatting, lint, and type-aware lint: passed
- package build and package lint: passed
- packed npm consumer type-check, client/SSR builds, runtime, SSR, and CLI smoke: passed

## Review

An initial local Codex pass noted that the new proof files had not yet been included in the staged patch. After staging the complete patch and preserving the exported interfaces, the second review found no correctness issues.

## Release note

Includes a patch changeset for `@ggsvelte/spec`. This repairs the declared type-superset contract without adding runtime accessor execution.
