### PR TITLE
docs: put the playground chart first and strip detritus

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -15,6 +15,7 @@
     "@ggsvelte/examples": "workspace:*",
     "@ggsvelte/spec": "workspace:*",
     "@ggsvelte/svelte": "workspace:*",
+    "bits-ui": "^2.18.1",
     "phosphor-svelte": "^3.1.0",
     "svelte-highlight": "^7.16.0"
   },

--- a/apps/docs/src/lib/Playground.svelte
+++ b/apps/docs/src/lib/Playground.svelte
@@ -10,6 +10,7 @@
   import PlaygroundOutput from "$lib/components/PlaygroundOutput.svelte";
   import PlaygroundPreview from "$lib/components/PlaygroundPreview.svelte";
   import PlaygroundShell from "$lib/components/PlaygroundShell.svelte";
+  import UiButton from "$lib/components/UiButton.svelte";
   import {
     PLAYGROUND_EXAMPLES,
     PLAYGROUND_SAMPLES,
@@ -55,10 +56,6 @@
   let shareUrl = $state("");
   let shareStatus = $state("");
   let shareSource = $state<HTMLElement>();
-  let reportSource = $state<HTMLElement>();
-  let reportStatus = $state("");
-  let scaleDecisions = $state<RenderModel["scaleDecisions"]>([]);
-  let guidePlans = $state<RenderModel["guidePlans"]>([]);
   let events = $state<readonly PlaygroundEventEntry[]>([]);
   let lifecycleTracker = $state(createCandidateLifecycleTracker());
 
@@ -106,7 +103,6 @@
   }
 
   const outputs = $derived(playgroundOutputs(workbench.committed));
-  const scaleReport = $derived(privacySafeScaleReport());
   const selectedSample = $derived(
     workbench.seed.source.kind === "sample" ? workbench.seed.source.id : "",
   );
@@ -290,9 +286,6 @@
       phase: "promoted",
       status: promoted.status,
     });
-    scaleDecisions = [];
-    guidePlans = [];
-    reportStatus = "";
     events = [];
     if (
       (origin === "apply" ||
@@ -327,11 +320,8 @@
     }
   }
 
