### PR TITLE
fix(core): uncensored natural baseline under scale domain pins (#449)

### DIFF
--- a/.changeset/uncensored-baseline-domains.md
+++ b/.changeset/uncensored-baseline-domains.md
@@ -1,0 +1,11 @@
+---
+"@ggsvelte/core": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+fix: train uncensored natural baseline when scale domain pins censor
+
+`runPipeline` with `baselineScales` and explicit x/y domains now trains
+baseline domains from a second prepare/train pass without domain pins, so
+zoom-out references match full data extent (Svelte double-pass parity).

--- a/packages/core/src/pipeline/baseline-uncensored.ts
+++ b/packages/core/src/pipeline/baseline-uncensored.ts
@@ -5,14 +5,14 @@
  */
 import type { PortableSpec, PositionScaleSpec } from "@ggsvelte/spec";
 
-import { computeEffectiveDomains } from "./compute-domains.js";
+import { computeTrainedBaselineDomains } from "./compute-domains-baseline.js";
 import { preparePanels } from "./prepare-panels.js";
 import { trainPipelineScales } from "./train-pipeline-scales.js";
 import type { EditionDefaults } from "../editions.js";
 import type { Advisory, PipelineWarning, RunOptions, ScaleDomainSnapshot } from "./types.js";
 
 /** True when either positional scale carries an explicit continuous domain pin. */
-export function hasPinnedPositionDomain(scales: PortableSpec["scales"] | undefined): boolean {
+function hasPinnedPositionDomain(scales: PortableSpec["scales"] | undefined): boolean {
   return (
     (scales?.x?.domain !== undefined && scales.x.domain.length >= 2) ||
     (scales?.y?.domain !== undefined && scales.y.domain.length >= 2)
@@ -25,7 +25,7 @@ function stripPositionDomain(config: PositionScaleSpec): PositionScaleSpec {
 }
 
 /** Clone PortableSpec scales without x/y `domain` (keep type/nice/breaks/etc.). */
-export function withoutPositionDomains(spec: PortableSpec): PortableSpec {
+function withoutPositionDomains(spec: PortableSpec): PortableSpec {
   if (spec.scales === undefined) return spec;
   const scales = { ...spec.scales };
   if (scales.x !== undefined) scales.x = stripPositionDomain(scales.x);
@@ -36,6 +36,12 @@ export function withoutPositionDomains(spec: PortableSpec): PortableSpec {
 /**
  * Train natural baseline domains from an uncensored prepare+train pass.
  * Diagnostics from the baseline pass are discarded (effective run owns them).
+ *
+ * Frames come from the domain-stripped spec (so pins do not censor pre-stat
+ * evidence). Domain training then applies the caller's `baselineScales`
+ * (nice/expand/type) — same path as the unpinned `computeBaselineDomains`
+ * branch — so injecting the snapshot as `baselineDomains` does not drop those
+ * options.
  */
 export function trainUncensoredBaselineDomains(input: {
   normalized: PortableSpec;
@@ -47,16 +53,16 @@ export function trainUncensoredBaselineDomains(input: {
   const scratchWarnings: PipelineWarning[] = [];
   const scratchAdvisories: Advisory[] = [];
   const prepared = preparePanels(unpinned, input.options, scratchWarnings, scratchAdvisories);
-  // Avoid nested baseline training on the uncensored pass.
+  // Collect axis inputs from uncensored frames only. Drop baseline* so this
+  // nested train cannot short-circuit or re-enter the uncensored helper.
   const {
     baselineScales: _baselineScales,
     baselineDomains: _baselineDomains,
     ...restOptions
   } = input.options;
-  const trainOptions: RunOptions = restOptions;
   const trained = trainPipelineScales({
     normalized: unpinned,
-    options: trainOptions,
+    options: restOptions,
     table: prepared.table,
     sourceTable: prepared.sourceTable,
     bindings: prepared.bindings,
@@ -70,11 +76,16 @@ export function trainUncensoredBaselineDomains(input: {
     warnings: scratchWarnings,
     advisories: scratchAdvisories,
   });
-  return computeEffectiveDomains(
-    trained.xTraining.scale,
-    trained.yTraining.scale,
-    trained.panelScales,
-  );
+  // Honor caller baselineScales (nice/expand/type) on uncensored inputs.
+  return computeTrainedBaselineDomains({
+    options: input.options,
+    freeX: prepared.freeX,
+    freeY: prepared.freeY,
+    facetPanels: prepared.facetPanels,
+    panelFrames: prepared.panelFrames,
+    xInputs: trained.xInputs,
+    yInputs: trained.yInputs,
+  });
 }
 
 /** Whether runPipeline should inject an uncensored baselineDomains snapshot. */

--- a/packages/core/src/pipeline/baseline-uncensored.ts
+++ b/packages/core/src/pipeline/baseline-uncensored.ts
@@ -1,0 +1,90 @@
+/**
+ * Uncensored natural baseline domains when effective scale domain pins censor
+ * pre-stat frames (#449). Mirrors the Svelte runtime double-pass: train
+ * baseline from data without position domain pins so zoom-out is not starved.
+ */
+import type { PortableSpec, PositionScaleSpec } from "@ggsvelte/spec";
+
+import { computeEffectiveDomains } from "./compute-domains.js";
+import { preparePanels } from "./prepare-panels.js";
+import { trainPipelineScales } from "./train-pipeline-scales.js";
+import type { EditionDefaults } from "../editions.js";
+import type { Advisory, PipelineWarning, RunOptions, ScaleDomainSnapshot } from "./types.js";
+
+/** True when either positional scale carries an explicit continuous domain pin. */
+export function hasPinnedPositionDomain(scales: PortableSpec["scales"] | undefined): boolean {
+  return (
+    (scales?.x?.domain !== undefined && scales.x.domain.length >= 2) ||
+    (scales?.y?.domain !== undefined && scales.y.domain.length >= 2)
+  );
+}
+
+function stripPositionDomain(config: PositionScaleSpec): PositionScaleSpec {
+  const { domain: _domain, ...rest } = config;
+  return rest;
+}
+
+/** Clone PortableSpec scales without x/y `domain` (keep type/nice/breaks/etc.). */
+export function withoutPositionDomains(spec: PortableSpec): PortableSpec {
+  if (spec.scales === undefined) return spec;
+  const scales = { ...spec.scales };
+  if (scales.x !== undefined) scales.x = stripPositionDomain(scales.x);
+  if (scales.y !== undefined) scales.y = stripPositionDomain(scales.y);
+  return { ...spec, scales };
+}
+
+/**
+ * Train natural baseline domains from an uncensored prepare+train pass.
+ * Diagnostics from the baseline pass are discarded (effective run owns them).
+ */
+export function trainUncensoredBaselineDomains(input: {
+  normalized: PortableSpec;
+  options: RunOptions;
+  editionDefaults: EditionDefaults;
+}): ScaleDomainSnapshot {
+  const unpinned = withoutPositionDomains(input.normalized);
+  // Baseline pass owns no product diagnostics — effective run reports them.
+  const scratchWarnings: PipelineWarning[] = [];
+  const scratchAdvisories: Advisory[] = [];
+  const prepared = preparePanels(unpinned, input.options, scratchWarnings, scratchAdvisories);
+  // Avoid nested baseline training on the uncensored pass.
+  const {
+    baselineScales: _baselineScales,
+    baselineDomains: _baselineDomains,
+    ...restOptions
+  } = input.options;
+  const trainOptions: RunOptions = restOptions;
+  const trained = trainPipelineScales({
+    normalized: unpinned,
+    options: trainOptions,
+    table: prepared.table,
+    sourceTable: prepared.sourceTable,
+    bindings: prepared.bindings,
+    facetPanels: prepared.facetPanels,
+    panelFrames: prepared.panelFrames,
+    freeX: prepared.freeX,
+    freeY: prepared.freeY,
+    xConversion: prepared.xConversion,
+    yConversion: prepared.yConversion,
+    editionDefaults: input.editionDefaults,
+    warnings: scratchWarnings,
+    advisories: scratchAdvisories,
+  });
+  return computeEffectiveDomains(
+    trained.xTraining.scale,
+    trained.yTraining.scale,
+    trained.panelScales,
+  );
+}
+
+/** Whether runPipeline should inject an uncensored baselineDomains snapshot. */
+export function needsUncensoredBaselinePass(
+  options: RunOptions,
+  scales: PortableSpec["scales"],
+): boolean {
+  return (
+    options.baselineScales !== undefined &&
+    options.baselineDomains === undefined &&
+    hasPinnedPositionDomain(scales)
+  );
+}

--- a/packages/core/src/pipeline/run-pipeline.ts
+++ b/packages/core/src/pipeline/run-pipeline.ts
@@ -5,6 +5,10 @@ import type { SpecInput, PortableSpec } from "@ggsvelte/spec";
 
 import { perfMark, perfMeasure } from "../perf.js";
 
+import {
+  needsUncensoredBaselinePass,
+  trainUncensoredBaselineDomains,
+} from "./baseline-uncensored.js";
 import type { Advisory, PipelineWarning, RenderModel, RunOptions } from "./types.js";
 import { allocatePipelineRunId } from "./run-id.js";
 import { setupPipelineRun } from "./setup-run.js";
@@ -25,9 +29,25 @@ export function runPipeline(spec: SpecInput | PortableSpec, options: RunOptions)
     warnings,
   );
 
+  // Natural baseline under domain pins: train from uncensored frames so
+  // zoom-out is not starved by pre-stat pin censoring (#449). baselineDomains
+  // still wins when the host already computed them (e.g. Svelte double pass).
+  let runOptions = options;
+  if (needsUncensoredBaselinePass(options, normalized.scales)) {
+    perfMark("ggsvelte:baseline:start");
+    const baselineDomains = trainUncensoredBaselineDomains({
+      normalized,
+      options,
+      editionDefaults,
+    });
+    runOptions = { ...options, baselineDomains };
+    perfMark("ggsvelte:baseline:end");
+    perfMeasure("ggsvelte:baseline", "ggsvelte:baseline:start", "ggsvelte:baseline:end");
+  }
+
   // bind + facet partition + per-panel frames
   perfMark("ggsvelte:bind:start");
-  const prepared = preparePanels(normalized, options, warnings, advisories);
+  const prepared = preparePanels(normalized, runOptions, warnings, advisories);
   perfMark("ggsvelte:bind:end");
   perfMeasure("ggsvelte:bind", "ggsvelte:bind:start", "ggsvelte:bind:end");
 
@@ -36,7 +56,7 @@ export function runPipeline(spec: SpecInput | PortableSpec, options: RunOptions)
   perfMark("ggsvelte:scales:start");
   const trained = trainPipelineScales({
     normalized,
-    options,
+    options: runOptions,
     table: prepared.table,
     sourceTable: prepared.sourceTable,
     bindings: prepared.bindings,
@@ -56,7 +76,7 @@ export function runPipeline(spec: SpecInput | PortableSpec, options: RunOptions)
   const model = finalizePipelineRun({
     runId,
     normalized,
-    options,
+    options: runOptions,
     theme,
     flip,
     prepared,

--- a/packages/core/tests/identity.test.ts
+++ b/packages/core/tests/identity.test.ts
@@ -179,11 +179,8 @@ describe("pipeline semantic identity", () => {
     expect(model.domains.effective.panels).toHaveLength(2);
   });
 
-  // SKIP (PR 3 follow-up): the natural baseline is trained from the same frames
-  // the effective pin already censored pre-stat, so an all-excluding pin starves
-  // it. The natural baseline (zoom-out reference) needs an uncensored evidence
-  // pass; the assertions below encode the correct target contract.
-  it.skip("trains latest natural baseline domains beside explicit effective zoom domains", () => {
+  // Uncensored second evidence pass when baselineScales + domain pins (#449).
+  it("trains latest natural baseline domains beside explicit effective zoom domains", () => {
     const model = runPipeline(
       {
         data: {
@@ -218,11 +215,7 @@ describe("pipeline semantic identity", () => {
       [1.9, 4.1],
       [1.9, 4.1],
     ]);
-    // Natural baseline: the un-pinned extent [0,20] widened by expansion. NOTE:
-    // under PR 3's pre-stat pin censoring the natural baseline currently shares
-    // the effective pin's censored frames, so an all-excluding pin starves it.
-    // Restoring an uncensored second evidence pass for the natural baseline (the
-    // zoom-out reference) is tracked as a follow-up.
+    // Natural baseline: uncensored data extent [0,20] with expansion (#449).
     expect(model.domains.baseline.x).toEqual([-1, 21]);
     expect(model.domains.baseline.y).toEqual([-1, 21]);
     expect(model.domains.baseline.panels.map((panel) => panel.x)).toEqual([

--- a/packages/core/tests/identity.test.ts
+++ b/packages/core/tests/identity.test.ts
@@ -227,6 +227,35 @@ describe("pipeline semantic identity", () => {
       [9.5, 20.5],
     ]);
 
+    // Codex P2: uncensored pass must honor baselineScales (nice/expand/type),
+    // not the stripped effective scale config. Data extent [1,19] nices to
+    // [0,20] then expands 5% → [-1,21]; with nice:false expand alone → [0.1,19.9].
+    const nicedBaseline = runPipeline(
+      {
+        data: {
+          values: [
+            { x: 1, y: 1 },
+            { x: 19, y: 19 },
+          ],
+        },
+        layers: [{ geom: "point", aes: { x: { field: "x" }, y: { field: "y" } } }],
+        scales: {
+          x: { type: "linear", domain: [2, 4], nice: false },
+          y: { type: "linear", domain: [2, 4], nice: false },
+        },
+      },
+      {
+        width: 400,
+        height: 240,
+        baselineScales: {
+          x: { type: "linear" },
+          y: { type: "linear" },
+        },
+      },
+    );
+    expect(nicedBaseline.domains.baseline.x).toEqual([-1, 21]);
+    expect(nicedBaseline.domains.baseline.y).toEqual([-1, 21]);
+
     const override = {
       x: [100, 200],
       y: [300, 400],


### PR DESCRIPTION
## Summary

Closes #449. Natural baseline under domain pins was trained from censored frames.

### Fix
- Second prepare/train without x/y domain when `baselineScales` is set and pins exist
- Inject as `baselineDomains` for finalize (Svelte double-pass parity)
- Host `baselineDomains` still wins

## Tests
- Unskipped identity contract for free-facet pin + natural baseline extents
