### PR TITLE
ci: parallelize packages/svelte chromium and firefox+webkit jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -430,18 +430,17 @@ jobs:
           execution: consumer
           hash: ${{ steps.content_hash.outputs.hash }}
 
+  # packages/svelte browser surface is two parallel jobs so chromium+coverage
+  # and firefox+webkit do not serialize (~90s wall-clock savings on the
+  # component path). Coverage + Codecov stay on the chromium job only.
   component-svelte:
-    name: component-svelte (packages/svelte vitest browser + ssr)
+    name: component-svelte (packages/svelte chromium + coverage + ssr)
 
     needs: [detect-changes, packages-dist]
     if: >-
       needs.detect-changes.outputs.component == 'true' &&
       needs.packages-dist.result == 'success'
     runs-on: ubuntu-latest
-    env:
-      # GitHub runs the container as root, while /github/home belongs to
-      # pwuser. Firefox refuses that ownership mismatch.
-      HOME: /root
     container:
       # Keep in sync with env.PLAYWRIGHT_CONTAINER_TAG above.
       image: mcr.microsoft.com/playwright:v1.61.1-noble
@@ -483,10 +482,11 @@ jobs:
             exit 1
           fi
       # Chromium collects browser v8 coverage (CDP; works under bun) and enforces
-      # thresholds. Firefox/webkit stay coverage-free. SSR runs under bun without
-      # --coverage: @vitest/coverage-v8 needs Node inspector Coverage APIs that
-      # bun does not implement ("Coverage APIs are not supported"). Local
-      # `test:coverage` can still collect SSR lcov under node for offline use.
+      # thresholds. SSR runs under bun without --coverage: @vitest/coverage-v8
+      # needs Node inspector Coverage APIs that bun does not implement
+      # ("Coverage APIs are not supported"). Local `test:coverage` can still
+      # collect SSR lcov under node for offline use. Firefox/webkit run in the
+      # parallel component-svelte-fx job (coverage-free).
       #
       # One shell retry: vitest `retry` only re-runs failed *tests*, not suite
       # import / iframe / coverage-v8 dynamic-import harness failures (PR #440).
@@ -500,10 +500,6 @@ jobs:
           fi
           echo "::warning::chromium+coverage failed once; retrying once for browser harness flake"
           bunx --bun vitest run --coverage --project chromium
-      - name: component tests (packages/svelte, firefox + webkit)
-        if: steps.content_hash.outputs.hit != 'true'
-        working-directory: packages/svelte
-        run: bunx --bun vitest run --project firefox --project webkit
       - name: component tests (packages/svelte, SSR)
         if: steps.content_hash.outputs.hit != 'true'
         working-directory: packages/svelte
