### PR TITLE
chore(#664): clarify ToolRail inactive color as --gg-toolInactive

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -160,6 +160,13 @@ properties:
 | `tooltipBorder`    | Tooltip hairline keyline            | grid, then panel border |
 | `toolActive`       | Active tool text and underline      | theme ink               |
 
+`interactionMuted` is a **number** (mark alpha). Host pages that restyle the
+tool rail / status chrome should override **`--gg-toolActive`** and
+**`--gg-toolInactive`** (colors), not `--gg-interactionMuted` — that custom
+property is reserved for `themeVar("interactionMuted")` opacity fallbacks.
+`--gg-theme-interactionMuted` on the plot root is the same numeric token
+published for interaction chrome CSS.
+
 Custom theme objects may override any relationship. Prefer relational defaults over a
 universal black, white, or blue because each theme must remain internally coherent.
 

--- a/apps/docs/src/app.css
+++ b/apps/docs/src/app.css
@@ -23,10 +23,10 @@
      appearance is independent of chart theme, so publish consumer color
      overrides here — otherwise --gg-theme-toolActive follows the (often
      light) chart ink and fails contrast on a dark frame (#651).
-     --gg-interactionMuted is the inactive *color* override (not the numeric
-     --gg-theme-interactionMuted mark-opacity token). */
+     --gg-toolInactive is the inactive *color* override; do not reuse
+     --gg-interactionMuted here (that name is themeVar mark-opacity). */
   --gg-toolActive: var(--fg);
-  --gg-interactionMuted: var(--muted);
+  --gg-toolInactive: var(--muted);
 
   min-width: 0;
   overflow: hidden;

--- a/packages/svelte/src/lib/chrome/StatusChrome.svelte
+++ b/packages/svelte/src/lib/chrome/StatusChrome.svelte
@@ -81,8 +81,8 @@
     top: 50%;
     transform: translate(-50%, -50%);
     /* --gg-theme-interactionMuted is a numeric alpha token — invalid in a
-       color position (see ToolRail.svelte). */
-    color: var(--gg-interactionMuted, currentColor);
+       color position (see ToolRail.svelte). Inactive chrome uses --gg-toolInactive. */
+    color: var(--gg-toolInactive, currentColor);
     font: 12px/1.4 var(--gg-font-family, sans-serif);
     pointer-events: none;
   }
@@ -93,7 +93,7 @@
     left: 0;
     margin: 0;
     /* Numeric alpha token — invalid in a color position (see ToolRail). */
-    color: var(--gg-interactionMuted, currentColor);
+    color: var(--gg-toolInactive, currentColor);
     font: 11px/1.4 var(--gg-font-family, sans-serif);
   }
 

--- a/packages/svelte/src/lib/chrome/ToolRail.svelte
+++ b/packages/svelte/src/lib/chrome/ToolRail.svelte
@@ -213,10 +213,9 @@
     padding: 0 10px;
     background: transparent;
     /* --gg-theme-interactionMuted is a NUMERIC alpha token (theme.ts
-       interactionMuted: 0.36) — substituting it here made this declaration
-       invalid at computed-value time, so only --gg-interactionMuted (a
-       consumer-supplied color) may appear in a color position. */
-    color: var(--gg-interactionMuted, currentColor);
+       interactionMuted: 0.36). Inactive chrome ink uses --gg-toolInactive so
+       it never collides with --gg-interactionMuted (themeVar opacity). */
+    color: var(--gg-toolInactive, currentColor);
     font: inherit;
     font-size: 14px;
     white-space: nowrap;

