### PR TITLE
perf(spec): skip exact-format cache for empty/oversize formats (#451)

### DIFF
--- a/.changeset/exact-format-cache-length.md
+++ b/.changeset/exact-format-cache-length.md
@@ -1,0 +1,10 @@
+---
+"@ggsvelte/spec": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+perf: skip exact-format compile cache for empty/oversize format strings
+
+`compileExactFormat` rejects length 0 and length >128 before any Map get/set so
+adversarial long rejected formats cannot accumulate as unbounded cache keys.

--- a/packages/spec/src/temporal-parse.ts
+++ b/packages/spec/src/temporal-parse.ts
@@ -424,6 +424,16 @@ const EXACT_FORMAT_CACHE_MAX = 256;
 const EXACT_FORMAT_CACHE = new Map<string, CompiledExactFormat>();
 
 function compileExactFormat(format: string): CompiledExactFormat {
+  // Length failures never enter the cache: rejected strings can be arbitrarily
+  // large, and retaining them as Map keys would bound memory only by the LRU
+  // entry count, not by key size (#451).
+  if (format.length === 0 || format.length > 128) {
+    return {
+      ok: false,
+      reason: "format length must be from 1 through 128 characters",
+    };
+  }
+
   const cached = EXACT_FORMAT_CACHE.get(format);
   if (cached !== undefined) {
     // Refresh LRU order (Map iterates in insertion order).
@@ -432,52 +442,44 @@ function compileExactFormat(format: string): CompiledExactFormat {
     return cached;
   }
 
-  let compiled: CompiledExactFormat;
-  if (format.length === 0 || format.length > 128) {
-    compiled = {
-      ok: false,
-      reason: "format length must be from 1 through 128 characters",
-    };
-  } else {
-    const tokens: string[] = [];
-    let pattern = "^";
-    let reason: string | null = null;
-    for (let index = 0; index < format.length; index++) {
-      const char = format[index]!;
-      if (char !== "%") {
-        pattern += escapeRegex(char);
-        continue;
-      }
-      const token = format[++index];
-      if (token === undefined) {
-        reason = "format cannot end with %";
-        break;
-      }
-      if (token === "%") {
-        pattern += "%";
-        continue;
-      }
-      const tokenPattern = FORMAT_TOKEN_PATTERNS[token];
-      if (tokenPattern === undefined) {
-        reason = `unsupported format token %${token}`;
-        break;
-      }
-      if (tokens.includes(token)) {
-        reason = `duplicate semantic format token %${token}`;
-        break;
-      }
-      tokens.push(token);
-      if (tokens.length > 32) {
-        reason = "format may contain at most 32 semantic tokens";
-        break;
-      }
-      pattern += tokenPattern;
+  const tokens: string[] = [];
+  let pattern = "^";
+  let reason: string | null = null;
+  for (let index = 0; index < format.length; index++) {
+    const char = format[index]!;
+    if (char !== "%") {
+      pattern += escapeRegex(char);
+      continue;
     }
-    compiled =
-      reason === null
-        ? { ok: true, tokens, regex: new RegExp(`${pattern}$`) }
-        : { ok: false, reason };
+    const token = format[++index];
+    if (token === undefined) {
+      reason = "format cannot end with %";
+      break;
+    }
+    if (token === "%") {
+      pattern += "%";
+      continue;
+    }
+    const tokenPattern = FORMAT_TOKEN_PATTERNS[token];
+    if (tokenPattern === undefined) {
+      reason = `unsupported format token %${token}`;
+      break;
+    }
+    if (tokens.includes(token)) {
+      reason = `duplicate semantic format token %${token}`;
+      break;
+    }
+    tokens.push(token);
+    if (tokens.length > 32) {
+      reason = "format may contain at most 32 semantic tokens";
+      break;
+    }
+    pattern += tokenPattern;
   }
+  const compiled: CompiledExactFormat =
+    reason === null
+      ? { ok: true, tokens, regex: new RegExp(`${pattern}$`) }
+      : { ok: false, reason };
 
   if (EXACT_FORMAT_CACHE.size >= EXACT_FORMAT_CACHE_MAX) {
     const oldest = EXACT_FORMAT_CACHE.keys().next().value;
@@ -485,6 +487,11 @@ function compileExactFormat(format: string): CompiledExactFormat {
   }
   EXACT_FORMAT_CACHE.set(format, compiled);
   return compiled;
+}
+
+/** Test-only: whether a format string is retained in the compile cache. */
+export function exactFormatCacheHasForTests(format: string): boolean {
+  return EXACT_FORMAT_CACHE.has(format);
 }
 
 function parseExactFormat(

--- a/packages/spec/tests/temporal.test.ts
+++ b/packages/spec/tests/temporal.test.ts
@@ -13,6 +13,7 @@ import {
   yq,
   fromEpochSeconds,
 } from "../src/temporal.ts";
+import { exactFormatCacheHasForTests } from "../src/temporal-parse.ts";
 
 describe("strict temporal parsing", () => {
   it("rejects blank strings for explicit epoch parsers", () => {
@@ -82,6 +83,28 @@ describe("strict temporal parsing", () => {
     expect(parseTemporal("2024", { format: "%s" })).toMatchObject({ ok: false });
     expect(parseTemporal("2024-12", { format: "%Y-%Y" })).toMatchObject({ ok: false });
     expect(parseTemporal("2024", { format: "x".repeat(129) })).toMatchObject({ ok: false });
+  });
+
+  it("does not retain empty or oversize exact formats as compile-cache keys (#451)", () => {
+    const oversize = "x".repeat(10_000);
+    const empty = "";
+    const oversizeResult = parseTemporal("2024", { format: oversize });
+    const emptyResult = parseTemporal("2024", { format: empty });
+    expect(oversizeResult).toMatchObject({
+      ok: false,
+      reason: "format length must be from 1 through 128 characters",
+    });
+    expect(emptyResult).toMatchObject({
+      ok: false,
+      reason: "format length must be from 1 through 128 characters",
+    });
+    expect(exactFormatCacheHasForTests(oversize)).toBe(false);
+    expect(exactFormatCacheHasForTests(empty)).toBe(false);
+
+    // Bounded invalid formats still cache (LRU path); length failures do not.
+    const unsupported = "%s";
+    expect(parseTemporal("2024", { format: unsupported })).toMatchObject({ ok: false });
+    expect(exactFormatCacheHasForTests(unsupported)).toBe(true);
   });
 
   /**


### PR DESCRIPTION
## Summary

Fixes #451: empty and oversize exact-format strings no longer enter EXACT_FORMAT_CACHE as Map keys.

compileExactFormat returns the length failure before any cache get/set. Bounded invalid formats (e.g. unsupported tokens) still cache under the existing LRU.

## Validation

- Oversized (10k) and empty format strings keep reason: format length must be from 1 through 128 characters
- Test-only probe confirms they are not retained in the compile cache
- Unsupported %s still caches (LRU path unchanged)

## Tests

bun test packages/spec (331 pass), including new #451 characterization in temporal.test.ts
