### PR TITLE
feat(docs): make the homepage hero the chart the guide builds

### DIFF
--- a/apps/docs/src/routes/+page.svelte
+++ b/apps/docs/src/routes/+page.svelte
@@ -1,15 +1,20 @@
 <script lang="ts">
   import { base } from "$app/paths";
-  import { GeomPoint, GGPlot } from "@ggsvelte/svelte";
+  import { GGPlot } from "@ggsvelte/svelte";
+  import { kyotoSakura } from "@ggsvelte/svelte/data";
 
-  import { penguins } from "$examples/point/scatter-color/data";
-  import { QUICKSTART_PAGE_SVELTE } from "$scripts/quickstart";
+  import {
+    foldSakura,
+    QUICKSTART_BUILDER_FRAGMENT,
+    QUICKSTART_PORTABLE_SPEC_FRAGMENT,
+    SAKURA_FINISHED_SVELTE,
+    SAKURA_STEPS,
+  } from "$scripts/quickstart";
   import CodeTabs from "$lib/CodeTabs.svelte";
   import { FEATURED_EXAMPLES, galleryEntryFor } from "$lib/catalog/gallery";
   import CopyCode from "$lib/components/CopyCode.svelte";
   import GrammarDemo from "$lib/components/GrammarDemo.svelte";
   import UiButton from "$lib/components/UiButton.svelte";
-  import { contrastChartTheme } from "$lib/docs-appearance-state.svelte";
   import { EXAMPLES } from "$lib/examples";
 
   const install = "npm install @ggsvelte/svelte";
@@ -17,70 +22,56 @@
   const featured = FEATURED_EXAMPLES.map((item) =>
     entries.find((entry) => entry.id === item.id)!,
   );
-  const heroTheme = $derived(contrastChartTheme());
+  // The hero is the getting-started chart, finished: same fold, same spec.
+  const hero = foldSakura(
+    SAKURA_STEPS.length,
+    kyotoSakura.map((row) => ({ ...row })),
+  );
   const tabs = [
-    { label: "Svelte", code: QUICKSTART_PAGE_SVELTE, language: "svelte" },
+    { label: "Svelte", code: SAKURA_FINISHED_SVELTE, language: "svelte" },
     {
       label: "Builder (TS)",
       language: "typescript",
-      code: `import { aes, gg } from "@ggsvelte/svelte";\n\nconst spec = gg(cars, aes({ x: "weight", y: "economy" }))\n  .geomPoint()\n  .spec();`,
+      code: QUICKSTART_BUILDER_FRAGMENT,
     },
     {
       label: "Spec (JSON)",
       language: "json",
-      code: `{
-  "data": {
-    "values": [{ "weight": 1.8, "economy": 37 }]
-  },
-  "layers": [
-    {
-      "geom": "point",
-      "aes": {
-        "x": { "field": "weight" },
-        "y": { "field": "economy" }
-      }
-    }
-  ]
-}`,
+      code: QUICKSTART_PORTABLE_SPEC_FRAGMENT,
     },
   ];
 </script>
 
 <section class="home-hero" aria-labelledby="home-heading">
-  <div class="hero-claim">
+  <div class="hero-masthead">
     <h1 id="home-heading">
-      An agent-first implementation of the layered grammar of graphics in Svelte
-      5
+      The layered grammar of graphics, in Svelte 5 — and in JSON
     </h1>
     <p>
-      ggplot2's layered grammar and defaults as Svelte components, a TypeScript
-      builder, and a validated JSON spec agents can write. Inspection,
-      selection, and zoom are part of the spec.
+      ggplot2's grammar and defaults as Svelte components, a TypeScript builder,
+      and a validated spec agents can write. Inspection, selection and zoom are
+      part of the spec.
     </p>
+    <CopyCode code={install} language="bash" accessibleLabel="Copy install" />
   </div>
 
   <div class="hero-plot">
     <GGPlot
