### PR TITLE
fix(ci): isolate block-output-paths guard tests from host env

### DIFF
--- a/scripts/block-output-paths.test.ts
+++ b/scripts/block-output-paths.test.ts
@@ -31,21 +31,26 @@ esac
   );
   chmodSync(fakeGit, 0o755);
 
-  const env = Object.fromEntries(
-    Object.entries(process.env).filter(([name]) => !name.startsWith("GIT_")),
-  );
+  // Minimal env only: spreading process.env on CI leaves GITHUB_* / locale /
+  // BASH_ENV values that can change branch resolution or stderr decoding.
+  // Empty-string overrides are also unreliable across Node/Bun spawn impls.
   return spawnSync("bash", [guard, hookArg], {
     cwd: sandbox,
     encoding: "utf8",
     env: {
-      ...env,
-      PATH: `${bin}:${env.PATH}`,
+      PATH: `${bin}:/usr/bin:/bin`,
       FAKE_BRANCH: branch,
       FAKE_STAGED: staged,
-      GITHUB_HEAD_REF: "",
-      GITHUB_REF_NAME: "",
+      HOME: sandbox,
+      TMPDIR: tmpdir(),
+      LC_ALL: "C.UTF-8",
+      LANG: "C.UTF-8",
     },
   });
+}
+
+function combinedOutput(result: ReturnType<typeof spawnSync>): string {
+  return `${result.stdout ?? ""}${result.stderr ?? ""}`;
 }
 
 describe("block-output-paths guard", () => {
@@ -56,7 +61,7 @@ describe("block-output-paths guard", () => {
   it("blocks a newly staged baseline on an ordinary branch", () => {
     const result = runGuard("feature/ordinary", baseline);
     expect(result.status).toBe(1);
-    expect(result.stderr).toContain("plot.png");
+    expect(combinedOutput(result)).toContain("plot.png");
   });
 
   it("allows the audited visual-update branch", () => {
@@ -66,12 +71,13 @@ describe("block-output-paths guard", () => {
   it("blocks a newly staged coverage report on an ordinary branch", () => {
     const result = runGuard("feature/ordinary", coverageArtifact, coverageArtifact);
     expect(result.status).toBe(1);
-    expect(result.stderr).toContain("coverage");
+    expect(combinedOutput(result)).toContain(coverageArtifact);
   });
 
   it("blocks coverage reports on audited visual-update branches", () => {
     const result = runGuard("vr-update/pr-11", coverageArtifact, coverageArtifact);
     expect(result.status).toBe(1);
-    expect(result.stderr).toContain("coverage");
+    // vr-update/* only exempts screenshot baselines; coverage stays blocked.
+    expect(combinedOutput(result)).toContain(coverageArtifact);
   });
 });

--- a/scripts/guards/block-output-paths.sh
+++ b/scripts/guards/block-output-paths.sh
@@ -27,9 +27,12 @@ if [[ ${#blocked[@]} -eq 0 ]]; then
   exit 0
 fi
 
-echo "BLOCKED: test/visual output paths are generated artifacts and must not be committed:" >&2
+# printf (not echo) so paths and ASCII-only messages are portable across
+# locales and shells; keep the full blocked list on stderr for tests and
+# operators.
+printf '%s\n' "BLOCKED: generated output paths must not be committed:" >&2
 for f in "${blocked[@]}"; do
-  echo "  $f" >&2
+  printf '  %s\n' "${f}" >&2
 done
-echo "Unstage them (git restore --staged <path>) — VR baselines land only via the vr-approve workflow." >&2
+printf '%s\n' "Unstage them (git restore --staged <path>) - VR baselines land only via the vr-approve workflow." >&2
 exit 1


### PR DESCRIPTION
## Summary
- #364 unit job failed once: block-output-paths guard test expected stderr to contain coverage but only the BLOCKED header was captured.
- Same runner passed the same suite on main minutes later; not reproducible locally or in Linux Docker (20/20 green).
- Harden the harness: minimal spawn env (no process.env spread / empty GITHUB_* overrides), assert on combined stdio, print blocked paths with printf.

Also includes the knip wrangler ignore so pre-push stays green (see #366). Drop that commit when rebasing if #366 lands first.

## Root cause
Test harness isolation gap under Actions: spreading host env and clearing GITHUB_HEAD_REF with empty strings is unreliable across Bun/Node spawn implementations, and multi-line stderr assertions were fragile.

## Test plan
- [x] bun test scripts/block-output-paths.test.ts (local + Docker Linux)
- [ ] CI unit job on this PR

Unblocks Version Packages #364 unit failure.