### PR TITLE
perf(core): O(E) contour polyline stitch without Array.unshift (#977)

### DIFF
--- a/.changeset/977-contour-stitch-linear.md
+++ b/.changeset/977-contour-stitch-linear.md
@@ -1,0 +1,11 @@
+---
+"@ggsvelte/core": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+perf(core): O(E) contour polyline stitch (no Array.unshift)
+
+Backward isoline extend used `chain.unshift` per edge and re-filtered
+adjacency for degree-1 seeds. Push into a prefix + reverse once, and keep
+remaining degrees + an endpoint-edge stack so stitch is linear in edge count.

--- a/packages/core/src/stats/contour.ts
+++ b/packages/core/src/stats/contour.ts
@@ -209,7 +209,7 @@ function gridCellSegments(
   return segs;
 }
 
-/** Stitch undirected segments into polylines (open or closed). */
+/** Stitch undirected segments into polylines (open or closed). O(E) total. */
 export function stitchSegments(segments: Array<[Pt, Pt]>): Pt[][] {
   if (segments.length === 0) return [];
   type Edge = { a: string; b: string; pa: Pt; pb: Pt; used: boolean };
@@ -221,30 +221,66 @@ export function stitchSegments(segments: Array<[Pt, Pt]>): Pt[][] {
     used: false,
   }));
   const adj = new Map<string, number[]>();
+  const remDeg = new Map<string, number>();
   for (let i = 0; i < edges.length; i++) {
     const e = edges[i]!;
     if (!adj.has(e.a)) adj.set(e.a, []);
     if (!adj.has(e.b)) adj.set(e.b, []);
     adj.get(e.a)!.push(i);
     adj.get(e.b)!.push(i);
+    remDeg.set(e.a, (remDeg.get(e.a) ?? 0) + 1);
+    remDeg.set(e.b, (remDeg.get(e.b) ?? 0) + 1);
   }
 
