### PR TITLE
fix(ci): bind visual approvals to merged source

### DIFF
--- a/.changeset/quiet-dates-guide.md
+++ b/.changeset/quiet-dates-guide.md
@@ -1,0 +1,7 @@
+---
+"@ggsvelte/svelte": patch
+---
+
+# Temporal agent guidance
+
+Clarify temporal parser and override behavior in the packaged ggsvelte agent skill.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1182,7 +1182,7 @@ jobs:
             echo "baseline changes from a same-repo vr-update branch (vr-approve flow) — ok"
             exit 0
           fi
-          echo "::error::this PR changes tests/visual/__screenshots__/ but is not a same-repo vr-update/pr-<n> branch. Baselines are container-generated only: have a maintainer comment /approve-visuals on the PR, then merge the resulting vr-update branch (see vr-approve.yml and docs/decisions/0009)."
+          echo "::error::this PR changes tests/visual/__screenshots__/ but is not a same-repo vr-update/pr-<n> branch. Baselines are container-generated only: merge the source PR, then have a maintainer comment /approve-visuals on it and merge the resulting vr-update branch (see vr-approve.yml and docs/decisions/0009)."
           exit 1
 
   # Single required aggregator. Skipped jobs are OK when routing disabled them;

--- a/.github/workflows/vr-approve.yml
+++ b/.github/workflows/vr-approve.yml
@@ -2,10 +2,10 @@
 # separation (plan, round-2 security fix).
 #
 # Security invariants (enforced in order):
-#   1. NEVER executes PR-authored code: no PR checkout, no bun install of PR
-#      manifests, no scripts from the artifact. It only downloads the
-#      `vr-baselines-approved` artifact produced by the unprivileged
-#      vr-compare run and verifies it as inert data.
+#   1. NEVER executes unmerged PR-authored code or anything from the artifact.
+#      After independent API verification, it checks out only the immutable
+#      commit already merged into the default branch. Baseline PNGs remain
+#      inert data; the trusted merged generator runs without GH_TOKEN in env.
 #   2. Flavor gate: only `/approve-visuals`-triggered (issue_comment) VR
 #      Compare runs proceed. Plain pull_request runs upload bootstrap
 #      candidates only and are never committed from here.
@@ -15,13 +15,15 @@
 #   4. INDEPENDENT approval re-verification via the API: artifact metadata is
 #      a hint, never a credential. The referenced comment must literally be
 #      `/approve-visuals`, must belong to the referenced PR, its author must
-#      hold write/maintain/admin, the metadata head SHA must be the PR's
-#      CURRENT head, and the comment must postdate the head commit — approval
-#      must postdate the code it approves. (Committer dates are self-reported
+#      hold write/maintain/admin, the artifact render SHA must be the PR's
+#      immutable merged commit on the repository default branch, and the
+#      comment must postdate both the merge and rendered commit. Requiring
+#      source-first landing keeps docs-owned previews consistent with main.
+#      (Committer dates are self-reported
 #      by pushers; the residual risk is bounded because the vr-update branch
 #      still lands through a human-reviewed PR.)
 #   5. Writes ONLY to a `vr-update/pr-<n>` branch in the base repo (never to
-#      the PR branch, never to a fork), idempotent per head SHA.
+#      the PR branch, never to a fork), idempotent per rendered merge SHA.
 #   6. `contents: write` is job-scoped; the workflow default is no permissions.
 #
 # Companion guard: ci.yml's `vr-baseline-guard` job rejects any PR diff that
@@ -54,7 +56,7 @@ jobs:
     permissions:
       contents: write # push the verified vr-update/pr-<n> branch
       actions: read # download the triggering run's artifact
-      pull-requests: read # re-verify the approval comment / PR head via API
+      pull-requests: read # re-verify the approval comment / merged PR via API
     steps:
       - name: flavor gate — only /approve-visuals (issue_comment) runs proceed
         id: gate
@@ -66,13 +68,13 @@ jobs:
             echo "approval-flavored VR Compare run — verifying"
             echo "approved=true" >> "$GITHUB_OUTPUT"
           else
-            echo "::notice::pull_request-flavored VR Compare run — candidate baselines only, NOT approved. Comment /approve-visuals on the PR (maintainers only) to land baselines."
+            echo "::notice::pull_request-flavored VR Compare run — candidate baselines only, NOT approved. After the source PR merges, comment /approve-visuals on it (maintainers only) to land baselines."
             {
               echo "## VR approve: not an approval run"
               echo ""
               echo "This VR Compare run was triggered by \`${RUN_EVENT}\`, so its artifact"
-              echo "holds bootstrap CANDIDATES only. A maintainer comments \`/approve-visuals\`"
-              echo "on the PR to regenerate + land baselines via the verified path."
+              echo "holds bootstrap CANDIDATES only. After the source PR merges, a maintainer"
+              echo "comments \`/approve-visuals\` on it to regenerate + land baselines via the verified path."
             } >> "$GITHUB_STEP_SUMMARY"
             echo "approved=false" >> "$GITHUB_OUTPUT"
           fi
@@ -98,17 +100,17 @@ jobs:
 
           # Metadata must exist and parse into well-formed fields. NOTE: for
           # issue_comment-flavored runs, github.event.workflow_run.head_sha
