### PR TITLE
fix(#784): route docs package.json generators to docs_site

### DIFF
--- a/scripts/ci-routing.test.ts
+++ b/scripts/ci-routing.test.ts
@@ -1,12 +1,16 @@
 import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 import {
   CACHEABLE_EXECUTIONS,
   CONTENT_HASH_SCHEMA,
   JOB_CONTENT_INPUTS,
+  LANE_PATTERNS,
   classifyChangedPaths,
   contentHashCacheKey,
+  docsPackageInvokedScripts,
+  docsSourceScriptImports,
   evaluateGate,
   formatGithubOutputs,
   formatTreeEntryDigest,
@@ -139,11 +143,26 @@ describe("classifyChangedPaths", () => {
       "apps/docs/src/lib/guide.ts",
       "apps/docs/src/lib/components/GettingStartedGuide.svelte",
       "apps/docs/src/lib/catalog/docs-tasks.ts",
+      // Sibling generated inventory modules are content-only (#784 lesson-charts).
+      "apps/docs/src/lib/generated/lesson-charts.ts",
+      "apps/docs/src/lib/generated/routes.ts",
+      "apps/docs/src/lib/generated/search-index.ts",
+      "apps/docs/src/lib/generated/playground-seeds.ts",
+      "apps/docs/src/lib/generated/gallery-previews.ts",
     ]) {
       const flags = classifyChangedPaths([file]);
       expect(flags.docs, file).toBe(true);
       expect(flags.docs_render, file).toBe(false);
     }
+  });
+
+  test("lesson-charts projection schedules docs site without VR", () => {
+    const path = "apps/docs/src/lib/generated/lesson-charts.ts";
+    const plan = planJobs(classifyChangedPaths([path]));
+    expect(plan.docs_site).toBe(true);
+    expect(plan.svelte_check).toBe(true);
+    expect(plan.docs_journeys).toBe(true);
+    expect(plan.vr).toBe(false);
   });
 
   test("unknown apps/docs shell paths fail closed to docs_render", () => {
@@ -523,6 +542,11 @@ describe("planJobs", () => {
       "scripts/gen-playground-seeds.ts",
       "scripts/check-docs-metadata.ts",
       "scripts/check-pages-links.ts",
+      // #784: package.json build/check invoke gen-lesson-charts; build invokes docs-csp.
+      "scripts/gen-lesson-charts.ts",
+      "scripts/gen-lesson-charts.test.ts",
+      "scripts/docs-csp.ts",
+      "scripts/docs-csp.test.ts",
     ]) {
       const flags = classifyChangedPaths([path]);
       expect(flags.docs, path).toBe(true);
@@ -530,6 +554,7 @@ describe("planJobs", () => {
       expect(plan.svelte_check, path).toBe(true);
       expect(plan.docs_site, path).toBe(true);
       expect(plan.pages, path).toBe(true);
+      expect(plan.docs_journeys, path).toBe(true);
       expect(plan.unit, path).toBe(true);
       expect(plan.build, path).toBe(true);
       expect(plan.vr, path).toBe(false);
@@ -558,11 +583,102 @@ describe("JOB_CONTENT_INPUTS (split build hashes)", () => {
       expect(inputs, execution).toContain("scripts/gen-playground-seeds.ts");
       expect(inputs, execution).toContain("scripts/check-docs-metadata.ts");
       expect(inputs, execution).toContain("scripts/check-pages-links.ts");
+      expect(inputs, execution).toContain("scripts/gen-lesson-charts.ts");
+      expect(inputs, execution).toContain("scripts/docs-csp.ts");
       expect(inputs, execution).toContain("scripts/gen-llms.ts");
       expect(inputs, execution).toContain("scripts/docs-seo.ts");
       expect(inputs, execution).toContain("scripts/quickstart.ts");
       expect(inputs, execution).toContain("scripts/guide-code-contract.ts");
       expect(inputs, execution).toContain("scripts/highlight-code.ts");
+      for (const file of ["scripts/gen-lesson-charts.ts", "scripts/docs-csp.ts"]) {
+        expect(listJobContentPaths(execution, [file]), `${execution}:${file}`).toContain(file);
+      }
+    }
+  });
+
+  test("component_journeys hashes gen-lesson-charts (lesson img counts on getting-started)", () => {
+    const file = "scripts/gen-lesson-charts.ts";
+    expect(JOB_CONTENT_INPUTS.component_journeys).toContain(file);
+    expect(listJobContentPaths("component_journeys", [file])).toContain(file);
+  });
+});
+
+describe("docs surface membership gates (#784)", () => {
+  test("docsPackageInvokedScripts parses bun script paths with and without flags", () => {
+    expect(
+      docsPackageInvokedScripts({
+        build: "bun ../../scripts/gen-a.ts --check && bun ../../scripts/docs-csp.ts",
+        check: "bun ../../scripts/gen-a.ts --check",
+        dev: "vite dev",
+      }),
+    ).toEqual(["scripts/docs-csp.ts", "scripts/gen-a.ts"]);
+  });
+
+  test("docsSourceScriptImports resolves $scripts module ids to scripts/*.ts", () => {
+    expect(
+      docsSourceScriptImports(`
+        import { x } from "$scripts/gen-llms";
+        import type { Y } from "$scripts/cli-docs";
+        import { z } from "$scripts/quickstart.ts";
+      `),
+    ).toEqual(["scripts/cli-docs.ts", "scripts/gen-llms.ts", "scripts/quickstart.ts"]);
+  });
+
+  test("every apps/docs package.json-invoked script is on the docs lane and docs surface hash", () => {
+    const pkgPath = join(import.meta.dir, "..", "apps", "docs", "package.json");
+    const pkg = JSON.parse(readFileSync(pkgPath, "utf8")) as {
+      scripts: Record<string, string>;
+    };
+    const invoked = docsPackageInvokedScripts(pkg.scripts);
+    // Sanity: build/check must surface at least the known generators.
+    expect(invoked).toContain("scripts/gen-lesson-charts.ts");
+    expect(invoked).toContain("scripts/docs-csp.ts");
+    expect(invoked.length).toBeGreaterThan(4);
+
+    for (const path of invoked) {
+      // Membership via patterns (exact path or covered by a docs-lane pattern).
+      const onDocsLane = LANE_PATTERNS.docs.some((pattern) => matchPathPattern(pattern, path));
+      expect(onDocsLane, `LANE_PATTERNS.docs missing ${path}`).toBe(true);
+      expect(classifyChangedPaths([path]).docs, path).toBe(true);
+      // Invoked files (not their .test.ts siblings) must bust docs surface hashes.
+      expect(listJobContentPaths("docs_site", [path]), `docs_site:${path}`).toContain(path);
+      expect(listJobContentPaths("svelte_check", [path]), `svelte_check:${path}`).toContain(path);
+    }
+  });
+
+  test("every $scripts import under apps/docs/src is on the docs lane and docs surface hash", () => {
+    const root = join(import.meta.dir, "..", "apps", "docs", "src");
+    const sources: string[] = [];
+    const walk = (dir: string) => {
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const full = join(dir, entry.name);
+        if (entry.isDirectory()) {
+          walk(full);
+          continue;
+        }
+        if (/\.(ts|js|svelte)$/.test(entry.name)) sources.push(full);
+      }
+    };
+    walk(root);
+
+    const imported = new Set<string>();
+    for (const file of sources) {
+      for (const path of docsSourceScriptImports(readFileSync(file, "utf8"))) {
+        imported.add(path);
+      }
+    }
+    expect(imported.size).toBeGreaterThan(0);
+    // Known $scripts consumers today.
+    expect(imported).toContain("scripts/gen-llms.ts");
+    expect(imported).toContain("scripts/docs-seo.ts");
+    expect(imported).toContain("scripts/cli-docs.ts");
+    expect(imported).toContain("scripts/quickstart.ts");
+
+    for (const path of [...imported].toSorted()) {
+      const onDocsLane = LANE_PATTERNS.docs.some((pattern) => matchPathPattern(pattern, path));
+      expect(onDocsLane, `LANE_PATTERNS.docs missing $scripts import ${path}`).toBe(true);
+      expect(listJobContentPaths("docs_site", [path]), `docs_site:${path}`).toContain(path);
+      expect(listJobContentPaths("svelte_check", [path]), `svelte_check:${path}`).toContain(path);
     }
   });
 });
@@ -1017,6 +1133,8 @@ describe("ci-routing module tree (split-safe)", () => {
       "classifyChangedPaths",
       "collectGitHeadInputDigests",
       "contentHashCacheKey",
+      "docsPackageInvokedScripts",
+      "docsSourceScriptImports",
       "emptyChangeFlags",
       "evaluateGate",
       "formatGithubOutputs",

--- a/scripts/ci-routing.ts
+++ b/scripts/ci-routing.ts
@@ -30,6 +30,8 @@ export {
   classifyChangedPaths,
   isDocsContentOnlyPath,
   isDocsRenderPath,
+  docsPackageInvokedScripts,
+  docsSourceScriptImports,
   planJobs,
   evaluateGate,
   formatGithubOutputs,

--- a/scripts/ci-routing/content-hash.ts
+++ b/scripts/ci-routing/content-hash.ts
@@ -100,6 +100,9 @@ const DOCS_SURFACE_CONTENT_INPUTS: readonly string[] = [
   "scripts/gen-playground-seeds.ts",
   "scripts/check-docs-metadata.ts",
   "scripts/check-pages-links.ts",
+  // #784: build/check --check gen-lesson-charts; build runs docs-csp after vite.
+  "scripts/gen-lesson-charts.ts",
+  "scripts/docs-csp.ts",
   // $scripts imports used by docs routes / layout (typecheck + published site).
   "scripts/gen-llms.ts",
   "scripts/gen-llms.test.ts",
@@ -280,6 +283,8 @@ export const JOB_CONTENT_INPUTS: Record<CacheableExecution, readonly string[]> =
     "scripts/gen-gallery-previews.test.ts",
     "scripts/gallery-preview-provenance.ts",
     "scripts/gallery-preview-provenance.test.ts",
+    // Journeys assert lesson-chart img counts on /guide/getting-started (#784).
+    "scripts/gen-lesson-charts.ts",
     "scripts/cloudflare-pages-config.test.ts",
     "scripts/deployment-artifact.ts",
     "scripts/deployment-artifact.test.ts",

--- a/scripts/ci-routing/routing.ts
+++ b/scripts/ci-routing/routing.ts
@@ -76,9 +76,17 @@ export const DOCS_CONTENT_ONLY_PATHS: readonly string[] = [
   "apps/docs/src/lib/generated/routes.ts",
   "apps/docs/src/lib/generated/playground-seeds.ts",
   "apps/docs/src/lib/generated/gallery-previews.ts",
+  // Inventory projection only; static SVGs under apps/docs/static/lesson stay fail-closed.
+  "apps/docs/src/lib/generated/lesson-charts.ts",
 ];
 
-/** Script generators that ship docs text/SEO/deployment without VR pixel impact. */
+/**
+ * Script generators listed here for documentation / isDocsContentOnlyPath consumers.
+ * For `scripts/**` paths this list has no routing effect: `isDocsRenderPath` only
+ * returns true for `apps/docs/**` and screenshot baselines (see that function).
+ * Keep membership aligned with LANE_PATTERNS.docs content generators when useful
+ * for vr-baseline-guard and future tightening; do not treat absence as "render".
+ */
 export const DOCS_CONTENT_SCRIPT_PATTERNS: readonly string[] = [
   "scripts/gen-llms.ts",
   "scripts/gen-llms.test.ts",
@@ -142,6 +150,11 @@ export const LANE_PATTERNS: Record<ChangeLane, readonly string[]> = {
     "scripts/check-docs-metadata.test.ts",
     "scripts/check-pages-links.ts",
     "scripts/check-pages-links.test.ts",
+    // #784: build/check run gen-lesson-charts --check; build runs docs-csp after vite.
+    "scripts/gen-lesson-charts.ts",
+    "scripts/gen-lesson-charts.test.ts",
+    "scripts/docs-csp.ts",
+    "scripts/docs-csp.test.ts",
     // Deployment generators and smoke contracts change the published artifact.
     "scripts/cloudflare-pages-config.test.ts",
     "scripts/deployment-artifact.ts",
@@ -262,6 +275,50 @@ export function isDocsRenderPath(filePath: string): boolean {
   // Screenshots feed gallery pages and smoke VR inventory.
   if (path.startsWith("tests/visual/__screenshots__/")) return true;
   return false;
+}
+
+/**
+ * Repo-relative `scripts/...` paths invoked via `bun …/scripts/<file>` in a
+ * package.json `scripts` map (typically apps/docs). Pure — no FS.
+ *
+ * Covers every script value (not only build/check) so a future prepare script
+ * is gated for free. Matches with or without trailing flags (`--check`).
+ *
+ * Scope: **direct invocation only**. Transitive helpers imported by those
+ * scripts (e.g. docs-route-inventory, quickstart) still need hand lists or a
+ * future module-graph derivation (#783 / follow-up).
+ */
+export function docsPackageInvokedScripts(scripts: Record<string, string>): string[] {
+  // bun ../../scripts/foo.ts  |  bun scripts/foo.ts  |  bun ./scripts/foo.ts
+  const re = /\bbun\s+(?:\.\.\/|\.\/)*scripts\/([^\s"'`;|&]+)/g;
+  const found = new Set<string>();
+  for (const value of Object.values(scripts)) {
+    re.lastIndex = 0;
+    for (const match of value.matchAll(re)) {
+      const leaf = match[1];
+      if (leaf === undefined || leaf.length === 0) continue;
+      found.add(`scripts/${leaf}`);
+    }
+  }
+  return [...found].toSorted();
+}
+
+/**
+ * Repo-relative `scripts/<id>.ts` paths imported via the docs `$scripts/*`
+ * alias. Pure — caller supplies source text.
+ *
+ * One-level import only (not the full module graph).
+ */
+export function docsSourceScriptImports(sourceText: string): string[] {
+  const re = /from\s+["']\$scripts\/([^"']+)["']/g;
+  const found = new Set<string>();
+  for (const match of sourceText.matchAll(re)) {
+    const id = match[1];
+    if (id === undefined || id.length === 0) continue;
+    const withExt = id.endsWith(".ts") || id.endsWith(".js") ? id : `${id}.ts`;
+    found.add(`scripts/${withExt}`);
+  }
+  return [...found].toSorted();
 }
 
 const LANE_NAMES = Object.keys(LANE_PATTERNS) as ChangeLane[];


### PR DESCRIPTION
## Summary

- **Bug:** `apps/docs` build/check invoke `gen-lesson-charts.ts --check` (and build invokes `docs-csp.ts`), but those paths were absent from `LANE_PATTERNS.docs` and `DOCS_SURFACE_CONTENT_INPUTS`. A PR that only touched them scheduled neither `docs_site` nor `svelte_check` — the jobs that run the gates.
- **Sibling miss:** `apps/docs/src/lib/generated/lesson-charts.ts` was not on `DOCS_CONTENT_ONLY_PATHS` while routes/search/playground/gallery projections were, so editing it fail-closed into full VR.
- **Recurrence gate:** pure helpers parse `bun …/scripts/*` from `apps/docs/package.json` and `$scripts/*` imports under `apps/docs/src/**`, and unit tests assert every path is on the docs lane + docs surface hash. Direct invocation only — not full module-graph derivation (still blocked on the broader artifact protocol in #783).

Also covers the same live miss for `scripts/docs-csp.ts` (build-only) and hashes `gen-lesson-charts` for `component_journeys` (getting-started lesson img counts).

## Test plan

- [x] `bun test scripts/ci-routing.test.ts` (77 pass)
- [x] `bun run check:scripts-ci-routing`
- [ ] CI green on this PR

Closes #784

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/835" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->