### PR TITLE
fix(core,spec): segment Codex P2 follow-ups from #601

### DIFF
--- a/.changeset/sweep-601-segment-p2s.md
+++ b/.changeset/sweep-601-segment-p2s.md
@@ -1,0 +1,13 @@
+---
+"@ggsvelte/core": patch
+"@ggsvelte/spec": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+fix: segment endpoint grouping, binned extent, auto-hit, validation
+
+- Exclude xend/yend from default discrete grouping
+- Gate binned-axis endpoint fields to segment layers only
+- Preserve geometry-based auto hit mode for geom segment
+- Reject non-field segment endpoint mappings at validate time

--- a/packages/core/src/grouping.ts
+++ b/packages/core/src/grouping.ts
@@ -63,6 +63,10 @@ const NON_GROUPING_CHANNELS: ReadonlySet<string> = new Set([
   "xmax",
   "ymin",
   "ymax",
+  // Segment endpoints — plot-level aes may inherit them onto non-segment layers
+  // that never consume them; they must not join the discrete interaction.
+  "xend",
+  "yend",
 ]);
 
 /** Distinct sentinel for null cells so null forms its own interaction level. */

--- a/packages/core/src/pipeline/build-candidates.ts
+++ b/packages/core/src/pipeline/build-candidates.ts
@@ -48,6 +48,7 @@ function createRawCandidateDatumResolver(
       value(binding.color.field),
     );
     const fillRank = ordinalColorRank(fill, binding.fill.field, () => value(binding.fill.field));
+    const autoMode = candidateAutoMode(binding, facts.primitiveIndex);
     return {
       xValue: value(binding.xField),
       yValue: value(binding.yField),
@@ -60,7 +61,7 @@ function createRawCandidateDatumResolver(
       seriesRank: colorRank >= 0 ? colorRank : fillRank >= 0 ? fillRank : group,
       sourceOrder: sourceRow,
       lineage: lineage.intern([sourceRow]),
-      autoMode: candidateAutoMode(binding, facts.primitiveIndex),
+      ...(autoMode === undefined ? {} : { autoMode }),
     };
   };
 }

--- a/packages/core/src/pipeline/candidate-construction/datum.ts
+++ b/packages/core/src/pipeline/candidate-construction/datum.ts
@@ -200,7 +200,7 @@ function assembleIdentityCandidateDatum(
     seriesRank: attrs.seriesRank,
     sourceOrder: attrs.sourceOrder,
     lineage: attrs.lineageKey,
-    autoMode: attrs.autoMode,
+    ...(attrs.autoMode === undefined ? {} : { autoMode: attrs.autoMode }),
   };
 }
 

--- a/packages/core/src/pipeline/frame-candidates-auto-mode.ts
+++ b/packages/core/src/pipeline/frame-candidates-auto-mode.ts
@@ -6,10 +6,14 @@ import type { ResolvedCandidateInspectMode } from "../candidate-store.js";
 import { interceptList } from "./frame-helpers.js";
 import type { LayerBinding } from "./types.js";
 
