### PR TITLE
feat: multi-part SF labels via stat_sf_coordinates (#809 phase 5)

### DIFF
--- a/packages/core/src/pipeline/frame-stats-sf-coordinates.ts
+++ b/packages/core/src/pipeline/frame-stats-sf-coordinates.ts
@@ -1,5 +1,6 @@
 /**
- * stat_sf_coordinates (#809 phase 2): one (x,y) per feature from portable GeoJSON.
+ * stat_sf_coordinates (#809 phase 2 + multi-part labels phase 5):
+ * one (x,y) per geometry part from portable GeoJSON (Multi* expands).
  */
 import { ColumnTable, type CellValue } from "../table.js";
 
@@ -7,7 +8,7 @@ import { emptyFrameExtras } from "./frame-helpers.js";
 import {
   geometryFieldName,
   parseSfGeometry,
-  representativePoint,
+  representativePoints,
   sfKindOf,
 } from "./sf-geometry.js";
 import type { LayerBinding, LayerFrame, PipelineWarning } from "./types.js";
@@ -52,16 +53,19 @@ export function buildSfCoordinatesFrame(
     const parsed = parseSfGeometry(geomCol[row]!, `/layers/${index}/data/${field}`);
     // Validate type is in the supported family (throws on GeometryCollection).
     sfKindOf(parsed.type);
-    const pt = representativePoint(parsed.type, parsed.coordinates);
-    if (pt === null) {
+    const pts = representativePoints(parsed.type, parsed.coordinates);
+    if (pts.length === 0) {
+      // One drop per input feature with no usable part (not per empty part).
       dropped++;
       continue;
     }
-    outX.push(pt[0]);
-    outY.push(pt[1]);
-    outGroups.push(groups[row] ?? 0);
-    outRowIndex.push(row);
-    valueRows.push(row);
+    for (const pt of pts) {
+      outX.push(pt[0]);
+      outY.push(pt[1]);
+      outGroups.push(groups[row] ?? 0);
+      outRowIndex.push(row);
+      valueRows.push(row);
+    }
   }
 
   if (dropped > 0) {

--- a/packages/core/src/pipeline/sf-geometry.ts
+++ b/packages/core/src/pipeline/sf-geometry.ts
@@ -126,35 +126,57 @@ function polygonCentroid(ring: unknown): SfPosition | null {
 }
 
 /**
- * One representative point per feature (ggplot2 stat_sf_coordinates-style).
- * Multi* geometries use the first component only in v1.
+ * One or more representative points for label placement (#809 phase 5).
+ * Multi* geometries expand to **one point per part** (not only the first).
+ * Degenerate / empty parts are skipped.
  */
-export function representativePoint(type: string, coordinates: unknown): SfPosition | null {
-  if (type === "Point") return isFinitePair(coordinates) ? coordinates : null;
+export function representativePoints(type: string, coordinates: unknown): readonly SfPosition[] {
+  if (type === "Point") return isFinitePair(coordinates) ? [coordinates] : [];
   if (type === "MultiPoint") {
-    if (!Array.isArray(coordinates)) return null;
+    if (!Array.isArray(coordinates)) return [];
     const pts: SfPosition[] = [];
     for (const c of coordinates) {
       if (isFinitePair(c)) pts.push(c);
     }
-    return meanPosition(pts);
+    return pts;
   }
-  if (type === "LineString") return meanPosition(ringPositions(coordinates));
+  if (type === "LineString") {
+    const m = meanPosition(ringPositions(coordinates));
+    return m === null ? [] : [m];
+  }
   if (type === "MultiLineString") {
-    if (!Array.isArray(coordinates) || coordinates.length === 0) return null;
-    return meanPosition(ringPositions(coordinates[0]));
+    if (!Array.isArray(coordinates)) return [];
+    const out: SfPosition[] = [];
+    for (const line of coordinates) {
+      const m = meanPosition(ringPositions(line));
+      if (m !== null) out.push(m);
+    }
+    return out;
   }
   if (type === "Polygon") {
-    if (!Array.isArray(coordinates) || coordinates.length === 0) return null;
-    return polygonCentroid(coordinates[0]);
+    if (!Array.isArray(coordinates) || coordinates.length === 0) return [];
+    const c = polygonCentroid(coordinates[0]);
+    return c === null ? [] : [c];
   }
   if (type === "MultiPolygon") {
-    if (!Array.isArray(coordinates) || coordinates.length === 0) return null;
-    const poly = coordinates[0];
-    if (!Array.isArray(poly) || poly.length === 0) return null;
-    return polygonCentroid(poly[0]);
+    if (!Array.isArray(coordinates)) return [];
+    const out: SfPosition[] = [];
+    for (const poly of coordinates) {
+      if (!Array.isArray(poly) || poly.length === 0) continue;
+      const c = polygonCentroid(poly[0]);
+      if (c !== null) out.push(c);
+    }
+    return out;
   }
-  return null;
+  return [];
+}
+
+/**
+ * First representative point (compat for single-point consumers).
+ * Prefer {@link representativePoints} for Multi* label expansion.
+ */
+export function representativePoint(type: string, coordinates: unknown): SfPosition | null {
+  return representativePoints(type, coordinates)[0] ?? null;
 }
 
 export function geometryFieldName(params: { geometry?: string } | undefined): string {

--- a/packages/core/tests/pipeline-m2/geom-sf-text.test.ts
+++ b/packages/core/tests/pipeline-m2/geom-sf-text.test.ts
@@ -97,6 +97,68 @@ describe("geom_sf_text / stat_sf_coordinates", () => {
     expect(batch.texts).toEqual(["a", "b"]);
   });
 
+  it("places one label per MultiPolygon part (same feature attrs)", () => {
+    const multi = geo({
+      type: "MultiPolygon",
+      coordinates: [
+        [
+          [
+            [0, 0],
+            [2, 0],
+            [2, 2],
+            [0, 2],
+            [0, 0],
+          ],
+        ],
+        [
+          [
+            [10, 10],
+            [12, 10],
+            [12, 12],
+            [10, 12],
+            [10, 10],
+          ],
+        ],
+      ],
+    });
+    const model = runPipeline(
+      gg({ geometry: [multi], name: ["islands"] }, aes({ label: "name" }))
+        .geomSfText()
+        .spec(),
+      size,
+    );
+    const batch = model.scene.batches[0] as GlyphsBatch;
+    expect(batch.texts).toEqual(["islands", "islands"]);
+    // Two distinct panel positions (centroids (1,1) vs (11,11)).
+    expect(batch.positions.length / 2).toBe(2);
+    expect(batch.positions[0]!).not.toBe(batch.positions[2]!);
+  });
+
+  it("places one label per MultiPoint vertex", () => {
+    const model = runPipeline(
+      gg(
+        {
+          geometry: [
+            geo({
+              type: "MultiPoint",
+              coordinates: [
+                [0, 0],
+                [5, 5],
+              ],
+            }),
+          ],
+          name: ["pts"],
+        },
+        aes({ label: "name" }),
+      )
+        .geomSfText()
+        .spec(),
+      size,
+    );
+    const batch = model.scene.batches[0] as GlyphsBatch;
+    expect(batch.texts).toEqual(["pts", "pts"]);
+  });
+
   it("uses exact auto hit mode", () => {
     const model = runPipeline(
       gg(

--- a/packages/core/tests/pipeline-m2/sf-geometry.test.ts
+++ b/packages/core/tests/pipeline-m2/sf-geometry.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Pure portable GeoJSON helpers for geom_sf / stat_sf_coordinates (#809).
+ */
+import { describe, expect, it } from "bun:test";
+
+import { representativePoint, representativePoints } from "../../src/pipeline/sf-geometry.ts";
+
+describe("representativePoints (#809 multi-part labels)", () => {
+  it("returns one point for Point / LineString / Polygon", () => {
+    expect(representativePoints("Point", [1, 2])).toEqual([[1, 2]]);
+    expect(
+      representativePoints("LineString", [
+        [0, 0],
+        [2, 0],
+        [2, 2],
+      ]),
+    ).toEqual([[4 / 3, 2 / 3]]);
+    // Unit square [0,2]×[0,2] exterior → centroid (1,1)
+    expect(
+      representativePoints("Polygon", [
+        [
+          [0, 0],
+          [2, 0],
+          [2, 2],
+          [0, 2],
+          [0, 0],
+        ],
+      ]),
+    ).toEqual([[1, 1]]);
+  });
+
+  it("returns one point per MultiPoint vertex", () => {
+    expect(
+      representativePoints("MultiPoint", [
+        [0, 0],
+        [1, 1],
+        [2, 3],
+      ]),
+    ).toEqual([
+      [0, 0],
+      [1, 1],
+      [2, 3],
+    ]);
+  });
+
+  it("returns one centroid per MultiPolygon part", () => {
+    const pts = representativePoints("MultiPolygon", [
+      [
+        [
+          [0, 0],
+          [2, 0],
+          [2, 2],
+          [0, 2],
+          [0, 0],
+        ],
+      ],
+      [
+        [
+          [10, 10],
+          [12, 10],
+          [12, 12],
+          [10, 12],
+          [10, 10],
+        ],
+      ],
+    ]);
+    expect(pts).toEqual([
+      [1, 1],
+      [11, 11],
+    ]);
+  });
+
+  it("returns one vertex-mean per MultiLineString part", () => {
+    expect(
+      representativePoints("MultiLineString", [
+        [
+          [0, 0],
+          [2, 0],
+        ],
+        [
+          [10, 10],
+          [10, 12],
+        ],
+      ]),
+    ).toEqual([
+      [1, 0],
+      [10, 11],
+    ]);
+  });
+
+  it("skips empty / degenerate Multi* parts", () => {
+    expect(
+      representativePoints("MultiPoint", [
+        [Number.NaN, 0],
+        [1, 2],
+      ]),
+    ).toEqual([[1, 2]]);
+    expect(
+      representativePoints("MultiPolygon", [
+        [[]],
+        [
+          [
+            [0, 0],
+            [2, 0],
+            [2, 2],
+            [0, 2],
+            [0, 0],
+          ],
+        ],
+      ]),
+    ).toEqual([[1, 1]]);
+  });
+
+  it("representativePoint remains first of multi-part list (compat)", () => {
+    expect(
+      representativePoint("MultiPolygon", [
+        [
+          [
+            [0, 0],
+            [2, 0],
+            [2, 2],
+            [0, 2],
+            [0, 0],
+          ],
+        ],
+        [
+          [
+            [10, 10],
+            [12, 10],
+            [12, 12],
+            [10, 12],
+            [10, 10],
+          ],
+        ],
+      ]),
+    ).toEqual([1, 1]);
+  });
+});

--- a/packages/spec/schema/v0.json
+++ b/packages/spec/schema/v0.json
@@ -2757,7 +2757,7 @@
         "stat": {
           "type": "string",
           "const": "sf_coordinates",
-          "description": "Extract one (x,y) representative point per feature from geometry."
+          "description": "Extract (x,y) representative points from geometry (Multi* → one point per part)."
         },
         "position": {
           "type": "string",
@@ -2853,12 +2853,12 @@
         "geom": {
           "type": "string",
           "const": "sf_label",
-          "description": "Simple-features labels with background boxes (ggplot2 geom_sf_label; #809 phase 3): places aes.label at a representative geometry point with a measured rounded rect. color=ink+box stroke; fill=box background."
+          "description": "Simple-features labels with background boxes (ggplot2 geom_sf_label; #809): places aes.label at representative geometry points with a measured rounded rect (Multi* → one label per part). color=ink+box stroke; fill=box background."
         },
         "stat": {
           "type": "string",
           "const": "sf_coordinates",
-          "description": "Extract one (x,y) representative point per feature from geometry."
+          "description": "Extract (x,y) representative points from geometry (Multi* → one point per part)."
         },
         "position": {
           "type": "string",

--- a/packages/spec/schema/v0.json
+++ b/packages/spec/schema/v0.json
@@ -2752,7 +2752,7 @@
         "geom": {
           "type": "string",
           "const": "sf_text",
-          "description": "Simple-features text labels (ggplot2 geom_sf_text; #809 phase 2): places aes.label at a representative point from each GeoJSON Geometry (stat_sf_coordinates)."
+          "description": "Simple-features text labels (ggplot2 geom_sf_text; #809): places aes.label at representative points from each GeoJSON Geometry (stat_sf_coordinates; Multi* expands one label per part)."
         },
         "stat": {
           "type": "string",

--- a/packages/spec/src/schema-declarations.ts
+++ b/packages/spec/src/schema-declarations.ts
@@ -2636,7 +2636,7 @@ export const SpecDeclarations = {
     {
       geom: Type.Literal("sf_text", {
         description:
-          "Simple-features text labels (ggplot2 geom_sf_text; #809 phase 2): places aes.label at a representative point from each GeoJSON Geometry (stat_sf_coordinates).",
+          "Simple-features text labels (ggplot2 geom_sf_text; #809): places aes.label at representative points from each GeoJSON Geometry (stat_sf_coordinates; Multi* expands one label per part).",
       }),
       stat: Type.Optional(
         Type.Literal("sf_coordinates", {

--- a/packages/spec/src/schema-declarations.ts
+++ b/packages/spec/src/schema-declarations.ts
@@ -2640,7 +2640,8 @@ export const SpecDeclarations = {
       }),
       stat: Type.Optional(
         Type.Literal("sf_coordinates", {
-          description: "Extract one (x,y) representative point per feature from geometry.",
+          description:
+            "Extract (x,y) representative points from geometry (Multi* → one point per part).",
         }),
       ),
       position: Type.Optional(
@@ -2732,11 +2733,12 @@ export const SpecDeclarations = {
     {
       geom: Type.Literal("sf_label", {
         description:
-          "Simple-features labels with background boxes (ggplot2 geom_sf_label; #809 phase 3): places aes.label at a representative geometry point with a measured rounded rect. color=ink+box stroke; fill=box background.",
+          "Simple-features labels with background boxes (ggplot2 geom_sf_label; #809): places aes.label at representative geometry points with a measured rounded rect (Multi* → one label per part). color=ink+box stroke; fill=box background.",
       }),
       stat: Type.Optional(
         Type.Literal("sf_coordinates", {
-          description: "Extract one (x,y) representative point per feature from geometry.",
+          description:
+            "Extract (x,y) representative points from geometry (Multi* → one point per part).",
         }),
       ),
       position: Type.Optional(


### PR DESCRIPTION
## Summary

**#809 phase 5** (stacks on #913 / `feat/809-sf-holes`): **multi-part SF labels**.

`stat_sf_coordinates` (and thus `geom_sf_text` / `geom_sf_label`) expands Multi* geometries to **one label per part**.

```ts
// MultiPolygon with two islands → two "islands" labels at each part centroid
gg({ geometry: [multiPolygon], name: ["islands"] }, aes({ label: "name" }))
  .geomSfText()
```

### Contract

| Type | Labels |
|------|--------|
| Point / LineString / Polygon | 1 (unchanged) |
| MultiPoint | 1 per finite point |
| MultiLineString | 1 per line (vertex mean) |
| MultiPolygon | 1 per polygon part (exterior-ring centroid) |
| Attributes | Duplicated from the source feature |
| Dropped | 1 warning unit per input feature with **no** usable part |

### Notes

- Pure seam: `representativePoints()`; `representativePoint()` remains first-of-list for compat
- Claude plan review: **nits approve** — ggplot2 is one-centroid-per-feature; we ship one-per-part as the deferred v1 completion of first-component-only (not a silent flip of a "whole" default we never had)
- Still deferred: CRS / `coord_sf`, GeometryCollection, hole topology under active coord transforms

## Test plan

- [x] `bun test packages/core/tests/pipeline-m2/sf-geometry.test.ts` (6 pure cases)
- [x] `bun test packages/core/tests/pipeline-m2/geom-sf-text.test.ts` (MultiPolygon + MultiPoint)
- [x] geom_sf / sf_label regressions + `tsc -b packages/spec packages/core`
- [x] schema emit

Related: #809

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/914" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->