### PR TITLE
fix(#718): pin how VR media emulation actually composes

### DIFF
--- a/tests/visual/docs-home-gallery.spec.ts
+++ b/tests/visual/docs-home-gallery.spec.ts
@@ -25,9 +25,9 @@ test("homepage first viewport leads with a live chart and two actions", async ({
  * chart adapts on its own — the page has to hand the surface back. The epoch
  * bands are the one mark whose meaning is carried by fill alone and which this
  * page never names, so under a requested palette they drop rather than paint
- * over it. Asserted through `emulateMedia`: the config's `contextOptions`
- * clobbers Playwright's `forcedColors` fixture, so `test.use` would silently
- * measure a normal page.
+ * over it. Asserted through `emulateMedia`: `forcedColors` is not a Playwright
+ * test option, so `test.use` would be dropped by the runner and this would
+ * silently measure a normal page (issue #718 — see playwright.config.ts).
  */
 test("homepage hero yields its surface and drops decorative fills in forced colors", async ({
   page,

--- a/tests/visual/docs-progressive-search.spec.ts
+++ b/tests/visual/docs-progressive-search.spec.ts
@@ -60,9 +60,10 @@ test("the finished chart answers keyboard inspection", async ({ page }) => {
  * The library sets `forced-color-adjust: none` on `.gg-plot`, so nothing in a
  * chart adapts on its own. The epoch bands are the one mark carried by fill
  * alone, so under a requested palette they drop and the names in the note
- * under the chart do the work instead. Asserted through `emulateMedia`: this
- * config sets `contextOptions`, which clobbers Playwright's `forcedColors`
- * fixture, so `test.use` would silently measure a normal page.
+ * under the chart do the work instead. Asserted through `emulateMedia`:
+ * `forcedColors` is not a Playwright test option, so `test.use` would be
+ * dropped by the runner and this would silently measure a normal page
+ * (issue #718 — see playwright.config.ts).
  */
 test("the finished chart drops its band fills and names the epochs in forced colors", async ({
   page,

--- a/tests/visual/media-emulation.spec.ts
+++ b/tests/visual/media-emulation.spec.ts
@@ -1,0 +1,75 @@
+/*
+ * Pins how media emulation actually composes in this project (issue #718).
+ *
+ * The suite's determinism depends on `prefers-reduced-motion: reduce` being on
+ * for every test, and several tests measure real forced-colors behaviour. Both
+ * are set through `contextOptions`, whose merge rules are easy to get wrong in
+ * a way that fails open: the page just looks normal and the assertions pass
+ * for the wrong reason. These tests fail closed instead.
+ *
+ * Deliberately not screenshots and deliberately not a docs route — every
+ * assertion here is about the browser context Playwright hands us, so a data
+ * URL keeps the signal free of anything the site could contribute.
+ */
+import { expect, test } from "@playwright/test";
+
+import { vrContextOptions } from "./playwright.config";
+
+const BLANK = "data:text/html,<title>media emulation</title>";
+
+async function media(page: import("@playwright/test").Page): Promise<{
+  reducedMotion: boolean;
+  forcedColors: boolean;
+  dark: boolean;
+}> {
+  await page.goto(BLANK);
+  return page.evaluate(() => ({
+    reducedMotion: matchMedia("(prefers-reduced-motion: reduce)").matches,
+    forcedColors: matchMedia("(forced-colors: active)").matches,
+    dark: matchMedia("(prefers-color-scheme: dark)").matches,
+  }));
+}
+
+test("reduced motion is active for every test in the project", async ({ page }) => {
+  expect(await media(page)).toMatchObject({ reducedMotion: true, forcedColors: false });
+});
+
+test.describe("colorScheme is a test option, so test.use composes with the base context", () => {
+  test.use({ colorScheme: "dark" });
+
+  test("dark scheme applies and reduced motion survives it", async ({ page }) => {
+    expect(await media(page)).toMatchObject({ dark: true, reducedMotion: true });
+  });
+});
+
+test.describe("forcedColors is NOT a test option, so test.use is silently dropped", () => {
+  // Canary. `forcedColors`, `reducedMotion` and `contrast` exist on
+  // BrowserContextOptions but not on Playwright's TestOptions (1.61.1 — also
+  // absent in 1.62), so the runner ignores this key without an error. When
+  // this test starts failing, Playwright has grown the fixture: switch the
+  // `page.emulateMedia` calls in docs-*.spec.ts and vr.spec.ts over to
+  // `test.use` and delete this block.
+  // @ts-expect-error forcedColors is not a Playwright test option
+  test.use({ forcedColors: "active" });
+
+  test("test.use({ forcedColors }) does not reach the browser", async ({ page }) => {
+    expect(await media(page)).toMatchObject({ forcedColors: false, reducedMotion: true });
+  });
+});
+
+test.describe("contextOptions replaces rather than merges", () => {
+  // Spreading `vrContextOptions` is what keeps reduced motion; a bare
+  // `{ forcedColors: "active" }` here would silently drop it.
+  test.use({ contextOptions: { ...vrContextOptions, forcedColors: "active" } });
+
+  test("spreading the project base keeps reduced motion alongside forced colors", async ({
+    page,
+  }) => {
+    expect(await media(page)).toMatchObject({ forcedColors: true, reducedMotion: true });
+  });
+});
+
+test("page.emulateMedia is the per-test form the suite uses, and it composes", async ({ page }) => {
+  await page.emulateMedia({ forcedColors: "active" });
+  expect(await media(page)).toMatchObject({ forcedColors: true, reducedMotion: true });
+});

--- a/tests/visual/playwright.config.ts
+++ b/tests/visual/playwright.config.ts
@@ -9,6 +9,7 @@
  * - retries 0: a flaky screenshot is a bug, not a retry candidate
  * - colorScheme pinned: the page theme comes ONLY from ?theme= (?vr mode
  *   ignores prefers-color-scheme by design)
+ * - reduced motion pinned through contextOptions (see vrContextOptions)
  * - snapshotPathTemplate WITHOUT any platform suffix: the pinned Playwright
  *   container (mcr.microsoft.com/playwright:v1.61.1-noble) is the ONLY
  *   baseline platform, so platform-suffixed names would be a lie
@@ -24,9 +25,30 @@
  *   VR_SNAPSHOT_DIR=.local-baselines bun run test:visual -- --update-snapshots
  *   VR_SNAPSHOT_DIR=.local-baselines bun run test:visual
  */
-import { defineConfig } from "@playwright/test";
+import { type BrowserContextOptions, defineConfig } from "@playwright/test";
 
 const snapshotDir = process.env["VR_SNAPSHOT_DIR"] ?? "__screenshots__";
+
+/**
+ * Project-wide browser-context media state (issue #718).
+ *
+ * `forcedColors`, `reducedMotion` and `contrast` exist on BrowserContextOptions
+ * but NOT on Playwright's TestOptions (checked in 1.61.1, the pinned version,
+ * and still absent in 1.62), so `contextOptions` is the only way to set them
+ * from a config — and `test.use({ forcedColors: "active" })` is dropped by the
+ * runner without an error. `colorScheme` IS a test option and composes fine:
+ * the real fixtures are spread over `contextOptions`, not replaced by it.
+ *
+ * Two supported ways to change media state for one test:
+ * - `page.emulateMedia({ forcedColors: "active" })` — what this suite uses,
+ *   composes with everything below;
+ * - `test.use({ contextOptions: { ...vrContextOptions, forcedColors: "active" } })`
+ *   — `contextOptions` REPLACES rather than merges, so the spread is what
+ *   keeps reduced motion on; a bare object silently drops it.
+ *
+ * tests/visual/media-emulation.spec.ts pins all of the above.
+ */
+export const vrContextOptions: BrowserContextOptions = { reducedMotion: "reduce" };
 
 export default defineConfig({
   testDir: ".",
@@ -51,7 +73,7 @@ export default defineConfig({
     deviceScaleFactor: 1,
     viewport: { width: 800, height: 640 },
     colorScheme: "light",
-    contextOptions: { reducedMotion: "reduce" },
+    contextOptions: vrContextOptions,
     locale: "en-US",
     timezoneId: "UTC",
     trace: "retain-on-failure",


### PR DESCRIPTION
Closes #718.

## The issue's diagnosis does not survive measurement

#718 says `use.contextOptions` clobbers Playwright's `forcedColors`/`colorScheme` fixtures, and proposes replacing it with a top-level `reducedMotion: "reduce"`. I probed the pinned Playwright **1.61.1** directly (throwaway config, `matchMedia` read out of a real context). Results:

| Probe | Result |
|---|---|
| `test.use({ forcedColors: "active" })`, config **with** `contextOptions` | `forced-colors: active` → **false** |
| `test.use({ forcedColors: "active" })`, config **without** `contextOptions` at all | `forced-colors: active` → **false** |
| `test.use({ colorScheme: "dark" })`, config with `contextOptions` | dark → **true**, reduced motion → **true** |
| top-level `use: { reducedMotion: "reduce" }` (the proposed fix) | reduced motion → **false** |
| `test.use({ contextOptions: { forcedColors: "active" } })` | forced → **true**, reduced motion → **false** (lost) |
| `page.emulateMedia({ forcedColors: "active" })` | forced → **true**, reduced motion → **true** |

Root cause of the reported symptom: `forcedColors`, `reducedMotion` and `contrast` exist on `BrowserContextOptions` but **not** on Playwright's `TestOptions` — `grep -c forcedColors playwright/types/test.d.ts` is 0 in 1.61.1 (and 1.62 has it only in a prose line). The runner ignores unknown `use` keys silently. `colorScheme` *is* a test option and already composes, because `_combinedContextOptions` spreads the fixtures **over** `contextOptions` (`playwright/lib/index.js:339`) rather than being replaced by it.

So the proposed fix would not fix the reported symptom, and would silently switch off reduced motion — a load-bearing determinism lever — for the whole suite. Demonstrated: applying it turns 4 of the 5 new tests red with `reducedMotion: false`.

## The real bug

One level down, and genuinely a silent-failure trap: `test.use({ contextOptions })` **replaces** the config's object instead of merging it, so any per-test `contextOptions` override drops `reducedMotion: "reduce"` with no error.

## What this PR does

- Keeps `contextOptions: { reducedMotion: "reduce" }` — it is the documented form (it is literally the doc example on `TestOptions.contextOptions`) and the only one that works — but names it `vrContextOptions` and **exports** it, so a per-test override can spread it and keep reduced motion.
- Documents in `playwright.config.ts` what actually composes and the two supported ways to change media state for one test.
- Adds `tests/visual/media-emulation.spec.ts` (5 non-screenshot tests) pinning every row of the table above. One is a **canary**: it asserts `test.use({ forcedColors })` does *not* reach the browser, so if Playwright ever grows the fixture the suite fails and points at the `emulateMedia` workarounds to be retired.
- Rewrites the two comments in `docs-home-gallery.spec.ts` and `docs-progressive-search.spec.ts` that stated the wrong reason for reaching for `emulateMedia`.

## Acceptance

- [x] "`test.use({ forcedColors: "active" })` actually activates forced colors, **or the config says in-tree why it cannot**" — second branch, taken because the first is not reachable in any current Playwright; now backed by an executable canary rather than only a comment.
- [x] `reducedMotion: "reduce"` still applies everywhere it did before — pinned by `media-emulation.spec.ts`.

## Evidence

- New spec: `5 passed` against the built docs site.
- Red-before-green: the spec fails to resolve `vrContextOptions` before the config change; with the issue's proposed fix applied it fails 4/5 on `reducedMotion: false`.
- `fmt:check`, `oxlint`, `lint:type-aware`, `knip`: clean. `tsc -p tests/visual` introduces no new errors (2 pre-existing, in `docs-contrast.spec.ts` and `helpers/deterministic.ts`).
- Ran the full `docs-home-gallery` + `docs-progressive-search` + new spec set locally after a fresh `build:docs`: 33 passed, 1 failed — `homepage grammar steps change real chart structure in place`, which fails identically on unmodified `origin/main` locally, so it is not from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)