### PR TITLE
perf(docs): O(n²)→O(n) example module lookup via id map

### DIFF
--- a/apps/docs/src/lib/example-module-index.ts
+++ b/apps/docs/src/lib/example-module-index.ts
@@ -1,0 +1,50 @@
+/**
+ * O(1) lookup over Vite `import.meta.glob` tables keyed by example id
+ * (`category/name`). Replaces linear `Object.keys(table).find(endsWith)`
+ * scans used when resolving every corpus entry (llms-full) or a single
+ * example page load.
+ */
+
+/**
+ * Extract `category/name` from a glob key when it ends with `/${leaf}`.
+ * Returns null when the path is not a two-segment example module for that leaf.
+ */
+export function exampleIdFromGlobKey(path: string, leaf: string): string | null {
+  const suffix = `/${leaf}`;
+  if (!path.endsWith(suffix)) return null;
+  const withoutLeaf = path.slice(0, -suffix.length);
+  const parts = withoutLeaf.split("/").filter((segment) => segment.length > 0);
+  if (parts.length < 2) return null;
+  return `${parts[parts.length - 2]}/${parts[parts.length - 1]}`;
+}
+
+/**
+ * Build a Map from example id → module. Walks `Object.keys` once and keeps
+ * the first entry for each id (same winner as `Array.find` on key order).
+ */
+export function indexExampleModulesById<T>(table: Record<string, T>, leaf: string): Map<string, T> {
+  const map = new Map<string, T>();
+  for (const key of Object.keys(table)) {
+    const id = exampleIdFromGlobKey(key, leaf);
+    if (id === null || map.has(id)) continue;
+    map.set(id, table[key]!);
+  }
+  return map;
+}
+
+/**
+ * O(1) require for a previously indexed glob table.
+ * Error text keeps the historical `*${suffix}` shape for logs/tests.
+ */
+export function requireExampleModule<T>(
+  map: Map<string, T>,
+  id: string,
+  leaf: string,
+  label = "example module",
+): T {
+  const value = map.get(id);
+  if (value === undefined) {
+    throw new Error(`${label} not found: */${id}/${leaf} (manifest out of sync with the tree?)`);
+  }
+  return value;
+}

--- a/apps/docs/src/lib/example-module-index.ts
+++ b/apps/docs/src/lib/example-module-index.ts
@@ -15,7 +15,10 @@ export function exampleIdFromGlobKey(path: string, leaf: string): string | null 
   const withoutLeaf = path.slice(0, -suffix.length);
   const parts = withoutLeaf.split("/").filter((segment) => segment.length > 0);
   if (parts.length < 2) return null;
-  return `${parts[parts.length - 2]}/${parts[parts.length - 1]}`;
+  const category = parts.at(-2);
+  const name = parts.at(-1);
+  if (category === undefined || name === undefined) return null;
+  return `${category}/${name}`;
 }
 
 /**
@@ -27,7 +30,9 @@ export function indexExampleModulesById<T>(table: Record<string, T>, leaf: strin
   for (const key of Object.keys(table)) {
     const id = exampleIdFromGlobKey(key, leaf);
     if (id === null || map.has(id)) continue;
-    map.set(id, table[key]!);
+    const value = table[key];
+    if (value === undefined) continue;
+    map.set(id, value);
   }
   return map;
 }

--- a/apps/docs/src/lib/examples.ts
+++ b/apps/docs/src/lib/examples.ts
@@ -7,6 +7,8 @@
 import type { PortableSpec } from "@ggsvelte/spec";
 import type { Component } from "svelte";
 
+import { indexExampleModulesById, requireExampleModule } from "./example-module-index.js";
+
 export { EXAMPLES } from "$examples/manifest";
 export type { ExampleManifestEntry } from "$examples/manifest";
 
@@ -21,13 +23,11 @@ const svelteSources = import.meta.glob<string>("$examples/*/*/Example.svelte", {
   import: "default",
 });
 
