### PR TITLE
refactor(docs): centralize code-tab languages and playground copy strings

### DIFF
--- a/apps/docs/src/lib/CodeTabs.svelte
+++ b/apps/docs/src/lib/CodeTabs.svelte
@@ -8,8 +8,11 @@
   import CopyIcon from "phosphor-svelte/lib/CopyIcon";
   import Highlight from "svelte-highlight";
 
-  import { copyText, MANUAL_COPY_STATUS } from "$lib/clipboard";
-  import { resolveCodeLanguage } from "$lib/code-languages";
+  import { briefCopyStatus, COPIED_STATUS, copyText } from "$lib/clipboard";
+  import {
+    languageFromCodeTabLabel,
+    resolveCodeLanguage,
+  } from "$lib/code-languages";
   import { nextRovingTabIndex } from "$lib/tab-roving";
 
   interface Tab {
@@ -30,31 +33,17 @@
   const activeTab = $derived(tabs[active]);
   const languageModule = $derived(
     resolveCodeLanguage(
-      activeTab?.language ?? languageFromLabel(activeTab?.label),
+      activeTab?.language ?? languageFromCodeTabLabel(activeTab?.label),
     ),
   );
-  const copied = $derived(copyStatus === "Copied.");
-
-  function languageFromLabel(label: string | undefined): string {
-    if (label === undefined) return "plaintext";
-    const lower = label.toLowerCase();
-    if (lower.includes("svelte")) return "svelte";
-    if (lower.includes("json") || lower.includes("spec")) return "json";
-    if (
-      lower.includes("ts") ||
-      lower.includes("builder") ||
-      lower.includes("type")
-    )
-      return "typescript";
-    return "plaintext";
-  }
+  const copied = $derived(copyStatus === COPIED_STATUS);
 
   async function copy(): Promise<void> {
     const code = tabs[active]?.code ?? "";
     if (codeNode === undefined) return;
     const result = await copyText(code, codeNode);
     clearTimeout(copyTimer);
-    copyStatus = result === "copied" ? "Copied." : MANUAL_COPY_STATUS;
+    copyStatus = briefCopyStatus(result);
     if (result === "copied") {
       copyTimer = setTimeout(() => {
         copyStatus = "";

--- a/apps/docs/src/lib/Playground.svelte
+++ b/apps/docs/src/lib/Playground.svelte
@@ -4,7 +4,7 @@
 
   import type { RenderModel } from "@ggsvelte/core";
 
-  import { copyText, MANUAL_LINK_COPY_STATUS } from "$lib/clipboard";
+  import { copyText } from "$lib/clipboard";
   import PlaygroundEditor from "$lib/components/PlaygroundEditor.svelte";
   import PlaygroundEvents from "$lib/components/PlaygroundEvents.svelte";
   import PlaygroundOutput from "$lib/components/PlaygroundOutput.svelte";
@@ -40,11 +40,15 @@
     resolvePlaygroundHashRestore,
   } from "$lib/playground-hash-restore";
   import {
+    PLAYGROUND_ACTIVE_FAILED_STATUS,
+    PLAYGROUND_SAMPLE_DISCARD_CONFIRM,
+    PLAYGROUND_UNDO_DISCARD_CONFIRM,
     shouldClearPlayHashAfterPromotion,
     shouldConfirmDiscardForSampleLoad,
     shouldConfirmDiscardForUndo,
   } from "$lib/playground-link-policy";
   import { playgroundOutputs } from "$lib/playground-output";
+  import { playgroundShareCopyStatus } from "$lib/playground-output-status";
   import {
     confirmPlaygroundRendered,
     createPlaygroundState,
@@ -179,9 +183,7 @@
     if (workbench.undoSnapshots.length === 0 || workbench.candidate !== null)
       return;
     if (shouldConfirmDiscardForUndo(workbench)) {
-      const discard = window.confirm(
-        "Discard the current draft and undo to the previous rendered chart? Copy it first if you need to keep it.",
-      );
+      const discard = window.confirm(PLAYGROUND_UNDO_DISCARD_CONFIRM);
       if (!discard) return;
     }
     const previous = activeCandidate();
@@ -193,9 +195,7 @@
   function loadSample(id: string): boolean {
     if (id === "") return false;
     if (shouldConfirmDiscardForSampleLoad(workbench)) {
-      const discard = window.confirm(
-        "Discard the current draft and load this sample? Copy it first if you need to keep it.",
-      );
+      const discard = window.confirm(PLAYGROUND_SAMPLE_DISCARD_CONFIRM);
       if (!discard) return false;
     }
     const sample = PLAYGROUND_SAMPLES.find((entry) => entry.id === id);
@@ -280,7 +280,7 @@
     workbench = reportPlaygroundDiagnostic(
       workbench,
       diagnostic,
-      "The current chart stopped safely. Reset the source to recover.",
+      PLAYGROUND_ACTIVE_FAILED_STATUS,
       false,
     );
     for (const detail of phaseNotesForCandidateTransition(previous, {
@@ -302,8 +302,7 @@
     await tick();
     if (shareSource === undefined) return;
     const result = await copyText(shareUrl, shareSource);
-    shareStatus =
-      result === "copied" ? "Share link copied." : MANUAL_LINK_COPY_STATUS;
+    shareStatus = playgroundShareCopyStatus(result);
   }
 </script>
 

--- a/apps/docs/src/lib/clipboard.ts
+++ b/apps/docs/src/lib/clipboard.ts
@@ -2,6 +2,13 @@ export const MANUAL_COPY_STATUS = "Clipboard unavailable. Code selected for manu
 export const MANUAL_LINK_COPY_STATUS =
   "Clipboard unavailable. Share link selected for manual copy.";
 
+/** Transient status after a successful code copy (CodeTabs / CopyCode). */
+export const COPIED_STATUS = "Copied.";
+
+export function briefCopyStatus(result: "copied" | "manual"): string {
+  return result === "copied" ? COPIED_STATUS : MANUAL_COPY_STATUS;
+}
+
 export function selectText(node: Node): void {
   const selection = window.getSelection();
   const range = document.createRange();

--- a/apps/docs/src/lib/code-languages.ts
+++ b/apps/docs/src/lib/code-languages.ts
@@ -35,3 +35,18 @@ export function resolveCodeLanguage(lang: string | undefined): LanguageType<stri
   if (lang === undefined || lang.trim() === "") return plaintext;
   return LANGUAGE_MODULES[lang.trim().toLowerCase()] ?? plaintext;
 }
+
+/**
+ * Infer a highlight language from a code-tab label when no explicit language prop is set
+ * (e.g. "Builder (TS)", "Spec (JSON)", "Svelte").
+ */
+export function languageFromCodeTabLabel(label: string | undefined): string {
+  if (label === undefined) return "plaintext";
+  const lower = label.toLowerCase();
+  if (lower.includes("svelte")) return "svelte";
+  if (lower.includes("json") || lower.includes("spec")) return "json";
+  if (lower.includes("ts") || lower.includes("builder") || lower.includes("type")) {
+    return "typescript";
+  }
+  return "plaintext";
+}

--- a/apps/docs/src/lib/components/CopyCode.svelte
+++ b/apps/docs/src/lib/components/CopyCode.svelte
@@ -3,7 +3,7 @@
   import CopyIcon from "phosphor-svelte/lib/CopyIcon";
   import Highlight from "svelte-highlight";
 
-  import { copyText, MANUAL_COPY_STATUS } from "$lib/clipboard";
+  import { briefCopyStatus, COPIED_STATUS, copyText } from "$lib/clipboard";
   import { resolveCodeLanguage } from "$lib/code-languages";
 
   const {
@@ -25,13 +25,13 @@
   let status = $state("");
   let timer: ReturnType<typeof setTimeout> | undefined;
   const languageModule = $derived(resolveCodeLanguage(language));
-  const copied = $derived(status === "Copied.");
+  const copied = $derived(status === COPIED_STATUS);
 
   async function copy(): Promise<void> {
     if (timer !== undefined) clearTimeout(timer);
     if (source === undefined) return;
     const result = await copyText(code, source);
-    status = result === "copied" ? "Copied." : MANUAL_COPY_STATUS;
+    status = briefCopyStatus(result);
     if (result === "copied") timer = setTimeout(() => (status = ""), 2000);
   }
 </script>

--- a/apps/docs/src/lib/playground-link-policy.ts
+++ b/apps/docs/src/lib/playground-link-policy.ts
@@ -68,6 +68,18 @@ export function shouldConfirmDiscardForSampleLoad(state: PlaygroundState): boole
   return !state.synchronized || state.candidate !== null || state.seed.source.kind === "custom";
 }
 
+/** window.confirm body when undo would discard a dirty draft. */
+export const PLAYGROUND_UNDO_DISCARD_CONFIRM =
+  "Discard the current draft and undo to the previous rendered chart? Copy it first if you need to keep it.";
+
+/** window.confirm body when loading a sample would discard local work. */
+export const PLAYGROUND_SAMPLE_DISCARD_CONFIRM =
+  "Discard the current draft and load this sample? Copy it first if you need to keep it.";
+
+/** Status after the active chart fails safely (last valid retained). */
+export const PLAYGROUND_ACTIVE_FAILED_STATUS =
+  "The current chart stopped safely. Reset the source to recover.";
+
 export function shouldClearPlayHashAfterPromotion(
   origin: PlaygroundCandidateOrigin | undefined,
   locationHash: string,

--- a/apps/docs/src/lib/playground-output-status.ts
+++ b/apps/docs/src/lib/playground-output-status.ts
@@ -1,10 +1,15 @@
-import { MANUAL_COPY_STATUS } from "./clipboard";
+import { MANUAL_COPY_STATUS, MANUAL_LINK_COPY_STATUS } from "./clipboard";
 import type { PlaygroundDiagnostic } from "./playground-state-types";
 
 export const PLAYGROUND_SVG_DOWNLOADED_STATUS = "SVG downloaded.";
+export const PLAYGROUND_SHARE_COPIED_STATUS = "Share link copied.";
 
 export function playgroundCopyStatus(label: string, result: "copied" | "manual"): string {
   return result === "copied" ? `${label} output copied.` : MANUAL_COPY_STATUS;
+}
+
+export function playgroundShareCopyStatus(result: "copied" | "manual"): string {
+  return result === "copied" ? PLAYGROUND_SHARE_COPIED_STATUS : MANUAL_LINK_COPY_STATUS;
 }
 
 export function playgroundSvgExportFailureStatus(diagnostic: PlaygroundDiagnostic): string {

--- a/scripts/clipboard-status.test.ts
+++ b/scripts/clipboard-status.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  briefCopyStatus,
+  COPIED_STATUS,
+  MANUAL_COPY_STATUS,
+  MANUAL_LINK_COPY_STATUS,
+} from "../apps/docs/src/lib/clipboard";
+import {
+  PLAYGROUND_SHARE_COPIED_STATUS,
+  playgroundShareCopyStatus,
+} from "../apps/docs/src/lib/playground-output-status";
+import {
+  PLAYGROUND_ACTIVE_FAILED_STATUS,
+  PLAYGROUND_SAMPLE_DISCARD_CONFIRM,
+  PLAYGROUND_UNDO_DISCARD_CONFIRM,
+} from "../apps/docs/src/lib/playground-link-policy";
+
+describe("briefCopyStatus", () => {
+  test("returns Copied. or manual fallback", () => {
+    expect(briefCopyStatus("copied")).toBe(COPIED_STATUS);
+    expect(briefCopyStatus("manual")).toBe(MANUAL_COPY_STATUS);
+  });
+});
+
+describe("playgroundShareCopyStatus", () => {
+  test("returns share-specific copied or manual link status", () => {
+    expect(playgroundShareCopyStatus("copied")).toBe(PLAYGROUND_SHARE_COPIED_STATUS);
+    expect(playgroundShareCopyStatus("manual")).toBe(MANUAL_LINK_COPY_STATUS);
+  });
+});
+
+describe("playground discard and failure copy", () => {
+  test("locks confirm and active-fail status strings", () => {
+    expect(PLAYGROUND_UNDO_DISCARD_CONFIRM).toContain("undo");
+    expect(PLAYGROUND_SAMPLE_DISCARD_CONFIRM).toContain("sample");
+    expect(PLAYGROUND_ACTIVE_FAILED_STATUS).toContain("stopped safely");
+  });
+});

--- a/scripts/code-languages.test.ts
+++ b/scripts/code-languages.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+
+import { languageFromCodeTabLabel, resolveCodeLanguage } from "../apps/docs/src/lib/code-languages";
+
+describe("languageFromCodeTabLabel", () => {
+  test("maps triptych labels to highlight languages", () => {
+    expect(languageFromCodeTabLabel("Svelte")).toBe("svelte");
+    expect(languageFromCodeTabLabel("Builder (TS)")).toBe("typescript");
+    expect(languageFromCodeTabLabel("Spec (JSON)")).toBe("json");
+    expect(languageFromCodeTabLabel("Type definitions")).toBe("typescript");
+    expect(languageFromCodeTabLabel("README")).toBe("plaintext");
+    expect(languageFromCodeTabLabel()).toBe("plaintext");
+  });
+});
+
+describe("resolveCodeLanguage", () => {
+  test("resolves aliases and falls back to plaintext", () => {
+    expect(typeof resolveCodeLanguage("ts")).toBe("object");
+    expect(resolveCodeLanguage("ts")).toBe(resolveCodeLanguage("typescript"));
+    expect(resolveCodeLanguage("")).toBe(resolveCodeLanguage("plaintext"));
+    expect(resolveCodeLanguage()).toBe(resolveCodeLanguage("plaintext"));
+    expect(resolveCodeLanguage("nope-not-a-lang")).toBe(resolveCodeLanguage("plaintext"));
+  });
+});


### PR DESCRIPTION
## Summary

Maintainability pass on `apps/docs` after PlaygroundOutput Svelte 5 UI (#510).

### Candidates

1. **CodeTabs** buried tab-label → highlight language inference next to presentation
2. **CodeTabs / CopyCode** duplicated `"Copied."` status wiring
3. **Playground** confirm/share/active-fail strings sat next to DOM handlers, not with pure link policy

### What changed

| Module | Role |
|--------|------|
| `code-languages.ts` | `languageFromCodeTabLabel` |
| `clipboard.ts` | `COPIED_STATUS` + `briefCopyStatus` |
| `playground-output-status.ts` | `playgroundShareCopyStatus` |
| `playground-link-policy.ts` | undo/sample confirm + active-fail status constants |
| CodeTabs / CopyCode / Playground | thin wiring |

## Tests

- New `scripts/code-languages.test.ts`, `scripts/clipboard-status.test.ts`
- Existing link-policy suite green
- `check:docs`, knip, type-aware lint clean
- Visual: code tabs, install copy fallback, output copy fallback, denied share clipboard

## Follow-ups

None. Remaining large docs modules are intentional page orchestrators or cohesive pure machines / CSS shells — further splits would be style-only.