### PR TITLE
docs: rewrite README examples with child grammar layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,10 @@ live output and complete source.
     GeomPoint,
     GeomSmooth,
     GGPlot,
-    scaleSizeContinuous,
+    Labs,
+    ScaleSizeContinuous,
+    ScaleXContinuous,
+    ThemeTufte,
   } from "@ggsvelte/svelte";
 
   import { gammaVirginis } from "./data.js";
@@ -43,19 +46,19 @@ live output and complete source.
 <GGPlot
   data={gammaVirginis}
   aes={{ x: "year", y: "angle" }}
-  theme="tufte"
-  scales={{ x: { labels: "d" }, ...scaleSizeContinuous({ range: [3, 8] }) }}
-  labs={{
-    title: "The first scatterplot, redrawn",
-    subtitle:
-      "Herschel plotted γ Virginis in 1833 and fitted the curve by hand",
-    x: "Year",
-    y: "Position angle (°)",
-    size: "Herschel's weight",
-  }}
   width={640}
   height={400}
 >
+  <ThemeTufte />
+  <ScaleXContinuous labels="d" />
+  <ScaleSizeContinuous range={[3, 8]} />
+  <Labs
+    title="The first scatterplot, redrawn"
+    subtitle="Herschel plotted γ Virginis in 1833 and fitted the curve by hand"
+    x="Year"
+    y="Position angle (°)"
+    size="Herschel's weight"
+  />
   <GeomSmooth method="loess" span={0.75} />
   <GeomPoint aes={{ size: "weight" }} alpha={0.85} />
 </GGPlot>
@@ -69,7 +72,14 @@ live output and complete source.
 
 ```svelte
 <script lang="ts">
-  import { GeomArea, GGPlot } from "@ggsvelte/svelte";
+  import {
+    GeomArea,
+    GGPlot,
+    Labs,
+    ScaleFillManual,
+    ScaleXDate,
+    ThemeEconomist,
+  } from "@ggsvelte/svelte";
 
   import { crimeanMortality } from "./data.js";
 </script>
@@ -77,25 +87,22 @@ live output and complete source.
 <GGPlot
   data={crimeanMortality}
   aes={{ x: "month", y: "deaths", fill: "cause" }}
-  theme="economist"
-  scales={{
-    x: { labels: "%b %Y" },
-    fill: {
-      type: "manual",
-      domain: ["Disease", "Wounds", "Other"],
-      range: ["#d14d41", "#014d64", "#4385be"],
-    },
-  }}
-  labs={{
-    title: "Deaths in the Crimea, 1854–56",
-    subtitle: "Annual rate per 1,000 — disease dwarfs combat, then collapses",
-    x: "Month",
-    y: "Deaths per 1,000 per year",
-    fill: "Cause",
-  }}
   width={640}
   height={400}
 >
+  <ThemeEconomist />
+  <ScaleXDate labels="%b %Y" />
+  <ScaleFillManual
+    domain={["Disease", "Wounds", "Other"]}
+    values={["#d14d41", "#014d64", "#4385be"]}
+  />
+  <Labs
+    title="Deaths in the Crimea, 1854–56"
+    subtitle="Annual rate per 1,000 — disease dwarfs combat, then collapses"
+    x="Month"
+    y="Deaths per 1,000 per year"
+    fill="Cause"
+  />
   <GeomArea alpha={0.9} />
 </GGPlot>
 ```
@@ -108,7 +115,13 @@ live output and complete source.
 
 ```svelte
 <script lang="ts">
-  import { GeomDensity, GGPlot } from "@ggsvelte/svelte";
+  import {
+    GeomDensity,
+    GGPlot,
+    Labs,
+    ScaleFillManual,
+    ThemeMinimal,
+  } from "@ggsvelte/svelte";
 
   import { galtonChildren } from "./data.js";
 </script>
@@ -116,24 +129,21 @@ live output and complete source.
 <GGPlot
   data={galtonChildren}
   aes={{ x: "height", fill: "gender" }}
-  theme="minimal"
-  scales={{
-    fill: {
-      type: "manual",
-      domain: ["Daughters", "Sons"],
-      range: ["#8b7ec8", "#3aa99f"],
-    },
-  }}
-  labs={{
-    title: "Heights of Galton's 934 adult children",
-    subtitle: "Two overlapping distributions, separated at the means",
-    x: "Height (inches)",
-    y: "Density",
-    fill: "Child",
-  }}
   width={640}
   height={400}
 >
+  <ThemeMinimal />
+  <ScaleFillManual
+    domain={["Daughters", "Sons"]}
+    values={["#8b7ec8", "#3aa99f"]}
+  />
+  <Labs
+    title="Heights of Galton's 934 adult children"
+    subtitle="Two overlapping distributions, separated at the means"
+    x="Height (inches)"
+    y="Density"
+    fill="Child"
+  />
   <GeomDensity alpha={0.45} />
 </GGPlot>
 ```
