### PR TITLE
fix(#748): cap every runner-backed job with timeout-minutes

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -25,6 +25,7 @@ jobs:
       group: bench-label-${{ github.ref }}
       cancel-in-progress: true
     runs-on: [self-hosted, ggsvelte]
+    timeout-minutes: 30
     container:
       image: ghcr.io/${{ github.repository }}/ci-runner:v1.61.1-noble
     defaults:

--- a/.github/workflows/build-ci-image.yml
+++ b/.github/workflows/build-ci-image.yml
@@ -49,6 +49,7 @@ jobs:
   build:
     name: build + push ci-runner image
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/cancel-on-pr-close.yml
+++ b/.github/workflows/cancel-on-pr-close.yml
@@ -23,6 +23,7 @@ jobs:
   cancel:
     name: cancel in-flight runs for closed PR
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       actions: write
       contents: read

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -34,6 +34,7 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.pull_request.head.ref != 'changeset-release/main'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/ci-actions-security.yml
+++ b/.github/workflows/ci-actions-security.yml
@@ -17,6 +17,7 @@ jobs:
   actions-security:
     name: actions-security (actionlint + zizmor)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:

--- a/.github/workflows/ci-bench-smoke.yml
+++ b/.github/workflows/ci-bench-smoke.yml
@@ -17,6 +17,7 @@ jobs:
   bench-smoke:
     name: bench-smoke (mitata, 1k workload)
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
     steps:

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -17,6 +17,7 @@ jobs:
   build:
     name: build (packages + knip + type-aware + publint)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
     steps:

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -11,6 +11,7 @@ jobs:
   checks:
     name: checks (pre-commit stage)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
     steps:

--- a/.github/workflows/ci-component-journeys.yml
+++ b/.github/workflows/ci-component-journeys.yml
@@ -28,6 +28,7 @@ jobs:
     name: component-journeys (docs a11y playwright)
 
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     env:
       # GitHub runs the container as root, while /github/home belongs to
       # pwuser. Firefox refuses that ownership mismatch.

--- a/.github/workflows/ci-component-spikes.yml
+++ b/.github/workflows/ci-component-spikes.yml
@@ -26,6 +26,7 @@ jobs:
     name: component-spikes (spikes/browser vitest)
 
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       # GitHub runs the container as root, while /github/home belongs to
       # pwuser. Firefox refuses that ownership mismatch.

--- a/.github/workflows/ci-component-svelte-fx.yml
+++ b/.github/workflows/ci-component-svelte-fx.yml
@@ -26,6 +26,7 @@ jobs:
     name: component-svelte-fx (packages/svelte firefox + webkit)
 
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     env:
       # GitHub runs the container as root, while /github/home belongs to
       # pwuser. Firefox refuses that ownership mismatch.

--- a/.github/workflows/ci-component-svelte.yml
+++ b/.github/workflows/ci-component-svelte.yml
@@ -29,6 +29,7 @@ jobs:
     name: component-svelte (packages/svelte chromium + coverage + ssr)
 
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     container:
       # Keep in sync with inputs.playwright_container_tag above.
       image: ghcr.io/${{ github.repository }}/ci-runner:${{ inputs.playwright_container_tag }}

--- a/.github/workflows/ci-consumer.yml
+++ b/.github/workflows/ci-consumer.yml
@@ -27,6 +27,7 @@ jobs:
   compatibility-matrix:
     name: compatibility matrix (machine-checked source)
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
     outputs:

--- a/.github/workflows/ci-docs-site.yml
+++ b/.github/workflows/ci-docs-site.yml
@@ -17,6 +17,7 @@ jobs:
   docs-site:
     name: docs-site (adapter-static build + pages links)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
     steps:

--- a/.github/workflows/ci-interaction-perf.yml
+++ b/.github/workflows/ci-interaction-perf.yml
@@ -20,6 +20,7 @@ jobs:
   interaction-perf:
     name: interaction-perf (p50/p95, informational)
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     env:
       HOME: /root
     container:

--- a/.github/workflows/ci-svelte-check.yml
+++ b/.github/workflows/ci-svelte-check.yml
@@ -17,6 +17,7 @@ jobs:
   svelte-check:
     name: svelte-check (packages/svelte + apps/docs)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
     steps:

--- a/.github/workflows/ci-unit.yml
+++ b/.github/workflows/ci-unit.yml
@@ -20,6 +20,7 @@ jobs:
   unit:
     name: unit (bun test spec + core)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
     steps:

--- a/.github/workflows/ci-vr-baseline-guard.yml
+++ b/.github/workflows/ci-vr-baseline-guard.yml
@@ -14,6 +14,7 @@ jobs:
     # not qualify. Legacy vr-update/pr-<n> bot path still allowed.
     name: vr-baseline-guard (same-PR smoke baselines)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
   detect-changes:
     name: detect-changes (path routing)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       actions: read
       contents: read
@@ -91,6 +92,7 @@ jobs:
     needs: detect-changes
     if: needs.detect-changes.outputs.packages_dist == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
     steps:
@@ -399,6 +401,7 @@ jobs:
       - bench-smoke
       - vr-baseline-guard
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -19,6 +19,7 @@ jobs:
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
 
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -18,6 +18,7 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/cloudflare-pages.yml
+++ b/.github/workflows/cloudflare-pages.yml
@@ -32,6 +32,7 @@ jobs:
     name: build immutable artifact
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
     # Same environment as deploy so DOCS_ANALYTICS_TOKEN (and other env secrets)
@@ -88,6 +89,7 @@ jobs:
     if: github.ref == 'refs/heads/main'
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
     concurrency:

--- a/.github/workflows/compatibility-nightly.yml
+++ b/.github/workflows/compatibility-nightly.yml
@@ -18,6 +18,7 @@ jobs:
   matrix:
     name: compatibility matrix (required + nightly)
     runs-on: [self-hosted, ggsvelte]
+    timeout-minutes: 30
     permissions:
       contents: read
     outputs:

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -46,6 +46,7 @@ jobs:
       (github.event.label.name == 'run-evals' &&
        github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: [self-hosted, ggsvelte]
+    timeout-minutes: 30
     permissions:
       contents: read
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,7 @@ jobs:
     name: changesets version-or-publish
     # GitHub-hosted: npm trusted publishing (OIDC) is not supported on self-hosted.
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: write # changesets/action pushes version commits + tags
       pull-requests: write # changesets/action opens the Version Packages PR

--- a/.github/workflows/vr-approve.yml
+++ b/.github/workflows/vr-approve.yml
@@ -59,6 +59,7 @@ jobs:
     # GitHub-hosted: privileged write path (pushes vr-update branches); keep off
     # the self-hosted pool that runs untrusted PR code.
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write # push the verified vr-update/pr-<n> branch
       actions: read # download the triggering run's artifact

--- a/.github/workflows/vr-compare.yml
+++ b/.github/workflows/vr-compare.yml
@@ -51,6 +51,7 @@ jobs:
     name: detect-changes (path routing)
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     outputs:
@@ -83,6 +84,7 @@ jobs:
     needs: detect-changes
     if: github.event_name == 'pull_request' && needs.detect-changes.outputs.vr == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
     container:
@@ -186,6 +188,7 @@ jobs:
     # ubuntu-latest, absent on the self-hosted ggsvelte runners) and runs no
     # checked-out code. vr-approve.yml already runs on ubuntu-latest.
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: read # resolve the merged PR via `gh api` (read-only)
@@ -264,6 +267,7 @@ jobs:
     needs: approve-gate
     if: needs.approve-gate.outputs.match == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read # checkout only; this job can write nothing
     container:

--- a/scripts/workflow-timeouts.test.ts
+++ b/scripts/workflow-timeouts.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Every runner-backed job must declare `timeout-minutes`.
+ *
+ * GitHub's default job timeout is 360 minutes. A job whose runner wedges before
+ * it reports a single step therefore sits `in_progress` for six hours, and any
+ * aggregator that `needs:` it — `ci-gate` — stays pending for the same six
+ * hours, blocking the PR with no signal and no log to read. That happened on
+ * #747: `svelte-check` normally finishes in ~80s, and one instance held the
+ * gate for 40+ minutes having emitted no steps at all, on a run whose fifteen
+ * sibling jobs were all green inside nine minutes.
+ *
+ * Nothing can tell a wedged runner from a genuinely slow job, so the fix is a
+ * declared ceiling per job: a hang becomes a fast, legible failure that can be
+ * re-run, instead of an indefinite stall.
+ *
+ * A job that calls a reusable workflow (`uses:`) CANNOT carry the key —
+ * actionlint rejects it ("when a reusable workflow is called with 'uses',
+ * 'timeout-minutes' is not available") — so the ceiling belongs on the
+ * `runs-on` job inside the called workflow, which is where the runner actually
+ * lives. That asymmetry is asserted below so it stays understood rather than
+ * rediscovered.
+ */
+import { describe, expect, it } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOT = join(import.meta.dir, "..");
+const WORKFLOWS = join(ROOT, ".github", "workflows");
+
+interface Job {
+  "runs-on"?: unknown;
+  uses?: unknown;
+  "timeout-minutes"?: unknown;
+}
+
+interface Workflow {
+  jobs?: Record<string, Job>;
+}
+
+/**
+ * Upper bound on any declared ceiling. The slowest job in the repo is the
+ * manual NVDA/TalkBack assistive-tech run at 45 minutes; nothing routine comes
+ * close (the slowest CI job, component-journeys, is ~7 minutes). A ceiling
+ * above this is indistinguishable from having none.
+ */
+const MAX_TIMEOUT_MINUTES = 60;
+
+function workflowFiles(): string[] {
+  return readdirSync(WORKFLOWS)
+    .filter((name) => name.endsWith(".yml") || name.endsWith(".yaml"))
+    .toSorted();
+}
+
+function parseWorkflow(name: string): Workflow {
+  return Bun.YAML.parse(readFileSync(join(WORKFLOWS, name), "utf8")) as Workflow;
+}
+
+describe("workflow job timeouts", () => {
+  const files = workflowFiles();
+
+  it("finds the workflow directory", () => {
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  for (const file of files) {
+    const jobs = Object.entries(parseWorkflow(file).jobs ?? {});
+
+    for (const [id, job] of jobs) {
+      const isReusableCall = job.uses !== undefined;
+      const declared = job["timeout-minutes"];
+
+      if (isReusableCall) {
+        it(`${file} · ${id} (reusable caller) leaves the timeout to the called workflow`, () => {
+          expect(declared, `${file} · ${id}`).toBeUndefined();
+        });
+        continue;
+      }
+
+      it(`${file} · ${id} declares a timeout at or under ${String(MAX_TIMEOUT_MINUTES)}m`, () => {
+        expect(declared, `${file} · ${id}: runner-backed job without timeout-minutes`).toBeNumber();
+        expect(declared as number, `${file} · ${id}`).toBeGreaterThan(0);
+        expect(declared as number, `${file} · ${id}`).toBeLessThanOrEqual(MAX_TIMEOUT_MINUTES);
+      });
+    }
+  }
+});


### PR DESCRIPTION
Closes #748.

## The incident

`svelte-check` on #747 held `ci-gate` for **47 minutes** without running. Not a slow check — a wedged runner:

| fact | value |
|---|---|
| `svelte-check` p50 over the last 10 successful runs | **81s** (max 85s) |
| this instance | `in_progress` 17:33:14Z → force-cancelled 18:20:19Z |
| steps reported by the jobs API | **0** — a healthy `in_progress` job reports **13** (confirmed on the rerun) |
| log blob | 404: never emitted a byte |
| the other 15 jobs in the same run | all green by 17:41Z |
| response to `gh run cancel` | ignored 7.5 min; healthy jobs here cancel in ~20s |
| githubstatus.com | "All Systems Operational" |

A runner was assigned (`GitHub Actions 1000026982`) and then never executed a step.

## Why it lasted 47 minutes

**No job in this repo declared `timeout-minutes`, so GitHub's 360-minute default applied.** 33 of 38 runner-backed jobs had no ceiling; only `ci-consumer`, `compatibility-nightly`, and the three `manual-at-*` workflows did.

One wedged runner could therefore block a required check for **six hours**, with no log and no failure — `ci-gate` simply never resolves. Nothing distinguishes a wedged runner from a slow job from the outside, so the fix is a declared ceiling: an indefinite stall becomes a fast failure you can re-run.

## What changed

**33 ceilings**, sized at roughly 4x each job's observed p50 (measured across the last 10–12 successful runs) with a 10-minute floor, generous where no recent successful run exists to measure:

| ceiling | jobs |
|---|---|
| 10m | detect-changes (x2), ci-gate, vr-baseline-guard, actions-security, approve-gate, cancel, changeset comment |
| 15m | svelte-check, checks, unit, build, docs-site, packages-dist, component-spikes, pages deploy, vr approve |
| 20m | bench-smoke, compatibility-matrix, claude-review, release, pages build |
| 25m | component-svelte, component-svelte-fx, component-journeys, interaction-perf |
| 30m | compare, approve-regenerate, claude, evals, bench-label, build-ci-image, nightly matrix |

For scale: the slowest routine job is `component-journeys` at ~6.7 min; the slowest job in the repo is the manual NVDA run, already capped at 35m.

## The constraint that shapes this

`timeout-minutes` **cannot** go on a job that calls a reusable workflow — verified, not assumed:

```
ci.yml:333:5: when a reusable workflow is called with "uses", "timeout-minutes" is not
available. only following keys are allowed: "name", "uses", "with", "secrets", "needs",
"if", and "permissions" in job "svelte-check" [syntax-check]
```

So the twelve domain jobs `ci.yml` dispatches carry the ceiling inside their own `ci-*.yml`, on the `runs-on` job where the runner actually lives. `scripts/workflow-timeouts.test.ts` asserts both halves of that split — runner-backed jobs must declare one, reusable callers must not — so the asymmetry is documented by a test rather than rediscovered next time.

## Regression guard actually runs

The guard lives in `scripts/`, and a workflow-only PR schedules `unit`, which is what executes `scripts/**` tests. Verified rather than assumed:

```
.github/workflows/ci-svelte-check.yml   unit: true | actions_security: true
.github/workflows/vr-compare.yml        unit: true | actions_security: true
```

(`routing.ts:431` — `changes.workflows` already feeds `unit`, per the note at `routing.ts:352` that "script tests live only there".)

## Verification

- `bun test scripts/workflow-timeouts.test.ts` — red first at **33 fail / 20 pass**, green after at **53 pass**
- `bun run test` — **2750 pass / 0 fail** (331 files; was 2697 before the 53 new cases)
- `bun run lint:actions` — 30 workflow files clean
- `bun run lint:actions:security` (zizmor) — no findings
- `bun run fmt:check` — clean
- #747's stuck run cancelled and re-run; `svelte-check` came back with `steps=13` and is executing normally

## Not covered

A ceiling makes a hang *fail fast* — it does not retry it. Recovery is still a manual re-run. Auto-retry on a timeout would need care (a genuinely slow job would retry forever), so it is deliberately out of scope here.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/749" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->