### PR TITLE
fix(docs): enforce UiButton radius/shadow at source (#696)

### DIFF
--- a/apps/docs/src/lib/Playground.svelte
+++ b/apps/docs/src/lib/Playground.svelte
@@ -431,12 +431,6 @@
     padding-block: 1rem 2.5rem;
   }
 
-  /* Playground spec: max 4px radius, no decorative shadow (DESIGN.md). */
-  .playground :global(.ui-button) {
-    border-radius: 4px;
-    box-shadow: none;
-  }
-
   .playground-intro {
     margin-bottom: 1.5rem;
   }

--- a/apps/docs/src/lib/components/UiButton.svelte
+++ b/apps/docs/src/lib/components/UiButton.svelte
@@ -45,17 +45,17 @@
     justify-content: center;
     gap: 0.4rem;
     border: 1px solid transparent;
-    border-radius: 0.5rem;
+    border-radius: var(--radius);
     padding: 0.5rem 0.9rem;
     font: 600 0.875rem/1.2 var(--body-font);
     letter-spacing: -0.01em;
     text-decoration: none;
     cursor: pointer;
+    box-shadow: none;
     transition:
       background-color 120ms ease,
       border-color 120ms ease,
       color 120ms ease,
-      box-shadow 120ms ease,
       opacity 120ms ease;
   }
 
@@ -75,7 +75,6 @@
     border-color: var(--accent);
     background: var(--accent);
     color: #fff;
-    box-shadow: 0 1px 0 color-mix(in srgb, var(--ink) 12%, transparent);
   }
 
   :global(
@@ -89,7 +88,6 @@
     border-color: var(--line);
     background: var(--paper);
     color: var(--ink);
-    box-shadow: 0 1px 0 color-mix(in srgb, var(--ink) 4%, transparent);
   }
 
   :global(
@@ -103,7 +101,6 @@
     border-color: transparent;
     background: transparent;
     color: var(--ink);
-    box-shadow: none;
   }
 
   :global(.ui-button--ghost:hover:not(:disabled):not([aria-disabled="true"])) {

--- a/scripts/uibutton-design-tokens.test.ts
+++ b/scripts/uibutton-design-tokens.test.ts
@@ -1,0 +1,44 @@
+/**
+ * UiButton must honor DESIGN.md at source (issue #696):
+ * - corner radius is the shared --radius token (4px host controls), not 0.5rem
+ * - no decorative default box-shadows (DESIGN.md rejects heavy default shadows)
+ * - playground must not patch those properties; compliance is source-level
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "bun:test";
+
+const ROOT = join(import.meta.dir, "..");
+const UIBUTTON = join(ROOT, "apps/docs/src/lib/components/UiButton.svelte");
+const PLAYGROUND = join(ROOT, "apps/docs/src/lib/Playground.svelte");
+const TOKENS = join(ROOT, "apps/docs/src/styles/tokens.css");
+
+describe("UiButton DESIGN.md radius and shadow (#696)", () => {
+  const button = readFileSync(UIBUTTON, "utf8");
+  const playground = readFileSync(PLAYGROUND, "utf8");
+  const tokens = readFileSync(TOKENS, "utf8");
+
+  it("tokens define --radius as 4px for ordinary host controls", () => {
+    expect(tokens).toMatch(/--radius\s*:\s*4px\b/);
+  });
+
+  it("uses var(--radius) instead of a hard-coded 0.5rem (8px) radius", () => {
+    expect(button).toMatch(/border-radius\s*:\s*var\(--radius\)/);
+    expect(button).not.toMatch(/border-radius\s*:\s*0\.5rem/);
+  });
+
+  it("does not ship decorative default box-shadows on primary or secondary", () => {
+    // Ghost may still set box-shadow: none; any non-none shadow is a DESIGN.md miss.
+    const shadowDecls = [...button.matchAll(/box-shadow\s*:\s*([^;]+);/g)].map((m) => m[1]!.trim());
+    expect(shadowDecls.length).toBeGreaterThan(0);
+    for (const value of shadowDecls) {
+      expect(value).toBe("none");
+    }
+  });
+
+  it("playground does not page-patch .ui-button radius or shadow", () => {
+    expect(playground).not.toMatch(/\.playground\s+:global\(\.ui-button\)\s*\{[^}]*border-radius/s);
+    expect(playground).not.toMatch(/\.playground\s+:global\(\.ui-button\)\s*\{[^}]*box-shadow/s);
+  });
+});


### PR DESCRIPTION
## Summary

- Point 1 of #696: `UiButton` ships DESIGN.md-compliant radius and no decorative shadows at source.
- `border-radius: var(--radius)` (4px host controls) instead of `0.5rem`.
- Drop primary/secondary decorative `box-shadow`s; base rule is `box-shadow: none`.
- Delete the playground page-scoped `.ui-button` patch that was papering over the component.

## Test plan

- [x] `bun test scripts/uibutton-design-tokens.test.ts` (source contract for radius, shadows, no playground override)
- [ ] CI green
- [ ] Visual smoke of docs buttons outside playground (site nav/CTAs) if CI screenshots differ

Closes part of #696 (UiButton item). Follow-up PR: code-surface unification.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1011" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->