@@ -146,7 +156,14 @@ live output and complete source.
 
 ```svelte
 <script lang="ts">
-  import { GeomPoint, GGPlot, scaleXLog10 } from "@ggsvelte/svelte";
+  import {
+    GeomPoint,
+    GGPlot,
+    Labs,
+    ScaleColorManual,
+    ScaleXLog10,
+    ThemeEconomist,
+  } from "@ggsvelte/svelte";
 
   import { londonCholera } from "./data.js";
 </script>
@@ -154,27 +171,24 @@ live output and complete source.
 <GGPlot
   data={londonCholera}
   aes={{ x: "density", y: "deathRate", color: "water" }}
-  theme="economist"
-  scales={{
-    ...scaleXLog10({ labels: "~s" }),
-    color: {
-      type: "manual",
-      domain: ["Battersea", "New River", "Kew"],
-      range: ["#d14d41", "#014d64", "#4385be"],
-    },
-  }}
   key="district"
   inspect={{ mode: "xy", pin: true }}
-  labs={{
-    title: "Cholera, crowding and water in London, 1849",
-    subtitle: "Death rate against population density, by water company",
-    x: "People per acre (log scale)",
-    y: "Cholera deaths per 10,000",
-    color: "Water supply",
-  }}
   width="container"
   height={400}
 >
+  <ThemeEconomist />
+  <ScaleXLog10 labels="~s" />
+  <ScaleColorManual
+    domain={["Battersea", "New River", "Kew"]}
+    values={["#d14d41", "#014d64", "#4385be"]}
+  />
+  <Labs
+    title="Cholera, crowding and water in London, 1849"
+    subtitle="Death rate against population density, by water company"
+    x="People per acre (log scale)"
+    y="Cholera deaths per 10,000"
+    color="Water supply"
+  />
   <GeomPoint size={3.5} />
 </GGPlot>
 ```
@@ -187,7 +201,13 @@ live output and complete source.
 
 ```svelte
 <script lang="ts">
-  import { GeomHistogram, GGPlot } from "@ggsvelte/svelte";
+  import {
+    FacetWrap,
+    GeomHistogram,
+    GGPlot,
+    Labs,
+    ThemeGgplot2,
+  } from "@ggsvelte/svelte";
 
   import { familyHeights } from "./data.js";
 </script>
@@ -195,18 +215,17 @@ live output and complete source.
 <GGPlot
   data={familyHeights}
   aes={{ x: "child", weight: "n" }}
-  theme="ggplot2"
-  facet={{ wrap: "pair", ncol: 2 }}
-  labs={{
-    title: "4,892 English children, measured by Pearson and Lee",
-    subtitle:
-      "Sons stand four and a half inches taller; the two daughter panels are the same girls, tabulated against each parent",
-    x: "Child's height (inches)",
-    y: "Children",
-  }}
   width={640}
   height={400}
 >
+  <ThemeGgplot2 />
+  <FacetWrap field="pair" ncol={2} />
+  <Labs
+    title="4,892 English children, measured by Pearson and Lee"
+    subtitle="Sons stand four and a half inches taller; the two daughter panels are the same girls, tabulated against each parent"
+    x="Child's height (inches)"
+    y="Children"
+  />
   <GeomHistogram bins={18} />
 </GGPlot>
 ```
@@ -219,7 +238,14 @@ live output and complete source.
 
 ```svelte
 <script lang="ts">
-  import { GeomBar, GGPlot } from "@ggsvelte/svelte";
+  import {
+    GeomBar,
+    GGPlot,
+    Labs,
+    ScaleFillManual,
+    ScaleYContinuous,
+    ThemeFivethirtyeight,
+  } from "@ggsvelte/svelte";
 
   import { armadaCrews } from "./data.js";
 </script>
@@ -227,26 +253,22 @@ live output and complete source.
 <GGPlot
   data={armadaCrews}
   aes={{ x: "squadron", fill: "role", weight: "men" }}
-  theme="fivethirtyeight"
-  scales={{
-    y: { labels: ".0%" },
-    fill: {
-      type: "manual",
-      domain: ["Soldiers", "Sailors"],
-      range: ["#c14a3d", "#3c6e8f"],
-    },
-  }}
-  labs={{
-    title: "Who sailed with the Armada, 1588",
-    subtitle:
-      "Soldiers outnumber sailors everywhere except the galleys and the light pataches",
-    x: "Squadron",
-    y: "Share of complement",
-    fill: "Role",
-  }}
   width={640}
   height={400}
 >
+  <ThemeFivethirtyeight />
+  <ScaleYContinuous labels=".0%" />
+  <ScaleFillManual
+    domain={["Soldiers", "Sailors"]}
+    values={["#c14a3d", "#3c6e8f"]}
+  />
+  <Labs
+    title="Who sailed with the Armada, 1588"
+    subtitle="Soldiers outnumber sailors everywhere except the galleys and the light pataches"
+    x="Squadron"
+    y="Share of complement"
+    fill="Role"
+  />
   <GeomBar position="fill" />
 </GGPlot>
 ```
