### PR TITLE
fix(core): warn when an after_stat color/fill mapping is ignored (#915)

### DIFF
--- a/.changeset/915-after-stat-color-warning.md
+++ b/.changeset/915-after-stat-color-warning.md
@@ -1,0 +1,18 @@
+---
+"@ggsvelte/core": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+fix: warn when an after_stat color/fill mapping is ignored (#915)
+
+An `{ stat }` mapping on `color`/`fill` was accepted for every geom but only
+`density_2d` / `density_2d_filled` ever resolve one into colour values, so
+elsewhere it was dropped without a diagnostic. Those cases now emit a
+`stat-channel-unsupported` warning naming the stat and the requested column.
+
+This is a warning rather than an error: the layer still renders exactly as
+before, and after-stat colour is a mapping we intend to support more widely
+(tracked separately).
+
+Migration: none — diagnostic only

--- a/packages/core/src/pipeline/bind-layer-color-binding.ts
+++ b/packages/core/src/pipeline/bind-layer-color-binding.ts
@@ -6,11 +6,13 @@ import type { ChannelValue } from "@ggsvelte/spec";
 import type { ColumnTable } from "../table.js";
 
 import { checkField } from "./bind-layer-check-field.js";
+import { STAT_COLOR_COLUMNS } from "./bind-layer-stat-columns.js";
 import type { ColorBinding, PipelineWarning } from "./types.js";
 
 export function colorBinding(
   channel: ChannelValue | undefined,
   channelName: string,
+  stat: string,
   layerIndex: number,
   table: ColumnTable,
   warnings: PipelineWarning[],
@@ -26,6 +28,16 @@ export function colorBinding(
     out.field = checkField(channel, channelName, layerIndex, table, warnings);
   } else if ("stat" in channel) {
     // after_stat columns (e.g. density_2d_filled fill → level; #802 phase 2).
+    // Only the density_2d frame resolves these into colour values, so warn
+    // rather than drop the mapping in silence (#915). This stays a warning,
+    // not a PipelineError as on style channels, because the layer still
+    // renders and after_stat colour is a mapping we may yet support.
+    if (!(STAT_COLOR_COLUMNS[stat] ?? []).includes(channel.stat)) {
+      warnings.push({
+        code: "stat-channel-unsupported",
+        message: `Layer ${layerIndex}: the ${stat} stat does not publish after-stat column "${channel.stat}" for aes.${channelName}; the mapping is ignored.`,
+      });
+    }
     out.statColumn = channel.stat;
   } else if ("value" in channel) {
     if (channel.scale === true) out.scaledConstant = channel.value;

--- a/packages/core/src/pipeline/bind-layer-extras.ts
+++ b/packages/core/src/pipeline/bind-layer-extras.ts
@@ -70,8 +70,8 @@ export function resolveLabelWeightColorFill(input: {
     );
   }
 
-  const color = colorBinding(aes.color, "color", index, table, warnings);
-  const fill = colorBinding(aes.fill, "fill", index, table, warnings);
+  const color = colorBinding(aes.color, "color", stat, index, table, warnings);
+  const fill = colorBinding(aes.fill, "fill", stat, index, table, warnings);
   applyColorOnFillGeomWarning(geom, index, color, warnings);
   const size = styleBinding(aes.size, "size", geom, stat, index, table, warnings);
   const linewidth = styleBinding(aes.linewidth, "linewidth", geom, stat, index, table, warnings);

--- a/packages/core/src/pipeline/bind-layer-stat-columns.ts
+++ b/packages/core/src/pipeline/bind-layer-stat-columns.ts
@@ -21,3 +21,15 @@ export const STAT_Y_COLUMNS: Record<string, readonly string[]> = {
   // Contour writes x/y as frame coordinates; after_stat level is not a y column.
   contour: [],
 };
+
+/**
+ * color/fill `{ stat }` columns each stat exposes. Only the density_2d frame
+ * builder resolves an after_stat column into colour values
+ * (`frame-stats-density-2d.ts`); every other frame builds colour from the
+ * mapped field alone, so an `{ stat }` mapping there is dropped (#915).
+ * Stats absent from this map publish nothing for colour.
+ */
+export const STAT_COLOR_COLUMNS: Record<string, readonly string[]> = {
+  density_2d: ["level", "density"],
+  density_2d_filled: ["level", "density"],
+};

--- a/packages/core/tests/pipeline-after-stat-color.test.ts
+++ b/packages/core/tests/pipeline-after-stat-color.test.ts
@@ -1,0 +1,96 @@
+/**
+ * after_stat color/fill diagnostics (#915).
+ *
+ * Only density_2d / density_2d_filled wire an after_stat column into
+ * color/fill (`frame-stats-density-2d.ts` — every other frame builds
+ * color/fill from the mapped *field* alone). Elsewhere an `{ stat }` colour
+ * mapping was accepted and then silently dropped, with no diagnostic.
+ */
+import { describe, expect, it } from "bun:test";
+import { aes, gg } from "@ggsvelte/spec";
+import { runPipeline } from "../src/pipeline.ts";
+
+const size = { width: 400, height: 300 };
+
+function statChannelWarnings(warnings: readonly { code: string; message: string }[]): string[] {
+  return warnings.filter((w) => w.code === "stat-channel-unsupported").map((w) => w.message);
+}
+
+function cloud(n: number): { x: number[]; y: number[] } {
+  const x: number[] = [];
+  const y: number[] = [];
+  for (let i = 0; i < n; i++) {
+    x.push(Math.cos(i) * 2);
+    y.push(Math.sin(i * 1.7) * 2);
+  }
+  return { x, y };
+}
+
+describe("after_stat color/fill (#915)", () => {
+  it("warns when a stat does not publish the after_stat fill column", () => {
+    const model = runPipeline(
+      gg({ x: [1, 2, 2, 3, 3, 3] }, aes({ x: "x", fill: { stat: "count" } }))
+        .geomHistogram({ binwidth: 1, boundary: 0 })
+        .spec(),
+      size,
+    );
+    const messages = statChannelWarnings(model.warnings);
+    expect(messages.length).toBe(1);
+    expect(messages[0]).toContain("fill");
+    expect(messages[0]).toContain("count");
+    // Diagnostic only — the layer still renders exactly as before.
+    expect(model.scene.batches.length).toBeGreaterThan(0);
+  });
+
+  it("warns for after_stat color on a stat with no colour outputs", () => {
+    const model = runPipeline(
+      gg({ x: [1, 2, 3], y: [1, 2, 3] }, aes({ x: "x", y: "y", color: { stat: "y" } }))
+        .geomPoint({ stat: "summary_bin", binwidth: 1, boundary: 0 })
+        .spec(),
+      size,
+    );
+    expect(statChannelWarnings(model.warnings).length).toBe(1);
+  });
+
+  it("stays silent for density_2d_filled fill = after_stat(level)", () => {
+    const model = runPipeline(
+      gg(cloud(60), aes({ x: "x", y: "y" }))
+        .geomDensity2dFilled({ n: 20, bins: 4 })
+        .spec(),
+      size,
+    );
+    expect(statChannelWarnings(model.warnings)).toEqual([]);
+  });
+
+  it("stays silent for density_2d color = after_stat(level)", () => {
+    const model = runPipeline(
+      gg(cloud(60), aes({ x: "x", y: "y", color: { stat: "level" } }))
+        .geomDensity2d({ n: 20, bins: 4 })
+        .spec(),
+      size,
+    );
+    expect(statChannelWarnings(model.warnings)).toEqual([]);
+  });
+
+  it("warns for an unknown column even on density_2d_filled", () => {
+    const model = runPipeline(
+      gg(cloud(60), aes({ x: "x", y: "y", fill: { stat: "bogus" } }))
+        .geomDensity2dFilled({ n: 20, bins: 4 })
+        .spec(),
+      size,
+    );
+    const messages = statChannelWarnings(model.warnings);
+    expect(messages.length).toBe(1);
+    expect(messages[0]).toContain("bogus");
+  });
+
+  it("does not warn for ordinary field-mapped fill", () => {
+    const model = runPipeline(
+      gg({ x: [1, 2, 3], g: ["a", "b", "a"] }, aes({ x: "x", fill: "g" }))
+        .geomHistogram({ binwidth: 1, boundary: 0 })
+        .spec(),
+      size,
+    );
+    expect(statChannelWarnings(model.warnings)).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #915.

## Problem

An `{ stat }` mapping on `aes.color` / `aes.fill` was accepted for every geom, but only the density_2d frame builder ever resolves an after-stat column into colour values:

- `frame-stats-density-2d.ts:98-99` — `colorOrFillValues(binding.color, col, computed)`
- every other frame — `colorValues: col(binding.color.field)`, field only (e.g. `frame-stats-bin-frame.ts:54-55`, `frame-stats-density.ts:63-64`, `frame-stats-boxplot.ts:46-47`)

So outside density_2d the mapping was dropped with **no diagnostic** — unlike the equivalent style-channel path, which raises `stat-channel-unsupported` (`bind-layer-style-binding.ts:68-74`).

## Validation

Confirmed by probe before writing the fix — `geom_histogram` with `fill = after_stat(count)`:

```
warnings: []          ← nothing reported
batches:  1           ← renders
fills:    undefined   ← mapping silently dropped
```

and `density_2d_filled` with `fill = after_stat(level)` producing real fills (`#440154`, `#fde725`, …), i.e. the one path that must keep working.

## What changed

`STAT_COLOR_COLUMNS` records which stats publish after-stat columns **for colour** (`density_2d` / `density_2d_filled` → `level`, `density`; nothing else). `colorBinding` now warns when the layer's stat does not publish the requested column.

It lives beside the existing `STAT_Y_COLUMNS` because the sets genuinely differ per channel — `level` is a valid *fill* column but explicitly not a valid *y* column (`bind-layer-stat-columns.ts:11-13`).

### Why a warning, not a `PipelineError`

The style-channel path throws. I deliberately did not mirror that:

- Throwing would turn currently-rendering plots into hard failures — a breaking change for output that is merely missing a mapping.
- `aes(fill = after_stat(count))` on a histogram is a core ggplot2 idiom. Erroring would cement it as invalid; it should eventually **work**. Filed as #953.

The issue's acceptance sketch permits "warn or error". This keeps the change purely additive: no rendering behaviour changes, only a diagnostic appears.

`out.statColumn` is deliberately left set rather than nulled — `scale-color-collect.ts:27` and `layer-fields.ts:85` read it, and nulling it would change scale/legend collection rather than just adding the diagnostic.

## Tests

`packages/core/tests/pipeline-after-stat-color.test.ts` — 3 verified RED before the fix, 3 guards that passed before and after:

| Test | Before |
|---|---|
| histogram `fill = after_stat(count)` warns | RED |
| `summary_bin` `color = after_stat(y)` warns | RED |
| unknown column on `density_2d_filled` warns | RED |
| `density_2d_filled` `fill = after_stat(level)` silent | guard |
| `density_2d` `color = after_stat(level)` silent | guard |
| ordinary field-mapped fill silent | guard |

## Verification

| Command | Result |
|---|---|
| `bun test packages/spec packages/core` | **2130 pass, 0 fail** |
| `bun run lint` | clean |
| `bun run check` | clean |

## Follow-ups

- #953 — support after_stat color/fill outside density_2d (the capability this warning points at)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/954" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->