### PR TITLE
perf(core): O(log L) legend label measures via truncateToFit

### DIFF
--- a/.changeset/legend-truncate-to-fit.md
+++ b/.changeset/legend-truncate-to-fit.md
@@ -1,0 +1,10 @@
+---
+"@ggsvelte/core": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+perf: O(L)→O(log L) legend label measures via shared truncateToFit
+
+Discrete and steps legend entries truncate with binary-search keep length
+(same helper as axes/band guides), not a reverse linear measure scan.

--- a/packages/core/src/legend.ts
+++ b/packages/core/src/legend.ts
@@ -10,6 +10,7 @@
  */
 import { linearTicks, tickStep } from "./layout/ticks.js";
 import type { TextMeasurer } from "./layout/measure.js";
+import { truncateToFit } from "./layout/truncate.js";
 import { encodeKey } from "./scales/state.js";
 import { bandKey } from "./scales/train.js";
 import type { SceneLegend, SceneLegendEntry } from "./scene.js";
@@ -120,15 +121,19 @@ export function disambiguatedLabels(values: readonly unknown[]): string[] {
   );
 }
 
+/** Ellipsis for legend entry truncation (same glyph as axis truncateToFit paths). */
+const LEGEND_ELLIPSIS = "…";
+
+/**
+ * Truncate a legend entry label to `maxWidth` via shared binary-search
+ * {@link truncateToFit}: O(log L) measureWidth calls (and O(L log L) string work)
+ * instead of a reverse linear scan O(L) measures / O(L²) joins.
+ *
+ * The pipeline's MetricsTableMeasurer is monotonic in keep length; under a
+ * non-monotonic native measurer this is best-effort (same contract as axes).
+ */
 function truncate(label: string, maxWidth: number, measurer: TextMeasurer): string {
-  if (measurer.measureWidth(label, FONT_SIZE) <= maxWidth) return label;
-  // oxlint-disable-next-line typescript/no-misused-spread -- code-point split is intentional
-  const chars = [...label];
-  for (let keep = chars.length - 1; keep >= 1; keep--) {
-    const candidate = chars.slice(0, keep).join("") + "…";
-    if (measurer.measureWidth(candidate, FONT_SIZE) <= maxWidth) return candidate;
-  }
-  return "…";
+  return truncateToFit(label, maxWidth, measurer, FONT_SIZE, LEGEND_ELLIPSIS);
 }
 
 /**

--- a/packages/core/tests/legend-truncate.test.ts
+++ b/packages/core/tests/legend-truncate.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Legend entry labels truncate via shared truncateToFit (binary search on keep
+ * length): O(log L) measureWidth calls per long label, not a reverse linear
+ * scan. Covers discrete and steps call sites in buildLegends.
+ */
+import { describe, expect, it } from "bun:test";
+
+import { FONT_METRICS } from "../src/layout/font-metrics.ts";
+import { MetricsTableMeasurer, type TextMeasurer } from "../src/layout/measure.ts";
+import { truncateToFit } from "../src/layout/truncate.ts";
+import { buildLegends, type DiscreteLegendInput, type StepsLegendInput } from "../src/legend.ts";
+
+const baseMeasurer = new MetricsTableMeasurer(FONT_METRICS);
+const FONT_SIZE = 11;
+const ELLIPSIS = "…";
+
+function countingMeasurer(): { measurer: TextMeasurer; count: () => number; reset: () => void } {
+  let measures = 0;
+  return {
+    measurer: {
+      measureWidth: (text, size) => {
+        measures++;
+        return baseMeasurer.measureWidth(text, size);
+      },
+      measureHeight: (size) => baseMeasurer.measureHeight(size),
+    },
+    count: () => measures,
+    reset: () => {
+      measures = 0;
+    },
+  };
+}
+
+function discreteInput(labels: readonly string[]): DiscreteLegendInput {
+  return {
+    kind: "discrete",
+    scale: "color",
+    title: "",
+    domain: labels,
+    firstSeen: labels,
+    colorOf: () => "#000",
+  };
+}
+
+function stepsInput(labels: readonly string[]): StepsLegendInput {
+  return {
+    kind: "steps",
+    scale: "fill",
+    title: "",
+    entries: labels.map((label) => ({ label, color: "#000" })),
+  };
+}
+
+describe("buildLegends truncation", () => {
+  it("truncates a long discrete entry to fit maxLabelWidth (matches truncateToFit)", () => {
+    const label = "Anlageverwaltungsgesellschaftsvertrag";
+    // maxWidth must leave a positive label budget after padding+swatch (4*2+10+6=24).
+    const maxWidth = 60;
+    const maxLabelWidth = Math.max(1, maxWidth - 4 * 2 - 10 - 6);
+    const block = buildLegends([discreteInput([label])], "stable-domain", baseMeasurer, maxWidth);
+    const legend = block.legends[0]!;
+    expect(legend.type).toBe("discrete");
+    if (legend.type !== "discrete") return;
+    const out = legend.entries[0]!.label;
+    expect(out).toBe(truncateToFit(label, maxLabelWidth, baseMeasurer, FONT_SIZE, ELLIPSIS));
+    expect(out.endsWith(ELLIPSIS)).toBe(true);
+    expect(baseMeasurer.measureWidth(out, FONT_SIZE)).toBeLessThanOrEqual(maxLabelWidth + 1e-6);
+  });
+
+  it("truncates a long steps entry the same way", () => {
+    const label = "x".repeat(80);
+    const maxWidth = 50;
+    const maxLabelWidth = Math.max(1, maxWidth - 4 * 2 - 12 - 6);
+    const block = buildLegends([stepsInput([label])], "stable-domain", baseMeasurer, maxWidth);
+    const legend = block.legends[0]!;
+    expect(legend.type).toBe("steps");
+    if (legend.type !== "steps") return;
+    const out = legend.entries[0]!.label;
+    expect(out).toBe(truncateToFit(label, maxLabelWidth, baseMeasurer, FONT_SIZE, ELLIPSIS));
+    expect(out.endsWith(ELLIPSIS)).toBe(true);
+  });
+
+  it("uses far fewer than L measureWidth calls for a long discrete label", () => {
+    const label = "x".repeat(200);
+    const maxWidth = 50;
+    const counter = countingMeasurer();
+    buildLegends([discreteInput([label])], "stable-domain", counter.measurer, maxWidth);
+    // Linear reverse scan measures ~L candidates; binary search is ~1+log2(L)+overhead
+    // (full label, truncated remeasure for labelWidth). Keep a hard ceiling well below L.
+    expect(counter.count()).toBeLessThan(40);
+    expect(counter.count()).toBeGreaterThan(1);
+  });
+
+  it("measureWidth count grows only logarithmically with label length", () => {
+    const maxWidth = 50;
+    const short = "x".repeat(40);
+    const long = "x".repeat(400);
+    const counter = countingMeasurer();
+    buildLegends([discreteInput([short])], "stable-domain", counter.measurer, maxWidth);
+    const shortCount = counter.count();
+    counter.reset();
+    buildLegends([discreteInput([long])], "stable-domain", counter.measurer, maxWidth);
+    const longCount = counter.count();
+    // 10× longer should not cost 10× measures (linear would). Allow small log growth + noise.
+    expect(longCount).toBeLessThan(shortCount + 15);
+    expect(longCount).toBeLessThan(50);
+  });
+});


