### PR TITLE
fix(core/spec/svelte): remaining multi-table edges after per-layer DataRef (#609)

### DIFF
--- a/.changeset/multi-table-edges-609.md
+++ b/.changeset/multi-table-edges-609.md
@@ -1,0 +1,16 @@
+---
+"@ggsvelte/core": patch
+"@ggsvelte/spec": patch
+"@ggsvelte/svelte": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+fix: remaining multi-table edges after per-layer DataRef
+
+Binned axes and fixed histogram bin ranges read each layer filtered table;
+transform diagnostics count filtered (not unfiltered) rows; scale validation
+keeps per-layer field evidence; boxplot outlier lineage is not double-remapped
+under facets; Svelte identity epochs fingerprint geom-child data props.
+
+Migration: none — corrects multi-table behavior under per-layer data

--- a/packages/core/src/pipeline/candidate-construction/datum-locate.ts
+++ b/packages/core/src/pipeline/candidate-construction/datum-locate.ts
@@ -31,23 +31,28 @@ function makeSourceValueLookup(
     sourceRow === null || field === undefined ? null : table.column(field)[sourceRow]!;
 }
 
-/** Boxplot outlier local/source row mapping for point primitives. */
+/**
+ * Boxplot outlier local/source row mapping for point primitives.
+ *
+ * `frame.box.outlierRow` is remapped to global SourceRegistry ids during frame
+ * assembly (`prepare-panels-frames`). Do not re-index through
+ * `facetPanel.sourceRows` — that double-remap breaks lineage under facets (#609).
+ */
 export function resolveOutlierContext(input: {
   frame: LayerFrame | undefined;
   batch: GeometryBatch;
   primitiveIndex: number;
+  /** Retained for call-site compatibility; no longer used for remapping. */
   facetPanel: FacetPanelDef | undefined;
 }): { outlierLocalRow: number | null; outlierSourceRow: number | null } {
-  const { frame, batch, primitiveIndex, facetPanel } = input;
-  const outlierLocalRow =
+  void input.facetPanel;
+  const { frame, batch, primitiveIndex } = input;
+  const outlierSourceRow =
     frame?.box !== null && frame?.binding.layer.geom === "boxplot" && batch.kind === "points"
       ? (frame?.box.outlierRow[primitiveIndex] ?? null)
       : null;
-  const outlierSourceRow =
-    outlierLocalRow === null
-      ? null
-      : (facetPanel?.sourceRows?.[outlierLocalRow] ?? outlierLocalRow);
-  return { outlierLocalRow, outlierSourceRow };
+  // outlierLocalRow kept for frame-row call sites; same global id (no panel remap).
+  return { outlierLocalRow: outlierSourceRow, outlierSourceRow };
 }
 
 export function locateIdentityCandidate(

--- a/packages/core/src/pipeline/prepare-panels-bin-ranges.ts
+++ b/packages/core/src/pipeline/prepare-panels-bin-ranges.ts
@@ -9,13 +9,19 @@ import type { LayerBinding } from "./types.js";
 
 export function computePanelBinRanges(
   bindings: readonly LayerBinding[],
-  table: ColumnTable,
+  /**
+   * Per-binding filtered tables (parallel to `bindings`). Each `stat: "bin"`
+   * layer trains its shared break range from its own table (#609).
+   */
+  tables: readonly ColumnTable[],
   faceted: boolean,
   freeX: boolean,
 ): Array<[number, number] | undefined> {
-  return bindings.map((binding) => {
+  return bindings.map((binding, index) => {
     const stat = binding.layer.stat ?? "identity";
     if (stat !== "bin" || !faceted || freeX || binding.xField === null) return void 0;
+    const table = tables[index] ?? tables[0];
+    if (table === undefined || !table.has(binding.xField)) return void 0;
     // Shared break grid over the transformed x column (bin runs in scale-space).
     return (
       finiteExtent([

--- a/packages/core/src/pipeline/prepare-panels-frames.ts
+++ b/packages/core/src/pipeline/prepare-panels-frames.ts
@@ -50,6 +50,8 @@ function sampleFailingSemantic(
 function emitTransformDomainWarnings(
   axis: "x" | "y",
   bindings: readonly LayerBinding[],
+  /** Per-binding filtered tables (parallel to bindings); same rows as frames/stats. */
+  tables: readonly ColumnTable[],
   transform: ColumnTransformConfig | undefined,
   warnings: PipelineWarning[],
   scaleDiagnostics: ScaleDiagnostic[],
@@ -58,12 +60,13 @@ function emitTransformDomainWarnings(
   const path = `/scales/${axis}`;
   // Keyed by sourceId+field so same field name on different tables both scan.
   const seen = new Set<string>();
-  for (const binding of bindings) {
+  for (let index = 0; index < bindings.length; index++) {
+    const binding = bindings[index]!;
     const field = axis === "x" ? binding.xField : binding.yField;
     if (field === null) continue;
-    // Prefer the filtered frame-binding table when available; fall back to source.
-    // Diagnostics count pre-facet filtered rows (same as the prior single-table path).
-    const table = binding.sourceTable;
+    // Scan the filtered layer table (rowFilters applied) so hidden out-of-domain
+    // rows do not emit false transform/OOB diagnostics (#609).
+    const table = tables[index] ?? binding.sourceTable;
     if (!table.has(field)) continue;
     const seenKey = `${binding.sourceId}|${field}`;
     if (seen.has(seenKey)) continue;
@@ -179,8 +182,9 @@ export function buildPanelFrames(input: {
 
   const bindings: LayerBinding[] = [];
   const panelFrames: LayerFrame[][] = facetPanels.map(() => []);
-  // Primary filtered table (first layer) for shared bin-range fallbacks.
-  const primaryFiltered = layerContexts[0]!.filteredTable;
+  // Per-layer filtered tables: binned extents, bin ranges, and transform
+  // diagnostics must read each layer's own filtered rows (#609).
+  const filteredLayerTables = layerContexts.map((ctx) => ctx.filteredTable);
 
   for (let index = 0; index < normalized.layers.length; index++) {
     const ctx = layerContexts[index]!;
@@ -227,12 +231,12 @@ export function buildPanelFrames(input: {
     resolveColumnTransform(normalized.scales?.x, temporal.xConversion) ?? undefined;
   const yTransform =
     resolveColumnTransform(normalized.scales?.y, temporal.yConversion) ?? undefined;
-  // type: "binned" boundaries — resolve from the first layer that maps the field.
+  // type: "binned" boundaries — union extents across every layer table.
   const xBinning = resolveBinnedAxis(
     "x",
     normalized.scales?.x,
     bindings,
-    primaryFiltered,
+    filteredLayerTables,
     temporal.xConversion,
     xTransform,
   );
@@ -240,7 +244,7 @@ export function buildPanelFrames(input: {
     "y",
     normalized.scales?.y,
     bindings,
-    primaryFiltered,
+    filteredLayerTables,
     temporal.yConversion,
     yTransform,
   );
@@ -251,11 +255,25 @@ export function buildPanelFrames(input: {
     binding.yBinning = yBinning;
   }
   // One deduplicated per-axis diagnostic for pre-stat transform-domain and OOB
-  // drops, counted on each layer's source table before faceting.
+  // drops, counted on each layer's filtered table before faceting.
   const transformDiagnostics: ScaleDiagnostic[] = [];
-  emitTransformDomainWarnings("x", bindings, xTransform, warnings, transformDiagnostics);
-  emitTransformDomainWarnings("y", bindings, yTransform, warnings, transformDiagnostics);
-  const binRanges = computePanelBinRanges(bindings, primaryFiltered, faceted, freeX);
+  emitTransformDomainWarnings(
+    "x",
+    bindings,
+    filteredLayerTables,
+    xTransform,
+    warnings,
+    transformDiagnostics,
+  );
+  emitTransformDomainWarnings(
+    "y",
+    bindings,
+    filteredLayerTables,
+    yTransform,
+    warnings,
+    transformDiagnostics,
+  );
+  const binRanges = computePanelBinRanges(bindings, filteredLayerTables, faceted, freeX);
   for (let p = 0; p < facetPanels.length; p++) {
     for (let index = 0; index < bindings.length; index++) {
       const ctx = layerContexts[index]!;

--- a/packages/core/src/pipeline/resolve-binned-axis.ts
+++ b/packages/core/src/pipeline/resolve-binned-axis.ts
@@ -20,7 +20,12 @@ export function resolveBinnedAxis(
   axis: "x" | "y",
   config: PositionScaleSpec | undefined,
   bindings: readonly LayerBinding[],
-  table: ColumnTable,
+  /**
+   * Per-binding filtered tables (parallel to `bindings`). Each binding's fields
+   * are read from its own table so multi-table layers (#609) train extents and
+   * type-check against the owning source, not the primary table alone.
+   */
+  tables: readonly ColumnTable[],
   conversion: PositionConversionContext,
   transform: ColumnTransformConfig | undefined,
 ): BinnedBoundaries | undefined {
@@ -52,14 +57,21 @@ export function resolveBinnedAxis(
 
   let lo = Number.POSITIVE_INFINITY;
   let hi = Number.NEGATIVE_INFINITY;
+  // Keyed by sourceId+field so same name on different tables both contribute.
   const seen = new Set<string>();
-  for (const binding of bindings) {
+  for (let index = 0; index < bindings.length; index++) {
+    const binding = bindings[index]!;
+    const table = tables[index] ?? tables[0];
+    if (table === undefined) continue;
     // Segment endpoints train the same axis — include them in auto binned extent.
     const fields =
       axis === "x" ? [binding.xField, binding.xendField] : [binding.yField, binding.yendField];
     for (const field of fields) {
-      if (field === null || seen.has(field)) continue;
-      seen.add(field);
+      if (field === null) continue;
+      const seenKey = `${binding.sourceId}|${field}`;
+      if (seen.has(seenKey)) continue;
+      seen.add(seenKey);
+      if (!table.has(field)) continue;
       const fieldType = positionFieldType(table, field, conversion);
       if (fieldType !== "quantitative") {
         throw new PipelineError(

--- a/packages/core/tests/candidate-construction/series-and-outlier.test.ts
+++ b/packages/core/tests/candidate-construction/series-and-outlier.test.ts
@@ -57,4 +57,23 @@ describe("resolveOutlierContext", () => {
       }),
     ).toEqual({ outlierLocalRow: null, outlierSourceRow: null });
   });
+
+  // #609 — outlierRow is already global after prepare-panels remap; do not
+  // re-index through facetPanel.sourceRows (double remap).
+  it("treats boxplot outlierRow as already-global source ids", async () => {
+    const { resolveOutlierContext } =
+      await import("../../src/pipeline/candidate-construction/datum.ts");
+    const result = resolveOutlierContext({
+      frame: fromAny({
+        box: { outlierRow: new Uint32Array([42]) },
+        binding: { layer: { geom: "boxplot" } },
+      }),
+      batch: fromAny({ kind: "points" }),
+      primitiveIndex: 0,
+      // A non-empty sourceRows would wrongly remap 42 → sourceRows[42] if still panel-local.
+      facetPanel: fromAny({ sourceRows: Array.from({ length: 50 }, (_, i) => i + 1000) }),
+    });
+    expect(result.outlierSourceRow).toBe(42);
+    expect(result.outlierLocalRow).toBe(42);
+  });
 });

--- a/packages/core/tests/pipeline-layer-data.test.ts
+++ b/packages/core/tests/pipeline-layer-data.test.ts
@@ -388,3 +388,148 @@ describe("layer data facets", () => {
     expect(markCount(model, "points")).toBe(2);
   });
 });
+
+// #609 — remaining multi-table edges deferred from PR #603.
+describe("multi-table edges (#609)", () => {
+  it("type:binned x reads each layer table (no unknown-field on later-layer field)", () => {
+    const model = runPipeline(
+      {
+        scales: { x: { type: "binned" } },
+        layers: [
+          {
+            geom: "point",
+            data: {
+              values: [
+                { a: 1, y: 1 },
+                { a: 2, y: 2 },
+              ],
+            },
+            aes: { x: { field: "a" }, y: { field: "y" } },
+          },
+          {
+            geom: "point",
+            data: {
+              values: [
+                { score: 10, y: 3 },
+                { score: 90, y: 4 },
+              ],
+            },
+            aes: { x: { field: "score" }, y: { field: "y" } },
+          },
+        ],
+      },
+      size,
+    );
+    expect(markCount(model, "points")).toBe(4);
+    // Extent must include the later-layer field (score up to 90), not only primary `a`.
+    const xDomain = model.domains.effective.x;
+    expect(xDomain[1]).toBeGreaterThanOrEqual(50);
+  });
+
+  it("fixed-x faceted histogram bins each layer's own x field", () => {
+    const model = runPipeline(
+      {
+        facet: { wrap: { field: "g" } },
+        scales: { x: { type: "linear" } },
+        layers: [
+          {
+            geom: "histogram",
+            stat: "bin",
+            data: {
+              values: [
+                { a: 1, g: "p" },
+                { a: 2, g: "p" },
+                { a: 1, g: "q" },
+                { a: 3, g: "q" },
+              ],
+            },
+            aes: { x: { field: "a" } },
+          },
+          {
+            geom: "histogram",
+            stat: "bin",
+            data: {
+              values: [
+                { score: 10, g: "p" },
+                { score: 20, g: "p" },
+                { score: 15, g: "q" },
+              ],
+            },
+            aes: { x: { field: "score" } },
+          },
+        ],
+      },
+      size,
+    );
+    expect(model.scene.panels.length).toBe(2);
+    // Both layers contribute rects without throwing unknown-field on `score`.
+    expect(markCount(model, "rects")).toBeGreaterThan(0);
+  });
+
+  it("transform diagnostics scan filtered layer tables, not unfiltered sources", () => {
+    const model = runPipeline(
+      {
+        data: {
+          values: [
+            { x: 1, y: 1, group: "keep" },
+            { x: -5, y: 2, group: "hide" },
+            { x: 10, y: 3, group: "keep" },
+          ],
+        },
+        aes: { x: { field: "x" }, y: { field: "y" }, color: { field: "group" } },
+        scales: { x: { type: "linear", transform: "log10" } },
+        layers: [{ geom: "point" }],
+      },
+      {
+        ...size,
+        rowFilters: [{ scale: "color", field: "group", mode: "exclude", values: ["hide"] }],
+      },
+    );
+    // Filtered-out non-positive x must not emit transform-domain diagnostics.
+    expect(model.warnings.some((w) => w.code === "scale-transform-domain")).toBe(false);
+    expect(model.scaleDiagnostics.some((d) => d.code === "scale-transform-domain")).toBe(false);
+    expect(markCount(model, "points")).toBe(2);
+  });
+
+  it("faceted boxplot outlier candidates keep global source rows (no double remap)", () => {
+    // Enough rows per panel that a panel-local outlier index can be confused with
+    // a different sourceRows entry if remapped twice (#609).
+    const values = [
+      { g: "a", cat: "box", y: 1 },
+      { g: "a", cat: "box", y: 2 },
+      { g: "a", cat: "box", y: 3 },
+      { g: "a", cat: "box", y: 4 },
+      { g: "a", cat: "box", y: 5 },
+      { g: "a", cat: "box", y: 100 }, // outlier at source row 5
+      { g: "b", cat: "box", y: 1 },
+      { g: "b", cat: "box", y: 2 },
+      { g: "b", cat: "box", y: 3 },
+      { g: "b", cat: "box", y: 4 },
+      { g: "b", cat: "box", y: 5 },
+      { g: "b", cat: "box", y: 6 },
+    ];
+    const model = runPipeline(
+      {
+        data: { values },
+        facet: { wrap: { field: "g" } },
+        layers: [
+          {
+            geom: "boxplot",
+            stat: "boxplot",
+            aes: { x: { field: "cat" }, y: { field: "y" } },
+          },
+        ],
+      },
+      size,
+    );
+    const outliers = Array.from({ length: model.candidates.size }, (_, id) =>
+      model.candidates.candidate(id),
+    ).filter((c) => c?.kind === "points" && c.yValue === 100);
+    expect(outliers.length).toBe(1);
+    const outlier = outliers[0]!;
+    // Lineage must pin the true observation row (index 5), not a remapped alias.
+    const keys = [...model.lineage.keys(outlier.lineage)];
+    expect(keys).toEqual([5]);
+    expect(model.row(5)?.y).toBe(100);
+  });
+});

--- a/packages/spec/src/validate-data-checks-position.ts
+++ b/packages/spec/src/validate-data-checks-position.ts
@@ -16,7 +16,7 @@ import {
   temporalLabelConfigurationError,
   temporalLocaleConfigurationError,
 } from "./temporal-interval.js";
-import type { FieldEvidenceMap } from "./validate-data-evidence.js";
+import type { FieldEvidenceEntry, FieldEvidenceMap } from "./validate-data-evidence.js";
 import {
   appendTemporalKindMismatch,
   temporalDecisionForField,
@@ -123,13 +123,19 @@ export function validateTemporalAxisConfiguration(scales: Record<string, unknown
 export function checkPositionScaleDataCompatibility(input: {
   scales: Record<string, unknown> | undefined;
   fields: FieldEvidenceMap;
+  /**
+   * Optional per-use evidence lookup. When provided, prefer it over the
+   * last-wins `fields` union so multi-table layers with the same field name
+   * keep their own type evidence (#609).
+   */
+  evidenceForUse?: (use: ChannelFieldUse) => FieldEvidenceEntry | undefined;
   axisFields: Record<"x" | "y", ChannelFieldUse[]>;
   invalidTemporalAxes: ReadonlySet<"x" | "y">;
   temporalDecisionCache: TemporalDecisionCache;
 }): SpecError[] {
   const { scales, fields, axisFields, invalidTemporalAxes, temporalDecisionCache } = input;
   const errors: SpecError[] = [];
-  const typeOf = (field: string) => fields.get(field)?.type ?? null;
+  const evidenceOf = (use: ChannelFieldUse) => input.evidenceForUse?.(use) ?? fields.get(use.field);
 
   for (const axis of AXIS_CHANNELS) {
     const config = scales?.[axis] as PositionScaleSpec | undefined;
@@ -137,10 +143,10 @@ export function checkPositionScaleDataCompatibility(input: {
       config?.type === "band" ? "band" : scaleRequestsTime(scales, axis) ? "time" : config?.type;
     if (declared === undefined || declared === "band" || invalidTemporalAxes.has(axis)) continue;
     for (const use of axisFields[axis]) {
-      const type = typeOf(use.field);
+      const info = evidenceOf(use);
+      const type = info?.type ?? null;
       if (type === null) continue;
       if (declared === "time") {
-        const info = fields.get(use.field);
         const decision = temporalDecisionForField(
           temporalDecisionCache,
           use.field,

--- a/packages/spec/src/validate-data-checks.ts
+++ b/packages/spec/src/validate-data-checks.ts
@@ -543,8 +543,9 @@ export function dataChecks(
   }
 
   // --- scale/type compatibility (order preserved for diagnostics) ------------
-  // Union layer evidence for global scale checks (same field name across layers
-  // is last-wins; per-layer unknown-field already used layer-local maps above).
+  // Union layer evidence as a fallback for non-layer-scoped checks (e.g. color
+  // manual ranges). Position scale checks prefer per-layer evidence via
+  // evidenceForUse so same field names on different tables stay independent (#609).
   const fields: FieldEvidenceMap = new Map(plotFields ?? undefined);
   if (layerResolved.status === "ok") {
     for (const layerMap of layerResolved.layers) {
@@ -555,6 +556,23 @@ export function dataChecks(
   if (fields.size === 0 && resolved.status === "ok") {
     for (const [name, entry] of resolved.fields) fields.set(name, entry);
   }
+  const layerMaps = layerResolved.status === "ok" ? layerResolved.layers : null;
+  const evidenceForUse = (use: { field: string; path: string }) => {
+    const match = /^\/layers\/(\d+)\//.exec(use.path);
+    if (match !== null && layerMaps !== null) {
+      const layerMap = layerMaps[Number(match[1])];
+      if (layerMap !== null && layerMap !== undefined) {
+        const hit = layerMap.get(use.field);
+        if (hit !== undefined) return hit;
+      }
+      // Layer with no override inherits plot evidence.
+      if (plotFields !== null) {
+        const hit = plotFields.get(use.field);
+        if (hit !== undefined) return hit;
+      }
+    }
+    return fields.get(use.field);
+  };
   const typeOf = (field: string) => fields.get(field)?.type ?? null;
   for (const aesthetic of ["shape", "linetype"] as const) {
     const config = scales?.[aesthetic] as { type?: string } | undefined;
@@ -728,6 +746,7 @@ export function dataChecks(
     ...checkPositionScaleDataCompatibility({
       scales,
       fields,
+      evidenceForUse,
       axisFields,
       invalidTemporalAxes,
       temporalDecisionCache,

--- a/packages/spec/tests/layer-data.test.ts
+++ b/packages/spec/tests/layer-data.test.ts
@@ -122,6 +122,44 @@ describe("layer data schema + normalize", () => {
     expect(err!.message).toContain("hwy");
     expect(err!.message).not.toContain("xmin");
   });
+
+  // #609 — scale checks must not last-wins-collapse same field names across layers.
+  it("scale-type-mismatch still fires when a later numeric layer shares field name v", () => {
+    const result = validate(
+      {
+        scales: { x: { type: "linear" } },
+        layers: [
+          {
+            geom: "point",
+            // strings first — last-wins union would hide this under the numeric layer.
+            data: {
+              values: [
+                { v: "a", y: 1 },
+                { v: "b", y: 2 },
+              ],
+            },
+            aes: { x: { field: "v" }, y: { field: "y" } },
+          },
+          {
+            geom: "point",
+            data: {
+              values: [
+                { v: 1, y: 3 },
+                { v: 2, y: 4 },
+              ],
+            },
+            aes: { x: { field: "v" }, y: { field: "y" } },
+          },
+        ],
+      },
+      {},
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    const mismatch = result.errors.filter((e) => e.code === "scale-type-mismatch");
+    expect(mismatch.length).toBeGreaterThanOrEqual(1);
+    expect(mismatch.some((e) => e.message.includes("v"))).toBe(true);
+  });
 });
 
 describe("layer data builder", () => {

--- a/packages/svelte/src/lib/plot-interaction-assembly.svelte.ts
+++ b/packages/svelte/src/lib/plot-interaction-assembly.svelte.ts
@@ -146,7 +146,12 @@ export function createPlotInteractionAssembly<
     const data = inputs.data();
     const spec = inputs.spec();
     const layers = inputs.layers();
-    const layerCount = layers === undefined ? inputs.registry.layers.length : layers.length;
+    // Declaration children expose live data getters via the registry.
+    const layerDescriptors =
+      layers === undefined
+        ? inputs.registry.layers
+        : layers.map((layer) => ({ data: (layer as { data?: unknown }).data }));
+    const layerCount = layerDescriptors.length;
     // Ready without reading `assembled` so chrome-only respecs do not re-enter.
     const ready = spec !== undefined || layerCount > 0;
     const sourceIdentity = (value: unknown) => identityTracker.sourceIdentity(value);
@@ -158,12 +163,16 @@ export function createPlotInteractionAssembly<
       spec !== undefined && typeof spec === "object"
         ? (spec as { datasets?: unknown }).datasets
         : undefined;
+    // Layer-local data must participate: a plot with only geom-child data and
+    // no plot data/spec prop would otherwise keep a stable epoch across row
+    // replacements (#609).
     return dataIdentityEpochToken({
       ready,
       dataToken: sourceIdentity(data),
       specToken: sourceIdentity(spec),
       data: contentData ?? null,
       datasets: contentDatasets ?? null,
+      layers: layerDescriptors,
       sourceIdentity,
     });
   });

--- a/packages/svelte/src/lib/runtime/semantic-keys.ts
+++ b/packages/svelte/src/lib/runtime/semantic-keys.ts
@@ -159,6 +159,22 @@ function datasetsOrderToken(datasets: unknown, sourceIdentity: (value: unknown) 
 }
 
 /**
+ * O(layers) fingerprint of geom-child / layer-local data props.
+ * Missing `layers` → `"null"` so legacy callers keep a stable suffix.
+ */
+export function layersDataOrderToken(
+  layers: readonly { readonly data?: unknown }[] | undefined,
+  sourceIdentity: (value: unknown) => string,
+): string {
+  if (layers === undefined) return "null";
+  let token = `L:${layers.length}`;
+  for (let index = 0; index < layers.length; index++) {
+    token += `|${index}=${dataContentOrderToken(layers[index]?.data, sourceIdentity)}`;
+  }
+  return token;
+}
+
+/**
  * Stable data/spec identity token for inspection reconcile epochs.
  *
  * Host supplies:
@@ -166,6 +182,8 @@ function datasetsOrderToken(datasets: unknown, sourceIdentity: (value: unknown) 
  * - `data` / `datasets` — content to order-fingerprint (prefer **prop** values,
  *   not a freshly assembled PortableSpec shell, so theme/labs respecs do not
  *   force a re-walk)
+ * - `layers` — optional geom-child descriptors whose `data` must also bump the
+ *   epoch when plot-level data/spec are absent (#609)
  * - `sourceIdentity` — stable object ids for the O(R) order fingerprint
  *
  * Ready=false (no plot yet) → `"no-data"`. Complexity: O(R) over row refs,
@@ -177,10 +195,11 @@ export function dataIdentityEpochToken(input: {
   readonly specToken: string;
   readonly data: unknown;
   readonly datasets: unknown;
+  readonly layers?: readonly { readonly data?: unknown }[];
   readonly sourceIdentity: (value: unknown) => string;
 }): string {
   if (!input.ready) return "no-data";
-  return `${input.dataToken}:${input.specToken}:${dataContentOrderToken(input.data, input.sourceIdentity)}:${datasetsOrderToken(input.datasets, input.sourceIdentity)}`;
+  return `${input.dataToken}:${input.specToken}:${dataContentOrderToken(input.data, input.sourceIdentity)}:${datasetsOrderToken(input.datasets, input.sourceIdentity)}:${layersDataOrderToken(input.layers, input.sourceIdentity)}`;
 }
 
 /** Empty semantic-key bag when there is no render model. */

--- a/packages/svelte/src/lib/runtime/semantic-keys.ts
+++ b/packages/svelte/src/lib/runtime/semantic-keys.ts
@@ -162,7 +162,7 @@ function datasetsOrderToken(datasets: unknown, sourceIdentity: (value: unknown) 
  * O(layers) fingerprint of geom-child / layer-local data props.
  * Missing `layers` → `"null"` so legacy callers keep a stable suffix.
  */
-export function layersDataOrderToken(
+function layersDataOrderToken(
   layers: readonly { readonly data?: unknown }[] | undefined,
   sourceIdentity: (value: unknown) => string,
 ): string {

--- a/packages/svelte/tests/runtime/semantic-keys-pure.test.ts
+++ b/packages/svelte/tests/runtime/semantic-keys-pure.test.ts
@@ -191,6 +191,60 @@ describe("dataIdentityEpochToken", () => {
     }
     spy.mockRestore();
   });
+
+  // #609 — geom-child layer data must participate in the identity epoch.
+  it("includes layer-local data in the epoch when plot data/spec are absent", () => {
+    const tracker = createSourceIdentityTracker();
+    const id = (value: unknown) => tracker.sourceIdentity(value);
+    const rowsA = [
+      { x: 1, y: 2 },
+      { x: 3, y: 4 },
+    ];
+    const rowsB = [
+      { x: 9, y: 8 },
+      { x: 7, y: 6 },
+    ];
+    const withoutLayers = dataIdentityEpochToken({
+      ready: true,
+      dataToken: id(undefined),
+      specToken: id(undefined),
+      data: null,
+      datasets: null,
+      sourceIdentity: id,
+    });
+    const withLayerA = dataIdentityEpochToken({
+      ready: true,
+      dataToken: id(undefined),
+      specToken: id(undefined),
+      data: null,
+      datasets: null,
+      layers: [{ data: rowsA }],
+      sourceIdentity: id,
+    });
+    const withLayerB = dataIdentityEpochToken({
+      ready: true,
+      dataToken: id(undefined),
+      specToken: id(undefined),
+      data: null,
+      datasets: null,
+      layers: [{ data: rowsB }],
+      sourceIdentity: id,
+    });
+    expect(withLayerA).not.toBe(withoutLayers);
+    expect(withLayerA).not.toBe(withLayerB);
+    // Same layer data reference → stable epoch.
+    expect(
+      dataIdentityEpochToken({
+        ready: true,
+        dataToken: id(undefined),
+        specToken: id(undefined),
+        data: null,
+        datasets: null,
+        layers: [{ data: rowsA }],
+        sourceIdentity: id,
+      }),
+    ).toBe(withLayerA);
+  });
 });
 
 describe("resolveSemanticKeysForPlot", () => {

--- a/packages/svelte/tests/runtime/semantic-keys-pure.test.ts
+++ b/packages/svelte/tests/runtime/semantic-keys-pure.test.ts
@@ -204,44 +204,31 @@ describe("dataIdentityEpochToken", () => {
       { x: 9, y: 8 },
       { x: 7, y: 6 },
     ];
-    const withoutLayers = dataIdentityEpochToken({
-      ready: true,
-      dataToken: id(undefined),
-      specToken: id(undefined),
+    // Plot-level data/spec absent — tokens are stable literals.
+    const absent = {
+      ready: true as const,
+      dataToken: "none",
+      specToken: "none",
       data: null,
       datasets: null,
       sourceIdentity: id,
-    });
+    };
+    const withoutLayers = dataIdentityEpochToken(absent);
     const withLayerA = dataIdentityEpochToken({
-      ready: true,
-      dataToken: id(undefined),
-      specToken: id(undefined),
-      data: null,
-      datasets: null,
+      ...absent,
       layers: [{ data: rowsA }],
-      sourceIdentity: id,
     });
     const withLayerB = dataIdentityEpochToken({
-      ready: true,
-      dataToken: id(undefined),
-      specToken: id(undefined),
-      data: null,
-      datasets: null,
+      ...absent,
       layers: [{ data: rowsB }],
-      sourceIdentity: id,
     });
     expect(withLayerA).not.toBe(withoutLayers);
     expect(withLayerA).not.toBe(withLayerB);
     // Same layer data reference → stable epoch.
     expect(
       dataIdentityEpochToken({
-        ready: true,
-        dataToken: id(undefined),
-        specToken: id(undefined),
-        data: null,
-        datasets: null,
+        ...absent,
         layers: [{ data: rowsA }],
-        sourceIdentity: id,
       }),
     ).toBe(withLayerA);
   });


### PR DESCRIPTION
## Summary

Closes #609 — remaining multi-table edges deferred from PR #603 (Codex P2s):

1. **resolveBinnedAxis / computePanelBinRanges** — read each binding filtered table (not only the primary table), so later-layer fields and extents work under per-layer DataRef.
2. **Transform diagnostics** — scan filtered layer tables so rowFilters that hide out-of-domain rows do not emit false scale-transform-domain / OOB warnings.
3. **Scale validation** — position scale checks resolve field evidence per layer path instead of last-wins-by-name across layers.
4. **Boxplot outliers** — resolveOutlierContext treats outlierRow as already-global (no second facetPanel.sourceRows remap).
5. **Svelte identity epochs** — dataIdentityEpochToken fingerprints geom-child / layer-local data so declaration-only plots bump the epoch when layer data is replaced.

## Test plan

- [x] TDD red then green for each edge in pipeline-layer-data, layer-data, series-and-outlier, semantic-keys-pure
- [x] bun test packages/core packages/spec (1675 pass)
- [x] bun run check (tsc clean)
- [x] Svelte pure semantic-keys suite green