### PR TITLE
fix(core): preserve bad coord fields; keep tessellation endpoints

### DIFF
--- a/packages/core/src/pipeline/candidate-construction/frame-row.ts
+++ b/packages/core/src/pipeline/candidate-construction/frame-row.ts
@@ -54,16 +54,48 @@ export function resolveCandidateFrameRow(input: {
   let derivedGroup = frame?.groups[frameRow] ?? 0;
 
   if (frame !== undefined && batch.kind === "paths") {
-    // O(log P) subpath lookup (was linear O(P) per vertex → O(V·P) at build).
-    // Null = OOB / empty offsets: keep default frameRow/derivedGroup (codex P1).
-    const subpath = pathSubpathIndex(batch.pathOffsets, primitiveIndex);
-    if (subpath !== null) {
-      derivedGroup = orderedGroups[Math.min(subpath, orderedGroups.length - 1)] ?? 0;
-      const rowsInGroup = getPathGroupSortedRows(frame).get(derivedGroup) ?? [];
-      const local = primitiveIndex - (batch.pathOffsets[subpath] ?? 0);
-      const reflected =
-        local < rowsInGroup.length ? local : Math.max(0, rowsInGroup.length * 2 - 1 - local);
-      frameRow = rowsInGroup[Math.min(reflected, rowsInGroup.length - 1)] ?? frameRow;
+    // After coord projection, candidate facts pass semanticIndex (pre-render
+    // topology) as primitiveIndex. Render pathOffsets are post-tessellation and
+    // cannot index that space; reconstruct group/local from frame groups instead.
+    if (batch.semanticIndex === undefined) {
+      // O(log P) subpath lookup (was linear O(P) per vertex → O(V·P) at build).
+      // Null = OOB / empty offsets: keep default frameRow/derivedGroup (codex P1).
+      const subpath = pathSubpathIndex(batch.pathOffsets, primitiveIndex);
+      if (subpath !== null) {
+        derivedGroup = orderedGroups[Math.min(subpath, orderedGroups.length - 1)] ?? 0;
+        const rowsInGroup = getPathGroupSortedRows(frame).get(derivedGroup) ?? [];
+        const local = primitiveIndex - (batch.pathOffsets[subpath] ?? 0);
+        const reflected =
+          local < rowsInGroup.length ? local : Math.max(0, rowsInGroup.length * 2 - 1 - local);
+        frameRow = rowsInGroup[Math.min(reflected, rowsInGroup.length - 1)] ?? frameRow;
+      }
+    } else if (batch.closed === true) {
+      // Closed ribbons: upper ascending + lower descending per group (2× rows).
+      const sorted = getPathGroupSortedRows(frame);
+      let cursor = 0;
+      let matched = false;
+      for (const group of orderedGroups) {
+        const rowsInGroup = sorted.get(group) ?? [];
+        const band = rowsInGroup.length * 2;
+        if (primitiveIndex >= cursor && primitiveIndex < cursor + band) {
+          const local = primitiveIndex - cursor;
+          const reflected =
+            local < rowsInGroup.length ? local : Math.max(0, rowsInGroup.length * 2 - 1 - local);
+          frameRow = rowsInGroup[Math.min(reflected, rowsInGroup.length - 1)] ?? frameRow;
+          derivedGroup = group;
+          matched = true;
+          break;
+        }
+        cursor += band;
+      }
+      if (!matched) {
+        frameRow = Math.min(Math.max(0, primitiveIndex), Math.max(0, frame.n - 1));
+        derivedGroup = frame.groups[frameRow] ?? derivedGroup;
+      }
+    } else {
+      // Open paths: semantic index is the pre-split vertex / frame row.
+      frameRow = Math.min(Math.max(0, primitiveIndex), Math.max(0, frame.n - 1));
+      derivedGroup = frame.groups[frameRow] ?? derivedGroup;
     }
   } else if (frame !== undefined && batch.kind === "segments") {
     if (frame.binding.layer.geom === "errorbar") frameRow = Math.floor(primitiveIndex / 3);

--- a/packages/core/src/pipeline/candidate-construction/frame-row.ts
+++ b/packages/core/src/pipeline/candidate-construction/frame-row.ts
@@ -42,6 +42,70 @@ export function getPathGroupSortedRows(
   return cached;
 }
 
+/** Closed-band layout: cumulative vertex starts per ordered group (2× rows each). */
+interface ClosedBandLayout {
+  readonly starts: readonly number[];
+  readonly groups: readonly number[];
+  readonly rowsByGroup: ReadonlyMap<number, readonly number[]>;
+  readonly total: number;
+}
+
+const closedBandLayoutCache = new WeakMap<object, ClosedBandLayout>();
+
+function getClosedBandLayout(
+  frame: Pick<LayerFrame, "groups" | "xNumeric">,
+  orderedGroups: readonly number[],
+): ClosedBandLayout {
+  let cached = closedBandLayoutCache.get(frame);
+  if (
+    cached !== undefined &&
+    cached.groups.length === orderedGroups.length &&
+    cached.groups.every((group, index) => group === orderedGroups[index])
+  ) {
+    return cached;
+  }
+  const rowsByGroup = getPathGroupSortedRows(frame);
+  const starts: number[] = [];
+  let cursor = 0;
+  for (const group of orderedGroups) {
+    starts.push(cursor);
+    cursor += (rowsByGroup.get(group)?.length ?? 0) * 2;
+  }
+  cached = {
+    starts,
+    groups: orderedGroups,
+    rowsByGroup,
+    total: cursor,
+  };
+  closedBandLayoutCache.set(frame, cached);
+  return cached;
+}
+
+function resolveClosedBandFrameRow(
+  layout: ClosedBandLayout,
+  primitiveIndex: number,
+): { frameRow: number; derivedGroup: number } | null {
+  if (primitiveIndex < 0 || primitiveIndex >= layout.total || layout.starts.length === 0)
+    return null;
+  // Binary search last start ≤ primitiveIndex (O(log G)).
+  let lo = 0;
+  let hi = layout.starts.length - 1;
+  while (lo < hi) {
+    const mid = (lo + hi + 1) >> 1;
+    if (layout.starts[mid]! <= primitiveIndex) lo = mid;
+    else hi = mid - 1;
+  }
+  const group = layout.groups[lo]!;
+  const rowsInGroup = layout.rowsByGroup.get(group) ?? [];
+  const local = primitiveIndex - layout.starts[lo]!;
+  const reflected =
+    local < rowsInGroup.length ? local : Math.max(0, rowsInGroup.length * 2 - 1 - local);
+  return {
+    frameRow: rowsInGroup[Math.min(reflected, rowsInGroup.length - 1)] ?? 0,
+    derivedGroup: group,
+  };
+}
+
 export function resolveCandidateFrameRow(input: {
   frame: LayerFrame | undefined;
   batch: GeometryBatch;
@@ -70,27 +134,16 @@ export function resolveCandidateFrameRow(input: {
         frameRow = rowsInGroup[Math.min(reflected, rowsInGroup.length - 1)] ?? frameRow;
       }
     } else if (batch.closed === true) {
-      // Closed ribbons: upper ascending + lower descending per group (2× rows).
-      const sorted = getPathGroupSortedRows(frame);
-      let cursor = 0;
-      let matched = false;
-      for (const group of orderedGroups) {
-        const rowsInGroup = sorted.get(group) ?? [];
-        const band = rowsInGroup.length * 2;
-        if (primitiveIndex >= cursor && primitiveIndex < cursor + band) {
-          const local = primitiveIndex - cursor;
-          const reflected =
-            local < rowsInGroup.length ? local : Math.max(0, rowsInGroup.length * 2 - 1 - local);
-          frameRow = rowsInGroup[Math.min(reflected, rowsInGroup.length - 1)] ?? frameRow;
-          derivedGroup = group;
-          matched = true;
-          break;
-        }
-        cursor += band;
-      }
-      if (!matched) {
+      const resolved = resolveClosedBandFrameRow(
+        getClosedBandLayout(frame, orderedGroups),
+        primitiveIndex,
+      );
+      if (resolved === null) {
         frameRow = Math.min(Math.max(0, primitiveIndex), Math.max(0, frame.n - 1));
         derivedGroup = frame.groups[frameRow] ?? derivedGroup;
+      } else {
+        frameRow = resolved.frameRow;
+        derivedGroup = resolved.derivedGroup;
       }
     } else {
       // Open paths: semantic index is the pre-split vertex / frame row.

--- a/packages/core/src/pipeline/coord-geometry.ts
+++ b/packages/core/src/pipeline/coord-geometry.ts
@@ -80,6 +80,11 @@ function tessellateSegment(
     error > COORD_TESSELLATION_TOLERANCE_PX &&
     budget.remaining > 1
   ) {
+    // Split remaining so the left half cannot starve the true endpoint, then
+    // reallocate any unused left capacity to the right for uneven curvature.
+    const leftRemaining = Math.floor(budget.remaining / 2);
+    const rightRemaining = budget.remaining - leftRemaining;
+    const left = { remaining: leftRemaining, capped: false };
     tessellateSegment(
       projector,
       width,
@@ -94,9 +99,10 @@ function tessellateSegment(
       rows,
       anchors,
       indices,
-      budget,
+      left,
       depth + 1,
     );
+    const right = { remaining: rightRemaining + left.remaining, capped: false };
     tessellateSegment(
       projector,
       width,
@@ -111,9 +117,11 @@ function tessellateSegment(
       rows,
       anchors,
       indices,
-      budget,
+      right,
       depth + 1,
     );
+    budget.remaining = right.remaining;
+    budget.capped ||= left.capped || right.capped;
     return;
   }
   if (
@@ -213,6 +221,22 @@ function projectPathBatch(
     );
     if (Number.isFinite(x) && Number.isFinite(y)) projectable[vertex] = 1;
     else invalidVertices++;
+  }
+  // Invalid vertices never become mandatory rendered anchors; free their
+  // reserved slots without exceeding max(0, cap − validMandatory).
+  if (invalidVertices > 0) {
+    const totalMandatory = sharedBudget?.mandatoryVertices ?? batch.positions.length / 2;
+    const validMandatory = Math.max(0, totalMandatory - invalidVertices);
+    const allowedExtra = Math.max(0, MAX_COORD_VERTICES_PER_PANEL_LAYER - validMandatory);
+    panelExtraRemaining = Math.min(panelExtraRemaining + invalidVertices, allowedExtra);
+    if (sharedBudget !== undefined) {
+      sharedBudget.mandatoryVertices = validMandatory;
+      sharedBudget.extraRemaining = Math.min(
+        sharedBudget.extraRemaining + invalidVertices,
+        allowedExtra,
+      );
+    }
+    capped = validMandatory > MAX_COORD_VERTICES_PER_PANEL_LAYER;
   }
 
   for (let s = 0; s + 1 < batch.pathOffsets.length; s++) {

--- a/packages/core/tests/candidate-construction/frame-row.test.ts
+++ b/packages/core/tests/candidate-construction/frame-row.test.ts
@@ -116,6 +116,52 @@ describe("resolveCandidateFrameRow paths", () => {
     ).toEqual({ frameRow: 3, derivedGroup: 1 });
   });
 
+  it("reflects closed-path reverse legs when semanticIndex is present (coord)", async () => {
+    const { resolveCandidateFrameRow } =
+      await import("../../src/pipeline/candidate-construction/frame-row.ts");
+    const frame = fromAny({
+      n: 2,
+      groups: [0, 0],
+      xNumeric: new Float64Array([0, 1]),
+      binding: { layer: { geom: "area" } },
+    });
+    // After coord, facts.primitiveIndex is semantic (pre-tessellation) path vertex.
+    // Closed band: verts 0..1 upper, 2..3 lower reverse.
+    const batch = fromAny({
+      kind: "paths",
+      closed: true,
+      pathOffsets: new Uint32Array([0, 10]), // render offsets deliberately different
+      semanticIndex: new Uint32Array(10),
+    });
+    expect(
+      resolveCandidateFrameRow({
+        frame,
+        batch,
+        primitiveIndex: 0,
+        orderedGroups: [0],
+        outlierLocalRow: null,
+      }),
+    ).toEqual({ frameRow: 0, derivedGroup: 0 });
+    expect(
+      resolveCandidateFrameRow({
+        frame,
+        batch,
+        primitiveIndex: 3,
+        orderedGroups: [0],
+        outlierLocalRow: null,
+      }),
+    ).toEqual({ frameRow: 0, derivedGroup: 0 });
+    expect(
+      resolveCandidateFrameRow({
+        frame,
+        batch,
+        primitiveIndex: 2,
+        orderedGroups: [0],
+        outlierLocalRow: null,
+      }),
+    ).toEqual({ frameRow: 1, derivedGroup: 0 });
+  });
+
   it("resolves many subpaths without linear pathOffsets scans (O(log P))", async () => {
     const { resolveCandidateFrameRow } =
       await import("../../src/pipeline/candidate-construction/frame-row.ts");

--- a/packages/core/tests/coord-transform.test.ts
+++ b/packages/core/tests/coord-transform.test.ts
@@ -136,6 +136,44 @@ describe("post-stat coordinate axis projector", () => {
     expect(warnings.some((warning) => warning.code === "coord-tessellation-cap")).toBe(true);
   });
 
+  it("reserves tessellation budget so segment endpoints still emit under a tight cap", () => {
+    // A shared remaining counter lets the left recursive half spend every slot
+    // and drop the true endpoint; split remaining so the right half keeps one.
+    const projector = buildPanelCoordProjector(
+      { x: linear([1, 100]), y: linear([1, 100]) },
+      {
+        type: "transform",
+        x: { transform: "log10", expand: false },
+        y: { transform: "sqrt", expand: false },
+      },
+    );
+    const batch: SegmentsBatch = {
+      kind: "segments",
+      layerIndex: 0,
+      panelIndex: 0,
+      segments: Float32Array.from([1, 1, 100, 100]),
+      rowIndex: Uint32Array.from([0]),
+      stroke: null,
+      linewidth: 1,
+      alpha: 1,
+    };
+    projectGeometryBatch(batch, projector, 100, 100, [], {
+      mandatoryVertices: 2,
+      // Tiny allowance: enough that recursion is attempted but left-biased
+      // consumption would otherwise starve the endpoint.
+      extraRemaining: 2,
+    });
+    const rendered = batch.renderPositions;
+    expect(rendered).toBeDefined();
+    expect(rendered!.length).toBeGreaterThanOrEqual(4);
+    const lastX = rendered![rendered!.length - 2]!;
+    const lastY = rendered![rendered!.length - 1]!;
+    const expectedX = projector.x.projectFraction(1) * 100;
+    const expectedY = (1 - projector.y.projectFraction(0)) * 100;
+    expect(lastX).toBeCloseTo(expectedX, 5);
+    expect(lastY).toBeCloseTo(expectedY, 5);
+  });
+
   it("tessellates diagonal segment render topology while retaining one semantic anchor", () => {
     const x = linear([1, 100]);
     const y = linear([1, 100]);

--- a/packages/core/tests/pipeline-coord-transform.test.ts
+++ b/packages/core/tests/pipeline-coord-transform.test.ts
@@ -407,6 +407,35 @@ describe("pipeline post-stat coord_transform", () => {
     expect(model.warnings.some((warning) => warning.code === "coord-invalid-geometry")).toBe(true);
   });
 
+  it("keeps post-split path candidate values aligned with pre-split semantic vertices", () => {
+    const model = runPipeline(
+      gg(
+        [
+          { x: 1, y: 1 },
+          { x: 2, y: 2 },
+          { x: 3, y: -1 },
+          { x: 4, y: 10 },
+          { x: 5, y: 100 },
+        ],
+        aes({ x: "x", y: "y" }),
+      )
+        .geomLine()
+        .coordTransform({ y: { transform: "log10", limits: [1, 100], expand: false } })
+        .spec(),
+      size,
+    );
+    // Two finite runs: (1,1)-(2,2) and (4,10)-(5,100). Values must stay on the
+    // authored vertices, not shift to neighbors after pathOffsets re-index.
+    const xs = candidates(model)
+      .map((candidate) => Number(candidate.xValue))
+      .toSorted((a, b) => a - b);
+    const ys = candidates(model)
+      .map((candidate) => Number(candidate.yValue))
+      .toSorted((a, b) => a - b);
+    expect(xs).toEqual([1, 2, 4, 5]);
+    expect(ys).toEqual([1, 2, 10, 100]);
+  });
+
   it("tessellates nonlinear paths without creating semantic candidates", () => {
     const model = runPipeline(
       gg(

--- a/packages/spec/src/normalize-coord.ts
+++ b/packages/spec/src/normalize-coord.ts
@@ -21,8 +21,10 @@ function normalizeCoordAxis(
       limits: [...(record["limits"] as unknown[])],
     }),
   } as CoordTransformAxisSpec;
-  if (record["reverse"] !== true) delete normalized.reverse;
-  if (record["expand"] !== false) delete normalized.expand;
+  // Drop valid defaults (including explicit undefined from option spreads);
+  // preserve malformed non-booleans for schema reject.
+  if (record["reverse"] === false || record["reverse"] === undefined) delete normalized.reverse;
+  if (record["expand"] === true || record["expand"] === undefined) delete normalized.expand;
   return normalized;
 }
 
@@ -60,12 +62,9 @@ export function normalizeCoord(coord: CoordSpec | undefined): CoordSpec | undefi
   const hasUnknownKey = Object.keys(transformed).some(
     (key) => key !== "type" && key !== "x" && key !== "y" && key !== "clip",
   );
-  if (
-    !effectiveCoordAxis(x) &&
-    !effectiveCoordAxis(y) &&
-    transformed.clip !== false &&
-    !hasUnknownKey
-  ) {
+  // Default clip is true/absent; only collapse when clip is a valid default.
+  const clipIsDefault = transformed.clip === true || transformed.clip === undefined;
+  if (!effectiveCoordAxis(x) && !effectiveCoordAxis(y) && clipIsDefault && !hasUnknownKey) {
     return undefined;
   }
   const normalized: CoordSpec = {
@@ -76,6 +75,7 @@ export function normalizeCoord(coord: CoordSpec | undefined): CoordSpec | undefi
   };
   if (!effectiveCoordAxis(x)) delete normalized.x;
   if (!effectiveCoordAxis(y)) delete normalized.y;
-  if (transformed.clip !== false) delete normalized.clip;
+  // Keep false and non-boolean clip (malformed) for validation.
+  if (transformed.clip === true || transformed.clip === undefined) delete normalized.clip;
   return normalized;
 }

--- a/packages/spec/src/normalize-coord.ts
+++ b/packages/spec/src/normalize-coord.ts
@@ -33,11 +33,18 @@ function effectiveCoordAxis(axis: ReturnType<typeof normalizeCoordAxis>): boolea
   const runtimeAxis = axis as unknown;
   if (runtimeAxis === null || typeof runtimeAxis !== "object" || Array.isArray(runtimeAxis))
     return true;
+  const reverse = (axis as { reverse?: unknown }).reverse;
+  const expand = (axis as { expand?: unknown }).expand;
+  // Non-boolean reverse/expand must stay effective so schema can reject them.
+  const malformedReverse = reverse !== undefined && reverse !== true && reverse !== false;
+  const malformedExpand = expand !== undefined && expand !== true && expand !== false;
   return (
     axis.transform !== "identity" ||
     axis.limits !== undefined ||
     axis.reverse === true ||
     axis.expand === false ||
+    malformedReverse ||
+    malformedExpand ||
     Object.keys(axis).some(
       (key) => key !== "transform" && key !== "limits" && key !== "reverse" && key !== "expand",
     )

--- a/packages/spec/tests/coord-transform-api.test.ts
+++ b/packages/spec/tests/coord-transform-api.test.ts
@@ -97,4 +97,40 @@ describe("coord_transform public contract", () => {
     expect(coordTransform()).toEqual({ type: "cartesian" });
     expect(coordTransform({ clip: true })).toEqual({ type: "cartesian" });
   });
+
+  it("drops explicit undefined coord defaults from option spreads", () => {
+    const spec = normalize({
+      layers: [{ geom: "point" }],
+      coord: {
+        type: "transform",
+        x: { transform: "log10", reverse: undefined, expand: undefined },
+        clip: undefined,
+      },
+    } as never);
+    expect(spec.coord).toEqual({ type: "transform", x: { transform: "log10" } });
+    expect(validate(spec).ok).toBe(true);
+  });
+
+  it("preserves malformed coord axis booleans and clip for schema validation", () => {
+    const badReverse = normalize({
+      layers: [{ geom: "point" }],
+      coord: { type: "transform", x: { transform: "log10", reverse: "yes" } },
+    } as never);
+    expect((badReverse.coord as { x?: { reverse?: unknown } } | undefined)?.x?.reverse).toBe("yes");
+    expect(validate(badReverse).ok).toBe(false);
+
+    const badExpand = normalize({
+      layers: [{ geom: "point" }],
+      coord: { type: "transform", x: { transform: "log10", expand: "no" } },
+    } as never);
+    expect((badExpand.coord as { x?: { expand?: unknown } } | undefined)?.x?.expand).toBe("no");
+    expect(validate(badExpand).ok).toBe(false);
+
+    const badClip = normalize({
+      layers: [{ geom: "point" }],
+      coord: { type: "transform", x: { transform: "log10" }, clip: "off" },
+    } as never);
+    expect((badClip.coord as { clip?: unknown } | undefined)?.clip).toBe("off");
+    expect(validate(badClip).ok).toBe(false);
+  });
 });

--- a/packages/spec/tests/coord-transform-api.test.ts
+++ b/packages/spec/tests/coord-transform-api.test.ts
@@ -111,6 +111,18 @@ describe("coord_transform public contract", () => {
     expect(validate(spec).ok).toBe(true);
   });
 
+  it("preserves malformed identity axes so schema still rejects them", () => {
+    const badIdentity = normalize({
+      layers: [{ geom: "point" }],
+      coord: { type: "transform", x: { transform: "identity", reverse: "yes" } },
+    } as never);
+    expect(badIdentity.coord).toBeDefined();
+    expect((badIdentity.coord as { x?: { reverse?: unknown } } | undefined)?.x?.reverse).toBe(
+      "yes",
+    );
+    expect(validate(badIdentity).ok).toBe(false);
+  });
+
   it("preserves malformed coord axis booleans and clip for schema validation", () => {
     const badReverse = normalize({
       layers: [{ geom: "point" }],


### PR DESCRIPTION
## Summary

Follow-up for unrebutted **post-merge** Codex findings on #380.

## Fixes

| Finding | Fix |
|---------|-----|
| Malformed coord `reverse`/`expand` deleted | Only drop `reverse: false` / `expand: true` |
| Malformed `clip` deleted / collapsed | Keep non-boolean `clip`; only drop `true` |
| Tessellation endpoint starvation | Split remaining across left/right halves |
| Invalid verts consume tessellation budget | Release budget after invalid filtering |
| Split path candidate frame rows | Resolve via `semanticIndex` when present |

## Parent

- https://github.com/ljodea/ggsvelte/pull/380

## Test plan

- [x] `preserves malformed coord axis booleans and clip for schema validation`
- [x] `reserves tessellation budget so segment endpoints still emit under a tight cap`
- [x] `keeps post-split path candidate values aligned with pre-split semantic vertices`
- [x] coord-transform + pipeline-coord-transform + candidate-construction suites