### PR TITLE
fix(docs): keep local CSP on HTTP

### DIFF
--- a/apps/docs/csp.ts
+++ b/apps/docs/csp.ts
@@ -1,0 +1,24 @@
+import type { DocsBuildConfig } from "./build-mode";
+
+export function docsCspDirectives(mode: DocsBuildConfig["mode"]) {
+  return {
+    "default-src": ["self"],
+    "base-uri": ["self"],
+    "connect-src": ["self", "https://cloudflareinsights.com"],
+    "font-src": ["self"],
+    "form-action": ["self"],
+    "frame-src": ["none"],
+    "img-src": ["self", "data:"],
+    "manifest-src": ["self"],
+    "media-src": ["self"],
+    "object-src": ["none"],
+    "script-src": ["self", "https://static.cloudflareinsights.com"],
+    "script-src-attr": ["none"],
+    "style-src": ["self"],
+    // Chart layout and palette values are bounded application output, not
+    // executable code. Keep this exception scoped to style attributes;
+    // inline style elements remain hash-only.
+    "style-src-attr": ["unsafe-inline"],
+    ...(mode === "dev" ? {} : { "upgrade-insecure-requests": true }),
+  } as const;
+}

--- a/apps/docs/svelte.config.js
+++ b/apps/docs/svelte.config.js
@@ -2,6 +2,7 @@ import adapter from "@sveltejs/adapter-static";
 import { vitePreprocess } from "@sveltejs/vite-plugin-svelte";
 
 import { resolveDocsBuildConfig } from "./build-mode.ts";
