### PR TITLE
refactor(#659): compose the repo and its docs as child layers (slices 8-9)

### DIFF
--- a/.changeset/659-slice8-repo-surface.md
+++ b/.changeset/659-slice8-repo-surface.md
@@ -1,0 +1,14 @@
+---
+"@ggsvelte/svelte": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+refactor(#659): compose the repo's own charts as child layers (slice 8)
+
+The docs site, the getting-started tutorial, the package README, the bundled
+agent skill, and the clean-consumer compatibility harness no longer pass the
+grammar props deprecated in 0.11.0 — they use `<Scale>`, `<Labs>`, `<Guides>`,
+`<Coord>`, `<Facet>`, and the theme shells instead. A new guard runs
+`ggsvelte-codemod`'s own transform over those sources and fails if any of them
+would still change.

--- a/.changeset/659-slice9-guide-child-api.md
+++ b/.changeset/659-slice9-guide-child-api.md
@@ -1,0 +1,13 @@
+---
+"@ggsvelte/svelte": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+docs(#659): teach the child-layer API in the guide (slice 9)
+
+Every Svelte snippet outside the upgrading page now composes scales, guides,
+coordinates, facets, labels, and themes as children rather than as the props
+deprecated in 0.11.0, and the copy-ready snippets on the themes page follow.
+The upgrading guide keeps the old form on purpose — it is the page that
+migrates away from it — and a guard asserts that exemption stays earned.

--- a/apps/docs/src/lib/components/ChartThemeLab.svelte
+++ b/apps/docs/src/lib/components/ChartThemeLab.svelte
@@ -1,5 +1,12 @@
 <script lang="ts">
-  import { GeomLine, GeomPoint, GGPlot } from "@ggsvelte/svelte";
+  import {
+    GeomLine,
+    GeomPoint,
+    GGPlot,
+    Labs,
+    Scale,
+    Theme,
+  } from "@ggsvelte/svelte";
   import type { ThemeName } from "@ggsvelte/spec";
   import { onMount } from "svelte";
 
@@ -63,23 +70,25 @@
     <GGPlot
       data={temperaturesKeyed}
       aes={{ x: "month", y: "temp", color: "city" }}
-      theme={resolvedTheme}
-      scales={{
-        x: { breaks: [...MONTH_BREAKS] },
-        color: { type: "ordinal", scheme },
-      }}
-      labs={{
-        title: "Monthly mean temperature",
-        x: "Month",
-        y: "Temperature (°C)",
-        color: "City",
-      }}
       key="id"
       inspect={{ mode: "x" }}
       legendFocus
       height={400}
       ariaLabel={`${resolvedTheme} theme with ${scheme} palette`}
     >
+      <Theme name={resolvedTheme} />
+      <Scale
+        value={{
+          x: { breaks: [...MONTH_BREAKS] },
+          color: { type: "ordinal", scheme },
+        }}
+      />
+      <Labs
+        title="Monthly mean temperature"
+        x="Month"
+        y="Temperature (°C)"
+        color="City"
+      />
       <GeomLine linewidth={2} />
       <GeomPoint size={2.5} />
     </GGPlot>

--- a/apps/docs/src/lib/components/GrammarDemo.svelte
+++ b/apps/docs/src/lib/components/GrammarDemo.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { GeomPoint, GeomSmooth, GGPlot } from "@ggsvelte/svelte";
+  import { GeomPoint, GeomSmooth, GGPlot, Theme } from "@ggsvelte/svelte";
 
   // Docs-owned specimen corpus, not the gallery example: point/scatter-color
   // now carries Guerry's 1833 moral statistics, and the hero wants a scatter
@@ -57,9 +57,9 @@
       inspect={active >= 3
         ? { mode: "exact", pin: true, maxDistance: 24 }
         : false}
-      theme={chartTheme}
       ariaLabel="Penguin mass increases with flipper length, grouped by species"
     >
+      <Theme name={chartTheme} />
       <GeomPoint alpha={0.72} />
       {#if active >= 2}
         <GeomSmooth method="loess" span={0.9} degree={1} se={false} />

--- a/apps/docs/src/lib/components/InteractionDemo.svelte
+++ b/apps/docs/src/lib/components/InteractionDemo.svelte
@@ -1,5 +1,11 @@
 <script lang="ts">
-  import { createPlotInteraction, GeomPoint, GGPlot } from "@ggsvelte/svelte";
+  import {
+    createPlotInteraction,
+    GeomPoint,
+    GGPlot,
+    Labs,
+    Scale,
+  } from "@ggsvelte/svelte";
 
   import CopyCode from "$lib/components/CopyCode.svelte";
 
@@ -79,7 +85,6 @@ ${closeScript}
       data={rows}
       aes={{ x: "period", y: "value", color: "series" }}
       layers={[{ geom: "point", params: { size: 4 } }]}
-      scales={{ color: { type: "ordinal", scheme: "observable10" } }}
       key="id"
       inspect
       select={{ type: "interval", mode: "xy" }}
@@ -88,10 +93,11 @@ ${closeScript}
       {interaction}
       interactionScope={scope}
       height={420}
-      labs={{ x: "Period", y: "Value", color: "Series" }}
       ariaLabel="Interactive series with inspect, select, zoom, and legend focus"
       onlegendfocus={describeLegend}
     >
+      <Scale value={{ color: { type: "ordinal", scheme: "observable10" } }} />
+      <Labs x="Period" y="Value" color="Series" />
       <GeomPoint size={4} />
     </GGPlot>
   </div>

--- a/apps/docs/src/lib/components/PaletteSpecimen.svelte
+++ b/apps/docs/src/lib/components/PaletteSpecimen.svelte
@@ -1,5 +1,12 @@
 <script lang="ts">
-  import { GeomCol, GGPlot } from "@ggsvelte/svelte";
+  import {
+    GeomCol,
+    GGPlot,
+    Guides,
+    Labs,
+    Scale,
+    Theme,
+  } from "@ggsvelte/svelte";
   import type { ThemeName } from "@ggsvelte/spec";
 
   import { languages } from "$lib/theme-specimens/data";
@@ -47,18 +54,18 @@
     <GGPlot
       data={languages}
       aes={{ x: "language", y: "respondents", fill: "language" }}
-      scales={{ fill: { type: "ordinal", scheme: name, reverse } }}
-      guides={{ fill: { type: "none" } }}
-      theme={paperTheme}
-      labs={{
-        title: "Survey respondents by language",
-        x: "Language",
-        y: "Respondents",
-      }}
       inspect={{ mode: "xy" }}
       height={340}
       ariaLabel={`${label} palette on ${paperTheme} paper`}
     >
+      <Theme name={paperTheme} />
+      <Scale value={{ fill: { type: "ordinal", scheme: name, reverse } }} />
+      <Guides value={{ fill: { type: "none" } }} />
+      <Labs
+        title="Survey respondents by language"
+        x="Language"
+        y="Respondents"
+      />
       <GeomCol width={0.75} />
     </GGPlot>
   </div>

--- a/apps/docs/src/lib/components/SequentialColorLab.svelte
+++ b/apps/docs/src/lib/components/SequentialColorLab.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { GeomRaster, GGPlot } from "@ggsvelte/svelte";
+  import { GeomRaster, GGPlot, Labs, Scale, Theme } from "@ggsvelte/svelte";
   import type { ColorScaleSpec } from "@ggsvelte/spec";
 
   import { VIRIDIS_COLORS } from "$lib/catalog/themes";
@@ -72,18 +72,18 @@
             <GGPlot
               data={grid}
               aes={{ x: "x", y: "y", fill: "z" }}
-              scales={{ fill: example.scale }}
-              theme="light"
-              labs={{
-                title: `${example.label} density surface`,
-                x: "x",
-                y: "y",
-                fill: "z",
-              }}
               inspect={{ mode: "xy" }}
               height={360}
               ariaLabel={`${example.label} sequential color example`}
             >
+              <Scale value={{ fill: example.scale }} />
+              <Theme name="light" />
+              <Labs
+                title={`${example.label} density surface`}
+                x="x"
+                y="y"
+                fill="z"
+              />
               <GeomRaster />
             </GGPlot>
           </div>

--- a/apps/docs/src/lib/components/ThemeSpecimen.svelte
+++ b/apps/docs/src/lib/components/ThemeSpecimen.svelte
@@ -8,7 +8,10 @@
     GeomSmooth,
     GeomText,
     GGPlot,
+    Labs,
+    Scale,
     scaleXLog10,
+    Theme,
   } from "@ggsvelte/svelte";
   import type { ThemeName } from "@ggsvelte/spec";
 
@@ -60,23 +63,25 @@
       <GGPlot
         data={temperaturesKeyed}
         aes={{ x: "month", y: "temp", color: "city" }}
-        theme={name}
-        scales={{
-          x: { breaks: [...MONTH_BREAKS] },
-          color: colorScale,
-        }}
-        labs={{
-          title: "Monthly mean temperature",
-          x: "Month",
-          y: "Temperature (°C)",
-          color: "City",
-        }}
         key="id"
         inspect={{ mode: "x" }}
         {legendFocus}
         height={plotHeight}
         ariaLabel={`${label} theme multi-series temperatures`}
       >
+        <Theme {name} />
+        <Scale
+          value={{
+            x: { breaks: [...MONTH_BREAKS] },
+            color: colorScale,
+          }}
+        />
+        <Labs
+          title="Monthly mean temperature"
+          x="Month"
+          y="Temperature (°C)"
+          color="City"
+        />
         <GeomLine linewidth={2} />
         <GeomPoint size={2.5} />
       </GGPlot>
@@ -84,20 +89,20 @@
       <GGPlot
         data={ridership}
         aes={{ x: "month", y: "riders", color: "mode" }}
-        theme={name}
-        scales={{ color: colorScale }}
-        labs={{
-          title: "Daily transit ridership",
-          x: "Month",
-          y: "Daily riders (thousands)",
-          color: "Mode",
-        }}
         key="id"
         inspect={{ mode: "x" }}
         {legendFocus}
         height={plotHeight}
         ariaLabel={`${label} theme ridership series`}
       >
+        <Theme {name} />
+        <Scale value={{ color: colorScale }} />
+        <Labs
+          title="Daily transit ridership"
+          x="Month"
+          y="Daily riders (thousands)"
+          color="Mode"
+        />
         <GeomLine linewidth={2} />
         <GeomPoint size={2.8} />
       </GGPlot>
@@ -105,102 +110,102 @@
       <GGPlot
         data={attendees}
         aes={{ x: "track", fill: "level" }}
-        theme={name}
-        scales={{ fill: colorScale }}
-        labs={{
-          title: "Conference attendees by track and experience",
-          x: "Track",
-          y: "Attendees",
-          fill: "Experience",
-        }}
         key="id"
         inspect={{ mode: "xy" }}
         {legendFocus}
         height={plotHeight}
         ariaLabel={`${label} theme dodged bars`}
       >
+        <Theme {name} />
+        <Scale value={{ fill: colorScale }} />
+        <Labs
+          title="Conference attendees by track and experience"
+          x="Track"
+          y="Attendees"
+          fill="Experience"
+        />
         <GeomBar position="dodge" />
       </GGPlot>
     {:else if kind === "generation-area"}
       <GGPlot
         data={generation}
         aes={{ x: "year", y: "twh", fill: "source" }}
-        theme={name}
-        scales={{
-          x: { labels: "d", nice: false },
-          fill: colorScale,
-        }}
-        labs={{
-          title: "Electricity generation mix",
-          x: "Year",
-          y: "Generation (TWh)",
-          fill: "Source",
-        }}
         key="id"
         inspect={{ mode: "x" }}
         {legendFocus}
         height={plotHeight}
         ariaLabel={`${label} theme stacked generation`}
       >
+        <Theme {name} />
+        <Scale
+          value={{
+            x: { labels: "d", nice: false },
+            fill: colorScale,
+          }}
+        />
+        <Labs
+          title="Electricity generation mix"
+          x="Year"
+          y="Generation (TWh)"
+          fill="Source"
+        />
         <GeomArea alpha={0.9} />
       </GGPlot>
     {:else if kind === "long-run-line"}
       <GGPlot
         data={longRunSeries}
         aes={{ x: "year", y: "value" }}
-        theme={name}
-        labs={{
-          title: "Long-run index, 1835–2025",
-          x: "Year",
-          y: "Index",
-        }}
         inspect={{ mode: "x" }}
         height={plotHeight}
         ariaLabel={`${label} theme long-run series`}
       >
+        <Theme {name} />
+        <Labs title="Long-run index, 1835–2025" x="Year" y="Index" />
         <GeomLine linewidth={1.5} />
       </GGPlot>
     {:else if kind === "penguins-scatter"}
       <GGPlot
         data={penguins}
         aes={{ x: "flipper", y: "mass", color: "species" }}
-        theme={name}
-        scales={{ color: colorScale }}
-        labs={{
-          title: "Penguin flipper length and body mass",
-          x: "Flipper length (mm)",
-          y: "Body mass (g)",
-          color: "Species",
-        }}
         key="id"
         inspect={{ mode: "xy" }}
         {legendFocus}
         height={plotHeight}
         ariaLabel={`${label} theme penguin scatter`}
       >
+        <Theme {name} />
+        <Scale value={{ color: colorScale }} />
+        <Labs
+          title="Penguin flipper length and body mass"
+          x="Flipper length (mm)"
+          y="Body mass (g)"
+          color="Species"
+        />
         <GeomPoint size={3.5} alpha={0.9} />
       </GGPlot>
     {:else if kind === "countries-scatter"}
       <GGPlot
         data={countries}
         aes={{ x: "gdp", y: "lifeExp", color: "region" }}
-        theme={name}
-        scales={{
-          ...scaleXLog10({ labels: "~s" }),
-          color: colorScale,
-        }}
-        labs={{
-          title: "Income and life expectancy",
-          x: "GDP per capita (USD, log scale)",
-          y: "Life expectancy (years)",
-          color: "Region",
-        }}
         key="country"
         inspect={{ mode: "xy" }}
         {legendFocus}
         height={plotHeight}
         ariaLabel={`${label} theme income scatter`}
       >
+        <Theme {name} />
+        <Scale
+          value={{
+            ...scaleXLog10({ labels: "~s" }),
+            color: colorScale,
+          }}
+        />
+        <Labs
+          title="Income and life expectancy"
+          x="GDP per capita (USD, log scale)"
+          y="Life expectancy (years)"
+          color="Region"
+        />
         <GeomPoint size={3.5} />
         <GeomSmooth method="lm" se={false} />
       </GGPlot>
@@ -208,16 +213,12 @@
       <GGPlot
         data={revenue}
         aes={{ x: "quarter", y: "amount" }}
-        theme={name}
-        labs={{
-          title: "Quarterly revenue",
-          x: "Quarter",
-          y: "Revenue (€ thousands)",
-        }}
         inspect={{ mode: "xy" }}
         height={plotHeight}
         ariaLabel={`${label} theme revenue columns`}
       >
+        <Theme {name} />
+        <Labs title="Quarterly revenue" x="Quarter" y="Revenue (€ thousands)" />
         <GeomCol width={0.7} />
         <GeomText aes={{ label: "label" }} dy={-8} size={11} />
       </GGPlot>
@@ -225,17 +226,17 @@
       <GGPlot
         data={cities}
         aes={{ x: "rent", y: "livability" }}
-        theme={name}
-        scales={{ x: { labels: ",d" } }}
-        labs={{
-          title: "Livability vs median rent",
-          x: "Median monthly rent (USD)",
-          y: "Livability index",
-        }}
         inspect={{ mode: "xy" }}
         height={plotHeight}
         ariaLabel={`${label} theme labeled cities`}
       >
+        <Theme {name} />
+        <Scale value={{ x: { labels: ",d" } }} />
+        <Labs
+          title="Livability vs median rent"
+          x="Median monthly rent (USD)"
+          y="Livability index"
+        />
         <GeomPoint size={3} />
         <GeomText aes={{ label: "city" }} dy={-9} size={10} />
       </GGPlot>

--- a/apps/docs/src/lib/theme-specimens/snippets.ts
+++ b/apps/docs/src/lib/theme-specimens/snippets.ts
@@ -5,7 +5,7 @@
 
 export function heroThemePaletteSnippet(theme: string, scheme: string): string {
   return `<script lang="ts">
-  import { GeomLine, GeomPoint, GGPlot } from "@ggsvelte/svelte";
+  import { GeomLine, GeomPoint, GGPlot, Labs, Scale, Theme } from "@ggsvelte/svelte";
 
   const temperatures = [
     { city: "Reykjavik", month: 1, temp: -0.5 },
@@ -21,28 +21,30 @@ export function heroThemePaletteSnippet(theme: string, scheme: string): string {
 <GGPlot
   data={temperatures}
   aes={{ x: "month", y: "temp", color: "city" }}
-  theme="${theme}"
-  scales={{
-    x: { breaks: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] },
-    color: { type: "ordinal", scheme: "${scheme}" },
-  }}
-  labs={{
-    title: "Monthly mean temperature",
-    x: "Month",
-    y: "Temperature (°C)",
-    color: "City",
-  }}
   inspect={{ mode: "x" }}
   legendFocus
   height={400}
 >
+  <Theme name="${theme}" />
+  <Scale
+    value={{
+      x: { breaks: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] },
+      color: { type: "ordinal", scheme: "${scheme}" },
+    }}
+  />
+  <Labs
+    title="Monthly mean temperature"
+    x="Month"
+    y="Temperature (°C)"
+    color="City"
+  />
   <GeomLine linewidth={2} />
   <GeomPoint size={2.5} />
 </GGPlot>`;
 }
 
 export const SEQUENTIAL_RASTER_SNIPPET = `<script lang="ts">
-  import { GeomRaster, GGPlot } from "@ggsvelte/svelte";
+  import { GeomRaster, GGPlot, Labs, Scale } from "@ggsvelte/svelte";
 
   // Regular x/y/z surface (48 cells in the live demos).
   const grid = [
@@ -56,14 +58,16 @@ export const SEQUENTIAL_RASTER_SNIPPET = `<script lang="ts">
 <GGPlot
   data={grid}
   aes={{ x: "x", y: "y", fill: "z" }}
-  scales={{
-    fill: { type: "sequential", scheme: "viridis" },
-    // reverse: true
-    // domain: [0.3, 0.7]  // pin inside actual z
-    // range: ["#2d1e2f", "#3d5a80", "#e76f51"]
-  }}
-  labs={{ title: "Density surface", x: "x", y: "y" }}
   height={400}
 >
+  <Scale
+    value={{
+      fill: { type: "sequential", scheme: "viridis" },
+      // reverse: true
+      // domain: [0.3, 0.7]  // pin inside actual z
+      // range: ["#2d1e2f", "#3d5a80", "#e76f51"]
+    }}
+  />
+  <Labs title="Density surface" x="x" y="y" />
   <GeomRaster />
 </GGPlot>`;

--- a/apps/docs/src/routes/+page.svelte
+++ b/apps/docs/src/routes/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { base } from "$app/paths";
   import type { PlotInspectionChange } from "@ggsvelte/svelte";
-  import { GeomPoint, GGPlot } from "@ggsvelte/svelte";
+  import { GeomPoint, GGPlot, Labs, Scale, Theme } from "@ggsvelte/svelte";
 
   import { guerry } from "$examples/point/scatter-color/data";
   import CodeTabs from "$lib/CodeTabs.svelte";
@@ -69,20 +69,19 @@
         maxDistance: 24,
         content: heroTooltip,
       }}
-      theme={heroTheme}
-      scales={{ color: { type: "ordinal", scheme: "tableau10" } }}
-      labs={{
-        title: "Literacy and crime in France, 1833",
-        subtitle:
-          "85 French departments — higher y means fewer crimes per head",
-        x: "Literate conscripts (%)",
-        y: "Population per crime against persons",
-        color: "Region",
-      }}
       width="container"
       height={400}
       ariaLabel="Literacy percentage against population per crime against persons for 85 French departments, coloured by region"
     >
+      <Theme name={heroTheme} />
+      <Scale value={{ color: { type: "ordinal", scheme: "tableau10" } }} />
+      <Labs
+        title="Literacy and crime in France, 1833"
+        subtitle="85 French departments — higher y means fewer crimes per head"
+        x="Literate conscripts (%)"
+        y="Population per crime against persons"
+        color="Region"
+      />
       <GeomPoint size={4} alpha={0.85} />
     </GGPlot>
   </div>

--- a/apps/docs/src/routes/__perf/legend-focus-100k/+page.svelte
+++ b/apps/docs/src/routes/__perf/legend-focus-100k/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { createPlotInteraction, GGPlot } from "@ggsvelte/svelte";
+  import { createPlotInteraction, GGPlot, Labs } from "@ggsvelte/svelte";
 
   const navigationData = Array.from({ length: 100_000 }, (_, id) => ({
     id,
@@ -39,9 +39,10 @@
       interactionScope={navigationScope}
       width={620}
       height={360}
-      labs={{ title: "100k navigation view", color: "Group" }}
       onrender={() => (commitsNavigation += 1)}
-    />
+    >
+      <Labs title="100k navigation view" color="Group" />
+    </GGPlot>
   </div>
   {#each ["A", "B", "C"] as name (name)}
     <div data-perf-plot={name}>
@@ -55,13 +56,14 @@
         interactionScope={scope}
         width={620}
         height={360}
-        labs={{ title: `Linked view ${name}`, color: "Group" }}
         onrender={() => {
           if (name === "A") commitsA += 1;
           else if (name === "B") commitsB += 1;
           else commitsC += 1;
         }}
-      />
+      >
+        <Labs title={`Linked view ${name}`} color="Group" />
+      </GGPlot>
     </div>
   {/each}
 </main>

--- a/apps/docs/src/routes/__perf/r3-interaction/+page.svelte
+++ b/apps/docs/src/routes/__perf/r3-interaction/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { createPlotInteraction, GGPlot } from "@ggsvelte/svelte";
+  import { createPlotInteraction, Facet, GGPlot, Labs } from "@ggsvelte/svelte";
 
   const FILTER_ROWS = 20_000;
   const FACET_ROWS = 12_000;
@@ -78,9 +78,10 @@
       legendFilter
       width={900}
       height={420}
-      labs={{ title: "R3 legend filter pipeline", color: "Group" }}
       onrender={() => (filterPipelineCommits += 1)}
-    />
+    >
+      <Labs title="R3 legend filter pipeline" color="Group" />
+    </GGPlot>
   </section>
 
   <section data-perf-plot="facet">
@@ -88,16 +89,17 @@
       data={facetData}
       aes={mapping}
       layers={[{ geom: "point", render: "canvas", params: { size: 1 } }]}
-      facet={{ wrap: "facet", ncol: 3 }}
       key="id"
       select={crossPanelSelect}
       interaction={facetInteraction}
       interactionScope={facetScope}
       width={900}
       height={420}
-      labs={{ title: "R3 cross-panel interval and precise bounds" }}
       onrender={() => (facetPipelineCommits += 1)}
-    />
+    >
+      <Facet wrap="facet" ncol={3} />
+      <Labs title="R3 cross-panel interval and precise bounds" />
+    </GGPlot>
   </section>
 
   <section data-perf-plot="zoom">
@@ -111,9 +113,10 @@
       interactionScope={zoomScope}
       width={900}
       height={420}
-      labs={{ title: "R3 precise zoom bounds" }}
       onrender={() => (zoomPipelineCommits += 1)}
-    />
+    >
+      <Labs title="R3 precise zoom bounds" />
+    </GGPlot>
   </section>
 </main>
 

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -16,7 +16,13 @@ Requires Node.js 22+ and Svelte 5.33.1+.
 
 ```svelte
 <script lang="ts">
-  import { GeomPoint, GGPlot, guideLegend } from "@ggsvelte/svelte";
+  import {
+    GeomPoint,
+    GGPlot,
+    guideLegend,
+    Guides,
+    Labs,
+  } from "@ggsvelte/svelte";
 
   const rows = [
     { engine: 1.8, highway: 29, class: "compact" },
@@ -30,16 +36,16 @@ Requires Node.js 22+ and Svelte 5.33.1+.
 <GGPlot
   data={rows}
   aes={{ x: "engine", y: "highway", color: "class" }}
-  guides={{ color: guideLegend({ position: "auto" }) }}
-  labs={{
-    title: "Highway efficiency by engine size",
-    x: "Engine displacement",
-    y: "Highway mileage",
-    color: "Class",
-  }}
   width="container"
   height={400}
 >
+  <Guides value={{ color: guideLegend({ position: "auto" }) }} />
+  <Labs
+    title="Highway efficiency by engine size"
+    x="Engine displacement"
+    y="Highway mileage"
+    color="Class"
+  />
   <GeomPoint size={4} />
 </GGPlot>
 ```
@@ -49,19 +55,19 @@ themes, and semantic interaction. Ordinary layers render as SVG; dense point lay
 can render on canvas while axes, legends, text, and accessible descriptions remain in
 the DOM.
 
-Use `coord={coordTransform({ x: "log10" })}` to project final geometry after
+Add `<Coord value={coordTransform({ x: "log10" })} />` to project final geometry after
 statistics without changing the values consumed by a fit or bin. Nonlinear paths are
 tessellated without creating inspectable rows, and interval or brush inversion returns
 semantic values.
 
-Use `coord={coordFixed()}` when equal data units must remain physically equal.
+Add `<Coord value={coordFixed()} />` when equal data units must remain physically equal.
 The Svelte renderer uses the same centered data rectangle and theme-owned
 letterbox gutters as headless SVG, including the `data-gg-layout="degraded"`
 state for unusually constrained allocations. `coord_fixed`, `coordEqual`, and
 `coord_equal` are re-exported aliases over the same portable implementation.
 
 Color/fill helpers are re-exported from the package root. For example,
-`scales={scaleColorBinned({ breaks: [0, 10, 100], range: ["#ddd", "#222"] })}`
+`<Scale value={scaleColorBinned({ breaks: [0, 10, 100], range: ["#ddd", "#222"] })} />`
 renders deterministic color steps and a colorsteps guide. Continuous,
 discrete, log10, sqrt, date, datetime, manual, and identity families use the
 same JSON accepted by `<GGPlot>`, with binding-identical `color`/`colour` and
@@ -72,7 +78,7 @@ the package root. Their per-mark/per-path vectors render consistently in SVG,
 canvas, and SSR; style legends retain keyboard focus and filtering behavior,
 and inspection reports resolved semantic style values.
 
-Pass `guides` directly to `<GGPlot>` to suppress or restyle axes and to place,
+Add a `<Guides>` child to suppress or restyle axes and to place,
 orient, title, order, or force legends/colorbars/colorsteps. Automatic guides move
 from right to bottom at narrow widths without retraining scales; merged exact-value
 entries keep keyboard focus and filtering across every represented aesthetic. The

--- a/packages/svelte/skills/ggsvelte/SKILL.md
+++ b/packages/svelte/skills/ggsvelte/SKILL.md
@@ -115,7 +115,7 @@ must survive filtering, reordering, or data refreshes.
 
 ```svelte
 <script lang="ts">
-  import { createPlotInteraction, GGPlot } from "@ggsvelte/svelte";
+  import { createPlotInteraction, Facet, GGPlot } from "@ggsvelte/svelte";
 
   const interaction = createPlotInteraction<number>();
   const scope = { keys: "sales-rows", intervals: "sales-range" } as const;
@@ -125,7 +125,6 @@ must survive filtering, reordering, or data refreshes.
   data={rows}
   aes={{ x: "date", y: "value", color: "series" }}
   layers={[{ geom: "point" }]}
-  facet={{ wrap: "region", ncol: 3 }}
   key="id"
   select={{ type: "interval", mode: "x", preset: "cross-panel" }}
   legendFocus
@@ -133,7 +132,9 @@ must survive filtering, reordering, or data refreshes.
   {interaction}
   interactionScope={scope}
   oninteraction={(event) => console.log(event)}
-/>
+>
+  <Facet wrap="region" ncol={3} />
+</GGPlot>
 ```
 
 - `inspect` adds tooltip, crosshair, keyboard traversal, and pinning; `select`

--- a/scripts/consumer-compat.ts
+++ b/scripts/consumer-compat.ts
@@ -261,7 +261,7 @@ export function writeConsumerFixture(
   writeFileSync(
     join(directory, "src", "routes", "contract", "+page.svelte"),
     `<script lang="ts">
-  import { coord_transform, coordTransform, dmy, GGPlot, GeomLine, GeomPoint, guideColorsteps, guideLegend, guide_legend, scaleColorBinned, scaleColourBinned, scaleShapeDiscrete, scaleSizeContinuous, scaleXBinned, scaleXDate, scaleXLog10, scale_color_binned, scale_colour_binned, scale_shape_discrete, scale_x_date, scale_x_log10, type GuidePlan, type PortableSpec } from "@ggsvelte/svelte";
+  import { Coord, coord_transform, coordTransform, dmy, GGPlot, GeomLine, GeomPoint, guideColorsteps, guideLegend, guide_legend, Guides, Scale, scaleColorBinned, scaleColourBinned, scaleShapeDiscrete, scaleSizeContinuous, scaleXBinned, scaleXDate, scaleXLog10, scale_color_binned, scale_colour_binned, scale_shape_discrete, scale_x_date, scale_x_log10, type GuidePlan, type PortableSpec } from "@ggsvelte/svelte";
   const spec: PortableSpec = ${JSON.stringify(plotSpec)};
   const temporalRows = [
     { year: "1835", value: 12 },
@@ -312,42 +312,42 @@ export function writeConsumerFixture(
 <GGPlot
   data={[{ x: 1, y: 1 }, { x: 10, y: 2 }, { x: 100, y: 3 }]}
   aes={{ x: "x", y: "y" }}
-  scales={scaleXLog10()}
   width={480}
   height={320}
   ariaLabel="Packed log transform contract chart"
 >
+  <Scale value={scaleXLog10()} />
   <GeomPoint />
 </GGPlot>
 <GGPlot
   data={[{ x: 1, y: 1 }, { x: 10, y: 2 }, { x: 100, y: 3 }]}
   aes={{ x: "x", y: "y", color: "x" }}
-  scales={scaleColorBinned({ breaks: [1, 10, 100] })}
-  guides={{ color: guideColorsteps({ position: "bottom", direction: "horizontal" }) }}
   width={480}
   height={320}
   ariaLabel="Packed binned color contract chart"
 >
+  <Scale value={scaleColorBinned({ breaks: [1, 10, 100] })} />
+  <Guides value={{ color: guideColorsteps({ position: "bottom", direction: "horizontal" }) }} />
   <GeomPoint />
 </GGPlot>
 <GGPlot
   data={[{ x: 1, y: 1, amount: 2, group: "a" }, { x: 2, y: 2, amount: 8, group: "b" }]}
   aes={{ x: "x", y: "y", size: "amount", shape: "group" }}
-  scales={{ ...scaleSizeContinuous(), ...scaleShapeDiscrete() }}
   width={480}
   height={320}
   ariaLabel="Packed mapped style contract chart"
 >
+  <Scale value={{ ...scaleSizeContinuous(), ...scaleShapeDiscrete() }} />
   <GeomPoint />
 </GGPlot>
 <GGPlot
   data={[{ x: 1, y: 1 }, { x: 10, y: 2 }, { x: 100, y: 3 }]}
   aes={{ x: "x", y: "y" }}
-  coord={coordTransform({ x: "log10" })}
   width={480}
   height={320}
   ariaLabel="Packed post-stat coordinate contract chart"
 >
+  <Coord value={coordTransform({ x: "log10" })} />
   <GeomPoint />
 </GGPlot>
 `,

--- a/scripts/llms-guide-content.ts
+++ b/scripts/llms-guide-content.ts
@@ -271,14 +271,13 @@ const root = scaleYSqrt({ reverse: true });
 The Svelte surface accepts the same JSON and re-exports the same helpers:
 
 \`\`\`svelte fragment
-<GGPlot
-  data={rows}
-  aes={{ x: "latency", y: "requests" }}
-  scales={{
-    x: { type: "linear", transform: "log10" },
-    y: { type: "linear", transform: "sqrt" },
-  }}
->
+<GGPlot data={rows} aes={{ x: "latency", y: "requests" }}>
+  <Scale
+    value={{
+      x: { type: "linear", transform: "log10" },
+      y: { type: "linear", transform: "sqrt" },
+    }}
+  />
   <GeomPoint />
   <GeomSmooth method="lm" />
 </GGPlot>
@@ -309,13 +308,15 @@ A binned scale assigns quantitative values to bounded transformed-space bins
 while preserving source values for tooltips and events:
 
 \`\`\`svelte fragment
-scales={{
-  x: {
-    type: "binned",
-    transform: "log10",
-    breaks: [1, 10, 100, 1000],
-  },
-}}
+<Scale
+  value={{
+    x: {
+      type: "binned",
+      transform: "log10",
+      breaks: [1, 10, 100, 1000],
+    },
+  }}
+/>
 \`\`\`
 
 The runtime keeps integer bin identities private for count/stack/fill/dodge.
@@ -340,8 +341,10 @@ apply the forward transform exactly once.
 Use a named categorical scheme when color identifies groups:
 
 \`\`\`svelte fragment
-aes={{ x: "weight", y: "economy", color: "vehicleClass" }}
-scales={{ color: { type: "ordinal", scheme: "observable10" } }}
+<GGPlot data={cars} aes={{ x: "weight", y: "economy", color: "vehicleClass" }}>
+  <Scale value={{ color: { type: "ordinal", scheme: "observable10" } }} />
+  <GeomPoint />
+</GGPlot>
 \`\`\`
 
 Stable assignments preserve category identity as rows filter or reorder. See
@@ -373,14 +376,13 @@ upper edge included. At most 65 boundaries (64 steps) are portable. A
 colorsteps guide exposes every boundary, label, swatch, and inclusivity rule:
 
 \`\`\`svelte fragment
-<GGPlot
-  data={rows}
-  aes={{ x: "hour", y: "pm25", color: "pm25" }}
-  scales={scaleColorBinned({
-    breaks: [0, 12, 35, 55, 100],
-    range: ["#2a9d8f", "#e9c46a", "#f4a261", "#e76f51"],
-  })}
->
+<GGPlot data={rows} aes={{ x: "hour", y: "pm25", color: "pm25" }}>
+  <Scale
+    value={scaleColorBinned({
+      breaks: [0, 12, 35, 55, 100],
+      range: ["#2a9d8f", "#e9c46a", "#f4a261", "#e76f51"],
+    })}
+  />
   <GeomPoint />
 </GGPlot>
 \`\`\`
@@ -470,6 +472,15 @@ const guides = {
 };
 \`\`\`
 
+In Svelte that object is a \`<Guides>\` child:
+
+\`\`\`svelte fragment
+<GGPlot data={rows} aes={{ x: "hour", y: "pm25", color: "pm25" }}>
+  <Guides value={guides} />
+  <GeomPoint />
+</GGPlot>
+\`\`\`
+
 Automatic legends stay right only when the viewport is wider than 480px and at
 least 320px of readable panel remains; otherwise they move below. Bottom keys
 wrap without shrinking type and bottom ramps are horizontal. Discrete guides
@@ -497,7 +508,10 @@ trained scales (flip, etc.) without rewriting aesthetic mappings.
 One grammar, one panel per group:
 
 \`\`\`svelte fragment
-facet={{ wrap: "vehicleClass", ncol: 2 }}
+<GGPlot data={cars} aes={{ x: "weight", y: "economy" }}>
+  <FacetWrap field="vehicleClass" ncol={2} />
+  <GeomPoint />
+</GGPlot>
 \`\`\`
 
 Fixed scales: compare magnitudes across panels. Free scales: within-panel shape
@@ -544,10 +558,13 @@ The portable JSON form is strict and callback-free:
 \`\`\`
 
 Use \`coordTransform\` or its identical ggplot2-style alias
-\`coord_transform\`. In Svelte, pass the result to \`coord\`:
+\`coord_transform\`. In Svelte it is a \`<CoordTransform>\` child, which takes
+the same options (\`<Coord value={coordTransform({ … })} />\` is the escape
+hatch for a coordinate computed elsewhere):
 
 \`\`\`svelte fragment
-<GGPlot coord={coordTransform({ x: "log10", y: "sqrt" })}>
+<GGPlot data={rows} aes={{ x: "exposure", y: "response" }}>
+  <CoordTransform x="log10" y="sqrt" />
   <GeomPoint />
   <GeomSmooth method="lm" />
 </GGPlot>
@@ -600,7 +617,10 @@ appearance is independent unless follow mode is explicit.
 Registered theme name; mappings unchanged:
 
 \`\`\`svelte fragment
-theme="economist"
+<GGPlot data={rows} aes={{ x: "year", y: "value" }}>
+  <ThemeEconomist />
+  <GeomLine />
+</GGPlot>
 \`\`\`
 
 Twelve themes, categorical palettes, sequential ramps:

--- a/scripts/quickstart.ts
+++ b/scripts/quickstart.ts
@@ -92,6 +92,16 @@ export interface SakuraSourceDelta {
   readonly consts?: readonly string[];
   /** `<GGPlot>` attributes, keyed by attribute name; a repeat replaces it. */
   readonly attrs?: Readonly<Record<string, string>>;
+  /**
+   * Declaration-only grammar children (`<Scale>`, `<Labs>`, `<ThemeTufte>`),
+   * keyed by the grammar piece they carry; a repeat replaces it.
+   *
+   * Held apart from {@link children} because they are not layers: they never
+   * appear in `childOrder`, and they are emitted ahead of every geom so that a
+   * later step adding a geom cannot silently reorder them (#659 D2 — child
+   * layers apply in registration order).
+   */
+  readonly grammar?: Readonly<Record<string, string>>;
   /** Child elements keyed by the layer they draw; a repeat replaces it. */
   readonly children?: Readonly<Record<string, string>>;
   /** Full bottom-to-top child order after this step. */
@@ -184,16 +194,18 @@ export const SAKURA_STEPS: readonly SakuraStep[] = [
     outcome: "Real dates on the axis, reversed: earlier spring now reads as up.",
     explanation:
       "The bloom day is a date, so the y scale is temporal — dateBreaks and dateLabels format it. Reversing the scale changes direction only; no value is touched, and the trend line above is refit from the same rows.",
-    fragment: `scales={{
-  y: {
-    type: "time",
-    temporalKind: "date",
-    reverse: true,
-    dateBreaks: "10 days",
-    dateLabels: "%b %d",
-    domain: ["${Y_BOTTOM}", "${Y_TOP}"],
-  },
-}}`,
+    fragment: `<Scale
+  value={{
+    y: {
+      type: "time",
+      temporalKind: "date",
+      reverse: true,
+      dateBreaks: "10 days",
+      dateLabels: "%b %d",
+      domain: ["${Y_BOTTOM}", "${Y_TOP}"],
+    },
+  }}
+/>`,
     chapterTitle: "Scales and guides",
     href: "/guide/scales-guides#date-and-time-axes",
     spec: {
@@ -213,24 +225,27 @@ export const SAKURA_STEPS: readonly SakuraStep[] = [
       labs: { x: "Year", y: "Peak bloom" },
     },
     source: {
-      attrs: {
-        scales: `  scales={{
-    y: {
-      type: "time",
-      temporalKind: "date",
-      reverse: true,
-      dateBreaks: "10 days",
-      dateLabels: "%b %d",
-      domain: ["${Y_BOTTOM}", "${Y_TOP}"],
-    },
-    x: { type: "linear", domain: [800, 2030], labels: "d" },
-    fill: {
-      type: "manual",
-      domain: [${SAKURA_EPOCHS.map((e) => `"${e.epoch}"`).join(", ")}],
-      range: ["#f5edc4", "#dce8f2", "#f3dcda"],
-    },
-  }}`,
-        labs: `  labs={{ x: "Year", y: "Peak bloom" }}`,
+      components: ["Labs", "Scale"],
+      grammar: {
+        scales: `  <Scale
+    value={{
+      y: {
+        type: "time",
+        temporalKind: "date",
+        reverse: true,
+        dateBreaks: "10 days",
+        dateLabels: "%b %d",
+        domain: ["${Y_BOTTOM}", "${Y_TOP}"],
+      },
+      x: { type: "linear", domain: [800, 2030], labels: "d" },
+      fill: {
+        type: "manual",
+        domain: [${SAKURA_EPOCHS.map((e) => `"${e.epoch}"`).join(", ")}],
+        range: ["#f5edc4", "#dce8f2", "#f3dcda"],
+      },
+    }}
+  />`,
+        labs: `  <Labs x="Year" y="Peak bloom" />`,
       },
     },
   },
@@ -402,15 +417,15 @@ export const SAKURA_STEPS: readonly SakuraStep[] = [
     outcome: "Tufte theme, a title that states the finding, a caption that cites the source.",
     explanation:
       "Theme is appearance; labs is editorial. Neither touches a mapping, so swapping themes cannot change what the chart claims.",
-    fragment: `theme="tufte"
-labs={{
-  title: "Kyoto cherry blossom, 812–2026",
-  subtitle: "Bloom now arrives about a week earlier than it did for a millennium",
-  caption: "838 observations. Data: Yasuyuki Aono (2008, 2010).",
-  x: "Year",
-  y: "Peak bloom",
-  fill: "Climate epoch",
-}}`,
+    fragment: `<ThemeTufte />
+<Labs
+  title="Kyoto cherry blossom, 812–2026"
+  subtitle="Bloom now arrives about a week earlier than it did for a millennium"
+  caption="838 observations. Data: Yasuyuki Aono (2008, 2010)."
+  x="Year"
+  y="Peak bloom"
+  fill="Climate epoch"
+/>`,
     chapterTitle: "Themes and color",
     href: "/guide/themes-color#choose-a-chart-theme",
     spec: {
@@ -425,18 +440,17 @@ labs={{
       },
     },
     source: {
-      attrs: {
-        theme: `  theme="tufte"`,
-        labs: `  labs={{
-    x: "Year",
-    y: "Peak bloom",
-    title: "Kyoto cherry blossom, 812–2026",
-    subtitle:
-      "Bloom now arrives about a week earlier than it did for a millennium",
-    caption:
-      "838 observations. Data: Yasuyuki Aono (2008, 2010).",
-    fill: "Climate epoch",
-  }}`,
+      components: ["ThemeTufte"],
+      grammar: {
+        theme: `  <ThemeTufte />`,
+        labs: `  <Labs
+    x="Year"
+    y="Peak bloom"
+    title="Kyoto cherry blossom, 812–2026"
+    subtitle="Bloom now arrives about a week earlier than it did for a millennium"
+    caption="838 observations. Data: Yasuyuki Aono (2008, 2010)."
+    fill="Climate epoch"
+  />`,
       },
     },
   },
@@ -480,6 +494,13 @@ const BASE_LAYERS: Record<string, LayerSpec> = { points: { geom: "point" } };
 const BASE_ORDER = ["points"];
 const BASE_CHILDREN: Record<string, string> = { points: "  <GeomPoint />" };
 
+/**
+ * Emission order for the grammar children, outermost concern first: how the
+ * chart looks, then how values map to the page, then what it is called. None
+ * of the three can override another, so this is readability only.
+ */
+const GRAMMAR_ORDER = ["theme", "scales", "labs"] as const;
+
 /** Layers that only make sense when the chart is wide enough to place text. */
 export const SAKURA_ANNOTATION_LAYERS = ["leaders", "callouts"] as const;
 
@@ -517,6 +538,7 @@ export function foldSakura(
     ["aes", `  aes={{ x: "year", y: "bloomRefDate" }}`],
   ]);
   const children: Record<string, string> = { ...BASE_CHILDREN };
+  const grammar: Record<string, string> = {};
   let childOrder: readonly string[] = BASE_ORDER;
 
   for (const step of steps) {
@@ -529,6 +551,7 @@ export function foldSakura(
     for (const component of step.source.components ?? []) components.add(component);
     consts.push(...(step.source.consts ?? []));
     for (const [name, text] of Object.entries(step.source.attrs ?? {})) attrs.set(name, text);
+    Object.assign(grammar, step.source.grammar ?? {});
     Object.assign(children, step.source.children ?? {});
     if (step.source.childOrder !== undefined) childOrder = step.source.childOrder;
   }
@@ -569,7 +592,7 @@ ${script}
 <GGPlot
 ${[...attrs.values()].join("\n")}
 >
-${childOrder.map((name) => children[name]).join("\n")}
+${[...GRAMMAR_ORDER.filter((name) => grammar[name] !== undefined).map((name) => grammar[name]!), ...childOrder.map((name) => children[name]!)].join("\n")}
 </GGPlot>`;
 
   return {

--- a/scripts/repo-child-layers.test.ts
+++ b/scripts/repo-child-layers.test.ts
@@ -1,0 +1,67 @@
+/**
+ * The repo composes its own charts the way it tells consumers to (#659 slice 8).
+ *
+ * 0.11.0 deprecated the seven grammar props on `<GGPlot>` (facet, coord,
+ * scales, guides, legend, theme, labs) in favour of declaration-only child
+ * layers, and shipped `ggsvelte-codemod` to migrate them. Documentation that
+ * still passes them is the loudest possible counter-argument, so this asserts
+ * the docs app's own Svelte sources — and the getting-started page the guide
+ * builds line by line — are already on the child form.
+ *
+ * The check IS the codemod: a file is migrated when running it over that file
+ * rewrites nothing (`changes`) and refuses nothing (`skipped`). Reusing the
+ * shipped transform rather than a bespoke regex means the guard cannot drift
+ * from what `npx ggsvelte-codemod` would tell a reader to do.
+ */
+import { describe, expect, it } from "bun:test";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+
+import { migratePlotProps } from "../packages/svelte/src/lib/codemod/migrate-plot-props.ts";
+import { foldSakura, QUICKSTART_PAGE_FILENAME, SAKURA_STEPS } from "./quickstart.ts";
+
+const ROOT = join(import.meta.dir, "..");
+
+function svelteFiles(dir: string): string[] {
+  return readdirSync(dir).flatMap((name) => {
+    const path = join(dir, name);
+    if (statSync(path).isDirectory()) return name === "node_modules" ? [] : svelteFiles(path);
+    return path.endsWith(".svelte") ? [path] : [];
+  });
+}
+
+/**
+ * Every authored `.svelte` in the docs app. `__perf` routes are in scope on
+ * purpose: they are read as usage examples as readily as the gallery is.
+ */
+const DOCS_SVELTE = svelteFiles(join(ROOT, "apps/docs/src"));
+
+describe("the repo's own charts use child layers, not deprecated grammar props", () => {
+  it("finds docs Svelte sources to check", () => {
+    // A broken walk would make every assertion below vacuously pass.
+    expect(DOCS_SVELTE.length).toBeGreaterThan(20);
+  });
+
+  for (const path of DOCS_SVELTE) {
+    const name = relative(ROOT, path);
+    it(`${name} needs no migration`, () => {
+      const result = migratePlotProps(readFileSync(path, "utf8"));
+      expect({
+        rewritable: result.changes.map((c) => `${c.prop} (line ${String(c.line)})`),
+        manual: result.skipped.map((s) => `${s.prop} (line ${String(s.line)})`),
+      }).toEqual({ rewritable: [], manual: [] });
+    });
+  }
+
+  // Every fold, not just the first and last: the getting-started page shows
+  // one of these per step, and a reader types whichever one is on screen.
+  for (let step = 0; step <= SAKURA_STEPS.length; step += 1) {
+    it(`the ${QUICKSTART_PAGE_FILENAME} at step ${String(step)} needs no migration`, () => {
+      const result = migratePlotProps(foldSakura(step).source);
+      expect({
+        rewritable: result.changes.map((c) => c.prop),
+        manual: result.skipped.map((s) => s.prop),
+      }).toEqual({ rewritable: [], manual: [] });
+    });
+  }
+});

--- a/scripts/repo-child-layers.test.ts
+++ b/scripts/repo-child-layers.test.ts
@@ -1,24 +1,35 @@
 /**
- * The repo composes its own charts the way it tells consumers to (#659 slice 8).
+ * The repo composes its own charts the way it tells consumers to (#659 slices
+ * 8 and 9).
  *
  * 0.11.0 deprecated the seven grammar props on `<GGPlot>` (facet, coord,
  * scales, guides, legend, theme, labs) in favour of declaration-only child
  * layers, and shipped `ggsvelte-codemod` to migrate them. Documentation that
  * still passes them is the loudest possible counter-argument, so this asserts
- * the docs app's own Svelte sources — and the getting-started page the guide
- * builds line by line — are already on the child form.
+ * two surfaces are on the child form: the docs app's own Svelte sources plus
+ * the getting-started page the guide builds line by line (slice 8), and every
+ * Svelte fence in the guide itself (slice 9).
  *
- * The check IS the codemod: a file is migrated when running it over that file
- * rewrites nothing (`changes`) and refuses nothing (`skipped`). Reusing the
- * shipped transform rather than a bespoke regex means the guard cannot drift
- * from what `npx ggsvelte-codemod` would tell a reader to do.
+ * For the sources, the check IS the codemod: a file is migrated when running
+ * it over that file rewrites nothing (`changes`) and refuses nothing
+ * (`skipped`). Reusing the shipped transform rather than a bespoke regex means
+ * the guard cannot drift from what `npx ggsvelte-codemod` would tell a reader
+ * to do. Guide fences are matched textually instead, because most of them are
+ * deliberately incomplete and would not parse.
  */
 import { describe, expect, it } from "bun:test";
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join, relative } from "node:path";
 
+import lifecycle from "../lifecycle.json";
 import { migratePlotProps } from "../packages/svelte/src/lib/codemod/migrate-plot-props.ts";
+import { guidePages, type LifecycleDoc } from "./gen-llms.ts";
+import { codeBlocks } from "./guide-code-contract.ts";
 import { foldSakura, QUICKSTART_PAGE_FILENAME, SAKURA_STEPS } from "./quickstart.ts";
+import {
+  heroThemePaletteSnippet,
+  SEQUENTIAL_RASTER_SNIPPET,
+} from "../apps/docs/src/lib/theme-specimens/snippets.ts";
 
 const ROOT = join(import.meta.dir, "..");
 
@@ -64,4 +75,64 @@ describe("the repo's own charts use child layers, not deprecated grammar props",
       }).toEqual({ rewritable: [], manual: [] });
     });
   }
+
+  // Whole files the themes page offers for copying, assembled as strings so
+  // the Svelte compiler never sees their literal </script> tags — which also
+  // puts them out of reach of the .svelte walk above.
+  const SNIPPETS: readonly (readonly [string, string])[] = [
+    ["heroThemePaletteSnippet", heroThemePaletteSnippet("tufte", "observable10")],
+    ["SEQUENTIAL_RASTER_SNIPPET", SEQUENTIAL_RASTER_SNIPPET],
+  ];
+
+  for (const [name, source] of SNIPPETS) {
+    it(`the ${name} the themes page offers for copying needs no migration`, () => {
+      const result = migratePlotProps(source);
+      expect({
+        rewritable: result.changes.map((c) => c.prop),
+        manual: result.skipped.map((s) => s.prop),
+      }).toEqual({ rewritable: [], manual: [] });
+    });
+  }
+});
+
+/**
+ * The seven props deprecated in 0.11.0, as they appear in an authored fence.
+ * Matched at the start of a line or straight after `<GGPlot` so `<Facet …>`,
+ * `<Theme name=…>` and a `theme` key inside a JSON spec never trip it.
+ */
+const DEPRECATED_PROP = /(?:^\s*|<GGPlot\s+)(facet|coord|scales|guides|legend|theme|labs)=/gm;
+
+/**
+ * The upgrading guide is the one page that must show the deprecated form: its
+ * whole job is a before/after table. Every other page teaches the child API.
+ */
+const SHOWS_THE_OLD_FORM = new Set(["upgrading"]);
+
+describe("the guide teaches child layers, not deprecated grammar props", () => {
+  const pages = guidePages(lifecycle as unknown as LifecycleDoc);
+
+  it("finds guide pages to check", () => {
+    expect(pages.length).toBeGreaterThan(10);
+  });
+
+  for (const page of pages) {
+    if (SHOWS_THE_OLD_FORM.has(page.slug)) continue;
+    it(`/guide/${page.slug} shows no deprecated grammar prop`, () => {
+      const offenders = codeBlocks(page.markdown)
+        .filter((block) => block.language === "svelte")
+        .flatMap((block) => [...block.source.matchAll(DEPRECATED_PROP)].map((m) => m[1]!));
+      expect(offenders).toEqual([]);
+    });
+  }
+
+  it("the upgrading guide still shows the deprecated form it migrates away from", () => {
+    // Guards the exemption above: if this page ever stops demonstrating the
+    // old shape, the allowlist is dead weight hiding a real regression.
+    const upgrading = pages.find((p) => p.slug === "upgrading");
+    expect(upgrading).toBeDefined();
+    const shown = codeBlocks(upgrading!.markdown)
+      .filter((block) => block.language === "svelte")
+      .flatMap((block) => [...block.source.matchAll(DEPRECATED_PROP)].map((m) => m[1]!));
+    expect(shown.length).toBeGreaterThan(0);
+  });
 });

