### PR TITLE
fix(svelte): legend filters with hidden annotation scaled-constant (#598)

### DIFF
--- a/.changeset/legend-filter-hidden-annotation.md
+++ b/.changeset/legend-filter-hidden-annotation.md
@@ -1,0 +1,11 @@
+---
+"@ggsvelte/svelte": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+fix: do not disable legend filters when a hidden rowless annotation scaled-constant shares a style scale
+
+A data field mapping + annotation `rule` constant on the same discrete style
+scale still exposes filter controls for the visible data categories. Rowful
+scaled constants that appear as legend entries remain non-filterable.

--- a/packages/svelte/src/lib/legend/filter-state.svelte.ts
+++ b/packages/svelte/src/lib/legend/filter-state.svelte.ts
@@ -187,9 +187,20 @@ export function createLegendFilterState(deps: LegendFilterStateDeps): LegendFilt
       if (field === undefined || fields.size !== 1) return [];
       // A scaled constant (aes { value, scale: true }) feeds this legend
       // without a field: toggling its entry would filter an unrelated field
-      // while the constant-colored layer stays rendered. Keep it static.
+      // while the constant-colored layer stays rendered. Keep it static —
+      // but only when that constant is actually a *visible* legend entry.
+      // Rowless annotation constants train the scale and appear on
+      // layerScaledConstants for focus/index, yet are excluded from the
+      // interactive legend domain (#598); those must not disable filters.
+      const scaledConstantKeys = new Set(
+        model.layerScaledConstants
+          .map((constants) => constants[sceneLegend.scale])
+          .filter((value): value is CellValue => value !== undefined)
+          .map((value) => encodeKey(value)),
+      );
       if (
-        model.layerScaledConstants.some((constants) => constants[sceneLegend.scale] !== undefined)
+        scaledConstantKeys.size > 0 &&
+        sceneLegend.entries.some((entry) => scaledConstantKeys.has(encodeKey(entry.value)))
       )
         return [];
       const current = localLegendFilters.find(

--- a/packages/svelte/tests/legend/filter-component.test.ts
+++ b/packages/svelte/tests/legend/filter-component.test.ts
@@ -332,4 +332,35 @@ describe("explicit legend filtering", () => {
 
     expect(container.querySelector(".gg-legend-filters")).toBeNull();
   });
+
+  it("still offers filters when a hidden annotation constant shares the style scale (#598)", async () => {
+    // Rowless rule annotation trains the scale but is excluded from the
+    // interactive legend domain. That must not disable filters for the data
+    // categories that *are* visible.
+    const { container } = render(GGPlot, {
+      data: [
+        { x: 1, y: 1, group: "a" },
+        { x: 2, y: 2, group: "a" },
+        { x: 1, y: 3, group: "b" },
+        { x: 2, y: 4, group: "b" },
+      ],
+      layers: [
+        { geom: "line", aes: { x: "x", y: "y", linetype: "group" } },
+        {
+          geom: "rule",
+          aes: { linetype: { value: "threshold", scale: true } },
+          params: { yintercept: 2 },
+        },
+      ],
+      scales: { linetype: { type: "ordinal" } },
+      legendFilter: true,
+      width: 360,
+      height: 260,
+    });
+    await until(() => container.querySelectorAll(".gg-legend-filters input").length === 2);
+
+    expect(container.querySelector("input[aria-label='Show a']")).not.toBeNull();
+    expect(container.querySelector("input[aria-label='Show b']")).not.toBeNull();
+    expect(container.querySelector("input[aria-label='Show threshold']")).toBeNull();
+  });
 });

--- a/packages/svelte/tests/legend/filter-state.test.ts
+++ b/packages/svelte/tests/legend/filter-state.test.ts
@@ -175,6 +175,94 @@ describe("createLegendFilterState toggle and mode", () => {
   });
 });
 
