### PR TITLE
fix(playground): derive snippet dataset var from datasetId (#694)

### DIFF
--- a/apps/docs/src/lib/Playground.svelte
+++ b/apps/docs/src/lib/Playground.svelte
@@ -119,7 +119,7 @@
   let mockNotice = $state(false);
 
   const outputs = $derived(
-    playgroundOutputs(workbench.committed, interactions),
+    playgroundOutputs(workbench.committed, interactions, datasetId),
   );
   const sampleLinks = $derived(
     PLAYGROUND_SAMPLES.map((s) => ({ id: s.id, title: s.title })),

--- a/apps/docs/src/lib/playground-output.ts
+++ b/apps/docs/src/lib/playground-output.ts
@@ -4,6 +4,7 @@ import {
   defaultPlaygroundInteractions,
   type PlaygroundInteractions,
 } from "./playground-agent-envelope";
+import { isPlaygroundDatasetId } from "./playground-dataset-schemas";
 import { playgroundBuilderOutput } from "./playground-output-builder";
 import type { PlaygroundOutput } from "./playground-output-types";
 
@@ -20,17 +21,13 @@ function scriptSafeJSON(value: unknown): string {
     .replaceAll("\u2029", "\\u2029");
 }
 
-function guessDatasetVarName(spec: PortableSpec): string {
-  const data = spec.data;
-  if (data === undefined || !("values" in data) || !Array.isArray(data.values)) {
-    return "rows";
-  }
-  const first = data.values[0];
-  if (first !== null && typeof first === "object") {
-    if ("species" in first) return "penguins";
-    if ("date" in first && "value" in first) return "monthly";
-    if ("region" in first) return "categories";
-  }
+/**
+ * The data seam is named after the curated dataset the caller selected — never
+ * after the shape of the rows (#694). Dataset ids are the single source of
+ * truth for dataset identity; an unknown or omitted id is a generic `rows`.
+ */
+function datasetVarName(datasetId: string | undefined): string {
+  if (datasetId !== undefined && isPlaygroundDatasetId(datasetId)) return datasetId;
   return "rows";
 }
 
@@ -53,12 +50,13 @@ function interactionPropsSource(interactions: PlaygroundInteractions): string {
 export function playgroundSvelteOutput(
   spec: PortableSpec,
   interactions: PlaygroundInteractions = defaultPlaygroundInteractions(),
+  datasetId?: string,
 ): string {
   const props = interactionPropsSource(interactions);
   const data = spec.data;
 
   if (data !== undefined && "values" in data && Array.isArray(data.values)) {
-    const varName = guessDatasetVarName(spec);
+    const varName = datasetVarName(datasetId);
     const rowsLiteral = scriptSafeJSON(data.values);
     // Spec JSON with a sentinel string as data.values — replaced with the variable name.
     const placeholder = "__GG_PLAYGROUND_DATA_VALUES__";
@@ -109,27 +107,28 @@ interface OutputCacheEntry {
   /** Spec-keyed outputs that do not depend on interactions. */
   builder: PlaygroundOutput | null;
   specJson: string | null;
-  /** Interaction-dependent Svelte snippet + assembled tab list per key. */
-  readonly byInteractions: Map<string, readonly PlaygroundOutput[]>;
+  /** Svelte snippet + assembled tab list per interactions/dataset key. */
+  readonly byVariant: Map<string, readonly PlaygroundOutput[]>;
 }
 
 const outputCache = new WeakMap<PortableSpec, OutputCacheEntry>();
 
-function interactionsKey(interactions: PlaygroundInteractions): string {
-  return JSON.stringify(interactions);
+function variantKey(interactions: PlaygroundInteractions, datasetId: string | undefined): string {
+  return JSON.stringify([interactions, datasetId ?? null]);
 }
 
 export function playgroundOutputs(
   spec: PortableSpec,
   interactions: PlaygroundInteractions = defaultPlaygroundInteractions(),
+  datasetId?: string,
 ): readonly PlaygroundOutput[] {
-  const key = interactionsKey(interactions);
+  const key = variantKey(interactions, datasetId);
   let entry = outputCache.get(spec);
   if (entry === undefined) {
-    entry = { builder: null, specJson: null, byInteractions: new Map() };
+    entry = { builder: null, specJson: null, byVariant: new Map() };
     outputCache.set(spec, entry);
   }
-  const hit = entry.byInteractions.get(key);
+  const hit = entry.byVariant.get(key);
   if (hit !== undefined) return hit;
 
   const builder = (entry.builder ??= playgroundBuilderOutput(spec));
@@ -139,7 +138,7 @@ export function playgroundOutputs(
       kind: "svelte",
       label: "Svelte",
       supported: true,
-      code: playgroundSvelteOutput(spec, interactions),
+      code: playgroundSvelteOutput(spec, interactions, datasetId),
     },
   ];
   if (builder.supported) {
@@ -153,7 +152,7 @@ export function playgroundOutputs(
   });
 
   const frozen = outputs as readonly PlaygroundOutput[];
-  entry.byInteractions.set(key, frozen);
+  entry.byVariant.set(key, frozen);
   return frozen;
 }
 

--- a/scripts/playground-output.test.ts
+++ b/scripts/playground-output.test.ts
@@ -9,6 +9,7 @@ import {
   rebuildPlaygroundSpecWithBuilder,
 } from "../apps/docs/src/lib/playground-output";
 import { defaultPlaygroundInteractions } from "../apps/docs/src/lib/playground-agent-envelope";
+import { PLAYGROUND_DATASET_SCHEMAS } from "../apps/docs/src/lib/playground-dataset-schemas";
 
 const spec: PortableSpec = {
   edition: 1,
@@ -129,6 +130,65 @@ describe("playground outputs", () => {
     expect(a).not.toBe(b);
     expect(b[0]?.code).toContain('select="point"');
     expect(b[0]?.code).toContain("zoom");
+  });
+
+  test("names the data seam after the dataset the caller selected", () => {
+    for (const schema of PLAYGROUND_DATASET_SCHEMAS) {
+      const dataset: PortableSpec = { ...spec, data: { values: [...schema.sampleRows] } };
+      const output = playgroundSvelteOutput(dataset, defaultPlaygroundInteractions(), schema.id);
+
+      expect(output).toContain(`const ${schema.id} = `);
+      expect(output).toContain(`"values": ${schema.id}`);
+      expect(parseSpecFromSvelteOutput(output)).toEqual(dataset);
+    }
+  });
+
+  test("trusts the dataset id over the column names in the rows", () => {
+    const penguinShaped: PortableSpec = {
+      ...spec,
+      data: { values: [{ id: "a1", species: "Adelie", flipper: 181, mass: 3750 }] },
+    };
+    const output = playgroundSvelteOutput(
+      penguinShaped,
+      defaultPlaygroundInteractions(),
+      "monthly",
+    );
+
+    expect(output).toContain("const monthly = ");
+    expect(output).not.toContain("const penguins = ");
+  });
+
+  test("falls back to rows for an omitted or unknown dataset id without sniffing columns", () => {
+    const penguinShaped: PortableSpec = {
+      ...spec,
+      data: { values: [{ id: "a1", species: "Adelie", flipper: 181, mass: 3750 }] },
+    };
+
+    for (const output of [
+      playgroundSvelteOutput(penguinShaped),
+      playgroundSvelteOutput(penguinShaped, defaultPlaygroundInteractions(), "not-a-dataset"),
+    ]) {
+      expect(output).toContain("const rows = ");
+      expect(output).not.toContain("const penguins = ");
+    }
+  });
+
+  test("keys the memo on the dataset id as well as the interactions", () => {
+    const dataset: PortableSpec = { ...spec, data: { values: [{ id: "m1", value: 1 }] } };
+    const interactions = defaultPlaygroundInteractions();
+    const asMonthly = playgroundOutputs(dataset, interactions, "monthly");
+    const asCategories = playgroundOutputs(dataset, interactions, "categories");
+
+    expect(asMonthly).not.toBe(asCategories);
+    expect(asMonthly[0]?.code).toContain("const monthly = ");
+    expect(asCategories[0]?.code).toContain("const categories = ");
+    expect(playgroundOutputs(dataset, interactions, "monthly")).toBe(asMonthly);
+  });
+
+  test("every curated dataset id is usable as a JavaScript identifier", () => {
+    for (const schema of PLAYGROUND_DATASET_SCHEMAS) {
+      expect(schema.id).toMatch(/^[A-Za-z_$][\w$]*$/u);
+    }
   });
 
   test("cannot terminate the component script or embed raw JS separators", () => {


### PR DESCRIPTION
## Problem

`playgroundSvelteOutput` named the data seam in the paste-ready Svelte snippet by sniffing the first row's columns:

```ts
if ("species" in first) return "penguins";
if ("date" in first && "value" in first) return "monthly";
if ("region" in first) return "categories";
```

Two consequences (from #694):

- Any user spec that happens to carry a `species` column is mislabelled `const penguins = …`.
- Adding a fourth curated dataset silently degrades the snippet to `const rows = …` with no error.

## Fix

`playgroundOutputs` and `playgroundSvelteOutput` take an optional `datasetId` third argument — the id the caller (`Playground.svelte`) already holds — and resolve the variable name through `isPlaygroundDatasetId`, keeping `playground-dataset-schemas.ts` the single source of truth for dataset identity. An unknown or omitted id emits a generic `rows` seam rather than guessing from the data.

The output memo key now covers the dataset id as well as the interactions, so switching datasets re-emits the snippet instead of serving a stale cached one.

## Tests (TDD, red first)

New cases in `scripts/playground-output.test.ts`:

- every curated dataset id (`penguins`, `monthly`, `categories`) names the seam, and the snippet still round-trips through `parseSpecFromSvelteOutput`
- penguin-shaped rows with `datasetId: "monthly"` emit `const monthly`, never `const penguins`
- omitted **and** unknown ids emit `const rows` — no column sniffing
- the memo is keyed on the dataset id (`monthly` vs `categories` are distinct objects; same args stay identity-stable)
- every curated dataset id is a valid JS identifier — so a future non-identifier id fails loudly here instead of emitting broken snippet source

Three of these failed before the change and pass after.

Closes #694

🤖 Generated with [Claude Code](https://claude.com/claude-code)