### PR TITLE
fix(core): ribbon temporal preflight, band measure, outline focus (#597)

### DIFF
--- a/.changeset/sweep-597-ribbon-p2s.md
+++ b/.changeset/sweep-597-ribbon-p2s.md
@@ -1,0 +1,11 @@
+---
+"@ggsvelte/core": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+fix: ribbon temporal preflight, band measure drop, outline focus mute
+
+- Preflight xmin/xmax only for rect/ribbon (not unused point mappings)
+- Drop ribbon rows when measure projection is non-finite (band measure axes)
+- Mirror fill focus masks onto presentation-only ribbon outline batches

--- a/packages/core/src/interaction-mask.ts
+++ b/packages/core/src/interaction-mask.ts
@@ -92,7 +92,10 @@ export interface FocusedPrimitive {
 /**
  * Project semantic emphasis keys onto renderer primitives without exposing a
  * mutable backing array. Batches without semantic candidates remain `null`,
- * so annotation-only geometry is not inadvertently de-emphasized.
+ * so pure annotation-only geometry is not inadvertently de-emphasized —
+ * except presentation-only path batches (`candidates: false`) that share a
+ * layer with a focused batch (ribbon outlines), which mirror that layer's mask
+ * so unselected outlines mute with their fill.
  */
 export function buildInteractionMasks<Key extends PropertyKey>(
   batches: readonly GeometryBatch[],
@@ -119,6 +122,43 @@ export function buildInteractionMasks<Key extends PropertyKey>(
       focused.set(candidate.batchIndex, values);
     }
     if (candidate.keys.some((key) => emphasis.has(key))) values[primitiveIndex] = 1;
+  }
+
+  // Mirror fill-batch focus onto presentation-only path batches on the same
+  // layer (ribbon outline open paths). Null masks stay fully opaque in canvas.
+  for (let index = 0; index < batches.length; index++) {
+    const batch = batches[index];
+    if (batch === undefined || batch.kind !== "paths" || batch.candidates !== false) continue;
+    if (focused.has(index)) continue;
+    let source: Uint8Array | undefined;
+    let sourceCount = 0;
+    for (let other = 0; other < batches.length; other++) {
+      if (other === index) continue;
+      const peer = batches[other];
+      if (peer === undefined || peer.layerIndex !== batch.layerIndex) continue;
+      const values = focused.get(other);
+      if (values === undefined) continue;
+      source = values;
+      sourceCount = renderPrimitiveCount(peer);
+      break;
+    }
+    if (source === undefined) continue;
+    const outlineCount = renderPrimitiveCount(batch);
+    const mirrored = new Uint8Array(outlineCount);
+    if (outlineCount === sourceCount) {
+      mirrored.set(source);
+    } else if (sourceCount > 0 && outlineCount === sourceCount * 2) {
+      // outline: "both" — two open subpaths per closed fill run
+      for (let path = 0; path < sourceCount; path++) {
+        const bit = source[path]!;
+        mirrored[path * 2] = bit;
+        mirrored[path * 2 + 1] = bit;
+      }
+    } else if (sourceCount > 0) {
+      // Length mismatch: mute all outline primitives under any active emphasis.
+      // (zeros = not focused → canvas draws at mutedAlpha)
+    }
+    focused.set(index, mirrored);
   }
 
   return freezeMasks(batches, focused);

--- a/packages/core/src/pipeline/geometry-ribbon.ts
+++ b/packages/core/src/pipeline/geometry-ribbon.ts
@@ -154,9 +154,18 @@ function finiteRibbonRuns(
     for (const row of rows) {
       const a = lo[row]!;
       const b = hi[row]!;
-      // Require bounds finite and the running coord to project (band or continuous).
+      // Require bounds finite, running coord projectable (band or continuous), and
+      // measure bounds projectable (band measure axes yield NaN — drop the row).
       const runningPx = projectRunning(frame, fx, orientation, row);
-      if (!Number.isFinite(a) || !Number.isFinite(b) || !Number.isFinite(runningPx)) {
+      const loPx = projectMeasure(frame, fx, orientation, a);
+      const hiPx = projectMeasure(frame, fx, orientation, b);
+      if (
+        !Number.isFinite(a) ||
+        !Number.isFinite(b) ||
+        !Number.isFinite(runningPx) ||
+        !Number.isFinite(loPx) ||
+        !Number.isFinite(hiPx)
+      ) {
         removed++;
         if (current.length >= 2) runs.push({ rows: current, group });
         current = [];

--- a/packages/core/src/pipeline/temporal-preflight-fields.ts
+++ b/packages/core/src/pipeline/temporal-preflight-fields.ts
@@ -38,12 +38,15 @@ export function preflightTemporalFields(input: {
       if (axisConversion.forcedDiscrete || axisConversion.forcedNonTemporal) return;
       assertTemporalConfiguration(axis, axisConversion);
       const isSegment = binding.layer.geom === "segment";
+      // xmin/xmax are only consumed by rect/ribbon (frame-identity gates the same
+      // way). Preflighting them on point/line/etc. fails scales.x.type:"time" when
+      // an unused bound column is non-temporal.
+      const consumesXBounds = binding.layer.geom === "rect" || binding.layer.geom === "ribbon";
       const fields =
         axis === "x"
           ? [
               binding.xField,
-              binding.xminField,
-              binding.xmaxField,
+              ...(consumesXBounds ? [binding.xminField, binding.xmaxField] : []),
               ...(isSegment ? [binding.xendField] : []),
             ]
           : [

--- a/packages/core/src/pipeline/temporal-preflight.ts
+++ b/packages/core/src/pipeline/temporal-preflight.ts
@@ -52,12 +52,12 @@ export function preflightTemporalBindings(input: {
     const concrete = new Map<string, PositionConversionContext>();
     for (const binding of bindings) {
       const isSegment = binding.layer.geom === "segment";
+      const consumesXBounds = binding.layer.geom === "rect" || binding.layer.geom === "ribbon";
       const fields =
         axis === "x"
           ? [
               binding.xField,
-              binding.xminField,
-              binding.xmaxField,
+              ...(consumesXBounds ? [binding.xminField, binding.xmaxField] : []),
               ...(isSegment ? [binding.xendField] : []),
             ]
           : [

--- a/packages/core/tests/interaction-mask.test.ts
+++ b/packages/core/tests/interaction-mask.test.ts
@@ -103,6 +103,53 @@ describe("buildInteractionMasks", () => {
 
     expect(buildInteractionMasks([pointBatch(1)], ["focus"], candidates)).toEqual([null]);
   });
+
+  it("mirrors fill focus onto presentation-only path batches on the same layer", () => {
+    // Ribbon fill (candidates) + outline (candidates: false). Outline must get a
+    // non-null mask so canvas mutes unselected outlines with the fill.
+    const fill: GeometryBatch = {
+      kind: "paths",
+      layerIndex: 0,
+      panelIndex: 0,
+      positions: new Float32Array(16),
+      rowIndex: new Uint32Array([0, 1, 2, 3]),
+      pathOffsets: new Uint32Array([0, 4, 8]),
+      strokes: [null, null],
+      fills: ["#f00", "#0f0"],
+      closed: true,
+      linewidth: 0,
+      alpha: 1,
+      curve: "linear",
+    };
+    const outline: GeometryBatch = {
+      kind: "paths",
+      layerIndex: 0,
+      panelIndex: 0,
+      positions: new Float32Array(32),
+      rowIndex: new Uint32Array(16),
+      pathOffsets: new Uint32Array([0, 4, 8, 12, 16]),
+      strokes: [null, null, null, null],
+      linewidth: 1,
+      alpha: 1,
+      curve: "linear",
+      candidates: false,
+    };
+    const candidates: SemanticCandidateKeys<string>[] = [
+      { batchIndex: 0, primitiveIndex: 0, keys: ["a"] },
+      { batchIndex: 0, primitiveIndex: 3, keys: ["b"] },
+    ];
+
+    const masks = buildInteractionMasks([fill, outline], ["a"], candidates);
+    expect(masks[0]?.isFocused(0)).toBe(true);
+    expect(masks[0]?.isFocused(1)).toBe(false);
+    // outline "both" → 2 subpaths per fill path; path 0 focused → edges 0,1 focused
+    expect(masks[1]).not.toBeNull();
+    expect(masks[1]?.primitiveCount).toBe(4);
+    expect(masks[1]?.isFocused(0)).toBe(true);
+    expect(masks[1]?.isFocused(1)).toBe(true);
+    expect(masks[1]?.isFocused(2)).toBe(false);
+    expect(masks[1]?.isFocused(3)).toBe(false);
+  });
 });
 
 describe("buildPrimitiveInteractionMasks", () => {

--- a/packages/core/tests/pipeline-m2/ribbon.test.ts
+++ b/packages/core/tests/pipeline-m2/ribbon.test.ts
@@ -144,4 +144,43 @@ describe("ribbon geom", () => {
     // 3 upper + 3 baseline
     expect(batch.positions.length / 2).toBe(6);
   });
+
+  it("drops rows when the measure axis is band (unprojectable bounds)", () => {
+    // scales.y.type: "band" makes projectMeasure return NaN; ribbons must not emit
+    // NaN path vertices — finiteRibbonRuns drops every row and yields no batch paths.
+    const model = runPipeline(
+      gg({ x: [1, 2, 3], lo: [0, 0, 0], hi: [1, 2, 1] }, aes({ x: "x", ymin: "lo", ymax: "hi" }))
+        .geomRibbon()
+        .scales({ y: { type: "band" } })
+        .spec(),
+      size,
+    );
+    const batch = model.scene.batches[0] as PathsBatch | undefined;
+    // No finite runs → either no path batch or empty subpaths
+    if (batch !== undefined && batch.kind === "paths") {
+      expect(batch.pathOffsets.length - 1).toBe(0);
+    } else {
+      expect(model.scene.batches.length).toBe(0);
+    }
+  });
+
+  it("does not fail temporal x preflight for unused xmin on a point layer", () => {
+    // Point maps xmin but does not consume it; scales.x.type:"time" must not parse xmin.
+    expect(() =>
+      runPipeline(
+        gg(
+          {
+            x: ["2024-01-01", "2024-01-02"],
+            y: [1, 2],
+            junk: ["not-a-date", "also-bad"],
+          },
+          aes({ x: "x", y: "y", xmin: "junk", xmax: "junk" }),
+        )
+          .geomPoint()
+          .scales({ x: { type: "time", parse: "iso" } })
+          .spec(),
+        size,
+      ),
+    ).not.toThrow();
+  });
 });


### PR DESCRIPTION
## Summary

Follow-up for unrebutted **post-merge** Codex P2s on #597 (geom ribbon).

| Finding | Fix |
|---------|-----|
| Limit xmin/xmax temporal preflight to consuming layers | Preflight + common-conversion only include xmin/xmax for `rect`/`ribbon` (matches frame-identity) |
| Reject unprojectable ribbon measure axes | `finiteRibbonRuns` also requires finite `projectMeasure` for lo/hi (band measure → drop rows) |
| Keep ribbon outlines in focus masks | `buildInteractionMasks` mirrors same-layer fill masks onto `candidates: false` path batches (1:1 or 1:2 for outline both) |

Pre-merge P2s on #597 were already fixed in-branch (disposition at merge); this PR covers the three findings that landed **after** merge.

## Tests

- `bun test packages/core/tests/pipeline-m2/ribbon.test.ts packages/core/tests/interaction-mask.test.ts`
- `bun run check`