### PR TITLE
fix(visual): isolate progressive lesson screenshots from skip-link chrome

### DIFF
--- a/tests/visual/docs-progressive-search.spec.ts
+++ b/tests/visual/docs-progressive-search.spec.ts
@@ -305,8 +305,14 @@ for (const [name, width, height] of [
   test(`progressive lesson ${name} visual contract`, async ({ page }) => {
     await page.setViewportSize({ width, height });
     await page.goto("/guide/getting-started?theme=light");
-    await page.locator(".site-header").evaluate((element) => {
-      element.style.visibility = "hidden";
+    // Lesson contracts cover the progressive step only. Hide fixed chrome that can
+    // overlay the element after scroll-into-view (site header + skip links, which
+    // become visible when focused and sit at position:fixed top-left).
+    await page.evaluate(() => {
+      (document.activeElement as HTMLElement | null)?.blur?.();
+      for (const el of document.querySelectorAll<HTMLElement>(".site-header, .skip-link")) {
+        el.style.visibility = "hidden";
+      }
     });
     const step = page.locator(".progressive-step").nth(3);
     await expect(step).toHaveScreenshot(`docs-progressive-lesson-${name}.png`);


### PR DESCRIPTION
## Summary
- Progressive lesson mobile VR failed on #364 (and the Cloudflare cutover branch) because a focused fixed-position Skip to docs navigation link overlaid the progressive-step after Playwright scroll-into-view.
- Diff was about 1% of pixels at the top edge only; expected baseline has no skip-link chrome.
- Hide .skip-link with .site-header and blur focus before the lesson screenshot.

Also includes the knip wrangler ignore so pre-push stays green (see #366). Drop that commit when rebasing if #366 lands first.

## Root cause
docs-progressive-search.spec.ts only hid .site-header. Skip links use position:fixed and become visible on :focus, so they contaminate element screenshots when they sit over the scrolled step (confirmed via CI actual/diff artifacts).

## Test plan
- [ ] CI VR Compare on this PR (pinned container)
- [ ] progressive lesson mobile visual contract passes
- [ ] progressive lesson desktop visual contract still passes

Unblocks Version Packages #364 VR failure once merged (release PR will refresh from main).