### PR TITLE
fix(core,spec): multi-table DataRef Codex P2 follow-ups from #603

### DIFF
--- a/.changeset/sweep-603-dataref-p2s.md
+++ b/.changeset/sweep-603-dataref-p2s.md
@@ -1,0 +1,15 @@
+---
+"@ggsvelte/core": patch
+"@ggsvelte/spec": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+fix: multi-table DataRef post-merge edges from #603
+
+- Seed named table cache from plot-level named data
+- Deduplicate plot+layer named refs in validation maxRows
+- Snapshot data on builder .layer()
+- Unify binned style binExtent across layers
+- Gate legend rowFilters to layers that map the scale field
+- Skip globalSourceRows retention on annotation frames

--- a/packages/core/src/pipeline/prepare-panels-frames.ts
+++ b/packages/core/src/pipeline/prepare-panels-frames.ts
@@ -8,6 +8,7 @@ import type { ColumnTable } from "../table.js";
 import { bindLayer } from "./bind.js";
 import { configureStyleBindings } from "./bind-layer-style-config.js";
 import type { FacetPanelDef } from "./facets.js";
+import { styleBinExtent } from "./frame-group-columns.js";
 import { buildFrame } from "./frame.js";
 import { remapToGlobalSourceRows, sliceLayerForPanel } from "./layer-panel-data.js";
 import { applyPosition } from "./position.js";
@@ -23,6 +24,40 @@ import { preflightTemporalBindings } from "./temporal-preflight.js";
 import type { ColumnTransformConfig } from "../scales/transform.js";
 
 const DOCS = "https://ggsvelte.sh/guide/errors";
