### PR TITLE
fix(#720): put workers/playground-api inside CI

### DIFF
--- a/.github/workflows/ci-unit.yml
+++ b/.github/workflows/ci-unit.yml
@@ -48,7 +48,7 @@ jobs:
         run: >
           bun test --coverage --coverage-reporter=lcov
           --coverage-dir=coverage/unit
-          packages/spec packages/core benchmarks scripts tests/evals
+          packages/spec packages/core benchmarks scripts tests/evals workers/playground-api
       - name: Upload unit coverage to Codecov
         # Custom if overrides default success() — keep the success gate so a
         # failed suite does not upload a partial report or count as green.

--- a/scripts/ci-routing.test.ts
+++ b/scripts/ci-routing.test.ts
@@ -76,6 +76,22 @@ describe("classifyChangedPaths", () => {
     expect(flags.markdown).toBe(true);
   });
 
+  test("worker sources sit on the workers lane only (issue #720)", () => {
+    const flags = classifyChangedPaths([
+      "workers/playground-api/src/handler.ts",
+      "workers/playground-api/test/handler.test.ts",
+      "workers/playground-api/wrangler.toml",
+    ]);
+    expect(flags.workers).toBe(true);
+    expect(flags.spec).toBe(false);
+    expect(flags.core).toBe(false);
+    expect(flags.svelte).toBe(false);
+    expect(flags.docs).toBe(false);
+    expect(flags.docs_render).toBe(false);
+    expect(flags.scripts).toBe(false);
+    expect(flags.visual).toBe(false);
+  });
+
   test("docs-only prose does not flip package lanes", () => {
     const flags = classifyChangedPaths([
       "docs/decisions/0001-declaration-only-children.md",
@@ -459,6 +475,26 @@ describe("planJobs", () => {
     expect(plan.component).toBe(false);
   });
 
+  test("worker changes schedule unit + build without the browser/docs surface (issue #720)", () => {
+    // workers/playground-api ships its own bun test suite; build carries the only
+    // type coverage the worker has (oxlint --type-aware + knip over the repo).
+    const plan = planJobs(classifyChangedPaths(["workers/playground-api/src/handler.ts"]));
+    expect(plan.checks).toBe(true);
+    expect(plan.unit).toBe(true);
+    expect(plan.build).toBe(true);
+    expect(plan.vr).toBe(false);
+    expect(plan.component).toBe(false);
+    expect(plan.consumer).toBe(false);
+    expect(plan.svelte_check).toBe(false);
+    expect(plan.docs_site).toBe(false);
+    expect(plan.docs_journeys).toBe(false);
+    expect(plan.pages).toBe(false);
+    expect(plan.packages_dist).toBe(false);
+    expect(plan.bench_smoke).toBe(false);
+    expect(plan.interaction_perf).toBe(false);
+    expect(plan.actions_security).toBe(false);
+  });
+
   test("scripts test-only changes never rebuild docs site or run svelte-check", () => {
     // release-wiring.test.ts (and other scripts/**/*.test.ts) used to force the
     // monolithic build job, which always ran vite build:docs.
@@ -504,6 +540,13 @@ describe("planJobs", () => {
 describe("JOB_CONTENT_INPUTS (split build hashes)", () => {
   test("build hash still includes apps/docs for knip/type-aware coverage", () => {
     expect(JOB_CONTENT_INPUTS.build).toContain("apps/docs/**");
+  });
+
+  test("unit and build hash the workers tree so worker edits miss the cache (issue #720)", () => {
+    const workerPath = "workers/playground-api/src/handler.ts";
+    for (const execution of ["unit", "build"] as const) {
+      expect(listJobContentPaths(execution, [workerPath]), execution).toEqual([workerPath]);
+    }
   });
 
   test("svelte_check and docs_site hash docs generators and $scripts imports", () => {

--- a/scripts/ci-routing/content-hash.ts
+++ b/scripts/ci-routing/content-hash.ts
@@ -135,6 +135,8 @@ export const JOB_CONTENT_INPUTS: Record<CacheableExecution, readonly string[]> =
     "benchmarks/**",
     "scripts/**",
     "tests/evals/**",
+    // workers/playground-api runs in the unit suite (issue #720).
+    "workers/**",
     "docs/accessibility/**",
     ".github/ISSUE_TEMPLATE/**",
     ".github/DISCUSSION_TEMPLATE/**",
@@ -167,6 +169,8 @@ export const JOB_CONTENT_INPUTS: Record<CacheableExecution, readonly string[]> =
     "examples/**",
     "scripts/**",
     "tests/evals/**",
+    // oxlint --type-aware + knip are the only type coverage workers get (#720).
+    "workers/**",
     "skills/**",
     "lifecycle.json",
     "support-matrix.json",

--- a/scripts/ci-routing/routing.ts
+++ b/scripts/ci-routing/routing.ts
@@ -26,6 +26,7 @@ export type ChangeLane =
   | "examples"
   | "benchmarks"
   | "scripts"
+  | "workers"
   | "evals"
   | "workflows"
   | "ci_workflow"
@@ -164,6 +165,10 @@ export const LANE_PATTERNS: Record<ChangeLane, readonly string[]> = {
     "README.md",
     "packages/svelte/README.md",
   ],
+  // Cloudflare workers (issue #720). They own a bun test suite and are only
+  // type-covered by the repo-wide oxlint --type-aware / knip pass in `build`;
+  // nothing here renders charts, so no browser/docs surface.
+  workers: ["workers/**"],
   evals: ["tests/evals/**"],
   workflows: [
     ".github/workflows/**",
@@ -349,6 +354,7 @@ export type PlanOptions = {
  * - docs generators (gen-llms / lifecycle.json) sit on the docs lane → pages
  * - pixel VR follows package surface, examples, visual tests, or docs_render only
  * - docs_journeys covers non-pixel Playwright structure/a11y for docs content PRs
+ * - workers run unit (own bun suite) + build (repo-wide type-aware lint / knip)
  *
  * Force tiers (do not collapse these):
  * - `forceProduct`: lockfile or ci-routing self-change — full package/browser surface.
@@ -377,7 +383,12 @@ export function planJobs(changes: ChangeFlags, options: PlanOptions = {}): JobPl
   // - docs_site: vite adapter-static + pages-links (product surface only)
   // A scripts/**/*.test.ts change must NOT schedule svelte_check or docs_site.
   const staticAnalysisSurface =
-    packageSurface || docsSurface || changes.scripts || changes.evals || forceProduct;
+    packageSurface ||
+    docsSurface ||
+    changes.scripts ||
+    changes.evals ||
+    changes.workers ||
+    forceProduct;
   const svelteCheckSurface = packageSurface || docsSurface || forceProduct;
   const docsSiteSurface = packageSurface || docsSurface || forceProduct;
 
@@ -412,6 +423,8 @@ export function planJobs(changes: ChangeFlags, options: PlanOptions = {}): JobPl
       changes.scripts ||
       changes.benchmarks ||
       changes.evals ||
+      // workers/playground-api ships its own bun test suite in the unit job.
+      changes.workers ||
       changes.docs ||
       changes.examples ||
       changes.workflows ||

--- a/scripts/release-wiring.test.ts
+++ b/scripts/release-wiring.test.ts
@@ -34,6 +34,16 @@ const ciJob = (ci: string, jobId: string): string => {
   const next = rest.search(/\n  [a-z0-9_-]+:\n/);
   return next === -1 ? ci.slice(start) : ci.slice(start, start + 1 + next);
 };
+/** Suite path arguments of a `bun test …` invocation (flags and values dropped). */
+const suiteArgs = (command: string): string[] => {
+  const start = command.indexOf("bun test");
+  if (start === -1) return [];
+  return command
+    .slice(start + "bun test".length)
+    .trim()
+    .split(/\s+/)
+    .filter((arg) => arg.length > 0 && !arg.startsWith("-"));
+};
 const selfHostedGgsvelteCount = (workflow: string) =>
   workflow
     .split("\n")
@@ -63,6 +73,29 @@ describe("R0 release wiring", () => {
     expect(read("codecov.yml")).toContain("component_id: packages-spec");
     expect(read(".pre-commit-config.yaml")).not.toContain("bun test packages/spec");
     expect(read(".pre-commit-config.yaml")).not.toContain("pre-push");
+  });
+
+  it("runs every root `bun test` suite in the CI unit job (issue #720)", () => {
+    // The root `test` script is the canonical suite list. Anything present there
+    // but absent from ci-unit.yml is a local-only suite that merges green.
+    const pkg = JSON.parse(read("package.json")) as { scripts: Record<string, string> };
+    const rootSuites = suiteArgs(pkg.scripts.test ?? "");
+    expect(rootSuites).toContain("workers/playground-api");
+
+    // Folded (`run: >`) scalar — collapse whitespace, then take the single
+    // coverage invocation up to the next step. Anchored on `--coverage` so the
+    // job's display name ("unit (bun test spec + core)") cannot match instead.
+    const unit = read(".github/workflows/ci-unit.yml").replaceAll(/\s+/g, " ");
+    const invocations = unit.match(/bun test --coverage/g) ?? [];
+    expect(invocations.length, "ci-unit.yml has exactly one coverage bun test").toBe(1);
+    const start = unit.indexOf("bun test --coverage");
+    const end = unit.indexOf(" - name: Upload unit coverage", start);
+    expect(end, "ci-unit.yml uploads unit coverage after bun test").toBeGreaterThan(start);
+    const ciSuites = suiteArgs(unit.slice(start, end));
+
+    for (const suite of rootSuites) {
+      expect(ciSuites, `ci-unit.yml runs ${suite}`).toContain(suite);
+    }
   });
 
   it("checks packed links in CI and the Cloudflare Pages deployment", () => {


### PR DESCRIPTION
Closes #720. Follow-up filed: #725.

## Problem

`workers/playground-api` was outside CI in three independent ways, verified at `10ea93b`:

| Surface | State before |
|---|---|
| `.github/workflows/ci-unit.yml` | ran `bun test packages/spec packages/core benchmarks scripts tests/evals` — the root `test` script's `workers/playground-api` was missing, so its 33-test suite was local-only |
| `scripts/ci-routing/routing.ts` | no `LANE_PATTERNS` entry matched `workers/**` → `planJobs` returned `unit: false, build: false` for a worker-only PR (only the always-on `checks` job ran) |
| `scripts/ci-routing/content-hash.ts` | `unit` and `build` inputs omitted `workers/**` → a worker edit could not invalidate a cached success marker even once the job was scheduled |

Net effect: a worker regression — including one that 503s all production playground generation — merged green.

## Change

1. **`ci-unit.yml`** — added `workers/playground-api` to the coverage `bun test` path list, matching the root `test` script.
2. **`routing.ts`** — new `workers` lane (`workers/**`) routed to `unit` (the worker owns a bun suite) and `build` (`oxlint --type-aware` + `knip` are the only type coverage the worker has; it has no build step of its own — wrangler bundles from source). Deliberately **not** routed to VR / component / consumer / svelte_check / docs_site / pages / docs_journeys / packages_dist / bench_smoke: nothing under `workers/` renders a chart.
3. **`content-hash.ts`** — `workers/**` added to the `unit` and `build` input patterns. This changes those two patterns strings, so existing `unit` / `build` markers are invalidated once (expected). `checks` is not a cacheable execution, so it needed nothing.

## Tests (TDD — RED before GREEN)

- `scripts/release-wiring.test.ts` — new parity test: every suite path in the root `package.json` `test` script must appear in the `ci-unit.yml` coverage invocation. Drift-proof in both directions rather than a hardcoded string, so a future suite added to the root script can't silently skip CI.
- `scripts/ci-routing.test.ts` — worker paths classify onto the `workers` lane only; a worker-only change plans `checks` + `unit` + `build` and nothing else; `listJobContentPaths` matches a worker path for both `unit` and `build`.

RED evidence (before the fix, 4 failures for the intended reasons):

```
(fail) classifyChangedPaths > worker sources sit on the workers lane only (issue #720)
(fail) planJobs > worker changes schedule unit + build without the browser/docs surface (issue #720)
(fail) JOB_CONTENT_INPUTS > unit and build hash the workers tree so worker edits miss the cache (issue #720)
(fail) R0 release wiring > runs every root `bun test` suite in the CI unit job (issue #720)  → "ci-unit.yml runs workers/playground-api"
```

The workflow parity test was re-verified RED by stashing only `ci-unit.yml` (`0 pass / 1 fail`) and GREEN with it restored.

GREEN evidence:

```
bun test scripts/ci-routing.test.ts scripts/ci-routing/ scripts/release-wiring.test.ts workers/playground-api
  177 pass, 0 fail, 1163 expect() calls

bun run test          → 2548 pass, 0 fail across 327 files
bun run lint          → clean
bun run lint:type-aware → clean
bun run fmt:check     → clean
bun run lint:actions  → 28 workflow file(s) clean
```

## Deferred

Item 4 of the issue (worker typecheck) → **#725**. The root `tsconfig.json` already includes `workers/**/*.ts`, but nothing ever runs `tsc` on it — it exists so `oxlint --type-aware` has type info. Running `tsc -p tsconfig.json --noEmit` today yields **276 pre-existing errors** (41 in `workers/**`, 235 in `scripts/**`, 46 of those in `scripts/ci-routing`), dominated by `TS4111` index-signature access, `exactOptionalPropertyTypes` mismatches, and `TS2741` on bun's `fetch` type in worker test stubs. Fixing those is source-level cleanup with behavioural risk, not CI wiring, so it is out of scope here; #725 records the evidence and the three options.

🤖 Generated with [Claude Code](https://claude.com/claude-code)