### PR TITLE
refactor(svelte): extract pure data-identity epoch input builder (#852)

### DIFF
--- a/.changeset/852-data-identity-epoch-input.md
+++ b/.changeset/852-data-identity-epoch-input.md
@@ -1,0 +1,11 @@
+---
+"@ggsvelte/svelte": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+refactor(svelte): extract pure data-identity epoch input builder
+
+Move markLayers-vs-layers-prop, ready-without-assembled, and explicit-spec
+content pick into buildDataIdentityEpochInput next to dataIdentityEpochToken.
+plot-engine keeps the tracker and $derived call site.

--- a/packages/svelte/src/lib/plot-engine.svelte.ts
+++ b/packages/svelte/src/lib/plot-engine.svelte.ts
@@ -98,7 +98,11 @@ import type { PlotAnnouncer } from "./runtime/announcer.svelte.js";
 import { createPlotRuntime } from "./runtime/runtime.svelte.js";
 import type { PlotRuntime } from "./runtime/runtime.svelte.js";
 import { createSemanticCandidateProjection } from "./runtime/semantic-candidate-projection.svelte.js";
-import { createSourceIdentityTracker, dataIdentityEpochToken } from "./runtime/semantic-keys.js";
+import {
+  buildDataIdentityEpochInput,
+  createSourceIdentityTracker,
+  dataIdentityEpochToken,
+} from "./runtime/semantic-keys.js";
 import {
   createSemanticKeyService,
   type SemanticKeyService,
@@ -432,44 +436,20 @@ export function createPlotEngine<
   // new prop references or in-place row-order changes still bump the epoch.
   // Tracker is owned for the component lifetime (never cleared).
   const identityTracker = createSourceIdentityTracker();
-  const dataIdentityEpoch = $derived.by(() => {
-    const data = inputs.data();
-    const spec = inputs.spec();
-    const layers = inputs.layers();
-    // Declaration children expose live data getters via the registry.
-    // MUST use markLayers (not layers): the widened Layer union has no `.data`
-    // at the top level, so reading registry.layers would silently drop
-    // layer-local data from the #609 epoch and make a theme-only plot
-    // look "ready".
-    const layerDescriptors =
-      layers === undefined
-        ? inputs.registry.markLayers
-        : layers.map((layer) => ({ data: (layer as { data?: unknown }).data }));
-    const layerCount = layerDescriptors.length;
-    // Ready without reading `assembled` so chrome-only respecs do not re-enter.
-    const ready = spec !== undefined || layerCount > 0;
-    const sourceIdentity = (value: unknown) => identityTracker.sourceIdentity(value);
-    // assemblePortableSpec: explicit `spec` wins and ignores the data prop —
-    // fingerprint the rendered source only (Codex P2).
-    const contentData =
-      spec !== undefined && typeof spec === "object" ? (spec as { data?: unknown }).data : data;
-    const contentDatasets =
-      spec !== undefined && typeof spec === "object"
-        ? (spec as { datasets?: unknown }).datasets
-        : undefined;
-    // Layer-local data must participate: a plot with only geom-child data and
-    // no plot data/spec prop would otherwise keep a stable epoch across row
-    // replacements (#609).
-    return dataIdentityEpochToken({
-      ready,
-      dataToken: sourceIdentity(data),
-      specToken: sourceIdentity(spec),
-      data: contentData ?? null,
-      datasets: contentDatasets ?? null,
-      layers: layerDescriptors,
-      sourceIdentity,
-    });
-  });
+  // Source identity tracker stays here (component lifetime). Pure fingerprint
+  // assembly lives in buildDataIdentityEpochInput (#852).
+  const dataIdentityEpoch = $derived.by(() =>
+    dataIdentityEpochToken(
+      buildDataIdentityEpochInput({
+        data: inputs.data(),
+        spec: inputs.spec(),
+        layers: inputs.layers(),
+        // Declaration children: markLayers only (not registry.layers) — #609.
+        registryMarkLayers: inputs.registry.markLayers,
+        sourceIdentity: (value: unknown) => identityTracker.sourceIdentity(value),
+      }),
+    ),
+  );
 
   // Live-region announcer (owned early so legend-reset effects can call it).
   const announcer = createPlotAnnouncer();

--- a/packages/svelte/src/lib/runtime/semantic-keys.ts
+++ b/packages/svelte/src/lib/runtime/semantic-keys.ts
@@ -175,6 +175,64 @@ function layersDataOrderToken(
 }
 
 /**
+ * Input bag for {@link dataIdentityEpochToken}. Built by the host (or
+ * {@link buildDataIdentityEpochInput}) so epoch construction stays pure.
+ */
+export type DataIdentityEpochTokenInput = {
+  readonly ready: boolean;
+  readonly dataToken: string;
+  readonly specToken: string;
+  readonly data: unknown;
+  readonly datasets: unknown;
+  readonly layers?: readonly { readonly data?: unknown }[];
+  readonly sourceIdentity: (value: unknown) => string;
+};
+
+/**
+ * Host-side assembly of {@link DataIdentityEpochTokenInput} from plot props.
+ *
+ * Pure: no runes, no assembled PortableSpec. Owns the markLayers-vs-layers-prop
+ * guard (#609), the ready-without-assembled rule, and the explicit-spec content
+ * pick (prop `data` is ignored when `spec` is an object — matches
+ * assemblePortableSpec).
+ */
+export function buildDataIdentityEpochInput(input: {
+  readonly data: unknown;
+  readonly spec: unknown;
+  readonly layers: readonly { readonly data?: unknown }[] | undefined;
+  readonly registryMarkLayers: readonly { readonly data?: unknown }[];
+  readonly sourceIdentity: (value: unknown) => string;
+}): DataIdentityEpochTokenInput {
+  // MUST use markLayers when layers prop is absent: the widened Layer union
+  // has no `.data` at the top level, so reading registry.layers would silently
+  // drop layer-local data from the #609 epoch.
+  const layerDescriptors =
+    input.layers === undefined
+      ? input.registryMarkLayers
+      : input.layers.map((layer) => ({ data: layer.data }));
+  const ready = input.spec !== undefined || layerDescriptors.length > 0;
+  // assemblePortableSpec: explicit `spec` wins and ignores the data prop —
+  // fingerprint the rendered source only.
+  const contentData =
+    input.spec !== undefined && typeof input.spec === "object"
+      ? (input.spec as { data?: unknown }).data
+      : input.data;
+  const contentDatasets =
+    input.spec !== undefined && typeof input.spec === "object"
+      ? (input.spec as { datasets?: unknown }).datasets
+      : undefined;
+  return {
+    ready,
+    dataToken: input.sourceIdentity(input.data),
+    specToken: input.sourceIdentity(input.spec),
+    data: contentData ?? null,
+    datasets: contentDatasets ?? null,
+    layers: layerDescriptors,
+    sourceIdentity: input.sourceIdentity,
+  };
+}
+
+/**
  * Stable data/spec identity token for inspection reconcile epochs.
  *
  * Host supplies:
@@ -189,15 +247,7 @@ function layersDataOrderToken(
  * Ready=false (no plot yet) → `"no-data"`. Complexity: O(R) over row refs,
  * not O(R·F) deep cell serialization.
  */
-export function dataIdentityEpochToken(input: {
-  readonly ready: boolean;
-  readonly dataToken: string;
-  readonly specToken: string;
-  readonly data: unknown;
-  readonly datasets: unknown;
-  readonly layers?: readonly { readonly data?: unknown }[];
-  readonly sourceIdentity: (value: unknown) => string;
-}): string {
+export function dataIdentityEpochToken(input: DataIdentityEpochTokenInput): string {
   if (!input.ready) return "no-data";
   return `${input.dataToken}:${input.specToken}:${dataContentOrderToken(input.data, input.sourceIdentity)}:${datasetsOrderToken(input.datasets, input.sourceIdentity)}:${layersDataOrderToken(input.layers, input.sourceIdentity)}`;
 }

--- a/packages/svelte/tests/runtime/semantic-keys-epoch-input.ssr.test.ts
+++ b/packages/svelte/tests/runtime/semantic-keys-epoch-input.ssr.test.ts
@@ -1,0 +1,165 @@
+/**
+ * #852 — pure host-side data-identity epoch input assembly.
+ * SSR lane: markLayers vs layers-prop, ready-without-assembled, content pick.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  buildDataIdentityEpochInput,
+  createSourceIdentityTracker,
+  dataIdentityEpochToken,
+} from "../../src/lib/runtime/semantic-keys.js";
+
+describe("buildDataIdentityEpochInput", () => {
+  it("uses registry markLayers when the layers prop is absent (not union layers)", () => {
+    const tracker = createSourceIdentityTracker();
+    const id = (value: unknown) => tracker.sourceIdentity(value);
+    const markRows = [
+      { x: 1, y: 2 },
+      { x: 3, y: 4 },
+    ];
+    // markLayers expose .data; a widened registry.layers entry would not.
+    const markLayers = [{ data: markRows }];
+    const input = buildDataIdentityEpochInput({
+      data: undefined,
+      spec: undefined,
+      layers: undefined,
+      registryMarkLayers: markLayers,
+      sourceIdentity: id,
+    });
+    expect(input.ready).toBe(true);
+    expect(input.layers).toEqual(markLayers);
+    // Token must include layer-local data (#609).
+    expect(dataIdentityEpochToken(input)).not.toBe(
+      dataIdentityEpochToken({
+        ...input,
+        layers: [],
+      }),
+    );
+  });
+
+  it("prefers the layers prop over registry markLayers when provided", () => {
+    const tracker = createSourceIdentityTracker();
+    const id = (value: unknown) => tracker.sourceIdentity(value);
+    const propRows = [{ x: 10, y: 20 }];
+    const markRows = [{ x: 1, y: 2 }];
+    const input = buildDataIdentityEpochInput({
+      data: undefined,
+      spec: undefined,
+      layers: [{ data: propRows }, { data: undefined }],
+      registryMarkLayers: [{ data: markRows }],
+      sourceIdentity: id,
+    });
+    expect(input.layers).toEqual([{ data: propRows }, { data: undefined }]);
+    // Prop path must not silently fingerprint markLayers instead.
+    const viaMarkOnly = buildDataIdentityEpochInput({
+      data: undefined,
+      spec: undefined,
+      layers: undefined,
+      registryMarkLayers: [{ data: markRows }],
+      sourceIdentity: id,
+    });
+    expect(dataIdentityEpochToken(input)).not.toBe(dataIdentityEpochToken(viaMarkOnly));
+  });
+
+  it("is ready from spec or layers without reading assembled", () => {
+    const tracker = createSourceIdentityTracker();
+    const id = (value: unknown) => tracker.sourceIdentity(value);
+    // Spec alone → ready (chrome-only respec path must not need assembled).
+    expect(
+      buildDataIdentityEpochInput({
+        data: undefined,
+        spec: { data: [{ x: 1 }] },
+        layers: undefined,
+        registryMarkLayers: [],
+        sourceIdentity: id,
+      }).ready,
+    ).toBe(true);
+    // Layers alone (mark registry) → ready.
+    expect(
+      buildDataIdentityEpochInput({
+        data: undefined,
+        spec: undefined,
+        layers: undefined,
+        registryMarkLayers: [{ data: [{ x: 1 }] }],
+        sourceIdentity: id,
+      }).ready,
+    ).toBe(true);
+    // Empty layers prop: length 0 → not ready; markLayers are ignored when prop is set.
+    expect(
+      buildDataIdentityEpochInput({
+        data: [{ x: 1 }],
+        spec: undefined,
+        layers: [],
+        registryMarkLayers: [{ data: [{ x: 99 }] }],
+        sourceIdentity: id,
+      }).ready,
+    ).toBe(false);
+    // No spec, no layers → not ready even if a data prop exists.
+    expect(
+      buildDataIdentityEpochInput({
+        data: [{ x: 1 }],
+        spec: undefined,
+        layers: undefined,
+        registryMarkLayers: [],
+        sourceIdentity: id,
+      }).ready,
+    ).toBe(false);
+  });
+
+  it("fingerprints spec content data/datasets when an explicit spec object wins", () => {
+    const tracker = createSourceIdentityTracker();
+    const id = (value: unknown) => tracker.sourceIdentity(value);
+    const propData = [{ x: 1 }];
+    const specData = [{ x: 9 }];
+    const shared = { a: [{ n: 1 }] };
+    const withSpec = buildDataIdentityEpochInput({
+      data: propData,
+      spec: { data: specData, datasets: shared },
+      layers: undefined,
+      registryMarkLayers: [],
+      sourceIdentity: id,
+    });
+    // assemblePortableSpec: explicit spec wins — prop data must not be fingerprinted.
+    expect(withSpec.data).toBe(specData);
+    expect(withSpec.datasets).toBe(shared);
+    const withoutSpec = buildDataIdentityEpochInput({
+      data: propData,
+      spec: undefined,
+      layers: undefined,
+      registryMarkLayers: [],
+      sourceIdentity: id,
+    });
+    expect(withoutSpec.data).toBe(propData);
+    expect(withoutSpec.datasets).toBeNull();
+    // Same identity tracker → different content tokens because data sources differ.
+    expect(dataIdentityEpochToken({ ...withSpec, ready: true })).not.toBe(
+      dataIdentityEpochToken({ ...withoutSpec, ready: true }),
+    );
+  });
+
+  it("emits stable prop tokens via sourceIdentity for data and spec refs", () => {
+    const tracker = createSourceIdentityTracker();
+    const id = (value: unknown) => tracker.sourceIdentity(value);
+    const data = [{ x: 1 }];
+    const spec = { data: [{ x: 2 }] };
+    const first = buildDataIdentityEpochInput({
+      data,
+      spec,
+      layers: undefined,
+      registryMarkLayers: [],
+      sourceIdentity: id,
+    });
+    const second = buildDataIdentityEpochInput({
+      data,
+      spec,
+      layers: undefined,
+      registryMarkLayers: [],
+      sourceIdentity: id,
+    });
+    expect(first.dataToken).toBe(second.dataToken);
+    expect(first.specToken).toBe(second.specToken);
+    expect(first.dataToken).toBe(id(data));
+    expect(first.specToken).toBe(id(spec));
+  });
+});


### PR DESCRIPTION
## Summary

- Extract `buildDataIdentityEpochInput` next to `dataIdentityEpochToken` so markLayers-vs-layers-prop, ready-without-assembled, and explicit-spec content pick are pure and SSR-testable.
- Wire `plot-engine` `$derived` to call the helper; keep `createSourceIdentityTracker` ownership in the engine.
- Add SSR unit tests covering the #609 layer path and content-data vs content-datasets pick.

Closes #852

## Test plan

- [x] `bun run test:ssr -- tests/runtime/semantic-keys-epoch-input.ssr.test.ts`
- [x] `bun run test:browser -- tests/interaction/plot-layer-epoch.test.ts tests/runtime/semantic-keys-pure.test.ts`
- [x] `bunx tsc --noEmit -p packages/svelte`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1021" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->