### PR TITLE
refactor(spec): extract validate-map-forms and tier-2 temporal tests

### DIFF
--- a/.changeset/spec-validate-map-forms-split.md
+++ b/.changeset/spec-validate-map-forms-split.md
@@ -1,0 +1,7 @@
+---
+"@ggsvelte/spec": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+Extract channel/DataRef form classification from the TypeBox error mapper and split temporal decision-reuse tier-2 tests into their own file. Public validate() behavior is unchanged.

--- a/packages/spec/src/validate-map-errors.ts
+++ b/packages/spec/src/validate-map-errors.ts
@@ -7,7 +7,8 @@
  * data refs, const enums) is reconstructed from keywords + schema lookup
  * against the Cyclic root being validated.
  *
- * Schema / path inspection lives in validate-schema-walk.ts.
+ * Schema / path inspection: validate-schema-walk.ts.
+ * Channel/data form classification: validate-map-forms.ts.
  * Used only by validate() — not part of the package public surface.
  */
 import type { TLocalizedValidationError } from "typebox/error";
@@ -21,153 +22,26 @@ import {
   lastSegment,
   numberBounds,
   objectPropertyNames,
-  pathSegments,
   pointerGet,
   schemaAtInstancePath,
   schemaAtSchemaPath,
   unionMembers,
-  type UnionMemberInfo,
 } from "./validate-schema-walk.js";
