### PR TITLE
fix(docs): defer getting-started live chart so mobile chrome stays tappable (#972)

### DIFF
--- a/apps/docs/src/lib/components/GettingStartedGuide.svelte
+++ b/apps/docs/src/lib/components/GettingStartedGuide.svelte
@@ -8,9 +8,8 @@
    * from what the reader copies.
    */
   import { base } from "$app/paths";
-  import { GGPlot } from "@ggsvelte/svelte";
   import { kyotoSakura } from "@ggsvelte/svelte/data";
-  import { onMount } from "svelte";
+  import { onMount, type Component } from "svelte";
 
   import {
     foldSakura,
@@ -38,26 +37,41 @@
    */
   const NARROW_CHART = 560;
 
-  let narrowChart = $state(false);
+  /**
+   * Assume narrow until the finished-chart container is measured. Starting at
+   * `false` forced a wide fold on first paint, then a second 838-point fold
+   * when ResizeObserver fired — on mobile that double work blocked chrome for
+   * ~17s before "Open site menu" was tappable (#972). Desktop still flips once
+   * (narrow → wide) when the container is actually wide enough for callouts.
+   */
+  let narrowChart = $state(true);
   let finishedChart = $state<HTMLElement>();
+  /** Live plot component — dynamically imported after first paint (#972). */
+  let LivePlot = $state<Component<{
+    spec: ReturnType<typeof foldSakura>["spec"];
+    key?: string;
+    inspect?: ReturnType<typeof foldSakura>["inspect"];
+    ariaLabel?: string;
+  }> | null>(null);
 
   /**
-   * The finished chart is the page's only live plot, so it is the one the
-   * annotation ladder applies to: below NARROW_CHART the record callouts
-   * would collide with the data.
+   * Fold only when the live plot is mounted. Computing the 838-point spec
+   * during first hydrate (even behind a placeholder) blocked mobile chrome
+   * for ~20s (#972).
    */
   const finished = $derived(
-    foldSakura(SAKURA_STEPS.length, rows, { annotations: !narrowChart }),
+    LivePlot === null
+      ? null
+      : foldSakura(SAKURA_STEPS.length, rows, { annotations: !narrowChart }),
   );
 
   const recordNames = SAKURA_RECORDS.map((record) => record.label).join("; ");
 
   /**
    * Every step chart ships as SVG the library rendered at build time
-   * (scripts/gen-lesson-charts.ts): each one illustrates a single delta, and a
-   * live 838-point plot costs about three seconds of hydration. The finished
-   * chart below the steps is the live one, which is where inspection is worth
-   * demonstrating.
+   * (scripts/gen-lesson-charts.ts): each one illustrates a single delta. The
+   * finished chart is the live 838-point plot — loaded when near the viewport
+   * so mobile chrome stays tappable (#972).
    */
   const chartSrc = (step: number): string =>
     `${base}/lesson/${step < 0 ? "first-render.svg" : `step-${String(step + 1)}.svg`}`;
@@ -65,14 +79,43 @@
   onMount(() => {
     const target = finishedChart;
     if (target === undefined) return;
-    if (typeof ResizeObserver === "undefined") return;
-    const observer = new ResizeObserver((entries) => {
-      const width = entries[0]?.contentRect.width;
-      if (width !== undefined) narrowChart = width < NARROW_CHART;
-    });
-    observer.observe(target);
+    let cancelled = false;
+    let loadStarted = false;
+
+    const observer =
+      typeof ResizeObserver === "undefined"
+        ? undefined
+        : new ResizeObserver((entries) => {
+            const width = entries[0]?.contentRect.width;
+            if (width !== undefined) narrowChart = width < NARROW_CHART;
+          });
+    observer?.observe(target);
+
+    const loadLivePlot = (): void => {
+      if (loadStarted || cancelled) return;
+      loadStarted = true;
+      void import("@ggsvelte/svelte").then((mod) => {
+        if (!cancelled) LivePlot = mod.GGPlot;
+      });
+    };
+
+    // Near-viewport only — do not idle-load. An early dynamic import + fold
+    // still monopolizes the main thread and stalls header clicks (#972).
+    const io = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          loadLivePlot();
+          io.disconnect();
+        }
+      },
+      { rootMargin: "240px 0px" },
+    );
+    io.observe(target);
+
     return () => {
-      observer.disconnect();
+      cancelled = true;
+      observer?.disconnect();
+      io.disconnect();
     };
   });
 </script>
@@ -154,12 +197,22 @@
 
   <h2 id="the-chart">The chart</h2>
   <div class="finished-chart lesson-output" bind:this={finishedChart}>