+/**
+ * Layer-level auto hit mode. Returns `undefined` when the store should use
+ * geometry-based {@link defaultAutoMode} (e.g. finite segments: axis from dx/dy).
+ */
 export function candidateAutoMode(
   binding: LayerBinding,
   primitiveIndex: number,
-): ResolvedCandidateInspectMode {
+): ResolvedCandidateInspectMode | undefined {
   switch (binding.layer.geom) {
     case "point":
     case "text":
@@ -29,6 +33,9 @@ export function candidateAutoMode(
       return "x";
     case "ribbon":
       return binding.ribbonOrientation === "y" ? "y" : "x";
+    case "segment":
+      // Geometry-based mode in defaultAutoMode (long horizontal → "y", vertical → "x").
+      return undefined;
     case "rule": {
       if (binding.ruleForm === "vertical") return "x";
       if (binding.ruleForm === "horizontal") return "y";

--- a/packages/core/src/pipeline/resolve-binned-axis.ts
+++ b/packages/core/src/pipeline/resolve-binned-axis.ts
@@ -63,9 +63,13 @@ export function resolveBinnedAxis(
     const binding = bindings[index]!;
     const table = tables[index] ?? tables[0];
     if (table === undefined) continue;
-    // Segment endpoints train the same axis — include them in auto binned extent.
+    // Segment endpoints train the same axis — only when this binding is a segment
+    // (plot-level aes can leave xend/yend on non-segment layers that ignore them).
+    const isSegment = binding.layer.geom === "segment";
     const fields =
-      axis === "x" ? [binding.xField, binding.xendField] : [binding.yField, binding.yendField];
+      axis === "x"
+        ? [binding.xField, ...(isSegment ? [binding.xendField] : [])]
+        : [binding.yField, ...(isSegment ? [binding.yendField] : [])];
     for (const field of fields) {
       if (field === null) continue;
       const seenKey = `${binding.sourceId}|${field}`;

--- a/packages/core/tests/grouping.test.ts
+++ b/packages/core/tests/grouping.test.ts
@@ -221,6 +221,25 @@ describe("deriveGroups: edge cases", () => {
     expect(r.groupCount).toBe(1);
   });
 
+  test("xend/yend never participate in default grouping", () => {
+    // Plot-level segment endpoints can inherit onto line/point layers; they must
+    // not split those layers by unused categorical endpoints.
+    const t: Columns = {
+      x: [1, 2, 3, 4],
+      y: [1, 2, 3, 4],
+      xend: ["a", "b", "a", "b"],
+      yend: ["c", "c", "d", "d"],
+    };
+    const r = deriveGroups(t, {
+      x: { field: "x" },
+      y: { field: "y" },
+      xend: { field: "xend" },
+      yend: { field: "yend" },
+    });
+    expect(r.source).toBe("none");
+    expect(r.groupCount).toBe(1);
+  });
+
   test("zero-row table yields zero groups", () => {
     const r = deriveGroups({ cat1: [] }, { x: { field: "cat1" } });
     expect(r.groupCount).toBe(0);

--- a/packages/core/tests/pipeline-m2/segment.test.ts
+++ b/packages/core/tests/pipeline-m2/segment.test.ts
@@ -74,6 +74,43 @@ describe("segment geom", () => {
     expect(model.scales.x.domain).toContain("Z");
   });
 
+  it("uses geometry-based auto hit mode (not forced xy)", () => {
+    // Vertical segment → defaultAutoMode "x"; horizontal → "y".
+    const model = runPipeline(
+      gg(
+        {
+          x: [1, 0],
+          y: [0, 1],
+          xend: [1, 10],
+          yend: [10, 1],
+        },
+        aes({ x: "x", y: "y", xend: "xend", yend: "yend" }),
+      )
+        .geomSegment()
+        .spec(),
+      size,
+    );
+    expect(model.candidates.candidate(0)?.autoMode).toBe("x");
+    expect(model.candidates.candidate(1)?.autoMode).toBe("y");
+  });
+
+  it("does not reject a binned x from unused plot-level xend on a point layer", () => {
+    // Plot aes includes xend for a sibling segment; point layer must not train
+    // binned x from the (possibly nominal) endpoint field.
+    expect(() =>
+      runPipeline(
+        gg(
+          { x: [1, 2, 3], y: [1, 2, 3], xend: ["a", "b", "c"], yend: [1, 2, 3] },
+          aes({ x: "x", y: "y", xend: "xend", yend: "yend" }),
+        )
+          .geomPoint()
+          .scales({ x: { type: "binned" } })
+          .spec(),
+        size,
+      ),
+    ).not.toThrow();
+  });
+
   it("requires all four endpoints at bind time", () => {
     expect(() =>
       runPipeline(

--- a/packages/spec/src/validate-structure-layers.ts
+++ b/packages/spec/src/validate-structure-layers.ts
@@ -274,11 +274,30 @@ export function layerStructuralErrors(
     if ((geom === "bar" || geom === "histogram" || geom === "density") && channel !== "x") {
       continue;
     }
-    if (mapped(channel) === undefined) {
+    const value = mapped(channel);
+    if (value === undefined) {
       errors.push({
         code: "missing-required-channel",
         path: `${layerPath}/aes/${channel}`,
         message: `The ${geom} geom requires a "${channel}" channel; map it in the layer's aes or the plot-level aes.`,
+        fix: {
+          description: `Map "${channel}" to a data field.`,
+          example: { [channel]: CHANNEL_FIX_EXAMPLE },
+        },
+      });
+      continue;
+    }
+    // Segment runtime only materializes field endpoints (checkField); constants/stat
+    // mappings would pass validation then throw in requireField — reject early.
+    if (
+      geom === "segment" &&
+      (channel === "x" || channel === "y" || channel === "xend" || channel === "yend") &&
+      !("field" in value)
+    ) {
+      errors.push({
+        code: "missing-required-channel",
+        path: `${layerPath}/aes/${channel}`,
+        message: `The segment geom requires aes.${channel} to map a data field (not a constant or stat).`,
         fix: {
           description: `Map "${channel}" to a data field.`,
           example: { [channel]: CHANNEL_FIX_EXAMPLE },

--- a/packages/spec/tests/segment.test.ts
+++ b/packages/spec/tests/segment.test.ts
@@ -71,4 +71,29 @@ describe("segment geom (spec)", () => {
     );
     expect(result.ok).toBe(true);
   });
+
+  it("rejects constant (non-field) segment endpoints", () => {
+    // Runtime only materializes field endpoints; constants must not pass validate.
+    const result = validate(
+      {
+        data: { values: [{ x: 1, y: 2 }] },
+        layers: [
+          {
+            geom: "segment",
+            aes: {
+              x: { field: "x" },
+              y: { field: "y" },
+              xend: { value: 3 },
+              yend: { value: 4 },
+            },
+          },
+        ],
+      },
+      {},
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors.some((e) => e.code === "missing-required-channel")).toBe(true);
+    expect(result.errors.map((e) => e.path).join(" ")).toMatch(/xend|yend/);
+  });
 });


### PR DESCRIPTION
## Summary

Follow-up for unrebutted post-merge Codex P2s on #601 (geom segment).

| Finding | Fix |
|---------|-----|
| Exclude endpoint channels from default grouping | `xend`/`yend` in `NON_GROUPING_CHANNELS` |
| Gate binned endpoint fields to segment layers | `resolve-binned-axis` only includes xend/yend when `geom === \"segment\"` |
| Preserve segment auto-hit mode | `candidateAutoMode` returns `undefined` for segment → store uses geometry-based `defaultAutoMode` |
| Reject non-field segment endpoints | validate requires field mappings for x/y/xend/yend on segment |

## Tests

- `bun test packages/core/tests/grouping.test.ts packages/core/tests/pipeline-m2/segment.test.ts packages/spec/tests/segment.test.ts`
- `bun run check`