### PR TITLE
test(spec): co-locate temporal tests with parse/column/helpers modules

### DIFF
--- a/.changeset/spec-temporal-test-split.md
+++ b/.changeset/spec-temporal-test-split.md
@@ -1,0 +1,7 @@
+---
+"@ggsvelte/spec": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+Split the long temporal characterization suite into parse, column, and helpers test files co-located with the temporal production modules. No runtime behavior change.

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "fmt": "bun node_modules/.bin/oxfmt && bun node_modules/.bin/prettier --write --log-level warn \"**/*.{svelte,md,yml,yaml}\"",
     "fmt:check": "bun node_modules/.bin/oxfmt --check && bun node_modules/.bin/prettier --check --log-level warn \"**/*.{svelte,md,yml,yaml}\"",
     "test": "bun test packages/spec packages/core benchmarks scripts tests/evals",
-    "test:temporal-parser": "bun test packages/spec/tests/temporal.test.ts packages/spec/tests/temporal-scale-schema.test.ts packages/spec/tests/temporal-scale-authoring.test.ts packages/spec/tests/temporal-source-gate.test.ts packages/core/tests/table-temporal.test.ts",
+    "test:temporal-parser": "bun test packages/spec/tests/temporal-parse.test.ts packages/spec/tests/temporal-column.test.ts packages/spec/tests/temporal-helpers.test.ts packages/spec/tests/temporal-scale-schema.test.ts packages/spec/tests/temporal-scale-authoring.test.ts packages/spec/tests/temporal-source-gate.test.ts packages/core/tests/table-temporal.test.ts",
     "test:temporal-pipeline": "bun test packages/core/tests/pipeline-temporal packages/core/tests/ticks.test.ts",
     "test:spikes": "cd spikes/browser && bun run --bun test",
     "test:visual": "bun node_modules/.bin/playwright test --config tests/visual/playwright.config.ts",

