### PR TITLE
perf(core): memoize geom_map join index across facet panels (#910)

### DIFF
--- a/.changeset/910-map-join-memo.md
+++ b/.changeset/910-map-join-memo.md
@@ -1,0 +1,11 @@
+---
+"@ggsvelte/core": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+perf(core): memoize geom_map join index across facet panels
+
+Fortified map table + byKey index are built once per LayerBinding (WeakMap)
+instead of once per panel. `map-region-missing` is also emitted at most once
+per layer per run.

--- a/packages/core/src/pipeline/frame-stats-map.ts
+++ b/packages/core/src/pipeline/frame-stats-map.ts
@@ -4,6 +4,9 @@
  * Values table (layer data) carries map_id + styles (fill/color/...).
  * Map table (params.map) carries coordinates (long/lat or x/y) + join key
  * (params.mapId default "region", then "id") and optional multipoly `group`.
+ *
+ * Fortified map table + byKey index are memoized per LayerBinding for the run
+ * so faceted panels do not rebuild the map join (#910).
  */
 import type { DataRef, PortableSpec } from "@ggsvelte/spec";
 
@@ -15,6 +18,19 @@ import type { LayerBinding, LayerFrame, PipelineWarning } from "./types.js";
 import { PipelineError } from "./types.js";
 
 type Datasets = PortableSpec["datasets"];
+
+/** Fortified map join index shared across facet panels for one map layer. */
+export type MapJoinIndex = {
+  readonly mapX: readonly CellValue[];
+  readonly mapY: readonly CellValue[];
+  readonly mapGroups: readonly CellValue[] | null;
+  readonly byKey: ReadonlyMap<string, readonly number[]>;
+  /** Emit map-region-missing at most once per layer per run. */
+  missingWarned: boolean;
+};
+
+/** Run-scoped cache: LayerBinding lives for one pipeline run only. */
+const mapJoinByBinding = new WeakMap<LayerBinding, MapJoinIndex>();
 
 function tableFromDataRef(ref: DataRef, datasets: Datasets | undefined, path: string): ColumnTable {
   if ("values" in ref) return ColumnTable.fromRows(ref.values);
@@ -73,13 +89,17 @@ function styleColumn(
   return valueRows.map((row) => col[row]!);
 }
 
-export function buildMapFrame(
+/**
+ * Resolve (or build once) the fortified map table + join index for a layer.
+ * Exported for unit tests that assert once-per-binding memoization (#910).
+ */
+export function resolveMapJoinIndex(
   binding: LayerBinding,
-  table: ColumnTable,
-  groups: readonly number[],
-  warnings: PipelineWarning[],
-  datasets?: Datasets,
-): LayerFrame {
+  datasets: Datasets | undefined,
+): MapJoinIndex {
+  const cached = mapJoinByBinding.get(binding);
+  if (cached !== undefined) return cached;
+
   const { layer, index } = binding;
   const params = (layer.params ?? {}) as {
     map?: DataRef;
@@ -90,14 +110,6 @@ export function buildMapFrame(
       "map-data-required",
       `/layers/${index}/params/map`,
       "geom_map requires params.map (a DataRef: { values }, { columns }, or { name }).",
-    );
-  }
-  const mapIdField = binding.mapIdField;
-  if (mapIdField === null) {
-    throw new PipelineError(
-      "missing-channel",
-      `/layers/${index}/aes/map_id`,
-      'The map geom requires a "map_id" channel joining value rows to the map.',
     );
   }
 
@@ -120,6 +132,37 @@ export function buildMapFrame(
     }
     list.push(i);
   }
+
+  const joinIndex: MapJoinIndex = {
+    mapX,
+    mapY,
+    mapGroups,
+    byKey,
+    missingWarned: false,
+  };
+  mapJoinByBinding.set(binding, joinIndex);
+  return joinIndex;
+}
+
+export function buildMapFrame(
+  binding: LayerBinding,
+  table: ColumnTable,
+  groups: readonly number[],
+  warnings: PipelineWarning[],
+  datasets?: Datasets,
+): LayerFrame {
+  const { index } = binding;
+  const mapIdField = binding.mapIdField;
+  if (mapIdField === null) {
+    throw new PipelineError(
+      "missing-channel",
+      `/layers/${index}/aes/map_id`,
+      'The map geom requires a "map_id" channel joining value rows to the map.',
+    );
+  }
+
+  const join = resolveMapJoinIndex(binding, datasets);
+  const { mapX, mapY, mapGroups, byKey } = join;
 
   const valueIds = table.column(mapIdField);
   const outX: number[] = [];
@@ -171,7 +214,8 @@ export function buildMapFrame(
     }
   }
 
-  if (missing > 0) {
+  if (missing > 0 && !join.missingWarned) {
+    join.missingWarned = true;
     warnings.push({
       code: "map-region-missing",
       message: `Layer ${index} (map): ${missing} value row(s) had no matching map region and were dropped.`,

--- a/packages/core/tests/pipeline-m2/geom-map.test.ts
+++ b/packages/core/tests/pipeline-m2/geom-map.test.ts
@@ -1,10 +1,10 @@
 /**
  * M2 pipeline — geom_map fortified region join (#808).
  */
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, spyOn } from "bun:test";
 import { aes, gg } from "@ggsvelte/spec";
 import { PipelineError, runPipeline } from "../../src/pipeline.ts";
-import { buildMapFrame } from "../../src/pipeline/frame-stats-map.ts";
+import { buildMapFrame, resolveMapJoinIndex } from "../../src/pipeline/frame-stats-map.ts";
 import type { PathsBatch } from "../../src/scene.ts";
 import { ColumnTable } from "../../src/table.ts";
 
@@ -244,5 +244,66 @@ describe("geom_map", () => {
         size,
       ),
     ).toThrow(/map-id-column-missing|zone_typo/);
+  });
+
+  it("memoizes fortified map table + byKey once per layer across facet panels (#910)", () => {
+    // Pre-fix: buildMapFrame called ColumnTable.fromColumns(map) once per panel.
+    const fromColumns = spyOn(ColumnTable, "fromColumns");
+    try {
+      const model = runPipeline(
+        gg(
+          {
+            state: ["A", "B", "A", "B"],
+            rate: [10, 20, 11, 21],
+            panel: ["p1", "p1", "p2", "p2"],
+          },
+          aes({ map_id: "state", fill: "rate" }),
+        )
+          .geomMap({ map: { columns: fortified } })
+          .facet({ wrap: "panel" })
+          .spec(),
+        size,
+      );
+      expect(model.scene.panels.length).toBe(2);
+      // Two region paths total still materialise across panels.
+      const batch = pathBatch(model);
+      expect(batch.pathOffsets.length - 1).toBeGreaterThanOrEqual(2);
+      const mapBuilds = fromColumns.mock.calls.filter((args) => args[0] === fortified).length;
+      expect(mapBuilds).toBe(1);
+    } finally {
+      fromColumns.mockRestore();
+    }
+  });
+
+  it("emits map-region-missing at most once per layer under facets (#910)", () => {
+    const model = runPipeline(
+      gg(
+        {
+          state: ["A", "missing", "B", "also-missing"],
+          rate: [10, 1, 20, 2],
+          panel: ["p1", "p1", "p2", "p2"],
+        },
+        aes({ map_id: "state", fill: "rate" }),
+      )
+        .geomMap({ map: { columns: fortified } })
+        .facet({ wrap: "panel" })
+        .spec(),
+      size,
+    );
+    expect(model.scene.panels.length).toBe(2);
+    const missing = model.warnings.filter((w) => w.code === "map-region-missing");
+    expect(missing).toHaveLength(1);
+  });
+
+  it("resolveMapJoinIndex returns the same object for the same binding", () => {
+    const binding = {
+      layer: { geom: "map", params: { map: { columns: fortified } } },
+      index: 0,
+      mapIdField: "state",
+    } as never;
+    const a = resolveMapJoinIndex(binding);
+    const b = resolveMapJoinIndex(binding);
+    expect(a).toBe(b);
+    expect(a.byKey.get("A")?.length).toBe(3);
   });
 });


### PR DESCRIPTION
## Summary

Fixes #910.

`buildMapFrame` rebuilt `params.map` → ColumnTable and the `byKey` join index on every facet panel because `buildFrame` runs per panel. Map data does not change across panels for a layer.

- Extract `resolveMapJoinIndex` with a run-scoped `WeakMap<LayerBinding, MapJoinIndex>`
- Emit `map-region-missing` at most once per layer (`missingWarned` on the cached index)

## Test plan

- [x] Faceted map: `ColumnTable.fromColumns(fortified)` called once (not once per panel)
- [x] Faceted map with missing regions: one `map-region-missing` warning
- [x] `resolveMapJoinIndex` identity for the same binding
- [x] Existing geom_map suite (15 tests)

## Follow-ups

None.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1009" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->