### PR TITLE
perf(spec): memoize lint transform-domain column scans (#425)

### DIFF
--- a/packages/spec/src/lint.ts
+++ b/packages/spec/src/lint.ts
@@ -149,6 +149,21 @@ function transformDomainOf(config: PositionScaleSpec | undefined): TransformDoma
   return null;
 }
 
+/** Count numeric values inside/outside a transform domain (non-numbers ignored). */
+function countTransformDomain(
+  values: readonly unknown[],
+  domain: TransformDomain,
+): readonly [inDomain: number, outOfDomain: number] {
+  let inDomain = 0;
+  let outOfDomain = 0;
+  for (const v of values) {
+    if (typeof v !== "number") continue;
+    if (domain.valid(v)) inDomain++;
+    else outOfDomain++;
+  }
+  return [inDomain, outOfDomain];
+}
+
 // ---------------------------------------------------------------------------
 // lintSpec
 // ---------------------------------------------------------------------------
@@ -294,10 +309,15 @@ export function lintSpec(
   // canonical `transform: "log10" | "sqrt"` are all handled here. log10 rejects
   // values <= 0; sqrt rejects values < 0. The advisory fires only on MIXED data
   // (some in-domain, some out) — all-invalid is the pipeline's error/warning.
+  //
+  // Multi-layer charts often share the same mapped field (plot aes or repeated
+  // layer aes). Memoize [inDomain, outOfDomain] per field name for this axis so
+  // a shared column is scanned once (O(n)), not once per layer (O(L·n)).
   for (const axis of ["x", "y"] as const) {
     const config = scales?.[axis] as PositionScaleSpec | undefined;
     const domain = transformDomainOf(config);
     if (domain === null) continue;
+    const fieldDomainCounts = new Map<string, readonly [inDomain: number, outOfDomain: number]>();
     for (let i = 0; i < layers.length; i++) {
       const layer = layers[i];
       if (!isRecord(layer)) continue;
@@ -305,13 +325,12 @@ export function lintSpec(
       const use = fieldOf(layerAes, axis);
       const values = use?.info.values;
       if (use === null || values === null || values === undefined) continue;
-      let inDomain = 0;
-      let outOfDomain = 0;
-      for (const v of values) {
-        if (typeof v !== "number") continue;
-        if (domain.valid(v)) inDomain++;
-        else outOfDomain++;
+      let counts = fieldDomainCounts.get(use.field);
+      if (counts === undefined) {
+        counts = countTransformDomain(values, domain);
+        fieldDomainCounts.set(use.field, counts);
       }
+      const [inDomain, outOfDomain] = counts;
       if (inDomain > 0 && outOfDomain > 0) {
         advisories.push({
           code: "transform-domain-data",

--- a/packages/spec/tests/lint.test.ts
+++ b/packages/spec/tests/lint.test.ts
@@ -169,6 +169,60 @@ describe("transform-domain-data", () => {
     // this mixed-data advisory.
     expect(lintSpec(spec([-1, -2, 0], { type: "log" }))).toEqual([]);
   });
+
+  /**
+   * Characterization for field-scan memoization (#425): multi-layer reuse of
+   * the same mapped field under a transform scale must keep one advisory per
+   * axis with stable counts, including plot-aes inheritance.
+   */
+  it("emits one advisory with stable counts when multiple layers share a mixed field", () => {
+    const advisories = lintSpec({
+      data: { columns: { x: [1, 2, 3, 4], y: [5, -1, 0, 10] } },
+      aes: { x: { field: "x" }, y: { field: "y" } },
+      scales: { y: { type: "log" } },
+      layers: [{ geom: "point" }, { geom: "line" }, { geom: "smooth" }],
+    });
+    expect(codesOf(advisories)).toEqual(["transform-domain-data"]);
+    expect(advisories[0]!.path).toBe("/scales/y");
+    // log10: -1 and 0 out of domain; 5 and 10 in domain.
+    expect(advisories[0]!.message).toContain("2 value(s) outside");
+    expect(advisories[0]!.message).toContain("2 valid");
+  });
+
+  it("reuses plot-level aes y across layers when scanning transform domain", () => {
+    const advisories = lintSpec({
+      data: { columns: { x: [1, 2, 3], y: [4, -4, 9] } },
+      aes: { x: { field: "x" }, y: { field: "y" } },
+      scales: { y: { type: "linear", transform: "sqrt" } },
+      // Layer aes omit y so effectiveChannel falls back to plot aes.
+      layers: [{ geom: "point" }, { geom: "line", aes: { x: { field: "x" } } }],
+    });
+    expect(codesOf(advisories)).toEqual(["transform-domain-data"]);
+    expect(advisories[0]!.message).toContain('field "y"');
+    expect(advisories[0]!.message).toContain("1 value(s) outside");
+  });
+
+  it("keeps first-hit field ordering when an earlier mixed field wins", () => {
+    const advisories = lintSpec({
+      data: {
+        columns: {
+          early: [5, -1, 10],
+          late: [1, -2, 3],
+          x: [1, 2, 3],
+        },
+      },
+      scales: { y: { type: "log" } },
+      layers: [
+        { geom: "point", aes: { x: { field: "x" }, y: { field: "early" } } },
+        { geom: "line", aes: { x: { field: "x" }, y: { field: "late" } } },
+      ],
+    });
+    expect(codesOf(advisories)).toEqual(["transform-domain-data"]);
+    // First mixed field encountered is "early" (1 out of domain: -1).
+    expect(advisories[0]!.message).toContain('field "early"');
+    expect(advisories[0]!.message).toContain("1 value(s) outside");
+    expect(advisories[0]!.message).not.toContain('field "late"');
+  });
 });
 
 describe("lintSpec options.limits", () => {


### PR DESCRIPTION
## Summary

Big-O maintain on packages/spec — deferred #425.

**Finding:** lint transform-domain-data rescanned full columns per layer under log10/sqrt scales (O(L·n)).

**Fix:** Memoize [inDomain, outOfDomain] per field name per axis; extract countTransformDomain helper.

**Tests:** multi-layer shared field, plot-aes inheritance, first-hit field ordering.

## Verification

bun test packages/spec (333 pass); bun run lint:type-aware clean.

## Follow-ups

- https://github.com/ljodea/ggsvelte/issues/451 — oversized exact-format cache keys

## Codex plan review

APPROVE-WITH-CHANGES: multi-layer + inheritance + first-hit tests added.

Closes #425.
