### PR TITLE
fix(docs): single-source the themes temperatures chart (#990)

### DIFF
--- a/apps/docs/src/lib/components/ChartThemeLab.svelte
+++ b/apps/docs/src/lib/components/ChartThemeLab.svelte
@@ -1,24 +1,15 @@
 <script lang="ts">
-  import {
-    GeomLine,
-    GeomPoint,
-    GGPlot,
-    Labs,
-    Scale,
-    Theme,
-  } from "@ggsvelte/svelte";
   import type { ThemeName } from "@ggsvelte/spec";
   import { onMount } from "svelte";
 
   import { CATEGORICAL_PALETTES, THEME_OPTIONS } from "$lib/catalog/themes";
   import CopyCode from "$lib/components/CopyCode.svelte";
+  import TemperaturesSpecimen from "$lib/components/TemperaturesSpecimen.svelte";
   import {
     readDocsAppearance,
     watchDocsAppearance,
     type DocsAppearance,
   } from "$lib/docs-appearance";
-  import { MONTH_BREAKS } from "$lib/theme-specimens/catalog";
-  import { temperaturesKeyed } from "$lib/theme-specimens/data";
   import { heroThemePaletteSnippet } from "$lib/theme-specimens/snippets";
 
   type SchemeName = (typeof CATEGORICAL_PALETTES)[number]["name"];
@@ -67,31 +58,13 @@
   </p>
 
   <div class="plot-panel">
-    <GGPlot
-      data={temperaturesKeyed}
-      aes={{ x: "month", y: "temp", color: "city" }}
-      key="id"
-      inspect={{ mode: "x" }}
-      legendFocus
+    <TemperaturesSpecimen
+      theme={resolvedTheme}
+      {scheme}
       height={400}
+      legendFocus={true}
       ariaLabel={`${resolvedTheme} theme with ${scheme} palette`}
-    >
-      <Theme name={resolvedTheme} />
-      <Scale
-        value={{
-          x: { breaks: [...MONTH_BREAKS] },
-          color: { type: "ordinal", scheme },
-        }}
-      />
-      <Labs
-        title="Monthly mean temperature"
-        x="Month"
-        y="Temperature (°C)"
-        color="City"
-      />
-      <GeomLine linewidth={2} />
-      <GeomPoint size={2.5} />
-    </GGPlot>
+    />
   </div>
 
   <div class="controls">

--- a/apps/docs/src/lib/components/TemperaturesSpecimen.svelte
+++ b/apps/docs/src/lib/components/TemperaturesSpecimen.svelte
@@ -9,6 +9,7 @@
   } from "@ggsvelte/svelte";
   import type { ThemeName } from "@ggsvelte/spec";
 
+  import type { SchemeName } from "$lib/theme-specimens/catalog";
   import { temperaturesKeyed } from "$lib/theme-specimens/data";
   import { TEMPERATURES_CHART } from "$lib/theme-specimens/temperatures-chart";
 
@@ -20,7 +21,7 @@
     ariaLabel,
   }: {
     theme: ThemeName;
-    scheme: string;
+    scheme: SchemeName;
     height: number;
     legendFocus: boolean;
     ariaLabel: string;

--- a/apps/docs/src/lib/components/TemperaturesSpecimen.svelte
+++ b/apps/docs/src/lib/components/TemperaturesSpecimen.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+  import {
+    GeomLine,
+    GeomPoint,
+    GGPlot,
+    Labs,
+    Scale,
+    Theme,
+  } from "@ggsvelte/svelte";
+  import type { ThemeName } from "@ggsvelte/spec";
+
+  import { temperaturesKeyed } from "$lib/theme-specimens/data";
+  import { TEMPERATURES_CHART } from "$lib/theme-specimens/temperatures-chart";
+
+  const {
+    theme,
+    scheme,
+    height,
+    legendFocus,
+    ariaLabel,
+  }: {
+    theme: ThemeName;
+    scheme: string;
+    height: number;
+    legendFocus: boolean;
+    ariaLabel: string;
+  } = $props();
+
+  const chart = TEMPERATURES_CHART;
+</script>
+
+<GGPlot
+  data={temperaturesKeyed}
+  aes={chart.aes}
+  key={chart.key}
+  inspect={chart.inspect}
+  {legendFocus}
+  {height}
+  {ariaLabel}
+>
+  <Theme name={theme} />
+  <Scale
+    value={{
+      x: { breaks: [...chart.monthBreaks] },
+      color: { type: "ordinal", scheme },
+    }}
+  />
+  <Labs
+    title={chart.labs.title}
+    x={chart.labs.x}
+    y={chart.labs.y}
+    color={chart.labs.color}
+  />
+  <GeomLine linewidth={chart.geomLine.linewidth} />
+  <GeomPoint size={chart.geomPoint.size} />
+</GGPlot>

--- a/apps/docs/src/lib/components/ThemeSpecimen.svelte
+++ b/apps/docs/src/lib/components/ThemeSpecimen.svelte
@@ -15,11 +15,11 @@
   } from "@ggsvelte/svelte";
   import type { ThemeName } from "@ggsvelte/spec";
 
