### PR TITLE
refactor(ci): extract detect-changes driver into scripts/ci-routing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,76 +108,11 @@ jobs:
           PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
+        # Path routing + #244 main thinning + #246 run-compat live in
+        # scripts/ci-routing/detect-changes.ts (issue #393). Env-only contract
+        # keeps untrusted PR text out of the shell script body (zizmor).
         shell: bash
-        run: |
-          set -euo pipefail
-          zero="0000000000000000000000000000000000000000"
-          if [ -z "${BASE_SHA}" ] || [ "${BASE_SHA}" = "${zero}" ]; then
-            echo "no usable base SHA — force-all"
-            bun scripts/ci-routing.ts emit-github-output --force-all
-          else
-            # Main + cancel-in-progress: a later markdown/workflow-only push must
-            # still route product work from earlier unvalidated main commits.
-            # Widen the base to the last successful CI head on main so the
-            # replacement run covers the cumulative unvalidated range.
-            if [ "${EVENT_NAME}" = "push" ] && [ "${GITHUB_REF}" = "refs/heads/main" ] && command -v gh >/dev/null 2>&1; then
-              last_ok="$(
-                gh api "repos/${REPO}/actions/workflows/ci.yml/runs?branch=main&status=completed&per_page=20" \
-                  --jq --arg head "${HEAD_SHA}" '
-                    [.workflow_runs[]
-                      | select(.conclusion == "success" and .head_sha != $head)
-                      | .head_sha][0] // empty
-                  ' 2>/dev/null || true
-              )"
-              if [ -n "${last_ok}" ]; then
-                echo "widening main route base ${BASE_SHA} → last successful CI ${last_ok}"
-                BASE_SHA="${last_ok}"
-              fi
-            fi
-            # Ensure the base object exists for the three-dot diff.
-            git fetch --no-tags --depth=1 origin "${BASE_SHA}" 2>/dev/null || true
-            if ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
-              echo "base SHA ${BASE_SHA} not resolvable — force-all"
-              bun scripts/ci-routing.ts emit-github-output --force-all
-            else
-              # --name-status keeps rename/copy source paths for classification.
-              mapfile -t files < <(git diff --name-status "${BASE_SHA}...${HEAD_SHA}" || true)
-              if [ "${#files[@]}" -eq 0 ]; then
-                # Empty diff (empty commit / metadata-only): still run cheap checks.
-                echo "empty changed-file set — checks-only routing"
-                printf '' | bun scripts/ci-routing.ts emit-github-output --stdin
-              else
-                printf '%s\n' "${files[@]}" | bun scripts/ci-routing.ts emit-github-output --stdin
-                echo "event=${EVENT_NAME} base=${BASE_SHA} head=${HEAD_SHA} files=${#files[@]}"
-                # Issue #244: main push re-running the full suite saturates the pool.
-                # Keep thinner main surface (checks/unit/build/actions-security);
-                # consumer/bench stay PR-primary. force-all paths still full-suite
-                # when base is missing.
-                # Keep packages_dist + component path-routed on main so Codecov
-                # can refresh the packages/svelte flag for branch/main badges
-                # (carryforward cannot bootstrap a first main-branch report).
-                if [ "${EVENT_NAME}" = "push" ] && [ "${GITHUB_REF}" = "refs/heads/main" ]; then
-                  {
-                    echo "consumer=false"
-                    echo "bench_smoke=false"
-                    echo "interaction_perf=false"
-                  } >> "$GITHUB_OUTPUT"
-                  echo "main push: thinned consumer/bench (issue #244); packages_dist+component stay path-routed for coverage"
-                fi
-              fi
-            fi
-          fi
-          # Issue #246: run-compat is an escape hatch for the full required
-          # consumer matrix even when path routing would skip (docs-only PRs).
-          # Applied after routing / #244 thinning so the label always wins on PRs.
-          if [ "${EVENT_NAME}" = "pull_request" ] &&
-            printf '%s' "${PR_LABELS:-}" | tr ',' '\n' | grep -qx 'run-compat'; then
-            {
-              echo "consumer=true"
-              echo "packages_dist=true"
-            } >> "$GITHUB_OUTPUT"
-            echo "run-compat: forced consumer + packages_dist (issue #246)"
-          fi
+        run: bun scripts/ci-routing.ts detect-changes
 
   # Early package build shared by component / consumer / interaction-perf
   # (issue #241). Unit and bench-smoke keep the cheaper `bun run check`

