### PR TITLE
perf: O(n²)→O(n log n) large-n quantile bisection bracket

### DIFF
--- a/packages/core/src/stats/quantile.ts
+++ b/packages/core/src/stats/quantile.ts
@@ -7,7 +7,8 @@
  * Fit: for fixed slope b, optimal intercept is the pinball-minimizing
  * order statistic of residuals y − b·x (⌈τ n⌉-th). Optimal slope chosen
  * among pairwise slopes (LP vertex property) for n ≤ PAIRWISE_CAP;
- * otherwise derivative-bisection on the profiled pinball loss.
+ * otherwise derivative-bisection on the profiled pinball loss without
+ * pairwise enumeration (default bracket + expand until subgradient signs differ).
  */
 
 import type { CellValue } from "../table.js";
@@ -138,22 +139,8 @@ function fitByBisection(
   rows: readonly number[],
   tau: number,
 ): QuantileFit {
-  // Bracket from data pairwise extremes + OLS-ish range.
   let lo = -1;
   let hi = 1;
-  const slopes = pairwiseSlopes(x, y, rows);
-  if (slopes.length > 1) {
-    let minS = slopes[0]!;
-    let maxS = slopes[0]!;
-    for (const s of slopes) {
-      if (s < minS) minS = s;
-      if (s > maxS) maxS = s;
-    }
-    const pad = Math.max(1, (maxS - minS) * 0.5, Math.abs(minS), Math.abs(maxS));
-    lo = minS - pad;
-    hi = maxS + pad;
-  }
-  // Expand until subgradient signs differ (or cap).
   for (let expand = 0; expand < 20; expand++) {
     const sLo = slopeSubgradientSign(x, y, rows, lo, tau);
     const sHi = slopeSubgradientSign(x, y, rows, hi, tau);

--- a/packages/core/tests/stats-quantile.test.ts
+++ b/packages/core/tests/stats-quantile.test.ts
@@ -85,6 +85,51 @@ describe("fitLinearQuantileRegression", () => {
     expect(shifted.slope).toBeCloseTo(base.slope, 8);
     expect(shifted.intercept).toBeCloseTo(base.intercept + 10, 8);
   });
+
+  // n > PAIRWISE_CAP (150) forces the bisection path (not pairwise LP vertices).
+  it("large-n collinear recovers y = 1 + 2x on the bisection path", () => {
+    const n = 300;
+    const x = new Float64Array(n);
+    const y = new Float64Array(n);
+    for (let i = 0; i < n; i++) {
+      x[i] = i;
+      y[i] = 1 + 2 * i;
+    }
+    for (const tau of [0.25, 0.5, 0.75]) {
+      const fit = fitLinearQuantileRegression(x, y, tau);
+      expect(fit).not.toBeNull();
+      expect(fit!.intercept).toBeCloseTo(1, 6);
+      expect(fit!.slope).toBeCloseTo(2, 6);
+    }
+  });
+
+  it("large-n steep collinear recovers y = 1 + 500x (expand from default bracket)", () => {
+    const n = 300;
+    const x = new Float64Array(n);
+    const y = new Float64Array(n);
+    for (let i = 0; i < n; i++) {
+      x[i] = i;
+      y[i] = 1 + 500 * i;
+    }
+    const fit = fitLinearQuantileRegression(x, y, 0.5);
+    expect(fit).not.toBeNull();
+    expect(fit!.intercept).toBeCloseTo(1, 4);
+    expect(fit!.slope).toBeCloseTo(500, 4);
+  });
+
+  it("large-n steep negative collinear recovers y = 1 - 200x", () => {
+    const n = 300;
+    const x = new Float64Array(n);
+    const y = new Float64Array(n);
+    for (let i = 0; i < n; i++) {
+      x[i] = i;
+      y[i] = 1 - 200 * i;
+    }
+    const fit = fitLinearQuantileRegression(x, y, 0.5);
+    expect(fit).not.toBeNull();
+    expect(fit!.intercept).toBeCloseTo(1, 4);
+    expect(fit!.slope).toBeCloseTo(-200, 4);
+  });
 });
 
 describe("statQuantile", () => {


### PR DESCRIPTION
## Summary

- **Audit target:** `packages/core/src/stats` (28 files; pipeline too large at 311)
- **Chosen finding:** `fitByBisection` in `packages/core/src/stats/quantile.ts` seeded `lo`/`hi` from full `pairwiseSlopes` — Θ(n²) even when `n > PAIRWISE_CAP` (150), defeating the documented large-n escape hatch
- **Fix:** delete pairwise seed; keep default `[-1, 1]` + existing expand/bisection. Pairwise LP-vertex search remains for `n ≤ 150`
- **Complexity:** large-n path Θ(n²) → O(n log n · iters) via residual sort in pinball/subgradient evals (expand ≤ 20, bisection ≤ 80)
- **n =** finite (x, y) rows per group in `stat_quantile` / geom_quantile

## Test plan

- [x] `bun test packages/core/tests/stats-quantile.test.ts packages/core/tests/pipeline-m2/quantile.test.ts` (16 pass)
- [x] Large-n collinear (n=300, τ ∈ {0.25, 0.5, 0.75}) recovers y = 1 + 2x
- [x] Steep large-n collinear y = 1 + 500x and y = 1 − 200x (forces expand from default bracket)

## Follow-ups

- https://github.com/ljodea/ggsvelte/issues/977 — contour O(E²) unshift stitch
- https://github.com/ljodea/ggsvelte/issues/978 — hitTest maxRadius recompute per probe
- https://github.com/ljodea/ggsvelte/issues/979 — a11y canvas full sort for CAP=100

Plan review: Codex CLI unavailable (ChatGPT account model mismatch); independent review via Grok (revise → delete-only seed; no wall-clock gate).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/980" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->