-  const polylines: Pt[][] = [];
-  for (let start = 0; start < edges.length; start++) {
-    if (edges[start]!.used) continue;
-    // Prefer starting at an endpoint (degree 1).
-    let seed = start;
-    for (let i = start; i < edges.length; i++) {
-      if (edges[i]!.used) continue;
-      const da = adj.get(edges[i]!.a)?.filter((j) => !edges[j]!.used).length ?? 0;
-      const db = adj.get(edges[i]!.b)?.filter((j) => !edges[j]!.used).length ?? 0;
-      if (da === 1 || db === 1) {
-        seed = i;
-        break;
+  // Prefer degree-1 seeds without O(E) unused-edge rescans: maintain a stack of
+  // edges that currently touch a remaining-degree-1 vertex (#977).
+  const open: number[] = [];
+  const inOpen = new Uint8Array(edges.length);
+  const enqueueIfEndpoint = (ei: number): void => {
+    if (edges[ei]!.used || inOpen[ei] === 1) return;
+    const e = edges[ei]!;
+    if ((remDeg.get(e.a) ?? 0) === 1 || (remDeg.get(e.b) ?? 0) === 1) {
+      open.push(ei);
+      inOpen[ei] = 1;
+    }
+  };
+  for (let i = 0; i < edges.length; i++) enqueueIfEndpoint(i);
+
+  const markUsed = (ei: number): void => {
+    const e = edges[ei]!;
+    if (e.used) return;
+    e.used = true;
+    for (const v of [e.a, e.b] as const) {
+      const d = (remDeg.get(v) ?? 0) - 1;
+      remDeg.set(v, d);
+      if (d === 1) {
+        for (const nei of adj.get(v) ?? []) {
+          if (!edges[nei]!.used) enqueueIfEndpoint(nei);
+        }
       }
     }
+  };
+
+  let scan = 0;
+  const nextSeed = (): number => {
+    while (open.length > 0) {
+      const ei = open.pop()!;
+      inOpen[ei] = 0;
+      if (!edges[ei]!.used) return ei;
+    }
+    while (scan < edges.length && edges[scan]!.used) scan++;
+    return scan < edges.length ? scan : -1;
+  };
+
+  const polylines: Pt[][] = [];
+  for (;;) {
+    const seed = nextSeed();
+    if (seed < 0) break;
     const e0 = edges[seed]!;
-    e0.used = true;
+    markUsed(seed);
+    // prefix collects the backward walk with push; reverse once at the end
+    // instead of chain.unshift per edge (O(E²) → O(E)).
+    const prefix: Pt[] = [];
     const chain: Pt[] = [e0.pa, e0.pb];
     // Extend forward from pb
     let head = e0.b;
@@ -253,7 +289,7 @@ export function stitchSegments(segments: Array<[Pt, Pt]>): Pt[][] {
       const cand = (adj.get(head) ?? []).find((j) => !edges[j]!.used);
       if (cand === undefined) break;
       const e = edges[cand]!;
-      e.used = true;
+      markUsed(cand);
       if (e.a === head) {
         chain.push(e.pb);
         head = e.b;
@@ -269,16 +305,18 @@ export function stitchSegments(segments: Array<[Pt, Pt]>): Pt[][] {
       const cand = (adj.get(tail) ?? []).find((j) => !edges[j]!.used);
       if (cand === undefined) break;
       const e = edges[cand]!;
-      e.used = true;
+      markUsed(cand);
       if (e.a === tail) {
-        chain.unshift(e.pb);
+        prefix.push(e.pb);
         tail = e.b;
       } else {
-        chain.unshift(e.pa);
+        prefix.push(e.pa);
         tail = e.a;
       }
     }
-    if (chain.length >= 2) polylines.push(chain);
+    prefix.reverse();
+    const poly = prefix.length === 0 ? chain : prefix.concat(chain);
+    if (poly.length >= 2) polylines.push(poly);
   }
   return polylines;
 }

--- a/packages/core/tests/stats-contour.test.ts
+++ b/packages/core/tests/stats-contour.test.ts
@@ -1,7 +1,7 @@
 /**
  * Pure stat_contour marching-squares isolines (#801).
  */
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, spyOn } from "bun:test";
 
 import { cellSegments, contourLevels, stitchSegments, statContour } from "../src/stats/contour.ts";
 
@@ -53,6 +53,91 @@ describe("stitchSegments", () => {
     ]);
     expect(lines.length).toBe(1);
     expect(lines[0]!.length).toBe(3);
+  });
+
+  it("extends both directions into one polyline", () => {
+    // Middle segment first so seed may start mid-chain; must still stitch ends.
+    const lines = stitchSegments([
+      [
+        { x: 1, y: 0 },
+        { x: 2, y: 0 },
+      ],
+      [
+        { x: 0, y: 0 },
+        { x: 1, y: 0 },
+      ],
+      [
+        { x: 2, y: 0 },
+        { x: 3, y: 0 },
+      ],
+    ]);
+    expect(lines.length).toBe(1);
+    const xs = lines[0]!.map((p) => p.x).toSorted((a, b) => a - b);
+    expect(xs).toEqual([0, 1, 2, 3]);
+  });
+
+  it("closes a square loop as one polyline", () => {
+    const lines = stitchSegments([
+      [
+        { x: 0, y: 0 },
+        { x: 1, y: 0 },
+      ],
+      [
+        { x: 1, y: 0 },
+        { x: 1, y: 1 },
+      ],
+      [
+        { x: 1, y: 1 },
+        { x: 0, y: 1 },
+      ],
+      [
+        { x: 0, y: 1 },
+        { x: 0, y: 0 },
+      ],
+    ]);
+    expect(lines.length).toBe(1);
+    // Closed loop: 4 edges → 5 vertices when first point is repeated, or 4 without.
+    // Current stitch emits chain length = edges+1 for open; for closed, head meets tail.
+    expect(lines[0]!.length).toBeGreaterThanOrEqual(4);
+    expect(lines[0]!.length).toBeLessThanOrEqual(5);
+  });
+
+  it("keeps multi-component isolines separate", () => {
+    const lines = stitchSegments([
+      [
+        { x: 0, y: 0 },
+        { x: 1, y: 0 },
+      ],
+      [
+        { x: 10, y: 0 },
+        { x: 11, y: 0 },
+      ],
+    ]);
+    expect(lines.length).toBe(2);
+    expect(lines.every((line) => line.length === 2)).toBe(true);
+  });
+
+  it("does not Array.unshift while stitching a long open chain (issue #977)", () => {
+    // Pre-fix: seeding at the high end of an open chain walks backward with
+    // chain.unshift per edge → O(E²) copies. Reverse edge order surfaces that.
+    const n = 2_000;
+    const segments: Array<[{ x: number; y: number }, { x: number; y: number }]> = [];
+    for (let i = 0; i < n; i++) {
+      segments.push([
+        { x: i, y: 0 },
+        { x: i + 1, y: 0 },
+      ]);
+    }
+    segments.reverse();
+    const unshiftSpy = spyOn(Array.prototype, "unshift");
+    try {
+      const lines = stitchSegments(segments);
+      expect(lines.length).toBe(1);
+      expect(lines[0]!.length).toBe(n + 1);
+      expect(unshiftSpy).not.toHaveBeenCalled();
+    } finally {
+      unshiftSpy.mockRestore();
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes #977.

`stitchSegments` grew open isolines with `chain.unshift` on the backward walk (O(E²) copies when the seed faces the long direction) and re-scanned remaining edges with `adj.filter(!used)` when picking degree-1 seeds.

- Backward walk: `prefix.push` + one `reverse` + `concat` (O(E))
- Seeds: remaining-degree map + stack of edges that touch degree-1 vertices (no per-component unused-edge rescan)

## Test plan

- [x] RED→GREEN: reverse-order 2000-edge open chain — unshift not called; length n+1
- [x] Characterization: both directions, closed square, multi-component
- [x] `bun test packages/core/tests/stats-contour.test.ts packages/core/tests/pipeline-m2/contour.test.ts packages/core/tests/pipeline-m2/density-2d*`

## Follow-ups

None.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1006" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->