### PR TITLE
refactor(svelte): extract pure diagnostic collectors from plot assembly

### DIFF
--- a/packages/svelte/src/lib/diagnostics/composition.ts
+++ b/packages/svelte/src/lib/diagnostics/composition.ts
@@ -265,7 +265,7 @@ export function collectCompositionDiagnostics(
     }
     if (isMergeKeyLayer(layer)) {
       const kind = layer.kind;
-      for (const key of Object.keys(layer.value as object)) {
+      for (const key of Object.keys(layer.value)) {
         if (mergeSeen[kind].has(key)) {
           mergeDuplicates[kind].add(key);
         } else {

--- a/packages/svelte/src/lib/diagnostics/composition.ts
+++ b/packages/svelte/src/lib/diagnostics/composition.ts
@@ -214,12 +214,15 @@ export function duplicatePlotLayerDiagnostic(
   };
 }
 
-function isMergeKeyKind(kind: string): kind is DuplicateMergeKeyKind {
-  return (MERGE_KEY_EMIT_ORDER as readonly string[]).includes(kind);
+type MergeKeyLayer = Extract<PlotLayerLike, { kind: DuplicateMergeKeyKind }>;
+type ReplaceLayer = Extract<PlotLayerLike, { kind: DuplicatePlotLayerKind }>;
+
+function isMergeKeyLayer(layer: PlotLayerLike): layer is MergeKeyLayer {
+  return (MERGE_KEY_EMIT_ORDER as readonly string[]).includes(layer.kind);
 }
 
-function isReplaceKind(kind: string): kind is DuplicatePlotLayerKind {
-  return (REPLACE_EMIT_ORDER as readonly string[]).includes(kind);
+function isReplaceLayer(layer: PlotLayerLike): layer is ReplaceLayer {
+  return (REPLACE_EMIT_ORDER as readonly string[]).includes(layer.kind);
 }
 
 /**
@@ -260,12 +263,9 @@ export function collectCompositionDiagnostics(
       }
       continue;
     }
-    if (isMergeKeyKind(layer.kind)) {
-      // After kind predicate, value is present on merge-key arms (not mark).
+    if (isMergeKeyLayer(layer)) {
       const kind = layer.kind;
-      const value = (layer as Extract<PlotLayerLike, { kind: DuplicateMergeKeyKind }>)
-        .value as object;
-      for (const key of Object.keys(value)) {
+      for (const key of Object.keys(layer.value as object)) {
         if (mergeSeen[kind].has(key)) {
           mergeDuplicates[kind].add(key);
         } else {
@@ -274,7 +274,7 @@ export function collectCompositionDiagnostics(
       }
       continue;
     }
-    if (isReplaceKind(layer.kind)) {
+    if (isReplaceLayer(layer)) {
       replaceCounts[layer.kind] += 1;
     }
   }
@@ -308,5 +308,9 @@ export function compositionAdvisoryDedupKey(diagnostic: CompositionDiagnostic): 
   if (isDuplicateMergeKeyDiagnostic(diagnostic)) {
     return `${diagnostic.code}:${diagnostic.kind}:${diagnostic.key}`;
   }
-  return `${diagnostic.code}:${diagnostic.kind}`;
+  if (isDuplicatePlotLayerDiagnostic(diagnostic)) {
+    return `${diagnostic.code}:${diagnostic.kind}`;
+  }
+  // Exhaustiveness: CompositionDiagnostic has only the three variants above.
+  return ((x: never) => x)(diagnostic);
 }

--- a/packages/svelte/src/lib/diagnostics/composition.ts
+++ b/packages/svelte/src/lib/diagnostics/composition.ts
@@ -21,10 +21,13 @@
  */
 import {
   GRAMMAR_FAMILIES,
+  MERGE_KEY_EMIT_ORDER,
+  REPLACE_EMIT_ORDER,
   grammarDocUrl,
   type MergeByKeyKind,
   type ReplaceKind,
 } from "../layers/grammar-families.js";
+import type { PlotLayerLike } from "../layers/types.js";
 
 export type CompositionDiagnosticCode =
   | "DUPLICATE_SCALE_CHANNEL"
@@ -209,4 +212,101 @@ export function duplicatePlotLayerDiagnostic(
     ],
     docUrl: grammarDocUrl(kind),
   };
+}
+
+function isMergeKeyKind(kind: string): kind is DuplicateMergeKeyKind {
+  return (MERGE_KEY_EMIT_ORDER as readonly string[]).includes(kind);
+}
+
+function isReplaceKind(kind: string): kind is DuplicatePlotLayerKind {
+  return (REPLACE_EMIT_ORDER as readonly string[]).includes(kind);
+}
+
+/**
+ * Scan plot layers for composition collisions (duplicate scale channels,
+ * keyed-MERGE key collisions, REPLACE multi-children). Pure — safe to call
+ * from a `$derived` that only re-reads `registry.layers`.
+ *
+ * Emission order: scale channels, then MERGE_KEY_EMIT_ORDER, then
+ * REPLACE_EMIT_ORDER. Mark layers are ignored.
+ */
+export function collectCompositionDiagnostics(
+  layers: readonly PlotLayerLike[],
+): CompositionDiagnostic[] {
+  const list: CompositionDiagnostic[] = [];
+  const seenChannels = new Set<string>();
+  const duplicateChannels = new Set<string>();
+  // Kind membership and emit order come from GRAMMAR_FAMILIES (#785).
+  // Scales keep their own advisory code (0.11.0 surface); labs/guides/legend
+  // share DUPLICATE_MERGE_KEY.
+  const mergeSeen = Object.fromEntries(
+    MERGE_KEY_EMIT_ORDER.map((k) => [k, new Set<string>()]),
+  ) as Record<DuplicateMergeKeyKind, Set<string>>;
+  const mergeDuplicates = Object.fromEntries(
+    MERGE_KEY_EMIT_ORDER.map((k) => [k, new Set<string>()]),
+  ) as Record<DuplicateMergeKeyKind, Set<string>>;
+  const replaceCounts = Object.fromEntries(REPLACE_EMIT_ORDER.map((k) => [k, 0])) as Record<
+    DuplicatePlotLayerKind,
+    number
+  >;
+  for (const layer of layers) {
+    if (layer.kind === "scale") {
+      for (const channel of Object.keys(layer.value)) {
+        if (seenChannels.has(channel)) {
+          duplicateChannels.add(channel);
+        } else {
+          seenChannels.add(channel);
+        }
+      }
+      continue;
+    }
+    if (isMergeKeyKind(layer.kind)) {
+      // After kind predicate, value is present on merge-key arms (not mark).
+      const kind = layer.kind;
+      const value = (layer as Extract<PlotLayerLike, { kind: DuplicateMergeKeyKind }>)
+        .value as object;
+      for (const key of Object.keys(value)) {
+        if (mergeSeen[kind].has(key)) {
+          mergeDuplicates[kind].add(key);
+        } else {
+          mergeSeen[kind].add(key);
+        }
+      }
+      continue;
+    }
+    if (isReplaceKind(layer.kind)) {
+      replaceCounts[layer.kind] += 1;
+    }
+  }
+  for (const channel of duplicateChannels) {
+    list.push(duplicateScaleChannelDiagnostic(channel));
+  }
+  for (const kind of MERGE_KEY_EMIT_ORDER) {
+    for (const key of mergeDuplicates[kind]) {
+      list.push(duplicateMergeKeyDiagnostic(kind, key));
+    }
+  }
+  for (const kind of REPLACE_EMIT_ORDER) {
+    if (replaceCounts[kind] > 1) {
+      list.push(duplicatePlotLayerDiagnostic(kind));
+    }
+  }
+  return list;
+}
+
+/**
+ * Once-per-instance advisory dedup key for composition diagnostics.
+ * Shape matches the assembly deliveredAdvisories Set:
+ * - scale: `${code}:${channel}`
+ * - merge-key: `${code}:${kind}:${key}`
+ * - replace: `${code}:${kind}`
+ */
+export function compositionAdvisoryDedupKey(diagnostic: CompositionDiagnostic): string {
+  if (isDuplicateScaleChannelDiagnostic(diagnostic)) {
+    return `${diagnostic.code}:${diagnostic.channel}`;
+  }
+  if (isDuplicateMergeKeyDiagnostic(diagnostic)) {
+    return `${diagnostic.code}:${diagnostic.kind}:${diagnostic.key}`;
+  }
+  return `${diagnostic.code}:${diagnostic.kind}`;
 }

--- a/packages/svelte/src/lib/interaction/wiring-advisories.ts
+++ b/packages/svelte/src/lib/interaction/wiring-advisories.ts
@@ -20,8 +20,8 @@ const HANDLER_CAPABILITY_PAIRS = [
   ["onlegendfilter", "legendFilter"],
 ] as const;
 
-export type WiringHandlerName = (typeof HANDLER_CAPABILITY_PAIRS)[number][0];
-export type WiringCapabilityName = (typeof HANDLER_CAPABILITY_PAIRS)[number][1];
+type WiringHandlerName = (typeof HANDLER_CAPABILITY_PAIRS)[number][0];
+type WiringCapabilityName = (typeof HANDLER_CAPABILITY_PAIRS)[number][1];
 
 /**
  * Full handler/capability bags (not Partial): missing keys would silently

--- a/packages/svelte/src/lib/interaction/wiring-advisories.ts
+++ b/packages/svelte/src/lib/interaction/wiring-advisories.ts
@@ -1,0 +1,61 @@
+/**
+ * Ambiguous-wiring advisories (ADR 0013 audit): prop combinations that
+ * silently do nothing.
+ *
+ * Pure collection — assembly reads current prop snapshots into
+ * {@link collectWiringDiagnostics} from a `$derived`. Delivery (once per
+ * code:prop per plot instance) stays in assembly.
+ */
+import {
+  INTERACTION_DIAGNOSTIC_CATALOG,
+  type InteractionDiagnostic,
+} from "./interaction-diagnostics.js";
+
+/** Handler prop → matching capability prop. */
+const HANDLER_CAPABILITY_PAIRS = [
+  ["oninspect", "inspect"],
+  ["onselect", "select"],
+  ["onzoom", "zoom"],
+  ["onlegendfocus", "legendFocus"],
+  ["onlegendfilter", "legendFilter"],
+] as const;
+
+export type WiringHandlerName = (typeof HANDLER_CAPABILITY_PAIRS)[number][0];
+export type WiringCapabilityName = (typeof HANDLER_CAPABILITY_PAIRS)[number][1];
+
+export type WiringDiagnosticInput = {
+  readonly interactionScope: unknown;
+  readonly interaction: unknown;
+  /** Present handlers only need defined vs undefined; values are not inspected. */
+  readonly handlers: Partial<Record<WiringHandlerName, unknown>>;
+  /** Capability "requested" means not undefined and not false. */
+  readonly capabilities: Partial<Record<WiringCapabilityName, unknown>>;
+};
+
+/**
+ * Collect scope-without-controller and handler-without-capability advisories
+ * from a plain snapshot. Re-run on every prop recompute so late-bound handlers
+ * still advise (assembly's once-per-code:prop Set handles dedup).
+ */
+export function collectWiringDiagnostics(input: WiringDiagnosticInput): InteractionDiagnostic[] {
+  const list: InteractionDiagnostic[] = [];
+  if (input.interactionScope !== undefined && input.interaction === undefined) {
+    list.push({ ...INTERACTION_DIAGNOSTIC_CATALOG.INTERACTION_SCOPE_WITHOUT_CONTROLLER });
+  }
+  for (const [handler, capability] of HANDLER_CAPABILITY_PAIRS) {
+    const handlerValue = input.handlers[handler];
+    if (handlerValue === undefined) continue;
+    // Capability "requested" (any value but undefined/false) is enough:
+    // requested-but-degraded configs already get their own diagnostics
+    // (requires-key, faceted zoom, ...) — never advise twice for one
+    // mistake.
+    const capabilityValue = input.capabilities[capability];
+    if (capabilityValue !== undefined && capabilityValue !== false) continue;
+    list.push({
+      ...INTERACTION_DIAGNOSTIC_CATALOG.INTERACTION_HANDLER_WITHOUT_CAPABILITY,
+      prop: handler,
+      actual: capability,
+    });
+  }
+  return list;
+}

--- a/packages/svelte/src/lib/interaction/wiring-advisories.ts
+++ b/packages/svelte/src/lib/interaction/wiring-advisories.ts
@@ -23,13 +23,18 @@ const HANDLER_CAPABILITY_PAIRS = [
 export type WiringHandlerName = (typeof HANDLER_CAPABILITY_PAIRS)[number][0];
 export type WiringCapabilityName = (typeof HANDLER_CAPABILITY_PAIRS)[number][1];
 
+/**
+ * Full handler/capability bags (not Partial): missing keys would silently
+ * drop advisories when the pair table grows. Call sites must list every
+ * entry from HANDLER_CAPABILITY_PAIRS.
+ */
 export type WiringDiagnosticInput = {
   readonly interactionScope: unknown;
   readonly interaction: unknown;
   /** Present handlers only need defined vs undefined; values are not inspected. */
-  readonly handlers: Partial<Record<WiringHandlerName, unknown>>;
+  readonly handlers: Record<WiringHandlerName, unknown>;
   /** Capability "requested" means not undefined and not false. */
-  readonly capabilities: Partial<Record<WiringCapabilityName, unknown>>;
+  readonly capabilities: Record<WiringCapabilityName, unknown>;
 };
 
 /**

--- a/packages/svelte/src/lib/plot-interaction-assembly.svelte.ts
+++ b/packages/svelte/src/lib/plot-interaction-assembly.svelte.ts
@@ -13,31 +13,22 @@ import type { PortableSpec } from "@ggsvelte/spec";
 
 import type { OrchestratorInputs } from "./plot-orchestrator.svelte.js";
 import {
-  duplicateMergeKeyDiagnostic,
-  duplicatePlotLayerDiagnostic,
-  duplicateScaleChannelDiagnostic,
-  isDuplicateMergeKeyDiagnostic,
-  isDuplicateScaleChannelDiagnostic,
+  collectCompositionDiagnostics,
+  compositionAdvisoryDedupKey,
   type CompositionDiagnostic,
-  type DuplicateMergeKeyKind,
-  type DuplicatePlotLayerKind,
 } from "./diagnostics/composition.js";
 import {
   deprecatedPropDiagnostic,
   type DeprecationDiagnostic,
   type PlotDiagnostic,
 } from "./diagnostics/deprecation.js";
-import {
-  MERGE_KEY_EMIT_ORDER,
-  REPLACE_EMIT_ORDER,
-  grammarDeprecationInputs,
-} from "./layers/grammar-families.js";
+import { grammarDeprecationInputs } from "./layers/grammar-families.js";
 import type {
   InteractionDiagnostic,
   PlotInteractionScope,
   ResolvedInteractionConfig,
 } from "./interaction/interaction.js";
-import { INTERACTION_DIAGNOSTIC_CATALOG } from "./interaction/interaction.js";
+import { collectWiringDiagnostics } from "./interaction/wiring-advisories.js";
 import { createPlotAnnouncer } from "./runtime/announcer.svelte.js";
 import { createSourceIdentityTracker, dataIdentityEpochToken } from "./runtime/semantic-keys.js";
 import {
@@ -57,14 +48,6 @@ import { createSurfaceState } from "./surface/surface-state.svelte.js";
 import { createSelectionState, type SelectionState } from "./selection/selection-state.svelte.js";
 import { presentationChromeForKind } from "./selection/selection.js";
 import { createPlotChromeState } from "./chrome/chrome-state.svelte.js";
-
-function isMergeKeyKind(kind: string): kind is DuplicateMergeKeyKind {
-  return (MERGE_KEY_EMIT_ORDER as readonly string[]).includes(kind);
-}
-
-function isReplaceKind(kind: string): kind is DuplicatePlotLayerKind {
-  return (REPLACE_EMIT_ORDER as readonly string[]).includes(kind);
-}
 
 export type PlotInteractionAssemblyDeps<
   Row extends Record<string, CellValue> = Record<string, CellValue>,
@@ -102,34 +85,31 @@ export function createPlotInteractionAssembly<
   // Wiring advisories (ADR 0013 audit): prop combinations that silently do
   // nothing. Unlike config diagnostics (re-delivered per recompute), these
   // fire once per prop per plot instance — a later capability toggle must
-  // not re-advise.
-  const wiringDiagnostics = $derived.by((): InteractionDiagnostic[] => {
-    const list: InteractionDiagnostic[] = [];
-    if (inputs.interactionScope() !== undefined && inputs.interaction() === undefined)
-      list.push({ ...INTERACTION_DIAGNOSTIC_CATALOG.INTERACTION_SCOPE_WITHOUT_CONTROLLER });
-    const handlerCapabilityPairs = [
-      ["oninspect", "inspect", inputs.oninspect(), inputs.inspect()],
-      ["onselect", "select", inputs.onselect(), inputs.select()],
-      ["onzoom", "zoom", inputs.onzoom(), inputs.zoom()],
-      ["onlegendfocus", "legendFocus", inputs.onlegendfocus(), inputs.legendFocus()],
-      ["onlegendfilter", "legendFilter", inputs.onlegendfilter(), inputs.legendFilter()],
-    ] as const;
-    for (const [handler, capability, handlerValue, capabilityValue] of handlerCapabilityPairs) {
-      if (handlerValue === undefined) continue;
-      // Capability "requested" (any value but undefined/false) is enough:
-      // requested-but-degraded configs already get their own diagnostics
-      // (requires-key, faceted zoom, ...) — never advise twice for one
-      // mistake.
-      if (capabilityValue !== undefined && capabilityValue !== false) continue;
-      list.push({
-        ...INTERACTION_DIAGNOSTIC_CATALOG.INTERACTION_HANDLER_WITHOUT_CAPABILITY,
-        prop: handler,
-        actual: capability,
-      });
-    }
-    return list;
-  });
-  // Shared once-per-code-per-prop Set for wiring + deprecation advisories.
+  // not re-advise. Pure collect lives in wiring-advisories.ts; snapshot is
+  // taken inside this derived so late-bound handlers still recompute.
+  const wiringDiagnostics = $derived.by((): InteractionDiagnostic[] =>
+    collectWiringDiagnostics({
+      interactionScope: inputs.interactionScope(),
+      interaction: inputs.interaction(),
+      handlers: {
+        oninspect: inputs.oninspect(),
+        onselect: inputs.onselect(),
+        onzoom: inputs.onzoom(),
+        onlegendfocus: inputs.onlegendfocus(),
+        onlegendfilter: inputs.onlegendfilter(),
+      },
+      capabilities: {
+        inspect: inputs.inspect(),
+        select: inputs.select(),
+        zoom: inputs.zoom(),
+        legendFocus: inputs.legendFocus(),
+        legendFilter: inputs.legendFilter(),
+      },
+    }),
+  );
+  // Shared once-per-code-per-prop Set for wiring + deprecation + composition.
+  // Delivery order is fixed: config effect (above) → wiring → deprecation →
+  // composition. Do not reorder these $effect registrations.
   const deliveredAdvisories = new Set<string>();
   $effect(() => {
     for (const diagnostic of wiringDiagnostics) {
@@ -164,81 +144,15 @@ export function createPlotInteractionAssembly<
     }
   });
 
-  // Composition advisories (#659 slices 3+5+6):
-  // - scale MERGE: duplicate aesthetic channels (dedup `${code}:${channel}`)
-  // - labs/guides/legend MERGE: duplicate keys in the same shallow merge
-  //   (dedup `${code}:${kind}:${key}`)
-  // - coord/facet/theme REPLACE: more than one child of that kind
-  //   (dedup `${code}:${kind}` so coord + facet dups deliver two advisories)
-  // Last child still wins (shallow merge / last write).
-  const compositionDiagnostics = $derived.by((): CompositionDiagnostic[] => {
-    const list: CompositionDiagnostic[] = [];
-    const seenChannels = new Set<string>();
-    const duplicateChannels = new Set<string>();
-    // Kind membership and emit order come from GRAMMAR_FAMILIES (#785).
-    // Scales keep their own advisory code (0.11.0 surface); labs/guides/legend
-    // share DUPLICATE_MERGE_KEY.
-    const mergeSeen = Object.fromEntries(
-      MERGE_KEY_EMIT_ORDER.map((k) => [k, new Set<string>()]),
-    ) as Record<DuplicateMergeKeyKind, Set<string>>;
-    const mergeDuplicates = Object.fromEntries(
-      MERGE_KEY_EMIT_ORDER.map((k) => [k, new Set<string>()]),
-    ) as Record<DuplicateMergeKeyKind, Set<string>>;
-    const replaceCounts = Object.fromEntries(REPLACE_EMIT_ORDER.map((k) => [k, 0])) as Record<
-      DuplicatePlotLayerKind,
-      number
-    >;
-    for (const layer of inputs.registry.layers) {
-      if (layer.kind === "scale") {
-        for (const channel of Object.keys(layer.value)) {
-          if (seenChannels.has(channel)) {
-            duplicateChannels.add(channel);
-          } else {
-            seenChannels.add(channel);
-          }
-        }
-        continue;
-      }
-      if (isMergeKeyKind(layer.kind)) {
-        // Narrow via kind predicate + assertion: Layer's value getter is only
-        // on non-mark arms; kind membership is table-driven (#785).
-        const kind = layer.kind;
-        const value = (layer as { readonly value: object }).value;
-        for (const key of Object.keys(value)) {
-          if (mergeSeen[kind].has(key)) {
-            mergeDuplicates[kind].add(key);
-          } else {
-            mergeSeen[kind].add(key);
-          }
-        }
-        continue;
-      }
-      if (isReplaceKind(layer.kind)) {
-        replaceCounts[layer.kind] += 1;
-      }
-    }
-    for (const channel of duplicateChannels) {
-      list.push(duplicateScaleChannelDiagnostic(channel));
-    }
-    for (const kind of MERGE_KEY_EMIT_ORDER) {
-      for (const key of mergeDuplicates[kind]) {
-        list.push(duplicateMergeKeyDiagnostic(kind, key));
-      }
-    }
-    for (const kind of REPLACE_EMIT_ORDER) {
-      if (replaceCounts[kind] > 1) {
-        list.push(duplicatePlotLayerDiagnostic(kind));
-      }
-    }
-    return list;
-  });
+  // Composition advisories (#659 slices 3+5+6): pure collect over
+  // registry.layers. Last child still wins (shallow merge / last write);
+  // delivery is once-per-dedup-key via compositionAdvisoryDedupKey.
+  const compositionDiagnostics = $derived.by((): CompositionDiagnostic[] =>
+    collectCompositionDiagnostics(inputs.registry.layers),
+  );
   $effect(() => {
     for (const diagnostic of compositionDiagnostics) {
-      const dedupKey = isDuplicateScaleChannelDiagnostic(diagnostic)
-        ? `${diagnostic.code}:${diagnostic.channel}`
-        : isDuplicateMergeKeyDiagnostic(diagnostic)
-          ? `${diagnostic.code}:${diagnostic.kind}:${diagnostic.key}`
-          : `${diagnostic.code}:${diagnostic.kind}`;
+      const dedupKey = compositionAdvisoryDedupKey(diagnostic);
       if (deliveredAdvisories.has(dedupKey)) continue;
       deliveredAdvisories.add(dedupKey);
       deliverDiagnostic(diagnostic);

--- a/packages/svelte/tests/diagnostics/composition-collect.ssr.test.ts
+++ b/packages/svelte/tests/diagnostics/composition-collect.ssr.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Pure composition-diagnostic collection (extracted from plot assembly).
+ * Node lane — no browser/GGPlot. Expected values are independent of
+ * implementation structure (codes, channels, emit order).
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  collectCompositionDiagnostics,
+  compositionAdvisoryDedupKey,
+} from "../../src/lib/diagnostics/composition.js";
+import type { PlotLayerLike } from "../../src/lib/layers/types.js";
+
+function scale(channel: string): PlotLayerLike {
+  return { kind: "scale", value: { [channel]: { type: "discrete" } } as never };
+}
+
+function labs(keys: Record<string, string>): PlotLayerLike {
+  return { kind: "labs", value: keys as never };
+}
+
+function guides(keys: Record<string, unknown>): PlotLayerLike {
+  return { kind: "guides", value: keys as never };
+}
+
+function legend(keys: Record<string, unknown>): PlotLayerLike {
+  return { kind: "legend", value: keys as never };
+}
+
+function coord(): PlotLayerLike {
+  return { kind: "coord", value: "flip" };
+}
+
+function facet(): PlotLayerLike {
+  return { kind: "facet", value: { rows: "g" } as never };
+}
+
+function theme(): PlotLayerLike {
+  return { kind: "theme", value: "dark" as never };
+}
+
+function mark(): PlotLayerLike {
+  return {
+    kind: "mark",
+    descriptor: { geom: "point", data: undefined, mapping: undefined } as never,
+  };
+}
+
+describe("collectCompositionDiagnostics", () => {
+  it("returns empty for no layers", () => {
+    expect(collectCompositionDiagnostics([])).toEqual([]);
+  });
+
+  it("ignores mark layers", () => {
+    expect(collectCompositionDiagnostics([mark(), mark()])).toEqual([]);
+  });
+
+  it("emits DUPLICATE_SCALE_CHANNEL once per colliding channel", () => {
+    const list = collectCompositionDiagnostics([scale("color"), scale("color"), scale("fill")]);
+    expect(list).toEqual([
+      expect.objectContaining({
+        code: "DUPLICATE_SCALE_CHANNEL",
+        channel: "color",
+        kind: "scale",
+        severity: "advisory",
+      }),
+    ]);
+  });
+
+  it("emits DUPLICATE_MERGE_KEY for labs/guides/legend collisions", () => {
+    const list = collectCompositionDiagnostics([
+      labs({ title: "A" }),
+      labs({ title: "B", x: "X" }),
+      guides({ color: {} }),
+      guides({ color: {}, size: {} }),
+      legend({ position: "right" }),
+      legend({ position: "bottom" }),
+    ]);
+    expect(
+      list.map((d) => [d.code, "kind" in d ? d.kind : null, "key" in d ? d.key : null]),
+    ).toEqual([
+      ["DUPLICATE_MERGE_KEY", "labs", "title"],
+      ["DUPLICATE_MERGE_KEY", "guides", "color"],
+      ["DUPLICATE_MERGE_KEY", "legend", "position"],
+    ]);
+  });
+
+  it("emits DUPLICATE_PLOT_LAYER when two REPLACE children share a kind", () => {
+    const list = collectCompositionDiagnostics([coord(), coord(), facet(), theme(), theme()]);
+    expect(list.map((d) => [d.code, "kind" in d ? d.kind : null])).toEqual([
+      ["DUPLICATE_PLOT_LAYER", "coord"],
+      ["DUPLICATE_PLOT_LAYER", "theme"],
+    ]);
+  });
+
+  it("emits scale channels, then merge-key families, then replace families (cross-family order)", () => {
+    const list = collectCompositionDiagnostics([
+      scale("color"),
+      scale("color"),
+      labs({ title: "A" }),
+      labs({ title: "B" }),
+      coord(),
+      coord(),
+    ]);
+    expect(list.map((d) => d.code)).toEqual([
+      "DUPLICATE_SCALE_CHANNEL",
+      "DUPLICATE_MERGE_KEY",
+      "DUPLICATE_PLOT_LAYER",
+    ]);
+  });
+});
+
+describe("compositionAdvisoryDedupKey", () => {
+  it("keys scale by channel, merge-key by kind+key, replace by kind", () => {
+    const [scaleDup] = collectCompositionDiagnostics([scale("color"), scale("color")]);
+    const [mergeDup] = collectCompositionDiagnostics([labs({ title: "A" }), labs({ title: "B" })]);
+    const [replaceDup] = collectCompositionDiagnostics([coord(), coord()]);
+    expect(compositionAdvisoryDedupKey(scaleDup)).toBe("DUPLICATE_SCALE_CHANNEL:color");
+    expect(compositionAdvisoryDedupKey(mergeDup)).toBe("DUPLICATE_MERGE_KEY:labs:title");
+    expect(compositionAdvisoryDedupKey(replaceDup)).toBe("DUPLICATE_PLOT_LAYER:coord");
+  });
+});

--- a/packages/svelte/tests/diagnostics/composition-collect.ssr.test.ts
+++ b/packages/svelte/tests/diagnostics/composition-collect.ssr.test.ts
@@ -12,19 +12,19 @@ import {
 import type { PlotLayerLike } from "../../src/lib/layers/types.js";
 
 function scale(channel: string): PlotLayerLike {
-  return { kind: "scale", value: { [channel]: { type: "discrete" } } as never };
+  return { kind: "scale", value: { [channel]: { type: "discrete" } } };
 }
 
 function labs(keys: Record<string, string>): PlotLayerLike {
-  return { kind: "labs", value: keys as never };
+  return { kind: "labs", value: keys };
 }
 
 function guides(keys: Record<string, unknown>): PlotLayerLike {
-  return { kind: "guides", value: keys as never };
+  return { kind: "guides", value: keys };
 }
 
 function legend(keys: Record<string, unknown>): PlotLayerLike {
-  return { kind: "legend", value: keys as never };
+  return { kind: "legend", value: keys };
 }
 
 function coord(): PlotLayerLike {
@@ -32,17 +32,17 @@ function coord(): PlotLayerLike {
 }
 
 function facet(): PlotLayerLike {
-  return { kind: "facet", value: { rows: "g" } as never };
+  return { kind: "facet", value: { rows: "g" } };
 }
 
 function theme(): PlotLayerLike {
-  return { kind: "theme", value: "dark" as never };
+  return { kind: "theme", value: "dark" };
 }
 
 function mark(): PlotLayerLike {
   return {
     kind: "mark",
-    descriptor: { geom: "point", data: undefined, mapping: undefined } as never,
+    descriptor: { geom: "point" },
   };
 }
 

--- a/packages/svelte/tests/interaction/wiring-advisories.ssr.test.ts
+++ b/packages/svelte/tests/interaction/wiring-advisories.ssr.test.ts
@@ -4,39 +4,50 @@
  */
 import { describe, expect, it } from "vitest";
 
-import { collectWiringDiagnostics } from "../../src/lib/interaction/wiring-advisories.js";
+import {
+  collectWiringDiagnostics,
+  type WiringDiagnosticInput,
+} from "../../src/lib/interaction/wiring-advisories.js";
+
+const emptyHandlers: WiringDiagnosticInput["handlers"] = {
+  oninspect: undefined,
+  onselect: undefined,
+  onzoom: undefined,
+  onlegendfocus: undefined,
+  onlegendfilter: undefined,
+};
+
+const emptyCapabilities: WiringDiagnosticInput["capabilities"] = {
+  inspect: undefined,
+  select: undefined,
+  zoom: undefined,
+  legendFocus: undefined,
+  legendFilter: undefined,
+};
+
+function snapshot(
+  partial: Partial<WiringDiagnosticInput> & {
+    handlers?: Partial<WiringDiagnosticInput["handlers"]>;
+    capabilities?: Partial<WiringDiagnosticInput["capabilities"]>;
+  } = {},
+): WiringDiagnosticInput {
+  return {
+    interactionScope: partial.interactionScope,
+    interaction: partial.interaction,
+    handlers: { ...emptyHandlers, ...partial.handlers },
+    capabilities: { ...emptyCapabilities, ...partial.capabilities },
+  };
+}
 
 describe("collectWiringDiagnostics", () => {
   it("returns empty when nothing is miswired", () => {
-    expect(
-      collectWiringDiagnostics({
-        interactionScope: undefined,
-        interaction: undefined,
-        handlers: {
-          oninspect: undefined,
-          onselect: undefined,
-          onzoom: undefined,
-          onlegendfocus: undefined,
-          onlegendfilter: undefined,
-        },
-        capabilities: {
-          inspect: undefined,
-          select: undefined,
-          zoom: undefined,
-          legendFocus: undefined,
-          legendFilter: undefined,
-        },
-      }),
-    ).toEqual([]);
+    expect(collectWiringDiagnostics(snapshot())).toEqual([]);
   });
 
   it("advises when interactionScope is set without a controller", () => {
-    const list = collectWiringDiagnostics({
-      interactionScope: { keys: "row-id" },
-      interaction: undefined,
-      handlers: {},
-      capabilities: {},
-    });
+    const list = collectWiringDiagnostics(
+      snapshot({ interactionScope: { keys: "row-id" }, interaction: undefined }),
+    );
     expect(list).toEqual([
       expect.objectContaining({
         code: "INTERACTION_SCOPE_WITHOUT_CONTROLLER",
@@ -47,30 +58,30 @@ describe("collectWiringDiagnostics", () => {
   });
 
   it("stays silent when scope accompanies a controller", () => {
-    const list = collectWiringDiagnostics({
-      interactionScope: { keys: "row-id" },
-      interaction: { id: "controller" },
-      handlers: {},
-      capabilities: {},
-    });
+    const list = collectWiringDiagnostics(
+      snapshot({
+        interactionScope: { keys: "row-id" },
+        interaction: { id: "controller" },
+      }),
+    );
     expect(list.map((d) => d.code)).not.toContain("INTERACTION_SCOPE_WITHOUT_CONTROLLER");
   });
 
   it("advises per dead handler, naming the capability prop", () => {
-    const list = collectWiringDiagnostics({
-      interactionScope: undefined,
-      interaction: undefined,
-      handlers: {
-        onselect: () => {},
-        onzoom: () => {},
-        oninspect: undefined,
-      },
-      capabilities: {
-        select: undefined,
-        zoom: false,
-        inspect: true,
-      },
-    });
+    const list = collectWiringDiagnostics(
+      snapshot({
+        handlers: {
+          onselect: () => {},
+          onzoom: () => {},
+          oninspect: undefined,
+        },
+        capabilities: {
+          select: undefined,
+          zoom: false,
+          inspect: true,
+        },
+      }),
+    );
     expect(
       list
         .filter((d) => d.code === "INTERACTION_HANDLER_WITHOUT_CAPABILITY")
@@ -82,43 +93,39 @@ describe("collectWiringDiagnostics", () => {
   });
 
   it("does not advise when the matching capability is requested", () => {
-    const list = collectWiringDiagnostics({
-      interactionScope: undefined,
-      interaction: undefined,
-      handlers: {
-        onselect: () => {},
-        onzoom: () => {},
-        oninspect: () => {},
-        onlegendfocus: () => {},
-        onlegendfilter: () => {},
-      },
-      capabilities: {
-        select: "point",
-        zoom: true,
-        inspect: true,
-        legendFocus: true,
-        legendFilter: true,
-      },
-    });
+    const list = collectWiringDiagnostics(
+      snapshot({
+        handlers: {
+          onselect: () => {},
+          onzoom: () => {},
+          oninspect: () => {},
+          onlegendfocus: () => {},
+          onlegendfilter: () => {},
+        },
+        capabilities: {
+          select: "point",
+          zoom: true,
+          inspect: true,
+          legendFocus: true,
+          legendFilter: true,
+        },
+      }),
+    );
     expect(list.map((d) => d.code)).not.toContain("INTERACTION_HANDLER_WITHOUT_CAPABILITY");
   });
 
   it("recomputes for a late-added handler (characterization of pure snapshot input)", () => {
-    const base = {
-      interactionScope: undefined as undefined,
-      interaction: undefined as undefined,
-      handlers: {
-        onselect: undefined as (() => void) | undefined,
-      },
-      capabilities: {
-        select: undefined as undefined,
-      },
-    };
-    expect(collectWiringDiagnostics(base)).toEqual([]);
-    const after = collectWiringDiagnostics({
-      ...base,
-      handlers: { onselect: () => {} },
+    const base = snapshot({
+      handlers: { onselect: undefined },
+      capabilities: { select: undefined },
     });
+    expect(collectWiringDiagnostics(base)).toEqual([]);
+    const after = collectWiringDiagnostics(
+      snapshot({
+        handlers: { onselect: () => {} },
+        capabilities: { select: undefined },
+      }),
+    );
     expect(after).toEqual([
       expect.objectContaining({
         code: "INTERACTION_HANDLER_WITHOUT_CAPABILITY",

--- a/packages/svelte/tests/interaction/wiring-advisories.ssr.test.ts
+++ b/packages/svelte/tests/interaction/wiring-advisories.ssr.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Pure wiring-advisory collection (extracted from plot assembly).
+ * Node lane — no browser/GGPlot.
+ */
+import { describe, expect, it } from "vitest";
+
+import { collectWiringDiagnostics } from "../../src/lib/interaction/wiring-advisories.js";
+
+describe("collectWiringDiagnostics", () => {
+  it("returns empty when nothing is miswired", () => {
+    expect(
+      collectWiringDiagnostics({
+        interactionScope: undefined,
+        interaction: undefined,
+        handlers: {
+          oninspect: undefined,
+          onselect: undefined,
+          onzoom: undefined,
+          onlegendfocus: undefined,
+          onlegendfilter: undefined,
+        },
+        capabilities: {
+          inspect: undefined,
+          select: undefined,
+          zoom: undefined,
+          legendFocus: undefined,
+          legendFilter: undefined,
+        },
+      }),
+    ).toEqual([]);
+  });
+
+  it("advises when interactionScope is set without a controller", () => {
+    const list = collectWiringDiagnostics({
+      interactionScope: { keys: "row-id" },
+      interaction: undefined,
+      handlers: {},
+      capabilities: {},
+    });
+    expect(list).toEqual([
+      expect.objectContaining({
+        code: "INTERACTION_SCOPE_WITHOUT_CONTROLLER",
+        severity: "advisory",
+        prop: "interactionScope",
+      }),
+    ]);
+  });
+
+  it("stays silent when scope accompanies a controller", () => {
+    const list = collectWiringDiagnostics({
+      interactionScope: { keys: "row-id" },
+      interaction: { id: "controller" },
+      handlers: {},
+      capabilities: {},
+    });
+    expect(list.map((d) => d.code)).not.toContain("INTERACTION_SCOPE_WITHOUT_CONTROLLER");
+  });
+
+  it("advises per dead handler, naming the capability prop", () => {
+    const list = collectWiringDiagnostics({
+      interactionScope: undefined,
+      interaction: undefined,
+      handlers: {
+        onselect: () => {},
+        onzoom: () => {},
+        oninspect: undefined,
+      },
+      capabilities: {
+        select: undefined,
+        zoom: false,
+        inspect: true,
+      },
+    });
+    expect(
+      list
+        .filter((d) => d.code === "INTERACTION_HANDLER_WITHOUT_CAPABILITY")
+        .map((d) => [d.prop, d.actual]),
+    ).toEqual([
+      ["onselect", "select"],
+      ["onzoom", "zoom"],
+    ]);
+  });
+
+  it("does not advise when the matching capability is requested", () => {
+    const list = collectWiringDiagnostics({
+      interactionScope: undefined,
+      interaction: undefined,
+      handlers: {
+        onselect: () => {},
+        onzoom: () => {},
+        oninspect: () => {},
+        onlegendfocus: () => {},
+        onlegendfilter: () => {},
+      },
+      capabilities: {
+        select: "point",
+        zoom: true,
+        inspect: true,
+        legendFocus: true,
+        legendFilter: true,
+      },
+    });
+    expect(list.map((d) => d.code)).not.toContain("INTERACTION_HANDLER_WITHOUT_CAPABILITY");
+  });
+
+  it("recomputes for a late-added handler (characterization of pure snapshot input)", () => {
+    const base = {
+      interactionScope: undefined as undefined,
+      interaction: undefined as undefined,
+      handlers: {
+        onselect: undefined as (() => void) | undefined,
+      },
+      capabilities: {
+        select: undefined as undefined,
+      },
+    };
+    expect(collectWiringDiagnostics(base)).toEqual([]);
+    const after = collectWiringDiagnostics({
+      ...base,
+      handlers: { onselect: () => {} },
+    });
+    expect(after).toEqual([
+      expect.objectContaining({
+        code: "INTERACTION_HANDLER_WITHOUT_CAPABILITY",
+        prop: "onselect",
+        actual: "select",
+      }),
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- Extract **composition** advisory collection into pure `collectCompositionDiagnostics` / `compositionAdvisoryDedupKey` on `diagnostics/composition.ts`
- Extract **wiring** advisory collection into pure `collectWiringDiagnostics` in `interaction/wiring-advisories.ts`
- Keep plot-interaction-assembly as the thin orchestrator: delivery order, once-per-instance dedup, and the TDZ-safe controller construction graph stay put

**Why:** `plot-interaction-assembly.svelte.ts` mixed pure diagnostic scanning with controller wiring. Composition/wiring rules could only be exercised through browser GGPlot suites. Pure collectors land on the SSR lane; assembly shrinks (~641 → ~555 lines) without touching construction order.

## Test plan

- [x] `bun run test:ssr` — 18 files / 141 tests (includes new `composition-collect.ssr.test.ts`, `wiring-advisories.ssr.test.ts`)
- [x] Chromium: `wiring-diagnostics.test.ts` (8)
- [x] Chromium: scale / coord-facet / labs-guides-legend / theme children suites (88)
- [x] Pre-existing `svelte-check` `panelAtOrOnly` errors on main (stale core dist) — not introduced here

## Follow-ups

- https://github.com/ljodea/ggsvelte/issues/852 — extract pure data-identity epoch fingerprint from assembly
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/853" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->