### PR TITLE
perf(spec): memoize temporal decisions in dataChecks (O(U·n)→O(n))

### DIFF
--- a/packages/spec/src/validate-data-checks.ts
+++ b/packages/spec/src/validate-data-checks.ts
@@ -9,7 +9,14 @@ import { configuredColorScaleType } from "./scale-helpers.js";
 import type { Aes, ChannelName, ColorScaleSpec, PositionScaleSpec } from "./schema.js";
 import { CHANNELS, GEOM_DEFAULTS, SEQUENTIAL_SCHEME_NAMES } from "./schema.js";
 import type { ProfileFieldType, ValidateLimits, ValidateOptions } from "./validate-data.js";
-import { parseTemporalColumn, temporalParserConfigurationError } from "./temporal.js";
+import {
+  canonicalTemporalParserKey,
+  parseTemporalColumn,
+  temporalParserConfigurationError,
+  type TemporalDecision,
+  type TemporalParseOptions,
+  type TemporalParserSpec,
+} from "./temporal.js";
 import {
   parseTemporalInterval,
   temporalLabelConfigurationError,
@@ -18,6 +25,7 @@ import {
 import {
   effectiveChannel,
   resolveFieldEvidence,
+  type FieldEvidenceEntry,
   type ResolveFieldEvidenceResult,
 } from "./validate-data-evidence.js";
 
@@ -63,6 +71,47 @@ const AXIS_CHANNELS = ["x", "y"] as const;
 const COLOR_CHANNELS = ["color", "fill"] as const;
 const SEQUENTIAL_SCHEMES = new Set<string>(SEQUENTIAL_SCHEME_NAMES);
 
+/**
+ * Resolve one field's temporal decision for scale compatibility checks.
+ *
+ * Memoized per dataChecks() call so multi-layer / multi-channel consumers of
+ * the same field under the same parser+options pay O(n) once, not O(U·n).
+ * When parser is auto and options match the evidence pass (no timezone /
+ * disambiguation), reuse FieldEvidenceEntry.temporal instead of re-scanning.
+ *
+ * Cache key omits parseFailure and temporalKind — those only affect how the
+ * decision is interpreted, not the decision itself.
+ */
+function temporalDecisionForField(
+  cache: Map<string, TemporalDecision | null | undefined>,
+  field: string,
+  info: FieldEvidenceEntry | undefined,
+  parser: TemporalParserSpec | "auto",
+  options: TemporalParseOptions,
+): TemporalDecision | null | undefined {
+  const parserKey = parser === "auto" ? "auto" : canonicalTemporalParserKey(parser);
+  const key = `${field}\0${parserKey}\0${options.timezone ?? ""}\0${options.disambiguation ?? ""}`;
+  if (cache.has(key)) return cache.get(key);
+
+  let decision: TemporalDecision | null | undefined;
+  if (info?.values === null || info?.values === undefined) {
+    // Profile-backed fields: no inline values. temporal is always null today.
+    decision = info?.temporal ?? null;
+  } else if (
+    parser === "auto" &&
+    options.timezone === undefined &&
+    options.disambiguation === undefined &&
+    info.temporal !== null
+  ) {
+    // Evidence was built with inferTemporalColumn(column) — same auto defaults.
+    decision = info.temporal;
+  } else {
+    decision = parseTemporalColumn(info.values, parser, options).decision;
+  }
+  cache.set(key, decision);
+  return decision;
+}
+
 export function dataChecks(
   spec: Record<string, unknown>,
   options: ValidateOptions,
@@ -71,6 +120,7 @@ export function dataChecks(
   preResolved?: ResolveFieldEvidenceResult,
 ): SpecError[] {
   const errors: SpecError[] = [];
+  const temporalDecisionCache = new Map<string, TemporalDecision | null | undefined>();
   const scales = isRecord(spec["scales"]) ? spec["scales"] : undefined;
   const scaleRequestsTime = (axis: "x" | "y"): boolean => {
     const config = scales?.[axis] as PositionScaleSpec | undefined;
@@ -328,15 +378,18 @@ export function dataChecks(
       if (type === null) continue;
       if (declared === "time") {
         const info = fields.get(use.field);
-        const decision =
-          info?.values === null || info?.values === undefined
-            ? info?.temporal
-            : parseTemporalColumn(info.values, config?.parse ?? "auto", {
-                ...(config?.timezone !== undefined && { timezone: config.timezone }),
-                ...(config?.disambiguation !== undefined && {
-                  disambiguation: config.disambiguation,
-                }),
-              }).decision;
+        const decision = temporalDecisionForField(
+          temporalDecisionCache,
+          use.field,
+          info,
+          config?.parse ?? "auto",
+          {
+            ...(config?.timezone !== undefined && { timezone: config.timezone }),
+            ...(config?.disambiguation !== undefined && {
+              disambiguation: config.disambiguation,
+            }),
+          },
+        );
         const censoredInvalid =
           config?.parse !== undefined &&
           config.parseFailure === "censor" &&
@@ -439,15 +492,18 @@ export function dataChecks(
       }
 
       const info = fields.get(use.field);
-      const decision =
-        info?.values === null || info?.values === undefined
-          ? info?.temporal
-          : parseTemporalColumn(info.values, config?.parse ?? "auto", {
-              ...(config?.timezone !== undefined && { timezone: config.timezone }),
-              ...(config?.disambiguation !== undefined && {
-                disambiguation: config.disambiguation,
-              }),
-            }).decision;
+      const decision = temporalDecisionForField(
+        temporalDecisionCache,
+        use.field,
+        info,
+        config?.parse ?? "auto",
+        {
+          ...(config?.timezone !== undefined && { timezone: config.timezone }),
+          ...(config?.disambiguation !== undefined && {
+            disambiguation: config.disambiguation,
+          }),
+        },
+      );
       const censoredInvalid =
         config?.parse !== undefined &&
         config.parseFailure === "censor" &&

--- a/packages/spec/tests/validate-tier2.test.ts
+++ b/packages/spec/tests/validate-tier2.test.ts
@@ -7,6 +7,7 @@
 import { fromAny } from "@total-typescript/shoehorn";
 import { describe, expect, it } from "bun:test";
 
+import { aes, gg } from "../src/builder.ts";
 import type { DataProfile } from "../src/validate-data.ts";
 import { validate } from "../src/validate.ts";
 
@@ -444,5 +445,143 @@ describe("tier 2 — M2 statistical layer (snapshot-tested messages)", () => {
     });
     expect(bad[0]!.code).toBe("unknown-stat-column");
     expect(bad[0]!.allowed).toEqual(["count", "density", "ncount", "ndensity"]);
+  });
+});
+
+/**
+ * Characterization for dataChecks temporal decisions: multi-consumer field
+ * reuse, auto+default evidence reuse (ambiguous/invalid/Date), and profile
+ * paths that must NOT reuse evidence temporal (always null) when options differ.
+ */
+describe("tier 2 — temporal decision reuse (characterization)", () => {
+  it("accepts multi-layer charts that share one temporal field under auto time scales", () => {
+    const when = ["2024-01-01", "2024-01-02", "2024-01-03"];
+    const value = [1, 2, 3];
+    const result = validate(
+      {
+        data: { columns: { when, value } },
+        aes: { x: { field: "when" }, y: { field: "value" } },
+        scales: { x: { type: "time" } },
+        layers: [{ geom: "point" }, { geom: "line" }, { geom: "smooth" }],
+      },
+      {},
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  it("reports the same ambiguous auto-inference detail once per consumer path", () => {
+    const errors = errorsOf({
+      data: {
+        columns: {
+          when: ["01/02/2023", "03/04/2023"],
+          value: [1, 2],
+        },
+      },
+      aes: { x: { field: "when" }, y: { field: "value" } },
+      scales: { x: { type: "time" } },
+      layers: [{ geom: "point" }, { geom: "line" }],
+    });
+    expect(errors.map((e) => e.code)).toEqual(["scale-type-mismatch", "scale-type-mismatch"]);
+    expect(errors.every((e) => e.message.includes("ambiguous between: mdy, dmy"))).toBe(true);
+    expect(errors.map((e) => e.path)).toEqual(["/layers/0/aes/x", "/layers/1/aes/x"]);
+  });
+
+  it("preserves explicit-parse rejection details across ymin and ymax on the same scale", () => {
+    const errors = errorsOf({
+      data: {
+        columns: {
+          group: ["a", "b"],
+          lo: ["31/12/2024", "01/01/2025"],
+          hi: ["not-a-date", "02/01/2025"],
+        },
+      },
+      layers: [
+        {
+          geom: "errorbar",
+          aes: { x: { field: "group" }, ymin: { field: "lo" }, ymax: { field: "hi" } },
+        },
+      ],
+      scales: { y: { type: "time", parse: "dmy" } },
+    });
+    const ymax = errors.filter((e) => e.path.endsWith("/ymax"));
+    expect(ymax).toHaveLength(1);
+    expect(ymax[0]?.message).toContain("rejected 1 value");
+    expect(ymax[0]?.message).toContain("not-a-date");
+  });
+
+  it("accepts builder Date cells under auto time scales after multi-layer canonicalize", () => {
+    // PortableSpec forbids raw Date cells; the builder ISO-coerces them, then
+    // multi-layer temporal consumers must share one decision for the field.
+    const when0 = new Date("2024-01-01T00:00:00.000Z");
+    const when1 = new Date("2024-01-02T00:00:00.000Z");
+    const spec = gg(
+      [
+        { when: when0, value: 1 },
+        { when: when1, value: 2 },
+      ],
+      aes({ x: "when", y: "value" }),
+    )
+      .geomPoint()
+      .geomLine()
+      .scaleXDatetime()
+      .spec();
+    expect(validate(spec, {}).ok).toBe(true);
+  });
+
+  it("validates the same field for both position and sequential color consumers", () => {
+    const when = ["2024-01-01", "2024-01-02", "2024-01-03"];
+    const result = validate(
+      {
+        data: { columns: { when, value: [1, 2, 3] } },
+        aes: { x: { field: "when" }, y: { field: "value" }, color: { field: "when" } },
+        scales: {
+          x: { type: "time" },
+          color: { type: "sequential", parse: "iso", temporalKind: "date" },
+        },
+        layers: [{ geom: "point" }],
+      },
+      {},
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  it("profile-backed temporal fields with timezone options do not invent inline evidence", () => {
+    // Profile fields have temporal: null / values: null. A non-default timezone
+    // must still accept profile-typed temporal fields (no accidental reuse of
+    // missing evidence decisions that would flip acceptance).
+    const profile: DataProfile = {
+      fields: [
+        { name: "when", type: "temporal" },
+        { name: "value", type: "quantitative" },
+      ],
+    };
+    const result = validate(
+      {
+        aes: { x: { field: "when" }, y: { field: "value" } },
+        scales: { x: { type: "time", timezone: "America/New_York" } },
+        layers: [{ geom: "point" }, { geom: "line" }],
+      },
+      { profile },
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  it("still rejects profile nominal fields under time scales with disambiguation set", () => {
+    const profile: DataProfile = {
+      fields: [
+        { name: "city", type: "nominal" },
+        { name: "value", type: "quantitative" },
+      ],
+    };
+    const errors = errorsOf(
+      {
+        aes: { x: { field: "city" }, y: { field: "value" } },
+        scales: { x: { type: "time", disambiguation: "earlier" } },
+        layers: [{ geom: "point" }, { geom: "line" }],
+      },
+      { profile },
+    );
+    expect(errors.map((e) => e.code)).toEqual(["scale-type-mismatch", "scale-type-mismatch"]);
+    expect(errors.every((e) => e.message.includes('field "city" is nominal'))).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Big-O maintain pass on `packages/spec`: fix the worst algorithmic hotspot in tier-2 scale/type temporal checks.

**Audit target:** `packages/spec` (25 production sources)

**Chosen finding:** pattern #5 repeated expensive computation in `dataChecks` — each axis/color field *use* called `parseTemporalColumn(...).decision`, re-scanning up to `maxRows` (100k) rows per multi-layer consumer and, for auto+default options, duplicating the evidence pass already stored on `FieldEvidenceEntry.temporal`.

**Before → after:** O(U · n) column re-parses → O(n) once per unique `(field, parser, timezone, disambiguation)` (and free reuse of evidence temporal for auto defaults).

**What n is:** inline data rows examined during tier-2 validate.

## Changes

- Local memo map in `dataChecks` via `temporalDecisionForField`
- Reuse `info.temporal` when `parse === "auto"` and no timezone/disambiguation
- Characterization tests for multi-layer/auto-ambiguous/invalid/Date-builder/color dual-consumer/profile paths

## Verification

```bash
bun test packages/spec
# 325 pass, 0 fail
```

## Follow-ups

- https://github.com/ljodea/ggsvelte/issues/424 — cache exact-format RegExp in `parseExactFormat`
- https://github.com/ljodea/ggsvelte/issues/425 — memoize lint transform-domain column scans

## Codex plan review

APPROVE-WITH-CHANGES: dropped public `decideTemporalColumn` export and RegExp-cache scope; kept local memo + validate-level characterization tests.