### PR TITLE
docs: icon-only copy controls and syntax highlighting

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -15,7 +15,6 @@
     "@ggsvelte/examples": "workspace:*",
     "@ggsvelte/spec": "workspace:*",
     "@ggsvelte/svelte": "workspace:*",
-    "highlight.js": "^11.11.1",
     "phosphor-svelte": "^3.1.0",
     "svelte-highlight": "^7.16.0"
   },

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -14,7 +14,10 @@
     "@ggsvelte/core": "workspace:*",
     "@ggsvelte/examples": "workspace:*",
     "@ggsvelte/spec": "workspace:*",
-    "@ggsvelte/svelte": "workspace:*"
+    "@ggsvelte/svelte": "workspace:*",
+    "highlight.js": "^11.11.1",
+    "phosphor-svelte": "^3.1.0",
+    "svelte-highlight": "^7.16.0"
   },
   "devDependencies": {
     "@sveltejs/adapter-static": "^3.0.10",

--- a/apps/docs/src/app.css
+++ b/apps/docs/src/app.css
@@ -5,6 +5,8 @@
 @import "./styles/tokens.css";
 @import "./styles/base.css";
 @import "./styles/shell.css";
+/* Code blocks are always dark (see --code-paper); atom-one-dark token colors. */
+@import "svelte-highlight/styles/atom-one-dark.css";
 
 .gg-example-frame {
   --bg: #ffffff;

--- a/apps/docs/src/lib/CodeTabs.svelte
+++ b/apps/docs/src/lib/CodeTabs.svelte
@@ -4,11 +4,17 @@
    * spec JSON (what agents emit), fluent-builder TypeScript (spec.ts), and
    * idiomatic Svelte components (Example.svelte) — each with a copy button.
    */
+  import CheckIcon from "phosphor-svelte/lib/CheckIcon";
+  import CopyIcon from "phosphor-svelte/lib/CopyIcon";
+  import Highlight from "svelte-highlight";
+
   import { copyText, MANUAL_COPY_STATUS } from "$lib/clipboard";
+  import { resolveCodeLanguage } from "$lib/code-languages";
 
   interface Tab {
     label: string;
     code: string;
+    language?: string;
   }
 
   const { tabs }: { tabs: Tab[] } = $props();
@@ -19,6 +25,28 @@
   const tabsetId = $props.id();
   const panelId = `${tabsetId}-panel`;
   let copyTimer: ReturnType<typeof setTimeout> | undefined;
+
+  const activeTab = $derived(tabs[active]);
+  const languageModule = $derived(
+    resolveCodeLanguage(
+      activeTab?.language ?? languageFromLabel(activeTab?.label),
+    ),
+  );
+  const copied = $derived(copyStatus === "Copied.");
+
+  function languageFromLabel(label: string | undefined): string {
+    if (label === undefined) return "plaintext";
+    const lower = label.toLowerCase();
+    if (lower.includes("svelte")) return "svelte";
+    if (lower.includes("json") || lower.includes("spec")) return "json";
+    if (
+      lower.includes("ts") ||
+      lower.includes("builder") ||
+      lower.includes("type")
+    )
+      return "typescript";
+    return "plaintext";
+  }
 
   async function copy(): Promise<void> {
     const code = tabs[active]?.code ?? "";
@@ -89,8 +117,17 @@
         </button>
       {/each}
     </div>
-    <button type="button" class="copy" onclick={copy}>
-      {copyStatus === "Copied." ? "Copied" : "Copy"}
+    <button
+      type="button"
+      class="copy"
+      aria-label={copied ? "Copied" : "Copy code"}
+      onclick={copy}
+    >
+      {#if copied}
+        <CheckIcon size={18} weight="bold" aria-hidden="true" />
+      {:else}
+        <CopyIcon size={18} weight="regular" aria-hidden="true" />
+      {/if}
     </button>
     <span class="visually-hidden" role="status">{copyStatus}</span>
   </div>
@@ -105,8 +142,9 @@
       role="region"
       aria-label="Code example"
       tabindex="0"
+      bind:this={codeNode}
     >
-      <pre><code bind:this={codeNode}>{tabs[active]?.code ?? ""}</code></pre>
+      <Highlight code={activeTab?.code ?? ""} language={languageModule} />
     </div>
   </div>
 </div>
@@ -136,7 +174,7 @@
     overflow-x: auto;
   }
 
-  .bar button {
+  .bar button[role="tab"] {
     min-height: 44px;
     flex: 0 0 auto;
     padding: 0.35rem 0.65rem;
@@ -149,14 +187,29 @@
     font: 600 0.82rem/1 var(--body-font);
   }
 
-  .bar button.active {
+  .bar button[role="tab"].active {
     border-bottom-color: var(--accent);
     color: var(--fg);
   }
 
   .bar .copy {
+    display: grid;
+    place-items: center;
+    width: 2.5rem;
+    height: 2.5rem;
+    min-width: 2.5rem;
+    min-height: 2.5rem;
     margin-left: auto;
+    padding: 0;
+    border: 0;
+    border-radius: 2px;
+    background: none;
     color: var(--accent);
+    cursor: pointer;
+  }
+
+  .bar .copy:hover {
+    background: color-mix(in srgb, var(--accent) 12%, transparent);
   }
 
   .scroll-region {
@@ -166,12 +219,22 @@
     color: var(--code-ink);
   }
 
-  pre {
+  .scroll-region :global(pre.hljs),
+  .scroll-region :global(pre) {
     min-width: max-content;
     margin: 0;
     padding: 1rem;
+    background: transparent !important;
+    color: inherit;
+    font-family: var(--code-font);
     font-size: 0.8rem;
     line-height: 1.5;
+  }
+
+  .scroll-region :global(code.hljs),
+  .scroll-region :global(code) {
+    background: transparent !important;
+    font-family: inherit;
   }
 
   @media (max-width: 35rem) {

--- a/apps/docs/src/lib/code-languages.ts
+++ b/apps/docs/src/lib/code-languages.ts
@@ -1,0 +1,37 @@
+/**
+ * Language modules for svelte-highlight, keyed by the fence / prop aliases
+ * used across docs call sites.
+ */
+import type { LanguageType } from "svelte-highlight/languages";
+import bash from "svelte-highlight/languages/bash";
+import css from "svelte-highlight/languages/css";
+import javascript from "svelte-highlight/languages/javascript";
+import json from "svelte-highlight/languages/json";
+import plaintext from "svelte-highlight/languages/plaintext";
+import svelte from "svelte-highlight/languages/svelte";
+import typescript from "svelte-highlight/languages/typescript";
+import xml from "svelte-highlight/languages/xml";
+
+const LANGUAGE_MODULES: Record<string, LanguageType<string>> = {
+  bash,
+  sh: bash,
+  shell: bash,
+  zsh: bash,
+  css,
+  js: javascript,
+  javascript,
+  json,
+  plaintext,
+  text: plaintext,
+  svelte,
+  ts: typescript,
+  typescript,
+  html: xml,
+  xml,
+};
+
+/** Resolve a language name (or empty) to a svelte-highlight language module. */
+export function resolveCodeLanguage(lang: string | undefined): LanguageType<string> {
+  if (lang === undefined || lang.trim() === "") return plaintext;
+  return LANGUAGE_MODULES[lang.trim().toLowerCase()] ?? plaintext;
+}

--- a/apps/docs/src/lib/components/ChartThemeLab.svelte
+++ b/apps/docs/src/lib/components/ChartThemeLab.svelte
@@ -96,7 +96,11 @@
       </GGPlot>
     </div>
     <p class="fragment-label">Svelte fragment</p>
-    <CopyCode {code} label="Copy selected theme code" />
+    <CopyCode
+      {code}
+      language="svelte"
+      accessibleLabel="Copy selected theme code"
+    />
   </div>
 </section>
 

--- a/apps/docs/src/lib/components/ColorFailureDemo.svelte
+++ b/apps/docs/src/lib/components/ColorFailureDemo.svelte
@@ -95,7 +95,11 @@
       {/if}
 
       <p class="fragment-label">Svelte fragment</p>
-      <CopyCode {code} label="Copy exhaustion example" />
+      <CopyCode
+        {code}
+        language="svelte"
+        accessibleLabel="Copy exhaustion example"
+      />
     </article>
   </div>
 </section>

--- a/apps/docs/src/lib/components/CopyCode.svelte
+++ b/apps/docs/src/lib/components/CopyCode.svelte
@@ -1,20 +1,31 @@
 <script lang="ts">
+  import CheckIcon from "phosphor-svelte/lib/CheckIcon";
+  import CopyIcon from "phosphor-svelte/lib/CopyIcon";
+  import Highlight from "svelte-highlight";
+
   import { copyText, MANUAL_COPY_STATUS } from "$lib/clipboard";
+  import { resolveCodeLanguage } from "$lib/code-languages";
 
   const {
     code,
-    label = "Copy",
-    accessibleLabel = label,
+    language = "",
+    /** @deprecated Prefer `accessibleLabel`. Kept as an aria-label alias. */
+    label,
+    accessibleLabel = label ?? "Copy code",
     class: className = "",
   }: {
     code: string;
+    language?: string;
     label?: string;
     accessibleLabel?: string;
     class?: string;
   } = $props();
+
   let source = $state<HTMLElement>();
   let status = $state("");
   let timer: ReturnType<typeof setTimeout> | undefined;
+  const languageModule = $derived(resolveCodeLanguage(language));
+  const copied = $derived(status === "Copied.");
 
   async function copy(): Promise<void> {
     if (timer !== undefined) clearTimeout(timer);
@@ -26,46 +37,77 @@
 </script>
 
 <div class={`copy-code ${className}`}>
-  <button type="button" aria-label={accessibleLabel} onclick={copy}
-    >{status === "Copied." ? "Copied" : label}</button
+  <button
+    type="button"
+    class="copy-trigger"
+    aria-label={copied ? "Copied" : accessibleLabel}
+    onclick={copy}
   >
-  <code bind:this={source}>{code}</code>
+    {#if copied}
+      <CheckIcon size={18} weight="bold" aria-hidden="true" />
+    {:else}
+      <CopyIcon size={18} weight="regular" aria-hidden="true" />
+    {/if}
+  </button>
+  <div class="code-body" bind:this={source}>
+    <Highlight {code} language={languageModule} />
+  </div>
   <span class="visually-hidden" role="status">{status}</span>
 </div>
 
 <style>
   .copy-code {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) auto;
-    align-items: stretch;
+    position: relative;
+    min-width: 0;
     border: 1px solid var(--line);
     border-radius: 2px;
     background: var(--code-paper);
     color: var(--code-ink);
   }
 
-  code {
-    grid-column: 1;
-    grid-row: 1;
-    display: flex;
-    align-items: center;
-    min-width: 0;
-    padding: 0.75rem 1rem;
-    overflow-x: auto;
-    white-space: nowrap;
+  .copy-trigger {
+    position: absolute;
+    z-index: 1;
+    top: 0.45rem;
+    right: 0.45rem;
+    display: grid;
+    place-items: center;
+    width: 2.5rem;
+    height: 2.5rem;
+    min-width: 2.5rem;
+    min-height: 2.5rem;
+    padding: 0;
+    border: 1px solid color-mix(in srgb, var(--code-ink) 28%, transparent);
+    border-radius: 2px;
+    background: color-mix(in srgb, var(--code-paper) 88%, transparent);
+    color: var(--code-ink);
+    cursor: pointer;
   }
 
-  button {
-    grid-column: 2;
-    grid-row: 1;
-    min-width: 5.5rem;
-    min-height: 44px;
-    border: 0;
-    border-left: 1px solid currentColor;
-    border-radius: 0;
-    background: transparent;
+  .copy-trigger:hover {
+    border-color: color-mix(in srgb, var(--code-ink) 55%, transparent);
+    background: color-mix(in srgb, var(--code-paper) 70%, var(--code-ink) 8%);
+  }
+
+  .code-body {
+    min-width: 0;
+    overflow-x: auto;
+  }
+
+  .code-body :global(pre.hljs),
+  .code-body :global(pre) {
+    margin: 0;
+    padding: 0.85rem 3.25rem 0.85rem 1rem;
+    background: transparent !important;
     color: inherit;
-    font: 600 0.82rem/1 var(--body-font);
-    cursor: pointer;
+    font-family: var(--code-font);
+    font-size: 0.85rem;
+    line-height: 1.55;
+  }
+
+  .code-body :global(code.hljs),
+  .code-body :global(code) {
+    background: transparent !important;
+    font-family: inherit;
   }
 </style>

--- a/apps/docs/src/lib/components/CopyCode.svelte
+++ b/apps/docs/src/lib/components/CopyCode.svelte
@@ -58,6 +58,7 @@
 <style>
   .copy-code {
     position: relative;
+    max-width: 100%;
     min-width: 0;
     border: 1px solid var(--line);
     border-radius: 2px;

--- a/apps/docs/src/lib/components/GettingStartedGuide.svelte
+++ b/apps/docs/src/lib/components/GettingStartedGuide.svelte
@@ -77,7 +77,8 @@
   <p class="guide-code-classification">Complete command</p>
   <CopyCode
     class="lesson-source"
-    label="Copy create command"
+    language="bash"
+    accessibleLabel="Copy create command"
     code={`npx sv create my-chart --template minimal --types ts --no-add-ons --install npm\ncd my-chart`}
   />
 
@@ -86,7 +87,8 @@
   <p class="guide-code-classification">Complete command</p>
   <CopyCode
     class="lesson-source"
-    label="Copy install"
+    language="bash"
+    accessibleLabel="Copy install"
     code="npm install @ggsvelte/svelte"
   />
 
@@ -163,7 +165,8 @@
       </div>
       <CopyCode
         class="lesson-source lesson-source--file"
-        label="Copy complete file"
+        language="svelte"
+        accessibleLabel="Copy complete file"
         code={QUICKSTART_PAGE_SVELTE}
       />
     </section>
@@ -187,7 +190,7 @@
         <p class="guide-code-classification">Fragment</p>
         <CopyCode
           class="lesson-source"
-          label="Copy fragment"
+          language="svelte"
           accessibleLabel={`Copy ${step.title} fragment`}
           code={step.fragment}
         />
@@ -229,7 +232,8 @@
   <p class="guide-code-classification">Fragment</p>
   <CopyCode
     class="lesson-source"
-    label="Copy builder fragment"
+    language="typescript"
+    accessibleLabel="Copy builder fragment"
     code={QUICKSTART_BUILDER_FRAGMENT}
   />
   <h3 id="portablespec-json">PortableSpec JSON</h3>
@@ -240,7 +244,8 @@
   <p class="guide-code-classification">Fragment</p>
   <CopyCode
     class="lesson-source"
-    label="Copy PortableSpec fragment"
+    language="json"
+    accessibleLabel="Copy PortableSpec fragment"
     code={QUICKSTART_PORTABLE_SPEC_FRAGMENT}
   />
 
@@ -253,13 +258,15 @@
   <p class="guide-code-classification">Fragment</p>
   <CopyCode
     class="lesson-source"
-    label="Copy headless fragment"
+    language="typescript"
+    accessibleLabel="Copy headless fragment"
     code={QUICKSTART_HEADLESS_FRAGMENT}
   />
   <p class="guide-code-classification">Fragment</p>
   <CopyCode
     class="lesson-source"
-    label="Copy CLI fragment"
+    language="bash"
+    accessibleLabel="Copy CLI fragment"
     code={QUICKSTART_CLI_FRAGMENT}
   />
 
@@ -339,25 +346,12 @@
   }
 
   .getting-started-guide :global(.lesson-source.copy-code) {
-    grid-template-columns: minmax(0, 1fr) auto;
     max-height: 28rem;
     overflow: auto;
   }
 
-  .getting-started-guide :global(.lesson-source code) {
-    align-items: start;
+  .getting-started-guide :global(.lesson-source .code-body pre) {
     white-space: pre;
-  }
-
-  .progressive-step :global(.lesson-source.copy-code) {
-    grid-template-columns: minmax(0, 1fr);
-  }
-
-  .progressive-step :global(.lesson-source.copy-code button) {
-    grid-row: 2;
-    grid-column: 1;
-    border-top: 1px solid currentColor;
-    border-left: 0;
   }
 
   .guide-code-classification {

--- a/apps/docs/src/lib/components/InteractiveThemeSpecimen.svelte
+++ b/apps/docs/src/lib/components/InteractiveThemeSpecimen.svelte
@@ -150,7 +150,11 @@
   <p class="fragment-label">
     Svelte component excerpt · provide your own rows and scope
   </p>
-  <CopyCode {code} label="Copy interaction theme code" />
+  <CopyCode
+    {code}
+    language="svelte"
+    accessibleLabel="Copy interaction theme code"
+  />
 </section>
 
 <style>

--- a/apps/docs/src/lib/components/PaletteSpecimen.svelte
+++ b/apps/docs/src/lib/components/PaletteSpecimen.svelte
@@ -67,7 +67,11 @@
   </div>
 
   <p class="fragment-label">Svelte fragment</p>
-  <CopyCode {code} label={`Copy ${label} palette code`} />
+  <CopyCode
+    {code}
+    language="svelte"
+    accessibleLabel={`Copy ${label} palette code`}
+  />
 </article>
 
 <style>

--- a/apps/docs/src/lib/components/SequentialColorLab.svelte
+++ b/apps/docs/src/lib/components/SequentialColorLab.svelte
@@ -99,7 +99,8 @@
           <p class="fragment-label">Svelte fragment</p>
           <CopyCode
             code={snippet(example)}
-            label={`Copy ${example.label} code`}
+            language="svelte"
+            accessibleLabel={`Copy ${example.label} code`}
           />
         </article>
       </li>

--- a/apps/docs/src/lib/components/ThemeSpecimen.svelte
+++ b/apps/docs/src/lib/components/ThemeSpecimen.svelte
@@ -47,7 +47,11 @@
     </GGPlot>
   </div>
   <p class="fragment-label">Svelte fragment</p>
-  <CopyCode {code} label={`Copy ${label} theme code`} />
+  <CopyCode
+    {code}
+    language="svelte"
+    accessibleLabel={`Copy ${label} theme code`}
+  />
 </article>
 
 <style>

--- a/apps/docs/src/routes/+page.svelte
+++ b/apps/docs/src/routes/+page.svelte
@@ -15,13 +15,15 @@
     entries.find((entry) => entry.id === item.id)!,
   );
   const tabs = [
-    { label: "Svelte", code: QUICKSTART_PAGE_SVELTE },
+    { label: "Svelte", code: QUICKSTART_PAGE_SVELTE, language: "svelte" },
     {
       label: "Builder (TS)",
+      language: "typescript",
       code: `import { aes, gg } from "@ggsvelte/svelte";\n\nconst spec = gg(cars, aes({ x: "weight", y: "economy" }))\n  .geomPoint()\n  .spec();`,
     },
     {
       label: "Spec (JSON)",
+      language: "json",
       code: `{"data":{"values":[{"weight":1.8,"economy":37}]},"layers":[{"geom":"point","aes":{"x":{"field":"weight"},"y":{"field":"economy"}}}]}`,
     },
   ];
@@ -48,7 +50,7 @@
   </div>
 
   <div class="hero-actions">
-    <CopyCode code={install} label="Copy install" />
+    <CopyCode code={install} language="bash" accessibleLabel="Copy install" />
     <div class="cta-row">
       <a class="primary-action" href={`${base}/guide/getting-started`}
         >Getting started</a

--- a/apps/docs/src/routes/examples/[category]/[name]/+page.svelte
+++ b/apps/docs/src/routes/examples/[category]/[name]/+page.svelte
@@ -22,9 +22,13 @@
       ?.compatibility,
   );
   const tabs = $derived([
-    { label: "Svelte", code: data.svelteSource },
-    { label: "Builder (TS)", code: data.specSource },
-    { label: "Spec (JSON)", code: JSON.stringify(data.spec, null, 2) },
+    { label: "Svelte", code: data.svelteSource, language: "svelte" },
+    { label: "Builder (TS)", code: data.specSource, language: "typescript" },
+    {
+      label: "Spec (JSON)",
+      code: JSON.stringify(data.spec, null, 2),
+      language: "json",
+    },
   ]);
 </script>
 

--- a/apps/docs/src/routes/guide/[slug]/+page.svelte
+++ b/apps/docs/src/routes/guide/[slug]/+page.svelte
@@ -5,6 +5,14 @@
 
   const { data }: PageProps = $props();
 
+  /** Phosphor Copy / Check (regular/bold) — must match scripts/llms-markdown.ts. */
+  const COPY_ICON_SVG =
+    '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor" viewBox="0 0 256 256" aria-hidden="true"><path d="M216,32H88a8,8,0,0,0-8,8V80H40a8,8,0,0,0-8,8V216a8,8,0,0,0,8,8H168a8,8,0,0,0,8-8V176h40a8,8,0,0,0,8-8V40A8,8,0,0,0,216,32ZM160,208H48V96H160Zm48-48H176V88a8,8,0,0,0-8-8H96V48H208Z"/></svg>';
+  const CHECK_ICON_SVG =
+    '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor" viewBox="0 0 256 256" aria-hidden="true"><path d="M229.66,77.66l-128,128a8,8,0,0,1-11.32,0l-56-56a8,8,0,0,1,11.32-11.32L96,188.69,218.34,66.34a8,8,0,0,1,11.32,11.32Z"/></svg>';
+
+  const resetTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
   async function copyGuideCode(event: MouseEvent): Promise<void> {
     const target = event.target;
     if (!(target instanceof Element)) return;
@@ -17,13 +25,42 @@
     const status = document.querySelector(`#${CSS.escape(`${codeId}-status`)}`);
     if (code === null || code === undefined || status === null) return;
 
+    const previous = resetTimers.get(codeId);
+    if (previous !== undefined) clearTimeout(previous);
+
     const result = await copyText(code.textContent ?? "", code);
-    status.textContent = result === "copied" ? "Copied." : MANUAL_COPY_STATUS;
+    if (result === "copied") {
+      button.innerHTML = CHECK_ICON_SVG;
+      button.setAttribute("aria-label", "Copied");
+      status.textContent = "Copied.";
+      status.classList.add("visually-hidden");
+      resetTimers.set(
+        codeId,
+        setTimeout(() => {
+          button.innerHTML = COPY_ICON_SVG;
+          button.setAttribute("aria-label", "Copy code");
+          status.textContent = "";
+          resetTimers.delete(codeId);
+        }, 2000),
+      );
+    } else {
+      button.innerHTML = COPY_ICON_SVG;
+      button.setAttribute("aria-label", "Copy code");
+      status.textContent = MANUAL_COPY_STATUS;
+      // Manual fallback needs visible instructions (Codex P2).
+      status.classList.remove("visually-hidden");
+    }
   }
 
   function enhanceCodeCopy(node: HTMLElement): { destroy: () => void } {
     node.addEventListener("click", copyGuideCode);
-    return { destroy: () => node.removeEventListener("click", copyGuideCode) };
+    return {
+      destroy: () => {
+        node.removeEventListener("click", copyGuideCode);
+        for (const timer of resetTimers.values()) clearTimeout(timer);
+        resetTimers.clear();
+      },
+    };
   }
 </script>
 

--- a/apps/docs/src/routes/reference/cli/+page.svelte
+++ b/apps/docs/src/routes/reference/cli/+page.svelte
@@ -24,7 +24,8 @@
   <p class="guide-code-classification">Fragment</p>
   <CopyCode
     class="cli-command"
-    label="Copy command"
+    language="bash"
+    accessibleLabel="Copy command"
     code="ggsvelte-render spec.json > chart.svg 2> diagnostics.jsonl"
   />
   <p>Errors, warnings, and advisories are JSON Lines on stderr.</p>

--- a/apps/docs/src/styles/base.css
+++ b/apps/docs/src/styles/base.css
@@ -270,6 +270,14 @@ pre {
   pointer-events: none;
 }
 
+.guide-code-copy [role="status"]:not(.visually-hidden) {
+  display: block;
+  min-height: 1.4em;
+  margin-top: 0.4rem;
+  color: var(--muted);
+  font-size: 0.82rem;
+}
+
 .prose :is(p, li, h3) code {
   padding: 0.08em 0.28em;
   border-radius: 2px;

--- a/apps/docs/src/styles/base.css
+++ b/apps/docs/src/styles/base.css
@@ -184,6 +184,40 @@ pre {
   background: transparent !important;
 }
 
+/*
+ * atom-one-dark comment/quote greys fail WCAG against --code-paper. Lift them
+ * so axe on example/detail pages (which include CodeTabs) stays clean.
+ */
+.hljs-comment,
+.hljs-quote {
+  color: #a8b0bd !important;
+  font-style: italic;
+}
+
+/* Wide fences scroll locally; never expand the document width. */
+.copy-code,
+.guide-code-copy,
+.code-tabs .scroll-region {
+  max-width: 100%;
+  min-width: 0;
+}
+
+.copy-code .code-body,
+.guide-code-copy pre,
+.code-tabs .scroll-region {
+  max-width: 100%;
+  overflow-x: auto;
+}
+
+.copy-code pre,
+.guide-code-copy pre,
+.code-tabs pre {
+  max-width: 100%;
+  white-space: pre;
+  word-break: normal;
+  overflow-wrap: normal;
+}
+
 .guide-code-classification {
   margin: 1.5rem 0 0.35rem;
   color: var(--muted);

--- a/apps/docs/src/styles/base.css
+++ b/apps/docs/src/styles/base.css
@@ -175,6 +175,15 @@ pre {
   line-height: 1.55;
 }
 
+/* highlight.js / svelte-highlight: keep our dark code surface, keep theme tokens */
+.prose pre code.hljs,
+.prose pre.hljs,
+.copy-code pre.hljs,
+.guide-code-copy pre code.hljs,
+.scroll-region pre.hljs {
+  background: transparent !important;
+}
+
 .guide-code-classification {
   margin: 1.5rem 0 0.35rem;
   color: var(--muted);
@@ -195,30 +204,36 @@ pre {
 
 .guide-code-copy pre {
   margin: 0;
-  padding-top: 3.25rem;
+  padding: 1rem 3.25rem 1rem 1rem;
 }
 
 .guide-code-copy button {
   position: absolute;
   z-index: 1;
-  top: 0.65rem;
-  right: 0.65rem;
-  min-height: 2.75rem;
-  padding: 0.35rem 0.65rem;
-  border: 1px solid currentColor;
+  top: 0.5rem;
+  right: 0.5rem;
+  display: grid;
+  place-items: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  min-width: 2.5rem;
+  min-height: 2.5rem;
+  padding: 0;
+  border: 1px solid color-mix(in srgb, var(--code-ink) 28%, transparent);
   border-radius: 2px;
-  background: var(--code-paper);
+  background: color-mix(in srgb, var(--code-paper) 88%, transparent);
   color: var(--code-ink);
-  font: 600 0.78rem/1 var(--body-font);
   cursor: pointer;
 }
 
-.guide-code-copy [role="status"] {
+.guide-code-copy button:hover {
+  border-color: color-mix(in srgb, var(--code-ink) 55%, transparent);
+  background: color-mix(in srgb, var(--code-paper) 70%, var(--code-ink) 8%);
+}
+
+.guide-code-copy button svg {
   display: block;
-  min-height: 1.4em;
-  margin-top: 0.4rem;
-  color: var(--muted);
-  font-size: 0.82rem;
+  pointer-events: none;
 }
 
 .prose :is(p, li, h3) code {

--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,7 @@
         "@types/node": "^26.1.1",
         "actionlint": "2.0.6",
         "axe-core": "^4.11.1",
+        "highlight.js": "^11.11.1",
         "knip": "6.27.0",
         "markdownlint-cli2": "0.23.1",
         "oxfmt": "0.59.0",
@@ -36,6 +37,9 @@
         "@ggsvelte/examples": "workspace:*",
         "@ggsvelte/spec": "workspace:*",
         "@ggsvelte/svelte": "workspace:*",
+        "highlight.js": "^11.11.1",
+        "phosphor-svelte": "^3.1.0",
+        "svelte-highlight": "^7.16.0",
       },
       "devDependencies": {
         "@sveltejs/adapter-static": "^3.0.10",
@@ -72,9 +76,9 @@
     },
     "packages/core": {
       "name": "@ggsvelte/core",
-      "version": "0.4.0",
+      "version": "0.5.1",
       "dependencies": {
-        "@ggsvelte/spec": "^0.3.1",
+        "@ggsvelte/spec": "^0.5.1",
       },
       "devDependencies": {
         "typescript": "^6.0.3",
@@ -82,7 +86,7 @@
     },
     "packages/spec": {
       "name": "@ggsvelte/spec",
-      "version": "0.4.0",
+      "version": "0.5.1",
       "dependencies": {
         "@js-temporal/polyfill": "^0.5.1",
         "typebox": "^1.3.6",
@@ -94,13 +98,13 @@
     },
     "packages/svelte": {
       "name": "@ggsvelte/svelte",
-      "version": "0.4.0",
+      "version": "0.5.1",
       "bin": {
         "ggsvelte-render": "bin/ggsvelte-render.js",
       },
       "dependencies": {
-        "@ggsvelte/core": "^0.3.1",
-        "@ggsvelte/spec": "^0.3.1",
+        "@ggsvelte/core": "^0.5.1",
+        "@ggsvelte/spec": "^0.5.1",
       },
       "devDependencies": {
         "@sveltejs/package": "^2.5.8",
@@ -823,7 +827,7 @@
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
-    "highlight.js": ["highlight.js@10.7.3", "", {}, "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="],
+    "highlight.js": ["highlight.js@11.11.1", "", {}, "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w=="],
 
     "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
 
@@ -1057,6 +1061,8 @@
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
+    "phosphor-svelte": ["phosphor-svelte@3.1.0", "", { "dependencies": { "estree-walker": "^3.0.3", "magic-string": "^0.30.13" }, "peerDependencies": { "svelte": "^5.0.0 || ^5.0.0-next.96", "vite": ">=5" }, "optionalPeers": ["vite"] }, "sha512-nldtxx+XCgNREvrb7O5xgDsefytXpSkPTx8Rnu3f2qQCUZLDV1rLxYSd2Jcwckuo9lZB1qKMqGR17P4UDC0PrA=="],
+
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
@@ -1158,6 +1164,8 @@
     "svelte": ["svelte@5.56.6", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.10", "@types/estree": "^1.0.5", "@types/trusted-types": "^2.0.7", "acorn": "^8.12.1", "aria-query": "5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "devalue": "^5.8.1", "esm-env": "^1.2.1", "esrap": "^2.2.12", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-p4HDLDogGHKRKCrgckQHNs5PEfXkju6JI5jTywueaKJI5hAdjPohEhRtQ0M1SWC/+TA73SPln+r7srr+7e4nZA=="],
 
     "svelte-check": ["svelte-check@4.7.3", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.25", "@sveltejs/load-config": "^0.2.0", "chokidar": "^4.0.1", "fdir": "^6.2.0", "picocolors": "^1.0.0", "sade": "^1.7.4" }, "peerDependencies": { "svelte": "^4.0.0 || ^5.0.0-next.0", "typescript": ">=5.0.0" }, "bin": { "svelte-check": "bin/svelte-check" } }, "sha512-DHdTCGX62R0fCxBEaT+USdASAnoaRBaaNczkRJl0K7o3WyoCeVUbVxo6fKqpOll/B+WMWCsiFK0eFrJSNBKZIg=="],
+
+    "svelte-highlight": ["svelte-highlight@7.16.0", "", { "dependencies": { "magic-string": "^0.30.17" } }, "sha512-0H7RwC+mvV/aZ7gFsg5bEDtFHsWlirKFlpw7HImjMQTclq3/bWjgtYV2sgMma90DU9H72G3J8n7fTlTUFWk76w=="],
 
     "svelte2tsx": ["svelte2tsx@0.7.57", "", { "dependencies": { "dedent-js": "^1.0.1", "scule": "^1.3.0" }, "peerDependencies": { "svelte": "^3.55 || ^4.0.0-next.0 || ^4.0 || ^5.0.0-next.0", "typescript": "^4.9.4 || ^5.0.0 || ^6.0.0" } }, "sha512-nQo0xEfUpSVjfkxan2UmC6Wl9UZVe9+/pglUiyBNMJ7KDQ9DDooucmXdToBOvzSfgYjj/kMYwf6CTTDz/z048w=="],
 
@@ -1276,6 +1284,8 @@
     "@vitest/browser/ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
     "bun-types/@types/node": ["@types/node@12.20.55", "", {}, "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="],
+
+    "cli-highlight/highlight.js": ["highlight.js@10.7.3", "", {}, "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="],
 
     "katex/commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -37,7 +37,6 @@
         "@ggsvelte/examples": "workspace:*",
         "@ggsvelte/spec": "workspace:*",
         "@ggsvelte/svelte": "workspace:*",
-        "highlight.js": "^11.11.1",
         "phosphor-svelte": "^3.1.0",
         "svelte-highlight": "^7.16.0",
       },

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -58,8 +58,8 @@
       "entry": ["src/routes/**/+*.ts", "src/lib/**/*.ts"],
       "project": ["src/**/*.ts", "*.{js,ts}"],
       // Imported only from .svelte files / the $examples alias, which knip
-      // does not trace.
-      "ignoreDependencies": ["@ggsvelte/examples"],
+      // does not trace. phosphor-svelte is deep-imported only from .svelte.
+      "ignoreDependencies": ["@ggsvelte/examples", "phosphor-svelte"],
     },
   },
 }

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "@types/node": "^26.1.1",
     "actionlint": "2.0.6",
     "axe-core": "^4.11.1",
+    "highlight.js": "^11.11.1",
     "knip": "6.27.0",
     "markdownlint-cli2": "0.23.1",
     "oxfmt": "0.59.0",

--- a/scripts/ci-routing/routing.ts
+++ b/scripts/ci-routing/routing.ts
@@ -67,6 +67,8 @@ export const LANE_PATTERNS: Record<ChangeLane, readonly string[]> = {
     "scripts/gen-llms.ts",
     "scripts/gen-llms.test.ts",
     "scripts/llms-markdown.ts",
+    "scripts/highlight-code.ts",
+    "scripts/highlight-code.test.ts",
     "scripts/llms-guide-content.ts",
     "scripts/docs-seo.ts",
     "scripts/diagnostic-docs.ts",

--- a/scripts/gen-llms.test.ts
+++ b/scripts/gen-llms.test.ts
@@ -52,7 +52,10 @@ describe("renderMarkdown", () => {
     expect(html).toContain('<h1 id="t">T</h1>');
     expect(html).toContain('<p>para with <code>code</code> and <a href="/y">x</a></p>');
     expect(html).toContain("<ul><li>a</li><li>b</li></ul>");
-    expect(html).toContain('<pre><code class="language-ts">const a = 1 &lt; 2;</code></pre>');
+    expect(html).toContain('<pre><code class="hljs language-ts">');
+    expect(html).toContain('hljs-keyword">const</span>');
+    expect(html).toContain('hljs-number">1</span>');
+    expect(html).toContain("&lt;");
   });
 
   it("escapes HTML everywhere", () => {
@@ -68,12 +71,16 @@ describe("renderMarkdown", () => {
     expect(html).toContain('href="https://example.com"');
   });
 
-  it("renders allowlisted copy fences with accessible controls and status", () => {
+  it("renders allowlisted copy fences with accessible icon controls and status", () => {
     const html = renderMarkdown('```json fragment copy\n{"x": 1}\n```');
     expect(html).toContain('<button type="button" data-copy-code="guide-code-1"');
+    expect(html).toContain('aria-label="Copy code"');
     expect(html).toContain('aria-describedby="guide-code-1-status"');
-    expect(html).toContain('<pre id="guide-code-1"><code class="language-json">');
-    expect(html).toContain('<span id="guide-code-1-status" role="status">');
+    expect(html).toContain("<svg");
+    expect(html).not.toContain(">Copy code</button>");
+    expect(html).toContain('<pre id="guide-code-1"><code class="hljs language-json">');
+    expect(html).toContain("hljs-");
+    expect(html).toContain('<span id="guide-code-1-status" role="status" class="visually-hidden">');
     expect(html).toContain('<p class="guide-code-classification">Fragment</p>');
   });
 

--- a/scripts/highlight-code.test.ts
+++ b/scripts/highlight-code.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "bun:test";
+
+import { highlightCodeToHtml, resolveHighlightLanguage } from "./highlight-code.ts";
+
+describe("highlight-code", () => {
+  it("maps fence aliases to registered languages", () => {
+    expect(resolveHighlightLanguage("ts")).toBe("typescript");
+    expect(resolveHighlightLanguage("svelte")).toBe("xml");
+    expect(resolveHighlightLanguage("sh")).toBe("bash");
+    expect(resolveHighlightLanguage("unknown-lang")).toBeUndefined();
+  });
+
+  it("emits highlight.js token spans for known languages", () => {
+    const html = highlightCodeToHtml("const answer = 42;", "ts");
+    expect(html).toContain("hljs-");
+    expect(html).toContain("const");
+    expect(html).not.toContain("<script");
+  });
+
+  it("escapes plaintext for unknown languages", () => {
+    expect(highlightCodeToHtml("<b>x</b>", "not-a-language")).toBe("&lt;b&gt;x&lt;/b&gt;");
+  });
+});

--- a/scripts/highlight-code.ts
+++ b/scripts/highlight-code.ts
@@ -1,0 +1,73 @@
+/**
+ * Shared syntax highlighting for guide markdown (SSR) and unit tests.
+ * Uses highlight.js with a small allowlisted language map; unknown languages
+ * fall back to escaped plaintext so untrusted fences never inject markup.
+ */
+import hljs from "highlight.js/lib/core";
+import bash from "highlight.js/lib/languages/bash";
+import css from "highlight.js/lib/languages/css";
+import javascript from "highlight.js/lib/languages/javascript";
+import json from "highlight.js/lib/languages/json";
+import typescript from "highlight.js/lib/languages/typescript";
+import xml from "highlight.js/lib/languages/xml";
+
+let registered = false;
+
+function ensureRegistered(): void {
+  if (registered) return;
+  hljs.registerLanguage("bash", bash);
+  hljs.registerLanguage("css", css);
+  hljs.registerLanguage("javascript", javascript);
+  hljs.registerLanguage("json", json);
+  hljs.registerLanguage("typescript", typescript);
+  // Svelte/HTML fences: tag-aware highlighting via the XML grammar.
+  hljs.registerLanguage("xml", xml);
+  registered = true;
+}
+
+/** Fence aliases used in guide markdown and docs components. */
+const LANGUAGE_ALIASES: Record<string, string> = {
+  bash: "bash",
+  sh: "bash",
+  shell: "bash",
+  zsh: "bash",
+  css: "css",
+  js: "javascript",
+  javascript: "javascript",
+  json: "json",
+  ts: "typescript",
+  typescript: "typescript",
+  html: "xml",
+  svelte: "xml",
+  xml: "xml",
+};
+
+function escapeHtml(s: string): string {
+  return s
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+/** Resolve a fence language token to a registered highlight.js language id. */
+export function resolveHighlightLanguage(lang: string): string | undefined {
+  const key = lang.trim().toLowerCase();
+  if (key === "") return undefined;
+  return LANGUAGE_ALIASES[key];
+}
+
+/**
+ * Highlight source to HTML token spans (no surrounding pre/code).
+ * Returns escaped plaintext when the language is unknown or highlighting fails.
+ */
+export function highlightCodeToHtml(source: string, lang: string): string {
+  ensureRegistered();
+  const resolved = resolveHighlightLanguage(lang);
+  if (resolved === undefined) return escapeHtml(source);
+  try {
+    return hljs.highlight(source, { language: resolved, ignoreIllegals: true }).value;
+  } catch {
+    return escapeHtml(source);
+  }
+}

--- a/scripts/llms-markdown.ts
+++ b/scripts/llms-markdown.ts
@@ -4,6 +4,7 @@
  * surfaces via gen-llms.
  */
 import { type CodeClassification } from "./guide-code-contract";
+import { highlightCodeToHtml } from "./highlight-code";
 
 // Minimal markdown renderer (headings, paragraphs, fenced code, inline code,
 // links, unordered lists) — enough for the guide sections below, nothing more.
@@ -16,6 +17,10 @@ function escapeHtml(s: string): string {
     .replaceAll(">", "&gt;")
     .replaceAll('"', "&quot;");
 }
+
+/** Phosphor Copy (regular) path — icon-only control for static HTML fences. */
+const COPY_ICON_SVG =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor" viewBox="0 0 256 256" aria-hidden="true"><path d="M216,32H88a8,8,0,0,0-8,8V80H40a8,8,0,0,0-8,8V216a8,8,0,0,0,8,8H168a8,8,0,0,0,8-8V176h40a8,8,0,0,0,8-8V40A8,8,0,0,0,216,32ZM160,208H48V96H160Zm48-48H176V88a8,8,0,0,0-8-8H96V48H208Z"/></svg>';
 
 function inline(s: string, base: string): string {
   let out = escapeHtml(s);
@@ -98,7 +103,8 @@ export function renderMarkdown(md: string, base = ""): string {
     }
   };
   const renderCode = (source: string): string => {
-    const languageClass = codeLang === "" ? "" : ` class="language-${codeLang}"`;
+    const languageClass = codeLang === "" ? ' class="hljs"' : ` class="hljs language-${codeLang}"`;
+    const highlighted = highlightCodeToHtml(source, codeLang);
     const classificationLabel =
       codeClassification === "fragment"
         ? "Fragment"
@@ -108,10 +114,10 @@ export function renderMarkdown(md: string, base = ""): string {
             ? "Complete command"
             : "Complete example";
     const label = `<p class="guide-code-classification">${classificationLabel}</p>`;
-    const rendered = `${label}<pre><code${languageClass}>${escapeHtml(source)}</code></pre>`;
-    if (!codeCopy) return rendered;
+    const pre = `<pre><code${languageClass}>${highlighted}</code></pre>`;
+    if (!codeCopy) return `${label}${pre}`;
     const id = `guide-code-${String(++copyCodeCount)}`;
-    return `${label}<div class="guide-code-copy"><button type="button" data-copy-code="${id}" aria-describedby="${id}-status">Copy code</button><pre id="${id}"><code${languageClass}>${escapeHtml(source)}</code></pre><span id="${id}-status" role="status"></span></div>`;
+    return `${label}<div class="guide-code-copy"><button type="button" data-copy-code="${id}" aria-label="Copy code" aria-describedby="${id}-status">${COPY_ICON_SVG}</button><pre id="${id}"><code${languageClass}>${highlighted}</code></pre><span id="${id}-status" role="status" class="visually-hidden"></span></div>`;
   };
 
   for (const line of lines) {


### PR DESCRIPTION
## Summary

- Replace the blocky "Copy {specific thing}" text buttons on docs code blocks with a single Phosphor copy/check icon (aria-label only).
- Add syntax highlighting for fenced guide markdown (highlight.js at render time) and for Svelte `CopyCode` / `CodeTabs` surfaces (`svelte-highlight` + atom-one-dark on the existing dark `--code-paper` surface).
- Reclaim layout: overlay icon instead of a side column that could eat half a short snippet.

## Test plan

- [x] `bun test scripts/highlight-code.test.ts scripts/gen-llms.test.ts`
- [x] `cd apps/docs && bun run --bun check`
- [x] Pre-push suite (knip, oxlint type-aware, package tests)
- [ ] Visual smoke: home install row, getting-started commands, example CodeTabs, guide error recipes with copy fences
- [ ] Confirm light/dark site themes both keep readable icon contrast on dark code blocks
- [ ] Confirm copy still works and announces via the status region / aria-label swap