### PR TITLE
perf(core): O(P·B)→O(P+B) SVG panel batch routing

### DIFF
--- a/.changeset/svg-panel-batch-routing.md
+++ b/.changeset/svg-panel-batch-routing.md
@@ -1,0 +1,10 @@
+---
+"@ggsvelte/core": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+perf: O(P·B)→O(P+B) SVG panel batch routing via shared groupBatchesByPanel
+
+Faceted pure-SVG renders no longer re-scan every geometry batch for each panel.
+`groupBatchesByPanel` (issue #185) is pure and shared with the canvas stratum path.

--- a/packages/core/src/dom/canvas.ts
+++ b/packages/core/src/dom/canvas.ts
@@ -22,6 +22,7 @@
  * Module split: leaf DOM helpers in `canvas-dom.ts`, mark drawers in
  * `canvas-marks.ts`, panel routing + focus presentation here.
  */
+import { groupBatchesByPanel } from "../group-batches-by-panel.js";
 import type { GeometryBatch, Scene } from "../scene.js";
 import type { ColorResolver } from "./canvas-dom.js";
 import { drawClippedToPanel } from "./canvas-dom.js";
@@ -33,37 +34,8 @@ import {
   maskIsAllFocused,
 } from "./canvas-marks.js";
 
-/**
- * Group geometry batches by panel once (issue #185): O(B) instead of
- * re-filtering the full list per panel (O(P·B)). Within each panel bucket,
- * order matches the original batch list so paint order is preserved.
- * When `withIndices` is true, also record each batch's original list index
- * for focus-mask alignment on the presentation path.
- *
- * Exported for unit tests that lock the single-pass complexity contract.
- */
-export function groupBatchesByPanel(
-  panelCount: number,
-  batches: readonly GeometryBatch[],
-  withIndices: boolean,
-): { byPanel: GeometryBatch[][]; indices: number[][] | null } {
-  const byPanel: GeometryBatch[][] = Array.from({ length: panelCount }, () => []);
-  const indices: number[][] | null = withIndices
-    ? Array.from({ length: panelCount }, () => [])
-    : null;
-  for (let i = 0; i < batches.length; i++) {
-    const batch = batches[i]!;
-    const p = batch.panelIndex;
-    // Malformed panelIndex (NaN, non-integer, out of range) is a pipeline bug;
-    // skip rather than throw so a bad batch cannot take down the whole stratum
-    // draw. Integer check matters: `byPanel[1.5]` / `byPanel[NaN]` are not
-    // real buckets, and the old filter path silently dropped those too.
-    if (!Number.isInteger(p) || p < 0 || p >= panelCount) continue;
-    byPanel[p]!.push(batch);
-    indices?.[p]!.push(i);
-  }
-  return { byPanel, indices };
-}
+/** Re-export pure helper for canvas tests and callers (issue #185). */
+export { groupBatchesByPanel };
 
 /**
  * Draw a canvas stratum's batches, clipped per panel (one canvas per

--- a/packages/core/src/group-batches-by-panel.ts
+++ b/packages/core/src/group-batches-by-panel.ts
@@ -1,0 +1,36 @@
+/**
+ * Group geometry batches by panel once (issue #185 / SVG #438 follow-up):
+ * O(P + B) bucket allocation + one pass over batches, instead of re-scanning
+ * the full batch list per panel (O(P·B)). Within each panel bucket, order
+ * matches the original batch list so paint order is preserved.
+ *
+ * Pure (no DOM) so both the canvas stratum drawer and the pure SVG renderer
+ * can share the same contract.
+ *
+ * When `withIndices` is true, also record each batch's original list index
+ * for focus-mask alignment on the canvas presentation path.
+ */
+import type { GeometryBatch } from "./scene.js";
+
+export function groupBatchesByPanel(
+  panelCount: number,
+  batches: readonly GeometryBatch[],
+  withIndices: boolean,
+): { byPanel: GeometryBatch[][]; indices: number[][] | null } {
+  const byPanel: GeometryBatch[][] = Array.from({ length: panelCount }, () => []);
+  const indices: number[][] | null = withIndices
+    ? Array.from({ length: panelCount }, () => [])
+    : null;
+  for (let i = 0; i < batches.length; i++) {
+    const batch = batches[i]!;
+    const p = batch.panelIndex;
+    // Malformed panelIndex (NaN, non-integer, out of range) is a pipeline bug;
+    // skip rather than throw so a bad batch cannot take down the whole stratum
+    // draw. Integer check matters: `byPanel[1.5]` / `byPanel[NaN]` are not
+    // real buckets, and the old filter path silently dropped those too.
+    if (!Number.isInteger(p) || p < 0 || p >= panelCount) continue;
+    byPanel[p]!.push(batch);
+    indices?.[p]!.push(i);
+  }
+  return { byPanel, indices };
+}

--- a/packages/core/src/render-svg-scene.ts
+++ b/packages/core/src/render-svg-scene.ts
@@ -2,6 +2,7 @@
  * Scene-level SVG assembly: panel chrome + sceneLabel + sceneToSVGString.
  * Chrome helpers stay file-private (only used by sceneToSVGString).
  */
+import { groupBatchesByPanel } from "./group-batches-by-panel.js";
 import type { Scene, SceneLegend, ScenePanel } from "./scene.js";
 import { STRIP_BAND } from "./scene.js";
 import { LEGEND_ROW_HEIGHT } from "./legend.js";
@@ -276,6 +277,10 @@ export function sceneToSVGString(scene: Scene): string {
     )
     .join("");
   parts.push(`<defs>${clips}</defs>`);
+  // One O(P+B) panel→batch index (issue #185) instead of re-scanning all
+  // batches per panel (O(P·B)). Bucket order preserves original batch list
+  // order within each panel.
+  const { byPanel } = groupBatchesByPanel(scene.panels.length, scene.batches, false);
   for (let i = 0; i < scene.panels.length; i++) {
     const p = scene.panels[i]!;
     parts.push(
@@ -286,9 +291,7 @@ export function sceneToSVGString(scene: Scene): string {
       renderGrid(p, theme),
       `<g class="gg-marks"${p.clip === false ? "" : ` clip-path="url(#gg-clip-${i})"`}>`,
     );
-    for (const batch of scene.batches) {
-      if (batch.panelIndex === i) parts.push(renderBatch(batch, theme));
-    }
+    for (const batch of byPanel[i]!) parts.push(renderBatch(batch, theme));
     parts.push("</g>");
     if (theme.showPanelBorder) {
       parts.push(

--- a/packages/core/tests/render-svg.test.ts
+++ b/packages/core/tests/render-svg.test.ts
@@ -158,7 +158,7 @@ describe("sceneToSVGString panel batch routing", () => {
     rawBatches: GeometryBatch[];
     sceneBase: Omit<Scene, "theme" | "panels" | "batches">;
   } {
-    const theme = resolveTheme(undefined);
+    const theme = resolveTheme();
     const panels: ScenePanel[] = Array.from({ length: panelCount }, (_, i) => ({
       id: `p${i}`,
       x: i * 10,

--- a/packages/core/tests/render-svg.test.ts
+++ b/packages/core/tests/render-svg.test.ts
@@ -10,6 +10,8 @@ import { aes, gg, normalize } from "@ggsvelte/spec";
 
 import { PipelineError } from "../src/pipeline.ts";
 import { renderToSVGString } from "../src/render-svg.ts";
+import { resolveTheme } from "../src/theme.ts";
+import type { GeometryBatch, Scene, ScenePanel } from "../src/scene.ts";
 
 const rows = [
   { x: 1, y: 10, cls: "a" },
@@ -143,5 +145,127 @@ describe("render-svg public facade", () => {
     type _Opts = import("../src/index.ts").RenderSVGOptions;
     const opts: _Opts = { width: 1, height: 1 };
     expect(opts.width).toBe(1);
+  });
+});
+
+describe("sceneToSVGString panel batch routing", () => {
+  function multiPanelScene(
+    panelCount: number,
+    batchesPerPanel: number,
+  ): {
+    theme: ReturnType<typeof resolveTheme>;
+    panels: ScenePanel[];
+    rawBatches: GeometryBatch[];
+    sceneBase: Omit<Scene, "theme" | "panels" | "batches">;
+  } {
+    const theme = resolveTheme(undefined);
+    const panels: ScenePanel[] = Array.from({ length: panelCount }, (_, i) => ({
+      id: `p${i}`,
+      x: i * 10,
+      y: 0,
+      width: 10,
+      height: 10,
+      strip: "",
+      axisX: null,
+      axisY: null,
+      grid: { x: [], y: [] },
+      clip: true,
+    }));
+    // Interleave layers across panels so a full re-scan would thrash:
+    // batch order: (panel 0 layer 0), (panel 1 layer 0), … then layer 1…
+    const rawBatches: GeometryBatch[] = [];
+    for (let layer = 0; layer < batchesPerPanel; layer++) {
+      for (let p = 0; p < panelCount; p++) {
+        rawBatches.push({
+          kind: "points",
+          layerIndex: layer,
+          panelIndex: p,
+          positions: Float32Array.from([layer + 1, p + 1]),
+          rowIndex: Uint32Array.from([layer * panelCount + p]),
+          size: 1,
+          alpha: 1,
+          shape: "circle",
+          fill: `c${layer}-${p}`,
+        });
+      }
+    }
+    // Invalid indices must be skipped without throwing or polluting buckets.
+    rawBatches.push({
+      kind: "points",
+      layerIndex: 99,
+      panelIndex: Number.NaN,
+      positions: Float32Array.from([0, 0]),
+      rowIndex: Uint32Array.from([999]),
+      size: 1,
+      alpha: 1,
+      shape: "circle",
+      fill: "invalid",
+    });
+    return {
+      theme,
+      panels,
+      rawBatches,
+      sceneBase: {
+        width: panelCount * 10,
+        height: 20,
+        axes: { x: { ticks: [], title: "" }, y: { ticks: [], title: "" } },
+        grid: { x: [], y: [] },
+        legends: [],
+        title: "",
+        subtitle: "",
+        caption: "",
+      },
+    };
+  }
+
+  it("inspects each batch once regardless of panel count (not O(P·B) re-scan)", async () => {
+    const { sceneToSVGString } = await import("../src/render-svg-scene.ts");
+    const panelCount = 16;
+    const batchesPerPanel = 3;
+    const { theme, panels, rawBatches, sceneBase } = multiPanelScene(panelCount, batchesPerPanel);
+    let indexReads = 0;
+    const batches = new Proxy(rawBatches, {
+      get(target, property, receiver): unknown {
+        if (typeof property === "string" && /^\d+$/.test(property)) indexReads++;
+        return Reflect.get(target, property, receiver) as unknown;
+      },
+    });
+    const svg = sceneToSVGString({
+      ...sceneBase,
+      theme,
+      panels,
+      batches,
+    });
+    // groupBatchesByPanel walks each list index once (including the invalid entry).
+    expect(indexReads).toBe(rawBatches.length);
+    // Every valid batch still rendered once (fill color is unique per batch).
+    for (let layer = 0; layer < batchesPerPanel; layer++) {
+      for (let p = 0; p < panelCount; p++) {
+        expect(svg).toContain(`fill="c${layer}-${p}"`);
+      }
+    }
+    expect(svg).not.toContain('fill="invalid"');
+  });
+
+  it("keeps panel order, within-panel batch order, and clip wrappers", async () => {
+    const { sceneToSVGString } = await import("../src/render-svg-scene.ts");
+    const { theme, panels, rawBatches, sceneBase } = multiPanelScene(3, 2);
+    panels[1] = { ...panels[1]!, clip: false };
+    const svg = sceneToSVGString({
+      ...sceneBase,
+      theme,
+      panels,
+      batches: rawBatches.filter((b) => Number.isInteger(b.panelIndex)),
+    });
+    const panelStarts = [...svg.matchAll(/data-panel="(\d+)"/g)].map((m) => m[1]);
+    expect(panelStarts).toEqual(["0", "1", "2"]);
+    // Within panel 0: layer 0 then layer 1 (c0-0 before c1-0).
+    expect(svg.indexOf('fill="c0-0"')).toBeLessThan(svg.indexOf('fill="c1-0"'));
+    expect(svg.indexOf('fill="c0-1"')).toBeLessThan(svg.indexOf('fill="c1-1"'));
+    // Panel 0 clipped; panel 1 unclipped marks group.
+    expect(svg).toContain('clip-path="url(#gg-clip-0)"');
+    const panel1Block = svg.slice(svg.indexOf('data-panel="1"'), svg.indexOf('data-panel="2"'));
+    expect(panel1Block).toContain('class="gg-marks"');
+    expect(panel1Block).not.toContain("clip-path=");
   });
 });


### PR DESCRIPTION
## Summary

Big-O maintain on `packages/core`.

**Finding:** pure SVG `sceneToSVGString` re-scanned every geometry batch for each facet panel — O(P·B). Canvas already fixed the same pattern with `groupBatchesByPanel` (issue #185).

**Fix:**
- Extract pure `groupBatchesByPanel` (no DOM) so SVG can share it
- `sceneToSVGString` buckets once then walks per-panel lists
- Complexity: O(P·B) batch inspections → O(P+B) (each batch indexed once)

## Test plan

- [x] `bun test packages/core` (968 pass)
- [x] Proxy inspection-count: 16 panels × 3 layers → B reads, not P·B
- [x] Order/clip regression; golden + facets SVG suites

## Follow-ups

None deferred.
