### PR TITLE
svelte: replace cyclic interaction wiring with one transition owner (#627)

### DIFF
--- a/packages/svelte/src/lib/inspection/inspection-state.svelte.ts
+++ b/packages/svelte/src/lib/inspection/inspection-state.svelte.ts
@@ -21,7 +21,8 @@
 import type { CandidateFacts, CellValue, RenderModel, ScenePanel } from "@ggsvelte/core";
 
 import { createInspectionCoordinator } from "./coordinator.js";
-import type { createInteractionReducer, InteractionAction } from "../interaction/reducer.js";
+import type { InteractionAction } from "../interaction/reducer.js";
+import type { InteractionTransitionPort } from "../interaction/transition-port.js";
 import type {
   InteractionSource,
   PlotInspection,
@@ -56,19 +57,13 @@ import {
 // Public types
 // ---------------------------------------------------------------------------
 
-/** Component-held reducer shape — factory-only export from interaction/reducer. */
-type InteractionReducer = ReturnType<typeof createInteractionReducer>;
-
 /** Inspect frame action delivered to onPointerFrame (non-move-area branch). */
 type InspectPointerFrameAction = Extract<InteractionAction, { type: "inspect" }>;
 
 export type InspectionStateDeps = {
   model: () => RenderModel | null;
-  /**
-   * Component-held reducer (plan mandate). Deferred: declared AFTER the
-   * factory — handler/effect-only reads.
-   */
-  reducer: () => InteractionReducer;
+  /** Authoritative cross-module transition seam (owner-populated). */
+  port: InteractionTransitionPort;
   inspectConfig: () => ResolvedInteractionConfig["inspect"];
   inspectEnabled: () => boolean;
   dataIdentityEpoch: () => string;
@@ -82,10 +77,6 @@ export type InspectionStateDeps = {
   plotId: () => string;
   tooltipHovered: () => boolean;
   clearTooltipHovered: () => void;
-  /** S7 state still host-held: dismiss plan.clearBrush → brushRect = null. */
-  clearBrush: () => void;
-  /** S7 fn still host-held: dismiss plan.returnToInspect. */
-  chooseTool: (tool: "inspect") => void;
   oninspect: () => ((event: PlotInspection<Record<string, CellValue>>) => void) | undefined;
   oninteraction: () =>
     | ((event: PlotInteractionEvent<Record<string, CellValue>>) => void)
@@ -93,6 +84,8 @@ export type InspectionStateDeps = {
   /** Stable sinks over the announcer. */
   announce: (message: string) => void;
   clearAnnouncement: () => void;
+  /** Owner-only: collect phased effect registration for deterministic ordering. */
+  onRegisterEffects?: (attach: () => void) => void;
 };
 
 /** Intent for a coalesced pointer-inspect frame (nearest lookup owned here). */
@@ -148,8 +141,6 @@ export type InspectionState = {
    * Returns false when the frame is dropped so the reducer skips dispatch.
    */
   onInspectPointerFrame(action: InspectPointerFrameAction): boolean;
-  /** Register disposal + scene-reconcile effects at the original host site. */
-  registerInspectionEffects(): void;
 };
 
 // ---------------------------------------------------------------------------
@@ -423,7 +414,7 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
       clearDismissedLatch();
     }
     // Real Escape cancels area + bumps epoch; close does not.
-    if (kind === "escape") deps.reducer().dispatch({ type: "escape", source });
+    if (kind === "escape") deps.port.dispatchReducer({ type: "escape", source });
     if (plan.emitClear) emitInspection({ type: "inspect", phase: "clear", source });
     inspection = null;
     inspectionSeed = null;
@@ -431,9 +422,9 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
     if (plan.clearPendingPinned) pendingPinnedPointer = null;
     if (plan.coordinator === "invalidate") inspectionCoordinator.invalidate();
     else inspectionCoordinator.release("pinned");
-    if (plan.clearBrush) deps.clearBrush();
+    if (plan.clearBrush) deps.port.clearBrush();
     if (plan.restoreFocus) queueMicrotask(() => deps.captureSurface()?.focus());
-    if (plan.returnToInspect) deps.chooseTool("inspect");
+    if (plan.returnToInspect) deps.port.chooseTool("inspect");
   }
 
   function closeInspection(source: InteractionSource, restoreFocus = true): void {
@@ -500,7 +491,7 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
       fallbackCandidate: () => model?.candidates.hitTest(input.point.x, input.point.y) ?? null,
       panelIdForIndex,
     });
-    const reducer = deps.reducer();
+    const reducer = deps.port.reducer;
     queuedPointerInspection = frame.queued;
     queuedPointerToken = reducer.frameToken();
     try {
@@ -520,7 +511,7 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
   function cancelPointerInspect(policy: CancelPointerInspectPolicy): void {
     queuedPointerInspection = null;
     if (policy.pendingPinned === "discard") pendingPinnedPointer = null;
-    deps.reducer().cancelScheduledPointer("inspect");
+    deps.port.cancelScheduledPointer("inspect");
   }
 
   /**
@@ -537,7 +528,7 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
     // called for empty frames (Codex plan review).
     const frameAction = resolveQueuedInspectFrameAction({
       hasPending: pending !== null,
-      tokenAccepted: pending === null || token === null || deps.reducer().accepts(token),
+      tokenAccepted: pending === null || token === null || deps.port.reducer.accepts(token),
       currentState: inspection === null ? "none" : inspection.state,
       candidateEpochMismatch:
         action.candidate !== null && action.candidate.epoch !== deps.model()?.runId,
@@ -567,7 +558,7 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
     return true;
   }
 
-  function registerInspectionEffects(): void {
+  function attachInspectionEffects(): void {
     $effect(() => {
       return () => {
         inspectionCoordinator.invalidate();
@@ -600,11 +591,11 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
         case "invalidate-reconcile-pinned": {
           // currentModel is non-null for invalidate-* (plan requires run advance).
           const runId = currentModel!.runId;
-          deps.reducer().dispatch({ type: "invalidate", reason: "scene" });
+          deps.port.dispatchReducer({ type: "invalidate", reason: "scene" });
           queuedPointerInspection = null;
           pendingPinnedPointer = null;
           queuedPointerToken = null;
-          deps.reducer().cancelScheduledPointer();
+          deps.port.cancelScheduledPointer();
           clearDismissedLatch();
           reconciledRun = runId;
           if (plan.type === "invalidate-clear-transient") {
@@ -643,6 +634,8 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
     });
   }
 
+  deps.onRegisterEffects?.(attachInspectionEffects);
+
   return {
     get inspection() {
       return inspection;
@@ -665,6 +658,5 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
     schedulePointerInspect,
     cancelPointerInspect,
     onInspectPointerFrame,
-    registerInspectionEffects,
   };
 }

--- a/packages/svelte/src/lib/interaction/transition-port.ts
+++ b/packages/svelte/src/lib/interaction/transition-port.ts
@@ -1,0 +1,278 @@
+/**
+ * Authoritative cross-module seam for chart-local interaction transitions.
+ *
+ * Pointer, keyboard, legend, and programmatic inputs route sibling operations
+ * through this port instead of deferred controller getters. The transition
+ * owner populates the port after constructing internal modules.
+ */
+import type { CandidateFacts, CellValue, RenderModel, ScenePanel } from "@ggsvelte/core";
+
+import type { ContinuousZoomDomains } from "../scene/geometry.js";
+import type { BrushRect } from "../surface/surface-handlers.js";
+import type { SceneHit } from "../surface/plot-px.js";
+import type { createInteractionReducer } from "./reducer.js";
+import type { InteractionAction, PointerScheduleKind } from "./reducer.js";
+import type {
+  InteractionSource,
+  InteractionTool,
+  IntervalSelection,
+  PlotInspectionChange,
+  PlotSelection,
+} from "./interaction.js";
+
+/** Component-held reducer shape — factory creates it inside surface. */
+type InteractionReducer = ReturnType<typeof createInteractionReducer>;
+
+/** Inspect frame action delivered to onPointerFrame (non-move-area branch). */
+export type InspectPointerFrameAction = Extract<InteractionAction, { type: "inspect" }>;
+
+/** Intent for a coalesced pointer-inspect frame (nearest lookup owned by inspection). */
+export type SchedulePointerInspectInput = {
+  readonly point: Readonly<{ x: number; y: number }>;
+  readonly source: InteractionSource;
+  readonly mode: "auto" | "exact" | "x" | "y" | "xy";
+  readonly maxDistance: number;
+};
+
+/** Cancel policy for pending pointer-inspect work. */
+export type CancelPointerInspectPolicy = {
+  readonly pendingPinned: "preserve" | "discard";
+};
+
+/**
+ * Cross-module interaction transition port. Read accessors and command methods
+ * are wired by the transition owner; leaf modules must not invoke port methods
+ * during construction.
+ */
+export interface InteractionTransitionPort {
+  // --- Inspection ---
+  readonly inspection: PlotInspectionChange<Record<string, CellValue>, PropertyKey> | null;
+  readonly inspectionPanel: ScenePanel | null;
+  schedulePointerInspect(input: SchedulePointerInspectInput): void;
+  cancelPointerInspect(policy: CancelPointerInspectPolicy): void;
+  onInspectPointerFrame(action: InspectPointerFrameAction): boolean;
+  setInspection(
+    hit: SceneHit | null,
+    source: InteractionSource,
+    state?: "transient" | "pinned",
+    concreteMode?: "exact" | "x" | "y" | "xy",
+    candidate?: CandidateFacts,
+  ): void;
+  closeInspection(source: InteractionSource, restoreFocus?: boolean): void;
+  dismissInspection(
+    kind: "escape" | "close",
+    source: InteractionSource,
+    opts?: { restoreFocus?: boolean; returnToInspect?: boolean },
+  ): void;
+  toggleInspectionPin(source: InteractionSource): void;
+  navigateDirection(dx: number, dy: number): void;
+  cycleCoincident(delta: number): void;
+  resetTraversalIndex(): void;
+
+  // --- Surface / reducer ---
+  readonly reducer: InteractionReducer;
+  readonly activeTool: InteractionTool;
+  readonly committedInterval: IntervalSelection | null;
+  clearBrush(): void;
+  chooseTool(next: InteractionTool): void;
+  clearTouchInspectStart(): void;
+  cancelScheduledPointer(kind?: PointerScheduleKind): void;
+  dispatchReducer(action: InteractionAction): void;
+
+  // --- Interval ---
+  finishBrushSelect(eventValue: IntervalSelection, source: InteractionSource): void;
+
+  // --- Zoom ---
+  applyBrushZoom(rect: BrushRect, source: InteractionSource): void;
+  commitZoom(domains: ContinuousZoomDomains | null, source: InteractionSource): void;
+
+  // --- Selection ---
+  emitSelection(event: PlotSelection): void;
+  togglePointKeys(keys: readonly PropertyKey[], source: InteractionSource): void;
+
+  // --- Semantic resolution (surface handlers) ---
+  semanticKey(row: Record<string, CellValue> | null, index: number | null): PropertyKey | null;
+  candidateSemanticKeys(candidate: CandidateFacts): PropertyKey[];
+
+  // --- Model (surface handlers, interval bounds) ---
+  readonly model: RenderModel | null;
+}
+
+/** Module handles populated incrementally by the transition owner. */
+export type InteractionTransitionWiring = {
+  inspection?: {
+    readonly inspection: PlotInspectionChange<Record<string, CellValue>, PropertyKey> | null;
+    readonly inspectionPanel: ScenePanel | null;
+    schedulePointerInspect(input: SchedulePointerInspectInput): void;
+    cancelPointerInspect(policy: CancelPointerInspectPolicy): void;
+    onInspectPointerFrame(action: InspectPointerFrameAction): boolean;
+    setInspection(
+      hit: SceneHit | null,
+      source: InteractionSource,
+      state?: "transient" | "pinned",
+      concreteMode?: "exact" | "x" | "y" | "xy",
+      candidate?: CandidateFacts,
+    ): void;
+    closeInspection(source: InteractionSource, restoreFocus?: boolean): void;
+    dismissInspection(
+      kind: "escape" | "close",
+      source: InteractionSource,
+      opts?: { restoreFocus?: boolean; returnToInspect?: boolean },
+    ): void;
+    toggleInspectionPin(source: InteractionSource): void;
+    navigateDirection(dx: number, dy: number): void;
+    cycleCoincident(delta: number): void;
+    resetTraversalIndex(): void;
+  };
+  surface?: {
+    readonly reducer: InteractionReducer;
+    readonly activeTool: InteractionTool;
+    clearBrush(): void;
+    chooseTool(next: InteractionTool): void;
+    clearTouchInspectStart(): void;
+  };
+  interval?: {
+    readonly committedInterval: IntervalSelection | null;
+    finishBrushSelect(eventValue: IntervalSelection, source: InteractionSource): void;
+  };
+  zoom?: {
+    applyBrushZoom(rect: BrushRect, source: InteractionSource): void;
+    commitZoom(domains: ContinuousZoomDomains | null, source: InteractionSource): void;
+  };
+  selection?: {
+    emitSelection(event: PlotSelection): void;
+    togglePointKeys(keys: readonly PropertyKey[], source: InteractionSource): void;
+  };
+  semanticKey?: (row: Record<string, CellValue> | null, index: number | null) => PropertyKey | null;
+  candidateSemanticKeys?: (candidate: CandidateFacts) => PropertyKey[];
+  model?: () => RenderModel | null;
+};
+
+export function bindInteractionTransitionPort(
+  wiring: InteractionTransitionWiring,
+): InteractionTransitionPort {
+  const requireInspection = (): NonNullable<InteractionTransitionWiring["inspection"]> => {
+    const inspection = wiring.inspection;
+    if (inspection === undefined)
+      throw new TypeError("InteractionTransitionPort inspection wiring is not ready.");
+    return inspection;
+  };
+  const requireSurface = (): NonNullable<InteractionTransitionWiring["surface"]> => {
+    const surface = wiring.surface;
+    if (surface === undefined)
+      throw new TypeError("InteractionTransitionPort surface wiring is not ready.");
+    return surface;
+  };
+  const requireInterval = (): NonNullable<InteractionTransitionWiring["interval"]> => {
+    const interval = wiring.interval;
+    if (interval === undefined)
+      throw new TypeError("InteractionTransitionPort interval wiring is not ready.");
+    return interval;
+  };
+  const requireZoom = (): NonNullable<InteractionTransitionWiring["zoom"]> => {
+    const zoom = wiring.zoom;
+    if (zoom === undefined)
+      throw new TypeError("InteractionTransitionPort zoom wiring is not ready.");
+    return zoom;
+  };
+  const requireSelection = (): NonNullable<InteractionTransitionWiring["selection"]> => {
+    const selection = wiring.selection;
+    if (selection === undefined)
+      throw new TypeError("InteractionTransitionPort selection wiring is not ready.");
+    return selection;
+  };
+
+  const port: InteractionTransitionPort = {
+    get inspection() {
+      return requireInspection().inspection;
+    },
+    get inspectionPanel() {
+      return requireInspection().inspectionPanel;
+    },
+    schedulePointerInspect(input) {
+      requireInspection().schedulePointerInspect(input);
+    },
+    cancelPointerInspect(policy) {
+      requireInspection().cancelPointerInspect(policy);
+    },
+    onInspectPointerFrame(action) {
+      return requireInspection().onInspectPointerFrame(action);
+    },
+    setInspection(...args) {
+      requireInspection().setInspection(...args);
+    },
+    closeInspection(source, restoreFocus) {
+      requireInspection().closeInspection(source, restoreFocus);
+    },
+    dismissInspection(...args) {
+      requireInspection().dismissInspection(...args);
+    },
+    toggleInspectionPin(source) {
+      requireInspection().toggleInspectionPin(source);
+    },
+    navigateDirection(dx, dy) {
+      requireInspection().navigateDirection(dx, dy);
+    },
+    cycleCoincident(delta) {
+      requireInspection().cycleCoincident(delta);
+    },
+    resetTraversalIndex() {
+      requireInspection().resetTraversalIndex();
+    },
+    get reducer() {
+      return requireSurface().reducer;
+    },
+    get activeTool() {
+      return requireSurface().activeTool;
+    },
+    get committedInterval() {
+      return requireInterval().committedInterval;
+    },
+    clearBrush() {
+      requireSurface().clearBrush();
+    },
+    chooseTool(next) {
+      requireSurface().chooseTool(next);
+    },
+    clearTouchInspectStart() {
+      requireSurface().clearTouchInspectStart();
+    },
+    cancelScheduledPointer(kind) {
+      requireSurface().reducer.cancelScheduledPointer(kind);
+    },
+    dispatchReducer(action) {
+      requireSurface().reducer.dispatch(action);
+    },
+    finishBrushSelect(eventValue, source) {
+      requireInterval().finishBrushSelect(eventValue, source);
+    },
+    applyBrushZoom(rect, source) {
+      requireZoom().applyBrushZoom(rect, source);
+    },
+    commitZoom(domains, source) {
+      requireZoom().commitZoom(domains, source);
+    },
+    emitSelection(event) {
+      requireSelection().emitSelection(event);
+    },
+    togglePointKeys(keys, source) {
+      requireSelection().togglePointKeys(keys, source);
+    },
+    semanticKey(row, index) {
+      const semanticKey = wiring.semanticKey;
+      if (semanticKey === undefined)
+        throw new TypeError("InteractionTransitionPort semanticKey wiring is not ready.");
+      return semanticKey(row, index);
+    },
+    candidateSemanticKeys(candidate) {
+      const candidateSemanticKeys = wiring.candidateSemanticKeys;
+      if (candidateSemanticKeys === undefined)
+        throw new TypeError("InteractionTransitionPort candidateSemanticKeys wiring is not ready.");
+      return candidateSemanticKeys(candidate);
+    },
+    get model() {
+      return wiring.model?.() ?? null;
+    },
+  };
+  return Object.freeze(port);
+}

--- a/packages/svelte/src/lib/interval/interval-state.svelte.ts
+++ b/packages/svelte/src/lib/interval/interval-state.svelte.ts
@@ -33,7 +33,6 @@ import type {
   IntervalSelection,
   PlotInteractionInterval,
   PlotInteractionScope,
-  PlotSelection,
   ReadonlyIntervalDomains,
   ResolvedInteractionConfig,
   SemanticIntervalAxis,
@@ -53,6 +52,7 @@ import {
   type IntervalConsumptionCandidate,
 } from "./consumption.js";
 import { boundsEditorInputForScale, semanticAxisFromBounds } from "./precise-bounds.js";
+import type { InteractionTransitionPort } from "../interaction/transition-port.js";
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -60,14 +60,14 @@ import { boundsEditorInputForScale, semanticAxisFromBounds } from "./precise-bou
 
 export type IntervalStateDeps = {
   model: () => RenderModel | null;
+  /** Authoritative cross-module transition seam (owner-populated). */
+  port: InteractionTransitionPort;
   interaction: () => PlotInteractionController<PropertyKey> | undefined;
   resolvedInteractionScope: () => PlotInteractionScope;
   /** Narrow getter over `interactionConfig.select`. */
   selectConfig: () => ResolvedInteractionConfig["select"];
   /** Host alias over the S4 zoom controller (construction-safe). */
   effectiveZoomDomains: () => ContinuousZoomDomains | null;
-  /** S4 controller write path for the bounds-editor zoom branch (stable fn). */
-  commitZoom: (domains: ContinuousZoomDomains | null, source: InteractionSource) => void;
   captureSurface: () => HTMLDivElement | null;
   /** Used by the precise-bounds lineage projection. */
   candidateSemanticKeys: (candidate: CandidateFacts) => PropertyKey[];
@@ -76,14 +76,6 @@ export type IntervalStateDeps = {
    * Projection ownership stays outside interval behavior.
    */
   consumptionCandidates: () => readonly IntervalConsumptionCandidate<PropertyKey>[];
-  /**
-   * Handler-only: `openBoundsEditor` select branch reads the host's inspection
-   * panel as its fallback target. Host derived is earlier than the factory and
-   * returns `ScenePanel | null`.
-   */
-  inspectionPanel: () => ScenePanel | null;
-  /** Hoisted host fn (shared with point selection until S7/S8). */
-  emitSelection: (event: PlotSelection) => void;
   announce: (message: string) => void;
 };
 
@@ -346,7 +338,7 @@ export function createIntervalState(deps: IntervalStateDeps): IntervalState {
     );
     committedInterval = null;
     committedIntervalRecord = null;
-    deps.emitSelection(event);
+    deps.port.emitSelection(event);
   }
 
   function clearCurrentPanelInterval(source: InteractionSource): void {
@@ -372,7 +364,7 @@ export function createIntervalState(deps: IntervalStateDeps): IntervalState {
     );
     committedInterval = null;
     committedIntervalRecord = null;
-    deps.emitSelection(event);
+    deps.port.emitSelection(event);
   }
 
   function semanticAxis(
@@ -470,7 +462,7 @@ export function createIntervalState(deps: IntervalStateDeps): IntervalState {
     // truthiness is identical.
     if (persistent ?? false) commitIntervalSelection(eventValue, source);
     // Emit after writes so listeners observe committed state (load-bearing).
-    deps.emitSelection(eventValue);
+    deps.port.emitSelection(eventValue);
   }
 
   function openBoundsEditor(
@@ -482,7 +474,7 @@ export function createIntervalState(deps: IntervalStateDeps): IntervalState {
     if (action === "select") {
       const panel =
         currentIntervalRecord === null
-          ? (deps.inspectionPanel() ?? deps.model()?.scene.panels[0])
+          ? (deps.port.inspectionPanel ?? deps.model()?.scene.panels[0])
           : currentIntervalPanel;
       if (panel === undefined) return;
       boundsEditor = {
@@ -499,7 +491,7 @@ export function createIntervalState(deps: IntervalStateDeps): IntervalState {
   function applyPreciseBounds(event: PreciseBoundsApplyEvent): void {
     if (event.action === "zoom") {
       if (event.scale === "band") return;
-      deps.commitZoom(
+      deps.port.commitZoom(
         frozenZoomDomains({
           ...deps.effectiveZoomDomains(),
           [event.axis]: [...event.bounds],
@@ -562,7 +554,7 @@ export function createIntervalState(deps: IntervalStateDeps): IntervalState {
       source: event.inputSource,
     });
     committedInterval = persistentSelectionOrNull(deps.selectConfig()?.persistent, eventValue);
-    deps.emitSelection(eventValue);
+    deps.port.emitSelection(eventValue);
     boundsEditor = null;
   }
 

--- a/packages/svelte/src/lib/legend/filter-state.svelte.ts
+++ b/packages/svelte/src/lib/legend/filter-state.svelte.ts
@@ -74,8 +74,8 @@ export type LegendFilterState = {
   toggle(target: FilterableLegendEntry, event: MouseEvent): void;
   reset(event: MouseEvent): void;
   setPointerType(type: string | null): void;
-  /** Register catalog-reconcile effect at its original host position. */
-  registerCatalogEffects(entries: () => readonly FilterableLegendEntry[]): void;
+  /** Register catalog-reconcile effect (owner-only lifecycle). */
+  attachCatalogEffects(entries: () => readonly FilterableLegendEntry[]): void;
 };
 
 // ---------------------------------------------------------------------------
@@ -295,7 +295,7 @@ export function createLegendFilterState(deps: LegendFilterStateDeps): LegendFilt
     legendFilterPointerType = type;
   }
 
-  function registerCatalogEffects(entries: () => readonly FilterableLegendEntry[]): void {
+  function attachCatalogEffects(entries: () => readonly FilterableLegendEntry[]): void {
     // Catalog changes prune values that no longer exist. An emptied clause is
     // removed, so a category that disappears and later returns is visible by
     // default. resetScales() deliberately does not alter this filter state.
@@ -376,6 +376,6 @@ export function createLegendFilterState(deps: LegendFilterStateDeps): LegendFilt
     toggle,
     reset,
     setPointerType,
-    registerCatalogEffects,
+    attachCatalogEffects,
   };
 }

--- a/packages/svelte/src/lib/legend/focus-state.svelte.ts
+++ b/packages/svelte/src/lib/legend/focus-state.svelte.ts
@@ -78,6 +78,8 @@ export type LegendFocusStateDeps = {
     | undefined;
   /** Stable announce sink (not a getter). */
   announce: (message: string) => void;
+  /** Owner-only: collect phased effect registration for deterministic ordering. */
+  onRegisterEffects?: (attach: () => void) => void;
 };
 
 export type LegendFocusState = {
@@ -97,8 +99,6 @@ export type LegendFocusState = {
   clearLegendFromControl(event: MouseEvent): void;
   setTouchIndexCleared(): void;
   setClearPointerType(type: string | null): void;
-  /** Register reconcile effects at their original host position. */
-  registerReconcileEffects(): void;
 };
 
 // ---------------------------------------------------------------------------
@@ -407,7 +407,7 @@ export function createLegendFocusState(deps: LegendFocusStateDeps): LegendFocusS
     previewLegend(null);
   }
 
-  function registerReconcileEffects(): void {
+  function attachReconcileEffects(): void {
     $effect.pre(() => {
       const count = deps.entries().length;
       const active = document.activeElement;
@@ -507,6 +507,8 @@ export function createLegendFocusState(deps: LegendFocusStateDeps): LegendFocusS
     });
   }
 
+  deps.onRegisterEffects?.(attachReconcileEffects);
+
   return {
     get effectiveEmphasisKeys() {
       return effectiveEmphasisKeys;
@@ -530,6 +532,5 @@ export function createLegendFocusState(deps: LegendFocusStateDeps): LegendFocusS
     clearLegendFromControl,
     setTouchIndexCleared,
     setClearPointerType,
-    registerReconcileEffects,
   };
 }

--- a/packages/svelte/src/lib/plot-interaction-assembly.svelte.ts
+++ b/packages/svelte/src/lib/plot-interaction-assembly.svelte.ts
@@ -27,13 +27,17 @@ import type { LegendEntryIdentity } from "./legend/focus.js";
 import { createLegendFilterState } from "./legend/filter-state.svelte.js";
 import { createLegendEntryKeyIndex } from "./legend/entry-key-index.svelte.js";
 import { createLegendFocusState } from "./legend/focus-state.svelte.js";
-import { createPlotZoomState, type PlotZoomState } from "./zoom/zoom-state.svelte.js";
+import { createPlotZoomState } from "./zoom/zoom-state.svelte.js";
 import { createIntervalState } from "./interval/interval-state.svelte.js";
 import { createInspectionState } from "./inspection/inspection-state.svelte.js";
 import { createSurfaceState } from "./surface/surface-state.svelte.js";
-import { createSelectionState, type SelectionState } from "./selection/selection-state.svelte.js";
+import { createSelectionState } from "./selection/selection-state.svelte.js";
 import { presentationChromeForKind } from "./selection/selection.js";
 import { createPlotChromeState } from "./chrome/chrome-state.svelte.js";
+import {
+  bindInteractionTransitionPort,
+  type InteractionTransitionWiring,
+} from "./interaction/transition-port.js";
 
 export type PlotInteractionAssemblyDeps<
   Row extends Record<string, CellValue> = Record<string, CellValue>,
@@ -179,6 +183,13 @@ export function createPlotInteractionAssembly<
   // Live-region announcer (owned early so legend-reset effects can call it).
   const announcer = createPlotAnnouncer();
 
+  const transitionWiring: InteractionTransitionWiring = {};
+  const port = bindInteractionTransitionPort(transitionWiring);
+  const effectRegistrars: Array<() => void> = [];
+  const collectEffects = (attach: () => void): void => {
+    effectRegistrars.push(attach);
+  };
+
   // ------------------------------------------------- legend filter
   // Construction-time deriveds read legendFilter/effectiveSpec only —
   // model is deferred (declared after the runtime).
@@ -211,6 +222,7 @@ export function createPlotInteractionAssembly<
       zoomState.resetForScales();
     },
     onrender: () => inputs.onrender(),
+    onRegisterLateEffects: collectEffects,
   });
   // Model dispose + onrender effects (after the legend-reset effects that
   // registered during legendFilterState construction; before late effects).
@@ -228,6 +240,7 @@ export function createPlotInteractionAssembly<
     spec: () => inputs.spec(),
     sourceIdentity: (value: unknown) => identityTracker.sourceIdentity(value),
     deliverDiagnostic,
+    onRegisterEffects: collectEffects,
   });
   const semanticKey: SemanticKeyService["semanticKey"] = (...args) =>
     semanticKeys.semanticKey(...args);
@@ -243,87 +256,15 @@ export function createPlotInteractionAssembly<
   });
 
   // ---------------------------------------------------------- interaction
-  // source rows/spec -> pipeline/scene + CandidateStore -> semantic resolver
-  // -> chart-local reducer -> tooltip/crosshair/tools/callbacks. Presentation
-  // consumes one resolved inspection and never reconstructs grouping itself.
+  // Chart-local transitions route through one port; the owner registers phased
+  // effects in deterministic order after sibling wiring is complete.
   const interactive = $derived(interactionConfig.interactive);
   const surfaceInteractive = $derived(interactionConfig.availableTools.length > 0);
+  const inspectEnabled = $derived(interactionConfig.inspect !== null);
+  const legendFocusEnabled = $derived(interactionConfig.legendFocus !== null);
 
-  // ------------------------------------------------- inspection
-  // Construction-time deriveds may read the earlier model. Phased effects
-  // register later via registerInspectionEffects().
-  // Reversed deps: reducer / clearBrush / chooseTool close over the later-
-  // declared surfaceState (handler/effect-only; construction guard).
-  const inspectionState = createInspectionState({
-    model: () => runtime.model,
-    // Deferred: surface owns the reducer (handler/effect only).
-    reducer: () => surfaceState.reducer,
-    inspectConfig: () => interactionConfig.inspect,
-    inspectEnabled: () => inspectEnabled,
-    dataIdentityEpoch: () => dataIdentityEpoch,
-    // Deferred: semantic-key service is declared later (handler only).
-    keyAt: (index) => semanticKeys.keyAt(index),
-    root: inputs.root,
-    captureSurface: inputs.captureSurface,
-    plotId: () => inputs.plotId,
-    tooltipHovered: () => tooltipHovered,
-    clearTooltipHovered: () => {
-      tooltipHovered = false;
-    },
-    clearBrush: () => {
-      surfaceState.clearBrush();
-    },
-    chooseTool: (next) => {
-      surfaceState.chooseTool(next);
-    },
-    oninspect: inputs.oninspect,
-    oninteraction: inputs.oninteraction,
-    announce: announceSink,
-    clearAnnouncement: () => {
-      announcer.clear();
-    },
-  });
-  // ------------------------------------------------- surface
-  // Construction-time deriveds read module-internal state + inspectConfig.
-  // Sibling controllers, sinks, and chrome getters are handler/effect-only.
-  // Phased effects register later via registerSurfaceEffects().
-  const surfaceState = createSurfaceState({
-    model: () => runtime.model,
-    root: inputs.root,
-    toolProp: () => inputs.tool(),
-    initialTool: () => interactionConfig.initialTool,
-    // Deferred: chrome availableTools (handler/effect only).
-    availableTools: () => chromeState.availableTools,
-    inspectConfig: () => interactionConfig.inspect,
-    selectConfig: () => interactionConfig.select,
-    // Deferred: chrome canPublishPointSelection (handler only).
-    pointSelectEnabled: () => chromeState.canPublishPointSelection,
-    ontoolchange: () => inputs.ontoolchange(),
-    surfaceInteractive: () => surfaceInteractive,
-    // Deferred: semantic-key service initializes later (issue #165).
-    candidateSemanticKeys: (candidate) => candidateSemanticKeys(candidate),
-    inspection: () => inspectionState,
-    // Deferred: interval is declared after surface (handler only).
-    interval: () => intervalState,
-    zoom: () => zoomState,
-    // Deferred: selection controller is declared after surface (handler only).
-    emitSelection: (event) => {
-      selectionState.emitSelection(event);
-    },
-    // Deferred: semantic-key service is declared later (handler only).
-    semanticKey: (row, index) => semanticKey(row, index),
-    // Deferred: selection controller is declared after surface (handler only).
-    togglePointKeys: (keys, source) => {
-      selectionState.togglePointKeys(keys, source);
-    },
-    tooltipHovered: () => tooltipHovered,
-    announce: announceSink,
-  });
-  const coordFlipped = $derived(assembled()?.coord?.type === "flip");
   let tooltipHovered = $state(false);
-  // ------------------------------------------------- selection
-  // Construction-time effectiveSelectedKeys reads earlier interaction/scope
-  // only. The later runtime projection module owns anchors and masks.
+
   const selectionState = createSelectionState({
     interaction: inputs.interaction,
     resolvedInteractionScope: () => resolvedInteractionScope,
@@ -332,12 +273,9 @@ export function createPlotInteractionAssembly<
     oninteraction: inputs.oninteraction,
     announce: announceSink,
   });
-  // Shared enablement predicates (avoid re-typing the same config gates).
-  const inspectEnabled = $derived(interactionConfig.inspect !== null);
-  const legendFocusEnabled = $derived(interactionConfig.legendFocus !== null);
-  // ------------------------------------------------- legend focus
-  // Factory sits after the enablement cluster so construction-time
-  // effectiveEmphasisKeys closes over earlier bindings only.
+  transitionWiring.selection = selectionState;
+  transitionWiring.zoom = zoomState;
+
   const legendFocusState = createLegendFocusState({
     interaction: inputs.interaction,
     resolvedInteractionScope: () => resolvedInteractionScope,
@@ -346,37 +284,79 @@ export function createPlotInteractionAssembly<
     root: inputs.root,
     entryKeys: () => legendEntryKeys,
     entries: () => interactiveLegendEntries,
-    // Deferred read of the later-declared cached derived (handlers only).
     pressed: () => effectiveLegendPressed,
     onlegendfocus: inputs.onlegendfocus,
     oninteraction: inputs.oninteraction,
     announce: announceSink,
+    onRegisterEffects: collectEffects,
   });
-  // ------------------------------------------------- interval selection
-  // Construction-time deriveds may read model/effectiveZoomDomains (both
-  // earlier-declared). Effects register here — relative order is runtime
-  // model effects < interval effects < semantic diagnostics.
+
   const intervalState = createIntervalState({
     model: () => runtime.model,
+    port,
     interaction: inputs.interaction,
     resolvedInteractionScope: () => resolvedInteractionScope,
     selectConfig: () => interactionConfig.select,
     effectiveZoomDomains: () => zoomState.effectiveZoomDomains,
-    // Direct construction edges (not deferred thunks): zoom + selection
-    // are already constructed when interval is built.
-    commitZoom: (...args: Parameters<PlotZoomState["commitZoom"]>) => {
-      zoomState.commitZoom(...args);
-    },
     captureSurface: inputs.captureSurface,
     candidateSemanticKeys: (candidate) => candidateSemanticKeys(candidate),
-    // Deferred: the projection module is constructed immediately after interval.
     consumptionCandidates: () => semanticCandidateProjection.intervalConsumptionCandidates,
-    inspectionPanel: () => inspectionState.inspectionPanel,
-    emitSelection: (...args: Parameters<SelectionState["emitSelection"]>) => {
-      selectionState.emitSelection(...args);
-    },
     announce: announceSink,
   });
+  transitionWiring.interval = intervalState;
+
+  const inspectionState = createInspectionState({
+    model: () => runtime.model,
+    port,
+    inspectConfig: () => interactionConfig.inspect,
+    inspectEnabled: () => inspectEnabled,
+    dataIdentityEpoch: () => dataIdentityEpoch,
+    keyAt: (index) => semanticKeys.keyAt(index),
+    root: inputs.root,
+    captureSurface: inputs.captureSurface,
+    plotId: () => inputs.plotId,
+    tooltipHovered: () => tooltipHovered,
+    clearTooltipHovered: () => {
+      tooltipHovered = false;
+    },
+    oninspect: inputs.oninspect,
+    oninteraction: inputs.oninteraction,
+    announce: announceSink,
+    clearAnnouncement: () => {
+      announcer.clear();
+    },
+    onRegisterEffects: collectEffects,
+  });
+  transitionWiring.inspection = inspectionState;
+
+  const surfaceState = createSurfaceState({
+    model: () => runtime.model,
+    port,
+    root: inputs.root,
+    toolProp: () => inputs.tool(),
+    initialTool: () => interactionConfig.initialTool,
+    availableTools: () => chromeState.availableTools,
+    inspectConfig: () => interactionConfig.inspect,
+    selectConfig: () => interactionConfig.select,
+    pointSelectEnabled: () => chromeState.canPublishPointSelection,
+    ontoolchange: () => inputs.ontoolchange(),
+    surfaceInteractive: () => surfaceInteractive,
+    tooltipHovered: () => tooltipHovered,
+    announce: announceSink,
+    onRegisterEffects: collectEffects,
+  });
+  transitionWiring.surface = {
+    reducer: surfaceState.reducer,
+    activeTool: surfaceState.activeTool,
+    clearBrush: () => surfaceState.clearBrush(),
+    chooseTool: (next) => surfaceState.chooseTool(next),
+    clearTouchInspectStart: () => surfaceState.clearTouchInspectStart(),
+  };
+  transitionWiring.semanticKey = semanticKey;
+  transitionWiring.candidateSemanticKeys = candidateSemanticKeys;
+  transitionWiring.model = () => runtime.model;
+
+  const coordFlipped = $derived(assembled()?.coord?.type === "flip");
   const semanticCandidateProjection = createSemanticCandidateProjection({
     model: () => runtime.model,
     candidateSemanticKeys: (candidate) => candidateSemanticKeys(candidate),
@@ -425,8 +405,6 @@ export function createPlotInteractionAssembly<
     resolvedHeight: () => runtime.resolvedHeight,
   });
   // Semantic diagnostics effects (before host diagnostic / surface effects).
-  semanticKeys.registerEffects();
-
   $effect(() => {
     for (const diagnostic of chromeState.areaScaleDiagnostics) deliverDiagnostic(diagnostic);
   });
@@ -435,12 +413,6 @@ export function createPlotInteractionAssembly<
     for (const diagnostic of chromeState.legendDiagnostics) deliverDiagnostic(diagnostic);
   });
 
-  // Surface window-teardown + tool-sync (after diagnostics, before catalog/
-  // focus/inspection registrations).
-  surfaceState.registerSurfaceEffects();
-
-  // Host-side deriveds kept outside the factory (construction-time free of
-  // the model read).
   const interactiveLegendEntries = $derived(
     legendFocusState.computeInteractiveEntries(runtime.model),
   );
@@ -449,23 +421,15 @@ export function createPlotInteractionAssembly<
     legendFocusState.computeLegendPressed(runtime.model),
   );
 
-  // Single source for "the legend clear row is shown": the root class and
-  // the filter fieldset's below-clear offset must flip together (the legend
-  // layout test pins their combined geometry).
   const legendClearActive = $derived(legendFocusEnabled && effectiveLegendPressed !== null);
 
-  // Host-side derived kept outside the factory (construction-time free of
-  // the model read).
   const filterableLegendEntries = $derived(legendFilterState.computeEntries(runtime.model));
-  // Catalog reconcile after model effects.
-  legendFilterState.registerCatalogEffects(() => filterableLegendEntries);
-  // Legend-focus reconcile after catalog.
-  legendFocusState.registerReconcileEffects();
-  // Inspection disposal + scene reconcile after legend-focus.
-  inspectionState.registerInspectionEffects();
 
-  // clientFlush/ready effect at end of script (late registration).
-  runtime.registerLateEffects();
+  effectRegistrars.push(() =>
+    legendFilterState.attachCatalogEffects(() => filterableLegendEntries),
+  );
+
+  for (const attach of effectRegistrars) attach();
 
   return {
     zoomState,

--- a/packages/svelte/src/lib/runtime/runtime.svelte.ts
+++ b/packages/svelte/src/lib/runtime/runtime.svelte.ts
@@ -36,6 +36,8 @@ export type PlotRuntimeDeps = {
    * (matches GGPlot.svelte:677-680).
    */
   onrender: () => ((model: RenderModel, spec: PortableSpec) => void) | undefined;
+  /** Owner-only: collect late effect registration (clientFlush/ready). */
+  onRegisterLateEffects?: (attach: () => void) => void;
 };
 
 export type PlotRuntime = {
@@ -49,8 +51,6 @@ export type PlotRuntime = {
   resetScales(): void;
   /** Register dispose + onrender effects (original position ~after legend resets). */
   registerModelEffects(): void;
-  /** Register clientFlush/ready effect (end of script). */
-  registerLateEffects(): void;
 };
 
 /**
@@ -214,13 +214,15 @@ export function createPlotRuntime(deps: PlotRuntimeDeps): PlotRuntime {
     });
   }
 
-  function registerLateEffects(): void {
+  function attachLateEffects(): void {
     // clientFlush via $effect: never runs during SSR → prerender stays
     // data-gg-ready="false" until the first client committed flush (decision 0009)
     $effect(() => {
       clientFlush = true;
     });
   }
+
+  deps.onRegisterLateEffects?.(attachLateEffects);
 
   return {
     get model() {
@@ -246,6 +248,5 @@ export function createPlotRuntime(deps: PlotRuntimeDeps): PlotRuntime {
     notifyPainted,
     resetScales,
     registerModelEffects,
-    registerLateEffects,
   };
 }

--- a/packages/svelte/src/lib/runtime/semantic-keys.svelte.ts
+++ b/packages/svelte/src/lib/runtime/semantic-keys.svelte.ts
@@ -25,6 +25,8 @@ export type SemanticKeyServiceDeps = {
   spec: () => unknown;
   sourceIdentity: (value: unknown) => string;
   deliverDiagnostic: (diagnostic: InteractionDiagnostic) => void;
+  /** Owner-only: collect phased effect registration for deterministic ordering. */
+  onRegisterEffects?: (attach: () => void) => void;
 };
 
 export type SemanticKeyService = {
@@ -32,8 +34,6 @@ export type SemanticKeyService = {
   candidateSemanticKeys(candidate: CandidateFacts): PropertyKey[];
   /** Direct map lookup (inspection coordinator / mask paths). */
   keyAt(index: number): PropertyKey | null;
-  /** Register diagnostics delivery at the host's original effect position. */
-  registerEffects(): void;
 };
 
 /**
@@ -65,11 +65,13 @@ export function createSemanticKeyService(deps: SemanticKeyServiceDeps): Semantic
     });
   });
 
-  function registerEffects(): void {
+  function attachSemanticEffects(): void {
     $effect(() => {
       for (const diagnostic of semanticKeys.diagnostics) deps.deliverDiagnostic(diagnostic);
     });
   }
+
+  deps.onRegisterEffects?.(attachSemanticEffects);
 
   function semanticKey(
     row: Record<string, CellValue> | null,
@@ -116,6 +118,5 @@ export function createSemanticKeyService(deps: SemanticKeyServiceDeps): Semantic
     keyAt(index: number): PropertyKey | null {
       return semanticKeys.keys.get(index) ?? null;
     },
-    registerEffects,
   };
 }

--- a/packages/svelte/src/lib/surface/surface-handlers.ts
+++ b/packages/svelte/src/lib/surface/surface-handlers.ts
@@ -104,7 +104,7 @@ export function createSurfaceHandlers(live: SurfaceHandlerLive): SurfaceHandlers
         live.setBrushRect(null);
         // set-tool already full-cancels the schedule; clear inspect payload only
         // (preserve pinned stash — matches prior clearQueuedPointer-only path).
-        deps.inspection().cancelPointerInspect({ pendingPinned: "preserve" });
+        deps.port.cancelPointerInspect({ pendingPinned: "preserve" });
         deps.ontoolchange()?.(next);
         break;
     }
@@ -148,7 +148,7 @@ export function createSurfaceHandlers(live: SurfaceHandlerLive): SurfaceHandlers
     });
     switch (action.type) {
       case "touch-inspect-drag-cancel":
-        deps.inspection().cancelPointerInspect({ pendingPinned: "preserve" });
+        deps.port.cancelPointerInspect({ pendingPinned: "preserve" });
         return;
       case "queue-area-move":
         queuedAreaSource = action.source;
@@ -157,7 +157,7 @@ export function createSurfaceHandlers(live: SurfaceHandlerLive): SurfaceHandlers
       case "queue-inspect":
         // mode/maxDistance from pure snapshot — no inspect config re-gate.
         // Inspection owns nearest lookup, token, and reducer.queuePointer.
-        deps.inspection().schedulePointerInspect({
+        deps.port.schedulePointerInspect({
           point: p,
           source: action.source,
           mode: action.mode,
@@ -178,7 +178,7 @@ export function createSurfaceHandlers(live: SurfaceHandlerLive): SurfaceHandlers
     const next = brushWithEnd(draft, point);
     live.setBrushRect(next);
     if (live.getActiveTool() === "select-area")
-      deps.emitSelection(selectionEvent("change", normalizedRect(next), source));
+      deps.port.emitSelection(selectionEvent("change", normalizedRect(next), source));
   }
 
   /** Map the live render model into the pure interval query scene adapter. */
@@ -203,13 +203,13 @@ export function createSurfaceHandlers(live: SurfaceHandlerLive): SurfaceHandlers
         live.setBrushRect(null);
         const eventValue = selectionEvent("end", finish.rect, source);
         // Interval owns commit + emit; surface only routes FinishBrushAction.
-        deps.interval().finishBrushSelect(eventValue, source);
+        deps.port.finishBrushSelect(eventValue, source);
         reducer.dispatch({ type: "cancel-area" });
         break;
       }
       case "zoom-end":
         live.setBrushRect(null);
-        deps.zoom().applyBrushZoom(finish.rect, source);
+        deps.port.applyBrushZoom(finish.rect, source);
         reducer.dispatch({ type: "cancel-area" });
         break;
       case "end-area":
@@ -231,16 +231,16 @@ export function createSurfaceHandlers(live: SurfaceHandlerLive): SurfaceHandlers
         })
       )
         return;
-      deps.inspection().cancelPointerInspect({ pendingPinned: "discard" });
+      deps.port.cancelPointerInspect({ pendingPinned: "discard" });
       reducer.cancelScheduledPointer();
-      deps.inspection().setInspection(null, "pointer");
+      deps.port.setInspection(null, "pointer");
     });
   }
 
   function onPointerDown(event: PointerEvent): void {
     // Always cancel queued inspection before pure routing (host cleanup).
     // Preserve pinned stash; full schedule cancel (inspect + move-area).
-    deps.inspection().cancelPointerInspect({ pendingPinned: "preserve" });
+    deps.port.cancelPointerInspect({ pendingPinned: "preserve" });
     reducer.cancelScheduledPointer();
     // point always computed (pure begin-area needs it; touch/none ignore).
     const p = plotPoint(event);
@@ -273,7 +273,7 @@ export function createSurfaceHandlers(live: SurfaceHandlerLive): SurfaceHandlers
         if (originPanel === null) break;
         // Pure table owns fresh vs extend corner policy.
         live.setBrushRect(action.corners);
-        deps.inspection().setInspection(null, action.source);
+        deps.port.setInspection(null, action.source);
         reducer.dispatch({
           type: "begin-area",
           point: p,
@@ -281,7 +281,7 @@ export function createSurfaceHandlers(live: SurfaceHandlerLive): SurfaceHandlers
         });
         if (action.emitSelectStart) {
           const startEvent = selectionEvent("start", normalizedRect(action.corners), action.source);
-          deps.emitSelection(startEvent);
+          deps.port.emitSelection(startEvent);
         }
         try {
           (event.currentTarget as HTMLElement).setPointerCapture(event.pointerId);
@@ -302,7 +302,7 @@ export function createSurfaceHandlers(live: SurfaceHandlerLive): SurfaceHandlers
   ): IntervalSelection {
     const originPanelId =
       reducer.state.area.kind === "idle"
-        ? deps.interval().committedInterval?.panelId
+        ? deps.port.committedInterval?.panelId
         : reducer.state.area.panelId;
     return buildIntervalSelectionFromScene({
       phase,
@@ -311,7 +311,7 @@ export function createSurfaceHandlers(live: SurfaceHandlerLive): SurfaceHandlers
       pixels: rect,
       scene: intervalQueryScene(),
       ...(originPanelId !== undefined && { panelId: originPanelId }),
-      keyForRow: (rowIndex) => deps.semanticKey(deps.model()?.row(rowIndex) ?? null, rowIndex),
+      keyForRow: (rowIndex) => deps.port.semanticKey(deps.model()?.row(rowIndex) ?? null, rowIndex),
     });
   }
 
@@ -343,9 +343,13 @@ export function createSurfaceHandlers(live: SurfaceHandlerLive): SurfaceHandlers
           maxDistance: action.maxDistance,
         });
         if (match !== null && match !== undefined) {
-          deps
-            .inspection()
-            .setInspection(hitFromCandidate(match), "touch", action.state, match.mode, match);
+          deps.port.setInspection(
+            hitFromCandidate(match),
+            "touch",
+            action.state,
+            match.mode,
+            match,
+          );
           suppressClickUntil = performance.now() + TOUCH_INSPECT_CLICK_SUPPRESS_MS;
         }
         break;