--- a/packages/spec/tests/temporal-column.test.ts
+++ b/packages/spec/tests/temporal-column.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Column temporal inference / materialization (packages/spec/src/temporal-column.ts).
+ * Value parsing: temporal-parse.test.ts. Authoring helpers: temporal-helpers.test.ts.
+ */
+import { describe, expect, it } from "bun:test";
+
+import { inferTemporalColumn, parseTemporalColumn } from "../src/temporal.ts";
+
+describe("value-driven temporal inference", () => {
+  it("infers string years but keeps numeric years quantitative/non-temporal", () => {
+    const years = inferTemporalColumn(["1835", "1900", null, "2026"]);
+    expect(years).toMatchObject({
+      status: "temporal",
+      parser: "year",
+      precision: "year",
+      validatedCount: 3,
+    });
+    expect(inferTemporalColumn([1835, 1900, 2026])).toMatchObject({ status: "nominal" });
+    expect(inferTemporalColumn([1835, "1900", "2026"])).toMatchObject({ status: "nominal" });
+  });
+
+  it("infers ISO, year-month, month-year, and year-quarter families", () => {
+    expect(inferTemporalColumn(["2024-01-01", "2024-02-03"])).toMatchObject({
+      status: "temporal",
+      parser: "iso",
+    });
+    expect(inferTemporalColumn(["2024-01", "2024-02"])).toMatchObject({
+      status: "temporal",
+      parser: "ym",
+    });
+    expect(inferTemporalColumn(["01-2024", "02-2024"])).toMatchObject({
+      status: "temporal",
+      parser: "my",
+    });
+    expect(inferTemporalColumn(["2024-Q1", "2024-Q4"])).toMatchObject({
+      status: "temporal",
+      parser: "yq",
+    });
+  });
+
+  it("does not guess ambiguous date orders or two-digit years", () => {
+    const ambiguous = inferTemporalColumn(["03/04/2024", "05/06/2024"]);
+    expect(ambiguous.status).toBe("ambiguous");
+    expect(ambiguous.candidates).toContain("mdy");
+    expect(ambiguous.candidates).toContain("dmy");
+    expect(inferTemporalColumn(["03/04/24", "05/06/24"])).toMatchObject({ status: "nominal" });
+  });
+
+  it("uses bounded head/tail classification then validates the whole column", () => {
+    const values = Array.from({ length: 100 }, (_, index) => `${1900 + index}`);
+    values[50] = "not-a-year";
+    const decision = inferTemporalColumn(values);
+    expect(decision).toMatchObject({ status: "invalid", failedCount: 1, validatedCount: 99 });
+    expect(decision.failures?.[0]?.value).toBe("not-a-year");
+  });
+
+  it("reports the finest precision independent of row order", () => {
+    const coarseFirst = inferTemporalColumn(["2024-01-01", "2024-01-02T12:30:45"]);
+    const fineFirst = inferTemporalColumn(["2024-01-02T12:30:45", "2024-01-01"]);
+    expect(coarseFirst.precision).toBe("second");
+    expect(fineFirst.precision).toBe("second");
+    expect(
+      parseTemporalColumn(["2024-01-01", "2024-01-02T12:30:45"], "iso").decision.precision,
+    ).toBe("second");
+  });
+
+  it("accepts Date plus compatible ISO values and rejects incoherent mixtures", () => {
+    expect(inferTemporalColumn([new Date("2024-01-01T00:00:00Z"), "2024-01-02"])).toMatchObject({
+      status: "temporal",
+      parser: "iso",
+    });
+    expect(inferTemporalColumn([new Date("2024-01-01T00:00:00Z"), "hello"])).toMatchObject({
+      status: "nominal",
+    });
+    expect(inferTemporalColumn([new Date("2024-01-01T00:00:00Z"), "2025"])).toMatchObject({
+      status: "nominal",
+    });
+  });
+
+  /**
+   * Regression for O(1)-memory sampling (#analyzeNonNull): number/boolean or
+   * mixed non-Date values outside the 64-value head/tail sample must still
+   * force nominal / full-column invalidation (full-column facts, not sample).
+   */
+  it("rejects number/boolean and mixed Date noise outside the head/tail sample window", () => {
+    const years = Array.from({ length: 200 }, (_, index) => `${1800 + index}`);
+    years[100] = 42 as unknown as string;
+    expect(inferTemporalColumn(years)).toMatchObject({
+      status: "nominal",
+      nonNullCount: 200,
+    });
+
+    const iso = Array.from(
+      { length: 200 },
+      (_, index) => `2024-01-${String((index % 28) + 1).padStart(2, "0")}`,
+    );
+    iso[100] = true as unknown as string;
+    expect(inferTemporalColumn(iso)).toMatchObject({ status: "nominal" });
+
+    const dates = Array.from(
+      { length: 200 },
+      (_, index) => new Date(Date.UTC(2024, 0, (index % 28) + 1)),
+    );
+    dates[100] = "not-a-date" as unknown as Date;
+    // Native Date column with an off-sample non-Date fails whole-column validation.
+    expect(inferTemporalColumn(dates).status).toBe("invalid");
+  });
+
+  it("keeps head/tail sample evidence for large temporal columns", () => {
+    const values = Array.from({ length: 200 }, (_, index) => `${1900 + index}`);
+    const decision = inferTemporalColumn(values);
+    expect(decision).toMatchObject({
+      status: "temporal",
+      parser: "year",
+      nonNullCount: 200,
+      validatedCount: 200,
+    });
+    expect(decision.evidence[0]).toBe("1900");
+    expect(decision.evidence).toHaveLength(8);
+  });
+});

--- a/packages/spec/tests/temporal-helpers.test.ts
+++ b/packages/spec/tests/temporal-helpers.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Temporal authoring helpers and parser identity keys (packages/spec/src/temporal.ts facade).
+ * Value parsing: temporal-parse.test.ts. Column inference: temporal-column.test.ts.
+ */
+import { describe, expect, it } from "bun:test";
+
+import {
+  canonicalTemporalParserKey,
+  TemporalParseError,
+  ymd,
+  dmy,
+  yq,
+  fromEpochSeconds,
+} from "../src/temporal.ts";
+
+describe("temporal authoring helpers and parser identity", () => {
+  it("returns Dates for scalar and array helpers", () => {
+    expect(ymd("2024-02-29")).toBeInstanceOf(Date);
+    expect(dmy(["31/12/2024", "01/01/2025"])).toHaveLength(2);
+    expect(yq("2024-Q2").toISOString()).toStartWith("2024-04-01T00:00:00.000Z");
+    expect(fromEpochSeconds(1_700_000_000).getTime()).toBe(1_700_000_000_000);
+    expect(() => ymd("2024-02-30")).toThrow(TemporalParseError);
+  });
+
+  it("canonicalizes semantic parser identities", () => {
+    expect(canonicalTemporalParserKey("dmy")).toBe("name:dmy");
+    expect(canonicalTemporalParserKey({ epoch: "seconds" })).toBe("epoch:seconds");
+    expect(canonicalTemporalParserKey({ format: "%Y-%m-%d" })).toBe(
+      canonicalTemporalParserKey({ format: "%Y-%m-%d" }),
+    );
+  });
+});

