### PR TITLE
fix(docs): smoother homepage loess + exact inspect (no path x-guide)

### DIFF
--- a/apps/docs/src/lib/components/GrammarDemo.svelte
+++ b/apps/docs/src/lib/components/GrammarDemo.svelte
@@ -41,6 +41,12 @@
     </ol>
   </div>
   <div class="grammar-output">
+    <!--
+      Exact inspect (not auto/x): smooth layers auto-mode to "x" and draw a
+      vertical guide that steals hits from points. Homepage needs point
+      tooltips only. degree 1 + wider span: specimen has ~10 rows/species;
+      default degree-2 loess at span 0.75 overfits and looks jagged.
+    -->
     <GGPlot
       data={penguins}
       aes={{
@@ -48,12 +54,16 @@
         y: "mass",
         ...(active >= 1 && { color: "species" }),
       }}
-      inspect={active >= 3}
+      inspect={active >= 3
+        ? { mode: "exact", pin: true, maxDistance: 24 }
+        : false}
       theme={chartTheme}
       ariaLabel="Penguin mass increases with flipper length, grouped by species"
     >
       <GeomPoint alpha={0.72} />
-      {#if active >= 2}<GeomSmooth method="loess" span={0.75} se={false} />{/if}
+      {#if active >= 2}
+        <GeomSmooth method="loess" span={0.9} degree={1} se={false} />
+      {/if}
     </GGPlot>
   </div>
 </section>

--- a/apps/docs/src/lib/home-code-path.ts
+++ b/apps/docs/src/lib/home-code-path.ts
@@ -6,13 +6,16 @@
  * never dump every row into a mile-tall panel. Matches the interactive demo
  * above the fold — not the hero Guerry chart.
  *
- * Interaction: GrammarDemo step 4 is only `inspect` (nearest-point hover/pin
- * tooltips). That is a GGPlot host prop — not a PortableSpec field and not a
- * builder method.
+ * Interaction: GrammarDemo step 4 uses exact inspect (nearest-point hover/pin
+ * tooltips, no vertical axis guide). That is a GGPlot host prop — not a
+ * PortableSpec field and not a builder method.
  * - Svelte / builder: set `inspect` on <GGPlot>
  * - JSON: agent envelope `{ interactions, spec }` (playground host maps
  *   interactions onto GGPlot props; bare PortableSpec is also accepted and
  *   defaults inspect on)
+ *
+ * Smooth params: local-linear loess (degree 1, span 0.9). The specimen has
+ * ~10 rows per species; default degree-2 / span 0.75 overfits and jaggeds.
  */
 
 export const HOME_CODE_PATH_SVELTE = `<script lang="ts">
@@ -24,12 +27,12 @@ export const HOME_CODE_PATH_SVELTE = `<script lang="ts">
 <GGPlot
   data={penguins}
   aes={{ x: "flipper", y: "mass", color: "species" }}
-  inspect
+  inspect={{ mode: "exact", pin: true, maxDistance: 24 }}
   width={640}
   height={400}
 >
   <GeomPoint alpha={0.72} />
-  <GeomSmooth method="loess" span={0.75} se={false} />
+  <GeomSmooth method="loess" span={0.9} degree={1} se={false} />
 </GGPlot>
 `;
 
@@ -45,16 +48,23 @@ export const HOME_CODE_PATH_BUILDER = `<script lang="ts">
     aes({ x: "flipper", y: "mass", color: "species" }),
   )
     .geomPoint({ alpha: 0.72 })
-    .geomSmooth({ method: "loess", span: 0.75, se: false })
+    .geomSmooth({ method: "loess", span: 0.9, degree: 1, se: false })
     .spec();
 </script>
 
-<GGPlot {spec} inspect width={640} height={400} />
+<GGPlot
+  {spec}
+  inspect={{ mode: "exact", pin: true, maxDistance: 24 }}
+  width={640}
+  height={400}
+/>
 `;
 
 /**
  * Agent envelope: host interaction flags + named-data PortableSpec.
  * `spec` alone is valid PortableSpec; interactions are applied by the host.
+ * `inspect: true` still defaults mode "auto" (path layers use x-crosshair);
+ * the homepage host opts into exact via the Svelte/builder tabs above.
  */
 export const HOME_CODE_PATH_SPEC_JSON = `{
   "interactions": {
@@ -86,7 +96,8 @@ export const HOME_CODE_PATH_SPEC_JSON = `{
         },
         "params": {
           "method": "loess",
-          "span": 0.75,
+          "span": 0.9,
+          "degree": 1,
           "se": false
         }
       }

--- a/tests/visual/docs-home-gallery.spec.ts
+++ b/tests/visual/docs-home-gallery.spec.ts
@@ -153,6 +153,27 @@ test("homepage grammar steps change real chart structure in place", async ({ pag
   await expect(output.locator(".gg-paths")).toHaveCount(1);
 });
 
+test("homepage grammar inspect is exact: point tooltip, no path x-crosshair", async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 900 });
+  await page.goto("/?theme=dark");
+  const output = page.locator(".grammar-output");
+  await expect(output.locator(".gg-plot-root")).toHaveAttribute("data-gg-ready", "true");
+  // Step 4 (Interaction) is the default open step.
+  await expect(output.locator(".gg-capture")).toBeVisible();
+
+  const capture = output.locator(".gg-capture");
+  await capture.focus();
+  await capture.press("ArrowRight");
+  const tooltip = output.locator(".gg-tooltip");
+  await expect(tooltip).toBeVisible();
+  // Species is carried on identity points; blank "-" means we hit the smooth
+  // path under auto mode "x" instead of a point.
+  await expect(tooltip.getByText("species")).toBeVisible();
+  await expect(tooltip.getByText("-")).toHaveCount(0);
+  // Exact mode: no full-panel vertical guide from path auto-mode "x".
+  await expect(output.locator(".gg-crosshair")).toHaveCount(0);
+});
+
 test("homepage mobile order is claim, specimen, then install", async ({ page }) => {
   await page.setViewportSize({ width: 375, height: 812 });
   await page.goto("/?theme=light");


### PR DESCRIPTION
## Summary

Homepage GrammarDemo penguins chart (point + smooth + inspect):

1. **Jagged smooth lines** — specimen has ~10 rows/species; default loess `degree: 2` + `span: 0.75` overfits (measured max step jump ~1000+ vs ~30 with local-linear). Switched to `degree={1} span={0.9}`.
2. **Vertical guide + blank species** — `inspect` boolean defaults to mode `"auto"`; path/smooth candidates use auto-mode `"x"`, which draws a full-panel crosshair and wins over nearby points so tooltips show `species: -`. Homepage now uses `inspect={{ mode: "exact", pin: true, maxDistance: 24 }}` (same pattern as the Guerry hero).

Mirrored in the home code-path triptych strings. Journey test covers exact inspect (species present, no `.gg-crosshair`).

## Durable follow-up

Filed **#770** — path/smooth x-crosshair steals hits from co-layered points under auto inspect. Homepage is a local opt-out only.

## Test plan

- [ ] Open `/` → grammar demo step 4: smooth lines look less jagged (no wild Gentoo/Adelie wiggles)
- [ ] Hover/keyboard inspect: tooltip shows a real species, not `-`
- [ ] No vertical crosshair line across the panel
- [ ] Clicking near/on points focuses points; trends are decoration only for hit targets in this demo
- [ ] Code-path triptych Svelte tab shows `mode: "exact"` and the new smooth params
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/771" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->