### PR TITLE
refactor(core): modularize identity candidate datum resolver (#533)

### DIFF
--- a/.changeset/identity-datum-modularize.md
+++ b/.changeset/identity-datum-modularize.md
@@ -1,0 +1,10 @@
+---
+"@ggsvelte/core": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+refactor: modularize identity candidate datum resolver
+
+Split locate, series, and shared types out of datum.ts; keep a thin factory
+plus lineage/attribute assembly. Public re-exports preserve test import paths.

--- a/packages/core/src/pipeline/candidate-construction/datum-locate.ts
+++ b/packages/core/src/pipeline/candidate-construction/datum-locate.ts
@@ -1,0 +1,102 @@
+/**
+ * Locate identity candidates: frame row, outlier context, mapped fields.
+ */
+import type { CandidateBuildFacts } from "../../candidate-store.js";
+import type { GeometryBatch } from "../../scene.js";
+import type { CellValue, ColumnTable } from "../../table.js";
+import type { FacetPanelDef } from "../facets.js";
+import type { LayerFrame, MappedField } from "../types.js";
+import { resolveCandidateFrameRow } from "./frame-row.js";
+import type { IdentityCandidateResolveContext, LocatedIdentityCandidate } from "./datum-types.js";
+
+function resolveCandidateFieldChannels(fields: readonly MappedField[]): {
+  xField: string | undefined;
+  yField: string | undefined;
+  colorField: string | undefined;
+  fillField: string | undefined;
+} {
+  return {
+    xField: fields.find((field) => field.channel === "x")?.field,
+    yField: fields.find((field) => field.channel === "y")?.field,
+    colorField: fields.find((field) => field.channel === "color")?.field,
+    fillField: fields.find((field) => field.channel === "fill")?.field,
+  };
+}
+
+function makeSourceValueLookup(
+  table: ColumnTable,
+  sourceRow: number | null,
+): (field: string | undefined) => CellValue {
+  return (field) =>
+    sourceRow === null || field === undefined ? null : table.column(field)[sourceRow]!;
+}
+
+/** Boxplot outlier local/source row mapping for point primitives. */
+export function resolveOutlierContext(input: {
+  frame: LayerFrame | undefined;
+  batch: GeometryBatch;
+  primitiveIndex: number;
+  facetPanel: FacetPanelDef | undefined;
+}): { outlierLocalRow: number | null; outlierSourceRow: number | null } {
+  const { frame, batch, primitiveIndex, facetPanel } = input;
+  const outlierLocalRow =
+    frame?.box !== null && frame?.binding.layer.geom === "boxplot" && batch.kind === "points"
+      ? (frame?.box.outlierRow[primitiveIndex] ?? null)
+      : null;
+  const outlierSourceRow =
+    outlierLocalRow === null
+      ? null
+      : (facetPanel?.sourceRows?.[outlierLocalRow] ?? outlierLocalRow);
+  return { outlierLocalRow, outlierSourceRow };
+}
+
+export function locateIdentityCandidate(
+  ctx: IdentityCandidateResolveContext,
+  facts: CandidateBuildFacts,
+): LocatedIdentityCandidate {
+  const {
+    seriesByRow,
+    sourceRowsByGroup,
+    sourceRowsByGroupX,
+    sourceRowsByGroupBin,
+    sourceRowsByGroupY,
+    frameGroups,
+  } = ctx.getIdentityIndex();
+  const fields = ctx.layerFields[facts.layerIndex] ?? [];
+  const sourceRow = facts.rowIndex;
+  const frame = ctx.panelFrames[facts.panelIndex]?.[facts.layerIndex];
+  const batch = ctx.scene.batches[facts.batchIndex]!;
+  const { outlierLocalRow, outlierSourceRow } = resolveOutlierContext({
+    frame,
+    batch,
+    primitiveIndex: facts.primitiveIndex,
+    facetPanel: ctx.facetPanels[facts.panelIndex],
+  });
+  const orderedGroups = frameGroups.get(`${facts.panelIndex}:${facts.layerIndex}`) ?? [0];
+  const { frameRow, derivedGroup } = resolveCandidateFrameRow({
+    frame,
+    batch,
+    primitiveIndex: facts.primitiveIndex,
+    orderedGroups,
+    outlierLocalRow,
+  });
+  const sourceValue = makeSourceValueLookup(ctx.table, sourceRow);
+  const { xField, yField, colorField, fillField } = resolveCandidateFieldChannels(fields);
+  return {
+    sourceRow,
+    frame,
+    outlierSourceRow,
+    frameRow,
+    derivedGroup,
+    sourceValue,
+    xField,
+    yField,
+    colorField,
+    fillField,
+    seriesByRow,
+    sourceRowsByGroup,
+    sourceRowsByGroupX,
+    sourceRowsByGroupBin,
+    sourceRowsByGroupY,
+  };
+}

--- a/packages/core/src/pipeline/candidate-construction/datum-series.ts
+++ b/packages/core/src/pipeline/candidate-construction/datum-series.ts
@@ -1,0 +1,76 @@
+/**
+ * Series identity + auto-mode for identity candidates.
+ */
+import type { CandidateBuildFacts } from "../../candidate-store.js";
+import type { CellValue } from "../../table.js";
+import { candidateAutoMode } from "../frame-candidates-auto-mode.js";
+import type { ResolvedColorScale } from "../types.js";
+import { ordinalSeriesRank } from "./datum-values.js";
+import type { IdentityCandidateResolveContext, LocatedIdentityCandidate } from "./datum-types.js";
+
+export function resolveCandidateSeries(input: {
+  sourceRow: number | null;
+  derivedGroup: number;
+  seriesByRow: Map<string, number>;
+  panelIndex: number;
+  layerIndex: number;
+  color: ResolvedColorScale | null;
+  fill: ResolvedColorScale | null;
+  colorField: string | undefined;
+  fillField: string | undefined;
+  sourceValue: (field: string | undefined) => CellValue;
+}): { group: number; seriesRank: number } {
+  const {
+    sourceRow,
+    derivedGroup,
+    seriesByRow,
+    panelIndex,
+    layerIndex,
+    color,
+    fill,
+    colorField,
+    fillField,
+    sourceValue,
+  } = input;
+  const group =
+    sourceRow === null
+      ? derivedGroup
+      : (seriesByRow.get(`${panelIndex}:${layerIndex}:${sourceRow}`) ?? 0);
+  const seriesRank = ordinalSeriesRank({
+    color,
+    fill,
+    colorField,
+    fillField,
+    sourceRow,
+    sourceValue,
+    group,
+  });
+  return { group, seriesRank };
+}
+
+export function resolveIdentitySeriesAndMode(
+  ctx: IdentityCandidateResolveContext,
+  facts: CandidateBuildFacts,
+  located: LocatedIdentityCandidate,
+): { group: number; seriesRank: number; autoMode: ReturnType<typeof candidateAutoMode> } {
+  const { sourceRow, frame, derivedGroup, sourceValue, colorField, fillField, seriesByRow } =
+    located;
+
+  const { group, seriesRank } = resolveCandidateSeries({
+    sourceRow,
+    derivedGroup,
+    seriesByRow,
+    panelIndex: facts.panelIndex,
+    layerIndex: facts.layerIndex,
+    color: ctx.color,
+    fill: ctx.fill,
+    colorField,
+    fillField,
+    sourceValue,
+  });
+  const autoMode = candidateAutoMode(
+    frame?.binding ?? ctx.bindings[facts.layerIndex]!,
+    facts.primitiveIndex,
+  );
+  return { group, seriesRank, autoMode };
+}

--- a/packages/core/src/pipeline/candidate-construction/datum-types.ts
+++ b/packages/core/src/pipeline/candidate-construction/datum-types.ts
@@ -1,0 +1,42 @@
+/**
+ * Shared context shapes for identity candidate datum resolution.
+ * Implementation modules: datum-locate, datum-series, datum (factory).
+ */
+import type { LineageStore } from "../../identity.js";
+import type { CellValue, ColumnTable } from "../../table.js";
+import type { FacetPanelDef } from "../facets.js";
+import type { LayerBinding, LayerFrame, MappedField, ResolvedColorScale } from "../types.js";
+import type { Scene } from "../../scene.js";
+import type { CandidateIdentityIndex } from "./identity-index.js";
+
+export interface IdentityCandidateResolveContext {
+  scene: Scene;
+  bindings: readonly LayerBinding[];
+  panelFrames: readonly (readonly LayerFrame[])[];
+  facetPanels: readonly FacetPanelDef[];
+  table: ColumnTable;
+  layerFields: readonly MappedField[][];
+  color: ResolvedColorScale | null;
+  fill: ResolvedColorScale | null;
+  lineage: LineageStore<number>;
+  getIdentityIndex: () => CandidateIdentityIndex;
+}
+
+/** Intermediate locate result before series/logical/lineage assembly. */
+export interface LocatedIdentityCandidate {
+  sourceRow: number | null;
+  frame: LayerFrame | undefined;
+  outlierSourceRow: number | null;
+  frameRow: number;
+  derivedGroup: number;
+  sourceValue: (field: string | undefined) => CellValue;
+  xField: string | undefined;
+  yField: string | undefined;
+  colorField: string | undefined;
+  fillField: string | undefined;
+  seriesByRow: Map<string, number>;
+  sourceRowsByGroup: Map<string, number[]>;
+  sourceRowsByGroupX: Map<string, number[]>;
+  sourceRowsByGroupBin: Map<string, number[]>;
+  sourceRowsByGroupY: Map<string, number[]>;
+}

--- a/packages/core/src/pipeline/candidate-construction/datum.ts
+++ b/packages/core/src/pipeline/candidate-construction/datum.ts
@@ -1,18 +1,27 @@
+/**
+ * Identity candidate datum resolver — thin factory + attribute assembly.
+ *
+ * Locate: datum-locate.ts · Series: datum-series.ts · Values: datum-values.ts
+ * Shared types: datum-types.ts · Represented-row filters: represented-rows.ts
+ */
 import type { CandidateBuildFacts, CandidateDatum } from "../../candidate-store.js";
 import type { LineageStore } from "../../identity.js";
-import type { GeometryBatch, Scene } from "../../scene.js";
+import type { Scene } from "../../scene.js";
 import type { CellValue, ColumnTable } from "../../table.js";
 import type { FacetPanelDef } from "../facets.js";
-import { candidateAutoMode } from "../frame-candidates-auto-mode.js";
 import type { LayerBinding, LayerFrame, MappedField, ResolvedColorScale } from "../types.js";
-import { ordinalSeriesRank, resolveCandidateLogicalValues } from "./datum-values.js";
-import { resolveCandidateFrameRow } from "./frame-row.js";
+import { candidateAutoMode } from "../frame-candidates-auto-mode.js";
+import { resolveCandidateLogicalValues } from "./datum-values.js";
+import { locateIdentityCandidate } from "./datum-locate.js";
+import { resolveIdentitySeriesAndMode } from "./datum-series.js";
+import type { IdentityCandidateResolveContext, LocatedIdentityCandidate } from "./datum-types.js";
 import type { CandidateIdentityIndex } from "./identity-index.js";
 import { filterRepresentedSourceRows } from "./represented-rows.js";
 
-// ---------------------------------------------------------------------------
-// Annotation context
-// ---------------------------------------------------------------------------
+// Public re-exports for characterization tests and external callers.
+export { resolveOutlierContext } from "./datum-locate.js";
+export { resolveCandidateSeries } from "./datum-series.js";
+
 function resolveAnnotationIntercepts(input: {
   frame: LayerFrame | undefined;
   primitiveIndex: number;
@@ -32,42 +41,6 @@ function resolveAnnotationIntercepts(input: {
   };
 }
 
-// ---------------------------------------------------------------------------
-// Candidate datum assembly
-// ---------------------------------------------------------------------------
-function assembleIdentityCandidateDatum(
-  ctx: IdentityCandidateResolveContext,
-  facts: CandidateBuildFacts,
-  located: LocatedIdentityCandidate,
-): CandidateDatum {
-  const attrs = resolveIdentityCandidateAttrs(ctx, facts, located);
-  const { xValue, yValue } = resolveCandidateLogicalValues({
-    annotationRule: attrs.annotationRule,
-    annotationX: attrs.annotationX,
-    annotationY: attrs.annotationY,
-    outlierSourceRow: located.outlierSourceRow,
-    sourceRow: located.sourceRow,
-    frame: located.frame,
-    frameRow: located.frameRow,
-    primitiveIndex: facts.primitiveIndex,
-    sourceValue: located.sourceValue,
-    xField: located.xField,
-    yField: located.yField,
-  });
-  return {
-    xValue,
-    yValue,
-    seriesId: attrs.group,
-    seriesRank: attrs.seriesRank,
-    sourceOrder: attrs.sourceOrder,
-    lineage: attrs.lineageKey,
-    autoMode: attrs.autoMode,
-  };
-}
-
-// ---------------------------------------------------------------------------
-// Candidate attribute facts
-// ---------------------------------------------------------------------------
 interface IdentityCandidateAttrs {
   group: number;
   seriesRank: number;
@@ -79,212 +52,6 @@ interface IdentityCandidateAttrs {
   annotationY: CellValue;
 }
 
-// ---------------------------------------------------------------------------
-// Candidate attributes
-// ---------------------------------------------------------------------------
-function resolveIdentityCandidateAttrs(
-  ctx: IdentityCandidateResolveContext,
-  facts: CandidateBuildFacts,
-  located: LocatedIdentityCandidate,
-): IdentityCandidateAttrs {
-  const { group, seriesRank, autoMode } = resolveIdentitySeriesAndMode(ctx, facts, located);
-  const lineageAnn = resolveIdentityLineageAndAnnotation(ctx, facts, located, group);
-  return {
-    group,
-    seriesRank,
-    autoMode,
-    ...lineageAnn,
-  };
-}
-
-// ---------------------------------------------------------------------------
-// Identity resolver context
-// ---------------------------------------------------------------------------
-interface IdentityCandidateResolveContext {
-  scene: Scene;
-  bindings: readonly LayerBinding[];
-  panelFrames: readonly (readonly LayerFrame[])[];
-  facetPanels: readonly FacetPanelDef[];
-  table: ColumnTable;
-  layerFields: readonly MappedField[][];
-  color: ResolvedColorScale | null;
-  fill: ResolvedColorScale | null;
-  lineage: LineageStore<number>;
-  getIdentityIndex: () => CandidateIdentityIndex;
-}
-
-// ---------------------------------------------------------------------------
-// Mapped field lookup
-// ---------------------------------------------------------------------------
-function resolveCandidateFieldChannels(fields: readonly MappedField[]): {
-  xField: string | undefined;
-  yField: string | undefined;
-  colorField: string | undefined;
-  fillField: string | undefined;
-} {
-  return {
-    xField: fields.find((field) => field.channel === "x")?.field,
-    yField: fields.find((field) => field.channel === "y")?.field,
-    colorField: fields.find((field) => field.channel === "color")?.field,
-    fillField: fields.find((field) => field.channel === "fill")?.field,
-  };
-}
-
-function makeSourceValueLookup(
-  table: ColumnTable,
-  sourceRow: number | null,
-): (field: string | undefined) => CellValue {
-  return (field) =>
-    sourceRow === null || field === undefined ? null : table.column(field)[sourceRow]!;
-}
-
-// ---------------------------------------------------------------------------
-// Lineage and annotation
-// ---------------------------------------------------------------------------
-function resolveIdentityLineageAndAnnotation(
-  ctx: IdentityCandidateResolveContext,
-  facts: CandidateBuildFacts,
-  located: LocatedIdentityCandidate,
-  group: number,
-): {
-  sourceOrder: number;
-  lineageKey: number;
-  annotationRule: boolean;
-  annotationX: CellValue;
-  annotationY: CellValue;
-} {
-  const {
-    sourceRow,
-    frame,
-    outlierSourceRow,
-    frameRow,
-    sourceRowsByGroup,
-    sourceRowsByGroupX,
-    sourceRowsByGroupBin,
-    sourceRowsByGroupY,
-  } = located;
-  const { annotationRule, annotationX, annotationY } = resolveAnnotationIntercepts({
-    frame,
-    primitiveIndex: facts.primitiveIndex,
-  });
-  const { sourceOrder, lineageKey } = resolveRepresentedSourceRows({
-    outlierSourceRow,
-    sourceRow,
-    group,
-    panelIndex: facts.panelIndex,
-    layerIndex: facts.layerIndex,
-    sourceRowsByGroup,
-    sourceRowsByGroupX,
-    sourceRowsByGroupBin,
-    sourceRowsByGroupY,
-    frame,
-    table: ctx.table,
-    frameRow,
-    lineage: ctx.lineage,
-    primitiveIndex: facts.primitiveIndex,
-  });
-  return { sourceOrder, lineageKey, annotationRule, annotationX, annotationY };
-}
-
-// ---------------------------------------------------------------------------
-// Located Candidate facts
-// ---------------------------------------------------------------------------
-interface LocatedIdentityCandidate {
-  sourceRow: number | null;
-  frame: LayerFrame | undefined;
-  outlierSourceRow: number | null;
-  frameRow: number;
-  derivedGroup: number;
-  sourceValue: (field: string | undefined) => CellValue;
-  xField: string | undefined;
-  yField: string | undefined;
-  colorField: string | undefined;
-  fillField: string | undefined;
-  seriesByRow: Map<string, number>;
-  sourceRowsByGroup: Map<string, number[]>;
-  sourceRowsByGroupX: Map<string, number[]>;
-  sourceRowsByGroupBin: Map<string, number[]>;
-  sourceRowsByGroupY: Map<string, number[]>;
-}
-
-// ---------------------------------------------------------------------------
-// Candidate location
-// ---------------------------------------------------------------------------
-function locateIdentityCandidate(
-  ctx: IdentityCandidateResolveContext,
-  facts: CandidateBuildFacts,
-): LocatedIdentityCandidate {
-  const {
-    seriesByRow,
-    sourceRowsByGroup,
-    sourceRowsByGroupX,
-    sourceRowsByGroupBin,
-    sourceRowsByGroupY,
-    frameGroups,
-  } = ctx.getIdentityIndex();
-  const fields = ctx.layerFields[facts.layerIndex] ?? [];
-  const sourceRow = facts.rowIndex;
-  const frame = ctx.panelFrames[facts.panelIndex]?.[facts.layerIndex];
-  const batch = ctx.scene.batches[facts.batchIndex]!;
-  const { outlierLocalRow, outlierSourceRow } = resolveOutlierContext({
-    frame,
-    batch,
-    primitiveIndex: facts.primitiveIndex,
-    facetPanel: ctx.facetPanels[facts.panelIndex],
-  });
-  const orderedGroups = frameGroups.get(`${facts.panelIndex}:${facts.layerIndex}`) ?? [0];
-  const { frameRow, derivedGroup } = resolveCandidateFrameRow({
-    frame,
-    batch,
-    primitiveIndex: facts.primitiveIndex,
-    orderedGroups,
-    outlierLocalRow,
-  });
-  const sourceValue = makeSourceValueLookup(ctx.table, sourceRow);
-  const { xField, yField, colorField, fillField } = resolveCandidateFieldChannels(fields);
-  return {
-    sourceRow,
-    frame,
-    outlierSourceRow,
-    frameRow,
-    derivedGroup,
-    sourceValue,
-    xField,
-    yField,
-    colorField,
-    fillField,
-    seriesByRow,
-    sourceRowsByGroup,
-    sourceRowsByGroupX,
-    sourceRowsByGroupBin,
-    sourceRowsByGroupY,
-  };
-}
-
-// ---------------------------------------------------------------------------
-// Boxplot outlier context
-// ---------------------------------------------------------------------------
-export function resolveOutlierContext(input: {
-  frame: LayerFrame | undefined;
-  batch: GeometryBatch;
-  primitiveIndex: number;
-  facetPanel: FacetPanelDef | undefined;
-}): { outlierLocalRow: number | null; outlierSourceRow: number | null } {
-  const { frame, batch, primitiveIndex, facetPanel } = input;
-  const outlierLocalRow =
-    frame?.box !== null && frame?.binding.layer.geom === "boxplot" && batch.kind === "points"
-      ? (frame?.box.outlierRow[primitiveIndex] ?? null)
-      : null;
-  const outlierSourceRow =
-    outlierLocalRow === null
-      ? null
-      : (facetPanel?.sourceRows?.[outlierLocalRow] ?? outlierLocalRow);
-  return { outlierLocalRow, outlierSourceRow };
-}
-
-// ---------------------------------------------------------------------------
-// Represented source rows
-// ---------------------------------------------------------------------------
 export function resolveRepresentedSourceRows(input: {
   outlierSourceRow: number | null;
   sourceRow: number | null;
@@ -346,9 +113,96 @@ export function resolveRepresentedSourceRows(input: {
   };
 }
 
-// ---------------------------------------------------------------------------
-// Identity datum resolution
-// ---------------------------------------------------------------------------
+function resolveIdentityLineageAndAnnotation(
+  ctx: IdentityCandidateResolveContext,
+  facts: CandidateBuildFacts,
+  located: LocatedIdentityCandidate,
+  group: number,
+): {
+  sourceOrder: number;
+  lineageKey: number;
+  annotationRule: boolean;
+  annotationX: CellValue;
+  annotationY: CellValue;
+} {
+  const {
+    sourceRow,
+    frame,
+    outlierSourceRow,
+    frameRow,
+    sourceRowsByGroup,
+    sourceRowsByGroupX,
+    sourceRowsByGroupBin,
+    sourceRowsByGroupY,
+  } = located;
+  const { annotationRule, annotationX, annotationY } = resolveAnnotationIntercepts({
+    frame,
+    primitiveIndex: facts.primitiveIndex,
+  });
+  const { sourceOrder, lineageKey } = resolveRepresentedSourceRows({
+    outlierSourceRow,
+    sourceRow,
+    group,
+    panelIndex: facts.panelIndex,
+    layerIndex: facts.layerIndex,
+    sourceRowsByGroup,
+    sourceRowsByGroupX,
+    sourceRowsByGroupBin,
+    sourceRowsByGroupY,
+    frame,
+    table: ctx.table,
+    frameRow,
+    lineage: ctx.lineage,
+    primitiveIndex: facts.primitiveIndex,
+  });
+  return { sourceOrder, lineageKey, annotationRule, annotationX, annotationY };
+}
+
+function resolveIdentityCandidateAttrs(
+  ctx: IdentityCandidateResolveContext,
+  facts: CandidateBuildFacts,
+  located: LocatedIdentityCandidate,
+): IdentityCandidateAttrs {
+  const { group, seriesRank, autoMode } = resolveIdentitySeriesAndMode(ctx, facts, located);
+  const lineageAnn = resolveIdentityLineageAndAnnotation(ctx, facts, located, group);
+  return {
+    group,
+    seriesRank,
+    autoMode,
+    ...lineageAnn,
+  };
+}
+
+function assembleIdentityCandidateDatum(
+  ctx: IdentityCandidateResolveContext,
+  facts: CandidateBuildFacts,
+  located: LocatedIdentityCandidate,
+): CandidateDatum {
+  const attrs = resolveIdentityCandidateAttrs(ctx, facts, located);
+  const { xValue, yValue } = resolveCandidateLogicalValues({
+    annotationRule: attrs.annotationRule,
+    annotationX: attrs.annotationX,
+    annotationY: attrs.annotationY,
+    outlierSourceRow: located.outlierSourceRow,
+    sourceRow: located.sourceRow,
+    frame: located.frame,
+    frameRow: located.frameRow,
+    primitiveIndex: facts.primitiveIndex,
+    sourceValue: located.sourceValue,
+    xField: located.xField,
+    yField: located.yField,
+  });
+  return {
+    xValue,
+    yValue,
+    seriesId: attrs.group,
+    seriesRank: attrs.seriesRank,
+    sourceOrder: attrs.sourceOrder,
+    lineage: attrs.lineageKey,
+    autoMode: attrs.autoMode,
+  };
+}
+
 function resolveIdentityCandidateDatum(
   ctx: IdentityCandidateResolveContext,
   facts: CandidateBuildFacts,
@@ -357,82 +211,6 @@ function resolveIdentityCandidateDatum(
   return assembleIdentityCandidateDatum(ctx, facts, located);
 }
 
-// ---------------------------------------------------------------------------
-// Series identity and mode
-// ---------------------------------------------------------------------------
-function resolveIdentitySeriesAndMode(
-  ctx: IdentityCandidateResolveContext,
-  facts: CandidateBuildFacts,
-  located: LocatedIdentityCandidate,
-): { group: number; seriesRank: number; autoMode: ReturnType<typeof candidateAutoMode> } {
-  const { sourceRow, frame, derivedGroup, sourceValue, colorField, fillField, seriesByRow } =
-    located;
-
-  const { group, seriesRank } = resolveCandidateSeries({
-    sourceRow,
-    derivedGroup,
-    seriesByRow,
-    panelIndex: facts.panelIndex,
-    layerIndex: facts.layerIndex,
-    color: ctx.color,
-    fill: ctx.fill,
-    colorField,
-    fillField,
-    sourceValue,
-  });
-  const autoMode = candidateAutoMode(
-    frame?.binding ?? ctx.bindings[facts.layerIndex]!,
-    facts.primitiveIndex,
-  );
-  return { group, seriesRank, autoMode };
-}
-
-// ---------------------------------------------------------------------------
-// Candidate series
-// ---------------------------------------------------------------------------
-export function resolveCandidateSeries(input: {
-  sourceRow: number | null;
-  derivedGroup: number;
-  seriesByRow: Map<string, number>;
-  panelIndex: number;
-  layerIndex: number;
-  color: ResolvedColorScale | null;
-  fill: ResolvedColorScale | null;
-  colorField: string | undefined;
-  fillField: string | undefined;
-  sourceValue: (field: string | undefined) => CellValue;
-}): { group: number; seriesRank: number } {
-  const {
-    sourceRow,
-    derivedGroup,
-    seriesByRow,
-    panelIndex,
-    layerIndex,
-    color,
-    fill,
-    colorField,
-    fillField,
-    sourceValue,
-  } = input;
-  const group =
-    sourceRow === null
-      ? derivedGroup
-      : (seriesByRow.get(`${panelIndex}:${layerIndex}:${sourceRow}`) ?? 0);
-  const seriesRank = ordinalSeriesRank({
-    color,
-    fill,
-    colorField,
-    fillField,
-    sourceRow,
-    sourceValue,
-    group,
-  });
-  return { group, seriesRank };
-}
-
-// ---------------------------------------------------------------------------
-// Identity datum resolver
-// ---------------------------------------------------------------------------
 export function createIdentityCandidateDatumResolver(input: {
   scene: Scene;
   bindings: readonly LayerBinding[];

--- a/packages/core/tests/candidate-construction-architecture.test.ts
+++ b/packages/core/tests/candidate-construction-architecture.test.ts
@@ -8,6 +8,9 @@ const constructionDir = join(pipelineDir, "candidate-construction");
 
 /** Intentional candidate-construction modules (one primary concern each). */
 const INTENTIONAL_MODULES = [
+  "datum-locate.ts",
+  "datum-series.ts",
+  "datum-types.ts",
   "datum-values.ts",
   "datum.ts",
   "frame-row.ts",
@@ -59,5 +62,24 @@ describe("Candidate construction architecture", () => {
     expect(datum).toMatch(/from "\.\/datum-values\.js"/);
     expect(datum).not.toMatch(/^export function ordinalSeriesRank/m);
     expect(datum).not.toMatch(/^export function resolveCandidateLogicalValues/m);
+  });
+
+  it("splits locate / series from the thin identity factory (#533)", () => {
+    const datum = readFileSync(join(constructionDir, "datum.ts"), "utf8");
+    const locate = readFileSync(join(constructionDir, "datum-locate.ts"), "utf8");
+    const series = readFileSync(join(constructionDir, "datum-series.ts"), "utf8");
+    const types = readFileSync(join(constructionDir, "datum-types.ts"), "utf8");
+    expect(types).toMatch(/export interface IdentityCandidateResolveContext/);
+    expect(types).toMatch(/export interface LocatedIdentityCandidate/);
+    expect(locate).toMatch(/^export function locateIdentityCandidate/m);
+    expect(locate).toMatch(/^export function resolveOutlierContext/m);
+    expect(series).toMatch(/^export function resolveCandidateSeries/m);
+    expect(datum).toMatch(/from "\.\/datum-locate\.js"/);
+    expect(datum).toMatch(/from "\.\/datum-series\.js"/);
+    expect(datum).toMatch(/^export function createIdentityCandidateDatumResolver/m);
+    // Bodies live in dedicated modules, not re-defined in the factory.
+    expect(datum).not.toMatch(/^export function resolveOutlierContext/m);
+    expect(datum).not.toMatch(/^export function resolveCandidateSeries/m);
+    expect(datum).not.toMatch(/^export function locateIdentityCandidate/m);
   });
 });


### PR DESCRIPTION
## Summary

Closes #533. Pure maintainability split of the identity candidate datum resolver.

### Modules
| File | Responsibility |
|------|----------------|
| `datum-types.ts` | `IdentityCandidateResolveContext`, `LocatedIdentityCandidate` |
| `datum-locate.ts` | `locateIdentityCandidate`, `resolveOutlierContext` |
| `datum-series.ts` | `resolveCandidateSeries`, series + auto-mode |
| `datum.ts` | thin factory, annotation/lineage assembly, `resolveRepresentedSourceRows` |
| `datum-values.ts` | unchanged (rank / logical values) |

Public APIs still import from `datum.ts` via re-exports.

### Size
- `datum.ts`: ~450 → ~231 lines

## Tests
- candidate-construction + architecture + candidate store suites green
- `tsc -b packages/core`

No store contract or behavior change.