### PR TITLE
ci: two-step prepublish path for Playwright tag bumps (#610)

### DIFF
--- a/.github/docker/ci-runner/Dockerfile
+++ b/.github/docker/ci-runner/Dockerfile
@@ -6,8 +6,10 @@
 # from GitHub's Azure runners (observed 15m50s / 34 kB/s). Baking it in once
 # removes that cost from every container job.
 #
-# PLAYWRIGHT_TAG MUST stay in sync with env.PLAYWRIGHT_CONTAINER_TAG in
-# .github/workflows/ci.yml. Build/publish via .github/workflows/build-ci-image.yml.
+# PLAYWRIGHT_TAG default tracks env.PLAYWRIGHT_TAG in build-ci-image.yml (the
+# publisher). Consumers in ci.yml may lag during a step-1 prepublish (#610);
+# never set this default behind the published/publisher tag. Procedure:
+# CONTRIBUTING.md "Bumping Playwright / the CI runner image".
 ARG PLAYWRIGHT_TAG=v1.61.1-noble
 FROM mcr.microsoft.com/playwright:${PLAYWRIGHT_TAG}
 

--- a/.github/workflows/build-ci-image.yml
+++ b/.github/workflows/build-ci-image.yml
@@ -17,6 +17,17 @@
 # the workflow non-dispatchable, so publishing requires a commit on main (review-
 # gated). On-demand rebuilds: re-run the last successful main run from the Actions
 # UI, or push a no-op change to the Dockerfile / this file.
+#
+# Playwright tag bumps (issue #610) are TWO-STEP — do not bump consumers in the
+# same PR as this publisher tag, or PR CI will try to pull a tag that only this
+# main-only workflow can create:
+#   1) Prepublish: bump PLAYWRIGHT_TAG here + ARG default in the Dockerfile;
+#      merge; wait for this workflow to publish ci-runner:<new-tag>.
+#   2) Consume: bump support-matrix / package pins / PLAYWRIGHT_CONTAINER_TAG
+#      and hardcoded ci-runner: image lines to the published tag.
+# Steady state: publisher tag == consumer tag. Publisher may *lead* consumers
+# between steps; it must never lag. Procedure: CONTRIBUTING.md
+# "Bumping Playwright / the CI runner image".
 name: build CI image
 
 on:
@@ -26,7 +37,8 @@ on:
       - .github/docker/ci-runner/Dockerfile
       - .github/workflows/build-ci-image.yml
 
-# PLAYWRIGHT_TAG MUST stay in sync with env.PLAYWRIGHT_CONTAINER_TAG in ci.yml.
+# PLAYWRIGHT_TAG may equal or lead env.PLAYWRIGHT_CONTAINER_TAG in ci.yml
+# (prepublish). Consumers must never reference a tag this file has not published.
 env:
   PLAYWRIGHT_TAG: v1.61.1-noble
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,12 +54,16 @@ concurrency:
 # unnecessary work, but no longer sit behind a repo-local four-job ceiling.
 
 env:
-  # Keep in sync with: spikes/browser devDependency "playwright" and the
-  # `component` job's container image below. The sync is asserted in a step.
-  # Container jobs now pull the prebaked ghcr.io/<repo>/ci-runner:<tag> image
-  # (Playwright + unzip). Bumping this tag requires FIRST rebuilding and
-  # publishing that tag via .github/workflows/build-ci-image.yml — otherwise
-  # every container job fails to pull the (nonexistent) new tag.
+  # Keep in sync with: support-matrix.json browsers.playwright, package pins
+  # (@playwright/test / playwright), and every hardcoded ci-runner: image line
+  # below (asserted in scripts/support-matrix.test.ts + per-job pin steps).
+  # Container jobs pull the prebaked ghcr.io/<repo>/ci-runner:<tag> image
+  # (Playwright + unzip), published ONLY on main by build-ci-image.yml.
+  # Bumping this tag is step 2 of a two-step process (issue #610): first
+  # prepublish the image by landing a publisher-only bump of PLAYWRIGHT_TAG in
+  # build-ci-image.yml (and the Dockerfile ARG default), then point consumers
+  # here at the published tag. Single-PR lockstep deadlocks PR CI on a missing
+  # pull. See CONTRIBUTING.md "Bumping Playwright / the CI runner image".
   PLAYWRIGHT_CONTAINER_TAG: v1.61.1-noble
 
 jobs:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,26 +77,26 @@ upstream, `.md`/`.yaml`/`.svelte` can fold back into oxfmt (`.oxfmtrc.json`
 
 ## Tool roster and versions (verified working, July 2026)
 
-| Tool                                         | Version                | Role                                                                                  |
-| -------------------------------------------- | ---------------------- | ------------------------------------------------------------------------------------- |
-| bun                                          | 1.3.14 (pinned)        | PM / runner / unit tests                                                              |
-| typescript                                   | 6.0.3                  | `tsc -b` project references (spec, core)                                              |
-| oxlint                                       | 1.73.0                 | JS/TS linting (correctness+suspicious error, pedantic warn)                           |
-| oxlint-tsgolint                              | 0.24.0                 | type-aware rules via `oxlint --type-aware` (no standalone CLI)                        |
-| oxfmt                                        | 0.58.0                 | formatter for ts/js/json/jsonc/css/toml                                               |
-| prettier + prettier-plugin-svelte            | 3.9.5 / 4.1.1          | formatter for .svelte/.md/.yaml (see quirk above)                                     |
-| markdownlint-cli2                            | 0.23.0                 | markdown lint (pre-commit stage; config `.markdownlint-cli2.jsonc`)                   |
-| svelte-check                                 | 4.7.3                  | Svelte template + type checking (packages/svelte)                                     |
-| knip                                         | 6.26.0                 | unused files/exports/deps (spikes ignored)                                            |
-| publint / @arethetypeswrong/cli              | 0.3.21 / 0.18.5        | package publish shape (skips unbuilt stubs)                                           |
-| actionlint (npm, wasm)                       | 2.0.6                  | workflow lint via `scripts/actionlint.ts` (no shellcheck integration — wasm build)    |
-| zizmor                                       | 1.26.1 (uv tool)       | Actions security audit                                                                |
-| @changesets/cli                              | 2.31.0                 | versioning/release (spec+core+ggsvelte linked, access public)                         |
-| vitest + @vitest/browser-playwright          | 4.1.10                 | browser-mode component tests (factory `playwright()` provider)                        |
-| playwright / @playwright/test                | 1.61.1 (exact pins)    | must match CI container `mcr.microsoft.com/playwright:v1.61.1-noble` — asserted in CI |
-| @sveltejs/kit + @sveltejs/adapter-static     | 2.x / 3.x              | apps/docs static docs site (the VR screenshot target)                                 |
-| svelte / vite / @sveltejs/vite-plugin-svelte | 5.56.4 / 8.1.4 / 7.2.0 | spike + adapter toolchain                                                             |
-| pre-commit                                   | 4.6.0                  | hook framework (both stages)                                                          |
+| Tool                                         | Version                | Role                                                                               |
+| -------------------------------------------- | ---------------------- | ---------------------------------------------------------------------------------- |
+| bun                                          | 1.3.14 (pinned)        | PM / runner / unit tests                                                           |
+| typescript                                   | 6.0.3                  | `tsc -b` project references (spec, core)                                           |
+| oxlint                                       | 1.73.0                 | JS/TS linting (correctness+suspicious error, pedantic warn)                        |
+| oxlint-tsgolint                              | 0.24.0                 | type-aware rules via `oxlint --type-aware` (no standalone CLI)                     |
+| oxfmt                                        | 0.58.0                 | formatter for ts/js/json/jsonc/css/toml                                            |
+| prettier + prettier-plugin-svelte            | 3.9.5 / 4.1.1          | formatter for .svelte/.md/.yaml (see quirk above)                                  |
+| markdownlint-cli2                            | 0.23.0                 | markdown lint (pre-commit stage; config `.markdownlint-cli2.jsonc`)                |
+| svelte-check                                 | 4.7.3                  | Svelte template + type checking (packages/svelte)                                  |
+| knip                                         | 6.26.0                 | unused files/exports/deps (spikes ignored)                                         |
+| publint / @arethetypeswrong/cli              | 0.3.21 / 0.18.5        | package publish shape (skips unbuilt stubs)                                        |
+| actionlint (npm, wasm)                       | 2.0.6                  | workflow lint via `scripts/actionlint.ts` (no shellcheck integration — wasm build) |
+| zizmor                                       | 1.26.1 (uv tool)       | Actions security audit                                                             |
+| @changesets/cli                              | 2.31.0                 | versioning/release (spec+core+ggsvelte linked, access public)                      |
+| vitest + @vitest/browser-playwright          | 4.1.10                 | browser-mode component tests (factory `playwright()` provider)                     |
+| playwright / @playwright/test                | 1.61.1 (exact pins)    | must match `ghcr.io/<repo>/ci-runner:v1.61.1-noble` — two-step bump (see below)    |
+| @sveltejs/kit + @sveltejs/adapter-static     | 2.x / 3.x              | apps/docs static docs site (the VR screenshot target)                              |
+| svelte / vite / @sveltejs/vite-plugin-svelte | 5.56.4 / 8.1.4 / 7.2.0 | spike + adapter toolchain                                                          |
+| pre-commit                                   | 4.6.0                  | hook framework (both stages)                                                       |
 
 ## Dependency updates (Dependabot)
 
@@ -112,8 +112,11 @@ upstream, `.md`/`.yaml`/`.svelte` can fold back into oxfmt (`.oxfmtrc.json`
 
 Dependabot does **not** auto-bump these (human-authored locksteps / release flow):
 
-- `playwright` / `@playwright/test` — exact pins must match every
-  `mcr.microsoft.com/playwright:v…-noble` container tag (asserted in CI).
+- `playwright` / `@playwright/test` — exact pins must match
+  `support-matrix.json` `browsers.playwright` and the consumer
+  `ghcr.io/<repo>/ci-runner:v…-noble` tag (asserted in
+  `scripts/support-matrix.test.ts`). Bump via the two-step procedure below —
+  never as a Dependabot PR.
 - `pnpm` — root pin must match `support-matrix.json` `packageManagers.pnpm`
   (asserted in `scripts/support-matrix.test.ts`).
 - `@ggsvelte/*` — internal publish ranges are owned by Changesets, not registry
@@ -121,6 +124,51 @@ Dependabot does **not** auto-bump these (human-authored locksteps / release flow
 
 Majors for `svelte`, `vite`, `@sveltejs/*`, `typescript`, and `vitest` are also
 ignored — land those as deliberate migrations.
+
+### Bumping Playwright / the CI runner image
+
+Container jobs pull `ghcr.io/<owner>/<repo>/ci-runner:<tag>` (Playwright +
+`unzip`), published **only** by [`.github/workflows/build-ci-image.yml`](.github/workflows/build-ci-image.yml)
+on pushes to `main` that touch the Dockerfile or that workflow. There is
+intentionally **no** `workflow_dispatch`: a dispatchable workflow can run an
+unreviewed branch's copy with `packages: write` and overwrite the published
+tag with a poisoned image. On-demand rebuilds re-run the last successful main
+run from the Actions UI, or push a no-op change to the Dockerfile / publisher
+workflow.
+
+A single PR that bumps **consumers and publisher together deadlocks**:
+`scripts/support-matrix.test.ts` used to force them equal, so the PR would
+point container jobs at `ci-runner:<new-tag>` before main could publish that
+tag. Use a **two-step** bump (issue
+[#610](https://github.com/ljodea/ggsvelte/issues/610)):
+
+**Step 1 — prepublish the image** (publisher may _lead_ consumers):
+
+1. Bump `PLAYWRIGHT_TAG` in `.github/workflows/build-ci-image.yml`.
+2. Bump `ARG PLAYWRIGHT_TAG` default in `.github/docker/ci-runner/Dockerfile`
+   to the same value.
+3. Do **not** change `support-matrix.json`, package pins, or consumer workflow
+   tags (`PLAYWRIGHT_CONTAINER_TAG` / hardcoded `ci-runner:` image lines).
+4. Merge to `main`; wait for the `build CI image` workflow to publish
+   `ghcr.io/<owner>/<repo>/ci-runner:<new-tag>`.
+5. Verify the tag exists (Actions run green, or
+   `docker manifest inspect ghcr.io/ljodea/ggsvelte/ci-runner:vX.Y.Z-noble`).
+
+**Step 2 — consume the published tag**:
+
+1. Bump `support-matrix.json` `browsers.playwright`.
+2. Bump root `@playwright/test`, `packages/svelte` `playwright`, and
+   `spikes/browser` `playwright` to the same version; run `bun install`.
+3. Bump `PLAYWRIGHT_CONTAINER_TAG` in `.github/workflows/ci.yml` and every
+   hardcoded `ci-runner:v…-noble` image line (`ci.yml`, `vr-compare.yml`,
+   `bench.yml`).
+4. Update any hardcoded version strings in
+   `scripts/release-wiring.test.ts` (and similar) if present.
+5. Merge once container jobs pull the prepublished image successfully.
+
+**Steady state:** publisher tag == consumer tag == matrix. Between step 1 and
+step 2 the publisher may be **ahead**; it must never lag (consumers would pull
+a tag main never publishes). The lockstep test encodes that inequality.
 
 ## Running the checks
 

--- a/scripts/support-matrix.test.ts
+++ b/scripts/support-matrix.test.ts
@@ -47,8 +47,11 @@ export function comparePlaywrightContainerTags(a: string, b: string): number {
 
 function extractWorkflowEnvTag(yaml: string, key: string): string {
   const m = new RegExp(`^\\s*${key}:\\s*(\\S+)\\s*$`, "m").exec(yaml);
-  if (!m?.[1]) throw new Error(`missing workflow env ${key}`);
-  return m[1];
+  const value = m?.[1];
+  if (value === undefined || value === "") {
+    throw new Error(`missing workflow env ${key}`);
+  }
+  return value;
 }
 
 describe("Playwright container tag helpers (issue #610)", () => {

--- a/scripts/support-matrix.test.ts
+++ b/scripts/support-matrix.test.ts
@@ -12,6 +12,63 @@ import {
 
 const root = join(import.meta.dir, "..");
 
+/** Parse `v1.61.1-noble` → parts. Throws on unexpected shape. */
+export function parsePlaywrightContainerTag(tag: string): {
+  major: number;
+  minor: number;
+  patch: number;
+  distro: string;
+} {
+  const m = /^v(\d+)\.(\d+)\.(\d+)-([a-z0-9]+)$/.exec(tag.trim());
+  if (!m) throw new Error(`unexpected Playwright container tag: ${tag}`);
+  return {
+    major: Number(m[1]),
+    minor: Number(m[2]),
+    patch: Number(m[3]),
+    distro: m[4]!,
+  };
+}
+
+/**
+ * Compare two tags of form `vX.Y.Z-distro` (−1 / 0 / 1). Same distro required.
+ * Used so the publisher tag may lead consumers during prepublish (#610).
+ */
+export function comparePlaywrightContainerTags(a: string, b: string): number {
+  const pa = parsePlaywrightContainerTag(a);
+  const pb = parsePlaywrightContainerTag(b);
+  if (pa.distro !== pb.distro) {
+    throw new Error(`Playwright tag distro mismatch: ${a} vs ${b}`);
+  }
+  if (pa.major !== pb.major) return pa.major < pb.major ? -1 : 1;
+  if (pa.minor !== pb.minor) return pa.minor < pb.minor ? -1 : 1;
+  if (pa.patch !== pb.patch) return pa.patch < pb.patch ? -1 : 1;
+  return 0;
+}
+
+function extractWorkflowEnvTag(yaml: string, key: string): string {
+  const m = new RegExp(`^\\s*${key}:\\s*(\\S+)\\s*$`, "m").exec(yaml);
+  if (!m?.[1]) throw new Error(`missing workflow env ${key}`);
+  return m[1];
+}
+
+describe("Playwright container tag helpers (issue #610)", () => {
+  test("parses and compares vX.Y.Z-distro tags", () => {
+    expect(parsePlaywrightContainerTag("v1.61.1-noble")).toEqual({
+      major: 1,
+      minor: 61,
+      patch: 1,
+      distro: "noble",
+    });
+    expect(comparePlaywrightContainerTags("v1.61.1-noble", "v1.61.1-noble")).toBe(0);
+    expect(comparePlaywrightContainerTags("v1.62.0-noble", "v1.61.1-noble")).toBe(1);
+    expect(comparePlaywrightContainerTags("v1.60.0-noble", "v1.61.1-noble")).toBe(-1);
+    expect(() => parsePlaywrightContainerTag("1.61.1-noble")).toThrow(/unexpected/);
+    expect(() => comparePlaywrightContainerTags("v1.61.1-noble", "v1.61.1-jammy")).toThrow(
+      /distro mismatch/,
+    );
+  });
+});
+
 describe("consumer support matrix", () => {
   test("PR default tier is a single Linux required row (issue #246)", () => {
     const matrix = loadSupportMatrix();
@@ -82,18 +139,25 @@ describe("consumer support matrix", () => {
       readFileSync(join(root, "packages/svelte/package.json"), "utf8"),
     ) as { devDependencies: Record<string, string> };
     const ci = readFileSync(join(root, ".github/workflows/ci.yml"), "utf8");
-    // The publisher's tag must track the matrix too: container jobs pull
-    // ci-runner:<PLAYWRIGHT_CONTAINER_TAG>, and only build-ci-image.yml publishes
-    // that tag. If a Playwright bump updated the matrix + ci.yml but left this
-    // publisher pinned, no matching image would be published and every container
-    // job would fail to pull. Lock all three copies to the same source.
+    // Consumers (matrix + package pins + ci.yml) must move in lockstep.
+    // The publisher (build-ci-image.yml) may equal consumers in steady state,
+    // or *lead* them after a step-1 prepublish of the next Playwright tag
+    // (issue #610). It must never lag: a lagging publisher means main would
+    // never publish the tag consumers already pull.
+    // See CONTRIBUTING.md "Bumping Playwright / the CI runner image".
     const buildCiImage = readFileSync(join(root, ".github/workflows/build-ci-image.yml"), "utf8");
+    const dockerfile = readFileSync(join(root, ".github/docker/ci-runner/Dockerfile"), "utf8");
+    const consumerTag = `v${matrix.browsers.playwright}-noble`;
+    const publisherTag = extractWorkflowEnvTag(buildCiImage, "PLAYWRIGHT_TAG");
     expect(rootManifest.packageManager).toBe(`bun@${matrix.packageManagers.bun}`);
     expect(rootManifest.devDependencies["@playwright/test"]).toBe(matrix.browsers.playwright);
     expect(rootManifest.devDependencies.pnpm).toBe(matrix.packageManagers.pnpm);
     expect(svelteManifest.devDependencies.playwright).toBe(matrix.browsers.playwright);
-    expect(ci).toContain(`PLAYWRIGHT_CONTAINER_TAG: v${matrix.browsers.playwright}-noble`);
-    expect(buildCiImage).toContain(`PLAYWRIGHT_TAG: v${matrix.browsers.playwright}-noble`);
+    expect(ci).toContain(`PLAYWRIGHT_CONTAINER_TAG: ${consumerTag}`);
+    expect(comparePlaywrightContainerTags(publisherTag, consumerTag)).toBeGreaterThanOrEqual(0);
+    // Dockerfile ARG default tracks the publisher (build-arg overrides it;
+    // keeping the default aligned avoids silent rebuilds against a stale base).
+    expect(dockerfile).toContain(`ARG PLAYWRIGHT_TAG=${publisherTag}`);
   });
 
   test("keeps the README support claim aligned with the matrix", () => {


### PR DESCRIPTION
## Summary

Fixes #610. Playwright / `ci-runner` tag bumps no longer require a single PR that tries to pull an unpublished GHCR image.

- **Lockstep relaxed:** consumers (`support-matrix`, package pins, `PLAYWRIGHT_CONTAINER_TAG`) stay equal; the publisher (`build-ci-image.yml` `PLAYWRIGHT_TAG` + Dockerfile ARG) may **equal or lead** consumers, never lag.
- **Security unchanged:** still no `workflow_dispatch` — only reviewed main commits publish the image.
- **Documented procedure** in `CONTRIBUTING.md` (step 1 prepublish → step 2 consume), plus comments on the publisher/consumer workflows.

## Test plan

- [x] `bun test scripts/support-matrix.test.ts`
- [x] `bun test scripts/release-wiring.test.ts`
- [ ] CI green on this PR
- [ ] Acceptance: a future Playwright bump can land step 1 (publisher-only) then step 2 (consumers) without missing-tag pull failures