### PR TITLE
refactor(svelte): extract inspection pointer-inspect queue

### DIFF
--- a/packages/svelte/src/lib/inspection/inspection-state.svelte.ts
+++ b/packages/svelte/src/lib/inspection/inspection-state.svelte.ts
@@ -2,11 +2,11 @@
  * Inspection controller extracted from GGPlot for S6.
  *
  * Owns inspection $state, inspectionSeed, lastInspectionFingerprint,
- * activeCandidateId, pointer-queue fields (queuedPointerToken,
- * queuedPointerInspection, pendingPinnedPointer), construction-time deriveds
- * (inspectionPanel, traversalHits), the coordinator, private resolve/emit
- * helpers, public set/toggle/dismiss/close/traversal/queue methods, and
- * phased effects (coordinator disposal + scene-reconcile).
+ * activeCandidateId, construction-time deriveds (inspectionPanel), the
+ * coordinator, private resolve/emit helpers, public set/toggle/dismiss/
+ * close/traversal methods, and phased effects (coordinator disposal +
+ * scene-reconcile). Pointer-inspect queue ownership lives in
+ * pointer-inspect.ts (schedule / cancel / onFrame / pending pin stash).
  *
  * Factory sits at the original queue-vars position (before the component-held
  * reducer). Construction-time deriveds read inspection (own) and model only.
@@ -24,7 +24,7 @@ import type { CandidateFacts, CellValue, RenderModel } from "@ggsvelte/core";
 import type { PanelBounds } from "../scene/geometry.js";
 
 import { createInspectionCoordinator } from "./coordinator.js";