-          # points at the DEFAULT branch (the comment's run context), not the
-          # PR head — so the head-SHA binding is asserted against the PR's
-          # current head via the API in the next step instead.
+          # points at the default branch run context, not necessarily the
+          # exact merged commit rendered by the unprivileged workflow. The
+          # render binding is independently asserted through the API next.
           [ -f metadata.txt ] || { echo "::error::metadata.txt missing"; exit 1; }
           pr="$(sed -n 's/^pr=//p' metadata.txt)"
-          head_sha="$(sed -n 's/^head_sha=//p' metadata.txt)"
+          render_sha="$(sed -n 's/^render_sha=//p' metadata.txt)"
           comment_id="$(sed -n 's/^comment_id=//p' metadata.txt)"
           case "${pr}" in (*[!0-9]*|'') echo "::error::invalid pr number in metadata"; exit 1 ;; esac
           case "${comment_id}" in (*[!0-9]*|'') echo "::error::invalid comment id in metadata"; exit 1 ;; esac
-          if ! printf '%s' "${head_sha}" | grep -Eq '^[0-9a-f]{40}$'; then
-            echo "::error::invalid head_sha in metadata"
+          if ! printf '%s' "${render_sha}" | grep -Eq '^[0-9a-f]{40}$'; then
+            echo "::error::invalid render_sha in metadata"
             exit 1
           fi
 
@@ -143,7 +145,7 @@ jobs:
           # Validated-above values only (numeric / 40-hex) — safe as outputs.
           {
             echo "pr=${pr}"
-            echo "head_sha=${head_sha}"
+            echo "render_sha=${render_sha}"
             echo "comment_id=${comment_id}"
           } >> "$GITHUB_OUTPUT"
 
@@ -153,13 +155,13 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ steps.verify.outputs.pr }}
-          HEAD_SHA: ${{ steps.verify.outputs.head_sha }}
+          RENDER_SHA: ${{ steps.verify.outputs.render_sha }}
           COMMENT_ID: ${{ steps.verify.outputs.comment_id }}
         run: |
           set -euo pipefail
-          # The artifact was produced by a run that executed PR-authored code,
-          # so its metadata could be forged. Re-derive every trust decision
-          # from the API; the metadata only tells us WHERE to look.
+          # The artifact was produced by an unprivileged run of the merged
+          # render commit, so its metadata is still untrusted. Re-derive every
+          # trust decision from the API; metadata only tells us WHERE to look.
 
           # (a) The referenced comment must literally be `/approve-visuals`.
           comment_json="$(gh api "repos/${REPO}/issues/comments/${COMMENT_ID}")"
@@ -186,108 +188,144 @@ jobs:
             *) echo "::error::comment author ${author} has insufficient permission: ${permission}"; exit 1 ;;
           esac
 
-          # (d) The metadata head SHA must be the PR's CURRENT head — binds
-          # the PNGs to the code being approved and refuses stale artifacts
-          # (workflow_run.head_sha is unusable here; see previous step).
-          current_head="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq .head.sha)"
-          if [ "${current_head}" != "${HEAD_SHA}" ]; then
-            echo "::error::PR #${PR_NUMBER} head moved: artifact is for ${HEAD_SHA}, PR is at ${current_head} — re-approve"
+          # (d) The source must be merged into this repository's default branch,
+          # and the artifact must render the immutable merged commit. This works
+          # for merge, squash, and rebase strategies and survives deleted heads.
+          pr_json="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}")"
+          merged_at="$(printf '%s' "${pr_json}" | jq -r '.merged_at // empty')"
+          if [ -z "${merged_at}" ]; then
+            echo "::error::source PR #${PR_NUMBER} is not merged"
             exit 1
           fi
+          base_repo="$(printf '%s' "${pr_json}" | jq -r '.base.repo.full_name // empty')"
+          base_ref="$(printf '%s' "${pr_json}" | jq -r '.base.ref // empty')"
+          default_branch="$(gh api "repos/${REPO}" --jq .default_branch)"
+          if [ "${base_repo}" != "${REPO}" ] || [ "${base_ref}" != "${default_branch}" ]; then
+            echo "::error::source PR #${PR_NUMBER} targeted ${base_repo}:${base_ref}, not ${REPO}:${default_branch}"
+            exit 1
+          fi
+          merged_sha="$(printf '%s' "${pr_json}" | jq -r '.merge_commit_sha // empty')"
+          if [ "${merged_sha}" != "${RENDER_SHA}" ]; then
+            echo "::error::artifact render is for ${RENDER_SHA}, but PR #${PR_NUMBER} merged as ${merged_sha}"
+            exit 1
+          fi
+          default_sha="$(gh api --method GET "repos/${REPO}/commits" -f sha="${default_branch}" -f per_page=1 --jq '.[0].sha')"
+          compare_status="$(gh api "repos/${REPO}/compare/${RENDER_SHA}...${default_sha}" --jq .status)"
+          case "${compare_status}" in
+            identical|ahead) ;;
+            *) echo "::error::merged render ${RENDER_SHA} is not reachable from ${default_branch} (${compare_status})"; exit 1 ;;
+          esac
 
