### PR TITLE
refactor(svelte): single inspection authority in InspectionState

### DIFF
--- a/packages/svelte/src/lib/inspection/apply.ts
+++ b/packages/svelte/src/lib/inspection/apply.ts
@@ -53,8 +53,7 @@ export type SetInspectionAction =
  *
  * Host note: `apply` is not terminal. After resolve, a null coordinator
  * result re-enters via `setInspection(null, source)` (default transient),
- * re-running these gates. Host still owns resolve, reducer, emit, and
- * the post-dispatch `shouldCommitInspection` gate.
+ * re-running these gates. InspectionState owns resolve/commit/emit.
  */
 export function resolveSetInspectionAction(input: SetInspectionInput): SetInspectionAction {
   if (input.currentState === "pinned" && input.requestedState === "transient")
@@ -64,21 +63,6 @@ export function resolveSetInspectionAction(input: SetInspectionInput): SetInspec
     return { type: "clear", emitClear: input.currentState !== "none" };
   }
   return { type: "apply" };
-}
-
-/**
- * After reducer inspect (+ optional toggle-pin) dispatch for an apply path,
- * whether the host should commit the resolved snapshot into inspection state.
- * Host: when false, return without mutating inspection / seed / emit.
- */
-export function shouldCommitInspection(input: {
-  readonly requestedState: "transient" | "pinned";
-  /** Host: `reducer.state.inspection.kind` after dispatch. */
-  readonly reducerKind: string;
-}): boolean {
-  if (input.requestedState === "transient" && input.reducerKind !== "transient") return false;
-  if (input.requestedState === "pinned" && input.reducerKind !== "pinned") return false;
-  return true;
 }
 
 export type ToggleInspectionPinInput = {

--- a/packages/svelte/src/lib/inspection/inspection-state.svelte.ts
+++ b/packages/svelte/src/lib/inspection/inspection-state.svelte.ts
@@ -45,7 +45,6 @@ import {
   resolveToggleInspectionPinAction,
   shouldAnnounceUnpin,
   shouldClearInspectionAnnouncement,
-  shouldCommitInspection,
   shouldFocusPinnedInteractiveTooltip,
 } from "./apply.js";
 import {
@@ -172,6 +171,13 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
   let inspectionSeed: CandidateFacts | null = null;
   let lastInspectionFingerprint = "";
   let activeCandidateId: number | null = null;
+  /**
+   * Same-candidate suppression after dismiss of a *transient* inspection
+   * (Escape). Pinned dismiss does not set the latch. Cleared on different
+   * candidate apply, effective null-clear, and scene invalidate.
+   */
+  let dismissedCandidateId: number | null = null;
+  let dismissedRunId: number | null = null;
 
   let queuedPointerToken: {
     readonly epoch: number;
@@ -179,6 +185,16 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
   } | null = null;
   let queuedPointerInspection: QueuedPointerInspection | null = null;
   let pendingPinnedPointer: QueuedPointerInspection | null = null;
+
+  function clearDismissedLatch(): void {
+    dismissedCandidateId = null;
+    dismissedRunId = null;
+  }
+
+  /** Cancel inspect schedule + payload; optional stash clear. */
+  function invalidatePointerInspect(policy: CancelPointerInspectPolicy): void {
+    cancelPointerInspect(policy);
+  }
 
   // Construction-safe: own state + earlier host model.
   const inspectionPanel = $derived.by(() => {
@@ -266,6 +282,10 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
       })
     )
       deps.clearAnnouncement();
+    // Non-pointer applies must cancel queued hover (was: reducer boundary cancel).
+    if (source !== "pointer" && source !== "touch") {
+      invalidatePointerInspect({ pendingPinned: "preserve" });
+    }
     const action = resolveSetInspectionAction({
       hasHit: hit !== null,
       requestedState: state,
@@ -276,14 +296,11 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
       case "ignore":
         return;
       case "clear": {
-        // Preserve both dispatches (before emit/release and after) — do not
-        // dedupe; may be load-bearing for reducer revision counting.
-        deps.reducer().dispatch({ type: "inspect", candidate: null, source });
         if (action.emitClear) emitInspection({ type: "inspect", phase: "clear", source });
         inspection = null;
         inspectionSeed = null;
+        clearDismissedLatch();
         inspectionCoordinator.release("transient");
-        deps.reducer().dispatch({ type: "inspect", candidate: null, source });
         return;
       }
       case "apply": {
@@ -294,32 +311,27 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
           setInspection(null, source);
           return;
         }
-        const next = resolved.snapshot;
-        const candidateRef = {
-          epoch: deps.model()?.runId ?? 0,
-          id: resolved.seed.id,
-          panelId: next.panelId,
-          x: hit!.x,
-          y: hit!.y,
-        };
-        deps.reducer().dispatch({ type: "inspect", candidate: candidateRef, source });
-        if (state === "pinned") deps.reducer().dispatch({ type: "toggle-pin", source });
+        const runId = deps.model()?.runId ?? 0;
+        // Same-candidate dismiss latch (Escape on transient).
         if (
-          !shouldCommitInspection({
-            requestedState: state,
-            reducerKind: deps.reducer().state.inspection.kind,
-          })
+          dismissedCandidateId === resolved.seed.id &&
+          dismissedRunId === runId &&
+          state === "transient"
         )
           return;
-        inspection = next;
+        if (dismissedCandidateId !== null && dismissedCandidateId !== resolved.seed.id)
+          clearDismissedLatch();
+        inspection = resolved.snapshot;
         inspectionSeed = resolved.seed;
         activeCandidateId = resolved.seed.id;
-        if (resolved.semanticChanged) emitInspection(next, resolved.semanticFingerprint);
+        if (resolved.semanticChanged)
+          emitInspection(resolved.snapshot, resolved.semanticFingerprint);
       }
     }
   }
 
   function toggleInspectionPin(source: InteractionSource): void {
+    invalidatePointerInspect({ pendingPinned: "preserve" });
     const pinAction = resolveToggleInspectionPinAction({
       hasInspection: inspection !== null,
       hasSeed: inspectionSeed !== null,
@@ -327,12 +339,8 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
       pending: pendingPinnedPointer,
     });
     if (pinAction.type === "ignore") return;
-    // toggle-pin always runs before restore/flip side effects; if flip
-    // resolve returns null the reducer stays toggled (no rollback).
-    deps.reducer().dispatch({ type: "toggle-pin", source });
     switch (pinAction.type) {
       case "restore-pending": {
-        // Pure gate carries pending payload — no host non-null assert.
         pendingPinnedPointer = null;
         inspectionCoordinator.release("pinned");
         inspection = null;
@@ -347,38 +355,25 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
         return;
       }
       case "flip": {
-        // inspection + seed non-null after non-ignore (pure gate).
-        const state = pinAction.state;
+        const nextState = pinAction.state;
         const resolved = resolveInspection(
           hitFromCandidate(inspectionSeed!),
           source,
-          state,
+          nextState,
           inspection!.mode,
           inspectionSeed!,
         );
         if (resolved === null) return;
         inspection = resolved.snapshot;
         inspectionSeed = resolved.seed;
-        if (state === "transient")
-          deps.reducer().dispatch({
-            type: "inspect",
-            candidate: {
-              epoch: deps.model()?.runId ?? 0,
-              id: inspectionSeed.id,
-              panelId: resolved.snapshot.panelId,
-              x: inspectionSeed.x,
-              y: inspectionSeed.y,
-            },
-            source,
-          });
-        if (state === "transient") inspectionCoordinator.release("pinned");
-        if (shouldAnnounceUnpin({ state, source }))
+        if (nextState === "transient") inspectionCoordinator.release("pinned");
+        if (shouldAnnounceUnpin({ state: nextState, source }))
           deps.announce(`${inspectionLiveText(resolved.snapshot)}, unpinned`);
         if (resolved.semanticChanged)
           emitInspection(resolved.snapshot, resolved.semanticFingerprint);
         if (
           shouldFocusPinnedInteractiveTooltip({
-            state,
+            state: nextState,
             contentMode: deps.inspectConfig()?.contentMode,
           })
         )
@@ -394,7 +389,7 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
 
   /**
    * Shared dismiss path for Escape and closeInspection.
-   * Pure plan owns escape-vs-close differences; host owns dispatch/emit/DOM.
+   * Escape also cancels area via reducer; close does not masquerade as Escape.
    */
   function dismissInspection(
     kind: "escape" | "close",
@@ -411,7 +406,18 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
         returnToInspect: opts.returnToInspect,
       }),
     });
