### PR TITLE
fix(scales): align color validate with runtime (#509 follow-up)

### DIFF
--- a/packages/core/src/pipeline/scale-color-sequential-format.ts
+++ b/packages/core/src/pipeline/scale-color-sequential-format.ts
@@ -58,6 +58,9 @@ function resolveColorLegendFormat(input: {
 
   // Log colorbars use decade ticks; linear span precision labels sub-unit
   // powers (0.001, 0.01, 0.1) as "0". Derive decimals from the domain floor.
+  // ECMA-402 caps maximumFractionDigits at 20 — extreme domains (e.g. 1e-300)
+  // use exponential labels instead of throwing RangeError.
+  const MAX_LOCALE_FRACTION_DIGITS = 20;
   let label: (value: number) => string;
   if (transform === "log10" && labelFormat === undefined) {
     const positives = domain.filter((value) => Number.isFinite(value) && value > 0);
@@ -66,6 +69,9 @@ function resolveColorLegendFormat(input: {
     label = (value: number) => {
       if (!Number.isFinite(value)) return String(value);
       if (decimals === 0) return defaultTickFormat(tickStep(domain[0], domain[1], 5))(value);
+      if (decimals > MAX_LOCALE_FRACTION_DIGITS) {
+        return value.toExponential(2);
+      }
       return value.toLocaleString("en-US", {
         maximumFractionDigits: decimals,
         minimumFractionDigits: 0,

--- a/packages/core/tests/pipeline-color-scales/sequential.test.ts
+++ b/packages/core/tests/pipeline-color-scales/sequential.test.ts
@@ -168,6 +168,20 @@ describe("sequential color scales", () => {
     expect(legend.ticks.map((tick) => tick.label)).not.toContain("0");
   });
 
+  it("formats extreme log10 color domains without RangeError", () => {
+    const model = runPipeline(
+      pointSpec([1e-300, 1], { type: "sequential", transform: "log10" }),
+      size,
+    );
+    const legend = model.scene.legends.find((candidate) => candidate.type === "ramp");
+    if (legend?.type !== "ramp") throw new Error("expected ramp legend");
+    expect(legend.ticks.length).toBeGreaterThan(0);
+    for (const tick of legend.ticks) {
+      expect(typeof tick.label).toBe("string");
+      expect(tick.label.length).toBeGreaterThan(0);
+    }
+  });
+
   it("still checks temporalKind when parseFailure censors invalid rows", () => {
     expect(() =>
       runPipeline(

--- a/packages/spec/src/validate-data-checks-color.ts
+++ b/packages/spec/src/validate-data-checks-color.ts
@@ -45,6 +45,7 @@ function discreteDomainKey(value: unknown): string {
 function expectedManualDomainLength(
   domain: unknown,
   fieldValueLists: readonly (readonly unknown[] | null | undefined)[],
+  scaledConstants: readonly unknown[] = [],
 ): number | null {
   if (Array.isArray(domain)) return domain.filter((value) => value !== null).length;
   const seen = new Set<string>();
@@ -57,6 +58,11 @@ function expectedManualDomainLength(
       seen.add(discreteDomainKey(value));
     }
   }
+  for (const value of scaledConstants) {
+    if (value === null) continue;
+    sawValues = true;
+    seen.add(discreteDomainKey(value));
+  }
   return sawValues ? seen.size : null;
 }
 
@@ -65,9 +71,12 @@ export function checkColorScaleDataCompatibility(input: {
   scales: Record<string, unknown> | undefined;
   fields: FieldEvidenceMap;
   colorFields: Record<"color" | "fill", ChannelFieldUse[]>;
+  /** Scaled constants (`{ value, scale: true }`) included in runtime domain training. */
+  colorScaledConstants?: Record<"color" | "fill", readonly unknown[]>;
   temporalDecisionCache: TemporalDecisionCache;
 }): SpecError[] {
   const { scales, fields, colorFields, temporalDecisionCache } = input;
+  const colorScaledConstants = input.colorScaledConstants ?? { color: [], fill: [] };
   const errors: SpecError[] = [];
   const typeOf = (field: string) => fields.get(field)?.type ?? null;
 
@@ -81,6 +90,7 @@ export function checkColorScaleDataCompatibility(input: {
       const expected = expectedManualDomainLength(
         config.domain,
         colorFields[channel].map((use) => fields.get(use.field)?.values),
+        colorScaledConstants[channel],
       );
       if (expected !== null && range.length !== expected) {
         errors.push({
@@ -124,7 +134,8 @@ export function checkColorScaleDataCompatibility(input: {
         config?.timezone !== undefined ||
         config?.disambiguation !== undefined;
 
-      // Quantitative fields with temporal-only options fail at resolve time.
+      // Quantitative fields with temporal-only options fail at resolve time unless
+      // parseFailure: "censor" recovers at least one temporal value (status invalid).
       if (type === "quantitative" && requestsTemporal) {
         const info = fields.get(use.field);
         const decision = temporalDecisionForField(
@@ -139,7 +150,11 @@ export function checkColorScaleDataCompatibility(input: {
             }),
           },
         );
-        if (decision?.status !== "temporal") {
+        const censoredInvalid =
+          config?.parse !== undefined &&
+          config.parseFailure === "censor" &&
+          decision?.status === "invalid";
+        if (decision?.status !== "temporal" && !censoredInvalid) {
           errors.push({
             code: "scale-type-mismatch",
             path: use.path,
@@ -152,8 +167,8 @@ export function checkColorScaleDataCompatibility(input: {
         }
         if (
           config?.temporalKind !== undefined &&
-          decision.kind !== null &&
-          decision.kind !== undefined &&
+          decision?.kind !== null &&
+          decision?.kind !== undefined &&
           decision.kind !== config.temporalKind
         ) {
           errors.push({
@@ -205,9 +220,11 @@ export function checkColorScaleDataCompatibility(input: {
         config.parseFailure === "censor" &&
         decision?.status === "invalid";
       if (decision?.status === "temporal" || censoredInvalid) {
+        // Mirror runtime: compare recovered kind even when status is invalid+censored.
         if (
-          decision?.status === "temporal" &&
           config?.temporalKind !== undefined &&
+          decision?.kind !== null &&
+          decision?.kind !== undefined &&
           decision.kind !== config.temporalKind
         ) {
           errors.push({

--- a/packages/spec/src/validate-data-checks.ts
+++ b/packages/spec/src/validate-data-checks.ts
@@ -82,6 +82,7 @@ export function dataChecks(
 
   const axisFields: Record<"x" | "y", ChannelFieldUse[]> = { x: [], y: [] };
   const colorFields: Record<"color" | "fill", ChannelFieldUse[]> = { color: [], fill: [] };
+  const colorScaledConstants: Record<"color" | "fill", unknown[]> = { color: [], fill: [] };
 
   for (let i = 0; i < layers.length; i++) {
     const layer = layers[i];
@@ -186,6 +187,17 @@ export function dataChecks(
         }
         continue;
       }
+      if ("value" in mapped) {
+        // Runtime trains manual/ordinal color domains on scaled constants too.
+        if (
+          (channel === "color" || channel === "fill") &&
+          mapped.scale === true &&
+          mapped.value !== null
+        ) {
+          colorScaledConstants[channel].push(mapped.value);
+        }
+        continue;
+      }
       if (!("field" in mapped)) continue;
 
       const info = fields.get(mapped.field);
@@ -238,6 +250,7 @@ export function dataChecks(
       scales,
       fields,
       colorFields,
+      colorScaledConstants,
       temporalDecisionCache,
     }),
   );

--- a/packages/spec/tests/validate-tier2-color.test.ts
+++ b/packages/spec/tests/validate-tier2-color.test.ts
@@ -150,4 +150,94 @@ describe("tier 2 — color scale data-aware validation", () => {
     if (result.ok) throw new Error("expected failure");
     expect(result.errors.some((error) => error.code === "scale-type-mismatch")).toBe(true);
   });
+
+  it("includes scaled color constants in manual domain length checks", () => {
+    const result = validate(
+      normalize({
+        data: {
+          values: [
+            { x: 1, y: 1 },
+            { x: 2, y: 2 },
+          ],
+        },
+        layers: [
+          {
+            geom: "point",
+            aes: { x: { field: "x" }, y: { field: "y" }, color: { value: "a", scale: true } },
+          },
+          {
+            geom: "point",
+            aes: { x: { field: "x" }, y: { field: "y" }, color: { value: "b", scale: true } },
+          },
+        ],
+        scales: { color: { type: "manual", range: ["#f00"] } },
+      }),
+      {},
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected failure");
+    expect(result.errors.some((error) => error.code === "scale-manual-domain-range")).toBe(true);
+  });
+
+  it("rejects censored temporal kind mismatches that runtime also rejects", () => {
+    const result = validate(
+      normalize({
+        data: {
+          values: [
+            { x: 1, y: 1, t: "2024-01-01 12:00" },
+            { x: 2, y: 2, t: "bad" },
+            { x: 3, y: 3, t: "2024-02-01 12:00" },
+          ],
+        },
+        layers: [
+          {
+            geom: "point",
+            aes: { x: { field: "x" }, y: { field: "y" }, color: { field: "t" } },
+          },
+        ],
+        scales: {
+          color: {
+            type: "sequential",
+            temporalKind: "date",
+            parse: "ymd_hm",
+            parseFailure: "censor",
+          },
+        },
+      }),
+      {},
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected failure");
+    expect(result.errors.some((error) => error.code === "scale-type-mismatch")).toBe(true);
+  });
+
+  it("allows censored epoch parses that the pipeline still renders", () => {
+    const result = validate(
+      normalize({
+        data: {
+          values: [
+            { x: 1, y: 1, t: 1_700_000_000_000 },
+            { x: 2, y: 2, t: 1e100 },
+            { x: 3, y: 3, t: 1_706_745_600_000 },
+          ],
+        },
+        layers: [
+          {
+            geom: "point",
+            aes: { x: { field: "x" }, y: { field: "y" }, color: { field: "t" } },
+          },
+        ],
+        scales: {
+          color: {
+            type: "sequential",
+            temporalKind: "datetime",
+            parse: { epoch: "milliseconds" },
+            parseFailure: "censor",
+          },
+        },
+      }),
+      {},
+    );
+    expect(result.ok).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

Follow-up for unrebutted post-merge Codex P2s on #509.

| Finding | Root cause | Fix |
|---------|------------|-----|
| Include scaled constants in manual domain checks | `colorFields` only recorded field mappings; runtime trains on `scaledConstant` | Collect `{value, scale:true}` and union into domain length |
| Mirror censored kind mismatches | Validator only compared kind when `status === \"temporal\"` | Compare recovered kind for invalid+censor too |
| Honor censored epoch parses | Quantitative path rejected any non-temporal decision | Allow `status === \"invalid\"` when `parseFailure: \"censor\"` |
| Clamp log colorbar precision | `decimals` from `1e-300` exceeds Intl max (20) → RangeError | Cap at 20; exponential labels beyond that |

## Tests

```text
bun test packages/spec/tests/validate-tier2-color.test.ts packages/core/tests/pipeline-color-scales/
# 36 pass

bun run check  # tsc -b packages/spec packages/core
```