### PR TITLE
fix: align gen-scale-children color-fill count comments (#870)

### DIFF
--- a/scripts/gen-scale-children.ts
+++ b/scripts/gen-scale-children.ts
@@ -65,11 +65,11 @@ function colourAliases(stem: string): string[] {
  *   position-binned      2
  *   position-temporal    4
  *   position-discrete    2
- *   color-fill          24
+ *   color-fill          30
  *   numeric-style       21
  *   finite-style         8
  *   ----------------------
- *   69 component files + 12 Colour aliases
+ *   75 component files + 15 Colour aliases
  */
 export const SHELL_MANIFEST: readonly ShellSpec[] = [
   // --- position-continuous (8) ---------------------------------------------
@@ -127,7 +127,7 @@ export const SHELL_MANIFEST: readonly ShellSpec[] = [
     "DiscretePositionScaleOptions",
   ]),
 
-  // --- color-fill (24 components + 12 Colour aliases) ----------------------
+  // --- color-fill (30 components + 15 Colour aliases) ----------------------
   // optionsTypes match the slice-3 hand-written shells exactly.
   shell(
     "scaleColorContinuous",


### PR DESCRIPTION
## Summary

Follow-up for unrebutted post-merge/pre-merge-async Devin finding on #870.

**Finding:** `scripts/gen-scale-children.ts` section header and shell-ledger comment still said color-fill was 24 components + 12 Colour aliases (69 shells total) after hue/grey/ordinal shells landed.

**Root cause:** Cardinality comments were not updated when the manifest grew; tests already assert the real numbers (`SHELL_MANIFEST` length 75, 15 aliases, `color-fill` family 30).

**Fix:** Update both comments to 30 components + 15 Colour aliases / 75 shells. No runtime change.

## Verification

- `bun test scripts/gen-scale-children.test.ts` — cardinality test passes (`75 component files + 15 aliases`, `color-fill === 30`)
- Comment-only change (no behavior)

Parent disposition: will reply on #870 thread after open.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/898" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->