### PR TITLE
fix(core,evals): resolve 3 post-merge Codex P2s on #596

### DIFF
--- a/packages/core/src/pipeline/frame-edge-expand.ts
+++ b/packages/core/src/pipeline/frame-edge-expand.ts
@@ -74,7 +74,17 @@ export function expandEdgeFrame(frame: LayerFrame, warnings: PipelineWarning[]):
 
   // Band axes train from centers only. Expand edges only on continuous axes
   // (mixed band+continuous tiles keep continuous-axis domain expansion).
+  // Clear inactive edge arrays so inherited plot-level ymin/ymax (or xmin/xmax)
+  // meant for rect/ribbon cannot train continuous edge evidence on a band axis.
   if (geom === "tile") {
+    if (xType === "nominal") {
+      frame.xmin = null;
+      frame.xmax = null;
+    }
+    if (yType === "nominal") {
+      frame.ymin = null;
+      frame.ymax = null;
+    }
     if (xType === "nominal" && yType === "nominal") return;
     const params = frame.binding.layer.params ?? {};
     const defW = defaultResolution(frame.xNumeric);

--- a/packages/core/src/pipeline/scale-axis-collect-x-binned.ts
+++ b/packages/core/src/pipeline/scale-axis-collect-x-binned.ts
@@ -11,8 +11,9 @@ export function collectBinnedXEvidence(frame: LayerFrame, acc: AxisCollectAcc): 
   const xConversion = xConversionOf(frame.binding);
   const geom = frame.binding.layer.geom;
   // Rect: only endpoint fields (never inherited plot-level x).
-  // Tile/raster: edges are often synthetic from centers — fall back to xField
-  // so temporal inference still sees the mapped center column.
+  // Tile/raster: edges are always synthesized from centers — always use
+  // xField for type/temporal evidence so inherited plot-level xmin/xmax
+  // (meant for a sibling rect/ribbon) cannot force a band x scale.
   // Stat-bin bars keep xField for the historical "binned …" type label.
   const evidenceFields =
     geom === "rect"
@@ -24,17 +25,9 @@ export function collectBinnedXEvidence(frame: LayerFrame, acc: AxisCollectAcc): 
           ),
         ]
       : geom === "tile" || geom === "raster"
-        ? [
-            ...new Set(
-              [
-                frame.binding.xminField,
-                frame.binding.xmaxField,
-                ...(frame.binding.xminField === null && frame.binding.xmaxField === null
-                  ? [frame.binding.xField]
-                  : []),
-              ].filter((field): field is string => field !== null),
-            ),
-          ]
+        ? frame.binding.xField === null
+          ? []
+          : [frame.binding.xField]
         : frame.binding.xField === null
           ? []
           : [frame.binding.xField];

--- a/packages/core/src/pipeline/scale-axis-collect-y.ts
+++ b/packages/core/src/pipeline/scale-axis-collect-y.ts
@@ -31,9 +31,12 @@ export function collectAxisInputsY(frame: LayerFrame, acc: AxisCollectAcc): void
       acc.numeric.push(frame.yNumeric);
     }
     if (frame.box !== null) acc.numeric.push(frame.box.outlierY);
-    const boundFields = [binding.yminField, binding.ymaxField].filter(
-      (field): field is string => field !== null,
-    );
+    // Tile/raster y edges are synthetic from centers — type evidence from
+    // yField only so inherited ymin/ymax cannot poison inference.
+    const boundFields =
+      geom === "tile" || geom === "raster"
+        ? []
+        : [binding.yminField, binding.ymaxField].filter((field): field is string => field !== null);
     const evidenceFields = [
       ...new Set(
         boundFields.length > 0 ? boundFields : binding.yField === null ? [] : [binding.yField],

--- a/packages/core/tests/pipeline-m2/rect-tile-raster.test.ts
+++ b/packages/core/tests/pipeline-m2/rect-tile-raster.test.ts
@@ -147,6 +147,72 @@ describe("geom tile", () => {
       ),
     ).toThrow(PipelineError);
   });
