### PR TITLE
fix(ci): harden component-svelte against browser harness flakes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -487,10 +487,19 @@ jobs:
       # --coverage: @vitest/coverage-v8 needs Node inspector Coverage APIs that
       # bun does not implement ("Coverage APIs are not supported"). Local
       # `test:coverage` can still collect SSR lcov under node for offline use.
+      #
+      # One shell retry: vitest `retry` only re-runs failed *tests*, not suite
+      # import / iframe / coverage-v8 dynamic-import harness failures (PR #440).
       - name: component tests (packages/svelte, chromium + coverage)
         if: steps.content_hash.outputs.hit != 'true'
         working-directory: packages/svelte
-        run: bunx --bun vitest run --coverage --project chromium
+        run: |
+          set -euo pipefail
+          if bunx --bun vitest run --coverage --project chromium; then
+            exit 0
+          fi
+          echo "::warning::chromium+coverage failed once; retrying once for browser harness flake"
+          bunx --bun vitest run --coverage --project chromium
       - name: component tests (packages/svelte, firefox + webkit)
         if: steps.content_hash.outputs.hit != 'true'
         working-directory: packages/svelte

--- a/packages/svelte/vitest.config.ts
+++ b/packages/svelte/vitest.config.ts
@@ -19,6 +19,13 @@ export default defineConfig({
     include: ["tests/**/*.test.ts"],
     exclude: ["tests/**/*.ssr.test.ts"],
     retry: process.env.CI === "true" ? 1 : 0,
+    // Keep per-file isolate (selection-state and friends rely on clean module
+    // state). Cap concurrent browser workers in CI so GH-hosted runners do not
+    // open dozens of isolated iframes under coverage-v8, which flakes as:
+    //   - Failed to fetch dynamically imported module (...test.ts / coverage-v8/browser)
+    //   - Cannot connect to the iframe
+    // (Storybook vitest-addon CI FAQ; seen on Version Packages #440).
+    maxWorkers: process.env.CI === "true" ? 2 : undefined,
     // Opt-in via --coverage. Browser collection runs on Chromium only
     // (v8-over-CDP); invoke with --project chromium so firefox/webkit
     // are not asked to report coverage.


### PR DESCRIPTION
## Summary

Investigated [PR #440](https://github.com/ljodea/ggsvelte/pull/440) (Version Packages) failing two CI jobs and fixed the underlying `component-svelte` harness flake on a fresh branch.

### Why #440 showed two failures

| Job | Role | What happened |
|-----|------|---------------|
| **component-svelte** | real failure | Chromium + coverage aborted mid-run |
| **ci-gate** | aggregator | Fails whenever any required job fails |

#440 only bumps versions/changelogs — no product logic. Main’s `component-svelte` was green on the same code minutes earlier.

### Root cause

Not a `selection.test.ts` assertion bug. The suite died under browser harness resource pressure:

1. `Failed to import … selection.test.ts` → `Failed to fetch dynamically imported module`
2. Cascading `@vitest/coverage-v8/browser` dynamic-import failures
3. `Cannot connect to the iframe` on `inspection-teardown.test.ts`
4. Screenshot protocol error on `release-matrix` hydration

Partial run: **1 failed | 29 passed (102)** files in ~43s, while healthy chromium runs finish ~100+ files in ~2–3 min. Matches the [Storybook vitest-addon CI FAQ](https://storybook.js.org/docs/writing-tests/integrations/vitest-addon#why-do-my-tests-fail-in-ci-with-failed-to-fetch-dynamically-imported-module-or-cannot-connect-to-the-iframe) for overloaded CI browser isolation.

### Fix

1. **`packages/svelte/vitest.config.ts`**: `maxWorkers: 2` when `CI=true` (keep `isolate: true` — `isolate: false` pollutes `selection-state` and friends).
2. **`.github/workflows/ci.yml`**: one shell retry on chromium+coverage. Vitest’s `retry` only re-runs failed *tests*, not suite-import / iframe harness failures.

### Verification

- Focused chromium suite under `CI=true` (selection + inspection-teardown): **54 passed**
- Confirmed `isolate: false` breaks selection-state (rejected that approach)
- `scripts/ci-composites.test.ts` + `scripts/release-wiring.test.ts`: **26 passed**