### PR TITLE
fix(docs): drop the last code-classification assertion missed by #685

### DIFF
--- a/tests/visual/docs-progressive-search.spec.ts
+++ b/tests/visual/docs-progressive-search.spec.ts
@@ -22,7 +22,7 @@ test("Getting Started renders the packed file and first live grammar delta", asy
 
   const step = guide.locator(".progressive-step").first();
   await expect(step.getByRole("heading", { level: 3 })).toHaveText("Map fields to position");
-  await expect(step.getByText("Fragment", { exact: true })).toBeVisible();
+  await expect(step.locator(".guide-code-classification")).toHaveCount(0);
   await expect(step.locator(".gg-points circle")).toHaveCount(8);
   await expect(step.getByRole("link", { name: "Read Data and mappings" })).toHaveAttribute(
     "href",


### PR DESCRIPTION
#685 removed the "Fragment" / "Complete command" labels from the docs renderer and from `GettingStartedGuide.svelte`, and updated the chapter-level assertion in `docs-progressive-search.spec.ts:190` to `toHaveCount(0)`.

It missed the second assertion in the same file, at line 25, which still required a "Fragment" label to be **visible** inside the first progressive step — an element the same PR had just deleted.

## Why it reached main

`component-journeys (docs a11y playwright)` was **cancelled**, not green, on #685, and `ci-gate` was failing when it merged. The break is now on `main` and fails every downstream PR — first observed on #684 (`1 failed, 84 passed`).

## The change

Mirrors the fix #685 already applied at line 190, so the assertion keeps proving the label is **gone** rather than proving it is present.

Grepped the whole `tests/visual` suite: these two are the only references, and both now assert absence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)