### PR TITLE
fix(#742): make the pixel VR comparison a required check

### DIFF
--- a/.github/workflows/vr-compare.yml
+++ b/.github/workflows/vr-compare.yml
@@ -175,6 +175,37 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
+  vr-gate:
+    # The single required status check for pixels (#742). ci.yml's `ci-gate`
+    # cannot cover the compare job: this workflow is deliberately separate and
+    # unprivileged, so it is unreachable from `needs`. Before this job existed
+    # the only job that measures pixels was advisory, and #732 merged an
+    # example whose baseline no longer matched it — leaving every later PR
+    # red for a reason its author did not cause.
+    #
+    # `always()` matters: a required context that never reports leaves the PR
+    # permanently unmergeable. This job reports on every pull request and
+    # decides the verdict from needs results.
+    name: vr-gate (required pixel aggregator)
+    if: always() && github.event_name == 'pull_request'
+    needs: [detect-changes, compare]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.3.14
+      - name: evaluate the pixel gate
+        env:
+          DETECT_RESULT: ${{ needs.detect-changes.result }}
+          VR_ROUTED: ${{ needs.detect-changes.outputs.vr }}
+          COMPARE_RESULT: ${{ needs.compare.result }}
+        run: bun scripts/ci-routing.ts vr-gate
+
   approve-gate:
     name: /approve-visuals — verify merge, resolve rendered commit (read-only)
     # Only comments ON a PR, only from commenters whose association implies

--- a/.github/workflows/vr-compare.yml
+++ b/.github/workflows/vr-compare.yml
@@ -190,6 +190,7 @@ jobs:
     if: always() && github.event_name == 'pull_request'
     needs: [detect-changes, compare]
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -412,24 +412,43 @@ without `GH_TOKEN` in its environment. Every step that holds the write
 credential is script-free (`gh`/`git` only): the commit/push and the
 `gh pr create` that opens the baseline PR.
 
-The source-first landing order is deliberate:
+### Pixel changes land with their own baselines (issue #742)
 
-1. Inspect the source PR's candidate report. For an intentional pixel change,
-   the red VR comparison is expected; keep VR Compare non-required so it cannot
-   deadlock this flow. `ci-gate`, code review, and the baseline evidence still
-   gate the source merge.
-2. Merge the source PR into the default branch.
-3. Comment `/approve-visuals` on the **merged** PR. A pre-merge command is
-   rejected, including one recorded in the same second as the merge.
-4. Review and merge the generated `vr-update/pr-<n>` PR. The approve workflow
-   opens it for you, and **close + reopen it once** so the required checks
-   run — GitHub starts no workflow runs for pull requests opened by the
-   Actions token.
+`vr-gate (required pixel aggregator)` is a **required status check**. A PR whose
+rendering changed cannot merge until the comparison is green against baselines
+committed in that same PR:
 
-This creates a short, explicit window where source has landed but its approved
-baselines have not. Finish step 4 promptly. Never merge an unexplained visual
-diff, and do not make VR Compare a required branch-protection check without
-redesigning this source-first protocol.
+1. The compare job goes red and uploads a `vr-baselines` artifact containing the
+   candidate PNGs the pinned container just rendered.
+2. Inspect the diff in the `vr-playwright-report` artifact. If the change is
+   intentional, download `vr-baselines`, copy its `__screenshots__/*.png` over
+   `tests/visual/__screenshots__/`, and commit them alongside the source change.
+   `vr-baseline-guard` allows exactly this pairing.
+3. The compare re-runs on the new head and must go green. That is the point:
+   a green required compare _proves_ the committed PNGs are byte-identical to
+   the pinned container's render of that commit (`maxDiffPixels` is 0), so a
+   hand-edited or partial baseline cannot land.
+
+Until this gate existed, VR Compare was advisory and the source-first
+`/approve-visuals` order below was the normal path. That order let an example
+merge ahead of its baseline (#732), and every later PR then inherited a red
+comparison it had not caused. Same-PR landing removes the window entirely.
+
+`/approve-visuals` remains for the two cases same-PR landing cannot serve:
+
+- **Bootstrap** — `tests/visual/__screenshots__/` is empty, so there is nothing
+  to compare and the compare job generates candidates instead.
+- **Repair** — baselines on the default branch are already stale (a pixel change
+  that merged before this gate, or a rendering change reaching an example whose
+  own PR did not touch it).
+
+For those, comment `/approve-visuals` on a **merged** PR (a pre-merge command is
+rejected, including one recorded in the same second as the merge), then review
+and merge the generated `vr-update/pr-<n>` PR — **close and reopen it once** so
+the required checks run, since GitHub starts no workflow runs for pull requests
+opened by the Actions token.
+
+Never merge an unexplained visual diff.
 
 Idempotency keys on the **open PR**, not the branch (issue #717): re-running
 `/approve-visuals` while the baseline PR is open is a no-op, but a

--- a/docs/decisions/0012-m3-notes.md
+++ b/docs/decisions/0012-m3-notes.md
@@ -158,6 +158,9 @@ bench-smoke unchanged.
   leave VR Compare red, so it is not a required branch-protection check; making
   it required would deadlock this order. This prevents docs-owned previews from
   publishing ahead of their source.
+  **Superseded by [0021](0021-required-pixel-gate.md)** (issue #742): the
+  comparison is now required and pixel changes land their own baselines, so
+  there is no post-merge window left to deadlock against.
 - `release.yml`: changesets/action, `id-token: write`, npm trusted
   publishing (OIDC + provenance via publishConfig; NO tokens), publish =
   `changeset publish` after `bun run build`; setup-node 24 for npm OIDC.
@@ -212,8 +215,8 @@ LICENSE (MIT, Liam O'Dea) at root + copied into each package; READMEs (root
    publishing only.
 4. **First CI run**: inspect VR candidates, merge source to the default branch,
    comment `/approve-visuals` on that merged PR, then merge the generated
-   `vr-update/pr-<n>` PR. Enable required checks afterward, but keep VR Compare
-   non-required because source-first approval would otherwise deadlock.
+   `vr-update/pr-<n>` PR. Enable required checks afterward, including
+   `vr-gate (required pixel aggregator)` once those baselines are green (0021).
 5. **Domain** (`ggsvelte.dev` or equivalent): optional pre-0.1.0; schema
    stays served from the repo/docs build until then.
 6. **Publish**: merge the changesets "Version Packages" PR → release.yml

--- a/docs/decisions/0021-required-pixel-gate.md
+++ b/docs/decisions/0021-required-pixel-gate.md
@@ -1,0 +1,68 @@
+# 0021 — The pixel comparison is a required check
+
+Supersedes the source-first publication invariant in
+[0012](0012-m3-notes.md) ("Intentional source diffs may leave VR Compare red,
+so it is not a required branch-protection check").
+
+## Context
+
+VR Compare measured pixels but could not block a merge. It lives in its own
+unprivileged workflow (trust separation — only `vr-compare.yml` executes
+unmerged PR code), so `ci.yml`'s `ci-gate` aggregator cannot reach it through
+`needs`, and 0012 deliberately kept it off the required list because the
+source-first `/approve-visuals` order would deadlock against it: baselines were
+regenerated only _after_ the source PR merged, so a required comparison would
+have blocked the very merge that unlocks the baselines.
+
+The cost of that decision came due in #732, which changed
+`examples/point/scatter-color`'s axis labels. Its comparison went red, as
+designed, and it merged anyway; no `/approve-visuals` followed. The baseline
+then depicted an example that no longer existed
+(`git merge-base --is-ancestor a0ae259d 3234cbc4` → true), and **every**
+subsequent PR inherited a 1347-pixel failure in a file it had not touched. Each
+author had to independently rediscover that the red job was not their fault.
+Issue #742.
+
+## Decision
+
+Make the comparison required, and move pixel changes to the same-PR landing
+path so there is nothing left to deadlock.
+
+- `vr-compare.yml` gains a `vr-gate (required pixel aggregator)` job. It runs
+  `if: always() && github.event_name == 'pull_request'`, so the context reports
+  on every pull request — a required check that sometimes fails to report leaves
+  PRs permanently unmergeable, which is a worse failure than the one being
+  fixed. The verdict comes from `evaluateVrGate` in
+  `scripts/ci-routing/vr-gate.ts`, not from YAML expressions, so it is unit
+  tested: routed comparisons must succeed, unrouted ones require nothing, and
+  anything else (skipped, cancelled, absent, or untrustworthy routing) fails
+  closed.
+- Authors commit candidate baselines in the PR that changes the rendering,
+  taking the PNGs from the compare run's `vr-baselines` artifact.
+  `vr-baseline-guard` already permits baseline diffs paired with
+  render-relevant paths; this makes that the normal path rather than the
+  preferred-but-optional one.
+- `/approve-visuals` is retained for bootstrap (empty baseline directory) and
+  for repairing baselines that are already stale on the default branch.
+
+## Consequences
+
+- A rendering change cannot merge with a baseline older than itself, and an
+  unrelated PR cannot inherit another PR's baseline debt, because the debt
+  cannot land.
+- Committed baselines are now _verified_ rather than merely path-guarded. Under
+  `maxDiffPixels: 0` a green required comparison proves the committed PNGs are
+  byte-identical to the pinned container's render of that exact commit, so a
+  hand-crafted or partial baseline fails. This strengthens decision 0009's
+  "baselines come only from the pinned container" from a convention into an
+  enforced property.
+- Intentional pixel changes cost an extra round trip: red compare → download
+  artifact → commit PNGs → green compare. That is the price of the guarantee,
+  and it replaces a post-merge chore that was silently skippable.
+- A genuinely flaky shot now blocks merges instead of being ignorable. `retries`
+  is 0 and `maxDiffPixels` is 0 by decision 0009 precisely so that a diff is
+  never dismissed as flake; if one appears, fix the determinism rather than
+  weakening the gate.
+- The check must be added to the "Protect main" ruleset's required contexts
+  _after_ the default branch's baselines are green, or the ruleset would block
+  every PR on pre-existing debt.

--- a/scripts/ci-routing/cli.ts
+++ b/scripts/ci-routing/cli.ts
@@ -16,6 +16,7 @@ import {
   type JobPlan,
 } from "./routing";
 import { evaluateCiGate } from "./ci-gate";
+import { evaluateVrGate } from "./vr-gate";
 import {
   CACHEABLE_EXECUTIONS,
   CONTENT_HASH_SCHEMA,
@@ -92,6 +93,11 @@ export async function runCiRoutingCli(argv: string[]): Promise<void> {
     return;
   }
 
+  if (cmd === "vr-gate") {
+    runVrGateCli();
+    return;
+  }
+
   if (cmd === "gate") {
     const requiredPath = flagValue(args, "--required");
     const resultsPath = flagValue(args, "--results");
@@ -124,6 +130,7 @@ function printHelp(): void {
   bun scripts/ci-routing.ts validate-success-marker --execution <name> --hash <hex>
   bun scripts/ci-routing.ts gate --required <file|-> --results <file|->
   bun scripts/ci-routing.ts ci-gate
+  bun scripts/ci-routing.ts vr-gate
 
   detect-changes reads EVENT_NAME, GITHUB_REF, BASE_SHA, HEAD_SHA, PR_LABELS,
   REPO, GITHUB_OUTPUT (and uses gh/git for main base widening).
@@ -134,6 +141,9 @@ function printHelp(): void {
   .. DOCS_JOURNEYS_REQ, CHECKS_RES .. VR_GUARD_RES, EVENT_NAME) and evaluates
   the required-jobs gate, including component-shard rollup and the PR-only
   vr-baseline-guard rule. Prints "ci-gate ok" or "ci-gate failed: <list>".
+  vr-gate reads vr-compare.yml's DETECT_RESULT, VR_ROUTED and COMPARE_RESULT
+  and decides the required pixel check: routed pixel compares must succeed,
+  unrouted ones need nothing (#742).
 `);
 }
 
@@ -287,6 +297,22 @@ function runCiGateCli(): void {
     return;
   }
   process.stdout.write("ci-gate ok\n");
+}
+
+/** vr-compare.yml's `vr-gate` job — the required pixel status check (#742). */
+function runVrGateCli(): void {
+  const env = process.env;
+  const verdict = evaluateVrGate({
+    detectChangesResult: env["DETECT_RESULT"],
+    vrRouted: env["VR_ROUTED"] === "true",
+    compareResult: env["COMPARE_RESULT"],
+  });
+  if (!verdict.ok) {
+    process.stderr.write(`vr-gate failed: ${verdict.reason}\n`);
+    process.exitCode = 1;
+    return;
+  }
+  process.stdout.write(`vr-gate ok: ${verdict.reason}\n`);
 }
 
 function parseCacheableExecution(raw: string | undefined): CacheableExecution {

--- a/scripts/ci-routing/vr-gate.test.ts
+++ b/scripts/ci-routing/vr-gate.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+
+import { evaluateVrGate } from "./vr-gate";
+
+describe("evaluateVrGate", () => {
+  test("routing skipped the pixel job — nothing to compare, gate passes", () => {
+    const verdict = evaluateVrGate({
+      detectChangesResult: "success",
+      vrRouted: false,
+      compareResult: "skipped",
+    });
+    expect(verdict.ok).toBe(true);
+  });
+
+  test("pixel compare failed — the exact case #732 merged through", () => {
+    const verdict = evaluateVrGate({
+      detectChangesResult: "success",
+      vrRouted: true,
+      compareResult: "failure",
+    });
+    expect(verdict.ok).toBe(false);
+    expect(verdict.reason).toContain("failure");
+  });
+
+  test("routed but the pixel job never reported — fail closed, never assume green", () => {
+    for (const compareResult of ["skipped", "cancelled", undefined, ""]) {
+      const verdict = evaluateVrGate({
+        detectChangesResult: "success",
+        vrRouted: true,
+        compareResult,
+      });
+      expect(verdict.ok, `compare=${String(compareResult)}`).toBe(false);
+    }
+  });
+
+  test("routing itself failed — its vr flag cannot be trusted either way", () => {
+    const verdict = evaluateVrGate({
+      detectChangesResult: "failure",
+      vrRouted: false,
+      compareResult: "skipped",
+    });
+    expect(verdict.ok).toBe(false);
+    expect(verdict.reason).toContain("detect-changes");
+  });
+
+  test("routed and the pixel compare passed — the only way a rendering change lands", () => {
+    const verdict = evaluateVrGate({
+      detectChangesResult: "success",
+      vrRouted: true,
+      compareResult: "success",
+    });
+    expect(verdict.ok).toBe(true);
+  });
+});

--- a/scripts/ci-routing/vr-gate.ts
+++ b/scripts/ci-routing/vr-gate.ts
@@ -1,0 +1,46 @@
+/**
+ * vr-gate job driver (issue #742) — the required-check aggregator for
+ * vr-compare.yml's pixel job.
+ *
+ * Why this exists: `vr-compare.yml` is deliberately a SEPARATE, unprivileged
+ * workflow (trust separation — see its header), so ci.yml's `ci-gate` cannot
+ * list it in `needs`. That left the only job that actually measures pixels
+ * outside the required set, so a PR could change an example's rendering, go
+ * red on the compare, and merge anyway (#732). Every later PR then inherited
+ * a failure it did not cause.
+ *
+ * A separate workflow can still be a REQUIRED STATUS CHECK, which is what
+ * this job is for: one stable context per PR whose verdict is derived here
+ * rather than in YAML.
+ */
+
+export type VrGateInput = {
+  /** Raw `needs.detect-changes.result`. */
+  detectChangesResult: string | undefined;
+  /** `needs.detect-changes.outputs.vr == 'true'`. */
+  vrRouted: boolean;
+  /** Raw `needs.compare.result`. */
+  compareResult: string | undefined;
+};
+
+export type VrGateVerdict = { ok: boolean; reason: string };
+
+export function evaluateVrGate(input: VrGateInput): VrGateVerdict {
+  if (input.detectChangesResult !== "success") {
+    return {
+      ok: false,
+      reason: `detect-changes is ${describe(input.detectChangesResult)} — routing cannot be trusted`,
+    };
+  }
+  if (input.vrRouted) {
+    if (input.compareResult !== "success") {
+      return { ok: false, reason: `vr routed but compare is ${describe(input.compareResult)}` };
+    }
+    return { ok: true, reason: "pixel compare succeeded for this head" };
+  }
+  return { ok: true, reason: "vr not routed for these paths — no pixel contract to check" };
+}
+
+function describe(result: string | undefined): string {
+  return result === undefined || result === "" ? "absent" : result;
+}

--- a/scripts/vr-gate-wiring.test.ts
+++ b/scripts/vr-gate-wiring.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Wiring contract for the vr-gate required check (#742). The evaluator's own
+ * rules live in scripts/ci-routing/vr-gate.test.ts; this file asserts that
+ * vr-compare.yml actually hands it the right inputs and that the job cannot
+ * be silently routed out of existence.
+ */
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const workflow = readFileSync(join(import.meta.dir, "../.github/workflows/vr-compare.yml"), "utf8");
+
+/** The `vr-gate:` job block, up to the next top-level job key. */
+function vrGateJob(): string {
+  const start = workflow.indexOf("\n  vr-gate:");
+  expect(start, "vr-compare.yml declares a vr-gate job").toBeGreaterThan(-1);
+  const rest = workflow.slice(start + 1);
+  const next = rest.slice(1).search(/\n {2}[a-z][\w-]*:\n/);
+  return next === -1 ? rest : rest.slice(0, next + 1);
+}
+
+describe("vr-gate wiring", () => {
+  test("runs on every pull request, whatever routing decided", () => {
+    const job = vrGateJob();
+    // `always()` is what makes the gate report even when compare failed or was
+    // skipped — without it the required context would simply never appear and
+    // the PR would sit unmergeable.
+    expect(job).toContain("if: always() && github.event_name == 'pull_request'");
+  });
+
+  test("depends on both jobs whose results it judges", () => {
+    const job = vrGateJob();
+    expect(job).toContain("needs: [detect-changes, compare]");
+  });
+
+  test("delegates the verdict to the tested evaluator, not to YAML expressions", () => {
+    const job = vrGateJob();
+    expect(job).toContain("bun scripts/ci-routing.ts vr-gate");
+    for (const variable of ["DETECT_RESULT", "VR_ROUTED", "COMPARE_RESULT"]) {
+      expect(job, variable).toContain(`${variable}:`);
+    }
+  });
+
+  test("its check name is stable — the ruleset pins this exact string", () => {
+    // Renaming this breaks the required-status-check context on the "Protect
+    // main" ruleset, which fails open (the check never reports). Treat the
+    // name as an external contract.
+    expect(vrGateJob()).toContain("name: vr-gate (required pixel aggregator)");
+  });
+});


### PR DESCRIPTION
Closes #742.

## The premise this changes

`CONTRIBUTING.md` and decision [0012](docs/decisions/0012-m3-notes.md) said, in
so many words, **do not** make VR Compare required. That was a real constraint,
not an oversight: baselines were regenerated only *after* the source PR merged
(`/approve-visuals`), so a required comparison would have blocked the very merge
that unlocks the baselines. 0012 also invited the alternative — "without
redesigning this source-first protocol". This PR does the redesign.

## Why

VR Compare measured pixels but could not block a merge. `vr-compare.yml` is
deliberately a separate, unprivileged workflow (it is the only one that executes
unmerged PR code), so `ci.yml`'s `ci-gate` cannot list it in `needs` — and it was
not a required status check either.

PR #732 changed `examples/point/scatter-color`'s axis labels. Its comparison went
red, as designed, and it merged anyway; no `/approve-visuals` followed:

```
git merge-base --is-ancestor a0ae259d 3234cbc4   # -> true
```

Every subsequent PR then inherited a 1347-pixel failure in a file it had not
touched, and each author had to independently work out that it was not their
fault.

## What

- **`vr-gate (required pixel aggregator)`** in `vr-compare.yml`. Runs
  `if: always() && github.event_name == 'pull_request'` — a required context that
  sometimes fails to report leaves PRs *permanently* unmergeable, which is worse
  than the bug being fixed.
- The verdict comes from **`evaluateVrGate`** (`scripts/ci-routing/vr-gate.ts`),
  not from YAML expressions, so it is unit tested. Routed comparisons must
  succeed; unrouted ones require nothing; skipped, cancelled, absent, or
  untrustworthy routing all fail closed.
- Pixel changes land their own baselines from the compare run's `vr-baselines`
  artifact. `vr-baseline-guard` already permitted that pairing; it is now the
  normal path rather than the preferred-but-optional one.
- `/approve-visuals` is retained for bootstrap and for repairing baselines that
  are already stale on `main`.
- Decision [0021](docs/decisions/0021-required-pixel-gate.md) records the change;
  0012's invariant is marked superseded; `CONTRIBUTING.md` rewritten.

## A property this gains, beyond the bug

Committed baselines were previously only *path*-guarded — nothing verified they
matched container output at merge time. With the comparison required and
`maxDiffPixels` at 0, a green gate **proves** the committed PNGs are
byte-identical to the pinned container's render of that exact commit. A
hand-edited or partial baseline now fails. That turns decision 0009's "baselines
come only from the pinned container" from a convention into an enforced property.

## Costs, stated plainly

- An intentional pixel change costs an extra round trip: red compare -> download
  artifact -> commit PNGs -> green compare. It replaces a post-merge chore that
  was silently skippable.
- A genuinely flaky shot now blocks merges instead of being ignorable. `retries`
  is 0 and `maxDiffPixels` is 0 by decision 0009 precisely so a diff is never
  dismissed as flake; if one appears, fix the determinism, do not weaken the gate.

## Landing order (matters)

`vr-gate` must be added to the **"Protect main" ruleset**'s required contexts
*after* `main`'s baselines are green — otherwise the ruleset would block every PR
on the pre-existing `point/scatter-color` debt. Sequence:

1. Merge this PR (the gate reports but is not yet required).
2. Comment `/approve-visuals` on it -> regenerates baselines at the merged commit
   -> merge the `vr-update/pr-<n>` PR. This clears acceptance item 2 of #742.
3. Add `vr-gate (required pixel aggregator)` to the ruleset.

## Verification

- `bun test scripts/ci-routing/vr-gate.test.ts scripts/vr-gate-wiring.test.ts` — 9 pass
- `bun run test` — 2706 pass, 0 fail (332 files)
- `bun run check`, `bun run lint`, `bun run lint:type-aware`, `bun run fmt:check` — clean
- `bun scripts/actionlint.ts` — 30 workflow files clean
- CLI smoke: `DETECT_RESULT=success VR_ROUTED=true COMPARE_RESULT=failure` -> exit 1;
  `VR_ROUTED=false COMPARE_RESULT=skipped` -> exit 0

**This PR's own VR comparison will be red** — that is the stale
`point/scatter-color` baseline, cleared by step 2 above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/750" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->