### PR TITLE
fix(core): resolve polygon-ring hits to their own frame row (#916)

### DIFF
--- a/.changeset/916-polygon-ring-frame-row.md
+++ b/.changeset/916-polygon-ring-frame-row.md
@@ -1,0 +1,17 @@
+---
+"@ggsvelte/core": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+fix: resolve polygon-ring hits to their own frame row (#916)
+
+Hits on closed filled rings (`geom_density_2d_filled`, `geom_polygon`,
+`geom_sf`) resolved through the x-sorted 2×N band reconstruction whenever no
+coord transform was active, so a vertex could report a neighbouring ring's
+row — and with it the wrong `after_stat(level)` / `after_stat(density)`.
+Candidate resolution now prefers the exact per-vertex rows the geometry already
+emits (`closedFrameRows`) for every closed path, not only after coord
+projection.
+
+Migration: none — hit resolution only

--- a/packages/core/src/pipeline/candidate-construction/frame-row.ts
+++ b/packages/core/src/pipeline/candidate-construction/frame-row.ts
@@ -119,10 +119,24 @@ export function resolveCandidateFrameRow(input: {
 
   if (frame !== undefined && batch.kind === "paths") {
     const explicitFrameRow = batch.frameRowIndex?.[primitiveIndex];
+    // Emitted closed-path frame rows are exact in both primitive-index spaces:
+    // with no coord they index render vertices, and after projection
+    // `semanticIndex` is a post-hole-strip vertex id keyed to this same array
+    // (hole stripping rewrites it alongside positions; projection leaves it).
+    const emittedClosedRow =
+      batch.closed === true ? batch.closedFrameRows?.[primitiveIndex] : undefined;
     if (explicitFrameRow !== undefined && explicitFrameRow < frame.n) {
       // Style-split lines emit exact frame rows so candidate identity survives
       // subpath reindexing after mapped stroke-style breaks.
       frameRow = explicitFrameRow;
+      derivedGroup = frame.groups[frameRow] ?? derivedGroup;
+    } else if (emittedClosedRow !== undefined) {
+      // Prefer emitted rows for every closed path, coord or not. Polygon rings
+      // (geom_polygon / geom_sf / density_2d_filled) keep authored winding and
+      // are not a 2×N reflected band, so the sorted-row reconstruction below
+      // would claim a neighbouring ring's row (#916); filtered ribbons need the
+      // same exactness after non-finite edge drops (#502).
+      frameRow = emittedClosedRow;
       derivedGroup = frame.groups[frameRow] ?? derivedGroup;
     } else if (batch.semanticIndex === undefined) {
       // After coord projection, candidate facts pass semanticIndex (pre-render
@@ -140,24 +154,18 @@ export function resolveCandidateFrameRow(input: {
         frameRow = rowsInGroup[Math.min(reflected, rowsInGroup.length - 1)] ?? frameRow;
       }
     } else if (batch.closed === true) {
-      // Prefer emitted closed-band frame rows (filtered ribbons) when present —
-      // layout from full frame groups mis-reflects after non-finite edge drops (#502).
-      const emitted = batch.closedFrameRows;
-      if (emitted !== undefined && primitiveIndex >= 0 && primitiveIndex < emitted.length) {
-        frameRow = emitted[primitiveIndex]!;
+      // Closed band with no emitted rows (handled above): reconstruct the 2×N
+      // upper/lower reflection from full frame groups.
+      const resolved = resolveClosedBandFrameRow(
+        getClosedBandLayout(frame, orderedGroups),
+        primitiveIndex,
+      );
+      if (resolved === null) {
+        frameRow = Math.min(Math.max(0, primitiveIndex), Math.max(0, frame.n - 1));
         derivedGroup = frame.groups[frameRow] ?? derivedGroup;
       } else {
-        const resolved = resolveClosedBandFrameRow(
-          getClosedBandLayout(frame, orderedGroups),
-          primitiveIndex,
-        );
-        if (resolved === null) {
-          frameRow = Math.min(Math.max(0, primitiveIndex), Math.max(0, frame.n - 1));
-          derivedGroup = frame.groups[frameRow] ?? derivedGroup;
-        } else {
-          frameRow = resolved.frameRow;
-          derivedGroup = resolved.derivedGroup;
-        }
+        frameRow = resolved.frameRow;
+        derivedGroup = resolved.derivedGroup;
       }
     } else {
       // Open paths: semantic index is the pre-split vertex / frame row.

--- a/packages/core/src/scene.ts
+++ b/packages/core/src/scene.ts
@@ -71,10 +71,11 @@ export interface PathsBatch {
    * resolution uses this instead of synthetic render topology indexes. */
   semanticIndex?: Uint32Array;
   /**
-   * Closed ribbons only: frame-row id per **pre-projection** semantic vertex
-   * (upper ascending, then lower descending). Matches emitted vertices after
-   * non-finite edge filtering so coord `semanticIndex` maps to the correct
-   * frame row (#502). Length = pre-projection vertex count.
+   * Closed paths: frame-row id per **pre-projection** semantic vertex — a
+   * ribbon band (upper ascending, then lower descending) or a polygon ring in
+   * authored winding order (#916). Matches emitted vertices after non-finite
+   * edge filtering so coord `semanticIndex` maps to the correct frame row
+   * (#502). Length = pre-projection vertex count.
    */
   closedFrameRows?: Uint32Array;
   /** Start offset (in points) of each subpath; length = subpathCount + 1. */

--- a/packages/core/tests/candidate-construction/frame-row.test.ts
+++ b/packages/core/tests/candidate-construction/frame-row.test.ts
@@ -243,6 +243,37 @@ describe("resolveCandidateFrameRow paths", () => {
     }
   });
 
+  /**
+   * Closed band, no emitted rows, and a primitive past the reconstructed 2×N
+   * layout: fall back to a clamped frame row rather than resolving nothing.
+   */
+  it("clamps out-of-layout closed-band primitives with no emitted rows", async () => {
+    const { resolveCandidateFrameRow } =
+      await import("../../src/pipeline/candidate-construction/frame-row.ts");
+    const frame = fromAny({
+      n: 2,
+      groups: [0, 0],
+      xNumeric: new Float64Array([0, 1]),
+      binding: { layer: { geom: "area" } },
+    });
+    // Band layout spans 2 rows × 2 = 4 vertices; 10 is past the end.
+    const batch = fromAny({
+      kind: "paths",
+      closed: true,
+      pathOffsets: new Uint32Array([0, 4]),
+      semanticIndex: new Uint32Array(4),
+    });
+    expect(
+      resolveCandidateFrameRow({
+        frame,
+        batch,
+        primitiveIndex: 10,
+        orderedGroups: [0],
+        outlierLocalRow: null,
+      }),
+    ).toEqual({ frameRow: 1, derivedGroup: 0 });
+  });
+
   it("resolves many subpaths without linear pathOffsets scans (O(log P))", async () => {
     const { resolveCandidateFrameRow } =
       await import("../../src/pipeline/candidate-construction/frame-row.ts");

--- a/packages/core/tests/candidate-construction/frame-row.test.ts
+++ b/packages/core/tests/candidate-construction/frame-row.test.ts
@@ -206,6 +206,43 @@ describe("resolveCandidateFrameRow paths", () => {
     ).toEqual({ frameRow: 0, derivedGroup: 0 });
   });
 
+  /**
+   * Polygon rings (geom_polygon / geom_sf / density_2d_filled) keep authored
+   * winding, not x-sorted order, and are not a 2×N reflected band. Without a
+   * coord transform there is no semanticIndex, so resolution used to fall into
+   * the x-sorted subpath reconstruction and claim a neighbouring ring's row —
+   * filled density bands resolved the wrong after_stat level (#916).
+   */
+  it("uses closedFrameRows for polygon rings with no coord semanticIndex", async () => {
+    const { resolveCandidateFrameRow } =
+      await import("../../src/pipeline/candidate-construction/frame-row.ts");
+    // xNumeric deliberately unsorted: data order [0,1,2,3], x-sorted [0,2,1,3].
+    const frame = fromAny({
+      n: 4,
+      groups: [0, 0, 0, 0],
+      xNumeric: new Float64Array([0, 2, 1, 3]),
+      binding: { layer: { geom: "density_2d_filled" } },
+    });
+    const batch = fromAny({
+      kind: "paths",
+      closed: true,
+      pathOffsets: new Uint32Array([0, 4]),
+      closedFrameRows: new Uint32Array([0, 1, 2, 3]),
+    });
+    // x-sorted reconstruction would map primitive 1 → frame row 2 (wrong ring).
+    for (const primitiveIndex of [0, 1, 2, 3]) {
+      expect(
+        resolveCandidateFrameRow({
+          frame,
+          batch,
+          primitiveIndex,
+          orderedGroups: [0],
+          outlierLocalRow: null,
+        }),
+      ).toEqual({ frameRow: primitiveIndex, derivedGroup: 0 });
+    }
+  });
+
   it("resolves many subpaths without linear pathOffsets scans (O(log P))", async () => {
     const { resolveCandidateFrameRow } =
       await import("../../src/pipeline/candidate-construction/frame-row.ts");

--- a/packages/core/tests/pipeline-m2/density-2d-filled.test.ts
+++ b/packages/core/tests/pipeline-m2/density-2d-filled.test.ts
@@ -71,6 +71,40 @@ describe("density_2d_filled geom (#802 phase 2)", () => {
     expect(spec.layers[0]?.aes?.fill).toEqual({ stat: "level" });
   });
 
+  /**
+   * A filled band hit must report the vertex it actually landed on. Ring
+   * vertices keep authored winding, so resolving them through the x-sorted
+   * band reconstruction reported a neighbouring ring's row and with it the
+   * wrong after_stat level/density (#916). Semantic x is a monotone function
+   * of pixel x, so correct resolution makes the two orders agree.
+   */
+  it("resolves filled-ring hits to their own vertex (#916)", () => {
+    const data = cloud(80);
+    const model = runPipeline(
+      gg(data, aes({ x: "x", y: "y" }))
+        .geomDensity2dFilled({ n: 30, bins: 5 })
+        .spec(),
+      size,
+    );
+    if (model.scene.batches.length === 0) return;
+    const batch = model.scene.batches[0] as PathsBatch;
+    expect(batch.closedFrameRows).toBeDefined();
+    expect(batch.semanticIndex).toBeUndefined(); // no coord transform in this spec
+
+    const hits: { x: number; xValue: number }[] = [];
+    for (let id = 0; id < model.candidates.size; id++) {
+      const candidate = model.candidates.candidate(id);
+      if (candidate === null || typeof candidate.xValue !== "number") continue;
+      hits.push({ x: candidate.x, xValue: candidate.xValue });
+    }
+    expect(hits.length).toBeGreaterThan(1);
+
+    hits.sort((a, b) => a.x - b.x);
+    for (let i = 1; i < hits.length; i++) {
+      expect(hits[i]!.xValue).toBeGreaterThanOrEqual(hits[i - 1]!.xValue - 1e-9);
+    }
+  });
+
   it("uses exact auto hit mode", () => {
     const data = cloud(80);
     const model = runPipeline(


### PR DESCRIPTION
Closes #916.

## Problem

Hits on closed filled rings resolved to a **neighbouring ring's** frame row, so filled density bands reported the wrong `after_stat(level)` / `after_stat(density)`.

`resolveCandidateFrameRow` consulted `batch.closedFrameRows` only inside the `semanticIndex !== undefined` branch (`frame-row.ts:142-148` pre-change) — i.e. only after a coord transform. With no coord transform, ring vertices fell through to the x-sorted subpath reconstruction (`:127-141`), which assumes ribbon 2×N upper/lower topology. Polygon rings (`geom_density_2d_filled`, `geom_polygon`, `geom_sf`) keep **authored winding**, not x-sorted order, so the reflection picked the wrong row.

## Validation

The issue reported the cause as "`polygonBatch` does not emit `frameRowIndex`". That part is stale — `polygonBatch` has emitted per-vertex `closedFrameRows` since #808/#502 (`geometry-paths-polygon.ts:67,90,131`). The array was already correct; the **resolver never read it** in the no-coord case. Verified by a failing unit test before the fix:

```text
- Expected  frameRow: 1
+ Received  frameRow: 2
```

## What changed

Hoist the `closedFrameRows` lookup above the `semanticIndex === undefined` branch so every closed path uses its exact emitted rows in both primitive-index spaces.

That array is already valid in both spaces:

- **no coord** — `primitiveIndex` is the render vertex index, which is exactly how `polygonBatch` keys the array
- **after coord** — `primitiveIndex` is `semanticIndex[renderVertex]`, the post-hole-strip vertex id that `stripUnremappedHoleRings` rewrites `closedFrameRows` in lockstep with (`coord-path-project.ts:93-104`)

Filtered ribbons (#502) get the same exactness without a coord transform as a side effect. The 2×N band reconstruction remains the fallback for closed batches that emit no rows.

Deliberately **not** done: emitting a second `frameRowIndex` array from `polygonBatch` (the issue's suggested direction). `frameRowIndex` takes precedence at `:121` and is *not* rewritten by hole-stripping, so it would mis-index under `coord_sf` and regress the hole handling from #941.

## Tests

Both verified RED before the fix, GREEN after:

- `packages/core/tests/candidate-construction/frame-row.test.ts` — polygon ring with unsorted `xNumeric` and no `semanticIndex` must resolve each vertex to its own row
- `packages/core/tests/pipeline-m2/density-2d-filled.test.ts` — pipeline-level: sorting real `density_2d_filled` hits by pixel x must give non-decreasing semantic x, i.e. each hit reports the vertex it landed on

## Verification

| Command | Result |
|---|---|
| `bun test packages/spec packages/core` | **2105 pass, 0 fail** |
| `bun run lint` | clean |
| `bun run check` | clean |

Note: the suite needs `tsc -b packages/spec packages/core` first — a stale `dist` makes 30 unrelated SF tests fail identically before and after this change.

## Docs drift corrected

Independent review flagged two stale contract comments, both fixed here: `scene.ts:73-78` said `closedFrameRows` was "Closed ribbons only" (polygons emit it too), and a new comment overstated that projection rewrites the array (hole-stripping does; projection leaves it).

## Follow-ups

None deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/947" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->