### PR TITLE
fix(spec): guard color validate for profiles and all-fail censor

### DIFF
--- a/packages/spec/src/validate-data-checks-color.ts
+++ b/packages/spec/src/validate-data-checks-color.ts
@@ -51,12 +51,10 @@ function expectedManualDomainLength(
   // DataProfile fields have values: null. If any participating field has
   // unknown values, do not infer length from scaled constants alone — runtime
   // domain also includes the field categories we cannot see here.
-  for (const values of fieldValueLists) {
-    if (values === null || values === undefined) return null;
-  }
   const seen = new Set<string>();
   let sawValues = false;
   for (const values of fieldValueLists) {
+    if (values === null || values === undefined) return null;
     sawValues = true;
     for (const value of values) {
       if (value === null) continue;

--- a/packages/spec/src/validate-data-checks-color.ts
+++ b/packages/spec/src/validate-data-checks-color.ts
@@ -48,10 +48,15 @@ function expectedManualDomainLength(
   scaledConstants: readonly unknown[] = [],
 ): number | null {
   if (Array.isArray(domain)) return domain.filter((value) => value !== null).length;
+  // DataProfile fields have values: null. If any participating field has
+  // unknown values, do not infer length from scaled constants alone — runtime
+  // domain also includes the field categories we cannot see here.
+  for (const values of fieldValueLists) {
+    if (values === null || values === undefined) return null;
+  }
   const seen = new Set<string>();
   let sawValues = false;
   for (const values of fieldValueLists) {
-    if (values === null || values === undefined) continue;
     sawValues = true;
     for (const value of values) {
       if (value === null) continue;
@@ -150,10 +155,13 @@ export function checkColorScaleDataCompatibility(input: {
             }),
           },
         );
+        // Censor only when at least one value parsed; all-fail invalid leaves
+        // no train extent and still throws at pipeline resolve.
         const censoredInvalid =
           config?.parse !== undefined &&
           config.parseFailure === "censor" &&
-          decision?.status === "invalid";
+          decision?.status === "invalid" &&
+          (decision.validatedCount ?? 0) > 0;
         if (decision?.status !== "temporal" && !censoredInvalid) {
           errors.push({
             code: "scale-type-mismatch",
@@ -218,7 +226,8 @@ export function checkColorScaleDataCompatibility(input: {
       const censoredInvalid =
         config?.parse !== undefined &&
         config.parseFailure === "censor" &&
-        decision?.status === "invalid";
+        decision?.status === "invalid" &&
+        (decision.validatedCount ?? 0) > 0;
       if (decision?.status === "temporal" || censoredInvalid) {
         // Mirror runtime: compare recovered kind even when status is invalid+censored.
         if (

--- a/packages/spec/src/validate-data-checks-color.ts
+++ b/packages/spec/src/validate-data-checks-color.ts
@@ -42,19 +42,28 @@ function discreteDomainKey(value: unknown): string {
   }
 }
 
+/** Exact domain size, or a lower bound when some field values are unknown. */
+type ManualDomainEstimate = { readonly kind: "exact" | "min"; readonly size: number };
+
 function expectedManualDomainLength(
   domain: unknown,
   fieldValueLists: readonly (readonly unknown[] | null | undefined)[],
   scaledConstants: readonly unknown[] = [],
-): number | null {
-  if (Array.isArray(domain)) return domain.filter((value) => value !== null).length;
-  // DataProfile fields have values: null. If any participating field has
-  // unknown values, do not infer length from scaled constants alone — runtime
-  // domain also includes the field categories we cannot see here.
+): ManualDomainEstimate | null {
+  if (Array.isArray(domain)) {
+    return { kind: "exact", size: domain.filter((value) => value !== null).length };
+  }
+  // DataProfile fields have values: null. Unknown field values disable an
+  // exact inference, but known scaled constants still yield a lower bound
+  // (runtime domain is at least those constants, plus any field categories).
   const seen = new Set<string>();
   let sawValues = false;
+  let unknownFieldValues = false;
   for (const values of fieldValueLists) {
-    if (values === null || values === undefined) return null;
+    if (values === null || values === undefined) {
+      unknownFieldValues = true;
+      continue;
+    }
     sawValues = true;
     for (const value of values) {
       if (value === null) continue;
@@ -66,7 +75,8 @@ function expectedManualDomainLength(
     sawValues = true;
     seen.add(discreteDomainKey(value));
   }
-  return sawValues ? seen.size : null;
+  if (!sawValues) return null;
+  return { kind: unknownFieldValues ? "min" : "exact", size: seen.size };
 }
 
 /** Post-layer color/fill scale type compatibility against collected field uses. */
@@ -95,13 +105,19 @@ export function checkColorScaleDataCompatibility(input: {
         colorFields[channel].map((use) => fields.get(use.field)?.values),
         colorScaledConstants[channel],
       );
-      if (expected !== null && range.length !== expected) {
+      const rangeMismatch =
+        expected !== null &&
+        (expected.kind === "exact" ? range.length !== expected.size : range.length < expected.size);
+      if (rangeMismatch && expected !== null) {
         errors.push({
           code: "scale-manual-domain-range",
           path: `/scales/${channel}`,
-          message: `The manual ${channel} scale needs one range color per domain value (${String(expected)} values, ${String(range.length)} colors).`,
+          message:
+            expected.kind === "exact"
+              ? `The manual ${channel} scale needs one range color per domain value (${String(expected.size)} values, ${String(range.length)} colors).`
+              : `The manual ${channel} scale has at least ${String(expected.size)} known domain values (scaled constants and/or observed categories) but only ${String(range.length)} range colors.`,
           fix: {
-            description: `Provide ${String(expected)} range colors, or set scales.${channel}.domain explicitly to match the range length.`,
+            description: `Provide at least ${String(expected.size)} range colors, or set scales.${channel}.domain explicitly to match the range length.`,
           },
         });
       }
@@ -153,13 +169,17 @@ export function checkColorScaleDataCompatibility(input: {
             }),
           },
         );
-        // Censor only when at least one value parsed; all-fail invalid leaves
-        // no train extent and still throws at pipeline resolve.
+        // Censor when at least one value parsed, or when an explicit domain can
+        // still train the scale (pipeline only throws color-transform-empty
+        // when domain is absent and extent is empty).
+        const hasExplicitDomain =
+          Array.isArray(config?.domain) &&
+          config.domain.filter((value) => value !== null).length === 2;
         const censoredInvalid =
           config?.parse !== undefined &&
           config.parseFailure === "censor" &&
           decision?.status === "invalid" &&
-          (decision.validatedCount ?? 0) > 0;
+          ((decision.validatedCount ?? 0) > 0 || hasExplicitDomain);
         if (decision?.status !== "temporal" && !censoredInvalid) {
           errors.push({
             code: "scale-type-mismatch",
@@ -221,11 +241,14 @@ export function checkColorScaleDataCompatibility(input: {
           }),
         },
       );
+      const hasExplicitDomain =
+        Array.isArray(config?.domain) &&
+        config.domain.filter((value) => value !== null).length === 2;
       const censoredInvalid =
         config?.parse !== undefined &&
         config.parseFailure === "censor" &&
         decision?.status === "invalid" &&
-        (decision.validatedCount ?? 0) > 0;
+        ((decision.validatedCount ?? 0) > 0 || hasExplicitDomain);
       if (decision?.status === "temporal" || censoredInvalid) {
         // Mirror runtime: compare recovered kind even when status is invalid+censored.
         if (

--- a/packages/spec/tests/validate-tier2-color.test.ts
+++ b/packages/spec/tests/validate-tier2-color.test.ts
@@ -308,4 +308,76 @@ describe("tier 2 — color scale data-aware validation", () => {
     if (result.ok) throw new Error("expected failure");
     expect(result.errors.some((error) => error.code === "scale-type-mismatch")).toBe(true);
   });
+
+  it("allows all-failed censored epoch parses when an explicit domain can train", () => {
+    const result = validate(
+      normalize({
+        data: {
+          values: [
+            { x: 1, y: 1, t: 1e100 },
+            { x: 2, y: 2, t: 1e101 },
+          ],
+        },
+        layers: [
+          {
+            geom: "point",
+            aes: { x: { field: "x" }, y: { field: "y" }, color: { field: "t" } },
+          },
+        ],
+        scales: {
+          color: {
+            type: "sequential",
+            temporalKind: "datetime",
+            parse: { epoch: "milliseconds" },
+            parseFailure: "censor",
+            domain: [1_700_000_000_000, 1_706_745_600_000],
+          },
+        },
+      }),
+      {},
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  it("still rejects when scaled constants alone exceed the manual range under DataProfile", () => {
+    const profile: DataProfile = {
+      fields: [
+        { name: "g", type: "nominal" },
+        { name: "x", type: "quantitative" },
+        { name: "y", type: "quantitative" },
+      ],
+    };
+    const result = validate(
+      normalize({
+        data: { name: "rows" },
+        layers: [
+          {
+            geom: "point",
+            aes: { x: { field: "x" }, y: { field: "y" }, color: { field: "g" } },
+          },
+          {
+            geom: "point",
+            aes: {
+              x: { field: "x" },
+              y: { field: "y" },
+              color: { value: "a", scale: true },
+            },
+          },
+          {
+            geom: "point",
+            aes: {
+              x: { field: "x" },
+              y: { field: "y" },
+              color: { value: "b", scale: true },
+            },
+          },
+        ],
+        scales: { color: { type: "manual", range: ["#f00"] } },
+      }),
+      { profile },
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected failure");
+    expect(result.errors.some((error) => error.code === "scale-manual-domain-range")).toBe(true);
+  });
 });

--- a/packages/spec/tests/validate-tier2-color.test.ts
+++ b/packages/spec/tests/validate-tier2-color.test.ts
@@ -6,6 +6,7 @@
 import { describe, expect, it } from "bun:test";
 
 import { normalize, validate } from "../src/index.js";
+import type { DataProfile } from "../src/validate-data.ts";
 
 const point = { geom: "point" as const };
 
@@ -239,5 +240,72 @@ describe("tier 2 — color scale data-aware validation", () => {
       {},
     );
     expect(result.ok).toBe(true);
+  });
+
+  it("does not infer manual domain length from scaled constants alone under DataProfile", () => {
+    // Profile fields have values: null. Constants must not stand in for unknown categories.
+    const profile: DataProfile = {
+      fields: [
+        { name: "g", type: "nominal" },
+        { name: "x", type: "quantitative" },
+        { name: "y", type: "quantitative" },
+      ],
+    };
+    const result = validate(
+      normalize({
+        data: { name: "rows" },
+        layers: [
+          {
+            geom: "point",
+            aes: { x: { field: "x" }, y: { field: "y" }, color: { field: "g" } },
+          },
+          {
+            geom: "point",
+            aes: {
+              x: { field: "x" },
+              y: { field: "y" },
+              color: { value: "ref", scale: true },
+            },
+          },
+        ],
+        // Runtime domain is categories(g) ∪ {ref}; under a profile we cannot
+        // know category count, so range length must not be checked against
+        // constants alone.
+        scales: { color: { type: "manual", range: ["#f00", "#0f0", "#00f"] } },
+      }),
+      { profile },
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects all-failed censored epoch parses that leave no train extent", () => {
+    const result = validate(
+      normalize({
+        data: {
+          values: [
+            { x: 1, y: 1, t: 1e100 },
+            { x: 2, y: 2, t: 1e101 },
+          ],
+        },
+        layers: [
+          {
+            geom: "point",
+            aes: { x: { field: "x" }, y: { field: "y" }, color: { field: "t" } },
+          },
+        ],
+        scales: {
+          color: {
+            type: "sequential",
+            temporalKind: "datetime",
+            parse: { epoch: "milliseconds" },
+            parseFailure: "censor",
+          },
+        },
+      }),
+      {},
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected failure");
+    expect(result.errors.some((error) => error.code === "scale-type-mismatch")).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Follow-up for unrebutted post-merge Codex P2s on #566.

| Finding | Fix |
|---------|-----|
| Don't infer profiled manual domains from constants alone | `expectedManualDomainLength` returns `null` if any field values list is unknown |
| Require a recovered value before censoring epoch parses | `censoredInvalid` requires `validatedCount > 0` (quant + nominal paths) |

## Tests

```text
bun test packages/spec/tests/validate-tier2-color.test.ts
# 9 pass

bun run check
```