### PR TITLE
refactor(docs): split playground codec into contract, validation, and wire

### DIFF
--- a/apps/docs/src/lib/playground-codec-contract.ts
+++ b/apps/docs/src/lib/playground-codec-contract.ts
@@ -1,0 +1,73 @@
+import type { PortableSpec, SpecError } from "@ggsvelte/spec";
+
+export const PLAYGROUND_MAX_ENCODED_LENGTH = 16 * 1024;
+export const PLAYGROUND_MAX_DECODED_BYTES = 12 * 1024;
+export const PLAYGROUND_MAX_DEPTH = 8;
+export const PLAYGROUND_MAX_ROWS = 500;
+export const PLAYGROUND_MAX_FIELDS = 64;
+export const PLAYGROUND_MAX_STRING_CODE_POINTS = 2_048;
+
+export interface PlaygroundSeedV1 {
+  readonly version: 1;
+  readonly source:
+    | { readonly kind: "example"; readonly id: string }
+    | { readonly kind: "sample"; readonly id: string }
+    | { readonly kind: "custom" };
+  readonly spec: PortableSpec;
+}
+
+export type PlaygroundCompatibility =
+  | {
+      readonly supported: true;
+      readonly seed: PlaygroundSeedV1;
+      readonly fragment: string;
+    }
+  | { readonly supported: false; readonly reason: string };
+
+export type PlaygroundCodecErrorCode =
+  | "UNKNOWN_VERSION"
+  | "ENCODED_TOO_LARGE"
+  | "INVALID_BASE64URL"
+  | "DECODED_TOO_LARGE"
+  | "INVALID_UTF8"
+  | "INVALID_JSON"
+  | "INVALID_SEED"
+  | "VERSION_MISMATCH"
+  | "INVALID_SOURCE"
+  | "NESTING_TOO_DEEP"
+  | "STRING_TOO_LONG"
+  | "TOO_MANY_ROWS"
+  | "TOO_MANY_FIELDS"
+  | "RAGGED_COLUMNS"
+  | "UNSAFE_FIELD"
+  | "INVALID_SPEC";
+
+export class PlaygroundCodecError extends Error {
+  readonly code: PlaygroundCodecErrorCode;
+  readonly diagnostics: readonly SpecError[];
+
+  constructor(
+    code: PlaygroundCodecErrorCode,
+    message: string,
+    diagnostics: readonly SpecError[] = [],
+  ) {
+    super(message);
+    this.name = "PlaygroundCodecError";
+    this.code = code;
+    this.diagnostics = diagnostics;
+  }
+}
+
+export type DecodePlaygroundHashResult =
+  | { readonly status: "absent" }
+  | { readonly status: "ok"; readonly seed: PlaygroundSeedV1 }
+  | { readonly status: "error"; readonly error: PlaygroundCodecError };
+
+/** Shared throw helper for sibling codec modules (not re-exported from the facade). */
+export function fail(
+  code: PlaygroundCodecErrorCode,
+  message: string,
+  diagnostics: readonly SpecError[] = [],
+): never {
+  throw new PlaygroundCodecError(code, message, diagnostics);
+}

--- a/apps/docs/src/lib/playground-codec.ts
+++ b/apps/docs/src/lib/playground-codec.ts
@@ -1,268 +1,44 @@
-import { validate, type PortableSpec, type SpecError } from "@ggsvelte/spec";
+/**
+ * Public playground fragment codec surface.
+ *
+ * Implementation is split across:
+ * - playground-codec-contract.ts — limits, types, PlaygroundCodecError, fail()
+ * - playground-seed-validation.ts — envelope, structural bounds, PortableSpec checks
+ * - playground-codec.ts — base64url wire format, encode/decode, share-size orchestration
+ */
 
-export const PLAYGROUND_MAX_ENCODED_LENGTH = 16 * 1024;
-export const PLAYGROUND_MAX_DECODED_BYTES = 12 * 1024;
-export const PLAYGROUND_MAX_DEPTH = 8;
-export const PLAYGROUND_MAX_ROWS = 500;
-export const PLAYGROUND_MAX_FIELDS = 64;
-export const PLAYGROUND_MAX_STRING_CODE_POINTS = 2_048;
+import {
+  fail,
+  PLAYGROUND_MAX_DECODED_BYTES,
+  PLAYGROUND_MAX_ENCODED_LENGTH,
+  PlaygroundCodecError,
+  type DecodePlaygroundHashResult,
+  type PlaygroundSeedV1,
+} from "./playground-codec-contract";
+import {
+  assertPlaygroundJsonBytes,
+  assertPlaygroundSeed,
+  validatePlaygroundSeedContents,
+} from "./playground-seed-validation";
+
+export {
+  PLAYGROUND_MAX_DECODED_BYTES,
+  PLAYGROUND_MAX_DEPTH,
+  PLAYGROUND_MAX_ENCODED_LENGTH,
+  PLAYGROUND_MAX_FIELDS,
+  PLAYGROUND_MAX_ROWS,
+  PLAYGROUND_MAX_STRING_CODE_POINTS,
+  PlaygroundCodecError,
+  type DecodePlaygroundHashResult,
+  type PlaygroundCodecErrorCode,
+  type PlaygroundCompatibility,
+  type PlaygroundSeedV1,
+} from "./playground-codec-contract";
+
+export { assertPlaygroundDraftSize } from "./playground-seed-validation";
 
 const HASH_PREFIX = "#play=";
 const PAYLOAD_PREFIX = "v1.";
