### PR TITLE
fix(core): address post-merge temporal stat findings from #336

### DIFF
--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -14,6 +14,8 @@
  *   - Errors and advisories go to stderr as JSON LINES:
  *       {"kind":"error","code",...} | {"kind":"warning",...} |
  *       {"kind":"advisory",...}
+ *     Scale inference diagnostics reuse those same `kind` values (mapped from
+ *     their internal severity) and set `source: "scale"` so hosts can filter.
  *
  * Exit codes (documented contract):
  *   0  rendered
@@ -285,7 +287,15 @@ export async function runCLI(
     for (const warning of model.warnings) errLine(io, { kind: "warning", ...warning });
     for (const advisory of model.advisories) errLine(io, { kind: "advisory", ...advisory });
     for (const diagnostic of model.scaleDiagnostics) {
-      errLine(io, { kind: "scale-diagnostic", ...diagnostic });
+      // Documented CLI contract is error|warning|advisory only. Scale diagnostics
+      // already carry severity; never invent a fourth kind on the success path.
+      const kind =
+        diagnostic.severity === "error"
+          ? "warning"
+          : diagnostic.severity === "warning"
+            ? "warning"
+            : "advisory";
+      errLine(io, { kind, source: "scale", ...diagnostic });
     }
     // Spec-lint advisories (Hadley lesson 16): valid-but-questionable specs.
     // Distinguished from pipeline heuristics by source: "spec-lint".

--- a/packages/core/src/pipeline/candidate-construction/identity-index.ts
+++ b/packages/core/src/pipeline/candidate-construction/identity-index.ts
@@ -1,10 +1,27 @@
+import type { BarParams } from "@ggsvelte/spec";
+
 import { bandKey } from "../../scales/train.js";
 import { ColumnTable } from "../../table.js";
 import type { FacetPanelDef } from "../facets.js";
-import { NO_ROW } from "../types.js";
+import { shouldAggregateOnSemanticTemporalX } from "../frame-stats-shared.js";
 import { xConversionOf, yConversionOf } from "../temporal-position.js";
-import type { LayerFrame } from "../types.js";
-import type { BarParams } from "@ggsvelte/spec";
+import type { LayerBinding, LayerFrame } from "../types.js";
+import { NO_ROW } from "../types.js";
+
+/** Key used for count/summary/boxplot group×x lineage buckets (matches frame xValues). */
+function aggregateLineageXKey(
+  table: ColumnTable,
+  field: string,
+  localRow: number,
+  binding: LayerBinding,
+): string {
+  const conversion = xConversionOf(binding);
+  const parsed = table.parsed(field, conversion.sourceParser, conversion.options);
+  if (shouldAggregateOnSemanticTemporalX(binding, parsed.decision.status)) {
+    return bandKey(parsed.valid[localRow] === 1 ? parsed.semantic[localRow] : null);
+  }
+  return bandKey(table.column(field)[localRow]);
+}
 
 // ---------------------------------------------------------------------------
 // Aggregate lineage buckets
@@ -201,7 +218,6 @@ export function buildCandidateIdentityIndex(
       // Only count/summary/boxplot resolve via group×x buckets; skip for other layers.
       const bucketByX = stat === "count" || stat === "summary" || stat === "boxplot";
       const xField = frame.binding.xField;
-      const xColumn = bucketByX && xField !== null ? frame.table.column(xField) : null;
       // Finite-y membership uses panel-local table indexes (localRow), then stores
       // source-table rows — same mapping as sourceRowsByGroup itself.
       const yField = frame.binding.yField;
@@ -217,13 +233,13 @@ export function buildCandidateIdentityIndex(
         const sourceRow = facetPanels[panelIndex]!.sourceRows?.[localRow] ?? localRow;
         const key = `${frameKey}:${group}`;
         appendSourceRowByGroupKey(sourceRowsByGroup, key, sourceRow);
-        if (xColumn !== null) {
+        if (bucketByX && xField !== null) {
           appendSourceRowByGroupX({
             sourceRowsByGroupX,
             panelIndex,
             layerIndex,
             group,
-            xKey: bandKey(xColumn[localRow]),
+            xKey: aggregateLineageXKey(frame.table, xField, localRow, frame.binding),
             sourceRow,
           });
         }
@@ -287,8 +303,19 @@ export function filterAggregateXRows(input: {
   field: string;
   outputX: unknown;
   baseRows: readonly number[];
+  /** When present, temporal summary/count keys match semantic epoch frame xValues. */
+  binding?: LayerBinding;
 }): number[] {
   const outputKey = bandKey(input.outputX);
+  if (input.binding !== undefined) {
+    const conversion = xConversionOf(input.binding);
+    const parsed = input.table.parsed(input.field, conversion.sourceParser, conversion.options);
+    if (shouldAggregateOnSemanticTemporalX(input.binding, parsed.decision.status)) {
+      return input.baseRows.filter(
+        (row) => bandKey(parsed.valid[row] === 1 ? parsed.semantic[row] : null) === outputKey,
+      );
+    }
+  }
   const col = input.table.column(input.field);
   return input.baseRows.filter((row) => bandKey(col[row]) === outputKey);
 }
@@ -386,6 +413,7 @@ export function filterRepresentedSourceRows(input: {
         field: aggregateXField,
         outputX,
         baseRows: representedRows,
+        binding: frame.binding,
       });
   } else if (needsBin) {
     representedRows =

--- a/packages/core/src/pipeline/frame-stats-count.ts
+++ b/packages/core/src/pipeline/frame-stats-count.ts
@@ -5,8 +5,8 @@ import { statCount } from "../stats/count.js";
 import { ColumnTable, type CellValue } from "../table.js";
 
 import { carriedColumns, emptyFrameExtras, removedStatWarning } from "./frame-helpers.js";
+import { makeColumnOf, shouldAggregateOnSemanticTemporalX } from "./frame-stats-shared.js";
 import { positionValuesToNumeric } from "./temporal-position.js";
-import { makeColumnOf } from "./frame-stats-shared.js";
 import type { LayerBinding, LayerFrame, PipelineWarning } from "./types.js";
 import { NO_ROW } from "./types.js";
 
@@ -25,8 +25,7 @@ export function buildCountFrame(
     binding.xConversion.sourceParser,
     binding.xConversion.options,
   );
-  const temporalX =
-    binding.xConversion.sourceParser !== "auto" || parsedX.decision.status === "temporal";
+  const temporalX = shouldAggregateOnSemanticTemporalX(binding, parsedX.decision.status);
   const countX: readonly (CellValue | null)[] = temporalX
     ? Array.from(parsedX.semantic, (value, row) => (parsedX.valid[row] === 1 ? value : null))
     : table.column(xField);

--- a/packages/core/src/pipeline/frame-stats-shared.ts
+++ b/packages/core/src/pipeline/frame-stats-shared.ts
@@ -3,6 +3,7 @@
  */
 import type { CellValue } from "../table.js";
 
+import type { PositionConversionContext } from "./temporal-position.js";
 import type { LayerBinding } from "./types.js";
 
 export type CarriedColumnOf = (
@@ -13,4 +14,25 @@ export type CarriedColumnOf = (
 export function makeColumnOf(binding: LayerBinding): CarriedColumnOf {
   return (result, x) => (field) =>
     field === null ? null : field === binding.xField ? x : (result.carried[field] ?? null);
+}
+
+/**
+ * Whether pre-stat aggregation should key x by semantic temporal epochs.
+ *
+ * Band consumers (explicit discrete scales, bar/col discretization without an
+ * explicit time scale) must keep raw categories so tick labels stay source-shaped.
+ */
+export function shouldAggregateOnSemanticTemporalX(
+  binding: Pick<LayerBinding, "layer" | "xConversion">,
+  parsedStatus: string,
+): boolean {
+  const conversion: PositionConversionContext = binding.xConversion;
+  if (conversion.forcedDiscrete || conversion.forcedNonTemporal) return false;
+  const geom = binding.layer.geom;
+  const barDiscretizes =
+    (geom === "bar" || geom === "col") && binding.layer.stat !== "bin" && !conversion.requestedTime;
+  if (barDiscretizes) return false;
+  return (
+    conversion.requestedTime || conversion.sourceParser !== "auto" || parsedStatus === "temporal"
+  );
 }

--- a/packages/core/src/pipeline/frame-stats-summary.ts
+++ b/packages/core/src/pipeline/frame-stats-summary.ts
@@ -4,11 +4,11 @@
 import type { ErrorbarParams } from "@ggsvelte/spec";
 
 import { statSummary } from "../stats/summary.js";
-import { ColumnTable } from "../table.js";
+import { ColumnTable, type CellValue } from "../table.js";
 
 import { carriedColumns, emptyFrameExtras, removedStatWarning } from "./frame-helpers.js";
+import { makeColumnOf, shouldAggregateOnSemanticTemporalX } from "./frame-stats-shared.js";
 import { positionValuesToNumeric } from "./temporal-position.js";
-import { makeColumnOf } from "./frame-stats-shared.js";
 import type { LayerBinding, LayerFrame, PipelineWarning } from "./types.js";
 import { NO_ROW } from "./types.js";
 
@@ -22,8 +22,18 @@ export function buildSummaryFrame(
   const carried = carriedColumns(binding, table);
   const columnOf = makeColumnOf(binding);
   const params = (layer.params ?? {}) as ErrorbarParams;
+  const xField = binding.xField!;
+  const parsedX = table.parsed(
+    xField,
+    binding.xConversion.sourceParser,
+    binding.xConversion.options,
+  );
+  const temporalX = shouldAggregateOnSemanticTemporalX(binding, parsedX.decision.status);
+  const summaryX: readonly (CellValue | null)[] = temporalX
+    ? Array.from(parsedX.semantic, (value, row) => (parsedX.valid[row] === 1 ? value : null))
+    : table.column(xField);
   const result = statSummary({
-    x: table.column(binding.xField!),
+    x: summaryX,
     y: table.numeric(
       binding.yField!,
       binding.yConversion.sourceParser,
@@ -42,7 +52,9 @@ export function buildSummaryFrame(
     table,
     n: result.x.length,
     xValues: result.x,
-    xNumeric: positionValuesToNumeric(result.x, binding.xConversion).values,
+    xNumeric: temporalX
+      ? Float64Array.from(result.x, (value) => (typeof value === "number" ? value : Number.NaN))
+      : positionValuesToNumeric(result.x, binding.xConversion).values,
     yValues: null,
     yNumeric: result.y,
     groups: result.groups,

--- a/packages/core/tests/cli.test.ts
+++ b/packages/core/tests/cli.test.ts
@@ -79,6 +79,37 @@ describe("runCLI", () => {
     );
   });
 
+  it("maps scale diagnostics onto the documented error|warning|advisory kinds", async () => {
+    const temporalSpec = {
+      data: {
+        values: [
+          { when: "1835", value: 1 },
+          { when: "2026", value: 2 },
+        ],
+      },
+      aes: { x: { field: "when" }, y: { field: "value" } },
+      layers: [{ geom: "point" }],
+    };
+    const { io, out, err } = makeIO(JSON.stringify(temporalSpec));
+    const code = await runCLI([], io);
+    expect(code).toBe(0);
+    expect(out.join("")).toStartWith("<svg ");
+    const lines = err.map((l) => JSON.parse(l) as Record<string, unknown>);
+    const kinds = new Set(lines.map((line) => line["kind"]));
+    expect(kinds.has("scale-diagnostic")).toBe(false);
+    for (const kind of kinds) {
+      expect(["error", "warning", "advisory"]).toContain(kind);
+    }
+    // Temporal inference still surfaces on stderr without inventing a fourth kind.
+    expect(
+      lines.some(
+        (line) =>
+          line["source"] === "scale" ||
+          (typeof line["code"] === "string" && line["code"].includes("temporal")),
+      ) || lines.some((line) => line["kind"] === "advisory"),
+    ).toBe(true);
+  });
+
   it("renders a spec from a file with --width/--height", async () => {
     const { io, out } = makeIO("", { "spec.json": JSON.stringify(SPEC) });
     const code = await runCLI(["spec.json", "--width", "300", "--height", "200"], io);

--- a/packages/core/tests/pipeline-build-candidates.test.ts
+++ b/packages/core/tests/pipeline-build-candidates.test.ts
@@ -287,6 +287,33 @@ describe("buildPipelineCandidates via runPipeline", () => {
     expect(sizes).toContain(1);
   });
 
+  it("temporal summary lineages use semantic epoch keys matching frame xValues", () => {
+    const model = runPipeline(
+      gg(
+        [
+          { when: "1/2/2025", value: 1 },
+          { when: "01/02/2025", value: 3 },
+          { when: "02/02/2025", value: 5 },
+        ],
+        aes({ x: "when", y: "value" }),
+      )
+        .geomErrorbar({ stat: "summary" })
+        .scaleXDate({ parse: "dmy", nice: false })
+        .spec(),
+      size,
+    );
+    const memberships = Array.from({ length: model.candidates.size }, (_, id) => {
+      const c = model.candidates.candidate(id)!;
+      return [...model.lineage.keys(c.lineage)].toSorted((a, b) => a - b);
+    });
+    // Two summary groups: dmy-equivalent first two rows, then third row alone.
+    expect(memberships.some((rows) => rows.length === 2 && rows[0] === 0 && rows[1] === 1)).toBe(
+      true,
+    );
+    expect(memberships.some((rows) => rows.length === 1 && rows[0] === 2)).toBe(true);
+    expect(memberships.every((rows) => rows.length > 0)).toBe(true);
+  });
+
   it("bin layers intern source rows using closed bin edges", () => {
     const model = runPipeline(
       {

--- a/packages/core/tests/pipeline-temporal.test.ts
+++ b/packages/core/tests/pipeline-temporal.test.ts
@@ -873,6 +873,61 @@ describe("temporal pipeline semantics", () => {
     expect(equivalentSpellings.scales.y.domain).toEqual([0, 2]);
   });
 
+  it("aggregates summary-stat temporal x by semantic epoch, not raw spelling", () => {
+    const model = runPipeline(
+      gg(
+        [
+          { when: "1/2/2025", value: 1 },
+          { when: "01/02/2025", value: 3 },
+        ],
+        aes({ x: "when", y: "value" }),
+      )
+        .geomErrorbar({ stat: "summary" })
+        .scaleXDate({ parse: "dmy", nice: false })
+        .spec(),
+      size,
+    );
+    expect(model.scales.x.type).toBe("time");
+    // One combined summary (mean_se of [1, 3]) — three segments for a single errorbar
+    // (vertical + two whiskers). Raw-string bucketing would emit two errorbars (6 segments).
+    const segments = model.scene.batches.find((batch) => batch.kind === "segments");
+    expect(segments?.kind).toBe("segments");
+    if (segments?.kind === "segments") {
+      expect(segments.segments.length / 4).toBe(3);
+    }
+    expect(model.scene.axes.x.ticks.filter((tick) => tick.kind === "major")).toHaveLength(1);
+    expect(model.scene.axes.x.ticks[0]!.label).toContain("2025");
+  });
+
+  it("keeps raw category labels for banded temporal count bars", () => {
+    const inferred = runPipeline(
+      gg([{ year: "1835" }, { year: "1835" }, { year: "2026" }], aes({ x: "year" }))
+        .geomBar()
+        .spec(),
+      size,
+    );
+    expect(inferred.scales.x.type).toBe("band");
+    if (inferred.scales.x.type === "band") {
+      expect(inferred.scales.x.domain).toEqual(["1835", "2026"]);
+    }
+    expect(inferred.scene.axes.x.ticks.map(({ label }) => label)).toEqual(["1835", "2026"]);
+    expect(inferred.scales.y.domain).toEqual([0, 2]);
+
+    const discrete = runPipeline(
+      gg([{ year: "1835" }, { year: "1835" }, { year: "2026" }], aes({ x: "year" }))
+        .geomBar()
+        .scaleXDiscrete()
+        .spec(),
+      size,
+    );
+    expect(discrete.scales.x.type).toBe("band");
+    if (discrete.scales.x.type === "band") {
+      expect(discrete.scales.x.domain).toEqual(["1835", "2026"]);
+    }
+    expect(discrete.scene.axes.x.ticks.map(({ label }) => label)).toEqual(["1835", "2026"]);
+    expect(discrete.scales.y.domain).toEqual([0, 2]);
+  });
+
   it("rejects invalid annotations after mapped data infers a temporal parser", () => {
     expect(() =>
       runPipeline(


### PR DESCRIPTION
## Summary
Follow-up for unrebutted post-merge Codex findings on #336.

### Findings
1. **P2** Summary stat did not normalize temporal x before grouping → equivalent calendar spellings (`1/2/2025` vs `01/02/2025`) produced duplicate errorbars.
2. **P2** Count stat always coerced temporal-looking x to epochs, so `geomBar` / `scaleXDiscrete` band domains showed millisecond labels instead of source categories.
3. **P3** CLI emitted `kind: "scale-diagnostic"`, outside the documented `error|warning|advisory` stderr contract.

### Fix
- Shared `shouldAggregateOnSemanticTemporalX` decides semantic vs raw pre-stat keys.
- Summary uses the same semantic path as count for continuous time axes.
- Count keeps raw labels when forced discrete or bar/col will train a band without an explicit time scale.
- CLI maps scale diagnostics onto warning/advisory with `source: "scale"`.

### Tests
- `packages/core/tests/pipeline-temporal.test.ts` — summary semantic aggregation + banded bar labels
- `packages/core/tests/cli.test.ts` — no fourth stderr kind
- Full core suite green in pre-push hooks

Parent: #336