### PR TITLE
refactor(ci): extract setup/install/packages-dist step composites

### DIFF
--- a/.github/actions/ci-bun-install/action.yml
+++ b/.github/actions/ci-bun-install/action.yml
@@ -1,0 +1,27 @@
+# Job-private Bun install cache (issue #319) + frozen-lockfile install.
+# Caller gates the whole step with `if:` when content-hash hit must skip install.
+name: CI bun install (private cache)
+description: >
+  Restore a runner.temp Bun install cache and run bun install --frozen-lockfile.
+  Uses job-private cache paths so self-hosted runners do not share HOME caches.
+
+inputs:
+  cache_key_prefix:
+    description: >
+      Cache key prefix — `bun` for host runners, `bun-container` for Playwright
+      container jobs (separate cache namespace).
+    required: false
+    default: "bun"
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ${{ runner.temp }}/bun-install-cache
+        key: ${{ inputs.cache_key_prefix }}-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+        restore-keys: ${{ inputs.cache_key_prefix }}-${{ runner.os }}-
+    - run: bun install --frozen-lockfile
+      shell: bash
+      env:
+        BUN_INSTALL_CACHE_DIR: ${{ runner.temp }}/bun-install-cache

--- a/.github/actions/ci-download-packages-dist/action.yml
+++ b/.github/actions/ci-download-packages-dist/action.yml
@@ -1,0 +1,30 @@
+# Download the same-run packages-dist artifact and verify package entrypoints
+# (issue #241). Caller gates with `if:` when content-hash hit must skip.
+name: CI download packages-dist
+description: >
+  Download the packages-dist artifact into packages/ and verify that
+  spec/core/svelte dist entrypoints exist.
+
+runs:
+  using: composite
+  steps:
+    - name: download shared packages/*/dist
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: packages-dist
+        # Producer uploads .packages-dist-upload/packages → extract as packages/.
+        path: packages
+    - name: verify downloaded package dist entrypoints
+      shell: bash
+      run: |
+        set -euo pipefail
+        for path in \
+          packages/spec/dist/index.js \
+          packages/core/dist/index.js \
+          packages/svelte/dist/index.js; do
+          if [ ! -f "${path}" ]; then
+            echo "::error::packages-dist artifact missing ${path} after download"
+            find packages -maxdepth 3 -type d 2>/dev/null | head -40 || true
+            exit 1
+          fi
+        done

--- a/.github/actions/ci-setup-bun/action.yml
+++ b/.github/actions/ci-setup-bun/action.yml
@@ -1,0 +1,20 @@
+# Pin + version for oven-sh/setup-bun used by CI jobs.
+# Call only AFTER actions/checkout — local composites are loaded from the
+# workspace, so checkout cannot live inside this action.
+name: CI setup Bun
+description: >
+  Install the lockstep Bun version via oven-sh/setup-bun (SHA-pinned).
+  Does not check out the repository.
+
+inputs:
+  bun-version:
+    description: Bun version string (keep in sync with packageManager / mise)
+    required: false
+    default: "1.3.14"
+
+runs:
+  using: composite
+  steps:
+    - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+      with:
+        bun-version: ${{ inputs.bun-version }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -122,6 +122,9 @@ updates:
       - "/"
       - "/.github/actions/ci-content-hash-restore"
       - "/.github/actions/ci-content-hash-write"
+      - "/.github/actions/ci-setup-bun"
+      - "/.github/actions/ci-bun-install"
+      - "/.github/actions/ci-download-packages-dist"
     schedule:
       interval: "weekly"
       day: "tuesday"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,9 +94,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-        with:
-          bun-version: 1.3.14
+      - uses: ./.github/actions/ci-setup-bun
       - id: route
         name: classify changed paths → job flags
         env:
@@ -195,9 +193,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-        with:
-          bun-version: 1.3.14
+      - uses: ./.github/actions/ci-setup-bun
       - id: content_hash
         name: compute content-hash (packages_dist)
         env:
@@ -245,16 +241,10 @@ jobs:
           cp -a .packages-dist-cache/packages/svelte/dist packages/svelte/
           echo "hit=true" >> "$GITHUB_OUTPUT"
           echo "packages-dist: restored from content-hash cache"
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - uses: ./.github/actions/ci-bun-install
         if: steps.restore_dist.outputs.hit != 'true'
         with:
-          path: ${{ runner.temp }}/bun-install-cache
-          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
-          restore-keys: bun-${{ runner.os }}-
-      - if: steps.restore_dist.outputs.hit != 'true'
-        run: bun install --frozen-lockfile
-        env:
-          BUN_INSTALL_CACHE_DIR: ${{ runner.temp }}/bun-install-cache
+          cache_key_prefix: bun
       - name: build packages (tsc -b + svelte-package)
         if: steps.restore_dist.outputs.hit != 'true'
         run: bun run build
@@ -318,17 +308,10 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+      - uses: ./.github/actions/ci-setup-bun
+      - uses: ./.github/actions/ci-bun-install
         with:
-          bun-version: 1.3.14
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ${{ runner.temp }}/bun-install-cache
-          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
-          restore-keys: bun-${{ runner.os }}-
-      - run: bun install --frozen-lockfile
-        env:
-          BUN_INSTALL_CACHE_DIR: ${{ runner.temp }}/bun-install-cache
+          cache_key_prefix: bun
       - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
       - run: uv tool install pre-commit
       # Pre-commit stage only. Pre-push parity (build, unit, svelte-check, knip,
@@ -351,25 +334,17 @@ jobs:
           # hard-coded historical commits (shallow clone would fail unit).
           fetch-depth: 0
           persist-credentials: false
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-        with:
-          bun-version: 1.3.14
+      - uses: ./.github/actions/ci-setup-bun
       - uses: ./.github/actions/ci-content-hash-restore
         id: content_hash
         with:
           execution: unit
           bypass: ${{ needs.detect-changes.outputs.bypass_content_cache }}
           disable: ${{ vars.CI_DISABLE_CONTENT_HASH }}
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - uses: ./.github/actions/ci-bun-install
         if: steps.content_hash.outputs.hit != 'true'
         with:
-          path: ${{ runner.temp }}/bun-install-cache
-          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
-          restore-keys: bun-${{ runner.os }}-
-      - if: steps.content_hash.outputs.hit != 'true'
-        run: bun install --frozen-lockfile
-        env:
-          BUN_INSTALL_CACHE_DIR: ${{ runner.temp }}/bun-install-cache
+          cache_key_prefix: bun
       - name: build spec/core dist (package exports point at dist/)
         if: steps.content_hash.outputs.hit != 'true'
         run: bun run check
@@ -413,9 +388,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-        with:
-          bun-version: 1.3.14
+      - uses: ./.github/actions/ci-setup-bun
       - id: matrix
         name: emit packed-consumer matrix (PR default vs full required)
         # Issue #246: PRs run one Linux consumer row by default; full required
@@ -461,9 +434,7 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ matrix.node }}
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-        with:
-          bun-version: 1.3.14
+      - uses: ./.github/actions/ci-setup-bun
       # Resolved toolchain versions (not matrix majors alone) — Node/npm patch
       # bumps must miss the consumer success-marker cache (Codex P2 on #245).
       # Keep resolution in the job so the content-hash composite stays protocol-only.
@@ -509,28 +480,8 @@ jobs:
         run: bun install --frozen-lockfile
         env:
           BUN_INSTALL_CACHE_DIR: ${{ runner.temp }}/bun-install-cache
-      - name: download shared packages/*/dist
+      - uses: ./.github/actions/ci-download-packages-dist
         if: steps.content_hash.outputs.hit != 'true'
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: packages-dist
-          # Producer uploads .packages-dist-upload/packages → extract as packages/.
-          path: packages
-      - name: verify downloaded package dist entrypoints
-        if: steps.content_hash.outputs.hit != 'true'
-        shell: bash
-        run: |
-          set -euo pipefail
-          for path in \
-            packages/spec/dist/index.js \
-            packages/core/dist/index.js \
-            packages/svelte/dist/index.js; do
-            if [ ! -f "${path}" ]; then
-              echo "::error::packages-dist artifact missing ${path} after download"
-              find packages -maxdepth 3 -type d 2>/dev/null | head -40 || true
-              exit 1
-            fi
-          done
       - name: type-check Svelte package source
         if: steps.content_hash.outputs.hit != 'true'
         run: bun run check:svelte
