### PR TITLE
docs: strip detritus, invert chart themes, flatten the gallery

### DIFF
--- a/apps/docs/src/lib/catalog/guide.ts
+++ b/apps/docs/src/lib/catalog/guide.ts
@@ -153,7 +153,7 @@ export const GUIDE_CATALOG = [
   {
     slug: "compatibility",
     title: "Compatibility",
-    description: "Tested Node, Svelte, package-manager, browser, and OS boundaries.",
+    description: "Tested Node, Svelte, browser, and OS versions.",
     section: "Production",
     navigationOrder: 40,
   },

--- a/apps/docs/src/lib/components/DocsShell.svelte
+++ b/apps/docs/src/lib/components/DocsShell.svelte
@@ -51,8 +51,8 @@
   <button
     id="guide-chapters-trigger"
     type="button"
-    aria-label="Open guide chapters"
-    onclick={openChapters}>Chapters</button
+    aria-label="Open docs navigation"
+    onclick={openChapters}>Menu</button
   >
   {#if headings.length > 0}
     <details>
@@ -85,10 +85,10 @@
 >
   <div class="chapter-dialog__panel">
     <div class="chapter-dialog__heading">
-      <span>Guide chapters</span>
+      <span>Docs</span>
       <button
         type="button"
-        aria-label="Close guide chapters"
+        aria-label="Close docs navigation"
         onclick={closeChapters}>Close</button
       >
     </div>

--- a/apps/docs/src/lib/components/GrammarDemo.svelte
+++ b/apps/docs/src/lib/components/GrammarDemo.svelte
@@ -1,30 +1,26 @@
 <script lang="ts">
   import { GeomPoint, GeomSmooth, GGPlot } from "@ggsvelte/svelte";
+
   import { penguins } from "$examples/point/scatter-color/data";
+  import { contrastChartTheme } from "$lib/docs-appearance-state.svelte";
 
   const steps = [
     { label: "Data", note: "Rows as plain objects." },
-    {
-      label: "Mappings",
-      note: "aes for x, y, and color identity.",
-    },
-    {
-      label: "Layers",
-      note: "GeomSmooth on top of GeomPoint.",
-    },
-    {
-      label: "Interaction",
-      note: "inspect after the layers work.",
-    },
+    { label: "Mappings", note: "aes for x, y, and color." },
+    { label: "Layers", note: "GeomSmooth over GeomPoint." },
+    { label: "Interaction", note: "inspect is a prop, not event plumbing." },
   ] as const;
-  let active = $state(0);
+  let active = $state(steps.length - 1);
+  const chartTheme = $derived(contrastChartTheme());
 </script>
 
 <section class="grammar-demo" aria-labelledby="grammar-heading">
   <div class="grammar-copy">
-    <p class="eyebrow">Composition</p>
-    <h2 id="grammar-heading">Data, aes, layers, inspect.</h2>
-    <p>One real chart. Each step adds grammar.</p>
+    <h2 id="grammar-heading">Interaction is declarative.</h2>
+    <p>
+      The grammar you know from ggplot2, plus a step it never had. Mouse over
+      the chart: inspection, pinning, selection, and zoom are spec fields.
+    </p>
     <ol>
       {#each steps as step, index (step.label)}
         <li class:active={active === index}>
@@ -42,9 +38,6 @@
     </ol>
   </div>
   <div class="grammar-output">
-    <div class="grammar-status" aria-live="polite">
-      Step {active + 1}: {steps[active]!.label}
-    </div>
     <GGPlot
       data={penguins}
       aes={{
@@ -53,6 +46,7 @@
         ...(active >= 1 && { color: "species" }),
       }}
       inspect={active >= 3}
+      theme={chartTheme}
       ariaLabel="Penguin mass increases with flipper length, grouped by species"
     >
       <GeomPoint alpha={0.72} />
@@ -78,13 +72,9 @@
     line-height: 0.95;
   }
 
-  .eyebrow {
-    margin: 0;
+  .grammar-copy > p {
+    max-width: 34rem;
     color: var(--muted);
-    font-size: 0.75rem;
-    font-weight: 600;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
   }
 
   ol {
@@ -123,6 +113,10 @@
     font-size: 1.2rem;
   }
 
+  button:hover strong {
+    text-decoration: underline;
+  }
+
   button small {
     opacity: 0;
     transition: opacity 120ms ease;
@@ -130,6 +124,11 @@
 
   li.active button {
     color: var(--ink);
+    box-shadow: inset 2px 0 0 var(--accent);
+  }
+
+  li.active button {
+    padding-left: 0.75rem;
   }
 
   li.active button small {
@@ -138,17 +137,6 @@
 
   .grammar-output {
     min-width: 0;
-    border: 1px solid var(--line);
-    background: #fff;
-  }
-
-  .grammar-status {
-    min-height: 44px;
-    padding: 0.75rem 1rem;
-    border-bottom: 1px solid #d9dee8;
-    color: #172033;
-    font-size: 0.85rem;
-    font-weight: 600;
   }
 
   @media (prefers-reduced-motion: reduce) {

--- a/apps/docs/src/lib/components/UiButton.svelte
+++ b/apps/docs/src/lib/components/UiButton.svelte
@@ -9,6 +9,7 @@
     class: className = "",
     type = "button",
     disabled = false,
+    href,
     onclick,
     children,
   }: {
@@ -16,19 +17,25 @@
     class?: string;
     type?: "button" | "submit" | "reset";
     disabled?: boolean;
+    href?: string;
     onclick?: (event: MouseEvent) => void;
     children: Snippet;
   } = $props();
+
+  const classes = $derived(
+    `ui-button ui-button--${variant}${className !== "" ? ` ${className}` : ""}`,
+  );
 </script>
 
-<Button.Root
-  class={`ui-button ui-button--${variant}${className !== "" ? ` ${className}` : ""}`}
-  {type}
-  {disabled}
-  {onclick}
->
-  {@render children()}
-</Button.Root>
+{#if href !== undefined}
+  <Button.Root class={classes} {href}>
+    {@render children()}
+  </Button.Root>
+{:else}
+  <Button.Root class={classes} {type} {disabled} {onclick}>
+    {@render children()}
+  </Button.Root>
+{/if}
 
 <style>
   :global(.ui-button) {

--- a/apps/docs/src/lib/components/UiButton.svelte
+++ b/apps/docs/src/lib/components/UiButton.svelte
@@ -23,7 +23,7 @@
   } = $props();
 
   const classes = $derived(
-    `ui-button ui-button--${variant}${className !== "" ? ` ${className}` : ""}`,
+    `ui-button ui-button--${variant}${className === "" ? "" : ` ${className}`}`,
   );
 </script>
 

--- a/apps/docs/src/lib/docs-appearance-state.svelte.ts
+++ b/apps/docs/src/lib/docs-appearance-state.svelte.ts
@@ -1,0 +1,24 @@
+/**
+ * Reactive view of the site appearance (data-theme on <html>) for components
+ * that must invert chart themes against the page: a dark chart on the light
+ * site needs no border to read as a plot, and vice versa.
+ */
+import { browser } from "$app/environment";
+
+import { type DocsAppearance, readDocsAppearance, watchDocsAppearance } from "./docs-appearance.js";
+
+export const docsAppearance = $state<{ current: DocsAppearance }>({
+  current: "light",
+});
+
+if (browser) {
+  docsAppearance.current = readDocsAppearance();
+  watchDocsAppearance((appearance) => {
+    docsAppearance.current = appearance;
+  });
+}
+
+/** Chart theme that contrasts with the current site appearance. */
+export function contrastChartTheme(): "light" | "dark" {
+  return docsAppearance.current === "light" ? "dark" : "light";
+}

--- a/apps/docs/src/lib/generated/routes.ts
+++ b/apps/docs/src/lib/generated/routes.ts
@@ -830,7 +830,7 @@ export const DOCS_ROUTES = [
   {
     path: "/guide/compatibility",
     title: "Compatibility — ggsvelte",
-    description: "Tested Node, Svelte, package-manager, browser, and OS boundaries.",
+    description: "Tested Node, Svelte, browser, and OS versions.",
     canonicalPath: "/guide/compatibility",
     kind: "page",
     index: true,
@@ -841,13 +841,7 @@ export const DOCS_ROUTES = [
       label: "Compatibility",
       order: 40,
     },
-    headings: [
-      {
-        id: "supported-consumers",
-        title: "Supported consumers",
-        level: 2,
-      },
-    ],
+    headings: [],
   },
   {
     path: "/guide/interaction-reference",

--- a/apps/docs/src/lib/generated/search-index.ts
+++ b/apps/docs/src/lib/generated/search-index.ts
@@ -1040,20 +1040,10 @@ export const DOCS_SEARCH_INDEX = [
     id: "page:guide-compatibility",
     kind: "page",
     title: "Compatibility",
-    summary: "Tested Node, Svelte, package-manager, browser, and OS boundaries.",
+    summary: "Tested Node, Svelte, browser, and OS versions.",
     href: "/guide/compatibility",
     keywords: ["Production"],
     exact: ["Compatibility"],
-  },
-  {
-    id: "heading:guide-compatibility:supported-consumers",
-    kind: "heading",
-    title: "Supported consumers",
-    summary:
-      "Supported consumers in Compatibility. Tested Node, Svelte, package-manager, browser, and OS boundaries.",
-    href: "/guide/compatibility#supported-consumers",
-    keywords: ["Compatibility", "Production"],
-    exact: ["Supported consumers"],
   },
   {
     id: "page:guide-interaction-reference",

--- a/apps/docs/src/routes/+page.svelte
+++ b/apps/docs/src/routes/+page.svelte
@@ -48,7 +48,10 @@
 
 <section class="home-hero" aria-labelledby="home-heading">
   <div class="hero-claim">
-    <h1 id="home-heading">A grammar of graphics for Svelte.</h1>
+    <h1 id="home-heading">
+      An agent-first implementation of the layered grammar of graphics in Svelte
+      5
+    </h1>
     <p>
       ggplot2's layered grammar and defaults as Svelte components, a TypeScript
       builder, and a validated JSON spec agents can write. Inspection,

--- a/apps/docs/src/routes/+page.svelte
+++ b/apps/docs/src/routes/+page.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
   import { base } from "$app/paths";
+  import { GeomPoint, GGPlot } from "@ggsvelte/svelte";
 
-  import SignaturePlot from "$examples/interaction/tooltip/Example.svelte";
+  import { penguins } from "$examples/point/scatter-color/data";
   import { QUICKSTART_PAGE_SVELTE } from "$scripts/quickstart";
   import CodeTabs from "$lib/CodeTabs.svelte";
   import { FEATURED_EXAMPLES, galleryEntryFor } from "$lib/catalog/gallery";
   import CopyCode from "$lib/components/CopyCode.svelte";
   import GrammarDemo from "$lib/components/GrammarDemo.svelte";
+  import UiButton from "$lib/components/UiButton.svelte";
+  import { contrastChartTheme } from "$lib/docs-appearance-state.svelte";
   import { EXAMPLES } from "$lib/examples";
 
   const install = "npm install @ggsvelte/svelte";
@@ -14,6 +17,7 @@
   const featured = FEATURED_EXAMPLES.map((item) =>
     entries.find((entry) => entry.id === item.id)!,
   );
+  const heroTheme = $derived(contrastChartTheme());
   const tabs = [
     { label: "Svelte", code: QUICKSTART_PAGE_SVELTE, language: "svelte" },
     {
@@ -24,53 +28,71 @@
     {
       label: "Spec (JSON)",
       language: "json",
-      code: `{"data":{"values":[{"weight":1.8,"economy":37}]},"layers":[{"geom":"point","aes":{"x":{"field":"weight"},"y":{"field":"economy"}}}]}`,
+      code: `{
+  "data": {
+    "values": [{ "weight": 1.8, "economy": 37 }]
+  },
+  "layers": [
+    {
+      "geom": "point",
+      "aes": {
+        "x": { "field": "weight" },
+        "y": { "field": "economy" }
+      }
+    }
+  ]
+}`,
     },
   ];
 </script>
 
 <section class="home-hero" aria-labelledby="home-heading">
   <div class="hero-claim">
-    <p class="eyebrow">Open source · Svelte 5</p>
-    <h1 id="home-heading">ggplot2 for Svelte.</h1>
+    <h1 id="home-heading">A grammar of graphics for Svelte.</h1>
     <p>
-      A layered grammar of graphics — aes, geoms, stats, scales, facets, themes
-      — as Svelte components, with PortableSpec JSON at the center. Built for
-      people who already know visualization, and for agents trained on eighteen
-      years of ggplot2.
+      ggplot2's layered grammar and defaults as Svelte components, a TypeScript
+      builder, and a validated JSON spec agents can write. Inspection,
+      selection, and zoom are part of the spec.
     </p>
   </div>
 
   <div class="hero-plot">
-    <div class="specimen-label">
-      <span>Live chart</span>
-      <a href={`${base}/examples/interactions/inspection`}>Example source</a>
-    </div>
-    <SignaturePlot />
+    <GGPlot
+      data={penguins}
+      aes={{ x: "flipper", y: "mass", color: "species" }}
+      inspect={{ mode: "x", pin: true, maxDistance: 24 }}
+      theme={heroTheme}
+      labs={{
+        title: "Penguin body mass by flipper length",
+        x: "Flipper length (mm)",
+        y: "Body mass (g)",
+        color: "Species",
+      }}
+      width="container"
+      height={400}
+      ariaLabel="Penguin mass increases with flipper length, grouped by species"
+    >
+      <GeomPoint size={4} alpha={0.85} />
+    </GGPlot>
   </div>
 
   <div class="hero-actions">
     <CopyCode code={install} language="bash" accessibleLabel="Copy install" />
     <div class="cta-row">
-      <a class="primary-action" href={`${base}/guide/getting-started`}
-        >Getting started</a
+      <UiButton variant="primary" href={`${base}/guide/getting-started`}>
+        Getting started
+      </UiButton>
+      <UiButton href={`${base}/examples`}>Examples</UiButton>
+      <UiButton variant="ghost" href={`${base}/playground`}>Playground</UiButton
       >
-      <a class="secondary-action" href={`${base}/examples`}>Examples</a>
     </div>
-    <p>
-      MIT. No account or hosted service.
-      <a href={`${base}/playground`}>Playground</a>
-    </p>
   </div>
 </section>
 
 <section class="home-featured" aria-labelledby="home-featured-heading">
   <header>
-    <div>
-      <p class="eyebrow">Examples</p>
-      <h2 id="home-featured-heading">Featured</h2>
-    </div>
-    <a href={`${base}/examples`}>All {entries.length}</a>
+    <h2 id="home-featured-heading">Examples</h2>
+    <a href={`${base}/examples`}>Gallery</a>
   </header>
   <ol>
     {#each featured as entry (entry.id)}
@@ -96,11 +118,11 @@
 
 <section class="code-path" aria-labelledby="code-path-heading">
   <div>
-    <p class="eyebrow">Surfaces</p>
     <h2 id="code-path-heading">Svelte, builder, or JSON.</h2>
     <p>
-      Same chart as a complete Svelte component, a TypeScript builder, or
-      PortableSpec JSON for validation, agents, and headless render.
+      Three surfaces, one spec. Svelte components inside an app, the TypeScript
+      builder anywhere else, and PortableSpec JSON — the surface agents write:
+      validated on the way in, rendered to SVG without a DOM.
     </p>
   </div>
   <CodeTabs {tabs} />
@@ -108,14 +130,13 @@
 
 <section class="evidence" aria-labelledby="evidence-heading">
   <header>
-    <p class="eyebrow">Docs</p>
-    <h2 id="evidence-heading">Contracts</h2>
+    <h2 id="evidence-heading">Docs</h2>
   </header>
   <dl>
     <div>
-      <dt>Compatibility</dt>
+      <dt>Getting started</dt>
       <dd>
-        <a href={`${base}/guide/compatibility`}>Node, Svelte, browsers, OS</a>
+        <a href={`${base}/guide/getting-started`}>Install and render a chart</a>
       </dd>
     </div>
     <div>
@@ -131,12 +152,6 @@
       </dd>
     </div>
     <div>
-      <dt>Diagnostics</dt>
-      <dd>
-        <a href={`${base}/guide/errors`}>Validation and pipeline codes</a>
-      </dd>
-    </div>
-    <div>
       <dt>Headless SVG</dt>
       <dd>
         <a href={`${base}/guide/getting-started#headless-and-server-rendering`}
@@ -144,26 +159,10 @@
         >
       </dd>
     </div>
-    <div>
-      <dt>PortableSpec</dt>
-      <dd>
-        <a href={`${base}/schema/v0.json`}>JSON Schema</a>
-      </dd>
-    </div>
   </dl>
 </section>
 
 <style>
-  .eyebrow,
-  .specimen-label span {
-    margin: 0;
-    color: var(--muted);
-    font-size: 0.75rem;
-    font-weight: 600;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-  }
-
   .home-hero {
     display: grid;
     grid-template-areas: "claim plot" "actions plot";
@@ -179,10 +178,10 @@
   }
 
   .hero-claim h1 {
-    max-width: 12ch;
+    max-width: 14ch;
     margin: 0.35rem 0 1.25rem;
-    font-size: clamp(4rem, 7.6vw, 8rem);
-    line-height: 0.82;
+    font-size: clamp(3.2rem, 6vw, 6rem);
+    line-height: 0.9;
     letter-spacing: -0.045em;
   }
 
@@ -197,39 +196,9 @@
     max-width: 34rem;
   }
 
-  .hero-actions > p {
-    color: var(--muted);
-    font-size: 0.82rem;
-  }
-
   .hero-plot {
     grid-area: plot;
     min-width: 0;
-    border: 1px solid var(--line);
-    background: #fff;
-    color: #172033;
-  }
-
-  .hero-plot :global(.event-status) {
-    min-height: 2.7rem;
-    margin: 0;
-    padding: 0.75rem 1rem;
-    border-top: 1px solid #d9dee8;
-    color: #5e6878;
-  }
-
-  .specimen-label {
-    display: flex;
-    justify-content: space-between;
-    gap: 1rem;
-    padding: 0.75rem 1rem;
-    border-bottom: 1px solid #d9dee8;
-  }
-
-  .specimen-label a {
-    color: inherit;
-    font-size: 0.82rem;
-    font-weight: 600;
   }
 
   .cta-row {
@@ -237,26 +206,6 @@
     flex-wrap: wrap;
     gap: 0.75rem;
     margin-top: 1rem;
-  }
-
-  .cta-row a {
-    display: inline-flex;
-    align-items: center;
-    min-height: 44px;
-    padding: 0.65rem 1rem;
-    border: 1px solid var(--ink);
-    border-radius: 4px;
-    font-weight: 600;
-    text-decoration: none;
-  }
-
-  .primary-action {
-    background: var(--ink);
-    color: var(--paper);
-  }
-
-  .secondary-action {
-    color: var(--ink);
   }
 
   .home-featured {
@@ -300,13 +249,16 @@
     text-decoration: none;
   }
 
+  .home-featured header a {
+    font-weight: 600;
+    text-decoration: underline;
+  }
+
   .preview-paper {
     display: grid;
     aspect-ratio: 4 / 3;
     place-items: center;
     overflow: hidden;
-    border: 1px solid var(--line);
-    background: #fff;
   }
 
   .preview-paper img {
@@ -358,10 +310,6 @@
       grid-template-columns: 1fr;
     }
 
-    .hero-claim h1 {
-      max-width: 12ch;
-    }
-
     .home-featured ol {
       grid-template-columns: repeat(2, minmax(0, 1fr));
     }
@@ -374,12 +322,7 @@
     }
 
     .hero-claim h1 {
-      font-size: clamp(3.4rem, 17vw, 5rem);
-    }
-
-    .specimen-label {
-      align-items: start;
-      flex-direction: column;
+      font-size: clamp(2.6rem, 12vw, 4rem);
     }
 
     .home-featured {

--- a/apps/docs/src/routes/docs/+page.svelte
+++ b/apps/docs/src/routes/docs/+page.svelte
@@ -7,19 +7,19 @@
     "/guide/themes-color": "Themes and color",
     "/guide/server-rendering-export": "Server rendering and export",
   };
+
+  // Diagnostics stays in the sidebar and search; it is a lookup page, not a
+  // starting point.
+  const tasks = DOCS_TASKS.filter((task) => task.label !== "Diagnostics");
 </script>
 
 <article class="docs-landing" aria-labelledby="docs-heading">
   <header>
     <h1 id="docs-heading">Documentation</h1>
-    <p>
-      Install, compose the grammar, add interaction, ship, and read the public
-      contracts.
-    </p>
   </header>
 
   <nav aria-label="Documentation tasks">
-    {#each DOCS_TASKS as task (task.label)}
+    {#each tasks as task (task.label)}
       <section>
         <a class="task-primary" href={`${base}${task.hrefs[0]}`}>
           <strong>{task.label}</strong>
@@ -63,13 +63,6 @@
     font-size: clamp(2.7rem, 7vw, 5.75rem);
     line-height: 0.94;
     letter-spacing: -0.035em;
-  }
-
-  header p {
-    max-width: 42rem;
-    margin: 1.25rem 0 0;
-    color: var(--muted);
-    font-size: 1.05rem;
   }
 
   nav {

--- a/apps/docs/src/routes/examples/+page.svelte
+++ b/apps/docs/src/routes/examples/+page.svelte
@@ -11,10 +11,14 @@
   } from "$lib/gallery-filter";
   import { EXAMPLES } from "$lib/examples";
 
-  const entries = EXAMPLES.map((entry) => galleryEntryFor(entry));
-  const featured = FEATURED_EXAMPLES.map((item) =>
-    entries.find((entry) => entry.id === item.id)!,
-  );
+  // One flat grid; the former featured six lead, the rest follow in
+  // manifest order.
+  const all = EXAMPLES.map((entry) => galleryEntryFor(entry));
+  const leadIds = new Set<string>(FEATURED_EXAMPLES.map((item) => item.id));
+  const entries = [
+    ...[...leadIds].map((id) => all.find((entry) => entry.id === id)!),
+    ...all.filter((entry) => !leadIds.has(entry.id)),
+  ];
   const categories = [
     ...new Set(entries.map((entry) => entry.category)),
   ].toSorted();
@@ -89,53 +93,10 @@
 <svelte:head><meta name="theme-color" content="#ffffff" /></svelte:head>
 
 <header class="gallery-intro">
-  <p class="eyebrow">Gallery</p>
   <h1>Examples</h1>
-  <p>
-    {entries.length} runnable charts from the same outputs used in visual regression.
-  </p>
 </header>
 
-<section class="featured-gallery" aria-labelledby="featured-heading">
-  <div class="section-heading">
-    <div>
-      <p class="eyebrow">Featured</p>
-      <h2 id="featured-heading">Featured</h2>
-    </div>
-    <a href="#all-examples">All {entries.length}</a>
-  </div>
-  <ol>
-    {#each featured as entry (entry.id)}
-      <li>
-        <a href={`${base}/examples/${entry.id}`} aria-label={entry.title}>
-          <figure>
-            <div class="preview-paper">
-              <img
-                src={`${base}${entry.previewPath}`}
-                alt=""
-                width="640"
-                height={entry.vrHeight ?? 400}
-                loading="eager"
-              />
-            </div>
-          </figure>
-        </a>
-      </li>
-    {/each}
-  </ol>
-</section>
-
-<section id="all-examples" class="catalog" aria-labelledby="catalog-heading">
-  <div class="section-heading">
-    <div>
-      <p class="eyebrow">Catalog</p>
-      <h2 id="catalog-heading">All examples</h2>
-    </div>
-    <p class="result-count" aria-live="polite">
-      {results.length} of {entries.length}
-    </p>
-  </div>
-
+<section class="catalog" aria-label="Examples">
   <form class="filters" onsubmit={(event) => event.preventDefault()}>
     <label>
       <span>Filter</span>
@@ -208,54 +169,24 @@
 
   .gallery-intro h1 {
     max-width: 12ch;
-    margin: 0.25rem 0 1rem;
+    margin: 0.25rem 0 0;
     font-size: clamp(3rem, 8vw, 6.5rem);
     line-height: 0.88;
   }
 
-  .gallery-intro > p:last-child {
-    max-width: 42rem;
-    color: var(--muted);
-    font-size: 1.08rem;
-  }
-
-  .eyebrow {
-    color: var(--muted);
-    font-size: 0.75rem;
-    font-weight: 600;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-  }
-
-  .section-heading {
-    display: flex;
-    align-items: end;
-    justify-content: space-between;
-    gap: 1.5rem;
-    margin-bottom: 1.5rem;
-    border-bottom: 1px solid var(--line);
-    padding-bottom: 1rem;
-  }
-
-  .section-heading :is(p, h2) {
-    margin: 0;
-  }
-
-  .featured-gallery ol,
   .example-grid {
     display: grid;
-    grid-template-columns: repeat(3, minmax(0, 1fr));
     gap: 1.25rem;
     margin: 0;
     padding: 0;
     list-style: none;
+    grid-template-columns: repeat(auto-fill, minmax(min(100%, 17rem), 1fr));
   }
 
   figure {
     margin: 0;
   }
 
-  .featured-gallery a,
   .example-grid a {
     color: inherit;
     text-decoration: none;
@@ -266,8 +197,6 @@
     aspect-ratio: 4 / 3;
     place-items: center;
     overflow: hidden;
-    border: 1px solid var(--line);
-    background: #fff;
   }
 
   img {
@@ -275,11 +204,6 @@
     width: 100%;
     height: 100%;
     object-fit: contain;
-  }
-
-  .catalog {
-    margin-top: clamp(4rem, 9vw, 8rem);
-    scroll-margin-top: 6rem;
   }
 
   .filters {
@@ -290,9 +214,8 @@
     align-items: end;
     gap: 0.75rem;
     margin-bottom: 2rem;
-    padding: 1rem;
+    padding: 1rem 0;
     border-block: 1px solid var(--line);
-    background: var(--wash);
   }
 
   .filters label {
@@ -324,15 +247,6 @@
     cursor: pointer;
   }
 
-  .example-grid {
-    grid-template-columns: repeat(auto-fill, minmax(min(100%, 17rem), 1fr));
-  }
-
-  .result-count {
-    color: var(--muted);
-    white-space: nowrap;
-  }
-
   .filter-notice,
   .zero-results {
     margin: 1.5rem 0;
@@ -344,10 +258,6 @@
   }
 
   @media (max-width: 64rem) {
-    .featured-gallery ol {
-      grid-template-columns: repeat(2, minmax(0, 1fr));
-    }
-
     .filters {
       grid-template-columns: 1fr 1fr;
     }
@@ -358,37 +268,8 @@
       padding-top: 2rem;
     }
 
-    .section-heading {
-      align-items: start;
-    }
-
-    .featured-gallery {
-      margin-inline: -1rem;
-    }
-
-    .featured-gallery .section-heading {
-      margin-inline: 1rem;
-    }
-
-    .featured-gallery ol {
-      grid-auto-columns: min(85vw, 21rem);
-      grid-template-columns: none;
-      grid-auto-flow: column;
-      gap: 1rem;
-      overflow-x: auto;
-      scroll-padding-inline: 1rem;
-      scroll-snap-type: x mandatory;
-      padding-inline: 1rem;
-    }
-
-    .featured-gallery li {
-      scroll-snap-align: start;
-    }
-
     .filters {
       grid-template-columns: 1fr;
-      margin-inline: -1rem;
-      padding-inline: 1rem;
     }
   }
 </style>

--- a/scripts/gen-llms.test.ts
+++ b/scripts/gen-llms.test.ts
@@ -18,6 +18,7 @@ import { ERROR_CATALOG, LINT_CATALOG } from "@ggsvelte/spec";
 import { INTERACTION_DIAGNOSTIC_CATALOG } from "../packages/svelte/src/lib/interaction/interaction.ts";
 
 import { EXAMPLES } from "../examples/manifest.ts";
+import supportMatrix from "../support-matrix.json";
 import type { LifecycleDoc } from "./gen-llms.ts";
 import { QUICKSTART_PAGE_SVELTE } from "./quickstart.ts";
 import {
@@ -174,12 +175,14 @@ describe("guide sections cover their catalogs", () => {
   });
 
   it("documents the machine-checked packed-consumer support contract", () => {
-    expect(COMPATIBILITY_MD).toContain("Node.js 22");
-    expect(COMPATIBILITY_MD).toContain("Svelte 5.33.1");
-    expect(COMPATIBILITY_MD).toContain("npm bundled with Node");
-    expect(COMPATIBILITY_MD).toContain("pnpm 11.13.0");
-    expect(COMPATIBILITY_MD).toContain("Bun 1.3.14");
-    expect(COMPATIBILITY_MD).toContain("packed tarballs");
+    expect(COMPATIBILITY_MD).toContain(`Node.js \`${supportMatrix.node.range}\``);
+    expect(COMPATIBILITY_MD).toContain(`Svelte \`${supportMatrix.svelte.range}\``);
+    expect(COMPATIBILITY_MD).toContain(`current ${supportMatrix.svelte.current}`);
+    expect(COMPATIBILITY_MD).toContain(`npm ${supportMatrix.packageManagers.npm}`);
+    expect(COMPATIBILITY_MD).toContain(`pnpm ${supportMatrix.packageManagers.pnpm}`);
+    expect(COMPATIBILITY_MD).toContain(`Bun ${supportMatrix.packageManagers.bun}`);
+    expect(COMPATIBILITY_MD).toContain(`Playwright ${supportMatrix.browsers.playwright}`);
+    expect(COMPATIBILITY_MD).toContain("support-matrix.json");
   });
 
   it("documents the complete interaction capability and event contracts", () => {

--- a/scripts/llms-guide-content.ts
+++ b/scripts/llms-guide-content.ts
@@ -853,26 +853,19 @@ timestamp helpers, exact-format parser, and epoch helpers return authoring Dates
 
 export const COMPATIBILITY_MD = `# Compatibility
 
-ggsvelte is tested from release-shaped packed tarballs, never only through
-workspace imports. “Supported” means a clean install, strict
-type-check, client production build, server render, pure Node render, and
-installed \`ggsvelte-render\` CLI execution all pass.
+Every release is tested as an installed package: clean install, strict
+type-check, client build, server render, pure Node render, and the
+\`ggsvelte-render\` CLI.
 
-## Supported consumers
+- Node.js \`${supportMatrix.node.range}\` (${supportMatrix.node.tested.join(" and ")} in CI; ${supportMatrix.node.canary} nightly)
+- Svelte \`${supportMatrix.svelte.range}\` (tested floor ${supportMatrix.svelte.minimum}, current ${supportMatrix.svelte.current})
+- npm ${supportMatrix.packageManagers.npm}, pnpm ${supportMatrix.packageManagers.pnpm}, Bun ${supportMatrix.packageManagers.bun}
+- Chromium, Firefox, and WebKit (Playwright ${supportMatrix.browsers.playwright})
+- Ubuntu and Windows in CI; macOS nightly
 
-- Node.js ${supportMatrix.node.tested.join(" and ")} are required release checks; Node.js ${supportMatrix.node.canary} is a nightly canary. Published packages declare \`${supportMatrix.node.range}\`.
-- Svelte ${supportMatrix.svelte.minimum} is the exact tested floor and ${supportMatrix.svelte.current} is the pinned current release. The peer range is \`${supportMatrix.svelte.range}\`.
-- Installers: npm ${supportMatrix.packageManagers.npm}, pnpm ${supportMatrix.packageManagers.pnpm}, and Bun ${supportMatrix.packageManagers.bun}.
-- Browsers: Chromium, Firefox, and WebKit from pinned Playwright ${supportMatrix.browsers.playwright}.
-- Ubuntu and Windows are required CI platforms; macOS is exercised nightly.
-
-The required matrix is deliberately a small covering set. A scheduled matrix
-adds Node Current, macOS, and more Windows/package-manager boundary pairs
-without making every pull request pay for a full Cartesian product. Exact,
-machine-checked rows live in [support-matrix.json](https://github.com/ljodea/ggsvelte/blob/main/support-matrix.json).
-
-The root \`bun@${supportMatrix.packageManagers.bun}\` pin is the contributor
-toolchain. Consumers may use any tested installer above; they do not need Bun.
+Exact machine-checked rows live in
+[support-matrix.json](https://github.com/ljodea/ggsvelte/blob/main/support-matrix.json).
+Bun is the contributor toolchain only; consumers can use any installer above.
 `;
 
 export const INTERACTIONS_MD = `# Interactions

--- a/tests/visual/docs-home-gallery.spec.ts
+++ b/tests/visual/docs-home-gallery.spec.ts
@@ -10,7 +10,7 @@ test("homepage first viewport leads with a live chart and two actions", async ({
   await page.setViewportSize({ width: 1280, height: 900 });
   await page.goto("/?theme=light");
   await expect(page.getByRole("heading", { level: 1 })).toHaveText(
-    "A grammar of graphics for Svelte.",
+    "An agent-first implementation of the layered grammar of graphics in Svelte 5",
   );
   await expect(page.locator(".home-hero .gg-plot-root")).toBeVisible();
   await expect(page.getByRole("link", { name: "Getting started" })).toBeVisible();

--- a/tests/visual/docs-home-gallery.spec.ts
+++ b/tests/visual/docs-home-gallery.spec.ts
@@ -9,7 +9,9 @@ async function expectNoOverflow(page: import("@playwright/test").Page): Promise<
 test("homepage first viewport leads with a live chart and two actions", async ({ page }) => {
   await page.setViewportSize({ width: 1280, height: 900 });
   await page.goto("/?theme=light");
-  await expect(page.getByRole("heading", { level: 1 })).toHaveText("ggplot2 for Svelte.");
+  await expect(page.getByRole("heading", { level: 1 })).toHaveText(
+    "A grammar of graphics for Svelte.",
+  );
   await expect(page.locator(".home-hero .gg-plot-root")).toBeVisible();
   await expect(page.getByRole("link", { name: "Getting started" })).toBeVisible();
   await expect(page.getByRole("link", { name: "Examples" }).first()).toBeVisible();
@@ -27,32 +29,31 @@ test("homepage preserves SSR chart output and hydrates its keyboard interaction"
   await page.goto("/");
   const plot = page.locator(".home-hero .gg-plot-root");
   await expect(plot).toHaveAttribute("data-gg-ready", "true");
-  const status = page.locator(".home-hero .event-status");
-  const initialStatus = await status.textContent();
   const capture = page.locator(".home-hero .gg-capture");
   await capture.focus();
   await capture.press("ArrowRight");
   await expect(page.locator(".home-hero .gg-tooltip")).toBeVisible();
-  await expect(status).not.toHaveText(initialStatus ?? "");
 });
 
 test("homepage grammar steps change real chart structure in place", async ({ page }) => {
   await page.goto("/");
   const output = page.locator(".grammar-output");
+  // The demo opens on the last step: layers, legend, and inspection all live.
   await expect(output.locator(".gg-points")).toHaveCount(1);
+  await expect(output.locator(".gg-legend")).toHaveCount(1);
+  await expect(output.locator(".gg-paths")).toHaveCount(1);
+  await expect(output.locator(".gg-capture")).toBeVisible();
+
+  await page.getByRole("button", { name: /Data/ }).click();
   await expect(output.locator(".gg-legend")).toHaveCount(0);
+  await expect(output.locator(".gg-paths")).toHaveCount(0);
 
   await page.getByRole("button", { name: /Mappings/ }).click();
   await expect(output.locator(".gg-legend")).toHaveCount(1);
-  await expect(output.locator(".grammar-status")).toHaveText("Step 2: Mappings");
+  await expect(output.locator(".gg-paths")).toHaveCount(0);
 
   await page.getByRole("button", { name: /Layers/ }).click();
   await expect(output.locator(".gg-paths")).toHaveCount(1);
-  await expect(output.locator(".grammar-status")).toHaveText("Step 3: Layers");
-
-  await page.getByRole("button", { name: /Interaction/ }).click();
-  await expect(output.locator(".gg-capture")).toBeVisible();
-  await expect(output.locator(".grammar-status")).toHaveText("Step 4: Interaction");
 });
 
 test("homepage mobile order is claim, specimen, then install", async ({ page }) => {
@@ -95,14 +96,12 @@ test("install copy and code tabs share the manual-copy fallback", async ({ page 
   await expect(tabs.first()).toHaveText("Svelte");
 });
 
-test("gallery exposes six featured previews and all generated previews", async ({ page }) => {
+test("gallery exposes every generated preview exactly once", async ({ page }) => {
   await page.goto("/examples");
-  await expect(page.locator(".featured-gallery li")).toHaveCount(6);
   // One meta.json per example under examples/ (grows when new specimens land).
   const exampleCount = 44; // +segment +layer-data-bands +fixed-aspect +facet/ordered-side-strips +ribbon/paint +col/mixed-outlier-labels
   await expect(page.locator(".example-grid li")).toHaveCount(exampleCount);
-  await expect(page.locator('img[src*="/previews/"]')).toHaveCount(6 + exampleCount);
-  await expect(page.getByText(`${String(exampleCount)} of ${String(exampleCount)}`)).toBeVisible();
+  await expect(page.locator('img[src*="/previews/"]')).toHaveCount(exampleCount);
 });
 
 test("gallery filtering is URL-addressable, preserves theme, and restores history", async ({
@@ -117,7 +116,6 @@ test("gallery filtering is URL-addressable, preserves theme, and restores histor
   expect(linkedCount).toBeGreaterThan(0);
   await page.getByLabel("Category").selectOption("bar");
   await expect(page).toHaveURL(/category=bar/);
-  await expect(page.getByText(/of \d+/)).toBeVisible();
   await page.goBack();
   await expect(page.getByLabel("Category")).toHaveValue("");
   await expect(page.locator(".example-grid li").first()).toBeVisible();

--- a/tests/visual/docs-progressive-search.spec.ts
+++ b/tests/visual/docs-progressive-search.spec.ts
@@ -94,10 +94,9 @@ test("Docs landing and sidebar expose the full path without duplicate Reference"
     "href",
     /\/guide\/responsive-charts$/,
   );
-  await expect(tasks.getByRole("link", { name: /Diagnostics/ })).toHaveAttribute(
-    "href",
-    /\/guide\/errors$/,
-  );
+  // Diagnostics is deliberately absent from the landing tasks; it stays in
+  // the sidebar and search.
+  await expect(tasks.getByRole("link", { name: /Diagnostics/ })).toHaveCount(0);
 
   const sidebar = page.getByRole("navigation", { name: "Guide chapters" });
   await expect(sidebar.getByRole("heading", { level: 2 })).toHaveText([

--- a/tests/visual/docs-shell.spec.ts
+++ b/tests/visual/docs-shell.spec.ts
@@ -134,7 +134,7 @@ test("mobile header and docs navigation are explicit, reachable controls", async
   await page.keyboard.press("Escape");
   await expect(siteMenu).toBeFocused();
 
-  const chapterMenu = page.getByRole("button", { name: "Open guide chapters" });
+  const chapterMenu = page.getByRole("button", { name: "Open docs navigation" });
   await expect(chapterMenu).toBeVisible();
   await expect(page.getByRole("link", { name: "Skip to docs navigation" })).toHaveAttribute(
     "href",
@@ -145,7 +145,7 @@ test("mobile header and docs navigation are explicit, reachable controls", async
   await expect(chapterDialog.getByRole("navigation", { name: "Guide chapters" })).toBeVisible();
   await page.setViewportSize({ width: 1280, height: 760 });
   await expect(chapterDialog).toBeVisible();
-  await chapterDialog.getByRole("button", { name: "Close guide chapters" }).click();
+  await chapterDialog.getByRole("button", { name: "Close docs navigation" }).click();
   await expectNoHorizontalOverflow(page);
 });
 

--- a/tests/visual/playground.spec.ts
+++ b/tests/visual/playground.spec.ts
@@ -116,10 +116,6 @@ async function applyTitle(page: Page, title: string): Promise<void> {
 
 test("landing page makes the gallery and local adaptation paths obvious", async ({ page }) => {
   await page.goto("/");
-  await expect(page.getByRole("link", { name: "Example source" })).toHaveAttribute(
-    "href",
-    /examples\/interactions\/inspection$/,
-  );
   await page.getByRole("link", { name: "Playground" }).first().click();
   await expect(page).toHaveURL(/\/playground$/);
   await expect(page.getByRole("heading", { name: "Playground" })).toBeVisible();


### PR DESCRIPTION
Docs-site overhaul: fewer words, charts as the star, no chrome.

## Home

- New title "A grammar of graphics for Svelte." and a subtitle that states the actual contributions (three surfaces, agent-writable JSON spec, declarative interaction).
- Hero is a borderless live `GGPlot` that renders in the **inverse** of the site theme (dark chart on light site, and vice versa) via a new `docs-appearance-state.svelte.ts` rune module watching `data-theme`.
- Removed: "OPEN SOURCE · SVELTE 5" eyebrow, "Live chart"/"Example source"/event-status chrome, "MIT. No account or hosted service." line, "FEATURED"/"All 44" labels.
- CTAs are bits-ui `UiButton`s (`href` support added to the component).
- Spec (JSON) tab is pretty-printed; surfaces copy now explains why three surfaces exist.
- Contracts section replaced with a Docs section inviting Getting started, Themes and color, Interactions, Headless SVG. Compatibility/Diagnostics/PortableSpec links removed from the front page.

## GrammarDemo

- Reframed around declarative interaction; starts on the Interaction step so mousing over the chart works immediately, with clearer clickable-step affordances.
- Border and "Step 1: Data" status bar removed; chart uses the inverse site theme.

## Docs landing + shell

- Subtitle removed; Diagnostics dropped from the invite list (still in sidebar and search).
- "Chapters" button renamed "Menu".

## Gallery

- One flat grid: former featured six lead, deduplicated; Featured/Catalog split, counts, subtitle, and preview borders removed. Filters kept.

## Verification

- `bun run check` clean; docs build clean.
- 43/44 Playwright visual specs pass; the one failure (search combobox Home/End caret) fails identically on an unmodified main build — pre-existing local-env issue.

Related follow-up issues filed: #653, #654, #655, #656.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
