### PR TITLE
fix(docs): preserve control contrast across themes

### DIFF
--- a/apps/docs/src/lib/components/InteractionDemo.svelte
+++ b/apps/docs/src/lib/components/InteractionDemo.svelte
@@ -113,6 +113,9 @@ ${closeScript}
 
 <style>
   .interaction-demo {
+    --gg-toolActive: var(--ink);
+    --gg-interactionMuted: var(--muted);
+
     display: grid;
     gap: 1rem;
     min-width: 0;

--- a/apps/docs/src/lib/components/InteractionDemo.svelte
+++ b/apps/docs/src/lib/components/InteractionDemo.svelte
@@ -114,7 +114,7 @@ ${closeScript}
 <style>
   .interaction-demo {
     --gg-toolActive: var(--ink);
-    --gg-interactionMuted: var(--muted);
+    --gg-toolInactive: var(--muted);
 
     display: grid;
     gap: 1rem;

--- a/apps/docs/src/lib/components/UiButton.svelte
+++ b/apps/docs/src/lib/components/UiButton.svelte
@@ -70,7 +70,8 @@
     opacity: 0.45;
   }
 
-  :global(.ui-button--primary) {
+  :global(.ui-button--primary),
+  :global(a.ui-button--primary:visited) {
     border-color: var(--accent);
     background: var(--accent);
     color: #fff;
@@ -109,7 +110,8 @@
     background: color-mix(in srgb, var(--ink) 6%, transparent);
   }
 
-  :root[data-theme="dark"] :global(.ui-button--primary) {
+  :root[data-theme="dark"] :global(.ui-button--primary),
+  :root[data-theme="dark"] :global(a.ui-button--primary:visited) {
     color: #0b1020;
   }
 </style>

--- a/tests/visual/docs-contrast.spec.ts
+++ b/tests/visual/docs-contrast.spec.ts
@@ -1,0 +1,87 @@
+import { expect, test } from "@playwright/test";
+
+function relativeLuminance(cssColor: string): number {
+  const channels = cssColor
+    .match(/[\d.]+/g)
+    ?.slice(0, 3)
+    .map(Number);
+  if (channels === undefined || channels.length !== 3) {
+    throw new Error(`Expected an sRGB color, got ${cssColor}`);
+  }
+  const scale = cssColor.startsWith("color(srgb") ? 255 : 1;
+  const linear = channels.map((channel) => {
+    const value = (channel * scale) / 255;
+    return value <= 0.04045 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * linear[0] + 0.7152 * linear[1] + 0.0722 * linear[2];
+}
+
+function contrastRatio(foreground: string, background: string): number {
+  const foregroundLuminance = relativeLuminance(foreground);
+  const backgroundLuminance = relativeLuminance(background);
+  return (
+    (Math.max(foregroundLuminance, backgroundLuminance) + 0.05) /
+    (Math.min(foregroundLuminance, backgroundLuminance) + 0.05)
+  );
+}
+
+for (const theme of ["light", "dark"] as const) {
+  test(`interaction tool labels meet AA contrast in ${theme} mode`, async ({ page }) => {
+    await page.goto(`/interactions?theme=${theme}`);
+    const demo = page.getByRole("region", { name: "Interaction demo" });
+    await expect(demo.locator(".gg-plot-root")).toHaveAttribute("data-gg-ready", "true");
+
+    const pageBackground = await page
+      .locator("body")
+      .evaluate((body) => getComputedStyle(body).backgroundColor);
+    for (const name of ["Inspect", "Select area"]) {
+      const foreground = await demo
+        .getByRole("button", { name, exact: true })
+        .evaluate((button) => getComputedStyle(button).color);
+      expect(
+        contrastRatio(foreground, pageBackground),
+        `${name} contrast in ${theme} mode`,
+      ).toBeGreaterThanOrEqual(4.5);
+    }
+  });
+
+  test(`homepage primary CTA preserves theme color after visiting in ${theme} mode`, async ({
+    page,
+  }) => {
+    await page.goto(`/?theme=${theme}`);
+    const cta = page.getByRole("link", {
+      name: "Getting started",
+      exact: true,
+    });
+    await cta.click();
+    await page.goBack();
+    await expect(cta).toBeVisible();
+
+    const colors = await cta.evaluate((link) => {
+      const style = getComputedStyle(link);
+      const visitedRules = [...document.styleSheets].flatMap((sheet) => {
+        try {
+          return [...sheet.cssRules]
+            .filter(
+              (rule): rule is CSSStyleRule =>
+                rule instanceof CSSStyleRule &&
+                rule.selectorText.includes("a.ui-button--primary:visited"),
+            )
+            .map((rule) => rule.style.color);
+        } catch {
+          return [];
+        }
+      });
+      return {
+        foreground: style.color,
+        background: style.backgroundColor,
+        visitedRules,
+      };
+    });
+
+    expect(contrastRatio(colors.foreground, colors.background)).toBeGreaterThanOrEqual(4.5);
+    expect(colors.visitedRules).toContain(
+      theme === "dark" ? "rgb(11, 16, 32)" : "rgb(255, 255, 255)",
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- preserve primary CTA colors after its link has been visited
- bind standalone interaction tool chrome to docs appearance tokens
- add WCAG AA browser regressions for both controls in light and dark modes

## Test plan
- [x] `bun run check:docs`
- [x] `bun run build`
- [x] `bun run build:docs`
- [x] `bun node_modules/.bin/playwright test --config tests/visual/playwright.config.ts tests/visual/docs-contrast.spec.ts`

Made with [Cursor](https://cursor.com)