### PR TITLE
perf(core): prealloc typed buffers for errorbar segment emit

### DIFF
--- a/.changeset/errorbar-prealloc-typed-buffers.md
+++ b/.changeset/errorbar-prealloc-typed-buffers.md
@@ -1,0 +1,11 @@
+---
+"@ggsvelte/core": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+perf: prealloc typed buffers for errorbar segment emit
+
+Errorbars fill Float32Array/Uint32Array sized to 3 segments per row;
+dense reuses capacity-n buffers, sparse slices — no number[] +
+Float32Array.from double-copy.

--- a/packages/core/src/pipeline/geometry-errorbar-rows.ts
+++ b/packages/core/src/pipeline/geometry-errorbar-rows.ts
@@ -1,10 +1,21 @@
 /**
- * Per-row errorbar segment emission (stem + caps).
+ * Per-row errorbar segment emission (stem + caps) into preallocated buffers.
+ *
+ * Each kept row emits 3 segments (12 floats, 3 row ids). Capacity is frame.n;
+ * dense reuses typed arrays, sparse compact slices (like rule segments/glyphs).
  */
 import type { LayerFrame, ResolvedColorScale } from "./types.js";
 import { colorOf } from "./types.js";
 import type { Frame } from "./geometry-shared.js";
 import { positionOf } from "./geometry-shared.js";
