### PR TITLE
fix(svelte): default bar/col inspect is tooltip-only (#633)

### DIFF
--- a/.changeset/rect-hover-mute-default-633.md
+++ b/.changeset/rect-hover-mute-default-633.md
@@ -1,0 +1,17 @@
+---
+"@ggsvelte/svelte": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+fix: default geom_col/bar inspect is tooltip-only (no sibling mute flicker)
+
+Bar/column hover no longer mutes sibling marks by default. Instant opacity
+mask toggles at bar gaps caused full-plot flicker under normal pointer
+movement. Default inspection is tooltip/ring-chrome only (rects still skip
+point rings). Opt in with `inspect={{ muteSiblings: true }}`; muted marks
+ease opacity with a short CSS transition (disabled under
+`prefers-reduced-motion`).
+
+Migration: none for typical charts. Authors who want #386-style relative
+de-emphasis on hover should set `inspect={{ muteSiblings: true }}`.

--- a/packages/svelte/src/lib/interaction/interaction.ts
+++ b/packages/svelte/src/lib/interaction/interaction.ts
@@ -135,6 +135,12 @@ export interface InspectOptions<Row = Record<string, CellValue>, Key = PropertyK
   readonly pin?: boolean;
   readonly maxDistance?: number;
   readonly contentMode?: "informational" | "interactive";
+  /**
+   * When true, inspection mutes non-focused marks (sibling bars/cols) via the
+   * interaction mask. Default false — tooltip-only hover avoids full-plot
+   * flicker when the pointer crosses gaps between rect marks (#633).
+   */
+  readonly muteSiblings?: boolean;
   readonly content?: Snippet<[PlotInspectionChange<Row, Key>]>;
 }
 

--- a/packages/svelte/src/lib/interaction/normalize-interaction-config.ts
+++ b/packages/svelte/src/lib/interaction/normalize-interaction-config.ts
@@ -32,6 +32,7 @@ export function normalizeInteractionConfig<Row, Key>(
         pin: value.pin ?? true,
         maxDistance,
         contentMode: value.contentMode ?? "informational",
+        muteSiblings: value.muteSiblings ?? false,
         ...(value.content !== undefined && { content: value.content }),
       });
     }

--- a/packages/svelte/src/lib/plot-interaction-assembly.svelte.ts
+++ b/packages/svelte/src/lib/plot-interaction-assembly.svelte.ts
@@ -384,6 +384,7 @@ export function createPlotInteractionAssembly<
     intervalKeys: () => intervalState.effectiveIntervalKeys,
     intervals: () => intervalState.effectiveIntervals,
     emphasisKeys: () => legendFocusState.effectiveEmphasisKeys,
