### PR TITLE
refactor(svelte): thin scene-reconcile apply out of InspectionState $effect (#855)

### DIFF
--- a/.changeset/855-scene-reconcile-apply.md
+++ b/.changeset/855-scene-reconcile-apply.md
@@ -1,0 +1,10 @@
+---
+"@ggsvelte/svelte": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+refactor(svelte): thin scene-reconcile apply out of InspectionState $effect
+
+`applySceneInspectReconcile(plan, bag)` owns the clear-disabled / invalidate-*
+side-effect table; the factory `$effect` is a short plan → apply shell (#855).

--- a/packages/svelte/src/lib/inspection/inspection-state.svelte.ts
+++ b/packages/svelte/src/lib/inspection/inspection-state.svelte.ts
@@ -51,6 +51,7 @@ import {
   type SchedulePointerInspectInput,
 } from "./pointer-inspect.js";
 import {
+  applySceneInspectReconcile,
   planInspectionDismiss,
   planSceneInspectReconcile,
   resolveInspectionEmitAction,
@@ -519,61 +520,59 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
       modelRunId: currentModel?.runId ?? null,
       reconciledRun,
     });
-    switch (plan.type) {
-      case "noop":
-      case "skip":
-        return;
-      case "clear-disabled":
-        inspectionCoordinator.invalidate();
+    // Thin plan → apply shell (#855). getInspectionState stays a thunk so
+    // same-run skip does not subscribe to hover inspection updates.
+    applySceneInspectReconcile(plan, {
+      model: currentModel,
+      dataIdentityEpoch: deps.dataIdentityEpoch,
+      clearInspection() {
         inspection = null;
         inspectionSeed = null;
-        clearDismissedLatch();
-        // Inspect-only cancel: move-area schedules must survive.
-        pointerQueue.cancel({ pendingPinned: "discard" });
-        return;
-      case "invalidate-clear-transient":
-      case "invalidate-idle":
-      case "invalidate-reconcile-pinned": {
-        // currentModel is non-null for invalidate-* (plan requires run advance).
-        const runId = currentModel!.runId;
-        // invalidate dispatch already cancels all scheduled pointer work.
-        reducerOf().dispatch({ type: "invalidate", reason: "scene" });
-        pointerQueue.clearForSceneInvalidate();
-        clearDismissedLatch();
+      },
+      setInspectionFromReconcile({ snapshot, seed }) {
+        inspection = snapshot;
+        inspectionSeed = seed;
+      },
+      setActiveCandidateId(id) {
+        activeCandidateId = id;
+      },
+      clearDismissedLatch,
+      setReconciledRun(runId) {
         reconciledRun = runId;
-        if (plan.type === "invalidate-clear-transient") {
-          inspectionCoordinator.release("transient");
-          inspection = null;
-          inspectionSeed = null;
-          return;
-        }
-        if (plan.type === "invalidate-idle") return;
-        const reconciled = inspectionCoordinator.reconcilePinned({
-          model: currentModel!,
-          identityEpoch: deps.dataIdentityEpoch(),
-          layoutEpoch: runId,
+      },
+      dispatchSceneInvalidate() {
+        reducerOf().dispatch({ type: "invalidate", reason: "scene" });
+      },
+      cancelPointerDiscardPending() {
+        pointerQueue.cancel({ pendingPinned: "discard" });
+      },
+      clearPointerForSceneInvalidate() {
+        pointerQueue.clearForSceneInvalidate();
+      },
+      coordinatorInvalidate() {
+        inspectionCoordinator.invalidate();
+      },
+      releaseTransient() {
+        inspectionCoordinator.release("transient");
+      },
+      reconcilePinned(input) {
+        return inspectionCoordinator.reconcilePinned({
+          ...input,
           source: "programmatic",
           completeness: "complete",
         });
-        if (reconciled === null) {
-          // Failed pinned reconcile: clear inspection only (not area Escape).
-          emitInspection({
-            type: "inspect",
-            phase: "clear",
-            source: "programmatic",
-          });
-          inspection = null;
-          inspectionSeed = null;
-        } else {
-          inspection = reconciled.snapshot;
-          inspectionSeed = reconciled.seed;
-          activeCandidateId = reconciled.seed.id;
-          if (reconciled.semanticChanged)
-            emitInspection(reconciled.snapshot, reconciled.semanticFingerprint);
-        }
-        break;
-      }
-    }
+      },
+      emitClearProgrammatic() {
+        emitInspection({
+          type: "inspect",
+          phase: "clear",
+          source: "programmatic",
+        });
+      },
+      emitSemanticChange(snapshot, semanticFingerprint) {
+        emitInspection(snapshot, semanticFingerprint);
+      },
+    });
   });
 
   return {

--- a/packages/svelte/src/lib/inspection/teardown.ts
+++ b/packages/svelte/src/lib/inspection/teardown.ts
@@ -1,12 +1,19 @@
 /**
- * Pure decision tables for capture-surface inspection *teardown* policy:
- * blur/outside dismiss, scene-run reconcile, emit fingerprint, escape/close plan.
- * Callers own reducer dispatch, field clears, coordinator, and focus.
+ * Decision tables and scene-reconcile apply for capture-surface inspection
+ * *teardown* policy: blur/outside dismiss, scene-run reconcile (plan + bag
+ * apply), emit fingerprint, escape/close plan.
+ *
+ * Plan helpers are pure. `applySceneInspectReconcile` only calls the host bag
+ * (reducer, coordinator, queue, field writes) — no $effect registration.
  */
 
-import type { InteractionSource } from "../interaction/interaction.js";
+import type { CandidateFacts, CellValue, RenderModel } from "@ggsvelte/core";
+
+import type { InteractionSource, PlotInspectionChange } from "../interaction/interaction.js";
 import { clearInspectionFingerprint } from "./coordinator.js";
 import type { InspectionHostState } from "./frame.js";
+
+type InspectionChangeSnapshot = PlotInspectionChange<Record<string, CellValue>, PropertyKey>;
 
 // ---- surface blur / outside pointer dismiss ----
 
@@ -98,6 +105,113 @@ export function planSceneInspectReconcile(input: {
     return { type: "invalidate-reconcile-pinned" };
   }
   return { type: "invalidate-idle" };
+}
+
+/**
+ * Host mutators for `applySceneInspectReconcile`. The `$effect` shell owns
+ * plan + bag wiring; this bag owns field writes and coordinator/queue/reducer.
+ */
+export type SceneInspectReconcileBag = {
+  /**
+   * Current model when the effect ran. Required non-null for invalidate-*
+   * plans (plan guarantees run advanced). clear-disabled / noop / skip may
+   * pass null.
+   */
+  readonly model: RenderModel | null;
+  readonly dataIdentityEpoch: () => PropertyKey;
+  /** Clear live inspection + seed (transient clear, disabled clear, failed pin). */
+  clearInspection(): void;
+  /** Commit a successful pinned reconcile (snapshot + seed). */
+  setInspectionFromReconcile(input: {
+    readonly snapshot: InspectionChangeSnapshot;
+    readonly seed: CandidateFacts;
+  }): void;
+  setActiveCandidateId(id: number | null): void;
+  clearDismissedLatch(): void;
+  setReconciledRun(runId: number): void;
+  /** Reducer `{ type: "invalidate", reason: "scene" }` (cancels all scheduled pointer). */
+  dispatchSceneInvalidate(): void;
+  /** clear-disabled: discard pending pin stash; inspect-only cancel. */
+  cancelPointerDiscardPending(): void;
+  /** invalidate-*: clear queue fields only (after dispatchSceneInvalidate). */
+  clearPointerForSceneInvalidate(): void;
+  coordinatorInvalidate(): void;
+  releaseTransient(): void;
+  reconcilePinned(input: {
+    readonly model: RenderModel;
+    readonly identityEpoch: PropertyKey;
+    readonly layoutEpoch: PropertyKey;
+  }): {
+    readonly snapshot: InspectionChangeSnapshot;
+    readonly seed: CandidateFacts;
+    readonly semanticChanged: boolean;
+    readonly semanticFingerprint: string;
+  } | null;
+  emitClearProgrammatic(): void;
+  emitSemanticChange(snapshot: InspectionChangeSnapshot, semanticFingerprint: string): void;
+};
+
+/**
+ * Apply a scene-run inspection reconcile plan via host mutators.
+ *
+ * Keeps the factory `$effect` as plan → apply. Ordering is load-bearing:
+ * invalidate-* dispatches reducer invalidate before queue field clears; pinned
+ * reconcile failure emits programmatic clear then clears fields.
+ */
+export function applySceneInspectReconcile(
+  plan: SceneInspectReconcilePlan,
+  bag: SceneInspectReconcileBag,
+): void {
+  switch (plan.type) {
+    case "noop":
+    case "skip":
+      return;
+    case "clear-disabled":
+      bag.coordinatorInvalidate();
+      bag.clearInspection();
+      bag.clearDismissedLatch();
+      // Inspect-only cancel: move-area schedules must survive.
+      bag.cancelPointerDiscardPending();
+      return;
+    case "invalidate-clear-transient":
+    case "invalidate-idle":
+    case "invalidate-reconcile-pinned": {
+      // Plan requires run advance → model is non-null for invalidate-*.
+      const model = bag.model;
+      if (model === null) return;
+      const runId = model.runId;
+      // invalidate dispatch already cancels all scheduled pointer work.
+      bag.dispatchSceneInvalidate();
+      bag.clearPointerForSceneInvalidate();
+      bag.clearDismissedLatch();
+      bag.setReconciledRun(runId);
+      if (plan.type === "invalidate-clear-transient") {
+        bag.releaseTransient();
+        bag.clearInspection();
+        return;
+      }
+      if (plan.type === "invalidate-idle") return;
+      const reconciled = bag.reconcilePinned({
+        model,
+        identityEpoch: bag.dataIdentityEpoch(),
+        layoutEpoch: runId,
+      });
+      if (reconciled === null) {
+        // Failed pinned reconcile: clear inspection only (not area Escape).
+        bag.emitClearProgrammatic();
+        bag.clearInspection();
+      } else {
+        bag.setInspectionFromReconcile({
+          snapshot: reconciled.snapshot,
+          seed: reconciled.seed,
+        });
+        bag.setActiveCandidateId(reconciled.seed.id);
+        if (reconciled.semanticChanged) {
+          bag.emitSemanticChange(reconciled.snapshot, reconciled.semanticFingerprint);
+        }
+      }
+    }
+  }
 }
 
 // ---- inspection emission fingerprint gate ----

--- a/packages/svelte/tests/inspection/inspection-teardown.test.ts
+++ b/packages/svelte/tests/inspection/inspection-teardown.test.ts
@@ -3,12 +3,16 @@
  */
 import { describe, expect, it } from "vitest";
 
+import type { CandidateFacts, RenderModel } from "@ggsvelte/core";
+
 import {
+  applySceneInspectReconcile,
   planInspectionDismiss,
   planSceneInspectReconcile,
   resolveInspectionEmitAction,
   resolveSurfaceBlurAction,
   shouldClosePinnedOnOutsidePointer,
+  type SceneInspectReconcileBag,
 } from "../../src/lib/inspection/teardown.js";
 
 describe("resolveSurfaceBlurAction", () => {
@@ -128,6 +132,168 @@ describe("planSceneInspectReconcile", () => {
         reconciledRun: 1,
       }),
     ).toEqual({ type: "invalidate-idle" });
+  });
+});
+
+describe("applySceneInspectReconcile", () => {
+  type Call = string;
+  type ReconcileResult = ReturnType<SceneInspectReconcileBag["reconcilePinned"]>;
+
+  function mockBag(opts?: {
+    model?: RenderModel | null;
+    reconcileResult?: ReconcileResult | "default-null";
+  }): { bag: SceneInspectReconcileBag; calls: Call[] } {
+    const calls: Call[] = [];
+    const model = opts && "model" in opts ? (opts.model ?? null) : ({ runId: 7 } as RenderModel);
+    const reconcileResult: ReconcileResult | "default-null" =
+      opts?.reconcileResult ?? "default-null";
+    const bag: SceneInspectReconcileBag = {
+      model,
+      dataIdentityEpoch: () => {
+        calls.push("dataIdentityEpoch");
+        return "epoch-1";
+      },
+      clearInspection() {
+        calls.push("clearInspection");
+      },
+      setInspectionFromReconcile() {
+        calls.push("setInspectionFromReconcile");
+      },
+      setActiveCandidateId(id) {
+        calls.push(`setActiveCandidateId:${String(id)}`);
+      },
+      clearDismissedLatch() {
+        calls.push("clearDismissedLatch");
+      },
+      setReconciledRun(runId) {
+        calls.push(`setReconciledRun:${runId}`);
+      },
+      dispatchSceneInvalidate() {
+        calls.push("dispatchSceneInvalidate");
+      },
+      cancelPointerDiscardPending() {
+        calls.push("cancelPointerDiscardPending");
+      },
+      clearPointerForSceneInvalidate() {
+        calls.push("clearPointerForSceneInvalidate");
+      },
+      coordinatorInvalidate() {
+        calls.push("coordinatorInvalidate");
+      },
+      releaseTransient() {
+        calls.push("releaseTransient");
+      },
+      reconcilePinned() {
+        calls.push("reconcilePinned");
+        return reconcileResult === "default-null" ? null : reconcileResult;
+      },
+      emitClearProgrammatic() {
+        calls.push("emitClearProgrammatic");
+      },
+      emitSemanticChange() {
+        calls.push("emitSemanticChange");
+      },
+    };
+    return { bag, calls };
+  }
+
+  it("noops and skips without side effects", () => {
+    for (const type of ["noop", "skip"] as const) {
+      const { bag, calls } = mockBag();
+      applySceneInspectReconcile({ type }, bag);
+      expect(calls).toEqual([]);
+    }
+  });
+
+  it("clear-disabled invalidates coordinator, clears fields, discards pending pin", () => {
+    const { bag, calls } = mockBag({ model: null });
+    applySceneInspectReconcile({ type: "clear-disabled" }, bag);
+    expect(calls).toEqual([
+      "coordinatorInvalidate",
+      "clearInspection",
+      "clearDismissedLatch",
+      "cancelPointerDiscardPending",
+    ]);
+  });
+
+  it("invalidate-clear-transient dispatches before queue clear then releases transient", () => {
+    const { bag, calls } = mockBag();
+    applySceneInspectReconcile({ type: "invalidate-clear-transient" }, bag);
+    expect(calls).toEqual([
+      "dispatchSceneInvalidate",
+      "clearPointerForSceneInvalidate",
+      "clearDismissedLatch",
+      "setReconciledRun:7",
+      "releaseTransient",
+      "clearInspection",
+    ]);
+  });
+
+  it("invalidate-idle advances reconciled run without clearing inspection", () => {
+    const { bag, calls } = mockBag();
+    applySceneInspectReconcile({ type: "invalidate-idle" }, bag);
+    expect(calls).toEqual([
+      "dispatchSceneInvalidate",
+      "clearPointerForSceneInvalidate",
+      "clearDismissedLatch",
+      "setReconciledRun:7",
+    ]);
+  });
+
+  it("invalidate-reconcile-pinned success commits snapshot and emits when semantic changed", () => {
+    const seed = { id: 42 } as CandidateFacts;
+    const snapshot = { state: "pinned" } as NonNullable<ReconcileResult>["snapshot"];
+    const { bag, calls } = mockBag({
+      reconcileResult: {
+        snapshot,
+        seed,
+        semanticChanged: true,
+        semanticFingerprint: "sem:1",
+      },
+    });
+    applySceneInspectReconcile({ type: "invalidate-reconcile-pinned" }, bag);
+    expect(calls).toEqual([
+      "dispatchSceneInvalidate",
+      "clearPointerForSceneInvalidate",
+      "clearDismissedLatch",
+      "setReconciledRun:7",
+      "dataIdentityEpoch",
+      "reconcilePinned",
+      "setInspectionFromReconcile",
+      "setActiveCandidateId:42",
+      "emitSemanticChange",
+    ]);
+  });
+
+  it("invalidate-reconcile-pinned failure emits programmatic clear then clears fields", () => {
+    const { bag, calls } = mockBag({ reconcileResult: null });
+    applySceneInspectReconcile({ type: "invalidate-reconcile-pinned" }, bag);
+    expect(calls).toEqual([
+      "dispatchSceneInvalidate",
+      "clearPointerForSceneInvalidate",
+      "clearDismissedLatch",
+      "setReconciledRun:7",
+      "dataIdentityEpoch",
+      "reconcilePinned",
+      "emitClearProgrammatic",
+      "clearInspection",
+    ]);
+  });
+
+  it("invalidate-reconcile-pinned success without semantic change does not emit", () => {
+    const seed = { id: 9 } as CandidateFacts;
+    const snapshot = { state: "pinned" } as NonNullable<ReconcileResult>["snapshot"];
+    const { bag, calls } = mockBag({
+      reconcileResult: {
+        snapshot,
+        seed,
+        semanticChanged: false,
+        semanticFingerprint: "sem:same",
+      },
+    });
+    applySceneInspectReconcile({ type: "invalidate-reconcile-pinned" }, bag);
+    expect(calls).not.toContain("emitSemanticChange");
+    expect(calls).toContain("setInspectionFromReconcile");
   });
 });
 


### PR DESCRIPTION
## Summary

- Fixes #855: extract `applySceneInspectReconcile(plan, bag)` so the scene-run reconcile `$effect` is a short plan → apply shell.
- Planning stays pure in `planSceneInspectReconcile`; the bag owns field writes, coordinator, pointer queue, reducer invalidate, and emit.
- `getInspectionState` remains a thunk so same-run skip does not subscribe to hover inspection updates.

## Validation

- Dense switch lived in `inspection-state.svelte.ts` `$effect` after pointer-queue extraction (#pointer-inspect).
- Apply ordering preserved: invalidate dispatch before queue field clears; pinned failure emits programmatic clear then clears fields.

## Test plan

- [x] `bun run --bun vitest run --project chromium tests/inspection/inspection-teardown.test.ts` (includes new apply bag sequence tests)
- [x] `bun run --bun vitest run --project chromium tests/inspection/inspection-state.construction-effects.test.ts` (transient clear / pinned reconcile / disabled clear / stash drop)

## Follow-ups

None.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1018" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->