@@ -364,32 +368,30 @@ export function createSurfaceHandlers(live: SurfaceHandlerLive): SurfaceHandlers
   function onSurfaceBlur(event: FocusEvent): void {
     const blurAction = resolveSurfaceBlurAction({
       relatedTargetInsideRoot: deps.root()?.contains(event.relatedTarget as Node | null) === true,
-      inspectionState: deps.inspection().inspection?.state ?? "none",
+      inspectionState: deps.port.inspection?.state ?? "none",
     });
     if (blurAction.type === "ignore") return;
-    // Shared for keep-pinned and clear-inspection (ordering is load-bearing).
-    deps.inspection().resetTraversalIndex();
-    deps.inspection().cancelPointerInspect({ pendingPinned: "preserve" });
-    if (blurAction.type === "blur-clear-inspection")
-      deps.inspection().setInspection(null, "keyboard");
+    deps.port.resetTraversalIndex();
+    deps.port.cancelPointerInspect({ pendingPinned: "preserve" });
+    if (blurAction.type === "blur-clear-inspection") deps.port.setInspection(null, "keyboard");
   }
 
   function onSurfaceKeyDown(event: KeyboardEvent): void {
     // Decision table is pure (surface/keyboard); this switch owns side
     // effects only. brushCorners is the draft source of truth (not reducer
     // live.getBrushing()); nudge/complete-area carry pure payloads so host only applies.
-    const inspection = deps.inspection();
+    const inspectionState = deps.port.inspection;
     const { action, preventDefault } = resolveSurfaceKeyAction({
       key: event.key,
       shiftKey: event.shiftKey,
       activeTool: live.getActiveTool(),
       brushCorners: live.getBrushRect(),
-      hasInspection: inspection.inspection !== null,
+      hasInspection: inspectionState !== null,
       pinEnabled: deps.inspectConfig()?.pin === true,
-      focusKey: inspection.inspection?.focus.key ?? null,
-      sourceKeys: inspection.inspection?.focus.sourceKeys ?? [],
-      inspectionAnchor: inspection.inspection?.focus.anchor ?? null,
-      inspectionPanel: inspection.inspectionPanel,
+      focusKey: inspectionState?.focus.key ?? null,
+      sourceKeys: inspectionState?.focus.sourceKeys ?? [],
+      inspectionAnchor: inspectionState?.focus.anchor ?? null,
+      inspectionPanel: deps.port.inspectionPanel,
       firstPanel: deps.model()?.scene.panels[0],
     });
     if (preventDefault) event.preventDefault();
@@ -423,19 +425,19 @@ export function createSurfaceHandlers(live: SurfaceHandlerLive): SurfaceHandlers
         return;
       }
       case "cycle-coincident":
