### PR TITLE
fix(#787): scope interaction nearest to the semantic viewport panel

### DIFF
--- a/.changeset/787-viewport-panel-scoping.md
+++ b/.changeset/787-viewport-panel-scoping.md
@@ -1,0 +1,8 @@
+---
+"@ggsvelte/core": patch
+"@ggsvelte/svelte": patch
+---
+
+# Scope interaction nearest-hits to the semantic viewport panel
+
+Faceted hover and point select can no longer seed another facet's candidate (#787).

--- a/packages/core/src/candidate-store-types.ts
+++ b/packages/core/src/candidate-store-types.ts
@@ -96,8 +96,18 @@ export interface CandidateStore {
   readonly x: Float32Array;
   readonly y: Float32Array;
   candidate(id: number): CandidateFacts | null;
-  /** Topmost painted candidate at a plot-pixel position, or null. */
+  /**
+   * Topmost painted candidate at a plot-pixel position, or null.
+   * Enforces panel clip (skips panels with clip !== false when the point is
+   * outside the panel rectangle). Soft hover targeting should use
+   * `SemanticViewportPanel.nearest` instead (#787).
+   */
   hitTest(x: number, y: number): CandidateFacts | null;
+  /**
+   * Soft nearest-candidate targeting. Does **not** enforce panel clip; pass
+   * `panelId` (or use `SemanticViewportPanel.nearest`) so faceted probes cannot
+   * seed another panel. `hitTest` is the clip-gated hard-hit counterpart.
+   */
   nearest(
     x: number,
     y: number,

--- a/packages/core/src/semantic-viewport.ts
+++ b/packages/core/src/semantic-viewport.ts
@@ -6,7 +6,12 @@ import type { PositionTransformName } from "./scales/transform.js";
 import type { ScenePanel } from "./scene.js";
 import type { PanelCoordProjector } from "./coord-projector.js";
 import type { CellValue } from "./table.js";
-import type { CandidateFacts, CandidateStore } from "./candidate-store.js";
+import type {
+  CandidateFacts,
+  CandidateInspectMode,
+  CandidateMatch,
+  CandidateStore,
+} from "./candidate-store.js";
 import { encodeKey } from "./scales/state.js";
 
 export interface PlotRect {
@@ -61,12 +66,28 @@ export interface SemanticViewportPanel {
   project(selection: SemanticViewportSelection): PlotRect;
   resolve(selection: SemanticViewportSelection): SemanticViewportDomains;
   query(rect: PlotRect, mode: "x" | "y" | "xy"): readonly CandidateFacts[];
+  /**
+   * Nearest candidate in this panel only. Soft targeting (does not enforce
+   * panel clip); contrast `CandidateStore.hitTest`, which is clip-gated.
+   * Prefer this over store.nearest without panelId so faceted hover/select
+   * cannot seed another panel's mark (#787).
+   */
+  nearest(
+    point: Readonly<{ x: number; y: number }>,
+    options: { mode: CandidateInspectMode; maxDistance: number },
+  ): CandidateMatch | null;
 }
 
 export interface SemanticViewport {
   readonly panels: readonly SemanticViewportPanel[];
   panel(id: string): SemanticViewportPanel | null;
   panelAt(point: Readonly<{ x: number; y: number }>): SemanticViewportPanel | null;
+  /**
+   * Panel under `point`, or the sole panel when the plot has exactly one.
+   * Owns the single-panel outside-panel brush/inspect fallback so interaction
+   * callers do not reimplement it divergently (#787).
+   */
+  panelAtOrOnly(point: Readonly<{ x: number; y: number }>): SemanticViewportPanel | null;
 }
 
 type ViewportScales = {
@@ -292,6 +313,13 @@ function createPanel(
       }
       return matches;
     },
+    nearest(point, options) {
+      return candidates.nearest(point.x, point.y, {
+        mode: options.mode,
+        maxDistance: options.maxDistance,
+        panelId: panel.id,
+      });
+    },
   };
 }
 
@@ -311,21 +339,25 @@ export function createSemanticViewport(
       candidates,
     ),
   );
+  function panelAt(point: Readonly<{ x: number; y: number }>): SemanticViewportPanel | null {
+    return (
+      viewportPanels.find(
+        (panel) =>
+          point.x >= panel.bounds.x0 &&
+          point.x <= panel.bounds.x1 &&
+          point.y >= panel.bounds.y0 &&
+          point.y <= panel.bounds.y1,
+      ) ?? null
+    );
+  }
   return {
     panels: viewportPanels,
     panel(id) {
       return viewportPanels.find((panel) => panel.id === id) ?? null;
     },
-    panelAt(point) {
-      return (
-        viewportPanels.find(
-          (panel) =>
-            point.x >= panel.bounds.x0 &&
-            point.x <= panel.bounds.x1 &&
-            point.y >= panel.bounds.y0 &&
-            point.y <= panel.bounds.y1,
-        ) ?? null
-      );
+    panelAt,
+    panelAtOrOnly(point) {
+      return panelAt(point) ?? (viewportPanels.length === 1 ? (viewportPanels[0] ?? null) : null);
     },
   };
 }

--- a/packages/core/tests/semantic-viewport.test.ts
+++ b/packages/core/tests/semantic-viewport.test.ts
@@ -367,4 +367,89 @@ describe("RenderModel semantic viewport", () => {
       expect(x.slice(["b", "missing"])).toBeUndefined();
     }
   });