-  function activeRendered(model: RenderModel): void {
+  function activeRendered(_model: RenderModel): void {
     workbench = confirmPlaygroundRendered(workbench);
-    scaleDecisions = model.scaleDecisions;
-    guidePlans = model.guidePlans;
-    reportStatus = "";
   }
 
   function recordInteraction(event: PlaygroundInteractionEvent): void {
@@ -339,9 +329,6 @@
   }
 
   function activeFailed(diagnostic: PlaygroundDiagnostic): void {
-    scaleDecisions = [];
-    guidePlans = [];
-    reportStatus = "";
     const previous = activeCandidate();
     workbench = reportPlaygroundDiagnostic(
       workbench,
@@ -359,63 +346,6 @@
     }
   }
 
-  function privacySafeScaleReport(): string {
-    return JSON.stringify(
-      {
-        decisions: scaleDecisions.map((decision) => ({
-          aesthetic: decision.aesthetic,
-          status: decision.status,
-          parser: decision.parser,
-          kind: decision.kind,
-          precision: decision.precision,
-          validatedCount: decision.validatedCount,
-          ambiguityCount: decision.ambiguity.length,
-          portableOverride: {
-            ...(decision.portableOverride.type !== undefined && {
-              type: decision.portableOverride.type,
-            }),
-            ...(decision.portableOverride.temporalKind !== undefined && {
-              temporalKind: decision.portableOverride.temporalKind,
-            }),
-            ...(decision.portableOverride.parse !== undefined && {
-              parse: decision.portableOverride.parse,
-            }),
-          },
-          guidePlanIds: decision.guidePlanIds ?? [],
-        })),
-        guides: guidePlans.map((guide) => ({
-          id: guide.id,
-          aesthetic: guide.aesthetic,
-          panelIndex: guide.panelIndex,
-          scaleType: guide.scaleType,
-          temporalKind: guide.temporalKind,
-          source: guide.source,
-          interval: guide.interval,
-          locale: guide.locale,
-          timezone: guide.timezone,
-          majorCount: guide.ticks.filter((entry) => entry.kind === "major")
-            .length,
-          minorCount: guide.ticks.filter((entry) => entry.kind === "minor")
-            .length,
-          overlap: guide.overlap,
-          marginOverflow: guide.marginOverflow,
-          degraded: guide.degraded,
-        })),
-      },
-      null,
-      2,
-    );
-  }
-
-  async function copyScaleReport(): Promise<void> {
-    if (reportSource === undefined) return;
-    const result = await copyText(scaleReport, reportSource);
-    reportStatus =
-      result === "copied"
-        ? "Copied a privacy-safe scale report without rows, field names, domains, or labels."
-        : "Clipboard unavailable. The privacy-safe scale report is selected for manual copy.";
-  }
-
   async function share(): Promise<void> {
     if (!workbench.canCopyOrShare) return;
     const hash = encodePlaygroundSeed(workbench.seed);
@@ -428,33 +358,21 @@
     if (shareSource === undefined) return;
     const result = await copyText(shareUrl, shareSource);
     shareStatus =
-      result === "copied"
-        ? "Share link copied. The PortableSpec is now in this URL and browser history."
-        : MANUAL_LINK_COPY_STATUS;
+      result === "copied" ? "Share link copied." : MANUAL_LINK_COPY_STATUS;
   }
 </script>
 
 <section class="playground" aria-labelledby="playground-heading">
   <header class="playground-intro">
-    <div>
-      <p class="eyebrow">Local only</p>
-      <h1 id="playground-heading">Playground</h1>
-      <p class="lede">
-        Edit a bounded PortableSpec. Inspect semantic events. Export Svelte,
-        builder TypeScript, JSON, or SVG. No upload, remote fetch, or code
-        execution.
-      </p>
-    </div>
-    <div class="share-actions">
-      <button type="button" onclick={share} disabled={!workbench.canCopyOrShare}
-        >Share this chart</button
-      >
-      <p>
-        Sharing explicitly puts the bounded PortableSpec in the URL and browser
-        history. URL fragments are not sent with HTTP requests, but anyone with
-        the link can read it.
-      </p>
-    </div>
+    <h1 id="playground-heading">Playground</h1>
+    <UiButton
+      type="button"
+      variant="primary"
+      onclick={share}
+      disabled={!workbench.canCopyOrShare}
+    >
+      Share this chart
+    </UiButton>
   </header>
 
   {#if shareUrl !== ""}
@@ -502,165 +420,37 @@
       <PlaygroundEvents entries={events} onClear={() => (events = [])} />
     {/snippet}
   </PlaygroundShell>
-
-  <section class="guide-inspector" aria-labelledby="axis-plans-heading">
-    <div>
-      <p class="eyebrow">Semantic inspection</p>
-      <h2 id="axis-plans-heading">Axis plans</h2>
-      <p>
-        Inspect bounded scale and guide decisions without copying source rows,
-        field names, domains, or labels.
-      </p>
-    </div>
-
-    <div class="guide-summary">
-      {#if scaleDecisions.length === 0}
-        <p>No temporal scale decision is active for this chart.</p>
-      {:else}
-        {#each scaleDecisions as decision}
-          <dl>
-            <div>
-              <dt>Axis</dt>
-              <dd>{decision.aesthetic}</dd>
-            </div>
-            <div>
-              <dt>Choice</dt>
-              <dd>{decision.status} · {decision.parser ?? "none"}</dd>
-            </div>
-            <div>
-              <dt>Precision</dt>
-              <dd>{decision.precision ?? "none"}</dd>
-            </div>
-            <div>
-              <dt>Validated</dt>
-              <dd>{decision.validatedCount.toLocaleString()} values</dd>
-            </div>
-          </dl>
-        {/each}
-      {/if}
-
-      {#each guidePlans as guide (guide.id)}
-        <dl>
-          <div>
-            <dt>Axis</dt>
-            <dd>{guide.aesthetic} · panel {guide.panelIndex + 1}</dd>
-          </div>
-          <div>
-            <dt>Break choice</dt>
-            <dd>{guide.source} · {guide.interval ?? "scale default"}</dd>
-          </div>
-          <div>
-            <dt>Ticks</dt>
-            <dd>
-              {guide.ticks.filter((entry) => entry.kind === "major").length} major
-              ·
-              {guide.ticks.filter((entry) => entry.kind === "minor").length} minor
-            </dd>
-          </div>
-          <div>
-            <dt>Layout</dt>
-            <dd>
-              {guide.overlap ? "overlap" : "fits"}{guide.marginOverflow
-                ? " · margin overflow"
-                : ""}
-            </dd>
-          </div>
-        </dl>
-      {/each}
-    </div>
-
-    <div class="report-actions">
-      <button type="button" onclick={() => void copyScaleReport()}
-        >Copy privacy-safe scale report</button
-      >
-      <a
-        href="https://github.com/ljodea/ggsvelte/issues/new?title=Scale%20report"
-        target="_blank"
-        rel="noreferrer">Report a scale issue</a
-      >
-      <pre
-        class="report-source"
-        aria-hidden="true"
-        bind:this={reportSource}>{scaleReport}</pre>
-      <p role="status" aria-live="polite">{reportStatus}</p>
-    </div>
-  </section>
 </section>
 
 <style>
   .playground {
     width: min(100% - 2rem, 96rem);
     margin: 0 auto;
-    padding-block: clamp(2rem, 5vw, 4.5rem);
+    padding-block: 1rem 2rem;
   }
 
   .playground-intro {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) minmax(16rem, 24rem);
-    gap: clamp(2rem, 7vw, 7rem);
-    align-items: end;
-  }
-
-  .eyebrow {
-    margin: 0;
-    color: var(--accent);
-    font-size: 0.75rem;
-    font-weight: 700;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem 1rem;
   }
 
   h1 {
-    max-width: 14ch;
-    margin: 0.3rem 0 1rem;
-    font-size: clamp(2.7rem, 6vw, 6rem);
-    line-height: 0.92;
-    letter-spacing: -0.045em;
-  }
-
-  .lede {
-    max-width: 48rem;
     margin: 0;
-    color: var(--muted);
-    font-size: 1.05rem;
-  }
-
-  .share-actions {
-    display: grid;
-    gap: 0.65rem;
-    border-top: 1px solid var(--line);
-    padding-top: 1rem;
-  }
-
-  .share-actions button {
-    min-height: 44px;
-    border: 1px solid var(--ink);
-    border-radius: 2px;
-    background: var(--ink);
-    color: var(--paper);
-    font: 650 0.88rem/1 var(--body-font);
-    cursor: pointer;
-  }
-
-  .share-actions button:disabled {
-    cursor: not-allowed;
-    opacity: 0.45;
-  }
-
-  .share-actions p,
-  .share-result p {
-    margin: 0;
-    color: var(--muted);
-    font-size: 0.78rem;
+    font-size: clamp(1.35rem, 2.4vw, 1.75rem);
+    line-height: 1.15;
+    letter-spacing: -0.03em;
   }
 
   .share-result {
     display: grid;
     grid-template-columns: minmax(0, 1fr) auto;
     gap: 0.75rem;
-    margin-top: 1rem;
+    margin-top: 0.75rem;
     border-block: 1px solid var(--line);
-    padding-block: 0.75rem;
+    padding-block: 0.65rem;
   }
 
   .share-result code {
@@ -669,111 +459,19 @@
     white-space: nowrap;
   }
 
-  .guide-inspector {
-    display: grid;
-    grid-template-columns: minmax(12rem, 0.7fr) minmax(0, 1.3fr);
-    gap: 1rem 2rem;
-    margin-top: 1.5rem;
-    border: 1px solid var(--line);
-    padding: 1rem;
-  }
-
-  .guide-inspector h2,
-  .guide-inspector p,
-  .guide-summary dl {
+  .share-result p {
     margin: 0;
-  }
-
-  .guide-inspector h2 {
-    margin-block: 0.2rem 0.5rem;
-  }
-
-  .guide-inspector > div > p:not(.eyebrow),
-  .report-actions p {
     color: var(--muted);
-    font-size: 0.8rem;
-  }
-
-  .guide-summary {
-    display: grid;
-    gap: 0.75rem;
-  }
-
-  .guide-summary dl {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 0.4rem 1rem;
-    border-bottom: 1px solid var(--line);
-    padding-bottom: 0.75rem;
-  }
-
-  .guide-summary dl div {
-    min-width: 0;
-  }
-
-  .guide-summary dt {
-    color: var(--muted);
-    font-size: 0.7rem;
-    text-transform: uppercase;
-  }
-
-  .guide-summary dd {
-    margin: 0;
-    overflow-wrap: anywhere;
-  }
-
-  .report-actions {
-    display: flex;
-    grid-column: 1 / -1;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 0.65rem;
-  }
-
-  .report-actions button {
-    min-height: 44px;
-    border: 1px solid var(--ink);
-    border-radius: 2px;
-    background: var(--ink);
-    padding-inline: 0.8rem;
-    color: var(--paper);
-    font: 650 0.82rem/1 var(--body-font);
-    cursor: pointer;
-  }
-
-  .report-actions a {
-    color: var(--accent);
-    font-size: 0.82rem;
-    font-weight: 650;
-  }
-
-  .report-actions p {
-    flex-basis: 100%;
-  }
-
-  .report-source {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    margin: 0;
-    overflow: hidden;
-    clip-path: inset(50%);
-    white-space: pre;
+    font-size: 0.78rem;
   }
 
   @media (max-width: 47.99rem) {
     .playground {
       width: min(100% - 1.25rem, 96rem);
+      padding-block: 0.75rem 1.5rem;
     }
 
-    .playground-intro {
-      grid-template-columns: 1fr;
-      gap: 1.5rem;
-    }
-
-    .share-result,
-    .guide-inspector,
-    .guide-summary dl {
+    .share-result {
       grid-template-columns: 1fr;
     }
   }

--- a/apps/docs/src/lib/components/PlaygroundEditor.svelte
+++ b/apps/docs/src/lib/components/PlaygroundEditor.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { tick } from "svelte";
 
+  import UiButton from "$lib/components/UiButton.svelte";
   import type { PlaygroundDiagnostic } from "$lib/playground-state";
 
   const {
@@ -51,7 +52,6 @@
     <p class="panel-number">02</p>
     <h2>Edit the PortableSpec</h2>
   </div>
-  <p>JSON only. No code runs.</p>
 </div>
 
 <div class="source-picker">
@@ -70,9 +70,6 @@
       <option value={sample.id}>{sample.title}</option>
     {/each}
   </select>
-  {#if selectedSample !== ""}
-    <p>{samples.find((sample) => sample.id === selectedSample)?.description}</p>
-  {/if}
 </div>
 
 <form
@@ -120,15 +117,15 @@
   {/if}
 
   <div class="editor-actions">
-    <button class="primary" type="submit" disabled={pending}
-      >{pending ? "Checking…" : "Apply draft"}</button
-    >
-    <button type="button" onclick={onUndo} disabled={pending || !canUndo}
-      >Undo chart</button
-    >
-    <button type="button" onclick={onReset} disabled={pending}
-      >Reset source</button
-    >
+    <UiButton variant="primary" type="submit" disabled={pending}>
+      {pending ? "Checking…" : "Apply draft"}
+    </UiButton>
+    <UiButton type="button" onclick={onUndo} disabled={pending || !canUndo}>
+      Undo chart
+    </UiButton>
+    <UiButton type="button" onclick={onReset} disabled={pending}>
+      Reset source
+    </UiButton>
   </div>
 </form>
 
@@ -142,12 +139,11 @@
     justify-content: space-between;
     gap: 1rem;
     border-bottom: 1px solid var(--line);
-    padding-bottom: 0.75rem;
+    padding-bottom: 0.6rem;
   }
 
   .panel-heading h2,
-  .panel-heading p,
-  .source-picker p {
+  .panel-heading p {
     margin: 0;
   }
 
@@ -156,9 +152,8 @@
     font-size: 1.05rem;
   }
 
-  .panel-heading > p,
-  .source-picker p,
   .limits {
+    margin: 0;
     color: var(--muted);
     font-size: 0.78rem;
   }
@@ -181,18 +176,16 @@
   }
 
   select,
-  textarea,
-  button {
-    min-height: 44px;
+  textarea {
+    min-height: 2.5rem;
     border: 1px solid var(--line);
-    border-radius: 2px;
+    border-radius: 0.5rem;
     background: var(--paper);
     color: var(--ink);
     font: inherit;
   }
 
-  select,
-  button {
+  select {
     padding: 0.55rem 0.7rem;
   }
 
@@ -205,14 +198,11 @@
     tab-size: 2;
   }
 
-  .limits {
-    margin: 0;
-  }
-
   .diagnostics {
     display: grid;
     gap: 0.5rem;
     border-left: 3px solid var(--danger, #b42318);
+    border-radius: 0 0.35rem 0.35rem 0;
     padding: 0.75rem;
     background: color-mix(in srgb, #b42318 7%, var(--paper));
   }
@@ -257,29 +247,14 @@
 
   .editor-actions {
     display: flex;
+    flex-wrap: wrap;
     gap: 0.55rem;
     padding-top: 0.35rem;
   }
 
-  button {
-    cursor: pointer;
-    font-weight: 650;
-  }
-
-  button.primary {
-    border-color: var(--accent);
-    background: var(--accent);
-    color: white;
-  }
-
-  button:disabled {
-    cursor: not-allowed;
-    opacity: 0.55;
-  }
-
   @media (max-width: 47.99rem) {
     :global(.editor-surface) {
-      padding: 1rem 0;
+      padding: 0.85rem 0.75rem;
     }
 
     textarea {

--- a/apps/docs/src/lib/components/PlaygroundEvents.svelte
+++ b/apps/docs/src/lib/components/PlaygroundEvents.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import UiButton from "$lib/components/UiButton.svelte";
   import {
     PLAYGROUND_MAX_EVENTS,
     type PlaygroundEventEntry,
@@ -28,9 +29,9 @@
         Interact with a mark to inspect public <code>oninteraction</code>
         payloads. This chart-local log is never persisted or shared.
       </p>
-      <button type="button" onclick={onClear} disabled={entries.length === 0}
-        >Clear events</button
-      >
+      <UiButton type="button" onclick={onClear} disabled={entries.length === 0}>
+        Clear events
+      </UiButton>
     </div>
     {#if newestFirst.length === 0}
       <p class="empty">
@@ -56,7 +57,7 @@
 <style>
   .event-inspector {
     margin-top: 1rem;
-    border-block: 1px solid var(--line);
+    border-top: 1px solid var(--line);
   }
 
   summary {
@@ -92,23 +93,6 @@
   .event-intro p,
   .empty {
     margin: 0;
-  }
-
-  button {
-    min-height: 44px;
-    flex: 0 0 auto;
-    border: 1px solid var(--line);
-    border-radius: 2px;
-    padding: 0.55rem 0.7rem;
-    background: var(--paper);
-    color: var(--ink);
-    font: 650 0.78rem/1 var(--body-font);
-    cursor: pointer;
-  }
-
-  button:disabled {
-    cursor: not-allowed;
-    opacity: 0.45;
   }
 
   ol {

--- a/apps/docs/src/lib/components/PlaygroundOutput.svelte
+++ b/apps/docs/src/lib/components/PlaygroundOutput.svelte
@@ -2,6 +2,7 @@
   import { tick, untrack } from "svelte";
 
   import { copyText, MANUAL_COPY_STATUS } from "$lib/clipboard";
+  import UiButton from "$lib/components/UiButton.svelte";
   import { playgroundSVGExport } from "$lib/playground-export";
   import type { PlaygroundOutput } from "$lib/playground-output";
   import type { PortableSpec } from "@ggsvelte/spec";
@@ -114,7 +115,7 @@
       anchor.href = objectUrl;
       anchor.download = result.filename;
       anchor.click();
-      exportStatus = "SVG downloaded from the render-confirmed chart.";
+      exportStatus = "SVG downloaded.";
     } catch (error) {
       exportStatus = `SVG export failed · export/download-failed: ${error instanceof Error ? error.message : "The browser refused the download."} The chart and outputs were retained.`;
     } finally {
@@ -129,26 +130,26 @@
     <h2>Export</h2>
   </div>
   <div class="output-actions">
-    <button
+    <UiButton
       type="button"
-      class="secondary"
+      variant="secondary"
       onclick={exportSVG}
-      disabled={!enabled}>Download SVG</button
+      disabled={!enabled}
     >
-    <button
+      Download SVG
+    </UiButton>
+    <UiButton
       type="button"
+      variant="primary"
       onclick={copy}
       disabled={!enabled || !activeOutput.supported || copying}
-      >{copying ? "Copying…" : `Copy ${activeOutput.label}`}</button
     >
+      {copying ? "Copying…" : `Copy ${activeOutput.label}`}
+    </UiButton>
   </div>
 </div>
 
-{#if enabled}
-  <p class="output-note">
-    Every enabled output contains the same render-confirmed PortableSpec.
-  </p>
-{:else}
+{#if !enabled}
   <p class="output-note blocked">
     Apply and render the draft successfully before copying, sharing, or
     exporting.
@@ -209,7 +210,7 @@
 
 <style>
   :global(.output-surface) {
-    padding: 1rem;
+    padding: 1rem 1.1rem;
   }
 
   .panel-heading,
@@ -223,7 +224,7 @@
     justify-content: space-between;
     gap: 1rem;
     border-bottom: 1px solid var(--line);
-    padding-bottom: 0.75rem;
+    padding-bottom: 0.6rem;
   }
 
   .panel-heading h2,
@@ -251,31 +252,9 @@
     justify-content: end;
   }
 
-  button {
-    min-height: 44px;
-    border: 1px solid var(--ink);
-    border-radius: 2px;
-    padding: 0.55rem 0.7rem;
-    background: var(--ink);
-    color: var(--paper);
-    font: 650 0.78rem/1 var(--body-font);
-    cursor: pointer;
-  }
-
-  button.secondary {
-    background: var(--paper);
-    color: var(--ink);
-  }
-
-  button:disabled {
-    cursor: not-allowed;
-    opacity: 0.45;
-  }
-
   .output-note,
   .action-status {
-    min-height: 2.5rem;
-    padding-block: 0.7rem;
+    padding-block: 0.55rem;
     color: var(--muted);
     font-size: 0.78rem;
   }
@@ -286,21 +265,29 @@
   }
 
   .output-tabs {
-    border-block: 1px solid var(--line);
+    margin-top: 0.35rem;
+    border: 1px solid var(--line);
+    border-radius: 0.45rem;
+    overflow: hidden;
   }
 
   .tab-list {
     max-width: 100%;
     overflow-x: auto;
     border-bottom: 1px solid var(--line);
+    background: var(--wash);
   }
 
   .tab-list button {
     flex: 0 0 auto;
+    min-height: 44px;
     border: 0;
     border-bottom: 2px solid transparent;
+    padding: 0.55rem 0.85rem;
     background: transparent;
     color: var(--muted);
+    font: 650 0.82rem/1 var(--body-font);
+    cursor: pointer;
   }
 
   .tab-list button.active {
@@ -309,13 +296,13 @@
   }
 
   pre {
-    max-height: 32rem;
+    max-height: 28rem;
     margin: 0;
     overflow: auto;
-    padding: 0.85rem;
+    padding: 1rem 1.1rem;
     background: var(--code-paper);
     color: var(--code-ink);
-    font: 0.72rem/1.55 var(--mono-font);
+    font: 0.78rem/1.55 var(--mono-font);
     white-space: pre;
   }
 
@@ -354,7 +341,7 @@
 
   @media (max-width: 47.99rem) {
     :global(.output-surface) {
-      padding: 1rem 0;
+      padding: 0.85rem 0.75rem;
     }
 
     .panel-heading {
@@ -366,7 +353,7 @@
     }
 
     pre {
-      max-height: 24rem;
+      max-height: 22rem;
     }
   }
 </style>

--- a/apps/docs/src/lib/components/PlaygroundPreview.svelte
+++ b/apps/docs/src/lib/components/PlaygroundPreview.svelte
@@ -101,7 +101,9 @@
   {#if lastValid}<strong class="last-valid">Last valid result</strong>{/if}
 </div>
 
-<p class="status" role="status" aria-live="polite">{status}</p>
+{#if status !== ""}
+  <p class="status" role="status" aria-live="polite">{status}</p>
+{/if}
 
 <div class="chart-stack" aria-busy={candidate !== null}>
   <div class="active-chart" bind:this={activeChartEl}>
@@ -148,30 +150,24 @@
   {/if}
 </div>
 
-<p class="local-note">
-  Rendering happens locally. Nothing in the editor is fetched, uploaded, or
-  executed as code.
-</p>
-
 <style>
   :global(.preview-surface) {
-    padding: 1rem;
+    padding: 1rem 1.1rem 1.15rem;
   }
 
   .panel-heading {
     display: flex;
-    min-height: 2.5rem;
+    min-height: 2rem;
     align-items: start;
     justify-content: space-between;
     gap: 1rem;
     border-bottom: 1px solid var(--line);
-    padding-bottom: 0.75rem;
+    padding-bottom: 0.6rem;
   }
 
   .panel-heading h2,
   .panel-heading p,
-  .status,
-  .local-note {
+  .status {
     margin: 0;
   }
 
@@ -188,6 +184,7 @@
 
   .last-valid {
     border: 1px solid currentColor;
+    border-radius: 0.35rem;
     padding: 0.3rem 0.45rem;
     color: #9b2c20;
     font-size: 0.72rem;
@@ -195,22 +192,18 @@
     text-transform: uppercase;
   }
 
-  .status,
-  .local-note {
+  .status {
+    padding-block: 0.55rem 0.35rem;
     color: var(--muted);
     font-size: 0.8rem;
   }
 
-  .status {
-    min-height: 2.7rem;
-    padding-block: 0.75rem;
-  }
-
   .chart-stack {
     display: grid;
-    min-height: 25rem;
+    min-height: 28rem;
     overflow: hidden;
-    border-block: 1px solid var(--line);
+    border: 1px solid var(--line);
+    border-radius: 0.35rem;
     background: var(--paper);
   }
 
@@ -227,21 +220,16 @@
 
   .render-error {
     display: grid;
-    min-height: 25rem;
+    min-height: 28rem;
     place-items: center;
     padding: 1rem;
     color: #9b2c20;
     text-align: center;
   }
 
-  .local-note {
-    border-top: 1px solid var(--line);
-    padding-top: 0.75rem;
-  }
-
   @media (max-width: 47.99rem) {
     :global(.preview-surface) {
-      padding: 1rem 0;
+      padding: 0.85rem 0.75rem;
     }
 
     .chart-stack {

--- a/apps/docs/src/lib/components/PlaygroundShell.svelte
+++ b/apps/docs/src/lib/components/PlaygroundShell.svelte
@@ -27,14 +27,13 @@
 <style>
   .playground-workspace {
     display: grid;
-    grid-template-columns: minmax(18rem, 0.82fr) minmax(25rem, 1.35fr) minmax(
-        18rem,
-        0.83fr
-      );
-    grid-template-areas: "editor preview output";
+    grid-template-columns: minmax(0, 1.7fr) minmax(16rem, 0.85fr);
+    grid-template-areas:
+      "preview editor"
+      "output output";
     gap: 1px;
-    margin-top: 1.5rem;
-    border-block: 1px solid var(--line);
+    margin-top: 0.75rem;
+    border: 1px solid var(--line);
     background: var(--line);
   }
 
@@ -55,16 +54,7 @@
     grid-area: output;
   }
 
-  @media (max-width: 74.99rem) {
-    .playground-workspace {
-      grid-template-columns: minmax(18rem, 0.9fr) minmax(0, 1.1fr);
-      grid-template-areas:
-        "editor preview"
-        "output output";
-    }
-  }
-
-  @media (max-width: 47.99rem) {
+  @media (max-width: 64rem) {
     .playground-workspace {
       grid-template-columns: minmax(0, 1fr);
       grid-template-areas:
@@ -77,7 +67,7 @@
     }
 
     .surface {
-      border-block: 1px solid var(--line);
+      border: 1px solid var(--line);
     }
   }
 </style>

--- a/apps/docs/src/lib/components/UiButton.svelte
+++ b/apps/docs/src/lib/components/UiButton.svelte
@@ -1,0 +1,108 @@
+<script lang="ts">
+  import { Button } from "bits-ui";
+  import type { Snippet } from "svelte";
+
+  type Variant = "primary" | "secondary" | "ghost";
+
+  const {
+    variant = "secondary",
+    class: className = "",
+    type = "button",
+    disabled = false,
+    onclick,
+    children,
+  }: {
+    variant?: Variant;
+    class?: string;
+    type?: "button" | "submit" | "reset";
+    disabled?: boolean;
+    onclick?: (event: MouseEvent) => void;
+    children: Snippet;
+  } = $props();
+</script>
+
+<Button.Root
+  class={`ui-button ui-button--${variant}${className !== "" ? ` ${className}` : ""}`}
+  {type}
+  {disabled}
+  {onclick}
+>
+  {@render children()}
+</Button.Root>
+
+<style>
+  :global(.ui-button) {
+    display: inline-flex;
+    min-height: 44px;
+    align-items: center;
+    justify-content: center;
+    gap: 0.4rem;
+    border: 1px solid transparent;
+    border-radius: 0.5rem;
+    padding: 0.5rem 0.9rem;
+    font: 600 0.875rem/1.2 var(--body-font);
+    letter-spacing: -0.01em;
+    text-decoration: none;
+    cursor: pointer;
+    transition:
+      background-color 120ms ease,
+      border-color 120ms ease,
+      color 120ms ease,
+      box-shadow 120ms ease,
+      opacity 120ms ease;
+  }
+
+  :global(.ui-button:focus-visible) {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+  }
+
+  :global(.ui-button:disabled),
+  :global(.ui-button[aria-disabled="true"]) {
+    cursor: not-allowed;
+    opacity: 0.45;
+  }
+
+  :global(.ui-button--primary) {
+    border-color: var(--accent);
+    background: var(--accent);
+    color: #fff;
+    box-shadow: 0 1px 0 color-mix(in srgb, var(--ink) 12%, transparent);
+  }
+
+  :global(
+    .ui-button--primary:hover:not(:disabled):not([aria-disabled="true"])
+  ) {
+    background: color-mix(in srgb, var(--accent) 88%, var(--ink));
+    border-color: color-mix(in srgb, var(--accent) 88%, var(--ink));
+  }
+
+  :global(.ui-button--secondary) {
+    border-color: var(--line);
+    background: var(--paper);
+    color: var(--ink);
+    box-shadow: 0 1px 0 color-mix(in srgb, var(--ink) 4%, transparent);
+  }
+
+  :global(
+    .ui-button--secondary:hover:not(:disabled):not([aria-disabled="true"])
+  ) {
+    border-color: color-mix(in srgb, var(--ink) 22%, var(--line));
+    background: var(--wash);
+  }
+
+  :global(.ui-button--ghost) {
+    border-color: transparent;
+    background: transparent;
+    color: var(--ink);
+    box-shadow: none;
+  }
+
+  :global(.ui-button--ghost:hover:not(:disabled):not([aria-disabled="true"])) {
+    background: color-mix(in srgb, var(--ink) 6%, transparent);
+  }
+
+  :root[data-theme="dark"] :global(.ui-button--primary) {
+    color: #0b1020;
+  }
+</style>

--- a/apps/docs/src/lib/playground-state.ts
+++ b/apps/docs/src/lib/playground-state.ts
@@ -148,7 +148,7 @@ export function createPlaygroundState(
     candidate: null,
     diagnostics: [],
     lastValid: false,
-    status: "Sample ready. Everything stays in this browser tab.",
+    status: "Ready.",
     nextGeneration: 1,
     undoSnapshots: [],
     navigationRecovery: null,
@@ -377,7 +377,6 @@ export function confirmPlaygroundRendered(state: PlaygroundState): PlaygroundSta
   return finalize({
     ...state,
     renderConfirmed: true,
-    status: "Sample rendered. Everything stays in this browser tab.",
     historyIntent: "none",
   });
 }

--- a/apps/docs/tsconfig.json
+++ b/apps/docs/tsconfig.json
@@ -4,6 +4,8 @@
   "compilerOptions": {
     "strict": true,
     "moduleResolution": "bundler",
+    // bits-ui ships CSS.Properties expansions that currently explode under TS 6.
+    "skipLibCheck": true,
     // Use the shipped Temporal polyfill declarations until the proposal lands;
     // TypeScript 6's esnext draft and @js-temporal/polyfill 0.5 have incompatible nominal types.
     "lib": ["ES2024", "DOM", "DOM.Iterable"],

--- a/bun.lock
+++ b/bun.lock
@@ -4,9 +4,6 @@
   "workspaces": {
     "": {
       "name": "ggsvelte-monorepo",
-      "dependencies": {
-        "@sveltejs/kit": "^2.70.1",
-      },
       "devDependencies": {
         "@arethetypeswrong/cli": "0.18.5",
         "@changesets/cli": "2.31.1",
@@ -40,12 +37,13 @@
         "@ggsvelte/examples": "workspace:*",
         "@ggsvelte/spec": "workspace:*",
         "@ggsvelte/svelte": "workspace:*",
+        "bits-ui": "^2.18.1",
         "phosphor-svelte": "^3.1.0",
         "svelte-highlight": "^7.16.0",
       },
       "devDependencies": {
         "@sveltejs/adapter-static": "^3.0.10",
-        "@sveltejs/kit": "^2.69.3",
+        "@sveltejs/kit": "^2.70.0",
         "@sveltejs/vite-plugin-svelte": "^7.2.0",
         "svelte": "^5.56.5",
         "svelte-check": "^4.7.3",
@@ -285,6 +283,12 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A=="],
 
+    "@floating-ui/core": ["@floating-ui/core@1.8.0", "", { "dependencies": { "@floating-ui/utils": "^0.2.12" } }, "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ=="],
+
+    "@floating-ui/dom": ["@floating-ui/dom@1.8.0", "", { "dependencies": { "@floating-ui/core": "^1.8.0", "@floating-ui/utils": "^0.2.12" } }, "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg=="],
+
+    "@floating-ui/utils": ["@floating-ui/utils@0.2.12", "", {}, "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww=="],
+
     "@ggsvelte-bench/benchmarks": ["@ggsvelte-bench/benchmarks@workspace:benchmarks"],
 
     "@ggsvelte-spike/browser": ["@ggsvelte-spike/browser@workspace:spikes/browser"],
@@ -352,6 +356,8 @@
     "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
 
     "@inquirer/external-editor": ["@inquirer/external-editor@1.0.3", "", { "dependencies": { "chardet": "^2.1.1", "iconv-lite": "^0.7.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA=="],
+
+    "@internationalized/date": ["@internationalized/date@3.12.2", "", { "dependencies": { "@swc/helpers": "^0.5.0" } }, "sha512-FY1Y+H64NDs+HAF6omlnWxm3mEpfgaCSWtL5l551ZZfImA+kGjPFgrnJrGjH6lfmLL0g8Z/mBu1R3kufeCp6Jw=="],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
@@ -611,6 +617,8 @@
 
     "@sveltejs/vite-plugin-svelte": ["@sveltejs/vite-plugin-svelte@7.2.0", "", { "dependencies": { "deepmerge": "^4.3.1", "magic-string": "^0.30.21", "obug": "^2.1.0", "vitefu": "^1.1.2" }, "peerDependencies": { "svelte": "^5.46.4", "vite": "^8.0.0-beta.7 || ^8.0.0" } }, "sha512-1SpkuMSRLfugrVX+IrKfE1RUegzo8AQzKQ6qQPfVzbcWi5IhuTPaKb5ZrLpucleFznkc4/RTeSPoRnGWFxX+EQ=="],
 
+    "@swc/helpers": ["@swc/helpers@0.5.23", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw=="],
+
     "@testing-library/svelte-core": ["@testing-library/svelte-core@1.1.3", "", { "peerDependencies": { "svelte": "^3 || ^4 || ^5 || ^5.0.0-next.0" } }, "sha512-KkMAvXeWorxN2Yn0kdC1lfoAItxpoj4uOWzxK5leDrNxonLvS5nwBFvztrroyTszQ0Wf/EU6iLT8JhY5qcn22g=="],
 
     "@total-typescript/shoehorn": ["@total-typescript/shoehorn@0.1.2", "", {}, "sha512-p7nNZbOZIofpDNyP0u1BctFbjxD44Qc+oO5jufgQdFdGIXJLc33QRloJpq7k5T59CTgLWfQSUxsuqLcmeurYRw=="],
@@ -690,6 +698,8 @@
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
 
     "better-path-resolve": ["better-path-resolve@1.0.0", "", { "dependencies": { "is-windows": "^1.0.0" } }, "sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g=="],
+
+    "bits-ui": ["bits-ui@2.18.1", "", { "dependencies": { "@floating-ui/core": "^1.7.1", "@floating-ui/dom": "^1.7.1", "esm-env": "^1.1.2", "runed": "^0.35.1", "svelte-toolbelt": "^0.10.6", "tabbable": "^6.2.0" }, "peerDependencies": { "@internationalized/date": "^3.8.1", "svelte": "^5.33.0" } }, "sha512-KkemzKFH4T3gt3H+P86JcnAWExjByv/6vlwjm/BoCwTPHu03yiCdxbghdJLvFReQTe0acCAiRcKfmixxD6XvlA=="],
 
     "blake3-wasm": ["blake3-wasm@2.1.5", "", {}, "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g=="],
 
@@ -833,6 +843,8 @@
 
     "ignore": ["ignore@7.0.6", "", {}, "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw=="],
 
+    "inline-style-parser": ["inline-style-parser@0.2.7", "", {}, "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="],
+
     "is-alphabetical": ["is-alphabetical@2.0.1", "", {}, "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="],
 
     "is-alphanumerical": ["is-alphanumerical@2.0.1", "", { "dependencies": { "is-alphabetical": "^2.0.0", "is-decimal": "^2.0.0" } }, "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw=="],
@@ -920,6 +932,8 @@
     "lodash.startcase": ["lodash.startcase@4.4.0", "", {}, "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg=="],
 
     "lru-cache": ["lru-cache@11.5.2", "", {}, "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g=="],
+
+    "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
@@ -1103,6 +1117,8 @@
 
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
+    "runed": ["runed@0.35.1", "", { "dependencies": { "dequal": "^2.0.3", "esm-env": "^1.0.0", "lz-string": "^1.5.0" }, "peerDependencies": { "@sveltejs/kit": "^2.21.0", "svelte": "^5.7.0" }, "optionalPeers": ["@sveltejs/kit"] }, "sha512-2F4Q/FZzbeJTFdIS/PuOoPRSm92sA2LhzTnv6FXhCoENb3huf5+fDuNOg1LNvGOouy3u/225qxmuJvcV3IZK5Q=="],
+
     "sade": ["sade@1.8.1", "", { "dependencies": { "mri": "^1.1.0" } }, "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A=="],
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
@@ -1149,6 +1165,8 @@
 
     "strip-json-comments": ["strip-json-comments@5.0.3", "", {}, "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw=="],
 
+    "style-to-object": ["style-to-object@1.0.14", "", { "dependencies": { "inline-style-parser": "0.2.7" } }, "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw=="],
+
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "supports-hyperlinks": ["supports-hyperlinks@3.2.0", "", { "dependencies": { "has-flag": "^4.0.0", "supports-color": "^7.0.0" } }, "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig=="],
@@ -1159,7 +1177,11 @@
 
     "svelte-highlight": ["svelte-highlight@7.16.0", "", { "dependencies": { "magic-string": "^0.30.17" } }, "sha512-0H7RwC+mvV/aZ7gFsg5bEDtFHsWlirKFlpw7HImjMQTclq3/bWjgtYV2sgMma90DU9H72G3J8n7fTlTUFWk76w=="],
 
+    "svelte-toolbelt": ["svelte-toolbelt@0.10.6", "", { "dependencies": { "clsx": "^2.1.1", "runed": "^0.35.1", "style-to-object": "^1.0.8" }, "peerDependencies": { "svelte": "^5.30.2" } }, "sha512-YWuX+RE+CnWYx09yseAe4ZVMM7e7GRFZM6OYWpBKOb++s+SQ8RBIMMe+Bs/CznBMc0QPLjr+vDBxTAkozXsFXQ=="],
+
     "svelte2tsx": ["svelte2tsx@0.7.57", "", { "dependencies": { "dedent-js": "^1.0.1", "scule": "^1.3.0" }, "peerDependencies": { "svelte": "^3.55 || ^4.0.0-next.0 || ^4.0 || ^5.0.0-next.0", "typescript": "^4.9.4 || ^5.0.0 || ^6.0.0" } }, "sha512-nQo0xEfUpSVjfkxan2UmC6Wl9UZVe9+/pglUiyBNMJ7KDQ9DDooucmXdToBOvzSfgYjj/kMYwf6CTTDz/z048w=="],
+
+    "tabbable": ["tabbable@6.5.0", "", {}, "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA=="],
 
     "term-size": ["term-size@2.2.1", "", {}, "sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg=="],
 

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -61,8 +61,8 @@
       "entry": ["src/routes/**/+*.ts", "src/lib/**/*.ts"],
       "project": ["src/**/*.ts", "*.{js,ts}"],
       // Imported only from .svelte files / the $examples alias, which knip
-      // does not trace. phosphor-svelte is deep-imported only from .svelte.
-      "ignoreDependencies": ["@ggsvelte/examples", "phosphor-svelte"],
+      // does not trace. phosphor-svelte / bits-ui are deep-imported only from .svelte.
+      "ignoreDependencies": ["@ggsvelte/examples", "phosphor-svelte", "bits-ui"],
     },
   },
 }

--- a/tests/visual/playground.spec.ts
+++ b/tests/visual/playground.spec.ts
@@ -136,6 +136,7 @@ test("interaction reference filters the exact public contract", async ({ page })
 test("compatible gallery details open the exact fragment while oversized examples explain why", async ({
   page,
 }) => {
+  test.setTimeout(60_000);
   await page.goto("/examples/point/scatter-color");
   const handoff = page.getByRole("link", { name: "Open in Playground" });
   await expect(handoff).toHaveAttribute("href", /\/playground#play=v1\.[A-Za-z0-9_-]+$/u);
@@ -235,45 +236,25 @@ test("valid edits render before Svelte copy becomes available and candidates sta
   );
 });
 
-test("temporal samples expose privacy-safe guide plans and keep ambiguous dates discrete", async ({
-  page,
-  context,
-}) => {
-  await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+test("temporal samples render and keep ambiguous dates discrete", async ({ page }) => {
   await page.goto("/playground");
   await settleVisualState(page);
 
   await page.getByLabel("Start from a sample").selectOption("raw-years");
   await expect(page.getByText("Rendered raw-years.")).toBeVisible();
-  await expect(page.getByRole("heading", { name: "Axis plans" })).toBeVisible();
-  await expect(page.getByText(/temporal · year/u)).toBeVisible();
-
-  await page.getByRole("button", { name: "Copy privacy-safe scale report" }).click();
-  await expect(page.getByRole("status").filter({ hasText: "Copied a privacy-safe" })).toBeVisible();
-  const report = await page.evaluate(() => navigator.clipboard.readText());
-  const serialized = report.toLowerCase();
-  expect(JSON.parse(report)).toMatchObject({
-    decisions: [{ aesthetic: "x", status: "temporal", parser: "year", precision: "year" }],
-    guides: expect.any(Array),
-  });
-  expect(serialized).not.toContain('"data"');
-  expect(serialized).not.toContain('"field"');
-  expect(serialized).not.toContain('"domain"');
-  expect(serialized).not.toContain('"label"');
-  expect(serialized).not.toContain("1835");
+  await expect(page.locator(".active-chart .gg-title")).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Axis plans" })).toHaveCount(0);
 
   await page.getByLabel("Start from a sample").selectOption("iso-dates");
   await expect(page.getByText("Rendered iso-dates.")).toBeVisible();
-  await expect(page.getByText(/temporal · iso/u)).toBeVisible();
+  await expect(page.locator(".active-chart .gg-title")).toBeVisible();
 
   await page.getByLabel("Start from a sample").selectOption("ambiguous-dates");
   await expect(page.getByText("Rendered ambiguous-dates.")).toBeVisible();
-  await expect(page.getByText(/nominal · none/u)).toBeVisible();
+  await expect(page.locator(".active-chart .gg-title")).toBeVisible();
 });
 
-test("axis-plan inspection supports multiple temporal decisions on one aesthetic", async ({
-  page,
-}) => {
+test("multiple temporal decisions on one aesthetic still render", async ({ page }) => {
   await page.goto("/playground");
   await settleVisualState(page);
   await page.getByLabel("PortableSpec JSON").fill(
@@ -303,7 +284,8 @@ test("axis-plan inspection supports multiple temporal decisions on one aesthetic
   );
   await page.getByRole("button", { name: "Apply draft" }).click();
   await expect(page.getByText("Rendered custom draft.")).toBeVisible();
-  await expect(page.getByText(/temporal · ymd/u)).toHaveCount(2);
+  await expect(page.locator(".active-chart .gg-title")).toHaveText("Temporal bounds");
+  await expect(page.getByRole("heading", { name: "Axis plans" })).toHaveCount(0);
 });
 
 test("191-year temporal guide stays collision-free with complete labels", async ({ page }) => {
@@ -649,24 +631,22 @@ test("denied clipboard selects the share URL with truthful fallback text", async
     "Clipboard unavailable. Share link selected for manual copy.",
   );
   expect(await page.evaluate(() => getSelection()?.toString())).toContain("#play=v1.");
-
-  await page.getByRole("button", { name: "Copy privacy-safe scale report" }).click();
-  await expect(
-    page.getByRole("status").filter({ hasText: "scale report is selected" }),
-  ).toBeVisible();
-  expect(await page.evaluate(() => getSelection()?.toString())).toContain('"guides"');
 });
 
 test("playground is preview-first, operable, and axe-clean at a touch-size viewport", async ({
   page,
 }) => {
+  // Init scripts bypass the page CSP; post-load addScriptTag does not.
+  await page.addInitScript({ content: axe.source });
   await page.setViewportSize({ width: 390, height: 844 });
   await page.goto("/playground");
   await settleVisualState(page);
 
   const preview = await page.locator(".preview-surface").boundingBox();
   const editor = await page.locator(".editor-surface").boundingBox();
+  const output = await page.locator(".output-surface").boundingBox();
   expect(preview?.y).toBeLessThan(editor?.y ?? 0);
+  expect(editor?.y).toBeLessThan(output?.y ?? 0);
   const horizontalOverflow = await page.evaluate(
     () => document.documentElement.scrollWidth - document.documentElement.clientWidth,
   );
@@ -681,7 +661,6 @@ test("playground is preview-first, operable, and axe-clean at a touch-size viewp
   await expect(page.getByRole("button", { name: "Copy Svelte" })).toBeVisible();
   await expect(page.locator("details.event-inspector")).not.toHaveAttribute("open", "");
 
-  await page.addScriptTag({ content: axe.source });
   const violations = await page.evaluate(async () => {
     const runner = (globalThis as typeof globalThis & { axe: typeof axe }).axe;
     return (await runner.run(document.querySelector(".playground")!)).violations.map(


### PR DESCRIPTION
## Summary
- Reorder the playground: **Preview (01) left and wide**, **Edit PortableSpec (02) right**, **Export (03) full-width below** so generated code is readable without horizontal scrolling.
- Shrink the hero (no giant “Playground” heading, no LOCAL ONLY badge, no marketing lede) so the chart is above the fold.
- Delete detritus copy and the agent-only **Axis plans / privacy-safe scale report** block.
- Replace blocky page buttons with a bits-ui-based `UiButton` (Apply / Undo / Reset / Share / Export / Clear events).

## Test plan
- [x] `bun test` playground unit suites (`playground-state`, export, output, events, lifecycle)
- [x] `svelte-check` clean for docs (with `skipLibCheck` for bits-ui TS 6 noise)
- [x] `playwright test playground.spec.ts` — 19/19 pass (layout, share, samples, axe at 390px)
- [ ] Spot-check `/playground` in browser: chart first, export readable below, no axis inspector