### PR TITLE
refactor(ci): share detect-changes driver with vr-compare (#415)

### DIFF
--- a/.github/workflows/vr-compare.yml
+++ b/.github/workflows/vr-compare.yml
@@ -66,28 +66,17 @@ jobs:
       - id: route
         name: classify changed paths → vr flag
         env:
+          # Same resolveRouteInputs + emit path as ci.yml (issue #415). PR-only:
+          # no main base widening; run-compat only affects consumer/packages_dist.
+          EVENT_NAME: ${{ github.event_name }}
+          GITHUB_REF: ${{ github.ref }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.sha }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          zero="0000000000000000000000000000000000000000"
-          if [ -z "${BASE_SHA}" ] || [ "${BASE_SHA}" = "${zero}" ]; then
-            bun scripts/ci-routing.ts emit-github-output --force-all
-            exit 0
-          fi
-          git fetch --no-tags --depth=1 origin "${BASE_SHA}" 2>/dev/null || true
-          if ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
-            bun scripts/ci-routing.ts emit-github-output --force-all
-            exit 0
-          fi
-          # --name-status keeps rename/copy source paths for classification.
-          mapfile -t files < <(git diff --name-status "${BASE_SHA}...${HEAD_SHA}" || true)
-          if [ "${#files[@]}" -eq 0 ]; then
-            printf '' | bun scripts/ci-routing.ts emit-github-output --stdin
-          else
-            printf '%s\n' "${files[@]}" | bun scripts/ci-routing.ts emit-github-output --stdin
-          fi
+          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+          REPO: ${{ github.repository }}
+        # Env-only contract: force-all / unresolvable base / empty / name-status
+        # live in scripts/ci-routing/detect-changes.ts (shared with ci.yml).
+        run: bun scripts/ci-routing.ts detect-changes
 
   compare:
     name: build docs, screenshot, upload candidate baselines

--- a/scripts/release-wiring.test.ts
+++ b/scripts/release-wiring.test.ts
@@ -295,8 +295,8 @@ describe("R0 release wiring", () => {
 
   it("path-routes CI jobs through scripts/ci-routing.ts and a ci-gate aggregator", () => {
     const ci = read(".github/workflows/ci.yml");
-    // ci.yml detect-changes delegates to the detect-changes driver; vr-compare
-    // still uses emit-github-output for its thinner base-resolution path.
+    // ci.yml and vr-compare both delegate path routing to the detect-changes
+    // driver (shared resolveRouteInputs base resolution — issue #415).
     expect(ci).toContain("scripts/ci-routing.ts detect-changes");
     expect(ci).toContain("  detect-changes:");
     expect(ci).toContain("  ci-gate:");
@@ -329,9 +329,11 @@ describe("R0 release wiring", () => {
     expect(ci).toContain("bun run lint:type-aware");
     expect(ci).toContain("bun run knip");
     expect(read(".pre-commit-config.yaml")).not.toContain("pre-push");
-    expect(read(".github/workflows/vr-compare.yml")).toContain(
-      "scripts/ci-routing.ts emit-github-output",
-    );
+    const vrCompare = read(".github/workflows/vr-compare.yml");
+    // Shared base-resolution with ci.yml (issue #415) — no inline force-all bash.
+    expect(vrCompare).toContain("scripts/ci-routing.ts detect-changes");
+    expect(vrCompare).not.toContain("emit-github-output");
+    expect(vrCompare).not.toContain('zero="0000000000000000000000000000000000000000"');
   });
 
   it("uses bash for the containerized visual approval job", () => {


### PR DESCRIPTION
## Summary

Closes #415. VR Compare path routing no longer embeds untestable base-resolution bash.

- vr-compare detect-changes job calls bun scripts/ci-routing.ts detect-changes (same env contract as ci.yml)
- Shared resolveRouteInputs covers force-all, empty diff, and name-status
- release-wiring characterization updated; actionlint clean

## Tests

- bun test scripts/release-wiring + detect-changes + ci-routing (112 pass)
- bun scripts/actionlint.ts clean
