### PR TITLE
feat: coord_sf fixed-aspect maps (#809 phase 8)

### DIFF
--- a/lifecycle.json
+++ b/lifecycle.json
@@ -216,6 +216,18 @@
           "kind": "value",
           "lifecycle": "experimental"
         },
+        "CoordSfOptions": {
+          "kind": "type",
+          "lifecycle": "experimental"
+        },
+        "CoordSfSpec": {
+          "kind": "type",
+          "lifecycle": "experimental"
+        },
+        "CoordSfSpecSchema": {
+          "kind": "value",
+          "lifecycle": "experimental"
+        },
         "CoordSpec": {
           "kind": "type",
           "lifecycle": "experimental"
@@ -1408,6 +1420,10 @@
           "kind": "value",
           "lifecycle": "experimental"
         },
+        "coordSf": {
+          "kind": "value",
+          "lifecycle": "experimental"
+        },
         "coordTransform": {
           "kind": "value",
           "lifecycle": "experimental"
@@ -1417,6 +1433,10 @@
           "lifecycle": "experimental"
         },
         "coord_fixed": {
+          "kind": "value",
+          "lifecycle": "experimental"
+        },
+        "coord_sf": {
           "kind": "value",
           "lifecycle": "experimental"
         },
@@ -3780,6 +3800,18 @@
         "CoordFlip": {
           "kind": "value",
           "lifecycle": "stable-intent"
+        },
+        "CoordSf": {
+          "kind": "value",
+          "lifecycle": "experimental"
+        },
+        "CoordSfOptions": {
+          "kind": "type",
+          "lifecycle": "experimental"
+        },
+        "CoordSfSpec": {
+          "kind": "type",
+          "lifecycle": "experimental"
         },
         "CoordSpec": {
           "kind": "type",

--- a/packages/core/src/diagnostics.ts
+++ b/packages/core/src/diagnostics.ts
@@ -163,7 +163,7 @@ export const PIPELINE_ERROR_CATALOG = {
   },
   "coord-fixed-free-scales": {
     summary: "Fixed-aspect coordinates were combined with free positional facet scales.",
-    fix: 'Use facet.scales = "fixed", or remove coord_fixed.',
+    fix: 'Use facet.scales = "fixed", or remove coord_fixed / coord_sf.',
   },
   "coord-fixed-invalid-aspect": {
     summary:

--- a/packages/core/src/pipeline/finalize-layout-pass.ts
+++ b/packages/core/src/pipeline/finalize-layout-pass.ts
@@ -110,7 +110,9 @@ export function finalizePanelLayoutPass(input: {
       faceted,
       freeX,
       freeY,
-      ...(normalized.coord?.type === "fixed" && { coordFixed: normalized.coord }),
+      ...((normalized.coord?.type === "fixed" || normalized.coord?.type === "sf") && {
+        coordFixed: normalized.coord,
+      }),
       nrow,
       ncol,
       facetPanels,

--- a/packages/core/src/pipeline/panel-layout-fixed.ts
+++ b/packages/core/src/pipeline/panel-layout-fixed.ts
@@ -1,4 +1,4 @@
-import type { CoordFixedSpec, Scales } from "@ggsvelte/spec";
+import type { CoordFixedSpec, CoordSfSpec, Scales } from "@ggsvelte/spec";
 
 import type { Tick } from "../layout/layout-types.js";
 import type { AxisGuidePlan } from "../layout/temporal-guide.js";
@@ -65,10 +65,13 @@ export interface FixedAspectLayoutResult {
  * Fit equal fixed-aspect data rectangles inside already-reserved panel allocations.
  * Chart chrome is therefore authoritative; this pass can only add paper gutters.
  */
+/** Fixed-aspect coord forms that share the same layout pass (`fixed` + `sf`). */
+export type FixedAspectCoordSpec = CoordFixedSpec | CoordSfSpec;
+
 export function applyFixedAspectLayout(input: {
   placements: readonly PanelPlacement[];
   panelScales: readonly { x: PositionScale; y: PositionScale }[];
-  coord: CoordFixedSpec;
+  coord: FixedAspectCoordSpec;
   faceted: boolean;
   freeX: boolean;
   freeY: boolean;
@@ -76,17 +79,18 @@ export function applyFixedAspectLayout(input: {
   warnings: PipelineWarning[];
 }): FixedAspectLayoutResult {
   if (input.freeX || input.freeY) {
+    const name = input.coord.type === "sf" ? "coord_sf" : "coord_fixed";
     const cause =
       "Fixed-aspect coordinates cannot assign one truthful physical data-unit ratio across free positional facet scales.";
     throw new PipelineError("coord-fixed-free-scales", "/facet/scales", cause, {
       code: "coord-fixed-free-scales",
       severity: "error",
       path: "/facet/scales",
-      problem: "coord_fixed is incompatible with free positional facet scales.",
+      problem: `${name} is incompatible with free positional facet scales.`,
       cause,
       fixes: [
         { description: 'Use facet.scales = "fixed".' },
-        { description: "Remove the fixed-aspect coordinate." },
+        { description: `Remove the ${name} coordinate.` },
       ],
       documentationUrl: "/guide/coordinate-systems#fixed-aspect",
     });

--- a/packages/core/src/pipeline/panel-layout.ts
+++ b/packages/core/src/pipeline/panel-layout.ts
@@ -2,7 +2,9 @@
  * Two-pass panel layout: facet grids and single-panel plots, including
  * axis-title/legend chrome and free-scale edge axes.
  */
-import type { CoordFixedSpec, PortableSpec, TemporalKind } from "@ggsvelte/spec";
+import type { PortableSpec, TemporalKind } from "@ggsvelte/spec";
+
+import type { FixedAspectCoordSpec } from "./panel-layout-fixed.js";
 
 import {
   assertLegendBlockFitsPlacedArea,
@@ -33,7 +35,7 @@ export function computePanelLayout(input: {
   faceted: boolean;
   freeX: boolean;
   freeY: boolean;
-  coordFixed?: CoordFixedSpec | undefined;
+  coordFixed?: FixedAspectCoordSpec | undefined;
   nrow: number;
   ncol: number;
   facetPanels: readonly FacetPanelDef[];

--- a/packages/core/tests/pipeline-coord-sf.test.ts
+++ b/packages/core/tests/pipeline-coord-sf.test.ts
@@ -1,0 +1,79 @@
+/**
+ * coord_sf pipeline — fixed-aspect layout for already-projected maps (#809).
+ */
+import { describe, expect, it } from "bun:test";
+
+import { aes, gg } from "@ggsvelte/spec";
+
+import { runPipeline } from "../src/pipeline.ts";
+
+function ratioOf(panel: { width: number; height: number }): number {
+  return panel.height / panel.width;
+}
+
+function geo(g: object): string {
+  return JSON.stringify(g);
+}
+
+describe("coord_sf pipeline (#809)", () => {
+  it("fits a square data rectangle at ratio 1 for equal projected units", () => {
+    const model = runPipeline(
+      gg(
+        [
+          { x: 0, y: 0 },
+          { x: 10, y: 10 },
+        ],
+        aes({ x: "x", y: "y" }),
+      )
+        .geomPoint()
+        .coordSf()
+        .spec(),
+      { width: 640, height: 400 },
+    );
+    const panel = model.scene.panels[0]!;
+    expect(ratioOf(panel)).toBeCloseTo(1, 10);
+  });
+
+  it("applies ratio as y-unit length / x-unit length", () => {
+    const model = runPipeline(
+      gg(
+        [
+          { x: 0, y: 0 },
+          { x: 10, y: 10 },
+        ],
+        aes({ x: "x", y: "y" }),
+      )
+        .geomPoint()
+        .coordSf({ ratio: 2 })
+        .spec(),
+      { width: 640, height: 640 },
+    );
+    expect(ratioOf(model.scene.panels[0]!)).toBeCloseTo(2, 10);
+  });
+
+  it("works with geom_sf already-projected polygons", () => {
+    const poly = geo({
+      type: "Polygon",
+      coordinates: [
+        [
+          [0, 0],
+          [4, 0],
+          [4, 2],
+          [0, 2],
+          [0, 0],
+        ],
+      ],
+    });
+    const model = runPipeline(
+      gg({ geometry: [poly] }, aes({}))
+        .geomSf()
+        .coordSf({ ratio: 1 })
+        .spec(),
+      { width: 400, height: 300 },
+    );
+    expect(model.scene.batches[0]?.kind).toBe("paths");
+    // Domain x span 4, y span 2 → unit aspect ratio 1 ⇒ panel h/w ≈ (2/4)*1 = 0.5
+    // after equal-unit fitting (y-span/x-span * ratio).
+    expect(ratioOf(model.scene.panels[0]!)).toBeCloseTo(0.5, 5);
+  });
+});

--- a/packages/spec/schema/v0.json
+++ b/packages/spec/schema/v0.json
@@ -1629,7 +1629,7 @@
         }
       },
       "additionalProperties": false,
-      "description": "Parameters for geom_sf (#809): portable GeoJSON Geometry column plus styling. Interior rings are even-odd holes; GeometryCollection expands. No CRS/coord_sf yet."
+      "description": "Parameters for geom_sf (#809): portable GeoJSON Geometry column plus styling. Interior rings are even-odd holes; GeometryCollection expands. Use coord_sf for fixed-aspect maps (CRS reproject deferred)."
     },
     "TextParams": {
       "type": "object",
@@ -2666,7 +2666,7 @@
         "geom": {
           "type": "string",
           "const": "sf",
-          "description": "Simple-features geometry (ggplot2 geom_sf; #809): already-projected GeoJSON Geometry JSON strings in a data column. Point/line/polygon families (incl. GeometryCollection of one family) with even-odd holes; no CRS or coord_sf yet."
+          "description": "Simple-features geometry (ggplot2 geom_sf; #809): already-projected GeoJSON Geometry JSON strings in a data column. Point/line/polygon families (incl. GeometryCollection of one family) with even-odd holes; use coord_sf for fixed-aspect (CRS reproject deferred)."
         },
         "stat": {
           "type": "string",
@@ -6456,6 +6456,26 @@
       "additionalProperties": false,
       "description": "A fixed-aspect Cartesian coordinate system. Layout fits the largest centered data rectangle after chart chrome is allocated."
     },
+    "CoordSfSpec": {
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "sf",
+          "description": "Simple-features coordinates for already-projected map data (ggplot2 coord_sf; #809). Fixed-aspect layout; no CRS transform in v1."
+        },
+        "ratio": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "description": "Physical y-unit length divided by physical x-unit length (default 1, equal projected units)."
+        }
+      },
+      "additionalProperties": false,
+      "description": "Fixed-aspect coordinates for portable geom_sf maps. Data must already be projected; CRS reproject / graticules are deferred."
+    },
     "CoordSpec": {
       "anyOf": [
         {
@@ -6466,9 +6486,12 @@
         },
         {
           "$ref": "#/$defs/CoordFixedSpec"
+        },
+        {
+          "$ref": "#/$defs/CoordSfSpec"
         }
       ],
-      "description": "The plot coordinate system: ordinary Cartesian, flipped Cartesian, post-stat transformed, or fixed-aspect."
+      "description": "The plot coordinate system: ordinary Cartesian, flipped Cartesian, post-stat transformed, fixed-aspect, or simple-features fixed-aspect."
     },
     "PlotSpec": {
       "type": "object",

--- a/packages/spec/src/builder-core.ts
+++ b/packages/spec/src/builder-core.ts
@@ -4,8 +4,10 @@
  */
 import {
   coordFixed,
+  coordSf,
   coordTransform,
   type CoordFixedOptions,
+  type CoordSfOptions,
   type CoordTransformOptions,
 } from "./coord-helpers.js";
 import { SpecValidationError } from "./errors.js";
@@ -312,6 +314,14 @@ export class GGBuilderCore {
   /** Equal-unit spelling of coordFixed(). */
   coordEqual(options: CoordFixedOptions = {}): GGBuilder {
     return this.coord(coordFixed(options));
+  }
+
+  /**
+   * Fixed-aspect coordinates for already-projected geom_sf maps (ggplot2
+   * coord_sf subset; #809). No CRS reproject in v1.
+   */
+  coordSf(options: CoordSfOptions = {}): GGBuilder {
+    return this.coord(coordSf(options));
   }
 
   /** Set the accessibility mode ("force-svg" keeps every layer in SVG). */

--- a/packages/spec/src/coord-helpers.ts
+++ b/packages/spec/src/coord-helpers.ts
@@ -1,5 +1,6 @@
 import type {
   CoordFixedSpec,
+  CoordSfSpec,
   CoordSpec,
   CoordTransformAxisSpec,
   CoordTransformSpec,
@@ -64,3 +65,26 @@ export const coordEqual = coordFixed;
 /** ggplot2-style aliases over the same implementation. */
 export const coord_fixed = coordFixed;
 export const coord_equal = coordEqual;
+
+export interface CoordSfOptions {
+  /**
+   * Physical y-unit length / x-unit length (default 1). Use 1 for equal
+   * projected metres; set explicitly for lon/lat display corrections.
+   */
+  ratio?: number;
+}
+
+/**
+ * Fixed-aspect coordinates for already-projected geom_sf maps (ggplot2
+ * `coord_sf` subset). No CRS transform or graticules in v1 — data must
+ * already be in plot space (#809 phase 8).
+ */
+export function coordSf(options: CoordSfOptions = {}): CoordSfSpec {
+  return {
+    type: "sf",
+    ...(options.ratio !== undefined && options.ratio !== 1 && { ratio: options.ratio }),
+  };
+}
+
+/** ggplot2-style alias for coordSf(). */
+export const coord_sf = coordSf;

--- a/packages/spec/src/error-catalog.ts
+++ b/packages/spec/src/error-catalog.ts
@@ -129,7 +129,7 @@ export const ERROR_CATALOG = {
   "coord-fixed-free-scales": {
     tier: 1,
     summary: "Fixed-aspect coordinates cannot represent free positional facet scales truthfully.",
-    fix: 'Use facet.scales = "fixed", or remove coord_fixed.',
+    fix: 'Use facet.scales = "fixed", or remove coord_fixed / coord_sf.',
   },
   // --- tier 1 structural (grammar rules the schema alone cannot express) ---
   "missing-required-channel": {

--- a/packages/spec/src/index.ts
+++ b/packages/spec/src/index.ts
@@ -23,6 +23,7 @@ export {
   ColLayerSchema,
   CoordSpecSchema,
   CoordFixedSpecSchema,
+  CoordSfSpecSchema,
   CoordTransformAxisSpecSchema,
   CoordTransformSpecSchema,
   CURRENT_EDITION,
@@ -88,6 +89,7 @@ export type {
   ColParams,
   CoordSpec,
   CoordFixedSpec,
+  CoordSfSpec,
   CoordTransformAxisSpec,
   CoordTransformSpec,
   DataColumns,
@@ -275,13 +277,16 @@ export type {
 export {
   coord_equal,
   coord_fixed,
+  coord_sf,
   coord_transform,
   coordEqual,
   coordFixed,
+  coordSf,
   coordTransform,
 } from "./coord-helpers.js";
 export type {
   CoordFixedOptions,
+  CoordSfOptions,
   CoordTransformAxisOptions,
   CoordTransformName,
   CoordTransformOptions,

--- a/packages/spec/src/normalize-coord.ts
+++ b/packages/spec/src/normalize-coord.ts
@@ -62,8 +62,8 @@ export function normalizeCoord(coord: CoordSpec | undefined): CoordSpec | undefi
       ? ({ ...record } as CoordSpec)
       : undefined;
   if (record["type"] === "flip") return { ...record } as CoordSpec;
-  if (record["type"] === "fixed") {
-    const fixed = { ...record } as unknown as { type: "fixed"; ratio?: unknown };
+  if (record["type"] === "fixed" || record["type"] === "sf") {
+    const fixed = { ...record } as unknown as { type: "fixed" | "sf"; ratio?: unknown };
     if (fixed.ratio === 1 || fixed.ratio === undefined) delete fixed.ratio;
     return fixed as CoordSpec;
   }

--- a/packages/spec/src/schema-declarations.ts
+++ b/packages/spec/src/schema-declarations.ts
@@ -1742,7 +1742,7 @@ export const SpecDeclarations = {
     {
       additionalProperties: false,
       description:
-        "Parameters for geom_sf (#809): portable GeoJSON Geometry column plus styling. Interior rings are even-odd holes; GeometryCollection expands. No CRS/coord_sf yet.",
+        "Parameters for geom_sf (#809): portable GeoJSON Geometry column plus styling. Interior rings are even-odd holes; GeometryCollection expands. Use coord_sf for fixed-aspect maps (CRS reproject deferred).",
     },
   ),
 
@@ -2561,7 +2561,7 @@ export const SpecDeclarations = {
     {
       geom: Type.Literal("sf", {
         description:
-          "Simple-features geometry (ggplot2 geom_sf; #809): already-projected GeoJSON Geometry JSON strings in a data column. Point/line/polygon families (incl. GeometryCollection of one family) with even-odd holes; no CRS or coord_sf yet.",
+          "Simple-features geometry (ggplot2 geom_sf; #809): already-projected GeoJSON Geometry JSON strings in a data column. Point/line/polygon families (incl. GeometryCollection of one family) with even-odd holes; use coord_sf for fixed-aspect (CRS reproject deferred).",
       }),
       stat: Type.Optional(
         Type.Literal("sf", {
@@ -3766,11 +3766,37 @@ export const SpecDeclarations = {
     },
   ),
 
+  CoordSfSpec: Type.Object(
+    {
+      type: Type.Literal("sf", {
+        description:
+          "Simple-features coordinates for already-projected map data (ggplot2 coord_sf; #809). Fixed-aspect layout; no CRS transform in v1.",
+      }),
+      ratio: Type.Optional(
+        Type.Number({
+          exclusiveMinimum: 0,
+          description:
+            "Physical y-unit length divided by physical x-unit length (default 1, equal projected units).",
+        }),
+      ),
+    },
+    {
+      additionalProperties: false,
+      description:
+        "Fixed-aspect coordinates for portable geom_sf maps. Data must already be projected; CRS reproject / graticules are deferred.",
+    },
+  ),
+
   CoordSpec: Type.Union(
-    [Type.Ref("CoordCartesianSpec"), Type.Ref("CoordTransformSpec"), Type.Ref("CoordFixedSpec")],
+    [
+      Type.Ref("CoordCartesianSpec"),
+      Type.Ref("CoordTransformSpec"),
+      Type.Ref("CoordFixedSpec"),
+      Type.Ref("CoordSfSpec"),
+    ],
     {
       description:
-        "The plot coordinate system: ordinary Cartesian, flipped Cartesian, post-stat transformed, or fixed-aspect.",
+        "The plot coordinate system: ordinary Cartesian, flipped Cartesian, post-stat transformed, fixed-aspect, or simple-features fixed-aspect.",
     },
   ),
 

--- a/packages/spec/src/schema.ts
+++ b/packages/spec/src/schema.ts
@@ -138,6 +138,7 @@ export const FacetSpecSchema = SpecModule.Import("FacetSpec");
 export const CoordTransformAxisSpecSchema = SpecModule.Import("CoordTransformAxisSpec");
 export const CoordTransformSpecSchema = SpecModule.Import("CoordTransformSpec");
 export const CoordFixedSpecSchema = SpecModule.Import("CoordFixedSpec");
+export const CoordSfSpecSchema = SpecModule.Import("CoordSfSpec");
 export const CoordSpecSchema = SpecModule.Import("CoordSpec");
 
 // ---------------------------------------------------------------------------
@@ -344,7 +345,9 @@ export type CoordTransformAxisSpec = SpecType<"CoordTransformAxisSpec">;
 export type CoordTransformSpec = SpecType<"CoordTransformSpec">;
 /** Fixed-aspect Cartesian coordinate configuration. */
 export type CoordFixedSpec = SpecType<"CoordFixedSpec">;
-/** Cartesian, flipped, post-stat transformed, or fixed-aspect coordinate system. */
+/** Simple-features fixed-aspect coordinates (already-projected maps; #809). */
+export type CoordSfSpec = SpecType<"CoordSfSpec">;
+/** Cartesian, flipped, post-stat transformed, fixed-aspect, or SF fixed-aspect. */
 export type CoordSpec = SpecType<"CoordSpec">;
 /** Per-layer rendering backend hint. */
 export type RenderBackend = SpecType<"RenderBackend">;

--- a/packages/spec/src/validate-structure-facet.ts
+++ b/packages/spec/src/validate-structure-facet.ts
@@ -11,22 +11,24 @@ export function coordFacetStructuralErrors(input: Record<string, unknown>): Spec
     typeof coord !== "object" ||
     coord === null ||
     Array.isArray(coord) ||
-    (coord as Record<string, unknown>)["type"] !== "fixed" ||
     typeof facet !== "object" ||
     facet === null ||
     Array.isArray(facet)
   ) {
     return [];
   }
+  const coordType = (coord as Record<string, unknown>)["type"];
+  if (coordType !== "fixed" && coordType !== "sf") return [];
   const scales = (facet as Record<string, unknown>)["scales"];
   if (scales === undefined || scales === "fixed") return [];
+  const coordName = coordType === "sf" ? "coord_sf" : "coord_fixed";
   return [
     {
       code: "coord-fixed-free-scales",
       path: "/facet/scales",
-      message: `coord_fixed cannot use facet scales ${JSON.stringify(scales)} because panels would imply unequal physical data-unit lengths.`,
+      message: `${coordName} cannot use facet scales ${JSON.stringify(scales)} because panels would imply unequal physical data-unit lengths.`,
       fix: {
-        description: 'Use facet.scales = "fixed", or remove the fixed-aspect coordinate.',
+        description: `Use facet.scales = "fixed", or remove the ${coordName} coordinate.`,
         example: "fixed",
       },
     },

--- a/packages/spec/tests/__snapshots__/catalog-coverage.test.ts.snap
+++ b/packages/spec/tests/__snapshots__/catalog-coverage.test.ts.snap
@@ -279,9 +279,10 @@ exports[`ERROR_CATALOG coverage [invalid-enum-value] is reproducible; message + 
       "flip",
       "transform",
       "fixed",
+      "sf",
     ],
     "code": "invalid-enum-value",
-    "message": "Invalid value "polar" for "type"; allowed: "cartesian", "flip", "transform", "fixed".",
+    "message": "Invalid value "polar" for "type"; allowed: "cartesian", "flip", "transform", "fixed", "sf".",
     "path": "/coord/type",
   },
 }
@@ -492,14 +493,14 @@ exports[`ERROR_CATALOG coverage [guide-aesthetic-incompatible] is reproducible; 
 exports[`ERROR_CATALOG coverage [coord-fixed-free-scales] is reproducible; message + fix snapshot 1`] = `
 {
   "catalog": {
-    "fix": "Use facet.scales = "fixed", or remove coord_fixed.",
+    "fix": "Use facet.scales = "fixed", or remove coord_fixed / coord_sf.",
     "summary": "Fixed-aspect coordinates cannot represent free positional facet scales truthfully.",
     "tier": 1,
   },
   "instance": {
     "code": "coord-fixed-free-scales",
     "fix": {
-      "description": "Use facet.scales = "fixed", or remove the fixed-aspect coordinate.",
+      "description": "Use facet.scales = "fixed", or remove the coord_fixed coordinate.",
       "example": "fixed",
     },
     "message": "coord_fixed cannot use facet scales "free_x" because panels would imply unequal physical data-unit lengths.",

--- a/packages/spec/tests/coord-sf-api.test.ts
+++ b/packages/spec/tests/coord-sf-api.test.ts
@@ -1,0 +1,68 @@
+/**
+ * coord_sf public contract (#809 phase 8).
+ */
+import { describe, expect, it } from "bun:test";
+
+import { aes, coord_sf, coordSf, gg, normalize, validate, type CoordSpec } from "../src/index.ts";
+
+const rows = [
+  { x: 0, y: 0, group: "a" },
+  { x: 10, y: 20, group: "b" },
+];
+
+function result(coord: unknown, facet?: unknown) {
+  return validate(
+    normalize({
+      data: { values: rows },
+      layers: [{ geom: "point", aes: { x: { field: "x" }, y: { field: "y" } } }],
+      ...(coord !== undefined && { coord: coord as never }),
+      ...(facet !== undefined && { facet: facet as never }),
+    }),
+  );
+}
+
+describe("coord_sf public contract (#809)", () => {
+  it("accepts fixed-aspect sf coordinates with optional ratio", () => {
+    expect(result({ type: "sf" }).ok).toBe(true);
+    expect(result({ type: "sf", ratio: 0.5 }).ok).toBe(true);
+    expect(result({ type: "sf", ratio: 2 }).ok).toBe(true);
+    for (const coord of [
+      { type: "sf", ratio: 0 },
+      { type: "sf", ratio: -1 },
+      { type: "sf", crs: "EPSG:4326" },
+    ]) {
+      expect(result(coord).ok).toBe(false);
+    }
+  });
+
+  it("normalizes helper, builder, and canonical JSON equally", () => {
+    expect(coord_sf).toBe(coordSf);
+    const canonical: CoordSpec = { type: "sf", ratio: 2 };
+    expect(coordSf({ ratio: 2 })).toEqual(canonical);
+    expect(coord_sf({ ratio: 2 })).toEqual(canonical);
+    expect(
+      gg(rows, aes({ x: "x", y: "y" }))
+        .geomPoint()
+        .coordSf({ ratio: 2 })
+        .spec().coord,
+    ).toEqual(canonical);
+  });
+
+  it("canonicalizes the default ratio", () => {
+    expect(coordSf()).toEqual({ type: "sf" });
+    expect(
+      normalize({ layers: [{ geom: "point" }], coord: { type: "sf", ratio: 1 } }).coord,
+    ).toEqual({ type: "sf" });
+  });
+
+  it("rejects free positional facets with the shared fixed-aspect error", () => {
+    for (const scales of ["free", "free_x", "free_y"] as const) {
+      const checked = result({ type: "sf" }, { wrap: "group", scales });
+      expect(checked.ok).toBe(false);
+      if (checked.ok) throw new Error("expected sf/free incompatibility");
+      const error = checked.errors.find((item) => item.code === "coord-fixed-free-scales");
+      expect(error?.code).toBe("coord-fixed-free-scales");
+      expect(error?.message).toContain("coord_sf");
+    }
+  });
+});

--- a/packages/svelte/src/lib/coord/CoordSf.svelte
+++ b/packages/svelte/src/lib/coord/CoordSf.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  /**
+   * <CoordSf> — declaration-only simple-features fixed-aspect coordinate layer
+   * for <GGPlot> (#809 phase 8). Accepts the same options as `coordSf(…)`.
+   * Already-projected data only (no CRS reproject in v1). Emits NO markup.
+   */
+  import { coordSf, type CoordSfOptions } from "@ggsvelte/spec";
+
+  import {
+    createPlotLayer,
+    definedProps,
+  } from "../layers/plot-layer.svelte.js";
+
+  const props: CoordSfOptions = $props();
+  createPlotLayer("coord", () => coordSf(definedProps(props)));
+</script>

--- a/packages/svelte/src/lib/index.ts
+++ b/packages/svelte/src/lib/index.ts
@@ -351,6 +351,7 @@ export { default as CoordCartesian } from "./coord/CoordCartesian.svelte";
 export { default as CoordTransform } from "./coord/CoordTransform.svelte";
 /** @lifecycle stable-intent */
 export { default as CoordFixed } from "./coord/CoordFixed.svelte";
+export { default as CoordSf } from "./coord/CoordSf.svelte";
 /** @lifecycle stable-intent */
 export { default as CoordEqual } from "./coord/CoordFixed.svelte";
 
@@ -605,7 +606,9 @@ export type {
   ColorScaleSpec,
   CoordSpec,
   CoordFixedOptions,
+  CoordSfOptions,
   CoordFixedSpec,
+  CoordSfSpec,
   CoordTransformAxisOptions,
   CoordTransformAxisSpec,
   CoordTransformName,


### PR DESCRIPTION
## Summary

**#809 phase 8** (stacks on #918 / `feat/809-stat-sf`): public **`coord_sf`**.

```ts
gg(geoTable, aes({ fill: "rate" }))
  .geomSf()
  .coordSf({ ratio: 1 })  // equal projected units
  .spec();
// coord: { type: "sf" }
```

### Contract

| Item | Choice |
|------|--------|
| Spec | `{ type: "sf", ratio?: number }` (y-unit / x-unit physical length; default 1) |
| Layout | Same fixed-aspect letterbox pass as `coord_fixed` |
| Free facets | `coord-fixed-free-scales` (messages name `coord_sf`) |
| CRS / graticules | **Deferred** — data must already be projected |
| Surface | `coordSf` / `coord_sf`, `.coordSf()`, `<CoordSf />` |

### Why

Issue #809 phases: (1) geometries, (2) labels, (3) projection/coord_sf. Full CRS is out of scope for portable v1; this ships the public name + truthful equal-unit map aspect for already-projected GeoJSON.

### Plan review

Claude CLI timed out; eng self-review (reuse layout, reject CRS keys via additionalProperties: false).

### Still deferred on #809

- CRS reproject / `default_crs` / datum graticules
- Hole ring metadata under active `coord_transform` tessellation

## Test plan

- [x] `packages/spec/tests/coord-sf-api.test.ts`
- [x] `packages/core/tests/pipeline-coord-sf.test.ts` (incl. geom_sf)
- [x] coord_fixed regressions + geom_sf suite
- [x] schema emit, lifecycle, catalog snapshots, type-contracts

Related: #809

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/924" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->