### PR TITLE
fix(core): wrap-then−45° band labels (hybrid rung #637)

### DIFF
--- a/.changeset/wrap-then-45-band-labels-637.md
+++ b/.changeset/wrap-then-45-band-labels-637.md
@@ -1,0 +1,14 @@
+---
+"@ggsvelte/core": patch
+"@ggsvelte/svelte": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+fix: wrap-then−45° hybrid band labels when plain wrap fails (#637)
+
+Auto categorical labels that cannot wrap now balance multi-word text onto
+≤2 shorter lines and rotate at −45° before full-string −45°/−90° + truncate.
+Svelte and SVG renderers draw multi-line end-anchored rotated ticks.
+
+Migration: none — auto layout quality only; author guide pins unchanged

--- a/packages/core/src/layout/band-guide-types.ts
+++ b/packages/core/src/layout/band-guide-types.ts
@@ -61,7 +61,10 @@ export interface BandAxisPlanTick {
   fullLabel: string;
   labeled: boolean;
   domainIndex: number;
-  /** Wrapped lines (present when mode === "wrapped"). */
+  /**
+   * Multi-line layout: mode `"wrapped"` (horizontal stack) or mode `"rotated"`
+   * with wrap-then-rotate (lines rotated at `angle`, ≤2 by default).
+   */
   lines?: string[];
   /** Rotation in degrees (present when mode === "rotated"). */
   angle?: number;

--- a/packages/core/src/layout/band-guide.ts
+++ b/packages/core/src/layout/band-guide.ts
@@ -4,7 +4,8 @@
  *
  *   single-line → wrapped (≤2 lines, top-aligned plane overlap; balanced
  *     breaks when greedy exceeds the line cap)
- *     → rotated (−45° then −90°; parallel-baseline text-text, not AABB vs column)
+ *     → wrap-then−45° (balanced ≤2 lines rotated; mode still "rotated"+lines)
+ *     → rotated full-string (−45° then −90°; parallel-baseline text-text)
  *     → truncate + margin-overflow warning
  *     → thin (labelEvery)
  *     → overlap warning
@@ -14,7 +15,8 @@
  *
  * Types live in `band-guide-types.ts`; wrap/cap helpers in `band-label-layout.ts`.
  * Wrap overlap assumes the same top-aligned tspan stack as Axis.svelte /
- * render-svg-scene (plane 0 = first line).
+ * render-svg-scene (plane 0 = first line). Multi-line rotated uses the same
+ * end-anchored `rotate()` + per-line `tspan` dy stack in both renderers.
  */
 
 import {
@@ -30,6 +32,7 @@ import {
   MIN_BAND_LABEL_GAP_PX,
   MODE_RANK,
   RAD,
+  balanceLabelLines,
   capEndOverhang,
   quantizeUp,
   wrapLabel,
@@ -254,16 +257,20 @@ export function planBandAxis(input: BandAxisPlanInput): BandAxisPlan {
   // The SVG renderer hangs rotated labels with text-anchor="end", so the along-
   // axis footprint is ASYMMETRIC about the tick: it extends mostly to the LEFT
   // (the text runs up-left from the tick), with only a half-line-height to the
-  // right. Model those exact bounds so mixed-width labels can't pass the overlap
-  // / side-margin checks and then clip the previous tick or the left edge.
+  // right. Multi-line rotated stacks additional lines with local +y dy (first
+  // line end-anchored at the tick); at −45° that grows the RIGHT extent.
   const leftExtOf = (width: number, angle: number) => {
     const a = Math.abs(angle) * RAD;
     return width * Math.cos(a) + (lineHeight / 2) * Math.sin(a);
   };
-  const rightExtOf = (angle: number) => (lineHeight / 2) * Math.sin(Math.abs(angle) * RAD);
-  const orthoOf = (width: number, angle: number) => {
+  const rightExtOf = (angle: number, lineCount = 1) => {
+    const lines = Math.max(1, lineCount);
+    return (lines - 0.5) * lineHeight * Math.sin(Math.abs(angle) * RAD);
+  };
+  const orthoOf = (width: number, angle: number, lineCount = 1) => {
     const a = Math.abs(angle) * RAD;
-    return width * Math.sin(a) + lineHeight * Math.cos(a);
+    const lines = Math.max(1, lineCount);
+    return width * Math.sin(a) + lines * lineHeight * Math.cos(a);
   };
   /** Widest label among the currently-labeled (every k-th) entries. */
   const labeledMaxWidth = (every: number) => {
@@ -285,15 +292,24 @@ export function planBandAxis(input: BandAxisPlanInput): BandAxisPlan {
     return rotatedTextCollides(1, -45) ? -90 : -45;
   };
 
-  const rotatedPlan = (angle: number): BandAxisPlan => {
+  type RotatedLineSource = {
+    /** Per-entry display lines (length 1 = full string). */
+    linesList: readonly (readonly string[])[];
+    /** Max glyph width per entry (after any truncation callers apply). */
+    widths: readonly number[];
+  };
+
+  const rotatedPlan = (angle: number, hybrid?: RotatedLineSource): BandAxisPlan => {
     const degraded: string[] = [];
     let labelEvery = 1;
     let overlap = false;
     let marginOverflow = false;
+    const isHybrid = hybrid !== undefined;
+    const lineCountOf = (i: number) => hybrid?.linesList[i]?.length ?? 1;
 
-    // Along-axis: do adjacent rotated labels still collide at their real positions?
-    // Gate thinning on the number of DISPLAYED ticks (a small authored-break subset
-    // of a huge domain must keep every break), never the full category count.
+    // Along-axis: parallel-baseline text-text only (same as full-string −45°).
+    // Multi-line dy stack grows the right AABB at −45°, but that is column-box
+    // geometry — not glyph collision. Asym extents still drive overhang below.
     if (rotatedTextCollides(1, angle)) {
       if (entries.length >= BAND_THIN_MIN_CATEGORIES) {
         // High cardinality: thin (never for a handful of named bars).
@@ -312,8 +328,14 @@ export function planBandAxis(input: BandAxisPlanInput): BandAxisPlan {
 
     // Orthogonal: recompute the footprint from the labels that survive thinning, so
     // a hidden wide label neither truncates visible text nor emits a false overflow.
-    const shownWidth = labeledMaxWidth(labelEvery);
-    const orthoNeeded = orthoOf(shownWidth, angle);
+    let shownWidth = 0;
+    let shownLines = 1;
+    for (let i = 0; i < entries.length; i += labelEvery) {
+      const w = isHybrid ? hybrid.widths[i]! : entries[i]!.width;
+      shownWidth = Math.max(shownWidth, w);
+      shownLines = Math.max(shownLines, lineCountOf(i));
+    }
+    const orthoNeeded = orthoOf(shownWidth, angle, shownLines);
     const a = Math.abs(angle) * RAD;
     const cosA = Math.cos(a);
     const sinA = Math.sin(a);
@@ -322,7 +344,7 @@ export function planBandAxis(input: BandAxisPlanInput): BandAxisPlan {
     // width cap from the orthogonal budget (side-cap truncation still applies).
     const orthoWidthBudget =
       orthoNeeded > orthoCap && sinA > 1e-9
-        ? Math.max(1, (orthoCap - lineHeight * cosA) / sinA)
+        ? Math.max(1, (orthoCap - shownLines * lineHeight * cosA) / sinA)
         : Number.POSITIVE_INFINITY;
 
     // Truncate each label to the TIGHTER of the bottom-cap budget and its own LEFT
@@ -330,11 +352,38 @@ export function planBandAxis(input: BandAxisPlanInput): BandAxisPlan {
     // must fit `center + marginCapPx` or it draws past the viewport into chrome.
     // (For −90 the left extent is width-independent, so truncation can't help; that
     // degenerate case is flagged in the overhang pass below.)
-    const ticks = buildTicks(labelEvery, (e) => {
+    // Hybrid: truncate only the widest line of each tick so display lines stay
+    // multi-line; full-string path truncates the single label as before.
+    const ticks = buildTicks(labelEvery, (e, i) => {
       let widthBudget = orthoWidthBudget;
       if (cosA > 1e-9) {
         const sideBudget = (e.center + marginCapPx - (lineHeight / 2) * sinA) / cosA;
         widthBudget = Math.min(widthBudget, sideBudget);
+      }
+      if (isHybrid) {
+        const lines = [...hybrid.linesList[i]!];
+        if (widthBudget !== Number.POSITIVE_INFINITY) {
+          let maxW = 0;
+          let maxIdx = 0;
+          for (let li = 0; li < lines.length; li++) {
+            const w = measurer.measureWidth(lines[li]!, fontSize);
+            if (w > maxW) {
+              maxW = w;
+              maxIdx = li;
+            }
+          }
+          if (maxW > widthBudget) {
+            lines[maxIdx] = truncateToFit(
+              lines[maxIdx]!,
+              Math.max(1, widthBudget),
+              measurer,
+              fontSize,
+              ellipsis,
+            );
+            marginOverflow = true;
+          }
+        }
+        return { label: lines.join(" "), lines, angle };
       }
       const label =
         widthBudget === Number.POSITIVE_INFINITY
@@ -347,15 +396,24 @@ export function planBandAxis(input: BandAxisPlanInput): BandAxisPlan {
     // One measureWidth per labeled tick: drives both band height (max width) and
     // end-anchored overhang (left/right extent). Avoids a second full scan.
     let shownMaxWidth = 0;
+    let shownMaxLines = 1;
     let rotLeft = 0;
     let rotRight = 0;
     for (let i = 0; i < ticks.length; i++) {
       if (!ticks[i]!.labeled) continue;
       const center = entries[i]!.center;
-      const width = measurer.measureWidth(ticks[i]!.label, fontSize);
+      const lines = ticks[i]!.lines;
+      const lineCount = lines !== undefined && lines.length > 0 ? lines.length : 1;
+      let width: number;
+      if (lines !== undefined && lines.length > 1) {
+        width = Math.max(...lines.map((l) => measurer.measureWidth(l, fontSize)));
+      } else {
+        width = measurer.measureWidth(ticks[i]!.label, fontSize);
+      }
       shownMaxWidth = Math.max(shownMaxWidth, width);
+      shownMaxLines = Math.max(shownMaxLines, lineCount);
       const leftExt = leftExtOf(width, angle);
-      const rightExt = rightExtOf(angle);
+      const rightExt = rightExtOf(angle, lineCount);
       // Width-independent residual (chiefly −90): if the footprint still exceeds the
       // side cap after truncation we cannot shrink it further — flag honestly.
       if (
@@ -367,7 +425,10 @@ export function planBandAxis(input: BandAxisPlanInput): BandAxisPlan {
       rotLeft = Math.max(rotLeft, leftExt - center);
       rotRight = Math.max(rotRight, rightExt - (extentPx - center));
     }
-    const labelBandHeight = quantizeUp(Math.min(orthoOf(shownMaxWidth, angle), orthoCap), quantum);
+    const labelBandHeight = quantizeUp(
+      Math.min(orthoOf(shownMaxWidth, angle, shownMaxLines), orthoCap),
+      quantum,
+    );
     if (marginOverflow) degraded.push("band-label-margin-overflow");
     const alongOverhang = Math.max(0, Math.min(marginCapPx, rotRight));
     const leftOverhang = Math.max(0, Math.min(marginCapPx, rotLeft));
@@ -386,6 +447,41 @@ export function planBandAxis(input: BandAxisPlanInput): BandAxisPlan {
     };
   };
 
+  /**
+   * Wrap-then−45°: balance multi-word labels onto ≤maxWrapLines, rotate at −45°.
+   * Accepted only when it beats full-string rotation on readability (no
+   * text-text collision, no margin overflow, and strictly less ortho band than
+   * full-string −45° — or full-string would overflow the bottom cap).
+   * Single-token-only axes return null.
+   */
+  const tryHybridRotatePlan = (): BandAxisPlan | null => {
+    const linesList = entries.map((e) =>
+      balanceLabelLines(e.label, maxWrapLines, measurer, fontSize),
+    );
+    if (!linesList.some((lines) => lines.length > 1)) return null;
+
+    const widths = linesList.map((lines) =>
+      Math.max(...lines.map((l) => measurer.measureWidth(l, fontSize))),
+    );
+    // Parallel −45 must clear; otherwise full-string may escalate to −90.
+    if (rotatedTextCollides(1, -45)) return null;
+
+    const hybrid = rotatedPlan(-45, { linesList, widths });
+    // Reject hybrid when it still collides or overflows — fall through to the
+    // full-string path which may thin / use −90 / truncate more honestly.
+    if (hybrid.overlap || hybrid.marginOverflow) return null;
+
+    // Compare against full-string −45° ortho without building a second plan
+    // (avoids doubling measureWidth on the common hybrid path).
+    const fullMaxW = labeledMaxWidth(1);
+    const fullOrtho = orthoOf(fullMaxW, -45, 1);
+    const fullWouldOverflow = fullOrtho > orthoCap + 1e-6;
+    if (!fullWouldOverflow && hybrid.labelBandHeight >= fullOrtho - 1e-6) {
+      return null;
+    }
+    return hybrid;
+  };
+
   // --- Author pins (no auto-escalation away from the chosen presentation) ---
   if (guideMode === "single") return withPin(singlePlan({ reportOverlap: true }));
   if (guideMode === "wrap") {
@@ -393,6 +489,7 @@ export function planBandAxis(input: BandAxisPlanInput): BandAxisPlan {
   }
   if (guideMode === "rotate") {
     // Prefer author angle; else the measured −45/−90 choice used by auto.
+    // Pins stay full-string (no silent wrap-then-rotate under mode:"rotate").
     return withPin(rotatedPlan(pinnedAngle ?? chooseAutoAngle()));
   }
 
@@ -412,6 +509,12 @@ export function planBandAxis(input: BandAxisPlanInput): BandAxisPlan {
   if (floor <= MODE_RANK.wrapped) {
     const wrapped = tryWrapPlan(false);
     if (wrapped !== null) return wrapped;
+  }
+
+  // --- wrap-then−45° (mode "rotated" + lines) before full-string rotate ---
+  if (floor <= MODE_RANK.rotated) {
+    const hybrid = tryHybridRotatePlan();
+    if (hybrid !== null) return hybrid;
   }
 
   // Prefer −45 (more readable, less bottom footprint); escalate to −90 ONLY when

--- a/packages/core/src/layout/band-label-layout.ts
+++ b/packages/core/src/layout/band-label-layout.ts
@@ -136,6 +136,30 @@ function bestFixedLineWrap(
 }
 
 /**
+ * Balanced multi-line split for wrap-then-rotate: ignore band width and pick
+ * word breaks that minimize the widest line (≤`maxLines`). Single-token labels
+ * stay one line. Used when plain wrap failed but shorter rotated lines would
+ * clear the orthogonal budget that full-string −45°/ −90° cannot.
+ */
+export function balanceLabelLines(
+  label: string,
+  maxLines: number,
+  measurer: TextMeasurer,
+  fontSize: number,
+): string[] {
+  const words = label.split(/\s+/).filter((w) => w.length > 0);
+  if (words.length <= 1) return [label === "" ? "" : (words[0] ?? label)];
+  const capped = Math.max(1, Math.min(maxLines, words.length));
+  if (capped === 1) return [words.join(" ")];
+  // Unlimited maxWidth → score is pure minimax line width (all "fit").
+  return (
+    bestFixedLineWrap(words, Number.POSITIVE_INFINITY, measurer, fontSize, capped) ?? [
+      words.join(" "),
+    ]
+  );
+}
+
+/**
  * Cap the along-axis overhang of the end labels using their ACTUAL displayed
  * positions (not the uniform band width). Horizontal labels that overhang past
  * the panel edge + margin cap are truncated (ellipsis) and flagged; the returned

--- a/packages/core/src/layout/layout-types.ts
+++ b/packages/core/src/layout/layout-types.ts
@@ -66,7 +66,10 @@ export interface Tick {
   domainIndex?: number;
   /** false when band-label thinning hides this tick's label. */
   labeled: boolean;
-  /** Wrapped label lines (band axis, mode "wrapped"). */
+  /**
+   * Multi-line label: mode "wrapped" (horizontal) or wrap-then-rotate
+   * (mode "rotated" + angle + lines).
+   */
   lines?: string[];
   /** Rotation in degrees (band axis, mode "rotated"): 0 | -45 | -90. */
   angle?: number;

--- a/packages/core/src/render-svg-scene.ts
+++ b/packages/core/src/render-svg-scene.ts
@@ -51,6 +51,25 @@ function collectPaintResources(scene: Scene): {
   return { paints, glows };
 }
 
+/** End-anchored rotated band label; multi-line via tspan dy (wrap-then−45°, #637). */
+function rotatedBandLabelSvg(
+  tick: { label: string; lines?: string[]; angle: number },
+  yOff: number,
+  labelSize: number,
+  font: string,
+): string {
+  const transform = `transform="translate(0,${px(yOff)}) rotate(${tick.angle})"`;
+  const attrs = `${transform} text-anchor="end" dominant-baseline="central" ${font}`;
+  if (tick.lines !== undefined && tick.lines.length > 1) {
+    const lineH = labelSize * 1.15;
+    const tspans = tick.lines
+      .map((line, i) => `<tspan x="0" dy="${i === 0 ? "0" : px(lineH)}">${escapeXML(line)}</tspan>`)
+      .join("");
+    return `<text ${attrs}>${tspans}</text>`;
+  }
+  return `<text ${attrs}>${escapeXML(tick.label)}</text>`;
+}
+
 function renderPanelAxes(panel: ScenePanel, theme: ThemeTokens): string {
   const parts: string[] = [];
   const axisText = themeVar("axisText", theme);
@@ -81,10 +100,7 @@ function renderPanelAxes(panel: ScenePanel, theme: ThemeTokens): string {
         const labelSize = tick.labelSize ?? theme.axisTextSize;
         const font = `fill="${axisText}" font-size="${px(labelSize)}" font-weight="${theme.fontWeight}"`;
         if (tick.angle !== undefined && tick.angle !== 0) {
-          // Rotated band label: hang below the axis, anchored at the tick.
-          parts.push(
-            `<text transform="translate(0,${px(yOff)}) rotate(${tick.angle})" text-anchor="end" dominant-baseline="central" ${font}>${escapeXML(tick.label)}</text>`,
-          );
+          parts.push(rotatedBandLabelSvg({ ...tick, angle: tick.angle }, yOff, labelSize, font));
         } else if (tick.lines !== undefined && tick.lines.length > 1) {
           // Wrapped band label: one tspan per line, centered.
           const lineH = labelSize * 1.15;

--- a/packages/core/src/scene.ts
+++ b/packages/core/src/scene.ts
@@ -225,7 +225,10 @@ export interface SceneTick {
   showTick?: boolean;
   showLabel?: boolean;
   labelSize?: number;
-  /** Wrapped label lines (band axis, mode "wrapped"). */
+  /**
+   * Multi-line label: mode "wrapped" (horizontal) or wrap-then-rotate
+   * (mode "rotated" + angle + lines).
+   */
   lines?: string[];
   /** Rotation in degrees (band axis, mode "rotated"): -45 | -90. */
   angle?: number;

--- a/packages/core/tests/band-guide/escalation-ladder.test.ts
+++ b/packages/core/tests/band-guide/escalation-ladder.test.ts
@@ -64,8 +64,8 @@ describe("planBandAxis: escalation ladder", () => {
   });
 
   it("measures each rotated labeled tick once for height and overhang", () => {
-    // Pre-fix: shownMaxWidth pass + overhang pass each called measureWidth
-    // per labeled tick (~30 total on this fixture). Single-pass is ~25.
+    // Full-string rotate path (single-token labels → hybrid cannot engage):
+    // pre-fix double-scanned ~30 measureWidth calls; single overhang pass ≤20.
     let measureWidthCalls = 0;
     const counting = {
       measureWidth: (text: string, fontSizePx: number) => {
@@ -75,11 +75,12 @@ describe("planBandAxis: escalation ladder", () => {
       measureHeight: (fontSizePx: number) => measurer.measureHeight(fontSizePx),
     };
     const p = plan(
-      ["Resolución", "Corrección (errores o erratas)", "Sentencia", "Orden", "Otro"],
+      ["Anlageverwaltungsgesellschaftsvertrag", "Kurzlabel", "Mittelwort", "Andere", "Noch"],
       240,
       { measurer: counting },
     );
     expect(p.mode).toBe("rotated");
+    expect(p.ticks.every((t) => t.lines === undefined || t.lines.length <= 1)).toBe(true);
     expect(measureWidthCalls).toBeLessThanOrEqual(27);
     expect(measureWidthCalls).toBeGreaterThan(0);
   });

--- a/packages/core/tests/band-guide/wrap-then-rotate.test.ts
+++ b/packages/core/tests/band-guide/wrap-then-rotate.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "bun:test";
+
+import { plan, measurer } from "./fixtures.ts";
+
+/** #637: wrap fails, full-string −45° truncates; hybrid wrap-then−45° keeps full text. */
+const LONG_CATS = [
+  "Resolución",
+  "Corrección (errores o erratas)",
+  "Sentencia",
+  "Orden",
+  "Otro",
+] as const;
+
+/** #634 desktop fixture — hybrid must not steal the wrap rung. */
+const MIXED_OUTLIER = [
+  "Real Decreto",
+  "Orden",
+  "Ley",
+  "Resolución",
+  "Corrección (errores o erratas)",
+  "Sentencia",
+  "Directiva",
+  "Reglamento",
+] as const;
+
+describe("planBandAxis: wrap-then−45° hybrid (#637)", () => {
+  it("at 240px prefers wrap-then−45° over full-string −45°+truncate", () => {
+    // wrap fails (unbreakable tokens / plane overlap). Full-string −45 needs the
+    // bottom cap to truncate the 4-token outlier. Hybrid balances that label onto
+    // ≤2 shorter lines, rotates at −45°, and keeps every glyph of fullLabel.
+    const p = plan([...LONG_CATS], 240);
+    expect(p.mode).toBe("rotated");
+    expect(p.angle).toBe(-45);
+    expect(p.ticks.every((t) => t.labeled)).toBe(true);
+    expect(p.ticks.every((t) => t.angle === -45)).toBe(true);
+
+    const long = p.ticks.find((t) => t.value === "Corrección (errores o erratas)");
+    expect(long).toBeDefined();
+    expect(long!.lines).toBeDefined();
+    expect(long!.lines!.length).toBeGreaterThan(1);
+    expect(long!.lines!.length).toBeLessThanOrEqual(2);
+    expect(long!.lines!.join(" ")).toBe("Corrección (errores o erratas)");
+    expect(long!.label.includes("…")).toBe(false);
+    expect(p.degraded).not.toContain("band-label-margin-overflow");
+
+    // Hybrid ortho uses shorter lines than full-string −45 (≈111px → overflow).
+    const lineH = measurer.measureHeight(11);
+    const fullStringOrtho =
+      measurer.measureWidth("Corrección (errores o erratas)", 11) * Math.SQRT1_2 +
+      lineH * Math.SQRT1_2;
+    expect(p.labelBandHeight).toBeLessThan(fullStringOrtho);
+    // Still a real rotated band — not a flat two-line wrap height.
+    expect(p.labelBandHeight).toBeGreaterThan(lineH * 2);
+  });
+
+  it("still wraps at desktop 640 (#634 regression) — hybrid only when wrap cannot", () => {
+    const p = plan([...MIXED_OUTLIER], 640);
+    expect(p.mode).toBe("wrapped");
+    expect(p.angle).toBe(0);
+    const long = p.ticks.find((t) => t.value === "Corrección (errores o erratas)");
+    expect(long!.lines?.join(" ") ?? long!.label).toBe("Corrección (errores o erratas)");
+    expect(long!.angle === undefined || long!.angle === 0).toBe(true);
+  });
+
+  it("keeps a uniform axis mode (no mix of wrap vs rotate ticks)", () => {
+    const p = plan([...LONG_CATS], 240);
+    expect(p.mode).toBe("rotated");
+    const angles = new Set(p.ticks.map((t) => t.angle ?? 0));
+    expect(angles.size).toBe(1);
+    // Short labels may be single-line under the shared −45° mode.
+    expect(p.ticks.every((t) => (t.lines?.length ?? 1) >= 1)).toBe(true);
+  });
+});

--- a/packages/core/tests/layout/band-axis.test.ts
+++ b/packages/core/tests/layout/band-axis.test.ts
@@ -19,12 +19,16 @@ describe("measured band x-axis (planner integration)", () => {
     expect(r.x.ticks.some((t) => (t.lines?.length ?? 1) === 2)).toBe(true);
   });
 
-  it("rotates and truncates at narrow width, still labelling every bar", () => {
+  it("wrap-then−45° at narrow width keeps every bar labelled without truncating (#637)", () => {
+    // 240px: plain wrap fails; hybrid balances multi-word labels and rotates −45°
+    // so the long outlier no longer needs ellipsis (full-string −45° used to).
     const r = layout(base({ width: 240, height: 300, x: bandX(SPANISH) }));
     expect(r.x.guidePlan?.bandLabelMode).toBe("rotated");
-    expect([-45, -90]).toContain(r.x.guidePlan?.bandLabelAngle);
+    expect(r.x.guidePlan?.bandLabelAngle).toBe(-45);
     expect(r.x.ticks.every((t) => t.labeled)).toBe(true);
-    expect(r.degradations).toContain("band-label-margin-overflow");
+    expect(r.x.ticks.some((t) => (t.lines?.length ?? 1) > 1)).toBe(true);
+    expect(r.x.ticks.every((t) => !t.label.includes("…"))).toBe(true);
+    expect(r.degradations).not.toContain("band-label-margin-overflow");
     expect(r.margins.bottom).toBeLessThanOrEqual(theme.maxMarginFraction * 300);
   });
 

--- a/packages/core/tests/pipeline-band.test.ts
+++ b/packages/core/tests/pipeline-band.test.ts
@@ -27,7 +27,20 @@ describe("band axis diagnostics (#387)", () => {
   });
 
   it("emits a band-label-margin-overflow diagnostic with a coord_flip fix", () => {
-    const model = runPipeline(spec, { width: 240, height: 300 });
+    // Unbreakable single-token labels: wrap and wrap-then−45° cannot help, so
+    // full-string −45° truncates and surfaces margin-overflow + coord_flip.
+    // (Multi-word Spanish rows at 240px now clear via hybrid #637 without this diag.)
+    const unbreakable: SpecInput = {
+      data: {
+        values: [
+          { category: "Anlageverwaltungsgesellschaftsvertrag", count: 9 },
+          { category: "Rechtsschutzversicherungsgesellschaften", count: 3 },
+          { category: "Donaudampfschiffahrtsgesellschaftskapitän", count: 2 },
+        ],
+      },
+      layers: [{ geom: "col", aes: { x: { field: "category" }, y: { field: "count" } } }],
+    };
+    const model = runPipeline(unbreakable, { width: 240, height: 300 });
     const diag = model.scaleDiagnostics.find((d) => d.code === "band-label-margin-overflow");
     expect(diag).toBeDefined();
     expect(diag?.path).toBe("/scales/x");

--- a/packages/core/tests/render-band-labels.test.ts
+++ b/packages/core/tests/render-band-labels.test.ts
@@ -38,6 +38,18 @@ describe("band label rendering (#387)", () => {
     expect(title).not.toBeNull();
   });
 
+  it("wrap-then−45° emits multi-line rotated tspans for the multi-word outlier (#637)", () => {
+    // 240px: plain wrap fails; hybrid balances the long label onto 2 lines at −45°.
+    const svg = renderToSVGString(spec, { width: 240, height: 300 });
+    expect(svg).toContain('rotate(-45)" text-anchor="end"');
+    // Hybrid path: rotated <text> contains <tspan> children (not a single glyph run).
+    const rotatedWithTspans = svg.match(/rotate\(-45\)"[^>]*>[\s\S]*?<tspan[\s\S]*?<\/text>/);
+    expect(rotatedWithTspans).not.toBeNull();
+    expect(svg).toContain("Corrección");
+    expect(svg).toContain("(errores o erratas)");
+    expect(svg).not.toContain("Corrección (errores o err…");
+  });
+
   it("keeps single-line rendering unchanged for short labels", () => {
     const shortSpec: SpecInput = {
       data: {

--- a/packages/svelte/src/lib/scene/Axis.svelte
+++ b/packages/svelte/src/lib/scene/Axis.svelte
@@ -57,14 +57,22 @@
         {/if}
         {#if tick.label !== "" && tick.showLabel !== false}
           {#if tick.angle !== undefined && tick.angle !== 0}
-            <!-- Rotated band label: hang below the axis, anchored at the tick. -->
+            <!-- Rotated band label: hang below the axis, end-anchored at the tick.
+                 Wrap-then-rotate (#637): multi-line via tspan dy in local Y. -->
             <text
               transform={`translate(0,${(theme.ticksX && tick.showTick !== false ? theme.tickLength : 0) + 3}) rotate(${tick.angle})`}
               text-anchor="end"
               dominant-baseline="central"
               fill={axisText}
               font-size={tick.labelSize ?? theme.axisTextSize}
-              font-weight={theme.fontWeight}>{tick.label}</text
+              font-weight={theme.fontWeight}
+              >{#if tick.lines !== undefined && tick.lines.length > 1}{#each tick.lines as line, li (li)}<tspan
+                    x="0"
+                    dy={li === 0
+                      ? 0
+                      : (tick.labelSize ?? theme.axisTextSize) * 1.15}
+                    >{line}</tspan
+                  >{/each}{:else}{tick.label}{/if}</text
             >
           {:else if tick.lines !== undefined && tick.lines.length > 1}
             <!-- Wrapped band label: one tspan per line, centered. -->


### PR DESCRIPTION
## Summary
- Implements the deferred B7 rung from #636: when plain wrap fails, balance multi-word labels onto ≤2 lines and rotate at **−45°** before full-string −45/−90 + truncate.
- Representation: `mode: "rotated"` + `lines` + `angle: -45` (no new mode). Author `mode: "rotate"` pins stay full-string.
- Renderers: multi-line end-anchored `tspan` stacks in `Axis.svelte` and `render-svg-scene.ts`, matching planner ortho/right-extent geometry.
- #634 desktop wrap path unchanged (hybrid only engages where wrap cannot).

## Test plan
- [x] `bun test packages/core/tests/band-guide/ packages/core/tests/render-band-labels.test.ts packages/core/tests/layout/band-axis.test.ts`
- [ ] CI unit / docs / VR green
- [ ] Spot-check: 240px long Spanish cats → hybrid −45 multi-line, no ellipsis; 640px mixed outlier → still wrap

Closes #637