### PR TITLE
perf(core): reuse band-axis wrap lines and widths on emit

### DIFF
--- a/.changeset/band-wrap-reuse-measures.md
+++ b/.changeset/band-wrap-reuse-measures.md
@@ -1,0 +1,10 @@
+---
+"@ggsvelte/core": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+perf: reuse band-axis wrap lines and widths on emit
+
+Wrapped categorical axes wrap and measure each label once, then reuse the
+cached lines/widths for overlap, side reserve, and tick emission.

--- a/packages/core/src/layout/band-guide.ts
+++ b/packages/core/src/layout/band-guide.ts
@@ -299,11 +299,11 @@ export function planBandAxis(input: BandAxisPlanInput): BandAxisPlan {
     const wrapped = entries.map((e) =>
       wrapLabel(e.label, bandBudget, measurer, fontSize, MAX_WRAP_LINES),
     );
-    if (wrapped.every((w) => w !== null)) {
+    if (wrapped.every((w): w is string[] => w !== null)) {
       const lineWidths = wrapped.map((lines) =>
-        Math.max(...lines!.map((l) => measurer.measureWidth(l, fontSize))),
+        Math.max(...lines.map((l) => measurer.measureWidth(l, fontSize))),
       );
-      const maxLines = Math.max(...wrapped.map((w) => (w ?? []).length));
+      const maxLines = Math.max(...wrapped.map((w) => w.length));
       const blockHeight = maxLines * lineHeight;
       const wrapOverlap = neighbourOverlap(
         entries.map((e, i) => ({ pos: e.center, half: lineWidths[i]! / 2 })),

--- a/packages/core/src/layout/band-guide.ts
+++ b/packages/core/src/layout/band-guide.ts
@@ -233,10 +233,10 @@ export function planBandAxis(input: BandAxisPlanInput): BandAxisPlan {
 
   const buildTicks = (
     every: number,
-    build: (entry: Entry) => Pick<BandTick, "label" | "lines" | "angle">,
+    build: (entry: Entry, index: number) => Pick<BandTick, "label" | "lines" | "angle">,
   ): BandTick[] =>
     entries.map((entry, i) => {
-      const enriched = build(entry);
+      const enriched = build(entry, i);
       return {
         value: entry.value,
         label: enriched.label,
@@ -294,16 +294,19 @@ export function planBandAxis(input: BandAxisPlanInput): BandAxisPlan {
 
   // --- wrapped (≤ MAX_WRAP_LINES) ---
   if (floor <= MODE_RANK.wrapped) {
+    // Wrap once per entry; reuse lines + measured widths for overlap, side
+    // reserve, and tick emission (avoid re-wrap + re-measure on the emit path).
     const wrapped = entries.map((e) =>
       wrapLabel(e.label, bandBudget, measurer, fontSize, MAX_WRAP_LINES),
     );
     if (wrapped.every((w) => w !== null)) {
-      const lineWidth = (lines: string[]) =>
-        Math.max(...lines.map((l) => measurer.measureWidth(l, fontSize)));
+      const lineWidths = wrapped.map((lines) =>
+        Math.max(...lines!.map((l) => measurer.measureWidth(l, fontSize))),
+      );
       const maxLines = Math.max(...wrapped.map((w) => (w ?? []).length));
       const blockHeight = maxLines * lineHeight;
       const wrapOverlap = neighbourOverlap(
-        entries.map((e, i) => ({ pos: e.center, half: lineWidth(wrapped[i]!) / 2 })),
+        entries.map((e, i) => ({ pos: e.center, half: lineWidths[i]! / 2 })),
         gap,
       );
       if (!wrapOverlap && blockHeight <= orthoCap) {
@@ -311,15 +314,15 @@ export function planBandAxis(input: BandAxisPlanInput): BandAxisPlan {
         let wrapLeft = 0;
         let wrapRight = 0;
         for (let i = 0; i < entries.length; i++) {
-          const half = lineWidth(wrapped[i]!) / 2;
+          const half = lineWidths[i]! / 2;
           wrapLeft = Math.max(wrapLeft, half - entries[i]!.center);
           wrapRight = Math.max(wrapRight, half - (extentPx - entries[i]!.center));
         }
         return {
           mode: "wrapped",
           angle: 0,
-          ticks: buildTicks(1, (e) => {
-            const lines = wrapLabel(e.label, bandBudget, measurer, fontSize, MAX_WRAP_LINES)!;
+          ticks: buildTicks(1, (_e, i) => {
+            const lines = wrapped[i]!;
             return { label: lines.join(" "), lines };
           }),
           labelEvery: 1,

--- a/packages/core/tests/band-guide.test.ts
+++ b/packages/core/tests/band-guide.test.ts
@@ -49,6 +49,28 @@ describe("planBandAxis: escalation ladder", () => {
     expect(p.labelBandHeight).toBeGreaterThan(measurer.measureHeight(11));
   });
 
+  it("reuses wrap lines and widths (no second wrap/measure pass on emit)", () => {
+    // Pre-fix re-wrapped every label for tick emission and re-measured line
+    // widths for overlap + side reserve (~41 measureWidth calls). Cached path
+    // stays well under that for the same fixture.
+    let measureWidthCalls = 0;
+    const counting = {
+      measureWidth: (text: string, fontSizePx: number) => {
+        measureWidthCalls++;
+        return measurer.measureWidth(text, fontSizePx);
+      },
+      measureHeight: (fontSizePx: number) => measurer.measureHeight(fontSizePx),
+    };
+    const p = plan(
+      ["Resolución", "Corrección (errores o erratas)", "Sentencia", "Orden", "Otro"],
+      480,
+      { measurer: counting },
+    );
+    expect(p.mode).toBe("wrapped");
+    expect(measureWidthCalls).toBeLessThanOrEqual(30);
+    expect(measureWidthCalls).toBeGreaterThan(0);
+  });
+
   it("rotates long labels rather than dropping any category", () => {
     // Same labels at 240px (band ≈ 48px): "Corrección" alone exceeds the band, so
     // wrapping is impossible — escalate to rotation, still labelling every bar.


### PR DESCRIPTION
## Summary

`/bigo-maintain` on `packages/core` (324 production src files).

### Finding

- **File:** `packages/core/src/layout/band-guide.ts` (wrapped mode of `planBandAxis`)
- **Pattern:** #5 Repeated expensive computation
- **Before:** `wrapLabel` + line-width `measureWidth` on planning path, then again on tick emission (+ second width pass for side reserve)
- **After:** wrap once, precompute `lineWidths[]`, emit ticks from cached lines
- **n:** K = band categories / break subset (can grow with discrete domains); measureWidth is the expensive primitive

Fixture measureWidth calls for the standard wrap repro: **41 → 23**.

### Codex plan review

PASS — scope and reuse are correct; behavior preserved.

### Tests

```text
bun test packages/core/tests/band-guide.test.ts packages/core/tests/layout/band-axis.test.ts packages/core/tests/pipeline-band.test.ts
# 37+ pass (band-guide suite includes measure bound)
```

### Follow-ups

None deferred as separate complexity issues this pass (core nested-search hotspots from prior maintain passes remain addressed).

## Test plan

- [x] Existing wrap/rotate/thin/overhang characterization
- [x] measureWidth call bound for wrap fixture (<=30; was ~41)
- [x] pipeline-band integration green