-import type { createInteractionReducer, InteractionAction } from "../interaction/reducer.js";
+import type { createInteractionReducer } from "../interaction/reducer.js";
 import type {
   InteractionSource,
   PlotInspection,
@@ -36,11 +36,6 @@ import { inspectionLiveText as inspectionLiveTextFor } from "../assembly/labels.
 import { plotTooltipDomId } from "../assembly/layout.js";
 import { hitFromCandidate, type SceneHit } from "../surface/plot-px.js";
 import {
-  buildQueuedInspectFrame,
-  resolveQueuedInspectFrameAction,
-  type QueuedPointerInspection,
-} from "./frame.js";
-import {
   resolveInspectionCompleteness,
   resolveInspectionMode,
   resolveSetInspectionAction,
@@ -49,6 +44,12 @@ import {
   shouldClearInspectionAnnouncement,
   shouldFocusPinnedInteractiveTooltip,
 } from "./apply.js";
+import {
+  createPointerInspectQueue,
+  type CancelPointerInspectPolicy,
+  type InspectPointerFrameAction,
+  type SchedulePointerInspectInput,
+} from "./pointer-inspect.js";
 import {
   planInspectionDismiss,
   planSceneInspectReconcile,
@@ -62,9 +63,6 @@ import {
 
 /** Component-held reducer shape — factory-only export from interaction/reducer. */
 type InteractionReducer = ReturnType<typeof createInteractionReducer>;
-
-/** Inspect frame action delivered to onPointerFrame (non-move-area branch). */
-type InspectPointerFrameAction = Extract<InteractionAction, { type: "inspect" }>;
 
 export type InspectionStateDeps = {
   model: () => RenderModel | null;
@@ -98,20 +96,6 @@ export type InspectionStateDeps = {
 function resolveReducer(reducer: InspectionStateDeps["reducer"]): InteractionReducer {
   return typeof reducer === "function" ? reducer() : reducer;
 }
-
-/** Intent for a coalesced pointer-inspect frame (nearest lookup owned here). */
-type SchedulePointerInspectInput = {
-  readonly point: Readonly<{ x: number; y: number }>;
-  readonly source: InteractionSource;
-  readonly mode: "auto" | "exact" | "x" | "y" | "xy";
-  readonly maxDistance: number;
-};
-
-/** Cancel policy for pending pointer-inspect work. */
-type CancelPointerInspectPolicy = {
-  /** Leave/clear: discard stash. Cancel/down/blur tool paths: preserve. */
-  readonly pendingPinned: "preserve" | "discard";
-};
 
 /** Panel geometry for crosshairs / keyboard clamp; id for scene lookups. */
 type InspectionPanelBounds = PanelBounds & { readonly id: string };
@@ -188,22 +172,22 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
   let dismissedCandidateId: number | null = null;
   let dismissedRunId: number | null = null;
 
-  let queuedPointerToken: {
-    readonly epoch: number;
-    readonly revision: number;
-  } | null = null;
-  let queuedPointerInspection: QueuedPointerInspection | null = null;
-  let pendingPinnedPointer: QueuedPointerInspection | null = null;
-
   function clearDismissedLatch(): void {
     dismissedCandidateId = null;
     dismissedRunId = null;
   }
 
-  /** Cancel inspect schedule + payload; optional stash clear. */
-  function invalidatePointerInspect(policy: CancelPointerInspectPolicy): void {
-    cancelPointerInspect(policy);
-  }
+  // Queue factory stores thunks only — does not call model/reducer at
+  // construction (armed-getter suite). setInspection is a function
+  // declaration (hoisted) so the apply-pending re-entry closes correctly.
+  const pointerQueue = createPointerInspectQueue({
+    model: () => deps.model(),
+    reducer: () => reducerOf(),
+    inspectionState: () => (inspection === null ? "none" : inspection.state),
+    setInspection: (hit, source, state, concreteMode, candidate) => {
+      setInspection(hit, source, state, concreteMode, candidate);
+    },
+  });
 
   // Construction-safe: own state + earlier host model.
   // Key off the inspection snapshot's panelId (authoritative from the seed
@@ -310,7 +294,7 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
     // (e.g. touch tap after a sub-threshold touch move scheduled inspect).
     // Pointer hover keeps the queue so successive move frames coalesce.
     if (source !== "pointer") {
-      invalidatePointerInspect({ pendingPinned: "preserve" });
+      pointerQueue.cancel({ pendingPinned: "preserve" });
     }
     const action = resolveSetInspectionAction({
       hasHit: hit !== null,
@@ -357,17 +341,18 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
   }
 
   function toggleInspectionPin(source: InteractionSource): void {
-    invalidatePointerInspect({ pendingPinned: "preserve" });
+    pointerQueue.cancel({ pendingPinned: "preserve" });
     const pinAction = resolveToggleInspectionPinAction({
       hasInspection: inspection !== null,
       hasSeed: inspectionSeed !== null,
       currentState: inspection?.state ?? "transient",
-      pending: pendingPinnedPointer,
+      pending: pointerQueue.peekPendingPinned(),
     });
     if (pinAction.type === "ignore") return;
     switch (pinAction.type) {
       case "restore-pending": {
-        pendingPinnedPointer = null;
+        // Consume stash (read+clear) so a second toggle cannot re-restore.
+        pointerQueue.takePendingPinned();
         inspectionCoordinator.release("pinned");
         inspection = null;
         inspectionSeed = null;
@@ -432,7 +417,8 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
         returnToInspect: opts.returnToInspect,
       }),
     });
-    invalidatePointerInspect({
+    // discard policy already clears pending pin stash — no second clear.
+    pointerQueue.cancel({
       pendingPinned: plan.clearPendingPinned ? "discard" : "preserve",
     });
     // Latch only when dismissing a *transient* inspection (Escape path).
@@ -448,7 +434,6 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
     inspection = null;
     inspectionSeed = null;
     if (plan.clearTooltipHovered) deps.clearTooltipHovered();
-    if (plan.clearPendingPinned) pendingPinnedPointer = null;
     if (plan.coordinator === "invalidate") inspectionCoordinator.invalidate();
     else inspectionCoordinator.release("pinned");
     // Cross-module clearBrush / returnToInspect: caller applies via
@@ -502,85 +487,15 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
   }
 
   function schedulePointerInspect(input: SchedulePointerInspectInput): void {
-    const model = deps.model();
-    // Panel-scoped nearest so faceted hover cannot seed another facet (#787).
-    // panelAtOrOnly keeps single-panel axis-margin hover working (Claude plan review).
-    const match =
-      model?.viewport.panelAtOrOnly(input.point)?.nearest(input.point, {
-        mode: input.mode,
-        maxDistance: input.maxDistance,
-      }) ?? null;
-    const frame = buildQueuedInspectFrame({
-      match,
-      source: input.source,
-      epoch: model?.runId ?? 0,
-      fallbackCandidate: () => model?.candidates.hitTest(input.point.x, input.point.y) ?? null,
-    });
-    const reducer = reducerOf();
-    queuedPointerInspection = frame.queued;
-    queuedPointerToken = reducer.frameToken();
-    try {
-      reducer.queuePointer({
-        type: "inspect",
-        candidate: frame.candidate,
-        source: input.source,
-      });
-    } catch (error) {
-      // No orphan payload if scheduling throws (Codex plan review).
-      queuedPointerInspection = null;
-      queuedPointerToken = null;
-      throw error;
-    }
+    pointerQueue.schedule(input);
   }
 
   function cancelPointerInspect(policy: CancelPointerInspectPolicy): void {
-    queuedPointerInspection = null;
-    if (policy.pendingPinned === "discard") pendingPinnedPointer = null;
-    reducerOf().cancelScheduledPointer("inspect");
+    pointerQueue.cancel(policy);
   }
 
-  /**
-   * Inspect branch of onPointerFrame. Returns false on drop so the reducer
-   * skips dispatch (atomic with InspectionState — Codex plan review).
-   */
   function onInspectPointerFrame(action: InspectPointerFrameAction): boolean {
-    // Snapshot then clear queues before pure routing (matches prior host).
-    const pending = queuedPointerInspection;
-    const token = queuedPointerToken;
-    queuedPointerInspection = null;
-    queuedPointerToken = null;
-    // Short-circuit tokenAccepted when no pending so accepts() is not
-    // called for empty frames (Codex plan review).
-    const frameAction = resolveQueuedInspectFrameAction({
-      hasPending: pending !== null,
-      tokenAccepted: pending === null || token === null || reducerOf().accepts(token),
-      currentState: inspection === null ? "none" : inspection.state,
-      candidateEpochMismatch:
-        action.candidate !== null && action.candidate.epoch !== deps.model()?.runId,
-    });
-    switch (frameAction.type) {
-      case "none":
-        // Empty frame: still allow reducer dispatch (prior host behavior when
-        // payload was cleared but a scheduled inspect still flushed).
-        return true;
-      case "drop":
-        return false;
-      case "stash-pending":
-        if (pending !== null) pendingPinnedPointer = pending;
-        return true;
-      case "apply-pending":
-        if (pending !== null) {
-          setInspection(
-            pending.hit,
-            pending.source,
-            "transient",
-            pending.concreteMode,
-            pending.candidate,
-          );
-        }
-        return true;
-    }
-    return true;
+    return pointerQueue.onFrame(action);
   }
 
   // Coordinator disposal + scene-run reconcile (formerly host-phased
@@ -610,18 +525,17 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
         inspection = null;
         inspectionSeed = null;
         clearDismissedLatch();
-        invalidatePointerInspect({ pendingPinned: "discard" });
+        // Inspect-only cancel: move-area schedules must survive.
+        pointerQueue.cancel({ pendingPinned: "discard" });
         return;
       case "invalidate-clear-transient":
       case "invalidate-idle":
       case "invalidate-reconcile-pinned": {
         // currentModel is non-null for invalidate-* (plan requires run advance).
         const runId = currentModel!.runId;
+        // invalidate dispatch already cancels all scheduled pointer work.
         reducerOf().dispatch({ type: "invalidate", reason: "scene" });
-        queuedPointerInspection = null;
-        pendingPinnedPointer = null;
-        queuedPointerToken = null;
-        reducerOf().cancelScheduledPointer();
+        pointerQueue.clearForSceneInvalidate();
         clearDismissedLatch();
         reconciledRun = runId;
         if (plan.type === "invalidate-clear-transient") {

--- a/packages/svelte/src/lib/inspection/pointer-inspect.ts
+++ b/packages/svelte/src/lib/inspection/pointer-inspect.ts
@@ -1,0 +1,204 @@
+/**
+ * Pointer-inspect queue ownership for InspectionState.
+ *
+ * Owns queued payload + frame token + pending-pin stash, nearest schedule,
+ * typed cancel, and onInspectPointerFrame routing. Pure frame tables stay in
+ * frame.ts; the host owns $state inspection snapshot, setInspection, dismiss,
+ * and scene-reconcile orchestration.
+ *
+ * Construction must not invoke deps.model / deps.reducer / deps.setInspection
+ * (armed-getter construction discipline on the host factory).
+ *
+ * onFrame may re-enter the host via setInspection (apply-pending). Snapshot
+ * then clear queue fields before pure routing so re-entrant cancel sees empty
+ * queue fields — load-bearing for touch-tap override of a pending rAF.
+ */
+
+import type { CandidateFacts, RenderModel } from "@ggsvelte/core";
+
+import type { InteractionAction, InteractionFrameToken } from "../interaction/reducer.js";
+import type { InteractionSource } from "../interaction/interaction.js";
+import type { SceneHit } from "../surface/plot-px.js";
+import {
+  buildQueuedInspectFrame,
+  resolveQueuedInspectFrameAction,
+  type InspectionHostState,
+  type QueuedPointerInspection,
+} from "./frame.js";
+
+/** Intent for a coalesced pointer-inspect frame (nearest lookup owned here). */
+export type SchedulePointerInspectInput = {
+  readonly point: Readonly<{ x: number; y: number }>;
+  readonly source: InteractionSource;
+  readonly mode: "auto" | "exact" | "x" | "y" | "xy";
+  readonly maxDistance: number;
+};
+
+/** Cancel policy for pending pointer-inspect work. */
+export type CancelPointerInspectPolicy = {
+  /** Leave/clear: discard stash. Cancel/down/blur tool paths: preserve. */
+  readonly pendingPinned: "preserve" | "discard";
+};
+
+/** Inspect frame action delivered to onPointerFrame (non-move-area branch). */
+export type InspectPointerFrameAction = Extract<InteractionAction, { type: "inspect" }>;
+
+/** Reducer methods the queue touches (host may pass a getter). */
+export type PointerInspectReducer = {
+  frameToken(): InteractionFrameToken;
+  accepts(token: InteractionFrameToken): boolean;
+  queuePointer(action: Extract<InteractionAction, { type: "inspect" | "move-area" }>): void;
+  cancelScheduledPointer(kind?: "inspect" | "move-area"): void;
+};
+
+export type PointerInspectQueueDeps = {
+  model: () => RenderModel | null;
+  reducer: () => PointerInspectReducer;
+  /** Host: `inspection === null ? "none" : inspection.state`. */
+  inspectionState: () => InspectionHostState;
+  setInspection: (
+    hit: SceneHit | null,
+    source: InteractionSource,
+    state?: "transient" | "pinned",
+    concreteMode?: "exact" | "x" | "y" | "xy",
+    candidate?: CandidateFacts,
+  ) => void;
+};
+
+export type PointerInspectQueue = {
+  schedule(input: SchedulePointerInspectInput): void;
+  cancel(policy: CancelPointerInspectPolicy): void;
+  onFrame(action: InspectPointerFrameAction): boolean;
+  /** Read-only peek for pin-toggle gates. */
+  peekPendingPinned(): QueuedPointerInspection | null;
+  /** Read+clear for restore-pending. */
+  takePendingPinned(): QueuedPointerInspection | null;
+  /**
+   * Scene invalidate-* path: clear queue fields only.
+   * Caller owns reducer.dispatch({ type: "invalidate" }) which already cancels
+   * all scheduled pointer work — do not call cancelScheduledPointer here.
+   */
+  clearForSceneInvalidate(): void;
+};
+
+/**
+ * Create the pointer-inspect queue. Does not invoke deps at construction.
+ */
+export function createPointerInspectQueue(deps: PointerInspectQueueDeps): PointerInspectQueue {
+  let queuedPointerToken: InteractionFrameToken | null = null;
+  let queuedPointerInspection: QueuedPointerInspection | null = null;
+  let pendingPinnedPointer: QueuedPointerInspection | null = null;
+
+  function schedule(input: SchedulePointerInspectInput): void {
+    const model = deps.model();
+    // Panel-scoped nearest so faceted hover cannot seed another facet (#787).
+    // panelAtOrOnly keeps single-panel axis-margin hover working.
+    const match =
+      model?.viewport.panelAtOrOnly(input.point)?.nearest(input.point, {
+        mode: input.mode,
+        maxDistance: input.maxDistance,
+      }) ?? null;
+    const frame = buildQueuedInspectFrame({
+      match,
+      source: input.source,
+      epoch: model?.runId ?? 0,
+      fallbackCandidate: () => model?.candidates.hitTest(input.point.x, input.point.y) ?? null,
+    });
+    const reducer = deps.reducer();
+    queuedPointerInspection = frame.queued;
+    queuedPointerToken = reducer.frameToken();
+    try {
+      reducer.queuePointer({
+        type: "inspect",
+        candidate: frame.candidate,
+        source: input.source,
+      });
+    } catch (error) {
+      // No orphan payload if scheduling throws.
+      queuedPointerInspection = null;
+      queuedPointerToken = null;
+      throw error;
+    }
+  }
+
+  function cancel(policy: CancelPointerInspectPolicy): void {
+    queuedPointerInspection = null;
+    if (policy.pendingPinned === "discard") pendingPinnedPointer = null;
+    deps.reducer().cancelScheduledPointer("inspect");
+  }
+
+  /**
+   * Inspect branch of onPointerFrame.
+   *
+   * Snapshot then clear before pure routing — re-entrant setInspection cancel
+   * must observe empty queue fields.
+   *
+   * Boolean return is retained for symmetry with move-area's onPointerFrame
+   * contract. For `type === "inspect"` the reducer never dispatches the frame
+   * payload (inspection is single-authority in InspectionState); callers that
+   * gate on false still get the pure-table "drop" signal for stale tokens.
+   */
+  function onFrame(action: InspectPointerFrameAction): boolean {
+    const pending = queuedPointerInspection;
+    const token = queuedPointerToken;
+    queuedPointerInspection = null;
+    queuedPointerToken = null;
+    // Short-circuit tokenAccepted when no pending so accepts() is not
+    // called for empty frames.
+    const frameAction = resolveQueuedInspectFrameAction({
+      hasPending: pending !== null,
+      tokenAccepted: pending === null || token === null || deps.reducer().accepts(token),
+      currentState: deps.inspectionState(),
+      candidateEpochMismatch:
+        action.candidate !== null && action.candidate.epoch !== deps.model()?.runId,
+    });
+    switch (frameAction.type) {
+      case "none":
+        // Empty frame (payload already cleared; scheduled inspect still flushed).
+        return true;
+      case "drop":
+        // Stale token / epoch mismatch — pure-table drop signal.
+        return false;
+      case "stash-pending":
+        if (pending !== null) pendingPinnedPointer = pending;
+        return true;
+      case "apply-pending":
+        if (pending !== null) {
+          deps.setInspection(
+            pending.hit,
+            pending.source,
+            "transient",
+            pending.concreteMode,
+            pending.candidate,
+          );
+        }
+        return true;
+    }
+    return true;
+  }
+
+  function peekPendingPinned(): QueuedPointerInspection | null {
+    return pendingPinnedPointer;
+  }
+
+  function takePendingPinned(): QueuedPointerInspection | null {
+    const pending = pendingPinnedPointer;
+    pendingPinnedPointer = null;
+    return pending;
+  }
+
+  function clearForSceneInvalidate(): void {
+    queuedPointerInspection = null;
+    pendingPinnedPointer = null;
+    queuedPointerToken = null;
+  }
+
+  return {
+    schedule,
+    cancel,
+    onFrame,
+    peekPendingPinned,
+    takePendingPinned,
+    clearForSceneInvalidate,
+  };
+}

--- a/packages/svelte/src/lib/inspection/pointer-inspect.ts
+++ b/packages/svelte/src/lib/inspection/pointer-inspect.ts
@@ -44,7 +44,7 @@ export type CancelPointerInspectPolicy = {
 export type InspectPointerFrameAction = Extract<InteractionAction, { type: "inspect" }>;
 
 /** Reducer methods the queue touches (host may pass a getter). */
-export type PointerInspectReducer = {
+type PointerInspectReducer = {
   frameToken(): InteractionFrameToken;
   accepts(token: InteractionFrameToken): boolean;
   queuePointer(action: Extract<InteractionAction, { type: "inspect" | "move-area" }>): void;

--- a/packages/svelte/tests/inspection/inspection-state.construction-effects.test.ts
+++ b/packages/svelte/tests/inspection/inspection-state.construction-effects.test.ts
@@ -200,6 +200,69 @@ describe("createInspectionState scene-reconcile effect", () => {
 
     destroy();
   });
+
+  it("scene invalidate drops stashed pending so unpin does not restore a pre-swap stash", () => {
+    const modelA = modelFor(continuousSpec());
+    Object.defineProperty(modelA, "runId", { value: 1, configurable: true });
+    const modelBox = reactiveBox<RenderModel | null>(modelA);
+    const { state, flushFrame, destroy } = mountInspectionController({
+      model: () => modelBox.value,
+      deferredFrames: true,
+    });
+
+    const first = candidateHit(modelA);
+    applyInspect(state, first.candidate);
+    flushSync();
+    state.toggleInspectionPin("pointer");
+    flushSync();
+    expect(state.inspection?.state).toBe("pinned");
+
+    let second: CandidateFacts | null = null;
+    for (let id = 0; id < modelA.candidates.size; id++) {
+      const candidate = modelA.candidates.candidate(id);
+      if (candidate !== null && candidate.id !== first.candidate.id) {
+        second = candidate;
+        break;
+      }
+    }
+    if (second === null) throw new Error("expected a second candidate");
+
+    // While pinned, a flushed inspect stashes rather than applying.
+    state.schedulePointerInspect({
+      point: { x: second.x, y: second.y },
+      source: "pointer",
+      mode: "xy",
+      maxDistance: 1e6,
+    });
+    flushFrame();
+    flushSync();
+    expect(state.inspection?.state).toBe("pinned");
+
+    // Responsive relayout (same data, advanced runId) reconciles the pin and
+    // must clear the queue stash so a later unpin flips the original seed.
+    const relayout = Object.create(
+      Object.getPrototypeOf(modelA) as object,
+      Object.getOwnPropertyDescriptors(modelA),
+    ) as RenderModel;
+    Object.defineProperty(relayout, "runId", { value: 2, configurable: true });
+    modelBox.set(relayout);
+    flushSync();
+    expect(state.inspection?.state).toBe("pinned");
+
+    state.toggleInspectionPin("pointer");
+    flushSync();
+    expect(state.inspection?.state).toBe("transient");
+    expect(state.inspection?.focus.anchor).toEqual({
+      x: first.candidate.x,
+      y: first.candidate.y,
+    });
+    expect(state.inspection?.focus.anchor).not.toEqual({
+      x: second.x,
+      y: second.y,
+    });
+
+    destroy();
+  });
 });
 
 describe("createInspectionState callback replacement", () => {

--- a/packages/svelte/tests/inspection/inspection-state.pin-queue.test.ts
+++ b/packages/svelte/tests/inspection/inspection-state.pin-queue.test.ts
@@ -375,6 +375,52 @@ describe("createInspectionState schedulePointerInspect / onInspectPointerFrame",
 
     destroy();
   });
+
+  it("clear-disabled discards inspect queue with inspect-only cancel (move-area survives)", () => {
+    let frame: (() => void) | null = null;
+    const frames: string[] = [];
+    let controller: ReturnType<typeof createInspectionState> | null = null;
+    const model = modelFor(continuousSpec());
+    const enabledBox = reactiveBox(true);
+    const reducer = createInteractionReducer({
+      scheduleFrame: (callback) => {
+        frame = callback;
+        return 1;
+      },
+      cancelFrame: () => {
+        frame = null;
+      },
+      onPointerFrame: (action) => {
+        frames.push(action.type);
+        if (action.type === "inspect") return controller!.onInspectPointerFrame(action);
+        return true;
+      },
+    });
+    const { state, destroy } = mountInspectionController({
+      model: () => model,
+      reducer: () => reducer,
+      inspectEnabled: () => enabledBox.value,
+    });
+    controller = state;
+
+    const { candidate, hit } = candidateHit(model);
+    state.setInspection(hit, "pointer", "transient", "xy", candidate);
+    flushSync();
+    expect(state.inspection?.state).toBe("transient");
+
+    // Queue move-area, then disable inspect (clear-disabled path).
+    reducer.queuePointer({ type: "move-area", point: { x: 3, y: 4 } });
+    expect(frame).not.toBeNull();
+    enabledBox.set(false);
+    flushSync();
+    expect(state.inspection).toBeNull();
+    // Inspect-only cancel must not kill the move-area schedule.
+    expect(frame).not.toBeNull();
+    frame?.();
+    expect(frames).toEqual(["move-area"]);
+
+    destroy();
+  });
 });
 describe("createInspectionState setInspection(null) clear ordering", () => {
   it("emits clear while inspection is still non-null, then clears state", () => {


### PR DESCRIPTION
## Summary

- Extract coalesced pointer-inspect **schedule / cancel / onFrame** ownership from `createInspectionState` into `packages/svelte/src/lib/inspection/pointer-inspect.ts`.
- Host keeps `$state` inspection snapshot, set/toggle/dismiss, traversal, and scene-reconcile `$effect` orchestration — without queue fields mixed in.
- Closed pending-pin API: `peekPendingPinned` / `takePendingPinned` (no setter). Two clear paths kept separate:
  - **clear-disabled** → inspect-only cancel (`cancelScheduledPointer("inspect")`) so move-area survives
  - **scene invalidate-*** → field clear only after reducer `invalidate` (which already cancels all scheduled pointer work)
- Delete dead host alias + redundant pending clear after discard cancel.
- Characterization tests for scene invalidate dropping stash and clear-disabled move-area survival.

### Why

`inspection-state.svelte.ts` mixed pointer-frame coalescing with apply/dismiss/traversal/scene effects. Pure frame tables already live in `frame.ts`; the remaining queue mutation + nearest lookup is a distinct non-rune lifecycle and is safer to own as a leaf module.

### Public surface (unchanged)

- `createInspectionState`, `InspectionState`, `InspectionStateDeps`
- Method names and behaviors for schedule / cancel / onFrame

## Verification

```bash
bun node_modules/.bin/tsc -b packages/spec packages/core   # local dist refresh if needed
cd packages/svelte
bun run test:browser --   tests/inspection/inspection-state.pin-queue.test.ts   tests/inspection/inspection-state.dismiss-traversal.test.ts   tests/inspection/inspection-state.construction-effects.test.ts   tests/inspection/inspection-frame.test.ts
bun run check
```

Results: **84** inspection characterization tests green (chromium/webkit/firefox); **svelte-check** 0 errors / 0 warnings.

## Follow-ups

- https://github.com/ljodea/ggsvelte/issues/854 — split inspection coordinator cache/token/reconcile surface
- https://github.com/ljodea/ggsvelte/issues/855 — thin scene-reconcile apply body out of InspectionState `$effect`
- https://github.com/ljodea/ggsvelte/issues/856 — Escape dismiss preserves pending pin stash across re-pin

## Test plan

- [x] pin-queue suite (schedule, stash, cancel, touch-tap, clear-disabled move-area)
- [x] construction-effects (armed getters + scene reconcile + stash drop on invalidate)
- [x] dismiss-traversal
- [x] frame pure tables
- [x] svelte-check
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/857" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->