### PR TITLE
fix(ci): route root README through unit showcase guard

### DIFF
--- a/scripts/ci-routing.test.ts
+++ b/scripts/ci-routing.test.ts
@@ -71,14 +71,25 @@ describe("classifyChangedPaths", () => {
   test("docs-only prose does not flip package lanes", () => {
     const flags = classifyChangedPaths([
       "docs/decisions/0001-declaration-only-children.md",
-      "README.md",
+      "CONTRIBUTING.md",
     ]);
     expect(flags.spec).toBe(false);
     expect(flags.core).toBe(false);
     expect(flags.svelte).toBe(false);
     expect(flags.docs).toBe(false);
+    expect(flags.scripts).toBe(false);
     expect(flags.markdown).toBe(true);
     expect(flags.lockfile).toBe(false);
+  });
+
+  test("root README is a unit contract input (readme-showcase), not markdown-only", () => {
+    const flags = classifyChangedPaths(["README.md"]);
+    expect(flags.scripts).toBe(true);
+    expect(flags.markdown).toBe(true);
+    const plan = planJobs(flags);
+    expect(plan.unit).toBe(true);
+    expect(plan.component).toBe(false);
+    expect(plan.vr).toBe(false);
   });
 
   test("llms module siblings stay on the docs lane (pages) without forcing VR", () => {
@@ -818,6 +829,12 @@ describe("unit content inputs cover actionlint config", () => {
     ]);
     expect(paths).toContain(".github/actionlint.yaml");
     expect(JOB_CONTENT_INPUTS.unit).toContain(".github/actionlint.yaml");
+  });
+
+  test("unit includes root README.md (scripts/readme-showcase.test.ts reads it)", () => {
+    const paths = listJobContentPaths("unit", ["README.md", "scripts/readme-showcase.test.ts"]);
+    expect(paths).toContain("README.md");
+    expect(JOB_CONTENT_INPUTS.unit).toContain("README.md");
   });
 });
 

--- a/scripts/ci-routing/content-hash.ts
+++ b/scripts/ci-routing/content-hash.ts
@@ -147,6 +147,8 @@ export const JOB_CONTENT_INPUTS: Record<CacheableExecution, readonly string[]> =
     ".markdownlint-cli2.jsonc",
     "knip.jsonc",
     ".pre-commit-config.yaml",
+    // scripts/readme-showcase.test.ts contracts the published README snippets.
+    "README.md",
   ],
   // Package build + knip + type-aware + publint + examples tsc (no vite docs site).
   // apps/docs stays hashed: knip + oxlint --type-aware still cover the docs app,

--- a/scripts/ci-routing/routing.ts
+++ b/scripts/ci-routing/routing.ts
@@ -160,6 +160,9 @@ export const LANE_PATTERNS: Record<ChangeLane, readonly string[]> = {
     ".github/ISSUE_TEMPLATE/**",
     ".github/DISCUSSION_TEMPLATE/**",
     ".changeset/**",
+    // readme-showcase.test.ts reads these files as contract inputs.
+    "README.md",
+    "packages/svelte/README.md",
   ],
   evals: ["tests/evals/**"],
   workflows: [


### PR DESCRIPTION
## Summary

Follow-up for unrebutted Codex finding on #379.

`scripts/readme-showcase.test.ts` reads root `README.md`, but:

1. Path routing treated root README as markdown-only → **unit skipped**
2. Unit content-hash inputs omitted `README.md` → **false-green** when unit ran for other reasons

## Fix

- Classify `README.md` and `packages/svelte/README.md` as `scripts` change inputs (unit-triggering)
- Add `README.md` to `JOB_CONTENT_INPUTS.unit` (svelte package README already covered by `packages/svelte/**`)

## Parent

- https://github.com/ljodea/ggsvelte/pull/379

## Test plan

- [x] `root README is a unit contract input`
- [x] `unit includes root README.md`
- [x] `bun test scripts/ci-routing.test.ts` (67 pass)