### PR TITLE
fix(#734): give the whole scripts tree a real tsc gate

### DIFF
--- a/apps/docs/build-mode.ts
+++ b/apps/docs/build-mode.ts
@@ -1,4 +1,4 @@
-const DOCS_BUILD_MODES = ["dev", "cloudflare-preview", "cloudflare-production"] as const;
+export const DOCS_BUILD_MODES = ["dev", "cloudflare-preview", "cloudflare-production"] as const;
 
 type DocsBuildMode = (typeof DOCS_BUILD_MODES)[number];
 

--- a/apps/docs/src/lib/code-languages.ts
+++ b/apps/docs/src/lib/code-languages.ts
@@ -31,7 +31,7 @@ const LANGUAGE_MODULES: Record<string, LanguageType<string>> = {
 };
 
 /** Resolve a language name (or empty) to a svelte-highlight language module. */
-export function resolveCodeLanguage(lang: string | undefined): LanguageType<string> {
+export function resolveCodeLanguage(lang?: string): LanguageType<string> {
   if (lang === undefined || lang.trim() === "") return plaintext;
   return LANGUAGE_MODULES[lang.trim().toLowerCase()] ?? plaintext;
 }
@@ -40,7 +40,7 @@ export function resolveCodeLanguage(lang: string | undefined): LanguageType<stri
  * Infer a highlight language from a code-tab label when no explicit language prop is set
  * (e.g. "Builder (TS)", "Spec (JSON)", "Svelte").
  */
-export function languageFromCodeTabLabel(label: string | undefined): string {
+export function languageFromCodeTabLabel(label?: string): string {
   if (label === undefined) return "plaintext";
   const lower = label.toLowerCase();
   if (lower.includes("svelte")) return "svelte";

--- a/apps/docs/src/lib/docs-appearance.ts
+++ b/apps/docs/src/lib/docs-appearance.ts
@@ -15,7 +15,7 @@ export type DocsAppearanceStorage = {
 export function readDocsAppearance(
   root: { dataset: DOMStringMap } = document.documentElement,
 ): DocsAppearance {
-  return root.dataset.theme === "dark" ? "dark" : "light";
+  return root.dataset["theme"] === "dark" ? "dark" : "light";
 }
 
 export function toggleDocsAppearance(current: DocsAppearance): DocsAppearance {
@@ -44,7 +44,7 @@ export function writeDocsAppearance(
   root: { dataset: DOMStringMap } = document.documentElement,
   storage?: DocsAppearanceStorage | null,
 ): void {
-  root.dataset.theme = appearance;
+  root.dataset["theme"] = appearance;
   const store = resolveDocsAppearanceStorage(storage);
   if (store === null) return;
   try {

--- a/apps/docs/src/lib/guide-code-copy.ts
+++ b/apps/docs/src/lib/guide-code-copy.ts
@@ -119,7 +119,7 @@ export function createGuideCodeCopyAttachment(
       }
       const button = (target as Element).closest<HTMLButtonElement>("button[data-copy-code]");
       if (button === null || !node.contains(button)) return;
-      const codeId = button.dataset.copyCode;
+      const codeId = button.dataset["copyCode"];
       if (codeId === undefined) return;
       const doc = node.ownerDocument;
       const block = doc.querySelector(`#${cssEscapeIdent(codeId)}`);

--- a/apps/docs/src/lib/playground-agent-client.ts
+++ b/apps/docs/src/lib/playground-agent-client.ts
@@ -39,10 +39,19 @@ export type GenerateChartResult =
       readonly retryAfterSeconds?: number;
     };
 
+/**
+ * The transport seam generateChart actually uses: one call, one Response.
+ * Narrower than `typeof fetch` on purpose — that type also carries the static
+ * `preconnect` member, which nothing here calls but which every injected stub
+ * would otherwise have to reproduce to typecheck. The global `fetch` still
+ * satisfies this.
+ */
+export type GenerateChartFetch = (input: string, init?: RequestInit) => Promise<Response>;
+
 export interface GenerateChartOptions {
   readonly apiUrl?: string;
   readonly mode?: "live" | "mock";
-  readonly fetchFn?: typeof fetch;
+  readonly fetchFn?: GenerateChartFetch;
   readonly signal?: AbortSignal;
 }
 
@@ -248,13 +257,13 @@ export async function generateChart(
     };
   }
 
-  const code = mapApiErrorCode(error.code);
+  const code = mapApiErrorCode(error["code"]);
   const retryAfter =
-    typeof error.retryAfterSeconds === "number" ? error.retryAfterSeconds : undefined;
+    typeof error["retryAfterSeconds"] === "number" ? error["retryAfterSeconds"] : undefined;
   return {
     ok: false,
     code,
-    message: typeof error.message === "string" ? error.message : messageForAgentError(code),
+    message: typeof error["message"] === "string" ? error["message"] : messageForAgentError(code),
     ...(retryAfter === undefined ? {} : { retryAfterSeconds: retryAfter }),
   };
 }

--- a/apps/docs/src/lib/playground-agent-envelope.ts
+++ b/apps/docs/src/lib/playground-agent-envelope.ts
@@ -43,30 +43,30 @@ export function defaultPlaygroundInteractions(): PlaygroundInteractions {
  * - zoom is mutually exclusive with interval select (both use brush)
  * - legendFilter / legendFocus only when discrete legend is present (caller gates UI)
  */
-export function normalizePlaygroundInteractions(raw: unknown): PlaygroundInteractions {
+export function normalizePlaygroundInteractions(raw?: unknown): PlaygroundInteractions {
   const defaults = defaultPlaygroundInteractions();
   if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
     return defaults;
   }
   const input = raw as Record<string, unknown>;
 
-  const inspect = input.inspect !== false;
+  const inspect = input["inspect"] !== false;
 
   let select: false | "point" | "interval" = false;
-  if (input.select === "point" || input.select === "interval") {
-    select = input.select;
-  } else if (input.select === true) {
+  if (input["select"] === "point" || input["select"] === "interval") {
+    select = input["select"];
+  } else if (input["select"] === true) {
     select = "point";
   }
 
-  let zoom = input.zoom === true;
+  let zoom = input["zoom"] === true;
   // Interval select and zoom both use brush — interval wins.
   if (select === "interval" && zoom) {
     zoom = false;
   }
 
-  const legendFilter = input.legendFilter === true;
-  const legendFocus = input.legendFocus === true;
+  const legendFilter = input["legendFilter"] === true;
+  const legendFocus = input["legendFocus"] === true;
 
   return { inspect, select, zoom, legendFilter, legendFocus };
 }
@@ -115,7 +115,7 @@ export function parsePlaygroundAgentEnvelope(input: unknown): ParseEnvelopeResul
   }
 
   const record = value as Record<string, unknown>;
-  if (!("spec" in record) || record.spec === undefined) {
+  if (!("spec" in record) || record["spec"] === undefined) {
     // Allow bare PortableSpec as a lenient fallback only when it looks like one.
     if ("layers" in record && "data" in record) {
       return {
@@ -133,9 +133,9 @@ export function parsePlaygroundAgentEnvelope(input: unknown): ParseEnvelopeResul
   return {
     ok: true,
     envelope: {
-      spec: record.spec,
-      interactions: normalizePlaygroundInteractions(record.interactions),
-      title: normalizeTitle(record.title),
+      spec: record["spec"],
+      interactions: normalizePlaygroundInteractions(record["interactions"]),
+      title: normalizeTitle(record["title"]),
     },
   };
 }
@@ -158,8 +158,8 @@ const DISCRETE_COLOR_FAMILIES: ReadonlySet<string> = new Set(["ordinal", "manual
 function colorChannelField(aes: unknown, channel: ColorChannel): string | null {
   if (!isRecord(aes)) return null;
   const mapping = aes[channel];
-  if (isRecord(mapping) && typeof mapping.field === "string" && mapping.field !== "") {
-    return mapping.field;
+  if (isRecord(mapping) && typeof mapping["field"] === "string" && mapping["field"] !== "") {
+    return mapping["field"];
   }
   if (typeof mapping === "string" && mapping !== "") return mapping;
   return null;
@@ -168,7 +168,7 @@ function colorChannelField(aes: unknown, channel: ColorChannel): string | null {
 /** One column's cells from inline rows or inline columns; null when absent. */
 function columnValues(data: unknown, field: string): CellValue[] | null {
   if (!isRecord(data)) return null;
-  const rows = data.values;
+  const rows = data["values"];
   if (Array.isArray(rows)) {
     const column: CellValue[] = [];
     for (const row of rows) {
@@ -176,7 +176,7 @@ function columnValues(data: unknown, field: string): CellValue[] | null {
     }
     return column.length > 0 ? column : null;
   }
-  const columns = data.columns;
+  const columns = data["columns"];
   if (isRecord(columns) && Array.isArray(columns[field])) {
     const column = columns[field] as CellValue[];
     return column.length > 0 ? column : null;
@@ -198,12 +198,12 @@ function channelDrawsDiscreteLegend(
   const field = colorChannelField(aes, channel);
   if (field === null) return false;
 
-  const scales = spec.scales;
+  const scales = spec["scales"];
   const config = isRecord(scales) ? scales[channel === "colour" ? "color" : channel] : undefined;
   const family = configuredColorScaleType(isRecord(config) ? config : undefined);
   if (family !== undefined) return DISCRETE_COLOR_FAMILIES.has(family);
 
-  const column = columnValues(layerData, field) ?? columnValues(spec.data, field);
+  const column = columnValues(layerData, field) ?? columnValues(spec["data"], field);
   // Named or absent data: the runtime may still draw a keyed legend, so keep
   // the affordance rather than silently dropping it.
   if (column === null) return true;
@@ -218,14 +218,16 @@ function channelDrawsDiscreteLegend(
 export function chartHasDiscreteLegend(spec: unknown): boolean {
   if (!isRecord(spec)) return false;
   for (const channel of COLOR_CHANNELS) {
-    if (channelDrawsDiscreteLegend(spec, spec.data, spec.aes, channel)) return true;
+    if (channelDrawsDiscreteLegend(spec, spec["data"], spec["aes"], channel)) return true;
   }
-  const layers = spec.layers;
+  const layers = spec["layers"];
   if (Array.isArray(layers)) {
     for (const layer of layers) {
       if (!isRecord(layer)) continue;
       for (const channel of COLOR_CHANNELS) {
-        if (channelDrawsDiscreteLegend(spec, layer.data ?? spec.data, layer.aes, channel)) {
+        if (
+          channelDrawsDiscreteLegend(spec, layer["data"] ?? spec["data"], layer["aes"], channel)
+        ) {
           return true;
         }
       }

--- a/package.json
+++ b/package.json
@@ -10,9 +10,10 @@
   ],
   "type": "module",
   "scripts": {
-    "check": "tsc -b packages/spec packages/core && bun run check:type-contracts && bun run check:workers && bun run check:scripts-ci-routing",
+    "check": "tsc -b packages/spec packages/core && bun run check:type-contracts && bun run check:workers && bun run check:scripts-ci-routing && bun run check:scripts",
     "check:workers": "bun node_modules/.bin/tsc -p workers/playground-api --noEmit",
     "check:scripts-ci-routing": "bun node_modules/.bin/tsc -p scripts/ci-routing --noEmit",
+    "check:scripts": "bun node_modules/.bin/tsc -p scripts --noEmit",
     "check:type-contracts": "tsc -p packages/spec/type-tests/tsconfig.json",
     "check:svelte": "cd packages/svelte && bun run --bun check",
     "check:examples": "bun node_modules/.bin/tsc -p examples --noEmit",

--- a/scripts/actionlint.ts
+++ b/scripts/actionlint.ts
@@ -28,7 +28,7 @@ const ACTIONLINT_YAML = ".github/actionlint.yaml";
  * `CI=true` and `GITHUB_ACTIONS=true`; local manual runs have neither.
  */
 export function allowSoftSkipLoadFailure(env: NodeJS.ProcessEnv = process.env): boolean {
-  return env.CI !== "true" && env.GITHUB_ACTIONS !== "true";
+  return env["CI"] !== "true" && env["GITHUB_ACTIONS"] !== "true";
 }
 
 /**

--- a/scripts/capture-gallery-lights.ts
+++ b/scripts/capture-gallery-lights.ts
@@ -34,7 +34,7 @@ const targets =
 async function settle(page: Page): Promise<void> {
   await page.emulateMedia({ colorScheme: "light", reducedMotion: "reduce" });
   await page.evaluate(async () => {
-    document.documentElement.dataset.visualTest = "";
+    document.documentElement.dataset["visualTest"] = "";
     await document.fonts.ready;
     await new Promise<void>((resolveFrame) => {
       requestAnimationFrame(() => {

--- a/scripts/changeset-check.ts
+++ b/scripts/changeset-check.ts
@@ -137,7 +137,7 @@ async function runEmitCli(args: string[]): Promise<void> {
   const decision = decideChangesetComment(files, discoverPublishedPackages(process.cwd()));
   writeFileSync(bodyOut, renderComment(decision));
   const outputs = `verdict=${decision.verdict}\n`;
-  const githubOutput = process.env.GITHUB_OUTPUT;
+  const githubOutput = process.env["GITHUB_OUTPUT"];
   if (typeof githubOutput === "string" && githubOutput.length > 0) {
     appendFileSync(githubOutput, outputs);
   }

--- a/scripts/ci-routing.test.ts
+++ b/scripts/ci-routing.test.ts
@@ -956,7 +956,10 @@ async function spawnCiRoutingCli(
 }> {
   const proc = Bun.spawn(["bun", "scripts/ci-routing.ts", ...args], {
     cwd: join(import.meta.dir, ".."),
-    env: env === undefined ? undefined : { ...process.env, ...env },
+    // Omit the key entirely when there is no override — `env: undefined` means
+    // "an env I am declining to describe" to SpawnOptions under
+    // exactOptionalPropertyTypes, not "inherit the parent's".
+    ...(env === undefined ? {} : { env: { ...process.env, ...env } }),
     stdout: "pipe",
     stderr: "pipe",
   });
@@ -1047,8 +1050,8 @@ describe("ci-routing module tree (split-safe)", () => {
     const plan = await spawnCiRoutingCli(["plan", "--force-all"]);
     expect(plan.exitCode).toBe(0);
     const planJson = JSON.parse(plan.stdout) as Record<string, boolean>;
-    expect(planJson.unit).toBe(true);
-    expect(planJson.pages).toBe(true);
+    expect(planJson["unit"]).toBe(true);
+    expect(planJson["pages"]).toBe(true);
 
     const emit = Bun.spawn(["bun", "scripts/ci-routing.ts", "emit-github-output", "--stdin"], {
       cwd: join(import.meta.dir, ".."),

--- a/scripts/ci-routing/tsconfig.json
+++ b/scripts/ci-routing/tsconfig.json
@@ -6,14 +6,14 @@
   // errors slipped through unseen. Run by `bun run check:scripts-ci-routing`
   // (chained into `check`), mirroring the worker gate from #725.
   //
-  // ci-routing is the first slice to be pulled in because it decides what CI
+  // ci-routing was the first slice to be pulled in because it decides what CI
   // runs: a type error here silently mis-routes every job on every PR. The rest
-  // of scripts/** still carries unchecked errors and stays on #734.
+  // of scripts/** followed in #734 and is now covered by scripts/tsconfig.json
+  // (check:scripts), which includes this directory as well.
   //
-  // Scoped to this directory only, and deliberately not to scripts/**: the
-  // sibling scripts/ci-routing.test.ts (the public re-export suite one level
-  // up) is outside the include, so widening this to the parent would drag in
-  // the unfixed remainder and fail `check` on code no one has held to tsc yet.
+  // This narrower project is kept rather than folded into that one: it fails on
+  // routing alone, without the tree's other 120-odd files in the program, so the
+  // gate that decides what CI runs stays legible and independently runnable.
   //
   // "types": ["bun"] matches how these scripts actually run — `bun scripts/…`,
   // with Bun.spawn and bun:test in the suites.

--- a/scripts/community-forms.test.ts
+++ b/scripts/community-forms.test.ts
@@ -43,7 +43,12 @@ function validateForm(path: string, issue: boolean): void {
   const ids = form.body!.flatMap((field) => (field.id === undefined ? [] : [field.id]));
   expect(new Set(ids).size, `${path} has duplicate field ids`).toBe(ids.length);
   for (const field of form.body!) {
-    expect(["markdown", "textarea", "input", "dropdown", "checkboxes"], path).toContain(field.type);
+    // `type` is optional on FormField because the YAML may omit it; GitHub
+    // rejects such a form outright, so say that here rather than letting
+    // toContain(undefined) report it as an unrecognised type.
+    const { type } = field;
+    if (type === undefined) throw new Error(`${path}: form field is missing "type"`);
+    expect(["markdown", "textarea", "input", "dropdown", "checkboxes"], path).toContain(type);
     expect(field.attributes, path).toBeObject();
     if (field.type !== "markdown") expect(field.id, path).toMatch(/^[a-z0-9_-]+$/);
     if (field.type === "dropdown") {

--- a/scripts/consumer-compat.ts
+++ b/scripts/consumer-compat.ts
@@ -52,10 +52,10 @@ export function resolveConsumerOptions(
   environment: Record<string, string | undefined>,
 ) {
   return {
-    packageManager: (args[0] ?? environment.PACKAGE_MANAGER ?? "npm") as PackageManager,
+    packageManager: (args[0] ?? environment["PACKAGE_MANAGER"] ?? "npm") as PackageManager,
     // Single-sourced from support-matrix.json — the floor lives in one place.
-    svelteVersion: args[1] ?? environment.SVELTE_VERSION ?? loadSupportMatrix().svelte.minimum,
-    packageManagerVersion: args[2] ?? environment.PACKAGE_MANAGER_VERSION,
+    svelteVersion: args[1] ?? environment["SVELTE_VERSION"] ?? loadSupportMatrix().svelte.minimum,
+    packageManagerVersion: args[2] ?? environment["PACKAGE_MANAGER_VERSION"],
   };
 }
 

--- a/scripts/deployment-asset-smoke.ts
+++ b/scripts/deployment-asset-smoke.ts
@@ -69,14 +69,12 @@ export async function smokeImmutableAssets(input: {
 }): Promise<AssetSmokeProblem[]> {
   const origin = new URL(input.baseUrl).origin;
   const timeoutMs = input.timeoutMs ?? ASSET_SMOKE_FETCH_TIMEOUT_MS;
-  const fetchImpl: FetchLike =
-    input.fetchImpl ??
-    ((url, init) =>
-      fetch(url, {
-        redirect: init?.redirect,
-        headers: init?.headers,
-        signal: init?.signal,
-      }));
+  // Forward init as-is. Re-listing the fields set each one to an explicit
+  // `undefined` when the caller omitted it, which is not the same request as
+  // omitting the key — `headers: undefined` is not a valid RequestInit under
+  // exactOptionalPropertyTypes, and FetchLike's init is already a structural
+  // subset of RequestInit.
+  const fetchImpl: FetchLike = input.fetchImpl ?? ((url, init) => fetch(url, init));
   const problems: AssetSmokeProblem[] = [];
 
   for (const path of input.paths) {

--- a/scripts/deprecation-catalog-anchors.test.ts
+++ b/scripts/deprecation-catalog-anchors.test.ts
@@ -45,7 +45,7 @@ describe("diagnostic catalog runtime docUrl anchors", () => {
       expect(url).toStartWith(GUIDE_URL_BASE);
       const [slug = "", fragment] = url.slice(GUIDE_URL_BASE.length).split("#");
       expect([...anchors.keys()], `unknown guide page "${slug}"`).toContain(slug);
-      expect(fragment, `${url}: missing fragment`).toBeDefined();
+      if (fragment === undefined) throw new Error(`${url}: missing fragment`);
       expect(
         [...(anchors.get(slug) ?? [])],
         `${url}: anchor #${fragment} missing from guide/${slug}`,

--- a/scripts/docs-appearance.test.ts
+++ b/scripts/docs-appearance.test.ts
@@ -11,7 +11,7 @@ import {
 
 function root(theme?: string): { dataset: DOMStringMap } {
   const dataset: DOMStringMap = {};
-  if (theme !== undefined) dataset.theme = theme;
+  if (theme !== undefined) dataset["theme"] = theme;
   return { dataset };
 }
 
@@ -53,7 +53,7 @@ describe("docs appearance", () => {
     const el = root("light");
     const storage = memoryStorage();
     writeDocsAppearance("dark", el, storage);
-    expect(el.dataset.theme).toBe("dark");
+    expect(el.dataset["theme"]).toBe("dark");
     expect(storage.store[DOCS_THEME_STORAGE_KEY]).toBe("dark");
   });
 
@@ -61,19 +61,19 @@ describe("docs appearance", () => {
     const el = root("light");
     const storage = memoryStorage({}, { throwOnSet: true });
     writeDocsAppearance("dark", el, storage);
-    expect(el.dataset.theme).toBe("dark");
+    expect(el.dataset["theme"]).toBe("dark");
   });
 
   test("write with null storage only mutates dataset", () => {
     const el = root("dark");
     writeDocsAppearance("light", el, null);
-    expect(el.dataset.theme).toBe("light");
+    expect(el.dataset["theme"]).toBe("light");
   });
 
   test("write with two args uses the lazy default storage resolver", () => {
     const el = root("light");
     writeDocsAppearance("dark", el);
-    expect(el.dataset.theme).toBe("dark");
+    expect(el.dataset["theme"]).toBe("dark");
   });
 });
 
@@ -86,12 +86,12 @@ describe("watchDocsAppearance", () => {
       return;
     }
     const el = document.createElement("div");
-    el.dataset.theme = "light";
+    el.dataset["theme"] = "light";
     const seen: string[] = [];
     const stop = watchDocsAppearance((appearance) => {
       seen.push(appearance);
     }, el);
-    el.dataset.theme = "dark";
+    el.dataset["theme"] = "dark";
     // MutationObserver is async; force a microtask flush is not always enough.
     // At least destroy must be callable.
     stop();

--- a/scripts/docs-csp.test.ts
+++ b/scripts/docs-csp.test.ts
@@ -3,18 +3,22 @@ import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import { DOCS_BUILD_MODES } from "../apps/docs/build-mode";
 import { docsCspDirectives } from "../apps/docs/csp";
 import { validateDocsCsp, validateHtmlCsp } from "./docs-csp";
 
 describe("docs CSP validation", () => {
+  // Driven off DOCS_BUILD_MODES rather than a literal list: the previous list
+  // still named "legacy-full" and "legacy-migration", which resolveDocsBuildConfig
+  // has rejected since the GitHub Pages modes were dropped. Those two iterations
+  // passed on nothing — docsCspDirectives only branches on `mode === "dev"`, so
+  // any unrecognised string satisfies the assertion. Deriving the list means a
+  // new mode fails here until its CSP behaviour is decided.
   it("upgrades insecure requests only for HTTPS publication modes", () => {
     expect(docsCspDirectives("dev")).not.toHaveProperty("upgrade-insecure-requests");
-    for (const mode of [
-      "legacy-full",
-      "cloudflare-preview",
-      "cloudflare-production",
-      "legacy-migration",
-    ] as const) {
+    const httpsModes = DOCS_BUILD_MODES.filter((mode) => mode !== "dev");
+    expect(httpsModes).toEqual(["cloudflare-preview", "cloudflare-production"]);
+    for (const mode of httpsModes) {
       expect(docsCspDirectives(mode)).toHaveProperty("upgrade-insecure-requests", true);
     }
   });

--- a/scripts/docs-tasks.test.ts
+++ b/scripts/docs-tasks.test.ts
@@ -2,17 +2,24 @@ import { describe, expect, it } from "bun:test";
 
 import { DOCS_TASKS } from "../apps/docs/src/lib/catalog/docs-tasks.ts";
 
-const expected = [
+// Typed wide rather than `as const`: DOCS_TASKS is a const-asserted literal, so
+// an `as const` expectation compares two readonly tuple types and toEqual has no
+// overload for that. The assertion is a runtime deep-equal either way.
+const expected: [string, readonly string[]][] = [
   ["Getting started", ["/guide/getting-started"]],
   ["Scales, themes, color", ["/guide/scales-guides", "/guide/themes-color"]],
   ["Interaction", ["/guide/inspect-pin"]],
   ["Layout and export", ["/guide/responsive-charts", "/guide/server-rendering-export"]],
   ["Diagnostics", ["/guide/errors"]],
-] as const;
+];
 
 describe("Docs entry points", () => {
   it("keeps the approved labels and ordered destinations literal", () => {
-    expect(DOCS_TASKS.map((task) => [task.label, task.hrefs])).toEqual(expected);
+    const published: [string, readonly string[]][] = DOCS_TASKS.map((task) => [
+      task.label,
+      task.hrefs,
+    ]);
+    expect(published).toEqual(expected);
   });
 
   it("gives every task a concrete destination description", () => {

--- a/scripts/gen-docs-search.ts
+++ b/scripts/gen-docs-search.ts
@@ -157,7 +157,10 @@ export function validateDocsSearchEntries<Entry extends DocsSearchEntry>(
       .filter((route) => route.index && route.kind === "page")
       .map((route) => [route.path, route] as const),
   );
-  const cliAnchors = new Set(CLI_REFERENCE_OPTIONS.map((option) => option.anchor));
+  // Set<string>, not the inferred union of the known anchors: this is looked up
+  // with anchors parsed out of arbitrary hrefs, and Set.has on a literal-union
+  // set rejects the very inputs the check exists to reject.
+  const cliAnchors = new Set<string>(CLI_REFERENCE_OPTIONS.map((option) => option.anchor));
   const ids = new Set<string>();
   const hrefTitles = new Set<string>();
   for (const entry of entries) {

--- a/scripts/gen-scale-children.test.ts
+++ b/scripts/gen-scale-children.test.ts
@@ -69,15 +69,17 @@ describe("SHELL_MANIFEST completeness", () => {
     expect(byFamily.get("color-fill")).toBe(18);
     expect(byFamily.get("numeric-style")).toBe(21);
     expect(byFamily.get("finite-style")).toBe(8);
-    // Families in the ledger match.
-    const ledgerFamilies = new Set(SCALE_CAPABILITIES.map((c) => c.family));
+    // Families in the ledger match. Set<string>, not the inferred literal union:
+    // ShellSpec.family is a plain string, and whether it names a real family is
+    // the thing under test — a narrower set would reject the input instead.
+    const ledgerFamilies = new Set<string>(SCALE_CAPABILITIES.map((c) => c.family));
     for (const family of byFamily.keys()) {
       expect(ledgerFamilies.has(family), `unknown family ${family}`).toBe(true);
     }
   });
 
   it("every family matches a SCALE_CAPABILITIES family string", () => {
-    const ledger = new Set(SCALE_CAPABILITIES.map((c) => c.family));
+    const ledger = new Set<string>(SCALE_CAPABILITIES.map((c) => c.family));
     for (const s of SHELL_MANIFEST) {
       expect(ledger.has(s.family), `${s.helper} family ${s.family}`).toBe(true);
     }

--- a/scripts/getting-started-headings.test.ts
+++ b/scripts/getting-started-headings.test.ts
@@ -51,7 +51,11 @@ describe("getting-started page navigation", () => {
 
   it("is what the generated route publishes", () => {
     const route = DOCS_ROUTES.find((entry) => entry.path === "/guide/getting-started");
-    expect(route?.headings).toEqual(
+    // Widened off the generated literal tuple: DOCS_ROUTES is const-asserted, so
+    // matching it exactly would demand a 14-element tuple on the expected side.
+    const published: readonly { id: string; title: string; level: number }[] | undefined =
+      route?.headings;
+    expect(published).toEqual(
       GETTING_STARTED_PAGE_HEADINGS.map(({ id, title, level }) => ({ id, title, level })),
     );
   });

--- a/scripts/guide-code-contract.test.ts
+++ b/scripts/guide-code-contract.test.ts
@@ -28,7 +28,14 @@ describe("guide code truth contract", () => {
         assertGuideCodeContract(page.markdown, page.slug);
       }).not.toThrow();
       for (const block of codeBlocks(page.markdown)) {
-        expect(["complete", "fragment"]).toContain(block.classification);
+        // Optional on CodeBlock — a fence carrying no complete/fragment flag is
+        // exactly the failure this asserts, and saying so beats toContain
+        // reporting undefined as a bad classification.
+        const { classification } = block;
+        if (classification === undefined) {
+          throw new Error(`${page.slug}: guide fence has no complete/fragment classification`);
+        }
+        expect(["complete", "fragment"]).toContain(classification);
       }
     }
   });

--- a/scripts/playground-codec.test.ts
+++ b/scripts/playground-codec.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 
-import type { PortableSpec } from "@ggsvelte/spec";
+import type { InlineData, PortableSpec } from "@ggsvelte/spec";
+
+import type { PlaygroundCodecErrorCode } from "../apps/docs/src/lib/playground-codec-contract";
 
 import {
   assertPlaygroundDraftSize,
@@ -35,7 +37,9 @@ const seed = (nextSpec: PortableSpec = spec): PlaygroundSeedV1 => ({
   spec: nextSpec,
 });
 
-function expectCode(hash: string, code: string): void {
+// Typed to the wire union, not string: a caller naming a code the codec cannot
+// emit is a stale test, and this is where that shows up.
+function expectCode(hash: string, code: PlaygroundCodecErrorCode): void {
   const result = decodePlaygroundHash(hash);
   expect(result.status).toBe("error");
   if (result.status === "error") expect(result.error.code).toBe(code);
@@ -159,13 +163,15 @@ describe("playground fragment codec", () => {
     Object.defineProperty(unsafeRow, "__proto__", { value: 1, enumerable: true });
     expectCode(rawHash(seed({ ...spec, data: { values: [unsafeRow] } })), "UNSAFE_FIELD");
 
-    const unsafeColumns: Record<string, readonly (string | number | boolean | null)[]> = {
+    const unsafeColumns: Record<string, (string | number | boolean | null)[]> = {
       value: [2],
     };
     Object.defineProperty(unsafeColumns, "constructor", { value: [1], enumerable: true });
     expectCode(rawHash(seed({ ...spec, data: { columns: unsafeColumns } })), "UNSAFE_FIELD");
 
-    const datasets = Object.create(null) as Record<string, PortableSpec["data"]>;
+    // Record<string, InlineData>, matching PortableSpec.datasets. PortableSpec["data"]
+    // also admits DataRef and undefined, neither of which a datasets entry may be.
+    const datasets = Object.create(null) as Record<string, InlineData>;
     datasets["__proto__"] = { values: [{ value: 2 }] };
     expectCode(rawHash(seed({ ...spec, data: { name: "__proto__" }, datasets })), "UNSAFE_FIELD");
   });

--- a/scripts/playground-events.test.ts
+++ b/scripts/playground-events.test.ts
@@ -14,7 +14,12 @@ function inspectEvent(key: PropertyKey, phase: "change" | "clear" = "change") {
       source: "keyboard",
     } as const satisfies PlaygroundInteractionEvent;
   }
-  return {
+  // Bound to a const before the `satisfies`, deliberately. PlaygroundInteractionEvent
+  // is the minimal structural shape (type/phase/source) and callers hand it whole
+  // interaction events — carrying that payload into `json` is what this fixture
+  // exists to prove. Applying `satisfies` to the fresh literal instead invokes
+  // excess-property checking, which rejects every field past the required three.
+  const changeEvent = {
     type: "inspect",
     phase,
     state: "transient",
@@ -43,7 +48,8 @@ function inspectEvent(key: PropertyKey, phase: "change" | "clear" = "change") {
         anchor: { x: 10, y: 20 },
       },
     ],
-  } as const satisfies PlaygroundInteractionEvent;
+  } as const;
+  return changeEvent satisfies PlaygroundInteractionEvent;
 }
 
 describe("playground semantic event log", () => {

--- a/scripts/progressive-docs.test.ts
+++ b/scripts/progressive-docs.test.ts
@@ -87,11 +87,11 @@ describe("progressive Docs journey", () => {
   it("keeps every lesson anchor and title aligned with generated route headings", () => {
     const stepIds: ReadonlySet<string> = new Set(SAKURA_STEPS.map((step) => step.id));
     const route = DOCS_ROUTES.find((entry) => entry.path === "/guide/getting-started");
-    expect(
-      route?.headings
-        ?.filter((heading) => stepIds.has(heading.id))
-        .map(({ id, title }) => ({ id, title })),
-    ).toEqual(SAKURA_STEPS.map(({ id, title }) => ({ id, title })));
+    // Widened off the generated literal union — see getting-started-headings.
+    const stepHeadings: { id: string; title: string }[] | undefined = route?.headings
+      ?.filter((heading) => stepIds.has(heading.id))
+      .map(({ id, title }) => ({ id, title }));
+    expect(stepHeadings).toEqual(SAKURA_STEPS.map(({ id, title }) => ({ id, title })));
   });
 
   it("keeps the human lesson out of the agent surface", () => {

--- a/scripts/readme-showcase.test.ts
+++ b/scripts/readme-showcase.test.ts
@@ -14,10 +14,27 @@ interface ReadmeExample {
   readonly source: string;
 }
 
+/**
+ * Both capture groups are mandatory in the pattern, so a match always carries
+ * them — but only at runtime. Assert it rather than coercing: a group that came
+ * back undefined would otherwise flow into `join(root, "examples", id, …)` and
+ * surface as an unrelated ENOENT several assertions later.
+ */
+function bothCaptures(match: RegExpExecArray): readonly [string, string] {
+  const [, first, second] = match;
+  if (first === undefined || second === undefined) {
+    throw new Error(`Malformed README.md block, expected two captures: ${match[0]}`);
+  }
+  return [first, second];
+}
+
 function readmeExamples(): readonly ReadmeExample[] {
   return [
     ...readme.matchAll(/<!-- example-source: ([^ ]+) -->\n\n```svelte\n([\s\S]*?)\n```/g),
-  ].map(([, id, source]) => ({ id, source }));
+  ].map((match) => {
+    const [id, source] = bothCaptures(match);
+    return { id, source };
+  });
 }
 
 function linkedPreviews(): ReadonlyMap<string, string> {
@@ -26,7 +43,10 @@ function linkedPreviews(): ReadonlyMap<string, string> {
       ...readme.matchAll(
         /\[!\[[^\]]+\]\((apps\/docs\/static\/previews\/[^)]+)\)\]\(https:\/\/ggsvelte\.sh\/examples\/([^)]+)\)/g,
       ),
-    ].map(([, path, id]) => [id, path]),
+    ].map((match) => {
+      const [path, id] = bothCaptures(match);
+      return [id, path] as const;
+    }),
   );
 }
 
@@ -41,7 +61,12 @@ describe("README visual showcase", () => {
     expect(categories.size).toBeGreaterThanOrEqual(8);
     expect([...previews.keys()].toSorted()).toEqual(examples.map(({ id }) => id).toSorted());
 
-    const generatedById = new Map(GALLERY_PREVIEWS.map((preview) => [preview.id, preview]));
+    // Keyed by string, not by the generated literal union: the lookup key comes
+    // out of the README, and "this id has no generated preview" is the failure
+    // this loop is here to report.
+    const generatedById = new Map<string, (typeof GALLERY_PREVIEWS)[number]>(
+      GALLERY_PREVIEWS.map((preview) => [preview.id, preview]),
+    );
     for (const [id, path] of previews) {
       const generated = generatedById.get(id);
       expect(generated, `${id} must have a generated gallery preview`).toBeDefined();

--- a/scripts/release-wiring.test.ts
+++ b/scripts/release-wiring.test.ts
@@ -79,7 +79,7 @@ describe("R0 release wiring", () => {
     // The root `test` script is the canonical suite list. Anything present there
     // but absent from ci-unit.yml is a local-only suite that merges green.
     const pkg = JSON.parse(read("package.json")) as { scripts: Record<string, string> };
-    const rootSuites = suiteArgs(pkg.scripts.test ?? "");
+    const rootSuites = suiteArgs(pkg.scripts["test"] ?? "");
     expect(rootSuites).toContain("workers/playground-api");
 
     // Folded (`run: >`) scalar — collapse whitespace, then take the single
@@ -152,11 +152,53 @@ describe("R0 release wiring", () => {
     // Every .ts in the directory, tests included: the suites are where the
     // module's contracts are asserted, so leaving them out would half-check it.
     expect(include, "tsconfig includes the directory's .ts files").toContain('"./**/*.ts"');
-    // Scoped to this directory only. The rest of scripts/** (and apps/**) still
-    // carries unchecked errors tracked on #734; widening the include here would
-    // fail `check` on code this PR never fixed.
+    // Scoped to this directory only, so the routing gate keeps failing on its own
+    // terms — scripts/tsconfig.json now covers this code as well, and a narrow
+    // project that cannot be skipped past is the point of keeping both.
     expect(include, "include stays inside scripts/ci-routing").not.toContain("..");
     expect(include).not.toContain("apps/");
+  });
+
+  it("typechecks the whole scripts tree inside `bun run check` (issue #734)", () => {
+    // Closes the gap #725 and #737 each took a slice of: scripts/** sat in the
+    // root tsconfig.json only so oxlint --type-aware had type information, and
+    // tsc was never run on it. Type-aware lint rules are a strict subset of tsc
+    // diagnostics, so 103 assignability, optionality and index-signature errors
+    // stood unseen — including a null-deref in the sakura G1 render assertion
+    // and two CSP assertions naming build modes that were deleted.
+    const pkg = JSON.parse(read("package.json")) as { scripts: Record<string, string> };
+    // Right-boundary anchored throughout: "check:scripts" is a prefix of the
+    // sibling "check:scripts-ci-routing", so a plain toContain passes on the
+    // routing gate alone and this whole assertion goes vacuous.
+    expect(pkg.scripts["check:scripts"]).toMatch(/tsc -p scripts(?![\w./-])/u);
+    // Chained into `check`, which ci-unit.yml runs and `build` re-enters.
+    expect(pkg.scripts["check"]).toMatch(/bun run check:scripts(?![\w:-])/u);
+    // Whole-line: `bun run check:pages-links` &c must not satisfy this.
+    expect(read(".github/workflows/ci-unit.yml")).toMatch(/^\s*run: bun run check$/mu);
+
+    const project = read("scripts/tsconfig.json");
+    // Base strictness is the point — the gate is worthless under looser options,
+    // and relaxing them for this tree was the option #734 rejected.
+    expect(project).toContain('"extends"');
+    expect(project).toContain("tsconfig.base.json");
+    // compilerOptions only — the surrounding comment names these flags to explain
+    // why they are inherited, and prose must not satisfy or fail the assertion.
+    const options = /"compilerOptions"\s*:\s*\{[^}]*\}/u.exec(project)?.[0] ?? "";
+    expect(options, "scripts/tsconfig.json declares compilerOptions").not.toBe("");
+    for (const relaxed of [
+      "noPropertyAccessFromIndexSignature",
+      "exactOptionalPropertyTypes",
+      "noUncheckedIndexedAccess",
+      "strict",
+    ]) {
+      expect(options, `scripts/tsconfig.json must not re-open ${relaxed}`).not.toContain(relaxed);
+    }
+    // Assert on the include list, not the whole file — `extends` legitimately
+    // escapes upwards to the repo root.
+    const include = /"include"\s*:\s*\[[^\]]*\]/u.exec(project)?.[0] ?? "";
+    // The whole tree, tests included: the suites are where these scripts'
+    // contracts are asserted, and 70 of the 103 errors were in them.
+    expect(include, "tsconfig includes the tree's .ts files").toContain('"./**/*.ts"');
   });
 
   it("checks packed links in CI and the Cloudflare Pages deployment", () => {
@@ -751,7 +793,7 @@ it("uses job-private Bun caches across CI workflows (issue #319)", () => {
   for (const [path, start, end] of [
     [".github/workflows/ci-consumer.yml", "  consumer-compat:", ""],
     [".github/workflows/compatibility-nightly.yml", "  packed-consumer:", ""],
-  ]) {
+  ] as const) {
     const workflow = read(path);
     const jobStart = workflow.indexOf(start);
     const jobEnd = end.length > 0 ? workflow.indexOf(end, jobStart) : workflow.length;

--- a/scripts/sakura-lesson.test.ts
+++ b/scripts/sakura-lesson.test.ts
@@ -28,7 +28,14 @@ const finished = foldSakura(SAKURA_STEPS.length, rows);
 /** Tick labels of one axis, top-to-bottom in screen order. */
 function yTicks(spec: unknown): { label: string; pos: number }[] {
   const model = runPipeline(spec as never, { width: 900, height: 480 });
-  return model.scene.panels[0]!.axisY.map((tick) => ({
+  // SceneTick[] | null — a panel renders no y-axis when placement says so. G1
+  // (earlier dates sit above later ones) is asserted against these ticks, so a
+  // missing axis has to say that, not die inside .map on null.
+  const axisY = model.scene.panels[0]?.axisY;
+  if (axisY === undefined || axisY === null) {
+    throw new Error("expected the first panel to render a y-axis");
+  }
+  return axisY.map((tick) => ({
     label: tick.label,
     pos: tick.pos,
   }));
@@ -138,7 +145,9 @@ describe("the sakura lesson folds to renderable specs", () => {
       Object.values(step.source.children ?? {}),
     ).concat("  <GeomPoint />");
     for (const child of children) {
-      for (const [, attribute] of child.matchAll(/^\s{4}([a-zA-Z]+)=/gm)) {
+      for (const match of child.matchAll(/^\s{4}([a-zA-Z]+)=/gm)) {
+        const attribute = match[1];
+        if (attribute === undefined) throw new Error(`unparsed prop line: ${match[0]}`);
         expect(componentProps.has(attribute), `<Geom…> has no ${attribute} prop`).toBe(true);
       }
       expect(child, "spec-level render hint spelled as a prop").not.toContain("render=");

--- a/scripts/support-matrix.test.ts
+++ b/scripts/support-matrix.test.ts
@@ -120,7 +120,10 @@ describe("consumer support matrix", () => {
   test("covers every installer, Svelte boundary, supported OS, and Node boundary", () => {
     const matrix = loadSupportMatrix(root);
     const rows = [...requiredConsumerRows(matrix), ...nightlyConsumerRows(matrix)];
-    expect(new Set(rows.map((row) => row.packageManager))).toEqual(
+    // Set<string> on both sides: the expected side is Object.keys, which cannot
+    // narrow to the PackageManager union, and the point of the assertion is that
+    // the two key sets are equal.
+    expect(new Set<string>(rows.map((row) => row.packageManager))).toEqual(
       new Set(Object.keys(matrix.packageManagers)),
     );
     expect(new Set(rows.map((row) => row.svelte))).toEqual(
@@ -154,8 +157,8 @@ describe("consumer support matrix", () => {
     const publisherTag = extractWorkflowEnvTag(buildCiImage, "PLAYWRIGHT_TAG");
     expect(rootManifest.packageManager).toBe(`bun@${matrix.packageManagers.bun}`);
     expect(rootManifest.devDependencies["@playwright/test"]).toBe(matrix.browsers.playwright);
-    expect(rootManifest.devDependencies.pnpm).toBe(matrix.packageManagers.pnpm);
-    expect(svelteManifest.devDependencies.playwright).toBe(matrix.browsers.playwright);
+    expect(rootManifest.devDependencies["pnpm"]).toBe(matrix.packageManagers.pnpm);
+    expect(svelteManifest.devDependencies["playwright"]).toBe(matrix.browsers.playwright);
     expect(ci).toContain(`PLAYWRIGHT_CONTAINER_TAG: ${consumerTag}`);
     expect(comparePlaywrightContainerTags(publisherTag, consumerTag)).toBeGreaterThanOrEqual(0);
     // Dockerfile ARG default tracks the publisher (build-arg overrides it;

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,0 +1,35 @@
+{
+  // tsc coverage for the whole repo-tooling tree. Until #734 these files sat in
+  // the root tsconfig.json purely so oxlint --type-aware had type information —
+  // tsc had never been run on that config, and type-aware lint rules are a
+  // strict subset of tsc's diagnostics, so assignability and optionality errors
+  // passed unseen. Run by `bun run check:scripts` (chained into `check`),
+  // following the worker gate from #725 and the ci-routing gate from #737.
+  //
+  // scripts/ci-routing keeps its own narrower project (check:scripts-ci-routing)
+  // because it decides what CI runs and is worth failing on independently; its
+  // files are inside this include too, which costs a second pass over seven
+  // files and keeps the routing gate meaningful when this one is skipped.
+  //
+  // "types": ["bun"] matches how these scripts actually run — `bun scripts/…`,
+  // with Bun.spawn and bun:test in the suites. "allowImportingTsExtensions" for
+  // the same reason: bun resolves `./foo.ts` directly and the tree imports that
+  // way throughout. Neither relaxes a strictness flag — tsconfig.base.json's
+  // exactOptionalPropertyTypes / noUncheckedIndexedAccess /
+  // noPropertyAccessFromIndexSignature all apply here in full.
+  //
+  // This program also pulls in the apps/docs/src/lib modules these scripts
+  // import, so those are held to tsconfig.base.json even though
+  // apps/docs/tsconfig.json extends ./.svelte-kit/tsconfig.json and svelte-check
+  // (`check:docs`) is the app's own gate. That is deliberate (#734): the
+  // imported lib modules are a shared surface, and the whole cost of holding
+  // them to the base config was 33 index-signature accesses. A new apps/docs
+  // module only enters this program once a script imports it.
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "types": ["bun"]
+  },
+  "include": ["./**/*.ts"]
+}

--- a/scripts/vr-approve-decision.test.ts
+++ b/scripts/vr-approve-decision.test.ts
@@ -169,7 +169,7 @@ describe("parseBooleanFlag", () => {
 
 /** Run the CLI exactly as the workflow does: env in, GITHUB_OUTPUT out. */
 const run = async (args: string[], env: Record<string, string>) => {
-  const outputFile = `${process.env.TMPDIR ?? "/tmp"}/vr-approve-decision-${args[0]}-${Bun.hash(JSON.stringify(env)).toString(16)}.txt`;
+  const outputFile = `${process.env["TMPDIR"] ?? "/tmp"}/vr-approve-decision-${args[0]}-${Bun.hash(JSON.stringify(env)).toString(16)}.txt`;
   await Bun.write(outputFile, "");
   const proc = Bun.spawn(["bun", `${import.meta.dir}/vr-approve-decision.ts`, ...args], {
     env: { ...process.env, ...env, GITHUB_OUTPUT: outputFile },

--- a/scripts/vr-approve-decision.ts
+++ b/scripts/vr-approve-decision.ts
@@ -130,7 +130,7 @@ function emit(outputs: Record<string, string>): void {
     .map(([key, value]) => `${key}=${value}\n`)
     .join("");
   process.stdout.write(rendered);
-  const target = process.env.GITHUB_OUTPUT;
+  const target = process.env["GITHUB_OUTPUT"];
   if (target !== undefined && target !== "") {
     // Values are enum-ish verdicts and single-line reasons — no delimiter needed.
     appendFileSync(target, rendered);
@@ -140,22 +140,22 @@ function emit(outputs: Record<string, string>): void {
 if (import.meta.main) {
   const [subcommand] = process.argv.slice(2);
   if (subcommand === "action") {
-    const decision = decideApproveAction(process.env.RENDER_SHA ?? "", {
-      tipSha: (process.env.BRANCH_TIP_SHA ?? "").trim(),
-      tipMessage: process.env.BRANCH_TIP_MESSAGE ?? "",
-      tipLandedOnDefault: parseBooleanFlag(process.env.BRANCH_TIP_LANDED, "branch tip landed"),
-      openPrNumber: parseOpenPrNumber(process.env.OPEN_PR_NUMBER),
+    const decision = decideApproveAction(process.env["RENDER_SHA"] ?? "", {
+      tipSha: (process.env["BRANCH_TIP_SHA"] ?? "").trim(),
+      tipMessage: process.env["BRANCH_TIP_MESSAGE"] ?? "",
+      tipLandedOnDefault: parseBooleanFlag(process.env["BRANCH_TIP_LANDED"], "branch tip landed"),
+      openPrNumber: parseOpenPrNumber(process.env["OPEN_PR_NUMBER"]),
     });
     emit({ action: decision.action, reason: decision.reason });
   } else if (subcommand === "pr-create") {
-    const action = process.env.ACTION ?? "";
+    const action = process.env["ACTION"] ?? "";
     if (action !== "skip" && action !== "open-pr" && action !== "render") {
-      throw new Error(`invalid action: ${JSON.stringify(process.env.ACTION)}`);
+      throw new Error(`invalid action: ${JSON.stringify(process.env["ACTION"])}`);
     }
     const decision = decidePrCreation({
       action,
-      pushed: parseBooleanFlag(process.env.PUSHED, "pushed"),
-      openPrNumber: parseOpenPrNumber(process.env.OPEN_PR_NUMBER),
+      pushed: parseBooleanFlag(process.env["PUSHED"], "pushed"),
+      openPrNumber: parseOpenPrNumber(process.env["OPEN_PR_NUMBER"]),
     });
     emit({ create: String(decision.create), reason: decision.reason });
   } else {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,18 +8,30 @@
   // web-standard APIs only (Request, Response, URL); bun's types cover them,
   // so no @cloudflare/workers-types.
   //
-  // tsc is NOT run on this config: it still reports ~190 errors nothing has
-  // ever been held to — the rest of scripts/**, plus the apps/docs modules
-  // those scripts import, which svelte-check covers under a config that does
-  // not extend tsconfig.base.json (#734). Two slices have been split out into their own
-  // projects, which `check` does run — workers/playground-api/tsconfig.json via
-  // check:workers (#725) and scripts/ci-routing/tsconfig.json via
-  // check:scripts-ci-routing (#734). The worker one is also the more accurate
-  // program of the two, since scripts/** membership here drags in @types/node
-  // and shadows the global fetch types.
+  // tsc is NOT run on this config, and `check` does not need it to be: every
+  // file it covers now belongs to a narrower project that `check` does run —
+  // workers/playground-api/tsconfig.json via check:workers (#725),
+  // scripts/ci-routing/tsconfig.json via check:scripts-ci-routing (#737), and
+  // scripts/tsconfig.json via check:scripts (#734).
+  //
+  // Running tsc here would report one error the per-project gates correctly do
+  // not, and it is an artifact of the combined program rather than a bug:
+  //
+  //   workers/playground-api/test/handler.test.ts: 'duplex' does not exist in
+  //   type 'RequestInit'
+  //
+  // `duplex: "half"` is required for the streaming-request-body test. It only
+  // fails here because scripts/** membership pulls @types/node into the program
+  // and its RequestInit shadows bun's, which does declare `duplex`. Under
+  // workers/playground-api/tsconfig.json the line is clean. Anything that wires
+  // tsc into this config has to split the global types, not re-suppress the line.
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "noEmit": true,
+    // Matches how this code runs and how it imports: `bun scripts/…` resolves
+    // `./foo.ts` directly, and the tree imports that way throughout. Without it
+    // this program reports 88 TS5097s that describe the config, not the code.
+    "allowImportingTsExtensions": true,
     "types": ["bun"]
   },
   "include": ["scripts/**/*.ts", "workers/**/*.ts"]


### PR DESCRIPTION
Closes #734.

`scripts/**` sat in the root `tsconfig.json` only so `oxlint --type-aware` had type information — tsc had never been run on it. Type-aware lint rules are a strict subset of tsc's diagnostics, so **103 errors** stood unseen.

Adds `scripts/tsconfig.json` and chains `check:scripts` into `check`, following the worker gate from #725 and the ci-routing gate from #737. The narrower `scripts/ci-routing` project is kept so the gate that decides what CI runs still fails on its own terms.

`bun run check`, `bun run test` (2645 pass), `lint`, `lint:type-aware`, `check:docs`, `check:svelte`, `check:examples`, and `fmt:check` are all green.

## Two of the errors were live defects

**`scripts/sakura-lesson.test.ts`** asserted gate G1 — earlier bloom dates sit *above* later ones — against `panels[0]!.axisY.map(…)`. `axisY` is `SceneTick[] | null`; a panel legitimately renders no y-axis (`placement.showAxisY ? left : null`). A missing axis would have died inside `.map` instead of failing the assertion it guards.

**`scripts/docs-csp.test.ts`** required `upgrade-insecure-requests` for `"legacy-full"` and `"legacy-migration"` — build modes deleted when GitHub Pages went away, and which `docs-build-mode.test.ts` already asserts are *rejected*. `docsCspDirectives` only branches on `mode === "dev"`, so both iterations passed on any unrecognised string. Now driven off an exported `DOCS_BUILD_MODES`, so a new mode fails here until its CSP behaviour is decided.

## Interfaces corrected, not tests bent around them

| Change | Why |
|---|---|
| `GenerateChartOptions.fetchFn`: `typeof fetch` → a `GenerateChartFetch` seam | `typeof fetch` carries the static `preconnect` member no caller uses; 13 stub injections could not typecheck without reproducing it |
| `resolveCodeLanguage`, `languageFromCodeTabLabel`, `normalizePlaygroundInteractions` take optional params | each implementation already handles `undefined`; only the signature disagreed |
| `deployment-asset-smoke` forwards `init` unchanged | re-listing the fields turned omitted ones into explicit `undefined`, which is not the same request |
| `gen-docs-search` builds its CLI anchor `Set` at `Set<string>` | inferred as the literal union, so `Set.has` rejected the arbitrary hrefs the check exists to validate |

The remaining 63 were index-signature accesses — 30 in `scripts/**`, 33 in the `apps/docs/src/lib` modules those scripts import — rewritten from tsc's own diagnostics.

## The apps/docs decision #734 asked for

Holding the imported `apps/docs/src/lib` modules to `tsconfig.base.json` is deliberate. They are a shared surface, and the whole cost of the stricter config was bracket access. A new apps/docs module only enters this program once a script imports it; `check:docs` (svelte-check) remains the app's own gate and still reports 0 errors.

## Root tsconfig

Left un-gated — every file it covers now belongs to a narrower project `check` does run. Its comment now records the one error it *would* report: `@types/node`'s `RequestInit` shadowing bun's and hiding `duplex` in the worker's streaming-body test. That is a combined-program artifact, not a bug, and #734's point (2) is preserved for anyone who later wires it.

## Test

`release-wiring.test.ts` gains a sibling to the #725/#737 wiring tests. Both its assertions were verified to fail when the wiring is broken — the first draft was vacuous, because `"check:scripts"` is a prefix of `"check:scripts-ci-routing"`, so the plain `toContain` passed on the routing gate alone. Both are now right-boundary anchored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/744" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->