+describe("createLegendFilterState scaled-constant gating (#598)", () => {
+  it("still filters data entries when a rowless annotation constant shares the style scale", () => {
+    // Core drops the annotation-only value from the interactive legend domain
+    // (empty key bucket), but still exports it on layerScaledConstants. Filter
+    // gating must key off *visible* legend entries — otherwise the hidden
+    // annotation disables filters for the real data categories.
+    const spec = gg(
+      [
+        { x: 1, y: 1, group: "a" },
+        { x: 2, y: 2, group: "a" },
+        { x: 1, y: 3, group: "b" },
+        { x: 2, y: 4, group: "b" },
+      ],
+      aes({ x: "x", y: "y" }),
+    )
+      .geomLine({ aes: { linetype: "group" } })
+      .geomRule({
+        yintercept: 2,
+        aes: { linetype: { value: "threshold", scale: true } },
+      })
+      .scaleLinetypeDiscrete()
+      .spec();
+    const model = modelFor(spec);
+
+    // Preconditions: annotation trains the scale but is not a legend entry;
+    // layerScaledConstants still carries it (focus/index contract).
+    const legend = model.scene.legends.find(
+      (entry) => entry.type === "discrete" && entry.scale === "linetype",
+    );
+    expect(legend?.type).toBe("discrete");
+    if (legend?.type !== "discrete") throw new Error("expected discrete linetype legend");
+    expect(legend.interactive).toBe(true);
+    expect(legend.entries.map((entry) => entry.value)).toEqual(["a", "b"]);
+    expect(model.layerScaledConstants.some((constants) => constants.linetype !== undefined)).toBe(
+      true,
+    );
+
+    const { value: state, destroy } = withFlushedEffectRoot(() =>
+      createLegendFilterState({
+        effectiveSpec: () => spec,
+        legendFilterProp: () => true,
+        onlegendfilter: noCallback,
+        oninteraction: noCallback,
+        announce: () => {},
+        model: () => model,
+      }),
+    );
+
+    const entries = state.computeEntries(model);
+    expect(entries).toHaveLength(2);
+    expect(entries.map((entry) => entry.entry.value).toSorted()).toEqual(["a", "b"]);
+    expect(entries.every((entry) => entry.field === "group")).toBe(true);
+
+    destroy();
+  });
+
+  it("keeps a rowful scaled-constant legend non-filterable", () => {
+    // A data-backed constant still appears as a legend entry; toggling data
+    // categories would filter the field while the constant-colored layer stays.
+    const spec = gg(
+      [
+        { x: 1, y: 1, group: "north" },
+        { x: 2, y: 2, group: "south" },
+      ],
+      aes({ x: "x", y: "y" }),
+    )
+      .geomPoint({ aes: { color: "group" } })
+      .geomLine({ aes: { color: { value: "reference", scale: true } } })
+      .spec();
+    const model = modelFor(spec);
+
+    const { value: state, destroy } = withFlushedEffectRoot(() =>
+      createLegendFilterState({
+        effectiveSpec: () => spec,
+        legendFilterProp: () => true,
+        onlegendfilter: noCallback,
+        oninteraction: noCallback,
+        announce: () => {},
+        model: () => model,
+      }),
+    );
+
+    expect(state.computeEntries(model)).toEqual([]);
+
+    destroy();
+  });
+});
+
 describe("createLegendFilterState capability and mode reset", () => {
   it("capability disable resets filters atomically with a single clear event + announce", () => {
     const events: LegendFilterEvent[] = [];

--- a/packages/svelte/tests/legend/filter-state.test.ts
+++ b/packages/svelte/tests/legend/filter-state.test.ts
@@ -225,7 +225,7 @@ describe("createLegendFilterState scaled-constant gating (#598)", () => {
 
     const entries = state.computeEntries(model);
     expect(entries).toHaveLength(2);
-    expect(entries.map((entry) => entry.entry.value).toSorted()).toEqual(["a", "b"]);
+    expect(new Set(entries.map((entry) => entry.entry.value))).toEqual(new Set(["a", "b"]));
     expect(entries.every((entry) => entry.field === "group")).toBe(true);
 
     destroy();


### PR DESCRIPTION
## Summary

Fixes #598.

When a discrete style scale is shared by a data field mapping **and** a rowless annotation `rule` scaled-constant, core correctly drops the annotation value from the interactive legend domain (empty key bucket). Filter gating still treated *any* `layerScaledConstants` entry for that scale as a full-scale block, so after finding D the hidden annotation silently disabled filters for the visible data categories.

**Change:** in `computeEntries`, only block filtering when a scaled constant’s value is an actual `sceneLegend.entries` member (via `encodeKey`). Rowful constants that still appear as legend entries remain non-filterable.

## Validation

- Core already excludes annotation-only values from mixed interactive legends (`pipeline-style-families.test.ts`) while `resolveLayerScaledConstants` still exports them.
- Confirmed pre-fix: `computeEntries` returned `[]` for the mixed data + annotation case despite legend entries `["a","b"]`.

## Test plan

- [x] RED → GREEN unit: mixed linetype data + annotation rule still yields 2 filterable entries (`filter-state.test.ts`)
- [x] Characterization: rowful scaled-constant legend still non-filterable
- [x] Component: filter checkboxes render for data categories; no threshold control (`filter-component.test.ts`)
- [x] Full `filter-state` + `filter-component` suites (87 tests, 3 browsers)
- [ ] CI on PR

## Follow-ups

None deferred from this fix.