### PR TITLE
docs(themes): chart-first showcase overhaul

### DIFF
--- a/apps/docs/src/lib/components/ChartThemeLab.svelte
+++ b/apps/docs/src/lib/components/ChartThemeLab.svelte
@@ -1,46 +1,76 @@
 <script lang="ts">
-  import { GeomPoint, GGPlot } from "@ggsvelte/svelte";
+  import { GeomLine, GeomPoint, GGPlot } from "@ggsvelte/svelte";
   import type { ThemeName } from "@ggsvelte/spec";
   import { onMount } from "svelte";
 
-  import { THEME_OPTIONS } from "$lib/catalog/themes";
+  import { CATEGORICAL_PALETTES, THEME_OPTIONS } from "$lib/catalog/themes";
   import CopyCode from "$lib/components/CopyCode.svelte";
   import {
     readDocsAppearance,
     watchDocsAppearance,
     type DocsAppearance,
   } from "$lib/docs-appearance";
+  import { MONTH_BREAKS } from "$lib/theme-specimens/catalog";
+  import { temperaturesKeyed } from "$lib/theme-specimens/data";
 
-  const rows = [
-    { quarter: 1, value: 24, group: "Observed" },
-    { quarter: 2, value: 38, group: "Observed" },
-    { quarter: 3, value: 45, group: "Observed" },
-    { quarter: 4, value: 63, group: "Observed" },
-    { quarter: 1, value: 31, group: "Expected" },
-    { quarter: 2, value: 41, group: "Expected" },
-    { quarter: 3, value: 54, group: "Expected" },
-    { quarter: 4, value: 70, group: "Expected" },
-  ];
+  type SchemeName = (typeof CATEGORICAL_PALETTES)[number]["name"];
 
   let explicitTheme = $state<ThemeName>("default");
+  let scheme = $state<SchemeName>("observable10");
   let followDocs = $state(false);
   let siteAppearance = $state<DocsAppearance>("light");
+
   const resolvedTheme = $derived<ThemeName>(
     followDocs ? siteAppearance : explicitTheme,
   );
-  const scheme = $derived(
-    THEME_OPTIONS.find((theme) => theme.name === resolvedTheme)?.scheme ??
-      "observable10",
-  );
+
+  const scriptClose = "</" + "script>";
+
+  /** Compact inline rows for the consumer-facing snippet only. */
   const code = $derived(
-    `<GGPlot
-  data={rows}
-  aes={{ x: "quarter", y: "value", color: "group" }}
-  theme="${resolvedTheme}"
-  scales={{ color: { scheme: "${scheme}" } }}
->
-  <GeomPoint size={4} />
-</GGPlot>`,
+    [
+      `<script lang="ts">`,
+      `  import { GeomLine, GeomPoint, GGPlot } from "@ggsvelte/svelte";`,
+      ``,
+      `  const temperatures = [`,
+      `    { city: "Reykjavik", month: 1, temp: -0.5 },`,
+      `    { city: "Reykjavik", month: 7, temp: 10.6 },`,
+      `    { city: "Berlin", month: 1, temp: 0.6 },`,
+      `    { city: "Berlin", month: 7, temp: 19.0 },`,
+      `    { city: "Singapore", month: 1, temp: 26.5 },`,
+      `    { city: "Singapore", month: 7, temp: 27.9 },`,
+      `    // …full series in your app`,
+      `  ];`,
+      scriptClose,
+      ``,
+      `<GGPlot`,
+      `  data={temperatures}`,
+      `  aes={{ x: "month", y: "temp", color: "city" }}`,
+      `  theme="${resolvedTheme}"`,
+      `  scales={{`,
+      `    x: { breaks: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] },`,
+      `    color: { type: "ordinal", scheme: "${scheme}" },`,
+      `  }}`,
+      `  labs={{`,
+      `    title: "Monthly mean temperature",`,
+      `    x: "Month",`,
+      `    y: "Temperature (°C)",`,
+      `    color: "City",`,
+      `  }}`,
+      `  inspect={{ mode: "x" }}`,
+      `  legendFocus`,
+      `  height={400}`,
+      `>`,
+      `  <GeomLine linewidth={2} />`,
+      `  <GeomPoint size={2.5} />`,
+      `</GGPlot>`,
+    ].join("\n"),
+  );
+
+  const statusText = $derived(
+    followDocs
+      ? `theme follows site appearance (${siteAppearance}) · scheme="${scheme}" remains yours`
+      : `theme="${resolvedTheme}" · scheme="${scheme}"`,
   );
 
   function syncSiteAppearance(): void {
@@ -60,62 +90,79 @@
   });
 </script>
 
-<section class="theme-lab" aria-label="Chart theme lab">
-  <div class="lab-output">
+<section class="theme-lab" aria-label="Chart theme and palette lab">
+  <p class="eyebrow">Live</p>
+  <h2>Try theme and palette</h2>
+  <p class="lede">
+    <code>theme</code> styles paper, grid, axes, and type.
+    <code>scales.color.scheme</code> colors series. Docs light/dark only applies when
+    Follow docs appearance is on.
+  </p>
+
+  <div class="plot-panel">
     <GGPlot
-      data={rows}
-      aes={{ x: "quarter", y: "value", color: "group" }}
+      data={temperaturesKeyed}
+      aes={{ x: "month", y: "temp", color: "city" }}
       theme={resolvedTheme}
-      scales={{ color: { type: "ordinal", scheme } }}
-      height={360}
-      ariaLabel={`${resolvedTheme} chart theme`}
+      scales={{
+        x: { breaks: [...MONTH_BREAKS] },
+        color: { type: "ordinal", scheme },
+      }}
+      labs={{
+        title: "Monthly mean temperature",
+        x: "Month",
+        y: "Temperature (°C)",
+        color: "City",
+      }}
+      key="id"
+      inspect={{ mode: "x" }}
+      legendFocus
+      height={400}
+      ariaLabel={`${resolvedTheme} theme with ${scheme} palette`}
     >
-      <GeomPoint size={4} />
+      <GeomLine linewidth={2} />
+      <GeomPoint size={2.5} />
     </GGPlot>
