### PR TITLE
fix: finish semantic viewport encapsulation for zoom + bounds edit

### DIFF
--- a/.changeset/finish-semantic-viewport.md
+++ b/.changeset/finish-semantic-viewport.md
@@ -1,0 +1,17 @@
+---
+"@ggsvelte/core": patch
+"@ggsvelte/svelte": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+fix: finish semantic viewport encapsulation for zoom + bounds edit
+
+Add `normalizedSpan` and `axisEditModel` on the model-owned semantic
+viewport so zoom degeneracy guards and interval bounds editing no longer
+reconstruct pixel normalization, axis reversal, or band slicing from raw
+`PositionScale` details.
+
+Migration: none for plot authors. Interaction callers that previously
+read `model.scales` for bounds-edit math should use
+`viewport.panel(id).axisEditModel(axis)` and `panel.normalizedSpan(rect)`.

--- a/apps/docs/src/lib/generated/routes.ts
+++ b/apps/docs/src/lib/generated/routes.ts
@@ -2108,8 +2108,8 @@ export const DOCS_ROUTES = [
         level: 2,
       },
       {
-        id: "experimental-268",
-        title: "experimental (268)",
+        id: "experimental-270",
+        title: "experimental (270)",
         level: 3,
       },
       {

--- a/apps/docs/src/lib/generated/search-index.ts
+++ b/apps/docs/src/lib/generated/search-index.ts
@@ -3482,14 +3482,14 @@ export const DOCS_SEARCH_INDEX = [
     exact: ["@ggsvelte/core"],
   },
   {
-    id: "heading:guide-lifecycle:experimental-268",
+    id: "heading:guide-lifecycle:experimental-270",
     kind: "heading",
-    title: "experimental (268)",
+    title: "experimental (270)",
     summary:
-      "experimental (268) in Lifecycle & editions. API stability tags per export, and the defaults-edition mechanism.",
-    href: "/guide/lifecycle#experimental-268",
+      "experimental (270) in Lifecycle & editions. API stability tags per export, and the defaults-edition mechanism.",
+    href: "/guide/lifecycle#experimental-270",
     keywords: ["Lifecycle & editions", "Reference"],
-    exact: ["experimental (268)"],
+    exact: ["experimental (270)"],
   },
   {
     id: "heading:guide-lifecycle:stable-intent-2",
@@ -9100,6 +9100,15 @@ export const DOCS_SEARCH_INDEX = [
     exact: ["AesMapping"],
   },
   {
+    id: "api:ggsvelte-core:AxisEditModel",
+    kind: "api",
+    title: "AxisEditModel",
+    summary: "@ggsvelte/core · type · experimental.",
+    href: "/guide/lifecycle#ggsvelte-core",
+    keywords: ["@ggsvelte/core", ".", "type", "experimental"],
+    exact: ["AxisEditModel"],
+  },
+  {
     id: "api:ggsvelte-core:AxisGuidePlan",
     kind: "api",
     title: "AxisGuidePlan",
@@ -9908,6 +9917,15 @@ export const DOCS_SEARCH_INDEX = [
     href: "/guide/lifecycle#ggsvelte-core",
     keywords: ["@ggsvelte/core", ".", "type", "experimental"],
     exact: ["NamedData"],
+  },
+  {
+    id: "api:ggsvelte-core:NormalizedSpan",
+    kind: "api",
+    title: "NormalizedSpan",
+    summary: "@ggsvelte/core · type · experimental.",
+    href: "/guide/lifecycle#ggsvelte-core",
+    keywords: ["@ggsvelte/core", ".", "type", "experimental"],
+    exact: ["NormalizedSpan"],
   },
   {
     id: "api:ggsvelte-core:NumberFormatter",

--- a/lifecycle.json
+++ b/lifecycle.json
@@ -2099,6 +2099,10 @@
           "kind": "type",
           "lifecycle": "experimental"
         },
+        "AxisEditModel": {
+          "kind": "type",
+          "lifecycle": "experimental"
+        },
         "AxisGuidePlan": {
           "kind": "type",
           "lifecycle": "experimental"
@@ -2456,6 +2460,10 @@
           "lifecycle": "experimental"
         },
         "NamedData": {
+          "kind": "type",
+          "lifecycle": "experimental"
+        },
+        "NormalizedSpan": {
           "kind": "type",
           "lifecycle": "experimental"
         },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -113,6 +113,8 @@ export type { CoordAxisProjector, PanelCoordProjector } from "./coord-projector.
 
 // Model-owned plot-pixel ↔ semantic projection
 export type {
+  AxisEditModel,
+  NormalizedSpan,
   PlotRect,
   SemanticViewportAxisSelection,
   SemanticViewport,

--- a/packages/core/src/semantic-viewport.ts
+++ b/packages/core/src/semantic-viewport.ts
@@ -173,10 +173,13 @@ function axisEditModelForScale(scale: PositionScale): AxisEditModel {
       slice(bounds) {
         const first = scale.indexOf(bounds[0]);
         const last = scale.indexOf(bounds[1]);
-        if (first === undefined || last === undefined) return undefined;
-        const lower = Math.min(first, last);
-        const upper = Math.max(first, last);
-        return scale.rawDomain.slice(lower, upper + 1) as readonly CellValue[];
+        let values: readonly CellValue[] | undefined;
+        if (first !== undefined && last !== undefined) {
+          const lower = Math.min(first, last);
+          const upper = Math.max(first, last);
+          values = scale.rawDomain.slice(lower, upper + 1) as readonly CellValue[];
+        }
+        return values;
       },
     };
   }

--- a/packages/core/src/semantic-viewport.ts
+++ b/packages/core/src/semantic-viewport.ts
@@ -2,6 +2,7 @@
  * Model-owned panel projection from plot pixels into semantic axis values.
  */
 import type { PositionScale } from "./scales/train.js";
+import type { PositionTransformName } from "./scales/transform.js";
 import type { ScenePanel } from "./scene.js";
 import type { PanelCoordProjector } from "./coord-projector.js";
 import type { CellValue } from "./table.js";
@@ -29,9 +30,33 @@ export interface SemanticViewportSelection {
   readonly y?: SemanticViewportAxisSelection;
 }
 
+export interface NormalizedSpan {
+  readonly x: number;
+  readonly y: number;
+}
+
+export type AxisEditModel =
+  | {
+      readonly kind: "continuous";
+      readonly type: "linear" | "time";
+      readonly transform: PositionTransformName;
+      readonly domain: readonly [number, number];
+      readonly reversed: boolean;
+    }
+  | {
+      readonly kind: "band";
+      readonly rawDomain: readonly CellValue[];
+      readonly reversed: boolean;
+      slice(bounds: readonly [unknown, unknown]): readonly CellValue[] | undefined;
+    };
+
 export interface SemanticViewportPanel {
   readonly id: string;
   readonly bounds: PlotRect;
+  /** Pre-flip screen-normalized axis widths of `rect` within panel bounds. */
+  normalizedSpan(rect: PlotRect): NormalizedSpan;
+  /** Per-axis edit surface for bounds editors (domain, reversal, band slicing). */
+  axisEditModel(axis: "x" | "y"): AxisEditModel;
   invert(rect: PlotRect): SemanticViewportDomains;
   project(selection: SemanticViewportSelection): PlotRect;
   resolve(selection: SemanticViewportSelection): SemanticViewportDomains;
@@ -138,6 +163,32 @@ function projectedSpan(
   ];
 }
 
+function axisEditModelForScale(scale: PositionScale): AxisEditModel {
+  if (scale.type === "band") {
+    const reversed = scale.rawDomain.length > 1 && (scale.normalize(scale.rawDomain[0]) ?? 0) > 0.5;
+    return {
+      kind: "band",
+      rawDomain: scale.rawDomain as readonly CellValue[],
+      reversed,
+      slice(bounds) {
+        const first = scale.indexOf(bounds[0]);
+        const last = scale.indexOf(bounds[1]);
+        if (first === undefined || last === undefined) return undefined;
+        const lower = Math.min(first, last);
+        const upper = Math.max(first, last);
+        return scale.rawDomain.slice(lower, upper + 1) as readonly CellValue[];
+      },
+    };
+  }
+  return {
+    kind: "continuous",
+    type: scale.type,
+    transform: scale.transform,
+    domain: scale.domain,
+    reversed: scale.normalize(scale.domain[0]) > scale.normalize(scale.domain[1]),
+  };
+}
+
 function createPanel(
   panel: ScenePanel,
   scales: Readonly<{ x: PositionScale; y: PositionScale }>,
@@ -154,6 +205,16 @@ function createPanel(
       y0: panel.y,
       x1: panel.x + panel.width,
       y1: panel.y + panel.height,
+    },
+    normalizedSpan(rect) {
+      const th0 = clamp((rect.x0 - panel.x) / panel.width);
+      const th1 = clamp((rect.x1 - panel.x) / panel.width);
+      const tv0 = clamp(1 - (rect.y1 - panel.y) / panel.height);
+      const tv1 = clamp(1 - (rect.y0 - panel.y) / panel.height);
+      return { x: th1 - th0, y: tv1 - tv0 };
+    },
+    axisEditModel(axis) {
+      return axisEditModelForScale(scales[axis]);
     },
     invert(rect) {
       const screenX0 = clamp((rect.x0 - panel.x) / panel.width);

--- a/packages/core/tests/semantic-viewport.test.ts
+++ b/packages/core/tests/semantic-viewport.test.ts
@@ -270,4 +270,101 @@ describe("RenderModel semantic viewport", () => {
       }).x,
     ).toEqual([1, true]);
   });
+
+  it("reports raw screen-normalized spans for a plot-pixel rect", () => {
+    const model = runPipeline(
+      gg(
+        [
+          { x: 0, y: 0 },
+          { x: 10, y: 10 },
+        ],
+        aes({ x: "x", y: "y" }),
+      )
+        .geomPoint()
+        .scales({
+          x: { domain: [0, 10], nice: false, expand: { mult: 0, add: 0 } },
+          y: { domain: [0, 10], nice: false, expand: { mult: 0, add: 0 } },
+        })
+        .spec(),
+      { width: 400, height: 300 },
+    );
+    const scenePanel = model.scene.panels[0]!;
+    const panel = model.viewport.panel(scenePanel.id)!;
+    const span = panel.normalizedSpan({
+      x0: scenePanel.x + scenePanel.width * 0.25,
+      y0: scenePanel.y + scenePanel.height * 0.25,
+      x1: scenePanel.x + scenePanel.width * 0.75,
+      y1: scenePanel.y + scenePanel.height * 0.75,
+    });
+
+    expect(span.x).toBeCloseTo(0.5, 10);
+    expect(span.y).toBeCloseTo(0.5, 10);
+  });
+
+  it("exposes a continuous axis edit model with domain and reversal", () => {
+    const model = runPipeline(
+      gg(
+        [
+          { x: 0, y: 0 },
+          { x: 10, y: 10 },
+        ],
+        aes({ x: "x", y: "y" }),
+      )
+        .geomPoint()
+        .scales({
+          x: { domain: [0, 10], nice: false, expand: { mult: 0, add: 0 } },
+          y: { domain: [0, 10], nice: false, expand: { mult: 0, add: 0 }, reverse: true },
+        })
+        .spec(),
+      { width: 400, height: 300 },
+    );
+    const scenePanel = model.scene.panels[0]!;
+    const panel = model.viewport.panel(scenePanel.id)!;
+    const x = panel.axisEditModel("x");
+    const y = panel.axisEditModel("y");
+
+    expect(x).toEqual({
+      kind: "continuous",
+      type: "linear",
+      transform: "identity",
+      domain: [0, 10],
+      reversed: false,
+    });
+    expect(y.kind).toBe("continuous");
+    if (y.kind === "continuous") {
+      expect(y.type).toBe("linear");
+      expect(y.transform).toBe("identity");
+      expect(y.domain[0]).toBeCloseTo(0, 10);
+      expect(y.domain[1]).toBeCloseTo(10, 10);
+      expect(y.reversed).toBe(true);
+    }
+  });
+
+  it("slices inclusive band categories between edit endpoints", () => {
+    const model = runPipeline(
+      gg(
+        [
+          { category: "a", y: 1 },
+          { category: "b", y: 2 },
+          { category: "c", y: 3 },
+          { category: "d", y: 4 },
+        ],
+        aes({ x: "category", y: "y" }),
+      )
+        .geomPoint()
+        .spec(),
+      { width: 400, height: 300 },
+    );
+    const scenePanel = model.scene.panels[0]!;
+    const panel = model.viewport.panel(scenePanel.id)!;
+    const x = panel.axisEditModel("x");
+
+    expect(x.kind).toBe("band");
+    if (x.kind === "band") {
+      expect(x.rawDomain).toEqual(["a", "b", "c", "d"]);
+      expect(x.slice(["b", "c"])).toEqual(["b", "c"]);
+      expect(x.slice(["c", "a"])).toEqual(["a", "b", "c"]);
+      expect(x.slice(["b", "missing"])).toBeUndefined();
+    }
+  });
 });

