### PR TITLE
refactor(docs): extract playground sample-load and undo plans

### DIFF
--- a/apps/docs/src/lib/Playground.svelte
+++ b/apps/docs/src/lib/Playground.svelte
@@ -43,8 +43,6 @@
     PLAYGROUND_SAMPLE_DISCARD_CONFIRM,
     PLAYGROUND_UNDO_DISCARD_CONFIRM,
     shouldClearPlayHashAfterPromotion,
-    shouldConfirmDiscardForSampleLoad,
-    shouldConfirmDiscardForUndo,
   } from "$lib/playground-link-policy";
   import { playgroundOutputs } from "$lib/playground-output";
   import { playgroundShareCopyStatus } from "$lib/playground-output-status";
@@ -56,9 +54,13 @@
     reportPlaygroundDiagnostic,
     setPlaygroundHistoryHash,
     stagePlaygroundSeed,
-    stagePlaygroundUndo,
     type PlaygroundDiagnostic,
   } from "$lib/playground-state";
+  import {
+    planSampleLoad,
+    planUndoChart,
+    workbenchCandidateRef,
+  } from "$lib/playground-workbench-actions";
   import {
     defaultPlaygroundInteractions,
     type PlaygroundAgentEnvelope,
@@ -173,10 +175,7 @@
   }
 
   function activeCandidate(): PlaygroundCandidateRef | null {
-    const candidate = workbench.candidate;
-    return candidate === null
-      ? null
-      : { generation: candidate.generation, origin: candidate.origin };
+    return workbenchCandidateRef(workbench);
   }
 
   function replaceLocationHash(hash: string | null): void {
@@ -245,37 +244,35 @@
   });
 
   function undoChart(): void {
-    if (workbench.undoSnapshots.length === 0 || workbench.candidate !== null)
-      return;
-    if (busy) return;
-    if (shouldConfirmDiscardForUndo(workbench)) {
+    let plan = planUndoChart(workbench, busy, false);
+    if (plan.kind === "noop") return;
+    if (plan.kind === "needs_confirm") {
       const discard = window.confirm(PLAYGROUND_UNDO_DISCARD_CONFIRM);
       if (!discard) return;
+      plan = planUndoChart(workbench, busy, true);
+      if (plan.kind !== "stage") return;
     }
-    const previous = activeCandidate();
-    const next = stagePlaygroundUndo(workbench);
-    workbench = next;
-    noteStagedCandidate(previous, next);
+    workbench = plan.workbench;
+    noteStagedCandidate(plan.previous, plan.workbench);
   }
 
   function loadSample(id: string): boolean {
-    if (id === "") return false;
-    if (shouldConfirmDiscardForSampleLoad(workbench)) {
+    let plan = planSampleLoad(workbench, id, PLAYGROUND_SAMPLES, false);
+    if (plan.kind === "noop") return false;
+    if (plan.kind === "needs_confirm") {
       const discard = window.confirm(PLAYGROUND_SAMPLE_DISCARD_CONFIRM);
       if (!discard) return false;
+      plan = planSampleLoad(workbench, id, PLAYGROUND_SAMPLES, true);
+      if (plan.kind !== "load") return false;
     }
-    const sample = PLAYGROUND_SAMPLES.find((entry) => entry.id === id);
-    if (sample === undefined) return false;
     cancelActiveRun();
-    const previous = activeCandidate();
-    const next = stagePlaygroundSeed(workbench, sample.seed, "source");
-    workbench = next;
-    interactions = defaultPlaygroundInteractions();
-    pendingInteractions = null;
-    pendingSuccess = null;
-    mockNotice = false;
-    agent = createPlaygroundAgentState();
-    noteStagedCandidate(previous, next);
+    workbench = plan.workbench;
+    interactions = plan.interactions;
+    pendingInteractions = plan.pendingInteractions;
+    pendingSuccess = plan.pendingSuccess;
+    mockNotice = plan.mockNotice;
+    agent = plan.agent;
+    noteStagedCandidate(plan.previous, plan.workbench);
     return true;
   }
 

--- a/apps/docs/src/lib/playground-link-policy.ts
+++ b/apps/docs/src/lib/playground-link-policy.ts
@@ -61,7 +61,8 @@ export function shouldConfirmDiscardForUndo(state: PlaygroundState): boolean {
 }
 
 /**
- * Confirm-gate only; empty id / missing sample lookup stay in the component.
+ * Confirm-gate only; empty id / missing sample lookup live in
+ * `planSampleLoad` (`playground-workbench-actions.ts`).
  * Guards an unshared agent-generated (custom) chart or an in-flight candidate.
  */
 export function shouldConfirmDiscardForSampleLoad(state: PlaygroundState): boolean {

--- a/apps/docs/src/lib/playground-workbench-actions.ts
+++ b/apps/docs/src/lib/playground-workbench-actions.ts
@@ -1,0 +1,124 @@
+/**
+ * Sample-load and undo workbench transitions extracted from Playground.svelte
+ * so the decision paths can be unit-tested without the Svelte shell.
+ *
+ * Confirm dialogs, cancelActiveRun, and candidate lifecycle emission stay in
+ * the component. This module only resolves lookup / confirm gates and returns
+ * the next pure state bundle.
+ */
+
+import {
+  defaultPlaygroundInteractions,
+  type PlaygroundInteractions,
+} from "./playground-agent-envelope";
+import { createPlaygroundAgentState, type PlaygroundAgentState } from "./playground-agent-state";
+import type { PlaygroundCandidateRef } from "./playground-candidate-lifecycle";
+import type { PlaygroundSeedV1 } from "./playground-codec";
+import {
+  shouldConfirmDiscardForSampleLoad,
+  shouldConfirmDiscardForUndo,
+} from "./playground-link-policy";
+import { stagePlaygroundSeed, stagePlaygroundUndo, type PlaygroundState } from "./playground-state";
+
+/** Catalog row for sample load (seed-bearing; not the share-link catalog shape). */
+export type WorkbenchSampleEntry = {
+  readonly id: string;
+  readonly seed: PlaygroundSeedV1;
+};
+
+export type SampleLoadPlan =
+  | { readonly kind: "noop" }
+  | { readonly kind: "needs_confirm" }
+  | {
+      readonly kind: "load";
+      readonly previous: PlaygroundCandidateRef | null;
+      readonly workbench: PlaygroundState;
+      readonly interactions: PlaygroundInteractions;
+      readonly pendingInteractions: null;
+      readonly pendingSuccess: null;
+      readonly mockNotice: false;
+      readonly agent: PlaygroundAgentState;
+    };
+
+export type UndoPlan =
+  | { readonly kind: "noop" }
+  | { readonly kind: "needs_confirm" }
+  | {
+      readonly kind: "stage";
+      readonly previous: PlaygroundCandidateRef | null;
+      readonly workbench: PlaygroundState;
+    };
+
+/** Candidate ref for lifecycle notes; null when no in-flight candidate. */
+export function workbenchCandidateRef(workbench: PlaygroundState): PlaygroundCandidateRef | null {
+  const candidate = workbench.candidate;
+  return candidate === null ? null : { generation: candidate.generation, origin: candidate.origin };
+}
+
+/**
+ * Plan a sample load.
+ *
+ * @param confirmed - true after the user accepted the discard dialog (or when
+ *   no confirm is required). When confirm is required and confirmed is false,
+ *   returns `needs_confirm` so the shell can re-call after the dialog.
+ */
+export function planSampleLoad(
+  workbench: PlaygroundState,
+  id: string,
+  samples: readonly WorkbenchSampleEntry[],
+  confirmed: boolean,
+): SampleLoadPlan {
+  if (id === "") return { kind: "noop" };
+  // Match Playground.svelte order: confirm-gate before catalog lookup so a
+  // discard dialog still appears for unknown ids when the gate is open
+  // (lookup then fails → noop after confirm).
+  if (shouldConfirmDiscardForSampleLoad(workbench) && !confirmed) {
+    return { kind: "needs_confirm" };
+  }
+
+  const sample = samples.find((entry) => entry.id === id);
+  if (sample === undefined) return { kind: "noop" };
+
+  const previous = workbenchCandidateRef(workbench);
+  const next = stagePlaygroundSeed(workbench, sample.seed, "source");
+  return {
+    kind: "load",
+    previous,
+    workbench: next,
+    interactions: defaultPlaygroundInteractions(),
+    pendingInteractions: null,
+    pendingSuccess: null,
+    mockNotice: false,
+    agent: createPlaygroundAgentState(),
+  };
+}
+
+/**
+ * Plan an undo transition.
+ *
+ * @param confirmed - true after the user accepted the discard dialog when
+ *   `shouldConfirmDiscardForUndo` requires it. Re-evaluates guards on the
+ *   re-call so a concurrent stage/busy change becomes a safe noop.
+ */
+export function planUndoChart(
+  workbench: PlaygroundState,
+  busy: boolean,
+  confirmed: boolean,
+): UndoPlan {
+  if (workbench.undoSnapshots.length === 0 || workbench.candidate !== null) {
+    return { kind: "noop" };
+  }
+  if (busy) return { kind: "noop" };
+  if (shouldConfirmDiscardForUndo(workbench) && !confirmed) {
+    return { kind: "needs_confirm" };
+  }
+
+  // After the candidate-null guard above, previous is always null — kept for
+  // symmetry with sample-load / stage lifecycle notes.
+  const previous = workbenchCandidateRef(workbench);
+  return {
+    kind: "stage",
+    previous,
+    workbench: stagePlaygroundUndo(workbench),
+  };
+}

--- a/scripts/playground-workbench-actions.test.ts
+++ b/scripts/playground-workbench-actions.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, test } from "bun:test";
+
+import type { PortableSpec } from "@ggsvelte/spec";
+
+import type { PlaygroundSeedV1 } from "../apps/docs/src/lib/playground-codec";
+import { defaultPlaygroundInteractions } from "../apps/docs/src/lib/playground-agent-envelope";
+import { planSampleLoad, planUndoChart } from "../apps/docs/src/lib/playground-workbench-actions";
+import {
+  confirmPlaygroundRendered,
+  createPlaygroundState,
+  editPlaygroundDraft,
+  promotePlaygroundCandidate,
+  stagePlaygroundSeed,
+} from "../apps/docs/src/lib/playground-state";
+
+const baseSpec: PortableSpec = {
+  edition: 1,
+  data: {
+    values: [
+      { x: 1, y: 2 },
+      { x: 2, y: 3 },
+    ],
+  },
+  layers: [
+    {
+      geom: "point",
+      stat: "identity",
+      position: "identity",
+      aes: { x: { field: "x" }, y: { field: "y" } },
+    },
+  ],
+  labs: { title: "Baseline" },
+};
+
+const sampleSeed = (id = "starter"): PlaygroundSeedV1 => ({
+  version: 1,
+  source: { kind: "sample", id },
+  spec: baseSpec,
+});
+
+const otherSeed: PlaygroundSeedV1 = {
+  version: 1,
+  source: { kind: "sample", id: "other" },
+  spec: { ...baseSpec, labs: { title: "Other" } },
+};
+
+const catalog = [
+  { id: "starter", seed: sampleSeed("starter") },
+  { id: "other", seed: otherSeed },
+] as const;
+
+describe("planSampleLoad", () => {
+  test("empty id is a noop", () => {
+    const workbench = createPlaygroundState(sampleSeed());
+    expect(planSampleLoad(workbench, "", catalog, false)).toEqual({ kind: "noop" });
+  });
+
+  test("unknown sample id is a noop", () => {
+    const workbench = createPlaygroundState(sampleSeed());
+    expect(planSampleLoad(workbench, "missing", catalog, false)).toEqual({ kind: "noop" });
+  });
+
+  test("known sample without confirm stages source candidate and resets session fields", () => {
+    const workbench = createPlaygroundState(sampleSeed());
+    const plan = planSampleLoad(workbench, "other", catalog, false);
+    expect(plan.kind).toBe("load");
+    if (plan.kind !== "load") return;
+
+    expect(plan.previous).toBeNull();
+    expect(plan.workbench.candidate?.origin).toBe("source");
+    expect(plan.workbench.candidate?.next.seed.source).toEqual({
+      kind: "sample",
+      id: "other",
+    });
+    expect(plan.interactions).toEqual(defaultPlaygroundInteractions());
+    expect(plan.pendingInteractions).toBeNull();
+    expect(plan.pendingSuccess).toBeNull();
+    expect(plan.mockNotice).toBe(false);
+    expect(plan.agent.phase).toBe("idle");
+  });
+
+  test("custom chart requires confirm before load; confirmed applies", () => {
+    const custom = createPlaygroundState({
+      version: 1,
+      source: { kind: "custom" },
+      spec: baseSpec,
+    });
+    expect(planSampleLoad(custom, "starter", catalog, false)).toEqual({
+      kind: "needs_confirm",
+    });
+
+    const plan = planSampleLoad(custom, "starter", catalog, true);
+    expect(plan.kind).toBe("load");
+    if (plan.kind !== "load") return;
+    expect(plan.workbench.candidate?.next.seed.source).toEqual({
+      kind: "sample",
+      id: "starter",
+    });
+  });
+
+  test("confirm gate runs before catalog lookup (unknown id still needs confirm)", () => {
+    const custom = createPlaygroundState({
+      version: 1,
+      source: { kind: "custom" },
+      spec: baseSpec,
+    });
+    expect(planSampleLoad(custom, "missing", catalog, false)).toEqual({
+      kind: "needs_confirm",
+    });
+    expect(planSampleLoad(custom, "missing", catalog, true)).toEqual({
+      kind: "noop",
+    });
+  });
+
+  test("in-flight candidate requires confirm and previous ref points at cancelled generation", () => {
+    const staged = stagePlaygroundSeed(createPlaygroundState(sampleSeed()), otherSeed, "agent");
+    expect(staged.candidate).not.toBeNull();
+    const generation = staged.candidate!.generation;
+
+    const blocked = planSampleLoad(staged, "starter", catalog, false);
+    expect(blocked.kind).toBe("needs_confirm");
+
+    const plan = planSampleLoad(staged, "starter", catalog, true);
+    expect(plan.kind).toBe("load");
+    if (plan.kind !== "load") return;
+    expect(plan.previous).toEqual({ generation, origin: "agent" });
+    expect(plan.workbench.candidate?.generation).not.toBe(generation);
+    expect(plan.workbench.candidate?.origin).toBe("source");
+  });
+});
+
+describe("planUndoChart", () => {
+  function workbenchWithUndo(): ReturnType<typeof createPlaygroundState> {
+    const initial = createPlaygroundState(sampleSeed());
+    const confirmed = confirmPlaygroundRendered(initial);
+    const staged = stagePlaygroundSeed(confirmed, otherSeed, "agent");
+    return promotePlaygroundCandidate(staged, staged.candidate!.generation);
+  }
+
+  test("noop when there are no undo snapshots", () => {
+    const workbench = createPlaygroundState(sampleSeed());
+    expect(planUndoChart(workbench, false, false)).toEqual({ kind: "noop" });
+  });
+
+  test("noop while a candidate is in flight", () => {
+    const withUndo = workbenchWithUndo();
+    const staged = stagePlaygroundSeed(withUndo, sampleSeed("starter"), "agent");
+    expect(staged.candidate).not.toBeNull();
+    expect(planUndoChart(staged, false, false)).toEqual({ kind: "noop" });
+  });
+
+  test("noop while agent is busy", () => {
+    const withUndo = workbenchWithUndo();
+    expect(planUndoChart(withUndo, true, false)).toEqual({ kind: "noop" });
+  });
+
+  test("desynced draft needs confirm; confirmed stages undo", () => {
+    const withUndo = workbenchWithUndo();
+    const desynced = editPlaygroundDraft(withUndo, withUndo.draft + "\n");
+    expect(planUndoChart(desynced, false, false)).toEqual({ kind: "needs_confirm" });
+
+    const plan = planUndoChart(desynced, false, true);
+    expect(plan.kind).toBe("stage");
+    if (plan.kind !== "stage") return;
+    expect(plan.previous).toBeNull();
+    expect(plan.workbench.candidate?.origin).toBe("undo");
+    expect(plan.workbench.candidate?.next.seed.source).toEqual({
+      kind: "sample",
+      id: "starter",
+    });
+  });
+
+  test("synchronized chart with undo history stages without confirm", () => {
+    const withUndo = workbenchWithUndo();
+    const plan = planUndoChart(withUndo, false, false);
+    expect(plan.kind).toBe("stage");
+    if (plan.kind !== "stage") return;
+    expect(plan.workbench.candidate?.origin).toBe("undo");
+  });
+
+  test("confirmed re-call is still noop when undo stack is empty or busy", () => {
+    const empty = createPlaygroundState(sampleSeed());
+    expect(planUndoChart(empty, false, true)).toEqual({ kind: "noop" });
+
+    const withUndo = workbenchWithUndo();
+    expect(planUndoChart(withUndo, true, true)).toEqual({ kind: "noop" });
+
+    const candidateInFlight = stagePlaygroundSeed(withUndo, sampleSeed("starter"), "agent");
+    expect(planUndoChart(candidateInFlight, false, true)).toEqual({ kind: "noop" });
+  });
+
+  test("plans do not mutate the input workbench", () => {
+    const custom = createPlaygroundState({
+      version: 1,
+      source: { kind: "custom" },
+      spec: baseSpec,
+    });
+    const before = structuredClone(custom);
+    planSampleLoad(custom, "starter", catalog, true);
+    expect(custom).toEqual(before);
+
+    const withUndo = workbenchWithUndo();
+    const undoBefore = structuredClone(withUndo);
+    planUndoChart(withUndo, false, false);
+    expect(withUndo).toEqual(undoBefore);
+  });
+});


### PR DESCRIPTION
## Summary

- Audit of `Playground.svelte` showed sample-load and undo still mixed confirm policy, catalog lookup, workbench staging, and session resets in the Svelte shell with no unit coverage of the combined decision.
- Extracted pure `planSampleLoad` / `planUndoChart` into `playground-workbench-actions.ts` (same pattern as `playground-agent-run`).
- Shell keeps `window.confirm`, `cancelActiveRun`, and candidate lifecycle emission; applies the plan result to `$state`.
- Shared `workbenchCandidateRef` for candidate ref snapshots used by lifecycle notes.

## Candidate (maintainability)

**Target:** `apps/docs/src/lib/Playground.svelte`  
**Chosen:** sample load + undo orchestration (real branching: empty/unknown id, discard confirm, busy/candidate guards, post-load session reset).  
**Not chosen:** promote/fail outcome “planning” — those paths are already thin apply layers over pure, tested modules.

## Test plan

- [x] `bun test scripts/playground-workbench-actions.test.ts` (13 pass)
- [x] `bun test scripts/playground-state.test.ts scripts/playground-link-policy.test.ts`
- [x] `bun run check:scripts`
- [x] `bun run check:docs` (svelte-check 0 errors / 0 warnings)

## Follow-ups

None deferred as open issues — remaining shell work is intentional orchestration glue (agent run, hash restore, share, promote/fail apply).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/923" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->