### PR TITLE
perf(core): Θ(R·B)→Θ(R) binned rect edges via xBinId

### DIFF
--- a/.changeset/binned-rect-slot-xbinid.md
+++ b/.changeset/binned-rect-slot-xbinid.md
@@ -1,0 +1,11 @@
+---
+"@ggsvelte/core": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+perf: Θ(R·B)→Θ(R) binned rect edges via xBinId
+
+Identity/count bar-col geometry on `type: "binned"` recovers bin edges from the
+stable integer `xBinId` (frame construction) instead of per-row
+`centers.findIndex` scans (B ≤ MAX_BINNED_BREAKS).

--- a/packages/core/src/pipeline/geometry-rects-slot.ts
+++ b/packages/core/src/pipeline/geometry-rects-slot.ts
@@ -43,12 +43,18 @@ export function resolveRectSlot(input: {
         sourceLeft = frame.xmin[row]!;
         sourceRight = frame.xmax[row]!;
       } else {
-        // A binned position scale snaps identity-stat rows to a transformed
-        // center. Recover that center's reviewed pre-stat boundaries.
+        // A binned position scale snaps identity/count rows to a transformed
+        // center. Recover edges via the stable integer bin id (built once at
+        // frame construction) — Θ(1) per row, not centers.findIndex (Θ(B)).
+        // xBinId is the discrete source of truth for stack/dodge/count too;
+        // float-center Object.is is only a defensive fallback when ids are absent.
         const boundaries = frame.binding.xBinning;
         const transformedCenter = frame.xNumeric?.[row];
         if (boundaries === undefined || transformedCenter === undefined) return null;
-        const index = boundaries.centers.findIndex((value) => Object.is(value, transformedCenter));
+        const index =
+          frame.xBinId === null
+            ? boundaries.centers.findIndex((value) => Object.is(value, transformedCenter))
+            : frame.xBinId[row]!;
         if (index < 0) return null;
         sourceLeft = boundaries.edges[index]!;
         sourceRight = boundaries.edges[index + 1]!;

--- a/packages/core/tests/geometry-rects-slot-binned.test.ts
+++ b/packages/core/tests/geometry-rects-slot-binned.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Binned identity/count rect slots: recover edges via stable `xBinId`, not
+ * O(R·B) `centers.findIndex` scans.
+ */
+import { fromAny, fromPartial } from "@total-typescript/shoehorn";
+import { describe, expect, it } from "bun:test";
+
+import { aes, gg, scaleXBinned } from "@ggsvelte/spec";
+
+import { resolveRectSlot } from "../src/pipeline/geometry-rects-slot.ts";
+import type { Frame } from "../src/pipeline/geometry-shared.ts";
+import type { LayerFrame } from "../src/pipeline/types.ts";
+import { runPipeline } from "../src/pipeline.ts";
+
+const size = { width: 640, height: 400 };
+
+function identityFx(): Frame {
+  return fromPartial<Frame>({
+    innerWidth: 100,
+    innerHeight: 100,
+    xScale: {
+      type: "linear",
+      transformedDomain: [0, 30] as const,
+      normalize: (v: number) => v / 30,
+      normalizeTransformed: (v: number) => v / 30,
+    },
+    yScale: {
+      type: "linear",
+      transformedDomain: [0, 1] as const,
+      normalize: (v: number) => v,
+      normalizeTransformed: (v: number) => v,
+    },
+  });
+}
+
+describe("resolveRectSlot — binned identity prefers xBinId over centers.findIndex", () => {
+  it("uses integer bin id when it disagrees with Object.is center scan", () => {
+    // Centers [5, 15] for edges [0,10,20]. Row 0's xNumeric equals center 0,
+    // but xBinId claims bin 1 — integer id is the discrete source of truth.
+    const frame = fromAny<LayerFrame>({
+      n: 1,
+      binding: {
+        index: 0,
+        xBinning: {
+          edges: [0, 10, 20],
+          centers: [5, 15],
+        },
+      },
+      xNumeric: Float64Array.of(5),
+      xBinId: Int32Array.of(1),
+      ymin: Float64Array.of(0),
+      ymax: Float64Array.of(1),
+      xmin: null,
+      xmax: null,
+      dodgeSlot: null,
+      dodgeSlotCounts: null,
+    });
+    const slot = resolveRectSlot({
+      frame,
+      fx: identityFx(),
+      row: 0,
+      binned: true,
+      widthFrac: 1,
+    });
+    expect(slot).not.toBeNull();
+    // Bin 1 spans [10, 20] → center 15 in scale space → normalize 15/30 = 0.5
+    expect(slot!.center).toBeCloseTo(0.5, 12);
+    expect(slot!.w).toBeCloseTo(10 / 30, 12);
+  });
+
+  it("drops rows with xBinId −1 (out of range)", () => {
+    const frame = fromAny<LayerFrame>({
+      n: 1,
+      binding: {
+        index: 0,
+        xBinning: {
+          edges: [0, 10, 20],
+          centers: [5, 15],
+        },
+      },
+      xNumeric: Float64Array.of(5),
+      xBinId: Int32Array.of(-1),
+      ymin: Float64Array.of(0),
+      ymax: Float64Array.of(1),
+      xmin: null,
+      xmax: null,
+      dodgeSlot: null,
+      dodgeSlotCounts: null,
+    });
+    expect(
+      resolveRectSlot({
+        frame,
+        fx: identityFx(),
+        row: 0,
+        binned: true,
+        widthFrac: 1,
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("scaleXBinned — identity geom_col edge recovery (pipeline seam)", () => {
+  it("unequal-width explicit bins yield proportional rect widths", () => {
+    // Breaks [0, 10, 40]: bin0 width 10, bin1 width 30 (3×).
+    const rows = [
+      { x: 5, y: 1 },
+      { x: 25, y: 1 },
+    ];
+    const model = runPipeline(
+      gg(rows, aes({ x: "x", y: "y" }))
+        .geomCol({ width: 1 })
+        .scales(scaleXBinned({ breaks: [0, 10, 40] }))
+        .spec(),
+      size,
+    );
+    const batch = model.scene.batches.find((b) => b.kind === "rects");
+    if (batch === undefined || batch.kind !== "rects") throw new Error("expected rects");
+    expect(batch.rowIndex.length).toBe(2);
+    const w0 = batch.rects[2]!;
+    const w1 = batch.rects[6]!;
+    expect(w1 / w0).toBeCloseTo(3, 5);
+  });
+
+  it("out-of-range x rows are removed from the rect batch", () => {
+    const rows = [
+      { x: 5, y: 1 },
+      { x: 100, y: 1 }, // outside [0, 30]
+      { x: 15, y: 1 },
+    ];
+    const model = runPipeline(
+      gg(rows, aes({ x: "x", y: "y" }))
+        .geomCol()
+        .scales(scaleXBinned({ breaks: [0, 10, 20, 30] }))
+        .spec(),
+      size,
+    );
+    const batch = model.scene.batches.find((b) => b.kind === "rects");
+    if (batch === undefined || batch.kind !== "rects") throw new Error("expected rects");
+    // Source rowIndex for kept rows is the original table index.
+    expect([...batch.rowIndex]).toEqual([0, 2]);
+  });
+});


### PR DESCRIPTION
## Summary

`/bigo-maintain` on `packages/core` (narrowed after 316 production files under `src/`).

### Audit finding (chosen)

- **File:** `packages/core/src/pipeline/geometry-rects-slot.ts`
- **Pattern:** #2 Nested linear search
- **Before:** Θ(R·B) `boundaries.centers.findIndex` per identity/count rect row on `type: "binned"` (no stat-bin `xmin`/`xmax`)
- **After:** Θ(R) via `frame.xBinId[row]` (B ≤ `MAX_BINNED_BREAKS` = 64)
- **n:** R = post-stat frame rows for identity/count bars/cols on a binned x scale; B = bin count

`xBinId` is already computed at identity/count frame build and survives stack/dodge. Integer ids are also the discrete source of truth (same as count aggregation / dodge keys); float-center `Object.is` remains only a defensive fallback when `xBinId` is null.

### Codex plan review

Revised after plan review: complexity phrasing as Θ(R·B)→Θ(R) with B capped; RED tests that prove the integer-id path (disagree with center scan; xBinId −1 drops); pipeline characterization for unequal-width bins and OOR removal.

### Tests

```text
bun test packages/core/tests/geometry-rects-slot-binned.test.ts   packages/core/tests/pipeline-position-binned.test.ts   packages/core/tests/pipeline-position-binned-ids.test.ts
# 27 pass, 0 fail
```

### Follow-ups

None deferred — other nested work inspected (canvas color batching C≤64 intentional; density window scan intentional; loess exact δ2 under size cap intentional).

## Test plan

- [x] Unit: `resolveRectSlot` prefers `xBinId` when it disagrees with center scan
- [x] Unit: `xBinId === -1` drops the row
- [x] Pipeline: unequal explicit bin widths → proportional rect widths
- [x] Pipeline: out-of-range x rows omitted from rect batch
- [x] Existing binned position + bin-id suites green