### PR TITLE
refactor(ci): extract ci-gate's inline heredoc into a tested script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1142,79 +1142,15 @@ jobs:
           VR_GUARD_RES: ${{ needs.vr-baseline-guard.result }}
           EVENT_NAME: ${{ github.event_name }}
         shell: bash
+        # Gate logic (required-job plan, component-shard rollup, PR-only
+        # vr-baseline-guard rule) lives in scripts/ci-routing/ci-gate.ts,
+        # unit-tested by scripts/ci-routing/ci-gate.test.ts and the CLI-level
+        # test in scripts/ci-routing.test.ts. This step only short-circuits
+        # on an untrustworthy detect-changes result before delegating.
         run: |
           set -euo pipefail
           if [ "${DETECT_RESULT}" != "success" ]; then
             echo "::error::detect-changes failed — cannot trust routing"
             exit 1
           fi
-          # vr/pages are enforced by their own workflows; interaction_perf is informational.
-          # vr-baseline-guard is always required on pull_request.
-          # docs_journeys is independent of component (content PRs run journeys without svelte/spikes).
-          bun -e '
-            import { evaluateGate, type JobName, type JobPlan, type JobResult } from "./scripts/ci-routing.ts";
-            const env = process.env;
-            const req = (k: string) => env[k] === "true";
-            const required: JobPlan = {
-              checks: req("CHECKS_REQ"),
-              unit: req("UNIT_REQ"),
-              component: req("COMPONENT_REQ"),
-              consumer: req("CONSUMER_REQ"),
-              build: req("BUILD_REQ"),
-              svelte_check: req("SVELTE_CHECK_REQ"),
-              docs_site: req("DOCS_SITE_REQ"),
-              actions_security: req("ACTIONS_REQ"),
-              bench_smoke: req("BENCH_REQ"),
-              interaction_perf: false,
-              packages_dist: req("PACKAGES_DIST_REQ"),
-              vr: false,
-              pages: false,
-              docs_journeys: req("DOCS_JOURNEYS_REQ"),
-            };
-            const shard = (k: string): JobResult => (env[k] as JobResult) || "skipped";
-            // Issue #243: package browser surface is svelte+spikes only.
-            // Journeys are gated separately via docs_journeys.
-            // component-svelte (chromium+ssr) and component-svelte-fx
-            // (firefox+webkit) run in parallel; both must succeed.
-            const componentShards = [
-              shard("COMPONENT_SVELTE_RES"),
-              shard("COMPONENT_SVELTE_FX_RES"),
-              shard("COMPONENT_SPIKES_RES"),
-            ];
-            let componentResult: JobResult = "skipped";
-            if (componentShards.every((r) => r === "skipped")) componentResult = "skipped";
-            else if (componentShards.every((r) => r === "success")) componentResult = "success";
-            else if (componentShards.some((r) => r === "failure" || r === "cancelled"))
-              componentResult = "failure";
-            else componentResult = "unknown";
-            const results: Partial<Record<JobName, JobResult>> = {
-              checks: env.CHECKS_RES as JobResult,
-              unit: env.UNIT_RES as JobResult,
-              component: componentResult,
-              consumer: env.CONSUMER_RES as JobResult,
-              build: env.BUILD_RES as JobResult,
-              svelte_check: env.SVELTE_CHECK_RES as JobResult,
-              docs_site: env.DOCS_SITE_RES as JobResult,
-              actions_security: env.ACTIONS_RES as JobResult,
-              bench_smoke: env.BENCH_RES as JobResult,
-              packages_dist: env.PACKAGES_DIST_RES as JobResult,
-              docs_journeys: shard("DOCS_JOURNEYS_RES"),
-            };
-            const gate = evaluateGate(required, results);
-            const failures = [...gate.failures];
-            if (env.EVENT_NAME === "pull_request") {
-              const guard = env.VR_GUARD_RES;
-              if (guard !== "success" && guard !== "skipped") {
-                // skipped only if the job if: filtered it out; on PR it always schedules.
-                failures.push(`vr-baseline-guard:${guard}`);
-              }
-              if (guard === "skipped") {
-                failures.push("vr-baseline-guard:skipped");
-              }
-            }
-            if (failures.length) {
-              console.error("ci-gate failed:", failures.join(", "));
-              process.exit(1);
-            }
-            console.log("ci-gate ok");
-          '
+          bun scripts/ci-routing.ts ci-gate

--- a/scripts/ci-routing.test.ts
+++ b/scripts/ci-routing.test.ts
@@ -895,13 +895,17 @@ describe("success marker protocol", () => {
   });
 });
 
