### PR TITLE
fix(core): prefer exact hits over path x-snap under inspect auto (#770)

### DIFF
--- a/.changeset/770-inspect-auto-prefer-exact.md
+++ b/.changeset/770-inspect-auto-prefer-exact.md
@@ -1,0 +1,16 @@
+---
+"@ggsvelte/core": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+fix(#770): prefer exact hits over path x-snap under inspect auto
+
+Under `inspect` auto mode, `CandidateStore.nearest` no longer lets
+path/smooth axis-snap distance beat co-layered point ring hits. Exact-mode
+geometric hits win first; pure x/y snap still applies when nothing exact is
+under the pointer (line-only charts unchanged). Explicit `mode: "x"|"y"|"xy"`
+is unchanged.
+
+Migration: none. Scatter + smooth with boolean/`auto` inspect now focuses
+points on hover instead of the trend line's full-panel vertical crosshair.

--- a/packages/core/src/candidate-store-build.ts
+++ b/packages/core/src/candidate-store-build.ts
@@ -92,7 +92,12 @@ export function assembleCandidateStore(
       let best = -1,
         bestDistance = Infinity,
         bestOrth = Infinity;
-      const mode: ResolvedCandidateInspectMode = search.mode === "auto" ? "exact" : search.mode;
+      // Under auto, exact-mode geometric hits (tier 1) beat pure axis-snap
+      // candidates (tier 2). Prevents path/smooth x-crosshair from stealing
+      // co-layered point hits (#770). Explicit mode is un-tiered.
+      let bestGeometric = false;
+      const isAuto = search.mode === "auto";
+      const mode: ResolvedCandidateInspectMode = isAuto ? "exact" : search.mode;
       let resultMode: ResolvedCandidateInspectMode = mode;
       const pathContainment = new Map<string, boolean>();
       const ids =
@@ -102,7 +107,7 @@ export function assembleCandidateStore(
       for (const id of ids) {
         if (search.panelId !== undefined && scene.panels[panelIds[id]!]!.id !== search.panelId)
           continue;
-        const candidateMode = search.mode === "auto" ? AUTO_MODES[autoModes[id]!]! : mode;
+        const candidateMode = isAuto ? AUTO_MODES[autoModes[id]!]! : mode;
         if (
           (candidateMode === "x" && xTokenIds[id] === -1) ||
           (candidateMode === "y" && yTokenIds[id] === -1)
@@ -124,11 +129,27 @@ export function assembleCandidateStore(
             : candidateMode === "y"
               ? Math.abs((flip ? ys[id] : xs[id])! - (flip ? py : px))
               : 0;
+        // Tier 1 = exact-mode candidates with a finite exactDistance only.
+        // Do not promote x/y candidates via stroke geometry (filled areas
+        // return unbounded containment hypot; Claude plan review #770).
+        const geometric = isAuto && candidateMode === "exact";
+        if (isAuto) {
+          if (geometric && !bestGeometric) {
+            best = id;
+            bestDistance = distance;
+            bestOrth = orth;
+            resultMode = candidateMode;
+            bestGeometric = true;
+            continue;
+          }
+          if (!geometric && bestGeometric) continue;
+        }
         if (distance < bestDistance || (distance === bestDistance && orth < bestOrth)) {
           best = id;
           bestDistance = distance;
           bestOrth = orth;
           resultMode = candidateMode;
+          if (isAuto) bestGeometric = geometric;
         }
       }
       const found = indexes.fact(best);

--- a/packages/core/src/candidate-store-build.ts
+++ b/packages/core/src/candidate-store-build.ts
@@ -97,7 +97,8 @@ export function assembleCandidateStore(
       // co-layered point hits (#770). Explicit mode is un-tiered.
       let bestGeometric = false;
       const isAuto = search.mode === "auto";
-      const mode: ResolvedCandidateInspectMode = isAuto ? "exact" : search.mode;
+      // Ternary must compare search.mode directly so TS narrows away "auto".
+      const mode: ResolvedCandidateInspectMode = search.mode === "auto" ? "exact" : search.mode;
       let resultMode: ResolvedCandidateInspectMode = mode;
       const pathContainment = new Map<string, boolean>();
       const ids =

--- a/packages/core/tests/candidate/store/nearest-mixed-auto.test.ts
+++ b/packages/core/tests/candidate/store/nearest-mixed-auto.test.ts
@@ -1,0 +1,206 @@
+/**
+ * #770 — under inspect auto mode, path/smooth x-axis snap must not steal hits
+ * from co-layered exact (point) candidates when the pointer is on a point.
+ */
+import { describe, expect, it } from "bun:test";
+
+import { buildCandidateStore } from "../../../src/candidate-store.ts";
+import { scene } from "../fixtures.ts";
+
+/** Point at (50, 30) + horizontal stroked path at y=80 (x 0..100). */
+function mixedPointPathScene() {
+  const plot = scene();
+  plot.batches = [
+    {
+      kind: "points",
+      layerIndex: 0,
+      panelIndex: 0,
+      positions: new Float32Array([50, 30]),
+      rowIndex: new Uint32Array([0]),
+      size: 5,
+      alpha: 1,
+      shape: "circle",
+      fill: null,
+    },
+    {
+      kind: "paths",
+      layerIndex: 1,
+      panelIndex: 0,
+      positions: new Float32Array([0, 80, 50, 80, 100, 80]),
+      rowIndex: new Uint32Array([1, 2, 3]),
+      pathOffsets: new Uint32Array([0, 3]),
+      strokes: [null],
+      linewidth: 2,
+      alpha: 1,
+      curve: "linear",
+    },
+  ];
+  return plot;
+}
+
+describe("CandidateStore.nearest auto — mixed point + path (#770)", () => {
+  it("prefers an exact point hit over path x-snap when the pointer is on the point", () => {
+    const store = buildCandidateStore(mixedPointPathScene(), {
+      datum: ({ kind, primitiveIndex }) =>
+        kind === "points"
+          ? { xValue: 50, yValue: 30, autoMode: "exact" as const, seriesId: 0 }
+          : {
+              xValue: primitiveIndex * 50,
+              yValue: 80,
+              autoMode: "x" as const,
+              seriesId: 1,
+            },
+    });
+    // Probe slightly off the point center but still inside the ring (size 5 + tol 3).
+    // Path vertex at x=50 has axis distance 2; point exact distance is ~2.8.
+    // Pure distance ranking therefore prefers the path (the #770 bug).
+    const hit = store.nearest(52, 32, { mode: "auto", maxDistance: 24 });
+    expect(hit).not.toBeNull();
+    expect(hit!.id).toBe(0);
+    expect(hit!.mode).toBe("exact");
+    expect(hit!.rowIndex).toBe(0);
+  });
+
+  it("still x-snaps a path-only chart under auto (no exact competitor)", () => {
+    const plot = scene();
+    plot.batches = [
+      {
+        kind: "paths",
+        layerIndex: 0,
+        panelIndex: 0,
+        positions: new Float32Array([0, 50, 50, 50, 100, 50]),
+        rowIndex: new Uint32Array([0, 1, 2]),
+        pathOffsets: new Uint32Array([0, 3]),
+        strokes: [null],
+        linewidth: 2,
+        alpha: 1,
+        curve: "linear",
+      },
+    ];
+    const store = buildCandidateStore(plot, {
+      datum: ({ primitiveIndex }) => ({
+        xValue: primitiveIndex * 50,
+        yValue: 50,
+        autoMode: "x" as const,
+      }),
+    });
+    // Far in y from the stroke; still within maxDistance on dominant x.
+    const hit = store.nearest(50, 90, { mode: "auto", maxDistance: 24 });
+    expect(hit).toMatchObject({ mode: "x" });
+    expect(hit!.id).toBe(1);
+  });
+
+  it("x-snaps the path when the pointer is on the stroke and away from points", () => {
+    const store = buildCandidateStore(mixedPointPathScene(), {
+      datum: ({ kind, primitiveIndex }) =>
+        kind === "points"
+          ? { xValue: 50, yValue: 30, autoMode: "exact" as const }
+          : {
+              xValue: primitiveIndex * 50,
+              yValue: 80,
+              autoMode: "x" as const,
+            },
+    });
+    const hit = store.nearest(50, 80, { mode: "auto", maxDistance: 24 });
+    expect(hit).not.toBeNull();
+    // No exact-mode ring hit at (50, 80); path axis-snap wins with mode "x".
+    expect(hit!.mode).toBe("x");
+    expect(hit!.id).not.toBe(0);
+  });
+
+  it("does not apply exact-over-path preference under explicit mode x", () => {
+    // Path sample sits at the probe's x; point sits 5px left so axis distance loses.
+    const plot = scene();
+    plot.batches = [
+      {
+        kind: "points",
+        layerIndex: 0,
+        panelIndex: 0,
+        positions: new Float32Array([45, 30]),
+        rowIndex: new Uint32Array([0]),
+        size: 8,
+        alpha: 1,
+        shape: "circle",
+        fill: null,
+      },
+      {
+        kind: "paths",
+        layerIndex: 1,
+        panelIndex: 0,
+        positions: new Float32Array([0, 80, 50, 80, 100, 80]),
+        rowIndex: new Uint32Array([1, 2, 3]),
+        pathOffsets: new Uint32Array([0, 3]),
+        strokes: [null],
+        linewidth: 2,
+        alpha: 1,
+        curve: "linear",
+      },
+    ];
+    const store = buildCandidateStore(plot, {
+      datum: ({ kind, primitiveIndex }) =>
+        kind === "points"
+          ? { xValue: 45, yValue: 30, autoMode: "exact" as const }
+          : {
+              xValue: primitiveIndex * 50,
+              yValue: 80,
+              autoMode: "x" as const,
+            },
+    });
+    // Explicit "x" is opt-in full-panel snap — path at x=50 beats point at x=45.
+    // (Under auto the same probe would prefer the point ring.)
+    const hit = store.nearest(50, 30, { mode: "x", maxDistance: 24 });
+    expect(hit).not.toBeNull();
+    expect(hit!.mode).toBe("x");
+    expect(hit!.id).not.toBe(0);
+    const underAuto = store.nearest(50, 30, { mode: "auto", maxDistance: 24 });
+    expect(underAuto).toMatchObject({ id: 0, mode: "exact" });
+  });
+
+  it("filled area still x-snaps under auto when hover is away from co-layered points", () => {
+    const plot = scene();
+    plot.batches = [
+      {
+        kind: "points",
+        layerIndex: 0,
+        panelIndex: 0,
+        positions: new Float32Array([10, 10]),
+        rowIndex: new Uint32Array([0]),
+        size: 4,
+        alpha: 1,
+        shape: "circle",
+        fill: null,
+      },
+      {
+        kind: "paths",
+        layerIndex: 1,
+        panelIndex: 0,
+        // Large filled triangle covering the probe region far from the point.
+        positions: new Float32Array([20, 20, 120, 20, 70, 100]),
+        rowIndex: new Uint32Array([1, 2, 3]),
+        pathOffsets: new Uint32Array([0, 3]),
+        strokes: [null],
+        fills: [null],
+        closed: true,
+        linewidth: 0,
+        alpha: 1,
+        curve: "linear",
+      },
+    ];
+    const store = buildCandidateStore(plot, {
+      datum: ({ kind, primitiveIndex }) =>
+        kind === "points"
+          ? { xValue: 10, yValue: 10, autoMode: "exact" as const }
+          : {
+              xValue: 20 + primitiveIndex * 40,
+              yValue: primitiveIndex === 2 ? 100 : 20,
+              autoMode: "x" as const,
+            },
+    });
+    // Inside the fill, far from the point — must not promote fill vertices via
+    // unbounded containment hypot; axis-snap (tier 2) picks nearest-in-x.
+    const hit = store.nearest(70, 40, { mode: "auto", maxDistance: 24 });
+    expect(hit).not.toBeNull();
+    expect(hit!.mode).toBe("x");
+    expect(hit!.id).not.toBe(0);
+  });
+});

--- a/packages/svelte/tests/inspection/inspection-frame.test.ts
+++ b/packages/svelte/tests/inspection/inspection-frame.test.ts
@@ -151,6 +151,19 @@ describe("buildQueuedPointerInspection", () => {
       candidate: match,
     });
   });
+
+  it("propagates exact mode from nearest so pointer path draws no x-crosshair (#770)", () => {
+    // CandidateStore.nearest under auto returns mode "exact" for co-layered
+    // point hits; concreteMode is what InteractionOverlay / apply use for guides.
+    const exactMatch = { ...match, mode: "exact" as const, autoMode: "exact" as const };
+    expect(
+      buildQueuedPointerInspection({
+        hit,
+        source: "pointer",
+        match: exactMatch,
+      }).concreteMode,
+    ).toBe("exact");
+  });
 });
 
 describe("buildQueuedInspectFrame", () => {


### PR DESCRIPTION
## Summary

Fixes #770: under `inspect` auto mode, path/smooth candidates with mode `"x"` used full-panel dominant-axis distance and routinely beat co-layered point ring hits, so hover near a scatter mark selected the trend line (incomplete identity) and drew a vertical crosshair.

**Root cause:** `CandidateStore.nearest` under `mode: "auto"` ranks every candidate by its per-layer autoMode distance with no mode priority — path x-distance of 0–2px always beats a point exact distance of ~3px.

**Fix:** Under auto only, two tiers:
1. **Geometric** — `candidateMode === "exact"` with non-null `exactDistance` (ring/rect/stroke containment as today).
2. **Axis-snap** — existing x/y/xy ranking, only when no geometric hit.

Explicit `mode: "x"|"y"|"xy"|"exact"` is unchanged. Path-only / line-only charts still x-snap when nothing exact is under the pointer. Filled areas are **not** promoted via containment hypot (Claude plan review).

Homepage `inspect={{ mode: "exact" }}` mitigation (#771) can be relaxed in a follow-up once this lands.

## Test plan

- [x] RED then GREEN: `packages/core/tests/candidate/store/nearest-mixed-auto.test.ts`
  - mixed point+path, probe in point ring with worse exact distance than path x-snap → point wins, mode `"exact"`
  - path-only still x-snaps under auto
  - hover on path stroke away from points → path mode `"x"`
  - explicit mode `"x"` still axis-snaps (preference is auto-only)
  - filled area + scatter: area still x-snaps (no tier-1 promotion of fill)
- [x] Regression: existing autoMode-x points far orthogonally (`points-queries.test.ts`)
- [x] Pointer path: `concreteMode` propagates `"exact"` from match (`inspection-frame.test.ts`)
- [ ] CI green

## Out of scope

- Keyboard inspect path still falls back to `seed.autoMode` (full crosshair on smooth) — pointer/touch fixed; keyboard is a separate follow-up if wanted.
- Tooltip blank identity fields for pure smooth hits.
- Removing homepage exact-inspect opt-out.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/775" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->