### PR TITLE
ci: extract Playwright version-sync into composite action (#578)

### DIFF
--- a/.github/actions/ci-assert-playwright-version-sync/action.yml
+++ b/.github/actions/ci-assert-playwright-version-sync/action.yml
@@ -1,0 +1,58 @@
+# Assert npm-resolved Playwright version matches the pinned container tag.
+# Callers gate the step with `if:` when content-hash hit must skip the check.
+name: CI assert Playwright version sync
+description: >
+  Resolve an npm Playwright package version from a working directory and fail
+  when v{version}-noble does not match the pinned container tag.
+
+inputs:
+  working_directory:
+    description: >
+      Directory to resolve the package from (repo-relative). Use `.` for the
+      monorepo root.
+    required: false
+    default: "."
+  package:
+    description: npm package name (`playwright` or `@playwright/test`)
+    required: false
+    default: "playwright"
+  scope:
+    description: >
+      Human-readable scope for log/error messages (e.g. packages/svelte,
+      spikes/browser, root @playwright/test (VR suite)).
+    required: true
+  container_tag:
+    description: Pinned Playwright container tag (v…-noble)
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: assert playwright npm/container version sync (${{ inputs.scope }})
+      shell: bash
+      env:
+        # env-indirection: inputs must not expand into the script body (zizmor).
+        WORKING_DIRECTORY: ${{ inputs.working_directory }}
+        PACKAGE: ${{ inputs.package }}
+        SCOPE: ${{ inputs.scope }}
+        CONTAINER_TAG: ${{ inputs.container_tag }}
+      run: |
+        set -euo pipefail
+        npm_version="$(
+          cd "${WORKING_DIRECTORY}"
+          bun -e 'console.log(require(`${process.env.PACKAGE}/package.json`).version)'
+        )"
+        expected="v${npm_version}-noble"
+        if [ "${PACKAGE}" = "playwright" ]; then
+          echo "${SCOPE} playwright: ${npm_version}; container tag: ${CONTAINER_TAG}"
+          if [ "${expected}" != "${CONTAINER_TAG}" ]; then
+            echo "::error::playwright npm version in ${SCOPE} (${npm_version}) does not match pinned container tag (${CONTAINER_TAG})"
+            exit 1
+          fi
+        else
+          echo "${SCOPE}: ${npm_version}; container tag: ${CONTAINER_TAG}"
+          if [ "${expected}" != "${CONTAINER_TAG}" ]; then
+            echo "::error::${PACKAGE} version (${npm_version}) does not match pinned container tag (${CONTAINER_TAG})"
+            exit 1
+          fi
+        fi

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -125,6 +125,7 @@ updates:
       - "/.github/actions/ci-setup-bun"
       - "/.github/actions/ci-bun-install"
       - "/.github/actions/ci-download-packages-dist"
+      - "/.github/actions/ci-assert-playwright-version-sync"
     schedule:
       interval: "weekly"
       day: "tuesday"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -474,15 +474,12 @@ jobs:
         if: steps.content_hash.outputs.hit != 'true'
       - name: assert playwright npm/container version sync (packages/svelte)
         if: steps.content_hash.outputs.hit != 'true'
-        run: |
-          set -euo pipefail
-          npm_version="$(cd packages/svelte && bun -e 'console.log(require("playwright/package.json").version)')"
-          expected="v${npm_version}-noble"
-          echo "packages/svelte playwright: ${npm_version}; container tag: ${PLAYWRIGHT_CONTAINER_TAG}"
-          if [ "${expected}" != "${PLAYWRIGHT_CONTAINER_TAG}" ]; then
-            echo "::error::playwright npm version in packages/svelte (${npm_version}) does not match pinned container tag (${PLAYWRIGHT_CONTAINER_TAG})"
-            exit 1
-          fi
+        uses: ./.github/actions/ci-assert-playwright-version-sync
+        with:
+          working_directory: packages/svelte
+          package: playwright
+          scope: packages/svelte
+          container_tag: ${{ env.PLAYWRIGHT_CONTAINER_TAG }}
       # Chromium collects browser v8 coverage (CDP; works under bun) and enforces
       # thresholds. SSR runs under bun without --coverage: @vitest/coverage-v8
       # needs Node inspector Coverage APIs that bun does not implement
@@ -602,15 +599,12 @@ jobs:
         if: steps.content_hash.outputs.hit != 'true'
       - name: assert playwright npm/container version sync (packages/svelte)
         if: steps.content_hash.outputs.hit != 'true'
