### PR TITLE
refactor(docs): stop stamping classification labels over code blocks

### DIFF
--- a/apps/docs/src/lib/components/GettingStartedGuide.svelte
+++ b/apps/docs/src/lib/components/GettingStartedGuide.svelte
@@ -68,7 +68,6 @@
 
   <h2 id="create-a-sveltekit-app">Create a SvelteKit app</h2>
   <p>Start with Node.js 22 or newer in an empty directory.</p>
-  <p class="guide-code-classification">Complete command</p>
   <CopyCode
     class="lesson-source"
     language="bash"
@@ -78,7 +77,6 @@
 
   <h2 id="install-ggsvelte">Install ggsvelte</h2>
   <p>Choose the package manager already used by the app.</p>
-  <p class="guide-code-classification">Complete command</p>
   <CopyCode
     class="lesson-source"
     language="bash"
@@ -181,7 +179,6 @@
       <div class="step-copy">
         <h3 id={step.id}>{step.title}</h3>
         <p>{step.outcome}</p>
-        <p class="guide-code-classification">Fragment</p>
         <CopyCode
           class="lesson-source"
           language="svelte"
@@ -223,7 +220,6 @@
   </p>
   <h3 id="fluent-builder">Fluent builder</h3>
   <p>Use the builder to construct specs programmatically in TypeScript.</p>
-  <p class="guide-code-classification">Fragment</p>
   <CopyCode
     class="lesson-source"
     language="typescript"
@@ -235,7 +231,6 @@
     Use PortableSpec to save, transmit, validate, or generate a chart without
     executable accessors.
   </p>
-  <p class="guide-code-classification">Fragment</p>
   <CopyCode
     class="lesson-source"
     language="json"
@@ -249,14 +244,12 @@
     <code>ggsvelte-render</code> CLI writes SVG to stdout and JSON Lines diagnostics
     to stderr.
   </p>
-  <p class="guide-code-classification">Fragment</p>
   <CopyCode
     class="lesson-source"
     language="typescript"
     accessibleLabel="Copy headless fragment"
     code={QUICKSTART_HEADLESS_FRAGMENT}
   />
-  <p class="guide-code-classification">Fragment</p>
   <CopyCode
     class="lesson-source"
     language="bash"
