### PR TITLE
fix(core): humanize default axis and legend titles (#961)

### DIFF
--- a/.changeset/961-humanize-guide-titles.md
+++ b/.changeset/961-humanize-guide-titles.md
@@ -15,3 +15,9 @@ authored. Explicit `labs` values (including `""` to hide) are unchanged.
 
 Also exports `spaceFieldName` / `humanizeFieldTitle` from `@ggsvelte/core`;
 tooltip `<dt>` labels share the spacing helper.
+
+Migration: none — additive
+
+Default axis/legend titles for multi-word field names change from raw
+identifiers to sentence case (e.g. `bloomRefDate` → `Bloom ref date`). Set
+`labs` explicitly to keep a previous string.

--- a/.changeset/961-humanize-guide-titles.md
+++ b/.changeset/961-humanize-guide-titles.md
@@ -1,0 +1,17 @@
+---
+"@ggsvelte/core": minor
+"@ggsvelte/svelte": patch
+"@ggsvelte/spec": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+fix: humanize default axis and legend titles from field names (#961)
+
+When `labs` omits a channel, guide titles now use `humanizeFieldTitle` —
+camelCase/snake_case field names become sentence case (`bloomRefDate` →
+`Bloom ref date`). Single-token names (`year`, `Region`, `count`) stay as
+authored. Explicit `labs` values (including `""` to hide) are unchanged.
+
+Also exports `spaceFieldName` / `humanizeFieldTitle` from `@ggsvelte/core`;
+tooltip `<dt>` labels share the spacing helper.

--- a/apps/docs/src/lib/generated/routes.ts
+++ b/apps/docs/src/lib/generated/routes.ts
@@ -2292,8 +2292,8 @@ export const DOCS_ROUTES = [
         level: 2,
       },
       {
-        id: "experimental-282",
-        title: "experimental (282)",
+        id: "experimental-284",
+        title: "experimental (284)",
         level: 3,
       },
       {

--- a/apps/docs/src/lib/generated/search-index.ts
+++ b/apps/docs/src/lib/generated/search-index.ts
@@ -3852,14 +3852,14 @@ export const DOCS_SEARCH_INDEX = [
     exact: ["@ggsvelte/core"],
   },
   {
-    id: "heading:guide-lifecycle:experimental-282",
+    id: "heading:guide-lifecycle:experimental-284",
     kind: "heading",
-    title: "experimental (282)",
+    title: "experimental (284)",
     summary:
-      "experimental (282) in Lifecycle & editions. API stability tags per export, and the defaults-edition mechanism.",
-    href: "/guide/lifecycle#experimental-282",
+      "experimental (284) in Lifecycle & editions. API stability tags per export, and the defaults-edition mechanism.",
+    href: "/guide/lifecycle#experimental-284",
     keywords: ["Lifecycle & editions", "Reference"],
-    exact: ["experimental (282)"],
+    exact: ["experimental (284)"],
   },
   {
     id: "heading:guide-lifecycle:stable-intent-2",
@@ -14640,6 +14640,15 @@ export const DOCS_SEARCH_INDEX = [
     exact: ["getScaleTransform"],
   },
   {
+    id: "api:ggsvelte-core:humanizeFieldTitle",
+    kind: "api",
+    title: "humanizeFieldTitle",
+    summary: "@ggsvelte/core · value · experimental.",
+    href: "/guide/lifecycle#ggsvelte-core",
+    keywords: ["@ggsvelte/core", ".", "value", "experimental"],
+    exact: ["humanizeFieldTitle"],
+  },
+  {
     id: "api:ggsvelte-core:inferDiscreteness",
     kind: "api",
     title: "inferDiscreteness",
@@ -15043,6 +15052,15 @@ export const DOCS_SEARCH_INDEX = [
     href: "/guide/lifecycle#ggsvelte-core",
     keywords: ["@ggsvelte/core", ".", "value", "experimental"],
     exact: ["serializeScaleState"],
+  },
+  {
+    id: "api:ggsvelte-core:spaceFieldName",
+    kind: "api",
+    title: "spaceFieldName",
+    summary: "@ggsvelte/core · value · experimental.",
+    href: "/guide/lifecycle#ggsvelte-core",
+    keywords: ["@ggsvelte/core", ".", "value", "experimental"],
+    exact: ["spaceFieldName"],
   },
   {
     id: "api:ggsvelte-core:statCount",

--- a/lifecycle.json
+++ b/lifecycle.json
@@ -3359,6 +3359,10 @@
           "kind": "type",
           "lifecycle": "experimental"
         },
+        "DEFAULT_FONT_STACK": {
+          "kind": "value",
+          "lifecycle": "experimental"
+        },
         "DEFAULT_LAYOUT_THEME": {
           "kind": "value",
           "lifecycle": "experimental"
@@ -3549,6 +3553,10 @@
         },
         "MetricsTable": {
           "kind": "type",
+          "lifecycle": "experimental"
+        },
+        "MetricsTableMeasurer": {
+          "kind": "value",
           "lifecycle": "experimental"
         },
         "NamedData": {

--- a/lifecycle.json
+++ b/lifecycle.json
@@ -3359,10 +3359,6 @@
           "kind": "type",
           "lifecycle": "experimental"
         },
-        "DEFAULT_FONT_STACK": {
-          "kind": "value",
-          "lifecycle": "experimental"
-        },
         "DEFAULT_LAYOUT_THEME": {
           "kind": "value",
           "lifecycle": "experimental"
@@ -3553,10 +3549,6 @@
         },
         "MetricsTable": {
           "kind": "type",
-          "lifecycle": "experimental"
-        },
-        "MetricsTableMeasurer": {
-          "kind": "value",
           "lifecycle": "experimental"
         },
         "NamedData": {
@@ -4075,6 +4067,10 @@
           "kind": "value",
           "lifecycle": "experimental"
         },
+        "humanizeFieldTitle": {
+          "kind": "value",
+          "lifecycle": "experimental"
+        },
         "inferDiscreteness": {
           "kind": "value",
           "lifecycle": "experimental"
@@ -4252,6 +4248,10 @@
           "lifecycle": "experimental"
         },
         "serializeScaleState": {
+          "kind": "value",
+          "lifecycle": "experimental"
+        },
+        "spaceFieldName": {
           "kind": "value",
           "lifecycle": "experimental"
         },

--- a/packages/core/src/humanize-field.ts
+++ b/packages/core/src/humanize-field.ts
@@ -1,0 +1,38 @@
+/**
+ * Field-name → readable guide label helpers (#961).
+ *
+ * Axis and legend titles fall through to the mapped field when `labs` omits
+ * that channel. Raw camelCase reads as an implementation leftover; these
+ * helpers space identifiers without inventing domain semantics.
+ */
+
+/**
+ * Split camelCase / snake_case identifiers into spaced words.
+ * Empty input stays empty. Leading/trailing underscores are trimmed away
+ * with the spaces they become. Already-spaced input is collapsed to single
+ * spaces. Single tokens (including all-lowercase and Title Case) are unchanged
+ * aside from underscore/spacing cleanup.
+ */
+export function spaceFieldName(fieldName: string): string {
+  if (fieldName.length === 0) return fieldName;
+  return fieldName
+    .replaceAll("_", " ")
+    .replaceAll(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replaceAll(/([A-Z]+)([A-Z][a-z])/g, "$1 $2")
+    .replaceAll(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * Default axis/legend title from a mapped field name.
+ *
+ * Multi-word identifiers become sentence case (`bloomRefDate` → `Bloom ref date`).
+ * Single tokens stay as authored (`Region`, `year`, `count`, `stackpos`) so
+ * short ggplot-style names and stat columns are not rewritten.
+ */
+export function humanizeFieldTitle(fieldName: string): string {
+  const spaced = spaceFieldName(fieldName);
+  if (spaced.length === 0 || !/\s/.test(spaced)) return spaced;
+  const lower = spaced.toLowerCase();
+  return lower.charAt(0).toUpperCase() + lower.slice(1);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -161,6 +161,7 @@ export type {
 
 // Layout (decision 0003)
 export { humanizeFieldTitle, spaceFieldName } from "./humanize-field.js";
+export { DEFAULT_FONT_STACK, MetricsTableMeasurer } from "./layout/measure.js";
 export type { MetricsTable, TextMeasurer } from "./layout/measure.js";
 export { FONT_METRICS } from "./layout/font-metrics.js";
 export {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -160,7 +160,7 @@ export type {
 } from "./diagnostics.js";
 
 // Layout (decision 0003)
-export { DEFAULT_FONT_STACK, MetricsTableMeasurer } from "./layout/measure.js";
+export { humanizeFieldTitle, spaceFieldName } from "./humanize-field.js";
 export type { MetricsTable, TextMeasurer } from "./layout/measure.js";
 export { FONT_METRICS } from "./layout/font-metrics.js";
 export {

--- a/packages/core/src/pipeline/panel-layout-chrome-labs.ts
+++ b/packages/core/src/pipeline/panel-layout-chrome-labs.ts
@@ -3,6 +3,7 @@
  */
 import type { PortableSpec } from "@ggsvelte/spec";
 
+import { humanizeFieldTitle } from "../humanize-field.js";
 import type { ThemeTokens } from "../theme.js";
 
 import { AXIS_TITLE_BAND, CAPTION_BAND, SUBTITLE_BAND, TITLE_BAND } from "./layout-helpers.js";
@@ -31,12 +32,13 @@ export function resolvePanelLayoutLabs(input: {
   const title = labs.title ?? "";
   const subtitle = labs.subtitle ?? "";
   const caption = labs.caption ?? "";
-  const xTitle = labs.x ?? allFrames.find((f) => f.binding.xField !== null)?.binding.xField ?? "";
-  const yTitle =
-    labs.y ??
+  const xField = allFrames.find((f) => f.binding.xField !== null)?.binding.xField ?? "";
+  const yField =
     allFrames.find((f) => f.binding.yField !== null)?.binding.yField ??
     allFrames.find((f) => f.binding.yStatColumn !== null)?.binding.yStatColumn ??
     "";
+  const xTitle = labs.x ?? humanizeFieldTitle(xField);
+  const yTitle = labs.y ?? humanizeFieldTitle(yField);
   const titleBand = Math.max(TITLE_BAND, theme.titleSize + 7);
   const subtitleBand = Math.max(SUBTITLE_BAND, theme.subtitleSize + 4);
   const captionBand = Math.max(CAPTION_BAND, theme.captionSize + 5);

--- a/packages/core/src/pipeline/train-pipeline-scales-color.ts
+++ b/packages/core/src/pipeline/train-pipeline-scales-color.ts
@@ -4,6 +4,7 @@
 import type { PortableSpec } from "@ggsvelte/spec";
 
 import type { EditionDefaults } from "../editions.js";
+import { humanizeFieldTitle } from "../humanize-field.js";
 import type { ColumnTable } from "../table.js";
 
 import { resolveColorScale } from "./scale-training.js";
@@ -54,7 +55,7 @@ export function trainPipelineColorScales(input: {
     sourceTable,
     scalesConfig.color,
     options.prevScales?.["color"] ?? null,
-    labs.color ?? firstColorField ?? "",
+    labs.color ?? humanizeFieldTitle(firstColorField ?? ""),
     warnings,
     advisories,
     editionDefaults,
@@ -67,7 +68,7 @@ export function trainPipelineColorScales(input: {
     sourceTable,
     scalesConfig.fill,
     options.prevScales?.["fill"] ?? null,
-    labs.fill ?? firstFillField ?? "",
+    labs.fill ?? humanizeFieldTitle(firstFillField ?? ""),
     warnings,
     advisories,
     editionDefaults,

--- a/packages/core/src/pipeline/train-pipeline-scales-style.ts
+++ b/packages/core/src/pipeline/train-pipeline-scales-style.ts
@@ -1,6 +1,7 @@
 /** Resolve all mapped non-color style scales for one pipeline run. */
 import type { PortableSpec, StyleAesthetic } from "@ggsvelte/spec";
 
+import { humanizeFieldTitle } from "../humanize-field.js";
 import type { ColumnTable } from "../table.js";
 
 import { resolveStyleScale } from "./scale-style.js";
@@ -35,7 +36,7 @@ export function trainPipelineStyleScales(input: {
       sourceTable,
       config: scalesConfig[aesthetic],
       prevState: options.prevScales?.[aesthetic] ?? null,
-      title: labs[aesthetic] ?? firstField,
+      title: labs[aesthetic] ?? humanizeFieldTitle(firstField),
       warnings,
     });
   }

--- a/packages/core/tests/humanize-field.test.ts
+++ b/packages/core/tests/humanize-field.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "bun:test";
+
+import { humanizeFieldTitle, spaceFieldName } from "../src/humanize-field.js";
+
+describe("spaceFieldName", () => {
+  it("returns empty string unchanged", () => {
+    expect(spaceFieldName("")).toBe("");
+  });
+
+  it("leaves single tokens alone", () => {
+    expect(spaceFieldName("year")).toBe("year");
+    expect(spaceFieldName("Region")).toBe("Region");
+    expect(spaceFieldName("count")).toBe("count");
+    expect(spaceFieldName("stackpos")).toBe("stackpos");
+  });
+
+  it("splits camelCase, snake_case, and acronym runs", () => {
+    expect(spaceFieldName("bloomRefDate")).toBe("bloom Ref Date");
+    expect(spaceFieldName("flipper_length")).toBe("flipper length");
+    expect(spaceFieldName("bloomDOYAdj")).toBe("bloom DOY Adj");
+  });
+
+  it("trims underscore edges and collapses already-spaced input", () => {
+    expect(spaceFieldName("_leading")).toBe("leading");
+    expect(spaceFieldName("trailing_")).toBe("trailing");
+    expect(spaceFieldName("__both__")).toBe("both");
+    expect(spaceFieldName("already  spaced")).toBe("already spaced");
+  });
+});
+
+describe("humanizeFieldTitle (#961)", () => {
+  it("sentence-cases multi-word identifiers for axis/legend titles", () => {
+    expect(humanizeFieldTitle("bloomRefDate")).toBe("Bloom ref date");
+    expect(humanizeFieldTitle("flipper_length")).toBe("Flipper length");
+    expect(humanizeFieldTitle("bloomDOYAdj")).toBe("Bloom doy adj");
+  });
+
+  it("preserves single tokens including stat columns", () => {
+    expect(humanizeFieldTitle("Region")).toBe("Region");
+    expect(humanizeFieldTitle("year")).toBe("year");
+    expect(humanizeFieldTitle("count")).toBe("count");
+    expect(humanizeFieldTitle("density")).toBe("density");
+    expect(humanizeFieldTitle("stackpos")).toBe("stackpos");
+    expect(humanizeFieldTitle("ecdf")).toBe("ecdf");
+  });
+
+  it("returns empty string unchanged", () => {
+    expect(humanizeFieldTitle("")).toBe("");
+  });
+});

--- a/packages/core/tests/pipeline-panel-layout.test.ts
+++ b/packages/core/tests/pipeline-panel-layout.test.ts
@@ -143,4 +143,40 @@ describe("panel layout via runPipeline", () => {
     expect(model.scene.axes.y.title).toBe("Miles");
     expect(model.scene.axes.x.title).toBe("Gallons");
   });
+
+  it("humanizes default axis and legend titles from camelCase fields (#961)", () => {
+    const model = runPipeline(
+      gg(
+        [
+          { bloomYear: 1850, bloomRefDate: 100, regionName: "A" },
+          { bloomYear: 1900, bloomRefDate: 110, regionName: "B" },
+        ],
+        aes({ x: "bloomYear", y: "bloomRefDate", color: "regionName" }),
+      )
+        .geomPoint()
+        .spec(),
+      size,
+    );
+    expect(model.scene.axes.x.title).toBe("Bloom year");
+    expect(model.scene.axes.y.title).toBe("Bloom ref date");
+    expect(model.scene.legends[0]?.title).toBe("Region name");
+  });
+
+  it("keeps explicit labs including empty string to hide axis titles (#961)", () => {
+    const model = runPipeline(
+      gg(
+        [
+          { bloomYear: 1850, bloomRefDate: 100 },
+          { bloomYear: 1900, bloomRefDate: 110 },
+        ],
+        aes({ x: "bloomYear", y: "bloomRefDate" }),
+      )
+        .geomPoint()
+        .labs({ x: "", y: "Peak bloom" })
+        .spec(),
+      size,
+    );
+    expect(model.scene.axes.x.title).toBe("");
+    expect(model.scene.axes.y.title).toBe("Peak bloom");
+  });
 });

--- a/packages/spec/schema/v0.json
+++ b/packages/spec/schema/v0.json
@@ -7605,39 +7605,39 @@
         },
         "x": {
           "type": "string",
-          "description": "X axis title. Defaults to the mapped field name."
+          "description": "X axis title. Defaults to a humanized form of the mapped field name (sentence case)."
         },
         "y": {
           "type": "string",
-          "description": "Y axis title. Defaults to the mapped field name."
+          "description": "Y axis title. Defaults to a humanized form of the mapped field name (sentence case)."
         },
         "color": {
           "type": "string",
-          "description": "Color legend title. Defaults to the mapped field name."
+          "description": "Color legend title. Defaults to a humanized form of the mapped field name (sentence case)."
         },
         "fill": {
           "type": "string",
-          "description": "Fill legend title. Defaults to the mapped field name."
+          "description": "Fill legend title. Defaults to a humanized form of the mapped field name (sentence case)."
         },
         "size": {
           "type": "string",
-          "description": "Size legend title. Defaults to the mapped field name."
+          "description": "Size legend title. Defaults to a humanized form of the mapped field name (sentence case)."
         },
         "linewidth": {
           "type": "string",
-          "description": "Linewidth legend title. Defaults to the mapped field name."
+          "description": "Linewidth legend title. Defaults to a humanized form of the mapped field name (sentence case)."
         },
         "alpha": {
           "type": "string",
-          "description": "Alpha legend title. Defaults to the mapped field name."
+          "description": "Alpha legend title. Defaults to a humanized form of the mapped field name (sentence case)."
         },
         "shape": {
           "type": "string",
-          "description": "Shape legend title. Defaults to the mapped field name."
+          "description": "Shape legend title. Defaults to a humanized form of the mapped field name (sentence case)."
         },
         "linetype": {
           "type": "string",
-          "description": "Linetype legend title. Defaults to the mapped field name."
+          "description": "Linetype legend title. Defaults to a humanized form of the mapped field name (sentence case)."
         }
       },
       "additionalProperties": false,

--- a/packages/spec/src/schema-declarations.ts
+++ b/packages/spec/src/schema-declarations.ts
@@ -4815,31 +4815,58 @@ export const SpecDeclarations = {
       subtitle: Type.Optional(Type.String({ description: "Plot subtitle, under the title." })),
       caption: Type.Optional(Type.String({ description: "Small caption under the plot." })),
       x: Type.Optional(
-        Type.String({ description: "X axis title. Defaults to the mapped field name." }),
+        Type.String({
+          description:
+            "X axis title. Defaults to a humanized form of the mapped field name (sentence case).",
+        }),
       ),
       y: Type.Optional(
-        Type.String({ description: "Y axis title. Defaults to the mapped field name." }),
+        Type.String({
+          description:
+            "Y axis title. Defaults to a humanized form of the mapped field name (sentence case).",
+        }),
       ),
       color: Type.Optional(
-        Type.String({ description: "Color legend title. Defaults to the mapped field name." }),
+        Type.String({
+          description:
+            "Color legend title. Defaults to a humanized form of the mapped field name (sentence case).",
+        }),
       ),
       fill: Type.Optional(
-        Type.String({ description: "Fill legend title. Defaults to the mapped field name." }),
+        Type.String({
+          description:
+            "Fill legend title. Defaults to a humanized form of the mapped field name (sentence case).",
+        }),
       ),
       size: Type.Optional(
-        Type.String({ description: "Size legend title. Defaults to the mapped field name." }),
+        Type.String({
+          description:
+            "Size legend title. Defaults to a humanized form of the mapped field name (sentence case).",
+        }),
       ),
       linewidth: Type.Optional(
-        Type.String({ description: "Linewidth legend title. Defaults to the mapped field name." }),
+        Type.String({
+          description:
+            "Linewidth legend title. Defaults to a humanized form of the mapped field name (sentence case).",
+        }),
       ),
       alpha: Type.Optional(
-        Type.String({ description: "Alpha legend title. Defaults to the mapped field name." }),
+        Type.String({
+          description:
+            "Alpha legend title. Defaults to a humanized form of the mapped field name (sentence case).",
+        }),
       ),
       shape: Type.Optional(
-        Type.String({ description: "Shape legend title. Defaults to the mapped field name." }),
+        Type.String({
+          description:
+            "Shape legend title. Defaults to a humanized form of the mapped field name (sentence case).",
+        }),
       ),
       linetype: Type.Optional(
-        Type.String({ description: "Linetype legend title. Defaults to the mapped field name." }),
+        Type.String({
+          description:
+            "Linetype legend title. Defaults to a humanized form of the mapped field name (sentence case).",
+        }),
       ),
     },
     {

--- a/packages/svelte/src/lib/inspection/display-members.ts
+++ b/packages/svelte/src/lib/inspection/display-members.ts
@@ -6,7 +6,7 @@
  * that render the default field rows should collapse identical *display*
  * payloads so users never see the same period/value block twice.
  */
-import type { CellValue } from "@ggsvelte/core";
+import { spaceFieldName, type CellValue } from "@ggsvelte/core";
 
 import type { NonEmptyReadonlyArray, PlotDatum, TooltipField } from "../interaction/interaction.js";
 
@@ -62,10 +62,12 @@ function isTooltipLabChannel(channel: string): channel is TooltipLabChannel {
  *
  * Preference order:
  * 1. Explicit lab for the field's channel (x/y/color/…), when non-empty
- * 2. Light humanization of the column name (camelCase / snake_case → words)
+ * 2. Light humanization of the column name via shared `spaceFieldName`
+ *    (camelCase / snake_case → words; multi-word → lowercase for scanability)
  * 3. Raw field name as last resort (empty input)
  *
  * Does not invent domain semantics ("crimePersons" stays "crime persons").
+ * Axis/legend titles use `humanizeFieldTitle` (sentence case) instead (#961).
  */
 export function tooltipFieldLabel(
   fieldName: string,
@@ -87,10 +89,7 @@ export function tooltipFieldLabel(
   }
 
   if (fieldName.length === 0) return fieldName;
-  const spaced = fieldName
-    .replaceAll("_", " ")
-    .replaceAll(/([a-z0-9])([A-Z])/g, "$1 $2")
-    .replaceAll(/([A-Z]+)([A-Z][a-z])/g, "$1 $2");
+  const spaced = spaceFieldName(fieldName);
   // Preserve intentional Title Case single tokens (e.g. "Region"); only fold
   // multi-word camelCase into lowercase words for scanability.
   if (!/\s/.test(spaced)) return spaced;

--- a/packages/svelte/tests/release-matrix.test.ts
+++ b/packages/svelte/tests/release-matrix.test.ts
@@ -260,8 +260,8 @@ describe("R-1/R0 release matrix", () => {
     expect(
       legends.map((legend) => [legend.title, legend.entries.map((entry) => entry.value)]),
     ).toEqual([
-      ["colorGroup", ["A", "B"]],
-      ["fillGroup", ["X", "Y"]],
+      ["Color group", ["A", "B"]],
+      ["Fill group", ["X", "Y"]],
     ]);
     const seed = model.candidates.candidate(0)!;
     const inspection = resolveInspection({


### PR DESCRIPTION
## Summary
- Fixes #961: when `labs` omits a channel, axis and legend titles no longer show raw camelCase field names (`bloomRefDate`).
- New `@ggsvelte/core` helpers `spaceFieldName` / `humanizeFieldTitle` (sentence case for multi-word; single tokens unchanged). Wired into panel axis titles and color/fill/style legend title fallbacks.
- Tooltip `<dt>` labels share `spaceFieldName` (still lowercase multi-word for scanability). Explicit `labs` including `""` to hide are unchanged.

## Validation
- Root cause: `resolvePanelLayoutLabs` and color/style scale trainers fell through to raw field strings.
- Plan review: also humanize legend titles (not only axes); sentence case for titles vs tooltip casing; core owns humanizer contract tests.

## Test plan
- [x] `bun test packages/core/tests/humanize-field.test.ts packages/core/tests/pipeline-panel-layout.test.ts`
- [x] `bun test packages/core` (1677 pass)
- [x] `vitest run tests/inspection/display-members.test.ts --project chromium` (20 pass)
- [ ] CI + vr-gate (update smoke baselines same-PR if titles appear on seats)

## Follow-ups
- #962 — mixed temporal tick formats on inferred date axes


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/964" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->