### PR TITLE
fix(ci): stop product-forcing VR on Dependabot CI pin bumps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,9 @@
 # emits per-job flags. Expensive jobs are skipped when their inputs did not
 # change (docs-only, workflow-only, markdown-only, …). The `ci-gate` job is
 # the single required aggregator so skipped jobs do not look like missing
-# checks. Changing this file forces the full surface (see ci_workflow lane).
+# checks. Product force (lockfile / ci-routing) schedules browser+package
+# surfaces; pure CI plumbing (this file's action pins, .github/actions) only
+# runs the cheap security/lint surface — see forceProduct in routing.ts.
 #
 # Content-hash skip (issue #245): when a job is still scheduled, it may
 # early-exit success if a validated success marker / packages-dist cache
@@ -19,7 +21,9 @@
 # JOB_CONTENT_INPUTS + recipe). Success-marker jobs use local composites
 # (.github/actions/ci-content-hash-restore|write); packages-dist keeps its
 # specialized dist-payload path. bypass_content_cache disables short-circuit
-# under force-all / lockfile / ci.yml / ci-routing / .github/actions changes.
+# under force-all / lockfile / ci.yml / ci-routing / .github/actions changes
+# so recipe pin bumps re-execute jobs that *are* scheduled; the next product
+# PR also misses cache because those paths are UNIVERSAL_CONTENT_INPUTS.
 # Invalidate by bumping CONTENT_HASH_SCHEMA, editing a matched input, or
 # setting repo variable CI_DISABLE_CONTENT_HASH=1. GHA cache is ref-scoped
 # (not a cross-PR registry). Exact cache keys only — no restore-keys for

