### PR TITLE
feat: GeometryCollection expand for geom_sf (#809 phase 6)

### DIFF
--- a/.changeset/809-geometrycollection.md
+++ b/.changeset/809-geometrycollection.md
@@ -1,0 +1,14 @@
+---
+"@ggsvelte/core": minor
+"@ggsvelte/spec": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+feat: GeometryCollection expand for geom_sf (#809 phase 6)
+
+Flatten GeoJSON GeometryCollection (recursively) to leaf point/line/polygon
+geometries for draw and labels. Mixed families still raise sf-geometry-mixed.
+
+Migration: none — additive; former GeometryCollection errors now expand when
+homogeneous.

--- a/packages/core/src/diagnostics-error-catalog.ts
+++ b/packages/core/src/diagnostics-error-catalog.ts
@@ -305,7 +305,7 @@ export const PIPELINE_ERROR_CATALOG = {
   },
   "sf-geometry-unsupported": {
     summary: "geom_sf received a GeoJSON type outside the v1 point/line/polygon families.",
-    fix: "Use Point, MultiPoint, LineString, MultiLineString, Polygon, or MultiPolygon (no GeometryCollection/CRS).",
+    fix: "Use Point/MultiPoint, LineString/MultiLineString, Polygon/MultiPolygon, or GeometryCollection of those families (no CRS).",
   },
   "sf-geometry-mixed": {
     summary: "One geom_sf layer mixes geometry families (point vs line vs polygon).",

--- a/packages/core/src/pipeline/frame-stats-sf-coordinates.ts
+++ b/packages/core/src/pipeline/frame-stats-sf-coordinates.ts
@@ -7,8 +7,7 @@ import { emptyFrameExtras } from "./frame-helpers.js";
 import {
   geometryFieldName,
   parseSfGeometry,
-  representativePoint,
-  sfKindOf,
+  representativePointsForGeometry,
 } from "./sf-geometry.js";
 import type { LayerBinding, LayerFrame, PipelineWarning } from "./types.js";
 import { PipelineError } from "./types.js";
@@ -83,19 +82,22 @@ export function buildSfCoordinatesFrame(
   let dropped = 0;
 
   for (let row = 0; row < table.rowCount; row++) {
-    const parsed = parseSfGeometry(geomCol[row]!, `/layers/${index}/data/${field}`);
-    // Validate type is in the supported family (throws on GeometryCollection).
-    sfKindOf(parsed.type, `/layers/${index}`);
-    const pt = representativePoint(parsed.type, parsed.coordinates);
-    if (pt === null) {
+    const path = `/layers/${index}/data/${field}`;
+    const parsed = parseSfGeometry(geomCol[row]!, path);
+    // GeometryCollection expands to one point per leaf (#809 phase 6).
+    const pts = representativePointsForGeometry(parsed, path);
+    if (pts.length === 0) {
+      // One drop per input feature with no usable part (empty GC / degenerate).
       dropped++;
       continue;
     }
-    outX.push(pt[0]);
-    outY.push(pt[1]);
-    outGroups.push(groups[row] ?? 0);
-    outRowIndex.push(row);
-    valueRows.push(row);
+    for (const pt of pts) {
+      outX.push(pt[0]);
+      outY.push(pt[1]);
+      outGroups.push(groups[row] ?? 0);
+      outRowIndex.push(row);
+      valueRows.push(row);
+    }
   }
 
   if (dropped > 0) {

--- a/packages/core/src/pipeline/frame-stats-sf.ts
+++ b/packages/core/src/pipeline/frame-stats-sf.ts
@@ -8,11 +8,13 @@ import { ColumnTable, type CellValue } from "../table.js";
 
 import { emptyFrameExtras } from "./frame-helpers.js";
 import {
+  expandSfLeaves,
   geometryFieldName,
   isFinitePair,
   parseSfGeometry,
   sfKindOf,
   type SfKind,
+  type SfLeaf,
   type SfPosition,
 } from "./sf-geometry.js";
 import type { LayerBinding, LayerFrame, PipelineWarning } from "./types.js";
@@ -132,37 +134,36 @@ export function buildSfFrame(
   let ringId = 0;
   let layerKind: SfKind | null = null;
   let holesIgnored = 0;
+  const layerPath = `/layers/${index}`;
 
-  for (let row = 0; row < table.rowCount; row++) {
-    const cellPath = `/layers/${index}/data/${field}`;
-    const parsed = parseSfGeometry(geomCol[row]!, cellPath);
-    const kind = sfKindOf(parsed.type, cellPath);
+  const emitLeaf = (leaf: SfLeaf, row: number): void => {
+    const kind = sfKindOf(leaf.type, layerPath);
     if (layerKind === null) layerKind = kind;
     else if (layerKind !== kind) {
       throw new PipelineError(
         "sf-geometry-mixed",
-        `/layers/${index}`,
+        layerPath,
         `geom_sf v1 requires a single geometry family per layer (found "${layerKind}" then "${kind}"). Split mixed types into separate layers.`,
       );
     }
 
-    const coords = parsed.coordinates;
-    if (parsed.type === "Point") {
+    const coords = leaf.coordinates;
+    if (leaf.type === "Point") {
       if (!isFinitePair(coords)) {
         throw new PipelineError(
           "sf-geometry-invalid",
-          `/layers/${index}`,
+          layerPath,
           "Point geometry requires a finite [x, y] coordinate pair.",
         );
       }
       pushPoint(outX, outY, outGroups, outRowIndex, valueRows, ringId++, row, coords);
-      continue;
+      return;
     }
-    if (parsed.type === "MultiPoint") {
+    if (leaf.type === "MultiPoint") {
       if (!Array.isArray(coords)) {
         throw new PipelineError(
           "sf-geometry-invalid",
-          `/layers/${index}`,
+          layerPath,
           "MultiPoint coordinates must be an array of positions.",
         );
       }
@@ -170,20 +171,20 @@ export function buildSfFrame(
         if (!isFinitePair(c)) continue;
         pushPoint(outX, outY, outGroups, outRowIndex, valueRows, ringId++, row, c);
       }
-      continue;
+      return;
     }
-    if (parsed.type === "LineString") {
+    if (leaf.type === "LineString") {
       const g = ringId++;
       if (!pushRing(outX, outY, outGroups, outRowIndex, valueRows, g, row, coords, 2, false)) {
         // drop empty
       }
-      continue;
+      return;
     }
-    if (parsed.type === "MultiLineString") {
+    if (leaf.type === "MultiLineString") {
       if (!Array.isArray(coords)) {
         throw new PipelineError(
           "sf-geometry-invalid",
-          `/layers/${index}`,
+          layerPath,
           "MultiLineString coordinates must be an array of line strings.",
         );
       }
@@ -191,26 +192,26 @@ export function buildSfFrame(
         const g = ringId++;
         pushRing(outX, outY, outGroups, outRowIndex, valueRows, g, row, line, 2, false);
       }
-      continue;
+      return;
     }
-    if (parsed.type === "Polygon") {
+    if (leaf.type === "Polygon") {
       if (!Array.isArray(coords) || coords.length === 0) {
         throw new PipelineError(
           "sf-geometry-invalid",
-          `/layers/${index}`,
+          layerPath,
           "Polygon coordinates must be a non-empty array of rings.",
         );
       }
       if (coords.length > 1) holesIgnored += coords.length - 1;
       const g = ringId++;
       pushRing(outX, outY, outGroups, outRowIndex, valueRows, g, row, coords[0], 3, true);
-      continue;
+      return;
     }
     // MultiPolygon
     if (!Array.isArray(coords)) {
       throw new PipelineError(
         "sf-geometry-invalid",
-        `/layers/${index}`,
+        layerPath,
         "MultiPolygon coordinates must be an array of polygons.",
       );
     }
@@ -220,6 +221,14 @@ export function buildSfFrame(
       const g = ringId++;
       pushRing(outX, outY, outGroups, outRowIndex, valueRows, g, row, poly[0], 3, true);
     }
+  };
+
+  for (let row = 0; row < table.rowCount; row++) {
+    const cellPath = `/layers/${index}/data/${field}`;
+    const parsed = parseSfGeometry(geomCol[row]!, cellPath);
+    // GeometryCollection expands to leaves; groups continue across parts (ringId++).
+    const leaves = expandSfLeaves(parsed, cellPath);
+    for (const leaf of leaves) emitLeaf(leaf, row);
   }
 
   if (holesIgnored > 0) {

--- a/packages/core/src/pipeline/sf-geometry.ts
+++ b/packages/core/src/pipeline/sf-geometry.ts
@@ -9,6 +9,19 @@ import { PipelineError } from "./types.js";
 export type SfKind = "point" | "line" | "polygon";
 export type SfPosition = readonly [number, number];
 
+/** Parsed GeoJSON Geometry object (coordinates and/or nested geometries). */
+export type SfParsed = {
+  type: string;
+  coordinates?: unknown;
+  geometries?: unknown;
+};
+
+/** Leaf geometry after GeometryCollection flattening (#809 phase 6). */
+export type SfLeaf = {
+  type: string;
+  coordinates: unknown;
+};
+
 export function isFinitePair(c: unknown): c is SfPosition {
   return (
     Array.isArray(c) &&
@@ -20,10 +33,7 @@ export function isFinitePair(c: unknown): c is SfPosition {
   );
 }
 
-export function parseSfGeometry(
-  raw: CellValue,
-  path: string,
-): { type: string; coordinates: unknown } {
+export function parseSfGeometry(raw: CellValue, path: string): SfParsed {
   if (typeof raw !== "string" || raw.length === 0) {
     throw new PipelineError(
       "sf-geometry-invalid",
@@ -41,23 +51,25 @@ export function parseSfGeometry(
       "geom_sf geometry cell is not valid JSON.",
     );
   }
-  if (parsed === null || typeof parsed !== "object" || !("type" in parsed)) {
+  if (
+    parsed === null ||
+    typeof parsed !== "object" ||
+    Array.isArray(parsed) ||
+    !("type" in parsed) ||
+    typeof (parsed as { type: unknown }).type !== "string"
+  ) {
     throw new PipelineError(
       "sf-geometry-invalid",
       path,
       'geom_sf geometry must be a GeoJSON Geometry object with a string "type".',
     );
   }
-  const type = parsed.type;
-  if (typeof type !== "string") {
-    throw new PipelineError(
-      "sf-geometry-invalid",
-      path,
-      'geom_sf geometry must be a GeoJSON Geometry object with a string "type".',
-    );
-  }
-  const coordinates = "coordinates" in parsed ? parsed.coordinates : undefined;
-  return { type, coordinates };
+  const geom = parsed as { type: string; coordinates?: unknown; geometries?: unknown };
+  return {
+    type: geom.type,
+    ...(geom.coordinates !== undefined && { coordinates: geom.coordinates }),
+    ...(geom.geometries !== undefined && { geometries: geom.geometries }),
+  };
 }
 
 export function sfKindOf(type: string, path = "/geometry"): SfKind {
@@ -75,9 +87,71 @@ export function sfKindOf(type: string, path = "/geometry"): SfKind {
       throw new PipelineError(
         "sf-geometry-unsupported",
         path,
-        `geom_sf does not support GeoJSON type "${type}" in v1 (point/line/polygon families only; no GeometryCollection or CRS).`,
+        `geom_sf does not support GeoJSON type "${type}" in v1 (point/line/polygon families only; no CRS).`,
       );
   }
+}
+
+/**
+ * Flatten GeometryCollection (recursively) to leaf Point/Line/Polygon families.
+ * Empty collections yield []. Mixed families are not filtered here — callers
+ * enforce layer homogeneity via {@link sfKindOf}.
+ */
+export function expandSfLeaves(geom: SfParsed, path: string): SfLeaf[] {
+  if (geom.type === "GeometryCollection") {
+    if (!Array.isArray(geom.geometries)) {
+      throw new PipelineError(
+        "sf-geometry-invalid",
+        path,
+        "GeometryCollection requires a geometries array.",
+      );
+    }
+    const out: SfLeaf[] = [];
+    for (const child of geom.geometries) {
+      if (
+        child === null ||
+        typeof child !== "object" ||
+        Array.isArray(child) ||
+        !("type" in child) ||
+        typeof (child as { type: unknown }).type !== "string"
+      ) {
+        throw new PipelineError(
+          "sf-geometry-invalid",
+          path,
+          "GeometryCollection members must be GeoJSON Geometry objects with a string type.",
+        );
+      }
+      const c = child as { type: string; coordinates?: unknown; geometries?: unknown };
+      out.push(
+        ...expandSfLeaves(
+          {
+            type: c.type,
+            ...(c.coordinates !== undefined && { coordinates: c.coordinates }),
+            ...(c.geometries !== undefined && { geometries: c.geometries }),
+          },
+          path,
+        ),
+      );
+    }
+    return out;
+  }
+  // Validate leaf family (throws on Feature, CRS objects, etc.).
+  sfKindOf(geom.type, path);
+  return [{ type: geom.type, coordinates: geom.coordinates }];
+}
+
+/** Label points for a geometry: GeometryCollection expands to one point per leaf. */
+export function representativePointsForGeometry(
+  geom: SfParsed,
+  path: string,
+): readonly SfPosition[] {
+  const leaves = expandSfLeaves(geom, path);
+  const out: SfPosition[] = [];
+  for (const leaf of leaves) {
+    const pt = representativePoint(leaf.type, leaf.coordinates);
+    if (pt !== null) out.push(pt);
+  }
+  return out;
 }
 
 function ringPositions(ring: unknown): SfPosition[] {

--- a/packages/core/tests/pipeline-m2/geom-sf-text.test.ts
+++ b/packages/core/tests/pipeline-m2/geom-sf-text.test.ts
@@ -134,6 +134,24 @@ describe("geom_sf_text / stat_sf_coordinates", () => {
     }
   });
 
+  it("places labels for each GeometryCollection leaf", () => {
+    const gc = geo({
+      type: "GeometryCollection",
+      geometries: [
+        { type: "Point", coordinates: [0, 0] },
+        { type: "Point", coordinates: [2, 2] },
+      ],
+    });
+    const model = runPipeline(
+      gg({ geometry: [gc], name: ["gc"] }, aes({ label: "name" }))
+        .geomSfText()
+        .spec(),
+      size,
+    );
+    const batch = model.scene.batches[0] as GlyphsBatch;
+    expect(batch.texts).toEqual(["gc", "gc"]);
+  });
+
   it("defaults stat to sf_coordinates", () => {
     const spec = gg(
       {

--- a/packages/core/tests/pipeline-m2/geom-sf.test.ts
+++ b/packages/core/tests/pipeline-m2/geom-sf.test.ts
@@ -235,7 +235,45 @@ describe("geom_sf", () => {
     }
   });
 
-  it("errors on GeometryCollection", () => {
+  it("renders GeometryCollection of polygons as multiple closed parts", () => {
+    const gc = geo({
+      type: "GeometryCollection",
+      geometries: [
+        {
+          type: "Polygon",
+          coordinates: [
+            [
+              [0, 0],
+              [1, 0],
+              [0.5, 1],
+              [0, 0],
+            ],
+          ],
+        },
+        {
+          type: "Polygon",
+          coordinates: [
+            [
+              [3, 0],
+              [4, 0],
+              [3.5, 1],
+              [3, 0],
+            ],
+          ],
+        },
+      ],
+    });
+    const model = runPipeline(
+      gg({ geometry: [gc], id: ["parts"] }, aes({ fill: "id" }))
+        .geomSf()
+        .spec(),
+      size,
+    );
+    const batch = model.scene.batches[0] as PathsBatch;
+    expect(batch.pathOffsets.length - 1).toBe(2);
+  });
+
+  it("errors when GeometryCollection mixes geometry families", () => {
     try {
       runPipeline(
         gg(
@@ -243,7 +281,20 @@ describe("geom_sf", () => {
             geometry: [
               geo({
                 type: "GeometryCollection",
-                geometries: [{ type: "Point", coordinates: [0, 0] }],
+                geometries: [
+                  { type: "Point", coordinates: [0, 0] },
+                  {
+                    type: "Polygon",
+                    coordinates: [
+                      [
+                        [0, 0],
+                        [1, 0],
+                        [0.5, 1],
+                        [0, 0],
+                      ],
+                    ],
+                  },
+                ],
               }),
             ],
           },
@@ -256,9 +307,7 @@ describe("geom_sf", () => {
       expect.unreachable();
     } catch (error) {
       expect(error).toBeInstanceOf(PipelineError);
-      expect((error as PipelineError).code).toBe("sf-geometry-unsupported");
-      // Layer-qualified path (not a bare "/geometry" that hides the layer).
-      expect((error as PipelineError).path).toMatch(/^\/layers\/0\//);
+      expect((error as PipelineError).code).toBe("sf-geometry-mixed");
     }
   });
 

--- a/packages/core/tests/pipeline-m2/sf-geometry-collection.test.ts
+++ b/packages/core/tests/pipeline-m2/sf-geometry-collection.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Pure GeometryCollection expand (#809 phase 6).
+ */
+import { describe, expect, it } from "bun:test";
+
+import { expandSfLeaves, representativePointsForGeometry } from "../../src/pipeline/sf-geometry.ts";
+import { PipelineError } from "../../src/pipeline/types.ts";
+
+describe("expandSfLeaves (#809 GeometryCollection)", () => {
+  it("flattens a homogeneous GeometryCollection to leaves", () => {
+    const leaves = expandSfLeaves(
+      {
+        type: "GeometryCollection",
+        geometries: [
+          { type: "Point", coordinates: [1, 2] },
+          { type: "Point", coordinates: [3, 4] },
+        ],
+      },
+      "/test",
+    );
+    expect(leaves).toEqual([
+      { type: "Point", coordinates: [1, 2] },
+      { type: "Point", coordinates: [3, 4] },
+    ]);
+  });
+
+  it("recursively flattens nested GeometryCollections", () => {
+    const leaves = expandSfLeaves(
+      {
+        type: "GeometryCollection",
+        geometries: [
+          {
+            type: "GeometryCollection",
+            geometries: [{ type: "Point", coordinates: [0, 0] }],
+          },
+          {
+            type: "Polygon",
+            coordinates: [
+              [
+                [0, 0],
+                [2, 0],
+                [2, 2],
+                [0, 2],
+                [0, 0],
+              ],
+            ],
+          },
+        ],
+      },
+      "/test",
+    );
+    expect(leaves.map((l) => l.type)).toEqual(["Point", "Polygon"]);
+  });
+
+  it("returns empty for empty GeometryCollection", () => {
+    expect(expandSfLeaves({ type: "GeometryCollection", geometries: [] }, "/test")).toEqual([]);
+  });
+
+  it("passes through leaf geometries", () => {
+    expect(expandSfLeaves({ type: "Point", coordinates: [1, 1] }, "/test")).toEqual([
+      { type: "Point", coordinates: [1, 1] },
+    ]);
+  });
+
+  it("rejects GeometryCollection without geometries array", () => {
+    expect(() => expandSfLeaves({ type: "GeometryCollection" }, "/test")).toThrow(PipelineError);
+  });
+});
+
+describe("representativePointsForGeometry (#809 GC labels)", () => {
+  it("one point per GeometryCollection leaf", () => {
+    const pts = representativePointsForGeometry(
+      {
+        type: "GeometryCollection",
+        geometries: [
+          { type: "Point", coordinates: [0, 0] },
+          { type: "Point", coordinates: [2, 2] },
+        ],
+      },
+      "/test",
+    );
+    expect(pts).toEqual([
+      [0, 0],
+      [2, 2],
+    ]);
+  });
+});

--- a/packages/spec/schema/v0.json
+++ b/packages/spec/schema/v0.json
@@ -1966,7 +1966,7 @@
         }
       },
       "additionalProperties": false,
-      "description": "Parameters for geom_sf (#809 phase 1): portable GeoJSON Geometry column plus styling. No CRS/coord_sf in v1."
+      "description": "Parameters for geom_sf (#809): portable GeoJSON Geometry column plus styling. GeometryCollection expands to leaf families. No CRS/coord_sf in v1."
     },
     "TextParams": {
       "type": "object",
@@ -3316,7 +3316,7 @@
         "geom": {
           "type": "string",
           "const": "sf",
-          "description": "Simple-features geometry (ggplot2 geom_sf; #809 phase 1): already-projected GeoJSON Geometry JSON strings in a data column. Point/line/polygon families; no CRS or coord_sf yet."
+          "description": "Simple-features geometry (ggplot2 geom_sf; #809): already-projected GeoJSON Geometry JSON strings in a data column. Point/line/polygon families and GeometryCollection of those; no CRS or coord_sf yet."
         },
         "stat": {
           "type": "string",

--- a/packages/spec/src/schema-declarations.ts
+++ b/packages/spec/src/schema-declarations.ts
@@ -2104,7 +2104,7 @@ export const SpecDeclarations = {
     {
       additionalProperties: false,
       description:
-        "Parameters for geom_sf (#809 phase 1): portable GeoJSON Geometry column plus styling. No CRS/coord_sf in v1.",
+        "Parameters for geom_sf (#809): portable GeoJSON Geometry column plus styling. GeometryCollection expands to leaf families. No CRS/coord_sf in v1.",
     },
   ),
 
@@ -3176,7 +3176,7 @@ export const SpecDeclarations = {
     {
       geom: Type.Literal("sf", {
         description:
-          "Simple-features geometry (ggplot2 geom_sf; #809 phase 1): already-projected GeoJSON Geometry JSON strings in a data column. Point/line/polygon families; no CRS or coord_sf yet.",
+          "Simple-features geometry (ggplot2 geom_sf; #809): already-projected GeoJSON Geometry JSON strings in a data column. Point/line/polygon families and GeometryCollection of those; no CRS or coord_sf yet.",
       }),
       stat: Type.Optional(
         Type.Literal("identity", { description: "SF layers expand geometry then draw as-is." }),


### PR DESCRIPTION
## Summary

**#809 phase 6** — **GeometryCollection** expand, standalone on current `main` (no stacked SF phase branches).

```ts
// GeometryCollection of two polygons → two closed path parts
gg({
  geometry: [JSON.stringify({
    type: "GeometryCollection",
    geometries: [polyA, polyB],
  })],
}, aes({ fill: "rate" })).geomSf()
```

### Contract

| Item | Choice |
|------|--------|
| Expand | Recursive flatten of `GeometryCollection` → leaf Point/Line/Polygon families |
| Parts | Continuous group ids across leaves (same as MultiPolygon) |
| Mixed families | `sf-geometry-mixed` (intra-collection or cross-row) |
| Empty GC | No drawable verts; coordinates drop + `sf-coordinates-dropped` |
| Labels | One label per leaf (`representativePointsForGeometry`) |
| CRS | Still unsupported |

### Why this PR

#917 stacks on unmerged holes/multipart branches. This reimplements the same contract **on post-#818 main** so it can land independently.

### Plan review

TDD: pure `expandSfLeaves` / `representativePointsForGeometry` → geom_sf / geom_sf_text pipeline.

Claude CLI not authenticated. Eng self-review of #917 design: **APPROVE** adapted to main (no holes ringIndex dependency).

## Test plan

- [x] `packages/core/tests/pipeline-m2/sf-geometry-collection.test.ts`
- [x] `geom-sf.test.ts` GC render + mixed error
- [x] `geom-sf-text.test.ts` GC labels
- [x] diagnostics catalog still complete

Related: #809  
Complements #917 (standalone main base)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/935" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->