### PR TITLE
refactor(docs): Svelte 5 PlaygroundOutput without effect-driven resets

### DIFF
--- a/apps/docs/src/lib/components/PlaygroundEditor.svelte
+++ b/apps/docs/src/lib/components/PlaygroundEditor.svelte
@@ -2,6 +2,10 @@
   import { tick } from "svelte";
 
   import UiButton from "$lib/components/UiButton.svelte";
+  import {
+    playgroundDiagnosticSignature,
+    shouldFocusDiagnosticsAlert,
+  } from "$lib/playground-output-ui";
   import type { PlaygroundDiagnostic } from "$lib/playground-state-types";
 
   const {
@@ -34,14 +38,12 @@
   let focusedSignature = "";
 
   $effect(() => {
-    const signature = diagnostics
-      .map((item) => `${item.source}:${item.code}:${item.path}`)
-      .join("|");
+    const signature = playgroundDiagnosticSignature(diagnostics);
     if (signature === "") {
       focusedSignature = "";
       return;
     }
-    if (signature === focusedSignature) return;
+    if (!shouldFocusDiagnosticsAlert(signature, focusedSignature)) return;
     focusedSignature = signature;
     void tick().then(() => alertElement?.focus());
   });

--- a/apps/docs/src/lib/components/PlaygroundOutput.svelte
+++ b/apps/docs/src/lib/components/PlaygroundOutput.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { tick, untrack } from "svelte";
+  import { tick } from "svelte";
 
   import { copyText } from "$lib/clipboard";
   import UiButton from "$lib/components/UiButton.svelte";
@@ -11,6 +11,10 @@
     playgroundSvgDownloadFailureStatus,
     playgroundSvgExportFailureStatus,
   } from "$lib/playground-output-status";
+  import {
+    clampOutputTabIndex,
+    copySessionMatchesOutputs,
+  } from "$lib/playground-output-ui";
   import { nextRovingTabIndex } from "$lib/tab-roving";
   import type { PortableSpec } from "@ggsvelte/spec";
 
@@ -24,38 +28,30 @@
     enabled: boolean;
   } = $props();
 
-  let active = $state(0);
+  let selected = $state(0);
   let fallbackSource = $state<HTMLElement>();
   let fallbackCode = $state("");
   let fallbackLabel = $state("output");
-  let manualFallback = $state(false);
+  let manualFallbackIntent = $state(false);
   let copying = $state(false);
-  let copyStatus = $state("");
+  let copyStatusRaw = $state("");
   let exportStatus = $state("");
-  let outputRevision = 0;
+  /** Outputs identity for the in-flight / completed copy session. */
+  let copySessionOutputs = $state<readonly PlaygroundOutput[] | null>(null);
   const tabsetId = $props.id();
   const panelId = `${tabsetId}-panel`;
+  const active = $derived(clampOutputTabIndex(selected, outputs.length));
   const activeOutput = $derived(outputs[active] ?? outputs[0]!);
