### PR TITLE
fix(docs): single-source route metadata types (#993)

### DIFF
--- a/scripts/docs-route-inventory.ts
+++ b/scripts/docs-route-inventory.ts
@@ -5,37 +5,18 @@ import {
   interactionExpositionSlug,
   isInteractionExposition,
 } from "../apps/docs/src/lib/catalog/interaction-exposition.ts";
-import { CLI_REFERENCE_OPTIONS } from "./cli-docs.ts";
 import { GUIDE_CATALOG, type GuideCatalogEntry } from "../apps/docs/src/lib/catalog/guide.ts";
+import type { DocsRouteMetadata } from "../apps/docs/src/lib/route-types.ts";
+import { CLI_REFERENCE_OPTIONS } from "./cli-docs.ts";
 
-export type DocsRouteKind = "page" | "alias" | "endpoint" | "performance";
-export type DocsShell = "site" | "docs";
-
-export interface RouteNavigation {
-  section: string;
-  label: string;
-  order: number;
-}
-
-export interface RouteHeading {
-  id: string;
-  title: string;
-  level: number;
-}
-
-export interface DocsRouteRecord {
-  path: string;
-  title: string;
-  description: string;
-  canonicalPath: string;
-  kind: DocsRouteKind;
-  index: boolean;
-  sitemap: boolean;
-  shell: DocsShell;
-  navigation?: RouteNavigation;
-  primaryNavigationOwner?: "reference";
-  headings?: RouteHeading[];
-}
+/** Script-side name for the shared route metadata contract (`DocsRouteMetadata`). */
+export type DocsRouteRecord = DocsRouteMetadata;
+export type {
+  DocsRouteKind,
+  DocsShell,
+  RouteHeading,
+  RouteNavigation,
+} from "../apps/docs/src/lib/route-types.ts";
 
 const TOP_LEVEL_ROUTES: readonly DocsRouteRecord[] = [
   {


### PR DESCRIPTION
## Summary

- Route metadata types lived twice: once in `apps/docs/src/lib/route-types.ts` (site) and once in `scripts/docs-route-inventory.ts` (generator). They agreed by coincidence, not by contract (#993).
- Delete the five duplicated declarations from the inventory script and import from `route-types.ts`.
- Keep `DocsRouteRecord` as an alias of `DocsRouteMetadata` so existing script call sites do not churn.

## Test plan

- [x] `bun test scripts/docs-route-inventory.test.ts scripts/gen-docs-routes.test.ts scripts/check-docs-metadata.test.ts` (17 pass)
- [x] `bun run check:scripts`
- [x] Deliberate contract proof: add required field on `route-types.ts` → `tsc -p scripts` fails; restore clean

Closes #993
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1003" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->