-          # (e) Approval must postdate the code it approves: the comment may
-          # not be older than the head commit's committer date.
+          # (e) Approval must postdate the merge, not merely the source head.
           comment_created="$(printf '%s' "${comment_json}" | jq -r .created_at)"
-          commit_date="$(gh api "repos/${REPO}/commits/${HEAD_SHA}" --jq .commit.committer.date)"
           comment_epoch="$(date -u -d "${comment_created}" +%s)"
-          commit_epoch="$(date -u -d "${commit_date}" +%s)"
-          if [ "${comment_epoch}" -lt "${commit_epoch}" ]; then
-            echo "::error::approval comment (${comment_created}) predates head commit (${commit_date}) — approve the current code, not older code"
+          merged_epoch="$(date -u -d "${merged_at}" +%s)"
+          if [ "${comment_epoch}" -le "${merged_epoch}" ]; then
+            echo "::error::approval comment predates merge — comment /approve-visuals again"
             exit 1
           fi
-          echo "approval verified: ${author} approved PR #${PR_NUMBER} @ ${HEAD_SHA}"
 
-      - name: idempotency — skip if this head SHA is already on the branch
+          # (f) Approval must also postdate the exact rendered commit.
+          commit_date="$(gh api "repos/${REPO}/commits/${RENDER_SHA}" --jq .commit.committer.date)"
+          commit_epoch="$(date -u -d "${commit_date}" +%s)"
+          if [ "${comment_epoch}" -le "${commit_epoch}" ]; then
+            echo "::error::approval comment (${comment_created}) predates rendered commit (${commit_date})"
+            exit 1
+          fi
+          echo "approval verified: ${author} approved merged PR #${PR_NUMBER} @ ${RENDER_SHA}"
+
+      - name: idempotency — skip if this render SHA is already on the branch
         id: idem
         if: steps.gate.outputs.approved == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ steps.verify.outputs.pr }}
-          HEAD_SHA: ${{ steps.verify.outputs.head_sha }}
+          RENDER_SHA: ${{ steps.verify.outputs.render_sha }}
         run: |
           set -euo pipefail
           branch="vr-update/pr-${PR_NUMBER}"
           tip="$(git ls-remote "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" "refs/heads/${branch}" | cut -f1)"
           if [ -n "${tip}" ]; then
             message="$(gh api "repos/${REPO}/commits/${tip}" --jq .commit.message)"
-            if printf '%s' "${message}" | grep -qF "${HEAD_SHA}"; then
-              echo "::notice::${branch} tip already carries baselines for ${HEAD_SHA} — nothing to do"
+            if printf '%s' "${message}" | grep -qF "${RENDER_SHA}"; then
+              echo "::notice::${branch} tip already carries baselines for ${RENDER_SHA} — nothing to do"
               echo "skip=true" >> "$GITHUB_OUTPUT"
               exit 0
             fi
           fi
           echo "skip=false" >> "$GITHUB_OUTPUT"
 
-      - name: checkout base repo (default branch — never PR code)
+      - name: checkout exact verified merged commit from base repo
         if: steps.gate.outputs.approved == 'true' && steps.idem.outputs.skip != 'true'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          # Pin trusted generation to the exact commit used for screenshots;
+          # a moving default branch must not desynchronize source and previews.
+          ref: ${{ steps.verify.outputs.render_sha }}
           persist-credentials: false
           path: base
 
-      - name: setup Bun for trusted default-branch generator
+      - name: setup Bun for verified merged-commit generator
         if: steps.gate.outputs.approved == 'true' && steps.idem.outputs.skip != 'true'
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.3.14
 
-      - name: install trusted default-branch dependencies
+      - name: install dependencies at verified merged commit
         if: steps.gate.outputs.approved == 'true' && steps.idem.outputs.skip != 'true'
         working-directory: base
         run: bun install --frozen-lockfile
         env:
           BUN_INSTALL_CACHE_DIR: ${{ runner.temp }}/bun-install-cache
 
-      - name: commit verified baselines to vr-update/pr-<n>
+      - name: materialize verified baseline branch without write credentials
+        if: steps.gate.outputs.approved == 'true' && steps.idem.outputs.skip != 'true'
+        env:
+          PR_NUMBER: ${{ steps.verify.outputs.pr }}
+        run: |
+          set -euo pipefail
+          pr="${PR_NUMBER}"
+          case "${pr}" in (*[!0-9]*|'') echo "::error::invalid pr number"; exit 1 ;; esac
+          cd base
+          git config user.name "ggsvelte-vr-bot"
+          git config user.email "vr-bot@users.noreply.github.com"
+          git checkout -B "vr-update/pr-${pr}"
+
+          mkdir -p tests/visual/__screenshots__
+          find ../vr-artifact -name '*.png' -exec cp {} tests/visual/__screenshots__/ \;
+
+          # Re-materialize docs-owned previews with the generator from the same
+          # verified merged commit that produced the screenshots. GH_TOKEN is
+          # intentionally absent while dependencies and repository code run.
+          bun scripts/gen-gallery-previews.ts
+          git add tests/visual/__screenshots__ apps/docs/static/previews \
+            apps/docs/src/lib/generated/gallery-previews.ts
+
+      - name: commit and push verified baselines to vr-update/pr-<n>
         if: steps.gate.outputs.approved == 'true' && steps.idem.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ steps.verify.outputs.pr }}
