### PR TITLE
fix(#725): give the playground-api worker a real tsc gate

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   ],
   "type": "module",
   "scripts": {
-    "check": "tsc -b packages/spec packages/core && bun run check:type-contracts",
+    "check": "tsc -b packages/spec packages/core && bun run check:type-contracts && bun run check:workers",
+    "check:workers": "bun node_modules/.bin/tsc -p workers/playground-api --noEmit",
     "check:type-contracts": "tsc -p packages/spec/type-tests/tsconfig.json",
     "check:svelte": "cd packages/svelte && bun run --bun check",
     "check:examples": "bun node_modules/.bin/tsc -p examples --noEmit",

--- a/scripts/ci-routing/content-hash.ts
+++ b/scripts/ci-routing/content-hash.ts
@@ -169,7 +169,8 @@ export const JOB_CONTENT_INPUTS: Record<CacheableExecution, readonly string[]> =
     "examples/**",
     "scripts/**",
     "tests/evals/**",
-    // oxlint --type-aware + knip are the only type coverage workers get (#720).
+    // build re-enters `bun run check`, which now runs check:workers tsc (#725)
+    // on top of the repo-wide type-aware lint + knip.
     "workers/**",
     "skills/**",
     "lifecycle.json",

--- a/scripts/ci-routing/routing.ts
+++ b/scripts/ci-routing/routing.ts
@@ -354,7 +354,7 @@ export type PlanOptions = {
  * - docs generators (gen-llms / lifecycle.json) sit on the docs lane → pages
  * - pixel VR follows package surface, examples, visual tests, or docs_render only
  * - docs_journeys covers non-pixel Playwright structure/a11y for docs content PRs
- * - workers run unit (own bun suite) + build (repo-wide type-aware lint / knip)
+ * - workers run unit (own bun suite + check:workers tsc) + build (type-aware lint / knip)
  *
  * Force tiers (do not collapse these):
  * - `forceProduct`: lockfile or ci-routing self-change — full package/browser surface.

--- a/scripts/release-wiring.test.ts
+++ b/scripts/release-wiring.test.ts
@@ -98,6 +98,38 @@ describe("R0 release wiring", () => {
     }
   });
 
+  it("typechecks the playground-api worker inside `bun run check` (issue #725)", () => {
+    // The worker has no build step — wrangler bundles straight from source — so
+    // this dedicated project is its only tsc coverage. The root tsconfig.json
+    // includes workers/** for oxlint --type-aware, but nothing ever ran tsc on
+    // it (#725), and type-aware lint rules are a strict subset of tsc
+    // diagnostics: assignability and optionality errors slipped through.
+    const pkg = JSON.parse(read("package.json")) as { scripts: Record<string, string> };
+    expect(pkg.scripts["check:workers"]).toContain("tsc -p workers/playground-api");
+    // Chained into `check`, which ci-unit.yml runs and `build` re-enters.
+    expect(pkg.scripts["check"]).toContain("bun run check:workers");
+    // Whole-line: `bun run check:pages-links` &c must not satisfy this.
+    expect(read(".github/workflows/ci-unit.yml")).toMatch(/^\s*run: bun run check$/mu);
+
+    // src alone would leave the bun:test suite unchecked, and 15 of the 41
+    // errors the project first surfaced were in it.
+    const project = read("workers/playground-api/tsconfig.json");
+    for (const glob of ['"src/**/*.ts"', '"test/**/*.ts"']) {
+      expect(project, `worker tsconfig includes ${glob}`).toContain(glob);
+    }
+    // eval/** stays out on purpose: it imports the docs client's envelope
+    // parser, and apps/docs is checked by svelte-check under a config that does
+    // not extend tsconfig.base.json. Pulling it in would make docs edits fail
+    // this worker gate instead of check:docs.
+    expect(project).not.toContain('"eval/');
+    // Tripwire on the reason, not just the outcome: if that import goes away,
+    // eval/** can be folded into the project and this test should be revisited.
+    expect(
+      read("workers/playground-api/eval/run-eval.ts"),
+      "eval/** exclusion is justified by its apps/docs import",
+    ).toContain("apps/docs/src/lib/playground-agent-envelope");
+  });
+
   it("checks packed links in CI and the Cloudflare Pages deployment", () => {
     expect(readCiSurface()).toContain("bun run check:pages-links");
     expect(read(".github/workflows/cloudflare-pages.yml")).toContain("bun run build:cloudflare");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,9 +4,15 @@
   // package is checked by svelte-check from its own directory. This config
   // exists so oxlint --type-aware has type information for scripts/ and the
   // Cloudflare workers under workers/ (which have no build step of their own —
-  // wrangler bundles them straight from source, so this is their only
-  // typecheck). The worker code uses web-standard APIs only (Request,
-  // Response, URL); bun's types cover them, so no @cloudflare/workers-types.
+  // wrangler bundles them straight from source). The worker code uses
+  // web-standard APIs only (Request, Response, URL); bun's types cover them,
+  // so no @cloudflare/workers-types.
+  //
+  // tsc is NOT run on this config: scripts/** still has ~200 errors it has
+  // never been held to (#725). The worker slice was split out into
+  // workers/playground-api/tsconfig.json, which `bun run check:workers` does
+  // run — and which is the more accurate program of the two, since scripts/**
+  // membership here drags in @types/node and shadows the global fetch types.
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "noEmit": true,

--- a/workers/playground-api/eval/run-eval.ts
+++ b/workers/playground-api/eval/run-eval.ts
@@ -126,7 +126,7 @@ function validateEnvelope(
 }
 
 async function main(): Promise<void> {
-  const apiKey = process.env.OPENROUTER_API_KEY;
+  const apiKey = process.env["OPENROUTER_API_KEY"];
   if (apiKey === undefined || apiKey === "") {
     console.error(
       "OPENROUTER_API_KEY is not set. This eval is maintainer-only; canned envelopes are validated by unit tests without a key.",
@@ -134,7 +134,7 @@ async function main(): Promise<void> {
     process.exit(2);
   }
 
-  const models = (process.env.MODEL_ALLOWLIST ?? DEFAULT_MODELS.join(","))
+  const models = (process.env["MODEL_ALLOWLIST"] ?? DEFAULT_MODELS.join(","))
     .split(",")
     .map((s) => s.trim())
     .filter(Boolean);

--- a/workers/playground-api/src/handler.ts
+++ b/workers/playground-api/src/handler.ts
@@ -20,6 +20,15 @@ export interface RateLimitBinding {
   limit(options: { key: string }): Promise<{ success: boolean }>;
 }
 
+/**
+ * The outbound-call seam. Structural on purpose: the handler only ever *calls*
+ * it, never touching runtime-specific members of the global `fetch` function
+ * object (bun's carries `preconnect`, workerd's does not). Typing the seam as
+ * `typeof fetch` would make every test stub owe whichever runtime's lib happens
+ * to be in scope a property the worker never uses (#725).
+ */
+export type FetchLike = (input: string, init: RequestInit) => Promise<Response>;
+
 export interface PlaygroundApiEnv {
   readonly OPENROUTER_API_KEY?: string;
   readonly MODEL_ALLOWLIST?: string;
@@ -27,7 +36,7 @@ export interface PlaygroundApiEnv {
   readonly RATE_LIMIT_IP?: RateLimitBinding;
   readonly RATE_LIMIT_GLOBAL?: RateLimitBinding;
   /** Injectable for tests. */
-  readonly fetch?: typeof fetch;
+  readonly fetch?: FetchLike;
   readonly log?: (line: Record<string, unknown>) => void;
   readonly now?: () => number;
 }
@@ -215,20 +224,24 @@ export async function handleGenerate(request: Request, env: PlaygroundApiEnv): P
     return jsonResponse(apiError("bad_request", SAFE_MESSAGES.oversized_input), 400, cors);
   }
 
-  let body: GenerateRequestBody;
+  let parsed: unknown;
   try {
     const raw = await request.arrayBuffer();
     if (raw.byteLength > MAX_REQUEST_BODY_BYTES) {
       return jsonResponse(apiError("bad_request", SAFE_MESSAGES.oversized_input), 400, cors);
     }
-    body = JSON.parse(new TextDecoder().decode(raw)) as GenerateRequestBody;
+    parsed = JSON.parse(new TextDecoder().decode(raw)) as unknown;
   } catch {
     return jsonResponse(apiError("bad_request", SAFE_MESSAGES.bad_request), 400, cors);
   }
 
-  if (!isObject(body)) {
+  if (!isObject(parsed)) {
     return jsonResponse(apiError("bad_request", SAFE_MESSAGES.bad_request), 400, cors);
   }
+  // Narrow once here rather than casting the JSON.parse result: the interface
+  // names the fields this handler reads, it is not evidence they are present or
+  // well-typed — every one is validated below.
+  const body: GenerateRequestBody = parsed;
 
   if (typeof body.prompt !== "string") {
     return jsonResponse(apiError("bad_request", SAFE_MESSAGES.bad_request), 400, cors);
@@ -378,10 +391,8 @@ export async function handleGenerate(request: Request, env: PlaygroundApiEnv): P
   // `models` requests provider-side fallback, so the first entry is not
   // necessarily what answered. Attributing output — and the outcome log that
   // tunes MODEL_ALLOWLIST — to a guess is worse than reporting null (#697).
-  const model =
-    isObject(completion) && typeof completion.model === "string" && completion.model !== ""
-      ? completion.model
-      : null;
+  const reported: unknown = isObject(completion) ? completion["model"] : undefined;
+  const model = typeof reported === "string" && reported !== "" ? reported : null;
 
   const content = extractContent(completion);
   if (content === null) {
@@ -468,15 +479,15 @@ export async function handleGenerate(request: Request, env: PlaygroundApiEnv): P
 
 function extractContent(completion: unknown): string | null {
   if (!isObject(completion)) return null;
-  const choices = completion.choices;
+  const choices = completion["choices"];
   if (!Array.isArray(choices) || choices.length === 0) return null;
   // Array.isArray() narrows `unknown` to `any[]`, so re-annotate to keep the
   // element unknown until isObject() proves its shape.
   const first: unknown = choices[0];
   if (!isObject(first)) return null;
-  const message = first.message;
+  const message = first["message"];
   if (!isObject(message)) return null;
-  const content = message.content;
+  const content = message["content"];
   if (typeof content === "string" && content.trim() !== "") return content;
   return null;
 }

--- a/workers/playground-api/src/prompt.ts
+++ b/workers/playground-api/src/prompt.ts
@@ -131,7 +131,10 @@ export function buildChatMessages(input: {
   readonly prompt: string;
   readonly currentSpec?: unknown;
   readonly priorEnvelope?: unknown;
-  readonly priorErrors?: unknown[];
+  // Explicit `| undefined`: under exactOptionalPropertyTypes the callers pass an
+  // `unknown[] | undefined` local rather than omitting the key, and the body
+  // below already branches on `!== undefined`.
+  readonly priorErrors?: unknown[] | undefined;
 }): { readonly messages: readonly ChatMessage[]; readonly systemBytes: number } {
   const system = assembleSystemPrompt(input.datasetId);
   let userContent = input.prompt.trim();

--- a/workers/playground-api/test/handler.test.ts
+++ b/workers/playground-api/test/handler.test.ts
@@ -463,8 +463,8 @@ describe("handleGenerate", () => {
       OPENROUTER_API_KEY: "sk-test-key",
       ...okLimiters,
       fetch: (url, init) => {
-        seenUrl = typeof url === "string" ? url : url instanceof URL ? url.href : url.url;
-        seenBody = JSON.parse(typeof init?.body === "string" ? init.body : "{}") as Record<
+        seenUrl = url;
+        seenBody = JSON.parse(typeof init.body === "string" ? init.body : "{}") as Record<
           string,
           unknown
         >;
@@ -488,7 +488,7 @@ describe("handleGenerate", () => {
       MODEL_ALLOWLIST: "vendor/free-a, vendor/free-b",
       ...okLimiters,
       fetch: (_url, init) => {
-        seenBody = JSON.parse(typeof init?.body === "string" ? init.body : "{}") as Record<
+        seenBody = JSON.parse(typeof init.body === "string" ? init.body : "{}") as Record<
           string,
           unknown
         >;
@@ -553,7 +553,9 @@ describe("handleGenerate", () => {
           controller.close();
         },
       }),
-      // @ts-expect-error duplex is required for a streaming request body.
+      // Required for a streaming request body. The suppression this used to
+      // carry was an artifact of the root tsconfig, where scripts/** pulls in
+      // @types/node and its RequestInit (no `duplex`) shadows bun's (#725).
       duplex: "half",
     });
     const res = await handleGenerate(req, {

--- a/workers/playground-api/tsconfig.json
+++ b/workers/playground-api/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  // The only tsc coverage the worker gets: wrangler bundles it straight from
+  // source, so there is no build step and it is not in the `tsc -b` graph. Run
+  // by `bun run check:workers` (chained into `check`) — see issue #725, where
+  // the root tsconfig.json turned out to exist only for oxlint --type-aware,
+  // whose type-aware rules are a strict subset of tsc's diagnostics.
+  //
+  // "types": ["bun"] stands in for the workerd runtime — bun's lib covers the
+  // web-standard Request/Response/URL surface the worker actually uses. This
+  // narrower program is a *truer* type environment than the root config, whose
+  // scripts/** members drag in @types/node and shadow the global fetch types.
+  // Injected seams are typed structurally (FetchLike in src/handler.ts) so no
+  // bun-specific shape leaks into the worker's own contract.
+  //
+  // eval/** is deliberately out: run-eval.ts is a maintainer-only harness that
+  // imports the docs client's envelope parser, and apps/docs is checked by
+  // svelte-check under apps/docs/tsconfig.json, which does NOT extend
+  // tsconfig.base.json. Including it would enforce base strictness on the docs
+  // app through a worker gate, so docs edits would fail here instead of in
+  // check:docs. src/** reaches only playground-dataset-schemas.ts, which is
+  // dependency-free by contract and clean under these options.
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["bun"]
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}


### PR DESCRIPTION
Closes #725. Follow-up for the deferred half: #734.

## Problem

`workers/playground-api` has no build step — wrangler bundles it straight from
source — so it is not in the `tsc -b` graph. The root `tsconfig.json` that
nominally covers it (`include: ["scripts/**/*.ts", "workers/**/*.ts"]`) exists
only so `oxlint --type-aware` has type information, and **nothing ever invoked
tsc on it**. Type-aware lint rules are a strict subset of tsc diagnostics, so
assignability and optionality errors were never checked anywhere.

Verified before the fix: 41 errors under `workers/**` — 24 in `src/handler.ts`,
15 in `test/handler.test.ts`, 2 in `eval/run-eval.ts`.

## What changed

Option 2 from the issue — the smallest step that closes the worker gap.

**The gate.** New `workers/playground-api/tsconfig.json` over `src/**` +
`test/**`, extending `tsconfig.base.json`, run by `bun run check:workers` and
chained into `check`. `ci-unit.yml` already runs `bun run check`, and `build`
re-enters it, so both existing CI lanes pick it up; CI routing already maps
`workers/**` to those lanes.

**`eval/** is deliberately excluded**, which is a departure from the issue's
sketch, on evidence found while implementing: `eval/run-eval.ts` imports the
docs client's envelope parser, and `apps/docs/tsconfig.json:3` extends
`./.svelte-kit/tsconfig.json`, *not* `tsconfig.base.json` — so
`noPropertyAccessFromIndexSignature` deliberately does not apply to the docs
app, where `check:docs` is the gate. Including `eval/**` dragged in three
`apps/docs` modules and 25 `TS4111`s, i.e. it would enforce base strictness on
the docs app through a worker gate, so docs edits would fail in `check:workers`
instead of `check:docs`. Its own two errors are fixed regardless. `src/**`
reaches only `playground-dataset-schemas.ts`, which is dependency-free by
contract and clean under these options. Rationale is in the tsconfig comment and
tripwired by the test.

**Worker fixes — none behavioural:**

- `env.fetch` is now a structural `FetchLike` rather than `typeof fetch`. The
  handler only ever *calls* the seam; demanding the whole fetch function object
  made every test stub owe `preconnect`, which is a bun-lib artifact of standing
  in for workerd. That was 15 of the 41 errors, and typing the seam for what it
  is fixes them without a single cast.
- `handleGenerate` parses the body into `unknown` and narrows once, replacing
  `JSON.parse(...) as GenerateRequestBody` — a cast asserting a shape nothing
  had validated yet. Reads then resolve against the interface instead of a
  `GenerateRequestBody & Record<string, unknown>` intersection, which is what
  produced ~13 `TS4111`s.
- Genuine index reads on parsed upstream completions use bracket access.
- `buildChatMessages` declares `priorErrors?: unknown[] | undefined`, matching
  what its callers pass and what its body already branches on (the one `TS2379`).

**A bonus finding.** The narrow project is the *more accurate* of the two
programs. `scripts/**` membership in the root config drags in `@types/node`,
whose `RequestInit` shadows bun's and lacks `duplex`. Proven by removing the
directive and running both configs: root reports `TS2353` at that line, the
worker project reports nothing. So the `@ts-expect-error` the streaming-body
test carried was suppressing an artifact, and it is now removed. This is the
one thing #734 must not re-suppress, and it is called out there.

## Tests

New assertion in `scripts/release-wiring.test.ts` (where #720 put the sibling
`workers/playground-api` suite-wiring assertion): `check:workers` invokes the
worker tsc, `check` chains it, `ci-unit.yml` runs `bun run check` as a whole
line, the project includes `src/**` + `test/**`, and `eval/**` is absent *along
with the import that justifies it* — so if that import goes away, the test tells
the next person to reconsider the exclusion.

Mutation-tested rather than assumed:

| mutation | result |
|---|---|
| `&& bun run check:workers` removed from `check` | fails |
| `test/**/*.ts` dropped from the project | fails (`worker tsconfig includes "test/**/*.ts"`) |
| both restored | 23 pass |

Also updated two comments this makes false: `content-hash.ts` ("oxlint
--type-aware + knip are the only type coverage workers get"), `routing.ts`'s
workers lane note, and the root `tsconfig.json` header.

## Verification

```
$ ./node_modules/.bin/tsc -p workers/playground-api --noEmit   # 41 errors -> exit 0
$ bun run check                                                 # exit 0 (chain incl. check:workers)
$ bun run test                                                  # 2637 pass, 0 fail (328 files)
$ bun run lint / lint:type-aware / fmt:check / knip / lint:package   # all clean
```

Root-config total drops 277 -> 237: `workers/**` 41 -> 1 (the `@types/node`
artifact above), `scripts/**` 203 and `apps/**` 33 untouched by design.

## Follow-ups

- #734 — `scripts/**` (203 errors), with the `apps/docs` strictness split and
  the `RequestInit` collision written up as prerequisites for wiring root tsc.