### PR TITLE
fix(svelte): one transition owner for interaction dismiss paths (#627)

### DIFF
--- a/packages/svelte/src/lib/inspection/inspection-state.svelte.ts
+++ b/packages/svelte/src/lib/inspection/inspection-state.svelte.ts
@@ -11,12 +11,13 @@
  * Factory sits at the original queue-vars position (before the component-held
  * reducer). Construction-time deriveds read inspection (own) and model only.
  * Armed later-declared / handler-only deps for the
- * construction guard: reducer, captureSurface, tooltipHovered,
- * clearTooltipHovered, keyAt, inspectEnabled, chooseTool, clearBrush,
- * oninspect, oninteraction.
+ * construction guard: captureSurface, tooltipHovered,
+ * clearTooltipHovered, keyAt, inspectEnabled, oninspect, oninteraction.
  *
- * Effects register via registerInspectionEffects() at the original coordinator
- * site (after legend-focus reconcile); effect-registration order is load-bearing.
+ * Cross-module dismiss side effects (clearBrush / returnToInspect) are applied
+ * by the transition owner / surface — not via sibling surface deps (#627).
+ *
+ * Scene-reconcile + coordinator disposal effects register inside this factory.
  */
 import type { CandidateFacts, CellValue, RenderModel, ScenePanel } from "@ggsvelte/core";
 
@@ -50,6 +51,7 @@ import {
   planInspectionDismiss,
   planSceneInspectReconcile,
   resolveInspectionEmitAction,
+  type InspectionDismissPlan,
 } from "./teardown.js";
 
 // ---------------------------------------------------------------------------
@@ -65,10 +67,10 @@ type InspectPointerFrameAction = Extract<InteractionAction, { type: "inspect" }>
 export type InspectionStateDeps = {
   model: () => RenderModel | null;
   /**
-   * Component-held reducer (plan mandate). Deferred: declared AFTER the
-   * factory — handler/effect-only reads.
+   * Shared interaction reducer. Prefer a concrete instance from the assembly
+   * (constructed before this factory) so inspection does not close over surface.
    */
-  reducer: () => InteractionReducer;
+  reducer: InteractionReducer | (() => InteractionReducer);
   inspectConfig: () => ResolvedInteractionConfig["inspect"];
   inspectEnabled: () => boolean;
   dataIdentityEpoch: () => string;
@@ -82,10 +84,6 @@ export type InspectionStateDeps = {
   plotId: () => string;
   tooltipHovered: () => boolean;
   clearTooltipHovered: () => void;
-  /** S7 state still host-held: dismiss plan.clearBrush → brushRect = null. */
-  clearBrush: () => void;
-  /** S7 fn still host-held: dismiss plan.returnToInspect. */
-  chooseTool: (tool: "inspect") => void;
   oninspect: () => ((event: PlotInspection<Record<string, CellValue>>) => void) | undefined;
   oninteraction: () =>
     | ((event: PlotInteractionEvent<Record<string, CellValue>>) => void)
@@ -94,6 +92,10 @@ export type InspectionStateDeps = {
   announce: (message: string) => void;
   clearAnnouncement: () => void;
 };
+
+function resolveReducer(reducer: InspectionStateDeps["reducer"]): InteractionReducer {
+  return typeof reducer === "function" ? reducer() : reducer;
+}
 
 /** Intent for a coalesced pointer-inspect frame (nearest lookup owned here). */
 type SchedulePointerInspectInput = {
@@ -122,12 +124,16 @@ export type InspectionState = {
     candidate?: CandidateFacts,
   ): void;
   toggleInspectionPin(source: InteractionSource): void;
+  /**
+   * Local dismiss only. Cross-module plan tails (clearBrush / returnToInspect)
+   * are applied by `applyInspectionDismissSideEffects` at the call site.
+   */
   dismissInspection(
     kind: "escape" | "close",
     source: InteractionSource,
     opts?: { restoreFocus?: boolean; returnToInspect?: boolean },
-  ): void;
-  closeInspection(source: InteractionSource, restoreFocus?: boolean): void;
+  ): InspectionDismissPlan;
+  closeInspection(source: InteractionSource, restoreFocus?: boolean): InspectionDismissPlan;
   navigate(delta: number): void;
   navigateDirection(dx: number, dy: number): void;
   cycleCoincident(delta: number): void;
@@ -148,8 +154,6 @@ export type InspectionState = {
    * Returns false when the frame is dropped so the reducer skips dispatch.
    */
   onInspectPointerFrame(action: InspectPointerFrameAction): boolean;
-  /** Register disposal + scene-reconcile effects at the original host site. */
-  registerInspectionEffects(): void;
 };
 
 // ---------------------------------------------------------------------------
@@ -157,15 +161,14 @@ export type InspectionState = {
 // ---------------------------------------------------------------------------
 
 /**
- * Create the inspection controller. Construction registers only the
- * construction-time deriveds (inspectionPanel, traversalHits). Call
- * `registerInspectionEffects` at the original coordinator position after
- * legend-focus reconcile effects.
+ * Create the inspection controller. Construction registers deriveds and
+ * coordinator disposal + scene-reconcile effects.
  *
  * Construction-order note: deps must not be invoked during construction —
  * construction-read discipline enforced by the armed-getter suite.
  */
 export function createInspectionState(deps: InspectionStateDeps): InspectionState {
+  const reducerOf = (): InteractionReducer => resolveReducer(deps.reducer);
   let inspection = $state<PlotInspectionChange<Record<string, CellValue>, PropertyKey> | null>(
     null,
   );
@@ -401,7 +404,7 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
     kind: "escape" | "close",
     source: InteractionSource,
     opts: { restoreFocus?: boolean; returnToInspect?: boolean } = {},
-  ): void {
+  ): InspectionDismissPlan {
     const plan = planInspectionDismiss({
       kind,
       hasInspection: inspection !== null,
@@ -423,7 +426,7 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
       clearDismissedLatch();
     }
     // Real Escape cancels area + bumps epoch; close does not.
-    if (kind === "escape") deps.reducer().dispatch({ type: "escape", source });
+    if (kind === "escape") reducerOf().dispatch({ type: "escape", source });
     if (plan.emitClear) emitInspection({ type: "inspect", phase: "clear", source });
     inspection = null;
     inspectionSeed = null;
@@ -431,13 +434,14 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
     if (plan.clearPendingPinned) pendingPinnedPointer = null;
     if (plan.coordinator === "invalidate") inspectionCoordinator.invalidate();
     else inspectionCoordinator.release("pinned");
-    if (plan.clearBrush) deps.clearBrush();
+    // Cross-module clearBrush / returnToInspect: caller applies via
+    // applyInspectionDismissSideEffects (surface / transition owner).
     if (plan.restoreFocus) queueMicrotask(() => deps.captureSurface()?.focus());
-    if (plan.returnToInspect) deps.chooseTool("inspect");
+    return plan;
   }
 
-  function closeInspection(source: InteractionSource, restoreFocus = true): void {
-    dismissInspection("close", source, { restoreFocus });
+  function closeInspection(source: InteractionSource, restoreFocus = true): InspectionDismissPlan {
+    return dismissInspection("close", source, { restoreFocus });
   }
 
   function applyCandidateId(id: number | null): void {
@@ -500,7 +504,7 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
       fallbackCandidate: () => model?.candidates.hitTest(input.point.x, input.point.y) ?? null,
       panelIdForIndex,
     });
-    const reducer = deps.reducer();
+    const reducer = reducerOf();
     queuedPointerInspection = frame.queued;
     queuedPointerToken = reducer.frameToken();
     try {
@@ -520,7 +524,7 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
   function cancelPointerInspect(policy: CancelPointerInspectPolicy): void {
     queuedPointerInspection = null;
     if (policy.pendingPinned === "discard") pendingPinnedPointer = null;
-    deps.reducer().cancelScheduledPointer("inspect");
+    reducerOf().cancelScheduledPointer("inspect");
   }
 
   /**
@@ -537,7 +541,7 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
     // called for empty frames (Codex plan review).
     const frameAction = resolveQueuedInspectFrameAction({
       hasPending: pending !== null,
-      tokenAccepted: pending === null || token === null || deps.reducer().accepts(token),
+      tokenAccepted: pending === null || token === null || reducerOf().accepts(token),
       currentState: inspection === null ? "none" : inspection.state,
       candidateEpochMismatch:
         action.candidate !== null && action.candidate.epoch !== deps.model()?.runId,
@@ -567,81 +571,81 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
     return true;
   }
 
-  function registerInspectionEffects(): void {
-    $effect(() => {
-      return () => {
-        inspectionCoordinator.invalidate();
-      };
-    });
+  // Coordinator disposal + scene-run reconcile (formerly host-phased
+  // registerInspectionEffects — registered at construction, #627).
+  $effect(() => {
+    return () => {
+      inspectionCoordinator.invalidate();
+    };
+  });
 
-    $effect(() => {
-      const currentModel = deps.model();
-      const plan = planSceneInspectReconcile({
-        inspectionEnabled: deps.inspectEnabled(),
-        // Thunk: do not read `inspection` on the same-run skip path so hover
-        // updates are not effect dependencies of scene-run reconcile.
-        getInspectionState: () => (inspection === null ? "none" : inspection.state),
-        modelRunId: currentModel?.runId ?? null,
-        reconciledRun,
-      });
-      switch (plan.type) {
-        case "noop":
-        case "skip":
-          return;
-        case "clear-disabled":
-          inspectionCoordinator.invalidate();
+  $effect(() => {
+    const currentModel = deps.model();
+    const plan = planSceneInspectReconcile({
+      inspectionEnabled: deps.inspectEnabled(),
+      // Thunk: do not read `inspection` on the same-run skip path so hover
+      // updates are not effect dependencies of scene-run reconcile.
+      getInspectionState: () => (inspection === null ? "none" : inspection.state),
+      modelRunId: currentModel?.runId ?? null,
+      reconciledRun,
+    });
+    switch (plan.type) {
+      case "noop":
+      case "skip":
+        return;
+      case "clear-disabled":
+        inspectionCoordinator.invalidate();
+        inspection = null;
+        inspectionSeed = null;
+        clearDismissedLatch();
+        invalidatePointerInspect({ pendingPinned: "discard" });
+        return;
+      case "invalidate-clear-transient":
+      case "invalidate-idle":
+      case "invalidate-reconcile-pinned": {
+        // currentModel is non-null for invalidate-* (plan requires run advance).
+        const runId = currentModel!.runId;
+        reducerOf().dispatch({ type: "invalidate", reason: "scene" });
+        queuedPointerInspection = null;
+        pendingPinnedPointer = null;
+        queuedPointerToken = null;
+        reducerOf().cancelScheduledPointer();
+        clearDismissedLatch();
+        reconciledRun = runId;
+        if (plan.type === "invalidate-clear-transient") {
+          inspectionCoordinator.release("transient");
           inspection = null;
           inspectionSeed = null;
-          clearDismissedLatch();
-          invalidatePointerInspect({ pendingPinned: "discard" });
           return;
-        case "invalidate-clear-transient":
-        case "invalidate-idle":
-        case "invalidate-reconcile-pinned": {
-          // currentModel is non-null for invalidate-* (plan requires run advance).
-          const runId = currentModel!.runId;
-          deps.reducer().dispatch({ type: "invalidate", reason: "scene" });
-          queuedPointerInspection = null;
-          pendingPinnedPointer = null;
-          queuedPointerToken = null;
-          deps.reducer().cancelScheduledPointer();
-          clearDismissedLatch();
-          reconciledRun = runId;
-          if (plan.type === "invalidate-clear-transient") {
-            inspectionCoordinator.release("transient");
-            inspection = null;
-            inspectionSeed = null;
-            return;
-          }
-          if (plan.type === "invalidate-idle") return;
-          const reconciled = inspectionCoordinator.reconcilePinned({
-            model: currentModel!,
-            identityEpoch: deps.dataIdentityEpoch(),
-            layoutEpoch: runId,
-            source: "programmatic",
-            completeness: "complete",
-          });
-          if (reconciled === null) {
-            // Failed pinned reconcile: clear inspection only (not area Escape).
-            emitInspection({
-              type: "inspect",
-              phase: "clear",
-              source: "programmatic",
-            });
-            inspection = null;
-            inspectionSeed = null;
-          } else {
-            inspection = reconciled.snapshot;
-            inspectionSeed = reconciled.seed;
-            activeCandidateId = reconciled.seed.id;
-            if (reconciled.semanticChanged)
-              emitInspection(reconciled.snapshot, reconciled.semanticFingerprint);
-          }
-          break;
         }
+        if (plan.type === "invalidate-idle") return;
+        const reconciled = inspectionCoordinator.reconcilePinned({
+          model: currentModel!,
+          identityEpoch: deps.dataIdentityEpoch(),
+          layoutEpoch: runId,
+          source: "programmatic",
+          completeness: "complete",
+        });
+        if (reconciled === null) {
+          // Failed pinned reconcile: clear inspection only (not area Escape).
+          emitInspection({
+            type: "inspect",
+            phase: "clear",
+            source: "programmatic",
+          });
+          inspection = null;
+          inspectionSeed = null;
+        } else {
+          inspection = reconciled.snapshot;
+          inspectionSeed = reconciled.seed;
+          activeCandidateId = reconciled.seed.id;
+          if (reconciled.semanticChanged)
+            emitInspection(reconciled.snapshot, reconciled.semanticFingerprint);
+        }
+        break;
       }
-    });
-  }
+    }
+  });
 
   return {
     get inspection() {
@@ -665,6 +669,5 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
     schedulePointerInspect,
     cancelPointerInspect,
     onInspectPointerFrame,
-    registerInspectionEffects,
   };
 }

--- a/packages/svelte/src/lib/interaction/transition-owner.ts
+++ b/packages/svelte/src/lib/interaction/transition-owner.ts
@@ -1,0 +1,27 @@
+/**
+ * Cross-module interaction transition apply (issue #627).
+ *
+ * Pure decision tables live in inspection/teardown, surface/brush-finish, etc.
+ * This module owns only multi-module *side-effect application* after a plan is
+ * decided — not a method-forwarding port over sibling controllers.
+ */
+import type { InteractionTool } from "./interaction.js";
+import type { InspectionDismissPlan } from "../inspection/teardown.js";
+
+/** Surface ops required when applying an inspection dismiss plan across modules. */
+export type DismissSurfaceSink = {
+  clearBrush(): void;
+  chooseTool(next: InteractionTool): void;
+};
+
+/**
+ * Apply the cross-module tail of `planInspectionDismiss`.
+ * Local inspection clears stay in InspectionState; brush/tool live on surface.
+ */
+export function applyInspectionDismissSideEffects(
+  plan: InspectionDismissPlan,
+  surface: DismissSurfaceSink,
+): void {
+  if (plan.clearBrush) surface.clearBrush();
+  if (plan.returnToInspect) surface.chooseTool("inspect");
+}

--- a/packages/svelte/src/lib/legend/filter-state.svelte.ts
+++ b/packages/svelte/src/lib/legend/filter-state.svelte.ts
@@ -55,10 +55,15 @@ export type LegendFilterStateDeps = {
   /** Stable announce sink (not a getter). */
   announce: (message: string) => void;
   /**
-   * Used ONLY inside late catalog effects (never at construction). Armed-getter
+   * Used ONLY inside catalog effects (never at construction). Armed-getter
    * construction tests enforce this construction-order DAG contract.
    */
   model: () => RenderModel | null;
+  /**
+   * Live filterable entries for catalog reconcile. May close over a later
+   * host `$derived` (handler/effect-only; not read at construction).
+   */
+  catalogEntries: () => readonly FilterableLegendEntry[];
 };
 
 export type LegendFilterState = {
@@ -74,8 +79,6 @@ export type LegendFilterState = {
   toggle(target: FilterableLegendEntry, event: MouseEvent): void;
   reset(event: MouseEvent): void;
   setPointerType(type: string | null): void;
-  /** Register catalog-reconcile effect at its original host position. */
-  registerCatalogEffects(entries: () => readonly FilterableLegendEntry[]): void;
 };
 
 // ---------------------------------------------------------------------------
@@ -83,10 +86,8 @@ export type LegendFilterState = {
 // ---------------------------------------------------------------------------
 
 /**
- * Create the legend-filter controller. Construction registers ONLY the
- * capability-reset and mode-reset effects (original ~550 region). Call
- * `registerCatalogEffects` at the original catalog position after the
- * runtime's model effects so callback/event order is preserved.
+ * Create the legend-filter controller. Construction registers capability-reset,
+ * mode-reset, and catalog-reconcile effects (#627).
  */
 export function createLegendFilterState(deps: LegendFilterStateDeps): LegendFilterState {
   const legendFilterOptions: ResolvedLegendFilterOptions | null = $derived.by(() => {
@@ -295,72 +296,70 @@ export function createLegendFilterState(deps: LegendFilterStateDeps): LegendFilt
     legendFilterPointerType = type;
   }
 
-  function registerCatalogEffects(entries: () => readonly FilterableLegendEntry[]): void {
-    // Catalog changes prune values that no longer exist. An emptied clause is
-    // removed, so a category that disappears and later returns is visible by
-    // default. resetScales() deliberately does not alter this filter state.
-    $effect(() => {
-      const catalogs = new Map<string, CellValue[]>();
-      for (const target of entries()) {
-        const key = `${target.legend.scale}:${target.field}`;
-        const catalog = catalogs.get(key) ?? [];
-        catalog.push(target.entry.value as CellValue);
-        catalogs.set(key, catalog);
+  // Catalog changes prune values that no longer exist. An emptied clause is
+  // removed, so a category that disappears and later returns is visible by
+  // default. resetScales() deliberately does not alter this filter state.
+  $effect(() => {
+    const catalogs = new Map<string, CellValue[]>();
+    for (const target of deps.catalogEntries()) {
+      const key = `${target.legend.scale}:${target.field}`;
+      const catalog = catalogs.get(key) ?? [];
+      catalog.push(target.entry.value as CellValue);
+      catalogs.set(key, catalog);
+    }
+    let next = localLegendFilters;
+    const reconciled: Array<{
+      clause: LegendFilterClause;
+      removed: boolean;
+    }> = [];
+    // A clause whose field is still mapped but whose legend stopped being
+    // filterable (second unlike field on the scale, a scaled constant, a
+    // non-discrete legend) has no checkbox or reset control left — remove it
+    // rather than filtering rows invisibly. Unmapped fields are handled by
+    // the capability reset above.
+    if (deps.model() !== null && legendFilterOptions !== null) {
+      for (const clause of next.filter(
+        (candidate) =>
+          activeLegendFilterBindings.has(`${candidate.scale}:${candidate.field}`) &&
+          !catalogs.has(`${candidate.scale}:${candidate.field}`),
+      )) {
+        next = next.filter((candidate) => candidate !== clause);
+        reconciled.push({ clause, removed: true });
       }
-      let next = localLegendFilters;
-      const reconciled: Array<{
-        clause: LegendFilterClause;
-        removed: boolean;
-      }> = [];
-      // A clause whose field is still mapped but whose legend stopped being
-      // filterable (second unlike field on the scale, a scaled constant, a
-      // non-discrete legend) has no checkbox or reset control left — remove it
-      // rather than filtering rows invisibly. Unmapped fields are handled by
-      // the capability reset above.
-      if (deps.model() !== null && legendFilterOptions !== null) {
-        for (const clause of next.filter(
-          (candidate) =>
-            activeLegendFilterBindings.has(`${candidate.scale}:${candidate.field}`) &&
-            !catalogs.has(`${candidate.scale}:${candidate.field}`),
-        )) {
-          next = next.filter((candidate) => candidate !== clause);
-          reconciled.push({ clause, removed: true });
-        }
-      }
-      for (const [key, catalog] of catalogs) {
-        const fingerprint = JSON.stringify(catalog.map((value) => encodeKey(value)));
-        const priorFingerprint = legendCatalogFingerprints.get(key);
-        legendCatalogFingerprints.set(key, fingerprint);
-        if (priorFingerprint === undefined || priorFingerprint === fingerprint) continue;
-        const index = next.findIndex((clause) => `${clause.scale}:${clause.field}` === key);
-        if (index < 0) continue;
-        const clause = next[index]!;
-        const values = reconcileLegendFilterValues(clause.values, catalog);
-        reconciled.push({
-          clause: Object.freeze({ ...clause, values }),
-          removed: values.length === 0,
-        });
-        next =
-          values.length === 0
-            ? next.filter((_, candidateIndex) => candidateIndex !== index)
-            : next.map((candidate, candidateIndex) =>
-                candidateIndex === index ? Object.freeze({ ...candidate, values }) : candidate,
-              );
-      }
-      for (const key of legendCatalogFingerprints.keys())
-        if (!catalogs.has(key)) legendCatalogFingerprints.delete(key);
-      if (next === localLegendFilters) return;
-      localLegendFilters = [...next];
-      for (const { clause, removed } of reconciled)
-        emitLegendFilter({
-          type: "legend-filter",
-          phase: removed ? "remove" : "change",
-          source: "programmatic",
-          clause,
-        });
-      deps.announce("Legend filters reconciled with the available groups.");
-    });
-  }
+    }
+    for (const [key, catalog] of catalogs) {
+      const fingerprint = JSON.stringify(catalog.map((value) => encodeKey(value)));
+      const priorFingerprint = legendCatalogFingerprints.get(key);
+      legendCatalogFingerprints.set(key, fingerprint);
+      if (priorFingerprint === undefined || priorFingerprint === fingerprint) continue;
+      const index = next.findIndex((clause) => `${clause.scale}:${clause.field}` === key);
+      if (index < 0) continue;
+      const clause = next[index]!;
+      const values = reconcileLegendFilterValues(clause.values, catalog);
+      reconciled.push({
+        clause: Object.freeze({ ...clause, values }),
+        removed: values.length === 0,
+      });
+      next =
+        values.length === 0
+          ? next.filter((_, candidateIndex) => candidateIndex !== index)
+          : next.map((candidate, candidateIndex) =>
+              candidateIndex === index ? Object.freeze({ ...candidate, values }) : candidate,
+            );
+    }
+    for (const key of legendCatalogFingerprints.keys())
+      if (!catalogs.has(key)) legendCatalogFingerprints.delete(key);
+    if (next === localLegendFilters) return;
+    localLegendFilters = [...next];
+    for (const { clause, removed } of reconciled)
+      emitLegendFilter({
+        type: "legend-filter",
+        phase: removed ? "remove" : "change",
+        source: "programmatic",
+        clause,
+      });
+    deps.announce("Legend filters reconciled with the available groups.");
+  });
 
   return {
     get options() {
@@ -376,6 +375,5 @@ export function createLegendFilterState(deps: LegendFilterStateDeps): LegendFilt
     toggle,
     reset,
     setPointerType,
-    registerCatalogEffects,
   };
 }

--- a/packages/svelte/src/lib/legend/focus-state.svelte.ts
+++ b/packages/svelte/src/lib/legend/focus-state.svelte.ts
@@ -97,8 +97,12 @@ export type LegendFocusState = {
   clearLegendFromControl(event: MouseEvent): void;
   setTouchIndexCleared(): void;
   setClearPointerType(type: string | null): void;
-  /** Register reconcile effects at their original host position. */
-  registerReconcileEffects(): void;
+  /**
+   * Install reconcile effects after host `$derived` entry lists exist.
+   * Irreducible late hook: entries/pressed close over host-held deriveds that
+   * require this factory's compute* methods (#627 — not a sibling-controller cycle).
+   */
+  installHostDerivedEffects(): void;
 };
 
 // ---------------------------------------------------------------------------
@@ -106,10 +110,9 @@ export type LegendFocusState = {
 // ---------------------------------------------------------------------------
 
 /**
- * Create the legend-focus controller. Construction registers only the
- * construction-time `effectiveEmphasisKeys` derived (over earlier host
- * bindings). Call `registerReconcileEffects` at the original catalog/reconcile
- * position after the host declares model-dependent deriveds.
+ * Create the legend-focus controller. Construction registers
+ * `effectiveEmphasisKeys`. Call `installHostDerivedEffects` after the host
+ * declares entry/pressed deriveds that this factory's compute* methods feed.
  */
 export function createLegendFocusState(deps: LegendFocusStateDeps): LegendFocusState {
   let localEmphasisKeys = $state<PropertyKey[]>([]);
@@ -407,7 +410,7 @@ export function createLegendFocusState(deps: LegendFocusStateDeps): LegendFocusS
     previewLegend(null);
   }
 
-  function registerReconcileEffects(): void {
+  function installHostDerivedEffects(): void {
     $effect.pre(() => {
       const count = deps.entries().length;
       const active = document.activeElement;
@@ -530,6 +533,6 @@ export function createLegendFocusState(deps: LegendFocusStateDeps): LegendFocusS
     clearLegendFromControl,
     setTouchIndexCleared,
     setClearPointerType,
-    registerReconcileEffects,
+    installHostDerivedEffects,
   };
 }

--- a/packages/svelte/src/lib/plot-interaction-assembly.svelte.ts
+++ b/packages/svelte/src/lib/plot-interaction-assembly.svelte.ts
@@ -1,9 +1,12 @@
 /**
  * Deep plot-interaction assembly.
  *
- * Owns controller construction, deferred sibling wiring, shared Candidate
- * projection, and phased effect registration. Callers provide reactive plot
- * facts; construction topology remains an implementation detail here.
+ * Owns controller construction and shared Candidate projection. Cross-module
+ * transition side effects (e.g. inspection dismiss → brush/tool) are applied
+ * via `applyInspectionDismissSideEffects` at the surface call site (#627).
+ * Leaf modules register their own effects at construction; assembly only
+ * wires host-held deriveds into catalog reconcile where data is not available
+ * at leaf construction time.
  */
 import type { CellValue } from "@ggsvelte/core";
 import type { PortableSpec } from "@ggsvelte/spec";
@@ -118,8 +121,8 @@ export function createPlotInteractionAssembly<
   };
 
   // Construction order is the topological order of direct construction-time
-  // reads; effect registration sequence is load-bearing. Deferred thunks break
-  // the runtime cycles (surface ↔ inspection ↔ interval ↔ selection).
+  // reads. Cross-module dismiss tails go through transition-owner at the
+  // surface call site; leaf effects register at construction (#627).
 
   // ------------------------------------------------------------ zoom respec
   // Construction-time deriveds read interaction/scope/zoomConfig/assembled
@@ -188,17 +191,15 @@ export function createPlotInteractionAssembly<
     onlegendfilter: () => inputs.onlegendfilter(),
     oninteraction: inputs.oninteraction,
     announce: announceSink,
-    // model is declared after the runtime; the getter is only invoked from
-    // late catalog effects (never at construction).
+    // model / catalogEntries close over later bindings (effect-only; not
+    // construction-time reads).
     model: () => runtime.model,
+    catalogEntries: () => filterableLegendEntries,
   });
 
   // ------------------------------------------------- plot runtime
   // Factory sits after zoom-respec and legend-filter so every direct
   // construction-time dep is already initialized (TDZ).
-  // Effect registration: model dispose/onrender effects register here;
-  // ResizeObserver registers later via registerLateEffects (after legend
-  // reconcile) — safe because the observer callback is async.
   const runtime = createPlotRuntime({
     widthProp: () => inputs.width(),
     heightProp: () => inputs.height(),
@@ -212,14 +213,9 @@ export function createPlotInteractionAssembly<
     },
     onrender: () => inputs.onrender(),
   });
-  // Model dispose + onrender effects (after the legend-reset effects that
-  // registered during legendFilterState construction; before late effects).
-  runtime.registerModelEffects();
-
-  // Semantic resolution as soon as the runtime model exists. Diagnostics
-  // effects register later; early construction makes interval projection
-  // safe when a shared controller arrives with pre-populated non-union
-  // intervals (#165).
+  // Semantic resolution as soon as the runtime model exists. Early
+  // construction makes interval projection safe when a shared controller
+  // arrives with pre-populated non-union intervals (#165).
   const semanticKeys = createSemanticKeyService({
     model: () => runtime.model,
     assembled,
@@ -249,81 +245,14 @@ export function createPlotInteractionAssembly<
   const interactive = $derived(interactionConfig.interactive);
   const surfaceInteractive = $derived(interactionConfig.availableTools.length > 0);
 
-  // ------------------------------------------------- inspection
-  // Construction-time deriveds may read the earlier model. Phased effects
-  // register later via registerInspectionEffects().
-  // Reversed deps: reducer / clearBrush / chooseTool close over the later-
-  // declared surfaceState (handler/effect-only; construction guard).
-  const inspectionState = createInspectionState({
-    model: () => runtime.model,
-    // Deferred: surface owns the reducer (handler/effect only).
-    reducer: () => surfaceState.reducer,
-    inspectConfig: () => interactionConfig.inspect,
-    inspectEnabled: () => inspectEnabled,
-    dataIdentityEpoch: () => dataIdentityEpoch,
-    // Deferred: semantic-key service is declared later (handler only).
-    keyAt: (index) => semanticKeys.keyAt(index),
-    root: inputs.root,
-    captureSurface: inputs.captureSurface,
-    plotId: () => inputs.plotId,
-    tooltipHovered: () => tooltipHovered,
-    clearTooltipHovered: () => {
-      tooltipHovered = false;
-    },
-    clearBrush: () => {
-      surfaceState.clearBrush();
-    },
-    chooseTool: (next) => {
-      surfaceState.chooseTool(next);
-    },
-    oninspect: inputs.oninspect,
-    oninteraction: inputs.oninteraction,
-    announce: announceSink,
-    clearAnnouncement: () => {
-      announcer.clear();
-    },
-  });
-  // ------------------------------------------------- surface
-  // Construction-time deriveds read module-internal state + inspectConfig.
-  // Sibling controllers, sinks, and chrome getters are handler/effect-only.
-  // Phased effects register later via registerSurfaceEffects().
-  const surfaceState = createSurfaceState({
-    model: () => runtime.model,
-    root: inputs.root,
-    toolProp: () => inputs.tool(),
-    initialTool: () => interactionConfig.initialTool,
-    // Deferred: chrome availableTools (handler/effect only).
-    availableTools: () => chromeState.availableTools,
-    inspectConfig: () => interactionConfig.inspect,
-    selectConfig: () => interactionConfig.select,
-    // Deferred: chrome canPublishPointSelection (handler only).
-    pointSelectEnabled: () => chromeState.canPublishPointSelection,
-    ontoolchange: () => inputs.ontoolchange(),
-    surfaceInteractive: () => surfaceInteractive,
-    // Deferred: semantic-key service initializes later (issue #165).
-    candidateSemanticKeys: (candidate) => candidateSemanticKeys(candidate),
-    inspection: () => inspectionState,
-    // Deferred: interval is declared after surface (handler only).
-    interval: () => intervalState,
-    zoom: () => zoomState,
-    // Deferred: selection controller is declared after surface (handler only).
-    emitSelection: (event) => {
-      selectionState.emitSelection(event);
-    },
-    // Deferred: semantic-key service is declared later (handler only).
-    semanticKey: (row, index) => semanticKey(row, index),
-    // Deferred: selection controller is declared after surface (handler only).
-    togglePointKeys: (keys, source) => {
-      selectionState.togglePointKeys(keys, source);
-    },
-    tooltipHovered: () => tooltipHovered,
-    announce: announceSink,
-  });
+  // Shared enablement predicates (avoid re-typing the same config gates).
+  const inspectEnabled = $derived(interactionConfig.inspect !== null);
+  const legendFocusEnabled = $derived(interactionConfig.legendFocus !== null);
   const coordFlipped = $derived(assembled()?.coord?.type === "flip");
   let tooltipHovered = $state(false);
+
   // ------------------------------------------------- selection
-  // Construction-time effectiveSelectedKeys reads earlier interaction/scope
-  // only. The later runtime projection module owns anchors and masks.
+  // Before surface so emit/toggle are direct (not deferred sibling getters).
   const selectionState = createSelectionState({
     interaction: inputs.interaction,
     resolvedInteractionScope: () => resolvedInteractionScope,
@@ -332,12 +261,91 @@ export function createPlotInteractionAssembly<
     oninteraction: inputs.oninteraction,
     announce: announceSink,
   });
-  // Shared enablement predicates (avoid re-typing the same config gates).
-  const inspectEnabled = $derived(interactionConfig.inspect !== null);
-  const legendFocusEnabled = $derived(interactionConfig.legendFocus !== null);
+
+  // ------------------------------------------------- inspection
+  // Reducer is still owned by surface (created next). Inspection takes a
+  // deferred reducer getter only for that TDZ edge; clearBrush/chooseTool are
+  // NOT wired here — surface applies dismiss plan tails via transition-owner.
+  let surfaceState!: ReturnType<typeof createSurfaceState>;
+  const inspectionState = createInspectionState({
+    model: () => runtime.model,
+    reducer: () => surfaceState.reducer,
+    inspectConfig: () => interactionConfig.inspect,
+    inspectEnabled: () => inspectEnabled,
+    dataIdentityEpoch: () => dataIdentityEpoch,
+    keyAt: (index) => semanticKeys.keyAt(index),
+    root: inputs.root,
+    captureSurface: inputs.captureSurface,
+    plotId: () => inputs.plotId,
+    tooltipHovered: () => tooltipHovered,
+    clearTooltipHovered: () => {
+      tooltipHovered = false;
+    },
+    oninspect: inputs.oninspect,
+    oninteraction: inputs.oninteraction,
+    announce: announceSink,
+    clearAnnouncement: () => {
+      announcer.clear();
+    },
+  });
+
+  // ------------------------------------------------- interval selection
+  // Before surface so finishBrushSelect is a direct ref (not deferred).
+  // consumptionCandidates still late-binds the projection module.
+  let semanticCandidateProjection!: ReturnType<typeof createSemanticCandidateProjection>;
+  const intervalState = createIntervalState({
+    model: () => runtime.model,
+    interaction: inputs.interaction,
+    resolvedInteractionScope: () => resolvedInteractionScope,
+    selectConfig: () => interactionConfig.select,
+    effectiveZoomDomains: () => zoomState.effectiveZoomDomains,
+    commitZoom: (...args: Parameters<PlotZoomState["commitZoom"]>) => {
+      zoomState.commitZoom(...args);
+    },
+    captureSurface: inputs.captureSurface,
+    candidateSemanticKeys: (candidate) => candidateSemanticKeys(candidate),
+    consumptionCandidates: () => semanticCandidateProjection.intervalConsumptionCandidates,
+    inspectionPanel: () => inspectionState.inspectionPanel,
+    emitSelection: (...args: Parameters<SelectionState["emitSelection"]>) => {
+      selectionState.emitSelection(...args);
+    },
+    announce: announceSink,
+  });
+
+  // ------------------------------------------------- surface
+  // Inspection + interval + selection already constructed — no sibling TDZ
+  // getters for those. Chrome availableTools / pointSelect still late.
+  let chromeState!: ReturnType<typeof createPlotChromeState>;
+  surfaceState = createSurfaceState({
+    model: () => runtime.model,
+    root: inputs.root,
+    toolProp: () => inputs.tool(),
+    initialTool: () => interactionConfig.initialTool,
+    availableTools: () => chromeState.availableTools,
+    inspectConfig: () => interactionConfig.inspect,
+    selectConfig: () => interactionConfig.select,
+    pointSelectEnabled: () => chromeState.canPublishPointSelection,
+    ontoolchange: () => inputs.ontoolchange(),
+    surfaceInteractive: () => surfaceInteractive,
+    candidateSemanticKeys: (candidate) => candidateSemanticKeys(candidate),
+    inspection: () => inspectionState,
+    interval: () => intervalState,
+    zoom: () => zoomState,
+    emitSelection: (event) => {
+      selectionState.emitSelection(event);
+    },
+    semanticKey: (row, index) => semanticKey(row, index),
+    togglePointKeys: (keys, source) => {
+      selectionState.togglePointKeys(keys, source);
+    },
+    tooltipHovered: () => tooltipHovered,
+    announce: announceSink,
+  });
+
   // ------------------------------------------------- legend focus
-  // Factory sits after the enablement cluster so construction-time
-  // effectiveEmphasisKeys closes over earlier bindings only.
+  // Host-held entry lists are $derived after this factory; effects that read
+  // them install via installHostDerivedEffects (irreducible late data, not a
+  // sibling-controller cycle — #627).
   const legendFocusState = createLegendFocusState({
     interaction: inputs.interaction,
     resolvedInteractionScope: () => resolvedInteractionScope,
@@ -346,38 +354,12 @@ export function createPlotInteractionAssembly<
     root: inputs.root,
     entryKeys: () => legendEntryKeys,
     entries: () => interactiveLegendEntries,
-    // Deferred read of the later-declared cached derived (handlers only).
     pressed: () => effectiveLegendPressed,
     onlegendfocus: inputs.onlegendfocus,
     oninteraction: inputs.oninteraction,
     announce: announceSink,
   });
-  // ------------------------------------------------- interval selection
-  // Construction-time deriveds may read model/effectiveZoomDomains (both
-  // earlier-declared). Effects register here — relative order is runtime
-  // model effects < interval effects < semantic diagnostics.
-  const intervalState = createIntervalState({
-    model: () => runtime.model,
-    interaction: inputs.interaction,
-    resolvedInteractionScope: () => resolvedInteractionScope,
-    selectConfig: () => interactionConfig.select,
-    effectiveZoomDomains: () => zoomState.effectiveZoomDomains,
-    // Direct construction edges (not deferred thunks): zoom + selection
-    // are already constructed when interval is built.
-    commitZoom: (...args: Parameters<PlotZoomState["commitZoom"]>) => {
-      zoomState.commitZoom(...args);
-    },
-    captureSurface: inputs.captureSurface,
-    candidateSemanticKeys: (candidate) => candidateSemanticKeys(candidate),
-    // Deferred: the projection module is constructed immediately after interval.
-    consumptionCandidates: () => semanticCandidateProjection.intervalConsumptionCandidates,
-    inspectionPanel: () => inspectionState.inspectionPanel,
-    emitSelection: (...args: Parameters<SelectionState["emitSelection"]>) => {
-      selectionState.emitSelection(...args);
-    },
-    announce: announceSink,
-  });
-  const semanticCandidateProjection = createSemanticCandidateProjection({
+  semanticCandidateProjection = createSemanticCandidateProjection({
     model: () => runtime.model,
     candidateSemanticKeys: (candidate) => candidateSemanticKeys(candidate),
     selectedKeys: () => selectionState.effectiveSelectedKeys,
@@ -408,7 +390,7 @@ export function createPlotInteractionAssembly<
   // ------------------------------------------------- plot chrome
   // All inputs earlier-declared. Pure construction-time deriveds —
   // no $state/handlers/effects.
-  const chromeState = createPlotChromeState({
+  chromeState = createPlotChromeState({
     model: () => runtime.model,
     zoomConfig: () => interactionConfig.zoom,
     selectConfig: () => interactionConfig.select,
@@ -425,8 +407,6 @@ export function createPlotInteractionAssembly<
     resolvedWidth: () => runtime.resolvedWidth,
     resolvedHeight: () => runtime.resolvedHeight,
   });
-  // Semantic diagnostics effects (before host diagnostic / surface effects).
-  semanticKeys.registerEffects();
 
   $effect(() => {
     for (const diagnostic of chromeState.areaScaleDiagnostics) deliverDiagnostic(diagnostic);
@@ -435,10 +415,6 @@ export function createPlotInteractionAssembly<
   $effect(() => {
     for (const diagnostic of chromeState.legendDiagnostics) deliverDiagnostic(diagnostic);
   });
-
-  // Surface window-teardown + tool-sync (after diagnostics, before catalog/
-  // focus/inspection registrations).
-  surfaceState.registerSurfaceEffects();
 
   // Host-side deriveds kept outside the factory (construction-time free of
   // the model read).
@@ -455,18 +431,11 @@ export function createPlotInteractionAssembly<
   // layout test pins their combined geometry).
   const legendClearActive = $derived(legendFocusEnabled && effectiveLegendPressed !== null);
 
-  // Host-side derived kept outside the factory (construction-time free of
-  // the model read).
+  // Host-side derived for catalog reconcile (closes over runtime.model).
   const filterableLegendEntries = $derived(legendFilterState.computeEntries(runtime.model));
-  // Catalog reconcile after model effects.
-  legendFilterState.registerCatalogEffects(() => filterableLegendEntries);
-  // Legend-focus reconcile after catalog.
-  legendFocusState.registerReconcileEffects();
-  // Inspection disposal + scene reconcile after legend-focus.
-  inspectionState.registerInspectionEffects();
 
-  // clientFlush/ready effect at end of script (late registration).
-  runtime.registerLateEffects();
+  // After host entry deriveds exist (irreducible late data for legend focus).
+  legendFocusState.installHostDerivedEffects();
 
   return {
     zoomState,

--- a/packages/svelte/src/lib/runtime/runtime.svelte.ts
+++ b/packages/svelte/src/lib/runtime/runtime.svelte.ts
@@ -2,7 +2,7 @@
  * Plot runtime: container sizing, model production (runPipeline + scale gate),
  * strata plan, paint ledger, and readiness. Extracted from GGPlot for S1.
  *
- * Effect registration is phased (see registerModelEffects / registerLateEffects)
+ * Effects register at construction (#627)
  * so relative order vs host effects is preserved.
  */
 import {
@@ -47,19 +47,12 @@ export type PlotRuntime = {
   readonly ready: boolean;
   notifyPainted(runId: number, stratumKey: string): void;
   resetScales(): void;
-  /** Register dispose + onrender effects (original position ~after legend resets). */
-  registerModelEffects(): void;
-  /** Register clientFlush/ready effect (end of script). */
-  registerLateEffects(): void;
 };
 
 /**
- * Create the plot runtime. Construction registers ONLY the ResizeObserver
- * effect. Call `registerModelEffects` and `registerLateEffects` at their
- * original host positions. Dep getters must not be invoked during construction
- * for construction-time deriveds; the host must declare every binding a dep
- * getter closes over BEFORE calling this factory (declaration order is the
- * topological order; direct construction-time reads of later bindings TDZ).
+ * Create the plot runtime. Construction registers ResizeObserver, model
+ * dispose/onrender, and clientFlush effects (#627). Dep getters must not be
+ * invoked during construction for construction-time deriveds.
  */
 export function createPlotRuntime(deps: PlotRuntimeDeps): PlotRuntime {
   // ------------------------------------------------- container width (RO)
@@ -185,7 +178,7 @@ export function createPlotRuntime(deps: PlotRuntimeDeps): PlotRuntime {
     scaleEpoch++;
   }
 
-  // Readiness: clientFlush is false until registerLateEffects runs its effect.
+  // Readiness: clientFlush flips true on first client effect flush (SSR stays false).
   let clientFlush = $state(false);
   const ready = $derived.by(() => {
     void paintEpoch;
@@ -199,28 +192,24 @@ export function createPlotRuntime(deps: PlotRuntimeDeps): PlotRuntime {
     });
   });
 
-  function registerModelEffects(): void {
-    // Memory ownership: dispose the previous model once the DOM has moved on
-    // (effect cleanup runs post-flush), and the last model on unmount.
-    $effect(() => {
-      const m = model;
-      return () => m?.dispose();
-    });
+  // Memory ownership: dispose the previous model once the DOM has moved on
+  // (effect cleanup runs post-flush), and the last model on unmount.
+  $effect(() => {
+    const m = model;
+    return () => m?.dispose();
+  });
 
-    $effect(() => {
-      const m = model;
-      const assembled = deps.assembled();
-      if (m !== null && assembled !== null) untrack(() => deps.onrender()?.(m, assembled));
-    });
-  }
+  $effect(() => {
+    const m = model;
+    const assembled = deps.assembled();
+    if (m !== null && assembled !== null) untrack(() => deps.onrender()?.(m, assembled));
+  });
 
-  function registerLateEffects(): void {
-    // clientFlush via $effect: never runs during SSR → prerender stays
-    // data-gg-ready="false" until the first client committed flush (decision 0009)
-    $effect(() => {
-      clientFlush = true;
-    });
-  }
+  // clientFlush via $effect: never runs during SSR → prerender stays
+  // data-gg-ready="false" until the first client committed flush (decision 0009)
+  $effect(() => {
+    clientFlush = true;
+  });
 
   return {
     get model() {
@@ -245,7 +234,5 @@ export function createPlotRuntime(deps: PlotRuntimeDeps): PlotRuntime {
     },
     notifyPainted,
     resetScales,
-    registerModelEffects,
-    registerLateEffects,
   };
 }

--- a/packages/svelte/src/lib/runtime/semantic-keys.svelte.ts
+++ b/packages/svelte/src/lib/runtime/semantic-keys.svelte.ts
@@ -32,15 +32,11 @@ export type SemanticKeyService = {
   candidateSemanticKeys(candidate: CandidateFacts): PropertyKey[];
   /** Direct map lookup (inspection coordinator / mask paths). */
   keyAt(index: number): PropertyKey | null;
-  /** Register diagnostics delivery at the host's original effect position. */
-  registerEffects(): void;
 };
 
 /**
  * Owns priorKeys, semantic key resolution, and diagnostics delivery.
- * Construction may happen as soon as the runtime model exists; call
- * `registerEffects` at the original GGPlot registration site so the
- * diagnostics `$effect` keeps its relative order.
+ * Diagnostics `$effect` registers at construction (#627).
  */
 export function createSemanticKeyService(deps: SemanticKeyServiceDeps): SemanticKeyService {
   // Owned for the component lifetime; resolveSemanticKeys mutates in place.
@@ -65,11 +61,9 @@ export function createSemanticKeyService(deps: SemanticKeyServiceDeps): Semantic
     });
   });
 
-  function registerEffects(): void {
-    $effect(() => {
-      for (const diagnostic of semanticKeys.diagnostics) deps.deliverDiagnostic(diagnostic);
-    });
-  }
+  $effect(() => {
+    for (const diagnostic of semanticKeys.diagnostics) deps.deliverDiagnostic(diagnostic);
+  });
 
   function semanticKey(
     row: Record<string, CellValue> | null,
@@ -116,6 +110,5 @@ export function createSemanticKeyService(deps: SemanticKeyServiceDeps): Semantic
     keyAt(index: number): PropertyKey | null {
       return semanticKeys.keys.get(index) ?? null;
     },
-    registerEffects,
   };
 }

--- a/packages/svelte/src/lib/surface/surface-handlers.ts
+++ b/packages/svelte/src/lib/surface/surface-handlers.ts
@@ -24,6 +24,7 @@ import {
 import { BRUSH_SECOND_CORNER_ANNOUNCEMENT } from "../assembly/labels.js";
 import { hitFromCandidate, plotPointFromClient } from "./plot-px.js";
 import { resolveSurfaceBlurAction } from "../inspection/teardown.js";
+import { applyInspectionDismissSideEffects } from "../interaction/transition-owner.js";
 import { resolveSurfaceKeyAction } from "./keyboard.js";
 import {
   advanceTouchInspectMoved,
@@ -434,11 +435,16 @@ export function createSurfaceHandlers(live: SurfaceHandlerLive): SurfaceHandlers
       case "toggle-pin":
         inspection.toggleInspectionPin("keyboard");
         return;
-      case "escape":
-        inspection.dismissInspection("escape", "keyboard", {
+      case "escape": {
+        const plan = inspection.dismissInspection("escape", "keyboard", {
           returnToInspect: action.returnToInspect,
         });
+        applyInspectionDismissSideEffects(plan, {
+          clearBrush,
+          chooseTool,
+        });
         break;
+      }
       case "none":
         break;
     }

--- a/packages/svelte/src/lib/surface/surface-state.svelte.ts
+++ b/packages/svelte/src/lib/surface/surface-state.svelte.ts
@@ -14,8 +14,7 @@
  * internal state + inspectConfig. Sibling controllers, sinks, and chrome
  * getters are handler/effect-only (armed for the construction guard).
  *
- * Effects register via registerSurfaceEffects() at the original line-810
- * position (after diagnostics effects, before catalog/focus/inspection).
+ * Window-teardown + tool-sync effects register inside this factory (#627).
  */
 import type { CandidateFacts, CellValue, RenderModel } from "@ggsvelte/core";
 
@@ -107,8 +106,6 @@ export type SurfaceState = {
   onCaptureClick(event: MouseEvent): void;
   onSurfaceKeyDown(event: KeyboardEvent): void;
   onSurfaceBlur(event: FocusEvent): void;
-  /** Register window-teardown + tool-sync effects at the original host site. */
-  registerSurfaceEffects(): void;
 };
 
 // ---------------------------------------------------------------------------
@@ -116,9 +113,8 @@ export type SurfaceState = {
 // ---------------------------------------------------------------------------
 
 /**
- * Create the surface controller. Construction registers only the
- * construction-time deriveds. Call `registerSurfaceEffects` at the original
- * line-810 position (after diagnostics, before catalog/focus/inspection).
+ * Create the surface controller. Construction registers deriveds and
+ * window-teardown + tool-sync effects.
  *
  * Construction-order note: deps must not be invoked during construction —
  * construction-read discipline enforced by the armed-getter suite.
@@ -184,45 +180,40 @@ export function createSurfaceState(deps: SurfaceStateDeps): SurfaceState {
     },
   });
 
-  function registerSurfaceEffects(): void {
-    // Window outside-pointer / blur teardown (original line-810).
-    $effect(() => {
-      // No-op cleanup keeps every code path returning a teardown (consistent-return).
-      if (!deps.surfaceInteractive()) return () => {};
-      const onOutsidePointer = (event: PointerEvent) => {
-        if (
-          !shouldClosePinnedOnOutsidePointer({
-            inspectionState: deps.inspection().inspection?.state,
-            targetInsideRoot: deps.root()?.contains(event.target as Node) === true,
-          })
-        )
-          return;
-        deps.inspection().closeInspection("pointer", false);
-      };
-      const cancelDraft = () => {
-        brushRect = null;
-        deps.inspection().cancelPointerInspect({ pendingPinned: "preserve" });
-        handlers.clearTouchInspectStart();
-        reducer.cancelScheduledPointer();
-        reducer.dispatch({ type: "cancel-area" });
-      };
-      window.addEventListener("pointerdown", onOutsidePointer);
-      window.addEventListener("blur", cancelDraft);
-      return () => {
-        window.removeEventListener("pointerdown", onOutsidePointer);
-        window.removeEventListener("blur", cancelDraft);
-      };
-    });
+  // Window outside-pointer / blur teardown + tool-sync (formerly host-phased
+  // registerSurfaceEffects — registered at construction, #627).
+  $effect(() => {
+    // No-op cleanup keeps every code path returning a teardown (consistent-return).
+    if (!deps.surfaceInteractive()) return () => {};
+    const onOutsidePointer = (event: PointerEvent) => {
+      if (
+        !shouldClosePinnedOnOutsidePointer({
+          inspectionState: deps.inspection().inspection?.state,
+          targetInsideRoot: deps.root()?.contains(event.target as Node) === true,
+        })
+      )
+        return;
+      deps.inspection().closeInspection("pointer", false);
+    };
+    const cancelDraft = () => {
+      brushRect = null;
+      deps.inspection().cancelPointerInspect({ pendingPinned: "preserve" });
+      handlers.clearTouchInspectStart();
+      reducer.cancelScheduledPointer();
+      reducer.dispatch({ type: "cancel-area" });
+    };
+    window.addEventListener("pointerdown", onOutsidePointer);
+    window.addEventListener("blur", cancelDraft);
+    return () => {
+      window.removeEventListener("pointerdown", onOutsidePointer);
+      window.removeEventListener("blur", cancelDraft);
+    };
+  });
 
-    // Tool-sync (original line-837).
-    $effect(() => {
-      const next = resolveEffectiveTool(
-        deps.toolProp() ?? deps.initialTool(),
-        deps.availableTools(),
-      );
-      reducer.dispatch({ type: "set-tool", tool: next });
-    });
-  }
+  $effect(() => {
+    const next = resolveEffectiveTool(deps.toolProp() ?? deps.initialTool(), deps.availableTools());
+    reducer.dispatch({ type: "set-tool", tool: next });
+  });
 
   return {
     get reducer() {
@@ -273,6 +264,5 @@ export function createSurfaceState(deps: SurfaceStateDeps): SurfaceState {
     onSurfaceBlur: (event) => {
       handlers.onSurfaceBlur(event);
     },
-    registerSurfaceEffects,
   };
 }

--- a/packages/svelte/tests/inspection/inspection-state.construction-effects.test.ts
+++ b/packages/svelte/tests/inspection/inspection-state.construction-effects.test.ts
@@ -33,8 +33,6 @@ describe("createInspectionState construction", () => {
     let clearTooltipHoveredCalls = 0;
     let keyAtCalls = 0;
     let inspectEnabledCalls = 0;
-    let chooseToolCalls = 0;
-    let clearBrushCalls = 0;
     let oninspectCalls = 0;
     let oninteractionCalls = 0;
     let plotIdCalls = 0;
@@ -75,12 +73,6 @@ describe("createInspectionState construction", () => {
         clearTooltipHovered: () => {
           clearTooltipHoveredCalls++;
         },
-        clearBrush: () => {
-          clearBrushCalls++;
-        },
-        chooseTool: () => {
-          chooseToolCalls++;
-        },
         oninspect: () => {
           oninspectCalls++;
           return noInspect();
@@ -100,28 +92,13 @@ describe("createInspectionState construction", () => {
     expect(clearTooltipHoveredCalls).toBe(0);
     expect(keyAtCalls).toBe(0);
     expect(inspectEnabledCalls).toBe(0);
-    expect(chooseToolCalls).toBe(0);
-    expect(clearBrushCalls).toBe(0);
     expect(oninspectCalls).toBe(0);
     expect(oninteractionCalls).toBe(0);
     expect(plotIdCalls).toBe(0);
-    // Accessors + one flush must not reach armed getters (construction-read
-    // discipline). Direct construction-time reads of armed deps would throw
-    // right here.
+    // Accessors before flush must not reach armed getters (construction-read
+    // discipline). Scene-reconcile effects may read inspectEnabled after flush.
     expect(state.inspection).toBeNull();
     expect(state.inspectionPanel).toBeNull();
-    flushSync();
-    expect(reducerCalls).toBe(0);
-    expect(captureSurfaceCalls).toBe(0);
-    expect(tooltipHoveredCalls).toBe(0);
-    expect(clearTooltipHoveredCalls).toBe(0);
-    expect(keyAtCalls).toBe(0);
-    expect(inspectEnabledCalls).toBe(0);
-    expect(chooseToolCalls).toBe(0);
-    expect(clearBrushCalls).toBe(0);
-    expect(oninspectCalls).toBe(0);
-    expect(oninteractionCalls).toBe(0);
-    expect(plotIdCalls).toBe(0);
     destroy();
   });
 });
@@ -149,7 +126,6 @@ describe("createInspectionState scene-reconcile effect", () => {
       oninspect: () => (event) => {
         events.push(event);
       },
-      registerEffects: true,
     });
 
     const { candidate, hit } = candidateHit(modelA);
@@ -238,7 +214,6 @@ describe("createInspectionState callback replacement", () => {
       model: () => model,
       oninspect: () => inspectBox.value,
       oninteraction: () => interactionBox.value,
-      registerEffects: false,
     });
 
     const { candidate, hit } = candidateHit(model);

--- a/packages/svelte/tests/inspection/inspection-state.dismiss-traversal.test.ts
+++ b/packages/svelte/tests/inspection/inspection-state.dismiss-traversal.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { CellValue } from "@ggsvelte/core";
 
 import type { PlotInspection } from "../../src/lib/interaction/interaction.js";
+import { applyInspectionDismissSideEffects } from "../../src/lib/interaction/transition-owner.js";
 import {
   candidateHit,
   continuousSpec,
@@ -30,17 +31,10 @@ describe("createInspectionState dismissInspection", () => {
       clearTooltipHovered: () => {
         tooltipHovered = false;
       },
-      clearBrush: () => {
-        brushCleared++;
-      },
-      chooseTool: (tool) => {
-        chooseToolCalls.push(tool);
-      },
       captureSurface: () => capture,
       oninspect: () => (event) => {
         events.push(event);
       },
-      registerEffects: false,
     });
 
     const { candidate, hit } = candidateHit(model);
@@ -48,7 +42,17 @@ describe("createInspectionState dismissInspection", () => {
     flushSync();
     events.length = 0;
 
-    state.dismissInspection("escape", "keyboard", { returnToInspect: true });
+    const escapePlan = state.dismissInspection("escape", "keyboard", {
+      returnToInspect: true,
+    });
+    applyInspectionDismissSideEffects(escapePlan, {
+      clearBrush: () => {
+        brushCleared++;
+      },
+      chooseTool: (tool) => {
+        chooseToolCalls.push(tool);
+      },
+    });
     flushSync();
     expect(state.inspection).toBeNull();
     expect(tooltipHovered).toBe(false);
@@ -61,11 +65,22 @@ describe("createInspectionState dismissInspection", () => {
     state.setInspection(hit, "pointer", "transient", "xy", candidate);
     flushSync();
     events.length = 0;
-    state.closeInspection("pointer", true);
+    const closePlan = state.closeInspection("pointer", true);
+    applyInspectionDismissSideEffects(closePlan, {
+      clearBrush: () => {
+        brushCleared++;
+      },
+      chooseTool: (tool) => {
+        chooseToolCalls.push(tool);
+      },
+    });
     flushSync();
     expect(state.inspection).toBeNull();
     await Promise.resolve();
     expect(focusSpy).toHaveBeenCalled();
+    // close plan must not clear brush / return to inspect
+    expect(closePlan.clearBrush).toBe(false);
+    expect(closePlan.returnToInspect).toBe(false);
 
     destroy();
   });
@@ -76,7 +91,6 @@ describe("createInspectionState traversal", () => {
     const model = modelFor(continuousSpec());
     const { state, destroy } = mountInspectionController({
       model: () => model,
-      registerEffects: false,
     });
 
     // Seed traversal at index 0 via navigate from -1.
@@ -126,7 +140,6 @@ describe("createInspectionState traversal", () => {
 
     const { state, destroy } = mountInspectionController({
       model: () => model,
-      registerEffects: false,
     });
 
     state.navigate(1);
@@ -163,7 +176,6 @@ describe("createInspectionState traversal", () => {
 
     const { state, destroy } = mountInspectionController({
       model: () => model,
-      registerEffects: false,
     });
 
     state.navigate(1);

--- a/packages/svelte/tests/inspection/inspection-state.harness.ts
+++ b/packages/svelte/tests/inspection/inspection-state.harness.ts
@@ -153,8 +153,7 @@ function createDeferredFrameScheduler(): {
 /**
  * Mount the controller with production-shaped deps: every reactive dep is a
  * getter (mirroring InspectionStateDeps). Harness owns the component-held
- * reducer and passes a getter. Call registerInspectionEffects when effects
- * are under test.
+ * reducer and passes a getter. Effects register inside the factory (#627).
  *
  * When `deferredFrames` is true, owns a deferred scheduler and wires
  * `onPointerFrame` → `onInspectPointerFrame` so schedule+flush is testable.
@@ -172,13 +171,10 @@ export function mountInspectionController(
     plotId?: () => string;
     tooltipHovered?: () => boolean;
     clearTooltipHovered?: () => void;
-    clearBrush?: () => void;
-    chooseTool?: (tool: "inspect") => void;
     oninspect?: InspectionStateDeps["oninspect"];
     oninteraction?: InspectionStateDeps["oninteraction"];
     announce?: (message: string) => void;
     clearAnnouncement?: () => void;
-    registerEffects?: boolean;
     /** Wire deferred frame + onInspectPointerFrame (for schedulePointerInspect). */
     deferredFrames?: boolean;
   } = {},
@@ -227,15 +223,12 @@ export function mountInspectionController(
       plotId: options.plotId ?? (() => "plot-test"),
       tooltipHovered: options.tooltipHovered ?? (() => false),
       clearTooltipHovered: options.clearTooltipHovered ?? (() => {}),
-      clearBrush: options.clearBrush ?? (() => {}),
-      chooseTool: options.chooseTool ?? (() => {}),
       oninspect: options.oninspect ?? noInspect,
       oninteraction: options.oninteraction ?? noInteraction,
       announce: options.announce ?? (() => {}),
       clearAnnouncement: options.clearAnnouncement ?? (() => {}),
     });
     controllerRef = controller;
-    if (options.registerEffects !== false) controller.registerInspectionEffects();
     return controller;
   });
 

--- a/packages/svelte/tests/inspection/inspection-state.pin-queue.test.ts
+++ b/packages/svelte/tests/inspection/inspection-state.pin-queue.test.ts
@@ -66,7 +66,6 @@ describe("createInspectionState setInspection", () => {
     const model = modelFor(continuousSpec());
     const { state, flushFrame, destroy } = mountInspectionController({
       model: () => model,
-      registerEffects: false,
       deferredFrames: true,
       inspectConfig: () => ({ mode: "xy", maxDistance: 1e6, pin: false }),
     });
@@ -128,7 +127,6 @@ describe("createInspectionState pin cycle", () => {
     const model = modelFor(continuousSpec());
     const { state, flushFrame, destroy } = mountInspectionController({
       model: () => model,
-      registerEffects: false,
       deferredFrames: true,
     });
 
@@ -181,7 +179,6 @@ describe("createInspectionState schedulePointerInspect / onInspectPointerFrame",
       announce: (message) => {
         announcements.push(message);
       },
-      registerEffects: false,
       deferredFrames: true,
     });
     const { candidate } = candidateHit(model);
@@ -198,6 +195,9 @@ describe("createInspectionState schedulePointerInspect / onInspectPointerFrame",
     expect(state.inspection).toBeNull();
 
     // Fresh schedule + flush → InspectionState owns transient lifecycle.
+    // Scene-reconcile may have already bumped reducer revision at mount;
+    // pin that applying inspect does not advance it further.
+    const revisionBeforeInspect = reducer.state.revision;
     state.schedulePointerInspect({
       point: { x: candidate.x, y: candidate.y },
       source: "pointer",
@@ -207,8 +207,8 @@ describe("createInspectionState schedulePointerInspect / onInspectPointerFrame",
     flushFrame();
     flushSync();
     expect(state.inspection?.state).toBe("transient");
-    // Reducer is not the inspection authority (no inspection field).
-    expect(reducer.state.revision).toBe(0);
+    // Reducer is not the inspection authority (inspect frames never commit).
+    expect(reducer.state.revision).toBe(revisionBeforeInspect);
 
     // Re-apply empty (queues cleared) keeps transient.
     expect(
@@ -363,7 +363,6 @@ describe("createInspectionState schedulePointerInspect / onInspectPointerFrame",
     const { state, destroy } = mountInspectionController({
       model: () => model,
       reducer: () => reducer,
-      registerEffects: false,
     });
     controller = state;
 
@@ -397,8 +396,6 @@ describe("createInspectionState setInspection(null) clear ordering", () => {
         plotId: () => "plot",
         tooltipHovered: () => false,
         clearTooltipHovered: () => {},
-        clearBrush: () => {},
-        chooseTool: () => {},
         oninspect: () => (event) => {
           if (event.phase === "clear") log.push(`emit-clear-inspection-${stateTag()}`);
         },
@@ -439,7 +436,6 @@ describe("createInspectionState completeness selection", () => {
       inspectConfig: modeXInspect,
       oninspect: () => oninspectBox.value,
       oninteraction: noInteraction,
-      registerEffects: false,
     });
 
     const candidate = firstCandidate(model);

--- a/packages/svelte/tests/interaction/transition-owner.test.ts
+++ b/packages/svelte/tests/interaction/transition-owner.test.ts
@@ -14,8 +14,8 @@ describe("applyInspectionDismissSideEffects", () => {
       hasInspection: true,
       returnToInspect: true,
     });
-    const clearBrush = vi.fn();
-    const chooseTool = vi.fn();
+    const clearBrush = vi.fn((): void => {});
+    const chooseTool = vi.fn((_tool: string): void => {});
 
     applyInspectionDismissSideEffects(plan, { clearBrush, chooseTool });
 
@@ -29,8 +29,8 @@ describe("applyInspectionDismissSideEffects", () => {
       hasInspection: true,
       restoreFocus: true,
     });
-    const clearBrush = vi.fn();
-    const chooseTool = vi.fn();
+    const clearBrush = vi.fn((): void => {});
+    const chooseTool = vi.fn((_tool: string): void => {});
 
     applyInspectionDismissSideEffects(plan, { clearBrush, chooseTool });
 
@@ -44,8 +44,8 @@ describe("applyInspectionDismissSideEffects", () => {
       hasInspection: true,
       returnToInspect: false,
     });
-    const clearBrush = vi.fn();
-    const chooseTool = vi.fn();
+    const clearBrush = vi.fn((): void => {});
+    const chooseTool = vi.fn((_tool: string): void => {});
 
     applyInspectionDismissSideEffects(plan, { clearBrush, chooseTool });
 

--- a/packages/svelte/tests/interaction/transition-owner.test.ts
+++ b/packages/svelte/tests/interaction/transition-owner.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Behavior tests for cross-module transition apply (#627).
+ * Expected values are independent of the production apply helper shape.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import { applyInspectionDismissSideEffects } from "../../src/lib/interaction/transition-owner.js";
+import { planInspectionDismiss } from "../../src/lib/inspection/teardown.js";
+
+describe("applyInspectionDismissSideEffects", () => {
+  it("escape with returnToInspect clears brush and chooses inspect", () => {
+    const plan = planInspectionDismiss({
+      kind: "escape",
+      hasInspection: true,
+      returnToInspect: true,
+    });
+    const clearBrush = vi.fn();
+    const chooseTool = vi.fn();
+
+    applyInspectionDismissSideEffects(plan, { clearBrush, chooseTool });
+
+    expect(clearBrush).toHaveBeenCalledTimes(1);
+    expect(chooseTool).toHaveBeenCalledWith("inspect");
+  });
+
+  it("close plan does not clear brush or choose tool", () => {
+    const plan = planInspectionDismiss({
+      kind: "close",
+      hasInspection: true,
+      restoreFocus: true,
+    });
+    const clearBrush = vi.fn();
+    const chooseTool = vi.fn();
+
+    applyInspectionDismissSideEffects(plan, { clearBrush, chooseTool });
+
+    expect(clearBrush).not.toHaveBeenCalled();
+    expect(chooseTool).not.toHaveBeenCalled();
+  });
+
+  it("escape without returnToInspect still clears brush only", () => {
+    const plan = planInspectionDismiss({
+      kind: "escape",
+      hasInspection: true,
+      returnToInspect: false,
+    });
+    const clearBrush = vi.fn();
+    const chooseTool = vi.fn();
+
+    applyInspectionDismissSideEffects(plan, { clearBrush, chooseTool });
+
+    expect(clearBrush).toHaveBeenCalledTimes(1);
+    expect(chooseTool).not.toHaveBeenCalled();
+  });
+});

--- a/packages/svelte/tests/legend/filter-state.test.ts
+++ b/packages/svelte/tests/legend/filter-state.test.ts
@@ -53,6 +53,7 @@ describe("createLegendFilterState construction", () => {
           modelCalls++;
           return null;
         },
+        catalogEntries: () => [],
       }),
     );
 
@@ -65,8 +66,7 @@ describe("createLegendFilterState construction", () => {
     expect(state.options).not.toBeNull();
     expect(state.filters).toEqual([]);
     expect(state.hasActiveFilters).toBe(false);
-    flushSync();
-    expect(modelCalls).toBe(0);
+    // Accessors alone must not read model. Catalog effect may read model on flush.
     destroy();
   });
 });
@@ -79,7 +79,8 @@ describe("createLegendFilterState toggle and mode", () => {
     const model = modelFor(spec);
 
     const { value: state, destroy } = withFlushedEffectRoot(() => {
-      const controller = createLegendFilterState({
+      let controller!: ReturnType<typeof createLegendFilterState>;
+      controller = createLegendFilterState({
         effectiveSpec: () => spec,
         legendFilterProp: () => true,
         onlegendfilter: () => (event) => {
@@ -90,8 +91,8 @@ describe("createLegendFilterState toggle and mode", () => {
           announcements.push(message);
         },
         model: () => model,
+        catalogEntries: () => controller.computeEntries(model),
       });
-      controller.registerCatalogEffects(() => controller.computeEntries(model));
       return controller;
     });
 
@@ -137,7 +138,8 @@ describe("createLegendFilterState toggle and mode", () => {
     const model = modelFor(spec);
 
     const { value: state, destroy } = withFlushedEffectRoot(() => {
-      const controller = createLegendFilterState({
+      let controller!: ReturnType<typeof createLegendFilterState>;
+      controller = createLegendFilterState({
         effectiveSpec: () => spec,
         legendFilterProp: () => ({ mode: "include" as const }),
         onlegendfilter: () => (event) => {
@@ -146,8 +148,8 @@ describe("createLegendFilterState toggle and mode", () => {
         oninteraction: noCallback,
         announce: () => {},
         model: () => model,
+        catalogEntries: () => controller.computeEntries(model),
       });
-      controller.registerCatalogEffects(() => controller.computeEntries(model));
       return controller;
     });
 
@@ -220,6 +222,7 @@ describe("createLegendFilterState scaled-constant gating (#598)", () => {
         oninteraction: noCallback,
         announce: () => {},
         model: () => model,
+        catalogEntries: () => [],
       }),
     );
 
@@ -254,6 +257,7 @@ describe("createLegendFilterState scaled-constant gating (#598)", () => {
         oninteraction: noCallback,
         announce: () => {},
         model: () => model,
+        catalogEntries: () => [],
       }),
     );
 
@@ -272,7 +276,8 @@ describe("createLegendFilterState capability and mode reset", () => {
     const model = modelFor(spec);
 
     const { value: state, destroy } = withFlushedEffectRoot(() => {
-      const controller = createLegendFilterState({
+      let controller!: ReturnType<typeof createLegendFilterState>;
+      controller = createLegendFilterState({
         effectiveSpec: () => spec,
         legendFilterProp: () => prop.value,
         onlegendfilter: () => (event) => {
@@ -283,8 +288,8 @@ describe("createLegendFilterState capability and mode reset", () => {
           announcements.push(message);
         },
         model: () => model,
+        catalogEntries: () => controller.computeEntries(model),
       });
-      controller.registerCatalogEffects(() => controller.computeEntries(model));
       return controller;
     });
 
@@ -322,7 +327,8 @@ describe("createLegendFilterState capability and mode reset", () => {
     const model = modelFor(spec);
 
     const { value: state, destroy } = withFlushedEffectRoot(() => {
-      const controller = createLegendFilterState({
+      let controller!: ReturnType<typeof createLegendFilterState>;
+      controller = createLegendFilterState({
         effectiveSpec: () => spec,
         legendFilterProp: () => prop.value,
         onlegendfilter: () => (event) => {
@@ -331,8 +337,8 @@ describe("createLegendFilterState capability and mode reset", () => {
         oninteraction: noCallback,
         announce: () => {},
         model: () => model,
+        catalogEntries: () => controller.computeEntries(model),
       });
-      controller.registerCatalogEffects(() => controller.computeEntries(model));
       return controller;
     });
 
@@ -367,7 +373,8 @@ describe("createLegendFilterState catalog reconciliation", () => {
     const modelBox = reactiveBox(modelFor(colorSpec(data.value)));
 
     const { value: state, destroy } = withFlushedEffectRoot(() => {
-      const controller = createLegendFilterState({
+      let controller!: ReturnType<typeof createLegendFilterState>;
+      controller = createLegendFilterState({
         effectiveSpec: () => colorSpec(data.value),
         legendFilterProp: () => true,
         onlegendfilter: () => (event) => {
@@ -376,8 +383,8 @@ describe("createLegendFilterState catalog reconciliation", () => {
         oninteraction: noCallback,
         announce: () => {},
         model: () => modelBox.value,
+        catalogEntries: () => controller.computeEntries(modelBox.value),
       });
-      controller.registerCatalogEffects(() => controller.computeEntries(modelBox.value));
       return controller;
     });
 
@@ -424,23 +431,21 @@ describe("runtime + legend-filter real cycle", () => {
       // runtime (never invoked during construction), so the catalog effect
       // always sees the freshly retrained model — no manual re-sync.
       let runtimeRef: PlotRuntime | null = null;
-      const controller = createLegendFilterState({
+      let controller!: ReturnType<typeof createLegendFilterState>;
+      controller = createLegendFilterState({
         effectiveSpec: () => spec,
         legendFilterProp: () => true,
         onlegendfilter: noCallback,
         oninteraction: noCallback,
         announce: () => {},
         model: () => runtimeRef?.model ?? null,
+        catalogEntries: () => controller.computeEntries(runtimeRef?.model ?? null),
       });
       const runtime = createPlotRuntime({
         ...runtimeDeps,
         effectiveLegendFilters: () => controller.filters,
       });
       runtimeRef = runtime;
-      // Host registration order (GGPlot.svelte): model -> catalog -> late.
-      runtime.registerModelEffects();
-      controller.registerCatalogEffects(() => controller.computeEntries(runtime.model));
-      runtime.registerLateEffects();
       return { runtime, controller };
     });
 

--- a/packages/svelte/tests/legend/focus-state.handlers.test.ts
+++ b/packages/svelte/tests/legend/focus-state.handlers.test.ts
@@ -56,16 +56,15 @@ describe("createLegendFocusState construction", () => {
       }),
     );
 
+    // $effect.pre roving sync may read entries at construction; handlers and
+    // other armed getters must stay cold until user input.
     expect(entryKeysCalls).toBe(0);
     expect(entriesCalls).toBe(0);
     expect(pressedCalls).toBe(0);
-    // Deriveds are lazy on client and server at the 5.33.1 floor, so this
-    // guard proves the exposed accessors reach no armed getter (reads + one
-    // flush below) — the construction-read discipline. Direct (non-derived)
-    // construction-time reads of armed deps would throw right here.
     expect(state.effectiveEmphasisKeys).toEqual([]);
     expect(state.previewIdentity).toBeNull();
     expect(state.rovingIndex).toBe(0);
+    // Effects install only via installHostDerivedEffects (not called here).
     flushSync();
     expect(entryKeysCalls).toBe(0);
     expect(entriesCalls).toBe(0);

--- a/packages/svelte/tests/legend/focus-state.harness.ts
+++ b/packages/svelte/tests/legend/focus-state.harness.ts
@@ -115,7 +115,7 @@ export function mountFocusController(
     // Deferred refs mirror the host's later-declared deriveds.
     entriesRef = () => controller.computeInteractiveEntries(model());
     pressedRef = () => controller.computeLegendPressed(model());
-    controller.registerReconcileEffects();
+    controller.installHostDerivedEffects();
     return controller;
   });
 

--- a/packages/svelte/tests/legend/focus-state.integration.test.ts
+++ b/packages/svelte/tests/legend/focus-state.integration.test.ts
@@ -67,6 +67,7 @@ describe("runtime + legend-focus real cycle", () => {
         oninteraction: noCallback,
         announce: () => {},
       });
+      focus.installHostDerivedEffects();
       const runtime = createPlotRuntime({
         ...runtimeDeps,
         effectiveLegendFilters: () => [],
@@ -87,9 +88,6 @@ describe("runtime + legend-focus real cycle", () => {
       entriesRef = () => focus.computeInteractiveEntries(runtime.model);
       pressedRef = () => focus.computeLegendPressed(runtime.model);
       // Host registration order: model -> catalog(S2) -> reconcile(S3) -> late.
-      runtime.registerModelEffects();
-      focus.registerReconcileEffects();
-      runtime.registerLateEffects();
       runtimeDeps.setOnrender((model) => {
         renders.push(model);
       });

--- a/packages/svelte/tests/plot-orchestrator-contract.ssr.test.ts
+++ b/packages/svelte/tests/plot-orchestrator-contract.ssr.test.ts
@@ -8,23 +8,12 @@ const interactionAssemblyPath = join(
   import.meta.dirname,
   "../src/lib/plot-interaction-assembly.svelte.ts",
 );
+const transitionOwnerPath = join(import.meta.dirname, "../src/lib/interaction/transition-owner.ts");
 
-function expectOrdered(source: string, tokens: readonly string[]): void {
-  let previousIndex = -1;
-  for (const token of tokens) {
-    const index = source.indexOf(token);
-    expect(index, `missing orchestrator contract token: ${token}`).toBeGreaterThanOrEqual(0);
-    expect(
-      index,
-      `${token} must remain after ${tokens[tokens.indexOf(token) - 1]}`,
-    ).toBeGreaterThan(previousIndex);
-    previousIndex = index;
-  }
-}
-
-describe("plot interaction assembly lifecycle contract", () => {
+describe("plot interaction assembly seam (#627)", () => {
   const orchestratorSource = readFileSync(orchestratorPath, "utf8");
   const assemblySource = readFileSync(interactionAssemblyPath, "utf8");
+  const transitionOwnerSource = readFileSync(transitionOwnerPath, "utf8");
 
   it("keeps interaction topology behind the assembly seam", () => {
     expect(orchestratorSource).toContain("createPlotInteractionAssembly(");
@@ -46,23 +35,6 @@ describe("plot interaction assembly lifecycle contract", () => {
     }
   });
 
-  it("keeps controller construction in dependency order", () => {
-    expectOrdered(assemblySource, [
-      "const zoomState = createPlotZoomState(",
-      "const legendFilterState = createLegendFilterState(",
-      "const runtime = createPlotRuntime(",
-      "const semanticKeys = createSemanticKeyService(",
-      "const legendEntryKeys = createLegendEntryKeyIndex(",
-      "const inspectionState = createInspectionState(",
-      "const surfaceState = createSurfaceState(",
-      "const selectionState = createSelectionState(",
-      "const legendFocusState = createLegendFocusState(",
-      "const intervalState = createIntervalState(",
-      "const semanticCandidateProjection = createSemanticCandidateProjection(",
-      "const chromeState = createPlotChromeState(",
-    ]);
-  });
-
   it("uses the model-owned CandidateStore without constructing a second hit index", () => {
     expect(assemblySource).not.toContain("buildHitIndex");
     expect(assemblySource).not.toContain("SceneHitIndex");
@@ -79,15 +51,18 @@ describe("plot interaction assembly lifecycle contract", () => {
     }
   });
 
-  it("keeps phased effects in registration order", () => {
-    expectOrdered(assemblySource, [
-      "runtime.registerModelEffects();",
-      "semanticKeys.registerEffects();",
-      "surfaceState.registerSurfaceEffects();",
-      "legendFilterState.registerCatalogEffects(",
-      "legendFocusState.registerReconcileEffects();",
-      "inspectionState.registerInspectionEffects();",
-      "runtime.registerLateEffects();",
-    ]);
+  it("owns multi-module dismiss apply in transition-owner (not inspection surface deps)", () => {
+    expect(transitionOwnerSource).toContain("applyInspectionDismissSideEffects");
+    expect(assemblySource).not.toContain("clearBrush: () =>");
+    expect(assemblySource).not.toContain("chooseTool: (next)");
+    expect(assemblySource).not.toContain("registerSurfaceEffects");
+    expect(assemblySource).not.toContain("registerInspectionEffects");
+    expect(assemblySource).not.toContain("registerCatalogEffects");
+    expect(assemblySource).not.toContain("registerReconcileEffects");
+    expect(assemblySource).not.toContain("registerModelEffects");
+    expect(assemblySource).not.toContain("registerLateEffects");
+    expect(assemblySource).not.toContain("semanticKeys.registerEffects");
+    // Irreducible host-derived legend-focus reconcile (not sibling cycles).
+    expect(assemblySource).toContain("installHostDerivedEffects");
   });
 });

--- a/packages/svelte/tests/runtime/runtime.test.ts
+++ b/packages/svelte/tests/runtime/runtime.test.ts
@@ -70,8 +70,6 @@ describe("createPlotRuntime construction", () => {
         effectiveSpec: minimalSpec,
       });
       const rt = createPlotRuntime(deps);
-      rt.registerModelEffects();
-      rt.registerLateEffects();
       return { runtime: rt, deps };
     });
     const { runtime, deps } = value;
@@ -108,8 +106,6 @@ describe("createPlotRuntime model production", () => {
         effectiveSpec: minimalSpec,
       });
       const rt = createPlotRuntime(deps);
-      rt.registerModelEffects();
-      rt.registerLateEffects();
       return rt;
     });
 
@@ -140,8 +136,6 @@ describe("createPlotRuntime model production", () => {
         resetZoom();
       });
       const rt = createPlotRuntime(deps);
-      rt.registerModelEffects();
-      rt.registerLateEffects();
       return rt;
     });
 
@@ -224,8 +218,6 @@ describe("createPlotRuntime model production", () => {
         effectiveSpec: canvasSpec,
       });
       const rt = createPlotRuntime(deps);
-      rt.registerModelEffects();
-      rt.registerLateEffects();
       return rt;
     });
 
@@ -258,8 +250,6 @@ describe("createPlotRuntime model production", () => {
         effectiveSpec: minimalSpec,
       });
       const rt = createPlotRuntime(deps);
-      rt.registerModelEffects();
-      rt.registerLateEffects();
       return rt;
     });
 
@@ -330,8 +320,6 @@ describe("createPlotRuntime model production", () => {
         deps.setRoot(el);
         deps.setWidth("container");
         const rt = createPlotRuntime(deps);
-        rt.registerModelEffects();
-        rt.registerLateEffects();
         return rt;
       });
 

--- a/packages/svelte/tests/runtime/semantic-keys-service.test.ts
+++ b/packages/svelte/tests/runtime/semantic-keys-service.test.ts
@@ -49,7 +49,6 @@ describe("createSemanticKeyService", () => {
           diagnostics.push(d.code);
         },
       });
-      created.registerEffects();
       return created;
     });
 
@@ -108,7 +107,6 @@ describe("createSemanticKeyService", () => {
         sourceIdentity: (value) => tracker.sourceIdentity(value),
         deliverDiagnostic: () => {},
       });
-      created.registerEffects();
       return created;
     });
 
@@ -153,7 +151,6 @@ describe("createSemanticKeyService", () => {
           diagnostics.push(d.code);
         },
       });
-      created.registerEffects();
       return created;
     });
 

--- a/packages/svelte/tests/surface/surface-state.construction-effects.test.ts
+++ b/packages/svelte/tests/surface/surface-state.construction-effects.test.ts
@@ -41,7 +41,6 @@ describe("createSurfaceState construction", () => {
     let availableToolsCalls = 0;
     let toolPropCalls = 0;
     let tooltipHoveredCalls = 0;
-    let coordFlippedCalls = 0;
     let surfaceInteractiveCalls = 0;
 
     // Minimal stubs so construction can close the cycle without real siblings.
@@ -108,10 +107,6 @@ describe("createSurfaceState construction", () => {
     const { value: state, destroy } = withEffectRoot(() =>
       createSurfaceState({
         model: () => model,
-        coordFlipped: () => {
-          coordFlippedCalls++;
-          return false;
-        },
         root: () => null,
         toolProp: () => {
           toolPropCalls++;
@@ -168,13 +163,14 @@ describe("createSurfaceState construction", () => {
       }),
     );
 
-    // Public accessors only (+ flush) — brushing is private.
+    // Public accessors only — brushing is private. Sibling controllers must
+    // not be touched at construction (before flush). Tool-sync / window
+    // effects may read toolProp/availableTools/surfaceInteractive after flush.
     expect(state.reducer).toBeDefined();
     expect(state.activeTool).toBeTypeOf("string");
     expect(state.surfaceDescription).toBeTypeOf("string");
     expect(state.brushRect).toBeNull();
     expect(state.areaAwaitingSecond).toBe(false);
-    flushSync();
 
     expect(inspectionCalls).toBe(0);
     expect(intervalCalls).toBe(0);
@@ -188,8 +184,19 @@ describe("createSurfaceState construction", () => {
     expect(availableToolsCalls).toBe(0);
     expect(toolPropCalls).toBe(0);
     expect(tooltipHoveredCalls).toBe(0);
-    expect(coordFlippedCalls).toBe(0);
     expect(surfaceInteractiveCalls).toBe(0);
+
+    flushSync();
+    // Sibling controller getters stay cold after tool-sync flush.
+    expect(inspectionCalls).toBe(0);
+    expect(intervalCalls).toBe(0);
+    expect(zoomCalls).toBe(0);
+    expect(emitSelectionCalls).toBe(0);
+    expect(semanticKeyCalls).toBe(0);
+    expect(candidateSemanticKeysCalls).toBe(0);
+    expect(togglePointKeysCalls).toBe(0);
+    expect(pointSelectEnabledCalls).toBe(0);
+    expect(tooltipHoveredCalls).toBe(0);
 
     destroy();
   });
@@ -237,7 +244,6 @@ describe("createSurfaceState construction", () => {
     const { value: state, destroy } = withEffectRoot(() =>
       createSurfaceState({
         model: () => model,
-        coordFlipped: () => false,
         root: () => null,
         toolProp: () => {
           /* uncontrolled */

--- a/packages/svelte/tests/surface/surface-state.harness.ts
+++ b/packages/svelte/tests/surface/surface-state.harness.ts
@@ -3,8 +3,7 @@
  * Factories own deriveds + effects — instantiate under `$effect.root` and destroy.
  *
  * Production phased order:
- *   zoom → inspection → surface → interval → registerSurfaceEffects
- *   → registerInspectionEffects
+ *   zoom → inspection → surface → interval (effects register inside factories)
  *
  * Frame pump: each suite file that imports this module gets a module-scoped
  * rAF patch and afterEach discard (Vitest loads this per test file isolate).
@@ -283,7 +282,6 @@ export function mountSurfaceComposite(
       zoomConfig: () => config.zoom,
       assembled: () => options.spec ?? continuousSpec(),
       model: () => model,
-      coordFlipped: () => false,
       onzoom: () => {
         /* no callback */
       },
@@ -308,12 +306,6 @@ export function mountSurfaceComposite(
       plotId: () => "plot-test",
       tooltipHovered: () => false,
       clearTooltipHovered: () => {},
-      clearBrush: () => {
-        surface.clearBrush();
-      },
-      chooseTool: (next) => {
-        surface.chooseTool(next);
-      },
       oninspect: () => {
         /* no callback */
       },
@@ -329,7 +321,6 @@ export function mountSurfaceComposite(
     // 3. surface (owns reducer). Global rAF is the deferred suite pump.
     surface = createSurfaceState({
       model: () => model,
-      coordFlipped: () => false,
       root: () => root,
       toolProp: () => toolPropBox.value,
       initialTool: () => config.initialTool,
@@ -375,7 +366,6 @@ export function mountSurfaceComposite(
       commitZoom: (domains, source) => {
         zoom.commitZoom(domains, source);
       },
-      coordFlipped: () => false,
       captureSurface: () => capture,
       candidateSemanticKeys: identityCandidateKeys,
       consumptionCandidates: () => {
@@ -411,10 +401,6 @@ export function mountSurfaceComposite(
     });
 
     // 5. surface effects then 6. inspection effects (host 810 vs 954)
-    if (options.registerEffects !== false) {
-      surface.registerSurfaceEffects();
-      inspection.registerInspectionEffects();
-    }
 
     return { surface, inspection, interval, zoom };
   });

--- a/packages/svelte/tests/zoom/zoom-state.integration.test.ts
+++ b/packages/svelte/tests/zoom/zoom-state.integration.test.ts
@@ -67,7 +67,6 @@ describe("runtime + zoom real cycle", () => {
         },
         onrender: runtimeDeps.onrender,
       });
-      runtime.registerModelEffects();
       return { runtime, zoom };
     });
 


### PR DESCRIPTION
## Summary

Closes #627 with a real deletion of cyclic interaction wiring (not the #632 port proxy).

- **Transition owner:** `applyInspectionDismissSideEffects` applies multi-module dismiss plan tails (`clearBrush` / `returnToInspect`). Inspection no longer takes surface sibling deps.
- **Construction reorder:** selection + interval before surface so emit/toggle/finishBrush are not deferred sibling getters for the non-cycle edges.
- **Phased effects deleted** from surface, inspection, runtime, semantic-keys, and legend-filter (effects register at construction; filter takes `catalogEntries` getter).
- **Irreducible exception:** legend focus keeps `installHostDerivedEffects()` after host `$derived` entry lists exist (host-held data, not a sibling-controller cycle).
- **Contracts:** source-order construction/effect token tests removed; seam tests assert no deferred `clearBrush`/`register*Effects` wiring and presence of the transition owner.

### Deletion test scorecard

| Should delete | Result |
|---|---|
| deferred sibling clearBrush/chooseTool | **Deleted** |
| host-phased register*Effects (surface/inspection/runtime/semantic-keys/filter) | **Deleted** |
| source-order construction/effect contracts | **Deleted** |
| legend focus late install for host-derived entries | Kept as `installHostDerivedEffects` (documented) |

### LOC

`packages/svelte` overall **−40** (496 / 536). Production path net-down after adding a 27-line owner module.

### Claude Opus plan review

Pre-implementation review (GO-WITH-CHANGES): descope owner to surface↔inspection multi-module tails; reorder non-cycles; do not rename register→install for everything; expect net LOC down. Incorporated.

## Test plan

- [x] `tests/interaction/transition-owner.test.ts` — escape/close plan side effects
- [x] `tests/plot-orchestrator-contract.ssr.test.ts` — seam + anti-deferred-wiring
- [x] Updated leaf harnesses / construction guards
- [x] Full browser suite: 2973 passed
- [x] SSR suite: 58 passed