### PR TITLE
fix: nuke multi-minute pre-push hook mega-suite

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,21 +1,18 @@
 # ggsvelte hooks (python pre-commit framework — plan M0b).
 #
-# pre-commit stage: sub-second — format staged files, lint staged files,
-# path guards. pre-push stage: the heavier roster (type-aware lint,
-# svelte-check, tsc -b, knip, package tests). CI runs BOTH stages via
-# `pre-commit run --all-files` for parity; CI is the contract, local hooks
-# are the mirror.
+# pre-commit stage only: sub-second — format staged files, lint staged files,
+# path guards. Heavy work (build, type-aware lint, svelte-check, knip, package
+# tests, actionlint/zizmor) lives in CI — never on the git push hook.
 #
 # All hooks are repo-local and invoke lockfile-installed binaries through
 # `bun` / `bun run` (never network bunx). `bun` must be on PATH
 # (see CONTRIBUTING.md, including the arm64/x64 note).
-default_install_hook_types: [pre-commit, pre-push]
+default_install_hook_types: [pre-commit]
 default_stages: [pre-commit]
 
 repos:
   - repo: local
     hooks:
-      # ---- pre-commit stage (fast, staged files only) ----
       - id: oxfmt
         name: oxfmt (staged)
         entry: bun node_modules/.bin/oxfmt
@@ -64,87 +61,3 @@ repos:
         # VR baselines (tests/visual/__screenshots__) land only via the
         # audited vr-update/pr-N branch. The hook checks the staged diff so
         # clean committed baselines do not break `pre-commit run --all-files`.