@@ -259,7 +281,14 @@ live output and complete source.
 
 ```svelte
 <script lang="ts">
-  import { GeomPoint, GGPlot, scaleColorContinuous } from "@ggsvelte/svelte";
+  import {
+    CoordFixed,
+    GeomPoint,
+    GGPlot,
+    Labs,
+    ScaleColorContinuous,
+    ThemeDark,
+  } from "@ggsvelte/svelte";
 
   import { greatLakesSurveys, greatLakesTruth } from "./data.js";
 </script>
@@ -267,20 +296,19 @@ live output and complete source.
 <GGPlot
   data={greatLakesSurveys}
   aes={{ x: "long", y: "lat", color: "year" }}
-  theme="dark"
-  coord={{ type: "fixed" }}
-  scales={scaleColorContinuous({ scheme: "viridis", labels: "d" })}
-  labs={{
-    title: "Eleven maps of the Great Lakes, 1688–1818",
-    subtitle:
-      "White crosses are the 39 true positions; each dot is one map's attempt at one of them",
-    x: "Longitude (°)",
-    y: "Latitude (°)",
-    color: "Map year",
-  }}
   width={640}
   height={400}
 >
+  <ThemeDark />
+  <CoordFixed />
+  <ScaleColorContinuous scheme="viridis" labels="d" />
+  <Labs
+    title="Eleven maps of the Great Lakes, 1688–1818"
+    subtitle="White crosses are the 39 true positions; each dot is one map's attempt at one of them"
+    x="Longitude (°)"
+    y="Latitude (°)"
+    color="Map year"
+  />
   <GeomPoint size={2.6} alpha={0.75} />
   <GeomPoint
     data={greatLakesTruth}
@@ -293,11 +321,12 @@ live output and complete source.
 
 [![Eleven old maps of the Great Lakes coloured by publication year against the true positions](apps/docs/static/previews/color-continuous-light.png)](https://ggsvelte.sh/examples/color/continuous)
 
-Guide presentation stays separate from scale math. Use `guides={{ color:
-guideColorbar({ position: "bottom" }) }}` (or fluent `.guides()`) to title,
-orient, place, suppress, or force axes and non-position guides. Automatic legends use
-the right side only while at least 320px of panel remains, then move below with
-complete accessible labels and unchanged scale assignments.
+Guide presentation stays separate from scale math. Use
+`<GuideColorbar channel="color" position="bottom" />` (or
+`<GuideLegend channel="color" position="bottom" />`, `<GuideNone channel="size" />`)
+to title, orient, place, suppress, or force axes and non-position guides. Automatic
+legends use the right side only while at least 320px of panel remains, then move below
+with complete accessible labels and unchanged scale assignments.
 
 ### [Boxplots](https://ggsvelte.sh/examples/boxplot/by-category)
 
@@ -305,7 +334,13 @@ complete accessible labels and unchanged scale assignments.
 
 ```svelte
 <script lang="ts">
-  import { GeomBoxplot, GGPlot } from "@ggsvelte/svelte";
+  import {
+    GeomBoxplot,
+    GGPlot,
+    Labs,
+    ScaleXDiscrete,
+    ThemeFew,
+  } from "@ggsvelte/svelte";
 
   import { michelsonRuns } from "./data.js";
 </script>
@@ -313,18 +348,17 @@ complete accessible labels and unchanged scale assignments.
 <GGPlot
   data={michelsonRuns}
   aes={{ x: "run", y: "velocity" }}
-  theme="few"
-  scales={{ x: { domain: ["Jun 5", "Jun 7", "Jun 9", "Jun 12", "Jul 2"] } }}
-  labs={{
-    title: "Michelson's five runs, 1879",
-    subtitle:
-      "Twenty measurements each — the runs disagree more than the readings within them",
-    x: "Run",
-    y: "Velocity (km/s − 299,000)",
-  }}
   width={640}
   height={400}
 >
+  <ThemeFew />
+  <ScaleXDiscrete domain={["Jun 5", "Jun 7", "Jun 9", "Jun 12", "Jul 2"]} />
+  <Labs
+    title="Michelson's five runs, 1879"
+    subtitle="Twenty measurements each — the runs disagree more than the readings within them"
+    x="Run"
+    y="Velocity (km/s − 299,000)"
+  />
   <GeomBoxplot />
 </GGPlot>
 ```
@@ -337,7 +371,12 @@ complete accessible labels and unchanged scale assignments.
 
 ```svelte
 <script lang="ts">
-  import { GeomLine, GGPlot } from "@ggsvelte/svelte";
+  import {
+    GeomLine,
+    GGPlot,
+    Labs,
+    ThemeFivethirtyeight,
+  } from "@ggsvelte/svelte";
 
   import { britishExports } from "./data.js";
 </script>
@@ -345,16 +384,16 @@ complete accessible labels and unchanged scale assignments.
 <GGPlot
   data={britishExports}
   aes={{ x: "year", y: "value" }}