-      data={penguins}
-      aes={{ x: "flipper", y: "mass", color: "species" }}
-      inspect={{ mode: "x", pin: true, maxDistance: 24 }}
-      theme={heroTheme}
-      labs={{
-        title: "Penguin body mass by flipper length",
-        x: "Flipper length (mm)",
-        y: "Body mass (g)",
-        color: "Species",
-      }}
+      spec={hero.spec}
+      key={hero.key}
+      inspect={hero.inspect}
       width="container"
-      height={400}
-      ariaLabel="Penguin mass increases with flipper length, grouped by species"
-    >
-      <GeomPoint size={4} alpha={0.85} />
-    </GGPlot>
+      height={480}
+      ariaLabel={"Kyoto peak cherry-blossom dates, 812 to 2026: stable near " +
+        "mid-April for a millennium, then about a week earlier since 1850"}
+    />
   </div>
 
   <div class="hero-actions">
-    <CopyCode code={install} language="bash" accessibleLabel="Copy install" />
+    <p class="hero-caption">
+      838 observations, six grammar elements, one file — built step by step in
+      <a href={`${base}/guide/getting-started`}>Getting started</a>.
+    </p>
     <div class="cta-row">
       <UiButton variant="primary" href={`${base}/guide/getting-started`}>
         Getting started
@@ -168,47 +159,61 @@
 <style>
   .home-hero {
     display: grid;
-    grid-template-areas: "claim plot" "actions plot";
-    grid-template-columns: minmax(18rem, 0.85fr) minmax(30rem, 1.15fr);
-    gap: 1.5rem clamp(2rem, 6vw, 6rem);
-    align-items: start;
-    min-height: calc(100svh - 8rem);
-    padding: clamp(3rem, 7vw, 7rem) 0 4rem;
+    gap: 2rem;
+    padding: clamp(2.5rem, 6vw, 5rem) 0 4rem;
   }
 
-  .hero-claim {
-    grid-area: claim;
+  /* Masthead row: claim, then the one thing to type, side by side. */
+  .hero-masthead {
+    display: grid;
+    grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr);
+    gap: 1rem clamp(2rem, 6vw, 5rem);
+    align-items: end;
   }
 