@@ -578,9 +529,7 @@ jobs:
           persist-credentials: false
       - name: install unzip (playwright image lacks it; setup-bun needs it)
         run: apt-get update && apt-get install -y --no-install-recommends unzip
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-        with:
-          bun-version: 1.3.14
+      - uses: ./.github/actions/ci-setup-bun
       - uses: ./.github/actions/ci-content-hash-restore
         id: content_hash
         with:
@@ -588,38 +537,12 @@ jobs:
           bypass: ${{ needs.detect-changes.outputs.bypass_content_cache }}
           disable: ${{ vars.CI_DISABLE_CONTENT_HASH }}
           container_tag: ${{ env.PLAYWRIGHT_CONTAINER_TAG }}
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - uses: ./.github/actions/ci-bun-install
         if: steps.content_hash.outputs.hit != 'true'
         with:
-          path: ${{ runner.temp }}/bun-install-cache
-          key: bun-container-${{ runner.os }}-${{ hashFiles('bun.lock') }}
-          restore-keys: bun-container-${{ runner.os }}-
-      - if: steps.content_hash.outputs.hit != 'true'
-        run: bun install --frozen-lockfile
-        env:
-          BUN_INSTALL_CACHE_DIR: ${{ runner.temp }}/bun-install-cache
-      - name: download shared packages/*/dist
+          cache_key_prefix: bun-container
+      - uses: ./.github/actions/ci-download-packages-dist
         if: steps.content_hash.outputs.hit != 'true'
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: packages-dist
-          # Producer uploads .packages-dist-upload/packages → extract as packages/.
-          path: packages
-      - name: verify downloaded package dist entrypoints
-        if: steps.content_hash.outputs.hit != 'true'
-        shell: bash
-        run: |
-          set -euo pipefail
-          for path in \
-            packages/spec/dist/index.js \
-            packages/core/dist/index.js \
-            packages/svelte/dist/index.js; do
-            if [ ! -f "${path}" ]; then
-              echo "::error::packages-dist artifact missing ${path} after download"
-              find packages -maxdepth 3 -type d 2>/dev/null | head -40 || true
-              exit 1
-            fi
-          done
       - name: assert playwright npm/container version sync (packages/svelte)
         if: steps.content_hash.outputs.hit != 'true'
         run: |
@@ -727,9 +650,7 @@ jobs:
           persist-credentials: false
       - name: install unzip (playwright image lacks it; setup-bun needs it)
         run: apt-get update && apt-get install -y --no-install-recommends unzip
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-        with:
-          bun-version: 1.3.14
+      - uses: ./.github/actions/ci-setup-bun
       - uses: ./.github/actions/ci-content-hash-restore
         id: content_hash
         with:
@@ -737,38 +658,12 @@ jobs:
           bypass: ${{ needs.detect-changes.outputs.bypass_content_cache }}
           disable: ${{ vars.CI_DISABLE_CONTENT_HASH }}
           container_tag: ${{ env.PLAYWRIGHT_CONTAINER_TAG }}
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - uses: ./.github/actions/ci-bun-install
         if: steps.content_hash.outputs.hit != 'true'
         with:
-          path: ${{ runner.temp }}/bun-install-cache
-          key: bun-container-${{ runner.os }}-${{ hashFiles('bun.lock') }}
-          restore-keys: bun-container-${{ runner.os }}-
-      - if: steps.content_hash.outputs.hit != 'true'
-        run: bun install --frozen-lockfile
-        env:
-          BUN_INSTALL_CACHE_DIR: ${{ runner.temp }}/bun-install-cache
-      - name: download shared packages/*/dist
+          cache_key_prefix: bun-container
+      - uses: ./.github/actions/ci-download-packages-dist
         if: steps.content_hash.outputs.hit != 'true'
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: packages-dist
-          # Producer uploads .packages-dist-upload/packages → extract as packages/.
-          path: packages
-      - name: verify downloaded package dist entrypoints
-        if: steps.content_hash.outputs.hit != 'true'
-        shell: bash
-        run: |
-          set -euo pipefail
-          for path in \
-            packages/spec/dist/index.js \
-            packages/core/dist/index.js \
-            packages/svelte/dist/index.js; do
-            if [ ! -f "${path}" ]; then
-              echo "::error::packages-dist artifact missing ${path} after download"
-              find packages -maxdepth 3 -type d 2>/dev/null | head -40 || true
-              exit 1
-            fi
-          done
       - name: assert playwright npm/container version sync (spikes/browser)
         if: steps.content_hash.outputs.hit != 'true'
         run: |
