### PR TITLE
fix(docs): homepage hero void, stacked chart, bun install

### DIFF
--- a/apps/docs/src/lib/components/GettingStartedGuide.svelte
+++ b/apps/docs/src/lib/components/GettingStartedGuide.svelte
@@ -119,7 +119,7 @@
     class="lesson-source"
     language="bash"
     accessibleLabel="Copy create command"
-    code={`npx sv create my-chart --template minimal --types ts --no-add-ons --install npm\ncd my-chart\nnpm install @ggsvelte/svelte`}
+    code={`bunx sv create my-chart --template minimal --types ts --no-add-ons --install bun\ncd my-chart\nbun install @ggsvelte/svelte`}
   />
 
   <h2 id="draw-your-first-chart">Draw your first chart</h2>

--- a/apps/docs/src/routes/+page.svelte
+++ b/apps/docs/src/routes/+page.svelte
@@ -15,7 +15,7 @@
 
   const { data }: PageProps = $props();
 
-  const install = "npm install @ggsvelte/svelte";
+  const install = "bun install @ggsvelte/svelte";
   const entries = EXAMPLES.map((entry) => galleryEntryFor(entry));
   const featured = FEATURED_EXAMPLES.map((item) =>
     entries.find((entry) => entry.id === item.id)!,
@@ -35,8 +35,7 @@
 <section class="home-hero" aria-labelledby="home-heading">
   <div class="hero-claim">
     <h1 id="home-heading">
-      An agent-first implementation of the layered grammar of graphics in Svelte
-      5
+      A layered grammar of graphics implemented for agents
     </h1>
     <p>
       ggplot2's layered grammar and defaults as Svelte components, a TypeScript
@@ -153,14 +152,19 @@
 </section>
 
 <style>
+  /*
+   * Stack by default: the chart is the hero and owns a full-width row until
+   * the viewport is wide enough for a true two-column composition.
+   * Never pin min-height to 100svh — a two-row grid under that rule stretches
+   * empty space between claim and actions into a multi-hundred-px void.
+   */
   .home-hero {
     display: grid;
-    grid-template-areas: "claim plot" "actions plot";
-    grid-template-columns: minmax(18rem, 0.85fr) minmax(30rem, 1.15fr);
-    gap: 1.5rem clamp(2rem, 6vw, 6rem);
+    grid-template-areas: "claim" "plot" "actions";
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
     align-items: start;
-    min-height: calc(100svh - 8rem);
-    padding: clamp(3rem, 7vw, 7rem) 0 4rem;
+    padding: clamp(2rem, 5vw, 4rem) 0 3rem;
   }
 
   .hero-claim {
@@ -168,11 +172,11 @@
   }
 
   .hero-claim h1 {
-    max-width: 14ch;
+    max-width: 16ch;
     margin: 0.35rem 0 1.25rem;
-    font-size: clamp(3.2rem, 6vw, 6rem);
-    line-height: 0.9;
-    letter-spacing: -0.045em;
+    font-size: clamp(2.8rem, 5.5vw, 4.75rem);
+    line-height: 0.95;
+    letter-spacing: -0.04em;
   }
 
   .hero-claim > p:last-child {
@@ -294,12 +298,16 @@
     color: var(--muted);
   }
 
-  @media (max-width: 64rem) {
+  /* Side-by-side only when claim + chart can coexist without squeezing the hero. */
+  @media (min-width: 72rem) {
     .home-hero {
-      grid-template-areas: "claim" "plot" "actions";
-      grid-template-columns: 1fr;
+      grid-template-areas: "claim plot" "actions plot";
+      grid-template-columns: minmax(16rem, 0.85fr) minmax(0, 1.15fr);
+      gap: 1.25rem clamp(1.5rem, 3vw, 3rem);
     }
+  }
 
+  @media (max-width: 64rem) {
     .home-featured ol {
       grid-template-columns: repeat(2, minmax(0, 1fr));
     }
@@ -307,12 +315,11 @@
 
   @media (max-width: 42rem) {
     .home-hero {
-      min-height: 0;
-      padding-top: 2rem;
+      padding-top: 1.5rem;
     }
 
     .hero-claim h1 {
-      font-size: clamp(2.6rem, 12vw, 4rem);
+      font-size: clamp(2.4rem, 11vw, 3.5rem);
     }
 
     .home-featured {

--- a/scripts/llms-guide-content.ts
+++ b/scripts/llms-guide-content.ts
@@ -32,9 +32,10 @@ same grammar, built up one element at a time on a real dataset — is at
 ## Install
 
 \`\`\`sh complete
-npm install @ggsvelte/svelte
-# or: pnpm add @ggsvelte/svelte
+bun install @ggsvelte/svelte
 # or: bun add @ggsvelte/svelte
+# or: npm install @ggsvelte/svelte
+# or: pnpm add @ggsvelte/svelte
 \`\`\`
 
 \`@ggsvelte/spec\` (schema, validate, builder) and \`@ggsvelte/core\`

--- a/tests/visual/docs-home-gallery.spec.ts
+++ b/tests/visual/docs-home-gallery.spec.ts
@@ -10,13 +10,68 @@ test("homepage first viewport leads with a live chart and two actions", async ({
   await page.setViewportSize({ width: 1280, height: 900 });
   await page.goto("/?theme=light");
   await expect(page.getByRole("heading", { level: 1 })).toHaveText(
-    "An agent-first implementation of the layered grammar of graphics in Svelte 5",
+    "A layered grammar of graphics implemented for agents",
   );
   await expect(page.locator(".home-hero .gg-plot-root")).toBeVisible();
   await expect(page.getByRole("link", { name: "Getting started" })).toBeVisible();
   await expect(page.getByRole("link", { name: "Examples" }).first()).toBeVisible();
   await expect(page.getByRole("button", { name: "Copy install" })).toBeVisible();
   await expectNoOverflow(page);
+});
+
+/**
+ * Narrow-ish desktop (below the wide side-by-side breakpoint): the hero chart
+ * is the product, so it owns a full-width row instead of sharing a horizontal
+ * plane with the claim. Also: the hero must size to content — a viewport-tall
+ * min-height stretched a two-row grid and left a multi-hundred-px void between
+ * claim and install.
+ */
+test("homepage mid-width stacks the hero chart full-width without empty void", async ({ page }) => {
+  await page.setViewportSize({ width: 960, height: 900 });
+  await page.goto("/?theme=light");
+  const metrics = await page.locator(".home-hero").evaluate((hero) => {
+    const claim = hero.querySelector(".hero-claim")!.getBoundingClientRect();
+    const plot = hero.querySelector(".hero-plot")!.getBoundingClientRect();
+    const actions = hero.querySelector(".hero-actions")!.getBoundingClientRect();
+    const box = hero.getBoundingClientRect();
+    return {
+      claimBottom: claim.bottom,
+      claimLeft: claim.left,
+      plotTop: plot.top,
+      plotLeft: plot.left,
+      plotWidth: plot.width,
+      actionsTop: actions.top,
+      heroWidth: box.width,
+      heroHeight: box.height,
+      gapAfterPlot: actions.top - plot.bottom,
+    };
+  });
+  // Chart sits below the claim on its own horizontal plane.
+  expect(metrics.plotTop).toBeGreaterThan(metrics.claimBottom - 1);
+  expect(Math.abs(metrics.plotLeft - metrics.claimLeft)).toBeLessThan(24);
+  expect(metrics.plotWidth / metrics.heroWidth).toBeGreaterThan(0.9);
+  // Install follows the chart tightly — no viewport-filling void.
+  // (Hero height itself can exceed the viewport when claim + 400px plot stack;
+  // the failure mode was empty space between plot and actions, not total height.)
+  expect(metrics.gapAfterPlot).toBeLessThan(64);
+});
+
+/** Wide layout may share a row with claim, but must not invent empty vertical space. */
+test("homepage wide layout keeps install adjacent to claim without hero void", async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await page.goto("/?theme=light");
+  const metrics = await page.locator(".home-hero").evaluate((hero) => {
+    const claim = hero.querySelector(".hero-claim")!.getBoundingClientRect();
+    const actions = hero.querySelector(".hero-actions")!.getBoundingClientRect();
+    return {
+      claimBottom: claim.bottom,
+      actionsTop: actions.top,
+      gapClaimToActions: actions.top - claim.bottom,
+    };
+  });
+  // claim → actions is a short stack on the left; no 100svh stretch between them.
+  expect(metrics.gapClaimToActions).toBeLessThan(96);
+  expect(metrics.actionsTop).toBeGreaterThan(metrics.claimBottom - 1);
 });
 
 test("homepage preserves SSR chart output and hydrates its keyboard interaction", async ({
@@ -90,7 +145,7 @@ test("install copy and code tabs share the manual-copy fallback", async ({ page 
     "Clipboard unavailable. Code selected for manual copy.",
   );
   expect(await page.evaluate(() => getSelection()?.toString())).toContain(
-    "npm install @ggsvelte/svelte",
+    "bun install @ggsvelte/svelte",
   );
   const tabs = page.getByRole("tablist", { name: "Code representations" }).getByRole("tab");
   await expect(tabs.first()).toHaveText("Svelte");

--- a/tests/visual/docs-home-gallery.spec.ts
+++ b/tests/visual/docs-home-gallery.spec.ts
@@ -42,7 +42,6 @@ test("homepage mid-width stacks the hero chart full-width without empty void", a
       plotWidth: plot.width,
       actionsTop: actions.top,
       heroWidth: box.width,
-      heroHeight: box.height,
       gapAfterPlot: actions.top - plot.bottom,
     };
   });


### PR DESCRIPTION
## Summary

- **Root cause:** `.home-hero` used `min-height: calc(100svh - 8rem)` on a two-row grid (`claim | plot` / `actions | plot`). Extra height expanded the rows, so install CTAs sat at the bottom of the viewport with a huge empty white void under the title — worst at mid-width where content was short.
- **Layout:** Stack claim → full-width plot → actions by default; only share a horizontal plane at `min-width: 72rem`. The chart is the hero product, not the typography.
- **Copy:** H1 → “A layered grammar of graphics implemented for agents”.
- **Install:** Home + getting-started + llms agent guide prefer `bun` / `bunx` (npm/pnpm still listed as alternatives where relevant).
- Not a bits-ui migration issue — `UiButton` already wraps bits-ui; this was pure CSS on `+page.svelte`.

## Test plan

- [x] Playwright `docs-home-gallery.spec.ts` (new mid-width stack + no-void assertions, title, bun install)
- [x] `bun test scripts/gen-llms.test.ts scripts/progressive-docs.test.ts`
- [x] Docs production build
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/751" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->