### PR TITLE
perf(core): prealloc rect emit; single-pass grid major/minor

### DIFF
--- a/.changeset/rects-prealloc-and-grid-single-pass.md
+++ b/.changeset/rects-prealloc-and-grid-single-pass.md
@@ -1,0 +1,10 @@
+---
+"@ggsvelte/core": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+perf: prealloc rect emit buffers; single-pass grid major/minor split
+
+`emitRectRows` writes into preallocated Float32Array/Uint32Array (dense no-copy;
+sparse compact). Scene panel grid positions collect major/minor in one tick pass.

--- a/packages/core/src/pipeline/assemble-scene-panels.ts
+++ b/packages/core/src/pipeline/assemble-scene-panels.ts
@@ -56,9 +56,8 @@ function numericMinorTicks(
   fromEnd: boolean,
 ): SceneTick[] {
   if (values === undefined || scale.type !== "linear") return [];
-  const majorValues = new Set(
-    major.filter((tick) => tick.kind === "major").map((tick) => tick.value),
-  );
+  // Callers pass major-only axes from axisTicks; collect values without a kind filter.
+  const majorValues = new Set(major.map((tick) => tick.value));
   const unique = [
     ...new Set(
       values.filter((value) => {
@@ -79,6 +78,20 @@ function numericMinorTicks(
     extent,
     fromEnd,
   );
+}
+
+/** Single pass over ticks → major/minor grid positions (avoids 2× filter+map). */
+function gridPositionsByKind(ticks: readonly SceneTick[]): {
+  major: number[];
+  minor: number[];
+} {
+  const major: number[] = [];
+  const minor: number[] = [];
+  for (const tick of ticks) {
+    if (tick.kind === "major") major.push(tick.pos);
+    else if (tick.kind === "minor") minor.push(tick.pos);
+  }
+  return { major, minor };
 }
 
 export function assembleScenePanels(input: {
@@ -141,6 +154,8 @@ export function assembleScenePanels(input: {
       projector?.y.active === true
         ? suppressProjectedLabelOverlap(projectedLeft, "vertical", measurer, input.axisTextSize)
         : projectedLeft;
+    const xGrid = gridPositionsByKind(bottom);
+    const yGrid = gridPositionsByKind(left);
     return {
       identity: facetPanels[p]!.identity,
       id: facetPanels[p]!.id,
@@ -153,10 +168,10 @@ export function assembleScenePanels(input: {
       axisX: placement.showAxisX ? bottom : null,
       axisY: placement.showAxisY ? left : null,
       grid: {
-        x: bottom.filter((tick) => tick.kind === "major").map((tick) => tick.pos),
-        y: left.filter((tick) => tick.kind === "major").map((tick) => tick.pos),
-        minorX: bottom.filter((tick) => tick.kind === "minor").map((tick) => tick.pos),
-        minorY: left.filter((tick) => tick.kind === "minor").map((tick) => tick.pos),
+        x: xGrid.major,
+        y: yGrid.major,
+        minorX: xGrid.minor,
+        minorY: yGrid.minor,
       },
     };
   });

--- a/packages/core/src/pipeline/geometry-rects-emit.ts
+++ b/packages/core/src/pipeline/geometry-rects-emit.ts
@@ -1,5 +1,8 @@
 /**
  * Emit bar/col rect pixels from resolved slots.
+ *
+ * Pre-allocates typed buffers (like geometry-points-collect) so large frames
+ * avoid dynamic number[] growth + Float32Array.from double-copy.
  */
 import type { LayerFrame } from "./types.js";
 import type { Frame } from "./geometry-shared.js";
@@ -11,16 +14,18 @@ export function emitRectRows(input: {
   binned: boolean;
   widthFrac: number;
 }): {
-  rects: number[];
-  rowIndexKept: number[];
-  keptRows: number[];
+  rects: Float32Array;
+  rowIndex: Uint32Array;
+  keptRows: Uint32Array;
+  kept: number;
   removed: number;
 } {
   const { frame, fx, binned, widthFrac } = input;
   const { n } = frame;
-  const rects: number[] = [];
-  const rowIndexKept: number[] = [];
-  const keptRows: number[] = [];
+  const rects = new Float32Array(n * 4);
+  const rowIndex = new Uint32Array(n);
+  const keptRows = new Uint32Array(n);
+  let kept = 0;
   let removed = 0;
   for (let row = 0; row < n; row++) {
     const slot = resolveRectSlot({ frame, fx, row, binned, widthFrac });
@@ -28,13 +33,37 @@ export function emitRectRows(input: {
       removed++;
       continue;
     }
+    const o = kept * 4;
     const xPx = (slot.center - slot.w / 2) * fx.innerWidth;
     const wPx = slot.w * fx.innerWidth;
     const y0 = fx.innerHeight - slot.t0 * fx.innerHeight;
     const y1 = fx.innerHeight - slot.t1 * fx.innerHeight;
-    rects.push(xPx, Math.min(y0, y1), wPx, Math.abs(y1 - y0));
-    rowIndexKept.push(frame.rowIndex[row]!);
-    keptRows.push(row);
+    rects[o] = xPx;
+    rects[o + 1] = Math.min(y0, y1);
+    rects[o + 2] = wPx;
+    rects[o + 3] = Math.abs(y1 - y0);
+    rowIndex[kept] = frame.rowIndex[row]!;
+    keptRows[kept] = row;
+    kept++;
   }
-  return { rects, rowIndexKept, keptRows, removed };
+  // Dense path (common for bar/col): buffers already exact-sized — no copy.
+  if (kept === n) return { rects, rowIndex, keptRows, kept, removed };
+  if (kept === 0) {
+    return {
+      rects: new Float32Array(0),
+      rowIndex: new Uint32Array(0),
+      keptRows: new Uint32Array(0),
+      kept: 0,
+      removed,
+    };
+  }
+  // Sparse path: compact exported buffers so full-n scratch can be GC'd.
+  // keptRows is only used inside rectsBatch; a view is enough.
+  return {
+    rects: rects.subarray(0, kept * 4).slice(),
+    rowIndex: rowIndex.subarray(0, kept).slice(),
+    keptRows: keptRows.subarray(0, kept),
+    kept,
+    removed,
+  };
 }

--- a/packages/core/src/pipeline/geometry-rects.ts
+++ b/packages/core/src/pipeline/geometry-rects.ts
@@ -37,29 +37,29 @@ export function rectsBatch(
     widthFrac = span === 0 ? 0 : ((params.width ?? DEFAULT_BAR_WIDTH) * resolution) / span;
   }
 
-  const { rects, rowIndexKept, keptRows, removed } = emitRectRows({
+  const { rects, rowIndex, keptRows, kept, removed } = emitRectRows({
     frame,
     fx,
     binned,
     widthFrac,
   });
   removedWarning(removed, binding.index, warnings);
-  if (keptRows.length === 0) return null;
+  if (kept === 0) return null;
 
   const batch: RectsBatch = {
     kind: "rects",
     layerIndex: binding.index,
     panelIndex: 0,
-    rects: Float32Array.from(rects),
-    rowIndex: Uint32Array.from(rowIndexKept),
+    rects,
+    rowIndex,
     fill: binding.fill.constant,
     alpha: params.alpha ?? 1,
   };
   if (fill !== null && (frame.fillValues !== null || binding.fill.scaledConstant !== null)) {
-    batch.fills = keptRows.map((row) =>
+    batch.fills = Array.from({ length: kept }, (_, j) =>
       colorOf(
         fill,
-        frame.fillValues === null ? binding.fill.scaledConstant! : frame.fillValues[row]!,
+        frame.fillValues === null ? binding.fill.scaledConstant! : frame.fillValues[keptRows[j]!]!,
       ),
     );
   }


### PR DESCRIPTION
## Summary

`/bigo-maintain` pass on `packages/core` pipeline geometry / scene assembly.

### Best candidate

| Area | Pattern | Before | After |
|------|---------|--------|-------|
| `emitRectRows` | #9 allocation in hot path | `number[]` push + `Float32Array.from` / `Uint32Array.from` double-copy | Prealloc typed buffers; dense `kept===n` returns as-is; sparse compact via `subarray().slice()` |
| `assembleScenePanels` grid | repeated filter+map | 4× walk over ticks for major/minor x/y | One `gridPositionsByKind` pass → major + minor pos arrays |
| `numericMinorTicks` | redundant filter | `major.filter(kind===major)` | Callers already pass major-only axes |

**What n is:** frame rows R for rect emit (bar/col/histogram layers); tick count K for grid split.

**Public surface:** `rectsBatch` still returns `RectsBatch | null`; `emitRectRows` remains internal.

### Codex plan review

- Fixed unconditional `.slice()` on dense path (P2).
- Peak Θ(R) prealloc matches `geometry-points-collect`; intentional for dense bar/col common path (not a behavior regression).

### Verification

```
bun test packages/core/tests/geometry-rects-resolution.test.ts   packages/core/tests/geometry-rects-slot-binned.test.ts   packages/core/tests/pipeline-position-binned.test.ts   packages/core/tests/pipeline-position-transform/minor-breaks.test.ts   packages/core/tests/pipeline-m1/geoms.test.ts   packages/core/tests/pipeline-coord-transform/geoms.test.ts   packages/core/tests/pipeline-panel-layout.test.ts   packages/core/tests/pipeline-geometry/run-pipeline-regression.test.ts
# 51 pass
oxlint on the 3 touched pipeline files — clean
```

## Follow-ups

None deferred from this audit slice (prior perf PRs already landed nested-search / sort-in-loop wins in this package).

## Test plan

- [x] Focused geom / rect / minor-breaks / panel tests green
- [x] oxlint clean on touched files
- [ ] CI unit suite on PR