### PR TITLE
core: consolidate source-row lineage into one owned module (#626)

### DIFF
--- a/packages/core/src/pipeline/candidate-construction/datum-locate.ts
+++ b/packages/core/src/pipeline/candidate-construction/datum-locate.ts
@@ -4,7 +4,6 @@
 import type { CandidateBuildFacts } from "../../candidate-store.js";
 import type { GeometryBatch } from "../../scene.js";
 import type { CellValue, ColumnTable } from "../../table.js";
-import type { FacetPanelDef } from "../facets.js";
 import type { LayerFrame, MappedField } from "../types.js";
 import { resolveCandidateFrameRow } from "./frame-row.js";
 import type { IdentityCandidateResolveContext, LocatedIdentityCandidate } from "./datum-types.js";
@@ -32,20 +31,16 @@ function makeSourceValueLookup(
 }
 
 /**
- * Boxplot outlier local/source row mapping for point primitives.
+ * Boxplot outlier source row for point primitives.
  *
- * `frame.box.outlierRow` is remapped to global SourceRegistry ids during frame
- * assembly (`prepare-panels-frames`). Do not re-index through
- * `facetPanel.sourceRows` — that double-remap breaks lineage under facets (#609).
+ * `frame.box.outlierRow` holds finalized global SourceRegistry ids after
+ * {@link finalizeFrameSourceRows} during panel assembly.
  */
 export function resolveOutlierContext(input: {
   frame: LayerFrame | undefined;
   batch: GeometryBatch;
   primitiveIndex: number;
-  /** Retained for call-site compatibility; no longer used for remapping. */
-  facetPanel: FacetPanelDef | undefined;
 }): { outlierLocalRow: number | null; outlierSourceRow: number | null } {
-  void input.facetPanel;
   const { frame, batch, primitiveIndex } = input;
   const outlierSourceRow =
     frame?.box !== null && frame?.binding.layer.geom === "boxplot" && batch.kind === "points"
@@ -75,7 +70,6 @@ export function locateIdentityCandidate(
     frame,
     batch,
     primitiveIndex: facts.primitiveIndex,
-    facetPanel: ctx.facetPanels[facts.panelIndex],
   });
   const orderedGroups = frameGroups.get(`${facts.panelIndex}:${facts.layerIndex}`) ?? [0];
   const { frameRow, derivedGroup } = resolveCandidateFrameRow({

--- a/packages/core/src/pipeline/candidate-construction/identity-buckets.ts
+++ b/packages/core/src/pipeline/candidate-construction/identity-buckets.ts
@@ -3,10 +3,10 @@ import type { BarParams } from "@ggsvelte/spec";
 import { bandKey } from "../../scales/train.js";
 import { ColumnTable } from "../../table.js";
 import { assignBinId } from "../binned-scale.js";
-import type { FacetPanelDef } from "../facets.js";
 import { shouldAggregateOnSemanticTemporalX } from "../frame-stats-shared.js";
 import { positionColumn, xConversionOf } from "../temporal-position.js";
 import type { LayerBinding, LayerFrame } from "../types.js";
+import { globalSourceRowForInputRow } from "../source-row-lineage.js";
 
 /** Key used for count/summary/boxplot group×x lineage buckets (matches frame xValues). */
 export function aggregateLineageXKey(
@@ -78,10 +78,9 @@ export function buildBinLineageBuckets(input: {
   frame: LayerFrame;
   panelIndex: number;
   layerIndex: number;
-  facetPanel: FacetPanelDef;
   sourceRowsByGroupBin: Map<string, number[]>;
 }): void {
-  const { frame, panelIndex, layerIndex, facetPanel, sourceRowsByGroupBin } = input;
+  const { frame, panelIndex, layerIndex, sourceRowsByGroupBin } = input;
   const field = frame.binding.xField;
   if (field === null) return;
 
@@ -124,8 +123,7 @@ export function buildBinLineageBuckets(input: {
     const membersByGroup = new Map<number, number[]>();
     for (let localRow = 0; localRow < inputGroups.length; localRow++) {
       const group = inputGroups[localRow]!;
-      const sourceRow =
-        frame.inputSourceRows?.[localRow] ?? facetPanel.sourceRows?.[localRow] ?? localRow;
+      const sourceRow = globalSourceRowForInputRow(frame, localRow);
       const members = membersByGroup.get(group);
       if (members === undefined) membersByGroup.set(group, [sourceRow]);
       else members.push(sourceRow);
@@ -159,8 +157,7 @@ export function buildBinLineageBuckets(input: {
     if (!Number.isFinite(value)) continue;
     const idx = findBinIndex(value, bins, closed);
     if (idx < 0) continue;
-    const sourceRow =
-      frame.inputSourceRows?.[localRow] ?? facetPanel.sourceRows?.[localRow] ?? localRow;
+    const sourceRow = globalSourceRowForInputRow(frame, localRow);
     bins[idx]!.bucket.push(sourceRow);
   }
 }

--- a/packages/core/src/pipeline/candidate-construction/identity-index.ts
+++ b/packages/core/src/pipeline/candidate-construction/identity-index.ts
@@ -8,6 +8,7 @@ import {
   appendSourceRowByGroupX,
   buildBinLineageBuckets,
 } from "./identity-buckets.js";
+import { globalSourceRowForInputRow } from "../source-row-lineage.js";
 
 export interface CandidateIdentityIndex {
   readonly seriesByRow: Map<string, number>;
@@ -37,7 +38,7 @@ export interface CandidateIdentityIndex {
 
 export function buildCandidateIdentityIndex(
   panelFrames: readonly (readonly LayerFrame[])[],
-  facetPanels: readonly FacetPanelDef[],
+  _facetPanels: readonly FacetPanelDef[],
 ): CandidateIdentityIndex {
   const seriesByRow = new Map<string, number>();
   const sourceRowsByGroup = new Map<string, number[]>();
@@ -56,11 +57,7 @@ export function buildCandidateIdentityIndex(
       // Only count/summary/boxplot resolve via group×x buckets; skip for other layers.
       const bucketByX = stat === "count" || stat === "summary" || stat === "boxplot";
       const xField = frame.binding.xField;
-      // localRow → sourceRow invariant: panel-local table indexes drive
-      // parse/finite-y membership; stored memberships are always source-table
-      // rows via `facetPanel.sourceRows?.[localRow] ?? localRow` (unfaceted =
-      // identity). Faceted temporal summary/count must not intern localRow into
-      // LineageStore keys (#437).
+      // Panel-local input rows → finalized global source ids (issue #626).
       const yField = frame.binding.yField;
       const finiteY =
         (stat === "smooth" || stat === "summary" || stat === "boxplot") && yField !== null;
@@ -86,10 +83,7 @@ export function buildCandidateIdentityIndex(
           : null;
       for (let localRow = 0; localRow < inputGroups.length; localRow++) {
         const group = inputGroups[localRow]!;
-        const sourceRow =
-          frame.inputSourceRows?.[localRow] ??
-          facetPanels[panelIndex]!.sourceRows?.[localRow] ??
-          localRow;
+        const sourceRow = globalSourceRowForInputRow(frame, localRow);
         const key = `${frameKey}:${group}`;
         appendSourceRowByGroupKey(sourceRowsByGroup, key, sourceRow);
         if (bucketByX && xField !== null) {
@@ -118,7 +112,6 @@ export function buildCandidateIdentityIndex(
           frame,
           panelIndex,
           layerIndex,
-          facetPanel: facetPanels[panelIndex]!,
           sourceRowsByGroupBin,
         });
       }

--- a/packages/core/src/pipeline/frame.ts
+++ b/packages/core/src/pipeline/frame.ts
@@ -5,7 +5,6 @@
 import type { ColumnTable } from "../table.js";
 
 import type { Advisory, LayerBinding, LayerFrame, PipelineWarning } from "./types.js";
-import { NO_ROW } from "./types.js";
 import { buildAnnotationFrame } from "./frame-annotation.js";
 import { expandEdgeFrame } from "./frame-edge-expand.js";
 import { deriveLayerGroups } from "./frame-helpers.js";
@@ -44,16 +43,4 @@ export function buildFrame(
   const frame = { ...buildIdentityFrame(binding, table, inputGroups), inputGroups };
   expandEdgeFrame(frame, warnings);
   return frame;
-}
-
-/**
- * Facet frames index into the PANEL table; hit-testing/tooltips need SOURCE
- * rows, so remap through the partition (NO_ROW stays NO_ROW).
- */
-export function remapSourceRows(frame: LayerFrame, sourceRows: number[] | null): void {
-  if (sourceRows === null) return;
-  for (let i = 0; i < frame.rowIndex.length; i++) {
-    const local = frame.rowIndex[i]!;
-    if (local !== NO_ROW) frame.rowIndex[i] = sourceRows[local]!;
-  }
 }

--- a/packages/core/src/pipeline/layer-panel-data.ts
+++ b/packages/core/src/pipeline/layer-panel-data.ts
@@ -11,7 +11,6 @@ import type { ColumnTable } from "../table.js";
 
 import type { FacetPanelDef } from "./facets-types.js";
 import type { SourceRegistry } from "./source-registry.js";
-import { NO_ROW } from "./types-no-row.js";
 
 export interface LayerPanelSlice {
   table: ColumnTable;
@@ -116,16 +115,4 @@ export function sliceLayerForPanel(input: {
     return { table: filteredTable, globalSourceRows };
   }
   return { table: filteredTable.subset(keep), globalSourceRows };
-}
-
-/** Remap frame.rowIndex panel-local indices through globalSourceRows. */
-export function remapToGlobalSourceRows(
-  rowIndex: Uint32Array,
-  globalSourceRows: readonly number[],
-): void {
-  for (let i = 0; i < rowIndex.length; i++) {
-    const local = rowIndex[i]!;
-    if (local === NO_ROW) continue;
-    rowIndex[i] = globalSourceRows[local] ?? NO_ROW;
-  }
 }

--- a/packages/core/src/pipeline/prepare-panels-frames.ts
+++ b/packages/core/src/pipeline/prepare-panels-frames.ts
@@ -10,7 +10,8 @@ import { configureStyleBindings } from "./bind-layer-style-config.js";
 import type { FacetPanelDef } from "./facets.js";
 import { styleBinExtent } from "./frame-group-columns.js";
 import { buildFrame } from "./frame.js";
-import { remapToGlobalSourceRows, sliceLayerForPanel } from "./layer-panel-data.js";
+import { finalizeFrameSourceRows } from "./source-row-lineage.js";
+import { sliceLayerForPanel } from "./layer-panel-data.js";
 import { applyPosition } from "./position.js";
 import { resolveColumnTransform } from "./position-program.js";
 import { assertInferredTemporalTransform } from "./scale-config-preflight.js";
@@ -335,15 +336,7 @@ export function buildPanelFrames(input: {
       // Annotation frames are rowless — do not retain the full panel source-row
       // array (can be huge under facets) when there is no lineage to resolve.
       if (bindings[index]!.ruleForm !== "annotation") {
-        // Pre-stat input rows and post-stat mark rows share the layer's global
-        // source-row namespace (filter + multi-table registry).
-        frame.inputSourceRows = slice.globalSourceRows;
-        // Map panel-local indices → global multi-table source rows.
-        remapToGlobalSourceRows(frame.rowIndex, slice.globalSourceRows);
-        // Boxplot outlier rows carry separate source indices.
-        if (frame.box !== null) {
-          remapToGlobalSourceRows(frame.box.outlierRow, slice.globalSourceRows);
-        }
+        finalizeFrameSourceRows(frame, slice);
       }
       assertRibbonBounds(frame);
       panelFrames[p]!.push(frame);

--- a/packages/core/src/pipeline/source-row-lineage.ts
+++ b/packages/core/src/pipeline/source-row-lineage.ts
@@ -27,7 +27,7 @@ export interface PanelSourceRowMap {
 }
 
 /** Remap panel-local indices in place through a finalized global map. */
-export function remapPanelLocalIndicesToGlobal(
+function remapPanelLocalIndicesToGlobal(
   rowIndex: Uint32Array,
   globalSourceRows: readonly number[],
 ): void {

--- a/packages/core/src/pipeline/source-row-lineage.ts
+++ b/packages/core/src/pipeline/source-row-lineage.ts
@@ -1,0 +1,69 @@
+/**
+ * Source-row lineage: owns conversion from panel-local rows to finalized
+ * global SourceRegistry ids (#626).
+ *
+ * Namespaces:
+ * - **filtered-local** — index into a layer table after row filters
+ * - **panel-local** — index into a facet-panel slice of that table
+ * - **source-local** — index into one physical source table (per sourceId)
+ * - **global** — contiguous multi-table id from {@link SourceRegistry}
+ *
+ * After {@link finalizeFrameSourceRows}, downstream modules consume only
+ * global ids via {@link globalSourceRowForInputRow} and finalized mark rows.
+ */
+import type { LayerFrame } from "./types-layer-frame.js";
+import { NO_ROW } from "./types-no-row.js";
+
+export class SourceRowLineageError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SourceRowLineageError";
+  }
+}
+
+/** Panel-local row → global source-row id map produced during facet slicing. */
+export interface PanelSourceRowMap {
+  readonly globalSourceRows: readonly number[];
+}
+
+/** Remap panel-local indices in place through a finalized global map. */
+export function remapPanelLocalIndicesToGlobal(
+  rowIndex: Uint32Array,
+  globalSourceRows: readonly number[],
+): void {
+  for (let i = 0; i < rowIndex.length; i++) {
+    const local = rowIndex[i]!;
+    if (local === NO_ROW) continue;
+    const global = globalSourceRows[local];
+    rowIndex[i] = global ?? NO_ROW;
+  }
+}
+
+/**
+ * Attach finalized global source-row ids to a frame after panel slice.
+ * Post-stat mark rows and boxplot outliers are remapped in place.
+ */
+export function finalizeFrameSourceRows(frame: LayerFrame, map: PanelSourceRowMap): void {
+  frame.inputSourceRows = [...map.globalSourceRows];
+  remapPanelLocalIndicesToGlobal(frame.rowIndex, map.globalSourceRows);
+  if (frame.box !== null) {
+    remapPanelLocalIndicesToGlobal(frame.box.outlierRow, map.globalSourceRows);
+  }
+}
+
+/** Global source-row id for one pre-stat panel-local input row. */
+export function globalSourceRowForInputRow(frame: LayerFrame, panelLocalRow: number): number {
+  const map = frame.inputSourceRows;
+  if (map === null) {
+    throw new SourceRowLineageError(
+      "Frame inputSourceRows is unset; finalize source-row lineage before candidate construction",
+    );
+  }
+  const global = map[panelLocalRow];
+  if (global === undefined) {
+    throw new SourceRowLineageError(
+      `Panel-local row ${panelLocalRow} is out of range for finalized inputSourceRows (length ${map.length})`,
+    );
+  }
+  return global;
+}

--- a/packages/core/src/pipeline/types-layer-frame.ts
+++ b/packages/core/src/pipeline/types-layer-frame.ts
@@ -46,8 +46,8 @@ export interface LayerFrame {
   inputGroups: readonly number[];
   /**
    * Global source-row id per pre-stat input table row (multi-table SourceRegistry
-   * ids after filter/facet remap). Length is `table.rowCount`. Used by aggregate
-   * lineage when FacetPanelDef.sourceRows is not layer-local (#589).
+   * ids after filter/facet remap). Length is `table.rowCount`. Set by
+   * {@link finalizeFrameSourceRows} during panel assembly (#626).
    */
   inputSourceRows: number[] | null;
   /** Source row per post-stat row (NO_ROW for synthesized rows). */

--- a/packages/core/tests/candidate-construction/bin-lineage-buckets.test.ts
+++ b/packages/core/tests/candidate-construction/bin-lineage-buckets.test.ts
@@ -58,6 +58,7 @@ describe("buildBinLineageBuckets missing-edges fallback (issue #218)", () => {
       n: groups.length,
       groups,
       inputGroups,
+      inputSourceRows: [0, 1, 2, 3, 4],
       xmin: null,
       xmax: null,
     });
@@ -66,7 +67,6 @@ describe("buildBinLineageBuckets missing-edges fallback (issue #218)", () => {
       frame,
       panelIndex: 0,
       layerIndex: 0,
-      facetPanel: fromAny({ sourceRows: null }),
       sourceRowsByGroupBin,
     });
 
@@ -76,7 +76,7 @@ describe("buildBinLineageBuckets missing-edges fallback (issue #218)", () => {
     expect(sourceRowsByGroupBin.get("0:0:1:3")).toEqual([1, 3]);
   });
 
-  it("remaps through facetPanel.sourceRows in first-seen order", async () => {
+  it("uses finalized inputSourceRows for global lineage ids", async () => {
     const buildBinLineageBuckets = await loadBuildBinLineageBuckets();
     const table = ColumnTable.fromRows([
       { g: "a", x: 1 },
@@ -91,6 +91,7 @@ describe("buildBinLineageBuckets missing-edges fallback (issue #218)", () => {
       n: groups.length,
       groups,
       inputGroups,
+      inputSourceRows: [10, 20, 30],
       xmin: null,
       xmax: null,
     });
@@ -99,7 +100,6 @@ describe("buildBinLineageBuckets missing-edges fallback (issue #218)", () => {
       frame,
       panelIndex: 2,
       layerIndex: 1,
-      facetPanel: fromAny({ sourceRows: [10, 20, 30] }),
       sourceRowsByGroupBin,
     });
 
@@ -127,6 +127,7 @@ describe("buildBinLineageBuckets missing-edges fallback (issue #218)", () => {
       n: k,
       groups,
       inputGroups,
+      inputSourceRows: Array.from({ length: n }, (_, i) => i),
       xmin: null,
       xmax: null,
     });
@@ -135,7 +136,6 @@ describe("buildBinLineageBuckets missing-edges fallback (issue #218)", () => {
       frame,
       panelIndex: 0,
       layerIndex: 0,
-      facetPanel: fromAny({ sourceRows: null }),
       sourceRowsByGroupBin,
     });
 

--- a/packages/core/tests/candidate-construction/series-and-outlier.test.ts
+++ b/packages/core/tests/candidate-construction/series-and-outlier.test.ts
@@ -53,13 +53,11 @@ describe("resolveOutlierContext", () => {
         frame: undefined,
         batch: fromAny({ kind: "points" }),
         primitiveIndex: 0,
-        facetPanel: undefined,
       }),
     ).toEqual({ outlierLocalRow: null, outlierSourceRow: null });
   });
 
-  // #609 — outlierRow is already global after prepare-panels remap; do not
-  // re-index through facetPanel.sourceRows (double remap).
+  // #609 — outlierRow is already global after finalizeFrameSourceRows.
   it("treats boxplot outlierRow as already-global source ids", async () => {
     const { resolveOutlierContext } =
       await import("../../src/pipeline/candidate-construction/datum.ts");
@@ -70,8 +68,6 @@ describe("resolveOutlierContext", () => {
       }),
       batch: fromAny({ kind: "points" }),
       primitiveIndex: 0,
-      // A non-empty sourceRows would wrongly remap 42 → sourceRows[42] if still panel-local.
-      facetPanel: fromAny({ sourceRows: Array.from({ length: 50 }, (_, i) => i + 1000) }),
     });
     expect(result.outlierSourceRow).toBe(42);
     expect(result.outlierLocalRow).toBe(42);

--- a/packages/core/tests/pipeline-frame/remap-source-rows.test.ts
+++ b/packages/core/tests/pipeline-frame/remap-source-rows.test.ts
@@ -1,14 +1,15 @@
 /**
- * remapSourceRows unit characterization.
+ * finalizeFrameSourceRows characterization (formerly remapSourceRows).
  */
 import { describe, expect, it } from "bun:test";
 
 import { bindLayer } from "../../src/pipeline/bind.ts";
-import { buildFrame, remapSourceRows } from "../../src/pipeline/frame.ts";
+import { buildFrame } from "../../src/pipeline/frame.ts";
+import { finalizeFrameSourceRows } from "../../src/pipeline/source-row-lineage.ts";
 import { NO_ROW } from "../../src/pipeline/types.ts";
 import { ColumnTable } from "../../src/table.ts";
 
-describe("remapSourceRows", () => {
+describe("finalizeFrameSourceRows", () => {
   it("rewrites local panel rows to source rows, leaving NO_ROW alone", () => {
     const table = ColumnTable.fromRows([
       { x: 1, y: 1 },
@@ -23,8 +24,9 @@ describe("remapSourceRows", () => {
     const frame = buildFrame(binding, table, [], []);
     frame.rowIndex[0] = 0;
     frame.rowIndex[1] = NO_ROW;
-    remapSourceRows(frame, [10, 20]);
+    finalizeFrameSourceRows(frame, { globalSourceRows: [10, 20] });
     expect(frame.rowIndex[0]).toBe(10);
     expect(frame.rowIndex[1]).toBe(NO_ROW);
+    expect(frame.inputSourceRows).toEqual([10, 20]);
   });
 });

--- a/packages/core/tests/source-row-lineage.test.ts
+++ b/packages/core/tests/source-row-lineage.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Source-row lineage: one owned conversion seam (#626).
+ */
+import { describe, expect, it } from "bun:test";
+
+import type { LayerFrame } from "../src/pipeline/types-layer-frame.ts";
+import { NO_ROW } from "../src/pipeline/types-no-row.ts";
+
+describe("globalSourceRowForInputRow", () => {
+  it("returns the finalized global id for a panel-local input row", async () => {
+    const { globalSourceRowForInputRow } = await import("../src/pipeline/source-row-lineage.ts");
+    const frame = { inputSourceRows: [100, 200, 300] } as LayerFrame;
+    expect(globalSourceRowForInputRow(frame, 1)).toBe(200);
+  });
+
+  it("throws when inputSourceRows was not finalized", async () => {
+    const { globalSourceRowForInputRow, SourceRowLineageError } =
+      await import("../src/pipeline/source-row-lineage.ts");
+    const frame = { inputSourceRows: null } as LayerFrame;
+    expect(() => globalSourceRowForInputRow(frame, 0)).toThrow(SourceRowLineageError);
+  });
+});
+
+describe("finalizeFrameSourceRows", () => {
+  it("sets inputSourceRows and remaps mark rows to global ids", async () => {
+    const { finalizeFrameSourceRows } = await import("../src/pipeline/source-row-lineage.ts");
+    const rowIndex = new Uint32Array([0, 1, NO_ROW]);
+    const outlierRow = new Uint32Array([1]);
+    const frame = {
+      inputSourceRows: null,
+      rowIndex,
+      box: { outlierRow },
+    } as LayerFrame;
+    finalizeFrameSourceRows(frame, { globalSourceRows: [10, 20] });
+    expect(frame.inputSourceRows).toEqual([10, 20]);
+    expect([...rowIndex]).toEqual([10, 20, NO_ROW]);
+    expect([...outlierRow]).toEqual([20]);
+  });
+});


### PR DESCRIPTION
## Summary
- Introduces `source-row-lineage.ts` as the single seam for converting panel-local rows to finalized global SourceRegistry ids (`finalizeFrameSourceRows`, `globalSourceRowForInputRow`).
- Wires panel assembly and candidate identity construction through that module, removing distributed fallback chains (`inputSourceRows ?? facetPanel.sourceRows ?? localRow`) and the unused `facetPanel` parameter on outlier/bin lineage paths.
- Adds focused lineage-module tests (TDD tracer bullets) plus updates bin/outlier unit tests to assert finalized `inputSourceRows` behavior.

## Test plan
- [x] `bun test packages/core/tests/source-row-lineage.test.ts`
- [x] `bun test packages/core` (1236 tests)
- [x] Existing faceted boxplot outlier lineage regression in `pipeline-layer-data.test.ts` still passes

Closes #626


Made with [Cursor](https://cursor.com)