### PR TITLE
fix(release): republish after missing @ggsvelte/spec@0.10.1 tarball

### DIFF
--- a/.changeset/republish-spec-missing-tarball.md
+++ b/.changeset/republish-spec-missing-tarball.md
@@ -1,0 +1,19 @@
+---
+"@ggsvelte/spec": patch
+"@ggsvelte/core": patch
+"@ggsvelte/svelte": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+fix: republish after missing `@ggsvelte/spec@0.10.1` npm tarball
+
+`changeset publish` reported success for `@ggsvelte/spec@0.10.1` and wrote
+registry metadata (including dist integrity/shasum), but the tarball URL
+`https://registry.npmjs.org/@ggsvelte/spec/-/spec-0.10.1.tgz` returns HTTP 404.
+`@ggsvelte/core@0.10.1` and `@ggsvelte/svelte@0.10.1` tarballs are fine.
+Because those packages depend on `@ggsvelte/spec@^0.10.1`, installs of 0.10.1
+fail end-to-end.
+
+No source changes — lockstep fixed-group patch so 0.10.2 re-uploads all three
+package tarballs and consumers can resolve a complete release again.


### PR DESCRIPTION
## Summary
- `@ggsvelte/spec@0.10.1` has npm metadata but the tarball URL 404s; core/svelte 0.10.1 are fine.
- Installs of `@ggsvelte/svelte@0.10.1` fail because they depend on `@ggsvelte/spec@^0.10.1`.
- Empty lockstep patch changeset so changesets cuts **0.10.2** and re-uploads all three packages.

## Test plan
- [ ] Merge → Version Packages PR opens for 0.10.2
- [ ] Merge Version Packages → release workflow publishes
- [ ] `curl -sI https://registry.npmjs.org/@ggsvelte/spec/-/spec-0.10.2.tgz` → 200
- [ ] `bun add @ggsvelte/svelte@0.10.2` succeeds in a clean dir