### PR TITLE
fix(svelte): cancel queued inspect before touch-tap apply

### DIFF
--- a/packages/svelte/src/lib/inspection/inspection-state.svelte.ts
+++ b/packages/svelte/src/lib/inspection/inspection-state.svelte.ts
@@ -284,8 +284,11 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
       })
     )
       deps.clearAnnouncement();
-    // Non-pointer applies must cancel queued hover (was: reducer boundary cancel).
-    if (source !== "pointer" && source !== "touch") {
+    // Direct applies (keyboard/touch/programmatic) must cancel queued hover /
+    // touch-move inspect frames so a pending rAF cannot override the apply
+    // (e.g. touch tap after a sub-threshold touch move scheduled inspect).
+    // Pointer hover keeps the queue so successive move frames coalesce.
+    if (source !== "pointer") {
       invalidatePointerInspect({ pendingPinned: "preserve" });
     }
     const action = resolveSetInspectionAction({

--- a/packages/svelte/tests/inspection/inspection-state.pin-queue.test.ts
+++ b/packages/svelte/tests/inspection/inspection-state.pin-queue.test.ts
@@ -61,6 +61,39 @@ describe("createInspectionState setInspection", () => {
 
     destroy();
   });
+
+  it("cancels queued inspect before applying a touch tap so rAF cannot override", () => {
+    const model = modelFor(continuousSpec());
+    const { state, flushFrame, destroy } = mountInspectionController({
+      model: () => model,
+      registerEffects: false,
+      deferredFrames: true,
+      inspectConfig: () => ({ mode: "xy", maxDistance: 1e6, pin: false }),
+    });
+    const hover = model.candidates.candidate(0);
+    const tap = model.candidates.candidate(1);
+    if (hover === null || tap === null) throw new Error("expected two candidates");
+    expect(hover.id).not.toBe(tap.id);
+
+    // Small touch move schedules inspect for hover candidate.
+    state.schedulePointerInspect({
+      point: { x: hover.x, y: hover.y },
+      source: "touch",
+      mode: "xy",
+      maxDistance: 1e6,
+    });
+    // Tap applies a different candidate without waiting for the frame.
+    state.setInspection(hitFromCandidate(tap), "touch", "transient", "xy", tap);
+    flushSync();
+    expect(state.inspection?.focus.anchor).toEqual({ x: tap.x, y: tap.y });
+
+    // Stale queued frame must not re-apply hover after the tap.
+    flushFrame();
+    flushSync();
+    expect(state.inspection?.focus.anchor).toEqual({ x: tap.x, y: tap.y });
+
+    destroy();
+  });
 });
 
 describe("createInspectionState pin cycle", () => {


### PR DESCRIPTION
## Summary

Follow-up for unrebutted post-merge Codex P2 on #512.

**Bug:** Small touch moves under the drag threshold still `queue-inspect`. `onPointerUp` then `setInspection(..., \"touch\")` for the tap without cancelling the queue, so a later rAF can re-apply the stale move candidate when `inspect.pin === false`.

**Fix:** `setInspection` cancels pending inspect for every non-`pointer` source (keyboard/touch/programmatic). Pointer hover keeps coalescing. Frame flush already clears queues before apply, so legitimate touch-sourced frames remain fine.

## Tests

```text
cd packages/svelte && bun x vitest run tests/inspection/inspection-state.pin-queue.test.ts --project chromium
# 8 pass — includes touch-tap vs queued hover race
```