### PR TITLE
ci: replace heavy-job mutex with cpuset-isolated runner heavy lane

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -5,3 +5,4 @@
 self-hosted-runner:
   labels:
     - ggsvelte
+    - ggsvelte-heavy

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -62,11 +62,7 @@ jobs:
   bench-label:
     name: bench-label (budget gate on 'run-bench' PRs)
     if: github.event_name == 'pull_request' && github.event.label.name == 'run-bench'
-    runs-on: [self-hosted, ggsvelte]
-    concurrency:
-      group: heavy-self-hosted-cpu
-      cancel-in-progress: false
-      queue: max
+    runs-on: [self-hosted, ggsvelte, ggsvelte-heavy]
     container:
       image: mcr.microsoft.com/playwright:v1.61.1-noble
     defaults:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,19 +39,22 @@ concurrency:
   # Cancel superseded runs on PRs/branches; never cancel main.
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
-# Heavy-job pool policy (issues #247 and #319):
-# Light jobs (detect-changes, checks, unit, actions-security, vr-baseline-guard,
-# compatibility-matrix, ci-gate) run freely. CPU-heavy work shares the repo-wide
-# `heavy-self-hosted-cpu` group with VR, Pages, and hard benchmarks so the four
-# runner services cannot oversubscribe their shared 8-vCPU host.
-# - Shared groups use `queue: max` so pending jobs wait (up to 100) instead of
-#   the default single-pending slot replacing earlier required runs.
-# - Informational interaction-perf shares the mutex despite being excluded from
-#   ci-gate; otherwise it can starve required work on the same physical host.
-# - Consumer throttling applies only to Ubuntu self-hosted rows; hosted
-#   Windows/macOS rows get a per-run unique group (no cross-PR serialization).
-# - Every Bun install uses a job-private runner.temp cache. The runner services
-#   share HOME, so ~/.bun/install/cache can race during concurrent restores.
+# Heavy-job pool policy (issues #247, #319, #321):
+# The self-hosted pool runs cpuset-isolated lanes. Two runner services carry
+# the `ggsvelte-heavy` label, each pinned to 4 dedicated host vCPUs; light
+# runners are pinned to 2 vCPUs each. CPU-heavy jobs opt into the heavy lane
+# via `runs-on: [self-hosted, ggsvelte, ggsvelte-heavy]`, so at most two run
+# concurrently and browser/Vitest worker auto-detection sees the allocated
+# CPU count (a docker shim applies the same cpuset to job containers).
+# - Light jobs (detect-changes, checks, unit, actions-security,
+#   vr-baseline-guard, compatibility-matrix, ci-gate) keep `ggsvelte` only and
+#   run freely; they may spill onto idle heavy runners without harm.
+# - Informational interaction-perf uses the heavy lane despite being excluded
+#   from ci-gate; it is CPU-heavy even though it is not required.
+# - Runner services share HOME; every Bun install uses a job-private
+#   runner.temp cache so concurrent restores cannot race.
+# - Job-started/completed hooks on the runners log host telemetry (load, PSI,
+#   memory, disk) so infra contention can be told apart from regressions.
 
 env:
   # Keep in sync with: spikes/browser devDependency "playwright" and the
