### PR TITLE
fix(spec): validate binned style breaks + domain agreement (#599)

### DIFF
--- a/.changeset/validate-binned-style-breaks.md
+++ b/.changeset/validate-binned-style-breaks.md
@@ -1,0 +1,15 @@
+---
+"@ggsvelte/spec": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+fix(spec): validate binned style breaks monotonicity and domain agreement (#599)
+
+Reject binned size/linewidth/alpha/shape/linetype scales whose authored `breaks`
+are non-finite or not strictly increasing, and reject specs where both `domain`
+and `breaks` are authored with disagreeing endpoints — pre-empting runtime
+`style-binned-breaks` / `style-domain-invalid` with targeted validation codes
+`scale-binned-breaks` and `scale-binned-domain`.
+
+Migration: none — additive diagnostics for specs that already failed at render

--- a/apps/docs/src/lib/generated/routes.ts
+++ b/apps/docs/src/lib/generated/routes.ts
@@ -1149,6 +1149,16 @@ export const DOCS_ROUTES = [
         level: 3,
       },
       {
+        id: "scale-binned-breaks",
+        title: "scale-binned-breaks",
+        level: 3,
+      },
+      {
+        id: "scale-binned-domain",
+        title: "scale-binned-domain",
+        level: 3,
+      },
+      {
         id: "guide-aesthetic-incompatible",
         title: "guide-aesthetic-incompatible",
         level: 3,

--- a/apps/docs/src/lib/generated/search-index.ts
+++ b/apps/docs/src/lib/generated/search-index.ts
@@ -1614,6 +1614,26 @@ export const DOCS_SEARCH_INDEX = [
     exact: ["scale-manual-domain-range"],
   },
   {
+    id: "heading:guide-errors:scale-binned-breaks",
+    kind: "heading",
+    title: "scale-binned-breaks",
+    summary:
+      "scale-binned-breaks in Errors reference. Understand validation, render, interaction, and CLI diagnostics and recover safely.",
+    href: "/guide/errors#scale-binned-breaks",
+    keywords: ["Errors reference", "Reference"],
+    exact: ["scale-binned-breaks"],
+  },
+  {
+    id: "heading:guide-errors:scale-binned-domain",
+    kind: "heading",
+    title: "scale-binned-domain",
+    summary:
+      "scale-binned-domain in Errors reference. Understand validation, render, interaction, and CLI diagnostics and recover safely.",
+    href: "/guide/errors#scale-binned-domain",
+    keywords: ["Errors reference", "Reference"],
+    exact: ["scale-binned-domain"],
+  },
+  {
     id: "heading:guide-errors:guide-aesthetic-incompatible",
     kind: "heading",
     title: "guide-aesthetic-incompatible",
@@ -15446,6 +15466,34 @@ export const DOCS_SEARCH_INDEX = [
       "Provide exactly one range color for each explicit domain value.",
     ],
     exact: ["scale-manual-domain-range", "validation:scale-manual-domain-range"],
+  },
+  {
+    id: "diagnostic:validation:scale-binned-breaks",
+    kind: "diagnostic",
+    title: "scale-binned-breaks · validation",
+    summary:
+      "A binned style scale's authored breaks are missing, non-finite after parsing, duplicated, or not strictly increasing.",
+    href: "/guide/errors#scale-binned-breaks",
+    keywords: [
+      "validation",
+      "error",
+      "Provide 2+ strictly increasing boundaries (numeric, or temporal strings that parse under the scale's parser).",
+    ],
+    exact: ["scale-binned-breaks", "validation:scale-binned-breaks"],
+  },
+  {
+    id: "diagnostic:validation:scale-binned-domain",
+    kind: "diagnostic",
+    title: "scale-binned-domain · validation",
+    summary:
+      "A binned style scale's explicit domain does not match the first and last authored breaks.",
+    href: "/guide/errors#scale-binned-domain",
+    keywords: [
+      "validation",
+      "error",
+      "Set domain to the first and last break values, or omit domain and let breaks define it.",
+    ],
+    exact: ["scale-binned-domain", "validation:scale-binned-domain"],
   },
   {
     id: "diagnostic:validation:guide-aesthetic-incompatible",

--- a/packages/core/tests/pipeline-style-families.test.ts
+++ b/packages/core/tests/pipeline-style-families.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { fromAny } from "@total-typescript/shoehorn";
 
-import type { PortableSpec } from "@ggsvelte/spec";
+import { SpecValidationError, type PortableSpec } from "@ggsvelte/spec";
 
 import { runPipeline } from "../src/pipeline.js";
 import { resolveStyleScale } from "../src/pipeline/scale-style.js";
@@ -813,7 +813,10 @@ describe("complete mapped style plumbing", () => {
     if (temporalPaths?.kind !== "paths") throw new Error("expected temporal binned paths");
     expect(temporalPaths.pathOffsets).toHaveLength(3);
 
-    expect(() =>
+    // Unparseable temporal breaks are rejected at validation (scale-binned-breaks)
+    // before the pipeline trainer can throw style-binned-breaks.
+    let unparseableBreaksError: unknown;
+    try {
       runPipeline(
         fromAny({
           data: {
@@ -834,8 +837,14 @@ describe("complete mapped style plumbing", () => {
           },
         }),
         viewport,
-      ),
-    ).toThrow(expect.objectContaining({ code: "style-binned-breaks" }));
+      );
+    } catch (error) {
+      unparseableBreaksError = error;
+    }
+    expect(unparseableBreaksError).toBeInstanceOf(SpecValidationError);
+    expect(
+      (unparseableBreaksError as SpecValidationError).errors.map((item) => item.code),
+    ).toContain("scale-binned-breaks");
   });
 
   it("normalizes a reversed binned style domain before grouping", () => {
@@ -1089,7 +1098,10 @@ describe("complete mapped style plumbing", () => {
   });
 
   it("rejects a binned domain that disagrees with its boundaries", () => {
-    expect(() =>
+    // Domain/breaks disagreement is now a validation-time scale-binned-domain
+    // (pre-empting runtime style-domain-invalid).
+    let domainBreaksError: unknown;
+    try {
       runPipeline(
         fromAny({
           data: { values: [{ x: 1, y: 1, amount: 3 }] },
@@ -1098,8 +1110,14 @@ describe("complete mapped style plumbing", () => {
           scales: { size: { type: "binned", domain: [0, 50], breaks: [0, 5, 10], range: [2, 6] } },
         }),
         viewport,
-      ),
-    ).toThrow(expect.objectContaining({ code: "style-domain-invalid" }));
+      );
+    } catch (error) {
+      domainBreaksError = error;
+    }
+    expect(domainBreaksError).toBeInstanceOf(SpecValidationError);
+    expect((domainBreaksError as SpecValidationError).errors.map((item) => item.code)).toContain(
+      "scale-binned-domain",
+    );
   });
 
   it("fails deterministically when temporal style values cannot be parsed", () => {

--- a/packages/spec/src/error-catalog.ts
+++ b/packages/spec/src/error-catalog.ts
@@ -109,6 +109,18 @@ export const ERROR_CATALOG = {
     summary: "A manual color scale has different domain and range lengths.",
     fix: "Provide exactly one range color for each explicit domain value.",
   },
+  "scale-binned-breaks": {
+    tier: 1,
+    summary:
+      "A binned style scale's authored breaks are missing, non-finite after parsing, duplicated, or not strictly increasing.",
+    fix: "Provide 2+ strictly increasing boundaries (numeric, or temporal strings that parse under the scale's parser).",
+  },
+  "scale-binned-domain": {
+    tier: 1,
+    summary:
+      "A binned style scale's explicit domain does not match the first and last authored breaks.",
+    fix: "Set domain to the first and last break values, or omit domain and let breaks define it.",
+  },
   "guide-aesthetic-incompatible": {
     tier: 1,
     summary: "A guide variant is incompatible with its aesthetic or trained scale family.",

--- a/packages/spec/src/validate-structure-style-bins.ts
+++ b/packages/spec/src/validate-structure-style-bins.ts
@@ -1,0 +1,167 @@
+/**
+ * Structural well-formedness for binned numeric/finite style scales.
+ * Mirrors runtime checks in scale-style-numeric.ts / scale-style-finite.ts:
+ * authored breaks must be finite + strictly increasing, and when both domain
+ * and breaks are authored their endpoints must agree.
+ *
+ * Independent of parseFailure and of data — recovery bounds must themselves
+ * be valid or the runtime throws style-binned-breaks / style-domain-invalid.
+ */
+import type { SpecError } from "./errors.js";
+import { parseTemporalColumn } from "./temporal-column.js";
+import { parseTemporal } from "./temporal-parse.js";
+import { temporalParserUsable } from "./validate-data-checks-temporal.js";
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+const BINNED_STYLE_AESTHETICS = ["size", "linewidth", "alpha", "shape", "linetype"] as const;
+
+/** Mirror core cellToNumber for non-temporal style boundary resolution. */
+function nonTemporalSemantic(value: unknown): number | undefined {
+  if (typeof value === "number") return Number.isFinite(value) ? value : undefined;
+  if (value instanceof Date) {
+    const epochMs = value.getTime();
+    return Number.isFinite(epochMs) ? epochMs : undefined;
+  }
+  if (typeof value === "boolean") return value ? 1 : 0;
+  if (typeof value === "string") {
+    const iso = parseTemporal(value, "iso");
+    if (iso.ok) return iso.epochMs;
+    if (value.trim() === "") return undefined;
+    const numeric = Number(value);
+    return Number.isFinite(numeric) ? numeric : undefined;
+  }
+  return undefined;
+}
+
+function resolveBoundarySemantics(
+  values: readonly unknown[],
+  config: Record<string, unknown>,
+): number[] | null {
+  const requestsTemporal =
+    config["temporalKind"] !== undefined ||
+    config["parse"] !== undefined ||
+    config["timezone"] !== undefined ||
+    config["disambiguation"] !== undefined;
+
+  if (!requestsTemporal) {
+    const mapped: number[] = [];
+    for (const value of values) {
+      const semantic = nonTemporalSemantic(value);
+      if (semantic === undefined) return null;
+      mapped.push(semantic);
+    }
+    return mapped;
+  }
+
+  // Schema-invalid temporal inputs still reach structure checks; defer rather
+  // than throw inside the temporal helpers (same gate as data-aware checks).
+  if (!temporalParserUsable(config["parse"])) return null;
+  if (config["timezone"] !== undefined && typeof config["timezone"] !== "string") return null;
+  if (config["disambiguation"] !== undefined && typeof config["disambiguation"] !== "string") {
+    return null;
+  }
+
+  const options = {
+    ...(typeof config["timezone"] === "string" && { timezone: config["timezone"] }),
+    ...(typeof config["disambiguation"] === "string" && {
+      disambiguation: config["disambiguation"] as "compatible" | "earlier" | "later" | "reject",
+    }),
+  };
+  const parser = (config["parse"] ?? "auto") as Parameters<typeof parseTemporalColumn>[1];
+  const column = parseTemporalColumn(values, parser, options);
+  const mapped: number[] = [];
+  for (let index = 0; index < values.length; index++) {
+    if (column.valid[index] !== 1) return null;
+    const epochMs = column.semantic[index];
+    if (epochMs === undefined || !Number.isFinite(epochMs)) return null;
+    mapped.push(epochMs);
+  }
+  return mapped;
+}
+
+function isStrictlyIncreasing(boundaries: readonly number[]): boolean {
+  for (let index = 1; index < boundaries.length; index++) {
+    const prev = boundaries[index - 1];
+    const current = boundaries[index];
+    if (prev === undefined || current === undefined || current <= prev) return false;
+  }
+  return true;
+}
+
+/**
+ * Config-only checks for binned size/linewidth/alpha/shape/linetype scales.
+ * Runs whenever the scale object is schema-valid (same cadence as color
+ * structural checks).
+ */
+export function binnedStyleScaleStructuralErrors(scales: Record<string, unknown>): SpecError[] {
+  const errors: SpecError[] = [];
+  for (const aesthetic of BINNED_STYLE_AESTHETICS) {
+    const config = scales[aesthetic];
+    if (!isRecord(config) || config["type"] !== "binned") continue;
+
+    const authoredBreaks = Array.isArray(config["breaks"]) ? config["breaks"] : undefined;
+    if (authoredBreaks === undefined) continue;
+
+    // Schema already enforces minItems: 2; still guard for partial schema paths.
+    if (authoredBreaks.length < 2) {
+      errors.push({
+        code: "scale-binned-breaks",
+        path: `/scales/${aesthetic}/breaks`,
+        message: `The ${aesthetic} boundaries must be finite and strictly increasing.`,
+        fix: {
+          description: "Provide at least two strictly increasing boundary values.",
+          example: [0, 10, 20],
+        },
+      });
+      continue;
+    }
+
+    const breakSemantics = resolveBoundarySemantics(authoredBreaks, config);
+    if (breakSemantics === null || !isStrictlyIncreasing(breakSemantics)) {
+      errors.push({
+        code: "scale-binned-breaks",
+        path: `/scales/${aesthetic}/breaks`,
+        message: `The ${aesthetic} boundaries must be finite and strictly increasing.`,
+        fix: {
+          description:
+            "Provide 2+ strictly increasing boundaries that parse under the scale's parser.",
+          example:
+            aesthetic === "size" || aesthetic === "linewidth" || aesthetic === "alpha"
+              ? [0, 10, 20]
+              : [0, 1, 2],
+        },
+      });
+      // Malformed breaks are the primary diagnostic; skip domain agreement.
+      continue;
+    }
+
+    const domain = Array.isArray(config["domain"]) ? config["domain"] : undefined;
+    if (domain === undefined || domain.length !== 2) continue;
+
+    const domainSemantics = resolveBoundarySemantics(domain, config);
+    if (domainSemantics === null || domainSemantics.length !== 2) {
+      // Unparseable domain is a separate runtime style-domain-invalid path; the
+      // censor-recovery check covers type-mismatch. Only emit agreement here when
+      // both sides fully resolve.
+      continue;
+    }
+
+    const first = breakSemantics[0]!;
+    const last = breakSemantics.at(-1)!;
+    if (domainSemantics[0] !== first || domainSemantics[1] !== last) {
+      errors.push({
+        code: "scale-binned-domain",
+        path: `/scales/${aesthetic}/domain`,
+        message: `The ${aesthetic} binned domain must match its first and last boundaries.`,
+        fix: {
+          description: "Set domain to the first and last break values, or omit domain.",
+          example: [first, last],
+        },
+      });
+    }
+  }
+  return errors;
+}

--- a/packages/spec/src/validate-structure.ts
+++ b/packages/spec/src/validate-structure.ts
@@ -4,6 +4,7 @@
  * Implementation:
  *  - validate-structure-layers.ts — geom channels, rule forms, M2 layer rules
  *  - validate-structure-scales.ts — named color/fill scheme vs family
+ *  - validate-structure-style-bins.ts — binned style breaks/domain well-formedness
  *  - validate-structure-facet.ts — wrap XOR grid form
  *
  * Used only by validate() — not public surface.
@@ -11,4 +12,5 @@
 
 export { layerStructuralErrors } from "./validate-structure-layers.js";
 export { colorScaleStructuralErrors, guideStructuralErrors } from "./validate-structure-scales.js";
+export { binnedStyleScaleStructuralErrors } from "./validate-structure-style-bins.js";
 export { coordFacetStructuralErrors, facetStructuralErrors } from "./validate-structure-facet.js";

--- a/packages/spec/src/validate.ts
+++ b/packages/spec/src/validate.ts
@@ -34,6 +34,7 @@ import {
 } from "./validate-data.js";
 import { collectSchemaShapeErrors, GEOM_BRANCHES } from "./validate-schema-shape.js";
 import {
+  binnedStyleScaleStructuralErrors,
   colorScaleStructuralErrors,
   coordFacetStructuralErrors,
   facetStructuralErrors,
@@ -124,7 +125,10 @@ export function validate(input: unknown, options?: ValidateOptions): ValidateRes
     }
 
     if (schemaValid && isRecord(input) && isRecord(input["scales"])) {
-      errors.push(...colorScaleStructuralErrors(input["scales"]));
+      errors.push(
+        ...colorScaleStructuralErrors(input["scales"]),
+        ...binnedStyleScaleStructuralErrors(input["scales"]),
+      );
     }
     if (schemaValid && isRecord(input)) {
       const guides = isRecord(input["guides"]) ? input["guides"] : {};

--- a/packages/spec/tests/__snapshots__/catalog-coverage.test.ts.snap
+++ b/packages/spec/tests/__snapshots__/catalog-coverage.test.ts.snap
@@ -886,3 +886,48 @@ exports[`ERROR_CATALOG coverage [paint-scale-conflict] is reproducible; message 
   },
 }
 `;
+
+exports[`ERROR_CATALOG coverage [scale-binned-breaks] is reproducible; message + fix snapshot 1`] = `
+{
+  "catalog": {
+    "fix": "Provide 2+ strictly increasing boundaries (numeric, or temporal strings that parse under the scale's parser).",
+    "summary": "A binned style scale's authored breaks are missing, non-finite after parsing, duplicated, or not strictly increasing.",
+    "tier": 1,
+  },
+  "instance": {
+    "code": "scale-binned-breaks",
+    "fix": {
+      "description": "Provide 2+ strictly increasing boundaries that parse under the scale's parser.",
+      "example": [
+        0,
+        10,
+        20,
+      ],
+    },
+    "message": "The size boundaries must be finite and strictly increasing.",
+    "path": "/scales/size/breaks",
+  },
+}
+`;
+
+exports[`ERROR_CATALOG coverage [scale-binned-domain] is reproducible; message + fix snapshot 1`] = `
+{
+  "catalog": {
+    "fix": "Set domain to the first and last break values, or omit domain and let breaks define it.",
+    "summary": "A binned style scale's explicit domain does not match the first and last authored breaks.",
+    "tier": 1,
+  },
+  "instance": {
+    "code": "scale-binned-domain",
+    "fix": {
+      "description": "Set domain to the first and last break values, or omit domain.",
+      "example": [
+        0,
+        10,
+      ],
+    },
+    "message": "The size binned domain must match its first and last boundaries.",
+    "path": "/scales/size/domain",
+  },
+}
+`;

--- a/packages/spec/tests/catalog-coverage.test.ts
+++ b/packages/spec/tests/catalog-coverage.test.ts
@@ -53,6 +53,18 @@ const TRIGGERS: Record<SpecErrorCode, Trigger> = {
       scales: { color: { type: "manual", domain: ["a", "b"], range: ["#f00"] } },
     },
   },
+  "scale-binned-breaks": {
+    spec: {
+      layers: [point],
+      scales: { size: { type: "binned", breaks: [10, 5, 0] } },
+    },
+  },
+  "scale-binned-domain": {
+    spec: {
+      layers: [point],
+      scales: { size: { type: "binned", domain: [0, 50], breaks: [0, 5, 10] } },
+    },
+  },
   "guide-aesthetic-incompatible": {
     spec: { layers: [point], scales: { x: { guide: { type: "legend" } } } },
   },

--- a/packages/spec/tests/validate-tier2-data.test.ts
+++ b/packages/spec/tests/validate-tier2-data.test.ts
@@ -356,6 +356,103 @@ describe("tier 2 — data-aware checks (inline data)", () => {
     ).toBe(true);
   });
 
+  it("rejects descending/duplicate binned style breaks with scale-binned-breaks (#599)", () => {
+    // Runtime throws style-binned-breaks for non-strictly-increasing boundaries;
+    // validation must pre-empt with a breaks-specific code (not scale-type-mismatch).
+    const descending = errorsOf({
+      ...base,
+      aes: { ...base.aes, size: { field: "temp" } },
+      scales: { size: { type: "binned", breaks: [10, 5, 0], range: [2, 6] } },
+      layers: [{ geom: "point" }],
+    });
+    expect(descending.map((e) => e.code)).toContain("scale-binned-breaks");
+    expect(descending.some((e) => e.code === "scale-type-mismatch")).toBe(false);
+
+    const duplicate = errorsOf({
+      ...base,
+      aes: { ...base.aes, linewidth: { field: "temp" } },
+      scales: { linewidth: { type: "binned", breaks: [0, 10, 10], range: [0.5, 2] } },
+      layers: [{ geom: "point" }],
+    });
+    expect(duplicate.map((e) => e.code)).toContain("scale-binned-breaks");
+
+    const finite = errorsOf({
+      ...base,
+      aes: { ...base.aes, shape: { field: "temp" } },
+      scales: { shape: { type: "binned", breaks: [2, 1, 0] } },
+      layers: [{ geom: "point" }],
+    });
+    expect(finite.map((e) => e.code)).toContain("scale-binned-breaks");
+  });
+
+  it("rejects binned domain that disagrees with breaks with scale-binned-domain (#599)", () => {
+    // Runtime style-domain-invalid when domain endpoints ≠ first/last breaks.
+    const errors = errorsOf({
+      ...base,
+      aes: { ...base.aes, size: { field: "temp" } },
+      scales: {
+        size: { type: "binned", domain: [0, 50], breaks: [0, 5, 10], range: [2, 6] },
+      },
+      layers: [{ geom: "point" }],
+    });
+    expect(errors.map((e) => e.code)).toContain("scale-binned-domain");
+    expect(errors[0]?.path).toBe("/scales/size/domain");
+  });
+
+  it("rejects non-monotonic temporal binned breaks regardless of parseFailure (#599)", () => {
+    // Censor recovery must not treat non-monotonic ISO breaks as a valid bound;
+    // the diagnostic is breaks-specific, not a generic type mismatch.
+    for (const parseFailure of ["error", "censor"] as const) {
+      const errors = errorsOf({
+        ...base,
+        aes: { ...base.aes, size: { field: "temp" } },
+        scales: {
+          size: {
+            type: "binned",
+            parse: "iso",
+            parseFailure,
+            breaks: ["2024-01-31", "2024-01-15", "2024-01-01"],
+          },
+        },
+        layers: [{ geom: "point" }],
+      });
+      expect(errors.map((e) => e.code)).toContain("scale-binned-breaks");
+    }
+  });
+
+  it("rejects temporal domain/breaks endpoint disagreement (#599)", () => {
+    const errors = errorsOf({
+      ...base,
+      aes: { ...base.aes, size: { field: "temp" } },
+      scales: {
+        size: {
+          type: "binned",
+          parse: "iso",
+          domain: ["2024-01-01", "2024-02-01"],
+          breaks: ["2024-01-01", "2024-01-15", "2024-01-31"],
+        },
+      },
+      layers: [{ geom: "point" }],
+    });
+    expect(errors.map((e) => e.code)).toContain("scale-binned-domain");
+  });
+
+  it("accepts matching domain and strictly increasing binned breaks (#599)", () => {
+    expect(
+      validate(
+        {
+          ...base,
+          aes: { ...base.aes, size: { field: "temp" } },
+          scales: {
+            size: { type: "binned", domain: [0, 20], breaks: [0, 10, 20], range: [2, 6] },
+          },
+          layers: [{ geom: "point" }],
+        },
+        {},
+      ).ok,
+    ).toBe(true);
+  });
+
   it("returns a diagnostic (not a thrown error) for a schema-invalid numeric-style parser", () => {
     // parse: 123 is a schema error, but tier-2 still runs; the temporal check must
     // defer to the schema diagnostic instead of crashing when the malformed parser
@@ -402,7 +499,8 @@ describe("tier 2 — data-aware checks (inline data)", () => {
   it("rejects a censored binned temporal style whose breaks do not parse", () => {
     // Authored binned breaks only rescue a censored all-invalid column if they parse
     // under the configured parser; unparseable breaks still throw style-binned-breaks
-    // at runtime, so validation must not accept them as a recovery bound.
+    // at runtime. Validation emits scale-binned-breaks for the malformed bounds and
+    // still scale-type-mismatch because they are not a usable recovery bound.
     const errors = errorsOf({
       ...base,
       aes: { ...base.aes, size: { field: "temp" } },
@@ -416,7 +514,7 @@ describe("tier 2 — data-aware checks (inline data)", () => {
       },
       layers: [{ geom: "point" }],
     });
-    expect(errors.map((e) => e.code)).toEqual(["scale-type-mismatch"]);
+    expect(errors.map((e) => e.code)).toEqual(["scale-binned-breaks", "scale-type-mismatch"]);
   });
 
   it("does not throw formatting a BigInt scaled constant in a diagnostic", () => {


### PR DESCRIPTION
## Summary

Closes #599.

Adds config-time validation for binned numeric (`size` / `linewidth` / `alpha`) and finite (`shape` / `linetype`) style scales so malformed recovery bounds fail before render:

- **scale-binned-breaks** — authored breaks must resolve to finite semantics and be strictly increasing (after the scale temporal parser when configured). Covers descending, duplicate, and unparseable temporal boundaries.
- **scale-binned-domain** — when both domain and breaks are authored, the domain endpoints must match the first and last breaks.

Mirrors runtime checks in `scale-style-numeric.ts` / `scale-style-finite.ts`. Independent of `parseFailure` so censor recovery cannot paper over bad bounds.

## Implementation

- New structural module `validate-structure-style-bins.ts`, wired next to color scale structural checks (schema-valid path).
- Catalog entries + coverage snapshots.
- Focused acceptance tests for numeric, finite, and temporal cases.

## Verification

- `bun run check` clean
- `bun test packages/spec` — 473 pass
- Browse verification of the four acceptance cases (all pass)

## Test plan

- [x] Descending/duplicate breaks -> scale-binned-breaks (not only type mismatch)
- [x] Domain endpoints disagree with first/last breaks -> scale-binned-domain
- [x] Temporal ISO breaks non-monotonic under parseFailure censor and error
- [x] Matching domain + increasing breaks still validates
- [x] Catalog coverage triggers for both new codes