### PR TITLE
fix(svelte): discard pending pin stash on Escape and clear (#856)

### DIFF
--- a/.changeset/856-escape-discard-pending-pin-stash.md
+++ b/.changeset/856-escape-discard-pending-pin-stash.md
@@ -1,0 +1,7 @@
+---
+"@ggsvelte/svelte": patch
+---
+
+# Escape discard of pending pin stash
+
+Escape (and setInspection clear) now discard the pending pin-restore stash so a later re-pin cannot restore a pre-dismiss candidate (#856).

--- a/packages/svelte/src/lib/inspection/inspection-state.svelte.ts
+++ b/packages/svelte/src/lib/inspection/inspection-state.svelte.ts
@@ -306,6 +306,9 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
       case "ignore":
         return;
       case "clear": {
+        // Clear ends the session — discard any orphan pending pin stash so a
+        // later re-pin cannot restore-pending a pre-clear candidate (#856).
+        pointerQueue.cancel({ pendingPinned: "discard" });
         if (action.emitClear) emitInspection({ type: "inspect", phase: "clear", source });
         inspection = null;
         inspectionSeed = null;

--- a/packages/svelte/src/lib/inspection/teardown.ts
+++ b/packages/svelte/src/lib/inspection/teardown.ts
@@ -151,9 +151,9 @@ export type InspectionDismissKind = "escape" | "close";
  * Used by a single host `dismissInspection` that Escape and closeInspection share.
  *
  * Escape (keyboard): invalidate coordinator, clear brush, optional returnToInspect;
- * does **not** clear pendingPinnedPointer (preserved host behavior — may be
- * intentional for pin-restore after tool reset).
- * Close: release pinned, clear pending, optional restore focus to capture surface.
+ * discards pending pin stash so a later re-pin cannot restore a pre-Escape
+ * candidate (#856). Close: release pinned, clear pending, optional restore
+ * focus to capture surface.
  */
 export type InspectionDismissPlan = {
   readonly emitClear: boolean;
@@ -181,7 +181,7 @@ export function planInspectionDismiss(input: {
   if (input.kind === "escape") {
     return {
       emitClear: input.hasInspection,
-      clearPendingPinned: false,
+      clearPendingPinned: true,
       coordinator: "invalidate",
       clearBrush: true,
       clearTooltipHovered: true,

--- a/packages/svelte/tests/inspection/inspection-state.dismiss-traversal.test.ts
+++ b/packages/svelte/tests/inspection/inspection-state.dismiss-traversal.test.ts
@@ -4,18 +4,90 @@
 import { flushSync } from "svelte";
 import { describe, expect, it, vi } from "vitest";
 
-import type { CellValue } from "@ggsvelte/core";
+import type { CandidateFacts, CellValue } from "@ggsvelte/core";
 
 import type { PlotInspection } from "../../src/lib/interaction/interaction.js";
 import { applyInspectionDismissSideEffects } from "../../src/lib/interaction/transition-owner.js";
 import {
   candidateHit,
   continuousSpec,
+  hitFromCandidate,
   modelFor,
   mountInspectionController,
 } from "./inspection-state.harness.js";
 
 describe("createInspectionState dismissInspection", () => {
+  it("escape discards pending pin stash so re-pin cannot restore a pre-Escape candidate (#856)", () => {
+    const model = modelFor(continuousSpec());
+    const { state, flushFrame, destroy } = mountInspectionController({
+      model: () => model,
+      deferredFrames: true,
+    });
+
+    const first = candidateHit(model);
+    state.setInspection(first.hit, "pointer", "transient", "xy", first.candidate);
+    flushSync();
+    state.toggleInspectionPin("pointer");
+    flushSync();
+    expect(state.inspection?.state).toBe("pinned");
+
+    let second: CandidateFacts | null = null;
+    for (let id = 0; id < model.candidates.size; id++) {
+      const candidate = model.candidates.candidate(id);
+      if (candidate !== null && candidate.id !== first.candidate.id) {
+        second = candidate;
+        break;
+      }
+    }
+    if (second === null) throw new Error("expected a second candidate");
+
+    // While pinned, a flushed inspect stashes rather than applying.
+    state.schedulePointerInspect({
+      point: { x: second.x, y: second.y },
+      source: "pointer",
+      mode: "xy",
+      maxDistance: 1e6,
+    });
+    flushFrame();
+    flushSync();
+    expect(state.inspection?.state).toBe("pinned");
+
+    // Escape ends the session — stash must not survive.
+    state.dismissInspection("escape", "keyboard");
+    flushSync();
+    expect(state.inspection).toBeNull();
+
+    // New transient + pin (third candidate), then unpin: must flip the current
+    // seed, not restore-pending the pre-Escape stash (second).
+    let third: CandidateFacts | null = null;
+    for (let id = 0; id < model.candidates.size; id++) {
+      const candidate = model.candidates.candidate(id);
+      if (candidate !== null && candidate.id !== first.candidate.id && candidate.id !== second.id) {
+        third = candidate;
+        break;
+      }
+    }
+    if (third === null) throw new Error("expected a third candidate");
+
+    state.setInspection(hitFromCandidate(third), "pointer", "transient", "xy", third);
+    flushSync();
+    state.toggleInspectionPin("pointer");
+    flushSync();
+    expect(state.inspection?.state).toBe("pinned");
+    expect(state.inspection?.focus.anchor).toEqual({ x: third.x, y: third.y });
+
+    state.toggleInspectionPin("pointer");
+    flushSync();
+    expect(state.inspection?.state).toBe("transient");
+    expect(state.inspection?.focus.anchor).toEqual({ x: third.x, y: third.y });
+    expect(state.inspection?.focus.anchor).not.toEqual({
+      x: second.x,
+      y: second.y,
+    });
+
+    destroy();
+  });
+
   it("escape vs close: clears tooltip/pending, brush, chooseTool, refocus, emit-clear", async () => {
     const model = modelFor(continuousSpec());
     let tooltipHovered = true;

--- a/packages/svelte/tests/inspection/inspection-teardown.test.ts
+++ b/packages/svelte/tests/inspection/inspection-teardown.test.ts
@@ -283,7 +283,9 @@ describe("resolveInspectionEmitAction", () => {
 });
 
 describe("planInspectionDismiss", () => {
-  it("plans escape with invalidate, brush clear, and optional returnToInspect", () => {
+  it("plans escape with invalidate, brush clear, pending discard, and optional returnToInspect", () => {
+    // #856: Escape ends the pin session — discard pending pin stash so a
+    // later re-pin cannot restore a pre-Escape candidate.
     expect(
       planInspectionDismiss({
         kind: "escape",
@@ -292,7 +294,7 @@ describe("planInspectionDismiss", () => {
       }),
     ).toEqual({
       emitClear: true,
-      clearPendingPinned: false,
+      clearPendingPinned: true,
       coordinator: "invalidate",
       clearBrush: true,
       clearTooltipHovered: true,
@@ -307,7 +309,7 @@ describe("planInspectionDismiss", () => {
       }),
     ).toEqual({
       emitClear: false,
-      clearPendingPinned: false,
+      clearPendingPinned: true,
       coordinator: "invalidate",
       clearBrush: true,
       clearTooltipHovered: true,


### PR DESCRIPTION
## Summary

- Escape dismiss now sets `clearPendingPinned: true` so the cancel path discards any pending pin-restore stash (#856).
- `setInspection(null)` clear also discards the stash (matches leave/clear cancel policy).
- Characterization test locks the sequence: pin → stash while pinned → Escape → new pin → unpin flips the current seed (does not restore the pre-Escape stash).

### Why

After the pointer-queue extract (#857), Escape still preserved the stash. That let a later re-pin restore a stale pre-Escape candidate instead of unpinning the current seed.

### Policy (documented on `planInspectionDismiss`)

| Dismiss | Pending pin stash |
|---------|-------------------|
| Escape  | **discard** |
| Close   | **discard** |
| setInspection clear | **discard** |
| Mid-gesture cancel / pointer-down | preserve (unchanged) |

## Test plan

- [x] RED: pure `planInspectionDismiss` escape expects `clearPendingPinned: true`
- [x] RED: public sequence fails by restoring pre-Escape stash on unpin
- [x] GREEN: chromium suite for teardown, dismiss-traversal, pin-queue, construction-effects, transition-owner
- [ ] CI green

Closes #856
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/885" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->