### PR TITLE
ci: restore elastic GitHub-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,12 @@
 # ggsvelte CI (plan M0b + path routing). Parallel jobs after a cached bun install.
 # All third-party actions pinned by full commit SHA (zizmor-enforced).
 #
-# Linux jobs use repo self-hosted runners labeled `ggsvelte` (ops tooling
-# lives outside this FOSS tree). Privileged write/OIDC workflows (release,
-# pages deploy, vr-approve, bench-trend) stay on GitHub-hosted runners so a
-# compromised CI workspace cannot harvest publish credentials. Windows/macOS
-# matrix rows and manual AT stay hosted as well.
+# PR and main-branch correctness jobs use standard GitHub-hosted runners. This
+# public repository receives hosted execution without consuming the owner's
+# private-repository minute allowance, and the elastic pool avoids serializing
+# the job graph behind a handful of persistent runner services. Explicit,
+# hardware-sensitive benchmark/nightly workflows may still use the repo's
+# self-hosted pool; privileged write/OIDC workflows remain GitHub-hosted.
 #
 # Path routing: scripts/ci-routing.ts classifies the changed file set and
 # emits per-job flags. Expensive jobs are skipped when their inputs did not
@@ -46,19 +47,11 @@ concurrency:
   # (concurrency alone does not cancel when no replacement run starts).
   cancel-in-progress: true
 
-# Self-hosted pool (issues #247, #319, #321, throughput fix 2026-07):
-# One cx53 host, four cpuset-isolated runners (4 vCPUs each), all labeled
-# only `ggsvelte`. There is NO separate heavy/light GitHub label: that
-# split was a lie once every runner carried both labels (same match set,
-# zero scheduling effect) and a bottleneck when only two runners had
-# `ggsvelte-heavy` while four "light" runners sat idle.
-# - Every Linux job uses `runs-on: [self-hosted, ggsvelte]`. Concurrency
-#   cap = 4 jobs host-wide (one per runner service). CPU isolation is
-#   systemd CPUAffinity + docker cpuset shim, not GitHub labels.
-# - Path routing + cancel-on-close + cancel-in-progress control *which*
-#   work runs; labels do not invent free capacity.
-# - Runner services share HOME; Bun installs use job-private runner.temp.
-# - Job hooks log host telemetry (load, PSI, memory, disk).
+# Hosted execution is deliberate: this workflow fans out into more jobs than
+# the four-runner self-hosted pool can admit concurrently. The former pool made
+# queue time dominate execution time and caused independent PRs to block one
+# another even on a 16-vCPU host. Path routing and content hashes still reduce
+# unnecessary work, but no longer sit behind a repo-local four-job ceiling.
 
 env:
   # Keep in sync with: spikes/browser devDependency "playwright" and the
@@ -68,7 +61,7 @@ env:
 jobs:
   detect-changes:
     name: detect-changes (path routing)
-    runs-on: [self-hosted, ggsvelte]
+    runs-on: ubuntu-latest
     permissions:
       actions: read
       contents: read
