### PR TITLE
refactor(docs): give the playground session a single owner (#988)

### DIFF
--- a/apps/docs/src/lib/Playground.svelte
+++ b/apps/docs/src/lib/Playground.svelte
@@ -16,13 +16,11 @@
   } from "$lib/generated/playground-seeds";
   import {
     acceptCandidatePhase,
-    candidateTransitionAccepted,
     createCandidateLifecycleTracker,
     emitPlaygroundCandidatePhase,
     phaseNotesForCandidateTransition,
     type PlaygroundCandidateIsolation,
     type PlaygroundCandidatePhaseDetail,
-    type PlaygroundCandidateRef,
   } from "$lib/playground-candidate-lifecycle";
   import {
     appendPlaygroundEvent,
@@ -34,55 +32,18 @@
     type PlaygroundSeedV1,
   } from "$lib/playground-codec";
   import {
-    applyPlaygroundHashRestoreState,
-    rejectRestoreCancelPhase,
-    resolvePlaygroundHashRestore,
-  } from "$lib/playground-hash-restore";
-  import {
     PLAYGROUND_ACTIVE_FAILED_STATUS,
-    PLAYGROUND_SAMPLE_DISCARD_CONFIRM,
-    PLAYGROUND_UNDO_DISCARD_CONFIRM,
     shouldClearPlayHashAfterPromotion,
   } from "$lib/playground-link-policy";
   import { playgroundOutputs } from "$lib/playground-output";
   import { playgroundShareCopyStatus } from "$lib/playground-output-status";