-        inspection.cycleCoincident(action.delta);
+        deps.port.cycleCoincident(action.delta);
         return;
       case "navigate-direction":
-        inspection.navigateDirection(action.dx, action.dy);
+        deps.port.navigateDirection(action.dx, action.dy);
         return;
       case "toggle-point-keys":
-        deps.togglePointKeys(action.keys, "keyboard");
+        deps.port.togglePointKeys(action.keys, "keyboard");
         return;
       case "toggle-pin":
-        inspection.toggleInspectionPin("keyboard");
+        deps.port.toggleInspectionPin("keyboard");
         return;
       case "escape":
-        inspection.dismissInspection("escape", "keyboard", {
+        deps.port.dismissInspection("escape", "keyboard", {
           returnToInspect: action.returnToInspect,
         });
         break;
@@ -445,14 +447,13 @@ export function createSurfaceHandlers(live: SurfaceHandlerLive): SurfaceHandlers
   }
 
   function onCaptureClick(event: MouseEvent): void {
-    const inspection = deps.inspection();
     const action = resolveCaptureClickAction({
       suppressClick: performance.now() < suppressClickUntil,
       activeTool: live.getActiveTool(),
       pointSelectEnabled: deps.pointSelectEnabled(),
       inspectEnabled: deps.inspectConfig() !== null,
       pinEnabled: deps.inspectConfig()?.pin === true,
-      hasInspection: inspection.inspection !== null,
+      hasInspection: deps.port.inspection !== null,
     });
     switch (action.type) {
       case "suppress":
@@ -465,11 +466,11 @@ export function createSurfaceHandlers(live: SurfaceHandlerLive): SurfaceHandlers
           maxDistance: POINT_SELECT_NEAREST_MAX_DISTANCE_PX,
         });
         if (match === null || match === undefined) break;
-        deps.togglePointKeys(deps.candidateSemanticKeys(match), "pointer");
+        deps.port.togglePointKeys(deps.port.candidateSemanticKeys(match), "pointer");
         break;
       }
       case "toggle-pin":