-
-  $effect(() => {
-    const nextOutputs = outputs;
-    untrack(() => {
-      outputRevision += 1;
-      if (active >= nextOutputs.length) active = 0;
-      const hadFallback = fallbackCode !== "";
-      fallbackCode = "";
-      fallbackLabel = "output";
-      manualFallback = false;
-      copyStatus = "";
-      copying = false;
-      if (hadFallback) getSelection()?.removeAllRanges();
-    });
-  });
+  const copySessionLive = $derived(
+    copySessionMatchesOutputs(copySessionOutputs, outputs),
+  );
+  const manualFallback = $derived(manualFallbackIntent && copySessionLive);
+  const copyStatus = $derived(copySessionLive ? copyStatusRaw : "");
 
   function select(index: number): void {
     if (copying) return;
-    active = index;
-    copyStatus = "";
+    selected = index;
+    copyStatusRaw = "";
   }
 
   function handleTabKey(event: KeyboardEvent, index: number): void {
@@ -72,22 +68,27 @@
 
   async function copy(): Promise<void> {
     if (!enabled || !activeOutput.supported || copying) return;
-    const selected = activeOutput;
-    const revision = outputRevision;
-    fallbackCode = selected.code;
-    fallbackLabel = selected.label;
-    manualFallback = false;
+    const selectedOutput = activeOutput;
+    const sessionOutputs = outputs;
+    copySessionOutputs = sessionOutputs;
+    fallbackCode = selectedOutput.code;
+    fallbackLabel = selectedOutput.label;
+    manualFallbackIntent = false;
     copying = true;
     await tick();
     if (fallbackSource === undefined) {
       copying = false;
       return;
     }
-    const result = await copyText(selected.code, fallbackSource);
-    if (revision !== outputRevision) return;
+    const result = await copyText(selectedOutput.code, fallbackSource);
+    if (!copySessionMatchesOutputs(sessionOutputs, outputs)) {
+      // Outputs changed mid-copy; drop the in-flight session without applying UI.
+      copying = false;
+      return;
+    }
     copying = false;
-    manualFallback = result !== "copied";
-    copyStatus = playgroundCopyStatus(selected.label, result);
+    manualFallbackIntent = result !== "copied";
+    copyStatusRaw = playgroundCopyStatus(selectedOutput.label, result);
   }
 
   function exportSVG(): void {

--- a/apps/docs/src/lib/components/PlaygroundOutput.svelte
+++ b/apps/docs/src/lib/components/PlaygroundOutput.svelte
@@ -36,8 +36,11 @@
   let copying = $state(false);
   let copyStatusRaw = $state("");
   let exportStatus = $state("");
-  /** Outputs identity for the in-flight / completed copy session. */
-  let copySessionOutputs = $state<readonly PlaygroundOutput[] | null>(null);
+  /**
+   * Outputs identity for the in-flight / completed copy session.
+   * `$state.raw` keeps the reference unproxied so identity compares work.
+   */
+  let copySessionOutputs = $state.raw<readonly PlaygroundOutput[] | null>(null);
   const tabsetId = $props.id();
   const panelId = `${tabsetId}-panel`;
   const active = $derived(clampOutputTabIndex(selected, outputs.length));
@@ -47,6 +50,15 @@
   );
   const manualFallback = $derived(manualFallbackIntent && copySessionLive);
   const copyStatus = $derived(copySessionLive ? copyStatusRaw : "");
+  const visibleFallbackCode = $derived(copySessionLive ? fallbackCode : "");
+  const visibleFallbackLabel = $derived(
+    copySessionLive ? fallbackLabel : "output",
+  );
+
+  // Drop any manual-copy selection when the session is invalidated (e.g. promote).
+  $effect(() => {
+    if (!copySessionLive) getSelection()?.removeAllRanges();
+  });
 
   function select(index: number): void {
     if (copying) return;
@@ -196,10 +208,10 @@
   class="manual-copy-source"
   aria-hidden={!manualFallback}
 >
-  <p>Copy the selected {fallbackLabel} output manually:</p>
+  <p>Copy the selected {visibleFallbackLabel} output manually:</p>
   <!-- svelte-ignore a11y_no_noninteractive_tabindex (visible manual-copy source is scrollable) -->
   <pre tabindex={manualFallback ? 0 : -1}><code bind:this={fallbackSource}
-      >{fallbackCode}</code
+      >{visibleFallbackCode}</code
     ></pre>
 </div>
 

--- a/apps/docs/src/lib/playground-output-ui.ts
+++ b/apps/docs/src/lib/playground-output-ui.ts
@@ -1,0 +1,33 @@
+/**
+ * Pure helpers for PlaygroundOutput tab/copy UI decisions.
+ * Keeps Svelte components free of $effect-driven state resets.
+ */
+
+/** Clamp a selected tab index when the outputs list shrinks. */
+export function clampOutputTabIndex(active: number, count: number): number {
+  if (count <= 0) return 0;
+  return active >= count ? 0 : active;
+}
+
+/**
+ * Whether a copy session still applies to the current outputs identity.
+ * When the outputs reference changes, stale copy UI must not surface.
+ */
+export function copySessionMatchesOutputs<T>(sessionOutputs: T | null, currentOutputs: T): boolean {
+  return sessionOutputs !== null && sessionOutputs === currentOutputs;
+}
+
+export function playgroundDiagnosticSignature(
+  diagnostics: readonly {
+    readonly source: string;
+    readonly code: string;
+    readonly path: string;
+  }[],
+): string {
+  return diagnostics.map((item) => `${item.source}:${item.code}:${item.path}`).join("|");
+}
+
+/** True when focus should move to the diagnostics alert for a new signature. */
+export function shouldFocusDiagnosticsAlert(signature: string, previouslyFocused: string): boolean {
+  return signature !== "" && signature !== previouslyFocused;
+}

--- a/scripts/playground-output-ui.test.ts
+++ b/scripts/playground-output-ui.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  clampOutputTabIndex,
+  copySessionMatchesOutputs,
+  playgroundDiagnosticSignature,
+  shouldFocusDiagnosticsAlert,
+} from "../apps/docs/src/lib/playground-output-ui";
+
+describe("clampOutputTabIndex", () => {
+  test("keeps in-range indices and clamps OOB to 0", () => {
+    expect(clampOutputTabIndex(1, 3)).toBe(1);
+    expect(clampOutputTabIndex(0, 3)).toBe(0);
+    expect(clampOutputTabIndex(3, 3)).toBe(0);
+    expect(clampOutputTabIndex(5, 2)).toBe(0);
+  });
+
+  test("empty list yields 0", () => {
+    expect(clampOutputTabIndex(2, 0)).toBe(0);
+  });
+});
+
+describe("copySessionMatchesOutputs", () => {
+  test("matches only the same reference", () => {
+    const a = [{ kind: "svelte" }];
+    const b = [{ kind: "svelte" }];
+    expect(copySessionMatchesOutputs(a, a)).toBe(true);
+    expect(copySessionMatchesOutputs(a, b)).toBe(false);
+    expect(copySessionMatchesOutputs(null, a)).toBe(false);
+  });
+});
+
+describe("playgroundDiagnosticSignature", () => {
+  test("joins source:code:path and detects new focus targets", () => {
+    const signature = playgroundDiagnosticSignature([
+      { source: "validation", code: "invalid-json", path: "" },
+      { source: "playground", code: "share-limit", path: "draft" },
+    ]);
+    expect(signature).toBe("validation:invalid-json:|playground:share-limit:draft");
+    expect(shouldFocusDiagnosticsAlert(signature, "")).toBe(true);
+    expect(shouldFocusDiagnosticsAlert(signature, signature)).toBe(false);
+    expect(shouldFocusDiagnosticsAlert("", "x")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Maintainability pass on `apps/docs` after nav/status extracts (#499).

### Candidate

`PlaygroundOutput.svelte` used `$effect` + `untrack` to mutate tab/copy state whenever `outputs` changed — a Svelte 5 anti-pattern (state updates inside effects). Diagnostic focus signature logic in `PlaygroundEditor` was also pure-but-inlined.

### What changed

| Module | Role |
|--------|------|
| `playground-output-ui.ts` | `clampOutputTabIndex`, `copySessionMatchesOutputs`, diagnostic signature helpers |
| `PlaygroundOutput.svelte` | `$derived` active tab + copy-session identity; no effect/untrack reset loop |
| `PlaygroundEditor.svelte` | uses shared diagnostic signature helpers |

Copy sessions key off the `outputs` reference so stale copy UI drops when the chart changes, without clearing state inside an effect. Mid-copy abort clears `copying` so the button cannot stick.

## Tests

- New `scripts/playground-output-ui.test.ts`
- `check:docs`, knip, type-aware lint clean
- Visual `playground.spec.ts` with retries (known history/candidate flakes; copy/export paths green)

## Follow-ups

None for this loop. Remaining large docs modules are intentional orchestrators or cohesive pure machines / CSS shells.