### PR TITLE
docs: rewrite site copy for expert readers

### DIFF
--- a/apps/docs/src/lib/Playground.svelte
+++ b/apps/docs/src/lib/Playground.svelte
@@ -307,13 +307,12 @@
 <section class="playground" aria-labelledby="playground-heading">
   <header class="playground-intro">
     <div>
-      <p class="eyebrow">Local PortableSpec workbench</p>
-      <h1 id="playground-heading">Adapt a chart, then take the Svelte</h1>
+      <p class="eyebrow">Local only</p>
+      <h1 id="playground-heading">Playground</h1>
       <p class="lede">
-        Start from a real example or a small sample. Edit bounded JSON, inspect
-        semantic events, and take complete Svelte, equivalent Builder or
-        PortableSpec, and deterministic SVG. No account, upload, remote fetch,
-        or code execution.
+        Edit a bounded PortableSpec. Inspect semantic events. Export Svelte,
+        builder TypeScript, JSON, or SVG. No upload, remote fetch, or code
+        execution.
       </p>
     </div>
     <div class="share-actions">

--- a/apps/docs/src/lib/catalog/docs-tasks.ts
+++ b/apps/docs/src/lib/catalog/docs-tasks.ts
@@ -6,32 +6,28 @@ export interface DocsTask {
 
 export const DOCS_TASKS = [
   {
-    label: "Build a chart",
-    description:
-      "Install one package and render a responsive, accessible chart from one Svelte file.",
+    label: "Getting started",
+    description: "Install @ggsvelte/svelte and render one chart from a Svelte file.",
     hrefs: ["/guide/getting-started"],
   },
   {
-    label: "Customize it",
-    description:
-      "Choose scales, guides, themes, and color without changing the meaning of the data.",
+    label: "Scales, themes, color",
+    description: "Axes, legends, chart themes, and categorical or sequential color.",
     hrefs: ["/guide/scales-guides", "/guide/themes-color"],
   },
   {
-    label: "Add interaction",
-    description: "Add inspect-and-pin behavior with a keyboard and touch path before linked state.",
+    label: "Interaction",
+    description: "Inspect, pin, select, zoom, and linked semantic state.",
     hrefs: ["/guide/inspect-pin"],
   },
   {
-    label: "Deploy it",
-    description:
-      "Make chart sizing predictable, then choose browser, server, or exported SVG output.",
+    label: "Layout and export",
+    description: "Container sizing, SVG/canvas rendering, SSR, and headless SVG.",
     hrefs: ["/guide/responsive-charts", "/guide/server-rendering-export"],
   },
   {
-    label: "Troubleshoot it",
-    description:
-      "Follow stable validation, rendering, interaction, and command-line diagnostic codes.",
+    label: "Diagnostics",
+    description: "Validation, render, interaction, and CLI error codes.",
     hrefs: ["/guide/errors"],
   },
 ] as const satisfies readonly DocsTask[];

--- a/apps/docs/src/lib/catalog/gallery.ts
+++ b/apps/docs/src/lib/catalog/gallery.ts
@@ -1,69 +1,29 @@
 import type { ExampleManifestEntry } from "../../../../../examples/manifest.js";
 import { GALLERY_PREVIEWS } from "../generated/gallery-previews.js";
 
-export interface FeaturedExample {
-  id: string;
-  jobTitle: string;
-  proof: string;
-  note: string;
-}
-
 export interface GalleryEntry extends ExampleManifestEntry {
   previewPath: string;
-  featured?: FeaturedExample;
+  featured: boolean;
 }
 
+/** Featured strip order on home and gallery. Identity only — titles come from the manifest. */
 export const FEATURED_EXAMPLES = [
-  {
-    id: "line/multi-series",
-    jobTitle: "Track several series over time",
-    proof: "Layered lines, stable color identity, and a clear legend for an application staple.",
-    note: "Multiple series · stable color",
-  },
-  {
-    id: "smooth/loess-scatter",
-    jobTitle: "Explain a noisy relationship",
-    proof: "Raw observations, a statistical smoother, and its confidence ribbon share one view.",
-    note: "Points · smooth · confidence ribbon",
-  },
-  {
-    id: "interaction/linked-views",
-    jobTitle: "Coordinate a chart with ordinary UI",
-    proof: "Semantic keys connect plots, controls, and an accessible table without callback loops.",
-    note: "Interactive · linked selection",
-  },
-  {
-    id: "facet/wrap",
-    jobTitle: "Compare distributions across groups",
-    proof: "Small multiples turn one specification into a repeated, readable comparison.",
-    note: "Facets · per-panel statistics",
-  },
-  {
-    id: "color/continuous",
-    jobTitle: "Map magnitude with ordered color",
-    proof:
-      "A perceptually ordered scale carries quantitative meaning without changing the data model.",
-    note: "Sequential color · continuous data",
-  },
-  {
-    id: "point/canvas-scatter",
-    jobTitle: "Render dense data responsibly",
-    proof: "Canvas marks keep SVG axes and an accessible chart surface for a 10,000-point view.",
-    note: "10k points · canvas marks · SVG chrome",
-  },
-] as const satisfies readonly FeaturedExample[];
+  { id: "line/multi-series" },
+  { id: "smooth/loess-scatter" },
+  { id: "interaction/linked-views" },
+  { id: "facet/wrap" },
+  { id: "color/continuous" },
+  { id: "point/canvas-scatter" },
+] as const;
 
-const featuredById = new Map<string, FeaturedExample>(
-  FEATURED_EXAMPLES.map((entry) => [entry.id, entry]),
-);
+const featuredIds = new Set<string>(FEATURED_EXAMPLES.map((entry) => entry.id));
 
 const previewById = new Map<string, string>(
   GALLERY_PREVIEWS.map((preview) => [preview.id, preview.path]),
 );
 
 export function galleryEntryFor(entry: ExampleManifestEntry): GalleryEntry {
-  const featured = featuredById.get(entry.id);
   const previewPath = previewById.get(entry.id);
   if (previewPath === undefined) throw new Error(`Missing generated preview for ${entry.id}`);
-  return { ...entry, previewPath, ...(featured !== undefined && { featured }) };
+  return { ...entry, previewPath, featured: featuredIds.has(entry.id) };
 }

--- a/apps/docs/src/lib/components/ChartThemeLab.svelte
+++ b/apps/docs/src/lib/components/ChartThemeLab.svelte
@@ -52,12 +52,11 @@
 
 <section class="theme-lab" aria-label="Chart theme lab">
   <div class="lab-copy">
-    <p class="eyebrow">Separate by default</p>
-    <h2>Site appearance is not chart meaning.</h2>
+    <p class="eyebrow">Independence</p>
+    <h2>Chart theme ≠ site appearance.</h2>
     <p>
-      Choose a chart theme independently so exported graphics keep their
-      intended paper and ink. Follow the docs appearance only when that behavior
-      is deliberate.
+      Theme travels with the chart. Link it to docs appearance only when you
+      want that.
     </p>
     <div class="controls">
       <div class="select-control">

--- a/apps/docs/src/lib/components/ColorFailureDemo.svelte
+++ b/apps/docs/src/lib/components/ColorFailureDemo.svelte
@@ -19,12 +19,12 @@
 <section class="limits" aria-label="Palette limits">
   <header class="section-heading">
     <div>
-      <p class="eyebrow">Failure is part of the contract</p>
-      <h2>Decide what happens when color runs out.</h2>
+      <p class="eyebrow">Exhaustion</p>
+      <h2>When the palette runs out.</h2>
     </div>
     <p>
-      Cycling keeps a chart renderable and warns once. Strict mode stops before
-      two categories can imply the same identity. Both results below come from
+      <code>onExhaust: "cycle"</code> warns once and reuses colors.
+      <code>"error"</code> fails validation before identity collides. Results from
       the public validation and pipeline APIs.
     </p>
   </header>
@@ -33,7 +33,7 @@
     <article class="incompatible">
       <p class="diagnostic-kind">Validation result</p>
       <code>{evidence.incompatible.code}</code>
-      <h3>A sequential scheme cannot drive ordinal categories.</h3>
+      <h3>Sequential scheme + ordinal categories</h3>
       <p>{evidence.incompatible.message}</p>
       <dl>
         <div>

--- a/apps/docs/src/lib/components/GettingStartedGuide.svelte
+++ b/apps/docs/src/lib/components/GettingStartedGuide.svelte
@@ -68,8 +68,8 @@
 <article class="guide getting-started-guide">
   <h1>Getting started</h1>
   <p class="lede">
-    Build a responsive, accessible chart in one Svelte file. See the result
-    first, then add one grammar decision at a time.
+    Install, render one chart from a Svelte file, then add aes, layers, scales,
+    facets, theme, and inspect one step at a time.
   </p>
 
   <h2 id="create-a-sveltekit-app">Create a SvelteKit app</h2>