+    muteSiblingsOnInspect: () => interactionConfig.inspect?.muteSiblings === true,
     inspectionFocus: () => {
       const current = inspectionState.inspection;
       const seed = inspectionState.inspectionSeed;

--- a/packages/svelte/src/lib/runtime/semantic-candidate-projection.svelte.ts
+++ b/packages/svelte/src/lib/runtime/semantic-candidate-projection.svelte.ts
@@ -24,6 +24,9 @@ type SemanticCandidate = IntervalConsumptionCandidate<PropertyKey> & {
   readonly kind: string;
 };
 
+/** Stable empty masks — avoid fresh `[]` identity churn on tooltip-only hover. */
+const EMPTY_INTERACTION_MASKS = Object.freeze([]) as readonly (BatchInteractionMask | null)[];
+
 /** OR two mask projections per batch (focused if either side is focused). */
 function unionInteractionMasks(
   left: readonly (BatchInteractionMask | null)[],
@@ -147,7 +150,7 @@ export function createSemanticCandidateProjection(
   );
   const interactionMasks = $derived.by((): readonly (BatchInteractionMask | null)[] => {
     const model = deps.model();
-    if (model === null) return [];
+    if (model === null) return EMPTY_INTERACTION_MASKS;
     const focus = deps.inspectionFocus();
     // Rect inspection primitives: muteSiblings opt-in, or layer under active
     // legend/controller emphasis so the seed bar stays focused (#386 / #633).
@@ -170,7 +173,7 @@ export function createSemanticCandidateProjection(
     }
     // Keyless rect inspection: layer seed primitives so legend/controller
     // emphasis keys do not suppress the hovered bar's de-emphasis (#386).
-    if (rectPrimitives === null) return keyMasks ?? [];
+    if (rectPrimitives === null) return keyMasks ?? EMPTY_INTERACTION_MASKS;
     const primitiveMasks = buildPrimitiveInteractionMasks(model.scene.batches, rectPrimitives);
     if (keyMasks === null) return primitiveMasks;
     return unionInteractionMasks(keyMasks, primitiveMasks);

--- a/packages/svelte/src/lib/runtime/semantic-candidate-projection.svelte.ts
+++ b/packages/svelte/src/lib/runtime/semantic-candidate-projection.svelte.ts
@@ -73,6 +73,11 @@ export type SemanticCandidateProjectionDeps = {
   intervalKeys: () => readonly PropertyKey[];
   intervals: () => readonly PlotInteractionInterval<PropertyKey>[];
   emphasisKeys: () => readonly PropertyKey[];
+  /**
+   * When true, rect inspection builds sibling-mute masks (#386 opt-in).
+   * Default off — tooltip-only hover (#633).
+   */
+  muteSiblingsOnInspect?: () => boolean;
   inspectionFocus: () => PresentationInspectionFocus | null;
 };
 
@@ -90,8 +95,11 @@ export type SemanticCandidateProjection = {
 export function createSemanticCandidateProjection(
   deps: SemanticCandidateProjectionDeps,
 ): SemanticCandidateProjection {
+  const muteSiblingsOnInspect = $derived(deps.muteSiblingsOnInspect?.() === true);
   const presentationFocusKeys = $derived(
-    mergePresentationFocusKeys(deps.emphasisKeys(), deps.inspectionFocus()),
+    mergePresentationFocusKeys(deps.emphasisKeys(), deps.inspectionFocus(), {
+      muteSiblings: muteSiblingsOnInspect,
+    }),
   );
   const selectedKeyCount = $derived(deps.selectedKeys().length);
   const emphasisKeyCount = $derived(deps.emphasisKeys().length);
@@ -141,8 +149,14 @@ export function createSemanticCandidateProjection(
     const model = deps.model();
     if (model === null) return [];
     const focus = deps.inspectionFocus();
+    // Rect inspection primitives: muteSiblings opt-in, or layer under active
+    // legend/controller emphasis so the seed bar stays focused (#386 / #633).
+    const applyRectInspectionMask = muteSiblingsOnInspect || emphasisKeyCount > 0;
     const rectPrimitives =
-      focus?.kind === "rects" && focus.primitives !== undefined && focus.primitives.length > 0
+      applyRectInspectionMask &&
+      focus?.kind === "rects" &&
+      focus.primitives !== undefined &&
+      focus.primitives.length > 0
         ? focus.primitives
         : null;
 
@@ -154,7 +168,7 @@ export function createSemanticCandidateProjection(
         sharedCandidateProjection,
       );
     }
-    // Keyless rect inspection: always layer seed primitives so legend/controller
+    // Keyless rect inspection: layer seed primitives so legend/controller
     // emphasis keys do not suppress the hovered bar's de-emphasis (#386).
     if (rectPrimitives === null) return keyMasks ?? [];
     const primitiveMasks = buildPrimitiveInteractionMasks(model.scene.batches, rectPrimitives);

--- a/packages/svelte/src/lib/scene/Batch.svelte
+++ b/packages/svelte/src/lib/scene/Batch.svelte
@@ -439,3 +439,18 @@
     {/each}
   </g>
 {/if}
+
+<style>
+  /* Soften mute/unmute when interaction masks are active (inspect.muteSiblings).
+     Gap flicker is primarily avoided by default-off mute (#633); this eases
+     opt-in transitions. Instant under prefers-reduced-motion. */
+  .gg-batch :global([data-gg-focused]) {
+    transition: opacity 120ms ease;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .gg-batch :global([data-gg-focused]) {
+      transition: none;
+    }
+  }
+</style>

--- a/packages/svelte/src/lib/scene/Batch.svelte
+++ b/packages/svelte/src/lib/scene/Batch.svelte
@@ -441,15 +441,18 @@
 {/if}
 
 <style>
-  /* Soften mute/unmute when interaction masks are active (inspect.muteSiblings).
-     Gap flicker is primarily avoided by default-off mute (#633); this eases
-     opt-in transitions. Instant under prefers-reduced-motion. */
-  .gg-batch :global([data-gg-focused]) {
+  /* Ease interaction-mask opacity changes (legend emphasis, muteSiblings, etc.).
+     Transition on direct mark children — not only [data-gg-focused] — so unmute
+     on mask clear still eases. Default-off mute (#633) avoids gap flicker; this
+     softens remaining mask transitions. Instant under prefers-reduced-motion. */
+  /* svelte-ignore css_unused_selector */
+  .gg-batch > :global(*) {
     transition: opacity 120ms ease;
   }
 
   @media (prefers-reduced-motion: reduce) {
-    .gg-batch :global([data-gg-focused]) {
+    /* svelte-ignore css_unused_selector */
+    .gg-batch > :global(*) {
       transition: none;
     }
   }

--- a/packages/svelte/src/lib/selection/selection.ts
+++ b/packages/svelte/src/lib/selection/selection.ts
@@ -17,7 +17,7 @@ export type CandidateAnchorKeys = {
   readonly kind?: string;
 };
 
-/** Point-like chrome by default; rect batches suppress rings (sibling mute is opt-in, #633). */
+/** Point-like chrome by default; rect batches suppress rings (#386). */
 export function presentationChromeForKind(kind: string | null | undefined): PresentationChrome {
   return kind === "rects" ? "none" : "ring";
 }

--- a/packages/svelte/src/lib/selection/selection.ts
+++ b/packages/svelte/src/lib/selection/selection.ts
@@ -1,6 +1,6 @@
 import type { InteractionSource, PointSelection } from "../interaction/interaction.js";
 
-/** Overlay chrome for a presentation anchor. Rect marks use relative de-emphasis, not rings. */
+/** Overlay chrome for a presentation anchor. Rect marks never use rings (#386). */
 export type PresentationChrome = "ring" | "none";
 
 export type PresentationAnchor = {
@@ -17,7 +17,7 @@ export type CandidateAnchorKeys = {
   readonly kind?: string;
 };
 
-/** Point-like chrome by default; rect batches use mask de-emphasis only. */
+/** Point-like chrome by default; rect batches suppress rings (sibling mute is opt-in, #633). */
 export function presentationChromeForKind(kind: string | null | undefined): PresentationChrome {
   return kind === "rects" ? "none" : "ring";
 }
@@ -202,21 +202,31 @@ export type PresentationInspectionFocus = {
   }[];
 };
 
+export type MergePresentationFocusOptions = {
+  /**
+   * When true, empty-emphasis rect inspection contributes focus keys so
+   * sibling marks can mute. Default false (#633); legend emphasis still unions.
+   */
+  readonly muteSiblings?: boolean;
+};
+
 /**
  * Keys used for interaction mask presentation.
  * - Legend emphasis alone: return emphasis (same reference when inspection null).
  * - Legend emphasis + inspection: freeze Set-union (emphasis → sourceKeys → key).
- * - Inspection of rect marks with empty emphasis: freeze inspection keys so
- *   bar/col hover can de-emphasize siblings without a point ring (#386).
+ * - Inspection of rect marks with empty emphasis: only when `muteSiblings` is
+ *   true — freeze inspection keys so bar/col hover can de-emphasize siblings
+ *   without a point ring (#386 opt-in; #633 default off).
  * - Other inspection-only cases: return empty emphasis (point chrome keeps rings).
  */
 export function mergePresentationFocusKeys(
   emphasisKeys: readonly PropertyKey[],
   inspection: PresentationInspectionFocus | null,
+  options: MergePresentationFocusOptions = {},
 ): readonly PropertyKey[] {
   if (inspection === null) return emphasisKeys;
   if (emphasisKeys.length === 0) {
-    if (inspection.kind !== "rects") return emphasisKeys;
+    if (inspection.kind !== "rects" || options.muteSiblings !== true) return emphasisKeys;
     const keys = [...inspection.sourceKeys, ...(inspection.key === null ? [] : [inspection.key])];
     if (keys.length === 0) return emphasisKeys;
     return Object.freeze([...new Set(keys)]);

--- a/packages/svelte/tests/interaction/interaction-hover-tooltip.test.ts
+++ b/packages/svelte/tests/interaction/interaction-hover-tooltip.test.ts
@@ -72,7 +72,7 @@ describe("hover + tooltip (overlays, never a pipeline re-run)", () => {
     await until(() => container.querySelector(".gg-tooltip") === null);
   });
 
-  it("geom_col hover de-emphasizes sibling bars without a circle ring (#386)", async () => {
+  it("geom_col hover shows tooltip without sibling mute by default (#633)", async () => {
     let model: RenderModel | null = null;
     const colRows = [
       { category: "A", count: 7030 },
@@ -84,6 +84,45 @@ describe("hover + tooltip (overlays, never a pipeline re-run)", () => {
       aes: { x: "category", y: "count" },
       layers: [{ geom: "col" }],
       inspect: true,
+      onrender: (m: RenderModel) => {
+        model = m;
+      },
+      ...size,
+    });
+    const m = requireModel(model);
+    let seed = m.candidates.candidate(0);
+    for (let id = 0; id < m.candidates.size; id++) {
+      const candidate = m.candidates.candidate(id);
+      if (candidate?.kind === "rects") {
+        seed = candidate;
+        break;
+      }
+    }
+    if (seed === null || seed.kind !== "rects") throw new Error("expected rect candidate");
+    const capture = container.querySelector(".gg-capture")!;
+    pointerMoveAt(capture, seed.x, seed.y);
+    await until(() => container.querySelector(".gg-tooltip") !== null);
+    // #386: still no point ring on rects
+    expect(container.querySelector(".gg-hover-ring")).toBeNull();
+    // #633: default is tooltip-only — no focus-mask de-emphasis flicker
+    expect(container.querySelectorAll(".gg-rects rect[data-gg-focused]")).toHaveLength(0);
+    for (const rect of container.querySelectorAll(".gg-rects rect")) {
+      expect(rect.getAttribute("opacity")).toBeNull();
+    }
+  });
+
+  it("geom_col hover mutes siblings when inspect.muteSiblings is true (#633)", async () => {
+    let model: RenderModel | null = null;
+    const colRows = [
+      { category: "A", count: 7030 },
+      { category: "B", count: 2100 },
+      { category: "C", count: 1800 },
+    ];
+    const { container } = render(GGPlot, {
+      data: colRows,
+      aes: { x: "category", y: "count" },
+      layers: [{ geom: "col" }],
+      inspect: { muteSiblings: true },
       onrender: (m: RenderModel) => {
         model = m;
       },

--- a/packages/svelte/tests/interaction/normalize-interaction-config.test.ts
+++ b/packages/svelte/tests/interaction/normalize-interaction-config.test.ts
@@ -25,8 +25,18 @@ describe("interaction capability normalization", () => {
         mode: "auto",
         pin: true,
         contentMode: "informational",
+        muteSiblings: false,
       },
       initialTool: "inspect",
+    });
+  });
+
+  it("defaults muteSiblings off and accepts explicit opt-in (#633)", () => {
+    expect(normalizeInteractionConfig({ inspect: true }).inspect).toMatchObject({
+      muteSiblings: false,
+    });
+    expect(normalizeInteractionConfig({ inspect: { muteSiblings: true } }).inspect).toMatchObject({
+      muteSiblings: true,
     });
   });
 

--- a/packages/svelte/tests/runtime/semantic-candidate-projection.test.ts
+++ b/packages/svelte/tests/runtime/semantic-candidate-projection.test.ts
@@ -61,7 +61,7 @@ describe("createSemanticCandidateProjection", () => {
     destroy();
   });
 
-  it("builds interaction masks from keyless rect inspection primitives", () => {
+  it("does not mute siblings from rect inspection by default (#633)", () => {
     const colModel = modelFor(
       gg(
         [
@@ -89,6 +89,55 @@ describe("createSemanticCandidateProjection", () => {
         intervalKeys: () => [],
         intervals: () => [],
         emphasisKeys: () => [],
+        muteSiblingsOnInspect: () => false,
+        inspectionFocus: () => ({
+          sourceKeys: [],
+          key: null,
+          kind: first.kind,
+          primitives: [
+            {
+              batchIndex: first.batchIndex,
+              primitiveIndex: first.primitiveIndex,
+            },
+          ],
+        }),
+      }),
+    );
+
+    expect(first.kind).toBe("rects");
+    expect(value.interactionMasks).toEqual([]);
+    destroy();
+  });
+
+  it("builds interaction masks from keyless rect inspection when muteSiblings is on", () => {
+    const colModel = modelFor(
+      gg(
+        [
+          { category: "A", count: 10 },
+          { category: "B", count: 20 },
+          { category: "C", count: 15 },
+        ],
+        aes({ x: "category", y: "count" }),
+      )
+        .geomCol()
+        .spec(),
+    );
+    const first = (() => {
+      for (let id = 0; id < colModel.candidates.size; id++) {
+        const candidate = colModel.candidates.candidate(id);
+        if (candidate?.rowIndex === 0) return candidate;
+      }
+      throw new Error("missing col candidate");
+    })();
+    const { value, destroy } = withFlushedEffectRoot(() =>
+      createSemanticCandidateProjection({
+        model: () => colModel,
+        candidateSemanticKeys: () => [],
+        selectedKeys: () => [],
+        intervalKeys: () => [],
+        intervals: () => [],
+        emphasisKeys: () => [],
+        muteSiblingsOnInspect: () => true,
         inspectionFocus: () => ({
           sourceKeys: [],
           key: null,

--- a/packages/svelte/tests/runtime/semantic-candidate-projection.test.ts
+++ b/packages/svelte/tests/runtime/semantic-candidate-projection.test.ts
@@ -159,7 +159,7 @@ describe("createSemanticCandidateProjection", () => {
     destroy();
   });
 
-  it("layers keyless rect seed primitives under active legend emphasis", () => {
+  it("layers keyless rect seed primitives under legend emphasis when muteSiblings is off (#633)", () => {
     const colModel = modelFor(
       gg(
         [
@@ -188,6 +188,8 @@ describe("createSemanticCandidateProjection", () => {
         intervalKeys: () => [],
         intervals: () => [],
         emphasisKeys: () => ["legend-only"],
+        // Emphasis alone still layers rect seeds (#386); muteSiblings stays off.
+        muteSiblingsOnInspect: () => false,
         inspectionFocus: () => ({
           sourceKeys: [],
           key: null,

--- a/packages/svelte/tests/selection/selection.test.ts
+++ b/packages/svelte/tests/selection/selection.test.ts
@@ -267,16 +267,43 @@ describe("mergePresentationFocusKeys", () => {
     expect(mergePresentationFocusKeys(emphasis, null)).toBe(emphasis);
   });
 
-  it("uses inspection keys alone for rect focus when emphasis is empty", () => {
+  it("uses inspection keys alone for rect focus when muteSiblings and emphasis is empty", () => {
     const empty: PropertyKey[] = [];
-    const result = mergePresentationFocusKeys(empty, {
-      sourceKeys: ["a", "b"],
-      key: "c",
-      kind: "rects",
-    });
+    const result = mergePresentationFocusKeys(
+      empty,
+      {
+        sourceKeys: ["a", "b"],
+        key: "c",
+        kind: "rects",
+      },
+      { muteSiblings: true },
+    );
     expect(result).toEqual(["a", "b", "c"]);
     expect(Object.isFrozen(result)).toBe(true);
     expect(result).not.toBe(empty);
+  });
+
+  it("ignores rect-only inspection keys when muteSiblings is off (#633)", () => {
+    const empty: PropertyKey[] = [];
+    expect(
+      mergePresentationFocusKeys(
+        empty,
+        {
+          sourceKeys: ["a", "b"],
+          key: "c",
+          kind: "rects",
+        },
+        { muteSiblings: false },
+      ),
+    ).toBe(empty);
+    // Default is off — same as muteSiblings: false
+    expect(
+      mergePresentationFocusKeys(empty, {
+        sourceKeys: ["a"],
+        key: null,
+        kind: "rects",
+      }),
+    ).toBe(empty);
   });
 
   it("unions emphasis then sourceKeys then optional key, dedupes, and freezes", () => {

--- a/packages/svelte/tests/selection/selection.test.ts
+++ b/packages/svelte/tests/selection/selection.test.ts
@@ -306,6 +306,23 @@ describe("mergePresentationFocusKeys", () => {
     ).toBe(empty);
   });
 
+  it("still unions rect inspection keys with legend emphasis when muteSiblings is off (#633)", () => {
+    expect(
+      mergePresentationFocusKeys(
+        ["legend"],
+        { sourceKeys: ["bar"], key: null, kind: "rects" },
+        { muteSiblings: false },
+      ),
+    ).toEqual(["legend", "bar"]);
+    expect(
+      mergePresentationFocusKeys(["legend"], {
+        sourceKeys: ["bar"],
+        key: "baz",
+        kind: "rects",
+      }),
+    ).toEqual(["legend", "bar", "baz"]);
+  });
+
   it("unions emphasis then sourceKeys then optional key, dedupes, and freezes", () => {
     const result = mergePresentationFocusKeys(["a"], {
       sourceKeys: ["b", "a"],

--- a/scripts/llms-guide-content.ts
+++ b/scripts/llms-guide-content.ts
@@ -918,7 +918,9 @@ concrete mode before an event is emitted. \`x\` and \`y\` return one
 representative per semantic series at the focused axis value; \`exact\` and
 \`xy\` return the focused datum. \`maxDistance\` is measured in CSS pixels: the
 dominant axis for \`x\` or \`y\`, Euclidean distance for \`xy\`, and geometry
-containment plus tolerance for \`exact\`.
+containment plus tolerance for \`exact\`. Rect marks (\`geom_col\` / \`geom_bar\`)
+never draw a point ring; default hover is tooltip-only. Pass
+\`muteSiblings: true\` to mute non-focused bars via the interaction mask.
 
 For custom HTML, pass a Svelte 5 snippet. Informational content is the default;
 choose \`contentMode: "interactive"\` only when the pinned tooltip contains


### PR DESCRIPTION
## Summary

- **Default** `inspect` on `geom_col` / `geom_bar` is tooltip-only: no sibling opacity mute. Instant mask toggles at bar gaps caused full-plot flicker under normal pointer movement (#633).
- **Opt-in** with `inspect={{ muteSiblings: true }}` restores #386-style relative de-emphasis.
- When mute is active, mark opacity eases over 120ms (disabled under `prefers-reduced-motion`).
- Rect marks still never draw point rings (#386 preserved).

## Changes

- `InspectOptions.muteSiblings` (default `false`) via `normalizeInteractionConfig`
- Gate rect inspection focus keys / primitive masks in `mergePresentationFocusKeys` + `createSemanticCandidateProjection`
- Legend/controller emphasis still layers seed masks so hover under emphasis keeps the focused bar
- CSS transition on `[data-gg-focused]` in `Batch.svelte`
- Docs note in interaction guide content

## Test plan

- [x] Default `inspect` on col chart: tooltip shows; no `data-gg-focused` / no sibling opacity change
- [x] `inspect={{ muteSiblings: true }}`: one focused bar, siblings muted, no hover ring
- [x] Unit: normalize defaults + opt-in; presentation focus keys; semantic projection masks
- [x] Legend focus still applies interaction masks (existing suite green)
- [ ] Manual: sweep pointer across low-cardinality columns — no full-plot flash by default

Closes #633.