### PR TITLE
ci: install unzip fast via Azure Ubuntu mirror (15m50s → ~15s)

### DIFF
--- a/.github/actions/ci-install-unzip/action.yml
+++ b/.github/actions/ci-install-unzip/action.yml
@@ -29,20 +29,22 @@ runs:
           echo "unzip already present ($(command -v unzip)); skipping apt."
           exit 0
         fi
-        list="$(mktemp)"
         keyring=/usr/share/keyrings/ubuntu-archive-keyring.gpg
+        # Write an azure-mirror, main-only source into sources.list.d so BOTH the
+        # update below and the install (which uses apt's default source config)
+        # resolve unzip from it.
         {
           echo "deb [signed-by=${keyring}] http://azure.archive.ubuntu.com/ubuntu noble main"
           echo "deb [signed-by=${keyring}] http://azure.archive.ubuntu.com/ubuntu noble-updates main"
-        } > "$list"
-        # Refresh indexes from ONLY the list above (sourceparts=- disables the
-        # image's default sources for this update), so we pull ~a few MB of
-        # `main` instead of the full 31 MB across universe/security/backports.
+        } > /etc/apt/sources.list.d/ci-unzip.list
+        # Restrict ONLY the update to our source (sourceparts=- skips the image's
+        # default sources), so we pull ~a few MB of `main` from the co-located
+        # Azure mirror instead of 31 MB across universe/security/backports from
+        # the throttled public mirrors.
         apt-get \
-          -o Dir::Etc::sourcelist="$list" \
           -o Dir::Etc::sourceparts="-" \
+          -o Dir::Etc::sourcelist="sources.list.d/ci-unzip.list" \
           -o APT::Get::List-Cleanup="0" \
           update
         apt-get install -y --no-install-recommends unzip
-        rm -f "$list"
-        unzip -v | head -1
+        echo "unzip installed: $(command -v unzip)"

--- a/.github/actions/ci-install-unzip/action.yml
+++ b/.github/actions/ci-install-unzip/action.yml
@@ -1,0 +1,48 @@
+# Install `unzip` into the Playwright container, fast.
+#
+# Why this exists: oven-sh/setup-bun extracts the Bun release zip with
+# @actions/tool-cache `extractZip`, which shells out to the system `unzip`
+# binary on Linux (verified in setup-bun src/action.ts). The
+# mcr.microsoft.com/playwright image ships no `unzip`, so every container job
+# has to install it before ci-setup-bun runs.
+#
+# Why not a plain `apt-get update`: GitHub-hosted runners run on Azure (the
+# runner banner prints `Azure Region: northcentralus`). The public
+# archive.ubuntu.com / security.ubuntu.com mirrors are badly throttled from
+# Azure -- a real run fetched 31.6 MB of apt indexes at 34.4 kB/s and took
+# 15m50s just to install unzip. This action instead refreshes ONLY `main` from
+# the co-located Azure Ubuntu mirror (a few MB, ~15s).
+#
+# No-op when `unzip` is already present (e.g. non-container runners already have
+# it), so calling this action is always safe.
+name: CI install unzip (fast)
+description: Install unzip into the Playwright container via the Azure Ubuntu mirror (main only).
+
+runs:
+  using: composite
+  steps:
+    - name: install unzip via Azure Ubuntu mirror (main only)
+      shell: bash
+      run: |
+        set -euo pipefail
+        if command -v unzip >/dev/null 2>&1; then
+          echo "unzip already present ($(command -v unzip)); skipping apt."
+          exit 0
+        fi
+        list="$(mktemp)"
+        keyring=/usr/share/keyrings/ubuntu-archive-keyring.gpg
+        {
+          echo "deb [signed-by=${keyring}] http://azure.archive.ubuntu.com/ubuntu noble main"
+          echo "deb [signed-by=${keyring}] http://azure.archive.ubuntu.com/ubuntu noble-updates main"
+        } > "$list"
+        # Refresh indexes from ONLY the list above (sourceparts=- disables the
+        # image's default sources for this update), so we pull ~a few MB of
+        # `main` instead of the full 31 MB across universe/security/backports.
+        apt-get \
+          -o Dir::Etc::sourcelist="$list" \
+          -o Dir::Etc::sourceparts="-" \
+          -o APT::Get::List-Cleanup="0" \
+          update
+        apt-get install -y --no-install-recommends unzip
+        rm -f "$list"
+        unzip -v | head -1

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -36,8 +36,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - name: install unzip (playwright image lacks it; setup-bun needs it)
-        run: apt-get update && apt-get install -y --no-install-recommends unzip
+      - uses: ./.github/actions/ci-install-unzip
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.3.14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -454,8 +454,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - name: install unzip (playwright image lacks it; setup-bun needs it)
-        run: apt-get update && apt-get install -y --no-install-recommends unzip
+      - uses: ./.github/actions/ci-install-unzip
       - uses: ./.github/actions/ci-setup-bun
       - uses: ./.github/actions/ci-content-hash-restore
         id: content_hash
@@ -584,8 +583,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - name: install unzip (playwright image lacks it; setup-bun needs it)
-        run: apt-get update && apt-get install -y --no-install-recommends unzip
+      - uses: ./.github/actions/ci-install-unzip
       - uses: ./.github/actions/ci-setup-bun
       - uses: ./.github/actions/ci-content-hash-restore
         id: content_hash
