### PR TITLE
refactor(spec): split lintSpec layer and scale rule modules

### DIFF
--- a/.changeset/spec-lint-rules-split.md
+++ b/.changeset/spec-lint-rules-split.md
@@ -1,0 +1,7 @@
+---
+"@ggsvelte/spec": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+Split lintSpec into layer and scale rule modules, guard schema-invalid scale entries so lint never throws, and keep catalog source-scan coverage multi-file. Public lintSpec behavior is otherwise unchanged.

--- a/packages/spec/src/lint-catalog.ts
+++ b/packages/spec/src/lint-catalog.ts
@@ -1,6 +1,7 @@
 /**
  * Spec lint-advisory catalog — pure data for docs and code identity.
- * Runtime SpecAdvisory instances and lintSpec() live in lint.ts.
+ * Runtime SpecAdvisory instances and lintSpec() live in lint.ts;
+ * rule emission sites: lint-layer-rules.ts and lint-scale-rules.ts.
  */
 
 /** One entry of the lint catalog (docs render straight from it). */

--- a/packages/spec/src/lint-layer-rules.ts
+++ b/packages/spec/src/lint-layer-rules.ts
@@ -1,0 +1,150 @@
+/**
+ * Layer-scoped lint rules: line-over-nominal-x, discrete-discrete-scatter,
+ * stacked-area-negative, many-discrete-colors.
+ * Scale-level rules: lint-scale-rules.ts. Orchestrator: lint.ts.
+ */
+import type { Aes, ChannelName } from "./schema.js";
+import { GEOM_DEFAULTS } from "./schema.js";
+import type { FieldEvidenceEntry, ProfileFieldType } from "./validate-data.js";
+import type { SpecAdvisory } from "./lint.js";
+
+const DISCRETE: ReadonlySet<ProfileFieldType> = new Set(["nominal", "ordinal"]);
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+/** Distinct non-null values in a column (single pass, no intermediate filter). */
+function countDistinctNonNull(values: readonly unknown[]): number {
+  const distinct = new Set<unknown>();
+  for (const value of values) {
+    if (value !== null) distinct.add(value);
+  }
+  return distinct.size;
+}
+
+export type LintFieldOf = (
+  layerAes: Aes | undefined,
+  channel: ChannelName,
+) => { field: string; info: FieldEvidenceEntry } | null;
+
+/** Layer-scoped advisories for one lintSpec pass. */
+export function collectLayerLintAdvisories(input: {
+  layers: unknown[];
+  fieldOf: LintFieldOf;
+}): SpecAdvisory[] {
+  const { layers, fieldOf } = input;
+  const advisories: SpecAdvisory[] = [];
+
+  // FieldEvidenceMap is built once per lintSpec/validate call; distinct counts
+  // for many-discrete-colors are memoized across layers/channels that share a
+  // field so a high-cardinality column is scanned O(n), not O(L·n).
+  const distinctNonNullByField = new Map<string, number>();
+
+  for (let i = 0; i < layers.length; i++) {
+    const layer = layers[i];
+    if (!isRecord(layer)) continue;
+    const geom = typeof layer["geom"] === "string" ? layer["geom"] : "";
+    const layerAes = isRecord(layer["aes"]) ? (layer["aes"] as Aes) : undefined;
+    const defaults = GEOM_DEFAULTS[geom as keyof typeof GEOM_DEFAULTS];
+    const position =
+      typeof layer["position"] === "string"
+        ? layer["position"]
+        : (defaults?.position ?? "identity");
+
+    // --- line-over-nominal-x ------------------------------------------------
+    if (geom === "line") {
+      const x = fieldOf(layerAes, "x");
+      if (x !== null && x.info.type === "nominal") {
+        advisories.push({
+          code: "line-over-nominal-x",
+          path: `/layers/${i}/aes/x`,
+          message: `This line layer connects points across "${x.field}", a nominal (unordered) field — the line's slopes carry no meaning.`,
+          suggestion: {
+            description:
+              'Use geom "col" (or "bar" with the count stat) for per-category values; keep "line" only for ordered x (numbers, dates, or a genuinely ordinal field).',
+            example: { geom: "col" },
+          },
+        });
+      }
+    }
+
+    // --- discrete-discrete-scatter -------------------------------------------
+    if (geom === "point" && position !== "jitter") {
+      const x = fieldOf(layerAes, "x");
+      const y = fieldOf(layerAes, "y");
+      if (
+        x !== null &&
+        y !== null &&
+        x.info.type !== null &&
+        y.info.type !== null &&
+        DISCRETE.has(x.info.type) &&
+        DISCRETE.has(y.info.type)
+      ) {
+        advisories.push({
+          code: "discrete-discrete-scatter",
+          path: `/layers/${i}`,
+          message: `This point layer maps discrete fields on both axes ("${x.field}" × "${y.field}") — identical combinations overplot invisibly.`,
+          suggestion: {
+            description:
+              'Add position: "jitter" to spread the points, or count the combinations and encode the count (e.g. point size).',
+            example: { geom: "point", position: "jitter" },
+          },
+        });
+      }
+    }
+
+    // --- stacked-area-negative -----------------------------------------------
+    if (geom === "area" && (position === "stack" || position === "fill")) {
+      const y = fieldOf(layerAes, "y");
+      const values = y?.info.values;
+      if (y !== null && values !== null && values !== undefined) {
+        const hasNegative = values.some((v) => typeof v === "number" && v < 0);
+        if (hasNegative) {
+          advisories.push({
+            code: "stacked-area-negative",
+            path: `/layers/${i}/aes/y`,
+            message: `This stacked area layer's y field "${y.field}" contains negative values — stacked bands will cross and misread as parts of a whole.`,
+            suggestion: {
+              description:
+                'Draw one line per series instead, or set position: "identity" to overlap the areas.',
+              example: { geom: "area", position: "identity" },
+            },
+          });
+        }
+      }
+    }
+
+    // --- many-discrete-colors -------------------------------------------------
+    for (const channel of ["color", "fill"] as const) {
+      const c = fieldOf(layerAes, channel);
+      const values = c?.info.values;
+      if (
+        c !== null &&
+        values !== null &&
+        values !== undefined &&
+        c.info.type !== null &&
+        DISCRETE.has(c.info.type)
+      ) {
+        let distinct = distinctNonNullByField.get(c.field);
+        if (distinct === undefined) {
+          distinct = countDistinctNonNull(values);
+          distinctNonNullByField.set(c.field, distinct);
+        }
+        if (distinct > 10) {
+          advisories.push({
+            code: "many-discrete-colors",
+            path: `/layers/${i}/aes/${channel}`,
+            message: `Field "${c.field}" maps ${distinct} distinct values to ${channel} — beyond ~10, hues stop being distinguishable and the default palette cycles.`,
+            suggestion: {
+              description: `Facet by "${c.field}", aggregate it to fewer categories, or pin scales.${channel}.domain (+ a range) to the values that matter.`,
+              example: { facet: { wrap: { field: c.field } } },
+            },
+          });
+        }
+      }
+    }
+  }
+
+  return advisories;
+}