@@ -827,9 +722,7 @@ jobs:
           persist-credentials: false
       - name: install unzip (playwright image lacks it; setup-bun needs it)
         run: apt-get update && apt-get install -y --no-install-recommends unzip
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-        with:
-          bun-version: 1.3.14
+      - uses: ./.github/actions/ci-setup-bun
       - uses: ./.github/actions/ci-content-hash-restore
         id: content_hash
         with:
@@ -837,38 +730,12 @@ jobs:
           bypass: ${{ needs.detect-changes.outputs.bypass_content_cache }}
           disable: ${{ vars.CI_DISABLE_CONTENT_HASH }}
           container_tag: ${{ env.PLAYWRIGHT_CONTAINER_TAG }}
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - uses: ./.github/actions/ci-bun-install
         if: steps.content_hash.outputs.hit != 'true'
         with:
-          path: ${{ runner.temp }}/bun-install-cache
-          key: bun-container-${{ runner.os }}-${{ hashFiles('bun.lock') }}
-          restore-keys: bun-container-${{ runner.os }}-
-      - if: steps.content_hash.outputs.hit != 'true'
-        run: bun install --frozen-lockfile
-        env:
-          BUN_INSTALL_CACHE_DIR: ${{ runner.temp }}/bun-install-cache
-      - name: download shared packages/*/dist
+          cache_key_prefix: bun-container
+      - uses: ./.github/actions/ci-download-packages-dist
         if: steps.content_hash.outputs.hit != 'true'
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: packages-dist
-          # Producer uploads .packages-dist-upload/packages → extract as packages/.
-          path: packages
-      - name: verify downloaded package dist entrypoints
-        if: steps.content_hash.outputs.hit != 'true'
-        shell: bash
-        run: |
-          set -euo pipefail
-          for path in \
-            packages/spec/dist/index.js \
-            packages/core/dist/index.js \
-            packages/svelte/dist/index.js; do
-            if [ ! -f "${path}" ]; then
-              echo "::error::packages-dist artifact missing ${path} after download"
-              find packages -maxdepth 3 -type d 2>/dev/null | head -40 || true
-              exit 1
-            fi
-          done
       - name: assert playwright npm/container version sync (root @playwright/test)
         if: steps.content_hash.outputs.hit != 'true'
         run: |
@@ -935,37 +802,11 @@ jobs:
           persist-credentials: false
       - name: install unzip (playwright image lacks it; setup-bun needs it)
         run: apt-get update && apt-get install -y --no-install-recommends unzip
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+      - uses: ./.github/actions/ci-setup-bun
+      - uses: ./.github/actions/ci-bun-install
         with:
-          bun-version: 1.3.14
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ${{ runner.temp }}/bun-install-cache
-          key: bun-container-${{ runner.os }}-${{ hashFiles('bun.lock') }}
-          restore-keys: bun-container-${{ runner.os }}-
-      - run: bun install --frozen-lockfile
-        env:
-          BUN_INSTALL_CACHE_DIR: ${{ runner.temp }}/bun-install-cache
-      - name: download shared packages/*/dist
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: packages-dist
-          # Producer uploads .packages-dist-upload/packages → extract as packages/.
-          path: packages
-      - name: verify downloaded package dist entrypoints
-        shell: bash
-        run: |
-          set -euo pipefail
-          for path in \
-            packages/spec/dist/index.js \
-            packages/core/dist/index.js \
-            packages/svelte/dist/index.js; do
-            if [ ! -f "${path}" ]; then
-              echo "::error::packages-dist artifact missing ${path} after download"
-              find packages -maxdepth 3 -type d 2>/dev/null | head -40 || true
-              exit 1
-            fi
-          done
+          cache_key_prefix: bun-container
+      - uses: ./.github/actions/ci-download-packages-dist
       - name: build docs for interaction performance fixtures
         run: DOCS_BUILD_MODE=legacy-full BASE_PATH=/ggsvelte bun run build:docs
       - name: interaction performance p50/p95 (informational — never fail the check)