+import { docsCspDirectives } from "./csp.ts";
 
 const build = resolveDocsBuildConfig({
   mode: process.env.DOCS_BUILD_MODE,
@@ -16,26 +17,7 @@ export default {
     paths: { base: build.base },
     csp: {
       mode: "hash",
-      directives: {
-        "default-src": ["self"],
-        "base-uri": ["self"],
-        "connect-src": ["self", "https://cloudflareinsights.com"],
-        "font-src": ["self"],
-        "form-action": ["self"],
-        "frame-src": ["none"],
-        "img-src": ["self", "data:"],
-        "manifest-src": ["self"],
-        "media-src": ["self"],
-        "object-src": ["none"],
-        "script-src": ["self", "https://static.cloudflareinsights.com"],
-        "script-src-attr": ["none"],
-        "style-src": ["self"],
-        // Chart layout and palette values are bounded application output, not
-        // executable code. Keep this exception scoped to style attributes;
-        // inline style elements remain hash-only.
-        "style-src-attr": ["unsafe-inline"],
-        "upgrade-insecure-requests": true,
-      },
+      directives: docsCspDirectives(build.mode),
     },
     prerender: {
       handleMissingId: ({ id, message }) => {

--- a/scripts/docs-csp.test.ts
+++ b/scripts/docs-csp.test.ts
@@ -113,6 +113,13 @@ describe("docs CSP validation", () => {
 
     writeFileSync(
       join(directory, "index.html"),
+      `<meta http-equiv="content-security-policy" content="${policy.replace("; upgrade-insecure-requests", "")}">`,
+    );
+    expect(validateDocsCsp(directory)).toContain("index.html: missing upgrade-insecure-requests");
+    expect(validateDocsCsp(directory, { requireUpgradeInsecureRequests: false })).toEqual([]);
+
+    writeFileSync(
+      join(directory, "index.html"),
       `<meta http-equiv="content-security-policy" content="${policy.replace("object-src 'none'; ", "")}">`,
     );
     expect(validateDocsCsp(directory)).toContain("index.html: object-src must include 'none'");

--- a/scripts/docs-csp.test.ts
+++ b/scripts/docs-csp.test.ts
@@ -3,9 +3,22 @@ import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import { docsCspDirectives } from "../apps/docs/csp";
 import { validateDocsCsp, validateHtmlCsp } from "./docs-csp";
 
 describe("docs CSP validation", () => {
+  it("upgrades insecure requests only for HTTPS publication modes", () => {
+    expect(docsCspDirectives("dev")).not.toHaveProperty("upgrade-insecure-requests");
+    for (const mode of [
+      "legacy-full",
+      "cloudflare-preview",
+      "cloudflare-production",
+      "legacy-migration",
+    ] as const) {
+      expect(docsCspDirectives(mode)).toHaveProperty("upgrade-insecure-requests", true);
+    }
+  });
+
   it("keeps visual determinism compatible with enforced style-element CSP", () => {
     const helper = readFileSync(
       join(import.meta.dir, "..", "tests", "visual", "helpers", "deterministic.ts"),

--- a/scripts/docs-csp.ts
+++ b/scripts/docs-csp.ts
@@ -111,7 +111,11 @@ const NOT_FOUND_DIRECTIVES = {
   "style-src-attr": ["'none'"],
 } as const;
 
-function validateRequiredDirectives(path: string, html: string): string[] {
+function validateRequiredDirectives(
+  path: string,
+  html: string,
+  requireUpgradeInsecureRequests: boolean,
+): string[] {
   const policy = cspPolicy(html);
   if (policy === null) return [];
   const parsed = directives(policy);
@@ -127,7 +131,7 @@ function validateRequiredDirectives(path: string, html: string): string[] {
       }
     }
   }
-  if (!parsed.has("upgrade-insecure-requests")) {
+  if (requireUpgradeInsecureRequests && !parsed.has("upgrade-insecure-requests")) {
     problems.push(`${path}: missing upgrade-insecure-requests`);
   }
   return problems;
@@ -142,8 +146,16 @@ function htmlFiles(directory: string): string[] {
     .filter((path) => path.endsWith(".html"));
 }
 
-export function validateDocsCsp(directory: string): string[] {
+export interface DocsCspValidationOptions {
+  readonly requireUpgradeInsecureRequests?: boolean;
+}
+
+export function validateDocsCsp(
+  directory: string,
+  options: DocsCspValidationOptions = {},
+): string[] {
   const problems: string[] = [];
+  const requireUpgradeInsecureRequests = options.requireUpgradeInsecureRequests ?? true;
   const headers = readFileSync(join(directory, "_headers"), "utf8");
   if (!/^\s*Content-Security-Policy:\s*frame-ancestors 'none'\s*$/im.test(headers)) {
     problems.push("_headers: missing enforced frame-ancestors 'none' policy");
@@ -156,7 +168,7 @@ export function validateDocsCsp(directory: string): string[] {
     const html = readFileSync(path, "utf8");
     problems.push(
       ...validateHtmlCsp(relativePath, html),
-      ...validateRequiredDirectives(relativePath, html),
+      ...validateRequiredDirectives(relativePath, html, requireUpgradeInsecureRequests),
     );
   }
   return problems;
@@ -164,7 +176,9 @@ export function validateDocsCsp(directory: string): string[] {
 
 if (import.meta.main) {
   const directory = process.argv[2] ?? join(import.meta.dir, "..", "apps", "docs", "build");
-  const problems = validateDocsCsp(directory);
+  const problems = validateDocsCsp(directory, {
+    requireUpgradeInsecureRequests: (process.env["DOCS_BUILD_MODE"] ?? "dev") !== "dev",
+  });
   if (problems.length > 0) {
     throw new Error(`Docs CSP validation failed:\n- ${problems.join("\n- ")}`);
   }


### PR DESCRIPTION
## Summary

- keep `upgrade-insecure-requests` enabled for every HTTPS publication mode
- omit it only from local `vite dev`, preventing localhost HTTP/WebSocket upgrades
- centralize the mode-aware CSP directives and cover the complete mode matrix

Follow-up to #391 and its Codex review finding.

## Verification

- `bun test scripts/docs-csp.test.ts`
- `bun run check:docs`
- type-aware lint and formatting checks
- unqualified `bun run build:docs` (dev mode)
- `DOCS_BUILD_MODE=cloudflare-preview bun run build:docs`
- live `vite dev` check: app served over HTTP with enforced CSP and no `upgrade-insecure-requests`
- full pre-push verification passed

## Release metadata

No Changeset: this changes only the private documentation application configuration.
