### PR TITLE
refactor(docs): extract playground agent run from Playground.svelte

### DIFF
--- a/apps/docs/src/lib/Playground.svelte
+++ b/apps/docs/src/lib/Playground.svelte
@@ -3,7 +3,6 @@
   import { onMount, tick } from "svelte";
 
   import type { RenderModel } from "@ggsvelte/core";
-  import type { SpecError } from "@ggsvelte/spec";
 
   import { copyText } from "$lib/clipboard";
   import PlaygroundBrowseLinks from "$lib/components/PlaygroundBrowseLinks.svelte";
@@ -70,21 +69,18 @@
   import { agentHandoffPrompt } from "$lib/playground-agent-handoff";
   import {
     agentIsBusy,
-    beginAgentRequest,
     completeAgentSuccess,
     createPlaygroundAgentState,
     failAgent,
     messageForAgentError,
     resolvePhaseLine,
     setAgentDrawing,
-    setAgentRepairing,
-    setAgentValidating,
     type PlaygroundAgentState,
   } from "$lib/playground-agent-state";
   import {
-    agentFailureIsRepairable,
-    validateAgentEnvelope,
-  } from "$lib/playground-agent-validate";
+    rateLimitLabelFor,
+    runPlaygroundAgentRun,
+  } from "$lib/playground-agent-run";
   import type { PlaygroundDatasetId } from "$lib/playground-dataset-schemas";
   import {
     PLAYGROUND_DEFAULT_DATASET,
@@ -149,10 +145,6 @@
       currentSpec: workbench.committed,
       userGoal: prompt,
     });
