### PR TITLE
ci: make interaction-perf opt-in via the run-bench label

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,9 +300,16 @@ jobs:
   interaction-perf:
     name: interaction-perf (p50/p95, informational)
     needs: [detect-changes, packages-dist]
+    # Opt-in only. The job is informational (its exit code is swallowed) but it
+    # still sits pending for ~15 min on every PR, so agents and humans waiting
+    # on "all checks reported" are blocked by a check that can never fail them.
+    # Budgets are still enforced — bench.yml's bench-label job runs the same
+    # `bun run test:interaction-perf` un-suppressed on 'run-bench' PRs — so this
+    # gate loses no coverage, it just stops taxing every unrelated PR.
     if: >-
       needs.detect-changes.outputs.interaction_perf == 'true' &&
-      needs.packages-dist.result == 'success'
+      needs.packages-dist.result == 'success' &&
+      contains(github.event.pull_request.labels.*.name, 'run-bench')
     uses: ./.github/workflows/ci-interaction-perf.yml
     permissions:
       contents: read


### PR DESCRIPTION
`interaction-perf` is informational — `ci-interaction-perf.yml` swallows the exit code and emits only a `::warning::` — yet it holds a pending check slot for ~15 minutes on every PR. Anything that waits for all checks to report blocks on a gate that cannot fail it.

Perf budgets are unaffected. `bench.yml`'s `bench-label` job already runs the same `bun run test:interaction-perf` **un-suppressed** on PRs labeled `run-bench`, and that one actually gates. This change points the informational run at the same label, so perf work opts in once and gets both.

Routing plumbing is untouched: the `interaction_perf` detect-changes output, content-hash inputs, and the ci-gate exclusion all stay as they were. 138 routing/wiring tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)