### PR TITLE
fix(core): honest band-guide pin overflow and overlap

### DIFF
--- a/apps/docs/src/lib/generated/search-index.ts
+++ b/apps/docs/src/lib/generated/search-index.ts
@@ -13260,7 +13260,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "diagnostic",
     title: "band-label-margin-overflow · warning",
     summary:
-      "A band label is truncated (ellipsis) to fit a bounded axis margin — a rotated label past the bottom cap, or a single-line end label past the side cap.",
+      "A band label exceeds a bounded axis margin — single-line end truncation, forced-wrap height/side overflow, or a rotated label past the bottom/side cap.",
     href: "/guide/errors#band-label-margin-overflow",
     keywords: [
       "warning",

--- a/packages/core/src/diagnostics.ts
+++ b/packages/core/src/diagnostics.ts
@@ -314,7 +314,7 @@ export const PIPELINE_WARNING_CATALOG = {
   },
   "band-label-margin-overflow": {
     summary:
-      "A band label is truncated (ellipsis) to fit a bounded axis margin — a rotated label past the bottom cap, or a single-line end label past the side cap.",
+      "A band label exceeds a bounded axis margin — single-line end truncation, forced-wrap height/side overflow, or a rotated label past the bottom/side cap.",
   },
   "coord-tessellation-cap": {
     summary:

--- a/packages/core/src/layout/band-guide.ts
+++ b/packages/core/src/layout/band-guide.ts
@@ -127,8 +127,13 @@ export function planBandAxis(input: BandAxisPlanInput): BandAxisPlan {
     if (marginOverflow) degraded.push("band-label-margin-overflow");
     let overlap = false;
     if (opts?.reportOverlap === true && entries.length > 0) {
+      // Remeasure after end-cap truncation so shortened display labels are what
+      // the overlap check sees (not the pre-truncation entry widths).
       overlap = neighbourOverlap(
-        entries.map((e) => ({ pos: e.center, half: e.width / 2 })),
+        ticks.map((tick, i) => ({
+          pos: entries[i]!.center,
+          half: measurer.measureWidth(tick.label, fontSize) / 2,
+        })),
         gap,
       );
       if (overlap) degraded.push("band-label-overlap");
@@ -176,13 +181,9 @@ export function planBandAxis(input: BandAxisPlanInput): BandAxisPlan {
 
   /** Try a wrap layout. When `force`, keep mode even if tokens can't wrap / overlap. */
   const tryWrapPlan = (force: boolean): BandAxisPlan | null => {
-    const wrapped = entries.map((e) => {
-      const lines = wrapLabel(e.label, bandBudget, measurer, fontSize, maxWrapLines);
-      if (lines !== null) return lines;
-      // Forced wrap: keep unbreakable tokens as a single (possibly over-wide) line
-      // so the author pin is not silently escalated to rotation.
-      return force ? [e.label] : null;
-    });
+    const wrapped = entries.map((e) =>
+      wrapLabel(e.label, bandBudget, measurer, fontSize, maxWrapLines, { force }),
+    );
     if (!force && !wrapped.every((w): w is string[] => w !== null)) return null;
     const linesList = wrapped as string[][];
     const lineWidths = linesList.map((lines) =>

--- a/packages/core/src/layout/band-label-layout.ts
+++ b/packages/core/src/layout/band-label-layout.ts
@@ -35,22 +35,34 @@ export function quantizeUp(px: number, quantum: number): number {
   return Math.ceil(px / quantum - 1e-9) * quantum;
 }
 
-/** Greedy word wrap; null when a single token exceeds `maxWidth` or lines > cap. */
+/**
+ * Greedy word wrap.
+ * - null when a single token exceeds `maxWidth` (unbreakable), or when
+ *   lines > cap and `force` is false.
+ * - When `force` is true and the wrap needs more than `maxLines`, keep the
+ *   first `maxLines - 1` lines and join the remainder onto the last line so
+ *   forced wrap pins stay multi-line instead of collapsing to the full label.
+ */
 export function wrapLabel(
   label: string,
   maxWidth: number,
   measurer: TextMeasurer,
   fontSize: number,
   maxLines: number,
+  options?: { readonly force?: boolean },
 ): string[] | null {
+  const force = options?.force === true;
   const words = label.split(/\s+/).filter((w) => w.length > 0);
   if (words.length <= 1) {
-    return measurer.measureWidth(label, fontSize) <= maxWidth ? [label] : null;
+    return measurer.measureWidth(label, fontSize) <= maxWidth || force ? [label] : null;
   }
   const lines: string[] = [];
   let current = "";
   for (const word of words) {
-    if (measurer.measureWidth(word, fontSize) > maxWidth) return null; // unbreakable token
+    if (measurer.measureWidth(word, fontSize) > maxWidth) {
+      // Unbreakable token — force keeps a single-line pin; auto escalates.
+      return force ? [label] : null;
+    }
     const trial = current === "" ? word : `${current} ${word}`;
     if (measurer.measureWidth(trial, fontSize) <= maxWidth) {
       current = trial;
@@ -60,7 +72,14 @@ export function wrapLabel(
     }
   }
   if (current !== "") lines.push(current);
-  return lines.length <= maxLines ? lines : null;
+  if (lines.length <= maxLines) return lines;
+  if (!force) return null;
+  // Cap: preserve multi-line presentation; remaining words sit on the last line
+  // (may be over-wide — callers report side/overlap overflow honestly).
+  if (maxLines === 1) return [lines.join(" ")];
+  const head = lines.slice(0, maxLines - 1);
+  const tail = lines.slice(maxLines - 1).join(" ");
+  return [...head, tail];
 }
 
 /**

--- a/packages/core/src/pipeline/assemble-render-model.ts
+++ b/packages/core/src/pipeline/assemble-render-model.ts
@@ -29,28 +29,37 @@ function bandGuideDiagnostic(code: string, aesthetic: "x" | "y", mode: BandLabel
   // A margin overflow on a single-line axis is a HORIZONTAL end-cap problem (a
   // wide end label past the panel edge), not a rotated-label bottom-margin one —
   // so steer the user to width, not height, and never claim rotation.
+  // Forced wrap overflow is neither rotation nor truncation: over-tall wraps need
+  // height; side overhang from wide wrap lines needs width — mention both.
   const horizontalCap = margin && mode === "single-line";
+  const wrappedCap = margin && mode === "wrapped";
   return {
     code,
     severity: "warning" as const,
     path: `/scales/${aesthetic}`,
     problem: horizontalCap
       ? "A categorical end label is truncated to fit the axis width."
-      : margin
-        ? "A rotated categorical label is truncated to fit the axis margin cap."
-        : "Categorical labels overlap even after wrapping and rotation.",
+      : wrappedCap
+        ? "A wrapped categorical label exceeds the axis margin budget."
+        : margin
+          ? "A rotated categorical label is truncated to fit the axis margin cap."
+          : "Categorical labels overlap even after wrapping and rotation.",
     cause: horizontalCap
       ? "The end label extends past the panel edge and the bounded side margin can't fit it."
-      : margin
-        ? "The full label is longer than the bounded bottom margin allows, even rotated."
-        : "There are more (or longer) categories than the axis width can separate.",
+      : wrappedCap
+        ? "The forced wrap footprint is taller than the bottom margin and/or wider than the side margin allows."
+        : margin
+          ? "The full label is longer than the bounded bottom margin allows, even rotated."
+          : "There are more (or longer) categories than the axis width can separate.",
     fixes: [
       {
         description: horizontalCap
           ? "Use shorter category labels or allocate more chart width."
-          : margin
-            ? "Use shorter category labels or allocate more chart height."
-            : "Reduce the number of categories or allocate more chart width.",
+          : wrappedCap
+            ? "Use shorter category labels, fewer wrap lines, or allocate more chart width/height."
+            : margin
+              ? "Use shorter category labels or allocate more chart height."
+              : "Reduce the number of categories or allocate more chart width.",
       },
       COORD_FLIP_FIX,
     ],

--- a/packages/core/tests/band-guide/author-pins.test.ts
+++ b/packages/core/tests/band-guide/author-pins.test.ts
@@ -23,6 +23,22 @@ describe("planBandAxis: author guide pins (#407)", () => {
     expect(pinned.degraded).toContain("band-label-overlap");
   });
 
+  it("mode:single measures overlap after end-label truncation", () => {
+    // Full pre-truncation widths collide; side-cap ellipsis shortens the ends so
+    // rendered labels clear each other. Using entry widths would false-positive.
+    const cats = ["VERYLONGLABEL", "A", "VERYLONGLABEL"];
+    const pinned = plan(cats, 120, {
+      config: { mode: "single" },
+      marginCapPx: 8,
+      orthogonalMarginCapPx: 200,
+    });
+    expect(pinned.mode).toBe("single-line");
+    expect(pinned.marginOverflow).toBe(true);
+    expect(pinned.ticks.some((t, i) => t.label !== cats[i])).toBe(true);
+    expect(pinned.overlap).toBe(false);
+    expect(pinned.degraded).not.toContain("band-label-overlap");
+  });
+
   it("mode:wrap pins wrap even when auto would stay single-line", () => {
     const short = ["IT", "HR", "Ops", "Sales"];
     expect(plan(short, 480).mode).toBe("single-line");
@@ -101,6 +117,26 @@ describe("planBandAxis: author guide pins (#407)", () => {
     });
     expect(twoLines.mode).toBe("wrapped");
     expect(twoLines.ticks.every((t) => (t.lines?.length ?? 0) <= 2)).toBe(true);
+  });
+
+  it("mode:wrap keeps capped multi-line layout when labels need more than wrap lines", () => {
+    // Multi-word label that needs >2 lines on a narrow band; forced wrap must
+    // not collapse back to a single full-width line.
+    const label = "one two three four five six seven eight";
+    // extent 150 → band ~50px: words fit individually but need >2 wrap lines.
+    const pinned = plan([label, "A", "B"], 150, {
+      config: { mode: "wrap", wrap: 2 },
+      orthogonalMarginCapPx: 200,
+      marginCapPx: 40,
+    });
+    expect(pinned.mode).toBe("wrapped");
+    const lines = pinned.ticks[0]?.lines;
+    expect(lines).toBeDefined();
+    expect(lines!.length).toBeGreaterThan(1);
+    expect(lines!.length).toBeLessThanOrEqual(2);
+    // Collapsing to the full label as one line would produce a single-line pin.
+    expect(lines![0]).not.toBe(label);
+    expect(lines!.join(" ")).toBe(label);
   });
 
   it("auto + guide.angle uses the pinned angle when escalating to rotate", () => {

--- a/packages/core/tests/pipeline-band.test.ts
+++ b/packages/core/tests/pipeline-band.test.ts
@@ -77,6 +77,21 @@ describe("band axis diagnostics (#387)", () => {
     expect(model.advisories.some((a) => a.code === "band-labels-rotated")).toBe(false);
   });
 
+  it("describes forced-wrap margin overflow without claiming rotation (Codex #527)", () => {
+    const wrapSpec: SpecInput = {
+      data: { values: rows },
+      layers: [{ geom: "col", aes: { x: { field: "category" }, y: { field: "count" } } }],
+      scales: { x: { guide: { mode: "wrap", wrap: 8 } } },
+    };
+    // Short height forces wrap block past the orthogonal margin cap.
+    const model = runPipeline(wrapSpec, { width: 560, height: 80 });
+    const diag = model.scaleDiagnostics.find((d) => d.code === "band-label-margin-overflow");
+    expect(diag).toBeDefined();
+    expect(diag?.problem).toMatch(/wrap/i);
+    expect(diag?.problem).not.toMatch(/rotat/i);
+    expect(diag?.cause).not.toMatch(/rotat/i);
+  });
+
   it("re-plans the narrower final facet panel so the band margin is reserved (Codex P2)", () => {
     // Two columns force each panel far narrower than the whole width. The band is
     // re-measured at the final panel size (not the optimistic approx), so the


### PR DESCRIPTION
## Summary

Follow-up for unrebutted post-merge Codex P2s on #527.

| Finding | Fix |
|---------|-----|
| Label forced-wrap overflow diagnostics correctly | `bandGuideDiagnostic` has a wrapped-mode branch (not rotation copy) |
| Preserve wrapping when forced labels exceed the line cap | `wrapLabel({ force })` caps at maxLines instead of collapsing to one line |
| Measure overlap after single-line truncation | Forced single remeasures tick labels after `capEndOverhang` |

## Tests

```text
bun test packages/core/tests/band-guide/ packages/core/tests/pipeline-band.test.ts packages/core/tests/layout/band-axis.test.ts
# 61 pass
```