### PR TITLE
refactor(docs): split playground builder output and svelte:window popstate

### DIFF
--- a/apps/docs/src/lib/Playground.svelte
+++ b/apps/docs/src/lib/Playground.svelte
@@ -137,11 +137,12 @@
     noteStagedCandidate(previous, next);
   }
 
+  function onPopState(): void {
+    restoreLocation("popstate");
+  }
+
   onMount(() => {
     restoreLocation("initial-navigation");
-    const onPopState = () => restoreLocation("popstate");
-    addEventListener("popstate", onPopState);
-    return () => removeEventListener("popstate", onPopState);
   });
 
   function editDraft(draft: string): void {
@@ -305,6 +306,8 @@
       result === "copied" ? "Share link copied." : MANUAL_LINK_COPY_STATUS;
   }
 </script>
+
+<svelte:window onpopstate={onPopState} />
 
 <section class="playground" aria-labelledby="playground-heading">
   <header class="playground-intro">

--- a/apps/docs/src/lib/components/PlaygroundPreview.svelte
+++ b/apps/docs/src/lib/components/PlaygroundPreview.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { PipelineError, type RenderModel } from "@ggsvelte/core";
+  import type { RenderModel } from "@ggsvelte/core";
   import { GGPlot } from "@ggsvelte/svelte";
 
   import type { PlaygroundInteractionEvent } from "$lib/playground-events";
@@ -7,6 +7,7 @@
     snapshotCandidateIsolation,
     type PlaygroundCandidateIsolation,
   } from "$lib/playground-candidate-lifecycle";
+  import { pipelineErrorToPlaygroundDiagnostic } from "$lib/playground-pipeline-diagnostic";
   import type {
     PlaygroundCandidate,
     PlaygroundDiagnostic,
@@ -69,28 +70,6 @@
       snapshotCandidateIsolation(candidateRoot, activeChartEl ?? null, probe),
     );
   }
-
-  function diagnostic(error: unknown): PlaygroundDiagnostic {
-    if (error instanceof PipelineError) {
-      return {
-        source: "pipeline",
-        code: error.code,
-        path: error.path,
-        message: error.message,
-        ...(error.diagnostic?.fixes[0]?.description === undefined
-          ? {}
-          : { fix: error.diagnostic.fixes[0].description }),
-      };
-    }
-    return {
-      source: "pipeline",
-      code: "render-failed",
-      path: "",
-      message:
-        error instanceof Error ? error.message : "The chart could not render.",
-      fix: "Adjust the PortableSpec or reset the source.",
-    };
-  }
 </script>
 
 <div class="panel-heading">
@@ -108,7 +87,10 @@
 <div class="chart-stack" aria-busy={candidate !== null}>
   <div class="active-chart" bind:this={activeChartEl}>
     {#key rendered}
-      <svelte:boundary onerror={(error) => onActiveFailed(diagnostic(error))}>
+      <svelte:boundary
+        onerror={(error) =>
+          onActiveFailed(pipelineErrorToPlaygroundDiagnostic(error))}
+      >
         <GGPlot
           spec={rendered}
           width="container"
@@ -136,7 +118,10 @@
       >
         <svelte:boundary
           onerror={(error) =>
-            onCandidateFailed(candidate.generation, diagnostic(error))}
+            onCandidateFailed(
+              candidate.generation,
+              pipelineErrorToPlaygroundDiagnostic(error),
+            )}
         >
           <GGPlot
             spec={candidate.next.rendered}

