### PR TITLE
refactor(docs): extract playground hash restore and shared tab roving

### DIFF
--- a/apps/docs/src/lib/CodeTabs.svelte
+++ b/apps/docs/src/lib/CodeTabs.svelte
@@ -10,6 +10,7 @@
 
   import { copyText, MANUAL_COPY_STATUS } from "$lib/clipboard";
   import { resolveCodeLanguage } from "$lib/code-languages";
+  import { nextRovingTabIndex } from "$lib/tab-roving";
 
   interface Tab {
     label: string;
@@ -67,19 +68,8 @@
   }
 
   function handleTabKey(event: KeyboardEvent, index: number): void {
-    let next = index;
-    if (event.key === "ArrowRight" || event.key === "ArrowDown") {
-      next = (index + 1) % tabs.length;
-    } else if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
-      next = (index - 1 + tabs.length) % tabs.length;
-    } else if (event.key === "Home") {
-      next = 0;
-    } else if (event.key === "End") {
-      next = tabs.length - 1;
-    } else {
-      return;
-    }
-
+    const next = nextRovingTabIndex(event.key, index, tabs.length);
+    if (next === null) return;
     event.preventDefault();
     select(next);
     const target = event.currentTarget;

--- a/apps/docs/src/lib/Playground.svelte
+++ b/apps/docs/src/lib/Playground.svelte
@@ -31,16 +31,18 @@
     type PlaygroundInteractionEvent,
   } from "$lib/playground-events";
   import {
-    decodePlaygroundHash,
     encodePlaygroundSeed,
     type PlaygroundSeedV1,
   } from "$lib/playground-codec";
   import {
-    sharedLinkRejectDiagnostic,
+    applyPlaygroundHashRestoreState,
+    rejectRestoreCancelPhase,
+    resolvePlaygroundHashRestore,
+  } from "$lib/playground-hash-restore";
+  import {
     shouldClearPlayHashAfterPromotion,
     shouldConfirmDiscardForSampleLoad,
     shouldConfirmDiscardForUndo,
-    verifiedSharedSeed,
   } from "$lib/playground-link-policy";
   import { playgroundOutputs } from "$lib/playground-output";
   import {
@@ -109,42 +111,29 @@
   }
 
   function restoreLocation(origin: "initial-navigation" | "popstate"): void {
-    const decoded = decodePlaygroundHash(window.location.hash);
-    if (decoded.status === "absent") {
-      if (origin === "popstate") {
-        const previous = activeCandidate();
-        const next = stagePlaygroundSeed(workbench, initialSeed, origin, null);
-        workbench = next;
-        noteStagedCandidate(previous, next);
-      }
-      return;
-    }
-    if (decoded.status === "error") {
-      replaceLocationHash(workbench.historyHash);
-      const previous = activeCandidate();
-      workbench = reportPlaygroundDiagnostic(
-        workbench,
-        sharedLinkRejectDiagnostic(decoded.error),
-        "The shared link was rejected. The current local chart and a truthful URL were retained.",
-      );
-      if (previous !== null) {
-        noteCandidatePhase({
-          generation: previous.generation,
-          origin: previous.origin,
-          phase: "cancelled",
-          status: workbench.status,
-        });
-      }
-      return;
-    }
-    const previous = activeCandidate();
-    const next = stagePlaygroundSeed(
-      workbench,
-      verifiedSharedSeed(window.location.hash, decoded.seed, shareCatalogs),
+    const decision = resolvePlaygroundHashRestore(
       origin,
       window.location.hash,
+      shareCatalogs,
+    );
+    if (decision.kind === "noop") return;
+    if (decision.kind === "reject") {
+      // Truthful URL first: drop the malformed fragment before reporting.
+      replaceLocationHash(workbench.historyHash);
+    }
+    const previous = activeCandidate();
+    const next = applyPlaygroundHashRestoreState(
+      workbench,
+      decision,
+      origin,
+      initialSeed,
     );
     workbench = next;
+    if (decision.kind === "reject") {
+      const cancel = rejectRestoreCancelPhase(previous, workbench.status);
+      if (cancel !== null) noteCandidatePhase(cancel);
+      return;
+    }
     noteStagedCandidate(previous, next);
   }
 

--- a/apps/docs/src/lib/components/PlaygroundOutput.svelte
+++ b/apps/docs/src/lib/components/PlaygroundOutput.svelte
@@ -5,6 +5,7 @@
   import UiButton from "$lib/components/UiButton.svelte";
   import { playgroundSVGExport } from "$lib/playground-export";
   import type { PlaygroundOutput } from "$lib/playground-output";
+  import { nextRovingTabIndex } from "$lib/tab-roving";
   import type { PortableSpec } from "@ggsvelte/spec";
 
   const {
@@ -52,18 +53,8 @@
   }
 
   function handleTabKey(event: KeyboardEvent, index: number): void {
-    let next = index;
-    if (event.key === "ArrowRight" || event.key === "ArrowDown") {
-      next = (index + 1) % outputs.length;
-    } else if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
-      next = (index - 1 + outputs.length) % outputs.length;
-    } else if (event.key === "Home") {
-      next = 0;
-    } else if (event.key === "End") {
-      next = outputs.length - 1;
-    } else {
-      return;
-    }
+    const next = nextRovingTabIndex(event.key, index, outputs.length);
+    if (next === null) return;
     event.preventDefault();
     select(next);
     const target = event.currentTarget;

--- a/apps/docs/src/lib/playground-hash-restore.ts
+++ b/apps/docs/src/lib/playground-hash-restore.ts
@@ -1,0 +1,99 @@
+import { decodePlaygroundHash, type PlaygroundSeedV1 } from "./playground-codec";
+import type { PlaygroundCandidatePhaseDetail } from "./playground-candidate-lifecycle";
+import {
+  sharedLinkRejectDiagnostic,
+  verifiedSharedSeed,
+  type PlaygroundShareCatalogs,
+} from "./playground-link-policy";
+import {
+  reportPlaygroundDiagnostic,
+  stagePlaygroundSeed,
+  type PlaygroundCandidateOrigin,
+  type PlaygroundDiagnostic,
+  type PlaygroundState,
+} from "./playground-state";
+
+export type PlaygroundHashRestoreOrigin = "initial-navigation" | "popstate";
+
+export type PlaygroundHashRestoreDecision =
+  | { readonly kind: "noop" }
+  | { readonly kind: "stage-initial" }
+  | {
+      readonly kind: "reject";
+      readonly diagnostic: PlaygroundDiagnostic;
+      readonly statusMessage: string;
+      /** Component must `replaceLocationHash(state.historyHash)` before applying state. */
+      readonly replaceWithHistoryHash: true;
+    }
+  | {
+      readonly kind: "stage";
+      readonly seed: PlaygroundSeedV1;
+      readonly historyHash: string;
+    };
+
+const REJECT_STATUS =
+  "The shared link was rejected. The current local chart and a truthful URL were retained.";
+
+/**
+ * Pure decision table for playground location hash restore.
+ * DOM replace and lifecycle emit stay in Playground.svelte.
+ */
+export function resolvePlaygroundHashRestore(
+  origin: PlaygroundHashRestoreOrigin,
+  hash: string,
+  catalogs: PlaygroundShareCatalogs,
+): PlaygroundHashRestoreDecision {
+  const decoded = decodePlaygroundHash(hash);
+  if (decoded.status === "absent") {
+    return origin === "popstate" ? { kind: "stage-initial" } : { kind: "noop" };
+  }
+  if (decoded.status === "error") {
+    return {
+      kind: "reject",
+      diagnostic: sharedLinkRejectDiagnostic(decoded.error),
+      statusMessage: REJECT_STATUS,
+      replaceWithHistoryHash: true,
+    };
+  }
+  return {
+    kind: "stage",
+    seed: verifiedSharedSeed(hash, decoded.seed, catalogs),
+    historyHash: hash,
+  };
+}
+
+/** Apply a hash-restore decision to workbench state (no DOM). */
+export function applyPlaygroundHashRestoreState(
+  state: PlaygroundState,
+  decision: PlaygroundHashRestoreDecision,
+  origin: PlaygroundHashRestoreOrigin,
+  initialSeed: PlaygroundSeedV1,
+): PlaygroundState {
+  switch (decision.kind) {
+    case "noop":
+      return state;
+    case "stage-initial":
+      return stagePlaygroundSeed(state, initialSeed, origin, null);
+    case "reject":
+      return reportPlaygroundDiagnostic(state, decision.diagnostic, decision.statusMessage);
+    case "stage":
+      return stagePlaygroundSeed(state, decision.seed, origin, decision.historyHash);
+  }
+}
+
+/**
+ * Cancel-phase detail after a reject apply, or null if no prior candidate.
+ * `statusAfterReport` must be the status **after** `applyPlaygroundHashRestoreState`.
+ */
+export function rejectRestoreCancelPhase(
+  previous: { readonly generation: number; readonly origin: PlaygroundCandidateOrigin } | null,
+  statusAfterReport: string,
+): PlaygroundCandidatePhaseDetail | null {
+  if (previous === null) return null;
+  return {
+    generation: previous.generation,
+    origin: previous.origin,
+    phase: "cancelled",
+    status: statusAfterReport,
+  };
+}

--- a/apps/docs/src/lib/playground-hash-restore.ts
+++ b/apps/docs/src/lib/playground-hash-restore.ts
@@ -69,16 +69,14 @@ export function applyPlaygroundHashRestoreState(
   origin: PlaygroundHashRestoreOrigin,
   initialSeed: PlaygroundSeedV1,
 ): PlaygroundState {
-  switch (decision.kind) {
-    case "noop":
-      return state;
-    case "stage-initial":
-      return stagePlaygroundSeed(state, initialSeed, origin, null);
-    case "reject":
-      return reportPlaygroundDiagnostic(state, decision.diagnostic, decision.statusMessage);
-    case "stage":
-      return stagePlaygroundSeed(state, decision.seed, origin, decision.historyHash);
+  if (decision.kind === "noop") return state;
+  if (decision.kind === "stage-initial") {
+    return stagePlaygroundSeed(state, initialSeed, origin, null);
   }
+  if (decision.kind === "reject") {
+    return reportPlaygroundDiagnostic(state, decision.diagnostic, decision.statusMessage);
+  }
+  return stagePlaygroundSeed(state, decision.seed, origin, decision.historyHash);
 }
 
 /**

--- a/apps/docs/src/lib/tab-roving.ts
+++ b/apps/docs/src/lib/tab-roving.ts
@@ -1,0 +1,12 @@
+/**
+ * Roving tabindex index for horizontal/vertical tablists (Arrow keys, Home, End).
+ * Returns null when the key is not a tab-navigation key or the tablist is empty.
+ */
+export function nextRovingTabIndex(key: string, index: number, count: number): number | null {
+  if (count <= 0) return null;
+  if (key === "ArrowRight" || key === "ArrowDown") return (index + 1) % count;
+  if (key === "ArrowLeft" || key === "ArrowUp") return (index - 1 + count) % count;
+  if (key === "Home") return 0;
+  if (key === "End") return count - 1;
+  return null;
+}

--- a/scripts/playground-hash-restore.test.ts
+++ b/scripts/playground-hash-restore.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, test } from "bun:test";
+
+import type { PortableSpec } from "@ggsvelte/spec";
+
+import {
+  encodePlaygroundSeed,
+  PlaygroundCodecError,
+  type PlaygroundSeedV1,
+} from "../apps/docs/src/lib/playground-codec";
+import {
+  applyPlaygroundHashRestoreState,
+  rejectRestoreCancelPhase,
+  resolvePlaygroundHashRestore,
+} from "../apps/docs/src/lib/playground-hash-restore";
+import {
+  createPlaygroundState,
+  stagePlaygroundDraft,
+  editPlaygroundDraft,
+} from "../apps/docs/src/lib/playground-state";
+
+const spec: PortableSpec = {
+  edition: 1,
+  data: { values: [{ x: 1, y: 2 }] },
+  layers: [
+    {
+      geom: "point",
+      stat: "identity",
+      position: "identity",
+      aes: { x: { field: "x" }, y: { field: "y" } },
+    },
+  ],
+};
+
+const sampleSeed = (id = "starter"): PlaygroundSeedV1 => ({
+  version: 1,
+  source: { kind: "sample", id },
+  spec,
+});
+
+const catalogs = {
+  examples: [
+    {
+      id: "area/basic",
+      compatibility: { supported: true as const, fragment: "#play=v1.trusted-example" },
+    },
+  ],
+  samples: [
+    { id: "starter", fragment: "#play=v1.trusted-sample" },
+    { id: "other", fragment: "#play=v1.other-sample" },
+  ],
+};
+
+const REJECT_STATUS =
+  "The shared link was rejected. The current local chart and a truthful URL were retained.";
+
+describe("resolvePlaygroundHashRestore", () => {
+  test("absent hash is noop on initial navigation and stage-initial on popstate", () => {
+    expect(resolvePlaygroundHashRestore("initial-navigation", "", catalogs)).toEqual({
+      kind: "noop",
+    });
+    expect(resolvePlaygroundHashRestore("initial-navigation", "#", catalogs)).toEqual({
+      kind: "noop",
+    });
+    expect(resolvePlaygroundHashRestore("popstate", "", catalogs)).toEqual({
+      kind: "stage-initial",
+    });
+  });
+
+  test("malformed hash rejects with diagnostic, exact status, and history-hash restore flag", () => {
+    const decision = resolvePlaygroundHashRestore(
+      "initial-navigation",
+      "#play=not-valid",
+      catalogs,
+    );
+    expect(decision.kind).toBe("reject");
+    if (decision.kind !== "reject") return;
+    expect(decision.replaceWithHistoryHash).toBe(true);
+    expect(decision.statusMessage).toBe(REJECT_STATUS);
+    expect(decision.diagnostic).toMatchObject({
+      source: "playground",
+      path: "#play",
+      fix: "Open a generated example link or reset to a built-in sample.",
+    });
+    expect(decision.diagnostic.code).toMatch(/^[a-z0-9-]+$/);
+  });
+
+  test("valid hash stages verified seed and keeps fragment as historyHash", () => {
+    const seed = sampleSeed();
+    const hash = encodePlaygroundSeed(seed);
+    // Force trusted fragment alignment for catalogs used above
+    const trustedHash = catalogs.samples[0]!.fragment;
+    // encode produces real payload; trust demotion uses exact fragment match
+    const decision = resolvePlaygroundHashRestore("popstate", hash, {
+      ...catalogs,
+      samples: [{ id: "starter", fragment: hash }],
+    });
+    expect(decision.kind).toBe("stage");
+    if (decision.kind !== "stage") return;
+    expect(decision.historyHash).toBe(hash);
+    expect(decision.seed.source).toEqual({ kind: "sample", id: "starter" });
+    void trustedHash;
+  });
+
+  test("untrusted sample attribution is demoted to custom on stage path", () => {
+    const seed = sampleSeed("starter");
+    const hash = encodePlaygroundSeed(seed);
+    const decision = resolvePlaygroundHashRestore("initial-navigation", hash, catalogs);
+    expect(decision.kind).toBe("stage");
+    if (decision.kind !== "stage") return;
+    // catalogs.samples[0].fragment is not this hash → demote
+    expect(decision.seed.source).toEqual({ kind: "custom" });
+  });
+});
+
+describe("applyPlaygroundHashRestoreState", () => {
+  test("noop returns the same state reference", () => {
+    const state = createPlaygroundState(sampleSeed());
+    expect(
+      applyPlaygroundHashRestoreState(state, { kind: "noop" }, "initial-navigation", sampleSeed()),
+    ).toBe(state);
+  });
+
+  test("stage-initial stages the provided initial seed with origin and null target hash", () => {
+    const state = createPlaygroundState(sampleSeed("other"));
+    const next = applyPlaygroundHashRestoreState(
+      state,
+      { kind: "stage-initial" },
+      "popstate",
+      sampleSeed("starter"),
+    );
+    expect(next.candidate).not.toBeNull();
+    expect(next.candidate?.origin).toBe("popstate");
+    expect(next.candidate?.next.seed.source).toEqual({ kind: "sample", id: "starter" });
+    expect(next.candidate?.next.historyHash).toBeNull();
+  });
+
+  test("reject reports diagnostic and exact status without clearing historyHash field on state", () => {
+    const state = createPlaygroundState(sampleSeed(), "#play=v1.prior");
+    const diagnostic = {
+      source: "playground" as const,
+      code: "invalid-base64url",
+      path: "#play",
+      message: "bad",
+      fix: "Open a generated example link or reset to a built-in sample.",
+    };
+    const next = applyPlaygroundHashRestoreState(
+      state,
+      {
+        kind: "reject",
+        diagnostic,
+        statusMessage: REJECT_STATUS,
+        replaceWithHistoryHash: true,
+      },
+      "popstate",
+      sampleSeed(),
+    );
+    expect(next.diagnostics).toEqual([diagnostic]);
+    expect(next.status).toBe(REJECT_STATUS);
+    expect(next.historyHash).toBe("#play=v1.prior");
+    expect(next.candidate).toBeNull();
+  });
+
+  test("stage stages trusted seed under the given origin and historyHash", () => {
+    const state = createPlaygroundState(sampleSeed("other"));
+    const seed = sampleSeed("starter");
+    const next = applyPlaygroundHashRestoreState(
+      state,
+      { kind: "stage", seed, historyHash: "#play=v1.trusted-sample" },
+      "initial-navigation",
+      sampleSeed(),
+    );
+    expect(next.candidate?.origin).toBe("initial-navigation");
+    expect(next.candidate?.next.historyHash).toBe("#play=v1.trusted-sample");
+    expect(next.candidate?.next.seed.source).toEqual({ kind: "sample", id: "starter" });
+  });
+});
+
+describe("rejectRestoreCancelPhase", () => {
+  test("returns null when there was no prior candidate", () => {
+    expect(rejectRestoreCancelPhase(null, REJECT_STATUS)).toBeNull();
+  });
+
+  test("returns cancelled phase using post-report status", () => {
+    const previous = { generation: 3, origin: "apply" as const };
+    expect(rejectRestoreCancelPhase(previous, REJECT_STATUS)).toEqual({
+      generation: 3,
+      origin: "apply",
+      phase: "cancelled",
+      status: REJECT_STATUS,
+    });
+  });
+
+  test("status must be read after report — pre-report status would be wrong", () => {
+    const state = createPlaygroundState(sampleSeed());
+    const pending = stagePlaygroundDraft(
+      editPlaygroundDraft(state, JSON.stringify({ ...spec, labs: { title: "Next" } }, null, 2)),
+    );
+    expect(pending.candidate).not.toBeNull();
+    const previous = {
+      generation: pending.candidate!.generation,
+      origin: pending.candidate!.origin,
+    };
+    const rejected = applyPlaygroundHashRestoreState(
+      pending,
+      {
+        kind: "reject",
+        diagnostic: {
+          source: "playground",
+          code: "invalid-json",
+          path: "#play",
+          message: "bad",
+          fix: "Open a generated example link or reset to a built-in sample.",
+        },
+        statusMessage: REJECT_STATUS,
+        replaceWithHistoryHash: true,
+      },
+      "popstate",
+      sampleSeed(),
+    );
+    expect(rejectRestoreCancelPhase(previous, pending.status)?.status).not.toBe(REJECT_STATUS);
+    expect(rejectRestoreCancelPhase(previous, rejected.status)).toEqual({
+      generation: previous.generation,
+      origin: previous.origin,
+      phase: "cancelled",
+      status: REJECT_STATUS,
+    });
+  });
+});
+
+// Ensure codec error path still flows through resolve (not only synthetic rejects).
+test("resolve reject uses sharedLinkRejectDiagnostic mapping for codec errors", () => {
+  const decision = resolvePlaygroundHashRestore("popstate", "#play=v1.!!!", catalogs);
+  expect(decision.kind).toBe("reject");
+  if (decision.kind !== "reject") return;
+  // Code is kebab form of a PlaygroundCodecErrorCode
+  expect(decision.diagnostic.source).toBe("playground");
+  expect(decision.diagnostic.path).toBe("#play");
+  void PlaygroundCodecError;
+});

--- a/scripts/tab-roving.test.ts
+++ b/scripts/tab-roving.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+
+import { nextRovingTabIndex } from "../apps/docs/src/lib/tab-roving";
+
+describe("nextRovingTabIndex", () => {
+  test("moves right/down and wraps", () => {
+    expect(nextRovingTabIndex("ArrowRight", 0, 3)).toBe(1);
+    expect(nextRovingTabIndex("ArrowDown", 2, 3)).toBe(0);
+  });
+
+  test("moves left/up and wraps", () => {
+    expect(nextRovingTabIndex("ArrowLeft", 0, 3)).toBe(2);
+    expect(nextRovingTabIndex("ArrowUp", 1, 3)).toBe(0);
+  });
+
+  test("Home and End jump to ends", () => {
+    expect(nextRovingTabIndex("Home", 2, 4)).toBe(0);
+    expect(nextRovingTabIndex("End", 0, 4)).toBe(3);
+  });
+
+  test("returns null for unknown keys and empty tablists", () => {
+    expect(nextRovingTabIndex("Enter", 0, 3)).toBeNull();
+    expect(nextRovingTabIndex("ArrowRight", 0, 0)).toBeNull();
+    expect(nextRovingTabIndex("Home", 0, -1)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Maintainability pass on `apps/docs` after codec (#442), link-policy (#445), and draft-validate (#455).

**Chosen candidate:** playground location-hash restore decision table lived only in `Playground.svelte` (unit-untested; visual journeys only), and tablist Arrow/Home/End navigation was copy-pasted across `CodeTabs` and `PlaygroundOutput`.

**What changed:**

| Module | Role |
|--------|------|
| `playground-hash-restore.ts` | Pure `resolvePlaygroundHashRestore` + `applyPlaygroundHashRestoreState` + `rejectRestoreCancelPhase` |
| `tab-roving.ts` | Pure `nextRovingTabIndex` |
| `Playground.svelte` | DOM hash replace + lifecycle emit; applies pure decisions |
| `CodeTabs.svelte` / `PlaygroundOutput.svelte` | Shared roving helper |

### Behavior locks

- Absent hash: `initial-navigation` → noop; `popstate` → stage initial seed
- Malformed hash: **replace URL with `historyHash` before** reporting diagnostic; cancel prior candidate with **post-report** status
- Valid hash: stage `verifiedSharedSeed` with fragment as `historyHash`
- Exact reject status string preserved

## Why this improves maintainability

Hash-restore origin×decode matrix and reject sequencing are unit-testable without DOM. Tab keyboard policy has one implementation.

## Tests

- New `scripts/playground-hash-restore.test.ts` (decision matrix, state apply, cancel-phase post-report status)
- New `scripts/tab-roving.test.ts`
- Existing `playground-link-policy` / `playground-state` / `playground-candidate-lifecycle` green (41 pass focused)
- `bun run check:docs` clean
- `bun run knip` clean
- `bun run test:visual -- playground.spec.ts` — 19/19 pass (includes share/Back-Forward and history reject paths)

## Independent review

Plan dual-reviewed (REVISE → dropped thin share URL helper, deferred svelte:window drive-by, locked reject URL + cancel ordering). Code review: no P1 findings on restore wiring or tab-roving parity.

## Follow-ups

- #462 — playground-state types leaf
- #463 — guide `use:action` → `{@attach}`