### PR TITLE
fix(core): transform-space lineage for bin/count/smooth (#365)

### DIFF
--- a/packages/core/src/pipeline/candidate-construction/identity-buckets.ts
+++ b/packages/core/src/pipeline/candidate-construction/identity-buckets.ts
@@ -2,9 +2,10 @@ import type { BarParams } from "@ggsvelte/spec";
 
 import { bandKey } from "../../scales/train.js";
 import { ColumnTable } from "../../table.js";
+import { assignBinId } from "../binned-scale.js";
 import type { FacetPanelDef } from "../facets.js";
 import { shouldAggregateOnSemanticTemporalX } from "../frame-stats-shared.js";
-import { xConversionOf } from "../temporal-position.js";
+import { positionColumn, xConversionOf } from "../temporal-position.js";
 import type { LayerBinding, LayerFrame } from "../types.js";
 
 /** Key used for count/summary/boxplot group×x lineage buckets (matches frame xValues). */
@@ -14,6 +15,12 @@ export function aggregateLineageXKey(
   localRow: number,
   binding: LayerBinding,
 ): string {
+  // Binned count stores bin ids on the frame; bucket membership must key by
+  // the same id (not the inverse-projected bin center in xValues).
+  if (binding.xBinning !== undefined) {
+    const transformed = positionColumn(table, field, xConversionOf(binding), binding.xTransform);
+    return bandKey(assignBinId(transformed[localRow]!, binding.xBinning));
+  }
   const conversion = xConversionOf(binding);
   const parsed = table.parsed(field, conversion.sourceParser, conversion.options);
   if (shouldAggregateOnSemanticTemporalX(binding, parsed.decision.status)) {
@@ -135,8 +142,14 @@ export function buildBinLineageBuckets(input: {
     bins.sort((a, b) => a.lo - b.lo || a.hi - b.hi);
   }
 
-  const xConversion = xConversionOf(frame.binding);
-  const xNumeric = frame.table.numeric(field, xConversion.sourceParser, xConversion.options);
+  // Bin edges are in scale space after pre-stat transforms; compare source
+  // rows in the same space so log/sqrt histograms retain lineage.
+  const xNumeric = positionColumn(
+    frame.table,
+    field,
+    xConversionOf(frame.binding),
+    frame.binding.xTransform,
+  );
   for (let localRow = 0; localRow < inputGroups.length; localRow++) {
     const group = inputGroups[localRow]!;
     const bins = binsByGroup.get(group);

--- a/packages/core/src/pipeline/candidate-construction/identity-index.ts
+++ b/packages/core/src/pipeline/candidate-construction/identity-index.ts
@@ -1,5 +1,5 @@
 import type { FacetPanelDef } from "../facets.js";
-import { yConversionOf } from "../temporal-position.js";
+import { positionColumn, xConversionOf, yConversionOf } from "../temporal-position.js";
 import type { LayerFrame } from "../types.js";
 import { NO_ROW } from "../types.js";
 import {
@@ -61,10 +61,25 @@ export function buildCandidateIdentityIndex(
       const yField = frame.binding.yField;
       const finiteY =
         (stat === "smooth" || stat === "summary" || stat === "boxplot") && yField !== null;
-      const yConversion = yConversionOf(frame.binding);
+      // Match stat reads: finite membership is after the pre-stat transform so
+      // log/sqrt OOD rows do not appear in candidate lineage for the fit.
       const yNumeric =
         finiteY && yField !== null
-          ? frame.table.numeric(yField, yConversion.sourceParser, yConversion.options)
+          ? positionColumn(
+              frame.table,
+              yField,
+              yConversionOf(frame.binding),
+              frame.binding.yTransform,
+            )
+          : null;
+      const xNumericForSmooth =
+        stat === "smooth" && xField !== null
+          ? positionColumn(
+              frame.table,
+              xField,
+              xConversionOf(frame.binding),
+              frame.binding.xTransform,
+            )
           : null;
       for (let localRow = 0; localRow < inputGroups.length; localRow++) {
         const group = inputGroups[localRow]!;
@@ -87,6 +102,9 @@ export function buildCandidateIdentityIndex(
           });
         }
         if (yNumeric !== null && Number.isFinite(yNumeric[localRow]!)) {
+          if (xNumericForSmooth !== null && !Number.isFinite(xNumericForSmooth[localRow]!)) {
+            continue;
+          }
           appendSourceRowByGroupKey(sourceRowsByGroupY, key, sourceRow);
         }
       }

--- a/packages/core/src/pipeline/candidate-construction/identity-index.ts
+++ b/packages/core/src/pipeline/candidate-construction/identity-index.ts
@@ -101,10 +101,9 @@ export function buildCandidateIdentityIndex(
             include: includeInX,
           });
         }
-        if (yNumeric !== null && Number.isFinite(yNumeric[localRow]!)) {
-          if (xNumericForSmooth !== null && !Number.isFinite(xNumericForSmooth[localRow]!)) {
-            continue;
-          }
+        const yOk = yNumeric !== null && Number.isFinite(yNumeric[localRow]!);
+        const xOk = xNumericForSmooth === null || Number.isFinite(xNumericForSmooth[localRow]!);
+        if (yOk && xOk) {
           appendSourceRowByGroupKey(sourceRowsByGroupY, key, sourceRow);
         }
       }

--- a/packages/core/src/pipeline/candidate-construction/represented-rows.ts
+++ b/packages/core/src/pipeline/candidate-construction/represented-rows.ts
@@ -2,8 +2,8 @@ import type { BarParams } from "@ggsvelte/spec";
 
 import { bandKey } from "../../scales/train.js";
 import type { ColumnTable } from "../../table.js";
-import { xConversionOf, yConversionOf } from "../temporal-position.js";
 import { shouldAggregateOnSemanticTemporalX } from "../frame-stats-shared.js";
+import { positionColumn, xConversionOf, yConversionOf } from "../temporal-position.js";
 import type { LayerBinding, LayerFrame } from "../types.js";
 
 export function filterAggregateXRows(input: {
@@ -43,8 +43,13 @@ export function filterBinRepresentedRows(input: {
   const frameGroup = frame.groups[frameRow];
   const firstInGroup = frameRow === 0 || frame.groups[frameRow - 1] !== frameGroup;
   const lastInGroup = frameRow === frame.n - 1 || frame.groups[frameRow + 1] !== frameGroup;
-  const xConversion = xConversionOf(frame.binding);
-  const numeric = table.numeric(field, xConversion.sourceParser, xConversion.options);
+  // Edges are scale-space; filter source rows after the same transform.
+  const numeric = positionColumn(
+    table,
+    field,
+    xConversionOf(frame.binding),
+    frame.binding.xTransform,
+  );
   return baseRows.filter((row) => {
     const value = numeric[row]!;
     if (!Number.isFinite(value)) return false;
@@ -60,8 +65,9 @@ export function filterAggregateYRows(input: {
   field: string;
   baseRows: readonly number[];
 }): number[] {
-  const conversion = yConversionOf(input.frame?.binding ?? {});
-  const numeric = input.table.numeric(input.field, conversion.sourceParser, conversion.options);
+  const binding = input.frame?.binding;
+  const conversion = yConversionOf(binding ?? {});
+  const numeric = positionColumn(input.table, input.field, conversion, binding?.yTransform);
   return input.baseRows.filter((row) => Number.isFinite(numeric[row]!));
 }
 
@@ -110,8 +116,13 @@ export function filterRepresentedSourceRows(input: {
   // Indexed group×x: buckets are the final represented membership (count: all
   // rows; summary/boxplot: finite-y only). Return the frozen array as-is so
   // LineageStore can WeakMap-intern once — no clone, no per-mark y re-filter.
+  // Binned counts key by integer bin id (frame.xBinId), not inverse centers.
   if (needsX && indexKeyPrefix !== null && input.sourceRowsByGroupX !== undefined) {
-    const indexed = input.sourceRowsByGroupX.get(`${indexKeyPrefix}:${bandKey(outputX)}`);
+    const xKey =
+      frame.binding.xBinning !== undefined && frame.xBinId !== null
+        ? bandKey(frame.xBinId[frameRow]!)
+        : bandKey(outputX);
+    const indexed = input.sourceRowsByGroupX.get(`${indexKeyPrefix}:${xKey}`);
     if (indexed !== undefined) return indexed;
   }
 

--- a/packages/core/src/pipeline/scale-axis-collect-x-extras.ts
+++ b/packages/core/src/pipeline/scale-axis-collect-x-extras.ts
@@ -2,6 +2,7 @@
  * Collect x evidence from boxplot outliers and annotation intercepts.
  */
 import type { AxisCollectAcc } from "./scale-axis-collect-acc.js";
+import { assertInferredTemporalTransform } from "./scale-config-preflight.js";
 import { positionValueToScaleSpace, positionValuesToNumeric } from "./temporal-position.js";
 import type { LayerFrame } from "./types.js";
 
@@ -14,12 +15,23 @@ export function collectXOutliersAndIntercepts(frame: LayerFrame, acc: AxisCollec
     const conversion = frame.binding.xConversion;
     const converted = positionValuesToNumeric([v], conversion);
     const numeric = converted.values[0] ?? Number.NaN;
-    acc.numeric.push(
-      Float64Array.of(positionValueToScaleSpace(v, conversion, frame.binding.xTransform)),
-    );
     const temporal =
       converted.decision.status === "temporal" ||
       (conversion.parser !== "auto" && Number.isFinite(numeric));
+    // Annotation-only axes never enter mapped-field temporal.decisions, so
+    // reject temporal intercepts under a non-identity transform here.
+    if (temporal) {
+      assertInferredTemporalTransform(
+        "x",
+        frame.binding.xTransform === undefined
+          ? undefined
+          : { transform: frame.binding.xTransform.transform.key },
+        true,
+      );
+    }
+    acc.numeric.push(
+      Float64Array.of(positionValueToScaleSpace(v, conversion, frame.binding.xTransform)),
+    );
     if (!temporal) acc.allTemporal = false;
     if (typeof v === "string" && !Number.isFinite(numeric)) acc.anyDiscrete = true;
     acc.sawContinuousEvidence = true;

--- a/packages/core/src/pipeline/scale-axis-collect-y.ts
+++ b/packages/core/src/pipeline/scale-axis-collect-y.ts
@@ -2,6 +2,7 @@
  * Collect y-axis training evidence from a single layer frame.
  */
 import { snapColumnToBins } from "./binned-scale.js";
+import { assertInferredTemporalTransform } from "./scale-config-preflight.js";
 import { isBarLike } from "./scale-axis-train.js";
 import {
   positionColumn,
@@ -76,12 +77,21 @@ export function collectAxisInputsY(frame: LayerFrame, acc: AxisCollectAcc): void
     acc.columns.push([v]);
     const converted = positionValuesToNumeric([v], yConversion);
     const numeric = converted.values[0] ?? Number.NaN;
-    acc.numeric.push(
-      Float64Array.of(positionValueToScaleSpace(v, yConversion, binding.yTransform)),
-    );
     const temporal =
       converted.decision.status === "temporal" ||
       (yConversion.parser !== "auto" && Number.isFinite(numeric));
+    if (temporal) {
+      assertInferredTemporalTransform(
+        "y",
+        binding.yTransform === undefined
+          ? undefined
+          : { transform: binding.yTransform.transform.key },
+        true,
+      );
+    }
+    acc.numeric.push(
+      Float64Array.of(positionValueToScaleSpace(v, yConversion, binding.yTransform)),
+    );
     if (!temporal) acc.allTemporal = false;
     if (typeof v === "string" && !Number.isFinite(numeric)) acc.anyDiscrete = true;
     acc.sawContinuousEvidence = true;

--- a/packages/core/tests/stat-interaction-contract.test.ts
+++ b/packages/core/tests/stat-interaction-contract.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "bun:test";
 
-import { runPipeline } from "../src/pipeline.ts";
+import { aes, gg, scaleXBinned, scaleXLog10, scaleYLog10 } from "@ggsvelte/spec";
+
+import { PipelineError, runPipeline } from "../src/pipeline.ts";
 
 const size = { width: 400, height: 240 };
 
@@ -138,6 +140,92 @@ describe("stat interaction contract", () => {
     expect(lineage(model, 0)).toEqual([0, 1]);
     expect(model.candidates.candidate(1)).toMatchObject({ xValue: 1.5, yValue: 1 });
     expect(lineage(model, 1)).toEqual([2]);
+  });
+
+  it("assigns log10 histogram lineage in transformed space (not raw semantics)", () => {
+    // binwidth 1 at boundary 0 under log10 → decade bins; rows 1,10,100,1000
+    // land in three bins with counts 2,1,1 — lineage must match those counts.
+    const model = runPipeline(
+      gg(
+        [1, 10, 100, 1000].map((x) => ({ x })),
+        aes({ x: "x" }),
+      )
+        .geomHistogram({ binwidth: 1, boundary: 0 })
+        .scales(scaleXLog10())
+        .spec(),
+      size,
+    );
+    const lineages = Array.from({ length: model.candidates.size }, (_, id) => lineage(model, id));
+    const counts = Array.from({ length: model.candidates.size }, (_, id) => {
+      const candidate = model.candidates.candidate(id)!;
+      return { y: candidate.yValue, n: lineages[id]!.length, rows: lineages[id] };
+    });
+    expect(counts.map((c) => c.y)).toEqual([2, 1, 1]);
+    expect(counts.map((c) => c.n)).toEqual([2, 1, 1]);
+    expect(lineages.flat().toSorted((a, b) => a - b)).toEqual([0, 1, 2, 3]);
+  });
+
+  it("resolves binned count lineage by bin id, not inverse bin center", () => {
+    const model = runPipeline(
+      gg([{ x: 1 }, { x: 2 }, { x: 11 }, { x: 12 }, { x: 13 }], aes({ x: "x" }))
+        .geomBar()
+        .scales(scaleXBinned({ breaks: [0, 10, 20] }))
+        .spec(),
+      size,
+    );
+    expect(model.candidates.size).toBe(2);
+    expect(model.candidates.candidate(0)).toMatchObject({ yValue: 2 });
+    expect(lineage(model, 0)).toEqual([0, 1]);
+    expect(model.candidates.candidate(1)).toMatchObject({ yValue: 3 });
+    expect(lineage(model, 1)).toEqual([2, 3, 4]);
+  });
+
+  it("excludes transform-invalid rows from smooth candidate lineage", () => {
+    const model = runPipeline(
+      gg(
+        [
+          { x: 1, y: 1 },
+          { x: 2, y: 4 },
+          { x: 3, y: 9 },
+          { x: 4, y: -1 },
+        ],
+        aes({ x: "x", y: "y" }),
+      )
+        .geomSmooth({ method: "lm", se: false })
+        .scales(scaleYLog10())
+        .spec(),
+      size,
+    );
+    expect(model.candidates.size).toBeGreaterThan(0);
+    for (let id = 0; id < model.candidates.size; id++) {
+      expect(lineage(model, id)).toEqual([0, 1, 2]);
+    }
+  });
+
+  it("rejects temporal annotation intercepts under a non-identity transform", () => {
+    expect(() =>
+      runPipeline(
+        {
+          data: { values: [{ dummy: 1 }] },
+          layers: [{ geom: "rule", params: { xintercept: "2024-01-01" } }],
+          scales: { x: { transform: "log10", nice: false } },
+        },
+        size,
+      ),
+    ).toThrow(PipelineError);
+    try {
+      runPipeline(
+        {
+          data: { values: [{ dummy: 1 }] },
+          layers: [{ geom: "rule", params: { xintercept: "2024-01-01" } }],
+          scales: { x: { transform: "log10", nice: false } },
+        },
+        size,
+      );
+    } catch (error) {
+      expect(error).toBeInstanceOf(PipelineError);
+      expect((error as PipelineError).code).toBe("scale-type-transform-conflict");
+    }
   });
 
   it("uses the box middle for aggregate primitives and the observation for outliers", () => {


### PR DESCRIPTION
## Summary

Follow-up for unrebutted **post-merge** Codex findings on #365.

After pre-stat position transforms, candidate lineage still used semantic source values against scale-space bin edges / aggregate keys, so log histograms and binned counts often returned **empty** source lineages. Smooth marks also claimed transform-invalid rows. Annotation-only temporal intercepts under `log10`/`sqrt` bypassed the mapped-field temporal+transform guard.

## Fixes

| Finding | Fix |
|---------|-----|
| Histogram lineage vs transformed edges | `buildBinLineageBuckets` + `filterBinRepresentedRows` use `positionColumn(... xTransform)` |
| Binned count lineage | Key/resolve `sourceRowsByGroupX` by bin id (`xBinId`), not inverse center |
| Smooth lineage | Finite y/x membership after transform |
| Temporal annotation + transform | `assertInferredTemporalTransform` on intercept collection |

## Deferred

- **baselineScales uncensored path** — valid; needs second evidence pass. Tracked as #449 (skipped identity contract already documents target).

## Parent

- https://github.com/ljodea/ggsvelte/pull/365

## Test plan

- [x] RED→GREEN regressions in `stat-interaction-contract.test.ts`
- [x] `bun test` candidate-construction + transform + interaction suites