### PR TITLE
refactor(docs): extract playground link policy and candidate phase notes

### DIFF
--- a/apps/docs/src/lib/Playground.svelte
+++ b/apps/docs/src/lib/Playground.svelte
@@ -20,8 +20,10 @@
     candidateTransitionAccepted,
     createCandidateLifecycleTracker,
     emitPlaygroundCandidatePhase,
+    phaseNotesForCandidateTransition,
     type PlaygroundCandidateIsolation,
     type PlaygroundCandidatePhaseDetail,
+    type PlaygroundCandidateRef,
   } from "$lib/playground-candidate-lifecycle";
   import {
     appendPlaygroundEvent,
@@ -33,6 +35,13 @@
     encodePlaygroundSeed,
     type PlaygroundSeedV1,
   } from "$lib/playground-codec";
+  import {
+    sharedLinkRejectDiagnostic,
+    shouldClearPlayHashAfterPromotion,
+    shouldConfirmDiscardForSampleLoad,
+    shouldConfirmDiscardForUndo,
+    verifiedSharedSeed,
+  } from "$lib/playground-link-policy";
   import { playgroundOutputs } from "$lib/playground-output";
   import {
     confirmPlaygroundRendered,
@@ -46,11 +55,14 @@
     stagePlaygroundDraft,
     stagePlaygroundSeed,
     stagePlaygroundUndo,
-    type PlaygroundCandidateOrigin,
     type PlaygroundDiagnostic,
   } from "$lib/playground-state";
   const initialSample = PLAYGROUND_SAMPLES[0]!;
   const initialSeed: PlaygroundSeedV1 = initialSample.seed;
+  const shareCatalogs = {
+    examples: PLAYGROUND_EXAMPLES,
+    samples: PLAYGROUND_SAMPLES,
+  };
 
   let workbench = $state(createPlaygroundState(initialSeed));
   let shareUrl = $state("");
