### PR TITLE
fix(ci): teach knip that wrangler is used via bunx in GHA

### DIFF
--- a/knip.jsonc
+++ b/knip.jsonc
@@ -9,8 +9,17 @@
   // is invoked as `bun node_modules/.bin/oxfmt` (arch-proof invocation, see
   // CONTRIBUTING.md), which knip's script parser does not resolve. The same
   // is true for markdownlint-cli2's explicit node_modules/.bin invocation
-  // and pnpm, which the clean-consumer harness resolves from PATH.
-  "ignoreDependencies": ["publint", "@arethetypeswrong/cli", "oxfmt", "markdownlint-cli2", "pnpm"],
+  // and pnpm, which the clean-consumer harness resolves from PATH. wrangler
+  // is invoked as `bunx wrangler pages deploy` from cloudflare-pages.yml —
+  // no import graph edge for knip to follow.
+  "ignoreDependencies": [
+    "publint",
+    "@arethetypeswrong/cli",
+    "oxfmt",
+    "markdownlint-cli2",
+    "pnpm",
+    "wrangler",
+  ],
   // Root-exported ggplot2 spellings are intentional binding-identical aliases
   // of the camelCase scale helpers, and declaration tests enforce that contract.
   "ignoreIssues": { "packages/spec/src/scale-helpers.ts": ["duplicates"] },


### PR DESCRIPTION
## Summary
- After the Cloudflare Pages cutover, local pre-push knip failed on an unused wrangler devDependency.
- wrangler is only invoked as bunx wrangler pages deploy from cloudflare-pages.yml, which knip cannot see.
- Ignore it the same way as other spawn-only tools (publint, oxfmt, pnpm).

## Test plan
- [x] bun run knip exits 0 locally
- [ ] CI build/static analysis job stays green

Not a #364 CI failure itself, but it blocked pushing the #364 fixes.