### PR TITLE
refactor(docs): extract playground draft validation from state machine

### DIFF
--- a/apps/docs/src/lib/playground-draft-validate.ts
+++ b/apps/docs/src/lib/playground-draft-validate.ts
@@ -1,0 +1,120 @@
+import { normalize, validate, type PortableSpec, type SpecError } from "@ggsvelte/spec";
+
+import {
+  assertPlaygroundDraftSize,
+  PLAYGROUND_MAX_DECODED_BYTES,
+  PLAYGROUND_MAX_DEPTH,
+  PLAYGROUND_MAX_ROWS,
+  PlaygroundCodecError,
+  validatePlaygroundSeed,
+  type PlaygroundSeedV1,
+} from "./playground-codec";
+import type { PlaygroundDiagnostic } from "./playground-state";
+
+const VALIDATE_LIMITS = {
+  maxRows: PLAYGROUND_MAX_ROWS,
+  maxBytes: PLAYGROUND_MAX_DECODED_BYTES,
+  maxDepth: PLAYGROUND_MAX_DEPTH,
+  maxDiagnostics: 100,
+} as const;
+
+export type PlaygroundDraftValidation =
+  | {
+      readonly ok: true;
+      readonly spec: PortableSpec;
+      readonly canonicalDraft: string;
+      /** Raw custom seed passed to validatePlaygroundSeed for side-effect checks only. */
+      readonly seed: PlaygroundSeedV1;
+    }
+  | { readonly ok: false; readonly diagnostics: readonly PlaygroundDiagnostic[] };
+
+export function serializePlaygroundSpec(spec: PortableSpec): string {
+  const pretty = JSON.stringify(spec, null, 2);
+  if (new TextEncoder().encode(pretty).byteLength <= PLAYGROUND_MAX_DECODED_BYTES) {
+    return pretty;
+  }
+  return JSON.stringify(spec);
+}
+
+function diagnosticFromSpec(error: SpecError): PlaygroundDiagnostic {
+  return {
+    source: "validation",
+    code: error.code,
+    path: error.path,
+    message: error.message,
+    ...(error.fix?.description === undefined ? {} : { fix: error.fix.description }),
+  };
+}
+
+/**
+ * Parse and validate a playground draft string without touching workbench state.
+ * Preserve order: size → JSON → shape validate → normalize → limits validate → seed bounds.
+ *
+ * `validatePlaygroundSeed` is used for its throw side-effect only; the returned seed is the
+ * raw custom envelope (not the codec's bounded return value), matching prior stagePlaygroundDraft.
+ */
+export function validatePlaygroundDraft(draft: string): PlaygroundDraftValidation {
+  let input: unknown;
+  try {
+    assertPlaygroundDraftSize(draft);
+    input = JSON.parse(draft) as unknown;
+  } catch (error) {
+    if (error instanceof PlaygroundCodecError) {
+      return {
+        ok: false,
+        diagnostics: [
+          {
+            source: "playground",
+            code: "share-limit",
+            path: "",
+            message: error.message,
+            fix: "Use a smaller portable spec.",
+          },
+        ],
+      };
+    }
+    return {
+      ok: false,
+      diagnostics: [
+        {
+          source: "playground",
+          code: "invalid-json",
+          path: "",
+          message: error instanceof Error ? error.message : "The draft is not valid JSON.",
+          fix: "Check quotes, commas, and brackets, then apply again.",
+        },
+      ],
+    };
+  }
+
+  const shape = validate(input);
+  if (!shape.ok) return { ok: false, diagnostics: shape.errors.map(diagnosticFromSpec) };
+  const normalized = normalize(shape.spec);
+  const checked = validate(normalized, { limits: VALIDATE_LIMITS });
+  if (!checked.ok) return { ok: false, diagnostics: checked.errors.map(diagnosticFromSpec) };
+
+  const canonicalDraft = serializePlaygroundSpec(checked.spec);
+  const seed: PlaygroundSeedV1 = {
+    version: 1,
+    source: { kind: "custom" },
+    spec: checked.spec,
+  };
+  try {
+    // Side-effect only — do not replace seed with the bounded return value.
+    validatePlaygroundSeed(seed);
+  } catch (error) {
+    return {
+      ok: false,
+      diagnostics: [
+        {
+          source: "playground",
+          code: "share-limit",
+          path: "",
+          message: error instanceof Error ? error.message : "The draft exceeds playground limits.",
+          fix: "Use a smaller portable spec.",
+        },
+      ],
+    };
+  }
+  return { ok: true, spec: checked.spec, canonicalDraft, seed };
+}

--- a/apps/docs/src/lib/playground-state.ts
+++ b/apps/docs/src/lib/playground-state.ts
@@ -1,15 +1,13 @@
-import { normalize, validate, type PortableSpec, type SpecError } from "@ggsvelte/spec";
+import type { PortableSpec } from "@ggsvelte/spec";
 
 import {
-  assertPlaygroundDraftSize,
   encodePlaygroundSeed,
-  PLAYGROUND_MAX_DECODED_BYTES,
-  PLAYGROUND_MAX_DEPTH,
-  PLAYGROUND_MAX_ROWS,
-  PlaygroundCodecError,
   validatePlaygroundSeed,
   type PlaygroundSeedV1,
 } from "./playground-codec";