-  theme="fivethirtyeight"
-  labs={{
-    title: "British and Irish exports, 1855–1899",
-    subtitle: "Raw four-digit strings infer a calendar scale",
-    x: "Year",
-    y: "£ millions",
-  }}
   width="container"
   height={400}
 >
+  <ThemeFivethirtyeight />
+  <Labs
+    title="British and Irish exports, 1855–1899"
+    subtitle="Raw four-digit strings infer a calendar scale"
+    x="Year"
+    y="£ millions"
+  />
   <GeomLine linewidth={1.5} />
 </GGPlot>
 ```
@@ -367,7 +406,14 @@ complete accessible labels and unchanged scale assignments.
 
 ```svelte
 <script lang="ts">
-  import { GeomCol, GeomText, GGPlot } from "@ggsvelte/svelte";
+  import {
+    GeomCol,
+    GeomText,
+    GGPlot,
+    Labs,
+    ScaleXDiscrete,
+    ThemeFivethirtyeight,
+  } from "@ggsvelte/svelte";
 
   import { polioTrial } from "./data.js";
 </script>
@@ -375,17 +421,17 @@ complete accessible labels and unchanged scale assignments.
 <GGPlot
   data={polioTrial}
   aes={{ x: "group", y: "rate" }}
-  theme="fivethirtyeight"
-  scales={{ x: { domain: ["Vaccinated", "Placebo", "Not inoculated"] } }}
-  labs={{
-    title: "The Salk vaccine field trial, 1954",
-    subtitle: "Paralytic polio per 100,000 children in the randomised arm",
-    x: "Group",
-    y: "Cases per 100,000",
-  }}
   width={640}
   height={400}
 >
+  <ThemeFivethirtyeight />
+  <ScaleXDiscrete domain={["Vaccinated", "Placebo", "Not inoculated"]} />
+  <Labs
+    title="The Salk vaccine field trial, 1954"
+    subtitle="Paralytic polio per 100,000 children in the randomised arm"
+    x="Group"
+    y="Cases per 100,000"
+  />
   <GeomCol width={0.7} />
   <GeomText aes={{ label: "label" }} dy={-8} />
 </GGPlot>

--- a/examples/area/stacked/Example.svelte
+++ b/examples/area/stacked/Example.svelte
@@ -1,5 +1,12 @@
 <script lang="ts">
-  import { GeomArea, GGPlot } from "@ggsvelte/svelte";
+  import {
+    GeomArea,
+    GGPlot,
+    Labs,
+    ScaleFillManual,
+    ScaleXDate,
+    ThemeEconomist,
+  } from "@ggsvelte/svelte";
 
   import { crimeanMortality } from "./data.js";
 </script>
@@ -7,24 +14,21 @@
 <GGPlot
   data={crimeanMortality}
   aes={{ x: "month", y: "deaths", fill: "cause" }}
-  theme="economist"
-  scales={{
-    x: { labels: "%b %Y" },
-    fill: {
-      type: "manual",
-      domain: ["Disease", "Wounds", "Other"],
-      range: ["#d14d41", "#014d64", "#4385be"],
-    },
-  }}
-  labs={{
-    title: "Deaths in the Crimea, 1854–56",
-    subtitle: "Annual rate per 1,000 — disease dwarfs combat, then collapses",
-    x: "Month",
-    y: "Deaths per 1,000 per year",
-    fill: "Cause",
-  }}
   width={640}
   height={400}
 >
+  <ThemeEconomist />
+  <ScaleXDate labels="%b %Y" />
+  <ScaleFillManual
+    domain={["Disease", "Wounds", "Other"]}
+    values={["#d14d41", "#014d64", "#4385be"]}
+  />
+  <Labs
+    title="Deaths in the Crimea, 1854–56"
+    subtitle="Annual rate per 1,000 — disease dwarfs combat, then collapses"
+    x="Month"
+    y="Deaths per 1,000 per year"
+    fill="Cause"
+  />
   <GeomArea alpha={0.9} />
 </GGPlot>

--- a/examples/bar/proportions/Example.svelte
+++ b/examples/bar/proportions/Example.svelte
@@ -1,5 +1,12 @@
 <script lang="ts">
-  import { GeomBar, GGPlot } from "@ggsvelte/svelte";
+  import {
+    GeomBar,
+    GGPlot,
+    Labs,
+    ScaleFillManual,
+    ScaleYContinuous,
+    ThemeFivethirtyeight,
+  } from "@ggsvelte/svelte";
 
   import { armadaCrews } from "./data.js";
 </script>
@@ -7,25 +14,21 @@
 <GGPlot
   data={armadaCrews}
   aes={{ x: "squadron", fill: "role", weight: "men" }}
-  theme="fivethirtyeight"
-  scales={{
-    y: { labels: ".0%" },
-    fill: {
-      type: "manual",
-      domain: ["Soldiers", "Sailors"],
-      range: ["#c14a3d", "#3c6e8f"],
-    },
-  }}
-  labs={{
-    title: "Who sailed with the Armada, 1588",
-    subtitle:
-      "Soldiers outnumber sailors everywhere except the galleys and the light pataches",
-    x: "Squadron",
-    y: "Share of complement",
-    fill: "Role",
-  }}
   width={640}
   height={400}
 >