--- a/packages/spec/tests/temporal-parse.test.ts
+++ b/packages/spec/tests/temporal-parse.test.ts
@@ -1,17 +1,14 @@
+/**
+ * Value-level temporal parsing characterization (packages/spec/src/temporal-parse.ts).
+ * Column inference: temporal-column.test.ts. Authoring helpers: temporal-helpers.test.ts.
+ */
 import { describe, expect, it } from "bun:test";
 
 import {
-  canonicalTemporalParserKey,
-  inferTemporalColumn,
   parseTemporal,
   parseTemporalColumn,
   parseTemporalFormat,
   temporalParserConfigurationError,
-  TemporalParseError,
-  ymd,
-  dmy,
-  yq,
-  fromEpochSeconds,
 } from "../src/temporal.ts";
 
 describe("strict temporal parsing", () => {
@@ -248,137 +245,5 @@ describe("strict temporal parsing", () => {
       Date.parse("2024-03-10T06:30:00.000Z"),
       Date.parse("2024-03-10T07:30:00.000Z"),
     ]);
-  });
-});
-
-describe("value-driven temporal inference", () => {
-  it("infers string years but keeps numeric years quantitative/non-temporal", () => {
-    const years = inferTemporalColumn(["1835", "1900", null, "2026"]);
-    expect(years).toMatchObject({
-      status: "temporal",
-      parser: "year",
-      precision: "year",
-      validatedCount: 3,
-    });
-    expect(inferTemporalColumn([1835, 1900, 2026])).toMatchObject({ status: "nominal" });
-    expect(inferTemporalColumn([1835, "1900", "2026"])).toMatchObject({ status: "nominal" });
-  });
-
-  it("infers ISO, year-month, month-year, and year-quarter families", () => {
-    expect(inferTemporalColumn(["2024-01-01", "2024-02-03"])).toMatchObject({
-      status: "temporal",
-      parser: "iso",
-    });
-    expect(inferTemporalColumn(["2024-01", "2024-02"])).toMatchObject({
-      status: "temporal",
-      parser: "ym",
-    });
-    expect(inferTemporalColumn(["01-2024", "02-2024"])).toMatchObject({
-      status: "temporal",
-      parser: "my",
-    });
-    expect(inferTemporalColumn(["2024-Q1", "2024-Q4"])).toMatchObject({
-      status: "temporal",
-      parser: "yq",
-    });
-  });
-
-  it("does not guess ambiguous date orders or two-digit years", () => {
-    const ambiguous = inferTemporalColumn(["03/04/2024", "05/06/2024"]);
-    expect(ambiguous.status).toBe("ambiguous");
-    expect(ambiguous.candidates).toContain("mdy");
-    expect(ambiguous.candidates).toContain("dmy");
-    expect(inferTemporalColumn(["03/04/24", "05/06/24"])).toMatchObject({ status: "nominal" });
-  });
-
-  it("uses bounded head/tail classification then validates the whole column", () => {
-    const values = Array.from({ length: 100 }, (_, index) => `${1900 + index}`);
-    values[50] = "not-a-year";
-    const decision = inferTemporalColumn(values);
-    expect(decision).toMatchObject({ status: "invalid", failedCount: 1, validatedCount: 99 });
-    expect(decision.failures?.[0]?.value).toBe("not-a-year");
-  });
-
-  it("reports the finest precision independent of row order", () => {
-    const coarseFirst = inferTemporalColumn(["2024-01-01", "2024-01-02T12:30:45"]);
-    const fineFirst = inferTemporalColumn(["2024-01-02T12:30:45", "2024-01-01"]);
-    expect(coarseFirst.precision).toBe("second");
-    expect(fineFirst.precision).toBe("second");
-    expect(
-      parseTemporalColumn(["2024-01-01", "2024-01-02T12:30:45"], "iso").decision.precision,
-    ).toBe("second");
-  });
-
-  it("accepts Date plus compatible ISO values and rejects incoherent mixtures", () => {
-    expect(inferTemporalColumn([new Date("2024-01-01T00:00:00Z"), "2024-01-02"])).toMatchObject({
-      status: "temporal",
-      parser: "iso",
-    });
-    expect(inferTemporalColumn([new Date("2024-01-01T00:00:00Z"), "hello"])).toMatchObject({
-      status: "nominal",
-    });
-    expect(inferTemporalColumn([new Date("2024-01-01T00:00:00Z"), "2025"])).toMatchObject({
-      status: "nominal",
-    });
-  });
-
-  /**
-   * Regression for O(1)-memory sampling (#analyzeNonNull): number/boolean or
-   * mixed non-Date values outside the 64-value head/tail sample must still
-   * force nominal / full-column invalidation (full-column facts, not sample).
-   */
-  it("rejects number/boolean and mixed Date noise outside the head/tail sample window", () => {
-    const years = Array.from({ length: 200 }, (_, index) => `${1800 + index}`);
-    years[100] = 42 as unknown as string;
-    expect(inferTemporalColumn(years)).toMatchObject({
-      status: "nominal",
-      nonNullCount: 200,
-    });
-
-    const iso = Array.from(
-      { length: 200 },
-      (_, index) => `2024-01-${String((index % 28) + 1).padStart(2, "0")}`,
-    );
-    iso[100] = true as unknown as string;
-    expect(inferTemporalColumn(iso)).toMatchObject({ status: "nominal" });
-
-    const dates = Array.from(
-      { length: 200 },
-      (_, index) => new Date(Date.UTC(2024, 0, (index % 28) + 1)),
-    );
-    dates[100] = "not-a-date" as unknown as Date;
-    // Native Date column with an off-sample non-Date fails whole-column validation.
-    expect(inferTemporalColumn(dates).status).toBe("invalid");
-  });
-
-  it("keeps head/tail sample evidence for large temporal columns", () => {
-    const values = Array.from({ length: 200 }, (_, index) => `${1900 + index}`);
-    const decision = inferTemporalColumn(values);
-    expect(decision).toMatchObject({
-      status: "temporal",
-      parser: "year",
-      nonNullCount: 200,
-      validatedCount: 200,
-    });
-    expect(decision.evidence[0]).toBe("1900");
-    expect(decision.evidence).toHaveLength(8);
-  });
-});
-
-describe("temporal authoring helpers and parser identity", () => {
-  it("returns Dates for scalar and array helpers", () => {
-    expect(ymd("2024-02-29")).toBeInstanceOf(Date);
-    expect(dmy(["31/12/2024", "01/01/2025"])).toHaveLength(2);
-    expect(yq("2024-Q2").toISOString()).toStartWith("2024-04-01T00:00:00.000Z");
-    expect(fromEpochSeconds(1_700_000_000).getTime()).toBe(1_700_000_000_000);
-    expect(() => ymd("2024-02-30")).toThrow(TemporalParseError);
-  });
-
-  it("canonicalizes semantic parser identities", () => {
-    expect(canonicalTemporalParserKey("dmy")).toBe("name:dmy");
-    expect(canonicalTemporalParserKey({ epoch: "seconds" })).toBe("epoch:seconds");
-    expect(canonicalTemporalParserKey({ format: "%Y-%m-%d" })).toBe(
-      canonicalTemporalParserKey({ format: "%Y-%m-%d" }),
-    );
   });
 });


### PR DESCRIPTION
## Summary

Maintainability pass on `packages/spec` found production modules largely post-split and cohesive. Remaining high-confidence win: co-locate the long temporal characterization suite with the production layout.

| Test file | Production home |
|-----------|-----------------|
| `temporal-parse.test.ts` | `temporal-parse.ts` value engines |
| `temporal-column.test.ts` | `temporal-column.ts` inference |
| `temporal-helpers.test.ts` | `temporal.ts` authoring helpers + keys |

Updated root `test:temporal-parser` script paths. No runtime behavior change.

## Audit note

Remaining large production files (`schema-declarations`, `temporal-parse`, `builder`, `validate-map-errors`, `validate-data-checks`) are pure `$defs` or cohesive after prior splits — kept rather than forced further cuts.

## Verification

- [x] `bun test packages/spec` (341 pass)
- [x] `bun test packages/spec/tests/temporal-parse.test.ts packages/spec/tests/temporal-column.test.ts packages/spec/tests/temporal-helpers.test.ts`