### PR TITLE
fix(#651): tool-rail labels readable in dark docs mode

### DIFF
--- a/apps/docs/src/app.css
+++ b/apps/docs/src/app.css
@@ -19,6 +19,14 @@
   --surface: #f6f8fa;
   --border: #d0d7de;
   --accent: #4269d0;
+  /* Tool-rail / status chrome sit in the frame, not on chart paper. Site
+     appearance is independent of chart theme, so publish consumer color
+     overrides here — otherwise --gg-theme-toolActive follows the (often
+     light) chart ink and fails contrast on a dark frame (#651).
+     --gg-interactionMuted is the inactive *color* override (not the numeric
+     --gg-theme-interactionMuted mark-opacity token). */
+  --gg-toolActive: var(--fg);
+  --gg-interactionMuted: var(--muted);
 
   min-width: 0;
   overflow: hidden;

--- a/packages/svelte/tests/chrome/docs-tool-rail-bridge.ssr.test.ts
+++ b/packages/svelte/tests/chrome/docs-tool-rail-bridge.ssr.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const docsAppCss = readFileSync(
+  join(import.meta.dirname, "../../../../apps/docs/src/app.css"),
+  "utf8",
+);
+
+describe("docs example-frame chrome bridge (#651)", () => {
+  it("publishes toolActive and interactionMuted color overrides on .gg-example-frame", () => {
+    // Dark theme only reassigns --fg / --muted; overrides reference those vars.
+    expect(docsAppCss).toMatch(/\.gg-example-frame\s*\{[^}]*--gg-toolActive:\s*var\(--fg\)/s);
+    expect(docsAppCss).toMatch(
+      /\.gg-example-frame\s*\{[^}]*--gg-interactionMuted:\s*var\(--muted\)/s,
+    );
+  });
+});

--- a/packages/svelte/tests/chrome/tool-rail-dark-contrast.test.ts
+++ b/packages/svelte/tests/chrome/tool-rail-dark-contrast.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import ToolRail from "../../src/lib/chrome/ToolRail.svelte";
+import { render } from "../helpers/render.js";
+
+function toolRailProps(activeTool: "inspect" | "point" = "point") {
+  return {
+    availableTools: ["inspect", "point", "zoom-area"] as const,
+    activeTool,
+    ready: true,
+    emptyPlot: false,
+    zoomDomains: null,
+    hasPointSelection: false,
+    hasIntervalSelection: false,
+    canSetIntervalBounds: false,
+    intervalAxes: [] as const,
+    onChooseTool: () => {},
+    onResetZoom: () => {},
+    onClearPointSelection: () => {},
+    onClearIntervalSelection: () => {},
+    onClearCurrentInterval: () => {},
+    onEditBounds: () => {},
+  };
+}
+
+/** Relative luminance (sRGB), WCAG. */
+function relativeLuminance(cssRgb: string): number {
+  const match = cssRgb.match(/rgba?\(\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)/i);
+  if (match === null) throw new Error(`expected rgb() color, got ${cssRgb}`);
+  const channel = (raw: string) => {
+    const s = Number(raw) / 255;
+    return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+  };
+  const r = channel(match[1]);
+  const g = channel(match[2]);
+  const b = channel(match[3]);
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+function contrastRatio(fg: string, bg: string): number {
+  const l1 = relativeLuminance(fg);
+  const l2 = relativeLuminance(bg);
+  const lighter = Math.max(l1, l2);
+  const darker = Math.min(l1, l2);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+describe("<ToolRail> dark-host contrast (#651)", () => {
+  it("fails contrast when light chart theme tokens paint active mode text", () => {
+    document.body.style.background = "#16181d";
+    document.body.style.color = "#e6e8eb";
+
+    const { container } = render(ToolRail, toolRailProps("point"));
+    const rail = container.querySelector<HTMLElement>(".gg-tool-rail")!;
+    // Mimic GGPlot rootStyle from the default (light) chart theme.
+    rail.style.setProperty("--gg-theme-toolActive", "#262626");
+    rail.style.setProperty("--gg-theme-interactionMuted", "0.36");
+    rail.style.setProperty("--gg-theme-interactionInk", "#262626");
+
+    const active = container.querySelector<HTMLButtonElement>("button.active")!;
+    const activeColor = getComputedStyle(active).color;
+    expect(contrastRatio(activeColor, "rgb(22, 24, 29)")).toBeLessThan(3);
+  });
+
+  it("meets WCAG AA when the host publishes tool chrome color overrides", () => {
+    document.body.style.background = "#16181d";
+    document.body.style.color = "#e6e8eb";
+
+    const { container } = render(ToolRail, toolRailProps("point"));
+    const rail = container.querySelector<HTMLElement>(".gg-tool-rail")!;
+    rail.style.setProperty("--gg-theme-toolActive", "#262626");
+    rail.style.setProperty("--gg-theme-interactionMuted", "0.36");
+    rail.style.setProperty("--gg-theme-interactionInk", "#262626");
+    // Docs .gg-example-frame bridge (site appearance ≠ chart theme).
+    rail.style.setProperty("--gg-toolActive", "#e6e8eb");
+    rail.style.setProperty("--gg-interactionMuted", "#9aa2ab");
+
+    const active = container.querySelector<HTMLButtonElement>("button.active")!;
+    const inactive = [...container.querySelectorAll<HTMLButtonElement>("button")].find(
+      (button) => !button.classList.contains("active"),
+    )!;
+
+    const bg = "rgb(22, 24, 29)";
+    expect(contrastRatio(getComputedStyle(active).color, bg)).toBeGreaterThanOrEqual(4.5);
+    expect(contrastRatio(getComputedStyle(inactive).color, bg)).toBeGreaterThanOrEqual(4.5);
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes [#651](https://github.com/ljodea/ggsvelte/issues/651): interaction tool-rail mode labels were unreadable on dark docs pages because active text used chart-theme `--gg-theme-toolActive` (light-theme ink) against the dark `.gg-example-frame`.
- Docs example frames now publish consumer overrides `--gg-toolActive: var(--fg)` and `--gg-interactionMuted: var(--muted)` so chrome follows site appearance while chart themes stay independent.
- Adds contrast + CSS presence tests locking the override contract.

## Validation
Browser probe: dark host `#16181d` + default light chart tokens → active `rgb(38,38,38)` (fails); with frame overrides → ≥4.5:1.

## Follow-ups
- [#664](https://github.com/ljodea/ggsvelte/issues/664): clarify/rename ToolRail muted CSS override tokens (library API polish; deferred from this fix).

## Test plan
- [x] `cd packages/svelte && bun run test:browser -- tests/chrome/tool-rail-dark-contrast.test.ts tests/chrome/tool-rail.test.ts`
- [x] `cd packages/svelte && bun run test:ssr -- tests/chrome/docs-tool-rail-bridge.ssr.test.ts`
- [ ] Manually: `/examples/interaction/linked-views` with docs dark appearance — Inspect / Select point / Zoom area labels legible


Made with [Cursor](https://cursor.com)