### PR TITLE
refactor(svelte): finishBrushSelect owns brush-end commit+emit

### DIFF
--- a/packages/svelte/src/lib/interval/interval-state.svelte.ts
+++ b/packages/svelte/src/lib/interval/interval-state.svelte.ts
@@ -106,11 +106,11 @@ export type IntervalState = {
   clearIntervalSelection(source: InteractionSource): void;
   clearCurrentPanelInterval(source: InteractionSource): void;
   /**
-   * Owns BOTH writes of the host's select-end branch (committedInterval +
-   * conditional private commit). Snapshots `selectConfig()?.persistent` once.
-   * Never calls emitSelection — host emits after this returns.
+   * Brush select-end: commit writes (committedInterval + conditional record)
+   * then emit. Snapshots `selectConfig()?.persistent` once. Always emits the
+   * end event (including non-persistent) so callers need no post-hook emit.
    */
-  applyBrushSelectEnd(eventValue: IntervalSelection, source: InteractionSource): void;
+  finishBrushSelect(eventValue: IntervalSelection, source: InteractionSource): void;
   openBoundsEditor(action: "select" | "zoom", axis: "x" | "y", trigger: HTMLElement): void;
   applyPreciseBounds(event: PreciseBoundsApplyEvent): void;
   cancelBoundsEditor(): void;
@@ -467,15 +467,17 @@ export function createIntervalState(deps: IntervalStateDeps): IntervalState {
     }
   }
 
