### PR TITLE
fix(facets): vertical collision for rotated side strip labels (#611)

### DIFF
--- a/.changeset/side-strip-vertical-collision.md
+++ b/.changeset/side-strip-vertical-collision.md
@@ -1,0 +1,13 @@
+---
+"@ggsvelte/core": patch
+"@ggsvelte/svelte": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+fix: cap and clip rotated left/right facet strip labels to panel height
+
+Long side-strip labels no longer paint into neighboring multi-row panels.
+Labels truncate with ellipsis to the panel-height advance budget; SVG/Svelte
+strip chrome clips to the strip band as defense in depth. Strip band width
+is remeasured against that vertical budget.

--- a/packages/core/src/pipeline/assemble-scene-build.ts
+++ b/packages/core/src/pipeline/assemble-scene-build.ts
@@ -71,6 +71,7 @@ export function assembleScene(input: AssembleSceneInput): Scene {
     coordProjectors,
     ...(measureText !== undefined && { measureText }),
     axisTextSize,
+    stripSize: theme.stripSize,
     hAxisTextSize: hGuide.theme?.labelSize ?? axisTextSize,
     vAxisTextSize: vGuide.theme?.labelSize ?? axisTextSize,
     tickChromePx,

--- a/packages/core/src/pipeline/assemble-scene-panels.ts
+++ b/packages/core/src/pipeline/assemble-scene-panels.ts
@@ -8,6 +8,7 @@ import type { SceneAxis, ScenePanel, SceneTick } from "../scene.js";
 import type { PositionScale } from "../scales/train.js";
 
 import type { FacetPanelDef } from "./facets.js";
+import { capSideStripLabel, isSideStrip } from "./facets-strip.js";
 import { axisTicks } from "./layout-helpers.js";
 import type { PanelPlacement } from "./panel-layout.js";
 
@@ -105,6 +106,8 @@ export function assembleScenePanels(input: {
   coordProjectors: readonly PanelCoordProjector[];
   measureText?: TextMeasurer | undefined;
   axisTextSize: number;
+  /** Theme strip font size used to cap rotated side-strip labels (#611). */
+  stripSize?: number;
   /** Resolved per-axis guide font sizes used for projected-label collision checks. */
   hAxisTextSize?: number;
   vAxisTextSize?: number;
@@ -120,6 +123,7 @@ export function assembleScenePanels(input: {
 } {
   const { placements, facetPanels, displayScales, hTitle, vTitle, strip, stripBand } = input;
   const measurer = input.measureText ?? new MetricsTableMeasurer(FONT_METRICS);
+  const stripSize = input.stripSize ?? 12;
 
   const scenePanels: ScenePanel[] = placements.map((placement, p) => {
     const { h, v } = displayScales(p);
@@ -174,6 +178,13 @@ export function assembleScenePanels(input: {
     const yGrid = gridPositionsByKind(left);
     const label = facetPanels[p]!.label;
     const hasStrip = label !== "";
+    // Left/right strips rotate labels 90°: advance width becomes vertical
+    // extent. Cap to panel height so multi-row layouts cannot paint into
+    // neighboring panel content (#611).
+    const stripLabel =
+      hasStrip && strip.show && isSideStrip(strip.position)
+        ? capSideStripLabel(label, placement.height, measurer, stripSize)
+        : label;
     return {
       identity: facetPanels[p]!.identity,
       id: facetPanels[p]!.id,
@@ -181,7 +192,7 @@ export function assembleScenePanels(input: {
       y: placement.y,
       width: placement.width,
       height: placement.height,
-      strip: label,
+      strip: stripLabel,
       ...(hasStrip && {
         stripPosition: strip.position,
         showStrip: strip.show,

--- a/packages/core/src/pipeline/facets-strip.ts
+++ b/packages/core/src/pipeline/facets-strip.ts
@@ -1,8 +1,14 @@
 /**
  * Facet strip band measurement for layout reservation.
+ *
+ * Left/right strips rotate labels 90° at render, so the measured advance
+ * width becomes the *vertical* extent. Callers cap that advance to the panel
+ * height (see `capSideStripLabel`) so multi-row layouts cannot paint into
+ * neighboring panels (#611).
  */
-import { STRIP_BAND } from "../scene.js";
 import type { TextMeasurer } from "../layout/measure.js";
+import { truncateToFit } from "../layout/truncate.js";
+import { STRIP_BAND } from "../scene.js";
 
 import type { FacetPanelDef, FacetStripConfig } from "./facets-types.js";
 
@@ -12,7 +18,8 @@ const STRIP_SIDE_PAD = 8;
 /**
  * Reserved strip band size in px:
  * - top/bottom → fixed STRIP_BAND height
- * - left/right → max label width + pad (at least STRIP_BAND)
+ * - left/right → max label width + pad (at least STRIP_BAND), optionally
+ *   capped by `sideMaxAdvance` when panel height is already known
  * - show false or unfaceted → 0
  */
 export function measureFacetStripBand(input: {
@@ -21,6 +28,11 @@ export function measureFacetStripBand(input: {
   panels: readonly FacetPanelDef[];
   measurer: TextMeasurer;
   stripSize: number;
+  /**
+   * Vertical budget for rotated side-strip labels (panel height). When set,
+   * band width never exceeds this advance (+ pad), matching capped labels.
+   */
+  sideMaxAdvance?: number;
 }): number {
   if (!input.faceted || !input.strip.show) return 0;
   if (input.strip.position === "top" || input.strip.position === "bottom") {
@@ -31,9 +43,31 @@ export function measureFacetStripBand(input: {
     if (panel.label === "") continue;
     maxW = Math.max(maxW, input.measurer.measureWidth(panel.label, input.stripSize));
   }
+  if (input.sideMaxAdvance !== undefined) {
+    maxW = Math.min(maxW, Math.max(0, input.sideMaxAdvance));
+  }
   return Math.max(STRIP_BAND, Math.ceil(maxW) + STRIP_SIDE_PAD);
+}
+
+/**
+ * Cap a left/right strip label so its advance width (vertical extent after
+ * 90° rotation) fits inside the panel height. Ellipsis when shortened.
+ */
+export function capSideStripLabel(
+  label: string,
+  maxAdvancePx: number,
+  measurer: TextMeasurer,
+  stripSize: number,
+  ellipsis = "…",
+): string {
+  if (label === "" || !(maxAdvancePx > 0)) return label;
+  return truncateToFit(label, maxAdvancePx, measurer, stripSize, ellipsis);
 }
 
 export function isVerticalStrip(position: FacetStripConfig["position"]): boolean {
   return position === "top" || position === "bottom";
+}
+
+export function isSideStrip(position: FacetStripConfig["position"]): boolean {
+  return position === "left" || position === "right";
 }

--- a/packages/core/src/pipeline/panel-layout.ts
+++ b/packages/core/src/pipeline/panel-layout.ts
@@ -60,7 +60,7 @@ export function computePanelLayout(input: {
   const strip = input.strip ?? DEFAULT_FACET_STRIP;
 
   const chrome = resolvePanelLayoutChrome(input);
-  const stripBand = measureFacetStripBand({
+  let stripBand = measureFacetStripBand({
     faceted,
     strip,
     panels: facetPanels,
@@ -85,6 +85,40 @@ export function computePanelLayout(input: {
     axis: { x: input.hGuide, y: input.vGuide },
     options,
   });
+  // Side strips rotate labels: advance becomes vertical. Remeasure the band
+  // against the shortest panel height so reserved width matches the capped
+  // rotated labels (#611). Left/right strip height does not feed approxH, so
+  // one remeasure converges.
+  if (
+    faceted &&
+    strip.show &&
+    (strip.position === "left" || strip.position === "right") &&
+    placements.length > 0
+  ) {
+    const sideMaxAdvance = Math.min(...placements.map((placement) => placement.height));
+    const cappedBand = measureFacetStripBand({
+      faceted,
+      strip,
+      panels: facetPanels,
+      measurer: chrome.measurer,
+      stripSize: input.theme.stripSize,
+      sideMaxAdvance,
+    });
+    if (cappedBand !== stripBand) {
+      stripBand = cappedBand;
+      placements = buildPanelPlacements({
+        faceted,
+        nrow,
+        ncol,
+        facetPanels,
+        strip,
+        stripBand,
+        chrome,
+        axis: { x: input.hGuide, y: input.vGuide },
+        options,
+      });
+    }
+  }
   let degraded = false;
   if (input.coordFixed !== undefined) {
     const fitted = applyFixedAspectLayout({

--- a/packages/core/src/render-svg-scene.ts
+++ b/packages/core/src/render-svg-scene.ts
@@ -138,7 +138,7 @@ function renderPanelAxes(panel: ScenePanel, theme: ThemeTokens): string {
 }
 
 /** Facet strip: band + centered label on the authored side of the panel. */
-function renderStrip(panel: ScenePanel, scene: Scene): string {
+function renderStrip(panel: ScenePanel, scene: Scene, panelIndex: number): string {
   if (panel.strip === "" || panel.showStrip === false) return "";
   const band = panel.stripBand ?? STRIP_BAND;
   if (band <= 0) return "";
@@ -153,6 +153,7 @@ function renderStrip(panel: ScenePanel, scene: Scene): string {
   let textX = panel.width / 2;
   let textY = bandDraw / 2;
   let textTransform = "";
+  let sideClip = false;
 
   // Layout reserves strip outside the axis margin band (see
   // panel-layout-facet-cells-place). Renderers place chrome in that reserved
@@ -173,6 +174,9 @@ function renderStrip(panel: ScenePanel, scene: Scene): string {
     textX = bandDraw / 2;
     textY = panel.height / 2;
     textTransform = ` transform="rotate(-90 ${px(textX)} ${px(textY)})"`;
+    // Rotated advance is vertical — clip to the panel-height band so a long
+    // label cannot paint into the row above/below (#611).
+    sideClip = true;
   } else {
     originX = panel.x + panel.width;
     rectW = bandDraw;
@@ -180,10 +184,18 @@ function renderStrip(panel: ScenePanel, scene: Scene): string {
     textX = bandDraw / 2;
     textY = panel.height / 2;
     textTransform = ` transform="rotate(90 ${px(textX)} ${px(textY)})"`;
+    sideClip = true;
   }
 
+  const clipId = `gg-strip-clip-${panelIndex}`;
+  const clipAttr = sideClip ? ` clip-path="url(#${clipId})"` : "";
+  const clipDef = sideClip
+    ? `<clipPath id="${clipId}"><rect width="${px(rectW)}" height="${px(rectH)}"/></clipPath>`
+    : "";
+
   return (
-    `<g class="gg-strip" transform="translate(${px(originX)},${px(originY)})">` +
+    `<g class="gg-strip" transform="translate(${px(originX)},${px(originY)})"${clipAttr}>` +
+    clipDef +
     `<rect width="${px(rectW)}" height="${px(rectH)}" fill="${stripFill}"/>` +
     `<text x="${px(textX)}" y="${px(textY)}" dy="0.32em" text-anchor="middle" fill="${ink}" font-size="${px(scene.theme.stripSize)}" font-weight="${scene.theme.stripWeight}"${textTransform}>${escapeXML(panel.strip)}</text>` +
     "</g>"
@@ -465,7 +477,7 @@ export function sceneToSVGString(scene: Scene, options: SceneSVGOptions = {}): s
         `<rect class="gg-panel-border" width="${px(p.width)}" height="${px(p.height)}" fill="none" stroke="${themeVar("panelBorder", theme)}" stroke-width="${px(theme.panelBorderWidth)}" vector-effect="non-scaling-stroke"/>`,
       );
     }
-    parts.push("</g>", renderStrip(p, scene), renderPanelAxes(p, theme));
+    parts.push("</g>", renderStrip(p, scene, i), renderPanelAxes(p, theme));
   }
   parts.push(renderAxisTitles(scene));
   for (const legend of scene.legends) {

--- a/packages/core/tests/facets/strip-position.test.ts
+++ b/packages/core/tests/facets/strip-position.test.ts
@@ -1,10 +1,12 @@
 /**
- * Facet strip position and visibility (issue #590).
+ * Facet strip position and visibility (issue #590 / #611).
  * Seam: runPipeline scene geometry + SVG strip chrome.
  */
 import { describe, expect, it } from "bun:test";
 import { aes, gg } from "@ggsvelte/spec";
 
+import { FONT_METRICS } from "../../src/layout/font-metrics.ts";
+import { MetricsTableMeasurer } from "../../src/layout/measure.ts";
 import { runPipeline } from "../../src/pipeline.ts";
 import { sceneToSVGString } from "../../src/render-svg.ts";
 import { STRIP_BAND } from "../../src/scene.ts";
@@ -107,5 +109,84 @@ describe("facet strip position — layout and render (#590)", () => {
 
     const svg = sceneToSVGString(model.scene);
     expect(svg).not.toContain('class="gg-strip"');
+  });
+});
+
+describe("side strip vertical collision (#611)", () => {
+  const longLabel =
+    "Extremely Long Facet Panel Label That Exceeds Short Multi-Row Panel Height When Rotated";
+
+  it("caps rotated left strip label advance to panel height and clips SVG paint", () => {
+    const model = runPipeline(
+      gg(
+        [
+          { x: 1, y: 1, g: "a" },
+          { x: 2, y: 2, g: "b" },
+          { x: 3, y: 3, g: "c" },
+          { x: 4, y: 4, g: "d" },
+        ],
+        aes({ x: "x", y: "y" }),
+      )
+        .geomPoint()
+        .facet({
+          wrap: {
+            field: "g",
+            levels: ["a", "b", "c", "d"],
+            labels: {
+              a: longLabel,
+              b: longLabel,
+              c: longLabel,
+              d: longLabel,
+            },
+          },
+          ncol: 1,
+          strip: { position: "left" },
+        })
+        .spec(),
+      // Short viewport → multi-row panels shorter than the full label advance.
+      { width: 360, height: 220 },
+    );
+
+    expect(model.scene.panels.length).toBe(4);
+    // Multi-row: distinct y positions
+    expect(new Set(model.scene.panels.map((p) => p.y)).size).toBeGreaterThan(1);
+
+    const measurer = new MetricsTableMeasurer(FONT_METRICS);
+    const stripSize = model.scene.theme.stripSize;
+
+    for (const panel of model.scene.panels) {
+      expect(panel.stripPosition).toBe("left");
+      // Rotated advance must fit inside the panel's vertical budget.
+      expect(measurer.measureWidth(panel.strip, stripSize)).toBeLessThanOrEqual(panel.height + 0.5);
+      // Full label was longer than the panel — expect ellipsis truncation.
+      expect(panel.strip.length).toBeLessThan(longLabel.length);
+      expect(panel.strip.endsWith("…")).toBe(true);
+      // Band width also respects the vertical budget (+ pad).
+      expect(panel.stripBand!).toBeLessThanOrEqual(Math.ceil(panel.height) + 8 + 1);
+    }
+
+    const svg = sceneToSVGString(model.scene);
+    expect(svg).toContain("gg-strip-clip-");
+    expect(svg).toContain('clip-path="url(#gg-strip-clip-0)"');
+    // Truncated label is rendered; full long string is not.
+    expect(svg).not.toContain(longLabel);
+    expect(svg).toContain("…");
+  });
+
+  it("leaves short side-strip labels untruncated", () => {
+    const model = runPipeline(
+      gg(wrapRows, aes({ x: "x", y: "y" }))
+        .geomPoint()
+        .facet({
+          wrap: { field: "g", levels: ["a", "b"], labels: { a: "Alpha", b: "Beta" } },
+          strip: { position: "left" },
+        })
+        .spec(),
+      size,
+    );
+    expect(model.scene.panels.map((p) => p.strip)).toEqual(["Alpha", "Beta"]);
+    const svg = sceneToSVGString(model.scene);
+    expect(svg).toContain("Alpha");
+    expect(svg).toContain("Beta");
   });
 });

--- a/packages/svelte/src/lib/scene/SceneView.svelte
+++ b/packages/svelte/src/lib/scene/SceneView.svelte
@@ -55,7 +55,7 @@
     focusMasks?: readonly (BatchInteractionMask | null)[];
   } = $props();
 
-  /** Strip band geometry matching core renderToSVGString (issue #590). */
+  /** Strip band geometry matching core renderToSVGString (issue #590 / #611). */
   function stripGeometry(panel: ScenePanel): {
     x: number;
     y: number;
@@ -64,6 +64,8 @@
     textX: number;
     textY: number;
     rotate: string | undefined;
+    /** Clip rotated side-strip labels to the panel-height band (#611). */
+    clip: boolean;
   } | null {
     if (panel.strip === "" || panel.showStrip === false) return null;
     const band = panel.stripBand ?? STRIP_BAND;
@@ -79,6 +81,7 @@
         textX: panel.width / 2,
         textY: bandDraw / 2,
         rotate: undefined,
+        clip: false,
       };
     }
     if (position === "bottom") {
@@ -92,6 +95,7 @@
         textX: panel.width / 2,
         textY: bandDraw / 2,
         rotate: undefined,
+        clip: false,
       };
     }
     if (position === "left") {
@@ -107,6 +111,7 @@
         textX,
         textY,
         rotate: `rotate(-90 ${textX} ${textY})`,
+        clip: true,
       };
     }
     const textX = bandDraw / 2;
@@ -119,6 +124,7 @@
       textX,
       textY,
       rotate: `rotate(90 ${textX} ${textY})`,
+      clip: true,
     };
   }
 
@@ -335,7 +341,16 @@
     </g>
     {#if drawChrome && stripGeometry(panel) !== null}
       {@const strip = stripGeometry(panel)!}
-      <g class="gg-strip" transform={`translate(${strip.x},${strip.y})`}>
+      <g
+        class="gg-strip"
+        transform={`translate(${strip.x},${strip.y})`}
+        clip-path={strip.clip ? `url(#${uid}-strip-clip-${i})` : undefined}
+      >
+        {#if strip.clip}
+          <clipPath id={`${uid}-strip-clip-${i}`}>
+            <rect width={strip.width} height={strip.height} />
+          </clipPath>
+        {/if}
         <rect
           width={strip.width}
           height={strip.height}


### PR DESCRIPTION
## Summary

Fixes #611.

Left/right facet strips reserve horizontal band width from label **advance width**, then rotate labels 90° for rendering. That advance becomes the *vertical* extent of the text. On multi-row wraps with long labels, chrome painted into neighboring panel rows while only horizontal space was reserved.

## Fix

1. **Cap labels** — `capSideStripLabel` truncates (ellipsis) so measureWidth ≤ panel height when assembling scene panels
2. **Layout** — remeasure side `stripBand` against the shortest panel height after the first placement pass
3. **Render** — clip left/right strip groups to the panel-height band in core SVG + Svelte `SceneView` (defense in depth)

## Test plan

- [x] Multi-row `ncol: 1` left strips with long labels: advance ≤ panel.height, ellipsis present, SVG `gg-strip-clip-*`
- [x] Short side-strip labels unchanged
- [x] Existing strip position suite still green
- [x] Full `packages/core/tests/facets` (45 tests)
- [x] `bun run lint:type-aware`
- [ ] CI on PR

## Follow-ups

None deferred.