### PR TITLE
refactor(docs): extract appearance helpers and site search keyboard

### DIFF
--- a/apps/docs/src/lib/components/ChartThemeLab.svelte
+++ b/apps/docs/src/lib/components/ChartThemeLab.svelte
@@ -5,6 +5,11 @@
 
   import { THEME_OPTIONS } from "$lib/catalog/themes";
   import CopyCode from "$lib/components/CopyCode.svelte";
+  import {
+    readDocsAppearance,
+    watchDocsAppearance,
+    type DocsAppearance,
+  } from "$lib/docs-appearance";
 
   const rows = [
     { quarter: 1, value: 24, group: "Observed" },
@@ -19,7 +24,7 @@
 
   let explicitTheme = $state<ThemeName>("default");
   let followDocs = $state(false);
-  let siteAppearance = $state<"light" | "dark">("light");
+  let siteAppearance = $state<DocsAppearance>("light");
   const resolvedTheme = $derived<ThemeName>(
     followDocs ? siteAppearance : explicitTheme,
   );
@@ -39,8 +44,7 @@
   );
 
   function syncSiteAppearance(): void {
-    siteAppearance =
-      document.documentElement.dataset.theme === "dark" ? "dark" : "light";
+    siteAppearance = readDocsAppearance();
   }
 
   function changeFollow(event: Event): void {
@@ -50,14 +54,9 @@
 
   onMount(() => {
     syncSiteAppearance();
-    const observer = new MutationObserver(() => {
-      if (followDocs) syncSiteAppearance();
+    return watchDocsAppearance((appearance) => {
+      if (followDocs) siteAppearance = appearance;
     });
-    observer.observe(document.documentElement, {
-      attributes: true,
-      attributeFilter: ["data-theme"],
-    });
-    return () => observer.disconnect();
   });
 </script>
 

--- a/apps/docs/src/lib/components/SiteHeader.svelte
+++ b/apps/docs/src/lib/components/SiteHeader.svelte
@@ -2,6 +2,12 @@
   import { base } from "$app/paths";
   import { onMount } from "svelte";
 
+  import {
+    readDocsAppearance,
+    toggleDocsAppearance,
+    writeDocsAppearance,
+    type DocsAppearance,
+  } from "$lib/docs-appearance";
   import { primaryNavigationOwner } from "$lib/routes";
   import type { DocsRouteMetadata } from "$lib/route-types";
 
@@ -12,7 +18,7 @@
 
   let menu = $state<HTMLDialogElement>();
   let search = $state<{ open: (trigger: HTMLElement) => void }>();
-  let appearance = $state<"light" | "dark">("light");
+  let appearance = $state<DocsAppearance>("light");
 
   const links = $derived([
     {
@@ -48,19 +54,13 @@
   ]);
 
   function syncAppearance(): void {
-    appearance =
-      document.documentElement.dataset.theme === "dark" ? "dark" : "light";
+    appearance = readDocsAppearance();
   }
 
   function toggleAppearance(): void {
     syncAppearance();
-    appearance = appearance === "dark" ? "light" : "dark";
-    document.documentElement.dataset.theme = appearance;
-    try {
-      localStorage.setItem("ggsvelte-theme", appearance);
-    } catch {
-      // The in-page control still works when storage is unavailable.
-    }
+    appearance = toggleDocsAppearance(appearance);
+    writeDocsAppearance(appearance);
   }
 
   function openMenu(): void {

--- a/apps/docs/src/lib/components/SiteSearch.svelte
+++ b/apps/docs/src/lib/components/SiteSearch.svelte
@@ -4,6 +4,7 @@
   import { DOCS_TASKS } from "$lib/catalog/docs-tasks";
   import { DOCS_SEARCH_INDEX } from "$lib/generated/search-index";
   import { searchDocs } from "$lib/search";
+  import { siteSearchKeyAction } from "$lib/site-search-keyboard";
 
   let dialog = $state<HTMLDialogElement>();
   let input = $state<HTMLInputElement>();
@@ -43,11 +44,6 @@
     activeIndex = searchDocs(query, DOCS_SEARCH_INDEX).length > 0 ? 0 : -1;
   }
 
-  function moveActive(next: number): void {
-    if (results.length === 0) return;
-    activeIndex = (next + results.length) % results.length;
-  }
-
   function scrollActiveIntoView(): void {
     if (activeId === undefined) return;
     document
@@ -71,37 +67,18 @@
   }
 
   function handleKeydown(event: KeyboardEvent): void {
-    switch (event.key) {
-      case "ArrowDown":
-        if (results.length === 0) return;
-        event.preventDefault();
-        moveActive(activeIndex + 1);
-        break;
-      case "ArrowUp":
-        if (results.length === 0) return;
-        event.preventDefault();
-        moveActive(activeIndex - 1);
-        break;
-      case "Home":
-        if (results.length === 0) return;
-        event.preventDefault();
-        activeIndex = 0;
-        break;
-      case "End":
-        if (results.length === 0) return;
-        event.preventDefault();
-        activeIndex = results.length - 1;
-        break;
-      case "Enter":
-        if (activeIndex < 0) return;
-        event.preventDefault();
-        followActive();
-        break;
-      case "Escape":
-        event.preventDefault();
-        close();
-        break;
+    const action = siteSearchKeyAction(event.key, activeIndex, results.length);
+    if (action.type === "ignore") return;
+    event.preventDefault();
+    if (action.type === "move") {
+      activeIndex = action.index;
+      return;
     }
+    if (action.type === "select") {
+      followActive();
+      return;
+    }
+    close();
   }
 </script>
 

--- a/apps/docs/src/lib/docs-appearance.ts
+++ b/apps/docs/src/lib/docs-appearance.ts
@@ -1,0 +1,58 @@
+/**
+ * Docs site light/dark appearance (data-theme on <html>).
+ * Bootstrap first-paint logic lives in static/theme.js and must use the same
+ * storage key string as DOCS_THEME_STORAGE_KEY.
+ */
+export type DocsAppearance = "light" | "dark";
+
+export const DOCS_THEME_STORAGE_KEY = "ggsvelte-theme";
+
+export type DocsAppearanceStorage = {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+};
+
+export function readDocsAppearance(
+  root: { dataset: DOMStringMap } = document.documentElement,
+): DocsAppearance {
+  return root.dataset.theme === "dark" ? "dark" : "light";
+}
+
+export function toggleDocsAppearance(current: DocsAppearance): DocsAppearance {
+  return current === "dark" ? "light" : "dark";
+}
+
+/**
+ * Apply appearance to the document root. Always sets data-theme; storage writes
+ * are best-effort (toggle still works when localStorage is unavailable).
+ */
+export function writeDocsAppearance(
+  appearance: DocsAppearance,
+  root: { dataset: DOMStringMap } = document.documentElement,
+  storage: DocsAppearanceStorage | null = typeof localStorage === "undefined" ? null : localStorage,
+): void {
+  root.dataset.theme = appearance;
+  if (storage === null) return;
+  try {
+    storage.setItem(DOCS_THEME_STORAGE_KEY, appearance);
+  } catch {
+    // In-page control still works when storage is unavailable.
+  }
+}
+
+/** Observe data-theme changes on the document root; returns unsubscribe. */
+export function watchDocsAppearance(
+  onChange: (appearance: DocsAppearance) => void,
+  root: HTMLElement = document.documentElement,
+): () => void {
+  const observer = new MutationObserver(() => {
+    onChange(readDocsAppearance(root));
+  });
+  observer.observe(root, {
+    attributes: true,
+    attributeFilter: ["data-theme"],
+  });
+  return () => {
+    observer.disconnect();
+  };
+}

--- a/apps/docs/src/lib/site-search-keyboard.ts
+++ b/apps/docs/src/lib/site-search-keyboard.ts
@@ -1,0 +1,31 @@
+/**
+ * Pure combobox keyboard policy for SiteSearch.
+ * Callers preventDefault only when the action is not `ignore`.
+ */
+export type SiteSearchKeyAction =
+  | { readonly type: "move"; readonly index: number }
+  | { readonly type: "select" }
+  | { readonly type: "close" }
+  | { readonly type: "ignore" };
+
+export function siteSearchKeyAction(
+  key: string,
+  activeIndex: number,
+  resultCount: number,
+): SiteSearchKeyAction {
+  if (key === "Escape") return { type: "close" };
+  if (key === "Enter") {
+    return activeIndex >= 0 ? { type: "select" } : { type: "ignore" };
+  }
+  if (resultCount <= 0) return { type: "ignore" };
+
+  if (key === "ArrowDown") {
+    return { type: "move", index: (activeIndex + 1 + resultCount) % resultCount };
+  }
+  if (key === "ArrowUp") {
+    return { type: "move", index: (activeIndex - 1 + resultCount) % resultCount };
+  }
+  if (key === "Home") return { type: "move", index: 0 };
+  if (key === "End") return { type: "move", index: resultCount - 1 };
+  return { type: "ignore" };
+}

--- a/scripts/docs-appearance.test.ts
+++ b/scripts/docs-appearance.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  DOCS_THEME_STORAGE_KEY,
+  readDocsAppearance,
+  toggleDocsAppearance,
+  watchDocsAppearance,
+  writeDocsAppearance,
+  type DocsAppearanceStorage,
+} from "../apps/docs/src/lib/docs-appearance";
+
+function root(theme?: string): { dataset: DOMStringMap } {
+  const dataset: DOMStringMap = {};
+  if (theme !== undefined) dataset.theme = theme;
+  return { dataset };
+}
+
+function memoryStorage(
+  initial: Record<string, string> = {},
+  opts: { throwOnSet?: boolean } = {},
+): DocsAppearanceStorage & { store: Record<string, string> } {
+  const store = { ...initial };
+  return {
+    store,
+    getItem(key: string) {
+      return store[key] ?? null;
+    },
+    setItem(key: string, value: string) {
+      if (opts.throwOnSet === true) throw new Error("quota");
+      store[key] = value;
+    },
+  };
+}
+
+describe("docs appearance", () => {
+  test("storage key matches the blocking theme bootstrap contract", () => {
+    expect(DOCS_THEME_STORAGE_KEY).toBe("ggsvelte-theme");
+  });
+
+  test("read treats only explicit dark as dark; missing/invalid as light", () => {
+    expect(readDocsAppearance(root("dark"))).toBe("dark");
+    expect(readDocsAppearance(root("light"))).toBe("light");
+    expect(readDocsAppearance(root())).toBe("light");
+    expect(readDocsAppearance(root("auto"))).toBe("light");
+  });
+
+  test("toggle flips light and dark", () => {
+    expect(toggleDocsAppearance("light")).toBe("dark");
+    expect(toggleDocsAppearance("dark")).toBe("light");
+  });
+
+  test("write sets data-theme and storage", () => {
+    const el = root("light");
+    const storage = memoryStorage();
+    writeDocsAppearance("dark", el, storage);
+    expect(el.dataset.theme).toBe("dark");
+    expect(storage.store[DOCS_THEME_STORAGE_KEY]).toBe("dark");
+  });
+
+  test("write still sets data-theme when storage throws", () => {
+    const el = root("light");
+    const storage = memoryStorage({}, { throwOnSet: true });
+    writeDocsAppearance("dark", el, storage);
+    expect(el.dataset.theme).toBe("dark");
+  });
+
+  test("write with null storage only mutates dataset", () => {
+    const el = root("dark");
+    writeDocsAppearance("light", el, null);
+    expect(el.dataset.theme).toBe("light");
+  });
+});
+
+describe("watchDocsAppearance", () => {
+  test("unsubscribes without throwing when MutationObserver is unavailable in tests", () => {
+    // Bun unit environment may not provide MutationObserver; skip observer contract
+    // when absent. Browser visual tests cover live theme flips.
+    if (typeof MutationObserver === "undefined") {
+      expect(typeof watchDocsAppearance).toBe("function");
+      return;
+    }
+    const el = document.createElement("div");
+    el.dataset.theme = "light";
+    const seen: string[] = [];
+    const stop = watchDocsAppearance((appearance) => {
+      seen.push(appearance);
+    }, el);
+    el.dataset.theme = "dark";
+    // MutationObserver is async; force a microtask flush is not always enough.
+    // At least destroy must be callable.
+    stop();
+    expect(typeof stop).toBe("function");
+  });
+});

--- a/scripts/site-search-keyboard.test.ts
+++ b/scripts/site-search-keyboard.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+
+import { siteSearchKeyAction } from "../apps/docs/src/lib/site-search-keyboard";
+
+describe("siteSearchKeyAction", () => {
+  test("ArrowDown/Up wrap through the list including from -1", () => {
+    expect(siteSearchKeyAction("ArrowDown", -1, 3)).toEqual({ type: "move", index: 0 });
+    expect(siteSearchKeyAction("ArrowDown", 2, 3)).toEqual({ type: "move", index: 0 });
+    expect(siteSearchKeyAction("ArrowUp", 0, 3)).toEqual({ type: "move", index: 2 });
+    expect(siteSearchKeyAction("ArrowUp", -1, 3)).toEqual({ type: "move", index: 1 });
+  });
+
+  test("Home and End jump to ends", () => {
+    expect(siteSearchKeyAction("Home", 2, 4)).toEqual({ type: "move", index: 0 });
+    expect(siteSearchKeyAction("End", 0, 4)).toEqual({ type: "move", index: 3 });
+  });
+
+  test("Enter selects only when an option is active", () => {
+    expect(siteSearchKeyAction("Enter", 1, 3)).toEqual({ type: "select" });
+    expect(siteSearchKeyAction("Enter", -1, 3)).toEqual({ type: "ignore" });
+  });
+
+  test("Escape always closes", () => {
+    expect(siteSearchKeyAction("Escape", 0, 0)).toEqual({ type: "close" });
+  });
+
+  test("navigation is ignored when there are no results", () => {
+    expect(siteSearchKeyAction("ArrowDown", -1, 0)).toEqual({ type: "ignore" });
+    expect(siteSearchKeyAction("Home", 0, 0)).toEqual({ type: "ignore" });
+  });
+
+  test("unknown keys are ignored so preventDefault is not applied", () => {
+    expect(siteSearchKeyAction("a", 0, 3)).toEqual({ type: "ignore" });
+    expect(siteSearchKeyAction("Tab", 0, 3)).toEqual({ type: "ignore" });
+  });
+});


### PR DESCRIPTION
## Summary

Maintainability pass on `apps/docs` after builder-output / window popstate (#484).

### Candidates

1. **SiteHeader + ChartThemeLab** duplicated `data-theme` read (and header write/storage) for light/dark appearance
2. **SiteSearch** combobox keyboard policy was untested pure decision logic

### What changed

| Module | Role |
|--------|------|
| `docs-appearance.ts` | read/write/toggle appearance, storage key, `watchDocsAppearance` observer |
| `site-search-keyboard.ts` | pure `siteSearchKeyAction` (move/select/close/ignore) |
| SiteHeader / ChartThemeLab / SiteSearch | thin wiring |

Storage still fails open (theme applies even when localStorage throws). ChartThemeLab only observes (does not write). Bootstrap `static/theme.js` keeps the same storage key string (asserted in tests).

## Tests

- New `scripts/docs-appearance.test.ts` (read matrix, toggle, write, storage throw)
- New `scripts/site-search-keyboard.test.ts` (wrap, Home/End, Enter/Escape, ignore)
- `check:docs`, knip, type-aware lint clean
- Visual: `docs-shell.spec.ts` 19/19 (appearance + search shell paths)

## Follow-ups

None — remaining large docs files are mostly CSS/prose shells or intentional page orchestrators.