### PR TITLE
test(docs): fix the stale classification-label assertion left on main

### DIFF
--- a/tests/visual/docs-progressive-search.spec.ts
+++ b/tests/visual/docs-progressive-search.spec.ts
@@ -22,7 +22,7 @@ test("Getting Started renders the packed file and first live grammar delta", asy
 
   const step = guide.locator(".progressive-step").first();
   await expect(step.getByRole("heading", { level: 3 })).toHaveText("Map fields to position");
-  await expect(step.getByText("Fragment", { exact: true })).toBeVisible();
+  await expect(step.locator(".guide-code-classification")).toHaveCount(0);
   await expect(step.locator(".gg-points circle")).toHaveCount(8);
   await expect(step.getByRole("link", { name: "Read Data and mappings" })).toHaveAttribute(
     "href",


### PR DESCRIPTION
#685 removed the uppercase classification labels over code blocks, but it merged with its CI run cancelled — so `tests/visual/docs-progressive-search.spec.ts` still asserts that the `Fragment` label is *visible* over the step fragment, and that test now fails on `main`.

One line: assert the label is absent, the same way the chapter-level check further down that file already does.

The same fix rides in #686, but `main` should not stay red until that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