-  import {
-    confirmPlaygroundRendered,
-    createPlaygroundState,
-    failPlaygroundCandidate,
-    promotePlaygroundCandidate,
-    reportPlaygroundDiagnostic,
-    setPlaygroundHistoryHash,
-    stagePlaygroundSeed,
-    type PlaygroundDiagnostic,
+  import type {
+    PlaygroundDiagnostic,
+    PlaygroundState,
   } from "$lib/playground-state";
-  import {
-    planSampleLoad,
-    planUndoChart,
-    workbenchCandidateRef,
-  } from "$lib/playground-workbench-actions";
-  import {
-    defaultPlaygroundInteractions,
-    type PlaygroundAgentEnvelope,
-    type PlaygroundInteractions,
-  } from "$lib/playground-agent-envelope";
   import { generateChart } from "$lib/playground-agent-client";
-  import { elidePlaygroundDatasetRows } from "$lib/playground-datasets";
   import { agentHandoffPrompt } from "$lib/playground-agent-handoff";
-  import {
-    agentIsBusy,
-    completeAgentSuccess,
-    createPlaygroundAgentState,
-    failAgent,
-    messageForAgentError,
-    resolvePhaseLine,
-    setAgentDrawing,
-    type PlaygroundAgentState,
-  } from "$lib/playground-agent-state";
-  import {
-    rateLimitLabelFor,
-    runPlaygroundAgentRun,
-  } from "$lib/playground-agent-run";
+  import { createPlaygroundSession } from "$lib/playground-session";
   import type { PlaygroundDatasetId } from "$lib/playground-dataset-schemas";
   import {
     PLAYGROUND_DEFAULT_DATASET,
@@ -97,63 +58,9 @@
     samples: PLAYGROUND_SAMPLES,
   };
 
-  let workbench = $state(createPlaygroundState(initialSeed));
-  let agent = $state<PlaygroundAgentState>(createPlaygroundAgentState());
-  let interactions = $state<PlaygroundInteractions>(
-    defaultPlaygroundInteractions(),
-  );
-  let pendingInteractions = $state<PlaygroundInteractions | null>(null);
-  let prompt = $state(PLAYGROUND_DEFAULT_PROMPT);
-  let datasetId = $state<PlaygroundDatasetId>(PLAYGROUND_DEFAULT_DATASET);
-  let shareUrl = $state("");
-  let shareStatus = $state("");
-  let shareSource = $state<HTMLElement>();
-  let events = $state<readonly PlaygroundEventEntry[]>([]);
+  // Revision bridge: session owns mutable state; Svelte re-reads via $derived.
+  let sessionRev = $state(0);
   let lifecycleTracker = $state(createCandidateLifecycleTracker());
-  let abortController = $state<AbortController | null>(null);
-  let rateLimitUntil = $state<number | null>(null);
-  let rateLimitLabel = $state("");
-  let nowTick = $state(Date.now());
-  // Monotonic run token: continuations from a superseded/cancelled pipeline
-  // must never touch state after a newer run (or a sample load) began.
-  let runSeq = 0;
-  let pendingSuccess = $state<PlaygroundAgentEnvelope | null>(null);
-  let mockNotice = $state(false);
-
-  const outputs = $derived(
-    playgroundOutputs(workbench.committed, interactions, datasetId),
-  );
-  const sampleLinks = $derived(
-    PLAYGROUND_SAMPLES.map((s) => ({ id: s.id, title: s.title })),
-  );
-  const busy = $derived(agentIsBusy(agent));
-  const phaseLine = $derived.by(() => {
-    const resolved = resolvePhaseLine(agent, nowTick);
-    if (resolved !== "") return resolved;
-    return mockNotice
-      ? "Instant sample — live generation isn't enabled yet."
-      : "";
-  });
-  const generateLabel = $derived(
-    rateLimitLabel === "" ? "Generate" : rateLimitLabel,
-  );
-  const generateDisabled = $derived(
-    rateLimitUntil !== null && nowTick < rateLimitUntil,
-  );
-  // Computed lazily at copy time — the ~10KB prompt assembly must not run
-  // on every keystroke (performance review).
-  function currentHandoffText(): string {
-    return agentHandoffPrompt({
-      currentSpec: workbench.committed,
-      userGoal: prompt,
-    });
-  }
-
-  function cancelActiveRun(): void {
-    runSeq += 1;
-    abortController?.abort();
-    abortController = null;
-  }
 
   function noteCandidatePhase(detail: PlaygroundCandidatePhaseDetail): void {
     const accepted = acceptCandidatePhase(lifecycleTracker, detail);
@@ -163,8 +70,11 @@
   }
 
   function noteStagedCandidate(
-    previous: PlaygroundCandidateRef | null,
-    next: typeof workbench,
+    previous: {
+      readonly generation: number;
+      readonly origin: PlaygroundCandidatePhaseDetail["origin"];
+    } | null,
+    next: PlaygroundState,
   ): void {
     for (const detail of phaseNotesForCandidateTransition(previous, {
       candidate: next.candidate,
@@ -174,8 +84,84 @@
     }
   }
 
-  function activeCandidate(): PlaygroundCandidateRef | null {
-    return workbenchCandidateRef(workbench);
+  const session = createPlaygroundSession({
+    initialSeed,
+    samples: PLAYGROUND_SAMPLES,
+    shareCatalogs,
+    generateChart,
+    confirm: (message) => window.confirm(message),
+    onChange: () => {
+      sessionRev += 1;
+    },
+    onWorkbenchStaged: ({ previous, workbench: next }) => {
+      noteStagedCandidate(previous, next);
+    },
+  });
+
+  // UI-only state (not race-sensitive coordination).
+  let prompt = $state(PLAYGROUND_DEFAULT_PROMPT);
+  let datasetId = $state<PlaygroundDatasetId>(PLAYGROUND_DEFAULT_DATASET);
+  let shareSource = $state<HTMLElement>();
+  let events = $state<readonly PlaygroundEventEntry[]>([]);
+  let nowTick = $state(Date.now());
+
+  const workbench = $derived.by(() => {
+    void sessionRev;
+    return session.workbench;
+  });
+  const agent = $derived.by(() => {
+    void sessionRev;
+    return session.agent;
+  });
+  const interactions = $derived.by(() => {
+    void sessionRev;
+    return session.interactions;
+  });
+  const shareUrl = $derived.by(() => {
+    void sessionRev;
+    return session.shareUrl;
+  });
+  const shareStatus = $derived.by(() => {
+    void sessionRev;
+    return session.shareStatus;
+  });
+  const rateLimitUntil = $derived.by(() => {
+    void sessionRev;
+    return session.rateLimitUntil;
+  });
+  const rateLimitLabel = $derived.by(() => {
+    void sessionRev;
+    return session.rateLimitLabel;
+  });
+  const busy = $derived.by(() => {
+    void sessionRev;
+    return session.busy;
+  });
+  const phaseLine = $derived.by(() => {
+    void sessionRev;
+    return session.phaseLine(nowTick);
+  });
+
+  const outputs = $derived(
+    playgroundOutputs(workbench.committed, interactions, datasetId),
+  );
+  const sampleLinks = $derived(
+    PLAYGROUND_SAMPLES.map((s) => ({ id: s.id, title: s.title })),
+  );
+  const generateLabel = $derived(
+    rateLimitLabel === "" ? "Generate" : rateLimitLabel,
+  );
+  const generateDisabled = $derived(
+    rateLimitUntil !== null && nowTick < rateLimitUntil,
+  );
+
+  // Computed lazily at copy time — the ~10KB prompt assembly must not run
+  // on every keystroke (performance review).
+  function currentHandoffText(): string {
+    return agentHandoffPrompt({
+      currentSpec: session.workbench.committed,
+      userGoal: prompt,
+    });
   }
 
   function replaceLocationHash(hash: string | null): void {
@@ -185,35 +171,21 @@
   }
 
   function restoreLocation(origin: "initial-navigation" | "popstate"): void {
-    const decision = resolvePlaygroundHashRestore(
-      origin,
-      window.location.hash,
-      shareCatalogs,
-    );
-    if (decision.kind === "noop") return;
-    // History restore replaces the chart: cancel any in-flight agent run and
-    // drop its pending payload so it can't apply to the restored chart.
-    cancelActiveRun();
-    pendingInteractions = null;
-    pendingSuccess = null;
-    if (agentIsBusy(agent)) agent = createPlaygroundAgentState();
-    if (decision.kind === "reject") {
-      replaceLocationHash(workbench.historyHash);
+    const side = session.restoreFromHash(origin, window.location.hash);
+    if (side.kind === "noop") return;
+    if (side.replaceWithHistoryHash !== null) {
+      replaceLocationHash(side.replaceWithHistoryHash);
     }
-    const previous = activeCandidate();
-    const next = applyPlaygroundHashRestoreState(
-      workbench,
-      decision,
-      origin,
-      initialSeed,
-    );
-    workbench = next;
-    if (decision.kind === "reject") {
-      const cancel = rejectRestoreCancelPhase(previous, workbench.status);
-      if (cancel !== null) noteCandidatePhase(cancel);
+    if (side.rejectCancel !== null) {
+      noteCandidatePhase({
+        generation: side.rejectCancel.generation,
+        origin: side.rejectCancel.origin,
+        phase: "cancelled",
+        status: side.rejectCancel.status,
+      });
       return;
     }
-    noteStagedCandidate(previous, next);
+    noteStagedCandidate(side.previous, side.workbench);
   }
 
   function onPopState(): void {
@@ -230,148 +202,34 @@
     if (!busy && rateLimitUntil === null) return;
     const id = window.setInterval(() => {
       nowTick = Date.now();
-      if (rateLimitUntil !== null) {
-        const remaining = Math.ceil((rateLimitUntil - nowTick) / 1000);
-        if (remaining <= 0) {
-          rateLimitUntil = null;
-          rateLimitLabel = "";
-        } else {
-          rateLimitLabel = rateLimitLabelFor(remaining);
-        }
-      }
+      session.tickNow(nowTick);
     }, 500);
     return () => window.clearInterval(id);
   });
 
   function undoChart(): void {
-    let plan = planUndoChart(workbench, busy, false);
-    if (plan.kind === "noop") return;
-    if (plan.kind === "needs_confirm") {
-      const discard = window.confirm(PLAYGROUND_UNDO_DISCARD_CONFIRM);
-      if (!discard) return;
-      plan = planUndoChart(workbench, busy, true);
-      if (plan.kind !== "stage") return;
-    }
-    workbench = plan.workbench;
-    noteStagedCandidate(plan.previous, plan.workbench);
+    session.undo();
   }
 
   function loadSample(id: string): boolean {
-    let plan = planSampleLoad(workbench, id, PLAYGROUND_SAMPLES, false);
-    if (plan.kind === "noop") return false;
-    if (plan.kind === "needs_confirm") {
-      const discard = window.confirm(PLAYGROUND_SAMPLE_DISCARD_CONFIRM);
-      if (!discard) return false;
-      plan = planSampleLoad(workbench, id, PLAYGROUND_SAMPLES, true);
-      if (plan.kind !== "load") return false;
-    }
-    cancelActiveRun();
-    workbench = plan.workbench;
-    interactions = plan.interactions;
-    pendingInteractions = plan.pendingInteractions;
-    pendingSuccess = plan.pendingSuccess;
-    mockNotice = plan.mockNotice;
-    agent = plan.agent;
-    noteStagedCandidate(plan.previous, plan.workbench);
-    return true;
-  }
-
-  function stageAgentSeed(
-    seed: PlaygroundSeedV1,
-    nextInteractions: PlaygroundInteractions,
-  ): void {
-    const previous = activeCandidate();
-    pendingInteractions = nextInteractions;
-    const next = stagePlaygroundSeed(workbench, seed, "agent");
-    workbench = next;
-    agent = setAgentDrawing(agent);
-    noteStagedCandidate(previous, next);
-  }
-
-  async function runAgentPipeline(
-    userPrompt: string,
-    dataset: PlaygroundDatasetId,
-    options: {
-      readonly example?: PlaygroundExamplePrompt;
-      readonly signal?: AbortSignal;
-    } = {},
-  ): Promise<void> {
-    const token = ++runSeq;
-    // A superseded or cancelled run must stop touching state entirely —
-    // its continuations would otherwise interleave with the newer run.
-    const isStale = (): boolean =>
-      token !== runSeq || options.signal?.aborted === true;
-
-    // Clear before the run so a cancelled live generate cannot inherit
-    // mock notice copy from a prior canned example.
-    mockNotice = false;
-
-    const outcome = await runPlaygroundAgentRun(
-      {
-        userPrompt,
-        dataset,
-        // Re-read at first generate and repair (send named data, never rows).
-        getCurrentSpec: () =>
-          elidePlaygroundDatasetRows(workbench.committed, dataset),
-        ...(options.example === undefined ? {} : { example: options.example }),
-        ...(options.signal === undefined ? {} : { signal: options.signal }),
-        isStale,
-        initialAgent: agent,
-      },
-      {
-        onAgent: (next) => {
-          agent = next;
-        },
-        generateChart,
-      },
-    );
-
-    if (outcome.kind === "stale") return;
-
-    if (outcome.kind === "failed") {
-      mockNotice = outcome.mockNotice;
-      if (outcome.rateLimit !== undefined) {
-        rateLimitUntil = outcome.rateLimit.until;
-        rateLimitLabel = outcome.rateLimit.label;
-      }
-      return;
-    }
-
-    // ready_to_stage — drawing is owned by stageAgentSeed, not the run module.
-    mockNotice = outcome.mockNotice;
-    pendingSuccess = outcome.pendingSuccess;
-    stageAgentSeed(outcome.seed, outcome.interactions);
+    return session.loadSample(id);
   }
 
   function onGenerate(): void {
     if (busy || generateDisabled) return;
     if (prompt.trim() === "") return;
-    cancelActiveRun();
-    const controller = new AbortController();
-    abortController = controller;
-    void runAgentPipeline(prompt, datasetId, { signal: controller.signal });
+    void session.runAgent(prompt, datasetId);
   }
 
   function onExample(example: PlaygroundExamplePrompt): void {
     if (busy) return;
     prompt = example.prompt;
     datasetId = example.datasetId;
-    cancelActiveRun();
-    const controller = new AbortController();
-    abortController = controller;
-    void runAgentPipeline(example.prompt, example.datasetId, {
-      example,
-      signal: controller.signal,
-    });
+    void session.runAgent(example.prompt, example.datasetId, { example });
   }
 
   function onCancel(): void {
-    cancelActiveRun();
-    pendingSuccess = null;
-    agent = failAgent(agent, {
-      code: "aborted",
-      message: messageForAgentError("aborted"),
-    });
+    session.cancel();
   }
 
   async function onCopyHandoff(): Promise<void> {
@@ -390,7 +248,7 @@
     generation: number,
     isolation: PlaygroundCandidateIsolation,
   ): void {
-    const current = workbench;
+    const current = session.workbench;
     const candidate = current.candidate;
     if (candidate?.generation !== generation) return;
     noteCandidatePhase({
@@ -406,63 +264,41 @@
   }
 
   function promoteAcceptedCandidate(generation: number): void {
-    const current = workbench;
-    const origin = current.candidate?.origin;
-    const promoted = promotePlaygroundCandidate(current, generation);
-    if (!candidateTransitionAccepted(current, promoted)) return;
-    workbench = promoted;
-    if (pendingInteractions !== null) {
-      interactions = pendingInteractions;
-      pendingInteractions = null;
-    }
-    if (origin === "agent" && pendingSuccess !== null) {
-      agent = completeAgentSuccess(agent, pendingSuccess);
-      pendingSuccess = null;
-    }
+    const result = session.promoteCandidate(generation);
+    if (!result.accepted) return;
     noteCandidatePhase({
       generation,
-      origin: origin ?? "agent",
+      origin: result.origin ?? "agent",
       phase: "promoted",
-      status: promoted.status,
+      status: result.workbench.status,
     });
     events = [];
-    if (shouldClearPlayHashAfterPromotion(origin, window.location.hash)) {
+    if (
+      shouldClearPlayHashAfterPromotion(result.origin, window.location.hash)
+    ) {
       replaceLocationHash(null);
     }
-    shareUrl = "";
-    shareStatus = "";
   }
 
   function reconcileCandidateFailure(
     generation: number,
     diagnostic: PlaygroundDiagnostic,
   ): void {
-    const current = workbench;
-    const origin = current.candidate?.origin;
-    const failed = failPlaygroundCandidate(current, generation, diagnostic);
-    if (!candidateTransitionAccepted(current, failed)) return;
-    workbench = failed;
-    pendingInteractions = null;
-    pendingSuccess = null;
+    const result = session.failCandidate(generation, diagnostic);
+    if (!result.accepted) return;
     noteCandidatePhase({
       generation,
-      origin: origin ?? "agent",
+      origin: result.origin ?? "agent",
       phase: "failed",
-      status: failed.status,
+      status: result.workbench.status,
     });
-    if (origin === "agent") {
-      agent = failAgent(agent, {
-        code: "pipeline",
-        message: diagnostic.message,
-      });
-    }
-    if (failed.navigationRecovery !== null) {
-      replaceLocationHash(failed.navigationRecovery.replaceHash);
+    if (result.navigationRecovery !== null) {
+      replaceLocationHash(result.navigationRecovery.replaceHash ?? null);
     }
   }
 
   function activeRendered(_model: RenderModel): void {
-    workbench = confirmPlaygroundRendered(workbench);
+    session.confirmRendered();
   }
 
   function recordInteraction(event: PlaygroundInteractionEvent): void {
@@ -470,39 +306,45 @@
   }
 
   function activeFailed(diagnostic: PlaygroundDiagnostic): void {
-    const previous = activeCandidate();
-    workbench = reportPlaygroundDiagnostic(
-      workbench,
+    const previous =
+      session.workbench.candidate === null
+        ? null
+        : {
+            generation: session.workbench.candidate.generation,
+            origin: session.workbench.candidate.origin,
+          };
+    const next = session.reportActiveFailed(
       diagnostic,
       PLAYGROUND_ACTIVE_FAILED_STATUS,
-      false,
     );
     for (const detail of phaseNotesForCandidateTransition(previous, {
       candidate: null,
-      status: workbench.status,
+      status: next.status,
     })) {
       noteCandidatePhase(detail);
     }
   }
 
   async function share(): Promise<void> {
-    if (!workbench.canCopyOrShare) return;
-    const hash = encodePlaygroundSeed(workbench.seed);
+    if (!session.workbench.canCopyOrShare) return;
+    const hash = encodePlaygroundSeed(session.workbench.seed);
     const url = new URL(window.location.href);
     url.hash = hash;
     pushSvelteKitState(url, {});
-    workbench = setPlaygroundHistoryHash(workbench, hash);
-    shareUrl = url.href;
+    session.setHistoryHash(hash);
+    session.setShareResult(url.href, "");
     await tick();
     if (shareSource === undefined) {
       // PlaygroundCode triggers share; status via shareStatus only.
-      shareStatus = playgroundShareCopyStatus(
-        await copyText(shareUrl, document.body),
+      session.setShareStatus(
+        playgroundShareCopyStatus(
+          await copyText(session.shareUrl, document.body),
+        ),
       );
       return;
     }
-    const result = await copyText(shareUrl, shareSource);
-    shareStatus = playgroundShareCopyStatus(result);
+    const result = await copyText(session.shareUrl, shareSource);
+    session.setShareStatus(playgroundShareCopyStatus(result));
   }
 </script>
 
@@ -542,7 +384,7 @@
     status={workbench.status}
     {interactions}
     onInteractionsChange={(next) => {
-      interactions = next;
+      session.setInteractions(next);
     }}
     onCandidateReady={candidateReady}
     onCandidateFailed={reconcileCandidateFailure}

--- a/apps/docs/src/lib/playground-session.ts
+++ b/apps/docs/src/lib/playground-session.ts
@@ -1,0 +1,505 @@
+/**
+ * Playground session owner — workbench + agent + run token + interactions + share.
+ *
+ * Extracted from Playground.svelte so the two state machines cannot drift without
+ * a single place that owns the race (#988). Continuations from a superseded or
+ * cancelled pipeline never touch state after a newer run (or sample load /
+ * hash restore) begins.
+ *
+ * Plain TypeScript (not `.svelte.ts`) so the race tests live next to the other
+ * playground unit suites under `scripts/` via bun:test — no component harness
+ * required (#991). DOM, clipboard, and candidate-lifecycle *emission* stay in
+ * the shell; this module owns the state transitions.
+ */
+
+import type {
+  GenerateChartOptions,
+  GenerateChartRequest,
+  GenerateChartResult,
+} from "./playground-agent-client";
+import {
+  defaultPlaygroundInteractions,
+  type PlaygroundAgentEnvelope,
+  type PlaygroundInteractions,
+} from "./playground-agent-envelope";
+import { rateLimitLabelFor, runPlaygroundAgentRun } from "./playground-agent-run";
+import {
+  agentIsBusy,
+  completeAgentSuccess,
+  createPlaygroundAgentState,
+  failAgent,
+  messageForAgentError,
+  resolvePhaseLine,
+  setAgentDrawing,
+  type PlaygroundAgentState,
+} from "./playground-agent-state";
+import {
+  candidateTransitionAccepted,
+  type PlaygroundCandidateRef,
+} from "./playground-candidate-lifecycle";
+import type { PlaygroundSeedV1 } from "./playground-codec";
+import type { PlaygroundDatasetId } from "./playground-dataset-schemas";
+import { elidePlaygroundDatasetRows } from "./playground-datasets";
+import {
+  applyPlaygroundHashRestoreState,
+  rejectRestoreCancelPhase,
+  resolvePlaygroundHashRestore,
+  type PlaygroundHashRestoreOrigin,
+} from "./playground-hash-restore";
+import {
+  PLAYGROUND_SAMPLE_DISCARD_CONFIRM,
+  PLAYGROUND_UNDO_DISCARD_CONFIRM,
+  type PlaygroundShareCatalogs,
+} from "./playground-link-policy";
+import type { PlaygroundExamplePrompt } from "./playground-prompts";
+import {
+  confirmPlaygroundRendered,
+  createPlaygroundState,
+  failPlaygroundCandidate,
+  promotePlaygroundCandidate,
+  reportPlaygroundDiagnostic,
+  setPlaygroundHistoryHash,
+  stagePlaygroundSeed,
+  type PlaygroundDiagnostic,
+  type PlaygroundState,
+} from "./playground-state";
+import {
+  planSampleLoad,
+  planUndoChart,
+  workbenchCandidateRef,
+  type WorkbenchSampleEntry,
+} from "./playground-workbench-actions";
+
+export type PlaygroundSessionGenerateChart = (
+  req: GenerateChartRequest,
+  opts?: GenerateChartOptions,
+) => Promise<GenerateChartResult>;
+
+export type PlaygroundSessionConfirm = (message: string) => boolean;
+
+export type PlaygroundSessionHashRestoreSideEffect =
+  | { readonly kind: "noop" }
+  | {
+      readonly kind: "applied";
+      readonly previous: PlaygroundCandidateRef | null;
+      readonly workbench: PlaygroundState;
+      /** When set, shell must `replaceLocationHash` before/with the apply. */
+      readonly replaceWithHistoryHash: string | null;
+      readonly rejectCancel: {
+        readonly generation: number;
+        readonly origin: PlaygroundCandidateRef["origin"];
+        readonly status: string;
+      } | null;
+    };
+
+export type PlaygroundSessionWorkbenchChange = {
+  readonly previous: PlaygroundCandidateRef | null;
+  readonly workbench: PlaygroundState;
+};
+
+export interface PlaygroundSessionOptions {
+  readonly initialSeed: PlaygroundSeedV1;
+  readonly samples: readonly WorkbenchSampleEntry[];
+  readonly shareCatalogs: PlaygroundShareCatalogs;
+  readonly generateChart: PlaygroundSessionGenerateChart;
+  /** Confirm dialogs (defaults to always-true so tests need no window). */
+  readonly confirm?: PlaygroundSessionConfirm;
+  readonly delay?: (ms: number) => Promise<void>;
+  readonly now?: () => number;
+  /** Fired after any owned state mutation (Svelte reactivity bridge). */
+  readonly onChange?: () => void;
+  /**
+   * Fired when workbench stages a new candidate (sample load, undo, agent
+   * stage). Shell uses this for lifecycle emission only.
+   */
+  readonly onWorkbenchStaged?: (change: PlaygroundSessionWorkbenchChange) => void;
+}
+export interface PlaygroundSession {
+  readonly workbench: PlaygroundState;
+  readonly agent: PlaygroundAgentState;
+  readonly interactions: PlaygroundInteractions;
+  readonly pendingInteractions: PlaygroundInteractions | null;
+  readonly mockNotice: boolean;
+  readonly rateLimitUntil: number | null;
+  readonly rateLimitLabel: string;
+  readonly shareUrl: string;
+  readonly shareStatus: string;
+  readonly busy: boolean;
+  phaseLine(now?: number): string;
+
+  loadSample(id: string): boolean;
+  runAgent(
+    userPrompt: string,
+    dataset: PlaygroundDatasetId,
+    options?: {
+      readonly example?: PlaygroundExamplePrompt;
+    },
+  ): Promise<void>;
+  cancel(): void;
+  undo(): boolean;
+  restoreFromHash(
+    origin: PlaygroundHashRestoreOrigin,
+    hash: string,
+  ): PlaygroundSessionHashRestoreSideEffect;
+
+  /** Candidate pipeline hooks used by PlaygroundPreview (still session-owned state). */
+  promoteCandidate(generation: number): {
+    readonly accepted: boolean;
+    readonly origin: PlaygroundCandidateRef["origin"] | undefined;
+    readonly workbench: PlaygroundState;
+  };
+  failCandidate(
+    generation: number,
+    diagnostic: PlaygroundDiagnostic,
+  ): {
+    readonly accepted: boolean;
+    readonly origin: PlaygroundCandidateRef["origin"] | undefined;
+    readonly workbench: PlaygroundState;
+    readonly navigationRecovery: {
+      readonly replaceHash: string | null;
+      readonly preserveForward: true;
+    } | null;
+  };
+  confirmRendered(): void;
+  reportActiveFailed(diagnostic: PlaygroundDiagnostic, statusMessage: string): PlaygroundState;
+  setInteractions(next: PlaygroundInteractions): void;
+  setHistoryHash(hash: string): void;
+  setShareResult(url: string, status: string): void;
+  clearShare(): void;
+  setShareStatus(status: string): void;
+  tickNow(now: number): void;
+}
+
+export function createPlaygroundSession(options: PlaygroundSessionOptions): PlaygroundSession {
+  const confirm = options.confirm ?? (() => true);
+  const now = options.now ?? Date.now;
+  const notify = (): void => {
+    options.onChange?.();
+  };
+
+  let workbench = createPlaygroundState(options.initialSeed);
+  let agent = createPlaygroundAgentState();
+  let interactions = defaultPlaygroundInteractions();
+  let pendingInteractions: PlaygroundInteractions | null = null;
+  let pendingSuccess: PlaygroundAgentEnvelope | null = null;
+  let mockNotice = false;
+  let rateLimitUntil: number | null = null;
+  let rateLimitLabel = "";
+  let shareUrl = "";
+  let shareStatus = "";
+  let abortController: AbortController | null = null;
+  // Monotonic run token: continuations from a superseded/cancelled pipeline
+  // must never touch state after a newer run (or a sample load) began.
+  let runSeq = 0;
+
+  function cancelActiveRun(): void {
+    runSeq += 1;
+    abortController?.abort();
+    abortController = null;
+  }
+
+  function stageAgentSeed(seed: PlaygroundSeedV1, nextInteractions: PlaygroundInteractions): void {
+    const previous = workbenchCandidateRef(workbench);
+    pendingInteractions = nextInteractions;
+    workbench = stagePlaygroundSeed(workbench, seed, "agent");
+    agent = setAgentDrawing(agent);
+    options.onWorkbenchStaged?.({ previous, workbench });
+    notify();
+  }
+
+  const session: PlaygroundSession = {
+    get workbench() {
+      return workbench;
+    },
+    get agent() {
+      return agent;
+    },
+    get interactions() {
+      return interactions;
+    },
+    get pendingInteractions() {
+      return pendingInteractions;
+    },
+    get mockNotice() {
+      return mockNotice;
+    },
+    get rateLimitUntil() {
+      return rateLimitUntil;
+    },
+    get rateLimitLabel() {
+      return rateLimitLabel;
+    },
+    get shareUrl() {
+      return shareUrl;
+    },
+    get shareStatus() {
+      return shareStatus;
+    },
+    get busy() {
+      return agentIsBusy(agent);
+    },
+    phaseLine(at = now()) {
+      const resolved = resolvePhaseLine(agent, at);
+      if (resolved !== "") return resolved;
+      return mockNotice ? "Instant sample — live generation isn't enabled yet." : "";
+    },
+
+    loadSample(id: string): boolean {
+      let plan = planSampleLoad(workbench, id, options.samples, false);
+      if (plan.kind === "noop") return false;
+      if (plan.kind === "needs_confirm") {
+        if (!confirm(PLAYGROUND_SAMPLE_DISCARD_CONFIRM)) return false;
+        plan = planSampleLoad(workbench, id, options.samples, true);
+        if (plan.kind !== "load") return false;
+      }
+      cancelActiveRun();
+      const previous = plan.previous;
+      workbench = plan.workbench;
+      interactions = plan.interactions;
+      pendingInteractions = plan.pendingInteractions;
+      pendingSuccess = plan.pendingSuccess;
+      mockNotice = plan.mockNotice;
+      agent = plan.agent;
+      options.onWorkbenchStaged?.({ previous, workbench });
+      notify();
+      return true;
+    },
+
+    async runAgent(userPrompt, dataset, runOptions = {}): Promise<void> {
+      // Match shell: cancel prior pipeline, then claim a fresh run token.
+      cancelActiveRun();
+      const controller = new AbortController();
+      abortController = controller;
+
+      const token = ++runSeq;
+      const isStale = (): boolean => token !== runSeq || controller.signal.aborted;
+
+      // Clear before the run so a cancelled live generate cannot inherit
+      // mock notice copy from a prior canned example.
+      mockNotice = false;
+      notify();
+
+      const outcome = await runPlaygroundAgentRun(
+        {
+          userPrompt,
+          dataset,
+          getCurrentSpec: () => elidePlaygroundDatasetRows(workbench.committed, dataset),
+          ...(runOptions.example === undefined ? {} : { example: runOptions.example }),
+          signal: controller.signal,
+          isStale,
+          initialAgent: agent,
+        },
+        {
+          onAgent: (next) => {
+            if (isStale()) return;
+            agent = next;
+            notify();
+          },
+          generateChart: options.generateChart,
+          ...(options.delay === undefined ? {} : { delay: options.delay }),
+          now,
+        },
+      );
+
+      if (outcome.kind === "stale") return;
+
+      if (outcome.kind === "failed") {
+        mockNotice = outcome.mockNotice;
+        if (outcome.rateLimit !== undefined) {
+          rateLimitUntil = outcome.rateLimit.until;
+          rateLimitLabel = outcome.rateLimit.label;
+        }
+        notify();
+        return;
+      }
+
+      mockNotice = outcome.mockNotice;
+      pendingSuccess = outcome.pendingSuccess;
+      stageAgentSeed(outcome.seed, outcome.interactions);
+    },
+
+    cancel(): void {
+      cancelActiveRun();
+      pendingSuccess = null;
+      agent = failAgent(agent, {
+        code: "aborted",
+        message: messageForAgentError("aborted"),
+      });
+      notify();
+    },
+
+    undo(): boolean {
+      let plan = planUndoChart(workbench, agentIsBusy(agent), false);
+      if (plan.kind === "noop") return false;
+      if (plan.kind === "needs_confirm") {
+        if (!confirm(PLAYGROUND_UNDO_DISCARD_CONFIRM)) return false;
+        plan = planUndoChart(workbench, agentIsBusy(agent), true);
+        if (plan.kind !== "stage") return false;
+      }
+      const previous = plan.previous;
+      workbench = plan.workbench;
+      options.onWorkbenchStaged?.({ previous, workbench });
+      notify();
+      return true;
+    },
+
+    restoreFromHash(origin, hash): PlaygroundSessionHashRestoreSideEffect {
+      const decision = resolvePlaygroundHashRestore(origin, hash, options.shareCatalogs);
+      if (decision.kind === "noop") return { kind: "noop" };
+
+      // History restore replaces the chart: cancel any in-flight agent run and
+      // drop its pending payload so it can't apply to the restored chart.
+      cancelActiveRun();
+      pendingInteractions = null;
+      pendingSuccess = null;
+      if (agentIsBusy(agent)) agent = createPlaygroundAgentState();
+
+      const previous = workbenchCandidateRef(workbench);
+      const replaceWithHistoryHash = decision.kind === "reject" ? workbench.historyHash : null;
+      const next = applyPlaygroundHashRestoreState(
+        workbench,
+        decision,
+        origin,
+        options.initialSeed,
+      );
+      workbench = next;
+
+      let rejectCancel: {
+        readonly generation: number;
+        readonly origin: PlaygroundCandidateRef["origin"];
+        readonly status: string;
+      } | null = null;
+      if (decision.kind === "reject") {
+        const cancel = rejectRestoreCancelPhase(previous, workbench.status);
+        if (cancel !== null) {
+          rejectCancel = {
+            generation: cancel.generation,
+            origin: cancel.origin,
+            status: cancel.status,
+          };
+        }
+      }
+
+      notify();
+      return {
+        kind: "applied",
+        previous,
+        workbench: next,
+        replaceWithHistoryHash,
+        rejectCancel,
+      };
+    },
+
+    promoteCandidate(generation) {
+      const current = workbench;
+      const origin = current.candidate?.origin;
+      const promoted = promotePlaygroundCandidate(current, generation);
+      if (!candidateTransitionAccepted(current, promoted)) {
+        return {
+          accepted: false,
+          origin: undefined,
+          workbench: current,
+        };
+      }
+      workbench = promoted;
+      if (pendingInteractions !== null) {
+        interactions = pendingInteractions;
+        pendingInteractions = null;
+      }
+      if (origin === "agent" && pendingSuccess !== null) {
+        agent = completeAgentSuccess(agent, pendingSuccess);
+        pendingSuccess = null;
+      }
+      shareUrl = "";
+      shareStatus = "";
+      notify();
+      return {
+        accepted: true,
+        origin,
+        workbench: promoted,
+      };
+    },
+
+    failCandidate(generation, diagnostic) {
+      const current = workbench;
+      const origin = current.candidate?.origin;
+      const failed = failPlaygroundCandidate(current, generation, diagnostic);
+      if (!candidateTransitionAccepted(current, failed)) {
+        return {
+          accepted: false,
+          origin: undefined,
+          workbench: current,
+          navigationRecovery: null,
+        };
+      }
+      workbench = failed;
+      pendingInteractions = null;
+      pendingSuccess = null;
+      if (origin === "agent") {
+        agent = failAgent(agent, {
+          code: "pipeline",
+          message: diagnostic.message,
+        });
+      }
+      notify();
+      return {
+        accepted: true,
+        origin,
+        workbench: failed,
+        navigationRecovery: failed.navigationRecovery,
+      };
+    },
+
+    confirmRendered(): void {
+      workbench = confirmPlaygroundRendered(workbench);
+      notify();
+    },
+
+    reportActiveFailed(diagnostic, statusMessage) {
+      workbench = reportPlaygroundDiagnostic(workbench, diagnostic, statusMessage, false);
+      notify();
+      return workbench;
+    },
+
+    setInteractions(next) {
+      interactions = next;
+      notify();
+    },
+
+    setHistoryHash(hash) {
+      workbench = setPlaygroundHistoryHash(workbench, hash);
+      notify();
+    },
+
+    setShareResult(url, status) {
+      shareUrl = url;
+      shareStatus = status;
+      notify();
+    },
+
+    clearShare() {
+      shareUrl = "";
+      shareStatus = "";
+      notify();
+    },
+
+    setShareStatus(status) {
+      shareStatus = status;
+      notify();
+    },
+
+    tickNow(at) {
+      if (rateLimitUntil === null) return;
+      const remaining = Math.ceil((rateLimitUntil - at) / 1000);
+      if (remaining <= 0) {
+        rateLimitUntil = null;
+        rateLimitLabel = "";
+      } else {
+        rateLimitLabel = rateLimitLabelFor(remaining);
+      }
+      notify();
+    },
+  };
+
+  return session;
+}

--- a/scripts/playground-session.test.ts
+++ b/scripts/playground-session.test.ts
@@ -1,0 +1,275 @@
+import { describe, expect, test } from "bun:test";
+
+import type { PortableSpec } from "@ggsvelte/spec";
+
+import type { GenerateChartResult } from "../apps/docs/src/lib/playground-agent-client";
+import {
+  defaultPlaygroundInteractions,
+  type PlaygroundAgentEnvelope,
+} from "../apps/docs/src/lib/playground-agent-envelope";
+import { encodePlaygroundSeed, type PlaygroundSeedV1 } from "../apps/docs/src/lib/playground-codec";
+import { createPlaygroundSession } from "../apps/docs/src/lib/playground-session";
+
+const baseSpec: PortableSpec = {
+  edition: 2,
+  data: {
+    values: [
+      { x: 1, y: 2 },
+      { x: 2, y: 3 },
+    ],
+  },
+  layers: [
+    {
+      geom: "point",
+      stat: "identity",
+      position: "identity",
+      aes: { x: { field: "x" }, y: { field: "y" } },
+    },
+  ],
+  labs: { title: "Baseline" },
+};
+
+const sampleSeed = (id = "starter", title = "Baseline"): PlaygroundSeedV1 => ({
+  version: 1,
+  source: { kind: "sample", id },
+  spec: { ...baseSpec, labs: { title } },
+});
+
+const catalog = [
+  { id: "starter", seed: sampleSeed("starter", "Starter") },
+  { id: "other", seed: sampleSeed("other", "Other") },
+] as const;
+
+const catalogs = {
+  examples: [] as const,
+  samples: [
+    { id: "starter", fragment: "#play=v1.trusted-starter" },
+    { id: "other", fragment: "#play=v1.trusted-other" },
+  ],
+};
+
+const validSpec: PortableSpec = {
+  edition: 2,
+  data: { name: "penguins" },
+  layers: [
+    {
+      geom: "point",
+      aes: { x: { field: "flipper" }, y: { field: "mass" } },
+    },
+  ],
+  labs: { title: "Generated" },
+};
+
+function envelope(spec: unknown, title: string | null = null): PlaygroundAgentEnvelope {
+  return {
+    spec,
+    interactions: defaultPlaygroundInteractions(),
+    title,
+  };
+}
+
+function okGenerate(env: PlaygroundAgentEnvelope, model = "live"): GenerateChartResult {
+  return {
+    ok: true,
+    model,
+    envelope: env,
+    rawEnvelope: {
+      spec: env.spec,
+      interactions: env.interactions,
+      title: env.title,
+    },
+  };
+}
+
+function deferredGenerate(): {
+  promise: Promise<GenerateChartResult>;
+  resolve: (result: GenerateChartResult) => void;
+} {
+  let resolve!: (result: GenerateChartResult) => void;
+  const promise = new Promise<GenerateChartResult>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+function candidateTitle(session: ReturnType<typeof createPlaygroundSession>): string | undefined {
+  const labs = session.workbench.candidate?.next.seed.spec.labs;
+  return labs === undefined || typeof labs === "string" ? undefined : labs.title;
+}
+
+describe("createPlaygroundSession run-token races", () => {
+  test("agent run superseded by a second run must not stage the first result", async () => {
+    const first = deferredGenerate();
+    const second = deferredGenerate();
+    let calls = 0;
+    const session = createPlaygroundSession({
+      initialSeed: sampleSeed(),
+      samples: catalog,
+      shareCatalogs: catalogs,
+      generateChart: () => {
+        calls += 1;
+        return calls === 1 ? first.promise : second.promise;
+      },
+    });
+
+    const run1 = session.runAgent("first prompt", "penguins");
+    // Let beginAgentRequest land before the second run bumps the token.
+    await Promise.resolve();
+    expect(session.agent.phase).toBe("awaiting-llm");
+
+    const run2 = session.runAgent("second prompt", "penguins");
+    await Promise.resolve();
+    expect(session.agent.phase).toBe("awaiting-llm");
+
+    // Stale first completion must not stage.
+    first.resolve(okGenerate(envelope({ ...validSpec, labs: { title: "First" } }, "First")));
+    await run1;
+    expect(candidateTitle(session)).toBeUndefined();
+    expect(session.workbench.candidate).toBeNull();
+
+    second.resolve(okGenerate(envelope({ ...validSpec, labs: { title: "Second" } }, "Second")));
+    await run2;
+    expect(candidateTitle(session)).toBe("Second");
+    expect(session.agent.phase).toBe("drawing");
+  });
+
+  test("agent run superseded by a sample load must not stage after the load", async () => {
+    const deferred = deferredGenerate();
+    const session = createPlaygroundSession({
+      initialSeed: sampleSeed(),
+      samples: catalog,
+      shareCatalogs: catalogs,
+      generateChart: () => deferred.promise,
+    });
+
+    const run = session.runAgent("slow prompt", "penguins");
+    await Promise.resolve();
+    expect(session.agent.phase).toBe("awaiting-llm");
+
+    expect(session.loadSample("other")).toBe(true);
+    expect(session.workbench.candidate?.origin).toBe("source");
+    expect(session.workbench.candidate?.next.seed.source).toEqual({
+      kind: "sample",
+      id: "other",
+    });
+    expect(session.agent.phase).toBe("idle");
+
+    deferred.resolve(okGenerate(envelope({ ...validSpec, labs: { title: "Late" } }, "Late")));
+    await run;
+    // Sample candidate must remain — the late agent result must not overwrite it.
+    expect(session.workbench.candidate?.origin).toBe("source");
+    expect(session.workbench.candidate?.next.seed.source).toEqual({
+      kind: "sample",
+      id: "other",
+    });
+    expect(session.agent.phase).toBe("idle");
+  });
+
+  test("cancel mid-repair then undo restores prior chart without agent busy", async () => {
+    let resolveRepair!: (result: GenerateChartResult) => void;
+    let calls = 0;
+    const session = createPlaygroundSession({
+      initialSeed: sampleSeed("starter", "Starter"),
+      samples: catalog,
+      shareCatalogs: catalogs,
+      generateChart: () => {
+        calls += 1;
+        if (calls === 1) {
+          // Invalid field forces a repair round.
+          return Promise.resolve(
+            okGenerate(
+              envelope({
+                edition: 2,
+                data: { name: "penguins" },
+                layers: [
+                  {
+                    geom: "point",
+                    aes: { x: { field: "nope" }, y: { field: "mass" } },
+                  },
+                ],
+              }),
+            ),
+          );
+        }
+        return new Promise<GenerateChartResult>((r) => {
+          resolveRepair = r;
+        });
+      },
+    });
+
+    // Build undo history: confirm the initial chart painted, then promote a sample.
+    session.confirmRendered();
+    expect(session.loadSample("other")).toBe(true);
+    expect(session.promoteCandidate(session.workbench.candidate!.generation).accepted).toBe(true);
+    expect(session.workbench.undoSnapshots.length).toBeGreaterThan(0);
+    expect(session.workbench.seed.source).toEqual({ kind: "sample", id: "other" });
+
+    const run = session.runAgent("repair me", "penguins");
+    // Drain the generate→validate→repair microtask queue until repair is pending.
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(calls).toBe(2);
+    expect(session.agent.phase).toBe("repairing");
+
+    session.cancel();
+    expect(session.agent.phase).toBe("failed");
+    expect(session.agent.failure?.code).toBe("aborted");
+    expect(session.busy).toBe(false);
+
+    // Late repair must not resurrect the cancelled run.
+    resolveRepair(okGenerate(envelope({ ...validSpec, labs: { title: "Repaired" } }, "Repaired")));
+    await run;
+    expect(session.workbench.candidate).toBeNull();
+    expect(session.agent.phase).toBe("failed");
+
+    expect(session.undo()).toBe(true);
+    expect(session.busy).toBe(false);
+    expect(session.agent.phase).toBe("failed"); // undo does not clear agent failure
+    expect(session.workbench.candidate?.origin).toBe("undo");
+    // Undo stages the prior snapshot (starter baseline before "other" promote).
+    expect(session.workbench.candidate?.next.seed.source).toEqual({
+      kind: "sample",
+      id: "starter",
+    });
+  });
+
+  test("#play= restore while a run is in flight cancels the run and keeps restored seed", async () => {
+    const deferred = deferredGenerate();
+    const session = createPlaygroundSession({
+      initialSeed: sampleSeed("starter", "Starter"),
+      samples: catalog,
+      shareCatalogs: {
+        examples: [],
+        samples: catalog.map((entry) => ({
+          id: entry.id,
+          fragment: encodePlaygroundSeed(entry.seed),
+        })),
+      },
+      generateChart: () => deferred.promise,
+    });
+
+    const run = session.runAgent("in flight", "penguins");
+    await Promise.resolve();
+    expect(session.agent.phase).toBe("awaiting-llm");
+
+    const hash = encodePlaygroundSeed(sampleSeed("other", "Other"));
+    const side = session.restoreFromHash("popstate", hash);
+    expect(side.kind).toBe("applied");
+    expect(session.workbench.candidate?.next.seed.source).toEqual({
+      kind: "sample",
+      id: "other",
+    });
+    // Busy agent must be reset so restore does not leave a drawing phase.
+    expect(session.agent.phase).toBe("idle");
+    expect(session.busy).toBe(false);
+
+    deferred.resolve(okGenerate(envelope({ ...validSpec, labs: { title: "Late" } }, "Late")));
+    await run;
+    expect(session.workbench.candidate?.next.seed.source).toEqual({
+      kind: "sample",
+      id: "other",
+    });
+    expect(session.agent.phase).toBe("idle");
+  });
+});


### PR DESCRIPTION
## Summary

- Extract `createPlaygroundSession` (`apps/docs/src/lib/playground-session.ts`) so workbench, agent, run token, interactions, and share state have one owner.
- Thin `Playground.svelte` to markup, lifecycle emission, DOM/clipboard, and a revision bridge for reactivity.
- Add unit tests for the four race orderings that `runSeq` was written to guard.

Closes #988.

## Why plain TypeScript (not `.svelte.ts`)

#988 asked for `playground-session.svelte.ts` and was blocked by #991 (docs component harness). The race surface does not need runes — a factory with getters is enough, and it plugs into the existing `scripts/` + `bun:test` path used by every other playground extraction. #991 remains open for real `.svelte` component coverage.

## Test plan

- [x] `bun test scripts/playground-session.test.ts` — four race orderings
- [x] Related playground suites still pass (`agent-run`, `workbench-actions`, `hash-restore`)
- [x] oxlint clean on touched files
- [ ] CI green on the PR

### Race cases covered

1. Agent run superseded by a second run — first must not stage
2. Agent run superseded by a sample load — same
3. Cancel mid-repair, then undo — late repair must not write; undo still works
4. `#play=` restore while a run is in flight — late result must not overwrite restore
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/998" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->