### PR TITLE
feat: stat_align shared continuous-x grid for stack (#815)

### DIFF
--- a/.changeset/815-stat-align.md
+++ b/.changeset/815-stat-align.md
@@ -11,4 +11,6 @@ Add `stat: "align"` on area and line layers. Union all finite x across groups,
 linearly interpolate each series onto that grid, and set y=0 outside a group's
 range so continuous-x stack/fill aligns.
 
-Area/Line use own stat unions (not shared IdentityOrUniqueStat). Migration: none.
+Area/Line use own stat unions (not shared IdentityOrUniqueStat).
+
+Migration: none — additive

--- a/.changeset/815-stat-align.md
+++ b/.changeset/815-stat-align.md
@@ -1,0 +1,14 @@
+---
+"@ggsvelte/spec": minor
+"@ggsvelte/core": minor
+---
+
+<!-- markdownlint-disable MD041 -->
+
+feat: stat_align shared continuous-x grid for stack (#815)
+
+Add `stat: "align"` on area and line layers. Union all finite x across groups,
+linearly interpolate each series onto that grid, and set y=0 outside a group's
+range so continuous-x stack/fill aligns.
+
+Area/Line use own stat unions (not shared IdentityOrUniqueStat). Migration: none.

--- a/apps/docs/src/lib/generated/routes.ts
+++ b/apps/docs/src/lib/generated/routes.ts
@@ -342,6 +342,11 @@ export const DOCS_ROUTES = [
         level: 2,
       },
       {
+        id: "align-shared-continuous-x-grid-for-stack",
+        title: "Align (shared continuous-x grid for stack)",
+        level: 2,
+      },
+      {
         id: "positions",
         title: "Positions",
         level: 2,

--- a/apps/docs/src/lib/generated/search-index.ts
+++ b/apps/docs/src/lib/generated/search-index.ts
@@ -374,6 +374,16 @@ export const DOCS_SEARCH_INDEX = [
     exact: ["Unique (first-wins aesthetic dedupe)"],
   },
   {
+    id: "heading:guide-statistics-positions:align-shared-continuous-x-grid-for-stack",
+    kind: "heading",
+    title: "Align (shared continuous-x grid for stack)",
+    summary:
+      "Align (shared continuous-x grid for stack) in Statistics and positions. Compute summaries and control how derived marks occupy the same coordinate space.",
+    href: "/guide/statistics-positions#align-shared-continuous-x-grid-for-stack",
+    keywords: ["Statistics and positions", "Core grammar"],
+    exact: ["Align (shared continuous-x grid for stack)"],
+  },
+  {
     id: "heading:guide-statistics-positions:positions",
     kind: "heading",
     title: "Positions",

--- a/packages/core/src/pipeline/frame-stats-align.ts
+++ b/packages/core/src/pipeline/frame-stats-align.ts
@@ -1,0 +1,48 @@
+/**
+ * Align stat → LayerFrame (shared x grid + interpolated y per group).
+ */
+import type { ColumnTable } from "../table.js";
+
+import { statAlign } from "../stats/align.js";
+import { carriedColumns, emptyFrameExtras, removedStatWarning } from "./frame-helpers.js";
+import { makeColumnOf, styleColumns } from "./frame-stats-shared.js";
+import { positionColumn } from "./temporal-position.js";
+import type { LayerBinding, LayerFrame, PipelineWarning } from "./types.js";
+import { NO_ROW } from "./types.js";
+
+export function buildAlignFrame(
+  binding: LayerBinding,
+  table: ColumnTable,
+  groups: readonly number[],
+  warnings: PipelineWarning[],
+): LayerFrame {
+  const { index } = binding;
+  const carried = carriedColumns(binding, table);
+  const columnOf = makeColumnOf(binding);
+  const result = statAlign({
+    x: positionColumn(table, binding.xField!, binding.xConversion, binding.xTransform),
+    y: positionColumn(table, binding.yField!, binding.yConversion, binding.yTransform),
+    groups,
+    carried,
+  });
+  removedStatWarning(result.dropped, index, "missing or non-finite x/y before align", warnings);
+  const col = columnOf(result, null);
+  return {
+    binding,
+    table,
+    n: result.x.length,
+    xValues: null,
+    xNumeric: result.x,
+    yValues: null,
+    yNumeric: result.y,
+    groups: result.groups,
+    inputGroups: groups,
+    inputSourceRows: null,
+    rowIndex: Uint32Array.from({ length: result.x.length }, () => NO_ROW),
+    colorValues: col(binding.color.field),
+    fillValues: col(binding.fill.field),
+    ...styleColumns(binding, col, { x: result.x, y: result.y }),
+    labelValues: col(binding.labelField),
+    ...emptyFrameExtras(),
+  };
+}

--- a/packages/core/src/pipeline/frame-stats.ts
+++ b/packages/core/src/pipeline/frame-stats.ts
@@ -4,6 +4,7 @@
  */
 import type { ColumnTable } from "../table.js";
 
+import { buildAlignFrame } from "./frame-stats-align.js";
 import { buildBinFrame, buildCountFrame, buildDensityFrame } from "./frame-stats-binning.js";
 import { buildBoxplotFrame, buildSmoothFrame, buildSummaryFrame } from "./frame-stats-fit.js";
 import { buildUniqueFrame } from "./frame-stats-unique.js";
@@ -21,6 +22,7 @@ export function buildNonIdentityFrame(
   if (stat === "identity") return null;
 
   if (stat === "unique") return buildUniqueFrame(binding, table, groups);
+  if (stat === "align") return buildAlignFrame(binding, table, groups, warnings);
   if (stat === "count") return buildCountFrame(binding, table, groups, warnings);
   if (stat === "bin") return buildBinFrame(binding, table, groups, warnings, advisories, binRange);
   if (stat === "density") return buildDensityFrame(binding, table, groups, warnings);

--- a/packages/core/src/stats/align.ts
+++ b/packages/core/src/stats/align.ts
@@ -1,0 +1,137 @@
+/**
+ * stat_align — interpolate series onto a shared x grid (#815).
+ * Clean-room contract for stacking continuous-x area/line.
+ *
+ * Shared grid = sorted unique finite x across all groups.
+ * Per group: linear interpolation of y onto the grid; outside the group's
+ * observed x range, y = 0 (stack-friendly; matches positionStack's
+ * non-finite→zero-height treatment).
+ *
+ * Within a group, duplicate x keeps the last finite y (stable last-wins).
+ */
+
+import type { CellValue } from "../table.js";
+
+export interface StatAlignInput {
+  readonly x: Float64Array;
+  readonly y: Float64Array;
+  readonly groups: readonly number[];
+  readonly carried: Readonly<Record<string, readonly CellValue[]>>;
+}
+
+export interface StatAlignResult {
+  readonly x: Float64Array;
+  readonly y: Float64Array;
+  readonly groups: number[];
+  readonly carried: Record<string, CellValue[]>;
+  readonly dropped: number;
+}
+
+/** Linear interpolate y at query x given sorted unique (x,y) series. Outside range → 0. */
+export function lerpSeries(xs: Float64Array, ys: Float64Array, query: number): number {
+  const n = xs.length;
+  if (n === 0 || !Number.isFinite(query)) return 0;
+  if (n === 1) return query === xs[0]! ? ys[0]! : 0;
+  if (query < xs[0]! || query > xs[n - 1]!) return 0;
+  // Binary search for rightmost xs[i] <= query
+  let lo = 0;
+  let hi = n - 1;
+  while (lo < hi) {
+    const mid = (lo + hi + 1) >> 1;
+    if (xs[mid]! <= query) lo = mid;
+    else hi = mid - 1;
+  }
+  const xLo = xs[lo]!;
+  const yLo = ys[lo]!;
+  if (xLo === query) return yLo;
+  if (lo === n - 1) return yLo;
+  const x1 = xs[lo + 1]!;
+  const y1 = ys[lo + 1]!;
+  const t = (query - xLo) / (x1 - xLo);
+  return yLo + t * (y1 - yLo);
+}
+
+/** Collapse a group's rows to sorted unique x with last-wins y. */
+export function seriesFromRows(
+  x: Float64Array,
+  y: Float64Array,
+  rows: readonly number[],
+): { xs: Float64Array; ys: Float64Array } | null {
+  const pts: { x: number; y: number }[] = [];
+  for (const row of rows) {
+    const xv = x[row]!;
+    const yv = y[row]!;
+    if (!Number.isFinite(xv) || !Number.isFinite(yv)) continue;
+    pts.push({ x: xv, y: yv });
+  }
+  if (pts.length === 0) return null;
+  pts.sort((a, b) => a.x - b.x || 0);
+  // Last-wins for duplicate x
+  const uniqX: number[] = [];
+  const uniqY: number[] = [];
+  for (const p of pts) {
+    if (uniqX.length > 0 && uniqX.at(-1) === p.x) {
+      uniqY[uniqY.length - 1] = p.y;
+    } else {
+      uniqX.push(p.x);
+      uniqY.push(p.y);
+    }
+  }
+  return { xs: Float64Array.from(uniqX), ys: Float64Array.from(uniqY) };
+}
+
+export function statAlign(input: StatAlignInput): StatAlignResult {
+  const { x, y, groups, carried } = input;
+  const byGroup = new Map<number, number[]>();
+  let dropped = 0;
+  const allX = new Set<number>();
+
+  for (let row = 0; row < x.length; row++) {
+    const xv = x[row]!;
+    const yv = y[row]!;
+    if (!Number.isFinite(xv) || !Number.isFinite(yv)) {
+      dropped++;
+      continue;
+    }
+    allX.add(xv);
+    const g = groups[row] ?? 0;
+    let list = byGroup.get(g);
+    if (list === undefined) {
+      list = [];
+      byGroup.set(g, list);
+    }
+    list.push(row);
+  }
+
+  const grid = Float64Array.from([...allX].toSorted((a, b) => a - b));
+  const outX: number[] = [];
+  const outY: number[] = [];
+  const outG: number[] = [];
+  const carriedOut: Record<string, CellValue[]> = {};
+  for (const key of Object.keys(carried)) carriedOut[key] = [];
+
+  const groupIds = [...byGroup.keys()].toSorted((a, b) => a - b);
+  for (const g of groupIds) {
+    const rows = byGroup.get(g)!;
+    const series = seriesFromRows(x, y, rows);
+    if (series === null) continue;
+    const rep = rows[0]!;
+    for (let i = 0; i < grid.length; i++) {
+      const xq = grid[i]!;
+      outX.push(xq);
+      outY.push(lerpSeries(series.xs, series.ys, xq));
+      outG.push(g);
+      for (const key of Object.keys(carriedOut)) {
+        carriedOut[key]!.push(carried[key]![rep]!);
+      }
+    }
+  }
+
+  return {
+    x: Float64Array.from(outX),
+    y: Float64Array.from(outY),
+    groups: outG,
+    carried: carriedOut,
+    dropped,
+  };
+}

--- a/packages/core/tests/pipeline-m2/align.test.ts
+++ b/packages/core/tests/pipeline-m2/align.test.ts
@@ -31,7 +31,7 @@ describe("stat align (#815)", () => {
     expect(batch.pathOffsets.length).toBe(3);
     // Domain y should cover stacked total at x=2: 3+4=7
     if (model.scales.y.type !== "band") {
-      expect(model.scales.y.domain[1] as number).toBeGreaterThanOrEqual(7 - 1e-9);
+      expect(model.scales.y.domain[1]).toBeGreaterThanOrEqual(7 - 1e-9);
     }
   });
 

--- a/packages/core/tests/pipeline-m2/align.test.ts
+++ b/packages/core/tests/pipeline-m2/align.test.ts
@@ -1,0 +1,45 @@
+/**
+ * M2 pipeline — stat align for continuous-x area stack (#815).
+ */
+import { describe, expect, it } from "bun:test";
+import { aes, gg } from "@ggsvelte/spec";
+import { runPipeline } from "../../src/pipeline.ts";
+import type { PathsBatch } from "../../src/scene.ts";
+import { size } from "./fixtures.ts";
+
+describe("stat align (#815)", () => {
+  it("enables stacked area when groups have different x samples", () => {
+    // Without align, different x keys don't co-stack; with align, both groups
+    // share x={0,1,2} and stack produces ymin/ymax.
+    const model = runPipeline(
+      gg(
+        {
+          x: [0, 2, 1, 2],
+          y: [1, 3, 2, 4],
+          g: ["a", "a", "b", "b"],
+        },
+        aes({ x: "x", y: "y", fill: "g" }),
+      )
+        .geomArea({ stat: "align", position: "stack" })
+        .spec(),
+      size,
+    );
+    const batch = model.scene.batches[0] as PathsBatch;
+    expect(batch.kind).toBe("paths");
+    expect(batch.closed).toBe(true);
+    // Two groups → two filled subpaths
+    expect(batch.pathOffsets.length).toBe(3);
+    // Domain y should cover stacked total at x=2: 3+4=7
+    if (model.scales.y.type !== "band") {
+      expect(model.scales.y.domain[1] as number).toBeGreaterThanOrEqual(7 - 1e-9);
+    }
+  });
+
+  it("rejects stat align on point", () => {
+    expect(() =>
+      gg({ x: [0, 1], y: [0, 1] }, aes({ x: "x", y: "y" }))
+        .layer({ geom: "point", stat: "align" as "identity", aes: { x: "x", y: "y" } })
+        .spec(),
+    ).toThrow();
+  });
+});

--- a/packages/core/tests/stats-align.test.ts
+++ b/packages/core/tests/stats-align.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Pure stat_align (#815).
+ */
+import { describe, expect, it } from "bun:test";
+
+import { lerpSeries, seriesFromRows, statAlign } from "../src/stats/align.ts";
+
+describe("lerpSeries", () => {
+  it("interpolates between knots and zeros outside range", () => {
+    const xs = Float64Array.of(0, 2, 4);
+    const ys = Float64Array.of(0, 10, 0);
+    expect(lerpSeries(xs, ys, 1)).toBeCloseTo(5, 12);
+    expect(lerpSeries(xs, ys, 0)).toBeCloseTo(0, 12);
+    expect(lerpSeries(xs, ys, 4)).toBeCloseTo(0, 12);
+    expect(lerpSeries(xs, ys, -1)).toBe(0);
+    expect(lerpSeries(xs, ys, 5)).toBe(0);
+  });
+});
+
+describe("seriesFromRows", () => {
+  it("last-wins on duplicate x", () => {
+    const x = Float64Array.of(1, 1, 2);
+    const y = Float64Array.of(3, 9, 4);
+    const s = seriesFromRows(x, y, [0, 1, 2]);
+    expect(s).not.toBeNull();
+    expect([...s!.xs]).toEqual([1, 2]);
+    expect([...s!.ys]).toEqual([9, 4]);
+  });
+});
+
+describe("statAlign", () => {
+  it("aligns two groups onto the union x grid with zeros outside range", () => {
+    // Group 0: (0,1), (2,3) — missing x=1
+    // Group 1: (1,5), (2,7) — missing x=0
+    const result = statAlign({
+      x: Float64Array.of(0, 2, 1, 2),
+      y: Float64Array.of(1, 3, 5, 7),
+      groups: [0, 0, 1, 1],
+      carried: { g: ["a", "a", "b", "b"] },
+    });
+    // grid = [0,1,2]; 2 groups × 3 = 6 rows
+    expect(result.x.length).toBe(6);
+    // group 0 at x=1: lerp(0,1)→(2,3) at 1 → 2
+    const g0 = [0, 1, 2].map((i) => result.y[i]!);
+    expect(g0[0]).toBeCloseTo(1, 12);
+    expect(g0[1]).toBeCloseTo(2, 12);
+    expect(g0[2]).toBeCloseTo(3, 12);
+    // group 1 at x=0: outside → 0
+    const g1 = [3, 4, 5].map((i) => result.y[i]!);
+    expect(g1[0]).toBe(0);
+    expect(g1[1]).toBeCloseTo(5, 12);
+    expect(g1[2]).toBeCloseTo(7, 12);
+    // carried first-seen per group
+    expect(result.carried.g![0]).toBe("a");
+    expect(result.carried.g![3]).toBe("b");
+  });
+});

--- a/packages/spec/schema/v0.json
+++ b/packages/spec/schema/v0.json
@@ -1438,9 +1438,14 @@
               "type": "string",
               "const": "bin",
               "description": "Continuous x binned; the canonical form of geom freqpoly. Do NOT map aes.y to a field; y defaults to {\"stat\": \"count\"}."
+            },
+            {
+              "type": "string",
+              "const": "align",
+              "description": "Interpolate each group onto the union of finite x values so continuous-x stack/fill aligns (#815). Outside a group's x range y is 0."
             }
           ],
-          "description": "Line stat: \"identity\" (default), \"unique\" (first-wins dedupe), or \"bin\" (freqpoly)."
+          "description": "Line stat: \"identity\" (default), \"unique\", \"bin\" (freqpoly), or \"align\" (shared x grid)."
         },
         "position": {
           "type": "string",
@@ -1948,10 +1953,27 @@
         "geom": {
           "type": "string",
           "const": "area",
-          "description": "Area geometry: a filled region from the y baseline (zero) to the y value, connected in x order per group. Use for stacked composition-over-time charts."
+          "description": "Area geometry: a filled region from the y baseline (zero) to the y value, connected in x order per group. Use for stacked composition-over-time charts. With stat align, series with different x samples share a common grid for stack/fill."
         },
         "stat": {
-          "$ref": "#/$defs/IdentityOrUniqueStat"
+          "anyOf": [
+            {
+              "type": "string",
+              "const": "identity",
+              "description": "Draw each data row as-is (default)."
+            },
+            {
+              "type": "string",
+              "const": "unique",
+              "description": "Drop duplicate rows on mapped aesthetics before drawing (first wins)."
+            },
+            {
+              "type": "string",
+              "const": "align",
+              "description": "Interpolate each group onto the union of finite x values so continuous-x stack/fill aligns (#815). Outside a group's x range y is 0."
+            }
+          ],
+          "description": "Area stat: \"identity\" (default), \"unique\" (first-wins dedupe), or \"align\" (shared x grid for stacking)."
         },
         "position": {
           "$ref": "#/$defs/StackablePosition"
@@ -1971,7 +1993,7 @@
         }
       },
       "additionalProperties": false,
-      "description": "An area layer. Requires x and y channels; rows are sorted by x within each group. Default position \"stack\"."
+      "description": "An area layer. Requires x and y channels; rows are sorted by x within each group. Default position \"stack\". Use stat \"align\" when groups have different continuous x samples."
     },
     "RibbonLayer": {
       "type": "object",

--- a/packages/spec/src/builder-options.ts
+++ b/packages/spec/src/builder-options.ts
@@ -49,7 +49,7 @@ export interface GeomLineOptions extends LineParams, GeomDataOption {
   aes?: AesInput;
   render?: RenderBackend;
   /** "identity" (default) or "unique" (dedupe mapped aesthetics; first wins). */
-  stat?: "identity" | "unique";
+  stat?: "identity" | "unique" | "align";
 }
 
 /** Path-layer sugar options (data-order polylines; style-only — no bin knobs). */
@@ -148,7 +148,7 @@ export interface GeomAreaOptions extends AreaParams, GeomDataOption {
   aes?: AesInput;
   render?: RenderBackend;
   /** "identity" (default) or "unique" (dedupe mapped aesthetics; first wins). */
-  stat?: "identity" | "unique";
+  stat?: "identity" | "unique" | "align";
   position?: StackablePosition;
 }
 

--- a/packages/spec/src/builder-options.ts
+++ b/packages/spec/src/builder-options.ts
@@ -48,8 +48,11 @@ export interface GeomPointOptions extends PointParams, GeomDataOption {
 export interface GeomLineOptions extends LineParams, GeomDataOption {
   aes?: AesInput;
   render?: RenderBackend;
-  /** "identity" (default) or "unique" (dedupe mapped aesthetics; first wins). */
-  stat?: "identity" | "unique" | "align";
+  /**
+   * identity (default) | unique (#813) | bin (freqpoly / #796) |
+   * align (shared continuous-x grid for stack/fill; #815).
+   */
+  stat?: "identity" | "unique" | "bin" | "align";
 }
 
 /** Path-layer sugar options (data-order polylines; style-only — no bin knobs). */

--- a/packages/spec/src/normalize-input.ts
+++ b/packages/spec/src/normalize-input.ts
@@ -112,8 +112,8 @@ export interface PointLayerInput extends LayerInputBase {
 
 export interface LineLayerInput extends LayerInputBase {
   geom: "line";
-  /** identity | unique (#813) | bin (freqpoly / #796) */
-  stat?: "identity" | "unique" | "bin";
+  /** identity | unique (#813) | bin (freqpoly / #796) | align (#815) */
+  stat?: "identity" | "unique" | "bin" | "align";
   position?: "identity";
   params?: LineParams;
 }
@@ -154,7 +154,7 @@ export interface FreqpolyLayerInput extends LayerInputBase {
 
 export interface AreaLayerInput extends LayerInputBase {
   geom: "area";
-  stat?: "identity" | "unique";
+  stat?: "identity" | "unique" | "align";
   position?: StackablePosition;
   params?: AreaParams;
 }

--- a/packages/spec/src/schema-catalog.ts
+++ b/packages/spec/src/schema-catalog.ts
@@ -72,6 +72,7 @@ export const KNOWN_STATS = [
   "boxplot",
   "density",
   "summary",
+  "align",
 ] as const;
 export type StatName = (typeof KNOWN_STATS)[number];
 

--- a/packages/spec/src/schema-declarations.ts
+++ b/packages/spec/src/schema-declarations.ts
@@ -1527,10 +1527,14 @@ export const SpecDeclarations = {
               description:
                 'Continuous x binned; the canonical form of geom freqpoly. Do NOT map aes.y to a field; y defaults to {"stat": "count"}.',
             }),
+            Type.Literal("align", {
+              description:
+                "Interpolate each group onto the union of finite x values so continuous-x stack/fill aligns (#815). Outside a group's x range y is 0.",
+            }),
           ],
           {
             description:
-              'Line stat: "identity" (default), "unique" (first-wins dedupe), or "bin" (freqpoly).',
+              'Line stat: "identity" (default), "unique", "bin" (freqpoly), or "align" (shared x grid).',
           },
         ),
       ),
@@ -1931,9 +1935,28 @@ export const SpecDeclarations = {
     {
       geom: Type.Literal("area", {
         description:
-          "Area geometry: a filled region from the y baseline (zero) to the y value, connected in x order per group. Use for stacked composition-over-time charts.",
+          "Area geometry: a filled region from the y baseline (zero) to the y value, connected in x order per group. Use for stacked composition-over-time charts. With stat align, series with different x samples share a common grid for stack/fill.",
       }),
-      stat: Type.Optional(Type.Ref("IdentityOrUniqueStat")),
+      stat: Type.Optional(
+        Type.Union(
+          [
+            Type.Literal("identity", {
+              description: "Draw each data row as-is (default).",
+            }),
+            Type.Literal("unique", {
+              description: "Drop duplicate rows on mapped aesthetics before drawing (first wins).",
+            }),
+            Type.Literal("align", {
+              description:
+                "Interpolate each group onto the union of finite x values so continuous-x stack/fill aligns (#815). Outside a group's x range y is 0.",
+            }),
+          ],
+          {
+            description:
+              'Area stat: "identity" (default), "unique" (first-wins dedupe), or "align" (shared x grid for stacking).',
+          },
+        ),
+      ),
       position: Type.Optional(Type.Ref("StackablePosition")),
       render: Type.Optional(Type.Ref("RenderBackend")),
       aes: Type.Optional(Type.Ref("Aes")),
@@ -1948,7 +1971,7 @@ export const SpecDeclarations = {
     {
       additionalProperties: false,
       description:
-        'An area layer. Requires x and y channels; rows are sorted by x within each group. Default position "stack".',
+        'An area layer. Requires x and y channels; rows are sorted by x within each group. Default position "stack". Use stat "align" when groups have different continuous x samples.',
     },
   ),
 

--- a/packages/svelte/src/lib/geoms/GeomArea.svelte
+++ b/packages/svelte/src/lib/geoms/GeomArea.svelte
@@ -18,8 +18,11 @@
     data?: DataInput | readonly Record<string, unknown>[];
     /** Layer-level aes (bare-string shorthand allowed); merges over plot aes. */
     aes?: AesInput;
-    /** "identity" (default) or "unique" (first-wins aesthetic dedupe; #813). */
-    stat?: "identity" | "unique";
+    /**
+     * identity (default) | unique (#813) |
+     * align (shared continuous-x grid for stack/fill; #815).
+     */
+    stat?: "identity" | "unique" | "align";
     /** Position adjustment: "stack" (default) | "fill" | "identity". */
     position?: StackablePosition;
   }

--- a/packages/svelte/src/lib/geoms/GeomLine.svelte
+++ b/packages/svelte/src/lib/geoms/GeomLine.svelte
@@ -12,8 +12,11 @@
     data?: DataInput | readonly Record<string, unknown>[];
     /** Layer-level aes (bare-string shorthand allowed); merges over plot aes. */
     aes?: AesInput;
-    /** identity | unique (#813) | bin (freqpoly form; #796). */
-    stat?: "identity" | "unique" | "bin";
+    /**
+     * identity | unique (#813) | bin (freqpoly; #796) |
+     * align (shared continuous-x grid for stack/fill; #815).
+     */
+    stat?: "identity" | "unique" | "bin" | "align";
   }
 
   const props: Props = $props();

--- a/scripts/llms-guide-content.ts
+++ b/scripts/llms-guide-content.ts
@@ -252,6 +252,27 @@ col, area, rect, ribbon, rule, segment, errorbar).
 [stat unique overplotting](/examples/point/stat-unique): stacked identical
 \`(x, y, series)\` triples collapse to one mark.
 
+## Align (shared continuous-x grid for stack)
+
+\`stat: "align"\` (ggplot2 \`stat_align\`) is for continuous-x \`area\` / \`line\`
+when series sample different x values. It unions finite x across groups,
+linearly interpolates each series onto that shared grid, and sets y to 0
+outside a group's observed x range so \`position: "stack"\` / \`"fill"\` can
+compose without jagged seams.
+
+\`\`\`ts fragment
+gg(data, aes({ x: "t", y: "v", fill: "series" }))
+  .geomArea({ stat: "align", position: "stack" })
+  .spec();
+\`\`\`
+
+\`\`\`svelte fragment
+<GeomArea stat="align" position="stack" />
+\`\`\`
+
+Available on **area** and **line** only (not point or shared identity-only
+geoms). Outside a group's x span y is 0 (stack-friendly).
+
 ## Positions
 
 Stack sums, dodge side-by-side groups, fill normalizes each stack to one, jitter


### PR DESCRIPTION
## Summary

- Implements **stat_align** (#815): union finite x across groups, linearly interpolate each series onto that shared grid, y=0 outside a group's observed x range so continuous-x `position: "stack"` / `"fill"` on area/line works when series sample different x.
- Area and Line get their own stat unions (`identity | unique | align`); align is **not** on the shared IdentityOrUniqueStat (Claude plan review).
- Pure `statAlign` + `lerpSeries` + pipeline `buildAlignFrame`; rejects align on unsupported geoms (e.g. point).

## Test plan

- [x] `bun test packages/core/tests/stats-align.test.ts packages/core/tests/pipeline-m2/align.test.ts` (5 pass)
- [ ] CI green on PR

Closes #815

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/896" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->