### PR TITLE
fix: related examples for exposition aliases after #760

### DIFF
--- a/apps/docs/src/lib/gallery-filter.ts
+++ b/apps/docs/src/lib/gallery-filter.ts
@@ -80,19 +80,31 @@ export function serializeGalleryFilter(
   return next;
 }
 
+/** Minimal seed for ranking when the current page is not itself a candidate. */
+export type RelatedSeed = Pick<GalleryEntry, "id" | "category" | "tags">;
+
+/**
+ * Rank related gallery cards for a detail page.
+ *
+ * `entries` is the candidate pool (usually `galleryCatalog`). When the current
+ * page is outside that pool — e.g. an interaction exposition still rendered at
+ * its old `/examples/interaction/*` alias — pass `seed` from the manifest so
+ * category/tag overlap still yields gallery neighbours instead of an empty list.
+ */
 export function rankRelatedExamples(
   currentId: string,
   entries: readonly GalleryEntry[],
   limit = 3,
+  seed?: RelatedSeed,
 ): GalleryEntry[] {
-  const current = entries.find((entry) => entry.id === currentId);
+  const current = seed ?? entries.find((entry) => entry.id === currentId);
   if (current === undefined || limit <= 0) return [];
   const ranked = entries
     .map((entry, index) => ({
       entry,
       index,
       score:
-        entry.id === currentId
+        entry.id === current.id
           ? -1
           : (entry.category === current.category ? 2 : 0) +
             entry.tags.filter((tag) => current.tags.includes(tag)).length,

--- a/apps/docs/src/routes/examples/[category]/[name]/+page.svelte
+++ b/apps/docs/src/routes/examples/[category]/[name]/+page.svelte
@@ -13,8 +13,10 @@
   const frameWidth = $derived(data.entry.vrWidth ?? 640);
   const frameHeight = $derived(data.entry.vrHeight ?? 400);
   const galleryEntries = galleryCatalog(EXAMPLES);
+  // Seed from the page entry so exposition aliases (outside galleryCatalog)
+  // still get gallery neighbours instead of an empty "More examples" section.
   const related = $derived(
-    rankRelatedExamples(data.entry.id, galleryEntries, 3),
+    rankRelatedExamples(data.entry.id, galleryEntries, 3, data.entry),
   );
   const tabs = $derived([
     { label: "Svelte", code: data.svelteSource, language: "svelte" },
@@ -119,32 +121,34 @@
     {/if}
   </section>
 
-  <section class="example-prose related" aria-labelledby="related-heading">
-    <div class="section-heading">
-      <div>
-        <p class="eyebrow">Related</p>
-        <h2 id="related-heading">More examples</h2>
+  {#if related.length > 0}
+    <section class="example-prose related" aria-labelledby="related-heading">
+      <div class="section-heading">
+        <div>
+          <p class="eyebrow">Related</p>
+          <h2 id="related-heading">More examples</h2>
+        </div>
+        <a href={`${base}/examples`}>All {galleryEntries.length}</a>
       </div>
-      <a href={`${base}/examples`}>All {galleryEntries.length}</a>
-    </div>
-    <ul>
-      {#each related as entry (entry.id)}
-        <li>
-          <a href={`${base}/examples/${entry.id}`} aria-label={entry.title}>
-            <div class="preview-paper">
-              <img
-                src={`${base}${entry.previewPath}`}
-                alt=""
-                width="640"
-                height={entry.vrHeight ?? 400}
-                loading="lazy"
-              />
-            </div>
-          </a>
-        </li>
-      {/each}
-    </ul>
-  </section>
+      <ul>
+        {#each related as entry (entry.id)}
+          <li>
+            <a href={`${base}/examples/${entry.id}`} aria-label={entry.title}>
+              <div class="preview-paper">
+                <img
+                  src={`${base}${entry.previewPath}`}
+                  alt=""
+                  width="640"
+                  height={entry.vrHeight ?? 400}
+                  loading="lazy"
+                />
+              </div>
+            </a>
+          </li>
+        {/each}
+      </ul>
+    </section>
+  {/if}
 </article>
 
 <style>

--- a/scripts/gallery.test.ts
+++ b/scripts/gallery.test.ts
@@ -95,6 +95,7 @@ describe("gallery filter URL contract", () => {
 
 describe("related example ranking", () => {
   const entries: GalleryEntry[] = EXAMPLES.map((entry) => galleryEntryFor(entry));
+  const catalog = galleryCatalog(EXAMPLES);
 
   test("excludes self, ranks overlap, uses manifest ties, and caps output", () => {
     const related = rankRelatedExamples("bar/stacked", entries, 3);
@@ -111,5 +112,23 @@ describe("related example ranking", () => {
     expect(
       rankRelatedExamples(synthetic.at(-1)!.id, synthetic, 2).map((entry) => entry.id),
     ).toEqual([synthetic[0]!.id, synthetic[1]!.id]);
+  });
+
+  test("without a seed, id outside the candidate catalog returns empty", () => {
+    // Exposition aliases use galleryCatalog (excludes expositions) as candidates.
+    expect(rankRelatedExamples("interaction/linked-views", catalog, 3)).toEqual([]);
+  });
+
+  test("with a seed outside the catalog, ranks gallery neighbours by category/tags", () => {
+    // Old /examples/interaction/* alias pages still render the shared template;
+    // their id is not in galleryCatalog, so ranking needs the manifest seed.
+    const seed = EXAMPLES.find((entry) => entry.id === "interaction/linked-views");
+    expect(seed).toBeDefined();
+    const related = rankRelatedExamples(seed!.id, catalog, 3, seed);
+    expect(related).toHaveLength(3);
+    expect(related.every((entry) => entry.id !== seed!.id)).toBe(true);
+    expect(related.every((entry) => catalog.some((c) => c.id === entry.id))).toBe(true);
+    // Prefer remaining gallery interaction examples over unrelated families.
+    expect(related[0]?.category).toBe("interaction");
   });
 });


### PR DESCRIPTION
## Summary

Follow-up for unrebutted post-merge Devin finding on #760:

> Relocated interaction demos show an empty "More examples" section on their old addresses

`galleryCatalog` correctly excludes interaction expositions from the public gallery. The shared example detail template still renders those pages at `/examples/interaction/*` (SEO aliases). `rankRelatedExamples` required the seed id to be present in the candidate list, so alias pages always got `related = []` while still rendering the "More examples" heading.

### Fix

1. Optional `seed` on `rankRelatedExamples` so a page outside the catalog still ranks gallery neighbours by category/tags.
2. Example detail page passes `data.entry` as seed.
3. Hide the related section when the list is empty (belt-and-suspenders).

## Test plan

- [x] `bun test scripts/gallery.test.ts` — new cases for outside-catalog seed / empty without seed
- [ ] CI green
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/764" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->