@@ -271,10 +271,10 @@
 
   <h2 id="where-next">Where next</h2>
   <ul>
-    <li><a href={`${base}/examples`}>Browse runnable examples</a>.</li>
-    <li><a href={`${base}/guide/interactions`}>Add interaction</a>.</li>
-    <li><a href={`${base}/guide/compatibility`}>Check compatibility</a>.</li>
-    <li><a href={`${base}/guide/errors`}>Recover from a diagnostic</a>.</li>
+    <li><a href={`${base}/examples`}>Examples</a></li>
+    <li><a href={`${base}/guide/interactions`}>Interaction</a></li>
+    <li><a href={`${base}/guide/compatibility`}>Compatibility</a></li>
+    <li><a href={`${base}/guide/errors`}>Diagnostics</a></li>
   </ul>
 </article>
 

--- a/apps/docs/src/lib/components/GrammarDemo.svelte
+++ b/apps/docs/src/lib/components/GrammarDemo.svelte
@@ -3,18 +3,18 @@
   import { penguins } from "$examples/point/scatter-color/data";
 
   const steps = [
-    { label: "Data", note: "Start with ordinary rows." },
+    { label: "Data", note: "Rows as plain objects." },
     {
       label: "Mappings",
-      note: "Map fields, including a stable series identity.",
+      note: "aes for x, y, and color identity.",
     },
     {
       label: "Layers",
-      note: "Compose a statistical layer without replacing the points.",
+      note: "GeomSmooth on top of GeomPoint.",
     },
     {
       label: "Interaction",
-      note: "Opt into inspection after the chart already works.",
+      note: "inspect after the layers work.",
     },
   ] as const;
   let active = $state(0);
@@ -22,12 +22,9 @@
 
 <section class="grammar-demo" aria-labelledby="grammar-heading">
   <div class="grammar-copy">