@@ -1007,25 +848,17 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-        with:
-          bun-version: 1.3.14
+      - uses: ./.github/actions/ci-setup-bun
       - uses: ./.github/actions/ci-content-hash-restore
         id: content_hash
         with:
           execution: build
           bypass: ${{ needs.detect-changes.outputs.bypass_content_cache }}
           disable: ${{ vars.CI_DISABLE_CONTENT_HASH }}
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - uses: ./.github/actions/ci-bun-install
         if: steps.content_hash.outputs.hit != 'true'
         with:
-          path: ${{ runner.temp }}/bun-install-cache
-          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
-          restore-keys: bun-${{ runner.os }}-
-      - if: steps.content_hash.outputs.hit != 'true'
-        run: bun install --frozen-lockfile
-        env:
-          BUN_INSTALL_CACHE_DIR: ${{ runner.temp }}/bun-install-cache
+          cache_key_prefix: bun
       - name: build packages (tsc -b + svelte-package)
         if: steps.content_hash.outputs.hit != 'true'
         run: bun run build
@@ -1069,25 +902,17 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-        with:
-          bun-version: 1.3.14
+      - uses: ./.github/actions/ci-setup-bun
       - uses: ./.github/actions/ci-content-hash-restore
         id: content_hash
         with:
           execution: svelte_check
           bypass: ${{ needs.detect-changes.outputs.bypass_content_cache }}
           disable: ${{ vars.CI_DISABLE_CONTENT_HASH }}
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - uses: ./.github/actions/ci-bun-install
         if: steps.content_hash.outputs.hit != 'true'
         with:
