### PR TITLE
fix(docs): stabilize playground candidate timing under loaded runners

### DIFF
--- a/apps/docs/src/lib/Playground.svelte
+++ b/apps/docs/src/lib/Playground.svelte
@@ -15,6 +15,14 @@
     PLAYGROUND_SAMPLES,
   } from "$lib/generated/playground-seeds";
   import {
+    acceptCandidatePhase,
+    candidateTransitionAccepted,
+    createCandidateLifecycleTracker,
+    emitPlaygroundCandidatePhase,
+    type PlaygroundCandidateIsolation,
+    type PlaygroundCandidatePhaseDetail,
+  } from "$lib/playground-candidate-lifecycle";
+  import {
     appendPlaygroundEvent,
     type PlaygroundEventEntry,
     type PlaygroundInteractionEvent,
@@ -37,6 +45,7 @@
     stagePlaygroundDraft,
     stagePlaygroundSeed,
     stagePlaygroundUndo,
+    type PlaygroundCandidateOrigin,
     type PlaygroundDiagnostic,
   } from "$lib/playground-state";
   const initialSample = PLAYGROUND_SAMPLES[0]!;
@@ -51,6 +60,50 @@
   let scaleDecisions = $state<RenderModel["scaleDecisions"]>([]);
   let guidePlans = $state<RenderModel["guidePlans"]>([]);
   let events = $state<readonly PlaygroundEventEntry[]>([]);
+  let lifecycleTracker = $state(createCandidateLifecycleTracker());
+
+  function noteCandidatePhase(detail: PlaygroundCandidatePhaseDetail): void {
+    const accepted = acceptCandidatePhase(lifecycleTracker, detail);
+    if (accepted === null) return;
+    lifecycleTracker = accepted.tracker;
+    emitPlaygroundCandidatePhase(accepted.detail);
+  }
+
+  function noteStagedCandidate(
+    previous: { generation: number; origin: PlaygroundCandidateOrigin } | null,
+    next: typeof workbench,
+  ): void {
+    if (
+      previous !== null &&
+      (next.candidate === null ||
+        next.candidate.generation !== previous.generation)
+    ) {
+      noteCandidatePhase({
+        generation: previous.generation,
+        origin: previous.origin,
+        phase: "cancelled",
+        status: next.status,
+      });
+    }
+    if (next.candidate !== null) {
+      noteCandidatePhase({
+        generation: next.candidate.generation,
+        origin: next.candidate.origin,
+        phase: "pending",
+        status: next.status,
+      });
+    }
+  }
+
+  function activeCandidate(): {
+    generation: number;
+    origin: PlaygroundCandidateOrigin;
+  } | null {
+    const candidate = workbench.candidate;
+    return candidate === null
+      ? null
+      : { generation: candidate.generation, origin: candidate.origin };
+  }
 
   const outputs = $derived(playgroundOutputs(workbench.committed));
   const scaleReport = $derived(privacySafeScaleReport());
@@ -88,12 +141,16 @@
     const decoded = decodePlaygroundHash(window.location.hash);
     if (decoded.status === "absent") {
       if (origin === "popstate") {
-        workbench = stagePlaygroundSeed(workbench, initialSeed, origin, null);
+        const previous = activeCandidate();
+        const next = stagePlaygroundSeed(workbench, initialSeed, origin, null);
+        workbench = next;
+        noteStagedCandidate(previous, next);
       }
       return;
     }
     if (decoded.status === "error") {
       replaceLocationHash(workbench.historyHash);
+      const previous = activeCandidate();
       workbench = reportPlaygroundDiagnostic(
         workbench,
         {
@@ -105,14 +162,25 @@
         },
         "The shared link was rejected. The current local chart and a truthful URL were retained.",
       );
+      if (previous !== null) {
+        noteCandidatePhase({
+          generation: previous.generation,
+          origin: previous.origin,
+          phase: "cancelled",
+          status: workbench.status,
+        });
+      }
       return;
     }