+
+  it("infers a time x scale from temporal tile centers with synthetic edges", () => {
+    const model = runPipeline(
+      gg(
+        {
+          day: ["2024-01-01", "2024-01-02", "2024-01-03"],
+          band: ["a", "b", "c"],
+          z: [1, 2, 3],
+        },
+        aes({ x: "day", y: "band", fill: "z" }),
+      )
+        .geomTile()
+        .spec(),
+      size,
+    );
+    expect(model.scales.x.type).toBe("time");
+  });
+
+  it("ignores inherited xmin/xmax for tile x-scale type (uses center x)", () => {
+    // Plot-level endpoint aes intended for rect/ribbon must not force a band
+    // x scale on tile when the layer maps continuous centers.
+    const model = runPipeline(
+      gg(
+        {
+          cat: ["a", "b"],
+          y0: [0, 0],
+          y1: [1, 1],
+          x: [0, 1],
+          y: [0, 1],
+          z: [1, 2],
+        },
+        aes({ xmin: "cat", xmax: "cat", ymin: "y0", ymax: "y1" }),
+      )
+        .geomTile({ aes: { x: "x", y: "y", fill: "z" } })
+        .scales({ x: { nice: false }, y: { nice: false } })
+        .spec(),
+      size,
+    );
+    expect(model.scales.x.type).toBe("linear");
+    const batch = model.scene.batches[0] as RectsBatch;
+    expect(batch.kind).toBe("rects");
+    expect(batch.rects.length / 4).toBe(2);
+  });
+
+  it("clears inherited ymin/ymax when tile y is categorical", () => {
+    const model = runPipeline(
+      gg(
+        {
+          x: [0, 1, 2],
+          y: ["a", "b", "c"],
+          ymin: [0, 0, 0],
+          ymax: [1, 1, 1],
+          z: [1, 2, 3],
+        },
+        aes({ x: "x", y: "y", ymin: "ymin", ymax: "ymax", fill: "z" }),
+      )
+        .geomTile()
+        .spec(),
+      size,
+    );
+    expect(model.scales.y.type).toBe("band");
+    expect(model.scales.y.domain).toEqual(["a", "b", "c"]);
+    const batch = model.scene.batches[0] as RectsBatch;
+    expect(batch.kind).toBe("rects");
+    expect(batch.rects.length / 4).toBe(3);
+  });
 });
 
 describe("geom raster", () => {
@@ -193,22 +259,5 @@ describe("geom raster", () => {
     expect(model.warnings.some((w) => w.code === "raster-irregular-spacing")).toBe(true);
     const batch = model.scene.batches[0] as RectsBatch;
     expect(batch.rects.length / 4).toBe(3);
-  });
-
-  it("infers a time x scale from temporal tile centers with synthetic edges", () => {
-    const model = runPipeline(
-      gg(
-        {
-          day: ["2024-01-01", "2024-01-02", "2024-01-03"],
-          band: ["a", "b", "c"],
-          z: [1, 2, 3],
-        },
-        aes({ x: "day", y: "band", fill: "z" }),
-      )
-        .geomTile()
-        .spec(),
-      size,
-    );
-    expect(model.scales.x.type).toBe("time");
   });
 });

--- a/tests/evals/harness.test.ts
+++ b/tests/evals/harness.test.ts
@@ -214,6 +214,29 @@ describe("dry-run pipeline", () => {
   });
 });
 
+describe("MockResponder map refusal", () => {
+  const profileLine =
+    'DataProfile (JSON):{"fields":[{"name":"revenue","type":"quantitative"},{"name":"state","type":"nominal"},{"name":"region","type":"nominal"},{"name":"y","type":"quantitative"},{"name":"station","type":"nominal"}]}';
+
+  test("refuses geographic map phrasing that is not an aesthetic mapping", async () => {
+    const mock = new MockResponder();
+    const reply = await mock.complete("", `map revenue to state on a US map.\n${profileLine}`);
+    const parsed = JSON.parse(reply) as { unsupported?: string };
+    expect(typeof parsed.unsupported).toBe("string");
+  });
+
+  test("still allows aesthetic map-to-channel phrases", async () => {
+    const mock = new MockResponder();
+    const reply = await mock.complete(
+      "",
+      `Scatter of y by station and map region to color.\n${profileLine}`,
+    );
+    const parsed = JSON.parse(reply) as { layers?: unknown[]; unsupported?: string };
+    expect(parsed.unsupported).toBeUndefined();
+    expect(Array.isArray(parsed.layers)).toBe(true);
+  });
+});
+
 // ---------------------------------------------------------------------------
 // (c) score.ts unit tests
 // ---------------------------------------------------------------------------

--- a/tests/evals/harness.test.ts
+++ b/tests/evals/harness.test.ts
@@ -235,6 +235,19 @@ describe("MockResponder map refusal", () => {
     expect(parsed.unsupported).toBeUndefined();
     expect(Array.isArray(parsed.layers)).toBe(true);
   });
