### PR TITLE
fix(#708): put the chart above the browse catalogue, not below it

### DIFF
--- a/apps/docs/src/lib/Playground.svelte
+++ b/apps/docs/src/lib/Playground.svelte
@@ -6,6 +6,7 @@
   import type { SpecError } from "@ggsvelte/spec";
 
   import { copyText } from "$lib/clipboard";
+  import PlaygroundBrowseLinks from "$lib/components/PlaygroundBrowseLinks.svelte";
   import PlaygroundCode from "$lib/components/PlaygroundCode.svelte";
   import PlaygroundEvents from "$lib/components/PlaygroundEvents.svelte";
   import PlaygroundPreview from "$lib/components/PlaygroundPreview.svelte";
@@ -626,7 +627,6 @@
     samples={sampleLinks}
     {onGenerate}
     {onCancel}
-    {onExample}
     onLoadSample={(id) => {
       loadSample(id);
     }}
@@ -650,6 +650,15 @@
     canUndo={workbench.undoSnapshots.length > 0}
     undoDisabled={busy || workbench.candidate !== null}
     onUndo={undoChart}
+  />
+
+  <PlaygroundBrowseLinks
+    samples={sampleLinks}
+    {busy}
+    {onExample}
+    onLoadSample={(id) => {
+      loadSample(id);
+    }}
   />
 
   <PlaygroundCode

--- a/apps/docs/src/lib/components/PlaygroundBrowseLinks.svelte
+++ b/apps/docs/src/lib/components/PlaygroundBrowseLinks.svelte
@@ -1,0 +1,91 @@
+<script lang="ts">
+  import {
+    PLAYGROUND_EXAMPLE_PROMPTS,
+    type PlaygroundExamplePrompt,
+  } from "$lib/playground-prompts";
+
+  let {
+    samples = [],
+    busy = false,
+    onExample,
+    onLoadSample,
+  }: {
+    samples?: readonly { id: string; title: string }[];
+    busy?: boolean;
+    onExample: (example: PlaygroundExamplePrompt) => void;
+    onLoadSample: (id: string) => void;
+  } = $props();
+</script>
+
+<!--
+  The browse catalogue sits BELOW the chart (#708). Above it, thirteen wrapping
+  44px links pushed the chart 1211px down a 844px-tall phone — chart-first is a
+  layout promise, not a slogan. Nothing is dropped: every example and sample is
+  still in the DOM and clickable.
+-->
+<div class="quiet-links">
+  <span class="quiet-label">Examples</span>
+  {#each PLAYGROUND_EXAMPLE_PROMPTS as example (example.id)}
+    <button
+      type="button"
+      class="text-link"
+      onclick={() => onExample(example)}
+      disabled={busy}
+    >
+      {example.label}
+    </button>
+  {/each}
+  <span class="quiet-label samples-label">Samples</span>
+  {#each samples as sample (sample.id)}
+    <button
+      type="button"
+      class="text-link"
+      onclick={() => onLoadSample(sample.id)}
+      disabled={busy}
+    >
+      {sample.title}
+    </button>
+  {/each}
+</div>
+
+<style>
+  .quiet-links {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.15rem 0.85rem;
+    /* Bottom spacing comes from .code-section's 3rem top margin below. */
+    margin-top: 1.5rem;
+  }
+
+  .quiet-label {
+    color: var(--muted);
+    font-size: 0.8rem;
+  }
+
+  .samples-label {
+    margin-left: 0.5rem;
+  }
+
+  .text-link {
+    appearance: none;
+    border: 0;
+    background: none;
+    padding: 0.35rem 0.15rem;
+    min-height: 44px;
+    color: var(--accent);
+    font: inherit;
+    cursor: pointer;
+    text-decoration: none;
+  }
+
+  .text-link:hover {
+    text-decoration: underline;
+  }
+
+  .text-link:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+    text-decoration: none;
+  }
+</style>

--- a/apps/docs/src/lib/components/PlaygroundPrompt.svelte
+++ b/apps/docs/src/lib/components/PlaygroundPrompt.svelte
@@ -5,10 +5,6 @@
     PLAYGROUND_PROMPT_MAX_CHARS,
     type PlaygroundDatasetId,
   } from "$lib/playground-dataset-schemas";
-  import {
-    PLAYGROUND_EXAMPLE_PROMPTS,
-    type PlaygroundExamplePrompt,
-  } from "$lib/playground-prompts";
   import type { PlaygroundAgentFailure } from "$lib/playground-agent-state";
   import type { SpecError } from "@ggsvelte/spec";
 
@@ -23,7 +19,6 @@
     samples = [],
     onGenerate,
     onCancel,
-    onExample,
     onLoadSample,
     onCopyHandoff,
   }: {
@@ -37,7 +32,6 @@
     samples?: readonly { id: string; title: string }[];
     onGenerate: () => void;
     onCancel: () => void;
-    onExample: (example: PlaygroundExamplePrompt) => void;
     onLoadSample: (id: string) => void;
     onCopyHandoff: () => void;
   } = $props();
@@ -147,31 +141,6 @@
       </button>
     </div>
   {/if}
-
-  <div class="quiet-links">
-    <span class="quiet-label">Examples</span>
-    {#each PLAYGROUND_EXAMPLE_PROMPTS as example (example.id)}
-      <button
-        type="button"
-        class="text-link"
-        onclick={() => onExample(example)}
-        disabled={busy}
-      >
-        {example.label}
-      </button>
-    {/each}
-    <span class="quiet-label samples-label">Samples</span>
-    {#each samples as sample (sample.id)}
-      <button
-        type="button"
-        class="text-link"
-        onclick={() => onLoadSample(sample.id)}
-        disabled={busy}
-      >
-        {sample.title}
-      </button>
-    {/each}
-  </div>
 </div>
 
 <style>
@@ -304,22 +273,6 @@
     font: 0.75rem/1.45 var(--code-font);
     border-radius: 4px;
     white-space: pre-wrap;
-  }
-
-  .quiet-links {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 0.15rem 0.85rem;
-  }
-
-  .quiet-label {
-    color: var(--muted);
-    font-size: 0.8rem;
-  }
-
-  .samples-label {
-    margin-left: 0.5rem;
   }
 
   @media (max-width: 44.99rem) {

--- a/tests/visual/playground.spec.ts
+++ b/tests/visual/playground.spec.ts
@@ -681,7 +681,8 @@ test("playground is chart-first, operable, and axe-clean at a touch-size viewpor
   page,
 }) => {
   await page.addInitScript({ content: axe.source });
-  await page.setViewportSize({ width: 390, height: 844 });
+  const viewport = { width: 390, height: 844 };
+  await page.setViewportSize(viewport);
   await page.goto("/playground");
   await settleVisualState(page);
 
@@ -691,6 +692,26 @@ test("playground is chart-first, operable, and axe-clean at a touch-size viewpor
     () => document.documentElement.scrollWidth - document.documentElement.clientWidth,
   );
   expect(horizontalOverflow).toBeLessThanOrEqual(1);
+  // Chart-first is a layout claim, not a slogan (#708): the chart's top edge
+  // must land inside the first screen, and the browse catalogue sits BELOW it.
+  const layout = await page.evaluate(() => {
+    const top = (selector: string): number => {
+      const element = document.querySelector(selector);
+      return element === null ? Number.NaN : element.getBoundingClientRect().top + window.scrollY;
+    };
+    return { chart: top(".active-chart"), browse: top(".quiet-links") };
+  });
+  expect(layout.chart).toBeLessThan(viewport.height);
+  expect(layout.browse).toBeGreaterThan(layout.chart);
+  // Every example and sample stays in the DOM and clickable, just lower down.
+  for (const name of ["Raw years", "ISO dates", "Ambiguous dates"]) {
+    const box = await page
+      .locator(".quiet-links")
+      .getByRole("button", { name, exact: true })
+      .boundingBox();
+    expect(box, name).not.toBeNull();
+    expect(box!.height, name).toBeGreaterThanOrEqual(44);
+  }
   // Primary controls must meet 44px; skip icon-only copy buttons inside CodeTabs.
   for (const name of ["Generate", "Share this chart", "Download SVG", "Inspect"]) {
     const box = await page.getByRole("button", { name, exact: true }).first().boundingBox();


### PR DESCRIPTION
## Problem

At 390x844 the playground chart's top edge sat **1211px** down the page — about 1.4 screens of chrome before the chart appears, on a surface whose premise is "first paint is a rendered chart, never a form or a void". Reproduced locally against the built site: `chartTop: 1211.19`.

The dominant contributor was the `.quiet-links` browse row (4 example prompts + 9 samples, each a wrapping 44px target) — 369px of links sitting between the prompt strip and the chart.

Neither of the other two contributors was available to cut, as #708 notes:

- the `<560px` capability row is an explicit DESIGN.md decision;
- trimming the sample catalogue is a product call, not a QA fix.

## Change (issue option 2)

Move the row rather than shrink it.

- `.quiet-links` moves out of `PlaygroundPrompt.svelte` into a new `PlaygroundBrowseLinks.svelte`, rendered **below** `PlaygroundPreview` in `Playground.svelte`.
- Every example and sample stays in the DOM with the same accessible name, the same `min-height: 44px` target, and the same `busy` disabled state — the temporal regression tests keep clicking them by title.
- The failure alert's three recovery samples stay inside the prompt: a deliberately narrower affordance, not a second copy of the catalogue.
- No DESIGN.md capability-row behaviour changed.

## Evidence

Measured on the built static site at 390x844 (the artifact the VR suite serves):

| | before | after |
|---|---|---|
| `.active-chart` top | 1211.19px | **834.45px** (inside the 844px viewport) |
| `.quiet-links` top | ~842px | 1306.45px (below the chart) |
| horizontal overflow | 0 | 0 |
| browse links present | 13 | 13 |
| min link height | 44px | 44px |

Test evidence:

- **RED first**: the new assertions in `tests/visual/playground.spec.ts` failed against the unmodified build with `Expected: < 844 / Received: 1211.1875`, then passed after the move.
- The touch-viewport test now asserts the layout claim instead of trusting it: chart top inside the first screen, browse row below the chart, and "Raw years" / "ISO dates" / "Ambiguous dates" still 44px and clickable inside `.quiet-links`.
- `playground.spec.ts` targets pass: `first paint shows a seeded interactive chart`, `degraded mode ... keeps samples usable`, `temporal samples render and keep ambiguous dates discrete`, `playground is chart-first, operable, and axe-clean at a touch-size viewport` — 4 passed.
- `/playground keeps wide content locally contained on mobile` (docs-shell.spec.ts) passes.
- `bun run test` — 2636 pass, 0 fail.
- `bun run check:docs` (svelte-check `--fail-on-warnings`) — 0 errors, 0 warnings; `lint`, `lint:type-aware`, `fmt:check`, `knip` clean.

No committed VR screenshot baseline covers `/playground`, so no baseline churn.

**Local-flake note, stated plainly:** several candidate-lifecycle tests in this spec (`example prompts generate instantly`, `Previous chart undo`, `custom agent chart requires confirm before sample load`, and others) fail on this machine with a drifting failure set run to run. I verified they fail the same way on a build of unmodified `origin/main` (`example prompts` failed 3/3 on `--repeat-each=3` at baseline), so they are pre-existing local instability, not a regression from this change. The pinned CI container is the arbiter.

Closes #708

🤖 Generated with [Claude Code](https://claude.com/claude-code)