### PR TITLE
refactor(spec): extract builder-data and split temporal scale tests

### DIFF
--- a/.changeset/spec-builder-data-split.md
+++ b/.changeset/spec-builder-data-split.md
@@ -1,0 +1,7 @@
+---
+"@ggsvelte/spec": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+Extract builder authoring data conversion into builder-data.ts and split the long temporal scale API tests into schema vs authoring files. Public builder exports are unchanged.

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "fmt": "bun node_modules/.bin/oxfmt && bun node_modules/.bin/prettier --write --log-level warn \"**/*.{svelte,md,yml,yaml}\"",
     "fmt:check": "bun node_modules/.bin/oxfmt --check && bun node_modules/.bin/prettier --check --log-level warn \"**/*.{svelte,md,yml,yaml}\"",
     "test": "bun test packages/spec packages/core benchmarks scripts tests/evals",
-    "test:temporal-parser": "bun test packages/spec/tests/temporal.test.ts packages/spec/tests/temporal-api.test.ts packages/spec/tests/temporal-source-gate.test.ts packages/core/tests/table-temporal.test.ts",
+    "test:temporal-parser": "bun test packages/spec/tests/temporal.test.ts packages/spec/tests/temporal-scale-schema.test.ts packages/spec/tests/temporal-scale-authoring.test.ts packages/spec/tests/temporal-source-gate.test.ts packages/core/tests/table-temporal.test.ts",
     "test:temporal-pipeline": "bun test packages/core/tests/pipeline-temporal.test.ts packages/core/tests/ticks.test.ts",
     "test:spikes": "cd spikes/browser && bun run --bun test",
     "test:visual": "bun node_modules/.bin/playwright test --config tests/visual/playwright.config.ts",

