### PR TITLE
perf(core): prealloc typed buffers for geom_text glyphs emit (#555)

### DIFF
--- a/.changeset/glyphs-prealloc-typed-buffers.md
+++ b/.changeset/glyphs-prealloc-typed-buffers.md
@@ -1,0 +1,10 @@
+---
+"@ggsvelte/core": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+perf: prealloc typed buffers for geom_text glyphs emit
+
+emitGlyphRows sizes Float32/Uint32 buffers to frame.n (like points/rects)
+and compacts only when marks are dropped — no number[] + Float32Array.from.

--- a/packages/core/src/pipeline/geometry-glyphs-pack.ts
+++ b/packages/core/src/pipeline/geometry-glyphs-pack.ts
@@ -5,13 +5,11 @@ import type { GlyphsBatch } from "../scene.js";
 
 import type { LayerFrame } from "./types.js";
 import { DEFAULT_TEXT_SIZE } from "./geometry-shared.js";
+import type { EmittedGlyphs } from "./geometry-glyphs-rows.js";
 
 export function packGlyphsBatch(input: {
   frame: LayerFrame;
-  positions: number[];
-  rowIndex: number[];
-  texts: string[];
-  colors: string[];
+  emitted: EmittedGlyphs;
   wantsColors: boolean;
   params: {
     anchor?: "start" | "middle" | "end";
@@ -19,21 +17,21 @@ export function packGlyphsBatch(input: {
     alpha?: number;
   };
 }): GlyphsBatch | null {
-  const { frame, positions, rowIndex, texts, colors, wantsColors, params } = input;
-  if (texts.length === 0) return null;
+  const { frame, emitted, wantsColors, params } = input;
+  if (emitted.kept === 0) return null;
   const { binding } = frame;
   const batch: GlyphsBatch = {
     kind: "glyphs",
     layerIndex: binding.index,
     panelIndex: 0,
-    positions: Float32Array.from(positions),
-    rowIndex: Uint32Array.from(rowIndex),
-    texts,
+    positions: emitted.positions,
+    rowIndex: emitted.rowIndex,
+    texts: emitted.texts,
     color: binding.color.constant,
     size: params.size ?? DEFAULT_TEXT_SIZE,
     anchor: params.anchor ?? "middle",
     alpha: params.alpha ?? 1,
   };
-  if (wantsColors) batch.colors = colors;
+  if (wantsColors && emitted.colors !== null) batch.colors = emitted.colors;
   return batch;
 }

--- a/packages/core/src/pipeline/geometry-glyphs-rows.ts
+++ b/packages/core/src/pipeline/geometry-glyphs-rows.ts
@@ -1,5 +1,8 @@
 /**
- * Per-row text glyph emission into mutable geometry buffers.
+ * Per-row text glyph emission into preallocated typed geometry buffers.
+ *
+ * Matches geometry-rects-emit / geometry-points-collect: pre-size to frame.n,
+ * then compact only when marks were dropped (NaN coords / missing label).
  */
 import { bandKey } from "../scales/train.js";
 
@@ -8,6 +11,15 @@ import { colorOf } from "./types.js";
 import type { Frame } from "./geometry-shared.js";
 import { positionOf } from "./geometry-shared.js";
 
+export interface EmittedGlyphs {
+  positions: Float32Array;
+  rowIndex: Uint32Array;
+  texts: string[];
+  colors: string[] | null;
+  kept: number;
+  removed: number;
+}
+
 export function emitGlyphRows(input: {
   frame: LayerFrame;
   fx: Frame;
@@ -15,13 +27,14 @@ export function emitGlyphRows(input: {
   wantsColors: boolean;
   dx: number;
   dy: number;
-  positions: number[];
-  rowIndex: number[];
-  texts: string[];
-  colors: string[];
-}): number {
-  const { frame, fx, color, wantsColors, dx, dy, positions, rowIndex, texts, colors } = input;
+}): EmittedGlyphs {
+  const { frame, fx, color, wantsColors, dx, dy } = input;
   const { binding, n } = frame;
+  const positions = new Float32Array(n * 2);
+  const rowIndex = new Uint32Array(n);
+  const texts = Array.from<string>({ length: n });
+  const colors = wantsColors ? Array.from<string>({ length: n }) : null;
+  let kept = 0;
   let removed = 0;
   for (let row = 0; row < n; row++) {
     const tx = positionOf(fx.xScale, frame.xNumeric, frame.xValues, row, frame.offsetX);
@@ -32,14 +45,38 @@ export function emitGlyphRows(input: {
       removed++;
       continue;
     }
-    positions.push(tx * fx.innerWidth + dx, fx.innerHeight - ty * fx.innerHeight + dy);
-    rowIndex.push(frame.rowIndex[row]!);
-    texts.push(bandKey(label));
-    if (wantsColors && color !== null) {
+    positions[kept * 2] = tx * fx.innerWidth + dx;
+    positions[kept * 2 + 1] = fx.innerHeight - ty * fx.innerHeight + dy;
+    rowIndex[kept] = frame.rowIndex[row]!;
+    texts[kept] = bandKey(label);
+    if (colors !== null && color !== null) {
       const value =
         frame.colorValues === null ? binding.color.scaledConstant! : frame.colorValues[row]!;
-      colors.push(colorOf(color, value));
+      colors[kept] = colorOf(color, value);
     }
+    kept++;
   }
-  return removed;
+
+  if (kept === n) {
+    return { positions, rowIndex, texts, colors, kept, removed };
+  }
+  if (kept === 0) {
+    return {
+      positions: new Float32Array(0),
+      rowIndex: new Uint32Array(0),
+      texts: [],
+      colors: wantsColors ? [] : null,
+      kept: 0,
+      removed,
+    };
+  }
+  // Sparse path: compact so full-n scratch can be GC'd.
+  return {
+    positions: positions.subarray(0, kept * 2).slice(),
+    rowIndex: rowIndex.subarray(0, kept).slice(),
+    texts: texts.slice(0, kept),
+    colors: colors === null ? null : colors.slice(0, kept),
+    kept,
+    removed,
+  };
 }

--- a/packages/core/src/pipeline/geometry-glyphs.ts
+++ b/packages/core/src/pipeline/geometry-glyphs.ts
@@ -23,24 +23,16 @@ export function glyphsBatch(
     dy?: number;
     alpha?: number;
   };
-  const positions: number[] = [];
-  const rowIndex: number[] = [];
-  const texts: string[] = [];
-  const colors: string[] = [];
   const wantsColors =
     color !== null && (frame.colorValues !== null || binding.color.scaledConstant !== null);
-  const removed = emitGlyphRows({
+  const emitted = emitGlyphRows({
     frame,
     fx,
     color,
     wantsColors,
     dx: params.dx ?? 0,
     dy: params.dy ?? 0,
-    positions,
-    rowIndex,
-    texts,
-    colors,
   });
-  removedWarning(removed, binding.index, warnings);
-  return packGlyphsBatch({ frame, positions, rowIndex, texts, colors, wantsColors, params });
+  removedWarning(emitted.removed, binding.index, warnings);
+  return packGlyphsBatch({ frame, emitted, wantsColors, params });
 }

--- a/packages/core/tests/pipeline-geometry/glyphs-prealloc.test.ts
+++ b/packages/core/tests/pipeline-geometry/glyphs-prealloc.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Glyph emit preallocation (#555) — typed buffers, no Float32Array.from on hot path.
+ */
+import { fromPartial } from "@total-typescript/shoehorn";
+import { describe, expect, it } from "bun:test";
+
+import { emitGlyphRows } from "../../src/pipeline/geometry-glyphs-rows.ts";
+import { packGlyphsBatch } from "../../src/pipeline/geometry-glyphs-pack.ts";
+import type { LayerFrame } from "../../src/pipeline/types.ts";
+import type { Frame } from "../../src/pipeline/geometry-shared.ts";
+
+function makeFrame(n: number, opts: { dropMiddle?: boolean } = {}): LayerFrame {
+  const xNumeric = new Float64Array(n);
+  const yNumeric = new Float64Array(n);
+  const rowIndex = new Uint32Array(n);
+  const labelValues: (string | null)[] = [];
+  for (let i = 0; i < n; i++) {
+    xNumeric[i] = i;
+    yNumeric[i] = i * 2;
+    rowIndex[i] = i;
+    // Drop middle row when requested (missing label → sparse path).
+    labelValues[i] = opts.dropMiddle === true && i === 1 ? null : `L${i}`;
+  }
+  return fromPartial<LayerFrame>({
+    n,
+    rowIndex,
+    xNumeric,
+    yNumeric,
+    xValues: null,
+    yValues: null,
+    labelValues,
+    colorValues: null,
+    offsetX: null,
+    offsetY: null,
+    binding: {
+      index: 0,
+      labelConstant: null,
+      color: { constant: "#111", scaledConstant: null },
+    },
+  });
+}
+
+function makeFx(): Frame {
+  return fromPartial<Frame>({
+    xScale: {
+      type: "linear",
+      normalize: (v: number) => v / 10,
+      normalizeTransformed: (v: number) => v / 10,
+    },
+    yScale: {
+      type: "linear",
+      normalize: (v: number) => v / 20,
+      normalizeTransformed: (v: number) => v / 20,
+    },
+    innerWidth: 100,
+    innerHeight: 50,
+  });
+}
+
+describe("emitGlyphRows prealloc (#555)", () => {
+  it("dense path keeps exact-sized typed positions without copy growth", () => {
+    const frame = makeFrame(4);
+    const emitted = emitGlyphRows({
+      frame,
+      fx: makeFx(),
+      color: null,
+      wantsColors: false,
+      dx: 0,
+      dy: 0,
+    });
+    expect(emitted.kept).toBe(4);
+    expect(emitted.removed).toBe(0);
+    expect(emitted.positions).toBeInstanceOf(Float32Array);
+    expect(emitted.positions.length).toBe(8);
+    expect(emitted.rowIndex).toBeInstanceOf(Uint32Array);
+    expect([...emitted.rowIndex]).toEqual([0, 1, 2, 3]);
+    expect(emitted.texts).toEqual(["L0", "L1", "L2", "L3"]);
+    // First mark: tx=0 → x=0; ty=0 → y=50 (flipped).
+    expect(emitted.positions[0]).toBeCloseTo(0);
+    expect(emitted.positions[1]).toBeCloseTo(50);
+  });
+
+  it("sparse path compacts buffers after dropped labels", () => {
+    const frame = makeFrame(3, { dropMiddle: true });
+    const emitted = emitGlyphRows({
+      frame,
+      fx: makeFx(),
+      color: null,
+      wantsColors: false,
+      dx: 1,
+      dy: -2,
+    });
+    expect(emitted.kept).toBe(2);
+    expect(emitted.removed).toBe(1);
+    expect(emitted.positions.length).toBe(4);
+    expect([...emitted.rowIndex]).toEqual([0, 2]);
+    expect(emitted.texts).toEqual(["L0", "L2"]);
+    const batch = packGlyphsBatch({
+      frame,
+      emitted,
+      wantsColors: false,
+      params: {},
+    });
+    expect(batch?.kind).toBe("glyphs");
+    if (batch?.kind === "glyphs") {
+      expect(batch.positions).toBe(emitted.positions);
+      expect(batch.texts).toEqual(["L0", "L2"]);
+    }
+  });
+
+  it("returns null when every row is dropped", () => {
+    const frame = makeFrame(2);
+    // Force all labels missing via constant path.
+    frame.binding = {
+      ...frame.binding,
+      labelConstant: null,
+    } as LayerFrame["binding"];
+    frame.labelValues = [null, null];
+    const emitted = emitGlyphRows({
+      frame,
+      fx: makeFx(),
+      color: null,
+      wantsColors: false,
+      dx: 0,
+      dy: 0,
+    });
+    expect(emitted.kept).toBe(0);
+    expect(packGlyphsBatch({ frame, emitted, wantsColors: false, params: {} })).toBeNull();
+  });
+});

--- a/packages/core/tests/pipeline-geometry/glyphs-prealloc.test.ts
+++ b/packages/core/tests/pipeline-geometry/glyphs-prealloc.test.ts
@@ -114,7 +114,7 @@ describe("emitGlyphRows prealloc (#555)", () => {
     frame.binding = {
       ...frame.binding,
       labelConstant: null,
-    } as LayerFrame["binding"];
+    };
     frame.labelValues = [null, null];
     const emitted = emitGlyphRows({
       frame,


### PR DESCRIPTION
## Summary

Closes #555.

### Problem
`geom_text` glyph emission used growing `number[]` buffers + `Float32Array.from` / `Uint32Array.from`, while points/rects already preallocate typed arrays.

### Fix
- `emitGlyphRows` preallocates `Float32Array(n*2)` + `Uint32Array(n)` (+ string arrays)
- Dense path keeps exact-sized buffers (no copy)
- Sparse path (missing labels / NaN) compact-slices once
- `packGlyphsBatch` attaches the typed arrays directly

### Tests
- New `glyphs-prealloc.test.ts` (dense / sparse / empty)
- Existing text glyph pipeline regression green
- `tsc -b packages/core`