-          APPROVED_HEAD_SHA: ${{ steps.verify.outputs.head_sha }}
+          APPROVED_RENDER_SHA: ${{ steps.verify.outputs.render_sha }}
         run: |
           set -euo pipefail
           pr="${PR_NUMBER}"
           case "${pr}" in (*[!0-9]*|'') echo "::error::invalid pr number"; exit 1 ;; esac
           branch="vr-update/pr-${pr}"
           push_url="https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git"
-
           cd base
-          git config user.name "ggsvelte-vr-bot"
-          git config user.email "vr-bot@users.noreply.github.com"
+
           # Record the current remote tip (empty if the branch is new) so the
-          # lease below only replaces exactly what we observed — a concurrent
-          # push between here and ours is rejected instead of clobbered.
+          # lease only replaces exactly what we observed. This credentialed
+          # step executes no repository scripts.
           old_tip="$(git ls-remote "${push_url}" "refs/heads/${branch}" | cut -f1)"
-          git checkout -B "${branch}"
-
-          mkdir -p tests/visual/__screenshots__
-          find ../vr-artifact -name '*.png' -exec cp {} tests/visual/__screenshots__/ \;
-
-          # Re-materialize docs-owned preview assets from the newly approved
-          # canonical light baselines. This executes only the trusted generator
-          # checked out from the default branch, never PR-authored code.
-          bun scripts/gen-gallery-previews.ts
-          git add tests/visual/__screenshots__ apps/docs/static/previews \
-            apps/docs/src/lib/generated/gallery-previews.ts
-
           if git diff --cached --quiet; then
-            echo "no baseline changes — nothing to commit (idempotent per head SHA)"
+            echo "no baseline changes — nothing to commit (idempotent per render SHA)"
             exit 0
           fi
-          # The head SHA in the message is the idempotency key checked above.
-          git commit -m "vr: update baselines for PR #${pr} @ ${APPROVED_HEAD_SHA}"
+          git commit -m "vr: update baselines for PR #${pr} @ ${APPROVED_RENDER_SHA}"
           git push --force-with-lease="refs/heads/${branch}:${old_tip}" \
             "${push_url}" "HEAD:refs/heads/${branch}"
           echo "pushed verified baselines to ${branch}"

--- a/.github/workflows/vr-compare.yml
+++ b/.github/workflows/vr-compare.yml
@@ -13,11 +13,13 @@
 #     INDEPENDENTLY re-verifies the approval via the API — metadata written
 #     here is a hint for the privileged half, never a credential.
 #
-# Approval flavor (M3): a maintainer comments `/approve-visuals` on a PR. The
-# approve-gate job checks the command + author association and resolves the
-# exact PR head SHA; approve-regenerate checks out THAT SHA, rebuilds, and
-# REGENERATES baselines inside the pinned container. Still unprivileged: PR
-# code runs only in read-only contexts, to produce inert PNGs.
+# Approval flavor (M3): after the source PR merges to the default branch, a
+# maintainer comments `/approve-visuals` on it. The approve-gate checks the
+# command, author association, merge target, and post-merge timestamp, then
+# resolves the immutable merged commit. approve-regenerate checks out THAT
+# commit from the base repo and REGENERATES baselines inside the pinned container.
+# Still unprivileged: merged code runs only in read-only contexts, producing
+# inert PNGs.
 #
 # Baseline policy (decision 0009): committed baselines in
 # tests/visual/__screenshots__/ come ONLY from this pinned container. While
@@ -185,7 +187,7 @@ jobs:
           retention-days: 7
 
   approve-gate:
-    name: /approve-visuals — parse command, resolve PR head (read-only)
+    name: /approve-visuals — verify merge, resolve rendered commit (read-only)
     # Only comments ON a PR, only from commenters whose association implies
     # repo trust (OWNER/MEMBER/COLLABORATOR). This job runs NO checked-out
     # code — just the command parse and a read-only API lookup.
@@ -199,11 +201,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read # resolve the PR head via `gh api` (read-only)
+      pull-requests: read # resolve the merged PR via `gh api` (read-only)
     outputs:
       match: ${{ steps.cmd.outputs.match }}
-      head_sha: ${{ steps.pr.outputs.head_sha }}
-      head_repo: ${{ steps.pr.outputs.head_repo }}
+      render_sha: ${{ steps.pr.outputs.render_sha }}
+      render_repo: ${{ steps.pr.outputs.render_repo }}
     steps:
       - name: trimmed comment body must be exactly `/approve-visuals`
         id: cmd
@@ -222,27 +224,56 @@ jobs:
             echo "match=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: resolve PR head SHA + head repo (read-only API)
+      - name: verify default-branch merge and resolve rendered commit (read-only API)
         id: pr
         if: steps.cmd.outputs.match == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.issue.number }}
+          COMMENT_CREATED_AT: ${{ github.event.comment.created_at }}
         run: |
           set -euo pipefail
-          head_sha="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq .head.sha)"
-          head_repo="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq .head.repo.full_name)"
-          if ! printf '%s' "${head_sha}" | grep -Eq '^[0-9a-f]{40}$'; then
-            echo "::error::resolved head SHA is not a 40-hex commit id: ${head_sha}"
+          pr_json="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}")"
+          merged_at="$(printf '%s' "${pr_json}" | jq -r '.merged_at // empty')"
+          if [ -z "${merged_at}" ]; then
+            echo "::error::source PR #${PR_NUMBER} is not merged — merge it to the default branch, then comment /approve-visuals"
             exit 1
           fi