-        inspection.toggleInspectionPin("pointer");
+        deps.port.toggleInspectionPin("pointer");
         break;
       case "none":
         break;
@@ -479,7 +480,7 @@ export function createSurfaceHandlers(live: SurfaceHandlerLive): SurfaceHandlers
   /** Pointer-cancel always drops draft/queue/touch-inspect and cancels area. */
   function onPointerCancel(): void {
     // Preserve pinned stash (leave discards; cancel preserves).
-    deps.inspection().cancelPointerInspect({ pendingPinned: "preserve" });
+    deps.port.cancelPointerInspect({ pendingPinned: "preserve" });
     touchInspectStart = null;
     touchInspectMoved = false;
     reducer.cancelScheduledPointer();

--- a/packages/svelte/src/lib/surface/surface-state.svelte.ts
+++ b/packages/svelte/src/lib/surface/surface-state.svelte.ts
@@ -9,30 +9,18 @@
  * receive live bindings so rAF frames and leave-microtasks never snapshot
  * stale tool/brush state.
  *
- * Construction topology (host): inspectionState is FIRST; this factory sits at
- * the original reducer position. Construction-time deriveds read ONLY module-
- * internal state + inspectConfig. Sibling controllers, sinks, and chrome
- * getters are handler/effect-only (armed for the construction guard).
- *
- * Effects register via registerSurfaceEffects() at the original line-810
- * position (after diagnostics effects, before catalog/focus/inspection).
+ * Cross-module transitions route through InteractionTransitionPort; the
+ * transition owner registers phased effects via onRegisterEffects.
  */
-import type { CandidateFacts, CellValue, RenderModel } from "@ggsvelte/core";
+import type { RenderModel } from "@ggsvelte/core";
 
-import type { InspectionState } from "../inspection/inspection-state.svelte.js";
-import type { IntervalState } from "../interval/interval-state.svelte.js";
-import type {
-  InteractionSource,
-  InteractionTool,
-  PlotSelection,
-  ResolvedInteractionConfig,
-} from "../interaction/interaction.js";
+import type { InteractionTool, ResolvedInteractionConfig } from "../interaction/interaction.js";
 import { createInteractionReducer } from "../interaction/reducer.js";
+import type { InteractionTransitionPort } from "../interaction/transition-port.js";
 import { resolveEffectiveTool } from "../interaction/capability.js";
 import { shouldClosePinnedOnOutsidePointer } from "../inspection/teardown.js";
 import { isAreaAwaitingSecond, isAreaBrushing } from "./pointer.js";
 import { buildSurfaceDescription } from "./surface-description.js";
-import type { PlotZoomState } from "../zoom/zoom-state.svelte.js";
 import { createSurfaceHandlers, type BrushRect } from "./surface-handlers.js";
 
 // ---------------------------------------------------------------------------
@@ -45,6 +33,8 @@ type InteractionReducer = ReturnType<typeof createInteractionReducer>;
 export type SurfaceStateDeps = {
   model: () => RenderModel | null;
   root: () => HTMLDivElement | null;
+  /** Authoritative cross-module transition seam (owner-populated). */
+  port: InteractionTransitionPort;
   /** Controlled-tool prop + resolved config/chrome (host/S8-held). */
   toolProp: () => InteractionTool | undefined;
   initialTool: () => ResolvedInteractionConfig["initialTool"];
@@ -62,32 +52,10 @@ export type SurfaceStateDeps = {
    * availableTools (codex P1-4).
    */
   surfaceInteractive: () => boolean;
-  /** Capture-click reads it — deferred closure, same #165 pattern. */
-  candidateSemanticKeys: (candidate: CandidateFacts) => PropertyKey[];
-  /** Sibling controllers (handler-only; inspection earlier, interval later). */
-  inspection: () => Pick<
-    InspectionState,
-    | "inspection"
-    | "inspectionPanel"
-    | "schedulePointerInspect"
-    | "cancelPointerInspect"
-    | "onInspectPointerFrame"
-    | "setInspection"
-    | "closeInspection"
-    | "dismissInspection"
-    | "toggleInspectionPin"
-    | "navigateDirection"
-    | "cycleCoincident"
-    | "resetTraversalIndex"
-  >;
-  interval: () => Pick<IntervalState, "finishBrushSelect" | "committedInterval">;
-  zoom: () => Pick<PlotZoomState, "applyBrushZoom">;
-  /** S8 host-held sinks. */
-  emitSelection: (event: PlotSelection) => void;
-  semanticKey: (row: Record<string, CellValue> | null, index: number | null) => PropertyKey | null;
-  togglePointKeys: (keys: readonly PropertyKey[], source: InteractionSource) => void;
   tooltipHovered: () => boolean;
   announce: (message: string) => void;
+  /** Owner-only: collect phased effect registration for deterministic ordering. */
+  onRegisterEffects?: (attach: () => void) => void;
 };
 
 export type SurfaceState = {
@@ -98,6 +66,7 @@ export type SurfaceState = {
   readonly areaAwaitingSecond: boolean;
   clearBrush(): void;
   chooseTool(next: InteractionTool): void;
+  clearTouchInspectStart(): void;
   onPointerMove(event: PointerEvent): void;
   onPointerDown(event: PointerEvent): void;
   onPointerUp(event: PointerEvent): void;
@@ -107,8 +76,6 @@ export type SurfaceState = {
   onCaptureClick(event: MouseEvent): void;
   onSurfaceKeyDown(event: KeyboardEvent): void;
   onSurfaceBlur(event: FocusEvent): void;
-  /** Register window-teardown + tool-sync effects at the original host site. */
-  registerSurfaceEffects(): void;
 };
 
 // ---------------------------------------------------------------------------
@@ -117,19 +84,13 @@ export type SurfaceState = {
 
 /**
  * Create the surface controller. Construction registers only the
- * construction-time deriveds. Call `registerSurfaceEffects` at the original
- * line-810 position (after diagnostics, before catalog/focus/inspection).
- *
- * Construction-order note: deps must not be invoked during construction —
- * construction-read discipline enforced by the armed-getter suite.
+ * construction-time deriveds. The transition owner registers effects through
+ * onRegisterEffects after sibling wiring is complete.
  */
 export function createSurfaceState(deps: SurfaceStateDeps): SurfaceState {
   let reducerRevision = $state(0);
-  // Late-bound: handlers are created after the reducer so onPointerFrame can
-  // call applyAreaMove without a construction cycle.
   let handlers!: ReturnType<typeof createSurfaceHandlers>;
 
-  // Reducer is created INSIDE the factory (original host position ~516).
   const reducer = createInteractionReducer({
     onChange: () => {
       reducerRevision += 1;
@@ -143,17 +104,14 @@ export function createSurfaceState(deps: SurfaceStateDeps): SurfaceState {
         handlers.applyAreaMove(action.point);
         return true;
       }
-      return deps.inspection().onInspectPointerFrame(action);
+      return deps.port.onInspectPointerFrame(action);
     },
   });
 
-  // Construction-safe: own state + inspectConfig only.
   const activeTool = $derived.by(() => {
     void reducerRevision;
     return reducer.state.tool;
   });
-  // Lazy pin read: only consult inspectConfig on the inspect tool branch so
-  // non-inspect tools do not subscribe to inspect config (dependency tracking).
   const surfaceDescription = $derived.by(() =>
     buildSurfaceDescription(
       activeTool,
@@ -162,7 +120,6 @@ export function createSurfaceState(deps: SurfaceStateDeps): SurfaceState {
   );
 
   let brushRect = $state<BrushRect | null>(null);
-  // Private — no remaining host consumer after extraction (codex P2-7).
   const brushing = $derived.by(() => {
     void reducerRevision;
     return isAreaBrushing(reducer.state.area.kind);
@@ -184,24 +141,22 @@ export function createSurfaceState(deps: SurfaceStateDeps): SurfaceState {
     },
   });
 
-  function registerSurfaceEffects(): void {
-    // Window outside-pointer / blur teardown (original line-810).
+  function attachSurfaceEffects(): void {
     $effect(() => {
-      // No-op cleanup keeps every code path returning a teardown (consistent-return).
       if (!deps.surfaceInteractive()) return () => {};
       const onOutsidePointer = (event: PointerEvent) => {
         if (
           !shouldClosePinnedOnOutsidePointer({
-            inspectionState: deps.inspection().inspection?.state,
+            inspectionState: deps.port.inspection?.state,
             targetInsideRoot: deps.root()?.contains(event.target as Node) === true,
           })
         )
           return;
-        deps.inspection().closeInspection("pointer", false);
+        deps.port.closeInspection("pointer", false);
       };
       const cancelDraft = () => {
         brushRect = null;
-        deps.inspection().cancelPointerInspect({ pendingPinned: "preserve" });
+        deps.port.cancelPointerInspect({ pendingPinned: "preserve" });
         handlers.clearTouchInspectStart();
         reducer.cancelScheduledPointer();
         reducer.dispatch({ type: "cancel-area" });
@@ -214,7 +169,6 @@ export function createSurfaceState(deps: SurfaceStateDeps): SurfaceState {
       };
     });
 
-    // Tool-sync (original line-837).
     $effect(() => {
       const next = resolveEffectiveTool(
         deps.toolProp() ?? deps.initialTool(),
@@ -223,6 +177,8 @@ export function createSurfaceState(deps: SurfaceStateDeps): SurfaceState {
       reducer.dispatch({ type: "set-tool", tool: next });
     });
   }
+
+  deps.onRegisterEffects?.(attachSurfaceEffects);
 
   return {
     get reducer() {
@@ -245,6 +201,9 @@ export function createSurfaceState(deps: SurfaceStateDeps): SurfaceState {
     },
     chooseTool: (next) => {
       handlers.chooseTool(next);
+    },
+    clearTouchInspectStart: () => {
+      handlers.clearTouchInspectStart();
     },
     onPointerMove: (event) => {
       handlers.onPointerMove(event);
@@ -273,6 +232,5 @@ export function createSurfaceState(deps: SurfaceStateDeps): SurfaceState {
     onSurfaceBlur: (event) => {
       handlers.onSurfaceBlur(event);
     },
-    registerSurfaceEffects,
   };
 }

--- a/packages/svelte/tests/helpers/runtime-deps.svelte.ts
+++ b/packages/svelte/tests/helpers/runtime-deps.svelte.ts
@@ -11,6 +11,7 @@ import type { LegendFilterClause } from "../../src/lib/legend/filter.js";
 import type { PlotRuntimeDeps } from "../../src/lib/runtime/runtime.svelte.js";
 
 export type ReactiveRuntimeDeps = PlotRuntimeDeps & {
+  attachLateEffects(): void;
   setWidth(v: number | "container" | undefined): void;
   setHeight(v: number | undefined): void;
   setAssembled(v: PortableSpec | null): void;
@@ -37,6 +38,7 @@ export function createReactiveRuntimeDeps(initial: {
   let root = $state<HTMLDivElement | null>(null);
   let onrender = $state<((model: RenderModel, spec: PortableSpec) => void) | undefined>();
   let resetZoom = $state<() => void>(() => {});
+  let attachLate: (() => void) | undefined;
 
   return {
     widthProp: () => width,
@@ -50,6 +52,12 @@ export function createReactiveRuntimeDeps(initial: {
       resetZoom();
     },
     onrender: () => onrender,
+    onRegisterLateEffects: (attach) => {
+      attachLate = attach;
+    },
+    attachLateEffects: () => {
+      attachLate?.();
+    },
     setWidth: (v) => {
       width = v;
     },

--- a/packages/svelte/tests/inspection/inspection-state.construction-effects.test.ts
+++ b/packages/svelte/tests/inspection/inspection-state.construction-effects.test.ts
@@ -9,6 +9,7 @@ import type { CandidateFacts, CellValue, RenderModel } from "@ggsvelte/core";
 import type { PlotInspection } from "../../src/lib/interaction/interaction.js";
 import { withEffectRoot } from "../helpers/effect-root.svelte.js";
 import { reactiveBox } from "../helpers/reactive-box.svelte.js";
+import { bindInteractionTransitionPort } from "../../src/lib/interaction/transition-port.js";
 import {
   applyInspect,
   candidateHit,
@@ -41,14 +42,24 @@ describe("createInspectionState construction", () => {
 
     const constructionModel = modelFor(continuousSpec());
     const reducer = createInteractionReducer();
+    const wiring: Parameters<typeof bindInteractionTransitionPort>[0] = {};
+    const port = bindInteractionTransitionPort(wiring);
+    wiring.surface = {
+      reducer,
+      activeTool: "inspect",
+      clearBrush: () => {
+        clearBrushCalls++;
+      },
+      chooseTool: () => {
+        chooseToolCalls++;
+      },
+      clearTouchInspectStart: () => {},
+    };
 
     const { value: state, destroy } = withEffectRoot(() =>
       createInspectionState({
         model: () => constructionModel,
-        reducer: () => {
-          reducerCalls++;
-          return reducer;
-        },
+        port,
         inspectConfig: defaultInspect,
         inspectEnabled: () => {
           inspectEnabledCalls++;
@@ -75,12 +86,6 @@ describe("createInspectionState construction", () => {
         clearTooltipHovered: () => {
           clearTooltipHoveredCalls++;
         },
-        clearBrush: () => {
-          clearBrushCalls++;
-        },
-        chooseTool: () => {
-          chooseToolCalls++;
-        },
         oninspect: () => {
           oninspectCalls++;
           return noInspect();
@@ -95,7 +100,6 @@ describe("createInspectionState construction", () => {
     );
 
     expect(reducerCalls).toBe(0);
-    expect(captureSurfaceCalls).toBe(0);
     expect(tooltipHoveredCalls).toBe(0);
     expect(clearTooltipHoveredCalls).toBe(0);
     expect(keyAtCalls).toBe(0);
@@ -112,7 +116,6 @@ describe("createInspectionState construction", () => {
     expect(state.inspectionPanel).toBeNull();
     flushSync();
     expect(reducerCalls).toBe(0);
-    expect(captureSurfaceCalls).toBe(0);
     expect(tooltipHoveredCalls).toBe(0);
     expect(clearTooltipHoveredCalls).toBe(0);
     expect(keyAtCalls).toBe(0);

--- a/packages/svelte/tests/inspection/inspection-state.harness.ts
+++ b/packages/svelte/tests/inspection/inspection-state.harness.ts
@@ -13,6 +13,10 @@ import type {
 import { normalizeInteractionConfig } from "../../src/lib/interaction/interaction.js";
 import { createInteractionReducer } from "../../src/lib/interaction/reducer.js";
 import {
+  bindInteractionTransitionPort,
+  type InteractionTransitionWiring,
+} from "../../src/lib/interaction/transition-port.js";
+import {
   createInspectionState,
   type InspectionStateDeps,
 } from "../../src/lib/inspection/inspection-state.svelte.js";
@@ -179,13 +183,15 @@ export function mountInspectionController(
     announce?: (message: string) => void;
     clearAnnouncement?: () => void;
     registerEffects?: boolean;
-    /** Wire deferred frame + onInspectPointerFrame (for schedulePointerInspect). */
     deferredFrames?: boolean;
   } = {},
 ): InspectionHarness {
   const defaultModel = modelFor(continuousSpec());
   const scheduler = options.deferredFrames === true ? createDeferredFrameScheduler() : null;
-  let controllerRef: ReturnType<typeof createInspectionState> | null = null;
+  const wiring: InteractionTransitionWiring = {};
+  const port = bindInteractionTransitionPort(wiring);
+  let chooseToolCalls: string[] = [];
+  const effectRegistrars: Array<() => void> = [];
 
   const ownedReducer =
     options.reducer === undefined
@@ -202,17 +208,30 @@ export function mountInspectionController(
               ? undefined
               : (action) => {
                   if (action.type === "inspect")
-                    return controllerRef!.onInspectPointerFrame(action);
+                    return wiring.inspection!.onInspectPointerFrame(action);
                   return true;
                 },
         })
       : null;
   const getReducer = options.reducer ?? (() => ownedReducer!);
 
+  wiring.surface = {
+    reducer: getReducer(),
+    activeTool: "inspect",
+    clearBrush: () => {
+      options.clearBrush?.();
+    },
+    chooseTool: (tool) => {
+      chooseToolCalls.push(tool);
+      options.chooseTool?.(tool as "inspect");
+    },
+    clearTouchInspectStart: () => {},
+  };
+
   const { value: state, destroy } = withFlushedEffectRoot(() => {
     const controller = createInspectionState({
       model: options.model ?? (() => defaultModel),
-      reducer: getReducer,
+      port,
       inspectConfig: options.inspectConfig ?? defaultInspect,
       inspectEnabled: options.inspectEnabled ?? (() => true),
       dataIdentityEpoch: options.dataIdentityEpoch ?? (() => "epoch-1"),
@@ -227,15 +246,18 @@ export function mountInspectionController(
       plotId: options.plotId ?? (() => "plot-test"),
       tooltipHovered: options.tooltipHovered ?? (() => false),
       clearTooltipHovered: options.clearTooltipHovered ?? (() => {}),
-      clearBrush: options.clearBrush ?? (() => {}),
-      chooseTool: options.chooseTool ?? (() => {}),
       oninspect: options.oninspect ?? noInspect,
       oninteraction: options.oninteraction ?? noInteraction,
       announce: options.announce ?? (() => {}),
       clearAnnouncement: options.clearAnnouncement ?? (() => {}),
+      onRegisterEffects: (attach) => {
+        effectRegistrars.push(attach);
+      },
     });
-    controllerRef = controller;
-    if (options.registerEffects !== false) controller.registerInspectionEffects();
+    wiring.inspection = controller;
+    if (options.registerEffects !== false) {
+      for (const attach of effectRegistrars) attach();
+    }
     return controller;
   });
 

--- a/packages/svelte/tests/inspection/inspection-state.pin-queue.test.ts
+++ b/packages/svelte/tests/inspection/inspection-state.pin-queue.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from "vitest";
 import type { CandidateFacts, CellValue } from "@ggsvelte/core";
 
 import type { PlotInspection } from "../../src/lib/interaction/interaction.js";
+import { bindInteractionTransitionPort } from "../../src/lib/interaction/transition-port.js";
 import { reactiveBox } from "../helpers/reactive-box.svelte.js";
 import {
   candidateHit,
@@ -385,9 +386,18 @@ describe("createInspectionState setInspection(null) clear ordering", () => {
     const stateTag = (): string => (controllerRef?.inspection === null ? "null" : "non-null");
 
     const handle = withFlushedEffectRoot(() => {
+      const wiring: Parameters<typeof bindInteractionTransitionPort>[0] = {};
+      const port = bindInteractionTransitionPort(wiring);
+      wiring.surface = {
+        reducer: createInteractionReducer(),
+        activeTool: "inspect",
+        clearBrush: () => {},
+        chooseTool: () => {},
+        clearTouchInspectStart: () => {},
+      };
       const controller = createInspectionState({
         model: () => model,
-        reducer: () => createInteractionReducer(),
+        port,
         inspectConfig: defaultInspect,
         inspectEnabled: () => true,
         dataIdentityEpoch: () => "epoch-1",
@@ -397,8 +407,6 @@ describe("createInspectionState setInspection(null) clear ordering", () => {
         plotId: () => "plot",
         tooltipHovered: () => false,
         clearTooltipHovered: () => {},
-        clearBrush: () => {},
-        chooseTool: () => {},
         oninspect: () => (event) => {
           if (event.phase === "clear") log.push(`emit-clear-inspection-${stateTag()}`);
         },
@@ -406,6 +414,7 @@ describe("createInspectionState setInspection(null) clear ordering", () => {
         announce: () => {},
         clearAnnouncement: () => {},
       });
+      wiring.inspection = controller;
       controllerRef = controller;
       return controller;
     });

--- a/packages/svelte/tests/interaction/transition-owner.test.ts
+++ b/packages/svelte/tests/interaction/transition-owner.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Interaction transition owner — observable transition routing through the port.
+ */
+import { flushSync } from "svelte";
+import { describe, expect, it } from "vitest";
+
+import { bindInteractionTransitionPort } from "../../src/lib/interaction/transition-port.js";
+import { createInteractionReducer } from "../../src/lib/interaction/reducer.js";
+import { createInspectionState } from "../../src/lib/inspection/inspection-state.svelte.js";
+import { candidateHit, continuousSpec, modelFor } from "../inspection/inspection-state.harness.js";
+import { withFlushedEffectRoot } from "../helpers/effect-root.svelte.js";
+
+describe("InteractionTransitionPort", () => {
+  it("routes dismiss inspection to clear brush and return to inspect through one port", () => {
+    const model = modelFor(continuousSpec());
+    let brushCleared = 0;
+    let chooseToolCalls: string[] = [];
+    const wiring: Parameters<typeof bindInteractionTransitionPort>[0] = {};
+    const port = bindInteractionTransitionPort(wiring);
+
+    const reducer = createInteractionReducer();
+    wiring.surface = {
+      reducer,
+      activeTool: "select-area",
+      clearBrush: () => {
+        brushCleared++;
+      },
+      chooseTool: (tool) => {
+        chooseToolCalls.push(tool);
+      },
+      clearTouchInspectStart: () => {},
+    };
+
+    const { value: inspection, destroy } = withFlushedEffectRoot(() =>
+      createInspectionState({
+        model: () => model,
+        port,
+        inspectConfig: () => ({ pin: true }),
+        inspectEnabled: () => true,
+        dataIdentityEpoch: () => "epoch-1",
+        keyAt: () => null,
+        root: () => null,
+        captureSurface: () => null,
+        plotId: () => "plot-test",
+        tooltipHovered: () => false,
+        clearTooltipHovered: () => {},
+        oninspect: () => {},
+        oninteraction: () => {},
+        announce: () => {},
+        clearAnnouncement: () => {},
+      }),
+    );
+    wiring.inspection = inspection;
+
+    const { candidate, hit } = candidateHit(model);
+    inspection.setInspection(hit, "pointer", "pinned", "xy", candidate);
+    flushSync();
+
+    inspection.dismissInspection("escape", "keyboard", { returnToInspect: true });
+    flushSync();
+
+    expect(inspection.inspection).toBeNull();
+    expect(brushCleared).toBe(1);
+    expect(chooseToolCalls).toEqual(["inspect"]);
+
+    destroy();
+  });
+});

--- a/packages/svelte/tests/interval/interval-state.construction-modes.test.ts
+++ b/packages/svelte/tests/interval/interval-state.construction-modes.test.ts
@@ -9,6 +9,7 @@ import { encodeKey } from "@ggsvelte/core";
 
 import { withEffectRoot } from "../helpers/effect-root.svelte.js";
 import { reactiveBox } from "../helpers/reactive-box.svelte.js";
+import { bindInteractionTransitionPort } from "../../src/lib/interaction/transition-port.js";
 import {
   bandXSpec,
   brushEvent,
@@ -38,35 +39,56 @@ describe("createIntervalState construction", () => {
     // read is not production-shaped and would defeat identity assertions).
     const constructionModel = modelFor(continuousSpec());
 
+    const wiring: Parameters<typeof bindInteractionTransitionPort>[0] = {};
+    const port = bindInteractionTransitionPort(wiring);
+    wiring.zoom = {
+      applyBrushZoom: () => {},
+      commitZoom: () => {
+        commitZoomCalls++;
+      },
+    };
+    wiring.selection = {
+      emitSelection: () => {
+        emitCalls++;
+      },
+      togglePointKeys: () => {},
+    };
+    wiring.inspection = {
+      get inspection() {
+        return null;
+      },
+      get inspectionPanel() {
+        inspectionPanelCalls++;
+        return null;
+      },
+      schedulePointerInspect: () => {},
+      cancelPointerInspect: () => {},
+      onInspectPointerFrame: () => true,
+      setInspection: () => {},
+      closeInspection: () => {},
+      dismissInspection: () => {},
+      toggleInspectionPin: () => {},
+      navigateDirection: () => {},
+      cycleCoincident: () => {},
+      resetTraversalIndex: () => {},
+    };
+    wiring.model = () => constructionModel;
+
     const { value: state, destroy } = withEffectRoot(() =>
       createIntervalState({
         model: () => constructionModel,
+        port,
         interaction: noController,
         resolvedInteractionScope: () => defaultScope,
         selectConfig: persistentSelect,
         effectiveZoomDomains: () => null,
-        commitZoom: () => {
-          commitZoomCalls++;
-        },
-        coordFlipped: () => false,
         captureSurface: () => null,
-        // Issue #165 history: under the retired eager-SSR floor, a
-        // pre-populated non-union controller + non-null model reached this
-        // at construction. Deriveds are lazy at the 5.33.1 floor, so this
-        // guard pins the common empty-intervals construction path only.
         candidateSemanticKeys: (candidate) => {
           candidateSemanticKeysCalls++;
           return identityCandidateKeys(candidate);
         },
         consumptionCandidates: () => {
           throw new Error("consumptionCandidates must remain lazy for empty intervals");
-        },
-        inspectionPanel: () => {
-          inspectionPanelCalls++;
-          return null;
-        },
-        emitSelection: () => {
-          emitCalls++;
         },
         announce: () => {
           announceCalls++;

--- a/packages/svelte/tests/interval/interval-state.harness.ts
+++ b/packages/svelte/tests/interval/interval-state.harness.ts
@@ -14,6 +14,10 @@ import type {
 } from "../../src/lib/interaction/interaction.js";
 import { createPlotInteraction } from "../../src/lib/interaction/controller.svelte.js";
 import {
+  bindInteractionTransitionPort,
+  type InteractionTransitionWiring,
+} from "../../src/lib/interaction/transition-port.js";
+import {
   createIntervalState,
   type IntervalStateDeps,
 } from "../../src/lib/interval/interval-state.svelte.js";
@@ -135,39 +139,77 @@ export type IntervalHarness = {
   destroy: () => void;
 };
 
+type IntervalMountOptions = {
+  model?: () => RenderModel | null;
+  interaction?: () => MaybeController;
+  resolvedInteractionScope?: () => PlotInteractionScope;
+  selectConfig?: () => SelectConfig;
+  effectiveZoomDomains?: () => ContinuousZoomDomains | null;
+  commitZoom?: (domains: ContinuousZoomDomains | null, source: InteractionSource) => void;
+  captureSurface?: () => HTMLDivElement | null;
+  candidateSemanticKeys?: (candidate: CandidateFacts) => PropertyKey[];
+  consumptionCandidates?: IntervalStateDeps["consumptionCandidates"];
+  inspectionPanel?: () => ScenePanel | null;
+  emitSelection?: (event: PlotSelection) => void;
+  announce?: (message: string) => void;
+};
+
 /**
  * Mount the controller with production-shaped deps: every reactive dep is a
  * getter (mirroring IntervalStateDeps). Tests that need reactivity pass
  * getters over their own reactive boxes; omitted options get static defaults.
  */
-export function mountIntervalController(
-  options: {
-    model?: () => RenderModel | null;
-    interaction?: () => MaybeController;
-    resolvedInteractionScope?: () => PlotInteractionScope;
-    selectConfig?: () => SelectConfig;
-    effectiveZoomDomains?: () => ContinuousZoomDomains | null;
-    commitZoom?: IntervalStateDeps["commitZoom"];
-    coordFlipped?: () => boolean;
-    captureSurface?: () => HTMLDivElement | null;
-    candidateSemanticKeys?: (candidate: CandidateFacts) => PropertyKey[];
-    consumptionCandidates?: IntervalStateDeps["consumptionCandidates"];
-    inspectionPanel?: () => ScenePanel | null;
-    emitSelection?: (event: PlotSelection) => void;
-    announce?: (message: string) => void;
-  } = {},
-): IntervalHarness {
+export function mountIntervalController(options: IntervalMountOptions = {}): IntervalHarness {
   const defaultModel = modelFor(continuousSpec());
+  const wiring: InteractionTransitionWiring = {};
+  const port = bindInteractionTransitionPort(wiring);
+  let commitZoomCalls = 0;
+  let emitSelectionCalls = 0;
+  let inspectionPanelCalls = 0;
+
+  wiring.zoom = {
+    applyBrushZoom: () => {},
+    commitZoom: (domains, source) => {
+      commitZoomCalls++;
+      options.commitZoom?.(domains, source);
+    },
+  };
+  wiring.selection = {
+    emitSelection: (event) => {
+      emitSelectionCalls++;
+      options.emitSelection?.(event);
+    },
+    togglePointKeys: () => {},
+  };
+  wiring.inspection = {
+    get inspection() {
+      return null;
+    },
+    get inspectionPanel() {
+      inspectionPanelCalls++;
+      return options.inspectionPanel?.() ?? null;
+    },
+    schedulePointerInspect: () => {},
+    cancelPointerInspect: () => {},
+    onInspectPointerFrame: () => true,
+    setInspection: () => {},
+    closeInspection: () => {},
+    dismissInspection: () => {},
+    toggleInspectionPin: () => {},
+    navigateDirection: () => {},
+    cycleCoincident: () => {},
+    resetTraversalIndex: () => {},
+  };
+  wiring.model = () => options.model?.() ?? defaultModel;
 
   const { value: state, destroy } = withFlushedEffectRoot(() =>
     createIntervalState({
       model: options.model ?? (() => defaultModel),
+      port,
       interaction: options.interaction ?? noController,
       resolvedInteractionScope: options.resolvedInteractionScope ?? (() => defaultScope),
       selectConfig: options.selectConfig ?? persistentSelect,
       effectiveZoomDomains: options.effectiveZoomDomains ?? (() => null),
-      commitZoom: options.commitZoom ?? (() => {}),
-      coordFlipped: options.coordFlipped ?? (() => false),
       captureSurface: options.captureSurface ?? (() => null),
       candidateSemanticKeys: options.candidateSemanticKeys ?? identityCandidateKeys,
       consumptionCandidates:
@@ -187,11 +229,13 @@ export function mountIntervalController(
           }
           return candidates;
         }),
-      inspectionPanel: options.inspectionPanel ?? (() => null),
-      emitSelection: options.emitSelection ?? (() => {}),
       announce: options.announce ?? (() => {}),
     }),
   );
+
+  void commitZoomCalls;
+  void emitSelectionCalls;
+  void inspectionPanelCalls;
 
   return { state, destroy };
 }

--- a/packages/svelte/tests/legend/filter-state.test.ts
+++ b/packages/svelte/tests/legend/filter-state.test.ts
@@ -91,7 +91,7 @@ describe("createLegendFilterState toggle and mode", () => {
         },
         model: () => model,
       });
-      controller.registerCatalogEffects(() => controller.computeEntries(model));
+      controller.attachCatalogEffects(() => controller.computeEntries(model));
       return controller;
     });
 
@@ -147,7 +147,7 @@ describe("createLegendFilterState toggle and mode", () => {
         announce: () => {},
         model: () => model,
       });
-      controller.registerCatalogEffects(() => controller.computeEntries(model));
+      controller.attachCatalogEffects(() => controller.computeEntries(model));
       return controller;
     });
 
@@ -284,7 +284,7 @@ describe("createLegendFilterState capability and mode reset", () => {
         },
         model: () => model,
       });
-      controller.registerCatalogEffects(() => controller.computeEntries(model));
+      controller.attachCatalogEffects(() => controller.computeEntries(model));
       return controller;
     });
 
@@ -332,7 +332,7 @@ describe("createLegendFilterState capability and mode reset", () => {
         announce: () => {},
         model: () => model,
       });
-      controller.registerCatalogEffects(() => controller.computeEntries(model));
+      controller.attachCatalogEffects(() => controller.computeEntries(model));
       return controller;
     });
 
@@ -377,7 +377,7 @@ describe("createLegendFilterState catalog reconciliation", () => {
         announce: () => {},
         model: () => modelBox.value,
       });
-      controller.registerCatalogEffects(() => controller.computeEntries(modelBox.value));
+      controller.attachCatalogEffects(() => controller.computeEntries(modelBox.value));
       return controller;
     });
 
@@ -437,10 +437,9 @@ describe("runtime + legend-filter real cycle", () => {
         effectiveLegendFilters: () => controller.filters,
       });
       runtimeRef = runtime;
-      // Host registration order (GGPlot.svelte): model -> catalog -> late.
       runtime.registerModelEffects();
-      controller.registerCatalogEffects(() => controller.computeEntries(runtime.model));
-      runtime.registerLateEffects();
+      controller.attachCatalogEffects(() => controller.computeEntries(runtime.model));
+      runtimeDeps.attachLateEffects();
       return { runtime, controller };
     });
 

--- a/packages/svelte/tests/legend/focus-state.harness.ts
+++ b/packages/svelte/tests/legend/focus-state.harness.ts
@@ -99,6 +99,7 @@ export function mountFocusController(
     });
     let entriesRef: () => readonly InteractiveLegendEntry[] = () => [];
     let pressedRef: () => LegendEntryIdentity | null = () => null;
+    let attachReconcile!: () => void;
     const controller = createLegendFocusState({
       interaction: options.interaction ?? noController,
       resolvedInteractionScope: () => defaultScope,
@@ -111,11 +112,13 @@ export function mountFocusController(
       onlegendfocus: options.onlegendfocus ?? noCallback,
       oninteraction: options.oninteraction ?? noCallback,
       announce: options.announce ?? (() => {}),
+      onRegisterEffects: (attach) => {
+        attachReconcile = attach;
+      },
     });
-    // Deferred refs mirror the host's later-declared deriveds.
     entriesRef = () => controller.computeInteractiveEntries(model());
     pressedRef = () => controller.computeLegendPressed(model());
-    controller.registerReconcileEffects();
+    attachReconcile();
     return controller;
   });
 

--- a/packages/svelte/tests/legend/focus-state.integration.test.ts
+++ b/packages/svelte/tests/legend/focus-state.integration.test.ts
@@ -52,6 +52,7 @@ describe("runtime + legend-focus real cycle", () => {
       let entriesRef: () => readonly InteractiveLegendEntry[] = () => [];
       let pressedRef: () => LegendEntryIdentity | null = () => null;
       let entryKeysRef: ReturnType<typeof createLegendEntryKeyIndex> | null = null;
+      let attachReconcile!: () => void;
       const focus = createLegendFocusState({
         interaction: noController,
         resolvedInteractionScope: () => defaultScope,
@@ -66,6 +67,9 @@ describe("runtime + legend-focus real cycle", () => {
         },
         oninteraction: noCallback,
         announce: () => {},
+        onRegisterEffects: (attach) => {
+          attachReconcile = attach;
+        },
       });
       const runtime = createPlotRuntime({
         ...runtimeDeps,
@@ -88,8 +92,8 @@ describe("runtime + legend-focus real cycle", () => {
       pressedRef = () => focus.computeLegendPressed(runtime.model);
       // Host registration order: model -> catalog(S2) -> reconcile(S3) -> late.
       runtime.registerModelEffects();
-      focus.registerReconcileEffects();
-      runtime.registerLateEffects();
+      attachReconcile();
+      runtimeDeps.attachLateEffects();
       runtimeDeps.setOnrender((model) => {
         renders.push(model);
       });

--- a/packages/svelte/tests/plot-orchestrator-contract.ssr.test.ts
+++ b/packages/svelte/tests/plot-orchestrator-contract.ssr.test.ts
@@ -4,27 +4,13 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 const orchestratorPath = join(import.meta.dirname, "../src/lib/plot-orchestrator.svelte.ts");
-const interactionAssemblyPath = join(
-  import.meta.dirname,
-  "../src/lib/plot-interaction-assembly.svelte.ts",
-);
-
-function expectOrdered(source: string, tokens: readonly string[]): void {
-  let previousIndex = -1;
-  for (const token of tokens) {
-    const index = source.indexOf(token);
-    expect(index, `missing orchestrator contract token: ${token}`).toBeGreaterThanOrEqual(0);
-    expect(
-      index,
-      `${token} must remain after ${tokens[tokens.indexOf(token) - 1]}`,
-    ).toBeGreaterThan(previousIndex);
-    previousIndex = index;
-  }
-}
+const assemblyPath = join(import.meta.dirname, "../src/lib/plot-interaction-assembly.svelte.ts");
+const transitionPortPath = join(import.meta.dirname, "../src/lib/interaction/transition-port.ts");
 
 describe("plot interaction assembly lifecycle contract", () => {
   const orchestratorSource = readFileSync(orchestratorPath, "utf8");
-  const assemblySource = readFileSync(interactionAssemblyPath, "utf8");
+  const assemblySource = readFileSync(assemblyPath, "utf8");
+  const transitionPortSource = readFileSync(transitionPortPath, "utf8");
 
   it("keeps interaction topology behind the assembly seam", () => {
     expect(orchestratorSource).toContain("createPlotInteractionAssembly(");
@@ -46,21 +32,23 @@ describe("plot interaction assembly lifecycle contract", () => {
     }
   });
 
-  it("keeps controller construction in dependency order", () => {
-    expectOrdered(assemblySource, [
-      "const zoomState = createPlotZoomState(",
-      "const legendFilterState = createLegendFilterState(",
-      "const runtime = createPlotRuntime(",
-      "const semanticKeys = createSemanticKeyService(",
-      "const legendEntryKeys = createLegendEntryKeyIndex(",
-      "const inspectionState = createInspectionState(",
-      "const surfaceState = createSurfaceState(",
-      "const selectionState = createSelectionState(",
-      "const legendFocusState = createLegendFocusState(",
-      "const intervalState = createIntervalState(",
-      "const semanticCandidateProjection = createSemanticCandidateProjection(",
-      "const chromeState = createPlotChromeState(",
-    ]);
+  it("routes sibling interaction transitions through one port owner", () => {
+    expect(assemblySource).toContain("bindInteractionTransitionPort(");
+    expect(assemblySource).toContain("port,");
+    expect(transitionPortSource).toContain("bindInteractionTransitionPort(");
+    for (const deferredSibling of [
+      "inspection: () => inspectionState",
+      "interval: () => intervalState",
+      "reducer: () => surfaceState.reducer",
+      "clearBrush: () =>",
+      "registerSurfaceEffects();",
+      "registerInspectionEffects();",
+      "registerCatalogEffects(",
+      "registerReconcileEffects();",
+      "registerLateEffects();",
+    ]) {
+      expect(assemblySource).not.toContain(deferredSibling);
+    }
   });
 
   it("uses the model-owned CandidateStore without constructing a second hit index", () => {
@@ -77,17 +65,5 @@ describe("plot interaction assembly lifecycle contract", () => {
     ]) {
       expect(assemblySource).not.toContain(implementationDetail);
     }
-  });
-
-  it("keeps phased effects in registration order", () => {
-    expectOrdered(assemblySource, [
-      "runtime.registerModelEffects();",
-      "semanticKeys.registerEffects();",
-      "surfaceState.registerSurfaceEffects();",
-      "legendFilterState.registerCatalogEffects(",
-      "legendFocusState.registerReconcileEffects();",
-      "inspectionState.registerInspectionEffects();",
-      "runtime.registerLateEffects();",
-    ]);
   });
 });

--- a/packages/svelte/tests/runtime/runtime.test.ts
+++ b/packages/svelte/tests/runtime/runtime.test.ts
@@ -71,7 +71,7 @@ describe("createPlotRuntime construction", () => {
       });
       const rt = createPlotRuntime(deps);
       rt.registerModelEffects();
-      rt.registerLateEffects();
+      deps.attachLateEffects();
       return { runtime: rt, deps };
     });
     const { runtime, deps } = value;
@@ -109,7 +109,7 @@ describe("createPlotRuntime model production", () => {
       });
       const rt = createPlotRuntime(deps);
       rt.registerModelEffects();
-      rt.registerLateEffects();
+      deps.attachLateEffects();
       return rt;
     });
 
@@ -141,7 +141,7 @@ describe("createPlotRuntime model production", () => {
       });
       const rt = createPlotRuntime(deps);
       rt.registerModelEffects();
-      rt.registerLateEffects();
+      deps.attachLateEffects();
       return rt;
     });
 
@@ -225,7 +225,7 @@ describe("createPlotRuntime model production", () => {
       });
       const rt = createPlotRuntime(deps);
       rt.registerModelEffects();
-      rt.registerLateEffects();
+      deps.attachLateEffects();
       return rt;
     });
 
@@ -259,7 +259,7 @@ describe("createPlotRuntime model production", () => {
       });
       const rt = createPlotRuntime(deps);
       rt.registerModelEffects();
-      rt.registerLateEffects();
+      deps.attachLateEffects();
       return rt;
     });
 
@@ -331,7 +331,7 @@ describe("createPlotRuntime model production", () => {
         deps.setWidth("container");
         const rt = createPlotRuntime(deps);
         rt.registerModelEffects();
-        rt.registerLateEffects();
+        deps.attachLateEffects();
         return rt;
       });
 

--- a/packages/svelte/tests/runtime/semantic-keys-service.test.ts
+++ b/packages/svelte/tests/runtime/semantic-keys-service.test.ts
@@ -34,6 +34,7 @@ describe("createSemanticKeyService", () => {
     const diagnostics: string[] = [];
 
     const { value: service, destroy } = withFlushedEffectRoot(() => {
+      let attachSemantic!: () => void;
       const created = createSemanticKeyService({
         model: () => model.value,
         assembled: () => ({
@@ -48,8 +49,11 @@ describe("createSemanticKeyService", () => {
         deliverDiagnostic: (d) => {
           diagnostics.push(d.code);
         },
+        onRegisterEffects: (attach) => {
+          attachSemantic = attach;
+        },
       });
-      created.registerEffects();
+      attachSemantic();
       return created;
     });
 
@@ -107,8 +111,8 @@ describe("createSemanticKeyService", () => {
         spec: () => null,
         sourceIdentity: (value) => tracker.sourceIdentity(value),
         deliverDiagnostic: () => {},
+        onRegisterEffects: (attach) => attach(),
       });
-      created.registerEffects();
       return created;
     });
 
@@ -152,8 +156,8 @@ describe("createSemanticKeyService", () => {
         deliverDiagnostic: (d) => {
           diagnostics.push(d.code);
         },
+        onRegisterEffects: (attach) => attach(),
       });
-      created.registerEffects();
       return created;
     });
 

--- a/packages/svelte/tests/surface/surface-state.construction-effects.test.ts
+++ b/packages/svelte/tests/surface/surface-state.construction-effects.test.ts
@@ -4,6 +4,7 @@
 import { flushSync } from "svelte";
 import { describe, expect, it } from "vitest";
 
+import { bindInteractionTransitionPort } from "../../src/lib/interaction/transition-port.js";
 import { hitFromCandidate } from "../../src/lib/surface/plot-px.js";
 import { withEffectRoot } from "../helpers/effect-root.svelte.js";
 import {
@@ -13,10 +14,8 @@ import {
   createSurfaceState,
   normalizeInteractionConfig,
   modelFor,
-  fromAny,
   panelCenterClient,
   pointerEvent,
-  type SurfaceStateDeps,
   type InteractionTool,
 } from "./surface-state.harness.js";
 
@@ -44,74 +43,13 @@ describe("createSurfaceState construction", () => {
     let coordFlippedCalls = 0;
     let surfaceInteractiveCalls = 0;
 
-    // Minimal stubs so construction can close the cycle without real siblings.
-    const stubInspection = fromAny<
-      SurfaceStateDeps["inspection"] extends () => infer R ? R : never
-    >({
-      get inspection() {
-        inspectionCalls++;
-        return null;
-      },
-      get inspectionPanel() {
-        inspectionCalls++;
-        return null;
-      },
-      schedulePointerInspect: () => {
-        inspectionCalls++;
-      },
-      cancelPointerInspect: () => {
-        inspectionCalls++;
-      },
-      onInspectPointerFrame: () => {
-        inspectionCalls++;
-        return true;
-      },
-      setInspection: () => {
-        inspectionCalls++;
-      },
-      closeInspection: () => {
-        inspectionCalls++;
-      },
-      dismissInspection: () => {
-        inspectionCalls++;
-      },
-      toggleInspectionPin: () => {
-        inspectionCalls++;
-      },
-      navigateDirection: () => {
-        inspectionCalls++;
-      },
-      cycleCoincident: () => {
-        inspectionCalls++;
-      },
-      resetTraversalIndex: () => {
-        inspectionCalls++;
-      },
-    });
+    const wiring: Parameters<typeof bindInteractionTransitionPort>[0] = {};
+    const port = bindInteractionTransitionPort(wiring);
 
-    const stubInterval = fromAny<SurfaceStateDeps["interval"] extends () => infer R ? R : never>({
-      get committedInterval() {
-        intervalCalls++;
-        return null;
-      },
-      finishBrushSelect: () => {
-        intervalCalls++;
-      },
-    });
-
-    const stubZoom = fromAny<SurfaceStateDeps["zoom"] extends () => infer R ? R : never>({
-      applyBrushZoom: () => {
-        zoomCalls++;
-      },
-    });
-
-    const { value: state, destroy } = withEffectRoot(() =>
-      createSurfaceState({
+    const { value: state, destroy } = withEffectRoot(() => {
+      const surface = createSurfaceState({
         model: () => model,
-        coordFlipped: () => {
-          coordFlippedCalls++;
-          return false;
-        },
+        port,
         root: () => null,
         toolProp: () => {
           toolPropCalls++;
@@ -134,39 +72,94 @@ describe("createSurfaceState construction", () => {
           surfaceInteractiveCalls++;
           return true;
         },
-        candidateSemanticKeys: () => {
-          candidateSemanticKeysCalls++;
-          return [];
-        },
-        inspection: () => {
-          inspectionCalls++;
-          return stubInspection;
-        },
-        interval: () => {
-          intervalCalls++;
-          return stubInterval;
-        },
-        zoom: () => {
-          zoomCalls++;
-          return stubZoom;
-        },
-        emitSelection: () => {
-          emitSelectionCalls++;
-        },
-        semanticKey: () => {
-          semanticKeyCalls++;
-          return null;
-        },
-        togglePointKeys: () => {
-          togglePointKeysCalls++;
-        },
         tooltipHovered: () => {
           tooltipHoveredCalls++;
           return false;
         },
         announce: () => {},
-      }),
-    );
+      });
+      wiring.surface = {
+        reducer: surface.reducer,
+        activeTool: surface.activeTool,
+        clearBrush: () => surface.clearBrush(),
+        chooseTool: (tool) => surface.chooseTool(tool),
+        clearTouchInspectStart: () => surface.clearTouchInspectStart(),
+      };
+      wiring.inspection = {
+        get inspection() {
+          inspectionCalls++;
+          return null;
+        },
+        get inspectionPanel() {
+          inspectionCalls++;
+          return null;
+        },
+        schedulePointerInspect: () => {
+          inspectionCalls++;
+        },
+        cancelPointerInspect: () => {
+          inspectionCalls++;
+        },
+        onInspectPointerFrame: () => {
+          inspectionCalls++;
+          return true;
+        },
+        setInspection: () => {
+          inspectionCalls++;
+        },
+        closeInspection: () => {
+          inspectionCalls++;
+        },
+        dismissInspection: () => {
+          inspectionCalls++;
+        },
+        toggleInspectionPin: () => {
+          inspectionCalls++;
+        },
+        navigateDirection: () => {
+          inspectionCalls++;
+        },
+        cycleCoincident: () => {
+          inspectionCalls++;
+        },
+        resetTraversalIndex: () => {
+          inspectionCalls++;
+        },
+      };
+      wiring.interval = {
+        get committedInterval() {
+          intervalCalls++;
+          return null;
+        },
+        finishBrushSelect: () => {
+          intervalCalls++;
+        },
+      };
+      wiring.zoom = {
+        applyBrushZoom: () => {
+          zoomCalls++;
+        },
+        commitZoom: () => {},
+      };
+      wiring.selection = {
+        emitSelection: () => {
+          emitSelectionCalls++;
+        },
+        togglePointKeys: () => {
+          togglePointKeysCalls++;
+        },
+      };
+      wiring.semanticKey = () => {
+        semanticKeyCalls++;
+        return null;
+      };
+      wiring.candidateSemanticKeys = () => {
+        candidateSemanticKeysCalls++;
+        return [];
+      };
+      wiring.model = () => model;
+      return surface;
+    });
 
     // Public accessors only (+ flush) — brushing is private.
     expect(state.reducer).toBeDefined();
@@ -204,44 +197,15 @@ describe("createSurfaceState construction", () => {
       zoom: true,
     });
     let inspectConfigCalls = 0;
-    const stubInspection = fromAny<
-      SurfaceStateDeps["inspection"] extends () => infer R ? R : never
-    >({
-      get inspection() {
-        return null;
-      },
-      schedulePointerInspect: () => {},
-      cancelPointerInspect: () => {},
-      onInspectPointerFrame: () => true,
-      setInspection: () => {},
-      closeInspection: () => {},
-      dismissInspection: () => {},
-      toggleInspectionPin: () => {},
-      navigateDirection: () => {},
-      cycleCoincident: () => {},
-      resetTraversalIndex: () => {},
-      get inspectionPanel() {
-        return null;
-      },
-    });
-    const stubInterval = fromAny<SurfaceStateDeps["interval"] extends () => infer R ? R : never>({
-      finishBrushSelect: () => {},
-      get committedInterval() {
-        return null;
-      },
-    });
-    const stubZoom = fromAny<SurfaceStateDeps["zoom"] extends () => infer R ? R : never>({
-      applyBrushZoom: () => {},
-    });
+    const wiring: Parameters<typeof bindInteractionTransitionPort>[0] = {};
+    const port = bindInteractionTransitionPort(wiring);
 
-    const { value: state, destroy } = withEffectRoot(() =>
-      createSurfaceState({
+    const { value: state, destroy } = withEffectRoot(() => {
+      const surface = createSurfaceState({
         model: () => model,
-        coordFlipped: () => false,
+        port,
         root: () => null,
-        toolProp: () => {
-          /* uncontrolled */
-        },
+        toolProp: () => {},
         initialTool: () => config.initialTool,
         availableTools: () => config.availableTools,
         inspectConfig: () => {
@@ -250,21 +214,49 @@ describe("createSurfaceState construction", () => {
         },
         selectConfig: () => config.select,
         pointSelectEnabled: () => false,
-        ontoolchange: () => {
-          /* no controlled callback */
-        },
+        ontoolchange: () => {},
         surfaceInteractive: () => true,
-        candidateSemanticKeys: () => [],
-        inspection: () => stubInspection,
-        interval: () => stubInterval,
-        zoom: () => stubZoom,
-        emitSelection: () => {},
-        semanticKey: () => null,
-        togglePointKeys: () => {},
         tooltipHovered: () => false,
         announce: () => {},
-      }),
-    );
+      });
+      wiring.surface = {
+        reducer: surface.reducer,
+        activeTool: surface.activeTool,
+        clearBrush: () => surface.clearBrush(),
+        chooseTool: (tool) => surface.chooseTool(tool),
+        clearTouchInspectStart: () => surface.clearTouchInspectStart(),
+      };
+      wiring.inspection = {
+        get inspection() {
+          return null;
+        },
+        get inspectionPanel() {
+          return null;
+        },
+        schedulePointerInspect: () => {},
+        cancelPointerInspect: () => {},
+        onInspectPointerFrame: () => true,
+        setInspection: () => {},
+        closeInspection: () => {},
+        dismissInspection: () => {},
+        toggleInspectionPin: () => {},
+        navigateDirection: () => {},
+        cycleCoincident: () => {},
+        resetTraversalIndex: () => {},
+      };
+      wiring.interval = {
+        get committedInterval() {
+          return null;
+        },
+        finishBrushSelect: () => {},
+      };
+      wiring.zoom = { applyBrushZoom: () => {}, commitZoom: () => {} };
+      wiring.selection = { emitSelection: () => {}, togglePointKeys: () => {} };
+      wiring.semanticKey = () => null;
+      wiring.candidateSemanticKeys = () => [];
+      wiring.model = () => model;
+      return surface;
+    });
 
     flushSync();
     inspectConfigCalls = 0;

--- a/packages/svelte/tests/surface/surface-state.harness.ts
+++ b/packages/svelte/tests/surface/surface-state.harness.ts
@@ -21,6 +21,10 @@ import type {
   PlotSelection,
 } from "../../src/lib/interaction/interaction.js";
 import { normalizeInteractionConfig } from "../../src/lib/interaction/interaction.js";
+import {
+  bindInteractionTransitionPort,
+  type InteractionTransitionWiring,
+} from "../../src/lib/interaction/transition-port.js";
 import { createPlotInteraction } from "../../src/lib/interaction/controller.svelte.js";
 import {
   createInspectionState,
@@ -271,34 +275,32 @@ export function mountSurfaceComposite(
   const semanticKey = identitySemanticKey();
 
   const { value: bundle, destroy: destroyRoot } = withFlushedEffectRoot(() => {
-    // Production order: zoom → inspection → surface → interval → effects.
-    // Deferred getters close over later const bindings (handler/effect only).
-    let surface!: SurfaceState;
-    let interval!: IntervalState;
+    const wiring: InteractionTransitionWiring = {};
+    const port = bindInteractionTransitionPort(wiring);
+    const effectRegistrars: Array<() => void> = [];
+    const collectEffects = (attach: () => void): void => {
+      effectRegistrars.push(attach);
+    };
 
-    // 1. zoom (pre-existing)
+    const selectionController = createPlotInteraction<PropertyKey>();
+
     const zoom = createPlotZoomState({
       interaction: noController,
       resolvedInteractionScope: () => ({ keys: "plot", x: "x", y: "y" }),
       zoomConfig: () => config.zoom,
       assembled: () => options.spec ?? continuousSpec(),
       model: () => model,
-      coordFlipped: () => false,
-      onzoom: () => {
-        /* no callback */
-      },
-      oninteraction: () => {
-        /* no callback */
-      },
+      onzoom: () => {},
+      oninteraction: () => {},
       announce: (message) => {
         announcements.push(message);
       },
     });
+    wiring.zoom = zoom;
 
-    // 2. inspection (before surface — reversed reducer dep)
     const inspection = createInspectionState({
       model: () => model,
-      reducer: () => surface.reducer,
+      port,
       inspectConfig: () => config.inspect,
       inspectEnabled: () => config.inspect !== null,
       dataIdentityEpoch: () => "epoch-1",
@@ -308,28 +310,19 @@ export function mountSurfaceComposite(
       plotId: () => "plot-test",
       tooltipHovered: () => false,
       clearTooltipHovered: () => {},
-      clearBrush: () => {
-        surface.clearBrush();
-      },
-      chooseTool: (next) => {
-        surface.chooseTool(next);
-      },
-      oninspect: () => {
-        /* no callback */
-      },
-      oninteraction: () => {
-        /* no callback */
-      },
+      oninspect: () => {},
+      oninteraction: () => {},
       announce: (message) => {
         announcements.push(message);
       },
       clearAnnouncement: () => {},
+      onRegisterEffects: collectEffects,
     });
+    wiring.inspection = inspection;
 
-    // 3. surface (owns reducer). Global rAF is the deferred suite pump.
-    surface = createSurfaceState({
+    const surface = createSurfaceState({
       model: () => model,
-      coordFlipped: () => false,
+      port,
       root: () => root,
       toolProp: () => toolPropBox.value,
       initialTool: () => config.initialTool,
@@ -339,43 +332,30 @@ export function mountSurfaceComposite(
       pointSelectEnabled: () => config.select?.type === "point",
       ontoolchange: () => onToolChangeBox.value,
       surfaceInteractive: () => options.surfaceInteractive ?? true,
-      candidateSemanticKeys: identityCandidateKeys,
-      inspection: () => inspection,
-      interval: () => interval,
-      zoom: () => zoom,
-      emitSelection: (event) => {
-        if (event.phase === "end") {
-          selectionOrderLog.push(
-            interval.committedInterval === null
-              ? "emit:end:before-commit"
-              : "emit:end:after-commit",
-          );
-        } else {
-          selectionOrderLog.push(`emit:${event.phase}`);
-        }
-        selectionEvents.push(event);
-      },
-      semanticKey,
-      togglePointKeys: (keys, source) => {
-        toggleCalls.push({ keys, source });
-      },
       tooltipHovered: () => false,
       announce: (message) => {
         announcements.push(message);
       },
+      onRegisterEffects: collectEffects,
     });
+    wiring.surface = {
+      reducer: surface.reducer,
+      activeTool: surface.activeTool,
+      clearBrush: () => surface.clearBrush(),
+      chooseTool: (next) => surface.chooseTool(next),
+      clearTouchInspectStart: () => surface.clearTouchInspectStart(),
+    };
+    wiring.semanticKey = semanticKey;
+    wiring.candidateSemanticKeys = identityCandidateKeys;
+    wiring.model = () => model;
 
-    // 4. interval AFTER surface (production order — deferred surface→interval)
-    interval = createIntervalState({
+    const interval = createIntervalState({
       model: () => model,
+      port,
       interaction: noController,
       resolvedInteractionScope: () => ({ keys: "plot", x: "x", y: "y", intervals: "plot" }),
       selectConfig: () => config.select,
       effectiveZoomDomains: () => zoom.effectiveZoomDomains,
-      commitZoom: (domains, source) => {
-        zoom.commitZoom(domains, source);
-      },
-      coordFlipped: () => false,
       captureSurface: () => capture,
       candidateSemanticKeys: identityCandidateKeys,
       consumptionCandidates: () => {
@@ -392,7 +372,12 @@ export function mountSurfaceComposite(
         }
         return candidates;
       },
-      inspectionPanel: () => inspection.inspectionPanel,
+      announce: (message) => {
+        announcements.push(message);
+      },
+    });
+    wiring.interval = interval;
+    wiring.selection = {
       emitSelection: (event) => {
         if (event.phase === "end") {
           selectionOrderLog.push(
@@ -405,16 +390,16 @@ export function mountSurfaceComposite(
         }
         selectionEvents.push(event);
       },
-      announce: (message) => {
-        announcements.push(message);
+      togglePointKeys: (keys, source) => {
+        toggleCalls.push({ keys, source });
       },
-    });
+    };
 
-    // 5. surface effects then 6. inspection effects (host 810 vs 954)
     if (options.registerEffects !== false) {
-      surface.registerSurfaceEffects();
-      inspection.registerInspectionEffects();
+      for (const attach of effectRegistrars) attach();
     }
+
+    void selectionController;
 
     return { surface, inspection, interval, zoom };
   });


### PR DESCRIPTION
## Summary

- Introduces `InteractionTransitionPort` as the cross-module seam for interaction transitions; assembly binds leaf modules incrementally and owns deterministic effect registration order.
- Refactors surface, inspection, interval, legend, and runtime modules to route cross-module calls through the port instead of deferred sibling getters; removes public `register*Effects()` APIs in favor of internal `onRegisterEffects` / `attachCatalogEffects` hooks.
- Replaces source-order contract tests with behavior tests: `transition-owner.test.ts` verifies dismiss-inspection routes through the port to `clearBrush()` + `chooseTool("inspect")`, and the orchestrator contract asserts assembly uses `bindInteractionTransitionPort` without deferred wiring.

Closes #627

## Test plan

- [x] `packages/svelte/tests/interaction/transition-owner.test.ts` — dismiss inspection routes through port
- [x] Updated construction/integration tests for surface, inspection, interval, legend, runtime harnesses
- [x] `packages/svelte/tests/plot-orchestrator-contract.ssr.test.ts` — assembly seam contract
- [x] Full chromium vitest suite (983 tests) passes locally after core rebuild


Made with [Cursor](https://cursor.com)