-async function spawnCiRoutingCli(args: string[]): Promise<{
+async function spawnCiRoutingCli(
+  args: string[],
+  env?: Record<string, string>,
+): Promise<{
   stdout: string;
   stderr: string;
   exitCode: number;
 }> {
   const proc = Bun.spawn(["bun", "scripts/ci-routing.ts", ...args], {
     cwd: join(import.meta.dir, ".."),
+    env: env === undefined ? undefined : { ...process.env, ...env },
     stdout: "pipe",
     stderr: "pipe",
   });
@@ -969,6 +973,7 @@ describe("ci-routing module tree (split-safe)", () => {
       "jobNames",
       "listJobContentPaths",
       "matchPathPattern",
+      "normalizeJobResult",
       "parseFileList",
       "parseGitLsTreeLine",
       "parseNameStatusList",
@@ -1010,6 +1015,43 @@ describe("ci-routing module tree (split-safe)", () => {
 
     const bad = await spawnCiRoutingCli(["not-a-command"]);
     expect(bad.exitCode).not.toBe(0);
+  });
+
+  test("ci-gate CLI reads env vars, aggregates component shards, and evaluates the PR guard rule", async () => {
+    const spawnCiGate = (env: Record<string, string>) => spawnCiRoutingCli(["ci-gate"], env);
+
+    const ok = await spawnCiGate({
+      EVENT_NAME: "pull_request",
+      CHECKS_REQ: "true",
+      CHECKS_RES: "success",
+      COMPONENT_REQ: "true",
+      COMPONENT_SVELTE_RES: "success",
+      COMPONENT_SPIKES_RES: "success",
+      VR_GUARD_RES: "success",
+    });
+    expect(ok.exitCode).toBe(0);
+    expect(ok.stdout).toContain("ci-gate ok");
+
+    const failed = await spawnCiGate({
+      EVENT_NAME: "pull_request",
+      CHECKS_REQ: "true",
+      CHECKS_RES: "success",
+      COMPONENT_REQ: "true",
+      COMPONENT_SVELTE_RES: "failure",
+      COMPONENT_SPIKES_RES: "success",
+      VR_GUARD_RES: "skipped",
+    });
+    expect(failed.exitCode).not.toBe(0);
+    expect(failed.stderr).toContain("ci-gate failed: component, vr-baseline-guard:skipped");
+
+    const pushEvent = await spawnCiGate({
+      EVENT_NAME: "push",
+      CHECKS_REQ: "true",
+      CHECKS_RES: "success",
+      // VR_GUARD_RES intentionally omitted — must not be checked on push.
+    });
+    expect(pushEvent.exitCode).toBe(0);
+    expect(pushEvent.stdout).toContain("ci-gate ok");
   });
 
   test("importing the root module does not require CLI argv", async () => {

--- a/scripts/ci-routing.test.ts
+++ b/scripts/ci-routing.test.ts
@@ -1026,18 +1026,23 @@ describe("ci-routing module tree (split-safe)", () => {
       CHECKS_RES: "success",
       COMPONENT_REQ: "true",
       COMPONENT_SVELTE_RES: "success",
+      COMPONENT_SVELTE_FX_RES: "success",
       COMPONENT_SPIKES_RES: "success",
       VR_GUARD_RES: "success",
     });
     expect(ok.exitCode).toBe(0);
     expect(ok.stdout).toContain("ci-gate ok");
 
+    // Only the middle shard (component-svelte-fx) fails — the other two
+    // succeed. Confirms the CLI actually reads all three shard env vars
+    // rather than silently dropping the third one added alongside it.
     const failed = await spawnCiGate({
       EVENT_NAME: "pull_request",
       CHECKS_REQ: "true",
       CHECKS_RES: "success",
       COMPONENT_REQ: "true",
-      COMPONENT_SVELTE_RES: "failure",
+      COMPONENT_SVELTE_RES: "success",
+      COMPONENT_SVELTE_FX_RES: "failure",
       COMPONENT_SPIKES_RES: "success",
       VR_GUARD_RES: "skipped",
     });

--- a/scripts/ci-routing.ts
+++ b/scripts/ci-routing.ts
@@ -33,6 +33,7 @@ export {
   planJobs,
   evaluateGate,
   formatGithubOutputs,
+  normalizeJobResult,
   parseFileList,
   parseNameStatusList,
   jobNames,

--- a/scripts/ci-routing/ci-gate.test.ts
+++ b/scripts/ci-routing/ci-gate.test.ts
@@ -32,36 +32,42 @@ function baseInput(over: Partial<CiGateInput> = {}): CiGateInput {
     eventName: "pull_request",
     required: ALL_UNREQUIRED,
     results: {},
-    componentSvelteResult: undefined,
-    componentSpikesResult: undefined,
+    componentShardResults: [],
     vrBaselineGuardResult: "success",
     ...over,
   };
 }
 
 describe("aggregateComponentShards", () => {
-  test("both skipped → skipped (missing env var, empty string, or explicit 'skipped')", () => {
-    expect(aggregateComponentShards("skipped", "skipped")).toBe("skipped");
-    expect(aggregateComponentShards("", "")).toBe("skipped");
+  test("all skipped → skipped (missing env var, empty string, or explicit 'skipped')", () => {
+    expect(aggregateComponentShards(["skipped", "skipped"])).toBe("skipped");
+    expect(aggregateComponentShards(["", ""])).toBe("skipped");
+    expect(aggregateComponentShards(["skipped", "skipped", "skipped"])).toBe("skipped");
   });
 
-  test("both success → success", () => {
-    expect(aggregateComponentShards("success", "success")).toBe("success");
+  test("all success → success", () => {
+    expect(aggregateComponentShards(["success", "success"])).toBe("success");
+    expect(aggregateComponentShards(["success", "success", "success"])).toBe("success");
   });
 
   test("one success, one skipped → unknown (not success, not all-skipped)", () => {
-    expect(aggregateComponentShards("success", "skipped")).toBe("unknown");
+    expect(aggregateComponentShards(["success", "skipped"])).toBe("unknown");
   });
 
   test("any failure or cancelled present → failure", () => {
-    expect(aggregateComponentShards("failure", "success")).toBe("failure");
-    expect(aggregateComponentShards("success", "cancelled")).toBe("failure");
-    expect(aggregateComponentShards("failure", "cancelled")).toBe("failure");
-    expect(aggregateComponentShards("failure", "skipped")).toBe("failure");
+    expect(aggregateComponentShards(["failure", "success"])).toBe("failure");
+    expect(aggregateComponentShards(["success", "cancelled"])).toBe("failure");
+    expect(aggregateComponentShards(["failure", "cancelled"])).toBe("failure");
+    expect(aggregateComponentShards(["failure", "skipped"])).toBe("failure");
+    expect(aggregateComponentShards(["success", "success", "failure"])).toBe("failure");
   });
 
   test("unrecognized shard string → unknown", () => {
-    expect(aggregateComponentShards("bogus", "success")).toBe("unknown");
+    expect(aggregateComponentShards(["bogus", "success"])).toBe("unknown");
+  });
+
+  test("three-shard reality (component-svelte, component-svelte-fx, component-spikes): one skip among two successes → unknown, not success", () => {
+    expect(aggregateComponentShards(["success", "success", "skipped"])).toBe("unknown");
   });
 });
 
@@ -121,27 +127,35 @@ describe("evaluateCiGate", () => {
     expect(gate).toEqual({ ok: true, failures: [] });
   });
 
-  test("component result is derived from the two shard inputs, not results.component", () => {
+  test("component result is derived from the shard inputs, not results.component", () => {
     const gate = evaluateCiGate(
       baseInput({
         required: { ...ALL_UNREQUIRED, component: true },
         results: { component: "success" }, // must be ignored — shards win
-        componentSvelteResult: "failure",
-        componentSpikesResult: "success",
+        componentShardResults: ["failure", "success"],
       }),
     );
     expect(gate.failures).toEqual(["component"]);
   });
 
-  test("component required + both shards success → not listed", () => {
+  test("component required + all shards success (svelte, svelte-fx, spikes) → not listed", () => {
     const gate = evaluateCiGate(
       baseInput({
         required: { ...ALL_UNREQUIRED, component: true },
-        componentSvelteResult: "success",
-        componentSpikesResult: "success",
+        componentShardResults: ["success", "success", "success"],
       }),
     );
     expect(gate).toEqual({ ok: true, failures: [] });
+  });
+
+  test("component required + one of three shards fails → listed", () => {
+    const gate = evaluateCiGate(
+      baseInput({
+        required: { ...ALL_UNREQUIRED, component: true },
+        componentShardResults: ["success", "failure", "success"],
+      }),
+    );
+    expect(gate.failures).toEqual(["component"]);
   });
 
   test("docs_journeys is independent of component shards", () => {
@@ -149,8 +163,7 @@ describe("evaluateCiGate", () => {
       baseInput({
         required: { ...ALL_UNREQUIRED, docs_journeys: true },
         results: { docs_journeys: "success" },
-        componentSvelteResult: "failure",
-        componentSpikesResult: "failure",
+        componentShardResults: ["failure", "failure", "failure"],
       }),
     );
     expect(gate).toEqual({ ok: true, failures: [] });

--- a/scripts/ci-routing/ci-gate.test.ts
+++ b/scripts/ci-routing/ci-gate.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Characterization tests for the ci-gate job driver, extracted verbatim from
+ * the `bun -e '...'` heredoc formerly inlined in .github/workflows/ci.yml's
+ * `ci-gate` job (issue: astral-maintain ci.yml pass). The workflow's bash
+ * guard (`DETECT_RESULT != success` → `::error::...` + exit 1) stays in the
+ * YAML unchanged — these tests cover only what ran inside the heredoc.
+ */
+import { describe, expect, test } from "bun:test";
+
+import { aggregateComponentShards, evaluateCiGate, type CiGateInput } from "./ci-gate";
+import type { JobPlan } from "./routing";
+
+const ALL_UNREQUIRED: JobPlan = {
+  checks: false,
+  unit: false,
+  component: false,
+  consumer: false,
+  build: false,
+  svelte_check: false,
+  docs_site: false,
+  actions_security: false,
+  bench_smoke: false,
+  interaction_perf: false,
+  packages_dist: false,
+  vr: false,
+  pages: false,
+  docs_journeys: false,
+};
+
+function baseInput(over: Partial<CiGateInput> = {}): CiGateInput {
+  return {
+    eventName: "pull_request",
+    required: ALL_UNREQUIRED,
+    results: {},
+    componentSvelteResult: undefined,
+    componentSpikesResult: undefined,
+    vrBaselineGuardResult: "success",
+    ...over,
+  };
+}
+
+describe("aggregateComponentShards", () => {
+  test("both skipped → skipped (missing env var, empty string, or explicit 'skipped')", () => {
+    expect(aggregateComponentShards("skipped", "skipped")).toBe("skipped");
+    expect(aggregateComponentShards("", "")).toBe("skipped");
+  });
+
+  test("both success → success", () => {
+    expect(aggregateComponentShards("success", "success")).toBe("success");
+  });
+
+  test("one success, one skipped → unknown (not success, not all-skipped)", () => {
+    expect(aggregateComponentShards("success", "skipped")).toBe("unknown");
+  });
+
+  test("any failure or cancelled present → failure", () => {
+    expect(aggregateComponentShards("failure", "success")).toBe("failure");
+    expect(aggregateComponentShards("success", "cancelled")).toBe("failure");
+    expect(aggregateComponentShards("failure", "cancelled")).toBe("failure");
+    expect(aggregateComponentShards("failure", "skipped")).toBe("failure");
+  });
+
+  test("unrecognized shard string → unknown", () => {
+    expect(aggregateComponentShards("bogus", "success")).toBe("unknown");
+  });
+});
+
+describe("evaluateCiGate", () => {
+  test("nothing required, all inputs empty → ok", () => {
+    const gate = evaluateCiGate(baseInput());
+    expect(gate).toEqual({ ok: true, failures: [] });
+  });
+
+  test("required job missing (skipped) → listed as failure", () => {
+    const gate = evaluateCiGate(
+      baseInput({
+        required: { ...ALL_UNREQUIRED, unit: true },
+        results: {},
+      }),
+    );
+    expect(gate.ok).toBe(false);
+    expect(gate.failures).toEqual(["unit"]);
+  });
+
+  test("required job succeeded → not listed", () => {
+    const gate = evaluateCiGate(
+      baseInput({
+        required: { ...ALL_UNREQUIRED, unit: true },
+        results: { unit: "success" },
+      }),
+    );
+    expect(gate).toEqual({ ok: true, failures: [] });
+  });
+
+  test("required job failed/cancelled → listed", () => {
+    expect(
+      evaluateCiGate(
+        baseInput({
+          required: { ...ALL_UNREQUIRED, build: true },
+          results: { build: "failure" },
+        }),
+      ).failures,
+    ).toEqual(["build"]);
+    expect(
+      evaluateCiGate(
+        baseInput({
+          required: { ...ALL_UNREQUIRED, build: true },
+          results: { build: "cancelled" },
+        }),
+      ).failures,
+    ).toEqual(["build"]);
+  });
+
+  test("not-required job's failure is ignored", () => {
+    const gate = evaluateCiGate(
+      baseInput({
+        required: ALL_UNREQUIRED,
+        results: { build: "failure" },
+      }),
+    );
+    expect(gate).toEqual({ ok: true, failures: [] });
+  });
+
+  test("component result is derived from the two shard inputs, not results.component", () => {
+    const gate = evaluateCiGate(
+      baseInput({
+        required: { ...ALL_UNREQUIRED, component: true },
+        results: { component: "success" }, // must be ignored — shards win
+        componentSvelteResult: "failure",
+        componentSpikesResult: "success",
+      }),
+    );
+    expect(gate.failures).toEqual(["component"]);
+  });
+
+  test("component required + both shards success → not listed", () => {
+    const gate = evaluateCiGate(
+      baseInput({
+        required: { ...ALL_UNREQUIRED, component: true },
+        componentSvelteResult: "success",
+        componentSpikesResult: "success",
+      }),
+    );
+    expect(gate).toEqual({ ok: true, failures: [] });
+  });
+
+  test("docs_journeys is independent of component shards", () => {
+    const gate = evaluateCiGate(
+      baseInput({
+        required: { ...ALL_UNREQUIRED, docs_journeys: true },
+        results: { docs_journeys: "success" },
+        componentSvelteResult: "failure",
+        componentSpikesResult: "failure",
+      }),
+    );
+    expect(gate).toEqual({ ok: true, failures: [] });
+  });
+
+  test("docs_journeys missing result → normalized to skipped → listed", () => {
+    const gate = evaluateCiGate(
+      baseInput({
+        required: { ...ALL_UNREQUIRED, docs_journeys: true },
+        results: {},
+      }),
+    );
+    expect(gate.failures).toEqual(["docs_journeys"]);
+  });
+
+  test("multiple required-job failures are all listed, in JOB_NAMES order", () => {
+    const gate = evaluateCiGate(
+      baseInput({
+        required: { ...ALL_UNREQUIRED, unit: true, build: true, docs_site: true },
+        results: { unit: "failure", build: "success", docs_site: "cancelled" },
+      }),
+    );
+    expect(gate.failures).toEqual(["unit", "docs_site"]);
+  });
+
+  describe("vr-baseline-guard PR-only rule", () => {
+    test("non-pull_request event never checks the guard, even when missing/failed", () => {
+      const gate = evaluateCiGate(
+        baseInput({ eventName: "push", vrBaselineGuardResult: undefined }),
+      );
+      expect(gate).toEqual({ ok: true, failures: [] });
+
+      const gate2 = evaluateCiGate(
+        baseInput({ eventName: "push", vrBaselineGuardResult: "failure" }),
+      );
+      expect(gate2).toEqual({ ok: true, failures: [] });
+    });
+
+    test("pull_request + guard success → no failure entry", () => {
+      const gate = evaluateCiGate(
+        baseInput({ eventName: "pull_request", vrBaselineGuardResult: "success" }),
+      );
+      expect(gate).toEqual({ ok: true, failures: [] });
+    });
+
+    test("pull_request + guard skipped → exactly one vr-baseline-guard:skipped entry", () => {
+      const gate = evaluateCiGate(
+        baseInput({ eventName: "pull_request", vrBaselineGuardResult: "skipped" }),
+      );
+      expect(gate.failures).toEqual(["vr-baseline-guard:skipped"]);
+    });
+
+    test("pull_request + guard failure/cancelled/unknown → single vr-baseline-guard:<result> entry", () => {
+      expect(evaluateCiGate(baseInput({ vrBaselineGuardResult: "failure" })).failures).toEqual([
+        "vr-baseline-guard:failure",
+      ]);
+      expect(evaluateCiGate(baseInput({ vrBaselineGuardResult: "cancelled" })).failures).toEqual([
+        "vr-baseline-guard:cancelled",
+      ]);
+      expect(evaluateCiGate(baseInput({ vrBaselineGuardResult: "bogus" })).failures).toEqual([
+        "vr-baseline-guard:bogus",
+      ]);
+    });
+
+    test("pull_request + guard undefined → vr-baseline-guard:undefined (raw, not normalized)", () => {
+      const gate = evaluateCiGate(baseInput({ vrBaselineGuardResult: undefined }));
+      expect(gate.failures).toEqual(["vr-baseline-guard:undefined"]);
+    });
+
+    test("pull_request + guard empty string → vr-baseline-guard: (raw, not normalized to skipped)", () => {
+      const gate = evaluateCiGate(baseInput({ vrBaselineGuardResult: "" }));
+      expect(gate.failures).toEqual(["vr-baseline-guard:"]);
+    });
+
+    test("guard failure appended after required-job failures", () => {
+      const gate = evaluateCiGate(
+        baseInput({
+          required: { ...ALL_UNREQUIRED, unit: true },
+          results: { unit: "failure" },
+          vrBaselineGuardResult: "cancelled",
+        }),
+      );
+      expect(gate.failures).toEqual(["unit", "vr-baseline-guard:cancelled"]);
+    });
+  });
+});

--- a/scripts/ci-routing/ci-gate.ts
+++ b/scripts/ci-routing/ci-gate.ts
@@ -1,0 +1,79 @@
+/**
+ * ci-gate job driver (extracted from .github/workflows/ci.yml's `ci-gate`
+ * job, "evaluate required jobs" step). The step's leading bash guard
+ * (`DETECT_RESULT != success` → `::error::detect-changes failed — cannot
+ * trust routing` + exit 1) stays in the workflow YAML unchanged; by the time
+ * this driver runs, detect-changes is known to have succeeded.
+ *
+ * `component` is not read from `needs.<job>.result` directly — it is rolled
+ * up from the two component shards (component-svelte, component-spikes;
+ * issue #243) so a single required flag covers both.
+ */
+import {
+  evaluateGate,
+  normalizeJobResult,
+  type GateEvaluation,
+  type JobName,
+  type JobPlan,
+  type JobResult,
+} from "./routing";
+
+/**
+ * Roll up the two component test shards into one `JobResult`. Both skipped
+ * → skipped; both success → success; either failure/cancelled → failure;
+ * anything else (e.g. one success one skipped, or an unrecognized string) →
+ * unknown.
+ */
+export function aggregateComponentShards(
+  svelteResult: string | undefined,
+  spikesResult: string | undefined,
+): JobResult {
+  const shards = [normalizeJobResult(svelteResult), normalizeJobResult(spikesResult)];
+  if (shards.every((r) => r === "skipped")) return "skipped";
+  if (shards.every((r) => r === "success")) return "success";
+  if (shards.some((r) => r === "failure" || r === "cancelled")) return "failure";
+  return "unknown";
+}
+
+export type CiGateInput = {
+  eventName: string;
+  required: JobPlan;
+  /** Raw `needs.<job>.result` strings, one per non-component required job. */
+  results: Partial<Record<JobName, string | undefined>>;
+  componentSvelteResult: string | undefined;
+  componentSpikesResult: string | undefined;
+  /**
+   * Raw `needs.vr-baseline-guard.result` — intentionally NOT normalized.
+   * The PR-only rule below observes the literal value (including an
+   * `undefined`/`""` env var) rather than treating it as "skipped".
+   */
+  vrBaselineGuardResult: string | undefined;
+};
+
+/**
+ * Evaluate the required-jobs gate: `evaluateGate` over every routed job
+ * (with `component` replaced by the shard rollup) plus a PR-only rule that
+ * vr-baseline-guard must be `success` — it always schedules on
+ * `pull_request`, so any other result (including `skipped`) is a failure.
+ */
+export function evaluateCiGate(input: CiGateInput): GateEvaluation {
+  const results: Partial<Record<JobName, string | undefined>> = {
+    ...input.results,
+    component: aggregateComponentShards(input.componentSvelteResult, input.componentSpikesResult),
+  };
+
+  const gate = evaluateGate(input.required, results);
+  const failures = [...gate.failures];
+
+  if (input.eventName === "pull_request") {
+    const guard = input.vrBaselineGuardResult;
+    if (guard !== "success" && guard !== "skipped") {
+      failures.push(`vr-baseline-guard:${guard}`);
+    }
+    if (guard === "skipped") {
+      failures.push("vr-baseline-guard:skipped");
+    }
+  }
+
+  return { ok: failures.length === 0, failures };
+}

--- a/scripts/ci-routing/ci-gate.ts
+++ b/scripts/ci-routing/ci-gate.ts
@@ -6,8 +6,10 @@
  * this driver runs, detect-changes is known to have succeeded.
  *
  * `component` is not read from `needs.<job>.result` directly — it is rolled
- * up from the two component shards (component-svelte, component-spikes;
- * issue #243) so a single required flag covers both.
+ * up from the component test shards (component-svelte, component-svelte-fx,
+ * component-spikes; issues #243, #575) so a single required flag covers all
+ * of them. The shard list is an array (not fixed-arity params) because it
+ * has already grown once and the aggregation rule is shard-count-agnostic.
  */
 import {
   evaluateGate,
@@ -19,16 +21,12 @@ import {
 } from "./routing";
 
 /**
- * Roll up the two component test shards into one `JobResult`. Both skipped
- * → skipped; both success → success; either failure/cancelled → failure;
- * anything else (e.g. one success one skipped, or an unrecognized string) →
- * unknown.
+ * Roll up the component test shards into one `JobResult`. All skipped →
+ * skipped; all success → success; any failure/cancelled → failure; anything
+ * else (e.g. one success one skipped, or an unrecognized string) → unknown.
  */
-export function aggregateComponentShards(
-  svelteResult: string | undefined,
-  spikesResult: string | undefined,
-): JobResult {
-  const shards = [normalizeJobResult(svelteResult), normalizeJobResult(spikesResult)];
+export function aggregateComponentShards(shardResults: readonly (string | undefined)[]): JobResult {
+  const shards = shardResults.map((r) => normalizeJobResult(r));
   if (shards.every((r) => r === "skipped")) return "skipped";
   if (shards.every((r) => r === "success")) return "success";
   if (shards.some((r) => r === "failure" || r === "cancelled")) return "failure";
@@ -40,8 +38,7 @@ export type CiGateInput = {
   required: JobPlan;
   /** Raw `needs.<job>.result` strings, one per non-component required job. */
   results: Partial<Record<JobName, string | undefined>>;
-  componentSvelteResult: string | undefined;
-  componentSpikesResult: string | undefined;
+  componentShardResults: readonly (string | undefined)[];
   /**
    * Raw `needs.vr-baseline-guard.result` — intentionally NOT normalized.
    * The PR-only rule below observes the literal value (including an
@@ -59,7 +56,7 @@ export type CiGateInput = {
 export function evaluateCiGate(input: CiGateInput): GateEvaluation {
   const results: Partial<Record<JobName, string | undefined>> = {
     ...input.results,
-    component: aggregateComponentShards(input.componentSvelteResult, input.componentSpikesResult),
+    component: aggregateComponentShards(input.componentShardResults),
   };
 
   const gate = evaluateGate(input.required, results);

--- a/scripts/ci-routing/cli.ts
+++ b/scripts/ci-routing/cli.ts
@@ -274,8 +274,11 @@ function runCiGateCli(): void {
       packages_dist: env.PACKAGES_DIST_RES,
       docs_journeys: env.DOCS_JOURNEYS_RES,
     },
-    componentSvelteResult: env.COMPONENT_SVELTE_RES,
-    componentSpikesResult: env.COMPONENT_SPIKES_RES,
+    componentShardResults: [
+      env.COMPONENT_SVELTE_RES,
+      env.COMPONENT_SVELTE_FX_RES,
+      env.COMPONENT_SPIKES_RES,
+    ],
     vrBaselineGuardResult: env.VR_GUARD_RES,
   });
   if (!gate.ok) {

--- a/scripts/ci-routing/cli.ts
+++ b/scripts/ci-routing/cli.ts
@@ -15,6 +15,7 @@ import {
   type JobName,
   type JobPlan,
 } from "./routing";
+import { evaluateCiGate } from "./ci-gate";
 import {
   CACHEABLE_EXECUTIONS,
   CONTENT_HASH_SCHEMA,
@@ -86,6 +87,11 @@ export async function runCiRoutingCli(argv: string[]): Promise<void> {
     return;
   }
 
+  if (cmd === "ci-gate") {
+    runCiGateCli();
+    return;
+  }
+
   if (cmd === "gate") {
     const requiredPath = flagValue(args, "--required");
     const resultsPath = flagValue(args, "--results");
@@ -117,12 +123,17 @@ function printHelp(): void {
   bun scripts/ci-routing.ts write-success-marker --execution <name> --hash <hex>
   bun scripts/ci-routing.ts validate-success-marker --execution <name> --hash <hex>
   bun scripts/ci-routing.ts gate --required <file|-> --results <file|->
+  bun scripts/ci-routing.ts ci-gate
 
   detect-changes reads EVENT_NAME, GITHUB_REF, BASE_SHA, HEAD_SHA, PR_LABELS,
   REPO, GITHUB_OUTPUT (and uses gh/git for main base widening).
   --from-git uses git diff --name-status (rename source + dest).
   --stdin accepts plain paths or name-status lines (tab-separated).
   hash-inputs uses git ls-tree -r HEAD (fail-closed). Emits hash + cache_key (+ GITHUB_OUTPUT).
+  ci-gate reads the ci.yml ci-gate job's required/result env vars (CHECKS_REQ
+  .. DOCS_JOURNEYS_REQ, CHECKS_RES .. VR_GUARD_RES, EVENT_NAME) and evaluates
+  the required-jobs gate, including component-shard rollup and the PR-only
+  vr-baseline-guard rule. Prints "ci-gate ok" or "ci-gate failed: <list>".
 `);
 }
 
@@ -222,6 +233,57 @@ function runDetectChangesCli(): void {
     throw new Error("detect-changes requires GITHUB_OUTPUT (job outputs path)");
   }
   runDetectChanges(input, createDetectChangesIo());
+}
+
+/**
+ * `ci-gate` job driver. The workflow's bash guard on `DETECT_RESULT` runs
+ * before this command (see ci.yml's `ci-gate` job) — by the time this is
+ * invoked, detect-changes is known to have succeeded.
+ */
+function runCiGateCli(): void {
+  const env = process.env;
+  const req = (k: string) => env[k] === "true";
+  const required: JobPlan = {
+    checks: req("CHECKS_REQ"),
+    unit: req("UNIT_REQ"),
+    component: req("COMPONENT_REQ"),
+    consumer: req("CONSUMER_REQ"),
+    build: req("BUILD_REQ"),
+    svelte_check: req("SVELTE_CHECK_REQ"),
+    docs_site: req("DOCS_SITE_REQ"),
+    actions_security: req("ACTIONS_REQ"),
+    bench_smoke: req("BENCH_REQ"),
+    interaction_perf: false,
+    packages_dist: req("PACKAGES_DIST_REQ"),
+    vr: false,
+    pages: false,
+    docs_journeys: req("DOCS_JOURNEYS_REQ"),
+  };
+  const gate = evaluateCiGate({
+    eventName: env.EVENT_NAME ?? "",
+    required,
+    results: {
+      checks: env.CHECKS_RES,
+      unit: env.UNIT_RES,
+      consumer: env.CONSUMER_RES,
+      build: env.BUILD_RES,
+      svelte_check: env.SVELTE_CHECK_RES,
+      docs_site: env.DOCS_SITE_RES,
+      actions_security: env.ACTIONS_RES,
+      bench_smoke: env.BENCH_RES,
+      packages_dist: env.PACKAGES_DIST_RES,
+      docs_journeys: env.DOCS_JOURNEYS_RES,
+    },
+    componentSvelteResult: env.COMPONENT_SVELTE_RES,
+    componentSpikesResult: env.COMPONENT_SPIKES_RES,
+    vrBaselineGuardResult: env.VR_GUARD_RES,
+  });
+  if (!gate.ok) {
+    process.stderr.write(`ci-gate failed: ${gate.failures.join(", ")}\n`);
+    process.exitCode = 1;
+    return;
+  }
+  process.stdout.write("ci-gate ok\n");
 }
 
 function parseCacheableExecution(raw: string | undefined): CacheableExecution {

--- a/scripts/ci-routing/routing.ts
+++ b/scripts/ci-routing/routing.ts
@@ -451,7 +451,7 @@ export function evaluateGate(
   const failures: string[] = [];
   for (const job of JOB_NAMES) {
     if (!required[job]) continue;
-    const result = normalizeResult(results[job]);
+    const result = normalizeJobResult(results[job]);
     if (result === "success") continue;
     if (result === "skipped") {
       failures.push(job);
@@ -463,7 +463,8 @@ export function evaluateGate(
   return { ok: failures.length === 0, failures };
 }
 
-function normalizeResult(value: string | undefined): JobResult {
+/** Coerce a raw `needs.<job>.result` string to `JobResult`; missing/empty → skipped. */
+export function normalizeJobResult(value: string | undefined): JobResult {
   if (value === "success" || value === "failure" || value === "cancelled" || value === "skipped") {
     return value;
   }


### PR DESCRIPTION
## Astral-maintain: ci.yml audit

Target: `.github/workflows/ci.yml`, chosen because it is 1137 lines and — unlike every other job in the file — the `ci-gate` job (the single required branch-protection check) carries ~65 lines of real control-flow logic inline in a `bun -e '...'` heredoc, invisible to `bun test` and untyped in CI.

Evidence: `detect-changes` and `vr-baseline-guard` already delegate to `scripts/ci-routing.ts` / `scripts/vr-baseline-guard.ts`. `ci-gate` reimplemented `evaluateGate` wiring by hand instead of reusing the (already-existing, unused) `gate --required/--results` CLI command, and additionally rolled its own component-shard aggregation and PR-only vr-baseline-guard rule — both un-exported, un-tested, YAML-only.

## What changed

- `scripts/ci-routing/ci-gate.ts` (new): `aggregateComponentShards` + `evaluateCiGate`, a direct, behavior-preserving restatement of the former heredoc's control flow — mirrors the existing `scripts/ci-routing/detect-changes.ts` pattern.
- `scripts/ci-routing/routing.ts`: export the previously-private `normalizeResult` as `normalizeJobResult` for reuse.
- `scripts/ci-routing/cli.ts`: new `ci-gate` command (env-var driven, same names ci.yml already sets) wired into `runCiRoutingCli`.
- `.github/workflows/ci.yml`: the `ci-gate` job's "evaluate required jobs" step keeps its bash `DETECT_RESULT` guard unchanged, and the 65-line heredoc becomes `run: bun scripts/ci-routing.ts ci-gate`.
- Added the existing `gate --required/--results` command stays untouched/unused by design — it's generic JSON-file-driven, `ci-gate` is the CI-specific adapter (a plan reviewer flagged mixing the two contracts as worse).

Explicitly did **not** introduce Python/uv — this is a 100% bun/TypeScript monorepo with zero existing Python, and the repo already has an established "logic in scripts/ci-routing/*.ts, YAML calls the script" pattern (`detect-changes`, `vr-baseline-guard`) that this change follows instead.

## Why this improves maintainability

- The job gating every merge in the repo is now covered by `bun test`, oxlint's type-aware pass, and manual CLI smoke checks — previously it had none of the three.
- Removes duplicated `evaluateGate` wiring; the CLI-level and pure-function tests pin the exact current truth table (per-job required/result semantics, component-svelte + component-spikes shard rollup, and the PR-only vr-baseline-guard rule, including its intentionally-unnormalized raw-value edge cases like `vr-baseline-guard:undefined`).
- Zero behavior change: same env var names, same stdout/stderr strings (`ci-gate ok` / `ci-gate failed: <list>`), same exit codes.

## Review

- Plan reviewed via `codex` (gpt-5.6-terra, high effort) before implementation — findings incorporated: keep the bash detect-changes guard untouched instead of folding it into the TS module (avoids a whole class of behavior-preservation risk around message/stream), pass `vrBaselineGuardResult` raw/unnormalized, add CLI-level integration tests (not just pure-function tests), rename the exported normalizer, and explicitly rule out folding the 3 duplicated playwright-version-sync one-liners into this PR.
- Code reviewed via `codex review` against `main...HEAD` — GATE: PASS, no P1/P2 findings.
- No standalone `claude` consult skill is available in this host, so plan review proceeded with `codex` alone per the astral-maintain fallback.

## Test plan

- [x] `bun test scripts` — 538 pass (0 fail), including new `scripts/ci-routing/ci-gate.test.ts` (22 tests) and the new CLI-level `ci-gate` test in `scripts/ci-routing.test.ts`
- [x] `bun run lint:type-aware` (oxlint --type-aware --deny-warnings .) — clean
- [x] `bun run lint:actions` (actionlint) — 13 workflow files clean
- [x] `uvx zizmor==1.26.1 .github/workflows/ci.yml` — no findings
- [x] `bun run knip` — clean, no unused-export findings for the new surface
- [x] Manual `bun scripts/ci-routing.ts ci-gate` smoke run against several env-var combinations (all-success PR, one required job skipped, push event with guard var unset, PR with guard skipped) — output matches the former heredoc exactly
- [x] `oxfmt` / `prettier --check` — clean

## Follow-ups

- #578 — dedupe the 3 duplicated playwright-npm-vs-container-tag version-sync one-liners (component-svelte / component-spikes / component-journeys) into one composite action. Deliberately out of scope for this PR (small, low-risk, unrelated to the ci-gate extraction; flagged explicitly by plan review as legitimate-but-separate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)