### PR TITLE
fix(svelte): re-export InteractionSource for interval test harness

### DIFF
--- a/packages/svelte/tests/interval/interval-state.bounds-editor.test.ts
+++ b/packages/svelte/tests/interval/interval-state.bounds-editor.test.ts
@@ -21,6 +21,7 @@ import {
   nonPersistentSelect,
   persistentSelect,
   type ContinuousZoomDomains,
+  type InteractionSource,
   type PlotSelection,
   type SelectConfig,
 } from "./interval-state.harness.js";

--- a/packages/svelte/tests/interval/interval-state.harness.ts
+++ b/packages/svelte/tests/interval/interval-state.harness.ts
@@ -198,4 +198,4 @@ export function mountIntervalController(
 
 export { createIntervalState, createPlotInteraction, modelFor, buildIntervalSelection };
 export type { ContinuousZoomDomains };
-export type { IntervalSelection, PlotInteractionScope, PlotSelection };
+export type { InteractionSource, IntervalSelection, PlotInteractionScope, PlotSelection };


### PR DESCRIPTION
## Summary

Follow-up for unrebutted Codex finding on #457.

`interval-state.bounds-editor.test.ts` references `InteractionSource` after the monolith split, but the harness imported it without re-exporting and the suite did not import the type.

## Fix

- Re-export `InteractionSource` from `interval-state.harness.ts`
- Import it in the bounds-editor suite

## Parent

- https://github.com/ljodea/ggsvelte/pull/457

## Test plan

- [x] `vitest run tests/interval/interval-state.bounds-editor.test.ts` (15 pass)
- [x] `svelte-check` clean