--- a/apps/docs/src/lib/playground-output-builder.ts
+++ b/apps/docs/src/lib/playground-output-builder.ts
@@ -1,0 +1,115 @@
+import { CURRENT_EDITION, gg, type PortableSpec } from "@ggsvelte/spec";
+
+import type { PlaygroundOutput } from "./playground-output-types";
+
+function builderUnsupportedReason(spec: PortableSpec): string | null {
+  if (spec.datasets !== undefined) {
+    return "Builder output cannot preserve named inline datasets yet. Copy Svelte or PortableSpec instead.";
+  }
+  return null;
+}
+
+function builderJSON(value: unknown): string {
+  return JSON.stringify(value, null, 2)
+    .replaceAll("<", "\\u003c")
+    .replaceAll("\u2028", "\\u2028")
+    .replaceAll("\u2029", "\\u2029");
+}
+
+function sortedJSONValue(input: unknown): unknown {
+  if (Array.isArray(input)) return input.map((entry) => sortedJSONValue(entry));
+  if (typeof input !== "object" || input === null) return input;
+  return Object.fromEntries(
+    Object.entries(input)
+      .toSorted(([left], [right]) => left.localeCompare(right))
+      .map(([key, entry]) => [key, sortedJSONValue(entry)]),
+  );
+}
+
+function sortedJSON(value: unknown): string {
+  return JSON.stringify(sortedJSONValue(value));
+}
+
+function builderCall(name: string, value: unknown): string {
+  return `  .${name}(${builderJSON(value)})`;
+}
+
+/** Rebuild through the public fluent API used by generated Builder output. */
+export function rebuildPlaygroundSpecWithBuilder(spec: PortableSpec): PortableSpec | null {
+  if (builderUnsupportedReason(spec) !== null) return null;
+  try {
+    let builder = gg(spec.data, spec.aes);
+    for (const layer of spec.layers) builder = builder.layer(layer);
+    if (spec.facet !== undefined) builder = builder.facet(spec.facet);
+    if (spec.coord !== undefined) builder = builder.coord(spec.coord);
+    if (spec.a11y !== undefined) builder = builder.a11y(spec.a11y);
+    if (spec.scales !== undefined) builder = builder.scales(spec.scales);
+    if (spec.legend !== undefined) builder = builder.legend(spec.legend);
+    if (spec.labs !== undefined) builder = builder.labs(spec.labs);
+    if (spec.theme !== undefined) builder = builder.theme(spec.theme);
+    return {
+      ...builder.spec(),
+      ...(spec.$schema === undefined ? {} : { $schema: spec.$schema }),
+      edition: spec.edition ?? CURRENT_EDITION,
+      ...(spec.width === undefined ? {} : { width: spec.width }),
+      ...(spec.height === undefined ? {} : { height: spec.height }),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function playgroundBuilderOutput(spec: PortableSpec): PlaygroundOutput {
+  const unsupported = builderUnsupportedReason(spec);
+  if (unsupported !== null) {
+    return {
+      kind: "builder",
+      label: "Builder",
+      supported: false,
+      code: "",
+      reason: unsupported,
+    };
+  }
+
+  const rebuilt = rebuildPlaygroundSpecWithBuilder(spec);
+  if (rebuilt === null || sortedJSON(rebuilt) !== sortedJSON(spec)) {
+    return {
+      kind: "builder",
+      label: "Builder",
+      supported: false,
+      code: "",
+      reason:
+        "The public Builder cannot reproduce this normalized PortableSpec exactly. Copy Svelte or PortableSpec instead.",
+    };
+  }
+
+  const startArguments = [spec.data, spec.aes]
+    .map((value) => (value === undefined ? "undefined" : builderJSON(value)))
+    .join(", ")
+    .replace(/, undefined$/u, "");
+  const calls = [
+    ...spec.layers.map((layer) => builderCall("layer", layer)),
+    ...(spec.facet === undefined ? [] : [builderCall("facet", spec.facet)]),
+    ...(spec.coord === undefined ? [] : [builderCall("coord", spec.coord)]),
+    ...(spec.a11y === undefined ? [] : [builderCall("a11y", spec.a11y)]),
+    ...(spec.scales === undefined ? [] : [builderCall("scales", spec.scales)]),
+    ...(spec.legend === undefined ? [] : [builderCall("legend", spec.legend)]),
+    ...(spec.labs === undefined ? [] : [builderCall("labs", spec.labs)]),
+    ...(spec.theme === undefined ? [] : [builderCall("theme", spec.theme)]),
+  ];
+  const metadata = {
+    ...(spec.$schema === undefined ? {} : { $schema: spec.$schema }),
+    edition: spec.edition ?? CURRENT_EDITION,
+    ...(spec.width === undefined ? {} : { width: spec.width }),
+    ...(spec.height === undefined ? {} : { height: spec.height }),
+  };
+  const metadataLines = Object.entries(metadata)
+    .map(([key, value]) => `  ${JSON.stringify(key)}: ${builderJSON(value)},`)
+    .join("\n");
+  return {
+    kind: "builder",
+    label: "Builder",
+    supported: true,
+    code: `import { gg, type PortableSpec } from "@ggsvelte/svelte";\n\nconst built = gg(${startArguments})\n${calls.join("\n")}\n  .spec();\n\nconst spec: PortableSpec = {\n  ...built,\n${metadataLines}\n};\n\nexport { spec };\n`,
+  };
+}

--- a/apps/docs/src/lib/playground-output-types.ts
+++ b/apps/docs/src/lib/playground-output-types.ts
@@ -1,0 +1,9 @@
+export type PlaygroundOutputKind = "svelte" | "builder" | "portable-spec";
+
+export interface PlaygroundOutput {
+  readonly kind: PlaygroundOutputKind;
+  readonly label: string;
+  readonly supported: boolean;
+  readonly code: string;
+  readonly reason?: string;
+}

--- a/apps/docs/src/lib/playground-output.ts
+++ b/apps/docs/src/lib/playground-output.ts
@@ -1,14 +1,13 @@
-import { CURRENT_EDITION, gg, type PortableSpec } from "@ggsvelte/spec";
+import type { PortableSpec } from "@ggsvelte/spec";
 
-export type PlaygroundOutputKind = "svelte" | "builder" | "portable-spec";
+import { playgroundBuilderOutput } from "./playground-output-builder";
+import type { PlaygroundOutput } from "./playground-output-types";
 
-export interface PlaygroundOutput {
-  readonly kind: PlaygroundOutputKind;
-  readonly label: string;
-  readonly supported: boolean;
-  readonly code: string;
-  readonly reason?: string;
-}
+export type { PlaygroundOutput, PlaygroundOutputKind } from "./playground-output-types";
+export {
+  playgroundBuilderOutput,
+  rebuildPlaygroundSpecWithBuilder,
+} from "./playground-output-builder";
 
 function scriptSafeJSON(spec: PortableSpec): string {
   return JSON.stringify(spec, null, 2)
@@ -26,118 +25,6 @@ export function playgroundSvelteOutput(spec: PortableSpec): string {
 
 <GGPlot {spec} />
 `;
-}
-
-function builderUnsupportedReason(spec: PortableSpec): string | null {
-  if (spec.datasets !== undefined) {
-    return "Builder output cannot preserve named inline datasets yet. Copy Svelte or PortableSpec instead.";
-  }
-  return null;
-}
-
-/** Rebuild through the public fluent API used by generated Builder output. */
-export function rebuildPlaygroundSpecWithBuilder(spec: PortableSpec): PortableSpec | null {
-  if (builderUnsupportedReason(spec) !== null) return null;
-  try {
-    let builder = gg(spec.data, spec.aes);
-    for (const layer of spec.layers) builder = builder.layer(layer);
-    if (spec.facet !== undefined) builder = builder.facet(spec.facet);
-    if (spec.coord !== undefined) builder = builder.coord(spec.coord);
-    if (spec.a11y !== undefined) builder = builder.a11y(spec.a11y);
-    if (spec.scales !== undefined) builder = builder.scales(spec.scales);
-    if (spec.legend !== undefined) builder = builder.legend(spec.legend);
-    if (spec.labs !== undefined) builder = builder.labs(spec.labs);
-    if (spec.theme !== undefined) builder = builder.theme(spec.theme);
-    return {
-      ...builder.spec(),
-      ...(spec.$schema === undefined ? {} : { $schema: spec.$schema }),
-      edition: spec.edition ?? CURRENT_EDITION,
-      ...(spec.width === undefined ? {} : { width: spec.width }),
-      ...(spec.height === undefined ? {} : { height: spec.height }),
-    };
-  } catch {
-    return null;
-  }
-}
-
-function builderJSON(value: unknown): string {
-  return JSON.stringify(value, null, 2)
-    .replaceAll("<", "\\u003c")
-    .replaceAll("\u2028", "\\u2028")
-    .replaceAll("\u2029", "\\u2029");
-}
-
-function sortedJSONValue(input: unknown): unknown {
-  if (Array.isArray(input)) return input.map((entry) => sortedJSONValue(entry));
-  if (typeof input !== "object" || input === null) return input;
-  return Object.fromEntries(
-    Object.entries(input)
-      .toSorted(([left], [right]) => left.localeCompare(right))
-      .map(([key, entry]) => [key, sortedJSONValue(entry)]),
-  );
-}
-
-function sortedJSON(value: unknown): string {
-  return JSON.stringify(sortedJSONValue(value));
-}
-
-function builderCall(name: string, value: unknown): string {
-  return `  .${name}(${builderJSON(value)})`;
-}
-
-export function playgroundBuilderOutput(spec: PortableSpec): PlaygroundOutput {
-  const unsupported = builderUnsupportedReason(spec);
-  if (unsupported !== null) {
-    return {
-      kind: "builder",
-      label: "Builder",
-      supported: false,
-      code: "",
-      reason: unsupported,
-    };
-  }
-
-  const rebuilt = rebuildPlaygroundSpecWithBuilder(spec);
-  if (rebuilt === null || sortedJSON(rebuilt) !== sortedJSON(spec)) {
-    return {
-      kind: "builder",
-      label: "Builder",
-      supported: false,
-      code: "",
-      reason:
-        "The public Builder cannot reproduce this normalized PortableSpec exactly. Copy Svelte or PortableSpec instead.",
-    };
-  }
-
-  const startArguments = [spec.data, spec.aes]
-    .map((value) => (value === undefined ? "undefined" : builderJSON(value)))
-    .join(", ")
-    .replace(/, undefined$/u, "");
-  const calls = [
-    ...spec.layers.map((layer) => builderCall("layer", layer)),
-    ...(spec.facet === undefined ? [] : [builderCall("facet", spec.facet)]),
-    ...(spec.coord === undefined ? [] : [builderCall("coord", spec.coord)]),
-    ...(spec.a11y === undefined ? [] : [builderCall("a11y", spec.a11y)]),
-    ...(spec.scales === undefined ? [] : [builderCall("scales", spec.scales)]),
-    ...(spec.legend === undefined ? [] : [builderCall("legend", spec.legend)]),
-    ...(spec.labs === undefined ? [] : [builderCall("labs", spec.labs)]),
-    ...(spec.theme === undefined ? [] : [builderCall("theme", spec.theme)]),
-  ];
-  const metadata = {
-    ...(spec.$schema === undefined ? {} : { $schema: spec.$schema }),
-    edition: spec.edition ?? CURRENT_EDITION,
-    ...(spec.width === undefined ? {} : { width: spec.width }),
-    ...(spec.height === undefined ? {} : { height: spec.height }),
-  };
-  const metadataLines = Object.entries(metadata)
-    .map(([key, value]) => `  ${JSON.stringify(key)}: ${builderJSON(value)},`)
-    .join("\n");
-  return {
-    kind: "builder",
-    label: "Builder",
-    supported: true,
-    code: `import { gg, type PortableSpec } from "@ggsvelte/svelte";\n\nconst built = gg(${startArguments})\n${calls.join("\n")}\n  .spec();\n\nconst spec: PortableSpec = {\n  ...built,\n${metadataLines}\n};\n\nexport { spec };\n`,
-  };
 }
 
 const outputCache = new WeakMap<PortableSpec, readonly PlaygroundOutput[]>();

--- a/apps/docs/src/lib/playground-pipeline-diagnostic.ts
+++ b/apps/docs/src/lib/playground-pipeline-diagnostic.ts
@@ -1,0 +1,28 @@
+import { PipelineError } from "@ggsvelte/core";
+
+import type { PlaygroundDiagnostic } from "./playground-state-types";
+
+/**
+ * Map a pipeline/render failure into the playground diagnostic surface.
+ * Preserves PipelineError code/path/message and the first catalog fix description.
+ */
+export function pipelineErrorToPlaygroundDiagnostic(error: unknown): PlaygroundDiagnostic {
+  if (error instanceof PipelineError) {
+    return {
+      source: "pipeline",
+      code: error.code,
+      path: error.path,
+      message: error.message,
+      ...(error.diagnostic?.fixes[0]?.description === undefined
+        ? {}
+        : { fix: error.diagnostic.fixes[0].description }),
+    };
+  }
+  return {
+    source: "pipeline",
+    code: "render-failed",
+    path: "",
+    message: error instanceof Error ? error.message : "The chart could not render.",
+    fix: "Adjust the PortableSpec or reset the source.",
+  };
+}

--- a/apps/docs/src/routes/examples/+page.svelte
+++ b/apps/docs/src/routes/examples/+page.svelte
@@ -72,7 +72,6 @@
   }
 
   onMount(() => {
-    addEventListener("popstate", readLocation);
     readLocation();
     if (resetNotice) {
       const url = new URL(location.href);
@@ -80,11 +79,12 @@
       history.replaceState(null, "", url);
     }
     return () => {
-      removeEventListener("popstate", readLocation);
       if (timer !== undefined) clearTimeout(timer);
     };
   });
 </script>
+
+<svelte:window onpopstate={readLocation} />
 
 <svelte:head><meta name="theme-color" content="#ffffff" /></svelte:head>
 

--- a/scripts/playground-pipeline-diagnostic.test.ts
+++ b/scripts/playground-pipeline-diagnostic.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+
+import { PipelineError } from "@ggsvelte/core";
+
+import { pipelineErrorToPlaygroundDiagnostic } from "../apps/docs/src/lib/playground-pipeline-diagnostic";
+
+const diagnosticWithFix = {
+  code: "INVALID_SCALE",
+  severity: "error" as const,
+  path: "scales.x",
+  problem: "Scale failed.",
+  cause: "bad domain",
+  fixes: [{ description: "Use a continuous scale." }],
+  documentationUrl: "https://example.test/scale",
+};
+
+describe("pipelineErrorToPlaygroundDiagnostic", () => {
+  test("maps PipelineError code, path, message, and first fix description", () => {
+    const error = new PipelineError(
+      "INVALID_SCALE",
+      "scales.x",
+      "Scale failed.",
+      diagnosticWithFix,
+    );
+    expect(pipelineErrorToPlaygroundDiagnostic(error)).toEqual({
+      source: "pipeline",
+      code: "INVALID_SCALE",
+      path: "scales.x",
+      message: "Scale failed.",
+      fix: "Use a continuous scale.",
+    });
+  });
+
+  test("maps PipelineError without fixes without a fix field", () => {
+    const error = new PipelineError("RENDER_FAILED", "layers[0]", "Boom");
+    expect(pipelineErrorToPlaygroundDiagnostic(error)).toEqual({
+      source: "pipeline",
+      code: "RENDER_FAILED",
+      path: "layers[0]",
+      message: "Boom",
+    });
+  });
+
+  test("maps generic Error to render-failed with message", () => {
+    expect(pipelineErrorToPlaygroundDiagnostic(new Error("canvas refused"))).toEqual({
+      source: "pipeline",
+      code: "render-failed",
+      path: "",
+      message: "canvas refused",
+      fix: "Adjust the PortableSpec or reset the source.",
+    });
+  });
+
+  test("maps non-Error unknown to default message", () => {
+    expect(pipelineErrorToPlaygroundDiagnostic("nope")).toEqual({
+      source: "pipeline",
+      code: "render-failed",
+      path: "",
+      message: "The chart could not render.",
+      fix: "Adjust the PortableSpec or reset the source.",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Maintainability pass on `apps/docs` after types leaf / guide attach (#478).

### Candidates

1. **`playground-output.ts`** mixed Svelte/PortableSpec facade with heavy Builder rebuild/codegen
2. **`PlaygroundPreview`** inline pipeline→diagnostic mapping (untested pure path)
3. **Playground + gallery** used `onMount` + `addEventListener("popstate")` instead of Svelte 5 `<svelte:window>`

### What changed

| Module | Role |
|--------|------|
| `playground-output-types.ts` | `PlaygroundOutputKind` / `PlaygroundOutput` |
| `playground-output-builder.ts` | rebuild + Builder codegen + unsupported reasons |
| `playground-output.ts` | Svelte/PortableSpec + WeakMap cache; re-exports builder API |
| `playground-pipeline-diagnostic.ts` | `pipelineErrorToPlaygroundDiagnostic` |
| `Playground.svelte` / `examples/+page.svelte` | stable `onpopstate` handlers via `<svelte:window>` |

Import paths for consumers stay on `playground-output`.

## Tests

- Existing `scripts/playground-output.test.ts` green (facade re-exports)
- New `scripts/playground-pipeline-diagnostic.test.ts` (PipelineError+fix, PipelineError bare, Error, unknown)
- `bun run check:docs`, `knip`, `lint:type-aware` clean
- Visual: `playground.spec.ts` + `docs-home-gallery.spec.ts` — 30/30 (includes Back/Forward restore)

## Follow-ups

None filed — remaining large docs Svelte files are mostly CSS/prose shells.