### PR TITLE
perf(core): O(K) band thinning overlap after one pos-sort

### DIFF
--- a/.changeset/axis-overlap-skip-sort-when-ordered.md
+++ b/.changeset/axis-overlap-skip-sort-when-ordered.md
@@ -1,0 +1,11 @@
+---
+"@ggsvelte/core": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+perf: O(K) band thinning overlap after one pos-sort
+
+Rotated band label thinning sorts projections once per angle then reuses the
+sorted list (filter by every-k). neighbourOverlap accepts alreadySorted for
+temporal re-checks.

--- a/packages/core/src/layout/axis-overlap.ts
+++ b/packages/core/src/layout/axis-overlap.ts
@@ -13,9 +13,23 @@ export interface ProjectedLabel {
   half: number;
 }
 
+export interface OverlapOrderOptions {
+  /**
+   * When true, `items` are already sorted by ascending `pos` and the O(k log k)
+   * sort is skipped. Callers that project domain order (or reverse then reverse
+   * for flipped axes) should pass this for the hot band-thinning path.
+   */
+  alreadySorted?: boolean;
+}
+
 /** True when any adjacent pair (sorted by position) collides within `gapPx`. */
-export function neighbourOverlap(items: readonly ProjectedLabel[], gapPx: number): boolean {
-  const sorted = [...items].toSorted((a, b) => a.pos - b.pos);
+export function neighbourOverlap(
+  items: readonly ProjectedLabel[],
+  gapPx: number,
+  options?: OverlapOrderOptions,
+): boolean {
+  const sorted =
+    options?.alreadySorted === true ? items : [...items].toSorted((a, b) => a.pos - b.pos);
   for (let i = 1; i < sorted.length; i++) {
     const prev = sorted[i - 1]!;
     const cur = sorted[i]!;
@@ -37,8 +51,13 @@ export interface AsymProjectedLabel {
 /** Asymmetric variant: collide the left neighbour's right extent against the
  *  right neighbour's left extent, so end-anchored rotated labels are judged at
  *  their real (renderer-matched) footprint rather than a centered approximation. */
-export function neighbourOverlapAsym(items: readonly AsymProjectedLabel[], gapPx: number): boolean {
-  const sorted = [...items].toSorted((a, b) => a.pos - b.pos);
+export function neighbourOverlapAsym(
+  items: readonly AsymProjectedLabel[],
+  gapPx: number,
+  options?: OverlapOrderOptions,
+): boolean {
+  const sorted =
+    options?.alreadySorted === true ? items : [...items].toSorted((a, b) => a.pos - b.pos);
   for (let i = 1; i < sorted.length; i++) {
     const prev = sorted[i - 1]!;
     const cur = sorted[i]!;

--- a/packages/core/src/layout/band-guide.ts
+++ b/packages/core/src/layout/band-guide.ts
@@ -183,26 +183,38 @@ export function planBandAxis(input: BandAxisPlanInput): BandAxisPlan {
     return width * Math.sin(a) + lineHeight * Math.cos(a);
   };
   /** Widest label among the currently-labeled (every k-th) entries. */
-  const labeledMaxWidth = (every: number) =>
-    Math.max(0, ...entries.filter((_, i) => i % every === 0).map((e) => e.width));
-  // Overlap of the rotated footprint measured at the ACTUAL displayed tick
-  // positions (every k-th when thinned) with each label's own end-anchored
-  // footprint — so a sparse break subset hundreds of px apart is never wrongly
-  // thinned, a hidden wide label never inflates the check, and a long label after
-  // a short one is caught overlapping its left neighbour.
-  const rotatedOverlaps = (angle: number, every: number) =>
-    neighbourOverlapAsym(
-      entries
-        .filter((_, i) => i % every === 0)
-        .map((e) => ({ pos: e.center, left: leftExtOf(e.width, angle), right: rightExtOf(angle) })),
-      gap,
-    );
+  const labeledMaxWidth = (every: number) => {
+    let max = 0;
+    for (let i = 0; i < entries.length; i += every) max = Math.max(max, entries[i]!.width);
+    return max;
+  };
+  // Overlap of the rotated footprint at displayed (every-k) ticks. Entries may
+  // be in authored break order (not domain order), so project+sort once per
+  // angle by pos, then filter by array index for thinning — O(K log K) once +
+  // O(K) per doubling step, not O(K log K) per step.
+  type AsymItem = { pos: number; left: number; right: number; index: number };
+  const rotatedOverlapsSorted = (angle: number, every: number, sorted: readonly AsymItem[]) => {
+    const items = every === 1 ? sorted : sorted.filter((item) => item.index % every === 0);
+    return neighbourOverlapAsym(items, gap, { alreadySorted: true });
+  };
+  const projectRotatedSorted = (angle: number): AsymItem[] =>
+    entries
+      .map((e, index) => ({
+        pos: e.center,
+        left: leftExtOf(e.width, angle),
+        right: rightExtOf(angle),
+        index,
+      }))
+      .toSorted((a, b) => a.pos - b.pos);
+
   // Prefer −45 (more readable, less bottom footprint); escalate to −90 ONLY when
   // −45 actually overlaps neighbours. A −45 label that merely exceeds the bottom
   // cap is truncated within the −45 budget below — switching to −90 for that would
   // need MORE bottom space (its footprint is the full label width) and truncate
   // harder without resolving any collision.
-  const angle = rotatedOverlaps(-45, 1) ? -90 : -45;
+  const sortedAtNeg45 = projectRotatedSorted(-45);
+  const angle = rotatedOverlapsSorted(-45, 1, sortedAtNeg45) ? -90 : -45;
+  const sortedAtAngle = angle === -45 ? sortedAtNeg45 : projectRotatedSorted(angle);
 
   const degraded: string[] = [];
   let labelEvery = 1;
@@ -212,13 +224,16 @@ export function planBandAxis(input: BandAxisPlanInput): BandAxisPlan {
   // Along-axis: do adjacent rotated labels still collide at their real positions?
   // Gate thinning on the number of DISPLAYED ticks (a small authored-break subset
   // of a huge domain must keep every break), never the full category count.
-  if (rotatedOverlaps(angle, 1)) {
+  if (rotatedOverlapsSorted(angle, 1, sortedAtAngle)) {
     if (entries.length >= BAND_THIN_MIN_CATEGORIES) {
       // High cardinality: thin (never for a handful of named bars).
-      while (rotatedOverlaps(angle, labelEvery) && labelEvery * 2 < entries.length) {
+      while (
+        rotatedOverlapsSorted(angle, labelEvery, sortedAtAngle) &&
+        labelEvery * 2 < entries.length
+      ) {
         labelEvery *= 2;
       }
-      if (rotatedOverlaps(angle, labelEvery)) {
+      if (rotatedOverlapsSorted(angle, labelEvery, sortedAtAngle)) {
         overlap = true;
         degraded.push("band-label-overlap");
       }

--- a/packages/core/src/layout/temporal-axis-candidates.ts
+++ b/packages/core/src/layout/temporal-axis-candidates.ts
@@ -119,12 +119,14 @@ function evaluateTicks(
     })
     .toSorted((left, right) => left.pos - right.pos);
 
+  // projected is already sorted by pos above — skip re-sort in neighbourOverlap.
   const overlap = neighbourOverlap(
     projected.map((tick) => ({
       pos: tick.pos,
       half: input.orient === "horizontal" ? tick.width / 2 : tick.height / 2,
     })),
     MIN_TEMPORAL_LABEL_GAP_PX,
+    { alreadySorted: true },
   );
   // Layout reserves tickLength + tickLabelGap (defaults 6 + 3) in addition to the
   // label extent. Match that chrome so near-cap labels still diagnose overflow.

--- a/packages/core/tests/band-guide/cardinality-breaks.test.ts
+++ b/packages/core/tests/band-guide/cardinality-breaks.test.ts
@@ -38,6 +38,32 @@ describe("planBandAxis: sparse explicit breaks (Codex P2)", () => {
     expect(p.ticks.every((t) => t.labeled)).toBe(true); // every authored break kept
     expect(p.overlap).toBe(false);
   });
+
+  it("orders overlap by position even when breaks are authored out of domain order", () => {
+    // Authored order [99, 0, 50] must not false-positive overlap: positions are
+    // far apart; sorting by pos (not array index) is required.
+    const longLabel = "Muy larga etiqueta de categoría con detalle";
+    const p = planBandAxis({
+      aesthetic: "x",
+      panelIndex: 0,
+      categoryCount: 100,
+      entries: [99, 0, 50].map((domainIndex) => ({
+        value: `c${domainIndex}`,
+        label: longLabel,
+        domainIndex,
+      })),
+      orient: "horizontal",
+      extentPx: 480,
+      reverse: false,
+      measurer,
+      fontSize: 11,
+      marginCapPx: 168,
+      orthogonalMarginCapPx: 400,
+    });
+    expect(p.labelEvery).toBe(1);
+    expect(p.ticks.every((t) => t.labeled)).toBe(true);
+    expect(p.overlap).toBe(false);
+  });
 });
 describe("planBandAxis: small authored break subset (Codex P2)", () => {
   it("never thins a handful of close-together authored breaks in a huge domain", () => {

--- a/packages/core/tests/band-guide/rotation-margin.test.ts
+++ b/packages/core/tests/band-guide/rotation-margin.test.ts
@@ -93,4 +93,25 @@ describe("neighbourOverlapAsym: end-anchored rotated footprint (Codex P2)", () =
     ];
     expect(neighbourOverlapAsym(items, 4)).toBe(false);
   });
+
+  it("alreadySorted matches default sort for ascending pos order", () => {
+    const items = [
+      { pos: 0, left: 2, right: 2 },
+      { pos: 20, left: 30, right: 2 },
+      { pos: 80, left: 5, right: 5 },
+    ];
+    expect(neighbourOverlapAsym(items, 4, { alreadySorted: true })).toBe(
+      neighbourOverlapAsym(items, 4),
+    );
+  });
+
+  it("alreadySorted still catches overlap when items are pre-ordered ascending", () => {
+    // Descending construction then reverse → ascending for alreadySorted.
+    const descending = [
+      { pos: 20, left: 30, right: 2 },
+      { pos: 0, left: 2, right: 2 },
+    ];
+    const ascending = [...descending].toSorted((a, b) => a.pos - b.pos);
+    expect(neighbourOverlapAsym(ascending, 4, { alreadySorted: true })).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

`/bigo-maintain` on `packages/core` (330 production src files).

### Finding

- **File:** `packages/core/src/layout/band-guide.ts` rotated thinning + `axis-overlap.ts`
- **Pattern:** #6 Sort inside loop (thinning while-loop)
- **Before:** each `labelEvery` step project+filter+sort → O(K log K) per doubling
- **After:** project+sort once per angle by position, then O(K) filter checks
- **n:** K = band categories / authored breaks

Also: temporal guide skips re-sorting after it already sorted projections.

### Codex plan review

Rejected unsafe domain-order equals pos-order (authored breaks can be reordered). Sort by pos once; filter every-k by array index.

### Tests

```text
bun test packages/core/tests/band-guide/
# 42 pass including out-of-order breaks and alreadySorted parity
```

### Follow-ups

None.

## Test plan

- [x] alreadySorted matches sort for ascending items
- [x] Out-of-domain-order sparse breaks do not false-overlap
- [x] High-cardinality thinning still works
- [x] Existing band characterization
