### PR TITLE
perf(spec): do not cache empty/oversize exact-format strings (#451)

### DIFF
--- a/packages/spec/src/temporal-parse.ts
+++ b/packages/spec/src/temporal-parse.ts
@@ -424,6 +424,15 @@ const EXACT_FORMAT_CACHE_MAX = 256;
 const EXACT_FORMAT_CACHE = new Map<string, CompiledExactFormat>();
 
 function compileExactFormat(format: string): CompiledExactFormat {
+  // Length failures must not touch the cache: keys would retain arbitrary
+  // user strings (including multi-MB rejects) for process lifetime (#451).
+  if (format.length === 0 || format.length > 128) {
+    return {
+      ok: false,
+      reason: "format length must be from 1 through 128 characters",
+    };
+  }
+
   const cached = EXACT_FORMAT_CACHE.get(format);
   if (cached !== undefined) {
     // Refresh LRU order (Map iterates in insertion order).
@@ -432,52 +441,44 @@ function compileExactFormat(format: string): CompiledExactFormat {
     return cached;
   }
 
-  let compiled: CompiledExactFormat;
-  if (format.length === 0 || format.length > 128) {
-    compiled = {
-      ok: false,
-      reason: "format length must be from 1 through 128 characters",
-    };
-  } else {
-    const tokens: string[] = [];
-    let pattern = "^";
-    let reason: string | null = null;
-    for (let index = 0; index < format.length; index++) {
-      const char = format[index]!;
-      if (char !== "%") {
-        pattern += escapeRegex(char);
-        continue;
-      }
-      const token = format[++index];
-      if (token === undefined) {
-        reason = "format cannot end with %";
-        break;
-      }
-      if (token === "%") {
-        pattern += "%";
-        continue;
-      }
-      const tokenPattern = FORMAT_TOKEN_PATTERNS[token];
-      if (tokenPattern === undefined) {
-        reason = `unsupported format token %${token}`;
-        break;
-      }
-      if (tokens.includes(token)) {
-        reason = `duplicate semantic format token %${token}`;
-        break;
-      }
-      tokens.push(token);
-      if (tokens.length > 32) {
-        reason = "format may contain at most 32 semantic tokens";
-        break;
-      }
-      pattern += tokenPattern;
+  const tokens: string[] = [];
+  let pattern = "^";
+  let reason: string | null = null;
+  for (let index = 0; index < format.length; index++) {
+    const char = format[index]!;
+    if (char !== "%") {
+      pattern += escapeRegex(char);
+      continue;
     }
-    compiled =
-      reason === null
-        ? { ok: true, tokens, regex: new RegExp(`${pattern}$`) }
-        : { ok: false, reason };
+    const token = format[++index];
+    if (token === undefined) {
+      reason = "format cannot end with %";
+      break;
+    }
+    if (token === "%") {
+      pattern += "%";
+      continue;
+    }
+    const tokenPattern = FORMAT_TOKEN_PATTERNS[token];
+    if (tokenPattern === undefined) {
+      reason = `unsupported format token %${token}`;
+      break;
+    }
+    if (tokens.includes(token)) {
+      reason = `duplicate semantic format token %${token}`;
+      break;
+    }
+    tokens.push(token);
+    if (tokens.length > 32) {
+      reason = "format may contain at most 32 semantic tokens";
+      break;
+    }
+    pattern += tokenPattern;
   }
+  const compiled: CompiledExactFormat =
+    reason === null
+      ? { ok: true, tokens, regex: new RegExp(`${pattern}$`) }
+      : { ok: false, reason };
 
   if (EXACT_FORMAT_CACHE.size >= EXACT_FORMAT_CACHE_MAX) {
     const oldest = EXACT_FORMAT_CACHE.keys().next().value;

--- a/packages/spec/tests/temporal.test.ts
+++ b/packages/spec/tests/temporal.test.ts
@@ -134,9 +134,8 @@ describe("strict temporal parsing", () => {
   it("keeps compile-time format configuration errors stable across repeated checks", () => {
     const unsupported = { format: "%s" } as const;
     const duplicate = { format: "%Y-%Y" } as const;
-    const tooLong = { format: "x".repeat(129) } as const;
 
-    for (const parser of [unsupported, duplicate, tooLong] as const) {
+    for (const parser of [unsupported, duplicate] as const) {
       const first = temporalParserConfigurationError(parser);
       const second = temporalParserConfigurationError(parser);
       expect(first).not.toBeNull();
@@ -155,6 +154,38 @@ describe("strict temporal parsing", () => {
     expect(parseTemporal("12-31", { format: "%m-%d" })).toEqual(
       parseTemporal("12-31", { format: "%m-%d" }),
     );
+  });
+
+  /**
+   * #451: empty and oversize formats must fail without retaining the full
+   * user string as a cache key (only 1..128 char formats enter the Map).
+   */
+  it("rejects empty and oversize exact formats with a stable length reason", () => {
+    const lengthReason = "format length must be from 1 through 128 characters";
+    const empty = parseTemporal("2024", { format: "" });
+    const emptyAgain = parseTemporal("2024", { format: "" });
+    expect(empty).toMatchObject({ ok: false, reason: lengthReason });
+    expect(emptyAgain).toEqual(empty);
+    expect(temporalParserConfigurationError({ format: "" })).toBe(lengthReason);
+
+    // Distinct oversize strings must each fail the same way without relying on
+    // cache identity (they must not be stored as Map keys).
+    const hugeA = "a".repeat(200);
+    const hugeB = "b".repeat(10_000);
+    const firstA = parseTemporal("x", { format: hugeA });
+    const secondA = parseTemporal("x", { format: hugeA });
+    const firstB = parseTemporal("x", { format: hugeB });
+    expect(firstA).toMatchObject({ ok: false, reason: lengthReason });
+    expect(secondA).toEqual(firstA);
+    expect(firstB).toMatchObject({ ok: false, reason: lengthReason });
+    expect(temporalParserConfigurationError({ format: hugeA })).toBe(lengthReason);
+    expect(temporalParserConfigurationError({ format: hugeB })).toBe(lengthReason);
+
+    // In-range formats still compile and can be reused.
+    const okFormat = { format: "%Y-%m-%d" } as const;
+    const ok = parseTemporal("2024-01-02", okFormat);
+    expect(ok).toMatchObject({ ok: true });
+    expect(parseTemporal("2024-01-02", okFormat)).toEqual(ok);
   });
 
   it("rejects DST gaps/folds by default and supports explicit disambiguation", () => {


### PR DESCRIPTION
## Summary

Big-O maintain on packages/spec — deferred #451 from PR #444 review.

**Finding:** `compileExactFormat` stored empty/oversize format strings as Map keys (up to 256 LRU entries of arbitrary size).

**Fix:** Return length failure before any cache touch; only formats of length 1..128 enter the cache.

## Verification

bun test packages/spec/tests/temporal.test.ts (20 pass); lint:type-aware clean.

Closes #451.