-          path: ${{ runner.temp }}/bun-install-cache
-          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
-          restore-keys: bun-${{ runner.os }}-
-      - if: steps.content_hash.outputs.hit != 'true'
-        run: bun install --frozen-lockfile
-        env:
-          BUN_INSTALL_CACHE_DIR: ${{ runner.temp }}/bun-install-cache
+          cache_key_prefix: bun
       - name: build packages (svelte-check imports package types)
         if: steps.content_hash.outputs.hit != 'true'
         run: bun run build
@@ -1114,25 +939,17 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-        with:
-          bun-version: 1.3.14
+      - uses: ./.github/actions/ci-setup-bun
       - uses: ./.github/actions/ci-content-hash-restore
         id: content_hash
         with:
           execution: docs_site
           bypass: ${{ needs.detect-changes.outputs.bypass_content_cache }}
           disable: ${{ vars.CI_DISABLE_CONTENT_HASH }}
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - uses: ./.github/actions/ci-bun-install
         if: steps.content_hash.outputs.hit != 'true'
         with:
-          path: ${{ runner.temp }}/bun-install-cache
-          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
-          restore-keys: bun-${{ runner.os }}-
-      - if: steps.content_hash.outputs.hit != 'true'
-        run: bun install --frozen-lockfile
-        env:
-          BUN_INSTALL_CACHE_DIR: ${{ runner.temp }}/bun-install-cache
+          cache_key_prefix: bun
       - name: build packages (docs import workspace packages)
         if: steps.content_hash.outputs.hit != 'true'
         run: bun run build
@@ -1159,25 +976,17 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-        with:
-          bun-version: 1.3.14
+      - uses: ./.github/actions/ci-setup-bun
       - uses: ./.github/actions/ci-content-hash-restore
         id: content_hash
         with:
           execution: actions_security
           bypass: ${{ needs.detect-changes.outputs.bypass_content_cache }}
           disable: ${{ vars.CI_DISABLE_CONTENT_HASH }}
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - uses: ./.github/actions/ci-bun-install
         if: steps.content_hash.outputs.hit != 'true'
         with:
-          path: ${{ runner.temp }}/bun-install-cache
-          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
-          restore-keys: bun-${{ runner.os }}-
-      - if: steps.content_hash.outputs.hit != 'true'
-        run: bun install --frozen-lockfile
-        env:
-          BUN_INSTALL_CACHE_DIR: ${{ runner.temp }}/bun-install-cache
+          cache_key_prefix: bun
       - name: actionlint (lockfile-installed wasm build)
         if: steps.content_hash.outputs.hit != 'true'
         run: bun run lint:actions
@@ -1203,25 +1012,17 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-        with:
-          bun-version: 1.3.14
+      - uses: ./.github/actions/ci-setup-bun
       - uses: ./.github/actions/ci-content-hash-restore
         id: content_hash
         with:
           execution: bench_smoke
           bypass: ${{ needs.detect-changes.outputs.bypass_content_cache }}
           disable: ${{ vars.CI_DISABLE_CONTENT_HASH }}
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - uses: ./.github/actions/ci-bun-install
         if: steps.content_hash.outputs.hit != 'true'
         with:
-          path: ${{ runner.temp }}/bun-install-cache
-          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
-          restore-keys: bun-${{ runner.os }}-
-      - if: steps.content_hash.outputs.hit != 'true'
-        run: bun install --frozen-lockfile
-        env:
-          BUN_INSTALL_CACHE_DIR: ${{ runner.temp }}/bun-install-cache
+          cache_key_prefix: bun
       - name: build spec/core dist (benchmarks import the packages)
         if: steps.content_hash.outputs.hit != 'true'
         run: bun run check
@@ -1251,9 +1052,7 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-        with:
-          bun-version: 1.3.14
+      - uses: ./.github/actions/ci-setup-bun
       - name: refuse baseline-only / content-only-justified smoke baseline diffs
         env:
           # env-indirection: branch names / repo names are PR-controlled text
@@ -1305,9 +1104,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-        with:
-          bun-version: 1.3.14
+      - uses: ./.github/actions/ci-setup-bun
       - name: evaluate required jobs
         env:
           DETECT_RESULT: ${{ needs.detect-changes.result }}