+
+export interface EmittedErrorbars {
+  segments: Float32Array;
+  rowIndex: Uint32Array;
+  strokes: string[] | null;
+  keptSegments: number;
+  removed: number;
+}
 
 export function emitErrorbarRows(input: {
   frame: LayerFrame;
@@ -12,13 +23,16 @@ export function emitErrorbarRows(input: {
   color: ResolvedColorScale | null;
   wantsColors: boolean;
   xSpanOf: (row: number, center: number) => readonly [number, number];
-  segments: number[];
-  rowIndex: number[];
-  strokes: string[];
-}): number {
-  const { frame, fx, color, wantsColors, xSpanOf, segments, rowIndex, strokes } = input;
+}): EmittedErrorbars {
+  const { frame, fx, color, wantsColors, xSpanOf } = input;
   const { binding, n } = frame;
+  // 3 segments × 4 floats per kept row; 3 row ids per kept row.
+  const segments = new Float32Array(n * 12);
+  const rowIndex = new Uint32Array(n * 3);
+  const strokes = wantsColors && color !== null ? Array.from<string>({ length: n * 3 }) : null;
+  let kept = 0; // kept *rows*
   let removed = 0;
+
   for (let row = 0; row < n; row++) {
     const tx = positionOf(fx.xScale, frame.xNumeric, frame.xValues, row);
     const t0 = fx.yScale.type === "band" ? NaN : fx.yScale.normalizeTransformed(frame.ymin![row]!);
@@ -43,15 +57,53 @@ export function emitErrorbarRows(input: {
     const capX1 = cap1 * fx.innerWidth;
     const y0 = fx.innerHeight - t0 * fx.innerHeight;
     const y1 = fx.innerHeight - t1 * fx.innerHeight;
-    segments.push(cx, y0, cx, y1, capX0, y0, capX1, y0, capX0, y1, capX1, y1);
+    const so = kept * 12;
+    segments[so] = cx;
+    segments[so + 1] = y0;
+    segments[so + 2] = cx;
+    segments[so + 3] = y1;
+    segments[so + 4] = capX0;
+    segments[so + 5] = y0;
+    segments[so + 6] = capX1;
+    segments[so + 7] = y0;
+    segments[so + 8] = capX0;
+    segments[so + 9] = y1;
+    segments[so + 10] = capX1;
+    segments[so + 11] = y1;
     const src = frame.rowIndex[row]!;
-    rowIndex.push(src, src, src);
-    if (wantsColors && color !== null) {
+    const ro = kept * 3;
+    rowIndex[ro] = src;
+    rowIndex[ro + 1] = src;
+    rowIndex[ro + 2] = src;
+    if (strokes !== null) {
       const value =
         frame.colorValues === null ? binding.color.scaledConstant! : frame.colorValues[row]!;
-      const c = colorOf(color, value);
-      strokes.push(c, c, c);
+      const c = colorOf(color!, value);
+      strokes[ro] = c;
+      strokes[ro + 1] = c;
+      strokes[ro + 2] = c;
     }
+    kept++;
   }
-  return removed;
+
+  const keptSegments = kept * 3;
+  if (kept === 0) {
+    return {
+      segments: new Float32Array(0),
+      rowIndex: new Uint32Array(0),
+      strokes: wantsColors ? [] : null,
+      keptSegments: 0,
+      removed,
+    };
+  }
+  if (kept === n) {
+    return { segments, rowIndex, strokes, keptSegments, removed };
+  }
+  return {
+    segments: segments.subarray(0, kept * 12).slice(),
+    rowIndex: rowIndex.subarray(0, keptSegments).slice(),
+    strokes: strokes === null ? null : strokes.slice(0, keptSegments),
+    keptSegments,
+    removed,
+  };
 }

--- a/packages/core/src/pipeline/geometry-errorbar.ts
+++ b/packages/core/src/pipeline/geometry-errorbar.ts
@@ -1,5 +1,8 @@
 /**
  * Errorbar geometry: vertical range plus caps.
+ *
+ * Emit preallocates typed segment buffers (3 segments per kept row); pack
+ * reuses dense buffers and never Float32Array.from a number[] scratch list.
  */
 import type { ErrorbarParams } from "@ggsvelte/spec";
 
@@ -28,32 +31,26 @@ export function errorbarBatch(
 
   const xSpanOf = makeErrorbarXSpan(frame, fx, widthParam);
 
-  const segments: number[] = [];
-  const rowIndex: number[] = [];
-  const strokes: string[] = [];
-  const removed = emitErrorbarRows({
+  const emitted = emitErrorbarRows({
     frame,
     fx,
     color,
     wantsColors,
     xSpanOf,
-    segments,
-    rowIndex,
-    strokes,
   });
-  removedWarning(removed, binding.index, warnings);
-  if (rowIndex.length === 0) return null;
+  removedWarning(emitted.removed, binding.index, warnings);
+  if (emitted.keptSegments === 0) return null;
 
   const batch: SegmentsBatch = {
     kind: "segments",
     layerIndex: binding.index,
     panelIndex: 0,
-    segments: Float32Array.from(segments),
-    rowIndex: Uint32Array.from(rowIndex),
+    segments: emitted.segments,
+    rowIndex: emitted.rowIndex,
     stroke: binding.color.constant,
     linewidth: params.linewidth ?? DEFAULT_RULE_LINEWIDTH,
     alpha: params.alpha ?? 1,
   };
-  if (wantsColors) batch.strokes = strokes;
+  if (wantsColors && emitted.strokes !== null) batch.strokes = emitted.strokes;
   return batch;
 }

--- a/packages/core/tests/geometry-errorbar-prealloc.test.ts
+++ b/packages/core/tests/geometry-errorbar-prealloc.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Errorbar emit prealloc: 3 segments per kept row into typed buffers;
+ * dense reuses capacity-n arrays, sparse slices.
+ */
+import { fromAny, fromPartial } from "@total-typescript/shoehorn";
+import { describe, expect, it } from "bun:test";
+
+import { emitErrorbarRows } from "../src/pipeline/geometry-errorbar-rows.ts";
+import type { Frame } from "../src/pipeline/geometry-shared.ts";
+import type { LayerFrame } from "../src/pipeline/types.ts";
+
+function fx(w = 100, h = 100): Frame {
+  return fromPartial<Frame>({
+    innerWidth: w,
+    innerHeight: h,
+    xScale: {
+      type: "linear",
+      normalize: (v: number) => v,
+      normalizeTransformed: (v: number) => v,
+    },
+    yScale: {
+      type: "linear",
+      normalize: (v: number) => v,
+      normalizeTransformed: (v: number) => v,
+    },
+  });
+}
+
+function frameOf(input: {
+  n: number;
+  x: Float64Array;
+  ymin: Float64Array;
+  ymax: Float64Array;
+  rowIndex?: Uint32Array;
+  colorValues?: string[] | null;
+}): LayerFrame {
+  return fromAny<LayerFrame>({
+    n: input.n,
+    xNumeric: input.x,
+    xValues: null,
+    yNumeric: null,
+    yValues: null,
+    ymin: input.ymin,
+    ymax: input.ymax,
+    rowIndex: input.rowIndex ?? Uint32Array.from({ length: input.n }, (_, i) => i + 1),
+    colorValues: input.colorValues ?? null,
+    binding: {
+      index: 0,
+      color: { constant: "#000", scaledConstant: null },
+    },
+  });
+}
+
+const fullSpan = (_row: number, center: number): readonly [number, number] => [
+  center - 0.1,
+  center + 0.1,
+];
+
+describe("emitErrorbarRows prealloc", () => {
+  it("dense path emits 3 segments per row and reuses full capacity", () => {
+    const frame = frameOf({
+      n: 2,
+      x: Float64Array.of(0.25, 0.75),
+      ymin: Float64Array.of(0.2, 0.3),
+      ymax: Float64Array.of(0.8, 0.9),
+    });
+    const emitted = emitErrorbarRows({
+      frame,
+      fx: fx(),
+      color: null,
+      wantsColors: false,
+      xSpanOf: fullSpan,
+    });
+    expect(emitted.removed).toBe(0);
+    expect(emitted.keptSegments).toBe(6);
+    expect(emitted.segments).toBeInstanceOf(Float32Array);
+    expect(emitted.rowIndex).toBeInstanceOf(Uint32Array);
+    expect(emitted.segments.length).toBe(24); // 2 rows × 12 floats
+    expect(emitted.rowIndex.length).toBe(6);
+    expect([...emitted.rowIndex]).toEqual([1, 1, 1, 2, 2, 2]);
+    // Stem of first bar: x=25, y from 80→20 (height - t*height)
+    expect(emitted.segments[0]).toBeCloseTo(25);
+    expect(emitted.segments[1]).toBeCloseTo(100 - 0.2 * 100);
+    expect(emitted.segments[2]).toBeCloseTo(25);
+    expect(emitted.segments[3]).toBeCloseTo(100 - 0.8 * 100);
+    expect(emitted.strokes).toBeNull();
+  });
+
+  it("sparse path compacts after dropped rows", () => {
+    const frame = frameOf({
+      n: 3,
+      x: Float64Array.of(0.2, Number.NaN, 0.8),
+      ymin: Float64Array.of(0.1, 0.1, 0.1),
+      ymax: Float64Array.of(0.9, 0.9, 0.9),
+      rowIndex: Uint32Array.of(10, 11, 12),
+    });
+    const emitted = emitErrorbarRows({
+      frame,
+      fx: fx(),
+      color: null,
+      wantsColors: false,
+      xSpanOf: fullSpan,
+    });
+    expect(emitted.removed).toBe(1);
+    expect(emitted.keptSegments).toBe(6); // 2 rows × 3
+    expect(emitted.segments.length).toBe(24);
+    expect(emitted.rowIndex.length).toBe(6);
+    expect([...emitted.rowIndex]).toEqual([10, 10, 10, 12, 12, 12]);
+    // Not the full n*12 scratch buffer (3×12=36)
+    expect(emitted.segments.byteLength).toBe(24 * 4);
+  });
+
+  it("returns empty typed arrays when every row is removed", () => {
+    const frame = frameOf({
+      n: 2,
+      x: Float64Array.of(Number.NaN, Number.NaN),
+      ymin: Float64Array.of(0, 0),
+      ymax: Float64Array.of(1, 1),
+    });
+    const emitted = emitErrorbarRows({
+      frame,
+      fx: fx(),
+      color: null,
+      wantsColors: false,
+      xSpanOf: fullSpan,
+    });
+    expect(emitted.keptSegments).toBe(0);
+    expect(emitted.removed).toBe(2);
+    expect(emitted.segments.length).toBe(0);
+    expect(emitted.rowIndex.length).toBe(0);
+  });
+
+  it("writes three stroke entries per kept row when colors are mapped", () => {
+    const frame = frameOf({
+      n: 1,
+      x: Float64Array.of(0.5),
+      ymin: Float64Array.of(0.2),
+      ymax: Float64Array.of(0.8),
+      colorValues: ["red"],
+    });
+    const color = fromAny({
+      scale: {
+        colorOf: (v: unknown) => `c:${String(v)}`,
+        naValue: null,
+        unknownValue: "#999",
+      },
+    });
+    const emitted = emitErrorbarRows({
+      frame,
+      fx: fx(),
+      color,
+      wantsColors: true,
+      xSpanOf: fullSpan,
+    });
+    expect(emitted.strokes).toEqual(["c:red", "c:red", "c:red"]);
+  });
+});


### PR DESCRIPTION
## Summary

Errorbar geometry used dynamic `number[]` push plus `Float32Array.from` / `Uint32Array.from` double-copy. Rule segments, glyphs, and rects already preallocate typed buffers.

- **Audit target:** `packages/core` pipeline geometry
- **Pattern:** #9 allocation in hot path
- **Before → after:** push + from → prealloc `Float32Array(n*12)` / `Uint32Array(n*3)` (3 segments per row); dense reuses; sparse `subarray().slice()`
- **What n is:** errorbar layer row count (`frame.n`)

## Test plan

- [x] `bun test packages/core/tests/geometry-errorbar-prealloc.test.ts` (dense/sparse/empty/colors)
- [x] `bun test packages/core/tests/pipeline-m2/errorbar.test.ts`
- [x] pipeline-geometry suite green
- [ ] CI unit suite on PR
