### PR TITLE
perf(core): O(1) summary/boxplot group×x lineage via finite-y prefilter

### DIFF
--- a/.changeset/summary-boxplot-groupx-lineage.md
+++ b/.changeset/summary-boxplot-groupx-lineage.md
@@ -1,0 +1,12 @@
+---
+"@ggsvelte/core": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+perf: O(1) summary/boxplot group×x lineage resolve via finite-y prefilter
+
+Build-time group×x buckets for summary/boxplot now store only finite-y source
+rows (with empty buckets when every y is non-finite), so candidate resolve
+returns the shared frozen array without per-mark y re-filtering or full-group
+clones. Count buckets are unchanged.

--- a/packages/core/src/pipeline/candidate-construction/identity-index.ts
+++ b/packages/core/src/pipeline/candidate-construction/identity-index.ts
@@ -33,11 +33,16 @@ function appendSourceRowByGroupX(input: {
   group: number;
   xKey: string;
   sourceRow: number;
+  /** When false, ensure the bucket exists but do not push (all-non-finite y path). */
+  include: boolean;
 }): void {
   const key = `${input.panelIndex}:${input.layerIndex}:${input.group}:${input.xKey}`;
   const members = input.sourceRowsByGroupX.get(key);
-  if (members === undefined) input.sourceRowsByGroupX.set(key, [input.sourceRow]);
-  else members.push(input.sourceRow);
+  if (members === undefined) {
+    input.sourceRowsByGroupX.set(key, input.include ? [input.sourceRow] : []);
+    return;
+  }
+  if (input.include) members.push(input.sourceRow);
 }
 
 function appendSourceRowByGroupKey(
@@ -184,7 +189,17 @@ function findBinIndex(value: number, bins: readonly BinEdge[], closed: "right" |
 export interface CandidateIdentityIndex {
   readonly seriesByRow: Map<string, number>;
   readonly sourceRowsByGroup: Map<string, number[]>;
-  /** `${panel}:${layer}:${group}:${bandKey(x)}` → source rows (count/summary/boxplot). */
+  /**
+   * `${panel}:${layer}:${group}:${bandKey(x)}` → source rows for aggregate
+   * group×x lineage (count/summary/boxplot).
+   *
+   * Count: every source row in the group×x bucket.
+   * Summary/boxplot (y mapped): only rows with finite y — the final represented
+   * membership so resolve returns this frozen array without a per-mark y scan
+   * (mirrors `sourceRowsByGroupY` / issue #216). Empty buckets are still present
+   * when every row at that x is non-finite, so lookups never fall through to a
+   * full-group re-scan.
+   */
   readonly sourceRowsByGroupX: Map<string, number[]>;
   /** `${panel}:${layer}:${group}:${frameRow}` → source rows (bin/histogram). */
   readonly sourceRowsByGroupBin: Map<string, number[]>;
@@ -234,6 +249,10 @@ export function buildCandidateIdentityIndex(
         const key = `${frameKey}:${group}`;
         appendSourceRowByGroupKey(sourceRowsByGroup, key, sourceRow);
         if (bucketByX && xField !== null) {
+          // Summary/boxplot: only finite y belongs in the final represented
+          // membership. Always create the group×x key (include=false) so an
+          // all-non-finite bucket is an empty frozen array, not a map miss.
+          const includeInX = yNumeric === null || Number.isFinite(yNumeric[localRow]!);
           appendSourceRowByGroupX({
             sourceRowsByGroupX,
             panelIndex,
@@ -241,6 +260,7 @@ export function buildCandidateIdentityIndex(
             group,
             xKey: aggregateLineageXKey(frame.table, xField, localRow, frame.binding),
             sourceRow,
+            include: includeInX,
           });
         }
         if (yNumeric !== null && Number.isFinite(yNumeric[localRow]!)) {
@@ -402,31 +422,38 @@ export function filterRepresentedSourceRows(input: {
     if (cachedY !== undefined) return cachedY;
   }
 
+  // Indexed group×x: buckets are the final represented membership (count: all
+  // rows; summary/boxplot: finite-y only). Return the frozen array as-is so
+  // LineageStore can WeakMap-intern once — no clone, no per-mark y re-filter.
+  if (needsX && indexKeyPrefix !== null && input.sourceRowsByGroupX !== undefined) {
+    const indexed = input.sourceRowsByGroupX.get(`${indexKeyPrefix}:${bandKey(outputX)}`);
+    if (indexed !== undefined) return indexed;
+  }
+
+  // Indexed bin membership (already final; bin never applies needsY).
+  if (needsBin && indexKeyPrefix !== null && input.sourceRowsByGroupBin !== undefined) {
+    const indexed = input.sourceRowsByGroupBin.get(`${indexKeyPrefix}:${frameRow}`);
+    if (indexed !== undefined) return indexed;
+  }
+
+  // Fallback without index maps: clone then filter (parity with pure filters).
   let representedRows = [...input.baseRows];
   if (needsX) {
-    representedRows =
-      (indexKeyPrefix !== null && input.sourceRowsByGroupX !== undefined
-        ? input.sourceRowsByGroupX.get(`${indexKeyPrefix}:${bandKey(outputX)}`)
-        : undefined) ??
-      filterAggregateXRows({
-        table,
-        field: aggregateXField,
-        outputX,
-        baseRows: representedRows,
-        binding: frame.binding,
-      });
+    representedRows = filterAggregateXRows({
+      table,
+      field: aggregateXField,
+      outputX,
+      baseRows: representedRows,
+      binding: frame.binding,
+    });
   } else if (needsBin) {
-    representedRows =
-      (indexKeyPrefix !== null && input.sourceRowsByGroupBin !== undefined
-        ? input.sourceRowsByGroupBin.get(`${indexKeyPrefix}:${frameRow}`)
-        : undefined) ??
-      filterBinRepresentedRows({
-        frame,
-        table,
-        frameRow,
-        field: aggregateXField,
-        baseRows: representedRows,
-      });
+    representedRows = filterBinRepresentedRows({
+      frame,
+      table,
+      frameRow,
+      field: aggregateXField,
+      baseRows: representedRows,
+    });
   }
 
   if (needsY) {

--- a/packages/core/tests/pipeline-build-candidates.test.ts
+++ b/packages/core/tests/pipeline-build-candidates.test.ts
@@ -1477,6 +1477,245 @@ describe("finite-y lineage cache (issue #216)", () => {
       expect(viaIndex.representedRows).toEqual(viaFilter);
     }
   });
+
+  it("summary/boxplot group×x buckets prefilter finite y for O(1) resolve", async () => {
+    const { preparePanels } = await import("../src/pipeline/prepare-panels.ts");
+    const { buildCandidateIdentityIndex } =
+      await import("../src/pipeline/candidate-construction/identity-index.ts");
+    const { filterRepresentedSourceRows, filterAggregateXRows, filterAggregateYRows } =
+      await import("../src/pipeline/candidate-construction/identity-index.ts");
+    const { resolveRepresentedSourceRows } =
+      await import("../src/pipeline/candidate-construction/datum.ts");
+    const { bandKey } = await import("../src/scales/train.ts");
+    const { LineageStore } = await import("../src/identity.ts");
+    const { normalize } = await import("@ggsvelte/spec");
+
+    const prepared = preparePanels(
+      normalize({
+        data: {
+          values: [
+            { g: "a", y: 1 },
+            { g: "a", y: Number.NaN },
+            { g: "a", y: 3 },
+            { g: "b", y: Number.NaN },
+            { g: "b", y: null },
+            { g: "c", y: 9 },
+          ],
+        },
+        layers: [
+          {
+            geom: "pointrange",
+            stat: "summary",
+            aes: { x: { field: "g" }, y: { field: "y" } },
+          },
+        ],
+      }),
+      size,
+      [],
+      [],
+    );
+    const index = buildCandidateIdentityIndex(prepared.panelFrames, prepared.facetPanels);
+    const groupA = "0:0:0";
+    const groupB = "0:0:1";
+    const groupC = "0:0:2";
+
+    // Finite-y prefilter at build (NaN/null y excluded); empty bucket still present for b.
+    expect(index.sourceRowsByGroupX.get(`${groupA}:${bandKey("a")}`)).toEqual([0, 2]);
+    expect(index.sourceRowsByGroupX.get(`${groupB}:${bandKey("b")}`)).toEqual([]);
+    expect(index.sourceRowsByGroupX.get(`${groupC}:${bandKey("c")}`)).toEqual([5]);
+
+    // Parity with pure x then y filter (no index).
+    const baseA = index.sourceRowsByGroup.get(groupA) ?? [];
+    const pureA = filterAggregateYRows({
+      table: prepared.table,
+      field: "y",
+      baseRows: filterAggregateXRows({
+        table: prepared.table,
+        field: "g",
+        outputX: "a",
+        baseRows: baseA,
+      }),
+    });
+    expect(index.sourceRowsByGroupX.get(`${groupA}:${bandKey("a")}`)).toEqual(pureA);
+
+    const frame = prepared.panelFrames[0]![0]!;
+    const lineage = new LineageStore<number>();
+    const lineageByX = new Map<string, number>();
+    for (let frameRow = 0; frameRow < frame.n; frameRow++) {
+      const group = frame.groups[frameRow] ?? 0;
+      const outputX = frame.xValues?.[frameRow] ?? frame.xNumeric?.[frameRow] ?? null;
+      const expected = index.sourceRowsByGroupX.get(`0:0:${group}:${bandKey(outputX)}`);
+      expect(expected).toBeDefined();
+
+      const viaIndex = filterRepresentedSourceRows({
+        frame,
+        table: prepared.table,
+        frameRow,
+        baseRows: index.sourceRowsByGroup.get(`0:0:${group}`) ?? [],
+        group,
+        panelIndex: 0,
+        layerIndex: 0,
+        sourceRowsByGroupX: index.sourceRowsByGroupX,
+      });
+      // Shared frozen bucket — no per-mark y re-filter allocation.
+      expect(viaIndex).toBe(expected);
+
+      const viaFilter = filterRepresentedSourceRows({
+        frame,
+        table: prepared.table,
+        frameRow,
+        baseRows: index.sourceRowsByGroup.get(`0:0:${group}`) ?? [],
+      });
+      expect(viaIndex).toEqual(viaFilter);
+
+      const resolved = resolveRepresentedSourceRows({
+        outlierSourceRow: null,
+        sourceRow: null,
+        group,
+        panelIndex: 0,
+        layerIndex: 0,
+        sourceRowsByGroup: index.sourceRowsByGroup,
+        sourceRowsByGroupX: index.sourceRowsByGroupX,
+        sourceRowsByGroupBin: index.sourceRowsByGroupBin,
+        sourceRowsByGroupY: index.sourceRowsByGroupY,
+        frame,
+        table: prepared.table,
+        frameRow,
+        lineage,
+        primitiveIndex: frameRow,
+      });
+      expect(resolved.representedRows).toBe(expected);
+      const xKey = bandKey(outputX);
+      const prior = lineageByX.get(xKey);
+      if (prior === undefined) lineageByX.set(xKey, resolved.lineageKey);
+      else expect(resolved.lineageKey).toBe(prior);
+    }
+
+    // Empty all-non-finite bucket interns as empty lineage, not a miss/fallback.
+    expect(lineage.count(lineageByX.get(bandKey("b"))!)).toBe(0);
+  });
+
+  it("count group×x reuses frozen bucket without clone (no y prefilter)", async () => {
+    const { preparePanels } = await import("../src/pipeline/prepare-panels.ts");
+    const { buildCandidateIdentityIndex } =
+      await import("../src/pipeline/candidate-construction/identity-index.ts");
+    const { filterRepresentedSourceRows } =
+      await import("../src/pipeline/candidate-construction/identity-index.ts");
+    const { bandKey } = await import("../src/scales/train.ts");
+    const { normalize } = await import("@ggsvelte/spec");
+
+    // Count never sets finiteY — every source row stays in the group×x bucket.
+    const prepared = preparePanels(
+      normalize(
+        gg([{ g: "a" }, { g: "a" }, { g: "a" }], aes({ x: "g" }))
+          .geomBar()
+          .spec(),
+      ),
+      size,
+      [],
+      [],
+    );
+    const index = buildCandidateIdentityIndex(prepared.panelFrames, prepared.facetPanels);
+    const bucket = index.sourceRowsByGroupX.get(`0:0:0:${bandKey("a")}`);
+    expect(bucket).toEqual([0, 1, 2]);
+    const frame = prepared.panelFrames[0]![0]!;
+    const viaIndex = filterRepresentedSourceRows({
+      frame,
+      table: prepared.table,
+      frameRow: 0,
+      baseRows: index.sourceRowsByGroup.get("0:0:0") ?? [],
+      group: 0,
+      panelIndex: 0,
+      layerIndex: 0,
+      sourceRowsByGroupX: index.sourceRowsByGroupX,
+    });
+    expect(viaIndex).toBe(bucket);
+  });
+
+  it("boxplot group×x drops non-finite y and reuses frozen bucket on resolve", async () => {
+    const { preparePanels } = await import("../src/pipeline/prepare-panels.ts");
+    const { buildCandidateIdentityIndex } =
+      await import("../src/pipeline/candidate-construction/identity-index.ts");
+    const { filterRepresentedSourceRows } =
+      await import("../src/pipeline/candidate-construction/identity-index.ts");
+    const { bandKey } = await import("../src/scales/train.ts");
+    const { normalize } = await import("@ggsvelte/spec");
+
+    const prepared = preparePanels(
+      normalize({
+        data: {
+          values: [
+            { group: "a", y: 1 },
+            { group: "a", y: 2 },
+            { group: "a", y: 3 },
+            { group: "a", y: null },
+            { group: "a", y: 100 },
+          ],
+        },
+        layers: [
+          {
+            geom: "boxplot",
+            stat: "boxplot",
+            aes: { x: { field: "group" }, y: { field: "y" } },
+          },
+        ],
+      }),
+      size,
+      [],
+      [],
+    );
+    const index = buildCandidateIdentityIndex(prepared.panelFrames, prepared.facetPanels);
+    const bucket = index.sourceRowsByGroupX.get(`0:0:0:${bandKey("a")}`);
+    // null y (row 3) excluded at build; finite y retained in first-seen order.
+    expect(bucket).toEqual([0, 1, 2, 4]);
+    const frame = prepared.panelFrames[0]![0]!;
+    for (let frameRow = 0; frameRow < frame.n; frameRow++) {
+      const viaIndex = filterRepresentedSourceRows({
+        frame,
+        table: prepared.table,
+        frameRow,
+        baseRows: index.sourceRowsByGroup.get("0:0:0") ?? [],
+        group: 0,
+        panelIndex: 0,
+        layerIndex: 0,
+        sourceRowsByGroupX: index.sourceRowsByGroupX,
+      });
+      expect(viaIndex).toBe(bucket);
+    }
+
+    // Pipeline: non-outlier box candidates share one lineage membership.
+    const model = runPipeline(
+      {
+        data: {
+          values: [
+            { group: "a", y: 1 },
+            { group: "a", y: 2 },
+            { group: "a", y: 3 },
+            { group: "a", y: null },
+            { group: "a", y: 100 },
+          ],
+        },
+        layers: [
+          {
+            geom: "boxplot",
+            stat: "boxplot",
+            aes: { x: { field: "group" }, y: { field: "y" } },
+          },
+        ],
+      },
+      size,
+    );
+    const candidates = Array.from({ length: model.candidates.size }, (_, id) =>
+      model.candidates.candidate(id),
+    ).flatMap((candidate) => (candidate === null ? [] : [candidate]));
+    const boxes = candidates.filter((candidate) => candidate.kind !== "points");
+    expect(boxes.length).toBeGreaterThan(0);
+    const refs = new Set(boxes.map((candidate) => candidate.lineage));
+    expect(refs.size).toBe(1);
+    expect([...model.lineage.keys(boxes[0]!.lineage)].toSorted((a, b) => a - b)).toEqual([
+      0, 1, 2, 4,
+    ]);
+  });
 });
 
 describe("pre-stat inputGroups cache (issue #217)", () => {


### PR DESCRIPTION
## Summary

Big-O maintain pass on `packages/core` (narrowed from 306 files to candidate construction hot path).

**Finding:** summary/boxplot candidate resolve did an O(1) `sourceRowsByGroupX` lookup, then re-filtered finite y with a new unfrozen array per mark (defeating `LineageStore` WeakMap intern) and always cloned the full group first.

**Fix:**
- Build-time group×x buckets for summary/boxplot store **final represented membership** (finite y only)
- Empty frozen buckets when every y at that x is non-finite (no map-miss fallback)
- Indexed resolve returns the shared frozen array — no clone, no per-mark y re-filter
- Count buckets unchanged (no y prefilter)

**Complexity:** per indexed aggregate mark resolve goes from O(g_x) filter + O(g_x log g_x) intern work to O(1) array return after first intern of each distinct bucket (mirrors smooth finite-y cache, issue #216).

## Audit target

`packages/core` → `pipeline/candidate-construction/identity-index.ts`

## Test plan

- [x] `bun test packages/core` (956 pass)
- [x] Characterization: summary empty all-non-finite bucket, frozen `toBe` reuse, boxplot null-y drop, count path identity

## Follow-ups

None deferred as GitHub issues: remaining scan candidates (canvas color batching O(C·n) with C≤64, LOESS exact-δ2) are intentional algorithm choices, not deferred hotspots.