@@ -346,15 +339,6 @@
 
   .getting-started-guide :global(.lesson-source .code-body pre) {
     white-space: pre;
-  }
-
-  .guide-code-classification {
-    margin: 1rem 0 0.35rem;
-    color: var(--muted);
-    font-size: 0.72rem;
-    font-weight: 700;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
   }
 
   @media (max-width: 63.99rem) {

--- a/apps/docs/src/routes/reference/cli/+page.svelte
+++ b/apps/docs/src/routes/reference/cli/+page.svelte
@@ -21,7 +21,6 @@
   <p>
     Pass one JSON file or omit it to read stdin. SVG is the only stdout output.
   </p>
-  <p class="guide-code-classification">Fragment</p>
   <CopyCode
     class="cli-command"
     language="bash"
@@ -109,15 +108,6 @@
 
   dd p + p {
     margin-top: 0.5rem;
-  }
-
-  .guide-code-classification {
-    margin: 1rem 0 0.35rem;
-    color: var(--muted);
-    font-size: 0.72rem;
-    font-weight: 700;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
   }
 
   .cli-reference :global(.cli-command code) {

--- a/apps/docs/src/styles/base.css
+++ b/apps/docs/src/styles/base.css
@@ -218,19 +218,6 @@ pre {
   overflow-wrap: normal;
 }
 
-.guide-code-classification {
-  margin: 1.5rem 0 0.35rem;
-  color: var(--muted);
-  font-size: 0.72rem;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.guide-code-classification + :is(pre, .guide-code-copy) {
-  margin-top: 0;
-}
-
 .guide-code-copy {
   position: relative;
   margin: 1.5rem 0;

--- a/scripts/gen-llms.test.ts
+++ b/scripts/gen-llms.test.ts
@@ -82,7 +82,19 @@ describe("renderMarkdown", () => {
     expect(html).toContain('<pre id="guide-code-1"><code class="hljs language-json">');
     expect(html).toContain("hljs-");
     expect(html).toContain('<span id="guide-code-1-status" role="status" class="visually-hidden">');
-    expect(html).toContain('<p class="guide-code-classification">Fragment</p>');
+  });
+
+  it("never stamps a classification label over a code block", () => {
+    for (const fence of [
+      '```json fragment copy\n{"x": 1}\n```',
+      "```svelte complete\n<script></script>\n```",
+      "```sh complete\nbun add @ggsvelte/svelte\n```",
+      "```ts\nconst x = 1;\n```",
+    ]) {
+      const html = renderMarkdown(fence);
+      expect(html).not.toContain("guide-code-classification");
+      expect(html).not.toMatch(/>(Fragment|Complete file|Complete command|Complete example)</);
+    }
   });
 
   it("adds stable unique heading fragments", () => {

--- a/scripts/llms-markdown.ts
+++ b/scripts/llms-markdown.ts
@@ -4,7 +4,6 @@
  * surfaces via gen-llms.
  */
 import { GUIDE_COPY_ICON_SVG } from "../apps/docs/src/lib/guide-code-copy";
-import { type CodeClassification } from "./guide-code-contract";
 import { highlightCodeToHtml } from "./highlight-code";
 
 // Minimal markdown renderer (headings, paragraphs, fenced code, inline code,
@@ -82,7 +81,6 @@ export function renderMarkdown(md: string, base = ""): string {
   let code: string[] | null = null;
   let codeLang = "";
   let codeCopy = false;
-  let codeClassification: CodeClassification = "fragment";
   let copyCodeCount = 0;
   const headingId = createHeadingId();
 
@@ -101,19 +99,10 @@ export function renderMarkdown(md: string, base = ""): string {
   const renderCode = (source: string): string => {
     const languageClass = codeLang === "" ? ' class="hljs"' : ` class="hljs language-${codeLang}"`;
     const highlighted = highlightCodeToHtml(source, codeLang);
-    const classificationLabel =
-      codeClassification === "fragment"
-        ? "Fragment"
-        : codeLang === "svelte"
-          ? "Complete file"
-          : codeLang === "sh"
-            ? "Complete command"
-            : "Complete example";
-    const label = `<p class="guide-code-classification">${classificationLabel}</p>`;
     const pre = `<pre><code${languageClass}>${highlighted}</code></pre>`;
-    if (!codeCopy) return `${label}${pre}`;
+    if (!codeCopy) return pre;
     const id = `guide-code-${String(++copyCodeCount)}`;
-    return `${label}<div class="guide-code-copy"><button type="button" data-copy-code="${id}" aria-label="Copy code" aria-describedby="${id}-status">${GUIDE_COPY_ICON_SVG}</button><pre id="${id}"><code${languageClass}>${highlighted}</code></pre><span id="${id}-status" role="status" class="visually-hidden"></span></div>`;
+    return `<div class="guide-code-copy"><button type="button" data-copy-code="${id}" aria-label="Copy code" aria-describedby="${id}-status">${GUIDE_COPY_ICON_SVG}</button><pre id="${id}"><code${languageClass}>${highlighted}</code></pre><span id="${id}-status" role="status" class="visually-hidden"></span></div>`;
   };
 
   for (const line of lines) {
@@ -132,7 +121,6 @@ export function renderMarkdown(md: string, base = ""): string {
       const [language = "", ...flags] = line.slice(3).trim().split(/\s+/);
       codeLang = /^[a-z0-9-]*$/i.test(language) ? language : "";
       codeCopy = flags.includes("copy");
-      codeClassification = flags.includes("complete") ? "complete" : "fragment";
       code = [];
       continue;
     }

--- a/scripts/no-code-labels.test.ts
+++ b/scripts/no-code-labels.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Suite-wide ban on classification labels over code blocks ("Fragment",
+ * "Complete file", "Complete command", "Complete example").
+ *
+ * The reader can see whether a block is a fragment; the filename or prose says
+ * the rest. The label was injected by the shared markdown renderer, so the ban
+ * is asserted on rendered output for every guide page — not only on the one
+ * page that motivated the removal — plus a source scan so nobody reintroduces
+ * a hand-written label in a Svelte route.
+ */
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "bun:test";
+
+import lifecycle from "../lifecycle.json";
+import { guidePages, type LifecycleDoc, renderMarkdown } from "./gen-llms.ts";
+
+const LABEL_CLASS = "guide-code-classification";
+const LABEL_TEXTS = /<p[^>]*>(Fragment|Complete file|Complete command|Complete example)<\/p>/;
+
+const DOCS_SRC = new URL("../apps/docs/src", import.meta.url).pathname;
+
+function walk(directory: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(directory)) {
+    const path = join(directory, entry);
+    if (statSync(path).isDirectory()) {
+      out.push(...walk(path));
+    } else if (/\.(svelte|css|ts)$/.test(entry) && !entry.endsWith("generated.ts")) {
+      out.push(path);
+    }
+  }
+  return out;
+}
+
+describe("code blocks carry no classification label", () => {
+  it("renders every guide page without a label", () => {
+    const pages = guidePages(lifecycle as unknown as LifecycleDoc);
+    expect(pages.length).toBeGreaterThan(5);
+    for (const page of pages) {
+      const html = renderMarkdown(page.markdown);
+      expect(html).not.toContain(LABEL_CLASS);
+      expect(html).not.toMatch(LABEL_TEXTS);
+    }
+  });
+
+  it("keeps the label out of docs source", () => {
+    const offenders = walk(DOCS_SRC).filter((path) =>
+      readFileSync(path, "utf8").includes(LABEL_CLASS),
+    );
+    expect(offenders).toEqual([]);
+  });
+});

--- a/tests/visual/docs-progressive-search.spec.ts
+++ b/tests/visual/docs-progressive-search.spec.ts
@@ -187,7 +187,7 @@ for (const chapter of [
       page.getByRole("navigation", { name: "Previous and next chapters" }),
     ).toBeVisible();
     await expect(page.locator(`a[href$="${chapter.evidence}"]`).first()).toBeVisible();
-    await expect(page.locator(".guide-code-classification").first()).toHaveText("Fragment");
+    await expect(page.locator(".guide-code-classification")).toHaveCount(0);
     await expectNoDocumentOverflow(page);
   });
 }


### PR DESCRIPTION
**Stack 1/4** — base for `gs/data` → `gs/lesson` → `gs/hero`.

Every fenced code block on the docs site was preceded by an uppercase
`FRAGMENT` / `COMPLETE COMMAND` label injected by the shared markdown
renderer. It narrates what the reader can already see, and it is the first
thing anyone evaluating the library reads.

- removes the injection at the renderer (`scripts/llms-markdown.ts`)
- removes the two hand-written labels in Svelte routes (guide component,
  `reference/cli`) and the styles
- adds a suite-wide regression (`scripts/no-code-labels.test.ts`) that renders
  every guide page and asserts no label survives, plus a source scan so none
  is reintroduced by hand

The `complete` / `fragment` fence flags stay: the guide-code contract still
uses them to verify that complete Svelte blocks are registry-registered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)