### PR TITLE
perf(core): unique-first resolution() O(R+U log U)

### DIFF
--- a/.changeset/resolution-unique-first.md
+++ b/.changeset/resolution-unique-first.md
@@ -1,0 +1,10 @@
+---
+"@ggsvelte/core": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+perf: unique-first resolution() O(R+U log U) for jitter/errorbar/bar width
+
+`resolution()` dedupes finite values before sorting so multiset columns cost
+O(R + U log U). Continuous geom_col bar width reuses the helper (gap 0 → 1).

--- a/packages/core/src/pipeline/geometry-rects.ts
+++ b/packages/core/src/pipeline/geometry-rects.ts
@@ -2,6 +2,7 @@
  * Bar/col (and binned histogram) rect geometry batch builder.
  */
 import type { RectsBatch } from "../scene.js";
+import { resolution as resolutionOf } from "../stats/numeric.js";
 
 import type { LayerFrame, PipelineWarning, ResolvedColorScale } from "./types.js";
 import { colorOf } from "./types.js";
@@ -27,15 +28,11 @@ export function rectsBatch(
     // binned position scale applies the authored/default width fraction.
     widthFrac = binding.xBinning === undefined ? 0 : (params.width ?? DEFAULT_BAR_WIDTH);
   } else {
-    const values = [...(frame.xNumeric ?? [])]
-      .filter((value) => Number.isFinite(value))
-      .toSorted((a, b) => a - b);
-    let resolution = Number.POSITIVE_INFINITY;
-    for (let index = 1; index < values.length; index++) {
-      const gap = values[index]! - values[index - 1]!;
-      if (gap > 0 && gap < resolution) resolution = gap;
-    }
-    if (!Number.isFinite(resolution)) resolution = 1;
+    // Continuous bar width tracks min positive x-gap (ggplot2 resolution).
+    // Fewer than two distinct x values → resolution 0 → fall back to gap 1 so
+    // widthFrac still has a finite data-unit scale (pre-unique-first parity).
+    const gap = resolutionOf(frame.xNumeric ?? []);
+    const resolution = gap > 0 ? gap : 1;
     const span = fx.xScale.transformedDomain[1] - fx.xScale.transformedDomain[0];
     widthFrac = span === 0 ? 0 : ((params.width ?? DEFAULT_BAR_WIDTH) * resolution) / span;
   }

--- a/packages/core/src/stats/numeric.ts
+++ b/packages/core/src/stats/numeric.ts
@@ -62,18 +62,24 @@ export function quantile7(sorted: readonly number[] | Float64Array, p: number): 
  * ggplot2's resolution(): the smallest positive difference between distinct
  * finite values. Returns 0 when there are fewer than two distinct values
  * (jitter then adds no offset — nothing to jitter within).
