### PR TITLE
refactor(docs): playground-state types leaf and guide {@attach} copy

### DIFF
--- a/apps/docs/src/lib/components/PlaygroundEditor.svelte
+++ b/apps/docs/src/lib/components/PlaygroundEditor.svelte
@@ -2,7 +2,7 @@
   import { tick } from "svelte";
 
   import UiButton from "$lib/components/UiButton.svelte";
-  import type { PlaygroundDiagnostic } from "$lib/playground-state";
+  import type { PlaygroundDiagnostic } from "$lib/playground-state-types";
 
   const {
     draft,

--- a/apps/docs/src/lib/components/PlaygroundPreview.svelte
+++ b/apps/docs/src/lib/components/PlaygroundPreview.svelte
@@ -10,7 +10,7 @@
   import type {
     PlaygroundCandidate,
     PlaygroundDiagnostic,
-  } from "$lib/playground-state";
+  } from "$lib/playground-state-types";
   import type { PortableSpec } from "@ggsvelte/spec";
 
   const {

--- a/apps/docs/src/lib/guide-code-copy.ts
+++ b/apps/docs/src/lib/guide-code-copy.ts
@@ -1,0 +1,161 @@
+/**
+ * Delegated copy controls for guide markdown fences (`data-copy-code`).
+ * Icons are shared with scripts/llms-markdown.ts (single source).
+ */
+import { copyText, MANUAL_COPY_STATUS } from "./clipboard";
+
+/** Phosphor Copy (regular) — must match static HTML from llms-markdown. */
+export const GUIDE_COPY_ICON_SVG =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor" viewBox="0 0 256 256" aria-hidden="true"><path d="M216,32H88a8,8,0,0,0-8,8V80H40a8,8,0,0,0-8,8V216a8,8,0,0,0,8,8H168a8,8,0,0,0,8-8V176h40a8,8,0,0,0,8-8V40A8,8,0,0,0,216,32ZM160,208H48V96H160Zm48-48H176V88a8,8,0,0,0-8-8H96V48H208Z"/></svg>';
+
+/** Phosphor Check (bold) — client-only feedback after successful copy. */
+export const GUIDE_CHECK_ICON_SVG =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor" viewBox="0 0 256 256" aria-hidden="true"><path d="M229.66,77.66l-128,128a8,8,0,0,1-11.32,0l-56-56a8,8,0,0,1,11.32-11.32L96,188.69,218.34,66.34a8,8,0,0,1,11.32,11.32Z"/></svg>';
+
+export const GUIDE_COPY_RESET_MS = 2000;
+
+function cssEscapeIdent(value: string): string {
+  if (typeof globalThis.CSS?.escape === "function") return globalThis.CSS.escape(value);
+  // guide fence ids are `guide-code-N`; keep a conservative fallback for tests.
+  return value.replaceAll(/[^a-zA-Z0-9_-]/gu, (ch) => `\\${ch}`);
+}
+
+export type GuideCopyFeedback = {
+  readonly icon: "copy" | "check";
+  readonly buttonAriaLabel: string;
+  readonly statusText: string;
+  readonly statusVisuallyHidden: boolean;
+  readonly resetMs: number | null;
+};
+
+export function guideCopyFeedback(result: "copied" | "manual"): GuideCopyFeedback {
+  if (result === "copied") {
+    return {
+      icon: "check",
+      buttonAriaLabel: "Copied",
+      statusText: "Copied.",
+      statusVisuallyHidden: true,
+      resetMs: GUIDE_COPY_RESET_MS,
+    };
+  }
+  return {
+    icon: "copy",
+    buttonAriaLabel: "Copy code",
+    statusText: MANUAL_COPY_STATUS,
+    statusVisuallyHidden: false,
+    resetMs: null,
+  };
+}
+
+/** Idle control state after a successful-copy reset timer fires. */
+export function guideCopyIdleFeedback(): GuideCopyFeedback {
+  return {
+    icon: "copy",
+    buttonAriaLabel: "Copy code",
+    statusText: "",
+    statusVisuallyHidden: true,
+    resetMs: null,
+  };
+}
+
+export function guideCopyIconSvg(icon: "copy" | "check"): string {
+  return icon === "check" ? GUIDE_CHECK_ICON_SVG : GUIDE_COPY_ICON_SVG;
+}
+
+export interface GuideCopyDomTargets {
+  readonly button: {
+    innerHTML: string;
+    setAttribute(name: string, value: string): void;
+  };
+  readonly status: {
+    textContent: string;
+    classList: { add(token: string): void; remove(token: string): void };
+  };
+}
+
+/** Apply pure feedback to the button/status nodes used by guide fences. */
+export function applyGuideCopyFeedback(
+  targets: GuideCopyDomTargets,
+  feedback: GuideCopyFeedback,
+): void {
+  targets.button.innerHTML = guideCopyIconSvg(feedback.icon);
+  targets.button.setAttribute("aria-label", feedback.buttonAriaLabel);
+  targets.status.textContent = feedback.statusText;
+  if (feedback.statusVisuallyHidden) targets.status.classList.add("visually-hidden");
+  else targets.status.classList.remove("visually-hidden");
+}
+
+export type GuideCodeCopyDeps = {
+  readonly copyText: (text: string, fallbackNode: Node) => Promise<"copied" | "manual">;
+  readonly setTimeout: typeof setTimeout;
+  readonly clearTimeout: typeof clearTimeout;
+};
+
+const defaultDeps: GuideCodeCopyDeps = {
+  copyText,
+  setTimeout,
+  clearTimeout,
+};
+
+/**
+ * Svelte 5 attachment: delegated click for `button[data-copy-code]` fences.
+ * Returns a destroy function that clears pending reset timers.
+ */
+export function createGuideCodeCopyAttachment(
+  deps: GuideCodeCopyDeps = defaultDeps,
+): (node: HTMLElement) => () => void {
+  return (node: HTMLElement) => {
+    const resetTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+    async function handleClick(event: MouseEvent): Promise<void> {
+      const target = event.target;
+      // Duck-type Element so unit tests can run without a browser DOM global.
+      if (
+        target === null ||
+        typeof target !== "object" ||
+        typeof (target as Element).closest !== "function"
+      ) {
+        return;
+      }
+      const button = (target as Element).closest<HTMLButtonElement>("button[data-copy-code]");
+      if (button === null || !node.contains(button)) return;
+      const codeId = button.dataset.copyCode;
+      if (codeId === undefined) return;
+      const doc = node.ownerDocument;
+      const block = doc.querySelector(`#${cssEscapeIdent(codeId)}`);
+      const code = block?.querySelector("code");
+      const status = doc.querySelector(`#${cssEscapeIdent(`${codeId}-status`)}`);
+      if (code === null || code === undefined || status === null) return;
+
+      const previous = resetTimers.get(codeId);
+      if (previous !== undefined) deps.clearTimeout(previous);
+
+      const result = await deps.copyText(code.textContent ?? "", code);
+      const feedback = guideCopyFeedback(result);
+      applyGuideCopyFeedback({ button, status }, feedback);
+
+      if (feedback.resetMs !== null) {
+        resetTimers.set(
+          codeId,
+          deps.setTimeout(() => {
+            applyGuideCopyFeedback({ button, status }, guideCopyIdleFeedback());
+            resetTimers.delete(codeId);
+          }, feedback.resetMs),
+        );
+      }
+    }
+
+    function onClick(event: MouseEvent): void {
+      void handleClick(event);
+    }
+
+    node.addEventListener("click", onClick);
+    return () => {
+      node.removeEventListener("click", onClick);
+      for (const timer of resetTimers.values()) deps.clearTimeout(timer);
+      resetTimers.clear();
+    };
+  };
+}
+
+export const attachGuideCodeCopy = createGuideCodeCopyAttachment();

--- a/apps/docs/src/lib/playground-candidate-lifecycle.ts
+++ b/apps/docs/src/lib/playground-candidate-lifecycle.ts
@@ -5,7 +5,7 @@
  * `ggsvelte:playground-candidate` CustomEvent; assistive technology uses
  * aria-busy / status live region, not this event.
  */
-import type { PlaygroundCandidateOrigin } from "./playground-state";
+import type { PlaygroundCandidateOrigin } from "./playground-state-types";
 
 export const PLAYGROUND_CANDIDATE_EVENT = "ggsvelte:playground-candidate";
 

--- a/apps/docs/src/lib/playground-draft-validate.ts
+++ b/apps/docs/src/lib/playground-draft-validate.ts
@@ -9,7 +9,7 @@ import {
   validatePlaygroundSeed,
   type PlaygroundSeedV1,
 } from "./playground-codec";
-import type { PlaygroundDiagnostic } from "./playground-state";
+import type { PlaygroundDiagnostic } from "./playground-state-types";
 
 const VALIDATE_LIMITS = {
   maxRows: PLAYGROUND_MAX_ROWS,

--- a/apps/docs/src/lib/playground-export.ts
+++ b/apps/docs/src/lib/playground-export.ts
@@ -1,7 +1,7 @@
 import { PipelineError, renderToSVGString } from "@ggsvelte/core";
 import type { PortableSpec } from "@ggsvelte/spec";
 
-import type { PlaygroundDiagnostic } from "./playground-state";
+import type { PlaygroundDiagnostic } from "./playground-state-types";
 
 export type PlaygroundSVGExportResult =
   | {

--- a/apps/docs/src/lib/playground-hash-restore.ts
+++ b/apps/docs/src/lib/playground-hash-restore.ts
@@ -5,13 +5,12 @@ import {
   verifiedSharedSeed,
   type PlaygroundShareCatalogs,
 } from "./playground-link-policy";
-import {
-  reportPlaygroundDiagnostic,
-  stagePlaygroundSeed,
-  type PlaygroundCandidateOrigin,
-  type PlaygroundDiagnostic,
-  type PlaygroundState,
-} from "./playground-state";
+import { reportPlaygroundDiagnostic, stagePlaygroundSeed } from "./playground-state";
+import type {
+  PlaygroundCandidateOrigin,
+  PlaygroundDiagnostic,
+  PlaygroundState,
+} from "./playground-state-types";
 
 export type PlaygroundHashRestoreOrigin = "initial-navigation" | "popstate";
 

--- a/apps/docs/src/lib/playground-link-policy.ts
+++ b/apps/docs/src/lib/playground-link-policy.ts
@@ -3,7 +3,7 @@ import type {
   PlaygroundCandidateOrigin,
   PlaygroundDiagnostic,
   PlaygroundState,
-} from "./playground-state";
+} from "./playground-state-types";
 
 export interface PlaygroundExampleCatalogEntry {
   readonly id: string;

--- a/apps/docs/src/lib/playground-state-types.ts
+++ b/apps/docs/src/lib/playground-state-types.ts
@@ -1,0 +1,58 @@
+import type { PortableSpec } from "@ggsvelte/spec";
+
+import type { PlaygroundSeedV1 } from "./playground-codec";
+
+export type PlaygroundDiagnosticSource = "playground" | "validation" | "pipeline" | "export";
+
+export interface PlaygroundDiagnostic {
+  readonly source: PlaygroundDiagnosticSource;
+  readonly code: string;
+  readonly path: string;
+  readonly message: string;
+  readonly fix?: string;
+}
+
+export type PlaygroundCandidateOrigin =
+  | "apply"
+  | "source"
+  | "reset"
+  | "undo"
+  | "initial-navigation"
+  | "popstate";
+
+export interface PlaygroundSnapshot {
+  readonly sourceBaseline: PlaygroundSeedV1;
+  readonly seed: PlaygroundSeedV1;
+  readonly draft: string;
+  readonly committed: PortableSpec;
+  readonly rendered: PortableSpec;
+  readonly renderConfirmed: boolean;
+  readonly historyHash: string | null;
+}
+
+export interface PlaygroundCandidate {
+  readonly generation: number;
+  readonly origin: PlaygroundCandidateOrigin;
+  readonly next: PlaygroundSnapshot;
+  readonly undoSnapshotsAfterPromotion?: readonly PlaygroundSnapshot[];
+}
+
+export interface PlaygroundNavigationRecovery {
+  readonly replaceHash: string | null;
+  readonly preserveForward: true;
+}
+
+export interface PlaygroundState extends PlaygroundSnapshot {
+  readonly candidate: PlaygroundCandidate | null;
+  readonly diagnostics: readonly PlaygroundDiagnostic[];
+  readonly lastValid: boolean;
+  readonly status: string;
+  readonly nextGeneration: number;
+  readonly undoSnapshots: readonly PlaygroundSnapshot[];
+  readonly synchronized: boolean;
+  readonly canCopyOrShare: boolean;
+  readonly navigationRecovery: PlaygroundNavigationRecovery | null;
+  readonly historyIntent: "none";
+}
+
+export const PLAYGROUND_MAX_UNDO_SNAPSHOTS = 20;

--- a/apps/docs/src/lib/playground-state.ts
+++ b/apps/docs/src/lib/playground-state.ts
@@ -1,68 +1,28 @@
-import type { PortableSpec } from "@ggsvelte/spec";
-
 import {
   encodePlaygroundSeed,
   validatePlaygroundSeed,
   type PlaygroundSeedV1,
 } from "./playground-codec";
 import { serializePlaygroundSpec, validatePlaygroundDraft } from "./playground-draft-validate";
+import {
+  PLAYGROUND_MAX_UNDO_SNAPSHOTS,
+  type PlaygroundCandidateOrigin,
+  type PlaygroundDiagnostic,
+  type PlaygroundSnapshot,
+  type PlaygroundState,
+} from "./playground-state-types";
 
 export { serializePlaygroundSpec } from "./playground-draft-validate";
-
-export type PlaygroundDiagnosticSource = "playground" | "validation" | "pipeline" | "export";
-
-export interface PlaygroundDiagnostic {
-  readonly source: PlaygroundDiagnosticSource;
-  readonly code: string;
-  readonly path: string;
-  readonly message: string;
-  readonly fix?: string;
-}
-
-export type PlaygroundCandidateOrigin =
-  | "apply"
-  | "source"
-  | "reset"
-  | "undo"
-  | "initial-navigation"
-  | "popstate";
-
-export interface PlaygroundSnapshot {
-  readonly sourceBaseline: PlaygroundSeedV1;
-  readonly seed: PlaygroundSeedV1;
-  readonly draft: string;
-  readonly committed: PortableSpec;
-  readonly rendered: PortableSpec;
-  readonly renderConfirmed: boolean;
-  readonly historyHash: string | null;
-}
-
-export interface PlaygroundCandidate {
-  readonly generation: number;
-  readonly origin: PlaygroundCandidateOrigin;
-  readonly next: PlaygroundSnapshot;
-  readonly undoSnapshotsAfterPromotion?: readonly PlaygroundSnapshot[];
-}
-
-export interface PlaygroundNavigationRecovery {
-  readonly replaceHash: string | null;
-  readonly preserveForward: true;
-}
-
-export interface PlaygroundState extends PlaygroundSnapshot {
-  readonly candidate: PlaygroundCandidate | null;
-  readonly diagnostics: readonly PlaygroundDiagnostic[];
-  readonly lastValid: boolean;
-  readonly status: string;
-  readonly nextGeneration: number;
-  readonly undoSnapshots: readonly PlaygroundSnapshot[];
-  readonly synchronized: boolean;
-  readonly canCopyOrShare: boolean;
-  readonly navigationRecovery: PlaygroundNavigationRecovery | null;
-  readonly historyIntent: "none";
-}
-
-export const PLAYGROUND_MAX_UNDO_SNAPSHOTS = 20;
+export {
+  PLAYGROUND_MAX_UNDO_SNAPSHOTS,
+  type PlaygroundCandidate,
+  type PlaygroundCandidateOrigin,
+  type PlaygroundDiagnostic,
+  type PlaygroundDiagnosticSource,
+  type PlaygroundNavigationRecovery,
+  type PlaygroundSnapshot,
+  type PlaygroundState,
+} from "./playground-state-types";
 
 function finalize(
   state: Omit<PlaygroundState, "synchronized" | "canCopyOrShare">,

--- a/apps/docs/src/routes/guide/[slug]/+page.svelte
+++ b/apps/docs/src/routes/guide/[slug]/+page.svelte
@@ -1,74 +1,16 @@
 <script lang="ts">
-  import { copyText, MANUAL_COPY_STATUS } from "$lib/clipboard";
   import GettingStartedGuide from "$lib/components/GettingStartedGuide.svelte";
+  import { attachGuideCodeCopy } from "$lib/guide-code-copy";
   import type { PageProps } from "./$types";
 
   const { data }: PageProps = $props();
-
-  /** Phosphor Copy / Check (regular/bold) — must match scripts/llms-markdown.ts. */
-  const COPY_ICON_SVG =
-    '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor" viewBox="0 0 256 256" aria-hidden="true"><path d="M216,32H88a8,8,0,0,0-8,8V80H40a8,8,0,0,0-8,8V216a8,8,0,0,0,8,8H168a8,8,0,0,0,8-8V176h40a8,8,0,0,0,8-8V40A8,8,0,0,0,216,32ZM160,208H48V96H160Zm48-48H176V88a8,8,0,0,0-8-8H96V48H208Z"/></svg>';
-  const CHECK_ICON_SVG =
-    '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor" viewBox="0 0 256 256" aria-hidden="true"><path d="M229.66,77.66l-128,128a8,8,0,0,1-11.32,0l-56-56a8,8,0,0,1,11.32-11.32L96,188.69,218.34,66.34a8,8,0,0,1,11.32,11.32Z"/></svg>';
-
-  const resetTimers = new Map<string, ReturnType<typeof setTimeout>>();
-
-  async function copyGuideCode(event: MouseEvent): Promise<void> {
-    const target = event.target;
-    if (!(target instanceof Element)) return;
-    const button = target.closest<HTMLButtonElement>("button[data-copy-code]");
-    if (button === null) return;
-    const codeId = button.dataset.copyCode;
-    if (codeId === undefined) return;
-    const block = document.querySelector(`#${CSS.escape(codeId)}`);
-    const code = block?.querySelector("code");
-    const status = document.querySelector(`#${CSS.escape(`${codeId}-status`)}`);
-    if (code === null || code === undefined || status === null) return;
-
-    const previous = resetTimers.get(codeId);
-    if (previous !== undefined) clearTimeout(previous);
-
-    const result = await copyText(code.textContent ?? "", code);
-    if (result === "copied") {
-      button.innerHTML = CHECK_ICON_SVG;
-      button.setAttribute("aria-label", "Copied");
-      status.textContent = "Copied.";
-      status.classList.add("visually-hidden");
-      resetTimers.set(
-        codeId,
-        setTimeout(() => {
-          button.innerHTML = COPY_ICON_SVG;
-          button.setAttribute("aria-label", "Copy code");
-          status.textContent = "";
-          resetTimers.delete(codeId);
-        }, 2000),
-      );
-    } else {
-      button.innerHTML = COPY_ICON_SVG;
-      button.setAttribute("aria-label", "Copy code");
-      status.textContent = MANUAL_COPY_STATUS;
-      // Manual fallback needs visible instructions (Codex P2).
-      status.classList.remove("visually-hidden");
-    }
-  }
-
-  function enhanceCodeCopy(node: HTMLElement): { destroy: () => void } {
-    node.addEventListener("click", copyGuideCode);
-    return {
-      destroy: () => {
-        node.removeEventListener("click", copyGuideCode);
-        for (const timer of resetTimers.values()) clearTimeout(timer);
-        resetTimers.clear();
-      },
-    };
-  }
 </script>
 
 {#if data.page.slug === "getting-started"}
   <GettingStartedGuide />
 {:else}
   <!-- Guide markdown is repository-authored catalog content, never user input. -->
-  <article class="guide prose" use:enhanceCodeCopy>
+  <article class="guide prose" {@attach attachGuideCodeCopy}>
     <!-- eslint-disable-next-line svelte/no-at-html-tags -->
     {@html data.html}
   </article>

--- a/scripts/guide-code-copy.test.ts
+++ b/scripts/guide-code-copy.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, test } from "bun:test";
+
+import { MANUAL_COPY_STATUS } from "../apps/docs/src/lib/clipboard";
+import {
+  applyGuideCopyFeedback,
+  createGuideCodeCopyAttachment,
+  GUIDE_CHECK_ICON_SVG,
+  GUIDE_COPY_ICON_SVG,
+  GUIDE_COPY_RESET_MS,
+  guideCopyFeedback,
+  guideCopyIdleFeedback,
+  guideCopyIconSvg,
+} from "../apps/docs/src/lib/guide-code-copy";
+
+describe("guideCopyFeedback", () => {
+  test("copied feedback shows check icon, hidden status, and reset timer", () => {
+    expect(guideCopyFeedback("copied")).toEqual({
+      icon: "check",
+      buttonAriaLabel: "Copied",
+      statusText: "Copied.",
+      statusVisuallyHidden: true,
+      resetMs: GUIDE_COPY_RESET_MS,
+    });
+    expect(guideCopyIconSvg("check")).toBe(GUIDE_CHECK_ICON_SVG);
+  });
+
+  test("manual feedback keeps copy icon and visible status", () => {
+    expect(guideCopyFeedback("manual")).toEqual({
+      icon: "copy",
+      buttonAriaLabel: "Copy code",
+      statusText: MANUAL_COPY_STATUS,
+      statusVisuallyHidden: false,
+      resetMs: null,
+    });
+    expect(guideCopyIconSvg("copy")).toBe(GUIDE_COPY_ICON_SVG);
+  });
+
+  test("idle feedback restores copy control after successful-copy reset", () => {
+    expect(guideCopyIdleFeedback()).toEqual({
+      icon: "copy",
+      buttonAriaLabel: "Copy code",
+      statusText: "",
+      statusVisuallyHidden: true,
+      resetMs: null,
+    });
+  });
+});
+
+describe("applyGuideCopyFeedback", () => {
+  test("writes icon, aria-label, status text, and visually-hidden class", () => {
+    const classes = new Set<string>();
+    const button = {
+      innerHTML: "",
+      setAttribute(_name: string, value: string) {
+        this.aria = value;
+      },
+      aria: "",
+    };
+    const status = {
+      textContent: "",
+      classList: {
+        add(token: string) {
+          classes.add(token);
+        },
+        remove(token: string) {
+          classes.delete(token);
+        },
+      },
+    };
+
+    applyGuideCopyFeedback({ button, status }, guideCopyFeedback("copied"));
+    expect(button.innerHTML).toBe(GUIDE_CHECK_ICON_SVG);
+    expect(button.aria).toBe("Copied");
+    expect(status.textContent).toBe("Copied.");
+    expect(classes.has("visually-hidden")).toBe(true);
+
+    applyGuideCopyFeedback({ button, status }, guideCopyFeedback("manual"));
+    expect(button.innerHTML).toBe(GUIDE_COPY_ICON_SVG);
+    expect(button.aria).toBe("Copy code");
+    expect(status.textContent).toBe(MANUAL_COPY_STATUS);
+    expect(classes.has("visually-hidden")).toBe(false);
+  });
+});
+
+describe("createGuideCodeCopyAttachment", () => {
+  test("copied path applies feedback, schedules reset, and destroy clears timer", async () => {
+    const timers = new Map<number, () => void>();
+    let nextId = 1;
+    let cleared: number[] = [];
+    const deps = {
+      copyText: () => Promise.resolve("copied" as const),
+      setTimeout: ((fn: () => void) => {
+        const id = nextId++;
+        timers.set(id, fn);
+        return id as unknown as ReturnType<typeof setTimeout>;
+      }) as typeof setTimeout,
+      clearTimeout: ((id: ReturnType<typeof setTimeout>) => {
+        cleared.push(id as unknown as number);
+        timers.delete(id as unknown as number);
+      }) as typeof clearTimeout,
+    };
+
+    const doc = {
+      querySelector(selector: string) {
+        if (selector === "#guide-code-1") return pre;
+        if (selector === "#guide-code-1-status") return status;
+        return null;
+      },
+    };
+    const code = { textContent: '{"field":"weight"}' };
+    const pre = {
+      querySelector(sel: string) {
+        return sel === "code" ? code : null;
+      },
+    };
+    const classes = new Set<string>(["visually-hidden"]);
+    const status = {
+      textContent: "",
+      classList: {
+        add(t: string) {
+          classes.add(t);
+        },
+        remove(t: string) {
+          classes.delete(t);
+        },
+      },
+    };
+    const button = {
+      dataset: { copyCode: "guide-code-1" },
+      innerHTML: GUIDE_COPY_ICON_SVG,
+      setAttribute(_n: string, v: string) {
+        this.aria = v;
+      },
+      aria: "Copy code",
+      closest(sel: string) {
+        return sel === "button[data-copy-code]" ? this : null;
+      },
+    };
+    let clickHandler: ((event: MouseEvent) => void) | undefined;
+    const node = {
+      ownerDocument: doc,
+      contains() {
+        return true;
+      },
+      addEventListener(_type: string, handler: (event: MouseEvent) => void) {
+        clickHandler = handler;
+      },
+      removeEventListener() {
+        clickHandler = undefined;
+      },
+    };
+
+    const destroy = createGuideCodeCopyAttachment(deps)(node as unknown as HTMLElement);
+    expect(clickHandler).toBeDefined();
+
+    clickHandler!({
+      target: button,
+    } as unknown as MouseEvent);
+    // Flush the fire-and-forget async handler.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(button.innerHTML).toBe(GUIDE_CHECK_ICON_SVG);
+    expect(button.aria).toBe("Copied");
+    expect(status.textContent).toBe("Copied.");
+    expect(classes.has("visually-hidden")).toBe(true);
+    expect(timers.size).toBe(1);
+
+    destroy();
+    expect(cleared).toEqual([1]);
+    expect(timers.size).toBe(0);
+  });
+
+  test("manual path leaves visible status and does not schedule reset", async () => {
+    const scheduled: number[] = [];
+    const deps = {
+      copyText: () => Promise.resolve("manual" as const),
+      setTimeout: ((_fn: () => void) => {
+        scheduled.push(1);
+        return 1 as unknown as ReturnType<typeof setTimeout>;
+      }) as typeof setTimeout,
+      clearTimeout: () => {},
+    };
+
+    const code = { textContent: "npm install" };
+    const pre = {
+      querySelector(sel: string) {
+        return sel === "code" ? code : null;
+      },
+    };
+    const classes = new Set<string>(["visually-hidden"]);
+    const status = {
+      textContent: "",
+      classList: {
+        add(t: string) {
+          classes.add(t);
+        },
+        remove(t: string) {
+          classes.delete(t);
+        },
+      },
+    };
+    const button = {
+      dataset: { copyCode: "guide-code-2" },
+      innerHTML: GUIDE_COPY_ICON_SVG,
+      setAttribute(_n: string, v: string) {
+        this.aria = v;
+      },
+      aria: "Copy code",
+      closest(sel: string) {
+        return sel === "button[data-copy-code]" ? this : null;
+      },
+    };
+    const doc = {
+      querySelector(selector: string) {
+        if (selector === "#guide-code-2") return pre;
+        if (selector === "#guide-code-2-status") return status;
+        return null;
+      },
+    };
+    let clickHandler: ((event: MouseEvent) => void) | undefined;
+    const node = {
+      ownerDocument: doc,
+      contains() {
+        return true;
+      },
+      addEventListener(_type: string, handler: (event: MouseEvent) => void) {
+        clickHandler = handler;
+      },
+      removeEventListener() {},
+    };
+
+    createGuideCodeCopyAttachment(deps)(node as unknown as HTMLElement);
+    clickHandler!({ target: button } as unknown as MouseEvent);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(button.innerHTML).toBe(GUIDE_COPY_ICON_SVG);
+    expect(button.aria).toBe("Copy code");
+    expect(status.textContent).toBe(MANUAL_COPY_STATUS);
+    expect(classes.has("visually-hidden")).toBe(false);
+    expect(scheduled).toEqual([]);
+  });
+});

--- a/scripts/llms-markdown.ts
+++ b/scripts/llms-markdown.ts
@@ -3,6 +3,7 @@
  * code, inline code, links, unordered lists). Shared by docs pages and llms
  * surfaces via gen-llms.
  */
+import { GUIDE_COPY_ICON_SVG } from "../apps/docs/src/lib/guide-code-copy";
 import { type CodeClassification } from "./guide-code-contract";
 import { highlightCodeToHtml } from "./highlight-code";
 
@@ -17,11 +18,6 @@ function escapeHtml(s: string): string {
     .replaceAll(">", "&gt;")
     .replaceAll('"', "&quot;");
 }
-
-/** Phosphor Copy (regular) path — icon-only control for static HTML fences. */
-const COPY_ICON_SVG =
-  '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor" viewBox="0 0 256 256" aria-hidden="true"><path d="M216,32H88a8,8,0,0,0-8,8V80H40a8,8,0,0,0-8,8V216a8,8,0,0,0,8,8H168a8,8,0,0,0,8-8V176h40a8,8,0,0,0,8-8V40A8,8,0,0,0,216,32ZM160,208H48V96H160Zm48-48H176V88a8,8,0,0,0-8-8H96V48H208Z"/></svg>';
-
 function inline(s: string, base: string): string {
   let out = escapeHtml(s);
   out = out.replaceAll(/`([^`]+)`/g, (_m, code: string) => `<code>${code}</code>`);
@@ -117,7 +113,7 @@ export function renderMarkdown(md: string, base = ""): string {
     const pre = `<pre><code${languageClass}>${highlighted}</code></pre>`;
     if (!codeCopy) return `${label}${pre}`;
     const id = `guide-code-${String(++copyCodeCount)}`;
-    return `${label}<div class="guide-code-copy"><button type="button" data-copy-code="${id}" aria-label="Copy code" aria-describedby="${id}-status">${COPY_ICON_SVG}</button><pre id="${id}"><code${languageClass}>${highlighted}</code></pre><span id="${id}-status" role="status" class="visually-hidden"></span></div>`;
+    return `${label}<div class="guide-code-copy"><button type="button" data-copy-code="${id}" aria-label="Copy code" aria-describedby="${id}-status">${GUIDE_COPY_ICON_SVG}</button><pre id="${id}"><code${languageClass}>${highlighted}</code></pre><span id="${id}-status" role="status" class="visually-hidden"></span></div>`;
   };
 
   for (const line of lines) {

--- a/scripts/playground-state-types.test.ts
+++ b/scripts/playground-state-types.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, test } from "bun:test";
+
+import { PLAYGROUND_MAX_UNDO_SNAPSHOTS as fromFacade } from "../apps/docs/src/lib/playground-state";
+import { PLAYGROUND_MAX_UNDO_SNAPSHOTS as fromLeaf } from "../apps/docs/src/lib/playground-state-types";
+
+describe("playground-state types leaf", () => {
+  test("MAX_UNDO is defined on the types leaf and re-exported from the facade", () => {
+    expect(fromLeaf).toBe(20);
+    expect(fromFacade).toBe(fromLeaf);
+  });
+});


### PR DESCRIPTION
## Summary

Maintainability pass on `apps/docs` after hash-restore / tab-roving (#464).

### Chosen candidates

1. **#462** — `playground-state.ts` mixed types with the state machine; `playground-draft-validate` (and other leaves) type-imported from the machine while the machine value-imported draft-validate.
2. **#463** — guide pages used legacy `use:action` for delegated code-copy; feedback policy was untested.

### What changed

| Module | Role |
|--------|------|
| `playground-state-types.ts` | Diagnostic/snapshot/candidate/state types + `PLAYGROUND_MAX_UNDO_SNAPSHOTS` |
| `playground-state.ts` | Machine only; re-exports types/constant for stable facade |
| Internal type-only consumers | Import from the types leaf |
| `guide-code-copy.ts` | Shared fence icons, pure feedback, injectable `{@attach}` attachment |
| `guide/[slug]/+page.svelte` | `{@attach attachGuideCodeCopy}` (no `use:`) |
| `scripts/llms-markdown.ts` | Imports `GUIDE_COPY_ICON_SVG` (single source) |

## Tests

- New `scripts/guide-code-copy.test.ts` (feedback matrix, DOM apply, attachment copied/manual + destroy clears timers)
- New `scripts/playground-state-types.test.ts` (facade re-export of MAX_UNDO)
- Existing playground state / draft-validate / hash-restore suites green
- `bun run check:docs`, `knip`, `lint:type-aware` clean
- `bun run test:visual -- docs-shell.spec.ts` — 19/19 (includes guide copy fallback)

## Follow-ups

Closes #462  
Closes #463