### PR TITLE
fix(core): multi-source facet layout union for per-layer DataRef (#608)

### DIFF
--- a/.changeset/multi-source-facet-layout-union.md
+++ b/.changeset/multi-source-facet-layout-union.md
@@ -1,0 +1,14 @@
+---
+"@ggsvelte/core": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+fix(core): union facet panel keys across complete per-layer DataRef sources
+
+When several layer-local tables each carry the facet fields but different
+levels, facet layout no longer stops at the first complete table. Panel keys
+are the union of every complete source so later layers cannot introduce
+orphaned levels.
+
+Migration: none — corrects multi-table facet layout under per-layer data

--- a/packages/core/src/pipeline/prepare-panels.ts
+++ b/packages/core/src/pipeline/prepare-panels.ts
@@ -3,7 +3,7 @@
  */
 import type { PortableSpec } from "@ggsvelte/spec";
 
-import { ColumnTable } from "../table.js";
+import { ColumnTable, type CellValue } from "../table.js";
 
 import { bindLayer } from "./bind.js";
 import { bindLayerTable, bindPlotData } from "./bind-data.js";
@@ -32,10 +32,12 @@ import type {
 export type { PreparedPanels } from "./prepare-panels-types.js";
 
 /**
- * Choose the table used to build facet layout:
- * 1. Plot table when it contains every facet field.
- * 2. Else first layer table that contains every facet field.
- * resolveFacet still throws unknown-field when the chosen table lacks a field.
+ * Choose the table used to build facet layout (#608):
+ * - Collect every complete source (plot + layers that have all facet fields).
+ * - One complete source → use it as-is.
+ * - Several complete sources → concatenate facet columns so resolveFacet
+ *   discovers the union of panel keys (layers still slice by panel identity).
+ * - None complete → fall back so resolveFacet can emit unknown-field.
  */
 function facetLayoutTable(
   facet: PortableSpec["facet"],
@@ -46,12 +48,37 @@ function facetLayoutTable(
   if (fields.length === 0) {
     return plotTable ?? layerSources[0] ?? ColumnTable.fromRows([]);
   }
-  if (plotTable !== null && fields.every((f) => plotTable.has(f))) return plotTable;
-  for (const table of layerSources) {
-    if (fields.every((f) => table.has(f))) return table;
+  const complete: ColumnTable[] = [];
+  if (plotTable !== null && fields.every((f) => plotTable.has(f))) {
+    complete.push(plotTable);
   }
-  // Fall back to plot or first layer so resolveFacet emits a clear unknown-field.
-  return plotTable ?? layerSources[0] ?? ColumnTable.fromRows([]);
+  for (const table of layerSources) {
+    if (fields.every((f) => table.has(f))) complete.push(table);
+  }
+  if (complete.length === 0) {
+    // Fall back to plot or first layer so resolveFacet emits a clear unknown-field.
+    return plotTable ?? layerSources[0] ?? ColumnTable.fromRows([]);
+  }
+  if (complete.length === 1) return complete[0]!;
+  return unionFacetKeyColumns(complete, fields);
+}
+
+/** Concatenate facet-key columns from complete sources for layout discovery. */
+function unionFacetKeyColumns(
+  tables: readonly ColumnTable[],
+  fields: readonly string[],
+): ColumnTable {
+  const columns: Record<string, CellValue[]> = {};
+  for (const field of fields) columns[field] = [];
+  for (const table of tables) {
+    const cols = fields.map((f) => table.column(f));
+    for (let row = 0; row < table.rowCount; row++) {
+      for (let i = 0; i < fields.length; i++) {
+        columns[fields[i]!]!.push(cols[i]![row]!);
+      }
+    }
+  }
+  return ColumnTable.fromColumns(columns);
 }
 
 /** Apply rowFilters only for clauses whose field exists on this layer table. */

--- a/packages/core/src/pipeline/prepare-panels.ts
+++ b/packages/core/src/pipeline/prepare-panels.ts
@@ -33,31 +33,26 @@ export type { PreparedPanels } from "./prepare-panels-types.js";
 
 /**
  * Choose the table used to build facet layout (#608):
- * - Collect every complete source (plot + layers that have all facet fields).
- * - One complete source → use it as-is.
+ * - `sources` is one filtered table per distinct SourceRegistry namespace
+ *   (caller dedupes inherited plot tables so we do not double-count).
+ * - Collect every complete source (has all facet fields).
+ * - One complete source → use it as-is (panel sourceRows stay real).
  * - Several complete sources → concatenate facet columns so resolveFacet
  *   discovers the union of panel keys (layers still slice by panel identity).
  * - None complete → fall back so resolveFacet can emit unknown-field.
  */
 function facetLayoutTable(
   facet: PortableSpec["facet"],
-  plotTable: ColumnTable | null,
-  layerSources: readonly ColumnTable[],
+  sources: readonly ColumnTable[],
 ): ColumnTable {
   const fields = facetFieldNames(facet);
   if (fields.length === 0) {
-    return plotTable ?? layerSources[0] ?? ColumnTable.fromRows([]);
+    return sources[0] ?? ColumnTable.fromRows([]);
   }
-  const complete: ColumnTable[] = [];
-  if (plotTable !== null && fields.every((f) => plotTable.has(f))) {
-    complete.push(plotTable);
-  }
-  for (const table of layerSources) {
-    if (fields.every((f) => table.has(f))) complete.push(table);
-  }
+  const complete = sources.filter((table) => fields.every((f) => table.has(f)));
   if (complete.length === 0) {
-    // Fall back to plot or first layer so resolveFacet emits a clear unknown-field.
-    return plotTable ?? layerSources[0] ?? ColumnTable.fromRows([]);
+    // Fall back so resolveFacet emits a clear unknown-field.
+    return sources[0] ?? ColumnTable.fromRows([]);
   }
   if (complete.length === 1) return complete[0]!;
   return unionFacetKeyColumns(complete, fields);
@@ -164,11 +159,21 @@ export function preparePanels(
   assertScaleConfiguration("x", normalized.scales?.x);
   assertScaleConfiguration("y", normalized.scales?.y);
 
-  const layoutTable = facetLayoutTable(
-    normalized.facet,
-    plotSource === null ? null : primaryFiltered.table,
-    layerContexts.map((c) => c.filteredTable),
-  );
+  // One filtered view per unfiltered source object: plot first when present,
+  // then layer-local tables. Inherited layers share plotSource and must not
+  // re-enter the complete set (#608 union without double-counting).
+  const layoutSources: ColumnTable[] = [];
+  const seenSourceTables = new Set<ColumnTable>();
+  if (plotSource !== null) {
+    layoutSources.push(primaryFiltered.table);
+    seenSourceTables.add(plotSource);
+  }
+  for (const ctx of layerContexts) {
+    if (seenSourceTables.has(ctx.sourceTable)) continue;
+    seenSourceTables.add(ctx.sourceTable);
+    layoutSources.push(ctx.filteredTable);
+  }
+  const layoutTable = facetLayoutTable(normalized.facet, layoutSources);
   // Closed levels still produce empty panels when every row was filtered out;
   // only implicit (data-driven) facets collapse to a single placeholder.
   const hasClosedLevels =

--- a/packages/core/tests/pipeline-layer-data.test.ts
+++ b/packages/core/tests/pipeline-layer-data.test.ts
@@ -294,4 +294,97 @@ describe("layer data facets", () => {
     // Both secondary points should render (one per panel) plus observations.
     expect(markCount(model, "points")).toBe(obs.length + 2);
   });
+
+  // #608: first-complete layout omitted panels that only appear on later layers.
+  it("unions facet levels across complete per-layer tables (wrap)", () => {
+    const model = runPipeline(
+      {
+        facet: { wrap: { field: "g" } },
+        layers: [
+          {
+            geom: "point",
+            data: {
+              values: [
+                { x: 1, y: 10, g: "a" },
+                { x: 2, y: 20, g: "a" },
+              ],
+            },
+            aes: { x: { field: "x" }, y: { field: "y" } },
+          },
+          {
+            geom: "point",
+            data: {
+              values: [
+                { x: 3, y: 30, g: "b" },
+                { x: 4, y: 40, g: "b" },
+              ],
+            },
+            aes: { x: { field: "x" }, y: { field: "y" } },
+          },
+        ],
+      },
+      size,
+    );
+    expect(model.scene.panels.map((p) => p.strip)).toEqual(["a", "b"]);
+    expect(markCount(model, "points")).toBe(4);
+  });
+
+  it("unions facet levels when a layer introduces levels absent from plot data", () => {
+    const model = runPipeline(
+      {
+        data: {
+          values: [
+            { x: 1, y: 10, g: "a" },
+            { x: 2, y: 20, g: "b" },
+          ],
+        },
+        aes: { x: { field: "x" }, y: { field: "y" } },
+        facet: { wrap: { field: "g" } },
+        layers: [
+          { geom: "point" },
+          {
+            geom: "point",
+            data: {
+              values: [
+                { x: 5, y: 50, g: "c", tag: "extra" },
+                { x: 6, y: 60, g: "c", tag: "extra" },
+              ],
+            },
+            aes: { x: { field: "x" }, y: { field: "y" } },
+          },
+        ],
+      },
+      size,
+    );
+    expect(model.scene.panels.map((p) => p.strip)).toEqual(["a", "b", "c"]);
+    // Plot points (2) + layer-local "c" points (2).
+    expect(markCount(model, "points")).toBe(4);
+  });
+
+  it("unions facet grid levels across complete per-layer tables", () => {
+    const model = runPipeline(
+      {
+        facet: { rows: { field: "r" }, cols: { field: "c" } },
+        layers: [
+          {
+            geom: "point",
+            data: { values: [{ x: 1, y: 1, r: "R1", c: "C1" }] },
+            aes: { x: { field: "x" }, y: { field: "y" } },
+          },
+          {
+            geom: "point",
+            data: { values: [{ x: 2, y: 2, r: "R2", c: "C2" }] },
+            aes: { x: { field: "x" }, y: { field: "y" } },
+          },
+        ],
+      },
+      size,
+    );
+    // Grid keeps the full rows × cols product (empty combos stay empty).
+    expect(model.scene.panels).toHaveLength(4);
+    expect(model.scene.panels.map((p) => p.strip).toSorted()).toEqual(
+      ["R1 / C1", "R1 / C2", "R2 / C1", "R2 / C2"].toSorted(),
+    );
+    expect(markCount(model, "points")).toBe(2);
+  });
 });


### PR DESCRIPTION
## Summary

- Facet layout no longer stops at the first complete table when building panels for multi-table specs
- Union facet-key columns across every complete source (plot + layer tables that carry all facet fields)
- Layers still slice by panel identity; only panel-key discovery changes

Closes #608
Closes #607

## Context

Deferred Codex P1 from PR #603: with per-layer `DataRef`, disjoint facet levels across layers produced missing panels (and dropped marks) because `facetLayoutTable` returned the first complete source only.

## Test plan

- [x] Failing TDD case first: wrap with two layers, only `g=a` then only `g=b` → panels `["a","b"]` and all 4 points
- [x] Plot + later layer introducing new level `c`
- [x] Facet grid product across disjoint complete sources
- [x] Existing layer-data facet / preparePanels / facets suites green