--- a/scripts/ci-composites.test.ts
+++ b/scripts/ci-composites.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Characterization + contract tests for CI step-cluster composites extracted
+ * from ci.yml (packages-dist download/verify, setup-bun pin, bun-install cache).
+ */
+import { describe, expect, it } from "bun:test";
+import { readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+
+const root = join(import.meta.dir, "..");
+const read = (path: string) => readFileSync(join(root, path), "utf8");
+
+const SETUP_BUN = ".github/actions/ci-setup-bun/action.yml";
+const BUN_INSTALL = ".github/actions/ci-bun-install/action.yml";
+const DOWNLOAD_DIST = ".github/actions/ci-download-packages-dist/action.yml";
+
+/** Jobs that download the shared packages-dist artifact. */
+const PACKAGES_DIST_CONSUMERS = [
+  "consumer-compat",
+  "component-svelte",
+  "component-spikes",
+  "component-journeys",
+  "interaction-perf",
+] as const;
+
+/** Jobs that run setup-bun (every Linux CI job except pure aggregators that still set it up). */
+const SETUP_BUN_JOBS = [
+  "detect-changes",
+  "packages-dist",
+  "checks",
+  "unit",
+  "compatibility-matrix",
+  "consumer-compat",
+  "component-svelte",
+  "component-spikes",
+  "component-journeys",
+  "interaction-perf",
+  "build",
+  "svelte-check",
+  "docs-site",
+  "actions-security",
+  "bench-smoke",
+  "vr-baseline-guard",
+  "ci-gate",
+] as const;
+
+/** Jobs that use the cache+install composite (not consumer-compat — install without actions/cache). */
+const BUN_INSTALL_JOBS = [
+  "packages-dist",
+  "checks",
+  "unit",
+  "component-svelte",
+  "component-spikes",
+  "component-journeys",
+  "interaction-perf",
+  "build",
+  "svelte-check",
+  "docs-site",
+  "actions-security",
+  "bench-smoke",
+] as const;
+
+const CONTAINER_BUN_INSTALL_JOBS = new Set([
+  "component-svelte",
+  "component-spikes",
+  "component-journeys",
+  "interaction-perf",
+]);
+
+function jobSlice(ci: string, jobId: string): string {
+  const start = ci.indexOf(`  ${jobId}:\n`);
+  expect(start, `job ${jobId} missing`).toBeGreaterThan(-1);
+  const rest = ci.slice(start + 1);
+  const next = rest.search(/\n  [a-z0-9_-]+:\n/);
+  return next === -1 ? ci.slice(start) : ci.slice(start, start + 1 + next);
+}
+
+describe("ci-download-packages-dist composite", () => {
+  it("exists with pinned download-artifact and three dist entrypoint checks", () => {
+    expect(existsSync(join(root, DOWNLOAD_DIST))).toBe(true);
+    const action = read(DOWNLOAD_DIST);
+    expect(action).toContain("actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c");
+    expect(action).toContain("name: packages-dist");
+    expect(action).toContain("path: packages");
+    expect(action).toContain("packages/spec/dist/index.js");
+    expect(action).toContain("packages/core/dist/index.js");
+    expect(action).toContain("packages/svelte/dist/index.js");
+    expect(action).toContain("shell: bash");
+  });
+
+  it("is the sole packages-dist download path for the five consumer jobs", () => {
+    const ci = read(".github/workflows/ci.yml");
+    for (const jobId of PACKAGES_DIST_CONSUMERS) {
+      const job = jobSlice(ci, jobId);
+      expect(job, jobId).toContain("uses: ./.github/actions/ci-download-packages-dist");
+      // No inline download-artifact for packages-dist in the job body.
+      expect(job, jobId).not.toMatch(
+        /download-artifact@[0-9a-f]+[\s\S]{0,120}name:\s*packages-dist/,
+      );
+    }
+    // Exactly five uses in ci.yml.
+    const uses = ci.match(/uses: \.\/\.github\/actions\/ci-download-packages-dist/g) ?? [];
+    expect(uses.length).toBe(5);
+  });
+});
+
+describe("ci-setup-bun composite", () => {
+  it("exists as setup-bun only (no checkout — local composites need prior checkout)", () => {
+    expect(existsSync(join(root, SETUP_BUN))).toBe(true);
+    const action = read(SETUP_BUN);
+    expect(action).toContain("oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6");
+    expect(action).toContain("bun-version:");
+    expect(action).toContain("1.3.14");
+    expect(action).not.toContain("actions/checkout@");
+  });
+
+  it("is used by every CI job that previously inlined setup-bun", () => {
+    const ci = read(".github/workflows/ci.yml");
+    for (const jobId of SETUP_BUN_JOBS) {
+      const job = jobSlice(ci, jobId);
+      expect(job, jobId).toContain("uses: ./.github/actions/ci-setup-bun");
+      expect(job, jobId).not.toContain("oven-sh/setup-bun@");
+    }
+    // Inline setup-bun should be gone from ci.yml (lives in composite only).
+    expect(ci).not.toContain("oven-sh/setup-bun@");
+  });
+});
+
+describe("ci-bun-install composite", () => {
+  it("exists with private runner.temp cache + frozen install", () => {
+    expect(existsSync(join(root, BUN_INSTALL))).toBe(true);
+    const action = read(BUN_INSTALL);
+    expect(action).toContain("actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9");
+    expect(action).toContain("path: ${{ runner.temp }}/bun-install-cache");
+    expect(action).toContain("BUN_INSTALL_CACHE_DIR: ${{ runner.temp }}/bun-install-cache");
+    expect(action).toContain("bun install --frozen-lockfile");
+    expect(action).not.toContain("path: ~/.bun/install/cache");
+    // Host vs container key prefix via input.
+    expect(action).toMatch(/cache_key_prefix|cache-key-prefix/);
+  });
+
+  it("wires host vs container cache prefixes for the twelve cache+install jobs", () => {
+    const ci = read(".github/workflows/ci.yml");
+    for (const jobId of BUN_INSTALL_JOBS) {
+      const job = jobSlice(ci, jobId);
+      expect(job, jobId).toContain("uses: ./.github/actions/ci-bun-install");
+      if (CONTAINER_BUN_INSTALL_JOBS.has(jobId)) {
+        expect(job, jobId).toMatch(/cache_key_prefix:\s*bun-container/);
+      } else {
+        expect(job, jobId).toMatch(/cache_key_prefix:\s*bun\b/);
+      }
+    }
+    // consumer-compat keeps install without actions/cache (matrix OS diversity).
+    const consumer = jobSlice(ci, "consumer-compat");
+    expect(consumer).not.toContain("uses: ./.github/actions/ci-bun-install");
+    expect(consumer).toContain("bun install --frozen-lockfile");
+    expect(consumer).toContain("BUN_INSTALL_CACHE_DIR: ${{ runner.temp }}/bun-install-cache");
+  });
+});
+
+describe("Dependabot covers new CI composites", () => {
+  it("lists each composite directory under github-actions", () => {
+    const dependabot = read(".github/dependabot.yml");
+    for (const dir of [
+      '"/.github/actions/ci-content-hash-restore"',
+      '"/.github/actions/ci-content-hash-write"',
+      '"/.github/actions/ci-setup-bun"',
+      '"/.github/actions/ci-bun-install"',
+      '"/.github/actions/ci-download-packages-dist"',
+    ]) {
+      expect(dependabot).toContain(dir);
+    }
+  });
+});

--- a/scripts/release-wiring.test.ts
+++ b/scripts/release-wiring.test.ts
@@ -63,8 +63,9 @@ describe("R0 release wiring", () => {
     expect(ci).toContain("mcr.microsoft.com/playwright:v1.61.1-noble");
     expect(ci).toContain("HOME: /root");
     // Package browser shards download packages/*/dist (issue #241); no monorepo rebuild.
+    // Download+verify lives in ci-download-packages-dist (pin + entrypoint checks).
     for (const job of [svelteJob, spikesJob]) {
-      expect(job).toContain("download-artifact");
+      expect(job).toContain("uses: ./.github/actions/ci-download-packages-dist");
       expect(job).toContain("packages-dist");
       expect(job).not.toContain("run: bun run build\n");
     }
@@ -72,7 +73,7 @@ describe("R0 release wiring", () => {
     expect(spikesJob).toContain("working-directory: spikes/browser");
     // Journeys: docs_journeys routing + full non-pixel inventory; may build docs site.
     expect(journeysJob).toContain("docs_journeys == 'true'");
-    expect(journeysJob).toContain("download-artifact");
+    expect(journeysJob).toContain("uses: ./.github/actions/ci-download-packages-dist");
     expect(journeysJob).toContain("packages-dist");
     expect(journeysJob).toContain("bun run build:docs");
     expect(journeysJob).not.toContain("bun run test:interaction-perf");
@@ -93,7 +94,7 @@ describe("R0 release wiring", () => {
     expect(interactionPerfJob).not.toContain("needs: [component]");
     expect(interactionPerfJob).toContain("informational");
     expect(interactionPerfJob).toContain("interaction_perf == 'true'");
-    expect(interactionPerfJob).toContain("download-artifact");
+    expect(interactionPerfJob).toContain("uses: ./.github/actions/ci-download-packages-dist");
     expect(interactionPerfJob).toContain("packages-dist");
     expect(bench).toContain("mcr.microsoft.com/playwright:v1.61.1-noble");
     expect(bench).toContain("bun run test:interaction-perf");
@@ -116,12 +117,12 @@ describe("R0 release wiring", () => {
     expect(producerJob).toContain("packages/core/dist");
     expect(producerJob).toContain("packages/svelte/dist");
     expect(producerJob).toContain("run: bun run build");
-    // Consumers download instead of rebuilding packages.
+    // Consumers download instead of rebuilding packages (via composite).
     const consumerJob = ci.slice(
       ci.indexOf("  consumer-compat:\n    name: packed consumer"),
       ci.indexOf("  component-svelte:\n    name: component-svelte"),
     );
-    expect(consumerJob).toContain("download-artifact");
+    expect(consumerJob).toContain("uses: ./.github/actions/ci-download-packages-dist");
     expect(consumerJob).toContain("packages-dist");
     expect(consumerJob).not.toContain("run: bun run build");
     // Unit and bench-smoke keep the cheaper bun run check path (Codex plan review).
@@ -336,6 +337,9 @@ describe("R0 release wiring", () => {
     // github-actions "/" only covers workflows; composites need their own dirs.
     expect(dependabot).toContain('"/.github/actions/ci-content-hash-restore"');
     expect(dependabot).toContain('"/.github/actions/ci-content-hash-write"');
+    expect(dependabot).toContain('"/.github/actions/ci-setup-bun"');
+    expect(dependabot).toContain('"/.github/actions/ci-bun-install"');
+    expect(dependabot).toContain('"/.github/actions/ci-download-packages-dist"');
     // Human-authored locksteps / Changesets-owned internal ranges.
     expect(dependabot).toContain('dependency-name: "playwright"');
     expect(dependabot).toContain('dependency-name: "@playwright/test"');
@@ -518,6 +522,13 @@ it("uses job-private Bun caches in self-hosted workflows (issue #319)", () => {
       bunCacheKeys.length,
     );
   }
+
+  // Shared install composite (ci.yml) must keep the private-cache protocol.
+  const bunInstall = read(".github/actions/ci-bun-install/action.yml");
+  expect(bunInstall).toContain("bun install --frozen-lockfile");
+  expect(bunInstall).toContain("path: ${{ runner.temp }}/bun-install-cache");
+  expect(bunInstall).toContain("BUN_INSTALL_CACHE_DIR: ${{ runner.temp }}/bun-install-cache");
+  expect(bunInstall).not.toContain("path: ~/.bun/install/cache");
 
   // Consumer fixtures run their own package-manager install from a later step,
   // so that step must receive the cache env independently of the root install.


### PR DESCRIPTION
## Summary

`.github/workflows/ci.yml` had grown to ~1.4k lines with the same step clusters pasted across 17 jobs (setup-bun pin, private Bun install cache, packages-dist download + entrypoint verify). That made pin bumps and packages-dist contract fixes multi-site edits.

This PR extracts three local composite actions (same pattern as the existing content-hash composites), keeps checkout **outside** composites (local actions load from the workspace), and leaves job names / `needs` / routing / content-hash topology unchanged.

### What changed

| Composite | Role |
|-----------|------|
| `.github/actions/ci-setup-bun` | SHA-pinned `oven-sh/setup-bun` + Bun version (17 call sites) |
| `.github/actions/ci-bun-install` | Job-private `runner.temp` cache + frozen install; host vs container key prefix (12 call sites; consumer-compat stays inline without `actions/cache`) |
| `.github/actions/ci-download-packages-dist` | Download `packages-dist` artifact + verify three dist entrypoints (5 call sites) |

Also:
- Dependabot `github-actions` directories for the three new composites
- Characterization tests in `scripts/ci-composites.test.ts`
- release-wiring updates for composite download path + #319 private-cache coverage of `ci-bun-install`

`ci.yml` went from **1412 → 1209** lines without changing job topology.

### Audit target / candidate

- **Target:** `.github/workflows/ci.yml`
- **Chosen fix:** step-cluster composites (not reusable workflows — those rename required checks)

### Verification

```text
bun test scripts/ci-composites.test.ts scripts/release-wiring.test.ts scripts/actionlint.test.ts scripts/ci-routing.test.ts
# 102 pass

bun run lint:actions          # 14 workflows clean
uvx zizmor .github/workflows  # no findings
uvx zizmor .github/actions    # no findings
pre-push (build, svelte-check, type-aware, knip, unit, actionlint, zizmor) passed on push
```

## Follow-ups

- https://github.com/ljodea/ggsvelte/issues/392 — domain job split without renaming required checks
- https://github.com/ljodea/ggsvelte/issues/393 — extract `detect-changes` bash into `scripts/`

## Test plan

- [x] Local characterization + release-wiring + actionlint + ci-routing tests
- [x] actionlint / zizmor clean
- [ ] CI green on this PR (workflow-only change schedules actions-security + unit)