+import { serializePlaygroundSpec, validatePlaygroundDraft } from "./playground-draft-validate";
+
+export { serializePlaygroundSpec } from "./playground-draft-validate";
 
 export type PlaygroundDiagnosticSource = "playground" | "validation" | "pipeline" | "export";
 
@@ -65,31 +63,6 @@ export interface PlaygroundState extends PlaygroundSnapshot {
 }
 
 export const PLAYGROUND_MAX_UNDO_SNAPSHOTS = 20;
-
-const VALIDATE_LIMITS = {
-  maxRows: PLAYGROUND_MAX_ROWS,
-  maxBytes: PLAYGROUND_MAX_DECODED_BYTES,
-  maxDepth: PLAYGROUND_MAX_DEPTH,
-  maxDiagnostics: 100,
-} as const;
-
-export function serializePlaygroundSpec(spec: PortableSpec): string {
-  const pretty = JSON.stringify(spec, null, 2);
-  if (new TextEncoder().encode(pretty).byteLength <= PLAYGROUND_MAX_DECODED_BYTES) {
-    return pretty;
-  }
-  return JSON.stringify(spec);
-}
-
-function diagnosticFromSpec(error: SpecError): PlaygroundDiagnostic {
-  return {
-    source: "validation",
-    code: error.code,
-    path: error.path,
-    message: error.message,
-    ...(error.fix?.description === undefined ? {} : { fix: error.fix.description }),
-  };
-}
 
 function finalize(
   state: Omit<PlaygroundState, "synchronized" | "canCopyOrShare">,
@@ -188,68 +161,19 @@ function invalidDraft(
 }
 
 export function stagePlaygroundDraft(state: PlaygroundState): PlaygroundState {
-  let input: unknown;
-  try {
-    assertPlaygroundDraftSize(state.draft);
-    input = JSON.parse(state.draft) as unknown;
-  } catch (error) {
-    if (error instanceof PlaygroundCodecError) {
-      return invalidDraft(state, [
-        {
-          source: "playground",
-          code: "share-limit",
-          path: "",
-          message: error.message,
-          fix: "Use a smaller portable spec.",
-        },
-      ]);
-    }
-    return invalidDraft(state, [
-      {
-        source: "playground",
-        code: "invalid-json",
-        path: "",
-        message: error instanceof Error ? error.message : "The draft is not valid JSON.",
-        fix: "Check quotes, commas, and brackets, then apply again.",
-      },
-    ]);
-  }
+  const validated = validatePlaygroundDraft(state.draft);
+  if (!validated.ok) return invalidDraft(state, validated.diagnostics);
 
-  const shape = validate(input);
-  if (!shape.ok) return invalidDraft(state, shape.errors.map(diagnosticFromSpec));
-  const normalized = normalize(shape.spec);
-  const checked = validate(normalized, { limits: VALIDATE_LIMITS });
-  if (!checked.ok) return invalidDraft(state, checked.errors.map(diagnosticFromSpec));
-
-  const canonical = serializePlaygroundSpec(checked.spec);
-  const nextSeed: PlaygroundSeedV1 = {
-    version: 1,
-    source: { kind: "custom" },
-    spec: checked.spec,
-  };
-  try {
-    validatePlaygroundSeed(nextSeed);
-  } catch (error) {
-    return invalidDraft(state, [
-      {
-        source: "playground",
-        code: "share-limit",
-        path: "",
-        message: error instanceof Error ? error.message : "The draft exceeds playground limits.",
-        fix: "Use a smaller portable spec.",
-      },
-    ]);
-  }
   const next: PlaygroundSnapshot = {
     sourceBaseline: state.sourceBaseline,
-    seed: nextSeed,
-    draft: canonical,
-    committed: checked.spec,
-    rendered: checked.spec,
+    seed: validated.seed,
+    draft: validated.canonicalDraft,
+    committed: validated.spec,
+    rendered: validated.spec,
     renderConfirmed: true,
     historyHash: null,
   };
-  return stage(state, "apply", next, canonical);
+  return stage(state, "apply", next, validated.canonicalDraft);
 }
 
 export function stagePlaygroundSeed(

--- a/scripts/playground-draft-validate.test.ts
+++ b/scripts/playground-draft-validate.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, test } from "bun:test";
+
+import type { PortableSpec } from "@ggsvelte/spec";
+
+import {
+  PLAYGROUND_MAX_DECODED_BYTES,
+  type PlaygroundSeedV1,
+} from "../apps/docs/src/lib/playground-codec";
+import {
+  serializePlaygroundSpec,
+  validatePlaygroundDraft,
+} from "../apps/docs/src/lib/playground-draft-validate";
+
+const baseSpec: PortableSpec = {
+  edition: 1,
+  data: {
+    values: [
+      { x: 1, y: 2 },
+      { x: 2, y: 3 },
+    ],
+  },
+  layers: [
+    {
+      geom: "point",
+      stat: "identity",
+      position: "identity",
+      aes: { x: { field: "x" }, y: { field: "y" } },
+    },
+  ],
+  labs: { title: "Baseline" },
+};
+
+describe("validatePlaygroundDraft", () => {
+  test("accepts a valid draft and returns custom seed with canonical draft", () => {
+    const draft = JSON.stringify(baseSpec);
+    const result = validatePlaygroundDraft(draft);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.spec).toEqual(baseSpec);
+    expect(result.canonicalDraft).toBe(serializePlaygroundSpec(baseSpec));
+    expect(result.seed).toEqual({
+      version: 1,
+      source: { kind: "custom" },
+      spec: baseSpec,
+    } satisfies PlaygroundSeedV1);
+    // Seed is the raw custom envelope, not a codec-clamped object identity change.
+    expect(result.seed.spec).toBe(result.spec);
+  });
+
+  test("maps invalid JSON to an exact playground diagnostic", () => {
+    const result = validatePlaygroundDraft("{");
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0]?.source).toBe("playground");
+    expect(result.diagnostics[0]?.code).toBe("invalid-json");
+    expect(result.diagnostics[0]?.path).toBe("");
+    expect(result.diagnostics[0]?.fix).toBe(
+      "Check quotes, commas, and brackets, then apply again.",
+    );
+    expect(result.diagnostics[0]?.message.length).toBeGreaterThan(0);
+  });
+
+  test("rejects oversized raw draft before parse as share-limit", () => {
+    const result = validatePlaygroundDraft("x".repeat(PLAYGROUND_MAX_DECODED_BYTES + 1));
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.diagnostics).toEqual([
+      {
+        source: "playground",
+        code: "share-limit",
+        path: "",
+        message: `Playground JSON must be at most ${String(PLAYGROUND_MAX_DECODED_BYTES / 1024)} KiB.`,
+        fix: "Use a smaller portable spec.",
+      },
+    ]);
+  });
+
+  test("maps schema failures to validation diagnostics", () => {
+    const result = validatePlaygroundDraft(JSON.stringify({ ...baseSpec, layers: [] }));
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+    expect(result.diagnostics[0]?.source).toBe("validation");
+    expect(result.diagnostics[0]?.code).toBeTruthy();
+    expect(result.diagnostics[0]?.path).toBeDefined();
+    expect(result.diagnostics[0]?.message.length).toBeGreaterThan(0);
+  });
+
+  test("rejects drafts that pass schema/limits but fail seed bounds as share-limit", () => {
+    // PortableSpec validate does not enforce playground string code-point caps;
+    // validatePlaygroundSeed does — that path must stay mapped to share-limit.
+    const tooLongTitle = "a".repeat(2_049);
+    const draft = JSON.stringify({
+      ...baseSpec,
+      labs: { title: tooLongTitle },
+    });
+    expect(new TextEncoder().encode(draft).byteLength).toBeLessThanOrEqual(
+      PLAYGROUND_MAX_DECODED_BYTES,
+    );
+    const result = validatePlaygroundDraft(draft);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.diagnostics).toEqual([
+      {
+        source: "playground",
+        code: "share-limit",
+        path: "",
+        message: "Shared playground strings must contain at most 2048 Unicode code points.",
+        fix: "Use a smaller portable spec.",
+      },
+    ]);
+  });
+});
+
+describe("serializePlaygroundSpec", () => {
+  test("pretty-prints when under the share byte budget and collapses when needed", () => {
+    const pretty = serializePlaygroundSpec(baseSpec);
+    expect(pretty).toContain("\n");
+    expect(JSON.parse(pretty)).toEqual(baseSpec);
+  });
+});