@@ -67,35 +79,18 @@
   }
 
   function noteStagedCandidate(
-    previous: { generation: number; origin: PlaygroundCandidateOrigin } | null,
+    previous: PlaygroundCandidateRef | null,
     next: typeof workbench,
   ): void {
-    if (
-      previous !== null &&
-      (next.candidate === null ||
-        next.candidate.generation !== previous.generation)
-    ) {
-      noteCandidatePhase({
-        generation: previous.generation,
-        origin: previous.origin,
-        phase: "cancelled",
-        status: next.status,
-      });
-    }
-    if (next.candidate !== null) {
-      noteCandidatePhase({
-        generation: next.candidate.generation,
-        origin: next.candidate.origin,
-        phase: "pending",
-        status: next.status,
-      });
+    for (const detail of phaseNotesForCandidateTransition(previous, {
+      candidate: next.candidate,
+      status: next.status,
+    })) {
+      noteCandidatePhase(detail);
     }
   }
 
-  function activeCandidate(): {
-    generation: number;
-    origin: PlaygroundCandidateOrigin;
-  } | null {
+  function activeCandidate(): PlaygroundCandidateRef | null {
     const candidate = workbench.candidate;
     return candidate === null
       ? null
@@ -111,26 +106,6 @@
     const url = new URL(window.location.href);
     url.hash = hash ?? "";
     history.replaceState(history.state, "", url);
-  }
-
-  function verifiedSharedSeed(
-    hash: string,
-    seed: PlaygroundSeedV1,
-  ): PlaygroundSeedV1 {
-    const source = seed.source;
-    if (source.kind === "custom") return seed;
-    const trusted =
-      source.kind === "example"
-        ? PLAYGROUND_EXAMPLES.some(
-            (entry) =>
-              entry.id === source.id &&
-              entry.compatibility.supported &&
-              entry.compatibility.fragment === hash,
-          )
-        : PLAYGROUND_SAMPLES.some(
-            (entry) => entry.id === source.id && entry.fragment === hash,
-          );
-    return trusted ? seed : { ...seed, source: { kind: "custom" } };
   }
 
   function restoreLocation(origin: "initial-navigation" | "popstate"): void {
@@ -149,13 +124,7 @@
       const previous = activeCandidate();
       workbench = reportPlaygroundDiagnostic(
         workbench,
-        {
-          source: "playground",
-          code: decoded.error.code.toLowerCase().replaceAll("_", "-"),
-          path: "#play",
-          message: decoded.error.message,
-          fix: "Open a generated example link or reset to a built-in sample.",
-        },
+        sharedLinkRejectDiagnostic(decoded.error),
         "The shared link was rejected. The current local chart and a truthful URL were retained.",
       );
       if (previous !== null) {
@@ -171,7 +140,7 @@
     const previous = activeCandidate();
     const next = stagePlaygroundSeed(
       workbench,
-      verifiedSharedSeed(window.location.hash, decoded.seed),
+      verifiedSharedSeed(window.location.hash, decoded.seed, shareCatalogs),
       origin,
       window.location.hash,
     );
@@ -190,13 +159,11 @@
     const previous = activeCandidate();
     const edited = editPlaygroundDraft(workbench, draft);
     workbench = edited;
-    if (previous !== null && edited.candidate === null) {
-      noteCandidatePhase({
-        generation: previous.generation,
-        origin: previous.origin,
-        phase: "cancelled",
-        status: edited.status,
-      });
+    for (const detail of phaseNotesForCandidateTransition(previous, {
+      candidate: edited.candidate,
+      status: edited.status,
+    })) {
+      noteCandidatePhase(detail);
     }
     if (!edited.synchronized) {
       shareUrl = "";
@@ -221,7 +188,7 @@
   function undoChart(): void {
     if (workbench.undoSnapshots.length === 0 || workbench.candidate !== null)
       return;
-    if (!workbench.synchronized) {
+    if (shouldConfirmDiscardForUndo(workbench)) {
       const discard = window.confirm(
         "Discard the current draft and undo to the previous rendered chart? Copy it first if you need to keep it.",
       );
@@ -235,11 +202,7 @@
 
   function loadSample(id: string): boolean {
     if (id === "") return false;
-    if (
-      !workbench.synchronized ||
-      workbench.candidate !== null ||
-      workbench.seed.source.kind === "custom"
-    ) {
+    if (shouldConfirmDiscardForSampleLoad(workbench)) {
       const discard = window.confirm(
         "Discard the current draft and load this sample? Copy it first if you need to keep it.",
       );
@@ -287,13 +250,7 @@
       status: promoted.status,
     });
     events = [];
-    if (
-      (origin === "apply" ||
-        origin === "source" ||
-        origin === "reset" ||
-        origin === "undo") &&
-      window.location.hash.startsWith("#play=")
-    ) {
+    if (shouldClearPlayHashAfterPromotion(origin, window.location.hash)) {
       replaceLocationHash(null);
     }
     shareUrl = "";
@@ -336,13 +293,11 @@
       "The current chart stopped safely. Reset the source to recover.",
       false,
     );
-    if (previous !== null) {
-      noteCandidatePhase({
-        generation: previous.generation,
-        origin: previous.origin,
-        phase: "cancelled",
-        status: workbench.status,
-      });
+    for (const detail of phaseNotesForCandidateTransition(previous, {
+      candidate: null,
+      status: workbench.status,
+    })) {
+      noteCandidatePhase(detail);
     }
   }
 

--- a/apps/docs/src/lib/playground-candidate-lifecycle.ts
+++ b/apps/docs/src/lib/playground-candidate-lifecycle.ts
@@ -105,6 +105,45 @@ export function candidateTransitionAccepted<T>(previous: T, next: T): boolean {
   return previous !== next;
 }
 
+export type PlaygroundCandidateRef = {
+  readonly generation: number;
+  readonly origin: PlaygroundCandidateOrigin;
+};
+
+/**
+ * Pure phase notes for a workbench transition that may cancel a prior candidate
+ * and/or stage a new one. Order is cancel-then-pending (matches Playground.svelte).
+ */
+export function phaseNotesForCandidateTransition(
+  previous: PlaygroundCandidateRef | null,
+  next: {
+    readonly candidate: PlaygroundCandidateRef | null;
+    readonly status: string;
+  },
+): readonly PlaygroundCandidatePhaseDetail[] {
+  const notes: PlaygroundCandidatePhaseDetail[] = [];
+  if (
+    previous !== null &&
+    (next.candidate === null || next.candidate.generation !== previous.generation)
+  ) {
+    notes.push({
+      generation: previous.generation,
+      origin: previous.origin,
+      phase: "cancelled",
+      status: next.status,
+    });
+  }
+  if (next.candidate !== null) {
+    notes.push({
+      generation: next.candidate.generation,
+      origin: next.candidate.origin,
+      phase: "pending",
+      status: next.status,
+    });
+  }
+  return notes;
+}
+
 export function emitPlaygroundCandidatePhase(
   detail: PlaygroundCandidatePhaseDetail,
   target: EventTarget = globalThis,

--- a/apps/docs/src/lib/playground-link-policy.ts
+++ b/apps/docs/src/lib/playground-link-policy.ts
@@ -1,0 +1,79 @@
+import type { PlaygroundCodecError, PlaygroundSeedV1 } from "./playground-codec";
+import type {
+  PlaygroundCandidateOrigin,
+  PlaygroundDiagnostic,
+  PlaygroundState,
+} from "./playground-state";
+
+export interface PlaygroundExampleCatalogEntry {
+  readonly id: string;
+  readonly compatibility:
+    | { readonly supported: true; readonly fragment: string }
+    | { readonly supported: false; readonly reason: string };
+}
+
+export interface PlaygroundSampleCatalogEntry {
+  readonly id: string;
+  readonly fragment: string;
+}
+
+export interface PlaygroundShareCatalogs {
+  readonly examples: readonly PlaygroundExampleCatalogEntry[];
+  readonly samples: readonly PlaygroundSampleCatalogEntry[];
+}
+
+/**
+ * Trust check for shared links that claim a sample/example identity.
+ * Untrusted attributions are demoted to `custom` so the UI does not lie.
+ */
+export function verifiedSharedSeed(
+  hash: string,
+  seed: PlaygroundSeedV1,
+  catalogs: PlaygroundShareCatalogs,
+): PlaygroundSeedV1 {
+  const source = seed.source;
+  if (source.kind === "custom") return seed;
+  const trusted =
+    source.kind === "example"
+      ? catalogs.examples.some(
+          (entry) =>
+            entry.id === source.id &&
+            entry.compatibility.supported &&
+            entry.compatibility.fragment === hash,
+        )
+      : catalogs.samples.some((entry) => entry.id === source.id && entry.fragment === hash);
+  return trusted ? seed : { ...seed, source: { kind: "custom" } };
+}
+
+export function sharedLinkRejectDiagnostic(error: PlaygroundCodecError): PlaygroundDiagnostic {
+  return {
+    source: "playground",
+    code: error.code.toLowerCase().replaceAll("_", "-"),
+    path: "#play",
+    message: error.message,
+    fix: "Open a generated example link or reset to a built-in sample.",
+  };
+}
+
+/** Confirm-gate only; empty undo stack / pending candidate guards stay in the component. */
+export function shouldConfirmDiscardForUndo(state: PlaygroundState): boolean {
+  return !state.synchronized;
+}
+
+/**
+ * Confirm-gate only; empty id / missing sample lookup stay in the component.
+ * Confirms when the draft is dirty, a candidate is pending, or the source is custom.
+ */
+export function shouldConfirmDiscardForSampleLoad(state: PlaygroundState): boolean {
+  return !state.synchronized || state.candidate !== null || state.seed.source.kind === "custom";
+}
+
+export function shouldClearPlayHashAfterPromotion(
+  origin: PlaygroundCandidateOrigin | undefined,
+  locationHash: string,
+): boolean {
+  return (
+    (origin === "apply" || origin === "source" || origin === "reset" || origin === "undo") &&
+    locationHash.startsWith("#play=")
+  );
+}

--- a/scripts/playground-candidate-lifecycle.test.ts
+++ b/scripts/playground-candidate-lifecycle.test.ts
@@ -5,6 +5,7 @@ import {
   candidateTransitionAccepted,
   createCandidateLifecycleTracker,
   emitPlaygroundCandidatePhase,
+  phaseNotesForCandidateTransition,
   PLAYGROUND_CANDIDATE_EVENT,
   type PlaygroundCandidatePhaseDetail,
 } from "../apps/docs/src/lib/playground-candidate-lifecycle";
@@ -100,5 +101,76 @@ describe("playground candidate lifecycle", () => {
     });
     emitPlaygroundCandidatePhase(detail({ phase: "pending" }), target);
     expect(seen).toEqual([detail({ phase: "pending" })]);
+  });
+
+  test("phaseNotesForCandidateTransition orders cancel then pending and no-ops when unchanged", () => {
+    const previous = { generation: 1, origin: "apply" as const };
+    const pending = { generation: 2, origin: "source" as const };
+
+    expect(
+      phaseNotesForCandidateTransition(previous, {
+        candidate: pending,
+        status: "Checking the next chart before replacing the last valid result.",
+      }),
+    ).toEqual([
+      {
+        generation: 1,
+        origin: "apply",
+        phase: "cancelled",
+        status: "Checking the next chart before replacing the last valid result.",
+      },
+      {
+        generation: 2,
+        origin: "source",
+        phase: "pending",
+        status: "Checking the next chart before replacing the last valid result.",
+      },
+    ]);
+
+    expect(
+      phaseNotesForCandidateTransition(previous, {
+        candidate: null,
+        status: "Draft changed. Apply it to check and render the next chart.",
+      }),
+    ).toEqual([
+      {
+        generation: 1,
+        origin: "apply",
+        phase: "cancelled",
+        status: "Draft changed. Apply it to check and render the next chart.",
+      },
+    ]);
+
+    expect(
+      phaseNotesForCandidateTransition(previous, {
+        candidate: previous,
+        status: "same generation still pending",
+      }),
+    ).toEqual([
+      {
+        generation: 1,
+        origin: "apply",
+        phase: "pending",
+        status: "same generation still pending",
+      },
+    ]);
+
+    expect(
+      phaseNotesForCandidateTransition(null, {
+        candidate: pending,
+        status: "Checking the next chart before replacing the last valid result.",
+      }),
+    ).toEqual([
+      {
+        generation: 2,
+        origin: "source",
+        phase: "pending",
+        status: "Checking the next chart before replacing the last valid result.",
+      },
+    ]);
+
+    expect(phaseNotesForCandidateTransition(null, { candidate: null, status: "Ready." })).toEqual(
+      [],
+    );
   });
 });

--- a/scripts/playground-link-policy.test.ts
+++ b/scripts/playground-link-policy.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, test } from "bun:test";
+
+import type { PortableSpec } from "@ggsvelte/spec";
+
+import { PlaygroundCodecError, type PlaygroundSeedV1 } from "../apps/docs/src/lib/playground-codec";
+import {
+  sharedLinkRejectDiagnostic,
+  shouldClearPlayHashAfterPromotion,
+  shouldConfirmDiscardForSampleLoad,
+  shouldConfirmDiscardForUndo,
+  verifiedSharedSeed,
+} from "../apps/docs/src/lib/playground-link-policy";
+import {
+  createPlaygroundState,
+  editPlaygroundDraft,
+  stagePlaygroundDraft,
+  type PlaygroundState,
+} from "../apps/docs/src/lib/playground-state";
+
+const spec: PortableSpec = {
+  edition: 1,
+  data: { values: [{ x: 1, y: 2 }] },
+  layers: [
+    {
+      geom: "point",
+      stat: "identity",
+      position: "identity",
+      aes: { x: { field: "x" }, y: { field: "y" } },
+    },
+  ],
+};
+
+const sampleSeed = (id = "starter"): PlaygroundSeedV1 => ({
+  version: 1,
+  source: { kind: "sample", id },
+  spec,
+});
+
+const exampleSeed = (id = "area/basic"): PlaygroundSeedV1 => ({
+  version: 1,
+  source: { kind: "example", id },
+  spec,
+});
+
+const catalogs = {
+  examples: [
+    {
+      id: "area/basic",
+      compatibility: { supported: true as const, fragment: "#play=v1.trusted-example" },
+    },
+    {
+      id: "unsupported/chart",
+      compatibility: { supported: false as const, reason: "too large" },
+    },
+  ],
+  samples: [
+    { id: "starter", fragment: "#play=v1.trusted-sample" },
+    { id: "other", fragment: "#play=v1.other-sample" },
+  ],
+};
+
+describe("verifiedSharedSeed", () => {
+  test("keeps custom sources untouched", () => {
+    const seed: PlaygroundSeedV1 = { version: 1, source: { kind: "custom" }, spec };
+    expect(verifiedSharedSeed("#play=v1.anything", seed, catalogs)).toEqual(seed);
+  });
+
+  test("keeps trusted sample and example fragments", () => {
+    expect(verifiedSharedSeed("#play=v1.trusted-sample", sampleSeed(), catalogs).source).toEqual({
+      kind: "sample",
+      id: "starter",
+    });
+    expect(verifiedSharedSeed("#play=v1.trusted-example", exampleSeed(), catalogs).source).toEqual({
+      kind: "example",
+      id: "area/basic",
+    });
+  });
+
+  test("demotes untrusted sample, mismatched fragment, unknown id, and unsupported example", () => {
+    expect(
+      verifiedSharedSeed("#play=v1.other-sample", sampleSeed("starter"), catalogs).source,
+    ).toEqual({ kind: "custom" });
+    expect(
+      verifiedSharedSeed("#play=v1.trusted-sample", sampleSeed("missing"), catalogs).source,
+    ).toEqual({ kind: "custom" });
+    expect(verifiedSharedSeed("#play=v1.wrong", exampleSeed(), catalogs).source).toEqual({
+      kind: "custom",
+    });
+    expect(
+      verifiedSharedSeed("#play=v1.x", exampleSeed("unsupported/chart"), catalogs).source,
+    ).toEqual({ kind: "custom" });
+  });
+});
+
+describe("sharedLinkRejectDiagnostic", () => {
+  test("maps codec error to playground diagnostic with kebab code and fixed path/fix", () => {
+    const error = new PlaygroundCodecError(
+      "ENCODED_TOO_LARGE",
+      "Shared playground payloads must be at most 16 KiB.",
+    );
+    expect(sharedLinkRejectDiagnostic(error)).toEqual({
+      source: "playground",
+      code: "encoded-too-large",
+      path: "#play",
+      message: "Shared playground payloads must be at most 16 KiB.",
+      fix: "Open a generated example link or reset to a built-in sample.",
+    });
+  });
+});
+
+describe("discard confirm gates", () => {
+  test("undo confirms only when draft is desynchronized", () => {
+    const state = createPlaygroundState(sampleSeed());
+    expect(shouldConfirmDiscardForUndo(state)).toBe(false);
+    const edited = editPlaygroundDraft(state, state.draft + "\n");
+    expect(shouldConfirmDiscardForUndo(edited)).toBe(true);
+  });
+
+  test("sample load confirms when desynchronized, pending candidate, or custom source", () => {
+    const sampleState = createPlaygroundState(sampleSeed());
+    expect(shouldConfirmDiscardForSampleLoad(sampleState)).toBe(false);
+
+    const custom = createPlaygroundState({ version: 1, source: { kind: "custom" }, spec });
+    expect(shouldConfirmDiscardForSampleLoad(custom)).toBe(true);
+
+    const edited = editPlaygroundDraft(sampleState, sampleState.draft + "\n");
+    expect(shouldConfirmDiscardForSampleLoad(edited)).toBe(true);
+
+    const pending = stagePlaygroundDraft(
+      editPlaygroundDraft(
+        sampleState,
+        JSON.stringify(
+          {
+            ...spec,
+            labs: { title: "Next" },
+          },
+          null,
+          2,
+        ),
+      ),
+    );
+    expect(pending.candidate).not.toBeNull();
+    expect(shouldConfirmDiscardForSampleLoad(pending)).toBe(true);
+  });
+});
+
+describe("shouldClearPlayHashAfterPromotion", () => {
+  test("clears only apply/source/reset/undo origins when hash is a play fragment", () => {
+    expect(shouldClearPlayHashAfterPromotion("apply", "#play=v1.abc")).toBe(true);
+    expect(shouldClearPlayHashAfterPromotion("source", "#play=v1.abc")).toBe(true);
+    expect(shouldClearPlayHashAfterPromotion("reset", "#play=v1.abc")).toBe(true);
+    expect(shouldClearPlayHashAfterPromotion("undo", "#play=v1.abc")).toBe(true);
+    expect(shouldClearPlayHashAfterPromotion("initial-navigation", "#play=v1.abc")).toBe(false);
+    expect(shouldClearPlayHashAfterPromotion("popstate", "#play=v1.abc")).toBe(false);
+    expect(shouldClearPlayHashAfterPromotion("apply", "#other")).toBe(false);
+    expect(shouldClearPlayHashAfterPromotion("apply", "")).toBe(false);
+  });
+});
+
+// Silence unused if tree-shaken fixtures stay for readability.
+void (null as unknown as PlaygroundState);


### PR DESCRIPTION
## Summary

Maintainability pass on `apps/docs` after the playground codec split (#442).

**Chosen candidate:** `Playground.svelte` (~478 lines, high churn) mixed pure share/link policy and candidate phase bookkeeping with Svelte/browser orchestration (tracked as #441).

**What changed:**

| Module | Role |
|--------|------|
| `playground-link-policy.ts` | Share-trust demotion, codec→diagnostic mapping, discard confirm gates, post-promote `#play=` clear policy |
| `playground-candidate-lifecycle.ts` | `phaseNotesForCandidateTransition` (cancel-then-pending order) |
| `Playground.svelte` | Markup + `$state`/`onMount`/history/clipboard/`queueMicrotask` wiring only for those decisions |

Public import paths for docs helpers stay private to the docs app. No package API change.

## Why this improves maintainability

Trust demotion, discard gates, and phase-note ordering are now unit-testable without DOM. Matches the acceptance sketch on #441.

## Tests

- New `scripts/playground-link-policy.test.ts` (trust matrix, exact reject diagnostic fields, confirm gates, hash-clear matrix)
- Extended `scripts/playground-candidate-lifecycle.test.ts` (phase note ordering)
- `bun test scripts/playground-link-policy.test.ts scripts/playground-candidate-lifecycle.test.ts scripts/playground-state.test.ts` (25 pass)
- `bun run check:docs` clean
- `bun run knip` clean
- Rebuilt docs + `bun run test:visual -- playground.spec.ts` — 18/19 then full pass on re-run of the share/Back-Forward case (timeout flake under parallel load, not a policy regression)

## Independent review

Code review found no P1 wiring regressions (transition order, trust demotion, discard gates, hash clear preserved).

## Follow-ups

- Closes #441

No new deferred issues; other large docs files (guide prose, gallery pages, SiteSearch UI) remain keep/opportunistic.