### PR TITLE
refactor(svelte): one table for grammar families (#785)

### DIFF
--- a/packages/svelte/src/lib/assembly/assemble.ts
+++ b/packages/svelte/src/lib/assembly/assemble.ts
@@ -4,55 +4,28 @@ import type {
   CoordSpec,
   DataInput,
   FacetInput,
-  GeomName,
   GuidesSpec,
   Labs,
   LayerInput,
   LegendSpec,
   PortableSpec,
-  PositionName,
-  PositionParams,
-  RenderBackend,
   Scales,
   SpecInput,
-  StatName,
   ThemeName,
   ThemeSpec,
 } from "@ggsvelte/spec";
 import { gg, normalize } from "@ggsvelte/spec";
 
 import type { PlotInteractionScope, ZoomInput } from "../interaction/interaction.js";
+import { foldPlotLayer } from "../layers/fold.js";
+import type { MarkLayerDescriptor, PlotLayerLike } from "../layers/types.js";
 
 /**
- * Structural mark-layer descriptor (live getters allowed). Kept local so this
- * module does not import `registry.svelte.ts`.
+ * Structural mark-layer descriptor (live getters allowed). Alias of the shared
+ * MarkLayerDescriptor so callers that already import from assemble keep working
+ * without pulling in the `.svelte.ts` registry (#785).
  */
-export type MarkLayerDescriptorLike = {
-  readonly geom: GeomName;
-  readonly stat?: StatName | undefined;
-  readonly aes?: AesInput | undefined;
-  readonly data?: DataInput | readonly Record<string, unknown>[] | undefined;
-  readonly position?: PositionName | undefined;
-  readonly positionParams?: PositionParams | undefined;
-  readonly render?: RenderBackend | undefined;
-  readonly params?: Record<string, unknown> | undefined;
-};
-
-/**
- * Structural non-mark (and optional mark) plot layer. Same discipline as
- * MarkLayerDescriptorLike: no import of the `.svelte.ts` registry module.
- * Live getters allowed on `value`. Module-private (structural callers pass
- * compatible objects; not a public export).
- */
-type PlotLayerLike =
-  | { readonly kind: "mark"; readonly descriptor: MarkLayerDescriptorLike }
-  | { readonly kind: "scale"; readonly value: Scales }
-  | { readonly kind: "theme"; readonly value: ThemeName | ThemeSpec }
-  | { readonly kind: "coord"; readonly value: CoordSpec | "flip" }
-  | { readonly kind: "facet"; readonly value: FacetInput }
-  | { readonly kind: "labs"; readonly value: Labs }
-  | { readonly kind: "guides"; readonly value: GuidesSpec }
-  | { readonly kind: "legend"; readonly value: LegendSpec };
+export type MarkLayerDescriptorLike = MarkLayerDescriptor;
 
 /** True when an object is already a single-key DataRef container. */
 function isWrappedDataRef(data: object): data is NonNullable<LayerInput["data"]> {
@@ -145,39 +118,6 @@ export function isFacetedPlotIntent(input: {
   );
 }
 
-/** Apply one non-mark plot layer onto the fluent builder. */
-function applyPlotLayer(
-  builder: ReturnType<typeof gg>,
-  layer: PlotLayerLike,
-): ReturnType<typeof gg> {
-  switch (layer.kind) {
-    case "mark":
-      // Marks travel through `input.layers` (toLayerInput); ignore if present.
-      return builder;
-    case "scale":
-      return builder.scales(layer.value);
-    case "theme":
-      return builder.theme(layer.value);
-    case "coord":
-      return builder.coord(layer.value);
-    case "facet":
-      return builder.facet(layer.value);
-    case "labs":
-      return builder.labs(layer.value);
-    case "guides":
-      return builder.guides(layer.value);
-    case "legend":
-      return builder.legend(layer.value);
-    default: {
-      // Exhaustiveness: a new Layer kind must be handled here, not silently
-      // dropped. `never` makes that a compile error; the throw makes an
-      // unforeseen runtime kind loud instead of a missing spec field.
-      const unhandled: never = layer;
-      throw new TypeError(`Unhandled plot layer kind: ${String(unhandled)}`);
-    }
-  }
-}
-
 /**
  * Build the normalized PortableSpec for GGPlot.
  * Explicit `spec` wins over everything (including non-mark children).
@@ -193,6 +133,7 @@ export function assemblePortableSpec(input: AssemblePortableSpecInput): Portable
   // Props first, then non-mark children (registration order) — children win (D2).
   // REPLACE families (theme/coord/facet): last write wins.
   // MERGE families (scales/guides/labs/legend): {...prev, ...next} puts child last.
+  // Fold dispatch is table-driven via foldPlotLayer (#785).
   if (input.facet !== undefined) builder = builder.facet(input.facet);
   if (input.coord !== undefined) builder = builder.coord(input.coord);
   if (input.a11y !== undefined) builder = builder.a11y(input.a11y);
@@ -202,7 +143,7 @@ export function assemblePortableSpec(input: AssemblePortableSpecInput): Portable
   if (input.theme !== undefined) builder = builder.theme(input.theme);
   if (input.labs !== undefined) builder = builder.labs(input.labs);
   for (const plotLayer of input.plotLayers ?? []) {
-    builder = applyPlotLayer(builder, plotLayer);
+    builder = foldPlotLayer(builder, plotLayer);
   }
   return builder.spec();
 }

--- a/packages/svelte/src/lib/codemod/migrate-plot-props.ts
+++ b/packages/svelte/src/lib/codemod/migrate-plot-props.ts
@@ -38,12 +38,11 @@
  */
 import { parse } from "svelte/compiler";
 
+import { grammarCodemodRules, type GrammarCodemodForm } from "../layers/grammar-families.js";
 import { applyEdits, type Edit } from "./edits.js";
 
-const GUIDE = "https://ggsvelte.sh/guide/upgrading";
-
 /** How a deprecated prop's value is handed to its replacement component. */
-type Form = "value" | "spread" | "theme";
+type Form = GrammarCodemodForm;
 
 interface PropRule {
   readonly component: string;
@@ -51,24 +50,12 @@ interface PropRule {
   readonly docUrl: string;
 }
 
-/** The seven props deprecated in 0.11.0, in GGPlotProps declaration order. */
-const RULES: Readonly<Record<string, PropRule>> = {
-  facet: { component: "Facet", form: "spread", docUrl: `${GUIDE}#compose-facet-as-a-child-layer` },
-  coord: { component: "Coord", form: "value", docUrl: `${GUIDE}#compose-coord-as-a-child-layer` },
-  scales: { component: "Scale", form: "value", docUrl: `${GUIDE}#compose-scales-as-child-layers` },
-  guides: { component: "Guides", form: "value", docUrl: `${GUIDE}#compose-guides-as-child-layers` },
-  legend: {
-    component: "Legend",
-    form: "spread",
-    docUrl: `${GUIDE}#compose-legend-as-a-child-layer`,
-  },
-  theme: {
-    component: "Theme",
-    form: "theme",
-    docUrl: `${GUIDE}#compose-the-theme-as-a-child-layer`,
-  },
-  labs: { component: "Labs", form: "spread", docUrl: `${GUIDE}#compose-labs-as-a-child-layer` },
-};
+/**
+ * The seven props deprecated in 0.11.0, in GGPlotProps declaration order.
+ * Built from GRAMMAR_FAMILIES / GGPLOT_PROP_ORDER (#785) so codemod rules
+ * cannot drift from deprecation metadata.
+ */
+const RULES: Readonly<Record<string, PropRule>> = grammarCodemodRules();
 
 /** A prop this run rewrote. */
 export interface PropChange {

--- a/packages/svelte/src/lib/diagnostics/composition.ts
+++ b/packages/svelte/src/lib/diagnostics/composition.ts
@@ -16,7 +16,15 @@
  * DUPLICATE_MERGE_KEY: it shipped in 0.11.0, its `channel` field and its
  * spelling-alias suggestion are scale-specific, and renaming a live advisory
  * code would break consumer `switch`es for no behavioural gain.
+ *
+ * Kind sets and doc anchors come from GRAMMAR_FAMILIES (#785).
  */
+import {
+  GRAMMAR_FAMILIES,
+  grammarDocUrl,
+  type MergeByKeyKind,
+  type ReplaceKind,
+} from "../layers/grammar-families.js";
 
 export type CompositionDiagnosticCode =
   | "DUPLICATE_SCALE_CHANNEL"
@@ -40,8 +48,8 @@ export interface DuplicateScaleChannelDiagnostic {
   readonly docUrl: string;
 }
 
-/** Keyed-MERGE families other than scales (#659 slice 6). */
-export type DuplicateMergeKeyKind = "labs" | "guides" | "legend";
+/** Keyed-MERGE families other than scales (#659 slice 6 / #785). */
+export type DuplicateMergeKeyKind = MergeByKeyKind;
 
 /**
  * Two children of one keyed-MERGE family wrote the same key. Unlike the
@@ -59,7 +67,7 @@ export interface DuplicateMergeKeyDiagnostic {
   readonly docUrl: string;
 }
 
-export type DuplicatePlotLayerKind = "coord" | "facet" | "theme";
+export type DuplicatePlotLayerKind = ReplaceKind;
 
 export interface DuplicatePlotLayerDiagnostic {
   readonly severity: "advisory";
@@ -104,41 +112,13 @@ export function isDuplicatePlotLayerDiagnostic(
   return d.code === "DUPLICATE_PLOT_LAYER";
 }
 
-const GUIDE_SCALE_CHILDREN = "https://ggsvelte.sh/guide/upgrading#compose-scales-as-child-layers";
-const GUIDE_COORD_CHILDREN = "https://ggsvelte.sh/guide/upgrading#compose-coord-as-a-child-layer";
-const GUIDE_FACET_CHILDREN = "https://ggsvelte.sh/guide/upgrading#compose-facet-as-a-child-layer";
-const GUIDE_THEME_CHILDREN =
-  "https://ggsvelte.sh/guide/upgrading#compose-the-theme-as-a-child-layer";
+function mergeKeyNoun(kind: DuplicateMergeKeyKind): string {
+  return GRAMMAR_FAMILIES[kind].mergeKeyNoun ?? "key";
+}
 
-const GUIDE_LABS_CHILDREN = "https://ggsvelte.sh/guide/upgrading#compose-labs-as-a-child-layer";
-const GUIDE_GUIDES_CHILDREN = "https://ggsvelte.sh/guide/upgrading#compose-guides-as-child-layers";
-const GUIDE_LEGEND_CHILDREN = "https://ggsvelte.sh/guide/upgrading#compose-legend-as-a-child-layer";
-
-const PLOT_LAYER_DOC_URL: Readonly<Record<DuplicatePlotLayerKind, string>> = {
-  coord: GUIDE_COORD_CHILDREN,
-  facet: GUIDE_FACET_CHILDREN,
-  theme: GUIDE_THEME_CHILDREN,
-};
-
-const MERGE_KEY_DOC_URL: Readonly<Record<DuplicateMergeKeyKind, string>> = {
-  labs: GUIDE_LABS_CHILDREN,
-  guides: GUIDE_GUIDES_CHILDREN,
-  legend: GUIDE_LEGEND_CHILDREN,
-};
-
-/** How each merge-key family names the thing that collided, for the message. */
-const MERGE_KEY_NOUN: Readonly<Record<DuplicateMergeKeyKind, string>> = {
-  labs: "label",
-  guides: "channel",
-  legend: "option",
-};
-
-/** The child element authors should look for when a key collides. */
-const MERGE_KEY_CHILD: Readonly<Record<DuplicateMergeKeyKind, string>> = {
-  labs: "<Labs>",
-  guides: "<Guide*>",
-  legend: "<Legend>",
-};
+function mergeKeyChild(kind: DuplicateMergeKeyKind): string {
+  return GRAMMAR_FAMILIES[kind].mergeKeyChild ?? `<${kind}>`;
+}
 
 /**
  * Frozen catalog entry for composition codes. Per-emission fields are filled
@@ -185,7 +165,7 @@ export function duplicateScaleChannelDiagnostic(channel: string): DuplicateScale
       `Keep one scale child per channel — remove all but the intended "${channel}" scale`,
       `British and American spellings write the same channel: <ScaleColorDiscrete/> and <ScaleColourContinuous/> both configure "color"`,
     ],
-    docUrl: GUIDE_SCALE_CHILDREN,
+    docUrl: grammarDocUrl("scale"),
   };
 }
 
@@ -195,6 +175,8 @@ export function duplicateMergeKeyDiagnostic(
   key: string,
 ): DuplicateMergeKeyDiagnostic {
   const entry = COMPOSITION_DIAGNOSTIC_CATALOG.DUPLICATE_MERGE_KEY;
+  const noun = mergeKeyNoun(kind);
+  const child = mergeKeyChild(kind);
   return {
     severity: entry.severity,
     code: "DUPLICATE_MERGE_KEY",
@@ -202,10 +184,10 @@ export function duplicateMergeKeyDiagnostic(
     kind,
     key,
     suggestions: [
-      `Set the ${MERGE_KEY_NOUN[kind]} "${key}" on exactly one ${MERGE_KEY_CHILD[kind]} child`,
-      `${kind} is a MERGE family: siblings that touch different ${MERGE_KEY_NOUN[kind]}s all survive — only "${key}" is overwritten`,
+      `Set the ${noun} "${key}" on exactly one ${child} child`,
+      `${kind} is a MERGE family: siblings that touch different ${noun}s all survive — only "${key}" is overwritten`,
     ],
-    docUrl: MERGE_KEY_DOC_URL[kind],
+    docUrl: grammarDocUrl(kind),
   };
 }
 
@@ -214,15 +196,17 @@ export function duplicatePlotLayerDiagnostic(
   kind: DuplicatePlotLayerKind,
 ): DuplicatePlotLayerDiagnostic {
   const entry = COMPOSITION_DIAGNOSTIC_CATALOG.DUPLICATE_PLOT_LAYER;
+  const shell =
+    kind === "theme" ? "Theme" : kind === "coord" ? "Coord" : kind === "facet" ? "Facet" : kind;
   return {
     severity: entry.severity,
     code: "DUPLICATE_PLOT_LAYER",
     message: entry.messageTemplate(kind),
     kind,
     suggestions: [
-      `Keep one <${kind === "theme" ? "Theme" : kind === "coord" ? "Coord" : "Facet"}*> child — remove earlier ${kind} children so the intended one is the only registration`,
+      `Keep one <${shell}*> child — remove earlier ${kind} children so the intended one is the only registration`,
       `${kind} is a REPLACE family: the last child fully replaces earlier ones (and any ${kind} prop)`,
     ],
-    docUrl: PLOT_LAYER_DOC_URL[kind],
+    docUrl: grammarDocUrl(kind),
   };
 }

--- a/packages/svelte/src/lib/geoms/registry.svelte.ts
+++ b/packages/svelte/src/lib/geoms/registry.svelte.ts
@@ -21,44 +21,10 @@
  */
 import { getContext, onDestroy, setContext } from "svelte";
 
-import type {
-  AesInput,
-  CoordSpec,
-  DataInput,
-  FacetInput,
-  GeomName,
-  GuidesSpec,
-  Labs,
-  LegendSpec,
-  PositionName,
-  PositionParams,
-  RenderBackend,
-  Scales,
-  StatName,
-  ThemeName,
-  ThemeSpec,
-} from "@ggsvelte/spec";
-
-/**
- * A live mark-layer descriptor: properties are getters over the child's
- * $props, so prop updates flow into the plot's derived spec without
- * re-registration. (`| undefined` is explicit so getter-backed objects
- * satisfy the type under exactOptionalPropertyTypes.)
- *
- * `params` is a plain record: each geom component narrows its own props
- * (typed per-geom), and normalize()/validate() enforce the per-geom schema.
- */
-export interface MarkLayerDescriptor {
-  readonly geom: GeomName;
-  readonly stat?: StatName | undefined;
-  readonly aes?: AesInput | undefined;
-  /** Optional layer-local data (#589). */
-  readonly data?: DataInput | readonly Record<string, unknown>[] | undefined;
-  readonly position?: PositionName | undefined;
-  readonly positionParams?: PositionParams | undefined;
-  readonly render?: RenderBackend | undefined;
-  readonly params?: Record<string, unknown> | undefined;
-}
+// #785: Layer / MarkLayerDescriptor live in runes-free layers/types.ts so
+// assemble.ts can share the same union without importing this .svelte.ts file.
+export type { Layer, MarkLayerDescriptor } from "../layers/types.js";
+import type { Layer, MarkLayerDescriptor } from "../layers/types.js";
 
 /**
  * @deprecated since 0.11.0 — use MarkLayerDescriptor.
@@ -66,25 +32,6 @@ export interface MarkLayerDescriptor {
  * https://ggsvelte.sh/guide/upgrading#0-10-to-0-11
  */
 export type LayerDescriptor = MarkLayerDescriptor;
-
-/**
- * Everything a declaration-only child may contribute to a plot.
- * Mark/geom layers map onto `spec.layers`; other kinds fold into top-level
- * portable-spec fields (theme/scale/coord/facet/labs/guides/legend).
- *
- * Live getters are load-bearing for non-mark variants exactly as for marks:
- * `value` reads the child's `$props` proxy so prop changes flow through the
- * plot's `$derived` with zero re-registration.
- */
-export type Layer =
-  | { readonly kind: "mark"; readonly descriptor: MarkLayerDescriptor }
-  | { readonly kind: "scale"; get value(): Scales }
-  | { readonly kind: "theme"; get value(): ThemeName | ThemeSpec }
-  | { readonly kind: "coord"; get value(): CoordSpec | "flip" }
-  | { readonly kind: "facet"; get value(): FacetInput }
-  | { readonly kind: "labs"; get value(): Labs }
-  | { readonly kind: "guides"; get value(): GuidesSpec }
-  | { readonly kind: "legend"; get value(): LegendSpec };
 
 let nextId = 0;
 let globalVersion = 0;

--- a/packages/svelte/src/lib/layers/fold.ts
+++ b/packages/svelte/src/lib/layers/fold.ts
@@ -1,0 +1,56 @@
+/**
+ * Fold non-mark grammar layers onto the fluent builder (#785).
+ * Pure module: no Svelte runes. Safe for assemble.ts.
+ */
+import { gg } from "@ggsvelte/spec";
+
+import { GRAMMAR_FAMILIES } from "./grammar-families.js";
+import type { GrammarLayerKind, PlotLayerLike } from "./types.js";
+
+type GgBuilder = ReturnType<typeof gg>;
+
+/**
+ * Apply one plot layer onto the fluent builder.
+ * Marks are ignored (they travel through `input.layers` / `toLayerInput`).
+ */
+export function foldPlotLayer(builder: GgBuilder, layer: PlotLayerLike): GgBuilder {
+  if (layer.kind === "mark") {
+    return builder;
+  }
+  const family = GRAMMAR_FAMILIES[layer.kind as GrammarLayerKind];
+  if (family === undefined) {
+    const unhandled: never = layer as never;
+    throw new TypeError(`Unhandled plot layer kind: ${String(unhandled)}`);
+  }
+  // Per-kind value types are checked by Layer / PlotLayerLike; one cast at the
+  // fold boundary keeps the table free of builder imports.
+  switch (family.builderMethod) {
+    case "scales":
+      return builder.scales(layer.value as Parameters<GgBuilder["scales"]>[0]);
+    case "theme":
+      return builder.theme(layer.value as Parameters<GgBuilder["theme"]>[0]);
+    case "coord":
+      return builder.coord(layer.value as Parameters<GgBuilder["coord"]>[0]);
+    case "facet":
+      return builder.facet(layer.value as Parameters<GgBuilder["facet"]>[0]);
+    case "labs":
+      return builder.labs(layer.value as Parameters<GgBuilder["labs"]>[0]);
+    case "guides":
+      return builder.guides(layer.value as Parameters<GgBuilder["guides"]>[0]);
+    case "legend":
+      return builder.legend(layer.value as Parameters<GgBuilder["legend"]>[0]);
+    default: {
+      const unhandled: never = family.builderMethod;
+      throw new TypeError(`Unhandled builder method: ${String(unhandled)}`);
+    }
+  }
+}
+
+/** Fold plot layers in registration order (children win over earlier siblings). */
+export function foldPlotLayers(builder: GgBuilder, layers: readonly PlotLayerLike[]): GgBuilder {
+  let next = builder;
+  for (const layer of layers) {
+    next = foldPlotLayer(next, layer);
+  }
+  return next;
+}

--- a/packages/svelte/src/lib/layers/fold.ts
+++ b/packages/svelte/src/lib/layers/fold.ts
@@ -4,8 +4,8 @@
  */
 import { gg } from "@ggsvelte/spec";
 
-import { GRAMMAR_FAMILIES } from "./grammar-families.js";
-import type { GrammarLayerKind, PlotLayerLike } from "./types.js";
+import { GRAMMAR_FAMILIES, type GrammarFamilyMeta } from "./grammar-families.js";
+import type { PlotLayerLike } from "./types.js";
 
 type GgBuilder = ReturnType<typeof gg>;
 
@@ -17,10 +17,13 @@ export function foldPlotLayer(builder: GgBuilder, layer: PlotLayerLike): GgBuild
   if (layer.kind === "mark") {
     return builder;
   }
-  const family = GRAMMAR_FAMILIES[layer.kind as GrammarLayerKind];
+  // Index via string map so unforeseen runtime kinds are undefined (not a
+  // silent miss). Typed callers already exhaust GrammarLayerKind.
+  const family = (GRAMMAR_FAMILIES as Readonly<Record<string, GrammarFamilyMeta | undefined>>)[
+    layer.kind
+  ];
   if (family === undefined) {
-    const unhandled: never = layer as never;
-    throw new TypeError(`Unhandled plot layer kind: ${String(unhandled)}`);
+    throw new TypeError(`Unhandled plot layer kind: ${layer.kind}`);
   }
   // Per-kind value types are checked by Layer / PlotLayerLike; one cast at the
   // fold boundary keeps the table free of builder imports.

--- a/packages/svelte/src/lib/layers/grammar-families.ts
+++ b/packages/svelte/src/lib/layers/grammar-families.ts
@@ -1,0 +1,314 @@
+/**
+ * Single source of truth for the seven grammar families (#785 / #659).
+ *
+ * Prop names, components, composition rules, doc anchors, deprecation windows,
+ * codemod forms, and suggestion copy live here. Consumers look up; they do not
+ * restate. `plot-props.ts` JSDoc keeps since/URL for the deprecation-wiring
+ * guard and is ratcheted against this table.
+ */
+import type { GrammarLayerKind } from "./types.js";
+
+const GUIDE = "https://ggsvelte.sh/guide/upgrading";
+
+/** How sibling children of the same kind compose when folding into the builder. */
+export type GrammarComposition = "merge-by-channel" | "merge-by-key" | "replace";
+
+/** How a deprecated prop's value is handed to its replacement component. */
+export type GrammarCodemodForm = "value" | "spread" | "theme";
+
+/** Fluent-builder method that receives this family's value. */
+export type GrammarBuilderMethod =
+  | "scales"
+  | "theme"
+  | "coord"
+  | "facet"
+  | "labs"
+  | "guides"
+  | "legend";
+
+export type GrammarFamilyMeta = {
+  readonly kind: GrammarLayerKind;
+  /** Deprecated `<GGPlot>` prop name (`scales` for kind `scale`). */
+  readonly propName: string;
+  /** Codemod escape-hatch component name. */
+  readonly component: string;
+  readonly codemodForm: GrammarCodemodForm;
+  readonly composition: GrammarComposition;
+  /** Heading anchor on /guide/upgrading (without `#`). */
+  readonly docAnchor: string;
+  readonly since: string;
+  readonly removeIn: string;
+  readonly suggestions: readonly string[];
+  readonly builderMethod: GrammarBuilderMethod;
+  /** DUPLICATE_MERGE_KEY message helpers (merge-by-key only). */
+  readonly mergeKeyNoun?: string;
+  readonly mergeKeyChild?: string;
+};
+
+type GrammarFamilies = {
+  readonly [K in GrammarLayerKind]: GrammarFamilyMeta & { readonly kind: K };
+};
+
+/**
+ * Authoritative metadata for every non-mark grammar family.
+ * Key order is insertion order (scale → theme → …); consumers that need a
+ * different emission order must use the explicit order constants below.
+ */
+export const GRAMMAR_FAMILIES: GrammarFamilies = {
+  scale: {
+    kind: "scale",
+    propName: "scales",
+    component: "Scale",
+    codemodForm: "value",
+    composition: "merge-by-channel",
+    docAnchor: "compose-scales-as-child-layers",
+    since: "0.11.0",
+    removeIn: "0.13.0",
+    builderMethod: "scales",
+    suggestions: [
+      'Replace scales={scaleColorDiscrete({scheme:"colorblind"})} with <ScaleColorDiscrete scheme="colorblind" />',
+      "Prefer named shells (<ScaleXContinuous/>, <ScaleSizeContinuous/>, <ScaleShapeDiscrete/>, …) for every family",
+      "Use <Scale value={…} /> as the escape hatch for raw/computed scale fragments",
+    ],
+  },
+  theme: {
+    kind: "theme",
+    propName: "theme",
+    component: "Theme",
+    codemodForm: "theme",
+    composition: "replace",
+    docAnchor: "compose-the-theme-as-a-child-layer",
+    since: "0.11.0",
+    removeIn: "0.13.0",
+    builderMethod: "theme",
+    suggestions: [
+      'Replace theme="dark" with <ThemeDark /> (or <Theme name="dark" />)',
+      'Role overrides stay as props on the child: <ThemeDark ink="#eee" />',
+    ],
+  },
+  coord: {
+    kind: "coord",
+    propName: "coord",
+    component: "Coord",
+    codemodForm: "value",
+    composition: "replace",
+    docAnchor: "compose-coord-as-a-child-layer",
+    since: "0.11.0",
+    removeIn: "0.13.0",
+    builderMethod: "coord",
+    suggestions: [
+      'Replace coord="flip" with <CoordFlip />',
+      "Use <CoordFixed ratio={…} />, <CoordTransform />, or <Coord value={…} /> for other systems",
+    ],
+  },
+  facet: {
+    kind: "facet",
+    propName: "facet",
+    component: "Facet",
+    codemodForm: "spread",
+    composition: "replace",
+    docAnchor: "compose-facet-as-a-child-layer",
+    since: "0.11.0",
+    removeIn: "0.13.0",
+    builderMethod: "facet",
+    suggestions: [
+      'Replace facet={{wrap:"g"}} with <FacetWrap field="g" />',
+      'Use <FacetGrid rows="a" cols="b" /> for a grid, or <Facet wrap={…} /> for the full FacetInput surface',
+    ],
+  },
+  labs: {
+    kind: "labs",
+    propName: "labs",
+    component: "Labs",
+    codemodForm: "spread",
+    composition: "merge-by-key",
+    docAnchor: "compose-labs-as-a-child-layer",
+    since: "0.11.0",
+    removeIn: "0.13.0",
+    builderMethod: "labs",
+    mergeKeyNoun: "label",
+    mergeKeyChild: "<Labs>",
+    suggestions: [
+      'Replace labs={{title:"Sales"}} with <Labs title="Sales" />',
+      'Per-aesthetic titles stay named props on the child: <Labs x="Quarter" color="Region" />',
+    ],
+  },
+  guides: {
+    kind: "guides",
+    propName: "guides",
+    component: "Guides",
+    codemodForm: "value",
+    composition: "merge-by-key",
+    docAnchor: "compose-guides-as-child-layers",
+    since: "0.11.0",
+    removeIn: "0.13.0",
+    builderMethod: "guides",
+    mergeKeyNoun: "channel",
+    mergeKeyChild: "<Guide*>",
+    suggestions: [
+      'Replace guides={{color:guideLegend({position:"bottom"})}} with <GuideLegend channel="color" position="bottom" />',
+      'The aesthetic is the channel prop: <GuideAxis channel="x"/>, <GuideNone channel="size"/>, …',
+      "Use <Guides value={…} /> as the escape hatch for raw/computed guide bags",
+    ],
+  },
+  legend: {
+    kind: "legend",
+    propName: "legend",
+    component: "Legend",
+    codemodForm: "spread",
+    composition: "merge-by-key",
+    docAnchor: "compose-legend-as-a-child-layer",
+    since: "0.11.0",
+    removeIn: "0.13.0",
+    builderMethod: "legend",
+    mergeKeyNoun: "option",
+    mergeKeyChild: "<Legend>",
+    suggestions: [
+      'Replace legend={{order:"sorted"}} with <Legend order="sorted" />',
+      "<Legend order> is the plot-wide entry-sort enum; <GuideLegend order={2}/> is a per-aesthetic placement rank",
+    ],
+  },
+};
+
+/** Deprecation advisory emission order (preserves pre-#785 ladder). */
+export const DEPRECATION_EMIT_ORDER: readonly GrammarLayerKind[] = [
+  "theme",
+  "scale",
+  "coord",
+  "facet",
+  "guides",
+  "legend",
+  "labs",
+] as const;
+
+/**
+ * GGPlotProps / codemod RULES order (declaration order in plot-props.ts).
+ * Codemod `changes[]` ordering depends on this.
+ */
+export const GGPLOT_PROP_ORDER: readonly GrammarLayerKind[] = [
+  "facet",
+  "coord",
+  "scale",
+  "guides",
+  "legend",
+  "theme",
+  "labs",
+] as const;
+
+/** DUPLICATE_MERGE_KEY advisory emission order. */
+export const MERGE_KEY_EMIT_ORDER = [
+  "labs",
+  "guides",
+  "legend",
+] as const satisfies readonly GrammarLayerKind[];
+
+/** DUPLICATE_PLOT_LAYER advisory emission order. */
+export const REPLACE_EMIT_ORDER = [
+  "coord",
+  "facet",
+  "theme",
+] as const satisfies readonly GrammarLayerKind[];
+
+export type MergeByKeyKind = (typeof MERGE_KEY_EMIT_ORDER)[number];
+export type ReplaceKind = (typeof REPLACE_EMIT_ORDER)[number];
+
+export function grammarFamily(kind: GrammarLayerKind): GrammarFamilyMeta {
+  return GRAMMAR_FAMILIES[kind];
+}
+
+export function grammarFamilyByProp(propName: string): GrammarFamilyMeta | undefined {
+  for (const kind of DEPRECATION_EMIT_ORDER) {
+    const family = GRAMMAR_FAMILIES[kind];
+    if (family.propName === propName) return family;
+  }
+  return undefined;
+}
+
+/** Deprecated GGPlot prop names in GGPlotProps order. */
+export const GRAMMAR_PROP_NAMES: readonly string[] = GGPLOT_PROP_ORDER.map(
+  (kind) => GRAMMAR_FAMILIES[kind].propName,
+);
+
+/** Full upgrading-guide docUrl for a family. */
+export function grammarDocUrl(kind: GrammarLayerKind): string {
+  return `${GUIDE}#${GRAMMAR_FAMILIES[kind].docAnchor}`;
+}
+
+/** Absolute docUrls for every family (catalog-anchor tests). */
+export const GRAMMAR_DOC_URLS: readonly string[] = (
+  Object.keys(GRAMMAR_FAMILIES) as GrammarLayerKind[]
+).map((kind) => grammarDocUrl(kind));
+
+/**
+ * Regex matching deprecated grammar props on `<GGPlot` or at line start.
+ * Same shape as the pre-#785 `DEPRECATED_PROP` in repo-child-layers.
+ */
+export function deprecatedGrammarPropPattern(): RegExp {
+  const names = GRAMMAR_PROP_NAMES.join("|");
+  return new RegExp(`(?:^\\s*|<GGPlot\\s+)(${names})=`, "gm");
+}
+
+/** Codemod rule bag keyed by prop name, in GGPLOT_PROP_ORDER. */
+export function grammarCodemodRules(): Readonly<
+  Record<
+    string,
+    { readonly component: string; readonly form: GrammarCodemodForm; readonly docUrl: string }
+  >
+> {
+  const rules: Record<
+    string,
+    { readonly component: string; readonly form: GrammarCodemodForm; readonly docUrl: string }
+  > = {};
+  for (const kind of GGPLOT_PROP_ORDER) {
+    const family = GRAMMAR_FAMILIES[kind];
+    rules[family.propName] = {
+      component: family.component,
+      form: family.codemodForm,
+      docUrl: grammarDocUrl(kind),
+    };
+  }
+  return rules;
+}
+
+export type GrammarPropReaders = {
+  readonly theme: () => unknown;
+  readonly scales: () => unknown;
+  readonly coord: () => unknown;
+  readonly facet: () => unknown;
+  readonly guides: () => unknown;
+  readonly legend: () => unknown;
+  readonly labs: () => unknown;
+};
+
+/**
+ * Build deprecation diagnostic inputs for every defined grammar prop,
+ * in {@link DEPRECATION_EMIT_ORDER}.
+ */
+export function grammarDeprecationInputs(readers: GrammarPropReaders): ReadonlyArray<{
+  readonly prop: string;
+  readonly since: string;
+  readonly removeIn: string;
+  readonly suggestions: readonly string[];
+  readonly anchor: string;
+}> {
+  const out: Array<{
+    readonly prop: string;
+    readonly since: string;
+    readonly removeIn: string;
+    readonly suggestions: readonly string[];
+    readonly anchor: string;
+  }> = [];
+  for (const kind of DEPRECATION_EMIT_ORDER) {
+    const family = GRAMMAR_FAMILIES[kind];
+    const reader = readers[family.propName as keyof GrammarPropReaders];
+    if (reader() === undefined) continue;
+    out.push({
+      prop: family.propName,
+      since: family.since,
+      removeIn: family.removeIn,
+      suggestions: family.suggestions,
+      anchor: family.docAnchor,
+    });
+  }
+  return out;
+}

--- a/packages/svelte/src/lib/layers/grammar-families.ts
+++ b/packages/svelte/src/lib/layers/grammar-families.ts
@@ -11,20 +11,13 @@ import type { GrammarLayerKind } from "./types.js";
 const GUIDE = "https://ggsvelte.sh/guide/upgrading";
 
 /** How sibling children of the same kind compose when folding into the builder. */
-export type GrammarComposition = "merge-by-channel" | "merge-by-key" | "replace";
+type GrammarComposition = "merge-by-channel" | "merge-by-key" | "replace";
 
 /** How a deprecated prop's value is handed to its replacement component. */
 export type GrammarCodemodForm = "value" | "spread" | "theme";
 
 /** Fluent-builder method that receives this family's value. */
-export type GrammarBuilderMethod =
-  | "scales"
-  | "theme"
-  | "coord"
-  | "facet"
-  | "labs"
-  | "guides"
-  | "legend";
+type GrammarBuilderMethod = "scales" | "theme" | "coord" | "facet" | "labs" | "guides" | "legend";
 
 export type GrammarFamilyMeta = {
   readonly kind: GrammarLayerKind;
@@ -211,10 +204,6 @@ export const REPLACE_EMIT_ORDER = [
 
 export type MergeByKeyKind = (typeof MERGE_KEY_EMIT_ORDER)[number];
 export type ReplaceKind = (typeof REPLACE_EMIT_ORDER)[number];
-
-export function grammarFamily(kind: GrammarLayerKind): GrammarFamilyMeta {
-  return GRAMMAR_FAMILIES[kind];
-}
 
 export function grammarFamilyByProp(propName: string): GrammarFamilyMeta | undefined {
   for (const kind of DEPRECATION_EMIT_ORDER) {

--- a/packages/svelte/src/lib/layers/types.ts
+++ b/packages/svelte/src/lib/layers/types.ts
@@ -1,0 +1,78 @@
+/**
+ * Runes-free layer types shared by the registry (`.svelte.ts`) and pure
+ * assembly (`assemble.ts`). #785: one `Layer` union — no structural clone.
+ */
+import type {
+  AesInput,
+  CoordSpec,
+  DataInput,
+  FacetInput,
+  GeomName,
+  GuidesSpec,
+  Labs,
+  LegendSpec,
+  PositionName,
+  PositionParams,
+  RenderBackend,
+  Scales,
+  StatName,
+  ThemeName,
+  ThemeSpec,
+} from "@ggsvelte/spec";
+
+/**
+ * A live mark-layer descriptor: properties are getters over the child's
+ * `$props`, so prop updates flow into the plot's derived spec without
+ * re-registration. (`| undefined` is explicit so getter-backed objects
+ * satisfy the type under exactOptionalPropertyTypes.)
+ *
+ * `params` is a plain record: each geom component narrows its own props
+ * (typed per-geom), and normalize()/validate() enforce the per-geom schema.
+ */
+export interface MarkLayerDescriptor {
+  readonly geom: GeomName;
+  readonly stat?: StatName | undefined;
+  readonly aes?: AesInput | undefined;
+  /** Optional layer-local data (#589). */
+  readonly data?: DataInput | readonly Record<string, unknown>[] | undefined;
+  readonly position?: PositionName | undefined;
+  readonly positionParams?: PositionParams | undefined;
+  readonly render?: RenderBackend | undefined;
+  readonly params?: Record<string, unknown> | undefined;
+}
+
+/**
+ * Everything a declaration-only child may contribute to a plot.
+ * Mark/geom layers map onto `spec.layers`; other kinds fold into top-level
+ * portable-spec fields (theme/scale/coord/facet/labs/guides/legend).
+ *
+ * Live getters are load-bearing for non-mark variants exactly as for marks:
+ * `value` reads the child's `$props` proxy so prop changes flow through the
+ * plot's `$derived` with zero re-registration.
+ */
+export type Layer =
+  | { readonly kind: "mark"; readonly descriptor: MarkLayerDescriptor }
+  | { readonly kind: "scale"; get value(): Scales }
+  | { readonly kind: "theme"; get value(): ThemeName | ThemeSpec }
+  | { readonly kind: "coord"; get value(): CoordSpec | "flip" }
+  | { readonly kind: "facet"; get value(): FacetInput }
+  | { readonly kind: "labs"; get value(): Labs }
+  | { readonly kind: "guides"; get value(): GuidesSpec }
+  | { readonly kind: "legend"; get value(): LegendSpec };
+
+/** Non-mark grammar layer kinds (the seven #659 families). */
+export type GrammarLayerKind = Exclude<Layer["kind"], "mark">;
+
+/**
+ * Structural form accepted by fold/assemble: `value` may be a live getter or a
+ * plain field. Compatible with registry `Layer` objects and test literals.
+ */
+export type PlotLayerLike =
+  | { readonly kind: "mark"; readonly descriptor: MarkLayerDescriptor }
+  | { readonly kind: "scale"; readonly value: Scales }
+  | { readonly kind: "theme"; readonly value: ThemeName | ThemeSpec }
+  | { readonly kind: "coord"; readonly value: CoordSpec | "flip" }
+  | { readonly kind: "facet"; readonly value: FacetInput }
+  | { readonly kind: "labs"; readonly value: Labs }
+  | { readonly kind: "guides"; readonly value: GuidesSpec }
+  | { readonly kind: "legend"; readonly value: LegendSpec };

--- a/packages/svelte/src/lib/plot-interaction-assembly.svelte.ts
+++ b/packages/svelte/src/lib/plot-interaction-assembly.svelte.ts
@@ -27,6 +27,11 @@ import {
   type DeprecationDiagnostic,
   type PlotDiagnostic,
 } from "./diagnostics/deprecation.js";
+import {
+  MERGE_KEY_EMIT_ORDER,
+  REPLACE_EMIT_ORDER,
+  grammarDeprecationInputs,
+} from "./layers/grammar-families.js";
 import type {
   InteractionDiagnostic,
   PlotInteractionScope,
@@ -52,6 +57,14 @@ import { createSurfaceState } from "./surface/surface-state.svelte.js";
 import { createSelectionState, type SelectionState } from "./selection/selection-state.svelte.js";
 import { presentationChromeForKind } from "./selection/selection.js";
 import { createPlotChromeState } from "./chrome/chrome-state.svelte.js";
+
+function isMergeKeyKind(kind: string): kind is DuplicateMergeKeyKind {
+  return (MERGE_KEY_EMIT_ORDER as readonly string[]).includes(kind);
+}
+
+function isReplaceKind(kind: string): kind is DuplicatePlotLayerKind {
+  return (REPLACE_EMIT_ORDER as readonly string[]).includes(kind);
+}
 
 export type PlotInteractionAssemblyDeps<
   Row extends Record<string, CellValue> = Record<string, CellValue>,
@@ -127,113 +140,21 @@ export function createPlotInteractionAssembly<
     }
   });
 
-  // Grammar-prop deprecations (#659): one advisory per deprecated prop that is
-  // !== undefined. Decidable from raw props — assembly does not participate.
-  // Reuses deliverDiagnostic and the same code:prop dedup Set as wiring.
-  const deprecationDiagnostics = $derived.by((): DeprecationDiagnostic[] => {
-    const list: DeprecationDiagnostic[] = [];
-    if (inputs.theme() !== undefined) {
-      list.push(
-        deprecatedPropDiagnostic({
-          prop: "theme",
-          since: "0.11.0",
-          removeIn: "0.13.0",
-          suggestions: [
-            'Replace theme="dark" with <ThemeDark /> (or <Theme name="dark" />)',
-            'Role overrides stay as props on the child: <ThemeDark ink="#eee" />',
-          ],
-          anchor: "compose-the-theme-as-a-child-layer",
-        }),
-      );
-    }
-    if (inputs.scales() !== undefined) {
-      list.push(
-        deprecatedPropDiagnostic({
-          prop: "scales",
-          since: "0.11.0",
-          removeIn: "0.13.0",
-          suggestions: [
-            'Replace scales={scaleColorDiscrete({scheme:"colorblind"})} with <ScaleColorDiscrete scheme="colorblind" />',
-            "Prefer named shells (<ScaleXContinuous/>, <ScaleSizeContinuous/>, <ScaleShapeDiscrete/>, …) for every family",
-            "Use <Scale value={…} /> as the escape hatch for raw/computed scale fragments",
-          ],
-          anchor: "compose-scales-as-child-layers",
-        }),
-      );
-    }
-    if (inputs.coord() !== undefined) {
-      list.push(
-        deprecatedPropDiagnostic({
-          prop: "coord",
-          since: "0.11.0",
-          removeIn: "0.13.0",
-          suggestions: [
-            'Replace coord="flip" with <CoordFlip />',
-            "Use <CoordFixed ratio={…} />, <CoordTransform />, or <Coord value={…} /> for other systems",
-          ],
-          anchor: "compose-coord-as-a-child-layer",
-        }),
-      );
-    }
-    if (inputs.facet() !== undefined) {
-      list.push(
-        deprecatedPropDiagnostic({
-          prop: "facet",
-          since: "0.11.0",
-          removeIn: "0.13.0",
-          suggestions: [
-            'Replace facet={{wrap:"g"}} with <FacetWrap field="g" />',
-            'Use <FacetGrid rows="a" cols="b" /> for a grid, or <Facet wrap={…} /> for the full FacetInput surface',
-          ],
-          anchor: "compose-facet-as-a-child-layer",
-        }),
-      );
-    }
-    if (inputs.guides() !== undefined) {
-      list.push(
-        deprecatedPropDiagnostic({
-          prop: "guides",
-          since: "0.11.0",
-          removeIn: "0.13.0",
-          suggestions: [
-            'Replace guides={{color:guideLegend({position:"bottom"})}} with <GuideLegend channel="color" position="bottom" />',
-            'The aesthetic is the channel prop: <GuideAxis channel="x"/>, <GuideNone channel="size"/>, …',
-            "Use <Guides value={…} /> as the escape hatch for raw/computed guide bags",
-          ],
-          anchor: "compose-guides-as-child-layers",
-        }),
-      );
-    }
-    if (inputs.legend() !== undefined) {
-      list.push(
-        deprecatedPropDiagnostic({
-          prop: "legend",
-          since: "0.11.0",
-          removeIn: "0.13.0",
-          suggestions: [
-            'Replace legend={{order:"sorted"}} with <Legend order="sorted" />',
-            "<Legend order> is the plot-wide entry-sort enum; <GuideLegend order={2}/> is a per-aesthetic placement rank",
-          ],
-          anchor: "compose-legend-as-a-child-layer",
-        }),
-      );
-    }
-    if (inputs.labs() !== undefined) {
-      list.push(
-        deprecatedPropDiagnostic({
-          prop: "labs",
-          since: "0.11.0",
-          removeIn: "0.13.0",
-          suggestions: [
-            'Replace labs={{title:"Sales"}} with <Labs title="Sales" />',
-            'Per-aesthetic titles stay named props on the child: <Labs x="Quarter" color="Region" />',
-          ],
-          anchor: "compose-labs-as-a-child-layer",
-        }),
-      );
-    }
-    return list;
-  });
+  // Grammar-prop deprecations (#659 / #785): table-driven via GRAMMAR_FAMILIES.
+  // One advisory per deprecated prop that is !== undefined. Decidable from
+  // raw props — assembly does not participate. Reuses deliverDiagnostic and
+  // the same code:prop dedup Set as wiring. Emission order is DEPRECATION_EMIT_ORDER.
+  const deprecationDiagnostics = $derived.by((): DeprecationDiagnostic[] =>
+    grammarDeprecationInputs({
+      theme: inputs.theme,
+      scales: inputs.scales,
+      coord: inputs.coord,
+      facet: inputs.facet,
+      guides: inputs.guides,
+      legend: inputs.legend,
+      labs: inputs.labs,
+    }).map((input) => deprecatedPropDiagnostic(input)),
+  );
   $effect(() => {
     for (const diagnostic of deprecationDiagnostics) {
       const dedupKey = `${diagnostic.code}:${diagnostic.prop}`;
@@ -254,23 +175,19 @@ export function createPlotInteractionAssembly<
     const list: CompositionDiagnostic[] = [];
     const seenChannels = new Set<string>();
     const duplicateChannels = new Set<string>();
-    // One scan over every keyed-MERGE family. Scales keep their own advisory
-    // code (0.11.0 surface); labs/guides/legend share DUPLICATE_MERGE_KEY.
-    const mergeSeen: Record<DuplicateMergeKeyKind, Set<string>> = {
-      labs: new Set(),
-      guides: new Set(),
-      legend: new Set(),
-    };
-    const mergeDuplicates: Record<DuplicateMergeKeyKind, Set<string>> = {
-      labs: new Set(),
-      guides: new Set(),
-      legend: new Set(),
-    };
-    const replaceCounts: Record<DuplicatePlotLayerKind, number> = {
-      coord: 0,
-      facet: 0,
-      theme: 0,
-    };
+    // Kind membership and emit order come from GRAMMAR_FAMILIES (#785).
+    // Scales keep their own advisory code (0.11.0 surface); labs/guides/legend
+    // share DUPLICATE_MERGE_KEY.
+    const mergeSeen = Object.fromEntries(
+      MERGE_KEY_EMIT_ORDER.map((k) => [k, new Set<string>()]),
+    ) as Record<DuplicateMergeKeyKind, Set<string>>;
+    const mergeDuplicates = Object.fromEntries(
+      MERGE_KEY_EMIT_ORDER.map((k) => [k, new Set<string>()]),
+    ) as Record<DuplicateMergeKeyKind, Set<string>>;
+    const replaceCounts = Object.fromEntries(REPLACE_EMIT_ORDER.map((k) => [k, 0])) as Record<
+      DuplicatePlotLayerKind,
+      number
+    >;
     for (const layer of inputs.registry.layers) {
       if (layer.kind === "scale") {
         for (const channel of Object.keys(layer.value)) {
@@ -282,29 +199,33 @@ export function createPlotInteractionAssembly<
         }
         continue;
       }
-      if (layer.kind === "labs" || layer.kind === "guides" || layer.kind === "legend") {
-        for (const key of Object.keys(layer.value)) {
-          if (mergeSeen[layer.kind].has(key)) {
-            mergeDuplicates[layer.kind].add(key);
+      if (isMergeKeyKind(layer.kind)) {
+        // Narrow via kind predicate + assertion: Layer's value getter is only
+        // on non-mark arms; kind membership is table-driven (#785).
+        const kind = layer.kind;
+        const value = (layer as { readonly value: object }).value;
+        for (const key of Object.keys(value)) {
+          if (mergeSeen[kind].has(key)) {
+            mergeDuplicates[kind].add(key);
           } else {
-            mergeSeen[layer.kind].add(key);
+            mergeSeen[kind].add(key);
           }
         }
         continue;
       }
-      if (layer.kind === "coord" || layer.kind === "facet" || layer.kind === "theme") {
+      if (isReplaceKind(layer.kind)) {
         replaceCounts[layer.kind] += 1;
       }
     }
     for (const channel of duplicateChannels) {
       list.push(duplicateScaleChannelDiagnostic(channel));
     }
-    for (const kind of ["labs", "guides", "legend"] as const) {
+    for (const kind of MERGE_KEY_EMIT_ORDER) {
       for (const key of mergeDuplicates[kind]) {
         list.push(duplicateMergeKeyDiagnostic(kind, key));
       }
     }
-    for (const kind of ["coord", "facet", "theme"] as const) {
+    for (const kind of REPLACE_EMIT_ORDER) {
       if (replaceCounts[kind] > 1) {
         list.push(duplicatePlotLayerDiagnostic(kind));
       }

--- a/packages/svelte/tests/layers/fold.ssr.test.ts
+++ b/packages/svelte/tests/layers/fold.ssr.test.ts
@@ -1,0 +1,69 @@
+/**
+ * #785: foldPlotLayer is the pure seam that replaces assemble.applyPlotLayer.
+ */
+import { gg } from "@ggsvelte/spec";
+import { describe, expect, it } from "vitest";
+
+import { foldPlotLayer, foldPlotLayers } from "../../src/lib/layers/fold.js";
+
+const rows = [
+  { x: 1, y: 2 },
+  { x: 3, y: 4 },
+];
+
+function base() {
+  return gg(rows, { x: "x", y: "y" }).layer({ geom: "point" });
+}
+
+describe("foldPlotLayer", () => {
+  it("applies the matching builder method per kind", () => {
+    expect(foldPlotLayer(base(), { kind: "theme", value: "dark" }).spec().theme).toBe("dark");
+    expect(foldPlotLayer(base(), { kind: "coord", value: "flip" }).spec().coord).toEqual({
+      type: "flip",
+    });
+    expect(foldPlotLayer(base(), { kind: "labs", value: { title: "T" } }).spec().labs?.title).toBe(
+      "T",
+    );
+    expect(
+      foldPlotLayer(base(), {
+        kind: "facet",
+        value: { wrap: "g" },
+      }).spec().facet,
+    ).toBeDefined();
+    expect(
+      foldPlotLayer(base(), {
+        kind: "legend",
+        value: { order: "sorted" },
+      }).spec().legend,
+    ).toBeDefined();
+  });
+
+  it("is a no-op for mark layers", () => {
+    const before = base().spec();
+    const after = foldPlotLayer(base(), {
+      kind: "mark",
+      descriptor: { geom: "line" },
+    }).spec();
+    expect(after.layers).toEqual(before.layers);
+    expect(after.theme).toEqual(before.theme);
+  });
+
+  it("preserves array order when folding multiple layers", () => {
+    const spec = foldPlotLayers(base(), [
+      { kind: "theme", value: "light" },
+      { kind: "theme", value: "dark" },
+      { kind: "labs", value: { title: "first" } },
+      { kind: "labs", value: { subtitle: "second" } },
+    ]).spec();
+    // REPLACE family: last theme wins.
+    expect(spec.theme).toBe("dark");
+    // MERGE family: later keys win / combine (builder shallow merge).
+    expect(spec.labs?.subtitle).toBe("second");
+  });
+
+  it("throws TypeError for an unknown kind at runtime", () => {
+    expect(() => foldPlotLayer(base(), { kind: "nope", value: {} } as never)).toThrowError(
+      /Unhandled plot layer kind/,
+    );
+  });
+});

--- a/packages/svelte/tests/layers/fold.ssr.test.ts
+++ b/packages/svelte/tests/layers/fold.ssr.test.ts
@@ -62,7 +62,7 @@ describe("foldPlotLayer", () => {
   });
 
   it("throws TypeError for an unknown kind at runtime", () => {
-    expect(() => foldPlotLayer(base(), { kind: "nope", value: {} } as never)).toThrowError(
+    expect(() => foldPlotLayer(base(), { kind: "nope", value: {} } as never)).toThrow(
       /Unhandled plot layer kind/,
     );
   });

--- a/packages/svelte/tests/layers/grammar-families.ssr.test.ts
+++ b/packages/svelte/tests/layers/grammar-families.ssr.test.ts
@@ -130,9 +130,7 @@ describe("GRAMMAR_FAMILIES completeness", () => {
 
 describe("grammarDeprecationInputs", () => {
   it("emits only defined props in DEPRECATION_EMIT_ORDER", () => {
-    const absent = (): unknown => {
-      return;
-    };
+    const absent = (): unknown => undefined;
     const inputs = grammarDeprecationInputs({
       theme: () => "dark",
       scales: absent,

--- a/packages/svelte/tests/layers/grammar-families.ssr.test.ts
+++ b/packages/svelte/tests/layers/grammar-families.ssr.test.ts
@@ -1,0 +1,161 @@
+/**
+ * #785: GRAMMAR_FAMILIES is the single metadata home for grammar families.
+ * Cross-checks against known constants and partitions — not self-tautologies.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  DEPRECATION_EMIT_ORDER,
+  GGPLOT_PROP_ORDER,
+  GRAMMAR_DOC_URLS,
+  GRAMMAR_FAMILIES,
+  GRAMMAR_PROP_NAMES,
+  MERGE_KEY_EMIT_ORDER,
+  REPLACE_EMIT_ORDER,
+  deprecatedGrammarPropPattern,
+  grammarCodemodRules,
+  grammarDeprecationInputs,
+  grammarDocUrl,
+  grammarFamilyByProp,
+} from "../../src/lib/layers/grammar-families.js";
+import type { GrammarLayerKind, Layer } from "../../src/lib/layers/types.js";
+
+const ALL_KINDS = Object.keys(GRAMMAR_FAMILIES) as GrammarLayerKind[];
+
+/** Expected prop set (pre-#785 RULES keys / plot-props grammar props). */
+const EXPECTED_PROPS = ["facet", "coord", "scales", "guides", "legend", "theme", "labs"] as const;
+
+describe("GRAMMAR_FAMILIES completeness", () => {
+  it("covers exactly the seven non-mark layer kinds", () => {
+    expect(new Set(ALL_KINDS)).toEqual(
+      new Set(["scale", "theme", "coord", "facet", "labs", "guides", "legend"]),
+    );
+    // Kind key equals row.kind for every entry.
+    for (const kind of ALL_KINDS) {
+      expect(GRAMMAR_FAMILIES[kind].kind).toBe(kind);
+    }
+  });
+
+  it("GrammarLayerKind is Exclude<Layer['kind'], 'mark'> (type + runtime)", () => {
+    type Expected = Exclude<Layer["kind"], "mark">;
+    // Compile-time assignability: ALL_KINDS must be assignable to Expected[].
+    const kinds: Expected[] = ALL_KINDS;
+    expect(kinds.includes("mark" as GrammarLayerKind)).toBe(false);
+  });
+
+  it("propNames match the seven deprecated GGPlot props (scale → scales)", () => {
+    expect(new Set(GRAMMAR_PROP_NAMES)).toEqual(new Set(EXPECTED_PROPS));
+    expect(GRAMMAR_FAMILIES.scale.propName).toBe("scales");
+    expect(grammarFamilyByProp("scales")?.kind).toBe("scale");
+  });
+
+  it("composition partition matches pre-#785 MERGE/REPLACE taxonomy", () => {
+    expect(GRAMMAR_FAMILIES.scale.composition).toBe("merge-by-channel");
+    for (const kind of MERGE_KEY_EMIT_ORDER) {
+      expect(GRAMMAR_FAMILIES[kind].composition).toBe("merge-by-key");
+      expect(GRAMMAR_FAMILIES[kind].mergeKeyNoun).toBeTruthy();
+      expect(GRAMMAR_FAMILIES[kind].mergeKeyChild).toBeTruthy();
+    }
+    for (const kind of REPLACE_EMIT_ORDER) {
+      expect(GRAMMAR_FAMILIES[kind].composition).toBe("replace");
+    }
+  });
+
+  it("order constants are complete permutations / composition subsets", () => {
+    expect(new Set(DEPRECATION_EMIT_ORDER)).toEqual(new Set(ALL_KINDS));
+    expect(new Set(GGPLOT_PROP_ORDER)).toEqual(new Set(ALL_KINDS));
+    // Deprecation ladder historical order.
+    expect([...DEPRECATION_EMIT_ORDER]).toEqual([
+      "theme",
+      "scale",
+      "coord",
+      "facet",
+      "guides",
+      "legend",
+      "labs",
+    ]);
+    // GGPlotProps / codemod declaration order.
+    expect([...GGPLOT_PROP_ORDER]).toEqual([
+      "facet",
+      "coord",
+      "scale",
+      "guides",
+      "legend",
+      "theme",
+      "labs",
+    ]);
+    expect([...MERGE_KEY_EMIT_ORDER]).toEqual(["labs", "guides", "legend"]);
+    expect([...REPLACE_EMIT_ORDER]).toEqual(["coord", "facet", "theme"]);
+  });
+
+  it("docUrls match the pre-#785 runtime advisory catalog list", () => {
+    const expected = [
+      "https://ggsvelte.sh/guide/upgrading#compose-scales-as-child-layers",
+      "https://ggsvelte.sh/guide/upgrading#compose-the-theme-as-a-child-layer",
+      "https://ggsvelte.sh/guide/upgrading#compose-coord-as-a-child-layer",
+      "https://ggsvelte.sh/guide/upgrading#compose-facet-as-a-child-layer",
+      "https://ggsvelte.sh/guide/upgrading#compose-labs-as-a-child-layer",
+      "https://ggsvelte.sh/guide/upgrading#compose-guides-as-child-layers",
+      "https://ggsvelte.sh/guide/upgrading#compose-legend-as-a-child-layer",
+    ];
+    expect(new Set(GRAMMAR_DOC_URLS)).toEqual(new Set(expected));
+    expect(grammarDocUrl("theme")).toBe(
+      "https://ggsvelte.sh/guide/upgrading#compose-the-theme-as-a-child-layer",
+    );
+  });
+
+  it("codemod rules preserve GGPlotProps order and pre-#785 forms", () => {
+    const rules = grammarCodemodRules();
+    expect(Object.keys(rules)).toEqual([...EXPECTED_PROPS]);
+    expect(rules.coord).toEqual({
+      component: "Coord",
+      form: "value",
+      docUrl: "https://ggsvelte.sh/guide/upgrading#compose-coord-as-a-child-layer",
+    });
+    expect(rules.theme?.form).toBe("theme");
+    expect(rules.facet?.form).toBe("spread");
+    expect(rules.labs?.form).toBe("spread");
+    expect(rules.scales?.form).toBe("value");
+  });
+
+  it("suggestion copy matches the pre-#785 deprecation ladder (theme + labs samples)", () => {
+    expect(GRAMMAR_FAMILIES.theme.suggestions).toEqual([
+      'Replace theme="dark" with <ThemeDark /> (or <Theme name="dark" />)',
+      'Role overrides stay as props on the child: <ThemeDark ink="#eee" />',
+    ]);
+    expect(GRAMMAR_FAMILIES.labs.suggestions[0]).toContain("<Labs title=");
+    expect(GRAMMAR_FAMILIES.scale.suggestions).toHaveLength(3);
+  });
+});
+
+describe("grammarDeprecationInputs", () => {
+  it("emits only defined props in DEPRECATION_EMIT_ORDER", () => {
+    const absent = (): unknown => {
+      return;
+    };
+    const inputs = grammarDeprecationInputs({
+      theme: () => "dark",
+      scales: absent,
+      coord: () => "flip",
+      facet: absent,
+      guides: absent,
+      legend: absent,
+      labs: () => ({ title: "T" }),
+    });
+    expect(inputs.map((d) => d.prop)).toEqual(["theme", "coord", "labs"]);
+    expect(inputs[0]?.since).toBe("0.11.0");
+    expect(inputs[0]?.removeIn).toBe("0.13.0");
+    expect(inputs[0]?.anchor).toBe("compose-the-theme-as-a-child-layer");
+  });
+});
+
+describe("deprecatedGrammarPropPattern", () => {
+  it("matches the seven props the way repo-child-layers did", () => {
+    const re = deprecatedGrammarPropPattern();
+    const source = `<GGPlot\n  facet={{wrap:"g"}}\n  theme="dark"\n  scales={{}}\n/>`;
+    const hits = [...source.matchAll(re)].map((m) => m[1]);
+    expect(hits).toEqual(["facet", "theme", "scales"]);
+    // Child components must not trip it.
+    expect(`<Theme name="dark" />`.match(re)).toBeNull();
+  });
+});

--- a/packages/svelte/tests/layers/plot-props-jsdoc-ratchet.ssr.test.ts
+++ b/packages/svelte/tests/layers/plot-props-jsdoc-ratchet.ssr.test.ts
@@ -1,0 +1,34 @@
+/**
+ * #785: plot-props.ts JSDoc stays (deprecation-wiring requires since + URL)
+ * but must match GRAMMAR_FAMILIES metadata (guard, not deletion).
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { GRAMMAR_FAMILIES, GGPLOT_PROP_ORDER } from "../../src/lib/layers/grammar-families.js";
+
+const plotPropsPath = join(import.meta.dirname, "../../src/lib/plot-props.ts");
+
+describe("plot-props JSDoc matches GRAMMAR_FAMILIES", () => {
+  const source = readFileSync(plotPropsPath, "utf8");
+
+  for (const kind of GGPLOT_PROP_ORDER) {
+    const family = GRAMMAR_FAMILIES[kind];
+    it(`${family.propName} JSDoc carries since, removeIn, and doc anchor from the table`, () => {
+      // Find the prop declaration and walk back to its nearest preceding
+      // @deprecated block (props are documented immediately above).
+      const propDecl = new RegExp(`\\b${family.propName}\\?:`);
+      const propIndex = source.search(propDecl);
+      expect(propIndex, `${family.propName} prop missing`).toBeGreaterThan(-1);
+      const before = source.slice(0, propIndex);
+      const blockStart = before.lastIndexOf("/**");
+      expect(blockStart, `${family.propName}: missing JSDoc`).toBeGreaterThan(-1);
+      const block = before.slice(blockStart);
+      expect(block).toMatch(/@deprecated/);
+      expect(block).toContain(`since ${family.since}`);
+      expect(block).toContain(family.removeIn);
+      expect(block).toContain(`#${family.docAnchor}`);
+    });
+  }
+});

--- a/scripts/deprecation-catalog-anchors.test.ts
+++ b/scripts/deprecation-catalog-anchors.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
+import { GRAMMAR_DOC_URLS } from "../packages/svelte/src/lib/layers/grammar-families.ts";
 import type { LifecycleDoc } from "./gen-llms.ts";
 import { guidePages, renderMarkdown } from "./gen-llms.ts";
 
@@ -31,16 +32,9 @@ function guideAnchors(): Map<string, Set<string>> {
  * (deprecatedPropDiagnostic) and composition (duplicateScaleChannelDiagnostic,
  * duplicateMergeKeyDiagnostic, duplicatePlotLayerDiagnostic) alike. All ship a
  * docUrl, so all need the anchor to actually resolve.
+ * Derived from GRAMMAR_FAMILIES (#785).
  */
-const RUNTIME_ADVISORY_URLS = [
-  "https://ggsvelte.sh/guide/upgrading#compose-the-theme-as-a-child-layer",
-  "https://ggsvelte.sh/guide/upgrading#compose-scales-as-child-layers",
-  "https://ggsvelte.sh/guide/upgrading#compose-coord-as-a-child-layer",
-  "https://ggsvelte.sh/guide/upgrading#compose-facet-as-a-child-layer",
-  "https://ggsvelte.sh/guide/upgrading#compose-labs-as-a-child-layer",
-  "https://ggsvelte.sh/guide/upgrading#compose-guides-as-child-layers",
-  "https://ggsvelte.sh/guide/upgrading#compose-legend-as-a-child-layer",
-] as const;
+const RUNTIME_ADVISORY_URLS = GRAMMAR_DOC_URLS;
 
 describe("diagnostic catalog runtime docUrl anchors", () => {
   it("every live runtime advisory docUrl anchor resolves in the rendered guide", () => {

--- a/scripts/repo-child-layers.test.ts
+++ b/scripts/repo-child-layers.test.ts
@@ -23,6 +23,7 @@ import { join, relative } from "node:path";
 
 import lifecycle from "../lifecycle.json";
 import { migratePlotProps } from "../packages/svelte/src/lib/codemod/migrate-plot-props.ts";
+import { deprecatedGrammarPropPattern } from "../packages/svelte/src/lib/layers/grammar-families.ts";
 import { guidePages, type LifecycleDoc } from "./gen-llms.ts";
 import { codeBlocks } from "./guide-code-contract.ts";
 import { foldSakura, QUICKSTART_PAGE_FILENAME, SAKURA_STEPS } from "./quickstart.ts";
@@ -99,8 +100,9 @@ describe("the repo's own charts use child layers, not deprecated grammar props",
  * The seven props deprecated in 0.11.0, as they appear in an authored fence.
  * Matched at the start of a line or straight after `<GGPlot` so `<Facet …>`,
  * `<Theme name=…>` and a `theme` key inside a JSON spec never trip it.
+ * Derived from GRAMMAR_FAMILIES (#785) so the list cannot drift from the table.
  */
-const DEPRECATED_PROP = /(?:^\s*|<GGPlot\s+)(facet|coord|scales|guides|legend|theme|labs)=/gm;
+const DEPRECATED_PROP = deprecatedGrammarPropPattern();
 
 /**
  * The upgrading guide is the one page that must show the deprecated form: its


### PR DESCRIPTION
## Summary

Centralizes the seven #659 grammar families (`scale`, `coord`, `facet`, `labs`, `guides`, `legend`, `theme`) into `GRAMMAR_FAMILIES` so prop names, composition rules, doc anchors, deprecation windows, codemod forms, and fold dispatch cannot drift across nine files.

- **`layers/types.ts`**: shared runes-free `Layer` / `MarkLayerDescriptor` (registry + assemble)
- **`layers/grammar-families.ts`**: sole runtime metadata home + order constants
- **`layers/fold.ts`**: pure `foldPlotLayer` used by `assemblePortableSpec`
- Table-driven deprecation ladder, composition diagnostics docs/kinds, codemod `RULES`, and repo guards
- `plot-props.ts` JSDoc kept (required by deprecation-wiring) and ratcheted against the table

No behaviour change intended.

### Residual restatement (out of scope)

`plot-orchestrator.svelte.ts` still lists the seven prop accessors as TypeScript properties — not free metadata; deriving that expands blast radius.

### Claude plan review

Plan reviewed via `/claude` consult before implementation. Updates applied: keep JSDoc + ratchet; explicit emission orders; types before fold wire; SSR test lane; derive kinds from `Layer`.

## Test plan

- [x] `vitest` SSR: `tests/layers` (21)
- [x] `vitest` SSR: `tests/codemod` (41)
- [x] `vitest` browser: assemble, labs/guides/legend, coord/facet, theme children, scale children
- [x] `bun test` scripts/repo-child-layers + deprecation-catalog-anchors
- [x] `bun run check` (svelte-check)

Closes #785
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/836" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->