### PR TITLE
fix(test): run mobile docs-shell journey on a light guide page (#946)

### DIFF
--- a/tests/visual/docs-shell.spec.ts
+++ b/tests/visual/docs-shell.spec.ts
@@ -134,10 +134,14 @@ test("desktop docs shell exposes chapter, breadcrumb, contents, and sequence nav
 });
 
 test("mobile header and docs navigation are explicit, reachable controls", async ({ page }) => {
-  // Lives in the journeys Playwright project (60s budget, #944). Prefer
-  // waitUntil/visibility waits over per-test setTimeout.
+  // Avoid /guide/getting-started here: its lesson chart islands block the main
+  // thread for ~17s before "Open site menu" is tappable (local workers=1), so
+  // dialog + resize straddled the old 30s budget (#946). Shell chrome is shared
+  // across guide pages (DocsShell); /guide/errors exercises the same menus
+  // without that hydrate cost. Journeys project budget stays 60s (#944) because
+  // other journeys still cold-load getting-started — see #972.
   await page.setViewportSize({ width: 375, height: 760 });
-  await page.goto(GUIDE_ROUTE, { waitUntil: "domcontentloaded" });
+  await page.goto("/guide/errors", { waitUntil: "domcontentloaded" });
 
   const siteMenu = page.getByRole("button", { name: "Open site menu" });
   await expect(siteMenu).toBeVisible({ timeout: 15_000 });

--- a/tests/visual/playwright.config.ts
+++ b/tests/visual/playwright.config.ts
@@ -87,8 +87,8 @@ export default defineConfig({
     // VR / visual-contract seats keep Playwright's default 30s budget.
     { name: "chromium", use: { browserName: "chromium" }, testIgnore: JOURNEYS_SPECS },
     // Docs a11y/structure journeys: cold CI hydrate straddled 30s (~30.2s
-    // observed; mobile dialog + resize worse). 60s is the former per-test
-    // mitigation, applied at project scope so local runs match CI (#944).
+    // observed). 60s remains project scope (#944) while getting-started chart
+    // islands still dominate several journeys (#946 follow-up).
     {
       name: "journeys",
       use: { browserName: "chromium" },


### PR DESCRIPTION
## Summary
- **Root cause (#946):** the mobile shell a11y journey targeted `/guide/getting-started`, whose lesson chart islands monopolize the main thread (~17s locally before \"Open site menu\" is tappable). Dialog/focus-trap were not the bottleneck.
- Point that journey at `/guide/errors` (same `DocsShell` chrome) — full journey ~5s locally.
- Keep journeys Playwright project at 60s; other journeys still cold-load getting-started.
- Follow-up: #972 (real getting-started hydrate cost).

## Test plan
- [x] `playwright … docs-shell.spec.ts -g 'mobile header' --project journeys` (~5.8s)
- [ ] CI `component-journeys` / `ci-gate` green

Closes #946


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/973" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->