### PR TITLE
fix(docs): recover from deploy-time immutable chunk misses

### DIFF
--- a/.github/workflows/cloudflare-pages.yml
+++ b/.github/workflows/cloudflare-pages.yml
@@ -23,8 +23,12 @@ on:
 permissions: {}
 
 concurrency:
+  # Cancel superseded builds. Main lands package refactors in bursts; each push
+  # rebuilds the docs artifact and flips production hashes. Queuing every
+  # intermediate deploy multiplies the window where a tab holds HTML that
+  # references retired `/_app/immutable/*` chunks (client "500 Internal Error").
   group: cloudflare-pages-production
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   deploy:
@@ -83,3 +87,10 @@ jobs:
           deployment_url=$(printf '%s\n' "${output}" | grep -Eo 'https://[^[:space:]]+\.pages\.dev' | tail -1)
           test -n "${deployment_url}"
           printf 'deployment-url=%s\n' "${deployment_url}" >> "${GITHUB_OUTPUT}"
+      - name: Verify immutable assets on the new deployment
+        shell: bash
+        run: |
+          set -euo pipefail
+          bun scripts/deployment-asset-smoke-cli.ts \
+            --base-url "${{ steps.deploy.outputs.deployment-url }}" \
+            --paths / /guide/getting-started /examples /playground

--- a/.github/workflows/cloudflare-pages.yml
+++ b/.github/workflows/cloudflare-pages.yml
@@ -88,9 +88,12 @@ jobs:
           test -n "${deployment_url}"
           printf 'deployment-url=%s\n' "${deployment_url}" >> "${GITHUB_OUTPUT}"
       - name: Verify immutable assets on the new deployment
+        env:
+          # Env-indirection: step outputs must not expand into the script body (zizmor).
+          DEPLOYMENT_URL: ${{ steps.deploy.outputs.deployment-url }}
         shell: bash
         run: |
           set -euo pipefail
           bun scripts/deployment-asset-smoke-cli.ts \
-            --base-url "${{ steps.deploy.outputs.deployment-url }}" \
+            --base-url "${DEPLOYMENT_URL}" \
             --paths / /guide/getting-started /examples /playground

--- a/apps/docs/src/app.html
+++ b/apps/docs/src/app.html
@@ -6,6 +6,7 @@
     <link rel="icon" href="%sveltekit.assets%/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <script src="%sveltekit.assets%/theme.js"></script>
+    <script src="%sveltekit.assets%/deploy-recovery.js"></script>
   </head>
   <body data-sveltekit-preload-data="hover">
     <div class="app-contents">%sveltekit.body%</div>

--- a/apps/docs/static/deploy-recovery.js
+++ b/apps/docs/static/deploy-recovery.js
@@ -1,0 +1,62 @@
+// Recover from post-deploy hashed-chunk misses. Cloudflare Pages serves one
+// deployment at a time: a new activate retires prior `/_app/immutable/*`
+// hashes. A tab that still has the previous shell (or hits an edge mid-flip)
+// then fails dynamic imports and SvelteKit surfaces "500 Internal Error".
+// Vite emits `vite:preloadError` for those misses; one guarded reload pulls
+// the current HTML + matching chunks. Guarded so a real missing asset cannot
+// loop.
+(function () {
+  var STORAGE_KEY = "ggsvelte-deploy-recovery-at";
+  var COOLDOWN_MS = 15000;
+
+  function recentlyReloaded() {
+    try {
+      var raw = sessionStorage.getItem(STORAGE_KEY);
+      if (raw === null) return false;
+      var previous = Number(raw);
+      if (!Number.isFinite(previous)) return false;
+      return Date.now() - previous < COOLDOWN_MS;
+    } catch {
+      return false;
+    }
+  }
+
+  function markReload() {
+    try {
+      sessionStorage.setItem(STORAGE_KEY, String(Date.now()));
+    } catch {
+      // Private mode / blocked storage: still attempt a single reload.
+    }
+  }
+
+  function shouldRecover(error) {
+    if (error === null || error === undefined) return false;
+    var message = typeof error === "string" ? error : error.message;
+    if (typeof message !== "string") return false;
+    return (
+      message.indexOf("Failed to fetch dynamically imported module") !== -1 ||
+      message.indexOf("error loading dynamically imported module") !== -1 ||
+      message.indexOf("Importing a module script failed") !== -1
+    );
+  }
+
+  function recover() {
+    if (recentlyReloaded()) return;
+    markReload();
+    location.reload();
+  }
+
+  window.addEventListener("vite:preloadError", function (event) {
+    try {
+      event.preventDefault();
+    } catch {
+      // Older engines may not expose preventDefault on this event.
+    }
+    recover();
+  });
+
+  window.addEventListener("unhandledrejection", function (event) {
+    if (!shouldRecover(event.reason)) return;
+    recover();
+  });
+})();

