### PR TITLE
perf(core): O(C·n)→O(n) canvas point subset color batching

### DIFF
--- a/.changeset/canvas-points-subset-group-by-color.md
+++ b/.changeset/canvas-points-subset-group-by-color.md
@@ -1,0 +1,10 @@
+---
+"@ggsvelte/core": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+perf: O(C·n)→O(n) canvas point subset color batching
+
+Masked multi-color point draws bucket included indices by global first-seen
+color in one pass instead of re-scanning the batch for each of up to 64 colors.

--- a/packages/core/src/dom/canvas-marks-points.ts
+++ b/packages/core/src/dom/canvas-marks-points.ts
@@ -84,28 +84,38 @@ export function drawPointsSubset(
     return;
   }
   // Interactive masks must not turn alternating categorical colors into one
-  // beginPath/fill pair per point. For the normal small categorical case,
-  // batch by first-seen color while retaining the focused-over-muted pass
-  // boundary. Fall back to contiguous runs for high-cardinality colors.
+  // beginPath/fill pair per point. For the normal small categorical case
+  // (≤64 global first-seen colors), bucket included indices by color in one
+  // O(n) pass — not re-scan n for each of C colors (O(C·n)). Preserve global
+  // first-seen paint order (including colors only present on the other mask
+  // half). Fall back to contiguous runs when cardinality exceeds 64.
   const uniqueColors: string[] = [];
-  const seenColors = new Set<string>();
-  for (let j = 0; j < n && uniqueColors.length <= 64; j++) {
+  const indicesByColor = new Map<string, number[]>();
+  let highCardinality = false;
+  for (let j = 0; j < n; j++) {
     const color = batch.colors[j] ?? batch.fill ?? themeInk;
-    if (seenColors.has(color)) continue;
-    seenColors.add(color);
-    uniqueColors.push(color);
+    let list = indicesByColor.get(color);
+    if (list === undefined) {
+      list = [];
+      indicesByColor.set(color, list);
+      uniqueColors.push(color);
+      // Mirror the prior discovery loop: collect at most 65 names, then bail
+      // to run-length (uniqueColors.length > 64). Incomplete buckets are unused.
+      if (uniqueColors.length > 64) {
+        highCardinality = true;
+        break;
+      }
+    }
+    if (includes(j)) list.push(j);
   }
-  if (uniqueColors.length <= 64) {
+  if (!highCardinality) {
     for (const color of uniqueColors) {
+      const list = indicesByColor.get(color)!;
+      if (list.length === 0) continue;
       ctx.fillStyle = resolve(color);
       ctx.beginPath();
-      let traced = false;
-      for (let j = 0; j < n; j++) {
-        if ((batch.colors[j] ?? batch.fill ?? themeInk) !== color || !includes(j)) continue;
-        tracePoint(ctx, batch, j);
-        traced = true;
-      }
-      if (traced) ctx.fill();
+      for (const j of list) tracePoint(ctx, batch, j);
+      ctx.fill();
     }
     return;
   }

--- a/packages/core/tests/dom/canvas-fixtures.ts
+++ b/packages/core/tests/dom/canvas-fixtures.ts
@@ -13,6 +13,7 @@ export interface RecordedCall {
   name: string;
   args: number[];
   alpha: number;
+  fillStyle: string;
   strokeStyle: string;
   lineWidth: number;
 }
@@ -52,6 +53,7 @@ export function recordingContext(): { ctx: CanvasRenderingContext2D; calls: Reco
             name: property,
             args,
             alpha: object.globalAlpha,
+            fillStyle: String(object.fillStyle),
             strokeStyle: object.strokeStyle,
             lineWidth: object.lineWidth,
           });

--- a/packages/core/tests/dom/canvas-fixtures.ts
+++ b/packages/core/tests/dom/canvas-fixtures.ts
@@ -53,7 +53,7 @@ export function recordingContext(): { ctx: CanvasRenderingContext2D; calls: Reco
             name: property,
             args,
             alpha: object.globalAlpha,
-            fillStyle: String(object.fillStyle),
+            fillStyle: object.fillStyle,
             strokeStyle: object.strokeStyle,
             lineWidth: object.lineWidth,
           });

--- a/packages/core/tests/dom/canvas-focus.test.ts
+++ b/packages/core/tests/dom/canvas-focus.test.ts
@@ -53,7 +53,58 @@ describe("drawStratum focus presentation", () => {
       focusMasks: [Uint8Array.from({ length: count }, (_, index) => (index % 10 === 0 ? 1 : 0))],
     });
 