-  .hero-claim h1 {
-    max-width: 14ch;
-    margin: 0.35rem 0 1.25rem;
-    font-size: clamp(3.2rem, 6vw, 6rem);
-    line-height: 0.9;
+  .hero-masthead h1 {
+    grid-row: span 2;
+    max-width: 18ch;
+    margin: 0;
+    font-size: clamp(2.8rem, 5.5vw, 5rem);
+    line-height: 0.92;
     letter-spacing: -0.045em;
   }
 
-  .hero-claim > p:last-child {
-    max-width: 36rem;
+  .hero-masthead p {
+    max-width: 40rem;
+    margin: 0;
     color: var(--muted);
-    font-size: 1.08rem;
+    font-size: 1.05rem;
+  }
+
+  /* The chart is the argument, so it gets the full width of the page. */
+  .hero-plot {
+    min-width: 0;
+    margin-inline: calc(-1 * clamp(1rem, 4vw, 4rem));
+    padding: 1.5rem clamp(1rem, 4vw, 4rem);
+    background: #fff;
+    color: #172033;
   }
 
   .hero-actions {
-    grid-area: actions;
-    max-width: 34rem;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem 2rem;
   }
 
-  .hero-plot {
-    grid-area: plot;
-    min-width: 0;
+  .hero-caption {
+    max-width: 40rem;
+    margin: 0;
+    color: var(--muted);
   }
 
   .cta-row {
     display: flex;
     flex-wrap: wrap;
     gap: 0.75rem;
-    margin-top: 1rem;
   }
 
   .home-featured {
@@ -308,9 +313,13 @@
   }
 
   @media (max-width: 64rem) {
-    .home-hero {
-      grid-template-areas: "claim" "plot" "actions";
+    .hero-masthead {
       grid-template-columns: 1fr;
+      align-items: start;
+    }
+
+    .hero-masthead h1 {
+      grid-row: auto;
     }
 
     .home-featured ol {
@@ -324,8 +333,8 @@
       padding-top: 2rem;
     }
 
-    .hero-claim h1 {
-      font-size: clamp(2.6rem, 12vw, 4rem);
+    .hero-masthead h1 {
+      font-size: clamp(2.4rem, 11vw, 3.6rem);
     }
 
     .home-featured {

--- a/apps/docs/src/routes/+page.svelte
+++ b/apps/docs/src/routes/+page.svelte
@@ -196,6 +196,24 @@
     color: #172033;
   }
 
+  /*
+   * Forced colors: the hero pins its own light surface, and the epoch bands
+   * are decorative context this page never names — neither should override a
+   * requested palette. Hand the surface back and drop the fills; the points,
+   * the trend and the record annotations carry the chart on their own. The
+   * lesson page does the same to the same chart.
+   */
+  @media (forced-colors: active) {
+    .hero-plot {
+      color: canvastext;
+      background: canvas;
+    }
+
+    .hero-plot :global(.gg-marks rect) {
+      fill: none;
+    }
+  }
+
   .hero-actions {
     display: flex;
     flex-wrap: wrap;

--- a/tests/visual/docs-home-gallery.spec.ts
+++ b/tests/visual/docs-home-gallery.spec.ts
@@ -20,6 +20,42 @@ test("homepage first viewport leads with a live chart and two actions", async ({
   await expectNoOverflow(page);
 });
 
+/*
+ * The library sets `forced-color-adjust: none` on `.gg-plot`, so nothing in a
+ * chart adapts on its own — the page has to hand the surface back. The epoch
+ * bands are the one mark whose meaning is carried by fill alone and which this
+ * page never names, so under a requested palette they drop rather than paint
+ * over it. Asserted through `emulateMedia`: the config's `contextOptions`
+ * clobbers Playwright's `forcedColors` fixture, so `test.use` would silently
+ * measure a normal page.
+ */
+test("homepage hero yields its surface and drops decorative fills in forced colors", async ({
+  page,
+}) => {
+  await page.emulateMedia({ forcedColors: "active", reducedMotion: "reduce" });
+  await page.goto("/?theme=light");
+  const hero = page.locator(".hero-plot");
+  await expect(hero.locator(".gg-plot-root")).toHaveAttribute("data-gg-ready", "true");
+  expect(await page.evaluate(() => matchMedia("(forced-colors: active)").matches)).toBe(true);
+
+  const fills = await hero
+    .locator(".gg-marks rect")
+    .evaluateAll((rects) => rects.map((rect) => getComputedStyle(rect).fill));
+  expect(fills.length).toBeGreaterThan(0);
+  expect(new Set(fills)).toEqual(new Set(["none"]));
+
+  const surface = await hero.evaluate((el) => getComputedStyle(el).backgroundColor);
+  const canvas = await page.evaluate(() => {
+    const probe = document.createElement("div");
+    probe.style.backgroundColor = "canvas";
+    document.body.append(probe);
+    const value = getComputedStyle(probe).backgroundColor;
+    probe.remove();
+    return value;
+  });
+  expect(surface).toBe(canvas);
+});
+
 test("homepage preserves SSR chart output and hydrates its keyboard interaction", async ({
   page,
   request,

--- a/tests/visual/docs-home-gallery.spec.ts
+++ b/tests/visual/docs-home-gallery.spec.ts
@@ -13,8 +13,9 @@ test("homepage first viewport leads with a live chart and two actions", async ({
     "The layered grammar of graphics, in Svelte 5 — and in JSON",
   );
   await expect(page.locator(".home-hero .gg-plot-root")).toBeVisible();
-  await expect(page.getByRole("link", { name: "Getting started" })).toBeVisible();
-  await expect(page.getByRole("link", { name: "Examples" }).first()).toBeVisible();
+  const cta = page.locator(".cta-row");
+  await expect(cta.getByRole("link", { name: "Getting started" })).toBeVisible();
+  await expect(cta.getByRole("link", { name: "Examples" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Copy install" })).toBeVisible();
   await expectNoOverflow(page);
 });
@@ -86,7 +87,7 @@ test("install copy and code tabs share the manual-copy fallback", async ({ page 
   });
   await page.goto("/");
   await page.getByRole("button", { name: "Copy install" }).click();
-  await expect(page.locator(".hero-actions [role=status]")).toHaveText(
+  await expect(page.locator(".hero-masthead [role=status]")).toHaveText(
     "Clipboard unavailable. Code selected for manual copy.",
   );
   expect(await page.evaluate(() => getSelection()?.toString())).toContain(

--- a/tests/visual/docs-home-gallery.spec.ts
+++ b/tests/visual/docs-home-gallery.spec.ts
@@ -10,7 +10,7 @@ test("homepage first viewport leads with a live chart and two actions", async ({
   await page.setViewportSize({ width: 1280, height: 900 });
   await page.goto("/?theme=light");
   await expect(page.getByRole("heading", { level: 1 })).toHaveText(
-    "An agent-first implementation of the layered grammar of graphics in Svelte 5",
+    "The layered grammar of graphics, in Svelte 5 — and in JSON",
   );
   await expect(page.locator(".home-hero .gg-plot-root")).toBeVisible();
   await expect(page.getByRole("link", { name: "Getting started" })).toBeVisible();
@@ -56,7 +56,7 @@ test("homepage grammar steps change real chart structure in place", async ({ pag
   await expect(output.locator(".gg-paths")).toHaveCount(1);
 });
 
-test("homepage mobile order is claim, specimen, then install", async ({ page }) => {
+test("homepage mobile order is masthead, specimen, then actions", async ({ page }) => {
   await page.setViewportSize({ width: 375, height: 812 });
   await page.goto("/?theme=light");
   const order = await page.locator(".home-hero > div").evaluateAll((nodes) =>
@@ -70,7 +70,7 @@ test("homepage mobile order is claim, specimen, then install", async ({ page }) 
     expect(item, `${className} is present`).toBeDefined();
     return item?.top ?? Number.POSITIVE_INFINITY;
   };
-  expect(topFor("hero-claim")).toBeLessThan(topFor("hero-plot"));
+  expect(topFor("hero-masthead")).toBeLessThan(topFor("hero-plot"));
   expect(topFor("hero-plot")).toBeLessThan(topFor("hero-actions"));
   await expectNoOverflow(page);
 });


### PR DESCRIPTION
**Stack 4/4** — based on #687, and an atomic land unit with it.

The hero rendered penguins while its code tabs showed cars — two different charts claiming to be the same example. Landing #687 without this would leave the homepage contradicting the page it links to.

It is now **a masthead row** (the claim and the one command to type) over a **full-bleed plot** of the finished Kyoto chart, with the actions below it. The code tabs show that same chart as Svelte, as builder calls, and as JSON — all from the shared constants, so the three surfaces really are three spellings of one spec rather than three unrelated snippets.

Verified in both themes on the built site: no console errors, CLS 0.0002, and the homepage's own prerendered weight is 14 KB gzipped.

### Forced colors — checked, and it was broken

The original description claimed the band fills drop under `forced-colors: active` and flagged it unverified. Checking it showed the claim was false twice over: the rule was scoped to `.lesson-output`, which exists only on the guide page, and `.hero-plot` additionally pins `background: #fff`.

The first measurement was wrong too, which is the more reusable lesson: `tests/visual/playwright.config.ts` sets `use.contextOptions`, and that **clobbers Playwright's `forcedColors` fixture** — `test.use({ forcedColors: "active" })` yields `matchMedia("(forced-colors: active)").matches === false` and measures a perfectly normal page. `page.emulateMedia` is the form that works, and is what the rest of `tests/visual` already uses.

The hero now yields its surface (`canvas` / `canvastext`) and drops the band fills. The bands are decorative here — this page names them in neither the caption nor the aria-label — so nothing is lost, and the points, the trend and the record annotations carry the chart. The guard is red-verified: reverting the CSS fails it with three colours instead of `none`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
