### PR TITLE
fix(#717): key VR approve idempotency on the open PR, not the branch

### DIFF
--- a/.github/workflows/vr-approve.yml
+++ b/.github/workflows/vr-approve.yml
@@ -24,7 +24,13 @@
 #      still lands through a human-reviewed PR.)
 #   5. Writes ONLY to a `vr-update/pr-<n>` branch in the base repo (never to
 #      the PR branch, never to a fork), idempotent per rendered merge SHA.
-#   6. `contents: write` is job-scoped; the workflow default is no permissions.
+#      The unit of idempotency is the OPEN PR, not the branch: a branch whose
+#      PR was never opened gets one instead of a silent skip (issue #717).
+#   6. `contents: write` and `pull-requests: write` are job-scoped (the latter
+#      only to open the vr-update PR); the workflow default is no permissions.
+#   7. Credential separation: every step holding GH_TOKEN is script-free
+#      (`gh`/`git` only). Repository code — the preview generator and the
+#      decision script — runs with no token in the environment.
 #
 # Companion guard: ci.yml's `vr-baseline-guard` job rejects any PR diff that
 # touches tests/visual/__screenshots__/ unless it comes from a same-repo
@@ -48,7 +54,7 @@ concurrency:
 
 jobs:
   approve:
-    name: verify candidate baselines, commit to vr-update branch
+    name: verify candidate baselines, commit to vr-update branch, open its PR
     if: github.event.workflow_run.conclusion == 'success'
     # GitHub-hosted: privileged write path (pushes vr-update branches); keep off
     # the self-hosted pool that runs untrusted PR code.
@@ -56,7 +62,7 @@ jobs:
     permissions:
       contents: write # push the verified vr-update/pr-<n> branch
       actions: read # download the triggering run's artifact
-      pull-requests: read # re-verify the approval comment / merged PR via API
+      pull-requests: write # re-verify the approval via API + open the vr-update PR (#717)
     steps:
       - name: flavor gate — only /approve-visuals (issue_comment) runs proceed
         id: gate
@@ -234,30 +240,75 @@ jobs:
           fi
           echo "approval verified: ${author} approved merged PR #${PR_NUMBER} @ ${RENDER_SHA}"
 
-      - name: idempotency — skip if this render SHA is already on the branch
-        id: idem
+      - name: read vr-update branch state (script-free, credentialed)
+        id: branch_state
         if: steps.gate.outputs.approved == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ steps.verify.outputs.pr }}
-          RENDER_SHA: ${{ steps.verify.outputs.render_sha }}
+          TIP_MESSAGE_FILE: ${{ runner.temp }}/vr-branch-tip-message.txt
         run: |
           set -euo pipefail
           branch="vr-update/pr-${PR_NUMBER}"
           tip="$(git ls-remote "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" "refs/heads/${branch}" | cut -f1)"
+          landed=false
+          open_pr=""
+          : > "${TIP_MESSAGE_FILE}"
           if [ -n "${tip}" ]; then