+  </div>
+
+  <div class="controls">
+    <div class="select-control">
+      <label for="chart-theme">Chart theme</label>
+      <select id="chart-theme" bind:value={explicitTheme} disabled={followDocs}>
+        {#each THEME_OPTIONS as theme (theme.name)}
+          <option value={theme.name}>{theme.label}</option>
+        {/each}
+      </select>
+    </div>
+    <div class="select-control">
+      <label for="chart-palette">Categorical palette</label>
+      <select id="chart-palette" bind:value={scheme}>
+        {#each CATEGORICAL_PALETTES as palette (palette.name)}
+          <option value={palette.name}>{palette.label}</option>
+        {/each}
+      </select>
+    </div>
+    <label class="follow-control">
+      <input type="checkbox" checked={followDocs} onchange={changeFollow} />
+      <span>Follow docs appearance</span>
+    </label>
+  </div>
+
+  <p class="resolved" role="status">{statusText}</p>
+
+  <div class="code-footer">
     <CopyCode
       {code}
       language="svelte"
-      accessibleLabel="Copy selected theme code"
+      accessibleLabel="Copy selected theme and palette code"
     />
-  </div>
-
-  <div class="lab-copy">
-    <p class="eyebrow">Live</p>
-    <h2>Pick a theme</h2>
-    <p>
-      <code>theme</code> is set on the plot. Site appearance is separate unless you
-      wire them yourself.
-    </p>
-    <div class="controls">
-      <div class="select-control">
-        <label for="chart-theme">Chart theme</label>
-        <select
-          id="chart-theme"
-          bind:value={explicitTheme}
-          disabled={followDocs}
-        >
-          {#each THEME_OPTIONS as theme (theme.name)}
-            <option value={theme.name}>{theme.label}</option>
-          {/each}
-        </select>
-      </div>
-      <label class="follow-control">
-        <input type="checkbox" checked={followDocs} onchange={changeFollow} />
-        <span>Follow docs appearance</span>
-      </label>
-    </div>
-    <p class="resolved" role="status">
-      theme="{resolvedTheme}"{followDocs ? " · following docs" : ""}
-    </p>
   </div>
 </section>
 
 <style>
   .theme-lab {
     display: grid;
-    grid-template-columns: minmax(0, 1.35fr) minmax(0, 0.65fr);
-    gap: clamp(1.5rem, 4vw, 3rem);
-    align-items: start;
+    gap: 0.85rem;
     min-width: 0;
     padding-block: clamp(1.5rem, 4vw, 2.5rem) clamp(2.5rem, 6vw, 4rem);
   }
@@ -130,31 +177,42 @@
   }
 
   h2 {
-    margin: 0.25rem 0 0.65rem;
+    margin: 0;
     font-size: clamp(1.5rem, 3vw, 2rem);
     line-height: 1.05;
     letter-spacing: -0.02em;
   }
 
-  .lab-copy {
-    min-width: 0;
+  .lede {
+    margin: 0;
+    max-width: 40rem;
+    color: var(--muted);
+    font-size: 0.98rem;
+    line-height: 1.45;
   }
 
-  .lab-copy > p:not(.eyebrow, .resolved) {
-    margin: 0;
-    max-width: 28rem;
-    color: var(--muted);
+  .lede code {
+    font-size: 0.9em;
+  }
+
+  .plot-panel {
+    width: min(100%, 52rem);
+    min-width: 0;
+    margin-top: 0.5rem;
   }
 
   .controls {
-    display: grid;
-    gap: 0.85rem;
-    margin-top: 1.5rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.85rem 1.25rem;
+    align-items: end;
+    width: min(100%, 52rem);
   }
 
   .select-control {
     display: grid;
     gap: 0.4rem;
+    min-width: min(100%, 12rem);
     font-size: 0.82rem;
     font-weight: 650;
   }
@@ -168,6 +226,11 @@
     background: var(--paper);
     color: var(--ink);
     font: inherit;
+  }
+
+  select:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
   }
 
   .follow-control {
@@ -186,26 +249,15 @@
 
   .resolved {
     min-height: 1.5rem;
-    margin: 0.75rem 0 0;
+    margin: 0;
+    width: min(100%, 52rem);
     color: var(--muted);
     font-size: 0.82rem;
     font-family: var(--code-font);
   }
 
-  .lab-output {
-    display: grid;
-    gap: 0.75rem;
+  .code-footer {
+    width: min(100%, 52rem);
     min-width: 0;
-  }
-
-  @media (max-width: 50rem) {
-    .theme-lab {
-      grid-template-columns: 1fr;
-      gap: 1.5rem;
-    }
-
-    .lab-output {
-      grid-row: 1;
-    }
   }
 </style>

--- a/apps/docs/src/lib/components/ChartThemeLab.svelte
+++ b/apps/docs/src/lib/components/ChartThemeLab.svelte
@@ -12,6 +12,7 @@
   } from "$lib/docs-appearance";
   import { MONTH_BREAKS } from "$lib/theme-specimens/catalog";
   import { temperaturesKeyed } from "$lib/theme-specimens/data";
+  import { heroThemePaletteSnippet } from "$lib/theme-specimens/snippets";
 
   type SchemeName = (typeof CATEGORICAL_PALETTES)[number]["name"];
 
@@ -24,48 +25,7 @@
     followDocs ? siteAppearance : explicitTheme,
   );
 
-  const scriptClose = "</" + "script>";
-
-  /** Compact inline rows for the consumer-facing snippet only. */
-  const code = $derived(
-    [
-      `<script lang="ts">`,
-      `  import { GeomLine, GeomPoint, GGPlot } from "@ggsvelte/svelte";`,
-      ``,
-      `  const temperatures = [`,
-      `    { city: "Reykjavik", month: 1, temp: -0.5 },`,
-      `    { city: "Reykjavik", month: 7, temp: 10.6 },`,
-      `    { city: "Berlin", month: 1, temp: 0.6 },`,
-      `    { city: "Berlin", month: 7, temp: 19.0 },`,
-      `    { city: "Singapore", month: 1, temp: 26.5 },`,
-      `    { city: "Singapore", month: 7, temp: 27.9 },`,
-      `    // …full series in your app`,
-      `  ];`,
-      scriptClose,
-      ``,
-      `<GGPlot`,
-      `  data={temperatures}`,
-      `  aes={{ x: "month", y: "temp", color: "city" }}`,
-      `  theme="${resolvedTheme}"`,
-      `  scales={{`,
-      `    x: { breaks: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] },`,
-      `    color: { type: "ordinal", scheme: "${scheme}" },`,
-      `  }}`,
-      `  labs={{`,
-      `    title: "Monthly mean temperature",`,
-      `    x: "Month",`,
-      `    y: "Temperature (°C)",`,
-      `    color: "City",`,
-      `  }}`,
-      `  inspect={{ mode: "x" }}`,
-      `  legendFocus`,
-      `  height={400}`,
-      `>`,
-      `  <GeomLine linewidth={2} />`,
-      `  <GeomPoint size={2.5} />`,
-      `</GGPlot>`,
-    ].join("\n"),
-  );
+  const code = $derived(heroThemePaletteSnippet(resolvedTheme, scheme));
 
   const statusText = $derived(
     followDocs

--- a/apps/docs/src/lib/components/PaletteGallery.svelte
+++ b/apps/docs/src/lib/components/PaletteGallery.svelte
@@ -116,8 +116,8 @@
 
   ol {
     display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: clamp(2rem, 4vw, 3rem) clamp(1.5rem, 3vw, 2.5rem);
+    grid-template-columns: 1fr;
+    gap: clamp(2.5rem, 5vw, 4rem);
     margin: 0;
     padding: 0;
     list-style: none;
@@ -125,11 +125,5 @@
 
   ol > li {
     min-width: 0;
-  }
-
-  @media (max-width: 50rem) {
-    ol {
-      grid-template-columns: 1fr;
-    }
   }
 </style>

--- a/apps/docs/src/lib/components/PaletteSpecimen.svelte
+++ b/apps/docs/src/lib/components/PaletteSpecimen.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-  import { GeomPoint, GGPlot } from "@ggsvelte/svelte";
+  import { GeomCol, GGPlot } from "@ggsvelte/svelte";
   import type { ThemeName } from "@ggsvelte/spec";
 
-  import CopyCode from "$lib/components/CopyCode.svelte";
+  import { languages } from "$lib/theme-specimens/data";
 
   const {
     name,
@@ -20,78 +20,59 @@
     paperTheme: ThemeName;
   } = $props();
 
-  const rows = [
-    { signal: 1, value: 22, category: "Alpha" },
-    { signal: 2, value: 37, category: "Beta" },
-    { signal: 3, value: 29, category: "Gamma" },
-    { signal: 4, value: 55, category: "Delta" },
-    { signal: 5, value: 46, category: "Epsilon" },
-  ];
   const displayColors = $derived(reverse ? colors.toReversed() : colors);
-  const code = $derived(
-    `<GGPlot
-  data={rows}
-  aes={{ x: "signal", y: "value", color: "category" }}
-  scales={{ color: { scheme: "${name}", reverse: ${String(reverse)} } }}
-  theme="${paperTheme}"
->
-  <GeomPoint size={4} />
-</GGPlot>`,
-  );
 </script>
 
-<article>
+<article class="specimen">
   <header>
     <div>
       <h3>{label}</h3>
-      <code>scheme="{name}"</code>
+      <span class="capacity">{capacity} colors</span>
     </div>
-    <span class="capacity">{capacity} colors</span>
   </header>
 
   <ul class="swatches" aria-label={`${label} ordered colors`}>
     {#each displayColors as color, index (`${color}-${String(index)}`)}
       <li
         style={`--swatch:${color}`}
+        title={color}
         aria-label={`${String(index + 1)}: ${color}`}
       >
-        <span aria-hidden="true"></span><code>{color}</code>
+        <span aria-hidden="true"></span>
       </li>
     {/each}
   </ul>
 
-  <div class="plot">
+  <div class="plot-panel">
     <GGPlot
-      data={rows}
-      aes={{ x: "signal", y: "value", color: "category" }}
-      scales={{ color: { type: "ordinal", scheme: name, reverse } }}
+      data={languages}
+      aes={{ x: "language", y: "respondents", fill: "language" }}
+      scales={{ fill: { type: "ordinal", scheme: name, reverse } }}
+      guides={{ fill: { type: "none" } }}
       theme={paperTheme}
-      height={260}
+      labs={{
+        title: "Survey respondents by language",
+        x: "Language",
+        y: "Respondents",
+      }}
+      inspect={{ mode: "xy" }}
+      height={340}
       ariaLabel={`${label} palette on ${paperTheme} paper`}
     >
-      <GeomPoint size={4} />
+      <GeomCol width={0.75} />
     </GGPlot>
   </div>
-
-  <CopyCode
-    {code}
-    language="svelte"
-    accessibleLabel={`Copy ${label} palette code`}
-  />
 </article>
 
 <style>
-  article {
+  .specimen {
     display: grid;
     gap: 0.75rem;
     min-width: 0;
   }
 
   header {
-    display: flex;
-    align-items: start;
-    justify-content: space-between;
-    gap: 1rem;
+    min-width: 0;
   }
 
   h3 {
@@ -100,33 +81,28 @@
     letter-spacing: -0.01em;
   }
 
-  header code {
+  .capacity {
     display: block;
     margin-top: 0.2rem;
     color: var(--muted);
     font-size: 0.78rem;
-  }
-
-  .capacity {
-    color: var(--muted);
-    font-size: 0.78rem;
     font-variant-numeric: tabular-nums;
-    white-space: nowrap;
   }
 
   .swatches {
     display: flex;
+    width: min(100%, 52rem);
     min-width: 0;
     margin: 0;
     padding: 0;
     overflow-x: auto;
     list-style: none;
+    gap: 2px;
   }
 
   .swatches li {
-    display: grid;
-    flex: 0 0 3.5rem;
-    gap: 0.35rem;
+    flex: 1 1 0;
+    min-width: 1.25rem;
   }
 
   .swatches span {
@@ -135,12 +111,8 @@
     background: var(--swatch);
   }
 
-  .swatches code {
-    color: var(--muted);
-    font-size: 0.6rem;
-  }
-
-  .plot {
+  .plot-panel {
+    width: min(100%, 52rem);
     min-width: 0;
   }
 </style>

--- a/apps/docs/src/lib/components/SequentialColorLab.svelte
+++ b/apps/docs/src/lib/components/SequentialColorLab.svelte
@@ -1,57 +1,74 @@
 <script lang="ts">
-  import { GeomPoint, GGPlot } from "@ggsvelte/svelte";
+  import { GeomRaster, GGPlot } from "@ggsvelte/svelte";
   import type { ColorScaleSpec } from "@ggsvelte/spec";
 
   import { VIRIDIS_COLORS } from "$lib/catalog/themes";
   import CopyCode from "$lib/components/CopyCode.svelte";
+  import { RASTER_Z_DOMAIN } from "$lib/theme-specimens/catalog";
+  import { grid } from "$lib/theme-specimens/data";
 
   interface SequentialExample {
     label: string;
     scale: ColorScaleSpec;
-    setting: string;
   }
-
-  const rows = [
-    { sequence: 1, score: 18, intensity: 0 },
-    { sequence: 2, score: 28, intensity: 20 },
-    { sequence: 3, score: 39, intensity: 40 },
-    { sequence: 4, score: 53, intensity: 60 },
-    { sequence: 5, score: 67, intensity: 80 },
-    { sequence: 6, score: 82, intensity: 100 },
-  ];
 
   const examples: readonly SequentialExample[] = [
     {
       label: "Viridis",
       scale: { type: "sequential", scheme: "viridis" },
-      setting: 'scheme: "viridis"',
     },
     {
       label: "Reversed",
       scale: { type: "sequential", scheme: "viridis", reverse: true },
-      setting: 'scheme: "viridis", reverse: true',
     },
     {
       label: "Custom range",
-      scale: { type: "sequential", range: ["#2d1e2f", "#3d5a80", "#e76f51"] },
-      setting: 'range: ["#2d1e2f", "#3d5a80", "#e76f51"]',
+      scale: {
+        type: "sequential",
+        range: ["#2d1e2f", "#3d5a80", "#e76f51"],
+      },
     },
     {
       label: "Pinned domain",
-      scale: { type: "sequential", scheme: "viridis", domain: [0, 100] },
-      setting: 'scheme: "viridis", domain: [0, 100]',
+      scale: {
+        type: "sequential",
+        scheme: "viridis",
+        domain: [...RASTER_Z_DOMAIN],
+      },
     },
   ];
 
-  function snippet(example: SequentialExample): string {
-    return `<GGPlot
-  data={rows}
-  aes={{ x: "sequence", y: "score", color: "intensity" }}
-  scales={{ color: { ${example.setting} } }}
->
-  <GeomPoint size={4} />
-</GGPlot>`;
-  }
+  const scriptClose = "</" + "script>";
+
+  /** Single section-level authoring fragment — not repeated per ramp. */
+  const sectionFragment = [
+    `<script lang="ts">`,
+    `  import { GeomRaster, GGPlot } from "@ggsvelte/svelte";`,
+    ``,
+    `  // Regular x/y/z surface (48 cells in the live demos).`,
+    `  const grid = [`,
+    `    { x: 0, y: 0, z: 0.12 },`,
+    `    { x: 1, y: 0, z: 0.45 },`,
+    `    { x: 2, y: 0, z: 0.88 },`,
+    `    // …`,
+    `  ];`,
+    scriptClose,
+    ``,
+    `<GGPlot`,
+    `  data={grid}`,
+    `  aes={{ x: "x", y: "y", fill: "z" }}`,
+    `  scales={{`,
+    `    fill: { type: "sequential", scheme: "viridis" },`,
+    `    // reverse: true`,
+    `    // domain: [0.3, 0.7]  // pin inside actual z`,
+    `    // range: ["#2d1e2f", "#3d5a80", "#e76f51"]`,
+    `  }}`,
+    `  labs={{ title: "Density surface", x: "x", y: "y" }}`,
+    `  height={400}`,
+    `>`,
+    `  <GeomRaster />`,
+    `</GGPlot>`,
+  ].join("\n");
 </script>
 
 <section class="sequential-lab" aria-label="Sequential color scales">
@@ -70,6 +87,11 @@
     </ol>
   </header>
 
+  <p class="lede">
+    Continuous fill on a density surface. Reverse, custom range, and pinned
+    domain should read clearly on the colorbar — not only on a few dots.
+  </p>
+
   <ol class="examples" aria-label="Sequential scale examples">
     {#each examples as example (example.label)}
       <li>
@@ -77,27 +99,38 @@
           <header>
             <h3>{example.label}</h3>
           </header>
-          <div class="plot">
+          <div class="plot-panel">
             <GGPlot
-              data={rows}
-              aes={{ x: "sequence", y: "score", color: "intensity" }}
-              scales={{ color: example.scale }}
+              data={grid}
+              aes={{ x: "x", y: "y", fill: "z" }}
+              scales={{ fill: example.scale }}
               theme="light"
-              height={280}
+              labs={{
+                title: `${example.label} density surface`,
+                x: "x",
+                y: "y",
+                fill: "z",
+              }}
+              inspect={{ mode: "xy" }}
+              height={360}
               ariaLabel={`${example.label} sequential color example`}
             >
-              <GeomPoint size={4} />
+              <GeomRaster />
             </GGPlot>
           </div>
-          <CopyCode
-            code={snippet(example)}
-            language="svelte"
-            accessibleLabel={`Copy ${example.label} code`}
-          />
         </article>
       </li>
     {/each}
   </ol>
+
+  <div class="section-code">
+    <p class="fragment-label">Authoring fragment</p>
+    <CopyCode
+      code={sectionFragment}
+      language="svelte"
+      accessibleLabel="Copy sequential raster authoring fragment"
+    />
+  </div>
 </section>
 
 <style>
@@ -122,7 +155,7 @@
     justify-content: space-between;
     gap: 1rem 2rem;
     min-width: 0;
-    margin-bottom: 1.5rem;
+    margin-bottom: 0.75rem;
   }
 
   h2 {
@@ -130,6 +163,14 @@
     font-size: clamp(1.75rem, 3.5vw, 2.5rem);
     line-height: 1;
     letter-spacing: -0.02em;
+  }
+
+  .lede {
+    margin: 0 0 1.5rem;
+    max-width: 40rem;
+    color: var(--muted);
+    font-size: 0.95rem;
+    line-height: 1.45;
   }
 
   .viridis-ramp {
@@ -149,8 +190,8 @@
 
   .examples {
     display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: clamp(2rem, 4vw, 3rem) clamp(1.5rem, 3vw, 2.5rem);
+    grid-template-columns: 1fr;
+    gap: clamp(2.5rem, 5vw, 4rem);
     margin: 0;
     padding: 0;
     list-style: none;
@@ -158,7 +199,7 @@
 
   article {
     display: grid;
-    gap: 0.75rem;
+    gap: 0.65rem;
     min-width: 0;
   }
 
@@ -168,13 +209,22 @@
     letter-spacing: -0.01em;
   }
 
-  .plot {
+  .plot-panel {
+    width: min(100%, 52rem);
     min-width: 0;
   }
 
-  @media (max-width: 50rem) {
-    .examples {
-      grid-template-columns: 1fr;
-    }
+  .section-code {
+    width: min(100%, 52rem);
+    margin-top: clamp(2rem, 4vw, 3rem);
+  }
+
+  .fragment-label {
+    margin: 0 0 0.5rem;
+    color: var(--muted);
+    font-size: 0.78rem;
+    font-weight: 650;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
   }
 </style>

--- a/apps/docs/src/lib/components/SequentialColorLab.svelte
+++ b/apps/docs/src/lib/components/SequentialColorLab.svelte
@@ -6,6 +6,7 @@
   import CopyCode from "$lib/components/CopyCode.svelte";
   import { RASTER_Z_DOMAIN } from "$lib/theme-specimens/catalog";
   import { grid } from "$lib/theme-specimens/data";
+  import { SEQUENTIAL_RASTER_SNIPPET } from "$lib/theme-specimens/snippets";
 
   interface SequentialExample {
     label: string;
@@ -37,38 +38,6 @@
       },
     },
   ];
-
-  const scriptClose = "</" + "script>";
-
-  /** Single section-level authoring fragment — not repeated per ramp. */
-  const sectionFragment = [
-    `<script lang="ts">`,
-    `  import { GeomRaster, GGPlot } from "@ggsvelte/svelte";`,
-    ``,
-    `  // Regular x/y/z surface (48 cells in the live demos).`,
-    `  const grid = [`,
-    `    { x: 0, y: 0, z: 0.12 },`,
-    `    { x: 1, y: 0, z: 0.45 },`,
-    `    { x: 2, y: 0, z: 0.88 },`,
-    `    // …`,
-    `  ];`,
-    scriptClose,
-    ``,
-    `<GGPlot`,
-    `  data={grid}`,
-    `  aes={{ x: "x", y: "y", fill: "z" }}`,
-    `  scales={{`,
-    `    fill: { type: "sequential", scheme: "viridis" },`,
-    `    // reverse: true`,
-    `    // domain: [0.3, 0.7]  // pin inside actual z`,
-    `    // range: ["#2d1e2f", "#3d5a80", "#e76f51"]`,
-    `  }}`,
-    `  labs={{ title: "Density surface", x: "x", y: "y" }}`,
-    `  height={400}`,
-    `>`,
-    `  <GeomRaster />`,
-    `</GGPlot>`,
-  ].join("\n");
 </script>
 
 <section class="sequential-lab" aria-label="Sequential color scales">
@@ -126,7 +95,7 @@
   <div class="section-code">
     <p class="fragment-label">Authoring fragment</p>
     <CopyCode
-      code={sectionFragment}
+      code={SEQUENTIAL_RASTER_SNIPPET}
       language="svelte"
       accessibleLabel="Copy sequential raster authoring fragment"
     />

--- a/apps/docs/src/lib/components/ThemeSpecimen.svelte
+++ b/apps/docs/src/lib/components/ThemeSpecimen.svelte
@@ -1,80 +1,256 @@
 <script lang="ts">
-  import { GeomPoint, GGPlot } from "@ggsvelte/svelte";
+  import {
+    GeomArea,
+    GeomBar,
+    GeomCol,
+    GeomLine,
+    GeomPoint,
+    GeomSmooth,
+    GeomText,
+    GGPlot,
+    scaleXLog10,
+  } from "@ggsvelte/svelte";
   import type { ThemeName } from "@ggsvelte/spec";
-  import { CATEGORICAL_SCHEME_NAMES } from "@ggsvelte/spec";
 
-  import CopyCode from "$lib/components/CopyCode.svelte";
-
-  type SchemeName = (typeof CATEGORICAL_SCHEME_NAMES)[number];
+  import type {
+    SchemeName,
+    ThemeSpecimenKind,
+  } from "$lib/theme-specimens/catalog";
+  import { MONTH_BREAKS } from "$lib/theme-specimens/catalog";
+  import {
+    attendees,
+    cities,
+    countries,
+    generation,
+    longRunSeries,
+    penguins,
+    revenue,
+    ridership,
+    temperaturesKeyed,
+  } from "$lib/theme-specimens/data";
 
   const {
     name,
     label,
+    caption,
+    kind,
     scheme,
+    legendFocus,
   }: {
     name: ThemeName;
     label: string;
+    caption: string;
+    kind: ThemeSpecimenKind;
     scheme: SchemeName;
+    legendFocus: boolean;
   } = $props();
 
-  const rows = [
-    { release: 1, response: 18, group: "North" },
-    { release: 2, response: 31, group: "North" },
-    { release: 3, response: 43, group: "North" },
-    { release: 4, response: 56, group: "North" },
-    { release: 1, response: 27, group: "South" },
-    { release: 2, response: 39, group: "South" },
-    { release: 3, response: 52, group: "South" },
-    { release: 4, response: 68, group: "South" },
-  ];
-  const code = $derived(
-    `<GGPlot
-  data={rows}
-  aes={{ x: "release", y: "response", color: "group" }}
-  theme="${name}"
-  scales={{ color: { scheme: "${scheme}" } }}
->
-  <GeomPoint size={3.5} />
-</GGPlot>`,
-  );
+  const plotHeight = 380;
+  const colorScale = $derived({ type: "ordinal" as const, scheme });
 </script>
 
-<article>
+<article class="specimen">
   <header>
     <h3>{label}</h3>
-    <code>theme="{name}"</code>
+    <p class="caption">{caption}</p>
   </header>
-  <div class="plot">
-    <GGPlot
-      data={rows}
-      aes={{ x: "release", y: "response", color: "group" }}
-      theme={name}
-      scales={{ color: { type: "ordinal", scheme } }}
-      height={280}
-      ariaLabel={`${label} theme with ${scheme} palette`}
-    >
-      <GeomPoint size={3.5} />
-    </GGPlot>
+
+  <div class="plot-panel">
+    {#if kind === "temps-line"}
+      <GGPlot
+        data={temperaturesKeyed}
+        aes={{ x: "month", y: "temp", color: "city" }}
+        theme={name}
+        scales={{
+          x: { breaks: [...MONTH_BREAKS] },
+          color: colorScale,
+        }}
+        labs={{
+          title: "Monthly mean temperature",
+          x: "Month",
+          y: "Temperature (°C)",
+          color: "City",
+        }}
+        key="id"
+        inspect={{ mode: "x" }}
+        {legendFocus}
+        height={plotHeight}
+        ariaLabel={`${label} theme multi-series temperatures`}
+      >
+        <GeomLine linewidth={2} />
+        <GeomPoint size={2.5} />
+      </GGPlot>
+    {:else if kind === "ridership-line"}
+      <GGPlot
+        data={ridership}
+        aes={{ x: "month", y: "riders", color: "mode" }}
+        theme={name}
+        scales={{ color: colorScale }}
+        labs={{
+          title: "Daily transit ridership",
+          x: "Month",
+          y: "Daily riders (thousands)",
+          color: "Mode",
+        }}
+        key="id"
+        inspect={{ mode: "x" }}
+        {legendFocus}
+        height={plotHeight}
+        ariaLabel={`${label} theme ridership series`}
+      >
+        <GeomLine linewidth={2} />
+        <GeomPoint size={2.8} />
+      </GGPlot>
+    {:else if kind === "attendees-dodge"}
+      <GGPlot
+        data={attendees}
+        aes={{ x: "track", fill: "level" }}
+        theme={name}
+        scales={{ fill: colorScale }}
+        labs={{
+          title: "Conference attendees by track and experience",
+          x: "Track",
+          y: "Attendees",
+          fill: "Experience",
+        }}
+        key="id"
+        inspect={{ mode: "xy" }}
+        {legendFocus}
+        height={plotHeight}
+        ariaLabel={`${label} theme dodged bars`}
+      >
+        <GeomBar position="dodge" />
+      </GGPlot>
+    {:else if kind === "generation-area"}
+      <GGPlot
+        data={generation}
+        aes={{ x: "year", y: "twh", fill: "source" }}
+        theme={name}
+        scales={{
+          x: { labels: "d", nice: false },
+          fill: colorScale,
+        }}
+        labs={{
+          title: "Electricity generation mix",
+          x: "Year",
+          y: "Generation (TWh)",
+          fill: "Source",
+        }}
+        key="id"
+        inspect={{ mode: "x" }}
+        {legendFocus}
+        height={plotHeight}
+        ariaLabel={`${label} theme stacked generation`}
+      >
+        <GeomArea alpha={0.9} />
+      </GGPlot>
+    {:else if kind === "long-run-line"}
+      <GGPlot
+        data={longRunSeries}
+        aes={{ x: "year", y: "value" }}
+        theme={name}
+        labs={{
+          title: "Long-run index, 1835–2025",
+          x: "Year",
+          y: "Index",
+        }}
+        inspect={{ mode: "x" }}
+        height={plotHeight}
+        ariaLabel={`${label} theme long-run series`}
+      >
+        <GeomLine linewidth={1.5} />
+      </GGPlot>
+    {:else if kind === "penguins-scatter"}
+      <GGPlot
+        data={penguins}
+        aes={{ x: "flipper", y: "mass", color: "species" }}
+        theme={name}
+        scales={{ color: colorScale }}
+        labs={{
+          title: "Penguin flipper length and body mass",
+          x: "Flipper length (mm)",
+          y: "Body mass (g)",
+          color: "Species",
+        }}
+        key="id"
+        inspect={{ mode: "xy" }}
+        {legendFocus}
+        height={plotHeight}
+        ariaLabel={`${label} theme penguin scatter`}
+      >
+        <GeomPoint size={3.5} alpha={0.9} />
+      </GGPlot>
+    {:else if kind === "countries-scatter"}
+      <GGPlot
+        data={countries}
+        aes={{ x: "gdp", y: "lifeExp", color: "region" }}
+        theme={name}
+        scales={{
+          ...scaleXLog10({ labels: "~s" }),
+          color: colorScale,
+        }}
+        labs={{
+          title: "Income and life expectancy",
+          x: "GDP per capita (USD, log scale)",
+          y: "Life expectancy (years)",
+          color: "Region",
+        }}
+        key="country"
+        inspect={{ mode: "xy" }}
+        {legendFocus}
+        height={plotHeight}
+        ariaLabel={`${label} theme income scatter`}
+      >
+        <GeomPoint size={3.5} />
+        <GeomSmooth method="lm" se={false} />
+      </GGPlot>
+    {:else if kind === "revenue-cols"}
+      <GGPlot
+        data={revenue}
+        aes={{ x: "quarter", y: "amount" }}
+        theme={name}
+        labs={{
+          title: "Quarterly revenue",
+          x: "Quarter",
+          y: "Revenue (€ thousands)",
+        }}
+        inspect={{ mode: "xy" }}
+        height={plotHeight}
+        ariaLabel={`${label} theme revenue columns`}
+      >
+        <GeomCol width={0.7} />
+        <GeomText aes={{ label: "label" }} dy={-8} size={11} />
+      </GGPlot>
+    {:else}
+      <GGPlot
+        data={cities}
+        aes={{ x: "rent", y: "livability" }}
+        theme={name}
+        scales={{ x: { labels: ",d" } }}
+        labs={{
+          title: "Livability vs median rent",
+          x: "Median monthly rent (USD)",
+          y: "Livability index",
+        }}
+        inspect={{ mode: "xy" }}
+        height={plotHeight}
+        ariaLabel={`${label} theme labeled cities`}
+      >
+        <GeomPoint size={3} />
+        <GeomText aes={{ label: "city" }} dy={-9} size={10} />
+      </GGPlot>
+    {/if}
   </div>
-  <CopyCode
-    {code}
-    language="svelte"
-    accessibleLabel={`Copy ${label} theme code`}
-  />
 </article>
 
 <style>
-  article {
+  .specimen {
     display: grid;
-    gap: 0.75rem;
+    gap: 0.65rem;
     min-width: 0;
   }
 
   header {
-    display: flex;
-    align-items: baseline;
-    justify-content: space-between;
-    gap: 1rem;
     min-width: 0;
   }
 
@@ -84,13 +260,16 @@
     letter-spacing: -0.01em;
   }
 
-  header > code {
+  .caption {
+    margin: 0.25rem 0 0;
+    max-width: 40rem;
     color: var(--muted);
-    font-size: 0.78rem;
-    white-space: nowrap;
+    font-size: 0.9rem;
+    line-height: 1.4;
   }
 
-  .plot {
+  .plot-panel {
+    width: min(100%, 52rem);
     min-width: 0;
   }
 </style>

--- a/apps/docs/src/lib/theme-specimens/catalog.ts
+++ b/apps/docs/src/lib/theme-specimens/catalog.ts
@@ -1,0 +1,145 @@
+import type { ThemeName } from "@ggsvelte/spec";
+import { CATEGORICAL_SCHEME_NAMES } from "@ggsvelte/spec";
+
+import { THEME_OPTIONS } from "$lib/catalog/themes";
+
+export type SchemeName = (typeof CATEGORICAL_SCHEME_NAMES)[number];
+
+/**
+ * Specimen chart kinds. Each maps to a real example corpus + geom stack that
+ * showcases the theme's furniture personality (panel, grid, axes, type).
+ */
+export type ThemeSpecimenKind =
+  | "temps-line"
+  | "ridership-line"
+  | "attendees-dodge"
+  | "generation-area"
+  | "long-run-line"
+  | "penguins-scatter"
+  | "countries-scatter"
+  | "revenue-cols"
+  | "cities-labels";
+
+export type ThemeSpecimenConfig = {
+  readonly name: ThemeName;
+  readonly label: string;
+  readonly caption: string;
+  readonly kind: ThemeSpecimenKind;
+  readonly scheme: SchemeName;
+  /** Discrete color/fill legend present — enable legendFocus. */
+  readonly legendFocus: boolean;
+};
+
+const BY_NAME = Object.fromEntries(THEME_OPTIONS.map((theme) => [theme.name, theme])) as Record<
+  ThemeName,
+  (typeof THEME_OPTIONS)[number]
+>;
+
+/** Full-width theme portrait rows, catalog order (default → tufte). */
+export const THEME_SPECIMENS: readonly ThemeSpecimenConfig[] = [
+  {
+    name: "default",
+    label: BY_NAME.default.label,
+    caption: "Hairline grids, no heavy frame — multi-series default hierarchy.",
+    kind: "temps-line",
+    scheme: BY_NAME.default.scheme,
+    legendFocus: true,
+  },
+  {
+    name: "light",
+    label: BY_NAME.light.label,
+    caption: "Fine ticks and a light panel border around categorical groups.",
+    kind: "attendees-dodge",
+    scheme: BY_NAME.light.scheme,
+    legendFocus: true,
+  },
+  {
+    name: "dark",
+    label: BY_NAME.dark.label,
+    caption: "Low-glare dark paper; large fills carry the series.",
+    kind: "generation-area",
+    scheme: BY_NAME.dark.scheme,
+    legendFocus: true,
+  },
+  {
+    name: "minimal",
+    label: BY_NAME.minimal.label,
+    caption: "Quiet grid and reduced type hierarchy on a single series.",
+    kind: "long-run-line",
+    scheme: BY_NAME.minimal.scheme,
+    legendFocus: false,
+  },
+  {
+    name: "ggplot2",
+    label: BY_NAME.ggplot2.label,
+    caption: "Gray panel and white grid — the classic R silhouette.",
+    kind: "penguins-scatter",
+    scheme: BY_NAME.ggplot2.scheme,
+    legendFocus: true,
+  },
+  {
+    name: "classic",
+    label: BY_NAME.classic.label,
+    caption: "Black axes and ticks, no grid — framed research scatter.",
+    kind: "countries-scatter",
+    scheme: BY_NAME.classic.scheme,
+    legendFocus: true,
+  },
+  {
+    name: "hrbr",
+    label: BY_NAME.hrbr.label,
+    caption: "Same quiet hierarchy as default; ipsum series colors.",
+    kind: "ridership-line",
+    scheme: BY_NAME.hrbr.scheme,
+    legendFocus: true,
+  },
+  {
+    name: "few",
+    label: BY_NAME.few.label,
+    caption: "Panel border and ticks, no grid — business comparisons.",
+    kind: "attendees-dodge",
+    scheme: BY_NAME.few.scheme,
+    legendFocus: true,
+  },
+  {
+    name: "clean",
+    label: BY_NAME.clean.label,
+    caption: "Dashed grids, axis lines, and value labels.",
+    kind: "revenue-cols",
+    scheme: BY_NAME.clean.scheme,
+    legendFocus: false,
+  },
+  {
+    name: "fivethirtyeight",
+    label: BY_NAME.fivethirtyeight.label,
+    caption: "Gray paper and white grid — editorial stacked mix.",
+    kind: "generation-area",
+    scheme: BY_NAME.fivethirtyeight.scheme,
+    legendFocus: true,
+  },
+  {
+    name: "economist",
+    label: BY_NAME.economist.label,
+    caption: "Cool blue paper and magazine multi-series strokes.",
+    kind: "ridership-line",
+    scheme: BY_NAME.economist.scheme,
+    legendFocus: true,
+  },
+  {
+    name: "tufte",
+    label: BY_NAME.tufte.label,
+    caption: "No grid; labels carry the structure.",
+    kind: "cities-labels",
+    scheme: BY_NAME.tufte.scheme,
+    legendFocus: false,
+  },
+];
+
+/** Month breaks shared by climate multi-series charts. */
+export const MONTH_BREAKS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] as const;
+
+/**
+ * Continuous z on the raster density surface is roughly 0–1.
+ * Pinned domain uses a mid interval so extremes clip visibly.
+ */
+export const RASTER_Z_DOMAIN = [0.3, 0.7] as const;

--- a/apps/docs/src/lib/theme-specimens/catalog.ts
+++ b/apps/docs/src/lib/theme-specimens/catalog.ts
@@ -1,7 +1,9 @@
 import type { ThemeName } from "@ggsvelte/spec";
 import { CATEGORICAL_SCHEME_NAMES } from "@ggsvelte/spec";
 
-import { THEME_OPTIONS } from "$lib/catalog/themes";
+// Relative import so bun unit tests (scripts/themes-page.test.ts) resolve without
+// the SvelteKit `$lib` alias.
+import { THEME_OPTIONS } from "../catalog/themes.js";
 
 export type SchemeName = (typeof CATEGORICAL_SCHEME_NAMES)[number];
 

--- a/apps/docs/src/lib/theme-specimens/data.ts
+++ b/apps/docs/src/lib/theme-specimens/data.ts
@@ -1,0 +1,40 @@
+/**
+ * Docs-only re-exports of example corpora for the /themes showcase.
+ * Never surface `$examples` paths in consumer-facing CopyCode snippets.
+ */
+export { languages } from "$examples/col/basic/data";
+export { revenue } from "$examples/col/value-labels/data";
+export { ridership } from "$examples/interaction/legend-filter/data";
+export { longRunSeries } from "$examples/line/time-axis/data";
+export { countries } from "$examples/point/log-scale/data";
+export { grid } from "$examples/raster/grid/data";
+export { cities } from "$examples/text/labels/data";
+
+import { generation as rawGeneration } from "$examples/area/stacked/data";
+import { attendees as rawAttendees } from "$examples/bar/dodged/data";
+import { temperatures as rawTemperatures } from "$examples/line/multi-series/data";
+import { penguins as rawPenguins } from "$examples/point/scatter-color/data";
+
+/** Climate normals with stable row keys for legend focus / inspect. */
+export const temperaturesKeyed = rawTemperatures.map((row) => ({
+  ...row,
+  id: `${row.city}-${String(row.month)}`,
+}));
+
+/** Generation mix with stable keys for legend focus. */
+export const generation = rawGeneration.map((row) => ({
+  ...row,
+  id: `${row.source}-${String(row.year)}`,
+}));
+
+/** Conference attendees with stable keys for legend focus. */
+export const attendees = rawAttendees.map((row, index) => ({
+  ...row,
+  id: `attendee-${String(index)}`,
+}));
+
+/** Penguins with stable keys for legend focus. */
+export const penguins = rawPenguins.map((row, index) => ({
+  ...row,
+  id: `${row.species}-${String(index)}`,
+}));

--- a/apps/docs/src/lib/theme-specimens/snippets.ts
+++ b/apps/docs/src/lib/theme-specimens/snippets.ts
@@ -1,0 +1,69 @@
+/**
+ * Consumer-facing code fragments for the themes page.
+ * Kept outside .svelte so the compiler never sees a literal </script> close tag.
+ */
+
+export function heroThemePaletteSnippet(theme: string, scheme: string): string {
+  return `<script lang="ts">
+  import { GeomLine, GeomPoint, GGPlot } from "@ggsvelte/svelte";
+
+  const temperatures = [
+    { city: "Reykjavik", month: 1, temp: -0.5 },
+    { city: "Reykjavik", month: 7, temp: 10.6 },
+    { city: "Berlin", month: 1, temp: 0.6 },
+    { city: "Berlin", month: 7, temp: 19.0 },
+    { city: "Singapore", month: 1, temp: 26.5 },
+    { city: "Singapore", month: 7, temp: 27.9 },
+    // …full series in your app
+  ];
+</script>
+
+<GGPlot
+  data={temperatures}
+  aes={{ x: "month", y: "temp", color: "city" }}
+  theme="${theme}"
+  scales={{
+    x: { breaks: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] },
+    color: { type: "ordinal", scheme: "${scheme}" },
+  }}
+  labs={{
+    title: "Monthly mean temperature",
+    x: "Month",
+    y: "Temperature (°C)",
+    color: "City",
+  }}
+  inspect={{ mode: "x" }}
+  legendFocus
+  height={400}
+>
+  <GeomLine linewidth={2} />
+  <GeomPoint size={2.5} />
+</GGPlot>`;
+}
+
+export const SEQUENTIAL_RASTER_SNIPPET = `<script lang="ts">
+  import { GeomRaster, GGPlot } from "@ggsvelte/svelte";
+
+  // Regular x/y/z surface (48 cells in the live demos).
+  const grid = [
+    { x: 0, y: 0, z: 0.12 },
+    { x: 1, y: 0, z: 0.45 },
+    { x: 2, y: 0, z: 0.88 },
+    // …
+  ];
+</script>
+
+<GGPlot
+  data={grid}
+  aes={{ x: "x", y: "y", fill: "z" }}
+  scales={{
+    fill: { type: "sequential", scheme: "viridis" },
+    // reverse: true
+    // domain: [0.3, 0.7]  // pin inside actual z
+    // range: ["#2d1e2f", "#3d5a80", "#e76f51"]
+  }}
+  labs={{ title: "Density surface", x: "x", y: "y" }}
+  height={400}
+>
+  <GeomRaster />
+</GGPlot>`;

--- a/apps/docs/src/routes/themes/+page.svelte
+++ b/apps/docs/src/routes/themes/+page.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
-  import { THEME_OPTIONS } from "$lib/catalog/themes";
+  import { base } from "$app/paths";
+
   import ChartThemeLab from "$lib/components/ChartThemeLab.svelte";
   import PaletteGallery from "$lib/components/PaletteGallery.svelte";
   import SequentialColorLab from "$lib/components/SequentialColorLab.svelte";
   import ThemeSpecimen from "$lib/components/ThemeSpecimen.svelte";
+  import { THEME_SPECIMENS } from "$lib/theme-specimens/catalog";
 </script>
 
 <main class="themes-page">
@@ -11,8 +13,12 @@
     <p class="eyebrow">Themes</p>
     <h1>Themes and color</h1>
     <p>
-      Built-in chart themes, categorical palettes, and sequential scales. Chart
-      theme is independent of site light/dark.
+      Chart themes style paper, grids, axes, and type. Palettes encode data.
+      Site light/dark is separate unless you wire them yourself.
+    </p>
+    <p class="guide-link">
+      Token-level theme and scale reference:
+      <a href={`${base}/guide/themes-color`}>Themes and color guide</a>.
     </p>
   </header>
 
@@ -24,12 +30,15 @@
       <h2 id="built-in-themes-heading">Chart themes</h2>
     </header>
     <ol aria-label="Built-in chart themes">
-      {#each THEME_OPTIONS as theme (theme.name)}
+      {#each THEME_SPECIMENS as specimen (specimen.name)}
         <li>
           <ThemeSpecimen
-            name={theme.name}
-            label={theme.label}
-            scheme={theme.scheme}
+            name={specimen.name}
+            label={specimen.label}
+            caption={specimen.caption}
+            kind={specimen.kind}
+            scheme={specimen.scheme}
+            legendFocus={specimen.legendFocus}
           />
         </li>
       {/each}
@@ -38,6 +47,28 @@
 
   <PaletteGallery />
   <SequentialColorLab />
+
+  <nav class="learning-path" aria-label="Next steps">
+    <p class="eyebrow">Next</p>
+    <ul>
+      <li>
+        <a href={`${base}/guide/themes-color`}>Themes and color guide</a>
+        — prop model and color rules
+      </li>
+      <li>
+        <a href={`${base}/examples/line/multi-series`}>Multi-series line</a>,
+        <a href={`${base}/examples/area/stacked`}>stacked area</a>,
+        <a href={`${base}/examples/bar/dodged`}>dodged bars</a>
+        — gallery sources for these charts
+      </li>
+      <li>
+        <a href={`${base}/examples/interaction/tooltip`}>Inspect</a>
+        and
+        <a href={`${base}/examples/interaction/legend-focus`}>legend focus</a>
+        — interaction props used on this page
+      </li>
+    </ul>
+  </nav>
 </main>
 
 <style>
@@ -59,10 +90,20 @@
     letter-spacing: -0.03em;
   }
 
-  .themes-intro > p:last-child {
+  .themes-intro > p:not(.eyebrow, .guide-link) {
     margin: 0;
     color: var(--muted);
     font-size: 1.02rem;
+  }
+
+  .guide-link {
+    margin: 0.85rem 0 0;
+    color: var(--muted);
+    font-size: 0.92rem;
+  }
+
+  .guide-link a {
+    color: var(--ink);
   }
 
   .eyebrow {
@@ -92,8 +133,8 @@
 
   ol {
     display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: clamp(2rem, 4vw, 3rem) clamp(1.5rem, 3vw, 2.5rem);
+    grid-template-columns: 1fr;
+    gap: clamp(2.5rem, 5vw, 4rem);
     margin: 0;
     padding: 0;
     list-style: none;
@@ -103,9 +144,24 @@
     min-width: 0;
   }
 
-  @media (max-width: 50rem) {
-    ol {
-      grid-template-columns: 1fr;
-    }
+  .learning-path {
+    padding-block: clamp(2rem, 5vw, 3.5rem);
+    border-top: 1px solid var(--line);
+  }
+
+  .learning-path ul {
+    margin: 0.75rem 0 0;
+    padding: 0;
+    list-style: none;
+    display: grid;
+    gap: 0.55rem;
+    max-width: 42rem;
+    color: var(--muted);
+    font-size: 0.95rem;
+    line-height: 1.45;
+  }
+
+  .learning-path a {
+    color: var(--ink);
   }
 </style>

--- a/scripts/themes-page.test.ts
+++ b/scripts/themes-page.test.ts
@@ -6,6 +6,7 @@ import {
   VIRIDIS_COLORS,
 } from "../apps/docs/src/lib/catalog/themes.ts";
 import { colorBehaviorEvidence } from "../apps/docs/src/lib/color-evidence.ts";
+import { RASTER_Z_DOMAIN, THEME_SPECIMENS } from "../apps/docs/src/lib/theme-specimens/catalog.ts";
 
 describe("themes catalog", () => {
   it("projects every public theme and categorical palette without docs-owned colors", () => {
@@ -119,6 +120,24 @@ describe("themes catalog", () => {
       "#b5de2b",
       "#fde725",
     ]);
+  });
+
+  it("lists every public theme as a full-width specimen with a real chart kind", () => {
+    expect(THEME_SPECIMENS.map((specimen) => specimen.name)).toEqual(
+      THEME_OPTIONS.map((theme) => theme.name),
+    );
+    for (const specimen of THEME_SPECIMENS) {
+      expect(specimen.caption.length).toBeGreaterThan(12);
+      expect(specimen.caption.length).toBeLessThanOrEqual(96);
+      expect(specimen.scheme).toBe(
+        THEME_OPTIONS.find((theme) => theme.name === specimen.name)!.scheme,
+      );
+    }
+    expect(new Set(THEME_SPECIMENS.map((specimen) => specimen.kind)).size).toBeGreaterThanOrEqual(
+      6,
+    );
+    expect(RASTER_Z_DOMAIN[0]).toBeLessThan(RASTER_Z_DOMAIN[1]);
+    expect(RASTER_Z_DOMAIN[1]).toBeLessThanOrEqual(1);
   });
 
   it("reports incompatible schemes and palette exhaustion through public boundaries", () => {

--- a/tests/visual/docs-themes.spec.ts
+++ b/tests/visual/docs-themes.spec.ts
@@ -25,18 +25,18 @@ test("theme code uses the shared manual-copy fallback", async ({ page }) => {
     });
   });
   await page.goto("/themes?theme=light");
-  const defaultCard = page
-    .getByRole("list", { name: "Built-in chart themes" })
-    .locator(":scope > li")
-    .first();
-  await defaultCard.getByRole("button", { name: "Copy Default theme code" }).click();
-  await expect(defaultCard.getByRole("status")).toHaveText(
+  // Only the hero lab retains a CopyCode block after the showcase overhaul.
+  const lab = page.getByRole("region", { name: "Chart theme and palette lab" });
+  await lab.getByRole("button", { name: "Copy selected theme and palette code" }).click();
+  await expect(lab.getByRole("status").filter({ hasText: "Clipboard unavailable" })).toHaveText(
     "Clipboard unavailable. Code selected for manual copy.",
   );
   expect(await page.evaluate(() => getSelection()?.toString())).toContain('theme="default"');
 });
 
-test("themes compares all built-in chart themes on the same live chart", async ({ page }) => {
+test("themes compares all built-in chart themes as full-width interactive portraits", async ({
+  page,
+}) => {
   await page.goto("/themes?theme=light");
 
   const list = page.getByRole("list", { name: "Built-in chart themes" });
@@ -59,8 +59,10 @@ test("themes compares all built-in chart themes on the same live chart", async (
 
   for (const specimen of await specimens.all()) {
     await expect(specimen.locator(".gg-plot-root")).toHaveAttribute("data-gg-ready", "true");
-    await expect(specimen.locator(".gg-points circle")).toHaveCount(8);
-    await expect(specimen.getByRole("button", { name: /^Copy .+ theme code$/ })).toBeVisible();
+    // No per-specimen CopyCode after the redesign.
+    await expect(specimen.getByRole("button", { name: /^Copy / })).toHaveCount(0);
+    // Charts use real corpora — never the old 8-dot synthetic scatter.
+    await expect(specimen.locator(".gg-plot-root")).toBeVisible();
   }
 });
 
@@ -68,8 +70,9 @@ test("chart theme stays separate until follow-docs appearance is explicit", asyn
   await page.setViewportSize({ width: 1280, height: 900 });
   await page.goto("/themes?theme=light");
 
-  const lab = page.getByRole("region", { name: "Chart theme lab" });
+  const lab = page.getByRole("region", { name: "Chart theme and palette lab" });
   const chartTheme = lab.getByLabel("Chart theme", { exact: true });
+  const palette = lab.getByLabel("Categorical palette", { exact: true });
   const follow = lab.getByRole("checkbox", { name: "Follow docs appearance" });
   const plot = lab.locator(".gg-plot-root");
   const chartPaper = () => plot.locator(".gg-paper").getAttribute("fill");
@@ -77,11 +80,19 @@ test("chart theme stays separate until follow-docs appearance is explicit", asyn
   await chartTheme.selectOption("economist");
   await expect(lab.locator(".copy-code code")).toContainText('theme="economist"');
   await expect.poll(chartPaper).toBe("var(--gg-paper, #d5e4eb)");
+  // Palette is independent of theme.
+  await palette.selectOption("tableau10");
+  await expect(lab.locator(".copy-code code")).toContainText('scheme: "tableau10"');
+  await expect(lab.locator(".copy-code code")).toContainText('theme="economist"');
+
   await page.getByRole("button", { name: "Dark appearance" }).click();
   await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
   await expect.poll(chartPaper).toBe("var(--gg-paper, #d5e4eb)");
 
   await follow.check();
+  await expect(lab.getByRole("status").filter({ hasText: "follows site" })).toContainText(
+    'scheme="tableau10"',
+  );
   await expect(lab.locator(".copy-code code")).toContainText('theme="dark"');
   await expect.poll(chartPaper).toBe("var(--gg-paper, #16181d)");
   await page.getByRole("button", { name: "Light appearance" }).click();
@@ -89,10 +100,13 @@ test("chart theme stays separate until follow-docs appearance is explicit", asyn
 
   await follow.uncheck();
   await expect(chartTheme).toHaveValue("economist");
+  await expect(palette).toHaveValue("tableau10");
   await expect.poll(chartPaper).toBe("var(--gg-paper, #d5e4eb)");
 });
 
-test("categorical palettes show exact ordered colors and reverse", async ({ page }) => {
+test("categorical palettes show ordered swatches and reverse without hex code chrome", async ({
+  page,
+}) => {
   await page.goto("/themes?theme=light");
 
   const region = page.getByRole("region", { name: "Categorical palettes" });
@@ -114,38 +128,35 @@ test("categorical palettes show exact ordered colors and reverse", async ({ page
   ]);
 
   const observable = cards.first();
-  await expect(
-    observable.getByRole("list", { name: "Observable 10 ordered colors" }).getByRole("listitem"),
-  ).toHaveText([
-    "#4269d0",
-    "#efb118",
-    "#ff725c",
-    "#6cc5b0",
-    "#3ca951",
-    "#ff8ab7",
-    "#a463f2",
-    "#97bbf5",
-    "#9c6b4e",
-    "#9498a0",
-  ]);
-  const firstMark = observable.locator(".gg-points circle").first();
-  await expect(firstMark).toHaveAttribute("fill", "#4269d0");
-
-  await region.getByRole("checkbox", { name: "Reverse" }).check();
-  const reversedSwatches = observable
+  const swatches = observable
     .getByRole("list", { name: "Observable 10 ordered colors" })
     .getByRole("listitem");
-  await expect(reversedSwatches.first()).toHaveText("#9498a0");
-  await expect(reversedSwatches.last()).toHaveText("#4269d0");
-  await expect(firstMark).toHaveAttribute("fill", "#9498a0");
-  await expect(observable.locator(".copy-code code")).toContainText("reverse: true");
+  await expect(swatches).toHaveCount(10);
+  // Hex lives in accessible names only — not as visible code under every chip.
+  await expect(swatches.first()).toHaveAttribute("aria-label", "1: #4269d0");
+  await expect(swatches.last()).toHaveAttribute("aria-label", "10: #9498a0");
+  await expect(swatches.first().locator("code")).toHaveCount(0);
+
+  // Col chart uses fill (not the old 5-point scatter).
+  await expect(observable.locator(".gg-plot-root")).toHaveAttribute("data-gg-ready", "true");
+  const firstMark = observable.locator(".gg-plot-root [fill='#4269d0']").first();
+  await expect(firstMark).toBeVisible();
+
+  await region.getByRole("checkbox", { name: "Reverse" }).check();
+  await expect(swatches.first()).toHaveAttribute("aria-label", "1: #9498a0");
+  await expect(swatches.last()).toHaveAttribute("aria-label", "10: #4269d0");
+  await expect(observable.locator(".gg-plot-root [fill='#9498a0']").first()).toBeVisible();
+
+  // No per-palette CopyCode.
+  await expect(observable.getByRole("button", { name: /^Copy / })).toHaveCount(0);
+
   await region.getByLabel("Chart paper", { exact: true }).selectOption("dark");
   await expect(observable.locator(".gg-paper")).toHaveAttribute("fill", "var(--gg-paper, #16181d)");
-  await expect(observable.locator(".copy-code code")).toContainText('theme="dark"');
-  await expect(firstMark).toHaveAttribute("fill", "#9498a0");
 });
 
-test("sequential color compares direction, custom stops, and a pinned domain", async ({ page }) => {
+test("sequential color compares direction, custom stops, and a pinned domain on raster", async ({
+  page,
+}) => {
   await page.goto("/themes?theme=light");
 
   const region = page.getByRole("region", { name: "Sequential color scales" });
@@ -160,22 +171,25 @@ test("sequential color compares direction, custom stops, and a pinned domain", a
     "Pinned domain",
   ]);
 
-  const normalMarks = cards.nth(0).locator(".gg-points circle");
-  await expect(normalMarks.first()).toHaveAttribute("fill", "#440154");
-  await expect(normalMarks.last()).toHaveAttribute("fill", "#fde725");
-  const reversedMarks = cards.nth(1).locator(".gg-points circle");
-  await expect(reversedMarks.first()).toHaveAttribute("fill", "#fde725");
-  await expect(reversedMarks.last()).toHaveAttribute("fill", "#440154");
-  const customMarks = cards.nth(2).locator(".gg-points circle");
-  await expect(customMarks.first()).toHaveAttribute("fill", "#2d1e2f");
-  await expect(customMarks.last()).toHaveAttribute("fill", "#e76f51");
-  await expect(cards.nth(3).locator(".gg-legend-label").first()).toHaveText("0");
-  await expect(cards.nth(3).locator(".gg-legend-label").last()).toHaveText("100");
+  for (const card of await cards.all()) {
+    await expect(card.locator(".gg-plot-root")).toHaveAttribute("data-gg-ready", "true");
+    // Raster surface, not the old 6-point scatter.
+    await expect(card.locator(".gg-points circle")).toHaveCount(0);
+  }
 
-  await expect(cards.nth(0).locator(".copy-code code")).toContainText('scheme: "viridis"');
-  await expect(cards.nth(1).locator(".copy-code code")).toContainText("reverse: true");
-  await expect(cards.nth(2).locator(".copy-code code")).toContainText('range: ["#2d1e2f"');
-  await expect(cards.nth(3).locator(".copy-code code")).toContainText("domain: [0, 100]");
+  // Pinned domain uses actual density z (~0.3–0.7), not the old [0, 100] point lab.
+  const pinnedLabels = cards.nth(3).locator(".gg-legend-label");
+  await expect(pinnedLabels.first()).toBeVisible();
+  await expect(pinnedLabels.last()).toBeVisible();
+  const firstLabel = (await pinnedLabels.first().textContent()) ?? "";
+  const lastLabel = (await pinnedLabels.last().textContent()) ?? "";
+  expect(Number(firstLabel)).toBeLessThan(Number(lastLabel));
+  expect(Number(lastLabel)).toBeLessThanOrEqual(1);
+
+  // One section-level authoring fragment only (not four per-ramp code blocks).
+  await expect(region.getByRole("button", { name: /Copy sequential/ })).toHaveCount(1);
+  await expect(region.locator(".copy-code code")).toContainText('scheme: "viridis"');
+  await expect(region.locator(".copy-code code")).toContainText("GeomRaster");
 });
 
 for (const width of [375, 768, 1024, 1280, 1600]) {


### PR DESCRIPTION
## Summary

- Rebuild `/themes` so **charts dominate**: delete per-specimen code blocks and `theme="…"` / `scheme="…"` badges; keep one complete hero snippet.
- Hero lab: multi-series climate lines with **independent theme + palette** pickers, controls **below** the chart, quiet `inspect` + `legendFocus`.
- Each built-in theme gets a **full-width** portrait with a real example corpus and geom matched to furniture personality (area, bars, scatter, lines, labels).
- Palettes: 8-language columns + swatches without hex code strips; sequential ramps use **raster density** surfaces with correct domain pinning.

## Test plan

- [x] `bun test scripts/themes-page.test.ts`
- [x] `svelte-check` clean for docs after package rebuild
- [x] `vite build` for apps/docs succeeds (themes page emitted)
- [ ] Manual: open `/themes` in light and dark site appearance
- [ ] Manual: hero theme/palette pickers update chart + code; follow-docs disables theme only
- [ ] Manual: 12 theme rows, no CopyCode under specimens, tooltips work without event logs