### PR TITLE
docs: purge narration and soft-teaching (#690)

### DIFF
--- a/apps/docs/src/lib/components/GrammarDemo.svelte
+++ b/apps/docs/src/lib/components/GrammarDemo.svelte
@@ -11,7 +11,7 @@
     { label: "Data", note: "Rows as plain objects." },
     { label: "Mappings", note: "aes for x, y, and color." },
     { label: "Layers", note: "GeomSmooth over GeomPoint." },
-    { label: "Interaction", note: "just one more layer" },
+    { label: "Interaction", note: "inspect and pin." },
   ] as const;
   let active = $state(steps.length - 1);
   const chartTheme = $derived(contrastChartTheme());
@@ -19,11 +19,8 @@
 
 <section class="grammar-demo" aria-labelledby="grammar-heading">
   <div class="grammar-copy">
-    <h2 id="grammar-heading">The missing layer.</h2>
-    <p>
-      Zero D3.js. Built for human-agent teams who want good default chart
-      interactions that just work.
-    </p>
+    <h2 id="grammar-heading">Inspect and pin are plot props.</h2>
+    <p>No D3 — not a second interaction library.</p>
     <ol>
       {#each steps as step, index (step.label)}
         <li class:active={active === index}>
@@ -79,7 +76,7 @@
   }
 
   h2 {
-    max-width: 13ch;
+    max-width: 18ch;
     margin: 0.25rem 0 1rem;
     font-size: clamp(2.5rem, 5vw, 4.5rem);
     line-height: 0.95;

--- a/apps/docs/src/lib/generated/routes.ts
+++ b/apps/docs/src/lib/generated/routes.ts
@@ -303,11 +303,6 @@ export const DOCS_ROUTES = [
         title: "Compose layers",
         level: 2,
       },
-      {
-        id: "choose-a-mark-for-the-question",
-        title: "Choose a mark for the question",
-        level: 2,
-      },
     ],
   },
   {

--- a/apps/docs/src/lib/generated/search-index.ts
+++ b/apps/docs/src/lib/generated/search-index.ts
@@ -325,16 +325,6 @@ export const DOCS_SEARCH_INDEX = [
     exact: ["Compose layers"],
   },
   {
-    id: "heading:guide-layers-marks:choose-a-mark-for-the-question",
-    kind: "heading",
-    title: "Choose a mark for the question",
-    summary:
-      "Choose a mark for the question in Layers and marks. Compose marks in paint order while sharing or overriding plot mappings.",
-    href: "/guide/layers-marks#choose-a-mark-for-the-question",
-    keywords: ["Layers and marks", "Core grammar"],
-    exact: ["Choose a mark for the question"],
-  },
-  {
     id: "page:guide-statistics-positions",
     kind: "page",
     title: "Statistics and positions",

--- a/apps/docs/src/routes/+page.svelte
+++ b/apps/docs/src/routes/+page.svelte
@@ -30,8 +30,8 @@
       A layered grammar of graphics implemented for agents
     </h1>
     <p>
-      Made for human-agent teams building embedded agents who need to make
-      reliable interactive visualizations on-demand.
+      ggplot2's grammar for Svelte. Every plot is strict JSON: validate,
+      correct, render headless.
     </p>
   </div>
 
@@ -131,11 +131,7 @@
     <h2 id="code-path-heading">
       Svelte for builders, JSON for embedded agents.
     </h2>
-    <p>
-      Svelte components help human-agent teams reason about visualizations
-      together. JSON specs allow agents operating in webapps to make interactive
-      charts on demand for rendering on-the-fly.
-    </p>
+    <p>Author in Svelte. Agents emit the same chart as PortableSpec JSON.</p>
   </div>
   <CodeTabs {tabs} />
 </section>

--- a/scripts/llms-guide-content.ts
+++ b/scripts/llms-guide-content.ts
@@ -166,15 +166,12 @@ export const DATA_MAPPINGS_MD = `# Data and mappings
 
 ## Map fields to position
 
-Numeric fields to position channels:
-
 \`\`\`svelte fragment
 aes={{ x: "weight", y: "economy" }}
 \`\`\`
 
-Change the mapping without reshaping rows, or change rows without changing the
-grammar. The [scatter with color example](/examples/point/scatter-color) adds a
-discrete color channel on the same positions.
+[Scatter with color](/examples/point/scatter-color) adds a discrete color channel
+on the same positions.
 
 ## Keep data local
 
@@ -190,8 +187,6 @@ mappings.
 
 ## Compose layers
 
-Line first, points on top:
-
 \`\`\`svelte fragment
 <GeomLine />
 <GeomPoint />
@@ -199,13 +194,7 @@ Line first, points on top:
 
 Layers inherit plot mappings unless a layer supplies its own mapping or data.
 [Multi-series line](/examples/line/multi-series) uses the same pattern with a
-stable discrete color scale.
-
-## Choose a mark for the question
-
-Points for records, lines for ordered series, columns for precomputed heights,
-bars for counts, rules/text for annotation. [Examples](/examples) shows each
-mark on real data.
+stable discrete color scale. [Examples](/examples) for every mark on real data.
 `;
 
 export const STATISTICS_POSITIONS_MD = `# Statistics and positions
@@ -214,8 +203,6 @@ Stats derive marks from mapped rows. Positions control how derived marks share
 coordinate space.
 
 ## Statistical summaries
-
-Fitted trend over points:
 
 \`\`\`svelte fragment
 <GeomPoint />
@@ -1046,8 +1033,6 @@ trained scales (flip, etc.) without rewriting aesthetic mappings.
 
 ## Facet a comparison
 
-One grammar, one panel per group:
-
 \`\`\`svelte fragment
 <GGPlot data={cars} aes={{ x: "weight", y: "economy" }}>
   <FacetWrap field="vehicleClass" ncol={2} />
@@ -1055,15 +1040,12 @@ One grammar, one panel per group:
 </GGPlot>
 \`\`\`
 
-Fixed scales: compare magnitudes across panels. Free scales: within-panel shape
-at the cost of cross-panel magnitude. [facet wrap](/examples/facet/wrap),
-[free-y](/examples/facet/wrap-free-y).
+[facet wrap](/examples/facet/wrap), [free-y](/examples/facet/wrap-free-y).
 
 ## Coordinates
 
 Prefer \`coord flip\` for horizontal bars over swapping x/y semantics.
-[Horizontal bar](/examples/bar/horizontal) keeps category on x, value on y, then
-flips presentation.
+[Horizontal bar](/examples/bar/horizontal).
 
 ## Scale transforms versus coordinate transforms
 
@@ -1189,8 +1171,6 @@ export const INSPECT_PIN_MD = `# Inspect and pin
 Chart-local: semantic crosshair, HTML tooltip, keyboard traversal, optional pin.
 
 ## Inspect and pin
-
-Stable row key + inspect:
 
 \`\`\`svelte fragment
 <GGPlot


### PR DESCRIPTION
## Summary

Applies the #690 / #687 copy standard beyond getting-started: delete code narration, soft teaching aimed at ggplot2 novices, and homepage importance-inflation diction.

### Homepage
- Hero: concrete PortableSpec claim instead of *human-agent teams… on-demand*
- Code path: dual-surface fact instead of *reason about… on-the-fly*
- Grammar demo: *inspect and pin are plot props* instead of *missing layer / just work*

### Guide (`scripts/llms-guide-content.ts`)
- Drop narrating labels before fragments (line first / fitted trend / numeric fields / one grammar / stable row key)
- Drop *Choose a mark for the question* and related soft facet/aes pedagogy
- Leave contract lines, example links, transform semantics intact

### Generated
- Routes and search index regenerated (removed `choose-a-mark` heading)

## Test plan
- [x] `bun test scripts/gen-llms.test.ts scripts/gen-docs-routes.test.ts scripts/gen-docs-search.test.ts scripts/no-code-labels.test.ts` (37 pass)
- [ ] CI green
- [ ] Spot-check `/`, `/guide/layers-marks`, `/guide/data-mappings`, `/guide/facets-coordinates`, `/guide/inspect-pin` after deploy preview if present

Closes #690
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1030" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->