+  <ThemeFivethirtyeight />
+  <ScaleYContinuous labels=".0%" />
+  <ScaleFillManual
+    domain={["Soldiers", "Sailors"]}
+    values={["#c14a3d", "#3c6e8f"]}
+  />
+  <Labs
+    title="Who sailed with the Armada, 1588"
+    subtitle="Soldiers outnumber sailors everywhere except the galleys and the light pataches"
+    x="Squadron"
+    y="Share of complement"
+    fill="Role"
+  />
   <GeomBar position="fill" />
 </GGPlot>

--- a/examples/boxplot/by-category/Example.svelte
+++ b/examples/boxplot/by-category/Example.svelte
@@ -1,5 +1,11 @@
 <script lang="ts">
-  import { GeomBoxplot, GGPlot } from "@ggsvelte/svelte";
+  import {
+    GeomBoxplot,
+    GGPlot,
+    Labs,
+    ScaleXDiscrete,
+    ThemeFew,
+  } from "@ggsvelte/svelte";
 
   import { michelsonRuns } from "./data.js";
 </script>
@@ -7,17 +13,16 @@
 <GGPlot
   data={michelsonRuns}
   aes={{ x: "run", y: "velocity" }}
-  theme="few"
-  scales={{ x: { domain: ["Jun 5", "Jun 7", "Jun 9", "Jun 12", "Jul 2"] } }}
-  labs={{
-    title: "Michelson's five runs, 1879",
-    subtitle:
-      "Twenty measurements each — the runs disagree more than the readings within them",
-    x: "Run",
-    y: "Velocity (km/s − 299,000)",
-  }}
   width={640}
   height={400}
 >
+  <ThemeFew />
+  <ScaleXDiscrete domain={["Jun 5", "Jun 7", "Jun 9", "Jun 12", "Jul 2"]} />
+  <Labs
+    title="Michelson's five runs, 1879"
+    subtitle="Twenty measurements each — the runs disagree more than the readings within them"
+    x="Run"
+    y="Velocity (km/s − 299,000)"
+  />
   <GeomBoxplot />
 </GGPlot>

--- a/examples/col/value-labels/Example.svelte
+++ b/examples/col/value-labels/Example.svelte
@@ -1,5 +1,12 @@
 <script lang="ts">
-  import { GeomCol, GeomText, GGPlot } from "@ggsvelte/svelte";
+  import {
+    GeomCol,
+    GeomText,
+    GGPlot,
+    Labs,
+    ScaleXDiscrete,
+    ThemeFivethirtyeight,
+  } from "@ggsvelte/svelte";
 
   import { polioTrial } from "./data.js";
 </script>
@@ -7,17 +14,17 @@
 <GGPlot
   data={polioTrial}
   aes={{ x: "group", y: "rate" }}
-  theme="fivethirtyeight"
-  scales={{ x: { domain: ["Vaccinated", "Placebo", "Not inoculated"] } }}
-  labs={{
-    title: "The Salk vaccine field trial, 1954",
-    subtitle: "Paralytic polio per 100,000 children in the randomised arm",
-    x: "Group",
-    y: "Cases per 100,000",
-  }}
   width={640}
   height={400}
 >
+  <ThemeFivethirtyeight />
+  <ScaleXDiscrete domain={["Vaccinated", "Placebo", "Not inoculated"]} />
+  <Labs
+    title="The Salk vaccine field trial, 1954"
+    subtitle="Paralytic polio per 100,000 children in the randomised arm"
+    x="Group"
+    y="Cases per 100,000"
+  />
   <GeomCol width={0.7} />
   <GeomText aes={{ label: "label" }} dy={-8} />
 </GGPlot>

--- a/examples/color/continuous/Example.svelte
+++ b/examples/color/continuous/Example.svelte
@@ -1,5 +1,12 @@
 <script lang="ts">
-  import { GeomPoint, GGPlot, scaleColorContinuous } from "@ggsvelte/svelte";
+  import {
+    CoordFixed,
+    GeomPoint,
+    GGPlot,
+    Labs,
+    ScaleColorContinuous,
+    ThemeDark,
+  } from "@ggsvelte/svelte";
 
   import { greatLakesSurveys, greatLakesTruth } from "./data.js";
 </script>
@@ -7,20 +14,19 @@
 <GGPlot
   data={greatLakesSurveys}
   aes={{ x: "long", y: "lat", color: "year" }}
-  theme="dark"
-  coord={{ type: "fixed" }}
-  scales={scaleColorContinuous({ scheme: "viridis", labels: "d" })}
-  labs={{
-    title: "Eleven maps of the Great Lakes, 1688–1818",
-    subtitle:
-      "White crosses are the 39 true positions; each dot is one map's attempt at one of them",
-    x: "Longitude (°)",
-    y: "Latitude (°)",
-    color: "Map year",
-  }}
   width={640}
   height={400}
 >
