### PR TITLE
refactor(core): move disambiguatedLabels out of legend layout (#841)

### DIFF
--- a/.changeset/841-domain-labels.md
+++ b/.changeset/841-domain-labels.md
@@ -1,0 +1,10 @@
+---
+"@ggsvelte/core": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+refactor(core): host disambiguatedLabels next to domain labeling
+
+Move the scale-domain label helper out of legend layout builders into
+domain-labels.ts. Public export and legend re-export stay stable.

--- a/packages/core/src/domain-labels.ts
+++ b/packages/core/src/domain-labels.ts
@@ -1,0 +1,29 @@
+/**
+ * Scale-domain presentation labels.
+ *
+ * Typed domain values can share a `bandKey` string (`1` and `"1"`). Callers that
+ * show those values as UI labels (legends, bounds editors, discrete guides)
+ * need collision-qualified strings so options stay distinguishable.
+ */
+
+import { bandKey } from "./scales/train.js";
+
+function valueKind(value: unknown): string {
+  if (value instanceof Date) return "date";
+  if (value === null) return "null";
+  if (typeof value === "string") return "text";
+  return typeof value;
+}
+
+/**
+ * Map domain values to presentation labels. Unique band keys stay bare;
+ * collisions get a `(kind)` suffix from the source value's runtime type.
+ */
+export function disambiguatedLabels(values: readonly unknown[]): string[] {
+  const raw = values.map((value) => bandKey(value));
+  const counts = new Map<string, number>();
+  for (const label of raw) counts.set(label, (counts.get(label) ?? 0) + 1);
+  return raw.map((label, index) =>
+    (counts.get(label) ?? 0) > 1 ? `${label} (${valueKind(values[index])})` : label,
+  );
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -220,8 +220,11 @@ export type {
   TickFormatter,
 } from "./layout/layout.js";
 
+// Domain presentation labels (scale-domain; legend.ts re-exports for one-release compat)
+export { disambiguatedLabels } from "./domain-labels.js";
+
 // Legends
-export { buildLegends, disambiguatedLabels, LEGEND_ROW_HEIGHT } from "./legend.js";
+export { buildLegends, LEGEND_ROW_HEIGHT } from "./legend.js";
 export type {
   DiscreteLegendInput,
   LegendBlock,

--- a/packages/core/src/legend-build-discrete.ts
+++ b/packages/core/src/legend-build-discrete.ts
@@ -4,8 +4,8 @@ import { DEFAULT_MISSING_COLOR } from "./scales/engine.js";
 import { encodeKey } from "./scales/state.js";
 import { bandKey } from "./scales/train.js";
 import type { SceneLegend, SceneLegendEntry } from "./scene.js";
+import { disambiguatedLabels } from "./domain-labels.js";
 import {
-  disambiguatedLabels,
   LEGEND_ROW_HEIGHT,
   legendTitleHeight,
   PADDING,

--- a/packages/core/src/legend-build-shared.ts
+++ b/packages/core/src/legend-build-shared.ts
@@ -1,12 +1,14 @@
 /** Shared legend layout metrics, style resolution, and label presentation helpers. */
 import type { TextMeasurer } from "./layout/measure.js";
 import { truncateToFit } from "./layout/truncate.js";
-import { bandKey } from "./scales/train.js";
 import {
   type LegendInput,
   type ResolvedLegendAppearance,
   LegendLayoutError,
 } from "./legend-build-types.js";
+
+// Re-export so legend-build/legend keep a stable path during the domain-labels split (#841).
+export { disambiguatedLabels } from "./domain-labels.js";
 
 const FONT_SIZE = 11;
 const TITLE_HEIGHT = 18;
@@ -21,22 +23,6 @@ const HORIZONTAL_RAMP_LENGTH = 180;
 
 /** Ellipsis for legend entry truncation (same glyph as axis paths). */
 const LEGEND_ELLIPSIS = "…";
-
-function valueKind(value: unknown): string {
-  if (value instanceof Date) return "date";
-  if (value === null) return "null";
-  if (typeof value === "string") return "text";
-  return typeof value;
-}
-
-export function disambiguatedLabels(values: readonly unknown[]): string[] {
-  const raw = values.map((value) => bandKey(value));
-  const counts = new Map<string, number>();
-  for (const label of raw) counts.set(label, (counts.get(label) ?? 0) + 1);
-  return raw.map((label, index) =>
-    (counts.get(label) ?? 0) > 1 ? `${label} (${valueKind(values[index])})` : label,
-  );
-}
 
 /** Binary-search truncation shared with axis layout, honoring guide typography. */
 function truncate(

--- a/packages/core/src/pipeline/scale-color-identity.ts
+++ b/packages/core/src/pipeline/scale-color-identity.ts
@@ -1,7 +1,7 @@
 /** Identity color/fill scale family (pass-through source colors). */
 import type { ColorScaleSpec } from "@ggsvelte/spec";
 
-import { disambiguatedLabels } from "../legend.js";
+import { disambiguatedLabels } from "../domain-labels.js";
 import { normalizeColor } from "../scales/color.js";
 import type { IdentityColorScale } from "../scales/non-position-color.js";
 import { encodeKey } from "../scales/state.js";

--- a/packages/core/src/pipeline/scale-color-manual.ts
+++ b/packages/core/src/pipeline/scale-color-manual.ts
@@ -1,7 +1,7 @@
 /** Manual color/fill scale family (explicit domain ↔ range). */
 import type { ColorScaleSpec } from "@ggsvelte/spec";
 
-import { disambiguatedLabels } from "../legend.js";
+import { disambiguatedLabels } from "../domain-labels.js";
 import { normalizeColor } from "../scales/color.js";
 import type { ManualColorScale } from "../scales/non-position-color.js";
 import { encodeKey } from "../scales/state.js";

--- a/packages/core/src/pipeline/scale-color-ordinal-result.ts
+++ b/packages/core/src/pipeline/scale-color-ordinal-result.ts
@@ -2,7 +2,7 @@
  * Pack ordinal ColorScale into ColorResolution + palette-inferred advisory.
  */
 import type { ColorScaleSpec } from "@ggsvelte/spec";
-import { disambiguatedLabels } from "../legend.js";
+import { disambiguatedLabels } from "../domain-labels.js";
 import { resolveMissingColors } from "../scales/engine.js";
 import type { ColorScale } from "../scales/train.js";
 import type { CellValue } from "../table.js";

--- a/packages/core/src/pipeline/scale-style-discrete.ts
+++ b/packages/core/src/pipeline/scale-style-discrete.ts
@@ -1,7 +1,7 @@
 /** Shared ordinal/manual discrete training and guide assembly for style aesthetics. */
 import type { StyleAesthetic } from "@ggsvelte/spec";
 
-import { disambiguatedLabels } from "../legend.js";
+import { disambiguatedLabels } from "../domain-labels.js";
 import type { StyleOutput, StyleScale } from "../scales/style.js";
 import {
   encodeKey,

--- a/packages/core/src/pipeline/scale-style-finite.ts
+++ b/packages/core/src/pipeline/scale-style-finite.ts
@@ -2,7 +2,7 @@
 import { LINETYPE_NAMES, POINT_SHAPE_NAMES } from "@ggsvelte/spec";
 
 import { numberFormatter } from "../layout/format.js";
-import { disambiguatedLabels } from "../legend.js";
+import { disambiguatedLabels } from "../domain-labels.js";
 import type { Linetype, PointShape, StyleScale } from "../scales/style.js";
 import { encodeKey, type ScaleState } from "../scales/state.js";
 import { finiteExtent } from "../scales/train.js";

--- a/packages/core/src/pipeline/scale-style-numeric.ts
+++ b/packages/core/src/pipeline/scale-style-numeric.ts
@@ -1,6 +1,6 @@
 /** Numeric style scales: size / linewidth / alpha (identity, sequential, binned, ordinal, manual). */
 import { linearTicks } from "../layout/ticks.js";
-import { disambiguatedLabels } from "../legend.js";
+import { disambiguatedLabels } from "../domain-labels.js";
 import type { StyleScale } from "../scales/style.js";
 import { encodeKey, type ScaleState } from "../scales/state.js";
 import { finiteExtent } from "../scales/train.js";

--- a/packages/core/tests/domain-labels.test.ts
+++ b/packages/core/tests/domain-labels.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Scale-domain presentation labels (#841).
+ * Colliding band keys must stay distinguishable in guides and bounds UIs.
+ */
+import { describe, expect, it } from "bun:test";
+
+import { disambiguatedLabels } from "../src/domain-labels.ts";
+// legend.ts re-exports the helper so existing deep imports keep working.
+import { disambiguatedLabels as fromLegend } from "../src/legend.ts";
+
+describe("disambiguatedLabels", () => {
+  it("leaves unique band keys alone", () => {
+    expect(disambiguatedLabels(["a", "b", 1])).toEqual(["a", "b", "1"]);
+  });
+
+  it("suffixes colliding band keys with value kind", () => {
+    expect(disambiguatedLabels(["1", 1])).toEqual(["1 (text)", "1 (number)"]);
+  });
+
+  it("qualifies date vs string collisions on the same band key", () => {
+    const date = new Date("2020-01-01T00:00:00.000Z");
+    // bandKey(Date) is the ISO string; a matching string collides.
+    expect(disambiguatedLabels([date, "2020-01-01T00:00:00.000Z"])).toEqual([
+      "2020-01-01T00:00:00.000Z (date)",
+      "2020-01-01T00:00:00.000Z (text)",
+    ]);
+  });
+
+  it("stays available from the legend re-export path", () => {
+    expect(fromLegend(["1", 1])).toEqual(["1 (text)", "1 (number)"]);
+  });
+});

--- a/packages/core/tests/legend-orchestration.test.ts
+++ b/packages/core/tests/legend-orchestration.test.ts
@@ -9,7 +9,6 @@ import { MetricsTableMeasurer } from "../src/layout/measure.ts";
 import {
   assertLegendBlockFitsPlacedArea,
   buildLegends,
-  disambiguatedLabels,
   type DiscreteLegendInput,
   type LegendInput,
 } from "../src/legend.ts";
@@ -27,16 +26,6 @@ function discrete(overrides: Partial<DiscreteLegendInput> = {}): DiscreteLegendI
     ...overrides,
   };
 }
-
-describe("disambiguatedLabels", () => {
-  it("leaves unique band keys alone", () => {
-    expect(disambiguatedLabels(["a", "b", 1])).toEqual(["a", "b", "1"]);
-  });
-
-  it("suffixes colliding band keys with value kind", () => {
-    expect(disambiguatedLabels(["1", 1])).toEqual(["1 (text)", "1 (number)"]);
-  });
-});
 
 describe("buildLegends domain order", () => {
   it("orders present-first-seen by firstSeen within domain", () => {


### PR DESCRIPTION
## Summary

- Hosts `disambiguatedLabels` in `packages/core/src/domain-labels.ts` next to scale/domain labeling, not legend pixel builders.
- Points scale pipeline and discrete legend builder at the new module.
- Keeps public export from `@ggsvelte/core` and the `legend.ts` re-export stable for one-release compatibility.

Closes #841

## Validation

Issue #841 is a real coupling: scale modules and svelte bounds UI imported a domain-label helper through legend layout.

## Test plan

- [x] `bun test packages/core/tests/domain-labels.test.ts packages/core/tests/legend-orchestration.test.ts`
- [x] `bun test packages/core/tests/pipeline-m1/legends-theme.test.ts`
- [x] `bun x tsc -b packages/spec packages/core`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1013" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->