### PR TITLE
fix: preserve SF polygon holes under coord_transform (#809 phase 9)

### DIFF
--- a/.changeset/809-sf-holes-coord-transform.md
+++ b/.changeset/809-sf-holes-coord-transform.md
@@ -1,0 +1,10 @@
+---
+"@ggsvelte/core": patch
+---
+
+# Preserve geom_sf polygon holes under coord_transform (#809 phase 9)
+
+`projectPathBatch` now projects each even-odd ring independently, remaps
+`ringStarts` after tessellation, and keeps `fillRule: "evenodd"`. Multi-ring
+compounds with any invalid vertex still drop whole. Replaces the #941 stopgap
+that stripped interior rings under active projectors.

--- a/packages/core/src/pipeline/coord-path-project.ts
+++ b/packages/core/src/pipeline/coord-path-project.ts
@@ -57,56 +57,6 @@ function expandedStepVertices(
   return { positions: p, rows: r, anchors: a, indices };
 }
 
-/**
- * Until coord_sf remaps multi-ring hole topology through tessellation, drop
- * interior-ring vertices (and even-odd metadata) before projection so exterior
- * alone is rendered. Deleting ringStarts/fillRule while keeping hole verts
- * merges exterior+hole into one ring (spurious chord + solid hole).
- */
-function stripUnremappedHoleRings(batch: PathsBatch): number {
-  const breaks = batch.ringStarts;
-  if (breaks === undefined || breaks.length === 0) {
-    if (batch.fillRule !== undefined) delete batch.fillRule;
-    return 0;
-  }
-  const positions: number[] = [];
-  const rows: number[] = [];
-  const closedFrameRows: number[] | undefined =
-    batch.closedFrameRows === undefined ? undefined : [];
-  const offsets: number[] = [0];
-  let dropped = 0;
-  for (let s = 0; s + 1 < batch.pathOffsets.length; s++) {
-    const start = batch.pathOffsets[s]!;
-    const end = batch.pathOffsets[s + 1]!;
-    let exteriorEnd = end;
-    for (let i = 0; i < breaks.length; i++) {
-      const rs = breaks[i]!;
-      if (rs > start && rs < end) {
-        exteriorEnd = rs;
-        break;
-      }
-    }
-    dropped += end - exteriorEnd;
-    for (let v = start; v < exteriorEnd; v++) {
-      positions.push(batch.positions[v * 2]!, batch.positions[v * 2 + 1]!);
-      rows.push(batch.rowIndex[v]!);
-      if (closedFrameRows !== undefined) {
-        closedFrameRows.push(batch.closedFrameRows![v]!);
-      }
-    }
-    offsets.push(positions.length / 2);
-  }
-  batch.positions = Float32Array.from(positions);
-  batch.rowIndex = Uint32Array.from(rows);
-  batch.pathOffsets = Uint32Array.from(offsets);
-  if (closedFrameRows !== undefined) {
-    batch.closedFrameRows = Uint32Array.from(closedFrameRows);
-  }
-  delete batch.ringStarts;
-  delete batch.fillRule;
-  return dropped;
-}
-
 export function projectPathBatch(
   batch: PathsBatch,
   projector: PanelCoordProjector,
@@ -115,18 +65,6 @@ export function projectPathBatch(
   warnings: PipelineWarning[],
   sharedBudget?: CoordTessellationBudget,
 ): void {
-  const holesDropped = stripUnremappedHoleRings(batch);
-  if (holesDropped > 0 && sharedBudget !== undefined) {
-    sharedBudget.mandatoryVertices = Math.max(0, sharedBudget.mandatoryVertices - holesDropped);
-    const allowedExtra = Math.max(
-      0,
-      MAX_COORD_VERTICES_PER_PANEL_LAYER - sharedBudget.mandatoryVertices,
-    );
-    sharedBudget.extraRemaining = Math.min(
-      sharedBudget.extraRemaining + holesDropped,
-      allowedExtra,
-    );
-  }
   const projected: number[] = [];
   const rows: number[] = [];
   const semanticAnchors: number[] = [];
@@ -178,6 +116,84 @@ export function projectPathBatch(
     capped = validMandatory > MAX_COORD_VERTICES_PER_PANEL_LAYER;
   }
 
+  /**
+   * Project a half-open source vertex range [runStart, runEnd) into `projected`.
+   * Returns false when the range is empty.
+   *
+   * Per-ring subpath vertex budget: each call resets subpathExtraRemaining, so
+   * an N-ring compound can use up to N × MAX_COORD_VERTICES_PER_SUBPATH of
+   * tessellation budget (panel cap still shared via panelExtraRemaining).
+   */
+  const projectRun = (runStart: number, runEnd: number): boolean => {
+    if (runEnd <= runStart) return false;
+    const authoredCount = runEnd - runStart;
+    const desiredStepCorners = batch.curve === "step" ? Math.max(0, 2 * (authoredCount - 1)) : 0;
+    const stepCornerAllowance = Math.min(
+      panelExtraRemaining,
+      Math.max(0, MAX_COORD_VERTICES_PER_SUBPATH - authoredCount),
+    );
+    const source =
+      batch.curve === "step"
+        ? expandedStepVertices(unprojected, batch.rowIndex, runStart, runEnd, stepCornerAllowance)
+        : {
+            positions: Array.from(unprojected.slice(runStart * 2, runEnd * 2)),
+            rows: Array.from(batch.rowIndex.slice(runStart, runEnd)),
+            anchors: Array.from({ length: authoredCount }, () => 1),
+            indices: indexRange(runStart, runEnd),
+          };
+    const count = source.rows.length;
+    if (count === 0) return false;
+    const emittedStepCorners = Math.max(0, count - authoredCount);
+    if (emittedStepCorners < desiredStepCorners) capped = true;
+    panelExtraRemaining -= emittedStepCorners;
+    const [firstX, firstY] = projectPoint(
+      projector,
+      width,
+      height,
+      source.positions[0]!,
+      source.positions[1]!,
+    );
+    projected.push(firstX, firstY);
+    rows.push(source.rows[0]!);
+    semanticAnchors.push(source.anchors[0]!);
+    semanticIndices.push(source.indices[0]!);
+    let subpathExtraRemaining = Math.max(0, MAX_COORD_VERTICES_PER_SUBPATH - count);
+    if (count > MAX_COORD_VERTICES_PER_SUBPATH) capped = true;
+    for (let i = 1; i < count; i++) {
+      const allowance = Math.min(subpathExtraRemaining, panelExtraRemaining);
+      const segmentBudget = { remaining: 1 + allowance, capped: false };
+      const before = projected.length / 2;
+      tessellateSegment(
+        projector,
+        width,
+        height,
+        source.positions[(i - 1) * 2]!,
+        source.positions[(i - 1) * 2 + 1]!,
+        source.positions[i * 2]!,
+        source.positions[i * 2 + 1]!,
+        source.rows[i]!,
+        source.indices[i]!,
+        projected,
+        rows,
+        semanticAnchors,
+        semanticIndices,
+        segmentBudget,
+      );
+      const added = projected.length / 2 - before;
+      const extraUsed = Math.max(0, added - 1);
+      subpathExtraRemaining -= extraUsed;
+      panelExtraRemaining -= extraUsed;
+      capped ||= segmentBudget.capped;
+      // The recursion marks its endpoint synthetic; the authored/stat vertex
+      // remains a semantic anchor even when midpoint vertices precede it.
+      if (added > 0) semanticAnchors[semanticAnchors.length - 1] = source.anchors[i]!;
+    }
+    return true;
+  };
+
+  const sourceRingStarts = batch.ringStarts;
+  const remappedRingStarts: number[] = [];
+
   for (let s = 0; s + 1 < batch.pathOffsets.length; s++) {
     const start = batch.pathOffsets[s]!;
     const end = batch.pathOffsets[s + 1]!;
@@ -191,77 +207,69 @@ export function projectPathBatch(
     // A partial closed polygon has no valid boundary: SVG and canvas filling
     // implicitly join its finite endpoints with a false chord. Drop that
     // source subpath instead of painting geometry across an invalid gap.
+    // Multi-ring compounds drop as a whole (no partial hole remapping).
     if (batch.closed === true && batch.fills !== undefined && sourceHasInvalidVertex) {
       droppedFilledSubpaths++;
       continue;
     }
+
+    // Hole rings (#809 phase 9): project each ring of this compound separately
+    // so tessellation never invents an exterior→hole chord, then remap
+    // ringStarts to post-projection vertex indices (per-compound interior breaks).
+    // Without fills, ringStarts is not remapped (undefined consumers); fall
+    // through to run-splitting and clear metadata at the end.
+    const holeCompound =
+      batch.closed === true &&
+      batch.fills !== undefined &&
+      sourceRingStarts !== undefined &&
+      sourceRingStarts.length > 0;
+    if (holeCompound) {
+      const cuts: number[] = [start];
+      for (let i = 0; i < sourceRingStarts.length; i++) {
+        const b = sourceRingStarts[i]!;
+        if (b > start && b < end) cuts.push(b);
+      }
+      cuts.push(end);
+      // No interior cuts in this subpath → ordinary single-ring project.
+      if (cuts.length === 2) {
+        if (!projectRun(start, end)) continue;
+        offsets.push(projected.length / 2);
+        strokes.push(batch.strokes[s] ?? null);
+        fills?.push(batch.fills?.[s] ?? null);
+        linewidths?.push(batch.linewidths?.[s] ?? batch.linewidth);
+        alphas?.push(batch.alphas?.[s] ?? batch.alpha);
+        linetypeIndexes?.push(batch.linetypeIndexes?.[s] ?? 0);
+        continue;
+      }
+      let emittedAny = false;
+      for (let c = 0; c + 1 < cuts.length; c++) {
+        const rs = cuts[c]!;
+        const re = cuts[c + 1]!;
+        if (re <= rs) continue;
+        // First ring of this compound is not a ringStarts entry; subsequent
+        // successful rings record the current projected vertex cursor.
+        if (emittedAny) remappedRingStarts.push(projected.length / 2);
+        if (projectRun(rs, re)) emittedAny = true;
+      }
+      if (!emittedAny) continue;
+      offsets.push(projected.length / 2);
+      strokes.push(batch.strokes[s] ?? null);
+      fills?.push(batch.fills?.[s] ?? null);
+      linewidths?.push(batch.linewidths?.[s] ?? batch.linewidth);
+      alphas?.push(batch.alphas?.[s] ?? batch.alpha);
+      linetypeIndexes?.push(batch.linetypeIndexes?.[s] ?? 0);
+      continue;
+    }
+
     let runStart = start;
     while (runStart < end) {
       while (runStart < end && projectable[runStart] === 0) runStart++;
       if (runStart >= end) break;
       let runEnd = runStart + 1;
       while (runEnd < end && projectable[runEnd] === 1) runEnd++;
-
-      const authoredCount = runEnd - runStart;
-      const desiredStepCorners = batch.curve === "step" ? Math.max(0, 2 * (authoredCount - 1)) : 0;
-      const stepCornerAllowance = Math.min(
-        panelExtraRemaining,
-        Math.max(0, MAX_COORD_VERTICES_PER_SUBPATH - authoredCount),
-      );
-      const source =
-        batch.curve === "step"
-          ? expandedStepVertices(unprojected, batch.rowIndex, runStart, runEnd, stepCornerAllowance)
-          : {
-              positions: Array.from(unprojected.slice(runStart * 2, runEnd * 2)),
-              rows: Array.from(batch.rowIndex.slice(runStart, runEnd)),
-              anchors: Array.from({ length: authoredCount }, () => 1),
-              indices: indexRange(runStart, runEnd),
-            };
-      const count = source.rows.length;
-      const emittedStepCorners = Math.max(0, count - authoredCount);
-      if (emittedStepCorners < desiredStepCorners) capped = true;
-      panelExtraRemaining -= emittedStepCorners;
-      const [firstX, firstY] = projectPoint(
-        projector,
-        width,
-        height,
-        source.positions[0]!,
-        source.positions[1]!,
-      );
-      projected.push(firstX, firstY);
-      rows.push(source.rows[0]!);
-      semanticAnchors.push(source.anchors[0]!);
-      semanticIndices.push(source.indices[0]!);
-      let subpathExtraRemaining = Math.max(0, MAX_COORD_VERTICES_PER_SUBPATH - count);
-      if (count > MAX_COORD_VERTICES_PER_SUBPATH) capped = true;
-      for (let i = 1; i < count; i++) {
-        const allowance = Math.min(subpathExtraRemaining, panelExtraRemaining);
-        const segmentBudget = { remaining: 1 + allowance, capped: false };
-        const before = projected.length / 2;
-        tessellateSegment(
-          projector,
-          width,
-          height,
-          source.positions[(i - 1) * 2]!,
-          source.positions[(i - 1) * 2 + 1]!,
-          source.positions[i * 2]!,
-          source.positions[i * 2 + 1]!,
-          source.rows[i]!,
-          source.indices[i]!,
-          projected,
-          rows,
-          semanticAnchors,
-          semanticIndices,
-          segmentBudget,
-        );
-        const added = projected.length / 2 - before;
-        const extraUsed = Math.max(0, added - 1);
-        subpathExtraRemaining -= extraUsed;
-        panelExtraRemaining -= extraUsed;
-        capped ||= segmentBudget.capped;
-        // The recursion marks its endpoint synthetic; the authored/stat vertex
-        // remains a semantic anchor even when midpoint vertices precede it.
-        if (added > 0) semanticAnchors[semanticAnchors.length - 1] = source.anchors[i]!;
+      if (!projectRun(runStart, runEnd)) {
+        runStart = runEnd + 1;
+        continue;
       }
       offsets.push(projected.length / 2);
       strokes.push(batch.strokes[s] ?? null);
@@ -284,10 +292,15 @@ export function projectPathBatch(
   if (linetypeIndexes !== undefined) batch.linetypeIndexes = Uint8Array.from(linetypeIndexes);
   batch.semanticAnchors = Uint8Array.from(semanticAnchors);
   batch.semanticIndex = Uint32Array.from(semanticIndices);
-  // Hole verts + ringStarts are stripped at entry (stripUnremappedHoleRings).
-  // Keep a defensive clear if a future path reintroduces them mid-function.
-  if (batch.ringStarts !== undefined) delete batch.ringStarts;
-  if (batch.fillRule !== undefined) delete batch.fillRule;
+  // Remap even-odd hole topology (#809 phase 9). Dropped compounds omit their
+  // ringStarts (no stale indices). Closing edges remain untessellated (paint closePath).
+  if (remappedRingStarts.length > 0) {
+    batch.ringStarts = Uint32Array.from(remappedRingStarts);
+    batch.fillRule = "evenodd";
+  } else {
+    if (batch.ringStarts !== undefined) delete batch.ringStarts;
+    if (batch.fillRule !== undefined) delete batch.fillRule;
+  }
   if (invalidVertices > 0) {
     warnings.push({
       code: "coord-invalid-geometry",

--- a/packages/core/tests/pipeline-m2/geom-sf.test.ts
+++ b/packages/core/tests/pipeline-m2/geom-sf.test.ts
@@ -207,27 +207,24 @@ describe("geom_sf", () => {
     expect(model.candidates.hitTest(hole.px, hole.py)).toBeNull();
   });
 
-  it("under active coord transform keeps exterior only (no merged hole verts)", () => {
-    // #934 / Devin: projectPathBatch dropped ringStarts/fillRule but kept hole
-    // vertices, so exterior+hole merged into one ring (spurious chord). Until
-    // coord_sf remaps multi-ring topology, strip hole verts so only exterior
-    // survives the transform (same as pre-phase-4 exterior-only under transforms).
+  it("preserves even-odd holes under nonlinear coord_transform (#809 phase 9)", () => {
+    // Diagonal edges under log10 (x only) need tessellation midpoints — axis-aligned
+    // edges stay collinear after an x-only warp, so they never insert verts.
+    // ringStarts must use post-projection indices (source [3] would be stale).
     const withHole = geo({
       type: "Polygon",
       coordinates: [
         [
           [1, 1],
-          [10, 1],
-          [10, 10],
-          [1, 10],
+          [100, 1],
+          [50, 100],
           [1, 1],
         ],
         [
-          [3, 3],
-          [7, 3],
-          [7, 7],
-          [3, 7],
-          [3, 3],
+          [20, 20],
+          [80, 20],
+          [50, 50],
+          [20, 20],
         ],
       ],
     });
@@ -245,12 +242,172 @@ describe("geom_sf", () => {
     const batch = model.scene.batches[0] as PathsBatch;
     expect(batch.kind).toBe("paths");
     expect(batch.closed).toBe(true);
-    // Hole metadata must not remain with stale indices.
-    expect(batch.ringStarts).toBeUndefined();
-    expect(batch.fillRule).toBeUndefined();
-    // Exterior only: 4 verts (closing duplicate dropped). Not exterior+hole (8).
-    expect(batch.positions.length / 2).toBe(4);
+    expect(batch.fillRule).toBe("evenodd");
+    expect(batch.ringStarts).toBeDefined();
+    expect(batch.ringStarts!.length).toBeGreaterThan(0);
+    // Exterior+hole source had 6 verts; log tessellation grows past that so
+    // remapped ringStarts cannot equal a naive source-index copy of [3].
+    expect(batch.positions.length / 2).toBeGreaterThan(6);
+    const holeBreak = batch.ringStarts![0]!;
+    expect(holeBreak).toBeGreaterThan(3);
+    expect(holeBreak).toBeLessThan(batch.positions.length / 2);
+
+    const scenePanel = model.scene.panels[0]!;
+    const vp = model.viewport.panel(scenePanel.id)!;
+    const toPlot = (dx: number, dy: number) => {
+      const rect = vp.project({
+        x: { kind: "continuous", domain: [dx, dx] },
+        y: { kind: "continuous", domain: [dy, dy] },
+      });
+      return { px: (rect.x0 + rect.x1) / 2, py: (rect.y0 + rect.y1) / 2 };
+    };
+    // Near exterior base (inside fill) vs triangular lake interior.
+    const exterior = toPlot(50, 10);
+    const hole = toPlot(50, 30);
+    expect(model.candidates.hitTest(exterior.px, exterior.py)).not.toBeNull();
+    expect(model.candidates.hitTest(hole.px, hole.py)).toBeNull();
+  });
+
+  it("drops multi-ring compounds with invalid verts under coord_transform", () => {
+    // log10 + limits: projector builds on [1,100] but verts at x=0 are NaN
+    // (same pattern as path-topology filled drop). Whole invalid compound drops;
+    // valid compound keeps remapped hole topology only.
+    const invalid = geo({
+      type: "Polygon",
+      coordinates: [
+        [
+          [0, 1],
+          [10, 1],
+          [10, 10],
+          [0, 10],
+          [0, 1],
+        ],
+        [
+          [3, 3],
+          [7, 3],
+          [7, 7],
+          [3, 7],
+          [3, 3],
+        ],
+      ],
+    });
+    const valid = geo({
+      type: "Polygon",
+      coordinates: [
+        [
+          [20, 20],
+          [40, 20],
+          [40, 40],
+          [20, 40],
+          [20, 20],
+        ],
+        [
+          [25, 25],
+          [35, 25],
+          [35, 35],
+          [25, 35],
+          [25, 25],
+        ],
+      ],
+    });
+    const model = runPipeline(
+      gg({ geometry: [invalid, valid] }, aes({}))
+        .geomSf()
+        .scales({
+          x: { type: "linear", domain: [0, 100], expand: { mult: 0, add: 0 } },
+          y: { type: "linear", domain: [0, 100], expand: { mult: 0, add: 0 } },
+        })
+        .coordTransform({
+          x: { transform: "log10", limits: [1, 100], expand: false },
+        })
+        .spec(),
+      size,
+    );
+    const batch = model.scene.batches[0] as PathsBatch;
+    // Only the valid compound remains as a filled subpath.
     expect(batch.pathOffsets.length - 1).toBe(1);
+    expect(batch.fillRule).toBe("evenodd");
+    expect(batch.ringStarts).toBeDefined();
+    expect(batch.ringStarts!.length).toBe(1);
+    // Single surviving compound: one interior-ring break strictly inside path.
+    const start = batch.pathOffsets[0]!;
+    const end = batch.pathOffsets[1]!;
+    const breakAt = batch.ringStarts![0]!;
+    expect(breakAt).toBeGreaterThan(start);
+    expect(breakAt).toBeLessThan(end);
+    expect(model.warnings.some((w) => w.code === "coord-invalid-geometry")).toBe(true);
+  });
+
+  it("remaps MultiPolygon holes under nonlinear coord_transform", () => {
+    // Diagonal first part tessellates under log10; second solid triangle has no hole.
+    const multi = geo({
+      type: "MultiPolygon",
+      coordinates: [
+        [
+          [
+            [1, 1],
+            [100, 1],
+            [50, 80],
+            [1, 1],
+          ],
+          [
+            [20, 15],
+            [80, 15],
+            [50, 40],
+            [20, 15],
+          ],
+        ],
+        [
+          [
+            [10, 85],
+            [40, 85],
+            [25, 100],
+            [10, 85],
+          ],
+        ],
+      ],
+    });
+    const model = runPipeline(
+      gg({ geometry: [multi] }, aes({}))
+        .geomSf()
+        .scales({
+          x: { type: "linear", domain: [1, 100], expand: { mult: 0, add: 0 } },
+          y: { type: "linear", domain: [1, 100], expand: { mult: 0, add: 0 } },
+        })
+        .coordTransform({ x: { transform: "log10", expand: false } })
+        .spec(),
+      size,
+    );
+    const batch = model.scene.batches[0] as PathsBatch;
+    expect(batch.pathOffsets.length - 1).toBe(2);
+    expect(batch.fillRule).toBe("evenodd");
+    expect(batch.ringStarts).toBeDefined();
+    // One hole break for the first compound only; second part is solid.
+    expect(batch.ringStarts!.length).toBe(1);
+    const start0 = batch.pathOffsets[0]!;
+    const end0 = batch.pathOffsets[1]!;
+    const start1 = batch.pathOffsets[1]!;
+    const end1 = batch.pathOffsets[2]!;
+    const holeBreak = batch.ringStarts![0]!;
+    expect(holeBreak).toBeGreaterThan(start0);
+    expect(holeBreak).toBeLessThan(end0);
+    // Second compound has no interior break in ringStarts.
+    expect(holeBreak < start1 || holeBreak >= end1).toBe(true);
+    // Tessellation grew past the 6+3 source verts (closings dropped).
+    expect(batch.positions.length / 2).toBeGreaterThan(9);
+
+    const scenePanel = model.scene.panels[0]!;
+    const vp = model.viewport.panel(scenePanel.id)!;
+    const toPlot = (dx: number, dy: number) => {
+      const rect = vp.project({
+        x: { kind: "continuous", domain: [dx, dx] },
+        y: { kind: "continuous", domain: [dy, dy] },
+      });
+      return { px: (rect.x0 + rect.x1) / 2, py: (rect.y0 + rect.y1) / 2 };
+    };
+    expect(model.candidates.hitTest(toPlot(50, 8).px, toPlot(50, 8).py)).not.toBeNull();
+    expect(model.candidates.hitTest(toPlot(50, 25).px, toPlot(50, 25).py)).toBeNull();
+    expect(model.candidates.hitTest(toPlot(25, 90).px, toPlot(25, 90).py)).not.toBeNull();
   });
 
   it("keeps MultiPolygon parts as separate compounds when one has a hole", () => {


### PR DESCRIPTION
## Summary

**#809 phase 9** — standalone on current `main` (post #941 strip stopgap).

`projectPathBatch` previously dropped interior rings under any active coord projector (`stripUnremappedHoleRings` from #941). Multi-ring `geom_sf` polygons now keep **even-odd holes** through `coord_transform`:

- Project each ring independently (no exterior→hole tessellation chord)
- Remap `ringStarts` to **post-projection** vertex indices
- Keep `fillRule: "evenodd"`
- Whole-compound drop when any vertex is domain-invalid (no stale indices)

### Contract

| Item | Choice |
|------|--------|
| Hole remapping | Per closed filled compound with `ringStarts` cuts |
| Invalid verts | Drop entire multi-ring compound |
| No fills + ringStarts | Clear metadata (no remap) |
| Closing edges | Untessellated (paint `closePath`) — pre-existing |
| CRS / graticules | Still deferred |

### Why re-land

Open #925 stacks on an older `coord_sf` branch. This re-lands the fix on post-#941 `main` (same pattern as #942 for phase 8).

### Plan review

TDD plan reviewed by Claude CLI: **REQUEST_CHANGES** on test design → addressed:

1. Nonlinear transform with **diagonal** edges (axis-aligned + x-only log stays collinear → no midpoints)
2. Domain-invalid multi-compound drop retained
3. MultiPolygon + hole + transform coverage
4. Per-compound ringStarts wording

## Test plan

- [x] `preserves even-odd holes under nonlinear coord_transform` (log10, diagonal poly, hit exterior / miss lake, `ringStarts` shifted past source index)
- [x] `drops multi-ring compounds with invalid verts under coord_transform`
- [x] `remaps MultiPolygon holes under nonlinear coord_transform`
- [x] Full geom_sf + geom_sf_text/label + pipeline-coord-transform suites (73 pass)

Related: #809
Complements #925 (standalone main base)
Supersedes #941 stopgap for active projectors

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/943" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->