### PR TITLE
fix(docs): shrink guide-code-copy public surface to 2 exports (#989)

### DIFF
--- a/apps/docs/src/lib/guide-code-copy.ts
+++ b/apps/docs/src/lib/guide-code-copy.ts
@@ -87,17 +87,20 @@ function applyGuideCopyFeedback(targets: GuideCopyDomTargets, feedback: GuideCop
 
 type GuideCodeCopyDeps = {
   readonly copyText: (text: string, fallbackNode: Node) => Promise<"copied" | "manual">;
-  readonly setTimeout: typeof setTimeout;
-  readonly clearTimeout: typeof clearTimeout;
+  /** Subset of setTimeout — only the (fn, ms) form the attachment uses. */
+  readonly setTimeout: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>;
+  readonly clearTimeout: (id: ReturnType<typeof setTimeout>) => void;
 };
 
 /** Live globals so tests can stub clipboard / timers without exporting deps. */
 const defaultDeps: GuideCodeCopyDeps = {
   copyText,
-  setTimeout: ((...args: Parameters<typeof setTimeout>) =>
-    globalThis.setTimeout(...args)) as typeof setTimeout,
-  clearTimeout: ((...args: Parameters<typeof clearTimeout>) =>
-    globalThis.clearTimeout(...args)) as typeof clearTimeout,
+  setTimeout(fn, ms) {
+    return globalThis.setTimeout(fn, ms);
+  },
+  clearTimeout(id) {
+    globalThis.clearTimeout(id);
+  },
 };
 
 /**

--- a/apps/docs/src/lib/guide-code-copy.ts
+++ b/apps/docs/src/lib/guide-code-copy.ts
@@ -1,6 +1,9 @@
 /**
  * Delegated copy controls for guide markdown fences (`data-copy-code`).
  * Icons are shared with scripts/llms-markdown.ts (single source).
+ *
+ * Public surface: GUIDE_COPY_ICON_SVG (static HTML) + attachGuideCodeCopy
+ * (Svelte attachment). Everything else is module-private.
  */
 import { copyText, MANUAL_COPY_STATUS } from "./clipboard";
 
@@ -9,10 +12,10 @@ export const GUIDE_COPY_ICON_SVG =
   '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor" viewBox="0 0 256 256" aria-hidden="true"><path d="M216,32H88a8,8,0,0,0-8,8V80H40a8,8,0,0,0-8,8V216a8,8,0,0,0,8,8H168a8,8,0,0,0,8-8V176h40a8,8,0,0,0,8-8V40A8,8,0,0,0,216,32ZM160,208H48V96H160Zm48-48H176V88a8,8,0,0,0-8-8H96V48H208Z"/></svg>';
 
 /** Phosphor Check (bold) — client-only feedback after successful copy. */
-export const GUIDE_CHECK_ICON_SVG =
+const GUIDE_CHECK_ICON_SVG =
   '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor" viewBox="0 0 256 256" aria-hidden="true"><path d="M229.66,77.66l-128,128a8,8,0,0,1-11.32,0l-56-56a8,8,0,0,1,11.32-11.32L96,188.69,218.34,66.34a8,8,0,0,1,11.32,11.32Z"/></svg>';
 
-export const GUIDE_COPY_RESET_MS = 2000;
+const GUIDE_COPY_RESET_MS = 2000;
 
 function cssEscapeIdent(value: string): string {
   if (typeof globalThis.CSS?.escape === "function") return globalThis.CSS.escape(value);
@@ -20,7 +23,7 @@ function cssEscapeIdent(value: string): string {
   return value.replaceAll(/[^a-zA-Z0-9_-]/gu, (ch) => `\\${ch}`);
 }
 
-export type GuideCopyFeedback = {
+type GuideCopyFeedback = {
   readonly icon: "copy" | "check";
   readonly buttonAriaLabel: string;
   readonly statusText: string;
@@ -28,7 +31,7 @@ export type GuideCopyFeedback = {
   readonly resetMs: number | null;
 };
 
-export function guideCopyFeedback(result: "copied" | "manual"): GuideCopyFeedback {
+function guideCopyFeedback(result: "copied" | "manual"): GuideCopyFeedback {
   if (result === "copied") {
     return {
       icon: "check",
@@ -48,7 +51,7 @@ export function guideCopyFeedback(result: "copied" | "manual"): GuideCopyFeedbac
 }
 
 /** Idle control state after a successful-copy reset timer fires. */
-export function guideCopyIdleFeedback(): GuideCopyFeedback {
+function guideCopyIdleFeedback(): GuideCopyFeedback {
   return {
     icon: "copy",
     buttonAriaLabel: "Copy code",
@@ -58,11 +61,11 @@ export function guideCopyIdleFeedback(): GuideCopyFeedback {
   };
 }
 
-export function guideCopyIconSvg(icon: "copy" | "check"): string {
+function guideCopyIconSvg(icon: "copy" | "check"): string {
   return icon === "check" ? GUIDE_CHECK_ICON_SVG : GUIDE_COPY_ICON_SVG;
 }
 
-export interface GuideCopyDomTargets {
+interface GuideCopyDomTargets {
   readonly button: {
     innerHTML: string;
     setAttribute(name: string, value: string): void;
@@ -74,10 +77,7 @@ export interface GuideCopyDomTargets {
 }
 
 /** Apply pure feedback to the button/status nodes used by guide fences. */
-export function applyGuideCopyFeedback(
-  targets: GuideCopyDomTargets,
-  feedback: GuideCopyFeedback,
-): void {
+function applyGuideCopyFeedback(targets: GuideCopyDomTargets, feedback: GuideCopyFeedback): void {
   targets.button.innerHTML = guideCopyIconSvg(feedback.icon);
   targets.button.setAttribute("aria-label", feedback.buttonAriaLabel);
   targets.status.textContent = feedback.statusText;
@@ -85,23 +85,26 @@ export function applyGuideCopyFeedback(
   else targets.status.classList.remove("visually-hidden");
 }
 
-export type GuideCodeCopyDeps = {
+type GuideCodeCopyDeps = {
   readonly copyText: (text: string, fallbackNode: Node) => Promise<"copied" | "manual">;
   readonly setTimeout: typeof setTimeout;
   readonly clearTimeout: typeof clearTimeout;
 };
 
+/** Live globals so tests can stub clipboard / timers without exporting deps. */
 const defaultDeps: GuideCodeCopyDeps = {
   copyText,
-  setTimeout,
-  clearTimeout,
+  setTimeout: ((...args: Parameters<typeof setTimeout>) =>
+    globalThis.setTimeout(...args)) as typeof setTimeout,
+  clearTimeout: ((...args: Parameters<typeof clearTimeout>) =>
+    globalThis.clearTimeout(...args)) as typeof clearTimeout,
 };
 
 /**
  * Svelte 5 attachment: delegated click for `button[data-copy-code]` fences.
  * Returns a destroy function that clears pending reset timers.
  */
-export function createGuideCodeCopyAttachment(
+function createGuideCodeCopyAttachment(
   deps: GuideCodeCopyDeps = defaultDeps,
 ): (node: HTMLElement) => () => void {
   return (node: HTMLElement) => {

--- a/apps/docs/src/lib/home-code-path.ts
+++ b/apps/docs/src/lib/home-code-path.ts
@@ -18,7 +18,7 @@
  * ~10 rows per species; default degree-2 / span 0.75 overfits and jaggeds.
  */
 
-export const HOME_CODE_PATH_SVELTE = `<script lang="ts">
+const HOME_CODE_PATH_SVELTE = `<script lang="ts">
   import { GeomPoint, GeomSmooth, GGPlot } from "@ggsvelte/svelte";
 
   import { penguins } from "./penguins.js";
@@ -37,7 +37,7 @@ export const HOME_CODE_PATH_SVELTE = `<script lang="ts">
 `;
 
 /** Builder produces PortableSpec; inspect is enabled on the host GGPlot. */
-export const HOME_CODE_PATH_BUILDER = `<script lang="ts">
+const HOME_CODE_PATH_BUILDER = `<script lang="ts">
   import { aes, gg } from "@ggsvelte/spec";
   import { GGPlot } from "@ggsvelte/svelte";
 
@@ -66,7 +66,7 @@ export const HOME_CODE_PATH_BUILDER = `<script lang="ts">
  * `inspect: true` still defaults mode "auto" (path layers use x-crosshair);
  * the homepage host opts into exact via the Svelte/builder tabs above.
  */
-export const HOME_CODE_PATH_SPEC_JSON = `{
+const HOME_CODE_PATH_SPEC_JSON = `{
   "interactions": {
     "inspect": true
   },
@@ -106,6 +106,7 @@ export const HOME_CODE_PATH_SPEC_JSON = `{
 }
 `;
 
+/** Only public home code-path surface — tab labels + sources for CodeTabs. */
 export const HOME_CODE_PATH_TABS: {
   label: string;
   code: string;

--- a/scripts/guide-code-copy.test.ts
+++ b/scripts/guide-code-copy.test.ts
@@ -1,244 +1,289 @@
-import { describe, expect, test } from "bun:test";
+/**
+ * Behavioral tests for guide fence copy controls.
+ *
+ * Drive the public attachment against a DOM fixture shaped like the HTML
+ * emitted by scripts/llms-markdown.ts — not the module's internal helpers.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import { MANUAL_COPY_STATUS } from "../apps/docs/src/lib/clipboard";
-import {
-  applyGuideCopyFeedback,
-  createGuideCodeCopyAttachment,
-  GUIDE_CHECK_ICON_SVG,
-  GUIDE_COPY_ICON_SVG,
-  GUIDE_COPY_RESET_MS,
-  guideCopyFeedback,
-  guideCopyIdleFeedback,
-  guideCopyIconSvg,
-} from "../apps/docs/src/lib/guide-code-copy";
+import { attachGuideCodeCopy, GUIDE_COPY_ICON_SVG } from "../apps/docs/src/lib/guide-code-copy";
 
-describe("guideCopyFeedback", () => {
-  test("copied feedback shows check icon, hidden status, and reset timer", () => {
-    expect(guideCopyFeedback("copied")).toEqual({
-      icon: "check",
-      buttonAriaLabel: "Copied",
-      statusText: "Copied.",
-      statusVisuallyHidden: true,
-      resetMs: GUIDE_COPY_RESET_MS,
-    });
-    expect(guideCopyIconSvg("check")).toBe(GUIDE_CHECK_ICON_SVG);
-  });
+/** Matches GUIDE_COPY_RESET_MS in guide-code-copy.ts (private). */
+const GUIDE_COPY_RESET_MS = 2000;
 
-  test("manual feedback keeps copy icon and visible status", () => {
-    expect(guideCopyFeedback("manual")).toEqual({
-      icon: "copy",
-      buttonAriaLabel: "Copy code",
-      statusText: MANUAL_COPY_STATUS,
-      statusVisuallyHidden: false,
-      resetMs: null,
-    });
-    expect(guideCopyIconSvg("copy")).toBe(GUIDE_COPY_ICON_SVG);
-  });
+type ClassList = {
+  add(token: string): void;
+  remove(token: string): void;
+  has(token: string): boolean;
+};
 
-  test("idle feedback restores copy control after successful-copy reset", () => {
-    expect(guideCopyIdleFeedback()).toEqual({
-      icon: "copy",
-      buttonAriaLabel: "Copy code",
-      statusText: "",
-      statusVisuallyHidden: true,
-      resetMs: null,
-    });
-  });
-});
+type FixtureButton = {
+  dataset: { copyCode: string };
+  innerHTML: string;
+  ariaLabel: string;
+  setAttribute(name: string, value: string): void;
+  closest(sel: string): FixtureButton | null;
+};
 
-describe("applyGuideCopyFeedback", () => {
-  test("writes icon, aria-label, status text, and visually-hidden class", () => {
-    const classes = new Set<string>();
-    const button = {
-      innerHTML: "",
-      setAttribute(_name: string, value: string) {
-        this.aria = value;
+type FixtureStatus = {
+  textContent: string;
+  classList: ClassList;
+};
+
+type FixtureCode = { textContent: string };
+type FixturePre = {
+  querySelector(sel: string): FixtureCode | null;
+};
+
+type FixtureDoc = {
+  querySelector(selector: string): FixturePre | FixtureStatus | null;
+};
+
+type FixtureRoot = {
+  ownerDocument: FixtureDoc;
+  contains(node: unknown): boolean;
+  addEventListener(type: string, handler: (event: MouseEvent) => void): void;
+  removeEventListener(type: string, handler: (event: MouseEvent) => void): void;
+  dispatchClick(target: FixtureButton): void;
+};
+
+/**
+ * Mount a single fence matching llms-markdown's `guide-code-copy` markup:
+ * button[data-copy-code] + pre#id > code + #id-status status span.
+ */
+function mountGuideCodeFence(
+  codeText: string,
+  id = "guide-code-1",
+): {
+  root: FixtureRoot;
+  button: FixtureButton;
+  status: FixtureStatus;
+  code: FixtureCode;
+} {
+  const code: FixtureCode = { textContent: codeText };
+  const pre: FixturePre = {
+    querySelector(sel: string) {
+      return sel === "code" ? code : null;
+    },
+  };
+  const statusClasses = new Set<string>(["visually-hidden"]);
+  const status: FixtureStatus = {
+    textContent: "",
+    classList: {
+      add(token: string) {
+        statusClasses.add(token);
       },
-      aria: "",
-    };
-    const status = {
-      textContent: "",
-      classList: {
-        add(token: string) {
-          classes.add(token);
-        },
-        remove(token: string) {
-          classes.delete(token);
-        },
+      remove(token: string) {
+        statusClasses.delete(token);
       },
-    };
+      has(token: string) {
+        return statusClasses.has(token);
+      },
+    },
+  };
+  const button: FixtureButton = {
+    dataset: { copyCode: id },
+    innerHTML: GUIDE_COPY_ICON_SVG,
+    ariaLabel: "Copy code",
+    setAttribute(name: string, value: string) {
+      if (name === "aria-label") this.ariaLabel = value;
+    },
+    closest(sel: string) {
+      return sel === "button[data-copy-code]" ? this : null;
+    },
+  };
+  const doc: FixtureDoc = {
+    querySelector(selector: string) {
+      if (selector === `#${id}`) return pre;
+      if (selector === `#${id}-status`) return status;
+      return null;
+    },
+  };
 
-    applyGuideCopyFeedback({ button, status }, guideCopyFeedback("copied"));
-    expect(button.innerHTML).toBe(GUIDE_CHECK_ICON_SVG);
-    expect(button.aria).toBe("Copied");
+  let clickHandler: ((event: MouseEvent) => void) | undefined;
+  const root: FixtureRoot = {
+    ownerDocument: doc,
+    contains() {
+      return true;
+    },
+    addEventListener(_type: string, handler: (event: MouseEvent) => void) {
+      clickHandler = handler;
+    },
+    removeEventListener() {
+      clickHandler = undefined;
+    },
+    dispatchClick(target: FixtureButton) {
+      if (clickHandler === undefined) throw new Error("no click listener attached");
+      clickHandler({ target } as unknown as MouseEvent);
+    },
+  };
+
+  return { root, button, status, code };
+}
+
+type PendingTimer = { id: number; fn: () => void; ms: number };
+
+function installTimerStubs(): {
+  pending: PendingTimer[];
+  restore: () => void;
+} {
+  const pending: PendingTimer[] = [];
+  let nextId = 1;
+  const realSetTimeout = globalThis.setTimeout;
+  const realClearTimeout = globalThis.clearTimeout;
+
+  globalThis.setTimeout = ((fn: TimerHandler, ms?: number) => {
+    const id = nextId++;
+    pending.push({ id, fn: fn as () => void, ms: ms ?? 0 });
+    return id as unknown as ReturnType<typeof setTimeout>;
+  }) as unknown as typeof setTimeout;
+
+  globalThis.clearTimeout = ((id: ReturnType<typeof setTimeout>) => {
+    const num = id as unknown as number;
+    const idx = pending.findIndex((t) => t.id === num);
+    if (idx >= 0) pending.splice(idx, 1);
+  }) as unknown as typeof clearTimeout;
+
+  return {
+    pending,
+    restore() {
+      globalThis.setTimeout = realSetTimeout;
+      globalThis.clearTimeout = realClearTimeout;
+    },
+  };
+}
+
+function installClipboardStub(mode: "copied" | "manual"): {
+  written: string[];
+  restore: () => void;
+} {
+  const written: string[] = [];
+  const previousNav = Object.getOwnPropertyDescriptor(globalThis, "navigator");
+  const previousWin = Object.getOwnPropertyDescriptor(globalThis, "window");
+  const previousDoc = Object.getOwnPropertyDescriptor(globalThis, "document");
+
+  const clipboard = {
+    writeText(text: string): Promise<void> {
+      if (mode === "manual") return Promise.reject(new Error("clipboard denied"));
+      written.push(text);
+      return Promise.resolve();
+    },
+  };
+
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: { clipboard },
+  });
+
+  // selectText (manual path) touches window.getSelection + document.createRange.
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      getSelection: () => ({
+        removeAllRanges() {},
+        addRange() {},
+      }),
+    },
+  });
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: {
+      createRange: () => ({
+        selectNodeContents() {},
+      }),
+    },
+  });
+
+  return {
+    written,
+    restore() {
+      if (previousNav === undefined) Reflect.deleteProperty(globalThis, "navigator");
+      else Object.defineProperty(globalThis, "navigator", previousNav);
+      if (previousWin === undefined) Reflect.deleteProperty(globalThis, "window");
+      else Object.defineProperty(globalThis, "window", previousWin);
+      if (previousDoc === undefined) Reflect.deleteProperty(globalThis, "document");
+      else Object.defineProperty(globalThis, "document", previousDoc);
+    },
+  };
+}
+
+/** Flush the fire-and-forget async click handler. */
+async function flushClick(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("attachGuideCodeCopy (DOM fixture)", () => {
+  let timers: ReturnType<typeof installTimerStubs>;
+  let clipboard: ReturnType<typeof installClipboardStub> | undefined;
+
+  beforeEach(() => {
+    timers = installTimerStubs();
+  });
+
+  afterEach(() => {
+    timers.restore();
+    clipboard?.restore();
+    clipboard = undefined;
+  });
+
+  test("click Copy swaps to check feedback, then reverts after reset timer", async () => {
+    clipboard = installClipboardStub("copied");
+    const { root, button, status, code } = mountGuideCodeFence('{"field":"weight"}');
+    const destroy = attachGuideCodeCopy(root as unknown as HTMLElement);
+
+    root.dispatchClick(button);
+    await flushClick();
+
+    expect(clipboard.written).toEqual([code.textContent]);
+    // Icon left the idle copy glyph (private check SVG is not exported).
+    expect(button.innerHTML).not.toBe(GUIDE_COPY_ICON_SVG);
+    expect(button.ariaLabel).toBe("Copied");
     expect(status.textContent).toBe("Copied.");
-    expect(classes.has("visually-hidden")).toBe(true);
+    expect(status.classList.has("visually-hidden")).toBe(true);
+    expect(timers.pending).toHaveLength(1);
+    expect(timers.pending[0]?.ms).toBe(GUIDE_COPY_RESET_MS);
 
-    applyGuideCopyFeedback({ button, status }, guideCopyFeedback("manual"));
+    // Fire the reset timer — control returns to idle copy state.
+    timers.pending[0]!.fn();
     expect(button.innerHTML).toBe(GUIDE_COPY_ICON_SVG);
-    expect(button.aria).toBe("Copy code");
-    expect(status.textContent).toBe(MANUAL_COPY_STATUS);
-    expect(classes.has("visually-hidden")).toBe(false);
-  });
-});
-
-describe("createGuideCodeCopyAttachment", () => {
-  test("copied path applies feedback, schedules reset, and destroy clears timer", async () => {
-    const timers = new Map<number, () => void>();
-    let nextId = 1;
-    let cleared: number[] = [];
-    const deps = {
-      copyText: () => Promise.resolve("copied" as const),
-      setTimeout: ((fn: () => void) => {
-        const id = nextId++;
-        timers.set(id, fn);
-        return id as unknown as ReturnType<typeof setTimeout>;
-      }) as typeof setTimeout,
-      clearTimeout: ((id: ReturnType<typeof setTimeout>) => {
-        cleared.push(id as unknown as number);
-        timers.delete(id as unknown as number);
-      }) as typeof clearTimeout,
-    };
-
-    const doc = {
-      querySelector(selector: string) {
-        if (selector === "#guide-code-1") return pre;
-        if (selector === "#guide-code-1-status") return status;
-        return null;
-      },
-    };
-    const code = { textContent: '{"field":"weight"}' };
-    const pre = {
-      querySelector(sel: string) {
-        return sel === "code" ? code : null;
-      },
-    };
-    const classes = new Set<string>(["visually-hidden"]);
-    const status = {
-      textContent: "",
-      classList: {
-        add(t: string) {
-          classes.add(t);
-        },
-        remove(t: string) {
-          classes.delete(t);
-        },
-      },
-    };
-    const button = {
-      dataset: { copyCode: "guide-code-1" },
-      innerHTML: GUIDE_COPY_ICON_SVG,
-      setAttribute(_n: string, v: string) {
-        this.aria = v;
-      },
-      aria: "Copy code",
-      closest(sel: string) {
-        return sel === "button[data-copy-code]" ? this : null;
-      },
-    };
-    let clickHandler: ((event: MouseEvent) => void) | undefined;
-    const node = {
-      ownerDocument: doc,
-      contains() {
-        return true;
-      },
-      addEventListener(_type: string, handler: (event: MouseEvent) => void) {
-        clickHandler = handler;
-      },
-      removeEventListener() {
-        clickHandler = undefined;
-      },
-    };
-
-    const destroy = createGuideCodeCopyAttachment(deps)(node as unknown as HTMLElement);
-    expect(clickHandler).toBeDefined();
-
-    clickHandler!({
-      target: button,
-    } as unknown as MouseEvent);
-    // Flush the fire-and-forget async handler.
-    await Promise.resolve();
-    await Promise.resolve();
-
-    expect(button.innerHTML).toBe(GUIDE_CHECK_ICON_SVG);
-    expect(button.aria).toBe("Copied");
-    expect(status.textContent).toBe("Copied.");
-    expect(classes.has("visually-hidden")).toBe(true);
-    expect(timers.size).toBe(1);
+    expect(button.ariaLabel).toBe("Copy code");
+    expect(status.textContent).toBe("");
+    expect(status.classList.has("visually-hidden")).toBe(true);
 
     destroy();
-    expect(cleared).toEqual([1]);
-    expect(timers.size).toBe(0);
   });
 
-  test("manual path leaves visible status and does not schedule reset", async () => {
-    const scheduled: number[] = [];
-    const deps = {
-      copyText: () => Promise.resolve("manual" as const),
-      setTimeout: ((_fn: () => void) => {
-        scheduled.push(1);
-        return 1 as unknown as ReturnType<typeof setTimeout>;
-      }) as typeof setTimeout,
-      clearTimeout: () => {},
-    };
+  test("clipboard failure keeps copy icon and shows manual status (no reset timer)", async () => {
+    clipboard = installClipboardStub("manual");
+    const { root, button, status } = mountGuideCodeFence("npm install", "guide-code-2");
+    attachGuideCodeCopy(root as unknown as HTMLElement);
 
-    const code = { textContent: "npm install" };
-    const pre = {
-      querySelector(sel: string) {
-        return sel === "code" ? code : null;
-      },
-    };
-    const classes = new Set<string>(["visually-hidden"]);
-    const status = {
-      textContent: "",
-      classList: {
-        add(t: string) {
-          classes.add(t);
-        },
-        remove(t: string) {
-          classes.delete(t);
-        },
-      },
-    };
-    const button = {
-      dataset: { copyCode: "guide-code-2" },
-      innerHTML: GUIDE_COPY_ICON_SVG,
-      setAttribute(_n: string, v: string) {
-        this.aria = v;
-      },
-      aria: "Copy code",
-      closest(sel: string) {
-        return sel === "button[data-copy-code]" ? this : null;
-      },
-    };
-    const doc = {
-      querySelector(selector: string) {
-        if (selector === "#guide-code-2") return pre;
-        if (selector === "#guide-code-2-status") return status;
-        return null;
-      },
-    };
-    let clickHandler: ((event: MouseEvent) => void) | undefined;
-    const node = {
-      ownerDocument: doc,
-      contains() {
-        return true;
-      },
-      addEventListener(_type: string, handler: (event: MouseEvent) => void) {
-        clickHandler = handler;
-      },
-      removeEventListener() {},
-    };
-
-    createGuideCodeCopyAttachment(deps)(node as unknown as HTMLElement);
-    clickHandler!({ target: button } as unknown as MouseEvent);
-    await Promise.resolve();
-    await Promise.resolve();
+    root.dispatchClick(button);
+    await flushClick();
 
     expect(button.innerHTML).toBe(GUIDE_COPY_ICON_SVG);
-    expect(button.aria).toBe("Copy code");
+    expect(button.ariaLabel).toBe("Copy code");
     expect(status.textContent).toBe(MANUAL_COPY_STATUS);
-    expect(classes.has("visually-hidden")).toBe(false);
-    expect(scheduled).toEqual([]);
+    expect(status.classList.has("visually-hidden")).toBe(false);
+    expect(timers.pending).toEqual([]);
+  });
+
+  test("destroy clears a pending reset timer so idle feedback never fires late", async () => {
+    clipboard = installClipboardStub("copied");
+    const { root, button, status } = mountGuideCodeFence("x = 1");
+    const destroy = attachGuideCodeCopy(root as unknown as HTMLElement);
+
+    root.dispatchClick(button);
+    await flushClick();
+    expect(button.ariaLabel).toBe("Copied");
+    expect(timers.pending).toHaveLength(1);
+
+    destroy();
+    expect(timers.pending).toHaveLength(0);
+    // Status remains at the post-copy state; destroy only cancels the timer.
+    expect(status.textContent).toBe("Copied.");
   });
 });


### PR DESCRIPTION
## Summary

- Closes #989: export only `GUIDE_COPY_ICON_SVG` and `attachGuideCodeCopy` from `guide-code-copy.ts`; the other ten symbols become module-private.
- Rewrite `scripts/guide-code-copy.test.ts` to drive the public attachment against a DOM fixture shaped like llms-markdown fence HTML (click Copy → feedback → reset timer; manual path when clipboard fails; destroy clears timers).
- Cheap fold-in: unexport the three `HOME_CODE_PATH_*` string constants so only `HOME_CODE_PATH_TABS` is public. Left `playground-output-types.ts` alone (shared type barrel used by multiple modules).

## Validation

- Confirmed only two external consumers of guide-code-copy: `attachGuideCodeCopy` in guide page, `GUIDE_COPY_ICON_SVG` in `llms-markdown.ts`.
- Confirmed home page only imports `HOME_CODE_PATH_TABS`.

## Test plan

- [x] `bun test scripts/guide-code-copy.test.ts` (3 pass)
- [x] `tsc -p scripts` has no errors in the changed files
- [ ] CI green
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1005" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->