--- a/scripts/sakura-lesson.test.ts
+++ b/scripts/sakura-lesson.test.ts
@@ -85,6 +85,9 @@ describe("the sakura lesson folds to renderable specs", () => {
     const lastChild = new Map<string, string>();
     for (const step of SAKURA_STEPS) {
       for (const [key, text] of Object.entries(step.source.attrs ?? {})) lastAttr.set(key, text);
+      // Grammar children ride with the attrs they replaced (#659 slice 8):
+      // they are not layers, so they must stay out of the layer count below.
+      for (const [key, text] of Object.entries(step.source.grammar ?? {})) lastAttr.set(key, text);
       for (const [key, text] of Object.entries(step.source.children ?? {}))
         lastChild.set(key, text);
     }
@@ -110,7 +113,7 @@ describe("the sakura lesson folds to renderable specs", () => {
       [2, 'fill: "epoch"', '"fill":{"field":"epoch"}'],
       [3, SAKURA_BASELINE, `"yintercept":"${SAKURA_BASELINE}"`],
       [3, '"#b3452f"', '"value":"#b3452f"'],
-      [4, 'theme="tufte"', '"theme":"tufte"'],
+      [4, "<ThemeTufte />", '"theme":"tufte"'],
       [5, 'key="year"', ""],
     ];
     for (const [index, inFragment, inSpec] of pairs) {

--- a/skills/ggsvelte/SKILL.md
+++ b/skills/ggsvelte/SKILL.md
@@ -115,7 +115,7 @@ must survive filtering, reordering, or data refreshes.
 
 ```svelte
 <script lang="ts">
-  import { createPlotInteraction, GGPlot } from "@ggsvelte/svelte";
+  import { createPlotInteraction, Facet, GGPlot } from "@ggsvelte/svelte";
 
   const interaction = createPlotInteraction<number>();
   const scope = { keys: "sales-rows", intervals: "sales-range" } as const;
@@ -125,7 +125,6 @@ must survive filtering, reordering, or data refreshes.
   data={rows}
   aes={{ x: "date", y: "value", color: "series" }}
   layers={[{ geom: "point" }]}
-  facet={{ wrap: "region", ncol: 3 }}
   key="id"
   select={{ type: "interval", mode: "x", preset: "cross-panel" }}
   legendFocus
@@ -133,7 +132,9 @@ must survive filtering, reordering, or data refreshes.
   {interaction}
   interactionScope={scope}
   oninteraction={(event) => console.log(event)}
-/>
+>
+  <Facet wrap="region" ncol={3} />
+</GGPlot>
 ```
 
 - `inspect` adds tooltip, crosshair, keyboard traversal, and pinning; `select`

--- a/tests/visual/docs-themes.spec.ts
+++ b/tests/visual/docs-themes.spec.ts
@@ -31,7 +31,9 @@ test("theme code uses the shared manual-copy fallback", async ({ page }) => {
   await expect(lab.getByRole("status").filter({ hasText: "Clipboard unavailable" })).toHaveText(
     "Clipboard unavailable. Code selected for manual copy.",
   );
-  expect(await page.evaluate(() => getSelection()?.toString())).toContain('theme="default"');
+  expect(await page.evaluate(() => getSelection()?.toString())).toContain(
+    '<Theme name="default" />',
+  );
 });
 
 test("themes compares all built-in chart themes as full-width interactive portraits", async ({
@@ -78,12 +80,12 @@ test("chart theme stays separate until follow-docs appearance is explicit", asyn
   const chartPaper = () => plot.locator(".gg-paper").getAttribute("fill");
 
   await chartTheme.selectOption("economist");
-  await expect(lab.locator(".copy-code code")).toContainText('theme="economist"');
+  await expect(lab.locator(".copy-code code")).toContainText('<Theme name="economist" />');
   await expect.poll(chartPaper).toBe("var(--gg-paper, #d5e4eb)");
   // Palette is independent of theme.
   await palette.selectOption("tableau10");
   await expect(lab.locator(".copy-code code")).toContainText('scheme: "tableau10"');
-  await expect(lab.locator(".copy-code code")).toContainText('theme="economist"');
+  await expect(lab.locator(".copy-code code")).toContainText('<Theme name="economist" />');
 
   await page.getByRole("button", { name: "Dark appearance" }).click();
   await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
@@ -93,7 +95,7 @@ test("chart theme stays separate until follow-docs appearance is explicit", asyn
   await expect(lab.getByRole("status").filter({ hasText: "follows site" })).toContainText(
     'scheme="tableau10"',
   );
-  await expect(lab.locator(".copy-code code")).toContainText('theme="dark"');
+  await expect(lab.locator(".copy-code code")).toContainText('<Theme name="dark" />');
   await expect.poll(chartPaper).toBe("var(--gg-paper, #16181d)");
   await page.getByRole("button", { name: "Light appearance" }).click();
   await expect.poll(chartPaper).toBe("var(--gg-paper, #ffffff)");


### PR DESCRIPTION
Closes the last two slices of #659: the repo and its documentation now compose
grammar pieces the way 0.11.0 tells consumers to.

## Slice 8 — the repo's own surface

0.11.0 deprecated seven props on `<GGPlot>` and shipped a codemod to migrate
them, while the docs site, the getting-started tutorial, the package README,
the bundled agent skill, and the clean-consumer contract page all still passed
those props. Most of this diff is the codemod's own output.

The thirteen `theme={expr}` sites it deliberately refuses (`theme` is
`ThemeName | ThemeSpec` and `<Theme>` has no `value` hatch) are hand-migrated
to `<Theme name={expr} />`; every one of those expressions is declared
`ThemeName` at its definition, which is why the rewrite is safe by hand and not
by machine.

`scripts/quickstart.ts` gains a `grammar` source delta beside `attrs` and
`children`. The tutorial's scales/labs/theme deltas are children now, but they
are not layers, so they stay out of `childOrder` and emit ahead of every geom —
which is also the precedence D2 requires of a prop that becomes a child.

## Slice 9 — the guide

scales-guides showed four `scales={{…}}` fragments, facets-coordinates showed
`facet` and `coord`, and themes-color's whole "choose a chart theme" lesson was
the single line `theme="economist"`. These now use children, preferring the
named shells the guide recommends by hand (`<FacetWrap>`, `<CoordTransform>`,
`<ThemeEconomist>`) over the mechanical escape hatches the codemod emits.

The responsive-guides section gains the Svelte fence it never had: it built a
`guides` object in TypeScript and stopped, leaving the reader to guess where it
went.

## The guard

`scripts/repo-child-layers.test.ts` is the acceptance criterion, written first
and failing first (8 docs files + 5 tutorial folds, then 3 guide pages).

For sources the check **is** the codemod — a file is migrated when
`migratePlotProps` rewrites nothing and refuses nothing — so the guard cannot
drift from what `npx ggsvelte-codemod` tells a reader to do. Guide fences are
matched textually instead, because most are deliberately incomplete and would
not parse.

The upgrading page is exempt: showing the old form is its job. A paired
assertion fails if it ever stops showing it, so the exemption cannot quietly
outlive its reason.

## Verification

| Gate | Result |
|------|--------|
| `bun test scripts` | 998 pass, 0 fail |
| `bun run check` | clean |
| `bun run check:docs` (svelte-check) | 1892 files, 0 errors, 0 warnings |
| `bun run lint` / `lint:type-aware` / `lint:md` | clean |
| `bun run knip` | clean |
| all `*:check` generators (lesson charts, docs search, gallery previews, playground seeds, manifest, lifecycle, routes) | current |

## Note on #659's acceptance criteria

The issue asks for `<GGPlot>` props to be "only `data` and `aes`". That was
narrowed during planning (D1) to "no grammar-piece prop bag": `spec`, `layers`,
and the runtime props (`width`, `height`, `key`, `inspect`, `select`, …) are
not grammar pieces and stay. The deprecated seven remain accepted with a
removal path documented in the upgrading guide — this PR is the documentation
half, not the removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/776" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->