### PR TITLE
fix(ci): give docs journeys a 60s Playwright project budget (#944)

### DIFF
--- a/.github/workflows/ci-component-journeys.yml
+++ b/.github/workflows/ci-component-journeys.yml
@@ -75,8 +75,10 @@ jobs:
         if: steps.content_hash.outputs.hit != 'true'
         # Enumerate every non-pixel docs journey. --grep-invert drops visual-contract
         # screenshots so content PRs never pay full-page goldens here.
+        # --project journeys selects the 60s-budget Playwright project (#944).
         run: >-
           bun run test:visual --
+          --project journeys
           docs-shell.spec.ts
           docs-home-gallery.spec.ts
           docs-progressive-search.spec.ts

--- a/.github/workflows/ci-component-journeys.yml
+++ b/.github/workflows/ci-component-journeys.yml
@@ -73,18 +73,12 @@ jobs:
         run: DOCS_BUILD_MODE=cloudflare-preview bun run build:docs
       - name: docs shell, home/gallery, progressive, themes, interaction, playground journeys
         if: steps.content_hash.outputs.hit != 'true'
-        # Enumerate every non-pixel docs journey. --grep-invert drops visual-contract
-        # screenshots so content PRs never pay full-page goldens here.
-        # --project journeys selects the 60s-budget Playwright project (#944).
+        # The journeys Playwright project selects the docs a11y/structure specs
+        # (60s budget, #944). --grep-invert drops visual-contract screenshots so
+        # content PRs never pay full-page goldens here.
         run: >-
           bun run test:visual --
           --project journeys
-          docs-shell.spec.ts
-          docs-home-gallery.spec.ts
-          docs-progressive-search.spec.ts
-          docs-themes.spec.ts
-          interaction-accessibility.spec.ts
-          playground.spec.ts
           --grep-invert 'visual contract'
       - uses: ./.github/actions/ci-content-hash-write
         if: steps.content_hash.outputs.hit != 'true' && steps.content_hash.outputs.bypass != 'true'

--- a/scripts/release-wiring.test.ts
+++ b/scripts/release-wiring.test.ts
@@ -252,6 +252,9 @@ describe("R0 release wiring", () => {
     expect(journeysJob).toContain("docs-progressive-search.spec.ts");
     expect(journeysJob).toContain("docs-themes.spec.ts");
     expect(journeysJob).toContain("--grep-invert 'visual contract'");
+    expect(journeysJob).toContain("--project journeys");
+    expect(read("tests/visual/playwright.config.ts")).toContain('name: "journeys"');
+    expect(read("tests/visual/playwright.config.ts")).toContain("timeout: 60_000");
     // ci-gate: package component = svelte+svelte-fx+spikes; docs_journeys is independent.
     expect(ci).toContain("COMPONENT_SVELTE_RES");
     expect(ci).toContain("COMPONENT_SVELTE_FX_RES");

--- a/scripts/release-wiring.test.ts
+++ b/scripts/release-wiring.test.ts
@@ -247,14 +247,16 @@ describe("R0 release wiring", () => {
     expect(journeysJob).toContain("packages-dist");
     expect(journeysJob).toContain("bun run build:docs");
     expect(journeysJob).not.toContain("bun run test:interaction-perf");
-    expect(journeysJob).toContain("interaction-accessibility.spec.ts");
-    expect(journeysJob).toContain("docs-home-gallery.spec.ts");
-    expect(journeysJob).toContain("docs-progressive-search.spec.ts");
-    expect(journeysJob).toContain("docs-themes.spec.ts");
     expect(journeysJob).toContain("--grep-invert 'visual contract'");
     expect(journeysJob).toContain("--project journeys");
     expect(read("tests/visual/playwright.config.ts")).toContain('name: "journeys"');
     expect(read("tests/visual/playwright.config.ts")).toContain("timeout: 60_000");
+    expect(read("tests/visual/playwright.config.ts")).toContain("docs-shell");
+    expect(read("tests/visual/playwright.config.ts")).toContain("docs-home-gallery");
+    expect(read("tests/visual/playwright.config.ts")).toContain("docs-progressive-search");
+    expect(read("tests/visual/playwright.config.ts")).toContain("docs-themes");
+    expect(read("tests/visual/playwright.config.ts")).toContain("interaction-accessibility");
+    expect(read("tests/visual/playwright.config.ts")).toContain("playground");
     // ci-gate: package component = svelte+svelte-fx+spikes; docs_journeys is independent.
     expect(ci).toContain("COMPONENT_SVELTE_RES");
     expect(ci).toContain("COMPONENT_SVELTE_FX_RES");

--- a/tests/visual/docs-shell.spec.ts
+++ b/tests/visual/docs-shell.spec.ts
@@ -134,9 +134,8 @@ test("desktop docs shell exposes chapter, breadcrumb, contents, and sequence nav
 });
 
 test("mobile header and docs navigation are explicit, reachable controls", async ({ page }) => {
-  // Dialog open/close + viewport resize can exceed the default 30s budget under
-  // cold static-server load (repeated flake on CI journeys).
-  test.setTimeout(60_000);
+  // Lives in the journeys Playwright project (60s budget, #944). Prefer
+  // waitUntil/visibility waits over per-test setTimeout.
   await page.setViewportSize({ width: 375, height: 760 });
   await page.goto(GUIDE_ROUTE, { waitUntil: "domcontentloaded" });
 
@@ -208,10 +207,7 @@ test("appearance control remains usable when browser storage is unavailable", as
 });
 
 test("route metadata is canonical, singular, and aliases are noindex", async ({ page }) => {
-  // Search index is lazy-loaded on first open (#948). Pre-fix CI sat at ~30s with
-  // the index in every navigation; keep a modest raised budget until a few green
-  // journeys runs confirm the default 30s is safe again.
-  test.setTimeout(45_000);
+  // Search index is lazy-loaded (#948); journeys project budget is 60s (#944).
   await page.goto(GUIDE_ROUTE);
   await expect(page).toHaveTitle("Getting started — ggsvelte");
   await expect(page.locator('link[rel="canonical"]')).toHaveCount(1);

--- a/tests/visual/playwright.config.ts
+++ b/tests/visual/playwright.config.ts
@@ -50,6 +50,10 @@ const snapshotDir = process.env["VR_SNAPSHOT_DIR"] ?? "__screenshots__";
  */
 export const vrContextOptions: BrowserContextOptions = { reducedMotion: "reduce" };
 
+/** Specs that the component-journeys CI job runs (#944). */
+const JOURNEYS_SPECS =
+  /(?:docs-shell|docs-home-gallery|docs-progressive-search|docs-themes|interaction-accessibility|playground)\.spec\.ts$/;
+
 export default defineConfig({
   testDir: ".",
   outputDir: "./test-results",
@@ -79,7 +83,19 @@ export default defineConfig({
     trace: "retain-on-failure",
     screenshot: "only-on-failure",
   },
-  projects: [{ name: "chromium", use: { browserName: "chromium" } }],
+  projects: [
+    // VR / visual-contract seats keep Playwright's default 30s budget.
+    { name: "chromium", use: { browserName: "chromium" }, testIgnore: JOURNEYS_SPECS },
+    // Docs a11y/structure journeys: cold CI hydrate straddled 30s (~30.2s
+    // observed; mobile dialog + resize worse). 60s is the former per-test
+    // mitigation, applied at project scope so local runs match CI (#944).
+    {
+      name: "journeys",
+      use: { browserName: "chromium" },
+      testMatch: JOURNEYS_SPECS,
+      timeout: 60_000,
+    },
+  ],
   webServer: {
     command: "bun ../../scripts/serve-docs.ts",
     port: 4173,


### PR DESCRIPTION
## Summary
- Fixes [#944](https://github.com/ljodea/ggsvelte/issues/944): docs-shell journeys no longer rely on per-test \`test.setTimeout(60_000|45_000)\`.
- Adds a Playwright \`journeys\` project (\`timeout: 60_000\`) for the docs a11y/structure specs; VR \`chromium\` project keeps the default 30s budget.
- Journeys CI runs \`--project journeys\`. Local \`bun run test:visual -- docs-shell.spec.ts\` also hits the 60s project.

## Validation
- Issue evidence: route-metadata ~30.2s on CI (straddling 30s); mobile dialog+resize worse — same 60s budget previously applied per-test.
- HTTP serving is not the bottleneck (issue: curl 2–7ms); residual cost is client hydrate under CI load (#948 removed search-index from first load).
- \`bun test scripts/release-wiring.test.ts\` — 26 pass.

## Test plan
- [x] \`bun test scripts/release-wiring.test.ts\`
- [ ] CI \`component-journeys\` green
- [ ] Confirm docs-shell mobile + route-metadata no longer use per-test setTimeout

## Follow-ups
- [#946](https://github.com/ljodea/ggsvelte/issues/946): same mobile test; project budget covers the timeout removal — further root-cause timing for dialog/resize still useful.
- Deeper main-bundle hydrate cuts beyond #948 if journeys still sit near 60s.

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/960" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->