### PR TITLE
refactor(docs): extract output status strings and primary nav links

### DIFF
--- a/apps/docs/src/lib/components/GettingStartedGuide.svelte
+++ b/apps/docs/src/lib/components/GettingStartedGuide.svelte
@@ -11,6 +11,7 @@
     QUICKSTART_PAGE_SVELTE,
     QUICKSTART_PORTABLE_SPEC_FRAGMENT,
   } from "$scripts/quickstart";
+  import { nextRovingTabIndex } from "$lib/tab-roving";
 
   import CopyCode from "./CopyCode.svelte";
 
@@ -20,6 +21,7 @@
     { weight: 3.1, economy: 25 },
     { weight: 4, economy: 19 },
   ];
+  const lessonSurfaces = ["output", "svelte"] as const;
   let lessonEnhanced = $state(false);
   let lessonSurface = $state<"output" | "svelte">("output");
   let outputTab = $state<HTMLButtonElement>();
@@ -38,19 +40,11 @@
   }
 
   function handleLessonTabs(event: KeyboardEvent): void {
-    if (event.key === "ArrowLeft" || event.key === "ArrowRight") {
-      event.preventDefault();
-      selectLessonSurface(
-        lessonSurface === "output" ? "svelte" : "output",
-        true,
-      );
-    } else if (event.key === "Home") {
-      event.preventDefault();
-      selectLessonSurface("output", true);
-    } else if (event.key === "End") {
-      event.preventDefault();
-      selectLessonSurface("svelte", true);
-    }
+    const index = lessonSurface === "output" ? 0 : 1;
+    const next = nextRovingTabIndex(event.key, index, lessonSurfaces.length);
+    if (next === null) return;
+    event.preventDefault();
+    selectLessonSurface(lessonSurfaces[next]!, true);
   }
 
   const lessonCars = [

--- a/apps/docs/src/lib/components/PlaygroundOutput.svelte
+++ b/apps/docs/src/lib/components/PlaygroundOutput.svelte
@@ -1,10 +1,16 @@
 <script lang="ts">
   import { tick, untrack } from "svelte";
 
-  import { copyText, MANUAL_COPY_STATUS } from "$lib/clipboard";
+  import { copyText } from "$lib/clipboard";
   import UiButton from "$lib/components/UiButton.svelte";
   import { playgroundSVGExport } from "$lib/playground-export";
   import type { PlaygroundOutput } from "$lib/playground-output";
+  import {
+    PLAYGROUND_SVG_DOWNLOADED_STATUS,
+    playgroundCopyStatus,
+    playgroundSvgDownloadFailureStatus,
+    playgroundSvgExportFailureStatus,
+  } from "$lib/playground-output-status";
   import { nextRovingTabIndex } from "$lib/tab-roving";
   import type { PortableSpec } from "@ggsvelte/spec";
 
@@ -81,10 +87,7 @@
     if (revision !== outputRevision) return;
     copying = false;
     manualFallback = result !== "copied";
-    copyStatus =
-      result === "copied"
-        ? `${selected.label} output copied.`
-        : MANUAL_COPY_STATUS;
+    copyStatus = playgroundCopyStatus(selected.label, result);
   }
 
   function exportSVG(): void {
@@ -92,7 +95,7 @@
     exportStatus = "";
     const result = playgroundSVGExport(rendered);
     if (!result.ok) {
-      exportStatus = `SVG export failed · ${result.diagnostic.source}/${result.diagnostic.code}: ${result.diagnostic.message} ${result.diagnostic.fix ?? ""}`;
+      exportStatus = playgroundSvgExportFailureStatus(result.diagnostic);
       return;
     }
 
@@ -106,9 +109,9 @@
       anchor.href = objectUrl;
       anchor.download = result.filename;
       anchor.click();
-      exportStatus = "SVG downloaded.";
+      exportStatus = PLAYGROUND_SVG_DOWNLOADED_STATUS;
     } catch (error) {
-      exportStatus = `SVG export failed · export/download-failed: ${error instanceof Error ? error.message : "The browser refused the download."} The chart and outputs were retained.`;
+      exportStatus = playgroundSvgDownloadFailureStatus(error);
     } finally {
       if (objectUrl !== null) URL.revokeObjectURL(objectUrl);
     }

