### PR TITLE
fix(docs): resolve relative smoke redirects

### DIFF
--- a/scripts/deployment-smoke.test.ts
+++ b/scripts/deployment-smoke.test.ts
@@ -22,6 +22,26 @@ describe("deployment HTTP smoke assertions", () => {
     ).toEqual([]);
   });
 
+  it("accepts a same-origin relative Location with the expected absolute destination", () => {
+    expect(
+      evaluateSmokeResponse(
+        {
+          name: "legacy-base cleanup redirect",
+          url: "https://ggsvelte.sh/ggsvelte/guide/getting-started?from=legacy-base",
+          status: 301,
+          redirectTo: "https://ggsvelte.sh/guide/getting-started?from=legacy-base",
+        },
+        {
+          status: 301,
+          headers: new Headers({
+            Location: "/guide/getting-started?from=legacy-base",
+          }),
+          body: "",
+        },
+      ),
+    ).toEqual([]);
+  });
+
   it("covers immutable preview routes and blocks promotion without noindex", () => {
     const plan = previewSmokePlan(
       "https://feature-cloudflare.ggsvelte.pages.dev",

--- a/scripts/deployment-smoke.ts
+++ b/scripts/deployment-smoke.ts
@@ -207,7 +207,15 @@ export function evaluateSmokeResponse(expected: SmokeExpectation, actual: SmokeR
   }
   if (expected.redirectTo !== undefined) {
     const location = actual.headers.get("location");
-    if (location !== expected.redirectTo) {
+    let resolvedLocation: string | null = null;
+    if (location !== null) {
+      try {
+        resolvedLocation = new URL(location, expected.url).href;
+      } catch {
+        resolvedLocation = null;
+      }
+    }
+    if (resolvedLocation !== expected.redirectTo) {
       problems.push(
         `${expected.name}: expected redirect ${expected.redirectTo}, received ${location ?? "no Location header"}`,
       );


### PR DESCRIPTION
## Summary

- resolve HTTP `Location` values against the requested URL before comparing redirect destinations
- accept standards-compliant same-origin relative redirects while retaining exact semantic destination checks

## Why

Cloudflare Pages normalizes a same-origin absolute `_redirects` destination to a relative `Location` response in production. Browsers resolve both to the same canonical URL, but the cutover smoke evaluator compared raw strings and reported a false failure.

## Evidence

- focused test covers the production response shape
- full 14-check production cutover smoke suite passes against `https://ggsvelte.sh`
- full pre-push package build, Svelte checks, type-aware lint, examples TypeScript, knip, and Bun tests pass
