### PR TITLE
fix(core): bin-edge lineage replays the stat's own cut (#905)

### DIFF
--- a/.changeset/905-bin-edge-lineage.md
+++ b/.changeset/905-bin-edge-lineage.md
@@ -1,0 +1,19 @@
+---
+"@ggsvelte/core": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+fix: bin-edge lineage replays the stat's own cut (#905)
+
+`stat_bin` and `stat_summary_bin` cut rows on ggplot2's **fuzzed** break grid
+but emitted only the exact edges, so interaction lineage — which re-derived
+membership from those edges — disagreed with the stat for any value inside the
+fuzz band around an interior break. A hovered bin could report a row that never
+contributed to it while omitting one that did.
+
+The binning stats now carry the cut they performed (fuzzed grid, closed side,
+and per-row bin index), and both lineage consumers replay it, so represented
+rows always match the rows the stat consumed.
+
+Migration: none — interaction lineage only

--- a/packages/core/src/pipeline/candidate-construction/identity-buckets.ts
+++ b/packages/core/src/pipeline/candidate-construction/identity-buckets.ts
@@ -1,7 +1,6 @@
-import type { BarParams } from "@ggsvelte/spec";
-
 import { bandKey } from "../../scales/train.js";
 import { ColumnTable } from "../../table.js";
+import { binIndexOf } from "../../stats/bin-breaks.js";
 import { assignBinId } from "../binned-scale.js";
 import { shouldAggregateOnSemanticTemporalX } from "../frame-stats-shared.js";
 import { positionColumn, xConversionOf } from "../temporal-position.js";