+  <ThemeDark />
+  <CoordFixed />
+  <ScaleColorContinuous scheme="viridis" labels="d" />
+  <Labs
+    title="Eleven maps of the Great Lakes, 1688–1818"
+    subtitle="White crosses are the 39 true positions; each dot is one map's attempt at one of them"
+    x="Longitude (°)"
+    y="Latitude (°)"
+    color="Map year"
+  />
   <GeomPoint size={2.6} alpha={0.75} />
   <GeomPoint
     data={greatLakesTruth}

--- a/examples/density/overlay/Example.svelte
+++ b/examples/density/overlay/Example.svelte
@@ -1,5 +1,11 @@
 <script lang="ts">
-  import { GeomDensity, GGPlot } from "@ggsvelte/svelte";
+  import {
+    GeomDensity,
+    GGPlot,
+    Labs,
+    ScaleFillManual,
+    ThemeMinimal,
+  } from "@ggsvelte/svelte";
 
   import { galtonChildren } from "./data.js";
 </script>
@@ -7,23 +13,20 @@
 <GGPlot
   data={galtonChildren}
   aes={{ x: "height", fill: "gender" }}
-  theme="minimal"
-  scales={{
-    fill: {
-      type: "manual",
-      domain: ["Daughters", "Sons"],
-      range: ["#8b7ec8", "#3aa99f"],
-    },
-  }}
-  labs={{
-    title: "Heights of Galton's 934 adult children",
-    subtitle: "Two overlapping distributions, separated at the means",
-    x: "Height (inches)",
-    y: "Density",
-    fill: "Child",
-  }}
   width={640}
   height={400}
 >
+  <ThemeMinimal />
+  <ScaleFillManual
+    domain={["Daughters", "Sons"]}
+    values={["#8b7ec8", "#3aa99f"]}
+  />
+  <Labs
+    title="Heights of Galton's 934 adult children"
+    subtitle="Two overlapping distributions, separated at the means"
+    x="Height (inches)"
+    y="Density"
+    fill="Child"
+  />
   <GeomDensity alpha={0.45} />
 </GGPlot>

--- a/examples/facet/wrap/Example.svelte
+++ b/examples/facet/wrap/Example.svelte
@@ -1,5 +1,11 @@
 <script lang="ts">
-  import { GeomHistogram, GGPlot } from "@ggsvelte/svelte";
+  import {
+    FacetWrap,
+    GeomHistogram,
+    GGPlot,
+    Labs,
+    ThemeGgplot2,
+  } from "@ggsvelte/svelte";
 
   import { familyHeights } from "./data.js";
 </script>
@@ -7,17 +13,16 @@
 <GGPlot
   data={familyHeights}
   aes={{ x: "child", weight: "n" }}
-  theme="ggplot2"
-  facet={{ wrap: "pair", ncol: 2 }}
-  labs={{
-    title: "4,892 English children, measured by Pearson and Lee",
-    subtitle:
-      "Sons stand four and a half inches taller; the two daughter panels are the same girls, tabulated against each parent",
-    x: "Child's height (inches)",
-    y: "Children",
-  }}
   width={640}
   height={400}
 >
+  <ThemeGgplot2 />
+  <FacetWrap field="pair" ncol={2} />
+  <Labs
+    title="4,892 English children, measured by Pearson and Lee"
+    subtitle="Sons stand four and a half inches taller; the two daughter panels are the same girls, tabulated against each parent"
+    x="Child's height (inches)"
+    y="Children"
+  />
   <GeomHistogram bins={18} />
 </GGPlot>

--- a/examples/line/time-axis/Example.svelte
+++ b/examples/line/time-axis/Example.svelte
@@ -1,5 +1,10 @@
 <script lang="ts">
-  import { GeomLine, GGPlot } from "@ggsvelte/svelte";
+  import {
+    GeomLine,
+    GGPlot,
+    Labs,
+    ThemeFivethirtyeight,
+  } from "@ggsvelte/svelte";
 
   import { britishExports } from "./data.js";
 </script>
@@ -7,15 +12,15 @@
 <GGPlot
   data={britishExports}
   aes={{ x: "year", y: "value" }}
-  theme="fivethirtyeight"
-  labs={{
-    title: "British and Irish exports, 1855–1899",
-    subtitle: "Raw four-digit strings infer a calendar scale",
-    x: "Year",
-    y: "£ millions",
-  }}
   width="container"
   height={400}
 >
+  <ThemeFivethirtyeight />
+  <Labs
+    title="British and Irish exports, 1855–1899"
+    subtitle="Raw four-digit strings infer a calendar scale"
+    x="Year"
+    y="£ millions"
+  />
   <GeomLine linewidth={1.5} />
 </GGPlot>

--- a/examples/point/log-scale/Example.svelte
+++ b/examples/point/log-scale/Example.svelte
@@ -1,5 +1,12 @@
 <script lang="ts">
