### PR TITLE
feat(docs): showcase themes and color scales

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -11,6 +11,7 @@
     "check": "bun ../../scripts/gen-docs-routes.ts --check && bun ../../scripts/gen-gallery-previews.ts --check && svelte-kit sync && svelte-check --fail-on-warnings"
   },
   "dependencies": {
+    "@ggsvelte/core": "workspace:*",
     "@ggsvelte/examples": "workspace:*",
     "@ggsvelte/spec": "workspace:*",
     "@ggsvelte/svelte": "workspace:*"

--- a/apps/docs/src/lib/catalog/themes.ts
+++ b/apps/docs/src/lib/catalog/themes.ts
@@ -1,0 +1,42 @@
+import { CATEGORICAL_SCHEMES, VIRIDIS_RAMP_10 } from "@ggsvelte/core";
+import { CATEGORICAL_SCHEME_NAMES, THEME_NAMES, type ThemeName } from "@ggsvelte/spec";
+
+const THEME_LABELS = {
+  default: "Default",
+  light: "Light",
+  dark: "Dark",
+  minimal: "Minimal",
+  ggplot2: "ggplot2",
+  classic: "Classic",
+  hrbr: "HRBR",
+  few: "Few",
+  clean: "Clean",
+  fivethirtyeight: "FiveThirtyEight",
+  economist: "Economist",
+  tufte: "Tufte",
+} as const satisfies Record<ThemeName, string>;
+
+const PALETTE_LABELS = {
+  observable10: "Observable 10",
+  ipsum: "Ipsum",
+  flexoki: "Flexoki",
+  tableau10: "Tableau 10",
+  colorblind: "Colorblind",
+} as const satisfies Record<(typeof CATEGORICAL_SCHEME_NAMES)[number], string>;
+
+export const THEME_OPTIONS = THEME_NAMES.map((name) => ({
+  name,
+  label: THEME_LABELS[name],
+}));
+
+export const CATEGORICAL_PALETTES = CATEGORICAL_SCHEME_NAMES.map((name) => {
+  const colors = CATEGORICAL_SCHEMES[name];
+  return {
+    name,
+    label: PALETTE_LABELS[name],
+    capacity: colors.length,
+    colors,
+  };
+});
+
+export const VIRIDIS_COLORS = VIRIDIS_RAMP_10;

--- a/apps/docs/src/lib/color-evidence.ts
+++ b/apps/docs/src/lib/color-evidence.ts
@@ -1,0 +1,101 @@
+import { PipelineError, runPipeline } from "@ggsvelte/core";
+import { validate, type PortableSpec } from "@ggsvelte/spec";
+
+export interface ColorBehaviorEvidence {
+  incompatible: {
+    code: string;
+    path: string;
+    message: string;
+    fix: string;
+  };
+  cycle: {
+    code: string;
+    message: string;
+  };
+  error: {
+    code: string;
+    path: string;
+    message: string;
+  };
+}
+
+const rows = [
+  { x: 1, y: 2, group: "Alpha" },
+  { x: 2, y: 3, group: "Beta" },
+  { x: 3, y: 4, group: "Gamma" },
+];
+
+function exhaustionSpec(onExhaust: "cycle" | "error"): PortableSpec {
+  return {
+    data: { values: rows },
+    layers: [
+      {
+        geom: "point",
+        aes: {
+          x: { field: "x" },
+          y: { field: "y" },
+          color: { field: "group" },
+        },
+      },
+    ],
+    scales: {
+      color: {
+        type: "ordinal",
+        range: ["#123456", "#abcdef"],
+        onExhaust,
+      },
+    },
+  };
+}
+
+export function colorBehaviorEvidence(): ColorBehaviorEvidence {
+  const incompatibleResult = validate({
+    ...exhaustionSpec("cycle"),
+    scales: { color: { type: "ordinal", scheme: "viridis" } },
+  });
+  if (incompatibleResult.ok) {
+    throw new Error("Expected the incompatible color scheme demonstration to fail validation.");
+  }
+  const incompatible = incompatibleResult.errors.find(
+    (diagnostic) => diagnostic.code === "scale-scheme-type",
+  );
+  if (incompatible === undefined || incompatible.fix === undefined) {
+    throw new Error("The incompatible color scheme demonstration returned no repair diagnostic.");
+  }
+
+  const cycle = runPipeline(exhaustionSpec("cycle"), { width: 640, height: 400 }).warnings.find(
+    (warning) => warning.code === "palette-exhausted",
+  );
+  if (cycle === undefined) {
+    throw new Error("The cycle demonstration returned no palette exhaustion warning.");
+  }
+
+  let failure: PipelineError | undefined;
+  try {
+    runPipeline(exhaustionSpec("error"), { width: 640, height: 400 });
+  } catch (error) {
+    if (!(error instanceof PipelineError)) throw error;
+    failure = error;
+  }
+  if (failure === undefined) {
+    throw new Error("Expected the strict palette exhaustion demonstration to fail.");
+  }
+
+  return {
+    incompatible: {
+      code: incompatible.code,
+      path: incompatible.path,
+      message: incompatible.message,
+      fix: incompatible.fix.description,
+    },
+    cycle: {
+      code: cycle.code,
+      message: cycle.message,
+    },
+    error: {
+      code: failure.code,
+      path: failure.path,
+      message: failure.message,
+    },
+  };
+}

--- a/apps/docs/src/lib/components/ChartThemeLab.svelte
+++ b/apps/docs/src/lib/components/ChartThemeLab.svelte
@@ -1,0 +1,210 @@
+<script lang="ts">
+  import { GeomPoint, GGPlot } from "@ggsvelte/svelte";
+  import type { ThemeName } from "@ggsvelte/spec";
+  import { onMount } from "svelte";
+
+  import { THEME_OPTIONS } from "$lib/catalog/themes";
+  import CopyCode from "$lib/components/CopyCode.svelte";
+
+  const rows = [
+    { quarter: 1, value: 24, group: "Observed" },
+    { quarter: 2, value: 38, group: "Observed" },
+    { quarter: 3, value: 45, group: "Observed" },
+    { quarter: 4, value: 63, group: "Observed" },
+    { quarter: 1, value: 31, group: "Expected" },
+    { quarter: 2, value: 41, group: "Expected" },
+    { quarter: 3, value: 54, group: "Expected" },
+    { quarter: 4, value: 70, group: "Expected" },
+  ];
+
+  let explicitTheme = $state<ThemeName>("default");
+  let followDocs = $state(false);
+  let siteAppearance = $state<"light" | "dark">("light");
+  const resolvedTheme = $derived<ThemeName>(
+    followDocs ? siteAppearance : explicitTheme,
+  );
+  const code = $derived(
+    `<GGPlot data={rows} aes={{ x: "quarter", y: "value", color: "group" }} theme="${resolvedTheme}">\n  <GeomPoint size={4} />\n</GGPlot>`,
+  );
+
+  function syncSiteAppearance(): void {
+    siteAppearance =
+      document.documentElement.dataset.theme === "dark" ? "dark" : "light";
+  }
+
+  function changeFollow(event: Event): void {
+    followDocs = (event.currentTarget as HTMLInputElement).checked;
+    if (followDocs) syncSiteAppearance();
+  }
+
+  onMount(() => {
+    syncSiteAppearance();
+    const observer = new MutationObserver(() => {
+      if (followDocs) syncSiteAppearance();
+    });
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["data-theme"],
+    });
+    return () => observer.disconnect();
+  });
+</script>
+
+<section class="theme-lab" aria-label="Chart theme lab">
+  <div class="lab-copy">
+    <p class="eyebrow">Separate by default</p>
+    <h2>Site appearance is not chart meaning.</h2>
+    <p>
+      Choose a chart theme independently so exported graphics keep their
+      intended paper and ink. Follow the docs appearance only when that behavior
+      is deliberate.
+    </p>
+    <div class="controls">
+      <div class="select-control">
+        <label for="chart-theme">Chart theme</label>
+        <select
+          id="chart-theme"
+          bind:value={explicitTheme}
+          disabled={followDocs}
+        >
+          {#each THEME_OPTIONS as theme (theme.name)}
+            <option value={theme.name}>{theme.label}</option>
+          {/each}
+        </select>
+      </div>
+      <label class="follow-control">
+        <input type="checkbox" checked={followDocs} onchange={changeFollow} />
+        <span>Follow docs appearance</span>
+      </label>
+    </div>
+    <p class="resolved" role="status">
+      Chart theme: <strong>{resolvedTheme}</strong>{followDocs
+        ? " · following docs"
+        : " · explicit"}
+    </p>
+  </div>
+
+  <div class="lab-output">
+    <div class="plot-paper">
+      <GGPlot
+        data={rows}
+        aes={{ x: "quarter", y: "value", color: "group" }}
+        theme={resolvedTheme}
+        height={340}
+        ariaLabel={`${resolvedTheme} chart theme comparison`}
+      >
+        <GeomPoint size={4} />
+      </GGPlot>
+    </div>
+    <p class="fragment-label">Svelte fragment</p>
+    <CopyCode {code} label="Copy selected theme code" />
+  </div>
+</section>
+
+<style>
+  .theme-lab {
+    display: grid;
+    grid-template-columns: minmax(17rem, 0.75fr) minmax(0, 1.25fr);
+    gap: clamp(2rem, 7vw, 7rem);
+    align-items: center;
+    padding-block: clamp(4rem, 9vw, 8rem);
+    border-top: 1px solid var(--line);
+  }
+
+  .eyebrow,
+  .fragment-label {
+    margin: 0;
+    color: var(--muted);
+    font-size: 0.72rem;
+    font-weight: 650;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  h2 {
+    max-width: 11ch;
+    margin: 0.25rem 0 1rem;
+    font-size: clamp(2.5rem, 5vw, 4.5rem);
+    line-height: 0.95;
+  }
+
+  .lab-copy > p:not(.eyebrow, .resolved) {
+    max-width: 34rem;
+    color: var(--muted);
+  }
+
+  .controls {
+    display: grid;
+    gap: 0.85rem;
+    margin-top: 2rem;
+  }
+
+  .select-control {
+    display: grid;
+    gap: 0.4rem;
+    font-size: 0.82rem;
+    font-weight: 650;
+  }
+
+  select {
+    width: 100%;
+    min-height: 44px;
+    padding: 0.6rem 2.5rem 0.6rem 0.75rem;
+    border: 1px solid var(--line-strong);
+    border-radius: 2px;
+    background: var(--paper);
+    color: var(--ink);
+    font: inherit;
+  }
+
+  .follow-control {
+    display: flex;
+    gap: 0.65rem;
+    align-items: center;
+    min-height: 44px;
+    font-size: 0.9rem;
+    font-weight: 600;
+  }
+
+  .follow-control input {
+    width: 1.15rem;
+    height: 1.15rem;
+  }
+
+  .resolved {
+    min-height: 1.5rem;
+    color: var(--muted);
+    font-size: 0.82rem;
+  }
+
+  .lab-output {
+    min-width: 0;
+    border: 1px solid var(--line);
+    background: var(--paper);
+  }
+
+  .plot-paper {
+    min-width: 0;
+    overflow: hidden;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .fragment-label {
+    padding: 0.8rem 1rem 0;
+  }
+
+  :global(.copy-code) {
+    margin: 0.5rem 1rem 1rem;
+  }
+
+  @media (max-width: 50rem) {
+    .theme-lab {
+      grid-template-columns: 1fr;
+      gap: 2rem;
+    }
+
+    .lab-output {
+      grid-row: 1;
+    }
+  }
+</style>

--- a/apps/docs/src/lib/components/ColorFailureDemo.svelte
+++ b/apps/docs/src/lib/components/ColorFailureDemo.svelte
@@ -1,0 +1,269 @@
+<script lang="ts">
+  import { GeomPoint, GGPlot } from "@ggsvelte/svelte";
+
+  import { colorBehaviorEvidence } from "$lib/color-evidence";
+  import CopyCode from "$lib/components/CopyCode.svelte";
+
+  const evidence = colorBehaviorEvidence();
+  const rows = [
+    { x: 1, y: 2, group: "Alpha" },
+    { x: 2, y: 3, group: "Beta" },
+    { x: 3, y: 4, group: "Gamma" },
+  ];
+  let behavior = $state<"cycle" | "error">("cycle");
+  const code = $derived(
+    `<GGPlot\n  data={rows}\n  aes={{ x: "x", y: "y", color: "group" }}\n  scales={{ color: {\n    range: ["#123456", "#abcdef"],\n    onExhaust: "${behavior}"\n  } }}\n>\n  <GeomPoint size={5} />\n</GGPlot>`,
+  );
+</script>
+
+<section class="limits" aria-label="Palette limits">
+  <header class="section-heading">
+    <div>
+      <p class="eyebrow">Failure is part of the contract</p>
+      <h2>Decide what happens when color runs out.</h2>
+    </div>
+    <p>
+      Cycling keeps a chart renderable and warns once. Strict mode stops before
+      two categories can imply the same identity. Both results below come from
+      the public validation and pipeline APIs.
+    </p>
+  </header>
+
+  <div class="limit-grid">
+    <article class="incompatible">
+      <p class="diagnostic-kind">Validation result</p>
+      <code>{evidence.incompatible.code}</code>
+      <h3>A sequential scheme cannot drive ordinal categories.</h3>
+      <p>{evidence.incompatible.message}</p>
+      <dl>
+        <div>
+          <dt>Path</dt>
+          <dd><code>{evidence.incompatible.path}</code></dd>
+        </div>
+        <div>
+          <dt>Safe fix</dt>
+          <dd>{evidence.incompatible.fix}</dd>
+        </div>
+      </dl>
+    </article>
+
+    <article class="exhaustion">
+      <div class="behavior-heading">
+        <div>
+          <p class="diagnostic-kind">Pipeline result</p>
+          <h3>Two colors, three categories</h3>
+        </div>
+        <label for="exhaustion-behavior">Exhaustion behavior</label>
+        <select id="exhaustion-behavior" bind:value={behavior}>
+          <option value="cycle">Cycle and warn</option>
+          <option value="error">Stop with error</option>
+        </select>
+      </div>
+
+      {#if behavior === "cycle"}
+        <div class="diagnostic warning" role="status">
+          <code>{evidence.cycle.code}</code>
+          <p>{evidence.cycle.message}</p>
+        </div>
+        <div class="plot-paper">
+          <GGPlot
+            data={rows}
+            aes={{ x: "x", y: "y", color: "group" }}
+            scales={{
+              color: {
+                type: "ordinal",
+                range: ["#123456", "#abcdef"],
+                onExhaust: "cycle",
+              },
+            }}
+            theme="light"
+            height={270}
+            ariaLabel="Three categories cycling through a two-color range"
+          >
+            <GeomPoint size={5} />
+          </GGPlot>
+        </div>
+      {:else}
+        <div class="diagnostic error" role="alert">
+          <code>{evidence.error.code}</code>
+          <p>{evidence.error.message}</p>
+          <p><strong>Path</strong> <code>{evidence.error.path}</code></p>
+          <p>
+            <strong>Safe fix</strong> Provide a larger range or an explicit domain.
+          </p>
+        </div>
+      {/if}
+
+      <p class="fragment-label">Svelte fragment</p>
+      <CopyCode {code} label="Copy exhaustion example" />
+    </article>
+  </div>
+</section>
+
+<style>
+  .limits {
+    padding-block: clamp(4rem, 9vw, 8rem);
+    border-top: 1px solid var(--line);
+  }
+
+  .eyebrow,
+  .diagnostic-kind,
+  .fragment-label {
+    margin: 0;
+    color: var(--muted);
+    font-size: 0.72rem;
+    font-weight: 650;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .section-heading {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(18rem, 0.55fr);
+    gap: clamp(2rem, 7vw, 7rem);
+    align-items: end;
+    margin-bottom: 2rem;
+  }
+
+  h2 {
+    max-width: 12ch;
+    margin: 0.25rem 0 0;
+    font-size: clamp(2.5rem, 5vw, 4.75rem);
+    line-height: 0.94;
+  }
+
+  .section-heading > p,
+  article > p:not(.diagnostic-kind, .fragment-label) {
+    color: var(--muted);
+  }
+
+  .limit-grid {
+    display: grid;
+    grid-template-columns: minmax(16rem, 0.65fr) minmax(0, 1.35fr);
+    gap: 1.25rem;
+    align-items: start;
+  }
+
+  article {
+    min-width: 0;
+    border: 1px solid var(--line);
+    background: var(--paper);
+  }
+
+  .incompatible {
+    padding: 1.25rem;
+  }
+
+  article h3 {
+    margin: 0.55rem 0;
+    font-size: 1.55rem;
+    line-height: 1.05;
+  }
+
+  .incompatible > code,
+  .diagnostic > code {
+    display: inline-block;
+    margin-top: 0.75rem;
+    color: var(--accent);
+    font-weight: 700;
+  }
+
+  dl {
+    display: grid;
+    gap: 0.75rem;
+    margin: 1.5rem 0 0;
+  }
+
+  dl div {
+    padding-top: 0.75rem;
+    border-top: 1px solid var(--line);
+  }
+
+  dt {
+    color: var(--muted);
+    font-size: 0.72rem;
+    font-weight: 650;
+    text-transform: uppercase;
+  }
+
+  dd {
+    margin: 0.25rem 0 0;
+  }
+
+  .behavior-heading {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 0.5rem 1rem;
+    align-items: end;
+    padding: 1.25rem;
+  }
+
+  .behavior-heading label {
+    grid-column: 2;
+    grid-row: 1;
+    color: var(--muted);
+    font-size: 0.72rem;
+    font-weight: 650;
+  }
+
+  select {
+    grid-column: 2;
+    grid-row: 2;
+    min-height: 44px;
+    padding: 0.6rem;
+    border: 1px solid var(--line-strong);
+    border-radius: 2px;
+    background: var(--paper);
+    color: var(--ink);
+    font: inherit;
+  }
+
+  .diagnostic {
+    min-height: 7rem;
+    padding: 1rem 1.25rem;
+    border-block: 1px solid var(--line);
+  }
+
+  .warning {
+    background: color-mix(in srgb, #efb118 12%, var(--paper));
+  }
+
+  .error {
+    background: color-mix(in srgb, #d14d41 10%, var(--paper));
+  }
+
+  .diagnostic p {
+    margin: 0.4rem 0 0;
+  }
+
+  .plot-paper {
+    min-width: 0;
+    overflow: hidden;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .fragment-label {
+    padding: 0.75rem 1rem 0;
+  }
+
+  :global(.copy-code) {
+    margin: 0.5rem 1rem 1rem;
+  }
+
+  @media (max-width: 50rem) {
+    .section-heading,
+    .limit-grid {
+      grid-template-columns: 1fr;
+    }
+
+    .behavior-heading {
+      grid-template-columns: 1fr;
+    }
+
+    .behavior-heading label,
+    select {
+      grid-column: 1;
+      grid-row: auto;
+    }
+  }
+</style>

--- a/apps/docs/src/lib/components/InteractiveThemeSpecimen.svelte
+++ b/apps/docs/src/lib/components/InteractiveThemeSpecimen.svelte
@@ -1,0 +1,282 @@
+<script lang="ts">
+  import { createPlotInteraction, GeomPoint, GGPlot } from "@ggsvelte/svelte";
+  import type { ThemeSpec } from "@ggsvelte/spec";
+
+  import CopyCode from "$lib/components/CopyCode.svelte";
+
+  const rows = [
+    { id: "a-1", period: 1, value: 24, series: "Alpha" },
+    { id: "a-2", period: 2, value: 38, series: "Alpha" },
+    { id: "a-3", period: 3, value: 52, series: "Alpha" },
+    { id: "b-1", period: 1, value: 42, series: "Beta" },
+    { id: "b-2", period: 2, value: 31, series: "Beta" },
+    { id: "b-3", period: 3, value: 61, series: "Beta" },
+    { id: "c-1", period: 1, value: 57, series: "Gamma" },
+    { id: "c-2", period: 2, value: 69, series: "Gamma" },
+    { id: "c-3", period: 3, value: 76, series: "Gamma" },
+  ];
+  const scope = {
+    keys: "theme-specimen-rows",
+    x: "theme-specimen-x",
+    y: "theme-specimen-y",
+  } as const;
+  const interaction = createPlotInteraction<string>();
+  const emphasized = $derived(interaction.emphasized(scope));
+  const selected = $derived(interaction.selected(scope));
+  let paperTheme = $state<"light" | "dark">("light");
+  let status = $state(
+    "Interaction is chart-local until it publishes semantic state.",
+  );
+  const theme = $derived<ThemeSpec>({
+    name: paperTheme,
+    interactionInk: paperTheme === "dark" ? "#f6bd60" : "#17324d",
+    interactionMuted: 0.18,
+    focusRing: "#e63946",
+    crosshair: "#007f8b",
+    selectionFill: "rgba(230, 57, 70, 0.16)",
+    selectionStroke: "#e63946",
+    tooltipPaper: paperTheme === "dark" ? "#242933" : "#fffdf7",
+    tooltipInk: paperTheme === "dark" ? "#f6f7f9" : "#172033",
+    tooltipBorder: "#007f8b",
+    toolActive: "#e63946",
+  });
+  const closeScript = ["</", "script>"].join("");
+  const code = `<script lang="ts">\n  import { createPlotInteraction, GGPlot, type ThemeSpec } from "@ggsvelte/svelte";\n  const interaction = createPlotInteraction<string>();\n  const theme = { name: "light", interactionMuted: 0.18, focusRing: "#e63946", crosshair: "#007f8b", selectionStroke: "#e63946", tooltipPaper: "#fffdf7", tooltipInk: "#172033", tooltipBorder: "#007f8b" } satisfies ThemeSpec;\n${closeScript}\n\n<GGPlot {interaction} {theme} interactionScope={scope} data={rows} key="id" aes={{ x: "period", y: "value", color: "series" }} layers={[{ geom: "point", params: { size: 4 } }]} inspect legendFocus select={{ type: "interval", mode: "xy" }} zoom={{ mode: "x" }} />`;
+
+  function describeLegend(event: {
+    phase: "change" | "clear";
+    state?: string;
+    label?: string;
+    keys?: readonly string[];
+  }): void {
+    status =
+      event.phase === "clear"
+        ? "Shared legend emphasis cleared."
+        : `${event.label ?? "Series"} ${event.state === "committed" ? "pinned" : "previewed"}; ${String(event.keys?.length ?? 0)} shared rows.`;
+  }
+
+  function clearShared(): void {
+    interaction.clearSelection({ scope, source: "programmatic" });
+    interaction.clearEmphasis({ scope, source: "programmatic" });
+    interaction.clearIntervals({ scope, source: "programmatic" });
+    interaction.resetZoom({ scope, source: "programmatic" });
+    status = "Selection, emphasis, and zoom cleared from ordinary Svelte UI.";
+  }
+</script>
+
+<section class="interactive-theme" aria-label="Custom interaction theme">
+  <header class="section-heading">
+    <div>
+      <p class="eyebrow">Custom ThemeSpec</p>
+      <h2>Theme the behavior, not only the backdrop.</h2>
+    </div>
+    <div>
+      <p>
+        Focus, crosshair, selection, tooltip, muted marks, and the active tool
+        use explicit roles. Stable keys carry semantic emphasis between an SVG
+        view and a canvas view.
+      </p>
+      <label for="interaction-paper">Interaction chart paper</label>
+      <select id="interaction-paper" bind:value={paperTheme}>
+        <option value="light">Light</option>
+        <option value="dark">Dark</option>
+      </select>
+    </div>
+  </header>
+
+  <div class="plots">
+    <article>
+      <p class="backend">SVG · local inspect overlays</p>
+      <GGPlot
+        data={rows}
+        aes={{ x: "period", y: "value", color: "series" }}
+        layers={[{ geom: "point", params: { size: 4 } }]}
+        scales={{ color: { type: "ordinal", scheme: "observable10" } }}
+        key="id"
+        inspect
+        select={{ type: "interval", mode: "xy" }}
+        zoom={{ mode: "x" }}
+        legendFocus
+        {interaction}
+        interactionScope={scope}
+        {theme}
+        height={350}
+        labs={{ title: "SVG view", x: "Period", y: "Value", color: "Series" }}
+        ariaLabel="Interactive SVG series with custom theme roles"
+        onlegendfocus={describeLegend}
+      >
+        <GeomPoint size={4} />
+      </GGPlot>
+    </article>
+
+    <article>
+      <p class="backend">Canvas · shared semantic state</p>
+      <GGPlot
+        data={rows}
+        aes={{ x: "period", y: "value", color: "series" }}
+        layers={[{ geom: "point", render: "canvas", params: { size: 4 } }]}
+        scales={{ color: { type: "ordinal", scheme: "observable10" } }}
+        key="id"
+        inspect
+        select={{ type: "interval", mode: "xy" }}
+        zoom={{ mode: "x" }}
+        legendFocus
+        {interaction}
+        interactionScope={scope}
+        {theme}
+        height={350}
+        labs={{
+          title: "Canvas view",
+          x: "Period",
+          y: "Value",
+          color: "Series",
+        }}
+        ariaLabel="Interactive canvas series sharing custom theme state"
+        onlegendfocus={describeLegend}
+      />
+    </article>
+  </div>
+
+  <div class="shared-status">
+    <div>
+      <strong>{emphasized.length} rows emphasized</strong>
+      <span
+        >{selected.length} rows selected · inspect tooltip and crosshair stay chart-local</span
+      >
+      <span role="status">{status}</span>
+    </div>
+    <button type="button" onclick={clearShared}>Clear shared state</button>
+  </div>
+
+  <p class="fragment-label">
+    Svelte component excerpt · provide your own rows and scope
+  </p>
+  <CopyCode {code} label="Copy interaction theme code" />
+</section>
+
+<style>
+  .interactive-theme {
+    padding-block: clamp(4rem, 9vw, 8rem);
+    border-top: 1px solid var(--line);
+  }
+
+  .eyebrow,
+  .backend,
+  .fragment-label {
+    margin: 0;
+    color: var(--muted);
+    font-size: 0.7rem;
+    font-weight: 650;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .section-heading {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(18rem, 0.55fr);
+    gap: clamp(2rem, 7vw, 7rem);
+    align-items: end;
+    margin-bottom: 2rem;
+  }
+
+  h2 {
+    max-width: 11ch;
+    margin: 0.25rem 0 0;
+    font-size: clamp(2.5rem, 5vw, 4.75rem);
+    line-height: 0.94;
+  }
+
+  .section-heading > div:last-child > p {
+    color: var(--muted);
+  }
+
+  .section-heading label {
+    display: block;
+    margin-top: 1rem;
+    color: var(--muted);
+    font-size: 0.75rem;
+    font-weight: 650;
+  }
+
+  select {
+    width: 100%;
+    min-height: 44px;
+    margin-top: 0.35rem;
+    padding: 0.6rem;
+    border: 1px solid var(--line-strong);
+    border-radius: 2px;
+    background: var(--paper);
+    color: var(--ink);
+    font: inherit;
+  }
+
+  .plots {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1rem;
+  }
+
+  article {
+    min-width: 0;
+    overflow: hidden;
+    border: 1px solid var(--line);
+    background: var(--paper);
+  }
+
+  .backend {
+    padding: 0.75rem 1rem;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .shared-status {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 1rem;
+    border: 1px solid var(--line);
+    border-top: 0;
+  }
+
+  .shared-status > div {
+    display: grid;
+    gap: 0.15rem;
+  }
+
+  .shared-status span {
+    color: var(--muted);
+    font-size: 0.78rem;
+  }
+
+  button {
+    min-height: 44px;
+    padding: 0.6rem 0.8rem;
+    border: 1px solid var(--line-strong);
+    border-radius: 2px;
+    background: var(--paper);
+    color: var(--ink);
+    font: 600 0.82rem/1 var(--body-font);
+  }
+
+  .fragment-label {
+    margin-top: 1.25rem;
+  }
+
+  :global(.copy-code) {
+    margin-top: 0.5rem;
+  }
+
+  @media (max-width: 58rem) {
+    .plots,
+    .section-heading {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  @media (max-width: 38rem) {
+    .shared-status {
+      align-items: stretch;
+      flex-direction: column;
+    }
+  }
+</style>

--- a/apps/docs/src/lib/components/PaletteGallery.svelte
+++ b/apps/docs/src/lib/components/PaletteGallery.svelte
@@ -1,0 +1,153 @@
+<script lang="ts">
+  import { CATEGORICAL_PALETTES } from "$lib/catalog/themes";
+  import PaletteSpecimen from "$lib/components/PaletteSpecimen.svelte";
+
+  let reverse = $state(false);
+  let paperTheme = $state<"light" | "dark">("light");
+</script>
+
+<section class="palette-gallery" aria-label="Categorical color schemes">
+  <header class="section-heading">
+    <div>
+      <p class="eyebrow">Categorical color</p>
+      <h2>Keep identity stable and capacity explicit.</h2>
+    </div>
+    <div>
+      <p>
+        Named schemes preserve category identity across chart themes. Capacity
+        tells you when a palette will repeat instead of pretending every
+        category is unique.
+      </p>
+      <div class="controls">
+        <div class="select-control">
+          <label for="palette-paper">Chart paper</label>
+          <select id="palette-paper" bind:value={paperTheme}>
+            <option value="light">Light</option>
+            <option value="dark">Dark</option>
+          </select>
+        </div>
+        <label class="check-control">
+          <input type="checkbox" bind:checked={reverse} />
+          <span>Reverse palettes</span>
+        </label>
+      </div>
+    </div>
+  </header>
+
+  <ol aria-label="Categorical palettes">
+    {#each CATEGORICAL_PALETTES as palette (palette.name)}
+      <li>
+        <PaletteSpecimen
+          name={palette.name}
+          label={palette.label}
+          colors={palette.colors}
+          capacity={palette.capacity}
+          {reverse}
+          {paperTheme}
+        />
+      </li>
+    {/each}
+  </ol>
+</section>
+
+<style>
+  .palette-gallery {
+    padding-block: clamp(4rem, 9vw, 8rem);
+    border-top: 1px solid var(--line);
+  }
+
+  .eyebrow {
+    margin: 0;
+    color: var(--muted);
+    font-size: 0.75rem;
+    font-weight: 650;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .section-heading {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(18rem, 0.55fr);
+    gap: clamp(2rem, 7vw, 7rem);
+    align-items: end;
+    margin-bottom: 2rem;
+  }
+
+  h2 {
+    max-width: 12ch;
+    margin: 0.25rem 0 0;
+    font-size: clamp(2.5rem, 5vw, 4.75rem);
+    line-height: 0.94;
+  }
+
+  .section-heading > div:last-child > p {
+    color: var(--muted);
+  }
+
+  .controls {
+    display: grid;
+    grid-template-columns: minmax(9rem, 1fr) minmax(10rem, 1fr);
+    gap: 0.75rem;
+    margin-top: 1.25rem;
+  }
+
+  .select-control {
+    display: grid;
+    gap: 0.35rem;
+    font-size: 0.78rem;
+    font-weight: 650;
+  }
+
+  select {
+    min-height: 44px;
+    padding: 0.6rem;
+    border: 1px solid var(--line-strong);
+    border-radius: 2px;
+    background: var(--paper);
+    color: var(--ink);
+    font: inherit;
+  }
+
+  .check-control {
+    display: flex;
+    gap: 0.6rem;
+    align-items: center;
+    min-height: 44px;
+    padding-top: 1rem;
+    font-size: 0.86rem;
+    font-weight: 600;
+  }
+
+  .check-control input {
+    width: 1.15rem;
+    height: 1.15rem;
+  }
+
+  ol {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1.25rem;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  ol > li {
+    min-width: 0;
+  }
+
+  @media (max-width: 50rem) {
+    .section-heading,
+    ol {
+      grid-template-columns: 1fr;
+    }
+
+    .controls {
+      grid-template-columns: 1fr;
+    }
+
+    .check-control {
+      padding-top: 0;
+    }
+  }
+</style>

--- a/apps/docs/src/lib/components/PaletteSpecimen.svelte
+++ b/apps/docs/src/lib/components/PaletteSpecimen.svelte
@@ -1,0 +1,150 @@
+<script lang="ts">
+  import { GeomPoint, GGPlot } from "@ggsvelte/svelte";
+  import type { ThemeName } from "@ggsvelte/spec";
+
+  import CopyCode from "$lib/components/CopyCode.svelte";
+
+  const {
+    name,
+    label,
+    colors,
+    capacity,
+    reverse,
+    paperTheme,
+  }: {
+    name: "observable10" | "ipsum" | "flexoki" | "tableau10" | "colorblind";
+    label: string;
+    colors: readonly string[];
+    capacity: number;
+    reverse: boolean;
+    paperTheme: ThemeName;
+  } = $props();
+
+  const rows = [
+    { signal: 1, value: 22, category: "Alpha" },
+    { signal: 2, value: 37, category: "Beta" },
+    { signal: 3, value: 29, category: "Gamma" },
+    { signal: 4, value: 55, category: "Delta" },
+    { signal: 5, value: 46, category: "Epsilon" },
+  ];
+  const displayColors = $derived(reverse ? colors.toReversed() : colors);
+  const code = $derived(
+    `<GGPlot\n  data={rows}\n  aes={{ x: "signal", y: "value", color: "category" }}\n  scales={{ color: { scheme: "${name}", reverse: ${String(reverse)} } }}\n  theme="${paperTheme}"\n>\n  <GeomPoint size={4} />\n</GGPlot>`,
+  );
+</script>
+
+<article>
+  <header>
+    <div>
+      <p>Named categorical scheme</p>
+      <h3>{label}</h3>
+    </div>
+    <strong>{capacity} colors</strong>
+  </header>
+
+  <ul class="swatches" aria-label={`${label} ordered colors`}>
+    {#each displayColors as color, index (`${color}-${String(index)}`)}
+      <li
+        style={`--swatch:${color}`}
+        aria-label={`${String(index + 1)}: ${color}`}
+      >
+        <span aria-hidden="true"></span><code>{color}</code>
+      </li>
+    {/each}
+  </ul>
+
+  <div class="plot-paper">
+    <GGPlot
+      data={rows}
+      aes={{ x: "signal", y: "value", color: "category" }}
+      scales={{ color: { type: "ordinal", scheme: name, reverse } }}
+      theme={paperTheme}
+      height={245}
+      ariaLabel={`${label} categorical color scheme on ${paperTheme} chart paper`}
+    >
+      <GeomPoint size={4} />
+    </GGPlot>
+  </div>
+
+  <p class="fragment-label">Svelte fragment</p>
+  <CopyCode {code} label={`Copy ${label} palette code`} />
+</article>
+
+<style>
+  article {
+    min-width: 0;
+    height: 100%;
+    border: 1px solid var(--line);
+    background: var(--paper);
+  }
+
+  header {
+    display: flex;
+    align-items: start;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 1rem;
+  }
+
+  header p,
+  .fragment-label {
+    margin: 0;
+    color: var(--muted);
+    font-size: 0.68rem;
+    font-weight: 650;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  h3 {
+    margin: 0.2rem 0 0;
+    font-size: 1.4rem;
+  }
+
+  header strong {
+    color: var(--muted);
+    font-size: 0.78rem;
+    white-space: nowrap;
+  }
+
+  .swatches {
+    display: flex;
+    min-width: 0;
+    margin: 0;
+    padding: 0 1rem 1rem;
+    overflow-x: auto;
+    list-style: none;
+  }
+
+  .swatches li {
+    display: grid;
+    flex: 0 0 3.5rem;
+    gap: 0.35rem;
+  }
+
+  .swatches span {
+    display: block;
+    height: 1.5rem;
+    border: 1px solid color-mix(in srgb, var(--swatch), #000 18%);
+    background: var(--swatch);
+  }
+
+  .swatches code {
+    color: var(--muted);
+    font-size: 0.6rem;
+  }
+
+  .plot-paper {
+    min-width: 0;
+    overflow: hidden;
+    border-block: 1px solid var(--line);
+  }
+
+  .fragment-label {
+    padding: 0.75rem 1rem 0;
+  }
+
+  :global(.copy-code) {
+    margin: 0.5rem 1rem 1rem;
+  }
+</style>

--- a/apps/docs/src/lib/components/SequentialColorLab.svelte
+++ b/apps/docs/src/lib/components/SequentialColorLab.svelte
@@ -1,0 +1,213 @@
+<script lang="ts">
+  import { GeomPoint, GGPlot } from "@ggsvelte/svelte";
+  import type { ColorScaleSpec } from "@ggsvelte/spec";
+
+  import { VIRIDIS_COLORS } from "$lib/catalog/themes";
+  import CopyCode from "$lib/components/CopyCode.svelte";
+
+  interface SequentialExample {
+    label: string;
+    note: string;
+    scale: ColorScaleSpec;
+    setting: string;
+  }
+
+  const rows = [
+    { sequence: 1, score: 18, intensity: 0 },
+    { sequence: 2, score: 28, intensity: 20 },
+    { sequence: 3, score: 39, intensity: 40 },
+    { sequence: 4, score: 53, intensity: 60 },
+    { sequence: 5, score: 67, intensity: 80 },
+    { sequence: 6, score: 82, intensity: 100 },
+  ];
+
+  const examples: readonly SequentialExample[] = [
+    {
+      label: "Viridis",
+      note: "Perceptually ordered from low to high.",
+      scale: { type: "sequential", scheme: "viridis" },
+      setting: 'scheme: "viridis"',
+    },
+    {
+      label: "Reversed viridis",
+      note: "Keep the scale; reverse its visual direction.",
+      scale: { type: "sequential", scheme: "viridis", reverse: true },
+      setting: 'scheme: "viridis", reverse: true',
+    },
+    {
+      label: "Custom range",
+      note: "Use supported hex stops for a publication-specific ramp.",
+      scale: { type: "sequential", range: ["#2d1e2f", "#3d5a80", "#e76f51"] },
+      setting: 'range: ["#2d1e2f", "#3d5a80", "#e76f51"]',
+    },
+    {
+      label: "Pinned domain",
+      note: "Hold the meaning of color steady across changing data.",
+      scale: { type: "sequential", scheme: "viridis", domain: [0, 100] },
+      setting: 'scheme: "viridis", domain: [0, 100]',
+    },
+  ];
+
+  function snippet(example: SequentialExample): string {
+    return `<GGPlot\n  data={rows}\n  aes={{ x: "sequence", y: "score", color: "intensity" }}\n  scales={{ color: { ${example.setting} } }}\n>\n  <GeomPoint size={4} />\n</GGPlot>`;
+  }
+</script>
+
+<section class="sequential-lab" aria-label="Sequential color scales">
+  <header class="section-heading">
+    <div>
+      <p class="eyebrow">Quantitative color</p>
+      <h2>Make direction and domain visible.</h2>
+    </div>
+    <div>
+      <p>
+        Sequential color encodes order. Reverse the public ramp instead of
+        rebuilding it, or pin a domain when two charts must share the same
+        meaning.
+      </p>
+      <ol class="viridis-ramp" aria-label="Viridis reference colors">
+        {#each VIRIDIS_COLORS as color, index (`${color}-${String(index)}`)}
+          <li
+            style={`--swatch:${color}`}
+            aria-label={`${String(index + 1)}: ${color}`}
+          ></li>
+        {/each}
+      </ol>
+    </div>
+  </header>
+
+  <ol class="examples" aria-label="Sequential scale examples">
+    {#each examples as example (example.label)}
+      <li>
+        <article>
+          <header>
+            <p>Sequential scale</p>
+            <h3>{example.label}</h3>
+            <span>{example.note}</span>
+          </header>
+          <div class="plot-paper">
+            <GGPlot
+              data={rows}
+              aes={{ x: "sequence", y: "score", color: "intensity" }}
+              scales={{ color: example.scale }}
+              theme="light"
+              height={265}
+              ariaLabel={`${example.label} sequential color example`}
+            >
+              <GeomPoint size={4} />
+            </GGPlot>
+          </div>
+          <p class="fragment-label">Svelte fragment</p>
+          <CopyCode
+            code={snippet(example)}
+            label={`Copy ${example.label} code`}
+          />
+        </article>
+      </li>
+    {/each}
+  </ol>
+</section>
+
+<style>
+  .sequential-lab {
+    padding-block: clamp(4rem, 9vw, 8rem);
+    border-top: 1px solid var(--line);
+  }
+
+  .eyebrow,
+  article header p,
+  .fragment-label {
+    margin: 0;
+    color: var(--muted);
+    font-size: 0.7rem;
+    font-weight: 650;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .section-heading {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(18rem, 0.55fr);
+    gap: clamp(2rem, 7vw, 7rem);
+    align-items: end;
+    margin-bottom: 2rem;
+  }
+
+  h2 {
+    max-width: 10ch;
+    margin: 0.25rem 0 0;
+    font-size: clamp(2.5rem, 5vw, 4.75rem);
+    line-height: 0.94;
+  }
+
+  .section-heading > div:last-child > p,
+  article header span {
+    color: var(--muted);
+  }
+
+  .viridis-ramp {
+    display: flex;
+    height: 1.5rem;
+    margin: 1rem 0 0;
+    padding: 0;
+    overflow: hidden;
+    border: 1px solid var(--line);
+    list-style: none;
+  }
+
+  .viridis-ramp li {
+    flex: 1;
+    background: var(--swatch);
+  }
+
+  .examples {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1.25rem;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  article {
+    min-width: 0;
+    height: 100%;
+    border: 1px solid var(--line);
+    background: var(--paper);
+  }
+
+  article > header {
+    min-height: 8.25rem;
+    padding: 1rem;
+  }
+
+  h3 {
+    margin: 0.2rem 0 0.55rem;
+    font-size: 1.5rem;
+  }
+
+  article header span {
+    font-size: 0.86rem;
+  }
+
+  .plot-paper {
+    min-width: 0;
+    overflow: hidden;
+    border-block: 1px solid var(--line);
+  }
+
+  .fragment-label {
+    padding: 0.75rem 1rem 0;
+  }
+
+  :global(.copy-code) {
+    margin: 0.5rem 1rem 1rem;
+  }
+
+  @media (max-width: 50rem) {
+    .section-heading,
+    .examples {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/apps/docs/src/lib/components/SiteFooter.svelte
+++ b/apps/docs/src/lib/components/SiteFooter.svelte
@@ -11,6 +11,7 @@
     <nav aria-label="Footer">
       <a href={`${base}/guide/getting-started`}>Docs</a>
       <a href={`${base}/examples`}>Gallery</a>
+      <a href={`${base}/themes`}>Themes</a>
       <a href={`${base}/reference/interactions`}>Reference</a>
       <a href={`${base}/schema/v0.json`}>JSON Schema</a>
       <a href="https://github.com/ljodea/ggsvelte" rel="external">GitHub ↗</a>

--- a/apps/docs/src/lib/components/SiteHeader.svelte
+++ b/apps/docs/src/lib/components/SiteHeader.svelte
@@ -24,6 +24,11 @@
       active: path === "/playground",
     },
     {
+      label: "Themes",
+      href: "/themes",
+      active: path === "/themes",
+    },
+    {
       label: "Reference",
       href: "/reference/interactions",
       active: path.startsWith("/reference"),

--- a/apps/docs/src/lib/components/ThemeSpecimen.svelte
+++ b/apps/docs/src/lib/components/ThemeSpecimen.svelte
@@ -1,0 +1,102 @@
+<script lang="ts">
+  import { GeomPoint, GGPlot } from "@ggsvelte/svelte";
+  import type { ThemeName } from "@ggsvelte/spec";
+
+  import CopyCode from "$lib/components/CopyCode.svelte";
+
+  const {
+    name,
+    label,
+  }: {
+    name: ThemeName;
+    label: string;
+  } = $props();
+
+  const rows = [
+    { release: 1, response: 18, group: "North" },
+    { release: 2, response: 31, group: "North" },
+    { release: 3, response: 43, group: "North" },
+    { release: 4, response: 56, group: "North" },
+    { release: 1, response: 27, group: "South" },
+    { release: 2, response: 39, group: "South" },
+    { release: 3, response: 52, group: "South" },
+    { release: 4, response: 68, group: "South" },
+  ];
+  const code = $derived(
+    `<GGPlot data={rows} aes={{ x: "release", y: "response", color: "group" }} theme="${name}">\n  <GeomPoint size={3.5} />\n</GGPlot>`,
+  );
+</script>
+
+<article>
+  <header>
+    <div>
+      <p>Built-in chart theme</p>
+      <h3>{label}</h3>
+    </div>
+    <code>{name}</code>
+  </header>
+  <div class="plot-paper">
+    <GGPlot
+      data={rows}
+      aes={{ x: "release", y: "response", color: "group" }}
+      theme={name}
+      height={230}
+      ariaLabel={`${label} theme applied to the controlled release and response chart`}
+    >
+      <GeomPoint size={3.5} />
+    </GGPlot>
+  </div>
+  <p class="fragment-label">Svelte fragment</p>
+  <CopyCode {code} label={`Copy ${label} theme code`} />
+</article>
+
+<style>
+  article {
+    min-width: 0;
+    height: 100%;
+    border: 1px solid var(--line);
+    background: var(--paper);
+  }
+
+  header {
+    display: flex;
+    align-items: start;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 1rem;
+  }
+
+  header p,
+  .fragment-label {
+    margin: 0;
+    color: var(--muted);
+    font-size: 0.68rem;
+    font-weight: 650;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  h3 {
+    margin: 0.2rem 0 0;
+    font-size: 1.4rem;
+  }
+
+  header > code {
+    color: var(--muted);
+    font-size: 0.72rem;
+  }
+
+  .plot-paper {
+    min-width: 0;
+    overflow: hidden;
+    border-block: 1px solid var(--line);
+  }
+
+  .fragment-label {
+    padding: 0.75rem 1rem 0;
+  }
+
+  :global(.copy-code) {
+    margin: 0.5rem 1rem 1rem;
+  }
+</style>

--- a/apps/docs/src/lib/generated/routes.ts
+++ b/apps/docs/src/lib/generated/routes.ts
@@ -36,6 +36,17 @@ export const DOCS_ROUTES = [
     shell: "site",
   },
   {
+    path: "/themes",
+    title: "Chart themes and color scales — ggsvelte",
+    description:
+      "Compare every built-in ggsvelte chart theme and color scheme with live, copyable Svelte examples.",
+    canonicalPath: "/themes",
+    kind: "page",
+    index: true,
+    sitemap: true,
+    shell: "site",
+  },
+  {
     path: "/reference/interactions",
     title: "Interaction reference — ggsvelte",
     description:

--- a/apps/docs/src/routes/+page.svelte
+++ b/apps/docs/src/routes/+page.svelte
@@ -127,6 +127,13 @@
       </dd>
     </div>
     <div>
+      <dt>Can I control the chart’s visual system?</dt>
+      <dd>
+        <a href={`${base}/themes`}>Compare chart themes</a>, palettes, and
+        interaction roles.
+      </dd>
+    </div>
+    <div>
       <dt>What happens when a spec is wrong?</dt>
       <dd>
         <a href={`${base}/guide/errors`}

--- a/apps/docs/src/routes/themes/+page.svelte
+++ b/apps/docs/src/routes/themes/+page.svelte
@@ -1,0 +1,145 @@
+<script lang="ts">
+  import { THEME_OPTIONS } from "$lib/catalog/themes";
+  import ChartThemeLab from "$lib/components/ChartThemeLab.svelte";
+  import ColorFailureDemo from "$lib/components/ColorFailureDemo.svelte";
+  import InteractiveThemeSpecimen from "$lib/components/InteractiveThemeSpecimen.svelte";
+  import PaletteGallery from "$lib/components/PaletteGallery.svelte";
+  import SequentialColorLab from "$lib/components/SequentialColorLab.svelte";
+  import ThemeSpecimen from "$lib/components/ThemeSpecimen.svelte";
+</script>
+
+<main class="themes-page">
+  <header class="themes-hero">
+    <p class="eyebrow">Themes & color</p>
+    <h1>Design the chart, not the plumbing.</h1>
+    <p>
+      Compare every built-in chart theme on the same data, then choose
+      categorical and sequential color behavior with explicit, portable scale
+      settings.
+    </p>
+  </header>
+
+  <ChartThemeLab />
+
+  <section class="theme-collection" aria-labelledby="built-in-themes-heading">
+    <header class="section-heading">
+      <div>
+        <p class="eyebrow">Twelve registered themes</p>
+        <h2 id="built-in-themes-heading">One chart. Twelve visual systems.</h2>
+      </div>
+      <p>
+        Data, mappings, layers, labels, and dimensions stay fixed. Only the
+        chart theme changes.
+      </p>
+    </header>
+    <ol aria-label="Built-in chart themes">
+      {#each THEME_OPTIONS as theme (theme.name)}
+        <li><ThemeSpecimen name={theme.name} label={theme.label} /></li>
+      {/each}
+    </ol>
+  </section>
+
+  <PaletteGallery />
+  <SequentialColorLab />
+  <ColorFailureDemo />
+  <InteractiveThemeSpecimen />
+</main>
+
+<style>
+  .themes-page {
+    padding-bottom: clamp(4rem, 9vw, 8rem);
+  }
+
+  .themes-hero {
+    display: grid;
+    grid-template-columns: minmax(0, 1.15fr) minmax(18rem, 0.55fr);
+    gap: clamp(2rem, 7vw, 7rem);
+    align-items: end;
+    min-height: min(46rem, calc(100svh - 8rem));
+    padding-block: clamp(4rem, 9vw, 8rem);
+  }
+
+  .themes-hero h1 {
+    grid-column: 1;
+    max-width: 10ch;
+    margin: 0.35rem 0 0;
+    font-size: clamp(4rem, 8vw, 8rem);
+    line-height: 0.84;
+    letter-spacing: -0.045em;
+  }
+
+  .themes-hero > p:last-child {
+    grid-column: 2;
+    margin: 0 0 0.5rem;
+    color: var(--muted);
+    font-size: 1.05rem;
+  }
+
+  .eyebrow {
+    margin: 0;
+    color: var(--muted);
+    font-size: 0.75rem;
+    font-weight: 650;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .theme-collection {
+    padding-block: clamp(4rem, 8vw, 7rem);
+    border-top: 1px solid var(--line);
+  }
+
+  .section-heading {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(16rem, 0.45fr);
+    gap: 2rem;
+    align-items: end;
+    margin-bottom: 2rem;
+  }
+
+  .section-heading h2 {
+    max-width: 12ch;
+    margin: 0.25rem 0 0;
+    font-size: clamp(2.5rem, 5vw, 4.75rem);
+    line-height: 0.94;
+  }
+
+  .section-heading > p {
+    color: var(--muted);
+  }
+
+  ol {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 1.25rem;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  @media (max-width: 72rem) {
+    ol {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+
+  @media (max-width: 50rem) {
+    .themes-hero,
+    .section-heading {
+      grid-template-columns: 1fr;
+    }
+
+    .themes-hero {
+      min-height: 0;
+    }
+
+    .themes-hero h1,
+    .themes-hero > p:last-child {
+      grid-column: 1;
+    }
+
+    ol {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/bun.lock
+++ b/bun.lock
@@ -31,6 +31,7 @@
       "name": "@ggsvelte/docs",
       "version": "0.0.0",
       "dependencies": {
+        "@ggsvelte/core": "workspace:*",
         "@ggsvelte/examples": "workspace:*",
         "@ggsvelte/spec": "workspace:*",
         "@ggsvelte/svelte": "workspace:*",
@@ -70,9 +71,9 @@
     },
     "packages/core": {
       "name": "@ggsvelte/core",
-      "version": "0.2.0",
+      "version": "0.3.1",
       "dependencies": {
-        "@ggsvelte/spec": "^0.2.0",
+        "@ggsvelte/spec": "^0.3.1",
       },
       "devDependencies": {
         "typescript": "^6.0.3",
@@ -80,7 +81,7 @@
     },
     "packages/spec": {
       "name": "@ggsvelte/spec",
-      "version": "0.2.0",
+      "version": "0.3.1",
       "dependencies": {
         "typebox": "^1.3.6",
       },
@@ -91,13 +92,13 @@
     },
     "packages/svelte": {
       "name": "@ggsvelte/svelte",
-      "version": "0.2.1",
+      "version": "0.3.1",
       "bin": {
         "ggsvelte-render": "bin/ggsvelte-render.js",
       },
       "dependencies": {
-        "@ggsvelte/core": "^0.2.0",
-        "@ggsvelte/spec": "^0.2.0",
+        "@ggsvelte/core": "^0.3.1",
+        "@ggsvelte/spec": "^0.3.1",
       },
       "devDependencies": {
         "@sveltejs/package": "^2.5.8",

--- a/scripts/check-pages-links.test.ts
+++ b/scripts/check-pages-links.test.ts
@@ -18,6 +18,7 @@ describe("packed Pages link checks", () => {
     "guide/migrating-pre-0-1.html",
     "guide/upgrading.html",
     "playground.html",
+    "themes.html",
     "reference/interactions.html",
     "examples/interaction/tooltip.html",
     "examples/interaction/brush-zoom.html",
@@ -85,6 +86,7 @@ describe("packed Pages link checks", () => {
     expect(requiredPages).toContain("examples/interactions/inspection.html");
     expect(requiredPages).toContain("examples/interactions/interval-selection.html");
     expect(requiredPages).toContain("playground.html");
+    expect(requiredPages).toContain("themes.html");
     expect(requiredPages).toContain("reference/interactions.html");
     expect(requiredPages).toContain("guide/interaction-reference.html");
     expect(requiredPages).toContain("robots.txt");

--- a/scripts/check-pages-links.ts
+++ b/scripts/check-pages-links.ts
@@ -10,6 +10,7 @@ export const requiredPages = [
   "guide/migrating-pre-0-1.html",
   "guide/upgrading.html",
   "playground.html",
+  "themes.html",
   "reference/interactions.html",
   "examples/interaction/tooltip.html",
   "examples/interaction/brush-zoom.html",

--- a/scripts/docs-route-inventory.test.ts
+++ b/scripts/docs-route-inventory.test.ts
@@ -30,6 +30,7 @@ describe("docs route inventory", () => {
     expect(paths.has("/examples/point/scatter-color")).toBe(true);
     expect(paths.has("/examples/interactions/inspection")).toBe(true);
     expect(paths.has("/playground")).toBe(true);
+    expect(paths.has("/themes")).toBe(true);
     expect(paths.has("/reference/interactions")).toBe(true);
     expect(paths.has("/__perf/r3-interaction")).toBe(true);
     expect(paths.has("/sitemap.xml")).toBe(true);
@@ -37,6 +38,20 @@ describe("docs route inventory", () => {
 
     expect(validateRouteInventory(inventory)).toBe(inventory);
     expect(JSON.parse(JSON.stringify(inventory))).toEqual(inventory);
+  });
+
+  it("publishes the themes destination with canonical acquisition metadata", () => {
+    expect(createDocsRouteInventory().find((entry) => entry.path === "/themes")).toEqual({
+      path: "/themes",
+      title: "Chart themes and color scales — ggsvelte",
+      description:
+        "Compare every built-in ggsvelte chart theme and color scheme with live, copyable Svelte examples.",
+      canonicalPath: "/themes",
+      kind: "page",
+      index: true,
+      sitemap: true,
+      shell: "site",
+    });
   });
 
   it("keeps aliases canonicalized, noindex, and out of the sitemap", () => {

--- a/scripts/docs-route-inventory.ts
+++ b/scripts/docs-route-inventory.ts
@@ -65,6 +65,17 @@ const TOP_LEVEL_ROUTES: readonly DocsRouteRecord[] = [
     shell: "site",
   },
   {
+    path: "/themes",
+    title: "Chart themes and color scales — ggsvelte",
+    description:
+      "Compare every built-in ggsvelte chart theme and color scheme with live, copyable Svelte examples.",
+    canonicalPath: "/themes",
+    kind: "page",
+    index: true,
+    sitemap: true,
+    shell: "site",
+  },
+  {
     path: "/reference/interactions",
     title: "Interaction reference — ggsvelte",
     description:

--- a/scripts/themes-page.test.ts
+++ b/scripts/themes-page.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  CATEGORICAL_PALETTES,
+  THEME_OPTIONS,
+  VIRIDIS_COLORS,
+} from "../apps/docs/src/lib/catalog/themes.ts";
+import { colorBehaviorEvidence } from "../apps/docs/src/lib/color-evidence.ts";
+
+describe("themes catalog", () => {
+  it("projects every public theme and categorical palette without docs-owned colors", () => {
+    expect(THEME_OPTIONS.map(({ name }) => name)).toEqual([
+      "default",
+      "light",
+      "dark",
+      "minimal",
+      "ggplot2",
+      "classic",
+      "hrbr",
+      "few",
+      "clean",
+      "fivethirtyeight",
+      "economist",
+      "tufte",
+    ]);
+
+    expect(CATEGORICAL_PALETTES).toEqual([
+      {
+        name: "observable10",
+        label: "Observable 10",
+        capacity: 10,
+        colors: [
+          "#4269d0",
+          "#efb118",
+          "#ff725c",
+          "#6cc5b0",
+          "#3ca951",
+          "#ff8ab7",
+          "#a463f2",
+          "#97bbf5",
+          "#9c6b4e",
+          "#9498a0",
+        ],
+      },
+      {
+        name: "ipsum",
+        label: "Ipsum",
+        capacity: 9,
+        colors: [
+          "#d18975",
+          "#8fd175",
+          "#3f2d54",
+          "#75b8d1",
+          "#2d543d",
+          "#c9d175",
+          "#d1ab75",
+          "#d175b8",
+          "#758bd1",
+        ],
+      },
+      {
+        name: "flexoki",
+        label: "Flexoki",
+        capacity: 8,
+        colors: [
+          "#D14D41",
+          "#DA702C",
+          "#D0A215",
+          "#879A39",
+          "#3AA99F",
+          "#4385BE",
+          "#8B7EC8",
+          "#CE5D97",
+        ],
+      },
+      {
+        name: "tableau10",
+        label: "Tableau 10",
+        capacity: 10,
+        colors: [
+          "#4E79A7",
+          "#F28E2B",
+          "#E15759",
+          "#76B7B2",
+          "#59A14F",
+          "#EDC948",
+          "#B07AA1",
+          "#FF9DA7",
+          "#9C755F",
+          "#BAB0AC",
+        ],
+      },
+      {
+        name: "colorblind",
+        label: "Colorblind",
+        capacity: 8,
+        colors: [
+          "#000000",
+          "#E69F00",
+          "#56B4E9",
+          "#009E73",
+          "#F0E442",
+          "#0072B2",
+          "#D55E00",
+          "#CC79A7",
+        ],
+      },
+    ]);
+
+    expect(VIRIDIS_COLORS).toEqual([
+      "#440154",
+      "#482878",
+      "#3e4989",
+      "#31688e",
+      "#26828e",
+      "#1f9e89",
+      "#35b779",
+      "#6ece58",
+      "#b5de2b",
+      "#fde725",
+    ]);
+  });
+
+  it("reports incompatible schemes and palette exhaustion through public boundaries", () => {
+    expect(colorBehaviorEvidence()).toEqual({
+      incompatible: {
+        code: "scale-scheme-type",
+        path: "/scales/color/scheme",
+        message: 'The sequential scheme "viridis" cannot be used with an ordinal color scale.',
+        fix: "Use a categorical scheme or provide an ordinal range of CSS colors.",
+      },
+      cycle: {
+        code: "palette-exhausted",
+        message:
+          "More than 2 discrete values; cycling the palette. Consider an explicit domain or a larger range. (Warned once.)",
+      },
+      error: {
+        code: "palette-exhausted",
+        path: "/scales/color",
+        message:
+          "Palette exhausted: 3 discrete values but range has only 2 entries and onExhaust is 'error'. Provide a larger range or an explicit domain.",
+      },
+    });
+  });
+});

--- a/tests/visual/docs-themes.spec.ts
+++ b/tests/visual/docs-themes.spec.ts
@@ -1,0 +1,289 @@
+import { expect, test } from "@playwright/test";
+
+test("themes is a first-class route from site navigation and the homepage", async ({ page }) => {
+  await page.goto("/themes?theme=light");
+  await expect(
+    page.getByRole("navigation", { name: "Primary" }).getByRole("link", { name: "Themes" }),
+  ).toHaveAttribute("aria-current", "page");
+  await expect(
+    page.getByRole("navigation", { name: "Footer" }).getByRole("link", { name: "Themes" }),
+  ).toBeVisible();
+
+  await page.goto("/?theme=light");
+  await expect(page.getByRole("link", { name: "Compare chart themes" })).toHaveAttribute(
+    "href",
+    /\/themes$/,
+  );
+});
+
+test("theme code uses the shared manual-copy fallback", async ({ page }) => {
+  await page.addInitScript(() => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: () => Promise.reject(new DOMException("Denied", "NotAllowedError")) },
+    });
+  });
+  await page.goto("/themes?theme=light");
+  const defaultCard = page
+    .getByRole("list", { name: "Built-in chart themes" })
+    .locator(":scope > li")
+    .first();
+  await defaultCard.getByRole("button", { name: "Copy Default theme code" }).click();
+  await expect(defaultCard.getByRole("status")).toHaveText(
+    "Clipboard unavailable. Code selected for manual copy.",
+  );
+  expect(await page.evaluate(() => getSelection()?.toString())).toContain('theme="default"');
+});
+
+test("themes compares all built-in chart themes on the same live chart", async ({ page }) => {
+  await page.goto("/themes?theme=light");
+
+  const list = page.getByRole("list", { name: "Built-in chart themes" });
+  const specimens = list.getByRole("listitem");
+  await expect(specimens).toHaveCount(12);
+  await expect(specimens.getByRole("heading", { level: 3 })).toHaveText([
+    "Default",
+    "Light",
+    "Dark",
+    "Minimal",
+    "ggplot2",
+    "Classic",
+    "HRBR",
+    "Few",
+    "Clean",
+    "FiveThirtyEight",
+    "Economist",
+    "Tufte",
+  ]);
+
+  for (const specimen of await specimens.all()) {
+    await expect(specimen.locator(".gg-plot-root")).toHaveAttribute("data-gg-ready", "true");
+    await expect(specimen.locator(".gg-points circle")).toHaveCount(8);
+    await expect(specimen.getByRole("button", { name: /^Copy .+ theme code$/ })).toBeVisible();
+  }
+});
+
+test("chart theme stays separate until follow-docs appearance is explicit", async ({ page }) => {
+  await page.goto("/themes?theme=light");
+
+  const lab = page.getByRole("region", { name: "Chart theme lab" });
+  const chartTheme = lab.getByLabel("Chart theme", { exact: true });
+  const follow = lab.getByRole("checkbox", { name: "Follow docs appearance" });
+  const plot = lab.locator(".gg-plot-root");
+  const chartPaper = () => plot.locator(".gg-paper").getAttribute("fill");
+
+  await chartTheme.selectOption("economist");
+  await expect(lab.locator(".copy-code code")).toContainText('theme="economist"');
+  await expect.poll(chartPaper).toBe("var(--gg-paper, #d5e4eb)");
+  await page.getByRole("button", { name: "Dark appearance" }).click();
+  await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
+  await expect.poll(chartPaper).toBe("var(--gg-paper, #d5e4eb)");
+
+  await follow.check();
+  await expect(lab.locator(".copy-code code")).toContainText('theme="dark"');
+  await expect.poll(chartPaper).toBe("var(--gg-paper, #16181d)");
+  await page.getByRole("button", { name: "Light appearance" }).click();
+  await expect.poll(chartPaper).toBe("var(--gg-paper, #ffffff)");
+
+  await follow.uncheck();
+  await expect(chartTheme).toHaveValue("economist");
+  await expect.poll(chartPaper).toBe("var(--gg-paper, #d5e4eb)");
+});
+
+test("categorical schemes show exact ordered colors and explicit behavior", async ({ page }) => {
+  await page.goto("/themes?theme=light");
+
+  const region = page.getByRole("region", { name: "Categorical color schemes" });
+  const cards = region.getByRole("list", { name: "Categorical palettes" }).locator(":scope > li");
+  await expect(cards).toHaveCount(5);
+  await expect(cards.getByRole("heading", { level: 3 })).toHaveText([
+    "Observable 10",
+    "Ipsum",
+    "Flexoki",
+    "Tableau 10",
+    "Colorblind",
+  ]);
+  await expect(cards.getByText(/colors$/)).toHaveText([
+    "10 colors",
+    "9 colors",
+    "8 colors",
+    "10 colors",
+    "8 colors",
+  ]);
+
+  const observable = cards.first();
+  await expect(
+    observable.getByRole("list", { name: "Observable 10 ordered colors" }).getByRole("listitem"),
+  ).toHaveText([
+    "#4269d0",
+    "#efb118",
+    "#ff725c",
+    "#6cc5b0",
+    "#3ca951",
+    "#ff8ab7",
+    "#a463f2",
+    "#97bbf5",
+    "#9c6b4e",
+    "#9498a0",
+  ]);
+  const firstMark = observable.locator(".gg-points circle").first();
+  await expect(firstMark).toHaveAttribute("fill", "#4269d0");
+
+  await region.getByRole("checkbox", { name: "Reverse palettes" }).check();
+  const reversedSwatches = observable
+    .getByRole("list", { name: "Observable 10 ordered colors" })
+    .getByRole("listitem");
+  await expect(reversedSwatches.first()).toHaveText("#9498a0");
+  await expect(reversedSwatches.last()).toHaveText("#4269d0");
+  await expect(firstMark).toHaveAttribute("fill", "#9498a0");
+  await expect(observable.locator(".copy-code code")).toContainText("reverse: true");
+  await region.getByLabel("Chart paper", { exact: true }).selectOption("dark");
+  await expect(observable.locator(".gg-paper")).toHaveAttribute("fill", "var(--gg-paper, #16181d)");
+  await expect(observable.locator(".copy-code code")).toContainText('theme="dark"');
+  await expect(firstMark).toHaveAttribute("fill", "#9498a0");
+});
+
+test("palette limits expose real warnings and caught failures", async ({ page }) => {
+  await page.goto("/themes?theme=light");
+
+  const demo = page.getByRole("region", { name: "Palette limits" });
+  await expect(demo.getByText("scale-scheme-type", { exact: true })).toBeVisible();
+  await expect(demo.getByText("palette-exhausted", { exact: true })).toBeVisible();
+  await expect(demo.locator(".gg-plot-root")).toHaveAttribute("data-gg-ready", "true");
+  const marks = demo.locator(".gg-points circle");
+  await expect(marks).toHaveCount(3);
+  await expect(marks.nth(0)).toHaveAttribute("fill", "#123456");
+  await expect(marks.nth(2)).toHaveAttribute("fill", "#123456");
+
+  await demo.getByLabel("Exhaustion behavior").selectOption("error");
+  await expect(demo.getByRole("alert")).toContainText("Palette exhausted");
+  await expect(demo.getByText("/scales/color", { exact: true })).toBeVisible();
+  await expect(demo.locator(".gg-plot-root")).toHaveCount(0);
+});
+
+test("sequential color compares direction, custom stops, and a pinned domain", async ({ page }) => {
+  await page.goto("/themes?theme=light");
+
+  const region = page.getByRole("region", { name: "Sequential color scales" });
+  const cards = region
+    .getByRole("list", { name: "Sequential scale examples" })
+    .locator(":scope > li");
+  await expect(cards).toHaveCount(4);
+  await expect(cards.getByRole("heading", { level: 3 })).toHaveText([
+    "Viridis",
+    "Reversed viridis",
+    "Custom range",
+    "Pinned domain",
+  ]);
+
+  const normalMarks = cards.nth(0).locator(".gg-points circle");
+  await expect(normalMarks.first()).toHaveAttribute("fill", "#440154");
+  await expect(normalMarks.last()).toHaveAttribute("fill", "#fde725");
+  const reversedMarks = cards.nth(1).locator(".gg-points circle");
+  await expect(reversedMarks.first()).toHaveAttribute("fill", "#fde725");
+  await expect(reversedMarks.last()).toHaveAttribute("fill", "#440154");
+  const customMarks = cards.nth(2).locator(".gg-points circle");
+  await expect(customMarks.first()).toHaveAttribute("fill", "#2d1e2f");
+  await expect(customMarks.last()).toHaveAttribute("fill", "#e76f51");
+  await expect(cards.nth(3).locator(".gg-legend-label").first()).toHaveText("0");
+  await expect(cards.nth(3).locator(".gg-legend-label").last()).toHaveText("100");
+
+  await expect(cards.nth(0).locator(".copy-code code")).toContainText('scheme: "viridis"');
+  await expect(cards.nth(1).locator(".copy-code code")).toContainText("reverse: true");
+  await expect(cards.nth(2).locator(".copy-code code")).toContainText('range: ["#2d1e2f"');
+  await expect(cards.nth(3).locator(".copy-code code")).toContainText("domain: [0, 100]");
+});
+
+test("custom interaction theme preserves linked emphasis across SVG and canvas", async ({
+  page,
+}) => {
+  await page.goto("/themes?theme=light");
+
+  const region = page.getByRole("region", { name: "Custom interaction theme" });
+  const plots = region.locator(".gg-plot-root");
+  await expect(region.locator(".copy-code code")).toContainText(
+    'import { createPlotInteraction, GGPlot, type ThemeSpec } from "@ggsvelte/svelte"',
+  );
+  await expect(region.locator(".copy-code code")).toContainText("satisfies ThemeSpec");
+  await expect(region.locator(".copy-code code")).toContainText(
+    'layers={[{ geom: "point", params: { size: 4 } }]}',
+  );
+  await expect(plots).toHaveCount(2);
+  await expect(plots.nth(0).locator("svg.gg-plot")).toBeVisible();
+  await expect(plots.nth(1).locator("canvas")).toBeVisible();
+  const alphaMarks = plots.nth(0).locator('.gg-points circle[fill="#4269d0"]');
+  await expect(alphaMarks).toHaveCount(3);
+
+  await plots.nth(0).getByRole("button", { name: "Series: Alpha (color legend)" }).click();
+  await expect(region.getByText("3 rows emphasized", { exact: true })).toBeVisible();
+  await expect(plots.nth(0).locator('circle[data-gg-focused="false"]').first()).toHaveAttribute(
+    "opacity",
+    "0.18",
+  );
+
+  await region.getByLabel("Interaction chart paper").selectOption("dark");
+  await expect(region.getByText("3 rows emphasized", { exact: true })).toBeVisible();
+  await expect(alphaMarks).toHaveCount(3);
+  await page.getByRole("button", { name: "Dark appearance" }).click();
+  await expect(region.getByText("3 rows emphasized", { exact: true })).toBeVisible();
+
+  await region.getByRole("button", { name: "Clear shared state" }).click();
+  await expect(region.getByText("0 rows emphasized", { exact: true })).toBeVisible();
+});
+
+for (const width of [375, 768, 1024, 1280, 1600]) {
+  test(`themes has no horizontal overflow at ${String(width)}px`, async ({ page }) => {
+    await page.setViewportSize({ width, height: 900 });
+    await page.goto("/themes?theme=light");
+    expect(
+      await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth),
+    ).toBe(true);
+  });
+}
+
+test("themes controls remain legible in forced colors with reduced motion", async ({ page }) => {
+  await page.emulateMedia({ forcedColors: "active", reducedMotion: "reduce" });
+  await page.goto("/themes?theme=light");
+  const select = page.getByLabel("Chart theme", { exact: true });
+  await select.focus();
+  await expect(select).toBeVisible();
+  expect(await select.evaluate((element) => getComputedStyle(element).outlineStyle)).not.toBe(
+    "none",
+  );
+  expect(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth)).toBe(true);
+});
+
+for (const [name, width, height] of [
+  ["desktop", 1280, 900],
+  ["mobile", 375, 812],
+] as const) {
+  test(`themes ${name} visual contract`, async ({ page }) => {
+    await page.setViewportSize({ width, height });
+    await page.goto("/themes?theme=light");
+    await expect(page).toHaveScreenshot(`docs-themes-${name}.png`);
+  });
+}
+
+test("inspection overlays stay local and use custom interaction roles", async ({ page }) => {
+  await page.goto("/themes?theme=light");
+
+  const region = page.getByRole("region", { name: "Custom interaction theme" });
+  const plots = region.locator(".gg-plot-root");
+  const svgPlot = plots.nth(0);
+  const canvasPlot = plots.nth(1);
+  const toolbar = svgPlot.getByRole("toolbar", { name: "Chart interaction tools" });
+  await expect(toolbar.locator(".gg-tool-modes").getByRole("button")).toHaveText([
+    "Inspect",
+    "Select area",
+    "Zoom area",
+  ]);
+
+  const capture = svgPlot.locator(".gg-capture");
+  await capture.focus();
+  await expect(capture).toHaveCSS("outline-color", "rgb(230, 57, 70)");
+  await capture.press("ArrowRight");
+  await expect(svgPlot.locator(".gg-tooltip")).toBeVisible();
+  await expect(svgPlot.locator(".gg-crosshair")).not.toHaveCount(0);
+  await expect(canvasPlot.locator(".gg-tooltip")).toHaveCount(0);
+  await expect(canvasPlot.locator(".gg-crosshair")).toHaveCount(0);
+});


### PR DESCRIPTION
## Summary

- add `/themes` as a first-class indexed product route with site navigation, canonical metadata, sitemap coverage, and packed static-build validation
- render every registered chart theme, all five categorical schemes, viridis variants, custom ranges, pinned domains, and real palette diagnostics through public ggsvelte APIs
- keep site appearance independent from chart themes unless the reader explicitly enables follow mode
- add a custom `ThemeSpec` interaction specimen linking SVG and canvas semantic state while keeping inspection overlays chart-local
- provide accessible controls and copyable, visibly labelled Svelte fragments using the shared clipboard fallback

## Behavior covered

- exact canonical theme, palette, capacity, and viridis projections
- public `validate()` / `runPipeline()` evidence for `scale-scheme-type` and `palette-exhausted`
- chart-theme/site-appearance separation and explicit follow behavior
- palette reversal, ordered swatches, chart paper, cycling, and strict exhaustion
- sequential direction, custom stops, and pinned domains
- linked legend emphasis across SVG/canvas, local keyboard inspection, custom focus/crosshair/tooltip roles
- responsive no-overflow checks at 375, 768, 1024, 1280, and 1600px
- forced-colors/reduced-motion control visibility and shared manual-copy fallback

## Verification

- `bun install --frozen-lockfile`
- `bun run check`
- `bun run check:examples`
- `bun run check:docs`
- `bun run lint`
- `bun run lint:type-aware`
- `bun run fmt:check`
- `bun run test` — 1,092 passed
- Svelte browser suite — 2,844 passed across Chromium, Firefox, and WebKit
- Svelte SSR suite — 14 passed
- four docs build modes plus packed-link validation
- `VR_SNAPSHOT_DIR=.local-baselines bun run test:visual -- docs-themes.spec.ts` — 17 passed
- browser QA at five widths — 25/25 plots ready, one H1, no overflow, no console errors
- actionlint and zizmor passed
- current-head Codex review: no actionable correctness findings remain

## Visual approval

This PR intentionally adds screenshot expectations without committing baseline PNGs. Per repository policy, `docs-themes-desktop.png` and `docs-themes-mobile.png` must be generated in the pinned container through `/approve-visuals` and land only from `vr-update/pr-<number>`.

## Release notes

No changeset: this changes the private documentation application and does not alter a published package API.
