### PR TITLE
feat(#818): convenience geoms jitter, hline, vline

### DIFF
--- a/.changeset/818-convenience-geoms.md
+++ b/.changeset/818-convenience-geoms.md
@@ -1,0 +1,15 @@
+---
+"@ggsvelte/spec": minor
+"@ggsvelte/svelte": minor
+---
+
+<!-- markdownlint-disable MD041 -->
+
+feat: convenience geoms jitter, hline, vline (#818)
+
+Add ggplot2-style geom aliases that normalize to existing marks:
+
+- `jitter` → `point` + `position: "jitter"` (`geomJitter` / `<GeomJitter>`; flat width/height/seed assemble into `positionParams` at the builder/component boundary)
+- `hline` / `vline` → `rule` (`geomHline` / `geomVline` / components); annotation intercepts suppress plot-aes inheritance; data-driven forms drop the orthogonal axis
+
+No new mark types. Migration: none — additive.

--- a/packages/spec/schema/v0.json
+++ b/packages/spec/schema/v0.json
@@ -1151,6 +1151,66 @@
       "additionalProperties": false,
       "description": "Styling parameters for the rule geom. The annotation form sets xintercept and/or yintercept here; the data-driven form maps aes.x OR aes.y instead (never both forms at once)."
     },
+    "HlineParams": {
+      "type": "object",
+      "properties": {
+        "yintercept": {
+          "$ref": "#/$defs/RuleIntercept",
+          "description": "ANNOTATION FORM ONLY: draw a horizontal rule at each of these fixed y positions. Mutually exclusive with mapping aes.y on this layer."
+        },
+        "alpha": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Rule opacity. Must be between 0 and 1 (inclusive). Default 1."
+        },
+        "linewidth": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "description": "Stroke width in px. Must be greater than 0. Default 1."
+        },
+        "strokePaint": {
+          "$ref": "#/$defs/GradientPaint",
+          "description": "Within-mark gradient stroke paint (not a data scale). Requires a solid fallback."
+        },
+        "glow": {
+          "$ref": "#/$defs/GlowSpec",
+          "description": "Bounded within-mark glow treatment (not theme decoration)."
+        }
+      },
+      "additionalProperties": false,
+      "description": "Parameters for the hline alias (ggplot2 geom_hline). Annotation form sets yintercept; data-driven form maps aes.y. Canonicalized by normalize() to a rule layer."
+    },
+    "VlineParams": {
+      "type": "object",
+      "properties": {
+        "xintercept": {
+          "$ref": "#/$defs/RuleIntercept",
+          "description": "ANNOTATION FORM ONLY: draw a vertical rule at each of these fixed x positions. Mutually exclusive with mapping aes.x on this layer."
+        },
+        "alpha": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Rule opacity. Must be between 0 and 1 (inclusive). Default 1."
+        },
+        "linewidth": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "description": "Stroke width in px. Must be greater than 0. Default 1."
+        },
+        "strokePaint": {
+          "$ref": "#/$defs/GradientPaint",
+          "description": "Within-mark gradient stroke paint (not a data scale). Requires a solid fallback."
+        },
+        "glow": {
+          "$ref": "#/$defs/GlowSpec",
+          "description": "Bounded within-mark glow treatment (not theme decoration)."
+        }
+      },
+      "additionalProperties": false,
+      "description": "Parameters for the vline alias (ggplot2 geom_vline). Annotation form sets xintercept; data-driven form maps aes.x. Canonicalized by normalize() to a rule layer."
+    },
     "SegmentParams": {
       "type": "object",
       "properties": {
@@ -1876,6 +1936,108 @@
       "additionalProperties": false,
       "description": "A reference-line layer (ggplot2's geom_vline/geom_hline, unified). Annotation form: fixed intercepts in params. Data-driven form: map aes.x OR aes.y."
     },
+    "HlineLayer": {
+      "type": "object",
+      "required": [
+        "geom"
+      ],
+      "properties": {
+        "geom": {
+          "type": "string",
+          "const": "hline",
+          "description": "Horizontal reference-line alias (ggplot2's geom_hline). Canonicalized by normalize() to a rule layer. Annotation form: set params.yintercept. Data-driven form: map aes.y (inherited plot x is dropped so the one-axis rule contract holds)."
+        },
+        "stat": {
+          "type": "string",
+          "const": "identity",
+          "description": "Hline layers draw the given positions as-is."
+        },
+        "render": {
+          "$ref": "#/$defs/RenderBackend"
+        },
+        "aes": {
+          "$ref": "#/$defs/Aes"
+        },
+        "data": {
+          "$ref": "#/$defs/DataRef",
+          "description": "Optional layer-local data. When omitted, the layer inherits plot-level data. When present, it may use inline rows, inline columns, or a named dataset (spec.datasets or runtime)."
+        },
+        "params": {
+          "$ref": "#/$defs/HlineParams"
+        }
+      },
+      "additionalProperties": false,
+      "description": "A horizontal reference-line layer alias (normalize() → rule). Annotation: params.yintercept. Data-driven: map aes.y."
+    },
+    "VlineLayer": {
+      "type": "object",
+      "required": [
+        "geom"
+      ],
+      "properties": {
+        "geom": {
+          "type": "string",
+          "const": "vline",
+          "description": "Vertical reference-line alias (ggplot2's geom_vline). Canonicalized by normalize() to a rule layer. Annotation form: set params.xintercept. Data-driven form: map aes.x (inherited plot y is dropped so the one-axis rule contract holds)."
+        },
+        "stat": {
+          "type": "string",
+          "const": "identity",
+          "description": "Vline layers draw the given positions as-is."
+        },
+        "render": {
+          "$ref": "#/$defs/RenderBackend"
+        },
+        "aes": {
+          "$ref": "#/$defs/Aes"
+        },
+        "data": {
+          "$ref": "#/$defs/DataRef",
+          "description": "Optional layer-local data. When omitted, the layer inherits plot-level data. When present, it may use inline rows, inline columns, or a named dataset (spec.datasets or runtime)."
+        },
+        "params": {
+          "$ref": "#/$defs/VlineParams"
+        }
+      },
+      "additionalProperties": false,
+      "description": "A vertical reference-line layer alias (normalize() → rule). Annotation: params.xintercept. Data-driven: map aes.x."
+    },
+    "JitterLayer": {
+      "type": "object",
+      "required": [
+        "geom"
+      ],
+      "properties": {
+        "geom": {
+          "type": "string",
+          "const": "jitter",
+          "description": "Jittered point alias (ggplot2's geom_jitter). Canonicalized by normalize() to a point layer with position jitter. Configure jitter amount via positionParams.width/height/seed."
+        },
+        "stat": {
+          "type": "string",
+          "const": "identity",
+          "description": "Jitter layers draw the data as-is."
+        },
+        "positionParams": {
+          "$ref": "#/$defs/PositionParams"
+        },
+        "render": {
+          "$ref": "#/$defs/RenderBackend"
+        },
+        "aes": {
+          "$ref": "#/$defs/Aes"
+        },
+        "data": {
+          "$ref": "#/$defs/DataRef",
+          "description": "Optional layer-local data. When omitted, the layer inherits plot-level data. When present, it may use inline rows, inline columns, or a named dataset (spec.datasets or runtime)."
+        },
+        "params": {
+          "$ref": "#/$defs/PointParams"
+        }
+      },
+      "additionalProperties": false,
+      "description": "A scatter layer with position \"jitter\" (alias; normalize() → point). Requires x and y channels. Jitter width/height/seed live on positionParams."
+    },
     "TextLayer": {
       "type": "object",
       "required": [
@@ -1988,6 +2150,15 @@
         },
         {
           "$ref": "#/$defs/RuleLayer"
+        },
+        {
+          "$ref": "#/$defs/HlineLayer"
+        },
+        {
+          "$ref": "#/$defs/VlineLayer"
+        },
+        {
+          "$ref": "#/$defs/JitterLayer"
         },
         {
           "$ref": "#/$defs/TextLayer"

--- a/packages/spec/src/builder-core.ts
+++ b/packages/spec/src/builder-core.ts
@@ -27,6 +27,8 @@ import type {
   GeomErrorbarOptions,
   GeomRibbonOptions,
   GeomHistogramOptions,
+  GeomHlineOptions,
+  GeomJitterOptions,
   GeomLineOptions,
   GeomPointOptions,
   GeomRasterOptions,
@@ -36,6 +38,7 @@ import type {
   GeomSmoothOptions,
   GeomTextOptions,
   GeomTileOptions,
+  GeomVlineOptions,
 } from "./builder-options.js";
 import type {
   A11yMode,
@@ -164,6 +167,44 @@ export class GGBuilderCore {
    */
   geomRule(options: GeomRuleOptions = {}): GGBuilder {
     return this.layer(layerFrom("rule", options));
+  }
+
+  /**
+   * Sugar for .layer({ geom: 'hline', ... }) — horizontal reference lines
+   * (ggplot2 geom_hline; normalize() → rule). Annotation: yintercept.
+   */
+  geomHline(options: GeomHlineOptions = {}): GGBuilder {
+    return this.layer(layerFrom("hline", options));
+  }
+
+  /**
+   * Sugar for .layer({ geom: 'vline', ... }) — vertical reference lines
+   * (ggplot2 geom_vline; normalize() → rule). Annotation: xintercept.
+   */
+  geomVline(options: GeomVlineOptions = {}): GGBuilder {
+    return this.layer(layerFrom("vline", options));
+  }
+
+  /**
+   * Sugar for .layer({ geom: 'jitter', ... }) — points with position jitter
+   * (ggplot2 geom_jitter; normalize() → point + position jitter). Flat
+   * width/height/seed are assembled into positionParams here (not by normalize).
+   */
+  geomJitter(options: GeomJitterOptions = {}): GGBuilder {
+    const { width, height, seed, positionParams, ...rest } = options;
+    const mergedPositionParams = {
+      ...positionParams,
+      ...(width !== undefined && { width }),
+      ...(height !== undefined && { height }),
+      ...(seed !== undefined && { seed }),
+    };
+    const hasPositionParams = Object.keys(mergedPositionParams).length > 0;
+    return this.layer(
+      layerFrom("jitter", {
+        ...rest,
+        ...(hasPositionParams && { positionParams: mergedPositionParams }),
+      }),
+    );
   }
 
   /** Sugar for .layer({ geom: 'text', ... }). */

--- a/packages/spec/src/builder-options.ts
+++ b/packages/spec/src/builder-options.ts
@@ -20,6 +20,8 @@ import type {
   RectParams,
   RenderBackend,
   RuleParams,
+  HlineParams,
+  VlineParams,
   SegmentParams,
   SmoothParams,
   StackablePosition,
@@ -129,6 +131,34 @@ export interface GeomAreaOptions extends AreaParams, GeomDataOption {
 export interface GeomRuleOptions extends RuleParams, GeomDataOption {
   aes?: AesInput;
   render?: RenderBackend;
+}
+
+/** Hline alias sugar: yintercept annotation (or map aes.y). */
+export interface GeomHlineOptions extends HlineParams, GeomDataOption {
+  aes?: AesInput;
+  render?: RenderBackend;
+}
+
+/** Vline alias sugar: xintercept annotation (or map aes.x). */
+export interface GeomVlineOptions extends VlineParams, GeomDataOption {
+  aes?: AesInput;
+  render?: RenderBackend;
+}
+
+/**
+ * Jitter alias sugar: point params + flat width/height/seed (assembled into
+ * positionParams by geomJitter — not a normalize peel).
+ */
+export interface GeomJitterOptions extends PointParams, GeomDataOption {
+  aes?: AesInput;
+  render?: RenderBackend;
+  /** Maximum horizontal jitter (data units / band-step fraction). */
+  width?: number;
+  /** Maximum vertical jitter (data units / band-step fraction). */
+  height?: number;
+  /** Seeded RNG seed (ggsvelte jitter is always seeded; default 42). */
+  seed?: number;
+  positionParams?: PositionParams;
 }
 
 /** Segment-layer sugar options: params plus optional layer-level aes. */

--- a/packages/spec/src/builder.ts
+++ b/packages/spec/src/builder.ts
@@ -39,6 +39,8 @@ export type {
   GeomDensityOptions,
   GeomErrorbarOptions,
   GeomHistogramOptions,
+  GeomHlineOptions,
+  GeomJitterOptions,
   GeomLineOptions,
   GeomPointOptions,
   GeomRasterOptions,
@@ -48,6 +50,7 @@ export type {
   GeomSmoothOptions,
   GeomTextOptions,
   GeomTileOptions,
+  GeomVlineOptions,
 } from "./builder-options.js";
 
 /**

--- a/packages/spec/src/capabilities.ts
+++ b/packages/spec/src/capabilities.ts
@@ -225,16 +225,31 @@ export type ScaleCapability = (typeof SCALE_CAPABILITIES)[number];
 
 /** One checked geom-consumption table for mapped style channels. */
 export const STYLE_AESTHETIC_GEOMS = {
-  size: ["point", "text"],
-  linewidth: ["line", "rule", "smooth", "boxplot", "errorbar", "rect", "tile", "ribbon", "segment"],
+  size: ["point", "jitter", "text"],
+  linewidth: [
+    "line",
+    "rule",
+    "hline",
+    "vline",
+    "smooth",
+    "boxplot",
+    "errorbar",
+    "rect",
+    "tile",
+    "ribbon",
+    "segment",
+  ],
   alpha: [
     "point",
+    "jitter",
     "line",
     "col",
     "bar",
     "histogram",
     "area",
     "rule",
+    "hline",
+    "vline",
     "text",
     "smooth",
     "boxplot",
@@ -246,8 +261,20 @@ export const STYLE_AESTHETIC_GEOMS = {
     "ribbon",
     "segment",
   ],
-  shape: ["point"],
-  linetype: ["line", "rule", "smooth", "boxplot", "errorbar", "rect", "tile", "ribbon", "segment"],
+  shape: ["point", "jitter"],
+  linetype: [
+    "line",
+    "rule",
+    "hline",
+    "vline",
+    "smooth",
+    "boxplot",
+    "errorbar",
+    "rect",
+    "tile",
+    "ribbon",
+    "segment",
+  ],
 } as const;
 
 export type StyleAesthetic = keyof typeof STYLE_AESTHETIC_GEOMS;

--- a/packages/spec/src/index.ts
+++ b/packages/spec/src/index.ts
@@ -39,6 +39,8 @@ export {
   FacetSpecSchema,
   GEOM_DEFAULTS,
   HistogramLayerSchema,
+  HlineLayerSchema,
+  JitterLayerSchema,
   KNOWN_GEOMS,
   KNOWN_POSITIONS,
   KNOWN_STATS,
@@ -52,6 +54,7 @@ export {
   PlotSpecSchema,
   PointLayerSchema,
   RuleLayerSchema,
+  VlineLayerSchema,
   ScalesSchema,
   SEQUENTIAL_SCHEME_NAMES,
   TemporalParserSpecSchemaRef,
@@ -116,7 +119,10 @@ export type {
   ColorstepsGuideSpec,
   NoneGuideSpec,
   HistogramLayer,
+  HlineLayer,
+  HlineParams,
   InlineData,
+  JitterLayer,
   Labs,
   LayerSpec,
   LegendSpec,
@@ -139,6 +145,8 @@ export type {
   RuleParams,
   SegmentLayer,
   SegmentParams,
+  VlineLayer,
+  VlineParams,
   ScaleExpansion,
   Scales,
   SmoothLayer,
@@ -467,6 +475,8 @@ export type {
   RuntimeErrorbarLayer,
   RuntimeRibbonLayer,
   RuntimeHistogramLayer,
+  RuntimeHlineLayer,
+  RuntimeJitterLayer,
   RuntimeLayerSpec,
   RuntimeLineLayer,
   RuntimePointLayer,
@@ -478,6 +488,7 @@ export type {
   RuntimeSpec,
   RuntimeTextLayer,
   RuntimeTileLayer,
+  RuntimeVlineLayer,
 } from "./runtime.js";
 
 // Canonicalizer
@@ -498,6 +509,8 @@ export type {
   FacetFieldInput,
   FacetInput,
   HistogramLayerInput,
+  HlineLayerInput,
+  JitterLayerInput,
   LayerInput,
   LineLayerInput,
   PointLayerInput,
@@ -508,6 +521,7 @@ export type {
   TileLayerInput,
   SpecInput,
   TextLayerInput,
+  VlineLayerInput,
 } from "./normalize.js";
 
 // Validation + agent error contract
@@ -551,6 +565,8 @@ export type {
   GeomDensityOptions,
   GeomErrorbarOptions,
   GeomHistogramOptions,
+  GeomHlineOptions,
+  GeomJitterOptions,
   GeomLineOptions,
   GeomPointOptions,
   GeomRasterOptions,
@@ -560,6 +576,7 @@ export type {
   GeomSmoothOptions,
   GeomTextOptions,
   GeomTileOptions,
+  GeomVlineOptions,
 } from "./builder.js";
 
 // Within-mark paint helpers (#591)

--- a/packages/spec/src/normalize-input.ts
+++ b/packages/spec/src/normalize-input.ts
@@ -28,6 +28,8 @@ import type {
   RectParams,
   RenderBackend,
   RuleParams,
+  HlineParams,
+  VlineParams,
   SegmentParams,
   Scales,
   SmoothParams,
@@ -151,6 +153,25 @@ export interface RuleLayerInput extends LayerInputBase {
   params?: RuleParams;
 }
 
+export interface HlineLayerInput extends LayerInputBase {
+  geom: "hline";
+  stat?: "identity";
+  params?: HlineParams;
+}
+
+export interface VlineLayerInput extends LayerInputBase {
+  geom: "vline";
+  stat?: "identity";
+  params?: VlineParams;
+}
+
+export interface JitterLayerInput extends LayerInputBase {
+  geom: "jitter";
+  stat?: "identity";
+  positionParams?: PositionParams;
+  params?: PointParams;
+}
+
 export interface TextLayerInput extends LayerInputBase {
   geom: "text";
   stat?: "identity";
@@ -232,6 +253,9 @@ export type LayerInput =
   | AreaLayerInput
   | RibbonLayerInput
   | RuleLayerInput
+  | HlineLayerInput
+  | VlineLayerInput
+  | JitterLayerInput
   | TextLayerInput
   | SmoothLayerInput
   | BoxplotLayerInput

--- a/packages/spec/src/normalize.ts
+++ b/packages/spec/src/normalize.ts
@@ -66,6 +66,8 @@ export type {
   FacetFieldInput,
   FacetInput,
   HistogramLayerInput,
+  HlineLayerInput,
+  JitterLayerInput,
   RibbonLayerInput,
   SegmentLayerInput,
   LayerInput,
@@ -78,6 +80,7 @@ export type {
   SpecInput,
   TextLayerInput,
   TileLayerInput,
+  VlineLayerInput,
 } from "./normalize-input.js";
 
 /** Canonicalize one channel: bare string -> { field }; clone canonical forms. */
@@ -122,18 +125,43 @@ function resolveLayerAes(plotAes: Aes | undefined, layerAes: Aes | undefined): A
   return Object.keys(out).length === 0 ? undefined : out;
 }
 
-/** Annotation-form rule layers (fixed intercepts) inherit NO plot aes —
- *  ggplot2's `inherit.aes = FALSE` on geom_vline/hline (Hadley lesson 15:
- *  honest, separate signatures for the two rule forms). */
+/** Annotation-form rule / hline / vline layers (fixed intercepts) inherit NO
+ *  plot aes — ggplot2's `inherit.aes = FALSE` on geom_vline/hline (Hadley
+ *  lesson 15: honest, separate signatures for the two rule forms).
+ *  Asymmetric: hline is annotation only when yintercept is set; vline only
+ *  when xintercept is set; rule when either intercept is set. */
 function isAnnotationRule(layer: LayerInput): boolean {
+  const params = layer.params as { xintercept?: unknown; yintercept?: unknown } | undefined;
+  if (layer.geom === "hline") return params?.yintercept !== undefined;
+  if (layer.geom === "vline") return params?.xintercept !== undefined;
   if (layer.geom !== "rule") return false;
-  const params = layer.params;
   return params?.xintercept !== undefined || params?.yintercept !== undefined;
 }
 
+/**
+ * Convenience geom aliases (#818 / histogram): rewrite to the canonical geom
+ * name. Pure renames only — no cross-field params surgery (positionParams stay
+ * positionParams; intercept params stay params).
+ */
+function canonicalGeom(geom: LayerInput["geom"]): LayerSpec["geom"] {
+  if (geom === "histogram") return "bar";
+  if (geom === "jitter") return "point";
+  if (geom === "hline" || geom === "vline") return "rule";
+  return geom;
+}
+
 function normalizeLayer(layer: LayerInput, plotAes: Aes | undefined): LayerSpec {
+  // Data-driven hline/vline are one-axis rules: drop the orthogonal position
+  // channel from inheritance so plot-level x+y does not trigger rule-both-axes.
+  let layerAesInput = layer.aes;
+  if (layer.geom === "hline" && !isAnnotationRule(layer)) {
+    layerAesInput = { ...layerAesInput, x: null };
+  } else if (layer.geom === "vline" && !isAnnotationRule(layer)) {
+    layerAesInput = { ...layerAesInput, y: null };
+  }
+
   const inherited = isAnnotationRule(layer) ? undefined : plotAes;
-  let aes = resolveLayerAes(inherited, normalizeAes(layer.aes));
+  let aes = resolveLayerAes(inherited, normalizeAes(layerAesInput));
   // Unknown geoms fall back to identity defaults so normalize never throws —
   // validate() rejects them right after with the proper did-you-mean error.
   const defaults = GEOM_DEFAULTS[layer.geom] ?? { stat: "identity", position: "identity" };
@@ -147,9 +175,7 @@ function normalizeLayer(layer: LayerInput, plotAes: Aes | undefined): LayerSpec 
   if (stat === "density" && aes?.y === undefined) {
     aes = { ...aes, y: { stat: "density" } };
   }
-  // The histogram geom is an ALIAS (one canonical form per concept): its
-  // post-normalize representation is a bar layer with the bin stat.
-  const geom = layer.geom === "histogram" ? "bar" : layer.geom;
+  const geom = canonicalGeom(layer.geom);
   const positionParams =
     "positionParams" in layer && layer.positionParams !== undefined
       ? { ...layer.positionParams }
@@ -159,10 +185,17 @@ function normalizeLayer(layer: LayerInput, plotAes: Aes | undefined): LayerSpec 
   // "auto" is the render default — one canonical form per concept, so it
   // canonicalizes away (same rule as coord "cartesian" / a11y "auto").
   const render = layer.render === "auto" ? undefined : layer.render;
+  // Jitter alias has no position field on the input type; always use defaults.
+  const position =
+    layer.geom === "jitter"
+      ? defaults.position
+      : "position" in layer && layer.position !== undefined
+        ? layer.position
+        : defaults.position;
   const out = {
     geom,
     stat,
-    position: layer.position ?? defaults.position,
+    position,
     ...(positionParams !== undefined && { positionParams }),
     ...(render !== undefined && { render }),
     ...(aes !== undefined && { aes }),

--- a/packages/spec/src/runtime.ts
+++ b/packages/spec/src/runtime.ts
@@ -24,6 +24,8 @@ import type {
   DensityLayer,
   ErrorbarLayer,
   HistogramLayer,
+  HlineLayer,
+  JitterLayer,
   LayerSpec,
   LineLayer,
   PointLayer,
@@ -36,6 +38,7 @@ import type {
   SmoothLayer,
   TextLayer,
   TileLayer,
+  VlineLayer,
 } from "./schema.js";
 
 /** A function channel accessor: computes the channel value per row. */
@@ -65,6 +68,9 @@ export interface RuntimeAreaLayer extends WithRuntimeAes<AreaLayer> {}
 export interface RuntimeRibbonLayer extends WithRuntimeAes<RibbonLayer> {}
 export interface RuntimeSegmentLayer extends WithRuntimeAes<SegmentLayer> {}
 export interface RuntimeRuleLayer extends WithRuntimeAes<RuleLayer> {}
+export interface RuntimeHlineLayer extends WithRuntimeAes<HlineLayer> {}
+export interface RuntimeVlineLayer extends WithRuntimeAes<VlineLayer> {}
+export interface RuntimeJitterLayer extends WithRuntimeAes<JitterLayer> {}
 export interface RuntimeTextLayer extends WithRuntimeAes<TextLayer> {}
 export interface RuntimeSmoothLayer extends WithRuntimeAes<SmoothLayer> {}
 export interface RuntimeBoxplotLayer extends WithRuntimeAes<BoxplotLayer> {}
@@ -84,6 +90,9 @@ export type RuntimeLayerSpec =
   | RuntimeRibbonLayer
   | RuntimeSegmentLayer
   | RuntimeRuleLayer
+  | RuntimeHlineLayer
+  | RuntimeVlineLayer
+  | RuntimeJitterLayer
   | RuntimeTextLayer
   | RuntimeSmoothLayer
   | RuntimeBoxplotLayer

--- a/packages/spec/src/schema-catalog.ts
+++ b/packages/spec/src/schema-catalog.ts
@@ -11,6 +11,8 @@ export const KNOWN_GEOMS = [
   "histogram",
   "area",
   "rule",
+  "hline",
+  "vline",
   "text",
   "smooth",
   "boxplot",
@@ -21,6 +23,7 @@ export const KNOWN_GEOMS = [
   "raster",
   "ribbon",
   "segment",
+  "jitter",
 ] as const;
 export type GeomName = (typeof KNOWN_GEOMS)[number];
 
@@ -80,7 +83,8 @@ export type PositionName = (typeof KNOWN_POSITIONS)[number];
  * Per-geom pipeline defaults, mirrored from ggplot2 (normalize() fills these):
  * geom bar counts (stat "count") and stacks; histogram bins and stacks;
  * col/area stack pre-computed values; boxplot dodges (ggplot2 defaults to
- * dodge2 — ggsvelte uses plain dodge, decision 0010); everything else is
+ * dodge2 — ggsvelte uses plain dodge, decision 0010); jitter aliases to
+ * point+position jitter; hline/vline alias to rule; everything else is
  * identity/identity.
  */
 export const GEOM_DEFAULTS: Record<GeomName, { stat: StatName; position: PositionName }> = {
@@ -91,6 +95,8 @@ export const GEOM_DEFAULTS: Record<GeomName, { stat: StatName; position: Positio
   histogram: { stat: "bin", position: "stack" },
   area: { stat: "identity", position: "stack" },
   rule: { stat: "identity", position: "identity" },
+  hline: { stat: "identity", position: "identity" },
+  vline: { stat: "identity", position: "identity" },
   text: { stat: "identity", position: "identity" },
   smooth: { stat: "smooth", position: "identity" },
   boxplot: { stat: "boxplot", position: "dodge" },
@@ -101,4 +107,5 @@ export const GEOM_DEFAULTS: Record<GeomName, { stat: StatName; position: Positio
   raster: { stat: "identity", position: "identity" },
   ribbon: { stat: "identity", position: "identity" },
   segment: { stat: "identity", position: "identity" },
+  jitter: { stat: "identity", position: "jitter" },
 };

--- a/packages/spec/src/schema-declarations.ts
+++ b/packages/spec/src/schema-declarations.ts
@@ -1288,6 +1288,86 @@ export const SpecDeclarations = {
     },
   ),
 
+  HlineParams: Type.Object(
+    {
+      yintercept: Type.Optional(
+        Type.Ref("RuleIntercept", {
+          description:
+            "ANNOTATION FORM ONLY: draw a horizontal rule at each of these fixed y positions. Mutually exclusive with mapping aes.y on this layer.",
+        }),
+      ),
+      alpha: Type.Optional(
+        Type.Number({
+          minimum: 0,
+          maximum: 1,
+          description: "Rule opacity. Must be between 0 and 1 (inclusive). Default 1.",
+        }),
+      ),
+      linewidth: Type.Optional(
+        Type.Number({
+          exclusiveMinimum: 0,
+          description: "Stroke width in px. Must be greater than 0. Default 1.",
+        }),
+      ),
+      strokePaint: Type.Optional(
+        Type.Ref("GradientPaint", {
+          description:
+            "Within-mark gradient stroke paint (not a data scale). Requires a solid fallback.",
+        }),
+      ),
+      glow: Type.Optional(
+        Type.Ref("GlowSpec", {
+          description: "Bounded within-mark glow treatment (not theme decoration).",
+        }),
+      ),
+    },
+    {
+      additionalProperties: false,
+      description:
+        "Parameters for the hline alias (ggplot2 geom_hline). Annotation form sets yintercept; data-driven form maps aes.y. Canonicalized by normalize() to a rule layer.",
+    },
+  ),
+
+  VlineParams: Type.Object(
+    {
+      xintercept: Type.Optional(
+        Type.Ref("RuleIntercept", {
+          description:
+            "ANNOTATION FORM ONLY: draw a vertical rule at each of these fixed x positions. Mutually exclusive with mapping aes.x on this layer.",
+        }),
+      ),
+      alpha: Type.Optional(
+        Type.Number({
+          minimum: 0,
+          maximum: 1,
+          description: "Rule opacity. Must be between 0 and 1 (inclusive). Default 1.",
+        }),
+      ),
+      linewidth: Type.Optional(
+        Type.Number({
+          exclusiveMinimum: 0,
+          description: "Stroke width in px. Must be greater than 0. Default 1.",
+        }),
+      ),
+      strokePaint: Type.Optional(
+        Type.Ref("GradientPaint", {
+          description:
+            "Within-mark gradient stroke paint (not a data scale). Requires a solid fallback.",
+        }),
+      ),
+      glow: Type.Optional(
+        Type.Ref("GlowSpec", {
+          description: "Bounded within-mark glow treatment (not theme decoration).",
+        }),
+      ),
+    },
+    {
+      additionalProperties: false,
+      description:
+        "Parameters for the vline alias (ggplot2 geom_vline). Annotation form sets xintercept; data-driven form maps aes.x. Canonicalized by normalize() to a rule layer.",
+    },
+  ),
+
   SegmentParams: Type.Object(
     {
       alpha: Type.Optional(
@@ -1837,6 +1917,85 @@ export const SpecDeclarations = {
     },
   ),
 
+  HlineLayer: Type.Object(
+    {
+      geom: Type.Literal("hline", {
+        description:
+          "Horizontal reference-line alias (ggplot2's geom_hline). Canonicalized by normalize() to a rule layer. Annotation form: set params.yintercept. Data-driven form: map aes.y (inherited plot x is dropped so the one-axis rule contract holds).",
+      }),
+      stat: Type.Optional(
+        Type.Literal("identity", { description: "Hline layers draw the given positions as-is." }),
+      ),
+      render: Type.Optional(Type.Ref("RenderBackend")),
+      aes: Type.Optional(Type.Ref("Aes")),
+      data: Type.Optional(
+        Type.Ref("DataRef", {
+          description:
+            "Optional layer-local data. When omitted, the layer inherits plot-level data. When present, it may use inline rows, inline columns, or a named dataset (spec.datasets or runtime).",
+        }),
+      ),
+      params: Type.Optional(Type.Ref("HlineParams")),
+    },
+    {
+      additionalProperties: false,
+      description:
+        "A horizontal reference-line layer alias (normalize() → rule). Annotation: params.yintercept. Data-driven: map aes.y.",
+    },
+  ),
+
+  VlineLayer: Type.Object(
+    {
+      geom: Type.Literal("vline", {
+        description:
+          "Vertical reference-line alias (ggplot2's geom_vline). Canonicalized by normalize() to a rule layer. Annotation form: set params.xintercept. Data-driven form: map aes.x (inherited plot y is dropped so the one-axis rule contract holds).",
+      }),
+      stat: Type.Optional(
+        Type.Literal("identity", { description: "Vline layers draw the given positions as-is." }),
+      ),
+      render: Type.Optional(Type.Ref("RenderBackend")),
+      aes: Type.Optional(Type.Ref("Aes")),
+      data: Type.Optional(
+        Type.Ref("DataRef", {
+          description:
+            "Optional layer-local data. When omitted, the layer inherits plot-level data. When present, it may use inline rows, inline columns, or a named dataset (spec.datasets or runtime).",
+        }),
+      ),
+      params: Type.Optional(Type.Ref("VlineParams")),
+    },
+    {
+      additionalProperties: false,
+      description:
+        "A vertical reference-line layer alias (normalize() → rule). Annotation: params.xintercept. Data-driven: map aes.x.",
+    },
+  ),
+
+  JitterLayer: Type.Object(
+    {
+      geom: Type.Literal("jitter", {
+        description:
+          "Jittered point alias (ggplot2's geom_jitter). Canonicalized by normalize() to a point layer with position jitter. Configure jitter amount via positionParams.width/height/seed.",
+      }),
+      stat: Type.Optional(
+        Type.Literal("identity", { description: "Jitter layers draw the data as-is." }),
+      ),
+      positionParams: Type.Optional(Type.Ref("PositionParams")),
+      render: Type.Optional(Type.Ref("RenderBackend")),
+      aes: Type.Optional(Type.Ref("Aes")),
+      data: Type.Optional(
+        Type.Ref("DataRef", {
+          description:
+            "Optional layer-local data. When omitted, the layer inherits plot-level data. When present, it may use inline rows, inline columns, or a named dataset (spec.datasets or runtime).",
+        }),
+      ),
+      params: Type.Optional(Type.Ref("PointParams")),
+    },
+    {
+      additionalProperties: false,
+      description:
+        'A scatter layer with position "jitter" (alias; normalize() → point). Requires x and y channels. Jitter width/height/seed live on positionParams.',
+    },
+  ),
+
   TextLayer: Type.Object(
     {
       geom: Type.Literal("text", {
@@ -1908,6 +2067,9 @@ export const SpecDeclarations = {
       Type.Ref("AreaLayer"),
       Type.Ref("RibbonLayer"),
       Type.Ref("RuleLayer"),
+      Type.Ref("HlineLayer"),
+      Type.Ref("VlineLayer"),
+      Type.Ref("JitterLayer"),
       Type.Ref("TextLayer"),
       Type.Ref("SmoothLayer"),
       Type.Ref("BoxplotLayer"),

--- a/packages/spec/src/schema.ts
+++ b/packages/spec/src/schema.ts
@@ -111,6 +111,9 @@ export const AreaLayerSchema = SpecModule.Import("AreaLayer");
 export const RibbonLayerSchema = SpecModule.Import("RibbonLayer");
 export const SegmentLayerSchema = SpecModule.Import("SegmentLayer");
 export const RuleLayerSchema = SpecModule.Import("RuleLayer");
+export const HlineLayerSchema = SpecModule.Import("HlineLayer");
+export const VlineLayerSchema = SpecModule.Import("VlineLayer");
+export const JitterLayerSchema = SpecModule.Import("JitterLayer");
 export const TextLayerSchema = SpecModule.Import("TextLayer");
 export const SmoothLayerSchema = SpecModule.Import("SmoothLayer");
 export const BoxplotLayerSchema = SpecModule.Import("BoxplotLayer");
@@ -190,6 +193,10 @@ export type BarParams = SpecType<"BarParams">;
 export type AreaParams = SpecType<"AreaParams">;
 /** Rule layer params (annotation intercepts + styling). */
 export type RuleParams = SpecType<"RuleParams">;
+/** Hline alias params (yintercept + styling). */
+export type HlineParams = SpecType<"HlineParams">;
+/** Vline alias params (xintercept + styling). */
+export type VlineParams = SpecType<"VlineParams">;
 /** Segment layer params (styling + lineend). */
 export type SegmentParams = SpecType<"SegmentParams">;
 /** Text layer params. */
@@ -231,6 +238,12 @@ export type HistogramLayer = LayerWithDataRef<SpecType<"HistogramLayer">>;
 export type AreaLayer = LayerWithDataRef<SpecType<"AreaLayer">>;
 /** A rule (reference line) layer. */
 export type RuleLayer = LayerWithDataRef<SpecType<"RuleLayer">>;
+/** An hline layer (alias; normalize() → rule). */
+export type HlineLayer = LayerWithDataRef<SpecType<"HlineLayer">>;
+/** A vline layer (alias; normalize() → rule). */
+export type VlineLayer = LayerWithDataRef<SpecType<"VlineLayer">>;
+/** A jitter layer (alias; normalize() → point + position jitter). */
+export type JitterLayer = LayerWithDataRef<SpecType<"JitterLayer">>;
 /** A text-label layer. */
 export type TextLayer = LayerWithDataRef<SpecType<"TextLayer">>;
 /** A smooth (fitted trend) layer. */
@@ -262,6 +275,9 @@ export type LayerSpec =
   | RibbonLayer
   | SegmentLayer
   | RuleLayer
+  | HlineLayer
+  | VlineLayer
+  | JitterLayer
   | TextLayer
   | SmoothLayer
   | BoxplotLayer

--- a/packages/spec/src/validate-schema-shape.ts
+++ b/packages/spec/src/validate-schema-shape.ts
@@ -17,6 +17,8 @@ import {
   DensityLayerSchema,
   ErrorbarLayerSchema,
   HistogramLayerSchema,
+  HlineLayerSchema,
+  JitterLayerSchema,
   LineLayerSchema,
   PlotSpecSchema,
   PointLayerSchema,
@@ -28,6 +30,7 @@ import {
   SmoothLayerSchema,
   TextLayerSchema,
   TileLayerSchema,
+  VlineLayerSchema,
 } from "./schema.js";
 import { mapValueErrors, unknownGeomError } from "./validate-map-errors.js";
 
@@ -42,6 +45,9 @@ export const GEOM_BRANCHES = {
   ribbon: RibbonLayerSchema,
   segment: SegmentLayerSchema,
   rule: RuleLayerSchema,
+  hline: HlineLayerSchema,
+  vline: VlineLayerSchema,
+  jitter: JitterLayerSchema,
   text: TextLayerSchema,
   smooth: SmoothLayerSchema,
   boxplot: BoxplotLayerSchema,

--- a/packages/spec/src/validate-structure-layers.ts
+++ b/packages/spec/src/validate-structure-layers.ts
@@ -20,12 +20,15 @@ function isRecord(v: unknown): v is Record<string, unknown> {
 /** Channels every geom needs mapped (after plot-aes inheritance). */
 const REQUIRED_CHANNELS: Record<string, ChannelName[]> = {
   point: ["x", "y"],
+  jitter: ["x", "y"],
   line: ["x", "y"],
   col: ["x", "y"],
   bar: ["x"],
   histogram: ["x"],
   area: ["x", "y"],
   rule: [], // form-checked separately
+  hline: [], // form-checked like rule (yintercept / aes.y)
+  vline: [], // form-checked like rule (xintercept / aes.x)
   text: ["x", "y", "label"],
   smooth: ["x", "y"],
   boxplot: ["x", "y"],
@@ -38,9 +41,12 @@ const REQUIRED_CHANNELS: Record<string, ChannelName[]> = {
   ribbon: [], // orientation-dependent; checked separately
 };
 
-function hasIntercepts(layer: Record<string, unknown>): boolean {
+/** Asymmetric intercept presence for rule / hline / vline form checks. */
+function hasGeomIntercepts(geom: string, layer: Record<string, unknown>): boolean {
   const params = layer["params"];
   if (!isRecord(params)) return false;
+  if (geom === "hline") return params["yintercept"] !== undefined;
+  if (geom === "vline") return params["xintercept"] !== undefined;
   return params["xintercept"] !== undefined || params["yintercept"] !== undefined;
 }
 
@@ -126,11 +132,12 @@ export function layerStructuralErrors(
   const layerAes = isRecord(layer["aes"]) ? (layer["aes"] as Aes) : undefined;
   const layerPath = `/layers/${index}`;
   const mapped = (channel: ChannelName) => effectiveChannel(plotAes, layerAes, channel);
-  // Annotation-form rules (fixed intercepts) inherit NO plot aes — normalize
-  // drops it — so a plot-level style meant for other layers must not trip the
-  // geom-capability check here. Match the rule-form x/y handling below by
-  // consulting only the rule's OWN aes for these layers.
-  const annotationRule = geom === "rule" && hasIntercepts(layer);
+  // Annotation-form rules / hline / vline (fixed intercepts) inherit NO plot
+  // aes — normalize drops it — so a plot-level style meant for other layers
+  // must not trip the geom-capability check here. Match the rule-form x/y
+  // handling below by consulting only the layer's OWN aes for these layers.
+  const isRuleFamily = geom === "rule" || geom === "hline" || geom === "vline";
+  const annotationRule = isRuleFamily && hasGeomIntercepts(geom, layer);
 
   for (const aesthetic of Object.keys(STYLE_AESTHETIC_GEOMS) as StyleAesthetic[]) {
     const value = annotationRule ? (layerAes?.[aesthetic] ?? undefined) : mapped(aesthetic);
@@ -147,44 +154,63 @@ export function layerStructuralErrors(
     });
   }
 
-  if (geom === "rule") {
-    const intercepts = hasIntercepts(layer);
+  if (isRuleFamily) {
+    const intercepts = hasGeomIntercepts(geom, layer);
     // The annotation form inherits NO plot aes (normalize drops it, matching
     // ggplot2's inherit.aes = FALSE) — only the layer's OWN x/y mappings
-    // conflict with intercepts.
+    // conflict with intercepts. Data-driven hline/vline sugar also nulls the
+    // orthogonal axis during normalize; pre-normalize validation still sees
+    // raw layer aes here.
     const own = (channel: "x" | "y") => layerAes?.[channel] ?? undefined;
-    const x = intercepts ? own("x") : mapped("x");
-    const y = intercepts ? own("y") : mapped("y");
+    let x = intercepts ? own("x") : mapped("x");
+    let y = intercepts ? own("y") : mapped("y");
+    // Pre-normalize data-driven aliases: orthogonal axis is not part of the form.
+    if (!intercepts && geom === "hline") x = undefined;
+    if (!intercepts && geom === "vline") y = undefined;
+    const interceptHint =
+      geom === "hline"
+        ? "params.yintercept"
+        : geom === "vline"
+          ? "params.xintercept"
+          : "params.xintercept/yintercept";
+    const dataHint = geom === "hline" ? "aes.y" : geom === "vline" ? "aes.x" : "aes.x/aes.y";
     if (intercepts && (x !== undefined || y !== undefined)) {
       errors.push({
         code: "rule-form-ambiguous",
         path: layerPath,
-        message:
-          "This rule layer mixes the annotation form (params.xintercept/yintercept) with mapped aes.x/aes.y. Use fixed intercepts OR a data mapping, never both.",
+        message: `This ${geom} layer mixes the annotation form (${interceptHint}) with mapped ${dataHint}. Use fixed intercepts OR a data mapping, never both.`,
         fix: {
           description:
-            "Remove the intercept params (data-driven form), or unset aes.x/aes.y with null (annotation form).",
-          example: { geom: "rule", aes: { x: null, y: null }, params: { yintercept: 0 } },
+            "Remove the intercept params (data-driven form), or unset the position aes with null (annotation form).",
+          example:
+            geom === "vline"
+              ? { geom: "vline", params: { xintercept: 0 } }
+              : { geom: geom === "hline" ? "hline" : "rule", params: { yintercept: 0 } },
         },
       });
     } else if (!intercepts && x === undefined && y === undefined) {
       errors.push({
         code: "rule-form-missing",
         path: layerPath,
-        message:
-          "This rule layer has neither fixed intercepts (params.xintercept/yintercept) nor a mapped aes.x/aes.y — nothing to draw.",
+        message: `This ${geom} layer has neither fixed intercepts (${interceptHint}) nor a mapped ${dataHint} — nothing to draw.`,
         fix: {
           description:
-            "Set params.yintercept (or xintercept) for an annotation, or map aes.x/aes.y to a field for data-driven rules.",
-          example: { geom: "rule", params: { yintercept: 0 } },
+            geom === "hline"
+              ? "Set params.yintercept for an annotation, or map aes.y for data-driven horizontal rules."
+              : geom === "vline"
+                ? "Set params.xintercept for an annotation, or map aes.x for data-driven vertical rules."
+                : "Set params.yintercept (or xintercept) for an annotation, or map aes.x/aes.y to a field for data-driven rules.",
+          example:
+            geom === "vline"
+              ? { geom: "vline", params: { xintercept: 0 } }
+              : { geom: geom === "hline" ? "hline" : "rule", params: { yintercept: 0 } },
         },
       });
     } else if (!intercepts && x !== undefined && y !== undefined) {
       errors.push({
         code: "rule-both-axes",
         path: layerPath,
-        message:
-          "This rule layer maps BOTH aes.x and aes.y; a data-driven rule is either vertical (map x) or horizontal (map y). Unset the other channel with null.",
+        message: `This ${geom} layer maps BOTH aes.x and aes.y; a data-driven rule is either vertical (map x) or horizontal (map y). Unset the other channel with null.`,
         fix: {
           description: "Keep one direction and unset the other channel with null.",
           example: { geom: "rule", aes: { y: null } },

--- a/packages/spec/tests/__snapshots__/catalog-coverage.test.ts.snap
+++ b/packages/spec/tests/__snapshots__/catalog-coverage.test.ts.snap
@@ -116,6 +116,8 @@ exports[`ERROR_CATALOG coverage [missing-geom] is reproducible; message + fix sn
       "histogram",
       "area",
       "rule",
+      "hline",
+      "vline",
       "text",
       "smooth",
       "boxplot",
@@ -126,6 +128,7 @@ exports[`ERROR_CATALOG coverage [missing-geom] is reproducible; message + fix sn
       "raster",
       "ribbon",
       "segment",
+      "jitter",
     ],
     "code": "missing-geom",
     "fix": {
@@ -134,7 +137,7 @@ exports[`ERROR_CATALOG coverage [missing-geom] is reproducible; message + fix sn
         "geom": "point",
       },
     },
-    "message": "Every layer needs a "geom" discriminator. Allowed geoms: "point", "line", "col", "bar", "histogram", "area", "rule", "text", "smooth", "boxplot", "density", "errorbar", "rect", "tile", "raster", "ribbon", "segment".",
+    "message": "Every layer needs a "geom" discriminator. Allowed geoms: "point", "line", "col", "bar", "histogram", "area", "rule", "hline", "vline", "text", "smooth", "boxplot", "density", "errorbar", "rect", "tile", "raster", "ribbon", "segment", "jitter".",
     "path": "/layers/0/geom",
   },
 }
@@ -156,6 +159,8 @@ exports[`ERROR_CATALOG coverage [unknown-geom] is reproducible; message + fix sn
       "histogram",
       "area",
       "rule",
+      "hline",
+      "vline",
       "text",
       "smooth",
       "boxplot",
@@ -166,6 +171,7 @@ exports[`ERROR_CATALOG coverage [unknown-geom] is reproducible; message + fix sn
       "raster",
       "ribbon",
       "segment",
+      "jitter",
     ],
     "code": "unknown-geom",
     "fix": {
@@ -174,7 +180,7 @@ exports[`ERROR_CATALOG coverage [unknown-geom] is reproducible; message + fix sn
         "geom": "point",
       },
     },
-    "message": "Unknown geom "pont". Allowed geoms: "point", "line", "col", "bar", "histogram", "area", "rule", "text", "smooth", "boxplot", "density", "errorbar", "rect", "tile", "raster", "ribbon", "segment". Did you mean "point"?",
+    "message": "Unknown geom "pont". Allowed geoms: "point", "line", "col", "bar", "histogram", "area", "rule", "hline", "vline", "text", "smooth", "boxplot", "density", "errorbar", "rect", "tile", "raster", "ribbon", "segment", "jitter". Did you mean "point"?",
     "path": "/layers/0/geom",
   },
 }
@@ -412,6 +418,51 @@ exports[`ERROR_CATALOG coverage [scale-manual-domain-range] is reproducible; mes
 }
 `;
 
+exports[`ERROR_CATALOG coverage [scale-binned-breaks] is reproducible; message + fix snapshot 1`] = `
+{
+  "catalog": {
+    "fix": "Provide 2+ strictly increasing boundaries (numeric, or temporal strings that parse under the scale's parser).",
+    "summary": "A binned style scale's authored breaks are missing, non-finite after parsing, duplicated, or not strictly increasing.",
+    "tier": 1,
+  },
+  "instance": {
+    "code": "scale-binned-breaks",
+    "fix": {
+      "description": "Provide 2+ strictly increasing boundaries that parse under the scale's parser.",
+      "example": [
+        0,
+        10,
+        20,
+      ],
+    },
+    "message": "The size boundaries must be finite and strictly increasing.",
+    "path": "/scales/size/breaks",
+  },
+}
+`;
+
+exports[`ERROR_CATALOG coverage [scale-binned-domain] is reproducible; message + fix snapshot 1`] = `
+{
+  "catalog": {
+    "fix": "Set domain to the first and last break values, or omit domain and let breaks define it.",
+    "summary": "A binned style scale's explicit domain does not match the first and last authored breaks.",
+    "tier": 1,
+  },
+  "instance": {
+    "code": "scale-binned-domain",
+    "fix": {
+      "description": "Set domain to the first and last break values, or omit domain.",
+      "example": [
+        0,
+        10,
+      ],
+    },
+    "message": "The size binned domain must match its first and last boundaries.",
+    "path": "/scales/size/domain",
+  },
+}
+`;
+
 exports[`ERROR_CATALOG coverage [guide-aesthetic-incompatible] is reproducible; message + fix snapshot 1`] = `
 {
   "catalog": {
@@ -482,12 +533,8 @@ exports[`ERROR_CATALOG coverage [rule-form-ambiguous] is reproducible; message +
   "instance": {
     "code": "rule-form-ambiguous",
     "fix": {
-      "description": "Remove the intercept params (data-driven form), or unset aes.x/aes.y with null (annotation form).",
+      "description": "Remove the intercept params (data-driven form), or unset the position aes with null (annotation form).",
       "example": {
-        "aes": {
-          "x": null,
-          "y": null,
-        },
         "geom": "rule",
         "params": {
           "yintercept": 0,
@@ -670,7 +717,7 @@ exports[`ERROR_CATALOG coverage [unsupported-geom-aesthetic] is reproducible; me
     "fix": {
       "description": "Remove aes.size or move it to a compatible point layer.",
     },
-    "message": "The line geom does not consume aes.size; supported geoms: point, text.",
+    "message": "The line geom does not consume aes.size; supported geoms: point, jitter, text.",
     "path": "/layers/0/aes/size",
   },
 }
@@ -695,6 +742,61 @@ exports[`ERROR_CATALOG coverage [ribbon-orientation-ambiguous] is reproducible; 
     },
     "message": "This ribbon layer maps both x-orientation (x+ymin+ymax) and y-orientation (y+xmin+xmax) contracts. Set params.orientation to "x" or "y".",
     "path": "/layers/0/params/orientation",
+  },
+}
+`;
+
+exports[`ERROR_CATALOG coverage [paint-stops-unordered] is reproducible; message + fix snapshot 1`] = `
+{
+  "catalog": {
+    "fix": "Sort stops by offset ascending (each offset between 0 and 1 inclusive).",
+    "summary": "A gradient paint's color stops are not in non-decreasing offset order.",
+    "tier": 2,
+  },
+  "instance": {
+    "code": "paint-stops-unordered",
+    "fix": {
+      "description": "Sort stops by offset ascending (each between 0 and 1).",
+      "example": {
+        "stops": [
+          {
+            "color": "#000000",
+            "offset": 0,
+          },
+          {
+            "color": "#ffffff",
+            "offset": 1,
+          },
+        ],
+      },
+    },
+    "message": "Gradient stop offsets must be non-decreasing; stop 1 has offset 0.1 after 0.9.",
+    "path": "/layers/0/params/fillPaint/stops/1/offset",
+  },
+}
+`;
+
+exports[`ERROR_CATALOG coverage [paint-scale-conflict] is reproducible; message + fix snapshot 1`] = `
+{
+  "catalog": {
+    "fix": "Remove the data-mapped fill/color aesthetic, or remove the paint and keep the scale.",
+    "summary": "Within-mark fillPaint/strokePaint cannot combine with a data-mapped fill/color scale channel.",
+    "tier": 2,
+  },
+  "instance": {
+    "code": "paint-scale-conflict",
+    "fix": {
+      "description": "Remove aes.fill field mapping, or remove fillPaint and keep the scale.",
+      "example": {
+        "params": {
+          "fillPaint": {
+            "type": "linear",
+          },
+        },
+      },
+    },
+    "message": "params.fillPaint cannot combine with a data-mapped fill channel (field or scaled constant).",
+    "path": "/layers/0/params/fillPaint",
   },
 }
 `;
@@ -828,106 +930,6 @@ exports[`ERROR_CATALOG coverage [validation-limit] is reproducible; message + fi
     "code": "validation-limit",
     "message": "Inline data has 2 rows across plot/layers, more than the documented maxRows limit (1); data-aware checks skipped. Validate with a DataProfile instead.",
     "path": "/data",
-  },
-}
-`;
-
-exports[`ERROR_CATALOG coverage [paint-stops-unordered] is reproducible; message + fix snapshot 1`] = `
-{
-  "catalog": {
-    "fix": "Sort stops by offset ascending (each offset between 0 and 1 inclusive).",
-    "summary": "A gradient paint's color stops are not in non-decreasing offset order.",
-    "tier": 2,
-  },
-  "instance": {
-    "code": "paint-stops-unordered",
-    "fix": {
-      "description": "Sort stops by offset ascending (each between 0 and 1).",
-      "example": {
-        "stops": [
-          {
-            "color": "#000000",
-            "offset": 0,
-          },
-          {
-            "color": "#ffffff",
-            "offset": 1,
-          },
-        ],
-      },
-    },
-    "message": "Gradient stop offsets must be non-decreasing; stop 1 has offset 0.1 after 0.9.",
-    "path": "/layers/0/params/fillPaint/stops/1/offset",
-  },
-}
-`;
-
-exports[`ERROR_CATALOG coverage [paint-scale-conflict] is reproducible; message + fix snapshot 1`] = `
-{
-  "catalog": {
-    "fix": "Remove the data-mapped fill/color aesthetic, or remove the paint and keep the scale.",
-    "summary": "Within-mark fillPaint/strokePaint cannot combine with a data-mapped fill/color scale channel.",
-    "tier": 2,
-  },
-  "instance": {
-    "code": "paint-scale-conflict",
-    "fix": {
-      "description": "Remove aes.fill field mapping, or remove fillPaint and keep the scale.",
-      "example": {
-        "params": {
-          "fillPaint": {
-            "type": "linear",
-          },
-        },
-      },
-    },
-    "message": "params.fillPaint cannot combine with a data-mapped fill channel (field or scaled constant).",
-    "path": "/layers/0/params/fillPaint",
-  },
-}
-`;
-
-exports[`ERROR_CATALOG coverage [scale-binned-breaks] is reproducible; message + fix snapshot 1`] = `
-{
-  "catalog": {
-    "fix": "Provide 2+ strictly increasing boundaries (numeric, or temporal strings that parse under the scale's parser).",
-    "summary": "A binned style scale's authored breaks are missing, non-finite after parsing, duplicated, or not strictly increasing.",
-    "tier": 1,
-  },
-  "instance": {
-    "code": "scale-binned-breaks",
-    "fix": {
-      "description": "Provide 2+ strictly increasing boundaries that parse under the scale's parser.",
-      "example": [
-        0,
-        10,
-        20,
-      ],
-    },
-    "message": "The size boundaries must be finite and strictly increasing.",
-    "path": "/scales/size/breaks",
-  },
-}
-`;
-
-exports[`ERROR_CATALOG coverage [scale-binned-domain] is reproducible; message + fix snapshot 1`] = `
-{
-  "catalog": {
-    "fix": "Set domain to the first and last break values, or omit domain and let breaks define it.",
-    "summary": "A binned style scale's explicit domain does not match the first and last authored breaks.",
-    "tier": 1,
-  },
-  "instance": {
-    "code": "scale-binned-domain",
-    "fix": {
-      "description": "Set domain to the first and last break values, or omit domain.",
-      "example": [
-        0,
-        10,
-      ],
-    },
-    "message": "The size binned domain must match its first and last boundaries.",
-    "path": "/scales/size/domain",
   },
 }
 `;

--- a/packages/spec/tests/__snapshots__/validate-tier2-m2.test.ts.snap
+++ b/packages/spec/tests/__snapshots__/validate-tier2-m2.test.ts.snap
@@ -1,5 +1,19 @@
 // Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
+exports[`tier 2 — M2 statistical layer (snapshot-tested messages) histogram y mapped to a field -> computed-y-mapped 1`] = `
+{
+  "code": "computed-y-mapped",
+  "fix": {
+    "description": "Switch the layer to geom "col" (identity stat) to draw mapped y values.",
+    "example": {
+      "geom": "col",
+    },
+  },
+  "message": "The histogram geom computes y with the bin stat, so aes.y must not map data. Use geom "col" for pre-computed heights, or unset y with null.",
+  "path": "/layers/0/aes/y",
+}
+`;
+
 exports[`tier 2 — M2 statistical layer (snapshot-tested messages) density y mapped to a field -> computed-y-mapped 1`] = `
 {
   "code": "computed-y-mapped",
@@ -69,19 +83,5 @@ exports[`tier 2 — M2 statistical layer (snapshot-tested messages) boxplot need
   },
   "message": "The boxplot geom needs a DISCRETE x this milestone, but field "v" is quantitative.",
   "path": "/layers/0/aes/x",
-}
-`;
-
-exports[`tier 2 — M2 statistical layer (snapshot-tested messages) histogram y mapped to a field -> computed-y-mapped 1`] = `
-{
-  "code": "computed-y-mapped",
-  "fix": {
-    "description": "Switch the layer to geom "col" (identity stat) to draw mapped y values.",
-    "example": {
-      "geom": "col",
-    },
-  },
-  "message": "The histogram geom computes y with the bin stat, so aes.y must not map data. Use geom "col" for pre-computed heights, or unset y with null.",
-  "path": "/layers/0/aes/y",
 }
 `;

--- a/packages/spec/tests/__snapshots__/validate.test.ts.snap
+++ b/packages/spec/tests/__snapshots__/validate.test.ts.snap
@@ -75,6 +75,8 @@ exports[`validate — agent errors (snapshot-tested messages) unknown geom with 
       "histogram",
       "area",
       "rule",
+      "hline",
+      "vline",
       "text",
       "smooth",
       "boxplot",
@@ -85,6 +87,7 @@ exports[`validate — agent errors (snapshot-tested messages) unknown geom with 
       "raster",
       "ribbon",
       "segment",
+      "jitter",
     ],
     "code": "unknown-geom",
     "fix": {
@@ -93,7 +96,7 @@ exports[`validate — agent errors (snapshot-tested messages) unknown geom with 
         "geom": "point",
       },
     },
-    "message": "Unknown geom "poit". Allowed geoms: "point", "line", "col", "bar", "histogram", "area", "rule", "text", "smooth", "boxplot", "density", "errorbar", "rect", "tile", "raster", "ribbon", "segment". Did you mean "point"?",
+    "message": "Unknown geom "poit". Allowed geoms: "point", "line", "col", "bar", "histogram", "area", "rule", "hline", "vline", "text", "smooth", "boxplot", "density", "errorbar", "rect", "tile", "raster", "ribbon", "segment", "jitter". Did you mean "point"?",
     "path": "/layers/0/geom",
   },
 ]
@@ -110,6 +113,8 @@ exports[`validate — agent errors (snapshot-tested messages) geom missing entir
       "histogram",
       "area",
       "rule",
+      "hline",
+      "vline",
       "text",
       "smooth",
       "boxplot",
@@ -120,6 +125,7 @@ exports[`validate — agent errors (snapshot-tested messages) geom missing entir
       "raster",
       "ribbon",
       "segment",
+      "jitter",
     ],
     "code": "missing-geom",
     "fix": {
@@ -128,7 +134,7 @@ exports[`validate — agent errors (snapshot-tested messages) geom missing entir
         "geom": "point",
       },
     },
-    "message": "Every layer needs a "geom" discriminator. Allowed geoms: "point", "line", "col", "bar", "histogram", "area", "rule", "text", "smooth", "boxplot", "density", "errorbar", "rect", "tile", "raster", "ribbon", "segment".",
+    "message": "Every layer needs a "geom" discriminator. Allowed geoms: "point", "line", "col", "bar", "histogram", "area", "rule", "hline", "vline", "text", "smooth", "boxplot", "density", "errorbar", "rect", "tile", "raster", "ribbon", "segment", "jitter".",
     "path": "/layers/0/geom",
   },
 ]
@@ -281,6 +287,8 @@ exports[`validate — agent errors (snapshot-tested messages) multiple errors ar
       "histogram",
       "area",
       "rule",
+      "hline",
+      "vline",
       "text",
       "smooth",
       "boxplot",
@@ -291,6 +299,7 @@ exports[`validate — agent errors (snapshot-tested messages) multiple errors ar
       "raster",
       "ribbon",
       "segment",
+      "jitter",
     ],
     "code": "unknown-geom",
     "fix": {
@@ -299,7 +308,7 @@ exports[`validate — agent errors (snapshot-tested messages) multiple errors ar
         "geom": "point",
       },
     },
-    "message": "Unknown geom "poit". Allowed geoms: "point", "line", "col", "bar", "histogram", "area", "rule", "text", "smooth", "boxplot", "density", "errorbar", "rect", "tile", "raster", "ribbon", "segment". Did you mean "point"?",
+    "message": "Unknown geom "poit". Allowed geoms: "point", "line", "col", "bar", "histogram", "area", "rule", "hline", "vline", "text", "smooth", "boxplot", "density", "errorbar", "rect", "tile", "raster", "ribbon", "segment", "jitter". Did you mean "point"?",
     "path": "/layers/0/geom",
   },
   {

--- a/packages/spec/tests/builder.test.ts
+++ b/packages/spec/tests/builder.test.ts
@@ -138,4 +138,37 @@ describe("gg builder — M2 sugar methods", () => {
       params: { alpha: 0.4 },
     });
   });
+
+  it("geomJitter assembles flat width/height/seed into positionParams (#818)", () => {
+    const spec = gg(xy, aes({ x: "x", y: "y" }))
+      .geomJitter({ width: 0.2, height: 0, seed: 9, alpha: 0.75, size: 2 })
+      .spec();
+    expect(spec.layers[0]).toEqual({
+      geom: "point",
+      stat: "identity",
+      position: "jitter",
+      positionParams: { width: 0.2, height: 0, seed: 9 },
+      aes: { x: { field: "x" }, y: { field: "y" } },
+      params: { alpha: 0.75, size: 2 },
+    });
+  });
+
+  it("geomHline / geomVline compile to rule annotations (#818)", () => {
+    const spec = gg(xy, aes({ x: "x", y: "y" }))
+      .geomHline({ yintercept: 0, linewidth: 1.2 })
+      .geomVline({ xintercept: 1, alpha: 0.5 })
+      .spec();
+    expect(spec.layers[0]).toEqual({
+      geom: "rule",
+      stat: "identity",
+      position: "identity",
+      params: { yintercept: 0, linewidth: 1.2 },
+    });
+    expect(spec.layers[1]).toEqual({
+      geom: "rule",
+      stat: "identity",
+      position: "identity",
+      params: { xintercept: 1, alpha: 0.5 },
+    });
+  });
 });

--- a/packages/spec/tests/normalize-convenience-geoms.test.ts
+++ b/packages/spec/tests/normalize-convenience-geoms.test.ts
@@ -1,0 +1,124 @@
+/**
+ * normalize() convenience geom aliases (#818): jitter → point+position jitter,
+ * hline/vline → rule (annotation inherit.aes = FALSE when intercepts set).
+ * Mirrors the histogram → bar+bin alias pattern in normalize-m2.test.ts.
+ */
+import { describe, expect, it } from "bun:test";
+
+import { normalize } from "../src/normalize.ts";
+import type { SpecInput } from "../src/normalize.ts";
+
+describe("normalize — convenience geom aliases (#818)", () => {
+  it("canonicalizes jitter → point + position jitter; keeps positionParams", () => {
+    const spec = normalize({
+      layers: [
+        {
+          geom: "jitter",
+          aes: { x: "x", y: "y" },
+          positionParams: { width: 0.2, height: 0.1, seed: 7 },
+          params: { alpha: 0.5, size: 3 },
+        },
+      ],
+    });
+    expect(spec.layers[0]).toEqual({
+      geom: "point",
+      stat: "identity",
+      position: "jitter",
+      positionParams: { width: 0.2, height: 0.1, seed: 7 },
+      aes: { x: { field: "x" }, y: { field: "y" } },
+      params: { alpha: 0.5, size: 3 },
+    });
+    expect(normalize(spec as SpecInput)).toEqual(spec);
+  });
+
+  it("fills jitter defaults without positionParams", () => {
+    const spec = normalize({
+      layers: [{ geom: "jitter", aes: { x: "x", y: "y" } }],
+    });
+    expect(spec.layers[0]).toEqual({
+      geom: "point",
+      stat: "identity",
+      position: "jitter",
+      aes: { x: { field: "x" }, y: { field: "y" } },
+    });
+  });
+
+  it("canonicalizes hline(yintercept) → rule annotation; strips plot aes inheritance", () => {
+    const spec = normalize({
+      aes: { x: "x", y: "y", color: "g" },
+      layers: [{ geom: "hline", params: { yintercept: 0, linewidth: 1.2 } }],
+    });
+    expect(spec.layers[0]).toEqual({
+      geom: "rule",
+      stat: "identity",
+      position: "identity",
+      params: { yintercept: 0, linewidth: 1.2 },
+    });
+    expect(normalize(spec as SpecInput)).toEqual(spec);
+  });
+
+  it("canonicalizes vline(xintercept) → rule annotation; strips plot aes inheritance", () => {
+    const spec = normalize({
+      aes: { x: "x", y: "y" },
+      layers: [{ geom: "vline", params: { xintercept: 1.5, alpha: 0.4 } }],
+    });
+    expect(spec.layers[0]).toEqual({
+      geom: "rule",
+      stat: "identity",
+      position: "identity",
+      params: { xintercept: 1.5, alpha: 0.4 },
+    });
+  });
+
+  it("data-driven hline → rule with aes.y; drops inherited x (one-axis rule form)", () => {
+    const spec = normalize({
+      aes: { x: "x", y: "y", color: "g" },
+      layers: [{ geom: "hline", aes: { y: "threshold" } }],
+    });
+    expect(spec.layers[0]).toMatchObject({
+      geom: "rule",
+      stat: "identity",
+      position: "identity",
+      aes: {
+        y: { field: "threshold" },
+        color: { field: "g" },
+      },
+    });
+    expect(spec.layers[0]!.aes).not.toHaveProperty("x");
+  });
+
+  it("data-driven vline → rule with aes.x; drops inherited y (one-axis rule form)", () => {
+    const spec = normalize({
+      aes: { x: "x", y: "y", color: "g" },
+      layers: [{ geom: "vline", aes: { x: "cut" } }],
+    });
+    expect(spec.layers[0]).toMatchObject({
+      geom: "rule",
+      aes: {
+        x: { field: "cut" },
+        color: { field: "g" },
+      },
+    });
+    expect(spec.layers[0]!.aes).not.toHaveProperty("y");
+  });
+
+  it("annotation hline keeps layer-local color value aes (not plot field inheritance)", () => {
+    const spec = normalize({
+      aes: { x: "x", y: "y", color: "g" },
+      layers: [
+        {
+          geom: "hline",
+          aes: { color: { value: "#d14d41" } },
+          params: { yintercept: 0 },
+        },
+      ],
+    });
+    expect(spec.layers[0]).toEqual({
+      geom: "rule",
+      stat: "identity",
+      position: "identity",
+      aes: { color: { value: "#d14d41" } },
+      params: { yintercept: 0 },
+    });
+  });
+});

--- a/packages/spec/tests/schema-surface.test.ts
+++ b/packages/spec/tests/schema-surface.test.ts
@@ -34,6 +34,8 @@ const VALUE_EXPORTS = [
   "FacetSpecSchema",
   "GEOM_DEFAULTS",
   "HistogramLayerSchema",
+  "HlineLayerSchema",
+  "JitterLayerSchema",
   "KNOWN_GEOMS",
   "KNOWN_POSITIONS",
   "KNOWN_STATS",
@@ -52,6 +54,7 @@ const VALUE_EXPORTS = [
   "SpecModule",
   "TextLayerSchema",
   "THEME_NAMES",
+  "VlineLayerSchema",
 ] as const;
 
 describe("schema facade surface", () => {

--- a/packages/svelte/src/lib/geoms/GeomHline.svelte
+++ b/packages/svelte/src/lib/geoms/GeomHline.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  /**
+   * <GeomHline> — declaration-only horizontal reference-line sugar for <GGPlot>
+   * (ggplot2 geom_hline; canonicalized to rule). Annotation form: set
+   * yintercept. Data-driven form: map aes.y. Same contract and z-order
+   * constraint as <GeomPoint> (decision 0001).
+   */
+  import type { DataInput, AesInput, HlineParams } from "@ggsvelte/spec";
+
+  import { createGeomLayer } from "./factory.svelte.js";
+
+  interface Props extends HlineParams {
+    /** Optional layer-local data (#589); inherits plot data when omitted. */
+    data?: DataInput | readonly Record<string, unknown>[];
+    /** Layer-level aes (bare-string shorthand allowed); merges over plot aes. */
+    aes?: AesInput;
+  }
+
+  const props: Props = $props();
+  createGeomLayer("hline", () => props, ["yintercept", "alpha", "linewidth"]);
+</script>

--- a/packages/svelte/src/lib/geoms/GeomJitter.svelte
+++ b/packages/svelte/src/lib/geoms/GeomJitter.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+  /**
+   * <GeomJitter> — declaration-only jittered-point sugar for <GGPlot>
+   * (ggplot2 geom_jitter; canonicalized to point + position jitter). Flat
+   * width/height/seed props assemble into positionParams. Same contract and
+   * z-order constraint as <GeomPoint> (decision 0001).
+   */
+  import type {
+    AesInput,
+    DataInput,
+    PointParams,
+    PositionParams,
+    RenderBackend,
+  } from "@ggsvelte/spec";
+
+  import { createGeomLayer } from "./factory.svelte.js";
+
+  interface Props extends PointParams {
+    /** Optional layer-local data (#589); inherits plot data when omitted. */
+    data?: DataInput | readonly Record<string, unknown>[];
+    /** Layer-level aes (bare-string shorthand allowed); merges over plot aes. */
+    aes?: AesInput;
+    /** Maximum horizontal jitter (data units / band-step fraction). */
+    width?: number;
+    /** Maximum vertical jitter (data units / band-step fraction). */
+    height?: number;
+    /** Seeded RNG seed (ggsvelte jitter is always seeded; default 42). */
+    seed?: number;
+    /** Explicit positionParams; flat width/height/seed override matching keys. */
+    positionParams?: PositionParams;
+    /** Rendering backend hint ("svg" | "canvas" | "auto"). */
+    render?: RenderBackend;
+  }
+
+  const props: Props = $props();
+  createGeomLayer(
+    "jitter",
+    () => {
+      const { width, height, seed, positionParams, ...rest } = props;
+      const merged = {
+        ...positionParams,
+        ...(width !== undefined && { width }),
+        ...(height !== undefined && { height }),
+        ...(seed !== undefined && { seed }),
+      };
+      return {
+        ...rest,
+        ...(Object.keys(merged).length > 0 && { positionParams: merged }),
+      };
+    },
+    ["alpha", "size", "shape"],
+  );
+</script>

--- a/packages/svelte/src/lib/geoms/GeomVline.svelte
+++ b/packages/svelte/src/lib/geoms/GeomVline.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  /**
+   * <GeomVline> — declaration-only vertical reference-line sugar for <GGPlot>
+   * (ggplot2 geom_vline; canonicalized to rule). Annotation form: set
+   * xintercept. Data-driven form: map aes.x. Same contract and z-order
+   * constraint as <GeomPoint> (decision 0001).
+   */
+  import type { DataInput, AesInput, VlineParams } from "@ggsvelte/spec";
+
+  import { createGeomLayer } from "./factory.svelte.js";
+
+  interface Props extends VlineParams {
+    /** Optional layer-local data (#589); inherits plot data when omitted. */
+    data?: DataInput | readonly Record<string, unknown>[];
+    /** Layer-level aes (bare-string shorthand allowed); merges over plot aes. */
+    aes?: AesInput;
+  }
+
+  const props: Props = $props();
+  createGeomLayer("vline", () => props, ["xintercept", "alpha", "linewidth"]);
+</script>

--- a/packages/svelte/src/lib/index.ts
+++ b/packages/svelte/src/lib/index.ts
@@ -78,6 +78,9 @@ export type {
   ZoomOptions,
 } from "./interaction/interaction.js";
 export { default as GeomPoint } from "./geoms/GeomPoint.svelte";
+export { default as GeomJitter } from "./geoms/GeomJitter.svelte";
+export { default as GeomHline } from "./geoms/GeomHline.svelte";
+export { default as GeomVline } from "./geoms/GeomVline.svelte";
 export { default as GeomLine } from "./geoms/GeomLine.svelte";
 export { default as GeomCol } from "./geoms/GeomCol.svelte";
 export { default as GeomBar } from "./geoms/GeomBar.svelte";

--- a/workers/playground-api/src/prompt.ts
+++ b/workers/playground-api/src/prompt.ts
@@ -36,14 +36,15 @@ Bare strings are invalid in JSON specs. Channels: x, y, color, fill, group, labe
 weight, ymin, ymax, xmin, xmax.
 
 ## Geoms / stats / positions
-Geoms: point, line, col, bar, histogram, area, rule, text, smooth, boxplot, density,
-errorbar, rect, tile, ribbon.
+Geoms: point, jitter, line, col, bar, histogram, area, rule, hline, vline, text,
+smooth, boxplot, density, errorbar, rect, tile, ribbon, segment, raster.
 Defaults: bar→count+stack; histogram→bin+stack; col/area→identity+stack;
-boxplot→boxplot+dodge; else identity.
+boxplot→boxplot+dodge; jitter→point+position jitter; hline/vline→rule; else identity.
 Positions are scoped per geom — one used outside its geom is rejected:
-bar/col/area/histogram → identity, stack, fill, dodge; point → identity, jitter, nudge;
+bar/col/area/histogram → identity, stack, fill, dodge; point/jitter → identity, jitter, nudge;
 boxplot → dodge, identity; every other geom → identity only.
 Bar/histogram/density must NOT map aes.y to a field (stat computes y).
+Aliases: jitter (point+jitter), hline/vline (rule), histogram (bar+bin).
 
 ## Scales / facet / coord
 scales.x/y: linear | binned | time | band. Time: {"type":"time","parse":"ymd"} for ISO dates.


### PR DESCRIPTION
## Summary

Implements [issue #818](https://github.com/ljodea/ggsvelte/issues/818): ggplot2-style convenience geom name aliases that normalize to existing marks. No new mark types.

| Alias | Canonical form |
|-------|----------------|
| `jitter` | `point` + `position: "jitter"` |
| `hline` | `rule` (horizontal; annotation `yintercept` or data-driven `aes.y`) |
| `vline` | `rule` (vertical; annotation `xintercept` or data-driven `aes.x`) |

Mirrors the existing `histogram` → `bar` + `stat: "bin"` alias pattern.

### Authoring surfaces

- Spec: `KNOWN_GEOMS`, layer schemas (`JitterLayer` / `HlineLayer` / `VlineLayer`), `GEOM_BRANCHES`, `STYLE_AESTHETIC_GEOMS`, `REQUIRED_CHANNELS`
- `normalize()` pure renames (no params↔positionParams surgery); annotation hline/vline suppress plot-aes inheritance asymmetrically; data-driven forms drop the orthogonal axis
- Builder: `geomJitter({ width, height, seed, ... })` assembles flat jitter keys into `positionParams`; `geomHline` / `geomVline`
- Svelte: `<GeomJitter>`, `<GeomHline>`, `<GeomVline>`
- JSON Schema artifact regenerated; playground prompt lists the aliases

### Intentional subsetting

- No `geom_abline` (tracked separately)
- Jitter width/height/seed live on `positionParams` at the SpecInput/normalize layer (ggplot2 flat call ergonomics only at builder/component)
- hline params do not accept `xintercept`; vline does not accept `yintercept`

### Plan review

TDD plan reviewed by Claude (APPROVE WITH CHANGES): pure rename only for jitter; asymmetric annotation checks for hline/vline; full catalog surfaces. Those review notes were applied.

## Test plan

- [x] `bun test packages/spec` (487 pass) including new `normalize-convenience-geoms.test.ts` and builder sugar cases
- [x] `bun test packages/core` green (aliases never reach core post-normalize)
- [x] `bun run schema:emit`
- [x] Snapshots updated for allowed-geom lists
- [ ] CI green on this PR
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/886" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->