### PR TITLE
feat(docs): add advanced playground tools

### DIFF
--- a/apps/docs/src/lib/Playground.svelte
+++ b/apps/docs/src/lib/Playground.svelte
@@ -4,6 +4,7 @@
 
   import { copyText, MANUAL_LINK_COPY_STATUS } from "$lib/clipboard";
   import PlaygroundEditor from "$lib/components/PlaygroundEditor.svelte";
+  import PlaygroundEvents from "$lib/components/PlaygroundEvents.svelte";
   import PlaygroundOutput from "$lib/components/PlaygroundOutput.svelte";
   import PlaygroundPreview from "$lib/components/PlaygroundPreview.svelte";
   import PlaygroundShell from "$lib/components/PlaygroundShell.svelte";
@@ -12,11 +13,16 @@
     PLAYGROUND_SAMPLES,
   } from "$lib/generated/playground-seeds";
   import {
+    appendPlaygroundEvent,
+    type PlaygroundEventEntry,
+    type PlaygroundInteractionEvent,
+  } from "$lib/playground-events";
+  import {
     decodePlaygroundHash,
     encodePlaygroundSeed,
     type PlaygroundSeedV1,
   } from "$lib/playground-codec";
-  import { playgroundSvelteOutput } from "$lib/playground-output";
+  import { playgroundOutputs } from "$lib/playground-output";
   import {
     confirmPlaygroundRendered,
     createPlaygroundState,
@@ -28,9 +34,9 @@
     setPlaygroundHistoryHash,
     stagePlaygroundDraft,
     stagePlaygroundSeed,
+    stagePlaygroundUndo,
     type PlaygroundDiagnostic,
   } from "$lib/playground-state";
-
   const initialSample = PLAYGROUND_SAMPLES[0]!;
   const initialSeed: PlaygroundSeedV1 = initialSample.seed;
 
@@ -38,8 +44,9 @@
   let shareUrl = $state("");
   let shareStatus = $state("");
   let shareSource = $state<HTMLElement>();
+  let events = $state<readonly PlaygroundEventEntry[]>([]);
 
-  const svelteOutput = $derived(playgroundSvelteOutput(workbench.committed));
+  const outputs = $derived(playgroundOutputs(workbench.committed));
   const selectedSample = $derived(
     workbench.seed.source.kind === "sample" ? workbench.seed.source.id : "",
   );