@@ -556,6 +552,79 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: component-svelte-failure-artifacts
+          path: packages/svelte/test-results/
+          if-no-files-found: ignore
+          retention-days: 7
+
+  # Parallel sibling of component-svelte: firefox + webkit only (no coverage).
+  # Distinct content-hash execution so a chromium cache hit cannot skip these
+  # engines, and vice versa.
+  component-svelte-fx:
+    name: component-svelte-fx (packages/svelte firefox + webkit)
+
+    needs: [detect-changes, packages-dist]
+    if: >-
+      needs.detect-changes.outputs.component == 'true' &&
+      needs.packages-dist.result == 'success'
+    runs-on: ubuntu-latest
+    env:
+      # GitHub runs the container as root, while /github/home belongs to
+      # pwuser. Firefox refuses that ownership mismatch.
+      HOME: /root
+    container:
+      # Keep in sync with env.PLAYWRIGHT_CONTAINER_TAG above.
+      image: mcr.microsoft.com/playwright:v1.61.1-noble
+    defaults:
+      run:
+        # The container's /bin/sh is dash, which rejects `set -o pipefail`.
+        shell: bash
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: install unzip (playwright image lacks it; setup-bun needs it)
+        run: apt-get update && apt-get install -y --no-install-recommends unzip
+      - uses: ./.github/actions/ci-setup-bun
+      - uses: ./.github/actions/ci-content-hash-restore
+        id: content_hash
+        with:
+          execution: component_svelte_fx
+          bypass: ${{ needs.detect-changes.outputs.bypass_content_cache }}
+          disable: ${{ vars.CI_DISABLE_CONTENT_HASH }}
+          container_tag: ${{ env.PLAYWRIGHT_CONTAINER_TAG }}
+      - uses: ./.github/actions/ci-bun-install
+        if: steps.content_hash.outputs.hit != 'true'
+        with:
+          cache_key_prefix: bun-container
+      - uses: ./.github/actions/ci-download-packages-dist
+        if: steps.content_hash.outputs.hit != 'true'
+      - name: assert playwright npm/container version sync (packages/svelte)
+        if: steps.content_hash.outputs.hit != 'true'
+        run: |
+          set -euo pipefail
+          npm_version="$(cd packages/svelte && bun -e 'console.log(require("playwright/package.json").version)')"
+          expected="v${npm_version}-noble"
+          echo "packages/svelte playwright: ${npm_version}; container tag: ${PLAYWRIGHT_CONTAINER_TAG}"
+          if [ "${expected}" != "${PLAYWRIGHT_CONTAINER_TAG}" ]; then
+            echo "::error::playwright npm version in packages/svelte (${npm_version}) does not match pinned container tag (${PLAYWRIGHT_CONTAINER_TAG})"
+            exit 1
+          fi
+      - name: component tests (packages/svelte, firefox + webkit)
+        if: steps.content_hash.outputs.hit != 'true'
+        working-directory: packages/svelte
+        run: bunx --bun vitest run --project firefox --project webkit
+      - uses: ./.github/actions/ci-content-hash-write
+        if: success() && steps.content_hash.outputs.hit != 'true' && steps.content_hash.outputs.bypass != 'true'
+        with:
+          execution: component_svelte_fx
+          hash: ${{ steps.content_hash.outputs.hash }}
+      - name: upload packages/svelte-fx failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: component-svelte-fx-failure-artifacts
           path: packages/svelte/test-results/
           if-no-files-found: ignore
           retention-days: 7
@@ -1026,6 +1095,7 @@ jobs:
       - compatibility-matrix
       - consumer-compat
       - component-svelte
+      - component-svelte-fx
       - component-spikes
       - component-journeys
       - build
@@ -1059,6 +1129,7 @@ jobs:
           CHECKS_RES: ${{ needs.checks.result }}
           UNIT_RES: ${{ needs.unit.result }}
           COMPONENT_SVELTE_RES: ${{ needs.component-svelte.result }}
+          COMPONENT_SVELTE_FX_RES: ${{ needs.component-svelte-fx.result }}
           COMPONENT_SPIKES_RES: ${{ needs.component-spikes.result }}
           DOCS_JOURNEYS_RES: ${{ needs.component-journeys.result }}
           CONSUMER_RES: ${{ needs.consumer-compat.result }}
@@ -1103,8 +1174,11 @@ jobs:
             const shard = (k: string): JobResult => (env[k] as JobResult) || "skipped";
             // Issue #243: package browser surface is svelte+spikes only.
             // Journeys are gated separately via docs_journeys.
+            // component-svelte (chromium+ssr) and component-svelte-fx
+            // (firefox+webkit) run in parallel; both must succeed.
             const componentShards = [
               shard("COMPONENT_SVELTE_RES"),
+              shard("COMPONENT_SVELTE_FX_RES"),
               shard("COMPONENT_SPIKES_RES"),
             ];
             let componentResult: JobResult = "skipped";

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -262,7 +262,8 @@ That runs:
    paths only) — do not chase SSR-report gaps or put thresholds there.
 
 CI (`.github/workflows/ci.yml`) runs chromium browser coverage on the
