### PR TITLE
ci: prebaked Playwright+unzip runner image (GHCR)

### DIFF
--- a/.github/docker/ci-runner/Dockerfile
+++ b/.github/docker/ci-runner/Dockerfile
@@ -1,0 +1,30 @@
+# CI runner image: the pinned Playwright image + `unzip` baked in.
+#
+# Why: oven-sh/setup-bun extracts the Bun release zip with the system `unzip`
+# binary, which the mcr.microsoft.com/playwright image does not ship. Installing
+# it per-job costs an `apt-get update` against Ubuntu mirrors that are throttled
+# from GitHub's Azure runners (observed 15m50s / 34 kB/s). Baking it in once
+# removes that cost from every container job.
+#
+# PLAYWRIGHT_TAG MUST stay in sync with env.PLAYWRIGHT_CONTAINER_TAG in
+# .github/workflows/ci.yml. Build/publish via .github/workflows/build-ci-image.yml.
+ARG PLAYWRIGHT_TAG=v1.61.1-noble
+FROM mcr.microsoft.com/playwright:${PLAYWRIGHT_TAG}
+
+# Refresh ONLY `main` from the co-located Azure Ubuntu mirror (a few MB) rather
+# than the full 31 MB of indexes across universe/security/backports from the
+# throttled public mirrors. Mirrors .github/actions/ci-install-unzip.
+RUN set -eux; \
+    keyring=/usr/share/keyrings/ubuntu-archive-keyring.gpg; \
+    { \
+      echo "deb [signed-by=${keyring}] http://azure.archive.ubuntu.com/ubuntu noble main"; \
+      echo "deb [signed-by=${keyring}] http://azure.archive.ubuntu.com/ubuntu noble-updates main"; \
+    } > /etc/apt/sources.list.d/ci-unzip.list; \
+    apt-get \
+      -o Dir::Etc::sourcelist=sources.list.d/ci-unzip.list \
+      -o Dir::Etc::sourceparts=- \
+      -o APT::Get::List-Cleanup=0 \
+      update; \
+    apt-get install -y --no-install-recommends unzip; \
+    rm -rf /var/lib/apt/lists/* /etc/apt/sources.list.d/ci-unzip.list; \
+    unzip -v | head -1

--- a/.github/workflows/build-ci-image.yml
+++ b/.github/workflows/build-ci-image.yml
@@ -1,0 +1,54 @@
+# Build and publish the CI runner image (Playwright + unzip) to GHCR.
+#
+# The image lets container jobs skip the per-job `apt-get install unzip` (slow
+# from GitHub's Azure runners against the public Ubuntu mirrors). Publishing is
+# free: ljodea/ggsvelte is public, so GHCR storage/bandwidth are not billed, and
+# image pulls inside Actions never bill data transfer.
+#
+# Runs on Dockerfile changes and on demand. After the first successful run
+# publishes ghcr.io/<owner>/<repo>/ci-runner:<tag>, container jobs can switch
+# their `image:` to it and drop the ci-install-unzip step.
+name: build CI image
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - .github/docker/ci-runner/Dockerfile
+      - .github/workflows/build-ci-image.yml
+
+# PLAYWRIGHT_TAG MUST stay in sync with env.PLAYWRIGHT_CONTAINER_TAG in ci.yml.
+env:
+  PLAYWRIGHT_TAG: v1.61.1-noble
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: build + push ci-runner image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: log in to GHCR
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: build and push
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .github/docker/ci-runner
+          build-args: PLAYWRIGHT_TAG=${{ env.PLAYWRIGHT_TAG }}
+          push: true
+          tags: ghcr.io/${{ github.repository }}/ci-runner:${{ env.PLAYWRIGHT_TAG }}
+          # Cache layers across builds to keep republishes fast.
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/build-ci-image.yml
+++ b/.github/workflows/build-ci-image.yml
@@ -36,7 +36,17 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      # The GitHub Actions cache backend (type=gha) requires the docker-container
+      # Buildx driver; the default `docker` driver does not support it, so the
+      # cache export silently no-ops (or errors). Set up Buildx first.
+      - name: set up Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+      # Only publish from main. workflow_dispatch can target any branch, so a
+      # write collaborator dispatching from an unmerged branch must NOT be able
+      # to overwrite the published tag — non-main dispatches are build-only
+      # (push=false below), and there is no reason to authenticate to GHCR.
       - name: log in to GHCR
+        if: github.ref == 'refs/heads/main'
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
@@ -47,7 +57,8 @@ jobs:
         with:
           context: .github/docker/ci-runner
           build-args: PLAYWRIGHT_TAG=${{ env.PLAYWRIGHT_TAG }}
-          push: true
+          # Build-only on non-main dispatches; publish only from main.
+          push: ${{ github.ref == 'refs/heads/main' }}
           tags: ghcr.io/${{ github.repository }}/ci-runner:${{ env.PLAYWRIGHT_TAG }}
           # Cache layers across builds to keep republishes fast.
           cache-from: type=gha


### PR DESCRIPTION
## What

Bakes `unzip` into the Playwright image so container jobs need **no runtime apt at all**. Complements #582 (which makes the runtime install fast); this removes it.

- `.github/docker/ci-runner/Dockerfile` — `FROM mcr.microsoft.com/playwright:<pinned tag>` + `unzip` (installed at build time via the same Azure-mirror `main`-only trick).
- `.github/workflows/build-ci-image.yml` — builds and pushes `ghcr.io/<owner>/<repo>/ci-runner:<tag>` on Dockerfile changes and on `workflow_dispatch`. SHA-pinned docker actions (zizmor). GHA layer cache.

## Cost

None billable. `ljodea/ggsvelte` is **public** → GHCR storage/bandwidth are free, and image pulls inside Actions never bill data transfer. Billable Actions minutes go *down*: same-order image pull, minus the apt step.

## Adoption (follow-up PR)

This PR only publishes the image (first build triggers on merge to `main`, or run it manually via `workflow_dispatch`). Once `ghcr.io/<owner>/<repo>/ci-runner:v1.61.1-noble` exists, a small follow-up flips the 8 container jobs' `image:` to it and drops the `ci-install-unzip` step. Keeping it separate avoids referencing an image that doesn't exist yet.

`PLAYWRIGHT_TAG` in the Dockerfile + workflow must stay in sync with `env.PLAYWRIGHT_CONTAINER_TAG` in ci.yml (noted in both files).