### PR TITLE
refactor(docs): migrate guide code-copy to {@attach} (#463)

### DIFF
--- a/apps/docs/src/lib/guide-code-copy.ts
+++ b/apps/docs/src/lib/guide-code-copy.ts
@@ -1,0 +1,65 @@
+/**
+ * Guide fenced-code copy UI: pure feedback policy + SVG icons shared with
+ * the guide article attachment. Behavior-sensitive DOM wiring stays in the
+ * route; this module is value-free for unit tests (#463).
+ */
+import { MANUAL_COPY_STATUS } from "./clipboard";
+
+/** Phosphor Copy / Check (regular/bold) — must match scripts/llms-markdown.ts. */
+export const GUIDE_COPY_ICON_SVG =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor" viewBox="0 0 256 256" aria-hidden="true"><path d="M216,32H88a8,8,0,0,0-8,8V80H40a8,8,0,0,0-8,8V216a8,8,0,0,0,8,8H168a8,8,0,0,0,8-8V176h40a8,8,0,0,0,8-8V40A8,8,0,0,0,216,32ZM160,208H48V96H160Zm48-48H176V88a8,8,0,0,0-8-8H96V48H208Z"/></svg>';
+
+export const GUIDE_CHECK_ICON_SVG =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor" viewBox="0 0 256 256" aria-hidden="true"><path d="M229.66,77.66l-128,128a8,8,0,0,1-11.32,0l-56-56a8,8,0,0,1,11.32-11.32L96,188.69,218.34,66.34a8,8,0,0,1,11.32,11.32Z"/></svg>';
+
+export type GuideCopyUiState = {
+  readonly buttonHtml: string;
+  readonly ariaLabel: string;
+  readonly statusText: string;
+  /** When true, status is screen-reader-only (`.visually-hidden`). */
+  readonly statusVisuallyHidden: boolean;
+};
+
+/** Idle / post-timeout control chrome. */
+export function guideCopyUiIdle(): GuideCopyUiState {
+  return {
+    buttonHtml: GUIDE_COPY_ICON_SVG,
+    ariaLabel: "Copy code",
+    statusText: "",
+    statusVisuallyHidden: true,
+  };
+}
+
+/**
+ * Control chrome after a clipboard attempt.
+ * - copied: brief check icon + hidden "Copied." live status
+ * - manual: restore copy icon + visible instructions (clipboard blocked)
+ */
+export function guideCopyUiAfter(result: "copied" | "manual"): GuideCopyUiState {
+  if (result === "copied") {
+    return {
+      buttonHtml: GUIDE_CHECK_ICON_SVG,
+      ariaLabel: "Copied",
+      statusText: "Copied.",
+      statusVisuallyHidden: true,
+    };
+  }
+  return {
+    buttonHtml: GUIDE_COPY_ICON_SVG,
+    ariaLabel: "Copy code",
+    statusText: MANUAL_COPY_STATUS,
+    statusVisuallyHidden: false,
+  };
+}
+
+export function applyGuideCopyUi(
+  button: HTMLButtonElement,
+  status: Element,
+  ui: GuideCopyUiState,
+): void {
+  button.innerHTML = ui.buttonHtml;
+  button.setAttribute("aria-label", ui.ariaLabel);
+  status.textContent = ui.statusText;
+  if (ui.statusVisuallyHidden) status.classList.add("visually-hidden");
+  else status.classList.remove("visually-hidden");
+}

--- a/apps/docs/src/routes/guide/[slug]/+page.svelte
+++ b/apps/docs/src/routes/guide/[slug]/+page.svelte
@@ -1,15 +1,14 @@
 <script lang="ts">
-  import { copyText, MANUAL_COPY_STATUS } from "$lib/clipboard";
+  import { copyText } from "$lib/clipboard";
+  import {
+    applyGuideCopyUi,
+    guideCopyUiAfter,
+    guideCopyUiIdle,
+  } from "$lib/guide-code-copy";
   import GettingStartedGuide from "$lib/components/GettingStartedGuide.svelte";
   import type { PageProps } from "./$types";
 
   const { data }: PageProps = $props();
-
-  /** Phosphor Copy / Check (regular/bold) — must match scripts/llms-markdown.ts. */
-  const COPY_ICON_SVG =
-    '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor" viewBox="0 0 256 256" aria-hidden="true"><path d="M216,32H88a8,8,0,0,0-8,8V80H40a8,8,0,0,0-8,8V216a8,8,0,0,0,8,8H168a8,8,0,0,0,8-8V176h40a8,8,0,0,0,8-8V40A8,8,0,0,0,216,32ZM160,208H48V96H160Zm48-48H176V88a8,8,0,0,0-8-8H96V48H208Z"/></svg>';
-  const CHECK_ICON_SVG =
-    '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor" viewBox="0 0 256 256" aria-hidden="true"><path d="M229.66,77.66l-128,128a8,8,0,0,1-11.32,0l-56-56a8,8,0,0,1,11.32-11.32L96,188.69,218.34,66.34a8,8,0,0,1,11.32,11.32Z"/></svg>';
 
   const resetTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
@@ -29,37 +28,25 @@
     if (previous !== undefined) clearTimeout(previous);
 
     const result = await copyText(code.textContent ?? "", code);
+    applyGuideCopyUi(button, status, guideCopyUiAfter(result));
     if (result === "copied") {
-      button.innerHTML = CHECK_ICON_SVG;
-      button.setAttribute("aria-label", "Copied");
-      status.textContent = "Copied.";
-      status.classList.add("visually-hidden");
       resetTimers.set(
         codeId,
         setTimeout(() => {
-          button.innerHTML = COPY_ICON_SVG;
-          button.setAttribute("aria-label", "Copy code");
-          status.textContent = "";
+          applyGuideCopyUi(button, status, guideCopyUiIdle());
           resetTimers.delete(codeId);
         }, 2000),
       );
-    } else {
-      button.innerHTML = COPY_ICON_SVG;
-      button.setAttribute("aria-label", "Copy code");
-      status.textContent = MANUAL_COPY_STATUS;
-      // Manual fallback needs visible instructions (Codex P2).
-      status.classList.remove("visually-hidden");
     }
   }
 
