### PR TITLE
fix(docs): keep playground copy sessions monotonic after promote

### DIFF
--- a/apps/docs/src/lib/components/PlaygroundOutput.svelte
+++ b/apps/docs/src/lib/components/PlaygroundOutput.svelte
@@ -14,6 +14,7 @@
   import {
     clampOutputTabIndex,
     copySessionMatchesOutputs,
+    nextCopySessionOutputs,
   } from "$lib/playground-output-ui";
   import { nextRovingTabIndex } from "$lib/tab-roving";
   import type { PortableSpec } from "@ggsvelte/spec";
@@ -55,9 +56,19 @@
     copySessionLive ? fallbackLabel : "output",
   );
 
-  // Drop any manual-copy selection when the session is invalidated (e.g. promote).
+  // Drop selection and clear the session when outputs leave the session identity.
+  // Clearing is monotonic so undo cannot revive a prior manual-copy session via
+  // playgroundOutputs' WeakMap cache on the restored PortableSpec.
   $effect(() => {
-    if (!copySessionLive) getSelection()?.removeAllRanges();
+    const nextSession = nextCopySessionOutputs(copySessionOutputs, outputs);
+    if (nextSession === copySessionOutputs) return;
+    getSelection()?.removeAllRanges();
+    copySessionOutputs = nextSession;
+    if (nextSession === null) {
+      manualFallbackIntent = false;
+      copyStatusRaw = "";
+      fallbackCode = "";
+    }
   });
 
   function select(index: number): void {
@@ -95,6 +106,8 @@
     const result = await copyText(selectedOutput.code, fallbackSource);
     if (!copySessionMatchesOutputs(sessionOutputs, outputs)) {
       // Outputs changed mid-copy; drop the in-flight session without applying UI.
+      // Effect also clears, but null here so we never write status onto a dead session.
+      copySessionOutputs = null;
       copying = false;
       return;
     }

--- a/apps/docs/src/lib/playground-output-ui.ts
+++ b/apps/docs/src/lib/playground-output-ui.ts
@@ -17,6 +17,19 @@ export function copySessionMatchesOutputs<T>(sessionOutputs: T | null, currentOu
   return sessionOutputs !== null && sessionOutputs === currentOutputs;
 }
 
+/**
+ * Reducer for copy-session binding. Keep the session only while `currentOutputs`
+ * is the same reference; otherwise return `null`.
+ *
+ * Invalidation is monotonic: once the session is cleared, a later return to a
+ * prior outputs identity (e.g. undo restoring a WeakMap-cached array) must not
+ * revive manual-copy UI from the earlier attempt — call this on every outputs
+ * observation and store the result.
+ */
+export function nextCopySessionOutputs<T>(sessionOutputs: T | null, currentOutputs: T): T | null {
+  return copySessionMatchesOutputs(sessionOutputs, currentOutputs) ? sessionOutputs : null;
+}
+
 export function playgroundDiagnosticSignature(
   diagnostics: readonly {
     readonly source: string;

--- a/scripts/playground-output-ui.test.ts
+++ b/scripts/playground-output-ui.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import {
   clampOutputTabIndex,
   copySessionMatchesOutputs,
+  nextCopySessionOutputs,
   playgroundDiagnosticSignature,
   shouldFocusDiagnosticsAlert,
 } from "../apps/docs/src/lib/playground-output-ui";
@@ -27,6 +28,30 @@ describe("copySessionMatchesOutputs", () => {
     expect(copySessionMatchesOutputs(a, a)).toBe(true);
     expect(copySessionMatchesOutputs(a, b)).toBe(false);
     expect(copySessionMatchesOutputs(null, a)).toBe(false);
+  });
+});
+
+describe("nextCopySessionOutputs", () => {
+  test("keeps the session only while outputs identity is unchanged", () => {
+    const a = [{ kind: "svelte" }];
+    const b = [{ kind: "svelte" }];
+    expect(nextCopySessionOutputs(a, a)).toBe(a);
+    expect(nextCopySessionOutputs(a, b)).toBe(null);
+    expect(nextCopySessionOutputs(null, a)).toBe(null);
+  });
+
+  test("invalidation is monotonic across promote then undo identities", () => {
+    // playgroundOutputs caches by PortableSpec; undo restores the same outputs
+    // array. Once the session left A for B, returning to A must not revive it.
+    const outputsA = [{ kind: "builder" as const }];
+    const outputsB = [{ kind: "builder" as const }];
+    let session: typeof outputsA | null = outputsA;
+    session = nextCopySessionOutputs(session, outputsA);
+    expect(session).toBe(outputsA);
+    session = nextCopySessionOutputs(session, outputsB);
+    expect(session).toBe(null);
+    session = nextCopySessionOutputs(session, outputsA);
+    expect(session).toBe(null);
   });
 });
 


### PR DESCRIPTION
## Summary

Follow-up for unrebutted post-merge / pre-merge-async Codex findings on #510.

### Findings

| Parent | Verdict | Disposition |
|--------|---------|-------------|
| P2 Clear stale manual copy selection after output changes | **Invalid / already fixed on #510** | Rebut on #510 — `visibleFallbackCode` empties the node and `$effect` clears selection; visual test already asserts empty code + empty selection after promote |
| P2 Don't revive invalidated copy sessions by identity | **Valid** | Fixed here |

### Root cause (valid finding)

`copySessionLive` was pure reference equality on the `outputs` array. `playgroundOutputs` WeakMap-caches by `PortableSpec`, and undo restores the same `committed` object from snapshots (`snapshotOf` keeps `committed: state.committed`). Flow:

1. Manual copy fallback on chart A (session = outputsA)
2. Promote chart B → UI hides (session still holds outputsA, live=false)
3. Undo to A → same outputsA reference → session revives with stale `manualFallbackIntent` / status

### Fix

- `nextCopySessionOutputs` reducer: mismatch → `null` (monotonic)
- Component effect applies the reducer and clears selection + session state
- Mid-copy abort also nulls the session before applying UI

## Tests

```text
bun test scripts/playground-output-ui.test.ts
# 6 pass — includes promote→undo identity sequence

bun run check:docs
# svelte-check 0 errors / 0 warnings
```

## Parent disposition

Replies on #510 threads; this PR is the fix for the valid finding.