-const UNSAFE_FIELDS = new Set(["__proto__", "constructor", "prototype"]);
-
-export interface PlaygroundSeedV1 {
-  readonly version: 1;
-  readonly source:
-    | { readonly kind: "example"; readonly id: string }
-    | { readonly kind: "sample"; readonly id: string }
-    | { readonly kind: "custom" };
-  readonly spec: PortableSpec;
-}
-
-export type PlaygroundCompatibility =
-  | {
-      readonly supported: true;
-      readonly seed: PlaygroundSeedV1;
-      readonly fragment: string;
-    }
-  | { readonly supported: false; readonly reason: string };
-
-export type PlaygroundCodecErrorCode =
-  | "UNKNOWN_VERSION"
-  | "ENCODED_TOO_LARGE"
-  | "INVALID_BASE64URL"
-  | "DECODED_TOO_LARGE"
-  | "INVALID_UTF8"
-  | "INVALID_JSON"
-  | "INVALID_SEED"
-  | "VERSION_MISMATCH"
-  | "INVALID_SOURCE"
-  | "NESTING_TOO_DEEP"
-  | "STRING_TOO_LONG"
-  | "TOO_MANY_ROWS"
-  | "TOO_MANY_FIELDS"
-  | "RAGGED_COLUMNS"
-  | "UNSAFE_FIELD"
-  | "INVALID_SPEC";
-
-export class PlaygroundCodecError extends Error {
-  readonly code: PlaygroundCodecErrorCode;
-  readonly diagnostics: readonly SpecError[];
-
-  constructor(
-    code: PlaygroundCodecErrorCode,
-    message: string,
-    diagnostics: readonly SpecError[] = [],
-  ) {
-    super(message);
-    this.name = "PlaygroundCodecError";
-    this.code = code;
-    this.diagnostics = diagnostics;
-  }
-}
-
-export type DecodePlaygroundHashResult =
-  | { readonly status: "absent" }
-  | { readonly status: "ok"; readonly seed: PlaygroundSeedV1 }
-  | { readonly status: "error"; readonly error: PlaygroundCodecError };
-
-function fail(
-  code: PlaygroundCodecErrorCode,
-  message: string,
-  diagnostics: readonly SpecError[] = [],
-): never {
-  throw new PlaygroundCodecError(code, message, diagnostics);
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function codePointLength(value: string): number {
-  return Array.from(value).length;
-}
-
-function assertString(value: string): void {
-  if (codePointLength(value) > PLAYGROUND_MAX_STRING_CODE_POINTS) {
-    fail(
-      "STRING_TOO_LONG",
-      `Shared playground strings must contain at most ${String(PLAYGROUND_MAX_STRING_CODE_POINTS)} Unicode code points.`,
-    );
-  }
-}
-
-/** Root objects/arrays have depth 1; scalar children do not add another level. */
-function assertBoundedTree(value: unknown, depth = 1): void {
-  if (typeof value === "string") {
-    assertString(value);
-    return;
-  }
-  if (typeof value !== "object" || value === null) return;
-  if (depth > PLAYGROUND_MAX_DEPTH) {
-    fail(
-      "NESTING_TOO_DEEP",
-      `Shared playground state must not nest deeper than ${String(PLAYGROUND_MAX_DEPTH)} levels.`,
-    );
-  }
-  if (Array.isArray(value)) {
-    for (const child of value) assertBoundedTree(child, depth + 1);
-    return;
-  }
-  for (const [key, child] of Object.entries(value)) {
-    assertString(key);
-    assertBoundedTree(child, depth + 1);
-  }
-}
-
-function assertSafeField(field: string): void {
-  if (UNSAFE_FIELDS.has(field)) {
-    fail("UNSAFE_FIELD", `Shared data uses the reserved field name ${JSON.stringify(field)}.`);
-  }
-}
-
-function assertJsonByteLength(source: string, label: string): Uint8Array {
-  // ASCII is the cheapest possible UTF-8 representation, so this avoids an
-  // allocation for obviously oversized editor input before JSON.parse.
-  if (source.length > PLAYGROUND_MAX_DECODED_BYTES) {
-    fail(
-      "DECODED_TOO_LARGE",
-      `${label} must be at most ${String(PLAYGROUND_MAX_DECODED_BYTES / 1024)} KiB.`,
-    );
-  }
-  const bytes = new TextEncoder().encode(source);
-  if (bytes.byteLength > PLAYGROUND_MAX_DECODED_BYTES) {
-    fail(
-      "DECODED_TOO_LARGE",
-      `${label} must be at most ${String(PLAYGROUND_MAX_DECODED_BYTES / 1024)} KiB.`,
-    );
-  }
-  return bytes;
-}
-
-function inlineDataRecords(spec: Record<string, unknown>): Record<string, unknown>[] {
-  const records: Record<string, unknown>[] = [];
-  const addData = (value: unknown): void => {
-    if (!isRecord(value)) return;
-    if (typeof value["name"] === "string") assertSafeField(value["name"]);
-    records.push(value);
-  };
-
-  addData(spec["data"]);
-  const layers = spec["layers"];
-  if (Array.isArray(layers)) {
-    for (const layer of layers) {
-      if (isRecord(layer)) addData(layer["data"]);
-    }
-  }
-  const datasets = spec["datasets"];
-  if (isRecord(datasets)) {
-    for (const [name, value] of Object.entries(datasets)) {
-      assertSafeField(name);
-      addData(value);
-    }
-  }
-  return records;
-}
-
-function assertInlineDataBounds(spec: unknown): void {
-  if (!isRecord(spec)) return;
-  let totalRows = 0;
-  for (const data of inlineDataRecords(spec)) {
-    if (Array.isArray(data["values"])) {
-      const rows = data["values"];
-      totalRows += rows.length;
-      for (const row of rows) {
-        if (!isRecord(row)) continue; // public validate() reports the shape error
-        const fields = Object.keys(row);
-        if (fields.length > PLAYGROUND_MAX_FIELDS) {
-          fail(
-            "TOO_MANY_FIELDS",
-            `Shared rows may contain at most ${String(PLAYGROUND_MAX_FIELDS)} fields.`,
-          );
-        }
-        for (const field of fields) assertSafeField(field);
-      }
-    }
-    if (isRecord(data["columns"])) {
-      const columns = data["columns"];
-      const fields = Object.keys(columns);
-      if (fields.length > PLAYGROUND_MAX_FIELDS) {
-        fail(
-          "TOO_MANY_FIELDS",
-          `Shared column data may contain at most ${String(PLAYGROUND_MAX_FIELDS)} columns.`,
-        );
-      }
-      for (const field of fields) assertSafeField(field);
-      const lengths = fields.map((field) => {
-        const column = columns[field];
-        return Array.isArray(column) ? column.length : 0;
-      });
-      if (new Set(lengths).size > 1) {
-        fail("RAGGED_COLUMNS", "Shared column data must use columns with equal lengths.");
-      }
-      totalRows += lengths[0] ?? 0;
-    }
-  }
-  if (totalRows > PLAYGROUND_MAX_ROWS) {
-    fail(
-      "TOO_MANY_ROWS",
-      `Shared playground state may contain at most ${String(PLAYGROUND_MAX_ROWS)} inline rows in total.`,
-    );
-  }
-}
-
-function assertSource(value: unknown): asserts value is PlaygroundSeedV1["source"] {
-  if (!isRecord(value) || typeof value["kind"] !== "string") {
-    fail("INVALID_SOURCE", "Shared playground state has an invalid source identity.");
-  }
-  if (value["kind"] === "custom") {
-    if (Object.keys(value).length !== 1) {
-      fail("INVALID_SOURCE", "A custom playground source cannot contain an id.");
-    }
-    return;
-  }
-  if (
-    (value["kind"] === "example" || value["kind"] === "sample") &&
-    typeof value["id"] === "string" &&
-    value["id"].length > 0 &&
-    Object.keys(value).length === 2
-  ) {
-    return;
-  }
-  fail("INVALID_SOURCE", "Shared playground state has an unknown source identity.");
-}
-
-function assertSeed(value: unknown): PlaygroundSeedV1 {
-  if (!isRecord(value) || !("spec" in value) || !("source" in value) || !("version" in value)) {
-    fail("INVALID_SEED", "Shared playground state must contain version, source, and spec.");
-  }
-  if (value["version"] !== 1) {
-    fail("VERSION_MISMATCH", "The fragment version and shared state version do not agree.");
-  }
-  assertSource(value["source"]);
-  assertBoundedTree(value);
-  assertInlineDataBounds(value["spec"]);
-  const result = validate(value["spec"], {
-    limits: {
-      maxRows: PLAYGROUND_MAX_ROWS,
-      maxBytes: PLAYGROUND_MAX_DECODED_BYTES,
-      maxDepth: PLAYGROUND_MAX_DEPTH,
-      maxDiagnostics: 100,
-    },
-  });
-  if (!result.ok) {
-    fail(
-      "INVALID_SPEC",
-      "Shared playground state contains an invalid PortableSpec.",
-      result.errors,
-    );
-  }
-  if (Object.keys(value).some((key) => !["version", "source", "spec"].includes(key))) {
-    fail("INVALID_SEED", "Shared playground state contains unknown envelope fields.");
-  }
-  return { version: 1, source: value["source"], spec: result.spec };
-}
 
 function bytesToBase64Url(bytes: Uint8Array): string {
   const encoded = btoa(String.fromCodePoint(...bytes));
@@ -288,19 +64,12 @@ function base64UrlToBytes(payload: string): Uint8Array {
   return bytes;
 }
 
-export function assertPlaygroundDraftSize(source: string): void {
-  assertJsonByteLength(source, "Playground JSON");
-}
-
 export function validatePlaygroundSeed(seed: PlaygroundSeedV1): PlaygroundSeedV1 {
-  // Preserve the most actionable structural reason (rows, fields, unsafe
-  // names) before applying the whole-envelope share-size ceiling.
-  assertBoundedTree(seed);
-  assertInlineDataBounds(seed.spec);
-  assertJsonByteLength(JSON.stringify(seed), "Shared playground JSON");
-  const bounded = assertSeed(seed);
+  // Structural reasons first (via validatePlaygroundSeedContents), then the
+  // whole-envelope encoded share-size ceiling owned by the wire format.
+  const bounded = validatePlaygroundSeedContents(seed);
   const payload = bytesToBase64Url(
-    assertJsonByteLength(JSON.stringify(bounded), "Shared playground JSON"),
+    assertPlaygroundJsonBytes(JSON.stringify(bounded), "Shared playground JSON"),
   );
   if (payload.length > PLAYGROUND_MAX_ENCODED_LENGTH) {
     fail(
@@ -351,7 +120,7 @@ export function decodePlaygroundHash(hash: string): DecodePlaygroundHashResult {
     } catch {
       fail("INVALID_JSON", "The shared playground payload is not valid JSON.");
     }
-    return { status: "ok", seed: assertSeed(parsed) };
+    return { status: "ok", seed: assertPlaygroundSeed(parsed) };
   } catch (error) {
     return {
       status: "error",

--- a/apps/docs/src/lib/playground-seed-validation.ts
+++ b/apps/docs/src/lib/playground-seed-validation.ts
@@ -1,0 +1,220 @@
+import { validate } from "@ggsvelte/spec";
+
+import {
+  fail,
+  PLAYGROUND_MAX_DECODED_BYTES,
+  PLAYGROUND_MAX_DEPTH,
+  PLAYGROUND_MAX_FIELDS,
+  PLAYGROUND_MAX_ROWS,
+  PLAYGROUND_MAX_STRING_CODE_POINTS,
+  type PlaygroundSeedV1,
+} from "./playground-codec-contract";
+
+const UNSAFE_FIELDS = new Set(["__proto__", "constructor", "prototype"]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function codePointLength(value: string): number {
+  return Array.from(value).length;
+}
+
+function assertString(value: string): void {
+  if (codePointLength(value) > PLAYGROUND_MAX_STRING_CODE_POINTS) {
+    fail(
+      "STRING_TOO_LONG",
+      `Shared playground strings must contain at most ${String(PLAYGROUND_MAX_STRING_CODE_POINTS)} Unicode code points.`,
+    );
+  }
+}
+
+/** Root objects/arrays have depth 1; scalar children do not add another level. */
+function assertBoundedTree(value: unknown, depth = 1): void {
+  if (typeof value === "string") {
+    assertString(value);
+    return;
+  }
+  if (typeof value !== "object" || value === null) return;
+  if (depth > PLAYGROUND_MAX_DEPTH) {
+    fail(
+      "NESTING_TOO_DEEP",
+      `Shared playground state must not nest deeper than ${String(PLAYGROUND_MAX_DEPTH)} levels.`,
+    );
+  }
+  if (Array.isArray(value)) {
+    for (const child of value) assertBoundedTree(child, depth + 1);
+    return;
+  }
+  for (const [key, child] of Object.entries(value)) {
+    assertString(key);
+    assertBoundedTree(child, depth + 1);
+  }
+}
+
+function assertSafeField(field: string): void {
+  if (UNSAFE_FIELDS.has(field)) {
+    fail("UNSAFE_FIELD", `Shared data uses the reserved field name ${JSON.stringify(field)}.`);
+  }
+}
+
+/** Shared decoded-size check for editor drafts and seed JSON (not re-exported from facade). */
+export function assertPlaygroundJsonBytes(source: string, label: string): Uint8Array {
+  // ASCII is the cheapest possible UTF-8 representation, so this avoids an
+  // allocation for obviously oversized editor input before JSON.parse.
+  if (source.length > PLAYGROUND_MAX_DECODED_BYTES) {
+    fail(
+      "DECODED_TOO_LARGE",
+      `${label} must be at most ${String(PLAYGROUND_MAX_DECODED_BYTES / 1024)} KiB.`,
+    );
+  }
+  const bytes = new TextEncoder().encode(source);
+  if (bytes.byteLength > PLAYGROUND_MAX_DECODED_BYTES) {
+    fail(
+      "DECODED_TOO_LARGE",
+      `${label} must be at most ${String(PLAYGROUND_MAX_DECODED_BYTES / 1024)} KiB.`,
+    );
+  }
+  return bytes;
+}
+
+function inlineDataRecords(spec: Record<string, unknown>): Record<string, unknown>[] {
+  const records: Record<string, unknown>[] = [];
+  const addData = (value: unknown): void => {
+    if (!isRecord(value)) return;
+    if (typeof value["name"] === "string") assertSafeField(value["name"]);
+    records.push(value);
+  };
+
+  addData(spec["data"]);
+  const layers = spec["layers"];
+  if (Array.isArray(layers)) {
+    for (const layer of layers) {
+      if (isRecord(layer)) addData(layer["data"]);
+    }
+  }
+  const datasets = spec["datasets"];
+  if (isRecord(datasets)) {
+    for (const [name, value] of Object.entries(datasets)) {
+      assertSafeField(name);
+      addData(value);
+    }
+  }
+  return records;
+}
+
+function assertInlineDataBounds(spec: unknown): void {
+  if (!isRecord(spec)) return;
+  let totalRows = 0;
+  for (const data of inlineDataRecords(spec)) {
+    if (Array.isArray(data["values"])) {
+      const rows = data["values"];
+      totalRows += rows.length;
+      for (const row of rows) {
+        if (!isRecord(row)) continue; // public validate() reports the shape error
+        const fields = Object.keys(row);
+        if (fields.length > PLAYGROUND_MAX_FIELDS) {
+          fail(
+            "TOO_MANY_FIELDS",
+            `Shared rows may contain at most ${String(PLAYGROUND_MAX_FIELDS)} fields.`,
+          );
+        }
+        for (const field of fields) assertSafeField(field);
+      }
+    }
+    if (isRecord(data["columns"])) {
+      const columns = data["columns"];
+      const fields = Object.keys(columns);
+      if (fields.length > PLAYGROUND_MAX_FIELDS) {
+        fail(
+          "TOO_MANY_FIELDS",
+          `Shared column data may contain at most ${String(PLAYGROUND_MAX_FIELDS)} columns.`,
+        );
+      }
+      for (const field of fields) assertSafeField(field);
+      const lengths = fields.map((field) => {
+        const column = columns[field];
+        return Array.isArray(column) ? column.length : 0;
+      });
+      if (new Set(lengths).size > 1) {
+        fail("RAGGED_COLUMNS", "Shared column data must use columns with equal lengths.");
+      }
+      totalRows += lengths[0] ?? 0;
+    }
+  }
+  if (totalRows > PLAYGROUND_MAX_ROWS) {
+    fail(
+      "TOO_MANY_ROWS",
+      `Shared playground state may contain at most ${String(PLAYGROUND_MAX_ROWS)} inline rows in total.`,
+    );
+  }
+}
+
+function assertSource(value: unknown): asserts value is PlaygroundSeedV1["source"] {
+  if (!isRecord(value) || typeof value["kind"] !== "string") {
+    fail("INVALID_SOURCE", "Shared playground state has an invalid source identity.");
+  }
+  if (value["kind"] === "custom") {
+    if (Object.keys(value).length !== 1) {
+      fail("INVALID_SOURCE", "A custom playground source cannot contain an id.");
+    }
+    return;
+  }
+  if (
+    (value["kind"] === "example" || value["kind"] === "sample") &&
+    typeof value["id"] === "string" &&
+    value["id"].length > 0 &&
+    Object.keys(value).length === 2
+  ) {
+    return;
+  }
+  fail("INVALID_SOURCE", "Shared playground state has an unknown source identity.");
+}
+
+/** Envelope + structural + PortableSpec validation (not re-exported from the facade). */
+export function assertPlaygroundSeed(value: unknown): PlaygroundSeedV1 {
+  if (!isRecord(value) || !("spec" in value) || !("source" in value) || !("version" in value)) {
+    fail("INVALID_SEED", "Shared playground state must contain version, source, and spec.");
+  }
+  if (value["version"] !== 1) {
+    fail("VERSION_MISMATCH", "The fragment version and shared state version do not agree.");
+  }
+  assertSource(value["source"]);
+  assertBoundedTree(value);
+  assertInlineDataBounds(value["spec"]);
+  const result = validate(value["spec"], {
+    limits: {
+      maxRows: PLAYGROUND_MAX_ROWS,
+      maxBytes: PLAYGROUND_MAX_DECODED_BYTES,
+      maxDepth: PLAYGROUND_MAX_DEPTH,
+      maxDiagnostics: 100,
+    },
+  });
+  if (!result.ok) {
+    fail(
+      "INVALID_SPEC",
+      "Shared playground state contains an invalid PortableSpec.",
+      result.errors,
+    );
+  }
+  if (Object.keys(value).some((key) => !["version", "source", "spec"].includes(key))) {
+    fail("INVALID_SEED", "Shared playground state contains unknown envelope fields.");
+  }
+  return { version: 1, source: value["source"], spec: result.spec };
+}
+
+export function assertPlaygroundDraftSize(source: string): void {
+  assertPlaygroundJsonBytes(source, "Playground JSON");
+}
+
+/**
+ * Structural seed validation before wire-size ceilings.
+ * Preserves actionable structural reasons (rows, fields, unsafe names) ahead of
+ * whole-envelope share-size checks performed by the wire facade.
+ */
+export function validatePlaygroundSeedContents(seed: PlaygroundSeedV1): PlaygroundSeedV1 {
+  assertBoundedTree(seed);
+  assertInlineDataBounds(seed.spec);
+  assertPlaygroundJsonBytes(JSON.stringify(seed), "Shared playground JSON");
+  return assertPlaygroundSeed(seed);
+}

--- a/scripts/playground-codec-surface.test.ts
+++ b/scripts/playground-codec-surface.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+
+import * as codec from "../apps/docs/src/lib/playground-codec";
+import type {
+  DecodePlaygroundHashResult,
+  PlaygroundCodecErrorCode,
+  PlaygroundCompatibility,
+  PlaygroundSeedV1,
+} from "../apps/docs/src/lib/playground-codec";
+// Generation and docs imports use the .js specifier; keep that path type-checkable.
+import type { PlaygroundSeedV1 as PlaygroundSeedV1FromJs } from "../apps/docs/src/lib/playground-codec.js";
+
+const REQUIRED_RUNTIME_EXPORTS = [
+  "PLAYGROUND_MAX_ENCODED_LENGTH",
+  "PLAYGROUND_MAX_DECODED_BYTES",
+  "PLAYGROUND_MAX_DEPTH",
+  "PLAYGROUND_MAX_ROWS",
+  "PLAYGROUND_MAX_FIELDS",
+  "PLAYGROUND_MAX_STRING_CODE_POINTS",
+  "PlaygroundCodecError",
+  "assertPlaygroundDraftSize",
+  "validatePlaygroundSeed",
+  "encodePlaygroundSeed",
+  "decodePlaygroundHash",
+] as const;
+
+describe("playground-codec public surface", () => {
+  test("exposes the stable runtime export set from the facade module", () => {
+    for (const name of REQUIRED_RUNTIME_EXPORTS) {
+      expect(name in codec, `missing runtime export: ${name}`).toBe(true);
+    }
+    expect(typeof codec.PlaygroundCodecError).toBe("function");
+    expect(typeof codec.assertPlaygroundDraftSize).toBe("function");
+    expect(typeof codec.validatePlaygroundSeed).toBe("function");
+    expect(typeof codec.encodePlaygroundSeed).toBe("function");
+    expect(typeof codec.decodePlaygroundHash).toBe("function");
+    expect(typeof codec.PLAYGROUND_MAX_ROWS).toBe("number");
+  });
+
+  test("does not leak internal leaf helpers on the facade", () => {
+    const leaked = [
+      "fail",
+      "assertSeed",
+      "assertPlaygroundSeed",
+      "assertBoundedTree",
+      "assertInlineDataBounds",
+      "bytesToBase64Url",
+      "base64UrlToBytes",
+      "assertJsonByteLength",
+    ];
+    for (const name of leaked) {
+      expect(name in codec, `internal helper leaked: ${name}`).toBe(false);
+    }
+  });
+
+  test("type imports from facade and .js specifier remain usable", () => {
+    const seed: PlaygroundSeedV1 = {
+      version: 1,
+      source: { kind: "custom" },
+      spec: {
+        edition: 1,
+        data: { values: [{ x: 1, y: 2 }] },
+        layers: [
+          {
+            geom: "point",
+            stat: "identity",
+            position: "identity",
+            aes: { x: { field: "x" }, y: { field: "y" } },
+          },
+        ],
+      },
+    };
+    const fromJs: PlaygroundSeedV1FromJs = seed;
+    const code: PlaygroundCodecErrorCode = "INVALID_JSON";
+    const compatibility: PlaygroundCompatibility = { supported: false, reason: "test" };
+    const decoded: DecodePlaygroundHashResult = { status: "absent" };
+    expect(fromJs.version).toBe(1);
+    expect(code).toBe("INVALID_JSON");
+    expect(compatibility.supported).toBe(false);
+    expect(decoded.status).toBe("absent");
+  });
+});

--- a/scripts/playground-codec.test.ts
+++ b/scripts/playground-codec.test.ts
@@ -8,7 +8,11 @@ import {
   encodePlaygroundSeed,
   PLAYGROUND_MAX_DECODED_BYTES,
   PLAYGROUND_MAX_ENCODED_LENGTH,
+  PLAYGROUND_MAX_FIELDS,
+  PLAYGROUND_MAX_ROWS,
+  PLAYGROUND_MAX_STRING_CODE_POINTS,
   PlaygroundCodecError,
+  validatePlaygroundSeed,
   type PlaygroundSeedV1,
 } from "../apps/docs/src/lib/playground-codec";
 
@@ -190,6 +194,135 @@ describe("playground fragment codec", () => {
       expect(result.error).toBeInstanceOf(PlaygroundCodecError);
       expect(result.error.code).toBe("INVALID_SPEC");
       expect(result.error.diagnostics[0]?.code).toBe("missing-required-channel");
+    }
+  });
+
+  test("rejects invalid JSON payloads after base64 decode", () => {
+    const binary = "{not-json";
+    const payload = btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/u, "");
+    expectCode(`#play=v1.${payload}`, "INVALID_JSON");
+  });
+
+  test("rejects unknown envelope fields on decode and validate", () => {
+    const withExtra = { ...seed(), unexpected: true };
+    expectCode(rawHash(withExtra), "INVALID_SEED");
+    expect(() => validatePlaygroundSeed(withExtra as PlaygroundSeedV1)).toThrow(
+      new PlaygroundCodecError(
+        "INVALID_SEED",
+        "Shared playground state contains unknown envelope fields.",
+      ),
+    );
+  });
+
+  test("accepts seeds at exact share limits and fails one over", () => {
+    // Column form stays under the JSON byte ceiling at the row limit.
+    const atRowsSeed: PlaygroundSeedV1 = {
+      version: 1,
+      source: { kind: "sample", id: "starter" },
+      spec: {
+        edition: 1,
+        data: {
+          columns: {
+            city: Array.from({ length: PLAYGROUND_MAX_ROWS }, () => "a"),
+            value: Array.from({ length: PLAYGROUND_MAX_ROWS }, (_, value) => value),
+          },
+        },
+        layers: spec.layers,
+      },
+    };
+    expect(validatePlaygroundSeed(atRowsSeed).spec.data).toEqual(atRowsSeed.spec.data);
+    expect(() =>
+      validatePlaygroundSeed({
+        ...atRowsSeed,
+        spec: {
+          ...atRowsSeed.spec,
+          data: {
+            columns: {
+              city: Array.from({ length: PLAYGROUND_MAX_ROWS + 1 }, () => "a"),
+              value: Array.from({ length: PLAYGROUND_MAX_ROWS + 1 }, (_, value) => value),
+            },
+          },
+        },
+      }),
+    ).toThrow(
+      new PlaygroundCodecError(
+        "TOO_MANY_ROWS",
+        `Shared playground state may contain at most ${String(PLAYGROUND_MAX_ROWS)} inline rows in total.`,
+      ),
+    );
+
+    const fieldNames = Array.from(
+      { length: PLAYGROUND_MAX_FIELDS },
+      (_, index) => `f${String(index)}`,
+    );
+    const atFieldsSeed: PlaygroundSeedV1 = {
+      version: 1,
+      source: { kind: "custom" },
+      spec: {
+        edition: 1,
+        data: {
+          columns: Object.fromEntries(fieldNames.map((name, index) => [name, [index]])),
+        },
+        layers: [
+          {
+            geom: "point",
+            stat: "identity",
+            position: "identity",
+            aes: { x: { field: "f0" }, y: { field: "f1" } },
+          },
+        ],
+      },
+    };
+    expect(validatePlaygroundSeed(atFieldsSeed).spec.data).toEqual(atFieldsSeed.spec.data);
+
+    const titleAtLimit = "a".repeat(PLAYGROUND_MAX_STRING_CODE_POINTS);
+    expect(
+      validatePlaygroundSeed(seed({ ...spec, labs: { title: titleAtLimit } })).spec.labs?.title,
+    ).toBe(titleAtLimit);
+  });
+
+  test("validatePlaygroundSeed prefers structural reasons over share-size ceilings", () => {
+    // Oversized string is reported before any whole-envelope DECoded/ENCODED ceiling.
+    const oversizedTitle = "🧭".repeat(PLAYGROUND_MAX_STRING_CODE_POINTS + 1);
+    expect(() =>
+      validatePlaygroundSeed(seed({ ...spec, labs: { title: oversizedTitle } })),
+    ).toThrow(
+      new PlaygroundCodecError(
+        "STRING_TOO_LONG",
+        `Shared playground strings must contain at most ${String(PLAYGROUND_MAX_STRING_CODE_POINTS)} Unicode code points.`,
+      ),
+    );
+
+    const tooManyRows = seed({
+      ...spec,
+      data: {
+        values: Array.from({ length: PLAYGROUND_MAX_ROWS + 1 }, (_, value) => ({ value })),
+      },
+    });
+    try {
+      validatePlaygroundSeed(tooManyRows);
+      throw new Error("expected validatePlaygroundSeed to throw");
+    } catch (error) {
+      expect(error).toBeInstanceOf(PlaygroundCodecError);
+      if (error instanceof PlaygroundCodecError) {
+        expect(error.code).toBe("TOO_MANY_ROWS");
+      }
+    }
+  });
+
+  test("validatePlaygroundSeed returns a bounded seed and preserves instanceof errors", () => {
+    const bounded = validatePlaygroundSeed(seed());
+    expect(bounded).toEqual(seed());
+    expect(bounded).not.toBe(seed());
+    try {
+      validatePlaygroundSeed(seed({ ...spec, data: { values: [{ value: 1 }] } }));
+      throw new Error("expected invalid spec");
+    } catch (error) {
+      expect(error).toBeInstanceOf(PlaygroundCodecError);
+      if (error instanceof PlaygroundCodecError) {
+        expect(error.name).toBe("PlaygroundCodecError");
+        expect(error.code).toBe("INVALID_SPEC");
+      }
     }
   });
 });


### PR DESCRIPTION
## Summary

Split the docs playground fragment codec for maintainability after reviewing `apps/docs` for oversized / mixed-concern modules (including test coverage).

**Chosen candidate:** `apps/docs/src/lib/playground-codec.ts` (was 364 lines) mixed three concerns:

1. Public contract (limits, types, `PlaygroundCodecError`)
2. Seed envelope + structural bounds + PortableSpec validation
3. `#play=v1.` base64url wire encode/decode and share-size orchestration

**Target structure:**

| Module | Role |
|--------|------|
| `playground-codec-contract.ts` | Limits, types, error class, shared `fail()` |
| `playground-seed-validation.ts` | Envelope, structural bounds, PortableSpec checks, draft size |
| `playground-codec.ts` | Wire format + public orchestration + explicit facade re-exports |

Consumers keep importing from `playground-codec` / `playground-codec.js`. Internal leaves are not part of the public surface.

## Why this improves maintainability

Share-size / envelope policy and wire-format changes no longer share one module. Matches prior maintainability splits in the monorepo (contract leaf → domain leaf → facade).

## Tests

- Strengthened `scripts/playground-codec.test.ts` characterization:
  - `INVALID_JSON`, unknown envelope fields
  - exact-limit acceptance
  - direct `validatePlaygroundSeed`
  - structural error precedence vs size ceilings
  - `instanceof` / error name stability
- New `scripts/playground-codec-surface.test.ts` facade runtime + type import lock (including `.js` specifier used by generation)

## Verification

- [x] `bun test scripts/playground-codec.test.ts scripts/playground-codec-surface.test.ts scripts/playground-state.test.ts scripts/gen-playground-seeds.test.ts scripts/check-pages-links.test.ts` (41 pass)
- [x] `bun run check:docs` (svelte-check clean)
- [x] `bun run knip` (clean)
- [x] Independent code review: no P1 findings

## Follow-ups

- #441 — thin `Playground.svelte` by extracting pure helpers / controller wiring (high-churn deferred candidate)

Plan review revised the original “bounds” leaf into contract + seed-validation so envelope validation is not mis-named as size bounds only.