-    deps.reducer().dispatch({ type: "escape", source });
+    invalidatePointerInspect({
+      pendingPinned: plan.clearPendingPinned ? "discard" : "preserve",
+    });
+    // Latch only when dismissing a *transient* inspection (Escape path).
+    if (inspection?.state === "transient" && inspectionSeed !== null) {
+      dismissedCandidateId = inspectionSeed.id;
+      dismissedRunId = deps.model()?.runId ?? null;
+    } else if (inspection?.state === "pinned") {
+      clearDismissedLatch();
+    }
+    // Real Escape cancels area + bumps epoch; close does not.
+    if (kind === "escape") deps.reducer().dispatch({ type: "escape", source });
     if (plan.emitClear) emitInspection({ type: "inspect", phase: "clear", source });
     inspection = null;
     inspectionSeed = null;
@@ -580,11 +586,8 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
           inspectionCoordinator.invalidate();
           inspection = null;
           inspectionSeed = null;
-          deps.reducer().dispatch({
-            type: "inspect",
-            candidate: null,
-            source: "programmatic",
-          });
+          clearDismissedLatch();
+          invalidatePointerInspect({ pendingPinned: "discard" });
           return;
         case "invalidate-clear-transient":
         case "invalidate-idle":
@@ -596,16 +599,12 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
           pendingPinnedPointer = null;
           queuedPointerToken = null;
           deps.reducer().cancelScheduledPointer();
