### PR TITLE
fix(core): group source-backed candidates by the row's owning table

### DIFF
--- a/.changeset/source-backed-candidates-per-layer-groups.md
+++ b/.changeset/source-backed-candidates-per-layer-groups.md
@@ -1,0 +1,16 @@
+---
+"@ggsvelte/core": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+Fix candidate grouping on all-identity plots where layers carry their own
+`data`. The source-backed strategy derived grouping from the plot's table, so a
+layer with its own columns threw `deriveGroups: unknown field "..."` as soon as
+candidates were resolved — and where it happened not to throw, it indexed a
+plot-length array with a global row id and silently collapsed those rows into
+one group. Grouping is now derived per owning table and indexed locally, the
+same way value reads already were.
+
+Migration: none — a plot that previously threw now renders, and per-layer series
+grouping is correct where it was collapsed.

--- a/packages/core/src/pipeline/build-candidates.ts
+++ b/packages/core/src/pipeline/build-candidates.ts
@@ -26,21 +26,35 @@ import type {
 
 function createRawCandidateDatumResolver(
   bindings: readonly LayerBinding[],
-  table: ColumnTable,
   sources: SourceRegistry,
   color: ResolvedColorScale | null,
   fill: ResolvedColorScale | null,
   lineage: LineageStore<number>,
 ): (facts: CandidateBuildFacts) => CandidateDatum {
-  const groupsByLayer = new Map<number, readonly number[]>();
-  const groupsFor = (layerIndex: number): readonly number[] => {
-    let groups = groupsByLayer.get(layerIndex);
-    if (groups === undefined) {
-      const binding = bindings[layerIndex];
-      groups = binding === undefined ? [] : deriveLayerGroups(binding, table);
-      groupsByLayer.set(layerIndex, groups);
+  // Grouping is derived per (layer, owning table) and indexed by the LOCAL row,
+  // for the same reason `value()` below routes through `sources.locate`: a layer
+  // with its own DataRef (#589) has fields the plot's table does not. Deriving
+  // from the plot table threw `deriveGroups: unknown field "…"` for any such
+  // layer, and — where it happened not to throw — indexed a plot-length array
+  // with a global row id, silently collapsing those rows into one group.
+  const groupsByLayer = new Map<number, WeakMap<ColumnTable, readonly number[]>>();
+  const groupFor = (layerIndex: number, sourceRow: number): number => {
+    const binding = bindings[layerIndex];
+    const located = sources.locate(sourceRow);
+    // Group 0 is the single-group default, which is what a primitive with no
+    // locatable source row (annotations, synthesized marks) should carry.
+    if (binding === undefined || located === null) return 0;
+    let byTable = groupsByLayer.get(layerIndex);
+    if (byTable === undefined) {
+      byTable = new WeakMap<ColumnTable, readonly number[]>();
+      groupsByLayer.set(layerIndex, byTable);
     }
-    return groups;
+    let groups = byTable.get(located.table);
+    if (groups === undefined) {
+      groups = deriveLayerGroups(binding, located.table);
+      byTable.set(located.table, groups);
+    }
+    return groups[located.localRow] ?? 0;
   };
   return (facts) => {
     const binding = bindings[facts.layerIndex];
@@ -55,7 +69,7 @@ function createRawCandidateDatumResolver(
     };
     const styleValue = (style: LayerBinding["size"]): CellValue =>
       style.field === null ? (style.scaledConstant ?? style.constant) : value(style.field);
-    const group = groupsFor(facts.layerIndex)[sourceRow] ?? 0;
+    const group = groupFor(facts.layerIndex, sourceRow);
     const colorRank = ordinalColorRank(color, binding.color.field, () =>
       value(binding.color.field),
     );
@@ -88,22 +102,23 @@ function isAllSourceBacked(bindings: readonly LayerBinding[]): boolean {
   );
 }
 
+// No plot `table` here: every value and every group this strategy resolves is
+// read through `sources`, which owns the per-layer tables.
 function buildSourceBackedCandidates(input: {
   scene: Scene;
   runId: number;
   flip: boolean;
   bindings: readonly LayerBinding[];
-  table: ColumnTable;
   sources: SourceRegistry;
   color: ResolvedColorScale | null;
   fill: ResolvedColorScale | null;
   lineage: LineageStore<number>;
 }): CandidateStore {
-  const { scene, runId, flip, bindings, table, sources, color, fill, lineage } = input;
+  const { scene, runId, flip, bindings, sources, color, fill, lineage } = input;
   return buildCandidateStore(scene, {
     epoch: runId,
     flip,
-    datum: createRawCandidateDatumResolver(bindings, table, sources, color, fill, lineage),
+    datum: createRawCandidateDatumResolver(bindings, sources, color, fill, lineage),
   });
 }
 

--- a/packages/core/tests/candidates-per-layer-data.test.ts
+++ b/packages/core/tests/candidates-per-layer-data.test.ts
@@ -85,3 +85,74 @@ describe("candidates with per-layer data", () => {
     );
   });
 });
+
+/**
+ * The suite above pins the identity-indexed path: its `smooth` layer is a stat,
+ * so `isAllSourceBacked` is false. A plot whose layers are *all* identity takes
+ * the source-backed path instead, and that one derived grouping from the plot's
+ * table rather than the row's owning table — so it threw on the same shape the
+ * suite above proves fixed. `examples/point/layer-data-bands` is exactly this
+ * shape (rect + point + text, every layer with its own data, no plot-level
+ * data), and its docs page threw `deriveGroups: unknown field "x"` during
+ * hydration, leaving the chart permanently unready.
+ */
+describe("source-backed candidates with per-layer data", () => {
+  const grouped = [
+    { x: 10, y: 40, cohort: "a" },
+    { x: 20, y: 44, cohort: "a" },
+    { x: 30, y: 61, cohort: "b" },
+    { x: 40, y: 65, cohort: "b" },
+  ];
+
+  const allIdentitySpec = {
+    layers: [
+      {
+        geom: "rect",
+        data: { values: bands },
+        aes: {
+          x: null,
+          y: null,
+          xmin: { field: "from" },
+          xmax: { field: "to" },
+          ymin: { field: "low" },
+          ymax: { field: "high" },
+          fill: { field: "epoch" },
+        },
+        params: { alpha: 0.5 },
+      },
+      {
+        geom: "point",
+        data: { values: grouped },
+        aes: { x: { field: "x" }, y: { field: "y" }, color: { field: "cohort" } },
+      },
+    ],
+    scales: {
+      fill: { type: "manual", domain: ["early", "late"], range: ["#eee", "#ddd"] },
+    },
+  };
+
+  const model = runPipeline(allIdentitySpec as never, { width: 600, height: 400 });
+  const facts = Array.from({ length: model.candidates.size }, (_, id) =>
+    model.candidates.candidate(id),
+  ).filter((candidate) => candidate !== null);
+
+  it("resolves every candidate when no layer inherits a plot-level table", () => {
+    // Before the fix, reading any candidate threw: grouping looked the rect
+    // layer's `from` and the point layer's `x` up in the (empty) plot table.
+    expect(facts.length).toBe(model.candidates.size);
+    expect(facts.length).toBeGreaterThan(0);
+  });
+
+  it("groups each layer by its own discrete field, not by plot-table row ids", () => {
+    const seriesIdsFor = (layerIndex: number): Set<number> =>
+      new Set(
+        facts
+          .filter((candidate) => candidate.layerIndex === layerIndex)
+          .map((candidate) => candidate.seriesId),
+      );
+    // Two epochs and two cohorts: each layer's rows must split into two groups.
+    // Indexing plot-table groups by a *global* row id collapsed these to one.
+    expect(seriesIdsFor(0).size).toBe(2);
+    expect(seriesIdsFor(1).size).toBe(2);
+  });
+});


### PR DESCRIPTION
## What's wrong

`examples/point/layer-data-bands` renders **nothing** in a browser. Its plot root never reaches `data-gg-ready="true"` because hydration throws:

```
pageerror: deriveGroups: unknown field "x"
```

So the docs page for that example is a blank frame. SSR/prerender pass, which is why no existing gate caught it — candidate construction is client-only, and the docs prerender only validates the spec.

## Root cause

`createRawCandidateDatumResolver` derived layer grouping from the **plot's** table:

```ts
groups = binding === undefined ? [] : deriveLayerGroups(binding, table);
...
const group = groupsFor(facts.layerIndex)[sourceRow] ?? 0;
```

A layer carrying its own `data` (#589) has fields the plot table does not, so `deriveGroups` throws on the first such field. This example has *no* plot-level data at all — every layer brings its own — so every field is unknown.

Where it happened *not* to throw it was still wrong: `groups[sourceRow]` indexes a plot-length array with a row id that is **global across sources**, so per-layer rows fell through `?? 0` and collapsed into a single series.

The `value()` reader immediately below already routed through `sources.locate` for exactly this reason — the #589 follow-up fixed value reads and left grouping behind.

## Fix

Grouping resolves through `sources.locate` and indexes by the **local** row, cached per (layer, owning table). The plot table is no longer passed to this strategy, since every read it makes now goes through the registry.

## Why the existing regression test missed it

`candidates-per-layer-data.test.ts` includes a `smooth` layer specifically to force the identity-indexed path, so `isAllSourceBacked` is false and this code never runs. The new suite pins the all-identity path, and asserts both halves: that candidates resolve at all, and that each layer's rows split into their own groups rather than collapsing to one.

## Verification

- `packages/core`: 1301 pass, 0 fail — the new suite is red before the fix with the exact production stack at `build-candidates.ts:40`, green after
- `bun run check` exit 0, `oxlint --type-aware --deny-warnings` exit 0

Found while regenerating the gallery previews for #656: the capture could not screenshot this example because the page never becomes ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/743" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->