-          echo "resolved PR #${PR_NUMBER} head: ${head_repo}@${head_sha}"
-          echo "head_sha=${head_sha}" >> "$GITHUB_OUTPUT"
-          echo "head_repo=${head_repo}" >> "$GITHUB_OUTPUT"
+
+          base_repo="$(printf '%s' "${pr_json}" | jq -r '.base.repo.full_name // empty')"
+          base_ref="$(printf '%s' "${pr_json}" | jq -r '.base.ref // empty')"
+          default_branch="$(gh api "repos/${REPO}" --jq .default_branch)"
+          if [ "${base_repo}" != "${REPO}" ] || [ "${base_ref}" != "${default_branch}" ]; then
+            echo "::error::source PR #${PR_NUMBER} targeted ${base_repo}:${base_ref}, not ${REPO}:${default_branch}"
+            exit 1
+          fi
+
+          comment_epoch="$(date -u -d "${COMMENT_CREATED_AT}" +%s)"
+          merged_epoch="$(date -u -d "${merged_at}" +%s)"
+          if [ "${comment_epoch}" -le "${merged_epoch}" ]; then
+            echo "::error::approval comment predates merge — comment /approve-visuals again after PR #${PR_NUMBER} merges"
+            exit 1
+          fi
+
+          render_sha="$(printf '%s' "${pr_json}" | jq -r '.merge_commit_sha // empty')"
+          render_repo="${REPO}"
+          if ! printf '%s' "${render_sha}" | grep -Eq '^[0-9a-f]{40}$'; then
+            echo "::error::resolved merged commit is not a 40-hex commit id: ${render_sha}"
+            exit 1
+          fi
+          default_sha="$(gh api --method GET "repos/${REPO}/commits" -f sha="${default_branch}" -f per_page=1 --jq '.[0].sha')"
+          compare_status="$(gh api "repos/${REPO}/compare/${render_sha}...${default_sha}" --jq .status)"
+          case "${compare_status}" in
+            identical|ahead) ;;
+            *) echo "::error::merged render ${render_sha} is not reachable from ${default_branch} (${compare_status})"; exit 1 ;;
+          esac
+          echo "resolved PR #${PR_NUMBER} merged render: ${render_repo}@${render_sha}"
+          echo "render_sha=${render_sha}" >> "$GITHUB_OUTPUT"
+          echo "render_repo=${render_repo}" >> "$GITHUB_OUTPUT"
 
   approve-regenerate:
-    name: /approve-visuals — regenerate baselines at PR head (pinned container)
+    name: /approve-visuals — regenerate baselines at merged commit (pinned container)
     needs: approve-gate
     if: needs.approve-gate.outputs.match == 'true'
     runs-on: [self-hosted, ggsvelte]
@@ -261,17 +292,17 @@ jobs:
         # The container's /bin/sh is dash, which rejects `set -o pipefail`.
         shell: bash
     steps:
-      # PR-authored code (build configs, plugins, the examples themselves)
-      # executes from here on. That is acceptable ONLY because this job is
+      # The merged render commit (build configs, plugins, examples) executes
+      # from here on. That is acceptable ONLY because this job is
       # read-only: no write permissions, no secrets beyond the read-only
       # default GITHUB_TOKEN, and its sole output is the inert artifact
       # below, which vr-approve.yml re-verifies against the API.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          repository: ${{ needs.approve-gate.outputs.head_repo }}
-          # Exact resolved SHA, never a movable branch ref — what gets
+          repository: ${{ needs.approve-gate.outputs.render_repo }}
+          # Exact merged SHA, never a movable branch ref — what gets
           # screenshotted is exactly what vr-approve re-verifies against.
-          ref: ${{ needs.approve-gate.outputs.head_sha }}
+          ref: ${{ needs.approve-gate.outputs.render_sha }}
           persist-credentials: false
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
@@ -294,13 +325,13 @@ jobs:
       - name: build static docs site (the VR screenshot target)
         run: bun run build:docs
 
-      - name: REGENERATE baselines at the approved head
+      - name: REGENERATE baselines at the approved merged commit
         run: bun run test:visual -- --update-snapshots
 
       - name: assemble approved-baseline artifact (PNGs + metadata)
         env:
           PR_NUMBER: ${{ github.event.issue.number }}
-          HEAD_SHA: ${{ needs.approve-gate.outputs.head_sha }}
+          RENDER_SHA: ${{ needs.approve-gate.outputs.render_sha }}
           COMMENT_ID: ${{ github.event.comment.id }}
           COMMENT_CREATED_AT: ${{ github.event.comment.created_at }}
           COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
@@ -314,7 +345,7 @@ jobs:
           # written — this file merely tells the privileged half where to look.
           printf '%s\n' \
             "pr=${PR_NUMBER}" \
-            "head_sha=${HEAD_SHA}" \
+            "render_sha=${RENDER_SHA}" \
             "comment_id=${COMMENT_ID}" \
             "comment_created_at=${COMMENT_CREATED_AT}" \
             "comment_author=${COMMENT_AUTHOR}" > vr-artifact/metadata.txt

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -353,15 +353,30 @@ docs/decisions/0009.
 
 ## Visual-regression trust model
 
