### PR TITLE
fix: codemod ignores Object.prototype attribute names (#761)

### DIFF
--- a/packages/svelte/src/lib/codemod/migrate-plot-props.ts
+++ b/packages/svelte/src/lib/codemod/migrate-plot-props.ts
@@ -441,7 +441,10 @@ export function migratePlotProps(source: string, options: MigrateOptions = {}): 
         previousEnd = attributeEnd;
         continue;
       }
-      const rule = RULES[name];
+      // Own keys only — plain RULES[name] walks Object.prototype and would
+      // treat constructor/toString/… as migratable (truthy functions), then
+      // emit <undefined …/> and an import of undefined under --write.
+      const rule = Object.hasOwn(RULES, name) ? RULES[name] : undefined;
       if (rule === undefined) {
         previousEnd = attributeEnd;
         continue;

--- a/packages/svelte/tests/codemod/migrate-plot-props.ssr.test.ts
+++ b/packages/svelte/tests/codemod/migrate-plot-props.ssr.test.ts
@@ -268,6 +268,21 @@ describe("migratePlotProps — element surgery", () => {
   });
 });
 
+describe("migratePlotProps — ignores non-rule attribute names", () => {
+  it("does not treat Object.prototype members as migratable props", () => {
+    // RULES is a plain object; RULES[name] without hasOwn walks the prototype
+    // and would treat constructor/toString/valueOf as "rules" with undefined
+    // form/component, corrupting the rewrite and import list.
+    const before = plot("<GGPlot data={rows} constructor={oops} toString={nope}>");
+    const result = migratePlotProps(before);
+
+    expect(result.code).toBe(before);
+    expect(result.changes).toEqual([]);
+    expect(result.code).not.toContain("<undefined");
+    expect(result.code).not.toMatch(/import \{[^}]*undefined/);
+  });
+});
+
 describe("migratePlotProps — ADR 0013 acceptance criteria", () => {
   const messy = [
     '<script lang="ts">',


### PR DESCRIPTION
## Summary

Follow-up for unrebutted post-merge Devin finding on #761:

> Plot attributes named after built-in object members produce corrupted rewrites

`RULES[name]` on a plain object walks the prototype chain. Names like `constructor` / `toString` returned truthy functions, so the `=== undefined` skip failed and the codemod emitted broken markup and imports under `--write`.

### Fix

- Look up rules with `Object.hasOwn(RULES, name)`
- SSR test covering `constructor` / `toString` attributes must leave the file untouched

## Test plan

- [x] `cd packages/svelte && bun run test:ssr -- tests/codemod/migrate-plot-props.ssr.test.ts`
- [ ] CI green
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/772" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->