+
+  it("panel.nearest never surfaces a candidate from another facet (#787)", () => {
+    // Stacked facets + mode "x": unscoped nearest uses a full-height strip and
+    // |Δx| distance, so a hover in A at B's screen-x seeds B. Panel-scoped
+    // nearest must refuse that leak.
+    const model = runPipeline(
+      gg(
+        [
+          { g: "A", x: 1, y: 5 },
+          { g: "B", x: 5, y: 5 },
+        ],
+        aes({ x: "x", y: "y" }),
+      )
+        .geomPoint()
+        .facet({ wrap: "g", ncol: 1 })
+        .scales({
+          x: { domain: [0, 10], nice: false, expand: { mult: 0, add: 0 } },
+          y: { domain: [0, 10], nice: false, expand: { mult: 0, add: 0 } },
+        })
+        .spec(),
+      { width: 200, height: 400 },
+    );
+    const panelA = model.scene.panels[0]!;
+    const candB = model.candidates.candidate(1)!;
+    expect(candB.panelId).toBe(model.scene.panels[1]!.id);
+
+    const probe = { x: candB.x, y: panelA.y + panelA.height / 2 };
+    // Documents the leak the viewport API closes.
+    expect(
+      model.candidates.nearest(probe.x, probe.y, { mode: "x", maxDistance: 24 })?.panelId,
+    ).toBe(candB.panelId);
+
+    const viewportPanel = model.viewport.panelAt(probe)!;
+    expect(viewportPanel.id).toBe(panelA.id);
+    expect(viewportPanel.nearest(probe, { mode: "x", maxDistance: 24 })).toBeNull();
+  });
+
+  it("panelAtOrOnly falls back only when the plot has a single panel", () => {
+    const single = runPipeline(
+      gg(
+        [
+          { x: 0, y: 0 },
+          { x: 10, y: 10 },
+        ],
+        aes({ x: "x", y: "y" }),
+      )
+        .geomPoint()
+        .scales({
+          x: { domain: [0, 10], nice: false, expand: { mult: 0, add: 0 } },
+          y: { domain: [0, 10], nice: false, expand: { mult: 0, add: 0 } },
+        })
+        .spec(),
+      { width: 400, height: 300 },
+    );
+    const only = single.viewport.panels[0]!;
+    const outside = { x: only.bounds.x0 - 10, y: only.bounds.y0 - 10 };
+    expect(single.viewport.panelAt(outside)).toBeNull();
+    expect(single.viewport.panelAtOrOnly(outside)?.id).toBe(only.id);
+    expect(
+      single.viewport.panelAtOrOnly({ x: only.bounds.x0 + 1, y: only.bounds.y0 + 1 })?.id,
+    ).toBe(only.id);
+
+    const multi = runPipeline(
+      gg(
+        [
+          { g: "A", x: 1, y: 1 },
+          { g: "B", x: 2, y: 2 },
+        ],
+        aes({ x: "x", y: "y" }),
+      )
+        .geomPoint()
+        .facet({ wrap: "g" })
+        .spec(),
+      { width: 400, height: 200 },
+    );
+    expect(multi.viewport.panels.length).toBe(2);
+    expect(multi.viewport.panelAtOrOnly({ x: -50, y: -50 })).toBeNull();
+    const first = multi.viewport.panels[0]!;
+    expect(
+      multi.viewport.panelAtOrOnly({
+        x: (first.bounds.x0 + first.bounds.x1) / 2,
+        y: (first.bounds.y0 + first.bounds.y1) / 2,
+      })?.id,
+    ).toBe(first.id);
+  });
 });

