### PR TITLE
perf(core): skip per-group sort in stat_summary mean_se path

### DIFF
--- a/.changeset/summary-mean-skip-sort.md
+++ b/.changeset/summary-mean-skip-sort.md
@@ -1,0 +1,10 @@
+---
+"@ggsvelte/core": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+perf: skip per-group sort in stat_summary mean_se path
+
+`statSummary` only sorts (group,x) buckets when median is requested. Default
+mean_se and min/max/sum stay O(n) per combination.

--- a/packages/core/src/stats/summary.ts
+++ b/packages/core/src/stats/summary.ts
@@ -49,24 +49,48 @@ export interface SummaryStatResult {
   dropped: number;
 }
 
-function applyFun(fun: SummaryFunName, sorted: readonly number[]): number {
+/**
+ * Apply a summary function to a group of values.
+ * - median requires ascending sort (caller must pass sorted).
+ * - min/max/mean/sum scan unsorted in O(n).
+ */
+function applyFun(fun: SummaryFunName, values: readonly number[], sorted: boolean): number {
   switch (fun) {
     case "mean":
-      return mean(sorted);
+      return mean(values);
     case "median": {
-      const n = sorted.length;
-      return n % 2 === 1 ? sorted[(n - 1) / 2]! : (sorted[n / 2 - 1]! + sorted[n / 2]!) / 2;
+      if (!sorted) {
+        throw new Error("statSummary: median requires sorted values");
+      }
+      const n = values.length;
+      return n % 2 === 1 ? values[(n - 1) / 2]! : (values[n / 2 - 1]! + values[n / 2]!) / 2;
     }
     case "sum": {
       let s = 0;
-      for (const v of sorted) s += v;
+      for (const v of values) s += v;
       return s;
     }
-    case "min":
-      return sorted[0]!;
-    default:
-      return sorted.at(-1)!;
+    case "min": {
+      let m = values[0]!;
+      for (let i = 1; i < values.length; i++) if (values[i]! < m) m = values[i]!;
+      return m;
+    }
+    default: {
+      // max
+      let m = values[0]!;
+      for (let i = 1; i < values.length; i++) if (values[i]! > m) m = values[i]!;
+      return m;
+    }
   }
+}
+
+/** True when any requested fun needs an ascending sort (only median). */
+function needsSortedValues(
+  fun: SummaryFunName,
+  funMin: SummaryFunName | undefined,
+  funMax: SummaryFunName | undefined,
+): boolean {
+  return fun === "median" || funMin === "median" || funMax === "median";
 }
 
 export function statSummary(input: SummaryStatInput): SummaryStatResult {
@@ -108,10 +132,15 @@ export function statSummary(input: SummaryStatInput): SummaryStatResult {
   const outY = new Float64Array(comboRows.length);
   const outYmin = new Float64Array(comboRows.length);
   const outYmax = new Float64Array(comboRows.length);
+  // Default mean_se (and min/max/sum) never need a sort — only median does.
+  // Skipping the O(n log n) sort per (group,x) keeps large repeated-x groups linear.
+  // mean/sum accumulate in input-row order (ggplot2/R data order), not sort order.
+  const sortValues = needsSortedValues(fun, input.funMin, input.funMax);
   for (let slot = 0; slot < comboRows.length; slot++) {
     const rows = comboRows[slot]!;
-    const values = rows.map((row) => y[row]!).toSorted((a, b) => a - b);
-    const center = applyFun(fun, values);
+    const values = rows.map((row) => y[row]!);
+    if (sortValues) values.sort((a, b) => a - b);
+    const center = applyFun(fun, values, sortValues);
     outY[slot] = center;
     if (input.funMin === undefined && input.funMax === undefined && fun === "mean") {
       // mean_se: mean ± sd/sqrt(n); a single observation has no spread.
@@ -119,8 +148,10 @@ export function statSummary(input: SummaryStatInput): SummaryStatResult {
       outYmin[slot] = center - se;
       outYmax[slot] = center + se;
     } else {
-      outYmin[slot] = input.funMin === undefined ? center : applyFun(input.funMin, values);
-      outYmax[slot] = input.funMax === undefined ? center : applyFun(input.funMax, values);
+      outYmin[slot] =
+        input.funMin === undefined ? center : applyFun(input.funMin, values, sortValues);
+      outYmax[slot] =
+        input.funMax === undefined ? center : applyFun(input.funMax, values, sortValues);
     }
   }
 

--- a/packages/core/tests/stats-unit.test.ts
+++ b/packages/core/tests/stats-unit.test.ts
@@ -132,6 +132,38 @@ describe("statSummary edges", () => {
     expect(result.ymin[0]).toBe(2);
     expect(result.ymax[0]).toBe(2);
   });
+
+  it("default mean_se is order-independent (no sort required)", () => {
+    // Large multiset; mean and se must match regardless of input order.
+    const yAsc = Float64Array.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    const yDesc = Float64Array.from([10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
+    const x = Array.from({ length: 10 }, () => "a");
+    const groups = Array.from({ length: 10 }, () => 0);
+    const a = statSummary({ x, y: yAsc, groups });
+    const b = statSummary({ x, y: yDesc, groups });
+    expect(a.y[0]).toBeCloseTo(5.5, 12);
+    expect(b.y[0]).toBeCloseTo(5.5, 12);
+    expect(a.ymin[0]).toBeCloseTo(b.ymin[0]!, 12);
+    expect(a.ymax[0]).toBeCloseTo(b.ymax[0]!, 12);
+    // se = sd/sqrt(10); sd of 1..10 is known.
+    const se = a.y[0]! - a.ymin[0]!;
+    expect(se).toBeGreaterThan(0);
+    expect(a.ymax[0]! - a.y[0]!).toBeCloseTo(se, 12);
+  });
+
+  it("min/max bounds without median skip full-group sort semantics", () => {
+    const result = statSummary({
+      x: ["a", "a", "a", "a"],
+      y: Float64Array.from([9, 1, 5, 3]),
+      groups: [0, 0, 0, 0],
+      fun: "mean",
+      funMin: "min",
+      funMax: "max",
+    });
+    expect(result.y[0]).toBeCloseTo(4.5, 12);
+    expect(result.ymin[0]).toBe(1);
+    expect(result.ymax[0]).toBe(9);
+  });
 });
 
 describe("loessFit edges", () => {


### PR DESCRIPTION
## Summary

`/bigo-maintain` on `packages/core` (325 production src files).

### Finding

- **File:** `packages/core/src/stats/summary.ts` (`statSummary`)
- **Pattern:** #6 Sort inside loop (unnecessary for default path)
- **Before:** every (group,x) bucket `toSorted` → **O(n log n)** per combination even for default mean_se
- **After:** sort only when fun/funMin/funMax includes **median**; min/max scan O(n)
- **n:** rows per (group, x) combination (can be large for dense y at few x)

mean/sum accumulate in input-row order (ggplot2/R data order). R fixtures 40/41 still pass.

### Codex plan review

Flagged FP order dependence vs always-sorted sum. Accepted: data-order mean matches R/ggplot2 better than forced ascending sort; parity fixtures green.

### Tests

```text
bun test packages/core/tests/stats-unit.test.ts packages/core/tests/stats-parity.test.ts …
# summary mean_se + median-min-max fixtures pass
```

### Follow-ups

None.

## Test plan

- [x] mean_se single-obs + multi-obs order-independent for ordinary values
- [x] mean + min/max without median
- [x] median still correct
- [x] R parity fixtures 40 and 41
