### PR TITLE
fix(core): address post-merge temporal guide findings from #348

### DIFF
--- a/packages/core/src/layout/format.ts
+++ b/packages/core/src/layout/format.ts
@@ -243,7 +243,8 @@ function displayParts(ms: number, options: TemporalLabelFormatOptions): Temporal
     cachedDateTimeFormat("en-US", timezone, { timeZoneName: "longOffset" }).formatToParts(ms),
     "timeZoneName",
   );
-  const offsetMatch = /^GMT([+-])(\d{2}):(\d{2})$/.exec(longOffset);
+  // Intl longOffset may include seconds for historical zones (e.g. GMT+05:21:10).
+  const offsetMatch = /^GMT([+-])(\d{2}):(\d{2})(?::\d{2})?$/.exec(longOffset);
   const offset =
     offsetMatch === null ? "+0000" : `${offsetMatch[1]}${offsetMatch[2]}${offsetMatch[3]}`;
   return {

--- a/packages/core/src/layout/temporal-guide.ts
+++ b/packages/core/src/layout/temporal-guide.ts
@@ -204,11 +204,16 @@ function buildTicks(
   intervalValue: TemporalInterval,
   input: TemporalAxisPlanInput,
 ): AxisGuideTick[] {
-  const labels = formatTemporalTickSequence(values, {
+  // Contextual abbreviations depend on sequence order. When the axis is reversed,
+  // format in visual order so the leftmost/topmost tick keeps full context, then
+  // map labels back onto ascending semantic values.
+  const formatOrder = input.reverse ? values.toReversed() : values;
+  const formatted = formatTemporalTickSequence(formatOrder, {
     ...temporalOptions(input),
     interval: intervalValue,
     ...(input.config.dateLabels !== undefined && { pattern: input.config.dateLabels }),
   });
+  const labels = input.reverse ? formatted.toReversed() : formatted;
   if (input.config.dateLabels === undefined && input.config.labels !== undefined) {
     for (let index = 0; index < labels.length; index++) {
       labels[index] = {
@@ -256,11 +261,14 @@ function evaluateTicks(
       break;
     }
   }
+  // Layout reserves tickLength + tickLabelGap (defaults 6 + 3) in addition to the
+  // label extent. Match that chrome so near-cap labels still diagnose overflow.
+  const tickChromePx = 6 + 3;
   const orthogonalCap = input.orthogonalMarginCapPx ?? input.marginCapPx;
   const marginOverflow = projected.some((tick) =>
     input.orient === "horizontal"
-      ? tick.width / 2 > input.marginCapPx || tick.height > orthogonalCap
-      : tick.width > input.marginCapPx || tick.height / 2 > orthogonalCap,
+      ? tick.width / 2 > input.marginCapPx || tick.height + tickChromePx > orthogonalCap
+      : tick.width + tickChromePx > input.marginCapPx || tick.height / 2 > orthogonalCap,
   );
   return { overlap, marginOverflow };
 }

--- a/packages/core/tests/temporal-guide.test.ts
+++ b/packages/core/tests/temporal-guide.test.ts
@@ -37,6 +37,37 @@ describe("temporal label formatting", () => {
     expect(format(Date.UTC(2024, 0, 1, 23))).toBe("2024-01-01");
   });
 
+  it("formats historical IANA offsets that include seconds in %z", () => {
+    const historical = Date.UTC(1880, 0, 1, 12);
+    const kolkata = compileTemporalLabelFormat("%z", {
+      kind: "datetime",
+      locale: "en-US",
+      timezone: "Asia/Kolkata",
+    });
+    expect(kolkata(historical)).toBe("+0521");
+    expect(kolkata(historical)).not.toBe("+0000");
+  });
+
+  it("contextualizes reversed temporal labels in visual order", () => {
+    const plan = planTemporalAxis({
+      aesthetic: "x",
+      panelIndex: 0,
+      domain: [Date.UTC(2025, 10, 1), Date.UTC(2026, 1, 1)],
+      kind: "date",
+      orient: "horizontal",
+      extentPx: 400,
+      reverse: true,
+      measurer,
+      fontSize: 11,
+      marginCapPx: 80,
+      config: { dateBreaks: "1 month" },
+    });
+    // Visual leading tick (rightmost domain value under reverse) keeps year context.
+    const visualLeading = plan.ticks.at(-1)!;
+    expect(visualLeading.label).toMatch(/2026|Feb/);
+    expect(visualLeading.label).not.toBe("Feb");
+  });
+
   it("builds contextual visible labels and standalone full labels", () => {
     const values = [
       Date.UTC(2025, 10, 1),


### PR DESCRIPTION
## Summary
Follow-up / disposition for unrebutted Codex findings on #348.

### Valid (fixed here)
1. **P3 %z historical offsets** — accept `GMT±HH:MM:SS` from Intl.
2. **P3 reversed label context** — format contextual labels in visual order.
3. **P3 margin overflow** — include default tickLength+tickLabelGap chrome in the budget check.

### Already fixed on main (rebutted on parent)
1. **P2 DST multi-hour phase** — civil cursor advances before projection; regression in `temporal-interval.test.ts` expects `04:00/06:00/08:00`.
2. **P2 temporal guides on linear/log** — tier-2 + pipeline reject with `scale-type-mismatch`.
3. **P3 error path option** — `TemporalGuideIntervalError` already carries aesthetic/option into finalize.

### Not actionable
1. **P3 multi-hour global anchor** — overlapping domains already share ticks under civil-day phase alignment; design preference, not a regression.

Parent: #348