### PR TITLE
fix: sanitize band guide plan for collision:preserve

### DIFF
--- a/packages/core/src/layout/layout-derive-ticks.ts
+++ b/packages/core/src/layout/layout-derive-ticks.ts
@@ -186,6 +186,31 @@ function ellipsizeBandPlan(
   };
 }
 
+/**
+ * Preserve mode renders full, un-truncated single-line labels (presentForLayout
+ * restores fullLabel for every tick and the margin computation uses those widths
+ * uncapped). The pinned-single planner it's routed through still runs its own
+ * end-cap truncation (capEndOverhang) for a normal single-line axis, so its raw
+ * output can carry an ellipsized label plus a false "the end label was truncated"
+ * diagnostic that never matches what's actually rendered. Restore full labels and
+ * drop that diagnostic; genuine neighbour-overlap stays since preserve truly can
+ * render overlapping full labels.
+ */
+function sanitizePreserveBandPlan(plan: BandAxisPlan): BandAxisPlan {
+  return {
+    ...plan,
+    ticks: plan.ticks.map((tick) => ({
+      ...tick,
+      label: tick.labeled ? tick.fullLabel : "",
+    })),
+    alongOverhang: 0,
+    leftOverhang: 0,
+    marginOverflow: false,
+    degraded: plan.degraded.filter((code) => code !== "band-label-margin-overflow"),
+    authorPinned: true,
+  };
+}
+
 export function deriveTicks(
   domain: Domain,
   requestedCount: number,
@@ -289,7 +314,9 @@ export function deriveTicks(
       const plan =
         context.bandCollision === "ellipsis"
           ? ellipsizeBandPlan(planned, domain.categories.length, context)
-          : planned;
+          : context.bandCollision === "preserve"
+            ? sanitizePreserveBandPlan(planned)
+            : planned;
       const ticks: Tick[] = plan.ticks.map((tick) => ({
         value: tick.value,
         label: tick.label,

--- a/packages/core/src/layout/layout-derive-ticks.ts
+++ b/packages/core/src/layout/layout-derive-ticks.ts
@@ -87,7 +87,7 @@ export interface DeriveTicksContext {
   quantum?: number;
   ellipsis?: string;
   /** Top-level band-axis collision override, resolved after scale-local guide settings. */
-  bandCollision?: "ellipsis";
+  bandCollision?: "ellipsis" | "preserve";
   previousGuidePlan?: AxisGuidePlan;
 }
 
@@ -249,8 +249,14 @@ export function deriveTicks(
     // Vertical band (native Y, or categorical-on-Y after coord_flip) falls through
     // to the legacy thin/truncate path.
     if (domain.band !== undefined && context.orient === "horizontal") {
+      // "preserve" renders full single-line labels downstream (presentForLayout),
+      // so the guide plan must reflect single-line mode too — otherwise the auto
+      // wrap/rotate plan leaks into the axis-title offset and wrap/rotate advisories
+      // for a layout that is never actually rendered.
       const resolvedGuide =
-        context.bandCollision === "ellipsis" ? { ...guide, mode: "single" as const } : guide;
+        context.bandCollision === "ellipsis" || context.bandCollision === "preserve"
+          ? { ...guide, mode: "single" as const }
+          : guide;
       const planned = planBandAxis({
         aesthetic: domain.band.aesthetic,
         panelIndex: domain.band.panelIndex,

--- a/packages/core/src/layout/layout.ts
+++ b/packages/core/src/layout/layout.ts
@@ -163,6 +163,7 @@ export function layoutPass(margins: Margins, input: LayoutInput, theme: LayoutTh
     quantum,
     ellipsis,
     ...(xPresentation?.collision === "ellipsis" && { bandCollision: "ellipsis" as const }),
+    ...(xPreserve && { bandCollision: "preserve" as const }),
     ...(input.previousGuidePlans?.x !== undefined && {
       previousGuidePlan: input.previousGuidePlans.x,
     }),

--- a/packages/core/tests/pipeline-responsive-guides.test.ts
+++ b/packages/core/tests/pipeline-responsive-guides.test.ts
@@ -270,6 +270,38 @@ describe("responsive guide planning", () => {
     expect(result.scene.panels[0]!.x).toBeGreaterThan(automatic.scene.panels[0]!.x);
   });
 
+  it("does not leak the auto wrap/rotate band plan into collision:preserve diagnostics", () => {
+    const categories = [
+      { category: "A deliberately long northern category", y: 1 },
+      { category: "A deliberately long southern category", y: 2 },
+    ];
+    const build = gg(categories, aes({ x: "category", y: "y" }))
+      .geomPoint()
+      .scales({ x: { type: "band" } })
+      .labs({ x: "Category" });
+    // At this width, automatic layout must escalate to wrap or rotate.
+    const automatic = runPipeline(build.spec(), { width: 280, height: 300 });
+    const automaticPlan = automatic.guidePlans.find(
+      (candidate) => candidate.type === "axis" && candidate.aesthetic === "x",
+    );
+    expect(automaticPlan?.type === "axis" && automaticPlan.bandLabelMode).not.toBe("single-line");
+
+    const result = runPipeline(build.guides({ x: guideAxis({ collision: "preserve" }) }).spec(), {
+      width: 280,
+      height: 300,
+    });
+    const plan = result.guidePlans.find(
+      (candidate) => candidate.type === "axis" && candidate.aesthetic === "x",
+    );
+    expect(plan?.type).toBe("axis");
+    if (plan?.type !== "axis") return;
+    // The rendered labels are always single-line full text (presentForLayout), so
+    // the guide plan must say so too — not the auto wrap/rotate plan that never renders.
+    expect(plan.bandLabelMode).toBe("single-line");
+    expect(result.scene.axes.x.titleOffset).toBeUndefined();
+    expect(result.advisories.filter(({ code }) => code.startsWith("band-labels-"))).toEqual([]);
+  });
+
   it("reclaims tick-label margins and diagnostics for hidden axes", () => {
     const categories = [
       { category: "A deliberately long northern category", y: 1 },

--- a/packages/core/tests/pipeline-responsive-guides.test.ts
+++ b/packages/core/tests/pipeline-responsive-guides.test.ts
@@ -302,6 +302,37 @@ describe("responsive guide planning", () => {
     expect(result.advisories.filter(({ code }) => code.startsWith("band-labels-"))).toEqual([]);
   });
 
+  it("does not report a truncated guide-plan label for an overhanging preserve end category", () => {
+    const categories = [
+      { category: "A", y: 1 },
+      {
+        category:
+          "A dramatically longer end-of-axis category label that overhangs far past the panel edge",
+        y: 2,
+      },
+    ];
+    const result = runPipeline(
+      gg(categories, aes({ x: "category", y: "y" }))
+        .geomPoint()
+        .scales({ x: { type: "band" } })
+        .guides({ x: guideAxis({ collision: "preserve" }) })
+        .spec(),
+      { width: 300, height: 300 },
+    );
+    const plan = result.guidePlans.find(
+      (candidate) => candidate.type === "axis" && candidate.aesthetic === "x",
+    );
+    expect(plan?.type).toBe("axis");
+    if (plan?.type !== "axis") return;
+    // The guide plan must report the SAME labels actually rendered — full text,
+    // not the end-cap truncated ellipsis that only the pinned-single planner emits.
+    expect(plan.ticks.map((tick) => tick.label)).toEqual(
+      result.scene.axes.x.ticks.map((tick) => tick.label),
+    );
+    expect(plan.marginOverflow).toBe(false);
+    expect(plan.degraded).not.toContain("band-label-margin-overflow");
+  });
+
   it("reclaims tick-label margins and diagnostics for hidden axes", () => {
     const categories = [
       { category: "A deliberately long northern category", y: 1 },


### PR DESCRIPTION
## Summary

Follow-up to #576, fixing a P2 finding that landed just before merge (comment [3632765392](https://github.com/ljodea/ggsvelte/pull/576#discussion_r3632765392) on `layout.ts:347`, "Sanitize preserve-mode band guide plans"):

`guideAxis({ collision: "preserve" })` renders full single-line labels — `presentForLayout` in `layout.ts` swaps every tick's presented label to `fullLabel` and clears wrap/rotate metadata. But `deriveTicks` (`layout-derive-ticks.ts`) still returned the *auto* wrap/rotate `BandAxisPlan` as the guide plan, which never reflected the actual single-line presentation. That leaked into:

- `assemble-scene-panels.ts`'s `bandTitleOffset` — pushing the x-axis title down to make room for a wrapped/rotated label band that is never rendered.
- `assemble-render-model.ts`'s `bandLabelAdvisories` — emitting `band-labels-wrapped`/`band-labels-rotated` diagnostics describing a layout that was overridden.
- The bottom margin reservation — using the (larger) wrap/rotate `bandLabelBandHeight` instead of the actual single-line height.

## Fix

Mirror the existing `collision: "ellipsis"` handling: force the band guide's `mode` to `"single"` when `collision` is `"preserve"` too, so `planBandAxis` returns the already-correct single-line plan (no wrap/rotate escalation) instead of computing one that's discarded downstream.

## Test plan

- [x] Added a failing-first regression in `packages/core/tests/pipeline-responsive-guides.test.ts` reproducing the leak (verified RED against the pre-fix code, GREEN after)
- [x] `bun test packages/core packages/spec` — all pass except 2 pre-existing, unrelated docs-generation snapshot failures (verified present on `origin/main` before this branch)
- [x] `bun run check` (tsc -b) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)