-function pick<T>(table: Record<string, () => Promise<T>>, suffix: string): () => Promise<T> {
-  const key = Object.keys(table).find((k) => k.endsWith(suffix));
-  if (key === undefined) {
-    throw new Error(`example module not found: *${suffix} (manifest out of sync with the tree?)`);
-  }
-  return table[key];
-}
+// Module-scoped id maps: O(n) once, O(1) per loadExample (was O(n) per pick).
+const componentsById = indexExampleModulesById(components, "Example.svelte");
+const specsById = indexExampleModulesById(specs, "spec.ts");
+const specSourcesById = indexExampleModulesById(specSources, "spec.ts");
+const svelteSourcesById = indexExampleModulesById(svelteSources, "Example.svelte");
 
 export interface LoadedExample {
   component: Component;
@@ -39,10 +39,10 @@ export interface LoadedExample {
 /** Load one example's live component, canonical spec, and raw sources. */
 export async function loadExample(id: string): Promise<LoadedExample> {
   const [component, spec, specSource, svelteSource] = await Promise.all([
-    pick(components, `/${id}/Example.svelte`)(),
-    pick(specs, `/${id}/spec.ts`)(),
-    pick(specSources, `/${id}/spec.ts`)(),
-    pick(svelteSources, `/${id}/Example.svelte`)(),
+    requireExampleModule(componentsById, id, "Example.svelte")(),
+    requireExampleModule(specsById, id, "spec.ts")(),
+    requireExampleModule(specSourcesById, id, "spec.ts")(),
+    requireExampleModule(svelteSourcesById, id, "Example.svelte")(),
   ]);
   return {
     component: component.default,

--- a/apps/docs/src/routes/llms-full.txt/+server.ts
+++ b/apps/docs/src/routes/llms-full.txt/+server.ts
@@ -11,6 +11,7 @@ import type { LlmsFullExample } from "$scripts/gen-llms";
 import { buildLlmsFull, docsDiscoveryFacts, pruneSpecData } from "$scripts/gen-llms";
 
 import { EXAMPLES } from "$lib/examples";
+import { indexExampleModulesById, requireExampleModule } from "$lib/example-module-index";
 import { docsBuildConfig } from "$lib/server/build-config";
 import { GUIDE_PAGES } from "$lib/guide";
 
@@ -25,18 +26,19 @@ const svelteSources = import.meta.glob<string>("$examples/*/*/Example.svelte", {
   eager: true,
 });
 
-function pick<T>(table: Record<string, T>, suffix: string): T {
-  const key = Object.keys(table).find((k) => k.endsWith(suffix));
-  if (key === undefined) {
-    throw new Error(`llms-full: example module not found: *${suffix}`);
-  }
-  return table[key];
-}
+// Module-scoped id maps: O(n) once per table, O(1) per EXAMPLE (was O(n²)).
+const specsById = indexExampleModulesById(specs, "spec.ts");
+const svelteSourcesById = indexExampleModulesById(svelteSources, "Example.svelte");
 
 export function GET(): Response {
   const config = docsBuildConfig();
   const examples: LlmsFullExample[] = EXAMPLES.map((entry) => {
-    const full = pick(specs, `/${entry.id}/spec.ts`).default;
+    const full = requireExampleModule(
+      specsById,
+      entry.id,
+      "spec.ts",
+      "llms-full: example module",
+    ).default;
     // Cap inline data so one 10k-row example cannot dominate the corpus.
     const { spec, prunedRows } = pruneSpecData(full, 20);
     const suffix =
@@ -44,7 +46,12 @@ export function GET(): Response {
     return {
       ...entry,
       specJSON: JSON.stringify(spec, null, 2) + suffix,
-      svelteSource: pick(svelteSources, `/${entry.id}/Example.svelte`),
+      svelteSource: requireExampleModule(
+        svelteSourcesById,
+        entry.id,
+        "Example.svelte",
+        "llms-full: example module",
+      ),
     };
   });
   return new Response(

--- a/scripts/example-module-index.test.ts
+++ b/scripts/example-module-index.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  exampleIdFromGlobKey,
+  indexExampleModulesById,
+  requireExampleModule,
+} from "../apps/docs/src/lib/example-module-index.js";
+
+describe("exampleIdFromGlobKey", () => {
+  test("extracts category/name from vite-style absolute paths", () => {
+    expect(exampleIdFromGlobKey("/repo/examples/point/scatter-color/spec.ts", "spec.ts")).toBe(
+      "point/scatter-color",
+    );
+    expect(
+      exampleIdFromGlobKey(
+        "/repo/examples/interaction/brush-zoom/Example.svelte",
+        "Example.svelte",
+      ),
+    ).toBe("interaction/brush-zoom");
+  });
+
+  test("returns null when the path does not end with the leaf", () => {
+    expect(exampleIdFromGlobKey("/repo/examples/point/scatter-color/data.ts", "spec.ts")).toBe(
+      null,
+    );
+  });
+
+  test("returns null when fewer than two path segments precede the leaf", () => {
+    expect(exampleIdFromGlobKey("/scatter-color/spec.ts", "spec.ts")).toBe(null);
+  });
+});
+
+describe("indexExampleModulesById", () => {
+  test("maps each example id to its module value", () => {
+    const table = {
+      "/abs/examples/point/scatter-color/spec.ts": { id: "a" },
+      "/abs/examples/line/multi-series/spec.ts": { id: "b" },
+      "/abs/examples/point/scatter-color/data.ts": { id: "noise" },
+    };
+    const map = indexExampleModulesById(table, "spec.ts");
+    expect(map.size).toBe(2);
+    expect(map.get("point/scatter-color")).toEqual({ id: "a" });
+    expect(map.get("line/multi-series")).toEqual({ id: "b" });
+  });
+
+  test("first Object.keys winner wins on duplicate ids (matches Array.find)", () => {
+    // Object key order is insertion order for string keys.
+    const table = {
+      "/first/examples/point/scatter-color/spec.ts": "first",
+      "/second/examples/point/scatter-color/spec.ts": "second",
+    };
+    const map = indexExampleModulesById(table, "spec.ts");
+    expect(map.get("point/scatter-color")).toBe("first");
+  });
+});
+
+describe("requireExampleModule", () => {
+  test("returns the mapped module", () => {
+    const map = indexExampleModulesById({ "/examples/bar/stacked/spec.ts": 42 }, "spec.ts");
+    expect(requireExampleModule(map, "bar/stacked", "spec.ts")).toBe(42);
+  });
+
+  test("throws with the historical *suffix shape when missing", () => {
+    const map = new Map<string, number>();
+    expect(() => requireExampleModule(map, "missing/id", "spec.ts")).toThrow(
+      "example module not found: */missing/id/spec.ts",
+    );
+  });
+});
+
+/** Historical linear pick — characterization oracle for Map parity. */
+function legacyPick<T>(table: Record<string, T>, suffix: string): T | undefined {
+  const key = Object.keys(table).find((k) => k.endsWith(suffix));
+  return key === undefined ? undefined : table[key];
+}
+
+describe("index parity with legacy endsWith pick", () => {
+  test("resolves the same module as pick for every id in a mixed-prefix table", () => {
+    const table: Record<string, string> = {
+      "/workspace/examples/point/scatter-color/spec.ts": "scatter",
+      "/workspace/examples/line/multi-series/spec.ts": "multi",
+      "/workspace/examples/interaction/brush-zoom/spec.ts": "brush",
+      "/workspace/examples/point/scatter-color/data.ts": "noise",
+    };
+    const map = indexExampleModulesById(table, "spec.ts");
+    for (const id of ["point/scatter-color", "line/multi-series", "interaction/brush-zoom"]) {
+      expect(map.get(id)).toBe(legacyPick(table, `/${id}/spec.ts`));
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Big-O maintain pass on `apps/docs` (scope narrowed past the 80-file audit cap: production `src` + configs, skip `generated/`/`build/`).

**Finding:** Nested linear search (#2) — `Object.keys(table).find(k => k.endsWith(suffix))` for every example when building `/llms-full.txt`, and four times per `loadExample` page load.

- **Before:** O(n²) for llms-full (n = corpus size, currently 85); O(n) per single example load
- **After:** O(n) index once at module load + O(1) lookup per id
- **n is:** number of example modules in the gallery corpus (grows with new geoms/examples)

Shared helper `example-module-index.ts`: extract `category/name` from glob keys, first-wins Map (matches `Array.find` key order). Wired in:

- `apps/docs/src/routes/llms-full.txt/+server.ts`
- `apps/docs/src/lib/examples.ts`

## Test plan

- [x] `bun test ./scripts/example-module-index.test.ts` (id extraction, first-wins, missing require, legacy-pick parity)
- [x] Linear `pick` removed from both call sites
- [ ] CI green on this PR

## Follow-ups

None. Other audit notes (gallery tag `includes`, `guideSequence` re-sort, linear docs search) stay tiny-n / intentional algorithms — not filed as issues.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1020" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->