@@ -60,19 +59,17 @@ export function appendSourceRowByGroupKey(
 
 interface BinEdge {
   frameRow: number;
-  lo: number;
-  hi: number;
-  first: boolean;
-  last: boolean;
   bucket: number[];
 }
 
 /**
  * Assign each source row to at most one bin in a single pass over the panel
- * rows (O(n log k) per group via binary search on ordered bin edges), instead
- * of re-scanning the full group once per output bin (O(k·g)).
- * When bin edges are absent, every mark represents the full group: members are
- * collected once per group and shared across that group's frame rows (O(n+k)).
+ * rows, replaying the stat's own cut (O(n log B) binary search over the fuzzed
+ * break grid, then an O(1) grid-bin → frame-row lookup) instead of re-scanning
+ * the full group once per output bin (O(k·g)).
+ * When the stat's cut or bin edges are absent, every mark represents the full
+ * group: members are collected once per group and shared across that group's
+ * frame rows (O(n+k)).
  */
 export function buildBinLineageBuckets(input: {
   frame: FinalizedLayerFrame;
@@ -86,9 +83,13 @@ export function buildBinLineageBuckets(input: {
 
   // Pre-stat groups cached on the frame during buildFrame (issue #217).
   const inputGroups = frame.inputGroups;
-  const closed = ((frame.binding.layer.params ?? {}) as BarParams).closed ?? "right";
   const binsByGroup = new Map<number, BinEdge[]>();
-  const missingEdges = frame.xmin === null || frame.xmax === null;
+  // Without the stat's own cut we cannot reproduce its fuzzed membership, so
+  // fall back to the same conservative "mark represents the whole group"
+  // behaviour used when bin edges are absent.
+  const cut = frame.binCut;
+  const missingEdges =
+    frame.xmin === null || frame.xmax === null || cut === undefined || cut === null;
   /** group → frame rows (missing-edges path only; enables O(n+k) fill). */
   const frameRowsByGroup = missingEdges ? new Map<number, number[]>() : null;
 
@@ -102,16 +103,7 @@ export function buildBinLineageBuckets(input: {
     }
     const bucket: number[] = [];
     sourceRowsByGroupBin.set(`${panelIndex}:${layerIndex}:${group}:${frameRow}`, bucket);
-    const first = frameRow === 0 || frame.groups[frameRow - 1] !== group;
-    const last = frameRow === frame.n - 1 || frame.groups[frameRow + 1] !== group;
-    const edge: BinEdge = {
-      frameRow,
-      lo: frame.xmin![frameRow]!,
-      hi: frame.xmax![frameRow]!,
-      first,
-      last,
-      bucket,
-    };
+    const edge: BinEdge = { frameRow, bucket };
     const list = binsByGroup.get(group);
     if (list === undefined) binsByGroup.set(group, [edge]);
     else list.push(edge);
@@ -137,8 +129,13 @@ export function buildBinLineageBuckets(input: {
     return;
   }
 
-  for (const bins of binsByGroup.values()) {
-    bins.sort((a, b) => a.lo - b.lo || a.hi - b.hi);
+  // Grid bin index → the frame row that emitted it. summary_bin omits empty
+  // bins, so the grid index is not the frame row.
+  const edgeByGridBin = new Map<number, Map<number, BinEdge>>();
+  for (const [group, bins] of binsByGroup) {
+    const byGridBin = new Map<number, BinEdge>();
+    for (const edge of bins) byGridBin.set(cut!.binIndex[edge.frameRow]!, edge);
+    edgeByGridBin.set(group, byGridBin);
   }
 
   // Bin edges are in scale space after pre-stat transforms; compare source
@@ -151,42 +148,14 @@ export function buildBinLineageBuckets(input: {
   );
   for (let localRow = 0; localRow < inputGroups.length; localRow++) {
     const group = inputGroups[localRow]!;
-    const bins = binsByGroup.get(group);
-    if (bins === undefined || bins.length === 0) continue;
+    const byGridBin = edgeByGridBin.get(group);
+    if (byGridBin === undefined || byGridBin.size === 0) continue;
     const value = xNumeric[localRow]!;
     if (!Number.isFinite(value)) continue;
-    const idx = findBinIndex(value, bins, closed);
-    if (idx < 0) continue;
-    const sourceRow = globalSourceRowForInputRow(frame, localRow);
-    bins[idx]!.bucket.push(sourceRow);
+    // Replay the stat's own cut (fuzzed breaks) — exact-edge predicates
+    // disagree with it inside the fuzz band around a break (#905).
+    const edge = byGridBin.get(binIndexOf(value, cut!.fuzzy, cut!.rightClosed));
+    if (edge === undefined) continue;
+    edge.bucket.push(globalSourceRowForInputRow(frame, localRow));
   }
-}
-
-function findBinIndex(value: number, bins: readonly BinEdge[], closed: "right" | "left"): number {
-  if (closed === "right") {
-    // First bin with hi >= value, then verify left edge (lo, hi] / first [lo, hi].
-    let lo = 0;
-    let hi = bins.length;
-    while (lo < hi) {
-      const mid = (lo + hi) >> 1;
-      if (bins[mid]!.hi < value) lo = mid + 1;
-      else hi = mid;
-    }
-    if (lo >= bins.length) return -1;
-    const bin = bins[lo]!;
-    return value <= bin.hi && (value > bin.lo || (bin.first && value >= bin.lo)) ? lo : -1;
-  }
-
-  // Last bin with lo <= value, then verify right edge [lo, hi) / last [lo, hi].
-  let lo = 0;
-  let hi = bins.length;
-  while (lo < hi) {
-    const mid = (lo + hi) >> 1;
-    if (bins[mid]!.lo <= value) lo = mid + 1;
-    else hi = mid;
-  }
-  const idx = lo - 1;
-  if (idx < 0) return -1;
-  const bin = bins[idx]!;
-  return value >= bin.lo && (value < bin.hi || (bin.last && value <= bin.hi)) ? idx : -1;
 }

--- a/packages/core/src/pipeline/candidate-construction/represented-rows.ts
+++ b/packages/core/src/pipeline/candidate-construction/represented-rows.ts
@@ -1,6 +1,5 @@
-import type { BarParams } from "@ggsvelte/spec";
-
 import { bandKey } from "../../scales/train.js";
+import { binIndexOf } from "../../stats/bin-breaks.js";
 import type { ColumnTable } from "../../table.js";
 import { shouldAggregateOnSemanticTemporalX } from "../frame-stats-shared.js";
 import { positionColumn, xConversionOf, yConversionOf } from "../temporal-position.js";
@@ -36,13 +35,11 @@ export function filterBinRepresentedRows(input: {
   baseRows: readonly number[];
 }): number[] {
   const { frame, table, frameRow, field, baseRows } = input;
-  if (frame.xmin === null || frame.xmax === null) return [...baseRows];
-  const hi = frame.xmax[frameRow]!;
-  const lo = frame.xmin[frameRow]!;
-  const closed = ((frame.binding.layer.params ?? {}) as BarParams).closed ?? "right";
-  const frameGroup = frame.groups[frameRow];
-  const firstInGroup = frameRow === 0 || frame.groups[frameRow - 1] !== frameGroup;
-  const lastInGroup = frameRow === frame.n - 1 || frame.groups[frameRow + 1] !== frameGroup;
+  const cut = frame.binCut;
+  // Without the stat's own cut we cannot reproduce its fuzzed membership.
+  if (frame.xmin === null || frame.xmax === null || cut === undefined || cut === null)
+    return [...baseRows];
+  const gridBin = cut.binIndex[frameRow]!;
   // Edges are scale-space; filter source rows after the same transform.
   const numeric = positionColumn(
     table,
@@ -53,9 +50,9 @@ export function filterBinRepresentedRows(input: {
   return baseRows.filter((row) => {
     const value = numeric[row]!;
     if (!Number.isFinite(value)) return false;
-    return closed === "right"
-      ? value <= hi && (value > lo || (firstInGroup && value >= lo))
-      : value >= lo && (value < hi || (lastInGroup && value <= hi));
+    // Replay the stat's own cut so this fallback path agrees with the indexed
+    // buckets, including inside the fuzz band around a break (#905).
+    return binIndexOf(value, cut.fuzzy, cut.rightClosed) === gridBin;
   });
 }
 

--- a/packages/core/src/pipeline/frame-helpers.ts
+++ b/packages/core/src/pipeline/frame-helpers.ts
@@ -13,6 +13,7 @@ export { carriedColumns, deriveLayerGroups } from "./frame-group-columns.js";
 export function emptyFrameExtras(): Pick<
   LayerFrame,
   | "bin"
+  | "binCut"
   | "dodge"
   | "box"
   | "smooth"
@@ -32,6 +33,7 @@ export function emptyFrameExtras(): Pick<
 > {
   return {
     bin: null,
+    binCut: null,
     dodge: null,
     box: null,
     smooth: null,

--- a/packages/core/src/pipeline/frame-stats-bin-frame.ts
+++ b/packages/core/src/pipeline/frame-stats-bin-frame.ts
@@ -19,6 +19,7 @@ type BinResult = {
   xmin: Float64Array;
   xmax: Float64Array;
   carried: Record<string, import("../table.js").CellValue[]>;
+  cut: { fuzzy: readonly number[]; rightClosed: boolean; binIndex: Int32Array };
 };
 
 export function packBinLayerFrame(
@@ -55,6 +56,8 @@ export function packBinLayerFrame(
     ...styleColumns(binding, col, columns),
     labelValues: col(binding.labelField),
     ...emptyFrameExtras(),
+    // Lineage replays the stat's own cut instead of re-deriving from edges (#905).
+    binCut: result.cut,
     xmin: result.xmin,
     xmax: result.xmax,
   };

--- a/packages/core/src/pipeline/frame-stats-manual.ts
+++ b/packages/core/src/pipeline/frame-stats-manual.ts
@@ -109,6 +109,7 @@ export function buildManualFrame(
             yId: sliceBinIds(full.bin.yId, keep),
           };
     return {
+      binCut: null,
       binding,
       table,
       n: keep.length,

--- a/packages/core/src/pipeline/frame-stats-summary-bin.ts
+++ b/packages/core/src/pipeline/frame-stats-summary-bin.ts
@@ -71,6 +71,8 @@ export function buildSummaryBinFrame(
     }),
     labelValues: col(binding.labelField),
     ...emptyFrameExtras(),
+    // Lineage replays the stat's own cut instead of re-deriving from edges (#905).
+    binCut: result.cut,
     ymin: result.ymin,
     ymax: result.ymax,
     xmin: result.xmin,

--- a/packages/core/src/pipeline/frame-stats-unique.ts
+++ b/packages/core/src/pipeline/frame-stats-unique.ts
@@ -123,6 +123,7 @@ export function buildUniqueFrame(
         };
 
   return {
+    binCut: null,
     binding,
     table,
     n: keep.length,

--- a/packages/core/src/pipeline/types-layer-frame.ts
+++ b/packages/core/src/pipeline/types-layer-frame.ts
@@ -35,6 +35,21 @@ interface BinPayload {
   yId: Int32Array | null;
 }
 
+/**
+ * The cut a binning stat actually performed, carried so interaction lineage
+ * reproduces it instead of re-deriving membership from the emitted (unfuzzed)
+ * edges. ggplot2 fuzzes breaks by 1e-8 × the median gap before cutting, so
+ * exact-edge predicates disagree with the stat inside that band (#905).
+ */
+interface BinCutPayload {
+  /** Fuzzed break grid passed to `binIndexOf` by the stat. */
+  fuzzy: readonly number[];
+  /** `closed: "right"` — resolved by the stat, not re-read from params. */
+  rightClosed: boolean;
+  /** Grid bin index per frame row (frame rows may omit empty bins). */
+  binIndex: Int32Array;
+}
+
 /** Dodge position slots (owned by bar/boxplot position + rect layout). */
 interface DodgePayload {
   slot: Uint32Array;
@@ -127,6 +142,8 @@ export interface LayerFrame extends LayerFrameCore {
   inputSourceRows: number[] | null;
   /** Discrete bin ids — only bin/count/rect consumers read this. */
   bin: BinPayload | null;
+  /** Stat-owned bin cut — only bin-edge interaction lineage reads this. */
+  binCut: BinCutPayload | null;
   /** Dodge slots — only bar/boxplot position + layout consumers read this. */
   dodge: DodgePayload | null;
   /** Boxplot hinges/outliers — only boxplot geometry + outlier lineage. */

--- a/packages/core/src/stats/bin.ts
+++ b/packages/core/src/stats/bin.ts
@@ -69,6 +69,12 @@ export interface BinStatResult {
   dropped: number;
   /** True when neither bins nor binwidth was given (default bins = 30). */
   usedDefaultBins: boolean;
+  /**
+   * The cut actually performed: the fuzzed grid handed to `binIndexOf` plus the
+   * grid bin index per emitted row. Interaction lineage replays this instead of
+   * re-deriving membership from the unfuzzed `xmin`/`xmax` edges (#905).
+   */
+  cut: { fuzzy: readonly number[]; rightClosed: boolean; binIndex: Int32Array };
 }
 
 export function statBin(input: BinStatInput): BinStatResult {
@@ -98,6 +104,7 @@ export function statBin(input: BinStatInput): BinStatResult {
     carried: Object.fromEntries(carriedNames.map((n) => [n, []])),
     dropped: x.length,
     usedDefaultBins,
+    cut: { fuzzy: [], rightClosed: true, binIndex: new Int32Array(0) },
   };
   if (min > max) return empty;
 
@@ -155,6 +162,7 @@ export function statBin(input: BinStatInput): BinStatResult {
   const outNcount = new Float64Array(n);
   const outNdensity = new Float64Array(n);
   const outGroups: number[] = [];
+  const outBinIndex = new Int32Array(n);
   const carried: Record<string, CellValue[]> = {};
   for (const name of carriedNames) carried[name] = [];
 
@@ -178,6 +186,7 @@ export function statBin(input: BinStatInput): BinStatResult {
       const hi = breaks.breaks[b + 1]!;
       const width = hi - lo;
       const c = counts[row]!;
+      outBinIndex[row] = b;
       outX[row] = (lo + hi) / 2;
       outXmin[row] = lo;
       outXmax[row] = hi;
@@ -204,5 +213,10 @@ export function statBin(input: BinStatInput): BinStatResult {
     carried,
     dropped,
     usedDefaultBins,
+    cut: {
+      fuzzy: breaks.fuzzy,
+      rightClosed: breaks.rightClosed,
+      binIndex: outBinIndex,
+    },
   };
 }

--- a/packages/core/src/stats/summary-bin.ts
+++ b/packages/core/src/stats/summary-bin.ts
@@ -49,6 +49,12 @@ export interface SummaryBinStatResult {
   carried: Record<string, CellValue[]>;
   dropped: number;
   usedDefaultBins: boolean;
+  /**
+   * The cut actually performed: the fuzzed grid handed to `binIndexOf` plus the
+   * grid bin index per emitted row. Interaction lineage replays this instead of
+   * re-deriving membership from the unfuzzed `xmin`/`xmax` edges (#905).
+   */
+  cut: { fuzzy: readonly number[]; rightClosed: boolean; binIndex: Int32Array };
 }
 
 export function statSummaryBin(input: SummaryBinStatInput): SummaryBinStatResult {
@@ -69,6 +75,7 @@ export function statSummaryBin(input: SummaryBinStatInput): SummaryBinStatResult
     carried: Object.fromEntries(carriedNames.map((n) => [n, []])),
     dropped,
     usedDefaultBins,
+    cut: { fuzzy: [], rightClosed: true, binIndex: new Int32Array(0) },
   });
 
   let min = Infinity;
@@ -131,6 +138,7 @@ export function statSummaryBin(input: SummaryBinStatInput): SummaryBinStatResult
   const outYmax: number[] = [];
   const outGroups: number[] = [];
   const sampleRows: number[] = [];
+  const outBinIndex: number[] = [];
 
   for (const g of groupOrder) {
     for (let bin = 0; bin < binCount; bin++) {
@@ -148,6 +156,7 @@ export function statSummaryBin(input: SummaryBinStatInput): SummaryBinStatResult
       outYmax.push(summarized.ymax);
       outGroups.push(g);
       sampleRows.push(bucket.sampleRow);
+      outBinIndex.push(bin);
     }
   }
 
@@ -168,5 +177,10 @@ export function statSummaryBin(input: SummaryBinStatInput): SummaryBinStatResult
     carried,
     dropped,
     usedDefaultBins,
+    cut: {
+      fuzzy: breaks.fuzzy,
+      rightClosed: breaks.rightClosed,
+      binIndex: Int32Array.from(outBinIndex),
+    },
   };
 }

--- a/packages/core/tests/candidate-construction/lineage-filters.test.ts
+++ b/packages/core/tests/candidate-construction/lineage-filters.test.ts
@@ -36,6 +36,12 @@ describe("lineage represented-row filters", () => {
       groups: new Uint32Array([0, 0]),
       n: 2,
       binding: { layer: { params: { closed: "right" } } },
+      // The stat's own cut over breaks [0, 2, 4] (fuzz = 1e-8 × median gap).
+      binCut: {
+        fuzzy: [0 - 2e-8, 2 + 2e-8, 4 + 2e-8],
+        rightClosed: true,
+        binIndex: new Int32Array([0, 1]),
+      },
     });
     expect(
       filterBinRepresentedRows({
@@ -92,6 +98,11 @@ describe("lineage filter column hoist (issue #220)", () => {
       groups: new Uint32Array([0]),
       n: 1,
       binding: { layer: { params: { closed: "right" } } },
+      binCut: {
+        fuzzy: [0 - 2e-8, 2 + 2e-8],
+        rightClosed: true,
+        binIndex: new Int32Array([0]),
+      },
     });
     const baseRows = Array.from({ length: 40 }, (_, i) => i);
     const reads = countColumnReads("x", () => {

--- a/packages/core/tests/pipeline-m2/bin-edge-lineage.test.ts
+++ b/packages/core/tests/pipeline-m2/bin-edge-lineage.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Bin-edge lineage parity (#905).
+ *
+ * The binning stats cut rows on ggplot2's **fuzzy** break grid, so a value
+ * inside the fuzz band (1e-8 × median gap) around an interior break is
+ * summarized into one bin while the exact-edge predicates that lineage used
+ * claimed the neighbouring one. Represented rows must match the rows the stat
+ * actually consumed, for both closed sides and for `bin` as well as
+ * `summary_bin`.
+ */
+import { describe, expect, it } from "bun:test";
+import { aes, gg } from "@ggsvelte/spec";
+import { runPipeline } from "../../src/pipeline.ts";
+import type { RenderModel } from "../../src/pipeline/types-render-model.ts";
+import { size } from "./fixtures.ts";
+
+/** Represented source rows per mark, keyed by the mark's semantic x. */
+function lineageByX(model: RenderModel): Map<number, number[]> {
+  const byX = new Map<number, number[]>();
+  for (let id = 0; id < model.candidates.size; id++) {
+    const candidate = model.candidates.candidate(id);
+    if (candidate === null || typeof candidate.xValue !== "number") continue;
+    byX.set(
+      candidate.xValue,
+      [...model.lineage.keys(candidate.lineage)].toSorted((a, b) => a - b),
+    );
+  }
+  return byX;
+}
+
+describe("summary_bin bin-edge lineage (#905)", () => {
+  // binwidth 1 + boundary 0 puts breaks on integers; fuzz = 1e-8 × 1.
+  // x=1+1e-9 sits inside the fuzz band ABOVE break 1, so right-closed
+  // cutting keeps it in (0,1] — the bin centered at 0.5.
+  const rightData = { x: [0.5, 1 + 1e-9, 1.5], y: [10, 20, 30] };
+
+  it("attributes a fuzz-band row to the bin whose summary consumed it", () => {
+    const model = runPipeline(
+      gg(rightData, aes({ x: "x", y: "y" }))
+        .geomPoint({ stat: "summary_bin", binwidth: 1, boundary: 0 })
+        .spec(),
+      size,
+    );
+    const byX = lineageByX(model);
+    // Bin (0,1] summarized rows 0 and 1 → mean(10,20) = 15.
+    const lowMark = model.candidates.candidate(0);
+    expect(lowMark?.yValue).toBe(15);
+    expect(byX.get(0.5)).toEqual([0, 1]);
+    // Bin (1,2] summarized row 2 only → 30.
+    expect(byX.get(1.5)).toEqual([2]);
+  });
+
+  it("mirrors for closed:left (fuzz band below an interior break)", () => {
+    // Left-closed fuzzes interior breaks DOWN, so a value just below break 1
+    // stays in [1,2) rather than falling back into [0,1).
+    const leftData = { x: [0.5, 1 - 1e-9, 1.5], y: [10, 20, 30] };
+    const model = runPipeline(
+      gg(leftData, aes({ x: "x", y: "y" }))
+        .geomPoint({ stat: "summary_bin", binwidth: 1, boundary: 0, closed: "left" })
+        .spec(),
+      size,
+    );
+    const byX = lineageByX(model);
+    // [1,2) consumed rows 1 and 2 → mean(20,30) = 25; [0,1) only row 0.
+    expect(byX.get(0.5)).toEqual([0]);
+    expect(byX.get(1.5)).toEqual([1, 2]);
+  });
+
+  it("keeps a row exactly on an interior break in exactly one bin", () => {
+    const onBreak = { x: [0.5, 1, 1.5], y: [10, 20, 30] };
+    for (const closed of ["right", "left"] as const) {
+      const model = runPipeline(
+        gg(onBreak, aes({ x: "x", y: "y" }))
+          .geomPoint({ stat: "summary_bin", binwidth: 1, boundary: 0, closed })
+          .spec(),
+        size,
+      );
+      const claims = [...lineageByX(model).values()].flat().filter((row) => row === 1);
+      expect(claims).toEqual([1]);
+    }
+  });
+
+  it("keeps finite-x rows with non-finite y in lineage (#901 contract)", () => {
+    // Row 1 has finite x but null y: the stat drops it from the summary, but it
+    // is still a represented row of the bin it falls in.
+    const withNull = { x: [0.5, 0.7, 1.5], y: [10, null, 30] };
+    const model = runPipeline(
+      gg(withNull, aes({ x: "x", y: "y" }))
+        .geomPoint({ stat: "summary_bin", binwidth: 1, boundary: 0 })
+        .spec(),
+      size,
+    );
+    expect(lineageByX(model).get(0.5)).toEqual([0, 1]);
+  });
+});
+
+describe("stat_bin bin-edge lineage (#905)", () => {
+  it("attributes a fuzz-band row to the bin that counted it", () => {
+    const model = runPipeline(
+      gg({ x: [0.5, 1 + 1e-9, 1.5] }, aes({ x: "x" }))
+        .geomHistogram({ binwidth: 1, boundary: 0 })
+        .spec(),
+      size,
+    );
+    const byX = lineageByX(model);
+    // The fuzz-band row is counted in (0,1], so lineage must agree.
+    expect(byX.get(0.5)).toEqual([0, 1]);
+    expect(byX.get(1.5)).toEqual([2]);
+  });
+});

--- a/packages/core/tests/stats-summary-bin.test.ts
+++ b/packages/core/tests/stats-summary-bin.test.ts
@@ -23,6 +23,20 @@ describe("statSummaryBin", () => {
     expect(result.ymax[0]!).toBe(10);
   });
 
+  it("returns an empty result and an empty cut when no x is finite", () => {
+    const result = statSummaryBin({
+      x: Float64Array.from([Number.NaN, Number.POSITIVE_INFINITY]),
+      y: Float64Array.from([1, 2]),
+      groups: [0, 0],
+      params: { binwidth: 1, boundary: 0 },
+    });
+    expect(result.x.length).toBe(0);
+    expect(result.dropped).toBe(2);
+    // No grid was built, so lineage has no cut to replay (#905).
+    expect(result.cut.binIndex.length).toBe(0);
+    expect(result.cut.fuzzy).toEqual([]);
+  });
+
   it("omits empty middle bins", () => {
     const result = statSummaryBin({
       x: Float64Array.from([0.5, 2.5]),


### PR DESCRIPTION
Closes #905.

## Problem

A hovered/selected bin could report a source row that **never contributed to it**, while omitting one that did.

`statBin` and `statSummaryBin` assign rows using ggplot2's **fuzzed** break grid — `binIndexOf(v, breaks.fuzzy, breaks.rightClosed)` (`stats/summary-bin.ts:107`, `stats/bin.ts:134`), where breaks are fuzzed by `1e-8 × median gap` (`stats/bin-breaks.ts:39-51`). But they emit only the **unfuzzed** edges as `xmin`/`xmax` (`summary-bin.ts:139-140`).

Both lineage consumers then re-derived membership from those exact edges, each with its own predicate:

- `buildBinLineageBuckets` → local `findBinIndex` (`identity-buckets.ts:165-192`)
- `filterBinRepresentedRows` (`represented-rows.ts:53-59`)

Inside the fuzz band around an interior break the three disagree.

## Validation

Reproduced through the real pipeline before writing any fix — `binwidth: 1, boundary: 0` (integer breaks), `x = [0.5, 1 + 1e-9, 1.5]`, `y = [10, 20, 30]`:

| Mark | `y` (what the stat computed) | lineage before | lineage after |
|---|---|---|---|
| bin (0,1] | `15` = mean(10, 20) → rows 0 **and 1** | `[0]` | `[0, 1]` |
| bin (1,2] | `30` → row 2 only | `[2, 1]` | `[2]` |

`stat_bin` was **confirmed** to share the defect by test, not assumed.

## What changed

The binning stats now export the cut they actually performed — the fuzzy grid, the resolved closed side, and the grid bin index per emitted row — and both consumers replay it through the same `binIndexOf`.

The duplicated exact-edge predicate is **deleted** rather than patched, so the indexed and fallback paths cannot drift apart again. The grid-bin → frame-row map is per group, which handles `summary_bin` omitting empty bins (`stat_bin` emits every group × bin).

Two traps found while planning, both now covered by regression tests:

- **Not** exporting `bucket.rows` as the mapping: `statSummaryBin` drops rows with non-finite **y** (`summary-bin.ts:103`), but the lineage contract is finite-**x** rows (`represented-rows.ts:55`). That would have silently dropped finite-x/NaN-y rows from lineage and regressed #901.
- **Not** fixing only `buildBinLineageBuckets`: `filterBinRepresentedRows` is a separate consumer, and `aggregate-lineage` asserts the two agree.

When the cut is absent, both consumers fall back to the existing conservative "mark represents the whole group" behaviour already used when bin edges are missing — not to a second, drifting predicate.

## Tests

`packages/core/tests/pipeline-m2/bin-edge-lineage.test.ts` — 3 verified RED before the fix, 2 are guards that passed before and after:

| Test | Before |
|---|---|
| fuzz-band row attributed to the bin that summarized it (`closed: right`) | RED |
| mirror for `closed: left` (fuzz band *below* a break) | RED |
| `stat_bin` fuzz-band row | RED |
| row exactly on an interior break claimed by exactly one bin, both closed sides | guard |
| finite-x / non-finite-y rows stay in lineage (#901 contract) | guard |

Two existing `lineage-filters` fixtures gained a `binCut`, since hand-built frames must now model the stat's cut to exercise that path.

## Verification

| Command | Result |
|---|---|
| `bun test packages/spec packages/core` | **2123 pass, 0 fail** |
| `bun run lint` | clean |
| `bun run check` | clean |

Note: the suite needs `bun run check` first (`CONTRIBUTING.md:184`) — tests import `@ggsvelte/spec` through `dist`.

## Follow-ups

None deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/949" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->