+
+  test("allows continuous/discrete scale modifiers before color/fill/style channels", async () => {
+    const mock = new MockResponder();
+    for (const prompt of [
+      "map z to continuous fill",
+      "map region to discrete color",
+      "map magnitude to continuous point size",
+    ]) {
+      const reply = await mock.complete("", `${prompt}.\n${profileLine}`);
+      const parsed = JSON.parse(reply) as { unsupported?: string };
+      expect(parsed.unsupported, `should allow aesthetic mapping: ${prompt}`).toBeUndefined();
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/evals/model.ts
+++ b/tests/evals/model.ts
@@ -288,10 +288,14 @@ export class MockResponder implements Responder {
     const profile = parseProfileLine(user);
 
     // Aesthetic mapping phrases like "map y to station" / "map period to fill"
-    // must not trigger the geographic-map refusal.
+    // must not trigger the geographic-map refusal. Only known aesthetic /
+    // position / style channels count — "map revenue to state" is geo-ish and
+    // must still refuse when the prompt also contains "map".
+    const aesChannel =
+      "(?:binned\\s+)?(?:colou?r|fill|x|y|xmin|xmax|ymin|ymax|width|height|size|alpha|shape|linewidth|linetype|label)";
     const aestheticMapping =
-      /\bmap\s+\S+\s+to\s+\S+/.test(prompt) ||
-      /\bmap\s+.+\s+to\s+(?:binned\s+)?(?:colou?r|fill)\b/.test(prompt) ||
+      new RegExp(`\\bmap\\s+\\S+\\s+to\\s+${aesChannel}\\b`).test(prompt) ||
+      new RegExp(`\\bmap\\s+${aesChannel}\\s+to\\s+\\S+\\b`).test(prompt) ||
       STYLE_CHANNELS.some((channel) => mappedStyleField(prompt, profile, channel) !== undefined);
     if (
       /choropleth|\b3-?d\b|surface plot|network diagram/.test(prompt) ||

--- a/tests/evals/model.ts
+++ b/tests/evals/model.ts
@@ -291,8 +291,10 @@ export class MockResponder implements Responder {
     // must not trigger the geographic-map refusal. Only known aesthetic /
     // position / style channels count — "map revenue to state" is geo-ish and
     // must still refuse when the prompt also contains "map".
+    // Scale modifiers match mappedStyleField (continuous/discrete/binned/point/line)
+    // so "map z to continuous fill" and "map region to discrete color" stay aesthetic.
     const aesChannel =
-      "(?:binned\\s+)?(?:colou?r|fill|x|y|xmin|xmax|ymin|ymax|width|height|size|alpha|shape|linewidth|linetype|label)";
+      "(?:(?:continuous|discrete|binned|point|line)\\s+){0,3}(?:colou?r|fill|x|y|xmin|xmax|ymin|ymax|width|height|size|alpha|shape|linewidth|linetype|label)";
     const aestheticMapping =
       new RegExp(`\\bmap\\s+\\S+\\s+to\\s+${aesChannel}\\b`).test(prompt) ||
       new RegExp(`\\bmap\\s+${aesChannel}\\s+to\\s+\\S+\\b`).test(prompt) ||


### PR DESCRIPTION
## Summary

Post-merge Codex review on #596 (`4208cbdf`, ~5 min after land) left 3 unreplied P2s. All three validated against main and fixed:

1. **Tile/raster x evidence from centers only** — inherited plot-level `xmin`/`xmax` no longer drives x type inference (`scale-axis-collect-x-binned.ts`).
2. **Clear inherited y bounds on band tile axes** — categorical tile `y` nulls out `frame.ymin`/`ymax` so continuous edge training cannot steal the axis (`frame-edge-expand.ts`); y type evidence for tile/raster also prefers center `yField` (`scale-axis-collect-y.ts`).
3. **Narrow MockResponder map-refusal exemption** — only known aesthetic/position/style channels skip the geo-map refusal; `"map revenue to state"` no longer bypasses it (`tests/evals/model.ts`).

## Test plan

- [x] RED then GREEN: inherited xmin/xmax continuous tile → linear x + rects
- [x] RED then GREEN: categorical tile y with inherited ymin/ymax → band y + rects
- [x] RED then GREEN: MockResponder refuses non-aesthetic map phrasing; still allows `map region to color`
- [x] `bun test packages/core/tests/pipeline-m2 packages/core/tests/pipeline-m1 tests/evals`
- [x] `bun run check`
- [ ] CI on PR

Closes post-merge findings on #596 (comments 3633813762, 3633813771, 3633813779).