### PR TITLE
refactor(spec): split mapPathGroup into union and keyword modules

### DIFF
--- a/.changeset/spec-validate-map-path-split.md
+++ b/.changeset/spec-validate-map-path-split.md
@@ -1,0 +1,7 @@
+---
+"@ggsvelte/spec": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+Split TypeBox path-group error mapping into union classification and keyword handlers. Public validate() agent diagnostics are unchanged.

--- a/packages/spec/src/validate-map-errors.ts
+++ b/packages/spec/src/validate-map-errors.ts
@@ -9,6 +9,8 @@
  *
  * Schema / path inspection: validate-schema-walk.ts.
  * Channel/data form classification: validate-map-forms.ts.
+ * Union path mapping: validate-map-path-unions.ts.
+ * Keyword path mapping: validate-map-path-keywords.ts.
  * Used only by validate() — not part of the package public surface.
  */
 import type { TLocalizedValidationError } from "typebox/error";
@@ -16,32 +18,9 @@ import type { TLocalizedValidationError } from "typebox/error";
 import type { SpecError } from "./errors.js";
 import { didYouMean } from "./errors.js";
 import { KNOWN_GEOMS } from "./schema.js";
-import {
-  additionalPropertiesIsClosed,
-  isRecord,
-  lastSegment,
-  numberBounds,
-  objectPropertyNames,
-  pointerGet,
-  schemaAtInstancePath,
-  schemaAtSchemaPath,
-  unionMembers,
-} from "./validate-schema-walk.js";
-import {
-  allowedKeysForPresentChannelForm,
-  allowedKeysForPresentDataForm,
-  additionalPropertyNames,
-  channelDiscriminatorKeys,
-  CHANNEL_FIX_EXAMPLE,
-  dataDiscriminatorKeys,
-  dataDiscriminatorsForUnion,
-  hasActionableAddlNoise,
-  isChannelPath,
-  isDataUnionPath,
-  isScalarValue,
-  looksLikeChannelForm,
-  looksLikeDataContainer,
-} from "./validate-map-forms.js";
+import { lastSegment, pointerGet } from "./validate-schema-walk.js";
+import { mapKeywordPathGroup } from "./validate-map-path-keywords.js";
+import { mapUnionPathGroup } from "./validate-map-path-unions.js";
 
 export interface MapErrorsContext {
   /** Schema root passed to Value.Errors (Cyclic `$defs`+`$ref`). */
@@ -86,10 +65,6 @@ function mapPathGroup(
   const key = lastSegment(instancePath);
   const valueAtPath = pointerGet(ctx.value, instancePath);
 
-  const anyOfErr = group.find((e) => e.keyword === "anyOf");
-  const constErrs = group.filter((e) => e.keyword === "const");
-  let activeFormKeys: ReadonlySet<string> | null = null;
-
   if (
     group.some((error) => error.keyword === "pattern") &&
     /^\/scales\/(?:color|fill)\/range\/\d+$/.test(path) &&
@@ -108,303 +83,18 @@ function mapPathGroup(
     ];
   }
 
-  // Object-branch noise in mixed unions (e.g. ThemeName | ThemeSpec): prefer
-  // required / additionalProperties over const-branch enum synthesis.
-  const hasObjectBranchNoise =
-    isRecord(valueAtPath) &&
-    group.some((e) => e.keyword === "additionalProperties" || e.keyword === "required");
+  const union = mapUnionPathGroup(instancePath, group, ctx, path, key, valueAtPath);
+  if (union.status === "done") return union.errors;
 
-  // anyOf / const unions FIRST: 1.x fans out branch failures (required +
-  // additionalProperties + anyOf) for object unions. Prefer the anyOf signal
-  // so DataRef / ChannelValue surface catalog codes, not branch noise — except
-  // when the instance already matches a near-canonical form (nested paths own
-  // the real diagnostic) or an object branch reported concrete property noise.
-  if (anyOfErr !== undefined || constErrs.length > 0) {
-    const unionSchema =
-      (anyOfErr === undefined
-        ? null
-        : schemaAtSchemaPath(ctx.schema, instancePath, anyOfErr.schemaPath)) ??
-      schemaAtInstancePath(ctx.schema, instancePath);
-    const members = unionMembers(unionSchema);
-
-    const isChannel =
-      members.refs.includes("FieldRef") ||
-      members.refs.some((r) => r.endsWith("FieldRef")) ||
-      isChannelPath(path);
-
-    if (isChannel && !members.allConst) {
-      // Near-canonical channel object:
-      // - mixed forms (field+value) → invalid-channel-value
-      // - form-illegal keys (field+scale) / typos → fall through to addl
-      // - nested type failures only (value: {}) → suppress union catalog
-      if (
-        isRecord(valueAtPath) &&
-        looksLikeChannelForm(valueAtPath) &&
-        typeof valueAtPath !== "string"
-      ) {
-        const discs = channelDiscriminatorKeys(valueAtPath);
-        if (discs.length > 1) {
-          return [
-            {
-              code: "invalid-channel-value",
-              path,
-              message: `Channel "${key}" mixes forms (${discs.map((d) => `"${d}"`).join(" and ")}); use exactly one of {"field": ...}, {"value": ...}, or {"stat": ...}.`,
-              fix: {
-                description: `Pick a single channel form for "${key}".`,
-                example: CHANNEL_FIX_EXAMPLE,
-              },
-            },
-          ];
-        }
-        const formKeys = allowedKeysForPresentChannelForm(valueAtPath);
-        if (formKeys !== null && hasActionableAddlNoise(group, formKeys)) {
-          activeFormKeys = formKeys;
-          // fall through to additionalProperties / required handlers
-        } else {
-          return [];
-        }
-      } else {
-        const bareString = typeof valueAtPath === "string";
-        return [
-          {
-            code: "invalid-channel-value",
-            path,
-            message: bareString
-              ? `Channel "${key}" is the bare string ${JSON.stringify(valueAtPath)}; portable specs require the canonical form {"field": ${JSON.stringify(valueAtPath)}}.`
-              : `Channel "${key}" must be {"field": ...}, {"value": ...}, {"stat": ...}, or null.`,
-            fix: {
-              description: `Use a canonical channel form, e.g. {"field": "column_name"} to map "${key}" to a data column.`,
-              example: bareString ? { field: valueAtPath } : CHANNEL_FIX_EXAMPLE,
-            },
-          },
-        ];
-      }
-    }
-
-    const isDataUnion =
-      members.refs.includes("DataValues") ||
-      members.refs.some((r) => r.includes("DataValues")) ||
-      (isDataUnionPath(path) && anyOfErr !== undefined);
-
-    if (isDataUnion) {
-      const allowedDataDiscriminators = dataDiscriminatorsForUnion(members, path);
-      const allowedDataForms = allowedDataDiscriminators.map((discriminator) =>
-        discriminator === "values"
-          ? '{"values": [...rows]}'
-          : discriminator === "columns"
-            ? '{"columns": {...arrays}}'
-            : '{"name": "dataset"}',
-      );
-      const allowedDataFormsMessage =
-        allowedDataForms.length === 2
-          ? `${allowedDataForms[0]} or ${allowedDataForms[1]}`
-          : `${allowedDataForms.slice(0, -1).join(", ")}, or ${allowedDataForms.at(-1)}`;
-      // Already wrapped as an allowed data form:
-      // - mixed allowed forms (values+name on DataRef) → invalid-data
-      // - illegal discriminators / extra siblings → fall through for unexpected-property
-      // - nested cell failures only → suppress invalid-data re-wrap
-      if (isRecord(valueAtPath) && looksLikeDataContainer(valueAtPath)) {
-        const discs = dataDiscriminatorKeys(valueAtPath, allowedDataDiscriminators);
-        if (discs.length > 1) {
-          return [
-            {
-              code: "invalid-data",
-              path,
-              message: `Data mixes forms (${discs.map((d) => `"${d}"`).join(" and ")}); use exactly one of ${allowedDataFormsMessage}.`,
-              allowed: [...allowedDataDiscriminators],
-              fix: {
-                description: "Pick a single data form.",
-                example: { values: [{ x: 1, y: 2 }] },
-              },
-            },
-          ];
-        }
-        const presentFormKeys = allowedKeysForPresentDataForm(
-          valueAtPath,
-          allowedDataDiscriminators,
-        );
-        const formKeys = presentFormKeys ?? new Set(allowedDataDiscriminators);
-        if (hasActionableAddlNoise(group, formKeys)) {
-          activeFormKeys = formKeys;
-          // fall through
-        } else {
-          return [];
-        }
-      } else {
-        return [
-          {
-            code: "invalid-data",
-            path,
-            message: `Data must be one of ${allowedDataFormsMessage}.`,
-            allowed: [...allowedDataDiscriminators],
-            fix: {
-              description: 'Wrap inline rows as {"values": [...]}.',
-              example: { values: [{ x: 1, y: 2 }] },
-            },
-          },
-        ];
-      }
-    }
-
-    // Prefer allowed values from the actual const errors TypeBox emitted —
-    // schemaPath resolution against Cyclic $defs can land on the wrong
-    // sibling union (e.g. scale type vs coord type both use `properties/type`).
-    let allowed: string[] = [];
-    if (constErrs.length > 0) {
-      allowed = constErrs
-        .map((e) => (e.params as { allowedValue?: unknown }).allowedValue)
-        .filter((v) => v !== undefined)
-        .map(String);
-    }
-    if (allowed.length === 0 && members.allConst && members.consts.length > 0) {
-      allowed = members.consts;
-    }
-    // Only promote const branch noise when the value could be an enum member.
-    // Mixed enum|object unions (theme) must not turn ThemeSpec property errors
-    // into "pick a theme name".
-    if (
-      allowed.length > 0 &&
-      (members.allConst || isScalarValue(valueAtPath)) &&
-      !hasObjectBranchNoise
-    ) {
-      if (allowed.length === 1 && constErrs.length <= 1 && anyOfErr === undefined) {
-        return [
-          {
-            code: "invalid-enum-value",
-            path,
-            message: `Invalid value ${JSON.stringify(valueAtPath)} for "${key}"; the only supported value is ${allowed.map((a) => `"${a}"`).join(", ")}.`,
-            allowed,
-          },
-        ];
-      }
-      const suggestion =
-        typeof valueAtPath === "string" ? didYouMean(valueAtPath, allowed) : undefined;
-      return [
-        {
-          code: "invalid-enum-value",
-          path,
-          message:
-            `Invalid value ${JSON.stringify(valueAtPath)} for "${key}"; allowed: ${allowed.map((c) => `"${c}"`).join(", ")}.` +
-            (suggestion === undefined ? "" : ` Did you mean "${suggestion}"?`),
-          allowed,
-          ...(suggestion !== undefined && {
-            fix: { description: `Set "${key}" to "${suggestion}".` },
-          }),
-        },
-      ];
-    }
-
-    if (anyOfErr !== undefined && !hasObjectBranchNoise) {
-      return [
-        {
-          code: "invalid-type",
-          path,
-          message: `${anyOfErr.message} at "${key}".`,
-        },
-      ];
-    }
-    // Mixed union with object-branch property noise: fall through to
-    // additionalProperties / required handlers below.
-  }
-
-  // additionalProperties: closed objects → unexpected keys; schema-valued
-  // additionalProperties (records / free-form rows) → value type failures.
-  const addl = group.find((e) => e.keyword === "additionalProperties");
-  if (addl !== undefined) {
-    const listed = additionalPropertyNames(group, activeFormKeys ?? new Set());
-    const objectSchema =
-      (typeof addl.schemaPath === "string"
-        ? schemaAtSchemaPath(ctx.schema, instancePath, addl.schemaPath)
-        : null) ?? schemaAtInstancePath(ctx.schema, instancePath);
-    if (!additionalPropertiesIsClosed(objectSchema)) {
-      return listed.map((prop) => {
-        const propPath = `${path}/${prop}`;
-        const propValue = pointerGet(ctx.value, `${instancePath}/${prop}`);
-        return {
-          code: "invalid-type" as const,
-          path: propPath,
-          message: `Invalid value for "${prop}" (got ${JSON.stringify(propValue)}).`,
-        };
-      });
-    }
-    const properties =
-      activeFormKeys === null ? objectPropertyNames(objectSchema) : [...activeFormKeys];
-    return listed.map((prop) => {
-      const propPath = `${path}/${prop}`;
-      const suggestion = didYouMean(prop, properties);
-      return {
-        code: "unexpected-property" as const,
-        path: propPath,
-        message:
-          `Unknown property "${prop}".` +
-          (suggestion === undefined ? "" : ` Did you mean "${suggestion}"?`),
-        allowed: properties,
-        ...(suggestion !== undefined && {
-          fix: { description: `Rename "${prop}" to "${suggestion}".` },
-        }),
-      };
-    });
-  }
-
-  // required: may list several missing keys.
-  const req = group.find((e) => e.keyword === "required");
-  if (req !== undefined) {
-    const missing = Array.isArray(req.params.requiredProperties)
-      ? req.params.requiredProperties
-      : [];
-    return missing.map((prop) => ({
-      code: "missing-property" as const,
-      path: `${path}/${prop}`,
-      message: `Missing required property "${prop}".`,
-    }));
-  }
-
-  // numeric range — use schema bounds when available for full min+max message.
-  const rangeErr = group.find((e) =>
-    ["minimum", "maximum", "exclusiveMinimum", "exclusiveMaximum"].includes(e.keyword),
+  return mapKeywordPathGroup(
+    instancePath,
+    group,
+    ctx,
+    path,
+    key,
+    valueAtPath,
+    union.activeFormKeys,
   );
-  if (rangeErr !== undefined) {
-    const propSchema =
-      schemaAtInstancePath(ctx.schema, instancePath) ??
-      schemaAtSchemaPath(ctx.schema, instancePath, rangeErr.schemaPath);
-    let bounds = numberBounds(propSchema);
-    if (bounds.length === 0) {
-      const limit = (rangeErr.params as { limit?: number }).limit;
-      const comparison = (rangeErr.params as { comparison?: string }).comparison;
-      if (typeof limit === "number" && typeof comparison === "string") {
-        bounds = [`${comparison} ${limit}`];
-      }
-    }
-    return [
-      {
-        code: "value-out-of-range",
-        path,
-        message: `Value ${JSON.stringify(valueAtPath)} for "${key}" is out of range (must be ${bounds.join(" and ")}).`,
-        fix: { description: `Set "${key}" to a number ${bounds.join(" and ")}.` },
-      },
-    ];
-  }
-
-  // Lone const (Literal) without anyOf group — handled above when constErrs
-  // non-empty; fall through to default for remaining keywords (type, etc.).
-
-  // Normalize 1.x "must be X" wording toward the catalog's "Expected X" form.
-  const first = group[0]!;
-  let message = first.message;
-  if (first.keyword === "type") {
-    const t = (first.params as { type?: string | string[] }).type;
-    const expected = Array.isArray(t) ? t.join("|") : t;
-    if (typeof expected === "string") {
-      message = `Expected ${expected}`;
-    }
-  }
-  return [
-    {
-      code: "invalid-type",
-      path,
-      message: `${message}${path === "" ? "" : ` at "${key}"`} (got ${JSON.stringify(valueAtPath)}).`,
-    },
-  ];
 }
 
 export function unknownGeomError(geom: unknown, layerPath: string): SpecError {

--- a/packages/spec/src/validate-map-path-keywords.ts
+++ b/packages/spec/src/validate-map-path-keywords.ts
@@ -1,0 +1,129 @@
+/**
+ * Keyword path mapping for TypeBox 1.x errors: additionalProperties, required,
+ * numeric range, and default type normalization.
+ * Union classification: validate-map-path-unions.ts. Orchestrator: validate-map-errors.ts.
+ */
+import type { TLocalizedValidationError } from "typebox/error";
+
+import type { SpecError } from "./errors.js";
+import { didYouMean } from "./errors.js";
+import {
+  additionalPropertiesIsClosed,
+  numberBounds,
+  objectPropertyNames,
+  pointerGet,
+  schemaAtInstancePath,
+  schemaAtSchemaPath,
+} from "./validate-schema-walk.js";
+import { additionalPropertyNames } from "./validate-map-forms.js";
+import type { MapErrorsContext } from "./validate-map-errors.js";
+
+/** Map remaining keywords after union classification (or when no anyOf/const). */
+export function mapKeywordPathGroup(
+  instancePath: string,
+  group: readonly TLocalizedValidationError[],
+  ctx: MapErrorsContext,
+  path: string,
+  key: string,
+  valueAtPath: unknown,
+  activeFormKeys: ReadonlySet<string> | null,
+): SpecError[] {
+  // additionalProperties: closed objects → unexpected keys; schema-valued
+  // additionalProperties (records / free-form rows) → value type failures.
+  const addl = group.find((e) => e.keyword === "additionalProperties");
+  if (addl !== undefined) {
+    const listed = additionalPropertyNames(group, activeFormKeys ?? new Set());
+    const objectSchema =
+      (typeof addl.schemaPath === "string"
+        ? schemaAtSchemaPath(ctx.schema, instancePath, addl.schemaPath)
+        : null) ?? schemaAtInstancePath(ctx.schema, instancePath);
+    if (!additionalPropertiesIsClosed(objectSchema)) {
+      return listed.map((prop) => {
+        const propPath = `${path}/${prop}`;
+        const propValue = pointerGet(ctx.value, `${instancePath}/${prop}`);
+        return {
+          code: "invalid-type" as const,
+          path: propPath,
+          message: `Invalid value for "${prop}" (got ${JSON.stringify(propValue)}).`,
+        };
+      });
+    }
+    const properties =
+      activeFormKeys === null ? objectPropertyNames(objectSchema) : [...activeFormKeys];
+    return listed.map((prop) => {
+      const propPath = `${path}/${prop}`;
+      const suggestion = didYouMean(prop, properties);
+      return {
+        code: "unexpected-property" as const,
+        path: propPath,
+        message:
+          `Unknown property "${prop}".` +
+          (suggestion === undefined ? "" : ` Did you mean "${suggestion}"?`),
+        allowed: properties,
+        ...(suggestion !== undefined && {
+          fix: { description: `Rename "${prop}" to "${suggestion}".` },
+        }),
+      };
+    });
+  }
+
+  // required: may list several missing keys.
+  const req = group.find((e) => e.keyword === "required");
+  if (req !== undefined) {
+    const missing = Array.isArray(req.params.requiredProperties)
+      ? req.params.requiredProperties
+      : [];
+    return missing.map((prop) => ({
+      code: "missing-property" as const,
+      path: `${path}/${prop}`,
+      message: `Missing required property "${prop}".`,
+    }));
+  }
+
+  // numeric range — use schema bounds when available for full min+max message.
+  const rangeErr = group.find((e) =>
+    ["minimum", "maximum", "exclusiveMinimum", "exclusiveMaximum"].includes(e.keyword),
+  );
+  if (rangeErr !== undefined) {
+    const propSchema =
+      schemaAtInstancePath(ctx.schema, instancePath) ??
+      schemaAtSchemaPath(ctx.schema, instancePath, rangeErr.schemaPath);
+    let bounds = numberBounds(propSchema);
+    if (bounds.length === 0) {
+      const limit = (rangeErr.params as { limit?: number }).limit;
+      const comparison = (rangeErr.params as { comparison?: string }).comparison;
+      if (typeof limit === "number" && typeof comparison === "string") {
+        bounds = [`${comparison} ${limit}`];
+      }
+    }
+    return [
+      {
+        code: "value-out-of-range",
+        path,
+        message: `Value ${JSON.stringify(valueAtPath)} for "${key}" is out of range (must be ${bounds.join(" and ")}).`,
+        fix: { description: `Set "${key}" to a number ${bounds.join(" and ")}.` },
+      },
+    ];
+  }
+
+  // Lone const (Literal) without anyOf group — handled in union module when
+  // constErrs non-empty; fall through to default for remaining keywords (type, etc.).
+
+  // Normalize 1.x "must be X" wording toward the catalog's "Expected X" form.
+  const first = group[0]!;
+  let message = first.message;
+  if (first.keyword === "type") {
+    const t = (first.params as { type?: string | string[] }).type;
+    const expected = Array.isArray(t) ? t.join("|") : t;
+    if (typeof expected === "string") {
+      message = `Expected ${expected}`;
+    }
+  }
+  return [
+    {
+      code: "invalid-type",
+      path,
+      message: `${message}${path === "" ? "" : ` at "${key}"`} (got ${JSON.stringify(valueAtPath)}).`,
+    },
+  ];
+}

--- a/packages/spec/src/validate-map-path-unions.ts
+++ b/packages/spec/src/validate-map-path-unions.ts
@@ -1,0 +1,272 @@
+/**
+ * anyOf/const union path mapping for TypeBox 1.x errors (channel forms, data
+ * refs, enums). Keyword handlers: validate-map-path-keywords.ts.
+ * Orchestrator: validate-map-errors.ts.
+ *
+ * Result contract:
+ *  - `{ status: "done", errors }` — including `errors: []` meaning "suppress
+ *    noisy union diagnostics; a nested path owns the real error"
+ *  - `{ status: "continue", activeFormKeys }` — fall through to keyword handlers
+ *    (activeFormKeys null when no near-canonical form keyed the fall-through)
+ */
+import type { TLocalizedValidationError } from "typebox/error";
+
+import type { SpecError } from "./errors.js";
+import { didYouMean } from "./errors.js";
+import {
+  isRecord,
+  schemaAtInstancePath,
+  schemaAtSchemaPath,
+  unionMembers,
+} from "./validate-schema-walk.js";
+import {
+  allowedKeysForPresentChannelForm,
+  allowedKeysForPresentDataForm,
+  channelDiscriminatorKeys,
+  CHANNEL_FIX_EXAMPLE,
+  dataDiscriminatorKeys,
+  dataDiscriminatorsForUnion,
+  hasActionableAddlNoise,
+  isChannelPath,
+  isDataUnionPath,
+  isScalarValue,
+  looksLikeChannelForm,
+  looksLikeDataContainer,
+} from "./validate-map-forms.js";
+import type { MapErrorsContext } from "./validate-map-errors.js";
+
+export type UnionPathResult =
+  | { status: "done"; errors: SpecError[] }
+  | { status: "continue"; activeFormKeys: ReadonlySet<string> | null };
+
+/**
+ * Classify anyOf/const group noise. When neither anyOf nor const is present,
+ * returns continue with null form keys so keyword handlers still run.
+ */
+export function mapUnionPathGroup(
+  instancePath: string,
+  group: readonly TLocalizedValidationError[],
+  ctx: MapErrorsContext,
+  path: string,
+  key: string,
+  valueAtPath: unknown,
+): UnionPathResult {
+  const anyOfErr = group.find((e) => e.keyword === "anyOf");
+  const constErrs = group.filter((e) => e.keyword === "const");
+
+  if (anyOfErr === undefined && constErrs.length === 0) {
+    return { status: "continue", activeFormKeys: null };
+  }
+
+  // Object-branch noise in mixed unions (e.g. ThemeName | ThemeSpec): prefer
+  // required / additionalProperties over const-branch enum synthesis.
+  const hasObjectBranchNoise =
+    isRecord(valueAtPath) &&
+    group.some((e) => e.keyword === "additionalProperties" || e.keyword === "required");
+
+  // anyOf / const unions FIRST: 1.x fans out branch failures (required +
+  // additionalProperties + anyOf) for object unions. Prefer the anyOf signal
+  // so DataRef / ChannelValue surface catalog codes, not branch noise — except
+  // when the instance already matches a near-canonical form (nested paths own
+  // the real diagnostic) or an object branch reported concrete property noise.
+  const unionSchema =
+    (anyOfErr === undefined
+      ? null
+      : schemaAtSchemaPath(ctx.schema, instancePath, anyOfErr.schemaPath)) ??
+    schemaAtInstancePath(ctx.schema, instancePath);
+  const members = unionMembers(unionSchema);
+
+  const isChannel =
+    members.refs.includes("FieldRef") ||
+    members.refs.some((r) => r.endsWith("FieldRef")) ||
+    isChannelPath(path);
+
+  if (isChannel && !members.allConst) {
+    // Near-canonical channel object:
+    // - mixed forms (field+value) → invalid-channel-value
+    // - form-illegal keys (field+scale) / typos → fall through to addl
+    // - nested type failures only (value: {}) → suppress union catalog
+    if (
+      isRecord(valueAtPath) &&
+      looksLikeChannelForm(valueAtPath) &&
+      typeof valueAtPath !== "string"
+    ) {
+      const discs = channelDiscriminatorKeys(valueAtPath);
+      if (discs.length > 1) {
+        return {
+          status: "done",
+          errors: [
+            {
+              code: "invalid-channel-value",
+              path,
+              message: `Channel "${key}" mixes forms (${discs.map((d) => `"${d}"`).join(" and ")}); use exactly one of {"field": ...}, {"value": ...}, or {"stat": ...}.`,
+              fix: {
+                description: `Pick a single channel form for "${key}".`,
+                example: CHANNEL_FIX_EXAMPLE,
+              },
+            },
+          ],
+        };
+      }
+      const formKeys = allowedKeysForPresentChannelForm(valueAtPath);
+      if (formKeys !== null && hasActionableAddlNoise(group, formKeys)) {
+        return { status: "continue", activeFormKeys: formKeys };
+      }
+      // Nested path owns the diagnostic — empty done, not fall-through.
+      return { status: "done", errors: [] };
+    }
+    const bareString = typeof valueAtPath === "string";
+    return {
+      status: "done",
+      errors: [
+        {
+          code: "invalid-channel-value",
+          path,
+          message: bareString
+            ? `Channel "${key}" is the bare string ${JSON.stringify(valueAtPath)}; portable specs require the canonical form {"field": ${JSON.stringify(valueAtPath)}}.`
+            : `Channel "${key}" must be {"field": ...}, {"value": ...}, {"stat": ...}, or null.`,
+          fix: {
+            description: `Use a canonical channel form, e.g. {"field": "column_name"} to map "${key}" to a data column.`,
+            example: bareString ? { field: valueAtPath } : CHANNEL_FIX_EXAMPLE,
+          },
+        },
+      ],
+    };
+  }
+
+  const isDataUnion =
+    members.refs.includes("DataValues") ||
+    members.refs.some((r) => r.includes("DataValues")) ||
+    (isDataUnionPath(path) && anyOfErr !== undefined);
+
+  if (isDataUnion) {
+    const allowedDataDiscriminators = dataDiscriminatorsForUnion(members, path);
+    const allowedDataForms = allowedDataDiscriminators.map((discriminator) =>
+      discriminator === "values"
+        ? '{"values": [...rows]}'
+        : discriminator === "columns"
+          ? '{"columns": {...arrays}}'
+          : '{"name": "dataset"}',
+    );
+    const allowedDataFormsMessage =
+      allowedDataForms.length === 2
+        ? `${allowedDataForms[0]} or ${allowedDataForms[1]}`
+        : `${allowedDataForms.slice(0, -1).join(", ")}, or ${allowedDataForms.at(-1)}`;
+    // Already wrapped as an allowed data form:
+    // - mixed allowed forms (values+name on DataRef) → invalid-data
+    // - illegal discriminators / extra siblings → fall through for unexpected-property
+    // - nested cell failures only → suppress invalid-data re-wrap
+    if (isRecord(valueAtPath) && looksLikeDataContainer(valueAtPath)) {
+      const discs = dataDiscriminatorKeys(valueAtPath, allowedDataDiscriminators);
+      if (discs.length > 1) {
+        return {
+          status: "done",
+          errors: [
+            {
+              code: "invalid-data",
+              path,
+              message: `Data mixes forms (${discs.map((d) => `"${d}"`).join(" and ")}); use exactly one of ${allowedDataFormsMessage}.`,
+              allowed: [...allowedDataDiscriminators],
+              fix: {
+                description: "Pick a single data form.",
+                example: { values: [{ x: 1, y: 2 }] },
+              },
+            },
+          ],
+        };
+      }
+      const presentFormKeys = allowedKeysForPresentDataForm(valueAtPath, allowedDataDiscriminators);
+      const formKeys = presentFormKeys ?? new Set(allowedDataDiscriminators);
+      if (hasActionableAddlNoise(group, formKeys)) {
+        return { status: "continue", activeFormKeys: formKeys };
+      }
+      // Nested path owns the diagnostic — empty done, not fall-through.
+      return { status: "done", errors: [] };
+    }
+    return {
+      status: "done",
+      errors: [
+        {
+          code: "invalid-data",
+          path,
+          message: `Data must be one of ${allowedDataFormsMessage}.`,
+          allowed: [...allowedDataDiscriminators],
+          fix: {
+            description: 'Wrap inline rows as {"values": [...]}.',
+            example: { values: [{ x: 1, y: 2 }] },
+          },
+        },
+      ],
+    };
+  }
+
+  // Prefer allowed values from the actual const errors TypeBox emitted —
+  // schemaPath resolution against Cyclic $defs can land on the wrong
+  // sibling union (e.g. scale type vs coord type both use `properties/type`).
+  let allowed: string[] = [];
+  if (constErrs.length > 0) {
+    allowed = constErrs
+      .map((e) => (e.params as { allowedValue?: unknown }).allowedValue)
+      .filter((v) => v !== undefined)
+      .map(String);
+  }
+  if (allowed.length === 0 && members.allConst && members.consts.length > 0) {
+    allowed = members.consts;
+  }
+  // Only promote const branch noise when the value could be an enum member.
+  // Mixed enum|object unions (theme) must not turn ThemeSpec property errors
+  // into "pick a theme name".
+  if (
+    allowed.length > 0 &&
+    (members.allConst || isScalarValue(valueAtPath)) &&
+    !hasObjectBranchNoise
+  ) {
+    if (allowed.length === 1 && constErrs.length <= 1 && anyOfErr === undefined) {
+      return {
+        status: "done",
+        errors: [
+          {
+            code: "invalid-enum-value",
+            path,
+            message: `Invalid value ${JSON.stringify(valueAtPath)} for "${key}"; the only supported value is ${allowed.map((a) => `"${a}"`).join(", ")}.`,
+            allowed,
+          },
+        ],
+      };
+    }
+    const suggestion =
+      typeof valueAtPath === "string" ? didYouMean(valueAtPath, allowed) : undefined;
+    return {
+      status: "done",
+      errors: [
+        {
+          code: "invalid-enum-value",
+          path,
+          message:
+            `Invalid value ${JSON.stringify(valueAtPath)} for "${key}"; allowed: ${allowed.map((c) => `"${c}"`).join(", ")}.` +
+            (suggestion === undefined ? "" : ` Did you mean "${suggestion}"?`),
+          allowed,
+          ...(suggestion !== undefined && {
+            fix: { description: `Set "${key}" to "${suggestion}".` },
+          }),
+        },
+      ],
+    };
+  }
+
+  if (anyOfErr !== undefined && !hasObjectBranchNoise) {
+    return {
+      status: "done",
+      errors: [
+        {
+          code: "invalid-type",
+          path,
+          message: `${anyOfErr.message} at "${key}".`,
+        },
+      ],
+    };
+  }
+  // Mixed union with object-branch property noise: fall through to
+  // additionalProperties / required handlers below.
+  return { status: "continue", activeFormKeys: null };
+}

--- a/packages/spec/tests/validate-map-errors.test.ts
+++ b/packages/spec/tests/validate-map-errors.test.ts
@@ -1,6 +1,8 @@
 /**
  * Characterization tests for TypeBox 1.x → agent SpecError mapping
- * (validate-map-errors.ts + validate-map-forms.ts + validate-schema-walk.ts).
+ * (validate-map-errors.ts + validate-map-path-unions.ts +
+ * validate-map-path-keywords.ts + validate-map-forms.ts +
+ * validate-schema-walk.ts).
  *
  * Exercises mapValueErrors classification through the public validate() entry.
  * Snapshot-tested agent messages remain in validate.test.ts (full orchestrator


### PR DESCRIPTION
## Summary

- Split TypeBox agent error path-group mapping (`validate-map-errors.ts`, was 436 lines / `mapPathGroup` ~330) into:
  - **`validate-map-path-unions.ts`** — anyOf/const channel, data, and enum classification
  - **`validate-map-path-keywords.ts`** — additionalProperties, required, range, default type
  - **`validate-map-errors.ts`** — `mapValueErrors` orchestrator + color-range pattern + `unknownGeomError` (~126 lines)
- Fall-through uses an explicit **`done` / `continue`** result (`done` with empty errors = suppress nested noise; `continue` + `activeFormKeys` = keyword handlers)

Public `mapValueErrors` / `validate()` diagnostics are unchanged.

### Why

Union form classification and keyword property mapping were sequential phases with different dependencies (`validate-map-forms` vs schema-walk property tools). Encoding fall-through as a result union documents the load-bearing empty-done suppressions.

## Test plan

- [x] `bun test packages/spec` (350 pass)
- [x] Focused: validate-map-errors, validate (snapshots), catalog-coverage, color-scale-api pattern
- [x] `bun run check` + knip

## Follow-ups

None deferred. Remaining long files in packages/spec are keep/cohesive (`schema-declarations`, `builder` fluent surface, `manual-at-schema` tests, `position-scale-api` cohesive contract suite, `temporal-column`/`ticks`).