-    <GGPlot
-      spec={finished.spec}
-      key={finished.key}
-      inspect={finished.inspect}
-      ariaLabel={`Kyoto cherry blossom, finished. Called out: ${recordNames}.`}
-    />
+    {#if LivePlot && finished}
+      <LivePlot
+        spec={finished.spec}
+        key={finished.key}
+        inspect={finished.inspect}
+        ariaLabel={`Kyoto cherry blossom, finished. Called out: ${recordNames}.`}
+      />
+    {:else}
+      <img
+        class="lesson-chart"
+        src={chartSrc(SAKURA_STEPS.length - 1)}
+        width={LESSON_CHART_WIDTH}
+        height={LESSON_CHART_HEIGHT}
+        alt={`Kyoto cherry blossom, finished. Called out: ${recordNames}.`}
+      />
+    {/if}
   </div>
 
   <h2 id="the-finished-file">The finished file</h2>

--- a/apps/docs/src/lib/components/GettingStartedGuide.svelte
+++ b/apps/docs/src/lib/components/GettingStartedGuide.svelte
@@ -9,7 +9,7 @@
    */
   import { base } from "$app/paths";
   import { kyotoSakura } from "@ggsvelte/svelte/data";
-  import { onMount, type Component } from "svelte";
+  import { onMount } from "svelte";
 
   import {
     foldSakura,
@@ -46,13 +46,10 @@
    */
   let narrowChart = $state(true);
   let finishedChart = $state<HTMLElement>();
-  /** Live plot component — dynamically imported after first paint (#972). */
-  let LivePlot = $state<Component<{
-    spec: ReturnType<typeof foldSakura>["spec"];
-    key?: string;
-    inspect?: ReturnType<typeof foldSakura>["inspect"];
-    ariaLabel?: string;
-  }> | null>(null);
+  /** Live plot component — dynamically imported when near the viewport (#972). */
+  let LivePlot = $state<null | (typeof import("@ggsvelte/svelte"))["GGPlot"]>(
+    null,
+  );
 
   /**
    * Fold only when the live plot is mounted. Computing the 838-point spec

--- a/tests/visual/docs-progressive-search.spec.ts
+++ b/tests/visual/docs-progressive-search.spec.ts
@@ -39,18 +39,23 @@ test("each step shows its own delta and the finished chart is live", async ({ pa
 
   // Every step chart is a build-time render; the page carries exactly one
   // live plot, the finished chart, where inspection is worth demonstrating.
+  // Live GGPlot hydrates only when near the viewport (#972); fold is slow.
   await expect(steps.locator("img.lesson-chart")).toHaveCount(6);
   await expect(steps.locator(".gg-plot-root")).toHaveCount(0);
-  const finished = page.locator(".finished-chart .gg-plot-root");
-  await expect(finished).toHaveAttribute("data-gg-ready", "true");
+  const finishedChart = page.locator(".finished-chart");
+  await finishedChart.scrollIntoViewIfNeeded();
+  const finished = finishedChart.locator(".gg-plot-root");
+  await expect(finished).toHaveAttribute("data-gg-ready", "true", { timeout: 45_000 });
   await expect(page.locator(".gg-plot-root")).toHaveCount(1);
   await expectNoDocumentOverflow(page);
 });
 
 test("the finished chart answers keyboard inspection", async ({ page }) => {
   await page.goto("/guide/getting-started?theme=light");
-  const capture = page.locator(".finished-chart .gg-capture");
-  await expect(capture).toBeVisible();
+  const finishedChart = page.locator(".finished-chart");
+  await finishedChart.scrollIntoViewIfNeeded();
+  const capture = finishedChart.locator(".gg-capture");
+  await expect(capture).toBeVisible({ timeout: 45_000 });
   await capture.focus();
   await capture.press("ArrowRight");
   await expect(page.locator(".finished-chart .gg-tooltip")).toBeVisible();
@@ -71,7 +76,10 @@ test("the finished chart drops its band fills and names the epochs in forced col
   await page.emulateMedia({ forcedColors: "active", reducedMotion: "reduce" });
   await page.goto("/guide/getting-started?theme=light");
   const finished = page.locator(".finished-chart");
-  await expect(finished.locator(".gg-plot-root")).toHaveAttribute("data-gg-ready", "true");
+  await finished.scrollIntoViewIfNeeded();
+  await expect(finished.locator(".gg-plot-root")).toHaveAttribute("data-gg-ready", "true", {
+    timeout: 45_000,
+  });
   expect(await page.evaluate(() => matchMedia("(forced-colors: active)").matches)).toBe(true);
 
   const fills = await finished

--- a/tests/visual/docs-progressive-search.spec.ts
+++ b/tests/visual/docs-progressive-search.spec.ts
@@ -159,9 +159,10 @@ test("prerendered Docs and lesson source remain useful without JavaScript", asyn
     'import { kyotoSakura } from "@ggsvelte/svelte/data"',
   );
   // Every step chart is a build-time render, so the whole lesson is readable
-  // with no JavaScript at all — only the inspect step loses its interaction.
+  // with no JavaScript at all — the finished chart stays a static SVG until
+  // hydrate near-viewport (#972); only inspect interaction needs JS.
   await expect(page.locator(".lesson-block .lesson-output")).toBeVisible();
-  await expect(page.locator("img.lesson-chart")).toHaveCount(7);
+  await expect(page.locator("img.lesson-chart")).toHaveCount(8);
   await expect(
     page.getByRole("heading", { level: 3, name: "Separate the signal from the noise" }),
   ).toBeVisible();

--- a/tests/visual/docs-shell.spec.ts
+++ b/tests/visual/docs-shell.spec.ts
@@ -134,14 +134,10 @@ test("desktop docs shell exposes chapter, breadcrumb, contents, and sequence nav
 });
 
 test("mobile header and docs navigation are explicit, reachable controls", async ({ page }) => {
-  // Avoid /guide/getting-started here: its lesson chart islands block the main
-  // thread for ~17s before "Open site menu" is tappable (local workers=1), so
-  // dialog + resize straddled the old 30s budget (#946). Shell chrome is shared
-  // across guide pages (DocsShell); /guide/errors exercises the same menus
-  // without that hydrate cost. Journeys project budget stays 60s (#944) because
-  // other journeys still cold-load getting-started — see #972.
+  // getting-started deferred its live GGPlot (#972) so mobile chrome is tappable
+  // in ~1s locally; this journey can stay on the primary guide again.
   await page.setViewportSize({ width: 375, height: 760 });
-  await page.goto("/guide/errors", { waitUntil: "domcontentloaded" });
+  await page.goto(GUIDE_ROUTE, { waitUntil: "domcontentloaded" });
 
   const siteMenu = page.getByRole("button", { name: "Open site menu" });
   await expect(siteMenu).toBeVisible({ timeout: 15_000 });
@@ -166,6 +162,23 @@ test("mobile header and docs navigation are explicit, reachable controls", async
   await expect(chapterDialog).toBeVisible();
   await chapterDialog.getByRole("button", { name: "Close docs navigation" }).click();
   await expectNoHorizontalOverflow(page);
+});
+
+test("getting-started mobile chrome is tappable before the live chart hydrates", async ({
+  page,
+}) => {
+  // Budget guard for #972: cold mobile must not wait on the 838-point GGPlot.
+  test.setTimeout(30_000);
+  const started = Date.now();
+  await page.setViewportSize({ width: 375, height: 760 });
+  await page.goto(GUIDE_ROUTE, { waitUntil: "domcontentloaded" });
+  await expect(page.getByRole("button", { name: "Open site menu" })).toBeVisible({
+    timeout: 10_000,
+  });
+  expect(
+    Date.now() - started,
+    "Open site menu should be tappable well under the old ~17s hydrate stall",
+  ).toBeLessThan(8_000);
 });
 
 test("code tabs implement automatic arrow, Home, and End activation with roving tabindex", async ({

--- a/tests/visual/playwright.config.ts
+++ b/tests/visual/playwright.config.ts
@@ -87,8 +87,8 @@ export default defineConfig({
     // VR / visual-contract seats keep Playwright's default 30s budget.
     { name: "chromium", use: { browserName: "chromium" }, testIgnore: JOURNEYS_SPECS },
     // Docs a11y/structure journeys: cold CI hydrate straddled 30s (~30.2s
-    // observed). 60s remains project scope (#944) while getting-started chart
-    // islands still dominate several journeys (#946 follow-up).
+    // observed). 60s remains project scope (#944); getting-started defers its
+    // live chart until near-viewport (#972) so shell chrome stays interactive.
     {
       name: "journeys",
       use: { browserName: "chromium" },


### PR DESCRIPTION
## Summary
- Default the finished chart to a narrow fold and **defer `foldSakura` + dynamic `GGPlot` import** until the finished chart is near the viewport, so cold mobile `/guide/getting-started` no longer blocks header chrome for ~17–22s.
- Restore the mobile docs-shell journey to getting-started and add a budget guard (`Open site menu` &lt; 8s).
- Progressive-search journeys scroll the finished chart into view and allow up to 45s for the live plot to become ready.

Closes #972

## Test plan
- [x] `docs-shell` journeys: mobile header + budget guard (menu ~0.4–1.4s locally)
- [x] `docs-progressive-search` finished-chart journeys (scroll + ready)
- [ ] CI component-journeys / docs checks on this PR


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/974" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->