--- a/packages/svelte/tests/chrome/docs-tool-rail-bridge.ssr.test.ts
+++ b/packages/svelte/tests/chrome/docs-tool-rail-bridge.ssr.test.ts
@@ -9,10 +9,11 @@ const docsAppCss = readFileSync(
 );
 
 describe("docs example-frame chrome bridge (#651)", () => {
-  it("publishes toolActive and interactionMuted color overrides on .gg-example-frame", () => {
+  it("publishes toolActive and toolInactive color overrides on .gg-example-frame", () => {
     // Dark theme only reassigns --fg / --muted; overrides reference those vars.
     expect(docsAppCss).toMatch(/\.gg-example-frame\s*\{[^}]*--gg-toolActive:\s*var\(--fg\)/s);
-    expect(docsAppCss).toMatch(
+    expect(docsAppCss).toMatch(/\.gg-example-frame\s*\{[^}]*--gg-toolInactive:\s*var\(--muted\)/s);
+    expect(docsAppCss).not.toMatch(
       /\.gg-example-frame\s*\{[^}]*--gg-interactionMuted:\s*var\(--muted\)/s,
     );
   });

--- a/packages/svelte/tests/chrome/status-chrome.test.ts
+++ b/packages/svelte/tests/chrome/status-chrome.test.ts
@@ -126,7 +126,7 @@ describe("StatusChrome", () => {
       })
       .join("\n");
     // --gg-theme-interactionMuted is a numeric alpha; invalid in color position.
-    expect(cssText).toMatch(/color:\s*var\(--gg-interactionMuted,\s*currentColor\)/i);
+    expect(cssText).toMatch(/color:\s*var\(--gg-toolInactive,\s*currentColor\)/i);
     expect(cssText).not.toMatch(
       /color:\s*var\(\s*--gg-interactionMuted\s*,\s*var\(\s*--gg-theme-interactionMuted/i,
     );

--- a/packages/svelte/tests/chrome/tool-rail-dark-contrast.test.ts
+++ b/packages/svelte/tests/chrome/tool-rail-dark-contrast.test.ts
@@ -73,7 +73,7 @@ describe("<ToolRail> dark-host contrast (#651)", () => {
     rail.style.setProperty("--gg-theme-interactionInk", "#262626");
     // Docs .gg-example-frame bridge (site appearance ≠ chart theme).
     rail.style.setProperty("--gg-toolActive", "#e6e8eb");
-    rail.style.setProperty("--gg-interactionMuted", "#9aa2ab");
+    rail.style.setProperty("--gg-toolInactive", "#9aa2ab");
 
     const active = container.querySelector<HTMLButtonElement>("button.active")!;
     const inactive = [...container.querySelectorAll<HTMLButtonElement>("button")].find(

--- a/packages/svelte/tests/chrome/tool-rail.test.ts
+++ b/packages/svelte/tests/chrome/tool-rail.test.ts
@@ -130,8 +130,8 @@ describe("<ToolRail> forced-colors disabled→enabled paint contract (#161)", ()
     render(ToolRail, toolRailProps());
     const cssText = documentCssText();
     // --gg-theme-interactionMuted is a number (0.36); invalid in `color:`.
-    // Only the consumer color override may appear in the color chain.
-    expect(cssText).toMatch(/color:\s*var\(--gg-interactionMuted,\s*currentColor\)/i);
+    // Inactive chrome ink uses --gg-toolInactive (not --gg-interactionMuted).
+    expect(cssText).toMatch(/color:\s*var\(--gg-toolInactive,\s*currentColor\)/i);
     expect(cssText).not.toMatch(
       /color:\s*var\(\s*--gg-interactionMuted\s*,\s*var\(\s*--gg-theme-interactionMuted/i,
     );


### PR DESCRIPTION
## Summary
- Closes [#664](https://github.com/ljodea/ggsvelte/issues/664): inactive tool/status chrome ink uses **`--gg-toolInactive`**.
- Leaves **`--gg-interactionMuted`** / **`--gg-theme-interactionMuted`** for mark-opacity (`themeVar`).
- Docs frame bridge + DESIGN.md updated accordingly.

## Test plan
- [x] vitest chrome ToolRail / StatusChrome / docs bridge / dark-contrast
- [ ] Spot-check dark docs frame tool rail still legible


Made with [Cursor](https://cursor.com)