### PR TITLE
test(docs): apps/docs component harness + SiteSearch race (#991)

### DIFF
--- a/.github/workflows/ci-component-journeys.yml
+++ b/.github/workflows/ci-component-journeys.yml
@@ -78,15 +78,11 @@ jobs:
           container_tag: ${{ inputs.playwright_container_tag }}
       # Docs .svelte component harness (issue #991). Runs before the static
       # build so a failed unit-level race test fails fast without vite build.
-      # svelte-kit sync materializes .svelte-kit/tsconfig.json that the app
-      # tsconfig extends (vite-plugin-svelte reads it during vitest startup).
+      # package.json `test` runs svelte-kit sync first (clean-checkout safe).
       - name: docs component tests (apps/docs, chromium)
         if: steps.content_hash.outputs.hit != 'true'
         working-directory: apps/docs
-        run: |
-          set -euo pipefail
-          bun x svelte-kit sync
-          bun run --bun test
+        run: bun run --bun test
       - name: build packaged interaction test target
         if: steps.content_hash.outputs.hit != 'true'
         run: DOCS_BUILD_MODE=cloudflare-preview bun run build:docs

--- a/.github/workflows/ci-component-journeys.yml
+++ b/.github/workflows/ci-component-journeys.yml
@@ -78,10 +78,15 @@ jobs:
           container_tag: ${{ inputs.playwright_container_tag }}
       # Docs .svelte component harness (issue #991). Runs before the static
       # build so a failed unit-level race test fails fast without vite build.
+      # svelte-kit sync materializes .svelte-kit/tsconfig.json that the app
+      # tsconfig extends (vite-plugin-svelte reads it during vitest startup).
       - name: docs component tests (apps/docs, chromium)
         if: steps.content_hash.outputs.hit != 'true'
         working-directory: apps/docs
-        run: bun run --bun test
+        run: |
+          set -euo pipefail
+          bun x svelte-kit sync
+          bun run --bun test
       - name: build packaged interaction test target
         if: steps.content_hash.outputs.hit != 'true'
         run: DOCS_BUILD_MODE=cloudflare-preview bun run build:docs

--- a/.github/workflows/ci-component-journeys.yml
+++ b/.github/workflows/ci-component-journeys.yml
@@ -68,6 +68,20 @@ jobs:
           package: "@playwright/test"
           scope: root @playwright/test (VR suite)
           container_tag: ${{ inputs.playwright_container_tag }}
+      - name: assert playwright npm/container version sync (apps/docs)
+        if: steps.content_hash.outputs.hit != 'true'
+        uses: ./.github/actions/ci-assert-playwright-version-sync
+        with:
+          working_directory: apps/docs
+          package: playwright
+          scope: apps/docs
+          container_tag: ${{ inputs.playwright_container_tag }}
+      # Docs .svelte component harness (issue #991). Runs before the static
+      # build so a failed unit-level race test fails fast without vite build.
+      - name: docs component tests (apps/docs, chromium)
+        if: steps.content_hash.outputs.hit != 'true'
+        working-directory: apps/docs
+        run: bun run --bun test
       - name: build packaged interaction test target
         if: steps.content_hash.outputs.hit != 'true'
         run: DOCS_BUILD_MODE=cloudflare-preview bun run build:docs
@@ -93,6 +107,7 @@ jobs:
           path: |
             tests/visual/test-results/
             tests/visual/playwright-report/
+            apps/docs/test-results/
           if-no-files-found: ignore
           retention-days: 7
 

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ tests/visual/test-results/
 tests/visual/playwright-report/
 tests/performance/test-results/
 packages/svelte/test-results/
+apps/docs/test-results/
 spikes/browser/test-results/
 benchmarks/results/
 .vitest-attachments/

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -8,7 +8,8 @@
     "dev": "vite dev",
     "build": "bun ../../scripts/gen-docs-routes.ts --check && bun ../../scripts/gen-docs-search.ts --check && bun ../../scripts/gen-lesson-charts.ts --check && bun ../../scripts/gen-gallery-previews.ts --check && bun ../../scripts/gen-playground-seeds.ts --check && svelte-kit sync && vite build && bun ../../scripts/check-docs-metadata.ts && bun ../../scripts/docs-csp.ts",
     "preview": "vite preview",
-    "check": "bun ../../scripts/gen-docs-routes.ts --check && bun ../../scripts/gen-docs-search.ts --check && bun ../../scripts/gen-lesson-charts.ts --check && bun ../../scripts/gen-gallery-previews.ts --check && bun ../../scripts/gen-playground-seeds.ts --check && svelte-kit sync && svelte-check --fail-on-warnings"
+    "check": "bun ../../scripts/gen-docs-routes.ts --check && bun ../../scripts/gen-docs-search.ts --check && bun ../../scripts/gen-lesson-charts.ts --check && bun ../../scripts/gen-gallery-previews.ts --check && bun ../../scripts/gen-playground-seeds.ts --check && svelte-kit sync && svelte-check --fail-on-warnings",
+    "test": "vitest run"
   },
   "dependencies": {
     "@ggsvelte/core": "workspace:*",
@@ -23,9 +24,13 @@
     "@sveltejs/adapter-static": "^3.0.10",
     "@sveltejs/kit": "^2.70.0",
     "@sveltejs/vite-plugin-svelte": "^7.2.0",
+    "@testing-library/svelte-core": "^1.1.3",
+    "@vitest/browser-playwright": "^4.1.10",
+    "playwright": "1.61.1",
     "svelte": "^5.56.7",
     "svelte-check": "^4.7.3",
     "typescript": "^6.0.3",
-    "vite": "^8.1.5"
+    "vite": "^8.1.5",
+    "vitest": "^4.1.10"
   }
 }

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -9,7 +9,7 @@
     "build": "bun ../../scripts/gen-docs-routes.ts --check && bun ../../scripts/gen-docs-search.ts --check && bun ../../scripts/gen-lesson-charts.ts --check && bun ../../scripts/gen-gallery-previews.ts --check && bun ../../scripts/gen-playground-seeds.ts --check && svelte-kit sync && vite build && bun ../../scripts/check-docs-metadata.ts && bun ../../scripts/docs-csp.ts",
     "preview": "vite preview",
     "check": "bun ../../scripts/gen-docs-routes.ts --check && bun ../../scripts/gen-docs-search.ts --check && bun ../../scripts/gen-lesson-charts.ts --check && bun ../../scripts/gen-gallery-previews.ts --check && bun ../../scripts/gen-playground-seeds.ts --check && svelte-kit sync && svelte-check --fail-on-warnings",
