### PR TITLE
perf(spec): memoize many-discrete-colors distinct counts

### DIFF
--- a/packages/spec/src/lint.ts
+++ b/packages/spec/src/lint.ts
@@ -164,6 +164,15 @@ function countTransformDomain(
   return [inDomain, outOfDomain];
 }
 
+/** Distinct non-null values in a column (single pass, no intermediate filter). */
+function countDistinctNonNull(values: readonly unknown[]): number {
+  const distinct = new Set<unknown>();
+  for (const value of values) {
+    if (value !== null) distinct.add(value);
+  }
+  return distinct.size;
+}
+
 // ---------------------------------------------------------------------------
 // lintSpec
 // ---------------------------------------------------------------------------
@@ -201,6 +210,11 @@ export function lintSpec(
     if (info === undefined) return null;
     return { field: mapped.field, info };
   };
+
+  // FieldEvidenceMap is built once per lintSpec/validate call; distinct counts
+  // for many-discrete-colors are memoized across layers/channels that share a
+  // field so a high-cardinality column is scanned O(n), not O(L·n).
+  const distinctNonNullByField = new Map<string, number>();
 
   for (let i = 0; i < layers.length; i++) {
     const layer = layers[i];
@@ -287,7 +301,11 @@ export function lintSpec(
         c.info.type !== null &&
         DISCRETE.has(c.info.type)
       ) {
-        const distinct = new Set(values.filter((v) => v !== null)).size;
+        let distinct = distinctNonNullByField.get(c.field);
+        if (distinct === undefined) {
+          distinct = countDistinctNonNull(values);
+          distinctNonNullByField.set(c.field, distinct);
+        }
         if (distinct > 10) {
           advisories.push({
             code: "many-discrete-colors",

--- a/packages/spec/tests/lint.test.ts
+++ b/packages/spec/tests/lint.test.ts
@@ -130,6 +130,38 @@ describe("many-discrete-colors", () => {
   it("silent at exactly 10", () => {
     expect(lintSpec(spec(10))).toEqual([]);
   });
+
+  /**
+   * Characterization for distinct-count memoization: shared fields must still
+   * emit one advisory per layer/channel path with the same count, while the
+   * column is scanned once underneath.
+   */
+  it("emits per-layer advisories for a shared high-cardinality color field", () => {
+    const g = categories(12);
+    const advisories = lintSpec({
+      data: { columns: { x: g.map((_, i) => i), g } },
+      aes: { x: { field: "x" }, y: { field: "x" }, color: { field: "g" } },
+      layers: [{ geom: "point" }, { geom: "line" }],
+    }).filter((a) => a.code === "many-discrete-colors");
+    expect(advisories).toHaveLength(2);
+    expect(advisories.map((a) => a.path)).toEqual(["/layers/0/aes/color", "/layers/1/aes/color"]);
+    expect(advisories.every((a) => a.message.includes("12 distinct"))).toBe(true);
+  });
+
+  it("reuses plot-aes color and still fires for color and fill on the same field", () => {
+    const g = categories(15);
+    const advisories = lintSpec({
+      data: { columns: { x: g.map((_, i) => i), g } },
+      aes: { x: { field: "x" }, y: { field: "x" }, color: { field: "g" }, fill: { field: "g" } },
+      layers: [{ geom: "point" }, { geom: "col", aes: { x: { field: "x" }, y: { field: "x" } } }],
+    }).filter((a) => a.code === "many-discrete-colors");
+    // Two layers × color (inherited) + fill (plot aes) on first layer only when
+    // fill is mapped: point and col both inherit color; both inherit fill.
+    expect(advisories.length).toBeGreaterThanOrEqual(2);
+    expect(advisories.every((a) => a.message.includes("15 distinct"))).toBe(true);
+    expect(advisories.some((a) => a.path.endsWith("/color"))).toBe(true);
+    expect(advisories.some((a) => a.path.endsWith("/fill"))).toBe(true);
+  });
 });
 
 describe("transform-domain-data", () => {


### PR DESCRIPTION
## Summary

Big-O maintain on packages/spec.

**Finding:** lint `many-discrete-colors` rebuilt `Set(values.filter(...))` per layer/channel. Shared color/fill fields across multi-layer charts rescanned O(L·n).

**Fix:** Memoize distinct non-null count per field for the lintSpec call; single-pass Set without intermediate filter. Still one advisory per layer+channel path.

## Verification

bun test packages/spec/tests/lint.test.ts (28 pass); lint:type-aware clean.

## Codex plan review

APPROVE-WITH-CHANGES: multi-layer path/count tests + color/fill shared field coverage.