-    expect(calls.filter((call) => call.name === "fill").length).toBeLessThanOrEqual(4);
+    // Focused indices are 0,10,20,… (all even → red only). Muted has both
+    // colors. Global first-seen order is red→blue within each multi-color pass.
+    expect(calls.filter((call) => call.name === "fill").map((c) => c.fillStyle)).toEqual([
+      "red",
+      "blue",
+      "red",
+    ]);
+    expect(calls.filter((call) => call.name === "arc")).toHaveLength(count);
+  });
+
+  it("keeps global first-seen color order when the first color is muted-only", () => {
+    // colors: red (index 0, muted), blue (1, focused), red (2, focused).
+    // Global first-seen is still red→blue even though the focused pass only
+    // draws blue then red indices — paint order must not flip to blue→red.
+    const colored: PointsBatch = {
+      ...points,
+      positions: Float32Array.from([0, 0, 1, 1, 2, 2]),
+      rowIndex: Uint32Array.from([0, 1, 2]),
+      colors: ["red", "blue", "red"],
+    };
+    const { ctx, calls } = recordingContext();
+    drawStratum(ctx, scene([colored]), [colored], resolve, {
+      focusMasks: [Uint8Array.from([0, 1, 1])],
+      mutedAlpha: 0.25,
+    });
+    const focusedFills = calls.filter((call) => call.name === "fill" && call.alpha === 0.8);
+    expect(focusedFills.map((c) => c.fillStyle)).toEqual(["red", "blue"]);
+    const focusedArcs = calls.filter((call) => call.name === "arc" && call.alpha === 0.8);
+    // red index 2 (x=2) then blue index 1 (x=1) — order follows color groups, not index.
+    expect(focusedArcs.map((c) => c.args[0])).toEqual([2, 1]);
+  });
+
+  it("falls back to run-length when more than 64 global colors are present", () => {
+    // Mixed mask so drawPointsSubset (not the all-focused fast path) runs.
+    const count = 70;
+    const colored: PointsBatch = {
+      ...points,
+      positions: Float32Array.from(
+        Array.from({ length: count }, (_, index) => [index, index]).flat(),
+      ),
+      rowIndex: Uint32Array.from({ length: count }, (_, index) => index),
+      colors: Array.from({ length: count }, (_, index) => `c${index}`),
+    };
+    const mask = Uint8Array.from({ length: count }, (_, index) => (index % 2 === 0 ? 1 : 0));
+    const { ctx, calls } = recordingContext();
+    drawStratum(ctx, scene([colored]), [colored], resolve, {
+      focusMasks: [mask],
+      mutedAlpha: 0.25,
+    });
+    // Unique color per point → each included point is its own run → one fill
+    // per included primitive across muted + focused passes (= count).
+    expect(calls.filter((call) => call.name === "fill").length).toBe(count);
     expect(calls.filter((call) => call.name === "arc")).toHaveLength(count);
   });
 


### PR DESCRIPTION
## Summary

`/bigo-maintain` on `packages/core` (320 production src files; prior #485 binned rect xBinId).

### Finding

- **File:** `packages/core/src/dom/canvas-marks-points.ts` (`drawPointsSubset`)
- **Pattern:** #2 Nested linear scan / repeated work
- **Before:** For each of C ≤ 64 first-seen colors, re-scan all n points (O(C·n))
- **After:** One O(n) pass buckets included indices under global first-seen colors, then O(C) fills
- **n:** point count in a canvas batch during focus/hover mask presentation; C ≤ 64 (above that → existing run-length path)

Paint order is preserved: colors are discovered over the full batch (not only the included half), so an early muted-only color still paints before later focused colors of a different hue.

### Codex plan review

Revised after plan review: global first-seen discovery (not included-only), record `fillStyle` for order assertions, exact fill-order / >64 run-length tests.

### Tests

```text
bun test packages/core/tests/dom/
# 33 pass, 0 fail
```

### Follow-ups

- https://github.com/ljodea/ggsvelte/issues/493 — unique-first `resolution()` O(R log R)→O(R+U log U)

## Test plan

- [x] Alternating categorical colors under mask: exact fillStyle order red→blue→red
- [x] Global first-seen order when first color is muted-only
- [x] >64 global colors → run-length path (mixed mask)
- [x] Existing canvas routing / segment / focus suite green