-    "test": "vitest run"
+    "test": "svelte-kit sync && vitest run"
   },
   "dependencies": {
     "@ggsvelte/core": "workspace:*",

--- a/apps/docs/src/lib/components/SiteSearch.svelte
+++ b/apps/docs/src/lib/components/SiteSearch.svelte
@@ -6,6 +6,7 @@
   import { searchDocs } from "$lib/search";
   import type { DocsSearchEntry } from "$lib/search-types";
   import { siteSearchKeyAction } from "$lib/site-search-keyboard";
+  import { assignDocsLocation } from "$lib/site-search-navigate";
 
   let dialog = $state<HTMLDialogElement>();
   let input = $state<HTMLInputElement>();
@@ -82,7 +83,7 @@
     const result = results[activeIndex];
     if (result === undefined) return;
     close();
-    window.location.assign(`${base}${result.href}`);
+    assignDocsLocation(`${base}${result.href}`);
   }
 
   async function handleKeydown(event: KeyboardEvent): Promise<void> {

--- a/apps/docs/src/lib/site-search-navigate.ts
+++ b/apps/docs/src/lib/site-search-navigate.ts
@@ -1,0 +1,8 @@
+/**
+ * Full-document navigation for SiteSearch.
+ * Isolated so component tests can mock without touching non-configurable
+ * `window.location` in Playwright (issue #991).
+ */
+export function assignDocsLocation(href: string): void {
+  window.location.assign(href);
+}

--- a/apps/docs/tests/helpers/render.ts
+++ b/apps/docs/tests/helpers/render.ts
@@ -1,0 +1,15 @@
+/**
+ * Synchronous render helper (same rationale as packages/svelte):
+ * vitest-browser-svelte's render() is async; the underlying
+ * @testing-library/svelte-core render is synchronous, which keeps first-paint
+ * assertions honest.
+ */
+import { cleanup, render as coreRender } from "@testing-library/svelte-core";
+import { beforeEach } from "vitest";
+
+beforeEach(() => {
+  cleanup();
+});
+
+export const render: typeof coreRender = (Component, options, setupOptions) =>
+  coreRender(Component, options ?? {}, setupOptions ?? {});

--- a/apps/docs/tests/mocks/app-paths.ts
+++ b/apps/docs/tests/mocks/app-paths.ts
@@ -1,0 +1,2 @@
+/** Minimal `$app/paths` stand-in for component tests outside SvelteKit. */
+export const base = "";

--- a/apps/docs/tests/site-search-enter-while-loading.test.ts
+++ b/apps/docs/tests/site-search-enter-while-loading.test.ts
@@ -1,0 +1,113 @@
+/**
+ * SiteSearch Enter-while-loading race (#948 / #991):
+ * Enter with a non-empty query while the index is still loading must wait for
+ * the index, select the first match, and navigate — not ignore the key.
+ */
+import { flushSync } from "svelte";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { DocsSearchEntry } from "$lib/search-types";
+
+const loadControl = vi.hoisted(() => {
+  let resolveEntries!: (entries: readonly DocsSearchEntry[]) => void;
+  let pending = new Promise<readonly DocsSearchEntry[]>((resolve) => {
+    resolveEntries = resolve;
+  });
+
+  return {
+    reset(): void {
+      pending = new Promise<readonly DocsSearchEntry[]>((resolve) => {
+        resolveEntries = resolve;
+      });
+    },
+    resolve(entries: readonly DocsSearchEntry[]): void {
+      resolveEntries(entries);
+    },
+    load(): Promise<readonly DocsSearchEntry[]> {
+      return pending;
+    },
+  };
+});
+
+const navigate = vi.hoisted(() => ({
+  assign: vi.fn(),
+}));
+
+vi.mock("$lib/load-docs-search-index", () => ({
+  loadDocsSearchIndex: () => loadControl.load(),
+  resetDocsSearchIndexLoaderForTests: () => loadControl.reset(),
+}));
+
+vi.mock("$lib/site-search-navigate", () => ({
+  assignDocsLocation: (href: string) => navigate.assign(href),
+}));
+
+import SiteSearch from "$lib/components/SiteSearch.svelte";
+
+import { render } from "./helpers/render.js";
+
+const FIXTURE_ENTRY: DocsSearchEntry = {
+  id: "getting-started",
+  kind: "page",
+  title: "Getting started",
+  summary: "Install @ggsvelte/svelte and render one chart.",
+  href: "/guide/getting-started",
+  keywords: ["install", "quickstart"],
+  exact: ["getting started"],
+};
+
+function siteSearchExports(component: unknown): {
+  open: (trigger: HTMLElement) => void;
+} {
+  return component as { open: (trigger: HTMLElement) => void };
+}
+
+describe("SiteSearch Enter while index is loading (#948)", () => {
+  beforeEach(() => {
+    loadControl.reset();
+    navigate.assign.mockReset();
+  });
+
+  it("waits for the index, selects the first match, and navigates", async () => {
+    const trigger = document.createElement("button");
+    document.body.append(trigger);
+
+    try {
+      const { container, component } = render(SiteSearch);
+      siteSearchExports(component).open(trigger);
+      flushSync();
+
+      const dialog = container.querySelector<HTMLDialogElement>("dialog.site-search");
+      expect(dialog?.open).toBe(true);
+      expect(container.querySelector(".search-status")?.textContent).toContain(
+        "Loading search index",
+      );
+
+      const input = container.querySelector<HTMLInputElement>("#docs-search-input");
+      expect(input).not.toBeNull();
+      input!.value = "getting";
+      input!.dispatchEvent(new Event("input", { bubbles: true }));
+      flushSync();
+
+      const enter = new KeyboardEvent("keydown", {
+        key: "Enter",
+        bubbles: true,
+        cancelable: true,
+      });
+      input!.dispatchEvent(enter);
+      expect(enter.defaultPrevented).toBe(true);
+
+      // Still loading: navigation must not fire until the index resolves.
+      expect(navigate.assign).not.toHaveBeenCalled();
+
+      loadControl.resolve([FIXTURE_ENTRY]);
+      await vi.waitFor(() => {
+        expect(navigate.assign).toHaveBeenCalledWith("/guide/getting-started");
+      });
+
+      expect(dialog?.open).toBe(false);
+    } finally {
+      trigger.remove();
+    }
+  });
+});

--- a/apps/docs/tests/site-search-enter-while-loading.test.ts
+++ b/apps/docs/tests/site-search-enter-while-loading.test.ts
@@ -35,11 +35,15 @@ const navigate = vi.hoisted(() => ({
 
 vi.mock("$lib/load-docs-search-index", () => ({
   loadDocsSearchIndex: () => loadControl.load(),
-  resetDocsSearchIndexLoaderForTests: () => loadControl.reset(),
+  resetDocsSearchIndexLoaderForTests: () => {
+    loadControl.reset();
+  },
 }));
 
 vi.mock("$lib/site-search-navigate", () => ({
-  assignDocsLocation: (href: string) => navigate.assign(href),
+  assignDocsLocation: (href: string): void => {
+    navigate.assign(href);
+  },
 }));
 
 import SiteSearch from "$lib/components/SiteSearch.svelte";
@@ -73,7 +77,8 @@ describe("SiteSearch Enter while index is loading (#948)", () => {
     document.body.append(trigger);
 
     try {
-      const { container, component } = render(SiteSearch);
+      const { container, component } = render(SiteSearch, {});
+
       siteSearchExports(component).open(trigger);
       flushSync();
 

--- a/apps/docs/tsconfig.json
+++ b/apps/docs/tsconfig.json
@@ -12,5 +12,8 @@
     // No ambient @types (the hoisted @types/bun's import.meta declarations
     // clash with vite/client's): the app code uses no bun/node globals.
     "types": []
-  }
+  },
+  // Component tests live under vitest browser mode (issue #991), not
+  // svelte-check — same split as packages/svelte (tests not in its include).
+  "exclude": ["tests/**"]
 }

--- a/apps/docs/vitest.config.ts
+++ b/apps/docs/vitest.config.ts
@@ -1,0 +1,44 @@
+// Docs app component tests: vitest 4 browser mode + Playwright chromium.
+// Same harness pattern as packages/svelte (issue #991).
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { svelte } from "@sveltejs/vite-plugin-svelte";
+import { playwright } from "@vitest/browser-playwright";
+import { defineConfig } from "vitest/config";
+
+const root = path.dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  plugins: [svelte()],
+  // One svelte runtime only: without these, vite prebundles the svelte
+  // runtime for the component imports while @testing-library/svelte-core
+  // loads the source copy -> two runtimes -> effect_orphan errors.
+  resolve: {
+    alias: {
+      $lib: path.join(root, "src/lib"),
+      "$app/paths": path.join(root, "tests/mocks/app-paths.ts"),
+    },
+    dedupe: ["svelte"],
+  },
+  optimizeDeps: { exclude: ["svelte", "@testing-library/svelte-core"] },
+  test: {
+    include: ["tests/**/*.test.ts"],
+    retry: process.env.CI === "true" ? 1 : 0,
+    maxWorkers: process.env.CI === "true" ? 2 : undefined,
+    browser: {
+      enabled: true,
+      provider: playwright(),
+      headless: true,
+      screenshotFailures: true,
+      screenshotDirectory: "test-results/screenshots",
+      trace: {
+        mode: "on-first-retry",
+        tracesDir: "test-results/traces",
+        screenshots: true,
+        snapshots: false,
+      },
+      instances: [{ browser: "chromium" }],
+    },
+  },
+});

--- a/apps/docs/vitest.config.ts
+++ b/apps/docs/vitest.config.ts
@@ -1,13 +1,12 @@
 // Docs app component tests: vitest 4 browser mode + Playwright chromium.
 // Same harness pattern as packages/svelte (issue #991).
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 
 import { svelte } from "@sveltejs/vite-plugin-svelte";
 import { playwright } from "@vitest/browser-playwright";
 import { defineConfig } from "vitest/config";
 
-const root = path.dirname(fileURLToPath(import.meta.url));
+const root = import.meta.dirname;
 
 export default defineConfig({
   plugins: [svelte()],

--- a/bun.lock
+++ b/bun.lock
@@ -45,10 +45,14 @@
         "@sveltejs/adapter-static": "^3.0.10",
         "@sveltejs/kit": "^2.70.0",
         "@sveltejs/vite-plugin-svelte": "^7.2.0",
+        "@testing-library/svelte-core": "^1.1.3",
+        "@vitest/browser-playwright": "^4.1.10",
+        "playwright": "1.61.1",
         "svelte": "^5.56.7",
         "svelte-check": "^4.7.3",
         "typescript": "^6.0.3",
         "vite": "^8.1.5",
+        "vitest": "^4.1.10",
       },
     },
     "benchmarks": {
@@ -76,9 +80,9 @@
     },
     "packages/core": {
       "name": "@ggsvelte/core",
-      "version": "0.11.1",
+      "version": "0.12.0",
       "dependencies": {
-        "@ggsvelte/spec": "^0.11.1",
+        "@ggsvelte/spec": "^0.12.0",
       },
       "devDependencies": {
         "typescript": "^6.0.3",
@@ -86,7 +90,7 @@
     },
     "packages/spec": {
       "name": "@ggsvelte/spec",
-      "version": "0.11.1",
+      "version": "0.12.0",
       "dependencies": {
         "@js-temporal/polyfill": "^0.5.1",
         "typebox": "^1.3.6",
@@ -98,14 +102,14 @@
     },
     "packages/svelte": {
       "name": "@ggsvelte/svelte",
-      "version": "0.11.1",
+      "version": "0.12.0",
       "bin": {
         "ggsvelte-codemod": "bin/ggsvelte-codemod.js",
         "ggsvelte-render": "bin/ggsvelte-render.js",
       },
       "dependencies": {
-        "@ggsvelte/core": "^0.11.1",
-        "@ggsvelte/spec": "^0.11.1",
+        "@ggsvelte/core": "^0.12.0",
+        "@ggsvelte/spec": "^0.12.0",
       },
       "devDependencies": {
         "@sveltejs/package": "^2.5.8",

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -71,9 +71,9 @@
     },
     "apps/docs": {
       // svelte.config.js / vite.config.ts are auto-entries via knip's
-      // svelte plugin.
-      "entry": ["src/routes/**/+*.ts", "src/lib/**/*.ts"],
-      "project": ["src/**/*.ts", "*.{js,ts}"],
+      // svelte plugin. Component tests (issue #991) are vitest browser entries.
+      "entry": ["src/routes/**/+*.ts", "src/lib/**/*.ts", "tests/**/*.test.ts"],
+      "project": ["src/**/*.ts", "tests/**/*.ts", "*.{js,ts}"],
       // Imported only from .svelte files / the $examples alias, which knip
       // does not trace. phosphor-svelte / bits-ui are deep-imported only from .svelte.
       "ignoreDependencies": ["@ggsvelte/examples", "phosphor-svelte", "bits-ui"],

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "build:cloudflare": "bun run build && bun run build:docs && bun run check:pages-links && bun scripts/deployment-artifact.ts",
     "smoke:deployment": "bun scripts/deployment-smoke-cli.ts",
     "schema:emit": "bun packages/spec/scripts/emit-schema.ts",
-    "test:components": "cd packages/svelte && bun run --bun test",
+    "test:components": "cd packages/svelte && bun run --bun test && cd ../../apps/docs && bun run --bun test",
     "bench": "cd benchmarks && bun run bench",
     "bench:smoke": "cd benchmarks && bun run bench:smoke",
     "bench:json": "cd benchmarks && bun run bench:json",

--- a/scripts/ci-composites.test.ts
+++ b/scripts/ci-composites.test.ts
@@ -212,7 +212,7 @@ describe("ci-assert-playwright-version-sync composite", () => {
     expect(action).not.toMatch(/uses:\s+(?!composite)/);
   });
 
-  it("is the sole playwright version-sync path for the four container jobs", () => {
+  it("is the sole playwright version-sync path for the container jobs", () => {
     const ci = readCiSurface();
     for (const jobId of PLAYWRIGHT_VERSION_SYNC_JOBS) {
       const job = jobSlice(ci, jobId);
@@ -222,11 +222,12 @@ describe("ci-assert-playwright-version-sync composite", () => {
         /require\(["'](?:playwright|@playwright\/test)\/package\.json["']\)/,
       );
     }
+    // svelte + svelte-fx + spikes + journeys root + journeys apps/docs (#991).
     const uses = ci.match(/uses: \.\/\.github\/actions\/ci-assert-playwright-version-sync/g) ?? [];
-    expect(uses.length).toBe(4);
+    expect(uses.length).toBe(5);
   });
 
-  it("wires scope/package inputs for svelte, spikes, and VR root", () => {
+  it("wires scope/package inputs for svelte, spikes, VR root, and docs components", () => {
     const ci = readCiSurface();
     const svelte = jobSlice(ci, "component-svelte");
     expect(svelte).toMatch(/working_directory:\s*packages\/svelte/);
@@ -242,6 +243,10 @@ describe("ci-assert-playwright-version-sync composite", () => {
     expect(journeys).toMatch(/working_directory:\s*\./);
     expect(journeys).toMatch(/package:\s*["']@playwright\/test["']/);
     expect(journeys).toMatch(/scope:\s*root @playwright\/test \(VR suite\)/);
+    // Docs .svelte harness (issue #991) pins playwright next to @playwright/test.
+    expect(journeys).toMatch(/working_directory:\s*apps\/docs/);
+    expect(journeys).toMatch(/scope:\s*apps\/docs/);
+    expect(journeys).toMatch(/docs component tests \(apps\/docs, chromium\)/);
   });
 });
 


### PR DESCRIPTION
## Summary

- **Issue:** #991 — no component test surface for `apps/docs` (23 `.svelte` components only covered by Playwright or not at all).
- **Harness:** vitest 4 browser mode + Playwright chromium under `apps/docs`, same pattern as `packages/svelte` (`@testing-library/svelte-core` sync render, `$lib` / `$app/paths` aliases).
- **Wiring:** root `test:components` runs packages/svelte then apps/docs; `component-journeys` CI runs docs component tests before the static build; knip entries updated.
- **First test:** `SiteSearch` Enter-while-loading race (#948) — waits for the deferred index, selects the first match, navigates via mockable `assignDocsLocation`.
- **Tiny extract:** `site-search-navigate.ts` so navigation is mockable without touching non-configurable `window.location` in Playwright.

Does not backfill the other 22 components — that is left for #988 / #989.

## Verification

```text
cd apps/docs && bun run --bun test
# SiteSearch Enter while index is loading (#948) (1)

bun test scripts/ci-composites.test.ts
# 10 pass

bun test scripts/docs-search-lazy.test.ts
# 3 pass

bun run knip
# clean (config hints only)
```

## Test plan

- [x] Docs component suite green locally
- [ ] CI `component-journeys` runs apps/docs vitest + playwright assert
- [ ] No regression on SiteSearch open / Enter after index ready (manual optional)

Closes #991

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1015" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->