### PR TITLE
fix(curve): linewidth default 1 + endpoint error geom name

### DIFF
--- a/packages/core/src/pipeline/geometry-curve.ts
+++ b/packages/core/src/pipeline/geometry-curve.ts
@@ -15,7 +15,7 @@ import { tessellateCurve } from "../stats/curve.js";
 import type { LayerFrame, PipelineWarning, ResolvedColorScale } from "./types.js";
 import { colorOf } from "./types.js";
 import type { Frame } from "./geometry-shared.js";
-import { DEFAULT_LINEWIDTH, positionOf, removedWarning } from "./geometry-shared.js";
+import { DEFAULT_RULE_LINEWIDTH, positionOf, removedWarning } from "./geometry-shared.js";
 import {
   indexedStyleVector,
   numericStyleVector,
@@ -136,7 +136,7 @@ export function curveBatch(
     linewidth:
       typeof literalLinewidth === "number"
         ? literalLinewidth
-        : (params.linewidth ?? DEFAULT_LINEWIDTH),
+        : (params.linewidth ?? DEFAULT_RULE_LINEWIDTH),
     ...(linewidths !== undefined && { linewidths }),
     alpha:
       alphas === undefined

--- a/packages/core/tests/pipeline-m2/curve.test.ts
+++ b/packages/core/tests/pipeline-m2/curve.test.ts
@@ -84,4 +84,17 @@ describe("curve geom (#794)", () => {
     );
     expect((def.scene.batches[0] as PathsBatch).linecap).toBe("butt");
   });
+
+  it("defaults linewidth to 1 (segment/rule default, schema Default 1)", () => {
+    const model = runPipeline(
+      gg(
+        { x: [0], y: [0], xend: [1], yend: [1] },
+        aes({ x: "x", y: "y", xend: "xend", yend: "yend" }),
+      )
+        .geomCurve({ ncp: 2 })
+        .spec(),
+      size,
+    );
+    expect((model.scene.batches[0] as PathsBatch).linewidth).toBe(1);
+  });
 });

--- a/packages/spec/src/validate-structure-layers.ts
+++ b/packages/spec/src/validate-structure-layers.ts
@@ -317,7 +317,7 @@ export function layerStructuralErrors(
       errors.push({
         code: "missing-required-channel",
         path: `${layerPath}/aes/${channel}`,
-        message: `The segment geom requires aes.${channel} to map a data field (not a constant or stat).`,
+        message: `The ${geom} geom requires aes.${channel} to map a data field (not a constant or stat).`,
         fix: {
           description: `Map "${channel}" to a data field.`,
           example: { [channel]: CHANNEL_FIX_EXAMPLE },

--- a/packages/spec/tests/segment.test.ts
+++ b/packages/spec/tests/segment.test.ts
@@ -95,5 +95,31 @@ describe("segment geom (spec)", () => {
     if (result.ok) return;
     expect(result.errors.some((e) => e.code === "missing-required-channel")).toBe(true);
     expect(result.errors.map((e) => e.path).join(" ")).toMatch(/xend|yend/);
+    expect(result.errors.map((e) => e.message).join(" ")).toMatch(/segment geom/);
+  });
+
+  it("rejects constant curve endpoints and names curve (not segment) in the message", () => {
+    const result = validate(
+      {
+        data: { values: [{ x: 1, y: 2 }] },
+        layers: [
+          {
+            geom: "curve",
+            aes: {
+              x: { field: "x" },
+              y: { field: "y" },
+              xend: { value: 3 },
+              yend: { value: 4 },
+            },
+          },
+        ],
+      },
+      {},
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    const messages = result.errors.map((e) => e.message).join(" ");
+    expect(messages).toMatch(/curve geom/);
+    expect(messages).not.toMatch(/segment geom/);
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #894 (merged). Devin re-review on the final head raised two valid P2s after the squash raced the shepherd loop:

1. **Default linewidth** — curveBatch fell back to DEFAULT_LINEWIDTH (1.5) while CurveParams docs and segment use 1 (DEFAULT_RULE_LINEWIDTH).
2. **Validation copy** — shared segment/curve field-endpoint check still said the segment geom when the layer was curve.

## Test plan

- [x] bun test packages/core/tests/pipeline-m2/curve.test.ts packages/spec/tests/segment.test.ts
- [ ] CI green

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/903" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->