-  function applyBrushSelectEnd(eventValue: IntervalSelection, source: InteractionSource): void {
+  function finishBrushSelect(eventValue: IntervalSelection, source: InteractionSource): void {
     // Snapshot once (drift-safe under reactive selectConfig replacement).
     const persistent = deps.selectConfig()?.persistent;
     committedInterval = persistentSelectionOrNull(persistent, eventValue);
-    // TRUTHY guard, exactly as the host's select-end branch — untyped JS
-    // consumers may pass truthy non-boolean `persistent` values, which the
-    // config normalizer forwards unchanged. `?? false` only maps nullish
-    // (already falsy) values, so runtime truthiness is identical.
+    // TRUTHY guard — untyped JS consumers may pass truthy non-boolean
+    // `persistent` values, which the config normalizer forwards unchanged.
+    // `?? false` only maps nullish (already falsy) values, so runtime
+    // truthiness is identical.
     if (persistent ?? false) commitIntervalSelection(eventValue, source);
+    // Emit after writes so listeners observe committed state (load-bearing).
+    deps.emitSelection(eventValue);
   }
 
   function openBoundsEditor(
@@ -605,7 +607,7 @@ export function createIntervalState(deps: IntervalStateDeps): IntervalState {
     },
     clearIntervalSelection,
     clearCurrentPanelInterval,
-    applyBrushSelectEnd,
+    finishBrushSelect,
     openBoundsEditor,
     applyPreciseBounds,
     cancelBoundsEditor,

--- a/packages/svelte/src/lib/surface/surface-handlers.ts
+++ b/packages/svelte/src/lib/surface/surface-handlers.ts
@@ -199,10 +199,8 @@ export function createSurfaceHandlers(live: SurfaceHandlerLive): SurfaceHandlers
       case "select-end": {
         live.setBrushRect(null);
         const eventValue = selectionEvent("end", finish.rect, source);
-        // Writes (committedInterval + conditional record) then host emit —
-        // order unchanged from the pre-extraction select-end branch.
-        deps.interval().applyBrushSelectEnd(eventValue, source);
-        deps.emitSelection(eventValue);
+        // Interval owns commit + emit; surface only routes FinishBrushAction.
+        deps.interval().finishBrushSelect(eventValue, source);
         reducer.dispatch({ type: "cancel-area" });
         break;
       }

--- a/packages/svelte/src/lib/surface/surface-state.svelte.ts
+++ b/packages/svelte/src/lib/surface/surface-state.svelte.ts
@@ -81,7 +81,7 @@ export type SurfaceStateDeps = {
     | "cycleCoincident"
     | "resetTraversalIndex"
   >;
-  interval: () => Pick<IntervalState, "applyBrushSelectEnd" | "committedInterval">;
+  interval: () => Pick<IntervalState, "finishBrushSelect" | "committedInterval">;
   zoom: () => Pick<PlotZoomState, "applyBrushZoom">;
   /** S8 host-held sinks. */
   emitSelection: (event: PlotSelection) => void;

--- a/packages/svelte/tests/interval/interval-state.bounds-editor.test.ts
+++ b/packages/svelte/tests/interval/interval-state.bounds-editor.test.ts
@@ -40,7 +40,7 @@ describe("createIntervalState bounds editor select path", () => {
       },
     });
 
-    state.applyBrushSelectEnd(
+    state.finishBrushSelect(
       brushEvent(bandModel, {
         domain: { x: ["north", "south"], y: [0, 20] },
         keys: ["0", "1"],
@@ -115,7 +115,7 @@ describe("createIntervalState bounds editor select path", () => {
     });
 
     // Wide domain so both continuous points remain in-interval after the edit.
-    state.applyBrushSelectEnd(
+    state.finishBrushSelect(
       brushEvent(spyModel, {
         domain: { x: [0, 20], y: [0, 30] },
         keys: ["0", "1"],
@@ -174,7 +174,7 @@ describe("createIntervalState bounds editor select path", () => {
     });
 
     // Seed a committed interval so the select bounds editor has a record.
-    state.applyBrushSelectEnd(brushEvent(model), "pointer");
+    state.finishBrushSelect(brushEvent(model), "pointer");
     flushSync();
 
     state.openBoundsEditor("select", "x", trigger);
@@ -317,7 +317,7 @@ describe("createIntervalState bounds-cancel effect", () => {
 
     const north = facet.scene.panels[0];
     if (north === undefined) throw new Error("expected north panel");
-    state.applyBrushSelectEnd(
+    state.finishBrushSelect(
       brushEvent(facet, {
         panelId: north.id,
         domain: { x: [0.5, 1.5], y: [0.5, 1.5] },

--- a/packages/svelte/tests/interval/interval-state.brush-config.test.ts
+++ b/packages/svelte/tests/interval/interval-state.brush-config.test.ts
@@ -1,5 +1,5 @@
 /**
- * createIntervalState tests — write-before-emit, applyBrushSelectEnd, selectConfig.
+ * createIntervalState tests — write-before-emit, finishBrushSelect, selectConfig.
  */
 import { fromAny } from "@total-typescript/shoehorn";
 import { flushSync } from "svelte";
@@ -30,7 +30,7 @@ describe("createIntervalState write-before-emit", () => {
       },
     });
 
-    state.applyBrushSelectEnd(brushEvent(model), "pointer");
+    state.finishBrushSelect(brushEvent(model), "pointer");
     flushSync();
     expect(state.committedInterval).not.toBeNull();
 
@@ -42,44 +42,51 @@ describe("createIntervalState write-before-emit", () => {
   });
 });
 
-describe("createIntervalState applyBrushSelectEnd", () => {
-  it("persistent sets committed + record; non-persistent nulls committed; method never emits", () => {
+describe("createIntervalState finishBrushSelect", () => {
+  it("persistent commits then emits end; non-persistent nulls commit but still emits end once", () => {
     const model = modelFor(continuousSpec());
     const events: PlotSelection[] = [];
+    const observedAtEmit: Array<IntervalSelection | null> = [];
     const selectBox = reactiveBox<SelectConfig>(persistentSelect());
 
     const { state, destroy } = mountIntervalController({
       model: () => model,
       selectConfig: () => selectBox.value,
       emitSelection: (event) => {
+        observedAtEmit.push(state.committedInterval);
         events.push(event);
       },
     });
 
-    state.applyBrushSelectEnd(brushEvent(model), "pointer");
+    state.finishBrushSelect(brushEvent(model), "pointer");
     flushSync();
     expect(state.committedInterval).not.toBeNull();
     expect(state.effectiveIntervals).toHaveLength(1);
-    expect(events).toEqual([]);
+    expect(events).toHaveLength(1);
+    expect(events[0]?.phase).toBe("end");
+    expect(observedAtEmit[0]).not.toBeNull();
 
     state.clearIntervalSelection("programmatic");
     flushSync();
     events.length = 0;
+    observedAtEmit.length = 0;
 
     selectBox.set(nonPersistentSelect());
     flushSync();
-    state.applyBrushSelectEnd(brushEvent(model), "pointer");
+    state.finishBrushSelect(brushEvent(model), "pointer");
     flushSync();
     expect(state.committedInterval).toBeNull();
     expect(state.effectiveIntervals).toEqual([]);
-    expect(events).toEqual([]);
+    expect(events).toHaveLength(1);
+    expect(events[0]?.phase).toBe("end");
+    expect(observedAtEmit[0]).toBeNull();
 
     destroy();
   });
 });
 
 describe("createIntervalState selectConfig replacement", () => {
-  it("flipping persistent post-flush is honored by the next applyBrushSelectEnd", () => {
+  it("flipping persistent post-flush is honored by the next finishBrushSelect", () => {
     const model = modelFor(continuousSpec());
     const selectBox = reactiveBox<SelectConfig>(persistentSelect());
     const { state, destroy } = mountIntervalController({
@@ -87,7 +94,7 @@ describe("createIntervalState selectConfig replacement", () => {
       selectConfig: () => selectBox.value,
     });
 
-    state.applyBrushSelectEnd(brushEvent(model), "pointer");
+    state.finishBrushSelect(brushEvent(model), "pointer");
     flushSync();
     expect(state.effectiveIntervals).toHaveLength(1);
 
@@ -96,7 +103,7 @@ describe("createIntervalState selectConfig replacement", () => {
     selectBox.set(nonPersistentSelect());
     flushSync();
 
-    state.applyBrushSelectEnd(brushEvent(model), "keyboard");
+    state.finishBrushSelect(brushEvent(model), "keyboard");
     flushSync();
     expect(state.committedInterval).toBeNull();
     expect(state.effectiveIntervals).toEqual([]);
@@ -104,7 +111,7 @@ describe("createIntervalState selectConfig replacement", () => {
     // Flip back to persistent.
     selectBox.set(persistentSelect());
     flushSync();
-    state.applyBrushSelectEnd(brushEvent(model), "keyboard");
+    state.finishBrushSelect(brushEvent(model), "keyboard");
     flushSync();
     expect(state.committedInterval).not.toBeNull();
     expect(state.effectiveIntervals).toHaveLength(1);

--- a/packages/svelte/tests/interval/interval-state.construction-modes.test.ts
+++ b/packages/svelte/tests/interval/interval-state.construction-modes.test.ts
@@ -130,7 +130,7 @@ describe("createIntervalState semantic Candidate consumption", () => {
       consumptionCandidates: () => sharedBag,
     });
 
-    state.applyBrushSelectEnd(brushEvent(model, { keys: ["0", "1"] }), "pointer");
+    state.finishBrushSelect(brushEvent(model, { keys: ["0", "1"] }), "pointer");
     flushSync();
     keyCalls = 0;
     const keys = state.effectiveIntervalKeys;
@@ -142,7 +142,7 @@ describe("createIntervalState semantic Candidate consumption", () => {
 });
 
 describe("createIntervalState local mode", () => {
-  it("applyBrushSelectEnd (persistent) commits record; clear empties and emits once; second clear is silent", () => {
+  it("finishBrushSelect (persistent) commits record; clear empties and emits once; second clear is silent", () => {
     const model = modelFor(continuousSpec());
     const events: PlotSelection[] = [];
     const { state, destroy } = mountIntervalController({
@@ -154,7 +154,7 @@ describe("createIntervalState local mode", () => {
     });
 
     const brush = brushEvent(model);
-    state.applyBrushSelectEnd(brush, "pointer");
+    state.finishBrushSelect(brush, "pointer");
     flushSync();
 
     const panelId = model.scene.panels[0]?.id;
@@ -167,13 +167,15 @@ describe("createIntervalState local mode", () => {
     // Public keys surface: literal keys from the event are stored.
     expect(state.effectiveIntervals[0]?.keys).toEqual(["0", "1"]);
     expect(state.effectiveIntervalKeys.length).toBeGreaterThan(0);
-    // applyBrushSelectEnd never emits — host owns emission.
-    expect(events).toEqual([]);
+    // finishBrushSelect emits end after commit (listeners see committed state).
+    expect(events).toHaveLength(1);
+    expect(events[0]?.phase).toBe("end");
+    expect(events[0]?.source).toBe("pointer");
 
     state.clearIntervalSelection("pointer");
     flushSync();
-    expect(events).toHaveLength(1);
-    expect(events[0]).toMatchObject({
+    expect(events).toHaveLength(2);
+    expect(events[1]).toMatchObject({
       type: "select",
       phase: "clear",
       mode: "xy",
@@ -211,7 +213,7 @@ describe("createIntervalState controller mode", () => {
     });
 
     const brush = brushEvent(model, { keys: ["k0"] });
-    state.applyBrushSelectEnd(brush, "pointer");
+    state.finishBrushSelect(brush, "pointer");
     flushSync();
     expect(state.effectiveIntervals).toHaveLength(1);
     expect(state.committedInterval).not.toBeNull();
@@ -225,7 +227,7 @@ describe("createIntervalState controller mode", () => {
 
     // Re-commit, then same-panel replacement with different domains clears
     // the pixel rect via sameIntervalRecord gate.
-    state.applyBrushSelectEnd(brush, "pointer");
+    state.finishBrushSelect(brush, "pointer");
     flushSync();
     expect(state.committedInterval).not.toBeNull();
 
@@ -271,7 +273,7 @@ describe("createIntervalState controller mode", () => {
       },
     });
 
-    state.applyBrushSelectEnd(
+    state.finishBrushSelect(
       brushEvent(model, {
         panelId: north.id,
         domain: { x: [0.5, 1.5], y: [0.5, 1.5] },
@@ -279,7 +281,7 @@ describe("createIntervalState controller mode", () => {
       }),
       "pointer",
     );
-    state.applyBrushSelectEnd(
+    state.finishBrushSelect(
       brushEvent(model, {
         panelId: south.id,
         domain: { x: [1.5, 2.5], y: [1.5, 2.5] },
@@ -336,7 +338,7 @@ describe("createIntervalState clearCurrentPanelInterval", () => {
       },
     });
 
-    state.applyBrushSelectEnd(
+    state.finishBrushSelect(
       brushEvent(model, {
         panelId: north.id,
         domain: { x: [0.5, 1.5], y: [0.5, 1.5] },
@@ -344,7 +346,7 @@ describe("createIntervalState clearCurrentPanelInterval", () => {
       }),
       "pointer",
     );
-    state.applyBrushSelectEnd(
+    state.finishBrushSelect(
       brushEvent(model, {
         panelId: south.id,
         domain: { x: [1.5, 2.5], y: [1.5, 2.5] },
@@ -398,7 +400,7 @@ describe("createIntervalState interval target availability", () => {
       selectConfig: persistentSelect,
     });
 
-    state.applyBrushSelectEnd(
+    state.finishBrushSelect(
       brushEvent(facetModel, {
         panelId: north.id,
         domain: { x: [0.5, 1.5], y: [0.5, 1.5] },
@@ -434,7 +436,7 @@ describe("createIntervalState semanticAxis (public behavior)", () => {
       selectConfig: persistentSelect,
     });
 
-    state.applyBrushSelectEnd(
+    state.finishBrushSelect(
       brushEvent(bandModel, {
         domain: {
           x: ["north", "south"],
@@ -452,7 +454,7 @@ describe("createIntervalState semanticAxis (public behavior)", () => {
     });
 
     // Empty/axis-less: domain with unmappable bounds → private commit early-
-    // returns (no record, no throw). applyBrushSelectEnd still writes
+    // returns (no record, no throw). finishBrushSelect still writes
     // committedInterval first (host 1796 order) — pin that synchronous write
     // before the reconcile effect (which drops the pixel rect when no record
     // backs it) has a chance to run.
@@ -468,7 +470,7 @@ describe("createIntervalState semanticAxis (public behavior)", () => {
       lineageCount: 0,
       source: "pointer",
     });
-    state.applyBrushSelectEnd(axisless, "pointer");
+    state.finishBrushSelect(axisless, "pointer");
     expect(state.committedInterval).not.toBeNull();
     expect(state.committedInterval?.panelId).toBe(panelId);
     expect(state.effectiveIntervals).toEqual([]);

--- a/packages/svelte/tests/surface/surface-state.brush.test.ts
+++ b/packages/svelte/tests/surface/surface-state.brush.test.ts
@@ -50,7 +50,7 @@ describe("createSurfaceState brush lifecycle", () => {
     expect(h.interval.committedInterval).toBeNull();
     expect(h.selectionEvents.some((e) => e.phase === "change")).toBe(true);
 
-    // Phase: pointerup select-end → real interval controller commits + end emit
+    // Phase: pointerup select-end → interval finishBrushSelect commits + emits
     h.surface.onPointerUp(pointerEvent("pointerup", h.capture, { clientX: end.x, clientY: end.y }));
     flushSync();
     expect(h.surface.brushRect).toBeNull();
@@ -58,14 +58,11 @@ describe("createSurfaceState brush lifecycle", () => {
     expect(h.interval.effectiveIntervals.length).toBeGreaterThan(0);
     const phases = h.selectionEvents.map((e) => e.phase);
     expect(phases[0]).toBe("start");
-    expect(phases.at(-1)).toBe("end");
     expect(phases.includes("change")).toBe(true);
-    // Load-bearing order: interval commit before host end emit (onselection
-    // readers may observe committedInterval synchronously in the callback).
-    const commitAt = h.selectionOrderLog.indexOf("commit");
-    const emitEndAt = h.selectionOrderLog.indexOf("emit:end");
-    expect(commitAt).toBeGreaterThanOrEqual(0);
-    expect(emitEndAt).toBeGreaterThan(commitAt);
+    expect(phases.filter((p) => p === "end")).toHaveLength(1);
+    expect(phases.at(-1)).toBe("end");
+    expect(h.selectionOrderLog).toContain("emit:end:after-commit");
+    expect(h.selectionOrderLog).not.toContain("emit:end:before-commit");
 
     h.destroy();
   });

--- a/packages/svelte/tests/surface/surface-state.construction-effects.test.ts
+++ b/packages/svelte/tests/surface/surface-state.construction-effects.test.ts
@@ -94,7 +94,7 @@ describe("createSurfaceState construction", () => {
         intervalCalls++;
         return null;
       },
-      applyBrushSelectEnd: () => {
+      finishBrushSelect: () => {
         intervalCalls++;
       },
     });
@@ -225,7 +225,7 @@ describe("createSurfaceState construction", () => {
       },
     });
     const stubInterval = fromAny<SurfaceStateDeps["interval"] extends () => infer R ? R : never>({
-      applyBrushSelectEnd: () => {},
+      finishBrushSelect: () => {},
       get committedInterval() {
         return null;
       },

--- a/packages/svelte/tests/surface/surface-state.harness.ts
+++ b/packages/svelte/tests/surface/surface-state.harness.ts
@@ -216,8 +216,9 @@ export type SurfaceHarness = {
   flushFrames: () => void;
   selectionEvents: PlotSelection[];
   /**
-   * Ordered side-effect log for select-end characterization:
-   * `commit` from applyBrushSelectEnd, `emit:<phase>` from emitSelection.
+   * Ordered emit log. For phase `end`, suffix records whether
+   * `interval.committedInterval` was already set when the emit ran
+   * (`after-commit` vs `before-commit`).
    */
   selectionOrderLog: string[];
   toolChanges: InteractionTool[];
@@ -343,7 +344,15 @@ export function mountSurfaceComposite(
       interval: () => interval,
       zoom: () => zoom,
       emitSelection: (event) => {
-        selectionOrderLog.push(`emit:${event.phase}`);
+        if (event.phase === "end") {
+          selectionOrderLog.push(
+            interval.committedInterval === null
+              ? "emit:end:before-commit"
+              : "emit:end:after-commit",
+          );
+        } else {
+          selectionOrderLog.push(`emit:${event.phase}`);
+        }
         selectionEvents.push(event);
       },
       semanticKey,
@@ -385,20 +394,21 @@ export function mountSurfaceComposite(
       },
       inspectionPanel: () => inspection.inspectionPanel,
       emitSelection: (event) => {
-        selectionOrderLog.push(`emit:${event.phase}`);
+        if (event.phase === "end") {
+          selectionOrderLog.push(
+            interval.committedInterval === null
+              ? "emit:end:before-commit"
+              : "emit:end:after-commit",
+          );
+        } else {
+          selectionOrderLog.push(`emit:${event.phase}`);
+        }
         selectionEvents.push(event);
       },
       announce: (message) => {
         announcements.push(message);
       },
     });
-
-    // Characterize select-end order: interval commit is recorded before emit.
-    const applyBrushSelectEnd = interval.applyBrushSelectEnd.bind(interval);
-    interval.applyBrushSelectEnd = (event, source) => {
-      selectionOrderLog.push("commit");
-      applyBrushSelectEnd(event, source);
-    };
 
     // 5. surface effects then 6. inspection effects (host 810 vs 954)
     if (options.registerEffects !== false) {


### PR DESCRIPTION
## Summary

- Replace `applyBrushSelectEnd` (write-only; host must emit after) with `finishBrushSelect` that **commits then emits**
- Surface `select-end` only builds the event and calls interval; no second `emitSelection`
- Tests: emit observes committed state; exactly one end event; non-persistent still emits end once

Codex plan review: **GO** (with test-strengthening adjustments applied).

## Test plan

- [x] interval + surface brush suites
- [x] type-aware lint
- [ ] CI green