--- a/packages/spec/src/builder-data.ts
+++ b/packages/spec/src/builder-data.ts
@@ -1,0 +1,139 @@
+/**
+ * Builder/Svelte authoring data conversion.
+ *
+ * Accepts rows, columns, or named DataRef forms with Date cells; snapshots
+ * inputs immutably for `gg()`; and materializes portable CellValue data
+ * (ISO date/datetime strings) for `.spec()`. Geom sugar and GGBuilder live
+ * in builder.ts.
+ */
+
+import type { AesInput } from "./normalize.js";
+import type { CellValue, DataRef, Scales } from "./schema.js";
+
+/** A builder/Svelte data cell. Dates canonicalize to ISO before validation. */
+export type AuthoringCellValue = CellValue | Date;
+export type AuthoringRows = readonly Readonly<Record<string, AuthoringCellValue>>[];
+export type AuthoringColumns = Readonly<Record<string, readonly AuthoringCellValue[]>>;
+export type AuthoringDataRef =
+  | { values: AuthoringRows }
+  | { columns: AuthoringColumns }
+  | { name: string };
+
+/** Data accepted by gg(): authoring rows, columns, or a data reference. */
+export type DataInput = AuthoringRows | AuthoringColumns | AuthoringDataRef;
+
+function isDataRef(data: DataInput): data is AuthoringDataRef {
+  if (Array.isArray(data)) return false;
+  const keys = Object.keys(data);
+  if (keys.length !== 1) return false;
+  const key = keys[0]!;
+  if (key === "name") return typeof (data as { name: unknown }).name === "string";
+  if (key === "values") return Array.isArray((data as { values: unknown }).values);
+  if (key === "columns") {
+    const columns = (data as { columns: unknown }).columns;
+    return typeof columns === "object" && columns !== null && !Array.isArray(columns);
+  }
+  return false;
+}
+
+function snapshotCell(value: AuthoringCellValue): AuthoringCellValue {
+  return value instanceof Date ? new Date(value.getTime()) : value;
+}
+
+function snapshotRows(rows: AuthoringRows): Record<string, AuthoringCellValue>[] {
+  return rows.map((row) =>
+    Object.fromEntries(Object.entries(row).map(([key, value]) => [key, snapshotCell(value)])),
+  );
+}
+
+function snapshotColumns(columns: AuthoringColumns): Record<string, AuthoringCellValue[]> {
+  return Object.fromEntries(
+    Object.entries(columns).map(([key, values]) => [
+      key,
+      values.map((value) => snapshotCell(value)),
+    ]),
+  );
+}
+
+export function toAuthoringDataRef(data: DataInput): AuthoringDataRef {
+  if (Array.isArray(data)) return { values: snapshotRows(data as AuthoringRows) };
+  if (isDataRef(data)) {
+    if ("name" in data) return data;
+    if ("values" in data) return { values: snapshotRows(data.values) };
+    return { columns: snapshotColumns(data.columns) };
+  }
+  return { columns: snapshotColumns(data as AuthoringColumns) };
+}
+
+function portableCell(value: AuthoringCellValue, calendarDate: boolean): CellValue {
+  if (!(value instanceof Date)) return value;
+  const iso = value.toISOString();
+  return calendarDate ? iso.slice(0, 10) : iso;
+}
+
+function portableRows(
+  rows: AuthoringRows,
+  calendarFields: ReadonlySet<string>,
+): Record<string, CellValue>[] {
+  return rows.map((row) =>
+    Object.fromEntries(
+      Object.entries(row).map(([key, value]) => [
+        key,
+        portableCell(value, calendarFields.has(key)),
+      ]),
+    ),
+  );
+}
+
+function portableColumns(
+  columns: AuthoringColumns,
+  calendarFields: ReadonlySet<string>,
+): Record<string, CellValue[]> {
+  return Object.fromEntries(
+    Object.entries(columns).map(([key, values]) => [
+      key,
+      values.map((value) => portableCell(value, calendarFields.has(key))),
+    ]),
+  );
+}
+
+export function toDataRef(data: AuthoringDataRef, calendarFields: ReadonlySet<string>): DataRef {
+  if ("name" in data) return data;
+  if ("values" in data) return { values: portableRows(data.values, calendarFields) };
+  return { columns: portableColumns(data.columns, calendarFields) };
+}
+
+function mappedField(value: AesInput[keyof AesInput]): string | null {
+  if (typeof value === "string") return value;
+  return value !== undefined && value !== null && "field" in value ? value.field : null;
+}
+
+/** Minimal state slice needed to decide calendar-date ISO truncation. */
+export interface BuilderCalendarSource {
+  readonly aes?: AesInput;
+  readonly layers: readonly { readonly aes?: AesInput }[];
+  readonly scales?: Scales;
+}
+
+/** Fields mapped on scales with temporalKind "date" (calendar ISO date cells). */
+export function calendarDateFields(state: BuilderCalendarSource): ReadonlySet<string> {
+  const fields = new Set<string>();
+  const mappings = [
+    ["x", ["x"]],
+    ["y", ["y", "ymin", "ymax"]],
+    ["color", ["color"]],
+    ["fill", ["fill"]],
+  ] as const;
+  for (const [scale, channels] of mappings) {
+    if (state.scales?.[scale]?.temporalKind !== "date") continue;
+    for (const channel of channels) {
+      const plotField = mappedField(state.aes?.[channel]);
+      if (plotField !== null) fields.add(plotField);
+      for (const layer of state.layers) {
+        const layerField = mappedField(layer.aes?.[channel]);
+        if (layerField !== null) fields.add(layerField);
+      }
+    }
+  }
+  return fields;
+}

--- a/packages/spec/src/builder.ts
+++ b/packages/spec/src/builder.ts
@@ -11,11 +11,21 @@
  * - `.spec()` normalizes and VALIDATES, returning a canonical PortableSpec or
  *   throwing SpecValidationError. Builder output therefore always validates
  *   against the published JSON Schema (property-tested).
