### PR TITLE
perf(core): prealloc typed buffers for geom_text glyphs emit

### DIFF
--- a/.changeset/glyphs-prealloc-typed-buffers.md
+++ b/.changeset/glyphs-prealloc-typed-buffers.md
@@ -1,0 +1,11 @@
+---
+"@ggsvelte/core": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+perf: prealloc typed buffers for geom_text glyph emit
+
+Text geometry fills Float32Array/Uint32Array (and string arrays) of length n
+once; dense frames reuse buffers without Float32Array.from double-copy;
+sparse frames compact with slice.

--- a/packages/core/src/pipeline/geometry-glyphs-pack.ts
+++ b/packages/core/src/pipeline/geometry-glyphs-pack.ts
@@ -1,17 +1,18 @@
 /**
- * Pack glyph buffers into a GlyphsBatch.
+ * Pack preallocated glyph buffers into a GlyphsBatch.
+ *
+ * Dense path (kept === n): return typed arrays as-is (no copy). Sparse path:
+ * compact with slice so full-n scratch can be GC'd.
  */
 import type { GlyphsBatch } from "../scene.js";
 
 import type { LayerFrame } from "./types.js";
 import { DEFAULT_TEXT_SIZE } from "./geometry-shared.js";
+import type { EmittedGlyphs } from "./geometry-glyphs-rows.js";
 
 export function packGlyphsBatch(input: {
   frame: LayerFrame;
-  positions: number[];
-  rowIndex: number[];
-  texts: string[];
-  colors: string[];
+  emitted: EmittedGlyphs;
   wantsColors: boolean;
   params: {
     anchor?: "start" | "middle" | "end";
@@ -19,21 +20,39 @@ export function packGlyphsBatch(input: {
     alpha?: number;
   };
 }): GlyphsBatch | null {
-  const { frame, positions, rowIndex, texts, colors, wantsColors, params } = input;
-  if (texts.length === 0) return null;
-  const { binding } = frame;
+  const { frame, emitted, wantsColors, params } = input;
+  const { kept, positions, rowIndex, texts, colors } = emitted;
+  if (kept === 0) return null;
+  const { binding, n } = frame;
+
+  let outPositions: Float32Array;
+  let outRows: Uint32Array;
+  let outTexts: string[];
+  let outColors: string[] | undefined;
+  if (kept === n) {
+    outPositions = positions;
+    outRows = rowIndex;
+    outTexts = texts;
+    outColors = colors ?? undefined;
+  } else {
+    outPositions = positions.slice(0, kept * 2);
+    outRows = rowIndex.slice(0, kept);
+    outTexts = texts.slice(0, kept);
+    outColors = colors === null ? undefined : colors.slice(0, kept);
+  }
+
   const batch: GlyphsBatch = {
     kind: "glyphs",
     layerIndex: binding.index,
     panelIndex: 0,
-    positions: Float32Array.from(positions),
-    rowIndex: Uint32Array.from(rowIndex),
-    texts,
+    positions: outPositions,
+    rowIndex: outRows,
+    texts: outTexts,
     color: binding.color.constant,
     size: params.size ?? DEFAULT_TEXT_SIZE,
     anchor: params.anchor ?? "middle",
     alpha: params.alpha ?? 1,
   };
-  if (wantsColors) batch.colors = colors;
+  if (wantsColors && outColors !== undefined) batch.colors = outColors;
   return batch;
 }

--- a/packages/core/src/pipeline/geometry-glyphs-rows.ts
+++ b/packages/core/src/pipeline/geometry-glyphs-rows.ts
@@ -1,5 +1,9 @@
 /**
- * Per-row text glyph emission into mutable geometry buffers.
+ * Per-row text glyph emission into preallocated geometry buffers.
+ *
+ * Pre-allocates Float32Array / Uint32Array / string arrays of length n (like
+ * geometry-rects-emit / points-collect) so large geom_text frames avoid
+ * dynamic number[] growth + Float32Array.from double-copy.
  */
 import { bandKey } from "../scales/train.js";
 
@@ -8,6 +12,16 @@ import { colorOf } from "./types.js";
 import type { Frame } from "./geometry-shared.js";
 import { positionOf } from "./geometry-shared.js";
 
+export interface EmittedGlyphs {
+  positions: Float32Array;
+  rowIndex: Uint32Array;
+  texts: string[];
+  /** Present only when mapped/scaled colors were requested. */
+  colors: string[] | null;
+  kept: number;
+  removed: number;
+}
+
 export function emitGlyphRows(input: {
   frame: LayerFrame;
   fx: Frame;
@@ -15,13 +29,14 @@ export function emitGlyphRows(input: {
   wantsColors: boolean;
   dx: number;
   dy: number;
-  positions: number[];
-  rowIndex: number[];
-  texts: string[];
-  colors: string[];
-}): number {
-  const { frame, fx, color, wantsColors, dx, dy, positions, rowIndex, texts, colors } = input;
+}): EmittedGlyphs {
+  const { frame, fx, color, wantsColors, dx, dy } = input;
   const { binding, n } = frame;
+  const positions = new Float32Array(n * 2);
+  const rowIndex = new Uint32Array(n);
+  const texts = Array.from<string>({ length: n });
+  const colors = wantsColors && color !== null ? Array.from<string>({ length: n }) : null;
+  let kept = 0;
   let removed = 0;
   for (let row = 0; row < n; row++) {
     const tx = positionOf(fx.xScale, frame.xNumeric, frame.xValues, row, frame.offsetX);
@@ -32,14 +47,17 @@ export function emitGlyphRows(input: {
       removed++;
       continue;
     }
-    positions.push(tx * fx.innerWidth + dx, fx.innerHeight - ty * fx.innerHeight + dy);
-    rowIndex.push(frame.rowIndex[row]!);
-    texts.push(bandKey(label));
-    if (wantsColors && color !== null) {
+    const o = kept * 2;
+    positions[o] = tx * fx.innerWidth + dx;
+    positions[o + 1] = fx.innerHeight - ty * fx.innerHeight + dy;
+    rowIndex[kept] = frame.rowIndex[row]!;
+    texts[kept] = bandKey(label);
+    if (colors !== null) {
       const value =
         frame.colorValues === null ? binding.color.scaledConstant! : frame.colorValues[row]!;
-      colors.push(colorOf(color, value));
+      colors[kept] = colorOf(color!, value);
     }
+    kept++;
   }
-  return removed;
+  return { positions, rowIndex, texts, colors, kept, removed };
 }

--- a/packages/core/src/pipeline/geometry-glyphs.ts
+++ b/packages/core/src/pipeline/geometry-glyphs.ts
@@ -23,24 +23,16 @@ export function glyphsBatch(
     dy?: number;
     alpha?: number;
   };
-  const positions: number[] = [];
-  const rowIndex: number[] = [];
-  const texts: string[] = [];
-  const colors: string[] = [];
   const wantsColors =
     color !== null && (frame.colorValues !== null || binding.color.scaledConstant !== null);
-  const removed = emitGlyphRows({
+  const emitted = emitGlyphRows({
     frame,
     fx,
     color,
     wantsColors,
     dx: params.dx ?? 0,
     dy: params.dy ?? 0,
-    positions,
-    rowIndex,
-    texts,
-    colors,
   });
-  removedWarning(removed, binding.index, warnings);
-  return packGlyphsBatch({ frame, positions, rowIndex, texts, colors, wantsColors, params });
+  removedWarning(emitted.removed, binding.index, warnings);
+  return packGlyphsBatch({ frame, emitted, wantsColors, params });
 }

--- a/packages/core/tests/geometry-glyphs-prealloc.test.ts
+++ b/packages/core/tests/geometry-glyphs-prealloc.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Glyph emit/pack prealloc: typed buffers with dense-as-is / sparse-slice,
+ * matching rects/points. Characterization of positions, rowIndex, texts,
+ * colors, and empty → null.
+ */
+import { fromAny } from "@total-typescript/shoehorn";
+import { describe, expect, it } from "bun:test";
+
+import { emitGlyphRows } from "../src/pipeline/geometry-glyphs-rows.ts";
+import { packGlyphsBatch } from "../src/pipeline/geometry-glyphs-pack.ts";
+import type { Frame } from "../src/pipeline/geometry-shared.ts";
+import type { LayerFrame } from "../src/pipeline/types.ts";
+
+function linearScale(): Frame["xScale"] {
+  return fromAny({
+    type: "linear",
+    normalize: (v: number) => v,
+    normalizeTransformed: (v: number) => v,
+  });
+}
+
+function fx100(): Frame {
+  return {
+    innerWidth: 100,
+    innerHeight: 100,
+    xScale: linearScale(),
+    yScale: linearScale(),
+  };
+}
+
+function textFrame(input: {
+  n: number;
+  x: Float64Array;
+  y: Float64Array;
+  labels: (string | null)[];
+  rowIndex?: Uint32Array;
+  colorValues?: (string | null)[] | null;
+}): LayerFrame {
+  const { n, x, y, labels } = input;
+  return fromAny<LayerFrame>({
+    n,
+    xNumeric: x,
+    yNumeric: y,
+    xValues: null,
+    yValues: null,
+    labelValues: labels,
+    rowIndex: input.rowIndex ?? Uint32Array.from({ length: n }, (_, i) => i),
+    colorValues: input.colorValues ?? null,
+    offsetX: null,
+    offsetY: null,
+    binding: {
+      index: 0,
+      labelConstant: null,
+      color: { constant: "#111", scaledConstant: null },
+    },
+  });
+}
+
+describe("emitGlyphRows prealloc", () => {
+  it("dense path fills typed buffers for every row", () => {
+    const frame = textFrame({
+      n: 2,
+      x: Float64Array.of(0.25, 0.75),
+      y: Float64Array.of(0.1, 0.9),
+      labels: ["a", "b"],
+    });
+    const emitted = emitGlyphRows({
+      frame,
+      fx: fx100(),
+      color: null,
+      wantsColors: false,
+      dx: 4,
+      dy: -2,
+    });
+    expect(emitted.kept).toBe(2);
+    expect(emitted.removed).toBe(0);
+    expect(emitted.positions).toBeInstanceOf(Float32Array);
+    expect(emitted.rowIndex).toBeInstanceOf(Uint32Array);
+    // Capacity n; dense pack will reuse without copy.
+    expect(emitted.positions.length).toBe(4);
+    expect(emitted.rowIndex.length).toBe(2);
+    expect(emitted.texts[0]).toBe("a");
+    expect(emitted.texts[1]).toBe("b");
+    expect(emitted.colors).toBeNull();
+    // x = t * width + dx; y = height - t * height + dy
+    expect(emitted.positions[0]).toBeCloseTo(0.25 * 100 + 4);
+    expect(emitted.positions[1]).toBeCloseTo(100 - 0.1 * 100 - 2);
+    expect(emitted.positions[2]).toBeCloseTo(0.75 * 100 + 4);
+    expect(emitted.positions[3]).toBeCloseTo(100 - 0.9 * 100 - 2);
+  });
+
+  it("skips null labels and non-finite positions (sparse kept)", () => {
+    const frame = textFrame({
+      n: 3,
+      x: Float64Array.of(0.2, Number.NaN, 0.8),
+      y: Float64Array.of(0.5, 0.5, 0.5),
+      labels: ["keep", "drop-nan", null],
+      rowIndex: Uint32Array.of(10, 11, 12),
+    });
+    // Fix third label to a keep so only middle drops for NaN; add fourth? n=3 with last null.
+    // Rows: 0 keep, 1 NaN x drop, 2 null label drop → kept 1
+    const emitted = emitGlyphRows({
+      frame,
+      fx: fx100(),
+      color: null,
+      wantsColors: false,
+      dx: 0,
+      dy: 0,
+    });
+    expect(emitted.kept).toBe(1);
+    expect(emitted.removed).toBe(2);
+    expect(emitted.rowIndex[0]).toBe(10);
+    expect(emitted.texts[0]).toBe("keep");
+  });
+
+  it("writes mapped colors only when wantsColors", () => {
+    const frame = textFrame({
+      n: 2,
+      x: Float64Array.of(0, 1),
+      y: Float64Array.of(0, 1),
+      labels: ["a", "b"],
+      colorValues: ["red", "blue"],
+    });
+    const resolved = {
+      scale: {
+        colorOf: (v: unknown) => `c:${String(v)}`,
+        naValue: null,
+        unknownValue: "#999",
+      },
+    };
+    const emitted = emitGlyphRows({
+      frame,
+      fx: fx100(),
+      color: fromAny(resolved),
+      wantsColors: true,
+      dx: 0,
+      dy: 0,
+    });
+    expect(emitted.colors).not.toBeNull();
+    expect(emitted.colors![0]).toBe("c:red");
+    expect(emitted.colors![1]).toBe("c:blue");
+  });
+});
+
+describe("packGlyphsBatch dense/sparse", () => {
+  it("dense path reuses preallocated typed arrays without shrinking", () => {
+    const frame = textFrame({
+      n: 2,
+      x: Float64Array.of(0, 1),
+      y: Float64Array.of(0, 1),
+      labels: ["a", "b"],
+    });
+    const emitted = emitGlyphRows({
+      frame,
+      fx: fx100(),
+      color: null,
+      wantsColors: false,
+      dx: 0,
+      dy: 0,
+    });
+    const batch = packGlyphsBatch({
+      frame,
+      emitted,
+      wantsColors: false,
+      params: { size: 14, anchor: "start" },
+    });
+    expect(batch).not.toBeNull();
+    expect(batch!.positions).toBe(emitted.positions);
+    expect(batch!.rowIndex).toBe(emitted.rowIndex);
+    expect(batch!.texts).toBe(emitted.texts);
+    expect(batch!.texts).toEqual(["a", "b"]);
+    expect(batch!.size).toBe(14);
+    expect(batch!.anchor).toBe("start");
+  });
+
+  it("sparse path compacts buffers to kept length", () => {
+    const frame = textFrame({
+      n: 3,
+      x: Float64Array.of(0.1, Number.NaN, 0.9),
+      y: Float64Array.of(0.2, 0.3, 0.4),
+      labels: ["left", "mid", "right"],
+      rowIndex: Uint32Array.of(1, 2, 3),
+    });
+    const emitted = emitGlyphRows({
+      frame,
+      fx: fx100(),
+      color: null,
+      wantsColors: false,
+      dx: 0,
+      dy: 0,
+    });
+    expect(emitted.kept).toBe(2);
+    const batch = packGlyphsBatch({
+      frame,
+      emitted,
+      wantsColors: false,
+      params: {},
+    });
+    expect(batch).not.toBeNull();
+    expect(batch!.positions.length).toBe(4);
+    expect(batch!.rowIndex.length).toBe(2);
+    expect(batch!.texts).toEqual(["left", "right"]);
+    expect([...batch!.rowIndex]).toEqual([1, 3]);
+    // Compact copy, not the full-n scratch buffer.
+    expect(batch!.positions).not.toBe(emitted.positions);
+    expect(batch!.positions.byteLength).toBe(4 * 4);
+  });
+
+  it("returns null when every row is removed", () => {
+    const frame = textFrame({
+      n: 2,
+      x: Float64Array.of(Number.NaN, Number.NaN),
+      y: Float64Array.of(0, 0),
+      labels: ["a", "b"],
+    });
+    const emitted = emitGlyphRows({
+      frame,
+      fx: fx100(),
+      color: null,
+      wantsColors: false,
+      dx: 0,
+      dy: 0,
+    });
+    expect(emitted.kept).toBe(0);
+    expect(packGlyphsBatch({ frame, emitted, wantsColors: false, params: {} })).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

`geom_text` glyph emit used dynamic `number[]` / `string[]` push growth plus `Float32Array.from` / `Uint32Array.from` double-copy. Points and rects already preallocate typed buffers.

- **Audit target:** `packages/core` (issue #555 from prior `/bigo-maintain`)
- **Pattern:** #9 allocation in hot path
- **Before → after:** push + from double-copy → prealloc `Float32Array(n*2)` / `Uint32Array(n)` / string arrays; dense reuses buffers; sparse `slice` to kept
- **What n is:** text mark row count (`frame.n`)

Codex plan review: require sparse/color/empty tests; emit owns allocation; avoid colors alloc when not wanted — all done.

Closes #555.

## Test plan

- [x] `bun test packages/core/tests/geometry-glyphs-prealloc.test.ts`
- [x] `bun test packages/core/tests/pipeline-m1/geoms.test.ts` (text geom + determinism)
- [x] strata + render-svg golden green
- [ ] CI unit suite on PR
