### PR TITLE
perf(core): unique-first resolution() O(R+U log U) (#493)

### DIFF
--- a/.changeset/resolution-unique-first.md
+++ b/.changeset/resolution-unique-first.md
@@ -1,0 +1,10 @@
+---
+"@ggsvelte/core": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+perf: unique-first resolution() O(R+U log U); continuous bars reuse helper
+
+`resolution` dedupes finite values before sorting so multiset columns only pay
+sort cost over distinct gaps. Continuous bar width uses the same helper.

--- a/packages/core/src/pipeline/geometry-rects.ts
+++ b/packages/core/src/pipeline/geometry-rects.ts
@@ -2,6 +2,7 @@
  * Bar/col (and binned histogram) rect geometry batch builder.
  */
 import type { RectsBatch } from "../scene.js";
+import { resolution } from "../stats/numeric.js";
 
 import type { LayerFrame, PipelineWarning, ResolvedColorScale } from "./types.js";
 import { colorOf } from "./types.js";
@@ -27,17 +28,12 @@ export function rectsBatch(
     // binned position scale applies the authored/default width fraction.
     widthFrac = binding.xBinning === undefined ? 0 : (params.width ?? DEFAULT_BAR_WIDTH);
   } else {
-    const values = [...(frame.xNumeric ?? [])]
-      .filter((value) => Number.isFinite(value))
-      .toSorted((a, b) => a - b);
-    let resolution = Number.POSITIVE_INFINITY;
-    for (let index = 1; index < values.length; index++) {
-      const gap = values[index]! - values[index - 1]!;
-      if (gap > 0 && gap < resolution) resolution = gap;
-    }
-    if (!Number.isFinite(resolution)) resolution = 1;
+    // Continuous x: bar width ∝ min positive gap (ggplot2 resolution).
+    // Fewer than two distinct values → fallback gap of 1 (pre-#493 inline path).
+    const gap = resolution(frame.xNumeric ?? []);
+    const resolvedGap = gap > 0 ? gap : 1;
     const span = fx.xScale.transformedDomain[1] - fx.xScale.transformedDomain[0];
-    widthFrac = span === 0 ? 0 : ((params.width ?? DEFAULT_BAR_WIDTH) * resolution) / span;
+    widthFrac = span === 0 ? 0 : ((params.width ?? DEFAULT_BAR_WIDTH) * resolvedGap) / span;
   }
 
   const { rects, rowIndexKept, keptRows, removed } = emitRectRows({

--- a/packages/core/src/stats/numeric.ts
+++ b/packages/core/src/stats/numeric.ts
@@ -62,18 +62,21 @@ export function quantile7(sorted: readonly number[] | Float64Array, p: number): 
  * ggplot2's resolution(): the smallest positive difference between distinct
  * finite values. Returns 0 when there are fewer than two distinct values
  * (jitter then adds no offset — nothing to jitter within).
+ *
+ * Unique-first (Set) then sort: O(R + U log U) instead of O(R log R) on
+ * multisets — only distinct gaps matter (#493).
  */
 export function resolution(values: readonly number[] | Float64Array): number {
-  const finite: number[] = [];
+  const unique = new Set<number>();
   for (let i = 0; i < values.length; i++) {
     const v = values[i]!;
-    if (Number.isFinite(v)) finite.push(v);
+    if (Number.isFinite(v)) unique.add(v);
   }
-  if (finite.length < 2) return 0;
-  finite.sort((a, b) => a - b);
+  if (unique.size < 2) return 0;
+  const sorted = [...unique].toSorted((a, b) => a - b);
   let min = Infinity;
-  for (let i = 1; i < finite.length; i++) {
-    const d = finite[i]! - finite[i - 1]!;
+  for (let i = 1; i < sorted.length; i++) {
+    const d = sorted[i]! - sorted[i - 1]!;
     if (d > 0 && d < min) min = d;
   }
   return Number.isFinite(min) ? min : 0;

--- a/packages/core/tests/stats-unit.test.ts
+++ b/packages/core/tests/stats-unit.test.ts
@@ -36,6 +36,13 @@ describe("numeric helpers", () => {
     expect(resolution([0, 0.5, NaN, 2])).toBe(0.5);
   });
 
+  it("resolution unique-first still finds min gap on large multisets (#493)", () => {
+    // R ≫ U: many duplicates, few distinct. Gap between 0 and 0.25 is the min.
+    const values = Float64Array.from({ length: 50_000 }, (_, i) => (i % 4) * 0.25);
+    expect(resolution(values)).toBe(0.25);
+    expect(resolution([1, 1, 1, 1, 3, 3, 3, 7, 7])).toBe(2);
+  });
+
   it("mulberry32 is deterministic and uniform in [0, 1)", () => {
     const a = mulberry32(42);
     const b = mulberry32(42);


### PR DESCRIPTION
## Summary

Closes #493.

- resolution(): unique-first via Set, then toSorted — O(R + U log U) vs O(R log R) on multisets
- Continuous bar width in geometry-rects.ts calls resolution() (DRY); gap 0 still falls back to 1
- Characterization: 50k multiset with 4 distinct values returns min gap 0.25

## Tests

- bun test packages/core/tests/stats-unit.test.ts
- continuous rect projection + rect slot / col geom suites green