-`component-svelte` job and unit-suite coverage (`bun test --coverage`) on the
+`component-svelte` job (parallel with coverage-free `component-svelte-fx` for
+firefox + webkit) and unit-suite coverage (`bun test --coverage`) on the
 `unit` job, then uploads lcov to Codecov via `codecov/codecov-action` (flags
 `unit` / `svelte`, path components for package badges). SSR coverage is **not**
 collected in CI: `@vitest/coverage-v8` needs Node inspector Coverage APIs that

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,6 @@
 # Codecov config for the ggsvelte monorepo.
-# Coverage is produced by CI (unit job: bun --coverage; component-svelte:
-# vitest --coverage) and uploaded via codecov/codecov-action.
+# Coverage is produced by CI (unit job: bun --coverage; component-svelte
+# chromium job: vitest --coverage) and uploaded via codecov/codecov-action.
 #
 # Package badges use components (path filters on a shared upload) so we do not
 # need one upload per package. Flags mark which job produced the report and

--- a/scripts/ci-composites.test.ts
+++ b/scripts/ci-composites.test.ts
@@ -17,6 +17,7 @@ const DOWNLOAD_DIST = ".github/actions/ci-download-packages-dist/action.yml";
 const PACKAGES_DIST_CONSUMERS = [
   "consumer-compat",
   "component-svelte",
+  "component-svelte-fx",
   "component-spikes",
   "component-journeys",
   "interaction-perf",
@@ -31,6 +32,7 @@ const SETUP_BUN_JOBS = [
   "compatibility-matrix",
   "consumer-compat",
   "component-svelte",
+  "component-svelte-fx",
   "component-spikes",
   "component-journeys",
   "interaction-perf",
@@ -49,6 +51,7 @@ const BUN_INSTALL_JOBS = [
   "checks",
   "unit",
   "component-svelte",
+  "component-svelte-fx",
   "component-spikes",
   "component-journeys",
   "interaction-perf",
@@ -61,6 +64,7 @@ const BUN_INSTALL_JOBS = [
 
 const CONTAINER_BUN_INSTALL_JOBS = new Set([
   "component-svelte",
+  "component-svelte-fx",
   "component-spikes",
   "component-journeys",
   "interaction-perf",
@@ -87,7 +91,7 @@ describe("ci-download-packages-dist composite", () => {
     expect(action).toContain("shell: bash");
   });
 
-  it("is the sole packages-dist download path for the five consumer jobs", () => {
+  it("is the sole packages-dist download path for the six consumer jobs", () => {
     const ci = read(".github/workflows/ci.yml");
     for (const jobId of PACKAGES_DIST_CONSUMERS) {
       const job = jobSlice(ci, jobId);
@@ -97,9 +101,9 @@ describe("ci-download-packages-dist composite", () => {
         /download-artifact@[0-9a-f]+[\s\S]{0,120}name:\s*packages-dist/,
       );
     }
-    // Exactly five uses in ci.yml.
+    // Exactly six uses in ci.yml (component-svelte split into chromium + fx).
     const uses = ci.match(/uses: \.\/\.github\/actions\/ci-download-packages-dist/g) ?? [];
-    expect(uses.length).toBe(5);
+    expect(uses.length).toBe(6);
   });
 });
 
@@ -138,7 +142,7 @@ describe("ci-bun-install composite", () => {
     expect(action).toMatch(/cache_key_prefix|cache-key-prefix/);
   });
 
-  it("wires host vs container cache prefixes for the twelve cache+install jobs", () => {
+  it("wires host vs container cache prefixes for the cache+install jobs", () => {
     const ci = read(".github/workflows/ci.yml");
     for (const jobId of BUN_INSTALL_JOBS) {
       const job = jobSlice(ci, jobId);

--- a/scripts/ci-routing.test.ts
+++ b/scripts/ci-routing.test.ts
@@ -614,10 +614,14 @@ describe("content-hash inputs", () => {
 
   test("component shards are distinct cacheable executions", () => {
     expect(CACHEABLE_EXECUTIONS).toContain("component_svelte");
+    expect(CACHEABLE_EXECUTIONS).toContain("component_svelte_fx");
     expect(CACHEABLE_EXECUTIONS).toContain("component_spikes");
     expect(CACHEABLE_EXECUTIONS).toContain("component_journeys");
     expect(JOB_CONTENT_INPUTS.component_spikes).toContain("spikes/**");
     expect(JOB_CONTENT_INPUTS.component_svelte).not.toContain("spikes/**");
+    // chromium and firefox+webkit share the packages/svelte input surface but
+    // must cache independently (parallel jobs, distinct execution keys).
+    expect(JOB_CONTENT_INPUTS.component_svelte_fx).toEqual(JOB_CONTENT_INPUTS.component_svelte);
   });
 
   test("listJobContentPaths is sorted and unique", () => {

--- a/scripts/ci-routing/content-hash.ts
+++ b/scripts/ci-routing/content-hash.ts
@@ -24,7 +24,8 @@ export const CONTENT_HASH_SCHEMA = 2;
 
 /**
  * Physical CI executions that may content-hash short-circuit.
- * Distinct from JobName: component is three shards; consumer is matrixed.
+ * Distinct from JobName: component is four shards (svelte chromium, svelte
+ * firefox+webkit, spikes, journeys); consumer is matrixed.
  */
 export type CacheableExecution =
   | "packages_dist"
@@ -36,6 +37,7 @@ export type CacheableExecution =
   | "bench_smoke"
   | "interaction_perf"
   | "component_svelte"
+  | "component_svelte_fx"
   | "component_spikes"
   | "component_journeys"
   | "consumer";
@@ -50,6 +52,7 @@ export const CACHEABLE_EXECUTIONS: readonly CacheableExecution[] = [
   "bench_smoke",
   "interaction_perf",
   "component_svelte",
+  "component_svelte_fx",
   "component_spikes",
   "component_journeys",
   "consumer",
@@ -214,6 +217,15 @@ export const JOB_CONTENT_INPUTS: Record<CacheableExecution, readonly string[]> =
     "examples/**",
   ],
   component_svelte: [
+    ...UNIVERSAL_CONTENT_INPUTS,
+    "packages/spec/**",
+    "packages/core/**",
+    "packages/svelte/**",
+    "skills/ggsvelte/**",
+  ],
+  // Same inputs as component_svelte (shared packages/svelte tree); distinct
+  // execution key so chromium+coverage and firefox+webkit cache independently.
+  component_svelte_fx: [
     ...UNIVERSAL_CONTENT_INPUTS,
     "packages/spec/**",
     "packages/core/**",

--- a/scripts/release-wiring.test.ts
+++ b/scripts/release-wiring.test.ts
@@ -44,9 +44,14 @@ describe("R0 release wiring", () => {
   it("runs the Playwright interaction performance gate with benchmark budgets", () => {
     const ci = read(".github/workflows/ci.yml");
     const bench = read(".github/workflows/bench.yml");
-    // Browser surface: svelte + spikes (component). Journeys is docs_journeys-routed.
+    // Browser surface: svelte (chromium) + svelte-fx (firefox/webkit) + spikes.
+    // Journeys is docs_journeys-routed.
     const svelteJob = ci.slice(
-      ci.indexOf("  component-svelte:"),
+      ci.indexOf("  component-svelte:\n"),
+      ci.indexOf("  component-svelte-fx:"),
+    );
+    const svelteFxJob = ci.slice(
+      ci.indexOf("  component-svelte-fx:"),
       ci.indexOf("  component-spikes:"),
     );
     const spikesJob = ci.slice(
@@ -65,12 +70,19 @@ describe("R0 release wiring", () => {
     expect(ci).toContain("HOME: /root");
     // Package browser shards download packages/*/dist (issue #241); no monorepo rebuild.
     // Download+verify lives in ci-download-packages-dist (pin + entrypoint checks).
-    for (const job of [svelteJob, spikesJob]) {
+    for (const job of [svelteJob, svelteFxJob, spikesJob]) {
       expect(job).toContain("uses: ./.github/actions/ci-download-packages-dist");
       expect(job).toContain("packages-dist");
       expect(job).not.toContain("run: bun run build\n");
     }
     expect(svelteJob).toContain("working-directory: packages/svelte");
+    expect(svelteJob).toContain("--project chromium");
+    expect(svelteJob).not.toContain("--project firefox");
+    expect(svelteFxJob).toContain("working-directory: packages/svelte");
+    expect(svelteFxJob).toContain("--project firefox");
+    expect(svelteFxJob).toContain("--project webkit");
+    expect(svelteFxJob).not.toContain("--coverage");
+    expect(svelteFxJob).toContain("HOME: /root");
     expect(spikesJob).toContain("working-directory: spikes/browser");
     // Journeys: docs_journeys routing + full non-pixel inventory; may build docs site.
     expect(journeysJob).toContain("docs_journeys == 'true'");
@@ -83,8 +95,9 @@ describe("R0 release wiring", () => {
     expect(journeysJob).toContain("docs-progressive-search.spec.ts");
     expect(journeysJob).toContain("docs-themes.spec.ts");
     expect(journeysJob).toContain("--grep-invert 'visual contract'");
-    // ci-gate: package component = svelte+spikes; docs_journeys is independent.
+    // ci-gate: package component = svelte+svelte-fx+spikes; docs_journeys is independent.
     expect(ci).toContain("COMPONENT_SVELTE_RES");
+    expect(ci).toContain("COMPONENT_SVELTE_FX_RES");
     expect(ci).toContain("COMPONENT_SPIKES_RES");
     expect(ci).toContain("DOCS_JOURNEYS_RES");
     expect(ci).toContain("DOCS_JOURNEYS_REQ");
@@ -121,7 +134,7 @@ describe("R0 release wiring", () => {
     // Consumers download instead of rebuilding packages (via composite).
     const consumerJob = ci.slice(
       ci.indexOf("  consumer-compat:\n    name: packed consumer"),
-      ci.indexOf("  component-svelte:\n    name: component-svelte"),
+      ci.indexOf("  component-svelte:\n    name: component-svelte (packages/svelte chromium"),
     );
     expect(consumerJob).toContain("uses: ./.github/actions/ci-download-packages-dist");
     expect(consumerJob).toContain("packages-dist");
@@ -195,6 +208,7 @@ describe("R0 release wiring", () => {
     // generous window so the content-hash write is still inside the slice.
     for (const [job, execution] of [
       ["component-svelte", "component_svelte"],
+      ["component-svelte-fx", "component_svelte_fx"],
       ["component-spikes", "component_spikes"],
       ["component-journeys", "component_journeys"],
     ] as const) {
@@ -210,7 +224,7 @@ describe("R0 release wiring", () => {
     // Consumer: runtime resolution stays in the job; matrix dims pass into restore composite.
     const consumerJob = ci.slice(
       ci.indexOf("  consumer-compat:\n    name: packed consumer"),
-      ci.indexOf("  component-svelte:\n    name: component-svelte"),
+      ci.indexOf("  component-svelte:\n    name: component-svelte (packages/svelte chromium"),
     );
     expect(consumerJob).toContain("uses: ./.github/actions/ci-content-hash-restore");
     expect(consumerJob).toContain("execution: consumer");


### PR DESCRIPTION
## Summary

- Split the serial `component-svelte` steps into two parallel jobs:
  - `component-svelte` — chromium + coverage + SSR + Codecov upload
  - `component-svelte-fx` — firefox + webkit (coverage-free)
- Wire both into `ci-gate` as package-browser shards (with spikes)
- Give each job its own content-hash execution key so cache hits cannot skip the other engines
- Update routing/composites/release-wiring contracts and docs comments

This removes ~90s of serial browser wall-clock on every CI run that schedules the packages/svelte component surface.

## Test plan

- [x] `bun test scripts/ci-composites.test.ts scripts/release-wiring.test.ts scripts/ci-routing.test.ts`
- [ ] CI green on this PR, including both `component-svelte` and `component-svelte-fx` when component routing is on (this PR touches `ci.yml` / content-hash so product force / bypass may apply as designed)