--- a/packages/svelte/src/lib/interval/interval-state.svelte.ts
+++ b/packages/svelte/src/lib/interval/interval-state.svelte.ts
@@ -273,24 +273,24 @@ export function createIntervalState(deps: IntervalStateDeps): IntervalState {
     if (boundsEditor === null || deps.model() === null) return null;
     const model = deps.model()!;
     if (boundsEditor.action === "zoom") {
-      const scale = model.scales[boundsEditor.axis];
-      if (scale.type === "band") return null;
+      const viewportPanel = model.viewport.panels[0];
+      if (viewportPanel === undefined) return null;
+      const scale = viewportPanel.axisEditModel(boundsEditor.axis);
+      if (scale.kind === "band") return null;
       const bounds = deps.effectiveZoomDomains()?.[boundsEditor.axis] ?? scale.domain;
       return boundsEditorInputForScale({
         axis: boundsEditor.axis,
         action: "zoom",
         scale,
         bounds,
-        reversed: scale.normalize(scale.domain[0]) > scale.normalize(scale.domain[1]),
       });
     }
     const record = currentIntervalRecord;
     const targetPanelId = record?.panelId ?? boundsEditor.panelId;
     if (targetPanelId === undefined) return null;
-    const panelIndex = model.scene.panels.findIndex((panel) => panel.id === targetPanelId);
-    if (panelIndex < 0) return null;
-    const scale =
-      model.scales.panels[panelIndex]?.[boundsEditor.axis] ?? model.scales[boundsEditor.axis];
+    const viewportPanel = model.viewport.panel(targetPanelId);
+    if (viewportPanel === null) return null;
+    const scale = viewportPanel.axisEditModel(boundsEditor.axis);
     const semantic = record?.domains[boundsEditor.axis];
     const bounds =
       semantic?.kind === "band"
@@ -301,9 +301,6 @@ export function createIntervalState(deps: IntervalStateDeps): IntervalState {
       action: "select",
       scale,
       ...(bounds !== undefined && { bounds }),
-      reversed:
-        scale.type !== "band" &&
-        scale.normalize(scale.domain[0]) > scale.normalize(scale.domain[1]),
     });
   });
 