--- a/packages/spec/src/lint-scale-rules.ts
+++ b/packages/spec/src/lint-scale-rules.ts
@@ -1,0 +1,110 @@
+/**
+ * Scale-level lint rules: transform-domain-data.
+ * Layer rules: lint-layer-rules.ts. Orchestrator: lint.ts.
+ */
+import type { Aes, PositionScaleSpec } from "./schema.js";
+import type { SpecAdvisory } from "./lint.js";
+import type { LintFieldOf } from "./lint-layer-rules.js";
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+/** Forward-transform domain rule for a position scale, or null if none. */
+interface TransformDomain {
+  valid(value: number): boolean;
+  /** Human label for the message ("log10" | "sqrt"). */
+  label: string;
+  /** Short description of the valid range ("positive" | "non-negative"). */
+  rule: string;
+}
+
+/**
+ * Resolve the effective forward-transform domain for a position scale, reading
+ * the spec BEFORE normalization. Both the authored legacy `type: "log"` and the
+ * canonical `transform: "log10" | "sqrt"` are covered; identity/time/untyped
+ * scales return null.
+ */
+function transformDomainOf(config: PositionScaleSpec | undefined): TransformDomain | null {
+  if (config === undefined) return null;
+  const transform = config.transform ?? (config.type === "log" ? "log10" : undefined);
+  if (transform === "log10") {
+    return { valid: (v) => v > 0, label: "log10", rule: "positive" };
+  }
+  if (transform === "sqrt") {
+    return { valid: (v) => v >= 0, label: "sqrt", rule: "non-negative" };
+  }
+  return null;
+}
+
+/** Count numeric values inside/outside a transform domain (non-numbers ignored). */
+function countTransformDomain(
+  values: readonly unknown[],
+  domain: TransformDomain,
+): readonly [inDomain: number, outOfDomain: number] {
+  let inDomain = 0;
+  let outOfDomain = 0;
+  for (const v of values) {
+    if (typeof v !== "number") continue;
+    if (domain.valid(v)) inDomain++;
+    else outOfDomain++;
+  }
+  return [inDomain, outOfDomain];
+}
+
+/** Scale-scoped advisories for one lintSpec pass. */
+export function collectScaleLintAdvisories(input: {
+  layers: unknown[];
+  scales: Record<string, unknown> | undefined;
+  fieldOf: LintFieldOf;
+}): SpecAdvisory[] {
+  const { layers, scales, fieldOf } = input;
+  const advisories: SpecAdvisory[] = [];
+
+  // --- transform-domain-data (scale-level, once per axis) ---------------------
+  // Detect the effective forward-transform domain BEFORE normalization: an
+  // authored `type: "log"` (canonicalizes to transform: "log10") and a
+  // canonical `transform: "log10" | "sqrt"` are all handled here. log10 rejects
+  // values <= 0; sqrt rejects values < 0. The advisory fires only on MIXED data
+  // (some in-domain, some out) — all-invalid is the pipeline's error/warning.
+  //
+  // Multi-layer charts often share the same mapped field (plot aes or repeated
+  // layer aes). Memoize [inDomain, outOfDomain] per field name for this axis so
+  // a shared column is scanned once (O(n)), not once per layer (O(L·n)).
+  for (const axis of ["x", "y"] as const) {
+    const raw = scales?.[axis];
+    // Schema-invalid scale entries must not throw — lint never blocks.
+    if (raw !== undefined && !isRecord(raw)) continue;
+    const config = raw as PositionScaleSpec | undefined;
+    const domain = transformDomainOf(config);
+    if (domain === null) continue;
+    const fieldDomainCounts = new Map<string, readonly [inDomain: number, outOfDomain: number]>();
+    for (let i = 0; i < layers.length; i++) {
+      const layer = layers[i];
+      if (!isRecord(layer)) continue;
+      const layerAes = isRecord(layer["aes"]) ? (layer["aes"] as Aes) : undefined;
+      const use = fieldOf(layerAes, axis);
+      const values = use?.info.values;
+      if (use === null || values === null || values === undefined) continue;
+      let counts = fieldDomainCounts.get(use.field);
+      if (counts === undefined) {
+        counts = countTransformDomain(values, domain);
+        fieldDomainCounts.set(use.field, counts);
+      }
+      const [inDomain, outOfDomain] = counts;
+      if (inDomain > 0 && outOfDomain > 0) {
+        advisories.push({
+          code: "transform-domain-data",
+          path: `/scales/${axis}`,
+          message: `scales.${axis} is a ${domain.label} scale, but field "${use.field}" has ${outOfDomain} value(s) outside its ${domain.rule} domain alongside ${inDomain} valid — those rows will be silently dropped before stats.`,
+          suggestion: {
+            description: `Filter the out-of-domain rows deliberately, or use an identity/linear scale if ${domain.rule} values are meaningful.`,
+          },
+        });
+        break; // one advisory per axis is enough
+      }
+    }
+  }
+
+  return advisories;
+}

