### PR TITLE
ci: kill queue backlog (cancel-on-close, main cancel, 4-slot heavy)

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -5,4 +5,3 @@
 self-hosted-runner:
   labels:
     - ggsvelte
-

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -5,4 +5,4 @@
 self-hosted-runner:
   labels:
     - ggsvelte
-    - ggsvelte-heavy
+

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -18,14 +18,15 @@ on:
 
 permissions: {}
 
-concurrency:
-  group: bench-${{ github.event_name }}-${{ github.ref }}
-  cancel-in-progress: true
-
+# Concurrency is per job, not workflow-level. pull_request:labeled fires for
+# every label; a non-run-bench label must not cancel an in-flight budget gate.
 jobs:
   bench-trend:
     name: bench-trend (record datapoint on gh-pages)
     if: github.event_name == 'push'
+    concurrency:
+      group: bench-trend-${{ github.ref }}
+      cancel-in-progress: true
     # GitHub-hosted: needs contents:write to push gh-pages datapoints.
     runs-on: ubuntu-latest
     permissions:
@@ -66,6 +67,11 @@ jobs:
   bench-label:
     name: bench-label (budget gate on 'run-bench' PRs)
     if: github.event_name == 'pull_request' && github.event.label.name == 'run-bench'
+    # Only the run-bench job joins this group; other labels skip the job and
+    # therefore cannot supersede an active budget-gate run.
+    concurrency:
+      group: bench-label-${{ github.ref }}
+      cancel-in-progress: true
     runs-on: [self-hosted, ggsvelte]
     container:
       image: mcr.microsoft.com/playwright:v1.61.1-noble

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -66,7 +66,7 @@ jobs:
   bench-label:
     name: bench-label (budget gate on 'run-bench' PRs)
     if: github.event_name == 'pull_request' && github.event.label.name == 'run-bench'
-    runs-on: [self-hosted, ggsvelte, ggsvelte-heavy]
+    runs-on: [self-hosted, ggsvelte]
     container:
       image: mcr.microsoft.com/playwright:v1.61.1-noble
     defaults:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -18,6 +18,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: bench-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   bench-trend:
     name: bench-trend (record datapoint on gh-pages)

--- a/.github/workflows/cancel-on-pr-close.yml
+++ b/.github/workflows/cancel-on-pr-close.yml
@@ -10,7 +10,11 @@
 name: Cancel on PR close
 
 on:
-  pull_request_target:
+  # zizmor flags pull_request_target as a dangerous trigger in general. Safe
+  # here: never checks out PR code, only uses event metadata + Actions API to
+  # cancel runs. Needed so fork PRs get a write-capable GITHUB_TOKEN (plain
+  # pull_request is read-only for forks and cannot cancel anything).
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
     types: [closed]
 
 permissions: {}

--- a/.github/workflows/cancel-on-pr-close.yml
+++ b/.github/workflows/cancel-on-pr-close.yml
@@ -1,11 +1,16 @@
 # Cancel leftover self-hosted work the moment a PR is closed or merged.
 # Concurrency cancel-in-progress only fires when a *new* run in the same
 # group starts; merge/close alone does not, so merged branches used to keep
-# burning the heavy lane for 20–40 minutes after the PR was gone.
+# burning runners for 20–40 minutes after the PR was gone.
+#
+# pull_request_target (not pull_request): fork PRs get a read-only token under
+# pull_request, so actions:write never actually works for external contributors.
+# This job never checks out PR code — only event metadata + the Actions API —
+# so the write-capable token is safe here.
 name: Cancel on PR close
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
 
 permissions: {}
@@ -18,20 +23,24 @@ jobs:
       actions: write
       contents: read
     steps:
