### PR TITLE
fix(#695): one source of truth for the playground wire error codes

### DIFF
--- a/apps/docs/src/lib/playground-agent-client.ts
+++ b/apps/docs/src/lib/playground-agent-client.ts
@@ -11,6 +11,7 @@ import {
 } from "./playground-agent-envelope";
 import type { PlaygroundAgentErrorCode } from "./playground-agent-state";
 import { messageForAgentError } from "./playground-agent-state";
+import { isPlaygroundApiErrorCode } from "./playground-api-error-codes";
 import type { PlaygroundDatasetId } from "./playground-dataset-schemas";
 import { mockGenerateEnvelope } from "./playground-prompts";
 
@@ -91,24 +92,12 @@ function resolveApiUrl(explicit?: string): string {
   return DEFAULT_PLAYGROUND_API_URL;
 }
 
+/**
+ * Recognised against the shared wire union (#695), so a new server code is
+ * carried through instead of being mislabelled as a provider outage.
+ */
 function mapApiErrorCode(code: unknown): PlaygroundAgentErrorCode {
-  const known: PlaygroundAgentErrorCode[] = [
-    "bad_request",
-    "prompt_too_long",
-    "unknown_dataset",
-    "origin_forbidden",
-    "not_found",
-    "method_not_allowed",
-    "rate_limited",
-    "upstream_rate_limited",
-    "upstream_error",
-    "bad_output",
-    "disabled",
-  ];
-  if (typeof code === "string" && (known as string[]).includes(code)) {
-    return code as PlaygroundAgentErrorCode;
-  }
-  return "upstream_error";
+  return isPlaygroundApiErrorCode(code) ? code : "upstream_error";
 }
 
 /**

--- a/apps/docs/src/lib/playground-agent-state.ts
+++ b/apps/docs/src/lib/playground-agent-state.ts
@@ -6,7 +6,10 @@
 import type { SpecError } from "@ggsvelte/spec";
 
 import type { PlaygroundAgentEnvelope } from "./playground-agent-envelope";
-import { PLAYGROUND_PROMPT_MAX_CHARS } from "./playground-dataset-schemas";
+import {
+  type PlaygroundApiErrorCode,
+  SHARED_API_ERROR_MESSAGES,
+} from "./playground-api-error-codes";
 
 export type PlaygroundAgentPhase =
   | "idle"
@@ -16,24 +19,20 @@ export type PlaygroundAgentPhase =
   | "drawing"
   | "failed";
 
-export type PlaygroundAgentErrorCode =
-  | "bad_request"
-  | "prompt_too_long"
-  | "unknown_dataset"
-  | "origin_forbidden"
-  | "not_found"
-  | "method_not_allowed"
-  | "rate_limited"
-  | "upstream_rate_limited"
-  | "upstream_error"
-  | "bad_output"
-  | "disabled"
-  /** The service itself failed or was intercepted — no worker body came back. */
+/**
+ * Failures the client raises on its own — never sent by the worker.
+ * `service_error`: the service failed or was intercepted, so no worker body
+ * came back at all.
+ */
+export type PlaygroundAgentLocalErrorCode =
   | "service_error"
   | "network"
   | "validation"
   | "pipeline"
   | "aborted";
+
+/** Every wire code (#695) plus the client-only ones. */
+export type PlaygroundAgentErrorCode = PlaygroundApiErrorCode | PlaygroundAgentLocalErrorCode;
 
 export interface PlaygroundAgentFailure {
   readonly code: PlaygroundAgentErrorCode;
@@ -164,9 +163,9 @@ export function messageForAgentError(code: PlaygroundAgentErrorCode, fallback?: 
   switch (code) {
     case "rate_limited":
     case "upstream_rate_limited":
-      return fallback ?? "Too many requests. Try again shortly.";
+      return fallback ?? SHARED_API_ERROR_MESSAGES.rate_limited;
     case "disabled":
-      return "Live generation is paused — the copy-to-your-agent path always works.";
+      return SHARED_API_ERROR_MESSAGES.disabled;
     case "network":
       return "Could not reach the generate service. Check your connection, or try a sample chart.";
     case "validation":
@@ -178,7 +177,7 @@ export function messageForAgentError(code: PlaygroundAgentErrorCode, fallback?: 
     case "bad_output":
       return "The model returned an unusable chart. Try a sample or rephrase.";
     case "upstream_error":
-      return "The model provider failed. Try again or use a sample chart.";
+      return SHARED_API_ERROR_MESSAGES.upstream_error;
     case "service_error":
       // Edge outage, proxy, or captive portal: nothing the user can rephrase.
       return "The generate service is unavailable. Try again shortly, or use a sample chart.";
@@ -188,9 +187,9 @@ export function messageForAgentError(code: PlaygroundAgentErrorCode, fallback?: 
     case "origin_forbidden":
       return "This origin cannot call live generation. Use a sample or copy the agent prompt.";
     case "prompt_too_long":
-      return `Prompt is too long (max ${PLAYGROUND_PROMPT_MAX_CHARS} characters).`;
+      return SHARED_API_ERROR_MESSAGES.prompt_too_long;
     case "unknown_dataset":
-      return "Unknown dataset.";
+      return SHARED_API_ERROR_MESSAGES.unknown_dataset;
     default:
       return fallback ?? "Generation failed. Try a sample chart or copy the agent prompt.";
   }

--- a/apps/docs/src/lib/playground-api-error-codes.ts
+++ b/apps/docs/src/lib/playground-api-error-codes.ts
@@ -1,0 +1,56 @@
+/**
+ * Dependency-free wire contract for playground-api failures, shared by the
+ * worker (workers/playground-api) and the docs client. Single source of truth
+ * for the error-code union and for the failure copy that must read the same
+ * whichever side produced it (#695).
+ *
+ * Same seam as playground-dataset-schemas.ts: the worker imports it straight
+ * from source, so this module must stay free of app-only imports.
+ */
+
+import { PLAYGROUND_PROMPT_MAX_CHARS } from "./playground-dataset-schemas";
+
+/**
+ * Every code the worker can put on the wire. Adding one here is a compile
+ * error in the worker's status map and safe-message table until it is handled,
+ * and the client's recognizer widens automatically — the drift this array
+ * exists to kill.
+ */
+export const PLAYGROUND_API_ERROR_CODES = [
+  "bad_request",
+  "prompt_too_long",
+  "unknown_dataset",
+  "origin_forbidden",
+  "not_found",
+  "method_not_allowed",
+  "rate_limited",
+  "upstream_rate_limited",
+  "upstream_error",
+  "bad_output",
+  "disabled",
+] as const;
+
+export type PlaygroundApiErrorCode = (typeof PLAYGROUND_API_ERROR_CODES)[number];
+
+export function isPlaygroundApiErrorCode(value: unknown): value is PlaygroundApiErrorCode {
+  return (
+    typeof value === "string" && (PLAYGROUND_API_ERROR_CODES as readonly string[]).includes(value)
+  );
+}
+
+/**
+ * Failure copy that must be byte-identical on both sides: the worker sends it
+ * when it answers, the client synthesises it when no worker body came back, and
+ * a user must not see two wordings for one failure.
+ *
+ * Codes absent from this table word their sides differently on purpose — the
+ * worker reports the transport fact ("No such endpoint."), the client tells the
+ * user what to do instead ("Use a sample chart or copy the agent prompt.").
+ */
+export const SHARED_API_ERROR_MESSAGES = {
+  prompt_too_long: `Prompt is too long (max ${PLAYGROUND_PROMPT_MAX_CHARS} characters).`,
+  unknown_dataset: "Unknown dataset.",
+  rate_limited: "Too many requests. Try again shortly.",
+  upstream_error: "The model provider failed. Try again or use a sample chart.",
+  disabled: "Live generation is paused — the copy-to-your-agent path always works.",
+} as const satisfies Partial<Record<PlaygroundApiErrorCode, string>>;

--- a/scripts/playground-api-error-codes.test.ts
+++ b/scripts/playground-api-error-codes.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  PLAYGROUND_API_ERROR_CODES,
+  SHARED_API_ERROR_MESSAGES,
+} from "../apps/docs/src/lib/playground-api-error-codes";
+import { generateChart } from "../apps/docs/src/lib/playground-agent-client";
+import { messageForAgentError } from "../apps/docs/src/lib/playground-agent-state";
+import { SAFE_MESSAGES, statusForError } from "../workers/playground-api/src/errors";
+
+/** Live-mode generateChart against a worker that answered with `code`. */
+async function codeFromWorkerBody(code: string): Promise<string> {
+  const result = await generateChart(
+    { prompt: "hi", datasetId: "penguins" },
+    {
+      mode: "live",
+      apiUrl: "https://example.test",
+      fetchFn: () =>
+        Promise.resolve(
+          new Response(JSON.stringify({ ok: false, error: { code, message: "boom" } }), {
+            status: 400,
+          }),
+        ),
+    },
+  );
+  return result.ok ? "ok" : result.code;
+}
+
+describe("playground wire error-code contract (#695)", () => {
+  // Deployed clients recognise exactly these codes, so dropping or renaming one
+  // is a breaking wire change and has to be a deliberate edit here.
+  test("the wire union is locked to the codes both sides were hand-copying", () => {
+    expect(PLAYGROUND_API_ERROR_CODES.toSorted()).toEqual([
+      "bad_output",
+      "bad_request",
+      "disabled",
+      "method_not_allowed",
+      "not_found",
+      "origin_forbidden",
+      "prompt_too_long",
+      "rate_limited",
+      "unknown_dataset",
+      "upstream_error",
+      "upstream_rate_limited",
+    ]);
+  });
+
+  test("the client round-trips every wire code instead of degrading it", async () => {
+    for (const code of PLAYGROUND_API_ERROR_CODES) {
+      expect(await codeFromWorkerBody(code)).toBe(code);
+    }
+  });
+
+  test("an unknown code still degrades to upstream_error", async () => {
+    expect(await codeFromWorkerBody("teapot_on_fire")).toBe("upstream_error");
+  });
+
+  test("the worker gives every wire code a status and a safe message", () => {
+    for (const code of PLAYGROUND_API_ERROR_CODES) {
+      expect(statusForError(code)).toBeGreaterThanOrEqual(400);
+      expect(SAFE_MESSAGES[code]).toBeTruthy();
+    }
+  });
+
+  test("shared copy is byte-identical on the worker and the client", () => {
+    const shared = Object.entries(SHARED_API_ERROR_MESSAGES);
+    expect(shared.length).toBeGreaterThan(0);
+    for (const [code, message] of shared) {
+      expect(SAFE_MESSAGES[code as keyof typeof SAFE_MESSAGES]).toBe(message);
+      expect(messageForAgentError(code as (typeof PLAYGROUND_API_ERROR_CODES)[number])).toBe(
+        message,
+      );
+    }
+  });
+
+  test("client-only codes are not part of the wire union", () => {
+    for (const local of ["service_error", "network", "validation", "pipeline", "aborted"]) {
+      expect((PLAYGROUND_API_ERROR_CODES as readonly string[]).includes(local)).toBe(false);
+    }
+  });
+});

--- a/workers/playground-api/src/errors.ts
+++ b/workers/playground-api/src/errors.ts
@@ -1,17 +1,11 @@
-import { PLAYGROUND_PROMPT_MAX_CHARS } from "../../../apps/docs/src/lib/playground-dataset-schemas";
+import {
+  type PlaygroundApiErrorCode,
+  SHARED_API_ERROR_MESSAGES,
+} from "../../../apps/docs/src/lib/playground-api-error-codes";
 
-export type PlaygroundApiErrorCode =
-  | "bad_request"
-  | "prompt_too_long"
-  | "unknown_dataset"
-  | "origin_forbidden"
-  | "not_found"
-  | "method_not_allowed"
-  | "rate_limited"
-  | "upstream_rate_limited"
-  | "upstream_error"
-  | "bad_output"
-  | "disabled";
+// The union lives with the wire contract in apps/docs so the client cannot
+// drift from it (#695); the status map and safe copy below stay worker-only.
+export type { PlaygroundApiErrorCode };
 
 export interface PlaygroundApiErrorBody {
   readonly code: PlaygroundApiErrorCode;
@@ -69,18 +63,25 @@ export function statusForError(code: PlaygroundApiErrorCode): number {
   return ERROR_STATUS[code];
 }
 
-/** User-facing messages — never echo upstream bodies. */
+/**
+ * User-facing messages — never echo upstream bodies. Keyed by the full union
+ * plus `oversized_input`, which is copy rather than a code: the handler sends
+ * it under `bad_request`, so it must never reach the wire union.
+ *
+ * Entries pulled from SHARED_API_ERROR_MESSAGES are the ones the client also
+ * has to say; the rest are worker-only wording.
+ */
 export const SAFE_MESSAGES = {
   bad_request: "The request is invalid.",
-  prompt_too_long: `Prompt is too long (max ${PLAYGROUND_PROMPT_MAX_CHARS} characters).`,
-  unknown_dataset: "Unknown dataset.",
+  prompt_too_long: SHARED_API_ERROR_MESSAGES.prompt_too_long,
+  unknown_dataset: SHARED_API_ERROR_MESSAGES.unknown_dataset,
   origin_forbidden: "Origin is not allowed.",
   not_found: "No such endpoint.",
   method_not_allowed: "Method not allowed.",
-  rate_limited: "Too many requests. Try again shortly.",
+  rate_limited: SHARED_API_ERROR_MESSAGES.rate_limited,
   upstream_rate_limited: "The model provider is rate-limiting. Try again shortly.",
-  upstream_error: "The model provider failed. Try again or use a sample chart.",
+  upstream_error: SHARED_API_ERROR_MESSAGES.upstream_error,
   bad_output: "The model returned an unusable response.",
-  disabled: "Live generation is paused — the copy-to-your-agent path always works.",
+  disabled: SHARED_API_ERROR_MESSAGES.disabled,
   oversized_input: "Request body is too large.",
-} as const;
+} as const satisfies Record<PlaygroundApiErrorCode | "oversized_input", string>;


### PR DESCRIPTION
Closes #695.

## Problem

The playground wire error-code union was written out three times with no compile-time link between the copies:

1. `PlaygroundApiErrorCode` — `workers/playground-api/src/errors.ts`
2. The first 11 members of `PlaygroundAgentErrorCode` — `apps/docs/src/lib/playground-agent-state.ts`
3. A hand-written `known` array in `mapApiErrorCode` — `apps/docs/src/lib/playground-agent-client.ts`

Adding a 12th server code produced no type error anywhere, and the client degraded the unrecognised code to `upstream_error` — a new server-side failure would ship to users mislabelled as a provider outage.

Five failure strings were also byte-identical across the worker's `SAFE_MESSAGES` and the client's `messageForAgentError` (`disabled`, `upstream_error`, `rate_limited`, `unknown_dataset`, `prompt_too_long`), so a copy edit on one side gave users two wordings for one failure.

## What changed

New dependency-free `apps/docs/src/lib/playground-api-error-codes.ts`, sitting on the same seam the worker already imports through (`playground-dataset-schemas.ts`). It exports `PLAYGROUND_API_ERROR_CODES`, the derived `PlaygroundApiErrorCode`, an `isPlaygroundApiErrorCode` recognizer, and `SHARED_API_ERROR_MESSAGES`.

- **Worker** re-exports the union and pulls the five shared strings; the HTTP status map and worker-only wording stay put. `SAFE_MESSAGES` now `satisfies Record<PlaygroundApiErrorCode | "oversized_input", string>`, so a new code is a compile error there as well as in `ERROR_STATUS`.
- **Client** derives `PlaygroundAgentErrorCode = PlaygroundApiErrorCode | PlaygroundAgentLocalErrorCode`, and `mapApiErrorCode` recognises codes off the shared array instead of a hand-written list (21 lines → 1).

### One correction to the issue's notes

The issue suggested `oversized_input` was either a missing union member or dead. It is neither: it is **copy**, not a code — the handler sends it under `bad_request` at `workers/playground-api/src/handler.ts:224,231,261,264,277,291`. It stays a worker-only `SAFE_MESSAGES` entry and is deliberately kept off the wire union; the `satisfies` clause names it explicitly so that stays intentional.

## Validation evidence

TDD: `scripts/playground-api-error-codes.test.ts` written first, failing on the missing module, then made green.

The SSOT claim was verified by mutation — temporarily adding a 12th code (`quota_exhausted`) to the shared array:

```
$ bun run check:workers
errors.ts(47,7): error TS2741: Property 'quota_exhausted' is missing ... in type 'Record<..., number>'
errors.ts(87,12): error TS1360: ... 'quota_exhausted' is missing ... in type 'Record<..., string>'
```

...and the client round-trip test then covered all 12 codes with no hand-edit, proving the recognizer widens automatically. Both were reverted; the mutation is not in the diff.

New tests: wire union is locked; client round-trips every wire code instead of degrading it; unknown codes still degrade to `upstream_error`; every wire code has a status ≥400 and a safe message; shared copy is byte-identical on both sides; client-only codes stay off the wire.

The cross-side tests live in `scripts/` rather than `workers/playground-api/test/` on purpose — the worker's tsconfig excludes `eval/**` precisely to keep the docs client out of its program, and importing the client into the worker test dir would undo that.

## Verification

| Command | Result |
|---|---|
| `bun run test` | 2643 pass, 0 fail (329 files) |
| `bun run check` (incl. `check:workers`) | clean |
| `bun run check:docs` (svelte-check) | 1826 files, 0 errors, 0 warnings |
| `bun run lint` / `lint:type-aware` | clean |
| `bun run fmt:check` | clean |
| `bun run knip` | clean |

## Follow-ups

None deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)