### PR TITLE
fix(docs): expand /docs hub and kill double dividers

### DIFF
--- a/apps/docs/src/routes/docs/+page.svelte
+++ b/apps/docs/src/routes/docs/+page.svelte
@@ -2,31 +2,68 @@
   import { base } from "$app/paths";
 
   import { DOCS_TASKS } from "$lib/catalog/docs-tasks";
+  import { GUIDE_CATALOG } from "$lib/catalog/guide";
+  import { GUIDE_NAVIGATION } from "$lib/routes";
 
   const linkLabels: Record<string, string> = {
     "/guide/themes-color": "Themes and color",
     "/guide/server-rendering-export": "Server rendering and export",
   };
 
-  // Diagnostics stays in the sidebar and search; it is a lookup page, not a
-  // starting point.
+  // Curated progressive entry points stay short; the full chapter map below
+  // lists every guide. Diagnostics stays in the chapter map and search.
   const tasks = DOCS_TASKS.filter((task) => task.label !== "Diagnostics");
+
+  const descriptionByPath = new Map<string, string>([
+    ...GUIDE_CATALOG.map(
+      (entry) => [`/guide/${entry.slug}`, entry.description] as const,
+    ),
+    ["/reference", "API surfaces, interaction props, and the CLI."],
+    [
+      "/reference/cli",
+      "Render, validate, and export charts from the terminal.",
+    ],
+    [
+      "/reference/interactions",
+      "Search interaction props, callbacks, event phases, and diagnostic codes.",
+    ],
+  ]);
+
+  // Distinct from sidebar `guide-*` ids so both can sit on this page.
+  function landingSectionId(section: string): string {
+    return `docs-landing-${section
+      .trim()
+      .toLowerCase()
+      .replaceAll(/[^a-z0-9]+/g, "-")
+      .replaceAll(/^-+|-+$/g, "")}`;
+  }
+
+  // Overview is this page; omit it from the chapter list.
+  const chapters = GUIDE_NAVIGATION.map((group) => ({
+    section: group.section,
+    entries: group.entries.filter((entry) => entry.path !== "/docs"),
+  })).filter((group) => group.entries.length > 0);
 </script>
 
 <article class="docs-landing" aria-labelledby="docs-heading">
   <header>
     <h1 id="docs-heading">Documentation</h1>
+    <p class="lede">
+      Progressive guides for the grammar, interaction, production, and release
+      paths — plus the full chapter map below.
+    </p>
   </header>
 