+  import TemperaturesSpecimen from "$lib/components/TemperaturesSpecimen.svelte";
   import type {
     SchemeName,
     ThemeSpecimenKind,
   } from "$lib/theme-specimens/catalog";
-  import { MONTH_BREAKS } from "$lib/theme-specimens/catalog";
   import {
     attendees,
     cities,
@@ -29,7 +29,6 @@
     penguins,
     revenue,
     ridership,
-    temperaturesKeyed,
   } from "$lib/theme-specimens/data";
 
   const {
@@ -60,31 +59,13 @@
 
   <div class="plot-panel">
     {#if kind === "temps-line"}
-      <GGPlot
-        data={temperaturesKeyed}
-        aes={{ x: "month", y: "temp", color: "city" }}
-        key="id"
-        inspect={{ mode: "x" }}
-        {legendFocus}
+      <TemperaturesSpecimen
+        theme={name}
+        {scheme}
         height={plotHeight}
+        {legendFocus}
         ariaLabel={`${label} theme multi-series temperatures`}
-      >
-        <Theme {name} />
-        <Scale
-          value={{
-            x: { breaks: [...MONTH_BREAKS] },
-            color: colorScale,
-          }}
-        />
-        <Labs
-          title="Monthly mean temperature"
-          x="Month"
-          y="Temperature (°C)"
-          color="City"
-        />
-        <GeomLine linewidth={2} />
-        <GeomPoint size={2.5} />
-      </GGPlot>
+      />
     {:else if kind === "ridership-line"}
       <GGPlot
         data={ridership}

--- a/apps/docs/src/lib/theme-specimens/snippets.ts
+++ b/apps/docs/src/lib/theme-specimens/snippets.ts
@@ -6,7 +6,7 @@
  * drift from what TemperaturesSpecimen renders (#990).
  */
 
-import { formatMonthBreaksLiteral, TEMPERATURES_CHART } from "./temperatures-chart.ts";
+import { formatMonthBreaksLiteral, TEMPERATURES_CHART } from "./temperatures-chart.js";
 
 export function heroThemePaletteSnippet(theme: string, scheme: string): string {
   const chart = TEMPERATURES_CHART;

--- a/apps/docs/src/lib/theme-specimens/snippets.ts
+++ b/apps/docs/src/lib/theme-specimens/snippets.ts
@@ -1,9 +1,16 @@
 /**
  * Consumer-facing code fragments for the themes page.
  * Kept outside .svelte so the compiler never sees a literal </script> close tag.
+ *
+ * The hero temperatures snippet is built from TEMPERATURES_CHART so it cannot
+ * drift from what TemperaturesSpecimen renders (#990).
  */
 
+import { formatMonthBreaksLiteral, TEMPERATURES_CHART } from "./temperatures-chart.ts";
+
 export function heroThemePaletteSnippet(theme: string, scheme: string): string {
+  const chart = TEMPERATURES_CHART;
+  const breaks = formatMonthBreaksLiteral(chart.monthBreaks);
   return `<script lang="ts">
   import { GeomLine, GeomPoint, GGPlot, Labs, Scale, Theme } from "@ggsvelte/svelte";
 
@@ -20,26 +27,27 @@ export function heroThemePaletteSnippet(theme: string, scheme: string): string {
 
 <GGPlot
   data={temperatures}
-  aes={{ x: "month", y: "temp", color: "city" }}
-  inspect={{ mode: "x" }}
+  aes={{ x: "${chart.aes.x}", y: "${chart.aes.y}", color: "${chart.aes.color}" }}
+  key="${chart.key}"
+  inspect={{ mode: "${chart.inspect.mode}" }}
   legendFocus
   height={400}
 >
   <Theme name="${theme}" />
   <Scale
     value={{
-      x: { breaks: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] },
+      x: { breaks: ${breaks} },
       color: { type: "ordinal", scheme: "${scheme}" },
     }}
   />
   <Labs
-    title="Monthly mean temperature"
-    x="Month"
-    y="Temperature (°C)"
-    color="City"
+    title="${chart.labs.title}"
+    x="${chart.labs.x}"
+    y="${chart.labs.y}"
+    color="${chart.labs.color}"
   />
-  <GeomLine linewidth={2} />
-  <GeomPoint size={2.5} />
+  <GeomLine linewidth={${String(chart.geomLine.linewidth)}} />
+  <GeomPoint size={${String(chart.geomPoint.size)}} />
 </GGPlot>`;
 }
 

--- a/apps/docs/src/lib/theme-specimens/temperatures-chart.ts
+++ b/apps/docs/src/lib/theme-specimens/temperatures-chart.ts
@@ -3,7 +3,7 @@
  * The live `<TemperaturesSpecimen>` and the copyable `heroThemePaletteSnippet`
  * both read from here so the snippet cannot drift from what the page renders.
  */
-import { MONTH_BREAKS } from "./catalog.ts";
+import { MONTH_BREAKS } from "./catalog.js";
 
 export const TEMPERATURES_CHART = {
   key: "id",

--- a/apps/docs/src/lib/theme-specimens/temperatures-chart.ts
+++ b/apps/docs/src/lib/theme-specimens/temperatures-chart.ts
@@ -1,0 +1,29 @@
+/**
+ * Single source of truth for the themes-page temperatures multi-series chart.
+ * The live `<TemperaturesSpecimen>` and the copyable `heroThemePaletteSnippet`
+ * both read from here so the snippet cannot drift from what the page renders.
+ */
+import { MONTH_BREAKS } from "./catalog.ts";
+
+export const TEMPERATURES_CHART = {
+  key: "id",
+  aes: { x: "month", y: "temp", color: "city" },
+  inspect: { mode: "x" as const },
+  labs: {
+    title: "Monthly mean temperature",
+    x: "Month",
+    y: "Temperature (°C)",
+    color: "City",
+  },
+  geomLine: { linewidth: 2 },
+  geomPoint: { size: 2.5 },
+  /** Month axis breaks shared with the rendered charts. */
+  monthBreaks: MONTH_BREAKS,
+} as const;
+
+/** Format month breaks for a consumer-facing Scale value literal. */
+export function formatMonthBreaksLiteral(
+  breaks: readonly number[] = TEMPERATURES_CHART.monthBreaks,
+): string {
+  return `[${breaks.join(", ")}]`;
+}

--- a/scripts/themes-page.test.ts
+++ b/scripts/themes-page.test.ts
@@ -6,7 +6,16 @@ import {
   VIRIDIS_COLORS,
 } from "../apps/docs/src/lib/catalog/themes.ts";
 import { colorBehaviorEvidence } from "../apps/docs/src/lib/color-evidence.ts";
-import { RASTER_Z_DOMAIN, THEME_SPECIMENS } from "../apps/docs/src/lib/theme-specimens/catalog.ts";
+import {
+  MONTH_BREAKS,
+  RASTER_Z_DOMAIN,
+  THEME_SPECIMENS,
+} from "../apps/docs/src/lib/theme-specimens/catalog.ts";
+import { heroThemePaletteSnippet } from "../apps/docs/src/lib/theme-specimens/snippets.ts";
+import {
+  formatMonthBreaksLiteral,
+  TEMPERATURES_CHART,
+} from "../apps/docs/src/lib/theme-specimens/temperatures-chart.ts";
 
 describe("themes catalog", () => {
   it("projects every public theme and categorical palette without docs-owned colors", () => {
@@ -321,5 +330,18 @@ describe("themes catalog", () => {
           "Palette exhausted: 3 discrete values but range has only 2 entries and onExhaust is 'error'. Provide a larger range or an explicit domain.",
       },
     });
+  });
+});
+
+describe("hero temperatures chart and copy snippet stay aligned (#990)", () => {
+  it("generates a snippet with the same key and month breaks the component renders", () => {
+    const snippet = heroThemePaletteSnippet("tufte", "observable10");
+    expect(snippet).toContain(`key="${TEMPERATURES_CHART.key}"`);
+    expect(snippet).toContain(
+      `x: { breaks: ${formatMonthBreaksLiteral(TEMPERATURES_CHART.monthBreaks)} }`,
+    );
+    // Shared config is what TemperaturesSpecimen spreads into Scale/GGPlot.
+    expect(TEMPERATURES_CHART.key).toBe("id");
+    expect([...TEMPERATURES_CHART.monthBreaks]).toEqual([...MONTH_BREAKS]);
   });
 });


### PR DESCRIPTION
## Summary

Closes #990.

The themes temperatures chart was authored three times (ChartThemeLab, ThemeSpecimen, and the copyable `heroThemePaletteSnippet`). The snippet had already drifted: it omitted `key="id"` and hard-coded month breaks instead of sharing `MONTH_BREAKS`.

- Add `TemperaturesSpecimen.svelte` and `TEMPERATURES_CHART` as the single chart config.
- ChartThemeLab and ThemeSpecimen both render the component.
- Generate the copy snippet from the same config.
- Guard with a themes-page unit test that asserts the snippet carries `key="id"` and the same breaks the component uses.

CSS duplication noted in the issue is left for a follow-up (out of scope for this fix).

## Test plan

- [x] `bun test scripts/themes-page.test.ts scripts/repo-child-layers.test.ts`
- [ ] CI green on the PR
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/997" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->