@@ -654,8 +652,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - name: install unzip (playwright image lacks it; setup-bun needs it)
-        run: apt-get update && apt-get install -y --no-install-recommends unzip
+      - uses: ./.github/actions/ci-install-unzip
       - uses: ./.github/actions/ci-setup-bun
       - uses: ./.github/actions/ci-content-hash-restore
         id: content_hash
@@ -726,8 +723,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - name: install unzip (playwright image lacks it; setup-bun needs it)
-        run: apt-get update && apt-get install -y --no-install-recommends unzip
+      - uses: ./.github/actions/ci-install-unzip
       - uses: ./.github/actions/ci-setup-bun
       - uses: ./.github/actions/ci-content-hash-restore
         id: content_hash
@@ -806,8 +802,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - name: install unzip (playwright image lacks it; setup-bun needs it)
-        run: apt-get update && apt-get install -y --no-install-recommends unzip
+      - uses: ./.github/actions/ci-install-unzip
       - uses: ./.github/actions/ci-setup-bun
       - uses: ./.github/actions/ci-bun-install
         with:

--- a/.github/workflows/vr-compare.yml
+++ b/.github/workflows/vr-compare.yml
@@ -288,7 +288,32 @@ jobs:
           # screenshotted is exactly what vr-approve re-verifies against.
           ref: ${{ needs.approve-gate.outputs.render_sha }}
           persist-credentials: false
-      - uses: ./.github/actions/ci-install-unzip
+      # Inlined (not `uses: ./.github/actions/ci-install-unzip`) on purpose: the
+      # checkout above replaced the workspace with the approved PR's merged
+      # render SHA, and a workspace-local `uses: ./...` resolves against THAT
+      # tree. Render SHAs merged before this helper existed would not contain
+      # the action, so the step would fail before setup-bun. This self-contained
+      # script works regardless of the checked-out tree. Mirrors
+      # .github/actions/ci-install-unzip (fast Azure-mirror, main-only).
+      - name: install unzip via Azure Ubuntu mirror (main only)
+        run: |
+          set -euo pipefail
+          if command -v unzip >/dev/null 2>&1; then
+            echo "unzip already present ($(command -v unzip)); skipping apt."
+            exit 0
+          fi
+          keyring=/usr/share/keyrings/ubuntu-archive-keyring.gpg
+          {
+            echo "deb [signed-by=${keyring}] http://azure.archive.ubuntu.com/ubuntu noble main"
+            echo "deb [signed-by=${keyring}] http://azure.archive.ubuntu.com/ubuntu noble-updates main"
+          } > /etc/apt/sources.list.d/ci-unzip.list
+          apt-get \
+            -o Dir::Etc::sourceparts="-" \
+            -o Dir::Etc::sourcelist="sources.list.d/ci-unzip.list" \
+            -o APT::Get::List-Cleanup="0" \
+            update
+          apt-get install -y --no-install-recommends unzip
+          echo "unzip installed: $(command -v unzip)"
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.3.14

--- a/.github/workflows/vr-compare.yml
+++ b/.github/workflows/vr-compare.yml
@@ -97,8 +97,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - name: install unzip (playwright image lacks it; setup-bun needs it)
-        run: apt-get update && apt-get install -y --no-install-recommends unzip
+      - uses: ./.github/actions/ci-install-unzip
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.3.14
@@ -289,6 +288,7 @@ jobs:
           # screenshotted is exactly what vr-approve re-verifies against.
           ref: ${{ needs.approve-gate.outputs.render_sha }}
           persist-credentials: false
+      - uses: ./.github/actions/ci-install-unzip
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.3.14


### PR DESCRIPTION
## Problem

Every Playwright-container job installs `unzip` before `ci-setup-bun` (setup-bun extracts Bun with the system `unzip` binary — verified in [setup-bun `src/action.ts`](https://github.com/oven-sh/setup-bun/blob/0c5077e51419868618aeaa5fe8019c62421857d6/src/action.ts#L183): `extractZip` shells out to `unzip` on Linux). The Playwright image ships no `unzip`.

It did this with a plain `apt-get update`. GitHub-hosted runners run on **Azure** (the runner banner prints `Azure Region: northcentralus`), where the public `archive.ubuntu.com` / `security.ubuntu.com` mirrors are throttled. A real run:

```
Fetched 31.6 MB in 15min 19s (34.4 kB/s)
```

with a 7.5-minute dead stall between two index fetches. That's **15m50s to install unzip**, on every container job. (The `/root/.docker/config.json: permission denied` warning in those logs is unrelated — it's the docker CLI, not apt.)

## Fix

New `ci-install-unzip` composite that refreshes **only `main` from the co-located Azure Ubuntu mirror** (`azure.archive.ubuntu.com`) via apt's single-source trick — a few MB, ~15s instead of 31.6 MB. It no-ops when `unzip` is already present, so it's safe on any runner. Swaps the 7 inline apt steps for it.

Also adds it to the vr-compare **approve-regenerate** job, which ran `setup-bun` in a container with no `unzip` installed — a latent failure masked only because that job sits behind the VR approve-gate and rarely fires.

Follow-up (#583): prebake unzip into a GHCR image to remove runtime apt entirely.