--- a/packages/svelte/src/lib/inspection/frame.ts
+++ b/packages/svelte/src/lib/inspection/frame.ts
@@ -49,8 +49,8 @@ export function buildQueuedPointerInspection(input: {
  *
  * Owns the single `match === null` branch for hit resolution + reducer
  * candidate ref (avoids three separate null checks / eager hitTest).
- * `fallbackCandidate` and `panelIdForIndex` are thunks evaluated only on the
- * path that needs them.
+ * `fallbackCandidate` is evaluated only on the path that needs it.
+ * Candidate `panelId` comes from the facts object (no scene index round-trip).
  */
 export type QueuedInspectFrameBuild = {
   readonly queued: QueuedPointerInspection;
@@ -63,8 +63,6 @@ export function buildQueuedInspectFrame(input: {
   readonly epoch: number;
   /** Evaluated only when match is null. */
   readonly fallbackCandidate: () => CandidateFacts | null;
-  /** Evaluated only when a candidate is found. */
-  readonly panelIdForIndex: (panelIndex: number) => string | null;
 }): QueuedInspectFrameBuild {
   if (input.match === null) {
     const fallback = input.fallbackCandidate();
@@ -79,7 +77,7 @@ export function buildQueuedInspectFrame(input: {
       candidate: {
         epoch: input.epoch,
         id: fallback.id,
-        panelId: input.panelIdForIndex(fallback.panelIndex),
+        panelId: fallback.panelId,
         x: fallback.x,
         y: fallback.y,
       },
@@ -96,7 +94,7 @@ export function buildQueuedInspectFrame(input: {
     candidate: {
       epoch: input.epoch,
       id: match.id,
-      panelId: input.panelIdForIndex(match.panelIndex),
+      panelId: match.panelId,
       x: match.x,
       y: match.y,
     },

--- a/packages/svelte/src/lib/inspection/inspection-state.svelte.ts
+++ b/packages/svelte/src/lib/inspection/inspection-state.svelte.ts
@@ -114,7 +114,7 @@ type CancelPointerInspectPolicy = {
 };
 
 /** Panel geometry for crosshairs / keyboard clamp; id for scene lookups. */
-export type InspectionPanelBounds = PanelBounds & { readonly id: string };
+type InspectionPanelBounds = PanelBounds & { readonly id: string };
 
 export type InspectionState = {
   readonly inspection: PlotInspectionChange<Record<string, CellValue>, PropertyKey> | null;

--- a/packages/svelte/src/lib/inspection/inspection-state.svelte.ts
+++ b/packages/svelte/src/lib/inspection/inspection-state.svelte.ts
@@ -19,7 +19,9 @@
  *
  * Scene-reconcile + coordinator disposal effects register inside this factory.
  */
-import type { CandidateFacts, CellValue, RenderModel, ScenePanel } from "@ggsvelte/core";
+import type { CandidateFacts, CellValue, RenderModel } from "@ggsvelte/core";
+
+import type { PanelBounds } from "../scene/geometry.js";
 
 import { createInspectionCoordinator } from "./coordinator.js";
 import type { createInteractionReducer, InteractionAction } from "../interaction/reducer.js";
@@ -111,9 +113,12 @@ type CancelPointerInspectPolicy = {
   readonly pendingPinned: "preserve" | "discard";
 };
 
+/** Panel geometry for crosshairs / keyboard clamp; id for scene lookups. */
+export type InspectionPanelBounds = PanelBounds & { readonly id: string };
+
 export type InspectionState = {
   readonly inspection: PlotInspectionChange<Record<string, CellValue>, PropertyKey> | null;
-  readonly inspectionPanel: ScenePanel | null;
+  readonly inspectionPanel: InspectionPanelBounds | null;
   /** Seed candidate for presentation chrome (kind); not emitted on public events. */
   readonly inspectionSeed: CandidateFacts | null;
   setInspection(
@@ -201,11 +206,23 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
   }
 
   // Construction-safe: own state + earlier host model.
-  const inspectionPanel = $derived.by(() => {
+  // Key off the inspection snapshot's panelId (authoritative from the seed
+  // candidate), not a re-hit of focus.anchor geometry (#787). Bounds come
+  // from the semantic viewport — no scene.panels.find round-trip.
+  const inspectionPanel = $derived.by((): InspectionPanelBounds | null => {
     if (inspection === null || deps.model() === null) return null;
-    const model = deps.model()!;
-    const viewportPanel = model.viewport.panelAt(inspection.focus.anchor);
-    return model.scene.panels.find((panel) => panel.id === viewportPanel?.id) ?? null;
+    const panelId = inspection.panelId;
+    if (panelId === null) return null;
+    const viewportPanel = deps.model()!.viewport.panel(panelId);
+    if (viewportPanel === null) return null;
+    const { x0, y0, x1, y1 } = viewportPanel.bounds;
+    return {
+      id: viewportPanel.id,
+      x: x0,
+      y: y0,
+      width: x1 - x0,
+      height: y1 - y0,
+    };
   });
 
   // Coordinator closes over keyAt — handler-only invocation (deferred).
@@ -484,16 +501,12 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
     activeCandidateId = null;
   }
 
-  function panelIdForIndex(index: number): string | null {
-    const panel = deps.model()?.scene.panels[index];
-    if (panel === undefined) return null;
-    return panel.id;
-  }
-
   function schedulePointerInspect(input: SchedulePointerInspectInput): void {
     const model = deps.model();
+    // Panel-scoped nearest so faceted hover cannot seed another facet (#787).
+    // panelAtOrOnly keeps single-panel axis-margin hover working (Claude plan review).
     const match =
-      model?.candidates.nearest(input.point.x, input.point.y, {
+      model?.viewport.panelAtOrOnly(input.point)?.nearest(input.point, {
         mode: input.mode,
         maxDistance: input.maxDistance,
       }) ?? null;
@@ -502,7 +515,6 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
       source: input.source,
       epoch: model?.runId ?? 0,
       fallbackCandidate: () => model?.candidates.hitTest(input.point.x, input.point.y) ?? null,
-      panelIdForIndex,
     });
     const reducer = reducerOf();
     queuedPointerInspection = frame.queued;

--- a/packages/svelte/src/lib/interval/interval-state.svelte.ts
+++ b/packages/svelte/src/lib/interval/interval-state.svelte.ts
@@ -78,10 +78,10 @@ export type IntervalStateDeps = {
   consumptionCandidates: () => readonly IntervalConsumptionCandidate<PropertyKey>[];
   /**
    * Handler-only: `openBoundsEditor` select branch reads the host's inspection
-   * panel as its fallback target. Host derived is earlier than the factory and
-   * returns `ScenePanel | null`.
+   * panel id as its fallback target. Host derived is earlier than the factory
+   * and returns bounds + id (or null).
    */
-  inspectionPanel: () => ScenePanel | null;
+  inspectionPanel: () => Readonly<{ id: string }> | null;
   /** Hoisted host fn (shared with point selection until S7/S8). */
   emitSelection: (event: PlotSelection) => void;
   announce: (message: string) => void;
@@ -472,11 +472,18 @@ export function createIntervalState(deps: IntervalStateDeps): IntervalState {
   ): void {
     boundsReturnFocus = trigger;
     if (action === "select") {
+      const model = deps.model();
       const panel =
         currentIntervalRecord === null
-          ? (deps.inspectionPanel() ?? deps.model()?.scene.panels[0])
+          ? (() => {
+              const inspectionTarget = deps.inspectionPanel();
+              if (inspectionTarget !== null && model !== null) {
+                return model.scene.panels.find((candidate) => candidate.id === inspectionTarget.id);
+              }
+              return model?.scene.panels[0];
+            })()
           : currentIntervalPanel;
-      if (panel === undefined) return;
+      if (panel === undefined || panel === null) return;
       boundsEditor = {
         action,
         axis,

--- a/packages/svelte/src/lib/surface/surface-handlers.ts
+++ b/packages/svelte/src/lib/surface/surface-handlers.ts
@@ -122,13 +122,7 @@ export function createSurfaceHandlers(live: SurfaceHandlerLive): SurfaceHandlers
   }
 
   function panelAtPoint(point: Readonly<{ x: number; y: number }>) {
-    const model = deps.model();
-    if (model === null) return null;
-    const viewportPanel = model.viewport.panelAt(point);
-    return (
-      model.scene.panels.find((panel) => panel.id === viewportPanel?.id) ??
-      (model.scene.panels.length === 1 ? model.scene.panels[0]! : null)
-    );
+    return deps.model()?.viewport.panelAtOrOnly(point) ?? null;
   }
 
   function onPointerMove(event: PointerEvent): void {
@@ -269,7 +263,7 @@ export function createSurfaceHandlers(live: SurfaceHandlerLive): SurfaceHandlers
         const originPanel = extending
           ? area.kind === "idle"
             ? null
-            : (model?.scene.panels.find((panel) => panel.id === area.panelId) ?? null)
+            : (model?.viewport.panel(area.panelId) ?? null)
           : panelAtPoint(p);
         if (originPanel === null) break;
         // Pure table owns fresh vs extend corner policy.
@@ -339,7 +333,8 @@ export function createSurfaceHandlers(live: SurfaceHandlerLive): SurfaceHandlers
         touchInspectStart = null;
         touchInspectMoved = false;
         // mode/maxDistance/state from pure inspect snapshot — no re-gate.
-        const match = deps.model()?.candidates.nearest(endPoint.x, endPoint.y, {
+        // Panel-scoped nearest so faceted taps cannot seed another facet (#787).
+        const match = deps.model()?.viewport.panelAtOrOnly(endPoint)?.nearest(endPoint, {
           mode: action.mode,
           maxDistance: action.maxDistance,
         });
@@ -466,7 +461,8 @@ export function createSurfaceHandlers(live: SurfaceHandlerLive): SurfaceHandlers
         break;
       case "toggle-point": {
         const point = plotPoint(event);
-        const match = deps.model()?.candidates.nearest(point.x, point.y, {
+        // Panel-scoped nearest so faceted point-select cannot toggle another facet (#787).
+        const match = deps.model()?.viewport.panelAtOrOnly(point)?.nearest(point, {
           mode: "xy",
           maxDistance: POINT_SELECT_NEAREST_MAX_DISTANCE_PX,
         });

--- a/packages/svelte/src/lib/surface/surface-handlers.ts
+++ b/packages/svelte/src/lib/surface/surface-handlers.ts
@@ -261,7 +261,7 @@ export function createSurfaceHandlers(live: SurfaceHandlerLive): SurfaceHandlers
         const extending = live.getAreaAwaitingSecond() && live.getBrushRect() !== null;
         const model = deps.model();
         const originPanel = extending
-          ? area.kind === "idle"
+          ? area.kind === "idle" || area.panelId === null
             ? null
             : (model?.viewport.panel(area.panelId) ?? null)
           : panelAtPoint(p);

--- a/packages/svelte/tests/inspection/inspection-frame.test.ts
+++ b/packages/svelte/tests/inspection/inspection-frame.test.ts
@@ -173,6 +173,7 @@ describe("buildQueuedInspectFrame", () => {
     autoMode: "xy" as const,
     layerIndex: 1,
     panelIndex: 2,
+    panelId: "panel-2",
     rowIndex: 1,
     lineage: 0,
     x: 12,
@@ -205,7 +206,6 @@ describe("buildQueuedInspectFrame", () => {
 
   it("uses fallback candidate identity when semantic nearest misses", () => {
     let fallbackCalls = 0;
-    let panelCalls = 0;
     const built = buildQueuedInspectFrame({
       match: null,
       source: "pointer",
@@ -214,13 +214,8 @@ describe("buildQueuedInspectFrame", () => {
         fallbackCalls += 1;
         return fallback;
       },
-      panelIdForIndex: () => {
-        panelCalls += 1;
-        return "p0";
-      },
     });
     expect(fallbackCalls).toBe(1);
-    expect(panelCalls).toBe(1);
     expect(built).toEqual({
       queued: {
         hit: {
@@ -246,7 +241,6 @@ describe("buildQueuedInspectFrame", () => {
 
   it("builds hit + queued mode + candidate from match without calling fallback", () => {
     let fallbackCalls = 0;
-    let panelCalls = 0;
     const built = buildQueuedInspectFrame({
       match,
       source: "touch",
@@ -255,14 +249,8 @@ describe("buildQueuedInspectFrame", () => {
         fallbackCalls += 1;
         return fallback;
       },
-      panelIdForIndex: (panelIndex) => {
-        panelCalls += 1;
-        expect(panelIndex).toBe(2);
-        return "panel-2";
-      },
     });
     expect(fallbackCalls).toBe(0);
-    expect(panelCalls).toBe(1);
     expect(built.queued).toEqual({
       hit: {
         layerIndex: 1,

--- a/packages/svelte/tests/interval/interval-state.harness.ts
+++ b/packages/svelte/tests/interval/interval-state.harness.ts
@@ -2,7 +2,7 @@
  * Shared harness for createIntervalState composite tests.
  * Factories own deriveds + effects — instantiate under `$effect.root` and destroy.
  */
-import type { CandidateFacts, RenderModel, ScenePanel } from "@ggsvelte/core";
+import type { CandidateFacts, RenderModel } from "@ggsvelte/core";
 import { aes, gg, type PortableSpec } from "@ggsvelte/spec";
 
 import type {
@@ -152,7 +152,7 @@ export function mountIntervalController(
     captureSurface?: () => HTMLDivElement | null;
     candidateSemanticKeys?: (candidate: CandidateFacts) => PropertyKey[];
     consumptionCandidates?: IntervalStateDeps["consumptionCandidates"];
-    inspectionPanel?: () => ScenePanel | null;
+    inspectionPanel?: () => Readonly<{ id: string }> | null;
     emitSelection?: (event: PlotSelection) => void;
     announce?: (message: string) => void;
   } = {},

--- a/packages/svelte/tests/interval/query-fixtures.ts
+++ b/packages/svelte/tests/interval/query-fixtures.ts
@@ -54,6 +54,9 @@ export function scene(partial: {
       panelAt() {
         return null;
       },
+      panelAtOrOnly() {
+        return panels.length === 1 ? (panels[0] ?? null) : null;
+      },
     },
     lineageKeys(id) {
       return lineage[id] ?? [];


### PR DESCRIPTION
## Summary

- Faceted hover/select called `CandidateStore.nearest` without `panelId`, so mode `x`/`y` full-height strips could seed another facet's candidate.
- Add `SemanticViewportPanel.nearest` (forwards `panelId`) and `SemanticViewport.panelAtOrOnly` (single-panel outside-panel fallback owned once in core).
- Wire Svelte surface + inspection call sites through those APIs; key `inspectionPanel` off the snapshot `panelId` + viewport bounds (no `scene.panels.find` in surface/inspection).
- Document the intentional `nearest` (soft) vs `hitTest` (clip-gated) split.

Closes #787.

## Claude plan review

Outside-voice plan review (**FAIL → revised before code**):
- Use `panelAtOrOnly` on *all* nearest sites (not `panelAt` for inspect) so single-panel axis-margin hover still works.
- Drop `resolveInspection`'s seed `nearest` from scope (dead path that can throw).
- Key `inspectionPanel` off `inspection.panelId`, not re-hit geometry.

## Test plan

- [x] Core: stacked-facet mode `x` leak documented + `panel.nearest` refuses cross-panel seed
- [x] Core: `panelAtOrOnly` single vs multi panel
- [x] Svelte pure: `buildQueuedInspectFrame` uses candidate `panelId` (no index round-trip)
- [x] Browser: inspection state + facets + interval construction suites
- [ ] CI green
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/837" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->