-        run: |
-          set -euo pipefail
-          npm_version="$(cd packages/svelte && bun -e 'console.log(require("playwright/package.json").version)')"
-          expected="v${npm_version}-noble"
-          echo "packages/svelte playwright: ${npm_version}; container tag: ${PLAYWRIGHT_CONTAINER_TAG}"
-          if [ "${expected}" != "${PLAYWRIGHT_CONTAINER_TAG}" ]; then
-            echo "::error::playwright npm version in packages/svelte (${npm_version}) does not match pinned container tag (${PLAYWRIGHT_CONTAINER_TAG})"
-            exit 1
-          fi
+        uses: ./.github/actions/ci-assert-playwright-version-sync
+        with:
+          working_directory: packages/svelte
+          package: playwright
+          scope: packages/svelte
+          container_tag: ${{ env.PLAYWRIGHT_CONTAINER_TAG }}
       - name: component tests (packages/svelte, firefox + webkit)
         if: steps.content_hash.outputs.hit != 'true'
         working-directory: packages/svelte
@@ -670,15 +664,12 @@ jobs:
         if: steps.content_hash.outputs.hit != 'true'
       - name: assert playwright npm/container version sync (spikes/browser)
         if: steps.content_hash.outputs.hit != 'true'
-        run: |
-          set -euo pipefail
-          npm_version="$(cd spikes/browser && bun -e 'console.log(require("playwright/package.json").version)')"
-          expected="v${npm_version}-noble"
-          echo "spikes/browser playwright: ${npm_version}; container tag: ${PLAYWRIGHT_CONTAINER_TAG}"
-          if [ "${expected}" != "${PLAYWRIGHT_CONTAINER_TAG}" ]; then
-            echo "::error::playwright npm version in spikes/browser (${npm_version}) does not match pinned container tag (${PLAYWRIGHT_CONTAINER_TAG})"
-            exit 1
-          fi
+        uses: ./.github/actions/ci-assert-playwright-version-sync
+        with:
+          working_directory: spikes/browser
+          package: playwright
+          scope: spikes/browser
+          container_tag: ${{ env.PLAYWRIGHT_CONTAINER_TAG }}
       - name: retired spike suites (browser + ssr projects)
         if: steps.content_hash.outputs.hit != 'true'
         working-directory: spikes/browser
@@ -740,14 +731,12 @@ jobs:
         if: steps.content_hash.outputs.hit != 'true'
       - name: assert playwright npm/container version sync (root @playwright/test)
         if: steps.content_hash.outputs.hit != 'true'
-        run: |
-          set -euo pipefail
-          vr_version="$(bun -e 'console.log(require("@playwright/test/package.json").version)')"
-          echo "root @playwright/test (VR suite): ${vr_version}; container tag: ${PLAYWRIGHT_CONTAINER_TAG}"
-          if [ "v${vr_version}-noble" != "${PLAYWRIGHT_CONTAINER_TAG}" ]; then
-            echo "::error::@playwright/test version (${vr_version}) does not match pinned container tag (${PLAYWRIGHT_CONTAINER_TAG})"
-            exit 1
-          fi
+        uses: ./.github/actions/ci-assert-playwright-version-sync
+        with:
+          working_directory: .
+          package: "@playwright/test"
+          scope: root @playwright/test (VR suite)
+          container_tag: ${{ env.PLAYWRIGHT_CONTAINER_TAG }}
       - name: build packaged interaction test target
         if: steps.content_hash.outputs.hit != 'true'
         run: DOCS_BUILD_MODE=cloudflare-preview bun run build:docs

--- a/scripts/ci-composites.test.ts
+++ b/scripts/ci-composites.test.ts
@@ -12,6 +12,15 @@ const read = (path: string) => readFileSync(join(root, path), "utf8");
 const SETUP_BUN = ".github/actions/ci-setup-bun/action.yml";
 const BUN_INSTALL = ".github/actions/ci-bun-install/action.yml";
 const DOWNLOAD_DIST = ".github/actions/ci-download-packages-dist/action.yml";
+const ASSERT_PW_SYNC = ".github/actions/ci-assert-playwright-version-sync/action.yml";
+
+/** Jobs that assert npm Playwright vs PLAYWRIGHT_CONTAINER_TAG. */
+const PLAYWRIGHT_VERSION_SYNC_JOBS = [
+  "component-svelte",
+  "component-svelte-fx",
+  "component-spikes",
+  "component-journeys",
+] as const;
 
 /** Jobs that download the shared packages-dist artifact. */
 const PACKAGES_DIST_CONSUMERS = [
@@ -161,6 +170,55 @@ describe("ci-bun-install composite", () => {
   });
 });
 