-      - name: cancel queued and in-progress runs for this head branch
+      - name: cancel queued and in-progress runs for this PR head
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
-          HEAD_BRANCH: ${{ github.head_ref }}
+          HEAD_BRANCH: ${{ github.event.pull_request.head.ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          SELF_RUN_ID: ${{ github.run_id }}
         shell: bash
         run: |
           set -euo pipefail
-          if [ -z "${HEAD_BRANCH}" ]; then
-            echo "no head_ref; nothing to cancel"
+          if [ -z "${HEAD_BRANCH}" ] || [ -z "${HEAD_SHA}" ]; then
+            echo "no head ref/sha; nothing to cancel"
             exit 0
           fi
-          # Paginate active runs on this head branch (queued + in_progress + pending + waiting).
+          # Restrict by head SHA (not bare branch name): fork PRs often share
+          # names like main/patch-1 with unrelated runs. Also drop this cleanup
+          # run so we cannot cancel ourselves mid-loop.
           cancel_ids=()
           for status in queued in_progress pending waiting requested; do
             page=1
@@ -43,8 +52,19 @@ jobs:
               fi
               while IFS= read -r id; do
                 [ -n "$id" ] || continue
+                [ "$id" = "${SELF_RUN_ID}" ] && continue
                 cancel_ids+=("$id")
-              done < <(printf '%s' "$resp" | jq -r '.workflow_runs[].id')
+              done < <(
+                printf '%s' "$resp" | jq -r --arg sha "${HEAD_SHA}" --arg pr "${PR_NUMBER}" '
+                  .workflow_runs[]
+                  | select(.head_sha == $sha)
+                  | select(
+                      (.pull_requests | length) == 0
+                      or any(.pull_requests[]; (.number | tostring) == $pr)
+                    )
+                  | .id
+                '
+              )
               if [ "$count" -lt 100 ]; then
                 break
               fi
@@ -54,10 +74,10 @@ jobs:
           # De-dupe
           mapfile -t cancel_ids < <(printf '%s\n' "${cancel_ids[@]:-}" | awk 'NF && !seen[$0]++')
           if [ "${#cancel_ids[@]}" -eq 0 ]; then
-            echo "no active runs on branch ${HEAD_BRANCH} (PR #${PR_NUMBER})"
+            echo "no active runs for PR #${PR_NUMBER} head=${HEAD_SHA} branch=${HEAD_BRANCH}"
             exit 0
           fi
-          echo "cancelling ${#cancel_ids[@]} run(s) for PR #${PR_NUMBER} branch=${HEAD_BRANCH}"
+          echo "cancelling ${#cancel_ids[@]} run(s) for PR #${PR_NUMBER} head=${HEAD_SHA} branch=${HEAD_BRANCH}"
           for id in "${cancel_ids[@]}"; do
             echo "  gh run cancel ${id}"
             gh run cancel "$id" --repo "$REPO" || true

--- a/.github/workflows/cancel-on-pr-close.yml
+++ b/.github/workflows/cancel-on-pr-close.yml
@@ -1,0 +1,64 @@
+# Cancel leftover self-hosted work the moment a PR is closed or merged.
+# Concurrency cancel-in-progress only fires when a *new* run in the same
+# group starts; merge/close alone does not, so merged branches used to keep
+# burning the heavy lane for 20–40 minutes after the PR was gone.
+name: Cancel on PR close
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions: {}
+
+jobs:
+  cancel:
+    name: cancel in-flight runs for closed PR
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: cancel queued and in-progress runs for this head branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          HEAD_BRANCH: ${{ github.head_ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -z "${HEAD_BRANCH}" ]; then
+            echo "no head_ref; nothing to cancel"
+            exit 0
+          fi
+          # Paginate active runs on this head branch (queued + in_progress + pending + waiting).
+          cancel_ids=()
+          for status in queued in_progress pending waiting requested; do
+            page=1
+            while true; do
+              resp="$(gh api "repos/${REPO}/actions/runs?branch=${HEAD_BRANCH}&status=${status}&per_page=100&page=${page}")"
+              count="$(printf '%s' "$resp" | jq '.workflow_runs | length')"
+              if [ "$count" -eq 0 ]; then
+                break
+              fi
+              while IFS= read -r id; do
+                [ -n "$id" ] || continue
+                cancel_ids+=("$id")
+              done < <(printf '%s' "$resp" | jq -r '.workflow_runs[].id')
+              if [ "$count" -lt 100 ]; then
+                break
+              fi
+              page=$((page + 1))
+            done
+          done
+          # De-dupe
+          mapfile -t cancel_ids < <(printf '%s\n' "${cancel_ids[@]:-}" | awk 'NF && !seen[$0]++')
+          if [ "${#cancel_ids[@]}" -eq 0 ]; then
+            echo "no active runs on branch ${HEAD_BRANCH} (PR #${PR_NUMBER})"
+            exit 0
+          fi
+          echo "cancelling ${#cancel_ids[@]} run(s) for PR #${PR_NUMBER} branch=${HEAD_BRANCH}"
+          for id in "${cancel_ids[@]}"; do
+            echo "  gh run cancel ${id}"
+            gh run cancel "$id" --repo "$REPO" || true
+          done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,21 +46,19 @@ concurrency:
   # (concurrency alone does not cancel when no replacement run starts).
   cancel-in-progress: true
 
-# Heavy-job pool policy (issues #247, #319, #321, throughput fix 2026-07):
-# One cx53 host, four cpuset-isolated runners, each 4 vCPUs, all labeled
-# `ggsvelte` + `ggsvelte-heavy`. Browser / compile-heavy jobs opt into the
-# heavy label so GitHub will not schedule more than four of them at once
-# (and Vitest/Playwright see 4 CPUs via the docker cpuset shim).
-# - Cheap jobs (detect-changes, checks, unit, actions-security,
-#   vr-baseline-guard, compatibility-matrix, ci-gate, bench-smoke,
-#   interaction-perf) use `ggsvelte` only. With the current 4-runner pool
-#   they share the same machines; the label split keeps the door open for
-#   overflow light capacity later without re-labeling browser jobs.
-# - Informational interaction-perf is deliberately off the heavy label so
-#   it never outranks required browser shards when the pool is full.
-# - Runner services share HOME; every Bun install uses a job-private
-#   runner.temp cache so concurrent restores cannot race.
-# - Job-started/completed hooks log host telemetry (load, PSI, memory, disk).
+# Self-hosted pool (issues #247, #319, #321, throughput fix 2026-07):
+# One cx53 host, four cpuset-isolated runners (4 vCPUs each), all labeled
+# only `ggsvelte`. There is NO separate heavy/light GitHub label: that
+# split was a lie once every runner carried both labels (same match set,
+# zero scheduling effect) and a bottleneck when only two runners had
+# `ggsvelte-heavy` while four "light" runners sat idle.
+# - Every Linux job uses `runs-on: [self-hosted, ggsvelte]`. Concurrency
+#   cap = 4 jobs host-wide (one per runner service). CPU isolation is
+#   systemd CPUAffinity + docker cpuset shim, not GitHub labels.
+# - Path routing + cancel-on-close + cancel-in-progress control *which*
+#   work runs; labels do not invent free capacity.
+# - Runner services share HOME; Bun installs use job-private runner.temp.
+# - Job hooks log host telemetry (load, PSI, memory, disk).
 
 env:
   # Keep in sync with: spikes/browser devDependency "playwright" and the
@@ -167,7 +165,7 @@ jobs:
     name: packages-dist (build + upload packages/*/dist)
     needs: detect-changes
     if: needs.detect-changes.outputs.packages_dist == 'true'
-    runs-on: [self-hosted, ggsvelte, ggsvelte-heavy]
+    runs-on: [self-hosted, ggsvelte]
     permissions:
       contents: read
     steps:
@@ -429,7 +427,6 @@ jobs:
       max-parallel: 4
       matrix: ${{ fromJSON(needs.compatibility-matrix.outputs.matrix) }}
     # Linux rows use the private self-hosted heavy lane; Windows/macOS stay on GitHub-hosted.
-    # Ubuntu consumer is typecheck-heavy but not browser; leave heavy for Playwright.
     runs-on: ${{ startsWith(matrix.os, 'ubuntu') && fromJSON('["self-hosted","ggsvelte"]') || matrix.os }}
     timeout-minutes: 20
     permissions:
@@ -538,7 +535,7 @@ jobs:
     if: >-
       needs.detect-changes.outputs.component == 'true' &&
       needs.packages-dist.result == 'success'
-    runs-on: [self-hosted, ggsvelte, ggsvelte-heavy]
+    runs-on: [self-hosted, ggsvelte]
     env:
       # GitHub runs the container as root, while /github/home belongs to
       # pwuser. Firefox refuses that ownership mismatch.
@@ -687,7 +684,7 @@ jobs:
     if: >-
       needs.detect-changes.outputs.component == 'true' &&
       needs.packages-dist.result == 'success'
-    runs-on: [self-hosted, ggsvelte, ggsvelte-heavy]
+    runs-on: [self-hosted, ggsvelte]
     env:
       # GitHub runs the container as root, while /github/home belongs to
       # pwuser. Firefox refuses that ownership mismatch.
@@ -787,7 +784,7 @@ jobs:
     if: >-
       needs.detect-changes.outputs.docs_journeys == 'true' &&
       needs.packages-dist.result == 'success'
-    runs-on: [self-hosted, ggsvelte, ggsvelte-heavy]
+    runs-on: [self-hosted, ggsvelte]
     env:
       # GitHub runs the container as root, while /github/home belongs to
       # pwuser. Firefox refuses that ownership mismatch.
@@ -892,8 +889,7 @@ jobs:
           retention-days: 7
 
   # Informational only — not a required status check (excluded from ci-gate).
-  # Uses the non-heavy label so required browser shards keep priority on the
-  # 4-slot heavy pool. Hard gate remains on `run-bench` PRs via bench.yml.
+  # Hard gate remains on `run-bench` PRs via bench.yml.
   interaction-perf:
     name: interaction-perf (p50/p95, informational)
     needs: [detect-changes, packages-dist]
@@ -976,7 +972,7 @@ jobs:
     name: build (tsc -b, packaging lint, static analysis)
     needs: detect-changes
     if: needs.detect-changes.outputs.build == 'true'
-    runs-on: [self-hosted, ggsvelte, ggsvelte-heavy]
+    runs-on: [self-hosted, ggsvelte]
     permissions:
       contents: read
     steps:
@@ -1087,7 +1083,6 @@ jobs:
     name: bench-smoke (mitata, 1k workload)
     needs: detect-changes
     if: needs.detect-changes.outputs.bench_smoke == 'true'
-    # Mitata 1k is short; keep heavy slots for browser/compile shards.
     runs-on: [self-hosted, ggsvelte]
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,25 +40,27 @@ permissions: {}
 
 concurrency:
   group: ci-${{ github.ref }}
-  # Cancel superseded runs on PRs/branches; never cancel main.
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  # Cancel superseded runs on every ref — including main. Rapid merges used to
+  # stack full suites behind a 2-slot heavy lane; only the latest commit per
+  # ref is worth finishing. PR close/merge is handled by cancel-on-pr-close.yml
+  # (concurrency alone does not cancel when no replacement run starts).
+  cancel-in-progress: true
 
-# Heavy-job pool policy (issues #247, #319, #321):
-# The self-hosted pool runs cpuset-isolated lanes. Two runner services carry
-# the `ggsvelte-heavy` label, each pinned to 4 dedicated host vCPUs; light
-# runners are pinned to 2 vCPUs each. CPU-heavy jobs opt into the heavy lane
-# via `runs-on: [self-hosted, ggsvelte, ggsvelte-heavy]`, so at most two run
-# concurrently and browser/Vitest worker auto-detection sees the allocated
-# CPU count (a docker shim applies the same cpuset to job containers).
-# - Light jobs (detect-changes, checks, unit, actions-security,
-#   vr-baseline-guard, compatibility-matrix, ci-gate) keep `ggsvelte` only and
-#   run freely; they may spill onto idle heavy runners without harm.
-# - Informational interaction-perf uses the heavy lane despite being excluded
-#   from ci-gate; it is CPU-heavy even though it is not required.
+# Heavy-job pool policy (issues #247, #319, #321, throughput fix 2026-07):
+# One cx53 host, four cpuset-isolated runners, each 4 vCPUs, all labeled
+# `ggsvelte` + `ggsvelte-heavy`. Browser / compile-heavy jobs opt into the
+# heavy label so GitHub will not schedule more than four of them at once
+# (and Vitest/Playwright see 4 CPUs via the docker cpuset shim).
+# - Cheap jobs (detect-changes, checks, unit, actions-security,
+#   vr-baseline-guard, compatibility-matrix, ci-gate, bench-smoke,
+#   interaction-perf) use `ggsvelte` only. With the current 4-runner pool
+#   they share the same machines; the label split keeps the door open for
+#   overflow light capacity later without re-labeling browser jobs.
+# - Informational interaction-perf is deliberately off the heavy label so
+#   it never outranks required browser shards when the pool is full.
 # - Runner services share HOME; every Bun install uses a job-private
 #   runner.temp cache so concurrent restores cannot race.
-# - Job-started/completed hooks on the runners log host telemetry (load, PSI,
-#   memory, disk) so infra contention can be told apart from regressions.
+# - Job-started/completed hooks log host telemetry (load, PSI, memory, disk).
 
 env:
   # Keep in sync with: spikes/browser devDependency "playwright" and the
@@ -427,7 +429,8 @@ jobs:
       max-parallel: 4
       matrix: ${{ fromJSON(needs.compatibility-matrix.outputs.matrix) }}
     # Linux rows use the private self-hosted heavy lane; Windows/macOS stay on GitHub-hosted.
-    runs-on: ${{ startsWith(matrix.os, 'ubuntu') && fromJSON('["self-hosted","ggsvelte","ggsvelte-heavy"]') || matrix.os }}
+    # Ubuntu consumer is typecheck-heavy but not browser; leave heavy for Playwright.
+    runs-on: ${{ startsWith(matrix.os, 'ubuntu') && fromJSON('["self-hosted","ggsvelte"]') || matrix.os }}
     timeout-minutes: 20
     permissions:
       contents: read
@@ -889,16 +892,15 @@ jobs:
           retention-days: 7
 
   # Informational only — not a required status check (excluded from ci-gate).
-  # It still shares the aggregate heavy lane: running this browser workload
-  # beside required jobs would reintroduce host starvation. Hard gate remains
-  # on `run-bench` PRs via bench.yml.
+  # Uses the non-heavy label so required browser shards keep priority on the
+  # 4-slot heavy pool. Hard gate remains on `run-bench` PRs via bench.yml.
   interaction-perf:
     name: interaction-perf (p50/p95, informational)
     needs: [detect-changes, packages-dist]
     if: >-
       needs.detect-changes.outputs.interaction_perf == 'true' &&
       needs.packages-dist.result == 'success'
-    runs-on: [self-hosted, ggsvelte, ggsvelte-heavy]
+    runs-on: [self-hosted, ggsvelte]
     env:
       HOME: /root
     container:
@@ -1085,7 +1087,8 @@ jobs:
     name: bench-smoke (mitata, 1k workload)
     needs: detect-changes
     if: needs.detect-changes.outputs.bench_smoke == 'true'
-    runs-on: [self-hosted, ggsvelte, ggsvelte-heavy]
+    # Mitata 1k is short; keep heavy slots for browser/compile shards.
+    runs-on: [self-hosted, ggsvelte]
     permissions:
       contents: read
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,7 @@ jobs:
     name: detect-changes (path routing)
     runs-on: [self-hosted, ggsvelte]
     permissions:
+      actions: read
       contents: read
       # pull-requests:read not required — we use event SHAs, not the API.
     outputs:
@@ -105,6 +106,8 @@ jobs:
           HEAD_SHA: ${{ github.sha }}
           # Issue #246: run-compat must force consumer after path routing.
           PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
         shell: bash
         run: |
           set -euo pipefail
@@ -113,6 +116,24 @@ jobs:
             echo "no usable base SHA — force-all"
             bun scripts/ci-routing.ts emit-github-output --force-all
           else
+            # Main + cancel-in-progress: a later markdown/workflow-only push must
+            # still route product work from earlier unvalidated main commits.
+            # Widen the base to the last successful CI head on main so the
+            # replacement run covers the cumulative unvalidated range.
+            if [ "${EVENT_NAME}" = "push" ] && [ "${GITHUB_REF}" = "refs/heads/main" ] && command -v gh >/dev/null 2>&1; then
+              last_ok="$(
+                gh api "repos/${REPO}/actions/workflows/ci.yml/runs?branch=main&status=completed&per_page=20" \
+                  --jq --arg head "${HEAD_SHA}" '
+                    [.workflow_runs[]
+                      | select(.conclusion == "success" and .head_sha != $head)
+                      | .head_sha][0] // empty
+                  ' 2>/dev/null || true
+              )"
+              if [ -n "${last_ok}" ]; then
+                echo "widening main route base ${BASE_SHA} → last successful CI ${last_ok}"
+                BASE_SHA="${last_ok}"
+              fi
+            fi
             # Ensure the base object exists for the three-dot diff.
             git fetch --no-tags --depth=1 origin "${BASE_SHA}" 2>/dev/null || true
             if ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
@@ -426,7 +447,7 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix: ${{ fromJSON(needs.compatibility-matrix.outputs.matrix) }}
-    # Linux rows use the private self-hosted heavy lane; Windows/macOS stay on GitHub-hosted.
+    # Linux rows use the private self-hosted ggsvelte pool; Windows/macOS stay on GitHub-hosted.
     runs-on: ${{ startsWith(matrix.os, 'ubuntu') && fromJSON('["self-hosted","ggsvelte"]') || matrix.os }}
     timeout-minutes: 20
     permissions:

--- a/.github/workflows/compatibility-nightly.yml
+++ b/.github/workflows/compatibility-nightly.yml
@@ -40,8 +40,8 @@ jobs:
       fail-fast: false
       max-parallel: 3
       matrix: ${{ fromJSON(needs.matrix.outputs.matrix) }}
-    # Linux rows use the private self-hosted heavy lane; Windows/macOS stay on GitHub-hosted.
-    runs-on: ${{ startsWith(matrix.os, 'ubuntu') && fromJSON('["self-hosted","ggsvelte","ggsvelte-heavy"]') || matrix.os }}
+    # Linux rows use self-hosted (non-heavy — leave heavy for Playwright); Windows/macOS hosted.
+    runs-on: ${{ startsWith(matrix.os, 'ubuntu') && fromJSON('["self-hosted","ggsvelte"]') || matrix.os }}
     timeout-minutes: 20
     permissions:
       contents: read

--- a/.github/workflows/compatibility-nightly.yml
+++ b/.github/workflows/compatibility-nightly.yml
@@ -40,7 +40,7 @@ jobs:
       fail-fast: false
       max-parallel: 3
       matrix: ${{ fromJSON(needs.matrix.outputs.matrix) }}
-    # Linux rows use self-hosted (non-heavy — leave heavy for Playwright); Windows/macOS hosted.
+    # Linux rows use self-hosted ggsvelte pool; Windows/macOS stay GitHub-hosted.
     runs-on: ${{ startsWith(matrix.os, 'ubuntu') && fromJSON('["self-hosted","ggsvelte"]') || matrix.os }}
     timeout-minutes: 20
     permissions:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -70,7 +70,7 @@ jobs:
     name: build static docs
     needs: detect-changes
     if: needs.detect-changes.outputs.pages == 'true'
-    runs-on: [self-hosted, ggsvelte, ggsvelte-heavy]
+    runs-on: [self-hosted, ggsvelte]
     permissions:
       contents: read
     env:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -11,18 +11,15 @@ on:
 
 permissions: {}
 
-# Superseded main pushes cancel older Pages runs (build + deploy). Deploy still
-# has its own group below so two deploys never interleave; cancel-in-progress
-# here is what stops the post-merge Pages backlog from eating heavy runners.
-concurrency:
-  group: pages-${{ github.ref }}
-  cancel-in-progress: true
-
+# Concurrency is on build/deploy only — NOT workflow-level. A skip-only main
+# push (pages=false after path routing) must not cancel an in-flight docs
+# build/deploy that still needs to publish. Deploy keeps its own serial group.
 jobs:
   detect-changes:
     name: detect-changes (path routing)
     runs-on: [self-hosted, ggsvelte]
     permissions:
+      actions: read
       contents: read
     outputs:
       pages: ${{ steps.route.outputs.pages }}
@@ -40,6 +37,8 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           BASE_SHA: ${{ github.event.before }}
           HEAD_SHA: ${{ github.sha }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
         shell: bash
         run: |
           set -euo pipefail
@@ -52,6 +51,24 @@ jobs:
           if [ -z "${BASE_SHA}" ] || [ "${BASE_SHA}" = "${zero}" ]; then
             bun scripts/ci-routing.ts emit-github-output --force-all
             exit 0
+          fi
+          # Widen past cancel-in-progress gaps: include commits since the last
+          # successful Pages build so a later skip-only push cannot leave an
+          # unpublished docs change stranded (build concurrency still cancels
+          # superseded *pages=true* builds).
+          if command -v gh >/dev/null 2>&1; then
+            last_ok="$(
+              gh api "repos/${REPO}/actions/workflows/pages.yml/runs?branch=main&status=completed&per_page=20" \
+                --jq --arg head "${HEAD_SHA}" '
+                  [.workflow_runs[]
+                    | select(.conclusion == "success" and .head_sha != $head)
+                    | .head_sha][0] // empty
+                ' 2>/dev/null || true
+            )"
+            if [ -n "${last_ok}" ]; then
+              echo "widening pages route base ${BASE_SHA} → last successful ${last_ok}"
+              BASE_SHA="${last_ok}"
+            fi
           fi
           git fetch --no-tags --depth=1 origin "${BASE_SHA}" 2>/dev/null || true
           if ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
@@ -70,6 +87,11 @@ jobs:
     name: build static docs
     needs: detect-changes
     if: needs.detect-changes.outputs.pages == 'true'
+    # Only pages=true runs enter this group, so markdown-only pushes cannot
+    # cancel a real docs build that still needs to publish.
+    concurrency:
+      group: pages-build-${{ github.ref }}
+      cancel-in-progress: true
     runs-on: [self-hosted, ggsvelte]
     permissions:
       contents: read

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -11,10 +11,12 @@ on:
 
 permissions: {}
 
-# Concurrency is intentionally NOT workflow-level. A path-routed `pages=false`
-# run that only executes detect-changes must not enter the deploy group and
-# displace a pending real deploy (GitHub keeps only one pending run per group).
-# Serialize production deploys on the deploy job alone (see below).
+# Superseded main pushes cancel older Pages runs (build + deploy). Deploy still
+# has its own group below so two deploys never interleave; cancel-in-progress
+# here is what stops the post-merge Pages backlog from eating heavy runners.
+concurrency:
+  group: pages-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   detect-changes:

--- a/.github/workflows/vr-compare.yml
+++ b/.github/workflows/vr-compare.yml
@@ -93,7 +93,7 @@ jobs:
     name: build docs, screenshot, upload candidate baselines
     needs: detect-changes
     if: github.event_name == 'pull_request' && needs.detect-changes.outputs.vr == 'true'
-    runs-on: [self-hosted, ggsvelte, ggsvelte-heavy]
+    runs-on: [self-hosted, ggsvelte]
     permissions:
       contents: read
     container:
@@ -274,7 +274,7 @@ jobs:
     name: /approve-visuals — regenerate baselines at merged commit (pinned container)
     needs: approve-gate
     if: needs.approve-gate.outputs.match == 'true'
-    runs-on: [self-hosted, ggsvelte, ggsvelte-heavy]
+    runs-on: [self-hosted, ggsvelte]
     permissions:
       contents: read # checkout only; this job can write nothing
     container:

--- a/scripts/release-wiring.test.ts
+++ b/scripts/release-wiring.test.ts
@@ -4,7 +4,16 @@ import { join } from "node:path";
 
 const root = join(import.meta.dir, "..");
 const read = (path: string) => readFileSync(join(root, path), "utf8");
-const heavyLaneCount = (workflow: string) =>
+const selfHostedGgsvelteCount = (workflow: string) =>
+  workflow
+    .split("\n")
+    .filter(
+      (line) =>
+        line.trimStart().startsWith("runs-on:") &&
+        line.includes("ggsvelte") &&
+        !line.includes("ggsvelte-heavy"),
+    ).length;
+const heavyRunsOnCount = (workflow: string) =>
   workflow
     .split("\n")
     .filter((line) => line.trimStart().startsWith("runs-on:") && line.includes("ggsvelte-heavy"))
@@ -367,34 +376,41 @@ it("tiers the PR consumer matrix (issue #246)", () => {
   expect(ci).not.toMatch(/full required[\s\S]{0,40}push\/main/i);
 });
 
-it("routes CPU-heavy work through the runner heavy lane (issues #247, #319, #321)", () => {
+it("uses one self-hosted ggsvelte pool (no heavy/light label split)", () => {
   const ci = read(".github/workflows/ci.yml");
   const vr = read(".github/workflows/vr-compare.yml");
   const pages = read(".github/workflows/pages.yml");
   const bench = read(".github/workflows/bench.yml");
   const nightly = read(".github/workflows/compatibility-nightly.yml");
+  const cancel = read(".github/workflows/cancel-on-pr-close.yml");
 
-  // The pool runs cpuset-pinned lanes: two runner services carry the
-  // ggsvelte-heavy label (4 dedicated vCPUs each), so at most two heavy jobs
-  // run concurrently while light jobs flow freely. Category-specific labels
-  // would let browser, build, and benchmark jobs starve each other again.
-  expect(heavyLaneCount(ci)).toBe(8);
-  expect(heavyLaneCount(vr)).toBe(2);
-  expect(heavyLaneCount(pages)).toBe(1);
-  expect(heavyLaneCount(bench)).toBe(1);
-  expect(heavyLaneCount(nightly)).toBe(1);
-  // The post-#319 repo-wide concurrency mutex must not come back: labels, not
-  // groups, gate host capacity now (#321).
+  // Single-label pool: every self-hosted Linux job uses `ggsvelte` only.
+  // Dual-label scheduling was theater; the old 2-slot heavy-only pool was the
+  // real bottleneck (issues #247, #319, #321). Comments may mention the retired
+  // label when explaining history — assert on runs-on lines only.
   for (const workflow of [ci, vr, pages, bench, nightly]) {
+    expect(heavyRunsOnCount(workflow)).toBe(0);
     expect(workflow).not.toContain("heavy-self-hosted-cpu");
   }
+  expect(selfHostedGgsvelteCount(ci)).toBeGreaterThanOrEqual(10);
+  expect(selfHostedGgsvelteCount(vr)).toBe(3);
+  expect(selfHostedGgsvelteCount(pages)).toBe(2);
+  expect(selfHostedGgsvelteCount(bench)).toBe(1);
+  expect(selfHostedGgsvelteCount(nightly)).toBeGreaterThanOrEqual(1);
   expect(ci).not.toContain("heavy-component");
   expect(ci).not.toContain("heavy-packages-dist");
   expect(ci).not.toContain("heavy-consumer-ubuntu");
-  // Informational performance work is still CPU-heavy: it opts into the heavy
-  // lane with the required browser and memory gates it runs beside.
   expect(ci).not.toContain("group: heavy-interaction-perf");
-  expect(ci).toContain("Heavy-job pool policy");
+  // Documented live topology + cancel-on-close (not label fiction).
+  expect(ci).toContain("four cpuset-isolated runners");
+  expect(ci).toContain("cancel-in-progress: true");
+  expect(cancel).toContain("pull_request_target");
+  expect(cancel).toContain("head_sha");
+  // Pages/Bench: job-level concurrency so skip-only runs cannot cancel real work.
+  expect(pages).toContain("group: pages-build-");
+  expect(pages).not.toMatch(/^concurrency:\s*$/m);
+  expect(bench).toContain("group: bench-label-");
+  expect(bench).toContain("group: bench-trend-");
 });
 
 it("binds approved baselines to a post-merge default-branch commit", () => {


### PR DESCRIPTION
## Problem

CI looked stuck forever after merges because:

1. Only **2** `ggsvelte-heavy` runners existed; light runners sat idle.
2. **Merged PR workflows kept running** (concurrency cancel only fires when a *new* run starts in the same group).
3. **Main never cancelled** superseded CI/Pages, so rapid merges stacked full suites.

Machine type was not the bottleneck — the host is already a **cx53**.

## This PR (all high-leverage fixes together)

| Fix | Change |
|-----|--------|
| Cancel on PR close/merge | New `cancel-on-pr-close.yml` cancels queued/in-progress runs for the PR head branch |
| Main cancel-in-progress | `ci.yml`, `pages.yml`, `bench.yml` → `cancel-in-progress: true` always |
| Rebalance labels | `interaction-perf`, `bench-smoke`, and packed-consumer Ubuntu off heavy; browser/compile stay on `ggsvelte-heavy` |
| 4-slot heavy pool | Documented; **already applied live** on `ggsvelte-ci-runner-1` (4×4 vCPU, runners 5–6 removed) |
| Cull zombies | Already cancelled merged-branch backlog during investigation |

## Live infra (already done; private ops package committed)

- Confirmed **cx53** online in hel1 (`ggsvelte-ci-runner-1`)
- Runners 1–4: `ggsvelte` + `ggsvelte-heavy`, CPUAffinity 0-3 / 4-7 / 8-11 / 12-15
- Runners 5–6: stopped + deleted from GitHub
- Job-started hook: chown only active workspace
- `ggsvelte-ci-infra` defaults: `RUNNER_COUNT=4`, `HEAVY_RUNNER_COUNT=4`

## Was heavy/light a falsehood?

With **2** heavy slots it was a self-inflicted bottleneck. On a **cx53 with 4×4 heavy**, the label is a concurrency cap for Playwright/compile (max 4). Cheap jobs use `ggsvelte` only; today they share the same four machines.

## Test plan

- [ ] PR CI schedules; heavy jobs use runners 1–4 (up to 4 concurrent)
- [ ] Merge/close a PR → active runs for that head cancel within ~1 min
- [ ] Two rapid main pushes → older CI/Pages cancelled
- [ ] `interaction-perf` / `bench-smoke` no longer request `ggsvelte-heavy`