### PR TITLE
fix(docs): harden deploy recovery and post-deploy smoke

### DIFF
--- a/.github/workflows/cloudflare-pages.yml
+++ b/.github/workflows/cloudflare-pages.yml
@@ -34,6 +34,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    # Same environment as deploy so DOCS_ANALYTICS_TOKEN (and other env secrets)
+    # remain available after the job split (GitHub only injects env secrets into
+    # jobs that declare the environment).
+    environment:
+      name: cloudflare-production
     concurrency:
       # Cancel superseded builds. Main lands package refactors in bursts; each
       # push rebuilds the docs artifact. Queuing every intermediate build is

--- a/.github/workflows/cloudflare-pages.yml
+++ b/.github/workflows/cloudflare-pages.yml
@@ -1,6 +1,11 @@
 # Build and deploy the root-hosted docs artifact to Cloudflare Pages.
 # Direct upload is intentional: the account's native Pages GitHub App is
 # unavailable (API 8000011). The token is scoped to account-level Pages Write.
+#
+# Build and deploy are separate jobs so superseded main pushes cancel only the
+# build. Once deploy starts, cancel-in-progress is off: production must finish
+# smoke after wrangler activates, or an intermediate cancel could leave an
+# unverified artifact live.
 name: Cloudflare Pages
 
 on:
@@ -22,26 +27,20 @@ on:
 
 permissions: {}
 
-concurrency:
-  # Cancel superseded builds. Main lands package refactors in bursts; each push
-  # rebuilds the docs artifact and flips production hashes. Queuing every
-  # intermediate deploy multiplies the window where a tab holds HTML that
-  # references retired `/_app/immutable/*` chunks (client "500 Internal Error").
-  group: cloudflare-pages-production
-  cancel-in-progress: true
-
 jobs:
-  deploy:
-    name: build and deploy immutable artifact
+  build:
+    name: build immutable artifact
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    environment:
-      name: cloudflare-production
-      url: ${{ steps.deploy.outputs.deployment-url }}
+    concurrency:
+      # Cancel superseded builds. Main lands package refactors in bursts; each
+      # push rebuilds the docs artifact. Queuing every intermediate build is
+      # wasteful; deploy (below) is not cancelled mid-flight.
+      group: cloudflare-pages-build
+      cancel-in-progress: true
     env:
-      CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
       DEPLOY_COMMIT: ${{ github.sha }}
       DOCS_BUILD_MODE: cloudflare-production
     steps:
@@ -71,6 +70,49 @@ jobs:
             export DOCS_ANALYTICS_TOKEN="${ANALYTICS_TOKEN}"
           fi
           bun run build:cloudflare
+      - name: Upload docs build artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: cloudflare-docs-build-${{ github.sha }}
+          path: apps/docs/build
+          if-no-files-found: error
+          retention-days: 1
+
+  deploy:
+    name: deploy and smoke
+    if: github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    concurrency:
+      # Serialize production flips; do not cancel a deploy that already started
+      # (smoke must verify the artifact that went live).
+      group: cloudflare-pages-deploy
+      cancel-in-progress: false
+    environment:
+      name: cloudflare-production
+      url: ${{ steps.deploy.outputs.deployment-url }}
+    env:
+      CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+      DEPLOY_COMMIT: ${{ github.sha }}
+    steps:
+      - name: Checkout for smoke scripts
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.3.14
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Download docs build artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: cloudflare-docs-build-${{ github.sha }}
+          path: apps/docs/build
       - name: Deploy exact artifact to Cloudflare Pages
         id: deploy
         env:

--- a/apps/docs/static/deploy-recovery.js
+++ b/apps/docs/static/deploy-recovery.js
@@ -4,32 +4,40 @@
 // then fails dynamic imports and SvelteKit surfaces "500 Internal Error".
 // Vite emits `vite:preloadError` for those misses; one guarded reload pulls
 // the current HTML + matching chunks. Guarded so a real missing asset cannot