--- a/scripts/ci-routing/cli.ts
+++ b/scripts/ci-routing/cli.ts
@@ -3,6 +3,7 @@
  * Invoked only via `scripts/ci-routing.ts` (`import.meta.main` lives there).
  */
 import { appendFileSync, mkdirSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
 
 import {
   classifyChangedPaths,
@@ -26,6 +27,7 @@ import {
   validateSuccessMarker,
   type CacheableExecution,
 } from "./content-hash";
+import { runDetectChanges, type DetectChangesInput, type DetectChangesIo } from "./detect-changes";
 
 export async function runCiRoutingCli(argv: string[]): Promise<void> {
   const args = argv.slice(2);
@@ -61,6 +63,11 @@ export async function runCiRoutingCli(argv: string[]): Promise<void> {
       appendFileSync(outPath, body);
     }
     process.stdout.write(body);
+    return;
+  }
+
+  if (cmd === "detect-changes") {
+    runDetectChangesCli();
     return;
   }
 
@@ -105,15 +112,116 @@ function printHelp(): void {
   bun scripts/ci-routing.ts classify [--files f1 f2 | --from-git --base <ref> | --stdin]
   bun scripts/ci-routing.ts plan [--files ... | --from-git --base <ref> | --stdin] [--force-all]
   bun scripts/ci-routing.ts emit-github-output [--files ... | --from-git --base <ref> | --stdin] [--force-all]
+  bun scripts/ci-routing.ts detect-changes
   bun scripts/ci-routing.ts hash-inputs --execution <name> [--os <runner.os>] [--container-tag <tag>] [--matrix-node N --matrix-pm NAME --matrix-pm-version V --matrix-svelte V] [--runtime-node-version V --runtime-pm-version V]
   bun scripts/ci-routing.ts write-success-marker --execution <name> --hash <hex>
   bun scripts/ci-routing.ts validate-success-marker --execution <name> --hash <hex>
   bun scripts/ci-routing.ts gate --required <file|-> --results <file|->
 
+  detect-changes reads EVENT_NAME, GITHUB_REF, BASE_SHA, HEAD_SHA, PR_LABELS,
+  REPO, GITHUB_OUTPUT (and uses gh/git for main base widening).
   --from-git uses git diff --name-status (rename source + dest).
   --stdin accepts plain paths or name-status lines (tab-separated).
   hash-inputs uses git ls-tree -r HEAD (fail-closed). Emits hash + cache_key (+ GITHUB_OUTPUT).
 `);
+}
+
+/**
+ * Production I/O for `detect-changes` — mirrors the former ci.yml bash:
+ * swallow gh/git fetch/diff failures; exact-key GITHUB_OUTPUT write.
+ */
+export function createDetectChangesIo(): DetectChangesIo {
+  return {
+    commandExists(name: string): boolean {
+      const r = spawnSync("bash", ["-c", `command -v ${JSON.stringify(name)}`], {
+        encoding: "utf8",
+      });
+      return r.status === 0;
+    },
+    findLastSuccessfulMainHead(repo: string, headSha: string): string | undefined {
+      // Issue #244 cumulative main range. See lastSuccessfulMainHeadJq — gh api
+      // has no jq --arg; the former bash form was a silent no-op under `|| true`.
+      const r = spawnSync(
+        "gh",
+        [
+          "api",
+          `repos/${repo}/actions/workflows/ci.yml/runs?branch=main&status=completed&per_page=20`,
+          "--jq",
+          lastSuccessfulMainHeadJq(headSha),
+        ],
+        { encoding: "utf8", maxBuffer: 10 * 1024 * 1024 },
+      );
+      if (r.status !== 0) return undefined;
+      const sha = (r.stdout ?? "").trim();
+      return sha.length > 0 ? sha : undefined;
+    },
+    gitFetchDepth1(sha: string): void {
+      spawnSync("git", ["fetch", "--no-tags", "--depth=1", "origin", sha], {
+        encoding: "utf8",
+        stdio: "ignore",
+      });
+    },
+    gitCommitExists(sha: string): boolean {
+      const r = spawnSync("git", ["cat-file", "-e", `${sha}^{commit}`], {
+        encoding: "utf8",
+        stdio: "ignore",
+      });
+      return r.status === 0;
+    },
+    gitDiffNameStatus(base: string, head: string): string[] | "error" {
+      // Large renames can exceed Node's default 1 MiB maxBuffer; treat overflow
+      // as error → force-all rather than silent checks-only.
+      const r = spawnSync("git", ["diff", "--name-status", `${base}...${head}`], {
+        encoding: "utf8",
+        maxBuffer: 50 * 1024 * 1024,
+      });
+      if (r.error || r.status !== 0) return "error";
+      const text = r.stdout ?? "";
+      return text
+        .split(/\r?\n/)
+        .map((l) => l.trimEnd())
+        .filter((l) => l.length > 0);
+    },
+    writeGithubOutput(body: string): void {
+      writeGithubOutput(body);
+      process.stdout.write(body);
+    },
+    log(msg: string): void {
+      process.stdout.write(`${msg}\n`);
+    },
+  };
+}
+
+/** jq program for last successful main CI head, excluding the current head. */
+export function lastSuccessfulMainHeadJq(headSha: string): string {
+  const headLit = JSON.stringify(headSha);
+  return `[.workflow_runs[] | select(.conclusion == "success" and .head_sha != ${headLit}) | .head_sha][0] // empty`;
+}
+
+function runDetectChangesCli(): void {
+  const env = process.env;
+  const input: DetectChangesInput = {
+    eventName: env.EVENT_NAME ?? "",
+    githubRef: env.GITHUB_REF ?? "",
+    baseSha: env.BASE_SHA ?? "",
+    headSha: env.HEAD_SHA ?? "",
+    prLabels: env.PR_LABELS ?? "",
+    repo: env.REPO ?? "",
+  };
+  if (input.eventName.length === 0) {
+    throw new Error("detect-changes requires EVENT_NAME");
+  }
+  if (input.headSha.length === 0) {
+    throw new Error("detect-changes requires HEAD_SHA");
+  }
+  if (input.repo.length === 0) {
+    throw new Error("detect-changes requires REPO");
+  }
+  const outPath = env.GITHUB_OUTPUT;
+  if (typeof outPath !== "string" || outPath.length === 0) {
+    throw new Error("detect-changes requires GITHUB_OUTPUT (job outputs path)");
+  }
+  runDetectChanges(input, createDetectChangesIo());
 }
 
 function parseCacheableExecution(raw: string | undefined): CacheableExecution {

--- a/scripts/ci-routing/cli.ts
+++ b/scripts/ci-routing/cli.ts
@@ -130,7 +130,7 @@ function printHelp(): void {
  * Production I/O for `detect-changes` — mirrors the former ci.yml bash:
  * swallow gh/git fetch/diff failures; exact-key GITHUB_OUTPUT write.
  */
-export function createDetectChangesIo(): DetectChangesIo {
+function createDetectChangesIo(): DetectChangesIo {
   return {
     commandExists(name: string): boolean {
       const r = spawnSync("bash", ["-c", `command -v ${JSON.stringify(name)}`], {

--- a/scripts/ci-routing/detect-changes.test.ts
+++ b/scripts/ci-routing/detect-changes.test.ts
@@ -1,0 +1,421 @@
+/**
+ * Characterization tests for the detect-changes job driver (issue #393).
+ * Injectable I/O — no live git/gh/network.
+ */
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  ZERO_SHA,
+  applyMainPushThinning,
+  applyRunCompat,
+  buildDetectChangesOutputs,
+  hasExactLabel,
+  isMainPush,
+  isMissingBase,
+  resolveRouteInputs,
+  runDetectChanges,
+  type DetectChangesInput,
+  type DetectChangesIo,
+} from "./detect-changes";
+import { classifyChangedPaths, formatGithubOutputs, planJobs } from "./routing";
+import { shouldBypassContentCache } from "./content-hash";
+
+function baseInput(over: Partial<DetectChangesInput> = {}): DetectChangesInput {
+  return {
+    eventName: "pull_request",
+    githubRef: "refs/pull/1/merge",
+    baseSha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    headSha: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    prLabels: "",
+    repo: "ljodea/ggsvelte",
+    ...over,
+  };
+}
+
+function mockIo(over: Partial<DetectChangesIo> = {}): DetectChangesIo & {
+  logs: string[];
+  outputs: string[];
+} {
+  const logs: string[] = [];
+  const outputs: string[] = [];
+  return {
+    logs,
+    outputs,
+    commandExists: () => false,
+    findLastSuccessfulMainHead: () => undefined,
+    gitFetchDepth1: () => {},
+    gitCommitExists: () => true,
+    gitDiffNameStatus: () => [],
+    writeGithubOutput: (body) => {
+      outputs.push(body);
+    },
+    log: (msg) => {
+      logs.push(msg);
+    },
+    ...over,
+  };
+}
+
+function parseOutput(body: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const line of body.trimEnd().split("\n")) {
+    const i = line.indexOf("=");
+    if (i < 0) continue;
+    out[line.slice(0, i)] = line.slice(i + 1);
+  }
+  return out;
+}
+
+describe("detect-changes helpers", () => {
+  test("isMissingBase treats empty and zero SHA", () => {
+    expect(isMissingBase("")).toBe(true);
+    expect(isMissingBase(ZERO_SHA)).toBe(true);
+    expect(isMissingBase("abc")).toBe(false);
+  });
+
+  test("isMainPush requires push + refs/heads/main", () => {
+    expect(isMainPush("push", "refs/heads/main")).toBe(true);
+    expect(isMainPush("pull_request", "refs/heads/main")).toBe(false);
+    expect(isMainPush("push", "refs/heads/feat")).toBe(false);
+  });
+
+  test("hasExactLabel matches bash grep -qx after comma split (no trim)", () => {
+    expect(hasExactLabel("run-compat", "run-compat")).toBe(true);
+    expect(hasExactLabel("docs,run-compat,other", "run-compat")).toBe(true);
+    expect(hasExactLabel("run-compat-extra", "run-compat")).toBe(false);
+    expect(hasExactLabel(" docs, run-compat", "run-compat")).toBe(false); // space
+    expect(hasExactLabel("", "run-compat")).toBe(false);
+  });
+});
+
+describe("resolveRouteInputs", () => {
+  test("missing base → force_all", () => {
+    const io = mockIo();
+    const r = resolveRouteInputs(baseInput({ baseSha: "" }), io);
+    expect(r).toEqual({ kind: "force_all", reason: "no usable base SHA — force-all" });
+  });
+
+  test("zero base → force_all", () => {
+    const r = resolveRouteInputs(baseInput({ baseSha: ZERO_SHA }), mockIo());
+    expect(r.kind).toBe("force_all");
+  });
+
+  test("unresolvable base after fetch → force_all", () => {
+    const io = mockIo({ gitCommitExists: () => false });
+    const r = resolveRouteInputs(baseInput(), io);
+    expect(r.kind).toBe("force_all");
+    if (r.kind === "force_all") {
+      expect(r.reason).toContain("not resolvable");
+    }
+  });
+
+  test("empty git diff → files empty (checks-only), not force_all", () => {
+    const io = mockIo({
+      gitDiffNameStatus: () => [],
+    });
+    const r = resolveRouteInputs(baseInput(), io);
+    expect(r).toEqual({
+      kind: "files",
+      files: [],
+      baseSha: baseInput().baseSha,
+      empty: true,
+    });
+  });
+
+  test("git diff error → force_all (not silent checks-only)", () => {
+    const io = mockIo({
+      gitDiffNameStatus: () => "error",
+    });
+    const r = resolveRouteInputs(baseInput(), io);
+    expect(r.kind).toBe("force_all");
+    if (r.kind === "force_all") {
+      expect(r.reason).toContain("git diff");
+      expect(r.reason).toContain("force-all");
+    }
+  });
+
+  test("name-status lines parse rename both sides", () => {
+    const io = mockIo({
+      gitDiffNameStatus: () => ["R100\tpackages/core/src/a.ts\tpackages/core/src/b.ts"],
+    });
+    const r = resolveRouteInputs(baseInput(), io);
+    expect(r.kind).toBe("files");
+    if (r.kind === "files") {
+      expect(r.files).toContain("packages/core/src/a.ts");
+      expect(r.files).toContain("packages/core/src/b.ts");
+      expect(r.empty).toBe(false);
+    }
+  });
+
+  test("main push widens base when gh returns last_ok", () => {
+    const lastOk = "cccccccccccccccccccccccccccccccccccccccc";
+    const io = mockIo({
+      commandExists: (n) => n === "gh",
+      findLastSuccessfulMainHead: () => lastOk,
+      gitDiffNameStatus: (base) => {
+        expect(base).toBe(lastOk);
+        return ["M\tpackages/core/src/x.ts"];
+      },
+    });
+    const r = resolveRouteInputs(
+      baseInput({ eventName: "push", githubRef: "refs/heads/main" }),
+      io,
+    );
+    expect(r.kind).toBe("files");
+    if (r.kind === "files") expect(r.baseSha).toBe(lastOk);
+    expect(io.logs.some((l) => l.includes("widening main route base"))).toBe(true);
+  });
+
+  test("main push does not widen when gh missing", () => {
+    let seenBase = "";
+    const io = mockIo({
+      commandExists: () => false,
+      findLastSuccessfulMainHead: () => {
+        throw new Error("should not call");
+      },
+      gitDiffNameStatus: (base) => {
+        seenBase = base;
+        return [];
+      },
+    });
+    const input = baseInput({ eventName: "push", githubRef: "refs/heads/main" });
+    resolveRouteInputs(input, io);
+    expect(seenBase).toBe(input.baseSha);
+  });
+
+  test("PR never widens even when gh available", () => {
+    let called = false;
+    const io = mockIo({
+      commandExists: () => true,
+      findLastSuccessfulMainHead: () => {
+        called = true;
+        return "dddddddddddddddddddddddddddddddddddddddd";
+      },
+      gitDiffNameStatus: () => [],
+    });
+    resolveRouteInputs(baseInput({ eventName: "pull_request" }), io);
+    expect(called).toBe(false);
+  });
+});
+
+describe("buildDetectChangesOutputs interactions", () => {
+  test("force-all emits full suite + bypass true", () => {
+    const { body, plan, bypassContentCache } = buildDetectChangesOutputs(baseInput(), {
+      kind: "force_all",
+      reason: "x",
+    });
+    expect(bypassContentCache).toBe(true);
+    expect(plan.unit).toBe(true);
+    expect(plan.consumer).toBe(true);
+    expect(plan.packages_dist).toBe(true);
+    const parsed = parseOutput(body);
+    expect(parsed.unit).toBe("true");
+    expect(parsed.bypass_content_cache).toBe("true");
+    // JOB_NAMES order: 14 jobs then bypass
+    const lines = body.trimEnd().split("\n");
+    expect(lines[0]).toBe("checks=true");
+    expect(lines.at(-1)).toBe("bypass_content_cache=true");
+    expect(lines.length).toBe(15);
+  });
+
+  test("force-all on main push does NOT thin consumer/bench", () => {
+    const { plan } = buildDetectChangesOutputs(
+      baseInput({ eventName: "push", githubRef: "refs/heads/main" }),
+      { kind: "force_all", reason: "x" },
+    );
+    expect(plan.consumer).toBe(true);
+    expect(plan.bench_smoke).toBe(true);
+    expect(plan.interaction_perf).toBe(true);
+  });
+
+  test("empty files → checks-only (not force-all)", () => {
+    const { plan, bypassContentCache } = buildDetectChangesOutputs(baseInput(), {
+      kind: "files",
+      files: [],
+      baseSha: "a",
+      empty: true,
+    });
+    expect(plan.checks).toBe(true);
+    expect(plan.unit).toBe(false);
+    expect(plan.consumer).toBe(false);
+    expect(bypassContentCache).toBe(false);
+  });
+
+  test("main push non-empty thins consumer/bench/interaction_perf only", () => {
+    const files = ["packages/core/src/x.ts"];
+    const { plan } = buildDetectChangesOutputs(
+      baseInput({ eventName: "push", githubRef: "refs/heads/main" }),
+      { kind: "files", files, baseSha: "a", empty: false },
+    );
+    const unthinned = planJobs(classifyChangedPaths(files));
+    expect(unthinned.consumer).toBe(true); // package surface would schedule consumer
+    expect(plan.consumer).toBe(false);
+    expect(plan.bench_smoke).toBe(false);
+    expect(plan.interaction_perf).toBe(false);
+    // Must NOT force-off component / packages_dist
+    expect(plan.component).toBe(unthinned.component);
+    expect(plan.packages_dist).toBe(unthinned.packages_dist);
+    expect(plan.unit).toBe(true);
+  });
+
+  test("main push empty diff does not thin (no consumer flags to clear anyway)", () => {
+    const { plan } = buildDetectChangesOutputs(
+      baseInput({ eventName: "push", githubRef: "refs/heads/main" }),
+      { kind: "files", files: [], baseSha: "a", empty: true },
+    );
+    // Empty path: checks only; thinning branch skipped
+    expect(plan.checks).toBe(true);
+    expect(plan.consumer).toBe(false);
+  });
+
+  test("run-compat on PR forces consumer+packages_dist after empty routing", () => {
+    const { plan } = buildDetectChangesOutputs(baseInput({ prLabels: "docs,run-compat" }), {
+      kind: "files",
+      files: [],
+      baseSha: "a",
+      empty: true,
+    });
+    expect(plan.checks).toBe(true);
+    expect(plan.consumer).toBe(true);
+    expect(plan.packages_dist).toBe(true);
+    // Other jobs stay checks-only
+    expect(plan.unit).toBe(false);
+    expect(plan.component).toBe(false);
+  });
+
+  test("run-compat applies on force-all PR (already true — still true)", () => {
+    const { plan } = buildDetectChangesOutputs(baseInput({ prLabels: "run-compat" }), {
+      kind: "force_all",
+      reason: "x",
+    });
+    expect(plan.consumer).toBe(true);
+    expect(plan.packages_dist).toBe(true);
+  });
+
+  test("run-compat does not fire on push even with label string present", () => {
+    const files = ["README.md"];
+    const { plan } = buildDetectChangesOutputs(
+      baseInput({
+        eventName: "push",
+        githubRef: "refs/heads/main",
+        prLabels: "run-compat",
+      }),
+      { kind: "files", files, baseSha: "a", empty: false },
+    );
+    // README alone → checks only; main thin not changing much; no run-compat
+    expect(plan.consumer).toBe(false);
+    expect(plan.packages_dist).toBe(false);
+  });
+
+  test("bypass_content_cache independent of thinning/run-compat patches", () => {
+    const files = ["packages/core/src/x.ts"];
+    const changes = classifyChangedPaths(files);
+    const expectedBypass = shouldBypassContentCache(changes, { forceAll: false });
+    const { bypassContentCache } = buildDetectChangesOutputs(
+      baseInput({
+        eventName: "push",
+        githubRef: "refs/heads/main",
+        prLabels: "run-compat", // ignored on push
+      }),
+      { kind: "files", files, baseSha: "a", empty: false },
+    );
+    expect(bypassContentCache).toBe(expectedBypass);
+  });
+
+  test("applyMainPushThinning / applyRunCompat are pure patches", () => {
+    const plan = planJobs(classifyChangedPaths(["packages/core/src/x.ts"]));
+    const thinned = applyMainPushThinning(plan);
+    expect(thinned.consumer).toBe(false);
+    expect(plan.consumer).toBe(true); // original untouched
+    const forced = applyRunCompat(thinned);
+    expect(forced.consumer).toBe(true);
+    expect(forced.packages_dist).toBe(true);
+  });
+});
+
+describe("runDetectChanges end-to-end (injected io)", () => {
+  test("writes single github output body for force-all", () => {
+    const io = mockIo();
+    runDetectChanges(baseInput({ baseSha: "" }), io);
+    expect(io.outputs.length).toBe(1);
+    expect(io.logs.some((l) => l.includes("force-all"))).toBe(true);
+    expect(parseOutput(io.outputs[0]!).unit).toBe("true");
+  });
+
+  test("main package change: one write, thinned flags", () => {
+    const io = mockIo({
+      gitDiffNameStatus: () => ["M\tpackages/core/src/x.ts"],
+    });
+    runDetectChanges(baseInput({ eventName: "push", githubRef: "refs/heads/main" }), io);
+    expect(io.outputs.length).toBe(1);
+    const o = parseOutput(io.outputs[0]!);
+    expect(o.unit).toBe("true");
+    expect(o.consumer).toBe("false");
+    expect(o.bench_smoke).toBe("false");
+    expect(o.interaction_perf).toBe("false");
+    expect(o.packages_dist).toBe("true");
+    expect(io.logs.some((l) => l.includes("thinned consumer/bench"))).toBe(true);
+  });
+
+  test("run-compat log + output on labeled PR with empty diff", () => {
+    const io = mockIo({ gitDiffNameStatus: () => [] });
+    runDetectChanges(baseInput({ prLabels: "run-compat" }), io);
+    expect(io.logs.some((l) => l.includes("run-compat: forced"))).toBe(true);
+    const o = parseOutput(io.outputs[0]!);
+    expect(o.consumer).toBe("true");
+    expect(o.packages_dist).toBe("true");
+  });
+});
+
+describe("production adapter contracts", () => {
+  test("lastSuccessfulMainHeadJq embeds head as a JSON string (no jq --arg)", async () => {
+    const { lastSuccessfulMainHeadJq } = await import("./cli");
+    const jq = lastSuccessfulMainHeadJq("abc123");
+    expect(jq).toContain('.head_sha != "abc123"');
+    expect(jq).not.toContain("--arg");
+    // Escapes quotes inside the sha (defensive — SHAs are hex, but contract is string-safe).
+    const weird = lastSuccessfulMainHeadJq('x"y');
+    expect(weird).toContain('.head_sha != "x\\"y"');
+  });
+});
+
+describe("detect-changes CLI smoke", () => {
+  test("force-all path via env writes GITHUB_OUTPUT", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "detect-changes-"));
+    const outPath = join(dir, "github_output");
+    try {
+      const proc = Bun.spawn(["bun", "scripts/ci-routing.ts", "detect-changes"], {
+        cwd: join(import.meta.dir, "../.."),
+        env: {
+          ...process.env,
+          EVENT_NAME: "pull_request",
+          GITHUB_REF: "refs/pull/9/merge",
+          BASE_SHA: "",
+          HEAD_SHA: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          PR_LABELS: "",
+          REPO: "ljodea/ggsvelte",
+          GITHUB_OUTPUT: outPath,
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const code = await proc.exited;
+      const stderr = await new Response(proc.stderr).text();
+      expect(code, stderr).toBe(0);
+      const body = readFileSync(outPath, "utf8");
+      expect(body).toContain("unit=true");
+      expect(body).toContain("bypass_content_cache=true");
+      // Matches formatGithubOutputs force-all
+      expect(body).toBe(
+        formatGithubOutputs(planJobs(classifyChangedPaths([]), { forceAll: true }), {
+          bypassContentCache: true,
+        }),
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/ci-routing/detect-changes.test.ts
+++ b/scripts/ci-routing/detect-changes.test.ts
@@ -45,7 +45,8 @@ function mockIo(over: Partial<DetectChangesIo> = {}): DetectChangesIo & {
     logs,
     outputs,
     commandExists: () => false,
-    findLastSuccessfulMainHead: () => undefined,
+    // Empty string = no last-ok (same branch as undefined in the driver).
+    findLastSuccessfulMainHead: () => "",
     gitFetchDepth1: () => {},
     gitCommitExists: () => true,
     gitDiffNameStatus: () => [],

--- a/scripts/ci-routing/detect-changes.ts
+++ b/scripts/ci-routing/detect-changes.ts
@@ -1,0 +1,196 @@
+/**
+ * detect-changes job driver (extracted from .github/workflows/ci.yml).
+ *
+ * Computes the final JobPlan (path routing + #244 main thinning + #246
+ * run-compat) and writes GITHUB_OUTPUT once. Git/gh side effects are
+ * injected so unit tests never touch the network.
+ */
+import {
+  classifyChangedPaths,
+  formatGithubOutputs,
+  parseNameStatusList,
+  planJobs,
+  type JobPlan,
+} from "./routing";
+import { shouldBypassContentCache } from "./content-hash";
+
+export const ZERO_SHA = "0000000000000000000000000000000000000000";
+
+export type DetectChangesInput = {
+  eventName: string;
+  githubRef: string;
+  baseSha: string;
+  headSha: string;
+  /** Comma-separated PR labels (GHA join). Matching is exact line after split — no trim. */
+  prLabels: string;
+  repo: string;
+};
+
+/**
+ * I/O surface for the driver. Production wires real git/gh; tests inject fakes.
+ */
+export type DetectChangesIo = {
+  commandExists: (name: string) => boolean;
+  /**
+   * Last successful main CI head excluding `headSha`, or undefined when
+   * unavailable / API fails / empty (mirrors `gh … || true` + empty jq).
+   */
+  findLastSuccessfulMainHead: (repo: string, headSha: string) => string | undefined;
+  /** Best-effort fetch; failures ignored (bash: `git fetch … || true`). */
+  gitFetchDepth1: (sha: string) => void;
+  gitCommitExists: (sha: string) => boolean;
+  /**
+   * `git diff --name-status base...head` lines.
+   * - `string[]` — successful diff (may be empty → checks-only)
+   * - `"error"` — command failed / buffer overflow → force-all (do not
+   *   collapse to empty/checks-only; that would skip product jobs while
+   *   detect-changes still greens)
+   */
+  gitDiffNameStatus: (base: string, head: string) => string[] | "error";
+  writeGithubOutput: (body: string) => void;
+  log: (msg: string) => void;
+};
+
+export function isMissingBase(baseSha: string): boolean {
+  return baseSha.length === 0 || baseSha === ZERO_SHA;
+}
+
+export function isMainPush(eventName: string, githubRef: string): boolean {
+  return eventName === "push" && githubRef === "refs/heads/main";
+}
+
+/** Exact label match after comma-split (no trim) — matches bash `grep -qx`. */
+export function hasExactLabel(prLabels: string, label: string): boolean {
+  if (prLabels.length === 0) return false;
+  return prLabels.split(",").some((line) => line === label);
+}
+
+/**
+ * Apply #244 main thinning: consumer / bench_smoke / interaction_perf off.
+ * Does not touch component or packages_dist (Codecov main badges).
+ */
+export function applyMainPushThinning(plan: JobPlan): JobPlan {
+  return {
+    ...plan,
+    consumer: false,
+    bench_smoke: false,
+    interaction_perf: false,
+  };
+}
+
+/** Apply #246 run-compat: force consumer + packages_dist on. */
+export function applyRunCompat(plan: JobPlan): JobPlan {
+  return {
+    ...plan,
+    consumer: true,
+    packages_dist: true,
+  };
+}
+
+type RouteResolution =
+  | { kind: "force_all"; reason: string }
+  | { kind: "files"; files: string[]; baseSha: string; empty: boolean };
+
+/**
+ * Resolve which files (or force-all) feed path routing — pure given io fakes.
+ */
+export function resolveRouteInputs(
+  input: DetectChangesInput,
+  io: DetectChangesIo,
+): RouteResolution {
+  if (isMissingBase(input.baseSha)) {
+    return { kind: "force_all", reason: "no usable base SHA — force-all" };
+  }
+
+  let baseSha = input.baseSha;
+
+  // Main + cancel-in-progress: widen base to last successful CI head on main.
+  if (isMainPush(input.eventName, input.githubRef) && io.commandExists("gh")) {
+    const lastOk = io.findLastSuccessfulMainHead(input.repo, input.headSha);
+    if (lastOk !== undefined && lastOk.length > 0) {
+      io.log(`widening main route base ${input.baseSha} → last successful CI ${lastOk}`);
+      baseSha = lastOk;
+    }
+  }
+
+  io.gitFetchDepth1(baseSha);
+  if (!io.gitCommitExists(baseSha)) {
+    return { kind: "force_all", reason: `base SHA ${baseSha} not resolvable — force-all` };
+  }
+
+  const nameStatusLines = io.gitDiffNameStatus(baseSha, input.headSha);
+  if (nameStatusLines === "error") {
+    return {
+      kind: "force_all",
+      reason: `git diff --name-status failed for ${baseSha}...${input.headSha} — force-all`,
+    };
+  }
+  if (nameStatusLines.length === 0) {
+    return { kind: "files", files: [], baseSha, empty: true };
+  }
+  // parseNameStatusList keeps rename/copy both sides (same as emit --stdin path).
+  const files = parseNameStatusList(nameStatusLines.join("\n"));
+  return { kind: "files", files, baseSha, empty: false };
+}
+
+/**
+ * Build final job flags after routing + optional main thin + run-compat.
+ */
+export function buildDetectChangesOutputs(
+  input: DetectChangesInput,
+  route: RouteResolution,
+): { body: string; plan: JobPlan; bypassContentCache: boolean } {
+  const forceAll = route.kind === "force_all";
+  const files = route.kind === "files" ? route.files : [];
+  const changes = classifyChangedPaths(files);
+  let plan = planJobs(changes, { forceAll });
+  const bypassContentCache = shouldBypassContentCache(changes, { forceAll });
+
+  // #244: thin only on main push with a resolved non-empty diff.
+  // force-all and empty-diff stay full / checks-only (no thin).
+  if (
+    !forceAll &&
+    route.kind === "files" &&
+    !route.empty &&
+    isMainPush(input.eventName, input.githubRef)
+  ) {
+    plan = applyMainPushThinning(plan);
+  }
+
+  // #246: last — label always wins on PRs, including force-all / empty paths.
+  if (input.eventName === "pull_request" && hasExactLabel(input.prLabels, "run-compat")) {
+    plan = applyRunCompat(plan);
+  }
+
+  const body = formatGithubOutputs(plan, { bypassContentCache });
+  return { body, plan, bypassContentCache };
+}
+
+/**
+ * Full detect-changes driver: resolve route → plan → single GITHUB_OUTPUT write.
+ */
+export function runDetectChanges(input: DetectChangesInput, io: DetectChangesIo): void {
+  const route = resolveRouteInputs(input, io);
+
+  if (route.kind === "force_all") {
+    io.log(route.reason);
+  } else if (route.empty) {
+    io.log("empty changed-file set — checks-only routing");
+  } else {
+    io.log(
+      `event=${input.eventName} base=${route.baseSha} head=${input.headSha} files=${route.files.length}`,
+    );
+    if (isMainPush(input.eventName, input.githubRef)) {
+      io.log(
+        "main push: thinned consumer/bench (issue #244); packages_dist+component stay path-routed for coverage",
+      );
+    }
+  }
+
+  if (input.eventName === "pull_request" && hasExactLabel(input.prLabels, "run-compat")) {
+    io.log("run-compat: forced consumer + packages_dist (issue #246)");
+  }
+
+  const { body } = buildDetectChangesOutputs(input, route);
+  io.writeGithubOutput(body);
+}

--- a/scripts/release-wiring.test.ts
+++ b/scripts/release-wiring.test.ts
@@ -158,7 +158,9 @@ describe("R0 release wiring", () => {
     // detect-changes exports bypass covering force-all / lockfile / ci.yml / router / actions.
     const detect = ci.slice(ci.indexOf("  detect-changes:"), ci.indexOf("  packages-dist:"));
     expect(detect).toContain("bypass_content_cache:");
-    expect(detect).toContain("emit-github-output");
+    // Job driver lives in scripts/ci-routing/detect-changes.ts (issue #393).
+    expect(detect).toContain("scripts/ci-routing.ts detect-changes");
+    expect(detect).not.toContain("emit-github-output");
 
     // packages-dist keeps its specialized dist-payload protocol (not the marker composite).
     const producerJob = ci.slice(
@@ -293,9 +295,33 @@ describe("R0 release wiring", () => {
 
   it("path-routes CI jobs through scripts/ci-routing.ts and a ci-gate aggregator", () => {
     const ci = read(".github/workflows/ci.yml");
-    expect(ci).toContain("scripts/ci-routing.ts emit-github-output");
+    // ci.yml detect-changes delegates to the detect-changes driver; vr-compare
+    // still uses emit-github-output for its thinner base-resolution path.
+    expect(ci).toContain("scripts/ci-routing.ts detect-changes");
     expect(ci).toContain("  detect-changes:");
     expect(ci).toContain("  ci-gate:");
+    expect(ci).toContain("ci-gate (required aggregator)");
+    expect(ci).toContain("DETECT_RESULT");
+    // Fifteen routing outputs must stay wired for branch protection / needs.
+    for (const out of [
+      "checks:",
+      "unit:",
+      "component:",
+      "consumer:",
+      "build:",
+      "svelte_check:",
+      "docs_site:",
+      "actions_security:",
+      "bench_smoke:",
+      "interaction_perf:",
+      "packages_dist:",
+      "vr:",
+      "pages:",
+      "docs_journeys:",
+      "bypass_content_cache:",
+    ]) {
+      expect(ci, out).toContain(`      ${out}`);
+    }
     // Checks job is pre-commit stage only (format/lint/guards). Heavy analysis
     // lives on dedicated CI jobs — never reintroduced via hook-stage pre-push.
     expect(ci).not.toContain("hook-stage pre-push");
@@ -382,28 +408,30 @@ describe("R0 release wiring", () => {
 });
 
 it("thins expensive jobs on main push (issue #244)", () => {
-  const ci = read(".github/workflows/ci.yml");
-  // Consumer/bench stay PR-primary; packages_dist+component remain path-routed
-  // so Codecov can refresh packages/svelte coverage on main.
-  expect(ci).toContain("main push: thinned consumer/bench (issue #244)");
-  expect(ci).toContain('echo "consumer=false"');
-  expect(ci).toContain('echo "bench_smoke=false"');
-  expect(ci).toContain('echo "interaction_perf=false"');
+  // Policy lives in detect-changes.ts after #393 extraction (not inline bash).
+  const driver = read("scripts/ci-routing/detect-changes.ts");
+  expect(driver).toContain("main push: thinned consumer/bench (issue #244)");
+  expect(driver).toContain("applyMainPushThinning");
+  expect(driver).toMatch(/consumer:\s*false/);
+  expect(driver).toMatch(/bench_smoke:\s*false/);
+  expect(driver).toMatch(/interaction_perf:\s*false/);
   // Must NOT force-off component/packages_dist on main (Codecov main badges).
-  const mainThin = ci.slice(
-    ci.indexOf("main push: thinned consumer/bench"),
-    ci.indexOf("main push: thinned consumer/bench") + 400,
+  const thinFn = driver.slice(
+    driver.indexOf("function applyMainPushThinning"),
+    driver.indexOf("function applyRunCompat"),
   );
-  expect(mainThin).not.toContain("component=false");
-  expect(mainThin).not.toContain("packages_dist=false");
+  expect(thinFn).not.toContain("component:");
+  expect(thinFn).not.toContain("packages_dist:");
 });
 
 it("tiers the PR consumer matrix (issue #246)", () => {
   const ci = read(".github/workflows/ci.yml");
+  const driver = read("scripts/ci-routing/detect-changes.ts");
   expect(ci).toContain("run-compat");
   expect(ci).toContain("flavor=pr");
   // Label must force consumer even when path routing would skip (Codex P2).
-  expect(ci).toContain("run-compat: forced consumer + packages_dist");
+  expect(driver).toContain("run-compat: forced consumer + packages_dist");
+  expect(driver).toContain("applyRunCompat");
   // Main push stays thinned per #244; full required is PR+label or nightly.
   expect(ci).not.toMatch(/full required[\s\S]{0,40}push\/main/i);
 });


### PR DESCRIPTION
## Summary

`/astral-maintain` on `.github/workflows/ci.yml` — implements deferred **#393** after the step-composite extraction in #394.

The `detect-changes` job owned a long bash driver (force-all, main base widening, empty/failed diffs, #244 main thinning, #246 run-compat) that could not be unit-tested. That logic now lives in `scripts/ci-routing/detect-changes.ts` with injectable I/O; the workflow step is env + one CLI invocation.

### Correctness fixes surfaced by the extract

| Issue | Before | After |
|-------|--------|-------|
| Main base widening (#244) | `gh api --jq --arg …` — **gh has no jq `--arg`**, so widening was a silent no-op under `\|\| true` | Embed head SHA as a JSON string in `--jq` (`lastSuccessfulMainHeadJq`) |
| Failed / oversized `git diff` | Treated as empty → **checks-only** (could skip product jobs while detect-changes greened) | `"error"` → **force-all** + larger `maxBuffer` |
| Missing `GITHUB_OUTPUT` | Silent success with empty outputs | CLI fails closed |

### Structure

- `scripts/ci-routing/detect-changes.ts` — resolve route → build final `JobPlan` (thin + run-compat patches) → **single** `formatGithubOutputs` write
- `bun scripts/ci-routing.ts detect-changes` — production I/O (git/gh)
- Characterization tests for the interaction matrix (force-all × main thin, empty × run-compat, widening gates, …)
- `release-wiring` assertions repointed at the driver + full 15-output job contract

Job ids, outputs, `needs`, and branch-protection names are unchanged.

## Astral audit

- **Target:** `.github/workflows/ci.yml`
- **Chosen:** extract `detect-changes` orchestration (#393)
- **Not chosen this PR:** domain reusable workflows (#392), packages-dist composite, playwright unzip preamble, ci-gate bun -e thin-up

## Verification

```text
bun test scripts/ci-routing/detect-changes.test.ts scripts/ci-routing.test.ts \
  scripts/release-wiring.test.ts scripts/ci-composites.test.ts scripts/actionlint.test.ts
# 129 pass

bun run lint:actions   # 13 workflows clean
uvx zizmor==1.26.1 .github/workflows .github/actions  # no findings
```

## Follow-ups

- https://github.com/ljodea/ggsvelte/issues/392 — domain job split without renaming required checks
- https://github.com/ljodea/ggsvelte/issues/415 — extract vr-compare base-resolution into shared helper
- Closes https://github.com/ljodea/ggsvelte/issues/393

## Test plan

- [x] Characterization + release-wiring + actionlint + ci-routing tests
- [x] actionlint / zizmor clean
- [ ] CI green on this PR (workflow + routing self-change → product force via `ci_routing` lane)