### PR TITLE
fix(core): closed ribbons resolve frame rows from emitted path (#502)

### DIFF
--- a/.changeset/closed-frame-rows-ribbon.md
+++ b/.changeset/closed-frame-rows-ribbon.md
@@ -1,0 +1,11 @@
+---
+"@ggsvelte/core": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+fix: closed ribbons map coord semantic indices via emitted frame rows
+
+Area/density/smooth closed bands attach `closedFrameRows` for each
+pre-projection vertex so candidate frame-row resolve survives non-finite edge
+filtering under `coordTransform`.

--- a/packages/core/src/pipeline/candidate-construction/frame-row.ts
+++ b/packages/core/src/pipeline/candidate-construction/frame-row.ts
@@ -134,16 +134,24 @@ export function resolveCandidateFrameRow(input: {
         frameRow = rowsInGroup[Math.min(reflected, rowsInGroup.length - 1)] ?? frameRow;
       }
     } else if (batch.closed === true) {
-      const resolved = resolveClosedBandFrameRow(
-        getClosedBandLayout(frame, orderedGroups),
-        primitiveIndex,
-      );
-      if (resolved === null) {
-        frameRow = Math.min(Math.max(0, primitiveIndex), Math.max(0, frame.n - 1));
+      // Prefer emitted closed-band frame rows (filtered ribbons) when present —
+      // layout from full frame groups mis-reflects after non-finite edge drops (#502).
+      const emitted = batch.closedFrameRows;
+      if (emitted !== undefined && primitiveIndex >= 0 && primitiveIndex < emitted.length) {
+        frameRow = emitted[primitiveIndex]!;
         derivedGroup = frame.groups[frameRow] ?? derivedGroup;
       } else {
-        frameRow = resolved.frameRow;
-        derivedGroup = resolved.derivedGroup;
+        const resolved = resolveClosedBandFrameRow(
+          getClosedBandLayout(frame, orderedGroups),
+          primitiveIndex,
+        );
+        if (resolved === null) {
+          frameRow = Math.min(Math.max(0, primitiveIndex), Math.max(0, frame.n - 1));
+          derivedGroup = frame.groups[frameRow] ?? derivedGroup;
+        } else {
+          frameRow = resolved.frameRow;
+          derivedGroup = resolved.derivedGroup;
+        }
       }
     } else {
       // Open paths: semantic index is the pre-split vertex / frame row.

--- a/packages/core/src/pipeline/geometry-paths-area.ts
+++ b/packages/core/src/pipeline/geometry-paths-area.ts
@@ -23,14 +23,15 @@ export function areaBatch(
   for (const rows of groupRows) rows.sort((a, b) => sortKey(a) - sortKey(b));
 
   // Draw later-stacked groups first so the first-seen group paints on top.
-  const { positions, rowIndex, pathOffsets, fills, strokes } = writeClosedPathGroups({
-    frame,
-    fx,
-    groupRows,
-    yTop: frame.ymax,
-    yBottom: frame.ymin,
-    fillOf: (rows) => areaGroupFillOf(frame, fill, rows),
-  });
+  const { positions, rowIndex, closedFrameRows, pathOffsets, fills, strokes } =
+    writeClosedPathGroups({
+      frame,
+      fx,
+      groupRows,
+      yTop: frame.ymax,
+      yBottom: frame.ymin,
+      fillOf: (rows) => areaGroupFillOf(frame, fill, rows),
+    });
 
   const params: { alpha?: number } =
     binding.layer.geom === "area" || binding.layer.geom === "density"
@@ -42,6 +43,7 @@ export function areaBatch(
     panelIndex: 0,
     positions,
     rowIndex,
+    closedFrameRows,
     pathOffsets,
     strokes,
     fills,

--- a/packages/core/src/pipeline/geometry-paths-closed-batch.ts
+++ b/packages/core/src/pipeline/geometry-paths-closed-batch.ts
@@ -15,6 +15,7 @@ export function writeClosedPathGroups(input: {
 }): {
   positions: Float32Array;
   rowIndex: Uint32Array;
+  closedFrameRows: Uint32Array;
   pathOffsets: Uint32Array;
   fills: (string | null)[];
   strokes: (string | null)[];
@@ -24,6 +25,7 @@ export function writeClosedPathGroups(input: {
   for (const rows of groupRows) total += rows.length * 2;
   const positions = new Float32Array(total * 2);
   const rowIndex = new Uint32Array(total);
+  const closedFrameRows = new Uint32Array(total);
   const pathOffsets = new Uint32Array(groupRows.length + 1);
   const fills: (string | null)[] = [];
   const strokes: (string | null)[] = [];
@@ -34,6 +36,7 @@ export function writeClosedPathGroups(input: {
     cursor = appendClosedBandEdges({
       positions,
       rowIndex,
+      closedFrameRows,
       cursor,
       rows,
       frame,
@@ -45,5 +48,5 @@ export function writeClosedPathGroups(input: {
     strokes.push(null);
   }
   pathOffsets[groupRows.length] = cursor;
-  return { positions, rowIndex, pathOffsets, fills, strokes };
+  return { positions, rowIndex, closedFrameRows, pathOffsets, fills, strokes };
 }

--- a/packages/core/src/pipeline/geometry-paths-closed.ts
+++ b/packages/core/src/pipeline/geometry-paths-closed.ts
@@ -13,6 +13,8 @@ import { positionOf } from "./geometry-shared.js";
 export function appendClosedBandEdges(input: {
   positions: Float32Array;
   rowIndex: Uint32Array;
+  /** Optional parallel frame-row ids (same length as rowIndex / vertex count). */
+  closedFrameRows?: Uint32Array;
   cursor: number;
   rows: readonly number[];
   frame: LayerFrame;
@@ -20,7 +22,7 @@ export function appendClosedBandEdges(input: {
   yTop: Float64Array;
   yBottom: Float64Array;
 }): number {
-  const { positions, rowIndex, rows, frame, fx, yTop, yBottom } = input;
+  const { positions, rowIndex, closedFrameRows, rows, frame, fx, yTop, yBottom } = input;
   let cursor = input.cursor;
 
   for (const row of rows) {
@@ -29,6 +31,7 @@ export function appendClosedBandEdges(input: {
     positions[cursor * 2] = tx * fx.innerWidth;
     positions[cursor * 2 + 1] = fx.innerHeight - ty * fx.innerHeight;
     rowIndex[cursor] = frame.rowIndex[row]!;
+    if (closedFrameRows !== undefined) closedFrameRows[cursor] = row;
     cursor++;
   }
   for (let i = rows.length - 1; i >= 0; i--) {
@@ -38,6 +41,7 @@ export function appendClosedBandEdges(input: {
     positions[cursor * 2] = tx * fx.innerWidth;
     positions[cursor * 2 + 1] = fx.innerHeight - ty * fx.innerHeight;
     rowIndex[cursor] = frame.rowIndex[row]!;
+    if (closedFrameRows !== undefined) closedFrameRows[cursor] = row;
     cursor++;
   }
   return cursor;

--- a/packages/core/src/pipeline/geometry-smooth-ribbon.ts
+++ b/packages/core/src/pipeline/geometry-smooth-ribbon.ts
@@ -28,24 +28,25 @@ export function buildSmoothRibbonBatch(input: {
     .filter((rows) => rows.length > 1);
   if (bandRows.length === 0) return null;
 
-  const { positions, rowIndex, pathOffsets, fills, strokes } = writeClosedPathGroups({
-    frame,
-    fx,
-    groupRows: bandRows,
-    yTop: frame.ymax,
-    yBottom: frame.ymin,
-    fillOf: (rows) => {
-      const first = rows[0]!;
-      // Ribbon tint: fill channel, else the line's color (band matches
-      // its line in multi-series smooths), else theme accent.
-      return (
-        groupColor(fill, frame.fillValues, binding.fill.scaledConstant, first) ??
-        binding.fill.constant ??
-        groupColor(color, frame.colorValues, binding.color.scaledConstant, first) ??
-        binding.color.constant
-      );
-    },
-  });
+  const { positions, rowIndex, closedFrameRows, pathOffsets, fills, strokes } =
+    writeClosedPathGroups({
+      frame,
+      fx,
+      groupRows: bandRows,
+      yTop: frame.ymax,
+      yBottom: frame.ymin,
+      fillOf: (rows) => {
+        const first = rows[0]!;
+        // Ribbon tint: fill channel, else the line's color (band matches
+        // its line in multi-series smooths), else theme accent.
+        return (
+          groupColor(fill, frame.fillValues, binding.fill.scaledConstant, first) ??
+          binding.fill.constant ??
+          groupColor(color, frame.colorValues, binding.color.scaledConstant, first) ??
+          binding.color.constant
+        );
+      },
+    });
 
   return {
     kind: "paths",
@@ -53,6 +54,7 @@ export function buildSmoothRibbonBatch(input: {
     panelIndex: 0,
     positions,
     rowIndex,
+    closedFrameRows,
     pathOffsets,
     strokes,
     fills,

--- a/packages/core/src/scene.ts
+++ b/packages/core/src/scene.ts
@@ -60,6 +60,13 @@ export interface PathsBatch {
   /** Original/stat primitive index for each render vertex. Candidate datum
    * resolution uses this instead of synthetic render topology indexes. */
   semanticIndex?: Uint32Array;
+  /**
+   * Closed ribbons only: frame-row id per **pre-projection** semantic vertex
+   * (upper ascending, then lower descending). Matches emitted vertices after
+   * non-finite edge filtering so coord `semanticIndex` maps to the correct
+   * frame row (#502). Length = pre-projection vertex count.
+   */
+  closedFrameRows?: Uint32Array;
   /** Start offset (in points) of each subpath; length = subpathCount + 1. */
   pathOffsets: Uint32Array;
   /** Stroke color per subpath (null = theme ink). */

--- a/packages/core/tests/candidate-construction/frame-row.test.ts
+++ b/packages/core/tests/candidate-construction/frame-row.test.ts
@@ -162,6 +162,50 @@ describe("resolveCandidateFrameRow paths", () => {
     ).toEqual({ frameRow: 1, derivedGroup: 0 });
   });
 
+  /**
+   * Filtered closed ribbon (#502): non-finite ymin/ymax rows are dropped before
+   * emission. Layout over full frame groups would mis-map reverse legs under
+   * coord semanticIndex; closedFrameRows records the emitted sequence.
+   */
+  it("uses closedFrameRows for filtered ribbon semantic vertices under coord", async () => {
+    const { resolveCandidateFrameRow } =
+      await import("../../src/pipeline/candidate-construction/frame-row.ts");
+    // Frame has 4 rows; only rows 0 and 2 are finite on the band (emitted).
+    // Closed path: upper [0,2] then reverse lower [2,0] → closedFrameRows [0,2,2,0].
+    const frame = fromAny({
+      n: 4,
+      groups: [0, 0, 0, 0],
+      xNumeric: new Float64Array([0, 1, 2, 3]),
+      binding: { layer: { geom: "smooth" } },
+    });
+    const batch = fromAny({
+      kind: "paths",
+      closed: true,
+      pathOffsets: new Uint32Array([0, 20]),
+      semanticIndex: new Uint32Array(20),
+      closedFrameRows: new Uint32Array([0, 2, 2, 0]),
+    });
+    // Full-group reflection would map primitive 1 → frame row 1 (filtered out).
+    expect(
+      resolveCandidateFrameRow({
+        frame,
+        batch,
+        primitiveIndex: 1,
+        orderedGroups: [0],
+        outlierLocalRow: null,
+      }),
+    ).toEqual({ frameRow: 2, derivedGroup: 0 });
+    expect(
+      resolveCandidateFrameRow({
+        frame,
+        batch,
+        primitiveIndex: 3,
+        orderedGroups: [0],
+        outlierLocalRow: null,
+      }),
+    ).toEqual({ frameRow: 0, derivedGroup: 0 });
+  });
+
   it("resolves many subpaths without linear pathOffsets scans (O(log P))", async () => {
     const { resolveCandidateFrameRow } =
       await import("../../src/pipeline/candidate-construction/frame-row.ts");

--- a/packages/core/tests/pipeline-geometry/run-pipeline-regression.test.ts
+++ b/packages/core/tests/pipeline-geometry/run-pipeline-regression.test.ts
@@ -117,6 +117,40 @@ describe("buildBatch dispatch via runPipeline", () => {
     expect(col.scene.batches.some((b) => b.kind === "rects")).toBe(true);
   });
 
+  it("smooth se ribbon attaches closedFrameRows for emitted band vertices (#502)", () => {
+    // Dense enough for loess SE; x starts at 1 so log10 coord is defined.
+    const rows = Array.from({ length: 30 }, (_, i) => ({
+      x: i + 1,
+      y: Math.sin(i / 4) * 10 + 20,
+    }));
+    const model = runPipeline(
+      gg(rows, aes({ x: "x", y: "y" }))
+        .geomSmooth({ method: "loess", se: true, n: 20 })
+        .coordTransform({ x: "log10" })
+        .spec(),
+      size,
+    );
+    const ribbon = model.scene.batches.find(
+      (b) => b.kind === "paths" && b.closed === true && b.fills !== undefined,
+    );
+    expect(ribbon?.kind).toBe("paths");
+    if (ribbon?.kind !== "paths") return;
+    expect(ribbon.closedFrameRows).toBeDefined();
+    // Pre-projection semantic verts: closedFrameRows length matches original topology
+    // (semanticIndex maps render → that space after coord).
+    expect(ribbon.closedFrameRows!.length).toBeGreaterThan(0);
+    if (ribbon.semanticIndex !== undefined) {
+      for (const semantic of ribbon.semanticIndex) {
+        expect(semantic).toBeLessThan(ribbon.closedFrameRows!.length);
+      }
+    }
+    // All closedFrameRows index into the smooth evaluation frame (0..n-1).
+    for (const row of ribbon.closedFrameRows!) {
+      expect(row).toBeGreaterThanOrEqual(0);
+      expect(row).toBeLessThan(50);
+    }
+  });
+
   it("smooth with se ribbon emits closed ribbon path under the line", () => {
     const model = runPipeline(
       gg(


### PR DESCRIPTION
## Summary

Closes #502. Closed ribbons (area/density/smooth SE) can filter non-finite edges before emission. Candidate frame-row resolve under `coordTransform` used full-group layout and could map reverse legs to the wrong frame row.

### Fix
- `PathsBatch.closedFrameRows`: frame-row id per pre-projection semantic vertex
- Written in `writeClosedPathGroups` / `appendClosedBandEdges`
- Attached on area + smooth ribbon batches
- `resolveCandidateFrameRow` prefers `closedFrameRows` when present (fallback keeps prior layout)

## Tests
- unit: filtered ribbon semantic verts under coord
- e2e: smooth SE + log10 coord attaches closedFrameRows aligned with semanticIndex
