### PR TITLE
fix(docs): address unrebutted Codex findings from #339

### DIFF
--- a/apps/docs/src/lib/catalog/guide.ts
+++ b/apps/docs/src/lib/catalog/guide.ts
@@ -8,6 +8,15 @@ export const GUIDE_SECTIONS = [
 ] as const;
 export type GuideSection = (typeof GUIDE_SECTIONS)[number];
 
+/** Stable HTML id / ARIA IDREF token for a guide section heading (no spaces). */
+export function guideSectionDomId(section: string): string {
+  return `guide-${section
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")}`;
+}
+
 interface GuideCatalogEntryBase {
   slug: string;
   title: string;

--- a/apps/docs/src/lib/catalog/guide.ts
+++ b/apps/docs/src/lib/catalog/guide.ts
@@ -13,8 +13,8 @@ export function guideSectionDomId(section: string): string {
   return `guide-${section
     .trim()
     .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "")}`;
+    .replaceAll(/[^a-z0-9]+/g, "-")
+    .replaceAll(/^-+|-+$/g, "")}`;
 }
 
 interface GuideCatalogEntryBase {

--- a/apps/docs/src/lib/components/DocsSidebar.svelte
+++ b/apps/docs/src/lib/components/DocsSidebar.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { base } from "$app/paths";
 
+  import { guideSectionDomId } from "$lib/catalog/guide";
   import type { GuideNavigationGroup } from "$lib/route-types";
 
   const {
@@ -18,8 +19,8 @@
 
 <nav class="docs-sidebar" aria-label={label}>
   {#each groups as group (group.section)}
-    <section aria-labelledby={`guide-${group.section.toLowerCase()}`}>
-      <h2 id={`guide-${group.section.toLowerCase()}`}>{group.section}</h2>
+    <section aria-labelledby={guideSectionDomId(group.section)}>
+      <h2 id={guideSectionDomId(group.section)}>{group.section}</h2>
       <ul>
         {#each group.entries as entry (entry.path)}
           <li>

--- a/apps/docs/src/lib/components/SiteSearch.svelte
+++ b/apps/docs/src/lib/components/SiteSearch.svelte
@@ -48,6 +48,19 @@
     activeIndex = (next + results.length) % results.length;
   }
 
+  function scrollActiveIntoView(): void {
+    if (activeId === undefined) return;
+    document.getElementById(activeId)?.scrollIntoView({ block: "nearest" });
+  }
+
+  $effect(() => {
+    // Keyboard navigation keeps focus on the combobox; scroll the selected option
+    // into the results scrollport so Enter target stays visible.
+    void activeIndex;
+    void results.length;
+    queueMicrotask(scrollActiveIntoView);
+  });
+
   function followActive(): void {
     const result = results[activeIndex];
     if (result === undefined) return;

--- a/apps/docs/src/lib/components/SiteSearch.svelte
+++ b/apps/docs/src/lib/components/SiteSearch.svelte
@@ -50,7 +50,9 @@
 
   function scrollActiveIntoView(): void {
     if (activeId === undefined) return;
-    document.getElementById(activeId)?.scrollIntoView({ block: "nearest" });
+    document
+      .querySelector(`#${CSS.escape(activeId)}`)
+      ?.scrollIntoView({ block: "nearest" });
   }
 
   $effect(() => {

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -91,7 +91,11 @@ export const CLI_OPTIONS = [
 
 const cliOptionLines = CLI_OPTIONS.map((option) => {
   const signature = `${option.flag}${option.value === "" ? "" : ` ${option.value}`}`;
-  return `  ${signature.padEnd(17)} ${option.description}`;
+  const detail =
+    "detail" in option && typeof option.detail === "string" && option.detail.length > 0
+      ? ` ${option.detail}`
+      : "";
+  return `  ${signature.padEnd(17)} ${option.description}${detail}`;
 }).join("\n");
 
 const USAGE = `Usage: ggsvelte-render [spec.json] [options]

--- a/packages/core/tests/cli.test.ts
+++ b/packages/core/tests/cli.test.ts
@@ -149,6 +149,17 @@ describe("runCLI", () => {
     expect(out).toHaveLength(0);
     expect(err.join("\n")).toContain("Usage: ggsvelte-render");
   });
+
+  it("--help includes --data detail for the named-dataset JSON shape", async () => {
+    const { io, err } = makeIO();
+    expect(await runCLI(["--help"], io)).toBe(0);
+    const help = err.join("\n");
+    const dataOption = CLI_OPTIONS.find((option) => option.flag === "--data");
+    expect(dataOption && "detail" in dataOption).toBe(true);
+    if (dataOption && "detail" in dataOption) {
+      expect(help).toContain(dataOption.detail);
+    }
+  });
 });
 
 describe("workspace bin smoke test", () => {

--- a/scripts/ci-routing.test.ts
+++ b/scripts/ci-routing.test.ts
@@ -263,6 +263,7 @@ describe("planJobs", () => {
   test("consumer harness and canonical Quickstart sources schedule the packed-consumer matrix", () => {
     for (const path of [
       "scripts/consumer-compat.ts",
+      "scripts/guide-code-contract.ts",
       "scripts/quickstart.ts",
       "scripts/quickstart-timing.ts",
     ]) {
@@ -270,6 +271,10 @@ describe("planJobs", () => {
       expect(plan.consumer).toBe(true);
       expect(plan.unit).toBe(true);
     }
+  });
+
+  test("guide-code-contract changes invalidate the consumer content-hash surface", () => {
+    expect(JOB_CONTENT_INPUTS.consumer).toContain("scripts/guide-code-contract.ts");
   });
 
   test("manual-AT evidence and community forms schedule unit", () => {

--- a/scripts/ci-routing/content-hash.ts
+++ b/scripts/ci-routing/content-hash.ts
@@ -187,6 +187,7 @@ export const JOB_CONTENT_INPUTS: Record<CacheableExecution, readonly string[]> =
     "packages/svelte/**",
     "scripts/consumer-compat.ts",
     "scripts/consumer-compat.test.ts",
+    "scripts/guide-code-contract.ts",
     "scripts/quickstart.ts",
     "scripts/quickstart-timing.ts",
     "scripts/quickstart-timing.test.ts",

--- a/scripts/ci-routing/routing.ts
+++ b/scripts/ci-routing/routing.ts
@@ -112,6 +112,8 @@ export const LANE_PATTERNS: Record<ChangeLane, readonly string[]> = {
   consumer_tools: [
     "scripts/consumer-compat.ts",
     "scripts/consumer-compat.test.ts",
+    // Packed fixture snippets live here; consumer-compat imports them.
+    "scripts/guide-code-contract.ts",
     "scripts/quickstart.ts",
     "scripts/quickstart-timing.ts",
     "scripts/quickstart-timing.test.ts",

--- a/scripts/guide-section-id.test.ts
+++ b/scripts/guide-section-id.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, test } from "bun:test";
+
+import { guideSectionDomId } from "../apps/docs/src/lib/catalog/guide.ts";
+
+describe("guideSectionDomId", () => {
+  test("slugifies multi-word guide sections for ARIA IDREFs", () => {
+    expect(guideSectionDomId("Core grammar")).toBe("guide-core-grammar");
+    expect(guideSectionDomId("Start")).toBe("guide-start");
+    expect(guideSectionDomId("  Extra  Spaces  ")).toBe("guide-extra-spaces");
+  });
+});


### PR DESCRIPTION
## Summary
Follow-up for four unrebutted pre-merge Codex P2s on #339.

### Findings → fixes
1. **ARIA section IDs** — `Core grammar` produced `guide-core grammar` (broken IDREFs). Added `guideSectionDomId()` → `guide-core-grammar`.
2. **CLI `--data` help** — `detail` shape never printed; `--help` now appends it.
3. **Consumer CI routing** — `guide-code-contract.ts` feeds packed fixtures but was outside `consumer_tools` / consumer content-hash inputs; both updated.
4. **Site search keyboard** — active option now `scrollIntoView({ block: "nearest" })` when `activeIndex` changes.

### Tests
- `scripts/guide-section-id.test.ts`
- `packages/core/tests/cli.test.ts` help detail
- `scripts/ci-routing.test.ts` consumer scheduling + content-hash

Parent: #339