-            message="$(gh api "repos/${REPO}/commits/${tip}" --jq .commit.message)"
-            if printf '%s' "${message}" | grep -qF "${RENDER_SHA}"; then
-              echo "::notice::${branch} tip already carries baselines for ${RENDER_SHA} — nothing to do"
-              echo "skip=true" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
+            # The tip message is arbitrary text, so it travels by file — never
+            # through GITHUB_OUTPUT (delimiter forgery) or a run: interpolation.
+            gh api "repos/${REPO}/commits/${tip}" --jq .commit.message > "${TIP_MESSAGE_FILE}"
+            default_branch="$(gh api "repos/${REPO}" --jq .default_branch)"
+            default_sha="$(gh api --method GET "repos/${REPO}/commits" -f sha="${default_branch}" -f per_page=1 --jq '.[0].sha')"
+            # ahead/identical means the tip is already contained in the default
+            # branch — its PR merged, so there is nothing left to open.
+            case "$(gh api "repos/${REPO}/compare/${tip}...${default_sha}" --jq .status)" in
+              identical|ahead) landed=true ;;
+            esac
+            open_pr="$(gh api --method GET "repos/${REPO}/pulls" -f state=open -f head="${REPO%%/*}:${branch}" --jq '.[0].number // empty')"
           fi
-          echo "skip=false" >> "$GITHUB_OUTPUT"
+          {
+            echo "tip=${tip}"
+            echo "landed=${landed}"
+            echo "open_pr=${open_pr}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: checkout the decision script from the default branch
+        if: steps.gate.outputs.approved == 'true'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Workflow control flow belongs to the default branch, like this file:
+          # recovering a PR merged before the script existed must still work.
+          ref: ${{ github.event.repository.default_branch }}
+          sparse-checkout: scripts/vr-approve-decision.ts
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+          path: tools
+
+      - name: setup Bun for the decision script and merged-commit generator
+        if: steps.gate.outputs.approved == 'true'
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.3.14
+
+      - name: decide — skip, open the missing PR, or render (issue #717)
+        id: decide
+        if: steps.gate.outputs.approved == 'true'
+        env:
+          RENDER_SHA: ${{ steps.verify.outputs.render_sha }}
+          BRANCH_TIP_SHA: ${{ steps.branch_state.outputs.tip }}
+          BRANCH_TIP_LANDED: ${{ steps.branch_state.outputs.landed }}
+          OPEN_PR_NUMBER: ${{ steps.branch_state.outputs.open_pr }}
+          TIP_MESSAGE_FILE: ${{ runner.temp }}/vr-branch-tip-message.txt
+        run: |
+          set -euo pipefail
+          # No token in this environment: the decision is repository code.
+          BRANCH_TIP_MESSAGE="$(cat "${TIP_MESSAGE_FILE}")" \
+            bun tools/scripts/vr-approve-decision.ts action
 
       - name: checkout exact verified merged commit from base repo
-        if: steps.gate.outputs.approved == 'true' && steps.idem.outputs.skip != 'true'
+        if: steps.gate.outputs.approved == 'true' && steps.decide.outputs.action == 'render'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # Pin trusted generation to the exact commit used for screenshots;
@@ -266,21 +317,15 @@ jobs:
           persist-credentials: false
           path: base
 
-      - name: setup Bun for verified merged-commit generator
-        if: steps.gate.outputs.approved == 'true' && steps.idem.outputs.skip != 'true'
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-        with:
-          bun-version: 1.3.14
-
       - name: install dependencies at verified merged commit
-        if: steps.gate.outputs.approved == 'true' && steps.idem.outputs.skip != 'true'
+        if: steps.gate.outputs.approved == 'true' && steps.decide.outputs.action == 'render'
         working-directory: base
         run: bun install --frozen-lockfile
         env:
           BUN_INSTALL_CACHE_DIR: ${{ runner.temp }}/bun-install-cache
 
       - name: materialize verified baseline branch without write credentials
-        if: steps.gate.outputs.approved == 'true' && steps.idem.outputs.skip != 'true'
+        if: steps.gate.outputs.approved == 'true' && steps.decide.outputs.action == 'render'
         env:
           PR_NUMBER: ${{ steps.verify.outputs.pr }}
         run: |
@@ -303,7 +348,8 @@ jobs:
             apps/docs/src/lib/generated/gallery-previews.ts
 
       - name: commit and push verified baselines to vr-update/pr-<n>
-        if: steps.gate.outputs.approved == 'true' && steps.idem.outputs.skip != 'true'
+        id: push
+        if: steps.gate.outputs.approved == 'true' && steps.decide.outputs.action == 'render'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
@@ -323,9 +369,76 @@ jobs:
           old_tip="$(git ls-remote "${push_url}" "refs/heads/${branch}" | cut -f1)"
           if git diff --cached --quiet; then
             echo "no baseline changes — nothing to commit (idempotent per render SHA)"
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           git commit -m "vr: update baselines for PR #${pr} @ ${APPROVED_RENDER_SHA}"
           git push --force-with-lease="refs/heads/${branch}:${old_tip}" \
             "${push_url}" "HEAD:refs/heads/${branch}"
           echo "pushed verified baselines to ${branch}"
+          echo "pushed=true" >> "$GITHUB_OUTPUT"
+
+      - name: re-read open PRs for the branch (script-free, credentialed)
+        id: pr_state
+        if: steps.gate.outputs.approved == 'true' && steps.decide.outputs.action != 'skip'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.verify.outputs.pr }}
+        run: |
+          set -euo pipefail
+          # Re-read rather than reuse the earlier fact: a maintainer may have
+          # opened the PR by hand while this run was rendering.
+          branch="vr-update/pr-${PR_NUMBER}"
+          open_pr="$(gh api --method GET "repos/${REPO}/pulls" -f state=open -f head="${REPO%%/*}:${branch}" --jq '.[0].number // empty')"
+          echo "open_pr=${open_pr}" >> "$GITHUB_OUTPUT"
+
+      - name: decide whether the vr-update PR still needs opening
+        id: pr_decide
+        if: steps.gate.outputs.approved == 'true' && steps.decide.outputs.action != 'skip'
+        env:
+          ACTION: ${{ steps.decide.outputs.action }}
+          PUSHED: ${{ steps.push.outputs.pushed == 'true' }}
+          OPEN_PR_NUMBER: ${{ steps.pr_state.outputs.open_pr }}
+        run: |
+          set -euo pipefail
+          bun tools/scripts/vr-approve-decision.ts pr-create
+
+      - name: open the vr-update PR (script-free, credentialed)
+        if: steps.gate.outputs.approved == 'true' && steps.pr_decide.outputs.create == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.verify.outputs.pr }}
+          RENDER_SHA: ${{ steps.verify.outputs.render_sha }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          branch="vr-update/pr-${PR_NUMBER}"
+          # printf, not a heredoc: block-scalar indentation would otherwise
+          # prefix every body line and render the whole thing as a code block.
+          body="$(printf '%s\n' \
+            "Baselines rendered by the pinned VR container at ${RENDER_SHA} — the merged" \
+            "commit for #${PR_NUMBER} — and verified by .github/workflows/vr-approve.yml" \
+            "(approver permission, merged default-branch commit, PNG-only artifact)." \
+            "" \
+            "Opened automatically so approved baselines cannot strand on an unreachable" \
+            "branch (issue #717)." \
+            "" \
+            "> [!IMPORTANT]" \
+            "> GitHub does not start workflow runs for pull requests opened by the" \
+            "> Actions token, so the required checks are absent here. Close and reopen" \
+            "> this PR to run them before merging.")"
+          url="$(gh pr create --repo "${REPO}" \
+            --base "${DEFAULT_BRANCH}" \
+            --head "${branch}" \
+            --title "vr: update baselines for PR #${PR_NUMBER} @ ${RENDER_SHA}" \
+            --body "${body}")"
+          echo "::notice::opened ${url} — close and reopen it to run the required checks"
+          {
+            echo "## VR baselines ready for review"
+            echo ""
+            echo "${url}"
+            echo ""
+            echo "Close and reopen it to run the required checks (Actions-opened PRs get none)."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -407,8 +407,9 @@ uploads inert PNG candidates. After source lands, `vr-approve.yml` independently
 verifies the comment, permission, default-branch merge, timestamp, and immutable
 `merge_commit_sha`. It checks out only that already-merged base-repository
 commit, verifies the PNG artifact, and runs the matching preview generator
-without `GH_TOKEN` in its environment. Only the final script-free commit/push
-step receives the write credential.
+without `GH_TOKEN` in its environment. Every step that holds the write
+credential is script-free (`gh`/`git` only): the commit/push and the
+`gh pr create` that opens the baseline PR.
 
 The source-first landing order is deliberate:
 
@@ -419,12 +420,22 @@ The source-first landing order is deliberate:
 2. Merge the source PR into the default branch.
 3. Comment `/approve-visuals` on the **merged** PR. A pre-merge command is
    rejected, including one recorded in the same second as the merge.
-4. Review and merge the generated `vr-update/pr-<n>` PR.
+4. Review and merge the generated `vr-update/pr-<n>` PR. The approve workflow
+   opens it for you, and **close + reopen it once** so the required checks
+   run — GitHub starts no workflow runs for pull requests opened by the
+   Actions token.
 
 This creates a short, explicit window where source has landed but its approved
 baselines have not. Finish step 4 promptly. Never merge an unexplained visual
 diff, and do not make VR Compare a required branch-protection check without
 redesigning this source-first protocol.
+
+Idempotency keys on the **open PR**, not the branch (issue #717): re-running
+`/approve-visuals` while the baseline PR is open is a no-op, but a
+`vr-update/pr-<n>` branch that already carries the right render and has no open
+PR gets one opened rather than a silent skip. The three-way decision
+(skip / open the PR / render, push, open the PR) lives in
+`scripts/vr-approve-decision.ts` and is unit-tested.
 
 ## Lifecycle policy (Hadley lesson 13)
 

--- a/scripts/release-wiring.test.ts
+++ b/scripts/release-wiring.test.ts
@@ -549,6 +549,73 @@ it("regenerates docs-owned gallery previews when approved baselines land", () =>
   expect(approve).toContain("apps/docs/src/lib/generated/gallery-previews.ts");
 });
 
+it("opens the vr-update PR instead of stranding baselines on a branch (issue #717)", () => {
+  const approve = read(".github/workflows/vr-approve.yml");
+
+  // Least privilege: PR write is added for `gh pr create`, nothing else moves.
+  expect(approve).toContain("pull-requests: write");
+  expect(approve).toContain("contents: write");
+  expect(approve).not.toContain("issues: write");
+
+  // The decision itself lives in a unit-tested script, not in YAML shell.
+  expect(approve).toContain("bun tools/scripts/vr-approve-decision.ts action");
+  expect(approve).toContain("bun tools/scripts/vr-approve-decision.ts pr-create");
+  // …run from the default branch, so recovering an old merged PR never depends
+  // on the rendered commit predating this script.
+  expect(approve).toContain("ref: ${{ github.event.repository.default_branch }}");
+  expect(approve).toContain("sparse-checkout: scripts/vr-approve-decision.ts");
+
+  // Open-PR existence is a fact the decision consumes, not a branch-tip guess.
+  expect(approve).toContain("-f state=open");
+  expect(approve).toContain('-f head="${REPO%%/*}:${branch}"');
+  expect(approve).not.toContain('echo "skip=true"');
+
+  // Render and the two PR-creation steps are gated on the script's verdicts.
+  expect(approve).toContain("steps.decide.outputs.action == 'render'");
+  expect(approve).toContain("steps.decide.outputs.action != 'skip'");
+  expect(approve).toContain("steps.pr_decide.outputs.create == 'true'");
+  expect(approve).toContain("gh pr create --repo");
+  expect(approve).toContain('--head "${branch}"');
+  expect(approve).toContain('--base "${DEFAULT_BRANCH}"');
+  // A push that changed nothing must not claim a branch worth reviewing.
+  expect(approve).toContain('echo "pushed=true"');
+  expect(approve).toContain('echo "pushed=false"');
+
+  const decide = approve.indexOf("bun tools/scripts/vr-approve-decision.ts action");
+  const checkout = approve.indexOf("checkout exact verified merged commit from base repo");
+  const push = approve.indexOf("commit and push verified baselines to vr-update/pr-<n>");
+  const create = approve.indexOf("gh pr create --repo");
+  expect(decide).toBeGreaterThan(-1);
+  expect(checkout).toBeGreaterThan(decide);
+  expect(create).toBeGreaterThan(push);
+});
+
+it("keeps the write credential out of every vr-approve step that runs repo code", () => {
+  const approve = read(".github/workflows/vr-approve.yml");
+  const steps = approve.split("\n      - name: ").slice(1);
+  expect(steps.length).toBeGreaterThan(8);
+
+  for (const step of steps) {
+    const label = step.split("\n")[0];
+    // The credential is *supplied* by an env assignment; a comment naming it
+    // (the generator step explains its absence) is not the same thing.
+    if (!/^\s+GH_TOKEN: /m.test(step)) continue;
+    // Credentialed steps stay script-free: `gh`/`git` only, never repository
+    // code from the checkout (invariant 1).
+    expect(step, `credentialed step runs repo code: ${label}`).not.toMatch(/\brun: bun\b/);
+    expect(step, `credentialed step runs repo code: ${label}`).not.toMatch(/\n\s+bun \S/);
+  }
+
+  const decideSteps = steps.filter((step) =>
+    step.includes("bun tools/scripts/vr-approve-decision.ts"),
+  );
+  expect(decideSteps.length).toBe(2);
+  for (const step of decideSteps) {
+    expect(step).not.toContain("GH_TOKEN");
+    expect(step).not.toContain("GITHUB_TOKEN");
+  }
+});
+
 it("uses job-private Bun caches across CI workflows (issue #319)", () => {
   const workflows = [
     ".github/workflows/ci.yml",

--- a/scripts/vr-approve-decision.test.ts
+++ b/scripts/vr-approve-decision.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  decideApproveAction,
+  decidePrCreation,
+  parseBooleanFlag,
+  parseOpenPrNumber,
+  type BranchState,
+} from "./vr-approve-decision.ts";
+
+/** What `process.env.X` yields when the workflow never set X. */
+const UNSET: string | undefined = undefined;
+
+const RENDER = "03c476e200271961f1f25ad4d1878caf1d9a9747";
+const OLD_RENDER = "1111111111111111111111111111111111111111";
+const TIP = "2222222222222222222222222222222222222222";
+
+const branch = (overrides: Partial<BranchState> = {}): BranchState => ({
+  tipSha: TIP,
+  tipMessage: `vr: update baselines for PR #680 @ ${RENDER}`,
+  tipLandedOnDefault: false,
+  openPrNumber: null,
+  ...overrides,
+});
+
+describe("decideApproveAction", () => {
+  test("no vr-update branch yet → render", () => {
+    const decision = decideApproveAction(RENDER, branch({ tipSha: "", tipMessage: "" }));
+    expect(decision.action).toBe("render");
+    expect(decision.reason).toContain("does not exist");
+  });
+
+  test("branch tip carries an older render → render", () => {
+    const decision = decideApproveAction(
+      RENDER,
+      branch({ tipMessage: `vr: update baselines for PR #680 @ ${OLD_RENDER}` }),
+    );
+    expect(decision.action).toBe("render");
+  });
+
+  test("branch tip carries this render but no PR is open → open the PR (issue #717)", () => {
+    const decision = decideApproveAction(RENDER, branch());
+    expect(decision.action).toBe("open-pr");
+    expect(decision.reason).toContain("no open PR");
+  });
+
+  test("branch tip carries this render and a PR is open → skip", () => {
+    const decision = decideApproveAction(RENDER, branch({ openPrNumber: 716 }));
+    expect(decision.action).toBe("skip");
+    expect(decision.reason).toContain("#716");
+  });
+
+  test("baselines already landed on the default branch → skip, never re-open a PR", () => {
+    const decision = decideApproveAction(RENDER, branch({ tipLandedOnDefault: true }));
+    expect(decision.action).toBe("skip");
+    expect(decision.reason).toContain("default branch");
+  });
+
+  test("landed check does not suppress a fresh render on a stale branch", () => {
+    const decision = decideApproveAction(
+      RENDER,
+      branch({ tipMessage: `vr: baselines @ ${OLD_RENDER}`, tipLandedOnDefault: true }),
+    );
+    expect(decision.action).toBe("render");
+  });
+
+  test("an open PR on a stale branch still renders — the push updates that PR", () => {
+    const decision = decideApproveAction(
+      RENDER,
+      branch({ tipMessage: `vr: baselines @ ${OLD_RENDER}`, openPrNumber: 716 }),
+    );
+    expect(decision.action).toBe("render");
+  });
+
+  test("a render SHA embedded in a longer hex string does not count", () => {
+    expect(
+      decideApproveAction(RENDER, branch({ tipMessage: `vr: baselines @ ${RENDER.slice(0, 39)}f` }))
+        .action,
+    ).toBe("render");
+    expect(
+      decideApproveAction(RENDER, branch({ tipMessage: `vr: baselines @ ${RENDER}abc` })).action,
+    ).toBe("render");
+  });
+
+  test("the render SHA is recognized wherever it sits in the message", () => {
+    expect(decideApproveAction(RENDER, branch({ tipMessage: `${RENDER} baselines` })).action).toBe(
+      "open-pr",
+    );
+    expect(
+      decideApproveAction(RENDER, branch({ tipMessage: `baselines (${RENDER})` })).action,
+    ).toBe("open-pr");
+  });
+
+  test("rejects a malformed render SHA rather than guessing", () => {
+    expect(() => decideApproveAction("not-a-sha", branch())).toThrow(/render SHA/);
+    expect(() => decideApproveAction(RENDER.toUpperCase(), branch())).toThrow(/render SHA/);
+  });
+
+  test("rejects a malformed branch tip SHA rather than guessing", () => {
+    expect(() => decideApproveAction(RENDER, branch({ tipSha: "HEAD" }))).toThrow(/tip SHA/);
+  });
+});
+
+describe("decidePrCreation", () => {
+  test("skip decisions never create a PR", () => {
+    expect(decidePrCreation({ action: "skip", pushed: false, openPrNumber: null }).create).toBe(
+      false,
+    );
+  });
+
+  test("open-pr with no open PR creates one", () => {
+    const decision = decidePrCreation({ action: "open-pr", pushed: false, openPrNumber: null });
+    expect(decision.create).toBe(true);
+  });
+
+  test("a PR opened between the decision and the push is not duplicated", () => {
+    const decision = decidePrCreation({ action: "open-pr", pushed: false, openPrNumber: 716 });
+    expect(decision.create).toBe(false);
+    expect(decision.reason).toContain("#716");
+  });
+
+  test("a fresh push with no open PR creates one", () => {
+    expect(decidePrCreation({ action: "render", pushed: true, openPrNumber: null }).create).toBe(
+      true,
+    );
+  });
+
+  test("a fresh push onto an already-open PR creates nothing", () => {
+    expect(decidePrCreation({ action: "render", pushed: true, openPrNumber: 716 }).create).toBe(
+      false,
+    );
+  });
+
+  test("render that produced no commit has no branch to open a PR for", () => {
+    const decision = decidePrCreation({ action: "render", pushed: false, openPrNumber: null });
+    expect(decision.create).toBe(false);
+    expect(decision.reason).toContain("no baseline changes");
+  });
+});
+
+describe("parseOpenPrNumber", () => {
+  test("empty and unset mean no open PR", () => {
+    expect(parseOpenPrNumber(UNSET)).toBeNull();
+    expect(parseOpenPrNumber("")).toBeNull();
+    expect(parseOpenPrNumber("  ")).toBeNull();
+  });
+
+  test("a positive integer is the PR number", () => {
+    expect(parseOpenPrNumber("716")).toBe(716);
+  });
+
+  test("rejects non-numeric and non-positive values", () => {
+    expect(() => parseOpenPrNumber("0")).toThrow(/open PR number/);
+    expect(() => parseOpenPrNumber("-1")).toThrow(/open PR number/);
+    expect(() => parseOpenPrNumber("7.5")).toThrow(/open PR number/);
+    expect(() => parseOpenPrNumber("716 717")).toThrow(/open PR number/);
+  });
+});
+
+describe("parseBooleanFlag", () => {
+  test("accepts only explicit booleans", () => {
+    expect(parseBooleanFlag("true", "pushed")).toBe(true);
+    expect(parseBooleanFlag("false", "pushed")).toBe(false);
+    expect(() => parseBooleanFlag("", "pushed")).toThrow(/pushed/);
+    expect(() => parseBooleanFlag(UNSET, "pushed")).toThrow(/pushed/);
+    expect(() => parseBooleanFlag("yes", "pushed")).toThrow(/pushed/);
+  });
+});
+
+/** Run the CLI exactly as the workflow does: env in, GITHUB_OUTPUT out. */
+const run = async (args: string[], env: Record<string, string>) => {
+  const outputFile = `${process.env.TMPDIR ?? "/tmp"}/vr-approve-decision-${args[0]}-${Bun.hash(JSON.stringify(env)).toString(16)}.txt`;
+  await Bun.write(outputFile, "");
+  const proc = Bun.spawn(["bun", `${import.meta.dir}/vr-approve-decision.ts`, ...args], {
+    env: { ...process.env, ...env, GITHUB_OUTPUT: outputFile },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  const outputs = await Bun.file(outputFile).text();
+  return { stdout, stderr, exitCode, outputs };
+};
+
+describe("CLI", () => {
+  test("action subcommand writes the decision to GITHUB_OUTPUT", async () => {
+    const result = await run(["action"], {
+      RENDER_SHA: RENDER,
+      BRANCH_TIP_SHA: TIP,
+      BRANCH_TIP_MESSAGE: `vr: update baselines for PR #680 @ ${RENDER}`,
+      BRANCH_TIP_LANDED: "false",
+      OPEN_PR_NUMBER: "",
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.outputs).toContain("action=open-pr");
+    expect(result.outputs).toMatch(/^reason=.+$/m);
+  });
+
+  test("action subcommand reports skip when the PR is already open", async () => {
+    const result = await run(["action"], {
+      RENDER_SHA: RENDER,
+      BRANCH_TIP_SHA: TIP,
+      BRANCH_TIP_MESSAGE: `vr: update baselines for PR #680 @ ${RENDER}`,
+      BRANCH_TIP_LANDED: "false",
+      OPEN_PR_NUMBER: "716",
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.outputs).toContain("action=skip");
+  });
+
+  test("pr-create subcommand writes the creation decision", async () => {
+    const result = await run(["pr-create"], {
+      ACTION: "render",
+      PUSHED: "true",
+      OPEN_PR_NUMBER: "",
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.outputs).toContain("create=true");
+  });
+
+  test("fails loudly on a malformed render SHA", async () => {
+    const result = await run(["action"], {
+      RENDER_SHA: "nope",
+      BRANCH_TIP_SHA: "",
+      BRANCH_TIP_MESSAGE: "",
+      BRANCH_TIP_LANDED: "false",
+      OPEN_PR_NUMBER: "",
+    });
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain("render SHA");
+  });
+
+  test("rejects an unknown subcommand", async () => {
+    const result = await run(["nonsense"], {});
+    expect(result.exitCode).not.toBe(0);
+  });
+});

--- a/scripts/vr-approve-decision.ts
+++ b/scripts/vr-approve-decision.ts
@@ -1,0 +1,164 @@
+/**
+ * VR approve decision — pure control flow for `.github/workflows/vr-approve.yml`.
+ *
+ * The approve workflow used to key idempotency on "does the branch tip already
+ * carry this render SHA", which is true the instant the branch is pushed. A
+ * `vr-update/pr-<n>` branch whose PR was never opened therefore short-circuited
+ * every later `/approve-visuals`, stranding correct baselines on an unreachable
+ * branch (#680 → issue #717).
+ *
+ * The unit of idempotency is the open PR, not the branch. This module owns that
+ * decision so it is unit-testable; the workflow keeps only credentialed,
+ * script-free fact-gathering and the `gh` calls that act on the verdict.
+ *
+ * Every input is untrusted-shaped text from a shell step, so malformed values
+ * throw instead of defaulting — a wrong decision here either strands baselines
+ * again or opens duplicate PRs.
+ */
+
+import { appendFileSync } from "node:fs";
+
+const SHA_PATTERN = /^[0-9a-f]{40}$/;
+
+export type BranchState = {
+  /** Remote tip SHA of `vr-update/pr-<n>`; empty when the branch does not exist. */
+  tipSha: string;
+  /** Commit message of that tip; empty when the branch does not exist. */
+  tipMessage: string;
+  /** True when the tip is already contained in the default branch. */
+  tipLandedOnDefault: boolean;
+  /** Number of the open PR whose head is that branch; null when none is open. */
+  openPrNumber: number | null;
+};
+
+/**
+ * `skip` — the render is already landed or already has an open PR.
+ * `open-pr` — the branch is correct but unreachable; open its PR.
+ * `render` — regenerate baselines, push, then open the PR.
+ */
+export type ApproveAction = "skip" | "open-pr" | "render";
+
+export type ApproveDecision = { action: ApproveAction; reason: string };
+
+export type PrCreationDecision = { create: boolean; reason: string };
+
+function assertSha(value: string, label: string): void {
+  if (!SHA_PATTERN.test(value)) {
+    throw new Error(`invalid ${label}: ${JSON.stringify(value)} (expected 40 lowercase hex chars)`);
+  }
+}
+
+/**
+ * True when the commit message references exactly this render SHA. Hex
+ * neighbours are excluded so a longer SHA that merely starts with the render
+ * SHA cannot pass for it.
+ */
+function messageCarriesRender(message: string, renderSha: string): boolean {
+  return new RegExp(`(?<![0-9a-f])${renderSha}(?![0-9a-f])`).test(message);
+}
+
+export function decideApproveAction(renderSha: string, branch: BranchState): ApproveDecision {
+  assertSha(renderSha, "render SHA");
+  if (branch.tipSha !== "") assertSha(branch.tipSha, "branch tip SHA");
+
+  if (branch.tipSha === "") {
+    return { action: "render", reason: "the vr-update branch does not exist yet" };
+  }
+  if (!messageCarriesRender(branch.tipMessage, renderSha)) {
+    return {
+      action: "render",
+      reason: `branch tip ${branch.tipSha} does not carry baselines for ${renderSha}`,
+    };
+  }
+  if (branch.tipLandedOnDefault) {
+    return {
+      action: "skip",
+      reason: `branch tip ${branch.tipSha} is already contained in the default branch`,
+    };
+  }
+  if (branch.openPrNumber !== null) {
+    return {
+      action: "skip",
+      reason: `PR #${branch.openPrNumber} is already open for these baselines`,
+    };
+  }
+  return {
+    action: "open-pr",
+    reason: `branch tip carries baselines for ${renderSha} but has no open PR — opening it`,
+  };
+}
+
+/**
+ * Decided again after the push, against a freshly re-read open-PR number: the
+ * `render` path may have pushed onto a branch whose PR was opened meanwhile,
+ * and a render that produced no commit has nothing to open a PR for.
+ */
+export function decidePrCreation(input: {
+  action: ApproveAction;
+  pushed: boolean;
+  openPrNumber: number | null;
+}): PrCreationDecision {
+  if (input.action === "skip") {
+    return { create: false, reason: "approve step skipped — no PR to open" };
+  }
+  if (input.openPrNumber !== null) {
+    return { create: false, reason: `PR #${input.openPrNumber} is already open for the branch` };
+  }
+  if (input.action === "render" && !input.pushed) {
+    return { create: false, reason: "no baseline changes were pushed — nothing to review" };
+  }
+  return { create: true, reason: "vr-update branch has baselines to land but no open PR" };
+}
+
+export function parseOpenPrNumber(raw: string | undefined): number | null {
+  const value = (raw ?? "").trim();
+  if (value === "") return null;
+  if (!/^[0-9]+$/.test(value) || Number(value) < 1) {
+    throw new Error(`invalid open PR number: ${JSON.stringify(raw)}`);
+  }
+  return Number(value);
+}
+
+export function parseBooleanFlag(raw: string | undefined, label: string): boolean {
+  if (raw === "true") return true;
+  if (raw === "false") return false;
+  throw new Error(`invalid ${label} flag: ${JSON.stringify(raw)} (expected "true" or "false")`);
+}
+
+function emit(outputs: Record<string, string>): void {
+  const rendered = Object.entries(outputs)
+    .map(([key, value]) => `${key}=${value}\n`)
+    .join("");
+  process.stdout.write(rendered);
+  const target = process.env.GITHUB_OUTPUT;
+  if (target !== undefined && target !== "") {
+    // Values are enum-ish verdicts and single-line reasons — no delimiter needed.
+    appendFileSync(target, rendered);
+  }
+}
+
+if (import.meta.main) {
+  const [subcommand] = process.argv.slice(2);
+  if (subcommand === "action") {
+    const decision = decideApproveAction(process.env.RENDER_SHA ?? "", {
+      tipSha: (process.env.BRANCH_TIP_SHA ?? "").trim(),
+      tipMessage: process.env.BRANCH_TIP_MESSAGE ?? "",
+      tipLandedOnDefault: parseBooleanFlag(process.env.BRANCH_TIP_LANDED, "branch tip landed"),
+      openPrNumber: parseOpenPrNumber(process.env.OPEN_PR_NUMBER),
+    });
+    emit({ action: decision.action, reason: decision.reason });
+  } else if (subcommand === "pr-create") {
+    const action = process.env.ACTION ?? "";
+    if (action !== "skip" && action !== "open-pr" && action !== "render") {
+      throw new Error(`invalid action: ${JSON.stringify(process.env.ACTION)}`);
+    }
+    const decision = decidePrCreation({
+      action,
+      pushed: parseBooleanFlag(process.env.PUSHED, "pushed"),
+      openPrNumber: parseOpenPrNumber(process.env.OPEN_PR_NUMBER),
+    });
+    emit({ create: String(decision.create), reason: decision.reason });
+  } else {
+    throw new Error(`unknown subcommand: ${JSON.stringify(subcommand)} (action | pr-create)`);
+  }
+}


### PR DESCRIPTION
Closes #717

## The bug

`vr-approve.yml` skipped whenever the `vr-update/pr-<n>` tip commit message already contained the render SHA — which is true the instant the branch is pushed. A branch whose PR was never opened therefore short-circuited *every* later `/approve-visuals`, and the notice read like success:

```
##[notice]vr-update/pr-680 tip already carries baselines for 03c476e2... — nothing to do
```

Baselines ended up correct, committed, and unreachable. #680 needed PR #716 opened by hand. There was also no `gh pr create` step at all, despite CONTRIBUTING telling maintainers to "review and merge the generated PR".

## The fix

The unit of idempotency is the **open PR**, not the branch:

| branch tip | state | action |
|---|---|---|
| carries render SHA | already contained in `main` | skip — the baselines landed |
| carries render SHA | open PR exists | skip — genuine no-op |
| carries render SHA | no open PR | **open the PR** (branch is already correct) |
| stale / absent | — | render, push, then open the PR |

The three-way decision and the post-push "does this still need a PR?" check moved out of YAML into `scripts/vr-approve-decision.ts`, so they are unit-tested rather than asserted structurally. Malformed inputs throw instead of defaulting — a wrong verdict here either strands baselines again or opens duplicate PRs.

The script is sparse-checked-out from the **default branch**, not the rendered commit: recovering a PR merged before this change must not depend on that commit carrying the script.

## Security invariants (unchanged)

- The decision runs as repository code with **no token** in its environment.
- Every credentialed step stays script-free (`gh`/`git` only) — asserted by a new test that walks every step of the workflow.
- The tip commit message travels by file, never through `GITHUB_OUTPUT` (delimiter forgery) or a `run:` interpolation.
- The job gains only `pull-requests: write`, needed for `gh pr create`; `contents`/`actions` are untouched.
- zizmor 1.26.1 and actionlint both clean.

## Known limitation, documented in the opened PR and CONTRIBUTING

GitHub starts no workflow runs for pull requests opened by the Actions token, so the auto-opened baseline PR arrives without the required `ci-gate` / `detect-changes` checks. Its body carries an `[!IMPORTANT]` note to close and reopen it once, which fires `pull_request: reopened` and runs them. This repo has no bot PAT, so that is the honest trade: a visible one-click step instead of a silent strand.

## Test evidence

- `scripts/vr-approve-decision.test.ts` — 26 tests: every decision branch, hex-boundary matching (a longer SHA that merely starts with the render SHA does not count), malformed-input throws, and the CLI end-to-end through `GITHUB_OUTPUT`.
- `scripts/release-wiring.test.ts` — two new structural tests: the workflow's gating/permissions/step order, and the credential-vs-repo-code separation across every step.
- `bun test scripts` → 706 pass. `bun run lint`, `lint:type-aware`, `fmt:check`, `lint:actions`, `knip`, `uvx zizmor==1.26.1` all clean.
- Replayed against live repo state: `vr-update/pr-699` with open PR #722 → `skip`; the same branch with its PR closed → `open-pr`; `vr-update/pr-680` after #716 merged → `skip` (landed); deleted branch → `render`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)