### PR TITLE
refactor(docs): extract playground-state types leaf (#462)

### DIFF
--- a/apps/docs/src/lib/playground-candidate-lifecycle.ts
+++ b/apps/docs/src/lib/playground-candidate-lifecycle.ts
@@ -5,7 +5,7 @@
  * `ggsvelte:playground-candidate` CustomEvent; assistive technology uses
  * aria-busy / status live region, not this event.
  */
-import type { PlaygroundCandidateOrigin } from "./playground-state";
+import type { PlaygroundCandidateOrigin } from "./playground-state-types";
 
 export const PLAYGROUND_CANDIDATE_EVENT = "ggsvelte:playground-candidate";
 

--- a/apps/docs/src/lib/playground-draft-validate.ts
+++ b/apps/docs/src/lib/playground-draft-validate.ts
@@ -9,7 +9,7 @@ import {
   validatePlaygroundSeed,
   type PlaygroundSeedV1,
 } from "./playground-codec";
-import type { PlaygroundDiagnostic } from "./playground-state";
+import type { PlaygroundDiagnostic } from "./playground-state-types";
 
 const VALIDATE_LIMITS = {
   maxRows: PLAYGROUND_MAX_ROWS,

--- a/apps/docs/src/lib/playground-export.ts
+++ b/apps/docs/src/lib/playground-export.ts
@@ -1,7 +1,7 @@
 import { PipelineError, renderToSVGString } from "@ggsvelte/core";
 import type { PortableSpec } from "@ggsvelte/spec";
 
-import type { PlaygroundDiagnostic } from "./playground-state";
+import type { PlaygroundDiagnostic } from "./playground-state-types";
 
 export type PlaygroundSVGExportResult =
   | {

--- a/apps/docs/src/lib/playground-link-policy.ts
+++ b/apps/docs/src/lib/playground-link-policy.ts
@@ -3,7 +3,7 @@ import type {
   PlaygroundCandidateOrigin,
   PlaygroundDiagnostic,
   PlaygroundState,
-} from "./playground-state";
+} from "./playground-state-types";
 
 export interface PlaygroundExampleCatalogEntry {
   readonly id: string;

--- a/apps/docs/src/lib/playground-state-types.ts
+++ b/apps/docs/src/lib/playground-state-types.ts
@@ -1,0 +1,65 @@
+/**
+ * Playground state machine types and constants.
+ *
+ * Value-free leaf so draft-validate / link-policy can import diagnostics
+ * without forming a cycle with the state machine (which imports draft-validate).
+ * @see #462
+ */
+import type { PortableSpec } from "@ggsvelte/spec";
+
+import type { PlaygroundSeedV1 } from "./playground-codec";
+
+export type PlaygroundDiagnosticSource = "playground" | "validation" | "pipeline" | "export";
+
+export interface PlaygroundDiagnostic {
+  readonly source: PlaygroundDiagnosticSource;
+  readonly code: string;
+  readonly path: string;
+  readonly message: string;
+  readonly fix?: string;
+}
+
+export type PlaygroundCandidateOrigin =
+  | "apply"
+  | "source"
+  | "reset"
+  | "undo"
+  | "initial-navigation"
+  | "popstate";
+
+export interface PlaygroundSnapshot {
+  readonly sourceBaseline: PlaygroundSeedV1;
+  readonly seed: PlaygroundSeedV1;
+  readonly draft: string;
+  readonly committed: PortableSpec;
+  readonly rendered: PortableSpec;
+  readonly renderConfirmed: boolean;
+  readonly historyHash: string | null;
+}
+
+export interface PlaygroundCandidate {
+  readonly generation: number;
+  readonly origin: PlaygroundCandidateOrigin;
+  readonly next: PlaygroundSnapshot;
+  readonly undoSnapshotsAfterPromotion?: readonly PlaygroundSnapshot[];
+}
+
+export interface PlaygroundNavigationRecovery {
+  readonly replaceHash: string | null;
+  readonly preserveForward: true;
+}
+
+export interface PlaygroundState extends PlaygroundSnapshot {
+  readonly candidate: PlaygroundCandidate | null;
+  readonly diagnostics: readonly PlaygroundDiagnostic[];
+  readonly lastValid: boolean;
+  readonly status: string;
+  readonly nextGeneration: number;
+  readonly undoSnapshots: readonly PlaygroundSnapshot[];
+  readonly synchronized: boolean;
+  readonly canCopyOrShare: boolean;
+  readonly navigationRecovery: PlaygroundNavigationRecovery | null;
+  readonly historyIntent: "none";
+}
+
+export const PLAYGROUND_MAX_UNDO_SNAPSHOTS = 20;

--- a/apps/docs/src/lib/playground-state.ts
+++ b/apps/docs/src/lib/playground-state.ts
@@ -1,68 +1,30 @@
-import type { PortableSpec } from "@ggsvelte/spec";
-
 import {
   encodePlaygroundSeed,
   validatePlaygroundSeed,
   type PlaygroundSeedV1,
 } from "./playground-codec";
 import { serializePlaygroundSpec, validatePlaygroundDraft } from "./playground-draft-validate";
+import {
+  PLAYGROUND_MAX_UNDO_SNAPSHOTS,
+  type PlaygroundCandidateOrigin,
+  type PlaygroundDiagnostic,
+  type PlaygroundSnapshot,
+  type PlaygroundState,
+} from "./playground-state-types";
 
 export { serializePlaygroundSpec } from "./playground-draft-validate";
 
-export type PlaygroundDiagnosticSource = "playground" | "validation" | "pipeline" | "export";
-
-export interface PlaygroundDiagnostic {
-  readonly source: PlaygroundDiagnosticSource;
-  readonly code: string;
-  readonly path: string;
-  readonly message: string;
-  readonly fix?: string;
-}
-
-export type PlaygroundCandidateOrigin =
-  | "apply"
-  | "source"
-  | "reset"
-  | "undo"
-  | "initial-navigation"
-  | "popstate";
-
-export interface PlaygroundSnapshot {
-  readonly sourceBaseline: PlaygroundSeedV1;
-  readonly seed: PlaygroundSeedV1;
-  readonly draft: string;
-  readonly committed: PortableSpec;
-  readonly rendered: PortableSpec;
-  readonly renderConfirmed: boolean;
-  readonly historyHash: string | null;
-}
-
-export interface PlaygroundCandidate {
-  readonly generation: number;
-  readonly origin: PlaygroundCandidateOrigin;
-  readonly next: PlaygroundSnapshot;
-  readonly undoSnapshotsAfterPromotion?: readonly PlaygroundSnapshot[];
-}
-
-export interface PlaygroundNavigationRecovery {
-  readonly replaceHash: string | null;
-  readonly preserveForward: true;
-}
-
-export interface PlaygroundState extends PlaygroundSnapshot {
-  readonly candidate: PlaygroundCandidate | null;
-  readonly diagnostics: readonly PlaygroundDiagnostic[];
-  readonly lastValid: boolean;
-  readonly status: string;
-  readonly nextGeneration: number;
-  readonly undoSnapshots: readonly PlaygroundSnapshot[];
-  readonly synchronized: boolean;
-  readonly canCopyOrShare: boolean;
-  readonly navigationRecovery: PlaygroundNavigationRecovery | null;
-  readonly historyIntent: "none";
-}
-
-export const PLAYGROUND_MAX_UNDO_SNAPSHOTS = 20;
+// Stable public surface: types + undo cap re-exported from the value-free leaf.
+export {
+  PLAYGROUND_MAX_UNDO_SNAPSHOTS,
+  type PlaygroundCandidate,
+  type PlaygroundCandidateOrigin,
+  type PlaygroundDiagnostic,
+  type PlaygroundDiagnosticSource,
+  type PlaygroundNavigationRecovery,
+  type PlaygroundSnapshot,
+  type PlaygroundState,
+} from "./playground-state-types";
 
 function finalize(
   state: Omit<PlaygroundState, "synchronized" | "canCopyOrShare">,


### PR DESCRIPTION
## Summary

Closes #462. Extract playground state types into a value-free leaf so draft-validate does not type-import the state machine (which imports draft-validate values).

- New playground-state-types.ts: diagnostics, snapshots, candidates, state, undo cap
- playground-state.ts re-exports for stable $lib/playground-state consumers
- draft-validate, link-policy, export, candidate-lifecycle import types from the leaf

## Tests

- bun test scripts/playground-state, draft-validate, link-policy, export, candidate-lifecycle (33 pass)
- bun run check:docs (svelte-check clean)
