### PR TITLE
perf(core): precompute point-batch maxRadius for hitTest (#978)

### DIFF
--- a/.changeset/978-hit-max-radius-precompute.md
+++ b/.changeset/978-hit-max-radius-precompute.md
@@ -1,0 +1,11 @@
+---
+"@ggsvelte/core": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+perf(core): precompute per-point-batch maxRadius for hitTest
+
+Variable aes(size) used to re-scan `batch.sizes` on every pointer probe.
+Build stores max(batch.size, …sizes)×1.25 on the spatial point-batch entry
+so resolveTopmostHit only expands the query pad from that value.

--- a/packages/core/src/candidate-hit-resolve.ts
+++ b/packages/core/src/candidate-hit-resolve.ts
@@ -18,6 +18,8 @@ type PointBatchIndex = {
   readonly spatial: {
     queryRect(loX: number, loY: number, hiX: number, hiY: number): number[];
   };
+  /** Precomputed max(batch.size, …sizes) * 1.25; see spatial-index build. */
+  readonly maxRadius: number;
 };
 
 export type TopmostHitContext = {
@@ -78,11 +80,7 @@ export function resolveTopmostHit(
         (px < panel.x || px > panel.x + panel.width || py < panel.y || py > panel.y + panel.height))
     )
       continue;
-    let maxRadius = batch.size;
-    if (batch.sizes !== undefined) {
-      for (const radius of batch.sizes) maxRadius = Math.max(maxRadius, radius);
-    }
-    maxRadius *= 1.25;
+    const maxRadius = entry.maxRadius;
     const localIds = entry.spatial
       .queryRect(
         px - maxRadius - hitTolerance,

--- a/packages/core/src/candidate-store-spatial-index.ts
+++ b/packages/core/src/candidate-store-spatial-index.ts
@@ -12,6 +12,8 @@ type PointBatchIndex = {
   readonly batchIndex: number;
   readonly ids: number[];
   readonly spatial: StaticQuadtree;
+  /** max(batch.size, …batch.sizes) * 1.25 — query pad without hitTolerance. */
+  readonly maxRadius: number;
 };
 
 export type SpatialIndex = {
@@ -84,6 +86,7 @@ export function buildSpatialIndex(indexes: CandidateStoreIndexes): SpatialIndex 
   // Pointer hit testing preserves reverse paint order and per-batch point
   // radius without expanding every query by the largest point in the scene.
   // This mirrors paint batches while remaining private to CandidateStore.
+  // maxRadius is fixed at build so hitTest never O(P)-scans batch.sizes (#978).
   const pointBatchIndexes = [...pointIdsByBatch.entries()].map(([batchIndex, ids]) => {
     const pointXs = new Float64Array(ids.length);
     const pointYs = new Float64Array(ids.length);
@@ -91,10 +94,20 @@ export function buildSpatialIndex(indexes: CandidateStoreIndexes): SpatialIndex 
       pointXs[i] = xs[ids[i]!]!;
       pointYs[i] = ys[ids[i]!]!;
     }
+    const batch = scene.batches[batchIndex]!;
+    let maxRadius = 0;
+    if (batch.kind === "points") {
+      maxRadius = batch.size;
+      if (batch.sizes !== undefined) {
+        for (const radius of batch.sizes) maxRadius = Math.max(maxRadius, radius);
+      }
+      maxRadius *= 1.25;
+    }
     return {
       batchIndex,
       ids,
       spatial: new StaticQuadtree(pointXs, pointYs),
+      maxRadius,
     };
   });
   pointIdsByBatch.clear();

--- a/packages/core/tests/candidate/spatial/points-queries.test.ts
+++ b/packages/core/tests/candidate/spatial/points-queries.test.ts
@@ -78,6 +78,84 @@ describe("candidate spatial query hot path (issue #214) — points-queries", () 
     expect(hypot).toHaveBeenCalledTimes(1);
     hypot.mockRestore();
   });
+  it("hitTest honors per-point sizes without rescanning the full sizes array (issue #978)", () => {
+    // Variable aes(size): max query pad must still cover the largest mark, but
+    // hitTest must not O(P)-scan batch.sizes on every probe (build precomputes).
+    const count = 5_000;
+    const positions = new Float32Array(count * 2);
+    const rawSizes = new Float32Array(count);
+    for (let i = 0; i < count; i++) {
+      // Sparse grid so one probe has a single clear hit under reverse paint order.
+      positions[i * 2] = (i % 100) * 2;
+      positions[i * 2 + 1] = Math.floor(i / 100) * 2;
+      rawSizes[i] = 2;
+    }
+    // Large bubble on the right of the default 200×120 panel.
+    const largeIndex = count - 1;
+    positions[largeIndex * 2] = 160;
+    positions[largeIndex * 2 + 1] = 60;
+    rawSizes[largeIndex] = 40;
+
+    const plotScene = scene();
+    plotScene.batches = [
+      {
+        kind: "points",
+        layerIndex: 0,
+        panelIndex: 0,
+        positions,
+        rowIndex: Uint32Array.from({ length: count }, (_, index) => index),
+        size: 2,
+        sizes: rawSizes,
+        alpha: 1,
+        shape: "circle",
+        fill: null,
+      },
+    ];
+    const store = buildCandidateStore(plotScene);
+    void store.x;
+
+    // Probe on the large bubble center and near its hit edge (size + default tol 3).
+    expect(store.hitTest(160, 60)?.id).toBe(largeIndex);
+    expect(store.hitTest(160 + 35, 60)?.id).toBe(largeIndex);
+    expect(store.hitTest(160 + 50, 60)).toBeNull();
+
+    const batch = plotScene.batches[0]!;
+    if (batch.kind !== "points" || batch.sizes === undefined) {
+      throw new Error("expected points batch with sizes");
+    }
+    // TypedArray brand breaks Proxy for-of; instrument with an indexable iterable
+    // so a full maxRadius scan is visible as O(P) iterator steps.
+    const originalSizes = batch.sizes;
+    let sizeIterSteps = 0;
+    batch.sizes = {
+      length: originalSizes.length,
+      [Symbol.iterator](): Iterator<number> {
+        let i = 0;
+        return {
+          next(): IteratorResult<number> {
+            if (i >= originalSizes.length) return { done: true, value: undefined };
+            sizeIterSteps++;
+            return { done: false, value: originalSizes[i++]! };
+          },
+        };
+      },
+    } as unknown as Float32Array;
+    // pointHitDistance reads sizes[primitive] — keep indexed access working.
+    for (let i = 0; i < originalSizes.length; i++) {
+      Object.defineProperty(batch.sizes, i, {
+        enumerable: true,
+        get(): number {
+          return originalSizes[i]!;
+        },
+      });
+    }
+
+    sizeIterSteps = 0;
+    // Any interior hit is fine — we only police full-array iteration for maxRadius.
+    expect(store.hitTest(10, 10)).not.toBeNull();
+    // Pre-fix: for (const r of batch.sizes) walks every element each probe.
+    expect(sizeIterSteps).toBe(0);
+  });
   it("queryRect does not read every batch for a tight brush on a large point cloud", () => {
     const count = 8_000;
     const cols = Math.ceil(Math.sqrt(count));


### PR DESCRIPTION
## Summary

Fixes #978.

Variable `aes(size)` put a full `batch.sizes` scan on every `hitTest` probe so large scatter layers paid O(P) before the quadtree query. Spatial index build already walks point batches; it now stores `max(batch.size, …sizes)×1.25` on each point-batch entry, and `resolveTopmostHit` reads that value.

## Validation

- Confirmed the O(P) loop in `packages/core/src/candidate-hit-resolve.ts` (pre-fix).
- `maxPointReach` already aggregates sizes at build; this mirrors that for the per-batch hit pad.

## Test plan

- [x] RED→GREEN: `packages/core/tests/candidate/spatial/points-queries.test.ts` — large bubble still hits; instrumented sizes iterator shows 0 full scans on probe
- [x] `bun test packages/core/tests/candidate` (148 pass)

## Follow-ups

None.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/996" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->