-
-      # ---- pre-push stage (all files) ----
-      # package-build runs FIRST: since M0c the package exports point at
-      # dist/, so svelte-check, type-aware lint, docs check, and
-      # cross-package bun tests all resolve @ggsvelte/*/ggsvelte through the
-      # emitted dist/ (tsc -b for spec/core + svelte-package for ggsvelte —
-      # the docs app and the examples corpus import the built ggsvelte).
-      - id: package-build
-        name: build packages (tsc -b + svelte-package)
-        entry: bun run build
-        language: system
-        pass_filenames: false
-        always_run: true
-        stages: [pre-push]
-
-      - id: docs-check
-        name: svelte-check (apps/docs) — also syncs .svelte-kit, which the
-          type-aware lint's apps/docs tsconfig extends; keep it BEFORE
-          oxlint-type-aware
-        entry: bun run check:docs
-        language: system
-        pass_filenames: false
-        always_run: true
-        stages: [pre-push]
-
-      - id: oxlint-type-aware
-        name: oxlint --type-aware (all files)
-        entry: bun run lint:type-aware
-        language: system
-        pass_filenames: false
-        always_run: true
-        stages: [pre-push]
-
-      - id: svelte-check
-        name: svelte-check (packages/svelte)
-        entry: bun run check:svelte
-        language: system
-        pass_filenames: false
-        always_run: true
-        stages: [pre-push]
-
-      - id: examples-typecheck
-        name: tsc -p examples (corpus .ts files; needs dist from package-build)
-        entry: bun run check:examples
-        language: system
-        pass_filenames: false
-        always_run: true
-        stages: [pre-push]
-
-      - id: knip
-        name: knip (unused files/exports/deps)
-        entry: bun run knip
-        language: system
-        pass_filenames: false
-        always_run: true
-        stages: [pre-push]
-
-      - id: bun-test-packages
-        name: bun test (spec + core + benchmarks + scripts + evals harness; svelte runs under vitest browser mode)
-        entry: bun test packages/spec packages/core benchmarks scripts tests/evals
-        language: system
-        pass_filenames: false
-        always_run: true
-        stages: [pre-push]
-
-      # Workflow lint: only when .github/** is in the push set (or --all-files).
-      # actionlint uses the lockfile wasm build; skips gracefully if it cannot
-      # load. zizmor is an optional uv tool — skip if missing. CI still runs
-      # both in the dedicated actions-security job (contract, not optional).
-      - id: actionlint
-        name: actionlint (.github/workflows)
-        entry: bun run lint:actions
-        language: system
-        pass_filenames: false
-        files: ^\.github/
-        stages: [pre-push]
-
-      - id: zizmor
-        name: zizmor (.github/workflows security)
-        entry: scripts/guards/zizmor-or-skip.sh
-        language: system
-        pass_filenames: false
-        files: ^\.github/
-        stages: [pre-push]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ tested support boundaries and what information helps the community respond.
    ```sh
    uv tool install pre-commit   # or pipx install pre-commit / brew install pre-commit
    uv tool install zizmor       # GitHub Actions security auditor (Rust, shipped via PyPI)
-   pre-commit install           # installs BOTH the pre-commit and pre-push git hooks
+   pre-commit install           # installs the fast pre-commit hook only (no pre-push)
    ```
 
 4. **Playwright browsers** (needed for component tests, the VR suite, and
@@ -154,18 +154,18 @@ ignored — land those as deliberate migrations.
 | `Rscript packages/core/tests/fixtures/*/generate.R`   | regenerate the ggplot2-parity fixtures (grouping, stats/positions; needs R + ggplot2)                                                             |
 | `bun run knip`                                        | unused files/exports/dependencies                                                                                                                 |
 | `bun run lint:package`                                | publint + attw (esm-only profile) over built packages — build first                                                                               |
-| `bun run lint:actions`                                | actionlint (wasm) over `.github/workflows` (also pre-push when `.github/**` changes; local soft-skip if wasm cannot load, fatal in CI)            |
-| `bun run lint:actions:security`                       | zizmor over `.github/workflows` (needs `uv tool install zizmor`; pre-push skips if missing)                                                       |
+| `bun run lint:actions`                                | actionlint (wasm) over `.github/workflows` (local soft-skip if wasm cannot load; fatal in CI actions-security job)                                |
+| `bun run lint:actions:security`                       | zizmor over `.github/workflows` (needs `uv tool install zizmor`; CI runs it in actions-security)                                                  |
 | `bun run test:spikes`                                 | retired M0a browser/ssr spike suites (vitest 4 browser mode)                                                                                      |
 | `cd spikes/pure && bun test`                          | retired M0a pure spike suites                                                                                                                     |
-| `pre-commit run --all-files`                          | everything the pre-commit stage runs                                                                                                              |
-| `pre-commit run --all-files --hook-stage pre-push`    | everything the pre-push stage runs (tsc-build runs first — later hooks need dist/)                                                                |
+| `pre-commit run --all-files`                          | fast staged-file parity (oxfmt/prettier/oxlint/markdownlint/manifest/path guards)                                                                 |
 
-CI (`.github/workflows/ci.yml`) runs a `checks` job with exact pre-commit
-parity (both stages) plus unit / component / build / actions-security /
-bench-smoke jobs. **CI is the contract; the git hooks are a convenience
-mirror.** If pre-push ever feels too slow, checks move to CI-required — they
-are never disabled.
+CI (`.github/workflows/ci.yml`) runs a `checks` job for pre-commit parity
+plus unit / component / build / actions-security / bench-smoke jobs.
+**CI is the contract.** Local git hooks are commit-only and sub-second;
+there is no pre-push mega-suite (build, type-aware lint, svelte-check, knip,
+package tests all live in CI). If an old clone still has a pre-push hook,
+remove it with `pre-commit uninstall -t pre-push` then `pre-commit install`.
 
 ### Path routing + content-hash skip
 
@@ -426,7 +426,7 @@ Consequences:
 
 - Run `bun run check` after a fresh clone before `bun run test`,
   `check:svelte`, or `lint:type-aware` — cross-package imports resolve
-  through `dist/`. The pre-push hooks and CI jobs already sequence this.
+  through `dist/`. CI jobs already sequence this.
 - `@ggsvelte/spec`: TypeBox schemas (decision 0004) + `Static<>` types,
   `normalize()`, tier-1 `validate()` with the agent error contract, the
   `gg()/aes()` builder, portability (`isPortable`/`toPortable`/
@@ -449,9 +449,9 @@ plus the VR-and-examples workstream (decision 0009): the `examples/` corpus
 and generated `examples/manifest.ts`, the `apps/docs` SvelteKit +
 adapter-static site, `<GGPlot>`'s `data-gg-ready` readiness signal, the
 `tests/visual` Playwright suite, and a real (un-guarded) `vr-compare.yml`.
-Pre-push consequence: the first hook is now **package-build**
-(`bun run build`, not just `tsc -b`) because docs/examples checks import the
-built `@ggsvelte/svelte` package.
+CI consequence: build jobs run **package-build** (`bun run build`, not just
+`tsc -b`) before docs/examples checks because those imports resolve through
+the built `@ggsvelte/svelte` package.
 
 ## Milestone context (M2 — statistical layer)
 

--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -1,6 +1,6 @@
 {
   // Type-checks the corpus's .ts files (spec.ts / data.ts / define.ts /
-  // manifest.ts) via `bun run check:examples` (pre-push + CI parity).
+  // manifest.ts) via `bun run check:examples` (CI / manual).
   // Example.svelte files are compiled and checked by the docs app
   // (apps/docs svelte-check + vite build). Requires `bun run check` +
   // `bun run build` first: imports resolve through the packages' dist/.

--- a/scripts/actionlint.test.ts
+++ b/scripts/actionlint.test.ts
@@ -115,29 +115,18 @@ describe("actionlint load-failure policy (Codex P1)", () => {
   });
 });
 
-describe("workflow lint local gates (issue #155)", () => {
-  it("wires actionlint into the pre-push stage, gated on .github/", () => {
+describe("workflow lint gates (issue #155)", () => {
+  it("does not wire actionlint/zizmor into git hooks (CI owns them)", () => {
     const hooks = read(".pre-commit-config.yaml");
-    expect(hooks).toMatch(/id:\s*actionlint/);
-    expect(hooks).toContain("bun run lint:actions");
-    expect(hooks).toMatch(/files:\s*\^\\.github\//);
-    // actionlint hook must be pre-push, not pre-commit (heavier, CI-parity).
-    const actionlintBlock = hooks.slice(hooks.indexOf("id: actionlint"));
-    const nextHook = actionlintBlock.indexOf("\n      - id:");
-    const block = nextHook === -1 ? actionlintBlock : actionlintBlock.slice(0, nextHook);
-    expect(block).toContain("stages: [pre-push]");
+    // Heavy workflow lint lives in the actions-security CI job only.
+    // Local pre-push was nuked: it made every push a multi-minute CI mirror.
+    expect(hooks).not.toMatch(/id:\s*actionlint/);
+    expect(hooks).not.toMatch(/id:\s*zizmor/);
+    expect(hooks).not.toContain("stages: [pre-push]");
+    expect(hooks).not.toContain("pre-push");
   });
 
-  it("wires zizmor into the pre-push stage with a graceful skip wrapper", () => {
-    const hooks = read(".pre-commit-config.yaml");
-    expect(hooks).toMatch(/id:\s*zizmor/);
-    expect(hooks).toContain("scripts/guards/zizmor-or-skip.sh");
-    const zizmorBlock = hooks.slice(hooks.indexOf("id: zizmor"));
-    const nextHook = zizmorBlock.indexOf("\n      - id:");
-    const block = nextHook === -1 ? zizmorBlock : zizmorBlock.slice(0, nextHook);
-    expect(block).toContain("stages: [pre-push]");
-    expect(block).toMatch(/files:\s*\^\\.github\//);
-
+  it("keeps the zizmor optional-skip guard for manual local runs", () => {
     const guard = read("scripts/guards/zizmor-or-skip.sh");
     expect(guard).toContain("command -v zizmor");
     expect(guard).toContain("skipping local gate");

--- a/scripts/actionlint.ts
+++ b/scripts/actionlint.ts
@@ -12,9 +12,9 @@
  * "label is unknown" suppressions from it so the two cannot drift.
  *
  * Load/init failures: fatal under CI (`CI` / `GITHUB_ACTIONS`), soft-skip only
- * on local machines (arch mismatch, missing wasm). The pre-push hook and the
- * required `actions-security` job both call this script; CI must never green
- * on a silent skip.
+ * on local machines (arch mismatch, missing wasm). The required
+ * `actions-security` CI job calls this script; CI must never green on a
+ * silent skip.
  *
  * Usage: bun scripts/actionlint.ts [files...]
  */
@@ -25,7 +25,7 @@ const ACTIONLINT_YAML = ".github/actionlint.yaml";
 
 /**
  * Soft-skip wasm load failures only outside CI. GitHub Actions sets both
- * `CI=true` and `GITHUB_ACTIONS=true`; local pre-push has neither.
+ * `CI=true` and `GITHUB_ACTIONS=true`; local manual runs have neither.
  */
 export function allowSoftSkipLoadFailure(env: NodeJS.ProcessEnv = process.env): boolean {
   return env.CI !== "true" && env.GITHUB_ACTIONS !== "true";

--- a/scripts/guards/zizmor-or-skip.sh
+++ b/scripts/guards/zizmor-or-skip.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# pre-push guard: run zizmor over .github/workflows when installed; skip
+# Optional local guard: run zizmor over .github/workflows when installed; skip
 # gracefully when the binary is missing so developers without the uv tool
 # are not blocked. CI's actions-security job always runs a pinned zizmor.
 set -euo pipefail

--- a/scripts/release-wiring.test.ts
+++ b/scripts/release-wiring.test.ts
@@ -20,9 +20,10 @@ const heavyRunsOnCount = (workflow: string) =>
     .length;
 
 describe("R0 release wiring", () => {
-  it("runs benchmark unit tests in CI and pre-push parity", () => {
+  it("runs benchmark unit tests in CI (not on git push hooks)", () => {
     const ci = read(".github/workflows/ci.yml");
-    // CI collects lcov for Codecov; pre-push stays plain (no coverage overhead).
+    // CI collects lcov for Codecov. Package tests are CI-only — pre-push was
+    // nuked so agents can push without re-running the full unit suite locally.
     expect(ci).toContain("packages/spec packages/core benchmarks scripts tests/evals");
     expect(ci).toContain("--coverage-reporter=lcov");
     expect(ci).toContain("coverage/unit");
@@ -30,9 +31,8 @@ describe("R0 release wiring", () => {
     expect(ci).toContain("flags: unit");
     expect(ci).toContain("flags: svelte");
     expect(read("codecov.yml")).toContain("component_id: packages-spec");
-    expect(read(".pre-commit-config.yaml")).toContain(
-      "bun test packages/spec packages/core benchmarks scripts tests/evals",
-    );
+    expect(read(".pre-commit-config.yaml")).not.toContain("bun test packages/spec");
+    expect(read(".pre-commit-config.yaml")).not.toContain("pre-push");
   });
 
   it("checks packed links in CI and the Pages deployment", () => {
@@ -295,12 +295,13 @@ describe("R0 release wiring", () => {
     expect(ci).toContain("scripts/ci-routing.ts emit-github-output");
     expect(ci).toContain("  detect-changes:");
     expect(ci).toContain("  ci-gate:");
-    // Pre-push mega-suite must not double-run on the checks job.
+    // Checks job is pre-commit stage only (format/lint/guards). Heavy analysis
+    // lives on dedicated CI jobs — never reintroduced via hook-stage pre-push.
     expect(ci).not.toContain("hook-stage pre-push");
     expect(ci).toContain("pre-commit run --all-files --show-diff-on-failure");
-    // Static analysis formerly on pre-push now lives on the build job.
     expect(ci).toContain("bun run lint:type-aware");
     expect(ci).toContain("bun run knip");
+    expect(read(".pre-commit-config.yaml")).not.toContain("pre-push");
     expect(read(".github/workflows/pages.yml")).toContain(
       "scripts/ci-routing.ts emit-github-output",
     );


### PR DESCRIPTION
## Summary
- Removes the entire **pre-push** stage from `.pre-commit-config.yaml` (build, svelte-check ×2, type-aware oxlint, knip, full package tests, actionlint/zizmor).
- Local hooks are **commit-only** and staged-file scoped; CI remains the contract for heavy checks.
- Updates wiring tests and CONTRIBUTING to match. Existing clones: `pre-commit uninstall -t pre-push && pre-commit install`.

## Why
Every agent `git push` / PR open was a multi-minute local CI mirror because every heavy hook had `always_run: true`. That is obtuse; CI already runs these jobs.

## Test plan
- [x] `bun test scripts/actionlint.test.ts scripts/release-wiring.test.ts`
- [x] `pre-commit uninstall -t pre-push` + `pre-commit install` leaves only pre-commit hook
- [ ] CI green on this PR (checks + unit + build still own heavy gates)