--- a/scripts/ci-routing.test.ts
+++ b/scripts/ci-routing.test.ts
@@ -213,8 +213,9 @@ describe("planJobs", () => {
     );
     expect(plan.checks).toBe(true);
     expect(plan.actions_security).toBe(true);
+    // release-wiring.test.ts asserts composite content-hash protocol wiring.
+    expect(plan.unit).toBe(true);
     // Not a product surface change — content-hash still bypasses on these paths.
-    expect(plan.unit).toBe(false);
     expect(plan.component).toBe(false);
     expect(plan.consumer).toBe(false);
     expect(plan.build).toBe(false);

--- a/scripts/ci-routing.test.ts
+++ b/scripts/ci-routing.test.ts
@@ -207,28 +207,59 @@ describe("planJobs", () => {
     expect(plan.unit).toBe(true);
   });
 
-  test("composite action changes force the full CI surface (no false-green on recipe-only edits)", () => {
+  test("composite action changes stay on CI-plumbing jobs (no VR/component for Dependabot pin bumps)", () => {
     const plan = planJobs(
       classifyChangedPaths([".github/actions/ci-content-hash-restore/action.yml"]),
     );
-    expect(plan.unit).toBe(true);
-    expect(plan.component).toBe(true);
-    expect(plan.consumer).toBe(true);
-    expect(plan.build).toBe(true);
-    expect(plan.bench_smoke).toBe(true);
+    expect(plan.checks).toBe(true);
     expect(plan.actions_security).toBe(true);
-    expect(plan.packages_dist).toBe(true);
+    // Not a product surface change — content-hash still bypasses on these paths.
+    expect(plan.unit).toBe(false);
+    expect(plan.component).toBe(false);
+    expect(plan.consumer).toBe(false);
+    expect(plan.build).toBe(false);
+    expect(plan.bench_smoke).toBe(false);
+    expect(plan.packages_dist).toBe(false);
+    expect(plan.vr).toBe(false);
+    expect(plan.pages).toBe(false);
+    expect(plan.interaction_perf).toBe(false);
   });
 
-  test("ci.yml self-changes force the full CI surface so routing cannot silently shrink", () => {
+  test("ci.yml self-changes run workflow unit + actions-security without browser surfaces", () => {
+    // Dependabot deps-ci groups often touch ci.yml only to bump action SHAs.
+    // Product force is reserved for lockfile / ci-routing; recipe identity is
+    // enforced via bypass_content_cache + UNIVERSAL_CONTENT_INPUTS instead.
     const plan = planJobs(classifyChangedPaths([".github/workflows/ci.yml"]));
+    expect(plan.checks).toBe(true);
     expect(plan.unit).toBe(true);
-    expect(plan.component).toBe(true);
-    expect(plan.consumer).toBe(true);
-    expect(plan.build).toBe(true);
-    expect(plan.bench_smoke).toBe(true);
     expect(plan.actions_security).toBe(true);
-    expect(plan.vr).toBe(true);
+    expect(plan.component).toBe(false);
+    expect(plan.consumer).toBe(false);
+    expect(plan.build).toBe(false);
+    expect(plan.bench_smoke).toBe(false);
+    expect(plan.packages_dist).toBe(false);
+    expect(plan.vr).toBe(false);
+    expect(plan.pages).toBe(false);
+    expect(plan.interaction_perf).toBe(false);
+  });
+
+  test("dependabot-style multi-workflow pin bump does not schedule VR or component", () => {
+    const plan = planJobs(
+      classifyChangedPaths([
+        ".github/workflows/ci.yml",
+        ".github/workflows/vr-compare.yml",
+        ".github/workflows/pages.yml",
+        ".github/actions/ci-content-hash-write/action.yml",
+      ]),
+    );
+    expect(plan.checks).toBe(true);
+    expect(plan.unit).toBe(true);
+    expect(plan.actions_security).toBe(true);
+    expect(plan.vr).toBe(false);
+    expect(plan.pages).toBe(false);
+    expect(plan.component).toBe(false);
+    expect(plan.consumer).toBe(false);
+    expect(plan.packages_dist).toBe(false);
   });
 
   test("ci-routing module self-changes force the full surface", () => {

--- a/scripts/ci-routing/content-hash.ts
+++ b/scripts/ci-routing/content-hash.ts
@@ -9,7 +9,9 @@
  * - Expanding JOB_CONTENT_INPUTS changes the patterns string inside the digest
  *   and invalidates old caches.
  * - `bypass_content_cache` is true under force-all or lockfile / ci.yml /
- *   ci-routing / composite-action changes.
+ *   ci-routing / composite-action changes (recipe identity). Path routing may
+ *   still skip product jobs for pure CI plumbing; bypass only matters when a
+ *   job is scheduled.
  * - Invalidation: bump CONTENT_HASH_SCHEMA, edit a matched input, change
  *   JOB_CONTENT_INPUTS patterns, or set repo variable CI_DISABLE_CONTENT_HASH=1.
  */

--- a/scripts/ci-routing/routing.ts
+++ b/scripts/ci-routing/routing.ts
@@ -7,10 +7,14 @@
  *   tested in-repo and SHA-pinned action surface stays small.
  * - `forceAll` is the safe fallback when git cannot compute a base (missing
  *   event.before, shallow history, etc.).
- * - Changing `.github/workflows/ci.yml` itself forces the full CI surface so a
- *   routing edit cannot land without exercising the jobs it controls.
+ * - Product force (lockfile / ci-routing) schedules browser + package surfaces.
+ *   CI plumbing (`ci.yml` pin bumps, composite actions under `.github/actions`)
+ *   does **not** product-force: Dependabot deps-ci PRs must not drag VR /
+ *   Playwright / packed-consumer. Recipe identity still bypasses content-hash
+ *   caches (see content-hash.ts) so the next product PR re-executes under the
+ *   new workflow/action pins.
  * - The `ci_routing` lane includes `scripts/ci-routing.ts` and
- *   `scripts/ci-routing/**` so module splits still force the full surface.
+ *   `scripts/ci-routing/**` so router edits still force the full surface.
  */
 
 export type ChangeLane =
@@ -112,7 +116,8 @@ export const LANE_PATTERNS: Record<ChangeLane, readonly string[]> = {
   ci_workflow: [".github/workflows/ci.yml"],
   ci_routing: ["scripts/ci-routing.ts", "scripts/ci-routing.test.ts", "scripts/ci-routing/**"],
   // Local composite actions used by ci.yml (content-hash restore/write). A change
-  // here is a CI recipe change and must force the full surface + bypass cache.
+  // here is a CI recipe change: bypass content-hash caches, schedule
+  // actions-security — but do not product-force VR/component/consumer.
   ci_actions: [".github/actions/**"],
   visual: ["tests/visual/**"],
   performance: [
@@ -252,6 +257,12 @@ export type PlanOptions = {
  * - consumer follows consumer harness scripts as well as packages
  * - bench_smoke follows svelte (retained-memory imports inspection)
  * - docs generators (gen-llms / lifecycle.json) sit on the docs lane → pages/vr
+ *
+ * Force tiers (do not collapse these):
+ * - `forceProduct`: lockfile or ci-routing self-change — full package/browser surface.
+ * - CI plumbing (`ci_workflow`, `ci_actions`): actions-security (+ unit via the
+ *   workflows lane when YAML changed). Never alone schedule VR / component /
+ *   consumer / pages. Content-hash bypass still applies (recipe identity).
  */
 export function planJobs(changes: ChangeFlags, options: PlanOptions = {}): JobPlan {
   if (options.forceAll === true) {
@@ -260,15 +271,17 @@ export function planJobs(changes: ChangeFlags, options: PlanOptions = {}): JobPl
     return all;
   }
 
-  const force = changes.lockfile || changes.ci_workflow || changes.ci_routing || changes.ci_actions;
-  const packageSurface = changes.spec || changes.core || changes.svelte || force;
-  const docsSurface = changes.docs || changes.examples || force;
+  // Product-wide force. Intentionally excludes ci.yml / .github/actions so
+  // Dependabot action pin bumps stay on the cheap CI-plumbing surface.
+  const forceProduct = changes.lockfile || changes.ci_routing;
+  const packageSurface = changes.spec || changes.core || changes.svelte || forceProduct;
+  const docsSurface = changes.docs || changes.examples || forceProduct;
   const browserSurface =
-    packageSurface || changes.spikes || changes.visual || changes.performance || force;
+    packageSurface || changes.spikes || changes.visual || changes.performance || forceProduct;
   // knip / type-aware / docs+examples check live on the build job once pre-push
   // parity is dropped from the checks job (to avoid double-running unit/build).
   const staticAnalysisSurface =
-    packageSurface || docsSurface || changes.scripts || changes.evals || force;
+    packageSurface || docsSurface || changes.scripts || changes.evals || forceProduct;
 
   // Shared packages/*/dist artifact for jobs that previously each ran
   // `bun run build`. Unit/bench-smoke stay on the cheaper `bun run check`
@@ -279,7 +292,7 @@ export function planJobs(changes: ChangeFlags, options: PlanOptions = {}): JobPl
     changes.visual ||
     changes.performance ||
     changes.consumer_tools ||
-    force;
+    forceProduct;
 
   return {
     // Cheap format/lint parity — always on so markdown-only PRs still get oxfmt/prettier.
@@ -294,18 +307,21 @@ export function planJobs(changes: ChangeFlags, options: PlanOptions = {}): JobPl
       changes.docs ||
       changes.examples ||
       changes.workflows ||
-      force,
+      forceProduct,
     component: browserSurface,
-    consumer: packageSurface || changes.consumer_tools || force,
+    consumer: packageSurface || changes.consumer_tools || forceProduct,
     build: staticAnalysisSurface,
-    actions_security: changes.workflows || force,
+    // Composite action recipe edits must still lint the actions surface even
+    // when no workflow YAML changed (Dependabot directories for composites).
+    actions_security: changes.workflows || changes.ci_actions || forceProduct,
     // retained-memory imports packages/svelte inspection coordinator.
-    bench_smoke: changes.benchmarks || changes.spec || changes.core || changes.svelte || force,
+    bench_smoke:
+      changes.benchmarks || changes.spec || changes.core || changes.svelte || forceProduct,
     // Informational only; path-gated and independent of the component job.
     interaction_perf: browserSurface,
     packages_dist: packagesDist,
-    vr: packageSurface || docsSurface || changes.visual || force,
-    pages: packageSurface || docsSurface || force,
+    vr: packageSurface || docsSurface || changes.visual || forceProduct,
+    pages: packageSurface || docsSurface || forceProduct,
   };
 }
 

--- a/scripts/ci-routing/routing.ts
+++ b/scripts/ci-routing/routing.ts
@@ -260,9 +260,10 @@ export type PlanOptions = {
  *
  * Force tiers (do not collapse these):
  * - `forceProduct`: lockfile or ci-routing self-change — full package/browser surface.
- * - CI plumbing (`ci_workflow`, `ci_actions`): actions-security (+ unit via the
- *   workflows lane when YAML changed). Never alone schedule VR / component /
- *   consumer / pages. Content-hash bypass still applies (recipe identity).
+ * - CI plumbing (`ci_workflow`, `ci_actions`): checks + unit + actions-security.
+ *   Never alone schedule VR / component / consumer / pages. Content-hash bypass
+ *   still applies (recipe identity). unit covers release-wiring assertions over
+ *   workflow YAML and composite action.yml (content-hash protocol).
  */
 export function planJobs(changes: ChangeFlags, options: PlanOptions = {}): JobPlan {
   if (options.forceAll === true) {
@@ -307,6 +308,9 @@ export function planJobs(changes: ChangeFlags, options: PlanOptions = {}): JobPl
       changes.docs ||
       changes.examples ||
       changes.workflows ||
+      // release-wiring.test.ts reads composite action.yml and asserts the
+      // content-hash protocol; schedule unit when those recipes change.
+      changes.ci_actions ||
       forceProduct,
     component: browserSurface,
     consumer: packageSurface || changes.consumer_tools || forceProduct,


### PR DESCRIPTION
## Summary

Path routing treated **CI plumbing** (`ci.yml` action pin bumps, `.github/actions/**` composites) the same as **product force** (lockfile / router edits). That scheduled VR screenshots, Playwright component shards, packed-consumer, and pages on Dependabot `deps-ci` PRs that only touch workflow/action SHAs — e.g. `actions/checkout` patch bumps that rewrote every workflow file including `ci.yml`.

### Root cause

In `planJobs`, a single `force` flag:

```ts
const force = changes.lockfile || changes.ci_workflow || changes.ci_routing || changes.ci_actions;
```

expanded into package/browser/docs surfaces. Non-`ci.yml` workflow files were already thin (`checks` + `unit` + `actions_security`); touching `ci.yml` or a composite action blew the suite open.

### Fix

Split force tiers:

| Lane | Before | After |
|------|--------|-------|
| `lockfile`, `ci_routing` | full product surface | full product surface (unchanged) |
| `ci_workflow` (ci.yml) | full product surface | CI plumbing only (`checks` + `unit` + `actions_security`) |
| `ci_actions` (composites) | full product surface | `checks` + `actions_security` |
| content-hash bypass | on all of the above | **unchanged** — recipe identity still invalidates markers; next product PR re-runs under new pins via `UNIVERSAL_CONTENT_INPUTS` |

### Evidence (simulated plans)

- Dependabot multi-workflow pin + composite → `checks, unit, actions_security` only; `vr=false`
- lockfile / ci-routing → still full surface + bypass
- docs-only → still pages + vr

## Test plan

- [x] `bun test scripts/ci-routing.test.ts` (53 pass)
- [x] Pre-push suite (tsc, svelte-check, knip, unit, actionlint, zizmor)
- [ ] CI on this PR: full surface expected (touches `scripts/ci-routing/**` — intentional product force)
- [ ] After merge, next `deps-ci` Dependabot PR should skip VR Compare heavy job and CI browser shards