+ *
+ * Unique-first (Set) then sort U: O(R + U log U) instead of sorting the full
+ * multiset O(R log R). Duplicates never affect the min positive gap.
  */
 export function resolution(values: readonly number[] | Float64Array): number {
-  const finite: number[] = [];
+  const unique: number[] = [];
+  const seen = new Set<number>();
   for (let i = 0; i < values.length; i++) {
     const v = values[i]!;
-    if (Number.isFinite(v)) finite.push(v);
+    if (!Number.isFinite(v) || seen.has(v)) continue;
+    seen.add(v);
+    unique.push(v);
   }
-  if (finite.length < 2) return 0;
-  finite.sort((a, b) => a - b);
+  if (unique.length < 2) return 0;
+  unique.sort((a, b) => a - b);
   let min = Infinity;
-  for (let i = 1; i < finite.length; i++) {
-    const d = finite[i]! - finite[i - 1]!;
+  for (let i = 1; i < unique.length; i++) {
+    const d = unique[i]! - unique[i - 1]!;
     if (d > 0 && d < min) min = d;
   }
   return Number.isFinite(min) ? min : 0;

--- a/packages/core/tests/geometry-rects-resolution.test.ts
+++ b/packages/core/tests/geometry-rects-resolution.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Continuous geom_col bar width uses stats.resolution (unique-first).
+ * Locks resolution()===0 → gap=1 fallback for lone/all-equal x.
+ */
+import { describe, expect, it } from "bun:test";
+
+import { aes, gg } from "@ggsvelte/spec";
+
+import { runPipeline } from "../src/pipeline.ts";
+
+const size = { width: 1000, height: 400 };
+
+function rectWidths(model: ReturnType<typeof runPipeline>): number[] {
+  const batch = model.scene.batches.find((b) => b.kind === "rects");
+  if (batch === undefined || batch.kind !== "rects") throw new Error("expected rects");
+  const widths: number[] = [];
+  for (let i = 0; i < batch.rects.length; i += 4) widths.push(batch.rects[i + 2]!);
+  return widths;
+}
+
+describe("continuous geom_col — resolution-driven bar width", () => {
+  it("min positive x-gap scales bar width (multiset cardinality ignored)", () => {
+    // Same domain [0,6]; min gaps 2 vs 1 → widths 2×.
+    const scales = {
+      x: {
+        type: "linear" as const,
+        domain: [0, 6] as [number, number],
+        expand: { mult: 0, add: 0 },
+      },
+      y: { type: "linear" as const, expand: { mult: 0, add: 0 } },
+    };
+    // Many duplicates of the same three x values — unique-first still sees gap 2.
+    const wideRows = Array.from({ length: 30 }, (_, i) => ({
+      x: [0, 2, 6][i % 3]!,
+      y: 1,
+    }));
+    const narrowRows = Array.from({ length: 30 }, (_, i) => ({
+      x: [0, 1, 6][i % 3]!,
+      y: 1,
+    }));
+    const wide = runPipeline(
+      gg(wideRows, aes({ x: "x", y: "y" }))
+        .geomCol({ width: 1 })
+        .scales(scales)
+        .spec(),
+      size,
+    );
+    const narrow = runPipeline(
+      gg(narrowRows, aes({ x: "x", y: "y" }))
+        .geomCol({ width: 1 })
+        .scales(scales)
+        .spec(),
+      size,
+    );
+    const wWide = rectWidths(wide)[0]!;
+    const wNarrow = rectWidths(narrow)[0]!;
+    expect(wWide / wNarrow).toBeCloseTo(2, 5);
+  });
+
+  it("all-equal continuous x uses gap=1 fallback (resolution 0)", () => {
+    // Without fallback, widthFrac would be 0 and bars would vanish.
+    const model = runPipeline(
+      gg(
+        [
+          { x: 5, y: 1 },
+          { x: 5, y: 2 },
+          { x: 5, y: 3 },
+        ],
+        aes({ x: "x", y: "y" }),
+      )
+        .geomCol({ width: 1 })
+        .scales({
+          x: { type: "linear", expand: { mult: 0, add: 0 } },
+          y: { type: "linear", expand: { mult: 0, add: 0 } },
+        })
+        .spec(),
+      size,
+    );
+    const widths = rectWidths(model);
+    expect(widths.length).toBe(3);
+    for (const w of widths) expect(w).toBeGreaterThan(0);
+  });
+});

--- a/packages/core/tests/stats-unit.test.ts
+++ b/packages/core/tests/stats-unit.test.ts
@@ -36,6 +36,16 @@ describe("numeric helpers", () => {
     expect(resolution([0, 0.5, NaN, 2])).toBe(0.5);
   });
 
+  it("resolution ignores multiset cardinality (unique-first)", () => {
+    // 10k rows over three distinct x values — gap is min(1,2)=1, not affected by dups.
+    const many = Float64Array.from({ length: 10_000 }, (_, i) => [0, 1, 3][i % 3]!);
+    expect(resolution(many)).toBe(1);
+    expect(resolution(Float64Array.from({ length: 5000 }, () => 7))).toBe(0);
+    expect(resolution(new Float64Array(0))).toBe(0);
+    // SameValueZero: +0 and -0 collapse; positive gaps only.
+    expect(resolution([0, -0, 1])).toBe(1);
+  });
+
   it("mulberry32 is deterministic and uniform in [0, 1)", () => {
     const a = mulberry32(42);
     const b = mulberry32(42);


### PR DESCRIPTION
## Summary

`/bigo-maintain` on `packages/core` — deferred #493 from the canvas subset pass.

### Finding

- **File:** `packages/core/src/stats/numeric.ts` (`resolution`)
- **Pattern:** sort full multiset when only distinct gaps matter
- **Before:** O(R log R) collect-all-finite + sort
- **After:** O(R + U log U) unique-first Set, sort U, min adjacent gap
- **n:** R = finite column length (jitter / errorbar / continuous bar width); U = distinct values

Also DRY: continuous `geom_col` bar width in `geometry-rects.ts` calls `resolution()` and maps `0 → gap 1` (lone/all-equal x still get finite bars).

### Codex plan review

Required pipeline lock for `resolution()===0 → gap=1`; multiset width ratio + all-equal bars. Correctness tests only (no fake complexity bench).

### Tests

```text
bun test packages/core/tests/stats-unit.test.ts packages/core/tests/geometry-rects-resolution.test.ts
# 20 pass
```

### Follow-ups

Closes https://github.com/ljodea/ggsvelte/issues/493

## Test plan

- [x] Existing resolution characterization
- [x] Unique-first multiset / empty / plus-minus zero
- [x] Continuous geom_col width scales with min gap under duplicates
- [x] All-equal continuous x bars remain positive width