-  <nav aria-label="Documentation tasks">
+  <nav class="docs-tasks" aria-label="Documentation tasks">
+    <h2 id="docs-tasks-heading">Start here</h2>
     {#each tasks as task (task.label)}
-      <section>
+      <section class="task">
         <a class="task-primary" href={`${base}${task.hrefs[0]}`}>
           <strong>{task.label}</strong>
           <span>{task.description}</span>
         </a>
         {#if task.hrefs.length > 1}
-          <p>
+          <p class="task-also">
             Also:
             {#each task.hrefs.slice(1) as href, index (href)}
               {#if index > 0}
@@ -39,6 +76,30 @@
     {/each}
   </nav>
 
+  <nav class="docs-chapters" aria-label="All documentation guides">
+    <h2 id="docs-chapters-heading">All guides</h2>
+    {#each chapters as group (group.section)}
+      <section
+        class="chapter-group"
+        aria-labelledby={landingSectionId(group.section)}
+      >
+        <h3 id={landingSectionId(group.section)}>{group.section}</h3>
+        <ul>
+          {#each group.entries as entry (entry.path)}
+            <li>
+              <a href={`${base}${entry.path}`}>
+                <strong>{entry.label}</strong>
+                {#if descriptionByPath.get(entry.path)}
+                  <span>{descriptionByPath.get(entry.path)}</span>
+                {/if}
+              </a>
+            </li>
+          {/each}
+        </ul>
+      </section>
+    {/each}
+  </nav>
+
   <section class="docs-next" aria-labelledby="docs-next-heading">
     <h2 id="docs-next-heading">Also</h2>
     <p>
@@ -47,14 +108,28 @@
       <a href={`${base}/reference`}>Reference</a>
       ·
       <a href={`${base}/playground`}>Playground</a>
+      ·
+      <a href={`${base}/themes`}>Themes</a>
+      ·
+      <a href={`${base}/interactions`}>Interactions</a>
     </p>
   </section>
 </article>
 
 <style>
-  .docs-landing header {
-    padding-bottom: 2rem;
-    border-bottom: 1px solid var(--line);
+  /*
+   * One border between regions only. Earlier this page stacked
+   * header border-bottom + nav border-top (and the same pattern before
+   * "Also"), which rendered as a double divider with a gap.
+   */
+  .docs-landing > * + * {
+    margin-top: 2.5rem;
+    padding-top: 2rem;
+    border-top: 1px solid var(--line);
+  }
+
+  header {
+    padding-bottom: 0;
   }
 
   h1 {
@@ -65,14 +140,33 @@
     letter-spacing: -0.035em;
   }
 
-  nav {
-    display: grid;
-    margin-top: 2rem;
-    border-top: 1px solid var(--line);
+  .lede {
+    max-width: 42rem;
+    margin: 1.25rem 0 0;
+    color: var(--muted);
+    font-size: 1.05rem;
+    line-height: 1.45;
   }
 
-  nav section {
-    border-bottom: 1px solid var(--line);
+  h2 {
+    margin: 0 0 1rem;
+    font-family: var(--display-font);
+    font-size: 1.35rem;
+    letter-spacing: -0.02em;
+  }
+
+  h3 {
+    margin: 0 0 0.65rem;
+    font-family: var(--display-font);
+    font-size: 0.95rem;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
+    color: var(--muted);
+  }
+
+  .docs-tasks .task + .task {
+    border-top: 1px solid var(--line);
   }
 
   .task-primary {
@@ -90,38 +184,77 @@
     text-decoration: underline;
   }
 
-  .task-primary strong {
+  .task-primary strong,
+  .docs-chapters a strong {
     font-family: var(--display-font);
     font-size: 1.1rem;
   }
 
   .task-primary span,
-  nav p {
+  .task-also,
+  .docs-chapters a span {
     color: var(--muted);
   }
 
-  nav p {
+  .task-also {
     margin: -0.75rem 0 1rem 42%;
     font-size: 0.82rem;
   }
 
-  .docs-next {
-    margin-top: 3rem;
-    padding-top: 2rem;
-    border-top: 1px solid var(--line);
+  .chapter-group + .chapter-group {
+    margin-top: 1.75rem;
+  }
+
+  .docs-chapters ul {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .docs-chapters li + li {
+    border-top: 1px solid color-mix(in srgb, var(--line) 70%, transparent);
+  }
+
+  .docs-chapters a {
+    display: grid;
+    grid-template-columns: minmax(10rem, 0.42fr) minmax(0, 1fr);
+    align-items: baseline;
+    gap: 1rem;
+    padding: 0.7rem 0;
+    color: var(--ink);
+    text-decoration: none;
+  }
+
+  .docs-chapters a:hover strong {
+    text-decoration: underline;
+  }
+
+  .docs-chapters a span {
+    font-size: 0.95rem;
+    line-height: 1.4;
   }
 
   .docs-next h2 {
     margin-top: 0;
   }
 
+  .docs-next p {
+    margin: 0;
+  }
+
   @media (max-width: 40rem) {
-    .task-primary {
+    .task-primary,
+    .docs-chapters a {
       grid-template-columns: 1fr;
-      gap: 0.35rem;
+      gap: 0.3rem;
     }
 
-    nav p {
+    .task-primary {
+      min-height: 0;
+      padding: 0.85rem 0;
+    }
+
+    .task-also {
       margin-left: 0;
     }
   }

--- a/scripts/docs-tasks.test.ts
+++ b/scripts/docs-tasks.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "bun:test";
 
 import { DOCS_TASKS } from "../apps/docs/src/lib/catalog/docs-tasks.ts";
+import { GUIDE_CATALOG } from "../apps/docs/src/lib/catalog/guide.ts";
+import { GUIDE_NAVIGATION } from "../apps/docs/src/lib/generated/routes.ts";
 
 // Typed wide rather than `as const`: DOCS_TASKS is a const-asserted literal, so
 // an `as const` expectation compares two readonly tuple types and toEqual has no
@@ -26,6 +28,35 @@ describe("Docs entry points", () => {
     for (const task of DOCS_TASKS) {
       expect(task.description.length).toBeGreaterThan(20);
       expect(task.hrefs[0]?.startsWith("/")).toBe(true);
+    }
+  });
+
+  it("keeps progressive tasks as a short subset of the full guide map", () => {
+    // The landing page still exposes DOCS_TASKS as "Start here", but the
+    // chapter index must list far more than those four hubs.
+    const taskDestinations = new Set(DOCS_TASKS.flatMap((task) => [...task.hrefs]));
+    const chapterPaths = GUIDE_NAVIGATION.flatMap((group) =>
+      group.entries.map((entry) => entry.path),
+    ).filter((path) => path !== "/docs");
+    expect(chapterPaths.length).toBeGreaterThan(taskDestinations.size * 2);
+    for (const href of taskDestinations) {
+      // Diagnostics (/guide/errors) and every progressive hub must resolve
+      // somewhere in the published navigation tree.
+      expect(chapterPaths.some((path) => path === href)).toBe(true);
+    }
+  });
+
+  it("publishes a description for every guide chapter on the landing map", () => {
+    const guidePaths = new Set(GUIDE_CATALOG.map((entry) => `/guide/${entry.slug}`));
+    for (const entry of GUIDE_CATALOG) {
+      expect(entry.description.length).toBeGreaterThan(20);
+    }
+    // Every navigable /guide/* chapter path is covered by catalog descriptions.
+    for (const group of GUIDE_NAVIGATION) {
+      for (const entry of group.entries) {
+        if (!entry.path.startsWith("/guide/")) continue;
+        expect(guidePaths.has(entry.path)).toBe(true);
+      }
     }
   });
 });

--- a/tests/visual/docs-progressive-search.spec.ts
+++ b/tests/visual/docs-progressive-search.spec.ts
@@ -116,8 +116,23 @@ test("Docs landing and sidebar expose the full path without duplicate Reference"
     /\/guide\/responsive-charts$/,
   );
   // Diagnostics is deliberately absent from the landing tasks; it stays in
-  // the sidebar and search.
+  // the chapter map, sidebar, and search.
   await expect(tasks.getByRole("link", { name: /Diagnostics/ })).toHaveCount(0);
+
+  // Full chapter index on the landing page (not just the four task hubs).
+  const index = page.getByRole("navigation", { name: "All documentation guides" });
+  await expect(index.getByRole("heading", { level: 3 })).toHaveText([
+    "Start",
+    "Core grammar",
+    "Interaction",
+    "Production",
+    "Reference",
+    "Release",
+  ]);
+  await expect(index.getByRole("link", { name: /Data and mappings/ })).toBeVisible();
+  await expect(index.getByRole("link", { name: /Dates without preprocessing/ })).toBeVisible();
+  await expect(index.getByRole("link", { name: /Errors reference/ })).toBeVisible();
+  await expect(index.getByRole("link", { name: /Upgrade in five minutes/ })).toBeVisible();
 
   const sidebar = page.getByRole("navigation", { name: "Guide chapters" });
   await expect(sidebar.getByRole("heading", { level: 2 })).toHaveText([


### PR DESCRIPTION
## Summary

- **Double dividers:** `/docs` stacked `header` `border-bottom` with `nav` `border-top` (and the same pattern before "Also"), so each region break rendered as two parallel rules with a gap. Regions now use a single sibling border.
- **Sparse hub:** The page only listed four progressive `DOCS_TASKS` hubs, so the docs looked like four pages even though the sidebar already ships the full guide tree. Keep those hubs as **Start here**, and add an **All guides** index driven by `GUIDE_NAVIGATION` with catalog descriptions, plus Themes/Interactions in Also.

## Investigation

| Symptom | Root cause |
| --- | --- |
| Double horizontal rules after the title and before "Also" | CSS: both adjacent borders on neighboring blocks |
| "Only four docs pages" | Intentional short task list with no full chapter map on the landing surface |

## Test plan

- [x] `bun test scripts/docs-tasks.test.ts`
- [ ] Visual: `/docs` shows one rule between regions, Start here (4 tasks), All guides by section, Also links
- [ ] `tests/visual/docs-progressive-search.spec.ts` landing assertions (CI)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1028" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->