-  }
-
-  function rateLimitLabelFor(seconds: number): string {
-    return `Try again in ${seconds}s`;
   }
 
   function cancelActiveRun(): void {
@@ -310,135 +302,48 @@
     const token = ++runSeq;
     // A superseded or cancelled run must stop touching state entirely —
     // its continuations would otherwise interleave with the newer run.
-    const stale = (): boolean =>
+    const isStale = (): boolean =>
       token !== runSeq || options.signal?.aborted === true;
 
-    agent = beginAgentRequest(agent, {
-      exampleMode: options.example !== undefined,
-    });
+    // Clear before the run so a cancelled live generate cannot inherit
+    // mock notice copy from a prior canned example.
     mockNotice = false;
 
-    try {
-      let rawEnvelope: unknown;
-      let envelope: PlaygroundAgentEnvelope;
+    const outcome = await runPlaygroundAgentRun(
+      {
+        userPrompt,
+        dataset,
+        // Re-read at first generate and repair (send named data, never rows).
+        getCurrentSpec: () =>
+          elidePlaygroundDatasetRows(workbench.committed, dataset),
+        ...(options.example === undefined ? {} : { example: options.example }),
+        ...(options.signal === undefined ? {} : { signal: options.signal }),
+        isStale,
+        initialAgent: agent,
+      },
+      {
+        onAgent: (next) => {
+          agent = next;
+        },
+        generateChart,
+      },
+    );
 
-      const example = options.example;
-      if (example === undefined) {
-        const first = await generateChart(
-          {
-            prompt: userPrompt,
-            datasetId: dataset,
-            // Send named data, never inlined rows (performance review S2).
-            currentSpec: elidePlaygroundDatasetRows(
-              workbench.committed,
-              dataset,
-            ),
-          },
-          { signal: options.signal },
-        );
-        if (stale()) return;
-        if (!first.ok) {
-          if (
-            first.code === "rate_limited" ||
-            first.code === "upstream_rate_limited"
-          ) {
-            const seconds = first.retryAfterSeconds ?? 60;
-            rateLimitUntil = Date.now() + seconds * 1000;
-            rateLimitLabel = rateLimitLabelFor(seconds);
-          }
-          agent = failAgent(agent, {
-            code: first.code,
-            message: first.message,
-            ...(first.retryAfterSeconds === undefined
-              ? {}
-              : { retryAfterSeconds: first.retryAfterSeconds }),
-          });
-          return;
-        }
-        if (first.model === "mock") mockNotice = true;
-        envelope = first.envelope;
-        rawEnvelope = first.rawEnvelope;
-      } else {
-        // Instant canned path (OV2-A) — brief phase line, then validate/stage.
-        await new Promise((resolve) => {
-          setTimeout(resolve, 120);
-        });
-        if (stale()) return;
-        envelope = example.envelope;
-        rawEnvelope = {
-          spec: envelope.spec,
-          interactions: envelope.interactions,
-          title: envelope.title,
-        };
+    if (outcome.kind === "stale") return;
+
+    if (outcome.kind === "failed") {
+      mockNotice = outcome.mockNotice;
+      if (outcome.rateLimit !== undefined) {
+        rateLimitUntil = outcome.rateLimit.until;
+        rateLimitLabel = outcome.rateLimit.label;
       }
-
-      agent = setAgentValidating(agent);
-      let validated = validateAgentEnvelope(envelope, dataset);
-
-      // One repair round, and only with raw SpecError[] to repair from: a
-      // seed-bound failure carries none, so repairing would spend a second
-      // model call and double the wait for nothing (#697).
-      if (
-        options.example === undefined &&
-        agentFailureIsRepairable(validated)
-      ) {
-        agent = setAgentRepairing(agent);
-        const repair = await generateChart(
-          {
-            prompt: userPrompt,
-            datasetId: dataset,
-            currentSpec: elidePlaygroundDatasetRows(
-              workbench.committed,
-              dataset,
-            ),
-            priorSpec: rawEnvelope,
-            priorErrors: validated.errors as SpecError[],
-          },
-          { signal: options.signal },
-        );
-        if (stale()) return;
-        if (!repair.ok) {
-          agent = failAgent(agent, {
-            code: repair.code,
-            message: repair.message,
-            details: validated.errors,
-          });
-          return;
-        }
-        envelope = repair.envelope;
-        rawEnvelope = repair.rawEnvelope;
-        validated = validateAgentEnvelope(envelope, dataset);
-      }
-
-      if (!validated.ok) {
-        agent = failAgent(agent, {
-          code: "validation",
-          message: validated.message,
-          details: validated.errors,
-        });
-        return;
-      }
-
-      if (stale()) return;
-      // Success completes on candidate promotion (the "Drawing…" phase is
-      // real; Generate stays disabled until the chart actually paints).
-      pendingSuccess = {
-        spec: validated.spec,
-        interactions: validated.interactions,
-        title: validated.title,
-      };
-      stageAgentSeed(validated.seed, validated.interactions);
-    } catch (error) {
-      // A throw must never strand the machine in a busy phase.
-      if (stale()) return;
-      agent = failAgent(agent, {
-        code: "pipeline",
-        message: messageForAgentError(
-          "pipeline",
-          error instanceof Error ? error.message : undefined,
-        ),
-      });
+      return;
     }
+
+    // ready_to_stage — drawing is owned by stageAgentSeed, not the run module.
+    mockNotice = outcome.mockNotice;
+    pendingSuccess = outcome.pendingSuccess;
+    stageAgentSeed(outcome.seed, outcome.interactions);
   }
 
   function onGenerate(): void {

--- a/apps/docs/src/lib/playground-agent-run.ts
+++ b/apps/docs/src/lib/playground-agent-run.ts
@@ -10,8 +10,6 @@
  * component owns `setAgentDrawing` so lifecycle emits see a consistent phase.
  */
 
-import type { SpecError } from "@ggsvelte/spec";
-
 import type {
   GenerateChartOptions,
   GenerateChartRequest,
@@ -171,7 +169,7 @@ export async function runPlaygroundAgentRun(
           datasetId: input.dataset,
           currentSpec: input.getCurrentSpec(),
           priorSpec: rawEnvelope,
-          priorErrors: validated.errors as SpecError[],
+          priorErrors: validated.errors,
         },
         signal === undefined ? undefined : { signal },
       );

--- a/apps/docs/src/lib/playground-agent-run.ts
+++ b/apps/docs/src/lib/playground-agent-run.ts
@@ -1,0 +1,230 @@
+/**
+ * Agent generate → validate → optional one-shot repair orchestration.
+ *
+ * Extracted from Playground.svelte so the run can be unit-tested without the
+ * Svelte shell. DOM, candidate lifecycle, and stagePlaygroundSeed stay in the
+ * component: this module only drives the agent machine via `onAgent` and
+ * returns a staging decision.
+ *
+ * Drawing phase is intentionally NOT set here — `stageAgentSeed` in the
+ * component owns `setAgentDrawing` so lifecycle emits see a consistent phase.
+ */
+
+import type { SpecError } from "@ggsvelte/spec";
+
+import type {
+  GenerateChartOptions,
+  GenerateChartRequest,
+  GenerateChartResult,
+} from "./playground-agent-client";
+import type { PlaygroundAgentEnvelope, PlaygroundInteractions } from "./playground-agent-envelope";
+import {
+  beginAgentRequest,
+  failAgent,
+  messageForAgentError,
+  setAgentRepairing,
+  setAgentValidating,
+  type PlaygroundAgentState,
+} from "./playground-agent-state";
+import { agentFailureIsRepairable, validateAgentEnvelope } from "./playground-agent-validate";
+import type { PlaygroundSeedV1 } from "./playground-codec";
+import type { PlaygroundDatasetId } from "./playground-dataset-schemas";
+import type { PlaygroundExamplePrompt } from "./playground-prompts";
+
+export function rateLimitLabelFor(seconds: number): string {
+  return `Try again in ${seconds}s`;
+}
+
+export interface PlaygroundAgentRunInput {
+  readonly userPrompt: string;
+  readonly dataset: PlaygroundDatasetId;
+  /**
+   * Re-read the elided committed spec at first generate and again at repair
+   * (matches the dual `elidePlaygroundDatasetRows(workbench.committed, …)`
+   * calls that lived in the component).
+   */
+  readonly getCurrentSpec: () => unknown;
+  readonly example?: PlaygroundExamplePrompt;
+  readonly signal?: AbortSignal;
+  /** True when this run was superseded (`runSeq`) or aborted. */
+  readonly isStale: () => boolean;
+  readonly initialAgent: PlaygroundAgentState;
+}
+
+export type PlaygroundAgentRunOutcome =
+  | { readonly kind: "stale" }
+  | {
+      readonly kind: "failed";
+      readonly mockNotice: boolean;
+      readonly rateLimit?: { readonly until: number; readonly label: string };
+    }
+  | {
+      readonly kind: "ready_to_stage";
+      readonly mockNotice: boolean;
+      readonly seed: PlaygroundSeedV1;
+      readonly interactions: PlaygroundInteractions;
+      readonly pendingSuccess: PlaygroundAgentEnvelope;
+    };
+
+export interface PlaygroundAgentRunDeps {
+  readonly onAgent: (agent: PlaygroundAgentState) => void;
+  readonly generateChart: (
+    req: GenerateChartRequest,
+    opts?: GenerateChartOptions,
+  ) => Promise<GenerateChartResult>;
+  readonly delay?: (ms: number) => Promise<void>;
+  readonly now?: () => number;
+}
+
+function defaultDelay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+/**
+ * Run one agent attempt. Intermediate agent phases are pushed through
+ * `deps.onAgent` only — the outcome never carries `agent`, so the component
+ * cannot clobber `setAgentDrawing` after staging.
+ */
+export async function runPlaygroundAgentRun(
+  input: PlaygroundAgentRunInput,
+  deps: PlaygroundAgentRunDeps,
+): Promise<PlaygroundAgentRunOutcome> {
+  const delay = deps.delay ?? defaultDelay;
+  const now = deps.now ?? Date.now;
+  const { onAgent, generateChart } = deps;
+  const { isStale, signal } = input;
+
+  let agent = beginAgentRequest(input.initialAgent, {
+    exampleMode: input.example !== undefined,
+    now: now(),
+  });
+  onAgent(agent);
+
+  let mockNotice = false;
+
+  try {
+    let rawEnvelope: unknown;
+    let envelope: PlaygroundAgentEnvelope;
+
+    const example = input.example;
+    if (example === undefined) {
+      const first = await generateChart(
+        {
+          prompt: input.userPrompt,
+          datasetId: input.dataset,
+          currentSpec: input.getCurrentSpec(),
+        },
+        signal === undefined ? undefined : { signal },
+      );
+      if (isStale()) return { kind: "stale" };
+      if (!first.ok) {
+        let rateLimit: { readonly until: number; readonly label: string } | undefined;
+        if (first.code === "rate_limited" || first.code === "upstream_rate_limited") {
+          const seconds = first.retryAfterSeconds ?? 60;
+          rateLimit = {
+            until: now() + seconds * 1000,
+            label: rateLimitLabelFor(seconds),
+          };
+        }
+        agent = failAgent(agent, {
+          code: first.code,
+          message: first.message,
+          ...(first.retryAfterSeconds === undefined
+            ? {}
+            : { retryAfterSeconds: first.retryAfterSeconds }),
+        });
+        onAgent(agent);
+        return rateLimit === undefined
+          ? { kind: "failed", mockNotice }
+          : { kind: "failed", mockNotice, rateLimit };
+      }
+      if (first.model === "mock") mockNotice = true;
+      envelope = first.envelope;
+      rawEnvelope = first.rawEnvelope;
+    } else {
+      // Instant canned path (OV2-A) — brief phase line, then validate/stage.
+      await delay(120);
+      if (isStale()) return { kind: "stale" };
+      envelope = example.envelope;
+      rawEnvelope = {
+        spec: envelope.spec,
+        interactions: envelope.interactions,
+        title: envelope.title,
+      };
+    }
+
+    agent = setAgentValidating(agent);
+    onAgent(agent);
+    let validated = validateAgentEnvelope(envelope, input.dataset);
+
+    // One repair round, and only with raw SpecError[] to repair from: a
+    // seed-bound failure carries none, so repairing would spend a second
+    // model call and double the wait for nothing (#697).
+    if (input.example === undefined && agentFailureIsRepairable(validated)) {
+      agent = setAgentRepairing(agent);
+      onAgent(agent);
+      const repair = await generateChart(
+        {
+          prompt: input.userPrompt,
+          datasetId: input.dataset,
+          currentSpec: input.getCurrentSpec(),
+          priorSpec: rawEnvelope,
+          priorErrors: validated.errors as SpecError[],
+        },
+        signal === undefined ? undefined : { signal },
+      );
+      if (isStale()) return { kind: "stale" };
+      if (!repair.ok) {
+        // Repair rate_limited deliberately does NOT set rate-limit UX —
+        // only the first generate attempt drives the countdown (preserve).
+        agent = failAgent(agent, {
+          code: repair.code,
+          message: repair.message,
+          details: validated.errors,
+        });
+        onAgent(agent);
+        return { kind: "failed", mockNotice };
+      }
+      envelope = repair.envelope;
+      rawEnvelope = repair.rawEnvelope;
+      validated = validateAgentEnvelope(envelope, input.dataset);
+    }
+
+    if (!validated.ok) {
+      agent = failAgent(agent, {
+        code: "validation",
+        message: validated.message,
+        details: validated.errors,
+      });
+      onAgent(agent);
+      return { kind: "failed", mockNotice };
+    }
+
+    if (isStale()) return { kind: "stale" };
+    // Success completes on candidate promotion (the "Drawing…" phase is
+    // real; Generate stays disabled until the chart actually paints).
+    // Agent remains validating | repairing — stageAgentSeed sets drawing.
+    return {
+      kind: "ready_to_stage",
+      mockNotice,
+      seed: validated.seed,
+      interactions: validated.interactions,
+      pendingSuccess: {
+        spec: validated.spec,
+        interactions: validated.interactions,
+        title: validated.title,
+      },
+    };
+  } catch (error) {
+    // A throw must never strand the machine in a busy phase.
+    if (isStale()) return { kind: "stale" };
+    agent = failAgent(agent, {
+      code: "pipeline",
+      message: messageForAgentError("pipeline", error instanceof Error ? error.message : undefined),
+    });
+    onAgent(agent);
+    return { kind: "failed", mockNotice };
+  }
+}

--- a/scripts/playground-agent-run.test.ts
+++ b/scripts/playground-agent-run.test.ts
@@ -108,10 +108,12 @@ describe("runPlaygroundAgentRun", () => {
     const agents: PlaygroundAgentState[] = [];
     const calls: GenerateChartRequest[] = [];
     const outcome = await runPlaygroundAgentRun(baseInput(), {
-      onAgent: (a) => agents.push(a),
-      generateChart: async (req) => {
+      onAgent: (a) => {
+        agents.push(a);
+      },
+      generateChart: (req) => {
         calls.push(req);
-        return okGenerate(envelope(validSpec, "Penguins"));
+        return Promise.resolve(okGenerate(envelope(validSpec, "Penguins")));
       },
       now: () => 1_000,
     });
@@ -130,8 +132,10 @@ describe("runPlaygroundAgentRun", () => {
   test("first-generate rate_limited sets rateLimit UX with retryAfterSeconds", async () => {
     const agents: PlaygroundAgentState[] = [];
     const outcome = await runPlaygroundAgentRun(baseInput(), {
-      onAgent: (a) => agents.push(a),
-      generateChart: async () => failGenerate("rate_limited", "slow", 24),
+      onAgent: (a) => {
+        agents.push(a);
+      },
+      generateChart: () => Promise.resolve(failGenerate("rate_limited", "slow", 24)),
       now: () => 5_000,
     });
     expect(outcome.kind).toBe("failed");
@@ -147,7 +151,7 @@ describe("runPlaygroundAgentRun", () => {
   test("upstream_rate_limited defaults retry to 60s when absent", async () => {
     const outcome = await runPlaygroundAgentRun(baseInput(), {
       onAgent: () => {},
-      generateChart: async () => failGenerate("upstream_rate_limited", "upstream slow"),
+      generateChart: () => Promise.resolve(failGenerate("upstream_rate_limited", "upstream slow")),
       now: () => 0,
     });
     expect(outcome.kind).toBe("failed");
@@ -161,7 +165,7 @@ describe("runPlaygroundAgentRun", () => {
   test("non-rate-limit first failure has no rateLimit fields", async () => {
     const outcome = await runPlaygroundAgentRun(baseInput(), {
       onAgent: () => {},
-      generateChart: async () => failGenerate("network", "down"),
+      generateChart: () => Promise.resolve(failGenerate("network", "down")),
     });
     expect(outcome.kind).toBe("failed");
     if (outcome.kind !== "failed") return;
@@ -172,10 +176,12 @@ describe("runPlaygroundAgentRun", () => {
     const calls: GenerateChartRequest[] = [];
     const agents: PlaygroundAgentState[] = [];
     const outcome = await runPlaygroundAgentRun(baseInput(), {
-      onAgent: (a) => agents.push(a),
-      generateChart: async (req) => {
+      onAgent: (a) => {
+        agents.push(a);
+      },
+      generateChart: (req) => {
         calls.push(req);
-        return okGenerate(envelope(seedBoundSpec));
+        return Promise.resolve(okGenerate(envelope(seedBoundSpec)));
       },
     });
     expect(outcome.kind).toBe("failed");
@@ -187,16 +193,18 @@ describe("runPlaygroundAgentRun", () => {
     const agents: PlaygroundAgentState[] = [];
     let n = 0;
     const outcome = await runPlaygroundAgentRun(baseInput(), {
-      onAgent: (a) => agents.push(a),
-      generateChart: async (req) => {
+      onAgent: (a) => {
+        agents.push(a);
+      },
+      generateChart: (req) => {
         n += 1;
         if (n === 1) {
           expect(req.priorErrors).toBeUndefined();
-          return okGenerate(envelope(invalidFieldSpec));
+          return Promise.resolve(okGenerate(envelope(invalidFieldSpec)));
         }
         expect(req.priorErrors?.length).toBeGreaterThan(0);
         expect(req.priorSpec).toBeDefined();
-        return okGenerate(envelope(validSpec, "Fixed"));
+        return Promise.resolve(okGenerate(envelope(validSpec, "Fixed")));
       },
     });
     expect(outcome.kind).toBe("ready_to_stage");
@@ -211,11 +219,13 @@ describe("runPlaygroundAgentRun", () => {
     let n = 0;
     const agents: PlaygroundAgentState[] = [];
     const outcome = await runPlaygroundAgentRun(baseInput(), {
-      onAgent: (a) => agents.push(a),
-      generateChart: async () => {
+      onAgent: (a) => {
+        agents.push(a);
+      },
+      generateChart: () => {
         n += 1;
-        if (n === 1) return okGenerate(envelope(invalidFieldSpec));
-        return failGenerate("rate_limited", "slow repair", 30);
+        if (n === 1) return Promise.resolve(okGenerate(envelope(invalidFieldSpec)));
+        return Promise.resolve(failGenerate("rate_limited", "slow repair", 30));
       },
     });
     expect(outcome.kind).toBe("failed");
@@ -230,10 +240,12 @@ describe("runPlaygroundAgentRun", () => {
     let n = 0;
     const agents: PlaygroundAgentState[] = [];
     const outcome = await runPlaygroundAgentRun(baseInput(), {
-      onAgent: (a) => agents.push(a),
-      generateChart: async () => {
+      onAgent: (a) => {
+        agents.push(a);
+      },
+      generateChart: () => {
         n += 1;
-        return okGenerate(envelope(invalidFieldSpec));
+        return Promise.resolve(okGenerate(envelope(invalidFieldSpec)));
       },
     });
     expect(outcome.kind).toBe("failed");
@@ -245,10 +257,12 @@ describe("runPlaygroundAgentRun", () => {
     let gate = false;
     const agents: PlaygroundAgentState[] = [];
     const outcome = await runPlaygroundAgentRun(baseInput({ isStale: () => gate }), {
-      onAgent: (a) => agents.push(a),
-      generateChart: async () => {
+      onAgent: (a) => {
+        agents.push(a);
+      },
+      generateChart: () => {
         gate = true;
-        return okGenerate(envelope(validSpec));
+        return Promise.resolve(okGenerate(envelope(validSpec)));
       },
     });
     expect(outcome.kind).toBe("stale");
@@ -267,10 +281,10 @@ describe("runPlaygroundAgentRun", () => {
     };
     const outcome = await runPlaygroundAgentRun(baseInput({ example, isStale: () => gate }), {
       onAgent: () => {},
-      generateChart: async () => {
+      generateChart: () => {
         throw new Error("example path must not generate");
       },
-      delay: async (ms) => {
+      delay: (ms) => {
         delays.push(ms);
         gate = true;
       },
@@ -284,11 +298,11 @@ describe("runPlaygroundAgentRun", () => {
     let gate = false;
     const outcome = await runPlaygroundAgentRun(baseInput({ isStale: () => gate }), {
       onAgent: () => {},
-      generateChart: async () => {
+      generateChart: () => {
         n += 1;
-        if (n === 1) return okGenerate(envelope(invalidFieldSpec));
+        if (n === 1) return Promise.resolve(okGenerate(envelope(invalidFieldSpec)));
         gate = true;
-        return okGenerate(envelope(validSpec));
+        return Promise.resolve(okGenerate(envelope(validSpec)));
       },
     });
     expect(outcome.kind).toBe("stale");
@@ -303,7 +317,7 @@ describe("runPlaygroundAgentRun", () => {
       onAgent: (a) => {
         if (a.phase === "validating") gate = true;
       },
-      generateChart: async () => okGenerate(envelope(validSpec)),
+      generateChart: () => Promise.resolve(okGenerate(envelope(validSpec))),
     });
     expect(outcome.kind).toBe("stale");
   });
@@ -320,12 +334,14 @@ describe("runPlaygroundAgentRun", () => {
       envelope: envelope(validSpec, "Example"),
     };
     const outcome = await runPlaygroundAgentRun(baseInput({ example }), {
-      onAgent: (a) => agents.push(a),
-      generateChart: async () => {
-        generates += 1;
-        return okGenerate(envelope(validSpec));
+      onAgent: (a) => {
+        agents.push(a);
       },
-      delay: async (ms) => {
+      generateChart: () => {
+        generates += 1;
+        return Promise.resolve(okGenerate(envelope(validSpec)));
+      },
+      delay: (ms) => {
         delays.push(ms);
       },
       now: () => 42,
@@ -349,11 +365,11 @@ describe("runPlaygroundAgentRun", () => {
     };
     const outcome = await runPlaygroundAgentRun(baseInput({ example }), {
       onAgent: () => {},
-      generateChart: async () => {
+      generateChart: () => {
         generates += 1;
-        return okGenerate(envelope(validSpec));
+        return Promise.resolve(okGenerate(envelope(validSpec)));
       },
-      delay: async () => {},
+      delay: () => {},
     });
     expect(outcome.kind).toBe("failed");
     expect(generates).toBe(0);
@@ -362,8 +378,10 @@ describe("runPlaygroundAgentRun", () => {
   test("thrown error maps to pipeline failure when not stale", async () => {
     const agents: PlaygroundAgentState[] = [];
     const outcome = await runPlaygroundAgentRun(baseInput(), {
-      onAgent: (a) => agents.push(a),
-      generateChart: async () => {
+      onAgent: (a) => {
+        agents.push(a);
+      },
+      generateChart: () => {
         throw new Error("boom");
       },
     });
@@ -376,8 +394,10 @@ describe("runPlaygroundAgentRun", () => {
     let gate = false;
     const agents: PlaygroundAgentState[] = [];
     const outcome = await runPlaygroundAgentRun(baseInput({ isStale: () => gate }), {
-      onAgent: (a) => agents.push(a),
-      generateChart: async () => {
+      onAgent: (a) => {
+        agents.push(a);
+      },
+      generateChart: () => {
         gate = true;
         throw new Error("late");
       },
@@ -390,7 +410,7 @@ describe("runPlaygroundAgentRun", () => {
   test("mock first generate then non-repairable fail preserves mockNotice", async () => {
     const outcome = await runPlaygroundAgentRun(baseInput(), {
       onAgent: () => {},
-      generateChart: async () => okGenerate(envelope(seedBoundSpec), "mock"),
+      generateChart: () => Promise.resolve(okGenerate(envelope(seedBoundSpec), "mock")),
     });
     expect(outcome.kind).toBe("failed");
     if (outcome.kind !== "failed") return;
@@ -400,7 +420,7 @@ describe("runPlaygroundAgentRun", () => {
   test("mock first generate success → ready_to_stage with mockNotice", async () => {
     const outcome = await runPlaygroundAgentRun(baseInput(), {
       onAgent: () => {},
-      generateChart: async () => okGenerate(envelope(validSpec, "Mock"), "mock"),
+      generateChart: () => Promise.resolve(okGenerate(envelope(validSpec, "Mock"), "mock")),
     });
     expect(outcome.kind).toBe("ready_to_stage");
     if (outcome.kind !== "ready_to_stage") return;
@@ -413,11 +433,11 @@ describe("runPlaygroundAgentRun", () => {
     let n = 0;
     await runPlaygroundAgentRun(baseInput({ signal: controller.signal }), {
       onAgent: () => {},
-      generateChart: async (_req, opts) => {
+      generateChart: (_req, opts) => {
         seen.push(opts?.signal);
         n += 1;
-        if (n === 1) return okGenerate(envelope(invalidFieldSpec));
-        return okGenerate(envelope(validSpec));
+        if (n === 1) return Promise.resolve(okGenerate(envelope(invalidFieldSpec)));
+        return Promise.resolve(okGenerate(envelope(validSpec)));
       },
     });
     expect(seen).toEqual([controller.signal, controller.signal]);
@@ -427,13 +447,15 @@ describe("runPlaygroundAgentRun", () => {
     let gate = false;
     const agents: PlaygroundAgentState[] = [];
     const outcome = await runPlaygroundAgentRun(baseInput({ isStale: () => gate }), {
-      onAgent: (a) => agents.push(a),
-      generateChart: async () => {
+      onAgent: (a) => {
+        agents.push(a);
+      },
+      generateChart: () => {
         gate = true;
         // Client maps AbortError to { ok: false, code: "aborted" }; if we
         // did not check isStale first, this would failAgent and clobber
         // onCancel's aborted failure.
-        return failGenerate("network", "aborted transport");
+        return Promise.resolve(failGenerate("network", "aborted transport"));
       },
     });
     expect(outcome.kind).toBe("stale");
@@ -456,14 +478,14 @@ describe("runPlaygroundAgentRun", () => {
       }),
       {
         onAgent: () => {},
-        generateChart: async (req) => {
+        generateChart: (req) => {
           n += 1;
           if (n === 1) {
             expect(req.currentSpec).toEqual({ read: 1 });
-            return okGenerate(envelope(invalidFieldSpec));
+            return Promise.resolve(okGenerate(envelope(invalidFieldSpec)));
           }
           expect(req.currentSpec).toEqual({ read: 2 });
-          return okGenerate(envelope(validSpec));
+          return Promise.resolve(okGenerate(envelope(validSpec)));
         },
       },
     );
@@ -477,9 +499,9 @@ describe("runPlaygroundAgentRun", () => {
       onAgent: (a) => {
         phases.push(a.phase);
       },
-      generateChart: async () => {
+      generateChart: () => {
         sawAwaitingBeforeGenerate = phases[0] === "awaiting-llm";
-        return okGenerate(envelope(validSpec));
+        return Promise.resolve(okGenerate(envelope(validSpec)));
       },
     });
     expect(sawAwaitingBeforeGenerate).toBe(true);

--- a/scripts/playground-agent-run.test.ts
+++ b/scripts/playground-agent-run.test.ts
@@ -287,6 +287,7 @@ describe("runPlaygroundAgentRun", () => {
       delay: (ms) => {
         delays.push(ms);
         gate = true;
+        return Promise.resolve();
       },
     });
     expect(outcome.kind).toBe("stale");
@@ -343,6 +344,7 @@ describe("runPlaygroundAgentRun", () => {
       },
       delay: (ms) => {
         delays.push(ms);
+        return Promise.resolve();
       },
       now: () => 42,
     });
@@ -369,7 +371,7 @@ describe("runPlaygroundAgentRun", () => {
         generates += 1;
         return Promise.resolve(okGenerate(envelope(validSpec)));
       },
-      delay: () => {},
+      delay: () => Promise.resolve(),
     });
     expect(outcome.kind).toBe("failed");
     expect(generates).toBe(0);

--- a/scripts/playground-agent-run.test.ts
+++ b/scripts/playground-agent-run.test.ts
@@ -1,0 +1,487 @@
+import { describe, expect, test } from "bun:test";
+
+import type {
+  GenerateChartRequest,
+  GenerateChartResult,
+} from "../apps/docs/src/lib/playground-agent-client";
+import {
+  defaultPlaygroundInteractions,
+  type PlaygroundAgentEnvelope,
+} from "../apps/docs/src/lib/playground-agent-envelope";
+import {
+  createPlaygroundAgentState,
+  type PlaygroundAgentState,
+} from "../apps/docs/src/lib/playground-agent-state";
+import {
+  rateLimitLabelFor,
+  runPlaygroundAgentRun,
+} from "../apps/docs/src/lib/playground-agent-run";
+import type { PlaygroundExamplePrompt } from "../apps/docs/src/lib/playground-prompts";
+
+const validSpec = {
+  edition: 2,
+  data: { name: "penguins" },
+  layers: [
+    {
+      geom: "point",
+      aes: { x: { field: "flipper" }, y: { field: "mass" } },
+    },
+  ],
+};
+
+const invalidFieldSpec = {
+  edition: 2,
+  data: { name: "penguins" },
+  layers: [
+    {
+      geom: "point",
+      aes: { x: { field: "nope" }, y: { field: "mass" } },
+    },
+  ],
+};
+
+/** Seed-bound (non-repairable): huge labs.subtitle. */
+const seedBoundSpec = {
+  ...validSpec,
+  labs: { subtitle: "x".repeat(3000) },
+};
+
+function envelope(spec: unknown, title: string | null = null): PlaygroundAgentEnvelope {
+  return {
+    spec,
+    interactions: defaultPlaygroundInteractions(),
+    title,
+  };
+}
+
+function okGenerate(env: PlaygroundAgentEnvelope, model = "live"): GenerateChartResult {
+  return {
+    ok: true,
+    model,
+    envelope: env,
+    rawEnvelope: {
+      spec: env.spec,
+      interactions: env.interactions,
+      title: env.title,
+    },
+  };
+}
+
+function failGenerate(
+  code: "rate_limited" | "upstream_rate_limited" | "network" | "upstream_error",
+  message: string,
+  retryAfterSeconds?: number,
+): GenerateChartResult {
+  return {
+    ok: false,
+    code,
+    message,
+    ...(retryAfterSeconds === undefined ? {} : { retryAfterSeconds }),
+  };
+}
+
+function phasesOf(agents: readonly PlaygroundAgentState[]): string[] {
+  return agents.map((a) => a.phase);
+}
+
+function baseInput(
+  overrides: Partial<Parameters<typeof runPlaygroundAgentRun>[0]> = {},
+): Parameters<typeof runPlaygroundAgentRun>[0] {
+  return {
+    userPrompt: "scatter penguins",
+    dataset: "penguins",
+    getCurrentSpec: () => ({ elided: true }),
+    isStale: () => false,
+    initialAgent: createPlaygroundAgentState(),
+    ...overrides,
+  };
+}
+
+describe("rateLimitLabelFor", () => {
+  test("formats countdown label", () => {
+    expect(rateLimitLabelFor(24)).toBe("Try again in 24s");
+  });
+});
+
+describe("runPlaygroundAgentRun", () => {
+  test("happy path: generate → validate → ready_to_stage; agent stays validating (not drawing)", async () => {
+    const agents: PlaygroundAgentState[] = [];
+    const calls: GenerateChartRequest[] = [];
+    const outcome = await runPlaygroundAgentRun(baseInput(), {
+      onAgent: (a) => agents.push(a),
+      generateChart: async (req) => {
+        calls.push(req);
+        return okGenerate(envelope(validSpec, "Penguins"));
+      },
+      now: () => 1_000,
+    });
+    expect(outcome.kind).toBe("ready_to_stage");
+    if (outcome.kind !== "ready_to_stage") return;
+    expect(outcome.mockNotice).toBe(false);
+    expect(outcome.pendingSuccess.title).toBe("Penguins");
+    expect(outcome.seed.version).toBe(1);
+    expect(outcome.seed.spec).toBeDefined();
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.currentSpec).toEqual({ elided: true });
+    expect(phasesOf(agents)).toEqual(["awaiting-llm", "validating"]);
+    expect(agents.at(-1)?.phase).toBe("validating");
+  });
+
+  test("first-generate rate_limited sets rateLimit UX with retryAfterSeconds", async () => {
+    const agents: PlaygroundAgentState[] = [];
+    const outcome = await runPlaygroundAgentRun(baseInput(), {
+      onAgent: (a) => agents.push(a),
+      generateChart: async () => failGenerate("rate_limited", "slow", 24),
+      now: () => 5_000,
+    });
+    expect(outcome.kind).toBe("failed");
+    if (outcome.kind !== "failed") return;
+    expect(outcome.rateLimit).toEqual({
+      until: 5_000 + 24_000,
+      label: "Try again in 24s",
+    });
+    expect(agents.at(-1)?.phase).toBe("failed");
+    expect(agents.at(-1)?.failure?.retryAfterSeconds).toBe(24);
+  });
+
+  test("upstream_rate_limited defaults retry to 60s when absent", async () => {
+    const outcome = await runPlaygroundAgentRun(baseInput(), {
+      onAgent: () => {},
+      generateChart: async () => failGenerate("upstream_rate_limited", "upstream slow"),
+      now: () => 0,
+    });
+    expect(outcome.kind).toBe("failed");
+    if (outcome.kind !== "failed") return;
+    expect(outcome.rateLimit).toEqual({
+      until: 60_000,
+      label: "Try again in 60s",
+    });
+  });
+
+  test("non-rate-limit first failure has no rateLimit fields", async () => {
+    const outcome = await runPlaygroundAgentRun(baseInput(), {
+      onAgent: () => {},
+      generateChart: async () => failGenerate("network", "down"),
+    });
+    expect(outcome.kind).toBe("failed");
+    if (outcome.kind !== "failed") return;
+    expect(outcome.rateLimit).toBeUndefined();
+  });
+
+  test("seed-bound validation fail is not repaired (no second generate)", async () => {
+    const calls: GenerateChartRequest[] = [];
+    const agents: PlaygroundAgentState[] = [];
+    const outcome = await runPlaygroundAgentRun(baseInput(), {
+      onAgent: (a) => agents.push(a),
+      generateChart: async (req) => {
+        calls.push(req);
+        return okGenerate(envelope(seedBoundSpec));
+      },
+    });
+    expect(outcome.kind).toBe("failed");
+    expect(calls).toHaveLength(1);
+    expect(agents.at(-1)?.failure?.code).toBe("validation");
+  });
+
+  test("repair succeeds: onAgent includes repairing; final phase stays repairing", async () => {
+    const agents: PlaygroundAgentState[] = [];
+    let n = 0;
+    const outcome = await runPlaygroundAgentRun(baseInput(), {
+      onAgent: (a) => agents.push(a),
+      generateChart: async (req) => {
+        n += 1;
+        if (n === 1) {
+          expect(req.priorErrors).toBeUndefined();
+          return okGenerate(envelope(invalidFieldSpec));
+        }
+        expect(req.priorErrors?.length).toBeGreaterThan(0);
+        expect(req.priorSpec).toBeDefined();
+        return okGenerate(envelope(validSpec, "Fixed"));
+      },
+    });
+    expect(outcome.kind).toBe("ready_to_stage");
+    if (outcome.kind !== "ready_to_stage") return;
+    expect(outcome.pendingSuccess.title).toBe("Fixed");
+    expect(phasesOf(agents)).toEqual(["awaiting-llm", "validating", "repairing"]);
+    expect(agents.at(-1)?.phase).toBe("repairing");
+    expect(agents.at(-1)?.repairUsed).toBe(true);
+  });
+
+  test("repair transport fail keeps first validation details and never sets rateLimit", async () => {
+    let n = 0;
+    const agents: PlaygroundAgentState[] = [];
+    const outcome = await runPlaygroundAgentRun(baseInput(), {
+      onAgent: (a) => agents.push(a),
+      generateChart: async () => {
+        n += 1;
+        if (n === 1) return okGenerate(envelope(invalidFieldSpec));
+        return failGenerate("rate_limited", "slow repair", 30);
+      },
+    });
+    expect(outcome.kind).toBe("failed");
+    if (outcome.kind !== "failed") return;
+    expect(outcome.rateLimit).toBeUndefined();
+    const failure = agents.at(-1)?.failure;
+    expect(failure?.code).toBe("rate_limited");
+    expect(failure?.details?.length).toBeGreaterThan(0);
+  });
+
+  test("repair still invalid → validation failure", async () => {
+    let n = 0;
+    const agents: PlaygroundAgentState[] = [];
+    const outcome = await runPlaygroundAgentRun(baseInput(), {
+      onAgent: (a) => agents.push(a),
+      generateChart: async () => {
+        n += 1;
+        return okGenerate(envelope(invalidFieldSpec));
+      },
+    });
+    expect(outcome.kind).toBe("failed");
+    expect(n).toBe(2);
+    expect(agents.at(-1)?.failure?.code).toBe("validation");
+  });
+
+  test("stale after first generate → stale (no fail)", async () => {
+    let gate = false;
+    const agents: PlaygroundAgentState[] = [];
+    const outcome = await runPlaygroundAgentRun(baseInput({ isStale: () => gate }), {
+      onAgent: (a) => agents.push(a),
+      generateChart: async () => {
+        gate = true;
+        return okGenerate(envelope(validSpec));
+      },
+    });
+    expect(outcome.kind).toBe("stale");
+    expect(phasesOf(agents)).toEqual(["awaiting-llm"]);
+  });
+
+  test("stale after example delay → stale", async () => {
+    let gate = false;
+    const delays: number[] = [];
+    const example: PlaygroundExamplePrompt = {
+      id: "ex",
+      label: "Ex",
+      prompt: "show penguins",
+      datasetId: "penguins",
+      envelope: envelope(validSpec, "Example"),
+    };
+    const outcome = await runPlaygroundAgentRun(baseInput({ example, isStale: () => gate }), {
+      onAgent: () => {},
+      generateChart: async () => {
+        throw new Error("example path must not generate");
+      },
+      delay: async (ms) => {
+        delays.push(ms);
+        gate = true;
+      },
+    });
+    expect(outcome.kind).toBe("stale");
+    expect(delays).toEqual([120]);
+  });
+
+  test("stale after repair generate → stale", async () => {
+    let n = 0;
+    let gate = false;
+    const outcome = await runPlaygroundAgentRun(baseInput({ isStale: () => gate }), {
+      onAgent: () => {},
+      generateChart: async () => {
+        n += 1;
+        if (n === 1) return okGenerate(envelope(invalidFieldSpec));
+        gate = true;
+        return okGenerate(envelope(validSpec));
+      },
+    });
+    expect(outcome.kind).toBe("stale");
+    expect(n).toBe(2);
+  });
+
+  test("stale after successful validate → stale (no ready_to_stage)", async () => {
+    // Flip on the validating phase (after first-generate stale check, before
+    // the post-validate gate) so validate still runs.
+    let gate = false;
+    const outcome = await runPlaygroundAgentRun(baseInput({ isStale: () => gate }), {
+      onAgent: (a) => {
+        if (a.phase === "validating") gate = true;
+      },
+      generateChart: async () => okGenerate(envelope(validSpec)),
+    });
+    expect(outcome.kind).toBe("stale");
+  });
+
+  test("example path: delay once, zero generate, ready_to_stage", async () => {
+    const agents: PlaygroundAgentState[] = [];
+    const delays: number[] = [];
+    let generates = 0;
+    const example: PlaygroundExamplePrompt = {
+      id: "ex",
+      label: "Ex",
+      prompt: "show penguins",
+      datasetId: "penguins",
+      envelope: envelope(validSpec, "Example"),
+    };
+    const outcome = await runPlaygroundAgentRun(baseInput({ example }), {
+      onAgent: (a) => agents.push(a),
+      generateChart: async () => {
+        generates += 1;
+        return okGenerate(envelope(validSpec));
+      },
+      delay: async (ms) => {
+        delays.push(ms);
+      },
+      now: () => 42,
+    });
+    expect(outcome.kind).toBe("ready_to_stage");
+    expect(generates).toBe(0);
+    expect(delays).toEqual([120]);
+    expect(agents[0]?.phaseLine).toContain("example");
+    expect(agents[0]?.exampleMode).toBe(true);
+    expect(phasesOf(agents)).toEqual(["awaiting-llm", "validating"]);
+  });
+
+  test("example path never enters repair even if envelope would be repairable", async () => {
+    let generates = 0;
+    const example: PlaygroundExamplePrompt = {
+      id: "ex",
+      label: "Ex",
+      prompt: "bad",
+      datasetId: "penguins",
+      envelope: envelope(invalidFieldSpec),
+    };
+    const outcome = await runPlaygroundAgentRun(baseInput({ example }), {
+      onAgent: () => {},
+      generateChart: async () => {
+        generates += 1;
+        return okGenerate(envelope(validSpec));
+      },
+      delay: async () => {},
+    });
+    expect(outcome.kind).toBe("failed");
+    expect(generates).toBe(0);
+  });
+
+  test("thrown error maps to pipeline failure when not stale", async () => {
+    const agents: PlaygroundAgentState[] = [];
+    const outcome = await runPlaygroundAgentRun(baseInput(), {
+      onAgent: (a) => agents.push(a),
+      generateChart: async () => {
+        throw new Error("boom");
+      },
+    });
+    expect(outcome.kind).toBe("failed");
+    expect(agents.at(-1)?.failure?.code).toBe("pipeline");
+    expect(agents.at(-1)?.failure?.message).toContain("boom");
+  });
+
+  test("thrown error while stale → stale", async () => {
+    let gate = false;
+    const agents: PlaygroundAgentState[] = [];
+    const outcome = await runPlaygroundAgentRun(baseInput({ isStale: () => gate }), {
+      onAgent: (a) => agents.push(a),
+      generateChart: async () => {
+        gate = true;
+        throw new Error("late");
+      },
+    });
+    expect(outcome.kind).toBe("stale");
+    // No failAgent after abort/supersede — only the initial awaiting phase.
+    expect(phasesOf(agents)).toEqual(["awaiting-llm"]);
+  });
+
+  test("mock first generate then non-repairable fail preserves mockNotice", async () => {
+    const outcome = await runPlaygroundAgentRun(baseInput(), {
+      onAgent: () => {},
+      generateChart: async () => okGenerate(envelope(seedBoundSpec), "mock"),
+    });
+    expect(outcome.kind).toBe("failed");
+    if (outcome.kind !== "failed") return;
+    expect(outcome.mockNotice).toBe(true);
+  });
+
+  test("mock first generate success → ready_to_stage with mockNotice", async () => {
+    const outcome = await runPlaygroundAgentRun(baseInput(), {
+      onAgent: () => {},
+      generateChart: async () => okGenerate(envelope(validSpec, "Mock"), "mock"),
+    });
+    expect(outcome.kind).toBe("ready_to_stage");
+    if (outcome.kind !== "ready_to_stage") return;
+    expect(outcome.mockNotice).toBe(true);
+  });
+
+  test("signal is forwarded to first generate and repair", async () => {
+    const controller = new AbortController();
+    const seen: Array<AbortSignal | undefined> = [];
+    let n = 0;
+    await runPlaygroundAgentRun(baseInput({ signal: controller.signal }), {
+      onAgent: () => {},
+      generateChart: async (_req, opts) => {
+        seen.push(opts?.signal);
+        n += 1;
+        if (n === 1) return okGenerate(envelope(invalidFieldSpec));
+        return okGenerate(envelope(validSpec));
+      },
+    });
+    expect(seen).toEqual([controller.signal, controller.signal]);
+  });
+
+  test("abort/stale after generate does not failAgent (onCancel owns aborted)", async () => {
+    let gate = false;
+    const agents: PlaygroundAgentState[] = [];
+    const outcome = await runPlaygroundAgentRun(baseInput({ isStale: () => gate }), {
+      onAgent: (a) => agents.push(a),
+      generateChart: async () => {
+        gate = true;
+        // Client maps AbortError to { ok: false, code: "aborted" }; if we
+        // did not check isStale first, this would failAgent and clobber
+        // onCancel's aborted failure.
+        return failGenerate("network", "aborted transport");
+      },
+    });
+    expect(outcome.kind).toBe("stale");
+    expect(phasesOf(agents)).toEqual(["awaiting-llm"]);
+    expect(agents.some((a) => a.phase === "failed")).toBe(false);
+  });
+
+  test("getCurrentSpec is called again on repair", async () => {
+    const specs: unknown[] = [];
+    let n = 0;
+    let reads = 0;
+    await runPlaygroundAgentRun(
+      baseInput({
+        getCurrentSpec: () => {
+          reads += 1;
+          const value = { read: reads };
+          specs.push(value);
+          return value;
+        },
+      }),
+      {
+        onAgent: () => {},
+        generateChart: async (req) => {
+          n += 1;
+          if (n === 1) {
+            expect(req.currentSpec).toEqual({ read: 1 });
+            return okGenerate(envelope(invalidFieldSpec));
+          }
+          expect(req.currentSpec).toEqual({ read: 2 });
+          return okGenerate(envelope(validSpec));
+        },
+      },
+    );
+    expect(reads).toBe(2);
+  });
+
+  test("onAgent fires synchronously before first await (busy latch)", async () => {
+    const phases: string[] = [];
+    let sawAwaitingBeforeGenerate = false;
+    await runPlaygroundAgentRun(baseInput(), {
+      onAgent: (a) => {
+        phases.push(a.phase);
+      },
+      generateChart: async () => {
+        sawAwaitingBeforeGenerate = phases[0] === "awaiting-llm";
+        return okGenerate(envelope(validSpec));
+      },
+    });
+    expect(sawAwaitingBeforeGenerate).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

`Playground.svelte` still held the multi-step agent orchestration (~140 lines): generate → validate → one repair → stage handoff, plus rate-limit UX and run-token supersede. That path was only exercisable through the Svelte shell / Playwright.

This PR extracts it into `playground-agent-run.ts` (same pattern as hash-restore / agent-state / agent-validate) and wires the component as a thin apply layer.

- **Drawing stays in the component** (`stageAgentSeed` owns `setAgentDrawing`) so candidate lifecycle emits stay consistent.
- **Rate-limit countdown is first-generate only** (repair rate-limits fail the agent without the button countdown).
- **`onAgent` is the only agent channel** — outcomes never carry `agent`, so success cannot clobber drawing after stage.
- **Dual elide preserved** via `getCurrentSpec()` at first generate and repair.
- Characterization tests lock repair gates, supersede/stale, example canned path, mock notice, signal forwarding, and abort-vs-failAgent ordering.

Related coverage gap tracking: #698 (unit path for repair/stale; worker/Playwright items remain there).

## Test plan

- [x] `bun test scripts/playground-agent-run.test.ts` (23 pass)
- [x] `bun run check:scripts`
- [x] svelte-check: no errors on `Playground.svelte` / `playground-agent-run.ts` (pre-existing docs errors elsewhere unchanged)
- [ ] Manual: Generate (mock) → Drawing phase → chart paints; Cancel mid-flight does not promote stale chart; example click is instant and offline
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/848" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->