### PR TITLE
fix(docs): homepage copy + inspect-visible code triptych

### DIFF
--- a/apps/docs/src/lib/components/GrammarDemo.svelte
+++ b/apps/docs/src/lib/components/GrammarDemo.svelte
@@ -22,8 +22,7 @@
     <h2 id="grammar-heading">The missing layer.</h2>
     <p>
       Zero D3.js. Built for human-agent teams who want good default chart
-      interactions that just work, instead of endless complexity and
-      footgun-rework loops.
+      interactions that just work.
     </p>
     <ol>
       {#each steps as step, index (step.label)}

--- a/apps/docs/src/lib/home-code-path.ts
+++ b/apps/docs/src/lib/home-code-path.ts
@@ -1,10 +1,18 @@
 /**
  * Home code-path triptych: the same penguins chart as GrammarDemo, shown as
- * Svelte children, the TypeScript builder, and a named-data PortableSpec.
+ * Svelte children, the TypeScript builder, and agent JSON.
  *
  * Hand-authored (not loadExample) so the JSON tab can use data: { name } and
  * never dump every row into a mile-tall panel. Matches the interactive demo
  * above the fold — not the hero Guerry chart.
+ *
+ * Interaction: GrammarDemo step 4 is only `inspect` (nearest-point hover/pin
+ * tooltips). That is a GGPlot host prop — not a PortableSpec field and not a
+ * builder method.
+ * - Svelte / builder: set `inspect` on <GGPlot>
+ * - JSON: agent envelope `{ interactions, spec }` (playground host maps
+ *   interactions onto GGPlot props; bare PortableSpec is also accepted and
+ *   defaults inspect on)
  */
 
 export const HOME_CODE_PATH_SVELTE = `<script lang="ts">
@@ -25,51 +33,65 @@ export const HOME_CODE_PATH_SVELTE = `<script lang="ts">
 </GGPlot>
 `;
 
-export const HOME_CODE_PATH_BUILDER = `import { aes, gg } from "@ggsvelte/spec";
+/** Builder produces PortableSpec; inspect is enabled on the host GGPlot. */
+export const HOME_CODE_PATH_BUILDER = `<script lang="ts">
+  import { aes, gg } from "@ggsvelte/spec";
+  import { GGPlot } from "@ggsvelte/svelte";
 
-import { penguins } from "./penguins.js";
+  import { penguins } from "./penguins.js";
 
-export const spec = gg(
-  penguins,
-  aes({ x: "flipper", y: "mass", color: "species" }),
-)
-  .geomPoint({ alpha: 0.72 })
-  .geomSmooth({ method: "loess", span: 0.75, se: false })
-  .spec();
+  const spec = gg(
+    penguins,
+    aes({ x: "flipper", y: "mass", color: "species" }),
+  )
+    .geomPoint({ alpha: 0.72 })
+    .geomSmooth({ method: "loess", span: 0.75, se: false })
+    .spec();
+</script>
+
+<GGPlot {spec} inspect width={640} height={400} />
 `;
 
-/** Named-data form agents emit when rows are supplied separately at render time. */
+/**
+ * Agent envelope: host interaction flags + named-data PortableSpec.
+ * `spec` alone is valid PortableSpec; interactions are applied by the host.
+ */
 export const HOME_CODE_PATH_SPEC_JSON = `{
-  "edition": 2,
-  "data": { "name": "penguins" },
-  "layers": [
-    {
-      "geom": "point",
-      "stat": "identity",
-      "position": "identity",
-      "aes": {
-        "x": { "field": "flipper" },
-        "y": { "field": "mass" },
-        "color": { "field": "species" }
+  "interactions": {
+    "inspect": true
+  },
+  "spec": {
+    "edition": 2,
+    "data": { "name": "penguins" },
+    "layers": [
+      {
+        "geom": "point",
+        "stat": "identity",
+        "position": "identity",
+        "aes": {
+          "x": { "field": "flipper" },
+          "y": { "field": "mass" },
+          "color": { "field": "species" }
+        },
+        "params": { "alpha": 0.72 }
       },
-      "params": { "alpha": 0.72 }
-    },
-    {
-      "geom": "smooth",
-      "stat": "smooth",
-      "position": "identity",
-      "aes": {
-        "x": { "field": "flipper" },
-        "y": { "field": "mass" },
-        "color": { "field": "species" }
-      },
-      "params": {
-        "method": "loess",
-        "span": 0.75,
-        "se": false
+      {
+        "geom": "smooth",
+        "stat": "smooth",
+        "position": "identity",
+        "aes": {
+          "x": { "field": "flipper" },
+          "y": { "field": "mass" },
+          "color": { "field": "species" }
+        },
+        "params": {
+          "method": "loess",
+          "span": 0.75,
+          "se": false
+        }
       }
-    }
-  ]
+    ]
+  }
 }
 `;
 
@@ -82,7 +104,7 @@ export const HOME_CODE_PATH_TABS: {
   {
     label: "Builder (TS)",
     code: HOME_CODE_PATH_BUILDER,
-    language: "typescript",
+    language: "svelte",
   },
   {
     label: "Spec (JSON)",

--- a/apps/docs/src/routes/+page.svelte
+++ b/apps/docs/src/routes/+page.svelte
@@ -27,9 +27,8 @@
       A layered grammar of graphics implemented for agents
     </h1>
     <p>
-      ggplot2's layered grammar and defaults as Svelte components, a TypeScript
-      builder, and a validated JSON spec agents can write. Inspection,
-      selection, and zoom are part of the spec.
+      Made for human-agent teams building embedded agents who need to make
+      reliable interactive visualizations on-demand.
     </p>
   </div>
 
@@ -96,12 +95,13 @@
 
 <section class="code-path" aria-labelledby="code-path-heading">
   <div>
-    <h2 id="code-path-heading">Svelte for builders, JSON for operations.</h2>
+    <h2 id="code-path-heading">
+      Svelte for builders, JSON for embedded agents.
+    </h2>
     <p>
-      Svelte components help human-agent teams reason about viz work together,
-      thanks to ggplot2 naming conventions that have been around for 18 years.
-      JSON specs allow agents operating in webapps to make interactive charts on
-      demand for rendering on-the-fly.
+      Svelte components help human-agent teams reason about visualizations
+      together. JSON specs allow agents operating in webapps to make interactive
+      charts on demand for rendering on-the-fly.
     </p>
   </div>
   <CodeTabs {tabs} />


### PR DESCRIPTION
## Summary

- Grammar demo: drop “endless complexity and footgun-rework loops.”
- Code-path heading: “JSON for embedded agents”; body uses “visualizations” and drops the 18-year ggplot2 naming aside.
- Hero subtitle: human-agent teams / embedded agents / on-demand interactive viz (replaces the layered-grammar feature dump).
- Code triptych: builder mounts `<GGPlot {spec} inspect />`; JSON uses the agent envelope with `interactions.inspect` so all three tabs show the same interaction surface as GrammarDemo step 4.

## Why the JSON tab looks different from PortableSpec alone

`inspect` is a **GGPlot host prop**, not a PortableSpec field (see playground agent handoff). Step 4 of the penguins demo is only `inspect={true}` — nearest-point hover/pin tooltips. Builder cannot encode it; pure JSON cannot either. The envelope is what the playground host applies as GGPlot props (bare PortableSpec still defaults inspect on).

## Test plan

- [ ] Home: hero subtitle and grammar/code-path copy read as intended
- [ ] Code tabs: Svelte / Builder / Spec (JSON) all show inspect enablement
- [ ] GrammarDemo step 4 still enables hover inspect on the live chart
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/758" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->