-
-const CHANNEL_FIX_EXAMPLE = { field: "column_name" };
-
-/** Channel names that live under aes (plot- or layer-level). */
-const AES_CHANNEL_KEYS = new Set([
-  "x",
-  "y",
-  "color",
-  "fill",
-  "size",
-  "linewidth",
-  "alpha",
-  "group",
-  "label",
-  "weight",
-  "ymin",
-  "ymax",
-]);
-
-/** True only for the channel node itself (`…/aes/<channel>`), not nested paths. */
-function isChannelPath(path: string): boolean {
-  const segs = pathSegments(path);
-  if (segs.length < 2) return false;
-  const i = segs.length - 2;
-  return segs[i] === "aes" && AES_CHANNEL_KEYS.has(segs[i + 1]!);
-}
-
-/**
- * DataRef / InlineData union roots only: `/data` or `/datasets/<name>`.
- * Nested paths under a data container must keep their own diagnostics.
- */
-function isDataUnionPath(path: string): boolean {
-  const segs = pathSegments(path);
-  if (segs.length === 1 && segs[0] === "data") return true;
-  if (segs.length === 2 && segs[0] === "datasets") return true;
-  return false;
-}
-
-/** Canonical channel object form (or null); bare strings are handled separately. */
-function looksLikeChannelForm(v: unknown): boolean {
-  if (v === null) return true;
-  if (!isRecord(v)) return false;
-  return "field" in v || "value" in v || "stat" in v;
-}
-
-/** Already a data container shape — do not suggest re-wrapping as `{ values: [...] }`. */
-function looksLikeDataContainer(v: unknown): boolean {
-  if (!isRecord(v)) return false;
-  return "values" in v || "columns" in v || "name" in v;
-}
-
-function isScalarValue(v: unknown): boolean {
-  return v === null || typeof v === "string" || typeof v === "number" || typeof v === "boolean";
-}
-
-/** Exclusive channel form discriminators (exactly one allowed per channel). */
-const CHANNEL_DISCRIMINATORS = ["field", "value", "stat"] as const;
-/** Exclusive data form discriminators (exactly one allowed per DataRef). */
-const DATA_DISCRIMINATORS = ["values", "columns", "name"] as const;
-
-/**
- * True when an additionalProperties failure lists a key that is *not* in
- * `ignoreKeys`. Used to ignore competing-branch noise (e.g. Columns rejecting
- * `values`) while still surfacing typos and form-illegal keys.
- */
-function additionalPropertyNames(
-  group: readonly TLocalizedValidationError[],
-  ignoreKeys: ReadonlySet<string> = new Set(),
-): string[] {
-  const names = new Set<string>();
-  for (const error of group) {
-    if (error.keyword !== "additionalProperties") continue;
-    const listed = Array.isArray(error.params.additionalProperties)
-      ? error.params.additionalProperties
-      : [];
-    for (const key of listed) {
-      if (!ignoreKeys.has(key)) names.add(key);
-    }
-  }
-  return [...names];
-}
-
-function hasActionableAddlNoise(
-  group: readonly TLocalizedValidationError[],
-  ignoreKeys: ReadonlySet<string>,
-): boolean {
-  return additionalPropertyNames(group, ignoreKeys).length > 0;
-}
-
-function channelDiscriminatorKeys(v: Record<string, unknown>): string[] {
-  return CHANNEL_DISCRIMINATORS.filter((k) => k in v);
-}
-
-function dataDiscriminatorKeys(
-  v: Record<string, unknown>,
-  allowed: readonly (typeof DATA_DISCRIMINATORS)[number][] = DATA_DISCRIMINATORS,
-): string[] {
-  return allowed.filter((k) => k in v);
-}
-
-function dataDiscriminatorsForUnion(
-  members: UnionMemberInfo,
-  path: string,
-): readonly (typeof DATA_DISCRIMINATORS)[number][] {
-  const allowed: (typeof DATA_DISCRIMINATORS)[number][] = [];
-  if (members.refs.some((ref) => ref.endsWith("DataValues"))) allowed.push("values");
-  if (members.refs.some((ref) => ref.endsWith("DataColumns"))) allowed.push("columns");
-  if (members.refs.some((ref) => ref.endsWith("DataName"))) allowed.push("name");
-  if (allowed.length > 0) return allowed;
-  return pathSegments(path)[0] === "datasets" ? ["values", "columns"] : DATA_DISCRIMINATORS;
-}
-
-/**
- * Keys legal on the single present channel form, or null when forms are mixed
- * / absent. FieldRef = {field}; ValueRef = {value, scale?}; StatRef = {stat}.
- */
-function allowedKeysForPresentChannelForm(v: Record<string, unknown>): Set<string> | null {
-  const discs = channelDiscriminatorKeys(v);
-  if (discs.length !== 1) return null;
-  switch (discs[0]) {
-    case "field":
-      return new Set(["field"]);
-    case "value":
-      return new Set(["value", "scale"]);
-    case "stat":
-      return new Set(["stat"]);
-    default:
-      return null;
-  }
-}
-
-/** Keys legal on the single present data form, or null when forms are mixed. */
-function allowedKeysForPresentDataForm(
-  v: Record<string, unknown>,
-  allowedDiscriminators: readonly (typeof DATA_DISCRIMINATORS)[number][],
-): Set<string> | null {
-  const discs = dataDiscriminatorKeys(v, allowedDiscriminators);
-  if (discs.length !== 1) return null;
-  return new Set([discs[0]!]);
-}
+import {
+  allowedKeysForPresentChannelForm,
+  allowedKeysForPresentDataForm,
+  additionalPropertyNames,
+  channelDiscriminatorKeys,
+  CHANNEL_FIX_EXAMPLE,
+  dataDiscriminatorKeys,
+  dataDiscriminatorsForUnion,
+  hasActionableAddlNoise,
+  isChannelPath,
+  isDataUnionPath,
+  isScalarValue,
+  looksLikeChannelForm,
+  looksLikeDataContainer,
+} from "./validate-map-forms.js";
 
 export interface MapErrorsContext {
   /** Schema root passed to Value.Errors (Cyclic `$defs`+`$ref`). */

--- a/packages/spec/src/validate-map-forms.ts
+++ b/packages/spec/src/validate-map-forms.ts
@@ -1,0 +1,147 @@
+/**
+ * Channel and DataRef form classification for TypeBox 1.x error mapping.
+ * Path/schema walk: validate-schema-walk.ts. SpecError mapping: validate-map-errors.ts.
+ */
+import type { TLocalizedValidationError } from "typebox/error";
+
+import { isRecord, pathSegments, type UnionMemberInfo } from "./validate-schema-walk.js";
+
+export const CHANNEL_FIX_EXAMPLE = { field: "column_name" };
+
+/** Channel names that live under aes (plot- or layer-level). */
+const AES_CHANNEL_KEYS = new Set([
+  "x",
+  "y",
+  "color",
+  "fill",
+  "size",
+  "linewidth",
+  "alpha",
+  "group",
+  "label",
+  "weight",
+  "ymin",
+  "ymax",
+]);
+
+/** True only for the channel node itself (`…/aes/<channel>`), not nested paths. */
+export function isChannelPath(path: string): boolean {
+  const segs = pathSegments(path);
+  if (segs.length < 2) return false;
+  const i = segs.length - 2;
+  return segs[i] === "aes" && AES_CHANNEL_KEYS.has(segs[i + 1]!);
+}
+
+/**
+ * DataRef / InlineData union roots only: `/data` or `/datasets/<name>`.
+ * Nested paths under a data container must keep their own diagnostics.
+ */
+export function isDataUnionPath(path: string): boolean {
+  const segs = pathSegments(path);
+  if (segs.length === 1 && segs[0] === "data") return true;
+  if (segs.length === 2 && segs[0] === "datasets") return true;
+  return false;
+}
+
+/** Canonical channel object form (or null); bare strings are handled separately. */
+export function looksLikeChannelForm(v: unknown): boolean {
+  if (v === null) return true;
+  if (!isRecord(v)) return false;
+  return "field" in v || "value" in v || "stat" in v;
+}
+
+/** Already a data container shape — do not suggest re-wrapping as `{ values: [...] }`. */
+export function looksLikeDataContainer(v: unknown): boolean {
+  if (!isRecord(v)) return false;
+  return "values" in v || "columns" in v || "name" in v;
+}
+
+export function isScalarValue(v: unknown): boolean {
+  return v === null || typeof v === "string" || typeof v === "number" || typeof v === "boolean";
+}
+
+/** Exclusive channel form discriminators (exactly one allowed per channel). */
+const CHANNEL_DISCRIMINATORS = ["field", "value", "stat"] as const;
+/** Exclusive data form discriminators (exactly one allowed per DataRef). */
+const DATA_DISCRIMINATORS = ["values", "columns", "name"] as const;
+
+/**
+ * True when an additionalProperties failure lists a key that is *not* in
+ * `ignoreKeys`. Used to ignore competing-branch noise (e.g. Columns rejecting
+ * `values`) while still surfacing typos and form-illegal keys.
+ */
+export function additionalPropertyNames(
+  group: readonly TLocalizedValidationError[],
+  ignoreKeys: ReadonlySet<string> = new Set(),
+): string[] {
+  const names = new Set<string>();
+  for (const error of group) {
+    if (error.keyword !== "additionalProperties") continue;
+    const listed = Array.isArray(error.params.additionalProperties)
+      ? error.params.additionalProperties
+      : [];
+    for (const key of listed) {
+      if (!ignoreKeys.has(key)) names.add(key);
+    }
+  }
+  return [...names];
+}
+
+export function hasActionableAddlNoise(
+  group: readonly TLocalizedValidationError[],
+  ignoreKeys: ReadonlySet<string>,
+): boolean {
+  return additionalPropertyNames(group, ignoreKeys).length > 0;
+}
+
+export function channelDiscriminatorKeys(v: Record<string, unknown>): string[] {
+  return CHANNEL_DISCRIMINATORS.filter((k) => k in v);
+}
+
+export function dataDiscriminatorKeys(
+  v: Record<string, unknown>,
+  allowed: readonly (typeof DATA_DISCRIMINATORS)[number][] = DATA_DISCRIMINATORS,
+): string[] {
+  return allowed.filter((k) => k in v);
+}
+
+export function dataDiscriminatorsForUnion(
+  members: UnionMemberInfo,
+  path: string,
+): readonly (typeof DATA_DISCRIMINATORS)[number][] {
+  const allowed: (typeof DATA_DISCRIMINATORS)[number][] = [];
+  if (members.refs.some((ref) => ref.endsWith("DataValues"))) allowed.push("values");
+  if (members.refs.some((ref) => ref.endsWith("DataColumns"))) allowed.push("columns");
+  if (members.refs.some((ref) => ref.endsWith("DataName"))) allowed.push("name");
+  if (allowed.length > 0) return allowed;
+  return pathSegments(path)[0] === "datasets" ? ["values", "columns"] : DATA_DISCRIMINATORS;
+}
+
+/**
+ * Keys legal on the single present channel form, or null when forms are mixed
+ * / absent. FieldRef = {field}; ValueRef = {value, scale?}; StatRef = {stat}.
+ */
+export function allowedKeysForPresentChannelForm(v: Record<string, unknown>): Set<string> | null {
+  const discs = channelDiscriminatorKeys(v);
+  if (discs.length !== 1) return null;
+  switch (discs[0]) {
+    case "field":
+      return new Set(["field"]);
+    case "value":
+      return new Set(["value", "scale"]);
+    case "stat":
+      return new Set(["stat"]);
+    default:
+      return null;
+  }
+}
+
+/** Keys legal on the single present data form, or null when forms are mixed. */
+export function allowedKeysForPresentDataForm(
+  v: Record<string, unknown>,
+  allowedDiscriminators: readonly (typeof DATA_DISCRIMINATORS)[number][],
+): Set<string> | null {
+  const discs = dataDiscriminatorKeys(v, allowedDiscriminators);
+  if (discs.length !== 1) return null;
+  return new Set([discs[0]!]);
+}

--- a/packages/spec/src/validate.ts
+++ b/packages/spec/src/validate.ts
@@ -6,7 +6,8 @@
  * `Value.Errors` over the same schemas that emit `schema/v0.json` — one
  * artifact, no drift.
  * Raw TypeBox union noise is mapped to the agent error contract in
- * validate-map-errors.ts (schema/path inspection in validate-schema-walk.ts).
+ * validate-map-errors.ts (schema walk: validate-schema-walk.ts; channel/data
+ * form classification: validate-map-forms.ts).
  * Data-free grammar rules live in validate-structure*.ts (layers / color
  * schemes / facet form). Data-aware checks live in validate-data*.ts
  * (evidence + checks modules, barrel at validate-data.ts).

--- a/packages/spec/tests/validate-map-errors.test.ts
+++ b/packages/spec/tests/validate-map-errors.test.ts
@@ -1,6 +1,6 @@
 /**
  * Characterization tests for TypeBox 1.x → agent SpecError mapping
- * (packages/spec/src/validate-map-errors.ts + validate-schema-walk.ts).
+ * (validate-map-errors.ts + validate-map-forms.ts + validate-schema-walk.ts).
  *
  * Exercises mapValueErrors classification through the public validate() entry.
  * Snapshot-tested agent messages remain in validate.test.ts (full orchestrator

--- a/packages/spec/tests/validate-tier2-data.test.ts
+++ b/packages/spec/tests/validate-tier2-data.test.ts
@@ -1,11 +1,11 @@
 /**
- * Tier-2 data-aware checks: inline data, DataProfile, input limits, temporal
- * decision reuse. Production: validate-data*.ts.
+ * Tier-2 data-aware checks: inline data, DataProfile, input limits.
+ * Temporal decision reuse: validate-tier2-temporal.test.ts.
+ * Production: validate-data*.ts.
  */
 import { fromAny } from "@total-typescript/shoehorn";
 import { describe, expect, it } from "bun:test";
 
-import { aes, gg } from "../src/builder.ts";
 import type { DataProfile } from "../src/validate-data.ts";
 import { validate } from "../src/validate.ts";
 
@@ -209,138 +209,5 @@ describe("tier 2 — input limits", () => {
     const errors = errorsOf({ layers }, { limits: { maxDiagnostics: 5 } });
     expect(errors).toHaveLength(6);
     expect(errors.at(-1)?.code).toBe("validation-limit");
-  });
-});
-
-describe("tier 2 — temporal decision reuse (characterization)", () => {
-  it("accepts multi-layer charts that share one temporal field under auto time scales", () => {
-    const when = ["2024-01-01", "2024-01-02", "2024-01-03"];
-    const value = [1, 2, 3];
-    const result = validate(
-      {
-        data: { columns: { when, value } },
-        aes: { x: { field: "when" }, y: { field: "value" } },
-        scales: { x: { type: "time" } },
-        layers: [{ geom: "point" }, { geom: "line" }, { geom: "smooth" }],
-      },
-      {},
-    );
-    expect(result.ok).toBe(true);
-  });
-
-  it("reports the same ambiguous auto-inference detail once per consumer path", () => {
-    const errors = errorsOf({
-      data: {
-        columns: {
-          when: ["01/02/2023", "03/04/2023"],
-          value: [1, 2],
-        },
-      },
-      aes: { x: { field: "when" }, y: { field: "value" } },
-      scales: { x: { type: "time" } },
-      layers: [{ geom: "point" }, { geom: "line" }],
-    });
-    expect(errors.map((e) => e.code)).toEqual(["scale-type-mismatch", "scale-type-mismatch"]);
-    expect(errors.every((e) => e.message.includes("ambiguous between: mdy, dmy"))).toBe(true);
-    expect(errors.map((e) => e.path)).toEqual(["/layers/0/aes/x", "/layers/1/aes/x"]);
-  });
-
-  it("preserves explicit-parse rejection details across ymin and ymax on the same scale", () => {
-    const errors = errorsOf({
-      data: {
-        columns: {
-          group: ["a", "b"],
-          lo: ["31/12/2024", "01/01/2025"],
-          hi: ["not-a-date", "02/01/2025"],
-        },
-      },
-      layers: [
-        {
-          geom: "errorbar",
-          aes: { x: { field: "group" }, ymin: { field: "lo" }, ymax: { field: "hi" } },
-        },
-      ],
-      scales: { y: { type: "time", parse: "dmy" } },
-    });
-    const ymax = errors.filter((e) => e.path.endsWith("/ymax"));
-    expect(ymax).toHaveLength(1);
-    expect(ymax[0]?.message).toContain("rejected 1 value");
-    expect(ymax[0]?.message).toContain("not-a-date");
-  });
-
-  it("accepts builder Date cells under auto time scales after multi-layer canonicalize", () => {
-    // PortableSpec forbids raw Date cells; the builder ISO-coerces them, then
-    // multi-layer temporal consumers must share one decision for the field.
-    const when0 = new Date("2024-01-01T00:00:00.000Z");
-    const when1 = new Date("2024-01-02T00:00:00.000Z");
-    const spec = gg(
-      [
-        { when: when0, value: 1 },
-        { when: when1, value: 2 },
-      ],
-      aes({ x: "when", y: "value" }),
-    )
-      .geomPoint()
-      .geomLine()
-      .scaleXDatetime()
-      .spec();
-    expect(validate(spec, {}).ok).toBe(true);
-  });
-
-  it("validates the same field for both position and sequential color consumers", () => {
-    const when = ["2024-01-01", "2024-01-02", "2024-01-03"];
-    const result = validate(
-      {
-        data: { columns: { when, value: [1, 2, 3] } },
-        aes: { x: { field: "when" }, y: { field: "value" }, color: { field: "when" } },
-        scales: {
-          x: { type: "time" },
-          color: { type: "sequential", parse: "iso", temporalKind: "date" },
-        },
-        layers: [{ geom: "point" }],
-      },
-      {},
-    );
-    expect(result.ok).toBe(true);
-  });
-
-  it("profile-backed temporal fields with timezone options do not invent inline evidence", () => {
-    // Profile fields have temporal: null / values: null. A non-default timezone
-    // must still accept profile-typed temporal fields (no accidental reuse of
-    // missing evidence decisions that would flip acceptance).
-    const profile: DataProfile = {
-      fields: [
-        { name: "when", type: "temporal" },
-        { name: "value", type: "quantitative" },
-      ],
-    };
-    const result = validate(
-      {
-        aes: { x: { field: "when" }, y: { field: "value" } },
-        scales: { x: { type: "time", timezone: "America/New_York" } },
-        layers: [{ geom: "point" }, { geom: "line" }],
-      },
-      { profile },
-    );
-    expect(result.ok).toBe(true);
-  });
-
-  it("still rejects profile nominal fields under time scales with disambiguation set", () => {
-    const profile: DataProfile = {
-      fields: [
-        { name: "city", type: "nominal" },
-        { name: "value", type: "quantitative" },
-      ],
-    };
-    const errors = errorsOf(
-      {
-        aes: { x: { field: "city" }, y: { field: "value" } },
-        scales: { x: { type: "time", disambiguation: "earlier" } },
-        layers: [{ geom: "point" }, { geom: "line" }],
-      },
-      { profile },
-    );
-    expect(errors.map((e) => e.code)).toEqual(["scale-type-mismatch", "scale-type-mismatch"]);
-    expect(errors.every((e) => e.message.includes('field "city" is nominal'))).toBe(true);
   });
 });

