### PR TITLE
feat(docs): generate technical discovery metadata

### DIFF
--- a/.changeset/clear-sites-find.md
+++ b/.changeset/clear-sites-find.md
@@ -1,0 +1,9 @@
+---
+"@ggsvelte/spec": patch
+"@ggsvelte/core": patch
+"@ggsvelte/svelte": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+Point published package metadata at the live documentation site and identify each package's monorepo directory.

--- a/apps/docs/src/lib/generated/routes.ts
+++ b/apps/docs/src/lib/generated/routes.ts
@@ -80,9 +80,9 @@ export const DOCS_ROUTES = [
   },
   {
     path: "/reference/interactions",
-    title: "Interaction reference — ggsvelte",
+    title: "Search interactions — ggsvelte",
     description:
-      "Search ggsvelte interaction capabilities, events, diagnostics, and accessibility defaults.",
+      "Filter ggsvelte interaction capabilities, events, diagnostics, and accessibility defaults.",
     canonicalPath: "/reference/interactions",
     kind: "page",
     index: true,

--- a/apps/docs/src/lib/generated/search-index.ts
+++ b/apps/docs/src/lib/generated/search-index.ts
@@ -64,12 +64,12 @@ export const DOCS_SEARCH_INDEX = [
   {
     id: "page:reference-interactions",
     kind: "page",
-    title: "Interaction reference",
+    title: "Search interactions",
     summary:
-      "Search ggsvelte interaction capabilities, events, diagnostics, and accessibility defaults.",
+      "Filter ggsvelte interaction capabilities, events, diagnostics, and accessibility defaults.",
     href: "/reference/interactions",
     keywords: ["Reference"],
-    exact: ["Interaction reference"],
+    exact: ["Search interactions"],
   },
   {
     id: "page:reference-cli",

--- a/apps/docs/src/routes/+layout.server.ts
+++ b/apps/docs/src/routes/+layout.server.ts
@@ -1,3 +1,4 @@
+import { buildSeoDocument, renderStructuredDataScript } from "$scripts/docs-seo";
 import { canonicalUrl, findDocsRoute, guideSequence, routePath } from "$lib/routes";
 import { docsBuildConfig } from "$lib/server/build-config";
 
@@ -7,11 +8,19 @@ export const load: LayoutServerLoad = ({ url }) => {
   const config = docsBuildConfig();
   const path = routePath(url.pathname, config.base);
   const route = findDocsRoute(path);
+  const seo = route === undefined ? undefined : buildSeoDocument(route, config.canonicalBase);
   return {
     site: config,
     path,
     route,
     canonical: route === undefined ? undefined : canonicalUrl(route, config.canonicalBase),
+    seo:
+      seo === undefined
+        ? undefined
+        : {
+            ...seo,
+            structuredDataScript: renderStructuredDataScript(seo.structuredData),
+          },
     sequence: guideSequence(path),
   };
 };

--- a/apps/docs/src/routes/+layout.svelte
+++ b/apps/docs/src/routes/+layout.svelte
@@ -21,6 +21,25 @@
   {#if data.canonical !== undefined}
     <link rel="canonical" href={data.canonical} />
   {/if}
+  {#if data.seo !== undefined}
+    <meta property="og:site_name" content="ggsvelte" />
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content={data.seo.title} />
+    <meta property="og:description" content={data.seo.description} />
+    <meta property="og:url" content={data.seo.canonical} />
+    <meta property="og:image" content={data.seo.image.url} />
+    <meta property="og:image:width" content={String(data.seo.image.width)} />
+    <meta property="og:image:height" content={String(data.seo.image.height)} />
+    <meta property="og:image:alt" content={data.seo.image.alt} />
+    <meta name="twitter:card" content={data.seo.twitterCard} />
+    <meta name="twitter:title" content={data.seo.title} />
+    <meta name="twitter:description" content={data.seo.description} />
+    <meta name="twitter:image" content={data.seo.image.url} />
+    <meta name="twitter:image:alt" content={data.seo.image.alt} />
+    {#if data.seo.structuredDataScript !== ""}
+      {@html data.seo.structuredDataScript}
+    {/if}
+  {/if}
   {#if noindex}
     <meta name="robots" content="noindex,follow" />
   {/if}

--- a/apps/docs/src/routes/llms-full.txt/+server.ts
+++ b/apps/docs/src/routes/llms-full.txt/+server.ts
@@ -8,9 +8,10 @@
 import type { PortableSpec } from "@ggsvelte/spec";
 
 import type { LlmsFullExample } from "$scripts/gen-llms";
-import { buildLlmsFull, pruneSpecData } from "$scripts/gen-llms";
+import { buildLlmsFull, docsDiscoveryFacts, pruneSpecData } from "$scripts/gen-llms";
 
 import { EXAMPLES } from "$lib/examples";
+import { docsBuildConfig } from "$lib/server/build-config";
 import { GUIDE_PAGES } from "$lib/guide";
 
 export const prerender = true;
@@ -33,6 +34,7 @@ function pick<T>(table: Record<string, T>, suffix: string): T {
 }
 
 export function GET(): Response {
+  const config = docsBuildConfig();
   const examples: LlmsFullExample[] = EXAMPLES.map((entry) => {
     const full = pick(specs, `/${entry.id}/spec.ts`).default;
     // Cap inline data so one 10k-row example cannot dominate the corpus.
@@ -45,7 +47,10 @@ export function GET(): Response {
       svelteSource: pick(svelteSources, `/${entry.id}/Example.svelte`),
     };
   });
-  return new Response(buildLlmsFull(GUIDE_PAGES, examples), {
-    headers: { "content-type": "text/plain; charset=utf-8" },
-  });
+  return new Response(
+    buildLlmsFull(GUIDE_PAGES, examples, docsDiscoveryFacts(config.canonicalBase)),
+    {
+      headers: { "content-type": "text/plain; charset=utf-8" },
+    },
+  );
 }

--- a/apps/docs/src/routes/llms.txt/+server.ts
+++ b/apps/docs/src/routes/llms.txt/+server.ts
@@ -4,15 +4,20 @@
  * from scripts/gen-llms.ts (bun-tested) + the generated examples manifest —
  * zero manual upkeep.
  */
-import { buildLlmsIndex } from "$scripts/gen-llms";
+import { buildLlmsIndex, docsDiscoveryFacts } from "$scripts/gen-llms";
 
 import { EXAMPLES } from "$lib/examples";
+import { docsBuildConfig } from "$lib/server/build-config";
 import { GUIDE_PAGES } from "$lib/guide";
 
 export const prerender = true;
 
 export function GET(): Response {
-  return new Response(buildLlmsIndex(GUIDE_PAGES, EXAMPLES), {
-    headers: { "content-type": "text/plain; charset=utf-8" },
-  });
+  const config = docsBuildConfig();
+  return new Response(
+    buildLlmsIndex(GUIDE_PAGES, EXAMPLES, docsDiscoveryFacts(config.canonicalBase)),
+    {
+      headers: { "content-type": "text/plain; charset=utf-8" },
+    },
+  );
 }

--- a/docs/search-verification.md
+++ b/docs/search-verification.md
@@ -1,0 +1,64 @@
+# Search ownership and sitemap runbook
+
+Use this during **PR 8**, after the immutable Cloudflare Pages preview passes and before declaring the apex cutover complete. This runbook prepares verification and submission; it does not claim search-engine acceptance or ranking.
+
+## Preconditions
+
+1. Record the deployed commit and immutable preview URL.
+2. Confirm these return `200` from the preview artifact:
+   - `/robots.txt`
+   - `/sitemap.xml`
+   - `/llms.txt`
+   - `/llms-full.txt`
+3. Run the repository metadata and link checks against the same commit.
+4. Confirm the production sitemap contains only canonical, indexable pages and uses `https://ggsvelte.sh`.
+
+## Google Search Console domain property
+
+1. Add the Domain property `ggsvelte.sh` in Google Search Console.
+2. Copy the exact `google-site-verification=…` TXT value shown by Search Console.
+3. Snapshot the current Cloudflare DNS record set before changing it.
+4. Add that value as a DNS TXT record at the zone apex. Do not place the token in this repository.
+5. Wait for public DNS propagation, then verify the exact value from at least two resolvers:
+
+   ```sh
+   dig +short TXT ggsvelte.sh @1.1.1.1
+   dig +short TXT ggsvelte.sh @8.8.8.8
+   ```
+
+6. Complete ownership verification in Search Console and record the timestamp and property type.
+7. After the apex is healthy, submit `https://ggsvelte.sh/sitemap.xml` in the Sitemaps report.
+8. Record submission acknowledgement, last-read status, discovered URL count, and any parser errors as separate fields.
+
+## Bing Webmaster Tools
+
+1. Add `https://ggsvelte.sh` in Bing Webmaster Tools.
+2. Prefer importing the already verified Search Console property. If import is unavailable, use Bing's DNS verification value and follow the same snapshot, TXT, propagation, and secret-handling steps above.
+3. Submit `https://ggsvelte.sh/sitemap.xml` only after the apex route and certificate checks pass.
+4. Record ownership verification, submission acknowledgement, fetch status, discovered URLs, and reported errors separately.
+
+## Post-submission checks
+
+From a fresh client and without a logged-in browser session:
+
+```sh
+curl --fail --silent --show-error --location https://ggsvelte.sh/ >/dev/null
+curl --fail --silent --show-error https://ggsvelte.sh/robots.txt
+curl --fail --silent --show-error https://ggsvelte.sh/sitemap.xml
+curl --fail --silent --show-error https://ggsvelte.sh/llms.txt | head
+```
+
+Inspect the home page, Getting Started, one gallery detail, Playground, Themes, and Reference in both webmaster tools. Track these states independently:
+
+- property ownership verified;
+- sitemap submitted;
+- sitemap fetched and parsed;
+- URL discovered;
+- URL crawled;
+- URL indexed.
+
+**Submission is not evidence of indexing.** Do not report indexing success until the engine reports the exact canonical URL as indexed. Ranking is a later observation, not a cutover acceptance gate.
+
+## Rollback
+
+If PR 8 rolls the apex back, leave ownership TXT records in place unless they interfere with recovery. Stop new sitemap submissions, restore the recorded DNS/Pages configuration, identify the last healthy deployment, and repeat the route, canonical, certificate, and sitemap checks before resuming submission work.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,13 +14,14 @@
     "svg",
     "visualization"
   ],
-  "homepage": "https://github.com/ljodea/ggsvelte",
+  "homepage": "https://ljodea.github.io/ggsvelte/",
   "bugs": "https://github.com/ljodea/ggsvelte/issues",
   "license": "MIT",
   "author": "Liam O'Dea",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ljodea/ggsvelte.git"
+    "url": "git+https://github.com/ljodea/ggsvelte.git",
+    "directory": "packages/core"
   },
   "files": [
     "dist",

--- a/packages/spec/package.json
+++ b/packages/spec/package.json
@@ -14,13 +14,14 @@
     "validation",
     "visualization"
   ],
-  "homepage": "https://github.com/ljodea/ggsvelte",
+  "homepage": "https://ljodea.github.io/ggsvelte/",
   "bugs": "https://github.com/ljodea/ggsvelte/issues",
   "license": "MIT",
   "author": "Liam O'Dea",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ljodea/ggsvelte.git"
+    "url": "git+https://github.com/ljodea/ggsvelte.git",
+    "directory": "packages/spec"
   },
   "files": [
     "dist",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -14,13 +14,14 @@
     "svelte5",
     "visualization"
   ],
-  "homepage": "https://github.com/ljodea/ggsvelte",
+  "homepage": "https://ljodea.github.io/ggsvelte/",
   "bugs": "https://github.com/ljodea/ggsvelte/issues",
   "license": "MIT",
   "author": "Liam O'Dea",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ljodea/ggsvelte.git"
+    "url": "git+https://github.com/ljodea/ggsvelte.git",
+    "directory": "packages/svelte"
   },
   "bin": {
     "ggsvelte-render": "bin/ggsvelte-render.js"

--- a/scripts/check-docs-metadata.test.ts
+++ b/scripts/check-docs-metadata.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type { DocsBuildConfig } from "../apps/docs/build-mode.ts";
+import sveltePackage from "../packages/svelte/package.json";
+import { validateDocsBuildMetadata } from "./check-docs-metadata.ts";
+import type { DocsRouteRecord } from "./docs-route-inventory.ts";
+
+const roots: string[] = [];
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+const config: DocsBuildConfig = {
+  mode: "cloudflare-production",
+  base: "",
+  canonicalBase: "https://ggsvelte.sh",
+  indexable: true,
+  analytics: true,
+};
+const route: DocsRouteRecord = {
+  path: "/",
+  title: "Home — ggsvelte",
+  description: "A distinct description.",
+  canonicalPath: "/",
+  kind: "page",
+  index: true,
+  sitemap: true,
+  shell: "site",
+};
+
+function fixture(html: string): string {
+  const root = mkdtempSync(join(tmpdir(), "ggsvelte-metadata-"));
+  roots.push(root);
+  writeFileSync(join(root, "index.html"), html);
+  writeFileSync(
+    join(root, "sitemap.xml"),
+    '<?xml version="1.0"?><urlset><url><loc>https://ggsvelte.sh/</loc></url></urlset>',
+  );
+  writeFileSync(
+    join(root, "robots.txt"),
+    "User-agent: *\nAllow: /\nSitemap: https://ggsvelte.sh/sitemap.xml\n",
+  );
+  const facts = [
+    `Package version: ${sveltePackage.version}`,
+    "Defaults edition: 2",
+    "Registered chart themes (12): default, light, dark, minimal, ggplot2, classic, hrbr, few, clean, fivethirtyeight, economist, tufte",
+    "[Docs](https://ggsvelte.sh/docs)",
+  ].join("\n");
+  writeFileSync(join(root, "llms.txt"), facts);
+  writeFileSync(join(root, "llms-full.txt"), facts);
+  return root;
+}
+
+function socialHead(structured = true): string {
+  const data = JSON.stringify([
+    {
+      "@context": "https://schema.org",
+      "@type": "WebSite",
+      name: "ggsvelte",
+      url: "https://ggsvelte.sh/",
+      description: "A distinct description.",
+    },
+    {
+      "@context": "https://schema.org",
+      "@type": "SoftwareSourceCode",
+      name: "ggsvelte",
+      codeRepository: "https://github.com/ljodea/ggsvelte",
+      programmingLanguage: ["TypeScript", "Svelte"],
+      license: "https://spdx.org/licenses/MIT.html",
+      runtimePlatform: "Node.js 22 or newer",
+      url: "https://ggsvelte.sh/",
+      version: sveltePackage.version,
+    },
+  ]);
+  return [
+    "<title>Home — ggsvelte</title>",
+    '<meta name="description" content="A distinct description."/>',
+    '<link rel="canonical" href="https://ggsvelte.sh/"/>',
+    '<meta property="og:site_name" content="ggsvelte"/>',
+    '<meta property="og:type" content="website"/>',
+    '<meta property="og:title" content="Home — ggsvelte"/>',
+    '<meta property="og:description" content="A distinct description."/>',
+    '<meta property="og:url" content="https://ggsvelte.sh/"/>',
+    '<meta property="og:image" content="https://ggsvelte.sh/previews/interaction-tooltip-light.png"/>',
+    '<meta property="og:image:width" content="640"/>',
+    '<meta property="og:image:height" content="400"/>',
+    '<meta property="og:image:alt" content="An interactive ggsvelte scatter plot with a pinned data inspection."/>',
+    '<meta name="twitter:card" content="summary_large_image"/>',
+    '<meta name="twitter:title" content="Home — ggsvelte"/>',
+    '<meta name="twitter:description" content="A distinct description."/>',
+    '<meta name="twitter:image" content="https://ggsvelte.sh/previews/interaction-tooltip-light.png"/>',
+    '<meta name="twitter:image:alt" content="An interactive ggsvelte scatter plot with a pinned data inspection."/>',
+    structured ? `<script type="application/ld+json">${data}</script>` : "",
+  ].join("");
+}
+
+describe("built docs metadata", () => {
+  it("rejects relative or wrong-origin links in generated LLM discovery files", () => {
+    const root = fixture(`<html><head>${socialHead()}</head><body></body></html>`);
+    writeFileSync(join(root, "llms.txt"), "[Docs](/docs)");
+
+    expect(() => {
+      validateDocsBuildMetadata(root, config, [route]);
+    }).toThrow("llms.txt");
+  });
+
+  it("rejects a public home page that omits required structured data", () => {
+    const root = fixture(`<html><head>${socialHead(false)}</head><body></body></html>`);
+
+    expect(() => {
+      validateDocsBuildMetadata(root, config, [route]);
+    }).toThrow("structured data");
+  });
+
+  it("rejects a public page that omits social metadata", () => {
+    const root = fixture(
+      '<html><head><title>Home — ggsvelte</title><meta name="description" content="A distinct description."/><link rel="canonical" href="https://ggsvelte.sh/"/></head><body></body></html>',
+    );
+
+    expect(() => {
+      validateDocsBuildMetadata(root, config, [route]);
+    }).toThrow("social metadata");
+  });
+});

--- a/scripts/check-docs-metadata.test.ts
+++ b/scripts/check-docs-metadata.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -86,7 +86,7 @@ function socialHead(structured = true): string {
     '<meta property="og:url" content="https://ggsvelte.sh/"/>',
     '<meta property="og:image" content="https://ggsvelte.sh/previews/interaction-tooltip-light.png"/>',
     '<meta property="og:image:width" content="640"/>',
-    '<meta property="og:image:height" content="400"/>',
+    '<meta property="og:image:height" content="740"/>',
     '<meta property="og:image:alt" content="An interactive ggsvelte scatter plot with a pinned data inspection."/>',
     '<meta name="twitter:card" content="summary_large_image"/>',
     '<meta name="twitter:title" content="Home — ggsvelte"/>',
@@ -98,6 +98,19 @@ function socialHead(structured = true): string {
 }
 
 describe("built docs metadata", () => {
+  it("preserves fenced source that names the legacy host without treating it as metadata", () => {
+    const root = fixture(`<html><head>${socialHead()}</head><body></body></html>`);
+    const llmsFull = readFileSync(join(root, "llms-full.txt"), "utf8");
+    writeFileSync(
+      join(root, "llms-full.txt"),
+      `${llmsFull}\n\n\`\`\`ts\nconst docs = "https://ljodea.github.io/ggsvelte/guide/errors";\n\`\`\`\n`,
+    );
+
+    expect(() => {
+      validateDocsBuildMetadata(root, config, [route]);
+    }).not.toThrow();
+  });
+
   it("rejects relative or wrong-origin links in generated LLM discovery files", () => {
     const root = fixture(`<html><head>${socialHead()}</head><body></body></html>`);
     writeFileSync(join(root, "llms.txt"), "[Docs](/docs)");

--- a/scripts/check-docs-metadata.ts
+++ b/scripts/check-docs-metadata.ts
@@ -7,6 +7,8 @@ import {
   routeCanonicalUrl,
   type DocsRouteRecord,
 } from "./docs-route-inventory.ts";
+import { buildSeoDocument } from "./docs-seo.ts";
+import { docsDiscoveryFacts } from "./gen-llms.ts";
 
 function fail(message: string): never {
   throw new Error(`Docs metadata check failed: ${message}`);
@@ -20,6 +22,14 @@ function htmlPath(buildDir: string, routePath: string): string {
 
 function matches(html: string, pattern: RegExp): string[] {
   return html.match(pattern) ?? [];
+}
+
+function escapeHtmlAttribute(value: string): string {
+  return value.replaceAll("&", "&amp;").replaceAll('"', "&quot;");
+}
+
+function requireHeadValue(head: string, markup: string, routePath: string, kind: string): void {
+  if (!head.includes(markup)) fail(`${routePath} social metadata is missing or disagrees: ${kind}`);
 }
 
 function listHtmlFiles(root: string, directory = root): string[] {
@@ -60,6 +70,58 @@ export function validateDocsBuildMetadata(
     if (!canonicals[0]!.includes(`href="${canonical}"`)) {
       fail(`${route.path} canonical does not match ${canonical}`);
     }
+    const title = escapeHtmlAttribute(route.title);
+    const description = escapeHtmlAttribute(route.description);
+    const expectedSeo = buildSeoDocument(route, config.canonicalBase);
+    const socialImage = expectedSeo.image.url;
+    for (const [kind, markup] of [
+      ["Open Graph site name", '<meta property="og:site_name" content="ggsvelte"/>'],
+      ["Open Graph type", '<meta property="og:type" content="website"/>'],
+      ["Open Graph title", `<meta property="og:title" content="${title}"/>`],
+      ["Open Graph description", `<meta property="og:description" content="${description}"/>`],
+      ["Open Graph URL", `<meta property="og:url" content="${canonical}"/>`],
+      ["Open Graph image", `<meta property="og:image" content="${socialImage}"/>`],
+      [
+        "Open Graph image width",
+        `<meta property="og:image:width" content="${String(expectedSeo.image.width)}"/>`,
+      ],
+      [
+        "Open Graph image height",
+        `<meta property="og:image:height" content="${String(expectedSeo.image.height)}"/>`,
+      ],
+      [
+        "Open Graph image alternative",
+        `<meta property="og:image:alt" content="${escapeHtmlAttribute(expectedSeo.image.alt)}"/>`,
+      ],
+      ["Twitter card", '<meta name="twitter:card" content="summary_large_image"/>'],
+      ["Twitter title", `<meta name="twitter:title" content="${title}"/>`],
+      ["Twitter description", `<meta name="twitter:description" content="${description}"/>`],
+      ["Twitter image", `<meta name="twitter:image" content="${socialImage}"/>`],
+      [
+        "Twitter image alternative",
+        `<meta name="twitter:image:alt" content="${escapeHtmlAttribute(expectedSeo.image.alt)}"/>`,
+      ],
+    ] as const) {
+      requireHeadValue(head, markup, route.path, kind);
+    }
+    const structuredScripts = [
+      ...head.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g),
+    ];
+    const expectedStructuredData = expectedSeo.structuredData;
+    if (structuredScripts.length !== (expectedStructuredData.length === 0 ? 0 : 1)) {
+      fail(`${route.path} structured data script count does not match the visible page`);
+    }
+    if (structuredScripts.length === 1) {
+      let actualStructuredData: unknown;
+      try {
+        actualStructuredData = JSON.parse(structuredScripts[0]![1]!);
+      } catch {
+        fail(`${route.path} structured data is not valid JSON`);
+      }
+      if (JSON.stringify(actualStructuredData) !== JSON.stringify(expectedStructuredData)) {
+        fail(`${route.path} structured data disagrees with generated route and package facts`);
+      }
+    }
     const shouldNoindex = !config.indexable || !route.index;
     if (robots.length !== (shouldNoindex ? 1 : 0)) {
       fail(`${route.path} robots policy does not match mode ${config.mode}`);
@@ -80,6 +142,23 @@ export function validateDocsBuildMetadata(
   if (!robots.includes(expectedPolicy)) fail(`robots.txt is missing ${expectedPolicy}`);
   if (!robots.includes(`Sitemap: ${config.canonicalBase}/sitemap.xml`)) {
     fail("robots.txt is missing the absolute mode-specific sitemap URL");
+  }
+
+  const facts = docsDiscoveryFacts(config.canonicalBase);
+  for (const filename of ["llms.txt", "llms-full.txt"] as const) {
+    const text = readFileSync(join(buildDir, filename), "utf8");
+    if (text.includes("](/")) fail(`${filename} contains a root-relative discovery link`);
+    if (config.base === "" && text.includes("https://ljodea.github.io/ggsvelte")) {
+      fail(`${filename} leaks the legacy production prefix into a root build`);
+    }
+    for (const expected of [
+      `Package version: ${facts.packageVersion}`,
+      `Defaults edition: ${String(facts.currentEdition)}`,
+      `Registered chart themes (${String(facts.themeNames.length)}): ${facts.themeNames.join(", ")}`,
+    ]) {
+      if (!text.includes(expected))
+        fail(`${filename} is missing current release fact: ${expected}`);
+    }
   }
 }
 

--- a/scripts/check-docs-metadata.ts
+++ b/scripts/check-docs-metadata.ts
@@ -8,7 +8,7 @@ import {
   type DocsRouteRecord,
 } from "./docs-route-inventory.ts";
 import { buildSeoDocument } from "./docs-seo.ts";
-import { docsDiscoveryFacts } from "./gen-llms.ts";
+import { docsDiscoveryFacts, markdownOutsideFences } from "./gen-llms.ts";
 
 function fail(message: string): never {
   throw new Error(`Docs metadata check failed: ${message}`);
@@ -147,8 +147,9 @@ export function validateDocsBuildMetadata(
   const facts = docsDiscoveryFacts(config.canonicalBase);
   for (const filename of ["llms.txt", "llms-full.txt"] as const) {
     const text = readFileSync(join(buildDir, filename), "utf8");
-    if (text.includes("](/")) fail(`${filename} contains a root-relative discovery link`);
-    if (config.base === "" && text.includes("https://ljodea.github.io/ggsvelte")) {
+    const discoveryText = markdownOutsideFences(text);
+    if (discoveryText.includes("](/")) fail(`${filename} contains a root-relative discovery link`);
+    if (config.base === "" && discoveryText.includes("https://ljodea.github.io/ggsvelte")) {
       fail(`${filename} leaks the legacy production prefix into a root build`);
     }
     for (const expected of [

--- a/scripts/ci-routing.test.ts
+++ b/scripts/ci-routing.test.ts
@@ -128,6 +128,7 @@ describe("planJobs", () => {
   test("docs generators schedule pages/vr (not scripts-only)", () => {
     for (const path of [
       "scripts/gen-llms.ts",
+      "scripts/docs-seo.ts",
       "scripts/gen-docs-search.ts",
       "scripts/gen-gallery-previews.ts",
       "scripts/cli-docs.ts",

--- a/scripts/ci-routing.ts
+++ b/scripts/ci-routing.ts
@@ -81,6 +81,7 @@ export const LANE_PATTERNS: Record<ChangeLane, readonly string[]> = {
     // Docs app imports `$scripts/gen-llms` and ships lifecycle-driven guide content.
     "scripts/gen-llms.ts",
     "scripts/gen-llms.test.ts",
+    "scripts/docs-seo.ts",
     "scripts/diagnostic-docs.ts",
     "scripts/quickstart.ts",
     "scripts/cli-docs.ts",

--- a/scripts/docs-route-inventory.test.ts
+++ b/scripts/docs-route-inventory.test.ts
@@ -144,6 +144,21 @@ describe("docs route inventory", () => {
     );
   });
 
+  it("requires unique acquisition metadata across indexable canonical routes", () => {
+    expect(() =>
+      validateRouteInventory([
+        route({ path: "/a", canonicalPath: "/a", title: "Same", description: "Same." }),
+        route({ path: "/b", canonicalPath: "/b", title: "Same", description: "Different." }),
+      ]),
+    ).toThrow("duplicate indexable title");
+    expect(() =>
+      validateRouteInventory([
+        route({ path: "/a", canonicalPath: "/a", title: "First", description: "Same." }),
+        route({ path: "/b", canonicalPath: "/b", title: "Second", description: "Same." }),
+      ]),
+    ).toThrow("duplicate indexable description");
+  });
+
   it("rejects duplicates, alias cycles, missing targets, and incomplete metadata", () => {
     const cases: DocsRouteRecord[][] = [
       [route(), route()],

--- a/scripts/docs-route-inventory.ts
+++ b/scripts/docs-route-inventory.ts
@@ -103,9 +103,9 @@ const TOP_LEVEL_ROUTES: readonly DocsRouteRecord[] = [
   },
   {
     path: "/reference/interactions",
-    title: "Interaction reference — ggsvelte",
+    title: "Search interactions — ggsvelte",
     description:
-      "Search ggsvelte interaction capabilities, events, diagnostics, and accessibility defaults.",
+      "Filter ggsvelte interaction capabilities, events, diagnostics, and accessibility defaults.",
     canonicalPath: "/reference/interactions",
     kind: "page",
     index: true,
@@ -239,6 +239,8 @@ function fail(message: string): never {
 
 export function validateRouteInventory<Route extends DocsRouteRecord>(routes: Route[]): Route[] {
   const byPath = new Map<string, Route>();
+  const indexableTitles = new Map<string, string>();
+  const indexableDescriptions = new Map<string, string>();
   for (const route of routes) {
     if (route.path !== "/" && (!route.path.startsWith("/") || route.path.endsWith("/"))) {
       fail(`route path must be an absolute path without a trailing slash: ${route.path}`);
@@ -257,6 +259,20 @@ export function validateRouteInventory<Route extends DocsRouteRecord>(routes: Ro
       fail(`performance route ${route.path} must be noindex and excluded from the sitemap`);
     }
     if (route.sitemap && !route.index) fail(`${route.path} cannot enter the sitemap while noindex`);
+    if (route.index) {
+      const titleOwner = indexableTitles.get(route.title);
+      if (titleOwner !== undefined) {
+        fail(`duplicate indexable title for ${titleOwner} and ${route.path}: ${route.title}`);
+      }
+      const descriptionOwner = indexableDescriptions.get(route.description);
+      if (descriptionOwner !== undefined) {
+        fail(
+          `duplicate indexable description for ${descriptionOwner} and ${route.path}: ${route.description}`,
+        );
+      }
+      indexableTitles.set(route.title, route.path);
+      indexableDescriptions.set(route.description, route.path);
+    }
     byPath.set(route.path, route);
   }
 

--- a/scripts/docs-seo.test.ts
+++ b/scripts/docs-seo.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "bun:test";
+
+import sveltePackage from "../packages/svelte/package.json";
+import { createDocsRouteInventory } from "./docs-route-inventory.ts";
+import {
+  buildSeoDocument,
+  renderStructuredDataScript,
+  serializeStructuredData,
+} from "./docs-seo.ts";
+
+describe("generated docs SEO", () => {
+  it("describes the canonical home page and repository with truthful structured data", () => {
+    const home = createDocsRouteInventory().find((route) => route.path === "/")!;
+    const seo = buildSeoDocument(home, "https://ggsvelte.sh");
+
+    expect(seo).toMatchObject({
+      title: "ggsvelte — layered grammar of graphics for Svelte",
+      description:
+        "Build publication-ready, interactive data graphics in Svelte with a layered grammar and a portable JSON specification.",
+      canonical: "https://ggsvelte.sh/",
+      image: {
+        url: "https://ggsvelte.sh/previews/interaction-tooltip-light.png",
+        width: 640,
+        height: 400,
+        alt: "An interactive ggsvelte scatter plot with a pinned data inspection.",
+      },
+      twitterCard: "summary_large_image",
+    });
+    expect(seo.structuredData).toEqual([
+      {
+        "@context": "https://schema.org",
+        "@type": "WebSite",
+        name: "ggsvelte",
+        url: "https://ggsvelte.sh/",
+        description:
+          "Build publication-ready, interactive data graphics in Svelte with a layered grammar and a portable JSON specification.",
+      },
+      {
+        "@context": "https://schema.org",
+        "@type": "SoftwareSourceCode",
+        name: "ggsvelte",
+        codeRepository: "https://github.com/ljodea/ggsvelte",
+        programmingLanguage: ["TypeScript", "Svelte"],
+        license: "https://spdx.org/licenses/MIT.html",
+        runtimePlatform: "Node.js 22 or newer",
+        url: "https://ggsvelte.sh/",
+        version: sveltePackage.version,
+      },
+    ]);
+  });
+
+  it("serializes structured data without allowing script termination", () => {
+    const json = serializeStructuredData([{ name: "</script><script>alert(1)</script>" }]);
+
+    expect(json).toBe('[{"name":"\\u003c/script>\\u003cscript>alert(1)\\u003c/script>"}]');
+    expect(json).not.toContain("<script");
+    expect(renderStructuredDataScript([{ name: "</script>" }])).toBe(
+      '<script type="application/ld+json">[{"name":"\\u003c/script>"}]</script>',
+    );
+  });
+
+  it("emits breadcrumbs only for routes that render the visible docs breadcrumb", () => {
+    const routes = createDocsRouteInventory();
+    const guide = routes.find((route) => route.path === "/guide/getting-started")!;
+    const docs = routes.find((route) => route.path === "/docs")!;
+    const gallery = routes.find((route) => route.path === "/examples")!;
+
+    expect(buildSeoDocument(guide, "https://ggsvelte.sh").structuredData).toEqual([
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        itemListElement: [
+          {
+            "@type": "ListItem",
+            position: 1,
+            name: "Docs",
+            item: "https://ggsvelte.sh/docs",
+          },
+          {
+            "@type": "ListItem",
+            position: 2,
+            name: "Getting started",
+            item: "https://ggsvelte.sh/guide/getting-started",
+          },
+        ],
+      },
+    ]);
+    expect(buildSeoDocument(docs, "https://ggsvelte.sh").structuredData).toEqual([]);
+    expect(buildSeoDocument(gallery, "https://ggsvelte.sh").structuredData).toEqual([]);
+  });
+});

--- a/scripts/docs-seo.test.ts
+++ b/scripts/docs-seo.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 
 import sveltePackage from "../packages/svelte/package.json";
 import { createDocsRouteInventory } from "./docs-route-inventory.ts";
@@ -21,11 +23,26 @@ describe("generated docs SEO", () => {
       image: {
         url: "https://ggsvelte.sh/previews/interaction-tooltip-light.png",
         width: 640,
-        height: 400,
+        height: 740,
         alt: "An interactive ggsvelte scatter plot with a pinned data inspection.",
       },
       twitterCard: "summary_large_image",
     });
+    const socialImage = readFileSync(
+      join(
+        import.meta.dir,
+        "..",
+        "apps",
+        "docs",
+        "static",
+        "previews",
+        "interaction-tooltip-light.png",
+      ),
+    );
+    expect([socialImage.readUInt32BE(16), socialImage.readUInt32BE(20)]).toEqual([
+      seo.image.width,
+      seo.image.height,
+    ]);
     expect(seo.structuredData).toEqual([
       {
         "@context": "https://schema.org",

--- a/scripts/docs-seo.ts
+++ b/scripts/docs-seo.ts
@@ -1,0 +1,115 @@
+import sveltePackage from "../packages/svelte/package.json";
+
+const REPOSITORY_URL = "https://github.com/ljodea/ggsvelte";
+const SOCIAL_IMAGE_PATH = "/previews/interaction-tooltip-light.png";
+
+export interface SeoRoute {
+  path: string;
+  title: string;
+  description: string;
+  canonicalPath: string;
+  shell: "site" | "docs";
+  navigation?: { section: string; label: string };
+  primaryNavigationOwner?: "reference";
+}
+
+export interface SeoImage {
+  url: string;
+  width: number;
+  height: number;
+  alt: string;
+}
+
+export interface SeoDocument {
+  title: string;
+  description: string;
+  canonical: string;
+  image: SeoImage;
+  twitterCard: "summary_large_image";
+  structuredData: object[];
+}
+
+function absoluteUrl(canonicalBase: string, path: string): string {
+  return `${canonicalBase.replace(/\/$/, "")}${path}`;
+}
+
+export function serializeStructuredData(data: readonly object[]): string {
+  return JSON.stringify(data)
+    .replaceAll("<", "\\u003c")
+    .replaceAll("\u2028", "\\u2028")
+    .replaceAll("\u2029", "\\u2029");
+}
+
+export function renderStructuredDataScript(data: readonly object[]): string {
+  if (data.length === 0) return "";
+  return `<script type="application/ld+json">${serializeStructuredData(data)}</script>`;
+}
+
+export function buildSeoDocument(route: SeoRoute, canonicalBase: string): SeoDocument {
+  const canonical = absoluteUrl(canonicalBase, route.canonicalPath);
+  const structuredData: object[] = [];
+  if (route.path === "/") {
+    structuredData.push(
+      {
+        "@context": "https://schema.org",
+        "@type": "WebSite",
+        name: "ggsvelte",
+        url: canonical,
+        description: route.description,
+      },
+      {
+        "@context": "https://schema.org",
+        "@type": "SoftwareSourceCode",
+        name: "ggsvelte",
+        codeRepository: REPOSITORY_URL,
+        programmingLanguage: ["TypeScript", "Svelte"],
+        license: "https://spdx.org/licenses/MIT.html",
+        runtimePlatform: "Node.js 22 or newer",
+        url: canonical,
+        version: sveltePackage.version,
+      },
+    );
+  }
+  if (route.shell === "docs") {
+    const reference =
+      route.primaryNavigationOwner === "reference" ||
+      route.path.startsWith("/reference") ||
+      route.navigation?.section === "Reference";
+    const rootName = reference ? "Reference" : "Docs";
+    const rootPath = reference ? "/reference" : "/docs";
+    if (route.path !== rootPath) {
+      structuredData.push({
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        itemListElement: [
+          {
+            "@type": "ListItem",
+            position: 1,
+            name: rootName,
+            item: absoluteUrl(canonicalBase, rootPath),
+          },
+          {
+            "@type": "ListItem",
+            position: 2,
+            name: route.navigation?.label ?? route.title.replace(" — ggsvelte", ""),
+            item: canonical,
+          },
+        ],
+      });
+    }
+  }
+
+  return {
+    title: route.title,
+    description: route.description,
+    canonical,
+    image: {
+      url: absoluteUrl(canonicalBase, SOCIAL_IMAGE_PATH),
+      width: 640,
+      height: 400,
+      alt: "An interactive ggsvelte scatter plot with a pinned data inspection.",
+    },
+    twitterCard: "summary_large_image",
+    structuredData,
+  };
+}

--- a/scripts/docs-seo.ts
+++ b/scripts/docs-seo.ts
@@ -106,7 +106,7 @@ export function buildSeoDocument(route: SeoRoute, canonicalBase: string): SeoDoc
     image: {
       url: absoluteUrl(canonicalBase, SOCIAL_IMAGE_PATH),
       width: 640,
-      height: 400,
+      height: 740,
       alt: "An interactive ggsvelte scatter plot with a pinned data inspection.",
     },
     twitterCard: "summary_large_image",

--- a/scripts/gen-llms.test.ts
+++ b/scripts/gen-llms.test.ts
@@ -312,14 +312,30 @@ describe("pruneSpecData", () => {
 describe("llms surfaces", () => {
   const pages = guidePages(lifecycle);
 
+  it("publishes absolute canonical links and implementation-derived release facts", () => {
+    const txt = buildLlmsIndex(pages.slice(0, 1), EXAMPLES.slice(0, 1), {
+      canonicalBase: "https://ggsvelte.sh",
+      packageVersion: "0.4.0",
+      currentEdition: 2,
+      themeNames: ["light", "dark"],
+    });
+
+    expect(txt).toContain("Package version: 0.4.0");
+    expect(txt).toContain("Defaults edition: 2");
+    expect(txt).toContain("Registered chart themes (2): light, dark");
+    expect(txt).toContain("(https://ggsvelte.sh/guide/getting-started)");
+    expect(txt).toContain("(https://ggsvelte.sh/examples/");
+    expect(txt).not.toMatch(/\]\(\//);
+  });
+
   it("llms.txt lists every guide page and every manifest example", () => {
     const txt = buildLlmsIndex(pages, EXAMPLES);
     expect(txt.startsWith("# ggsvelte\n")).toBe(true);
-    for (const page of pages) expect(txt).toContain(`(/guide/${page.slug})`);
-    expect(txt).toContain("(/schema/v0.json)");
-    expect(txt).toContain("(/playground)");
-    expect(txt).toContain("(/reference/interactions)");
-    for (const ex of EXAMPLES) expect(txt).toContain(`(/examples/${ex.id})`);
+    for (const page of pages) expect(txt).toContain(`(https://ggsvelte.sh/guide/${page.slug})`);
+    expect(txt).toContain("(https://ggsvelte.sh/schema/v0.json)");
+    expect(txt).toContain("(https://ggsvelte.sh/playground)");
+    expect(txt).toContain("(https://ggsvelte.sh/reference/interactions)");
+    for (const ex of EXAMPLES) expect(txt).toContain(`(https://ggsvelte.sh/examples/${ex.id})`);
     expect(pages.map((page) => page.slug)).toContain("interactions");
     expect(pages.map((page) => page.slug)).toContain("interaction-reference");
     expect(pages.map((page) => page.slug)).toContain("migrating-pre-0-1");
@@ -339,6 +355,36 @@ describe("llms surfaces", () => {
     expect(linked?.title).toBe("Link plots, controls, and a table");
     expect(linked?.tags).toContain("controller");
     expect(linked?.tags).toContain("linked-views");
+  });
+
+  it("llms-full.txt carries the same canonical origin and release facts", () => {
+    const txt = buildLlmsFull(
+      [
+        {
+          slug: "start",
+          title: "Start",
+          description: "Start here.",
+          markdown:
+            '# Start\n\n[Errors](/guide/errors)\n\n[Legacy](https://ljodea.github.io/ggsvelte/guide/errors)\n\n```ts fragment\nconst preserved = "https://ljodea.github.io/ggsvelte/guide/errors";\n```',
+        },
+      ],
+      [],
+      {
+        canonicalBase: "https://preview.example",
+        packageVersion: "0.4.0",
+        currentEdition: 2,
+        themeNames: ["light", "dark"],
+      },
+    );
+
+    expect(txt).toContain("Package version: 0.4.0");
+    expect(txt).toContain("Defaults edition: 2");
+    expect(txt).toContain("Registered chart themes (2): light, dark");
+    expect(txt).toContain("[Errors](https://preview.example/guide/errors)");
+    expect(txt).toContain("[Legacy](https://preview.example/guide/errors)");
+    expect(txt).not.toContain("[Legacy](https://ljodea.github.io/ggsvelte");
+    expect(txt).toContain('const preserved = "https://ljodea.github.io/ggsvelte/guide/errors";');
+    expect(txt).not.toMatch(/\]\(\//);
   });
 
   it("llms-full.txt embeds guide prose + spec JSON + svelte source per example", () => {

--- a/scripts/gen-llms.test.ts
+++ b/scripts/gen-llms.test.ts
@@ -137,7 +137,8 @@ describe("guide sections cover their catalogs", () => {
     for (const s of lifecycle.surfaces) expect(md).toContain(s.package);
     expect(md).toContain("`normalize`");
     expect(md).toContain("stable-intent");
-    expect(md).toContain("edition: 1");
+    expect(md).toContain("edition: 2");
+    expect(md).not.toContain("stamps `edition: 1`");
   });
 
   it("getting-started leads with the exact complete responsive SvelteKit page", () => {

--- a/scripts/gen-llms.ts
+++ b/scripts/gen-llms.ts
@@ -17,7 +17,14 @@
  * for its prerendered endpoints and guide pages.
  */
 import { ADVISORY_CATALOG } from "@ggsvelte/core";
-import { LINT_CATALOG, SCALE_CAPABILITIES, TEMPORAL_PARSER_NAMES } from "@ggsvelte/spec";
+import {
+  CURRENT_EDITION,
+  LINT_CATALOG,
+  SCALE_CAPABILITIES,
+  TEMPORAL_PARSER_NAMES,
+  THEME_NAMES,
+} from "@ggsvelte/spec";
+import sveltePackage from "../packages/svelte/package.json";
 import { INTERACTION_DIAGNOSTIC_CATALOG } from "../packages/svelte/src/lib/interaction/interaction";
 import { GUIDE_CATALOG, type GuideSlug } from "../apps/docs/src/lib/catalog/guide";
 import supportMatrix from "../support-matrix.json";
@@ -1887,15 +1894,56 @@ export function guidePages(lifecycle: LifecycleDoc): GuidePage[] {
   });
 }
 
+export interface DocsDiscoveryFacts {
+  canonicalBase: string;
+  packageVersion: string;
+  currentEdition: number;
+  themeNames: readonly string[];
+}
+
+export function docsDiscoveryFacts(canonicalBase: string): DocsDiscoveryFacts {
+  return {
+    canonicalBase,
+    packageVersion: sveltePackage.version,
+    currentEdition: CURRENT_EDITION,
+    themeNames: THEME_NAMES,
+  };
+}
+
+function absoluteMarkdownLinks(markdown: string, canonicalBase: string): string {
+  const origin = canonicalBase.replace(/\/$/, "");
+  let fenced = false;
+  return markdown
+    .split("\n")
+    .map((line) => {
+      if (line.trimStart().startsWith("```")) {
+        fenced = !fenced;
+        return line;
+      }
+      if (fenced) return line;
+      return line
+        .replaceAll("https://ljodea.github.io/ggsvelte", origin)
+        .replaceAll(/\]\((\/[^)\s]*)\)/g, (_match, path: string) => `](${origin}${path})`);
+    })
+    .join("\n");
+}
+
 /** llms.txt — the curated index (llmstxt.org shape: H1, blurb, link lists). */
 export function buildLlmsIndex(
   pages: readonly GuidePage[],
   examples: readonly LlmsExampleEntry[],
+  facts: DocsDiscoveryFacts = docsDiscoveryFacts("https://ggsvelte.sh"),
 ): string {
   const lines = [
     "# ggsvelte",
     "",
     "> A layered grammar of graphics for JavaScript: ggplot2 semantics (aes/geom/stat/scale/coord/facet/theme/position), a strictly-JSON PortableSpec that agents emit (published JSON Schema for constrained decoding), a fluent builder, Svelte 5 components, hybrid SVG/canvas rendering, and value-stable color scales. validate() returns { code, path, message, fix } errors whose fix.example is machine-applicable.",
+    "",
+    "## Current release facts",
+    "",
+    `- Package version: ${facts.packageVersion}`,
+    `- Defaults edition: ${String(facts.currentEdition)}`,
+    `- Registered chart themes (${String(facts.themeNames.length)}): ${facts.themeNames.join(", ")}`,
     "",
     "## Docs",
     "",
@@ -1921,7 +1969,7 @@ export function buildLlmsIndex(
     lines.push(`- [${ex.title}](/examples/${ex.id}): ${ex.description}`);
   }
   lines.push("");
-  return lines.join("\n");
+  return absoluteMarkdownLinks(lines.join("\n"), facts.canonicalBase);
 }
 
 /**
@@ -1974,11 +2022,18 @@ export function pruneSpecData(spec: unknown, maxRows = 20): { spec: unknown; pru
 export function buildLlmsFull(
   pages: readonly GuidePage[],
   examples: readonly LlmsFullExample[],
+  facts: DocsDiscoveryFacts = docsDiscoveryFacts("https://ggsvelte.sh"),
 ): string {
   const parts = [
     "# ggsvelte — full docs corpus for language models",
     "",
     "Generated from the docs guide sources and the examples manifest (one source, three uses). Each example shows its canonical PortableSpec JSON (what an agent should emit) and the equivalent Svelte component usage.",
+    "",
+    "## Current release facts",
+    "",
+    `- Package version: ${facts.packageVersion}`,
+    `- Defaults edition: ${String(facts.currentEdition)}`,
+    `- Registered chart themes (${String(facts.themeNames.length)}): ${facts.themeNames.join(", ")}`,
     "",
     "---",
     "",
@@ -2009,5 +2064,5 @@ export function buildLlmsFull(
       "",
     );
   }
-  return parts.join("\n");
+  return absoluteMarkdownLinks(parts.join("\n"), facts.canonicalBase);
 }

--- a/scripts/gen-llms.ts
+++ b/scripts/gen-llms.ts
@@ -1820,7 +1820,7 @@ Every public export carries a lifecycle tag (generated into
 
 ## Defaults editions
 
-\`normalize()\` stamps \`edition: 1\` onto every spec that doesn't carry one,
+\`normalize()\` stamps \`edition: ${String(CURRENT_EDITION)}\` onto every spec that doesn't carry one,
 freezing which generation of DEFAULT aesthetics (theme role tokens,
 categorical palette, sequential ramp) the spec was authored against. When a
 future edition ships better defaults, stamped specs keep their original look
@@ -1908,6 +1908,20 @@ export function docsDiscoveryFacts(canonicalBase: string): DocsDiscoveryFacts {
     currentEdition: CURRENT_EDITION,
     themeNames: THEME_NAMES,
   };
+}
+
+export function markdownOutsideFences(markdown: string): string {
+  let fenced = false;
+  return markdown
+    .split("\n")
+    .filter((line) => {
+      if (line.trimStart().startsWith("```")) {
+        fenced = !fenced;
+        return false;
+      }
+      return !fenced;
+    })
+    .join("\n");
 }
 
 function absoluteMarkdownLinks(markdown: string, canonicalBase: string): string {

--- a/scripts/package-identity.test.ts
+++ b/scripts/package-identity.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const root = join(import.meta.dir, "..");
+const packagePaths = [
+  "packages/spec/package.json",
+  "packages/core/package.json",
+  "packages/svelte/package.json",
+] as const;
+
+type PublishedManifest = {
+  name: string;
+  version: string;
+  homepage?: string;
+  repository?: { type?: string; url?: string; directory?: string };
+};
+
+function manifest(path: string): PublishedManifest {
+  return JSON.parse(readFileSync(join(root, path), "utf8")) as PublishedManifest;
+}
+
+describe("published package identity", () => {
+  it("points each package at the live docs and its exact monorepo directory", () => {
+    const manifests = packagePaths.map((path) => manifest(path));
+
+    const versions = manifests.map(({ version }) => version);
+    expect(new Set(versions).size).toBe(1);
+    expect(versions[0]).toMatch(/^\d+\.\d+\.\d+$/);
+    for (const [index, entry] of manifests.entries()) {
+      expect(entry.homepage).toBe("https://ljodea.github.io/ggsvelte/");
+      expect(entry.repository).toEqual({
+        type: "git",
+        url: "git+https://github.com/ljodea/ggsvelte.git",
+        directory: packagePaths[index]!.replace("/package.json", ""),
+      });
+    }
+  });
+});

--- a/scripts/search-verification.test.ts
+++ b/scripts/search-verification.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const runbookPath = join(import.meta.dir, "..", "docs", "search-verification.md");
+
+describe("search verification runbook", () => {
+  it("keeps ownership verification, sitemap submission, and indexing as separate outcomes", () => {
+    const runbook = readFileSync(runbookPath, "utf8");
+
+    expect(runbook).toContain("Google Search Console domain property");
+    expect(runbook).toContain("Bing Webmaster Tools");
+    expect(runbook).toContain("https://ggsvelte.sh/sitemap.xml");
+    expect(runbook).toContain("Submission is not evidence of indexing");
+    expect(runbook).toContain("PR 8");
+    expect(runbook).toContain("Rollback");
+  });
+});

--- a/tests/visual/docs-shell.spec.ts
+++ b/tests/visual/docs-shell.spec.ts
@@ -216,6 +216,45 @@ test("route metadata is canonical, singular, and aliases are noindex", async ({ 
   await expect(page.locator('link[rel="canonical"]')).toHaveCount(0);
 });
 
+test("public metadata exposes social cards and truthful route-local structured data", async ({
+  page,
+}) => {
+  await page.goto("/");
+  const mode = await page.locator("#main-content").getAttribute("data-build-mode");
+  const canonicalBase =
+    mode === "legacy-full" ? "https://ljodea.github.io/ggsvelte" : "https://ggsvelte.sh";
+  await expect(page.locator('meta[property="og:url"]')).toHaveAttribute(
+    "content",
+    `${canonicalBase}/`,
+  );
+  await expect(page.locator('meta[property="og:image"]')).toHaveAttribute(
+    "content",
+    `${canonicalBase}/previews/interaction-tooltip-light.png`,
+  );
+  await expect(page.locator('meta[name="twitter:card"]')).toHaveAttribute(
+    "content",
+    "summary_large_image",
+  );
+  const homeData = JSON.parse(
+    (await page.locator('script[type="application/ld+json"]').textContent()) ?? "[]",
+  ) as Array<{ "@type": string }>;
+  expect(homeData.map((entry) => entry["@type"])).toEqual(["WebSite", "SoftwareSourceCode"]);
+
+  await page.goto(GUIDE_ROUTE);
+  const guideData = JSON.parse(
+    (await page.locator('script[type="application/ld+json"]').textContent()) ?? "[]",
+  ) as Array<{ "@type": string; itemListElement?: Array<{ name: string }> }>;
+  expect(guideData).toMatchObject([
+    {
+      "@type": "BreadcrumbList",
+      itemListElement: [{ name: "Docs" }, { name: "Getting started" }],
+    },
+  ]);
+
+  await page.goto("/examples");
+  await expect(page.locator('script[type="application/ld+json"]')).toHaveCount(0);
+});
+
 test("guide shell visual contract: desktop light, dark, and forced colors", async ({ page }) => {
   await page.setViewportSize({ width: 1280, height: 900 });
   await page.goto(`${GUIDE_ROUTE}?theme=light`);


### PR DESCRIPTION
## Summary

- generate canonical Open Graph, Twitter, `WebSite`, `SoftwareSourceCode`, and visible-breadcrumb JSON-LD from route/package facts
- make `llms.txt` and `llms-full.txt` origin-aware while preserving fenced source verbatim and publishing current package, edition, and theme facts
- enforce unique acquisition metadata, canonical agreement, social/structured metadata, route exclusions, LLM link origins, and legacy-prefix isolation in built artifacts
- align published package homepages and monorepo directories, with a Changeset
- add the exact Search Console/Bing ownership, sitemap submission, monitoring, and rollback runbook for PR 8

Repository website/description were confirmed and eight public topics were added through the GitHub repository settings. The homepage remains on the live GitHub Pages URL until the separate PR 8 apex cutover.

## TDD evidence

Each behavior landed red → green through public build/generator boundaries:

- generated SEO and safe structured-data serialization
- breadcrumb ownership and non-duplication
- indexable title/description uniqueness
- absolute, origin-aware LLM links and implementation-derived release facts
- package identity and webmaster runbook contracts
- negative built-artifact checks for missing social/structured data and relative discovery links

## Verification

- `pre-commit run --all-files --show-diff-on-failure`
- `pre-commit run --hook-stage pre-push --all-files --show-diff-on-failure`
- 42 focused unit/contract tests
- 19 nonvisual docs-shell Playwright journeys
- Cloudflare production and preview builds + metadata validation
- legacy full and migration builds + metadata validation
- `bun run check:pages-links`
- `bun run lint:type-aware`
- `bun run knip`
- package build, package lint, docs/Svelte checks, examples typecheck, actionlint, and zizmor through the full pre-push gate

## CI stability follow-up

The dense Firefox axe timeout was fixed independently on `main` by #348 and inherited during the final rebase. Playground timing flakes remain tracked separately in #352.

## Visuals

Head metadata and generated text only. No screenshot bytes are included and no visual baseline change is expected.
