### PR TITLE
fix(docs): MultiPoint SF labels are per-point, not vertex mean (#936)

### DIFF
--- a/scripts/gen-llms.test.ts
+++ b/scripts/gen-llms.test.ts
@@ -30,6 +30,7 @@ import {
   buildLlmsIndex,
   GETTING_STARTED_MD,
   COMPATIBILITY_MD,
+  STATISTICS_POSITIONS_MD,
   INTERACTIONS_MD,
   INTERACTION_REFERENCE_MD,
   INTERACTION_REFERENCE_INDEX,
@@ -209,6 +210,15 @@ describe("guide sections cover their catalogs", () => {
     expect(TEMPORAL_SCALES_MD).toContain("scaleDecisions");
     expect(TEMPORAL_SCALES_MD).toContain('.scaleXDate({ parse: "dmy" })');
     expect(TEMPORAL_SCALES_MD).toContain("scale_x_discrete()");
+  });
+
+  it("documents multi-part SF labels: MultiPoint per point, LineString vertex mean", () => {
+    // #809 phase 5: MultiPoint emits one label per finite point (not a single mean).
+    // LineString still uses the vertex mean. The guide must not contradict itself.
+    expect(STATISTICS_POSITIONS_MD).toContain("### SF text labels");
+    expect(STATISTICS_POSITIONS_MD).toContain("one label per part");
+    expect(STATISTICS_POSITIONS_MD).toContain("LineString uses the vertex mean");
+    expect(STATISTICS_POSITIONS_MD).not.toContain("MultiPoint/LineString use the vertex mean");
   });
 
   it("documents the machine-checked packed-consumer support contract", () => {

--- a/scripts/llms-guide-content.ts
+++ b/scripts/llms-guide-content.ts
@@ -396,7 +396,7 @@ gg(regions, aes({ fill: "rate" })).geomSf().spec();
 
 \`geom_sf_text\` (ggplot2 \`geom_sf_text\`) defaults to \`stat_sf_coordinates\`:
 one representative point per geometry part, then draws \`aes.label\` there.
-Point coordinates pass through; MultiPoint/LineString use the vertex mean;
+Point coordinates pass through; LineString uses the vertex mean;
 Polygon uses the exterior-ring shoelace centroid. **MultiPoint /
 MultiLineString / MultiPolygon emit one label per part** (feature aesthetics
 duplicated onto each part). Requires \`aes.label\` (no \`aes.x\`/\`aes.y\`).


### PR DESCRIPTION
## Summary

Follow-up for unrebutted post-merge Devin finding on #936.

The SF text-labels guide said MultiPoint/LineString use the vertex mean, but
`representativePoints` for MultiPoint now returns one point per finite
coordinate (phase 5). Only LineString still uses the vertex mean. That left
the guide self-contradicting against the bold multipartite sentence.

## Root cause

Stale clause after #809 phase 5: MultiPoint placement changed; prose did not.

## Changes

- `scripts/llms-guide-content.ts`: "LineString uses the vertex mean"
- `scripts/gen-llms.test.ts`: contract test locks multipartite wording

## Evidence

```
bun test scripts/gen-llms.test.ts
# 30 pass
```

Parent: #936
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/938" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->