### PR TITLE
refactor(core): unify GeometryBatch render primitive counts

### DIFF
--- a/packages/core/src/candidate-geometry.ts
+++ b/packages/core/src/candidate-geometry.ts
@@ -1,10 +1,39 @@
 import type { ResolvedCandidateInspectMode } from "./candidate-store-types.js";
 import type { GeometryBatch } from "./scene.js";
 
+/**
+ * Geometry-array topology for candidate indexes / hit refine:
+ * - rects / segments: packed float arrays
+ * - points / glyphs / paths: vertices (`positions.length / 2`)
+ *
+ * Distinct from {@link renderPrimitiveCount} (paint/focus marks) and
+ * {@link candidatePrimitiveCount} (inspectable anchors).
+ */
 export function primitiveCount(batch: GeometryBatch): number {
   if (batch.kind === "rects") return batch.rects.length / 4;
   if (batch.kind === "segments") return batch.segments.length / 4;
   return batch.positions.length / 2;
+}
+
+/**
+ * Paint / focus / mark-threshold address space (one count for canvas focus,
+ * interaction masks, SVG mark totals, and backend auto threshold).
+ * Paths count **subpaths**, not tessellated vertices.
+ */
+export function renderPrimitiveCount(batch: GeometryBatch): number {
+  switch (batch.kind) {
+    case "points":
+    case "glyphs":
+      return batch.rowIndex.length;
+    case "paths":
+      return Math.max(0, batch.pathOffsets.length - 1);
+    case "rects":
+      return batch.rects.length / 4;
+    case "segments":
+      return batch.segments.length / 4;
+    default:
+      return 0;
+  }
 }
 
 export function isCandidatePrimitive(batch: GeometryBatch, primitiveIndex: number): boolean {

--- a/packages/core/src/dom/canvas-marks-mask.ts
+++ b/packages/core/src/dom/canvas-marks-mask.ts
@@ -2,6 +2,7 @@
 /**
  * Focus-mask types and helpers for canvas mark drawers.
  */
+import { renderPrimitiveCount } from "../candidate-geometry.js";
 import type { GeometryBatch } from "../scene.js";
 import type { BatchInteractionMask } from "../interaction-mask.js";
 
@@ -27,17 +28,7 @@ export function maskIncludes(mask: PrimitiveFocusMask, index: number): boolean {
 
 /** Primitive count for focus-mask address space (paths = subpaths, not vertices). */
 export function batchPrimitiveCount(batch: GeometryBatch): number {
-  switch (batch.kind) {
-    case "points":
-    case "rects":
-    case "segments":
-    case "glyphs":
-      return batch.rowIndex.length;
-    case "paths":
-      return Math.max(0, batch.pathOffsets.length - 1);
-    default:
-      return 0;
-  }
+  return renderPrimitiveCount(batch);
 }
 
 /** True when every addressable primitive is focused (fast path → full drawBatch). */

--- a/packages/core/src/interaction-mask.ts
+++ b/packages/core/src/interaction-mask.ts
@@ -1,4 +1,4 @@
-import { pathSubpathIndex } from "./candidate-geometry.js";
+import { pathSubpathIndex, renderPrimitiveCount } from "./candidate-geometry.js";
 import type { GeometryBatch } from "./scene.js";
 
 /** Semantic source-row keys associated with one renderer candidate. */
@@ -22,11 +22,6 @@ export interface LegendValueMembership<Key extends PropertyKey = PropertyKey> {
   readonly keys: readonly Key[];
 }
 
-function primitiveCount(batch: GeometryBatch): number {
-  if (batch.kind === "paths") return Math.max(0, batch.pathOffsets.length - 1);
-  return batch.rowIndex.length;
-}
-
 function pathForVertex(offsets: Uint32Array, vertexIndex: number): number | null {
   if (
     !Number.isInteger(vertexIndex) ||
@@ -40,7 +35,7 @@ function pathForVertex(offsets: Uint32Array, vertexIndex: number): number | null
 
 function rendererPrimitive(batch: GeometryBatch, candidateIndex: number): number | null {
   if (batch.kind === "paths") return pathForVertex(batch.pathOffsets, candidateIndex);
-  const count = primitiveCount(batch);
+  const count = renderPrimitiveCount(batch);
   return Number.isInteger(candidateIndex) && candidateIndex >= 0 && candidateIndex < count
     ? candidateIndex
     : null;
@@ -70,7 +65,7 @@ export function buildInteractionMasks<Key extends PropertyKey>(
 
     let values = focused.get(candidate.batchIndex);
     if (values === undefined) {
-      values = new Uint8Array(primitiveCount(batch));
+      values = new Uint8Array(renderPrimitiveCount(batch));
       focused.set(candidate.batchIndex, values);
     }
     if (candidate.keys.some((key) => emphasis.has(key))) values[primitiveIndex] = 1;

--- a/packages/core/src/pipeline/geometry-mark-count.ts
+++ b/packages/core/src/pipeline/geometry-mark-count.ts
@@ -1,19 +1,11 @@
 /**
  * Mark counts per geometry batch (backend auto threshold, a11y hints).
+ * Single definition: {@link renderPrimitiveCount}.
  */
+import { renderPrimitiveCount } from "../candidate-geometry.js";
 import type { GeometryBatch } from "../scene.js";
 
 /** Marks in one batch (points/glyphs per row, paths per subpath, ...). */
 export function batchMarkCount(batch: GeometryBatch): number {
-  switch (batch.kind) {
-    case "points":
-    case "glyphs":
-      return batch.rowIndex.length;
-    case "paths":
-      return Math.max(0, batch.pathOffsets.length - 1);
-    case "rects":
-      return batch.rects.length / 4;
-    default:
-      return batch.segments.length / 4;
-  }
+  return renderPrimitiveCount(batch);
 }

--- a/packages/core/src/render-svg-marks.ts
+++ b/packages/core/src/render-svg-marks.ts
@@ -2,6 +2,7 @@
  * Mark/batch SVG emitters for the pure renderer.
  * Public: countMarks, pathData. Internal: renderBatch.
  */
+import { renderPrimitiveCount } from "./candidate-geometry.js";
 import type {
   GlyphsBatch,
   PathsBatch,
@@ -16,23 +17,7 @@ import { escapeXML, px } from "./render-svg-format.js";
 
 export function countMarks(scene: Scene): number {
   let marks = 0;
-  for (const batch of scene.batches) {
-    switch (batch.kind) {
-      case "points":
-      case "glyphs":
-        marks += batch.rowIndex.length;
-        break;
-      case "paths":
-        marks += Math.max(0, batch.pathOffsets.length - 1);
-        break;
-      case "rects":
-        marks += batch.rects.length / 4;
-        break;
-      case "segments":
-        marks += batch.segments.length / 4;
-        break;
-    }
-  }
+  for (const batch of scene.batches) marks += renderPrimitiveCount(batch);
   return marks;
 }
 

--- a/packages/core/tests/candidate-geometry.test.ts
+++ b/packages/core/tests/candidate-geometry.test.ts
@@ -1,13 +1,18 @@
 import { describe, expect, it, spyOn } from "bun:test";
 
 import {
+  candidatePrimitiveCount,
   closestOrthInRange,
   directionalNearestInOrder,
   panelRangeInOrder,
   pathRange,
   pathSubpathIndex,
+  primitiveCount,
+  renderPrimitiveCount,
   samePath,
 } from "../src/candidate-geometry.ts";
+import { batchMarkCount } from "../src/pipeline.ts";
+import { batchPrimitiveCount } from "../src/dom/canvas-marks-mask.ts";
 import type { PathsBatch } from "../src/scene.ts";
 
 /** Minimal paths batch with the given offsets and enough vertices. */
@@ -68,6 +73,21 @@ describe("pathSubpathIndex / pathRange", () => {
     expect(pathRange(withEmpty, 2)).toEqual([2, 5]);
     expect(pathRange(withEmpty, 1.5)).toEqual([0, 2]);
     expect(pathRange(withEmpty, 2.25)).toEqual([2, 5]);
+  });
+});
+
+describe("render vs candidate primitive algebra (tessellated path)", () => {
+  it("separates render subpaths, geometry vertices, and semantic candidates", () => {
+    // 2 subpaths, 9 vertices, 3 semantic anchors (tessellated path).
+    const batch: PathsBatch = {
+      ...pathsBatch([0, 4, 9]),
+      semanticAnchors: new Uint8Array([1, 0, 0, 1, 0, 0, 0, 0, 1]),
+    };
+    expect(renderPrimitiveCount(batch)).toBe(2); // subpaths
+    expect(primitiveCount(batch)).toBe(9); // vertices
+    expect(candidatePrimitiveCount(batch)).toBe(3); // anchors
+    expect(batchMarkCount(batch)).toBe(2);
+    expect(batchPrimitiveCount(batch)).toBe(2);
   });
 });
 

--- a/packages/core/tests/pipeline-geometry/errorbar-batch.test.ts
+++ b/packages/core/tests/pipeline-geometry/errorbar-batch.test.ts
@@ -23,7 +23,7 @@ describe("makeErrorbarHalfWidth", () => {
   });
 });
 
-describe("batchMarkCount", () => {
+describe("batchMarkCount / renderPrimitiveCount", () => {
   it("counts points and glyphs by rowIndex length", () => {
     const points: PointsBatch = {
       kind: "points",
@@ -37,6 +37,19 @@ describe("batchMarkCount", () => {
       fill: null,
     };
     expect(batchMarkCount(points)).toBe(3);
+    const glyphs = {
+      kind: "glyphs" as const,
+      layerIndex: 0,
+      panelIndex: 0,
+      positions: new Float32Array(4),
+      rowIndex: new Uint32Array([0, 1]),
+      texts: ["a", "b"],
+      color: null,
+      size: 12,
+      anchor: "middle" as const,
+      alpha: 1,
+    };
+    expect(batchMarkCount(glyphs)).toBe(2);
   });
 
   it("counts paths by subpath count (pathOffsets length - 1)", () => {


### PR DESCRIPTION
## Summary

- Add `renderPrimitiveCount` as the single paint/focus/mark-threshold algebra
- Wire `interaction-mask`, `batchMarkCount`, `batchPrimitiveCount`, and SVG `countMarks` through it
- Keep `primitiveCount` (array topology) and `candidatePrimitiveCount` (semantic anchors) distinct
- Test tessellated path: vertices ≠ candidates ≠ subpaths
- Codex plan review: **GO with adjustments** (also unify canvas-marks-mask + countMarks) — applied

## Test plan

- [x] candidate-geometry + interaction-mask + canvas-focus + batchMarkCount tests
- [ ] CI green