-`vr-compare.yml` (unprivileged, `pull_request`, no secrets) is the ONLY place
-PR-authored code executes; it builds packages + docs, runs the VR suite in
-the pinned container, and uploads candidate baselines as a `vr-baselines`
-artifact (PNGs + pr/head-SHA metadata). `vr-approve.yml` (privileged,
-`workflow_run`, job-scoped `contents: write`) never executes PR code: it
-verifies the artifact as inert data (PNG magic bytes, count/size limits, SHA
-match) and pushes to a `vr-update/pr-<n>` branch. The maintainer
-`/approve-visuals` gate is TODO (M3) and the gate defaults to _not approved_,
-so the privileged path is dormant until then. Do not weaken these invariants.
+`vr-compare.yml` is the only workflow that executes **unmerged** PR code. It
+has no secrets or write permissions, renders in the pinned container, and
+uploads inert PNG candidates. After source lands, `vr-approve.yml` independently
+verifies the comment, permission, default-branch merge, timestamp, and immutable
+`merge_commit_sha`. It checks out only that already-merged base-repository
+commit, verifies the PNG artifact, and runs the matching preview generator
+without `GH_TOKEN` in its environment. Only the final script-free commit/push
+step receives the write credential.
+
+The source-first landing order is deliberate:
+
+1. Inspect the source PR's candidate report. For an intentional pixel change,
+   the red VR comparison is expected; keep VR Compare non-required so it cannot
+   deadlock this flow. `ci-gate`, code review, and the baseline evidence still
+   gate the source merge.
+2. Merge the source PR into the default branch.
+3. Comment `/approve-visuals` on the **merged** PR. A pre-merge command is
+   rejected, including one recorded in the same second as the merge.
+4. Review and merge the generated `vr-update/pr-<n>` PR.
+
+This creates a short, explicit window where source has landed but its approved
+baselines have not. Finish step 4 promptly. Never merge an unexplained visual
+diff, and do not make VR Compare a required branch-protection check without
+redesigning this source-first protocol.
 
 ## Lifecycle policy (Hadley lesson 13)
 

--- a/docs/decisions/0012-m3-notes.md
+++ b/docs/decisions/0012-m3-notes.md
@@ -135,21 +135,29 @@ bench-smoke unchanged.
 
 ## VR approval flow (completed) + release
 
-- `vr-compare.yml` gains the `/approve-visuals` path: issue_comment trigger,
-  OWNER/MEMBER/COLLABORATOR author association, PR head resolved via API,
-  checkout of that exact SHA, pinned-container `--update-snapshots` run,
-  `vr-baselines-approved` artifact (PNGs + pr/head_sha/comment metadata).
-  Still unprivileged (read-only token) — PR code executes only here.
-- `vr-approve.yml`: the gate is real — approval flavor only, artifact
-  verified as inert data (PNG magic bytes, ≤500 files, ≤50 MiB), the
-  approval INDEPENDENTLY re-verified via the API (comment body/author
-  permission/PR match; created_at not older than the head commit;
-  head_sha must equal the PR's CURRENT head — deliberately stronger than
-  the workflow_run.head_sha field, which is useless for comment-triggered
-  runs), idempotent per head SHA, commits only to `vr-update/pr-<n>`.
+- `vr-compare.yml` provides the `/approve-visuals` path after source merge:
+  issue_comment trigger, OWNER/MEMBER/COLLABORATOR association, exact command,
+  default-branch target, and a comment timestamp strictly newer than the merge.
+  It resolves the post-merge `merge_commit_sha`, confirms that commit remains
+  reachable from the default branch, checks it out from the base repository,
+  and regenerates `vr-baselines-approved` in the pinned container. This half
+  remains unprivileged (read-only token).
+- `vr-approve.yml` independently re-verifies the comment body/linkage, live
+  collaborator permission, merged/default target, strict post-merge timestamp,
+  immutable `render_sha == merge_commit_sha`, and default-branch reachability.
+  It accepts only PNGs (magic bytes, ≤500 files, ≤50 MiB), runs the already-
+  merged commit's preview generator without `GH_TOKEN` in the environment, and
+  exposes write credentials only to the final script-free commit/push step.
+  Publication is idempotent per render SHA and limited to `vr-update/pr-<n>`.
 - CI guard: new `vr-baseline-guard` job rejects PR diffs touching
   `tests/visual/__screenshots__/` unless the head is a same-repo
   `vr-update/pr-N` branch.