### PR DESCRIPTION
## Summary

Maintainability pass on `apps/docs` after the codec split (#442) and link-policy extract (#445).

**Chosen candidate:** `playground-state.ts` (was 400 lines) mixed workbench transitions with the draft apply pipeline (size → JSON → validate → normalize → limits → seed bounds).

**What changed:**

| Module | Role |
|--------|------|
| `playground-draft-validate.ts` | `validatePlaygroundDraft` + `serializePlaygroundSpec` |
| `playground-state.ts` | State machine; thin `stagePlaygroundDraft` wrapper; re-exports `serializePlaygroundSpec` |

Import paths for consumers stay on `playground-state` (and types remain there). Draft validation is independently unit-testable.

## Behavior preserved

- Validation order unchanged
- `validatePlaygroundSeed` remains side-effect-only (raw custom seed staged, not codec-clamped return)
- Diagnostic codes/messages/fixes for invalid-json, share-limit, and mapped validation errors

## Tests

- New `scripts/playground-draft-validate.test.ts` (valid path, invalid JSON, raw oversized draft, schema failure, seed string-cap share-limit)
- Existing `scripts/playground-state.test.ts` + `playground-link-policy.test.ts` green (25 pass across focused suite)
- `bun run check:docs` clean
- `bun run knip` clean

## Independent review

Code review: no P1 findings on order, share-limit paths, seed side-effect semantics, or facade re-exports.

## Follow-ups

None filed — remaining large docs files are keep/opportunistic (guide prose, page composition, UI shells).