### PR TITLE
fix(core): narrow binned lineage keys and forced-linear intercepts

### DIFF
--- a/packages/core/src/pipeline/candidate-construction/identity-buckets.ts
+++ b/packages/core/src/pipeline/candidate-construction/identity-buckets.ts
@@ -15,9 +15,9 @@ export function aggregateLineageXKey(
   localRow: number,
   binding: LayerBinding,
 ): string {
-  // Binned count stores bin ids on the frame; bucket membership must key by
-  // the same id (not the inverse-projected bin center in xValues).
-  if (binding.xBinning !== undefined) {
+  // Only count aggregates on bin ids (frame.xBinId). Summary/boxplot still
+  // aggregate on actual x values even when a binned scale is attached.
+  if (binding.xBinning !== undefined && (binding.layer.stat ?? "identity") === "count") {
     const transformed = positionColumn(table, field, xConversionOf(binding), binding.xTransform);
     return bandKey(assignBinId(transformed[localRow]!, binding.xBinning));
   }

--- a/packages/core/src/pipeline/scale-axis-collect-x-extras.ts
+++ b/packages/core/src/pipeline/scale-axis-collect-x-extras.ts
@@ -20,8 +20,9 @@ export function collectXOutliersAndIntercepts(frame: LayerFrame, acc: AxisCollec
       (conversion.parser !== "auto" && Number.isFinite(numeric));
     // Annotation-only axes never enter mapped-field temporal.decisions, so
     // reject temporal intercepts under a non-identity transform here — but
-    // respect forced-linear axes (year-like strings stay quantitative).
-    if (temporal && !conversion.forcedNonTemporal) {
+    // forced-linear axes may coerce year-like strings ("2024") quantitatively
+    // only when the value is finite.
+    if (temporal && !(conversion.forcedNonTemporal && Number.isFinite(numeric))) {
       assertInferredTemporalTransform(
         "x",
         frame.binding.xTransform === undefined

--- a/packages/core/src/pipeline/scale-axis-collect-x-extras.ts
+++ b/packages/core/src/pipeline/scale-axis-collect-x-extras.ts
@@ -19,8 +19,9 @@ export function collectXOutliersAndIntercepts(frame: LayerFrame, acc: AxisCollec
       converted.decision.status === "temporal" ||
       (conversion.parser !== "auto" && Number.isFinite(numeric));
     // Annotation-only axes never enter mapped-field temporal.decisions, so
-    // reject temporal intercepts under a non-identity transform here.
-    if (temporal) {
+    // reject temporal intercepts under a non-identity transform here — but
+    // respect forced-linear axes (year-like strings stay quantitative).
+    if (temporal && !conversion.forcedNonTemporal) {
       assertInferredTemporalTransform(
         "x",
         frame.binding.xTransform === undefined

--- a/packages/core/src/pipeline/scale-axis-collect-y.ts
+++ b/packages/core/src/pipeline/scale-axis-collect-y.ts
@@ -80,7 +80,7 @@ export function collectAxisInputsY(frame: LayerFrame, acc: AxisCollectAcc): void
     const temporal =
       converted.decision.status === "temporal" ||
       (yConversion.parser !== "auto" && Number.isFinite(numeric));
-    if (temporal) {
+    if (temporal && !yConversion.forcedNonTemporal) {
       assertInferredTemporalTransform(
         "y",
         binding.yTransform === undefined

--- a/packages/core/src/pipeline/scale-axis-collect-y.ts
+++ b/packages/core/src/pipeline/scale-axis-collect-y.ts
@@ -80,7 +80,7 @@ export function collectAxisInputsY(frame: LayerFrame, acc: AxisCollectAcc): void
     const temporal =
       converted.decision.status === "temporal" ||
       (yConversion.parser !== "auto" && Number.isFinite(numeric));
-    if (temporal && !yConversion.forcedNonTemporal) {
+    if (temporal && !(yConversion.forcedNonTemporal && Number.isFinite(numeric))) {
       assertInferredTemporalTransform(
         "y",
         binding.yTransform === undefined

--- a/packages/core/tests/stat-interaction-contract.test.ts
+++ b/packages/core/tests/stat-interaction-contract.test.ts
@@ -241,6 +241,19 @@ describe("stat interaction contract", () => {
     expect(model.domains.effective.x[1]).toBeGreaterThan(model.domains.effective.x[0]!);
   });
 
+  it("still rejects non-finite date intercepts on forced-linear log axes", () => {
+    expect(() =>
+      runPipeline(
+        {
+          data: { values: [{ dummy: 1 }] },
+          layers: [{ geom: "rule", params: { xintercept: "2024-01-01" } }],
+          scales: { x: { type: "linear", transform: "log10", nice: false } },
+        },
+        size,
+      ),
+    ).toThrow(PipelineError);
+  });
+
   it("uses the box middle for aggregate primitives and the observation for outliers", () => {
     const model = runPipeline(
       {

--- a/packages/core/tests/stat-interaction-contract.test.ts
+++ b/packages/core/tests/stat-interaction-contract.test.ts
@@ -228,6 +228,19 @@ describe("stat interaction contract", () => {
     }
   });
 
+  it("allows forced-linear numeric annotation strings under log10", () => {
+    const model = runPipeline(
+      {
+        data: { values: [{ dummy: 1 }] },
+        layers: [{ geom: "rule", params: { xintercept: "2024" } }],
+        scales: { x: { type: "linear", transform: "log10", nice: false } },
+      },
+      size,
+    );
+    expect(model.domains.effective.x[0]).toBeGreaterThan(0);
+    expect(model.domains.effective.x[1]).toBeGreaterThan(model.domains.effective.x[0]!);
+  });
+
   it("uses the box middle for aggregate primitives and the observation for outliers", () => {
     const model = runPipeline(
       {


### PR DESCRIPTION
## Summary

Follow-up for post-merge Codex P2s on #450.

1. **Bin-id lineage keys** only for `stat: "count"` (summary/boxplot keep x-value keys even when `xBinning` is set).
2. **Forced-linear** annotation intercepts skip temporal+transform rejection (`!conversion.forcedNonTemporal`).

## Parent

- https://github.com/ljodea/ggsvelte/pull/450

## Test plan

- [x] `allows forced-linear numeric annotation strings under log10`
- [x] existing binned-count / temporal-annotation regressions still green