### PR TITLE
feat: GeometryCollection expand for geom_sf (#809 phase 6)

### DIFF
--- a/packages/core/src/diagnostics.ts
+++ b/packages/core/src/diagnostics.ts
@@ -316,7 +316,7 @@ export const PIPELINE_ERROR_CATALOG = {
   },
   "sf-geometry-unsupported": {
     summary: "geom_sf received a GeoJSON type outside the v1 point/line/polygon families.",
-    fix: "Use Point, MultiPoint, LineString, MultiLineString, Polygon, or MultiPolygon (no GeometryCollection/CRS).",
+    fix: "Use Point/MultiPoint, LineString/MultiLineString, Polygon/MultiPolygon, or GeometryCollection of those families (no CRS).",
   },
   "sf-geometry-mixed": {
     summary: "One geom_sf layer mixes geometry families (point vs line vs polygon).",

--- a/packages/core/src/pipeline/frame-stats-sf-coordinates.ts
+++ b/packages/core/src/pipeline/frame-stats-sf-coordinates.ts
@@ -8,8 +8,7 @@ import { emptyFrameExtras } from "./frame-helpers.js";
 import {
   geometryFieldName,
   parseSfGeometry,
-  representativePoints,
-  sfKindOf,
+  representativePointsForGeometry,
 } from "./sf-geometry.js";
 import type { LayerBinding, LayerFrame, PipelineWarning } from "./types.js";
 import { PipelineError } from "./types.js";
@@ -50,12 +49,12 @@ export function buildSfCoordinatesFrame(
   let dropped = 0;
 
   for (let row = 0; row < table.rowCount; row++) {
-    const parsed = parseSfGeometry(geomCol[row]!, `/layers/${index}/data/${field}`);
-    // Validate type is in the supported family (throws on GeometryCollection).
-    sfKindOf(parsed.type);
-    const pts = representativePoints(parsed.type, parsed.coordinates);
+    const path = `/layers/${index}/data/${field}`;
+    const parsed = parseSfGeometry(geomCol[row]!, path);
+    // GeometryCollection + Multi* expand to one point per part (#809 phase 5–6).
+    const pts = representativePointsForGeometry(parsed, path);
     if (pts.length === 0) {
-      // One drop per input feature with no usable part (not per empty part).
+      // One drop per input feature with no usable part (empty GC / degenerate).
       dropped++;
       continue;
     }

--- a/packages/core/src/pipeline/frame-stats-sf.ts
+++ b/packages/core/src/pipeline/frame-stats-sf.ts
@@ -9,11 +9,13 @@ import { ColumnTable, type CellValue } from "../table.js";
 
 import { emptyFrameExtras } from "./frame-helpers.js";
 import {
+  expandSfLeaves,
   geometryFieldName,
   isFinitePair,
   parseSfGeometry,
   sfKindOf,
   type SfKind,
+  type SfLeaf,
   type SfPosition,
 } from "./sf-geometry.js";
 import type { LayerBinding, LayerFrame, PipelineWarning } from "./types.js";
@@ -148,25 +150,25 @@ export function buildSfFrame(
 
   let ringId = 0;
   let layerKind: SfKind | null = null;
+  const layerPath = `/layers/${index}`;
 
-  for (let row = 0; row < table.rowCount; row++) {
-    const parsed = parseSfGeometry(geomCol[row]!, `/layers/${index}/data/${field}`);
-    const kind = sfKindOf(parsed.type);
+  const emitLeaf = (leaf: SfLeaf, row: number): void => {
+    const kind = sfKindOf(leaf.type);
     if (layerKind === null) layerKind = kind;
     else if (layerKind !== kind) {
       throw new PipelineError(
         "sf-geometry-mixed",
-        `/layers/${index}`,
+        layerPath,
         `geom_sf v1 requires a single geometry family per layer (found "${layerKind}" then "${kind}"). Split mixed types into separate layers.`,
       );
     }
 
-    const coords = parsed.coordinates;
-    if (parsed.type === "Point") {
+    const coords = leaf.coordinates;
+    if (leaf.type === "Point") {
       if (!isFinitePair(coords)) {
         throw new PipelineError(
           "sf-geometry-invalid",
-          `/layers/${index}`,
+          layerPath,
           "Point geometry requires a finite [x, y] coordinate pair.",
         );
       }
@@ -182,13 +184,13 @@ export function buildSfFrame(
         row,
         coords,
       );
-      continue;
+      return;
     }
-    if (parsed.type === "MultiPoint") {
+    if (leaf.type === "MultiPoint") {
       if (!Array.isArray(coords)) {
         throw new PipelineError(
           "sf-geometry-invalid",
-          `/layers/${index}`,
+          layerPath,
           "MultiPoint coordinates must be an array of positions.",
         );
       }
@@ -196,18 +198,18 @@ export function buildSfFrame(
         if (!isFinitePair(c)) continue;
         pushPoint(outX, outY, outGroups, outRingIndex, outRowIndex, valueRows, ringId++, 0, row, c);
       }
-      continue;
+      return;
     }
-    if (parsed.type === "LineString") {
+    if (leaf.type === "LineString") {
       const g = ringId++;
       pushRing(outX, outY, outGroups, outRingIndex, outRowIndex, valueRows, g, 0, row, coords, 2);
-      continue;
+      return;
     }
-    if (parsed.type === "MultiLineString") {
+    if (leaf.type === "MultiLineString") {
       if (!Array.isArray(coords)) {
         throw new PipelineError(
           "sf-geometry-invalid",
-          `/layers/${index}`,
+          layerPath,
           "MultiLineString coordinates must be an array of line strings.",
         );
       }
@@ -215,25 +217,25 @@ export function buildSfFrame(
         const g = ringId++;
         pushRing(outX, outY, outGroups, outRingIndex, outRowIndex, valueRows, g, 0, row, line, 2);
       }
-      continue;
+      return;
     }
-    if (parsed.type === "Polygon") {
+    if (leaf.type === "Polygon") {
       if (!Array.isArray(coords) || coords.length === 0) {
         throw new PipelineError(
           "sf-geometry-invalid",
-          `/layers/${index}`,
+          layerPath,
           "Polygon coordinates must be a non-empty array of rings.",
         );
       }
       const g = ringId++;
       pushPolygonRings(outX, outY, outGroups, outRingIndex, outRowIndex, valueRows, g, row, coords);
-      continue;
+      return;
     }
     // MultiPolygon
     if (!Array.isArray(coords)) {
       throw new PipelineError(
         "sf-geometry-invalid",
-        `/layers/${index}`,
+        layerPath,
         "MultiPolygon coordinates must be an array of polygons.",
       );
     }
@@ -242,6 +244,14 @@ export function buildSfFrame(
       const g = ringId++;
       pushPolygonRings(outX, outY, outGroups, outRingIndex, outRowIndex, valueRows, g, row, poly);
     }
+  };
+
+  for (let row = 0; row < table.rowCount; row++) {
+    const path = `/layers/${index}/data/${field}`;
+    const parsed = parseSfGeometry(geomCol[row]!, path);
+    // GeometryCollection expands to leaves; groups continue across parts (ringId++).
+    const leaves = expandSfLeaves(parsed, path);
+    for (const leaf of leaves) emitLeaf(leaf, row);
   }
 
   if (layerKind === null || outX.length === 0) {

--- a/packages/core/src/pipeline/sf-geometry.ts
+++ b/packages/core/src/pipeline/sf-geometry.ts
@@ -9,6 +9,19 @@ import { PipelineError } from "./types.js";
 export type SfKind = "point" | "line" | "polygon";
 export type SfPosition = readonly [number, number];
 
+/** Parsed GeoJSON Geometry object (coordinates and/or nested geometries). */
+export type SfParsed = {
+  type: string;
+  coordinates?: unknown;
+  geometries?: unknown;
+};
+
+/** Leaf geometry after GeometryCollection flattening (#809 phase 6). */
+export type SfLeaf = {
+  type: string;
+  coordinates: unknown;
+};
+
 export function isFinitePair(c: unknown): c is SfPosition {
   return (
     Array.isArray(c) &&
@@ -20,10 +33,7 @@ export function isFinitePair(c: unknown): c is SfPosition {
   );
 }
 
-export function parseSfGeometry(
-  raw: CellValue,
-  path: string,
-): { type: string; coordinates: unknown } {
+export function parseSfGeometry(raw: CellValue, path: string): SfParsed {
   if (typeof raw !== "string" || raw.length === 0) {
     throw new PipelineError(
       "sf-geometry-invalid",
@@ -44,6 +54,7 @@ export function parseSfGeometry(
   if (
     parsed === null ||
     typeof parsed !== "object" ||
+    Array.isArray(parsed) ||
     !("type" in parsed) ||
     typeof (parsed as { type: unknown }).type !== "string"
   ) {
@@ -53,8 +64,12 @@ export function parseSfGeometry(
       'geom_sf geometry must be a GeoJSON Geometry object with a string "type".',
     );
   }
-  const geom = parsed as { type: string; coordinates?: unknown };
-  return { type: geom.type, coordinates: geom.coordinates };
+  const geom = parsed as { type: string; coordinates?: unknown; geometries?: unknown };
+  return {
+    type: geom.type,
+    ...(geom.coordinates !== undefined && { coordinates: geom.coordinates }),
+    ...(geom.geometries !== undefined && { geometries: geom.geometries }),
+  };
 }
 
 export function sfKindOf(type: string): SfKind {
@@ -72,9 +87,70 @@ export function sfKindOf(type: string): SfKind {
       throw new PipelineError(
         "sf-geometry-unsupported",
         "/geometry",
-        `geom_sf does not support GeoJSON type "${type}" in v1 (point/line/polygon families only; no GeometryCollection or CRS).`,
+        `geom_sf does not support GeoJSON type "${type}" in v1 (point/line/polygon families only; no CRS).`,
       );
   }
+}
+
+/**
+ * Flatten GeometryCollection (recursively) to leaf Point/Line/Polygon families.
+ * Empty collections yield []. Mixed families are not filtered here — callers
+ * enforce layer homogeneity via {@link sfKindOf}.
+ */
+export function expandSfLeaves(geom: SfParsed, path: string): SfLeaf[] {
+  if (geom.type === "GeometryCollection") {
+    if (!Array.isArray(geom.geometries)) {
+      throw new PipelineError(
+        "sf-geometry-invalid",
+        path,
+        "GeometryCollection requires a geometries array.",
+      );
+    }
+    const out: SfLeaf[] = [];
+    for (const child of geom.geometries) {
+      if (
+        child === null ||
+        typeof child !== "object" ||
+        Array.isArray(child) ||
+        !("type" in child) ||
+        typeof (child as { type: unknown }).type !== "string"
+      ) {
+        throw new PipelineError(
+          "sf-geometry-invalid",
+          path,
+          "GeometryCollection members must be GeoJSON Geometry objects with a string type.",
+        );
+      }
+      const c = child as { type: string; coordinates?: unknown; geometries?: unknown };
+      out.push(
+        ...expandSfLeaves(
+          {
+            type: c.type,
+            ...(c.coordinates !== undefined && { coordinates: c.coordinates }),
+            ...(c.geometries !== undefined && { geometries: c.geometries }),
+          },
+          path,
+        ),
+      );
+    }
+    return out;
+  }
+  // Validate leaf family (throws on Feature, CRS objects, etc.).
+  sfKindOf(geom.type);
+  return [{ type: geom.type, coordinates: geom.coordinates }];
+}
+
+/** All label points for a geometry (GeometryCollection + Multi* expand). */
+export function representativePointsForGeometry(
+  geom: SfParsed,
+  path: string,
+): readonly SfPosition[] {
+  const leaves = expandSfLeaves(geom, path);
+  const out: SfPosition[] = [];
+  for (const leaf of leaves) {
+    out.push(...representativePoints(leaf.type, leaf.coordinates));
+  }
+  return out;
 }
 
 function ringPositions(ring: unknown): SfPosition[] {

--- a/packages/core/tests/pipeline-m2/geom-sf-text.test.ts
+++ b/packages/core/tests/pipeline-m2/geom-sf-text.test.ts
@@ -159,6 +159,24 @@ describe("geom_sf_text / stat_sf_coordinates", () => {
     expect(batch.texts).toEqual(["pts", "pts"]);
   });
 
+  it("places labels for each GeometryCollection leaf", () => {
+    const gc = geo({
+      type: "GeometryCollection",
+      geometries: [
+        { type: "Point", coordinates: [0, 0] },
+        { type: "Point", coordinates: [2, 2] },
+      ],
+    });
+    const model = runPipeline(
+      gg({ geometry: [gc], name: ["gc"] }, aes({ label: "name" }))
+        .geomSfText()
+        .spec(),
+      size,
+    );
+    const batch = model.scene.batches[0] as GlyphsBatch;
+    expect(batch.texts).toEqual(["gc", "gc"]);
+  });
+
   it("uses exact auto hit mode", () => {
     const model = runPipeline(
       gg(

--- a/packages/core/tests/pipeline-m2/geom-sf.test.ts
+++ b/packages/core/tests/pipeline-m2/geom-sf.test.ts
@@ -328,7 +328,45 @@ describe("geom_sf", () => {
     }
   });
 
-  it("errors on GeometryCollection", () => {
+  it("renders GeometryCollection of polygons as multiple closed parts", () => {
+    const gc = geo({
+      type: "GeometryCollection",
+      geometries: [
+        {
+          type: "Polygon",
+          coordinates: [
+            [
+              [0, 0],
+              [1, 0],
+              [0.5, 1],
+              [0, 0],
+            ],
+          ],
+        },
+        {
+          type: "Polygon",
+          coordinates: [
+            [
+              [3, 0],
+              [4, 0],
+              [3.5, 1],
+              [3, 0],
+            ],
+          ],
+        },
+      ],
+    });
+    const model = runPipeline(
+      gg({ geometry: [gc], id: ["parts"] }, aes({ fill: "id" }))
+        .geomSf()
+        .spec(),
+      size,
+    );
+    const batch = model.scene.batches[0] as PathsBatch;
+    expect(batch.pathOffsets.length - 1).toBe(2);
+  });
+
+  it("errors when GeometryCollection mixes geometry families", () => {
     try {
       runPipeline(
         gg(
@@ -336,7 +374,20 @@ describe("geom_sf", () => {
             geometry: [
               geo({
                 type: "GeometryCollection",
-                geometries: [{ type: "Point", coordinates: [0, 0] }],
+                geometries: [
+                  { type: "Point", coordinates: [0, 0] },
+                  {
+                    type: "Polygon",
+                    coordinates: [
+                      [
+                        [0, 0],
+                        [1, 0],
+                        [0.5, 1],
+                        [0, 0],
+                      ],
+                    ],
+                  },
+                ],
               }),
             ],
           },
@@ -349,7 +400,7 @@ describe("geom_sf", () => {
       expect.unreachable();
     } catch (error) {
       expect(error).toBeInstanceOf(PipelineError);
-      expect((error as PipelineError).code).toBe("sf-geometry-unsupported");
+      expect((error as PipelineError).code).toBe("sf-geometry-mixed");
     }
   });
 

--- a/packages/core/tests/pipeline-m2/sf-geometry.test.ts
+++ b/packages/core/tests/pipeline-m2/sf-geometry.test.ts
@@ -3,7 +3,12 @@
  */
 import { describe, expect, it } from "bun:test";
 
-import { representativePoint, representativePoints } from "../../src/pipeline/sf-geometry.ts";
+import {
+  expandSfLeaves,
+  representativePoint,
+  representativePoints,
+  representativePointsForGeometry,
+} from "../../src/pipeline/sf-geometry.ts";
 
 describe("representativePoints (#809 multi-part labels)", () => {
   it("returns one point for Point / LineString / Polygon", () => {
@@ -134,5 +139,80 @@ describe("representativePoints (#809 multi-part labels)", () => {
         ],
       ]),
     ).toEqual([1, 1]);
+  });
+});
+
+describe("expandSfLeaves (#809 GeometryCollection)", () => {
+  it("flattens a homogeneous GeometryCollection to leaves", () => {
+    const leaves = expandSfLeaves(
+      {
+        type: "GeometryCollection",
+        geometries: [
+          { type: "Point", coordinates: [1, 2] },
+          { type: "Point", coordinates: [3, 4] },
+        ],
+      },
+      "/test",
+    );
+    expect(leaves).toEqual([
+      { type: "Point", coordinates: [1, 2] },
+      { type: "Point", coordinates: [3, 4] },
+    ]);
+  });
+
+  it("recursively flattens nested GeometryCollections", () => {
+    const leaves = expandSfLeaves(
+      {
+        type: "GeometryCollection",
+        geometries: [
+          {
+            type: "GeometryCollection",
+            geometries: [{ type: "Point", coordinates: [0, 0] }],
+          },
+          {
+            type: "Polygon",
+            coordinates: [
+              [
+                [0, 0],
+                [2, 0],
+                [2, 2],
+                [0, 2],
+                [0, 0],
+              ],
+            ],
+          },
+        ],
+      },
+      "/test",
+    );
+    expect(leaves.map((l) => l.type)).toEqual(["Point", "Polygon"]);
+  });
+
+  it("returns empty for empty GeometryCollection", () => {
+    expect(expandSfLeaves({ type: "GeometryCollection", geometries: [] }, "/test")).toEqual([]);
+  });
+
+  it("labels expand through GeometryCollection leaves", () => {
+    const pts = representativePointsForGeometry(
+      {
+        type: "GeometryCollection",
+        geometries: [
+          { type: "Point", coordinates: [1, 1] },
+          {
+            type: "MultiPoint",
+            coordinates: [
+              [2, 2],
+              [3, 3],
+            ],
+          },
+        ],
+      },
+      "/test",
+    );
+    expect(pts).toEqual([
+      [1, 1],
+      [2, 2],
+      [3, 3],
+    ]);
   });
 });

--- a/packages/spec/schema/v0.json
+++ b/packages/spec/schema/v0.json
@@ -1629,7 +1629,7 @@
         }
       },
       "additionalProperties": false,
-      "description": "Parameters for geom_sf (#809): portable GeoJSON Geometry column plus styling. Interior rings are even-odd holes. No CRS/coord_sf yet."
+      "description": "Parameters for geom_sf (#809): portable GeoJSON Geometry column plus styling. Interior rings are even-odd holes; GeometryCollection expands. No CRS/coord_sf yet."
     },
     "TextParams": {
       "type": "object",
@@ -2666,7 +2666,7 @@
         "geom": {
           "type": "string",
           "const": "sf",
-          "description": "Simple-features geometry (ggplot2 geom_sf; #809): already-projected GeoJSON Geometry JSON strings in a data column. Point/line/polygon families with even-odd holes; no CRS or coord_sf yet."
+          "description": "Simple-features geometry (ggplot2 geom_sf; #809): already-projected GeoJSON Geometry JSON strings in a data column. Point/line/polygon families (incl. GeometryCollection of one family) with even-odd holes; no CRS or coord_sf yet."
         },
         "stat": {
           "type": "string",

--- a/packages/spec/src/schema-declarations.ts
+++ b/packages/spec/src/schema-declarations.ts
@@ -1742,7 +1742,7 @@ export const SpecDeclarations = {
     {
       additionalProperties: false,
       description:
-        "Parameters for geom_sf (#809): portable GeoJSON Geometry column plus styling. Interior rings are even-odd holes. No CRS/coord_sf yet.",
+        "Parameters for geom_sf (#809): portable GeoJSON Geometry column plus styling. Interior rings are even-odd holes; GeometryCollection expands. No CRS/coord_sf yet.",
     },
   ),
 
@@ -2561,7 +2561,7 @@ export const SpecDeclarations = {
     {
       geom: Type.Literal("sf", {
         description:
-          "Simple-features geometry (ggplot2 geom_sf; #809): already-projected GeoJSON Geometry JSON strings in a data column. Point/line/polygon families with even-odd holes; no CRS or coord_sf yet.",
+          "Simple-features geometry (ggplot2 geom_sf; #809): already-projected GeoJSON Geometry JSON strings in a data column. Point/line/polygon families (incl. GeometryCollection of one family) with even-odd holes; no CRS or coord_sf yet.",
       }),
       stat: Type.Optional(
         Type.Literal("identity", { description: "SF layers expand geometry then draw as-is." }),


### PR DESCRIPTION
## Summary

**#809 phase 6** (stacks on #914 / `feat/809-sf-multipart-labels`): **GeometryCollection** support.

```ts
// GeometryCollection of two polygons → two closed path parts
gg({
  geometry: [JSON.stringify({
    type: "GeometryCollection",
    geometries: [polyA, polyB],
  })],
}, aes({ fill: "rate" })).geomSf()
```

### Contract

| Item | Choice |
|------|--------|
| Expand | Recursive flatten of `GeometryCollection` → leaf Point/Line/Polygon families |
| Parts | Continuous group ids across leaves (same as MultiPolygon) |
| Mixed families | `sf-geometry-mixed` (intra-collection or cross-row) |
| Empty GC | No drawable verts for that feature; coordinates drop + `sf-coordinates-dropped` |
| Labels | One label per leaf part (and Multi* still expand) |
| CRS | Still unsupported |

### Plan review

Claude: **nits approve** — addressed parse widening (`geometries` field), continuous part indexing, empty-GC drop semantics, schema/diagnostic copy.

### Still deferred on #809

- CRS / `coord_sf`
- Mixed families in one layer (still intentionally errors)
- Hole topology under active coord transforms

## Test plan

- [x] Pure `expandSfLeaves` + `representativePointsForGeometry`
- [x] M2 geom_sf GC render + mixed GC error
- [x] M2 geom_sf_text GC labels
- [x] diagnostics + sf_label regressions + `tsc -b packages/spec packages/core`
- [x] schema emit

Related: #809

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/917" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->