### PR TITLE
perf(core): O(R) band path x-sort keys (not per-comparator)

### DIFF
--- a/.changeset/path-x-sort-precompute-keys.md
+++ b/.changeset/path-x-sort-precompute-keys.md
@@ -1,0 +1,10 @@
+---
+"@ggsvelte/core": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+perf: O(R) band path x-sort keys (not per-comparator indexOf)
+
+line/area/smooth group sorts materialize band domain ranks once, then
+compare O(1); continuous x still sorts on `xNumeric` directly.

--- a/packages/core/src/pipeline/geometry-paths-area.ts
+++ b/packages/core/src/pipeline/geometry-paths-area.ts
@@ -5,7 +5,7 @@ import type { PathsBatch } from "../scene.js";
 
 import type { LayerFrame, PipelineWarning, ResolvedColorScale } from "./types.js";
 import type { Frame } from "./geometry-shared.js";
-import { bucketByGroup, xSortKey } from "./geometry-shared.js";
+import { bucketByGroup, sortGroupRowsByX } from "./geometry-shared.js";
 import { writeClosedPathGroups } from "./geometry-paths-closed-batch.js";
 import { areaGroupFillOf } from "./geometry-paths-area-fill.js";
 
@@ -19,8 +19,7 @@ export function areaBatch(
   if (frame.ymin === null || frame.ymax === null) return null;
   const groupRows = bucketByGroup(frame, fx, frame.ymax, warnings);
   if (groupRows.length === 0) return null;
-  const sortKey = xSortKey(frame, fx);
-  for (const rows of groupRows) rows.sort((a, b) => sortKey(a) - sortKey(b));
+  sortGroupRowsByX(groupRows, frame, fx);
 
   // Draw later-stacked groups first so the first-seen group paints on top.
   const { positions, rowIndex, pathOffsets, fills, strokes } = writeClosedPathGroups({

--- a/packages/core/src/pipeline/geometry-paths-line.ts
+++ b/packages/core/src/pipeline/geometry-paths-line.ts
@@ -5,7 +5,7 @@ import type { PathsBatch } from "../scene.js";
 
 import type { LayerFrame, PipelineWarning, ResolvedColorScale } from "./types.js";
 import type { Frame } from "./geometry-shared.js";
-import { DEFAULT_LINEWIDTH, bucketByGroup, xSortKey } from "./geometry-shared.js";
+import { DEFAULT_LINEWIDTH, bucketByGroup, sortGroupRowsByX } from "./geometry-shared.js";
 import { writeLineSubpaths } from "./geometry-paths-line-write.js";
 
 export function lineBatch(
@@ -17,8 +17,7 @@ export function lineBatch(
   const { binding } = frame;
   const subpaths = bucketByGroup(frame, fx, null, warnings);
   if (subpaths.length === 0) return null;
-  const sortKey = xSortKey(frame, fx);
-  for (const rows of subpaths) rows.sort((a, b) => sortKey(a) - sortKey(b));
+  sortGroupRowsByX(subpaths, frame, fx);
 
   const { positions, rowIndex, pathOffsets, strokes } = writeLineSubpaths({
     frame,

--- a/packages/core/src/pipeline/geometry-shared-bucket.ts
+++ b/packages/core/src/pipeline/geometry-shared-bucket.ts
@@ -38,3 +38,29 @@ export function xSortKey(frame: LayerFrame, fx: Frame): (row: number) => number 
       ? (fx.xScale.indexOf(frame.xValues?.[row] ?? null) ?? Number.MAX_SAFE_INTEGER)
       : frame.xNumeric![row]!;
 }
+
+/**
+ * Sort each group's row indices by ascending x (path/line/area/smooth).
+ *
+ * Callers pass groups already filtered by {@link bucketByGroup} (finite x/y).
+ * Band x: materialize domain ranks once — O(R) `indexOf`/encodeKey lookups —
+ * then O(1) comparator reads (not O(R log R) key re-evals during sort).
+ * Continuous x: compare `frame.xNumeric` directly (no key array).
+ */
+export function sortGroupRowsByX(
+  groupRows: readonly number[][],
+  frame: LayerFrame,
+  fx: Frame,
+): void {
+  if (fx.xScale.type === "band") {
+    const keys = new Float64Array(frame.n);
+    const xValues = frame.xValues;
+    for (let row = 0; row < frame.n; row++) {
+      keys[row] = fx.xScale.indexOf(xValues?.[row] ?? null) ?? Number.MAX_SAFE_INTEGER;
+    }
+    for (const rows of groupRows) rows.sort((a, b) => keys[a]! - keys[b]!);
+    return;
+  }
+  const x = frame.xNumeric!;
+  for (const rows of groupRows) rows.sort((a, b) => x[a]! - x[b]!);
+}

--- a/packages/core/src/pipeline/geometry-shared-bucket.ts
+++ b/packages/core/src/pipeline/geometry-shared-bucket.ts
@@ -32,13 +32,6 @@ export function bucketByGroup(
   return groupRows.filter((rows) => rows !== undefined && rows.length > 0);
 }
 
-export function xSortKey(frame: LayerFrame, fx: Frame): (row: number) => number {
-  return (row: number) =>
-    fx.xScale.type === "band"
-      ? (fx.xScale.indexOf(frame.xValues?.[row] ?? null) ?? Number.MAX_SAFE_INTEGER)
-      : frame.xNumeric![row]!;
-}
-
 /**
  * Sort each group's row indices by ascending x (path/line/area/smooth).
  *

--- a/packages/core/src/pipeline/geometry-shared.ts
+++ b/packages/core/src/pipeline/geometry-shared.ts
@@ -12,4 +12,4 @@ export {
   removedWarning,
   type Frame,
 } from "./geometry-shared-position.js";
-export { bucketByGroup, xSortKey } from "./geometry-shared-bucket.js";
+export { bucketByGroup, sortGroupRowsByX, xSortKey } from "./geometry-shared-bucket.js";

--- a/packages/core/src/pipeline/geometry-shared.ts
+++ b/packages/core/src/pipeline/geometry-shared.ts
@@ -12,4 +12,4 @@ export {
   removedWarning,
   type Frame,
 } from "./geometry-shared-position.js";
-export { bucketByGroup, sortGroupRowsByX, xSortKey } from "./geometry-shared-bucket.js";
+export { bucketByGroup, sortGroupRowsByX } from "./geometry-shared-bucket.js";

--- a/packages/core/src/pipeline/geometry-smooth.ts
+++ b/packages/core/src/pipeline/geometry-smooth.ts
@@ -5,7 +5,7 @@ import type { GeometryBatch } from "../scene.js";
 
 import type { LayerFrame, PipelineWarning, ResolvedColorScale } from "./types.js";
 import type { Frame } from "./geometry-shared.js";
-import { bucketByGroup, xSortKey } from "./geometry-shared.js";
+import { bucketByGroup, sortGroupRowsByX } from "./geometry-shared.js";
 import { buildSmoothLineBatch } from "./geometry-smooth-line.js";
 import { buildSmoothRibbonBatch } from "./geometry-smooth-ribbon.js";
 
@@ -18,8 +18,7 @@ export function smoothBatches(
 ): GeometryBatch[] {
   const groupRows = bucketByGroup(frame, fx, null, warnings);
   if (groupRows.length === 0) return [];
-  const sortKey = xSortKey(frame, fx);
-  for (const rows of groupRows) rows.sort((a, b) => sortKey(a) - sortKey(b));
+  sortGroupRowsByX(groupRows, frame, fx);
 
   const out: GeometryBatch[] = [];
   // Ribbon drawn first, under the line.

--- a/packages/core/tests/geometry-shared-bucket-sort.test.ts
+++ b/packages/core/tests/geometry-shared-bucket-sort.test.ts
@@ -1,0 +1,106 @@
+/**
+ * sortGroupRowsByX: one O(R) band indexOf pass, then O(1) comparator reads.
+ */
+import { fromAny, fromPartial } from "@total-typescript/shoehorn";
+import { describe, expect, it } from "bun:test";
+
+import { trainBand, trainContinuous } from "../src/scales/train.ts";
+import { sortGroupRowsByX } from "../src/pipeline/geometry-shared-bucket.ts";
+import type { Frame } from "../src/pipeline/geometry-shared.ts";
+import type { LayerFrame } from "../src/pipeline/types.ts";
+
+describe("sortGroupRowsByX", () => {
+  it("orders band x by domain rank, not row arrival order", () => {
+    const band = trainBand([["a", "b", "c"]]);
+    // Shuffled arrival: c, a, b within one group.
+    const frame = fromAny<LayerFrame>({
+      n: 3,
+      xValues: ["c", "a", "b"],
+      xNumeric: null,
+      groups: [0, 0, 0],
+    });
+    const fx = fromPartial<Frame>({ xScale: band });
+    const groupRows = [[0, 1, 2]];
+    sortGroupRowsByX(groupRows, frame, fx);
+    expect(groupRows[0]).toEqual([1, 2, 0]); // a, b, c
+  });
+
+  it("orders continuous x by xNumeric without mutating the array", () => {
+    const linear = trainContinuous([[0, 1, 2]], {});
+    const xNumeric = Float64Array.of(30, 10, 20);
+    const frame = fromAny<LayerFrame>({
+      n: 3,
+      xValues: null,
+      xNumeric,
+      groups: [0, 0, 0],
+    });
+    const fx = fromPartial<Frame>({ xScale: linear });
+    const groupRows = [[0, 1, 2]];
+    sortGroupRowsByX(groupRows, frame, fx);
+    expect(groupRows[0]).toEqual([1, 2, 0]);
+    expect([...xNumeric]).toEqual([30, 10, 20]);
+  });
+
+  it('distinguishes typed keys 1 vs "1" (encodeKey parity)', () => {
+    const band = trainBand([[1, "1"]]);
+    const frame = fromAny<LayerFrame>({
+      n: 2,
+      xValues: ["1", 1],
+      xNumeric: null,
+      groups: [0, 0],
+    });
+    const fx = fromPartial<Frame>({ xScale: band });
+    const groupRows = [[0, 1]];
+    sortGroupRowsByX(groupRows, frame, fx);
+    // Domain order: number 1 then string "1"
+    expect(groupRows[0]).toEqual([1, 0]);
+  });
+
+  it("calls band indexOf once per frame row (not per comparator)", () => {
+    const band = trainBand([["a", "b", "c", "d", "e"]]);
+    let indexOfCalls = 0;
+    const instrumented = {
+      ...band,
+      indexOf(value: unknown): number | undefined {
+        indexOfCalls++;
+        return band.indexOf(value);
+      },
+    };
+    const n = 40;
+    const labels = ["e", "d", "c", "b", "a"] as const;
+    const xValues = Array.from({ length: n }, (_, i) => labels[i % labels.length]!);
+    const frame = fromAny<LayerFrame>({
+      n,
+      xValues,
+      xNumeric: null,
+      groups: Array.from({ length: n }, () => 0),
+    });
+    const fx = fromPartial<Frame>({ xScale: instrumented });
+    const groupRows = [Array.from({ length: n }, (_, i) => i)];
+    sortGroupRowsByX(groupRows, frame, fx);
+    expect(indexOfCalls).toBe(n);
+    // Sorted into domain order a…e repeating by original relative ties (unstable ok).
+    const ranks = groupRows[0]!.map((row) => band.indexOf(xValues[row]!)!);
+    for (let i = 1; i < ranks.length; i++) {
+      expect(ranks[i]!).toBeGreaterThanOrEqual(ranks[i - 1]!);
+    }
+  });
+
+  it("sorts each group independently", () => {
+    const band = trainBand([["a", "b", "c"]]);
+    const frame = fromAny<LayerFrame>({
+      n: 4,
+      xValues: ["c", "a", "b", "a"],
+      xNumeric: null,
+      groups: [0, 0, 1, 1],
+    });
+    const fx = fromPartial<Frame>({ xScale: band });
+    const groupRows = [
+      [0, 1], // c, a → a, c
+      [2, 3], // b, a → a, b
+    ];
+    sortGroupRowsByX(groupRows, frame, fx);
+    expect(groupRows[0]).toEqual([1, 0]);
+    expect(groupRows[1]).toEqual([3, 2]);
+  });
+});


### PR DESCRIPTION
## Summary

`/bigo-maintain` on `packages/core` path geometry sort.

### Finding

| Area | Pattern | Before | After |
|------|---------|--------|-------|
| `lineBatch` / `areaBatch` / `smoothBatches` | #5 repeated key work in sort | Band `xSortKey` → `indexOf`/`encodeKey` on **every** comparator (~2·R log R key evals) | `sortGroupRowsByX`: O(R) key materialization, O(1) compares; continuous uses `xNumeric` directly |

**What n is:** frame rows R (categorical/band x common for multi-series line/area).

**Complexity note:** sort remains O(Σ r_g log r_g); win is key-eval cost O(R log R · encode) → O(R · encode).

### Codex plan review

- Added focused unit tests (shuffled band order, typed 1 vs string 1, continuous non-mutation, instrumented indexOf call count = R, multi-group independence).
- Tightened claim: not a sort-order asymp change; reduces key re-evals.
- Sentinel MAX_SAFE_INTEGER retained for parity with prior xSortKey (defensive; pipeline groups are pre-filtered by bucketByGroup).

### Verification

```
bun test packages/core/tests/geometry-shared-bucket-sort.test.ts   packages/core/tests/pipeline-m1/geoms.test.ts   packages/core/tests/pipeline-geometry/run-pipeline-regression.test.ts   packages/core/tests/pipeline-geometry/paths-boxplot.test.ts   packages/core/tests/pipeline-coord-transform/geoms.test.ts
# 37 pass
oxlint clean on touched sources + test
```

## Follow-ups

None deferred from this slice.

## Test plan

- [x] Unit: sort order + indexOf O(R)
- [x] Geom / path characterization green
- [ ] CI unit suite on PR