### PR TITLE
fix(#734): give scripts/ci-routing a real tsc gate

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,9 @@
   ],
   "type": "module",
   "scripts": {
-    "check": "tsc -b packages/spec packages/core && bun run check:type-contracts && bun run check:workers",
+    "check": "tsc -b packages/spec packages/core && bun run check:type-contracts && bun run check:workers && bun run check:scripts-ci-routing",
     "check:workers": "bun node_modules/.bin/tsc -p workers/playground-api --noEmit",
+    "check:scripts-ci-routing": "bun node_modules/.bin/tsc -p scripts/ci-routing --noEmit",
     "check:type-contracts": "tsc -p packages/spec/type-tests/tsconfig.json",
     "check:svelte": "cd packages/svelte && bun run --bun check",
     "check:examples": "bun node_modules/.bin/tsc -p examples --noEmit",

--- a/scripts/ci-routing/cli.ts
+++ b/scripts/ci-routing/cli.ts
@@ -59,7 +59,7 @@ export async function runCiRoutingCli(argv: string[]): Promise<void> {
     const plan = planJobs(changes, { forceAll });
     const bypassContentCache = shouldBypassContentCache(changes, { forceAll });
     const body = formatGithubOutputs(plan, { bypassContentCache });
-    const outPath = process.env.GITHUB_OUTPUT;
+    const outPath = process.env["GITHUB_OUTPUT"];
     if (typeof outPath === "string" && outPath.length > 0) {
       appendFileSync(outPath, body);
     }
@@ -212,12 +212,12 @@ export function lastSuccessfulMainHeadJq(headSha: string): string {
 function runDetectChangesCli(): void {
   const env = process.env;
   const input: DetectChangesInput = {
-    eventName: env.EVENT_NAME ?? "",
-    githubRef: env.GITHUB_REF ?? "",
-    baseSha: env.BASE_SHA ?? "",
-    headSha: env.HEAD_SHA ?? "",
-    prLabels: env.PR_LABELS ?? "",
-    repo: env.REPO ?? "",
+    eventName: env["EVENT_NAME"] ?? "",
+    githubRef: env["GITHUB_REF"] ?? "",
+    baseSha: env["BASE_SHA"] ?? "",
+    headSha: env["HEAD_SHA"] ?? "",
+    prLabels: env["PR_LABELS"] ?? "",
+    repo: env["REPO"] ?? "",
   };
   if (input.eventName.length === 0) {
     throw new Error("detect-changes requires EVENT_NAME");
@@ -228,7 +228,7 @@ function runDetectChangesCli(): void {
   if (input.repo.length === 0) {
     throw new Error("detect-changes requires REPO");
   }
-  const outPath = env.GITHUB_OUTPUT;
+  const outPath = env["GITHUB_OUTPUT"];
   if (typeof outPath !== "string" || outPath.length === 0) {
     throw new Error("detect-changes requires GITHUB_OUTPUT (job outputs path)");
   }
@@ -260,26 +260,26 @@ function runCiGateCli(): void {
     docs_journeys: req("DOCS_JOURNEYS_REQ"),
   };
   const gate = evaluateCiGate({
-    eventName: env.EVENT_NAME ?? "",
+    eventName: env["EVENT_NAME"] ?? "",
     required,
     results: {
-      checks: env.CHECKS_RES,
-      unit: env.UNIT_RES,
-      consumer: env.CONSUMER_RES,
-      build: env.BUILD_RES,
-      svelte_check: env.SVELTE_CHECK_RES,
-      docs_site: env.DOCS_SITE_RES,
-      actions_security: env.ACTIONS_RES,
-      bench_smoke: env.BENCH_RES,
-      packages_dist: env.PACKAGES_DIST_RES,
-      docs_journeys: env.DOCS_JOURNEYS_RES,
+      checks: env["CHECKS_RES"],
+      unit: env["UNIT_RES"],
+      consumer: env["CONSUMER_RES"],
+      build: env["BUILD_RES"],
+      svelte_check: env["SVELTE_CHECK_RES"],
+      docs_site: env["DOCS_SITE_RES"],
+      actions_security: env["ACTIONS_RES"],
+      bench_smoke: env["BENCH_RES"],
+      packages_dist: env["PACKAGES_DIST_RES"],
+      docs_journeys: env["DOCS_JOURNEYS_RES"],
     },
     componentShardResults: [
-      env.COMPONENT_SVELTE_RES,
-      env.COMPONENT_SVELTE_FX_RES,
-      env.COMPONENT_SPIKES_RES,
+      env["COMPONENT_SVELTE_RES"],
+      env["COMPONENT_SVELTE_FX_RES"],
+      env["COMPONENT_SPIKES_RES"],
     ],
-    vrBaselineGuardResult: env.VR_GUARD_RES,
+    vrBaselineGuardResult: env["VR_GUARD_RES"],
   });
   if (!gate.ok) {
     process.stderr.write(`ci-gate failed: ${gate.failures.join(", ")}\n`);
@@ -303,7 +303,7 @@ function parseCacheableExecution(raw: string | undefined): CacheableExecution {
 
 async function runHashInputsCli(args: string[]): Promise<void> {
   const execution = parseCacheableExecution(flagValue(args, "--execution"));
-  const os = flagValue(args, "--os") ?? process.env.RUNNER_OS ?? "unknown";
+  const os = flagValue(args, "--os") ?? process.env["RUNNER_OS"] ?? "unknown";
   const containerTag = flagValue(args, "--container-tag");
   const matrixNode = flagValue(args, "--matrix-node");
   const matrixPm = flagValue(args, "--matrix-pm");
@@ -340,13 +340,16 @@ async function runHashInputsCli(args: string[]): Promise<void> {
     );
   }
 
+  // Absent flags are omitted rather than passed as explicit `undefined`:
+  // contentHashCacheKey's optional dimensions are omit-or-provide by contract
+  // (exactOptionalPropertyTypes), and each one it sees adds a key segment.
   const cacheKey = contentHashCacheKey({
     execution,
     hash,
     os,
-    containerTag: containerTag ?? undefined,
-    matrix,
-    runtime,
+    ...(containerTag === undefined ? {} : { containerTag }),
+    ...(matrix === undefined ? {} : { matrix }),
+    ...(runtime === undefined ? {} : { runtime }),
   });
   const marker = successMarkerPath(execution);
   const body = [
@@ -357,7 +360,7 @@ async function runHashInputsCli(args: string[]): Promise<void> {
     `execution=${execution}`,
   ].join("\n");
 
-  const outPath = process.env.GITHUB_OUTPUT;
+  const outPath = process.env["GITHUB_OUTPUT"];
   if (typeof outPath === "string" && outPath.length > 0) {
     appendFileSync(outPath, `${body}\n`);
   }
@@ -406,7 +409,7 @@ async function runValidateSuccessMarkerCli(args: string[]): Promise<void> {
 }
 
 function writeGithubOutput(body: string): void {
-  const outPath = process.env.GITHUB_OUTPUT;
+  const outPath = process.env["GITHUB_OUTPUT"];
   if (typeof outPath === "string" && outPath.length > 0) {
     appendFileSync(outPath, body);
   }

--- a/scripts/ci-routing/content-hash.ts
+++ b/scripts/ci-routing/content-hash.ts
@@ -167,6 +167,8 @@ export const JOB_CONTENT_INPUTS: Record<CacheableExecution, readonly string[]> =
     "packages/svelte/**",
     "apps/docs/**",
     "examples/**",
+    // check:scripts-ci-routing tsc covers scripts/ci-routing/** (#734); the
+    // rest of scripts/** is still type-aware lint + knip only.
     "scripts/**",
     "tests/evals/**",
     // build re-enters `bun run check`, which now runs check:workers tsc (#725)
@@ -450,14 +452,14 @@ export function parseSuccessMarker(body: string): SuccessMarker | null {
     const parsed: unknown = JSON.parse(body);
     if (parsed === null || typeof parsed !== "object") return null;
     const obj = parsed as Record<string, unknown>;
-    if (typeof obj.schema !== "number") return null;
-    if (typeof obj.execution !== "string") return null;
-    if (typeof obj.hash !== "string" || obj.hash.length === 0) return null;
-    if (!(CACHEABLE_EXECUTIONS as readonly string[]).includes(obj.execution)) return null;
+    if (typeof obj["schema"] !== "number") return null;
+    if (typeof obj["execution"] !== "string") return null;
+    if (typeof obj["hash"] !== "string" || obj["hash"].length === 0) return null;
+    if (!(CACHEABLE_EXECUTIONS as readonly string[]).includes(obj["execution"])) return null;
     return {
-      schema: obj.schema,
-      execution: obj.execution as CacheableExecution,
-      hash: obj.hash,
+      schema: obj["schema"],
+      execution: obj["execution"] as CacheableExecution,
+      hash: obj["hash"],
     };
   } catch {
     return null;
@@ -530,7 +532,7 @@ async function ensureGitSafeDirectory(): Promise<void> {
   const dirs = new Set<string>();
   const cwd = process.cwd();
   if (cwd.length > 0) dirs.add(cwd);
-  const workspace = process.env.GITHUB_WORKSPACE;
+  const workspace = process.env["GITHUB_WORKSPACE"];
   if (workspace !== undefined && workspace.length > 0) dirs.add(workspace);
 
   for (const dir of dirs) {

--- a/scripts/ci-routing/detect-changes.test.ts
+++ b/scripts/ci-routing/detect-changes.test.ts
@@ -213,8 +213,8 @@ describe("buildDetectChangesOutputs interactions", () => {
     expect(plan.consumer).toBe(true);
     expect(plan.packages_dist).toBe(true);
     const parsed = parseOutput(body);
-    expect(parsed.unit).toBe("true");
-    expect(parsed.bypass_content_cache).toBe("true");
+    expect(parsed["unit"]).toBe("true");
+    expect(parsed["bypass_content_cache"]).toBe("true");
     // JOB_NAMES order: 14 jobs then bypass
     const lines = body.trimEnd().split("\n");
     expect(lines[0]).toBe("checks=true");
@@ -343,7 +343,7 @@ describe("runDetectChanges end-to-end (injected io)", () => {
     runDetectChanges(baseInput({ baseSha: "" }), io);
     expect(io.outputs.length).toBe(1);
     expect(io.logs.some((l) => l.includes("force-all"))).toBe(true);
-    expect(parseOutput(io.outputs[0]!).unit).toBe("true");
+    expect(parseOutput(io.outputs[0]!)["unit"]).toBe("true");
   });
 
   test("main package change: one write, thinned flags", () => {
@@ -353,11 +353,11 @@ describe("runDetectChanges end-to-end (injected io)", () => {
     runDetectChanges(baseInput({ eventName: "push", githubRef: "refs/heads/main" }), io);
     expect(io.outputs.length).toBe(1);
     const o = parseOutput(io.outputs[0]!);
-    expect(o.unit).toBe("true");
-    expect(o.consumer).toBe("false");
-    expect(o.bench_smoke).toBe("false");
-    expect(o.interaction_perf).toBe("false");
-    expect(o.packages_dist).toBe("true");
+    expect(o["unit"]).toBe("true");
+    expect(o["consumer"]).toBe("false");
+    expect(o["bench_smoke"]).toBe("false");
+    expect(o["interaction_perf"]).toBe("false");
+    expect(o["packages_dist"]).toBe("true");
     expect(io.logs.some((l) => l.includes("thinned consumer/bench"))).toBe(true);
   });
 
@@ -366,8 +366,8 @@ describe("runDetectChanges end-to-end (injected io)", () => {
     runDetectChanges(baseInput({ prLabels: "run-compat" }), io);
     expect(io.logs.some((l) => l.includes("run-compat: forced"))).toBe(true);
     const o = parseOutput(io.outputs[0]!);
-    expect(o.consumer).toBe("true");
-    expect(o.packages_dist).toBe("true");
+    expect(o["consumer"]).toBe("true");
+    expect(o["packages_dist"]).toBe("true");
   });
 });
 

--- a/scripts/ci-routing/routing.ts
+++ b/scripts/ci-routing/routing.ts
@@ -165,9 +165,10 @@ export const LANE_PATTERNS: Record<ChangeLane, readonly string[]> = {
     "README.md",
     "packages/svelte/README.md",
   ],
-  // Cloudflare workers (issue #720). They own a bun test suite and are only
-  // type-covered by the repo-wide oxlint --type-aware / knip pass in `build`;
-  // nothing here renders charts, so no browser/docs surface.
+  // Cloudflare workers (issue #720). They own a bun test suite and are
+  // type-covered by check:workers tsc (#725) plus the repo-wide oxlint
+  // --type-aware / knip pass; nothing here renders charts, so no browser/docs
+  // surface.
   workers: ["workers/**"],
   evals: ["tests/evals/**"],
   workflows: [

--- a/scripts/ci-routing/tsconfig.json
+++ b/scripts/ci-routing/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  // The only tsc coverage this directory gets. scripts/** sits in the root
+  // tsconfig.json purely so oxlint --type-aware has type information — tsc has
+  // never been run on that config (#734), and type-aware lint rules are a
+  // strict subset of tsc's diagnostics, so index-signature and optionality
+  // errors slipped through unseen. Run by `bun run check:scripts-ci-routing`
+  // (chained into `check`), mirroring the worker gate from #725.
+  //
+  // ci-routing is the first slice to be pulled in because it decides what CI
+  // runs: a type error here silently mis-routes every job on every PR. The rest
+  // of scripts/** still carries unchecked errors and stays on #734.
+  //
+  // Scoped to this directory only, and deliberately not to scripts/**: the
+  // sibling scripts/ci-routing.test.ts (the public re-export suite one level
+  // up) is outside the include, so widening this to the parent would drag in
+  // the unfixed remainder and fail `check` on code no one has held to tsc yet.
+  //
+  // "types": ["bun"] matches how these scripts actually run — `bun scripts/…`,
+  // with Bun.spawn and bun:test in the suites.
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["bun"]
+  },
+  "include": ["./**/*.ts"]
+}

--- a/scripts/release-wiring.test.ts
+++ b/scripts/release-wiring.test.ts
@@ -130,6 +130,35 @@ describe("R0 release wiring", () => {
     ).toContain("apps/docs/src/lib/playground-agent-envelope");
   });
 
+  it("typechecks scripts/ci-routing inside `bun run check` (issue #734)", () => {
+    // Same gap as the worker (#725), one directory further in: scripts/** is in
+    // the root tsconfig.json only so oxlint --type-aware has type information,
+    // and tsc has never been run on it. ci-routing decides which jobs CI runs,
+    // so it is the slice where a silent type error costs the most.
+    const pkg = JSON.parse(read("package.json")) as { scripts: Record<string, string> };
+    expect(pkg.scripts["check:scripts-ci-routing"]).toContain("tsc -p scripts/ci-routing");
+    // Chained into `check`, which ci-unit.yml runs and `build` re-enters.
+    expect(pkg.scripts["check"]).toContain("bun run check:scripts-ci-routing");
+    // Whole-line: `bun run check:pages-links` &c must not satisfy this.
+    expect(read(".github/workflows/ci-unit.yml")).toMatch(/^\s*run: bun run check$/mu);
+
+    const project = read("scripts/ci-routing/tsconfig.json");
+    // Base strictness is the point — the gate is worthless under looser options.
+    expect(project).toContain('"extends"');
+    expect(project).toContain("tsconfig.base.json");
+    // Assert on the include list, not the whole file — `extends` legitimately
+    // escapes upwards to the repo root.
+    const include = /"include"\s*:\s*\[[^\]]*\]/u.exec(project)?.[0] ?? "";
+    // Every .ts in the directory, tests included: the suites are where the
+    // module's contracts are asserted, so leaving them out would half-check it.
+    expect(include, "tsconfig includes the directory's .ts files").toContain('"./**/*.ts"');
+    // Scoped to this directory only. The rest of scripts/** (and apps/**) still
+    // carries unchecked errors tracked on #734; widening the include here would
+    // fail `check` on code this PR never fixed.
+    expect(include, "include stays inside scripts/ci-routing").not.toContain("..");
+    expect(include).not.toContain("apps/");
+  });
+
   it("checks packed links in CI and the Cloudflare Pages deployment", () => {
     expect(readCiSurface()).toContain("bun run check:pages-links");
     expect(read(".github/workflows/cloudflare-pages.yml")).toContain("bun run build:cloudflare");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,11 +8,15 @@
   // web-standard APIs only (Request, Response, URL); bun's types cover them,
   // so no @cloudflare/workers-types.
   //
-  // tsc is NOT run on this config: scripts/** still has ~200 errors it has
-  // never been held to (#725). The worker slice was split out into
-  // workers/playground-api/tsconfig.json, which `bun run check:workers` does
-  // run — and which is the more accurate program of the two, since scripts/**
-  // membership here drags in @types/node and shadows the global fetch types.
+  // tsc is NOT run on this config: it still reports ~190 errors nothing has
+  // ever been held to — the rest of scripts/**, plus the apps/docs modules
+  // those scripts import, which svelte-check covers under a config that does
+  // not extend tsconfig.base.json (#734). Two slices have been split out into their own
+  // projects, which `check` does run — workers/playground-api/tsconfig.json via
+  // check:workers (#725) and scripts/ci-routing/tsconfig.json via
+  // check:scripts-ci-routing (#734). The worker one is also the more accurate
+  // program of the two, since scripts/** membership here drags in @types/node
+  // and shadows the global fetch types.
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "noEmit": true,


### PR DESCRIPTION
Partial fix for #734 (ci-routing slice only — leave the issue open).

## Problem

`scripts/**` is included in the root `tsconfig.json` only so `oxlint --type-aware` has type information. **Nothing ever ran tsc on it.** Type-aware lint rules are a strict subset of tsc diagnostics, so assignability and optionality errors were never checked: **46 errors under `scripts/ci-routing/**`** on current main (TS4111 index-signature access + TS2379 exactOptionalPropertyTypes).

ci-routing decides which jobs CI runs. A silent type error there mis-routes every PR.

#725/#735 already closed the worker half of the original gap with Option 2 (dedicated project + `check:workers`). This PR is the first scripts/** slice of the same option on #734.

## What changed

- New `scripts/ci-routing/tsconfig.json` over `./**/*.ts`, extending `tsconfig.base.json`, run by `bun run check:scripts-ci-routing` and chained into `check` (ci-unit.yml already runs `bun run check` as a whole line; `build` re-enters it).
- Sibling `scripts/ci-routing.test.ts` (one level up) deliberately stays out of the include so the rest of scripts/** is not forced through this gate unfixed.
- Type fixes only:
  - `process.env` / `Record<string, unknown|string>` reads use bracket access (TS4111)
  - `contentHashCacheKey` call site omits optional dimensions instead of passing explicit `undefined` (TS2379 / exactOptionalPropertyTypes)
- Tripwire in `scripts/release-wiring.test.ts` (sibling of the #725 worker assertion): script chained, project extends base, include is `"./**/*.ts"` and does not escape the directory.
- Comments in `content-hash.ts`, `routing.ts`, and root `tsconfig.json` updated so they no longer claim only oxlint covers these slices.

## Out of scope (still on #734)

- Remaining ~157 scripts/** errors outside `scripts/ci-routing/`
- Root `tsc -p tsconfig.json` in `check` (pulls apps/docs under base strictness through the back door + `@types/node` RequestInit/`duplex` collision)
- Closing #734

## Verification

```
$ ./node_modules/.bin/tsc -p scripts/ci-routing --noEmit   # exit 0
$ bun run check                                            # exit 0 (chain incl. check:workers + check:scripts-ci-routing)
$ bun test scripts/release-wiring.test.ts scripts/ci-routing  # 146 pass, 0 fail
$ bun run lint / lint:type-aware / fmt:check               # all clean
```

## Follow-ups

- #734 remains open for the rest of scripts/** (and the apps/docs / RequestInit prerequisites written up there).