### PR TITLE
fix(docs): make cutover smoke truthful

### DIFF
--- a/apps/docs/static/_redirects
+++ b/apps/docs/static/_redirects
@@ -1,4 +1,4 @@
 /bench https://ljodea.github.io/ggsvelte/bench/ 302
 /bench/* https://ljodea.github.io/ggsvelte/bench/:splat 302
-/ggsvelte / 301
-/ggsvelte/* /:splat 301
+/ggsvelte https://ggsvelte.sh/ 301
+/ggsvelte/* https://ggsvelte.sh/:splat 301

--- a/scripts/deployment-artifact.test.ts
+++ b/scripts/deployment-artifact.test.ts
@@ -6,6 +6,7 @@ import { join } from "node:path";
 import {
   buildDeploymentIdentity,
   deploymentBuildConfig,
+  ensureNotFoundNoindex,
   ensurePreviewNoindexHeader,
   validateDeploymentArtifact,
 } from "./deployment-artifact.ts";
@@ -25,8 +26,8 @@ const REQUIRED_HEADERS = `/*
 
 const REQUIRED_REDIRECTS = `/bench https://ljodea.github.io/ggsvelte/bench/ 302
 /bench/* https://ljodea.github.io/ggsvelte/bench/:splat 302
-/ggsvelte / 301
-/ggsvelte/* /:splat 301
+/ggsvelte https://ggsvelte.sh/ 301
+/ggsvelte/* https://ggsvelte.sh/:splat 301
 `;
 
 const SOURCE_COMMIT = "0123456789abcdef0123456789abcdef01234567";
@@ -57,7 +58,7 @@ function makeCompleteArtifact(buildMode: "cloudflare-preview" | "cloudflare-prod
   const buildDirectory = mkdtempSync(join(tmpdir(), "ggsvelte-cloudflare-artifact-"));
   for (const [path, contents] of [
     ["index.html", '<link rel="canonical" href="https://ggsvelte.sh/">'],
-    ["404.html", '<meta name="robots" content="noindex,follow">Not found'],
+    ["404.html", '<meta name="robots" content="noindex,follow"><h1>Not found</h1>'],
     [
       "_headers",
       buildMode === "cloudflare-preview"
@@ -142,6 +143,23 @@ describe("deployment artifact identity", () => {
     }
   });
 
+  it("makes the unknown-route fallback index-safe and useful without JavaScript", () => {
+    const buildDirectory = mkdtempSync(join(tmpdir(), "ggsvelte-cloudflare-not-found-"));
+    try {
+      writeFileSync(
+        join(buildDirectory, "404.html"),
+        '<html><head></head><body><div style="display: contents"><script>start()</script></div></body></html>',
+      );
+      ensureNotFoundNoindex(buildDirectory);
+      const html = readFileSync(join(buildDirectory, "404.html"), "utf8");
+      expect(html).toContain('<meta name="robots" content="noindex,follow" />');
+      expect(html).toContain("<h1>Not found</h1>");
+      expect(html).toContain('<a href="/">Go to the ggsvelte documentation</a>');
+    } finally {
+      rmSync(buildDirectory, { recursive: true, force: true });
+    }
+  });
+
   it("injects a broad noindex header only into preview artifacts", () => {
     const preview = mkdtempSync(join(tmpdir(), "ggsvelte-cloudflare-preview-"));
     const production = mkdtempSync(join(tmpdir(), "ggsvelte-cloudflare-production-"));
@@ -184,6 +202,21 @@ describe("deployment artifact identity", () => {
     }
   });
 
+  it("rejects an unknown-route fallback with no no-JavaScript message", () => {
+    const buildDirectory = makeCompleteArtifact("cloudflare-production");
+    try {
+      writeFileSync(
+        join(buildDirectory, "404.html"),
+        '<meta name="robots" content="noindex,follow">',
+      );
+      expect(
+        validateDeploymentArtifact(buildDirectory, expectedArtifact("cloudflare-production")),
+      ).toContain("404.html must render Not found without JavaScript");
+    } finally {
+      rmSync(buildDirectory, { recursive: true, force: true });
+    }
+  });
+
   it("rejects missing security, cache, and fixed-destination redirect policies", () => {
     const buildDirectory = makeCompleteArtifact("cloudflare-production");
     try {
@@ -201,7 +234,7 @@ describe("deployment artifact identity", () => {
         "_headers must cache only SvelteKit immutable assets for one year",
       );
       expect(problems).toContain("_redirects is missing the fixed legacy benchmark redirect");
-      expect(problems).toContain("_redirects is missing the /ggsvelte cleanup redirect");
+      expect(problems).toContain("_redirects is missing the absolute /ggsvelte cleanup redirect");
     } finally {
       rmSync(buildDirectory, { recursive: true, force: true });
     }

--- a/scripts/deployment-artifact.test.ts
+++ b/scripts/deployment-artifact.test.ts
@@ -156,8 +156,9 @@ describe("deployment artifact identity", () => {
       ensureNotFoundNoindex(buildDirectory);
       const html = readFileSync(join(buildDirectory, "404.html"), "utf8");
       expect(html).toContain('<meta name="robots" content="noindex,follow" />');
-      expect(html).toContain("<noscript><main><h1>Not found</h1>");
+      expect(html).toContain("<main><h1>Not found</h1>");
       expect(html).toContain('<a href="/">Go to the ggsvelte documentation</a>');
+      expect(html).not.toContain("<script");
     } finally {
       rmSync(buildDirectory, { recursive: true, force: true });
     }
@@ -215,6 +216,21 @@ describe("deployment artifact identity", () => {
       expect(
         validateDeploymentArtifact(buildDirectory, expectedArtifact("cloudflare-production")),
       ).toContain("404.html must render Not found without JavaScript");
+    } finally {
+      rmSync(buildDirectory, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects a scripted unknown-route fallback", () => {
+    const buildDirectory = makeCompleteArtifact("cloudflare-production");
+    try {
+      writeFileSync(
+        join(buildDirectory, "404.html"),
+        '<meta name="robots" content="noindex,follow"><main><h1>Not found</h1></main><script>start()</script>',
+      );
+      expect(
+        validateDeploymentArtifact(buildDirectory, expectedArtifact("cloudflare-production")),
+      ).toContain("404.html must remain useful without client scripts");
     } finally {
       rmSync(buildDirectory, { recursive: true, force: true });
     }

--- a/scripts/deployment-artifact.test.ts
+++ b/scripts/deployment-artifact.test.ts
@@ -58,7 +58,10 @@ function makeCompleteArtifact(buildMode: "cloudflare-preview" | "cloudflare-prod
   const buildDirectory = mkdtempSync(join(tmpdir(), "ggsvelte-cloudflare-artifact-"));
   for (const [path, contents] of [
     ["index.html", '<link rel="canonical" href="https://ggsvelte.sh/">'],
-    ["404.html", '<meta name="robots" content="noindex,follow"><h1>Not found</h1>'],
+    [
+      "404.html",
+      '<meta name="robots" content="noindex,follow"><noscript><main><h1>Not found</h1></main></noscript>',
+    ],
     [
       "_headers",
       buildMode === "cloudflare-preview"
@@ -153,7 +156,7 @@ describe("deployment artifact identity", () => {
       ensureNotFoundNoindex(buildDirectory);
       const html = readFileSync(join(buildDirectory, "404.html"), "utf8");
       expect(html).toContain('<meta name="robots" content="noindex,follow" />');
-      expect(html).toContain("<h1>Not found</h1>");
+      expect(html).toContain("<noscript><main><h1>Not found</h1>");
       expect(html).toContain('<a href="/">Go to the ggsvelte documentation</a>');
     } finally {
       rmSync(buildDirectory, { recursive: true, force: true });

--- a/scripts/deployment-artifact.ts
+++ b/scripts/deployment-artifact.ts
@@ -76,13 +76,23 @@ export interface DeploymentExpectation {
 
 export function ensureNotFoundNoindex(buildDirectory: string): void {
   const path = join(buildDirectory, "404.html");
-  const html = readFileSync(path, "utf8");
-  if (html.includes('name="robots" content="noindex')) return;
-  if (!html.includes("</head>")) throw new Error("404.html is missing its closing head tag");
-  writeFileSync(
-    path,
-    html.replace("</head>", '    <meta name="robots" content="noindex,follow" />\n  </head>'),
-  );
+  let html = readFileSync(path, "utf8");
+  if (!html.includes('name="robots" content="noindex')) {
+    if (!html.includes("</head>")) throw new Error("404.html is missing its closing head tag");
+    html = html.replace(
+      "</head>",
+      '    <meta name="robots" content="noindex,follow" />\n  </head>',
+    );
+  }
+  if (!html.includes("<h1>Not found</h1>")) {
+    const mount = '<div style="display: contents">';
+    if (!html.includes(mount)) throw new Error("404.html is missing its application mount");
+    html = html.replace(
+      mount,
+      `${mount}\n      <main><h1>Not found</h1><p>This page does not exist.</p><p><a href="/">Go to the ggsvelte documentation</a></p></main>`,
+    );
+  }
+  writeFileSync(path, html);
 }
 
 export function ensurePreviewNoindexHeader(
@@ -128,11 +138,14 @@ export function validateDeploymentArtifact(
     }
   }
   const notFoundPath = join(buildDirectory, "404.html");
-  if (
-    existsSync(notFoundPath) &&
-    !readFileSync(notFoundPath, "utf8").includes('name="robots" content="noindex')
-  ) {
-    problems.push("404.html must contain a noindex robots policy");
+  if (existsSync(notFoundPath)) {
+    const notFoundHtml = readFileSync(notFoundPath, "utf8");
+    if (!notFoundHtml.includes('name="robots" content="noindex')) {
+      problems.push("404.html must contain a noindex robots policy");
+    }
+    if (!notFoundHtml.includes("<h1>Not found</h1>")) {
+      problems.push("404.html must render Not found without JavaScript");
+    }
   }
 
   if (expected.buildMode === "cloudflare-preview" && hasAnalyticsBeacon) {
@@ -183,8 +196,8 @@ export function validateDeploymentArtifact(
     if (!redirects.includes("/bench/* https://ljodea.github.io/ggsvelte/bench/:splat 302")) {
       problems.push("_redirects is missing the fixed legacy benchmark redirect");
     }
-    if (!redirects.includes("/ggsvelte/* /:splat 301")) {
-      problems.push("_redirects is missing the /ggsvelte cleanup redirect");
+    if (!redirects.includes("/ggsvelte/* https://ggsvelte.sh/:splat 301")) {
+      problems.push("_redirects is missing the absolute /ggsvelte cleanup redirect");
     }
   }
 

--- a/scripts/deployment-artifact.ts
+++ b/scripts/deployment-artifact.ts
@@ -84,12 +84,12 @@ export function ensureNotFoundNoindex(buildDirectory: string): void {
       '    <meta name="robots" content="noindex,follow" />\n  </head>',
     );
   }
-  if (!html.includes("<h1>Not found</h1>")) {
+  if (!html.includes("<noscript><main><h1>Not found</h1>")) {
     const mount = '<div style="display: contents">';
     if (!html.includes(mount)) throw new Error("404.html is missing its application mount");
     html = html.replace(
       mount,
-      `${mount}\n      <main><h1>Not found</h1><p>This page does not exist.</p><p><a href="/">Go to the ggsvelte documentation</a></p></main>`,
+      `${mount}\n      <noscript><main><h1>Not found</h1><p>This page does not exist.</p><p><a href="/">Go to the ggsvelte documentation</a></p></main></noscript>`,
     );
   }
   writeFileSync(path, html);
@@ -143,7 +143,7 @@ export function validateDeploymentArtifact(
     if (!notFoundHtml.includes('name="robots" content="noindex')) {
       problems.push("404.html must contain a noindex robots policy");
     }
-    if (!notFoundHtml.includes("<h1>Not found</h1>")) {
+    if (!notFoundHtml.includes("<noscript><main><h1>Not found</h1>")) {
       problems.push("404.html must render Not found without JavaScript");
     }
   }

--- a/scripts/deployment-artifact.ts
+++ b/scripts/deployment-artifact.ts
@@ -75,24 +75,31 @@ export interface DeploymentExpectation {
 }
 
 export function ensureNotFoundNoindex(buildDirectory: string): void {
-  const path = join(buildDirectory, "404.html");
-  let html = readFileSync(path, "utf8");
-  if (!html.includes('name="robots" content="noindex')) {
-    if (!html.includes("</head>")) throw new Error("404.html is missing its closing head tag");
-    html = html.replace(
-      "</head>",
-      '    <meta name="robots" content="noindex,follow" />\n  </head>',
-    );
-  }
-  if (!html.includes("<noscript><main><h1>Not found</h1>")) {
-    const mount = '<div style="display: contents">';
-    if (!html.includes(mount)) throw new Error("404.html is missing its application mount");
-    html = html.replace(
-      mount,
-      `${mount}\n      <noscript><main><h1>Not found</h1><p>This page does not exist.</p><p><a href="/">Go to the ggsvelte documentation</a></p></main></noscript>`,
-    );
-  }
-  writeFileSync(path, html);
+  writeFileSync(
+    join(buildDirectory, "404.html"),
+    `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex,follow" />
+    <title>Not found — ggsvelte</title>
+    <style>
+      :root { color-scheme: light dark; font-family: ui-sans-serif, system-ui, sans-serif; }
+      body { margin: 0; min-height: 100vh; display: grid; place-items: center; background: #f7f5ef; color: #171714; }
+      main { width: min(32rem, calc(100% - 3rem)); }
+      h1 { margin: 0 0 0.75rem; font-family: ui-serif, Georgia, serif; font-size: clamp(2.5rem, 8vw, 5rem); line-height: 0.95; }
+      p { color: #5a574f; font-size: 1.05rem; line-height: 1.6; }
+      a { color: inherit; font-weight: 650; text-underline-offset: 0.2em; }
+      @media (prefers-color-scheme: dark) { body { background: #171714; color: #f7f5ef; } p { color: #bdb8ad; } }
+    </style>
+  </head>
+  <body>
+    <main><h1>Not found</h1><p>This page does not exist.</p><p><a href="/">Go to the ggsvelte documentation</a></p></main>
+  </body>
+</html>
+`,
+  );
 }
 
 export function ensurePreviewNoindexHeader(
@@ -143,8 +150,11 @@ export function validateDeploymentArtifact(
     if (!notFoundHtml.includes('name="robots" content="noindex')) {
       problems.push("404.html must contain a noindex robots policy");
     }
-    if (!notFoundHtml.includes("<noscript><main><h1>Not found</h1>")) {
+    if (!notFoundHtml.includes("<main><h1>Not found</h1>")) {
       problems.push("404.html must render Not found without JavaScript");
+    }
+    if (notFoundHtml.includes("<script")) {
+      problems.push("404.html must remain useful without client scripts");
     }
   }
 


### PR DESCRIPTION
## Summary

- render a useful no-JavaScript `Not found` response in the Cloudflare Pages fallback
- require the fallback content during artifact validation
- make `/ggsvelte/*` cleanup redirects emit the absolute canonical URL expected by cutover smoke checks

## Production evidence

The initial cutover smoke run found two failures while every other apex, host redirect, artifact, migration, and benchmark check passed:

1. `404.html` was an empty SvelteKit application shell before JavaScript started.
2. Cloudflare emitted the relative `Location: /guide/...` from the cleanup rule while the deployment contract requires the canonical absolute URL.

The exact hotfix commit was deployed to `09d0a8b0.ggsvelte.pages.dev` and verified:

- unknown route: HTTP 404 with one semantic `main`, one `Not found` heading, and no client scripts
- cleanup route: HTTP 301 with absolute `Location: https://ggsvelte.sh/guide/getting-started?from=legacy-base`
- `artifact.json`: exact source commit and `cloudflare-production` mode

## Tests

- `bun test scripts/deployment-artifact.test.ts scripts/deployment-smoke.test.ts`
- full pre-push package build, Svelte checks, type-aware lint, examples TypeScript, knip, and Bun tests
- real `cloudflare-production` artifact build and validation