-  import { GeomPoint, GGPlot, scaleXLog10 } from "@ggsvelte/svelte";
+  import {
+    GeomPoint,
+    GGPlot,
+    Labs,
+    ScaleColorManual,
+    ScaleXLog10,
+    ThemeEconomist,
+  } from "@ggsvelte/svelte";
 
   import { londonCholera } from "./data.js";
 </script>
@@ -7,26 +14,23 @@
 <GGPlot
   data={londonCholera}
   aes={{ x: "density", y: "deathRate", color: "water" }}
-  theme="economist"
-  scales={{
-    ...scaleXLog10({ labels: "~s" }),
-    color: {
-      type: "manual",
-      domain: ["Battersea", "New River", "Kew"],
-      range: ["#d14d41", "#014d64", "#4385be"],
-    },
-  }}
   key="district"
   inspect={{ mode: "xy", pin: true }}
-  labs={{
-    title: "Cholera, crowding and water in London, 1849",
-    subtitle: "Death rate against population density, by water company",
-    x: "People per acre (log scale)",
-    y: "Cholera deaths per 10,000",
-    color: "Water supply",
-  }}
   width="container"
   height={400}
 >
+  <ThemeEconomist />
+  <ScaleXLog10 labels="~s" />
+  <ScaleColorManual
+    domain={["Battersea", "New River", "Kew"]}
+    values={["#d14d41", "#014d64", "#4385be"]}
+  />
+  <Labs
+    title="Cholera, crowding and water in London, 1849"
+    subtitle="Death rate against population density, by water company"
+    x="People per acre (log scale)"
+    y="Cholera deaths per 10,000"
+    color="Water supply"
+  />
   <GeomPoint size={3.5} />
 </GGPlot>

--- a/examples/smooth/loess-scatter/Example.svelte
+++ b/examples/smooth/loess-scatter/Example.svelte
@@ -3,7 +3,10 @@
     GeomPoint,
     GeomSmooth,
     GGPlot,
-    scaleSizeContinuous,
+    Labs,
+    ScaleSizeContinuous,
+    ScaleXContinuous,
+    ThemeTufte,
   } from "@ggsvelte/svelte";
 
   import { gammaVirginis } from "./data.js";
@@ -12,19 +15,19 @@
 <GGPlot
   data={gammaVirginis}
   aes={{ x: "year", y: "angle" }}
-  theme="tufte"
-  scales={{ x: { labels: "d" }, ...scaleSizeContinuous({ range: [3, 8] }) }}
-  labs={{
-    title: "The first scatterplot, redrawn",
-    subtitle:
-      "Herschel plotted γ Virginis in 1833 and fitted the curve by hand",
-    x: "Year",
-    y: "Position angle (°)",
-    size: "Herschel's weight",
-  }}
   width={640}
   height={400}
 >
+  <ThemeTufte />
+  <ScaleXContinuous labels="d" />
+  <ScaleSizeContinuous range={[3, 8]} />
+  <Labs
+    title="The first scatterplot, redrawn"
+    subtitle="Herschel plotted γ Virginis in 1833 and fitted the curve by hand"
+    x="Year"
+    y="Position angle (°)"
+    size="Herschel's weight"
+  />
   <GeomSmooth method="loess" span={0.75} />
   <GeomPoint aes={{ size: "weight" }} alpha={0.85} />
 </GGPlot>

--- a/scripts/example-theme-parity.test.ts
+++ b/scripts/example-theme-parity.test.ts
@@ -46,9 +46,23 @@ const THEME_SHELL: Readonly<Record<string, string>> = {
 };
 
 const ANY_THEME_SHELL = new RegExp(`<(?:${Object.values(THEME_SHELL).join("|")})\\b`, "g");
+/**
+ * Generic `<Theme …>` shell only. `<Theme\b` does not match `ThemeDark` etc.
+ * because the next character after `Theme` is still a word char (no boundary).
+ */
+const ANY_GENERIC_THEME = /<Theme\b/g;
 
 function countMatches(source: string, pattern: RegExp): number {
   return source.match(pattern)?.length ?? 0;
+}
+
+/** Every theme declaration form (prop, named shell, or generic `<Theme name>`). */
+function totalThemeDeclarations(source: string): number {
+  return (
+    countMatches(source, ANY_THEME_PROP) +
+    countMatches(source, ANY_THEME_SHELL) +
+    countMatches(source, ANY_GENERIC_THEME)
+  );
 }
 
 /** Count how many times `theme` is declared on hand-written plots (prop or child). */
