### PR TITLE
perf(core): O(K·D)→O(K+D) band break domainIndex via encodeKey map

### DIFF
--- a/.changeset/band-break-domain-index.md
+++ b/.changeset/band-break-domain-index.md
@@ -1,0 +1,11 @@
+---
+"@ggsvelte/core": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+perf: O(K·D)→O(K+D) band break domainIndex via encodeKey map
+
+Explicit band scale breaks resolve domain indices with a first-occurrence
+`encodeKey` map (trainBand identity), including signed zero and typed 1/"1".
+Band break lists are also deduped in O(K) in layoutDomain.

--- a/packages/core/src/layout/layout-derive-ticks.ts
+++ b/packages/core/src/layout/layout-derive-ticks.ts
@@ -43,15 +43,19 @@ export function firstDomainIndexByEncodeKey(
 /** Resolve band tick entries: full domain or break-filtered domainIndex list. */
 function resolveBandEntries(
   domain: Extract<Domain, { type: "band" }>,
-): { value: unknown; domainIndex: number }[] {
+): { value: string | number; domainIndex: number }[] {
   const rawCategories = domain.rawCategories ?? domain.categories;
   if (domain.breaks === undefined) {
     return domain.categories.map((value, domainIndex) => ({ value, domainIndex }));
   }
   const domainIndexOf = firstDomainIndexByEncodeKey(rawCategories);
-  return domain.breaks
-    .map((value) => ({ value, domainIndex: domainIndexOf(value) }))
-    .filter(({ domainIndex }) => domainIndex >= 0);
+  const entries: { value: string | number; domainIndex: number }[] = [];
+  for (const value of domain.breaks) {
+    const domainIndex = domainIndexOf(value);
+    if (domainIndex < 0) continue;
+    entries.push({ value, domainIndex });
+  }
+  return entries;
 }
 
 export interface AxisTicks {

--- a/packages/core/src/layout/layout-derive-ticks.ts
+++ b/packages/core/src/layout/layout-derive-ticks.ts
@@ -2,6 +2,7 @@
  * Tick derivation for one layout measurement pass: band (measured + legacy),
  * temporal guides, linear / log10 / sqrt continuous ticks, and explicit breaks.
  */
+import { encodeKey } from "../scales/state.js";
 import type { CellValue } from "../table.js";
 import type { AxisGuidePlan } from "./temporal-guide.js";
 import { planTemporalAxis } from "./temporal-guide.js";
@@ -16,6 +17,42 @@ import {
 } from "./ticks.js";
 import { defaultTimeTickFormat, timeTicks } from "./time.js";
 import type { BandLayoutDomainContext, Domain, Tick, TickFormatter } from "./layout-types.js";
+
+/**
+ * First-occurrence domain index by discrete identity (`encodeKey`, same as
+ * trainBand.indexOf). O(D) build, O(1) lookup — replaces O(K·D) findIndex over
+ * rawCategories for each explicit break.
+ */
+export function firstDomainIndexByEncodeKey(
+  rawCategories: readonly unknown[],
+): (value: unknown) => number {
+  const indexByKey = new Map<string, number>();
+  for (let index = 0; index < rawCategories.length; index++) {
+    const key = encodeKey(rawCategories[index]);
+    if (!indexByKey.has(key)) indexByKey.set(key, index);
+  }
+  return (value: unknown): number => {
+    try {
+      return indexByKey.get(encodeKey(value)) ?? -1;
+    } catch {
+      return -1;
+    }
+  };
+}
+
+/** Resolve band tick entries: full domain or break-filtered domainIndex list. */
+function resolveBandEntries(
+  domain: Extract<Domain, { type: "band" }>,
+): { value: unknown; domainIndex: number }[] {
+  const rawCategories = domain.rawCategories ?? domain.categories;
+  if (domain.breaks === undefined) {
+    return domain.categories.map((value, domainIndex) => ({ value, domainIndex }));
+  }
+  const domainIndexOf = firstDomainIndexByEncodeKey(rawCategories);
+  return domain.breaks
+    .map((value) => ({ value, domainIndex: domainIndexOf(value) }))
+    .filter(({ domainIndex }) => domainIndex >= 0);
+}
 
 export interface AxisTicks {
   ticks: Tick[];
@@ -107,21 +144,13 @@ export function deriveTicks(
 ): AxisTicks {
   if (domain.type === "band") {
     const rawCategories = domain.rawCategories ?? domain.categories;
+    // Resolve break-filtered (or full-domain) entries once for both the measured
+    // horizontal planner and the legacy vertical path — O(D+K) via encodeKey map.
+    const resolved = resolveBandEntries(domain);
     // Measured planner: horizontal band axes with a planning context only (G1).
     // Vertical band (native Y, or categorical-on-Y after coord_flip) falls through
     // to the legacy thin/truncate path.
     if (domain.band !== undefined && context.orient === "horizontal") {
-      // Resolve break-filtered entries with the same identity match as the
-      // legacy path (breaks are typed raw values → match rawCategories).
-      const resolved =
-        domain.breaks === undefined
-          ? domain.categories.map((value, domainIndex) => ({ value, domainIndex }))
-          : domain.breaks
-              .map((value) => ({
-                value,
-                domainIndex: rawCategories.findIndex((category) => Object.is(category, value)),
-              }))
-              .filter(({ domainIndex }) => domainIndex >= 0);
       const plan = planBandAxis({
         aesthetic: domain.band.aesthetic,
         panelIndex: domain.band.panelIndex,
@@ -168,22 +197,13 @@ export function deriveTicks(
         bandLabelEvery: plan.labelEvery,
       };
     }
-    const entries =
-      domain.breaks === undefined
-        ? domain.categories.map((value, domainIndex) => ({ value, domainIndex }))
-        : domain.breaks
-            .map((value) => ({
-              value,
-              domainIndex: rawCategories.findIndex((category) => Object.is(category, value)),
-            }))
-            .filter(({ domainIndex }) => domainIndex >= 0);
-    const ticks = entries.map(({ value, domainIndex }, index) => ({
+    const ticks = resolved.map(({ value, domainIndex }, index) => ({
       value,
       label: format ? format(value, NaN) : String(value),
       domainIndex,
       labeled: index % labelEvery === 0,
     }));
-    return { ticks, step: NaN, empty: entries.length === 0 };
+    return { ticks, step: NaN, empty: resolved.length === 0 };
   }
   const { min, max } = domain;
   if (!Number.isFinite(min) || !Number.isFinite(max)) {

--- a/packages/core/src/pipeline/layout-domain.ts
+++ b/packages/core/src/pipeline/layout-domain.ts
@@ -31,7 +31,7 @@ export function layoutDomain(
             const key = encodeKey(value);
             if (seen.has(key)) continue;
             seen.add(key);
-            unique.push(value as string | number);
+            unique.push(value);
           }
           return unique;
         })(),

--- a/packages/core/src/pipeline/layout-domain.ts
+++ b/packages/core/src/pipeline/layout-domain.ts
@@ -23,10 +23,18 @@ export function layoutDomain(
       categories: [...scale.domain],
       rawCategories: scale.rawDomain,
       ...(breaks !== undefined && {
-        breaks: breaks.filter(
-          (value, index) =>
-            breaks.findIndex((candidate) => encodeKey(candidate) === encodeKey(value)) === index,
-        ),
+        // First-occurrence dedupe by encodeKey (O(K)), not nested findIndex (O(K²)).
+        breaks: (() => {
+          const seen = new Set<string>();
+          const unique: typeof breaks = [];
+          for (const value of breaks) {
+            const key = encodeKey(value);
+            if (seen.has(key)) continue;
+            seen.add(key);
+            unique.push(value);
+          }
+          return unique;
+        })(),
       }),
       ...(band !== undefined && { band }),
     };

--- a/packages/core/src/pipeline/layout-domain.ts
+++ b/packages/core/src/pipeline/layout-domain.ts
@@ -26,12 +26,12 @@ export function layoutDomain(
         // First-occurrence dedupe by encodeKey (O(K)), not nested findIndex (O(K²)).
         breaks: (() => {
           const seen = new Set<string>();
-          const unique: typeof breaks = [];
+          const unique: (string | number)[] = [];
           for (const value of breaks) {
             const key = encodeKey(value);
             if (seen.has(key)) continue;
             seen.add(key);
-            unique.push(value);
+            unique.push(value as string | number);
           }
           return unique;
         })(),

--- a/packages/core/tests/layout/band-break-index.test.ts
+++ b/packages/core/tests/layout/band-break-index.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Band break → domainIndex resolution: encodeKey map O(D+K), first-occurrence,
+ * signed zero / typed identity (trainBand parity).
+ */
+import { describe, expect, it } from "bun:test";
+
+import {
+  deriveTicks,
+  firstDomainIndexByEncodeKey,
+  type DeriveTicksContext,
+} from "../../src/layout/layout-derive-ticks.ts";
+import type { Domain } from "../../src/layout/layout-types.ts";
+import { MetricsTableMeasurer } from "../../src/layout/measure.ts";
+import { FONT_METRICS } from "../../src/layout/font-metrics.ts";
+import { layoutDomain } from "../../src/pipeline/layout-domain.ts";
+import { trainBand } from "../../src/scales/train.ts";
+
+const measurer = new MetricsTableMeasurer(FONT_METRICS);
+
+function verticalCtx(extentPx = 400): DeriveTicksContext {
+  return {
+    orient: "vertical",
+    extentPx,
+    measurer,
+    fontSize: 11,
+    marginCapPx: 80,
+  };
+}
+
+function horizontalCtx(extentPx = 400): DeriveTicksContext {
+  return {
+    orient: "horizontal",
+    extentPx,
+    measurer,
+    fontSize: 11,
+    marginCapPx: 80,
+    orthogonalMarginCapPx: 80,
+    orthogonalChromePx: 10,
+  };
+}
+
+describe("firstDomainIndexByEncodeKey", () => {
+  it("returns first occurrence for encodeKey identity", () => {
+    const lookup = firstDomainIndexByEncodeKey([1, "1", 1, true]);
+    expect(lookup(1)).toBe(0);
+    expect(lookup("1")).toBe(1);
+    expect(lookup(true)).toBe(3);
+    expect(lookup(false)).toBe(-1);
+  });
+
+  it("keeps signed zero distinct (trainBand encodeKey)", () => {
+    const lookup = firstDomainIndexByEncodeKey([0, -0, 1]);
+    expect(lookup(0)).toBe(0);
+    expect(lookup(-0)).toBe(1);
+  });
+
+  it("treats NaN as a single key", () => {
+    const lookup = firstDomainIndexByEncodeKey([Number.NaN, 1, Number.NaN]);
+    expect(lookup(Number.NaN)).toBe(0);
+  });
+
+  it("indexes each rawCategories element at most once (O(D) build)", () => {
+    const D = 4_000;
+    const raw = Array.from({ length: D }, (_, i) => `cat-${i}`);
+    let reads = 0;
+    const proxied = new Proxy(raw, {
+      get(target, property, receiver): unknown {
+        if (typeof property === "string" && /^\d+$/.test(property)) reads++;
+        return Reflect.get(target, property, receiver) as unknown;
+      },
+    });
+    const lookup = firstDomainIndexByEncodeKey(proxied);
+    expect(reads).toBe(D);
+    // Lookups must not re-scan rawCategories.
+    reads = 0;
+    for (let k = 0; k < 200; k++) expect(lookup(`cat-${k * 10}`)).toBe(k * 10);
+    expect(reads).toBe(0);
+  });
+});
+
+describe("deriveTicks band breaks via encodeKey map", () => {
+  it("resolves reordered / subset breaks to first domainIndex (legacy vertical)", () => {
+    const domain: Domain = {
+      type: "band",
+      categories: ["a", "b", "c", "d"],
+      rawCategories: ["a", "b", "c", "d"],
+      breaks: ["c", "a", "missing"],
+    };
+    const { ticks } = deriveTicks(domain, 4, undefined, 1, verticalCtx());
+    expect(ticks.map((t) => ({ value: t.value, domainIndex: t.domainIndex }))).toEqual([
+      { value: "c", domainIndex: 2 },
+      { value: "a", domainIndex: 0 },
+    ]);
+  });
+
+  it('resolves signed-zero and typed 1/"1" breaks on measured horizontal path', () => {
+    const domain: Domain = {
+      type: "band",
+      categories: ["0", "-0", "1", "1"], // presentation labels (bandKey)
+      rawCategories: [0, -0, 1, "1"],
+      breaks: [-0, "1", 0, 1],
+      band: {
+        aesthetic: "x",
+        panelIndex: 0,
+        config: {},
+      },
+    };
+    // categories length must match raw for planner; labels are bandKey form
+    domain.categories = domain.rawCategories!.map((v) => (Object.is(v, -0) ? "-0" : String(v)));
+    const { ticks, empty } = deriveTicks(domain, 4, undefined, 1, horizontalCtx(600));
+    expect(empty).toBe(false);
+    const byValue = new Map(ticks.map((t) => [t.domainIndex, t.value]));
+    // domainIndex points into rawCategories first occurrence
+    expect(byValue.get(1)).toBe(-0); // break -0
+    expect(byValue.get(3)).toBe("1");
+    expect(byValue.get(0)).toBe(0);
+    expect(byValue.get(2)).toBe(1);
+  });
+
+  it("break resolution does not re-scan rawCategories per break (O(D+K) reads)", () => {
+    const D = 3_000;
+    const K = 300;
+    const raw = Array.from({ length: D }, (_, i) => i);
+    const breaks = Array.from({ length: K }, (_, i) => i * 10);
+    let reads = 0;
+    const rawCategories = new Proxy(raw, {
+      get(target, property, receiver): unknown {
+        if (typeof property === "string" && /^\d+$/.test(property)) reads++;
+        return Reflect.get(target, property, receiver) as unknown;
+      },
+    });
+    const domain: Domain = {
+      type: "band",
+      categories: raw.map(String),
+      rawCategories,
+      breaks,
+    };
+    deriveTicks(domain, K, undefined, 1, verticalCtx());
+    // Build map: D reads. Must not approach K·D (900k).
+    expect(reads).toBe(D);
+    expect(reads).toBeLessThan(D + K); // no per-break rescan of categories
+  });
+});
+
+describe("layoutDomain band break dedupe", () => {
+  it("keeps first-occurrence order and signed zeros", () => {
+    const scale = trainBand([[0, -0, 1, 0]]);
+    const domain = layoutDomain(scale, [0, 1, 0, -0, 1]);
+    expect(domain.type).toBe("band");
+    if (domain.type !== "band") throw new Error("expected band");
+    expect(domain.breaks).toEqual([0, 1, -0]);
+  });
+});


### PR DESCRIPTION
## Summary

Big-O maintain on `packages/core`.

**Finding:** explicit band scale breaks resolved `domainIndex` with `rawCategories.findIndex(Object.is)` per break — O(K·D) where D is domain cardinality (unbounded) and K is break count.

**Fix:**
- First-occurrence `encodeKey` map (same identity as `trainBand.indexOf`: signed zero, 1 vs `"1"`)
- Shared break resolution for measured + legacy band paths
- `layoutDomain` band break dedupe O(K) via Set

## Test plan

- [x] `bun test packages/core` (978 pass)
- [x] Inspection-count: D=3000, K=300 → D raw reads, not K·D
- [x] Signed zero / typed identity / first-occurrence characterization

## Follow-ups

None. (Binned rect center findIndex remains B≤64 → Θ(n); not filed.)
