### PR TITLE
fix(docs): require bare production /ggsvelte cleanup redirect

### DIFF
--- a/scripts/deployment-artifact.test.ts
+++ b/scripts/deployment-artifact.test.ts
@@ -244,6 +244,21 @@ describe("deployment artifact identity", () => {
     }
   });
 
+  it("requires the exact bare /ggsvelte absolute cleanup on production, not only the wildcard", () => {
+    const buildDirectory = makeCompleteArtifact("cloudflare-production");
+    try {
+      writeFileSync(
+        join(buildDirectory, "_redirects"),
+        `/ggsvelte/* https://ggsvelte.sh/:splat 301\n`,
+      );
+      expect(
+        validateDeploymentArtifact(buildDirectory, expectedArtifact("cloudflare-production")),
+      ).toContain("_redirects is missing the absolute /ggsvelte cleanup redirect");
+    } finally {
+      rmSync(buildDirectory, { recursive: true, force: true });
+    }
+  });
+
   it("rejects preview artifacts without a broad noindex header", () => {
     const buildDirectory = makeCompleteArtifact("cloudflare-preview");
     try {

--- a/scripts/deployment-artifact.test.ts
+++ b/scripts/deployment-artifact.test.ts
@@ -259,6 +259,23 @@ describe("deployment artifact identity", () => {
     }
   });
 
+  it("requires a line-anchored bare /ggsvelte production cleanup, not a substring match", () => {
+    const buildDirectory = makeCompleteArtifact("cloudflare-production");
+    try {
+      writeFileSync(
+        join(buildDirectory, "_redirects"),
+        `/old/ggsvelte https://ggsvelte.sh/ 301
+/ggsvelte/* https://ggsvelte.sh/:splat 301
+`,
+      );
+      expect(
+        validateDeploymentArtifact(buildDirectory, expectedArtifact("cloudflare-production")),
+      ).toContain("_redirects is missing the absolute /ggsvelte cleanup redirect");
+    } finally {
+      rmSync(buildDirectory, { recursive: true, force: true });
+    }
+  });
+
   it("rejects preview artifacts without a broad noindex header", () => {
     const buildDirectory = makeCompleteArtifact("cloudflare-preview");
     try {

--- a/scripts/deployment-artifact.ts
+++ b/scripts/deployment-artifact.ts
@@ -43,6 +43,11 @@ const REQUIRED_DEPLOYMENT_FILES = [
   "artifact.json",
 ] as const;
 
+/** True when `rule` appears as a full `_redirects` line (trim-insensitive). */
+function hasRedirectRule(redirects: string, rule: string): boolean {
+  return redirects.split(/\r?\n/).some((line) => line.trim() === rule);
+}
+
 export function routeInventoryDigest(routes: readonly DeploymentRoute[]): string {
   const inventory = routes
     .map((route) =>
@@ -235,22 +240,23 @@ export function validateDeploymentArtifact(
     }
     if (expected.buildMode === "cloudflare-production") {
       // Bare `/ggsvelte` does not match `/ggsvelte/*`; require both exact + wildcard.
+      // Line-anchored: `/old/ggsvelte …` must not satisfy the bare-source check.
       if (
-        !redirects.includes("/ggsvelte https://ggsvelte.sh/ 301") ||
-        !redirects.includes("/ggsvelte/* https://ggsvelte.sh/:splat 301")
+        !hasRedirectRule(redirects, "/ggsvelte https://ggsvelte.sh/ 301") ||
+        !hasRedirectRule(redirects, "/ggsvelte/* https://ggsvelte.sh/:splat 301")
       ) {
         problems.push("_redirects is missing the absolute /ggsvelte cleanup redirect");
       }
     } else if (expected.buildMode === "cloudflare-preview") {
       if (
-        redirects.includes("/ggsvelte https://ggsvelte.sh/ 301") ||
-        redirects.includes("/ggsvelte/* https://ggsvelte.sh/:splat 301")
+        hasRedirectRule(redirects, "/ggsvelte https://ggsvelte.sh/ 301") ||
+        hasRedirectRule(redirects, "/ggsvelte/* https://ggsvelte.sh/:splat 301")
       ) {
         problems.push("preview _redirects must not send /ggsvelte cleanup traffic to production");
       }
       if (
-        !redirects.includes("/ggsvelte / 301") ||
-        !redirects.includes("/ggsvelte/* /:splat 301")
+        !hasRedirectRule(redirects, "/ggsvelte / 301") ||
+        !hasRedirectRule(redirects, "/ggsvelte/* /:splat 301")
       ) {
         problems.push("_redirects is missing the same-origin /ggsvelte cleanup redirect");
       }

--- a/scripts/deployment-artifact.ts
+++ b/scripts/deployment-artifact.ts
@@ -234,7 +234,11 @@ export function validateDeploymentArtifact(
       problems.push("_redirects must not preserve /bench GitHub Pages history redirects");
     }
     if (expected.buildMode === "cloudflare-production") {
-      if (!redirects.includes("/ggsvelte/* https://ggsvelte.sh/:splat 301")) {
+      // Bare `/ggsvelte` does not match `/ggsvelte/*`; require both exact + wildcard.
+      if (
+        !redirects.includes("/ggsvelte https://ggsvelte.sh/ 301") ||
+        !redirects.includes("/ggsvelte/* https://ggsvelte.sh/:splat 301")
+      ) {
         problems.push("_redirects is missing the absolute /ggsvelte cleanup redirect");
       }
     } else if (expected.buildMode === "cloudflare-preview") {


### PR DESCRIPTION
## Summary

Follow-up for unrebutted Codex finding on #372 (pre-merge async, never dispositioned).

Production `validateDeploymentArtifact` only required:

```
/ggsvelte/* https://ggsvelte.sh/:splat 301
```

Bare `/ggsvelte` does **not** match `/ggsvelte/*`, so a dropped exact rule (`/ggsvelte https://ggsvelte.sh/ 301`) could still validate while leaving the legacy base path uncanonicalized. Static source and smoke already carry both rules; preview already required exact + wildcard. Production now mirrors that contract.

## Root cause

Asymmetric validation: #372 tightened preview to require both same-origin rules, but production still checked only the wildcard absolute rule.

## Test plan

- [x] RED→GREEN: `requires the exact bare /ggsvelte absolute cleanup on production, not only the wildcard`
- [x] `bun test scripts/deployment-artifact.test.ts` (23 pass)

## Parent

- https://github.com/ljodea/ggsvelte/pull/372