@@ -80,8 +94,7 @@ describe("example theme parity (spec.ts vs Example.svelte)", () => {
       if (theme === undefined) {
         // No theme in the spec means the renderer resolves the built-in
         // default; the component must not quietly assert something else.
-        expect(countMatches(source, ANY_THEME_PROP)).toBe(0);
-        expect(countMatches(source, ANY_THEME_SHELL)).toBe(0);
+        expect(totalThemeDeclarations(source)).toBe(0);
         return;
       }
 
@@ -97,11 +110,10 @@ describe("example theme parity (spec.ts vs Example.svelte)", () => {
       }
 
       // Every hand-written <GGPlot> must name the spec's theme (prop or child),
-      // and no plot may carry a theme the spec does not declare.
+      // and no plot may carry a theme the spec does not declare. Both counters
+      // include prop / named shell / generic `<Theme name="…">` so they agree.
       expect(themeDeclarations(source, theme)).toBe(handWritten);
-      expect(countMatches(source, ANY_THEME_PROP) + countMatches(source, ANY_THEME_SHELL)).toBe(
-        handWritten,
-      );
+      expect(totalThemeDeclarations(source)).toBe(handWritten);
     });
   }
 });

--- a/scripts/example-theme-parity.test.ts
+++ b/scripts/example-theme-parity.test.ts
@@ -9,6 +9,9 @@
  *
  * So the duplication is allowed, but it is not allowed to disagree. Guard for
  * #656, which is the first change to make theme load-bearing in examples/**.
+ *
+ * Theme may be declared either as the deprecated `theme="…"` GGPlot prop or as
+ * a declaration-only child (`<ThemeDark />`, `<Theme name="dark" />`, …).
  */
 import { describe, expect, it } from "bun:test";
 import { readFileSync } from "node:fs";
@@ -26,8 +29,35 @@ const PASSTHROUGH = /<GGPlot\b[^>]*\{spec\}/g;
 const GGPLOT_TAG = /<GGPlot\b/g;
 const ANY_THEME_PROP = /\btheme=/g;
 
+/** Named theme shells exported from `@ggsvelte/svelte` (ThemeName → component). */
+const THEME_SHELL: Readonly<Record<string, string>> = {
+  default: "ThemeDefault",
+  light: "ThemeLight",
+  dark: "ThemeDark",
+  minimal: "ThemeMinimal",
+  ggplot2: "ThemeGgplot2",
+  classic: "ThemeClassic",
+  hrbr: "ThemeHrbr",
+  few: "ThemeFew",
+  clean: "ThemeClean",
+  fivethirtyeight: "ThemeFivethirtyeight",
+  economist: "ThemeEconomist",
+  tufte: "ThemeTufte",
+};
+
+const ANY_THEME_SHELL = new RegExp(`<(?:${Object.values(THEME_SHELL).join("|")})\\b`, "g");
+
 function countMatches(source: string, pattern: RegExp): number {
   return source.match(pattern)?.length ?? 0;
+}
+
+/** Count how many times `theme` is declared on hand-written plots (prop or child). */
+function themeDeclarations(source: string, theme: string): number {
+  const shell = THEME_SHELL[theme];
+  const propForm = countMatches(source, new RegExp(`\\btheme="${theme}"`, "g"));
+  const shellForm = shell === undefined ? 0 : countMatches(source, new RegExp(`<${shell}\\b`, "g"));
+  const genericForm = countMatches(source, new RegExp(`<Theme\\b[^>]*\\bname="${theme}"`, "g"));
+  return propForm + shellForm + genericForm;
 }
 
 async function loadSpec(id: string): Promise<PortableSpec> {
@@ -51,6 +81,7 @@ describe("example theme parity (spec.ts vs Example.svelte)", () => {
         // No theme in the spec means the renderer resolves the built-in
         // default; the component must not quietly assert something else.
         expect(countMatches(source, ANY_THEME_PROP)).toBe(0);
+        expect(countMatches(source, ANY_THEME_SHELL)).toBe(0);
         return;
       }
 
@@ -65,10 +96,12 @@ describe("example theme parity (spec.ts vs Example.svelte)", () => {
         return;
       }
 
-      // Every hand-written <GGPlot> must name the spec's theme, and no plot may
-      // carry a theme the spec does not declare.
-      expect(countMatches(source, new RegExp(`\\btheme="${theme}"`, "g"))).toBe(handWritten);
-      expect(countMatches(source, ANY_THEME_PROP)).toBe(handWritten);
+      // Every hand-written <GGPlot> must name the spec's theme (prop or child),
+      // and no plot may carry a theme the spec does not declare.
+      expect(themeDeclarations(source, theme)).toBe(handWritten);
+      expect(countMatches(source, ANY_THEME_PROP) + countMatches(source, ANY_THEME_SHELL)).toBe(
+        handWritten,
+      );
     });
   }
 });


### PR DESCRIPTION
## Summary
- Convert every root README showcase example from deprecated GGPlot props (`theme`, `scales`, `labs`, `facet`, `coord`) to declaration-only child components (`Theme*`, `Scale*`, `Labs`, `FacetWrap`, `CoordFixed`).
- Keep `examples/**/Example.svelte` identical to the README fences (enforced by `readme-showcase`).
- Teach `example-theme-parity` to accept named theme shells as well as `theme="…"` so gallery/spec parity still holds.

## Test plan
- [x] `bun test scripts/readme-showcase.test.ts scripts/example-theme-parity.test.ts`
- [ ] Spot-check gallery pages for the 10 showcased examples still render
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/762" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->