--- a/apps/docs/static/deploy-recovery.js
+++ b/apps/docs/static/deploy-recovery.js
@@ -30,13 +30,13 @@
   }
 
   function shouldRecover(error) {
-    if (error === null || error === undefined) return false;
-    var message = typeof error === "string" ? error : error.message;
-    if (typeof message !== "string") return false;
+    // String(TypeError) includes the message text without property access that
+    // type-aware oxlint treats as unsafe any under --deny-warnings.
+    var message = typeof error === "string" ? error : String(error);
     return (
-      message.indexOf("Failed to fetch dynamically imported module") !== -1 ||
-      message.indexOf("error loading dynamically imported module") !== -1 ||
-      message.indexOf("Importing a module script failed") !== -1
+      message.includes("Failed to fetch dynamically imported module") ||
+      message.includes("error loading dynamically imported module") ||
+      message.includes("Importing a module script failed")
     );
   }
 

--- a/scripts/cloudflare-pages-config.test.ts
+++ b/scripts/cloudflare-pages-config.test.ts
@@ -89,6 +89,21 @@ describe("Cloudflare Pages project contract", () => {
     expect(workflow).toContain("if: github.ref == 'refs/heads/main'");
     expect(workflow).toContain("ref: ${{ github.sha }}");
     expect(workflow).not.toContain("pull_request:");
+    // Superseded main pushes must not each flip production hashes in sequence.
+    expect(workflow).toMatch(/cancel-in-progress:\s*true/);
+    expect(workflow).toContain("bun scripts/deployment-asset-smoke-cli.ts");
+  });
+
+  it("ships a CSP-safe deploy-recovery bootstrap from static assets", () => {
+    const appHtml = readFileSync(join(ROOT, "apps", "docs", "src", "app.html"), "utf8");
+    const recovery = readFileSync(
+      join(ROOT, "apps", "docs", "static", "deploy-recovery.js"),
+      "utf8",
+    );
+    expect(appHtml).toContain('src="%sveltekit.assets%/deploy-recovery.js"');
+    expect(recovery).toContain("vite:preloadError");
+    expect(recovery).toContain("Failed to fetch dynamically imported module");
+    expect(recovery).toContain("ggsvelte-deploy-recovery-at");
   });
 
   it("does not keep a GitHub Pages deployment workflow or legacy migration scripts", () => {

--- a/scripts/deployment-asset-smoke-cli.ts
+++ b/scripts/deployment-asset-smoke-cli.ts
@@ -15,11 +15,14 @@ function pathArguments(): string[] {
   for (let index = 0; index < process.argv.length; index += 1) {
     if (process.argv[index] !== "--paths") continue;
     let cursor = index + 1;
-    if (cursor >= process.argv.length || process.argv[cursor]!.startsWith("--")) {
+    const first = process.argv[cursor];
+    if (first === undefined || first.startsWith("--")) {
       throw new Error("Missing value for --paths");
     }
-    while (cursor < process.argv.length && !process.argv[cursor]!.startsWith("--")) {
-      values.push(process.argv[cursor]!);
+    while (cursor < process.argv.length) {
+      const value = process.argv[cursor];
+      if (value === undefined || value.startsWith("--")) break;
+      values.push(value);
       cursor += 1;
     }
   }

--- a/scripts/deployment-asset-smoke-cli.ts
+++ b/scripts/deployment-asset-smoke-cli.ts
@@ -1,0 +1,49 @@
+import { smokeImmutableAssets } from "./deployment-asset-smoke.ts";
+
+function argument(name: string): string {
+  const index = process.argv.indexOf(name);
+  const value = index < 0 ? undefined : process.argv[index + 1];
+  if (value === undefined || value.startsWith("--")) {
+    throw new Error(`Missing required argument: ${name}`);
+  }
+  return value;
+}
+
+/** Collect `--paths /a /b /c` or repeated `--paths /a --paths /b`. */
+function pathArguments(): string[] {
+  const values: string[] = [];
+  for (let index = 0; index < process.argv.length; index += 1) {
+    if (process.argv[index] !== "--paths") continue;
+    let cursor = index + 1;
+    if (cursor >= process.argv.length || process.argv[cursor]!.startsWith("--")) {
+      throw new Error("Missing value for --paths");
+    }
+    while (cursor < process.argv.length && !process.argv[cursor]!.startsWith("--")) {
+      values.push(process.argv[cursor]!);
+      cursor += 1;
+    }
+  }
+  return values;
+}
+
+async function main(): Promise<void> {
+  const baseUrl = argument("--base-url");
+  const expanded = pathArguments();
+  if (expanded.length === 0) {
+    throw new Error("Pass at least one path: --paths / /guide/getting-started");
+  }
+
+  const problems = await smokeImmutableAssets({ baseUrl, paths: expanded });
+  const evidence = {
+    schemaVersion: 1,
+    baseUrl,
+    paths: expanded,
+    checkedAt: new Date().toISOString(),
+    passed: problems.length === 0,
+    problems,
+  };
+  console.log(JSON.stringify(evidence, null, 2));
+  if (!evidence.passed) process.exitCode = 1;
+}
+
+if (import.meta.main) await main();

--- a/scripts/deployment-asset-smoke.test.ts
+++ b/scripts/deployment-asset-smoke.test.ts
@@ -105,12 +105,11 @@ describe("deployment immutable asset smoke", () => {
       return Promise.reject(new Error(`unexpected fetch: ${input}`));
     };
 
-    await expect(
-      smokeImmutableAssets({
-        baseUrl: "https://example.pages.dev",
-        paths: ["/"],
-        fetchImpl,
-      }),
-    ).resolves.toEqual([]);
+    const problems = await smokeImmutableAssets({
+      baseUrl: "https://example.pages.dev",
+      paths: ["/"],
+      fetchImpl,
+    });
+    expect(problems).toEqual([]);
   });
 });

--- a/scripts/deployment-asset-smoke.test.ts
+++ b/scripts/deployment-asset-smoke.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  evaluateAssetProbe,
+  extractImmutableAssets,
+  smokeImmutableAssets,
+  type FetchLike,
+} from "./deployment-asset-smoke.ts";
+
+describe("deployment immutable asset smoke", () => {
+  it("extracts hashed SvelteKit immutable assets from prerendered HTML", () => {
+    const html = `
+      <link href="./_app/immutable/entry/start.ABC.js" rel="modulepreload">
+      <link href="/_app/immutable/nodes/2.DEF.js" rel="modulepreload">
+      <script type="module" src="./_app/immutable/entry/app.GHI.js"></script>
+      <link href="./_app/immutable/assets/0.JKL.css" rel="stylesheet">
+    `;
+    expect(extractImmutableAssets(html)).toEqual([
+      "_app/immutable/assets/0.JKL.css",
+      "_app/immutable/entry/app.GHI.js",
+      "_app/immutable/entry/start.ABC.js",
+      "_app/immutable/nodes/2.DEF.js",
+    ]);
+  });
+
+  it("rejects missing assets and HTML served at JS URLs", () => {
+    expect(
+      evaluateAssetProbe({
+        asset: "_app/immutable/nodes/2.missing.js",
+        url: "https://ggsvelte.sh/_app/immutable/nodes/2.missing.js",
+        status: 404,
+        contentType: "text/html",
+      }),
+    ).toContain("expected HTTP 200");
+
+    expect(
+      evaluateAssetProbe({
+        asset: "_app/immutable/nodes/2.fake.js",
+        url: "https://ggsvelte.sh/_app/immutable/nodes/2.fake.js",
+        status: 200,
+        contentType: "text/html; charset=utf-8",
+      }),
+    ).toContain("text/html");
+
+    expect(
+      evaluateAssetProbe({
+        asset: "_app/immutable/nodes/2.ok.js",
+        url: "https://ggsvelte.sh/_app/immutable/nodes/2.ok.js",
+        status: 200,
+        contentType: "text/javascript",
+      }),
+    ).toBeNull();
+  });
+
+  it("fails when a page's modulepreload graph includes a retired hash", async () => {
+    const html = `<link href="./_app/immutable/nodes/2.BAFAK46o.js" rel="modulepreload">`;
+    const fetchImpl: FetchLike = (input) => {
+      if (input.endsWith("/") || input.endsWith("/guide/getting-started")) {
+        return Promise.resolve({
+          status: 200,
+          headers: { get: () => "text/html" },
+          text: () => Promise.resolve(html),
+        });
+      }
+      if (input.includes("2.BAFAK46o.js")) {
+        return Promise.resolve({
+          status: 404,
+          headers: { get: () => "text/html" },
+          text: () => Promise.resolve("<!doctype html><title>Not found</title>"),
+        });
+      }
+      return Promise.reject(new Error(`unexpected fetch: ${input}`));
+    };
+
+    const problems = await smokeImmutableAssets({
+      baseUrl: "https://ggsvelte.sh",
+      paths: ["/"],
+      fetchImpl,
+    });
+    expect(problems.length).toBe(1);
+    expect(problems[0]?.message).toContain("2.BAFAK46o.js");
+    expect(problems[0]?.message).toContain("404");
+  });
+
+  it("passes when every referenced immutable asset returns a non-HTML 200", async () => {
+    const html = `
+      <link href="./_app/immutable/entry/start.OK.js" rel="modulepreload">
+      <link href="./_app/immutable/nodes/2.OK.js" rel="modulepreload">
+    `;
+    const fetchImpl: FetchLike = (input) => {
+      if (input.endsWith("https://example.pages.dev/") || input === "https://example.pages.dev/") {
+        return Promise.resolve({
+          status: 200,
+          headers: { get: () => "text/html" },
+          text: () => Promise.resolve(html),
+        });
+      }
+      if (input.includes("/_app/immutable/")) {
+        return Promise.resolve({
+          status: 200,
+          headers: { get: () => "text/javascript; charset=utf-8" },
+          text: () => Promise.resolve("export {}"),
+        });
+      }
+      return Promise.reject(new Error(`unexpected fetch: ${input}`));
+    };
+
+    await expect(
+      smokeImmutableAssets({
+        baseUrl: "https://example.pages.dev",
+        paths: ["/"],
+        fetchImpl,
+      }),
+    ).resolves.toEqual([]);
+  });
+});

--- a/scripts/deployment-asset-smoke.ts
+++ b/scripts/deployment-asset-smoke.ts
@@ -60,7 +60,13 @@ export async function smokeImmutableAssets(input: {
   readonly fetchImpl?: FetchLike;
 }): Promise<AssetSmokeProblem[]> {
   const origin = new URL(input.baseUrl).origin;
-  const fetchImpl = input.fetchImpl ?? (fetch as FetchLike);
+  const fetchImpl: FetchLike =
+    input.fetchImpl ??
+    ((url, init) =>
+      fetch(url, {
+        redirect: init?.redirect,
+        headers: init?.headers,
+      }));
   const problems: AssetSmokeProblem[] = [];
 
   for (const path of input.paths) {

--- a/scripts/deployment-asset-smoke.ts
+++ b/scripts/deployment-asset-smoke.ts
@@ -1,0 +1,127 @@
+/**
+ * Post-deploy integrity checks for SvelteKit immutable assets.
+ *
+ * Cloudflare Pages flips production to a single deployment. If HTML is served
+ * while a referenced `/_app/immutable/*` chunk is missing (or returns the
+ * HTML 404 fallback), the browser fails dynamic import and the docs shell
+ * shows "500 Internal Error". Smoke the HTML → asset graph before greenlighting.
+ */
+
+// Character class: stop at quotes, whitespace, or tag close — not a literal "\s".
+const IMMUTABLE_ASSET_RE = /(?:\.\/|\/)?(_app\/immutable\/[^"'>\s]+)/g;
+
+export function extractImmutableAssets(html: string): string[] {
+  const assets = new Set<string>();
+  for (const match of html.matchAll(IMMUTABLE_ASSET_RE)) {
+    const path = match[1];
+    if (path !== undefined) assets.add(path);
+  }
+  return [...assets].toSorted();
+}
+
+export interface AssetProbe {
+  readonly asset: string;
+  readonly url: string;
+  readonly status: number;
+  readonly contentType: string | null;
+}
+
+export interface AssetSmokeProblem {
+  readonly path: string;
+  readonly message: string;
+}
+
+export function evaluateAssetProbe(probe: AssetProbe): string | null {
+  if (probe.status !== 200) {
+    return `${probe.asset}: expected HTTP 200, received ${String(probe.status)} (${probe.url})`;
+  }
+  const contentType = probe.contentType?.toLowerCase() ?? "";
+  if (probe.asset.endsWith(".js") && contentType.includes("text/html")) {
+    return `${probe.asset}: JavaScript URL returned text/html (likely 404 fallback HTML)`;
+  }
+  if (probe.asset.endsWith(".css") && contentType.includes("text/html")) {
+    return `${probe.asset}: CSS URL returned text/html (likely 404 fallback HTML)`;
+  }
+  return null;
+}
+
+export type FetchLike = (
+  input: string,
+  init?: { redirect?: "manual" | "follow" | "error"; headers?: Record<string, string> },
+) => Promise<{
+  status: number;
+  headers: { get(name: string): string | null };
+  text(): Promise<string>;
+}>;
+
+export async function smokeImmutableAssets(input: {
+  readonly baseUrl: string;
+  readonly paths: readonly string[];
+  readonly fetchImpl?: FetchLike;
+}): Promise<AssetSmokeProblem[]> {
+  const origin = new URL(input.baseUrl).origin;
+  const fetchImpl = input.fetchImpl ?? (fetch as FetchLike);
+  const problems: AssetSmokeProblem[] = [];
+
+  for (const path of input.paths) {
+    const pageUrl = new URL(path.startsWith("/") ? path : `/${path}`, `${origin}/`).href;
+    let html: string;
+    try {
+      const response = await fetchImpl(pageUrl, {
+        redirect: "follow",
+        headers: {
+          "cache-control": "no-cache",
+          "user-agent": "ggsvelte-deployment-asset-smoke/1",
+        },
+      });
+      if (response.status !== 200) {
+        problems.push({
+          path,
+          message: `${path}: page expected HTTP 200, received ${String(response.status)}`,
+        });
+        continue;
+      }
+      html = await response.text();
+    } catch (error) {
+      problems.push({
+        path,
+        message: `${path}: page request failed: ${error instanceof Error ? error.message : String(error)}`,
+      });
+      continue;
+    }
+
+    const assets = extractImmutableAssets(html);
+    if (assets.length === 0) {
+      problems.push({ path, message: `${path}: no /_app/immutable assets found in HTML` });
+      continue;
+    }
+
+    for (const asset of assets) {
+      const assetUrl = new URL(asset, `${origin}/`).href;
+      try {
+        const response = await fetchImpl(assetUrl, {
+          redirect: "follow",
+          headers: {
+            "cache-control": "no-cache",
+            "user-agent": "ggsvelte-deployment-asset-smoke/1",
+          },
+        });
+        const probe: AssetProbe = {
+          asset,
+          url: assetUrl,
+          status: response.status,
+          contentType: response.headers.get("content-type"),
+        };
+        const problem = evaluateAssetProbe(probe);
+        if (problem !== null) problems.push({ path, message: problem });
+      } catch (error) {
+        problems.push({
+          path,
+          message: `${asset}: request failed: ${error instanceof Error ? error.message : String(error)}`,
+        });
+      }
+    }
+  }
+
+  return problems;
+}


### PR DESCRIPTION
## Summary

Production docs at ggsvelte.sh were intermittently showing SvelteKit's **"500 Internal Error"** page. HTTP status for HTML routes stayed 200; the real failure was client-side:

- `TypeError: Failed to fetch dynamically imported module: …/_app/immutable/nodes/2.<hash>.js`
- Network: that hashed chunk returned **404**
- Browser text: **500 Internal Error**

Root cause: Cloudflare Pages serves one deployment at a time. Rapid `main` merges (many `packages/**` pushes) each rebuild and flip production. When HTML references new content hashes while a tab still holds a prior shell—or hits the flip mid-load—retired `/_app/immutable/*` chunks 404 and hydration dies.

### Fix

1. **`deploy-recovery.js`** (CSP-safe static script) — one guarded `location.reload()` on `vite:preloadError` / dynamic-import rejections so mid-deploy tabs self-heal.
2. **`cancel-in-progress: true`** on the Cloudflare Pages workflow — do not queue every intermediate deploy; only the latest superseding build ships.
3. **Post-deploy asset smoke** — after `wrangler pages deploy`, walk key pages' modulepreload graphs and fail if any immutable asset is missing or returns HTML.

## Test plan

- [x] `bun test scripts/deployment-asset-smoke.test.ts scripts/cloudflare-pages-config.test.ts`
- [x] Live apex asset smoke: all preloaded assets 200 (`passed: true`)
- [x] Browser recheck on https://ggsvelte.sh/ — no console errors, homepage renders "ggplot2 for Svelte"
- [ ] After merge: Cloudflare Pages deploy green; post-deploy asset smoke step green
- [ ] Hard-refresh apex; confirm `deploy-recovery.js` is present in HTML