@@ -83,6 +90,7 @@
       workbench = reportPlaygroundDiagnostic(
         workbench,
         {
+          source: "playground",
           code: decoded.error.code.toLowerCase().replaceAll("_", "-"),
           path: "#play",
           message: decoded.error.message,
@@ -124,6 +132,18 @@
     workbench = resetPlaygroundSource(workbench);
   }
 
+  function undoChart(): void {
+    if (workbench.undoSnapshots.length === 0 || workbench.candidate !== null)
+      return;
+    if (!workbench.synchronized) {
+      const discard = window.confirm(
+        "Discard the current draft and undo to the previous rendered chart? Copy it first if you need to keep it.",
+      );
+      if (!discard) return;
+    }
+    workbench = stagePlaygroundUndo(workbench);
+  }
+
   function loadSample(id: string): boolean {
     if (id === "") return false;
     if (
@@ -151,8 +171,12 @@
       const promoted = promotePlaygroundCandidate(current, generation);
       if (promoted === current) return;
       workbench = promoted;
+      events = [];
       if (
-        (origin === "apply" || origin === "source") &&
+        (origin === "apply" ||
+          origin === "source" ||
+          origin === "reset" ||
+          origin === "undo") &&
         window.location.hash.startsWith("#play=")
       ) {
         replaceLocationHash(null);
@@ -170,6 +194,10 @@
     if (workbench.navigationRecovery !== null) {
       replaceLocationHash(workbench.navigationRecovery.replaceHash);
     }
+  }
+
+  function recordInteraction(event: PlaygroundInteractionEvent): void {
+    events = appendPlaygroundEvent(events, event);
   }
 
   function activeFailed(diagnostic: PlaygroundDiagnostic): void {
@@ -205,9 +233,10 @@
       <p class="eyebrow">Local PortableSpec workbench</p>
       <h1 id="playground-heading">Adapt a chart, then take the Svelte</h1>
       <p class="lede">
-        Start from a real example or a small sample. Edit bounded JSON, render
-        it locally, and copy one complete Svelte component. No account, upload,
-        remote fetch, or code execution.
+        Start from a real example or a small sample. Edit bounded JSON, inspect
+        semantic events, and take complete Svelte, equivalent Builder or
+        PortableSpec, and deterministic SVG. No account, upload, remote fetch,
+        or code execution.
       </p>
     </div>
     <div class="share-actions">
@@ -241,6 +270,7 @@
         onActiveRendered={() =>
           (workbench = confirmPlaygroundRendered(workbench))}
         onActiveFailed={activeFailed}
+        onInteraction={recordInteraction}
       />
     {/snippet}
     {#snippet editor()}
@@ -250,17 +280,21 @@
         {selectedSample}
         diagnostics={workbench.diagnostics}
         pending={workbench.candidate !== null}
+        canUndo={workbench.undoSnapshots.length > 0}
         onEdit={editDraft}
         onApply={applyDraft}
+        onUndo={undoChart}
         onReset={resetSource}
         onLoadSample={loadSample}
       />
     {/snippet}
     {#snippet output()}
       <PlaygroundOutput
-        code={svelteOutput}
+        {outputs}
+        rendered={workbench.rendered}
         enabled={workbench.canCopyOrShare}
       />
+      <PlaygroundEvents entries={events} onClear={() => (events = [])} />
     {/snippet}
   </PlaygroundShell>
 </section>

--- a/apps/docs/src/lib/components/PlaygroundEditor.svelte
+++ b/apps/docs/src/lib/components/PlaygroundEditor.svelte
@@ -9,8 +9,10 @@
     selectedSample,
     diagnostics,
     pending,
+    canUndo,
     onEdit,
     onApply,
+    onUndo,
     onReset,
     onLoadSample,
   }: {
@@ -19,8 +21,10 @@
     selectedSample: string;
     diagnostics: readonly PlaygroundDiagnostic[];
     pending: boolean;
+    canUndo: boolean;
     onEdit: (draft: string) => void;
     onApply: () => void;
+    onUndo: () => void;
     onReset: () => void;
     onLoadSample: (id: string) => boolean;
   } = $props();
@@ -30,7 +34,7 @@
 
   $effect(() => {
     const signature = diagnostics
-      .map((item) => `${item.code}:${item.path}`)
+      .map((item) => `${item.source}:${item.code}:${item.path}`)
       .join("|");
     if (signature === "") {
       focusedSignature = "";
@@ -98,9 +102,12 @@
     >
       <strong>Draft not applied</strong>
       <ol>
-        {#each diagnostics as diagnostic (`${diagnostic.code}:${diagnostic.path}`)}
+        {#each diagnostics as diagnostic (`${diagnostic.source}:${diagnostic.code}:${diagnostic.path}`)}
           <li>
-            <code>{diagnostic.code}</code>
+            <p class="diagnostic-identity">
+              <span>{diagnostic.source}</span>
+              <code>{diagnostic.code}</code>
+            </p>
             {#if diagnostic.path !== ""}<span>{diagnostic.path}</span>{/if}
             <p>{diagnostic.message}</p>
             {#if diagnostic.fix !== undefined}<p class="fix">
@@ -115,6 +122,9 @@
   <div class="editor-actions">
     <button class="primary" type="submit" disabled={pending}
       >{pending ? "Checking…" : "Apply draft"}</button
+    >
+    <button type="button" onclick={onUndo} disabled={pending || !canUndo}
+      >Undo chart</button
     >
     <button type="button" onclick={onReset} disabled={pending}
       >Reset source</button
@@ -214,14 +224,28 @@
     padding-left: 1.2rem;
   }
 
+  .diagnostic-identity {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    align-items: baseline;
+  }
+
+  .diagnostic-identity span {
+    color: var(--accent);
+    font: 700 0.68rem/1 var(--body-font);
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+
   .diagnostics li p,
-  .diagnostics li span {
+  .diagnostics li > span {
     margin: 0.2rem 0 0;
     overflow-wrap: anywhere;
     font-size: 0.82rem;
   }
 
-  .diagnostics li span {
+  .diagnostics li > span {
     display: block;
     color: var(--muted);
     font-family: var(--mono-font);

--- a/apps/docs/src/lib/components/PlaygroundEvents.svelte
+++ b/apps/docs/src/lib/components/PlaygroundEvents.svelte
@@ -1,0 +1,155 @@
+<script lang="ts">
+  import {
+    PLAYGROUND_MAX_EVENTS,
+    type PlaygroundEventEntry,
+  } from "$lib/playground-events";
+
+  const {
+    entries,
+    onClear,
+  }: {
+    entries: readonly PlaygroundEventEntry[];
+    onClear: () => void;
+  } = $props();
+
+  const newestFirst = $derived(entries.toReversed());
+</script>
+
+<details class="event-inspector">
+  <summary>
+    <span>Semantic events</span>
+    <span class="count"
+      >{entries.length} / {PLAYGROUND_MAX_EVENTS} local records</span
+    >
+  </summary>
+  <div class="event-body">
+    <div class="event-intro">
+      <p>
+        Interact with a mark to inspect public <code>oninteraction</code>
+        payloads. This chart-local log is never persisted or shared.
+      </p>
+      <button type="button" onclick={onClear} disabled={entries.length === 0}
+        >Clear events</button
+      >
+    </div>
+    {#if newestFirst.length === 0}
+      <p class="empty">
+        No semantic events yet. Move to or focus a chart mark.
+      </p>
+    {:else}
+      <ol aria-label="Semantic event log">
+        {#each newestFirst as entry (entry.sequence)}
+          <li>
+            <header>
+              <strong>{entry.type}/{entry.phase}</strong>
+              <span>#{entry.sequence} · {entry.source}</span>
+            </header>
+            <!-- svelte-ignore a11y_no_noninteractive_tabindex (event JSON is scrollable) -->
+            <pre tabindex="0"><code>{entry.json}</code></pre>
+          </li>
+        {/each}
+      </ol>
+    {/if}
+  </div>
+</details>
+
+<style>
+  .event-inspector {
+    margin-top: 1rem;
+    border-block: 1px solid var(--line);
+  }
+
+  summary {
+    display: flex;
+    min-height: 44px;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.6rem 0;
+    cursor: pointer;
+    font-weight: 700;
+  }
+
+  .count,
+  .event-intro p,
+  .empty,
+  li header span {
+    color: var(--muted);
+    font-size: 0.75rem;
+  }
+
+  .event-body {
+    padding-block: 0.75rem 1rem;
+  }
+
+  .event-intro {
+    display: flex;
+    align-items: start;
+    justify-content: space-between;
+    gap: 1rem;
+  }
+
+  .event-intro p,
+  .empty {
+    margin: 0;
+  }
+
+  button {
+    min-height: 44px;
+    flex: 0 0 auto;
+    border: 1px solid var(--line);
+    border-radius: 2px;
+    padding: 0.55rem 0.7rem;
+    background: var(--paper);
+    color: var(--ink);
+    font: 650 0.78rem/1 var(--body-font);
+    cursor: pointer;
+  }
+
+  button:disabled {
+    cursor: not-allowed;
+    opacity: 0.45;
+  }
+
+  ol {
+    display: grid;
+    gap: 0.75rem;
+    margin: 1rem 0 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  li {
+    min-width: 0;
+    border-left: 2px solid var(--accent);
+    padding-left: 0.65rem;
+  }
+
+  li header {
+    display: flex;
+    justify-content: space-between;
+    gap: 0.75rem;
+  }
+
+  pre {
+    max-height: 16rem;
+    margin: 0.45rem 0 0;
+    overflow: auto;
+    padding: 0.65rem;
+    background: var(--code-paper);
+    color: var(--code-ink);
+    font: 0.7rem/1.5 var(--mono-font);
+  }
+
+  @media (max-width: 47.99rem) {
+    summary,
+    .event-intro,
+    li header {
+      align-items: start;
+    }
+
+    .event-intro {
+      display: grid;
+    }
+  }
+</style>

--- a/apps/docs/src/lib/components/PlaygroundOutput.svelte
+++ b/apps/docs/src/lib/components/PlaygroundOutput.svelte
@@ -1,56 +1,200 @@
 <script lang="ts">
+  import { tick } from "svelte";
+
   import { copyText, MANUAL_COPY_STATUS } from "$lib/clipboard";
+  import { playgroundSVGExport } from "$lib/playground-export";
+  import type { PlaygroundOutput } from "$lib/playground-output";
+  import type { PortableSpec } from "@ggsvelte/spec";
 
   const {
-    code,
+    outputs,
+    rendered,
     enabled,
   }: {
-    code: string;
+    outputs: readonly PlaygroundOutput[];
+    rendered: PortableSpec;
     enabled: boolean;
   } = $props();
 
-  let source = $state<HTMLElement>();
-  let status = $state("");
+  let active = $state(0);
+  let fallbackSource = $state<HTMLElement>();
+  let fallbackCode = $state("");
+  let fallbackLabel = $state("output");
+  let manualFallback = $state(false);
+  let copying = $state(false);
+  let copyStatus = $state("");
+  let exportStatus = $state("");
+  const tabsetId = $props.id();
+  const panelId = `${tabsetId}-panel`;
+  const activeOutput = $derived(outputs[active] ?? outputs[0]!);
+
+  function select(index: number): void {
+    if (copying) return;
+    active = index;
+    copyStatus = "";
+  }
+
+  function handleTabKey(event: KeyboardEvent, index: number): void {
+    let next = index;
+    if (event.key === "ArrowRight" || event.key === "ArrowDown") {
+      next = (index + 1) % outputs.length;
+    } else if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
+      next = (index - 1 + outputs.length) % outputs.length;
+    } else if (event.key === "Home") {
+      next = 0;
+    } else if (event.key === "End") {
+      next = outputs.length - 1;
+    } else {
+      return;
+    }
+    event.preventDefault();
+    select(next);
+    const target = event.currentTarget;
+    if (!(target instanceof HTMLButtonElement)) return;
+    const buttons =
+      target.parentElement?.querySelectorAll<HTMLButtonElement>('[role="tab"]');
+    buttons?.[next]?.focus();
+  }
 
   async function copy(): Promise<void> {
-    if (!enabled || source === undefined) return;
-    const result = await copyText(code, source);
-    status =
-      result === "copied" ? "Svelte component copied." : MANUAL_COPY_STATUS;
+    if (!enabled || !activeOutput.supported || copying) return;
+    const selected = activeOutput;
+    fallbackCode = selected.code;
+    fallbackLabel = selected.label;
+    manualFallback = false;
+    copying = true;
+    await tick();
+    if (fallbackSource === undefined) {
+      copying = false;
+      return;
+    }
+    const result = await copyText(selected.code, fallbackSource);
+    copying = false;
+    manualFallback = result !== "copied";
+    copyStatus =
+      result === "copied"
+        ? `${selected.label} output copied.`
+        : MANUAL_COPY_STATUS;
+  }
+
+  function exportSVG(): void {
+    if (!enabled) return;
+    exportStatus = "";
+    const result = playgroundSVGExport(rendered);
+    if (!result.ok) {
+      exportStatus = `SVG export failed · ${result.diagnostic.source}/${result.diagnostic.code}: ${result.diagnostic.message} ${result.diagnostic.fix ?? ""}`;
+      return;
+    }
+
+    let objectUrl: string | null = null;
+    try {
+      const blob = new Blob([result.svg], {
+        type: "image/svg+xml;charset=utf-8",
+      });
+      objectUrl = URL.createObjectURL(blob);
+      const anchor = document.createElement("a");
+      anchor.href = objectUrl;
+      anchor.download = result.filename;
+      anchor.click();
+      exportStatus = "SVG downloaded from the render-confirmed chart.";
+    } catch (error) {
+      exportStatus = `SVG export failed · export/download-failed: ${error instanceof Error ? error.message : "The browser refused the download."} The chart and outputs were retained.`;
+    } finally {
+      if (objectUrl !== null) URL.revokeObjectURL(objectUrl);
+    }
   }
 </script>
 
 <div class="panel-heading">
   <div>
     <p class="panel-number">03</p>
-    <h2>Take the Svelte component</h2>
+    <h2>Take the chart with you</h2>
   </div>
-  <button type="button" onclick={copy} disabled={!enabled}>Copy Svelte</button>
+  <div class="output-actions">
+    <button
+      type="button"
+      class="secondary"
+      onclick={exportSVG}
+      disabled={!enabled}>Download SVG</button
+    >
+    <button
+      type="button"
+      onclick={copy}
+      disabled={!enabled || !activeOutput.supported || copying}
+      >{copying ? "Copying…" : `Copy ${activeOutput.label}`}</button
+    >
+  </div>
 </div>
 
 {#if enabled}
   <p class="output-note">
-    This complete file contains the last render-confirmed PortableSpec.
+    Every enabled output contains the same render-confirmed PortableSpec.
   </p>
 {:else}
   <p class="output-note blocked">
-    Apply and render the draft successfully before copying or sharing output.
+    Apply and render the draft successfully before copying, sharing, or
+    exporting.
   </p>
 {/if}
 
-<!-- svelte-ignore a11y_no_noninteractive_tabindex (keyboard users must reach the scrollable source) -->
-<pre role="region" aria-label="Generated Svelte component" tabindex="0"><code
-    bind:this={source}>{code}</code
-  ></pre>
-<p class="copy-status" role="status" aria-live="polite">{status}</p>
+<div class="output-tabs">
+  <div class="tab-list" role="tablist" aria-label="Generated output formats">
+    {#each outputs as output, index (output.kind)}
+      <button
+        id={`${tabsetId}-tab-${String(index)}`}
+        type="button"
+        role="tab"
+        aria-controls={panelId}
+        aria-selected={active === index}
+        tabindex={active === index ? 0 : -1}
+        class:active={active === index}
+        aria-disabled={copying}
+        onclick={() => select(index)}
+        onkeydown={(event) => handleTabKey(event, index)}>{output.label}</button
+      >
+    {/each}
+  </div>
+  <div
+    id={panelId}
+    role="tabpanel"
+    aria-labelledby={`${tabsetId}-tab-${String(active)}`}
+  >
+    {#if activeOutput.supported}
+      <!-- svelte-ignore a11y_no_noninteractive_tabindex (keyboard users must reach the scrollable source) -->
+      <pre
+        role="region"
+        aria-label={activeOutput.kind === "svelte"
+          ? "Generated Svelte component"
+          : `Generated ${activeOutput.label} output`}
+        tabindex="0"><code>{activeOutput.code}</code></pre>
+    {:else}
+      <div class="unsupported" role="status">
+        <strong>Builder output unavailable for this chart</strong>
+        <p>{activeOutput.reason}</p>
+      </div>
+    {/if}
+  </div>
+</div>
+<p class="action-status" role="status" aria-live="polite">{copyStatus}</p>
+<p class="action-status" role="status" aria-live="polite">{exportStatus}</p>
+<div class:visible={manualFallback} class="manual-copy-source">
+  <p>Copy the selected {fallbackLabel} output manually:</p>
+  <!-- svelte-ignore a11y_no_noninteractive_tabindex (manual-copy source is scrollable) -->
+  <pre tabindex="0"><code bind:this={fallbackSource}>{fallbackCode}</code></pre>
+</div>
 
 <style>
   :global(.output-surface) {
     padding: 1rem;
   }
 
-  .panel-heading {
+  .panel-heading,
+  .output-actions,
+  .tab-list {
     display: flex;
+  }
+
+  .panel-heading {
     align-items: start;
     justify-content: space-between;
     gap: 1rem;
@@ -61,7 +205,8 @@
   .panel-heading h2,
   .panel-heading p,
   .output-note,
-  .copy-status {
+  .action-status,
+  .unsupported p {
     margin: 0;
   }
 
@@ -76,6 +221,12 @@
     letter-spacing: 0.08em;
   }
 
+  .output-actions {
+    flex-wrap: wrap;
+    gap: 0.45rem;
+    justify-content: end;
+  }
+
   button {
     min-height: 44px;
     border: 1px solid var(--ink);
@@ -83,8 +234,13 @@
     padding: 0.55rem 0.7rem;
     background: var(--ink);
     color: var(--paper);
-    font: 650 0.82rem/1 var(--body-font);
+    font: 650 0.78rem/1 var(--body-font);
     cursor: pointer;
+  }
+
+  button.secondary {
+    background: var(--paper);
+    color: var(--ink);
   }
 
   button:disabled {
@@ -93,32 +249,96 @@
   }
 
   .output-note,
-  .copy-status {
-    min-height: 2.7rem;
-    padding-block: 0.75rem;
+  .action-status {
+    min-height: 2.5rem;
+    padding-block: 0.7rem;
     color: var(--muted);
     font-size: 0.78rem;
   }
 
-  .output-note.blocked {
+  .output-note.blocked,
+  .unsupported {
     color: #9b2c20;
   }
 
+  .output-tabs {
+    border-block: 1px solid var(--line);
+  }
+
+  .tab-list {
+    max-width: 100%;
+    overflow-x: auto;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .tab-list button {
+    flex: 0 0 auto;
+    border: 0;
+    border-bottom: 2px solid transparent;
+    background: transparent;
+    color: var(--muted);
+  }
+
+  .tab-list button.active {
+    border-bottom-color: var(--accent);
+    color: var(--ink);
+  }
+
   pre {
-    max-height: 37rem;
+    max-height: 32rem;
     margin: 0;
     overflow: auto;
-    border-block: 1px solid var(--line);
     padding: 0.85rem;
     background: var(--code-paper);
     color: var(--code-ink);
-    font: 0.74rem/1.55 var(--mono-font);
+    font: 0.72rem/1.55 var(--mono-font);
     white-space: pre;
+  }
+
+  .unsupported {
+    min-height: 12rem;
+    padding: 1rem;
+    background: color-mix(in srgb, #b42318 6%, var(--paper));
+  }
+
+  .unsupported p {
+    margin-top: 0.5rem;
+    color: var(--muted);
+    font-size: 0.82rem;
+  }
+
+  .manual-copy-source {
+    position: fixed;
+    left: -200vw;
+    width: min(32rem, calc(100vw - 2rem));
+  }
+
+  .manual-copy-source.visible {
+    position: static;
+    margin-top: 0.75rem;
+  }
+
+  .manual-copy-source p {
+    margin: 0 0 0.5rem;
+    color: var(--muted);
+    font-size: 0.78rem;
+  }
+
+  .manual-copy-source pre {
+    max-height: 12rem;
   }
 
   @media (max-width: 47.99rem) {
     :global(.output-surface) {
       padding: 1rem 0;
+    }
+
+    .panel-heading {
+      display: grid;
+    }
+
+    .output-actions {
+      justify-content: start;
     }
 
     pre {

--- a/apps/docs/src/lib/components/PlaygroundOutput.svelte
+++ b/apps/docs/src/lib/components/PlaygroundOutput.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { tick } from "svelte";
+  import { tick, untrack } from "svelte";
 
   import { copyText, MANUAL_COPY_STATUS } from "$lib/clipboard";
   import { playgroundSVGExport } from "$lib/playground-export";
@@ -24,9 +24,25 @@
   let copying = $state(false);
   let copyStatus = $state("");
   let exportStatus = $state("");
+  let outputRevision = 0;
   const tabsetId = $props.id();
   const panelId = `${tabsetId}-panel`;
   const activeOutput = $derived(outputs[active] ?? outputs[0]!);
+
+  $effect(() => {
+    const nextOutputs = outputs;
+    untrack(() => {
+      outputRevision += 1;
+      if (active >= nextOutputs.length) active = 0;
+      const hadFallback = fallbackCode !== "";
+      fallbackCode = "";
+      fallbackLabel = "output";
+      manualFallback = false;
+      copyStatus = "";
+      copying = false;
+      if (hadFallback) getSelection()?.removeAllRanges();
+    });
+  });
 
   function select(index: number): void {
     if (copying) return;
@@ -59,6 +75,7 @@
   async function copy(): Promise<void> {
     if (!enabled || !activeOutput.supported || copying) return;
     const selected = activeOutput;
+    const revision = outputRevision;
     fallbackCode = selected.code;
     fallbackLabel = selected.label;
     manualFallback = false;
@@ -69,6 +86,7 @@
       return;
     }
     const result = await copyText(selected.code, fallbackSource);
+    if (revision !== outputRevision) return;
     copying = false;
     manualFallback = result !== "copied";
     copyStatus =
@@ -177,10 +195,16 @@
 </div>
 <p class="action-status" role="status" aria-live="polite">{copyStatus}</p>
 <p class="action-status" role="status" aria-live="polite">{exportStatus}</p>
-<div class:visible={manualFallback} class="manual-copy-source">
+<div
+  class:visible={manualFallback}
+  class="manual-copy-source"
+  aria-hidden={!manualFallback}
+>
   <p>Copy the selected {fallbackLabel} output manually:</p>
-  <!-- svelte-ignore a11y_no_noninteractive_tabindex (manual-copy source is scrollable) -->
-  <pre tabindex="0"><code bind:this={fallbackSource}>{fallbackCode}</code></pre>
+  <!-- svelte-ignore a11y_no_noninteractive_tabindex (visible manual-copy source is scrollable) -->
+  <pre tabindex={manualFallback ? 0 : -1}><code bind:this={fallbackSource}
+      >{fallbackCode}</code
+    ></pre>
 </div>
 
 <style>

--- a/apps/docs/src/lib/components/PlaygroundPreview.svelte
+++ b/apps/docs/src/lib/components/PlaygroundPreview.svelte
@@ -2,6 +2,7 @@
   import { PipelineError } from "@ggsvelte/core";
   import { GGPlot } from "@ggsvelte/svelte";
 
+  import type { PlaygroundInteractionEvent } from "$lib/playground-events";
   import type {
     PlaygroundCandidate,
     PlaygroundDiagnostic,
@@ -17,6 +18,7 @@
     onCandidateFailed,
     onActiveRendered,
     onActiveFailed,
+    onInteraction,
   }: {
     rendered: PortableSpec;
     candidate: PlaygroundCandidate | null;
@@ -29,11 +31,13 @@
     ) => void;
     onActiveRendered: () => void;
     onActiveFailed: (diagnostic: PlaygroundDiagnostic) => void;
+    onInteraction: (event: PlaygroundInteractionEvent) => void;
   } = $props();
 
   function diagnostic(error: unknown): PlaygroundDiagnostic {
     if (error instanceof PipelineError) {
       return {
+        source: "pipeline",
         code: error.code,
         path: error.path,
         message: error.message,
@@ -43,6 +47,7 @@
       };
     }
     return {
+      source: "pipeline",
       code: "render-failed",
       path: "",
       message:
@@ -66,7 +71,13 @@
   <div class="active-chart">
     {#key rendered}
       <svelte:boundary onerror={(error) => onActiveFailed(diagnostic(error))}>
-        <GGPlot spec={rendered} width="container" onrender={onActiveRendered} />
+        <GGPlot
+          spec={rendered}
+          width="container"
+          inspect={true}
+          oninteraction={onInteraction}
+          onrender={onActiveRendered}
+        />
         {#snippet failed()}
           <div class="render-error" role="status">
             The last valid chart could not be painted. Reset the source to

--- a/apps/docs/src/lib/generated/routes.ts
+++ b/apps/docs/src/lib/generated/routes.ts
@@ -44,7 +44,7 @@ export const DOCS_ROUTES = [
     path: "/playground",
     title: "PortableSpec playground — ggsvelte",
     description:
-      "Open a real ggsvelte example, edit a bounded PortableSpec locally, and copy a complete Svelte component or share URL.",
+      "Edit a bounded PortableSpec locally, inspect semantic events, and take complete Svelte, equivalent Builder or JSON, SVG, or a share URL.",
     canonicalPath: "/playground",
     kind: "page",
     index: true,

--- a/apps/docs/src/lib/generated/search-index.ts
+++ b/apps/docs/src/lib/generated/search-index.ts
@@ -36,7 +36,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "page",
     title: "PortableSpec playground",
     summary:
-      "Open a real ggsvelte example, edit a bounded PortableSpec locally, and copy a complete Svelte component or share URL.",
+      "Edit a bounded PortableSpec locally, inspect semantic events, and take complete Svelte, equivalent Builder or JSON, SVG, or a share URL.",
     href: "/playground",
     keywords: [],
     exact: ["PortableSpec playground"],

--- a/apps/docs/src/lib/playground-events.ts
+++ b/apps/docs/src/lib/playground-events.ts
@@ -1,0 +1,38 @@
+import type { CellValue } from "@ggsvelte/core";
+import type { PlotInteractionEvent } from "@ggsvelte/svelte";
+
+export type PlaygroundInteractionEvent = PlotInteractionEvent<Record<string, CellValue>>;
+
+export const PLAYGROUND_MAX_EVENTS = 20;
+
+export interface PlaygroundEventEntry {
+  readonly sequence: number;
+  readonly type: PlaygroundInteractionEvent["type"];
+  readonly phase: string;
+  readonly source: string;
+  readonly json: string;
+}
+
+function jsonSafeEvent(event: PlaygroundInteractionEvent): unknown {
+  return JSON.parse(
+    JSON.stringify(event, (_key, value: unknown) => {
+      if (typeof value === "symbol" || typeof value === "bigint") return String(value);
+      return value;
+    }),
+  ) as unknown;
+}
+
+export function appendPlaygroundEvent(
+  entries: readonly PlaygroundEventEntry[],
+  event: PlaygroundInteractionEvent,
+): readonly PlaygroundEventEntry[] {
+  const projected = jsonSafeEvent(event);
+  const next: PlaygroundEventEntry = {
+    sequence: (entries.at(-1)?.sequence ?? 0) + 1,
+    type: event.type,
+    phase: event.phase,
+    source: event.source,
+    json: JSON.stringify(projected, null, 2),
+  };
+  return [...entries, next].slice(-PLAYGROUND_MAX_EVENTS);
+}

--- a/apps/docs/src/lib/playground-export.ts
+++ b/apps/docs/src/lib/playground-export.ts
@@ -1,0 +1,46 @@
+import { PipelineError, renderToSVGString } from "@ggsvelte/core";
+import type { PortableSpec } from "@ggsvelte/spec";
+
+import type { PlaygroundDiagnostic } from "./playground-state";
+
+export type PlaygroundSVGExportResult =
+  | {
+      readonly ok: true;
+      readonly filename: "ggsvelte-chart.svg";
+      readonly svg: string;
+    }
+  | {
+      readonly ok: false;
+      readonly diagnostic: PlaygroundDiagnostic;
+    };
+
+type SVGRenderer = typeof renderToSVGString;
+
+/** Serialize only an already validated, render-confirmed PortableSpec. */
+export function playgroundSVGExport(
+  spec: PortableSpec,
+  render: SVGRenderer = renderToSVGString,
+): PlaygroundSVGExportResult {
+  try {
+    return {
+      ok: true,
+      filename: "ggsvelte-chart.svg",
+      svg: render(spec, {
+        width: spec.width ?? 960,
+        height: spec.height ?? 540,
+        maxMarks: 100_000,
+      }),
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      diagnostic: {
+        source: "export",
+        code: error instanceof PipelineError ? error.code : "svg-export-failed",
+        path: error instanceof PipelineError ? error.path : "",
+        message: error instanceof Error ? error.message : "The SVG export could not be serialized.",
+        fix: "Keep the current chart, then retry or reduce the spec before exporting.",
+      },
+    };
+  }
+}

--- a/apps/docs/src/lib/playground-output.ts
+++ b/apps/docs/src/lib/playground-output.ts
@@ -1,4 +1,14 @@
-import type { PortableSpec } from "@ggsvelte/spec";
+import { CURRENT_EDITION, gg, type PortableSpec } from "@ggsvelte/spec";
+
+export type PlaygroundOutputKind = "svelte" | "builder" | "portable-spec";
+
+export interface PlaygroundOutput {
+  readonly kind: PlaygroundOutputKind;
+  readonly label: string;
+  readonly supported: boolean;
+  readonly code: string;
+  readonly reason?: string;
+}
 
 function scriptSafeJSON(spec: PortableSpec): string {
   return JSON.stringify(spec, null, 2)
@@ -17,6 +27,142 @@ export function playgroundSvelteOutput(spec: PortableSpec): string {
 
 <GGPlot {spec} />
 `;
+}
+
+function builderUnsupportedReason(spec: PortableSpec): string | null {
+  if (spec.datasets !== undefined) {
+    return "Builder output cannot preserve named inline datasets yet. Copy Svelte or PortableSpec instead.";
+  }
+  return null;
+}
+
+/** Rebuild through the public fluent API used by generated Builder output. */
+export function rebuildPlaygroundSpecWithBuilder(spec: PortableSpec): PortableSpec | null {
+  if (builderUnsupportedReason(spec) !== null) return null;
+  try {
+    let builder = gg(spec.data, spec.aes);
+    for (const layer of spec.layers) builder = builder.layer(layer);
+    if (spec.facet !== undefined) builder = builder.facet(spec.facet);
+    if (spec.coord !== undefined) builder = builder.coord(spec.coord);
+    if (spec.a11y !== undefined) builder = builder.a11y(spec.a11y);
+    if (spec.scales !== undefined) builder = builder.scales(spec.scales);
+    if (spec.legend !== undefined) builder = builder.legend(spec.legend);
+    if (spec.labs !== undefined) builder = builder.labs(spec.labs);
+    if (spec.theme !== undefined) builder = builder.theme(spec.theme);
+    return {
+      ...builder.spec(),
+      ...(spec.$schema === undefined ? {} : { $schema: spec.$schema }),
+      edition: spec.edition ?? CURRENT_EDITION,
+      ...(spec.width === undefined ? {} : { width: spec.width }),
+      ...(spec.height === undefined ? {} : { height: spec.height }),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function builderJSON(value: unknown): string {
+  return JSON.stringify(value, null, 2)
+    .replaceAll("<", "\\u003c")
+    .replaceAll("\u2028", "\\u2028")
+    .replaceAll("\u2029", "\\u2029");
+}
+
+function sortedJSONValue(input: unknown): unknown {
+  if (Array.isArray(input)) return input.map((entry) => sortedJSONValue(entry));
+  if (typeof input !== "object" || input === null) return input;
+  return Object.fromEntries(
+    Object.entries(input)
+      .toSorted(([left], [right]) => left.localeCompare(right))
+      .map(([key, entry]) => [key, sortedJSONValue(entry)]),
+  );
+}
+
+function sortedJSON(value: unknown): string {
+  return JSON.stringify(sortedJSONValue(value));
+}
+
+function builderCall(name: string, value: unknown): string {
+  return `  .${name}(${builderJSON(value)})`;
+}
+
+export function playgroundBuilderOutput(spec: PortableSpec): PlaygroundOutput {
+  const unsupported = builderUnsupportedReason(spec);
+  if (unsupported !== null) {
+    return {
+      kind: "builder",
+      label: "Builder",
+      supported: false,
+      code: "",
+      reason: unsupported,
+    };
+  }
+
+  const rebuilt = rebuildPlaygroundSpecWithBuilder(spec);
+  if (rebuilt === null || sortedJSON(rebuilt) !== sortedJSON(spec)) {
+    return {
+      kind: "builder",
+      label: "Builder",
+      supported: false,
+      code: "",
+      reason:
+        "The public Builder cannot reproduce this normalized PortableSpec exactly. Copy Svelte or PortableSpec instead.",
+    };
+  }
+
+  const startArguments = [spec.data, spec.aes]
+    .map((value) => (value === undefined ? "undefined" : builderJSON(value)))
+    .join(", ")
+    .replace(/, undefined$/u, "");
+  const calls = [
+    ...spec.layers.map((layer) => builderCall("layer", layer)),
+    ...(spec.facet === undefined ? [] : [builderCall("facet", spec.facet)]),
+    ...(spec.coord === undefined ? [] : [builderCall("coord", spec.coord)]),
+    ...(spec.a11y === undefined ? [] : [builderCall("a11y", spec.a11y)]),
+    ...(spec.scales === undefined ? [] : [builderCall("scales", spec.scales)]),
+    ...(spec.legend === undefined ? [] : [builderCall("legend", spec.legend)]),
+    ...(spec.labs === undefined ? [] : [builderCall("labs", spec.labs)]),
+    ...(spec.theme === undefined ? [] : [builderCall("theme", spec.theme)]),
+  ];
+  const metadata = {
+    ...(spec.$schema === undefined ? {} : { $schema: spec.$schema }),
+    edition: spec.edition ?? CURRENT_EDITION,
+    ...(spec.width === undefined ? {} : { width: spec.width }),
+    ...(spec.height === undefined ? {} : { height: spec.height }),
+  };
+  const metadataLines = Object.entries(metadata)
+    .map(([key, value]) => `  ${JSON.stringify(key)}: ${builderJSON(value)},`)
+    .join("\n");
+  return {
+    kind: "builder",
+    label: "Builder",
+    supported: true,
+    code: `import { gg, type PortableSpec } from "@ggsvelte/spec";\n\nconst built = gg(${startArguments})\n${calls.join("\n")}\n  .spec();\n\nconst spec: PortableSpec = {\n  ...built,\n${metadataLines}\n};\n\nexport { spec };\n`,
+  };
+}
+
+const outputCache = new WeakMap<PortableSpec, readonly PlaygroundOutput[]>();
+
+export function playgroundOutputs(spec: PortableSpec): readonly PlaygroundOutput[] {
+  const cached = outputCache.get(spec);
+  if (cached !== undefined) return cached;
+  const outputs: readonly PlaygroundOutput[] = [
+    {
+      kind: "svelte",
+      label: "Svelte",
+      supported: true,
+      code: playgroundSvelteOutput(spec),
+    },
+    playgroundBuilderOutput(spec),
+    {
+      kind: "portable-spec",
+      label: "PortableSpec",
+      supported: true,
+      code: JSON.stringify(spec, null, 2),
+    },
+  ];
+  outputCache.set(spec, outputs);
+  return outputs;
 }
 
 /** Test helper proving generated source preserves the committed JSON value. */

--- a/apps/docs/src/lib/playground-output.ts
+++ b/apps/docs/src/lib/playground-output.ts
@@ -19,8 +19,7 @@ function scriptSafeJSON(spec: PortableSpec): string {
 
 export function playgroundSvelteOutput(spec: PortableSpec): string {
   return `<script lang="ts">
-  import type { PortableSpec } from "@ggsvelte/spec";
-  import { GGPlot } from "@ggsvelte/svelte";
+  import { GGPlot, type PortableSpec } from "@ggsvelte/svelte";
 
   const spec: PortableSpec = ${scriptSafeJSON(spec)};
 </script>
@@ -137,7 +136,7 @@ export function playgroundBuilderOutput(spec: PortableSpec): PlaygroundOutput {
     kind: "builder",
     label: "Builder",
     supported: true,
-    code: `import { gg, type PortableSpec } from "@ggsvelte/spec";\n\nconst built = gg(${startArguments})\n${calls.join("\n")}\n  .spec();\n\nconst spec: PortableSpec = {\n  ...built,\n${metadataLines}\n};\n\nexport { spec };\n`,
+    code: `import { gg, type PortableSpec } from "@ggsvelte/svelte";\n\nconst built = gg(${startArguments})\n${calls.join("\n")}\n  .spec();\n\nconst spec: PortableSpec = {\n  ...built,\n${metadataLines}\n};\n\nexport { spec };\n`,
   };
 }
 

--- a/apps/docs/src/lib/playground-state.ts
+++ b/apps/docs/src/lib/playground-state.ts
@@ -11,14 +11,23 @@ import {
   type PlaygroundSeedV1,
 } from "./playground-codec";
 
+export type PlaygroundDiagnosticSource = "playground" | "validation" | "pipeline" | "export";
+
 export interface PlaygroundDiagnostic {
+  readonly source: PlaygroundDiagnosticSource;
   readonly code: string;
   readonly path: string;
   readonly message: string;
   readonly fix?: string;
 }
 
-export type PlaygroundCandidateOrigin = "apply" | "source" | "initial-navigation" | "popstate";
+export type PlaygroundCandidateOrigin =
+  | "apply"
+  | "source"
+  | "reset"
+  | "undo"
+  | "initial-navigation"
+  | "popstate";
 
 export interface PlaygroundSnapshot {
   readonly sourceBaseline: PlaygroundSeedV1;
@@ -34,6 +43,7 @@ export interface PlaygroundCandidate {
   readonly generation: number;
   readonly origin: PlaygroundCandidateOrigin;
   readonly next: PlaygroundSnapshot;
+  readonly undoSnapshotsAfterPromotion?: readonly PlaygroundSnapshot[];
 }
 
 export interface PlaygroundNavigationRecovery {
@@ -47,11 +57,14 @@ export interface PlaygroundState extends PlaygroundSnapshot {
   readonly lastValid: boolean;
   readonly status: string;
   readonly nextGeneration: number;
+  readonly undoSnapshots: readonly PlaygroundSnapshot[];
   readonly synchronized: boolean;
   readonly canCopyOrShare: boolean;
   readonly navigationRecovery: PlaygroundNavigationRecovery | null;
   readonly historyIntent: "none";
 }
+
+export const PLAYGROUND_MAX_UNDO_SNAPSHOTS = 20;
 
 const VALIDATE_LIMITS = {
   maxRows: PLAYGROUND_MAX_ROWS,
@@ -70,6 +83,7 @@ export function serializePlaygroundSpec(spec: PortableSpec): string {
 
 function diagnosticFromSpec(error: SpecError): PlaygroundDiagnostic {
   return {
+    source: "validation",
     code: error.code,
     path: error.path,
     message: error.message,
@@ -97,11 +111,17 @@ function stage(
   origin: PlaygroundCandidateOrigin,
   next: PlaygroundSnapshot,
   draft = state.draft,
+  undoSnapshotsAfterPromotion?: readonly PlaygroundSnapshot[],
 ): PlaygroundState {
   return finalize({
     ...state,
     draft,
-    candidate: { generation: state.nextGeneration, origin, next },
+    candidate: {
+      generation: state.nextGeneration,
+      origin,
+      next,
+      ...(undoSnapshotsAfterPromotion === undefined ? {} : { undoSnapshotsAfterPromotion }),
+    },
     diagnostics: [],
     lastValid: false,
     status: "Checking the next chart before replacing the last valid result.",
@@ -130,6 +150,7 @@ export function createPlaygroundState(
     lastValid: false,
     status: "Sample ready. Everything stays in this browser tab.",
     nextGeneration: 1,
+    undoSnapshots: [],
     navigationRecovery: null,
     historyIntent: "none",
   });
@@ -175,6 +196,7 @@ export function stagePlaygroundDraft(state: PlaygroundState): PlaygroundState {
     if (error instanceof PlaygroundCodecError) {
       return invalidDraft(state, [
         {
+          source: "playground",
           code: "share-limit",
           path: "",
           message: error.message,
@@ -184,6 +206,7 @@ export function stagePlaygroundDraft(state: PlaygroundState): PlaygroundState {
     }
     return invalidDraft(state, [
       {
+        source: "playground",
         code: "invalid-json",
         path: "",
         message: error instanceof Error ? error.message : "The draft is not valid JSON.",
@@ -209,6 +232,7 @@ export function stagePlaygroundDraft(state: PlaygroundState): PlaygroundState {
   } catch (error) {
     return invalidDraft(state, [
       {
+        source: "playground",
         code: "share-limit",
         path: "",
         message: error instanceof Error ? error.message : "The draft exceeds playground limits.",
@@ -231,7 +255,7 @@ export function stagePlaygroundDraft(state: PlaygroundState): PlaygroundState {
 export function stagePlaygroundSeed(
   state: PlaygroundState,
   seed: PlaygroundSeedV1,
-  origin: Exclude<PlaygroundCandidateOrigin, "apply">,
+  origin: Exclude<PlaygroundCandidateOrigin, "apply" | "undo">,
   targetHash?: string | null,
 ): PlaygroundState {
   const bounded = validatePlaygroundSeed(seed);
@@ -252,16 +276,46 @@ export function stagePlaygroundSeed(
   return stage(state, origin, next);
 }
 
+function snapshotOf(state: PlaygroundSnapshot): PlaygroundSnapshot {
+  return {
+    sourceBaseline: state.sourceBaseline,
+    seed: state.seed,
+    draft: serializePlaygroundSpec(state.committed),
+    committed: state.committed,
+    rendered: state.rendered,
+    renderConfirmed: state.renderConfirmed,
+    historyHash: state.historyHash,
+  };
+}
+
+function changedSnapshot(current: PlaygroundSnapshot, next: PlaygroundSnapshot): boolean {
+  return (
+    JSON.stringify(current.seed) !== JSON.stringify(next.seed) ||
+    JSON.stringify(current.sourceBaseline) !== JSON.stringify(next.sourceBaseline)
+  );
+}
+
 export function promotePlaygroundCandidate(
   state: PlaygroundState,
   generation: number,
 ): PlaygroundState {
-  if (state.candidate?.generation !== generation) return state;
-  const next = state.candidate.next;
+  const candidate = state.candidate;
+  if (candidate?.generation !== generation) return state;
+  const next = candidate.next;
+  const nextUndoSnapshots =
+    candidate.undoSnapshotsAfterPromotion ??
+    (candidate.origin === "initial-navigation" ||
+    candidate.origin === "popstate" ||
+    candidate.origin === "reset"
+      ? []
+      : state.renderConfirmed && changedSnapshot(state, next)
+        ? [...state.undoSnapshots, snapshotOf(state)].slice(-PLAYGROUND_MAX_UNDO_SNAPSHOTS)
+        : state.undoSnapshots);
   return finalize({
     ...state,
     ...next,
     candidate: null,
+    undoSnapshots: nextUndoSnapshots,
     diagnostics: [],
     lastValid: false,
     status: `Rendered ${next.seed.source.kind === "custom" ? "custom draft" : next.seed.source.id}.`,
@@ -294,7 +348,19 @@ export function failPlaygroundCandidate(
 }
 
 export function resetPlaygroundSource(state: PlaygroundState): PlaygroundState {
-  return stagePlaygroundSeed(state, state.sourceBaseline, "source");
+  return stagePlaygroundSeed(state, state.sourceBaseline, "reset");
+}
+
+export function stagePlaygroundUndo(state: PlaygroundState): PlaygroundState {
+  if (state.candidate !== null || state.undoSnapshots.length === 0) return state;
+  const target = state.undoSnapshots.at(-1)!;
+  return stage(
+    state,
+    "undo",
+    { ...target, historyHash: null },
+    state.draft,
+    state.undoSnapshots.slice(0, -1),
+  );
 }
 
 export function setPlaygroundHistoryHash(

--- a/apps/docs/src/lib/playground-state.ts
+++ b/apps/docs/src/lib/playground-state.ts
@@ -288,11 +288,8 @@ function snapshotOf(state: PlaygroundSnapshot): PlaygroundSnapshot {
   };
 }
 
-function changedSnapshot(current: PlaygroundSnapshot, next: PlaygroundSnapshot): boolean {
-  return (
-    JSON.stringify(current.seed) !== JSON.stringify(next.seed) ||
-    JSON.stringify(current.sourceBaseline) !== JSON.stringify(next.sourceBaseline)
-  );
+function changedRenderedChart(current: PlaygroundSnapshot, next: PlaygroundSnapshot): boolean {
+  return JSON.stringify(current.rendered) !== JSON.stringify(next.rendered);
 }
 
 export function promotePlaygroundCandidate(
@@ -308,7 +305,7 @@ export function promotePlaygroundCandidate(
     candidate.origin === "popstate" ||
     candidate.origin === "reset"
       ? []
-      : state.renderConfirmed && changedSnapshot(state, next)
+      : state.renderConfirmed && changedRenderedChart(state, next)
         ? [...state.undoSnapshots, snapshotOf(state)].slice(-PLAYGROUND_MAX_UNDO_SNAPSHOTS)
         : state.undoSnapshots);
   return finalize({

--- a/scripts/docs-route-inventory.ts
+++ b/scripts/docs-route-inventory.ts
@@ -71,7 +71,7 @@ const TOP_LEVEL_ROUTES: readonly DocsRouteRecord[] = [
     path: "/playground",
     title: "PortableSpec playground — ggsvelte",
     description:
-      "Open a real ggsvelte example, edit a bounded PortableSpec locally, and copy a complete Svelte component or share URL.",
+      "Edit a bounded PortableSpec locally, inspect semantic events, and take complete Svelte, equivalent Builder or JSON, SVG, or a share URL.",
     canonicalPath: "/playground",
     kind: "page",
     index: true,

--- a/scripts/gen-llms.ts
+++ b/scripts/gen-llms.ts
@@ -315,7 +315,8 @@ advisories for valid-but-questionable specs.
 - [Interactions](/guide/interactions) — inspection, selection, zoom, typed
   events, keyboard behavior, and stable identity.
 - [PortableSpec playground](/playground) — open a compatible example, edit a
-  bounded local PortableSpec, and copy complete Svelte or an explicit share URL
+  bounded local PortableSpec, inspect semantic events, and take complete Svelte,
+  equivalent Builder or JSON, deterministic SVG, or an explicit share URL
   without uploads, remote fetches, or code execution.
 - [Compatibility](/guide/compatibility) — tested Node, Svelte, installer,
   browser, and operating-system boundaries.
@@ -1861,7 +1862,7 @@ export function buildLlmsIndex(
     lines.push(`- [${page.title}](/guide/${page.slug}): ${page.description}`);
   }
   lines.push(
-    "- [PortableSpec playground](/playground): open a compatible example, edit bounded local JSON, and copy complete Svelte or an explicit share URL",
+    "- [PortableSpec playground](/playground): edit bounded local JSON, inspect semantic events, and take complete Svelte, equivalent Builder or JSON, SVG, or an explicit share URL",
     "- [Search interaction reference](/reference/interactions): filter interaction capabilities, events, diagnostics, and accessibility guidance",
     "- [JSON Schema v0](/schema/v0.json): the PortableSpec schema (unstable in v0.1)",
     "- [llms-full.txt](/llms-full.txt): all docs prose plus every example (spec JSON + Svelte source)",

--- a/scripts/playground-events.test.ts
+++ b/scripts/playground-events.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  appendPlaygroundEvent,
+  PLAYGROUND_MAX_EVENTS,
+  type PlaygroundInteractionEvent,
+} from "../apps/docs/src/lib/playground-events";
+
+function inspectEvent(key: PropertyKey, phase: "change" | "clear" = "change") {
+  if (phase === "clear") {
+    return {
+      type: "inspect",
+      phase,
+      source: "keyboard",
+    } as const satisfies PlaygroundInteractionEvent;
+  }
+  return {
+    type: "inspect",
+    phase,
+    state: "transient",
+    source: "pointer",
+    mode: "exact",
+    panelId: null,
+    focus: {
+      key,
+      row: { x: 1, label: "first" },
+      sourceKeys: [key],
+      lineageCount: 1,
+      layerIndex: 0,
+      panelId: null,
+      fields: [{ channel: "x", field: "x", value: 1 }],
+      anchor: { x: 10, y: 20 },
+    },
+    members: [
+      {
+        key,
+        row: { x: 1, label: "first" },
+        sourceKeys: [key],
+        lineageCount: 1,
+        layerIndex: 0,
+        panelId: null,
+        fields: [{ channel: "x", field: "x", value: 1 }],
+        anchor: { x: 10, y: 20 },
+      },
+    ],
+  } as const satisfies PlaygroundInteractionEvent;
+}
+
+describe("playground semantic event log", () => {
+  test("projects public events to deterministic JSON-safe records", () => {
+    const log = appendPlaygroundEvent([], inspectEvent(Symbol("row")));
+    expect(log).toHaveLength(1);
+    expect(log[0]).toMatchObject({
+      sequence: 1,
+      type: "inspect",
+      phase: "change",
+      source: "pointer",
+    });
+    expect(log[0]?.json).toContain('"key": "Symbol(row)"');
+    expect(() => {
+      JSON.parse(log[0]!.json);
+    }).not.toThrow();
+  });
+
+  test("keeps only the newest bounded records in append order", () => {
+    let log = [] as ReturnType<typeof appendPlaygroundEvent>;
+    for (let index = 0; index < PLAYGROUND_MAX_EVENTS + 3; index += 1) {
+      log = appendPlaygroundEvent(log, inspectEvent(index));
+    }
+    expect(log).toHaveLength(PLAYGROUND_MAX_EVENTS);
+    expect(log[0]?.sequence).toBe(4);
+    expect(log.at(-1)?.sequence).toBe(PLAYGROUND_MAX_EVENTS + 3);
+  });
+});

--- a/scripts/playground-export.test.ts
+++ b/scripts/playground-export.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+
+import { PipelineError } from "@ggsvelte/core";
+import type { PortableSpec } from "@ggsvelte/spec";
+
+import { playgroundSVGExport } from "../apps/docs/src/lib/playground-export";
+
+const spec: PortableSpec = {
+  edition: 2,
+  data: { values: [{ x: 1, y: 2 }] },
+  layers: [
+    {
+      geom: "point",
+      stat: "identity",
+      position: "identity",
+      aes: { x: { field: "x" }, y: { field: "y" } },
+    },
+  ],
+  labs: { title: "Exported chart" },
+};
+
+describe("playground SVG export", () => {
+  test("serializes one render-confirmed spec to a deterministic standalone SVG", () => {
+    const result = playgroundSVGExport(spec);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.filename).toBe("ggsvelte-chart.svg");
+    expect(result.svg).toStartWith("<svg");
+    expect(result.svg).toContain("Exported chart");
+    expect(result.svg).toContain('role="img"');
+  });
+
+  test("returns a source-aware failure without a partial SVG", () => {
+    const result = playgroundSVGExport(spec, () => {
+      throw new PipelineError("renderer-failure", "", "The renderer stopped.");
+    });
+    expect(result).toEqual({
+      ok: false,
+      diagnostic: {
+        source: "export",
+        code: "renderer-failure",
+        path: "",
+        message: "The renderer stopped.",
+        fix: "Keep the current chart, then retry or reduce the spec before exporting.",
+      },
+    });
+    expect("svg" in result).toBe(false);
+  });
+});

--- a/scripts/playground-output.test.ts
+++ b/scripts/playground-output.test.ts
@@ -42,7 +42,7 @@ describe("playground outputs", () => {
       code: JSON.stringify(current, null, 2),
     });
     expect(rebuildPlaygroundSpecWithBuilder(current)).toEqual(current);
-    expect(outputs[1]?.code).toContain('import { gg, type PortableSpec } from "@ggsvelte/spec";');
+    expect(outputs[1]?.code).toContain('import { gg, type PortableSpec } from "@ggsvelte/svelte";');
     expect(outputs[1]?.code).toContain(".layer(");
     expect(playgroundOutputs(current)).toBe(outputs);
   });
@@ -107,8 +107,8 @@ describe("playground outputs", () => {
 
   test("is one complete component containing the exact committed PortableSpec", () => {
     const output = playgroundSvelteOutput(spec);
-    expect(output).toContain('import { GGPlot } from "@ggsvelte/svelte";');
-    expect(output).toContain('import type { PortableSpec } from "@ggsvelte/spec";');
+    expect(output).toContain('import { GGPlot, type PortableSpec } from "@ggsvelte/svelte";');
+    expect(output).not.toContain('from "@ggsvelte/spec";');
     expect(output).toContain("const spec: PortableSpec =");
     expect(output).toContain("<GGPlot {spec} />");
     expect(parseSpecFromSvelteOutput(output)).toEqual(spec);

--- a/scripts/playground-output.test.ts
+++ b/scripts/playground-output.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, test } from "bun:test";
 
-import type { PortableSpec } from "@ggsvelte/spec";
+import { normalize, type PortableSpec } from "@ggsvelte/spec";
 
 import {
   parseSpecFromSvelteOutput,
+  playgroundOutputs,
   playgroundSvelteOutput,
+  rebuildPlaygroundSpecWithBuilder,
 } from "../apps/docs/src/lib/playground-output";
 
 const spec: PortableSpec = {
@@ -25,7 +27,84 @@ const spec: PortableSpec = {
   ],
 };
 
-describe("playground Svelte output", () => {
+describe("playground outputs", () => {
+  test("derives exact Svelte, Builder, and PortableSpec outputs from one committed spec", () => {
+    const current: PortableSpec = { ...spec, height: 400 };
+    const outputs = playgroundOutputs(current);
+
+    expect(outputs.map((output) => output.kind)).toEqual(["svelte", "builder", "portable-spec"]);
+    expect(outputs[0]?.supported).toBe(true);
+    expect(outputs[1]?.supported).toBe(true);
+    expect(outputs[2]).toEqual({
+      kind: "portable-spec",
+      label: "PortableSpec",
+      supported: true,
+      code: JSON.stringify(current, null, 2),
+    });
+    expect(rebuildPlaygroundSpecWithBuilder(current)).toEqual(current);
+    expect(outputs[1]?.code).toContain('import { gg, type PortableSpec } from "@ggsvelte/spec";');
+    expect(outputs[1]?.code).toContain(".layer(");
+    expect(playgroundOutputs(current)).toBe(outputs);
+  });
+
+  test("covers every public Builder method before claiming exact equivalence", () => {
+    const rich = normalize({
+      $schema: "https://ggsvelte.sh/schema/v0.json",
+      edition: 2,
+      data: { values: [{ x: 1, y: 2, group: "A" }] },
+      aes: { x: "x", y: "y" },
+      layers: [{ geom: "point" }],
+      facet: { wrap: "group" },
+      coord: { type: "flip" },
+      a11y: "force-svg",
+      scales: { x: { type: "linear" } },
+      legend: { order: "sorted" },
+      labs: { title: "All builder methods" },
+      theme: "minimal",
+      width: 640,
+      height: 360,
+    });
+    const builder = playgroundOutputs(rich)[1];
+
+    expect(rebuildPlaygroundSpecWithBuilder(rich)).toEqual(rich);
+    expect(builder?.supported).toBe(true);
+    for (const method of ["layer", "facet", "coord", "a11y", "scales", "legend", "labs", "theme"]) {
+      expect(builder?.code).toContain(`.${method}(`);
+    }
+    expect(builder?.code).toContain('"width": 640');
+    expect(builder?.code).toContain('"height": 360');
+  });
+
+  test("turns an unexpected public Builder rejection into an unsupported result", () => {
+    const malformed: PortableSpec = { ...spec, layers: [] };
+    expect(rebuildPlaygroundSpecWithBuilder(malformed)).toBeNull();
+    const builder = playgroundOutputs(malformed)[1];
+    expect(builder).toMatchObject({
+      kind: "builder",
+      supported: false,
+      code: "",
+    });
+    expect(builder?.reason).toContain("cannot reproduce");
+  });
+
+  test("refuses Builder output when the public builder would lose committed meaning", () => {
+    const named: PortableSpec = {
+      ...spec,
+      edition: 2,
+      data: { name: "rows" },
+      datasets: { rows: { values: [{ label: "A", value: 1 }] } },
+    };
+    const builder = playgroundOutputs(named)[1];
+
+    expect(builder).toMatchObject({
+      kind: "builder",
+      supported: false,
+      code: "",
+    });
+    expect(builder?.reason).toContain("named inline datasets");
+    expect(rebuildPlaygroundSpecWithBuilder(named)).toBeNull();
+  });
+
   test("is one complete component containing the exact committed PortableSpec", () => {
     const output = playgroundSvelteOutput(spec);
     expect(output).toContain('import { GGPlot } from "@ggsvelte/svelte";');

--- a/scripts/playground-state.test.ts
+++ b/scripts/playground-state.test.ts
@@ -7,13 +7,16 @@ import {
   type PlaygroundSeedV1,
 } from "../apps/docs/src/lib/playground-codec";
 import {
+  confirmPlaygroundRendered,
   createPlaygroundState,
   editPlaygroundDraft,
+  PLAYGROUND_MAX_UNDO_SNAPSHOTS,
   failPlaygroundCandidate,
   promotePlaygroundCandidate,
   resetPlaygroundSource,
   stagePlaygroundDraft,
   stagePlaygroundSeed,
+  stagePlaygroundUndo,
 } from "../apps/docs/src/lib/playground-state";
 
 const baseSpec: PortableSpec = {
@@ -59,7 +62,11 @@ describe("playground state", () => {
     expect(invalid.committed).toEqual(baseSpec);
     expect(invalid.rendered).toEqual(baseSpec);
     expect(invalid.lastValid).toBe(true);
-    expect(invalid.diagnostics[0]?.code).toBe("empty-layers");
+    expect(invalid.diagnostics[0]).toMatchObject({
+      source: "validation",
+      code: "empty-layers",
+      path: "/layers",
+    });
     expect(invalid.canCopyOrShare).toBe(false);
   });
 
@@ -141,11 +148,84 @@ describe("playground state", () => {
     expect(promoted.canCopyOrShare).toBe(true);
   });
 
+  test("never records an unpainted initial chart as an undo snapshot", () => {
+    const staged = stagePlaygroundDraft(
+      editPlaygroundDraft(createPlaygroundState(sampleSeed), JSON.stringify(nextSpec)),
+    );
+    const promoted = promotePlaygroundCandidate(staged, staged.candidate!.generation);
+    expect(promoted.undoSnapshots).toEqual([]);
+  });
+
+  test("undo records only render-confirmed chart changes and promotes atomically", () => {
+    const first = promotePlaygroundCandidate(
+      stagePlaygroundDraft(
+        editPlaygroundDraft(
+          confirmPlaygroundRendered(createPlaygroundState(sampleSeed)),
+          JSON.stringify(nextSpec),
+        ),
+      ),
+      1,
+    );
+    expect(first.undoSnapshots).toHaveLength(1);
+
+    const secondSpec: PortableSpec = { ...nextSpec, labs: { title: "Second" } };
+    const secondStaged = stagePlaygroundDraft(
+      editPlaygroundDraft(first, JSON.stringify(secondSpec)),
+    );
+    const second = promotePlaygroundCandidate(secondStaged, secondStaged.candidate!.generation);
+    expect(second.undoSnapshots).toHaveLength(2);
+
+    const undoStaged = stagePlaygroundUndo(second);
+    expect(undoStaged.candidate?.origin).toBe("undo");
+    expect(undoStaged.committed.labs?.title).toBe("Second");
+    expect(undoStaged.undoSnapshots).toHaveLength(2);
+
+    const undone = promotePlaygroundCandidate(undoStaged, undoStaged.candidate!.generation);
+    expect(undone.committed.labs?.title).toBe("Edited");
+    expect(undone.draft).toContain("Edited");
+    expect(undone.undoSnapshots).toHaveLength(1);
+  });
+
+  test("bounds meaningful undo history", () => {
+    let state = confirmPlaygroundRendered(createPlaygroundState(sampleSeed));
+    for (let index = 1; index <= PLAYGROUND_MAX_UNDO_SNAPSHOTS + 3; index += 1) {
+      const staged = stagePlaygroundDraft(
+        editPlaygroundDraft(
+          state,
+          JSON.stringify({ ...nextSpec, labs: { title: `Version ${String(index)}` } }),
+        ),
+      );
+      state = promotePlaygroundCandidate(staged, staged.candidate!.generation);
+    }
+    expect(state.undoSnapshots).toHaveLength(PLAYGROUND_MAX_UNDO_SNAPSHOTS);
+    expect(state.undoSnapshots[0]?.committed.labs?.title).toBe("Version 3");
+  });
+
+  test("failed candidates and navigation never create stale undo history", () => {
+    const initial = confirmPlaygroundRendered(createPlaygroundState(sampleSeed));
+    const staged = stagePlaygroundDraft(editPlaygroundDraft(initial, JSON.stringify(nextSpec)));
+    const failed = failPlaygroundCandidate(staged, staged.candidate!.generation, {
+      code: "render-failed",
+      path: "",
+      message: "No chart was promoted.",
+      source: "pipeline",
+    });
+    expect(failed.undoSnapshots).toEqual([]);
+    expect(stagePlaygroundUndo(failed)).toBe(failed);
+
+    const changed = promotePlaygroundCandidate(staged, staged.candidate!.generation);
+    expect(changed.undoSnapshots).toHaveLength(1);
+    const navigated = stagePlaygroundSeed(changed, sampleSeed, "popstate", null);
+    const promoted = promotePlaygroundCandidate(navigated, navigated.candidate!.generation);
+    expect(promoted.undoSnapshots).toEqual([]);
+  });
+
   test("pipeline failure keeps committed output and records last-valid state", () => {
     const staged = stagePlaygroundDraft(
       editPlaygroundDraft(createPlaygroundState(sampleSeed), JSON.stringify(nextSpec)),
     );
     const failed = failPlaygroundCandidate(staged, staged.candidate!.generation, {
+      source: "pipeline",
       code: "palette-exhausted",
       path: "/scales/color",
       message: "The palette cannot represent this domain.",
@@ -156,7 +236,11 @@ describe("playground state", () => {
     expect(failed.draft).toContain("Edited");
     expect(failed.lastValid).toBe(true);
     expect(failed.canCopyOrShare).toBe(false);
-    expect(failed.diagnostics[0]?.code).toBe("palette-exhausted");
+    expect(failed.diagnostics[0]).toMatchObject({
+      source: "pipeline",
+      code: "palette-exhausted",
+      path: "/scales/color",
+    });
   });
 
   test("source and navigation candidates leave the complete retained snapshot untouched until promotion", () => {
@@ -175,6 +259,7 @@ describe("playground state", () => {
       code: "render-failed",
       path: "",
       message: "The shared chart could not render.",
+      source: "pipeline",
     });
     expect(failed.draft).toBe("draft in progress");
     expect(failed.seed).toEqual(sampleSeed);
@@ -199,10 +284,11 @@ describe("playground state", () => {
       1,
     );
     const reset = resetPlaygroundSource(promotedEdit);
-    expect(reset.candidate?.origin).toBe("source");
+    expect(reset.candidate?.origin).toBe("reset");
     expect(reset.historyIntent).toBe("none");
     const restored = promotePlaygroundCandidate(reset, reset.candidate!.generation);
     expect(restored.committed).toEqual(baseSpec);
     expect(restored.sourceBaseline).toEqual(sampleSeed);
+    expect(restored.undoSnapshots).toEqual([]);
   });
 });

--- a/scripts/playground-state.test.ts
+++ b/scripts/playground-state.test.ts
@@ -156,6 +156,16 @@ describe("playground state", () => {
     expect(promoted.undoSnapshots).toEqual([]);
   });
 
+  test("does not record metadata-only promotion as a chart undo snapshot", () => {
+    const initial = confirmPlaygroundRendered(createPlaygroundState(sampleSeed));
+    const staged = stagePlaygroundDraft(initial);
+    expect(staged.candidate?.next.seed.source).toEqual({ kind: "custom" });
+
+    const promoted = promotePlaygroundCandidate(staged, staged.candidate!.generation);
+    expect(promoted.rendered).toEqual(initial.rendered);
+    expect(promoted.undoSnapshots).toEqual([]);
+  });
+
   test("undo records only render-confirmed chart changes and promotes atomically", () => {
     const first = promotePlaygroundCandidate(
       stagePlaygroundDraft(

--- a/tests/visual/playground.spec.ts
+++ b/tests/visual/playground.spec.ts
@@ -1,3 +1,5 @@
+import { readFile } from "node:fs/promises";
+
 import { expect, test, type Page } from "@playwright/test";
 import axe from "axe-core";
 
@@ -125,20 +127,28 @@ test("valid edits render before Svelte copy becomes available and candidates sta
   await expect(page.getByRole("button", { name: "Copy Svelte" })).toBeDisabled();
   await page.getByRole("button", { name: "Apply draft" }).click();
 
-  const candidate = page.locator(".candidate-chart");
-  await candidate.waitFor({ state: "attached" });
+  const candidateState = await page
+    .waitForFunction(() => {
+      const node = document.querySelector<HTMLElement>(".candidate-chart");
+      if (node === null) return null;
+      return {
+        focusables: node.querySelectorAll("button, a, input, select, textarea, [tabindex]").length,
+        exposed: node.querySelectorAll('[role="img"], [role="status"], [aria-live]').length,
+        inert: node.inert,
+        inertAttribute: node.hasAttribute("inert"),
+        hidden: node.getAttribute("aria-hidden"),
+      };
+    })
+    .then((handle) => handle.jsonValue());
   await expect(page.locator('.active-chart > [data-retained-during-candidate="true"]')).toHaveCount(
     1,
   );
-  expect(
-    await candidate.evaluate((node) => ({
-      focusables: node.querySelectorAll("button, a, input, select, textarea, [tabindex]").length,
-      exposed: node.querySelectorAll('[role="img"], [role="status"], [aria-live]').length,
-      inert: (node as HTMLElement).inert,
-      inertAttribute: node.hasAttribute("inert"),
-      hidden: node.getAttribute("aria-hidden"),
-    })),
-  ).toMatchObject({ inert: true, inertAttribute: true, hidden: "true" });
+  expect(candidateState).toMatchObject({
+    focusables: 0,
+    inert: true,
+    inertAttribute: true,
+    hidden: "true",
+  });
 
   await expect(page.getByText("Rendered custom draft.")).toBeVisible();
   await expect(page.locator(".active-chart .gg-title")).toHaveText("Edited locally");
@@ -146,6 +156,159 @@ test("valid edits render before Svelte copy becomes available and candidates sta
   await expect(page.getByLabel("Generated Svelte component")).toContainText(
     "const spec: PortableSpec",
   );
+});
+
+test("advanced outputs stay ordered and undo restores one render-confirmed snapshot", async ({
+  page,
+  context,
+}) => {
+  await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+  await page.goto("/playground");
+  await settleVisualState(page);
+  await applyTitle(page, "First committed chart");
+  await applyTitle(page, "Second committed chart");
+
+  await expect(page.getByRole("tab")).toHaveText(["Svelte", "Builder", "PortableSpec"]);
+  await page.getByRole("tab", { name: "Builder" }).click();
+  await expect(page.getByLabel("Generated Builder output")).toContainText(
+    'import { gg, type PortableSpec } from "@ggsvelte/spec";',
+  );
+  await page.getByRole("button", { name: "Copy Builder" }).click();
+  expect(await page.evaluate(() => navigator.clipboard.readText())).toContain("const built = gg(");
+  await page.getByRole("tab", { name: "PortableSpec" }).click();
+  await expect(page.getByLabel("Generated PortableSpec output")).toContainText(
+    "Second committed chart",
+  );
+  await page.getByRole("button", { name: "Copy PortableSpec" }).click();
+  expect(await page.evaluate(() => navigator.clipboard.readText())).toContain(
+    '"title": "Second committed chart"',
+  );
+
+  await page.getByLabel("PortableSpec JSON").fill("draft to preserve before undo");
+  page.once("dialog", (dialog) => dialog.dismiss());
+  await page.getByRole("button", { name: "Undo chart" }).click();
+  await expect(page.locator(".active-chart .gg-title")).toHaveText("Second committed chart");
+  await expect(page.getByLabel("PortableSpec JSON")).toHaveValue("draft to preserve before undo");
+
+  page.once("dialog", (dialog) => dialog.accept());
+  await page.getByRole("button", { name: "Undo chart" }).click();
+  await expect(page.locator(".active-chart .gg-title")).toHaveText("First committed chart");
+  await expect(page.getByLabel("PortableSpec JSON")).toHaveValue(/First committed chart/u);
+  await expect(page.getByLabel("Generated PortableSpec output")).toContainText(
+    "First committed chart",
+  );
+});
+
+test("output copy fallback stays bound to the selected representation", async ({ page }) => {
+  await page.addInitScript(() => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: () =>
+          new Promise((_resolve, reject) => {
+            setTimeout(() => {
+              reject(new DOMException("Denied", "NotAllowedError"));
+            }, 1000);
+          }),
+      },
+    });
+  });
+  await page.goto("/playground");
+  await settleVisualState(page);
+  const builderTab = page.getByRole("tab", { name: "Builder" });
+  const portableTab = page.getByRole("tab", { name: "PortableSpec" });
+  await builderTab.click();
+  await page.getByRole("button", { name: "Copy Builder" }).evaluate((button: HTMLButtonElement) => {
+    button.click();
+  });
+  await portableTab.evaluate((button: HTMLButtonElement) => {
+    button.click();
+  });
+  await expect(builderTab).toHaveAttribute("aria-selected", "true");
+
+  await expect(page.locator(".manual-copy-source.visible")).toContainText(
+    'import { gg, type PortableSpec } from "@ggsvelte/spec";',
+  );
+  await expect(page.locator(".manual-copy-source.visible")).toContainText(
+    "Copy the selected Builder output manually",
+  );
+  expect(await page.evaluate(() => getSelection()?.toString())).toContain("const built = gg(");
+  await portableTab.click();
+  await expect(portableTab).toHaveAttribute("aria-selected", "true");
+});
+
+test("Builder output explains rather than lowers unsupported named datasets", async ({ page }) => {
+  await page.goto("/playground");
+  await settleVisualState(page);
+  const spec = await readSpec(page);
+  const data = spec["data"] as { values: unknown[] };
+  spec["datasets"] = { rows: { values: data.values } };
+  spec["data"] = { name: "rows" };
+  await page.getByLabel("PortableSpec JSON").fill(JSON.stringify(spec, null, 2));
+  await page.getByRole("button", { name: "Apply draft" }).click();
+  await expect(page.getByText("Rendered custom draft.")).toBeVisible();
+
+  await page.getByRole("tab", { name: "Builder" }).click();
+  await expect(page.getByText("Builder output unavailable for this chart")).toBeVisible();
+  await expect(page.getByText(/cannot preserve named inline datasets/u)).toBeVisible();
+  await expect(page.getByRole("button", { name: "Copy Builder" })).toBeDisabled();
+});
+
+test("SVG export downloads complete output and reports browser download failures", async ({
+  page,
+}) => {
+  await page.goto("/playground");
+  await settleVisualState(page);
+
+  const downloadPromise = page.waitForEvent("download");
+  await page.getByRole("button", { name: "Download SVG" }).click();
+  const download = await downloadPromise;
+  expect(download.suggestedFilename()).toBe("ggsvelte-chart.svg");
+  const path = await download.path();
+  if (path === null) throw new Error("expected a downloaded SVG path");
+  expect(await readFile(path, "utf8")).toMatch(/^<svg[\s>]/u);
+  await expect(page.getByRole("status").filter({ hasText: "SVG downloaded" })).toBeVisible();
+
+  await page.evaluate(() => {
+    URL.createObjectURL = () => {
+      throw new Error("Downloads disabled for test");
+    };
+  });
+  await page.getByRole("button", { name: "Download SVG" }).click();
+  await expect(
+    page.getByRole("status").filter({ hasText: "export/download-failed" }),
+  ).toContainText("The chart and outputs were retained.");
+});
+
+test("semantic event inspection is local, bounded, clearable, and reset by promotion", async ({
+  page,
+}) => {
+  await page.goto("/playground");
+  await settleVisualState(page);
+  const inspector = page.locator("details.event-inspector");
+  await expect(inspector).not.toHaveAttribute("open", "");
+  await inspector.locator("summary").click();
+
+  const chart = page.getByRole("group", {
+    name: "Penguin flippers and body mass",
+  });
+  await chart.focus();
+  await chart.press("ArrowRight");
+  await expect(page.getByRole("list", { name: "Semantic event log" })).toContainText(
+    "inspect/change",
+  );
+  await expect(
+    page.getByRole("list", { name: "Semantic event log" }).locator("pre").first(),
+  ).toContainText('"source": "keyboard"');
+
+  await page.getByRole("button", { name: "Clear events" }).click();
+  await expect(page.getByText("No semantic events yet.", { exact: false })).toBeVisible();
+
+  await chart.press("ArrowRight");
+  await expect(page.getByRole("list", { name: "Semantic event log" })).toBeVisible();
+  await applyTitle(page, "Events reset on promotion");
+  await expect(page.getByRole("list", { name: "Semantic event log" })).toHaveCount(0);
+  await expect(page.getByText("No semantic events yet.", { exact: false })).toBeVisible();
 });
 
 test("schema and pipeline failures preserve and label the last render-confirmed chart", async ({
@@ -160,6 +323,7 @@ test("schema and pipeline failures preserve and label the last render-confirmed 
   await page.getByLabel("PortableSpec JSON").fill('{"layers":[]}');
   await page.getByRole("button", { name: "Apply draft" }).click();
   await expect(page.getByRole("alert")).toBeFocused();
+  await expect(page.getByRole("alert")).toContainText("validation");
   await expect(page.getByRole("alert")).toContainText("empty-layers");
   await expect(page.getByText("Last valid result", { exact: true })).toBeVisible();
   await expect(page.locator(".active-chart .gg-title")).toHaveText(baselineTitle);
@@ -173,6 +337,7 @@ test("schema and pipeline failures preserve and label the last render-confirmed 
 
   await page.getByLabel("PortableSpec JSON").fill(JSON.stringify(PIPELINE_FAILURE_SPEC, null, 2));
   await page.getByRole("button", { name: "Apply draft" }).click();
+  await expect(page.getByRole("alert")).toContainText("pipeline");
   await expect(page.getByRole("alert")).toContainText("palette-exhausted");
   await expect(page.locator(".active-chart .gg-title")).toHaveText(baselineTitle);
   await expect(page.locator(".active-chart .gg-title")).not.toHaveText(
@@ -319,6 +484,7 @@ test("playground is preview-first, operable, and axe-clean at a touch-size viewp
   await expect(page.getByRole("button", { name: "Apply draft" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Share this chart" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Copy Svelte" })).toBeVisible();
+  await expect(page.locator("details.event-inspector")).not.toHaveAttribute("open", "");
 
   await page.addScriptTag({ content: axe.source });
   const violations = await page.evaluate(async () => {

--- a/tests/visual/playground.spec.ts
+++ b/tests/visual/playground.spec.ts
@@ -171,7 +171,7 @@ test("advanced outputs stay ordered and undo restores one render-confirmed snaps
   await expect(page.getByRole("tab")).toHaveText(["Svelte", "Builder", "PortableSpec"]);
   await page.getByRole("tab", { name: "Builder" }).click();
   await expect(page.getByLabel("Generated Builder output")).toContainText(
-    'import { gg, type PortableSpec } from "@ggsvelte/spec";',
+    'import { gg, type PortableSpec } from "@ggsvelte/svelte";',
   );
   await page.getByRole("button", { name: "Copy Builder" }).click();
   expect(await page.evaluate(() => navigator.clipboard.readText())).toContain("const built = gg(");
@@ -215,6 +215,9 @@ test("output copy fallback stays bound to the selected representation", async ({
   });
   await page.goto("/playground");
   await settleVisualState(page);
+  const manualCopySource = page.locator(".manual-copy-source");
+  await expect(manualCopySource).toHaveAttribute("aria-hidden", "true");
+  await expect(manualCopySource.locator("pre")).toHaveAttribute("tabindex", "-1");
   const builderTab = page.getByRole("tab", { name: "Builder" });
   const portableTab = page.getByRole("tab", { name: "PortableSpec" });
   await builderTab.click();
@@ -227,7 +230,7 @@ test("output copy fallback stays bound to the selected representation", async ({
   await expect(builderTab).toHaveAttribute("aria-selected", "true");
 
   await expect(page.locator(".manual-copy-source.visible")).toContainText(
-    'import { gg, type PortableSpec } from "@ggsvelte/spec";',
+    'import { gg, type PortableSpec } from "@ggsvelte/svelte";',
   );
   await expect(page.locator(".manual-copy-source.visible")).toContainText(
     "Copy the selected Builder output manually",
@@ -235,6 +238,12 @@ test("output copy fallback stays bound to the selected representation", async ({
   expect(await page.evaluate(() => getSelection()?.toString())).toContain("const built = gg(");
   await portableTab.click();
   await expect(portableTab).toHaveAttribute("aria-selected", "true");
+
+  await applyTitle(page, "Fallback invalidated by promotion");
+  await expect(manualCopySource).toHaveAttribute("aria-hidden", "true");
+  await expect(manualCopySource).not.toHaveClass(/visible/u);
+  await expect(manualCopySource.locator("code")).toBeEmpty();
+  expect(await page.evaluate(() => getSelection()?.toString() ?? "")).toBe("");
 });
 
 test("Builder output explains rather than lowers unsupported named datasets", async ({ page }) => {


### PR DESCRIPTION
## Summary

- add Svelte-first output tabs for semantically checked Builder and exact PortableSpec representations
- add deterministic SVG downloads with explicit failure recovery and no partial output
- add bounded, render-confirmed snapshot undo with atomic candidate promotion
- add source-aware validation/pipeline diagnostics and a bounded chart-local semantic event inspector
- preserve the local-only, bounded PortableSpec trust boundary and preview-first responsive layout

## Stack

- **Base:** #345 (`feat/docs-playground-basic`)
- This PR intentionally contains only the PR 6B delta and should merge after #345.

## Safety and behavior

- Builder output is emitted only when reconstruction through the public builder is exactly equivalent; named inline datasets get a visible unsupported reason.
- Copy/share/export remain disabled unless the draft, committed spec, and render-confirmed chart agree.
- Undo records only successful rendered chart transitions, is capped at 20 snapshots, and clears at reset/navigation boundaries.
- SVG serialization uses public `renderToSVGString()` with fixed safety limits; browser failures produce no download.
- Events come only from the active chart's public `oninteraction` callback, stay local/in-memory, cap at 20 records, and clear on chart promotion.
- No arbitrary code execution, persistence, uploads, remote fetches, analytics, or shared interaction controller was added.

## Test plan

- `bun test --coverage packages/spec packages/core benchmarks scripts tests/evals` — 1,218 passing; new event/export/output modules at 100% line/function coverage
- `bun run fmt:check`
- `bun run lint`
- `bun run lint:type-aware`
- `bun run check && bun run check:svelte && bun run check:examples && bun run check:docs`
- `bun run knip && bun run lint:package && bun run lint:md`
- `bun run lint:actions`
- `uvx zizmor .github/workflows` — no findings (1 ignored, 44 suppressed)
- 15 non-visual playground Playwright journeys, including output-copy race recovery, exact Builder refusal, undo, SVG success/failure, diagnostics, events, history, mobile, and axe
- local-only zero-diff desktop/tablet/mobile candidate visual contracts
- Cloudflare preview/production and legacy full/migration builds, followed by packed Pages link validation

## Visual baseline policy

No screenshot bytes are included. After the feature commit lands, trusted baselines must be generated from the immutable merged head through the standalone `/approve-visuals` workflow and reviewed in a companion PR.
