### PR TITLE
refactor(svelte): collapse inspect pointer-frame protocol

### DIFF
--- a/packages/svelte/src/lib/inspection/frame.ts
+++ b/packages/svelte/src/lib/inspection/frame.ts
@@ -1,7 +1,8 @@
 /**
  * Pure decision tables for capture-surface inspection *frame* policy:
  * pointer-move queue payloads and onPointerFrame routing.
- * Callers own queue mutation and setInspection side effects.
+ * InspectionState owns queue mutation and setInspection side effects;
+ * these tables stay pure routing helpers.
  */
 
 import type { CandidateFacts, CandidateMatch } from "@ggsvelte/core";
@@ -128,21 +129,15 @@ export type QueuedInspectFrameAction =
   | { readonly type: "apply-pending" };
 
 /**
- * Pure decision for the inspect branch of `onPointerFrame` after the host
- * has snapshotted and cleared queue fields.
+ * Pure decision for the inspect branch of `onInspectPointerFrame` after
+ * InspectionState has snapshotted and cleared queue fields.
  *
- * Priority (matches current host):
+ * Priority:
  *   1. none — !hasPending
- *   2. drop — !tokenAccepted (stale frame token)
+ *   2. drop — !tokenAccepted (stale frame token) → skip reducer dispatch
  *   3. stash-pending — currentState === "pinned"
- *   4. drop — candidateEpochMismatch
+ *   4. drop — candidateEpochMismatch → skip reducer dispatch
  *   5. apply-pending
- *
- * Host sequencing: snapshot pending + token, clear `queuedPointerInspection`
- * and `queuedPointerToken`, then call this helper, then switch:
- *   none/drop → return
- *   stash-pending → `pendingPinnedPointer = pending`
- *   apply-pending → `setInspection(pending…, "transient", …)`
  */
 export function resolveQueuedInspectFrameAction(
   input: QueuedInspectFrameInput,

--- a/packages/svelte/src/lib/inspection/inspection-state.svelte.ts
+++ b/packages/svelte/src/lib/inspection/inspection-state.svelte.ts
@@ -21,11 +21,7 @@
 import type { CandidateFacts, CellValue, RenderModel, ScenePanel } from "@ggsvelte/core";
 
 import { createInspectionCoordinator } from "./coordinator.js";
-import type {
-  createInteractionReducer,
-  InteractionAction,
-  InteractionFrameToken,
-} from "../interaction/reducer.js";
+import type { createInteractionReducer, InteractionAction } from "../interaction/reducer.js";
 import type {
   InteractionSource,
   PlotInspection,
@@ -37,7 +33,11 @@ import { inspectionLiveText as inspectionLiveTextFor } from "../assembly/labels.
 import { plotTooltipDomId } from "../assembly/layout.js";
 import { panelContainingAnchor } from "../scene/geometry.js";
 import { hitFromCandidate, type SceneHit } from "../surface/plot-px.js";
-import { resolveQueuedInspectFrameAction, type QueuedPointerInspection } from "./frame.js";
+import {
+  buildQueuedInspectFrame,
+  resolveQueuedInspectFrameAction,
+  type QueuedPointerInspection,
+} from "./frame.js";
 import {
   resolveInspectionCompleteness,
   resolveInspectionMode,
@@ -97,6 +97,20 @@ export type InspectionStateDeps = {
   clearAnnouncement: () => void;
 };
 
+/** Intent for a coalesced pointer-inspect frame (nearest lookup owned here). */
+export type SchedulePointerInspectInput = {
+  readonly point: Readonly<{ x: number; y: number }>;
+  readonly source: InteractionSource;
+  readonly mode: "auto" | "exact" | "x" | "y" | "xy";
+  readonly maxDistance: number;
+};
+
+/** Cancel policy for pending pointer-inspect work. */
+export type CancelPointerInspectPolicy = {
+  /** Leave/clear: discard stash. Cancel/down/blur tool paths: preserve. */
+  readonly pendingPinned: "preserve" | "discard";
+};
+
 export type InspectionState = {
   readonly inspection: PlotInspectionChange<Record<string, CellValue>, PropertyKey> | null;
   readonly inspectionPanel: ScenePanel | null;
@@ -120,14 +134,20 @@ export type InspectionState = {
   /** Blur-path reset; scene-reconcile does NOT reset the index. */
   resetTraversalIndex(): void;
   /**
-   * Reducer onPointerFrame non-move-area branch: snapshot-then-clear queues,
-   * pure route, stash or setInspection apply.
+   * Schedule a coalesced pointer-inspect frame from pointer intent.
+   * Owns nearest/hitTest, queue payload+token, and reducer.queuePointer.
    */
-  applyQueuedInspectFrame(action: InspectPointerFrameAction): void;
-  queuePointerFrame(queued: QueuedPointerInspection, token: InteractionFrameToken): void;
-  /** Clears ONLY the queued payload (token stays). Matches every host clear site. */
-  clearQueuedPointer(): void;
-  clearPendingPinned(): void;
+  schedulePointerInspect(input: SchedulePointerInspectInput): void;
+  /**
+   * Cancel pending inspect schedule + clear queued payload.
+   * Does not cancel move-area (typed cancel on the reducer).
+   */
+  cancelPointerInspect(policy: CancelPointerInspectPolicy): void;
+  /**
+   * Reducer onPointerFrame inspect branch sink.
+   * Returns false when the frame is dropped so the reducer skips dispatch.
+   */
+  onInspectPointerFrame(action: InspectPointerFrameAction): boolean;
   /** Register disposal + scene-reconcile effects at the original host site. */
   registerInspectionEffects(): void;
 };
@@ -448,7 +468,54 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
     activeCandidateId = null;
   }
 
-  function applyQueuedInspectFrame(action: InspectPointerFrameAction): void {
+  function panelIdForIndex(index: number): string | null {
+    const panel = deps.model()?.scene.panels[index];
+    if (panel === undefined) return null;
+    return panel.id;
+  }
+
+  function schedulePointerInspect(input: SchedulePointerInspectInput): void {
+    const model = deps.model();
+    const match =
+      model?.candidates.nearest(input.point.x, input.point.y, {
+        mode: input.mode,
+        maxDistance: input.maxDistance,
+      }) ?? null;
+    const frame = buildQueuedInspectFrame({
+      match,
+      source: input.source,
+      epoch: model?.runId ?? 0,
+      fallbackCandidate: () => model?.candidates.hitTest(input.point.x, input.point.y) ?? null,
+      panelIdForIndex,
+    });
+    const reducer = deps.reducer();
+    queuedPointerInspection = frame.queued;
+    queuedPointerToken = reducer.frameToken();
+    try {
+      reducer.queuePointer({
+        type: "inspect",
+        candidate: frame.candidate,
+        source: input.source,
+      });
+    } catch (error) {
+      // No orphan payload if scheduling throws (Codex plan review).
+      queuedPointerInspection = null;
+      queuedPointerToken = null;
+      throw error;
+    }
+  }
+
+  function cancelPointerInspect(policy: CancelPointerInspectPolicy): void {
+    queuedPointerInspection = null;
+    if (policy.pendingPinned === "discard") pendingPinnedPointer = null;
+    deps.reducer().cancelScheduledPointer("inspect");
+  }
+
+  /**
+   * Inspect branch of onPointerFrame. Returns false on drop so the reducer
+   * skips dispatch (atomic with InspectionState — Codex plan review).
+   */
+  function onInspectPointerFrame(action: InspectPointerFrameAction): boolean {
     // Snapshot then clear queues before pure routing (matches prior host).
     const pending = queuedPointerInspection;
     const token = queuedPointerToken;
@@ -465,37 +532,26 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
     });
     switch (frameAction.type) {
       case "none":
+        // Empty frame: still allow reducer dispatch (prior host behavior when
+        // payload was cleared but a scheduled inspect still flushed).
+        return true;
       case "drop":
-        return;
+        return false;
       case "stash-pending":
-        if (pending === null) return;
-        pendingPinnedPointer = pending;
-        return;
+        if (pending !== null) pendingPinnedPointer = pending;
+        return true;
       case "apply-pending":
-        if (pending === null) return;
-        setInspection(
-          pending.hit,
-          pending.source,
-          "transient",
-          pending.concreteMode,
-          pending.candidate,
-        );
-        break;
+        if (pending !== null) {
+          setInspection(
+            pending.hit,
+            pending.source,
+            "transient",
+            pending.concreteMode,
+            pending.candidate,
+          );
+        }
+        return true;
     }
-  }
-
-  function queuePointerFrame(queued: QueuedPointerInspection, token: InteractionFrameToken): void {
-    queuedPointerInspection = queued;
-    queuedPointerToken = token;
-  }
-
-  function clearQueuedPointer(): void {
-    // Only the payload — token is NOT cleared (every host clear site).
-    queuedPointerInspection = null;
-  }
-
-  function clearPendingPinned(): void {
-    pendingPinnedPointer = null;
   }
 
   function registerInspectionEffects(): void {
@@ -597,10 +653,9 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
     navigateDirection,
     cycleCoincident,
     resetTraversalIndex,
-    applyQueuedInspectFrame,
-    queuePointerFrame,
-    clearQueuedPointer,
-    clearPendingPinned,
+    schedulePointerInspect,
+    cancelPointerInspect,
+    onInspectPointerFrame,
     registerInspectionEffects,
   };
 }

--- a/packages/svelte/src/lib/inspection/inspection-state.svelte.ts
+++ b/packages/svelte/src/lib/inspection/inspection-state.svelte.ts
@@ -98,7 +98,7 @@ export type InspectionStateDeps = {
 };
 
 /** Intent for a coalesced pointer-inspect frame (nearest lookup owned here). */
-export type SchedulePointerInspectInput = {
+type SchedulePointerInspectInput = {
   readonly point: Readonly<{ x: number; y: number }>;
   readonly source: InteractionSource;
   readonly mode: "auto" | "exact" | "x" | "y" | "xy";
@@ -106,7 +106,7 @@ export type SchedulePointerInspectInput = {
 };
 
 /** Cancel policy for pending pointer-inspect work. */
-export type CancelPointerInspectPolicy = {
+type CancelPointerInspectPolicy = {
   /** Leave/clear: discard stash. Cancel/down/blur tool paths: preserve. */
   readonly pendingPinned: "preserve" | "discard";
 };

--- a/packages/svelte/src/lib/inspection/inspection-state.svelte.ts
+++ b/packages/svelte/src/lib/inspection/inspection-state.svelte.ts
@@ -552,6 +552,7 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
         }
         return true;
     }
+    return true;
   }
 
   function registerInspectionEffects(): void {

--- a/packages/svelte/src/lib/interaction/reducer.ts
+++ b/packages/svelte/src/lib/interaction/reducer.ts
@@ -62,13 +62,19 @@ function sameCandidate(
   return a === b || (a !== null && b !== null && a.epoch === b.epoch && a.id === b.id);
 }
 
+export type PointerScheduleKind = "inspect" | "move-area";
+
 export function createInteractionReducer(
   options: {
     initialTool?: InteractionTool;
     onChange?: (state: InteractionReducerState) => void;
+    /**
+     * Continuous pointer-frame sink. Return `false` to skip the subsequent
+     * `dispatch` (atomic drop for stale inspect frames). Void/`true` dispatches.
+     */
     onPointerFrame?: (
       action: Extract<InteractionAction, { type: "inspect" | "move-area" }>,
-    ) => void;
+    ) => boolean | void;
     scheduleFrame?: (callback: () => void) => unknown;
     cancelFrame?: (handle: unknown) => void;
   } = {},
@@ -85,7 +91,16 @@ export function createInteractionReducer(
     null;
   let frameHandle: unknown = null;
 
-  const cancelScheduledPointer = (): void => {
+  /**
+   * Cancel the coalesced pointer schedule. With `kind`, cancel only when the
+   * queued action matches (inspect cancel must not kill move-area).
+   */
+  const cancelScheduledPointer = (kind?: PointerScheduleKind): void => {
+    if (
+      kind !== undefined &&
+      (scheduledPointerAction === null || scheduledPointerAction.type !== kind)
+    )
+      return;
     if (frameHandle !== null) options.cancelFrame?.(frameHandle);
     frameHandle = null;
     scheduledPointerAction = null;
@@ -215,8 +230,10 @@ export function createInteractionReducer(
         const latest = scheduledPointerAction;
         scheduledPointerAction = null;
         if (latest !== null) {
-          options.onPointerFrame?.(latest);
-          dispatch(latest);
+          // false = atomic drop (e.g. stale inspect token): skip dispatch so
+          // reducer inspection does not diverge from InspectionState.
+          const shouldDispatch = options.onPointerFrame?.(latest);
+          if (shouldDispatch !== false) dispatch(latest);
         }
       });
     },

--- a/packages/svelte/src/lib/surface/surface-state.svelte.ts
+++ b/packages/svelte/src/lib/surface/surface-state.svelte.ts
@@ -37,7 +37,7 @@ import {
 } from "../interval/query.js";
 import { BRUSH_SECOND_CORNER_ANNOUNCEMENT } from "../assembly/labels.js";
 import { hitFromCandidate, plotPointFromClient } from "./plot-px.js";
-import { buildQueuedInspectFrame } from "../inspection/frame.js";
+
 import {
   resolveSurfaceBlurAction,
   shouldClosePinnedOnOutsidePointer,
@@ -94,10 +94,9 @@ export type SurfaceStateDeps = {
     InspectionState,
     | "inspection"
     | "inspectionPanel"
-    | "applyQueuedInspectFrame"
-    | "queuePointerFrame"
-    | "clearQueuedPointer"
-    | "clearPendingPinned"
+    | "schedulePointerInspect"
+    | "cancelPointerInspect"
+    | "onInspectPointerFrame"
     | "setInspection"
     | "closeInspection"
     | "dismissInspection"
@@ -169,9 +168,9 @@ export function createSurfaceState(deps: SurfaceStateDeps): SurfaceState {
     onPointerFrame: (action) => {
       if (action.type === "move-area") {
         applyAreaMove(action.point, queuedAreaSource);
-      } else {
-        deps.inspection().applyQueuedInspectFrame(action);
+        return true;
       }
+      return deps.inspection().onInspectPointerFrame(action);
     },
   });
 
@@ -228,8 +227,9 @@ export function createSurfaceState(deps: SurfaceStateDeps): SurfaceState {
       case "apply":
         reducer.dispatch({ type: "set-tool", tool: next });
         brushRect = null;
-        deps.inspection().clearQueuedPointer();
-        reducer.cancelScheduledPointer();
+        // set-tool already full-cancels the schedule; clear inspect payload only
+        // (preserve pinned stash — matches prior clearQueuedPointer-only path).
+        deps.inspection().cancelPointerInspect({ pendingPinned: "preserve" });
         deps.ontoolchange()?.(next);
         break;
     }
@@ -243,13 +243,6 @@ export function createSurfaceState(deps: SurfaceStateDeps): SurfaceState {
     const scene = deps.model()?.scene;
     if (scene === undefined) return { x: 0, y: 0 };
     return plotPointFromClient(event.clientX, event.clientY, rect, scene);
-  }
-
-  /** Private — only consumer is the pointer-frame builder. */
-  function panelId(index: number): string | null {
-    const panel = deps.model()?.scene.panels[index];
-    if (panel === undefined) return null;
-    return panel.id;
   }
 
   function panelAtPoint(point: Readonly<{ x: number; y: number }>) {
@@ -277,37 +270,22 @@ export function createSurfaceState(deps: SurfaceStateDeps): SurfaceState {
     });
     switch (action.type) {
       case "touch-inspect-drag-cancel":
-        deps.inspection().clearQueuedPointer();
-        reducer.cancelScheduledPointer();
+        deps.inspection().cancelPointerInspect({ pendingPinned: "preserve" });
         return;
       case "queue-area-move":
         queuedAreaSource = action.source;
         reducer.queuePointer({ type: "move-area", point: p });
         return;
-      case "queue-inspect": {
+      case "queue-inspect":
         // mode/maxDistance from pure snapshot — no inspect config re-gate.
-        const model = deps.model();
-        const match =
-          model?.candidates.nearest(p.x, p.y, {
-            mode: action.mode,
-            maxDistance: action.maxDistance,
-          }) ?? null;
-        // One null branch for exact-geometry fallback + reducer candidate.
-        const frame = buildQueuedInspectFrame({
-          match,
+        // Inspection owns nearest lookup, token, and reducer.queuePointer.
+        deps.inspection().schedulePointerInspect({
+          point: p,
           source: action.source,
-          epoch: model?.runId ?? 0,
-          fallbackCandidate: () => model?.candidates.hitTest(p.x, p.y) ?? null,
-          panelIdForIndex: (index) => panelId(index),
-        });
-        deps.inspection().queuePointerFrame(frame.queued, reducer.frameToken());
-        reducer.queuePointer({
-          type: "inspect",
-          candidate: frame.candidate,
-          source: action.source,
+          mode: action.mode,
+          maxDistance: action.maxDistance,
         });
         break;
-      }
       case "none":
         break;
     }
@@ -375,8 +353,7 @@ export function createSurfaceState(deps: SurfaceStateDeps): SurfaceState {
         })
       )
         return;
-      deps.inspection().clearQueuedPointer();
-      deps.inspection().clearPendingPinned();
+      deps.inspection().cancelPointerInspect({ pendingPinned: "discard" });
       reducer.cancelScheduledPointer();
       deps.inspection().setInspection(null, "pointer");
     });
@@ -384,7 +361,8 @@ export function createSurfaceState(deps: SurfaceStateDeps): SurfaceState {
 
   function onPointerDown(event: PointerEvent): void {
     // Always cancel queued inspection before pure routing (host cleanup).
-    deps.inspection().clearQueuedPointer();
+    // Preserve pinned stash; full schedule cancel (inspect + move-area).
+    deps.inspection().cancelPointerInspect({ pendingPinned: "preserve" });
     reducer.cancelScheduledPointer();
     // point always computed (pure begin-area needs it; touch/none ignore).
     const p = plotPoint(event);
@@ -622,7 +600,8 @@ export function createSurfaceState(deps: SurfaceStateDeps): SurfaceState {
 
   /** Pointer-cancel always drops draft/queue/touch-inspect and cancels area. */
   function onPointerCancel(): void {
-    deps.inspection().clearQueuedPointer();
+    // Preserve pinned stash (leave discards; cancel preserves).
+    deps.inspection().cancelPointerInspect({ pendingPinned: "preserve" });
     touchInspectStart = null;
     touchInspectMoved = false;
     reducer.cancelScheduledPointer();
@@ -666,7 +645,7 @@ export function createSurfaceState(deps: SurfaceStateDeps): SurfaceState {
       };
       const cancelDraft = () => {
         brushRect = null;
-        deps.inspection().clearQueuedPointer();
+        deps.inspection().cancelPointerInspect({ pendingPinned: "preserve" });
         touchInspectStart = null;
         reducer.cancelScheduledPointer();
         reducer.dispatch({ type: "cancel-area" });

--- a/packages/svelte/tests/inspection/inspection-state.construction-effects.test.ts
+++ b/packages/svelte/tests/inspection/inspection-state.construction-effects.test.ts
@@ -7,7 +7,6 @@ import { describe, expect, it } from "vitest";
 import type { CandidateFacts, CellValue, RenderModel } from "@ggsvelte/core";
 
 import type { PlotInspection } from "../../src/lib/interaction/interaction.js";
-import type { QueuedPointerInspection } from "../../src/lib/inspection/frame.js";
 import { withEffectRoot } from "../helpers/effect-root.svelte.js";
 import { reactiveBox } from "../helpers/reactive-box.svelte.js";
 import {
@@ -144,7 +143,7 @@ describe("createInspectionState scene-reconcile effect", () => {
     const enabledBox = reactiveBox(true);
     const events: PlotInspection<Record<string, CellValue>>[] = [];
 
-    const { state, reducer, destroy } = mountInspectionController({
+    const { state, destroy } = mountInspectionController({
       model: () => modelBox.value,
       inspectEnabled: () => enabledBox.value,
       oninspect: () => (event) => {
@@ -190,13 +189,13 @@ describe("createInspectionState scene-reconcile effect", () => {
     // Reconcile-pinned CLEAR path, deterministic: swap to a model with
     // DISJOINT row ids (keyAt cannot find the pinned seed) → one programmatic
     // clear emit + teardown of any queued/pending frames.
-    const pendingQueued: QueuedPointerInspection = {
-      hit: hitFromCandidate(b.candidate),
+    // Queue a pending inspect payload via the intentful schedule API (no flush).
+    state.schedulePointerInspect({
+      point: { x: b.candidate.x, y: b.candidate.y },
       source: "pointer",
-      concreteMode: "xy",
-      candidate: b.candidate,
-    };
-    state.queuePointerFrame(pendingQueued, reducer.frameToken());
+      mode: "xy",
+      maxDistance: 1e6,
+    });
     events.length = 0;
     Object.defineProperty(modelA, "runId", { value: 5, configurable: true });
     modelBox.set(modelA);
@@ -204,7 +203,7 @@ describe("createInspectionState scene-reconcile effect", () => {
     expect(state.inspection).toBeNull();
     expect(events.some((event) => event.phase === "clear")).toBe(true);
     // Invalidate teardown cleared the queued frame: a fresh apply is empty.
-    state.applyQueuedInspectFrame({
+    state.onInspectPointerFrame({
       type: "inspect",
       candidate: {
         epoch: modelA.runId,

--- a/packages/svelte/tests/inspection/inspection-state.harness.ts
+++ b/packages/svelte/tests/inspection/inspection-state.harness.ts
@@ -140,13 +140,45 @@ export type InspectionHarness = {
   state: ReturnType<typeof createInspectionState>;
   reducer: InteractionReducer;
   destroy: () => void;
+  /** Flush a deferred frame when mount used `deferredFrames: true`. */
+  flushFrame: () => void;
 };
+
+/** Controllable rAF for schedulePointerInspect tests (never sync — handle assign). */
+export function createDeferredFrameScheduler(): {
+  scheduleFrame: (callback: () => void) => number;
+  cancelFrame: (handle: unknown) => void;
+  flush: () => void;
+  readonly pending: boolean;
+} {
+  let frame: (() => void) | null = null;
+  return {
+    scheduleFrame: (callback) => {
+      frame = callback;
+      return 1;
+    },
+    cancelFrame: () => {
+      frame = null;
+    },
+    flush: () => {
+      const next = frame;
+      frame = null;
+      next?.();
+    },
+    get pending() {
+      return frame !== null;
+    },
+  };
+}
 
 /**
  * Mount the controller with production-shaped deps: every reactive dep is a
  * getter (mirroring InspectionStateDeps). Harness owns the component-held
  * reducer and passes a getter. Call registerInspectionEffects when effects
  * are under test.
+ *
+ * When `deferredFrames` is true, owns a deferred scheduler and wires
+ * `onPointerFrame` → `onInspectPointerFrame` so schedule+flush is testable.
  */
 export function mountInspectionController(
   options: {
@@ -168,17 +200,32 @@ export function mountInspectionController(
     announce?: (message: string) => void;
     clearAnnouncement?: () => void;
     registerEffects?: boolean;
+    /** Wire deferred frame + onInspectPointerFrame (for schedulePointerInspect). */
+    deferredFrames?: boolean;
   } = {},
 ): InspectionHarness {
   const defaultModel = modelFor(continuousSpec());
+  const scheduler = options.deferredFrames === true ? createDeferredFrameScheduler() : null;
+  let controllerRef: ReturnType<typeof createInspectionState> | null = null;
+
   const ownedReducer =
     options.reducer === undefined
       ? createInteractionReducer({
-          scheduleFrame: (callback) => {
-            callback();
-            return 0;
-          },
-          cancelFrame: () => {},
+          scheduleFrame:
+            scheduler?.scheduleFrame ??
+            ((callback) => {
+              callback();
+              return 0;
+            }),
+          cancelFrame: scheduler?.cancelFrame ?? (() => {}),
+          onPointerFrame:
+            scheduler === null
+              ? undefined
+              : (action) => {
+                  if (action.type === "inspect")
+                    return controllerRef!.onInspectPointerFrame(action);
+                  return true;
+                },
         })
       : null;
   const getReducer = options.reducer ?? (() => ownedReducer!);
@@ -208,11 +255,19 @@ export function mountInspectionController(
       announce: options.announce ?? (() => {}),
       clearAnnouncement: options.clearAnnouncement ?? (() => {}),
     });
+    controllerRef = controller;
     if (options.registerEffects !== false) controller.registerInspectionEffects();
     return controller;
   });
 
-  return { state, reducer: getReducer(), destroy };
+  return {
+    state,
+    reducer: getReducer(),
+    destroy,
+    flushFrame: () => {
+      scheduler?.flush();
+    },
+  };
 }
 
 // Re-exports used by construction / armed-getter suites

--- a/packages/svelte/tests/inspection/inspection-state.harness.ts
+++ b/packages/svelte/tests/inspection/inspection-state.harness.ts
@@ -145,7 +145,7 @@ export type InspectionHarness = {
 };
 
 /** Controllable rAF for schedulePointerInspect tests (never sync — handle assign). */
-export function createDeferredFrameScheduler(): {
+function createDeferredFrameScheduler(): {
   scheduleFrame: (callback: () => void) => number;
   cancelFrame: (handle: unknown) => void;
   flush: () => void;

--- a/packages/svelte/tests/inspection/inspection-state.pin-queue.test.ts
+++ b/packages/svelte/tests/inspection/inspection-state.pin-queue.test.ts
@@ -7,7 +7,6 @@ import { describe, expect, it } from "vitest";
 import type { CandidateFacts, CellValue } from "@ggsvelte/core";
 
 import type { PlotInspection } from "../../src/lib/interaction/interaction.js";
-import type { QueuedPointerInspection } from "../../src/lib/inspection/frame.js";
 import { reactiveBox } from "../helpers/reactive-box.svelte.js";
 import {
   candidateHit,
@@ -93,11 +92,12 @@ describe("createInspectionState pin cycle", () => {
     destroy();
   });
 
-  it("restore-pending path via stashed queued frame while pinned", () => {
+  it("restore-pending path via schedulePointerInspect while pinned", () => {
     const model = modelFor(continuousSpec());
-    const { state, reducer, destroy } = mountInspectionController({
+    const { state, flushFrame, destroy } = mountInspectionController({
       model: () => model,
       registerEffects: false,
+      deferredFrames: true,
     });
 
     const first = candidateHit(model);
@@ -107,7 +107,6 @@ describe("createInspectionState pin cycle", () => {
     flushSync();
     expect(state.inspection?.state).toBe("pinned");
 
-    // Second candidate as pending restore payload.
     let second: CandidateFacts | null = null;
     for (let id = 0; id < model.candidates.size; id++) {
       const candidate = model.candidates.candidate(id);
@@ -117,31 +116,20 @@ describe("createInspectionState pin cycle", () => {
       }
     }
     if (second === null) throw new Error("expected a second candidate");
-    const pending: QueuedPointerInspection = {
-      hit: hitFromCandidate(second),
+
+    state.schedulePointerInspect({
+      point: { x: second.x, y: second.y },
       source: "pointer",
-      concreteMode: "xy",
-      candidate: second,
-    };
-    state.queuePointerFrame(pending, reducer.frameToken());
-    state.applyQueuedInspectFrame({
-      type: "inspect",
-      candidate: {
-        epoch: model.runId,
-        id: second.id,
-        panelId: second.panelId,
-        x: second.x,
-        y: second.y,
-      },
-      source: "pointer",
+      mode: "xy",
+      maxDistance: 1e6,
     });
+    flushFrame();
     flushSync();
     // Still pinned — pending was stashed, not applied.
     expect(state.inspection?.state).toBe("pinned");
 
     state.toggleInspectionPin("pointer");
     flushSync();
-    // restore-pending → transient on the stashed second hit.
     expect(state.inspection?.state).toBe("transient");
     expect(state.inspection?.focus.anchor).toEqual({
       x: second.x,
@@ -152,83 +140,120 @@ describe("createInspectionState pin cycle", () => {
   });
 });
 
-describe("createInspectionState applyQueuedInspectFrame", () => {
-  it("drops stale token, stashes when pinned, applies when fresh, drops on epoch mismatch; always clears queues first", () => {
+describe("createInspectionState schedulePointerInspect / onInspectPointerFrame", () => {
+  it("applies on flush, drops stale tokens without reducer dispatch, stashes when pinned, cancels before flush", () => {
     const model = modelFor(continuousSpec());
     const announcements: string[] = [];
-    const { state, reducer, destroy } = mountInspectionController({
+    const { state, reducer, flushFrame, destroy } = mountInspectionController({
       model: () => model,
       announce: (message) => {
         announcements.push(message);
       },
       registerEffects: false,
+      deferredFrames: true,
     });
-    const { candidate, hit } = candidateHit(model);
-    const queued: QueuedPointerInspection = {
-      hit,
-      source: "pointer",
-      concreteMode: "xy",
-      candidate,
-    };
-    const frameCandidate = {
-      epoch: model.runId,
-      id: candidate.id,
-      panelId: candidate.panelId,
-      x: candidate.x,
-      y: candidate.y,
-    };
+    const { candidate } = candidateHit(model);
 
-    // Empty frame path: no pending → none; queues stay empty; no inspection.
-    state.applyQueuedInspectFrame({
-      type: "inspect",
-      candidate: null,
-      source: "pointer",
-    });
+    // Empty frame path: no pending → none; no inspection change.
+    expect(
+      state.onInspectPointerFrame({
+        type: "inspect",
+        candidate: null,
+        source: "pointer",
+      }),
+    ).toBe(true);
     flushSync();
     expect(state.inspection).toBeNull();
 
-    // Stale token → drop (queue cleared before routing).
-    state.queuePointerFrame(queued, { epoch: 0, revision: 0 });
-    // Advance reducer epoch so token is stale.
-    reducer.dispatch({ type: "invalidate", reason: "scene" });
-    state.applyQueuedInspectFrame({
-      type: "inspect",
-      candidate: frameCandidate,
+    // Fresh schedule + flush → transient on both authorities.
+    state.schedulePointerInspect({
+      point: { x: candidate.x, y: candidate.y },
       source: "pointer",
+      mode: "xy",
+      maxDistance: 1e6,
     });
+    flushFrame();
     flushSync();
-    expect(state.inspection).toBeNull();
-    // Second apply is empty-frame (queues stayed cleared after drop).
-    state.applyQueuedInspectFrame({
-      type: "inspect",
-      candidate: frameCandidate,
-      source: "pointer",
-    });
-    expect(state.inspection).toBeNull();
-
-    // Fresh token + transient → apply.
-    state.queuePointerFrame(queued, reducer.frameToken());
-    state.applyQueuedInspectFrame({
-      type: "inspect",
-      candidate: frameCandidate,
-      source: "pointer",
-    });
-    flushSync();
-    expect(state.inspection).not.toBeNull();
     expect(state.inspection?.state).toBe("transient");
-    // Queues cleared: re-apply is empty.
-    state.applyQueuedInspectFrame({
-      type: "inspect",
-      candidate: frameCandidate,
-      source: "pointer",
-    });
+    expect(reducer.state.inspection.kind).toBe("transient");
+    expect(reducer.state.inspection.candidate?.id).toBe(candidate.id);
+
+    // Re-apply empty (queues cleared) keeps transient.
+    expect(
+      state.onInspectPointerFrame({
+        type: "inspect",
+        candidate: {
+          epoch: model.runId,
+          id: candidate.id,
+          panelId: candidate.panelId,
+          x: candidate.x,
+          y: candidate.y,
+        },
+        source: "pointer",
+      }),
+    ).toBe(true);
     flushSync();
     expect(state.inspection?.state).toBe("transient");
 
-    // Pinned → stash-pending (not apply over pinned).
+    // Stale token → drop; skip reducer dispatch (atomic).
+    state.setInspection(null, "pointer");
+    flushSync();
+    reducer.dispatch({ type: "inspect", candidate: null, source: "programmatic" });
+    // Clear activeCandidate so a later set-active is guaranteed to commit.
+    reducer.dispatch({ type: "set-active", candidate: null });
+    state.schedulePointerInspect({
+      point: { x: candidate.x, y: candidate.y },
+      source: "pointer",
+      mode: "xy",
+      maxDistance: 1e6,
+    });
+    const scheduledToken = reducer.frameToken();
+    // Advance revision without cancelling the schedule (set-active with a
+    // different ref always commits when active was null).
+    reducer.dispatch({
+      type: "set-active",
+      candidate: {
+        epoch: model.runId,
+        id: candidate.id + 10_000,
+        panelId: candidate.panelId,
+        x: candidate.x,
+        y: candidate.y,
+      },
+    });
+    expect(reducer.accepts(scheduledToken)).toBe(false);
+    const revBefore = reducer.state.revision;
+    flushFrame();
+    flushSync();
+    expect(state.inspection).toBeNull();
+    // Drop skipped dispatch — inspection kind stays idle (not transient).
+    expect(reducer.state.inspection.kind).toBe("idle");
+    expect(reducer.state.revision).toBe(revBefore);
+
+    // Cancel before flush → no apply.
+    state.schedulePointerInspect({
+      point: { x: candidate.x, y: candidate.y },
+      source: "pointer",
+      mode: "xy",
+      maxDistance: 1e6,
+    });
+    state.cancelPointerInspect({ pendingPinned: "preserve" });
+    flushFrame();
+    flushSync();
+    expect(state.inspection).toBeNull();
+
+    // Pin + schedule other candidate → stash; single-stash; restore then flip.
+    state.schedulePointerInspect({
+      point: { x: candidate.x, y: candidate.y },
+      source: "pointer",
+      mode: "xy",
+      maxDistance: 1e6,
+    });
+    flushFrame();
+    flushSync();
     state.toggleInspectionPin("pointer");
     flushSync();
     expect(state.inspection?.state).toBe("pinned");
+
     let other: CandidateFacts | null = null;
     for (let id = 0; id < model.candidates.size; id++) {
       const c = model.candidates.candidate(id);
@@ -238,50 +263,34 @@ describe("createInspectionState applyQueuedInspectFrame", () => {
       }
     }
     if (other === null) throw new Error("expected another candidate");
-    const otherQueued: QueuedPointerInspection = {
-      hit: hitFromCandidate(other),
+
+    state.schedulePointerInspect({
+      point: { x: other.x, y: other.y },
       source: "pointer",
-      concreteMode: "xy",
-      candidate: other,
-    };
-    state.queuePointerFrame(otherQueued, reducer.frameToken());
-    const otherFrame = {
-      epoch: model.runId,
-      id: other.id,
-      panelId: other.panelId,
-      x: other.x,
-      y: other.y,
-    };
-    state.applyQueuedInspectFrame({
-      type: "inspect",
-      candidate: otherFrame,
-      source: "pointer",
+      mode: "xy",
+      maxDistance: 1e6,
     });
+    flushFrame();
     flushSync();
     expect(state.inspection?.state).toBe("pinned");
-    // Queues cleared ON the stash path: a second apply must be an empty frame
-    // (no double-stash). Discriminator below: restore-pending consumes the
-    // SINGLE stash silently, so the NEXT unpin after re-pinning must take the
-    // flip branch — which is the only branch that announces "unpinned".
-    state.applyQueuedInspectFrame({
-      type: "inspect",
-      candidate: otherFrame,
+    // Second schedule+flush must not double-stash.
+    state.schedulePointerInspect({
+      point: { x: other.x, y: other.y },
       source: "pointer",
+      mode: "xy",
+      maxDistance: 1e6,
     });
+    flushFrame();
     flushSync();
     expect(state.inspection?.state).toBe("pinned");
-    // Unpin #1 (keyboard — the announcing source class): restore-pending
-    // consumes the stash and never announces; transient lands on the stashed
-    // candidate's anchor.
+
     announcements.length = 0;
     state.toggleInspectionPin("keyboard");
     flushSync();
     expect(state.inspection?.state).toBe("transient");
     expect(state.inspection?.focus.anchor).toEqual({ x: other.x, y: other.y });
     expect(announcements.some((m) => m.includes("unpinned"))).toBe(false);
-    // Re-pin, unpin #2 (keyboard): with the stash gone (single-stash), this
-    // is the FLIP branch, which announces for keyboard. A double-stash
-    // regression would restore again silently instead.
+
     state.toggleInspectionPin("keyboard");
     flushSync();
     announcements.length = 0;
@@ -290,77 +299,64 @@ describe("createInspectionState applyQueuedInspectFrame", () => {
     expect(state.inspection?.state).toBe("transient");
     expect(announcements.some((m) => m.includes("unpinned"))).toBe(true);
 
-    // Epoch mismatch → drop (from a clean transient base).
-    state.setInspection(null, "pointer");
+    // cancelPointerInspect({ discard }) drops stash → flip announces.
+    state.toggleInspectionPin("keyboard");
     flushSync();
-    state.queuePointerFrame(queued, reducer.frameToken());
-    state.applyQueuedInspectFrame({
-      type: "inspect",
-      candidate: { ...frameCandidate, epoch: model.runId + 999 },
+    state.schedulePointerInspect({
+      point: { x: candidate.x, y: candidate.y },
       source: "pointer",
+      mode: "xy",
+      maxDistance: 1e6,
     });
+    flushFrame();
     flushSync();
-    expect(state.inspection).toBeNull();
+    expect(state.inspection?.state).toBe("pinned");
+    state.cancelPointerInspect({ pendingPinned: "discard" });
+    announcements.length = 0;
+    state.toggleInspectionPin("keyboard");
+    flushSync();
+    expect(state.inspection?.state).toBe("transient");
+    expect(announcements.some((m) => m.includes("unpinned"))).toBe(true);
 
     destroy();
   });
 
-  it("host-facing mutators: clearQueuedPointer drops the payload; clearPendingPinned drops the stash", () => {
+  it("typed inspect cancel does not cancel a pending move-area schedule", () => {
+    let frame: (() => void) | null = null;
+    const frames: string[] = [];
+    let controller: ReturnType<typeof createInspectionState> | null = null;
     const model = modelFor(continuousSpec());
-    const announcements: string[] = [];
-    const { state, reducer, destroy } = mountInspectionController({
-      model: () => model,
-      announce: (message) => {
-        announcements.push(message);
+    const reducer = createInteractionReducer({
+      scheduleFrame: (callback) => {
+        frame = callback;
+        return 1;
       },
+      cancelFrame: () => {
+        frame = null;
+      },
+      onPointerFrame: (action) => {
+        frames.push(action.type);
+        if (action.type === "inspect") return controller!.onInspectPointerFrame(action);
+        return true;
+      },
+    });
+    const { state, destroy } = mountInspectionController({
+      model: () => model,
+      reducer: () => reducer,
       registerEffects: false,
     });
-    const { candidate, hit } = candidateHit(model);
-    const queued: QueuedPointerInspection = {
-      hit,
-      source: "pointer",
-      concreteMode: "xy",
-      candidate,
-    };
-    const frame = {
-      epoch: model.runId,
-      id: candidate.id,
-      panelId: candidate.panelId,
-      x: candidate.x,
-      y: candidate.y,
-    };
+    controller = state;
 
-    // clearQueuedPointer clears ONLY the payload (host leave/cancel paths):
-    // a fresh-token frame that would otherwise apply must become empty.
-    state.queuePointerFrame(queued, reducer.frameToken());
-    state.clearQueuedPointer();
-    state.applyQueuedInspectFrame({ type: "inspect", candidate: frame, source: "pointer" });
-    flushSync();
-    expect(state.inspection).toBeNull();
-
-    // clearPendingPinned drops a stashed pending: the next unpin must take
-    // the announcing FLIP branch instead of a silent restore.
-    state.queuePointerFrame(queued, reducer.frameToken());
-    state.applyQueuedInspectFrame({ type: "inspect", candidate: frame, source: "pointer" });
-    flushSync();
-    expect(state.inspection?.state).toBe("transient");
-    state.toggleInspectionPin("pointer");
-    flushSync();
-    state.queuePointerFrame(queued, reducer.frameToken());
-    state.applyQueuedInspectFrame({ type: "inspect", candidate: frame, source: "pointer" });
-    flushSync();
-    expect(state.inspection?.state).toBe("pinned");
-    state.clearPendingPinned();
-    announcements.length = 0;
-    state.toggleInspectionPin("keyboard");
-    flushSync();
-    expect(state.inspection?.state).toBe("transient");
-    expect(announcements.some((m) => m.includes("unpinned"))).toBe(true);
+    reducer.queuePointer({ type: "move-area", point: { x: 1, y: 2 } });
+    expect(frame).not.toBeNull();
+    state.cancelPointerInspect({ pendingPinned: "preserve" });
+    expect(frame).not.toBeNull();
+    frame?.();
+    expect(frames).toEqual(["move-area"]);
 
     destroy();
   });
 });
-
 describe("createInspectionState setInspection(null) clear ordering", () => {
   it("pins ordered sequence: dispatch1(non-null) → emit while still non-null → clear → dispatch2(null)", () => {
     const model = modelFor(continuousSpec());

--- a/packages/svelte/tests/interaction/unit.test.ts
+++ b/packages/svelte/tests/interaction/unit.test.ts
@@ -256,4 +256,43 @@ describe("chart-local interaction reducer", () => {
     expect(frame).toBeNull();
     expect(reducer.state.inspection.candidate?.id).toBe(2);
   });
+
+  it("typed cancelScheduledPointer only clears matching kind; onPointerFrame false skips dispatch", () => {
+    let frame: (() => void) | null = null;
+    const seen: string[] = [];
+    const reducer = createInteractionReducer({
+      scheduleFrame: (callback) => {
+        frame = callback;
+        return 1;
+      },
+      cancelFrame: () => {
+        frame = null;
+      },
+      onPointerFrame: (action) => {
+        seen.push(action.type);
+        if (action.type === "inspect") return false;
+        return true;
+      },
+    });
+
+    reducer.queuePointer({ type: "move-area", point: { x: 1, y: 2 } });
+    expect(frame).not.toBeNull();
+    reducer.cancelScheduledPointer("inspect");
+    expect(frame).not.toBeNull();
+    (frame as (() => void) | null)?.();
+    expect(seen).toEqual(["move-area"]);
+
+    frame = null;
+    seen.length = 0;
+    reducer.queuePointer({
+      type: "inspect",
+      candidate: candidate(1),
+      source: "pointer",
+    });
+    const rev = reducer.state.revision;
+    (frame as (() => void) | null)?.();
+    expect(seen).toEqual(["inspect"]);
+    expect(reducer.state.revision).toBe(rev);
+    expect(reducer.state.inspection.kind).toBe("idle");
+  });
 });

--- a/packages/svelte/tests/surface/surface-state.construction-effects.test.ts
+++ b/packages/svelte/tests/surface/surface-state.construction-effects.test.ts
@@ -56,17 +56,15 @@ describe("createSurfaceState construction", () => {
         inspectionCalls++;
         return null;
       },
-      applyQueuedInspectFrame: () => {
+      schedulePointerInspect: () => {
         inspectionCalls++;
       },
-      queuePointerFrame: () => {
+      cancelPointerInspect: () => {
         inspectionCalls++;
       },
-      clearQueuedPointer: () => {
+      onInspectPointerFrame: () => {
         inspectionCalls++;
-      },
-      clearPendingPinned: () => {
-        inspectionCalls++;
+        return true;
       },
       setInspection: () => {
         inspectionCalls++;
@@ -212,11 +210,10 @@ describe("createSurfaceState construction", () => {
       get inspection() {
         return null;
       },
-      clearQueuedPointer: () => {},
-      clearPendingPinned: () => {},
+      schedulePointerInspect: () => {},
+      cancelPointerInspect: () => {},
+      onInspectPointerFrame: () => true,
       setInspection: () => {},
-      applyQueuedInspectFrame: () => {},
-      queuePointerFrame: () => {},
       closeInspection: () => {},
       dismissInspection: () => {},
       toggleInspectionPin: () => {},

--- a/packages/svelte/tests/surface/surface-state.input-lifecycle.test.ts
+++ b/packages/svelte/tests/surface/surface-state.input-lifecycle.test.ts
@@ -7,7 +7,6 @@ import { describe, expect, it, vi } from "vitest";
 import type { CandidateFacts } from "@ggsvelte/core";
 
 import { hitFromCandidate } from "../../src/lib/surface/plot-px.js";
-import type { QueuedPointerInspection } from "../../src/lib/inspection/frame.js";
 import { TOUCH_INSPECT_CLICK_SUPPRESS_MS } from "../../src/lib/surface/pointer.js";
 import {
   firstCandidate,
@@ -293,25 +292,14 @@ describe("createSurfaceState pointer cancel vs lost capture", () => {
     flushSync();
     expect(h.inspection.inspection?.state).toBe("pinned");
 
-    // Stash pending via queued frame while pinned.
-    const pending: QueuedPointerInspection = {
-      hit: hitFromCandidate(second),
+    // Stash pending via intentful schedule while pinned.
+    h.inspection.schedulePointerInspect({
+      point: { x: second.x, y: second.y },
       source: "pointer",
-      concreteMode: "xy",
-      candidate: second,
-    };
-    h.inspection.queuePointerFrame(pending, h.surface.reducer.frameToken());
-    h.inspection.applyQueuedInspectFrame({
-      type: "inspect",
-      candidate: {
-        epoch: h.model.runId,
-        id: second.id,
-        panelId: second.panelId,
-        x: second.x,
-        y: second.y,
-      },
-      source: "pointer",
+      mode: "xy",
+      maxDistance: 1e6,
     });
+    h.flushFrames();
     flushSync();
     expect(h.inspection.inspection?.state).toBe("pinned");
 
@@ -350,24 +338,13 @@ describe("createSurfaceState pointer cancel vs lost capture", () => {
     h.inspection.toggleInspectionPin("pointer");
     flushSync();
 
-    const pending: QueuedPointerInspection = {
-      hit: hitFromCandidate(second),
+    h.inspection.schedulePointerInspect({
+      point: { x: second.x, y: second.y },
       source: "pointer",
-      concreteMode: "xy",
-      candidate: second,
-    };
-    h.inspection.queuePointerFrame(pending, h.surface.reducer.frameToken());
-    h.inspection.applyQueuedInspectFrame({
-      type: "inspect",
-      candidate: {
-        epoch: h.model.runId,
-        id: second.id,
-        panelId: second.panelId,
-        x: second.x,
-        y: second.y,
-      },
-      source: "pointer",
+      mode: "xy",
+      maxDistance: 1e6,
     });
+    h.flushFrames();
     flushSync();
 
     h.surface.chooseTool("select-area");


### PR DESCRIPTION
## Summary

- Collapse the multi-step hover-inspect protocol (`queuePointerFrame` + `frameToken` + `reducer.queuePointer` + `applyQueuedInspectFrame`) into intentful `InspectionState` methods:
  - `schedulePointerInspect({ point, source, mode, maxDistance })` — owns nearest/hitTest, token, and queue
  - `cancelPointerInspect({ pendingPinned: preserve | discard })` — typed cancel (inspect only)
  - `onInspectPointerFrame` — frame sink; returns `false` on drop so the reducer skips dispatch (atomic stale-token handling)
- `cancelScheduledPointer(kind?)` so inspect cancel cannot kill `move-area`
- Tests rewritten to hit outcomes via the new seams (no `frameToken` peering)

Codex reviewed the plan (NO-GO on the first draft for shallow rename / cross-domain cancel / dual authority on drop); this PR incorporates those fixes.

## Test plan

- [x] `packages/svelte` inspection + surface + interaction unit tests (browser matrix)
- [x] `svelte-check` clean
- [ ] CI green