+          clearDismissedLatch();
           reconciledRun = runId;
           if (plan.type === "invalidate-clear-transient") {
             inspectionCoordinator.release("transient");
             inspection = null;
             inspectionSeed = null;
-            deps.reducer().dispatch({
-              type: "inspect",
-              candidate: null,
-              source: "programmatic",
-            });
             return;
           }
           if (plan.type === "invalidate-idle") return;
@@ -617,8 +616,7 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
             completeness: "complete",
           });
           if (reconciled === null) {
-            deps.reducer().dispatch({ type: "escape", source: "programmatic" });
-            deps.reducer().dispatch({ type: "set-active", candidate: null });
+            // Failed pinned reconcile: clear inspection only (not area Escape).
             emitInspection({
               type: "inspect",
               phase: "clear",

--- a/packages/svelte/src/lib/interaction/reducer.ts
+++ b/packages/svelte/src/lib/interaction/reducer.ts
@@ -1,5 +1,6 @@
 import type { InteractionSource, InteractionTool } from "./interaction.js";
 
+/** Candidate identity carried on inspect pointer-frame payloads (not reducer state). */
 export interface InteractionCandidateRef {
   readonly epoch: number;
   readonly id: number;
@@ -7,12 +8,6 @@ export interface InteractionCandidateRef {
   readonly x: number;
   readonly y: number;
 }
-
-export type InspectionState = Readonly<{
-  kind: "idle" | "transient" | "pinned" | "dismissed";
-  candidate: InteractionCandidateRef | null;
-  source: InteractionSource;
-}>;
 
 type AreaState =
   | Readonly<{ kind: "idle" }>
@@ -24,42 +19,33 @@ type AreaState =
       current: Readonly<{ x: number; y: number }>;
     }>;
 
+/**
+ * Reducer owns tool + area brush + frame epoch/revision.
+ * Inspection lifecycle lives solely in InspectionState (single authority).
+ */
 export interface InteractionReducerState {
   readonly revision: number;
   readonly epoch: number;
   readonly tool: InteractionTool;
-  readonly inspection: InspectionState;
   readonly area: AreaState;
-  readonly activeCandidate: InteractionCandidateRef | null;
 }
 
+/**
+ * Actions. `inspect` is a **pointer-frame payload only** — delivered to
+ * `onPointerFrame` and never stored on reducer state.
+ */
 export type InteractionAction =
   | { type: "inspect"; candidate: InteractionCandidateRef | null; source: InteractionSource }
-  | { type: "toggle-pin"; source: InteractionSource }
   | { type: "escape"; source: InteractionSource }
   | { type: "set-tool"; tool: InteractionTool }
   | { type: "begin-area"; point: Readonly<{ x: number; y: number }>; panelId: string | null }
   | { type: "move-area"; point: Readonly<{ x: number; y: number }> }
   | { type: "cancel-area" }
-  | { type: "set-active"; candidate: InteractionCandidateRef | null }
   | { type: "invalidate"; reason: "resize" | "data" | "scene" | "dispose" };
 
 export interface InteractionFrameToken {
   readonly epoch: number;
   readonly revision: number;
-}
-
-const idleInspection = (source: InteractionSource = "programmatic"): InspectionState => ({
-  kind: "idle",
-  candidate: null,
-  source,
-});
-
-function sameCandidate(
-  a: InteractionCandidateRef | null,
-  b: InteractionCandidateRef | null,
-): boolean {
-  return a === b || (a !== null && b !== null && a.epoch === b.epoch && a.id === b.id);
 }
 
 export type PointerScheduleKind = "inspect" | "move-area";
@@ -69,8 +55,9 @@ export function createInteractionReducer(
     initialTool?: InteractionTool;
     onChange?: (state: InteractionReducerState) => void;
     /**
-     * Continuous pointer-frame sink. Return `false` to skip the subsequent
-     * `dispatch` (atomic drop for stale inspect frames). Void/`true` dispatches.
+     * Continuous pointer-frame sink.
+     * - inspect: InspectionState only (never reducer-dispatched)
+     * - move-area: may return false to skip dispatch (unused today)
      */
     onPointerFrame?: (
       action: Extract<InteractionAction, { type: "inspect" | "move-area" }>,
@@ -83,9 +70,7 @@ export function createInteractionReducer(
     revision: 0,
     epoch: 0,
     tool: options.initialTool ?? "inspect",
-    inspection: idleInspection(),
     area: { kind: "idle" },
-    activeCandidate: null,
   };
   let scheduledPointerAction: Extract<InteractionAction, { type: "inspect" | "move-area" }> | null =
     null;
@@ -112,70 +97,26 @@ export function createInteractionReducer(
   };
 
   const dispatch = (action: InteractionAction): void => {
-    // Discrete boundaries always win over queued pointer coordinates. This
-    // keeps cancel/keyboard/tool changes synchronous with the visible state.
+    // Discrete boundaries always win over queued pointer coordinates.
     if (
       action.type === "escape" ||
       action.type === "set-tool" ||
       action.type === "cancel-area" ||
-      action.type === "invalidate" ||
-      ("source" in action && action.source !== "pointer" && action.source !== "touch")
+      action.type === "invalidate"
     )
       cancelScheduledPointer();
     switch (action.type) {
-      case "inspect": {
-        if (state.inspection.kind === "pinned") return;
-        if (action.candidate === null) {
-          if (state.inspection.kind === "idle") return;
-          commit({ inspection: idleInspection(action.source) });
-          return;
-        }
-        if (
-          state.inspection.kind === "dismissed" &&
-          sameCandidate(state.inspection.candidate, action.candidate)
-        )
-          return;
-        if (
-          state.inspection.kind === "transient" &&
-          sameCandidate(state.inspection.candidate, action.candidate)
-        )
-          return;
-        commit({
-          activeCandidate: action.candidate,
-          inspection: { kind: "transient", candidate: action.candidate, source: action.source },
-        });
+      case "inspect":
+        // Inspect payloads are frame-only; never mutate reducer state.
         return;
-      }
-      case "toggle-pin": {
-        const current = state.inspection;
-        if (current.kind === "pinned") {
-          commit({ inspection: idleInspection(action.source) });
-        } else if (current.candidate !== null) {
-          commit({
-            inspection: { kind: "pinned", candidate: current.candidate, source: action.source },
-          });
-        }
-        return;
-      }
-      case "escape": {
-        if (state.area.kind !== "idle") {
-          commit({ area: { kind: "idle" }, epoch: state.epoch + 1 });
-        } else if (state.inspection.kind === "pinned") {
-          commit({ inspection: idleInspection(action.source), epoch: state.epoch + 1 });
-        } else if (state.inspection.candidate === null) {
+      case "escape":
+        // Area cancel + epoch only. Inspection dismiss is InspectionState-owned.
+        if (state.area.kind === "idle") {
           commit({ epoch: state.epoch + 1 });
         } else {
-          commit({
-            inspection: {
-              kind: "dismissed",
-              candidate: state.inspection.candidate,
-              source: action.source,
-            },
-            epoch: state.epoch + 1,
-          });
+          commit({ area: { kind: "idle" }, epoch: state.epoch + 1 });
         }
         return;
-      }
       case "set-tool":
         if (state.tool !== action.tool || state.area.kind !== "idle") {
           commit({ tool: action.tool, area: { kind: "idle" }, epoch: state.epoch + 1 });
@@ -184,7 +125,6 @@ export function createInteractionReducer(
       case "begin-area":
         if (state.tool !== "select-area" && state.tool !== "zoom-area") return;
         commit({
-          inspection: idleInspection(),
           area: {
             kind: "first-corner",
             tool: state.tool,
@@ -200,10 +140,6 @@ export function createInteractionReducer(
         return;
       case "cancel-area":
         if (state.area.kind !== "idle") commit({ area: { kind: "idle" }, epoch: state.epoch + 1 });
-        return;
-      case "set-active":
-        if (!sameCandidate(state.activeCandidate, action.candidate))
-          commit({ activeCandidate: action.candidate });
         return;
       case "invalidate":
         commit({ area: { kind: "idle" }, epoch: state.epoch + 1 });
@@ -229,12 +165,14 @@ export function createInteractionReducer(
         frameHandle = null;
         const latest = scheduledPointerAction;
         scheduledPointerAction = null;
-        if (latest !== null) {
-          // false = atomic drop (e.g. stale inspect token): skip dispatch so
-          // reducer inspection does not diverge from InspectionState.
-          const shouldDispatch = options.onPointerFrame?.(latest);
-          if (shouldDispatch !== false) dispatch(latest);
+        if (latest === null) return;
+        // Inspect frames are owned by InspectionState — never reducer-dispatched.
+        if (latest.type === "inspect") {
+          options.onPointerFrame?.(latest);
+          return;
         }
+        const shouldDispatch = options.onPointerFrame?.(latest);
+        if (shouldDispatch !== false) dispatch(latest);
       });
     },
     cancelScheduledPointer,

--- a/packages/svelte/src/lib/surface/surface-handlers.ts
+++ b/packages/svelte/src/lib/surface/surface-handlers.ts
@@ -366,7 +366,7 @@ export function createSurfaceHandlers(live: SurfaceHandlerLive): SurfaceHandlers
     if (blurAction.type === "ignore") return;
     // Shared for keep-pinned and clear-inspection (ordering is load-bearing).
     deps.inspection().resetTraversalIndex();
-    reducer.dispatch({ type: "set-active", candidate: null });
+    deps.inspection().cancelPointerInspect({ pendingPinned: "preserve" });
     if (blurAction.type === "blur-clear-inspection")
       deps.inspection().setInspection(null, "keyboard");
   }

--- a/packages/svelte/tests/inspection/inspection-state.harness.ts
+++ b/packages/svelte/tests/inspection/inspection-state.harness.ts
@@ -115,27 +115,6 @@ export function applyInspect(
   );
 }
 
-/** Wrap a reducer so inspect-null dispatches are logged (shared spy). */
-export function wrapReducerWithLog(
-  base: InteractionReducer,
-  onInspectNull: (count: number) => void,
-): InteractionReducer {
-  let nullDispatches = 0;
-  return {
-    ...base,
-    dispatch: (action) => {
-      if (action.type === "inspect" && action.candidate === null) {
-        nullDispatches++;
-        onInspectNull(nullDispatches);
-      }
-      base.dispatch(action);
-    },
-    get state() {
-      return base.state;
-    },
-  };
-}
-
 export type InspectionHarness = {
   state: ReturnType<typeof createInspectionState>;
   reducer: InteractionReducer;

--- a/packages/svelte/tests/inspection/inspection-state.pin-queue.test.ts
+++ b/packages/svelte/tests/inspection/inspection-state.pin-queue.test.ts
@@ -23,7 +23,6 @@ import {
   mountInspectionController,
   noInspect,
   noInteraction,
-  wrapReducerWithLog,
   withFlushedEffectRoot,
   type InspectCb,
 } from "./inspection-state.harness.js";
@@ -165,7 +164,7 @@ describe("createInspectionState schedulePointerInspect / onInspectPointerFrame",
     flushSync();
     expect(state.inspection).toBeNull();
 
-    // Fresh schedule + flush → transient on both authorities.
+    // Fresh schedule + flush → InspectionState owns transient lifecycle.
     state.schedulePointerInspect({
       point: { x: candidate.x, y: candidate.y },
       source: "pointer",
@@ -175,8 +174,8 @@ describe("createInspectionState schedulePointerInspect / onInspectPointerFrame",
     flushFrame();
     flushSync();
     expect(state.inspection?.state).toBe("transient");
-    expect(reducer.state.inspection.kind).toBe("transient");
-    expect(reducer.state.inspection.candidate?.id).toBe(candidate.id);
+    // Reducer is not the inspection authority (no inspection field).
+    expect(reducer.state.revision).toBe(0);
 
     // Re-apply empty (queues cleared) keeps transient.
     expect(
@@ -195,12 +194,10 @@ describe("createInspectionState schedulePointerInspect / onInspectPointerFrame",
     flushSync();
     expect(state.inspection?.state).toBe("transient");
 
-    // Stale token → drop; skip reducer dispatch (atomic).
+    // Stale token → drop (no InspectionState apply).
     state.setInspection(null, "pointer");
     flushSync();
-    reducer.dispatch({ type: "inspect", candidate: null, source: "programmatic" });
-    // Clear activeCandidate so a later set-active is guaranteed to commit.
-    reducer.dispatch({ type: "set-active", candidate: null });
+    reducer.dispatch({ type: "set-tool", tool: "select-area" });
     state.schedulePointerInspect({
       point: { x: candidate.x, y: candidate.y },
       source: "pointer",
@@ -208,26 +205,16 @@ describe("createInspectionState schedulePointerInspect / onInspectPointerFrame",
       maxDistance: 1e6,
     });
     const scheduledToken = reducer.frameToken();
-    // Advance revision without cancelling the schedule (set-active with a
-    // different ref always commits when active was null).
+    // begin-area bumps revision without cancelling the inspect schedule.
     reducer.dispatch({
-      type: "set-active",
-      candidate: {
-        epoch: model.runId,
-        id: candidate.id + 10_000,
-        panelId: candidate.panelId,
-        x: candidate.x,
-        y: candidate.y,
-      },
+      type: "begin-area",
+      point: { x: 0, y: 0 },
+      panelId: "panel:all",
     });
     expect(reducer.accepts(scheduledToken)).toBe(false);
-    const revBefore = reducer.state.revision;
     flushFrame();
     flushSync();
     expect(state.inspection).toBeNull();
-    // Drop skipped dispatch — inspection kind stays idle (not transient).
-    expect(reducer.state.inspection.kind).toBe("idle");
-    expect(reducer.state.revision).toBe(revBefore);
 
     // Cancel before flush → no apply.
     state.schedulePointerInspect({
@@ -358,23 +345,16 @@ describe("createInspectionState schedulePointerInspect / onInspectPointerFrame",
   });
 });
 describe("createInspectionState setInspection(null) clear ordering", () => {
-  it("pins ordered sequence: dispatch1(non-null) → emit while still non-null → clear → dispatch2(null)", () => {
+  it("emits clear while inspection is still non-null, then clears state", () => {
     const model = modelFor(continuousSpec());
     const log: string[] = [];
-    // controllerRef lets both spies record inspection-nullness AT CALL TIME —
-    // that positional evidence is what discriminates the ordering (a refactor
-    // moving the state clear after the second dispatch flips dispatch-2's tag).
     let controllerRef: ReturnType<typeof createInspectionState> | null = null;
     const stateTag = (): string => (controllerRef?.inspection === null ? "null" : "non-null");
-    const base = createInteractionReducer();
-    const wrapped = wrapReducerWithLog(base, (count) => {
-      log.push(`dispatch-${count}-inspection-${stateTag()}`);
-    });
 
     const handle = withFlushedEffectRoot(() => {
       const controller = createInspectionState({
         model: () => model,
-        reducer: () => wrapped,
+        reducer: () => createInteractionReducer(),
         inspectConfig: defaultInspect,
         inspectEnabled: () => true,
         dataIdentityEpoch: () => "epoch-1",
@@ -404,17 +384,8 @@ describe("createInspectionState setInspection(null) clear ordering", () => {
 
     handle.value.setInspection(null, "pointer");
 
-    // Exact host order (base 1173-1180): first inspect-null dispatch and the
-    // clear emit both observe a STILL NON-NULL inspection; the state clear +
-    // coordinator release happen between the emit and the SECOND dispatch, so
-    // dispatch-2 observes null. (The transient coordinator release itself is
-    // module-private and not observable without API widening; its position is
-    // pinned transitively by the state-clear tag on dispatch-2.)
-    expect(log).toEqual([
-      "dispatch-1-inspection-non-null",
-      "emit-clear-inspection-non-null",
-      "dispatch-2-inspection-null",
-    ]);
+    // Single-authority clear: emit observes non-null, then state is null.
+    expect(log).toEqual(["emit-clear-inspection-non-null"]);
     expect(handle.value.inspection).toBeNull();
 
     handle.destroy();

--- a/packages/svelte/tests/inspection/surface-inspection.test.ts
+++ b/packages/svelte/tests/inspection/surface-inspection.test.ts
@@ -13,7 +13,6 @@ import {
   resolveToggleInspectionPinAction,
   shouldAnnounceUnpin,
   shouldClearInspectionAnnouncement,
-  shouldCommitInspection,
   shouldFocusPinnedInteractiveTooltip,
   type SetInspectionInput,
   type ToggleInspectionPinInput,
@@ -413,44 +412,6 @@ describe("buildQueuedInspectFrame", () => {
       x: 12,
       y: 24,
     });
-  });
-});
-
-describe("shouldCommitInspection", () => {
-  it("commits when reducer kind matches requested state", () => {
-    expect(
-      shouldCommitInspection({
-        requestedState: "transient",
-        reducerKind: "transient",
-      }),
-    ).toBe(true);
-    expect(
-      shouldCommitInspection({
-        requestedState: "pinned",
-        reducerKind: "pinned",
-      }),
-    ).toBe(true);
-  });
-
-  it("abandons when reducer kind does not match requested state", () => {
-    expect(
-      shouldCommitInspection({
-        requestedState: "transient",
-        reducerKind: "pinned",
-      }),
-    ).toBe(false);
-    expect(
-      shouldCommitInspection({
-        requestedState: "pinned",
-        reducerKind: "transient",
-      }),
-    ).toBe(false);
-    expect(
-      shouldCommitInspection({
-        requestedState: "transient",
-        reducerKind: "none",
-      }),
-    ).toBe(false);
   });
 });
 

--- a/packages/svelte/tests/interaction/unit.test.ts
+++ b/packages/svelte/tests/interaction/unit.test.ts
@@ -155,7 +155,7 @@ describe("interaction capability normalization", () => {
 });
 
 describe("chart-local interaction reducer", () => {
-  it("pins, unpins, dismisses transient content, and suppresses equal changes", () => {
+  it("inspect dispatches are no-ops (inspection authority is InspectionState)", () => {
     const onChange = vi.fn();
     const reducer = createInteractionReducer({
       onChange: () => {
@@ -167,24 +167,22 @@ describe("chart-local interaction reducer", () => {
       candidate: candidate(1),
       source: "pointer",
     });
-    reducer.dispatch({
-      type: "inspect",
-      candidate: candidate(1),
-      source: "pointer",
-    });
-    expect(onChange).toHaveBeenCalledTimes(1);
-    expect(reducer.state.inspection.kind).toBe("transient");
+    expect(onChange).toHaveBeenCalledTimes(0);
+    expect(reducer.state.revision).toBe(0);
+  });
 
-    reducer.dispatch({ type: "toggle-pin", source: "pointer" });
-    expect(reducer.state.inspection.kind).toBe("pinned");
+  it("escape cancels area and bumps epoch without inspection state", () => {
+    const reducer = createInteractionReducer();
+    reducer.dispatch({ type: "set-tool", tool: "select-area" });
     reducer.dispatch({
-      type: "inspect",
-      candidate: candidate(2),
-      source: "pointer",
+      type: "begin-area",
+      point: { x: 10, y: 10 },
+      panelId: "panel:all",
     });
-    expect(reducer.state.inspection.candidate?.id).toBe(1);
+    const epoch = reducer.state.epoch;
     reducer.dispatch({ type: "escape", source: "keyboard" });
-    expect(reducer.state.inspection.kind).toBe("idle");
+    expect(reducer.state.area.kind).toBe("idle");
+    expect(reducer.state.epoch).toBe(epoch + 1);
   });
 
   it("keeps Select area and Zoom area mutually exclusive", () => {
@@ -217,9 +215,9 @@ describe("chart-local interaction reducer", () => {
     expect(reducer.accepts(next)).toBe(false);
   });
 
-  it("coalesces continuous pointer coordinates once per frame and lets boundaries cancel them", () => {
+  it("coalesces inspect frames without reducer mutation; set-tool cancels the schedule", () => {
     let frame: (() => void) | null = null;
-    const changes: number[] = [];
+    const seen: number[] = [];
     const reducer = createInteractionReducer({
       scheduleFrame: (callback) => {
         frame = callback;
@@ -228,8 +226,8 @@ describe("chart-local interaction reducer", () => {
       cancelFrame: () => {
         frame = null;
       },
-      onChange: (state) => {
-        changes.push(state.revision);
+      onPointerFrame: (action) => {
+        if (action.type === "inspect" && action.candidate !== null) seen.push(action.candidate.id);
       },
     });
     reducer.queuePointer({
@@ -242,10 +240,10 @@ describe("chart-local interaction reducer", () => {
       candidate: candidate(2),
       source: "pointer",
     });
-    expect(changes).toHaveLength(0);
+    expect(seen).toHaveLength(0);
     (frame as (() => void) | null)?.();
-    expect(reducer.state.inspection.candidate?.id).toBe(2);
-    expect(changes).toHaveLength(1);
+    expect(seen).toEqual([2]);
+    expect(reducer.state.revision).toBe(0);
 
     reducer.queuePointer({
       type: "inspect",
@@ -254,10 +252,10 @@ describe("chart-local interaction reducer", () => {
     });
     reducer.dispatch({ type: "set-tool", tool: "zoom-area" });
     expect(frame).toBeNull();
-    expect(reducer.state.inspection.candidate?.id).toBe(2);
+    expect(seen).toEqual([2]);
   });
 
-  it("typed cancelScheduledPointer only clears matching kind; onPointerFrame false skips dispatch", () => {
+  it("typed cancelScheduledPointer only clears matching kind; inspect frames never dispatch", () => {
     let frame: (() => void) | null = null;
     const seen: string[] = [];
     const reducer = createInteractionReducer({
@@ -270,7 +268,6 @@ describe("chart-local interaction reducer", () => {
       },
       onPointerFrame: (action) => {
         seen.push(action.type);
-        if (action.type === "inspect") return false;
         return true;
       },
     });
@@ -292,7 +289,7 @@ describe("chart-local interaction reducer", () => {
     const rev = reducer.state.revision;
     (frame as (() => void) | null)?.();
     expect(seen).toEqual(["inspect"]);
+    // Inspect frames never bump reducer revision.
     expect(reducer.state.revision).toBe(rev);
-    expect(reducer.state.inspection.kind).toBe("idle");
   });
 });

--- a/packages/svelte/tests/surface/surface-state.input-lifecycle.test.ts
+++ b/packages/svelte/tests/surface/surface-state.input-lifecycle.test.ts
@@ -176,7 +176,6 @@ describe("createSurfaceState onSurfaceBlur", () => {
     h.surface.onSurfaceBlur(new FocusEvent("blur", { bubbles: true, relatedTarget: null }));
     flushSync();
     expect(h.inspection.inspection).toBeNull();
-    expect(h.surface.reducer.state.activeCandidate).toBeNull();
 
     // Pinned survives genuine blur
     h.inspection.setInspection(
@@ -193,7 +192,6 @@ describe("createSurfaceState onSurfaceBlur", () => {
     h.surface.onSurfaceBlur(new FocusEvent("blur", { bubbles: true, relatedTarget: null }));
     flushSync();
     expect(h.inspection.inspection?.state).toBe("pinned");
-    expect(h.surface.reducer.state.activeCandidate).toBeNull();
 
     h.destroy();
   });


### PR DESCRIPTION
## Summary

- **Single inspection authority:** `InspectionState` owns lifecycle (transient/pinned, dismiss latch, emit)
- **Reducer narrowed** to tool + area + frame epoch/revision (no `inspection` / `activeCandidate` state)
- Inspect pointer frames never reducer-dispatch; Escape cancels area only
- Delete `shouldCommitInspection` dual-gate
- Codex plan review: **GO with adjustments** applied

## Test plan

- [x] interaction + inspection + surface browser suites
- [x] type-aware lint + knip clean
- [ ] CI green