### PR TITLE
fix(docs): keep preview /ggsvelte cleanup off production

### DIFF
--- a/scripts/block-output-paths.test.ts
+++ b/scripts/block-output-paths.test.ts
@@ -1,4 +1,4 @@
-import { spawnSync } from "node:child_process";
+import { spawnSync, type SpawnSyncReturns } from "node:child_process";
 import { chmodSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
@@ -13,7 +13,7 @@ afterEach(() => {
   for (const sandbox of sandboxes.splice(0)) rmSync(sandbox, { recursive: true, force: true });
 });
 
-function runGuard(branch: string, staged: string, hookArg = baseline) {
+function runGuard(branch: string, staged: string, hookArg = baseline): SpawnSyncReturns<string> {
   const sandbox = mkdtempSync(resolve(tmpdir(), "ggsvelte-output-guard-"));
   const bin = resolve(sandbox, "bin");
   sandboxes.push(sandbox);
@@ -49,12 +49,8 @@ esac
   });
 }
 
-function combinedOutput(result: ReturnType<typeof spawnSync>): string {
-  const stdout =
-    typeof result.stdout === "string" ? result.stdout : (result.stdout?.toString("utf8") ?? "");
-  const stderr =
-    typeof result.stderr === "string" ? result.stderr : (result.stderr?.toString("utf8") ?? "");
-  return `${stdout}${stderr}`;
+function combinedOutput(result: SpawnSyncReturns<string>): string {
+  return `${result.stdout ?? ""}${result.stderr ?? ""}`;
 }
 
 describe("block-output-paths guard", () => {

--- a/scripts/deployment-artifact.test.ts
+++ b/scripts/deployment-artifact.test.ts
@@ -7,6 +7,7 @@ import {
   buildDeploymentIdentity,
   deploymentBuildConfig,
   ensureNotFoundNoindex,
+  ensurePreviewCleanupRedirects,
   ensurePreviewNoindexHeader,
   validateDeploymentArtifact,
 } from "./deployment-artifact.ts";
@@ -24,10 +25,16 @@ const REQUIRED_HEADERS = `/*
   Cache-Control: public, max-age=31536000, immutable
 `;
 
-const REQUIRED_REDIRECTS = `/bench https://ljodea.github.io/ggsvelte/bench/ 302
+const PRODUCTION_REDIRECTS = `/bench https://ljodea.github.io/ggsvelte/bench/ 302
 /bench/* https://ljodea.github.io/ggsvelte/bench/:splat 302
 /ggsvelte https://ggsvelte.sh/ 301
 /ggsvelte/* https://ggsvelte.sh/:splat 301
+`;
+
+const PREVIEW_REDIRECTS = `/bench https://ljodea.github.io/ggsvelte/bench/ 302
+/bench/* https://ljodea.github.io/ggsvelte/bench/:splat 302
+/ggsvelte / 301
+/ggsvelte/* /:splat 301
 `;
 
 const SOURCE_COMMIT = "0123456789abcdef0123456789abcdef01234567";
@@ -68,7 +75,7 @@ function makeCompleteArtifact(buildMode: "cloudflare-preview" | "cloudflare-prod
         ? REQUIRED_HEADERS.replace("/*\n", "/*\n  X-Robots-Tag: noindex, nofollow\n")
         : REQUIRED_HEADERS,
     ],
-    ["_redirects", REQUIRED_REDIRECTS],
+    ["_redirects", buildMode === "cloudflare-preview" ? PREVIEW_REDIRECTS : PRODUCTION_REDIRECTS],
     ["robots.txt", "Sitemap: https://ggsvelte.sh/sitemap.xml"],
     ["sitemap.xml", "<loc>https://ggsvelte.sh/</loc>"],
     ["artifact.json", `${JSON.stringify(buildDeploymentIdentity(expectedArtifact(buildMode)))}\n`],
@@ -182,6 +189,55 @@ describe("deployment artifact identity", () => {
     }
   });
 
+  it("rewrites absolute /ggsvelte cleanup redirects to same-origin only for preview", () => {
+    const preview = mkdtempSync(join(tmpdir(), "ggsvelte-preview-redirects-"));
+    const production = mkdtempSync(join(tmpdir(), "ggsvelte-production-redirects-"));
+    try {
+      writeFileSync(join(preview, "_redirects"), PRODUCTION_REDIRECTS);
+      writeFileSync(join(production, "_redirects"), PRODUCTION_REDIRECTS);
+      ensurePreviewCleanupRedirects(preview, "cloudflare-preview");
+      ensurePreviewCleanupRedirects(production, "cloudflare-production");
+      expect(readFileSync(join(preview, "_redirects"), "utf8")).toBe(PREVIEW_REDIRECTS);
+      expect(readFileSync(join(production, "_redirects"), "utf8")).toBe(PRODUCTION_REDIRECTS);
+    } finally {
+      rmSync(preview, { recursive: true, force: true });
+      rmSync(production, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects preview artifacts that send /ggsvelte cleanup traffic to production", () => {
+    const buildDirectory = makeCompleteArtifact("cloudflare-preview");
+    try {
+      writeFileSync(join(buildDirectory, "_redirects"), PRODUCTION_REDIRECTS);
+      const problems = validateDeploymentArtifact(
+        buildDirectory,
+        expectedArtifact("cloudflare-preview"),
+      );
+      expect(problems).toContain(
+        "preview _redirects must not send /ggsvelte cleanup traffic to production",
+      );
+    } finally {
+      rmSync(buildDirectory, { recursive: true, force: true });
+    }
+  });
+
+  it("requires same-origin /ggsvelte cleanup redirects on preview artifacts", () => {
+    const buildDirectory = makeCompleteArtifact("cloudflare-preview");
+    try {
+      writeFileSync(
+        join(buildDirectory, "_redirects"),
+        `/bench https://ljodea.github.io/ggsvelte/bench/ 302
+/bench/* https://ljodea.github.io/ggsvelte/bench/:splat 302
+`,
+      );
+      expect(
+        validateDeploymentArtifact(buildDirectory, expectedArtifact("cloudflare-preview")),
+      ).toContain("_redirects is missing the same-origin /ggsvelte cleanup redirect");
+    } finally {
+      rmSync(buildDirectory, { recursive: true, force: true });
+    }
+  });
+
   it("rejects preview artifacts without a broad noindex header", () => {
     const buildDirectory = makeCompleteArtifact("cloudflare-preview");
     try {
@@ -264,7 +320,7 @@ describe("deployment artifact identity", () => {
     try {
       writeFileSync(
         join(buildDirectory, "_redirects"),
-        `https://ggsvelte.pages.dev/* https://ggsvelte.sh/:splat 301\n${REQUIRED_REDIRECTS}`,
+        `https://ggsvelte.pages.dev/* https://ggsvelte.sh/:splat 301\n${PRODUCTION_REDIRECTS}`,
       );
       expect(
         validateDeploymentArtifact(buildDirectory, expectedArtifact("cloudflare-production")),

--- a/scripts/deployment-artifact.test.ts
+++ b/scripts/deployment-artifact.test.ts
@@ -238,6 +238,24 @@ describe("deployment artifact identity", () => {
     }
   });
 
+  it("requires the exact bare /ggsvelte same-origin cleanup on preview, not only the wildcard", () => {
+    const buildDirectory = makeCompleteArtifact("cloudflare-preview");
+    try {
+      writeFileSync(
+        join(buildDirectory, "_redirects"),
+        `/bench https://ljodea.github.io/ggsvelte/bench/ 302
+/bench/* https://ljodea.github.io/ggsvelte/bench/:splat 302
+/ggsvelte/* /:splat 301
+`,
+      );
+      expect(
+        validateDeploymentArtifact(buildDirectory, expectedArtifact("cloudflare-preview")),
+      ).toContain("_redirects is missing the same-origin /ggsvelte cleanup redirect");
+    } finally {
+      rmSync(buildDirectory, { recursive: true, force: true });
+    }
+  });
+
   it("rejects preview artifacts without a broad noindex header", () => {
     const buildDirectory = makeCompleteArtifact("cloudflare-preview");
     try {

--- a/scripts/deployment-artifact.ts
+++ b/scripts/deployment-artifact.ts
@@ -236,7 +236,10 @@ export function validateDeploymentArtifact(
       ) {
         problems.push("preview _redirects must not send /ggsvelte cleanup traffic to production");
       }
-      if (!redirects.includes("/ggsvelte/* /:splat 301")) {
+      if (
+        !redirects.includes("/ggsvelte / 301") ||
+        !redirects.includes("/ggsvelte/* /:splat 301")
+      ) {
         problems.push("_redirects is missing the same-origin /ggsvelte cleanup redirect");
       }
     }

--- a/scripts/deployment-artifact.ts
+++ b/scripts/deployment-artifact.ts
@@ -116,6 +116,25 @@ export function ensurePreviewNoindexHeader(
   writeFileSync(path, headers.replace("/*\n", "/*\n  X-Robots-Tag: noindex, nofollow\n"));
 }
 
+/**
+ * Production keeps absolute `/ggsvelte` cleanup redirects so cutover smoke sees
+ * canonical `Location: https://ggsvelte.sh/...`. Preview must stay on the
+ * preview origin — rewrite those rules to same-host targets so trusted
+ * previews never force traffic onto production.
+ */
+export function ensurePreviewCleanupRedirects(
+  buildDirectory: string,
+  buildMode: DeploymentBuildMode,
+): void {
+  if (buildMode !== "cloudflare-preview") return;
+  const path = join(buildDirectory, "_redirects");
+  if (!existsSync(path)) return;
+  const redirects = readFileSync(path, "utf8")
+    .replaceAll("/ggsvelte https://ggsvelte.sh/ 301", "/ggsvelte / 301")
+    .replaceAll("/ggsvelte/* https://ggsvelte.sh/:splat 301", "/ggsvelte/* /:splat 301");
+  writeFileSync(path, redirects);
+}
+
 export function validateDeploymentArtifact(
   buildDirectory: string,
   expected: DeploymentExpectation,
@@ -206,8 +225,20 @@ export function validateDeploymentArtifact(
     if (!redirects.includes("/bench/* https://ljodea.github.io/ggsvelte/bench/:splat 302")) {
       problems.push("_redirects is missing the fixed legacy benchmark redirect");
     }
-    if (!redirects.includes("/ggsvelte/* https://ggsvelte.sh/:splat 301")) {
-      problems.push("_redirects is missing the absolute /ggsvelte cleanup redirect");
+    if (expected.buildMode === "cloudflare-production") {
+      if (!redirects.includes("/ggsvelte/* https://ggsvelte.sh/:splat 301")) {
+        problems.push("_redirects is missing the absolute /ggsvelte cleanup redirect");
+      }
+    } else if (expected.buildMode === "cloudflare-preview") {
+      if (
+        redirects.includes("/ggsvelte https://ggsvelte.sh/ 301") ||
+        redirects.includes("/ggsvelte/* https://ggsvelte.sh/:splat 301")
+      ) {
+        problems.push("preview _redirects must not send /ggsvelte cleanup traffic to production");
+      }
+      if (!redirects.includes("/ggsvelte/* /:splat 301")) {
+        problems.push("_redirects is missing the same-origin /ggsvelte cleanup redirect");
+      }
     }
   }
 
@@ -284,6 +315,7 @@ function main(): void {
   };
   ensureNotFoundNoindex(buildDirectory);
   ensurePreviewNoindexHeader(buildDirectory, config.mode);
+  ensurePreviewCleanupRedirects(buildDirectory, config.mode);
   writeFileSync(
     join(buildDirectory, "artifact.json"),
     `${JSON.stringify(buildDeploymentIdentity(expected), null, 2)}\n`,


### PR DESCRIPTION
## Summary

Follow-up for unrebutted post-merge Codex finding on #367:

- Absolute `/ggsvelte/* → https://ggsvelte.sh/:splat` cleanup was required for **both** Cloudflare production and preview artifacts.
- Trusted previews therefore redirected `/ggsvelte/*` to production, which violates the cutover contract that preview hosts must not redirect to production and bypasses the preview noindex boundary for that path.

### Fix

- Gate the absolute cleanup contract on `cloudflare-production` only.
- Rewrite preview `_redirects` to same-origin `/ggsvelte` cleanup via `ensurePreviewCleanupRedirects` (mirrors preview noindex header injection).
- Reject preview artifacts that still send `/ggsvelte` cleanup traffic to production.
- Also fix pre-push type-aware lint on the `#368` block-output-paths harness (`SpawnSyncReturns<string>`).

## Root cause

#367 correctly made production cleanup absolute so cutover smoke sees canonical `Location` headers. Validation and static `_redirects` were shared with preview without a mode split.

## Tests

- `bun test scripts/deployment-artifact.test.ts scripts/deployment-smoke.test.ts scripts/block-output-paths.test.ts`
- Pre-push: package build, svelte-check, type-aware lint, knip, bun tests

## Parent

Addresses unrebutted Codex review on https://github.com/ljodea/ggsvelte/pull/367#discussion_r3620015098