+ *
+ * Authoring data conversion (Date snapshot / portable ISO materialization)
+ * lives in builder-data.ts.
  */
 import { coordTransform, type CoordTransformOptions } from "./coord-helpers.js";
 import { SpecValidationError } from "./errors.js";
 import type { AesInput, FacetInput, LayerInput, SpecInput } from "./normalize.js";
 import { normalize } from "./normalize.js";
+import {
+  calendarDateFields,
+  toAuthoringDataRef,
+  toDataRef,
+  type AuthoringDataRef,
+  type DataInput,
+} from "./builder-data.js";
 import {
   scaleColorBinned,
   scaleColorContinuous,
@@ -68,9 +78,7 @@ import type {
   AreaParams,
   BarParams,
   BoxplotParams,
-  CellValue,
   ColParams,
-  DataRef,
   DensityParams,
   ErrorbarParams,
   Labs,
@@ -91,6 +99,14 @@ import type {
 } from "./schema.js";
 import { validate } from "./validate.js";
 
+export type {
+  AuthoringCellValue,
+  AuthoringColumns,
+  AuthoringDataRef,
+  AuthoringRows,
+  DataInput,
+} from "./builder-data.js";
+
 /**
  * Identity helper for aesthetic mappings, mirroring ggplot2's aes(). Accepts
  * the bare-string shorthand ('displ' means { field: 'displ' }); the shorthand
@@ -98,126 +114,6 @@ import { validate } from "./validate.js";
  */
 export function aes(mapping: AesInput): AesInput {
   return mapping;
-}
-
-/** A builder/Svelte data cell. Dates canonicalize to ISO before validation. */
-export type AuthoringCellValue = CellValue | Date;
-export type AuthoringRows = readonly Readonly<Record<string, AuthoringCellValue>>[];
-export type AuthoringColumns = Readonly<Record<string, readonly AuthoringCellValue[]>>;
-export type AuthoringDataRef =
-  | { values: AuthoringRows }
-  | { columns: AuthoringColumns }
-  | { name: string };
-
-/** Data accepted by gg(): authoring rows, columns, or a data reference. */
-export type DataInput = AuthoringRows | AuthoringColumns | AuthoringDataRef;
-
-function isDataRef(data: DataInput): data is AuthoringDataRef {
-  if (Array.isArray(data)) return false;
-  const keys = Object.keys(data);
-  if (keys.length !== 1) return false;
-  const key = keys[0]!;
-  if (key === "name") return typeof (data as { name: unknown }).name === "string";
-  if (key === "values") return Array.isArray((data as { values: unknown }).values);
-  if (key === "columns") {
-    const columns = (data as { columns: unknown }).columns;
-    return typeof columns === "object" && columns !== null && !Array.isArray(columns);
-  }
-  return false;
-}
-
-function snapshotCell(value: AuthoringCellValue): AuthoringCellValue {
-  return value instanceof Date ? new Date(value.getTime()) : value;
-}
-
-function snapshotRows(rows: AuthoringRows): Record<string, AuthoringCellValue>[] {
-  return rows.map((row) =>
-    Object.fromEntries(Object.entries(row).map(([key, value]) => [key, snapshotCell(value)])),
-  );
-}
-
-function snapshotColumns(columns: AuthoringColumns): Record<string, AuthoringCellValue[]> {
-  return Object.fromEntries(
-    Object.entries(columns).map(([key, values]) => [
-      key,
-      values.map((value) => snapshotCell(value)),
-    ]),
-  );
-}
-
-function toAuthoringDataRef(data: DataInput): AuthoringDataRef {
-  if (Array.isArray(data)) return { values: snapshotRows(data as AuthoringRows) };
-  if (isDataRef(data)) {
-    if ("name" in data) return data;
-    if ("values" in data) return { values: snapshotRows(data.values) };
-    return { columns: snapshotColumns(data.columns) };
-  }
-  return { columns: snapshotColumns(data as AuthoringColumns) };
-}
-
-function portableCell(value: AuthoringCellValue, calendarDate: boolean): CellValue {
-  if (!(value instanceof Date)) return value;
-  const iso = value.toISOString();
-  return calendarDate ? iso.slice(0, 10) : iso;
-}
-
-function portableRows(
-  rows: AuthoringRows,
-  calendarFields: ReadonlySet<string>,
-): Record<string, CellValue>[] {
-  return rows.map((row) =>
-    Object.fromEntries(
-      Object.entries(row).map(([key, value]) => [
-        key,
-        portableCell(value, calendarFields.has(key)),
-      ]),
-    ),
-  );
-}
-
-function portableColumns(
-  columns: AuthoringColumns,
-  calendarFields: ReadonlySet<string>,
-): Record<string, CellValue[]> {
-  return Object.fromEntries(
-    Object.entries(columns).map(([key, values]) => [
-      key,
-      values.map((value) => portableCell(value, calendarFields.has(key))),
-    ]),
-  );
-}
-
-function toDataRef(data: AuthoringDataRef, calendarFields: ReadonlySet<string>): DataRef {
-  if ("name" in data) return data;
-  if ("values" in data) return { values: portableRows(data.values, calendarFields) };
-  return { columns: portableColumns(data.columns, calendarFields) };
-}
-
-function mappedField(value: AesInput[keyof AesInput]): string | null {
-  if (typeof value === "string") return value;
-  return value !== undefined && value !== null && "field" in value ? value.field : null;
-}
-
-function calendarDateFields(state: BuilderState): ReadonlySet<string> {
-  const fields = new Set<string>();
-  const mappings = [
-    ["x", ["x"]],
-    ["y", ["y", "ymin", "ymax"]],
-    ["color", ["color"]],
-    ["fill", ["fill"]],
-  ] as const;
-  for (const [scale, channels] of mappings) {
-    if (state.scales?.[scale]?.temporalKind !== "date") continue;
-    for (const channel of channels) {
-      const plotField = mappedField(state.aes?.[channel]);
-      if (plotField !== null) fields.add(plotField);
-      for (const layer of state.layers) {
-        const layerField = mappedField(layer.aes?.[channel]);
-        if (layerField !== null) fields.add(layerField);
-      }
-    }
-  }
-  return fields;
 }
 
 /** Point-layer sugar options: params plus aes and position (jitter/nudge). */

--- a/packages/spec/tests/builder-data.test.ts
+++ b/packages/spec/tests/builder-data.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Characterization for packages/spec/src/builder-data.ts (authoring data
+ * snapshot + portable ISO materialization).
+ */
+import { describe, expect, it } from "bun:test";
+
+import { calendarDateFields, toAuthoringDataRef, toDataRef } from "../src/builder-data.ts";
+import { aes, gg } from "../src/builder.ts";
+
+const rows = [
+  { x: 1, y: 2, cls: "a" },
+  { x: 2, y: 3, cls: "b" },
+];
+
+describe("builder-data — authoring forms", () => {
+  it("accepts rows, columns, and named DataRef through gg()", () => {
+    expect(gg(rows).geomPoint().spec().data).toEqual({ values: rows });
+    expect(
+      gg({ x: [1, 2], y: [2, 3] })
+        .geomPoint()
+        .spec().data,
+    ).toEqual({
+      columns: { x: [1, 2], y: [2, 3] },
+    });
+    expect(gg({ name: "cars" }).geomPoint().spec().data).toEqual({ name: "cars" });
+  });
+
+  it("snapshots row Date cells so later mutation of the source does not leak", () => {
+    const when = new Date("2024-06-15T12:00:00.000Z");
+    const source = [{ when, value: 1 }];
+    const authoring = toAuthoringDataRef(source);
+    when.setUTCFullYear(1999);
+    if (!("values" in authoring)) throw new Error("expected values form");
+    const snapped = authoring.values[0]!.when;
+    expect(snapped).toBeInstanceOf(Date);
+    expect((snapped as Date).toISOString()).toBe("2024-06-15T12:00:00.000Z");
+  });
+
+  it("materializes Date cells as full ISO unless the scale is calendar date", () => {
+    const when = new Date("2024-06-15T12:00:00.000Z");
+    const authoring = toAuthoringDataRef([{ when, value: 1 }]);
+    const datetime = toDataRef(authoring, new Set());
+    expect(datetime).toEqual({
+      values: [{ when: "2024-06-15T12:00:00.000Z", value: 1 }],
+    });
+    const calendar = toDataRef(authoring, new Set(["when"]));
+    expect(calendar).toEqual({
+      values: [{ when: "2024-06-15", value: 1 }],
+    });
+  });
+
+  it("calendarDateFields tracks plot and layer mappings on date scales", () => {
+    const fields = calendarDateFields({
+      aes: aes({ x: "when", y: "value" }),
+      layers: [{ aes: aes({ color: "group" }) }],
+      scales: {
+        x: { type: "time", temporalKind: "date" },
+        color: { type: "time", temporalKind: "date" },
+      },
+    });
+    expect([...fields].toSorted()).toEqual(["group", "when"]);
+  });
+});

--- a/packages/spec/tests/builder.test.ts
+++ b/packages/spec/tests/builder.test.ts
@@ -47,17 +47,8 @@ describe("gg builder", () => {
     expect(viaBuilder).toEqual(handWritten);
   });
 
-  it("accepts rows, columns, and DataRef data forms", () => {
-    expect(gg(rows).geomPoint().spec().data).toEqual({ values: rows });
-    expect(
-      gg({ x: [1, 2], y: [2, 3] })
-        .geomPoint()
-        .spec().data,
-    ).toEqual({
-      columns: { x: [1, 2], y: [2, 3] },
-    });
-    expect(gg({ name: "cars" }).geomPoint().spec().data).toEqual({ name: "cars" });
-  });
+  // Data-form acceptance + Date snapshot/portable materialization:
+  // packages/spec/tests/builder-data.test.ts
 
   it("labs() merges over previous labs", () => {
     const spec = gg(rows).geomPoint().labs({ title: "T" }).labs({ x: "X" }).spec();

--- a/packages/spec/tests/temporal-scale-authoring.test.ts
+++ b/packages/spec/tests/temporal-scale-authoring.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Temporal scale authoring surfaces: capability ledger, helper aliases, builder
+ * Date canonicalization. Schema validation: temporal-scale-schema.test.ts.
+ */
+import { describe, expect, it } from "bun:test";
+
+import {
+  aes,
+  gg,
+  normalize,
+  scaleXDate,
+  scaleXDatetime,
+  scaleXDiscrete,
+  scaleYDate,
+  scaleYDatetime,
+  scaleYDiscrete,
+  scale_x_date,
+  scale_x_datetime,
+  scale_x_discrete,
+  SCALE_CAPABILITIES,
+  scale_y_date,
+  scale_y_datetime,
+  scale_y_discrete,
+  validate,
+} from "../src/index.ts";
+
+describe("temporal scale authoring surfaces", () => {
+  it("records implemented helpers and reserved inert mappings in the capability ledger", () => {
+    const temporal = SCALE_CAPABILITIES.find(
+      (capability) => capability.family === "position-temporal",
+    );
+    expect(temporal?.runtime).toBe("implemented");
+    expect(temporal?.helpers).toContain("scaleXDate");
+    expect(temporal?.helpers).toContain("scale_x_date");
+    expect(temporal?.helpers).toContain("scaleYDatetime");
+    expect(
+      SCALE_CAPABILITIES.find((capability) => capability.family === "mapped-style-reserved")
+        ?.runtime,
+    ).toBe("schema-only");
+  });
+
+  it("exports binding-identical camel and ggplot2 aliases", () => {
+    expect(scale_x_date).toBe(scaleXDate);
+    expect(scale_x_datetime).toBe(scaleXDatetime);
+    expect(scale_y_date).toBe(scaleYDate);
+    expect(scale_y_datetime).toBe(scaleYDatetime);
+    expect(scale_x_discrete).toBe(scaleXDiscrete);
+    expect(scale_y_discrete).toBe(scaleYDiscrete);
+  });
+
+  it("normalizes helper, builder, and canonical scale configuration equally", () => {
+    const options = {
+      parse: "dmy" as const,
+      timezone: "UTC",
+      disambiguation: "reject" as const,
+      dateBreaks: "2 weeks",
+      dateMinorBreaks: "1 week",
+      dateLabels: "%e %b",
+      locale: "en-GB",
+      weekStart: "monday" as const,
+    };
+    const helper = scaleXDate(options);
+    expect(helper).toEqual({
+      x: {
+        type: "time",
+        temporalKind: "date",
+        parse: "dmy",
+        timezone: "UTC",
+        disambiguation: "reject",
+        dateBreaks: "2 weeks",
+        dateMinorBreaks: "1 week",
+        dateLabels: "%e %b",
+        locale: "en-GB",
+        weekStart: "monday",
+      },
+    });
+
+    const built = gg(
+      [
+        { when: "31/12/2024", value: 1 },
+        { when: "01/01/2025", value: 2 },
+      ],
+      aes({ x: "when", y: "value" }),
+    )
+      .geomLine()
+      .scaleXDate(options)
+      .spec();
+    expect(built.scales).toEqual(helper);
+
+    expect(scaleYDate()).toEqual({ y: { type: "time", temporalKind: "date" } });
+    expect(scaleXDatetime()).toEqual({ x: { type: "time", temporalKind: "datetime" } });
+    expect(scaleYDatetime()).toEqual({ y: { type: "time", temporalKind: "datetime" } });
+    expect(scaleXDiscrete()).toEqual({ x: { type: "band" } });
+    expect(scaleYDiscrete()).toEqual({ y: { type: "band" } });
+    expect(
+      scaleXDiscrete({
+        reverse: true,
+        dateBreaks: "1 day",
+        dateMinorBreaks: "12 hours",
+        dateLabels: "%Y-%m-%d",
+        locale: "en-GB",
+        weekStart: "monday",
+      } as never),
+    ).toEqual({ x: { type: "band", reverse: true } });
+    expect(
+      normalize({
+        layers: [{ geom: "point" }],
+        scales: {
+          x: {
+            type: "band",
+            reverse: true,
+            dateBreaks: "1 day",
+            dateMinorBreaks: "12 hours",
+            dateLabels: "%Y-%m-%d",
+            locale: "en-GB",
+            weekStart: "monday",
+          },
+        },
+      }).scales,
+    ).toEqual({ x: { type: "band", reverse: true } });
+  });
+
+  it("canonicalizes authoring Date cells before PortableSpec validation", () => {
+    const when = new Date("2024-01-02T03:04:05.000Z");
+    const spec = gg([{ when, value: 1 }], aes({ x: "when", y: "value" }))
+      .geomPoint()
+      .spec();
+    expect(spec.data).toEqual({ values: [{ when: "2024-01-02T03:04:05.000Z", value: 1 }] });
+    expect(validate(spec).ok).toBe(true);
+    expect(
+      validate({
+        layers: [{ geom: "point" }],
+        data: { values: [{ when, value: 1 }] },
+      }).ok,
+    ).toBe(false);
+  });
+
+  it("canonicalizes Date cells mapped to calendar scales as ISO dates", () => {
+    const spec = gg(
+      [
+        { when: new Date("2024-01-01T00:00:00.000Z"), value: 1 },
+        { when: new Date("2024-01-02T00:00:00.000Z"), value: 2 },
+      ],
+      aes({ x: "when", y: "value" }),
+    )
+      .geomLine()
+      .scaleXDate({ parse: "iso" })
+      .spec();
+
+    expect(spec.data).toEqual({
+      values: [
+        { when: "2024-01-01", value: 1 },
+        { when: "2024-01-02", value: 2 },
+      ],
+    });
+  });
+});

--- a/packages/spec/tests/temporal-scale-schema.test.ts
+++ b/packages/spec/tests/temporal-scale-schema.test.ts
@@ -1,24 +1,10 @@
+/**
+ * Temporal position scale schema validation (portable parsers, guide options).
+ * Authoring helpers / builder Date canonicalization: temporal-scale-authoring.test.ts.
+ */
 import { describe, expect, it } from "bun:test";
 
-import {
-  aes,
-  gg,
-  normalize,
-  scaleXDate,
-  scaleXDatetime,
-  scaleXDiscrete,
-  scaleYDate,
-  scaleYDatetime,
-  scaleYDiscrete,
-  scale_x_date,
-  scale_x_datetime,
-  SCALE_CAPABILITIES,
-  scale_x_discrete,
-  scale_y_date,
-  scale_y_datetime,
-  scale_y_discrete,
-  validate,
-} from "../src/index.ts";
+import { scaleXDate, scaleXDiscrete, validate } from "../src/index.ts";
 
 const compileOnlyTemporalTypeAssertions = (): void => {
   // @ts-expect-error portable temporal parsers never accept callbacks
@@ -376,137 +362,5 @@ describe("temporal scale schema", () => {
     for (const x of invalid) {
       expect(validate({ layers: [{ geom: "point" }], scales: { x } }).ok).toBe(false);
     }
-  });
-});
-
-describe("temporal scale authoring surfaces", () => {
-  it("records implemented helpers and reserved inert mappings in the capability ledger", () => {
-    const temporal = SCALE_CAPABILITIES.find(
-      (capability) => capability.family === "position-temporal",
-    );
-    expect(temporal?.runtime).toBe("implemented");
-    expect(temporal?.helpers).toContain("scaleXDate");
-    expect(temporal?.helpers).toContain("scale_x_date");
-    expect(temporal?.helpers).toContain("scaleYDatetime");
-    expect(
-      SCALE_CAPABILITIES.find((capability) => capability.family === "mapped-style-reserved")
-        ?.runtime,
-    ).toBe("schema-only");
-  });
-
-  it("exports binding-identical camel and ggplot2 aliases", () => {
-    expect(scale_x_date).toBe(scaleXDate);
-    expect(scale_x_datetime).toBe(scaleXDatetime);
-    expect(scale_y_date).toBe(scaleYDate);
-    expect(scale_y_datetime).toBe(scaleYDatetime);
-    expect(scale_x_discrete).toBe(scaleXDiscrete);
-    expect(scale_y_discrete).toBe(scaleYDiscrete);
-  });
-
-  it("normalizes helper, builder, and canonical scale configuration equally", () => {
-    const options = {
-      parse: "dmy" as const,
-      timezone: "UTC",
-      disambiguation: "reject" as const,
-      dateBreaks: "2 weeks",
-      dateMinorBreaks: "1 week",
-      dateLabels: "%e %b",
-      locale: "en-GB",
-      weekStart: "monday" as const,
-    };
-    const helper = scaleXDate(options);
-    expect(helper).toEqual({
-      x: {
-        type: "time",
-        temporalKind: "date",
-        parse: "dmy",
-        timezone: "UTC",
-        disambiguation: "reject",
-        dateBreaks: "2 weeks",
-        dateMinorBreaks: "1 week",
-        dateLabels: "%e %b",
-        locale: "en-GB",
-        weekStart: "monday",
-      },
-    });
-
-    const built = gg(
-      [
-        { when: "31/12/2024", value: 1 },
-        { when: "01/01/2025", value: 2 },
-      ],
-      aes({ x: "when", y: "value" }),
-    )
-      .geomLine()
-      .scaleXDate(options)
-      .spec();
-    expect(built.scales).toEqual(helper);
-
-    expect(scaleYDate()).toEqual({ y: { type: "time", temporalKind: "date" } });
-    expect(scaleXDatetime()).toEqual({ x: { type: "time", temporalKind: "datetime" } });
-    expect(scaleYDatetime()).toEqual({ y: { type: "time", temporalKind: "datetime" } });
-    expect(scaleXDiscrete()).toEqual({ x: { type: "band" } });
-    expect(scaleYDiscrete()).toEqual({ y: { type: "band" } });
-    expect(
-      scaleXDiscrete({
-        reverse: true,
-        dateBreaks: "1 day",
-        dateMinorBreaks: "12 hours",
-        dateLabels: "%Y-%m-%d",
-        locale: "en-GB",
-        weekStart: "monday",
-      } as never),
-    ).toEqual({ x: { type: "band", reverse: true } });
-    expect(
-      normalize({
-        layers: [{ geom: "point" }],
-        scales: {
-          x: {
-            type: "band",
-            reverse: true,
-            dateBreaks: "1 day",
-            dateMinorBreaks: "12 hours",
-            dateLabels: "%Y-%m-%d",
-            locale: "en-GB",
-            weekStart: "monday",
-          },
-        },
-      }).scales,
-    ).toEqual({ x: { type: "band", reverse: true } });
-  });
-
-  it("canonicalizes authoring Date cells before PortableSpec validation", () => {
-    const when = new Date("2024-01-02T03:04:05.000Z");
-    const spec = gg([{ when, value: 1 }], aes({ x: "when", y: "value" }))
-      .geomPoint()
-      .spec();
-    expect(spec.data).toEqual({ values: [{ when: "2024-01-02T03:04:05.000Z", value: 1 }] });
-    expect(validate(spec).ok).toBe(true);
-    expect(
-      validate({
-        layers: [{ geom: "point" }],
-        data: { values: [{ when, value: 1 }] },
-      }).ok,
-    ).toBe(false);
-  });
-
-  it("canonicalizes Date cells mapped to calendar scales as ISO dates", () => {
-    const spec = gg(
-      [
-        { when: new Date("2024-01-01T00:00:00.000Z"), value: 1 },
-        { when: new Date("2024-01-02T00:00:00.000Z"), value: 2 },
-      ],
-      aes({ x: "when", y: "value" }),
-    )
-      .geomLine()
-      .scaleXDate({ parse: "iso" })
-      .spec();
-
-    expect(spec.data).toEqual({
-      values: [
-        { when: "2024-01-01", value: 1 },
-        { when: "2024-01-02", value: 2 },
-      ],
-    });
   });
 });


### PR DESCRIPTION
## Summary

Closes #428. Partially addresses #429.

### Production

Extract authoring data conversion from `builder.ts` into `builder-data.ts`:

- rows / columns / named `DataRef` acceptance and immutable Date snapshotting for `gg()`
- portable ISO materialization for `.spec()` (full instant vs calendar-date truncation)
- `calendarDateFields` for temporalKind `"date"` field detection

`builder.ts` keeps geom/scale sugar, `GGBuilder`, and re-exports authoring types so package root exports stay stable.

### Tests

- New `builder-data.test.ts` co-locates data-form + snapshot/ISO characterization
- Split the long `temporal-api.test.ts` into:
  - `temporal-scale-schema.test.ts`
  - `temporal-scale-authoring.test.ts`
- Updated root `test:temporal-parser` script paths

## Verification

- [x] `bun test packages/spec` (333 pass)
- [x] `bun run check`
- [x] `bun run knip`
- [x] Independent code review GATE: PASS

## Follow-ups

- #429 remainder — split `validate-tier2.test.ts` by concern when next touching tier-2 modules