-    workbench = stagePlaygroundSeed(
+    const previous = activeCandidate();
+    const next = stagePlaygroundSeed(
       workbench,
       verifiedSharedSeed(window.location.hash, decoded.seed),
       origin,
       window.location.hash,
     );
+    workbench = next;
+    noteStagedCandidate(previous, next);
   }
 
   onMount(() => {
@@ -123,8 +191,17 @@
   });
 
   function editDraft(draft: string): void {
+    const previous = activeCandidate();
     const edited = editPlaygroundDraft(workbench, draft);
     workbench = edited;
+    if (previous !== null && edited.candidate === null) {
+      noteCandidatePhase({
+        generation: previous.generation,
+        origin: previous.origin,
+        phase: "cancelled",
+        status: edited.status,
+      });
+    }
     if (!edited.synchronized) {
       shareUrl = "";
       shareStatus = "";
@@ -132,11 +209,17 @@
   }
 
   function applyDraft(): void {
-    workbench = stagePlaygroundDraft(workbench);
+    const previous = activeCandidate();
+    const next = stagePlaygroundDraft(workbench);
+    workbench = next;
+    noteStagedCandidate(previous, next);
   }
 
   function resetSource(): void {
-    workbench = resetPlaygroundSource(workbench);
+    const previous = activeCandidate();
+    const next = resetPlaygroundSource(workbench);
+    workbench = next;
+    noteStagedCandidate(previous, next);
   }
 
   function undoChart(): void {
@@ -148,7 +231,10 @@
       );
       if (!discard) return;
     }
-    workbench = stagePlaygroundUndo(workbench);
+    const previous = activeCandidate();
+    const next = stagePlaygroundUndo(workbench);
+    workbench = next;
+    noteStagedCandidate(previous, next);
   }
 
   function loadSample(id: string): boolean {
@@ -165,44 +251,79 @@
     }
     const sample = PLAYGROUND_SAMPLES.find((entry) => entry.id === id);
     if (sample === undefined) return false;
-    workbench = stagePlaygroundSeed(workbench, sample.seed, "source");
+    const previous = activeCandidate();
+    const next = stagePlaygroundSeed(workbench, sample.seed, "source");
+    workbench = next;
+    noteStagedCandidate(previous, next);
     return true;
   }
 
