### PR TITLE
fix(docs): lazy-load search index until SiteSearch opens (#948)

### DIFF
--- a/apps/docs/src/lib/components/SiteSearch.svelte
+++ b/apps/docs/src/lib/components/SiteSearch.svelte
@@ -23,7 +23,7 @@
   );
 
   async function ensureIndex(): Promise<void> {
-    if (loadState === "ready" || loadState === "loading") return;
+    if (loadState === "ready") return;
     loadState = "loading";
     try {
       entries = await loadDocsSearchIndex();
@@ -85,9 +85,25 @@
     window.location.assign(`${base}${result.href}`);
   }
 
-  function handleKeydown(event: KeyboardEvent): void {
+  async function handleKeydown(event: KeyboardEvent): Promise<void> {
     const action = siteSearchKeyAction(event.key, activeIndex, results.length);
-    if (action.type === "ignore") return;
+    if (action.type === "ignore") {
+      // Enter with no active option is ignored while the index is still loading;
+      // wait for it and select the first match for the current query (#948).
+      if (
+        event.key === "Enter" &&
+        loadState !== "ready" &&
+        query.trim() !== ""
+      ) {
+        event.preventDefault();
+        await ensureIndex();
+        if (results.length > 0) {
+          activeIndex = 0;
+          followActive();
+        }
+      }
+      return;
+    }
     event.preventDefault();
     if (action.type === "move") {
       activeIndex = action.index;

--- a/apps/docs/src/lib/components/SiteSearch.svelte
+++ b/apps/docs/src/lib/components/SiteSearch.svelte
@@ -2,8 +2,9 @@
   import { base } from "$app/paths";
 
   import { DOCS_TASKS } from "$lib/catalog/docs-tasks";
-  import { DOCS_SEARCH_INDEX } from "$lib/generated/search-index";
+  import { loadDocsSearchIndex } from "$lib/load-docs-search-index";
   import { searchDocs } from "$lib/search";
+  import type { DocsSearchEntry } from "$lib/search-types";
   import { siteSearchKeyAction } from "$lib/site-search-keyboard";
 
   let dialog = $state<HTMLDialogElement>();
@@ -11,7 +12,9 @@
   let returnFocus = $state<HTMLElement>();
   let query = $state("");
   let activeIndex = $state(-1);
-  const results = $derived(searchDocs(query, DOCS_SEARCH_INDEX));
+  let entries = $state<readonly DocsSearchEntry[]>([]);
+  let loadState = $state<"idle" | "loading" | "ready" | "error">("idle");
+  const results = $derived(searchDocs(query, entries));
   const expanded = $derived(query.trim() !== "" && results.length > 0);
   const activeId = $derived(
     activeIndex >= 0 && activeIndex < results.length
@@ -19,12 +22,28 @@
       : undefined,
   );
 
+  async function ensureIndex(): Promise<void> {
+    if (loadState === "ready" || loadState === "loading") return;
+    loadState = "loading";
+    try {
+      entries = await loadDocsSearchIndex();
+      loadState = "ready";
+      if (query.trim() !== "") {
+        activeIndex = results.length > 0 ? 0 : -1;
+      }
+    } catch (error) {
+      console.error("Failed to load docs search index", error);
+      loadState = "error";
+    }
+  }
+
   export function open(trigger: HTMLElement): void {
     returnFocus = trigger;
     query = "";
     activeIndex = -1;
     dialog?.showModal();
     queueMicrotask(() => input?.focus());
+    void ensureIndex();
   }
 
   function close(): void {
@@ -41,7 +60,7 @@
 
   function updateQuery(event: Event): void {
     query = (event.currentTarget as HTMLInputElement).value;
-    activeIndex = searchDocs(query, DOCS_SEARCH_INDEX).length > 0 ? 0 : -1;
+    activeIndex = results.length > 0 ? 0 : -1;
   }
 
   function scrollActiveIntoView(): void {
@@ -118,7 +137,11 @@
     />
 
     <p class="search-status" role="status">
-      {#if query.trim() !== ""}
+      {#if loadState === "loading"}
+        Loading search index…
+      {:else if loadState === "error"}
+        Search is unavailable. Close and try again.
+      {:else if query.trim() !== ""}
         {results.length === 0
           ? "No matching documentation."
           : `${results.length} ${results.length === 1 ? "result" : "results"}.`}

--- a/apps/docs/src/lib/load-docs-search-index.ts
+++ b/apps/docs/src/lib/load-docs-search-index.ts
@@ -1,0 +1,35 @@
+import type { DocsSearchEntry } from "./search-types.js";
+
+type SearchIndexModule = {
+  DOCS_SEARCH_INDEX: readonly DocsSearchEntry[];
+};
+
+type SearchIndexImporter = () => Promise<SearchIndexModule>;
+
+const defaultImporter: SearchIndexImporter = () =>
+  import("./generated/search-index.js") as Promise<SearchIndexModule>;
+
+let pending: Promise<readonly DocsSearchEntry[]> | undefined;
+
+/**
+ * Load the generated docs search index once (dynamic import) and reuse it.
+ * Ordinary docs navigations must not pay for this module until search opens.
+ */
+export function loadDocsSearchIndex(
+  importer: SearchIndexImporter = defaultImporter,
+): Promise<readonly DocsSearchEntry[]> {
+  if (pending === undefined) {
+    pending = importer()
+      .then((module) => module.DOCS_SEARCH_INDEX)
+      .catch((error: unknown) => {
+        pending = undefined;
+        throw error;
+      });
+  }
+  return pending;
+}
+
+/** Test-only: drop the cached promise between cases. */
+export function resetDocsSearchIndexLoaderForTests(): void {
+  pending = undefined;
+}

--- a/apps/docs/src/lib/load-docs-search-index.ts
+++ b/apps/docs/src/lib/load-docs-search-index.ts
@@ -7,7 +7,9 @@ type SearchIndexModule = {
 type SearchIndexImporter = () => Promise<SearchIndexModule>;
 
 const defaultImporter: SearchIndexImporter = () =>
-  import("./generated/search-index.js") as Promise<SearchIndexModule>;
+  import("./generated/search-index.js").then((module) => ({
+    DOCS_SEARCH_INDEX: module.DOCS_SEARCH_INDEX,
+  }));
 
 let pending: Promise<readonly DocsSearchEntry[]> | undefined;
 
@@ -18,14 +20,12 @@ let pending: Promise<readonly DocsSearchEntry[]> | undefined;
 export function loadDocsSearchIndex(
   importer: SearchIndexImporter = defaultImporter,
 ): Promise<readonly DocsSearchEntry[]> {
-  if (pending === undefined) {
-    pending = importer()
-      .then((module) => module.DOCS_SEARCH_INDEX)
-      .catch((error: unknown) => {
-        pending = undefined;
-        throw error;
-      });
-  }
+  pending ??= importer()
+    .then((module) => module.DOCS_SEARCH_INDEX)
+    .catch((error: unknown) => {
+      pending = undefined;
+      throw error;
+    });
   return pending;
 }
 

--- a/scripts/docs-search-lazy.test.ts
+++ b/scripts/docs-search-lazy.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+import {
+  loadDocsSearchIndex,
+  resetDocsSearchIndexLoaderForTests,
+} from "../apps/docs/src/lib/load-docs-search-index.ts";
+
+const docsSrc = path.join(import.meta.dirname, "../apps/docs/src");
+
+function walkFiles(root: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    const full = path.join(root, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "generated") continue;
+      out.push(...walkFiles(full));
+      continue;
+    }
+    if (/\.(svelte|ts|js)$/.test(entry.name)) out.push(full);
+  }
+  return out;
+}
+
+describe("docs search index lazy load (#948)", () => {
+  it("loads the index once and reuses the same promise", async () => {
+    resetDocsSearchIndexLoaderForTests();
+    const first = loadDocsSearchIndex();
+    const second = loadDocsSearchIndex();
+    expect(second).toBe(first);
+    const entries = await first;
+    expect(entries.length).toBeGreaterThan(100);
+    expect(entries.some((entry) => entry.href.includes("/guide/"))).toBe(true);
+  });
+
+  it("clears the cache after failure so a later open can retry", async () => {
+    resetDocsSearchIndexLoaderForTests();
+    const failing = loadDocsSearchIndex(() => Promise.reject(new Error("chunk missing")));
+    await expect(failing).rejects.toThrow("chunk missing");
+    const recovered = await loadDocsSearchIndex(() =>
+      Promise.resolve({
+        DOCS_SEARCH_INDEX: [
+          {
+            id: "probe",
+            kind: "page" as const,
+            title: "Probe",
+            summary: "ok",
+            href: "/guide/getting-started",
+            keywords: [],
+            exact: [],
+          },
+        ],
+      }),
+    );
+    expect(recovered).toHaveLength(1);
+    expect(recovered[0]?.id).toBe("probe");
+  });
+
+  it("keeps the docs UI load path free of a static search-index import", () => {
+    const offenders: string[] = [];
+    for (const file of walkFiles(docsSrc)) {
+      const rel = path.relative(docsSrc, file);
+      if (rel === "lib/load-docs-search-index.ts") continue;
+      const source = readFileSync(file, "utf8");
+      if (
+        /from\s*["'][^"']*generated\/search-index[^"']*["']/.test(source) &&
+        !/import\s*\(\s*["'][^"']*generated\/search-index/.test(source)
+      ) {
+        offenders.push(rel);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/scripts/docs-search-lazy.test.ts
+++ b/scripts/docs-search-lazy.test.ts
@@ -37,7 +37,14 @@ describe("docs search index lazy load (#948)", () => {
   it("clears the cache after failure so a later open can retry", async () => {
     resetDocsSearchIndexLoaderForTests();
     const failing = loadDocsSearchIndex(() => Promise.reject(new Error("chunk missing")));
-    await expect(failing).rejects.toThrow("chunk missing");
+    let caught: unknown;
+    try {
+      await failing;
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toBe("chunk missing");
     const recovered = await loadDocsSearchIndex(() =>
       Promise.resolve({
         DOCS_SEARCH_INDEX: [

--- a/tests/visual/docs-shell.spec.ts
+++ b/tests/visual/docs-shell.spec.ts
@@ -208,10 +208,10 @@ test("appearance control remains usable when browser storage is unavailable", as
 });
 
 test("route metadata is canonical, singular, and aliases are noindex", async ({ page }) => {
-  // Three full navigations (guide, alias, 404), each hydrating the generated
-  // search index (~760KB) — measured 17s locally and 30.2s on CI journeys,
-  // straddling the default 30s budget regardless of the change under test.
-  test.setTimeout(60_000);
+  // Search index is lazy-loaded on first open (#948). Pre-fix CI sat at ~30s with
+  // the index in every navigation; keep a modest raised budget until a few green
+  // journeys runs confirm the default 30s is safe again.
+  test.setTimeout(45_000);
   await page.goto(GUIDE_ROUTE);
   await expect(page).toHaveTitle("Getting started — ggsvelte");
   await expect(page.locator('link[rel="canonical"]')).toHaveCount(1);


### PR DESCRIPTION
## Summary
- Fixes [#948](https://github.com/ljodea/ggsvelte/issues/948): `SiteSearch` no longer statically imports `DOCS_SEARCH_INDEX` (~789KB), which previously rode into every docs page via `SiteHeader`.
- Index loads once on first search open via dynamic `import()`, with loading / error status (retry on reopen) and query-before-ready handled.
- Guardrail test walks `apps/docs/src` and fails if anything other than the loader statically imports `generated/search-index`.
- Journeys route-metadata timeout reduced 60s → 45s (not all the way to 30s until CI timings confirm margin).

## Validation
- Static import site confirmed: only `SiteSearch.svelte` imported the index; header mounts it on every page.
- `bun test scripts/docs-search-lazy.test.ts scripts/docs-search.test.ts` — 12 pass.
- Before/after wall times for the journeys test itself are left to CI (no local built docs artifact in this slot); timeout kept at 45s pending green runs.

## Test plan
- [x] `bun test scripts/docs-search-lazy.test.ts`
- [x] `bun test scripts/docs-search.test.ts`
- [ ] CI `component-journeys` green; note route-metadata duration vs prior ~30s
- [ ] Manually: open search, type before index lands, see results; force chunk fail → error status then reopen retries

## Follow-ups
- Drop route-metadata timeout to default 30s after several green journeys runs with timings.
- #944 / #946 still cover remaining journeys cold-start / mobile-shell cost.

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/959" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->