### PR TITLE
docs: prefer bun add over bun install for the package

### DIFF
--- a/apps/docs/src/lib/components/GettingStartedGuide.svelte
+++ b/apps/docs/src/lib/components/GettingStartedGuide.svelte
@@ -86,7 +86,7 @@
     class="lesson-source"
     language="bash"
     accessibleLabel="Copy install command"
-    code="bun install @ggsvelte/svelte"
+    code="bun add @ggsvelte/svelte"
   />
 
   <h2 id="start-with-a-basic-plot">Start with a basic plot</h2>

--- a/apps/docs/src/routes/+page.svelte
+++ b/apps/docs/src/routes/+page.svelte
@@ -15,7 +15,7 @@
 
   type GuerryRow = (typeof guerry)[number];
 
-  const install = "bun install @ggsvelte/svelte";
+  const install = "bun add @ggsvelte/svelte";
   const entries = galleryCatalog(EXAMPLES);
   const featured = FEATURED_EXAMPLES.map((item) =>
     entries.find((entry) => entry.id === item.id)!,

--- a/scripts/llms-guide-content.ts
+++ b/scripts/llms-guide-content.ts
@@ -32,8 +32,7 @@ same grammar, built up one element at a time on a real dataset — is at
 ## Install
 
 \`\`\`sh complete
-bun install @ggsvelte/svelte
-# or: bun add @ggsvelte/svelte
+bun add @ggsvelte/svelte
 # or: npm install @ggsvelte/svelte
 # or: pnpm add @ggsvelte/svelte
 \`\`\`

--- a/tests/visual/docs-home-gallery.spec.ts
+++ b/tests/visual/docs-home-gallery.spec.ts
@@ -213,7 +213,7 @@ test("install copy and code tabs share the manual-copy fallback", async ({ page 
     "Clipboard unavailable. Code selected for manual copy.",
   );
   expect(await page.evaluate(() => getSelection()?.toString())).toContain(
-    "bun install @ggsvelte/svelte",
+    "bun add @ggsvelte/svelte",
   );
   const tabs = page.getByRole("tablist", { name: "Code representations" }).getByRole("tab");
   await expect(tabs.first()).toHaveText("Svelte");


### PR DESCRIPTION
## Summary

Prefer `bun add @ggsvelte/svelte` everywhere we document adding the dependency. `bun install` is for syncing existing deps from the lockfile.

## Files

- docs home install snippet
- getting started Install
- llms getting-started install fence
- docs home gallery visual test expectation

Package READMEs already used `bun add`.

## Test plan

- [x] `bun test scripts/gen-llms.test.ts scripts/progressive-docs.test.ts`
- [x] `rg 'bun install @ggsvelte'` → no matches
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/782" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->