### PR TITLE
fix(core): preserve error severity on CLI scale diagnostics (#357)

### DIFF
--- a/.changeset/scale-diag-cli-kind.md
+++ b/.changeset/scale-diag-cli-kind.md
@@ -1,0 +1,9 @@
+---
+"@ggsvelte/spec": patch
+"@ggsvelte/core": patch
+"@ggsvelte/svelte": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+Map scale-diagnostic severity onto the CLI stderr `kind` field 1:1 so error-severity diagnostics emit `kind: "error"` instead of being demoted to `warning`.

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -38,6 +38,13 @@ export interface CLIIO {
   writeErr(line: string): void;
 }
 
+/** Map a scale diagnostic's severity onto the documented CLI JSONL `kind`. */
+export function scaleDiagnosticCliKind(
+  severity: "advisory" | "warning" | "error",
+): "advisory" | "warning" | "error" {
+  return severity;
+}
+
 export const CLI_OPTIONS = [
   {
     anchor: "width",
@@ -292,14 +299,12 @@ export async function runCLI(
     for (const advisory of model.advisories) errLine(io, { kind: "advisory", ...advisory });
     for (const diagnostic of model.scaleDiagnostics) {
       // Documented CLI contract is error|warning|advisory only. Scale diagnostics
-      // already carry severity; never invent a fourth kind on the success path.
-      const kind =
-        diagnostic.severity === "error"
-          ? "warning"
-          : diagnostic.severity === "warning"
-            ? "warning"
-            : "advisory";
-      errLine(io, { kind, source: "scale", ...diagnostic });
+      // already carry severity; map 1:1 and never invent a fourth kind.
+      errLine(io, {
+        kind: scaleDiagnosticCliKind(diagnostic.severity),
+        source: "scale",
+        ...diagnostic,
+      });
     }
     // Spec-lint advisories (Hadley lesson 16): valid-but-questionable specs.
     // Distinguished from pipeline heuristics by source: "spec-lint".

--- a/packages/core/tests/cli.test.ts
+++ b/packages/core/tests/cli.test.ts
@@ -9,7 +9,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import type { CLIIO } from "../src/cli.ts";
-import { CLI_OPTIONS, runCLI } from "../src/cli.ts";
+import { CLI_OPTIONS, runCLI, scaleDiagnosticCliKind } from "../src/cli.ts";
 
 const SPEC = {
   data: {
@@ -108,6 +108,14 @@ describe("runCLI", () => {
           (typeof line["code"] === "string" && line["code"].includes("temporal")),
       ) || lines.some((line) => line["kind"] === "advisory"),
     ).toBe(true);
+  });
+
+  it("preserves scale diagnostic severity on the documented CLI kind field", () => {
+    // Success-path scale diagnostics may carry severity "error" (public ScaleDiagnostic
+    // permits it). JSONL consumers gate on kind; kind must match severity, not demote.
+    expect(scaleDiagnosticCliKind("error")).toBe("error");
+    expect(scaleDiagnosticCliKind("warning")).toBe("warning");
+    expect(scaleDiagnosticCliKind("advisory")).toBe("advisory");
   });
 
   it("renders a spec from a file with --width/--height", async () => {


### PR DESCRIPTION
## Summary

Follow-up for unrebutted post-merge Codex finding on #357.

- Success-path scale diagnostics were mapped with `severity: "error"` → `kind: "warning"`, so JSONL consumers that gate on the documented `kind` field treated error-level scale diagnostics as warnings.
- Root cause: the #357 mapping intentionally collapsed error and warning onto `warning` while the module contract says kinds are **mapped from internal severity**.
- Fix: map severity 1:1 via `scaleDiagnosticCliKind`, so `error`/`warning`/`advisory` stay consistent on `kind` (and still carry `severity` + `source: "scale"`).

## Parent finding

> Preserve error scale diagnostic severity — when a successful render includes a non-fatal scale diagnostic with `severity: "error"`, emit `kind: "error"` instead of demoting to `warning`.

## Test plan

- [x] `bun test packages/core/tests/cli.test.ts` — 15 pass, including new contract test for severity→kind identity
- [x] Pre-push suite (package build, oxlint type-aware, knip, bun test) passed on push