--- a/packages/spec/tests/validate-tier2-temporal.test.ts
+++ b/packages/spec/tests/validate-tier2-temporal.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Tier-2 temporal decision reuse characterization (cache keys, multi-consumer paths).
+ * Other data-aware checks: validate-tier2-data.test.ts.
+ * Production: validate-data-checks.ts temporalDecisionForField.
+ */
+import { describe, expect, it } from "bun:test";
+
+import { aes, gg } from "../src/builder.ts";
+import type { DataProfile } from "../src/validate-data.ts";
+import { validate } from "../src/validate.ts";
+
+function errorsOf(input: unknown, options?: Parameters<typeof validate>[1]) {
+  const result = validate(input, options ?? {});
+  if (result.ok) throw new Error("expected validation failure");
+  return result.errors;
+}
+
+describe("tier 2 — temporal decision reuse (characterization)", () => {
+  it("accepts multi-layer charts that share one temporal field under auto time scales", () => {
+    const when = ["2024-01-01", "2024-01-02", "2024-01-03"];
+    const value = [1, 2, 3];
+    const result = validate(
+      {
+        data: { columns: { when, value } },
+        aes: { x: { field: "when" }, y: { field: "value" } },
+        scales: { x: { type: "time" } },
+        layers: [{ geom: "point" }, { geom: "line" }, { geom: "smooth" }],
+      },
+      {},
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  it("reports the same ambiguous auto-inference detail once per consumer path", () => {
+    const errors = errorsOf({
+      data: {
+        columns: {
+          when: ["01/02/2023", "03/04/2023"],
+          value: [1, 2],
+        },
+      },
+      aes: { x: { field: "when" }, y: { field: "value" } },
+      scales: { x: { type: "time" } },
+      layers: [{ geom: "point" }, { geom: "line" }],
+    });
+    expect(errors.map((e) => e.code)).toEqual(["scale-type-mismatch", "scale-type-mismatch"]);
+    expect(errors.every((e) => e.message.includes("ambiguous between: mdy, dmy"))).toBe(true);
+    expect(errors.map((e) => e.path)).toEqual(["/layers/0/aes/x", "/layers/1/aes/x"]);
+  });
+
+  it("preserves explicit-parse rejection details across ymin and ymax on the same scale", () => {
+    const errors = errorsOf({
+      data: {
+        columns: {
+          group: ["a", "b"],
+          lo: ["31/12/2024", "01/01/2025"],
+          hi: ["not-a-date", "02/01/2025"],
+        },
+      },
+      layers: [
+        {
+          geom: "errorbar",
+          aes: { x: { field: "group" }, ymin: { field: "lo" }, ymax: { field: "hi" } },
+        },
+      ],
+      scales: { y: { type: "time", parse: "dmy" } },
+    });
+    const ymax = errors.filter((e) => e.path.endsWith("/ymax"));
+    expect(ymax).toHaveLength(1);
+    expect(ymax[0]?.message).toContain("rejected 1 value");
+    expect(ymax[0]?.message).toContain("not-a-date");
+  });
+
+  it("accepts builder Date cells under auto time scales after multi-layer canonicalize", () => {
+    // PortableSpec forbids raw Date cells; the builder ISO-coerces them, then
+    // multi-layer temporal consumers must share one decision for the field.
+    const when0 = new Date("2024-01-01T00:00:00.000Z");
+    const when1 = new Date("2024-01-02T00:00:00.000Z");
+    const spec = gg(
+      [
+        { when: when0, value: 1 },
+        { when: when1, value: 2 },
+      ],
+      aes({ x: "when", y: "value" }),
+    )
+      .geomPoint()
+      .geomLine()
+      .scaleXDatetime()
+      .spec();
+    expect(validate(spec, {}).ok).toBe(true);
+  });
+
+  it("validates the same field for both position and sequential color consumers", () => {
+    const when = ["2024-01-01", "2024-01-02", "2024-01-03"];
+    const result = validate(
+      {
+        data: { columns: { when, value: [1, 2, 3] } },
+        aes: { x: { field: "when" }, y: { field: "value" }, color: { field: "when" } },
+        scales: {
+          x: { type: "time" },
+          color: { type: "sequential", parse: "iso", temporalKind: "date" },
+        },
+        layers: [{ geom: "point" }],
+      },
+      {},
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  it("profile-backed temporal fields with timezone options do not invent inline evidence", () => {
+    // Profile fields have temporal: null / values: null. A non-default timezone
+    // must still accept profile-typed temporal fields (no accidental reuse of
+    // missing evidence decisions that would flip acceptance).
+    const profile: DataProfile = {
+      fields: [
+        { name: "when", type: "temporal" },
+        { name: "value", type: "quantitative" },
+      ],
+    };
+    const result = validate(
+      {
+        aes: { x: { field: "when" }, y: { field: "value" } },
+        scales: { x: { type: "time", timezone: "America/New_York" } },
+        layers: [{ geom: "point" }, { geom: "line" }],
+      },
+      { profile },
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  it("still rejects profile nominal fields under time scales with disambiguation set", () => {
+    const profile: DataProfile = {
+      fields: [
+        { name: "city", type: "nominal" },
+        { name: "value", type: "quantitative" },
+      ],
+    };
+    const errors = errorsOf(
+      {
+        aes: { x: { field: "city" }, y: { field: "value" } },
+        scales: { x: { type: "time", disambiguation: "earlier" } },
+        layers: [{ geom: "point" }, { geom: "line" }],
+      },
+      { profile },
+    );
+    expect(errors.map((e) => e.code)).toEqual(["scale-type-mismatch", "scale-type-mismatch"]);
+    expect(errors.every((e) => e.message.includes('field "city" is nominal'))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Maintainability split for `@ggsvelte/spec` validation:

### Production

| Module | Role |
|--------|------|
| `validate-map-forms.ts` | Channel/DataRef path + form discriminators for error mapping |
| `validate-map-errors.ts` | `mapValueErrors` / `mapPathGroup` + `unknownGeomError` |
| `validate-schema-walk.ts` | (existing) Cyclic schema/path inspection |

`validate.ts` still imports the mapper only.

### Tests

| File | Concern |
|------|---------|
| `validate-tier2-data.test.ts` | Inline data, DataProfile, input limits |
| `validate-tier2-temporal.test.ts` | Temporal decision reuse characterization |

## Verification

- [x] `bun test packages/spec` (344 pass)
- [x] `bun run check`
- [x] `bun run knip`