### PR TITLE
ci: hash highlight-code in component_journeys cache

### DIFF
--- a/scripts/ci-routing.test.ts
+++ b/scripts/ci-routing.test.ts
@@ -764,6 +764,8 @@ describe("component_journeys content inputs cover llms modules", () => {
     for (const file of [
       "scripts/gen-llms.ts",
       "scripts/llms-markdown.ts",
+      "scripts/highlight-code.ts",
+      "scripts/highlight-code.test.ts",
       "scripts/llms-guide-content.ts",
     ]) {
       expect(inputs, file).toContain(file);

--- a/scripts/ci-routing/content-hash.ts
+++ b/scripts/ci-routing/content-hash.ts
@@ -179,6 +179,10 @@ export const JOB_CONTENT_INPUTS: Record<CacheableExecution, readonly string[]> =
     "scripts/gen-llms.ts",
     "scripts/gen-llms.test.ts",
     "scripts/llms-markdown.ts",
+    // llms-markdown imports highlight-code for fenced-block HTML; hash it or
+    // a highlight-only change can cache-hit and skip docs journeys (Codex P2).
+    "scripts/highlight-code.ts",
+    "scripts/highlight-code.test.ts",
     "scripts/llms-guide-content.ts",
     "scripts/docs-seo.ts",
     "scripts/diagnostic-docs.ts",


### PR DESCRIPTION
## Summary

- Codex P2 on #382: `scripts/highlight-code.ts` is imported by `llms-markdown.ts` for fenced-block HTML, but `JOB_CONTENT_INPUTS.component_journeys` only hashed `llms-markdown.ts`.
- A highlight-only change could content-cache-hit `component_journeys` and skip `build:docs` + docs shell/interaction/playground tests even though rendered guide HTML changed.
- Add `scripts/highlight-code.ts` and its test to the journeys content-hash inputs; extend the existing coverage test.

## Test plan

- [x] `bun test scripts/ci-routing.test.ts` (60 pass)
- [x] Pre-push suite