### PR TITLE
fix(scales): color follow-ups from post-merge #414 review

### DIFF
--- a/packages/core/src/pipeline/prepare-panels-frames.ts
+++ b/packages/core/src/pipeline/prepare-panels-frames.ts
@@ -1,7 +1,7 @@
 /**
  * Build per-panel LayerFrames: bind layers, stats, position, remap source rows.
  */
-import type { PortableSpec } from "@ggsvelte/spec";
+import { configuredColorScaleType, type PortableSpec } from "@ggsvelte/spec";
 
 import type { ColumnTable } from "../table.js";
 
@@ -166,11 +166,13 @@ export function buildPanelFrames(input: {
 
   for (let index = 0; index < normalized.layers.length; index++) {
     const binding = bindLayer(normalized.layers[index]!, index, table, warnings, conversions);
+    // Match resolveColorScale family intent (domainMode/onExhaust → ordinal)
+    // so line/stat grouping treats inferred ordinal color as discrete groups.
     binding.color.forcedDiscrete = ["ordinal", "manual"].includes(
-      normalized.scales?.color?.type ?? "",
+      configuredColorScaleType(normalized.scales?.color) ?? normalized.scales?.color?.type ?? "",
     );
     binding.fill.forcedDiscrete = ["ordinal", "manual"].includes(
-      normalized.scales?.fill?.type ?? "",
+      configuredColorScaleType(normalized.scales?.fill) ?? normalized.scales?.fill?.type ?? "",
     );
     bindings.push(binding);
   }

--- a/packages/core/src/pipeline/scale-color-sequential-format.ts
+++ b/packages/core/src/pipeline/scale-color-sequential-format.ts
@@ -54,7 +54,25 @@ function resolveColorLegendFormat(input: {
     return { label, fullLabel };
   }
 
-  let label = defaultTickFormat(tickStep(domain[0], domain[1], 5));
+  // Log colorbars use decade ticks; linear span precision labels sub-unit
+  // powers (0.001, 0.01, 0.1) as "0". Derive decimals from the domain floor.
+  const transform = config?.transform ?? "identity";
+  let label: (value: number) => string;
+  if (transform === "log10" && labelFormat === undefined) {
+    const positives = domain.filter((value) => Number.isFinite(value) && value > 0);
+    const minAbs = positives.length > 0 ? Math.min(...positives) : 1;
+    const decimals = minAbs < 1 ? Math.max(0, Math.ceil(-Math.log10(minAbs))) : 0;
+    label = (value: number) => {
+      if (!Number.isFinite(value)) return String(value);
+      if (decimals === 0) return defaultTickFormat(tickStep(domain[0], domain[1], 5))(value);
+      return value.toLocaleString("en-US", {
+        maximumFractionDigits: decimals,
+        minimumFractionDigits: 0,
+      });
+    };
+  } else {
+    label = defaultTickFormat(tickStep(domain[0], domain[1], 5));
+  }
   if (labelFormat !== undefined) {
     const formatter = numberFormatter(labelFormat);
     if (formatter.ok) {
@@ -78,7 +96,11 @@ export function resolveSequentialLegendFormat(
   return resolveColorLegendFormat({
     domain: scale.domain,
     temporalKind: scale.temporalKind ?? null,
-    config,
+    config: {
+      ...config,
+      ...(scale.transform !== undefined &&
+        config?.transform === undefined && { transform: scale.transform }),
+    },
     name,
     warnings,
   });

--- a/packages/core/src/pipeline/scale-color-sequential-format.ts
+++ b/packages/core/src/pipeline/scale-color-sequential-format.ts
@@ -16,11 +16,13 @@ export interface ColorLegendFormatter {
 function resolveColorLegendFormat(input: {
   domain: readonly [number, number];
   temporalKind: TemporalKind | null;
+  transform?: "identity" | "log10" | "sqrt";
   config: ColorScaleSpec | undefined;
   name: "color" | "fill";
   warnings: PipelineWarning[];
 }): ColorLegendFormatter {
   const { domain, temporalKind, config, name, warnings } = input;
+  const transform = input.transform ?? config?.transform ?? "identity";
   const labelFormat = config?.labels;
   if (temporalKind !== null) {
     const options = {
@@ -56,7 +58,6 @@ function resolveColorLegendFormat(input: {
 
   // Log colorbars use decade ticks; linear span precision labels sub-unit
   // powers (0.001, 0.01, 0.1) as "0". Derive decimals from the domain floor.
-  const transform = config?.transform ?? "identity";
   let label: (value: number) => string;
   if (transform === "log10" && labelFormat === undefined) {
     const positives = domain.filter((value) => Number.isFinite(value) && value > 0);
@@ -96,11 +97,8 @@ export function resolveSequentialLegendFormat(
   return resolveColorLegendFormat({
     domain: scale.domain,
     temporalKind: scale.temporalKind ?? null,
-    config: {
-      ...config,
-      ...(scale.transform !== undefined &&
-        config?.transform === undefined && { transform: scale.transform }),
-    },
+    transform: scale.transform,
+    config,
     name,
     warnings,
   });

--- a/packages/core/src/pipeline/scale-color-values.ts
+++ b/packages/core/src/pipeline/scale-color-values.ts
@@ -100,9 +100,12 @@ export function resolveColorValueView(input: {
     warnings.push({ code: "color-temporal-censored", message: cause });
   }
 
+  // Check kind whenever parse recovered a precision — including partial
+  // parseFailure: "censor" columns whose overall status is "invalid".
   if (
-    temporal &&
     config?.temporalKind !== undefined &&
+    parsed.decision.kind !== null &&
+    parsed.decision.kind !== undefined &&
     parsed.decision.kind !== config.temporalKind
   ) {
     throw colorScaleError(

--- a/packages/core/tests/pipeline-color-families.test.ts
+++ b/packages/core/tests/pipeline-color-families.test.ts
@@ -385,4 +385,73 @@ describe("generic non-position color scales", () => {
       }),
     );
   });
+
+  it("groups lines by inferred ordinal color from domainMode grow", () => {
+    const model = runPipeline(
+      fromAny({
+        data: {
+          values: [
+            { x: 1, y: 1, c: 1 },
+            { x: 2, y: 2, c: 2 },
+            { x: 3, y: 3, c: 1 },
+          ],
+        },
+        layers: [
+          {
+            geom: "line",
+            aes: { x: { field: "x" }, y: { field: "y" }, color: { field: "c" } },
+          },
+        ],
+        scales: { color: { domainMode: "grow" } },
+      }),
+      size,
+    );
+    expect(model.scales.color?.kind).toBe("ordinal");
+    const batch = model.scene.batches.find((candidate) => candidate.kind === "paths");
+    expect(batch?.kind).toBe("paths");
+    if (batch?.kind !== "paths") throw new Error("expected paths");
+    expect(batch.pathOffsets.length).toBe(3); // two series + terminal
+  });
+
+  it("formats log10 colorbar ticks with sub-unit decimals", () => {
+    const model = runPipeline(
+      pointSpec([0.001, 1000], { type: "sequential", transform: "log10" }),
+      size,
+    );
+    const legend = model.scene.legends.find((candidate) => candidate.type === "ramp");
+    if (legend?.type !== "ramp") throw new Error("expected ramp legend");
+    expect(legend.ticks.map((tick) => tick.label)).toContain("0.001");
+    expect(legend.ticks.map((tick) => tick.label)).not.toContain("0");
+  });
+
+  it("still checks temporalKind when parseFailure censors invalid rows", () => {
+    expect(() =>
+      runPipeline(
+        fromAny({
+          data: {
+            values: [
+              { x: 1, y: 1, t: "2024-01-01 12:00" },
+              { x: 2, y: 2, t: "bad" },
+              { x: 3, y: 3, t: "2024-02-01 12:00" },
+            ],
+          },
+          layers: [
+            {
+              geom: "point",
+              aes: { x: { field: "x" }, y: { field: "y" }, color: { field: "t" } },
+            },
+          ],
+          scales: {
+            color: {
+              type: "sequential",
+              temporalKind: "date",
+              parse: "ymd_hm",
+              parseFailure: "censor",
+            },
+          },
+        }),
+        size,
+      ),
+    ).toThrow(expect.objectContaining({ code: "color-temporal-kind" }));
+  });
 });

--- a/packages/spec/src/validate-data-checks.ts
+++ b/packages/spec/src/validate-data-checks.ts
@@ -111,22 +111,47 @@ function temporalDecisionForField(
   return decision;
 }
 
-function uniqueNonNullCount(values: readonly unknown[]): number {
-  const seen = new Set<string>();
-  for (const value of values) {
-    if (value === null) continue;
-    seen.add(typeof value === "string" ? value : JSON.stringify(value));
+/** Type-preserving key for discrete domain identity (mirrors core encodeKey). */
+function discreteDomainKey(value: unknown): string {
+  switch (typeof value) {
+    case "string":
+      return value.startsWith("@") ? "@" + value : value;
+    case "number":
+      if (Number.isNaN(value)) return "@n:NaN";
+      if (Object.is(value, -0)) return "@n:-0";
+      return "@n:" + String(value);
+    case "boolean":
+      return "@b:" + String(value);
+    case "bigint":
+      return "@i:" + value.toString();
+    case "undefined":
+      return "@undefined";
+    default:
+      if (value === null) return "@null";
+      if (value instanceof Date) {
+        const t = value.getTime();
+        return "@d:" + (Number.isNaN(t) ? "NaN" : String(t));
+      }
+      return JSON.stringify(value);
   }
-  return seen.size;
 }
 
 function expectedManualDomainLength(
   domain: unknown,
-  fieldValues: readonly unknown[] | null | undefined,
+  fieldValueLists: readonly (readonly unknown[] | null | undefined)[],
 ): number | null {
   if (Array.isArray(domain)) return domain.filter((value) => value !== null).length;
-  if (fieldValues === null || fieldValues === undefined) return null;
-  return uniqueNonNullCount(fieldValues);
+  const seen = new Set<string>();
+  let sawValues = false;
+  for (const values of fieldValueLists) {
+    if (values === null || values === undefined) continue;
+    sawValues = true;
+    for (const value of values) {
+      if (value === null) continue;
+      seen.add(discreteDomainKey(value));
+    }
+  }
+  return sawValues ? seen.size : null;
 }
 
 export function dataChecks(
@@ -462,12 +487,14 @@ export function dataChecks(
     const config = scales?.[channel] as ColorScaleSpec | undefined;
     const effectiveType = configuredColorScaleType(config);
 
-    // Manual range length vs domain / inferred unique values.
+    // Manual range length vs domain / inferred unique values (union across layers).
     if ((effectiveType === "manual" || config?.type === "manual") && Array.isArray(config?.range)) {
       const range = config.range;
-      for (const use of colorFields[channel]) {
-        const expected = expectedManualDomainLength(config.domain, fields.get(use.field)?.values);
-        if (expected === null || range.length === expected) continue;
+      const expected = expectedManualDomainLength(
+        config.domain,
+        colorFields[channel].map((use) => fields.get(use.field)?.values),
+      );
+      if (expected !== null && range.length !== expected) {
         errors.push({
           code: "scale-manual-domain-range",
           path: `/scales/${channel}`,
@@ -524,17 +551,29 @@ export function dataChecks(
             }),
           },
         );
-        const epochParser =
-          typeof config?.parse === "object" &&
-          config.parse !== null &&
-          "epoch" in (config.parse as object);
-        if (decision?.status !== "temporal" && !epochParser) {
+        if (decision?.status !== "temporal") {
           errors.push({
             code: "scale-type-mismatch",
             path: use.path,
-            message: `scales.${channel} requests temporal colors but field "${use.field}" is quantitative (numbers are not treated as temporal without an epoch parser).`,
+            message: `scales.${channel} requests temporal colors but field "${use.field}" is quantitative (numbers are not treated as temporal without a successful epoch parse).`,
             fix: {
-              description: `Map a temporal field, use parse: { epoch: "ms" | "s" }, or remove temporal color options.`,
+              description: `Map a temporal field, use a working parse: { epoch: "ms" | "s" }, or remove temporal color options.`,
+            },
+          });
+          continue;
+        }
+        if (
+          config?.temporalKind !== undefined &&
+          decision.kind !== null &&
+          decision.kind !== undefined &&
+          decision.kind !== config.temporalKind
+        ) {
+          errors.push({
+            code: "scale-type-mismatch",
+            path: use.path,
+            message: `scales.${channel} requests temporal kind "${config.temporalKind}" but field "${use.field}" parses as "${decision.kind}".`,
+            fix: {
+              description: `Use the ${decision.kind ?? "matching"} color helper or correct the source precision.`,
             },
           });
           continue;

--- a/packages/spec/src/validate-data-checks.ts
+++ b/packages/spec/src/validate-data-checks.ts
@@ -111,6 +111,24 @@ function temporalDecisionForField(
   return decision;
 }
 
+function uniqueNonNullCount(values: readonly unknown[]): number {
+  const seen = new Set<string>();
+  for (const value of values) {
+    if (value === null) continue;
+    seen.add(typeof value === "string" ? value : JSON.stringify(value));
+  }
+  return seen.size;
+}
+
+function expectedManualDomainLength(
+  domain: unknown,
+  fieldValues: readonly unknown[] | null | undefined,
+): number | null {
+  if (Array.isArray(domain)) return domain.filter((value) => value !== null).length;
+  if (fieldValues === null || fieldValues === undefined) return null;
+  return uniqueNonNullCount(fieldValues);
+}
+
 export function dataChecks(
   spec: Record<string, unknown>,
   options: ValidateOptions,
@@ -442,12 +460,30 @@ export function dataChecks(
 
   for (const channel of COLOR_CHANNELS) {
     const config = scales?.[channel] as ColorScaleSpec | undefined;
+    const effectiveType = configuredColorScaleType(config);
+
+    // Manual range length vs domain / inferred unique values.
+    if ((effectiveType === "manual" || config?.type === "manual") && Array.isArray(config?.range)) {
+      const range = config.range;
+      for (const use of colorFields[channel]) {
+        const expected = expectedManualDomainLength(config.domain, fields.get(use.field)?.values);
+        if (expected === null || range.length === expected) continue;
+        errors.push({
+          code: "scale-manual-domain-range",
+          path: `/scales/${channel}`,
+          message: `The manual ${channel} scale needs one range color per domain value (${String(expected)} values, ${String(range.length)} colors).`,
+          fix: {
+            description: `Provide ${String(expected)} range colors, or set scales.${channel}.domain explicitly to match the range length.`,
+          },
+        });
+      }
+    }
+
     const inferredFromSequentialScheme =
       config?.type === undefined &&
       config?.range === undefined &&
       config?.scheme !== undefined &&
       SEQUENTIAL_SCHEMES.has(config.scheme);
-    const effectiveType = configuredColorScaleType(config);
     if (effectiveType !== "sequential" && effectiveType !== "binned") continue;
     for (const use of colorFields[channel]) {
       const type = typeOf(use.field);
@@ -466,13 +502,47 @@ export function dataChecks(
         });
         continue;
       }
-      if (type !== "nominal" && type !== "ordinal") continue;
 
       const requestsTemporal =
         config?.temporalKind !== undefined ||
         config?.parse !== undefined ||
         config?.timezone !== undefined ||
         config?.disambiguation !== undefined;
+
+      // Quantitative fields with temporal-only options fail at resolve time.
+      if (type === "quantitative" && requestsTemporal) {
+        const info = fields.get(use.field);
+        const decision = temporalDecisionForField(
+          temporalDecisionCache,
+          use.field,
+          info,
+          config?.parse ?? "auto",
+          {
+            ...(config?.timezone !== undefined && { timezone: config.timezone }),
+            ...(config?.disambiguation !== undefined && {
+              disambiguation: config.disambiguation,
+            }),
+          },
+        );
+        const epochParser =
+          typeof config?.parse === "object" &&
+          config.parse !== null &&
+          "epoch" in (config.parse as object);
+        if (decision?.status !== "temporal" && !epochParser) {
+          errors.push({
+            code: "scale-type-mismatch",
+            path: use.path,
+            message: `scales.${channel} requests temporal colors but field "${use.field}" is quantitative (numbers are not treated as temporal without an epoch parser).`,
+            fix: {
+              description: `Map a temporal field, use parse: { epoch: "ms" | "s" }, or remove temporal color options.`,
+            },
+          });
+          continue;
+        }
+      }
+
+      if (type !== "nominal" && type !== "ordinal") continue;
+
       if (!requestsTemporal) {
         errors.push({
           code: "scale-type-mismatch",

--- a/packages/spec/tests/color-scale-api.test.ts
+++ b/packages/spec/tests/color-scale-api.test.ts
@@ -308,3 +308,53 @@ describe("color/fill scale authoring API", () => {
     ).toBe(false);
   });
 });
+
+describe("color scale data-aware validation", () => {
+  it("rejects manual range that is shorter than the inferred domain", () => {
+    const result = validate(
+      normalize({
+        data: {
+          values: [
+            { x: 1, y: 1, g: "a" },
+            { x: 2, y: 2, g: "b" },
+          ],
+        },
+        layers: [
+          {
+            geom: "point",
+            aes: { x: { field: "x" }, y: { field: "y" }, color: { field: "g" } },
+          },
+        ],
+        scales: { color: { type: "manual", range: ["#f00"] } },
+      }),
+      {},
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected failure");
+    expect(result.errors.some((error) => error.code === "scale-manual-domain-range")).toBe(true);
+  });
+
+  it("rejects temporal color options on quantitative fields without epoch parse", () => {
+    const result = validate(
+      normalize({
+        data: {
+          values: [
+            { x: 1, y: 1, c: 100 },
+            { x: 2, y: 2, c: 200 },
+          ],
+        },
+        layers: [
+          {
+            geom: "point",
+            aes: { x: { field: "x" }, y: { field: "y" }, color: { field: "c" } },
+          },
+        ],
+        scales: { color: { type: "sequential", temporalKind: "date", parse: "dmy" } },
+      }),
+      {},
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected failure");
+    expect(result.errors.some((error) => error.code === "scale-type-mismatch")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up for unrebutted **post-merge** Codex findings on #414 (generic color/fill families).

## Fixes

| Finding | Fix |
|---------|-----|
| Inferred ordinal color not grouped | `forcedDiscrete` uses `configuredColorScaleType` |
| Temporal options on quantitative fields | Data-aware `scale-type-mismatch` |
| Manual range shorter than domain | Data-aware `scale-manual-domain-range` |
| Log colorbar labels as `0` | Log-aware tick formatting |
| temporalKind skipped when censoring | Check `decision.kind` even when status is invalid |

## Parent

- https://github.com/ljodea/ggsvelte/pull/414

## Test plan

- [x] pipeline-color-families + color-scale-api data-aware tests
- [x] type-aware lint clean