### PR TITLE
fix(#697): close playground-api error-taxonomy and contract gaps

### DIFF
--- a/apps/docs/src/lib/Playground.svelte
+++ b/apps/docs/src/lib/Playground.svelte
@@ -80,7 +80,10 @@
     setAgentValidating,
     type PlaygroundAgentState,
   } from "$lib/playground-agent-state";
-  import { validateAgentEnvelope } from "$lib/playground-agent-validate";
+  import {
+    agentFailureIsRepairable,
+    validateAgentEnvelope,
+  } from "$lib/playground-agent-validate";
   import type { PlaygroundDatasetId } from "$lib/playground-dataset-schemas";
   import {
     PLAYGROUND_DEFAULT_DATASET,
@@ -371,8 +374,13 @@
       agent = setAgentValidating(agent);
       let validated = validateAgentEnvelope(envelope, dataset);
 
-      if (!validated.ok && options.example === undefined) {
-        // One repair round with raw SpecError[].
+      // One repair round, and only with raw SpecError[] to repair from: a
+      // seed-bound failure carries none, so repairing would spend a second
+      // model call and double the wait for nothing (#697).
+      if (
+        options.example === undefined &&
+        agentFailureIsRepairable(validated)
+      ) {
         agent = setAgentRepairing(agent);
         const repair = await generateChart(
           {

--- a/apps/docs/src/lib/playground-agent-client.ts
+++ b/apps/docs/src/lib/playground-agent-client.ts
@@ -97,6 +97,8 @@ function mapApiErrorCode(code: unknown): PlaygroundAgentErrorCode {
     "prompt_too_long",
     "unknown_dataset",
     "origin_forbidden",
+    "not_found",
+    "method_not_allowed",
     "rate_limited",
     "upstream_rate_limited",
     "upstream_error",
@@ -107,6 +109,41 @@ function mapApiErrorCode(code: unknown): PlaygroundAgentErrorCode {
     return code as PlaygroundAgentErrorCode;
   }
   return "upstream_error";
+}
+
+/**
+ * A body only counts as an error the worker sent when it carries the contract
+ * shape `{ ok: false, error: {…} }`. Cloudflare 1101 pages, proxy errors, and
+ * captive portals do not, and must not be reported as model output (#697).
+ */
+function workerErrorBody(body: unknown): Record<string, unknown> | null {
+  if (body === null || typeof body !== "object") return null;
+  const record = body as { ok?: unknown; error?: unknown };
+  if (record.ok !== false) return null;
+  if (record.error === null || typeof record.error !== "object" || Array.isArray(record.error)) {
+    return null;
+  }
+  return record.error as Record<string, unknown>;
+}
+
+/** Seconds from a `Retry-After` delta header; absent/date forms are ignored. */
+function retryAfterSeconds(response: Response): number | undefined {
+  const raw = response.headers.get("Retry-After");
+  if (raw === null) return undefined;
+  const seconds = Number(raw.trim());
+  return Number.isFinite(seconds) && seconds >= 0 ? seconds : undefined;
+}
+
+/**
+ * Failures with no worker body: the transport reached *something*, but not the
+ * generate contract. Status is the only signal, so it decides the code.
+ */
+function codeForStatuslessBody(status: number): PlaygroundAgentErrorCode {
+  if (status === 429) return "rate_limited";
+  // 2xx means the worker answered with a body it should never produce; every
+  // other status means the request never reached a working worker.
+  if (status >= 200 && status < 300) return "bad_output";
+  return "service_error";
 }
 
 export async function generateChart(
@@ -175,10 +212,14 @@ export async function generateChart(
   try {
     body = await response.json();
   } catch {
+    // Not JSON at all: an edge error page, a proxy, or a captive portal.
+    const code = codeForStatuslessBody(response.status);
+    const retryAfter = retryAfterSeconds(response);
     return {
       ok: false,
-      code: "bad_output",
-      message: messageForAgentError("bad_output"),
+      code,
+      message: messageForAgentError(code),
+      ...(retryAfter === undefined ? {} : { retryAfterSeconds: retryAfter }),
     };
   }
 
@@ -205,17 +246,26 @@ export async function generateChart(
     };
   }
 
-  const error =
-    body !== null && typeof body === "object" && "error" in body
-      ? (body as { error: Record<string, unknown> }).error
-      : null;
-  const code = mapApiErrorCode(error?.code);
+  const error = workerErrorBody(body);
+  if (error === null) {
+    // JSON, but not the generate contract — status is the only honest signal.
+    const code = codeForStatuslessBody(response.status);
+    const retryAfter = retryAfterSeconds(response);
+    return {
+      ok: false,
+      code,
+      message: messageForAgentError(code),
+      ...(retryAfter === undefined ? {} : { retryAfterSeconds: retryAfter }),
+    };
+  }
+
+  const code = mapApiErrorCode(error.code);
   const retryAfter =
-    typeof error?.retryAfterSeconds === "number" ? error.retryAfterSeconds : undefined;
+    typeof error.retryAfterSeconds === "number" ? error.retryAfterSeconds : undefined;
   return {
     ok: false,
     code,
-    message: typeof error?.message === "string" ? error.message : messageForAgentError(code),
+    message: typeof error.message === "string" ? error.message : messageForAgentError(code),
     ...(retryAfter === undefined ? {} : { retryAfterSeconds: retryAfter }),
   };
 }

--- a/apps/docs/src/lib/playground-agent-envelope.ts
+++ b/apps/docs/src/lib/playground-agent-envelope.ts
@@ -3,6 +3,9 @@
  * Shape: { spec, interactions?, title? }
  */
 
+import { discretenessOf, inferFieldType, type CellValue } from "@ggsvelte/core";
+import { configuredColorScaleType } from "@ggsvelte/spec";
+
 export interface PlaygroundInteractions {
   readonly inspect: boolean;
   readonly select: false | "point" | "interval";
@@ -137,42 +140,94 @@ export function parsePlaygroundAgentEnvelope(input: unknown): ParseEnvelopeResul
   };
 }
 
-function aesHasDiscreteLegendChannel(aes: unknown): boolean {
-  if (aes === null || typeof aes !== "object" || Array.isArray(aes)) {
-    return false;
-  }
-  const a = aes as Record<string, unknown>;
-  for (const channel of ["color", "fill", "colour"] as const) {
-    const mapping = a[channel];
-    if (
-      mapping !== null &&
-      typeof mapping === "object" &&
-      !Array.isArray(mapping) &&
-      "field" in mapping
-    ) {
-      return true;
-    }
-    if (typeof mapping === "string" && mapping.length > 0) return true;
-  }
-  return false;
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
-/** Whether the chart appears to carry a discrete color/fill legend channel. */
-export function chartHasDiscreteLegend(spec: unknown): boolean {
-  if (spec === null || typeof spec !== "object" || Array.isArray(spec)) {
-    return false;
+const COLOR_CHANNELS = ["color", "fill", "colour"] as const;
+type ColorChannel = (typeof COLOR_CHANNELS)[number];
+
+/** Families that draw a keyed legend; `sequential`/`binned` draw a ramp/steps. */
+const DISCRETE_COLOR_FAMILIES: ReadonlySet<string> = new Set(["ordinal", "manual", "identity"]);
+
+/**
+ * Field a color channel maps to, or null for constants (`{value}`) and absent
+ * channels. Bare strings are not valid channel values, but models emit them,
+ * so they are read leniently as field names.
+ */
+function colorChannelField(aes: unknown, channel: ColorChannel): string | null {
+  if (!isRecord(aes)) return null;
+  const mapping = aes[channel];
+  if (isRecord(mapping) && typeof mapping.field === "string" && mapping.field !== "") {
+    return mapping.field;
   }
-  const record = spec as Record<string, unknown>;
-  if (aesHasDiscreteLegendChannel(record.aes)) return true;
-  const layers = record.layers;
+  if (typeof mapping === "string" && mapping !== "") return mapping;
+  return null;
+}
+
+/** One column's cells from inline rows or inline columns; null when absent. */
+function columnValues(data: unknown, field: string): CellValue[] | null {
+  if (!isRecord(data)) return null;
+  const rows = data.values;
+  if (Array.isArray(rows)) {
+    const column: CellValue[] = [];
+    for (const row of rows) {
+      if (isRecord(row) && field in row) column.push(row[field] as CellValue);
+    }
+    return column.length > 0 ? column : null;
+  }
+  const columns = data.columns;
+  if (isRecord(columns) && Array.isArray(columns[field])) {
+    const column = columns[field] as CellValue[];
+    return column.length > 0 ? column : null;
+  }
+  return null;
+}
+
+/**
+ * Whether one color channel resolves to a discrete legend, mirroring the
+ * pipeline: an authored family wins, otherwise the field's inferred type
+ * decides (quantitative and temporal fields train a continuous ramp).
+ */
+function channelDrawsDiscreteLegend(
+  spec: Record<string, unknown>,
+  layerData: unknown,
+  aes: unknown,
+  channel: ColorChannel,
+): boolean {
+  const field = colorChannelField(aes, channel);
+  if (field === null) return false;
+
+  const scales = spec.scales;
+  const config = isRecord(scales) ? scales[channel === "colour" ? "color" : channel] : undefined;
+  const family = configuredColorScaleType(isRecord(config) ? config : undefined);
+  if (family !== undefined) return DISCRETE_COLOR_FAMILIES.has(family);
+
+  const column = columnValues(layerData, field) ?? columnValues(spec.data, field);
+  // Named or absent data: the runtime may still draw a keyed legend, so keep
+  // the affordance rather than silently dropping it.
+  if (column === null) return true;
+  return discretenessOf(inferFieldType(column)) === "discrete";
+}
+
+/**
+ * Whether the chart draws a discrete color/fill legend — the only kind that
+ * can be filtered or focused. Field presence alone is not enough: a
+ * quantitative field renders a colorbar with no keys to click (#697).
+ */
+export function chartHasDiscreteLegend(spec: unknown): boolean {
+  if (!isRecord(spec)) return false;
+  for (const channel of COLOR_CHANNELS) {
+    if (channelDrawsDiscreteLegend(spec, spec.data, spec.aes, channel)) return true;
+  }
+  const layers = spec.layers;
   if (Array.isArray(layers)) {
     for (const layer of layers) {
-      if (
-        layer !== null &&
-        typeof layer === "object" &&
-        aesHasDiscreteLegendChannel((layer as Record<string, unknown>).aes)
-      ) {
-        return true;
+      if (!isRecord(layer)) continue;
+      for (const channel of COLOR_CHANNELS) {
+        if (channelDrawsDiscreteLegend(spec, layer.data ?? spec.data, layer.aes, channel)) {
+          return true;
+        }
       }
     }
   }

--- a/apps/docs/src/lib/playground-agent-state.ts
+++ b/apps/docs/src/lib/playground-agent-state.ts
@@ -21,11 +21,15 @@ export type PlaygroundAgentErrorCode =
   | "prompt_too_long"
   | "unknown_dataset"
   | "origin_forbidden"
+  | "not_found"
+  | "method_not_allowed"
   | "rate_limited"
   | "upstream_rate_limited"
   | "upstream_error"
   | "bad_output"
   | "disabled"
+  /** The service itself failed or was intercepted — no worker body came back. */
+  | "service_error"
   | "network"
   | "validation"
   | "pipeline"
@@ -175,6 +179,12 @@ export function messageForAgentError(code: PlaygroundAgentErrorCode, fallback?: 
       return "The model returned an unusable chart. Try a sample or rephrase.";
     case "upstream_error":
       return "The model provider failed. Try again or use a sample chart.";
+    case "service_error":
+      // Edge outage, proxy, or captive portal: nothing the user can rephrase.
+      return "The generate service is unavailable. Try again shortly, or use a sample chart.";
+    case "not_found":
+    case "method_not_allowed":
+      return "The generate service is misconfigured. Use a sample chart or copy the agent prompt.";
     case "origin_forbidden":
       return "This origin cannot call live generation. Use a sample or copy the agent prompt.";
     case "prompt_too_long":

--- a/apps/docs/src/lib/playground-agent-validate.ts
+++ b/apps/docs/src/lib/playground-agent-validate.ts
@@ -29,6 +29,12 @@ const VALIDATE_LIMITS = {
   maxDiagnostics: 100,
 } as const;
 
+export interface AgentValidateFailure {
+  readonly ok: false;
+  readonly errors: readonly SpecError[];
+  readonly message: string;
+}
+
 export type AgentValidateResult =
   | {
       readonly ok: true;
@@ -37,11 +43,20 @@ export type AgentValidateResult =
       readonly interactions: PlaygroundInteractions;
       readonly title: string | null;
     }
-  | {
-      readonly ok: false;
-      readonly errors: readonly SpecError[];
-      readonly message: string;
-    };
+  | AgentValidateFailure;
+
+/**
+ * Whether a failure carries diagnostics a repair round could act on.
+ *
+ * Seed bounds are share-codec limits, not SpecError codes, so those failures
+ * return `errors: []`. Repairing on an empty list spends a second model call —
+ * and doubles the user's wait — on a prompt with no diagnostic signal (#697).
+ */
+export function agentFailureIsRepairable(
+  result: AgentValidateResult,
+): result is AgentValidateFailure {
+  return !result.ok && result.errors.length > 0;
+}
 
 export function validateAgentEnvelope(
   envelope: PlaygroundAgentEnvelope,

--- a/scripts/playground-agent-envelope.test.ts
+++ b/scripts/playground-agent-envelope.test.ts
@@ -59,6 +59,133 @@ describe("playground agent envelope", () => {
     expect(coerced.legendFocus).toBe(false);
   });
 
+  // A quantitative colour channel renders a colourbar, which has nothing to
+  // filter or focus — but the invitation line still promised legend filtering
+  // because only field *presence* was checked (#697).
+  test("continuous colour channels do not enable legend filter/focus", () => {
+    const rows = [
+      { species: "Adelie", mass: 3750, date: "2024-01-01" },
+      { species: "Gentoo", mass: 5200, date: "2024-02-01" },
+    ];
+    const quantitative = {
+      data: { values: rows },
+      layers: [{ geom: "point", aes: { color: { field: "mass" } } }],
+    };
+    expect(chartHasDiscreteLegend(quantitative)).toBe(false);
+
+    const temporal = {
+      data: { values: rows },
+      layers: [{ geom: "point", aes: { color: { field: "date" } } }],
+    };
+    expect(chartHasDiscreteLegend(temporal)).toBe(false);
+
+    const discrete = {
+      data: { values: rows },
+      layers: [{ geom: "point", aes: { color: { field: "species" } } }],
+    };
+    expect(chartHasDiscreteLegend(discrete)).toBe(true);
+
+    const coerced = coerceInteractionsForChart(
+      {
+        inspect: true,
+        select: false,
+        zoom: false,
+        legendFilter: true,
+        legendFocus: true,
+      },
+      chartHasDiscreteLegend(quantitative),
+    );
+    expect(coerced.legendFilter).toBe(false);
+    expect(coerced.legendFocus).toBe(false);
+  });
+
+  test("column-oriented data is read for the same decision", () => {
+    const columns = {
+      data: { columns: { region: ["North", "South"], amount: [12, 40] } },
+      layers: [{ geom: "bar", aes: { fill: { field: "amount" } } }],
+    };
+    expect(chartHasDiscreteLegend(columns)).toBe(false);
+    expect(
+      chartHasDiscreteLegend({
+        data: { columns: { region: ["North", "South"], amount: [12, 40] } },
+        layers: [{ geom: "bar", aes: { fill: { field: "region" } } }],
+      }),
+    ).toBe(true);
+  });
+
+  test("the configured colour scale family outranks the data", () => {
+    const rows = [
+      { grade: 1, label: "a" },
+      { grade: 2, label: "b" },
+    ];
+    // Numbers, but authored as categories → discrete legend.
+    expect(
+      chartHasDiscreteLegend({
+        data: { values: rows },
+        scales: { color: { type: "ordinal" } },
+        layers: [{ geom: "point", aes: { color: { field: "grade" } } }],
+      }),
+    ).toBe(true);
+    // Strings, but authored as a ramp/steps → colourbar or colour steps.
+    for (const type of ["sequential", "binned"] as const) {
+      expect(
+        chartHasDiscreteLegend({
+          data: { values: rows },
+          scales: { fill: { type } },
+          layers: [{ geom: "bar", aes: { fill: { field: "label" } } }],
+        }),
+      ).toBe(false);
+    }
+    // A sequential scheme implies the same family without an explicit type.
+    expect(
+      chartHasDiscreteLegend({
+        data: { values: rows },
+        scales: { color: { scheme: "viridis" } },
+        layers: [{ geom: "point", aes: { color: { field: "label" } } }],
+      }),
+    ).toBe(false);
+  });
+
+  test("an unresolvable colour field keeps the legend affordance", () => {
+    // No data to profile: the runtime may still draw a discrete legend, so the
+    // toggles stay available rather than silently disappearing.
+    expect(
+      chartHasDiscreteLegend({
+        layers: [{ geom: "point", aes: { color: { field: "species" } } }],
+      }),
+    ).toBe(true);
+    expect(
+      chartHasDiscreteLegend({
+        data: { values: [{ species: "Adelie" }] },
+        layers: [{ geom: "point", aes: { color: { field: "absent" } } }],
+      }),
+    ).toBe(true);
+  });
+
+  test("layer-local data profiles the layer's own colour field", () => {
+    expect(
+      chartHasDiscreteLegend({
+        data: { values: [{ species: "Adelie" }] },
+        layers: [
+          {
+            geom: "point",
+            data: { values: [{ mass: 3750 }, { mass: 5200 }] },
+            aes: { color: { field: "mass" } },
+          },
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  test("constant colour is not a legend channel", () => {
+    expect(
+      chartHasDiscreteLegend({
+        data: { values: [{ mass: 1 }] },
+        layers: [{ geom: "point", aes: { color: { value: "steelblue" } } }],
+      }),
+    ).toBe(false);
+  });
+
   test("caps title length and strips control characters", () => {
     const result = parsePlaygroundAgentEnvelope({
       spec: { layers: [], data: { values: [] } },

--- a/scripts/playground-agent-state.test.ts
+++ b/scripts/playground-agent-state.test.ts
@@ -46,6 +46,17 @@ describe("playground agent state", () => {
     expect(messageForAgentError("network")).toContain("Could not reach");
   });
 
+  test("every code has copy that does not blame the model for an infra failure", () => {
+    // A service outage must not tell the user to rephrase their prompt, and a
+    // misrouted client must not read as a model failure (#697).
+    expect(messageForAgentError("service_error")).not.toContain("model");
+    expect(messageForAgentError("service_error")).toContain("sample");
+    for (const code of ["not_found", "method_not_allowed"] as const) {
+      expect(messageForAgentError(code)).not.toContain("model returned");
+      expect(messageForAgentError(code).length).toBeGreaterThan(0);
+    }
+  });
+
   test("failAgent records taxonomy", () => {
     const state = failAgent(beginAgentRequest(createPlaygroundAgentState()), {
       code: "rate_limited",
@@ -186,5 +197,129 @@ describe("generateChart live-mode response handling", () => {
     expect(result.ok).toBe(false);
     if (result.ok) return;
     expect(result.code).toBe("bad_output");
+  });
+});
+
+// bad_output means "the worker gave us a chart we cannot use" and tells the
+// user to rephrase. An edge outage or captive portal is neither the model's
+// fault nor fixable by rephrasing, so status is read before the body (#697).
+describe("generateChart separates infrastructure failures from bad output", () => {
+  const infraBody = "<html><title>1101 Worker threw exception</title></html>";
+
+  test("edge 5xx HTML is a service failure, not unusable model output", async () => {
+    for (const status of [500, 502, 503]) {
+      const result = await generateChart(
+        { prompt: "hi", datasetId: "penguins" },
+        {
+          mode: "live",
+          apiUrl: "https://example.test",
+          fetchFn: () => Promise.resolve(new Response(infraBody, { status })),
+        },
+      );
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.code).toBe("service_error");
+      expect(result.message).not.toContain("rephrase");
+    }
+  });
+
+  test("worker-shaped 502 keeps the code the worker declared", async () => {
+    for (const code of ["upstream_error", "bad_output"] as const) {
+      const result = await generateChart(
+        { prompt: "hi", datasetId: "penguins" },
+        {
+          mode: "live",
+          apiUrl: "https://example.test",
+          fetchFn: () =>
+            Promise.resolve(
+              new Response(JSON.stringify({ ok: false, error: { code, message: "m" } }), {
+                status: 502,
+              }),
+            ),
+        },
+      );
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.code).toBe(code);
+    }
+  });
+
+  test("an intermediary 429 with no worker body still throttles the UI", async () => {
+    const result = await generateChart(
+      { prompt: "hi", datasetId: "penguins" },
+      {
+        mode: "live",
+        apiUrl: "https://example.test",
+        fetchFn: () =>
+          Promise.resolve(
+            new Response("<html>rate limited</html>", {
+              status: 429,
+              headers: { "Retry-After": "30" },
+            }),
+          ),
+      },
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.code).toBe("rate_limited");
+    expect(result.retryAfterSeconds).toBe(30);
+  });
+
+  test("a 404 from a misrouted client is not reported as a model failure", async () => {
+    const result = await generateChart(
+      { prompt: "hi", datasetId: "penguins" },
+      {
+        mode: "live",
+        apiUrl: "https://example.test",
+        fetchFn: () =>
+          Promise.resolve(
+            new Response(
+              JSON.stringify({ ok: false, error: { code: "not_found", message: "No such." } }),
+              { status: 404 },
+            ),
+          ),
+      },
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.code).toBe("not_found");
+  });
+
+  test("a 200 worker body with no envelope is still bad_output", async () => {
+    const result = await generateChart(
+      { prompt: "hi", datasetId: "penguins" },
+      {
+        mode: "live",
+        apiUrl: "https://example.test",
+        fetchFn: () => Promise.resolve(new Response(JSON.stringify({ ok: true }), { status: 200 })),
+      },
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.code).toBe("bad_output");
+  });
+
+  test("a null model (worker could not attribute the completion) reads as unknown", async () => {
+    const result = await generateChart(
+      { prompt: "hi", datasetId: "penguins" },
+      {
+        mode: "live",
+        apiUrl: "https://example.test",
+        fetchFn: () =>
+          Promise.resolve(
+            new Response(
+              JSON.stringify({
+                ok: true,
+                model: null,
+                envelope: { spec: { edition: 2, data: { name: "penguins" }, layers: [] } },
+              }),
+              { status: 200 },
+            ),
+          ),
+      },
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.model).toBe("unknown");
   });
 });

--- a/scripts/playground-agent-validate.test.ts
+++ b/scripts/playground-agent-validate.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  agentFailureIsRepairable,
+  validateAgentEnvelope,
+} from "../apps/docs/src/lib/playground-agent-validate";
+import {
+  defaultPlaygroundInteractions,
+  type PlaygroundAgentEnvelope,
+} from "../apps/docs/src/lib/playground-agent-envelope";
+
+function envelope(spec: unknown): PlaygroundAgentEnvelope {
+  return { spec, interactions: defaultPlaygroundInteractions(), title: null };
+}
+
+const scatter = {
+  edition: 2,
+  data: { name: "penguins" },
+  layers: [{ geom: "point", aes: { x: { field: "flipper" }, y: { field: "mass" } } }],
+};
+
+describe("agent envelope repair gate", () => {
+  test("spec errors are repairable — the model gets diagnostics to work from", () => {
+    const result = validateAgentEnvelope(
+      envelope({ ...scatter, layers: [{ geom: "point", aes: { x: { field: "nope" } } }] }),
+      "penguins",
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors.length).toBeGreaterThan(0);
+    expect(agentFailureIsRepairable(result)).toBe(true);
+  });
+
+  // Seed bounds are share-codec limits, not SpecError codes, so the repair
+  // round would send `priorErrors: []` — a second model call carrying zero
+  // diagnostic signal while doubling the user's wait and the spend (#697).
+  test("seed-bound failures are not repairable", () => {
+    const result = validateAgentEnvelope(
+      envelope({ ...scatter, labs: { subtitle: "x".repeat(3000) } }),
+      "penguins",
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors).toEqual([]);
+    expect(result.message).toContain("code points");
+    expect(agentFailureIsRepairable(result)).toBe(false);
+  });
+
+  test("a valid envelope is never repairable", () => {
+    const result = validateAgentEnvelope(envelope(scatter), "penguins");
+    expect(result.ok).toBe(true);
+    expect(agentFailureIsRepairable(result)).toBe(false);
+  });
+});

--- a/workers/playground-api/README.md
+++ b/workers/playground-api/README.md
@@ -82,6 +82,11 @@ Response:
 }
 ```
 
+`model` is `null` when the completion does not name the model that answered:
+`models[]` requests provider-side fallback, so the first allowlist entry is a
+guess, and that guess would also pollute the outcome log used to tune
+`MODEL_ALLOWLIST`.
+
 or
 
 ```json
@@ -91,11 +96,32 @@ or
 }
 ```
 
-Error codes: `bad_request | prompt_too_long | unknown_dataset | origin_forbidden |
-rate_limited | upstream_rate_limited | upstream_error | bad_output | disabled`.
+Error codes and their canonical statuses:
+
+| Code                                                | Status |
+| --------------------------------------------------- | ------ |
+| `bad_request`, `prompt_too_long`, `unknown_dataset` | 400    |
+| `origin_forbidden`                                  | 403    |
+| `not_found`                                         | 404    |
+| `method_not_allowed`                                | 405    |
+| `rate_limited`, `upstream_rate_limited`             | 429    |
+| `upstream_error`, `bad_output`                      | 502    |
+| `disabled`                                          | 503    |
+
+`statusForError(code)` reproduces the status from the code alone, and every
+error body — including the router's 404 — comes from `apiError()`.
 
 Semantic validation is **client-side**. The worker only checks that the model
 returned a JSON object.
+
+## CORS
+
+Success responses require an allowlisted origin (`src/cors.ts`). Refusals do
+not: preflight is approved for every origin and the 403 `origin_forbidden` body
+echoes the requesting origin in `Access-Control-Allow-Origin`, so the client
+reads a typed error instead of an opaque browser-level network failure.
+Credentials are never allowed, and the allowlist still gates generation itself —
+an unlisted origin gets the 403 without any upstream call.
 
 ## Logging
 

--- a/workers/playground-api/eval/run-eval.ts
+++ b/workers/playground-api/eval/run-eval.ts
@@ -23,6 +23,8 @@ import { DEFAULT_MODELS } from "../src/handler";
 
 const GATE = 0.7;
 const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
+/** Row label when the completion does not say which model answered. */
+const UNATTRIBUTED_MODEL = "(unattributed)";
 
 interface EvalCase {
   readonly id: string;
@@ -97,7 +99,10 @@ async function callOpenRouter(
   };
   const content = json.choices?.[0]?.message?.content;
   if (typeof content !== "string") return { error: "empty content" };
-  return { model: json.model ?? models[0]!, content };
+  // The eval exists to pick models: attributing a row to models[0] when the
+  // completion did not name one would corrupt the very statistic it produces,
+  // since `models` requests provider-side fallback (#697).
+  return { model: json.model ?? UNATTRIBUTED_MODEL, content };
 }
 
 function validateEnvelope(

--- a/workers/playground-api/src/cors.ts
+++ b/workers/playground-api/src/cors.ts
@@ -21,6 +21,20 @@ export function matchCorsOrigin(origin: string | null): string | null {
   return null;
 }
 
+/**
+ * Headers for a refused or not-found response (403 origin_forbidden, 404).
+ *
+ * These bodies carry no data — only a typed error code — so they echo the
+ * requesting origin. Without `Access-Control-Allow-Origin` the browser blocks
+ * the body, `fetch` rejects with a TypeError, and the client can only report a
+ * generic network failure, which made `origin_forbidden` unreachable (#697).
+ * Never grants credentials: the allowlist still gates every success response.
+ */
+export function errorCorsHeaders(origin: string | null): Record<string, string> {
+  if (origin === null || origin === "") return { Vary: "Origin" };
+  return { "Access-Control-Allow-Origin": origin, Vary: "Origin" };
+}
+
 // Returns a plain record, not the wider `HeadersInit` union: callers spread
 // the result into response-header literals, and `HeadersInit` also admits
 // `string[][]`, which would spread to numeric indices.

--- a/workers/playground-api/src/errors.ts
+++ b/workers/playground-api/src/errors.ts
@@ -5,6 +5,8 @@ export type PlaygroundApiErrorCode =
   | "prompt_too_long"
   | "unknown_dataset"
   | "origin_forbidden"
+  | "not_found"
+  | "method_not_allowed"
   | "rate_limited"
   | "upstream_rate_limited"
   | "upstream_error"
@@ -24,7 +26,8 @@ export interface PlaygroundApiErrorResponse {
 
 export interface PlaygroundApiSuccessResponse {
   readonly ok: true;
-  readonly model: string;
+  /** null when the completion did not name the model that answered (#697). */
+  readonly model: string | null;
   readonly envelope: unknown;
 }
 
@@ -52,6 +55,8 @@ const ERROR_STATUS: Record<PlaygroundApiErrorCode, number> = {
   prompt_too_long: 400,
   unknown_dataset: 400,
   origin_forbidden: 403,
+  not_found: 404,
+  method_not_allowed: 405,
   rate_limited: 429,
   upstream_rate_limited: 429,
   disabled: 503,
@@ -70,6 +75,8 @@ export const SAFE_MESSAGES = {
   prompt_too_long: `Prompt is too long (max ${PLAYGROUND_PROMPT_MAX_CHARS} characters).`,
   unknown_dataset: "Unknown dataset.",
   origin_forbidden: "Origin is not allowed.",
+  not_found: "No such endpoint.",
+  method_not_allowed: "Method not allowed.",
   rate_limited: "Too many requests. Try again shortly.",
   upstream_rate_limited: "The model provider is rate-limiting. Try again shortly.",
   upstream_error: "The model provider failed. Try again or use a sample chart.",

--- a/workers/playground-api/src/handler.ts
+++ b/workers/playground-api/src/handler.ts
@@ -3,7 +3,7 @@
  */
 
 import { isPlaygroundDatasetId } from "../../../apps/docs/src/lib/playground-dataset-schemas";
-import { corsHeaders, matchCorsOrigin } from "./cors";
+import { corsHeaders, errorCorsHeaders, matchCorsOrigin } from "./cors";
 import { apiError, SAFE_MESSAGES, statusForError, type PlaygroundApiResponse } from "./errors";
 import {
   buildChatMessages,
@@ -116,21 +116,27 @@ export async function handleGenerate(request: Request, env: PlaygroundApiEnv): P
   const cors = corsHeaders(matchedOrigin);
 
   if (request.method === "OPTIONS") {
-    if (origin !== null && matchedOrigin === null) {
-      return jsonResponse(apiError("origin_forbidden", SAFE_MESSAGES.origin_forbidden), 403, cors);
-    }
-    return new Response(null, { status: 204, headers: cors });
+    // Preflight is approved for every origin, including unlisted ones. The
+    // allowlist is enforced on the actual request below; a 403 preflight is a
+    // browser-level network error, which would leave the typed origin_forbidden
+    // body unreadable and force the client into a bogus `network` code (#697).
+    return new Response(null, { status: 204, headers: corsHeaders(matchedOrigin ?? origin) });
   }
 
   if (request.method !== "POST") {
-    return jsonResponse(apiError("bad_request", SAFE_MESSAGES.bad_request), 405, {
-      ...cors,
-      Allow: "POST, OPTIONS",
-    });
+    return jsonResponse(
+      apiError("method_not_allowed", SAFE_MESSAGES.method_not_allowed),
+      statusForError("method_not_allowed"),
+      { ...cors, Allow: "POST, OPTIONS" },
+    );
   }
 
   if (origin !== null && matchedOrigin === null) {
-    return jsonResponse(apiError("origin_forbidden", SAFE_MESSAGES.origin_forbidden), 403, cors);
+    return jsonResponse(
+      apiError("origin_forbidden", SAFE_MESSAGES.origin_forbidden),
+      statusForError("origin_forbidden"),
+      errorCorsHeaders(origin),
+    );
   }
 
   // Fail CLOSED: a key with no rate limiting is an unshaped public proxy.
@@ -369,8 +375,13 @@ export async function handleGenerate(request: Request, env: PlaygroundApiEnv): P
     );
   }
 
+  // `models` requests provider-side fallback, so the first entry is not
+  // necessarily what answered. Attributing output — and the outcome log that
+  // tunes MODEL_ALLOWLIST — to a guess is worse than reporting null (#697).
   const model =
-    isObject(completion) && typeof completion.model === "string" ? completion.model : models[0]!;
+    isObject(completion) && typeof completion.model === "string" && completion.model !== ""
+      ? completion.model
+      : null;
 
   const content = extractContent(completion);
   if (content === null) {

--- a/workers/playground-api/src/index.ts
+++ b/workers/playground-api/src/index.ts
@@ -2,6 +2,8 @@
  * Cloudflare Worker entry — playground generate API.
  */
 
+import { errorCorsHeaders } from "./cors";
+import { apiError, SAFE_MESSAGES, statusForError } from "./errors";
 import { handleGenerate, type PlaygroundApiEnv } from "./handler";
 
 export interface Env extends PlaygroundApiEnv {}
@@ -18,14 +20,15 @@ export default {
         headers: { "Content-Type": "application/json; charset=utf-8", Vary: "Origin" },
       });
     }
-    // Cross-origin callers cannot read this body (no ACAO by design) — the
-    // shipped client only calls /v1/generate.
-    return new Response(
-      JSON.stringify({ ok: false, error: { code: "bad_request", message: "Not found." } }),
-      {
-        status: 404,
-        headers: { "Content-Type": "application/json; charset=utf-8", Vary: "Origin" },
+    // One taxonomy: the 404 body comes from apiError() with a code whose
+    // canonical status is 404, and it echoes the origin so a misrouted client
+    // reads `not_found` instead of an opaque CORS failure (#697).
+    return new Response(JSON.stringify(apiError("not_found", SAFE_MESSAGES.not_found)), {
+      status: statusForError("not_found"),
+      headers: {
+        "Content-Type": "application/json; charset=utf-8",
+        ...errorCorsHeaders(request.headers.get("Origin")),
       },
-    );
+    });
   },
 };

--- a/workers/playground-api/test/handler.test.ts
+++ b/workers/playground-api/test/handler.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
 import { matchCorsOrigin } from "../src/cors";
+import { statusForError } from "../src/errors";
 import { DEFAULT_MODELS, handleGenerate, sanitizeForLeak } from "../src/handler";
+import worker from "../src/index";
 import {
   assembleSystemPrompt,
   buildChatMessages,
@@ -100,6 +102,49 @@ describe("handleGenerate", () => {
     expect(res.status).toBe(403);
     const body = (await res.json()) as { error: { code: string } };
     expect(body.error.code).toBe("origin_forbidden");
+  });
+
+  // Without these two the typed 403 is undeliverable: the browser blocks a
+  // preflight that is not 2xx, and blocks a response with no ACAO, so the
+  // client reports `network` and the origin_forbidden arm is dead code (#697).
+  test("forbidden origin can read the 403 body (echoed ACAO, no credentials)", async () => {
+    const res = await handleGenerate(
+      request({ prompt: "hi", datasetId: "penguins" }, { origin: "https://evil.example" }),
+      { OPENROUTER_API_KEY: "sk-test" },
+    );
+    expect(res.status).toBe(403);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("https://evil.example");
+    expect(res.headers.get("Vary")).toBe("Origin");
+    expect(res.headers.get("Access-Control-Allow-Credentials")).toBeNull();
+  });
+
+  test("preflight succeeds for an unlisted origin so the POST can be refused in JSON", async () => {
+    const res = await handleGenerate(
+      request({}, { method: "OPTIONS", origin: "https://evil.example" }),
+      {},
+    );
+    expect(res.status).toBe(204);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("https://evil.example");
+    expect(res.headers.get("Access-Control-Allow-Methods")).toBe("POST, OPTIONS");
+    expect(res.headers.get("Access-Control-Allow-Headers")).toBe("Content-Type");
+    expect(res.headers.get("Access-Control-Allow-Credentials")).toBeNull();
+  });
+
+  test("preflight approval does not let an unlisted origin generate", async () => {
+    let called = false;
+    const res = await handleGenerate(
+      request({ prompt: "hi", datasetId: "penguins" }, { origin: "https://evil.example" }),
+      {
+        OPENROUTER_API_KEY: "sk-test",
+        ...okLimiters,
+        fetch: () => {
+          called = true;
+          return Promise.resolve(new Response("{}", { status: 200 }));
+        },
+      },
+    );
+    expect(res.status).toBe(403);
+    expect(called).toBe(false);
   });
 
   test("prompt too long and unknown dataset", async () => {
@@ -225,6 +270,66 @@ describe("handleGenerate", () => {
     expect(body.envelope).toEqual(envelope);
   });
 
+  // models[] enables provider-side fallback, so models[0] is a guess, not a
+  // fact — and that guess also feeds the outcome log used to tune the
+  // allowlist. Unknown must stay unknown (#697).
+  test("model is null when the completion omits it", async () => {
+    const logs: Record<string, unknown>[] = [];
+    const res = await handleGenerate(request({ prompt: "scatter", datasetId: "penguins" }), {
+      OPENROUTER_API_KEY: "sk-test-key",
+      MODEL_ALLOWLIST: "vendor/free-a, vendor/free-b",
+      ...okLimiters,
+      log: (line) => {
+        logs.push(line);
+      },
+      fetch: () =>
+        Promise.resolve(
+          new Response(JSON.stringify({ choices: [{ message: { content: "{}" } }] }), {
+            status: 200,
+          }),
+        ),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; model: string | null };
+    expect(body.ok).toBe(true);
+    expect(body.model).toBeNull();
+    expect(logs.at(-1)?.["model"]).toBeNull();
+  });
+
+  test("blank or non-string model is reported as unknown, not as the first allowlist entry", async () => {
+    const res = await handleGenerate(request({ prompt: "scatter", datasetId: "penguins" }), {
+      OPENROUTER_API_KEY: "sk-test-key",
+      ...okLimiters,
+      fetch: () =>
+        Promise.resolve(
+          new Response(JSON.stringify({ model: "", choices: [{ message: { content: "{}" } }] }), {
+            status: 200,
+          }),
+        ),
+    });
+    expect(((await res.json()) as { model: string | null }).model).toBeNull();
+  });
+
+  test("bad_output logs the real model when the completion names one", async () => {
+    const logs: Record<string, unknown>[] = [];
+    await handleGenerate(request({ prompt: "scatter", datasetId: "penguins" }), {
+      OPENROUTER_API_KEY: "sk-test-key",
+      ...okLimiters,
+      log: (line) => {
+        logs.push(line);
+      },
+      fetch: () =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify({ model: "vendor/fallback", choices: [{ message: { content: "[]" } }] }),
+            { status: 200 },
+          ),
+        ),
+    });
+    expect(logs.at(-1)?.["outcome"]).toBe("bad_output");
+    expect(logs.at(-1)?.["model"]).toBe("vendor/fallback");
+  });
+
   test("refuses oversized priorSpec before calling OpenRouter", async () => {
     let called = false;
     const huge = "x".repeat(9 * 1024);
@@ -341,6 +446,11 @@ describe("handleGenerate", () => {
     );
     expect(res.status).toBe(405);
     expect(res.headers.get("Allow")).toBe("POST, OPTIONS");
+    // The status must be reproducible from the code alone — bad_request would
+    // canonicalize to 400 and misreport the failure to any client that maps it.
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("method_not_allowed");
+    expect(statusForError("method_not_allowed")).toBe(405);
   });
 
   // The outbound call is the only place money is spent. Without these
@@ -478,5 +588,41 @@ describe("handleGenerate", () => {
     );
     expect(res.status).toBe(400);
     expect(called).toBe(false);
+  });
+});
+
+describe("worker routing", () => {
+  test("health responds without touching the generate path", async () => {
+    const res = await worker.fetch(new Request("https://playground-api.ggsvelte.sh/health"), {});
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as { ok: boolean }).ok).toBe(true);
+  });
+
+  test("unknown paths return a typed not_found body at 404", async () => {
+    const res = await worker.fetch(
+      new Request("https://playground-api.ggsvelte.sh/v2/generate", {
+        headers: { Origin: "https://ggsvelte.sh" },
+      }),
+      {},
+    );
+    expect(res.status).toBe(404);
+    expect(statusForError("not_found")).toBe(404);
+    const body = (await res.json()) as { ok: boolean; error: { code: string } };
+    expect(body.ok).toBe(false);
+    expect(body.error.code).toBe("not_found");
+    // Allowed origins must be able to read the body they were sent.
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("https://ggsvelte.sh");
+  });
+
+  test("unknown paths from an unlisted origin stay readable but uncredentialed", async () => {
+    const res = await worker.fetch(
+      new Request("https://playground-api.ggsvelte.sh/nope", {
+        headers: { Origin: "https://evil.example" },
+      }),
+      {},
+    );
+    expect(res.status).toBe(404);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("https://evil.example");
+    expect(res.headers.get("Access-Control-Allow-Credentials")).toBeNull();
   });
 });


### PR DESCRIPTION
Closes #697.

Six post-merge gaps from the review of #683, each fixed test-first. No item was deferred.

## 1. `origin_forbidden` was unreachable from any browser

`corsHeaders(null)` emitted only `Vary`, and the OPTIONS preflight for an unlisted origin was itself a 403. A preflight that is not 2xx is a browser-level network error, so `fetch` rejected with a `TypeError` before the POST was ever sent — the client reported `network` and both the `mapApiErrorCode` and `messageForAgentError` arms for `origin_forbidden` were dead code.

Preflight is now approved for every origin, and refusals (403, and the router's 404) echo the requesting origin via `errorCorsHeaders()`. **The allowlist is unchanged as a control**: the actual POST from an unlisted origin still returns 403 before any upstream call, and credentials are never granted. Covered by a test asserting the refused origin never reaches OpenRouter.

## 2. Infrastructure outages were reported as `bad_output`

`playground-agent-client.ts` JSON-parsed every response and labelled anything unparseable "The model returned an unusable chart" — telling users to rephrase their prompt during a Cloudflare 1101 or a captive-portal interception.

The client now checks the contract shape first (`{ ok: false, error: {…} }`) and falls back to status:

| Response | Code |
|----------|------|
| worker-shaped body | the code the worker declared |
| 2xx, not worker-shaped | `bad_output` |
| 429, not worker-shaped | `rate_limited` (+ `Retry-After`) |
| any other non-2xx | `service_error` *(new)* |

## 3. Seed-bound failures fired a useless repair round

`validateAgentEnvelope` returns `errors: []` for share-codec limit failures, but the pipeline still ran repair with `priorErrors: []` — a second model call with zero diagnostic signal, doubling the user's wait and the spend. Gated on a new `agentFailureIsRepairable()` type guard.

## 4. `model` misattributed output

`models[]` requests provider-side fallback, so `models[0]` was a guess — and it fed the outcome log used to tune `MODEL_ALLOWLIST`. Unknown is now `null` (`PlaygroundApiSuccessResponse.model` is `string | null`); the client still renders `"unknown"`. Same one-line fix in the maintainer eval script, whose entire purpose is per-model statistics.

## 5. 405/404 used `bad_request` (canonical status 400)

Added `method_not_allowed` (405) and `not_found` (404) to `PlaygroundApiErrorCode`, and routed the handler's 405 and the router's hand-rolled 404 through `apiError()` + `statusForError()`. Both new codes were added to the client union too, so the worker cannot emit a code the client silently rewrites to `upstream_error`.

## 6. `legendFilter`/`legendFocus` on continuous colour

`chartHasDiscreteLegend()` only checked that a colour/fill channel had a `field`, so `color: {field: "mass"}` drew a colourbar while the invitation line promised legend filtering.

It now mirrors the pipeline's own decision (`configuredColorScaleType() ?? discreteness of the inferred field type`), reusing `inferFieldType`/`discretenessOf` from `@ggsvelte/core` rather than re-deriving the rule:

- authored `ordinal` / `manual` / `identity` → discrete; `sequential` / `binned` → not
- otherwise the field's values decide (quantitative and temporal → continuous)
- unresolvable field (named dataset, absent column) → keeps the affordance, as today

Swept every shipped playground sample: exactly one verdict changes — `binned-colorsteps`, which colours a quantitative field through a binned scale. That is the bug.

## Validation

Each gap was reproduced as a failing test before the fix (e.g. the 403 test failed on a missing `Access-Control-Allow-Origin`; the client returned `bad_output` for a 500 HTML body; `chartHasDiscreteLegend` returned `true` for `color: {field: "mass"}`).

```
bun test workers/playground-api scripts   →  691 pass, 0 fail
bun run test (full suite)                 →  2494 pass, 0 fail
bun run check / check:docs                →  0 errors, 0 warnings (1784 files)
bun run lint / lint:type-aware / knip / lint:md / fmt:check → clean
```

New tests: 11 worker tests (readable 403, preflight approval, allowlist still enforced, typed 404/405, null model, unattributed-model logging) and 15 docs-lib tests (status-first taxonomy, repair gate, continuous-colour legend detection incl. column-oriented data, layer-local data, and authored scale families).

## Follow-ups

- #720 (new) — `workers/playground-api` is outside CI: `ci-unit.yml` does not list it, `ci-routing` has no `workers` lane, and no `tsc` covers it. The worker tests in this PR were verified locally; CI will not run them until that lands.
- #695 already tracks deduplicating the worker/client error-code union — this PR adds two codes to both sides by hand, which makes that follow-up more valuable, not less.

🤖 Generated with [Claude Code](https://claude.com/claude-code)