--- a/apps/docs/src/lib/components/SiteHeader.svelte
+++ b/apps/docs/src/lib/components/SiteHeader.svelte
@@ -8,6 +8,7 @@
     writeDocsAppearance,
     type DocsAppearance,
   } from "$lib/docs-appearance";
+  import { primaryNavLinks } from "$lib/primary-nav-links";
   import { primaryNavigationOwner } from "$lib/routes";
   import type { DocsRouteMetadata } from "$lib/route-types";
 
@@ -20,38 +21,7 @@
   let search = $state<{ open: (trigger: HTMLElement) => void }>();
   let appearance = $state<DocsAppearance>("light");
 
-  const links = $derived([
-    {
-      label: "Docs",
-      href: "/docs",
-      active: owner === "docs",
-    },
-    {
-      label: "Gallery",
-      href: "/examples",
-      active: path.startsWith("/examples"),
-    },
-    {
-      label: "Playground",
-      href: "/playground",
-      active: path === "/playground",
-    },
-    {
-      label: "Themes",
-      href: "/themes",
-      active: path === "/themes",
-    },
-    {
-      label: "Interactions",
-      href: "/interactions",
-      active: path === "/interactions",
-    },
-    {
-      label: "Reference",
-      href: "/reference",
-      active: owner === "reference",
-    },
-  ]);
+  const links = $derived(primaryNavLinks(path, owner));
 
   function syncAppearance(): void {
     appearance = readDocsAppearance();

--- a/apps/docs/src/lib/playground-output-status.ts
+++ b/apps/docs/src/lib/playground-output-status.ts
@@ -1,0 +1,17 @@
+import { MANUAL_COPY_STATUS } from "./clipboard";
+import type { PlaygroundDiagnostic } from "./playground-state-types";
+
+export const PLAYGROUND_SVG_DOWNLOADED_STATUS = "SVG downloaded.";
+
+export function playgroundCopyStatus(label: string, result: "copied" | "manual"): string {
+  return result === "copied" ? `${label} output copied.` : MANUAL_COPY_STATUS;
+}
+
+export function playgroundSvgExportFailureStatus(diagnostic: PlaygroundDiagnostic): string {
+  return `SVG export failed · ${diagnostic.source}/${diagnostic.code}: ${diagnostic.message} ${diagnostic.fix ?? ""}`;
+}
+
+export function playgroundSvgDownloadFailureStatus(error: unknown): string {
+  const detail = error instanceof Error ? error.message : "The browser refused the download.";
+  return `SVG export failed · export/download-failed: ${detail} The chart and outputs were retained.`;
+}

--- a/apps/docs/src/lib/primary-nav-links.ts
+++ b/apps/docs/src/lib/primary-nav-links.ts
@@ -1,0 +1,43 @@
+export type PrimaryNavOwner = "docs" | "reference";
+
+export type PrimaryNavLink = {
+  readonly label: string;
+  readonly href: string;
+  readonly active: boolean;
+};
+
+/** Primary site chrome links shared by desktop nav and the mobile menu. */
+export function primaryNavLinks(path: string, owner?: PrimaryNavOwner): readonly PrimaryNavLink[] {
+  return [
+    {
+      label: "Docs",
+      href: "/docs",
+      active: owner === "docs",
+    },
+    {
+      label: "Gallery",
+      href: "/examples",
+      active: path.startsWith("/examples"),
+    },
+    {
+      label: "Playground",
+      href: "/playground",
+      active: path === "/playground",
+    },
+    {
+      label: "Themes",
+      href: "/themes",
+      active: path === "/themes",
+    },
+    {
+      label: "Interactions",
+      href: "/interactions",
+      active: path === "/interactions",
+    },
+    {
+      label: "Reference",
+      href: "/reference",
+      active: owner === "reference",
+    },
+  ];
+}

--- a/scripts/playground-output-status.test.ts
+++ b/scripts/playground-output-status.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+
+import { MANUAL_COPY_STATUS } from "../apps/docs/src/lib/clipboard";
+import {
+  PLAYGROUND_SVG_DOWNLOADED_STATUS,
+  playgroundCopyStatus,
+  playgroundSvgDownloadFailureStatus,
+  playgroundSvgExportFailureStatus,
+} from "../apps/docs/src/lib/playground-output-status";
+
+describe("playgroundCopyStatus", () => {
+  test("reports copied label and manual fallback", () => {
+    expect(playgroundCopyStatus("Svelte", "copied")).toBe("Svelte output copied.");
+    expect(playgroundCopyStatus("Builder", "manual")).toBe(MANUAL_COPY_STATUS);
+  });
+});
+
+describe("playground SVG export status", () => {
+  test("formats diagnostic failures with optional fix", () => {
+    expect(
+      playgroundSvgExportFailureStatus({
+        source: "export",
+        code: "svg-export-failed",
+        path: "",
+        message: "Could not serialize.",
+        fix: "Retry after apply.",
+      }),
+    ).toBe("SVG export failed · export/svg-export-failed: Could not serialize. Retry after apply.");
+    expect(
+      playgroundSvgExportFailureStatus({
+        source: "pipeline",
+        code: "render-failed",
+        path: "/layers",
+        message: "Boom",
+      }),
+    ).toBe("SVG export failed · pipeline/render-failed: Boom ");
+  });
+
+  test("formats download failures and success constant", () => {
+    expect(playgroundSvgDownloadFailureStatus(new Error("Denied"))).toBe(
+      "SVG export failed · export/download-failed: Denied The chart and outputs were retained.",
+    );
+    expect(playgroundSvgDownloadFailureStatus("x")).toBe(
+      "SVG export failed · export/download-failed: The browser refused the download. The chart and outputs were retained.",
+    );
+    expect(PLAYGROUND_SVG_DOWNLOADED_STATUS).toBe("SVG downloaded.");
+  });
+});

--- a/scripts/primary-nav-links.test.ts
+++ b/scripts/primary-nav-links.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+
+import { primaryNavLinks } from "../apps/docs/src/lib/primary-nav-links";
+
+describe("primaryNavLinks", () => {
+  test("marks docs owner and gallery path prefixes", () => {
+    const links = primaryNavLinks("/guide/getting-started", "docs");
+    expect(links.map((link) => link.label)).toEqual([
+      "Docs",
+      "Gallery",
+      "Playground",
+      "Themes",
+      "Interactions",
+      "Reference",
+    ]);
+    expect(links.find((link) => link.href === "/docs")?.active).toBe(true);
+    expect(links.find((link) => link.href === "/examples")?.active).toBe(false);
+    expect(links.find((link) => link.href === "/reference")?.active).toBe(false);
+  });
+
+  test("marks gallery children and exact playground/themes/interactions", () => {
+    expect(
+      primaryNavLinks("/examples/point/scatter").find((link) => link.href === "/examples")?.active,
+    ).toBe(true);
+    expect(primaryNavLinks("/playground").find((link) => link.href === "/playground")?.active).toBe(
+      true,
+    );
+    expect(primaryNavLinks("/themes").find((link) => link.href === "/themes")?.active).toBe(true);
+    expect(
+      primaryNavLinks("/interactions").find((link) => link.href === "/interactions")?.active,
+    ).toBe(true);
+  });
+
+  test("marks reference owner", () => {
+    expect(
+      primaryNavLinks("/reference/cli", "reference").find((link) => link.href === "/reference")
+        ?.active,
+    ).toBe(true);
+    expect(
+      primaryNavLinks("/reference/cli", "reference").find((link) => link.href === "/docs")?.active,
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Maintainability pass on `apps/docs` after appearance helpers (#490/#494).

### Candidates

1. **PlaygroundOutput** status strings for copy/SVG export were untested UI copy contracts (visual tests match substrings)
2. **SiteHeader** primary nav active rules duplicated desktop/mobile via one `$derived` array but not unit-tested
3. **GettingStartedGuide** lesson tab keyboard reimplemented roving instead of shared `nextRovingTabIndex`

### What changed

| Module | Role |
|--------|------|
| `playground-output-status.ts` | copy + SVG export/download status formatters |
| `primary-nav-links.ts` | primary chrome link list + active rules |
| PlaygroundOutput / SiteHeader / GettingStartedGuide | thin wiring |

## Tests

- New unit tests for status formatters and nav active matrix
- Existing tab-roving suite still green
- `check:docs`, knip, type-aware lint clean
- Visual: `playground.spec.ts` + `docs-shell.spec.ts` 38/38

## Follow-ups

None — remaining large docs modules are intentional orchestrators (Playground page) or cohesive pure machines/CSS-heavy shells.