### PR TITLE
perf(core): prealloc typed buffers for rule segment emit

### DIFF
--- a/.changeset/segments-prealloc-typed-buffers.md
+++ b/.changeset/segments-prealloc-typed-buffers.md
@@ -1,0 +1,12 @@
+---
+"@ggsvelte/core": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+perf: prealloc typed buffers for rule segment emit
+
+Data and annotation rule segments fill Float32Array/Uint32Array sized to
+max mark count; dense reuses buffers, sparse compact slices — no number[]
+
+- Float32Array.from double-copy.

--- a/packages/core/src/pipeline/geometry-segments-data.ts
+++ b/packages/core/src/pipeline/geometry-segments-data.ts
@@ -5,6 +5,7 @@ import type { LayerFrame, ResolvedColorScale } from "./types.js";
 import { colorOf } from "./types.js";
 import type { Frame } from "./geometry-shared.js";
 import { positionOf } from "./geometry-shared.js";
+import type { SegmentEmitBuffers } from "./geometry-segments-emit.js";
 
 export function emitDataSegments(input: {
   frame: LayerFrame;
@@ -13,23 +14,14 @@ export function emitDataSegments(input: {
   wantsColors: boolean;
   pushVertical: (t: number | undefined, row: number) => void;
   pushHorizontal: (t: number | undefined, row: number) => void;
-  rowIndex: number[];
-  perSegmentColors: string[];
+  buffers: SegmentEmitBuffers;
+  strokes: string[] | null;
 }): void {
-  const {
-    frame,
-    fx,
-    color,
-    wantsColors,
-    pushVertical,
-    pushHorizontal,
-    rowIndex,
-    perSegmentColors,
-  } = input;
+  const { frame, fx, color, wantsColors, pushVertical, pushHorizontal, buffers, strokes } = input;
   const { binding } = frame;
 
   for (let row = 0; row < frame.n; row++) {
-    const before = rowIndex.length;
+    const before = buffers.kept;
     if (binding.ruleForm === "vertical") {
       pushVertical(positionOf(fx.xScale, frame.xNumeric, frame.xValues, row), frame.rowIndex[row]!);
     } else {
@@ -38,10 +30,10 @@ export function emitDataSegments(input: {
         frame.rowIndex[row]!,
       );
     }
-    if (wantsColors && color !== null && rowIndex.length > before) {
+    if (wantsColors && color !== null && strokes !== null && buffers.kept > before) {
       const value =
         frame.colorValues === null ? binding.color.scaledConstant! : frame.colorValues[row]!;
-      perSegmentColors.push(colorOf(color, value));
+      strokes[before] = colorOf(color, value);
     }
   }
 }

--- a/packages/core/src/pipeline/geometry-segments-emit.ts
+++ b/packages/core/src/pipeline/geometry-segments-emit.ts
@@ -1,36 +1,76 @@
 /**
- * Push vertical/horizontal rule segments into mutable geometry buffers.
+ * Push vertical/horizontal rule segments into preallocated typed buffers.
+ *
+ * Capacity is sized once by the caller (data: frame.n; annotation: intercept
+ * count). Dense keep reuses buffers; sparse compact is handled after emit.
  */
 import type { Frame } from "./geometry-shared.js";
 
-export function createSegmentEmitters(input: {
-  fx: Frame;
-  segments: number[];
-  rowIndex: number[];
-  onRemoved: () => void;
-}): {
+export interface SegmentEmitBuffers {
+  segments: Float32Array;
+  rowIndex: Uint32Array;
+  kept: number;
+  removed: number;
+}
+
+export function createSegmentEmitters(input: { fx: Frame; buffers: SegmentEmitBuffers }): {
   pushVertical: (t: number | undefined, row: number) => void;
   pushHorizontal: (t: number | undefined, row: number) => void;
 } {
-  const { fx, segments, rowIndex, onRemoved } = input;
+  const { fx, buffers } = input;
   return {
     pushVertical(t, row) {
       if (t === undefined || Number.isNaN(t)) {
-        onRemoved();
+        buffers.removed++;
         return;
       }
       const x = t * fx.innerWidth;
-      segments.push(x, 0, x, fx.innerHeight);
-      rowIndex.push(row);
+      const o = buffers.kept * 4;
+      buffers.segments[o] = x;
+      buffers.segments[o + 1] = 0;
+      buffers.segments[o + 2] = x;
+      buffers.segments[o + 3] = fx.innerHeight;
+      buffers.rowIndex[buffers.kept] = row;
+      buffers.kept++;
     },
     pushHorizontal(t, row) {
       if (t === undefined || Number.isNaN(t)) {
-        onRemoved();
+        buffers.removed++;
         return;
       }
       const y = fx.innerHeight - t * fx.innerHeight;
-      segments.push(0, y, fx.innerWidth, y);
-      rowIndex.push(row);
+      const o = buffers.kept * 4;
+      buffers.segments[o] = 0;
+      buffers.segments[o + 1] = y;
+      buffers.segments[o + 2] = fx.innerWidth;
+      buffers.segments[o + 3] = y;
+      buffers.rowIndex[buffers.kept] = row;
+      buffers.kept++;
     },
+  };
+}
+
+/** Compact full-capacity scratch to exact kept length (or empty arrays). */
+export function compactSegmentBuffers(
+  buffers: SegmentEmitBuffers,
+  capacity: number,
+): { segments: Float32Array; rowIndex: Uint32Array; kept: number; removed: number } {
+  const { kept, removed, segments, rowIndex } = buffers;
+  if (kept === 0) {
+    return {
+      segments: new Float32Array(0),
+      rowIndex: new Uint32Array(0),
+      kept: 0,
+      removed,
+    };
+  }
+  if (kept === capacity) {
+    return { segments, rowIndex, kept, removed };
+  }
+  return {
+    segments: segments.subarray(0, kept * 4).slice(),
+    rowIndex: rowIndex.subarray(0, kept).slice(),
+    kept,
+    removed,
   };
 }

--- a/packages/core/src/pipeline/geometry-segments-pack.ts
+++ b/packages/core/src/pipeline/geometry-segments-pack.ts
@@ -1,5 +1,7 @@
 /**
- * Pack mutable segment buffers into a SegmentsBatch.
+ * Pack preallocated segment buffers into a SegmentsBatch.
+ *
+ * Callers pass already-compact typed arrays (dense as-is or sparse-sliced).
  */
 import type { SegmentsBatch } from "../scene.js";
 
@@ -8,12 +10,12 @@ import { DEFAULT_RULE_LINEWIDTH } from "./geometry-shared.js";
 
 export function packSegmentsBatch(input: {
   frame: LayerFrame;
-  segments: number[];
-  rowIndex: number[];
-  perSegmentColors: string[];
+  segments: Float32Array;
+  rowIndex: Uint32Array;
+  strokes: string[] | null;
   wantsColors: boolean;
 }): SegmentsBatch | null {
-  const { frame, segments, rowIndex, perSegmentColors, wantsColors } = input;
+  const { frame, segments, rowIndex, strokes, wantsColors } = input;
   if (rowIndex.length === 0) return null;
   const { binding } = frame;
   const params = (binding.layer.params ?? {}) as { linewidth?: number; alpha?: number };
@@ -21,12 +23,14 @@ export function packSegmentsBatch(input: {
     kind: "segments",
     layerIndex: binding.index,
     panelIndex: 0,
-    segments: Float32Array.from(segments),
-    rowIndex: Uint32Array.from(rowIndex),
+    segments,
+    rowIndex,
     stroke: binding.color.constant,
     linewidth: params.linewidth ?? DEFAULT_RULE_LINEWIDTH,
     alpha: params.alpha ?? 1,
   };
-  if (wantsColors && binding.ruleForm !== "annotation") batch.strokes = perSegmentColors;
+  if (wantsColors && binding.ruleForm !== "annotation" && strokes !== null) {
+    batch.strokes = strokes;
+  }
   return batch;
 }

--- a/packages/core/src/pipeline/geometry-segments.ts
+++ b/packages/core/src/pipeline/geometry-segments.ts
@@ -1,5 +1,8 @@
 /**
  * Rule segment geometry batch builder (annotation intercepts + data-driven).
+ *
+ * Pre-allocates Float32Array/Uint32Array to the max mark count (data: n,
+ * annotation: intercept count), then densifies/compacts like glyphs/rects.
  */
 import type { SegmentsBatch } from "../scene.js";
 
@@ -8,7 +11,11 @@ import type { Frame } from "./geometry-shared.js";
 import { removedWarning } from "./geometry-shared.js";
 import { emitAnnotationSegments } from "./geometry-segments-annotation.js";
 import { emitDataSegments } from "./geometry-segments-data.js";
-import { createSegmentEmitters } from "./geometry-segments-emit.js";
+import {
+  compactSegmentBuffers,
+  createSegmentEmitters,
+  type SegmentEmitBuffers,
+} from "./geometry-segments-emit.js";
 import { packSegmentsBatch } from "./geometry-segments-pack.js";
 
 export function segmentsBatch(
@@ -18,21 +25,26 @@ export function segmentsBatch(
   warnings: PipelineWarning[],
 ): SegmentsBatch | null {
   const { binding } = frame;
-  const segments: number[] = [];
-  const rowIndex: number[] = [];
-  const perSegmentColors: string[] = [];
   const wantsColors =
     color !== null && (frame.colorValues !== null || binding.color.scaledConstant !== null);
-  let removed = 0;
 
-  const { pushVertical, pushHorizontal } = createSegmentEmitters({
-    fx,
-    segments,
-    rowIndex,
-    onRemoved: () => {
-      removed++;
-    },
-  });
+  const capacity =
+    binding.ruleForm === "annotation"
+      ? frame.xIntercepts.length + frame.yIntercepts.length
+      : frame.n;
+
+  const buffers: SegmentEmitBuffers = {
+    segments: new Float32Array(capacity * 4),
+    rowIndex: new Uint32Array(capacity),
+    kept: 0,
+    removed: 0,
+  };
+  const strokes =
+    wantsColors && binding.ruleForm !== "annotation"
+      ? Array.from<string>({ length: capacity })
+      : null;
+
+  const { pushVertical, pushHorizontal } = createSegmentEmitters({ fx, buffers });
 
   if (binding.ruleForm === "annotation") {
     emitAnnotationSegments({ frame, fx, pushVertical, pushHorizontal });
@@ -44,10 +56,27 @@ export function segmentsBatch(
       wantsColors,
       pushVertical,
       pushHorizontal,
-      rowIndex,
-      perSegmentColors,
+      buffers,
+      strokes,
     });
   }
-  removedWarning(removed, binding.index, warnings);
-  return packSegmentsBatch({ frame, segments, rowIndex, perSegmentColors, wantsColors });
+
+  removedWarning(buffers.removed, binding.index, warnings);
+  const compact = compactSegmentBuffers(buffers, capacity);
+  const outStrokes =
+    strokes === null
+      ? null
+      : compact.kept === 0
+        ? []
+        : compact.kept === capacity
+          ? strokes
+          : strokes.slice(0, compact.kept);
+
+  return packSegmentsBatch({
+    frame,
+    segments: compact.segments,
+    rowIndex: compact.rowIndex,
+    strokes: outStrokes,
+    wantsColors,
+  });
 }

--- a/packages/core/tests/geometry-segments-prealloc.test.ts
+++ b/packages/core/tests/geometry-segments-prealloc.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Rule segment emit/pack prealloc: typed buffers sized to capacity,
+ * dense reuse / sparse compact (like glyphs/rects).
+ */
+import { fromAny, fromPartial } from "@total-typescript/shoehorn";
+import { describe, expect, it } from "bun:test";
+
+import {
+  compactSegmentBuffers,
+  createSegmentEmitters,
+  type SegmentEmitBuffers,
+} from "../src/pipeline/geometry-segments-emit.ts";
+import { packSegmentsBatch } from "../src/pipeline/geometry-segments-pack.ts";
+import type { Frame } from "../src/pipeline/geometry-shared.ts";
+import type { LayerFrame } from "../src/pipeline/types.ts";
+import { NO_ROW } from "../src/pipeline/types.ts";
+
+function fx(w = 100, h = 50): Frame {
+  return fromPartial<Frame>({
+    innerWidth: w,
+    innerHeight: h,
+    xScale: { type: "linear", normalize: (v: number) => v },
+    yScale: { type: "linear", normalize: (v: number) => v },
+  });
+}
+
+function emptyBuffers(capacity: number): SegmentEmitBuffers {
+  return {
+    segments: new Float32Array(capacity * 4),
+    rowIndex: new Uint32Array(capacity),
+    kept: 0,
+    removed: 0,
+  };
+}
+
+describe("createSegmentEmitters prealloc", () => {
+  it("writes vertical and horizontal segments into typed slots", () => {
+    const buffers = emptyBuffers(2);
+    const { pushVertical, pushHorizontal } = createSegmentEmitters({ fx: fx(), buffers });
+    pushVertical(0.25, 3);
+    pushHorizontal(0.5, 7);
+    expect(buffers.kept).toBe(2);
+    expect(buffers.removed).toBe(0);
+    // vertical at x=25: (25,0)-(25,50)
+    expect([...buffers.segments.subarray(0, 4)]).toEqual([25, 0, 25, 50]);
+    // horizontal at y=25 (height - 0.5*height): (0,25)-(100,25)
+    expect([...buffers.segments.subarray(4, 8)]).toEqual([0, 25, 100, 25]);
+    expect([...buffers.rowIndex.subarray(0, 2)]).toEqual([3, 7]);
+  });
+
+  it("counts removed for NaN / undefined without writing", () => {
+    const buffers = emptyBuffers(2);
+    const { pushVertical } = createSegmentEmitters({ fx: fx(), buffers });
+    pushVertical(Number.NaN, 1);
+    pushVertical(undefined, 2);
+    expect(buffers.kept).toBe(0);
+    expect(buffers.removed).toBe(2);
+  });
+});
+
+describe("compactSegmentBuffers", () => {
+  it("dense path returns the same typed arrays", () => {
+    const buffers = emptyBuffers(1);
+    const { pushVertical } = createSegmentEmitters({ fx: fx(), buffers });
+    pushVertical(0.1, 0);
+    const compact = compactSegmentBuffers(buffers, 1);
+    expect(compact.kept).toBe(1);
+    expect(compact.segments).toBe(buffers.segments);
+    expect(compact.rowIndex).toBe(buffers.rowIndex);
+  });
+
+  it("sparse path slices to kept length", () => {
+    const buffers = emptyBuffers(3);
+    const { pushVertical } = createSegmentEmitters({ fx: fx(), buffers });
+    pushVertical(0.1, 1);
+    pushVertical(Number.NaN, 2);
+    pushVertical(0.9, 3);
+    const compact = compactSegmentBuffers(buffers, 3);
+    expect(compact.kept).toBe(2);
+    expect(compact.removed).toBe(1);
+    expect(compact.segments.length).toBe(8);
+    expect(compact.rowIndex.length).toBe(2);
+    expect([...compact.rowIndex]).toEqual([1, 3]);
+    expect(compact.segments).not.toBe(buffers.segments);
+  });
+
+  it("empty path returns zero-length typed arrays", () => {
+    const compact = compactSegmentBuffers(emptyBuffers(4), 4);
+    expect(compact.kept).toBe(0);
+    expect(compact.segments.length).toBe(0);
+    expect(compact.rowIndex.length).toBe(0);
+  });
+});
+
+describe("packSegmentsBatch", () => {
+  it("builds a SegmentsBatch from pre-compacted typed arrays", () => {
+    const frame = fromAny<LayerFrame>({
+      binding: {
+        index: 2,
+        color: { constant: "#abc" },
+        ruleForm: "vertical",
+        layer: { params: { linewidth: 2, alpha: 0.5 } },
+      },
+    });
+    const segments = Float32Array.of(10, 0, 10, 50);
+    const rowIndex = Uint32Array.of(NO_ROW);
+    const batch = packSegmentsBatch({
+      frame,
+      segments,
+      rowIndex,
+      strokes: null,
+      wantsColors: false,
+    });
+    expect(batch).not.toBeNull();
+    expect(batch!.segments).toBe(segments);
+    expect(batch!.rowIndex).toBe(rowIndex);
+    expect(batch!.linewidth).toBe(2);
+    expect(batch!.alpha).toBe(0.5);
+    expect(batch!.stroke).toBe("#abc");
+  });
+
+  it("returns null when no segments", () => {
+    const frame = fromAny<LayerFrame>({
+      binding: { index: 0, color: { constant: null }, ruleForm: "vertical", layer: {} },
+    });
+    expect(
+      packSegmentsBatch({
+        frame,
+        segments: new Float32Array(0),
+        rowIndex: new Uint32Array(0),
+        strokes: null,
+        wantsColors: false,
+      }),
+    ).toBeNull();
+  });
+});

--- a/packages/core/tests/pipeline-geometry/errorbar-batch.test.ts
+++ b/packages/core/tests/pipeline-geometry/errorbar-batch.test.ts
@@ -107,17 +107,17 @@ describe("packSegmentsBatch", () => {
     expect(
       packSegmentsBatch({
         frame,
-        segments: [],
-        rowIndex: [],
-        perSegmentColors: [],
+        segments: new Float32Array(0),
+        rowIndex: new Uint32Array(0),
+        strokes: null,
         wantsColors: false,
       }),
     ).toBeNull();
     const batch = packSegmentsBatch({
       frame,
-      segments: [0, 0, 10, 10],
-      rowIndex: [3],
-      perSegmentColors: [],
+      segments: Float32Array.of(0, 0, 10, 10),
+      rowIndex: Uint32Array.of(3),
+      strokes: null,
       wantsColors: false,
     });
     expect(batch?.kind).toBe("segments");


### PR DESCRIPTION
## Summary

Rule segment geometry (`geom_rule` annotation + data-driven) used dynamic `number[]` push plus `Float32Array.from` / `Uint32Array.from` double-copy. Glyphs/rects/points already preallocate typed buffers.

- **Audit target:** `packages/core` pipeline geometry (after #555 glyphs landed via #564)
- **Pattern:** #9 allocation in hot path
- **Before → after:** push + from → prealloc `Float32Array(capacity*4)` / `Uint32Array(capacity)`; dense reuses; sparse `subarray().slice()`
- **What capacity is:** data form `frame.n`; annotation form intercept count

Also closes duplicate attempt #570 (glyphs) which conflicted with #564 already on main.

## Test plan

- [x] `bun test packages/core/tests/geometry-segments-prealloc.test.ts`
- [x] `bun test packages/core/tests/pipeline-m1/geoms.test.ts` (rule forms)
- [x] `pipeline-geometry` suite including updated packSegmentsBatch test
- [ ] CI unit suite on PR