+
+const STYLE_AESTHETICS = ["size", "linewidth", "alpha", "shape", "linetype"] as const;
+
+/**
+ * After per-layer configureStyleBindings, pin the same binExtent on every
+ * binding that trains a global binned style scale without authored breaks/domain.
+ */
+function unifyBinnedStyleExtents(
+  bindings: readonly LayerBinding[],
+  tables: readonly ColumnTable[],
+  scales: PortableSpec["scales"] | undefined,
+): void {
+  for (const aesthetic of STYLE_AESTHETICS) {
+    const config = scales?.[aesthetic];
+    if (config?.type !== "binned") continue;
+    if (config.breaks !== undefined || config.domain !== undefined) continue;
+    let low = Number.POSITIVE_INFINITY;
+    let high = Number.NEGATIVE_INFINITY;
+    for (let index = 0; index < bindings.length; index++) {
+      const style = bindings[index]![aesthetic];
+      if (style.binned !== true || style.field === null) continue;
+      const extent = styleBinExtent(style, tables[index]!);
+      if (extent === undefined) continue;
+      low = Math.min(low, extent[0]);
+      high = Math.max(high, extent[1]);
+    }
+    if (!Number.isFinite(low)) continue;
+    const unified: readonly [number, number] = [low, high];
+    for (const binding of bindings) {
+      const style = binding[aesthetic];
+      if (style.binned === true && style.field !== null) style.binExtent = unified;
+    }
+  }
+}
 
 /** Up to `limit` finite semantic values that failed the transform (invalid). */
 function sampleFailingSemantic(
@@ -207,6 +242,9 @@ export function buildPanelFrames(input: {
     configureStyleBindings(binding, normalized.scales, ctx.filteredTable);
     bindings.push(binding);
   }
+  // Unify binned style extents across layers that share a global style scale so
+  // default grouping bins match the multi-layer-trained legend (not layer-local).
+  unifyBinnedStyleExtents(bindings, filteredLayerTables, normalized.scales);
   const temporal = preflightTemporalBindings({
     table: layerContexts[0]!.sourceTable,
     bindings,
@@ -294,14 +332,18 @@ export function buildPanelFrames(input: {
         binRanges[index],
       );
       applyPosition(frame, advisories, slice.table);
-      // Pre-stat input rows and post-stat mark rows share the layer's global
-      // source-row namespace (filter + multi-table registry).
-      frame.inputSourceRows = slice.globalSourceRows;
-      // Map panel-local indices → global multi-table source rows.
-      remapToGlobalSourceRows(frame.rowIndex, slice.globalSourceRows);
-      // Boxplot outlier rows carry separate source indices.
-      if (frame.box !== null) {
-        remapToGlobalSourceRows(frame.box.outlierRow, slice.globalSourceRows);
+      // Annotation frames are rowless — do not retain the full panel source-row
+      // array (can be huge under facets) when there is no lineage to resolve.
+      if (bindings[index]!.ruleForm !== "annotation") {
+        // Pre-stat input rows and post-stat mark rows share the layer's global
+        // source-row namespace (filter + multi-table registry).
+        frame.inputSourceRows = slice.globalSourceRows;
+        // Map panel-local indices → global multi-table source rows.
+        remapToGlobalSourceRows(frame.rowIndex, slice.globalSourceRows);
+        // Boxplot outlier rows carry separate source indices.
+        if (frame.box !== null) {
+          remapToGlobalSourceRows(frame.box.outlierRow, slice.globalSourceRows);
+        }
       }
       assertRibbonBounds(frame);
       panelFrames[p]!.push(frame);

--- a/packages/core/src/pipeline/prepare-panels.ts
+++ b/packages/core/src/pipeline/prepare-panels.ts
@@ -86,11 +86,9 @@ function layerMapsLegendFilter(
   clause: NonNullable<RunOptions["rowFilters"]>[number],
 ): boolean {
   const channel = clause.scale;
-  const layerAes = layer.aes as Record<string, unknown> | undefined;
-  const plot = plotAes as Record<string, unknown> | undefined;
-  const mapped = layerAes?.[channel] ?? plot?.[channel];
+  const mapped = layer.aes?.[channel] ?? plotAes?.[channel];
   if (mapped === undefined || mapped === null || typeof mapped !== "object") return false;
-  return "field" in mapped && (mapped as { field: unknown }).field === clause.field;
+  return "field" in mapped && mapped.field === clause.field;
 }
 
 /** Apply rowFilters only for clauses this layer maps on the matching scale. */

--- a/packages/core/src/pipeline/prepare-panels.ts
+++ b/packages/core/src/pipeline/prepare-panels.ts
@@ -76,13 +76,36 @@ function unionFacetKeyColumns(
   return ColumnTable.fromColumns(columns);
 }
 
-/** Apply rowFilters only for clauses whose field exists on this layer table. */
+/**
+ * Whether this layer's effective aes maps `clause.scale` to `clause.field`.
+ * Legend filters must not hide layers that merely have a same-named column.
+ */
+function layerMapsLegendFilter(
+  layer: PortableSpec["layers"][number],
+  plotAes: PortableSpec["aes"],
+  clause: NonNullable<RunOptions["rowFilters"]>[number],
+): boolean {
+  const channel = clause.scale;
+  const layerAes = layer.aes as Record<string, unknown> | undefined;
+  const plot = plotAes as Record<string, unknown> | undefined;
+  const mapped = layerAes?.[channel] ?? plot?.[channel];
+  if (mapped === undefined || mapped === null || typeof mapped !== "object") return false;
+  return "field" in mapped && (mapped as { field: unknown }).field === clause.field;
+}
+
+/** Apply rowFilters only for clauses this layer maps on the matching scale. */
 function filterLayerTable(
   table: ColumnTable,
   clauses: RunOptions["rowFilters"],
+  layer?: PortableSpec["layers"][number],
+  plotAes?: PortableSpec["aes"],
 ): { table: ColumnTable; sourceRows: number[] | null } {
   if (clauses === undefined || clauses.length === 0) return { table, sourceRows: null };
-  const applicable = clauses.filter((c) => table.has(c.field));
+  const applicable = clauses.filter((c) => {
+    if (!table.has(c.field)) return false;
+    if (layer === undefined) return true;
+    return layerMapsLegendFilter(layer, plotAes, c);
+  });
   return applyRuntimeRowFilters(table, applicable);
 }
 
@@ -97,6 +120,18 @@ export function preparePanels(
   // Reuse ColumnTable instances for identical named refs so shared datasets
   // share SourceRegistry namespaces (and therefore source-row identity).
   const namedTableCache = new Map<string, ColumnTable>();
+  // Seed from plot-level named data so an explicit layer `data: { name }` that
+  // matches the plot ref reuses the same table (and registry row range).
+  const plotData = normalized.data;
+  if (
+    plotSource !== null &&
+    plotData !== undefined &&
+    "name" in plotData &&
+    !("values" in plotData) &&
+    !("columns" in plotData)
+  ) {
+    namedTableCache.set(plotData.name, plotSource);
+  }
 
   const layerContexts: LayerDataContext[] = [];
   for (let index = 0; index < normalized.layers.length; index++) {
@@ -126,7 +161,7 @@ export function preparePanels(
       }
     }
     const sourceId = registry.register(sourceTable);
-    const filtered = filterLayerTable(sourceTable, options.rowFilters);
+    const filtered = filterLayerTable(sourceTable, options.rowFilters, layer, normalized.aes);
     layerContexts.push({
       sourceTable,
       filteredTable: filtered.table,

--- a/packages/core/tests/pipeline-layer-data.test.ts
+++ b/packages/core/tests/pipeline-layer-data.test.ts
@@ -532,4 +532,82 @@ describe("multi-table edges (#609)", () => {
     expect(keys).toEqual([5]);
     expect(model.row(5)?.y).toBe(100);
   });
+
+  it("shares source-row identity for plot named ref and explicit layer named ref", () => {
+    // Same name:"cars" at plot and layer must reuse one ColumnTable / registry range.
+    const model = runPipeline(
+      {
+        data: { name: "cars" },
+        datasets: { cars: { values: obs } },
+        layers: [
+          { geom: "point", aes: { x: { field: "x" }, y: { field: "y" } } },
+          {
+            geom: "point",
+            data: { name: "cars" },
+            aes: { x: { field: "x" }, y: { field: "y" } },
+          },
+        ],
+      },
+      size,
+    );
+    // Four source rows once — not 8 from a double registry registration.
+    expect(model.row(0)).toMatchObject({ x: 1, y: 10 });
+    expect(model.row(3)).toMatchObject({ x: 4, y: 25 });
+    expect(model.row(4) == null).toBe(true);
+  });
+
+  it("does not apply a color legend filter to layers that do not map color", () => {
+    // Layer 1 maps color:group; layer 2 has a group column for faceting only.
+    const model = runPipeline(
+      {
+        layers: [
+          {
+            geom: "point",
+            data: {
+              values: [
+                { x: 1, y: 1, group: "a" },
+                { x: 2, y: 2, group: "b" },
+              ],
+            },
+            aes: { x: { field: "x" }, y: { field: "y" }, color: { field: "group" } },
+          },
+          {
+            geom: "point",
+            data: {
+              values: [
+                { x: 3, y: 3, group: "a" },
+                { x: 4, y: 4, group: "b" },
+              ],
+            },
+            aes: { x: { field: "x" }, y: { field: "y" } },
+          },
+        ],
+      },
+      {
+        ...size,
+        rowFilters: [{ scale: "color", field: "group", mode: "exclude", values: ["a"] }],
+      },
+    );
+    // Layer 1 loses group "a"; layer 2 keeps both rows (no color mapping).
+    expect(markCount(model, "points")).toBe(3);
+  });
+
+  it("does not retain panel source rows on annotation frames", () => {
+    const model = runPipeline(
+      {
+        data: { values: obs },
+        layers: [
+          { geom: "point", aes: { x: { field: "x" }, y: { field: "y" } } },
+          { geom: "rule", params: { yintercept: 15 } },
+        ],
+      },
+      size,
+    );
+    // Annotation batch has no source rows; rowIndex sentinel remains NO_ROW.
+    const rule = model.scene.batches.find((b) => b.kind === "segments" || b.kind === "paths");
+    expect(rule).toBeDefined();
+    if (rule !== undefined) {
+      for (const row of rule.rowIndex) expect(row).toBe(0xffffffff);
+    }
+  });
 });

--- a/packages/core/tests/pipeline-layer-data.test.ts
+++ b/packages/core/tests/pipeline-layer-data.test.ts
@@ -553,7 +553,7 @@ describe("multi-table edges (#609)", () => {
     // Four source rows once — not 8 from a double registry registration.
     expect(model.row(0)).toMatchObject({ x: 1, y: 10 });
     expect(model.row(3)).toMatchObject({ x: 4, y: 25 });
-    expect(model.row(4) == null).toBe(true);
+    expect(model.row(4)).toBeNull();
   });
 
   it("does not apply a color legend filter to layers that do not map color", () => {

--- a/packages/core/tests/pipeline-temporal/stats-facets.test.ts
+++ b/packages/core/tests/pipeline-temporal/stats-facets.test.ts
@@ -42,7 +42,7 @@ describe("temporal pipeline: stats and facets", () => {
       { when: "05/06/2024", value: 3, visibility: "keep" },
     ];
     const model = runPipeline(
-      gg(rows, aes({ x: "when", y: "value" }))
+      gg(rows, aes({ x: "when", y: "value", color: "visibility" }))
         .geomErrorbar({ stat: "summary" })
         .spec(),
       {

--- a/packages/core/tests/runtime-filter-pipeline.test.ts
+++ b/packages/core/tests/runtime-filter-pipeline.test.ts
@@ -59,7 +59,8 @@ describe("runPipeline runtime row filters", () => {
     const model = runPipeline(
       {
         data: { values: rows },
-        aes: { x: "group" },
+        // fill maps the filtered field so the legend-scale gate applies the clause.
+        aes: { x: "group", fill: "group" },
         layers: [{ geom: "bar" as const }],
       },
       {
@@ -141,7 +142,7 @@ describe("runPipeline runtime row filters", () => {
   test("filters before count stats, positional scale training, and axis layout", () => {
     const countSpec = {
       data: { values: rows },
-      aes: { x: "group" },
+      aes: { x: "group", fill: "group" },
       layers: [{ geom: "bar" as const }],
     };
     const initial = runPipeline(countSpec, size);

--- a/packages/spec/src/builder-core.ts
+++ b/packages/spec/src/builder-core.ts
@@ -122,7 +122,16 @@ export class GGBuilderCore {
 
   /** Add a layer (canonical form — the geom* methods are sugar for this). */
   layer(layer: LayerInput): GGBuilder {
-    return this.#with({ layers: [...this.#state.layers, layer] });
+    // Snapshot authoring data at insertion (same as geom* sugar via layerFrom)
+    // so later mutation of caller-owned arrays cannot leak into .spec().
+    if (layer.data === undefined) {
+      return this.#with({ layers: [...this.#state.layers, layer] });
+    }
+    const snapped = {
+      ...layer,
+      data: toAuthoringDataRef(layer.data as DataInput),
+    } as LayerInput;
+    return this.#with({ layers: [...this.#state.layers, snapped] });
   }
 
   /** Sugar for .layer({ geom: 'point', ... }). */

--- a/packages/spec/src/builder-core.ts
+++ b/packages/spec/src/builder-core.ts
@@ -127,10 +127,9 @@ export class GGBuilderCore {
     if (layer.data === undefined) {
       return this.#with({ layers: [...this.#state.layers, layer] });
     }
-    const snapped = {
-      ...layer,
-      data: toAuthoringDataRef(layer.data as DataInput),
-    } as LayerInput;
+    // layer.data is AuthoringDataRef at rest; cast through DataInput for snapshot.
+    const data: DataInput = layer.data;
+    const snapped = { ...layer, data: toAuthoringDataRef(data) } as LayerInput;
     return this.#with({ layers: [...this.#state.layers, snapped] });
   }
 

--- a/packages/spec/src/validate-data-evidence.ts
+++ b/packages/spec/src/validate-data-evidence.ts
@@ -211,7 +211,16 @@ export function resolveLayerFieldEvidence(
     totalRows += rowCount;
     totalBytes += estimateBytes(columns, rowCount);
   };
-  if (plotColumns !== null) countTable("__plot__", plotColumns);
+  if (plotColumns !== null) {
+    // Prefer name: key so plot-level { name } matching a layer named ref is not
+    // double-counted toward maxRows (same embedded/named dataset once).
+    const plotData = spec["data"];
+    const plotKey =
+      isRecord(plotData) && typeof plotData["name"] === "string"
+        ? `name:${plotData["name"]}`
+        : "__plot__";
+    countTable(plotKey, plotColumns);
+  }
 
   const layers = Array.isArray(spec["layers"]) ? (spec["layers"] as unknown[]) : [];
   const layerColumns: Array<Record<string, readonly CellValue[]> | null | "runtime"> = [];

--- a/packages/spec/tests/layer-data.test.ts
+++ b/packages/spec/tests/layer-data.test.ts
@@ -175,4 +175,46 @@ describe("layer data builder", () => {
     expect(spec.layers[1]!.data).toEqual({ values: bands });
     expect(spec.data).toBeUndefined();
   });
+
+  it("snapshots data passed to .layer() so later mutation cannot leak", () => {
+    const rows = [
+      { x: 1, y: 2 },
+      { x: 3, y: 4 },
+    ];
+    const builder = gg().layer({
+      geom: "point",
+      data: { values: rows },
+      aes: { x: { field: "x" }, y: { field: "y" } },
+    });
+    rows[0]!.x = 999;
+    const spec = builder.spec();
+    expect(spec.layers[0]!.data).toEqual({
+      values: [
+        { x: 1, y: 2 },
+        { x: 3, y: 4 },
+      ],
+    });
+  });
+});
+
+describe("layer data validation limits", () => {
+  it("does not double-count plot named ref and matching layer named ref toward maxRows", () => {
+    const values = Array.from({ length: 60_000 }, (_, i) => ({ x: i, y: i }));
+    const result = validate(
+      {
+        data: { name: "cars" },
+        datasets: { cars: { values } },
+        layers: [
+          { geom: "point", aes: { x: { field: "x" }, y: { field: "y" } } },
+          {
+            geom: "point",
+            data: { name: "cars" },
+            aes: { x: { field: "x" }, y: { field: "y" } },
+          },
+        ],
+      },
+      { limits: { maxRows: 100_000 } },
+    );
+    expect(result.ok).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

Follow-up for unrebutted post-merge Codex P2s on #603 (per-layer DataRef).

| Finding | Fix |
|---------|-----|
| Seed named cache with plot refs | `namedTableCache` seeded from plot-level `{ name }` |
| Deduplicate plot named refs in limits | maxRows accounting uses `name:<n>` for plot named data |
| Snapshot data via `.layer()` | `toAuthoringDataRef` at `.layer()` insertion |
| Align binned style grouping | `unifyBinnedStyleExtents` across layer tables |
| Gate legend row filters | apply only when layer maps that scale→field |
| Avoid annotation source rows | skip `inputSourceRows` remap for annotation rule frames |

## Tests

- `bun test packages/core/tests/pipeline-layer-data.test.ts packages/spec/tests/layer-data.test.ts`
- `bun run check`