-  function candidateRendered(generation: number): void {
-    // Keep the inert candidate mounted briefly so assistive-technology and
-    // browser tests can observe the pending state before atomic promotion.
-    window.setTimeout(() => {
-      const current = workbench;
-      const origin = current.candidate?.origin;
-      const promoted = promotePlaygroundCandidate(current, generation);
-      if (promoted === current) return;
-      workbench = promoted;
-      scaleDecisions = [];
-      guidePlans = [];
-      reportStatus = "";
-      events = [];
-      if (
-        (origin === "apply" ||
-          origin === "source" ||
-          origin === "reset" ||
-          origin === "undo") &&
-        window.location.hash.startsWith("#play=")
-      ) {
-        replaceLocationHash(null);
-      }
-      shareUrl = "";
-      shareStatus = "";
-    }, 300);
+  function candidateReady(
+    generation: number,
+    isolation: PlaygroundCandidateIsolation,
+  ): void {
+    const current = workbench;
+    const candidate = current.candidate;
+    if (candidate?.generation !== generation) return;
+    noteCandidatePhase({
+      generation,
+      origin: candidate.origin,
+      phase: "ready",
+      status: current.status,
+      isolation,
+    });
+    // Microtask boundary: avoid re-entrant Svelte updates from GGPlot onrender.
+    queueMicrotask(() => {
+      promoteAcceptedCandidate(generation);
+    });
+  }
+
+  function promoteAcceptedCandidate(generation: number): void {
+    const current = workbench;
+    const origin = current.candidate?.origin;
+    const promoted = promotePlaygroundCandidate(current, generation);
+    if (!candidateTransitionAccepted(current, promoted)) return;
+    workbench = promoted;
+    noteCandidatePhase({
+      generation,
+      origin: origin ?? "apply",
+      phase: "promoted",
+      status: promoted.status,
+    });
+    scaleDecisions = [];
+    guidePlans = [];
+    reportStatus = "";
+    events = [];
+    if (
+      (origin === "apply" ||
+        origin === "source" ||
+        origin === "reset" ||
+        origin === "undo") &&
+      window.location.hash.startsWith("#play=")
+    ) {
+      replaceLocationHash(null);
+    }
+    shareUrl = "";
+    shareStatus = "";
   }
 
   function reconcileCandidateFailure(
     generation: number,
     diagnostic: PlaygroundDiagnostic,
   ): void {
-    workbench = failPlaygroundCandidate(workbench, generation, diagnostic);
-    if (workbench.navigationRecovery !== null) {
-      replaceLocationHash(workbench.navigationRecovery.replaceHash);
+    const current = workbench;
+    const origin = current.candidate?.origin;
+    const failed = failPlaygroundCandidate(current, generation, diagnostic);
+    if (!candidateTransitionAccepted(current, failed)) return;
+    workbench = failed;
+    noteCandidatePhase({
+      generation,
+      origin: origin ?? "apply",
+      phase: "failed",
+      status: failed.status,
+    });
+    if (failed.navigationRecovery !== null) {
+      replaceLocationHash(failed.navigationRecovery.replaceHash);
     }
   }
 
@@ -221,12 +342,21 @@
     scaleDecisions = [];
     guidePlans = [];
     reportStatus = "";
+    const previous = activeCandidate();
     workbench = reportPlaygroundDiagnostic(
       workbench,
       diagnostic,
       "The current chart stopped safely. Reset the source to recover.",
       false,
     );
+    if (previous !== null) {
+      noteCandidatePhase({
+        generation: previous.generation,
+        origin: previous.origin,
+        phase: "cancelled",
+        status: workbench.status,
+      });
+    }
   }
 
   function privacySafeScaleReport(): string {
@@ -341,7 +471,7 @@
         candidate={workbench.candidate}
         lastValid={workbench.lastValid}
         status={workbench.status}
-        onCandidateRendered={candidateRendered}
+        onCandidateReady={candidateReady}
         onCandidateFailed={reconcileCandidateFailure}
         onActiveRendered={activeRendered}
         onActiveFailed={activeFailed}

--- a/apps/docs/src/lib/components/PlaygroundPreview.svelte
+++ b/apps/docs/src/lib/components/PlaygroundPreview.svelte
@@ -3,6 +3,10 @@
   import { GGPlot } from "@ggsvelte/svelte";
 
   import type { PlaygroundInteractionEvent } from "$lib/playground-events";
+  import {
+    snapshotCandidateIsolation,
+    type PlaygroundCandidateIsolation,
+  } from "$lib/playground-candidate-lifecycle";
   import type {
     PlaygroundCandidate,
     PlaygroundDiagnostic,
@@ -14,7 +18,7 @@
     candidate,
     lastValid,
     status,
-    onCandidateRendered,
+    onCandidateReady,
     onCandidateFailed,
     onActiveRendered,
     onActiveFailed,
@@ -24,7 +28,10 @@
     candidate: PlaygroundCandidate | null;
     lastValid: boolean;
     status: string;
-    onCandidateRendered: (generation: number) => void;
+    onCandidateReady: (
+      generation: number,
+      isolation: PlaygroundCandidateIsolation,
+    ) => void;
     onCandidateFailed: (
       generation: number,
       diagnostic: PlaygroundDiagnostic,
@@ -33,6 +40,35 @@
     onActiveFailed: (diagnostic: PlaygroundDiagnostic) => void;
     onInteraction: (event: PlaygroundInteractionEvent) => void;
   } = $props();
+
+  let activeChartEl = $state<HTMLDivElement | undefined>();
+  let candidateChartEl = $state<HTMLDivElement | undefined>();
+
+  function candidatePainted(generation: number): void {
+    const candidateRoot =
+      candidateChartEl ??
+      (document.querySelector(".candidate-chart") as HTMLElement | null);
+    if (candidateRoot === null) {
+      onCandidateReady(generation, {
+        inert: true,
+        inertAttribute: true,
+        ariaHidden: "true",
+        activeRetained: false,
+        activeTitle: null,
+      });
+      return;
+    }
+    const probe =
+      (
+        window as typeof window & {
+          playgroundRetainedActive?: Element | null;
+        }
+      ).playgroundRetainedActive ?? null;
+    onCandidateReady(
+      generation,
+      snapshotCandidateIsolation(candidateRoot, activeChartEl ?? null, probe),
+    );
+  }
 
   function diagnostic(error: unknown): PlaygroundDiagnostic {
     if (error instanceof PipelineError) {
@@ -68,7 +104,7 @@
 <p class="status" role="status" aria-live="polite">{status}</p>
 
 <div class="chart-stack" aria-busy={candidate !== null}>
-  <div class="active-chart">
+  <div class="active-chart" bind:this={activeChartEl}>
     {#key rendered}
       <svelte:boundary onerror={(error) => onActiveFailed(diagnostic(error))}>
         <GGPlot
@@ -90,7 +126,12 @@
 
   {#if candidate !== null}
     {#key candidate.generation}
-      <div class="candidate-chart" aria-hidden="true" inert>
+      <div
+        class="candidate-chart"
+        aria-hidden="true"
+        inert
+        bind:this={candidateChartEl}
+      >
         <svelte:boundary
           onerror={(error) =>
             onCandidateFailed(candidate.generation, diagnostic(error))}
@@ -98,7 +139,7 @@
           <GGPlot
             spec={candidate.next.rendered}
             width="container"
-            onrender={() => onCandidateRendered(candidate.generation)}
+            onrender={() => candidatePainted(candidate.generation)}
           />
           {#snippet failed()}{/snippet}
         </svelte:boundary>

--- a/apps/docs/src/lib/playground-candidate-lifecycle.ts
+++ b/apps/docs/src/lib/playground-candidate-lifecycle.ts
@@ -1,0 +1,141 @@
+/**
+ * Playground candidate lifecycle phases for deterministic test observation.
+ *
+ * Docs-app only (not a published package API). Tests listen for the
+ * `ggsvelte:playground-candidate` CustomEvent; assistive technology uses
+ * aria-busy / status live region, not this event.
+ */
+import type { PlaygroundCandidateOrigin } from "./playground-state";
+
+export const PLAYGROUND_CANDIDATE_EVENT = "ggsvelte:playground-candidate";
+
+export type PlaygroundCandidatePhase = "pending" | "ready" | "promoted" | "failed" | "cancelled";
+
+export type PlaygroundCandidateTerminalPhase = "promoted" | "failed" | "cancelled";
+
+export interface PlaygroundCandidateIsolation {
+  readonly inert: boolean;
+  readonly inertAttribute: boolean;
+  readonly ariaHidden: string | null;
+  readonly activeRetained: boolean;
+  /** Active chart title at candidate ready — proves last-valid content is still painted. */
+  readonly activeTitle: string | null;
+}
+
+export interface PlaygroundCandidatePhaseDetail {
+  readonly generation: number;
+  readonly origin: PlaygroundCandidateOrigin;
+  readonly phase: PlaygroundCandidatePhase;
+  readonly status: string;
+  readonly isolation?: PlaygroundCandidateIsolation;
+}
+
+/** Tracks which generations have already reached a terminal phase. */
+export interface PlaygroundCandidateLifecycleTracker {
+  readonly terminalByGeneration: ReadonlyMap<number, PlaygroundCandidateTerminalPhase>;
+  readonly readyGenerations: ReadonlySet<number>;
+}
+
+export function createCandidateLifecycleTracker(): PlaygroundCandidateLifecycleTracker {
+  return {
+    terminalByGeneration: new Map(),
+    readyGenerations: new Set(),
+  };
+}
+
+const TERMINAL: ReadonlySet<PlaygroundCandidatePhase> = new Set([
+  "promoted",
+  "failed",
+  "cancelled",
+]);
+
+export function isTerminalPhase(
+  phase: PlaygroundCandidatePhase,
+): phase is PlaygroundCandidateTerminalPhase {
+  return TERMINAL.has(phase);
+}
+
+/**
+ * Decide whether a phase transition is allowed for a generation.
+ * Returns null when the emission must be suppressed (stale / duplicate).
+ */
+export function acceptCandidatePhase(
+  tracker: PlaygroundCandidateLifecycleTracker,
+  detail: PlaygroundCandidatePhaseDetail,
+): {
+  readonly detail: PlaygroundCandidatePhaseDetail;
+  readonly tracker: PlaygroundCandidateLifecycleTracker;
+} | null {
+  if (tracker.terminalByGeneration.has(detail.generation)) return null;
+
+  if (detail.phase === "ready") {
+    if (tracker.readyGenerations.has(detail.generation)) return null;
+    const readyGenerations = new Set([...tracker.readyGenerations, detail.generation]);
+    return {
+      detail,
+      tracker: { ...tracker, readyGenerations },
+    };
+  }
+
+  if (isTerminalPhase(detail.phase)) {
+    const terminalByGeneration = new Map([
+      ...tracker.terminalByGeneration,
+      [detail.generation, detail.phase],
+    ]);
+    return {
+      detail,
+      tracker: { ...tracker, terminalByGeneration },
+    };
+  }
+
+  // pending: allow once per generation unless already past pending (ready or terminal)
+  if (detail.phase === "pending") {
+    if (tracker.readyGenerations.has(detail.generation)) return null;
+    return { detail, tracker };
+  }
+
+  return null;
+}
+
+/**
+ * Whether a promote/fail state transition was accepted by the pure state machine.
+ * Callers must only emit terminal phases when this is true.
+ */
+export function candidateTransitionAccepted<T>(previous: T, next: T): boolean {
+  return previous !== next;
+}
+
+export function emitPlaygroundCandidatePhase(
+  detail: PlaygroundCandidatePhaseDetail,
+  target: EventTarget = globalThis,
+): void {
+  target.dispatchEvent(
+    new CustomEvent(PLAYGROUND_CANDIDATE_EVENT, {
+      detail,
+    }),
+  );
+}
+
+export function snapshotCandidateIsolation(
+  candidateRoot: HTMLElement,
+  activeChartRoot: ParentNode | null,
+  retainedActiveProbe: Element | null = null,
+): PlaygroundCandidateIsolation {
+  const doc = candidateRoot.ownerDocument;
+  const retentionHost =
+    activeChartRoot instanceof Element ? activeChartRoot : doc.querySelector(".active-chart");
+  const titleRoot = retentionHost instanceof Element ? retentionHost : doc;
+  return {
+    inert: candidateRoot.inert,
+    inertAttribute: candidateRoot.hasAttribute("inert"),
+    ariaHidden: candidateRoot.getAttribute("aria-hidden"),
+    // Prefer object-identity probe (survives Svelte attribute reconciliation).
+    // Fall back to the legacy data-attribute marker for callers that set it.
+    activeRetained:
+      (retainedActiveProbe !== null && retentionHost === retainedActiveProbe) ||
+      (retentionHost instanceof Element &&
+        (retentionHost.matches('[data-retained-during-candidate="true"]') ||
+          retentionHost.querySelector('[data-retained-during-candidate="true"]') !== null)),
+    activeTitle: titleRoot.querySelector(".gg-title")?.textContent ?? null,
+  };
+}

--- a/scripts/playground-candidate-lifecycle.test.ts
+++ b/scripts/playground-candidate-lifecycle.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  acceptCandidatePhase,
+  candidateTransitionAccepted,
+  createCandidateLifecycleTracker,
+  emitPlaygroundCandidatePhase,
+  PLAYGROUND_CANDIDATE_EVENT,
+  type PlaygroundCandidatePhaseDetail,
+} from "../apps/docs/src/lib/playground-candidate-lifecycle";
+
+function detail(
+  overrides: Partial<PlaygroundCandidatePhaseDetail> &
+    Pick<PlaygroundCandidatePhaseDetail, "phase">,
+): PlaygroundCandidatePhaseDetail {
+  return {
+    generation: 1,
+    origin: "apply",
+    status: "Checking the next chart before replacing the last valid result.",
+    ...overrides,
+  };
+}
+
+describe("playground candidate lifecycle", () => {
+  test("accepts pending → ready → promoted exactly once per generation", () => {
+    let tracker = createCandidateLifecycleTracker();
+    const pending = acceptCandidatePhase(tracker, detail({ phase: "pending" }));
+    expect(pending).not.toBeNull();
+    tracker = pending!.tracker;
+
+    const ready = acceptCandidatePhase(
+      tracker,
+      detail({
+        phase: "ready",
+        isolation: {
+          inert: true,
+          inertAttribute: true,
+          ariaHidden: "true",
+          activeRetained: true,
+          activeTitle: "Baseline",
+        },
+      }),
+    );
+    expect(ready).not.toBeNull();
+    expect(ready!.detail.isolation?.inert).toBe(true);
+    tracker = ready!.tracker;
+
+    const promoted = acceptCandidatePhase(
+      tracker,
+      detail({ phase: "promoted", status: "Rendered custom draft." }),
+    );
+    expect(promoted).not.toBeNull();
+    tracker = promoted!.tracker;
+
+    expect(acceptCandidatePhase(tracker, detail({ phase: "promoted" }))).toBeNull();
+    expect(acceptCandidatePhase(tracker, detail({ phase: "failed" }))).toBeNull();
+    expect(acceptCandidatePhase(tracker, detail({ phase: "cancelled" }))).toBeNull();
+    expect(acceptCandidatePhase(tracker, detail({ phase: "ready" }))).toBeNull();
+  });
+
+  test("suppresses duplicate ready and allows cancelled when never promoted", () => {
+    let tracker = createCandidateLifecycleTracker();
+    tracker = acceptCandidatePhase(tracker, detail({ phase: "pending" }))!.tracker;
+    tracker = acceptCandidatePhase(tracker, detail({ phase: "ready" }))!.tracker;
+    expect(acceptCandidatePhase(tracker, detail({ phase: "ready" }))).toBeNull();
+
+    const cancelled = acceptCandidatePhase(
+      tracker,
+      detail({ phase: "cancelled", status: "Draft changed." }),
+    );
+    expect(cancelled).not.toBeNull();
+    expect(cancelled!.detail.phase).toBe("cancelled");
+  });
+
+  test("suppresses terminal emission after failed and keeps generations independent", () => {
+    let tracker = createCandidateLifecycleTracker();
+    tracker = acceptCandidatePhase(tracker, detail({ generation: 1, phase: "pending" }))!.tracker;
+    tracker = acceptCandidatePhase(tracker, detail({ generation: 1, phase: "failed" }))!.tracker;
+    expect(acceptCandidatePhase(tracker, detail({ generation: 1, phase: "promoted" }))).toBeNull();
+
+    const next = acceptCandidatePhase(
+      tracker,
+      detail({ generation: 2, origin: "source", phase: "pending" }),
+    );
+    expect(next).not.toBeNull();
+    expect(next!.detail.generation).toBe(2);
+  });
+
+  test("candidateTransitionAccepted mirrors reference-equality used by pure state helpers", () => {
+    const state = { candidate: null };
+    expect(candidateTransitionAccepted(state, state)).toBe(false);
+    expect(candidateTransitionAccepted(state, { candidate: null })).toBe(true);
+  });
+
+  test("emitPlaygroundCandidatePhase dispatches the documented event name with detail", () => {
+    const target = new EventTarget();
+    const seen: PlaygroundCandidatePhaseDetail[] = [];
+    target.addEventListener(PLAYGROUND_CANDIDATE_EVENT, (event) => {
+      seen.push((event as CustomEvent<PlaygroundCandidatePhaseDetail>).detail);
+    });
+    emitPlaygroundCandidatePhase(detail({ phase: "pending" }), target);
+    expect(seen).toEqual([detail({ phase: "pending" })]);
+  });
+});

--- a/tests/visual/playground.spec.ts
+++ b/tests/visual/playground.spec.ts
@@ -5,6 +5,10 @@ import axe from "axe-core";
 
 import type { PortableSpec } from "@ggsvelte/spec";
 
+import {
+  PLAYGROUND_CANDIDATE_EVENT,
+  type PlaygroundCandidatePhaseDetail,
+} from "../../apps/docs/src/lib/playground-candidate-lifecycle";
 import { encodePlaygroundSeed } from "../../apps/docs/src/lib/playground-codec";
 import { settleVisualState } from "./helpers/deterministic";
 
@@ -15,58 +19,50 @@ async function readSpec(page: Page): Promise<Record<string, unknown>> {
   >;
 }
 
-interface CandidateObservation {
-  status: string | null;
-  focusables: number;
-  semanticDescendants: number;
-  inert: boolean;
-  inertAttribute: boolean;
-  hidden: string | null;
-  activeRetained: boolean;
-}
+type CandidatePhaseLog = PlaygroundCandidatePhaseDetail[];
 
-async function observeCandidateTransitions(page: Page): Promise<void> {
-  await page.addInitScript(() => {
+async function installCandidatePhaseLog(page: Page): Promise<void> {
+  await page.addInitScript((eventName) => {
     const observedWindow = window as typeof window & {
-      playgroundCandidateObservations?: CandidateObservation[];
+      playgroundCandidatePhases?: CandidatePhaseLog;
     };
-    const observations: CandidateObservation[] = [];
-    observedWindow.playgroundCandidateObservations = observations;
-    const capture = () => {
-      const node = document.querySelector<HTMLElement>(".candidate-chart");
-      if (node === null) return;
-      observations.push({
-        status: document.querySelector(".preview-surface .status")?.textContent ?? null,
-        focusables: node.querySelectorAll("button, a, input, select, textarea, [tabindex]").length,
-        semanticDescendants: node.querySelectorAll('[role="img"], [role="status"], [aria-live]')
-          .length,
-        inert: node.inert,
-        inertAttribute: node.hasAttribute("inert"),
-        hidden: node.getAttribute("aria-hidden"),
-        activeRetained:
-          document.querySelector('.active-chart > [data-retained-during-candidate="true"]') !==
-          null,
-      });
-    };
-    new MutationObserver(capture).observe(document, {
-      attributes: true,
-      characterData: true,
-      childList: true,
-      subtree: true,
+    const phases: CandidatePhaseLog = [];
+    observedWindow.playgroundCandidatePhases = phases;
+    window.addEventListener(eventName, (event) => {
+      phases.push((event as CustomEvent<PlaygroundCandidatePhaseDetail>).detail);
     });
-    capture();
-  });
+  }, PLAYGROUND_CANDIDATE_EVENT);
 }
 
-function candidateObservations(page: Page): Promise<CandidateObservation[]> {
+function candidatePhaseLog(page: Page): Promise<CandidatePhaseLog> {
   return page.evaluate(
     () =>
       (
         window as typeof window & {
-          playgroundCandidateObservations?: CandidateObservation[];
+          playgroundCandidatePhases?: CandidatePhaseLog;
         }
-      ).playgroundCandidateObservations ?? [],
+      ).playgroundCandidatePhases ?? [],
   );
+}
+
+function phasesForGeneration(log: CandidatePhaseLog, generation: number): CandidatePhaseLog {
+  return log.filter((entry) => entry.generation === generation);
+}
+
+async function waitForGenerationTerminal(
+  page: Page,
+  generation: number,
+): Promise<CandidatePhaseLog> {
+  await expect
+    .poll(async () => {
+      const log = await candidatePhaseLog(page);
+      return phasesForGeneration(log, generation).some(
+        (entry) =>
+          entry.phase === "promoted" || entry.phase === "failed" || entry.phase === "cancelled",
+      );
+    })
+    .toBe(true);
+  return phasesForGeneration(await candidatePhaseLog(page), generation);
 }
 
 const PIPELINE_FAILURE_SPEC = {
@@ -154,60 +150,82 @@ test("compatible gallery details open the exact fragment while oversized example
 });
 
 test("initial candidate keeps the pending status until promotion", async ({ page }) => {
-  await observeCandidateTransitions(page);
+  await installCandidatePhaseLog(page);
   await page.goto(`/playground${VALID_INITIAL_FRAGMENT}`);
+
   await expect
-    .poll(async () =>
-      (await candidateObservations(page)).some(
-        (observation) =>
-          observation.status === "Checking the next chart before replacing the last valid result.",
-      ),
-    )
-    .toBe(true);
+    .poll(async () => {
+      const log = await candidatePhaseLog(page);
+      return log.find((entry) => entry.phase === "pending" && entry.origin === "initial-navigation")
+        ?.generation;
+    })
+    .toEqual(expect.any(Number));
+
+  const generation = (await candidatePhaseLog(page)).find(
+    (entry) => entry.phase === "pending" && entry.origin === "initial-navigation",
+  )!.generation;
+  const phases = await waitForGenerationTerminal(page, generation);
+  expect(phases.map((entry) => entry.phase)).toEqual(["pending", "ready", "promoted"]);
+  expect(phases[0]).toMatchObject({
+    origin: "initial-navigation",
+    status: "Checking the next chart before replacing the last valid result.",
+  });
+  expect(phases[1]?.isolation).toMatchObject({
+    inert: true,
+    inertAttribute: true,
+    ariaHidden: "true",
+  });
   await expect(page.locator(".active-chart .gg-title")).toHaveText("Initial candidate");
 });
 
 test("valid edits render before Svelte copy becomes available and candidates stay inert", async ({
   page,
 }) => {
-  await observeCandidateTransitions(page);
+  await installCandidatePhaseLog(page);
   await page.goto("/playground");
   await settleVisualState(page);
   await expect(page.getByRole("button", { name: "Copy Svelte" })).toBeEnabled();
-  const activeChartNode = page.locator(".active-chart > *").first();
-  await activeChartNode.evaluate((node) => {
+  // Capture the active-chart element identity before apply. Promotion must not
+  // replace this node while the candidate is pending (Svelte may rewrite attrs).
+  await page.locator(".active-chart").evaluate((node) => {
+    (
+      window as typeof window & { playgroundRetainedActive?: Element | null }
+    ).playgroundRetainedActive = node;
     (node as HTMLElement).dataset["retainedDuringCandidate"] = "true";
   });
 
+  const before = await candidatePhaseLog(page);
   const spec = await readSpec(page);
   spec["labs"] = { ...(spec["labs"] as Record<string, unknown>), title: "Edited locally" };
   await page.getByLabel("PortableSpec JSON").fill(JSON.stringify(spec, null, 2));
   await expect(page.getByRole("button", { name: "Copy Svelte" })).toBeDisabled();
   await page.getByRole("button", { name: "Apply draft" }).click();
 
-  const isIsolatedCandidate = (observation: CandidateObservation) =>
-    observation.activeRetained &&
-    observation.inert &&
-    observation.inertAttribute &&
-    observation.hidden === "true" &&
-    observation.focusables === 0 &&
-    observation.semanticDescendants === 1;
   await expect
-    .poll(async () =>
-      (await candidateObservations(page)).some((observation) => isIsolatedCandidate(observation)),
-    )
-    .toBe(true);
-  const candidateState = (await candidateObservations(page)).find((observation) =>
-    isIsolatedCandidate(observation),
-  );
-  expect(candidateState).toMatchObject({
-    focusables: 0,
-    semanticDescendants: 1,
+    .poll(async () => {
+      const log = await candidatePhaseLog(page);
+      return log.find(
+        (entry, index) =>
+          index >= before.length && entry.phase === "pending" && entry.origin === "apply",
+      )?.generation;
+    })
+    .toEqual(expect.any(Number));
+
+  const generation = (await candidatePhaseLog(page)).find(
+    (entry, index) =>
+      index >= before.length && entry.phase === "pending" && entry.origin === "apply",
+  )!.generation;
+  const phases = await waitForGenerationTerminal(page, generation);
+  expect(phases.map((entry) => entry.phase)).toEqual(["pending", "ready", "promoted"]);
+  expect(phases[1]?.isolation).toMatchObject({
     inert: true,
     inertAttribute: true,
-    hidden: "true",
-    activeRetained: true,
+    ariaHidden: "true",
+    // Last-valid active chart content retained while candidate paints.
+    activeTitle: "Penguin flippers and body mass",
   });
+  // Identity probe: the pre-apply .active-chart node must still be mounted at ready.
+  expect(phases[1]?.isolation?.activeRetained).toBe(true);
 
   await expect(page.getByText("Rendered custom draft.")).toBeVisible();
   await expect(page.locator(".active-chart .gg-title")).toHaveText("Edited locally");


### PR DESCRIPTION
## Summary

- Closes #352: flaky playground candidate-timing journeys under loaded CI/VR runners
- Removes the artificial **300ms** post-paint promotion hold (throughput win per successful apply/sample/navigation)
- Adds a durable docs-only `ggsvelte:playground-candidate` lifecycle event (`pending → ready → promoted|failed|cancelled`) with one terminal per generation
- Rewrites the two journeys to assert exact per-generation phase order and isolation at `ready` (no MutationObserver TOCTOU)

## Root cause

Tests observed a short-lived live DOM pending window. Under load, promotion finished before observers/locators recorded it. The product paid 300ms wall-clock after every successful candidate paint so tests could race that window.

## Test plan

- [x] `bun test scripts/playground-candidate-lifecycle.test.ts` (+ playground-state)
- [x] `bun run check:docs` (0 errors / 0 warnings)
- [x] `bun run build:docs`
- [x] 3× consecutive CI-shaped suite at `--workers=8`:
  `docs-shell.spec.ts` + `interaction-accessibility.spec.ts` + `playground.spec.ts` (invert visual contract) → **44/44** each pass

## Acceptance (#352)

- [x] Both journeys pass under 8-worker loaded runs (3 consecutive full suite passes)
- [x] Tests prove pending-before-promotion via ordered phase history for the caused generation
- [x] Active-chart retention + candidate inert/`aria-hidden` asserted at `ready`
- [x] No Playwright retries added; gate is deterministic