### PR TITLE
feat(core): resolve after_stat color/fill outside density_2d (#953)

### DIFF
--- a/.changeset/953-after-stat-color-fill.md
+++ b/.changeset/953-after-stat-color-fill.md
@@ -6,6 +6,8 @@
 
 feat(core): resolve after_stat color/fill outside density_2d (#953)
 
+Migration: none — additive
+
 `aes(fill = after_stat(count))` on histograms and the same pattern for
 `density` / `ncount` / `ndensity`, plus count and density stats, now map
 into continuous fill/color scales and legends. Shared `colorColumns`

--- a/.changeset/953-after-stat-color-fill.md
+++ b/.changeset/953-after-stat-color-fill.md
@@ -1,0 +1,12 @@
+---
+"@ggsvelte/core": minor
+---
+
+<!-- markdownlint-disable MD041 -->
+
+feat(core): resolve after_stat color/fill outside density_2d (#953)
+
+`aes(fill = after_stat(count))` on histograms and the same pattern for
+`density` / `ncount` / `ndensity`, plus count and density stats, now map
+into continuous fill/color scales and legends. Shared `colorColumns`
+helper; `STAT_COLOR_COLUMNS` extended so #915 no longer warns for these.

--- a/packages/core/src/pipeline/bind-layer-stat-columns.ts
+++ b/packages/core/src/pipeline/bind-layer-stat-columns.ts
@@ -28,16 +28,18 @@ export const STAT_Y_COLUMNS: Record<string, readonly string[]> = {
 };
 
 /**
- * color/fill `{ stat }` columns each stat exposes. Frame builders that resolve
- * after_stat colour: density_2d / density_2d_filled (`frame-stats-density-2d.ts`)
- * and bin_hex (`frame-stats-bin-hex.ts` fill + color). Every other frame builds
- * colour from the mapped field alone, so an `{ stat }` mapping there is dropped
- * (#915). Stats absent from this map publish nothing for colour.
+ * color/fill `{ stat }` columns each stat exposes. Frame builders resolve these
+ * via `colorColumns` in `frame-stats-shared.ts` (#953). Stats absent from this
+ * map publish nothing for colour — bind emits `stat-channel-unsupported` (#915).
  */
 export const STAT_COLOR_COLUMNS: Record<string, readonly string[]> = {
+  // bin / histogram: count + density family (ggplot2 after_stat on fill/color).
+  bin: ["count", "density", "ncount", "ndensity"],
   bin_2d: ["count", "density", "ncount", "ndensity"],
-  density_2d: ["level", "density"],
-  density_2d_filled: ["level", "density"],
   // bin_hex fill defaults to after_stat count (ggplot2 geom_hex; #800).
   bin_hex: ["count", "density", "ncount", "ndensity"],
+  count: ["count"],
+  density: ["density", "count", "scaled", "ndensity"],
+  density_2d: ["level", "density"],
+  density_2d_filled: ["level", "density"],
 };

--- a/packages/core/src/pipeline/frame-stats-bin-2d.ts
+++ b/packages/core/src/pipeline/frame-stats-bin-2d.ts
@@ -4,10 +4,9 @@
 import type { ColumnTable } from "../table.js";
 
 import { statBin2d } from "../stats/bin-2d.js";
-import type { CellValue } from "../table.js";
 
 import { carriedColumns, emptyFrameExtras, removedStatWarning } from "./frame-helpers.js";
-import { makeColumnOf, styleColumns } from "./frame-stats-shared.js";
+import { colorColumns, makeColumnOf, styleColumns } from "./frame-stats-shared.js";
 import { positionColumn } from "./temporal-position.js";
 import type { Advisory, LayerBinding, LayerFrame, PipelineWarning } from "./types.js";
 import { NO_ROW } from "./types.js";
@@ -53,16 +52,6 @@ export function buildBin2dFrame(
   };
   const col = columnOf(result, null);
 
-  // fill after_stat: prefer statColumn (default count), else carried field.
-  let fillValues: readonly CellValue[] | null = null;
-  const fillStat = binding.fill.statColumn ?? null;
-  if (fillStat === null) {
-    fillValues = col(binding.fill.field);
-  } else {
-    const series = columns[fillStat] ?? result.count;
-    fillValues = Array.from(series, (v) => v as CellValue);
-  }
-
   return {
     binding,
     table,
@@ -75,8 +64,8 @@ export function buildBin2dFrame(
     inputGroups: groups,
     inputSourceRows: null,
     rowIndex: Uint32Array.from({ length: result.x.length }, () => NO_ROW),
-    colorValues: col(binding.color.field),
-    fillValues,
+    // after_stat color/fill (default fill = count; #799 / #953).
+    ...colorColumns(binding, col, columns),
     ...styleColumns(binding, col, columns),
     labelValues: col(binding.labelField),
     ...emptyFrameExtras(),

--- a/packages/core/src/pipeline/frame-stats-bin-frame.ts
+++ b/packages/core/src/pipeline/frame-stats-bin-frame.ts
@@ -4,7 +4,7 @@
 import type { ColumnTable } from "../table.js";
 
 import { emptyFrameExtras } from "./frame-helpers.js";
-import { styleColumns, type makeColumnOf } from "./frame-stats-shared.js";
+import { colorColumns, styleColumns, type makeColumnOf } from "./frame-stats-shared.js";
 import { forwardMeasureOnce } from "./stat-measure-transform.js";
 import type { LayerBinding, LayerFrame } from "./types.js";
 import { NO_ROW } from "./types.js";
@@ -51,8 +51,7 @@ export function packBinLayerFrame(
     inputGroups,
     inputSourceRows: null,
     rowIndex: Uint32Array.from({ length: result.x.length }, () => NO_ROW),
-    colorValues: col(binding.color.field),
-    fillValues: col(binding.fill.field),
+    ...colorColumns(binding, col, columns),
     ...styleColumns(binding, col, columns),
     labelValues: col(binding.labelField),
     ...emptyFrameExtras(),

--- a/packages/core/src/pipeline/frame-stats-bin-hex.ts
+++ b/packages/core/src/pipeline/frame-stats-bin-hex.ts
@@ -1,12 +1,12 @@
 /**
  * bin_hex stat → LayerFrame for hex polygon geometry.
  */
-import type { CellValue, ColumnTable } from "../table.js";
+import type { ColumnTable } from "../table.js";
 
 import { statBinHex } from "../stats/bin-hex.js";
 
 import { carriedColumns, emptyFrameExtras, removedStatWarning } from "./frame-helpers.js";
-import { makeColumnOf, styleColumns } from "./frame-stats-shared.js";
+import { colorColumns, makeColumnOf, styleColumns } from "./frame-stats-shared.js";
 import { positionColumn } from "./temporal-position.js";
 import type { Advisory, LayerBinding, LayerFrame, PipelineWarning } from "./types.js";
 import { NO_ROW } from "./types.js";
@@ -50,26 +50,6 @@ export function buildBinHexFrame(
   };
   const col = columnOf(result, null);
 
-  let fillValues: readonly CellValue[] | null = null;
-  const fillStat = binding.fill.statColumn ?? null;
-  if (fillStat === null) {
-    fillValues = col(binding.fill.field);
-  } else {
-    const series = columns[fillStat] ?? result.count;
-    fillValues = Array.from(series, (v) => v as CellValue);
-  }
-
-  // Outline colour: resolve after_stat the same way as fill (bin_hex publishes
-  // count/density/… in STAT_COLOR_COLUMNS; field-only would drop color: {stat}).
-  let colorValues: readonly CellValue[] | null = null;
-  const colorStat = binding.color.statColumn ?? null;
-  if (colorStat === null) {
-    colorValues = col(binding.color.field);
-  } else {
-    const series = columns[colorStat] ?? result.count;
-    colorValues = Array.from(series, (v) => v as CellValue);
-  }
-
   return {
     binding,
     table,
@@ -82,8 +62,8 @@ export function buildBinHexFrame(
     inputGroups: groups,
     inputSourceRows: null,
     rowIndex: Uint32Array.from({ length: result.x.length }, () => NO_ROW),
-    colorValues,
-    fillValues,
+    // after_stat color/fill (default fill = count; #800 / #953).
+    ...colorColumns(binding, col, columns),
     ...styleColumns(binding, col, columns),
     labelValues: col(binding.labelField),
     ...emptyFrameExtras(),

--- a/packages/core/src/pipeline/frame-stats-count.ts
+++ b/packages/core/src/pipeline/frame-stats-count.ts
@@ -8,6 +8,7 @@ import { scaleTransform } from "../scales/transform.js";
 import { carriedColumns, emptyFrameExtras, removedStatWarning } from "./frame-helpers.js";
 import { binIdColumn } from "./binned-scale.js";
 import {
+  colorColumns,
   makeColumnOf,
   shouldAggregateOnSemanticTemporalX,
   styleColumns,
@@ -110,8 +111,7 @@ export function buildCountFrame(
     inputGroups: groups,
     inputSourceRows: null,
     rowIndex: Uint32Array.from({ length: result.x.length }, () => NO_ROW),
-    colorValues: col(binding.color.field),
-    fillValues: col(binding.fill.field),
+    ...colorColumns(binding, col, { count: result.count }),
     ...styleColumns(binding, col, { count: result.count }),
     labelValues: col(binding.labelField),
     ...emptyFrameExtras(),

--- a/packages/core/src/pipeline/frame-stats-density-2d.ts
+++ b/packages/core/src/pipeline/frame-stats-density-2d.ts
@@ -6,25 +6,13 @@
 import type { Density2dParams } from "@ggsvelte/spec";
 
 import { statDensity2d } from "../stats/density-2d.js";
-import type { CellValue, ColumnTable } from "../table.js";
+import type { ColumnTable } from "../table.js";
 
 import { carriedColumns, emptyFrameExtras, removedStatWarning } from "./frame-helpers.js";
-import { makeColumnOf, styleColumns } from "./frame-stats-shared.js";
+import { colorColumns, makeColumnOf, styleColumns } from "./frame-stats-shared.js";
 import { positionColumn } from "./temporal-position.js";
-import type { ColorBinding, LayerBinding, LayerFrame, PipelineWarning } from "./types.js";
+import type { LayerBinding, LayerFrame, PipelineWarning } from "./types.js";
 import { NO_ROW } from "./types.js";
-
-function colorOrFillValues(
-  binding: ColorBinding,
-  columnOf: (field: string | null) => readonly CellValue[] | null,
-  computed: Readonly<Record<string, Float64Array>>,
-): readonly CellValue[] | null {
-  if ((binding.statColumn ?? null) !== null) {
-    const col = computed[binding.statColumn!];
-    return col === undefined ? null : Array.from(col);
-  }
-  return columnOf(binding.field);
-}
 
 export function buildDensity2dFrame(
   binding: LayerBinding,
@@ -95,8 +83,7 @@ export function buildDensity2dFrame(
     inputGroups: groups,
     inputSourceRows: null,
     rowIndex: Uint32Array.from({ length: outN }, () => NO_ROW),
-    colorValues: colorOrFillValues(binding.color, col, computed),
-    fillValues: colorOrFillValues(binding.fill, col, computed),
+    ...colorColumns(binding, col, computed),
     ...styleColumns(binding, col, computed),
     labelValues: col(binding.labelField),
     ...emptyFrameExtras(),

--- a/packages/core/src/pipeline/frame-stats-density.ts
+++ b/packages/core/src/pipeline/frame-stats-density.ts
@@ -6,7 +6,7 @@ import type { ColumnTable } from "../table.js";
 import { scaleTransform } from "../scales/transform.js";
 
 import { carriedColumns, emptyFrameExtras, removedStatWarning } from "./frame-helpers.js";
-import { makeColumnOf, styleColumns } from "./frame-stats-shared.js";
+import { colorColumns, makeColumnOf, styleColumns } from "./frame-stats-shared.js";
 import { transformedZeroBaseline } from "./position-baseline.js";
 import { forwardMeasureOnce } from "./stat-measure-transform.js";
 import { positionColumn } from "./temporal-position.js";
@@ -60,8 +60,7 @@ export function buildDensityFrame(
     inputGroups: groups,
     inputSourceRows: null,
     rowIndex: Uint32Array.from({ length: outN }, () => NO_ROW),
-    colorValues: col(binding.color.field),
-    fillValues: col(binding.fill.field),
+    ...colorColumns(binding, col, columns),
     ...styleColumns(binding, col, columns),
     labelValues: col(binding.labelField),
     ...emptyFrameExtras(),

--- a/packages/core/src/pipeline/frame-stats-shared.ts
+++ b/packages/core/src/pipeline/frame-stats-shared.ts
@@ -4,7 +4,7 @@
 import type { CellValue } from "../table.js";
 
 import type { PositionConversionContext } from "./temporal-position.js";
-import type { LayerBinding, LayerFrame } from "./types.js";
+import type { ColorBinding, LayerBinding, LayerFrame } from "./types.js";
 
 export type CarriedColumnOf = (
   result: { carried: Record<string, CellValue[]> },
@@ -14,6 +14,29 @@ export type CarriedColumnOf = (
 export function makeColumnOf(binding: LayerBinding): CarriedColumnOf {
   return (result, x) => (field) =>
     field === null ? null : field === binding.xField ? x : (result.carried[field] ?? null);
+}
+
+/**
+ * Resolve color/fill from a mapped field or an after_stat computed column (#953).
+ * Float64 after-stat series become CellValue arrays for scale training.
+ */
+export function colorColumns(
+  binding: LayerBinding,
+  columnOf: (field: string | null) => readonly CellValue[] | null,
+  computed: Readonly<Record<string, Float64Array | readonly CellValue[]>> = {},
+): Pick<LayerFrame, "colorValues" | "fillValues"> {
+  const valueOf = (channel: ColorBinding): readonly CellValue[] | null => {
+    const stat = channel.statColumn ?? null;
+    if (stat !== null) {
+      const col = computed[stat];
+      return col === undefined ? null : Array.from(col);
+    }
+    return columnOf(channel.field);
+  };
+  return {
+    colorValues: valueOf(binding.color),
+    fillValues: valueOf(binding.fill),
+  };
 }
 
 /** Resolve source/carried and after-stat style columns through one contract. */

--- a/packages/core/tests/pipeline-after-stat-color-resolve.test.ts
+++ b/packages/core/tests/pipeline-after-stat-color-resolve.test.ts
@@ -1,0 +1,99 @@
+/**
+ * after_stat color/fill resolution outside density_2d (#953).
+ *
+ * Stats already publish count/density/… columns; frame builders must wire
+ * them into colorValues/fillValues so continuous scales train and legends
+ * reflect the after-stat domain.
+ */
+import { describe, expect, it } from "bun:test";
+import { aes, gg } from "@ggsvelte/spec";
+import { runPipeline } from "../src/pipeline.ts";
+import type { PathsBatch, RectsBatch } from "../src/scene.ts";
+
+const size = { width: 400, height: 300 };
+
+function statChannelWarnings(warnings: readonly { code: string; message: string }[]): string[] {
+  return warnings.filter((w) => w.code === "stat-channel-unsupported").map((w) => w.message);
+}
+
+describe("after_stat color/fill resolution (#953)", () => {
+  it("maps fill = after_stat(count) on geom_histogram and trains a continuous fill scale", () => {
+    const model = runPipeline(
+      gg({ x: [1, 2, 2, 3, 3, 3, 4, 4, 4, 4] }, aes({ x: "x", fill: { stat: "count" } }))
+        .geomHistogram({ binwidth: 1, boundary: 0.5 })
+        .spec(),
+      size,
+    );
+    expect(statChannelWarnings(model.warnings)).toEqual([]);
+    expect(model.scales.fill?.kind).toBe("sequential");
+    const batch = model.scene.batches[0] as RectsBatch;
+    expect(batch.kind).toBe("rects");
+    expect(batch.fills).toBeDefined();
+    // Uneven counts → more than one painted fill colour.
+    expect(new Set(batch.fills).size).toBeGreaterThan(1);
+    // Legend trains on the after-stat domain (continuous ramp for fill).
+    const fillLegend = model.scene.legends.find((l) => l.scale === "fill");
+    expect(fillLegend).toBeDefined();
+    expect(fillLegend?.type).toBe("ramp");
+  });
+
+  it("resolves fill = after_stat(density) on geom_histogram", () => {
+    const model = runPipeline(
+      gg({ x: [1, 2, 2, 3, 3, 3] }, aes({ x: "x", fill: { stat: "density" } }))
+        .geomHistogram({ binwidth: 1, boundary: 0.5 })
+        .spec(),
+      size,
+    );
+    expect(statChannelWarnings(model.warnings)).toEqual([]);
+    expect(model.scales.fill?.kind).toBe("sequential");
+    const batch = model.scene.batches[0] as RectsBatch;
+    expect(new Set(batch.fills ?? []).size).toBeGreaterThan(1);
+  });
+
+  it("resolves fill = after_stat(ncount) and ndensity on geom_histogram", () => {
+    // Histogram is bar geom: data colouring is fill, not outline color.
+    for (const col of ["ncount", "ndensity"] as const) {
+      const model = runPipeline(
+        gg({ x: [1, 2, 2, 3, 3, 3, 4] }, aes({ x: "x", fill: { stat: col } }))
+          .geomHistogram({ binwidth: 1, boundary: 0.5 })
+          .spec(),
+        size,
+      );
+      expect(statChannelWarnings(model.warnings)).toEqual([]);
+      expect(model.scales.fill?.kind).toBe("sequential");
+      const batch = model.scene.batches[0] as RectsBatch;
+      expect(new Set(batch.fills ?? []).size).toBeGreaterThan(1);
+    }
+  });
+
+  it("maps fill = after_stat(count) on geom_bar (stat count)", () => {
+    const model = runPipeline(
+      gg({ x: ["a", "a", "b", "c", "c", "c"] }, aes({ x: "x", fill: { stat: "count" } }))
+        .geomBar()
+        .spec(),
+      size,
+    );
+    expect(statChannelWarnings(model.warnings)).toEqual([]);
+    expect(model.scales.fill?.kind).toBe("sequential");
+    const batch = model.scene.batches[0] as RectsBatch;
+    expect(batch.kind).toBe("rects");
+    expect(new Set(batch.fills ?? []).size).toBeGreaterThan(1);
+  });
+
+  it("maps fill = after_stat(density) on geom_density", () => {
+    const x = Array.from({ length: 80 }, (_, i) => Math.sin(i) * 2 + i * 0.05);
+    const model = runPipeline(
+      gg({ x }, aes({ x: "x", fill: { stat: "density" } }))
+        .geomDensity()
+        .spec(),
+      size,
+    );
+    expect(statChannelWarnings(model.warnings)).toEqual([]);
+    expect(model.scales.fill?.kind).toBe("sequential");
+    const batch = model.scene.batches[0] as PathsBatch;
+    expect(batch.kind).toBe("paths");
+    expect(batch.fills).toBeDefined();
+    // Density area is one path; fill is still scaled from after_stat density.
+    expect(batch.fills!.some((f) => f !== null && f !== undefined)).toBe(true);
+  });
+});

--- a/packages/core/tests/pipeline-after-stat-color.test.ts
+++ b/packages/core/tests/pipeline-after-stat-color.test.ts
@@ -1,11 +1,9 @@
 /**
  * after_stat color/fill diagnostics (#915).
  *
- * density_2d / density_2d_filled and bin_hex resolve after_stat colour into
- * frame color/fill values. Every other frame builds colour from the mapped
- * *field* alone; an `{ stat }` colour mapping there is accepted only when the
- * stat publishes the column, then dropped without a painted value — so those
- * stats emit `stat-channel-unsupported` when the column is not published.
+ * Supported stats (bin, count, density, density_2d, bin_hex, …) publish
+ * columns in STAT_COLOR_COLUMNS and resolve them via colorColumns (#953).
+ * Unsupported stats still emit `stat-channel-unsupported`.
  */
 import { describe, expect, it } from "bun:test";
 import { aes, gg } from "@ggsvelte/spec";
@@ -28,18 +26,14 @@ function cloud(n: number): { x: number[]; y: number[] } {
 }
 
 describe("after_stat color/fill (#915)", () => {
-  it("warns when a stat does not publish the after_stat fill column", () => {
+  it("stays silent for geom_histogram fill = after_stat(count) (#953)", () => {
     const model = runPipeline(
       gg({ x: [1, 2, 2, 3, 3, 3] }, aes({ x: "x", fill: { stat: "count" } }))
         .geomHistogram({ binwidth: 1, boundary: 0 })
         .spec(),
       size,
     );
-    const messages = statChannelWarnings(model.warnings);
-    expect(messages.length).toBe(1);
-    expect(messages[0]).toContain("fill");
-    expect(messages[0]).toContain("count");
-    // Diagnostic only — the layer still renders exactly as before.
+    expect(statChannelWarnings(model.warnings)).toEqual([]);
     expect(model.scene.batches.length).toBeGreaterThan(0);
   });
 


### PR DESCRIPTION
## Summary

- Shared `colorColumns` helper resolves field or after_stat color/fill (same contract as `styleColumns`).
- Wire it through **bin** (histogram), **count**, **density**, and fold **density_2d** / **bin_hex** / **bin_2d** onto it.
- Extend `STAT_COLOR_COLUMNS` so #915 no longer warns for supported combinations.
- Tests: continuous fill scale + legend for `aes(fill = after_stat(count))` on histogram; density/ncount/ndensity; count and density stats.

## Test plan

- [x] `bun test packages/core/tests/pipeline-after-stat-color-resolve.test.ts`
- [x] `bun test packages/core/tests/pipeline-after-stat-color.test.ts` (updated #915 cases)
- [x] Related geom/hex/bin2d/histogram/density suites green
- [x] `bun run check` (tsc + type-contracts + lifecycle)

Closes #953
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1019" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->