--- a/packages/spec/src/lint.ts
+++ b/packages/spec/src/lint.ts
@@ -21,22 +21,18 @@
  *    MIXED data (some in-domain, some out), where the silent row-drop is most
  *    surprising.
  *
+ * Implementation:
+ *  - lint-catalog.ts — pure advisory catalog (re-exported here)
+ *  - lint-layer-rules.ts — layer-scoped rules
+ *  - lint-scale-rules.ts — scale-level transform-domain-data
+ *
  * Wired into `validate(spec, { lint: true })` (advisories ride the result)
  * and into the `ggsvelte-render` CLI (stderr JSON lines, kind "advisory",
  * source "spec-lint").
- *
- * The pure advisory catalog lives in lint-catalog.ts and is re-exported here
- * so package imports keep the ./lint.js path (same pattern as errors/error-catalog).
  */
 import type { JSONValue } from "./portability.js";
-import type { Aes, ChannelName, PositionScaleSpec } from "./schema.js";
-import { GEOM_DEFAULTS } from "./schema.js";
-import type {
-  FieldEvidenceEntry,
-  FieldEvidenceMap,
-  ProfileFieldType,
-  ValidateOptions,
-} from "./validate-data.js";
+import type { Aes, ChannelName } from "./schema.js";
+import type { FieldEvidenceEntry, FieldEvidenceMap, ValidateOptions } from "./validate-data.js";
 import {
   DEFAULT_VALIDATE_LIMITS,
   effectiveChannel,
@@ -44,6 +40,8 @@ import {
 } from "./validate-data.js";
 
 import type { LintAdvisoryCode } from "./lint-catalog.js";
+import { collectLayerLintAdvisories } from "./lint-layer-rules.js";
+import { collectScaleLintAdvisories } from "./lint-scale-rules.js";
 
 export { LINT_CATALOG, type LintAdvisoryCode, type LintCatalogEntry } from "./lint-catalog.js";
 
@@ -82,59 +80,6 @@ function buildEvidence(
   return resolved.status === "ok" ? resolved.fields : null;
 }
 
-const DISCRETE: ReadonlySet<ProfileFieldType> = new Set(["nominal", "ordinal"]);
-
-/** Forward-transform domain rule for a position scale, or null if none. */
-interface TransformDomain {
-  valid(value: number): boolean;
-  /** Human label for the message ("log10" | "sqrt"). */
-  label: string;
-  /** Short description of the valid range ("positive" | "non-negative"). */
-  rule: string;
-}
-
-/**
- * Resolve the effective forward-transform domain for a position scale, reading
- * the spec BEFORE normalization. Both the authored legacy `type: "log"` and the
- * canonical `transform: "log10" | "sqrt"` are covered; identity/time/untyped
- * scales return null.
- */
-function transformDomainOf(config: PositionScaleSpec | undefined): TransformDomain | null {
-  if (config === undefined) return null;
-  const transform = config.transform ?? (config.type === "log" ? "log10" : undefined);
-  if (transform === "log10") {
-    return { valid: (v) => v > 0, label: "log10", rule: "positive" };
-  }
-  if (transform === "sqrt") {
-    return { valid: (v) => v >= 0, label: "sqrt", rule: "non-negative" };
-  }
-  return null;
-}
-
-/** Count numeric values inside/outside a transform domain (non-numbers ignored). */
-function countTransformDomain(
-  values: readonly unknown[],
-  domain: TransformDomain,
-): readonly [inDomain: number, outOfDomain: number] {
-  let inDomain = 0;
-  let outOfDomain = 0;
-  for (const v of values) {
-    if (typeof v !== "number") continue;
-    if (domain.valid(v)) inDomain++;
-    else outOfDomain++;
-  }
-  return [inDomain, outOfDomain];
-}
-
-/** Distinct non-null values in a column (single pass, no intermediate filter). */
-function countDistinctNonNull(values: readonly unknown[]): number {
-  const distinct = new Set<unknown>();
-  for (const value of values) {
-    if (value !== null) distinct.add(value);
-  }
-  return distinct.size;
-}
-
 // ---------------------------------------------------------------------------
 // lintSpec
 // ---------------------------------------------------------------------------
@@ -156,7 +101,6 @@ export function lintSpec(
   sharedEvidence?: FieldEvidenceMap | null,
 ): SpecAdvisory[] {
   if (!isRecord(spec) || !Array.isArray(spec["layers"])) return [];
-  const advisories: SpecAdvisory[] = [];
   const evidence = sharedEvidence === undefined ? buildEvidence(spec, options) : sharedEvidence;
   const plotAes = isRecord(spec["aes"]) ? (spec["aes"] as Aes) : undefined;
   const layers = spec["layers"] as unknown[];
@@ -173,157 +117,8 @@ export function lintSpec(
     return { field: mapped.field, info };
   };
 
-  // FieldEvidenceMap is built once per lintSpec/validate call; distinct counts
-  // for many-discrete-colors are memoized across layers/channels that share a
-  // field so a high-cardinality column is scanned O(n), not O(L·n).
-  const distinctNonNullByField = new Map<string, number>();
-
-  for (let i = 0; i < layers.length; i++) {
-    const layer = layers[i];
-    if (!isRecord(layer)) continue;
-    const geom = typeof layer["geom"] === "string" ? layer["geom"] : "";
-    const layerAes = isRecord(layer["aes"]) ? (layer["aes"] as Aes) : undefined;
-    const defaults = GEOM_DEFAULTS[geom as keyof typeof GEOM_DEFAULTS];
-    const position =
-      typeof layer["position"] === "string"
-        ? layer["position"]
-        : (defaults?.position ?? "identity");
-
-    // --- line-over-nominal-x ------------------------------------------------
-    if (geom === "line") {
-      const x = fieldOf(layerAes, "x");
-      if (x !== null && x.info.type === "nominal") {
-        advisories.push({
-          code: "line-over-nominal-x",
-          path: `/layers/${i}/aes/x`,
-          message: `This line layer connects points across "${x.field}", a nominal (unordered) field — the line's slopes carry no meaning.`,
-          suggestion: {
-            description:
-              'Use geom "col" (or "bar" with the count stat) for per-category values; keep "line" only for ordered x (numbers, dates, or a genuinely ordinal field).',
-            example: { geom: "col" },
-          },
-        });
-      }
-    }
-
-    // --- discrete-discrete-scatter -------------------------------------------
-    if (geom === "point" && position !== "jitter") {
-      const x = fieldOf(layerAes, "x");
-      const y = fieldOf(layerAes, "y");
-      if (
-        x !== null &&
-        y !== null &&
-        x.info.type !== null &&
-        y.info.type !== null &&
-        DISCRETE.has(x.info.type) &&
-        DISCRETE.has(y.info.type)
-      ) {
-        advisories.push({
-          code: "discrete-discrete-scatter",
-          path: `/layers/${i}`,
-          message: `This point layer maps discrete fields on both axes ("${x.field}" × "${y.field}") — identical combinations overplot invisibly.`,
-          suggestion: {
-            description:
-              'Add position: "jitter" to spread the points, or count the combinations and encode the count (e.g. point size).',
-            example: { geom: "point", position: "jitter" },
-          },
-        });
-      }
-    }
-
-    // --- stacked-area-negative -----------------------------------------------
-    if (geom === "area" && (position === "stack" || position === "fill")) {
-      const y = fieldOf(layerAes, "y");
-      const values = y?.info.values;
-      if (y !== null && values !== null && values !== undefined) {
-        const hasNegative = values.some((v) => typeof v === "number" && v < 0);
-        if (hasNegative) {
-          advisories.push({
-            code: "stacked-area-negative",
-            path: `/layers/${i}/aes/y`,
-            message: `This stacked area layer's y field "${y.field}" contains negative values — stacked bands will cross and misread as parts of a whole.`,
-            suggestion: {
-              description:
-                'Draw one line per series instead, or set position: "identity" to overlap the areas.',
-              example: { geom: "area", position: "identity" },
-            },
-          });
-        }
-      }
-    }
-
-    // --- many-discrete-colors -------------------------------------------------
-    for (const channel of ["color", "fill"] as const) {
-      const c = fieldOf(layerAes, channel);
-      const values = c?.info.values;
-      if (
-        c !== null &&
-        values !== null &&
-        values !== undefined &&
-        c.info.type !== null &&
-        DISCRETE.has(c.info.type)
-      ) {
-        let distinct = distinctNonNullByField.get(c.field);
-        if (distinct === undefined) {
-          distinct = countDistinctNonNull(values);
-          distinctNonNullByField.set(c.field, distinct);
-        }
-        if (distinct > 10) {
-          advisories.push({
-            code: "many-discrete-colors",
-            path: `/layers/${i}/aes/${channel}`,
-            message: `Field "${c.field}" maps ${distinct} distinct values to ${channel} — beyond ~10, hues stop being distinguishable and the default palette cycles.`,
-            suggestion: {
-              description: `Facet by "${c.field}", aggregate it to fewer categories, or pin scales.${channel}.domain (+ a range) to the values that matter.`,
-              example: { facet: { wrap: { field: c.field } } },
-            },
-          });
-        }
-      }
-    }
-  }
-
-  // --- transform-domain-data (scale-level, once per axis) ---------------------
-  // Detect the effective forward-transform domain BEFORE normalization: an
-  // authored `type: "log"` (canonicalizes to transform: "log10") and a
-  // canonical `transform: "log10" | "sqrt"` are all handled here. log10 rejects
-  // values <= 0; sqrt rejects values < 0. The advisory fires only on MIXED data
-  // (some in-domain, some out) — all-invalid is the pipeline's error/warning.
-  //
-  // Multi-layer charts often share the same mapped field (plot aes or repeated
-  // layer aes). Memoize [inDomain, outOfDomain] per field name for this axis so
-  // a shared column is scanned once (O(n)), not once per layer (O(L·n)).
-  for (const axis of ["x", "y"] as const) {
-    const config = scales?.[axis] as PositionScaleSpec | undefined;
-    const domain = transformDomainOf(config);
-    if (domain === null) continue;
-    const fieldDomainCounts = new Map<string, readonly [inDomain: number, outOfDomain: number]>();
-    for (let i = 0; i < layers.length; i++) {
-      const layer = layers[i];
-      if (!isRecord(layer)) continue;
-      const layerAes = isRecord(layer["aes"]) ? (layer["aes"] as Aes) : undefined;
-      const use = fieldOf(layerAes, axis);
-      const values = use?.info.values;
-      if (use === null || values === null || values === undefined) continue;
-      let counts = fieldDomainCounts.get(use.field);
-      if (counts === undefined) {
-        counts = countTransformDomain(values, domain);
-        fieldDomainCounts.set(use.field, counts);
-      }
-      const [inDomain, outOfDomain] = counts;
-      if (inDomain > 0 && outOfDomain > 0) {
-        advisories.push({
-          code: "transform-domain-data",
-          path: `/scales/${axis}`,
-          message: `scales.${axis} is a ${domain.label} scale, but field "${use.field}" has ${outOfDomain} value(s) outside its ${domain.rule} domain alongside ${inDomain} valid — those rows will be silently dropped before stats.`,
-          suggestion: {
-            description: `Filter the out-of-domain rows deliberately, or use an identity/linear scale if ${domain.rule} values are meaningful.`,
-          },
-        });
-        break; // one advisory per axis is enough
-      }
-    }
-  }
-
-  return advisories;
+  return [
+    ...collectLayerLintAdvisories({ layers, fieldOf }),
+    ...collectScaleLintAdvisories({ layers, scales, fieldOf }),
+  ];
 }

--- a/packages/spec/tests/lint-rules.test.ts
+++ b/packages/spec/tests/lint-rules.test.ts
@@ -2,6 +2,7 @@
  * Spec-lint rule characterization — each rule fires on its questionable spec,
  * stays silent on the sound variant, and skips without evidence. Catalog
  * coverage stays here so firedCodes accumulates across rule describes.
+ * Production: lint-layer-rules.ts + lint-scale-rules.ts via lintSpec.
  * Wiring/limits: lint-wiring.test.ts. Catalog data: lint-catalog.ts.
  */
 import { readFileSync } from "node:fs";
@@ -260,18 +261,26 @@ describe("LINT_CATALOG coverage", () => {
     expect([...firedCodes].toSorted()).toEqual(Object.keys(LINT_CATALOG).toSorted());
   });
 
-  it("source-scan: every code emitted by lint.ts is cataloged and vice-versa (bijective)", () => {
-    // Mirror of core's source↔catalog scanner: scan lintSpec emissions for every
-    // `code: "..."` literal, and prove it matches LINT_CATALOG exactly — no
-    // retired code lingers, no cataloged code is unemitted. Catalog data is
-    // pure (lint-catalog.ts); emission sites remain in lint.ts.
-    const src = readFileSync(new URL("../src/lint.ts", import.meta.url), "utf8");
+  it("source-scan: every code emitted by lint rule modules is cataloged and vice-versa (bijective)", () => {
+    // Mirror of core's source↔catalog scanner: scan lint rule emission sites for
+    // every `code: "..."` literal, and prove it matches LINT_CATALOG exactly —
+    // no retired code lingers, no cataloged code is unemitted. Catalog data is
+    // pure (lint-catalog.ts); emission sites live in the rule modules.
+    const emissionSources = [
+      readFileSync(new URL("../src/lint-layer-rules.ts", import.meta.url), "utf8"),
+      readFileSync(new URL("../src/lint-scale-rules.ts", import.meta.url), "utf8"),
+    ];
     const catalogSrc = readFileSync(new URL("../src/lint-catalog.ts", import.meta.url), "utf8");
+    const orchestratorSrc = readFileSync(new URL("../src/lint.ts", import.meta.url), "utf8");
     const emitted = new Set<string>();
-    for (const m of src.matchAll(/\bcode:\s*"([a-z0-9-]+)"/g)) emitted.add(m[1]!);
+    for (const src of emissionSources) {
+      for (const m of src.matchAll(/\bcode:\s*"([a-z0-9-]+)"/g)) emitted.add(m[1]!);
+    }
     expect([...emitted].toSorted()).toEqual(Object.keys(LINT_CATALOG).toSorted());
-    // The retired late-log codes must not survive anywhere in the source.
-    for (const blob of [src, catalogSrc]) {
+    // Orchestrator must not re-emit codes (would double-count and drift).
+    expect([...orchestratorSrc.matchAll(/\bcode:\s*"([a-z0-9-]+)"/g)]).toEqual([]);
+    // The retired late-log codes must not survive anywhere in the lint source tree.
+    for (const blob of [...emissionSources, orchestratorSrc, catalogSrc]) {
       expect(blob).not.toContain("log-nonpositive-data");
       expect(blob).not.toContain("log-domain-not-positive");
     }

--- a/packages/spec/tests/lint-wiring.test.ts
+++ b/packages/spec/tests/lint-wiring.test.ts
@@ -10,6 +10,49 @@ import { validate } from "../src/validate.ts";
 
 const codesOf = (advisories: ReturnType<typeof lintSpec>) => advisories.map((a) => a.code);
 
+describe("lintSpec never throws on schema-invalid scale entries", () => {
+  it("skips non-record scale values without fabricating advisories", () => {
+    const advisories = lintSpec({
+      data: { columns: { x: [1, 2, -1], y: [1, 2, 3] } },
+      aes: { x: { field: "x" }, y: { field: "y" } },
+      layers: [{ geom: "point" }],
+      scales: { y: null, x: "log" },
+    });
+    expect(advisories).toEqual([]);
+  });
+
+  it("lets validate report schema errors when lint is enabled alongside bad scales", () => {
+    const result = validate(
+      {
+        data: { values: [{ x: 1, y: 2 }] },
+        layers: [{ geom: "point", aes: { x: { field: "x" }, y: { field: "y" } } }],
+        scales: { y: null },
+      },
+      { lint: true },
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected validation failure");
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+});
+
+describe("lintSpec advisory ordering across rule modules", () => {
+  it("emits layer advisories before scale advisories for the same spec", () => {
+    const advisories = lintSpec({
+      data: {
+        columns: {
+          cat: ["a", "b", "c"],
+          y: [1, 2, -1],
+        },
+      },
+      aes: { x: { field: "cat" }, y: { field: "y" } },
+      layers: [{ geom: "line" }],
+      scales: { y: { type: "log" } },
+    });
+    expect(codesOf(advisories)).toEqual(["line-over-nominal-x", "transform-domain-data"]);
+  });
+});
+
 describe("lintSpec options.limits", () => {
   /** Line-over-nominal-x fixture with `rows` nominal categories cycling a/b/c. */
   const nominalLineSpec = (rows: number) => {


### PR DESCRIPTION
## Summary

- Split `lintSpec` (`lint.ts`, was 329 lines) into focused modules:
  - **`lint-layer-rules.ts`** — line-over-nominal-x, discrete-discrete-scatter, stacked-area-negative, many-discrete-colors
  - **`lint-scale-rules.ts`** — transform-domain-data (+ transform domain helpers)
  - **`lint.ts`** — orchestrator, evidence build, `SpecAdvisory`, catalog re-export (~128 lines)
- **Guard:** non-record scale entries (e.g. `scales: { y: null }`) no longer throw inside lint; lint remains non-blocking
- Tests: multi-file catalog source-scan; characterization for malformed scales and layer→scale advisory ordering

Public `lintSpec` / `LINT_CATALOG` / `SpecAdvisory` surface is unchanged.

### Why

Catalog was already extracted; the remaining file mixed four layer rules with one scale-level rule and separate memoization scopes. Clear section boundaries make independent evolution safer.

## Test plan

- [x] `bun test packages/spec` (350 pass)
- [x] `bun run check` + knip
- [x] Focused lint-rules + lint-wiring suites

## Follow-ups

None deferred. Remaining long files in packages/spec are keep/cohesive (`schema-declarations`, `builder` fluent surface, `validate-map-errors` fall-throughs, `manual-at-schema` tests, `position-scale-api` cohesive contract suite).