### PR TITLE
perf(spec): cache exact-format RegExp compile (#424)

### DIFF
--- a/packages/spec/src/temporal-parse.ts
+++ b/packages/spec/src/temporal-parse.ts
@@ -419,11 +419,18 @@ type CompiledExactFormat =
   | { ok: true; tokens: readonly string[]; regex: RegExp }
   | { ok: false; reason: string };
 
+/** Cap retained formats so adversarial/churned author strings cannot grow unbounded. */
+const EXACT_FORMAT_CACHE_MAX = 256;
 const EXACT_FORMAT_CACHE = new Map<string, CompiledExactFormat>();
 
 function compileExactFormat(format: string): CompiledExactFormat {
   const cached = EXACT_FORMAT_CACHE.get(format);
-  if (cached !== undefined) return cached;
+  if (cached !== undefined) {
+    // Refresh LRU order (Map iterates in insertion order).
+    EXACT_FORMAT_CACHE.delete(format);
+    EXACT_FORMAT_CACHE.set(format, cached);
+    return cached;
+  }
 
   let compiled: CompiledExactFormat;
   if (format.length === 0 || format.length > 128) {
@@ -472,6 +479,10 @@ function compileExactFormat(format: string): CompiledExactFormat {
         : { ok: false, reason };
   }
 
+  if (EXACT_FORMAT_CACHE.size >= EXACT_FORMAT_CACHE_MAX) {
+    const oldest = EXACT_FORMAT_CACHE.keys().next().value;
+    if (oldest !== undefined) EXACT_FORMAT_CACHE.delete(oldest);
+  }
   EXACT_FORMAT_CACHE.set(format, compiled);
   return compiled;
 }

--- a/packages/spec/src/temporal-parse.ts
+++ b/packages/spec/src/temporal-parse.ts
@@ -405,42 +405,90 @@ function escapeRegex(value: string): string {
   return value.replaceAll(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+/**
+ * Compile-time exact-format artifacts only (pattern + capture tokens, or a
+ * format-level failure). Shared across scalar parseTemporal, column parsing,
+ * helpers, and temporalParserConfigurationError so a column of n values with
+ * the same format pays one compile, not n.
+ *
+ * Only pre-match failures are cached (length, trailing %, unsupported /
+ * duplicate tokens). Post-match semantic rules (%Y required, %m+%q, clock
+ * completeness) stay value-driven.
+ */
+type CompiledExactFormat =
+  | { ok: true; tokens: readonly string[]; regex: RegExp }
+  | { ok: false; reason: string };
+
+const EXACT_FORMAT_CACHE = new Map<string, CompiledExactFormat>();
+
+function compileExactFormat(format: string): CompiledExactFormat {
+  const cached = EXACT_FORMAT_CACHE.get(format);
+  if (cached !== undefined) return cached;
+
+  let compiled: CompiledExactFormat;
+  if (format.length === 0 || format.length > 128) {
+    compiled = {
+      ok: false,
+      reason: "format length must be from 1 through 128 characters",
+    };
+  } else {
+    const tokens: string[] = [];
+    let pattern = "^";
+    let reason: string | null = null;
+    for (let index = 0; index < format.length; index++) {
+      const char = format[index]!;
+      if (char !== "%") {
+        pattern += escapeRegex(char);
+        continue;
+      }
+      const token = format[++index];
+      if (token === undefined) {
+        reason = "format cannot end with %";
+        break;
+      }
+      if (token === "%") {
+        pattern += "%";
+        continue;
+      }
+      const tokenPattern = FORMAT_TOKEN_PATTERNS[token];
+      if (tokenPattern === undefined) {
+        reason = `unsupported format token %${token}`;
+        break;
+      }
+      if (tokens.includes(token)) {
+        reason = `duplicate semantic format token %${token}`;
+        break;
+      }
+      tokens.push(token);
+      if (tokens.length > 32) {
+        reason = "format may contain at most 32 semantic tokens";
+        break;
+      }
+      pattern += tokenPattern;
+    }
+    compiled =
+      reason !== null
+        ? { ok: false, reason }
+        : { ok: true, tokens, regex: new RegExp(`${pattern}$`) };
+  }
+
+  EXACT_FORMAT_CACHE.set(format, compiled);
+  return compiled;
+}
+
 function parseExactFormat(
   value: string,
   format: string,
   options: TemporalParseOptions,
 ): TemporalParseResult {
-  if (format.length === 0 || format.length > 128)
-    return temporalParseFailure("format length must be from 1 through 128 characters");
-  const tokens: string[] = [];
-  let pattern = "^";
-  for (let index = 0; index < format.length; index++) {
-    const char = format[index]!;
-    if (char !== "%") {
-      pattern += escapeRegex(char);
-      continue;
-    }
-    const token = format[++index];
-    if (token === undefined) return temporalParseFailure("format cannot end with %");
-    if (token === "%") {
-      pattern += "%";
-      continue;
-    }
-    const tokenPattern = FORMAT_TOKEN_PATTERNS[token];
-    if (tokenPattern === undefined)
-      return temporalParseFailure(`unsupported format token %${token}`);
-    if (tokens.includes(token))
-      return temporalParseFailure(`duplicate semantic format token %${token}`);
-    tokens.push(token);
-    if (tokens.length > 32)
-      return temporalParseFailure("format may contain at most 32 semantic tokens");
-    pattern += tokenPattern;
-  }
-  pattern += "$";
-  const match = new RegExp(pattern).exec(value);
+  const compiled = compileExactFormat(format);
+  if (!compiled.ok) return temporalParseFailure(compiled.reason);
+  const match = compiled.regex.exec(value);
   if (match === null) return temporalParseFailure("value does not match the exact format");
   const values: Record<string, string> = {};
-  for (let index = 0; index < tokens.length; index++) values[tokens[index]!] = match[index + 1]!;
+  for (let index = 0; index < compiled.tokens.length; index++) {
+    values[compiled.tokens[index]!] = match[index + 1]!;
+  }
   if (values["Y"] === undefined) return temporalParseFailure("exact formats require %Y");
   if (values["m"] !== undefined && values["q"] !== undefined)
     return temporalParseFailure("exact formats cannot contain both %m and %q");

--- a/packages/spec/src/temporal-parse.ts
+++ b/packages/spec/src/temporal-parse.ts
@@ -467,9 +467,9 @@ function compileExactFormat(format: string): CompiledExactFormat {
       pattern += tokenPattern;
     }
     compiled =
-      reason !== null
-        ? { ok: false, reason }
-        : { ok: true, tokens, regex: new RegExp(`${pattern}$`) };
+      reason === null
+        ? { ok: true, tokens, regex: new RegExp(`${pattern}$`) }
+        : { ok: false, reason };
   }
 
   EXACT_FORMAT_CACHE.set(format, compiled);

--- a/packages/spec/tests/temporal.test.ts
+++ b/packages/spec/tests/temporal.test.ts
@@ -123,10 +123,12 @@ describe("strict temporal parsing", () => {
     expect(firstBad).toMatchObject({ ok: false });
 
     // Helper array path shares the same compiled format surface.
-    const dates = parseTemporalFormat([good, good], format.format);
+    const dates: Date[] = parseTemporalFormat([good, good], format.format);
     expect(dates).toHaveLength(2);
-    expect(dates[0]?.getTime()).toBe(dates[1]?.getTime());
-    if (firstGood.ok) expect(dates[0]?.getTime()).toBe(firstGood.epochMs);
+    const firstMs = dates[0]!.getTime();
+    const secondMs = dates[1]!.getTime();
+    expect(firstMs).toBe(secondMs);
+    if (firstGood.ok) expect(firstMs).toBe(firstGood.epochMs);
   });
 
   it("keeps compile-time format configuration errors stable across repeated checks", () => {

--- a/packages/spec/tests/temporal.test.ts
+++ b/packages/spec/tests/temporal.test.ts
@@ -5,6 +5,8 @@ import {
   inferTemporalColumn,
   parseTemporal,
   parseTemporalColumn,
+  parseTemporalFormat,
+  temporalParserConfigurationError,
   TemporalParseError,
   ymd,
   dmy,
@@ -80,6 +82,77 @@ describe("strict temporal parsing", () => {
     expect(parseTemporal("2024", { format: "%s" })).toMatchObject({ ok: false });
     expect(parseTemporal("2024-12", { format: "%Y-%Y" })).toMatchObject({ ok: false });
     expect(parseTemporal("2024", { format: "x".repeat(129) })).toMatchObject({ ok: false });
+  });
+
+  /**
+   * Characterization for compile-once exact-format parsing (#424): column,
+   * scalar, helper, and config-error entry points must keep identical
+   * success/failure semantics when the same format is reused many times.
+   */
+  it("keeps exact-format column decisions identical to per-cell parseTemporal", () => {
+    const format = { format: "%d|%m|%Y" } as const;
+    const values = ["31|12|2024", "01|01|2025", "not-a-date", "15|06|2023"];
+    const column = parseTemporalColumn(values, format);
+    expect(column.decision.status).toBe("invalid");
+    expect(column.decision.failedCount).toBe(1);
+    expect(column.decision.validatedCount).toBe(3);
+    for (let index = 0; index < values.length; index++) {
+      const cell = parseTemporal(values[index]!, format);
+      if (cell.ok) {
+        expect(column.valid[index]).toBe(1);
+        expect(column.semantic[index]).toBe(cell.epochMs);
+      } else {
+        expect(column.valid[index]).toBe(0);
+        expect(Number.isNaN(column.semantic[index]!)).toBe(true);
+      }
+    }
+  });
+
+  it("reuses exact-format success and failure reasons across repeated scalar calls", () => {
+    const format = { format: "%Y-%m-%d %H:%M" } as const;
+    const good = "2024-07-04 13:45";
+    const bad = "2024/07/04 13:45";
+    const firstGood = parseTemporal(good, format);
+    const secondGood = parseTemporal(good, format);
+    expect(firstGood).toEqual(secondGood);
+    expect(firstGood).toMatchObject({ ok: true, kind: "datetime", precision: "minute" });
+
+    const firstBad = parseTemporal(bad, format);
+    const secondBad = parseTemporal(bad, format);
+    expect(firstBad).toEqual(secondBad);
+    expect(firstBad).toMatchObject({ ok: false });
+
+    // Helper array path shares the same compiled format surface.
+    const dates = parseTemporalFormat([good, good], format.format);
+    expect(dates).toHaveLength(2);
+    expect(dates[0]?.getTime()).toBe(dates[1]?.getTime());
+    if (firstGood.ok) expect(dates[0]?.getTime()).toBe(firstGood.epochMs);
+  });
+
+  it("keeps compile-time format configuration errors stable across repeated checks", () => {
+    const unsupported = { format: "%s" } as const;
+    const duplicate = { format: "%Y-%Y" } as const;
+    const tooLong = { format: "x".repeat(129) } as const;
+
+    for (const parser of [unsupported, duplicate, tooLong] as const) {
+      const first = temporalParserConfigurationError(parser);
+      const second = temporalParserConfigurationError(parser);
+      expect(first).not.toBeNull();
+      expect(second).toBe(first);
+    }
+
+    expect(temporalParserConfigurationError({ format: "ends-with-%" })).toBe(
+      temporalParserConfigurationError({ format: "ends-with-%" }),
+    );
+    expect(temporalParserConfigurationError({ format: "ends-with-%" })).not.toBeNull();
+
+    // Post-match semantic rules (%Y required) are value-driven, not pure config
+    // sampling failures only when the sample also lacks %Y.
+    expect(temporalParserConfigurationError({ format: "%m-%d" })).not.toBeNull();
+    expect(parseTemporal("12-31", { format: "%m-%d" })).toMatchObject({ ok: false });
+    expect(parseTemporal("12-31", { format: "%m-%d" })).toEqual(
+      parseTemporal("12-31", { format: "%m-%d" }),
+    );
   });
 
   it("rejects DST gaps/folds by default and supports explicit disambiguation", () => {


### PR DESCRIPTION
## Summary

Big-O maintain on packages/spec — #424 exact-format RegExp cache.

**Finding:** parseExactFormat rebuilt tokens + new RegExp every cell.

**Fix:** compileExactFormat + EXACT_FORMAT_CACHE in temporal-parse.ts (one compile per format string).

**Tests:** column/scalar/helper/config characterization. bun test packages/spec: 330 pass.

**Follow-up:** #425 lint transform-domain memo (still open).

Closes #424.

