### PR TITLE
fix(docs): unify code-surface treatment across four sites (#696)

### DIFF
--- a/apps/docs/src/lib/CodeTabs.svelte
+++ b/apps/docs/src/lib/CodeTabs.svelte
@@ -117,7 +117,7 @@
   >
     <!-- svelte-ignore a11y_no_noninteractive_tabindex (scrollable code must be keyboard reachable) -->
     <div
-      class="scroll-region"
+      class="scroll-region code-surface"
       role="region"
       aria-label="Code example"
       tabindex="0"
@@ -193,27 +193,22 @@
 
   .scroll-region {
     max-width: 100%;
-    overflow-x: auto;
-    background: var(--code-paper);
-    color: var(--code-ink);
   }
 
   .scroll-region :global(pre.hljs),
   .scroll-region :global(pre) {
     min-width: max-content;
     margin: 0;
-    padding: 1rem;
+    padding: 0;
     background: transparent !important;
     color: inherit;
-    font-family: var(--code-font);
-    font-size: 0.8rem;
-    line-height: 1.5;
+    font: inherit;
   }
 
   .scroll-region :global(code.hljs),
   .scroll-region :global(code) {
     background: transparent !important;
-    font-family: inherit;
+    font: inherit;
   }
 
   @media (max-width: 35rem) {

--- a/apps/docs/src/lib/CodeTabs.svelte
+++ b/apps/docs/src/lib/CodeTabs.svelte
@@ -191,15 +191,21 @@
     background: color-mix(in srgb, var(--accent) 12%, transparent);
   }
 
+  /*
+   * code-surface puts padding on the box; here the box is the scrollport.
+   * Keep padding on the scrollable pre so inline-end gap survives horizontal
+   * scroll (Blink/WebKit drop scrollport padding at the end of overflow).
+   */
   .scroll-region {
     max-width: 100%;
+    padding: 0;
   }
 
   .scroll-region :global(pre.hljs),
   .scroll-region :global(pre) {
     min-width: max-content;
     margin: 0;
-    padding: 0;
+    padding: 1rem;
     background: transparent !important;
     color: inherit;
     font: inherit;

--- a/apps/docs/src/lib/components/PlaygroundEvents.svelte
+++ b/apps/docs/src/lib/components/PlaygroundEvents.svelte
@@ -65,7 +65,8 @@
               <span>#{entry.sequence} · {entry.source}</span>
             </header>
             <!-- svelte-ignore a11y_no_noninteractive_tabindex (event JSON is scrollable) -->
-            <pre tabindex="0"><code>{entry.json}</code></pre>
+            <pre class="code-surface" tabindex="0"><code>{entry.json}</code
+              ></pre>
           </li>
         {/each}
       </ol>
@@ -149,11 +150,6 @@
   pre {
     max-height: 16rem;
     margin: 0.45rem 0 0;
-    overflow: auto;
-    padding: 0.65rem;
-    background: var(--code-paper);
-    color: var(--code-ink);
-    font: 0.7rem/1.5 var(--code-font);
   }
 
   @media (max-width: 44.99rem) {

--- a/apps/docs/src/lib/components/PlaygroundPrompt.svelte
+++ b/apps/docs/src/lib/components/PlaygroundPrompt.svelte
@@ -120,7 +120,9 @@
       {#if failure.details !== undefined && failure.details.length > 0}
         <details bind:open={detailsOpen} class="details">
           <summary>Details</summary>
-          <pre class="details-pre">{formatDetails(failure.details)}</pre>
+          <pre class="details-pre code-surface">{formatDetails(
+              failure.details,
+            )}</pre>
         </details>
       {/if}
       <p class="next-action">
@@ -265,13 +267,7 @@
 
   .details-pre {
     max-height: 12rem;
-    overflow: auto;
     margin: 0.35rem 0 0;
-    padding: 0.65rem;
-    background: var(--code-paper);
-    color: var(--code-ink);
-    font: 0.75rem/1.45 var(--code-font);
-    border-radius: 4px;
     white-space: pre-wrap;
   }
 

--- a/apps/docs/src/styles/base.css
+++ b/apps/docs/src/styles/base.css
@@ -165,14 +165,25 @@ pre {
   max-width: 44rem;
 }
 
+/*
+ * Shared host code surface (#696): one radius/type/padding for docs pre
+ * blocks. Call sites: .prose pre, PlaygroundEvents, PlaygroundPrompt,
+ * CodeTabs. Layout-only extras (max-height, margin, white-space) stay local.
+ */
+.code-surface,
 .prose pre {
   overflow-x: auto;
-  margin: 1.5rem 0;
   padding: 1rem;
-  border-radius: 3px;
+  border-radius: var(--radius);
   background: var(--code-paper);
   color: var(--code-ink);
-  line-height: 1.55;
+  font-family: var(--code-font);
+  font-size: 0.8rem;
+  line-height: 1.5;
+}
+
+.prose pre {
+  margin: 1.5rem 0;
 }
 
 /* highlight.js / svelte-highlight: keep our dark code surface, keep theme tokens */

--- a/scripts/code-surface-design-tokens.test.ts
+++ b/scripts/code-surface-design-tokens.test.ts
@@ -41,7 +41,7 @@ describe("shared .code-surface in base.css (#696)", () => {
     for (const prop of SURFACE_PROPS) {
       expect(base).toMatch(
         new RegExp(
-          `\\.code-surface[^{]*\\{[^}]*${prop.replace(/[()]/g, "\\$&").replace(/: /, "\\s*:\\s*")}`,
+          `\\.code-surface[^{]*\\{[^}]*${prop.replaceAll(/[()]/g, "\\$&").replaceAll(": ", "\\s*:\\s*")}`,
           "s",
         ),
       );

--- a/scripts/code-surface-design-tokens.test.ts
+++ b/scripts/code-surface-design-tokens.test.ts
@@ -84,8 +84,12 @@ describe("four code-block call sites use .code-surface (#696)", () => {
   it("CodeTabs scroll region applies code-surface and inherits type from it", () => {
     expect(tabs).toMatch(/class="[^"]*\bcode-surface\b[^"]*"/);
     const css = styleBlock(tabs);
-    // No private font-size / padding restatement that re-forks the surface.
+    // Surface type/ink come from .code-surface; do not re-fork font-size or paper.
     expect(css).not.toMatch(/font-size\s*:\s*0\.8rem/);
     expect(css).not.toMatch(/\.scroll-region[^{]*\{[^}]*background\s*:\s*var\(--code-paper\)/s);
+    // Padding must live on the scrollable pre (not only the scrollport) so
+    // inline-end gap survives horizontal scroll of wide samples.
+    expect(css).toMatch(/\.scroll-region[^{]*\{[^}]*padding\s*:\s*0\b/s);
+    expect(css).toMatch(/pre[^{]*\{[^}]*padding\s*:\s*1rem/s);
   });
 });

--- a/scripts/code-surface-design-tokens.test.ts
+++ b/scripts/code-surface-design-tokens.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Shared docs code-surface treatment (issue #696 point 2).
+ *
+ * Four call sites used to diverge on radius (0/3px/4px), font-size
+ * (0.7/0.75/0.8rem), padding (0.65rem/1rem), and line-height (1.45/1.5/1.55).
+ * One `.code-surface` rule in base.css is the source of truth; the four sites
+ * must use it instead of re-stating surface tokens.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "bun:test";
+
+const ROOT = join(import.meta.dir, "..");
+const BASE = join(ROOT, "apps/docs/src/styles/base.css");
+const EVENTS = join(ROOT, "apps/docs/src/lib/components/PlaygroundEvents.svelte");
+const PROMPT = join(ROOT, "apps/docs/src/lib/components/PlaygroundPrompt.svelte");
+const TABS = join(ROOT, "apps/docs/src/lib/CodeTabs.svelte");
+
+const SURFACE_PROPS = [
+  "border-radius: var(--radius)",
+  "padding: 1rem",
+  "font-size: 0.8rem",
+  "line-height: 1.5",
+  "background: var(--code-paper)",
+  "color: var(--code-ink)",
+  "font-family: var(--code-font)",
+] as const;
+
+function styleBlock(source: string): string {
+  const match = source.match(/<style[^>]*>([\s\S]*?)<\/style>/);
+  return match?.[1] ?? "";
+}
+
+describe("shared .code-surface in base.css (#696)", () => {
+  const base = readFileSync(BASE, "utf8");
+
+  it("defines .code-surface with the canonical host code tokens", () => {
+    // Selector group must include .code-surface so all four sites share one rule.
+    expect(base).toMatch(/\.code-surface\b/);
+    for (const prop of SURFACE_PROPS) {
+      expect(base).toMatch(
+        new RegExp(
+          `\\.code-surface[^{]*\\{[^}]*${prop.replace(/[()]/g, "\\$&").replace(/: /, "\\s*:\\s*")}`,
+          "s",
+        ),
+      );
+    }
+  });
+
+  it("styles .prose pre via the shared surface (not a one-off 3px radius)", () => {
+    // .prose pre must be co-selected with .code-surface or be a pure margin wrapper.
+    expect(base).toMatch(/\.code-surface\s*,\s*\.prose\s+pre|\.prose\s+pre\s*,\s*\.code-surface/);
+    expect(base).not.toMatch(/\.prose\s+pre\s*\{[^}]*border-radius\s*:\s*3px/s);
+  });
+});
+
+describe("four code-block call sites use .code-surface (#696)", () => {
+  const events = readFileSync(EVENTS, "utf8");
+  const prompt = readFileSync(PROMPT, "utf8");
+  const tabs = readFileSync(TABS, "utf8");
+
+  it("PlaygroundEvents applies code-surface and does not restate surface tokens", () => {
+    expect(events).toMatch(/class="[^"]*\bcode-surface\b[^"]*"/);
+    const css = styleBlock(events);
+    // Only the event JSON pre rule — summary chrome may use other sizes.
+    expect(css).toMatch(/pre\s*\{[^}]*max-height/s);
+    expect(css).not.toMatch(/pre\s*\{[^}]*border-radius\s*:/s);
+    expect(css).not.toMatch(/pre\s*\{[^}]*background\s*:\s*var\(--code-paper\)/s);
+    expect(css).not.toMatch(/pre\s*\{[^}]*font(?:-size)?\s*:\s*0\.7rem/s);
+    expect(css).not.toMatch(/pre\s*\{[^}]*padding\s*:\s*0\.65rem/s);
+  });
+
+  it("PlaygroundPrompt details pre applies code-surface and does not restate surface tokens", () => {
+    expect(prompt).toMatch(/class="[^"]*\bcode-surface\b[^"]*"/);
+    const css = styleBlock(prompt);
+    // Layout-only extras (max-height, margin, white-space) are fine; surface tokens are not.
+    expect(css).not.toMatch(/\.details-pre[^{]*\{[^}]*border-radius\s*:/s);
+    expect(css).not.toMatch(/\.details-pre[^{]*\{[^}]*background\s*:\s*var\(--code-paper\)/s);
+    expect(css).not.toMatch(/\.details-pre[^{]*\{[^}]*font\s*:\s*0\.75rem/s);
+    expect(css).not.toMatch(/\.details-pre[^{]*\{[^}]*padding\s*:\s*0\.65rem/s);
+  });
+
+  it("CodeTabs scroll region applies code-surface and inherits type from it", () => {
+    expect(tabs).toMatch(/class="[^"]*\bcode-surface\b[^"]*"/);
+    const css = styleBlock(tabs);
+    // No private font-size / padding restatement that re-forks the surface.
+    expect(css).not.toMatch(/font-size\s*:\s*0\.8rem/);
+    expect(css).not.toMatch(/\.scroll-region[^{]*\{[^}]*background\s*:\s*var\(--code-paper\)/s);
+  });
+});


### PR DESCRIPTION
## Summary

- Point 2 of #696: four code-block treatments diverged (radius 0/3px/4px, font 0.7–0.8rem, padding 0.65–1rem, line-height 1.45–1.55).
- Add shared `.code-surface` in `base.css` with DESIGN.md-aligned host tokens (`var(--radius)`, 1rem padding, 0.8rem/1.5 type, code paper/ink).
- Wire `.prose pre`, `PlaygroundEvents`, `PlaygroundPrompt` details pre, and `CodeTabs` scroll region to it; leave only layout extras local.

## Test plan

- [x] `bun test scripts/code-surface-design-tokens.test.ts`
- [ ] CI green (docs a11y journeys, VR gate if pixel-sensitive)
- [ ] Spot-check prose fences, example CodeTabs, playground events JSON, and agent failure details

Closes #696 (with #1011 for the UiButton item).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1012" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->