### PR TITLE
fix(core): keep binned legend bin edges distinguishable (#955)

### DIFF
--- a/.changeset/955-binned-legend-labels.md
+++ b/.changeset/955-binned-legend-labels.md
@@ -1,0 +1,16 @@
+---
+"@ggsvelte/core": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+fix: keep binned legend bin edges distinguishable (#955)
+
+Default binned colour and numeric-style legends formatted edges with axis
+`tickStep(domain, 5)` precision, so fractional bins on a small domain (e.g.
+0–4 over 5 bins) could collapse adjacent edges to the same label and emit
+degenerate ranges like `"2–2"`. Labels now derive decimals from the minimum
+adjacent bin width so distinct edges stay distinct; integer-edge legends and
+explicit `labels` formats are unchanged.
+
+Migration: none — display-only for affected fractional-bin legends

--- a/packages/core/src/pipeline/scale-color-binned.ts
+++ b/packages/core/src/pipeline/scale-color-binned.ts
@@ -10,7 +10,7 @@ import type { CellValue } from "../table.js";
 
 import { fallbackColors, warnUnknownColors } from "./scale-color-family-helpers.js";
 import { resolveSequentialRange } from "./scale-color-sequential-domain.js";
-import { resolveBinnedLegendFormat } from "./scale-color-sequential-format.js";
+import { minAdjacentWidth, resolveBinnedLegendFormat } from "./scale-color-sequential-format.js";
 import type { ColorResolution } from "./scale-color-types.js";
 import { resolveColorValueView } from "./scale-color-values.js";
 import { PipelineError, type PipelineWarning } from "./types.js";
@@ -175,12 +175,14 @@ export function resolveBinnedColorScale(input: {
     }).length,
     warnings,
   );
+  const formatStep = minAdjacentWidth(breaks);
   const formatter = resolveBinnedLegendFormat({
     domain,
     temporalKind: view.temporalKind,
     config,
     name,
     warnings,
+    ...(formatStep !== undefined && { formatStep }),
   });
   const steps = breaks.slice(0, -1).map((lower, index) => {
     const upper = breaks[index + 1]!;

--- a/packages/core/src/pipeline/scale-color-sequential-format.ts
+++ b/packages/core/src/pipeline/scale-color-sequential-format.ts
@@ -13,6 +13,17 @@ export interface ColorLegendFormatter {
   fullLabel(value: number): string;
 }
 
+/** Minimum positive adjacent gap among finite break edges (skips non-positive gaps). */
+export function minAdjacentWidth(breaks: readonly number[]): number | undefined {
+  let min: number | undefined;
+  for (let index = 1; index < breaks.length; index++) {
+    const width = breaks[index]! - breaks[index - 1]!;
+    if (!Number.isFinite(width) || width <= 0) continue;
+    if (min === undefined || width < min) min = width;
+  }
+  return min;
+}
+
 function resolveColorLegendFormat(input: {
   domain: readonly [number, number];
   temporalKind: TemporalKind | null;
@@ -20,6 +31,8 @@ function resolveColorLegendFormat(input: {
   config: Pick<ColorScaleSpec, "labels" | "timezone" | "transform"> | undefined;
   name: string;
   warnings: PipelineWarning[];
+  /** When set (binned legends), use bin width for decimals instead of axis tickStep. */
+  formatStep?: number;
 }): ColorLegendFormatter {
   const { domain, temporalKind, config, name, warnings } = input;
   const transform = input.transform ?? config?.transform ?? "identity";
@@ -78,7 +91,11 @@ function resolveColorLegendFormat(input: {
       });
     };
   } else {
-    label = defaultTickFormat(tickStep(domain[0], domain[1], 5));
+    const step =
+      input.formatStep !== undefined && Number.isFinite(input.formatStep) && input.formatStep > 0
+        ? input.formatStep
+        : tickStep(domain[0], domain[1], 5);
+    label = defaultTickFormat(step);
   }
   if (labelFormat !== undefined) {
     const formatter = numberFormatter(labelFormat);
@@ -100,6 +117,7 @@ export function resolveStyleLegendFormat(input: {
   config: { labels?: string; timezone?: string } | undefined;
   name: string;
   warnings: PipelineWarning[];
+  formatStep?: number;
 }): ColorLegendFormatter {
   return resolveColorLegendFormat(input);
 }
@@ -126,6 +144,7 @@ export function resolveBinnedLegendFormat(input: {
   config: ColorScaleSpec;
   name: "color" | "fill";
   warnings: PipelineWarning[];
+  formatStep?: number;
 }): ColorLegendFormatter {
   return resolveColorLegendFormat(input);
 }

--- a/packages/core/src/pipeline/scale-style-numeric.ts
+++ b/packages/core/src/pipeline/scale-style-numeric.ts
@@ -6,7 +6,7 @@ import { encodeKey, type ScaleState } from "../scales/state.js";
 import { finiteExtent } from "../scales/train.js";
 import type { CellValue } from "../table.js";
 
-import { resolveStyleLegendFormat } from "./scale-color-sequential-format.js";
+import { minAdjacentWidth, resolveStyleLegendFormat } from "./scale-color-sequential-format.js";
 import { discreteStyleResolution, styleGuideEntry } from "./scale-style-discrete.js";
 import type { NumericStyleAesthetic, StyleResolution } from "./scale-style-types.js";
 import { resolveNumericStyleValueView, type NumericStyleConfig } from "./scale-style-values.js";
@@ -218,12 +218,14 @@ function numericSequentialResolution(input: {
     kind === "binned"
       ? boundaries.slice(0, -1)
       : ((sequentialBreaks as number[] | undefined) ?? linearTicks(low, high, 5));
+  const formatStep = kind === "binned" ? minAdjacentWidth(boundaries) : undefined;
   const formatter = resolveStyleLegendFormat({
     domain,
     temporalKind: view.temporalKind,
     config,
     name: aesthetic,
     warnings,
+    ...(formatStep !== undefined && { formatStep }),
   });
   const entries = ticks.map((value, index) =>
     styleGuideEntry(

--- a/packages/core/tests/pipeline-color-scales/binned.test.ts
+++ b/packages/core/tests/pipeline-color-scales/binned.test.ts
@@ -96,6 +96,22 @@ describe("binned color scales", () => {
     expect(colorsteps.steps.map((step) => step.label)).toEqual(["1.0–10.0", "10.0–100.0"]);
   });
 
+  it("keeps adjacent default bin edges distinguishable in legend labels (#955)", () => {
+    // Domain 0–4 / 5 equal bins → edges 0, 0.8, 1.6, 2.4, 3.2, 4. Axis-style
+    // tickStep(domain, 5) precision used to collapse 1.6 and 2.4 both to "2"
+    // and emit a degenerate "2–2" step.
+    const model = runPipeline(pointSpec([0, 1, 2, 3, 4], { type: "binned" }), size);
+    const colorsteps = model.guidePlans.find((candidate) => candidate.type === "colorsteps");
+    if (colorsteps?.type !== "colorsteps") throw new Error("expected colorsteps plan");
+    expect(colorsteps.steps.map((step) => step.label)).toEqual([
+      "0.0–0.8",
+      "0.8–1.6",
+      "1.6–2.4",
+      "2.4–3.2",
+      "3.2–4.0",
+    ]);
+  });
+
   it("rejects a binned domain that disagrees with explicit boundaries", () => {
     expect(() =>
       runPipeline(

--- a/packages/core/tests/pipeline-style-families/guides-legends.test.ts
+++ b/packages/core/tests/pipeline-style-families/guides-legends.test.ts
@@ -123,6 +123,33 @@ describe("style guides and legend interactivity", () => {
     expect(plan.entries.map((entry) => entry.value)).toEqual([0, 25, 50, 75, 100]);
   });
 
+  it("keeps adjacent default binned size edges distinguishable in legend labels (#955)", () => {
+    const model = runPipeline(
+      fromAny({
+        data: {
+          values: [0, 1, 2, 3, 4].map((amount, index) => ({
+            x: index + 1,
+            y: index + 1,
+            amount,
+          })),
+        },
+        aes: { x: { field: "x" }, y: { field: "y" }, size: { field: "amount" } },
+        layers: [{ geom: "point" }],
+        scales: { size: { type: "binned" } },
+      }),
+      viewport,
+    );
+    const plan = model.guidePlans.find((p) => p.aesthetic === "size");
+    if (plan?.type !== "discrete") throw new Error("expected size discrete guide plan");
+    expect(plan.entries.map((entry) => entry.label)).toEqual([
+      "0.0–0.8",
+      "0.8–1.6",
+      "1.6–2.4",
+      "2.4–3.2",
+      "3.2–4.0",
+    ]);
+  });
+
   it("rejects a field-mapped style on a fixed-intercept annotation rule", () => {
     // An annotation rule emits no data rows, so a field mapping has nothing to
     // map and would produce NaN/invalid style vectors — reject it loudly.


### PR DESCRIPTION
## Summary
- Fixes [#955](https://github.com/ljodea/ggsvelte/issues/955): default binned colour (and size/alpha/linewidth) legends on domains like `0–4` / 5 bins no longer emit degenerate labels such as `"2–2"`.
- Root cause: legend formatting reused axis `tickStep(domain, 5)` precision (`1` for that domain), so edges `1.6` and `2.4` both rendered as `"2"`.
- Fix: pass minimum adjacent bin width as `formatStep` into the shared colour/style legend formatter (identity/sqrt path only; log10 and temporal branches unchanged).

## Validation
- Reproduced via `runPipeline` with `{ type: "binned" }` on values spanning `0–4` → labels included `"2–2"`.
- After fix: `["0.0–0.8","0.8–1.6","1.6–2.4","2.4–3.2","3.2–4.0"]`.
- Integer-edge case `[1,10,100,1000]` still `"1–10"`, `"10–100"`, `"100–1,000"`.
- Explicit `labels: ".1f"` still wins.
- log10 binned smoke: `[1,10,100,1000]` still `"1–10"`, `"10–100"`, `"100–1,000"`.

## Test plan
- [x] `bun test packages/core/tests/pipeline-color-scales/binned.test.ts`
- [x] `bun test packages/core/tests/pipeline-style-families/guides-legends.test.ts`
- [x] `bun test packages/core/tests/pipeline-color-scales/ packages/core/tests/pipeline-style-families/` (58 pass)

## Follow-ups
- Temporal binned legends still ignore `formatStep` (date tick formats); same collapse class possible for sub-day bins — track separately if needed.

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/958" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->