### PR TITLE
test(core): characterize faceted temporal summary lineage (#437)

### DIFF
--- a/packages/core/src/pipeline/candidate-construction/identity-index.ts
+++ b/packages/core/src/pipeline/candidate-construction/identity-index.ts
@@ -56,8 +56,11 @@ export function buildCandidateIdentityIndex(
       // Only count/summary/boxplot resolve via group×x buckets; skip for other layers.
       const bucketByX = stat === "count" || stat === "summary" || stat === "boxplot";
       const xField = frame.binding.xField;
-      // Finite-y membership uses panel-local table indexes (localRow), then stores
-      // source-table rows — same mapping as sourceRowsByGroup itself.
+      // localRow → sourceRow invariant: panel-local table indexes drive
+      // parse/finite-y membership; stored memberships are always source-table
+      // rows via `facetPanel.sourceRows?.[localRow] ?? localRow` (unfaceted =
+      // identity). Faceted temporal summary/count must not intern localRow into
+      // LineageStore keys (#437).
       const yField = frame.binding.yField;
       const finiteY =
         (stat === "smooth" || stat === "summary" || stat === "boxplot") && yField !== null;

--- a/packages/core/tests/candidate-construction/aggregate-lineage.test.ts
+++ b/packages/core/tests/candidate-construction/aggregate-lineage.test.ts
@@ -80,6 +80,68 @@ describe("aggregate lineage index (issue #184)", () => {
     }
   });
 
+  /**
+   * Faceted temporal summary (#437): parse/finite-y use panel-local rows;
+   * buckets store source-table rows. Unequal panel membership + spelling
+   * variants must not leak local indexes into sourceRowsByGroupX.
+   */
+  it("faceted temporal summary group×x buckets use source rows and merge epoch spellings", async () => {
+    const { preparePanels } = await import("../../src/pipeline/prepare-panels.ts");
+    const { buildCandidateIdentityIndex } =
+      await import("../../src/pipeline/candidate-construction/identity-index.ts");
+    const { bandKey } = await import("../../src/scales/train.ts");
+    const { normalize } = await import("@ggsvelte/spec");
+
+    const prepared = preparePanels(
+      normalize(
+        gg(
+          [
+            { region: "north", when: "1/2/2025", value: 1 },
+            { region: "north", when: "01/02/2025", value: 3 },
+            { region: "north", when: "02/02/2025", value: 5 },
+            { region: "south", when: "1/2/2025", value: 10 },
+            { region: "south", when: "03/02/2025", value: 7 },
+          ],
+          aes({ x: "when", y: "value" }),
+        )
+          .geomErrorbar({ stat: "summary" })
+          .facet({ wrap: "region" })
+          .scaleXDate({ parse: "dmy", nice: false })
+          .spec(),
+      ),
+      size,
+      [],
+      [],
+    );
+
+    expect(prepared.facetPanels.map((p) => ({ label: p.label, sourceRows: p.sourceRows }))).toEqual(
+      [
+        { label: "north", sourceRows: [0, 1, 2] },
+        { label: "south", sourceRows: [3, 4] },
+      ],
+    );
+
+    const index = buildCandidateIdentityIndex(prepared.panelFrames, prepared.facetPanels);
+    // dmy: 1/2/2025 ≡ 01/02/2025 → 2025-02-01 UTC
+    const day1 = bandKey(Date.UTC(2025, 1, 1));
+    const day2 = bandKey(Date.UTC(2025, 1, 2));
+    const day3 = bandKey(Date.UTC(2025, 1, 3));
+
+    // Panel 0 (north): local rows 0..2 → source 0..2; spellings merge on day1.
+    expect(index.sourceRowsByGroup.get("0:0:0")).toEqual([0, 1, 2]);
+    expect(index.sourceRowsByGroupX.get(`0:0:0:${day1}`)).toEqual([0, 1]);
+    expect(index.sourceRowsByGroupX.get(`0:0:0:${day2}`)).toEqual([2]);
+    // Panel 1 (south): local 0,1 → source 3,4 — not [0,1].
+    expect(index.sourceRowsByGroup.get("1:0:0")).toEqual([3, 4]);
+    expect(index.sourceRowsByGroupX.get(`1:0:0:${day1}`)).toEqual([3]);
+    expect(index.sourceRowsByGroupX.get(`1:0:0:${day3}`)).toEqual([4]);
+    // No local-index pollution: south must never claim source rows 0–2.
+    for (const [key, rows] of index.sourceRowsByGroupX) {
+      if (!key.startsWith("1:")) continue;
+      expect(rows.every((row) => row >= 3)).toBe(true);
+    }
+  });
+
   it("does not build group×x buckets for identity layers that never consume them", async () => {
     const { preparePanels } = await import("../../src/pipeline/prepare-panels.ts");
     const { buildCandidateIdentityIndex } =

--- a/packages/core/tests/candidate-construction/pipeline-build.test.ts
+++ b/packages/core/tests/candidate-construction/pipeline-build.test.ts
@@ -103,6 +103,50 @@ describe("buildPipelineCandidates via runPipeline", () => {
     expect(memberships.every((rows) => rows.length > 0)).toBe(true);
   });
 
+  /**
+   * Combined facet + temporal summary path (#437): unequal panel membership
+   * with local-row parsing must still intern source-table lineage keys.
+   */
+  it("faceted temporal summary marks carry exact source-row lineage memberships", () => {
+    const model = runPipeline(
+      gg(
+        [
+          { region: "north", when: "1/2/2025", value: 1 },
+          { region: "north", when: "01/02/2025", value: 3 },
+          { region: "north", when: "02/02/2025", value: 5 },
+          { region: "south", when: "1/2/2025", value: 10 },
+          { region: "south", when: "03/02/2025", value: 7 },
+        ],
+        aes({ x: "when", y: "value" }),
+      )
+        .geomErrorbar({ stat: "summary" })
+        .facet({ wrap: "region" })
+        .scaleXDate({ parse: "dmy", nice: false })
+        .spec(),
+      size,
+    );
+
+    const byPanel = new Map<string, Set<string>>();
+    for (let id = 0; id < model.candidates.size; id++) {
+      const c = model.candidates.candidate(id)!;
+      const rows = [...model.lineage.keys(c.lineage)].toSorted((a, b) => a - b);
+      const key = rows.join(",");
+      const panel = c.panelId;
+      const set = byPanel.get(panel) ?? new Set<string>();
+      set.add(key);
+      byPanel.set(panel, set);
+    }
+
+    const north = [...byPanel.entries()].find(([id]) => id.includes("north"));
+    const south = [...byPanel.entries()].find(([id]) => id.includes("south"));
+    expect(north).toBeDefined();
+    expect(south).toBeDefined();
+    // North: merged spelling pair [0,1] + singleton day-2 [2].
+    expect(north![1]).toEqual(new Set(["0,1", "2"]));
+    // South: source rows 3 and 4 only (local 0,1 in that panel).
+    expect(south![1]).toEqual(new Set(["3", "4"]));
+  });
+
   it("bin layers intern source rows using closed bin edges", () => {
     const model = runPipeline(
       {


### PR DESCRIPTION
## Summary

Closes #437. Characterization for the combined faceted + temporal summary lineage path.

### Index path
- Facet-wrap temporal summary with unequal panel membership
- Asserts `sourceRowsByGroup` / `sourceRowsByGroupX` store **source** rows (south: 3,4 not local 0,1)
- Confirms dmy spelling variants merge on the same epoch within a panel

### E2E path
- `runPipeline` errorbar summary marks: north lineages `{0,1}` and `{2}`; south `{3}` and `{4}`

### Docs
- Documents the localRow to sourceRow invariant next to the identity-index build loop

## Tests

`bun test packages/core/tests/candidate-construction/aggregate-lineage.test.ts packages/core/tests/candidate-construction/pipeline-build.test.ts` (16 pass)