@@ -157,12 +160,7 @@ jobs:
     name: packages-dist (build + upload packages/*/dist)
     needs: detect-changes
     if: needs.detect-changes.outputs.packages_dist == 'true'
-    runs-on: [self-hosted, ggsvelte]
-    # Cap concurrent heavy work on the shared self-hosted host (#247).
-    concurrency:
-      group: heavy-self-hosted-cpu
-      cancel-in-progress: false
-      queue: max
+    runs-on: [self-hosted, ggsvelte, ggsvelte-heavy]
     permissions:
       contents: read
     steps:
@@ -423,14 +421,8 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix: ${{ fromJSON(needs.compatibility-matrix.outputs.matrix) }}
-    # Linux rows use the private self-hosted pool; Windows/macOS stay on GitHub-hosted.
-    runs-on: ${{ startsWith(matrix.os, 'ubuntu') && fromJSON('["self-hosted","ggsvelte"]') || matrix.os }}
-    # Cap concurrent Ubuntu/self-hosted consumer rows only (#247). Hosted
-    # Windows/macOS rows get a unique group so they are not serialized.
-    concurrency:
-      group: ${{ startsWith(matrix.os, 'ubuntu') && 'heavy-self-hosted-cpu' || format('heavy-consumer-hosted-{0}', github.run_id) }}
-      cancel-in-progress: false
-      queue: max
+    # Linux rows use the private self-hosted heavy lane; Windows/macOS stay on GitHub-hosted.
+    runs-on: ${{ startsWith(matrix.os, 'ubuntu') && fromJSON('["self-hosted","ggsvelte","ggsvelte-heavy"]') || matrix.os }}
     timeout-minutes: 20
     permissions:
       contents: read
@@ -538,12 +530,7 @@ jobs:
     if: >-
       needs.detect-changes.outputs.component == 'true' &&
       needs.packages-dist.result == 'success'
-    runs-on: [self-hosted, ggsvelte]
-    # Shared with all required CPU-heavy jobs on this host (#247, #319).
-    concurrency:
-      group: heavy-self-hosted-cpu
-      cancel-in-progress: false
-      queue: max
+    runs-on: [self-hosted, ggsvelte, ggsvelte-heavy]
     env:
       # GitHub runs the container as root, while /github/home belongs to
       # pwuser. Firefox refuses that ownership mismatch.
@@ -692,12 +679,7 @@ jobs:
     if: >-
       needs.detect-changes.outputs.component == 'true' &&
       needs.packages-dist.result == 'success'
-    runs-on: [self-hosted, ggsvelte]
-    # Shared with all required CPU-heavy jobs on this host (#247, #319).
-    concurrency:
-      group: heavy-self-hosted-cpu
-      cancel-in-progress: false
-      queue: max
+    runs-on: [self-hosted, ggsvelte, ggsvelte-heavy]
     env:
       # GitHub runs the container as root, while /github/home belongs to
       # pwuser. Firefox refuses that ownership mismatch.
@@ -795,12 +777,7 @@ jobs:
     if: >-
       needs.detect-changes.outputs.component == 'true' &&
       needs.packages-dist.result == 'success'
-    runs-on: [self-hosted, ggsvelte]
-    # Shared with all required CPU-heavy jobs on this host (#247, #319).
-    concurrency:
-      group: heavy-self-hosted-cpu
-      cancel-in-progress: false
-      queue: max
+    runs-on: [self-hosted, ggsvelte, ggsvelte-heavy]
     env:
       # GitHub runs the container as root, while /github/home belongs to
       # pwuser. Firefox refuses that ownership mismatch.
@@ -904,12 +881,7 @@ jobs:
     if: >-
       needs.detect-changes.outputs.interaction_perf == 'true' &&
       needs.packages-dist.result == 'success'
-    runs-on: [self-hosted, ggsvelte]
-    # Informational does not mean CPU-light; share the host-wide mutex (#319).
-    concurrency:
-      group: heavy-self-hosted-cpu
-      cancel-in-progress: false
-      queue: max
+    runs-on: [self-hosted, ggsvelte, ggsvelte-heavy]
     env:
       HOME: /root
     container:
@@ -985,11 +957,7 @@ jobs:
     name: build (tsc -b, packaging lint, static analysis)
     needs: detect-changes
     if: needs.detect-changes.outputs.build == 'true'
-    runs-on: [self-hosted, ggsvelte]
-    concurrency:
-      group: heavy-self-hosted-cpu
-      cancel-in-progress: false
-      queue: max
+    runs-on: [self-hosted, ggsvelte, ggsvelte-heavy]
     permissions:
       contents: read
     steps:
@@ -1100,11 +1068,7 @@ jobs:
     name: bench-smoke (mitata, 1k workload)
     needs: detect-changes
     if: needs.detect-changes.outputs.bench_smoke == 'true'
-    runs-on: [self-hosted, ggsvelte]
-    concurrency:
-      group: heavy-self-hosted-cpu
-      cancel-in-progress: false
-      queue: max
+    runs-on: [self-hosted, ggsvelte, ggsvelte-heavy]
     permissions:
       contents: read
     steps:

--- a/.github/workflows/compatibility-nightly.yml
+++ b/.github/workflows/compatibility-nightly.yml
@@ -40,12 +40,8 @@ jobs:
       fail-fast: false
       max-parallel: 3
       matrix: ${{ fromJSON(needs.matrix.outputs.matrix) }}
-    # Linux rows use the private self-hosted pool; Windows/macOS stay on GitHub-hosted.
-    runs-on: ${{ startsWith(matrix.os, 'ubuntu') && fromJSON('["self-hosted","ggsvelte"]') || matrix.os }}
-    concurrency:
-      group: ${{ startsWith(matrix.os, 'ubuntu') && 'heavy-self-hosted-cpu' || format('heavy-nightly-hosted-{0}', github.run_id) }}
-      cancel-in-progress: false
-      queue: max
+    # Linux rows use the private self-hosted heavy lane; Windows/macOS stay on GitHub-hosted.
+    runs-on: ${{ startsWith(matrix.os, 'ubuntu') && fromJSON('["self-hosted","ggsvelte","ggsvelte-heavy"]') || matrix.os }}
     timeout-minutes: 20
     permissions:
       contents: read

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -68,11 +68,7 @@ jobs:
     name: build static docs
     needs: detect-changes
     if: needs.detect-changes.outputs.pages == 'true'
-    runs-on: [self-hosted, ggsvelte]
-    concurrency:
-      group: heavy-self-hosted-cpu
-      cancel-in-progress: false
-      queue: max
+    runs-on: [self-hosted, ggsvelte, ggsvelte-heavy]
     permissions:
       contents: read
     steps:

--- a/.github/workflows/vr-compare.yml
+++ b/.github/workflows/vr-compare.yml
@@ -93,11 +93,7 @@ jobs:
     name: build docs, screenshot, upload candidate baselines
     needs: detect-changes
     if: github.event_name == 'pull_request' && needs.detect-changes.outputs.vr == 'true'
-    runs-on: [self-hosted, ggsvelte]
-    concurrency:
-      group: heavy-self-hosted-cpu
-      cancel-in-progress: false
-      queue: max
+    runs-on: [self-hosted, ggsvelte, ggsvelte-heavy]
     permissions:
       contents: read
     container:
@@ -276,11 +272,7 @@ jobs:
     name: /approve-visuals — regenerate baselines at merged commit (pinned container)
     needs: approve-gate
     if: needs.approve-gate.outputs.match == 'true'
-    runs-on: [self-hosted, ggsvelte]
-    concurrency:
-      group: heavy-self-hosted-cpu
-      cancel-in-progress: false
-      queue: max
+    runs-on: [self-hosted, ggsvelte, ggsvelte-heavy]
     permissions:
       contents: read # checkout only; this job can write nothing
     container:

--- a/scripts/actionlint.test.ts
+++ b/scripts/actionlint.test.ts
@@ -77,8 +77,9 @@ jobs: {}
     expect(prepared).not.toContain("queue: max");
     expect(prepared).toContain("group: heavy-component");
     expect(prepared).toContain("cancel-in-progress: false");
-    // Real workflow file still has queue: max; only lint input is rewritten.
-    expect(read(".github/workflows/ci.yml")).toContain("queue: max");
+    // Workflows dropped queue: max with the heavy-lane switch (#321); the
+    // strip stays so a future reintroduction cannot break the wasm linter.
+    expect(read(".github/workflows/ci.yml")).not.toContain("queue: max");
   });
 
   it("keeps .github/actionlint.yaml labels wired into the wasm runner", () => {

--- a/scripts/release-wiring.test.ts
+++ b/scripts/release-wiring.test.ts
@@ -4,12 +4,11 @@ import { join } from "node:path";
 
 const root = join(import.meta.dir, "..");
 const read = (path: string) => readFileSync(join(root, path), "utf8");
-const heavyGroupCount = (workflow: string) =>
+const heavyLaneCount = (workflow: string) =>
   workflow
     .split("\n")
-    .filter(
-      (line) => line.trimStart().startsWith("group:") && line.includes("heavy-self-hosted-cpu"),
-    ).length;
+    .filter((line) => line.trimStart().startsWith("runs-on:") && line.includes("ggsvelte-heavy"))
+    .length;
 
 describe("R0 release wiring", () => {
   it("runs benchmark unit tests in CI and pre-push parity", () => {
@@ -354,28 +353,33 @@ it("tiers the PR consumer matrix (issue #246)", () => {
   expect(ci).not.toMatch(/full required[\s\S]{0,40}push\/main/i);
 });
 
-it("caps aggregate heavy self-hosted work across workflows (issues #247 and #319)", () => {
+it("routes CPU-heavy work through the runner heavy lane (issues #247, #319, #321)", () => {
   const ci = read(".github/workflows/ci.yml");
   const vr = read(".github/workflows/vr-compare.yml");
   const pages = read(".github/workflows/pages.yml");
   const bench = read(".github/workflows/bench.yml");
   const nightly = read(".github/workflows/compatibility-nightly.yml");
 
-  // One repo-wide group is the aggregate mutex. Category-specific groups let
-  // browser, build, and benchmark jobs starve each other on the same host.
-  expect(heavyGroupCount(ci)).toBe(8);
-  expect(heavyGroupCount(vr)).toBe(2);
-  expect(heavyGroupCount(pages)).toBe(1);
-  expect(heavyGroupCount(bench)).toBe(1);
-  expect(heavyGroupCount(nightly)).toBe(1);
+  // The pool runs cpuset-pinned lanes: two runner services carry the
+  // ggsvelte-heavy label (4 dedicated vCPUs each), so at most two heavy jobs
+  // run concurrently while light jobs flow freely. Category-specific labels
+  // would let browser, build, and benchmark jobs starve each other again.
+  expect(heavyLaneCount(ci)).toBe(8);
+  expect(heavyLaneCount(vr)).toBe(2);
+  expect(heavyLaneCount(pages)).toBe(1);
+  expect(heavyLaneCount(bench)).toBe(1);
+  expect(heavyLaneCount(nightly)).toBe(1);
+  // The post-#319 repo-wide concurrency mutex must not come back: labels, not
+  // groups, gate host capacity now (#321).
+  for (const workflow of [ci, vr, pages, bench, nightly]) {
+    expect(workflow).not.toContain("heavy-self-hosted-cpu");
+  }
   expect(ci).not.toContain("heavy-component");
   expect(ci).not.toContain("heavy-packages-dist");
   expect(ci).not.toContain("heavy-consumer-ubuntu");
-  // Informational performance work is still CPU-heavy: leaving it outside the
-  // mutex can starve the required browser and memory gates it runs beside.
+  // Informational performance work is still CPU-heavy: it opts into the heavy
+  // lane with the required browser and memory gates it runs beside.
   expect(ci).not.toContain("group: heavy-interaction-perf");
-  // Pending jobs queue instead of replacing each other (GitHub queue: max).
-  for (const workflow of [ci, vr, pages, bench, nightly]) expect(workflow).toContain("queue: max");
   expect(ci).toContain("Heavy-job pool policy");
 });
 


### PR DESCRIPTION
## Summary

Closes #321. Follow-up to #247 and #319.

The four-runner/8-vCPU host made CPU-heavy jobs oversubscribe when packed together, which forced the repo-wide `heavy-self-hosted-cpu` concurrency mutex after #319 — correct, but it fully serialized CI, VR Compare, Pages, and Bench heavy work.

The runner pool now provides **cpuset-isolated lanes**: two runner services carry the `ggsvelte-heavy` label (4 dedicated vCPUs each) and light runners are pinned to 2 vCPUs each. Heavy jobs opt into the lane via `runs-on: [self-hosted, ggsvelte, ggsvelte-heavy]` — at most two run concurrently, with no workflow-level serialization.

## What changes

- **12 heavy jobs** across ci/vr-compare/pages/bench/compatibility-nightly drop the `heavy-self-hosted-cpu` mutex and target `ggsvelte-heavy`
- **consumer-compat / packed-consumer** Ubuntu rows ride the heavy lane (hosted Windows/macOS rows unchanged)
- Policy comment in `ci.yml` rewritten for the lane model
- Structural wiring test now asserts lane routing (same per-workflow heavy counts) and bans reintroducing the mutex; actionlint learns the `ggsvelte-heavy` label

## Ops side (private ops package, already applied)

- systemd `CPUAffinity` pins each runner service to its slot; jobs' `nproc`/worker auto-detection sees the allocated CPU count, not the whole host
- a `docker` CLI shim injects the slot's cpuset into `docker create|run`, so Playwright container jobs are pinned too (containers are siblings of the service cgroup)
- job-started/completed hooks log host telemetry (load, PSI cpu/mem/io, MemAvailable, disk %, cgroup throttling) to the job log and `/var/log/ci-runner-telemetry.log`
- legacy shared Bun cache removed at provision; all services share `/home/runner`, and job-private `runner.temp` caches remain the isolation boundary
- **capacity note**: cx53 (16 vCPU) is exhausted EU-wide at PR time; a cpx42 bridge host (1 heavy + 2 light, same lane mechanics) serves CI until the cx53 swap lands — tracked in ops, no repo impact

## Acceptance mapping (#321)

- [x] At most two heavy jobs concurrently, with explicit CPU allocations — two `ggsvelte-heavy` runners, 4 dedicated vCPUs each
- [x] Worker auto-detection sees allocated CPUs — cpuset on service + container shim (verified: container `nproc` = slot size)
- [x] Telemetry distinguishing infra load from product regressions — hook-emitted load/PSI/memory/disk per job
- [x] Shared `/home/runner` confirmed; legacy shared Bun cache cleaned; job-private caches stay
- [ ] CI + VR + Pages overlap without starvation gaps — this PR's own runs exercise the lanes; telemetry gives the evidence trail

## Test plan

- [x] `bun run lint:actions` clean (12 workflow files)
- [x] `bun test packages/spec packages/core benchmarks scripts tests/evals` — 1192 pass
- [ ] This PR's CI on the new lanes: heavy jobs land on `ggsvelte-heavy` runners only, ≤2 concurrent