-  function enhanceCodeCopy(node: HTMLElement): { destroy: () => void } {
+  /** Delegated copy on prerendered guide HTML — attachment, not `use:action`. */
+  function enhanceCodeCopy(node: HTMLElement) {
     node.addEventListener("click", copyGuideCode);
-    return {
-      destroy: () => {
-        node.removeEventListener("click", copyGuideCode);
-        for (const timer of resetTimers.values()) clearTimeout(timer);
-        resetTimers.clear();
-      },
+    return () => {
+      node.removeEventListener("click", copyGuideCode);
+      for (const timer of resetTimers.values()) clearTimeout(timer);
+      resetTimers.clear();
     };
   }
 </script>
@@ -68,7 +55,7 @@
   <GettingStartedGuide />
 {:else}
   <!-- Guide markdown is repository-authored catalog content, never user input. -->
-  <article class="guide prose" use:enhanceCodeCopy>
+  <article class="guide prose" {@attach enhanceCodeCopy}>
     <!-- eslint-disable-next-line svelte/no-at-html-tags -->
     {@html data.html}
   </article>

--- a/scripts/guide-code-copy.test.ts
+++ b/scripts/guide-code-copy.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  GUIDE_CHECK_ICON_SVG,
+  GUIDE_COPY_ICON_SVG,
+  guideCopyUiAfter,
+  guideCopyUiIdle,
+} from "../apps/docs/src/lib/guide-code-copy.ts";
+import { MANUAL_COPY_STATUS } from "../apps/docs/src/lib/clipboard.ts";
+
+describe("guide copy UI policy (#463)", () => {
+  it("idle restores copy chrome with empty hidden status", () => {
+    expect(guideCopyUiIdle()).toEqual({
+      buttonHtml: GUIDE_COPY_ICON_SVG,
+      ariaLabel: "Copy code",
+      statusText: "",
+      statusVisuallyHidden: true,
+    });
+  });
+
+  it("copied shows check icon and hidden live status", () => {
+    expect(guideCopyUiAfter("copied")).toEqual({
+      buttonHtml: GUIDE_CHECK_ICON_SVG,
+      ariaLabel: "Copied",
+      statusText: "Copied.",
+      statusVisuallyHidden: true,
+    });
+  });
+
+  it("manual fallback keeps copy icon and visible instructions", () => {
+    expect(guideCopyUiAfter("manual")).toEqual({
+      buttonHtml: GUIDE_COPY_ICON_SVG,
+      ariaLabel: "Copy code",
+      statusText: MANUAL_COPY_STATUS,
+      statusVisuallyHidden: false,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #463. Guide fenced-code copy no longer uses `use:action`.

- Article uses `{@attach enhanceCodeCopy}` (cleanup on detach clears timers)
- Pure feedback policy + icons in `guide-code-copy.ts` (idle / copied / manual visible instructions)
- Unit tests for the policy in `scripts/guide-code-copy.test.ts`

## Acceptance

- [x] No `use:` action on the guide article
- [x] Manual clipboard fallback still uses visible MANUAL_COPY_STATUS
- [x] Copied state still sets check icon + hidden live status

## Tests

- `bun test scripts/guide-code-copy.test.ts`
- `bun run check:docs` (svelte-check clean)
