### PR TITLE
feat: public stat_sf as geom_sf default (#809 phase 7)

### DIFF
--- a/packages/core/src/pipeline/frame-stats.ts
+++ b/packages/core/src/pipeline/frame-stats.ts
@@ -12,6 +12,7 @@ import { buildManualFrame } from "./frame-stats-manual.js";
 import { buildQuantileFrame } from "./frame-stats-quantile.js";
 import { buildSummaryBinFrame } from "./frame-stats-summary-bin.js";
 import { buildSfCoordinatesFrame } from "./frame-stats-sf-coordinates.js";
+import { buildSfFrame } from "./frame-stats-sf.js";
 import { buildUniqueFrame } from "./frame-stats-unique.js";
 import type { Advisory, LayerBinding, LayerFrame, PipelineWarning } from "./types.js";
 
@@ -26,6 +27,8 @@ export function buildNonIdentityFrame(
   const stat = binding.layer.stat ?? "identity";
   if (stat === "identity") return null;
 
+  // ggplot2 stat_sf: expand portable GeoJSON to drawable parts (#809 phase 7).
+  if (stat === "sf") return buildSfFrame(binding, table, groups, warnings);
   if (stat === "sf_coordinates") return buildSfCoordinatesFrame(binding, table, groups, warnings);
   if (stat === "unique") return buildUniqueFrame(binding, table, groups);
   if (stat === "manual") return buildManualFrame(binding, table, groups, warnings);

--- a/packages/core/src/pipeline/frame.ts
+++ b/packages/core/src/pipeline/frame.ts
@@ -9,7 +9,6 @@ import { buildAnnotationFrame } from "./frame-annotation.js";
 import { expandEdgeFrame } from "./frame-edge-expand.js";
 import { deriveLayerGroups } from "./frame-helpers.js";
 import { buildIdentityFrame } from "./frame-identity.js";
-import { buildSfFrame } from "./frame-stats-sf.js";
 import { buildNonIdentityFrame } from "./frame-stats.js";
 
 export { deriveLayerGroups } from "./frame-helpers.js";
@@ -31,10 +30,7 @@ export function buildFrame(
   // Derive once per frame; identity index + bin lineage consume frame.inputGroups.
   const inputGroups = deriveLayerGroups(binding, table);
 
-  if (binding.layer.geom === "sf") {
-    return { ...buildSfFrame(binding, table, inputGroups, warnings), inputGroups };
-  }
-
+  // geom_sf default stat is "sf" (geometry expand via buildNonIdentityFrame).
   const nonIdentity = buildNonIdentityFrame(
     binding,
     table,

--- a/packages/core/tests/pipeline-m2/geom-sf.test.ts
+++ b/packages/core/tests/pipeline-m2/geom-sf.test.ts
@@ -415,4 +415,11 @@ describe("geom_sf", () => {
     expect(batch.closed).toBe(true);
     expect(batch.pathOffsets.length - 1).toBe(1);
   });
+
+  it("defaults stat to sf (ggplot2 stat_sf)", () => {
+    const spec = gg({ geometry: [polyA] }, aes({}))
+      .geomSf()
+      .spec();
+    expect(spec.layers[0]?.stat).toBe("sf");
+  });
 });

--- a/packages/spec/schema/v0.json
+++ b/packages/spec/schema/v0.json
@@ -2670,8 +2670,8 @@
         },
         "stat": {
           "type": "string",
-          "const": "identity",
-          "description": "SF layers expand geometry then draw as-is."
+          "const": "sf",
+          "description": "Geometry expand (ggplot2 stat_sf; #809): portable GeoJSON → drawable point/line/polygon parts."
         },
         "position": {
           "type": "string",
@@ -2693,7 +2693,7 @@
         }
       },
       "additionalProperties": false,
