### PR TITLE
fix(core): strip SF hole verts under active coord transforms (#934)

### DIFF
--- a/packages/core/src/pipeline/coord-path-project.ts
+++ b/packages/core/src/pipeline/coord-path-project.ts
@@ -57,6 +57,56 @@ function expandedStepVertices(
   return { positions: p, rows: r, anchors: a, indices };
 }
 
+/**
+ * Until coord_sf remaps multi-ring hole topology through tessellation, drop
+ * interior-ring vertices (and even-odd metadata) before projection so exterior
+ * alone is rendered. Deleting ringStarts/fillRule while keeping hole verts
+ * merges exterior+hole into one ring (spurious chord + solid hole).
+ */
+function stripUnremappedHoleRings(batch: PathsBatch): number {
+  const breaks = batch.ringStarts;
+  if (breaks === undefined || breaks.length === 0) {
+    if (batch.fillRule !== undefined) delete batch.fillRule;
+    return 0;
+  }
+  const positions: number[] = [];
+  const rows: number[] = [];
+  const closedFrameRows: number[] | undefined =
+    batch.closedFrameRows === undefined ? undefined : [];
+  const offsets: number[] = [0];
+  let dropped = 0;
+  for (let s = 0; s + 1 < batch.pathOffsets.length; s++) {
+    const start = batch.pathOffsets[s]!;
+    const end = batch.pathOffsets[s + 1]!;
+    let exteriorEnd = end;
+    for (let i = 0; i < breaks.length; i++) {
+      const rs = breaks[i]!;
+      if (rs > start && rs < end) {
+        exteriorEnd = rs;
+        break;
+      }
+    }
+    dropped += end - exteriorEnd;
+    for (let v = start; v < exteriorEnd; v++) {
+      positions.push(batch.positions[v * 2]!, batch.positions[v * 2 + 1]!);
+      rows.push(batch.rowIndex[v]!);
+      if (closedFrameRows !== undefined) {
+        closedFrameRows.push(batch.closedFrameRows![v]!);
+      }
+    }
+    offsets.push(positions.length / 2);
+  }
+  batch.positions = Float32Array.from(positions);
+  batch.rowIndex = Uint32Array.from(rows);
+  batch.pathOffsets = Uint32Array.from(offsets);
+  if (closedFrameRows !== undefined) {
+    batch.closedFrameRows = Uint32Array.from(closedFrameRows);
+  }
+  delete batch.ringStarts;
+  delete batch.fillRule;
+  return dropped;
+}
+
 export function projectPathBatch(
   batch: PathsBatch,
   projector: PanelCoordProjector,
@@ -65,6 +115,18 @@ export function projectPathBatch(
   warnings: PipelineWarning[],
   sharedBudget?: CoordTessellationBudget,
 ): void {
+  const holesDropped = stripUnremappedHoleRings(batch);
+  if (holesDropped > 0 && sharedBudget !== undefined) {
+    sharedBudget.mandatoryVertices = Math.max(0, sharedBudget.mandatoryVertices - holesDropped);
+    const allowedExtra = Math.max(
+      0,
+      MAX_COORD_VERTICES_PER_PANEL_LAYER - sharedBudget.mandatoryVertices,
+    );
+    sharedBudget.extraRemaining = Math.min(
+      sharedBudget.extraRemaining + holesDropped,
+      allowedExtra,
+    );
+  }
   const projected: number[] = [];
   const rows: number[] = [];
   const semanticAnchors: number[] = [];
@@ -222,9 +284,8 @@ export function projectPathBatch(
   if (linetypeIndexes !== undefined) batch.linetypeIndexes = Uint8Array.from(linetypeIndexes);
   batch.semanticAnchors = Uint8Array.from(semanticAnchors);
   batch.semanticIndex = Uint32Array.from(semanticIndices);
-  // Multi-ring hole topology is not remapped under active coord transforms yet
-  // (#809 phase 4 / coord_sf deferred). Drop even-odd ring metadata so hits
-  // do not use stale vertex indices after tessellation.
+  // Hole verts + ringStarts are stripped at entry (stripUnremappedHoleRings).
+  // Keep a defensive clear if a future path reintroduces them mid-function.
   if (batch.ringStarts !== undefined) delete batch.ringStarts;
   if (batch.fillRule !== undefined) delete batch.fillRule;
   if (invalidVertices > 0) {

--- a/packages/core/tests/pipeline-m2/geom-sf.test.ts
+++ b/packages/core/tests/pipeline-m2/geom-sf.test.ts
@@ -207,6 +207,52 @@ describe("geom_sf", () => {
     expect(model.candidates.hitTest(hole.px, hole.py)).toBeNull();
   });
 
+  it("under active coord transform keeps exterior only (no merged hole verts)", () => {
+    // #934 / Devin: projectPathBatch dropped ringStarts/fillRule but kept hole
+    // vertices, so exterior+hole merged into one ring (spurious chord). Until
+    // coord_sf remaps multi-ring topology, strip hole verts so only exterior
+    // survives the transform (same as pre-phase-4 exterior-only under transforms).
+    const withHole = geo({
+      type: "Polygon",
+      coordinates: [
+        [
+          [1, 1],
+          [10, 1],
+          [10, 10],
+          [1, 10],
+          [1, 1],
+        ],
+        [
+          [3, 3],
+          [7, 3],
+          [7, 7],
+          [3, 7],
+          [3, 3],
+        ],
+      ],
+    });
+    const model = runPipeline(
+      gg({ geometry: [withHole] }, aes({}))
+        .geomSf()
+        .scales({
+          x: { type: "linear", domain: [1, 100], expand: { mult: 0, add: 0 } },
+          y: { type: "linear", domain: [1, 100], expand: { mult: 0, add: 0 } },
+        })
+        .coordTransform({ x: { transform: "log10", expand: false } })
+        .spec(),
+      size,
+    );
+    const batch = model.scene.batches[0] as PathsBatch;
+    expect(batch.kind).toBe("paths");
+    expect(batch.closed).toBe(true);
+    // Hole metadata must not remain with stale indices.
+    expect(batch.ringStarts).toBeUndefined();
+    expect(batch.fillRule).toBeUndefined();
+    // Exterior only: 4 verts (closing duplicate dropped). Not exterior+hole (8).
+    expect(batch.positions.length / 2).toBe(4);
+    expect(batch.pathOffsets.length - 1).toBe(1);
+  });
+
   it("keeps MultiPolygon parts as separate compounds when one has a hole", () => {
     const multi = geo({
       type: "MultiPolygon",


### PR DESCRIPTION
## Summary

Follow-up for unrebutted post-merge Devin finding on #934.

`projectPathBatch` dropped `ringStarts` / `fillRule` under active coord
transforms but kept hole vertices inside the same subpath. Renderers and
hit-testing then treated exterior+hole as one ring: a chord into the hole and
a solid fill over the hole.

## Root cause

Hole topology is not remapped through tessellation (`#809` phase 4 /
`coord_sf` deferred). Metadata was cleared; vertices were not.

## Fix

Strip interior-ring vertices (and even-odd metadata) at the start of
`projectPathBatch` so only the exterior is projected. Identity / inactive
projectors still keep even-odd holes. Remapping rings through tessellation
remains deferred with `coord_sf`.

## Evidence

```
bun test packages/core/tests/pipeline-m2/geom-sf.test.ts packages/core/tests/pipeline-coord-transform
# 40 pass
```

Parent: #934
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/941" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->