### PR TITLE
feat: multi-part SF labels via stat_sf_coordinates (#809 phase 5)

### DIFF
--- a/.changeset/809-multipart-labels.md
+++ b/.changeset/809-multipart-labels.md
@@ -11,5 +11,4 @@ MultiPoint / MultiLineString / MultiPolygon expand to one label per geometry
 part (exterior centroid / vertex mean). Duplicates feature aesthetics onto each
 part.
 
-Migration: Multi* features that previously got a single first-component label
-now get one label per part.
+Migration: <https://ggsvelte.sh/guide/statistics-positions#sf-text-labels-geom-sf-text>

--- a/.changeset/809-multipart-labels.md
+++ b/.changeset/809-multipart-labels.md
@@ -1,0 +1,15 @@
+---
+"@ggsvelte/core": minor
+"@ggsvelte/spec": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+feat: multi-part SF labels via stat_sf_coordinates (#809 phase 5)
+
+MultiPoint / MultiLineString / MultiPolygon expand to one label per geometry
+part (exterior centroid / vertex mean). Duplicates feature aesthetics onto each
+part.
+
+Migration: Multi* features that previously got a single first-component label
+now get one label per part.

--- a/packages/core/src/pipeline/frame-stats-sf-coordinates.ts
+++ b/packages/core/src/pipeline/frame-stats-sf-coordinates.ts
@@ -1,5 +1,6 @@
 /**
- * stat_sf_coordinates (#809 phase 2): one (x,y) per feature from portable GeoJSON.
+ * stat_sf_coordinates (#809 phase 2 + multi-part labels phase 5):
+ * one (x,y) per geometry part from portable GeoJSON (Multi* expands).
  */
 import { ColumnTable, type CellValue } from "../table.js";
 
@@ -7,7 +8,7 @@ import { emptyFrameExtras } from "./frame-helpers.js";
 import {
   geometryFieldName,
   parseSfGeometry,
-  representativePoint,
+  representativePoints,
   sfKindOf,
 } from "./sf-geometry.js";
 import type { LayerBinding, LayerFrame, PipelineWarning } from "./types.js";
@@ -83,19 +84,23 @@ export function buildSfCoordinatesFrame(
   let dropped = 0;
 
   for (let row = 0; row < table.rowCount; row++) {
-    const parsed = parseSfGeometry(geomCol[row]!, `/layers/${index}/data/${field}`);
+    const path = `/layers/${index}/data/${field}`;
+    const parsed = parseSfGeometry(geomCol[row]!, path);
     // Validate type is in the supported family (throws on GeometryCollection).
-    sfKindOf(parsed.type, `/layers/${index}`);
-    const pt = representativePoint(parsed.type, parsed.coordinates);
-    if (pt === null) {
+    sfKindOf(parsed.type, path);
+    const pts = representativePoints(parsed.type, parsed.coordinates);
+    if (pts.length === 0) {
+      // One drop per input feature with no usable part (not per empty part).
       dropped++;
       continue;
     }
-    outX.push(pt[0]);
-    outY.push(pt[1]);
-    outGroups.push(groups[row] ?? 0);
-    outRowIndex.push(row);
-    valueRows.push(row);
+    for (const pt of pts) {
+      outX.push(pt[0]);
+      outY.push(pt[1]);
+      outGroups.push(groups[row] ?? 0);
+      outRowIndex.push(row);
+      valueRows.push(row);
+    }
   }
 
   if (dropped > 0) {

--- a/packages/core/src/pipeline/sf-geometry.ts
+++ b/packages/core/src/pipeline/sf-geometry.ts
@@ -129,35 +129,57 @@ function polygonCentroid(ring: unknown): SfPosition | null {
 }
 
 /**
- * One representative point per feature (ggplot2 stat_sf_coordinates-style).
- * Multi* geometries use the first component only in v1.
+ * One or more representative points for label placement (#809 phase 5).
+ * Multi* geometries expand to **one point per part** (not only the first).
+ * Degenerate / empty parts are skipped.
  */
-export function representativePoint(type: string, coordinates: unknown): SfPosition | null {
-  if (type === "Point") return isFinitePair(coordinates) ? coordinates : null;
+export function representativePoints(type: string, coordinates: unknown): readonly SfPosition[] {
+  if (type === "Point") return isFinitePair(coordinates) ? [coordinates] : [];
   if (type === "MultiPoint") {
-    if (!Array.isArray(coordinates)) return null;
+    if (!Array.isArray(coordinates)) return [];
     const pts: SfPosition[] = [];
     for (const c of coordinates) {
       if (isFinitePair(c)) pts.push(c);
     }
-    return meanPosition(pts);
+    return pts;
   }
-  if (type === "LineString") return meanPosition(ringPositions(coordinates));
+  if (type === "LineString") {
+    const m = meanPosition(ringPositions(coordinates));
+    return m === null ? [] : [m];
+  }
   if (type === "MultiLineString") {
-    if (!Array.isArray(coordinates) || coordinates.length === 0) return null;
-    return meanPosition(ringPositions(coordinates[0]));
+    if (!Array.isArray(coordinates)) return [];
+    const out: SfPosition[] = [];
+    for (const line of coordinates) {
+      const m = meanPosition(ringPositions(line));
+      if (m !== null) out.push(m);
+    }
+    return out;
   }
   if (type === "Polygon") {
-    if (!Array.isArray(coordinates) || coordinates.length === 0) return null;
-    return polygonCentroid(coordinates[0]);
+    if (!Array.isArray(coordinates) || coordinates.length === 0) return [];
+    const c = polygonCentroid(coordinates[0]);
+    return c === null ? [] : [c];
   }
   if (type === "MultiPolygon") {
-    if (!Array.isArray(coordinates) || coordinates.length === 0) return null;
-    const poly: unknown = coordinates[0];
-    if (!Array.isArray(poly) || poly.length === 0) return null;
-    return polygonCentroid(poly[0]);
+    if (!Array.isArray(coordinates)) return [];
+    const out: SfPosition[] = [];
+    for (const poly of coordinates) {
+      if (!Array.isArray(poly) || poly.length === 0) continue;
+      const c = polygonCentroid(poly[0]);
+      if (c !== null) out.push(c);
+    }
+    return out;
   }
-  return null;
+  return [];
+}
+
+/**
+ * First representative point (compat for single-point consumers).
+ * Prefer {@link representativePoints} for Multi* label expansion.
+ */
+export function representativePoint(type: string, coordinates: unknown): SfPosition | null {
+  return representativePoints(type, coordinates)[0] ?? null;
 }
 
 export function geometryFieldName(params: { geometry?: string } | undefined): string {

--- a/packages/core/tests/pipeline-m2/geom-sf-text.test.ts
+++ b/packages/core/tests/pipeline-m2/geom-sf-text.test.ts
@@ -88,6 +88,68 @@ describe("geom_sf_text / stat_sf_coordinates", () => {
     expect(batch.texts).toEqual(["a", "b"]);
   });
 
+  it("places one label per MultiPolygon part (same feature attrs)", () => {
+    const multi = geo({
+      type: "MultiPolygon",
+      coordinates: [
+        [
+          [
+            [0, 0],
+            [2, 0],
+            [2, 2],
+            [0, 2],
+            [0, 0],
+          ],
+        ],
+        [
+          [
+            [10, 10],
+            [12, 10],
+            [12, 12],
+            [10, 12],
+            [10, 10],
+          ],
+        ],
+      ],
+    });
+    const model = runPipeline(
+      gg({ geometry: [multi], name: ["islands"] }, aes({ label: "name" }))
+        .geomSfText()
+        .spec(),
+      size,
+    );
+    const batch = model.scene.batches[0] as GlyphsBatch;
+    expect(batch.texts).toEqual(["islands", "islands"]);
+    // Two distinct panel positions (centroids (1,1) vs (11,11)).
+    expect(batch.positions.length / 2).toBe(2);
+    expect(batch.positions[0]!).not.toBe(batch.positions[2]!);
+  });
+
+  it("places one label per MultiPoint vertex", () => {
+    const model = runPipeline(
+      gg(
+        {
+          geometry: [
+            geo({
+              type: "MultiPoint",
+              coordinates: [
+                [0, 0],
+                [5, 5],
+              ],
+            }),
+          ],
+          name: ["pts"],
+        },
+        aes({ label: "name" }),
+      )
+        .geomSfText()
+        .spec(),
+      size,
+    );
+    const batch = model.scene.batches[0] as GlyphsBatch;
+    expect(batch.texts).toEqual(["pts", "pts"]);
+  });
+
   it("uses exact auto hit mode", () => {
     const model = runPipeline(
       gg(

--- a/packages/core/tests/pipeline-m2/sf-geometry.test.ts
+++ b/packages/core/tests/pipeline-m2/sf-geometry.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Pure portable GeoJSON helpers for geom_sf / stat_sf_coordinates (#809).
+ */
+import { describe, expect, it } from "bun:test";
+
+import { representativePoint, representativePoints } from "../../src/pipeline/sf-geometry.ts";
+
+describe("representativePoints (#809 multi-part labels)", () => {
+  it("returns one point for Point / LineString / Polygon", () => {
+    expect(representativePoints("Point", [1, 2])).toEqual([[1, 2]]);
+    expect(
+      representativePoints("LineString", [
+        [0, 0],
+        [2, 0],
+        [2, 2],
+      ]),
+    ).toEqual([[4 / 3, 2 / 3]]);
+    // Unit square [0,2]×[0,2] exterior → centroid (1,1)
+    expect(
+      representativePoints("Polygon", [
+        [
+          [0, 0],
+          [2, 0],
+          [2, 2],
+          [0, 2],
+          [0, 0],
+        ],
+      ]),
+    ).toEqual([[1, 1]]);
+  });
+
+  it("returns one point per MultiPoint vertex", () => {
+    expect(
+      representativePoints("MultiPoint", [
+        [0, 0],
+        [1, 1],
+        [2, 3],
+      ]),
+    ).toEqual([
+      [0, 0],
+      [1, 1],
+      [2, 3],
+    ]);
+  });
+
+  it("returns one centroid per MultiPolygon part", () => {
+    const pts = representativePoints("MultiPolygon", [
+      [
+        [
+          [0, 0],
+          [2, 0],
+          [2, 2],
+          [0, 2],
+          [0, 0],
+        ],
+      ],
+      [
+        [
+          [10, 10],
+          [12, 10],
+          [12, 12],
+          [10, 12],
+          [10, 10],
+        ],
+      ],
+    ]);
+    expect(pts).toEqual([
+      [1, 1],
+      [11, 11],
+    ]);
+  });
+
+  it("returns one vertex-mean per MultiLineString part", () => {
+    expect(
+      representativePoints("MultiLineString", [
+        [
+          [0, 0],
+          [2, 0],
+        ],
+        [
+          [10, 10],
+          [10, 12],
+        ],
+      ]),
+    ).toEqual([
+      [1, 0],
+      [10, 11],
+    ]);
+  });
+
+  it("skips empty / degenerate Multi* parts", () => {
+    expect(
+      representativePoints("MultiPoint", [
+        [Number.NaN, 0],
+        [1, 2],
+      ]),
+    ).toEqual([[1, 2]]);
+    expect(
+      representativePoints("MultiPolygon", [
+        [[]],
+        [
+          [
+            [0, 0],
+            [2, 0],
+            [2, 2],
+            [0, 2],
+            [0, 0],
+          ],
+        ],
+      ]),
+    ).toEqual([[1, 1]]);
+  });
+
+  it("representativePoint remains first of multi-part list (compat)", () => {
+    expect(
+      representativePoint("MultiPolygon", [
+        [
+          [
+            [0, 0],
+            [2, 0],
+            [2, 2],
+            [0, 2],
+            [0, 0],
+          ],
+        ],
+        [
+          [
+            [10, 10],
+            [12, 10],
+            [12, 12],
+            [10, 12],
+            [10, 10],
+          ],
+        ],
+      ]),
+    ).toEqual([1, 1]);
+  });
+});

--- a/packages/spec/schema/v0.json
+++ b/packages/spec/schema/v0.json
@@ -3462,12 +3462,12 @@
         "geom": {
           "type": "string",
           "const": "sf_text",
-          "description": "Simple-features text labels (ggplot2 geom_sf_text; #809 phase 2): places aes.label at a representative point from each GeoJSON Geometry (stat_sf_coordinates)."
+          "description": "Simple-features text labels (ggplot2 geom_sf_text; #809): places aes.label at representative geometry points (Multi* → one label per part; stat_sf_coordinates)."
         },
         "stat": {
           "type": "string",
           "const": "sf_coordinates",
-          "description": "Extract one (x,y) representative point per feature from geometry."
+          "description": "Extract (x,y) representative points from geometry (Multi* → one point per part)."
         },
         "position": {
           "type": "string",
@@ -3563,12 +3563,12 @@
         "geom": {
           "type": "string",
           "const": "sf_label",
-          "description": "Simple-features labels with background boxes (ggplot2 geom_sf_label; #809 phase 3): places aes.label at a representative geometry point with a measured rounded rect. color=ink+box stroke; fill=box background."
+          "description": "Simple-features labels with background boxes (ggplot2 geom_sf_label; #809): places aes.label at representative geometry points with a measured rounded rect (Multi* → one label per part). color=ink+box stroke; fill=box background."
         },
         "stat": {
           "type": "string",
           "const": "sf_coordinates",
-          "description": "Extract one (x,y) representative point per feature from geometry."
+          "description": "Extract (x,y) representative points from geometry (Multi* → one point per part)."
         },
         "position": {
           "type": "string",

--- a/packages/spec/src/schema-declarations.ts
+++ b/packages/spec/src/schema-declarations.ts
@@ -3315,11 +3315,12 @@ export const SpecDeclarations = {
     {
       geom: Type.Literal("sf_text", {
         description:
-          "Simple-features text labels (ggplot2 geom_sf_text; #809 phase 2): places aes.label at a representative point from each GeoJSON Geometry (stat_sf_coordinates).",
+          "Simple-features text labels (ggplot2 geom_sf_text; #809): places aes.label at representative geometry points (Multi* → one label per part; stat_sf_coordinates).",
       }),
       stat: Type.Optional(
         Type.Literal("sf_coordinates", {
-          description: "Extract one (x,y) representative point per feature from geometry.",
+          description:
+            "Extract (x,y) representative points from geometry (Multi* → one point per part).",
         }),
       ),
       position: Type.Optional(
@@ -3411,11 +3412,12 @@ export const SpecDeclarations = {
     {
       geom: Type.Literal("sf_label", {
         description:
-          "Simple-features labels with background boxes (ggplot2 geom_sf_label; #809 phase 3): places aes.label at a representative geometry point with a measured rounded rect. color=ink+box stroke; fill=box background.",
+          "Simple-features labels with background boxes (ggplot2 geom_sf_label; #809): places aes.label at representative geometry points with a measured rounded rect (Multi* → one label per part). color=ink+box stroke; fill=box background.",
       }),
       stat: Type.Optional(
         Type.Literal("sf_coordinates", {
-          description: "Extract one (x,y) representative point per feature from geometry.",
+          description:
+            "Extract (x,y) representative points from geometry (Multi* → one point per part).",
         }),
       ),
       position: Type.Optional(

--- a/scripts/llms-guide-content.ts
+++ b/scripts/llms-guide-content.ts
@@ -394,10 +394,16 @@ gg(regions, aes({ fill: "rate" })).geomSf().spec();
 ### SF text labels (\`geom_sf_text\`)
 
 \`geom_sf_text\` (ggplot2 \`geom_sf_text\`) defaults to \`stat_sf_coordinates\`:
-one representative point per feature, then draws \`aes.label\` there. Point
-coordinates pass through; MultiPoint/LineString use the vertex mean; Polygon
-uses the exterior-ring shoelace centroid. Multi* geometries use the **first**
-component only in v1. Requires \`aes.label\` (no \`aes.x\`/\`aes.y\`).
+one representative point per geometry part, then draws \`aes.label\` there.
+Point coordinates pass through; MultiPoint/LineString use the vertex mean;
+Polygon uses the exterior-ring shoelace centroid. **MultiPoint /
+MultiLineString / MultiPolygon emit one label per part** (feature aesthetics
+duplicated onto each part). Requires \`aes.label\` (no \`aes.x\`/\`aes.y\`).
+
+**Migration (multi-part labels):** earlier releases labeled only the first
+Multi* component. Callers that relied on a single first-component label will
+now see one label per part — filter geometries or aggregate labels if you need
+the old single-label behavior.
 
 \`\`\`svelte fragment
 <GeomSf alpha={0.55} />


### PR DESCRIPTION
## Summary

**#809 phase 5** — multi-part SF labels, standalone on current `main`.

```ts
// MultiPolygon with two islands → two "islands" labels at each part centroid
gg({ geometry: [multiPolygon], name: ["islands"] }, aes({ label: "name" }))
  .geomSfText()
```

### Contract

| Type | Labels |
|------|--------|
| Point / LineString / Polygon | 1 (unchanged) |
| MultiPoint | 1 per finite point |
| MultiLineString | 1 per line (vertex mean) |
| MultiPolygon | 1 per polygon part (exterior-ring centroid) |
| Attributes | Duplicated from the source feature |
| Dropped | 1 warning unit per input feature with **no** usable part |

### Why this PR

#914 stacks on unmerged holes. This reimplements the same contract **on post-spoke main** so it can land independently.

### Plan review

TDD seams: pure `representativePoints` → `stat_sf_coordinates` expand → geom_sf_text Multi* cases.

Claude CLI not authenticated. Eng self-review of #914 design: **APPROVE** — one-per-part is the v1 completion of first-component-only (documented migration).

## Test plan

- [x] `packages/core/tests/pipeline-m2/sf-geometry.test.ts` (6 pure cases)
- [x] `geom-sf-text.test.ts` MultiPolygon + MultiPoint
- [x] geom_sf_label suite green
- [x] pipeline-m2 (180 pass)

Related: #809  
Complements #914 (standalone main base)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/936" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->