### PR TITLE
docs: cut the Compatibility page to the support matrix

### DIFF
--- a/apps/docs/src/lib/catalog/guide.ts
+++ b/apps/docs/src/lib/catalog/guide.ts
@@ -153,7 +153,7 @@ export const GUIDE_CATALOG = [
   {
     slug: "compatibility",
     title: "Compatibility",
-    description: "Tested Node, Svelte, package-manager, browser, and OS boundaries.",
+    description: "Tested Node, Svelte, browser, and OS versions.",
     section: "Production",
     navigationOrder: 40,
   },

--- a/apps/docs/src/lib/generated/routes.ts
+++ b/apps/docs/src/lib/generated/routes.ts
@@ -830,7 +830,7 @@ export const DOCS_ROUTES = [
   {
     path: "/guide/compatibility",
     title: "Compatibility — ggsvelte",
-    description: "Tested Node, Svelte, package-manager, browser, and OS boundaries.",
+    description: "Tested Node, Svelte, browser, and OS versions.",
     canonicalPath: "/guide/compatibility",
     kind: "page",
     index: true,
@@ -841,13 +841,7 @@ export const DOCS_ROUTES = [
       label: "Compatibility",
       order: 40,
     },
-    headings: [
-      {
-        id: "supported-consumers",
-        title: "Supported consumers",
-        level: 2,
-      },
-    ],
+    headings: [],
   },
   {
     path: "/guide/interaction-reference",

--- a/apps/docs/src/lib/generated/search-index.ts
+++ b/apps/docs/src/lib/generated/search-index.ts
@@ -1040,20 +1040,10 @@ export const DOCS_SEARCH_INDEX = [
     id: "page:guide-compatibility",
     kind: "page",
     title: "Compatibility",
-    summary: "Tested Node, Svelte, package-manager, browser, and OS boundaries.",
+    summary: "Tested Node, Svelte, browser, and OS versions.",
     href: "/guide/compatibility",
     keywords: ["Production"],
     exact: ["Compatibility"],
-  },
-  {
-    id: "heading:guide-compatibility:supported-consumers",
-    kind: "heading",
-    title: "Supported consumers",
-    summary:
-      "Supported consumers in Compatibility. Tested Node, Svelte, package-manager, browser, and OS boundaries.",
-    href: "/guide/compatibility#supported-consumers",
-    keywords: ["Compatibility", "Production"],
-    exact: ["Supported consumers"],
   },
   {
     id: "page:guide-interaction-reference",

--- a/scripts/gen-llms.test.ts
+++ b/scripts/gen-llms.test.ts
@@ -18,6 +18,7 @@ import { ERROR_CATALOG, LINT_CATALOG } from "@ggsvelte/spec";
 import { INTERACTION_DIAGNOSTIC_CATALOG } from "../packages/svelte/src/lib/interaction/interaction.ts";
 
 import { EXAMPLES } from "../examples/manifest.ts";
+import supportMatrix from "../support-matrix.json";
 import type { LifecycleDoc } from "./gen-llms.ts";
 import { QUICKSTART_PAGE_SVELTE } from "./quickstart.ts";
 import {
@@ -174,12 +175,14 @@ describe("guide sections cover their catalogs", () => {
   });
 
   it("documents the machine-checked packed-consumer support contract", () => {
-    expect(COMPATIBILITY_MD).toContain("Node.js 22");
-    expect(COMPATIBILITY_MD).toContain("Svelte 5.33.1");
-    expect(COMPATIBILITY_MD).toContain("npm bundled with Node");
-    expect(COMPATIBILITY_MD).toContain("pnpm 11.13.0");
-    expect(COMPATIBILITY_MD).toContain("Bun 1.3.14");
-    expect(COMPATIBILITY_MD).toContain("packed tarballs");
+    expect(COMPATIBILITY_MD).toContain(`Node.js \`${supportMatrix.node.range}\``);
+    expect(COMPATIBILITY_MD).toContain(`Svelte \`${supportMatrix.svelte.range}\``);
+    expect(COMPATIBILITY_MD).toContain(`current ${supportMatrix.svelte.current}`);
+    expect(COMPATIBILITY_MD).toContain(`npm ${supportMatrix.packageManagers.npm}`);
+    expect(COMPATIBILITY_MD).toContain(`pnpm ${supportMatrix.packageManagers.pnpm}`);
+    expect(COMPATIBILITY_MD).toContain(`Bun ${supportMatrix.packageManagers.bun}`);
+    expect(COMPATIBILITY_MD).toContain(`Playwright ${supportMatrix.browsers.playwright}`);
+    expect(COMPATIBILITY_MD).toContain("support-matrix.json");
   });
 
   it("documents the complete interaction capability and event contracts", () => {

--- a/scripts/llms-guide-content.ts
+++ b/scripts/llms-guide-content.ts
@@ -853,26 +853,19 @@ timestamp helpers, exact-format parser, and epoch helpers return authoring Dates
 
 export const COMPATIBILITY_MD = `# Compatibility
 
-ggsvelte is tested from release-shaped packed tarballs, never only through
-workspace imports. “Supported” means a clean install, strict
-type-check, client production build, server render, pure Node render, and
-installed \`ggsvelte-render\` CLI execution all pass.
+Every release is tested as an installed package: clean install, strict
+type-check, client build, server render, pure Node render, and the
+\`ggsvelte-render\` CLI.
 
-## Supported consumers
+- Node.js \`${supportMatrix.node.range}\` (${supportMatrix.node.tested.join(" and ")} in CI; ${supportMatrix.node.canary} nightly)
+- Svelte \`${supportMatrix.svelte.range}\` (tested floor ${supportMatrix.svelte.minimum}, current ${supportMatrix.svelte.current})
+- npm ${supportMatrix.packageManagers.npm}, pnpm ${supportMatrix.packageManagers.pnpm}, Bun ${supportMatrix.packageManagers.bun}
+- Chromium, Firefox, and WebKit (Playwright ${supportMatrix.browsers.playwright})
+- Ubuntu and Windows in CI; macOS nightly
 
-- Node.js ${supportMatrix.node.tested.join(" and ")} are required release checks; Node.js ${supportMatrix.node.canary} is a nightly canary. Published packages declare \`${supportMatrix.node.range}\`.
-- Svelte ${supportMatrix.svelte.minimum} is the exact tested floor and ${supportMatrix.svelte.current} is the pinned current release. The peer range is \`${supportMatrix.svelte.range}\`.
-- Installers: npm ${supportMatrix.packageManagers.npm}, pnpm ${supportMatrix.packageManagers.pnpm}, and Bun ${supportMatrix.packageManagers.bun}.
-- Browsers: Chromium, Firefox, and WebKit from pinned Playwright ${supportMatrix.browsers.playwright}.
-- Ubuntu and Windows are required CI platforms; macOS is exercised nightly.
-
-The required matrix is deliberately a small covering set. A scheduled matrix
-adds Node Current, macOS, and more Windows/package-manager boundary pairs
-without making every pull request pay for a full Cartesian product. Exact,
-machine-checked rows live in [support-matrix.json](https://github.com/ljodea/ggsvelte/blob/main/support-matrix.json).
-
-The root \`bun@${supportMatrix.packageManagers.bun}\` pin is the contributor
-toolchain. Consumers may use any tested installer above; they do not need Bun.
+Exact machine-checked rows live in
+[support-matrix.json](https://github.com/ljodea/ggsvelte/blob/main/support-matrix.json).
+Bun is the contributor toolchain only; consumers can use any installer above.
 `;
 
 export const INTERACTIONS_MD = `# Interactions


### PR DESCRIPTION
Cuts `/guide/compatibility` from ~200 words of release-engineering methodology to the support matrix a user actually needs.

- `COMPATIBILITY_MD` in `scripts/llms-guide-content.ts` (single source for the guide page and llms.txt) now: one sentence defining "supported" (every release tested as an installed package), five matrix bullets, and a close pointing at `support-matrix.json`. All version numbers still interpolated from `supportMatrix` — nothing hardcoded.
- Deleted: "release-shaped packed tarballs", "required release checks", the "deliberately a small covering set … Cartesian product" paragraph.
- Catalog description tightened to "Tested Node, Svelte, browser, and OS versions."
- Regenerated `routes.ts` and `search-index.ts`.

Verification: `bun run check` in apps/docs passes (all gen --check steps current, svelte-check 0 errors/0 warnings).

Stacked on #657 (base: `docs/anti-slop-overhaul`).

Note: this was intended for grok-4.5 dispatch, but the Grok Build balance is exhausted (402), so it was implemented directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