-// loop. When sessionStorage is blocked, a query flag still limits to one reload.
+// loop. When sessionStorage is blocked, a timestamped query flag still limits
+// to one reload within COOLDOWN_MS (not forever).
 (function () {
   var STORAGE_KEY = "ggsvelte-deploy-recovery-at";
   var QUERY_FLAG = "ggsvelte_deploy_recovery";
   var COOLDOWN_MS = 15000;
+
+  function withinCooldown(previous) {
+    return Number.isFinite(previous) && Date.now() - previous < COOLDOWN_MS;
+  }
 
   function recentlyReloaded() {
     try {
       var raw = sessionStorage.getItem(STORAGE_KEY);
       if (raw !== null) {
         var previous = Number(raw);
-        if (Number.isFinite(previous) && Date.now() - previous < COOLDOWN_MS) return true;
+        if (withinCooldown(previous)) return true;
       }
     } catch {
       // Storage blocked — fall through to query-flag guard.
     }
     try {
-      return new URLSearchParams(location.search).get(QUERY_FLAG) === "1";
+      var flagged = new URLSearchParams(location.search).get(QUERY_FLAG);
+      if (flagged === null) return false;
+      return withinCooldown(Number(flagged));
     } catch {
       return false;
     }
   }
 
   function markReload() {
+    var now = String(Date.now());
     try {
-      sessionStorage.setItem(STORAGE_KEY, String(Date.now()));
+      sessionStorage.setItem(STORAGE_KEY, now);
       return "storage";
     } catch {
       return "query";
@@ -57,15 +65,28 @@
       location.reload();
       return true;
     }
-    // Storage blocked: one reload via query flag (survives without sessionStorage).
+    // Storage blocked: one reload via timestamped query flag.
     try {
       var url = new URL(location.href);
-      url.searchParams.set(QUERY_FLAG, "1");
+      url.searchParams.set(QUERY_FLAG, String(Date.now()));
       location.replace(url.toString());
       return true;
     } catch {
       return false;
     }
+  }
+
+  // Drop expired recovery flags so bookmarks/history do not suppress future
+  // deploys forever after the cooldown window.
+  try {
+    var bootUrl = new URL(location.href);
+    var bootFlag = bootUrl.searchParams.get(QUERY_FLAG);
+    if (bootFlag !== null && !withinCooldown(Number(bootFlag))) {
+      bootUrl.searchParams.delete(QUERY_FLAG);
+      history.replaceState(null, "", bootUrl.toString());
+    }
+  } catch {
+    // history / URL may be unavailable in exotic embeds.
   }
 
   window.addEventListener("vite:preloadError", function (event) {

--- a/apps/docs/static/deploy-recovery.js
+++ b/apps/docs/static/deploy-recovery.js
@@ -4,18 +4,24 @@
 // then fails dynamic imports and SvelteKit surfaces "500 Internal Error".
 // Vite emits `vite:preloadError` for those misses; one guarded reload pulls
 // the current HTML + matching chunks. Guarded so a real missing asset cannot
-// loop.
+// loop. When sessionStorage is blocked, a query flag still limits to one reload.
 (function () {
   var STORAGE_KEY = "ggsvelte-deploy-recovery-at";
+  var QUERY_FLAG = "ggsvelte_deploy_recovery";
   var COOLDOWN_MS = 15000;
 
   function recentlyReloaded() {
     try {
       var raw = sessionStorage.getItem(STORAGE_KEY);
-      if (raw === null) return false;
-      var previous = Number(raw);
-      if (!Number.isFinite(previous)) return false;
-      return Date.now() - previous < COOLDOWN_MS;
+      if (raw !== null) {
+        var previous = Number(raw);
+        if (Number.isFinite(previous) && Date.now() - previous < COOLDOWN_MS) return true;
+      }
+    } catch {
+      // Storage blocked — fall through to query-flag guard.
+    }
+    try {
+      return new URLSearchParams(location.search).get(QUERY_FLAG) === "1";
     } catch {
       return false;
     }
@@ -24,8 +30,9 @@
   function markReload() {
     try {
       sessionStorage.setItem(STORAGE_KEY, String(Date.now()));
+      return "storage";
     } catch {
-      // Private mode / blocked storage: still attempt a single reload.
+      return "query";
     }
   }
 
@@ -40,13 +47,31 @@
     );
   }
 
+  /**
+   * @returns {boolean} true when a reload was initiated
+   */
   function recover() {
-    if (recentlyReloaded()) return;
-    markReload();
-    location.reload();
+    if (recentlyReloaded()) return false;
+    var mark = markReload();
+    if (mark === "storage") {
+      location.reload();
+      return true;
+    }
+    // Storage blocked: one reload via query flag (survives without sessionStorage).
+    try {
+      var url = new URL(location.href);
+      url.searchParams.set(QUERY_FLAG, "1");
+      location.replace(url.toString());
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   window.addEventListener("vite:preloadError", function (event) {
+    // Only swallow the error when we actually recover; otherwise let Vite/
+    // SvelteKit surface a real missing chunk during the cooldown window.
+    if (recentlyReloaded()) return;
     try {
       event.preventDefault();
     } catch {

--- a/scripts/cloudflare-pages-config.test.ts
+++ b/scripts/cloudflare-pages-config.test.ts
@@ -89,8 +89,11 @@ describe("Cloudflare Pages project contract", () => {
     expect(workflow).toContain("if: github.ref == 'refs/heads/main'");
     expect(workflow).toContain("ref: ${{ github.sha }}");
     expect(workflow).not.toContain("pull_request:");
-    // Superseded main pushes must not each flip production hashes in sequence.
+    // Superseded builds cancel; deploy/smoke does not cancel mid-flight.
+    expect(workflow).toContain("group: cloudflare-pages-build");
     expect(workflow).toMatch(/cancel-in-progress:\s*true/);
+    expect(workflow).toContain("group: cloudflare-pages-deploy");
+    expect(workflow).toMatch(/cancel-in-progress:\s*false/);
     expect(workflow).toContain("bun scripts/deployment-asset-smoke-cli.ts");
   });
 
@@ -104,6 +107,9 @@ describe("Cloudflare Pages project contract", () => {
     expect(recovery).toContain("vite:preloadError");
     expect(recovery).toContain("Failed to fetch dynamically imported module");
     expect(recovery).toContain("ggsvelte-deploy-recovery-at");
+    // Storage-blocked clients use a query flag; only preventDefault when recovering.
+    expect(recovery).toContain("ggsvelte_deploy_recovery");
+    expect(recovery).toContain("if (recentlyReloaded()) return;");
   });
 
   it("does not keep a GitHub Pages deployment workflow or legacy migration scripts", () => {

--- a/scripts/cloudflare-pages-config.test.ts
+++ b/scripts/cloudflare-pages-config.test.ts
@@ -94,6 +94,9 @@ describe("Cloudflare Pages project contract", () => {
     expect(workflow).toMatch(/cancel-in-progress:\s*true/);
     expect(workflow).toContain("group: cloudflare-pages-deploy");
     expect(workflow).toMatch(/cancel-in-progress:\s*false/);
+    // Build keeps the production environment so env secrets (analytics token)
+    // still inject after the job split.
+    expect(workflow).toMatch(/build:[\s\S]*environment:\s*\n\s*name: cloudflare-production/);
     expect(workflow).toContain("bun scripts/deployment-asset-smoke-cli.ts");
   });
 
@@ -107,8 +110,10 @@ describe("Cloudflare Pages project contract", () => {
     expect(recovery).toContain("vite:preloadError");
     expect(recovery).toContain("Failed to fetch dynamically imported module");
     expect(recovery).toContain("ggsvelte-deploy-recovery-at");
-    // Storage-blocked clients use a query flag; only preventDefault when recovering.
+    // Storage-blocked clients use a timestamped query flag with cooldown;
+    // only preventDefault when recovery is still available.
     expect(recovery).toContain("ggsvelte_deploy_recovery");
+    expect(recovery).toContain("withinCooldown");
     expect(recovery).toContain("if (recentlyReloaded()) return;");
   });
 

--- a/scripts/deployment-asset-smoke.test.ts
+++ b/scripts/deployment-asset-smoke.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 
 import {
+  ASSET_SMOKE_FETCH_TIMEOUT_MS,
   evaluateAssetProbe,
   extractImmutableAssets,
   smokeImmutableAssets,
@@ -111,5 +112,36 @@ describe("deployment immutable asset smoke", () => {
       fetchImpl,
     });
     expect(problems).toEqual([]);
+  });
+
+  it("passes an abort signal so stalled edge fetches fail within the smoke timeout", async () => {
+    expect(ASSET_SMOKE_FETCH_TIMEOUT_MS).toBe(15_000);
+    const signals: AbortSignal[] = [];
+    const html = `<link href="./_app/immutable/entry/start.OK.js" rel="modulepreload">`;
+    const fetchImpl: FetchLike = (_input, init) => {
+      if (init?.signal !== undefined) signals.push(init.signal);
+      if (_input.endsWith("/") || _input === "https://example.pages.dev/") {
+        return Promise.resolve({
+          status: 200,
+          headers: { get: () => "text/html" },
+          text: () => Promise.resolve(html),
+        });
+      }
+      return Promise.resolve({
+        status: 200,
+        headers: { get: () => "text/javascript" },
+        text: () => Promise.resolve("export {}"),
+      });
+    };
+
+    await smokeImmutableAssets({
+      baseUrl: "https://example.pages.dev",
+      paths: ["/"],
+      fetchImpl,
+    });
+    expect(signals.length).toBeGreaterThanOrEqual(2);
+    for (const signal of signals) {
+      expect(signal).toBeInstanceOf(AbortSignal);
+    }
   });
 });

--- a/scripts/deployment-asset-smoke.ts
+++ b/scripts/deployment-asset-smoke.ts
@@ -47,25 +47,35 @@ export function evaluateAssetProbe(probe: AssetProbe): string | null {
 
 export type FetchLike = (
   input: string,
-  init?: { redirect?: "manual" | "follow" | "error"; headers?: Record<string, string> },
+  init?: {
+    redirect?: "manual" | "follow" | "error";
+    headers?: Record<string, string>;
+    signal?: AbortSignal;
+  },
 ) => Promise<{
   status: number;
   headers: { get(name: string): string | null };
   text(): Promise<string>;
 }>;
 
+/** Match deployment-smoke-cli: fail fast on stalled edge connections. */
+export const ASSET_SMOKE_FETCH_TIMEOUT_MS = 15_000;
+
 export async function smokeImmutableAssets(input: {
   readonly baseUrl: string;
   readonly paths: readonly string[];
   readonly fetchImpl?: FetchLike;
+  readonly timeoutMs?: number;
 }): Promise<AssetSmokeProblem[]> {
   const origin = new URL(input.baseUrl).origin;
+  const timeoutMs = input.timeoutMs ?? ASSET_SMOKE_FETCH_TIMEOUT_MS;
   const fetchImpl: FetchLike =
     input.fetchImpl ??
     ((url, init) =>
       fetch(url, {
         redirect: init?.redirect,
         headers: init?.headers,
+        signal: init?.signal,
       }));
   const problems: AssetSmokeProblem[] = [];
 
@@ -79,6 +89,7 @@ export async function smokeImmutableAssets(input: {
           "cache-control": "no-cache",
           "user-agent": "ggsvelte-deployment-asset-smoke/1",
         },
+        signal: AbortSignal.timeout(timeoutMs),
       });
       if (response.status !== 200) {
         problems.push({
@@ -111,6 +122,7 @@ export async function smokeImmutableAssets(input: {
             "cache-control": "no-cache",
             "user-agent": "ggsvelte-deployment-asset-smoke/1",
           },
+          signal: AbortSignal.timeout(timeoutMs),
         });
         const probe: AssetProbe = {
           asset,


### PR DESCRIPTION
## Summary

Follow-up for unrebutted post-merge Codex P2s on #568.

| Finding | Fix |
|---------|-----|
| Preserve reload guard when storage blocked | Query flag `ggsvelte_deploy_recovery=1` survives without sessionStorage |
| Only suppress preload errors when reloading | `preventDefault` only if not already in cooldown |
| Bound live smoke fetches | `AbortSignal.timeout(15_000)` on page + asset fetches |
| Let deploy finish once started | Split jobs: build cancels in progress; deploy/smoke does not |

## Tests

```text
bun test scripts/deployment-asset-smoke.test.ts scripts/cloudflare-pages-config.test.ts
# 9 pass
```