+- Source-first publication invariant (added after PR #337): maintainers inspect
+  candidate evidence, merge source, comment `/approve-visuals` on the merged PR,
+  then review and merge the generated baseline PR. Intentional source diffs may
+  leave VR Compare red, so it is not a required branch-protection check; making
+  it required would deadlock this order. This prevents docs-owned previews from
+  publishing ahead of their source.
 - `release.yml`: changesets/action, `id-token: write`, npm trusted
   publishing (OIDC + provenance via publishConfig; NO tokens), publish =
   `changeset publish` after `bun run build`; setup-node 24 for npm OIDC.
@@ -202,9 +210,10 @@ LICENSE (MIT, Liam O'Dea) at root + copied into each package; READMEs (root
    `@ggsvelte/core` pointing at `.github/workflows/release.yml`.
 3. **Secrets**: `ANTHROPIC_API_KEY` (evals.yml). No NPM_TOKEN — trusted
    publishing only.
-4. **First CI run**: bootstraps VR container baselines via the
-   vr-compare → `/approve-visuals` → vr-approve path; then enable branch
-   protection with the required checks.
+4. **First CI run**: inspect VR candidates, merge source to the default branch,
+   comment `/approve-visuals` on that merged PR, then merge the generated
+   `vr-update/pr-<n>` PR. Enable required checks afterward, but keep VR Compare
+   non-required because source-first approval would otherwise deadlock.
 5. **Domain** (`ggsvelte.dev` or equivalent): optional pre-0.1.0; schema
    stays served from the repo/docs build until then.
 6. **Publish**: merge the changesets "Version Packages" PR → release.yml

--- a/packages/svelte/skills/ggsvelte/SKILL.md
+++ b/packages/svelte/skills/ggsvelte/SKILL.md
@@ -41,8 +41,10 @@ ndensity`; density→`density, scaled`; smooth→`y, ymin, ymax, se`;
 - **facet**: wrap form `{"wrap": {"field": "g"}, "ncol": 3}` XOR grid form
   `{"rows": {...}, "cols": {...}}`; `"scales": "fixed"|"free"|"free_x"|"free_y"`.
 - **scales**: per channel: `{"type": "linear"|"log"|"time"|"band"}` for x/y;
-  time scales additionally accept `"parse"` (closed names such as `"dmy"`),
-  `"temporalKind"`, `"timezone"`, and `"disambiguation"`.
+  time scales additionally accept `"parse"` (closed names such as `"dmy"`,
+  exact `{ "format": ... }`, or `{ "epoch": "seconds"|"milliseconds" }`),
+  `"temporalKind"`, `"timezone"`, `"disambiguation"`, and
+  `"parseFailure":"error"|"censor"`.
   `{"type": "ordinal"|"sequential", "scheme"?, "range"?, "domain"?}` for
   color/fill. Defaults are inferred and disclosed as advisories.
 - **temporal defaults**: ISO dates/date-times, four-digit year strings,
@@ -50,6 +52,14 @@ ndensity`; density→`density, scaled`; smooth→`y, ymin, ymax, se`;
   plus whole-column validation. Ambiguous ordered dates stay discrete: set
   `"parse":"dmy"` or `"parse":"mdy"`. For year-like identifiers, force
   `{"type":"band"}`. Never preprocess dates into indexes.
+- **temporal override rules**: `.scaleXDate()`/`.scaleYDate()` serialize mapped
+  authoring `Date` cells as calendar dates; `.scaleXDatetime()`/
+  `.scaleYDatetime()` preserve instants.
+  Explicit `linear`/`log` disables temporal inference, so numeric strings stay
+  quantitative. Explicit ordinal color/fill keeps temporal-looking labels as
+  separate groups; sequential temporal color/fill uses parsed domains and
+  calendar legend labels. Censoring is available only with an explicit parser;
+  invalid configuration and ambiguous automatic inference remain errors.
 - Rendering surfaces: `<GGPlot spec={...}/>` (Svelte),
   `renderToSVGString(spec, {width, height})` (headless, Node-safe),
   `ggsvelte-render spec.json > out.svg` (CLI; JSON-line diagnostics on stderr).

--- a/scripts/release-wiring.test.ts
+++ b/scripts/release-wiring.test.ts
@@ -379,6 +379,44 @@ it("caps aggregate heavy self-hosted work across workflows (issues #247 and #319
   expect(ci).toContain("Heavy-job pool policy");
 });
 
+it("binds approved baselines to a post-merge default-branch commit", () => {
+  const compare = read(".github/workflows/vr-compare.yml");
+  const approve = read(".github/workflows/vr-approve.yml");
+  const checkout = approve.indexOf("checkout exact verified merged commit from base repo");
+
+  for (const workflow of [compare, approve]) {
+    expect(workflow).toContain(".merge_commit_sha");
+    expect(workflow).toContain(".base.repo.full_name");
+    expect(workflow).toContain(".base.ref");
+    expect(workflow).toContain("default_branch");
+    expect(workflow).toContain('comment_epoch="$(date -u -d');
+    expect(workflow).toContain('merged_epoch="$(date -u -d');
+    expect(workflow).toContain('if [ "${comment_epoch}" -le "${merged_epoch}" ]; then');
+    expect(workflow).toContain("identical|ahead");
+    expect(workflow).toContain('-f sha="${default_branch}"');
+  }
+  expect(compare).toContain("compare/${render_sha}...${default_sha}");
+  expect(compare).toContain('render_repo="${REPO}"');
+  expect(compare).not.toContain(".head.repo.full_name");
+  expect(compare).toContain("source PR #${PR_NUMBER} is not merged");
+  expect(compare).toContain("approval comment predates merge");
+  expect(compare).toContain("ref: ${{ needs.approve-gate.outputs.render_sha }}");
+  expect(approve).toContain("compare/${RENDER_SHA}...${default_sha}");
+  expect(approve).toContain("artifact render is for ${RENDER_SHA}");
+  expect(approve).toContain('if [ "${comment_epoch}" -le "${commit_epoch}" ]; then');
+  expect(approve).toContain("ref: ${{ steps.verify.outputs.render_sha }}");
+  expect(approve.indexOf('merged_at="$(printf')).toBeLessThan(checkout);
+
+  const installAndGenerator = approve.slice(
+    approve.indexOf("install dependencies at verified merged commit"),
+    approve.indexOf("commit and push verified baselines to vr-update/pr-<n>"),
+  );
+  expect(installAndGenerator).toContain("bun install --frozen-lockfile");
+  expect(installAndGenerator).toContain("bun scripts/gen-gallery-previews.ts");
+  expect(installAndGenerator).not.toContain("GH_TOKEN:");
+  expect(installAndGenerator).not.toContain("GITHUB_TOKEN:");
+});
+
 it("regenerates docs-owned gallery previews when approved baselines land", () => {
   const approve = read(".github/workflows/vr-approve.yml");
   const copy = approve.indexOf("find ../vr-artifact -name '*.png'");

--- a/skills/ggsvelte/SKILL.md
+++ b/skills/ggsvelte/SKILL.md
@@ -41,8 +41,10 @@ ndensity`; density→`density, scaled`; smooth→`y, ymin, ymax, se`;
 - **facet**: wrap form `{"wrap": {"field": "g"}, "ncol": 3}` XOR grid form
   `{"rows": {...}, "cols": {...}}`; `"scales": "fixed"|"free"|"free_x"|"free_y"`.
 - **scales**: per channel: `{"type": "linear"|"log"|"time"|"band"}` for x/y;
-  time scales additionally accept `"parse"` (closed names such as `"dmy"`),
-  `"temporalKind"`, `"timezone"`, and `"disambiguation"`.
+  time scales additionally accept `"parse"` (closed names such as `"dmy"`,
+  exact `{ "format": ... }`, or `{ "epoch": "seconds"|"milliseconds" }`),
+  `"temporalKind"`, `"timezone"`, `"disambiguation"`, and
+  `"parseFailure":"error"|"censor"`.
   `{"type": "ordinal"|"sequential", "scheme"?, "range"?, "domain"?}` for
   color/fill. Defaults are inferred and disclosed as advisories.
 - **temporal defaults**: ISO dates/date-times, four-digit year strings,
@@ -50,6 +52,14 @@ ndensity`; density→`density, scaled`; smooth→`y, ymin, ymax, se`;
   plus whole-column validation. Ambiguous ordered dates stay discrete: set
   `"parse":"dmy"` or `"parse":"mdy"`. For year-like identifiers, force
   `{"type":"band"}`. Never preprocess dates into indexes.
+- **temporal override rules**: `.scaleXDate()`/`.scaleYDate()` serialize mapped
+  authoring `Date` cells as calendar dates; `.scaleXDatetime()`/
+  `.scaleYDatetime()` preserve instants.
+  Explicit `linear`/`log` disables temporal inference, so numeric strings stay
+  quantitative. Explicit ordinal color/fill keeps temporal-looking labels as
+  separate groups; sequential temporal color/fill uses parsed domains and
+  calendar legend labels. Censoring is available only with an explicit parser;
+  invalid configuration and ambiguous automatic inference remain errors.
 - Rendering surfaces: `<GGPlot spec={...}/>` (Svelte),
   `renderToSVGString(spec, {width, height})` (headless, Node-safe),
   `ggsvelte-render spec.json > out.svg` (CLI; JSON-line diagnostics on stderr).


### PR DESCRIPTION
## Summary

- update the canonical and packaged ggsvelte agent skill with the temporal parser, Date/datetime, quantitative override, and temporal color semantics shipped in #336
- make visual approval source-first: approval is accepted only after a default-branch merge and is bound to the immutable `merge_commit_sha`
- render screenshots and docs previews from the same verified base-repository commit, with write credentials absent while repository code runs
- document the intentional source → approval → baseline landing order discovered while resolving #337
- add a patch changeset for the packaged skill update

## Visual approval invariants

- unmerged PR code runs only in the unprivileged workflow
- pre-merge and same-second approval comments are rejected
- non-default targets and unreachable render commits are rejected
- merge, squash, rebase, deleted-fork, and slash-containing default-branch cases resolve through the base repository and commit SHAs
- the privileged half independently re-verifies comment linkage, live permission, merge target, timestamps, render SHA, and reachability
- dependency install and preview generation have no `GH_TOKEN` environment entry; the credentialed step executes no repository scripts

## Verification

- `bun run test`: **1,162 passed**
- focused release/skill/temporal suites: **63 passed**
- full native-arm64 pre-push gate passed: package builds, docs and Svelte checks, type-aware lint, examples TypeScript, knip, tests, actionlint, and zizmor
- canonical and packaged skills are sync-tested

## Independent review

Independent Grok and Codex rereviews found no remaining P0/P1 issues. Every reported P2/P3 was also addressed, including strict timestamp equality, exact compare/check-out dataflow assertions, default-branch names containing `/`, stale trust-model docs, source-first branch-protection guidance, merged-generator naming, and write-token isolation.

## Related

Follow-up to #336 and #337.