@@ -186,7 +179,7 @@ jobs:
     name: packages-dist (build + upload packages/*/dist)
     needs: detect-changes
     if: needs.detect-changes.outputs.packages_dist == 'true'
-    runs-on: [self-hosted, ggsvelte]
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
@@ -301,7 +294,7 @@ jobs:
     name: checks (pre-commit stage)
     needs: detect-changes
     if: needs.detect-changes.outputs.checks == 'true'
-    runs-on: [self-hosted, ggsvelte]
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
@@ -324,7 +317,7 @@ jobs:
     name: unit (bun test spec + core)
     needs: detect-changes
     if: needs.detect-changes.outputs.unit == 'true'
-    runs-on: [self-hosted, ggsvelte]
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
@@ -379,7 +372,7 @@ jobs:
     name: compatibility matrix (machine-checked source)
     needs: detect-changes
     if: needs.detect-changes.outputs.consumer == 'true'
-    runs-on: [self-hosted, ggsvelte]
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     outputs:
@@ -422,8 +415,8 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix: ${{ fromJSON(needs.compatibility-matrix.outputs.matrix) }}
-    # Linux rows use the private self-hosted ggsvelte pool; Windows/macOS stay on GitHub-hosted.
-    runs-on: ${{ startsWith(matrix.os, 'ubuntu') && fromJSON('["self-hosted","ggsvelte"]') || matrix.os }}
+    # Every matrix row uses its standard GitHub-hosted image.
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     permissions:
       contents: read
@@ -509,7 +502,7 @@ jobs:
     if: >-
       needs.detect-changes.outputs.component == 'true' &&
       needs.packages-dist.result == 'success'
-    runs-on: [self-hosted, ggsvelte]
+    runs-on: ubuntu-latest
     env:
       # GitHub runs the container as root, while /github/home belongs to
       # pwuser. Firefox refuses that ownership mismatch.
@@ -630,7 +623,7 @@ jobs:
     if: >-
       needs.detect-changes.outputs.component == 'true' &&
       needs.packages-dist.result == 'success'
-    runs-on: [self-hosted, ggsvelte]
+    runs-on: ubuntu-latest
     env:
       # GitHub runs the container as root, while /github/home belongs to
       # pwuser. Firefox refuses that ownership mismatch.
@@ -702,7 +695,7 @@ jobs:
     if: >-
       needs.detect-changes.outputs.docs_journeys == 'true' &&
       needs.packages-dist.result == 'success'
-    runs-on: [self-hosted, ggsvelte]
+    runs-on: ubuntu-latest
     env:
       # GitHub runs the container as root, while /github/home belongs to
       # pwuser. Firefox refuses that ownership mismatch.
@@ -786,7 +779,7 @@ jobs:
     if: >-
       needs.detect-changes.outputs.interaction_perf == 'true' &&
       needs.packages-dist.result == 'success'
-    runs-on: [self-hosted, ggsvelte]
+    runs-on: ubuntu-latest
     env:
       HOME: /root
     container:
@@ -841,7 +834,7 @@ jobs:
     name: build (packages + knip + type-aware + publint)
     needs: detect-changes
     if: needs.detect-changes.outputs.build == 'true'
-    runs-on: [self-hosted, ggsvelte]
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
@@ -895,7 +888,7 @@ jobs:
     name: svelte-check (packages/svelte + apps/docs)
     needs: detect-changes
     if: needs.detect-changes.outputs.svelte_check == 'true'
-    runs-on: [self-hosted, ggsvelte]
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
@@ -932,7 +925,7 @@ jobs:
     name: docs-site (adapter-static build + pages links)
     needs: detect-changes
     if: needs.detect-changes.outputs.docs_site == 'true'
-    runs-on: [self-hosted, ggsvelte]
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
@@ -969,7 +962,7 @@ jobs:
     name: actions-security (actionlint + zizmor)
     needs: detect-changes
     if: needs.detect-changes.outputs.actions_security == 'true'
-    runs-on: [self-hosted, ggsvelte]
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
@@ -1005,7 +998,7 @@ jobs:
     name: bench-smoke (mitata, 1k workload)
     needs: detect-changes
     if: needs.detect-changes.outputs.bench_smoke == 'true'
-    runs-on: [self-hosted, ggsvelte]
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
@@ -1044,7 +1037,7 @@ jobs:
     # not qualify. Legacy vr-update/pr-<n> bot path still allowed.
     name: vr-baseline-guard (same-PR smoke baselines)
     if: github.event_name == 'pull_request'
-    runs-on: [self-hosted, ggsvelte]
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
@@ -1097,7 +1090,7 @@ jobs:
       - actions-security
       - bench-smoke
       - vr-baseline-guard
-    runs-on: [self-hosted, ggsvelte]
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:

--- a/.github/workflows/vr-compare.yml
+++ b/.github/workflows/vr-compare.yml
@@ -50,7 +50,7 @@ jobs:
   detect-changes:
     name: detect-changes (path routing)
     if: github.event_name == 'pull_request'
-    runs-on: [self-hosted, ggsvelte]
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     outputs:
@@ -93,7 +93,7 @@ jobs:
     name: build docs, screenshot, upload candidate baselines
     needs: detect-changes
     if: github.event_name == 'pull_request' && needs.detect-changes.outputs.vr == 'true'
-    runs-on: [self-hosted, ggsvelte]
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     container:
@@ -274,7 +274,7 @@ jobs:
     name: /approve-visuals — regenerate baselines at merged commit (pinned container)
     needs: approve-gate
     if: needs.approve-gate.outputs.match == 'true'
-    runs-on: [self-hosted, ggsvelte]
+    runs-on: ubuntu-latest
     permissions:
       contents: read # checkout only; this job can write nothing
     container:

--- a/scripts/release-wiring.test.ts
+++ b/scripts/release-wiring.test.ts
@@ -408,31 +408,32 @@ it("tiers the PR consumer matrix (issue #246)", () => {
   expect(ci).not.toMatch(/full required[\s\S]{0,40}push\/main/i);
 });
 
-it("uses one self-hosted ggsvelte pool (no heavy/light label split)", () => {
+it("uses elastic hosted runners for PR correctness and visual checks", () => {
   const ci = read(".github/workflows/ci.yml");
   const vr = read(".github/workflows/vr-compare.yml");
   const bench = read(".github/workflows/bench.yml");
   const nightly = read(".github/workflows/compatibility-nightly.yml");
   const cancel = read(".github/workflows/cancel-on-pr-close.yml");
 
-  // Single-label pool: every self-hosted Linux job uses `ggsvelte` only.
-  // Dual-label scheduling was theater; the old 2-slot heavy-only pool was the
-  // real bottleneck (issues #247, #319, #321). Comments may mention the retired
-  // label when explaining history — assert on runs-on lines only.
+  // PR CI and VR must not regress to the four-slot repo-local pool. Optional,
+  // hardware-sensitive benchmark and nightly workflows may remain self-hosted.
   for (const workflow of [ci, vr, bench, nightly]) {
     expect(heavyRunsOnCount(workflow)).toBe(0);
     expect(workflow).not.toContain("heavy-self-hosted-cpu");
   }
-  expect(selfHostedGgsvelteCount(ci)).toBeGreaterThanOrEqual(10);
-  expect(selfHostedGgsvelteCount(vr)).toBe(3);
+  expect(selfHostedGgsvelteCount(ci)).toBe(0);
+  expect(selfHostedGgsvelteCount(vr)).toBe(0);
+  expect(ci.match(/runs-on: ubuntu-latest/g)?.length).toBeGreaterThanOrEqual(16);
+  expect(ci).toContain("runs-on: ${{ matrix.os }}");
+  expect(vr.match(/runs-on: ubuntu-latest/g)?.length).toBeGreaterThanOrEqual(4);
   expect(selfHostedGgsvelteCount(bench)).toBe(1);
   expect(selfHostedGgsvelteCount(nightly)).toBeGreaterThanOrEqual(1);
   expect(ci).not.toContain("heavy-component");
   expect(ci).not.toContain("heavy-packages-dist");
   expect(ci).not.toContain("heavy-consumer-ubuntu");
   expect(ci).not.toContain("group: heavy-interaction-perf");
-  // Documented live topology + cancel-on-close (not label fiction).
-  expect(ci).toContain("four cpuset-isolated runners");
+  // Superseded/closed work is still cancelled independently of runner choice.
+  expect(ci).toContain("elastic pool");
   expect(ci).toContain("cancel-in-progress: true");
   expect(cancel).toContain("pull_request_target");
   expect(cancel).toContain("head_sha");
@@ -492,7 +493,7 @@ it("regenerates docs-owned gallery previews when approved baselines land", () =>
   expect(approve).toContain("apps/docs/src/lib/generated/gallery-previews.ts");
 });
 
-it("uses job-private Bun caches in self-hosted workflows (issue #319)", () => {
+it("uses job-private Bun caches across CI workflows (issue #319)", () => {
   const workflows = [
     ".github/workflows/ci.yml",
     ".github/workflows/vr-compare.yml",


### PR DESCRIPTION
## What changed

- Move every ordinary `CI` workflow job from the four-slot `ggsvelte` self-hosted pool to standard GitHub-hosted runners.
- Move VR change detection, comparison, and approved-baseline regeneration to `ubuntu-latest`.
- Restore the consumer matrix to its declared standard hosted OS images.
- Replace the policy test that enforced universal self-hosting with a regression test that keeps PR CI and VR on elastic hosted runners.
- Leave explicitly invoked benchmark, nightly compatibility, and eval workflows on the self-hosted pool for now.

## Why

PR #150 moved a wide, highly parallel job graph onto four repo-scoped runner services to avoid GitHub-hosted usage. The repository is public, so standard hosted execution is fully discounted and does not consume the owner's private-repository Actions allowance.

The fixed pool became the actual bottleneck. A representative hosted run before #150 completed 12 jobs in about 3 minutes with near-zero queueing. Recent full PR runs consumed roughly 54 runner-minutes but accumulated 66–147 queue-minutes, with individual jobs waiting as long as 24 minutes to start. Routing, hashes, sharding, CPU affinity, and a larger host could not remove the four-job admission ceiling.

This PR changes only runner placement and its enforcement policy so the result is measurable without simultaneously redesigning the job graph.

## Expected developer impact

Independent PRs should fan out without blocking one another on four persistent services. Required feedback should arrive in minutes rather than tens of minutes, allowing agents and humans to act on failures instead of bypassing unfinished CI.

## Experiment

Compare this PR's job start timestamps and workflow wall time with the recent self-hosted baseline:

- full PR workflow wall time: 35–48 minutes
- aggregate per-job queue time: 66–147 minutes
- longest observed job queue: 24 minutes

The first signal is whether sibling jobs start within seconds after `detect-changes` completes.

## Validation

- `bun test scripts/release-wiring.test.ts scripts/ci-routing.test.ts scripts/actionlint.test.ts scripts/ci-composites.test.ts` — 102 passed
- `bun run lint:actions` — 13 workflow files clean
- `uvx zizmor==1.26.1 .github/workflows .github/actions` — no findings
- staged pre-commit hooks — passed
