### PR TITLE
fix(#709): author playground samples against CURRENT_EDITION

### DIFF
--- a/apps/docs/src/lib/generated/playground-seeds.ts
+++ b/apps/docs/src/lib/generated/playground-seeds.ts
@@ -430,7 +430,7 @@ export const PLAYGROUND_SAMPLES: readonly GeneratedPlaygroundSample[] = [
         id: "starter-scatter",
       },
       spec: {
-        edition: 1,
+        edition: 2,
         data: {
           values: [
             {
@@ -503,7 +503,7 @@ export const PLAYGROUND_SAMPLES: readonly GeneratedPlaygroundSample[] = [
       },
     },
     fragment:
-      "#play=v1.eyJ2ZXJzaW9uIjoxLCJzb3VyY2UiOnsia2luZCI6InNhbXBsZSIsImlkIjoic3RhcnRlci1zY2F0dGVyIn0sInNwZWMiOnsiZWRpdGlvbiI6MSwiZGF0YSI6eyJ2YWx1ZXMiOlt7ImlkIjoiYTEiLCJzcGVjaWVzIjoiQWRlbGllIiwiZmxpcHBlciI6MTgxLCJtYXNzIjozNzUwfSx7ImlkIjoiYTIiLCJzcGVjaWVzIjoiQWRlbGllIiwiZmxpcHBlciI6MTg2LCJtYXNzIjozODAwfSx7ImlkIjoiYzEiLCJzcGVjaWVzIjoiQ2hpbnN0cmFwIiwiZmxpcHBlciI6MTk2LCJtYXNzIjo0MDUwfSx7ImlkIjoiYzIiLCJzcGVjaWVzIjoiQ2hpbnN0cmFwIiwiZmxpcHBlciI6MjAxLCJtYXNzIjo0MzAwfSx7ImlkIjoiZzEiLCJzcGVjaWVzIjoiR2VudG9vIiwiZmxpcHBlciI6MjExLCJtYXNzIjo1MDAwfSx7ImlkIjoiZzIiLCJzcGVjaWVzIjoiR2VudG9vIiwiZmxpcHBlciI6MjIxLCJtYXNzIjo1NTUwfV19LCJsYXllcnMiOlt7Imdlb20iOiJwb2ludCIsInN0YXQiOiJpZGVudGl0eSIsInBvc2l0aW9uIjoiaWRlbnRpdHkiLCJhZXMiOnsieCI6eyJmaWVsZCI6ImZsaXBwZXIifSwieSI6eyJmaWVsZCI6Im1hc3MifSwiY29sb3IiOnsiZmllbGQiOiJzcGVjaWVzIn19LCJwYXJhbXMiOnsic2l6ZSI6NCwiYWxwaGEiOjAuODJ9fV0sImxhYnMiOnsidGl0bGUiOiJQZW5ndWluIGZsaXBwZXJzIGFuZCBib2R5IG1hc3MiLCJ4IjoiRmxpcHBlciBsZW5ndGggKG1tKSIsInkiOiJCb2R5IG1hc3MgKGcpIiwiY29sb3IiOiJTcGVjaWVzIn0sImhlaWdodCI6NDAwfX0",
+      "#play=v1.eyJ2ZXJzaW9uIjoxLCJzb3VyY2UiOnsia2luZCI6InNhbXBsZSIsImlkIjoic3RhcnRlci1zY2F0dGVyIn0sInNwZWMiOnsiZWRpdGlvbiI6MiwiZGF0YSI6eyJ2YWx1ZXMiOlt7ImlkIjoiYTEiLCJzcGVjaWVzIjoiQWRlbGllIiwiZmxpcHBlciI6MTgxLCJtYXNzIjozNzUwfSx7ImlkIjoiYTIiLCJzcGVjaWVzIjoiQWRlbGllIiwiZmxpcHBlciI6MTg2LCJtYXNzIjozODAwfSx7ImlkIjoiYzEiLCJzcGVjaWVzIjoiQ2hpbnN0cmFwIiwiZmxpcHBlciI6MTk2LCJtYXNzIjo0MDUwfSx7ImlkIjoiYzIiLCJzcGVjaWVzIjoiQ2hpbnN0cmFwIiwiZmxpcHBlciI6MjAxLCJtYXNzIjo0MzAwfSx7ImlkIjoiZzEiLCJzcGVjaWVzIjoiR2VudG9vIiwiZmxpcHBlciI6MjExLCJtYXNzIjo1MDAwfSx7ImlkIjoiZzIiLCJzcGVjaWVzIjoiR2VudG9vIiwiZmxpcHBlciI6MjIxLCJtYXNzIjo1NTUwfV19LCJsYXllcnMiOlt7Imdlb20iOiJwb2ludCIsInN0YXQiOiJpZGVudGl0eSIsInBvc2l0aW9uIjoiaWRlbnRpdHkiLCJhZXMiOnsieCI6eyJmaWVsZCI6ImZsaXBwZXIifSwieSI6eyJmaWVsZCI6Im1hc3MifSwiY29sb3IiOnsiZmllbGQiOiJzcGVjaWVzIn19LCJwYXJhbXMiOnsic2l6ZSI6NCwiYWxwaGEiOjAuODJ9fV0sImxhYnMiOnsidGl0bGUiOiJQZW5ndWluIGZsaXBwZXJzIGFuZCBib2R5IG1hc3MiLCJ4IjoiRmxpcHBlciBsZW5ndGggKG1tKSIsInkiOiJCb2R5IG1hc3MgKGcpIiwiY29sb3IiOiJTcGVjaWVzIn0sImhlaWdodCI6NDAwfX0",
   },
   {
     id: "monthly-line",
@@ -516,7 +516,7 @@ export const PLAYGROUND_SAMPLES: readonly GeneratedPlaygroundSample[] = [
         id: "monthly-line",
       },
       spec: {
-        edition: 1,
+        edition: 2,
         data: {
           values: [
             {
@@ -570,7 +570,7 @@ export const PLAYGROUND_SAMPLES: readonly GeneratedPlaygroundSample[] = [
       },
     },
     fragment:
-      "#play=v1.eyJ2ZXJzaW9uIjoxLCJzb3VyY2UiOnsia2luZCI6InNhbXBsZSIsImlkIjoibW9udGhseS1saW5lIn0sInNwZWMiOnsiZWRpdGlvbiI6MSwiZGF0YSI6eyJ2YWx1ZXMiOlt7ImRhdGUiOiIyMDI0LTAxLTAxIiwidmFsdWUiOjR9LHsiZGF0ZSI6IjIwMjQtMDItMDEiLCJ2YWx1ZSI6N30seyJkYXRlIjoiMjAyNC0wMy0wMSIsInZhbHVlIjo1fSx7ImRhdGUiOiIyMDI0LTA0LTAxIiwidmFsdWUiOjl9XX0sImxheWVycyI6W3siZ2VvbSI6ImxpbmUiLCJzdGF0IjoiaWRlbnRpdHkiLCJwb3NpdGlvbiI6ImlkZW50aXR5IiwiYWVzIjp7IngiOnsiZmllbGQiOiJkYXRlIn0sInkiOnsiZmllbGQiOiJ2YWx1ZSJ9fSwicGFyYW1zIjp7ImxpbmV3aWR0aCI6MS44fX1dLCJzY2FsZXMiOnsieCI6eyJ0eXBlIjoidGltZSIsInBhcnNlIjoieW1kIn19LCJsYWJzIjp7InRpdGxlIjoiTW9udGhseSBzZXJpZXMiLCJ4IjoiTW9udGgiLCJ5IjoiVmFsdWUifSwiaGVpZ2h0Ijo0MDB9fQ",
+      "#play=v1.eyJ2ZXJzaW9uIjoxLCJzb3VyY2UiOnsia2luZCI6InNhbXBsZSIsImlkIjoibW9udGhseS1saW5lIn0sInNwZWMiOnsiZWRpdGlvbiI6MiwiZGF0YSI6eyJ2YWx1ZXMiOlt7ImRhdGUiOiIyMDI0LTAxLTAxIiwidmFsdWUiOjR9LHsiZGF0ZSI6IjIwMjQtMDItMDEiLCJ2YWx1ZSI6N30seyJkYXRlIjoiMjAyNC0wMy0wMSIsInZhbHVlIjo1fSx7ImRhdGUiOiIyMDI0LTA0LTAxIiwidmFsdWUiOjl9XX0sImxheWVycyI6W3siZ2VvbSI6ImxpbmUiLCJzdGF0IjoiaWRlbnRpdHkiLCJwb3NpdGlvbiI6ImlkZW50aXR5IiwiYWVzIjp7IngiOnsiZmllbGQiOiJkYXRlIn0sInkiOnsiZmllbGQiOiJ2YWx1ZSJ9fSwicGFyYW1zIjp7ImxpbmV3aWR0aCI6MS44fX1dLCJzY2FsZXMiOnsieCI6eyJ0eXBlIjoidGltZSIsInBhcnNlIjoieW1kIn19LCJsYWJzIjp7InRpdGxlIjoiTW9udGhseSBzZXJpZXMiLCJ4IjoiTW9udGgiLCJ5IjoiVmFsdWUifSwiaGVpZ2h0Ijo0MDB9fQ",
   },
   {
     id: "raw-years",
@@ -583,7 +583,7 @@ export const PLAYGROUND_SAMPLES: readonly GeneratedPlaygroundSample[] = [
         id: "raw-years",
       },
       spec: {
-        edition: 1,
+        edition: 2,
         data: {
           values: [
             {
@@ -627,7 +627,7 @@ export const PLAYGROUND_SAMPLES: readonly GeneratedPlaygroundSample[] = [
       },
     },
     fragment:
-      "#play=v1.eyJ2ZXJzaW9uIjoxLCJzb3VyY2UiOnsia2luZCI6InNhbXBsZSIsImlkIjoicmF3LXllYXJzIn0sInNwZWMiOnsiZWRpdGlvbiI6MSwiZGF0YSI6eyJ2YWx1ZXMiOlt7InllYXIiOiIxODM1IiwidmFsdWUiOjEyfSx7InllYXIiOiIxOTAwIiwidmFsdWUiOjE5fSx7InllYXIiOiIyMDI2IiwidmFsdWUiOjMxfV19LCJsYXllcnMiOlt7Imdlb20iOiJsaW5lIiwic3RhdCI6ImlkZW50aXR5IiwicG9zaXRpb24iOiJpZGVudGl0eSIsImFlcyI6eyJ4Ijp7ImZpZWxkIjoieWVhciJ9LCJ5Ijp7ImZpZWxkIjoidmFsdWUifX0sInBhcmFtcyI6eyJsaW5ld2lkdGgiOjEuOH19XSwibGFicyI6eyJ0aXRsZSI6IlJhdyB5ZWFyIGluZmVyZW5jZSIsIngiOiJZZWFyIiwieSI6IlZhbHVlIn0sImhlaWdodCI6NDAwfX0",
+      "#play=v1.eyJ2ZXJzaW9uIjoxLCJzb3VyY2UiOnsia2luZCI6InNhbXBsZSIsImlkIjoicmF3LXllYXJzIn0sInNwZWMiOnsiZWRpdGlvbiI6MiwiZGF0YSI6eyJ2YWx1ZXMiOlt7InllYXIiOiIxODM1IiwidmFsdWUiOjEyfSx7InllYXIiOiIxOTAwIiwidmFsdWUiOjE5fSx7InllYXIiOiIyMDI2IiwidmFsdWUiOjMxfV19LCJsYXllcnMiOlt7Imdlb20iOiJsaW5lIiwic3RhdCI6ImlkZW50aXR5IiwicG9zaXRpb24iOiJpZGVudGl0eSIsImFlcyI6eyJ4Ijp7ImZpZWxkIjoieWVhciJ9LCJ5Ijp7ImZpZWxkIjoidmFsdWUifX0sInBhcmFtcyI6eyJsaW5ld2lkdGgiOjEuOH19XSwibGFicyI6eyJ0aXRsZSI6IlJhdyB5ZWFyIGluZmVyZW5jZSIsIngiOiJZZWFyIiwieSI6IlZhbHVlIn0sImhlaWdodCI6NDAwfX0",
   },
   {
     id: "iso-dates",
@@ -640,7 +640,7 @@ export const PLAYGROUND_SAMPLES: readonly GeneratedPlaygroundSample[] = [
         id: "iso-dates",
       },
       spec: {
-        edition: 1,
+        edition: 2,
         data: {
           values: [
             {
@@ -684,7 +684,7 @@ export const PLAYGROUND_SAMPLES: readonly GeneratedPlaygroundSample[] = [
       },
     },
     fragment:
-      "#play=v1.eyJ2ZXJzaW9uIjoxLCJzb3VyY2UiOnsia2luZCI6InNhbXBsZSIsImlkIjoiaXNvLWRhdGVzIn0sInNwZWMiOnsiZWRpdGlvbiI6MSwiZGF0YSI6eyJ2YWx1ZXMiOlt7ImRhdGUiOiIyMDI0LTAxLTAxIiwidmFsdWUiOjR9LHsiZGF0ZSI6IjIwMjQtMDItMDEiLCJ2YWx1ZSI6N30seyJkYXRlIjoiMjAyNC0wMy0wMSIsInZhbHVlIjo1fV19LCJsYXllcnMiOlt7Imdlb20iOiJsaW5lIiwic3RhdCI6ImlkZW50aXR5IiwicG9zaXRpb24iOiJpZGVudGl0eSIsImFlcyI6eyJ4Ijp7ImZpZWxkIjoiZGF0ZSJ9LCJ5Ijp7ImZpZWxkIjoidmFsdWUifX0sInBhcmFtcyI6eyJsaW5ld2lkdGgiOjEuOH19XSwibGFicyI6eyJ0aXRsZSI6IklTTyBkYXRlIGluZmVyZW5jZSIsIngiOiJEYXRlIiwieSI6IlZhbHVlIn0sImhlaWdodCI6NDAwfX0",
+      "#play=v1.eyJ2ZXJzaW9uIjoxLCJzb3VyY2UiOnsia2luZCI6InNhbXBsZSIsImlkIjoiaXNvLWRhdGVzIn0sInNwZWMiOnsiZWRpdGlvbiI6MiwiZGF0YSI6eyJ2YWx1ZXMiOlt7ImRhdGUiOiIyMDI0LTAxLTAxIiwidmFsdWUiOjR9LHsiZGF0ZSI6IjIwMjQtMDItMDEiLCJ2YWx1ZSI6N30seyJkYXRlIjoiMjAyNC0wMy0wMSIsInZhbHVlIjo1fV19LCJsYXllcnMiOlt7Imdlb20iOiJsaW5lIiwic3RhdCI6ImlkZW50aXR5IiwicG9zaXRpb24iOiJpZGVudGl0eSIsImFlcyI6eyJ4Ijp7ImZpZWxkIjoiZGF0ZSJ9LCJ5Ijp7ImZpZWxkIjoidmFsdWUifX0sInBhcmFtcyI6eyJsaW5ld2lkdGgiOjEuOH19XSwibGFicyI6eyJ0aXRsZSI6IklTTyBkYXRlIGluZmVyZW5jZSIsIngiOiJEYXRlIiwieSI6IlZhbHVlIn0sImhlaWdodCI6NDAwfX0",
   },
   {
     id: "ambiguous-dates",
@@ -697,7 +697,7 @@ export const PLAYGROUND_SAMPLES: readonly GeneratedPlaygroundSample[] = [
         id: "ambiguous-dates",
       },
       spec: {
-        edition: 1,
+        edition: 2,
         data: {
           values: [
             {
@@ -741,7 +741,7 @@ export const PLAYGROUND_SAMPLES: readonly GeneratedPlaygroundSample[] = [
       },
     },
     fragment:
-      "#play=v1.eyJ2ZXJzaW9uIjoxLCJzb3VyY2UiOnsia2luZCI6InNhbXBsZSIsImlkIjoiYW1iaWd1b3VzLWRhdGVzIn0sInNwZWMiOnsiZWRpdGlvbiI6MSwiZGF0YSI6eyJ2YWx1ZXMiOlt7ImRhdGUiOiIwMy8wNC8yMDI0IiwidmFsdWUiOjR9LHsiZGF0ZSI6IjA1LzA2LzIwMjQiLCJ2YWx1ZSI6N30seyJkYXRlIjoiMDcvMDgvMjAyNCIsInZhbHVlIjo1fV19LCJsYXllcnMiOlt7Imdlb20iOiJsaW5lIiwic3RhdCI6ImlkZW50aXR5IiwicG9zaXRpb24iOiJpZGVudGl0eSIsImFlcyI6eyJ4Ijp7ImZpZWxkIjoiZGF0ZSJ9LCJ5Ijp7ImZpZWxkIjoidmFsdWUifX0sInBhcmFtcyI6eyJsaW5ld2lkdGgiOjEuOH19XSwibGFicyI6eyJ0aXRsZSI6IkFtYmlndW91cyBkYXRlcyBzdGF5IGRpc2NyZXRlIiwieCI6IkRhdGUiLCJ5IjoiVmFsdWUifSwiaGVpZ2h0Ijo0MDB9fQ",
+      "#play=v1.eyJ2ZXJzaW9uIjoxLCJzb3VyY2UiOnsia2luZCI6InNhbXBsZSIsImlkIjoiYW1iaWd1b3VzLWRhdGVzIn0sInNwZWMiOnsiZWRpdGlvbiI6MiwiZGF0YSI6eyJ2YWx1ZXMiOlt7ImRhdGUiOiIwMy8wNC8yMDI0IiwidmFsdWUiOjR9LHsiZGF0ZSI6IjA1LzA2LzIwMjQiLCJ2YWx1ZSI6N30seyJkYXRlIjoiMDcvMDgvMjAyNCIsInZhbHVlIjo1fV19LCJsYXllcnMiOlt7Imdlb20iOiJsaW5lIiwic3RhdCI6ImlkZW50aXR5IiwicG9zaXRpb24iOiJpZGVudGl0eSIsImFlcyI6eyJ4Ijp7ImZpZWxkIjoiZGF0ZSJ9LCJ5Ijp7ImZpZWxkIjoidmFsdWUifX0sInBhcmFtcyI6eyJsaW5ld2lkdGgiOjEuOH19XSwibGFicyI6eyJ0aXRsZSI6IkFtYmlndW91cyBkYXRlcyBzdGF5IGRpc2NyZXRlIiwieCI6IkRhdGUiLCJ5IjoiVmFsdWUifSwiaGVpZ2h0Ijo0MDB9fQ",
   },
   {
     id: "post-stat-coordinate",
@@ -1025,7 +1025,7 @@ export const PLAYGROUND_SAMPLES: readonly GeneratedPlaygroundSample[] = [
         id: "category-columns",
       },
       spec: {
-        edition: 1,
+        edition: 2,
         data: {
           values: [
             {
@@ -1070,6 +1070,6 @@ export const PLAYGROUND_SAMPLES: readonly GeneratedPlaygroundSample[] = [
       },
     },
     fragment:
-      "#play=v1.eyJ2ZXJzaW9uIjoxLCJzb3VyY2UiOnsia2luZCI6InNhbXBsZSIsImlkIjoiY2F0ZWdvcnktY29sdW1ucyJ9LCJzcGVjIjp7ImVkaXRpb24iOjEsImRhdGEiOnsidmFsdWVzIjpbeyJjYXRlZ29yeSI6Ik5vcnRoIiwidmFsdWUiOjE0fSx7ImNhdGVnb3J5IjoiU291dGgiLCJ2YWx1ZSI6OX0seyJjYXRlZ29yeSI6IkVhc3QiLCJ2YWx1ZSI6MTd9LHsiY2F0ZWdvcnkiOiJXZXN0IiwidmFsdWUiOjEyfV19LCJsYXllcnMiOlt7Imdlb20iOiJjb2wiLCJzdGF0IjoiaWRlbnRpdHkiLCJwb3NpdGlvbiI6InN0YWNrIiwiYWVzIjp7IngiOnsiZmllbGQiOiJjYXRlZ29yeSJ9LCJ5Ijp7ImZpZWxkIjoidmFsdWUifX19XSwibGFicyI6eyJ0aXRsZSI6IkNhdGVnb3J5IHRvdGFscyIsIngiOiJSZWdpb24iLCJ5IjoiVmFsdWUifSwiaGVpZ2h0Ijo0MDB9fQ",
+      "#play=v1.eyJ2ZXJzaW9uIjoxLCJzb3VyY2UiOnsia2luZCI6InNhbXBsZSIsImlkIjoiY2F0ZWdvcnktY29sdW1ucyJ9LCJzcGVjIjp7ImVkaXRpb24iOjIsImRhdGEiOnsidmFsdWVzIjpbeyJjYXRlZ29yeSI6Ik5vcnRoIiwidmFsdWUiOjE0fSx7ImNhdGVnb3J5IjoiU291dGgiLCJ2YWx1ZSI6OX0seyJjYXRlZ29yeSI6IkVhc3QiLCJ2YWx1ZSI6MTd9LHsiY2F0ZWdvcnkiOiJXZXN0IiwidmFsdWUiOjEyfV19LCJsYXllcnMiOlt7Imdlb20iOiJjb2wiLCJzdGF0IjoiaWRlbnRpdHkiLCJwb3NpdGlvbiI6InN0YWNrIiwiYWVzIjp7IngiOnsiZmllbGQiOiJjYXRlZ29yeSJ9LCJ5Ijp7ImZpZWxkIjoidmFsdWUifX19XSwibGFicyI6eyJ0aXRsZSI6IkNhdGVnb3J5IHRvdGFscyIsIngiOiJSZWdpb24iLCJ5IjoiVmFsdWUifSwiaGVpZ2h0Ijo0MDB9fQ",
   },
 ];

--- a/apps/docs/src/lib/playground-samples.ts
+++ b/apps/docs/src/lib/playground-samples.ts
@@ -1,4 +1,4 @@
-import type { PortableSpec } from "@ggsvelte/spec";
+import { CURRENT_EDITION, type PortableSpec } from "@ggsvelte/spec";
 
 export interface PlaygroundSample {
   readonly id: string;
@@ -13,7 +13,7 @@ export const PLAYGROUND_SAMPLES = [
     title: "Penguin scatter",
     description: "Compare flipper length and body mass by species.",
     spec: {
-      edition: 1,
+      edition: CURRENT_EDITION,
       data: {
         values: [
           { id: "a1", species: "Adelie", flipper: 181, mass: 3750 },
@@ -51,7 +51,7 @@ export const PLAYGROUND_SAMPLES = [
     title: "Monthly line",
     description: "Edit a compact time series with an explicit date parser.",
     spec: {
-      edition: 1,
+      edition: CURRENT_EDITION,
       data: {
         values: [
           { date: "2024-01-01", value: 4 },
@@ -79,7 +79,7 @@ export const PLAYGROUND_SAMPLES = [
     title: "Raw years",
     description: "Infer a calendar axis from unprocessed four-digit year strings.",
     spec: {
-      edition: 1,
+      edition: CURRENT_EDITION,
       data: {
         values: [
           { year: "1835", value: 12 },
@@ -105,7 +105,7 @@ export const PLAYGROUND_SAMPLES = [
     title: "ISO dates",
     description: "Infer a calendar axis from unprocessed ISO date strings.",
     spec: {
-      edition: 1,
+      edition: CURRENT_EDITION,
       data: {
         values: [
           { date: "2024-01-01", value: 4 },
@@ -131,7 +131,7 @@ export const PLAYGROUND_SAMPLES = [
     title: "Ambiguous dates",
     description: "Keep ambiguous day/month strings discrete until a parser is explicit.",
     spec: {
-      edition: 1,
+      edition: CURRENT_EDITION,
       data: {
         values: [
           { date: "03/04/2024", value: 4 },
@@ -157,7 +157,7 @@ export const PLAYGROUND_SAMPLES = [
     title: "Post-stat coordinate transform",
     description: "Fit in ordinary scale space, then project the final x coordinate through log10.",
     spec: {
-      edition: 2,
+      edition: CURRENT_EDITION,
       data: {
         values: [
           { exposure: 1, response: 2.2 },
@@ -204,7 +204,7 @@ export const PLAYGROUND_SAMPLES = [
     description:
       "Fit an equal-unit data rectangle after chart chrome so a unit circle stays circular.",
     spec: {
-      edition: 2,
+      edition: CURRENT_EDITION,
       data: {
         values: [
           { x: 1, y: 0 },
@@ -241,7 +241,7 @@ export const PLAYGROUND_SAMPLES = [
     title: "Binned colorsteps",
     description: "Translate quantitative values into deterministic semantic color intervals.",
     spec: {
-      edition: 2,
+      edition: CURRENT_EDITION,
       data: {
         values: [
           { hour: 0, pm25: 4 },
@@ -285,7 +285,7 @@ export const PLAYGROUND_SAMPLES = [
     title: "Category columns",
     description: "Compare a few named categories with direct values.",
     spec: {
-      edition: 1,
+      edition: CURRENT_EDITION,
       data: {
         values: [
           { category: "North", value: 14 },

--- a/scripts/gen-playground-seeds.test.ts
+++ b/scripts/gen-playground-seeds.test.ts
@@ -3,9 +3,13 @@ import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import type { PortableSpec } from "@ggsvelte/spec";
+import { CURRENT_EDITION, type PortableSpec } from "@ggsvelte/spec";
 
 import { EXAMPLES } from "../examples/manifest";
+import {
+  playgroundBuilderOutput,
+  playgroundSvelteOutput,
+} from "../apps/docs/src/lib/playground-output";
 import { PLAYGROUND_SAMPLES } from "../apps/docs/src/lib/playground-samples";
 import { evaluatePlaygroundCompatibility, generatePlaygroundSeeds } from "./gen-playground-seeds";
 
@@ -119,4 +123,29 @@ describe("generated playground seeds", () => {
         "This example is larger than the 12 KiB share limit. Open a smaller example or sample.",
     });
   }, 15_000); // Full Linux coverage consistently takes ~5.35s; keep the integrity check intact.
+
+  test("authors every sample against the current defaults edition", async () => {
+    // A sample that pins an older edition freezes THAT edition's default look
+    // into every seed and copied snippet it produces (#709).
+    expect(PLAYGROUND_SAMPLES.map((sample) => [sample.id, sample.spec.edition])).toEqual(
+      PLAYGROUND_SAMPLES.map((sample) => [sample.id, CURRENT_EDITION]),
+    );
+
+    const generated = await import("../apps/docs/src/lib/generated/playground-seeds");
+    expect(
+      generated.PLAYGROUND_SAMPLES.map((sample) => [sample.id, sample.seed.spec.edition]),
+    ).toEqual(generated.PLAYGROUND_SAMPLES.map((sample) => [sample.id, CURRENT_EDITION]));
+  });
+
+  test("hands copied snippets the current defaults edition", async () => {
+    const generated = await import("../apps/docs/src/lib/generated/playground-seeds");
+    const starter = generated.PLAYGROUND_SAMPLES.find((sample) => sample.id === "starter-scatter");
+    if (starter === undefined) throw new Error("the default starter-scatter sample is missing");
+    const spec = starter.seed.spec;
+
+    expect(playgroundSvelteOutput(spec)).toContain(`"edition": ${String(CURRENT_EDITION)}`);
+    const builder = playgroundBuilderOutput(spec);
+    expect(builder.supported).toBe(true);
+    expect(builder.code).toContain(`"edition": ${String(CURRENT_EDITION)}`);
+  });
 });


### PR DESCRIPTION
## Problem

`PLAYGROUND_SAMPLES` pinned `edition: 1` on six sample specs — including `starter-scatter`, the chart the playground opens by default — while `CURRENT_EDITION` is `2` (`packages/spec/src/schema-catalog.ts:36`).

Editions key the default theme table (`packages/core/src/editions.ts`: edition 1 → `LEGACY_BUILTIN_THEMES`, edition 2 → `BUILTIN_THEMES`), so the pin was load-bearing. Every copy path serializes the spec verbatim (`playgroundSvelteOutput`) or re-stamps `spec.edition ?? CURRENT_EDITION` (`playground-output-builder.ts:53,102`), which means a user copying the playground's own starter snippet walked away with `"edition": 1` — legacy defaults frozen into their code forever.

## Fix

`apps/docs/src/lib/playground-samples.ts` now imports `CURRENT_EDITION` and uses it for all nine samples (replacing both the six `1`s and the three already-correct hardcoded `2`s), so the pin tracks the schema catalog instead of drifting from it. Generated seeds regenerated via `bun run playground:seeds:gen`.

## Gallery / examples decision

Examples were already correct and are untouched: no `examples/*/spec.ts` sets `edition` (`grep -rln edition examples --include=spec.ts` → 0 hits), and `evaluatePlaygroundCompatibility` runs every example through `normalize()`, which stamps `CURRENT_EDITION` when absent (`packages/spec/src/normalize.ts:259`). The samples file was the only pin source.

## Tests

Two new tests in `scripts/gen-playground-seeds.test.ts` (RED before the fix, both failing on the exact symptom):

- every sample carries `CURRENT_EDITION`, in both the source array and the generated seed specs
- the default `starter-scatter` sample's copied **Svelte** and **Builder** snippets both emit `"edition": 2`

## Verification

- `bun test scripts/gen-playground-seeds.test.ts` → 6 pass, 0 fail
- `bun run test` (full unit suite) → 2469 pass, 0 fail
- `bun run playground:seeds:check` → seeds current
- `bun run check`, `bun run check:docs` (svelte-check: 1784 files, 0 errors, 0 warnings), `bun run lint`, `bun run lint:type-aware`, `bun run fmt:check` → all clean

No VR baseline impact: `tests/visual/vr.spec.ts` screenshots only `/examples/*` routes; no VR spec snapshots a playground sample chart.

Closes #709

🤖 Generated with [Claude Code](https://claude.com/claude-code)