### PR TITLE
fix(dotplot): honor aes.fill for histodot paint (#900)

### DIFF
--- a/packages/core/src/pipeline/geometry-dispatch.ts
+++ b/packages/core/src/pipeline/geometry-dispatch.ts
@@ -35,8 +35,10 @@ export function dispatchGeometryBatch(
 ): GeometryBatch[] {
   switch (frame.binding.layer.geom) {
     case "point":
-    case "dotplot":
       return single(pointsBatch(frame, fx, color, styles, warnings));
+    case "dotplot":
+      // Pass fill so histodot dots honor aes.fill (ggplot2 fill grouping; #900).
+      return single(pointsBatch(frame, fx, color, styles, warnings, fill));
     case "line": {
       // stat_connect emits tied-x step corners; a post-stat x-sort would
       // scramble elbows (#816). Identity line still sorts by x.

--- a/packages/core/src/pipeline/geometry-points.ts
+++ b/packages/core/src/pipeline/geometry-points.ts
@@ -78,11 +78,11 @@ export function pointsBatch(
 
   // geom_dotplot paints with fill when present (schema: "Map fill/color for groups").
   // Solid point marks only have one paint channel; fill wins over color when both map.
-  const paintWithFill =
-    geom === "dotplot" &&
-    (fill !== null
-      ? frame.fillValues !== null || binding.fill.scaledConstant !== null
-      : binding.fill.constant !== null);
+  const fillMapped =
+    frame.fillValues !== null ||
+    binding.fill.scaledConstant !== null ||
+    binding.fill.constant !== null;
+  const paintWithFill = geom === "dotplot" && fillMapped;
   const paintScale = paintWithFill ? fill : color;
   const paintValues = paintWithFill ? frame.fillValues : frame.colorValues;
   const paintChannel = paintWithFill ? binding.fill : binding.color;
@@ -114,7 +114,7 @@ export function pointsBatch(
     const colors = Array.from<string>({ length: collected.kept });
     for (let j = 0; j < collected.kept; j++) {
       const row = collected.keptRows[j]!;
-      const value = paintValues === null ? paintChannel.scaledConstant! : paintValues[row]!;
+      const value = paintValues !== null ? paintValues[row]! : paintChannel.scaledConstant!;
       colors[j] = colorOf(paintScale, value);
     }
     batch.colors = colors;

--- a/packages/core/src/pipeline/geometry-points.ts
+++ b/packages/core/src/pipeline/geometry-points.ts
@@ -48,6 +48,8 @@ export function pointsBatch(
   color: ResolvedColorScale | null,
   styles: ResolvedStyleScales,
   warnings: PipelineWarning[],
+  /** Fill scale — used as paint for geom_dotplot (ggplot2 fill grouping; #900). */
+  fill: ResolvedColorScale | null = null,
 ): PointsBatch | null {
   const { binding, n } = frame;
   const collected = collectPointPositions(frame, fx);
@@ -74,6 +76,17 @@ export function pointsBatch(
   else if (typeof params.size === "number") markSize = params.size;
   else if (geom === "dotplot") markSize = dotplotRadiusPx(frame, fx, params);
 
+  // geom_dotplot paints with fill when present (schema: "Map fill/color for groups").
+  // Solid point marks only have one paint channel; fill wins over color when both map.
+  const paintWithFill =
+    geom === "dotplot" &&
+    (fill !== null
+      ? frame.fillValues !== null || binding.fill.scaledConstant !== null
+      : binding.fill.constant !== null);
+  const paintScale = paintWithFill ? fill : color;
+  const paintValues = paintWithFill ? frame.fillValues : frame.colorValues;
+  const paintChannel = paintWithFill ? binding.fill : binding.color;
+
   const batch: PointsBatch = {
     kind: "points",
     layerIndex: binding.index,
@@ -84,7 +97,7 @@ export function pointsBatch(
     alpha: typeof literalAlpha === "number" ? literalAlpha : (params.alpha ?? 1),
     shape:
       typeof literalShape === "string" ? (literalShape as PointShape) : (params.shape ?? "circle"),
-    fill: binding.color.constant,
+    fill: paintChannel.constant,
   };
   const sizes = numericStyleVector(frame, "size", collected.keptRows, styles);
   const alphas = numericStyleVector(frame, "alpha", collected.keptRows, styles);
@@ -97,13 +110,12 @@ export function pointsBatch(
     batch.alphas = alphas;
   }
   if (shapeIndexes !== undefined) batch.shapeIndexes = shapeIndexes;
-  if (color !== null && (frame.colorValues !== null || binding.color.scaledConstant !== null)) {
+  if (paintScale !== null && (paintValues !== null || paintChannel.scaledConstant !== null)) {
     const colors = Array.from<string>({ length: collected.kept });
     for (let j = 0; j < collected.kept; j++) {
       const row = collected.keptRows[j]!;
-      const value =
-        frame.colorValues === null ? binding.color.scaledConstant! : frame.colorValues[row]!;
-      colors[j] = colorOf(color, value);
+      const value = paintValues === null ? paintChannel.scaledConstant! : paintValues[row]!;
+      colors[j] = colorOf(paintScale, value);
     }
     batch.colors = colors;
   }

--- a/packages/core/src/pipeline/geometry-points.ts
+++ b/packages/core/src/pipeline/geometry-points.ts
@@ -114,7 +114,7 @@ export function pointsBatch(
     const colors = Array.from<string>({ length: collected.kept });
     for (let j = 0; j < collected.kept; j++) {
       const row = collected.keptRows[j]!;
-      const value = paintValues !== null ? paintValues[row]! : paintChannel.scaledConstant!;
+      const value = paintValues === null ? paintChannel.scaledConstant! : paintValues[row]!;
       colors[j] = colorOf(paintScale, value);
     }
     batch.colors = colors;

--- a/packages/core/tests/pipeline-m2/dotplot.test.ts
+++ b/packages/core/tests/pipeline-m2/dotplot.test.ts
@@ -88,4 +88,35 @@ describe("dotplot geom (histodot bindot)", () => {
     expect(colors).toBeDefined();
     expect(new Set(colors).size).toBe(2);
   });
+
+  // ggplot2 geom_dotplot groups by fill by default; schema advertises "Map fill/color".
+  it("fill aesthetic paints per-observation dots", () => {
+    const model = runPipeline(
+      gg(data, aes({ x: "x", fill: "g" }))
+        .geomDotplot({ binwidth: 1, boundary: 0.5 })
+        .spec(),
+      size,
+    );
+    const batch = model.scene.batches[0] as PointsBatch;
+    expect(batch.kind).toBe("points");
+    const colors = batch.colors;
+    expect(colors).toBeDefined();
+    expect(new Set(colors).size).toBe(2);
+  });
+
+  it("fill paint wins over color when both are mapped", () => {
+    const model = runPipeline(
+      gg(
+        { x: [1, 1, 2, 2], fillG: ["a", "a", "b", "b"], colorG: ["x", "x", "x", "x"] },
+        aes({ x: "x", fill: "fillG", color: "colorG" }),
+      )
+        .geomDotplot({ binwidth: 1, boundary: 0.5 })
+        .spec(),
+      size,
+    );
+    const batch = model.scene.batches[0] as PointsBatch;
+    expect(batch.colors).toBeDefined();
+    // fill has 2 levels; color is constant — paint must follow fill.
+    expect(new Set(batch.colors).size).toBe(2);
+  });
 });


### PR DESCRIPTION
## Summary

Follow-up for unrebutted post-merge Devin finding on #900:

> **Coloring dotplot groups by fill silently produces uncolored dots**

`buildBindotFrame` already computes per-observation `fillValues`, and the DotplotLayer schema says "Map fill/color for groups", but `pointsBatch` only painted from the color channel. Mapped `aes.fill` was a silent no-op.

**Root cause:** `dispatchGeometryBatch` routed `dotplot` through `pointsBatch` without the fill scale; paint logic only consulted `frame.colorValues`.

**Fix:** pass fill into `pointsBatch` for `dotplot` and prefer fill (then color) for solid-point paint — matching ggplot2 geom_dotplot fill grouping.

## Tests

- [x] `fill aesthetic paints per-observation dots`
- [x] `fill paint wins over color when both are mapped`
- [x] existing color aesthetic test still green

```bash
bun test packages/core/tests/pipeline-m2/dotplot.test.ts
```

## Parent

- Parent PR: #900
- Comment thread: fillValues computed but never rendered
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/919" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->