@@ -376,24 +373,20 @@ export function createIntervalState(deps: IntervalStateDeps): IntervalState {
   }
 
   function semanticAxis(
-    panelIndex: number,
+    panelId: string,
     axis: "x" | "y",
     bounds: readonly [unknown, unknown] | undefined,
   ): SemanticIntervalAxis | undefined {
     if (bounds === undefined || deps.model() === null) return undefined;
-    const model = deps.model()!;
-    const scale = model.scales.panels[panelIndex]?.[axis] ?? model.scales[axis];
-    if (scale.type === "band") {
-      const first = scale.indexOf(bounds[0]);
-      const last = scale.indexOf(bounds[1]);
-      if (first === undefined || last === undefined) return undefined;
-      const lower = Math.min(first, last);
-      const upper = Math.max(first, last);
+    const viewportPanel = deps.model()!.viewport.panel(panelId);
+    if (viewportPanel === null) return undefined;
+    const scale = viewportPanel.axisEditModel(axis);
+    if (scale.kind === "band") {
+      const values = scale.slice(bounds);
+      if (values === undefined) return undefined;
       return Object.freeze({
         kind: "band",
-        values: Object.freeze(
-          scale.rawDomain.slice(lower, upper + 1).map((value) => encodeKey(value)),
-        ),
+        values: Object.freeze(values.map((value) => encodeKey(value))),
       });
     }
     return semanticAxisFromBounds(scale.type, scale.transform, [
@@ -432,10 +425,9 @@ export function createIntervalState(deps: IntervalStateDeps): IntervalState {
     const targetPanelId = event.panelId;
     if (targetPanelId === null || deps.model() === null) return;
     const model = deps.model()!;
-    const panelIndex = model.scene.panels.findIndex((panel) => panel.id === targetPanelId);
-    if (panelIndex < 0) return;
-    const x = semanticAxis(panelIndex, "x", event.domain.x);
-    const y = semanticAxis(panelIndex, "y", event.domain.y);
+    if (model.viewport.panel(targetPanelId) === null) return;
+    const x = semanticAxis(targetPanelId, "x", event.domain.x);
+    const y = semanticAxis(targetPanelId, "y", event.domain.y);
     // An empty facet panel trains no band domain, so no semantic axis
     // survives the selection mode. The controller rejects axis-less
     // intervals (TypeError) — treat the brush as an empty selection.
@@ -513,9 +505,8 @@ export function createIntervalState(deps: IntervalStateDeps): IntervalState {
     const targetPanelId = prior?.panelId ?? boundsEditor?.panelId;
     if (targetPanelId === null || targetPanelId === undefined || deps.model() === null) return;
     const model = deps.model()!;
-    const panelIndex = model.scene.panels.findIndex((candidate) => candidate.id === targetPanelId);
-    if (panelIndex < 0) return;
-    const axis = semanticAxis(panelIndex, event.axis, event.bounds);
+    if (model.viewport.panel(targetPanelId) === null) return;
+    const axis = semanticAxis(targetPanelId, event.axis, event.bounds);
     if (axis === undefined) return;
     const domains = Object.freeze({
       ...prior?.domains,

--- a/packages/svelte/src/lib/interval/precise-bounds.ts
+++ b/packages/svelte/src/lib/interval/precise-bounds.ts
@@ -31,7 +31,7 @@ export function boundsEditorInputForScale(
     // collisions so the two <select> options stay distinguishable.
     const labels = disambiguatedLabels(scale.rawDomain);
     const categories = scale.rawDomain.map((value, index) => ({
-      value: value as BoundsCategoryValue,
+      value,
       label: labels[index] ?? String(value),
     }));
     const requested = options.bounds;

--- a/packages/svelte/src/lib/interval/precise-bounds.ts
+++ b/packages/svelte/src/lib/interval/precise-bounds.ts
@@ -1,7 +1,7 @@
 import {
   disambiguatedLabels,
   encodeKey,
-  type PositionScale,
+  type AxisEditModel,
   type PositionTransformName,
 } from "@ggsvelte/core";
 
@@ -17,7 +17,7 @@ import type { SemanticIntervalAxis } from "../interaction/interaction.js";
 export interface BoundsEditorInputForScaleOptions {
   readonly axis: BoundsAxis;
   readonly action: BoundsAction;
-  readonly scale: PositionScale;
+  readonly scale: AxisEditModel;
   readonly bounds?: readonly [number, number] | readonly [BoundsCategoryValue, BoundsCategoryValue];
   readonly reversed?: boolean;
 }
@@ -26,7 +26,7 @@ export function boundsEditorInputForScale(
   options: BoundsEditorInputForScaleOptions,
 ): BoundsEditorInput | null {
   const { scale } = options;
-  if (scale.type === "band") {
+  if (scale.kind === "band") {
     // Typed categories can share a presentation label (1 and "1"); qualify
     // collisions so the two <select> options stay distinguishable.
     const labels = disambiguatedLabels(scale.rawDomain);
@@ -60,7 +60,7 @@ export function boundsEditorInputForScale(
       scale: "band",
       bounds,
       categories,
-      reversed: options.reversed ?? false,
+      reversed: options.reversed ?? scale.reversed,
     };
   }
   const requested = (options.bounds as readonly [number, number] | undefined) ?? scale.domain;
@@ -74,7 +74,7 @@ export function boundsEditorInputForScale(
       action: options.action,
       scale: "time",
       bounds,
-      reversed: options.reversed ?? false,
+      reversed: options.reversed ?? scale.reversed,
     };
   }
   return {
@@ -83,7 +83,7 @@ export function boundsEditorInputForScale(
     scale: "linear",
     transform: scale.transform,
     bounds,
-    reversed: options.reversed ?? false,
+    reversed: options.reversed ?? scale.reversed,
   };
 }
 

--- a/packages/svelte/src/lib/zoom/zoom.ts
+++ b/packages/svelte/src/lib/zoom/zoom.ts
@@ -249,14 +249,9 @@ export function resolveBrushZoomDomains(
   mode: ZoomMode,
   current: ContinuousZoomDomains | null,
 ): ContinuousZoomDomains | null {
-  const width = panel.bounds.x1 - panel.bounds.x0;
-  const height = panel.bounds.y1 - panel.bounds.y0;
-  const th0 = Math.max(0, Math.min(1, (rect.x0 - panel.bounds.x0) / width));
-  const th1 = Math.max(0, Math.min(1, (rect.x1 - panel.bounds.x0) / width));
-  const tv0 = Math.max(0, Math.min(1, 1 - (rect.y1 - panel.bounds.y0) / height));
-  const tv1 = Math.max(0, Math.min(1, 1 - (rect.y0 - panel.bounds.y0) / height));
+  const span = panel.normalizedSpan(rect);
   // Guard uses raw screen fractions, not flip-remapped domains.
-  if (th1 - th0 <= 0 && tv1 - tv0 <= 0) return null;
+  if (span.x <= 0 && span.y <= 0) return null;
   const inverted = panel.invert(rect);
   const next: ContinuousZoomDomains = { ...current };
   if (

--- a/packages/svelte/tests/interval/precise-bounds.test.ts
+++ b/packages/svelte/tests/interval/precise-bounds.test.ts
@@ -1,7 +1,7 @@
 import { fromPartial } from "@total-typescript/shoehorn";
 import { describe, expect, it } from "vitest";
 
-import { trainBand, type PositionScale } from "@ggsvelte/core";
+import { trainBand, type AxisEditModel, type CellValue } from "@ggsvelte/core";
 
 import {
   boundsEditorInputForScale,
@@ -11,6 +11,25 @@ import {
   consumeIntervalKeys,
   recomputePanelIntervalKeys,
 } from "../../src/lib/interval/consumption.js";
+
+function continuousEdit(
+  type: "linear" | "time",
+  transform: "identity" | "log10" | "sqrt",
+  domain: readonly [number, number] = [1, 100],
+): AxisEditModel {
+  return { kind: "continuous", type, transform, domain, reversed: false };
+}
+
+function bandEdit(rawDomain: readonly CellValue[]): AxisEditModel {
+  return {
+    kind: "band",
+    rawDomain,
+    reversed: false,
+    slice() {
+      return undefined;
+    },
+  };
+}
 
 describe("precise plot bounds adapters", () => {
   it.each([
@@ -24,7 +43,7 @@ describe("precise plot bounds adapters", () => {
       const input = boundsEditorInputForScale({
         axis: "x",
         action: "select",
-        scale: fromPartial<PositionScale>({ type, transform, domain: [1, 100] }),
+        scale: continuousEdit(type, transform),
         bounds: [90, 10],
         reversed: true,
       });
@@ -43,11 +62,10 @@ describe("precise plot bounds adapters", () => {
     const input = boundsEditorInputForScale({
       axis: "y",
       action: "select",
-      scale: fromPartial<PositionScale>({
-        type: "band",
-        domain: ["north", "south"],
+      scale: fromPartial<AxisEditModel>({
+        kind: "band",
         rawDomain: ["north", "south"],
-        step: 0.5,
+        reversed: false,
       }),
     });
     expect(input).toMatchObject({
@@ -61,7 +79,7 @@ describe("precise plot bounds adapters", () => {
   });
 
   it("returns null for band bounds missing from the current scale", () => {
-    const scale = trainBand([["north", "south"]]);
+    const scale = bandEdit(trainBand([["north", "south"]]).rawDomain as readonly CellValue[]);
     // A stored endpoint whose category disappeared (data update, linked plot
     // with a different catalog) must not silently map to the first option.
     expect(
@@ -84,7 +102,9 @@ describe("precise plot bounds adapters", () => {
 
   it("round-trips typed band categories through precise and cross-panel selection", () => {
     const date = new Date("2025-01-02T00:00:00.000Z");
-    const scale = trainBand([[1, "1", true, false, null, date]]);
+    const scale = bandEdit(
+      trainBand([[1, "1", true, false, null, date]]).rawDomain as readonly CellValue[],
+    );
     const input = boundsEditorInputForScale({
       axis: "x",
       action: "select",

--- a/packages/svelte/tests/interval/precise-bounds.test.ts
+++ b/packages/svelte/tests/interval/precise-bounds.test.ts
@@ -21,14 +21,11 @@ function continuousEdit(
 }
 
 function bandEdit(rawDomain: readonly CellValue[]): AxisEditModel {
-  return {
+  return fromPartial<AxisEditModel>({
     kind: "band",
     rawDomain,
     reversed: false,
-    slice() {
-      return undefined;
-    },
-  };
+  });
 }
 
 describe("precise plot bounds adapters", () => {

--- a/packages/svelte/tests/zoom/zoom.test.ts
+++ b/packages/svelte/tests/zoom/zoom.test.ts
@@ -39,6 +39,14 @@ const viewportPanel = (domains: {
     id: "panel",
     bounds: { x0: 0, y0: 0, x1: 100, y1: 100 },
     invert: () => domains,
+    normalizedSpan: (rect) => {
+      const clamp = (value: number) => Math.max(0, Math.min(1, value));
+      const th0 = clamp(rect.x0 / 100);
+      const th1 = clamp(rect.x1 / 100);
+      const tv0 = clamp(1 - rect.y1 / 100);
+      const tv1 = clamp(1 - rect.y0 / 100);
+      return { x: th1 - th0, y: tv1 - tv0 };
+    },
   });
 
 describe("filterZoomDomainsByMode", () => {

--- a/packages/svelte/tests/zoom/zoom.test.ts
+++ b/packages/svelte/tests/zoom/zoom.test.ts
@@ -2,7 +2,7 @@ import { fromAny, fromPartial } from "@total-typescript/shoehorn";
 import { describe, expect, it } from "vitest";
 
 import type { PortableSpec } from "@ggsvelte/spec";
-import type { CellValue, SemanticViewport, SemanticViewportPanel } from "@ggsvelte/core";
+import type { CellValue, PlotRect, SemanticViewport, SemanticViewportPanel } from "@ggsvelte/core";
 
 import {
   applyZoomToSpec,
@@ -39,7 +39,7 @@ const viewportPanel = (domains: {
     id: "panel",
     bounds: { x0: 0, y0: 0, x1: 100, y1: 100 },
     invert: () => domains,
-    normalizedSpan: (rect) => {
+    normalizedSpan: (rect: PlotRect) => {
       const clamp = (value: number) => Math.max(0, Math.min(1, value));
       const th0 = clamp(rect.x0 / 100);
       const th1 = clamp(rect.x1 / 100);


### PR DESCRIPTION
## Summary
- Add `SemanticViewportPanel.normalizedSpan` and `axisEditModel` so pixel normalization, axis reversal, and band slicing live in the model-owned semantic viewport.
- Route zoom degeneracy guards and interval bounds-editor / `semanticAxis` through those APIs; stop reading raw `model.scales` for this math.
- Cover the new viewport behaviors with core tests; keep svelte zoom/interval suites green.

## Test plan
- [x] `bun test packages/core/tests/semantic-viewport.test.ts`
- [x] `bun run check` (core/spec rebuild)
- [x] `bun run check:svelte`
- [x] svelte vitest: zoom + precise-bounds + interval-state bounds/construction (chromium)
- [ ] CI green on the PR

Made with [Cursor](https://cursor.com)