### PR TITLE
fix(ci): scope /approve-visuals regenerate to vr.spec.ts smoke (#421)

### DIFF
--- a/.github/workflows/vr-compare.yml
+++ b/.github/workflows/vr-compare.yml
@@ -322,8 +322,13 @@ jobs:
         run: bun run build:docs
 
       - name: REGENERATE baselines at the approved merged commit
+        # Smoke-only (tests/visual/vr.spec.ts) — same scope as the compare job.
+        # The full tests/visual suite includes non-snapshot assertion journeys
+        # (a11y, docs, playground). --update-snapshots cannot make those pass,
+        # so a red assertion test on main would permanently block all baseline
+        # updates (#421). Only vr.spec.ts owns committed __screenshots__/ PNGs.
         # workers=1 matches the compare job — canvas-scatter hydrate is main-thread heavy.
-        run: bun run test:visual -- --workers=1 --update-snapshots
+        run: bun run test:visual -- vr.spec.ts --workers=1 --update-snapshots
 
       - name: assemble approved-baseline artifact (PNGs + metadata)
         env:

--- a/.github/workflows/vr-compare.yml
+++ b/.github/workflows/vr-compare.yml
@@ -323,11 +323,14 @@ jobs:
 
       - name: REGENERATE baselines at the approved merged commit
         # Smoke-only screenshots (tests/visual/vr.spec.ts) — same scope as compare.
-        # Non-snapshot journeys (a11y, docs, playground) and non-pixel assertions
-        # (e.g. scroll/touch-action) live outside this file so a red hard assert
-        # cannot block --update-snapshots / vr-baselines-approved (#421).
+        # Checkout is the *merged render SHA* of the approved PR (security: pin
+        # what gets screenshotted). That tree may predate moving the non-pixel
+        # scroll assert out of vr.spec.ts, so --grep-invert drops that title on
+        # legacy SHAs. Current main already keeps vr.spec screenshot-only (#421).
         # workers=1 matches the compare job — canvas-scatter hydrate is main-thread heavy.
-        run: bun run test:visual -- vr.spec.ts --workers=1 --update-snapshots
+        run: >-
+          bun run test:visual -- vr.spec.ts --workers=1 --update-snapshots
+          --grep-invert 'preserves real page scrolling'
 
       - name: assemble approved-baseline artifact (PNGs + metadata)
         env:

--- a/.github/workflows/vr-compare.yml
+++ b/.github/workflows/vr-compare.yml
@@ -322,11 +322,10 @@ jobs:
         run: bun run build:docs
 
       - name: REGENERATE baselines at the approved merged commit
-        # Smoke-only (tests/visual/vr.spec.ts) — same scope as the compare job.
-        # The full tests/visual suite includes non-snapshot assertion journeys
-        # (a11y, docs, playground). --update-snapshots cannot make those pass,
-        # so a red assertion test on main would permanently block all baseline
-        # updates (#421). Only vr.spec.ts owns committed __screenshots__/ PNGs.
+        # Smoke-only screenshots (tests/visual/vr.spec.ts) — same scope as compare.
+        # Non-snapshot journeys (a11y, docs, playground) and non-pixel assertions
+        # (e.g. scroll/touch-action) live outside this file so a red hard assert
+        # cannot block --update-snapshots / vr-baselines-approved (#421).
         # workers=1 matches the compare job — canvas-scatter hydrate is main-thread heavy.
         run: bun run test:visual -- vr.spec.ts --workers=1 --update-snapshots
 

--- a/scripts/release-wiring.test.ts
+++ b/scripts/release-wiring.test.ts
@@ -351,8 +351,11 @@ describe("R0 release wiring", () => {
     expect(job).toContain("bun run test:visual -- vr.spec.ts --workers=1 --update-snapshots");
     // Must not reintroduce the full-suite regenerate command.
     expect(job).not.toMatch(/bun run test:visual -- --workers=1 --update-snapshots/);
-    // Smoke file must stay screenshot-only: non-pixel assertions in vr.spec.ts
-    // still fail regenerate even when scoped to that file (Codex P2 on #531).
+    // approve-regenerate checks out the *approved PR's merge SHA*, which may
+    // still contain the pre-move non-pixel scroll test in vr.spec.ts. Invert
+    // that title so legacy render trees cannot block baseline upload.
+    expect(job).toContain("--grep-invert 'preserves real page scrolling'");
+    // Smoke file on main must stay screenshot-only (Codex P2 on #531).
     const smokeSpec = read("tests/visual/vr.spec.ts");
     expect(smokeSpec).not.toContain("without a golden");
     expect(smokeSpec).not.toContain("preserves real page scrolling");

--- a/scripts/release-wiring.test.ts
+++ b/scripts/release-wiring.test.ts
@@ -341,6 +341,18 @@ describe("R0 release wiring", () => {
     expect(approvalJob).toContain("shell: bash");
   });
 
+  it("scopes approve-regenerate to smoke VR screenshots only (#421)", () => {
+    // Full-suite --update-snapshots fails on non-snapshot assertion tests and
+    // permanently blocks baseline landing when any journey is red (see #421).
+    const workflow = read(".github/workflows/vr-compare.yml");
+    const approvalJob = workflow.slice(workflow.indexOf("  approve-regenerate:"));
+    const nextJob = approvalJob.search(/\n  [a-zA-Z0-9_-]+:/);
+    const job = nextJob === -1 ? approvalJob : approvalJob.slice(0, nextJob);
+    expect(job).toContain("bun run test:visual -- vr.spec.ts --workers=1 --update-snapshots");
+    // Must not reintroduce the full-suite regenerate command.
+    expect(job).not.toMatch(/bun run test:visual -- --workers=1 --update-snapshots/);
+  });
+
   it("wires Dependabot for bun workspaces and GitHub Actions", () => {
     const dependabot = read(".github/dependabot.yml");
     expect(dependabot).toContain('package-ecosystem: "bun"');

--- a/scripts/release-wiring.test.ts
+++ b/scripts/release-wiring.test.ts
@@ -351,6 +351,13 @@ describe("R0 release wiring", () => {
     expect(job).toContain("bun run test:visual -- vr.spec.ts --workers=1 --update-snapshots");
     // Must not reintroduce the full-suite regenerate command.
     expect(job).not.toMatch(/bun run test:visual -- --workers=1 --update-snapshots/);
+    // Smoke file must stay screenshot-only: non-pixel assertions in vr.spec.ts
+    // still fail regenerate even when scoped to that file (Codex P2 on #531).
+    const smokeSpec = read("tests/visual/vr.spec.ts");
+    expect(smokeSpec).not.toContain("without a golden");
+    expect(smokeSpec).not.toContain("preserves real page scrolling");
+    const journeysSpec = read("tests/visual/interaction-accessibility.spec.ts");
+    expect(journeysSpec).toContain("preserves real page scrolling");
   });
 
   it("wires Dependabot for bun workspaces and GitHub Actions", () => {

--- a/tests/visual/interaction-accessibility.spec.ts
+++ b/tests/visual/interaction-accessibility.spec.ts
@@ -97,3 +97,23 @@ test("interval example supports the two-tap touch journey", async ({ page }) => 
   await expect(page.locator(".gg-selection")).toBeVisible();
   await expect(page.locator(".event-status")).toContainText("end:");
 });
+
+// Non-pixel — lives here (docs journeys), not in vr.spec.ts. The approve-visuals
+// regenerate path runs only vr.spec.ts with --update-snapshots; a hard assertion
+// in that file can fail independently of goldens and block baseline landing (#421).
+test("interaction inspect mode preserves real page scrolling", async ({ page }) => {
+  await page.setViewportSize({ width: 800, height: 420 });
+  await page.goto("/examples/interaction/tooltip?vr&theme=light");
+  await settleVisualState(page);
+  await page.evaluate(() => {
+    document.body.style.minHeight = "2000px";
+  });
+  const capture = page.locator(".gg-capture");
+  await expect(capture).toHaveCSS("touch-action", /pan-y/);
+  const box = await capture.boundingBox();
+  if (box === null) throw new Error("expected an inspection capture surface");
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+  const before = await page.evaluate(() => window.scrollY);
+  await page.mouse.wheel(0, 500);
+  await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(before);
+});

--- a/tests/visual/vr.spec.ts
+++ b/tests/visual/vr.spec.ts
@@ -153,21 +153,3 @@ for (const scenario of SMOKE_SCENARIOS) {
     await handler(page, scenario);
   });
 }
-
-// Non-pixel interaction behavior retained without a golden.
-test("interaction inspect mode preserves real page scrolling", async ({ page }) => {
-  await page.setViewportSize({ width: 800, height: 420 });
-  await page.goto("/examples/interaction/tooltip?vr&theme=light");
-  await settleVisualState(page);
-  await page.evaluate(() => {
-    document.body.style.minHeight = "2000px";
-  });
-  const capture = page.locator(".gg-capture");
-  await expect(capture).toHaveCSS("touch-action", /pan-y/);
-  const box = await capture.boundingBox();
-  if (box === null) throw new Error("expected an inspection capture surface");
-  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
-  const before = await page.evaluate(() => window.scrollY);
-  await page.mouse.wheel(0, 500);
-  await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(before);
-});


### PR DESCRIPTION
## Summary

Partial fix for #421 (the **secondary finding** that permanently blocked baseline landing).

### Problem
`approve-regenerate` ran:

```bash
bun run test:visual -- --workers=1 --update-snapshots
```

That executes **all** of `tests/visual/` (a11y, docs journeys, playground, …). `--update-snapshots` only rewrites screenshot baselines — it cannot make hard assertion tests pass. When any unrelated journey is red on main, **every** `/approve-visuals` regenerate fails and no `vr-baselines-approved` artifact is produced.

Only `tests/visual/vr.spec.ts` owns the committed `__screenshots__/*.png` set. The pull_request compare job already scopes to that file.

### Fix
Align regenerate with compare:

```bash
bun run test:visual -- vr.spec.ts --workers=1 --update-snapshots
```

### Remaining for #421 (not this PR)
- Re-comment `/approve-visuals` on #408 (or a later band-axis render PR) so stale `col-basic` / `boxplot-by-category` PNGs actually refresh via the now-unblocked path.
- #417 is already closed; this removes the full-suite regenerate trap regardless of future journey failures.

## Tests
- `bun test scripts/release-wiring.test.ts` — new contract that approve-regenerate is smoke-only