### PR TITLE
test(docs): pin gallery filter journey to catalog haystack (#773)

### DIFF
--- a/apps/docs/src/lib/gallery-filter-journey.ts
+++ b/apps/docs/src/lib/gallery-filter-journey.ts
@@ -1,0 +1,13 @@
+/**
+ * Contract for the gallery URL-filter journey
+ * (`tests/visual/docs-home-gallery.spec.ts`).
+ *
+ * Query/category must hit the live gallery haystack (id, title, tags,
+ * docsSection, category) — not chart Labs copy and not meta descriptions
+ * (deleted corpus-wide in #765; see #773 / #767).
+ *
+ * Unit tests import the same constants so a drift between the journey and the
+ * catalog fails at `bun test` speed instead of only on component-journeys.
+ */
+export const GALLERY_FILTER_JOURNEY_QUERY = "scatter";
+export const GALLERY_FILTER_JOURNEY_CATEGORY = "bar";

--- a/scripts/gallery.test.ts
+++ b/scripts/gallery.test.ts
@@ -8,6 +8,10 @@ import {
   type GalleryEntry,
 } from "../apps/docs/src/lib/catalog/gallery.js";
 import {
+  GALLERY_FILTER_JOURNEY_CATEGORY,
+  GALLERY_FILTER_JOURNEY_QUERY,
+} from "../apps/docs/src/lib/gallery-filter-journey.js";
+import {
   filterGallery,
   parseGalleryFilter,
   rankRelatedExamples,
@@ -51,7 +55,9 @@ describe("gallery filter URL contract", () => {
     expect(filterGallery(entries, { query: "", categories: [], tags: [] })).toEqual(entries);
   });
 
-  test("searches manifest titles, descriptions, and tags", () => {
+  test("searches manifest id, title, tags, and docsSection (not Labs copy)", () => {
+    // Descriptions were emptied corpus-wide (#765); filter still accepts the
+    // field but journey terms must match non-description haystack.
     const curated = filterGallery(entries, {
       query: "multi-series line",
       categories: [],
@@ -70,6 +76,31 @@ describe("gallery filter URL contract", () => {
     expect(result.every((entry) => entry.category === "bar" && entry.tags.includes("fill"))).toBe(
       true,
     );
+  });
+
+  test("URL-filter journey query and category stay findable on the public gallery", () => {
+    // Shared with docs-home-gallery.spec.ts so a #765-style content deletion
+    // fails here instead of only on the required component-journeys job (#773).
+    const catalog = galleryCatalog(EXAMPLES);
+    const byQuery = filterGallery(catalog, {
+      query: GALLERY_FILTER_JOURNEY_QUERY,
+      categories: [],
+      tags: [],
+    });
+    expect(byQuery.length).toBeGreaterThan(0);
+    expect(catalog.some((entry) => entry.category === GALLERY_FILTER_JOURNEY_CATEGORY)).toBe(true);
+  });
+
+  test("every gallery entry is reachable via its own name fragment", () => {
+    const catalog = galleryCatalog(EXAMPLES);
+    for (const entry of catalog) {
+      const hits = filterGallery(catalog, {
+        query: entry.name,
+        categories: [],
+        tags: [],
+      });
+      expect(hits.some((hit) => hit.id === entry.id)).toBe(true);
+    }
   });
 
   test("round-trips deterministic gallery keys while preserving unrelated query params", () => {

--- a/tests/visual/docs-home-gallery.spec.ts
+++ b/tests/visual/docs-home-gallery.spec.ts
@@ -1,5 +1,10 @@
 import { expect, test } from "@playwright/test";
 
+import {
+  GALLERY_FILTER_JOURNEY_CATEGORY,
+  GALLERY_FILTER_JOURNEY_QUERY,
+} from "../../apps/docs/src/lib/gallery-filter-journey";
+
 async function expectNoOverflow(page: import("@playwright/test").Page): Promise<void> {
   expect(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)).toBe(
     true,
@@ -227,15 +232,16 @@ test("gallery filtering is URL-addressable, preserves theme, and restores histor
 }) => {
   await page.goto("/examples?theme=dark");
   const search = page.getByRole("searchbox", { name: "Filter" });
-  // Query must hit gallery haystack (id/title/tags/section) — chart Labs copy
-  // and deleted meta descriptions are not indexed.
-  await search.fill("scatter");
-  await expect(page).toHaveURL(/theme=dark.*q=scatter|q=scatter.*theme=dark/);
+  // Shared with scripts/gallery.test.ts — must hit haystack (id/title/tags/section).
+  // Chart Labs copy and deleted meta descriptions are not indexed (#765/#773).
+  await search.fill(GALLERY_FILTER_JOURNEY_QUERY);
+  const q = GALLERY_FILTER_JOURNEY_QUERY;
+  await expect(page).toHaveURL(new RegExp(`theme=dark.*q=${q}|q=${q}.*theme=dark`));
   await expect(page.locator(".example-grid li").first()).toBeVisible();
   const linkedCount = await page.locator(".example-grid li").count();
   expect(linkedCount).toBeGreaterThan(0);
-  await page.getByLabel("Category").selectOption("bar");
-  await expect(page).toHaveURL(/category=bar/);
+  await page.getByLabel("Category").selectOption(GALLERY_FILTER_JOURNEY_CATEGORY);
+  await expect(page).toHaveURL(new RegExp(`category=${GALLERY_FILTER_JOURNEY_CATEGORY}`));
   await page.goBack();
   await expect(page.getByLabel("Category")).toHaveValue("");
   await expect(page.locator(".example-grid li").first()).toBeVisible();


### PR DESCRIPTION
## Summary

- **Product fix already on main:** #767 switched the gallery URL-filter journey from `q=wheat` (description-only after #765 emptied meta descriptions) to `q=scatter`. That made `component-journeys` / `ci-gate` green again (CI run 30181845809).
- **This PR:** share the journey query/category as `apps/docs/src/lib/gallery-filter-journey.ts`, import them from both the Playwright journey and unit tests, and assert every public gallery entry remains findable via its name fragment so the next content deletion fails at `bun test` speed instead of only on the required journeys job.

Closes #773.

## Investigation

Root cause of the red gate: filter haystack is id/title/description/category/docsSection/tags; #765 zeroed descriptions; journey used `wheat` which only lived in those descriptions (and Labs titles, not indexed). Zero results → `.example-grid li` missing → timeout.

## Test plan

- [x] `bun test scripts/gallery.test.ts` (13 pass)
- [x] Local filterGallery: wheat=0, scatter=8 (simulates pre-#767 failure mode)
- [ ] CI `component-journeys` green on this PR (path routing should schedule docs journeys)

## Claude plan review

Consulted via `/claude`: revised away from a brittle `wheat → 0` absence pin toward a shared journey constant + findability invariant. Implemented that revision.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/774" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->