### PR TITLE
fix(spec): align temporal color censor recovery with runtime (#573)

### DIFF
--- a/.changeset/sweep-573-color-censor-recovery.md
+++ b/.changeset/sweep-573-color-censor-recovery.md
@@ -1,0 +1,12 @@
+---
+"@ggsvelte/spec": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+fix: align temporal color censor recovery with runtime channel training
+
+parseFailure: "censor" on sequential/binned color now recovers from
+channel-wide training sources (sibling fields, scaled constants), parseable
+domain endpoints, and parseable binned breaks — matching collectColorChannelValues
+and sequential/binned train behavior.

--- a/packages/spec/src/validate-data-checks-color.ts
+++ b/packages/spec/src/validate-data-checks-color.ts
@@ -7,6 +7,7 @@ import type { SpecError } from "./errors.js";
 import { configuredColorScaleType } from "./scale-helpers.js";
 import type { ColorScaleSpec } from "./schema.js";
 import { SEQUENTIAL_SCHEME_NAMES } from "./schema.js";
+import { parseTemporal } from "./temporal-parse.js";
 import type { FieldEvidenceMap } from "./validate-data-evidence.js";
 import {
   temporalDecisionForField,
@@ -17,6 +18,121 @@ import {
 
 const COLOR_CHANNELS = ["color", "fill"] as const;
 const SEQUENTIAL_SCHEMES = new Set<string>(SEQUENTIAL_SCHEME_NAMES);
+
+/**
+ * Recovery sources for `parseFailure: "censor"` on temporal color/fill scales.
+ * Mirrors runtime `collectColorChannelValues` + sequential/binned train:
+ * - domain endpoints must parse (else color-domain-invalid / color-binned-domain)
+ * - binned breaks of length ≥ 2 must parse (else color-binned-breaks)
+ * - sibling fields / scaled constants that yield at least one temporal value train
+ *   the channel even when the current field is entirely censored
+ */
+function colorTemporalCensorRecovery(input: {
+  config: ColorScaleSpec | undefined;
+  colorFields: readonly ChannelFieldUse[];
+  colorScaledConstants: readonly unknown[];
+  fields: FieldEvidenceMap;
+  temporalDecisionCache: TemporalDecisionCache;
+  typeOf: (field: string) => string | null;
+}): {
+  hasExplicitDomain: boolean;
+  hasBinnedBreaks: boolean;
+  trainingFields: ReadonlySet<string>;
+  constantTrains: boolean;
+} {
+  const { config, colorFields, colorScaledConstants, fields, temporalDecisionCache, typeOf } =
+    input;
+  const parseUsable = temporalParserUsable(config?.parse);
+  const temporalOptionsUsable =
+    (config?.timezone === undefined || typeof config.timezone === "string") &&
+    (config?.disambiguation === undefined || typeof config.disambiguation === "string");
+  const temporalInputsUsable = parseUsable && temporalOptionsUsable;
+  const temporalOptions = {
+    ...(config?.timezone !== undefined &&
+      typeof config.timezone === "string" && { timezone: config.timezone }),
+    ...(config?.disambiguation !== undefined &&
+      typeof config.disambiguation === "string" && {
+        disambiguation: config.disambiguation,
+      }),
+  };
+  const parseableBound = (value: unknown): boolean =>
+    temporalInputsUsable &&
+    config?.parse !== undefined &&
+    parseTemporal(value, config.parse as Parameters<typeof parseTemporal>[1], temporalOptions).ok;
+
+  const domainValues = Array.isArray(config?.domain)
+    ? config.domain.filter((value) => value !== null)
+    : [];
+  const hasExplicitDomain =
+    domainValues.length === 2 && domainValues.every((value) => parseableBound(value));
+  const binnedBreaks =
+    config?.type === "binned" && Array.isArray(config.breaks)
+      ? config.breaks.filter((value) => value !== null)
+      : [];
+  const hasBinnedBreaks =
+    binnedBreaks.length >= 2 && binnedBreaks.every((value) => parseableBound(value));
+
+  const trainingFields = new Set<string>();
+  const requestsTemporal =
+    config?.temporalKind !== undefined ||
+    config?.parse !== undefined ||
+    config?.timezone !== undefined ||
+    config?.disambiguation !== undefined;
+  if (temporalInputsUsable && requestsTemporal) {
+    const parser = (config?.parse ?? "auto") as Parameters<typeof temporalDecisionForField>[3];
+    for (const use of colorFields) {
+      const type = typeOf(use.field);
+      if (type === "temporal") {
+        trainingFields.add(use.field);
+        continue;
+      }
+      if (type !== "quantitative" && type !== "nominal" && type !== "ordinal") continue;
+      const decision = temporalDecisionForField(
+        temporalDecisionCache,
+        use.field,
+        fields.get(use.field),
+        parser,
+        temporalOptions,
+      );
+      if (
+        decision !== null &&
+        decision !== undefined &&
+        (decision.status === "temporal" || (decision.validatedCount ?? 0) > 0)
+      ) {
+        trainingFields.add(use.field);
+      }
+    }
+  } else {
+    for (const use of colorFields) {
+      if (typeOf(use.field) === "temporal") trainingFields.add(use.field);
+    }
+  }
+
+  const constantTrains = colorScaledConstants.some((value) => parseableBound(value));
+  return { hasExplicitDomain, hasBinnedBreaks, trainingFields, constantTrains };
+}
+
+function censoredTemporalColorRecovers(input: {
+  config: ColorScaleSpec | undefined;
+  decision: { status: string; validatedCount?: number } | null | undefined;
+  field: string;
+  recovery: {
+    hasExplicitDomain: boolean;
+    hasBinnedBreaks: boolean;
+    trainingFields: ReadonlySet<string>;
+    constantTrains: boolean;
+  };
+}): boolean {
+  if (input.config?.parse === undefined || input.config.parseFailure !== "censor") return false;
+  if (input.decision?.status !== "invalid") return false;
+  if ((input.decision.validatedCount ?? 0) > 0) return true;
+  if (input.recovery.hasExplicitDomain || input.recovery.hasBinnedBreaks) return true;
+  if (input.recovery.constantTrains) return true;
+  for (const field of input.recovery.trainingFields) {
+    if (field !== input.field) return true;
+  }
+  return false;
+}
 
 /** Type-preserving key for discrete domain identity (mirrors core encodeKey). */
 function discreteDomainKey(value: unknown): string {
@@ -130,6 +246,21 @@ export function checkColorScaleDataCompatibility(input: {
       config?.scheme !== undefined &&
       SEQUENTIAL_SCHEMES.has(config.scheme);
     if (effectiveType !== "sequential" && effectiveType !== "binned") continue;
+
+    const requestsTemporal =
+      config?.temporalKind !== undefined ||
+      config?.parse !== undefined ||
+      config?.timezone !== undefined ||
+      config?.disambiguation !== undefined;
+    const recovery = colorTemporalCensorRecovery({
+      config,
+      colorFields: colorFields[channel],
+      colorScaledConstants: colorScaledConstants[channel],
+      fields,
+      temporalDecisionCache,
+      typeOf,
+    });
+
     for (const use of colorFields[channel]) {
       const type = typeOf(use.field);
       if (
@@ -148,14 +279,10 @@ export function checkColorScaleDataCompatibility(input: {
         continue;
       }
 
-      const requestsTemporal =
-        config?.temporalKind !== undefined ||
-        config?.parse !== undefined ||
-        config?.timezone !== undefined ||
-        config?.disambiguation !== undefined;
-
       // Quantitative fields with temporal-only options fail at resolve time unless
-      // parseFailure: "censor" recovers at least one temporal value (status invalid).
+      // parseFailure: "censor" recovers via this field, a sibling, a scaled constant,
+      // or a parseable domain / binned breaks (pipeline only throws color-transform-empty
+      // when every channel value fails and no authored bound trains the scale).
       if (type === "quantitative" && requestsTemporal) {
         // A schema-invalid parser reaches tier-2 (schema errors don't short-circuit
         // it); handing it to temporalDecisionForField would throw instead of
@@ -174,17 +301,12 @@ export function checkColorScaleDataCompatibility(input: {
             }),
           },
         );
-        // Censor when at least one value parsed, or when an explicit domain can
-        // still train the scale (pipeline only throws color-transform-empty
-        // when domain is absent and extent is empty).
-        const hasExplicitDomain =
-          Array.isArray(config?.domain) &&
-          config.domain.filter((value) => value !== null).length === 2;
-        const censoredInvalid =
-          config?.parse !== undefined &&
-          config.parseFailure === "censor" &&
-          decision?.status === "invalid" &&
-          ((decision.validatedCount ?? 0) > 0 || hasExplicitDomain);
+        const censoredInvalid = censoredTemporalColorRecovers({
+          config,
+          decision,
+          field: use.field,
+          recovery,
+        });
         if (decision?.status !== "temporal" && !censoredInvalid) {
           errors.push({
             code: "scale-type-mismatch",
@@ -250,14 +372,12 @@ export function checkColorScaleDataCompatibility(input: {
           }),
         },
       );
-      const hasExplicitDomain =
-        Array.isArray(config?.domain) &&
-        config.domain.filter((value) => value !== null).length === 2;
-      const censoredInvalid =
-        config?.parse !== undefined &&
-        config.parseFailure === "censor" &&
-        decision?.status === "invalid" &&
-        ((decision.validatedCount ?? 0) > 0 || hasExplicitDomain);
+      const censoredInvalid = censoredTemporalColorRecovers({
+        config,
+        decision,
+        field: use.field,
+        recovery,
+      });
       if (decision?.status === "temporal" || censoredInvalid) {
         // Mirror runtime: compare recovered kind even when status is invalid+censored.
         if (

--- a/packages/spec/src/validate-data-checks-color.ts
+++ b/packages/spec/src/validate-data-checks-color.ts
@@ -22,10 +22,11 @@ const SEQUENTIAL_SCHEMES = new Set<string>(SEQUENTIAL_SCHEME_NAMES);
 /**
  * Recovery sources for `parseFailure: "censor"` on temporal color/fill scales.
  * Mirrors runtime `collectColorChannelValues` + sequential/binned train:
- * - domain endpoints must parse (else color-domain-invalid / color-binned-domain)
- * - binned breaks of length ≥ 2 must parse (else color-binned-breaks)
- * - sibling fields / scaled constants that yield at least one temporal value train
- *   the channel even when the current field is entirely censored
+ * - domain endpoints must parse (else color-domain-invalid / color-binned-domain);
+ *   a present-but-unusable domain blocks all recovery (runtime throws first)
+ * - binned breaks of length ≥ 2 must parse and be strictly increasing
+ * - sibling fields / scaled constants train only when they parse under the
+ *   configured parser (and match temporalKind when authored)
  */
 function colorTemporalCensorRecovery(input: {
   config: ColorScaleSpec | undefined;
@@ -37,6 +38,8 @@ function colorTemporalCensorRecovery(input: {
 }): {
   hasExplicitDomain: boolean;
   hasBinnedBreaks: boolean;
+  /** Authored domain exists but is not a usable two-endpoint train bound. */
+  domainBlocksRecovery: boolean;
   trainingFields: ReadonlySet<string>;
   constantTrains: boolean;
 } {
@@ -55,22 +58,34 @@ function colorTemporalCensorRecovery(input: {
         disambiguation: config.disambiguation,
       }),
   };
-  const parseableBound = (value: unknown): boolean => {
-    if (!temporalInputsUsable || config?.parse === undefined) return false;
-    return parseTemporal(value, config.parse, temporalOptions).ok;
+  const parseBound = (value: unknown) => {
+    if (!temporalInputsUsable || config?.parse === undefined) return null;
+    const result = parseTemporal(value, config.parse, temporalOptions);
+    return result.ok ? result : null;
   };
 
   const domainValues = Array.isArray(config?.domain)
     ? config.domain.filter((value) => value !== null)
     : [];
   const hasExplicitDomain =
-    domainValues.length === 2 && domainValues.every((value) => parseableBound(value));
+    domainValues.length === 2 && domainValues.every((value) => parseBound(value) !== null);
+  // Runtime throws color-domain-invalid / color-binned-domain whenever domain is
+  // authored but not exactly two parseable endpoints — before siblings/breaks train.
+  const domainBlocksRecovery = Array.isArray(config?.domain) && !hasExplicitDomain;
+
   const binnedBreaks =
     config?.type === "binned" && Array.isArray(config.breaks)
       ? config.breaks.filter((value) => value !== null)
       : [];
+  const parsedBreaks = binnedBreaks.map((value) => parseBound(value));
   const hasBinnedBreaks =
-    binnedBreaks.length >= 2 && binnedBreaks.every((value) => parseableBound(value));
+    parsedBreaks.length >= 2 &&
+    parsedBreaks.every((result) => result !== null) &&
+    parsedBreaks.every((result, index) => {
+      if (index === 0 || result === null) return true;
+      const prev = parsedBreaks[index - 1];
+      return prev !== null && result.epochMs > prev.epochMs;
+    });
 
   const trainingFields = new Set<string>();
   const requestsTemporal =
@@ -82,11 +97,16 @@ function colorTemporalCensorRecovery(input: {
     const parser = config?.parse ?? "auto";
     for (const use of colorFields) {
       const type = typeOf(use.field);
-      if (type === "temporal") {
-        trainingFields.add(use.field);
+      // Always reparse under the configured parser — type:"temporal" from default
+      // evidence does not mean the value trains when parse is an explicit override.
+      if (
+        type !== "temporal" &&
+        type !== "quantitative" &&
+        type !== "nominal" &&
+        type !== "ordinal"
+      ) {
         continue;
       }
-      if (type !== "quantitative" && type !== "nominal" && type !== "ordinal") continue;
       const decision = temporalDecisionForField(
         temporalDecisionCache,
         use.field,
@@ -97,19 +117,30 @@ function colorTemporalCensorRecovery(input: {
       if (
         decision !== null &&
         decision !== undefined &&
-        (decision.status === "temporal" || (decision.validatedCount ?? 0) > 0)
+        (decision.status === "temporal" || (decision.validatedCount ?? 0) > 0) &&
+        (config?.temporalKind === undefined ||
+          decision.kind === null ||
+          decision.kind === undefined ||
+          decision.kind === config.temporalKind)
       ) {
         trainingFields.add(use.field);
       }
     }
-  } else {
-    for (const use of colorFields) {
-      if (typeOf(use.field) === "temporal") trainingFields.add(use.field);
-    }
   }
 
-  const constantTrains = colorScaledConstants.some((value) => parseableBound(value));
-  return { hasExplicitDomain, hasBinnedBreaks, trainingFields, constantTrains };
+  const kindOk = (kind: string | undefined): boolean =>
+    config?.temporalKind === undefined || kind === undefined || kind === config.temporalKind;
+  const constantTrains = colorScaledConstants.some((value) => {
+    const parsed = parseBound(value);
+    return parsed !== null && kindOk(parsed.kind);
+  });
+  return {
+    hasExplicitDomain,
+    hasBinnedBreaks,
+    domainBlocksRecovery,
+    trainingFields,
+    constantTrains,
+  };
 }
 
 function censoredTemporalColorRecovers(input: {
@@ -119,12 +150,15 @@ function censoredTemporalColorRecovers(input: {
   recovery: {
     hasExplicitDomain: boolean;
     hasBinnedBreaks: boolean;
+    domainBlocksRecovery: boolean;
     trainingFields: ReadonlySet<string>;
     constantTrains: boolean;
   };
 }): boolean {
   if (input.config?.parse === undefined || input.config.parseFailure !== "censor") return false;
   if (input.decision?.status !== "invalid") return false;
+  // A present-but-unusable domain always throws at runtime before recovery sources apply.
+  if (input.recovery.domainBlocksRecovery) return false;
   if ((input.decision.validatedCount ?? 0) > 0) return true;
   if (input.recovery.hasExplicitDomain || input.recovery.hasBinnedBreaks) return true;
   if (input.recovery.constantTrains) return true;

--- a/packages/spec/src/validate-data-checks-color.ts
+++ b/packages/spec/src/validate-data-checks-color.ts
@@ -7,7 +7,7 @@ import type { SpecError } from "./errors.js";
 import { configuredColorScaleType } from "./scale-helpers.js";
 import type { ColorScaleSpec } from "./schema.js";
 import { SEQUENTIAL_SCHEME_NAMES } from "./schema.js";
-import { parseTemporal } from "./temporal-parse.js";
+import { parseTemporalColumn } from "./temporal-column.js";
 import type { FieldEvidenceMap } from "./validate-data-evidence.js";
 import {
   temporalDecisionForField,
@@ -43,12 +43,12 @@ function colorTemporalCensorRecovery(input: {
   trainingFields: ReadonlySet<string>;
   constantTrains: boolean;
   /**
-   * A scaled constant parses under the configured parser but conflicts with
-   * temporalKind — runtime still includes it in collectColorChannelValues and
-   * throws color-temporal-kind, so recovery and otherwise-valid fields must fail.
+   * A channel value (scaled constant or sibling field) parses under the
+   * configured/auto parser but conflicts with temporalKind — runtime still
+   * includes it in collectColorChannelValues and throws color-temporal-kind.
    */
-  constantKindConflicts: boolean;
-  conflictingConstantKind: string | null;
+  kindConflicts: boolean;
+  conflictingKind: string | null;
 } {
   const { config, colorFields, colorScaledConstants, fields, temporalDecisionCache, typeOf } =
     input;
@@ -65,10 +65,25 @@ function colorTemporalCensorRecovery(input: {
         disambiguation: config.disambiguation,
       }),
   };
-  const parseBound = (value: unknown) => {
-    if (!temporalInputsUsable || config?.parse === undefined) return null;
-    const result = parseTemporal(value, config.parse, temporalOptions);
-    return result.ok ? result : null;
+  // Runtime uses config?.parse ?? "auto" in resolveColorValueView — kind-conflict
+  // detection must do the same (not only when parse is explicit). parseTemporal does
+  // not accept "auto", so column parsing is the shared path for both cases.
+  const parser: Parameters<typeof temporalDecisionForField>[3] = config?.parse ?? "auto";
+  const parseBound = (value: unknown): { epochMs: number; kind: string | undefined } | null => {
+    if (!temporalInputsUsable) return null;
+    if (value === null || value === undefined) return null;
+    if (!(value instanceof Date) && typeof value !== "string" && typeof value !== "number") {
+      return null;
+    }
+    const column = parseTemporalColumn(
+      [value] as Parameters<typeof parseTemporalColumn>[0],
+      parser,
+      temporalOptions,
+    );
+    if (column.valid[0] !== 1) return null;
+    const epochMs = column.semantic[0];
+    if (epochMs === undefined || !Number.isFinite(epochMs)) return null;
+    return { epochMs, kind: column.decision.kind ?? undefined };
   };
 
   const domainValues = Array.isArray(config?.domain)
@@ -80,39 +95,48 @@ function colorTemporalCensorRecovery(input: {
   // authored but not exactly two parseable endpoints — before siblings/breaks train.
   const domainBlocksRecovery = Array.isArray(config?.domain) && !hasExplicitDomain;
 
-  const binnedBreaks =
-    config?.type === "binned" && Array.isArray(config.breaks)
-      ? config.breaks.filter((value) => value !== null)
-      : [];
+  // Do not drop null breaks: runtime maps every authored break and throws
+  // color-binned-breaks when any maps to undefined.
+  const authoredBreaks =
+    config?.type === "binned" && Array.isArray(config.breaks) ? config.breaks : [];
   const parsedBreakEpochs: number[] = [];
-  for (const value of binnedBreaks) {
-    const parsed = parseBound(value);
-    if (parsed === null) {
-      parsedBreakEpochs.length = 0;
-      break;
-    }
-    parsedBreakEpochs.push(parsed.epochMs);
-  }
-  let hasBinnedBreaks = parsedBreakEpochs.length >= 2;
-  if (hasBinnedBreaks) {
-    for (let index = 1; index < parsedBreakEpochs.length; index++) {
-      const prev = parsedBreakEpochs[index - 1];
-      const current = parsedBreakEpochs[index];
-      if (prev === undefined || current === undefined || current <= prev) {
-        hasBinnedBreaks = false;
+  let hasBinnedBreaks = false;
+  if (authoredBreaks.length >= 2) {
+    let allParseable = true;
+    for (const value of authoredBreaks) {
+      if (value === null) {
+        allParseable = false;
         break;
+      }
+      const parsed = parseBound(value);
+      if (parsed === null) {
+        allParseable = false;
+        break;
+      }
+      parsedBreakEpochs.push(parsed.epochMs);
+    }
+    if (allParseable && parsedBreakEpochs.length >= 2) {
+      hasBinnedBreaks = true;
+      for (let index = 1; index < parsedBreakEpochs.length; index++) {
+        const prev = parsedBreakEpochs[index - 1];
+        const current = parsedBreakEpochs[index];
+        if (prev === undefined || current === undefined || current <= prev) {
+          hasBinnedBreaks = false;
+          break;
+        }
       }
     }
   }
 
   const trainingFields = new Set<string>();
+  let kindConflicts = false;
+  let conflictingKind: string | null = null;
   const requestsTemporal =
     config?.temporalKind !== undefined ||
     config?.parse !== undefined ||
     config?.timezone !== undefined ||
     config?.disambiguation !== undefined;
   if (temporalInputsUsable && requestsTemporal) {
-    const parser = config?.parse ?? "auto";
     for (const use of colorFields) {
       const type = typeOf(use.field);
       // Always reparse under the configured parser — type:"temporal" from default
@@ -132,33 +156,34 @@ function colorTemporalCensorRecovery(input: {
         parser,
         temporalOptions,
       );
+      if (decision === null || decision === undefined) continue;
+      const trains = decision.status === "temporal" || (decision.validatedCount ?? 0) > 0;
+      if (!trains) continue;
       if (
-        decision !== null &&
-        decision !== undefined &&
-        (decision.status === "temporal" || (decision.validatedCount ?? 0) > 0) &&
-        (config?.temporalKind === undefined ||
-          decision.kind === null ||
-          decision.kind === undefined ||
-          decision.kind === config.temporalKind)
+        typeof config?.temporalKind === "string" &&
+        decision.kind !== null &&
+        decision.kind !== undefined &&
+        decision.kind !== config.temporalKind
       ) {
-        trainingFields.add(use.field);
+        kindConflicts = true;
+        conflictingKind = decision.kind;
+        continue;
       }
+      trainingFields.add(use.field);
     }
   }
 
   const kindOk = (kind: string | undefined): boolean =>
     config?.temporalKind === undefined || kind === undefined || kind === config.temporalKind;
   let constantTrains = false;
-  let constantKindConflicts = false;
-  let conflictingConstantKind: string | null = null;
   for (const value of colorScaledConstants) {
     const parsed = parseBound(value);
     if (parsed === null) continue;
     if (kindOk(parsed.kind)) {
       constantTrains = true;
     } else {
-      constantKindConflicts = true;
-      conflictingConstantKind = parsed.kind;
+      kindConflicts = true;
+      conflictingKind = parsed.kind ?? null;
     }
   }
   return {
@@ -167,8 +192,8 @@ function colorTemporalCensorRecovery(input: {
     domainBlocksRecovery,
     trainingFields,
     constantTrains,
-    constantKindConflicts,
-    conflictingConstantKind,
+    kindConflicts,
+    conflictingKind,
   };
 }
 
@@ -182,16 +207,15 @@ function censoredTemporalColorRecovers(input: {
     domainBlocksRecovery: boolean;
     trainingFields: ReadonlySet<string>;
     constantTrains: boolean;
-    constantKindConflicts: boolean;
+    kindConflicts: boolean;
   };
 }): boolean {
   if (input.config?.parse === undefined || input.config.parseFailure !== "censor") return false;
   if (input.decision?.status !== "invalid") return false;
   // A present-but-unusable domain always throws at runtime before recovery sources apply.
   if (input.recovery.domainBlocksRecovery) return false;
-  // Wrong-kind scaled constants still participate in channel training and throw
-  // color-temporal-kind — they cannot be ignored as non-training.
-  if (input.recovery.constantKindConflicts) return false;
+  // Kind-mismatched channel values still train and throw color-temporal-kind.
+  if (input.recovery.kindConflicts) return false;
   if ((input.decision.validatedCount ?? 0) > 0) return true;
   if (input.recovery.hasExplicitDomain || input.recovery.hasBinnedBreaks) return true;
   if (input.recovery.constantTrains) return true;
@@ -327,19 +351,19 @@ export function checkColorScaleDataCompatibility(input: {
       temporalDecisionCache,
       typeOf,
     });
-    // Runtime collects scaled constants into the same temporal column as fields;
-    // a kind conflict throws color-temporal-kind for the whole channel.
+    // Runtime collects all channel values into one temporal column; a kind
+    // conflict (sibling field or scaled constant) throws color-temporal-kind.
     if (
-      recovery.constantKindConflicts &&
+      recovery.kindConflicts &&
       typeof config?.temporalKind === "string" &&
-      recovery.conflictingConstantKind !== null
+      recovery.conflictingKind !== null
     ) {
       errors.push({
         code: "scale-type-mismatch",
         path: `/scales/${channel}`,
-        message: `scales.${channel} requests temporal kind "${config.temporalKind}" but a scaled constant parses as "${recovery.conflictingConstantKind}".`,
+        message: `scales.${channel} requests temporal kind "${config.temporalKind}" but a channel value parses as "${recovery.conflictingKind}".`,
         fix: {
-          description: `Use a ${config.temporalKind} scaled constant, or set temporalKind to "${recovery.conflictingConstantKind}".`,
+          description: `Use ${config.temporalKind} values for every color mapping and scaled constant, or set temporalKind to "${recovery.conflictingKind}".`,
         },
       });
     }

--- a/packages/spec/src/validate-data-checks-color.ts
+++ b/packages/spec/src/validate-data-checks-color.ts
@@ -42,6 +42,13 @@ function colorTemporalCensorRecovery(input: {
   domainBlocksRecovery: boolean;
   trainingFields: ReadonlySet<string>;
   constantTrains: boolean;
+  /**
+   * A scaled constant parses under the configured parser but conflicts with
+   * temporalKind — runtime still includes it in collectColorChannelValues and
+   * throws color-temporal-kind, so recovery and otherwise-valid fields must fail.
+   */
+  constantKindConflicts: boolean;
+  conflictingConstantKind: string | null;
 } {
   const { config, colorFields, colorScaledConstants, fields, temporalDecisionCache, typeOf } =
     input;
@@ -141,16 +148,27 @@ function colorTemporalCensorRecovery(input: {
 
   const kindOk = (kind: string | undefined): boolean =>
     config?.temporalKind === undefined || kind === undefined || kind === config.temporalKind;
-  const constantTrains = colorScaledConstants.some((value) => {
+  let constantTrains = false;
+  let constantKindConflicts = false;
+  let conflictingConstantKind: string | null = null;
+  for (const value of colorScaledConstants) {
     const parsed = parseBound(value);
-    return parsed !== null && kindOk(parsed.kind);
-  });
+    if (parsed === null) continue;
+    if (kindOk(parsed.kind)) {
+      constantTrains = true;
+    } else {
+      constantKindConflicts = true;
+      conflictingConstantKind = parsed.kind;
+    }
+  }
   return {
     hasExplicitDomain,
     hasBinnedBreaks,
     domainBlocksRecovery,
     trainingFields,
     constantTrains,
+    constantKindConflicts,
+    conflictingConstantKind,
   };
 }
 
@@ -164,12 +182,16 @@ function censoredTemporalColorRecovers(input: {
     domainBlocksRecovery: boolean;
     trainingFields: ReadonlySet<string>;
     constantTrains: boolean;
+    constantKindConflicts: boolean;
   };
 }): boolean {
   if (input.config?.parse === undefined || input.config.parseFailure !== "censor") return false;
   if (input.decision?.status !== "invalid") return false;
   // A present-but-unusable domain always throws at runtime before recovery sources apply.
   if (input.recovery.domainBlocksRecovery) return false;
+  // Wrong-kind scaled constants still participate in channel training and throw
+  // color-temporal-kind — they cannot be ignored as non-training.
+  if (input.recovery.constantKindConflicts) return false;
   if ((input.decision.validatedCount ?? 0) > 0) return true;
   if (input.recovery.hasExplicitDomain || input.recovery.hasBinnedBreaks) return true;
   if (input.recovery.constantTrains) return true;
@@ -305,6 +327,22 @@ export function checkColorScaleDataCompatibility(input: {
       temporalDecisionCache,
       typeOf,
     });
+    // Runtime collects scaled constants into the same temporal column as fields;
+    // a kind conflict throws color-temporal-kind for the whole channel.
+    if (
+      recovery.constantKindConflicts &&
+      typeof config?.temporalKind === "string" &&
+      recovery.conflictingConstantKind !== null
+    ) {
+      errors.push({
+        code: "scale-type-mismatch",
+        path: `/scales/${channel}`,
+        message: `scales.${channel} requests temporal kind "${config.temporalKind}" but a scaled constant parses as "${recovery.conflictingConstantKind}".`,
+        fix: {
+          description: `Use a ${config.temporalKind} scaled constant, or set temporalKind to "${recovery.conflictingConstantKind}".`,
+        },
+      });
+    }
 
     for (const use of colorFields[channel]) {
       const type = typeOf(use.field);

--- a/packages/spec/src/validate-data-checks-color.ts
+++ b/packages/spec/src/validate-data-checks-color.ts
@@ -55,10 +55,10 @@ function colorTemporalCensorRecovery(input: {
         disambiguation: config.disambiguation,
       }),
   };
-  const parseableBound = (value: unknown): boolean =>
-    temporalInputsUsable &&
-    config?.parse !== undefined &&
-    parseTemporal(value, config.parse as Parameters<typeof parseTemporal>[1], temporalOptions).ok;
+  const parseableBound = (value: unknown): boolean => {
+    if (!temporalInputsUsable || config?.parse === undefined) return false;
+    return parseTemporal(value, config.parse, temporalOptions).ok;
+  };
 
   const domainValues = Array.isArray(config?.domain)
     ? config.domain.filter((value) => value !== null)
@@ -79,7 +79,7 @@ function colorTemporalCensorRecovery(input: {
     config?.timezone !== undefined ||
     config?.disambiguation !== undefined;
   if (temporalInputsUsable && requestsTemporal) {
-    const parser = (config?.parse ?? "auto") as Parameters<typeof temporalDecisionForField>[3];
+    const parser = config?.parse ?? "auto";
     for (const use of colorFields) {
       const type = typeOf(use.field);
       if (type === "temporal") {

--- a/packages/spec/src/validate-data-checks-color.ts
+++ b/packages/spec/src/validate-data-checks-color.ts
@@ -77,15 +77,26 @@ function colorTemporalCensorRecovery(input: {
     config?.type === "binned" && Array.isArray(config.breaks)
       ? config.breaks.filter((value) => value !== null)
       : [];
-  const parsedBreaks = binnedBreaks.map((value) => parseBound(value));
-  const hasBinnedBreaks =
-    parsedBreaks.length >= 2 &&
-    parsedBreaks.every((result) => result !== null) &&
-    parsedBreaks.every((result, index) => {
-      if (index === 0 || result === null) return true;
-      const prev = parsedBreaks[index - 1];
-      return prev !== null && result.epochMs > prev.epochMs;
-    });
+  const parsedBreakEpochs: number[] = [];
+  for (const value of binnedBreaks) {
+    const parsed = parseBound(value);
+    if (parsed === null) {
+      parsedBreakEpochs.length = 0;
+      break;
+    }
+    parsedBreakEpochs.push(parsed.epochMs);
+  }
+  let hasBinnedBreaks = parsedBreakEpochs.length >= 2;
+  if (hasBinnedBreaks) {
+    for (let index = 1; index < parsedBreakEpochs.length; index++) {
+      const prev = parsedBreakEpochs[index - 1];
+      const current = parsedBreakEpochs[index];
+      if (prev === undefined || current === undefined || current <= prev) {
+        hasBinnedBreaks = false;
+        break;
+      }
+    }
+  }
 
   const trainingFields = new Set<string>();
   const requestsTemporal =

--- a/packages/spec/tests/validate-tier2-color.test.ts
+++ b/packages/spec/tests/validate-tier2-color.test.ts
@@ -339,6 +339,176 @@ describe("tier 2 — color scale data-aware validation", () => {
     expect(result.ok).toBe(true);
   });
 
+  it("rejects all-failed censored epoch parses when the explicit domain does not parse", () => {
+    // Runtime only maps domain endpoints through semanticOf and throws
+    // color-domain-invalid when either endpoint fails the parser. A two-entry
+    // domain of unparseable strings must not suppress the scale-type-mismatch.
+    const result = validate(
+      normalize({
+        data: {
+          values: [
+            { x: 1, y: 1, t: 1e100 },
+            { x: 2, y: 2, t: 1e101 },
+          ],
+        },
+        layers: [
+          {
+            geom: "point",
+            aes: { x: { field: "x" }, y: { field: "y" }, color: { field: "t" } },
+          },
+        ],
+        scales: {
+          color: {
+            type: "sequential",
+            temporalKind: "datetime",
+            parse: { epoch: "milliseconds" },
+            parseFailure: "censor",
+            domain: ["bad", "worse"],
+          },
+        },
+      }),
+      {},
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected failure");
+    expect(result.errors.some((error) => error.code === "scale-type-mismatch")).toBe(true);
+  });
+
+  it("allows all-failed censored temporal colors when a sibling layer trains the channel", () => {
+    // Runtime collectColorChannelValues unions every layer's color values before
+    // finiteExtent. An all-invalid layer is censored when another layer supplies
+    // a valid epoch; validation must not reject field-by-field independently.
+    const result = validate(
+      normalize({
+        data: {
+          values: [
+            { x: 1, y: 1, bad: 1e100, good: 1_700_000_000_000 },
+            { x: 2, y: 2, bad: 1e101, good: 1_706_745_600_000 },
+          ],
+        },
+        layers: [
+          {
+            geom: "point",
+            aes: { x: { field: "x" }, y: { field: "y" }, color: { field: "bad" } },
+          },
+          {
+            geom: "point",
+            aes: { x: { field: "x" }, y: { field: "y" }, color: { field: "good" } },
+          },
+        ],
+        scales: {
+          color: {
+            type: "sequential",
+            temporalKind: "datetime",
+            parse: { epoch: "milliseconds" },
+            parseFailure: "censor",
+          },
+        },
+      }),
+      {},
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  it("allows all-failed censored temporal colors when a scaled constant trains the channel", () => {
+    const result = validate(
+      normalize({
+        data: {
+          values: [
+            { x: 1, y: 1, t: 1e100 },
+            { x: 2, y: 2, t: 1e101 },
+          ],
+        },
+        layers: [
+          {
+            geom: "point",
+            aes: { x: { field: "x" }, y: { field: "y" }, color: { field: "t" } },
+          },
+          {
+            geom: "point",
+            aes: {
+              x: { field: "x" },
+              y: { field: "y" },
+              color: { value: 1_700_000_000_000, scale: true },
+            },
+          },
+        ],
+        scales: {
+          color: {
+            type: "sequential",
+            temporalKind: "datetime",
+            parse: { epoch: "milliseconds" },
+            parseFailure: "censor",
+          },
+        },
+      }),
+      {},
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  it("allows all-failed censored binned temporal colors trained from authored breaks", () => {
+    // resolveBinnedColorScale maps breaks and uses first/last as domain when the
+    // data extent is empty under parseFailure: "censor".
+    const result = validate(
+      normalize({
+        data: {
+          values: [
+            { x: 1, y: 1, t: "not-a-date" },
+            { x: 2, y: 2, t: "also-bad" },
+          ],
+        },
+        layers: [
+          {
+            geom: "point",
+            aes: { x: { field: "x" }, y: { field: "y" }, color: { field: "t" } },
+          },
+        ],
+        scales: {
+          color: {
+            type: "binned",
+            parse: "iso",
+            parseFailure: "censor",
+            breaks: ["2024-01-01", "2024-01-15", "2024-01-31"],
+          },
+        },
+      }),
+      {},
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects all-failed censored binned temporal colors when breaks do not parse", () => {
+    const result = validate(
+      normalize({
+        data: {
+          values: [
+            { x: 1, y: 1, t: "not-a-date" },
+            { x: 2, y: 2, t: "also-bad" },
+          ],
+        },
+        layers: [
+          {
+            geom: "point",
+            aes: { x: { field: "x" }, y: { field: "y" }, color: { field: "t" } },
+          },
+        ],
+        scales: {
+          color: {
+            type: "binned",
+            parse: "iso",
+            parseFailure: "censor",
+            breaks: ["not-a-date", "also-bad"],
+          },
+        },
+      }),
+      {},
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected failure");
+    expect(result.errors.some((error) => error.code === "scale-type-mismatch")).toBe(true);
+  });
+
   it("still rejects when scaled constants alone exceed the manual range under DataProfile", () => {
     const profile: DataProfile = {
       fields: [

--- a/packages/spec/tests/validate-tier2-color.test.ts
+++ b/packages/spec/tests/validate-tier2-color.test.ts
@@ -660,8 +660,123 @@ describe("tier 2 — color scale data-aware validation", () => {
     if (result.ok) throw new Error("expected failure");
     expect(
       result.errors.some(
-        (error) =>
-          error.code === "scale-type-mismatch" && error.message.includes("scaled constant"),
+        (error) => error.code === "scale-type-mismatch" && error.message.includes("channel value"),
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects kind-mismatched scaled constants when parse is omitted (auto)", () => {
+    // Runtime uses parse ?? "auto"; conflict detection must not require explicit parse.
+    const result = validate(
+      normalize({
+        data: {
+          values: [
+            { x: 1, y: 1, when: "2024-01-15" },
+            { x: 2, y: 2, when: "2024-02-15" },
+          ],
+        },
+        layers: [
+          {
+            geom: "point",
+            aes: { x: { field: "x" }, y: { field: "y" }, color: { field: "when" } },
+          },
+          {
+            geom: "point",
+            aes: {
+              x: { field: "x" },
+              y: { field: "y" },
+              color: { value: "2024-01-01T12:00", scale: true },
+            },
+          },
+        ],
+        scales: {
+          color: {
+            type: "sequential",
+            temporalKind: "date",
+          },
+        },
+      }),
+      {},
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected failure");
+    expect(result.errors.some((error) => error.code === "scale-type-mismatch")).toBe(true);
+  });
+
+  it("rejects all-failed censored binned temporal colors when a break is null", () => {
+    const result = validate(
+      normalize({
+        data: {
+          values: [
+            { x: 1, y: 1, t: "not-a-date" },
+            { x: 2, y: 2, t: "also-bad" },
+          ],
+        },
+        layers: [
+          {
+            geom: "point",
+            aes: { x: { field: "x" }, y: { field: "y" }, color: { field: "t" } },
+          },
+        ],
+        scales: {
+          color: {
+            type: "binned",
+            parse: "iso",
+            parseFailure: "censor",
+            breaks: ["2024-01-01", null, "2024-02-01"],
+          },
+        },
+      }),
+      {},
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected failure");
+    expect(result.errors.some((error) => error.code === "scale-type-mismatch")).toBe(true);
+  });
+
+  it("rejects a kind-mismatched sibling even when a scaled constant would recover", () => {
+    const result = validate(
+      normalize({
+        data: {
+          values: [
+            { x: 1, y: 1, bad: "xx", when: "2024-01-01T12:00" },
+            { x: 2, y: 2, bad: "yy", when: "2024-02-01T12:00" },
+          ],
+        },
+        layers: [
+          {
+            geom: "point",
+            aes: { x: { field: "x" }, y: { field: "y" }, color: { field: "bad" } },
+          },
+          {
+            geom: "point",
+            aes: { x: { field: "x" }, y: { field: "y" }, color: { field: "when" } },
+          },
+          {
+            geom: "point",
+            aes: {
+              x: { field: "x" },
+              y: { field: "y" },
+              color: { value: "2024-01-15", scale: true },
+            },
+          },
+        ],
+        scales: {
+          color: {
+            type: "sequential",
+            temporalKind: "date",
+            parse: "iso",
+            parseFailure: "censor",
+          },
+        },
+      }),
+      {},
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected failure");
+    expect(
+      result.errors.some(
+        (error) => error.code === "scale-type-mismatch" && error.message.includes("channel value"),
       ),
     ).toBe(true);
   });

--- a/packages/spec/tests/validate-tier2-color.test.ts
+++ b/packages/spec/tests/validate-tier2-color.test.ts
@@ -617,6 +617,55 @@ describe("tier 2 — color scale data-aware validation", () => {
     expect(result.errors.some((error) => error.code === "scale-type-mismatch")).toBe(true);
   });
 
+  it("rejects a kind-mismatched scaled constant even when a sibling field would recover", () => {
+    // Runtime unions sibling field values with scaled constants before the kind check.
+    const result = validate(
+      normalize({
+        data: {
+          values: [
+            { x: 1, y: 1, bad: "xx", good: "2024-01-15" },
+            { x: 2, y: 2, bad: "yy", good: "2024-02-15" },
+          ],
+        },
+        layers: [
+          {
+            geom: "point",
+            aes: { x: { field: "x" }, y: { field: "y" }, color: { field: "bad" } },
+          },
+          {
+            geom: "point",
+            aes: { x: { field: "x" }, y: { field: "y" }, color: { field: "good" } },
+          },
+          {
+            geom: "point",
+            aes: {
+              x: { field: "x" },
+              y: { field: "y" },
+              color: { value: "2024-01-01T12:00", scale: true },
+            },
+          },
+        ],
+        scales: {
+          color: {
+            type: "sequential",
+            temporalKind: "date",
+            parse: "iso",
+            parseFailure: "censor",
+          },
+        },
+      }),
+      {},
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected failure");
+    expect(
+      result.errors.some(
+        (error) =>
+          error.code === "scale-type-mismatch" && error.message.includes("scaled constant"),
+      ),
+    ).toBe(true);
+  });
+
   it("rejects all-failed censored colors when an authored domain is present but unusable", () => {
     // Runtime throws color-domain-invalid before other recovery sources can train.
     const result = validate(

--- a/packages/spec/tests/validate-tier2-color.test.ts
+++ b/packages/spec/tests/validate-tier2-color.test.ts
@@ -509,6 +509,151 @@ describe("tier 2 — color scale data-aware validation", () => {
     expect(result.errors.some((error) => error.code === "scale-type-mismatch")).toBe(true);
   });
 
+  it("rejects all-failed censored binned temporal colors when breaks are not strictly increasing", () => {
+    // Runtime color-binned-breaks requires boundaries strictly increasing in transform space.
+    const result = validate(
+      normalize({
+        data: {
+          values: [
+            { x: 1, y: 1, t: "not-a-date" },
+            { x: 2, y: 2, t: "also-bad" },
+          ],
+        },
+        layers: [
+          {
+            geom: "point",
+            aes: { x: { field: "x" }, y: { field: "y" }, color: { field: "t" } },
+          },
+        ],
+        scales: {
+          color: {
+            type: "binned",
+            parse: "iso",
+            parseFailure: "censor",
+            breaks: ["2024-02-01", "2024-01-01"],
+          },
+        },
+      }),
+      {},
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected failure");
+    expect(result.errors.some((error) => error.code === "scale-type-mismatch")).toBe(true);
+  });
+
+  it("does not treat a temporal sibling as recovery under a mismatched explicit parser", () => {
+    // Sibling ISO dates do not train a dmy color scale; runtime reparses the channel
+    // with the configured parser and censors them too.
+    const result = validate(
+      normalize({
+        data: {
+          values: [
+            { x: 1, y: 1, bad: "xx", good: "2024-01-15" },
+            { x: 2, y: 2, bad: "yy", good: "2024-02-15" },
+          ],
+        },
+        layers: [
+          {
+            geom: "point",
+            aes: { x: { field: "x" }, y: { field: "y" }, color: { field: "bad" } },
+          },
+          {
+            geom: "point",
+            aes: { x: { field: "x" }, y: { field: "y" }, color: { field: "good" } },
+          },
+        ],
+        scales: {
+          color: {
+            type: "sequential",
+            temporalKind: "date",
+            parse: "dmy",
+            parseFailure: "censor",
+          },
+        },
+      }),
+      {},
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected failure");
+    expect(result.errors.some((error) => error.code === "scale-type-mismatch")).toBe(true);
+  });
+
+  it("rejects recovery via a scaled constant whose temporal kind conflicts", () => {
+    const result = validate(
+      normalize({
+        data: {
+          values: [
+            { x: 1, y: 1, t: "not-a-date" },
+            { x: 2, y: 2, t: "also-bad" },
+          ],
+        },
+        layers: [
+          {
+            geom: "point",
+            aes: { x: { field: "x" }, y: { field: "y" }, color: { field: "t" } },
+          },
+          {
+            geom: "point",
+            aes: {
+              x: { field: "x" },
+              y: { field: "y" },
+              color: { value: "2024-01-01T12:00", scale: true },
+            },
+          },
+        ],
+        scales: {
+          color: {
+            type: "sequential",
+            temporalKind: "date",
+            parse: "iso",
+            parseFailure: "censor",
+          },
+        },
+      }),
+      {},
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected failure");
+    expect(result.errors.some((error) => error.code === "scale-type-mismatch")).toBe(true);
+  });
+
+  it("rejects all-failed censored colors when an authored domain is present but unusable", () => {
+    // Runtime throws color-domain-invalid before other recovery sources can train.
+    const result = validate(
+      normalize({
+        data: {
+          values: [
+            { x: 1, y: 1, bad: 1e100, good: 1_700_000_000_000 },
+            { x: 2, y: 2, bad: 1e101, good: 1_706_745_600_000 },
+          ],
+        },
+        layers: [
+          {
+            geom: "point",
+            aes: { x: { field: "x" }, y: { field: "y" }, color: { field: "bad" } },
+          },
+          {
+            geom: "point",
+            aes: { x: { field: "x" }, y: { field: "y" }, color: { field: "good" } },
+          },
+        ],
+        scales: {
+          color: {
+            type: "sequential",
+            temporalKind: "datetime",
+            parse: { epoch: "milliseconds" },
+            parseFailure: "censor",
+            domain: [1_700_000_000_000],
+          },
+        },
+      }),
+      {},
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected failure");
+    expect(result.errors.some((error) => error.code === "scale-type-mismatch")).toBe(true);
+  });
+
   it("still rejects when scaled constants alone exceed the manual range under DataProfile", () => {
     const profile: DataProfile = {
       fields: [


### PR DESCRIPTION
## Summary

Follow-up for unrebutted post-merge Codex P2s on #573.

With `parseFailure: "censor"`, tier-2 color validation recovered only from the **current field's** `validatedCount` or a two-entry `domain` (without parsing the endpoints). Runtime is stricter and broader:

1. **Channel-wide training** — `collectColorChannelValues` unions every layer + scaled constants before `finiteExtent`; an all-invalid layer is censored when a sibling field or scaled constant supplies a valid value.
2. **Parseable domain** — sequential/binned train only maps endpoints through `semanticOf` and throws `color-domain-invalid` / `color-binned-domain` when either fails.
3. **Binned breaks** — `resolveBinnedColorScale` can train from authored `breaks` when the data extent is empty.

## Tests

- `bun test packages/spec/tests/validate-tier2-color.test.ts`
- Also green: `validate-tier2-data.test.ts`, `validate-tier2-temporal-position.test.ts`

## Parent disposition

Will comment on #573 with this PR number after open.