### PR DESCRIPTION
## Summary

Legend discrete/steps entry labels still used a private reverse-linear `truncate` (O(L) `measureWidth` calls and O(L²) string joins per long label). Axes and band guides already use shared `truncateToFit` binary search. This PR routes legend through the same helper.

- **Audit target:** `packages/core` (hot layout/legend/path paths; full package is ~336 sources)
- **Pattern:** #5 repeated expensive computation (linear measure scan)
- **Before → after:** O(L) measures / O(L²) joins → O(log L) measures / O(L log L) string work per truncated entry (×E entries on a full legend rebuild)
- **What L is:** code-point length of legend labels (long product names / i18n)

Codex plan review corrected the headline complexity wording (call count ≠ total work) and required covering both discrete and steps call sites — both done.

## Test plan

- [x] `bun test packages/core/tests/legend-truncate.test.ts` — fit parity with `truncateToFit`, steps path, measure ceiling, log growth across 40 vs 400 code points
- [x] `bun test packages/core/tests/pipeline-m1/legends-theme.test.ts packages/core/tests/layout/truncate.test.ts`
- [ ] CI unit suite on PR

## Follow-ups

- https://github.com/ljodea/ggsvelte/issues/555 — prealloc typed buffers for geom_text glyphs emit
- https://github.com/ljodea/ggsvelte/issues/556 — deriveGroups groupCount without `Math.max(...groups)` spread