-    <p class="eyebrow">Svelte-first composition</p>
-    <h2 id="grammar-heading">Build the chart by adding meaning</h2>
-    <p>
-      Each step changes the same real ggsvelte chart. Nothing here is a
-      decorative mockup.
-    </p>
+    <p class="eyebrow">Composition</p>
+    <h2 id="grammar-heading">Data, aes, layers, inspect.</h2>
+    <p>One real chart. Each step adds grammar.</p>
     <ol>
       {#each steps as step, index (step.label)}
         <li class:active={active === index}>

--- a/apps/docs/src/lib/components/InteractiveThemeSpecimen.svelte
+++ b/apps/docs/src/lib/components/InteractiveThemeSpecimen.svelte
@@ -67,14 +67,13 @@
 <section class="interactive-theme" aria-label="Custom interaction theme">
   <header class="section-heading">
     <div>
-      <p class="eyebrow">Custom ThemeSpec</p>
-      <h2>Theme the behavior, not only the backdrop.</h2>
+      <p class="eyebrow">ThemeSpec</p>
+      <h2>Interaction roles</h2>
     </div>
     <div>
       <p>
-        Focus, crosshair, selection, tooltip, muted marks, and the active tool
-        use explicit roles. Stable keys carry semantic emphasis between an SVG
-        view and a canvas view.
+        Focus, crosshair, selection, tooltip, muted marks, active tool — each a
+        role on ThemeSpec. Semantic keys share emphasis across SVG and canvas.
       </p>
       <label for="interaction-paper">Interaction chart paper</label>
       <select id="interaction-paper" bind:value={paperTheme}>

--- a/apps/docs/src/lib/components/PaletteGallery.svelte
+++ b/apps/docs/src/lib/components/PaletteGallery.svelte
@@ -9,14 +9,13 @@
 <section class="palette-gallery" aria-label="Categorical color schemes">
   <header class="section-heading">
     <div>
-      <p class="eyebrow">Categorical color</p>
-      <h2>Keep identity stable and capacity explicit.</h2>
+      <p class="eyebrow">Categorical</p>
+      <h2>Named schemes</h2>
     </div>
     <div>
       <p>
-        Named schemes preserve category identity across chart themes. Capacity
-        tells you when a palette will repeat instead of pretending every
-        category is unique.
+        Stable category colors across themes. Capacity is the point at which
+        colors repeat under cycle, or fail under error.
       </p>
       <div class="controls">
         <div class="select-control">

--- a/apps/docs/src/lib/components/PlaygroundOutput.svelte
+++ b/apps/docs/src/lib/components/PlaygroundOutput.svelte
@@ -126,7 +126,7 @@
 <div class="panel-heading">
   <div>
     <p class="panel-number">03</p>
-    <h2>Take the chart with you</h2>
+    <h2>Export</h2>
   </div>
   <div class="output-actions">
     <button

--- a/apps/docs/src/lib/components/PlaygroundPreview.svelte
+++ b/apps/docs/src/lib/components/PlaygroundPreview.svelte
@@ -60,7 +60,7 @@
 <div class="panel-heading">
   <div>
     <p class="panel-number">01</p>
-    <h2>See the result</h2>
+    <h2>Preview</h2>
   </div>
   {#if lastValid}<strong class="last-valid">Last valid result</strong>{/if}
 </div>

--- a/apps/docs/src/lib/components/SequentialColorLab.svelte
+++ b/apps/docs/src/lib/components/SequentialColorLab.svelte
@@ -56,14 +56,13 @@
 <section class="sequential-lab" aria-label="Sequential color scales">
   <header class="section-heading">
     <div>
-      <p class="eyebrow">Quantitative color</p>
-      <h2>Make direction and domain visible.</h2>
+      <p class="eyebrow">Sequential</p>
+      <h2>Ramps and domains</h2>
     </div>
     <div>
       <p>
-        Sequential color encodes order. Reverse the public ramp instead of
-        rebuilding it, or pin a domain when two charts must share the same
-        meaning.
+        Order encoding. Reverse the ramp or pin <code>domain</code> when charts must
+        share the same scale meaning.
       </p>
       <ol class="viridis-ramp" aria-label="Viridis reference colors">
         {#each VIRIDIS_COLORS as color, index (`${color}-${String(index)}`)}

--- a/apps/docs/src/lib/components/SiteFooter.svelte
+++ b/apps/docs/src/lib/components/SiteFooter.svelte
@@ -6,7 +6,7 @@
   <div class="site-footer__inner">
     <div>
       <a class="site-brand" href={`${base}/`}>ggsvelte</a>
-      <p>A layered grammar for clear, interactive data graphics in Svelte.</p>
+      <p>Layered grammar of graphics for Svelte.</p>
     </div>
     <nav aria-label="Footer">
       <a href={`${base}/docs`}>Docs</a>

--- a/apps/docs/src/lib/components/SiteSearch.svelte
+++ b/apps/docs/src/lib/components/SiteSearch.svelte
@@ -176,10 +176,12 @@
     {#if query.trim() === "" || results.length === 0}
       <nav
         class="search-tasks"
-        aria-label={query.trim() === "" ? "Start with a task" : "Try a task"}
+        aria-label={query.trim() === ""
+          ? "Common destinations"
+          : "Other destinations"}
       >
         <p>
-          {query.trim() === "" ? "Start with a task" : "Try a task instead"}
+          {query.trim() === "" ? "Common destinations" : "Other destinations"}
         </p>
         {#each DOCS_TASKS as task (task.label)}
           <a href={`${base}${task.hrefs[0]}`} onclick={close}>{task.label}</a>

--- a/apps/docs/src/lib/gallery-filter.ts
+++ b/apps/docs/src/lib/gallery-filter.ts
@@ -40,8 +40,6 @@ export function filterGallery(
         entry.category,
         entry.docsSection,
         ...entry.tags,
-        entry.featured?.jobTitle ?? "",
-        entry.featured?.proof ?? "",
       ].join(" "),
     );
     return query.split(" ").every((part) => haystack.includes(part));

--- a/apps/docs/src/lib/generated/routes.ts
+++ b/apps/docs/src/lib/generated/routes.ts
@@ -6,7 +6,7 @@ export const DOCS_ROUTES = [
     path: "/",
     title: "ggsvelte — layered grammar of graphics for Svelte",
     description:
-      "Build publication-ready, interactive data graphics in Svelte with a layered grammar and a portable JSON specification.",
+      "Layered grammar of graphics for Svelte: ggplot2-style aes, geoms, stats, and themes, with PortableSpec JSON and hybrid SVG/canvas rendering.",
     canonicalPath: "/",
     kind: "page",
     index: true,
@@ -16,8 +16,7 @@ export const DOCS_ROUTES = [
   {
     path: "/docs",
     title: "Documentation — ggsvelte",
-    description:
-      "Build, customize, interact with, deploy, and troubleshoot ggsvelte charts through a task-first learning path.",
+    description: "Install, compose the grammar, add interaction, ship, and read public contracts.",
     canonicalPath: "/docs",
     kind: "page",
     index: true,
@@ -32,8 +31,7 @@ export const DOCS_ROUTES = [
   {
     path: "/examples",
     title: "Gallery — ggsvelte",
-    description:
-      "Browse runnable ggsvelte charts across marks, statistics, scales, and interaction.",
+    description: "Runnable ggsvelte examples across marks, stats, scales, and interaction.",
     canonicalPath: "/examples",
     kind: "page",
     index: true,
@@ -44,7 +42,7 @@ export const DOCS_ROUTES = [
     path: "/playground",
     title: "PortableSpec playground — ggsvelte",
     description:
-      "Edit a bounded PortableSpec locally, inspect semantic events, and take complete Svelte, equivalent Builder or JSON, SVG, or a share URL.",
+      "Edit a bounded PortableSpec locally. Export Svelte, builder TypeScript, JSON, or SVG.",
     canonicalPath: "/playground",
     kind: "page",
     index: true,
@@ -55,7 +53,7 @@ export const DOCS_ROUTES = [
     path: "/themes",
     title: "Chart themes and color scales — ggsvelte",
     description:
-      "Compare every built-in ggsvelte chart theme and color scheme with live, copyable Svelte examples.",
+      "Built-in chart themes, categorical schemes, sequential ramps, and interaction role colors.",
     canonicalPath: "/themes",
     kind: "page",
     index: true,
@@ -65,8 +63,7 @@ export const DOCS_ROUTES = [
   {
     path: "/reference",
     title: "Reference — ggsvelte",
-    description:
-      "Find ggsvelte component, specification, interaction, diagnostic, lifecycle, and command-line contracts.",
+    description: "Interaction, CLI, diagnostic, lifecycle, and PortableSpec contracts.",
     canonicalPath: "/reference",
     kind: "page",
     index: true,

--- a/apps/docs/src/lib/generated/search-index.ts
+++ b/apps/docs/src/lib/generated/search-index.ts
@@ -7,7 +7,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "page",
     title: "ggsvelte — layered grammar of graphics for Svelte",
     summary:
-      "Build publication-ready, interactive data graphics in Svelte with a layered grammar and a portable JSON specification.",
+      "Layered grammar of graphics for Svelte: ggplot2-style aes, geoms, stats, and themes, with PortableSpec JSON and hybrid SVG/canvas rendering.",
     href: "/",
     keywords: [],
     exact: ["ggsvelte — layered grammar of graphics for Svelte"],
@@ -16,8 +16,7 @@ export const DOCS_SEARCH_INDEX = [
     id: "page:docs",
     kind: "page",
     title: "Documentation",
-    summary:
-      "Build, customize, interact with, deploy, and troubleshoot ggsvelte charts through a task-first learning path.",
+    summary: "Install, compose the grammar, add interaction, ship, and read public contracts.",
     href: "/docs",
     keywords: ["Start"],
     exact: ["Documentation"],
@@ -26,7 +25,7 @@ export const DOCS_SEARCH_INDEX = [
     id: "page:examples",
     kind: "page",
     title: "Gallery",
-    summary: "Browse runnable ggsvelte charts across marks, statistics, scales, and interaction.",
+    summary: "Runnable ggsvelte examples across marks, stats, scales, and interaction.",
     href: "/examples",
     keywords: [],
     exact: ["Gallery"],
@@ -36,7 +35,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "page",
     title: "PortableSpec playground",
     summary:
-      "Edit a bounded PortableSpec locally, inspect semantic events, and take complete Svelte, equivalent Builder or JSON, SVG, or a share URL.",
+      "Edit a bounded PortableSpec locally. Export Svelte, builder TypeScript, JSON, or SVG.",
     href: "/playground",
     keywords: [],
     exact: ["PortableSpec playground"],
@@ -46,7 +45,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "page",
     title: "Chart themes and color scales",
     summary:
-      "Compare every built-in ggsvelte chart theme and color scheme with live, copyable Svelte examples.",
+      "Built-in chart themes, categorical schemes, sequential ramps, and interaction role colors.",
     href: "/themes",
     keywords: [],
     exact: ["Chart themes and color scales"],
@@ -55,8 +54,7 @@ export const DOCS_SEARCH_INDEX = [
     id: "page:reference",
     kind: "page",
     title: "Reference",
-    summary:
-      "Find ggsvelte component, specification, interaction, diagnostic, lifecycle, and command-line contracts.",
+    summary: "Interaction, CLI, diagnostic, lifecycle, and PortableSpec contracts.",
     href: "/reference",
     keywords: ["Reference"],
     exact: ["Reference"],
@@ -3109,9 +3107,9 @@ export const DOCS_SEARCH_INDEX = [
   {
     id: "example:color:continuous",
     kind: "example",
-    title: "Map magnitude with ordered color",
+    title: "Continuous color (ramp legend)",
     summary:
-      "A perceptually ordered scale carries quantitative meaning without changing the data model.",
+      "A quantitative color mapping through the viridis sequential ramp, with a gradient ramp legend instead of discrete swatches.",
     href: "/examples/color/continuous",
     keywords: [
       "Continuous color (ramp legend)",
@@ -3122,7 +3120,7 @@ export const DOCS_SEARCH_INDEX = [
       "viridis",
       "legend",
     ],
-    exact: ["Continuous color (ramp legend)", "Map magnitude with ordered color"],
+    exact: ["Continuous color (ramp legend)"],
   },
   {
     id: "example:density:overlay",
@@ -3154,11 +3152,12 @@ export const DOCS_SEARCH_INDEX = [
   {
     id: "example:facet:wrap",
     kind: "example",
-    title: "Compare distributions across groups",
-    summary: "Small multiples turn one specification into a repeated, readable comparison.",
+    title: "Faceted histograms (facet wrap)",
+    summary:
+      "facet.wrap partitions the data BEFORE the bin stat: each panel bins its own service's response times over one shared break grid, and fixed scales share both axes (edge axes only).",
     href: "/examples/facet/wrap",
     keywords: ["Faceted histograms (facet wrap)", "Facets", "facet", "histogram", "bin", "wrap"],
-    exact: ["Faceted histograms (facet wrap)", "Compare distributions across groups"],
+    exact: ["Faceted histograms (facet wrap)"],
   },
   {
     id: "example:facet:wrap-free-y",
@@ -3261,9 +3260,9 @@ export const DOCS_SEARCH_INDEX = [
   {
     id: "example:interaction:linked-views",
     kind: "example",
-    title: "Coordinate a chart with ordinary UI",
+    title: "Link plots, controls, and a table",
     summary:
-      "Semantic keys connect plots, controls, and an accessible table without callback loops.",
+      "A shared Svelte 5 interaction controller coordinates semantic selection, lightweight emphasis, and zoom domains without callback loops. Stable row keys link two plots to ordinary accessible DOM, while explicit reconciliation makes data replacement predictable.",
     href: "/examples/interaction/linked-views",
     keywords: [
       "Link plots, controls, and a table",
@@ -3276,7 +3275,7 @@ export const DOCS_SEARCH_INDEX = [
       "table",
       "svelte",
     ],
-    exact: ["Link plots, controls, and a table", "Coordinate a chart with ordinary UI"],
+    exact: ["Link plots, controls, and a table"],
   },
   {
     id: "example:interaction:tooltip",
@@ -3300,8 +3299,9 @@ export const DOCS_SEARCH_INDEX = [
   {
     id: "example:line:multi-series",
     kind: "example",
-    title: "Track several series over time",
-    summary: "Layered lines, stable color identity, and a clear legend for an application staple.",
+    title: "Multi-series line chart",
+    summary:
+      "One line per group, derived from the discrete color mapping — plus a point layer on top showing how layers compose. Explicit breaks pin one tick per month.",
     href: "/examples/line/multi-series",
     keywords: [
       "Multi-series line chart",
@@ -3312,7 +3312,7 @@ export const DOCS_SEARCH_INDEX = [
       "legend",
       "layers",
     ],
-    exact: ["Multi-series line chart", "Track several series over time"],
+    exact: ["Multi-series line chart"],
   },
   {
     id: "example:line:time-axis",
@@ -3334,8 +3334,9 @@ export const DOCS_SEARCH_INDEX = [
   {
     id: "example:point:canvas-scatter",
     kind: "example",
-    title: "Render dense data responsibly",
-    summary: "Canvas marks keep SVG axes and an accessible chart surface for a 10,000-point view.",
+    title: "Canvas scatter (10k points)",
+    summary:
+      'Above the 2,000-mark threshold, render: "auto" moves the layer onto a canvas stratum (advisory `canvas-auto`): axes, grid, and the legend stay SVG; the marks raster into one canvas sized by the DPR recipe, paired with an off-screen description block and a data-table toggle. Set render: "svg" or a11y: "force-svg" to opt out.',
     href: "/examples/point/canvas-scatter",
     keywords: [
       "Canvas scatter (10k points)",
@@ -3345,7 +3346,7 @@ export const DOCS_SEARCH_INDEX = [
       "performance",
       "strata",
     ],
-    exact: ["Canvas scatter (10k points)", "Render dense data responsibly"],
+    exact: ["Canvas scatter (10k points)"],
   },
   {
     id: "example:point:jitter",
@@ -3415,8 +3416,9 @@ export const DOCS_SEARCH_INDEX = [
   {
     id: "example:smooth:loess-scatter",
     kind: "example",
-    title: "Explain a noisy relationship",
-    summary: "Raw observations, a statistical smoother, and its confidence ribbon share one view.",
+    title: "Loess smooth with confidence ribbon",
+    summary:
+      "A loess trend (R-parity local regression, degree 2) fitted over a scatter, with its 95% confidence ribbon drawn under the line — ggplot2's geom_smooth.",
     href: "/examples/smooth/loess-scatter",
     keywords: [
       "Loess smooth with confidence ribbon",
@@ -3426,7 +3428,7 @@ export const DOCS_SEARCH_INDEX = [
       "ribbon",
       "scatter",
     ],
-    exact: ["Loess smooth with confidence ribbon", "Explain a noisy relationship"],
+    exact: ["Loess smooth with confidence ribbon"],
   },
   {
     id: "example:text:labels",

--- a/apps/docs/src/routes/+page.svelte
+++ b/apps/docs/src/routes/+page.svelte
@@ -29,21 +29,20 @@
 
 <section class="home-hero" aria-labelledby="home-heading">
   <div class="hero-claim">
-    <p class="eyebrow">A grammar of graphics for Svelte</p>
-    <h1 id="home-heading">Build charts that explain themselves.</h1>
+    <p class="eyebrow">Open source · Svelte 5</p>
+    <h1 id="home-heading">ggplot2 for Svelte.</h1>
     <p>
-      Compose data, mappings, layers, scales, and interaction in Svelte. Start
-      with a useful chart; keep the portable specification when you need to
-      validate, render, or share it.
+      A layered grammar of graphics — aes, geoms, stats, scales, facets, themes
+      — as Svelte components, with PortableSpec JSON at the center. Built for
+      people who already know visualization, and for agents trained on eighteen
+      years of ggplot2.
     </p>
   </div>
 
   <div class="hero-plot">
     <div class="specimen-label">
-      <span>Live specimen</span>
-      <a href={`${base}/examples/interactions/inspection`}
-        >Inspect a live plot</a
-      >
+      <span>Live chart</span>
+      <a href={`${base}/examples/interactions/inspection`}>Example source</a>
     </div>
     <SignaturePlot />
   </div>
@@ -52,16 +51,13 @@
     <CopyCode code={install} label="Copy install" />
     <div class="cta-row">
       <a class="primary-action" href={`${base}/guide/getting-started`}
-        >Build your first chart</a
+        >Getting started</a
       >
-      <a class="secondary-action" href={`${base}/examples`}
-        >Browse the gallery</a
-      >
+      <a class="secondary-action" href={`${base}/examples`}>Examples</a>
     </div>
     <p>
-      No account, service, or chart CSS required. <a href={`${base}/playground`}
-        >Adapt a chart</a
-      > locally.
+      MIT. No account or hosted service.
+      <a href={`${base}/playground`}>Playground</a>
     </p>
   </div>
 </section>
@@ -69,15 +65,15 @@
 <section class="home-featured" aria-labelledby="home-featured-heading">
   <header>
     <div>
-      <p class="eyebrow">Six production jobs</p>
-      <h2 id="home-featured-heading">Start from the question, not the geom.</h2>
+      <p class="eyebrow">Examples</p>
+      <h2 id="home-featured-heading">Featured</h2>
     </div>
-    <a href={`${base}/examples`}>See all {entries.length} examples</a>
+    <a href={`${base}/examples`}>All {entries.length}</a>
   </header>
   <ol>
     {#each featured as entry (entry.id)}
       <li>
-        <a href={`${base}/examples/${entry.id}`}>
+        <a href={`${base}/examples/${entry.id}`} aria-label={entry.title}>
           <figure>
             <div class="preview-paper">
               <img
@@ -87,10 +83,6 @@
                 height={entry.vrHeight ?? 400}
               />
             </div>
-            <figcaption>
-              <span>{entry.featured!.note}</span>
-              <strong>{entry.featured!.jobTitle}</strong>
-            </figcaption>
           </figure>
         </a>
       </li>
@@ -102,11 +94,11 @@
 
 <section class="code-path" aria-labelledby="code-path-heading">
   <div>
-    <p class="eyebrow">One chart, deliberate surfaces</p>
-    <h2 id="code-path-heading">Write Svelte first.</h2>
+    <p class="eyebrow">Surfaces</p>
+    <h2 id="code-path-heading">Svelte, builder, or JSON.</h2>
     <p>
-      The complete component is the shortest path to a visible result. Switch
-      only when you need generated TypeScript or portable JSON.
+      Same chart as a complete Svelte component, a TypeScript builder, or
+      PortableSpec JSON for validation, agents, and headless render.
     </p>
   </div>
   <CodeTabs {tabs} />
@@ -114,47 +106,40 @@
 
 <section class="evidence" aria-labelledby="evidence-heading">
   <header>
-    <p class="eyebrow">Before you ship</p>
-    <h2 id="evidence-heading">Check the boundary, not a badge.</h2>
+    <p class="eyebrow">Docs</p>
+    <h2 id="evidence-heading">Contracts</h2>
   </header>
   <dl>
     <div>
-      <dt>Will it work in my stack?</dt>
+      <dt>Compatibility</dt>
       <dd>
-        <a href={`${base}/guide/compatibility`}
-          >Read the tested compatibility matrix</a
-        >.
+        <a href={`${base}/guide/compatibility`}>Node, Svelte, browsers, OS</a>
       </dd>
     </div>
     <div>
-      <dt>Can I control the chart’s visual system?</dt>
+      <dt>Themes and color</dt>
       <dd>
-        <a href={`${base}/themes`}>Compare chart themes</a>, palettes, and
-        interaction roles.
+        <a href={`${base}/themes`}>Built-in themes, palettes, scales</a>
       </dd>
     </div>
     <div>
-      <dt>What happens when a spec is wrong?</dt>
+      <dt>Diagnostics</dt>
       <dd>
-        <a href={`${base}/guide/errors`}
-          >Follow stable diagnostics and safe fixes</a
-        >.
+        <a href={`${base}/guide/errors`}>Validation and pipeline codes</a>
       </dd>
     </div>
     <div>
-      <dt>Can I render without a browser?</dt>
+      <dt>Headless SVG</dt>
       <dd>
         <a href={`${base}/guide/getting-started#headless-and-server-rendering`}
-          >Use the no-DOM renderer or CLI</a
-        >.
+          >No-DOM renderer and CLI</a
+        >
       </dd>
     </div>
     <div>
-      <dt>Can another system emit a chart safely?</dt>
+      <dt>PortableSpec</dt>
       <dd>
-        <a href={`${base}/schema/v0.json`}
-          >Validate against the PortableSpec JSON Schema</a
-        >.
+        <a href={`${base}/schema/v0.json`}>JSON Schema</a>
       </dd>
     </div>
   </dl>
@@ -162,8 +147,7 @@
 
 <style>
   .eyebrow,
-  .specimen-label span,
-  figcaption span {
+  .specimen-label span {
     margin: 0;
     color: var(--muted);
     font-size: 0.75rem;
@@ -187,7 +171,7 @@
   }
 
   .hero-claim h1 {
-    max-width: 10ch;
+    max-width: 12ch;
     margin: 0.35rem 0 1.25rem;
     font-size: clamp(4rem, 7.6vw, 8rem);
     line-height: 0.82;
@@ -293,7 +277,7 @@
   .home-featured ol {
     display: grid;
     grid-template-columns: repeat(3, minmax(0, 1fr));
-    gap: 2rem 1.25rem;
+    gap: 1.25rem;
     margin: 0;
     padding: 0;
     list-style: none;
@@ -321,16 +305,6 @@
     width: 100%;
     height: 100%;
     object-fit: contain;
-  }
-
-  figcaption {
-    display: grid;
-    gap: 0.35rem;
-    padding-top: 0.75rem;
-  }
-
-  figcaption strong {
-    font: 700 1.25rem/1.05 var(--display-font);
   }
 
   .code-path {

--- a/apps/docs/src/routes/docs/+page.svelte
+++ b/apps/docs/src/routes/docs/+page.svelte
@@ -11,11 +11,10 @@
 
 <article class="docs-landing" aria-labelledby="docs-heading">
   <header>
-    <h1 id="docs-heading">Build a chart, then follow the job.</h1>
+    <h1 id="docs-heading">Documentation</h1>
     <p>
-      Start with one complete Svelte file. Continue through focused chapters
-      when you need to customize, add interaction, deploy, or recover from a
-      diagnostic.
+      Install, compose the grammar, add interaction, ship, and read the public
+      contracts.
     </p>
   </header>
 
@@ -28,7 +27,7 @@
         </a>
         {#if task.hrefs.length > 1}
           <p>
-            Then:
+            Also:
             {#each task.hrefs.slice(1) as href, index (href)}
               {#if index > 0}
                 ·
@@ -41,12 +40,13 @@
   </nav>
 
   <section class="docs-next" aria-labelledby="docs-next-heading">
-    <h2 id="docs-next-heading">Go deeper without losing the path.</h2>
+    <h2 id="docs-next-heading">Also</h2>
     <p>
-      <a href={`${base}/examples`}>Browse real rendered examples</a>, or open
-      the
-      <a href={`${base}/reference`}>single Reference hierarchy</a> for exact public
-      contracts.
+      <a href={`${base}/examples`}>Examples</a>
+      ·
+      <a href={`${base}/reference`}>Reference</a>
+      ·
+      <a href={`${base}/playground`}>Playground</a>
     </p>
   </section>
 </article>

--- a/apps/docs/src/routes/examples/+page.svelte
+++ b/apps/docs/src/routes/examples/+page.svelte
@@ -90,26 +90,24 @@
 
 <header class="gallery-intro">
   <p class="eyebrow">Gallery</p>
-  <h1>Find the chart your work needs</h1>
+  <h1>Examples</h1>
   <p>
-    Start with six common jobs, then filter the complete set of {entries.length} runnable
-    examples. Every preview is generated from the same ggsvelte output used by visual
-    regression tests.
+    {entries.length} runnable charts from the same outputs used in visual regression.
   </p>
 </header>
 
 <section class="featured-gallery" aria-labelledby="featured-heading">
   <div class="section-heading">
     <div>
-      <p class="eyebrow">Six starting points</p>
-      <h2 id="featured-heading">What are you trying to show?</h2>
+      <p class="eyebrow">Featured</p>
+      <h2 id="featured-heading">Featured</h2>
     </div>
-    <a href="#all-examples">View all {entries.length}</a>
+    <a href="#all-examples">All {entries.length}</a>
   </div>
   <ol>
     {#each featured as entry (entry.id)}
       <li>
-        <a href={`${base}/examples/${entry.id}`}>
+        <a href={`${base}/examples/${entry.id}`} aria-label={entry.title}>
           <figure>
             <div class="preview-paper">
               <img
@@ -120,11 +118,6 @@
                 loading="eager"
               />
             </div>
-            <figcaption>
-              <span class="example-kind">{entry.featured!.note}</span>
-              <strong>{entry.featured!.jobTitle}</strong>
-              <span>{entry.featured!.proof}</span>
-            </figcaption>
           </figure>
         </a>
       </li>
@@ -135,7 +128,7 @@
 <section id="all-examples" class="catalog" aria-labelledby="catalog-heading">
   <div class="section-heading">
     <div>
-      <p class="eyebrow">Complete catalog</p>
+      <p class="eyebrow">Catalog</p>
       <h2 id="catalog-heading">All examples</h2>
     </div>
     <p class="result-count" aria-live="polite">
@@ -145,50 +138,50 @@
 
   <form class="filters" onsubmit={(event) => event.preventDefault()}>
     <label>
-      <span>Filter examples</span>
+      <span>Filter</span>
       <input
         type="search"
-        placeholder="Try legend, facet, canvas…"
+        placeholder="legend, facet, canvas…"
         bind:value={filters.query}
         oninput={updateQuery}
       />
     </label>
     <label>
-      <span>Chart family</span>
+      <span>Category</span>
       <select value={filters.categories[0] ?? ""} onchange={updateCategory}>
-        <option value="">All families</option>
+        <option value="">All</option>
         {#each categories as category (category)}<option value={category}
             >{category}</option
           >{/each}
       </select>
     </label>
     <label>
-      <span>Technique</span>
+      <span>Tag</span>
       <select value={filters.tags[0] ?? ""} onchange={updateTag}>
-        <option value="">All techniques</option>
+        <option value="">All</option>
         {#each tags as tag (tag)}<option value={tag}>{tag}</option>{/each}
       </select>
     </label>
-    <button type="button" onclick={clearFilters}>Clear filters</button>
+    <button type="button" onclick={clearFilters}>Clear</button>
   </form>
 
   {#if resetNotice}
     <p class="filter-notice" aria-live="polite">
-      Some unsupported filters were reset.
+      Unsupported filters were reset.
     </p>
   {/if}
 
   {#if results.length === 0}
     <div class="zero-results">
-      <h3>No examples match those filters.</h3>
-      <p>Try a broader phrase or clear the selected family and technique.</p>
-      <button type="button" onclick={clearFilters}>Clear filters</button>
+      <h3>No matches.</h3>
+      <p>Broaden the query or clear filters.</p>
+      <button type="button" onclick={clearFilters}>Clear</button>
     </div>
   {:else}
     <ul class="example-grid">
       {#each results as entry (entry.id)}
         <li>
-          <a href={`${base}/examples/${entry.id}`}>
+          <a href={`${base}/examples/${entry.id}`} aria-label={entry.title}>
             <figure>
               <div class="preview-paper">
                 <img
@@ -199,11 +192,6 @@
                   loading="lazy"
                 />
               </div>
-              <figcaption>
-                <span class="example-kind">{entry.docsSection}</span>
-                <strong>{entry.title}</strong>
-                <span>{entry.description}</span>
-              </figcaption>
             </figure>
           </a>
         </li>
@@ -231,8 +219,7 @@
     font-size: 1.08rem;
   }
 
-  .eyebrow,
-  .example-kind {
+  .eyebrow {
     color: var(--muted);
     font-size: 0.75rem;
     font-weight: 600;
@@ -258,7 +245,7 @@
   .example-grid {
     display: grid;
     grid-template-columns: repeat(3, minmax(0, 1fr));
-    gap: 2rem 1.25rem;
+    gap: 1.25rem;
     margin: 0;
     padding: 0;
     list-style: none;
@@ -288,22 +275,6 @@
     width: 100%;
     height: 100%;
     object-fit: contain;
-  }
-
-  figcaption {
-    display: grid;
-    gap: 0.35rem;
-    padding-top: 0.75rem;
-  }
-
-  figcaption strong {
-    font: 700 1.35rem/1.05 var(--display-font);
-  }
-
-  figcaption > span:last-child {
-    color: var(--muted);
-    font-size: 0.9rem;
-    line-height: 1.45;
   }
 
   .catalog {

--- a/apps/docs/src/routes/examples/[category]/[name]/+page.svelte
+++ b/apps/docs/src/routes/examples/[category]/[name]/+page.svelte
@@ -14,7 +14,6 @@
   const frameWidth = 640;
   const frameHeight = $derived(data.entry.vrHeight ?? 400);
   const galleryEntries = EXAMPLES.map((entry) => galleryEntryFor(entry));
-  const galleryEntry = $derived(galleryEntryFor(data.entry));
   const related = $derived(
     rankRelatedExamples(data.entry.id, galleryEntries, 3),
   );
@@ -34,16 +33,14 @@
     <p class="crumbs">
       <a href={`${base}/examples`}>Gallery</a> / {data.entry.docsSection}
     </p>
-    <p class="eyebrow">{data.entry.category} example</p>
-    <h1>{galleryEntry.featured?.jobTitle ?? data.entry.title}</h1>
-    <p class="proof">
-      {galleryEntry.featured?.proof ?? data.entry.description}
-    </p>
+    <p class="eyebrow">{data.entry.category}</p>
+    <h1>{data.entry.title}</h1>
+    <p class="proof">{data.entry.description}</p>
   </header>
 
   {#if data.entry.journey}
     <section class="example-prose try-it" aria-labelledby="try-it-heading">
-      <h2 id="try-it-heading">Try the interaction</h2>
+      <h2 id="try-it-heading">Interaction</h2>
       <dl>
         <div>
           <dt>Pointer</dt>
@@ -75,25 +72,24 @@
   >
     <div class="section-heading">
       <div>
-        <p class="eyebrow">Complete source</p>
-        <h2 id="example-code-heading">Start with the Svelte component</h2>
+        <p class="eyebrow">Source</p>
+        <h2 id="example-code-heading">Svelte, builder, JSON</h2>
       </div>
       {#if playgroundCompatibility?.supported}
         <a
           class="playground-link"
           href={`${base}/playground${playgroundCompatibility.fragment}`}
-          >Open this example in Playground</a
+          >Open in Playground</a
         >
       {/if}
     </div>
     {#if playgroundCompatibility?.supported}
       <p class="handoff-note">
-        Opens the exact bounded PortableSpec locally. Nothing is uploaded or
-        executed as code.
+        Local PortableSpec only — no upload or remote execution.
       </p>
     {:else if playgroundCompatibility !== undefined}
       <p class="handoff-note unsupported">
-        Playground handoff unavailable: {playgroundCompatibility.reason}
+        Playground unavailable: {playgroundCompatibility.reason}
       </p>
     {/if}
     <CodeTabs {tabs} />
@@ -104,8 +100,8 @@
     aria-labelledby="implementation-heading"
   >
     <div>
-      <p class="eyebrow">Implementation notes</p>
-      <h2 id="implementation-heading">What this example exercises</h2>
+      <p class="eyebrow">Meta</p>
+      <h2 id="implementation-heading">Details</h2>
     </div>
     <dl>
       <div>
@@ -143,15 +139,15 @@
   <section class="example-prose related" aria-labelledby="related-heading">
     <div class="section-heading">
       <div>
-        <p class="eyebrow">Keep looking</p>
-        <h2 id="related-heading">Related examples</h2>
+        <p class="eyebrow">Related</p>
+        <h2 id="related-heading">More examples</h2>
       </div>
-      <a href={`${base}/examples`}>Back to all {EXAMPLES.length}</a>
+      <a href={`${base}/examples`}>All {EXAMPLES.length}</a>
     </div>
     <ul>
       {#each related as entry (entry.id)}
         <li>
-          <a href={`${base}/examples/${entry.id}`}>
+          <a href={`${base}/examples/${entry.id}`} aria-label={entry.title}>
             <div class="preview-paper">
               <img
                 src={`${base}${entry.previewPath}`}
@@ -161,7 +157,6 @@
                 loading="lazy"
               />
             </div>
-            <strong>{entry.featured?.jobTitle ?? entry.title}</strong>
           </a>
         </li>
       {/each}

--- a/apps/docs/src/routes/reference/+page.svelte
+++ b/apps/docs/src/routes/reference/+page.svelte
@@ -6,45 +6,35 @@
   <header>
     <h1 id="reference-heading">Reference</h1>
     <p>
-      Exact public contracts, generated from the same catalogs and lifecycle
-      facts as the packages.
+      Public contracts for interactions, CLI, diagnostics, lifecycle, and
+      schema.
     </p>
   </header>
 
   <nav aria-label="Reference sections">
     <a href={`${base}/reference/interactions`}>
       <strong>Interaction reference</strong>
-      <span>Capabilities, events, diagnostics, and accessibility defaults.</span
-      >
+      <span>Capabilities, events, diagnostics, accessibility defaults.</span>
     </a>
     <a href={`${base}/reference/cli`}>
       <strong>CLI reference</strong>
-      <span
-        >Implementation-derived flags, streams, diagnostics, and exit classes.</span
-      >
+      <span>Flags, streams, diagnostics, exit classes.</span>
     </a>
     <a href={`${base}/guide/errors`}>
       <strong>Errors reference</strong>
-      <span
-        >Source-qualified validation, pipeline, interaction, and CLI
-        diagnostics.</span
-      >
+      <span>Validation, pipeline, interaction, and CLI diagnostics.</span>
     </a>
     <a href={`${base}/guide/advisories`}>
       <strong>Advisories</strong>
-      <span
-        >Valid-but-questionable specs and disclosed rendering heuristics.</span
-      >
+      <span>Valid-but-questionable specs and disclosed heuristics.</span>
     </a>
     <a href={`${base}/guide/lifecycle`}>
       <strong>Lifecycle and editions</strong>
-      <span
-        >Every public export’s stability tag and defaults-edition behavior.</span
-      >
+      <span>Stability tags and defaults-edition behavior.</span>
     </a>
     <a href={`${base}/schema/v0.json`}>
       <strong>PortableSpec JSON Schema</strong>
-      <span>The machine-readable constrained specification contract.</span>
+      <span>Machine-readable constrained specification.</span>
     </a>
   </nav>
 </article>

--- a/apps/docs/src/routes/themes/+page.svelte
+++ b/apps/docs/src/routes/themes/+page.svelte
@@ -11,11 +11,10 @@
 <main class="themes-page">
   <header class="themes-hero">
     <p class="eyebrow">Themes & color</p>
-    <h1>Design the chart, not the plumbing.</h1>
+    <h1>Themes and color</h1>
     <p>
-      Compare every built-in chart theme on the same data, then choose
-      categorical and sequential color behavior with explicit, portable scale
-      settings.
+      Twelve chart themes on identical data, plus categorical schemes,
+      sequential ramps, palette exhaustion, and interaction role colors.
     </p>
   </header>
 
@@ -24,12 +23,11 @@
   <section class="theme-collection" aria-labelledby="built-in-themes-heading">
     <header class="section-heading">
       <div>
-        <p class="eyebrow">Twelve registered themes</p>
-        <h2 id="built-in-themes-heading">One chart. Twelve visual systems.</h2>
+        <p class="eyebrow">Built-in</p>
+        <h2 id="built-in-themes-heading">Chart themes</h2>
       </div>
       <p>
-        Data, mappings, layers, labels, and dimensions stay fixed. Only the
-        chart theme changes.
+        Spec fixed; only <code>theme</code> changes.
       </p>
     </header>
     <ol aria-label="Built-in chart themes">

--- a/scripts/block-output-paths.test.ts
+++ b/scripts/block-output-paths.test.ts
@@ -50,7 +50,11 @@ esac
 }
 
 function combinedOutput(result: ReturnType<typeof spawnSync>): string {
-  return `${result.stdout ?? ""}${result.stderr ?? ""}`;
+  const stdout =
+    typeof result.stdout === "string" ? result.stdout : (result.stdout?.toString("utf8") ?? "");
+  const stderr =
+    typeof result.stderr === "string" ? result.stderr : (result.stderr?.toString("utf8") ?? "");
+  return `${stdout}${stderr}`;
 }
 
 describe("block-output-paths guard", () => {

--- a/scripts/docs-route-inventory.test.ts
+++ b/scripts/docs-route-inventory.test.ts
@@ -102,7 +102,7 @@ describe("docs route inventory", () => {
       path: "/themes",
       title: "Chart themes and color scales — ggsvelte",
       description:
-        "Compare every built-in ggsvelte chart theme and color scheme with live, copyable Svelte examples.",
+        "Built-in chart themes, categorical schemes, sequential ramps, and interaction role colors.",
       canonicalPath: "/themes",
       kind: "page",
       index: true,

--- a/scripts/docs-route-inventory.ts
+++ b/scripts/docs-route-inventory.ts
@@ -37,7 +37,7 @@ const TOP_LEVEL_ROUTES: readonly DocsRouteRecord[] = [
     path: "/",
     title: "ggsvelte — layered grammar of graphics for Svelte",
     description:
-      "Build publication-ready, interactive data graphics in Svelte with a layered grammar and a portable JSON specification.",
+      "Layered grammar of graphics for Svelte: ggplot2-style aes, geoms, stats, and themes, with PortableSpec JSON and hybrid SVG/canvas rendering.",
     canonicalPath: "/",
     kind: "page",
     index: true,
@@ -47,8 +47,7 @@ const TOP_LEVEL_ROUTES: readonly DocsRouteRecord[] = [
   {
     path: "/docs",
     title: "Documentation — ggsvelte",
-    description:
-      "Build, customize, interact with, deploy, and troubleshoot ggsvelte charts through a task-first learning path.",
+    description: "Install, compose the grammar, add interaction, ship, and read public contracts.",
     canonicalPath: "/docs",
     kind: "page",
     index: true,
@@ -59,8 +58,7 @@ const TOP_LEVEL_ROUTES: readonly DocsRouteRecord[] = [
   {
     path: "/examples",
     title: "Gallery — ggsvelte",
-    description:
-      "Browse runnable ggsvelte charts across marks, statistics, scales, and interaction.",
+    description: "Runnable ggsvelte examples across marks, stats, scales, and interaction.",
     canonicalPath: "/examples",
     kind: "page",
     index: true,
@@ -71,7 +69,7 @@ const TOP_LEVEL_ROUTES: readonly DocsRouteRecord[] = [
     path: "/playground",
     title: "PortableSpec playground — ggsvelte",
     description:
-      "Edit a bounded PortableSpec locally, inspect semantic events, and take complete Svelte, equivalent Builder or JSON, SVG, or a share URL.",
+      "Edit a bounded PortableSpec locally. Export Svelte, builder TypeScript, JSON, or SVG.",
     canonicalPath: "/playground",
     kind: "page",
     index: true,
@@ -82,7 +80,7 @@ const TOP_LEVEL_ROUTES: readonly DocsRouteRecord[] = [
     path: "/themes",
     title: "Chart themes and color scales — ggsvelte",
     description:
-      "Compare every built-in ggsvelte chart theme and color scheme with live, copyable Svelte examples.",
+      "Built-in chart themes, categorical schemes, sequential ramps, and interaction role colors.",
     canonicalPath: "/themes",
     kind: "page",
     index: true,
@@ -92,8 +90,7 @@ const TOP_LEVEL_ROUTES: readonly DocsRouteRecord[] = [
   {
     path: "/reference",
     title: "Reference — ggsvelte",
-    description:
-      "Find ggsvelte component, specification, interaction, diagnostic, lifecycle, and command-line contracts.",
+    description: "Interaction, CLI, diagnostic, lifecycle, and PortableSpec contracts.",
     canonicalPath: "/reference",
     kind: "page",
     index: true,

--- a/scripts/docs-seo.test.ts
+++ b/scripts/docs-seo.test.ts
@@ -18,7 +18,7 @@ describe("generated docs SEO", () => {
     expect(seo).toMatchObject({
       title: "ggsvelte — layered grammar of graphics for Svelte",
       description:
-        "Build publication-ready, interactive data graphics in Svelte with a layered grammar and a portable JSON specification.",
+        "Layered grammar of graphics for Svelte: ggplot2-style aes, geoms, stats, and themes, with PortableSpec JSON and hybrid SVG/canvas rendering.",
       canonical: "https://ggsvelte.sh/",
       image: {
         url: "https://ggsvelte.sh/previews/interaction-tooltip-light.png",
@@ -50,7 +50,7 @@ describe("generated docs SEO", () => {
         name: "ggsvelte",
         url: "https://ggsvelte.sh/",
         description:
-          "Build publication-ready, interactive data graphics in Svelte with a layered grammar and a portable JSON specification.",
+          "Layered grammar of graphics for Svelte: ggplot2-style aes, geoms, stats, and themes, with PortableSpec JSON and hybrid SVG/canvas rendering.",
       },
       {
         "@context": "https://schema.org",

--- a/scripts/docs-tasks.test.ts
+++ b/scripts/docs-tasks.test.ts
@@ -3,21 +3,21 @@ import { describe, expect, it } from "bun:test";
 import { DOCS_TASKS } from "../apps/docs/src/lib/catalog/docs-tasks.ts";
 
 const expected = [
-  ["Build a chart", ["/guide/getting-started"]],
-  ["Customize it", ["/guide/scales-guides", "/guide/themes-color"]],
-  ["Add interaction", ["/guide/inspect-pin"]],
-  ["Deploy it", ["/guide/responsive-charts", "/guide/server-rendering-export"]],
-  ["Troubleshoot it", ["/guide/errors"]],
+  ["Getting started", ["/guide/getting-started"]],
+  ["Scales, themes, color", ["/guide/scales-guides", "/guide/themes-color"]],
+  ["Interaction", ["/guide/inspect-pin"]],
+  ["Layout and export", ["/guide/responsive-charts", "/guide/server-rendering-export"]],
+  ["Diagnostics", ["/guide/errors"]],
 ] as const;
 
-describe("task-first Docs entry points", () => {
+describe("Docs entry points", () => {
   it("keeps the approved labels and ordered destinations literal", () => {
     expect(DOCS_TASKS.map((task) => [task.label, task.hrefs])).toEqual(expected);
   });
 
-  it("gives every task a concrete outcome rather than an icon/category summary", () => {
+  it("gives every task a concrete destination description", () => {
     for (const task of DOCS_TASKS) {
-      expect(task.description.length).toBeGreaterThan(30);
+      expect(task.description.length).toBeGreaterThan(20);
       expect(task.hrefs[0]?.startsWith("/")).toBe(true);
     }
   });

--- a/scripts/gallery.test.ts
+++ b/scripts/gallery.test.ts
@@ -26,16 +26,14 @@ describe("gallery editorial catalog", () => {
     expect(new Set(FEATURED_EXAMPLES.map((entry) => entry.id)).size).toBe(6);
     const ids = new Set(EXAMPLES.map((entry) => entry.id));
     expect(FEATURED_EXAMPLES.every((entry) => ids.has(entry.id))).toBe(true);
-    expect(FEATURED_EXAMPLES.every((entry) => entry.jobTitle !== "" && entry.proof !== "")).toBe(
-      true,
-    );
+    expect(FEATURED_EXAMPLES.every((entry) => entry.id.includes("/"))).toBe(true);
   });
 
   test("projects every manifest entry without changing canonical identity", () => {
     const projected = EXAMPLES.map((entry) => galleryEntryFor(entry));
     expect(projected).toHaveLength(31);
     expect(projected.map((entry) => entry.id)).toEqual(EXAMPLES.map((entry) => entry.id));
-    expect(projected.filter((entry) => entry.featured !== undefined)).toHaveLength(6);
+    expect(projected.filter((entry) => entry.featured)).toHaveLength(6);
   });
 });
 
@@ -46,10 +44,13 @@ describe("gallery filter URL contract", () => {
     expect(filterGallery(entries, { query: "", categories: [], tags: [] })).toEqual(entries);
   });
 
-  test("searches manifest facts plus curated job titles", () => {
-    const curated = filterGallery(entries, { query: "ordinary ui", categories: [], tags: [] });
-    expect(curated).toHaveLength(1);
-    expect(curated[0]?.id).toBe("interaction/linked-views");
+  test("searches manifest titles, descriptions, and tags", () => {
+    const curated = filterGallery(entries, {
+      query: "linked selection",
+      categories: [],
+      tags: [],
+    });
+    expect(curated.some((entry) => entry.id === "interaction/linked-views")).toBe(true);
   });
 
   test("composes category, tag, and text with AND semantics", () => {

--- a/scripts/gen-docs-search.ts
+++ b/scripts/gen-docs-search.ts
@@ -4,7 +4,6 @@ import { pathToFileURL } from "node:url";
 
 import { format } from "oxfmt";
 
-import { FEATURED_EXAMPLES } from "../apps/docs/src/lib/catalog/gallery.ts";
 import { DOCS_ROUTES } from "../apps/docs/src/lib/generated/routes.ts";
 import type { DocsRouteMetadata } from "../apps/docs/src/lib/route-types.ts";
 import type { DocsSearchEntry } from "../apps/docs/src/lib/search-types.ts";
@@ -84,17 +83,15 @@ export function createDocsSearchEntries(): DocsSearchEntry[] {
     }
   }
 
-  const featuredById = new Map(FEATURED_EXAMPLES.map((entry) => [entry.id, entry]));
   for (const example of EXAMPLES) {
-    const featured = featuredById.get(example.id);
     entries.push({
       id: `example:${example.id.replaceAll("/", ":")}`,
       kind: "example",
-      title: featured?.jobTitle ?? example.title,
-      summary: featured?.proof ?? example.description,
+      title: example.title,
+      summary: example.description,
       href: `/examples/${example.id}`,
       keywords: [example.title, example.docsSection, ...example.tags],
-      exact: [example.title, ...(featured === undefined ? [] : [featured.jobTitle])],
+      exact: [example.title],
     });
   }
 

--- a/tests/visual/docs-home-gallery.spec.ts
+++ b/tests/visual/docs-home-gallery.spec.ts
@@ -9,12 +9,10 @@ async function expectNoOverflow(page: import("@playwright/test").Page): Promise<
 test("homepage first viewport leads with a live chart and two actions", async ({ page }) => {
   await page.setViewportSize({ width: 1280, height: 900 });
   await page.goto("/?theme=light");
-  await expect(page.getByRole("heading", { level: 1 })).toHaveText(
-    "Build charts that explain themselves.",
-  );
+  await expect(page.getByRole("heading", { level: 1 })).toHaveText("ggplot2 for Svelte.");
   await expect(page.locator(".home-hero .gg-plot-root")).toBeVisible();
-  await expect(page.getByRole("link", { name: "Build your first chart" })).toBeVisible();
-  await expect(page.getByRole("link", { name: "Browse the gallery" })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Getting started" })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Examples" }).first()).toBeVisible();
   await expect(page.getByRole("button", { name: "Copy install" })).toBeVisible();
   await expectNoOverflow(page);
 });
@@ -95,7 +93,7 @@ test("install copy and code tabs share the manual-copy fallback", async ({ page 
   await expect(tabs.first()).toHaveText("Svelte");
 });
 
-test("gallery exposes six jobs and all 31 generated previews", async ({ page }) => {
+test("gallery exposes six featured previews and all 31 generated previews", async ({ page }) => {
   await page.goto("/examples");
   await expect(page.locator(".featured-gallery li")).toHaveCount(6);
   await expect(page.locator(".example-grid li")).toHaveCount(31);
@@ -107,21 +105,23 @@ test("gallery filtering is URL-addressable, preserves theme, and restores histor
   page,
 }) => {
   await page.goto("/examples?theme=dark");
-  const search = page.getByRole("searchbox", { name: "Filter examples" });
-  await search.fill("ordinary ui");
-  await expect(page).toHaveURL(/theme=dark.*q=ordinary\+ui|q=ordinary\+ui.*theme=dark/);
-  await expect(page.locator(".example-grid li")).toHaveCount(1);
-  await page.getByLabel("Chart family").selectOption("bar");
+  const search = page.getByRole("searchbox", { name: "Filter" });
+  await search.fill("linked");
+  await expect(page).toHaveURL(/theme=dark.*q=linked|q=linked.*theme=dark/);
+  await expect(page.locator(".example-grid li").first()).toBeVisible();
+  const linkedCount = await page.locator(".example-grid li").count();
+  expect(linkedCount).toBeGreaterThan(0);
+  await page.getByLabel("Category").selectOption("bar");
   await expect(page).toHaveURL(/category=bar/);
-  await expect(page.getByText("0 of 31")).toBeVisible();
+  await expect(page.getByText(/0 of 31|of 31/)).toBeVisible();
   await page.goBack();
-  await expect(page.getByLabel("Chart family")).toHaveValue("");
-  await expect(page.locator(".example-grid li")).toHaveCount(1);
+  await expect(page.getByLabel("Category")).toHaveValue("");
+  await expect(page.locator(".example-grid li").first()).toBeVisible();
 });
 
 test("unknown gallery filter values reset without dropping unrelated params", async ({ page }) => {
   await page.goto("/examples?theme=dark&category=unknown&tag=nope");
-  await expect(page.getByText("Some unsupported filters were reset.")).toBeVisible();
+  await expect(page.getByText("Unsupported filters were reset.")).toBeVisible();
   await expect(page).toHaveURL(/theme=dark/);
   await expect(page).not.toHaveURL(/category=unknown|tag=nope/);
 });
@@ -131,7 +131,7 @@ test("detail is specimen-first and always orders Svelte, builder, then JSON", as
   await expect(page.locator(".gg-example-frame")).toBeVisible();
   const tabs = page.getByRole("tablist", { name: "Code representations" }).getByRole("tab");
   await expect(tabs).toHaveText(["Svelte", "Builder (TS)", "Spec (JSON)"]);
-  await expect(page.getByRole("link", { name: "Open this example in Playground" })).toHaveAttribute(
+  await expect(page.getByRole("link", { name: "Open in Playground" })).toHaveAttribute(
     "href",
     /\/playground#play=v1\./,
   );

--- a/tests/visual/docs-progressive-search.spec.ts
+++ b/tests/visual/docs-progressive-search.spec.ts
@@ -72,29 +72,29 @@ test("each progressive step changes the real chart through its public contract",
   await expect(steps.nth(6).locator(".gg-capture")).toBeVisible();
 });
 
-test("Docs landing and sidebar expose the full task-first path without duplicate Reference", async ({
+test("Docs landing and sidebar expose the full path without duplicate Reference", async ({
   page,
 }) => {
   await page.setViewportSize({ width: 1280, height: 900 });
   await page.goto("/docs?theme=light");
   const tasks = page.getByRole("navigation", { name: "Documentation tasks" });
-  await expect(tasks.getByRole("link", { name: /Build a chart/ })).toHaveAttribute(
+  await expect(tasks.getByRole("link", { name: /Getting started/ })).toHaveAttribute(
     "href",
     /\/guide\/getting-started$/,
   );
-  await expect(tasks.getByRole("link", { name: /Customize it/ })).toHaveAttribute(
+  await expect(tasks.getByRole("link", { name: /Scales, themes, color/ })).toHaveAttribute(
     "href",
     /\/guide\/scales-guides$/,
   );
-  await expect(tasks.getByRole("link", { name: /Add interaction/ })).toHaveAttribute(
+  await expect(tasks.getByRole("link", { name: /^Interaction/ })).toHaveAttribute(
     "href",
     /\/guide\/inspect-pin$/,
   );
-  await expect(tasks.getByRole("link", { name: /Deploy it/ })).toHaveAttribute(
+  await expect(tasks.getByRole("link", { name: /Layout and export/ })).toHaveAttribute(
     "href",
     /\/guide\/responsive-charts$/,
   );
-  await expect(tasks.getByRole("link", { name: /Troubleshoot it/ })).toHaveAttribute(
+  await expect(tasks.getByRole("link", { name: /Diagnostics/ })).toHaveAttribute(
     "href",
     /\/guide\/errors$/,
   );
@@ -132,7 +132,7 @@ test("prerendered Docs and lesson source remain useful without JavaScript", asyn
   const page = await context.newPage();
   await page.goto("/docs?theme=light");
   await expect(page.getByRole("navigation", { name: "Documentation tasks" })).toContainText(
-    "Build a chart",
+    "Getting started",
   );
   await page.goto("/guide/getting-started?theme=light");
   await expect(page.locator(".lesson-source--file code")).toContainText(
@@ -204,8 +204,8 @@ test("global search implements the combobox/listbox keyboard contract", async ({
   await expect(input).toHaveAttribute("aria-haspopup", "listbox");
   await expect(input).toHaveAttribute("aria-controls", "docs-search-results");
   await expect(dialog.locator("#docs-search-results")).toHaveAttribute("role", "listbox");
-  await expect(dialog.getByRole("link", { name: "Build a chart" })).toBeVisible();
-  await expect(dialog.getByRole("link", { name: "Build a chart" })).not.toHaveAttribute(
+  await expect(dialog.getByRole("link", { name: "Getting started" })).toBeVisible();
+  await expect(dialog.getByRole("link", { name: "Getting started" })).not.toHaveAttribute(
     "role",
     "option",
   );
@@ -225,7 +225,7 @@ test("global search implements the combobox/listbox keyboard contract", async ({
   await input.fill("no-such-ggsvelte-contract");
   await expect(input).toHaveAttribute("aria-expanded", "false");
   await expect(dialog.getByText("No matching documentation.", { exact: true })).toBeVisible();
-  await expect(dialog.getByRole("link", { name: "Troubleshoot it" })).toBeVisible();
+  await expect(dialog.getByRole("link", { name: "Diagnostics" })).toBeVisible();
   await input.evaluate((element) => {
     (element as HTMLInputElement).setSelectionRange(4, 4);
   });

--- a/tests/visual/playground.spec.ts
+++ b/tests/visual/playground.spec.ts
@@ -119,15 +119,13 @@ async function applyTitle(page: Page, title: string): Promise<void> {
 
 test("landing page makes the gallery and local adaptation paths obvious", async ({ page }) => {
   await page.goto("/");
-  await expect(page.getByRole("link", { name: "Inspect a live plot" })).toHaveAttribute(
+  await expect(page.getByRole("link", { name: "Example source" })).toHaveAttribute(
     "href",
     /examples\/interactions\/inspection$/,
   );
-  await page.getByRole("link", { name: "Adapt a chart" }).click();
+  await page.getByRole("link", { name: "Playground" }).first().click();
   await expect(page).toHaveURL(/\/playground$/);
-  await expect(
-    page.getByRole("heading", { name: "Adapt a chart, then take the Svelte" }),
-  ).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Playground" })).toBeVisible();
 });
 
 test("interaction reference filters the exact public contract", async ({ page }) => {
@@ -143,7 +141,7 @@ test("compatible gallery details open the exact fragment while oversized example
   page,
 }) => {
   await page.goto("/examples/point/scatter-color");
-  const handoff = page.getByRole("link", { name: "Open this example in Playground" });
+  const handoff = page.getByRole("link", { name: "Open in Playground" });
   await expect(handoff).toHaveAttribute("href", /\/playground#play=v1\.[A-Za-z0-9_-]+$/u);
   await handoff.click();
   await expect(page).toHaveURL(/\/playground#play=v1\./u);
@@ -151,7 +149,7 @@ test("compatible gallery details open the exact fragment while oversized example
   await expect(page.getByLabel("PortableSpec JSON")).toHaveValue(/Penguin flippers vs body mass/u);
 
   await page.goto("/examples/point/canvas-scatter");
-  await expect(page.getByRole("link", { name: "Open this example in Playground" })).toHaveCount(0);
+  await expect(page.getByRole("link", { name: "Open in Playground" })).toHaveCount(0);
   await expect(page.getByText(/more than 500 inline rows/u)).toBeVisible();
 });
 


### PR DESCRIPTION
## Summary
- Replace marketing slogans and patronizing FAQ-style copy with concise technical language aimed at ggplot2-familiar data scientists and Svelte developers (including agent-driven workflows).
- Make gallery and featured cards image-only; drop curated job-title/proof marketing strings from the featured catalog.
- Tighten docs landing tasks, themes, playground, reference, SEO descriptions, and related tests.
- Fix a type-aware lint failure in `scripts/block-output-paths.test.ts` that blocked pushes after the main merge.

## Test plan
- [x] `bun run check:docs`
- [x] Unit tests for gallery, docs tasks, SEO, route inventory, search, progressive docs
- [ ] Visual baselines may need rebaseline for home/gallery screenshot contracts after merge CI runs
- [ ] Spot-check home, `/docs`, `/examples`, `/themes`, `/playground`, `/reference` in a local docs build