### PR TITLE
test(playground): close agent pipeline and worker coverage gaps (#698)

### DIFF
--- a/scripts/cloudflare-playground-api-config.test.ts
+++ b/scripts/cloudflare-playground-api-config.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Config-contract for workers/playground-api/wrangler.toml.
+ *
+ * handleGenerate fails closed when OPENROUTER_API_KEY is set but a rate-limit
+ * binding is missing (503 disabled). A typo in either the toml binding names
+ * or PlaygroundApiEnv therefore 503s 100% of production traffic while the
+ * handler unit suite stays green — same failure mode as the Pages config
+ * contract in cloudflare-pages-config.test.ts (#698).
+ */
+
+const ROOT = join(import.meta.dir, "..");
+const TOML = readFileSync(join(ROOT, "workers", "playground-api", "wrangler.toml"), "utf8");
+const HANDLER = readFileSync(join(ROOT, "workers", "playground-api", "src", "handler.ts"), "utf8");
+
+function bindingNames(toml: string): string[] {
+  const names: string[] = [];
+  for (const match of toml.matchAll(/^\s*name\s*=\s*"([^"]+)"/gmu)) {
+    const name = match[1];
+    if (name !== undefined) names.push(name);
+  }
+  return names;
+}
+
+describe("Cloudflare playground-api wrangler contract", () => {
+  it("names the worker and pins the entry module", () => {
+    expect(TOML).toMatch(/^\s*name\s*=\s*"ggsvelte-playground-api"/mu);
+    expect(TOML).toMatch(/^\s*main\s*=\s*"src\/index\.ts"/mu);
+    expect(TOML).toMatch(/^\s*compatibility_date\s*=\s*"\d{4}-\d{2}-\d{2}"/mu);
+  });
+
+  it("declares the rate-limit bindings the handler fails closed without", () => {
+    const names = bindingNames(TOML);
+    expect(names).toContain("RATE_LIMIT_IP");
+    expect(names).toContain("RATE_LIMIT_GLOBAL");
+    expect(TOML).toMatch(/\[\[unsafe\.bindings\]\][\s\S]*type\s*=\s*"ratelimit"/u);
+  });
+
+  it("keeps PlaygroundApiEnv field names aligned with wrangler bindings and vars", () => {
+    // Interface is the TypeScript contract; toml is the deploy contract.
+    expect(HANDLER).toMatch(/readonly OPENROUTER_API_KEY\?: string/u);
+    expect(HANDLER).toMatch(/readonly MODEL_ALLOWLIST\?: string/u);
+    expect(HANDLER).toMatch(/readonly DISABLED\?: string/u);
+    expect(HANDLER).toMatch(/readonly RATE_LIMIT_IP\?: RateLimitBinding/u);
+    expect(HANDLER).toMatch(/readonly RATE_LIMIT_GLOBAL\?: RateLimitBinding/u);
+
+    expect(TOML).toMatch(/MODEL_ALLOWLIST\s*=/u);
+    expect(TOML).toMatch(/DISABLED\s*=/u);
+    // Secret is set at deploy time, not in committed vars.
+    expect(TOML).toContain("wrangler secret put OPENROUTER_API_KEY");
+    expect(TOML).not.toMatch(/^\s*OPENROUTER_API_KEY\s*=/mu);
+  });
+
+  it("pins free-tier allowlist defaults that match DEFAULT_MODELS", () => {
+    // A silent drift here would send paid traffic or an empty models list.
+    expect(HANDLER).toContain("google/gemini-2.0-flash-exp:free");
+    expect(HANDLER).toContain("meta-llama/llama-3.3-70b-instruct:free");
+    expect(TOML).toContain("google/gemini-2.0-flash-exp:free");
+    expect(TOML).toContain("meta-llama/llama-3.3-70b-instruct:free");
+  });
+});

--- a/scripts/playground-agent-state.test.ts
+++ b/scripts/playground-agent-state.test.ts
@@ -77,6 +77,26 @@ describe("playground agent client", () => {
     expect(result.envelope.spec).toBeDefined();
   });
 
+  // Production default is mock until the worker is deployed. Every other unit
+  // test passes an explicit mode and Playwright uses ?gg-api=live, so this is
+  // the only assertion that pins the no-option path.
+  test("default mode (no options, no query hook) is mock", async () => {
+    let fetchCalled = false;
+    const result = await generateChart(
+      { prompt: "hi", datasetId: "penguins" },
+      {
+        fetchFn: () => {
+          fetchCalled = true;
+          return Promise.resolve(new Response("{}", { status: 500 }));
+        },
+      },
+    );
+    expect(fetchCalled).toBe(false);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.model).toBe("mock");
+  });
+
   test("fetch rejection maps to network (OV8-2)", async () => {
     const result = await generateChart(
       { prompt: "hi", datasetId: "penguins" },

--- a/scripts/playground-output.test.ts
+++ b/scripts/playground-output.test.ts
@@ -201,4 +201,29 @@ describe("playground outputs", () => {
     expect(output).toContain("\\u2028");
     expect(output).toContain("\\u2029");
   });
+
+  // A second `"values": "__GG_PLAYGROUND_DATA_VALUES__"` (e.g. in layer params)
+  // makes the data seam non-unique; the generator must fall back to plain
+  // inline data rather than replacing the wrong occurrence.
+  test("falls back to inline data when the sentinel string appears as another values field", () => {
+    const forged: PortableSpec = {
+      ...spec,
+      layers: [
+        {
+          geom: "point",
+          stat: "identity",
+          position: "identity",
+          aes: { x: { field: "label" }, y: { field: "value" } },
+          // Forged second values field — same serial form as the data seam.
+          params: { values: "__GG_PLAYGROUND_DATA_VALUES__" },
+        },
+      ],
+    };
+    const output = playgroundSvelteOutput(forged);
+    expect(output).not.toContain("← replace with your rows");
+    expect(output).not.toMatch(/"values":\s*rows/u);
+    expect(output).toContain("const spec: PortableSpec =");
+    expect(output).toContain('"__GG_PLAYGROUND_DATA_VALUES__"');
+    expect(parseSpecFromSvelteOutput(output)).toEqual(forged);
+  });
 });

--- a/scripts/playground-output.test.ts
+++ b/scripts/playground-output.test.ts
@@ -206,7 +206,9 @@ describe("playground outputs", () => {
   // makes the data seam non-unique; the generator must fall back to plain
   // inline data rather than replacing the wrong occurrence.
   test("falls back to inline data when the sentinel string appears as another values field", () => {
-    const forged: PortableSpec = {
+    // Intentionally illegal layer shape: a second `values` field that serializes
+    // to the same quoted form as the data seam. Cast is the point of the forge.
+    const forged = {
       ...spec,
       layers: [
         {
@@ -214,11 +216,10 @@ describe("playground outputs", () => {
           stat: "identity",
           position: "identity",
           aes: { x: { field: "label" }, y: { field: "value" } },
-          // Forged second values field — same serial form as the data seam.
           params: { values: "__GG_PLAYGROUND_DATA_VALUES__" },
         },
       ],
-    };
+    } as unknown as PortableSpec;
     const output = playgroundSvelteOutput(forged);
     expect(output).not.toContain("← replace with your rows");
     expect(output).not.toMatch(/"values":\s*rows/u);

--- a/tests/visual/playground.spec.ts
+++ b/tests/visual/playground.spec.ts
@@ -427,6 +427,127 @@ test("cancel during generation reaches the aborted state", async ({ page }) => {
   await expect(page.getByRole("button", { name: "Generate" })).toBeEnabled();
 });
 
+test("repair transport failure keeps prior chart and shows SpecError Details", async ({ page }) => {
+  let calls = 0;
+  await page.route("**/v1/generate", async (route) => {
+    calls += 1;
+    if (calls === 1) {
+      // Repairable: unknown field on curated penguins schema.
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          ok: true,
+          model: "stub/model",
+          envelope: {
+            spec: {
+              edition: 2,
+              data: { name: "penguins" },
+              layers: [
+                {
+                  geom: "point",
+                  aes: { x: { field: "no_such_field" }, y: { field: "mass" } },
+                },
+              ],
+              labs: { title: "Must not promote" },
+              height: 400,
+            },
+            interactions: {
+              inspect: true,
+              select: false,
+              zoom: false,
+              legendFilter: false,
+              legendFocus: false,
+            },
+            title: "Must not promote",
+          },
+        }),
+      });
+      return;
+    }
+    // Second call is the repair round — fail the transport.
+    await route.fulfill({
+      status: 502,
+      contentType: "application/json",
+      body: JSON.stringify({
+        ok: false,
+        error: { code: "upstream_error", message: "Upstream failed" },
+      }),
+    });
+  });
+
+  const beforeTitle = await (async () => {
+    await page.goto("/playground?gg-api=live");
+    await settleVisualState(page);
+    return page.locator(".active-chart .gg-title").textContent();
+  })();
+
+  await page.getByLabel("Rewrite this chart").fill("Chart that needs repair then fails");
+  await page.getByRole("button", { name: "Generate" }).click();
+
+  const alert = page.getByRole("alert");
+  await expect(alert).toBeVisible();
+  // Degraded UX: Details disclosure with the first-round SpecError payload.
+  await expect(alert.getByText("Details")).toBeVisible();
+  await alert.getByText("Details").click();
+  await expect(alert.locator("pre")).toContainText("no_such_field");
+  // Prior chart stays put — never promote the invalid envelope.
+  await expect(page.locator(".active-chart .gg-title")).toHaveText(beforeTitle ?? "");
+  expect(calls).toBe(2);
+});
+
+test("repair still invalid surfaces validation Details and does not promote", async ({ page }) => {
+  await page.route("**/v1/generate", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        ok: true,
+        model: "stub/model",
+        envelope: {
+          spec: {
+            edition: 2,
+            data: { name: "penguins" },
+            layers: [
+              {
+                geom: "point",
+                aes: { x: { field: "no_such_field" }, y: { field: "mass" } },
+              },
+            ],
+            labs: { title: "Still broken" },
+            height: 400,
+          },
+          interactions: {
+            inspect: true,
+            select: false,
+            zoom: false,
+            legendFilter: false,
+            legendFocus: false,
+          },
+          title: "Still broken",
+        },
+      }),
+    });
+  });
+
+  await page.goto("/playground?gg-api=live");
+  await settleVisualState(page);
+  const beforeTitle = await page.locator(".active-chart .gg-title").textContent();
+
+  await page.getByLabel("Rewrite this chart").fill("Keep failing validation after repair");
+  await page.getByRole("button", { name: "Generate" }).click();
+
+  const alert = page.getByRole("alert");
+  await expect(alert).toBeVisible();
+  // Failure message is the first SpecError text (not a generic code label).
+  await expect(alert.locator("p").first()).not.toBeEmpty();
+  await expect(alert.getByText("Details")).toBeVisible();
+  await alert.getByText("Details").click();
+  await expect(alert.locator("pre")).toContainText("no_such_field");
+  await expect(page.locator(".active-chart .gg-title")).toHaveText(beforeTitle ?? "");
+  await expect(page.locator(".active-chart .gg-title")).not.toHaveText("Still broken");
+});
+
 test("capability toggles change codegen output", async ({ page }) => {
   await page.goto("/playground");
   await settleVisualState(page);

--- a/workers/playground-api/test/handler.test.ts
+++ b/workers/playground-api/test/handler.test.ts
@@ -163,6 +163,79 @@ describe("handleGenerate", () => {
     );
   });
 
+  test("rejects whitespace-only, missing, and non-string prompts", async () => {
+    for (const body of [
+      { prompt: "   \n\t  ", datasetId: "penguins" },
+      { datasetId: "penguins" },
+      { prompt: 42, datasetId: "penguins" },
+      { prompt: null, datasetId: "penguins" },
+    ]) {
+      const res = await handleGenerate(request(body), {
+        OPENROUTER_API_KEY: "sk-test",
+        ...okLimiters,
+      });
+      expect(res.status).toBe(400);
+      expect(((await res.json()) as { error: { code: string } }).error.code).toBe("bad_request");
+    }
+  });
+
+  test("rejects non-array priorErrors", async () => {
+    const res = await handleGenerate(
+      request({
+        prompt: "fix",
+        datasetId: "penguins",
+        priorSpec: { edition: 2 },
+        priorErrors: { code: "not-an-array" },
+      }),
+      { OPENROUTER_API_KEY: "sk-test", ...okLimiters },
+    );
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: { code: string } }).error.code).toBe("bad_request");
+  });
+
+  test("slices priorErrors to PRIOR_ERRORS_MAX before assembling messages", async () => {
+    let repairUser = "";
+    const seven = Array.from({ length: 7 }, (_, i) => ({
+      code: `err-${i}`,
+      path: `/${i}`,
+      message: `m${i}`,
+    }));
+    await handleGenerate(
+      request({
+        prompt: "fix",
+        datasetId: "penguins",
+        priorSpec: { edition: 2, data: { name: "penguins" }, layers: [] },
+        priorErrors: seven,
+      }),
+      {
+        OPENROUTER_API_KEY: "sk-test-key",
+        ...okLimiters,
+        fetch: (_url, init) => {
+          const body = JSON.parse(typeof init.body === "string" ? init.body : "{}") as {
+            messages?: Array<{ role: string; content: string }>;
+          };
+          repairUser =
+            body.messages?.find((m) => m.role === "user" && m.content.includes("SpecError"))
+              ?.content ??
+            body.messages?.filter((m) => m.role === "user").at(-1)?.content ??
+            "";
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({ model: "m", choices: [{ message: { content: "{}" } }] }),
+              {
+                status: 200,
+              },
+            ),
+          );
+        },
+      },
+    );
+    expect(repairUser).toContain("err-0");
+    expect(repairUser).toContain("err-4");
+    expect(repairUser).not.toContain("err-5");
+    expect(repairUser).not.toContain("err-6");
+  });
+
   test("disabled kill-switch and missing key", async () => {
     const disabled = await handleGenerate(request({ prompt: "hi", datasetId: "penguins" }), {
       DISABLED: "true",
@@ -237,6 +310,47 @@ describe("handleGenerate", () => {
       expect(line).toHaveProperty("outcome");
       expect(line).toHaveProperty("repair_used");
     }
+  });
+
+  // The 429 path returns a canned SAFE_MESSAGE and cannot exercise the
+  // false branches. A model envelope that itself embeds key-shaped text is
+  // the only path that hits sanitizeForLeak → false → bad_output.
+  test("drops a model envelope that contains a key-shaped string as bad_output", async () => {
+    const leaky = {
+      spec: {
+        edition: 2,
+        data: { name: "penguins" },
+        layers: [{ geom: "point" }],
+        labs: { title: "sk-abcdefghijklmnopqrstuvwxyz" },
+      },
+      interactions: { inspect: true },
+      title: "Leaked",
+    };
+    const res = await handleGenerate(request({ prompt: "scatter", datasetId: "penguins" }), {
+      OPENROUTER_API_KEY: "sk-test-key",
+      ...okLimiters,
+      fetch: () =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify({
+              model: "test/model",
+              choices: [{ message: { content: JSON.stringify(leaky) } }],
+            }),
+            { status: 200 },
+          ),
+        ),
+    });
+    expect(res.status).toBe(statusForError("bad_output"));
+    const text = await res.text();
+    expect(text).not.toContain("sk-abcdefghijklmnopqrstuvwxyz");
+    expect((JSON.parse(text) as { error: { code: string } }).error.code).toBe("bad_output");
+  });
+
+  test("sanitizeForLeak flags key, Authorization Bearer, and OPENROUTER+key patterns", () => {
+    expect(sanitizeForLeak("plain chart title")).toBe(true);
+    expect(sanitizeForLeak("sk-abcdefghijklmnop")).toBe(false);
+    expect(sanitizeForLeak("Authorization: Bearer tok")).toBe(false);
+    expect(sanitizeForLeak("OPENROUTER_API_KEY present")).toBe(false);
   });
 
   test("happy path returns envelope JSON object", async () => {


### PR DESCRIPTION
## Summary

Closes #698 — post-merge coverage gaps from the #683 playground agent pipeline review.

- **Playwright:** repair transport failure and repair-still-invalid both keep the prior chart and open the SpecError Details disclosure (the degraded UX that had no journey coverage).
- **Client:** `generateChart` without mode/`?gg-api` pins production default transport to mock.
- **Worker:** whitespace/missing/non-string prompt, non-array `priorErrors`, `PRIOR_ERRORS_MAX` slice, and `sanitizeForLeak` false path (key-shaped model envelope → `bad_output`).
- **Config contract:** `wrangler.toml` binding/var names aligned with `PlaygroundApiEnv` and free-tier `DEFAULT_MODELS` (fail-closed limiter typo would otherwise 503 prod while unit tests stayed green).
- **Codegen:** sentinel-forgery fallback when a second `"values": "__GG_PLAYGROUND_DATA_VALUES__"` appears in the spec.

`runSeq` supersede is already covered by `scripts/playground-session.test.ts` (double `runAgent` and sample-load races). UI disables Generate/samples while busy, so a second Generate click is not a user path.

## Test plan

- [x] `bun test workers/playground-api scripts/playground-output.test.ts scripts/playground-agent-state.test.ts scripts/cloudflare-playground-api-config.test.ts scripts/playground-session.test.ts scripts/playground-agent-run.test.ts`
- [x] `playwright test playground.spec.ts -g "repair transport|repair still invalid|cancel during"`
- [ ] CI green on this PR
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1025" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->