+describe("ci-assert-playwright-version-sync composite", () => {
+  it("exists with env-indirected inputs and noble tag comparison", () => {
+    expect(existsSync(join(root, ASSERT_PW_SYNC))).toBe(true);
+    const action = read(ASSERT_PW_SYNC);
+    expect(action).toContain("using: composite");
+    expect(action).toContain("WORKING_DIRECTORY: ${{ inputs.working_directory }}");
+    expect(action).toContain("PACKAGE: ${{ inputs.package }}");
+    expect(action).toContain("SCOPE: ${{ inputs.scope }}");
+    expect(action).toContain("CONTAINER_TAG: ${{ inputs.container_tag }}");
+    expect(action).toContain('expected="v${npm_version}-noble"');
+    expect(action).toContain("::error::");
+    expect(action).toContain("shell: bash");
+    // No external actions — pure assertion step.
+    expect(action).not.toMatch(/uses:\s+(?!composite)/);
+  });
+
+  it("is the sole playwright version-sync path for the four container jobs", () => {
+    const ci = read(".github/workflows/ci.yml");
+    for (const jobId of PLAYWRIGHT_VERSION_SYNC_JOBS) {
+      const job = jobSlice(ci, jobId);
+      expect(job, jobId).toContain("uses: ./.github/actions/ci-assert-playwright-version-sync");
+      // No inline require("playwright…") version assertions left in job bodies.
+      expect(job, jobId).not.toMatch(
+        /require\(["'](?:playwright|@playwright\/test)\/package\.json["']\)/,
+      );
+    }
+    const uses = ci.match(/uses: \.\/\.github\/actions\/ci-assert-playwright-version-sync/g) ?? [];
+    expect(uses.length).toBe(4);
+  });
+
+  it("wires scope/package inputs for svelte, spikes, and VR root", () => {
+    const ci = read(".github/workflows/ci.yml");
+    const svelte = jobSlice(ci, "component-svelte");
+    expect(svelte).toMatch(/working_directory:\s*packages\/svelte/);
+    expect(svelte).toMatch(/package:\s*playwright/);
+    expect(svelte).toMatch(/scope:\s*packages\/svelte/);
+
+    const spikes = jobSlice(ci, "component-spikes");
+    expect(spikes).toMatch(/working_directory:\s*spikes\/browser/);
+    expect(spikes).toMatch(/package:\s*playwright/);
+    expect(spikes).toMatch(/scope:\s*spikes\/browser/);
+
+    const journeys = jobSlice(ci, "component-journeys");
+    expect(journeys).toMatch(/working_directory:\s*\./);
+    expect(journeys).toMatch(/package:\s*["']@playwright\/test["']/);
+    expect(journeys).toMatch(/scope:\s*root @playwright\/test \(VR suite\)/);
+  });
+});
+
 describe("Dependabot covers new CI composites", () => {
   it("lists each composite directory under github-actions", () => {
     const dependabot = read(".github/dependabot.yml");
@@ -170,6 +228,7 @@ describe("Dependabot covers new CI composites", () => {
       '"/.github/actions/ci-setup-bun"',
       '"/.github/actions/ci-bun-install"',
       '"/.github/actions/ci-download-packages-dist"',
+      '"/.github/actions/ci-assert-playwright-version-sync"',
     ]) {
       expect(dependabot).toContain(dir);
     }

--- a/scripts/release-wiring.test.ts
+++ b/scripts/release-wiring.test.ts
@@ -406,6 +406,7 @@ describe("R0 release wiring", () => {
     expect(dependabot).toContain('"/.github/actions/ci-setup-bun"');
     expect(dependabot).toContain('"/.github/actions/ci-bun-install"');
     expect(dependabot).toContain('"/.github/actions/ci-download-packages-dist"');
+    expect(dependabot).toContain('"/.github/actions/ci-assert-playwright-version-sync"');
     // Human-authored locksteps / Changesets-owned internal ranges.
     expect(dependabot).toContain('dependency-name: "playwright"');
     expect(dependabot).toContain('dependency-name: "@playwright/test"');


### PR DESCRIPTION
## Summary

- Extract the duplicated Playwright npm/container version-sync bash blocks into `.github/actions/ci-assert-playwright-version-sync`
- Wire all four container jobs (`component-svelte`, `component-svelte-fx`, `component-spikes`, `component-journeys`) to the composite
- Register the new composite directory with Dependabot and characterization tests

Closes #578

## Test plan

- [x] `bun test scripts/ci-composites.test.ts scripts/release-wiring.test.ts`
- [x] `bun run lint:actions` (actionlint clean)
- [x] `zizmor .github/workflows` (no findings)
- [x] Local smoke of the composite script against packages/svelte and root `@playwright/test`
- [ ] CI component jobs still pass the version-sync step when the content-hash misses