### PR TITLE
refactor(core): narrow LayerFrame into core + per-geom payloads

### DIFF
--- a/.changeset/narrow-layerframe-payloads.md
+++ b/.changeset/narrow-layerframe-payloads.md
@@ -1,0 +1,10 @@
+---
+"@ggsvelte/core": patch
+---
+
+# Narrow LayerFrame into core + per-geom payloads
+
+Nest bin/dodge/smooth/box behind optional payloads so geometry modules own
+their extras, and introduce FinalizedLayerFrame so post-assembly candidate
+construction reads non-null lineage at the type level instead of a runtime
+null throw on every call.

--- a/packages/core/src/pipeline/build-candidates.ts
+++ b/packages/core/src/pipeline/build-candidates.ts
@@ -16,7 +16,12 @@ import { createLazyIdentityIndex } from "./candidate-construction/identity-index
 import type { FacetPanelDef } from "./facets.js";
 import { candidateAutoMode } from "./frame-candidates-auto-mode.js";
 import { deriveLayerGroups } from "./frame-helpers.js";
-import type { LayerBinding, LayerFrame, MappedField, ResolvedColorScale } from "./types.js";
+import type {
+  FinalizedLayerFrame,
+  LayerBinding,
+  MappedField,
+  ResolvedColorScale,
+} from "./types.js";
 
 function createRawCandidateDatumResolver(
   bindings: readonly LayerBinding[],
@@ -99,7 +104,7 @@ function buildIdentityIndexedCandidates(input: {
   runId: number;
   flip: boolean;
   bindings: readonly LayerBinding[];
-  panelFrames: readonly (readonly LayerFrame[])[];
+  panelFrames: readonly (readonly FinalizedLayerFrame[])[];
   facetPanels: readonly FacetPanelDef[];
   table: ColumnTable;
   layerFields: readonly MappedField[][];
@@ -149,7 +154,7 @@ export function buildPipelineCandidates(input: {
   runId: number;
   flip: boolean;
   bindings: readonly LayerBinding[];
-  panelFrames: readonly (readonly LayerFrame[])[];
+  panelFrames: readonly (readonly FinalizedLayerFrame[])[];
   facetPanels: readonly FacetPanelDef[];
   table: ColumnTable;
   layerFields: readonly MappedField[][];

--- a/packages/core/src/pipeline/candidate-construction/datum-types.ts
+++ b/packages/core/src/pipeline/candidate-construction/datum-types.ts
@@ -5,14 +5,19 @@
 import type { LineageStore } from "../../identity.js";
 import type { CellValue, ColumnTable } from "../../table.js";
 import type { FacetPanelDef } from "../facets.js";
-import type { LayerBinding, LayerFrame, MappedField, ResolvedColorScale } from "../types.js";
+import type {
+  FinalizedLayerFrame,
+  LayerBinding,
+  MappedField,
+  ResolvedColorScale,
+} from "../types.js";
 import type { Scene } from "../../scene.js";
 import type { CandidateIdentityIndex } from "./identity-index.js";
 
 export interface IdentityCandidateResolveContext {
   scene: Scene;
   bindings: readonly LayerBinding[];
-  panelFrames: readonly (readonly LayerFrame[])[];
+  panelFrames: readonly (readonly FinalizedLayerFrame[])[];
   facetPanels: readonly FacetPanelDef[];
   table: ColumnTable;
   layerFields: readonly MappedField[][];
@@ -25,7 +30,7 @@ export interface IdentityCandidateResolveContext {
 /** Intermediate locate result before series/logical/lineage assembly. */
 export interface LocatedIdentityCandidate {
   sourceRow: number | null;
-  frame: LayerFrame | undefined;
+  frame: FinalizedLayerFrame | undefined;
   outlierSourceRow: number | null;
   frameRow: number;
   derivedGroup: number;

--- a/packages/core/src/pipeline/candidate-construction/datum.ts
+++ b/packages/core/src/pipeline/candidate-construction/datum.ts
@@ -9,7 +9,13 @@ import type { LineageStore } from "../../identity.js";
 import type { Scene } from "../../scene.js";
 import type { CellValue, ColumnTable } from "../../table.js";
 import type { FacetPanelDef } from "../facets.js";
-import type { LayerBinding, LayerFrame, MappedField, ResolvedColorScale } from "../types.js";
+import type {
+  FinalizedLayerFrame,
+  LayerBinding,
+  LayerFrame,
+  MappedField,
+  ResolvedColorScale,
+} from "../types.js";
 import { candidateAutoMode } from "../frame-candidates-auto-mode.js";
 import { resolveCandidateLogicalValues } from "./datum-values.js";
 import { locateIdentityCandidate } from "./datum-locate.js";
@@ -242,7 +248,7 @@ function resolveIdentityCandidateDatum(
 export function createIdentityCandidateDatumResolver(input: {
   scene: Scene;
   bindings: readonly LayerBinding[];
-  panelFrames: readonly (readonly LayerFrame[])[];
+  panelFrames: readonly (readonly FinalizedLayerFrame[])[];
   facetPanels: readonly FacetPanelDef[];
   table: ColumnTable;
   layerFields: readonly MappedField[][];

--- a/packages/core/src/pipeline/candidate-construction/identity-buckets.ts
+++ b/packages/core/src/pipeline/candidate-construction/identity-buckets.ts
@@ -5,7 +5,7 @@ import { ColumnTable } from "../../table.js";
 import { assignBinId } from "../binned-scale.js";
 import { shouldAggregateOnSemanticTemporalX } from "../frame-stats-shared.js";
 import { positionColumn, xConversionOf } from "../temporal-position.js";
-import type { LayerBinding, LayerFrame } from "../types.js";
+import type { FinalizedLayerFrame, LayerBinding } from "../types.js";
 import { globalSourceRowForInputRow } from "../source-row-lineage.js";
 
 /** Key used for count/summary/boxplot group×x lineage buckets (matches frame xValues). */
@@ -15,7 +15,7 @@ export function aggregateLineageXKey(
   localRow: number,
   binding: LayerBinding,
 ): string {
-  // Only count aggregates on bin ids (frame.xBinId). Summary/boxplot still
+  // Only count aggregates on bin ids (frame.bin.xId). Summary/boxplot still
   // aggregate on actual x values even when a binned scale is attached.
   if (binding.xBinning !== undefined && (binding.layer.stat ?? "identity") === "count") {
     const transformed = positionColumn(table, field, xConversionOf(binding), binding.xTransform);
@@ -75,7 +75,7 @@ interface BinEdge {
  * collected once per group and shared across that group's frame rows (O(n+k)).
  */
 export function buildBinLineageBuckets(input: {
-  frame: LayerFrame;
+  frame: FinalizedLayerFrame;
   panelIndex: number;
   layerIndex: number;
   sourceRowsByGroupBin: Map<string, number[]>;

--- a/packages/core/src/pipeline/candidate-construction/identity-index.ts
+++ b/packages/core/src/pipeline/candidate-construction/identity-index.ts
@@ -1,6 +1,6 @@
 import type { FacetPanelDef } from "../facets.js";
 import { positionColumn, xConversionOf, yConversionOf } from "../temporal-position.js";
-import type { LayerFrame } from "../types.js";
+import type { FinalizedLayerFrame } from "../types.js";
 import { NO_ROW } from "../types.js";
 import {
   aggregateLineageXKey,
@@ -37,7 +37,7 @@ export interface CandidateIdentityIndex {
 }
 
 export function buildCandidateIdentityIndex(
-  panelFrames: readonly (readonly LayerFrame[])[],
+  panelFrames: readonly (readonly FinalizedLayerFrame[])[],
   _facetPanels: readonly FacetPanelDef[],
 ): CandidateIdentityIndex {
   const seriesByRow = new Map<string, number>();
@@ -143,7 +143,7 @@ export function buildCandidateIdentityIndex(
 }
 
 export function createLazyIdentityIndex(
-  panelFrames: readonly (readonly LayerFrame[])[],
+  panelFrames: readonly (readonly FinalizedLayerFrame[])[],
   facetPanels: readonly FacetPanelDef[],
 ): () => CandidateIdentityIndex {
   let identityIndex: CandidateIdentityIndex | null = null;

--- a/packages/core/src/pipeline/candidate-construction/represented-rows.ts
+++ b/packages/core/src/pipeline/candidate-construction/represented-rows.ts
@@ -116,11 +116,11 @@ export function filterRepresentedSourceRows(input: {
   // Indexed group×x: buckets are the final represented membership (count: all
   // rows; summary/boxplot: finite-y only). Return the frozen array as-is so
   // LineageStore can WeakMap-intern once — no clone, no per-mark y re-filter.
-  // Binned counts key by integer bin id (frame.xBinId), not inverse centers.
+  // Binned counts key by integer bin id (frame.bin.xId), not inverse centers.
   if (needsX && indexKeyPrefix !== null && input.sourceRowsByGroupX !== undefined) {
     const xKey =
-      frame.binding.xBinning !== undefined && frame.xBinId !== null
-        ? bandKey(frame.xBinId[frameRow]!)
+      frame.binding.xBinning !== undefined && frame.bin?.xId != null
+        ? bandKey(frame.bin.xId[frameRow]!)
         : bandKey(outputX);
     const indexed = input.sourceRowsByGroupX.get(`${indexKeyPrefix}:${xKey}`);
     if (indexed !== undefined) return indexed;

--- a/packages/core/src/pipeline/candidate-construction/represented-rows.ts
+++ b/packages/core/src/pipeline/candidate-construction/represented-rows.ts
@@ -118,7 +118,8 @@ export function filterRepresentedSourceRows(input: {
   // LineageStore can WeakMap-intern once — no clone, no per-mark y re-filter.
   // Binned counts key by integer bin id (frame.bin.xId), not inverse centers.
   if (needsX && indexKeyPrefix !== null && input.sourceRowsByGroupX !== undefined) {
-    const xBinId = frame.bin === null ? null : frame.bin.xId;
+    const bin = frame.bin;
+    const xBinId = bin === undefined || bin === null ? null : bin.xId;
     const xKey =
       frame.binding.xBinning !== undefined && xBinId !== null
         ? bandKey(xBinId[frameRow]!)

--- a/packages/core/src/pipeline/candidate-construction/represented-rows.ts
+++ b/packages/core/src/pipeline/candidate-construction/represented-rows.ts
@@ -118,9 +118,10 @@ export function filterRepresentedSourceRows(input: {
   // LineageStore can WeakMap-intern once — no clone, no per-mark y re-filter.
   // Binned counts key by integer bin id (frame.bin.xId), not inverse centers.
   if (needsX && indexKeyPrefix !== null && input.sourceRowsByGroupX !== undefined) {
+    const xBinId = frame.bin === null ? null : frame.bin.xId;
     const xKey =
-      frame.binding.xBinning !== undefined && frame.bin?.xId != null
-        ? bandKey(frame.bin.xId[frameRow]!)
+      frame.binding.xBinning !== undefined && xBinId !== null
+        ? bandKey(xBinId[frameRow]!)
         : bandKey(outputX);
     const indexed = input.sourceRowsByGroupX.get(`${indexKeyPrefix}:${xKey}`);
     if (indexed !== undefined) return indexed;

--- a/packages/core/src/pipeline/frame-helpers.ts
+++ b/packages/core/src/pipeline/frame-helpers.ts
@@ -12,8 +12,10 @@ export { carriedColumns, deriveLayerGroups } from "./frame-group-columns.js";
 /** Fresh all-null frame extras (each stat branch fills what it uses). */
 export function emptyFrameExtras(): Pick<
   LayerFrame,
-  | "xBinId"
-  | "yBinId"
+  | "bin"
+  | "dodge"
+  | "box"
+  | "smooth"
   | "ymin"
   | "ymax"
   | "xmin"
@@ -22,18 +24,16 @@ export function emptyFrameExtras(): Pick<
   | "yend"
   | "xendValues"
   | "yendValues"
-  | "dodgeSlot"
-  | "dodgeSlotCounts"
   | "offsetX"
   | "offsetY"
-  | "box"
-  | "smoothBand"
   | "xIntercepts"
   | "yIntercepts"
 > {
   return {
-    xBinId: null,
-    yBinId: null,
+    bin: null,
+    dodge: null,
+    box: null,
+    smooth: null,
     ymin: null,
     ymax: null,
     xmin: null,
@@ -42,12 +42,8 @@ export function emptyFrameExtras(): Pick<
     yend: null,
     xendValues: null,
     yendValues: null,
-    dodgeSlot: null,
-    dodgeSlotCounts: null,
     offsetX: null,
     offsetY: null,
-    box: null,
-    smoothBand: false,
     xIntercepts: [],
     yIntercepts: [],
   };

--- a/packages/core/src/pipeline/frame-identity.ts
+++ b/packages/core/src/pipeline/frame-identity.ts
@@ -83,14 +83,29 @@ export function buildIdentityFrame(
     linetypeValues: binding.linetype.field === null ? null : table.column(binding.linetype.field),
     labelValues: binding.labelField === null ? null : table.column(binding.labelField),
     ...emptyFrameExtras(),
-    xBinId:
-      binding.xField === null
-        ? null
-        : binIdOf(table, binding.xField, binding.xConversion, binding.xTransform, binding.xBinning),
-    yBinId:
-      binding.yField === null
-        ? null
-        : binIdOf(table, binding.yField, binding.yConversion, binding.yTransform, binding.yBinning),
+    bin: (() => {
+      const xId =
+        binding.xField === null
+          ? null
+          : binIdOf(
+              table,
+              binding.xField,
+              binding.xConversion,
+              binding.xTransform,
+              binding.xBinning,
+            );
+      const yId =
+        binding.yField === null
+          ? null
+          : binIdOf(
+              table,
+              binding.yField,
+              binding.yConversion,
+              binding.yTransform,
+              binding.yBinning,
+            );
+      return xId === null && yId === null ? null : { xId, yId };
+    })(),
     ymin:
       binding.yminField === null
         ? null

--- a/packages/core/src/pipeline/frame-stats-count.ts
+++ b/packages/core/src/pipeline/frame-stats-count.ts
@@ -115,6 +115,7 @@ export function buildCountFrame(
     ...styleColumns(binding, col, { count: result.count }),
     labelValues: col(binding.labelField),
     ...emptyFrameExtras(),
-    xBinId: binned === null ? null : Int32Array.from(result.x, (id) => id as number),
+    bin:
+      binned === null ? null : { xId: Int32Array.from(result.x, (id) => id as number), yId: null },
   };
 }

--- a/packages/core/src/pipeline/frame-stats-smooth-frame.ts
+++ b/packages/core/src/pipeline/frame-stats-smooth-frame.ts
@@ -52,6 +52,6 @@ export function packSmoothLayerFrame(
     ...emptyFrameExtras(),
     ymin: result.ymin,
     ymax: result.ymax,
-    smoothBand: result.hasBand,
+    smooth: { band: result.hasBand },
   };
 }

--- a/packages/core/src/pipeline/geometry-boxplot-body-row.ts
+++ b/packages/core/src/pipeline/geometry-boxplot-body-row.ts
@@ -39,10 +39,10 @@ export function layoutBoxplotBodyRow(input: {
   }
   let center = tc;
   let w = widthFrac;
-  if (frame.dodgeSlot !== null && frame.dodgeSlotCounts !== null) {
-    const slotCount = Math.max(1, frame.dodgeSlotCounts[row]!);
+  if (frame.dodge !== null) {
+    const slotCount = Math.max(1, frame.dodge.slotCounts[row]!);
     w = widthFrac / slotCount;
-    center = tc + widthFrac * ((frame.dodgeSlot[row]! + 0.5) / slotCount - 0.5);
+    center = tc + widthFrac * ((frame.dodge.slot[row]! + 0.5) / slotCount - 0.5);
   }
   const cx = center * fx.innerWidth;
   const half = (w / 2) * fx.innerWidth;

--- a/packages/core/src/pipeline/geometry-rects-slot.ts
+++ b/packages/core/src/pipeline/geometry-rects-slot.ts
@@ -51,7 +51,8 @@ export function resolveRectSlot(input: {
         const boundaries = frame.binding.xBinning;
         const transformedCenter = frame.xNumeric?.[row];
         if (boundaries === undefined || transformedCenter === undefined) return null;
-        const xBinId = frame.bin === null ? null : frame.bin.xId;
+        const bin = frame.bin;
+        const xBinId = bin === undefined || bin === null ? null : bin.xId;
         const index =
           xBinId === null
             ? boundaries.centers.findIndex((value) => Object.is(value, transformedCenter))

--- a/packages/core/src/pipeline/geometry-rects-slot.ts
+++ b/packages/core/src/pipeline/geometry-rects-slot.ts
@@ -51,10 +51,11 @@ export function resolveRectSlot(input: {
         const boundaries = frame.binding.xBinning;
         const transformedCenter = frame.xNumeric?.[row];
         if (boundaries === undefined || transformedCenter === undefined) return null;
+        const xBinId = frame.bin === null ? null : frame.bin.xId;
         const index =
-          frame.bin?.xId == null
+          xBinId === null
             ? boundaries.centers.findIndex((value) => Object.is(value, transformedCenter))
-            : frame.bin.xId[row]!;
+            : xBinId[row]!;
         if (index < 0) return null;
         sourceLeft = boundaries.edges[index]!;
         sourceRight = boundaries.edges[index + 1]!;

--- a/packages/core/src/pipeline/geometry-rects-slot.ts
+++ b/packages/core/src/pipeline/geometry-rects-slot.ts
@@ -28,11 +28,11 @@ export function resolveRectSlot(input: {
     }
     center = tc;
     w = widthFrac;
-    if (frame.dodgeSlot !== null && frame.dodgeSlotCounts !== null) {
-      const slotCount = Math.max(1, frame.dodgeSlotCounts[row]!);
+    if (frame.dodge !== null) {
+      const slotCount = Math.max(1, frame.dodge.slotCounts[row]!);
       const full = w;
       w = full / slotCount;
-      center += full * ((frame.dodgeSlot[row]! + 0.5) / slotCount - 0.5);
+      center += full * ((frame.dodge.slot[row]! + 0.5) / slotCount - 0.5);
     }
   } else {
     let sourceLeft: number;
@@ -46,15 +46,15 @@ export function resolveRectSlot(input: {
         // A binned position scale snaps identity/count rows to a transformed
         // center. Recover edges via the stable integer bin id (built once at
         // frame construction) — Θ(1) per row, not centers.findIndex (Θ(B)).
-        // xBinId is the discrete source of truth for stack/dodge/count too;
+        // bin.xId is the discrete source of truth for stack/dodge/count too;
         // float-center Object.is is only a defensive fallback when ids are absent.
         const boundaries = frame.binding.xBinning;
         const transformedCenter = frame.xNumeric?.[row];
         if (boundaries === undefined || transformedCenter === undefined) return null;
         const index =
-          frame.xBinId === null
+          frame.bin?.xId == null
             ? boundaries.centers.findIndex((value) => Object.is(value, transformedCenter))
-            : frame.xBinId[row]!;
+            : frame.bin.xId[row]!;
         if (index < 0) return null;
         sourceLeft = boundaries.edges[index]!;
         sourceRight = boundaries.edges[index + 1]!;
@@ -74,9 +74,9 @@ export function resolveRectSlot(input: {
       sourceRight = transformedCenter + half;
     }
     // Dodge in scale space, then project both final edges independently.
-    if (frame.dodgeSlot !== null && frame.dodgeSlotCounts !== null) {
-      const slotCount = Math.max(1, frame.dodgeSlotCounts[row]!);
-      const slot = frame.dodgeSlot[row]!;
+    if (frame.dodge !== null) {
+      const slotCount = Math.max(1, frame.dodge.slotCounts[row]!);
+      const slot = frame.dodge.slot[row]!;
       const full = sourceRight - sourceLeft;
       sourceRight = sourceLeft + (full * (slot + 1)) / slotCount;
       sourceLeft += (full * slot) / slotCount;

--- a/packages/core/src/pipeline/geometry-smooth-ribbon.ts
+++ b/packages/core/src/pipeline/geometry-smooth-ribbon.ts
@@ -19,7 +19,7 @@ export function buildSmoothRibbonBatch(input: {
 }): GeometryBatch | null {
   const { frame, fx, color, fill, groupRows, styles } = input;
   const { binding } = frame;
-  if (!frame.smoothBand || frame.ymin === null || frame.ymax === null) return null;
+  if (!frame.smooth?.band || frame.ymin === null || frame.ymax === null) return null;
 
   const bandRows = groupRows
     .map((rows) =>

--- a/packages/core/src/pipeline/geometry-smooth-ribbon.ts
+++ b/packages/core/src/pipeline/geometry-smooth-ribbon.ts
@@ -19,7 +19,13 @@ export function buildSmoothRibbonBatch(input: {
 }): GeometryBatch | null {
   const { frame, fx, color, fill, groupRows, styles } = input;
   const { binding } = frame;
-  if (frame.smooth === null || !frame.smooth.band || frame.ymin === null || frame.ymax === null) {
+  if (
+    frame.smooth === undefined ||
+    frame.smooth === null ||
+    !frame.smooth.band ||
+    frame.ymin === null ||
+    frame.ymax === null
+  ) {
     return null;
   }
 

--- a/packages/core/src/pipeline/geometry-smooth-ribbon.ts
+++ b/packages/core/src/pipeline/geometry-smooth-ribbon.ts
@@ -19,7 +19,9 @@ export function buildSmoothRibbonBatch(input: {
 }): GeometryBatch | null {
   const { frame, fx, color, fill, groupRows, styles } = input;
   const { binding } = frame;
-  if (!frame.smooth?.band || frame.ymin === null || frame.ymax === null) return null;
+  if (frame.smooth === null || !frame.smooth.band || frame.ymin === null || frame.ymax === null) {
+    return null;
+  }
 
   const bandRows = groupRows
     .map((rows) =>

--- a/packages/core/src/pipeline/position-bar.ts
+++ b/packages/core/src/pipeline/position-bar.ts
@@ -16,8 +16,9 @@ export function barSlotKeys(frame: LayerFrame): (number | string)[] | null {
   // A binned position scale groups by the stable integer bin id, NOT the
   // rendered float center: raw source values inside one bin stack/dodge
   // together with no float-equality fragility and no id leak into geometry.
-  if (frame.binding?.xBinning !== undefined && frame.bin?.xId != null) {
-    return Array.from(frame.bin.xId);
+  const xBinId = frame.bin === null ? null : frame.bin.xId;
+  if (frame.binding?.xBinning !== undefined && xBinId !== null) {
+    return Array.from(xBinId);
   }
   if (frame.xValues !== null) return frame.xValues.map((v) => encodeKey(v));
   if (frame.xNumeric !== null) return Array.from(frame.xNumeric);

--- a/packages/core/src/pipeline/position-bar.ts
+++ b/packages/core/src/pipeline/position-bar.ts
@@ -16,8 +16,8 @@ export function barSlotKeys(frame: LayerFrame): (number | string)[] | null {
   // A binned position scale groups by the stable integer bin id, NOT the
   // rendered float center: raw source values inside one bin stack/dodge
   // together with no float-equality fragility and no id leak into geometry.
-  if (frame.binding?.xBinning !== undefined && frame.xBinId !== null) {
-    return Array.from(frame.xBinId);
+  if (frame.binding?.xBinning !== undefined && frame.bin?.xId != null) {
+    return Array.from(frame.bin.xId);
   }
   if (frame.xValues !== null) return frame.xValues.map((v) => encodeKey(v));
   if (frame.xNumeric !== null) return Array.from(frame.xNumeric);
@@ -55,8 +55,7 @@ export function applyBarLikePosition(frame: LayerFrame): boolean {
   frame.ymax = ymax;
   if (position === "dodge") {
     const dodge = positionDodge({ slots, groups: frame.groups });
-    frame.dodgeSlot = dodge.slot;
-    frame.dodgeSlotCounts = dodge.slotCount;
+    frame.dodge = { slot: dodge.slot, slotCounts: dodge.slotCount };
   }
   return true;
 }

--- a/packages/core/src/pipeline/position-bar.ts
+++ b/packages/core/src/pipeline/position-bar.ts
@@ -16,7 +16,8 @@ export function barSlotKeys(frame: LayerFrame): (number | string)[] | null {
   // A binned position scale groups by the stable integer bin id, NOT the
   // rendered float center: raw source values inside one bin stack/dodge
   // together with no float-equality fragility and no id leak into geometry.
-  const xBinId = frame.bin === null ? null : frame.bin.xId;
+  const bin = frame.bin;
+  const xBinId = bin === undefined || bin === null ? null : bin.xId;
   if (frame.binding?.xBinning !== undefined && xBinId !== null) {
     return Array.from(xBinId);
   }

--- a/packages/core/src/pipeline/position-boxplot.ts
+++ b/packages/core/src/pipeline/position-boxplot.ts
@@ -16,7 +16,6 @@ export function applyBoxplotPosition(frame: LayerFrame): boolean {
     slots: frame.xValues.map((v) => encodeKey(v)),
     groups: frame.groups,
   });
-  frame.dodgeSlot = dodge.slot;
-  frame.dodgeSlotCounts = dodge.slotCount;
+  frame.dodge = { slot: dodge.slot, slotCounts: dodge.slotCount };
   return true;
 }

--- a/packages/core/src/pipeline/prepare-panels-frames.ts
+++ b/packages/core/src/pipeline/prepare-panels-frames.ts
@@ -338,11 +338,12 @@ export function buildPanelFrames(input: {
       // array (can be huge under facets) when there is no lineage to resolve.
       // Still mark lineage finalized (empty) so panelFrames is FinalizedLayerFrame[].
       let finalized: FinalizedLayerFrame;
-      if (bindings[index]!.ruleForm !== "annotation") {
-        finalized = finalizeFrameSourceRows(frame, slice);
-      } else {
+      if (bindings[index]!.ruleForm === "annotation") {
+        // Rowless — empty lineage map (do not retain huge panel source-row arrays).
         frame.inputSourceRows = [];
         finalized = frame as FinalizedLayerFrame;
+      } else {
+        finalized = finalizeFrameSourceRows(frame, slice);
       }
       assertRibbonBounds(finalized);
       panelFrames[p]!.push(finalized);

--- a/packages/core/src/pipeline/prepare-panels-frames.ts
+++ b/packages/core/src/pipeline/prepare-panels-frames.ts
@@ -172,8 +172,8 @@ function emitTransformDomainWarnings(
 }
 import type {
   Advisory,
+  FinalizedLayerFrame,
   LayerBinding,
-  LayerFrame,
   PipelineWarning,
   ScaleDecision,
   ScaleDiagnostic,
@@ -197,7 +197,8 @@ export function buildPanelFrames(input: {
   conversions: Readonly<{ x: PositionConversionContext; y: PositionConversionContext }>;
 }): {
   bindings: LayerBinding[];
-  panelFrames: LayerFrame[][];
+  /** All frames are lineage-finalized (annotation frames use an empty map). */
+  panelFrames: FinalizedLayerFrame[][];
   scaleDecisions: ScaleDecision[];
   scaleDiagnostics: ScaleDiagnostic[];
   xConversion: PositionConversionContext;
@@ -217,7 +218,7 @@ export function buildPanelFrames(input: {
   } = input;
 
   const bindings: LayerBinding[] = [];
-  const panelFrames: LayerFrame[][] = facetPanels.map(() => []);
+  const panelFrames: FinalizedLayerFrame[][] = facetPanels.map(() => []);
   // Per-layer filtered tables: binned extents, bin ranges, and transform
   // diagnostics must read each layer's own filtered rows (#609).
   const filteredLayerTables = layerContexts.map((ctx) => ctx.filteredTable);
@@ -335,11 +336,16 @@ export function buildPanelFrames(input: {
       applyPosition(frame, advisories, slice.table);
       // Annotation frames are rowless — do not retain the full panel source-row
       // array (can be huge under facets) when there is no lineage to resolve.
+      // Still mark lineage finalized (empty) so panelFrames is FinalizedLayerFrame[].
+      let finalized: FinalizedLayerFrame;
       if (bindings[index]!.ruleForm !== "annotation") {
-        finalizeFrameSourceRows(frame, slice);
+        finalized = finalizeFrameSourceRows(frame, slice);
+      } else {
+        frame.inputSourceRows = [];
+        finalized = frame as FinalizedLayerFrame;
       }
-      assertRibbonBounds(frame);
-      panelFrames[p]!.push(frame);
+      assertRibbonBounds(finalized);
+      panelFrames[p]!.push(finalized);
     }
   }
   warnEmptyLayers(bindings, panelFrames, warnings);

--- a/packages/core/src/pipeline/prepare-panels-types.ts
+++ b/packages/core/src/pipeline/prepare-panels-types.ts
@@ -6,7 +6,7 @@ import type { ColumnTable } from "../table.js";
 import type { FacetPanelDef, FacetStripConfig } from "./facets.js";
 import type { PositionConversionContext } from "./temporal-position.js";
 import type { SourceRegistry } from "./source-registry.js";
-import type { LayerBinding, LayerFrame, ScaleDecision, ScaleDiagnostic } from "./types.js";
+import type { FinalizedLayerFrame, LayerBinding, ScaleDecision, ScaleDiagnostic } from "./types.js";
 
 /** Per-layer bound source + filter remap (#589). */
 export interface LayerDataContext {
@@ -34,7 +34,7 @@ export interface PreparedPanels {
   strip: FacetStripConfig;
   facetPanels: FacetPanelDef[];
   bindings: LayerBinding[];
-  panelFrames: LayerFrame[][];
+  panelFrames: FinalizedLayerFrame[][];
   scaleDecisions: ScaleDecision[];
   scaleDiagnostics: ScaleDiagnostic[];
   xConversion: PositionConversionContext;

--- a/packages/core/src/pipeline/prepare-panels.ts
+++ b/packages/core/src/pipeline/prepare-panels.ts
@@ -21,8 +21,8 @@ import type { LayerDataContext, PreparedPanels } from "./prepare-panels-types.js
 import { SourceRegistry } from "./source-registry.js";
 import type {
   Advisory,
+  FinalizedLayerFrame,
   LayerBinding,
-  LayerFrame,
   PipelineWarning,
   RunOptions,
   ScaleDecision,
@@ -224,7 +224,7 @@ export function preparePanels(
   const facetFields = facetFieldNames(normalized.facet);
 
   let bindings: LayerBinding[] = [];
-  let panelFrames: LayerFrame[][] = facetPanels.map(() => []);
+  let panelFrames: FinalizedLayerFrame[][] = facetPanels.map(() => []);
   let scaleDecisions: ScaleDecision[] = [];
   let scaleDiagnostics: ScaleDiagnostic[] = [];
   let resolvedConversions = conversions;

--- a/packages/core/src/pipeline/source-row-lineage.ts
+++ b/packages/core/src/pipeline/source-row-lineage.ts
@@ -10,8 +10,10 @@
  *
  * After {@link finalizeFrameSourceRows}, downstream modules consume only
  * global ids via {@link globalSourceRowForInputRow} and finalized mark rows.
+ * The return type {@link FinalizedLayerFrame} is the type-level seam that
+ * replaces a null-check throw on every candidate-construction call.
  */
-import type { LayerFrame } from "./types-layer-frame.js";
+import type { FinalizedLayerFrame, LayerFrame } from "./types-layer-frame.js";
 import { NO_ROW } from "./types-no-row.js";
 
 export class SourceRowLineageError extends Error {
@@ -42,27 +44,29 @@ function remapPanelLocalIndicesToGlobal(
 /**
  * Attach finalized global source-row ids to a frame after panel slice.
  * Post-stat mark rows and boxplot outliers are remapped in place.
+ * Returns the same frame narrowed to {@link FinalizedLayerFrame}.
  */
-export function finalizeFrameSourceRows(frame: LayerFrame, map: PanelSourceRowMap): void {
+export function finalizeFrameSourceRows(
+  frame: LayerFrame,
+  map: PanelSourceRowMap,
+): FinalizedLayerFrame {
   frame.inputSourceRows = [...map.globalSourceRows];
   remapPanelLocalIndicesToGlobal(frame.rowIndex, map.globalSourceRows);
   if (frame.box !== null) {
     remapPanelLocalIndicesToGlobal(frame.box.outlierRow, map.globalSourceRows);
   }
+  return frame as FinalizedLayerFrame;
 }
 
 /** Global source-row id for one pre-stat panel-local input row. */
-export function globalSourceRowForInputRow(frame: LayerFrame, panelLocalRow: number): number {
-  const map = frame.inputSourceRows;
-  if (map === null) {
-    throw new SourceRowLineageError(
-      "Frame inputSourceRows is unset; finalize source-row lineage before candidate construction",
-    );
-  }
-  const global = map[panelLocalRow];
+export function globalSourceRowForInputRow(
+  frame: FinalizedLayerFrame,
+  panelLocalRow: number,
+): number {
+  const global = frame.inputSourceRows[panelLocalRow];
   if (global === undefined) {
     throw new SourceRowLineageError(
-      `Panel-local row ${panelLocalRow} is out of range for finalized inputSourceRows (length ${map.length})`,
+      `Panel-local row ${panelLocalRow} is out of range for finalized inputSourceRows (length ${frame.inputSourceRows.length})`,
     );
   }
   return global;

--- a/packages/core/src/pipeline/types-frame.ts
+++ b/packages/core/src/pipeline/types-frame.ts
@@ -9,7 +9,6 @@ export { NO_ROW } from "./types-no-row.js";
 export type { ColorBinding, LayerBinding, RuleForm, StyleBinding } from "./types-binding.js";
 export type {
   BinPayload,
-  BoxFrame,
   BoxPayload,
   DodgePayload,
   FinalizedLayerFrame,

--- a/packages/core/src/pipeline/types-frame.ts
+++ b/packages/core/src/pipeline/types-frame.ts
@@ -7,15 +7,7 @@ import type { ResolvedColorScale } from "./types-public.js";
 
 export { NO_ROW } from "./types-no-row.js";
 export type { ColorBinding, LayerBinding, RuleForm, StyleBinding } from "./types-binding.js";
-export type {
-  BinPayload,
-  BoxPayload,
-  DodgePayload,
-  FinalizedLayerFrame,
-  LayerFrame,
-  LayerFrameCore,
-  SmoothPayload,
-} from "./types-layer-frame.js";
+export type { FinalizedLayerFrame, LayerFrame } from "./types-layer-frame.js";
 
 /** Per-mark color lookup over a resolved scale with distinct NA/unknown fallbacks. */
 export function colorOf(resolved: ResolvedColorScale, value: CellValue): string {

--- a/packages/core/src/pipeline/types-frame.ts
+++ b/packages/core/src/pipeline/types-frame.ts
@@ -7,7 +7,16 @@ import type { ResolvedColorScale } from "./types-public.js";
 
 export { NO_ROW } from "./types-no-row.js";
 export type { ColorBinding, LayerBinding, RuleForm, StyleBinding } from "./types-binding.js";
-export type { LayerFrame } from "./types-layer-frame.js";
+export type {
+  BinPayload,
+  BoxFrame,
+  BoxPayload,
+  DodgePayload,
+  FinalizedLayerFrame,
+  LayerFrame,
+  LayerFrameCore,
+  SmoothPayload,
+} from "./types-layer-frame.js";
 
 /** Per-mark color lookup over a resolved scale with distinct NA/unknown fallbacks. */
 export function colorOf(resolved: ResolvedColorScale, value: CellValue): string {

--- a/packages/core/src/pipeline/types-layer-frame.ts
+++ b/packages/core/src/pipeline/types-layer-frame.ts
@@ -24,9 +24,6 @@ export interface BoxPayload {
   outlierRow: Uint32Array;
 }
 
-/** @deprecated Prefer {@link BoxPayload}. */
-export type BoxFrame = BoxPayload;
-
 /**
  * Discrete bin identity per post-stat row (owned by bin/count + rect slots).
  * −1 = unbinned / out-of-range. Separate from rendered `xNumeric`/`yNumeric`

--- a/packages/core/src/pipeline/types-layer-frame.ts
+++ b/packages/core/src/pipeline/types-layer-frame.ts
@@ -12,7 +12,7 @@ import type { LayerBinding } from "./types-binding.js";
 type StyleValueColumn = readonly CellValue[] | Float64Array;
 
 /** Boxplot-stat extras (owned by boxplot geometry + outlier lineage). */
-export interface BoxPayload {
+interface BoxPayload {
   lower: Float64Array;
   middle: Float64Array;
   upper: Float64Array;
@@ -30,20 +30,20 @@ export interface BoxPayload {
  * centers: this is the discrete identity for count aggregation and stack /
  * fill / dodge grouping. Never serialized into the public model.
  */
-export interface BinPayload {
+interface BinPayload {
   xId: Int32Array | null;
   yId: Int32Array | null;
 }
 
 /** Dodge position slots (owned by bar/boxplot position + rect layout). */
-export interface DodgePayload {
+interface DodgePayload {
   slot: Uint32Array;
   /** Per-row dodge slot count (per-x, ggplot2 preserve="total"). */
   slotCounts: Uint32Array;
 }
 
 /** Smooth-stat ribbon flag (owned by smooth geometry). */
-export interface SmoothPayload {
+interface SmoothPayload {
   /** Layer draws an SE ribbon (ymin/ymax are the band). */
   band: boolean;
 }
@@ -52,7 +52,7 @@ export interface SmoothPayload {
  * Shared fields every stage may read: binding, table, positions, styles,
  * groups, and pre-finalize lineage placeholders.
  */
-export interface LayerFrameCore {
+interface LayerFrameCore {
   binding: LayerBinding;
   /** The (facet-panel) table this frame was computed from. */
   table: ColumnTable;

--- a/packages/core/src/pipeline/types-layer-frame.ts
+++ b/packages/core/src/pipeline/types-layer-frame.ts
@@ -1,5 +1,9 @@
 /**
  * Post-stat LayerFrame: panel-local geometry inputs after bind + stat + position.
+ *
+ * Shape: a narrow shared core (columns · x/y · group · lineage) plus optional
+ * per-geom payloads. Geometry modules own their payload fields; shared stages
+ * and candidate-construction read only the core (and lineage after finalize).
  */
 import type { CellValue, ColumnTable } from "../table.js";
 
@@ -7,7 +11,8 @@ import type { LayerBinding } from "./types-binding.js";
 
 type StyleValueColumn = readonly CellValue[] | Float64Array;
 
-interface BoxFrame {
+/** Boxplot-stat extras (owned by boxplot geometry + outlier lineage). */
+export interface BoxPayload {
   lower: Float64Array;
   middle: Float64Array;
   upper: Float64Array;
@@ -19,7 +24,38 @@ interface BoxFrame {
   outlierRow: Uint32Array;
 }
 
-export interface LayerFrame {
+/** @deprecated Prefer {@link BoxPayload}. */
+export type BoxFrame = BoxPayload;
+
+/**
+ * Discrete bin identity per post-stat row (owned by bin/count + rect slots).
+ * −1 = unbinned / out-of-range. Separate from rendered `xNumeric`/`yNumeric`
+ * centers: this is the discrete identity for count aggregation and stack /
+ * fill / dodge grouping. Never serialized into the public model.
+ */
+export interface BinPayload {
+  xId: Int32Array | null;
+  yId: Int32Array | null;
+}
+
+/** Dodge position slots (owned by bar/boxplot position + rect layout). */
+export interface DodgePayload {
+  slot: Uint32Array;
+  /** Per-row dodge slot count (per-x, ggplot2 preserve="total"). */
+  slotCounts: Uint32Array;
+}
+
+/** Smooth-stat ribbon flag (owned by smooth geometry). */
+export interface SmoothPayload {
+  /** Layer draws an SE ribbon (ymin/ymax are the band). */
+  band: boolean;
+}
+
+/**
+ * Shared fields every stage may read: binding, table, positions, styles,
+ * groups, and pre-finalize lineage placeholders.
+ */
+export interface LayerFrameCore {
   binding: LayerBinding;
   /** The (facet-panel) table this frame was computed from. */
   table: ColumnTable;
@@ -29,14 +65,6 @@ export interface LayerFrame {
   xNumeric: Float64Array | null;
   yValues: readonly CellValue[] | null;
   yNumeric: Float64Array | null;
-  /**
-   * type: "binned" only — the stable integer bin id per post-stat row (−1 =
-   * unbinned/out-of-range). Separate from the rendered `xNumeric`/`yNumeric`
-   * transformed centers: this is the discrete identity for count aggregation
-   * and stack/fill/dodge grouping. Never serialized into the public model.
-   */
-  xBinId: Int32Array | null;
-  yBinId: Int32Array | null;
   groups: readonly number[];
   /**
    * Pre-stat group id per input table row (canonical first-seen order).
@@ -44,12 +72,6 @@ export interface LayerFrame {
    * Length is always `table.rowCount` (empty for annotation frames with no rows).
    */
   inputGroups: readonly number[];
-  /**
-   * Global source-row id per pre-stat input table row (multi-table SourceRegistry
-   * ids after filter/facet remap). Length is `table.rowCount`. Set by
-   * {@link finalizeFrameSourceRows} during panel assembly (#626).
-   */
-  inputSourceRows: number[] | null;
   /** Source row per post-stat row (NO_ROW for synthesized rows). */
   rowIndex: Uint32Array;
   colorValues: readonly CellValue[] | null;
@@ -74,17 +96,43 @@ export interface LayerFrame {
   xendValues: readonly CellValue[] | null;
   /** Raw segment end y values (discrete evidence); null when unused. */
   yendValues: readonly CellValue[] | null;
-  dodgeSlot: Uint32Array | null;
-  /** Per-row dodge slot count (per-x, ggplot2 preserve="total"). */
-  dodgeSlotCounts: Uint32Array | null;
   /** Jitter/nudge offsets (data units / band-step fractions). */
   offsetX: Float64Array | null;
   offsetY: Float64Array | null;
-  /** Boxplot-stat extras. */
-  box: BoxFrame | null;
-  /** Smooth-stat: the layer draws a se ribbon (ymin/ymax are the band). */
-  smoothBand: boolean;
   /** Annotation-rule intercepts (data units). */
   xIntercepts: CellValue[];
   yIntercepts: CellValue[];
 }
+
+/**
+ * Full post-stat frame: core + per-geom payloads + lineage channel.
+ *
+ * `inputSourceRows` starts null at frame construction and is filled by
+ * {@link finalizeFrameSourceRows}. Downstream candidate construction should
+ * take {@link FinalizedLayerFrame} so the null is not re-checked at every call.
+ */
+export interface LayerFrame extends LayerFrameCore {
+  /**
+   * Global source-row id per pre-stat input table row (multi-table SourceRegistry
+   * ids after filter/facet remap). Length is `table.rowCount`. Set by
+   * {@link finalizeFrameSourceRows} during panel assembly (#626).
+   */
+  inputSourceRows: number[] | null;
+  /** Discrete bin ids — only bin/count/rect consumers read this. */
+  bin: BinPayload | null;
+  /** Dodge slots — only bar/boxplot position + layout consumers read this. */
+  dodge: DodgePayload | null;
+  /** Boxplot hinges/outliers — only boxplot geometry + outlier lineage. */
+  box: BoxPayload | null;
+  /** Smooth SE band flag — only smooth ribbon geometry. */
+  smooth: SmoothPayload | null;
+}
+
+/**
+ * Frame after {@link finalizeFrameSourceRows}: lineage is present.
+ * Candidate-construction and other post-assembly readers use this type so the
+ * type system replaces the pre-finalize runtime throw at the call site.
+ */
+export type FinalizedLayerFrame = Omit<LayerFrame, "inputSourceRows"> & {
+  inputSourceRows: number[];
+};

--- a/packages/core/src/pipeline/types.ts
+++ b/packages/core/src/pipeline/types.ts
@@ -22,7 +22,6 @@ export { CANVAS_AUTO_THRESHOLD, PipelineError } from "./types-public.js";
 
 export type {
   BinPayload,
-  BoxFrame,
   BoxPayload,
   ColorBinding,
   DodgePayload,

--- a/packages/core/src/pipeline/types.ts
+++ b/packages/core/src/pipeline/types.ts
@@ -21,10 +21,17 @@ export type {
 export { CANVAS_AUTO_THRESHOLD, PipelineError } from "./types-public.js";
 
 export type {
+  BinPayload,
+  BoxFrame,
+  BoxPayload,
   ColorBinding,
+  DodgePayload,
+  FinalizedLayerFrame,
   LayerBinding,
   LayerFrame,
+  LayerFrameCore,
   RuleForm,
+  SmoothPayload,
   StyleBinding,
 } from "./types-frame.js";
 export { NO_ROW, colorOf } from "./types-frame.js";

--- a/packages/core/src/pipeline/types.ts
+++ b/packages/core/src/pipeline/types.ts
@@ -21,16 +21,11 @@ export type {
 export { CANVAS_AUTO_THRESHOLD, PipelineError } from "./types-public.js";
 
 export type {
-  BinPayload,
-  BoxPayload,
   ColorBinding,
-  DodgePayload,
   FinalizedLayerFrame,
   LayerBinding,
   LayerFrame,
-  LayerFrameCore,
   RuleForm,
-  SmoothPayload,
   StyleBinding,
 } from "./types-frame.js";
 export { NO_ROW, colorOf } from "./types-frame.js";

--- a/packages/core/tests/geometry-rects-slot-binned.test.ts
+++ b/packages/core/tests/geometry-rects-slot-binned.test.ts
@@ -1,5 +1,5 @@
 /**
- * Binned identity/count rect slots: recover edges via stable `xBinId`, not
+ * Binned identity/count rect slots: recover edges via stable `bin.xId`, not
  * O(R·B) `centers.findIndex` scans.
  */
 import { fromAny, fromPartial } from "@total-typescript/shoehorn";
@@ -33,10 +33,10 @@ function identityFx(): Frame {
   });
 }
 
-describe("resolveRectSlot — binned identity prefers xBinId over centers.findIndex", () => {
+describe("resolveRectSlot — binned identity prefers bin.xId over centers.findIndex", () => {
   it("uses integer bin id when it disagrees with Object.is center scan", () => {
     // Centers [5, 15] for edges [0,10,20]. Row 0's xNumeric equals center 0,
-    // but xBinId claims bin 1 — integer id is the discrete source of truth.
+    // but bin.xId claims bin 1 — integer id is the discrete source of truth.
     const frame = fromAny<LayerFrame>({
       n: 1,
       binding: {
@@ -47,13 +47,12 @@ describe("resolveRectSlot — binned identity prefers xBinId over centers.findIn
         },
       },
       xNumeric: Float64Array.of(5),
-      xBinId: Int32Array.of(1),
+      bin: { xId: Int32Array.of(1), yId: null },
       ymin: Float64Array.of(0),
       ymax: Float64Array.of(1),
       xmin: null,
       xmax: null,
-      dodgeSlot: null,
-      dodgeSlotCounts: null,
+      dodge: null,
     });
     const slot = resolveRectSlot({
       frame,
@@ -68,7 +67,7 @@ describe("resolveRectSlot — binned identity prefers xBinId over centers.findIn
     expect(slot!.w).toBeCloseTo(10 / 30, 12);
   });
 
-  it("drops rows with xBinId −1 (out of range)", () => {
+  it("drops rows with bin.xId −1 (out of range)", () => {
     const frame = fromAny<LayerFrame>({
       n: 1,
       binding: {
@@ -79,13 +78,12 @@ describe("resolveRectSlot — binned identity prefers xBinId over centers.findIn
         },
       },
       xNumeric: Float64Array.of(5),
-      xBinId: Int32Array.of(-1),
+      bin: { xId: Int32Array.of(-1), yId: null },
       ymin: Float64Array.of(0),
       ymax: Float64Array.of(1),
       xmin: null,
       xmax: null,
-      dodgeSlot: null,
-      dodgeSlotCounts: null,
+      dodge: null,
     });
     expect(
       resolveRectSlot({

--- a/packages/core/tests/pipeline-position.test.ts
+++ b/packages/core/tests/pipeline-position.test.ts
@@ -90,10 +90,9 @@ describe("applyPosition — stack/fill/dodge on bars", () => {
     );
     const frame = buildFrame(binding, table, [], []);
     applyPosition(frame, [], table);
-    const slots = frame.dodgeSlot;
-    expect(slots).not.toBeNull();
-    expect(frame.dodgeSlotCounts).not.toBeNull();
-    expect(new Set(slots ?? []).size).toBeGreaterThan(1);
+    expect(frame.dodge).not.toBeNull();
+    expect(frame.dodge!.slotCounts).toBeDefined();
+    expect(new Set(frame.dodge!.slot).size).toBeGreaterThan(1);
   });
 });
 

--- a/packages/core/tests/pipeline-scale-training/fixtures.ts
+++ b/packages/core/tests/pipeline-scale-training/fixtures.ts
@@ -17,12 +17,12 @@ export function emptyExtras(): Pick<
   | "yend"
   | "xendValues"
   | "yendValues"
-  | "dodgeSlot"
-  | "dodgeSlotCounts"
+  | "bin"
+  | "dodge"
+  | "box"
+  | "smooth"
   | "offsetX"
   | "offsetY"
-  | "box"
-  | "smoothBand"
   | "xIntercepts"
   | "yIntercepts"
 > {
@@ -35,12 +35,12 @@ export function emptyExtras(): Pick<
     yend: null,
     xendValues: null,
     yendValues: null,
-    dodgeSlot: null,
-    dodgeSlotCounts: null,
+    bin: null,
+    dodge: null,
+    box: null,
+    smooth: null,
     offsetX: null,
     offsetY: null,
-    box: null,
-    smoothBand: false,
     xIntercepts: [],
     yIntercepts: [],
   };

--- a/packages/core/tests/source-row-lineage.test.ts
+++ b/packages/core/tests/source-row-lineage.test.ts
@@ -1,28 +1,29 @@
 /**
  * Source-row lineage: one owned conversion seam (#626).
+ * FinalizedLayerFrame is the post-assembly contract (null lineage is typed out).
  */
 import { describe, expect, it } from "bun:test";
 
-import type { LayerFrame } from "../src/pipeline/types-layer-frame.ts";
+import type { FinalizedLayerFrame, LayerFrame } from "../src/pipeline/types-layer-frame.ts";
 import { NO_ROW } from "../src/pipeline/types-no-row.ts";
 
 describe("globalSourceRowForInputRow", () => {
   it("returns the finalized global id for a panel-local input row", async () => {
     const { globalSourceRowForInputRow } = await import("../src/pipeline/source-row-lineage.ts");
-    const frame = { inputSourceRows: [100, 200, 300] } as LayerFrame;
+    const frame = { inputSourceRows: [100, 200, 300] } as FinalizedLayerFrame;
     expect(globalSourceRowForInputRow(frame, 1)).toBe(200);
   });
 
-  it("throws when inputSourceRows was not finalized", async () => {
+  it("throws when panel-local row is out of range", async () => {
     const { globalSourceRowForInputRow, SourceRowLineageError } =
       await import("../src/pipeline/source-row-lineage.ts");
-    const frame = { inputSourceRows: null } as LayerFrame;
-    expect(() => globalSourceRowForInputRow(frame, 0)).toThrow(SourceRowLineageError);
+    const frame = { inputSourceRows: [100] } as FinalizedLayerFrame;
+    expect(() => globalSourceRowForInputRow(frame, 5)).toThrow(SourceRowLineageError);
   });
 });
 
 describe("finalizeFrameSourceRows", () => {
-  it("sets inputSourceRows and remaps mark rows to global ids", async () => {
+  it("sets inputSourceRows and returns FinalizedLayerFrame", async () => {
     const { finalizeFrameSourceRows } = await import("../src/pipeline/source-row-lineage.ts");
     const rowIndex = new Uint32Array([0, 1, NO_ROW]);
     const outlierRow = new Uint32Array([1]);
@@ -30,10 +31,46 @@ describe("finalizeFrameSourceRows", () => {
       inputSourceRows: null,
       rowIndex,
       box: { outlierRow },
+      bin: null,
+      dodge: null,
+      smooth: null,
     } as LayerFrame;
-    finalizeFrameSourceRows(frame, { globalSourceRows: [10, 20] });
-    expect(frame.inputSourceRows).toEqual([10, 20]);
+    const finalized = finalizeFrameSourceRows(frame, { globalSourceRows: [10, 20] });
+    expect(finalized.inputSourceRows).toEqual([10, 20]);
+    // Same object, narrowed type: lineage is non-null.
+    expect(finalized).toBe(frame);
     expect([...rowIndex]).toEqual([10, 20, NO_ROW]);
     expect([...outlierRow]).toEqual([20]);
+  });
+
+  it("does not require box payload when outliers are absent", async () => {
+    const { finalizeFrameSourceRows } = await import("../src/pipeline/source-row-lineage.ts");
+    const rowIndex = new Uint32Array([0]);
+    const frame = {
+      inputSourceRows: null,
+      rowIndex,
+      box: null,
+      bin: null,
+      dodge: null,
+      smooth: null,
+    } as LayerFrame;
+    const finalized = finalizeFrameSourceRows(frame, { globalSourceRows: [42] });
+    expect(finalized.inputSourceRows).toEqual([42]);
+    expect([...rowIndex]).toEqual([42]);
+  });
+});
+
+describe("LayerFrame payload seam", () => {
+  it("core + payloads are distinct optional slots (empty extras)", async () => {
+    const { emptyFrameExtras } = await import("../src/pipeline/frame-helpers.ts");
+    const extras = emptyFrameExtras();
+    expect(extras.bin).toBeNull();
+    expect(extras.dodge).toBeNull();
+    expect(extras.box).toBeNull();
+    expect(extras.smooth).toBeNull();
+    // Flat geom fields no longer exist on the shared extras bag.
+    expect("xBinId" in extras).toBe(false);
+    expect("dodgeSlot" in extras).toBe(false);
+    expect("smoothBand" in extras).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Implements the "Narrow the LayerFrame carrier" architecture card with a PR-sized tradeoff:

**Problem (verified):** The pipeline's central `LayerFrame` was a 37-field bag. Geom-only fields (`box`, `smoothBand`, `dodgeSlot`/`dodgeSlotCounts`, `xBinId`/`yBinId`) leaked into every consumer (~15 geometry modules + candidate-construction). `inputSourceRows: number[] | null` was a cross-stage mutable channel whose ordering was enforced by a runtime throw in `globalSourceRowForInputRow`, not types.

**Tradeoff (what we ship vs full AFTER design):**
- **In:** Nest geom extras as optional payloads (`bin`, `dodge`, `box`, `smooth`) and introduce `LayerFrameCore` + `FinalizedLayerFrame` so post-assembly candidate construction sees non-null lineage at the type level.
- **Out of this PR:** Module-private opacity (TS monorepo cannot enforce "only geom X can import payload X" without package splits), and further nesting of multi-geom fields (`ymin`/`ymax`, segment ends, intercepts, offsets).

**After:**
- Shared core: columns · x/y · group · styles · shared bounds
- Payloads: `bin` · `dodge` · `box` · `smooth` (each null when unused)
- `finalizeFrameSourceRows` returns `FinalizedLayerFrame`; `panelFrames` is `FinalizedLayerFrame[][]`; candidate identity index / datum resolvers take that type
- Annotation frames finalize with an empty lineage map (still rowless, no huge source-row array)

## Test plan

- [x] TDD: `packages/core/tests/source-row-lineage.test.ts` — FinalizedLayerFrame return, out-of-range throw, empty extras payload slots
- [x] Updated geometry/position/candidate tests for `bin` / `dodge` payloads
- [x] `bun test packages/core` — 1265 pass
- [x] `bun run check` (tsc -b packages/spec packages/core + type contracts)
- [ ] CI green on this PR