-      "description": "An sf geometry layer. Requires a geometry column of GeoJSON Geometry JSON strings (params.geometry, default \"geometry\"). Coordinates must already be projected."
+      "description": "An sf geometry layer. Requires a geometry column of GeoJSON Geometry JSON strings (params.geometry, default \"geometry\"). Coordinates must already be projected. Default stat is \"sf\"."
     },
     "SfTextParams": {
       "type": "object",

--- a/packages/spec/src/normalize-input.ts
+++ b/packages/spec/src/normalize-input.ts
@@ -259,7 +259,8 @@ export interface CurveLayerInput extends LayerInputBase {
 
 export interface SfLayerInput extends LayerInputBase {
   geom: "sf";
-  stat?: "identity";
+  /** Geometry expand (ggplot2 `stat_sf`); default from GEOM_DEFAULTS. */
+  stat?: "sf";
   position?: "identity";
   params?: SfParams;
 }

--- a/packages/spec/src/runtime.ts
+++ b/packages/spec/src/runtime.ts
@@ -37,6 +37,9 @@ import type {
   CurveLayer,
   RuleLayer,
   QuantileLayer,
+  SfLabelLayer,
+  SfLayer,
+  SfTextLayer,
   SmoothLayer,
   TextLayer,
   TileLayer,
@@ -81,6 +84,9 @@ export interface RuntimeErrorbarLayer extends WithRuntimeAes<ErrorbarLayer> {}
 export interface RuntimeRectLayer extends WithRuntimeAes<RectLayer> {}
 export interface RuntimeTileLayer extends WithRuntimeAes<TileLayer> {}
 export interface RuntimeRasterLayer extends WithRuntimeAes<RasterLayer> {}
+export interface RuntimeSfLayer extends WithRuntimeAes<SfLayer> {}
+export interface RuntimeSfTextLayer extends WithRuntimeAes<SfTextLayer> {}
+export interface RuntimeSfLabelLayer extends WithRuntimeAes<SfLabelLayer> {}
 
 export type RuntimeLayerSpec =
   | RuntimePointLayer
@@ -103,7 +109,10 @@ export type RuntimeLayerSpec =
   | RuntimeErrorbarLayer
   | RuntimeRectLayer
   | RuntimeTileLayer
-  | RuntimeRasterLayer;
+  | RuntimeRasterLayer
+  | RuntimeSfLayer
+  | RuntimeSfTextLayer
+  | RuntimeSfLabelLayer;
 
 /** The in-memory spec superset ({ fn } channel accessors allowed). */
 type RuntimeSpecPortableFields = Omit<PortableSpec, "aes" | "layers">;

--- a/packages/spec/src/schema-catalog.ts
+++ b/packages/spec/src/schema-catalog.ts
@@ -82,6 +82,7 @@ export const KNOWN_STATS = [
   "summary",
   "summary_bin",
   "align",
+  "sf",
   "sf_coordinates",
 ] as const;
 export type StatName = (typeof KNOWN_STATS)[number];
@@ -120,7 +121,7 @@ export const GEOM_DEFAULTS: Record<GeomName, { stat: StatName; position: Positio
   ribbon: { stat: "identity", position: "identity" },
   segment: { stat: "identity", position: "identity" },
   curve: { stat: "identity", position: "identity" },
-  sf: { stat: "identity", position: "identity" },
+  sf: { stat: "sf", position: "identity" },
   sf_text: { stat: "sf_coordinates", position: "identity" },
   sf_label: { stat: "sf_coordinates", position: "identity" },
 };

--- a/packages/spec/src/schema-declarations.ts
+++ b/packages/spec/src/schema-declarations.ts
@@ -2564,7 +2564,10 @@ export const SpecDeclarations = {
           "Simple-features geometry (ggplot2 geom_sf; #809): already-projected GeoJSON Geometry JSON strings in a data column. Point/line/polygon families (incl. GeometryCollection of one family) with even-odd holes; no CRS or coord_sf yet.",
       }),
       stat: Type.Optional(
-        Type.Literal("identity", { description: "SF layers expand geometry then draw as-is." }),
+        Type.Literal("sf", {
+          description:
+            "Geometry expand (ggplot2 stat_sf; #809): portable GeoJSON → drawable point/line/polygon parts.",
+        }),
       ),
       position: Type.Optional(
         Type.Literal("identity", { description: "SF layers use identity positioning." }),
@@ -2582,7 +2585,7 @@ export const SpecDeclarations = {
     {
       additionalProperties: false,
       description:
-        'An sf geometry layer. Requires a geometry column of GeoJSON Geometry JSON strings (params.geometry, default "geometry"). Coordinates must already be projected.',
+        'An sf geometry layer. Requires a geometry column of GeoJSON Geometry JSON strings (params.geometry, default "geometry"). Coordinates must already be projected. Default stat is "sf".',
     },
   ),
 


### PR DESCRIPTION
## Summary

**#809 phase 7** (stacks on #917 / `feat/809-sf-geometrycollection`): public **`stat_sf`**.

```ts
gg(data, aes({ fill: "rate" })).geomSf().spec()
// layer.stat === "sf"  (was identity + geom-gated expand)
```

### Contract

| Item | Choice |
|------|--------|
| `KNOWN_STATS` | adds `"sf"` |
| Default | `geom_sf` → `stat: "sf"`, `position: "identity"` |
| Expand | `buildSfFrame` via `buildNonIdentityFrame` (no geom-only special case) |
| Schema | `SfLayer.stat` is `"sf"` only |
| Runtime | `RuntimeSfLayer` / `RuntimeSfTextLayer` / `RuntimeSfLabelLayer` on `RuntimeLayerSpec` |

### Why

Issue #809 lists **stats: `sf`, `sf_coordinates`**. Expand already existed as a geom gate; this matches the ggplot2 public name and unblocks RuntimeSpec type parity for the SF stack CI.

### Plan review

Claude CLI timed out; eng self-review (stat path + Runtime union gap).

### Still deferred on #809

- CRS / `coord_sf` / projections
- Hole topology remapping under active `coord_transform`

## Test plan

- [x] `geom_sf` defaults `stat` to `"sf"`
- [x] Full geom_sf / sf_text / sf_label / sf-geometry suite green
- [x] `tsc -b packages/spec packages/core` + `check:type-contracts`
- [x] schema emit

Related: #809

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/918" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->