### PR TITLE
docs(svelte): rewrite shipped agent skill for the 0.12 child-layer API

### DIFF
--- a/.changeset/skill-rewrite-children-references.md
+++ b/.changeset/skill-rewrite-children-references.md
@@ -1,0 +1,13 @@
+---
+"@ggsvelte/svelte": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+docs(svelte): rewrite the shipped agent skill artifact for the 0.12 API
+
+The skill (`skills/ggsvelte/`, shipped in the package tarball) now teaches
+child-layer composition as the canonical Svelte form, draws the JSON-vs-props
+aes distinction, covers the 0.11.0 grammar-prop deprecation and codemod, and
+adds a `references/` tree with exhaustive geom/stat/theme/palette/scale
+inventories checked against the spec catalogs by `scripts/skill-content.test.ts`.

--- a/packages/svelte/skills/ggsvelte/SKILL.md
+++ b/packages/svelte/skills/ggsvelte/SKILL.md
@@ -1,169 +1,191 @@
 ---
 name: ggsvelte
-description: Build data visualizations with ggsvelte, a grammar-of-graphics charting library (ggplot2 semantics, JSON specs, Svelte 5 components, headless SVG rendering). Use whenever creating, editing, validating, or debugging charts, plots, graphs, scatter plots, bar charts, histograms, line charts, boxplots, density plots, faceted/small-multiple charts, or data visualization in a JavaScript/TypeScript/Svelte project; when code imports from "@ggsvelte/svelte", "@ggsvelte/spec", or "@ggsvelte/core"; when emitting a ggsvelte plot spec JSON; or when rendering charts server-side/headless to SVG.
+description: Build data visualizations with ggsvelte, a grammar-of-graphics charting library (ggplot2 semantics, Svelte 5 child-component composition, JSON specs, headless SVG rendering). Use whenever creating, editing, validating, or debugging charts, plots, graphs, scatter plots, bar charts, histograms, line charts, boxplots, density plots, violins, heatmaps, maps, faceted/small-multiple charts, or data visualization in a JavaScript/TypeScript/Svelte project; when code imports from "@ggsvelte/svelte", "@ggsvelte/spec", or "@ggsvelte/core"; when composing GGPlot with Geom*/Scale*/Theme*/Facet*/Coord*/Guide*/Labs children; when emitting a ggsvelte plot spec JSON; or when rendering charts server-side/headless to SVG.
 ---
 
 # ggsvelte
 
-A layered grammar of graphics with ggplot2 nomenclature. **You emit a JSON
-`PortableSpec`; a deterministic renderer draws it.** Never build SVG or
-canvas output yourself — describe the plot, let the pipeline render it.
+A layered grammar of graphics with ggplot2 nomenclature. Two ways to author the
+same grammar — never build SVG or canvas output yourself:
+
+- **Svelte apps (canonical):** `<GGPlot>` with declaration-only children —
+  `<GeomPoint/>`, `<ThemeMinimal/>`, `<ScaleXLog10/>`, `<FacetWrap/>`, `<Labs/>`.
+- **Agents / headless:** emit a JSON `PortableSpec`, check it with
+  `validate(spec)`, render with `renderToSVGString(spec, {width, height})`
+  (Node-safe), `ggsvelte-render spec.json > out.svg` (CLI), or `<GGPlot spec>`.
+  A third skin, the `gg()` builder, produces the same spec in TypeScript.
 
 ## Mental model
 
-```text
-spec = data + aes (mappings) + layers[]        one layer = { geom, stat, position, aes?, params? }
-       + scales? coord? facet? labs? theme?
+```text fragment
+spec = data + aes (mappings) + layers[]
+       + scales? coord? facet? labs? theme? guides?
+one layer = { geom, stat?, position?, positionParams?, aes?, params?, render?, data? }
 ```
 
 - **data**: `{"values": [rows]}`, `{"columns": {name: [...]}}`, or
   `{"name": "dataset"}` (resolved from `spec.datasets` or runtime data).
-- **aes**: channel → canonical form. `{"field": "col"}` maps a data column;
-  `{"value": "red"}` is a constant; `{"stat": "count"}` reads a stat output;
-  `null` unsets an inherited channel. **Bare strings are invalid in JSON
-  specs** — always `{"field": ...}`. Channels: x, y, color (strokes/points),
-  fill (bars/areas), group, label, weight, ymin, ymax, xmin, xmax, width, height.
-  Mapped size, linewidth, alpha, shape, and linetype are supported on the geoms
-  that consume them (see STYLE_AESTHETIC_GEOMS).
-- **layers**: drawn in order. Geoms: `point, line, col, bar, histogram, area,
-rule, text, smooth, boxplot, density, errorbar, rect, tile, raster, ribbon`. Each geom has a default
-  stat/position (bar → count+stack, histogram → bin+stack, col/area →
-  identity+stack, boxplot → boxplot+dodge, everything else identity).
-- **stats compute columns**: count→`count`; bin→`count, density, ncount,
-ndensity`; density→`density, scaled`; smooth→`y, ymin, ymax, se`;
-  boxplot→`ymin, lower, middle, upper, ymax`; summary→`y, ymin, ymax`.
-  A stat that computes y means you must NOT map `aes.y` to a field
-  (bar/histogram/density) — the `computed-y-mapped` error.
-- **positions**: `stack, fill` (proportions), `dodge` (side-by-side),
-  `jitter` (seeded, deterministic), `nudge`, `identity`.
-- **coord**: `{"type": "flip"}` = horizontal bars (map the category to x,
-  the value to y, then flip). Post-stat projection uses
-  `{"type":"transform","x":{"transform":"log10"},"y":{"transform":"sqrt"}}`
-  with optional semantic `limits`, `reverse`, `expand`, and plot-level `clip`.
-  Use `coordTransform`/`coord_transform`; unlike scale transforms, coordinate
-  transforms preserve stat inputs, tessellate curved render topology, and
-  invert coordinates before scales for interactions. Non-identity coordinate
-  transforms require continuous non-temporal axes. Fixed aspect uses
-  `{"type":"fixed","ratio":1}`, `coordFixed`/`coord_fixed`, or
-  `coordEqual`/`coord_equal`; ratio is physical y-unit/x-unit length. Fixed
-  coordinates fit a centered data rectangle after chart chrome and reject
-  free positional facet scales.
-- **facet**: wrap form `{"wrap": {"field": "g"}, "ncol": 3}` XOR grid form
-  `{"rows": {...}, "cols": {...}}`; `"scales": "fixed"|"free"|"free_x"|"free_y"`.
-- **scales**: canonical x/y families are `{"type": "linear"|"binned"|"time"|"band"}`.
-  Numeric continuous/binned scales accept `"transform":"identity"|"log10"|"sqrt"`,
-  semantic `domain`/`limits`, `oob:"censor"|"squish"`, `expand`, `nice`,
-  major/minor breaks, and `reverse`. Authored `type:"log"` is accepted but
-  canonicalizes to `type:"linear", transform:"log10"`; trained models never
-  report type `log`. Scale transforms run before stats and positions. Binned
-  integer ids remain private; guides, candidates, and events use semantic values.
-  Helpers include `scaleXLog10`, `scaleYSqrt`, `scaleXBinned` and binding-identical
-  `scale_x_log10`, `scale_y_sqrt`, `scale_x_binned` aliases. Time scales additionally accept `"parse"` (closed names such as `"dmy"`,
-  exact `{ "format": ... }`, or `{ "epoch": "seconds"|"milliseconds" }`),
-  `"temporalKind"`, `"timezone"`, `"disambiguation"`,
-  `"parseFailure":"error"|"censor"`, `"dateBreaks"`,
-  `"dateMinorBreaks"`, `"dateLabels"`, `"locale"`, and `"weekStart"`.
-  Color/fill families are `ordinal`, `sequential`, `binned`, `manual`, and
-  `identity`. Sequential/binned accept identity/log10/sqrt transforms,
-  semantic domains/breaks, OOB policy, temporal parser options, and explicit
-  `naValue`/`unknownValue`; `labels` accepts numeric or temporal formats for
-  colorbars and colorsteps. Manual requires one range color per domain value;
-  identity validates source hex colors and suppresses its guide by default.
-  Bounded warnings count mapped NA and unknown fallback values.
-  Use continuous/discrete/binned/log10/sqrt/date/datetime/manual/identity
-  helpers for color or fill. `color`/`colour` and ggplot2 snake-case exports
-  are binding-identical. GuidePlans are `discrete`, `colorbar`, or
-  `colorsteps`. Defaults are inferred and disclosed as advisories.
-- **guides**: top-level `guides` overrides scale-local `guide`. Use `axis`,
-  `legend`, `colorbar`, `colorsteps`, or `none` through the camelCase helpers
-  (or binding-identical snake-case aliases). Guide options style titles,
-  ticks/labels, numeric order, `auto|right|bottom` placement,
-  `auto|vertical|horizontal` direction, collision handling, force visibility,
-  and bounded theme roles without changing scale math. Auto non-position guides
-  move below when the viewport is at most 480px or a right guide would leave
-  less than 320px of panel. Exact discrete entries remain interactive; numeric
-  ticks/bins do not. Force identity/single-value manual guides explicitly.
-- **temporal defaults**: ISO dates/date-times, four-digit year strings,
-  year-months, month-years, and year-quarters infer time after bounded sampling
-  plus whole-column validation. Ambiguous ordered dates stay discrete: set
-  `"parse":"dmy"` or `"parse":"mdy"`. For year-like identifiers, force
-  `{"type":"band"}`. Never preprocess dates into indexes. Automatic temporal
-  labels use measured panel extent and calendar boundaries; inspect
-  `model.guidePlans` for the selected interval and visible/full labels.
-- **temporal override rules**: `.scaleXDate()`/`.scaleYDate()` serialize mapped
-  authoring `Date` cells as calendar dates; `.scaleXDatetime()`/
-  `.scaleYDatetime()` preserve instants; `.scaleXTime()`/`.scaleYTime()`
-  (ggplot2 `scale_*_time`) are time-of-day only — portable numbers are
-  **seconds since midnight** (mapped to epoch ms on 1970-01-01Z); `Date` cells
-  use the UTC clock portion; default labels `%H:%M:%S`.
-  Explicit `linear`/`binned` (including authored alias `log`) disables temporal inference, so numeric strings stay
-  quantitative. Explicit ordinal color/fill keeps temporal-looking labels as
-  separate groups; sequential temporal color/fill uses parsed domains and
-  calendar legend labels. Censoring is available only with an explicit parser;
-  invalid configuration and ambiguous automatic inference remain errors.
-  Use e.g. `.scaleXDatetime({ dateBreaks: "2 weeks", dateMinorBreaks: "1 day",
-dateLabels: "%e %b", locale: "en-GB", timezone: "Europe/London" })`.
-  Explicit `breaks` outrank `dateBreaks`; `dateLabels` outranks `labels`.
-  Authored labels are preserved with a diagnostic rather than silently
-  rotated, thinned, or truncated.
-- Rendering surfaces: `<GGPlot spec={...}/>` (Svelte),
-  `renderToSVGString(spec, {width, height})` (headless, Node-safe),
-  `ggsvelte-render spec.json > out.svg` (CLI; JSON-line diagnostics on stderr).
+- **layers** draw in order — later layers on top (z-order).
+- Geom defaults: bar → count+stack, histogram → bin+stack, col/area →
+  identity+stack, boxplot → boxplot+dodge, violin → ydensity+dodge,
+  jitter → point+jitter, freqpoly → bin, smooth → smooth, count → sum,
+  density → density, hex → bin_hex, everything else identity+identity.
 
-## Svelte interactions (v0.2+)
+## Aes: JSON specs vs Svelte props
 
-`@ggsvelte/svelte` requires Svelte `^5.33.1`. Interactions are opt-in props on
-`<GGPlot>`; always provide a stable `key` field when selection or linked views
-must survive filtering, reordering, or data refreshes.
+The one rule that differs between the two skins:
 
-```svelte
+| Surface                                 | `x: "displ"` bare string              | canonical                |
+| --------------------------------------- | ------------------------------------- | ------------------------ |
+| JSON `PortableSpec` (incl. `spec` prop) | INVALID                               | `{"field": "displ"}`     |
+| Svelte `aes` prop (plot or `Geom*`)     | valid shorthand, expands to `{field}` | same object form also OK |
+
+Canonical channel forms: `{"field": "col"}` maps a column, `{"value": "red"}`
+is a constant, `{"stat": "count"}` reads a stat output, `null` unsets an
+inherited channel. Layer aes merges over plot aes per channel.
+Channels (25): x, y, color, fill, size, linewidth, alpha, shape, linetype,
+group, label, weight, ymin, ymax, xmin, xmax, xend, yend, width, height, z,
+map_id, angle, radius, sample. Mapped size/linewidth/alpha/shape/linetype work
+only on the geoms in `STYLE_AESTHETIC_GEOMS`.
+
+## Svelte composition — children are canonical
+
+```svelte fragment
 <script lang="ts">
-  import { createPlotInteraction, Facet, GGPlot } from "@ggsvelte/svelte";
+  import {
+    GeomPoint,
+    GeomSmooth,
+    GGPlot,
+    Labs,
+    ScaleColorDiscrete,
+    ThemeMinimal,
+  } from "@ggsvelte/svelte";
 
-  const interaction = createPlotInteraction<number>();
-  const scope = { keys: "sales-rows", intervals: "sales-range" } as const;
+  const cars = [
+    { displ: 1.8, hwy: 29, class: "compact" },
+    { displ: 2.0, hwy: 31, class: "compact" },
+    { displ: 3.5, hwy: 26, class: "midsize" },
+    { displ: 5.3, hwy: 20, class: "suv" },
+    { displ: 5.7, hwy: 17, class: "suv" },
+    { displ: 6.2, hwy: 16, class: "suv" },
+  ];
 </script>
 
-<GGPlot
-  data={rows}
-  aes={{ x: "date", y: "value", color: "series" }}
-  layers={[{ geom: "point" }]}
-  key="id"
-  select={{ type: "interval", mode: "x", preset: "cross-panel" }}
-  legendFocus
-  legendFilter
-  {interaction}
-  interactionScope={scope}
-  oninteraction={(event) => console.log(event)}
->
-  <Facet wrap="region" ncol={3} />
+<GGPlot data={cars} aes={{ x: "displ", y: "hwy", color: "class" }} height={400}>
+  <ThemeMinimal />
+  <ScaleColorDiscrete scheme="tableau10" />
+  <Labs
+    title="Bigger engines, thirstier cars"
+    x="Displacement (l)"
+    y="Highway mpg"
+    color="Class"
+  />
+  <GeomSmooth method="loess" se={false} />
+  <GeomPoint size={3} alpha={0.85} />
 </GGPlot>
 ```
 
-- `inspect` adds tooltip, crosshair, keyboard traversal, and pinning; `select`
-  supports point or interval selection; `zoom` enables brush zoom.
-- Faceted interval presets are `independent`, `union`, and `cross-panel`.
-  After an interval or zoom commit, accessible controls accept exact bounds.
-- `legendFocus` only emphasizes a discrete group. `legendFilter` changes the
-  included rows and reruns the grammar while preserving stable color identity.
-- Share one `createPlotInteraction()` controller between plots to link semantic
-  selection, emphasis, interval, and zoom state. Give plots matching
-  `interactionScope` channels only when they should coordinate.
-- Use controlled controller methods such as `setSelection`, `setInterval`, and
-  `setZoom` for external controls. Observe all interaction kinds through
-  `oninteraction`, or use capability-specific handlers such as `onselect`,
-  `onzoom`, `onlegendfocus`, and `onlegendfilter`.
-- A handler without its matching capability prop, or `interactionScope` without
-  an `interaction` controller, is inert and emits a development advisory.
+Convention: theme → scales → guides → labs → mark layers. Grammar children
+(theme/scale/coord/facet/guides/labs/legend) render no markup and register
+declaratively; mark-layer registration order is z-order (points above smooth
+here). Every geom takes aesthetics through one `aes` object prop (bare-string
+shorthand allowed) and constant style params as direct props (`size={3}`);
+structural props are `data`, `stat`, `position`, `positionParams`, `render`.
+
+`<GGPlot>` props: `spec`, `data`, `aes`, `layers`, `key`, `width`
+(number | "container"), `height`, `a11y`, `ariaLabel`, the interaction props
+(`inspect`, `select`, `zoom`, `legendFocus`, `legendFilter`, `tool`,
+`interaction`, `interactionScope`), the `on*` handlers, and `children`.
+Instance methods: `resetScales()`, `setZoom()`.
+
+Precedence: `spec` wins over everything else. For mark layers, an explicit
+`layers` prop wins over geom children — use it for dynamic layer lists (a keyed
+`{#each}` reorder does not preserve z-order). For grammar families, children
+win over the deprecated props. Coord/facet/theme REPLACE (last wins); scales
+merge per channel; labs/guides/legend merge per key. Duplicates emit
+`DUPLICATE_PLOT_LAYER` / `DUPLICATE_SCALE_CHANNEL` / `DUPLICATE_MERGE_KEY`
+advisories — full semantics in
+[references/composition-surfaces.md](references/composition-surfaces.md).
+
+**Deprecated (since 0.11.0, planned removal in 0.13.0):** the seven `<GGPlot>`
+grammar props `facet`, `coord`, `scales`, `guides`, `legend`, `theme`, `labs`.
+Compose them as children instead; `spec`, `data`, `aes`, and `layers` stay
+first-class. Migrate existing code with `npx ggsvelte-codemod --write src`
+(dry-run without `--write`). Using a deprecated prop fires a
+`DEPRECATED_PLOT_PROP` advisory via `ondiagnostic`.
+
+## Which geom for which data
+
+| x type           | y type                                | extra              | recommend                                                    |
+| ---------------- | ------------------------------------- | ------------------ | ------------------------------------------------------------ |
+| quantitative     | quantitative                          | ≤ ~2k rows         | `point` (+ `smooth` layer for trend)                         |
+| quantitative     | quantitative                          | many rows          | `point` with `"render": "canvas"`, or `hex`/`bin_2d` density |
+| temporal         | quantitative                          | —                  | `line` (multi-series: map `color` to the series field)       |
+| nominal/ordinal  | quantitative (pre-aggregated)         | —                  | `col`; many/long labels → add a `flip` coord                 |
+| nominal/ordinal  | (none — count rows)                   | —                  | `bar` (count stat; do NOT map y)                             |
+| quantitative     | (none — distribution)                 | —                  | `histogram` (or `density` for smooth overlay)                |
+| nominal          | quantitative (distribution per group) | —                  | `boxplot` (or `violin` for shape)                            |
+| nominal          | nominal                               | —                  | `point` + `"position": "jitter"`, or counts via `count`      |
+| quantitative     | quantitative                          | uncertainty bounds | `errorbar` (map ymin/ymax) or `smooth` (se ribbon)           |
+| any of the above | + one more nominal field              | few values         | same geom + facet wrap on that field                         |
+
+Only the everyday geoms appear above. All 50 geoms (violin, hex, contour, qq,
+step, segment, sf/maps, text/label annotation, …), all 28 stats with their
+computed columns, and the position rules live in
+[references/geoms-and-stats.md](references/geoms-and-stats.md) — read it
+whenever the user wants a geom, stat, or annotation not shown here.
+
+Two rules worth keeping in working memory:
+
+- **Positions are scoped per geom** (a disallowed position is a schema error):
+  stack/fill only on bar, col, histogram, area; dodge on those plus boxplot
+  and violin; jitter on point, count, jitter; nudge on point, count, text,
+  label; identity everywhere.
+- **A stat that computes y forbids mapping `aes.y` to a field**
+  (bar/histogram/density/…) — the `computed-y-mapped` error. Read stat outputs
+  with `{"stat": "count"}` aes.
+
+## Scales, palettes, themes
+
+- x/y families: `{"type": "linear"|"binned"|"time"|"band"}` with
+  `"transform": "identity"|"log10"|"sqrt"`, `domain`/`limits`,
+  `oob: "censor"|"squish"`, `expand`, `nice`, breaks, `reverse`. Authored
+  `type:"log"` canonicalizes to linear+log10. Scale transforms run before
+  stats and positions; coord transforms run after stats.
+- color/fill families: `ordinal`, `sequential`, `binned`, `manual`,
+  `identity`. 34 named schemes — 14 categorical (`observable10`, `tableau10`,
+  `colorblind`, `Set1`…) and 20 sequential/diverging (`viridis`, `magma`,
+  `Blues`, `RdBu`…). Size/linewidth/alpha and shape/linetype have their own
+  scale families.
+- Three equivalent skins:
+  JSON `"scales": {"x": {"type": "linear", "transform": "log10"}}` ≡ helper
+  functions `scaleXLog10()` / `scale_x_log10()` (binding-identical camelCase,
+  snake_case, and Colour spellings, from `@ggsvelte/spec`) ≡ components
+  `<ScaleXLog10/>`. The `gg()` builder chains the same names:
+  `gg(rows, aes({ x: "flipper", y: "mass" })).geomPoint({ alpha: 0.7 }).scaleXLog10().spec()`.
+- Temporal: ISO dates/date-times, four-digit-year strings, year-months, and
+  year-quarters infer time automatically. Ambiguous ordered dates need
+  `"parse": "dmy"` or `"mdy"`; force `{"type": "band"}` for year-like
+  identifiers; never preprocess dates into indexes.
+- Themes: 17 names (`default`, `light`, `dark`, `minimal`, `ggplot2`,
+  `classic`, `bw`, `hrbr`, `few`, `clean`, `fivethirtyeight`, `economist`,
+  `tufte`, `linedraw`, `void`, plus `grey`/`gray` aliasing `ggplot2`) as
+  `<ThemeTufte/>`-style children or `"theme": "tufte"` in JSON.
+
+Full option surfaces — every scale option, the `Scale*` component matrix, all
+scheme tables, the whole temporal/parser system:
+[references/scales-and-palettes.md](references/scales-and-palettes.md).
+Themes, coords, facets, guides, legend order, and `Labs` in depth:
+[references/composition-surfaces.md](references/composition-surfaces.md).
 
 ## The validation contract (use it!)
 
-`validate(spec)` = schema shape. `validate(spec, { profile })` adds
-data-aware checks against a `DataProfile` —
+`validate(spec)` = schema shape. `validate(spec, { profile })` adds data-aware
+checks against a `DataProfile` —
 `{"fields": [{"name": "displ", "type": "quantitative"}], "rowCount": 234}`
 (types: quantitative | temporal | ordinal | nominal). Every error is:
 
-```json
+```json fragment
 {
   "code": "unknown-field",
   "path": "/layers/0/aes/x",
@@ -180,63 +202,79 @@ data-aware checks against a `DataProfile` —
 `validate(spec, { lint: true })` additionally returns advisories for
 valid-but-questionable specs (line over unordered categories, >10 discrete
 colors, stacked negative areas, discrete×discrete scatter, transform-domain
-mixed-sign data). Advisories never block; fix them when they match intent.
+mixed-sign data); `lintSpec(spec)` is the standalone equivalent. Advisories
+never block; fix them when they match intent. `normalize(input)` canonicalizes
+authoring sugar into a `PortableSpec`; `isPortable`/`toPortable` check and
+strip runtime-only fields. CLIs: `ggsvelte-render spec.json > out.svg`
+(JSON-line diagnostics on stderr) and `ggsvelte-codemod [--write] src`.
 
-## Which geom for which data (DataProfile → recommendation)
-
-| x type           | y type                                | extra              | recommend                                                            |
-| ---------------- | ------------------------------------- | ------------------ | -------------------------------------------------------------------- |
-| quantitative     | quantitative                          | ≤ ~2k rows         | `point` (+ `smooth` layer for trend)                                 |
-| quantitative     | quantitative                          | many rows          | `point` with `"render": "canvas"`, or `histogram`/`density` per axis |
-| temporal         | quantitative                          | —                  | `line` (multi-series: map `color` to the series field)               |
-| nominal/ordinal  | quantitative (pre-aggregated)         | —                  | `col`; many/long labels → add `"coord": {"type": "flip"}`            |
-| nominal/ordinal  | (none — count rows)                   | —                  | `bar` (count stat; do NOT map y)                                     |
-| quantitative     | (none — distribution)                 | —                  | `histogram` (or `density` for smooth overlay)                        |
-| nominal          | quantitative (distribution per group) | —                  | `boxplot`                                                            |
-| nominal          | nominal                               | —                  | `point` + `"position": "jitter"`, or counts via size                 |
-| quantitative     | quantitative                          | uncertainty bounds | `errorbar` (map ymin/ymax) or `smooth` (se ribbon)                   |
-| any of the above | + one more nominal field              | few values         | same geom + `facet.wrap` on that field                               |
-
-Annotations (reference lines): `rule` with `params.yintercept`/`xintercept`
-(no aes). Data-driven rules: map exactly ONE of aes.x / aes.y.
-
-## Recipes (canonical spec JSON — top 20)
+## Recipes (spec JSON — the everyday twelve)
 
 All specs assume inline `"data": {"values": [...]}` or a named dataset.
-`A` = aes shorthand shown expanded once, then abbreviated for space.
 
-1. **Scatter** — `{"layers":[{"geom":"point","aes":{"x":{"field":"displ"},"y":{"field":"hwy"}}}]}`
-2. **Scatter colored by category** — add `"color":{"field":"class"}` to the aes.
-3. **Scatter + trend** — `{"aes":{"x":{"field":"x"},"y":{"field":"y"}},"layers":[{"geom":"point"},{"geom":"smooth","params":{"method":"loess"}}]}` (plot-level aes inherits into both layers)
-4. **Line (time series)** — `{"layers":[{"geom":"line","aes":{"x":{"field":"date"},"y":{"field":"value"}}}]}` (ISO dates, raw four-digit years, year-months, and year-quarters infer time automatically; add `"scales":{"x":{"type":"time","parse":"dmy"}}` only for an explicit ordered parser)
-5. **Multi-series line** — map `"color":{"field":"series"}` (grouping follows).
-6. **Column chart (pre-computed heights)** — `{"layers":[{"geom":"col","aes":{"x":{"field":"category"},"y":{"field":"amount"}}}]}`
-7. **Bar chart (count rows per category)** — `{"layers":[{"geom":"bar","aes":{"x":{"field":"category"}}}]}` — never map y on bar.
-8. **Horizontal bars** — recipe 6 or 7 + `"coord":{"type":"flip"}`.
-9. **Stacked bars** — recipe 7 + `"fill":{"field":"subgroup"}` in aes (stack is the default position).
-10. **Dodged (grouped) bars** — recipe 9 + `"position":"dodge"` on the layer.
-11. **Proportion bars (100% stacked)** — recipe 9 + `"position":"fill"`.
-12. **Histogram** — `{"layers":[{"geom":"histogram","aes":{"x":{"field":"measure"}},"params":{"bins":30}}]}` (or `"binwidth"`; never both `center` and `boundary`).
-13. **Density overlay** — `{"layers":[{"geom":"density","aes":{"x":{"field":"measure"},"color":{"field":"group"}}}]}`
-14. **Boxplot by category** — `{"layers":[{"geom":"boxplot","aes":{"x":{"field":"group"},"y":{"field":"value"}}}]}` (x must be discrete)
-15. **Stacked area** — `{"layers":[{"geom":"area","aes":{"x":{"field":"date"},"y":{"field":"value"},"fill":{"field":"series"}}}]}`
-16. **Errorbar (mean ± se)** — `{"layers":[{"geom":"errorbar","stat":"summary","aes":{"x":{"field":"group"},"y":{"field":"value"}}}]}`
-17. **Reference line annotation** — add layer `{"geom":"rule","params":{"yintercept":0}}`.
-18. **Value labels on columns** — recipe 6 + layer `{"geom":"text","aes":{"x":{"field":"category"},"y":{"field":"amount"},"label":{"field":"amount"}},"params":{"dy":-8}}` (`dy`/`dx` are px offsets; `position: "nudge"` + `positionParams.x/y` offsets in DATA units)
-19. **Facets (small multiples)** — any recipe + `"facet":{"wrap":{"field":"panel"},"ncol":3}` (add `"scales":"free_y"` for per-panel y).
-20. **Big scatter (canvas)** — recipe 1 + `"render":"canvas"` on the layer (or let >2000 marks auto-switch; `"a11y":"force-svg"` at plot level overrides for assistive tech). Log10 axis: `"scales":{"x":{"type":"linear","transform":"log10"}}` (positive data only; transform runs before stats). Jittered categorical scatter: `"position":"jitter"` on a point layer.
+1. **Scatter** — `{"layers":[{"geom":"point","aes":{"x":{"field":"displ"},"y":{"field":"hwy"}}}]}`; color by category: add `"color":{"field":"class"}`.
+2. **Scatter + trend** — `{"aes":{"x":{"field":"x"},"y":{"field":"y"}},"layers":[{"geom":"point"},{"geom":"smooth","params":{"method":"loess"}}]}` (plot-level aes inherits into both layers).
+3. **Line (time series)** — `{"layers":[{"geom":"line","aes":{"x":{"field":"date"},"y":{"field":"value"}}}]}`; multi-series: map `"color":{"field":"series"}`.
+4. **Column chart (pre-computed heights)** — `{"layers":[{"geom":"col","aes":{"x":{"field":"category"},"y":{"field":"amount"}}}]}`
+5. **Bar chart (count rows)** — `{"layers":[{"geom":"bar","aes":{"x":{"field":"category"}}}]}` — never map y on bar.
+6. **Horizontal bars** — recipe 4 or 5 + `"coord":{"type":"flip"}`.
+7. **Stacked / dodged / proportion bars** — recipe 5 + `"fill":{"field":"subgroup"}` in aes (stack is the default); `"position":"dodge"` for side-by-side, `"position":"fill"` for 100% stacked.
+8. **Histogram** — `{"layers":[{"geom":"histogram","aes":{"x":{"field":"measure"}},"params":{"bins":30}}]}` (or `"binwidth"`; never both `center` and `boundary`).
+9. **Boxplot by category** — `{"layers":[{"geom":"boxplot","aes":{"x":{"field":"group"},"y":{"field":"value"}}}]}` (x must be discrete).
+10. **Facets (small multiples)** — any recipe + `"facet":{"wrap":{"field":"panel"},"ncol":3}` (add `"scales":"free_y"` for per-panel y).
+11. **Reference line annotation** — add layer `{"geom":"rule","params":{"yintercept":0}}`.
+12. **Finishing** — `"labs":{"title":...,"x":...,"y":...}`, `"width"`/`"height"` in px, `"theme":"minimal"`.
 
-Finish with `"labs": {"title": ..., "x": ..., "y": ...}` for human-readable
-labels, `"width"`/`"height"` in px, `"theme": "default"|"light"|"dark"|"minimal"`.
+The same charts as Svelte children, twice over:
 
-## References
+```svelte fragment
+<GGPlot data={sales} aes={{ x: "quarter", y: "amount", fill: "region" }}>
+  <GeomCol position="dodge" />
+</GGPlot>
+```
+
+```svelte fragment
+<GGPlot data={measurements} aes={{ x: "value" }}>
+  <FacetWrap field="site" ncol={2} />
+  <GeomHistogram bins={20} />
+</GGPlot>
+```
+
+Long-tail recipes — errorbar, value labels, canvas big-scatter, log axis,
+violin, tile heatmap, hex density, ECDF step, ribbon, flipped boxplot,
+per-layer aes override, sf/map — each as validated JSON plus a Svelte twin:
+[references/recipes.md](references/recipes.md).
+
+## Interactions (Svelte props, not spec fields)
+
+Opt-in `<GGPlot>` props: `inspect` (tooltip/crosshair/keyboard/pinning),
+`select` (point or interval), `zoom` (brush), `legendFocus` (emphasis only),
+`legendFilter` (refilters and reruns the grammar, colors stay stable). Always
+give a stable `key` when selection or linked views must survive filtering or
+refreshes. Link plots by sharing one `createPlotInteraction()` controller and
+matching `interactionScope` channels; observe everything through
+`oninteraction` or per-capability handlers. Faceted interval presets, the
+controller API, `Tooltip`, handler payloads, and diagnostics:
+[references/interactions.md](references/interactions.md) — read it before
+writing any interactive or linked-view code.
+
+## Pointers
 
 - JSON Schema (constrained decoding): `packages/spec/schema/v0.json` in the
   repo, `/schema/v0.json` on the docs site, or
   `import schema from "@ggsvelte/spec/schema/v0.json"`.
 - Full corpus for models: `/llms-full.txt` on the docs site (all guide prose
-  - every example with spec JSON and Svelte source); index at `/llms.txt`.
+  plus every example with spec JSON and Svelte source); index at `/llms.txt`.
 - Error catalog: `/guide/errors`; advisories: `/guide/advisories`;
   lifecycle/editions: `/guide/lifecycle` (specs are stamped with the current
-  appearance edition, currently 2; editions do not preserve incorrect pre-1.0
-  parser or scale execution).
+  appearance edition, currently 2). Upgrading off deprecated props:
+  `/guide/upgrading`.
+- References in this skill — read the one that matches the task:
+  [geoms-and-stats.md](references/geoms-and-stats.md) (any geom/stat/position
+  beyond the everyday set, annotations),
+  [scales-and-palettes.md](references/scales-and-palettes.md) (scale options,
+  palettes, temporal),
+  [composition-surfaces.md](references/composition-surfaces.md) (themes,
+  coords, facets, guides, merge semantics),
+  [interactions.md](references/interactions.md) (tooltips, selection, linking),
+  [recipes.md](references/recipes.md) (long-tail chart recipes).

--- a/packages/svelte/skills/ggsvelte/SKILL.md
+++ b/packages/svelte/skills/ggsvelte/SKILL.md
@@ -129,7 +129,7 @@ first-class. Migrate existing code with `npx ggsvelte-codemod --write src`
 | quantitative     | quantitative                          | uncertainty bounds | `errorbar` (map ymin/ymax) or `smooth` (se ribbon)           |
 | any of the above | + one more nominal field              | few values         | same geom + facet wrap on that field                         |
 
-Only the everyday geoms appear above. All 50 geoms (violin, hex, contour, qq,
+Only the everyday geoms appear above. All 49 geoms (violin, hex, contour, qq,
 step, segment, sf/maps, text/label annotation, …), all 28 stats with their
 computed columns, and the position rules live in
 [references/geoms-and-stats.md](references/geoms-and-stats.md) — read it

--- a/packages/svelte/skills/ggsvelte/references/composition-surfaces.md
+++ b/packages/svelte/skills/ggsvelte/references/composition-surfaces.md
@@ -1,0 +1,200 @@
+<!-- Source of truth: packages/spec/src/schema-names.ts (THEME_NAMES), packages/svelte/src/lib/index.ts (component exports), packages/svelte/src/lib/plot-props.ts, packages/svelte/src/lib/layers/ (merge semantics, grammar-families). Inventory tables are asserted complete by scripts/skill-content.test.ts. -->
+
+# Composition surfaces: themes, coords, facets, guides, labs
+
+Every surface here exists in three equivalent forms: a key in the JSON
+`PortableSpec`, a deprecated `<GGPlot>` prop (removable in 0.13.0), and a
+declaration-only child component (canonical in Svelte). Child components emit
+no markup, register on init, unregister on destroy, and are inert without a
+`<GGPlot>` ancestor.
+
+## Themes
+
+JSON form: `"theme": "minimal"` (a registered name) or a theme object —
+optional `"name"` base plus role overrides, e.g.
+`{"name": "dark", "ink": "#eee"}`. `grey` and `gray` are registered aliases of
+`ggplot2` (same token map).
+
+| Name                    | Look                                                                       |
+| ----------------------- | -------------------------------------------------------------------------- |
+| default                 | quiet hrbrthemes-style base: real typography, hairline grid, no axis frame |
+| light                   | light grid, thin panel border, x/y ticks                                   |
+| dark                    | dark paper and panel, light ink                                            |
+| minimal                 | light grid only, no ticks or border                                        |
+| ggplot2                 | classic grey panel, white grid                                             |
+| classic                 | no grid, black axis lines and ticks                                        |
+| bw                      | white panel, grey grid, black rectangular border (print/B&W)               |
+| hrbr                    | same token map as default                                                  |
+| few                     | no grid, thin panel border (Stephen Few)                                   |
+| clean                   | dashed y grid only, axis lines and ticks                                   |
+| fivethirtyeight         | grey paper and panel, white grid, blue accent                              |
+| economist               | pale blue paper, white grid, x ticks, red accent                           |
+| tufte                   | monochrome ink, no grid                                                    |
+| linedraw                | black-on-white line art: hairline black grid, black border                 |
+| void                    | no axes, grid, or panel chrome; marks and legends remain                   |
+| grey (alias of ggplot2) | UK theme_grey                                                              |
+| gray (alias of ggplot2) | US theme_gray                                                              |
+
+Svelte: one named shell per product theme — `ThemeDefault`, `ThemeLight`,
+`ThemeDark`, `ThemeMinimal`, `ThemeGgplot2`, `ThemeClassic`, `ThemeBw`,
+`ThemeHrbr`, `ThemeFew`, `ThemeClean`, `ThemeFivethirtyeight`,
+`ThemeEconomist`, `ThemeTufte`, `ThemeLinedraw`, `ThemeVoid`, `ThemeGrey`,
+`ThemeGray`. Escape hatch `<Theme name={dynamicName} />` for reactive names.
+Every shell and `<Theme>` also accepts role-override props (`ink`, `paper`,
+`accent`, `grid`, `panel`, `axisText`, `axisLine`, `tickColor`,
+`panelBorder`, tooltip/selection/focus roles, …): `<ThemeDark ink="#eee" />`.
+
+## Coords
+
+Components: `Coord` (escape hatch, `value: CoordSpec | "flip"`), `CoordFlip`,
+`CoordCartesian`, `CoordTransform`, `CoordFixed`, `CoordEqual` (alias of
+`CoordFixed`), `CoordSf`. `<CoordCartesian/>` registers `{"type":"cartesian"}`,
+which `normalize()` drops when bare — use it to clear an earlier coord under
+REPLACE. JSON forms:
+
+```json fragment
+"coord": {"type": "flip"}
+```
+
+```json fragment
+"coord": {
+  "type": "transform",
+  "x": {"transform": "log10", "limits": [1, 1000], "reverse": false, "expand": true},
+  "y": {"transform": "sqrt"},
+  "clip": true
+}
+```
+
+- Coord transform runs AFTER stats and scale training (scale `transform` runs
+  before stats). It preserves stat inputs; coordinate `limits` are a viewport —
+  they never remove rows or recompute statistics. `expand` (default true) adds
+  a 5% display expansion to explicit limits; `clip` (default true) clips marks
+  to the panel.
+- Non-identity coordinate transforms require continuous, non-temporal
+  position scales on the transformed axes.
+- `{"type": "fixed", "ratio": 1}`: ratio is physical y-unit length divided by
+  physical x-unit length (default 1). Layout fits the largest centered data
+  rectangle after chart chrome. Fixed-aspect coords reject free positional
+  facet scales (`coord-fixed-free-scales` error).
+- `{"type": "sf"}` (`<CoordSf/>`): fixed-aspect coords for already-projected
+  map data; no CRS reprojection in v1. Accepts `ratio` like fixed.
+
+## Facets
+
+Components: `Facet` (full `FacetInput` surface), `FacetWrap` (`field`,
+`ncol?`, `scales?`, `strip?`), `FacetGrid` (`rows?`, `cols?`, `scales?`,
+`strip?`). `field`/`rows`/`cols` accept a bare string or
+`{ field, levels?, labels? }` for authored panel order and strip text. Wrap
+form is mutually exclusive with rows/cols; a bare `<Facet/>` fails validate
+with `facet-form-missing`.
+
+```json fragment
+"facet": {"wrap": {"field": "region"}, "ncol": 3, "scales": "free_y",
+          "strip": {"position": "top", "show": true}}
+```
+
+- Panels partition the data BEFORE stats and positions run — each panel
+  computes its own counts, bins, and stacks.
+- `scales`: `"fixed"` (default — panels share both positional scales) |
+  `"free"` | `"free_x"` | `"free_y"`. Discrete color/fill assignments are
+  ALWAYS global (one legend), whatever `scales` says.
+- `strip`: `position` `"top"` (default) | `"bottom"` | `"left"` | `"right"`
+  (left/right strips take layout space rather than overlaying the panel);
+  `show` (default true) — set false when direct labels are authored elsewhere.
+
+## Guides, legend, labs
+
+Guides are keyed by aesthetic channel: `x`, `y`, `color`, `fill`, `size`,
+`linewidth`, `alpha`, `shape`, `linetype`. Components: `Guides`
+(escape hatch, `value: GuidesSpec`), plus one shell per guide type carrying a
+`channel` prop — `GuideAxis` (channels `x`/`y` only), `GuideLegend`,
+`GuideColorbar`, `GuideColorsteps` (non-position channels), `GuideNone` (any
+channel). `<GuideLegend channel="color" position="bottom"/>` assembles
+`guides: {"color": {"type": "legend", "position": "bottom"}}`.
+
+- Top-level `guides` override a scale-local `guide`.
+- Shared options: `title`, `theme` (bounded size/gap overrides), `collision`;
+  non-position guides add integer `order` (placement rank), `position`
+  `"auto"|"right"|"bottom"`, `direction` `"auto"|"vertical"|"horizontal"`,
+  and `force` (show a guide suppressed by default, e.g. identity scales).
+- Responsive rule: `auto`-positioned non-position guides move below the panel
+  when the viewport is 480px wide or less, or when a right guide would leave
+  under 320px of panel (after an estimated 80px of other chrome).
+- `<Legend order="stable-domain"|"present-first-seen"|"sorted"/>` is the
+  plot-wide legend ENTRY-SORT enum (default `stable-domain`; ordering never
+  changes color assignments). Distinct from `<GuideLegend order={2}/>`, a
+  per-aesthetic integer placement rank — same word, unrelated concepts.
+- `Labs` takes flat string props: `title`, `subtitle`, `caption`, `x`, `y`,
+  `color`, `fill`, `size`, `linewidth`, `alpha`, `shape`, `linetype`. The
+  spec type is re-exported from `@ggsvelte/svelte` as `LabsSpec`.
+
+```svelte fragment
+<GGPlot
+  data={rows}
+  aes={{ x: "cat", y: "val", fill: "group" }}
+  layers={[{ geom: "col" }]}
+>
+  <CoordFlip />
+  <FacetWrap field="region" ncol={2} />
+  <ThemeMinimal />
+  <Labs title="Sales by category" x="Category" y="Sales" />
+  <GuideLegend channel="fill" position="bottom" />
+  <Legend order="sorted" />
+</GGPlot>
+```
+
+Equivalent complete JSON spec:
+
+```json complete
+{
+  "data": {
+    "values": [
+      { "cat": "a", "val": 3, "group": "g1", "region": "west" },
+      { "cat": "b", "val": 5, "group": "g2", "region": "west" },
+      { "cat": "a", "val": 2, "group": "g1", "region": "east" },
+      { "cat": "b", "val": 4, "group": "g2", "region": "east" }
+    ]
+  },
+  "layers": [
+    {
+      "geom": "col",
+      "aes": {
+        "x": { "field": "cat" },
+        "y": { "field": "val" },
+        "fill": { "field": "group" }
+      }
+    }
+  ],
+  "coord": { "type": "flip" },
+  "facet": { "wrap": { "field": "region" }, "ncol": 2 },
+  "theme": "minimal",
+  "labs": { "title": "Sales by category", "x": "Category", "y": "Sales" },
+  "guides": { "fill": { "type": "legend", "position": "bottom" } },
+  "legend": { "order": "sorted" }
+}
+```
+
+## Replace-vs-merge semantics (child layers)
+
+- The `spec` prop wins over everything — when set, all other props and all
+  children are ignored.
+- Mark layers: the `layers` prop, when set, is used INSTEAD of geom children.
+  Otherwise geom children register in document order, and registration order
+  is z-order (first = bottom).
+- Grammar (non-mark) families fold onto the builder AFTER the matching
+  deprecated prop, in registration order — so a grammar child overrides its
+  prop, and later siblings beat earlier ones.
+- REPLACE families — `coord`, `facet`, `theme`: the last registration fully
+  replaces earlier ones (and any matching prop). Two or more children of one
+  kind emit a `DUPLICATE_PLOT_LAYER` advisory.
+- Scales merge per-channel; two scale children configuring the same channel
+  emit `DUPLICATE_SCALE_CHANNEL` (note British/American spellings write the
+  same channel: `<ScaleColorDiscrete/>` and `<ScaleColourContinuous/>` both
+  configure `color`).
+- `labs`, `guides`, `legend` are keyed-MERGE families: siblings touching
+  different keys all survive; a colliding key emits `DUPLICATE_MERGE_KEY` and
+  the later child's value wins. The value at a key is replaced whole — a
+  guide child never field-merges into another guide object for that channel.
+- All three advisory codes arrive through `ondiagnostic` with severity
+  `"advisory"`; the chart still renders.
+- Grammar children emit no markup and are inert without a `<GGPlot>` ancestor.

--- a/packages/svelte/skills/ggsvelte/references/geoms-and-stats.md
+++ b/packages/svelte/skills/ggsvelte/references/geoms-and-stats.md
@@ -1,0 +1,258 @@
+<!-- Source of truth: packages/spec/src/schema-catalog.ts (KNOWN_GEOMS, KNOWN_STATS, KNOWN_POSITIONS, GEOM_DEFAULTS), packages/spec/src/schema-declarations.ts (per-geom position unions, params), packages/svelte/src/lib/geoms/. Inventory tables are asserted complete by scripts/skill-content.test.ts. -->
+
+# Geoms, stats, and positions
+
+A JSON layer is `{ "geom": ..., "stat"?, "position"?, "positionParams"?, "aes"?, "data"?, "params"?, "render"? }`.
+Every geom is also a Svelte component (`<GeomPoint/>` inside `<GGPlot>`); the component takes
+`data`, `aes`, `stat`, `position`, `positionParams`, `render` props, and its constant style
+params (the layer's `params` keys) as DIRECT props — each component whitelists exactly its
+geom's param keys via `createGeomLayer` (`packages/svelte/src/lib/geoms/*.svelte`):
+
+```svelte fragment
+<GeomPoint
+  aes={{ x: "displ", y: "hwy" }}
+  size={3}
+  alpha={0.6}
+  position="jitter"
+  positionParams={{ seed: 7 }}
+/>
+```
+
+Omit `stat`/`position` to get the geom's defaults (normalize fills them in). Each layer
+declaration allows only its own stat and position values — anything else is a schema error.
+
+Component layer z-order equals registration order (decision 0001). Static markup, `{#if}`
+membership, and unkeyed `{#each}` keep declaration order; keyed `{#each}` reorder or
+re-mount appends re-registered layers at the END — use the props-first API
+(`layers={[...]}`) for dynamic layer composition. Components emit no markup and are inert
+outside a `<GGPlot>` ancestor.
+
+## Geom inventory
+
+All 49 geoms. "Default" is stat+position from GEOM_DEFAULTS. "Channels" lists required
+channels (all geoms also consume color/fill/alpha and group where meaningful; strokes take
+linewidth/linetype, points take size/shape). "Positions" is the layer's full allowed set.
+
+| geom                | component           | default (stat + position)    | channels                                             | key params                                                                     | positions                    |
+| ------------------- | ------------------- | ---------------------------- | ---------------------------------------------------- | ------------------------------------------------------------------------------ | ---------------------------- |
+| `point`             | GeomPoint           | identity + identity          | x, y                                                 | alpha, size, shape; summary_bin/manual add bins, binwidth, fun, funMin, funMax | identity, jitter, nudge      |
+| `line`              | GeomLine            | identity + identity          | x, y (ecdf/bin: x only)                              | linewidth, alpha, curve, connection, bins, binwidth, fun                       | identity                     |
+| `path`              | GeomPath            | identity + identity          | x, y (data order, not x-sorted)                      | linewidth, curve, connection; ellipse: level, type, segments                   | identity                     |
+| `step`              | GeomStep            | identity + identity          | x, y                                                 | direction ("hv" default, "vh", "mid")                                          | identity                     |
+| `col`               | GeomCol             | identity + stack             | x (discrete), y (height)                             | width, alpha                                                                   | stack, fill, dodge, identity |
+| `bar`               | GeomBar             | count + stack                | x only (y computed)                                  | width, alpha; stat bin adds bins, binwidth                                     | stack, fill, dodge, identity |
+| `histogram`         | GeomHistogram       | bin + stack                  | x (continuous; y computed)                           | bins (default 30), binwidth, boundary, center, closed                          | stack, fill, dodge, identity |
+| `freqpoly`          | GeomFreqpoly        | bin + identity               | x (continuous; y computed)                           | bins, binwidth, boundary, center, closed, linewidth                            | identity                     |
+| `area`              | GeomArea            | identity + stack             | x, y                                                 | alpha; stat align for mismatched x samples                                     | stack, fill, dodge, identity |
+| `ribbon`            | GeomRibbon          | identity + identity          | x+ymin+ymax OR y+xmin+xmax                           | alpha, outline, orientation                                                    | identity                     |
+| `rule`              | GeomRule            | identity + identity          | none (annotation) or exactly ONE of x / y            | xintercept, yintercept, linewidth                                              | identity                     |
+| `hline`             | GeomHline           | identity + identity          | none, or aes.y (data-driven)                         | yintercept, linewidth                                                          | identity                     |
+| `vline`             | GeomVline           | identity + identity          | none, or aes.x (data-driven)                         | xintercept, linewidth                                                          | identity                     |
+| `abline`            | GeomAbline          | identity + identity          | none (annotation only)                               | slope, intercept, linewidth                                                    | identity                     |
+| `text`              | GeomText            | identity + identity          | x, y, label                                          | size, anchor, dx, dy (px offsets)                                              | identity, nudge              |
+| `label`             | GeomLabel           | identity + identity          | x, y, label                                          | size, anchor, dx, dy, padding, radius, linewidth                               | identity, nudge              |
+| `smooth`            | GeomSmooth          | smooth + identity            | x, y (quantitative)                                  | method, se, level, span, degree, n                                             | identity                     |
+| `quantile`          | GeomQuantile        | quantile + identity          | x, y (quantitative)                                  | quantiles (default [0.25, 0.5, 0.75]), n                                       | identity                     |
+| `boxplot`           | GeomBoxplot         | boxplot + dodge              | x (discrete), y (quantitative)                       | width, coef, outlierSize, linewidth                                            | dodge, identity              |
+| `violin`            | GeomViolin          | ydensity + dodge             | x (discrete), y (continuous)                         | bw, adjust, trim, scale, width                                                 | dodge, identity              |
+| `density`           | GeomDensity         | density + identity           | x (continuous; y computed)                           | bw, adjust, n, cut                                                             | identity                     |
+| `errorbar`          | GeomErrorbar        | identity + identity          | x, ymin, ymax (identity); x, y (summary/summary_bin) | width, fun, funMin, funMax, bins, binwidth                                     | identity                     |
+| `linerange`         | GeomLinerange       | identity + identity          | x, ymin, ymax (identity); x, y (summary)             | none                                                                           | identity                     |
+| `pointrange`        | GeomPointrange      | identity + identity          | x, y, ymin, ymax (identity); x, y (summary)          | size, shape, linewidth, fun                                                    | identity                     |
+| `crossbar`          | GeomCrossbar        | identity + identity          | x, y, ymin, ymax                                     | width, fatten, fun, funMin, funMax                                             | identity                     |
+| `rect`              | GeomRect            | identity + identity          | xmin, xmax, ymin, ymax                               | linewidth, alpha                                                               | identity                     |
+| `tile`              | GeomTile            | identity + identity          | x, y (cell centers); width/height via aes or params  | width, height, linewidth                                                       | identity                     |
+| `raster`            | GeomRaster          | identity + identity          | x, y (regular grid), fill                            | hjust, vjust, interpolate                                                      | identity                     |
+| `bin_2d`            | GeomBin2d           | bin_2d + identity            | x, y (continuous; fill defaults to after-stat count) | bins, binwidth, drop                                                           | identity                     |
+| `hex`               | GeomHex             | bin_hex + identity           | x, y (continuous; fill defaults to after-stat count) | bins, drop                                                                     | identity                     |
+| `segment`           | GeomSegment         | identity + identity          | x, y, xend, yend                                     | linewidth, lineend                                                             | identity                     |
+| `curve`             | GeomCurve           | identity + identity          | x, y, xend, yend                                     | curvature, angle, ncp, lineend                                                 | identity                     |
+| `spoke`             | GeomSpoke           | identity + identity          | x, y; angle (radians) + radius via aes or params     | angle, radius, linewidth                                                       | identity                     |
+| `count`             | GeomCount           | sum + identity               | x, y (size defaults to after-stat n)                 | alpha, size, shape                                                             | identity, jitter, nudge      |
+| `jitter`            | GeomJitter          | identity + jitter            | x, y (alias; normalize → point + position jitter)    | alpha, size, shape                                                             | jitter                       |
+| `function`          | GeomFunction        | function + identity          | none (y computed from params.fun)                    | fun, n, xlim, args                                                             | identity                     |
+| `polygon`           | GeomPolygon         | identity + identity          | x, y (vertices in data order, auto-closed)           | alpha, linewidth                                                               | identity                     |
+| `contour`           | GeomContour         | contour + identity           | x, y, z (regular complete grid)                      | bins (default 10), binwidth, breaks                                            | identity                     |
+| `density_2d`        | GeomDensity2d       | density_2d + identity        | x, y (continuous)                                    | h, adjust, n, bins, binwidth, breaks                                           | identity                     |
+| `density_2d_filled` | GeomDensity2dFilled | density_2d_filled + identity | x, y (continuous; fill defaults to after-stat level) | h, adjust, n, bins, breaks                                                     | identity                     |
+| `dotplot`           | GeomDotplot         | bindot + identity            | x (continuous; y is computed stackpos)               | bins, binwidth, stackdir, stackratio, dotsize                                  | identity                     |
+| `rug`               | GeomRug             | identity + identity          | x and/or y (match params.sides)                      | sides (default "bl"), length                                                   | identity                     |
+| `map`               | GeomMap             | identity + identity          | map_id (joined to map data)                          | map (required DataRef), mapId                                                  | identity                     |
+| `sf`                | GeomSf              | sf + identity                | none (GeoJSON geometry column)                       | geometry (default "geometry"), size, linewidth                                 | identity                     |
+| `sf_text`           | GeomSfText          | sf_coordinates + identity    | label (+ geometry column; no x/y)                    | geometry, size, anchor, dx, dy                                                 | identity                     |
+| `sf_label`          | GeomSfLabel         | sf_coordinates + identity    | label (+ geometry column; no x/y)                    | geometry, padding, radius, dx, dy                                              | identity                     |
+| `blank`             | GeomBlank           | identity + identity          | any mapped channel (trains scales, draws nothing)    | none                                                                           | identity                     |
+| `qq`                | GeomQq              | qq + identity                | sample                                               | size, shape                                                                    | identity                     |
+| `qq_line`           | GeomQqLine          | qq_line + identity           | sample                                               | linewidth                                                                      | identity                     |
+
+Alias geoms (rewritten by `normalize`): `histogram` → bar + stat bin; `freqpoly` → line +
+stat bin; `jitter` → point + position jitter; `hline`/`vline` → rule. Annotation-form
+rule/hline/vline (fixed intercepts in params) inherit NO plot aes. Any geom absent from
+GEOM_DEFAULTS notes above defaults to identity + identity.
+
+## Stat inventory
+
+There are NO `Stat*` components — `stat` is a prop on geom components and a field on JSON
+layers. Stats either compute new columns (read them with the after-stat aes form
+`{"stat": "count"}`) or transform rows in place.
+
+**Computed-y rule:** when the stat computes y (bar/histogram/freqpoly, line + stat bin or
+ecdf, density, function, dotplot/bindot), `aes.y` must NOT map a field — that is the
+`computed-y-mapped` error. Leave y unmapped (the default after-stat mapping applies), map
+`{"stat": "..."}` explicitly, or unset an inherited y with `null`:
+
+```json fragment
+{
+  "geom": "histogram",
+  "aes": { "x": { "field": "hwy" }, "y": { "stat": "density" } },
+  "params": { "bins": 20 }
+}
+```
+
+**After-stat color/fill:** `{"stat": ...}` on color or fill resolves ONLY for the stats
+that publish color columns — `bin_2d` and `bin_hex` (count, density, ncount, ndensity)
+and `density_2d` / `density_2d_filled` (level, density). On every other stat an
+after-stat color mapping is dropped; those geoms already default fill to the right
+after-stat column, so usually map nothing at all.
+
+| stat                | computed columns                                          | typical geoms                                                             | key params                                               |
+| ------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------- | -------------------------------------------------------- |
+| `identity`          | none (rows drawn as-is)                                   | most geoms (default)                                                      | —                                                        |
+| `unique`            | none (dedupes rows on mapped aesthetics, first wins)      | point, line, path, col, text, rect, rule, segment, ribbon, area, errorbar | —                                                        |
+| `manual`            | none (one row per group via a named aggregate)            | point, line, path                                                         | fun (required: first, last, mean, median, min, max, sum) |
+| `connect`           | none (expands successive points into connection vertices) | path (ggplot2 default), line                                              | connection (hv, vh, mid, linear)                         |
+| `align`             | none (interpolates each group onto the union of x values) | area, line                                                                | —                                                        |
+| `count`             | count                                                     | bar                                                                       | —                                                        |
+| `bin`               | count, density, ncount, ndensity                          | histogram, bar, freqpoly, line                                            | bins (default 30), binwidth, boundary, center, closed    |
+| `bin_hex`           | count, density, ncount, ndensity                          | hex                                                                       | bins, drop                                               |
+| `bin_2d`            | count, density, ncount, ndensity                          | bin_2d                                                                    | bins, binwidth, drop                                     |
+| `smooth`            | y, ymin, ymax, se                                         | smooth                                                                    | method, se, level, span, degree, n                       |
+| `quantile`          | y (one line per quantile)                                 | quantile                                                                  | quantiles, n                                             |
+| `boxplot`           | ymin, lower, middle, upper, ymax                          | boxplot                                                                   | coef                                                     |
+| `density`           | density, count, scaled, ndensity                          | density                                                                   | bw, adjust, n, cut                                       |
+| `summary`           | y, ymin, ymax                                             | errorbar, linerange, pointrange, crossbar                                 | fun, funMin, funMax (default mean ± se)                  |
+| `summary_bin`       | y, ymin, ymax (per x bin)                                 | point, line, errorbar                                                     | fun + bins, binwidth, boundary, center, closed           |
+| `sum`               | n, prop (aggregates coincident x, y)                      | count, point                                                              | —                                                        |
+| `ydensity`          | density, count, scaled, violinwidth, y                    | violin                                                                    | bw, adjust, n, trim, scale                               |
+| `function`          | y (evaluates a portable named fun)                        | function                                                                  | fun, n, xlim, args                                       |
+| `ecdf`              | ecdf (y defaults to it)                                   | line (use params.curve "step-hv")                                         | —                                                        |
+| `contour`           | level                                                     | contour                                                                   | bins, binwidth, breaks                                   |
+| `density_2d`        | level, density (isolines; also after-stat color)          | density_2d                                                                | h, adjust, n, bins, breaks                               |
+| `density_2d_filled` | level, density (filled bands)                             | density_2d_filled                                                         | h, adjust, n, bins, breaks                               |
+| `bindot`            | stackpos (the computed y; count is NOT a valid y here)    | dotplot                                                                   | bins, binwidth, stackdir, stackratio                     |
+| `ellipse`           | none (one closed normal-ellipse ring per group)           | path                                                                      | level, type, segments                                    |
+| `sf`                | none (renders the GeoJSON geometry column)                | sf                                                                        | geometry                                                 |
+| `sf_coordinates`    | none (computes x/y anchors from geometry)                 | sf_text, sf_label                                                         | geometry                                                 |
+| `qq`                | sample, theoretical                                       | qq                                                                        | —                                                        |
+| `qq_line`           | sample, theoretical                                       | qq_line                                                                   | —                                                        |
+
+### Stat usage patterns
+
+Non-default stats go on the layer; their params share the layer's `params` object.
+
+```json fragment
+{
+  "geom": "errorbar",
+  "stat": "summary",
+  "aes": { "x": { "field": "group" }, "y": { "field": "value" } }
+}
+```
+
+```json fragment
+{
+  "geom": "line",
+  "stat": "ecdf",
+  "aes": { "x": { "field": "value" } },
+  "params": { "curve": "step-hv" }
+}
+```
+
+```json fragment
+{
+  "geom": "line",
+  "stat": "manual",
+  "aes": { "x": { "field": "month" }, "y": { "field": "value" } },
+  "params": { "fun": "mean" }
+}
+```
+
+```json fragment
+{ "geom": "function", "params": { "fun": "sin", "n": 200, "xlim": [0, 6.28] } }
+```
+
+```json fragment
+{
+  "geom": "point",
+  "stat": "summary_bin",
+  "aes": { "x": { "field": "carat" }, "y": { "field": "price" } },
+  "params": { "bins": 20, "fun": "median" }
+}
+```
+
+- `summary` / `summary_bin` default to mean ± se; override with `fun`, `funMin`, `funMax`
+  (first, last, mean, median, min, max, sum).
+- `align` fixes continuous-x stack/fill when groups sample different x values (area, line).
+- `connect` (path/line) expands point pairs into hv / vh / mid / linear connectors.
+- `unique` dedupes rows on the mapped aesthetic combination, first occurrence wins.
+- `ellipse` on path draws one closed normal-data ellipse per group (params.level default 0.95).
+
+## Position inventory
+
+All 6 positions. Each layer declaration scopes which it accepts (see the geom table); a
+disallowed position is a schema error, not a silent fallback.
+
+| position   | effect                                           | positionParams                                                                                    | allowed on                                 |
+| ---------- | ------------------------------------------------ | ------------------------------------------------------------------------------------------------- | ------------------------------------------ |
+| `identity` | leave positions unchanged                        | —                                                                                                 | every geom                                 |
+| `stack`    | pile grouped values (positive up, negative down) | —                                                                                                 | bar, col, histogram, area                  |
+| `fill`     | stack, then rescale to proportions of 1          | —                                                                                                 | bar, col, histogram, area                  |
+| `dodge`    | place groups side by side within each x band     | — (no width param)                                                                                | bar, col, histogram, area, boxplot, violin |
+| `jitter`   | seeded random offsets — ALWAYS deterministic     | width, height (data units on continuous axes, band-step fractions on discrete), seed (default 42) | point, count, jitter                       |
+| `nudge`    | fixed offset in data units / band-step fractions | x, y (default 0)                                                                                  | point, count, text, label                  |
+
+`positionParams` exists only on layers that allow jitter or nudge (point, count, jitter,
+text, label). Jitter defaults width/height to 40% of the data resolution; pass `seed` to
+vary the (reproducible) layout. Stack, fill, and dodge take no parameters.
+
+## Annotations
+
+There is no `Annotate` API — annotate with ordinary geom layers:
+
+- **Reference lines:** `rule` with `params.yintercept` / `params.xintercept` and NO aes
+  (annotation form; inherits nothing). `hline` (params.yintercept) and `vline`
+  (params.xintercept) are aliases that normalize to rule. Data-driven rules map exactly
+  ONE of aes.x / aes.y (both mapped is the `rule-both-axes` error).
+- **Sloped line:** `abline` with `params.slope` and `params.intercept` (annotation only —
+  no data-mapped slope).
+- **Text:** `text` / `label` with layer-local inline data. `params.dx`/`params.dy` are PX
+  offsets; `position: "nudge"` + `positionParams.x`/`y` offset in DATA units.
+- **Arrows and callout paths:** `segment` (straight; x, y, xend, yend) or `curve` (same
+  channels plus curvature/angle/ncp).
+- **Radial marks:** `spoke` (x, y plus angle in radians and radius from aes or params).
+
+```json complete
+{
+  "data": {
+    "values": [
+      { "x": 1, "y": 3 },
+      { "x": 2, "y": 5 },
+      { "x": 3, "y": 4 }
+    ]
+  },
+  "aes": { "x": { "field": "x" }, "y": { "field": "y" } },
+  "layers": [
+    { "geom": "point" },
+    { "geom": "rule", "params": { "yintercept": 4 } },
+    {
+      "geom": "text",
+      "data": { "values": [{ "x": 2, "y": 5, "note": "peak" }] },
+      "aes": {
+        "x": { "field": "x" },
+        "y": { "field": "y" },
+        "label": { "field": "note" }
+      },
+      "params": { "dy": -8 }
+    }
+  ]
+}
+```

--- a/packages/svelte/skills/ggsvelte/references/interactions.md
+++ b/packages/svelte/skills/ggsvelte/references/interactions.md
@@ -1,0 +1,135 @@
+<!-- Source of truth: packages/svelte/src/lib/plot-props.ts, packages/svelte/src/lib/interaction/ (controller, config, diagnostics), packages/svelte/src/lib/index.ts. -->
+
+# Svelte interactions
+
+`@ggsvelte/svelte` requires Svelte `^5.33.1` (peerDependency). Interactions are
+opt-in PROPS on `<GGPlot>` — they are not spec fields and never appear in a
+PortableSpec. Always pass a stable `key` when selection, legend focus, or
+coordinated intervals must survive filtering, reordering, or data refreshes.
+
+## Capability props
+
+| Prop           | Input                                                  | What it enables                                                                                                                                                                                                                                                   |
+| -------------- | ------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `inspect`      | `boolean \| InspectOptions`                            | Tooltip, semantic crosshair, keyboard traversal, pinning. Options: `mode` (`"auto" \| "exact" \| "x" \| "y" \| "xy"`), `pin`, `maxDistance` (CSS px), `contentMode` (`"informational" \| "interactive"`), `muteSiblings`, `content` (Snippet, see Tooltip below). |
+| `select`       | `false \| "point" \| "interval" \| SelectOptions`      | Point or interval selection. Options: `type` (`"point" \| "interval"`), `mode` (`"x" \| "y" \| "xy"`, interval only), `multiple`, `persistent`, `preset` (faceted intervals, below).                                                                              |
+| `zoom`         | `boolean \| ZoomOptions`                               | Brush zoom. Options: `mode` (`"x" \| "y" \| "xy"`), `trigger` (`"brush"`). Currently requires one unfaceted panel.                                                                                                                                                |
+| `legendFocus`  | `boolean \| { preview?: boolean }`                     | Discrete legend preview, focus, and linked emphasis. Emphasis only — never changes included rows. Discrete color/fill legends only; continuous ramps stay static.                                                                                                 |
+| `legendFilter` | `boolean \| LegendFilterOptions`                       | Data-changing filtering through discrete legend controls: changes the included rows and reruns the grammar while preserving stable color identity. Options: `mode` (`"exclude" \| "include"`), `multiple`.                                                        |
+| `key`          | column name or `(row, index) => PropertyKey`           | Stable semantic identity for public interaction payloads. Required for durable point selection, coordinated interval presets, and legend focus/filter. Duplicate or unstable keys are diagnostic errors.                                                          |
+| `tool`         | `"inspect" \| "point" \| "select-area" \| "zoom-area"` | Controlled initial/active tool; observe changes with `ontoolchange`.                                                                                                                                                                                              |
+| `ariaLabel`    | `string`                                               | Accessible chart name; falls back to the plot title or a generated label.                                                                                                                                                                                         |
+| `a11y`         | `A11yMode`                                             | `"force-svg"` keeps every layer as SVG marks.                                                                                                                                                                                                                     |
+
+After an interval or zoom commit, accessible controls accept exact bounds.
+
+## Faceted interval presets
+
+`select={{ type: "interval", preset }}` coordinates durable intervals across
+facet panels:
+
+- `independent` — only the matching panel consumes its interval.
+- `union` — matching rows from every stored panel interval are combined.
+- `cross-panel` — the sole origin interval is projected into compatible panels.
+
+`union` and `cross-panel` require a stable `key`; without one they combine no
+rows (warning `INTERACTION_INTERVAL_PRESET_REQUIRES_KEY`).
+
+## Controller: durable shared state
+
+`createPlotInteraction<Key>()` creates chart-independent semantic state that
+outlives any one plot. Pass the same controller to every plot that should link,
+via the `interaction` prop. The controller owns stable keys and scoped data
+domains only; each chart translates them to its own render model.
+
+- Mutation methods: `setSelection(keys, {scope, source?})`, `toggleSelection`,
+  `clearSelection`, `setEmphasis`, `clearEmphasis`, `setInterval`,
+  `clearInterval`, `clearIntervals`, `setZoom(domains, {scope, source?})`,
+  `resetZoom`, `reconcileKeys` (call after replacing rows).
+- Reads: `selected(scope)`, `emphasized(scope)`, `isSelected(key, scope)`,
+  `intervals(scope)`, `zoom(scope)`, `snapshot`, `revision` (reactive).
+- `createPlotInteraction({ onchange })` observes every transition
+  (`kind`, `source`, `revision`).
+
+`interactionScope` (`{ keys, x?, y?, intervals? }`) names the identity
+namespaces used for linking: key state crosses charts only through `keys`;
+data-space zoom crosses one positional channel only when that channel's scope
+also matches; `intervals` defaults to `keys`. Give plots matching scope
+channels only when they should coordinate.
+
+A `<GGPlot>` component instance also exports `resetScales()` and
+`setZoom(domains)` for imperative per-chart control.
+
+## Handlers
+
+`oninspect`, `onselect`, `onzoom`, `onlegendfocus`, `onlegendfilter`,
+`oninteraction` (union of all five event types), `ondiagnostic`,
+`ontoolchange`, and `onrender(model, spec)` — called after each committed
+render with the RenderModel (warnings, advisories, scales) and the normalized
+PortableSpec.
+
+A handler without its matching capability prop (for example `onselect` without
+`select`), or `interactionScope` without an `interaction` controller, is inert
+and emits a development advisory (`INTERACTION_HANDLER_WITHOUT_CAPABILITY`,
+`INTERACTION_SCOPE_WITHOUT_CONTROLLER`).
+
+## Tooltip
+
+Enabling `inspect` renders the default HTML tooltip; no extra component is
+needed. Customize its body with the `inspect.content` snippet, which receives a
+`PlotInspectionChange` (`focus`/`members` are `PlotDatum` values whose `fields`
+are `TooltipField` rows: `{ channel, field, value }`). The exported `Tooltip`
+component is the same positioned shell for advanced custom rendering.
+`TooltipContext` is a deprecated (0.1.0) alias of `PlotInspectionChange`.
+
+## Diagnostics
+
+`ondiagnostic` receives `PlotDiagnostic`, the union of three catalogs (each
+entry has `severity`, `code`, `message`, `prop`, `suggestions`, `docUrl`):
+
+- `INTERACTION_DIAGNOSTIC_CATALOG` — capability/key/lineage checks, e.g.
+  `INTERACTION_POINT_REQUIRES_KEY`, `INTERACTION_DUPLICATE_KEY`,
+  `INTERACTION_UNSTABLE_KEY`, `INTERACTION_INTERVAL_FACET_UNSUPPORTED`,
+  `INTERACTION_INTERVAL_SCALE_UNSUPPORTED` (continuous linear/log/time only),
+  `INTERACTION_LEGEND_DISCRETE_ONLY`, `INTERACTION_TOOL_UNAVAILABLE`, and the
+  two wiring advisories named above.
+- `DEPRECATION_DIAGNOSTIC_CATALOG` — one code, `DEPRECATED_PLOT_PROP`, for
+  every grammar prop deprecated in 0.11.0 (`prop` carries the name).
+- `COMPOSITION_DIAGNOSTIC_CATALOG` — child-layer composition collisions:
+  `DUPLICATE_PLOT_LAYER`, `DUPLICATE_SCALE_CHANNEL`, `DUPLICATE_MERGE_KEY`.
+
+## Worked example: linked faceted selection
+
+```svelte fragment
+<script lang="ts">
+  import {
+    createPlotInteraction,
+    Facet,
+    GeomPoint,
+    GGPlot,
+  } from "@ggsvelte/svelte";
+
+  const interaction = createPlotInteraction<number>();
+  const scope = { keys: "sales-rows", intervals: "sales-range" } as const;
+</script>
+
+<GGPlot
+  data={rows}
+  aes={{ x: "date", y: "value", color: "series" }}
+  key="id"
+  select={{ type: "interval", mode: "x", preset: "cross-panel" }}
+  legendFocus
+  legendFilter
+  {interaction}
+  interactionScope={scope}
+  oninteraction={(event) => console.log(event.type, event)}
+>
+  <Facet wrap="region" ncol={3} />
+  <GeomPoint />
+</GGPlot>
+```
+
+Any second plot given the same `interaction` controller and a matching
+`interactionScope` stays linked: brushing an interval in one panel projects it
+cross-panel, external UI can call `interaction.setSelection(...)`, and legend
+filtering reruns the grammar without reshuffling series colors.

--- a/packages/svelte/skills/ggsvelte/references/recipes.md
+++ b/packages/svelte/skills/ggsvelte/references/recipes.md
@@ -1,0 +1,438 @@
+<!-- Recipes adapted from examples/<category>/<name>/ where noted; hand-authored recipes are validated by scripts/skill-content.test.ts (normalize + validate on every json complete fence). -->
+
+# Long-tail recipes
+
+Each recipe pairs a validated JSON `PortableSpec` with its Svelte-children twin.
+Inline data is cut to a few rows — swap in yours. Plot-level `aes` inherits into
+every layer; a layer `aes` merges over it, and `null` unsets a channel.
+
+## Error bars from raw values (stat summary)
+
+Raw observations per group; the summary stat computes mean ± se, no preaggregation.
+<!-- adapted from examples/errorbar/mean-se/ -->
+
+```json complete
+{
+  "data": {
+    "values": [
+      { "drug": "A", "sleep": 0.7 },
+      { "drug": "A", "sleep": 1.6 },
+      { "drug": "A", "sleep": 0.2 },
+      { "drug": "B", "sleep": 1.9 },
+      { "drug": "B", "sleep": 3.4 },
+      { "drug": "B", "sleep": 2.5 }
+    ]
+  },
+  "aes": { "x": { "field": "drug" }, "y": { "field": "sleep" } },
+  "layers": [
+    {
+      "geom": "point",
+      "position": "jitter",
+      "positionParams": { "width": 0.1, "height": 0, "seed": 7 },
+      "params": { "alpha": 0.5 }
+    },
+    { "geom": "errorbar", "stat": "summary", "params": { "width": 0.3 } }
+  ]
+}
+```
+
+```svelte fragment
+<GGPlot data={rows} aes={{ x: "drug", y: "sleep" }}>
+  <GeomPoint
+    position="jitter"
+    positionParams={{ width: 0.1, height: 0, seed: 7 }}
+    alpha={0.5}
+  />
+  <GeomErrorbar stat="summary" width={0.3} />
+</GGPlot>
+```
+
+## Value labels on columns
+
+`dy`/`dx` are PIXEL offsets (negative dy = up); `position: "nudge"` + `positionParams` offsets in DATA units instead.
+<!-- adapted from examples/text/labels/ -->
+
+```json complete
+{
+  "data": {
+    "values": [
+      { "cat": "a", "n": 4 },
+      { "cat": "b", "n": 7 },
+      { "cat": "c", "n": 5 }
+    ]
+  },
+  "aes": { "x": { "field": "cat" }, "y": { "field": "n" } },
+  "layers": [
+    { "geom": "col" },
+    {
+      "geom": "text",
+      "aes": { "label": { "field": "n" } },
+      "params": { "dy": -8 }
+    }
+  ]
+}
+```
+
+```svelte fragment
+<GGPlot data={rows} aes={{ x: "cat", y: "n" }}>
+  <GeomCol />
+  <GeomText aes={{ label: "n" }} dy={-8} />
+</GGPlot>
+```
+
+## Big scatter on canvas
+
+`"render": "canvas"` forces the canvas path; layers over 2000 marks switch on their own. Plot-level `"a11y": "force-svg"` overrides for assistive tech.
+<!-- adapted from examples/point/canvas-scatter/ -->
+
+```json complete
+{
+  "data": {
+    "values": [
+      { "x": 1, "y": 2 },
+      { "x": 2, "y": 3 },
+      { "x": 3, "y": 2.5 },
+      { "x": 4, "y": 4 }
+    ]
+  },
+  "layers": [
+    {
+      "geom": "point",
+      "render": "canvas",
+      "aes": { "x": { "field": "x" }, "y": { "field": "y" } },
+      "params": { "size": 1.2, "alpha": 0.4 }
+    }
+  ],
+  "a11y": "force-svg"
+}
+```
+
+```svelte fragment
+<GGPlot data={rows} aes={{ x: "x", y: "y" }} a11y="force-svg">
+  <GeomPoint render="canvas" size={1.2} alpha={0.4} />
+</GGPlot>
+```
+
+## Log10 axis scatter
+
+Positive data only; the transform runs before stats. Authored `"type": "log"` canonicalizes to this form.
+<!-- adapted from examples/point/log-scale/ -->
+
+```json complete
+{
+  "data": {
+    "values": [
+      { "density": 10, "rate": 3 },
+      { "density": 100, "rate": 9 },
+      { "density": 1000, "rate": 30 },
+      { "density": 5000, "rate": 55 }
+    ]
+  },
+  "layers": [
+    {
+      "geom": "point",
+      "aes": { "x": { "field": "density" }, "y": { "field": "rate" } }
+    }
+  ],
+  "scales": { "x": { "type": "linear", "transform": "log10" } }
+}
+```
+
+```svelte fragment
+<GGPlot data={rows} aes={{ x: "density", y: "rate" }}>
+  <ScaleXLog10 />
+  <GeomPoint />
+</GGPlot>
+```
+
+## Violin with jittered points
+
+Distribution shape per group; needs several y values per group for the density. Seeded jitter is deterministic.
+<!-- adapted from examples/boxplot/violin/ -->
+
+```json complete
+{
+  "data": {
+    "values": [
+      { "run": "a", "v": 1 },
+      { "run": "a", "v": 2 },
+      { "run": "a", "v": 2.4 },
+      { "run": "a", "v": 3.1 },
+      { "run": "a", "v": 1.7 },
+      { "run": "b", "v": 4 },
+      { "run": "b", "v": 5.2 },
+      { "run": "b", "v": 4.4 },
+      { "run": "b", "v": 6 },
+      { "run": "b", "v": 5.1 }
+    ]
+  },
+  "aes": { "x": { "field": "run" }, "y": { "field": "v" } },
+  "layers": [
+    { "geom": "violin", "params": { "trim": true, "alpha": 0.7 } },
+    {
+      "geom": "point",
+      "position": "jitter",
+      "positionParams": { "width": 0.08, "height": 0, "seed": 3 },
+      "params": { "size": 2 }
+    }
+  ]
+}
+```
+
+```svelte fragment
+<GGPlot data={rows} aes={{ x: "run", y: "v" }}>
+  <GeomViolin trim alpha={0.7} />
+  <GeomPoint
+    position="jitter"
+    positionParams={{ width: 0.08, height: 0, seed: 3 }}
+    size={2}
+  />
+</GGPlot>
+```
+
+## Tile heatmap (discrete x/y, continuous fill)
+
+One tile per (x, y) pair; a sequential fill scale carries the value.
+<!-- adapted from examples/tile/heatmap/ -->
+
+```json complete
+{
+  "data": {
+    "values": [
+      { "day": "Mon", "hour": "am", "n": 3 },
+      { "day": "Mon", "hour": "pm", "n": 8 },
+      { "day": "Tue", "hour": "am", "n": 5 },
+      { "day": "Tue", "hour": "pm", "n": 12 }
+    ]
+  },
+  "layers": [
+    {
+      "geom": "tile",
+      "aes": {
+        "x": { "field": "day" },
+        "y": { "field": "hour" },
+        "fill": { "field": "n" }
+      }
+    }
+  ],
+  "scales": { "fill": { "type": "sequential", "scheme": "viridis" } }
+}
+```
+
+```svelte fragment
+<GGPlot data={rows} aes={{ x: "day", y: "hour", fill: "n" }}>
+  <ScaleFillContinuous scheme="viridis" />
+  <GeomTile />
+</GGPlot>
+```
+
+## Hex density heatmap
+
+Overplotted x/y pairs binned into hexagons; fill defaults to the stat's `count`. `bin_2d` is the rectangular twin.
+<!-- adapted from examples/hex/basic/ -->
+
+```json complete
+{
+  "data": {
+    "values": [
+      { "x": 1, "y": 1 },
+      { "x": 1.1, "y": 1.2 },
+      { "x": 0.9, "y": 0.8 },
+      { "x": 3, "y": 3 },
+      { "x": 3.2, "y": 2.9 },
+      { "x": 2.8, "y": 3.1 }
+    ]
+  },
+  "layers": [
+    {
+      "geom": "hex",
+      "aes": { "x": { "field": "x" }, "y": { "field": "y" } },
+      "params": { "bins": 6 }
+    }
+  ]
+}
+```
+
+```svelte fragment
+<GGPlot data={rows} aes={{ x: "x", y: "y" }}>
+  <GeomHex bins={6} />
+</GGPlot>
+```
+
+## Step chart (ECDF)
+
+Stairs through precomputed points; `direction: "hv"` is the ECDF convention. `step` takes stat `identity` only, so compute F̂(x) = i/n yourself.
+<!-- adapted from examples/step/ecdf/ -->
+
+```json complete
+{
+  "data": {
+    "values": [
+      { "x": 1.2, "y": 0.25 },
+      { "x": 2, "y": 0.5 },
+      { "x": 3.1, "y": 0.75 },
+      { "x": 4.5, "y": 1 }
+    ]
+  },
+  "layers": [
+    {
+      "geom": "step",
+      "aes": { "x": { "field": "x" }, "y": { "field": "y" } },
+      "params": { "direction": "hv" }
+    }
+  ]
+}
+```
+
+```svelte fragment
+<GGPlot data={rows} aes={{ x: "x", y: "y" }}>
+  <GeomStep direction="hv" />
+</GGPlot>
+```
+
+## Ribbon band with a center line
+
+Map ymin/ymax at plot level for the band; the line layer adds its own y.
+<!-- adapted from examples/ribbon/bounds/ -->
+
+```json complete
+{
+  "data": {
+    "values": [
+      { "t": 1, "lo": 2, "hi": 5, "mid": 3.4 },
+      { "t": 2, "lo": 3, "hi": 6, "mid": 4.5 },
+      { "t": 3, "lo": 2.5, "hi": 7, "mid": 4.8 },
+      { "t": 4, "lo": 4, "hi": 8, "mid": 6 }
+    ]
+  },
+  "aes": {
+    "x": { "field": "t" },
+    "ymin": { "field": "lo" },
+    "ymax": { "field": "hi" }
+  },
+  "layers": [
+    { "geom": "ribbon", "params": { "alpha": 0.35 } },
+    {
+      "geom": "line",
+      "aes": { "y": { "field": "mid" } },
+      "params": { "linewidth": 1.5 }
+    }
+  ]
+}
+```
+
+```svelte fragment
+<GGPlot data={rows} aes={{ x: "t", ymin: "lo", ymax: "hi" }}>
+  <GeomRibbon alpha={0.35} />
+  <GeomLine aes={{ y: "mid" }} linewidth={1.5} />
+</GGPlot>
+```
+
+## Horizontal boxplot (coord flip)
+
+Map the category to x and the value to y as usual, then flip — long labels get room.
+<!-- hand-authored; validated by skill-content test -->
+
+```json complete
+{
+  "data": {
+    "values": [
+      { "g": "a", "v": 1 },
+      { "g": "a", "v": 2 },
+      { "g": "a", "v": 3 },
+      { "g": "a", "v": 2.2 },
+      { "g": "b", "v": 4 },
+      { "g": "b", "v": 5 },
+      { "g": "b", "v": 6 },
+      { "g": "b", "v": 4.8 }
+    ]
+  },
+  "layers": [
+    {
+      "geom": "boxplot",
+      "aes": { "x": { "field": "g" }, "y": { "field": "v" } }
+    }
+  ],
+  "coord": { "type": "flip" }
+}
+```
+
+```svelte fragment
+<GGPlot data={rows} aes={{ x: "g", y: "v" }}>
+  <CoordFlip />
+  <GeomBoxplot />
+</GGPlot>
+```
+
+## Smooth trend with per-layer aes override
+
+Both layers inherit x/y; only the point layer maps size. A layer channel set to `null` would drop an inherited one instead.
+<!-- adapted from examples/smooth/loess-scatter/ -->
+
+```json complete
+{
+  "data": {
+    "values": [
+      { "year": 1, "angle": 10, "w": 1 },
+      { "year": 2, "angle": 14, "w": 3 },
+      { "year": 3, "angle": 13, "w": 2 },
+      { "year": 4, "angle": 18, "w": 4 },
+      { "year": 5, "angle": 21, "w": 2 },
+      { "year": 6, "angle": 20, "w": 5 }
+    ]
+  },
+  "aes": { "x": { "field": "year" }, "y": { "field": "angle" } },
+  "layers": [
+    { "geom": "smooth", "params": { "method": "loess", "span": 0.9 } },
+    {
+      "geom": "point",
+      "aes": { "size": { "field": "w" } },
+      "params": { "alpha": 0.85 }
+    }
+  ]
+}
+```
+
+```svelte fragment
+<GGPlot data={rows} aes={{ x: "year", y: "angle" }}>
+  <GeomSmooth method="loess" span={0.9} />
+  <GeomPoint aes={{ size: "w" }} alpha={0.85} />
+</GGPlot>
+```
+
+## Map polygons (geom sf)
+
+Rows carry a `geometry` column of GeoJSON Geometry JSON strings, already projected; map no x/y — fill carries the value.
+<!-- adapted from examples/sf/basic/ -->
+
+```json complete
+{
+  "data": {
+    "values": [
+      {
+        "region": "A",
+        "rate": 12,
+        "geometry": "{\"type\":\"Polygon\",\"coordinates\":[[[0,0],[2,0],[1,2],[0,0]]]}"
+      },
+      {
+        "region": "B",
+        "rate": 28,
+        "geometry": "{\"type\":\"Polygon\",\"coordinates\":[[[2.2,0],[4.2,0],[3.2,2],[2.2,0]]]}"
+      }
+    ]
+  },
+  "layers": [
+    {
+      "geom": "sf",
+      "aes": { "fill": { "field": "rate" } },
+      "params": { "linewidth": 0.8 }
+    }
+  ]
+}
+```
+
+```svelte fragment
+<GGPlot data={regions} aes={{ fill: "rate" }}>
+  <GeomSf linewidth={0.8} />
+</GGPlot>
+```

--- a/packages/svelte/skills/ggsvelte/references/scales-and-palettes.md
+++ b/packages/svelte/skills/ggsvelte/references/scales-and-palettes.md
@@ -1,0 +1,295 @@
+<!-- Source of truth: packages/spec/src/schema-names.ts (scheme/shape/linetype names), packages/spec/src/capabilities.ts (SCALE_CAPABILITIES), scripts/gen-scale-children.ts (Scale* component generation), packages/spec/src/scale-*.ts helpers. Inventory tables are asserted complete by scripts/skill-content.test.ts. -->
+
+# Scales and palettes
+
+## Scale families
+
+`SCALE_CAPABILITIES` declares seven families. `scaleTypes` are the canonical
+post-normalize types; authored aliases never survive `normalize` (e.g. authored
+`type: "log"` becomes `{ "type": "linear", "transform": "log10" }` — trained
+models never report type `log`).
+
+| Family              | Aesthetics             | Canonical types                               | Transforms            | Authored aliases |
+| ------------------- | ---------------------- | --------------------------------------------- | --------------------- | ---------------- |
+| position-continuous | x, y                   | linear                                        | identity, log10, sqrt | log              |
+| position-binned     | x, y                   | binned                                        | identity, log10, sqrt | —                |
+| position-temporal   | x, y                   | time                                          | identity              | —                |
+| position-discrete   | x, y                   | band                                          | —                     | —                |
+| color-fill          | color, fill            | ordinal, sequential, binned, manual, identity | identity, log10, sqrt | —                |
+| numeric-style       | size, linewidth, alpha | sequential, ordinal, binned, manual, identity | identity              | —                |
+| finite-style        | shape, linetype        | ordinal, binned, manual, identity             | —                     | —                |
+
+**Ordering contract**: scale transforms run before stats and positions (a
+log10 x reshapes what `stat: "smooth"` sees). Coordinate transforms
+(`coord: {"type": "transform", ...}`) run after stats and preserve stat inputs.
+
+### Position scales (x/y)
+
+Options on any position scale (`PositionScaleSpec`):
+
+| Option        | Values / default                                            | Notes                                                                           |
+| ------------- | ----------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| `type`        | linear, binned, time, band (+ authored alias log)           | Omit to infer from field type                                                   |
+| `transform`   | identity (default), log10 (values > 0), sqrt (values >= 0)  | Only identity on time scales                                                    |
+| `domain`      | `[min, max]` (continuous/time) or full category list (band) | Pins the scale; out-of-domain data drops with a warning                         |
+| `oob`         | censor (default) or squish                                  | Applied to explicit source limits, before stats                                 |
+| `nice`        | boolean, default true                                       | Rounds inferred domain to tick-friendly bounds; ignored with `domain`           |
+| `zero`        | boolean                                                     | Bars/cols/areas force true on the measure axis; set false to override           |
+| `expand`      | `{ mult, add }`                                             | Default `{mult: 0.05, add: 0}` non-temporal; time axes default to zero          |
+| `breaks`      | numbers, or ISO strings on time scales                      | Explicit ticks; on binned scales these are bin boundaries, at most 65 (64 bins) |
+| `minorBreaks` | numbers                                                     | Minor gridlines; time scales use `dateMinorBreaks` instead                      |
+| `reverse`     | boolean, default false                                      | Flips output direction                                                          |
+| `labels`      | format string                                               | Time: strftime-style; numeric: `",d"`, `".1f"`, `".0%"`, `"~s"`                 |
+| `naValue`     | number or null (default)                                    | Substitute for missing positional values, after OOB, before transform           |
+| `guide`       | GuideSpec                                                   | Axis styling; band axes accept BandAxisGuideSpec                                |
+
+Helper functions additionally accept `limits` as authoring sugar for `domain`
+(supplying both throws). `scaleXReverse`/`scaleYReverse` omit the `transform`
+and `reverse` options by type. Binned integer ids stay private; guides and
+events use semantic values.
+
+```json fragment
+"scales": { "x": { "type": "linear", "transform": "log10", "limits": [1, 1000] } }
+```
+
+### Color and fill scales
+
+Five types, each gating its own option set (`ColorScaleSpec`; forbidden
+options fail schema validation):
+
+- **ordinal** — discrete categories. `scheme` (categorical name, or a
+  sequential name for discrete sampling), `range` (explicit hex list),
+  `domain`, `domainMode` (`grow` default preserves assignments across filters;
+  `data` rebuilds), `reverse`, `onExhaust`. No transform, breaks, oob, labels.
+- **sequential** — continuous ramp. `scheme` or `range` (>= 2 colors
+  interpolated), `transform`, `domain` `[min, max]`, `breaks` (colorbar
+  reference ticks), `oob`, `labels`, temporal parser options. Guide plan:
+  `colorbar`.
+- **binned** — color steps. Same shape as sequential but `breaks` are ordered
+  boundaries (at most 65). Guide plan: `colorsteps`.
+- **manual** — explicit mapping. `range` is required and must supply one color
+  per `domain` value (mismatched lengths are the `color-manual-domain-range`
+  error). No scheme, breaks, reverse, oob, labels, onExhaust.
+- **identity** — data cells are the colors. Only `naValue`, `unknownValue`,
+  and `guide` are allowed. Each source value is validated as `#rgb`/`#rrggbb`;
+  invalid cells map to `unknownValue` with a bounded warning. The guide is
+  suppressed by default — force it with `"guide": {"type": "legend", "force": true}`.
+
+`naValue` colors null/missing cells; `unknownValue` colors invalid,
+out-of-domain, or unmapped cells. Both default to `#999999`. Bounded warnings
+count how many cells fell back. Guide plans are `discrete` (ordinal, manual,
+identity), `colorbar` (sequential), or `colorsteps` (binned); identity and
+single-entry manual guides need `force: true` to appear. When `type` is
+omitted, a named `scheme` selects its family (categorical → ordinal,
+sequential name → sequential).
+
+### Style scales
+
+- **numeric-style** (size, linewidth, alpha): sequential, ordinal, binned,
+  manual, identity — numeric output ranges instead of colors, identity
+  transform only. `sizeUnit` applies to size only (alpha's schema drops it so
+  it cannot no-op silently). Manual domain/range length mismatch is
+  `style-manual-domain-range`. Extra size helpers: `scaleSizeArea` /
+  `scale_size_area` (area-true scaling, ggplot2's recommended default),
+  `scaleSizeBinnedArea` / `scale_size_binned_area`, and `scaleRadius` /
+  `scale_radius`. Bare ggplot2 names `scale_size`, `scale_linewidth`,
+  `scale_alpha` alias the continuous helpers.
+- **finite-style** (shape, linetype): ordinal, binned, manual, identity over a
+  closed symbol set (see the tables below) — no transform. Manual ranges and
+  identity values must be members of the audited name lists.
+
+## The Scale* component system
+
+98 generated `.svelte` shells plus 28 alias exports plus the hand-written
+`<Scale>` escape hatch = 127 `Scale*` components exported from
+`@ggsvelte/svelte`. Shells are generated by `bun run scale:children:gen`
+(scripts/gen-scale-children.ts; `--check` is the drift gate). Do not edit them
+by hand.
+
+Which variants exist per channel (aliases in parentheses are extra export
+names for the same component):
+
+| Variant                          | X, Y | Color, Fill | Size                   | Linewidth                   | Alpha                   | Shape                   | Linetype                   |
+| -------------------------------- | ---- | ----------- | ---------------------- | --------------------------- | ----------------------- | ----------------------- | -------------------------- |
+| Continuous                       | yes  | yes         | yes                    | yes                         | yes                     | —                       | —                          |
+| Discrete                         | yes  | yes         | yes (ScaleSizeOrdinal) | yes (ScaleLinewidthOrdinal) | yes (ScaleAlphaOrdinal) | yes (ScaleShapeOrdinal) | yes (ScaleLinetypeOrdinal) |
+| Binned                           | yes  | yes         | yes                    | yes                         | yes                     | yes                     | yes                        |
+| Log10, Sqrt                      | yes  | yes         | —                      | —                           | —                       | —                       | —                          |
+| Reverse                          | yes  | —           | —                      | —                           | —                       | —                       | —                          |
+| Date, Datetime                   | yes  | yes         | yes                    | yes                         | yes                     | —                       | —                          |
+| Time                             | yes  | —           | —                      | —                           | —                       | —                       | —                          |
+| Manual, Identity                 | —    | yes         | yes                    | yes                         | yes                     | yes                     | yes                        |
+| Ordinal                          | —    | yes         | (alias)                | (alias)                     | (alias)                 | (alias)                 | (alias)                    |
+| Brewer, Distiller, Fermenter     | —    | yes         | —                      | —                           | —                       | —                       | —                          |
+| Steps, Steps2, Stepsn            | —    | yes         | —                      | —                           | —                       | —                       | —                          |
+| Gradient, Gradient2, Gradientn   | —    | yes         | —                      | —                           | —                       | —                       | —                          |
+| Hue, Grey                        | —    | yes         | —                      | —                           | —                       | —                       | —                          |
+| ViridisC, ViridisD, ViridisB     | —    | yes         | —                      | —                           | —                       | —                       | —                          |
+| Area, BinnedArea (+ ScaleRadius) | —    | —           | yes                    | —                           | —                       | —                       | —                          |
+
+Every `ScaleColor*` component also exports a British `ScaleColour*` alias (24
+aliases; same file, same binding). `ScaleColorOrdinal` is a distinct component
+(explicit ordinal family), unlike the style-channel Ordinal names which are
+re-exports of the Discrete shells.
+
+**Function-twin pattern.** Every shell wraps one camelCase helper from
+`@ggsvelte/spec`; the component's props are that helper's options object
+flattened (undefined props are stripped). Each camelCase helper has a
+binding-identical ggplot2 snake_case twin, and every Color helper has a
+binding-identical Colour twin: `scaleXLog10` is `scale_x_log10`;
+`scaleColourBrewer` is `scaleColorBrewer` is `scale_color_brewer` is
+`scale_colour_brewer`. Brewer/Distiller/Fermenter and Viridis helpers accept
+ggplot2's `palette`/`option` (maps to `scheme`) and `direction` (`-1` sets
+`reverse: true`).
+
+```svelte fragment
+<GGPlot
+  data={rows}
+  aes={{ x: "day", y: "kwh", color: "site" }}
+  layers={[{ geom: "line" }]}
+>
+  <ScaleXDate dateBreaks="1 month" dateLabels="%b %Y" />
+  <ScaleColorBrewer palette="Dark2" />
+</GGPlot>
+```
+
+**Escape hatch.** `<Scale value={scalesFragment} />` registers a raw `Scales`
+fragment — use it for computed scales or variable references. It is
+byte-identity-preserving: `value` is not routed through any helper.
+
+## Palettes
+
+### Categorical schemes (14)
+
+| Scheme               | Description                                                       |
+| -------------------- | ----------------------------------------------------------------- |
+| observable10         | Default: 10-hue Observable 10 palette                             |
+| ipsum                | hrbrthemes ipsum palette, published source order                  |
+| flexoki              | Flexoki light-background qualitative palette                      |
+| tableau10            | Tableau 10 qualitative palette                                    |
+| colorblind           | ggthemes 8-color colorblind-safe palette                          |
+| Set1                 | ColorBrewer qualitative, saturated primaries                      |
+| Set2                 | ColorBrewer qualitative, muted pastels                            |
+| Set3                 | ColorBrewer qualitative, light 12-class                           |
+| Dark2                | ColorBrewer qualitative, dark tones                               |
+| Paired               | ColorBrewer qualitative, light/dark pairs                         |
+| Accent               | ColorBrewer qualitative, accented mix                             |
+| hue                  | Evenly spaced HSL hues — the ggplot2-shaped `scale_*_hue` default |
+| grey                 | Greyscale discrete ramp (`scale_*_grey`)                          |
+| gray (alias of grey) | Same scheme, US spelling — identical colors                       |
+
+`grey` and `gray` are the same scheme; both spellings validate and produce
+identical output. Sequential scheme names are also legal on ordinal scales
+(discrete sampling along the ramp — what `scale_*_viridis_d` does).
+
+**Palette exhaustion** (`onExhaust`, ordinal scales only): `cycle` (default)
+restarts the palette and emits the bounded `palette-exhausted` warning once;
+`error` throws the `palette-exhausted` pipeline error instead.
+
+### Sequential schemes (20)
+
+| Scheme   | Description                                            |
+| -------- | ------------------------------------------------------ |
+| viridis  | Default sequential: perceptually uniform purple→yellow |
+| magma    | Perceptually uniform black→red→pale yellow             |
+| plasma   | Perceptually uniform blue→magenta→yellow               |
+| inferno  | Perceptually uniform black→orange→yellow               |
+| cividis  | Colorblind-optimized blue→yellow                       |
+| turbo    | Google turbo rainbow (high contrast, not uniform)      |
+| Blues    | ColorBrewer single-hue light→dark blue                 |
+| Greens   | ColorBrewer single-hue light→dark green                |
+| Reds     | ColorBrewer single-hue light→dark red                  |
+| Oranges  | ColorBrewer single-hue light→dark orange               |
+| Purples  | ColorBrewer single-hue light→dark purple               |
+| Greys    | ColorBrewer single-hue light→dark grey                 |
+| YlOrRd   | ColorBrewer multi-hue yellow→orange→red                |
+| YlGnBu   | ColorBrewer multi-hue yellow→green→blue                |
+| BuPu     | ColorBrewer multi-hue blue→purple                      |
+| RdYlBu   | ColorBrewer diverging red→yellow→blue                  |
+| RdBu     | ColorBrewer diverging red→white→blue                   |
+| BrBG     | ColorBrewer diverging brown→teal                       |
+| Spectral | ColorBrewer diverging rainbow                          |
+| PuOr     | ColorBrewer diverging purple→orange                    |
+
+### Finite symbol sets (default assignment order)
+
+| Point shapes (6) | Linetypes (6) |
+| ---------------- | ------------- |
+| circle           | solid         |
+| triangle         | dashed        |
+| square           | dotted        |
+| diamond          | dotdash       |
+| plus             | longdash      |
+| cross            | twodash       |
+
+## Temporal scales
+
+**Auto-inference.** ISO dates and date-times, four-digit-year strings,
+year-months, month-years, and year-quarters infer a time scale after bounded
+sampling plus whole-column validation. Ambiguous ordered dates (`01/02/2026`)
+stay discrete — set `"parse": "dmy"` or `"parse": "mdy"`. For year-like
+identifiers that are labels, not instants, force `{"type": "band"}`. Never
+preprocess dates into row indexes. Explicit `linear`/`binned` (including
+authored `log`) disables temporal inference, so numeric strings stay
+quantitative. Explicit ordinal color/fill keeps temporal-looking labels as
+separate groups; sequential temporal color/fill parses domains and uses
+calendar legend labels.
+
+**Time-scale options** (position and sequential/binned color scales):
+
+| Option                          | Values / default                                                                                                                                                                                                            |
+| ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `parse`                         | Named parser (`"iso"`, `"year"`, `"ym"`, `"my"`, `"yq"`, `"ymd"`, `"ydm"`, `"mdy"`, `"myd"`, `"dmy"`, `"dym"`, and their `_hm`/`_hms` variants), exact `{ "format": "..." }`, or `{ "epoch": "seconds" \| "milliseconds" }` |
+| `parseFailure`                  | `error` (default) stops with bounded evidence; `censor` drops invalid values to missing with a warning. Censoring requires an explicit parser                                                                               |
+| `temporalKind`                  | `date` (calendar dates), `datetime` (instants), `time` (position only: time of day)                                                                                                                                         |
+| `timezone`                      | IANA zone for timezone-less input; default `UTC`                                                                                                                                                                            |
+| `disambiguation`                | DST gap/fold policy: `reject` (default), `earlier`, `later`, `compatible`                                                                                                                                                   |
+| `dateBreaks`, `dateMinorBreaks` | `"<step> <unit>"`, e.g. `"2 weeks"`; units millisecond…year, step 1–1,000,000                                                                                                                                               |
+| `dateLabels`                    | Strict tokens: `%Y %y %m %b %B %d %e %a %A %H %I %M %S %L %p %q %z %Z %%`                                                                                                                                                   |
+| `locale`                        | BCP 47 tag for labels; default `en-US`                                                                                                                                                                                      |
+| `weekStart`                     | Weekday for week boundaries; default `monday`                                                                                                                                                                               |
+
+**Precedence**: explicit `breaks` outrank `dateBreaks`; `dateLabels` outranks
+`labels`. Authored labels are preserved with a diagnostic — never silently
+rotated, thinned, or truncated. Automatic temporal labels use measured panel
+extent and calendar boundaries; inspect `model.guidePlans` for the selected
+interval and labels.
+
+**Authoring surfaces.** The `gg()` builder has `.scaleXDate()`,
+`.scaleXDatetime()`, `.scaleXTime()` (and Y forms), each with component twins
+(`<ScaleXDate/>` …) and function twins (`scaleXDate`/`scale_x_date` …).
+Date helpers serialize mapped authoring `Date` cells as calendar dates;
+datetime helpers preserve instants. `scaleXTime`/`scale_x_time` is time-of-day
+only: portable numbers are **seconds since midnight** (mapped to epoch ms on
+1970-01-01Z), `Date` cells use the UTC clock portion, and default labels are
+`%H:%M:%S`.
+
+**Parser helpers** (from `@ggsvelte/spec`): `ymd`, `ydm`, `mdy`, `myd`, `dmy`,
+`dym` (each also as `_hm`/`_hms`, e.g. `dmy_hms`), `ym`, `my`, `yq`,
+`parseTemporalFormat(value, format)`, `fromEpochSeconds`,
+`fromEpochMilliseconds`. Each accepts one value or an array, returns `Date`(s),
+and throws `TemporalParseError` on failure — use them to convert columns at
+authoring time instead of hand-rolled parsing.
+
+```json complete
+{
+  "data": {
+    "values": [
+      { "day": "2026-01-05", "kwh": 12.1, "site": "north" },
+      { "day": "2026-02-02", "kwh": 14.9, "site": "north" },
+      { "day": "2026-01-05", "kwh": 13.4, "site": "south" },
+      { "day": "2026-02-02", "kwh": 16.0, "site": "south" }
+    ]
+  },
+  "aes": {
+    "x": { "field": "day" },
+    "y": { "field": "kwh" },
+    "color": { "field": "site" }
+  },
+  "layers": [{ "geom": "line" }],
+  "scales": {
+    "x": { "type": "time", "dateBreaks": "1 month", "dateLabels": "%b %Y" },
+    "color": { "type": "ordinal", "scheme": "Dark2" }
+  }
+}
+```

--- a/scripts/ci-routing.test.ts
+++ b/scripts/ci-routing.test.ts
@@ -408,6 +408,16 @@ describe("planJobs", () => {
     expect(plan.consumer).toBe(true);
   });
 
+  test("skill reference changes route like the skill itself", () => {
+    // The references/ tree ships in the npm package; a glob regression that
+    // narrowed routing to SKILL.md alone must fail here, not in production.
+    const plan = planJobs(classifyChangedPaths(["skills/ggsvelte/references/geoms-and-stats.md"]));
+    expect(plan.unit).toBe(true);
+    expect(plan.component).toBe(true);
+    expect(plan.build).toBe(true);
+    expect(plan.consumer).toBe(true);
+  });
+
   test("svelte-only changes run unit (lifecycle) and bench_smoke (retained-memory)", () => {
     const plan = planJobs(classifyChangedPaths(["packages/svelte/src/lib/index.ts"]));
     expect(plan.unit).toBe(true);

--- a/scripts/skill-content.test.ts
+++ b/scripts/skill-content.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Content contract for the shipped agent skill (skills/ggsvelte/).
+ *
+ * The skill ships inside the ggsvelte npm package and teaches agents the
+ * grammar; a stale or broken claim there produces broken charts downstream.
+ * Three guards:
+ *
+ * 1. Fence contract — every code fence carries exactly one of
+ *    `complete`/`fragment`, and every `json complete` fence must normalize
+ *    and validate the way examples do (examples/define.ts).
+ * 2. Deprecated grammar props — no Svelte fence (complete or fragment) shows
+ *    the seven props deprecated in 0.11.0. Same textual match as
+ *    repo-child-layers.test.ts uses for guide fences.
+ * 3. Inventory completeness — the reference tables must have a structured row
+ *    for every geom, stat, position, theme, and color scheme the spec knows.
+ *    Adding one upstream turns the skill red until it is documented; this is
+ *    the pre-changesets lock-step guard.
+ *
+ * The `test` theme is excluded from the theme inventory on purpose: it is
+ *    the internal snapshot theme, not a product surface.
+ */
+import { describe, expect, it } from "bun:test";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+
+import {
+  CATEGORICAL_SCHEME_NAMES,
+  KNOWN_GEOMS,
+  KNOWN_POSITIONS,
+  KNOWN_STATS,
+  normalize,
+  SEQUENTIAL_SCHEME_NAMES,
+  THEME_NAMES,
+  validate,
+} from "@ggsvelte/spec";
+import { deprecatedGrammarPropPattern } from "../packages/svelte/src/lib/layers/grammar-families.ts";
+import { codeBlocks } from "./guide-code-contract.ts";
+
+const ROOT = join(import.meta.dir, "..");
+const SKILL_DIR = join(ROOT, "skills", "ggsvelte");
+
+function markdownFiles(dir: string): string[] {
+  return readdirSync(dir).flatMap((name) => {
+    const path = join(dir, name);
+    if (statSync(path).isDirectory()) return markdownFiles(path);
+    return path.endsWith(".md") ? [path] : [];
+  });
+}
+
+const FILES = markdownFiles(SKILL_DIR).map((path) => ({
+  name: relative(SKILL_DIR, path),
+  markdown: readFileSync(path, "utf8"),
+}));
+
+describe("skill fence contract", () => {
+  it("finds skill markdown to check", () => {
+    expect(FILES.length).toBeGreaterThan(0);
+  });
+
+  for (const file of FILES) {
+    it(`${file.name}: every fence is flagged complete or fragment`, () => {
+      const unflagged = codeBlocks(file.markdown)
+        .filter((block) => block.classification === undefined)
+        .map((block) => block.language || "(none)");
+      expect(unflagged).toEqual([]);
+    });
+
+    it(`${file.name}: every complete JSON fence normalizes and validates`, () => {
+      for (const block of codeBlocks(file.markdown)) {
+        if (block.language !== "json" || block.classification !== "complete") continue;
+        const spec = normalize(JSON.parse(block.source));
+        // Tier 2 ({}): skill specs carry inline data, so data-aware checks
+        // run too — the same bar examples/define.ts sets.
+        const result = validate(spec, {});
+        expect({ snippet: block.source, errors: result.ok ? [] : result.errors }).toEqual({
+          snippet: block.source,
+          errors: [],
+        });
+      }
+    });
+  }
+});
+
+describe("skill Svelte fences use child layers, not deprecated grammar props", () => {
+  const pattern = deprecatedGrammarPropPattern();
+
+  for (const file of FILES) {
+    it(`${file.name} shows no deprecated grammar prop`, () => {
+      const offenders = codeBlocks(file.markdown)
+        .filter((block) => block.language === "svelte")
+        .flatMap((block) => [...block.source.matchAll(pattern)].map((m) => m[1]!));
+      expect(offenders).toEqual([]);
+    });
+  }
+});
+
+/**
+ * A name counts as documented only when it appears as its own table cell
+ * (`| name |`) or leads one (`| name (…` for annotations like aliases) in the
+ * expected reference file — prose mentions and substrings do not count.
+ */
+function tableCellNames(markdown: string): Set<string> {
+  const names = new Set<string>();
+  for (const line of markdown.split("\n")) {
+    if (!line.startsWith("|")) continue;
+    for (const rawCell of line.split("|")) {
+      const cell = rawCell.trim().replaceAll(/^`|`$/g, "");
+      if (cell) names.add(cell.split(/[\s(]/, 1)[0]!.replace(/`$/, ""));
+    }
+  }
+  return names;
+}
+
+describe("reference inventories are complete", () => {
+  const referenceFile = (name: string): string =>
+    readFileSync(join(SKILL_DIR, "references", name), "utf8");
+
+  const inventories: readonly {
+    file: string;
+    label: string;
+    names: readonly string[];
+  }[] = [
+    { file: "geoms-and-stats.md", label: "geoms", names: KNOWN_GEOMS },
+    { file: "geoms-and-stats.md", label: "stats", names: KNOWN_STATS },
+    { file: "geoms-and-stats.md", label: "positions", names: KNOWN_POSITIONS },
+    {
+      file: "composition-surfaces.md",
+      label: "themes",
+      // `test` is the internal snapshot theme — deliberately undocumented.
+      names: THEME_NAMES.filter((name) => name !== "test"),
+    },
+    {
+      file: "scales-and-palettes.md",
+      label: "categorical schemes",
+      names: CATEGORICAL_SCHEME_NAMES,
+    },
+    {
+      file: "scales-and-palettes.md",
+      label: "sequential schemes",
+      names: SEQUENTIAL_SCHEME_NAMES,
+    },
+  ];
+
+  for (const inventory of inventories) {
+    it(`references/${inventory.file} documents every ${inventory.label}`, () => {
+      const cells = tableCellNames(referenceFile(inventory.file));
+      const missing = inventory.names.filter((name) => !cells.has(name));
+      expect(missing).toEqual([]);
+    });
+  }
+});

--- a/scripts/skill-content.test.ts
+++ b/scripts/skill-content.test.ts
@@ -33,6 +33,7 @@ import {
   THEME_NAMES,
   validate,
 } from "@ggsvelte/spec";
+import type { SpecInput } from "@ggsvelte/spec";
 import { deprecatedGrammarPropPattern } from "../packages/svelte/src/lib/layers/grammar-families.ts";
 import { codeBlocks } from "./guide-code-contract.ts";
 
@@ -68,7 +69,7 @@ describe("skill fence contract", () => {
     it(`${file.name}: every complete JSON fence normalizes and validates`, () => {
       for (const block of codeBlocks(file.markdown)) {
         if (block.language !== "json" || block.classification !== "complete") continue;
-        const spec = normalize(JSON.parse(block.source));
+        const spec = normalize(JSON.parse(block.source) as SpecInput);
         // Tier 2 ({}): skill specs carry inline data, so data-aware checks
         // run too — the same bar examples/define.ts sets.
         const result = validate(spec, {});

--- a/scripts/skill-sync.test.ts
+++ b/scripts/skill-sync.test.ts
@@ -1,19 +1,45 @@
 /**
- * skills/ggsvelte/SKILL.md is the source; the copy shipped inside the
- * ggsvelte npm package (packages/svelte/skills/ggsvelte/SKILL.md, listed in
- * its "files") must stay byte-identical. Re-copy when editing:
- *   cp skills/ggsvelte/SKILL.md packages/svelte/skills/ggsvelte/SKILL.md
+ * skills/ggsvelte/ is the source tree; the copy shipped inside the ggsvelte
+ * npm package (packages/svelte/skills/ggsvelte/, listed in its "files") must
+ * stay byte-identical file for file — SKILL.md and everything under
+ * references/. Re-sync when editing (rsync, because cp -R never deletes
+ * files removed from the source):
+ *   rsync -a --delete skills/ggsvelte/ packages/svelte/skills/ggsvelte/
  */
-import { expect, it } from "bun:test";
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import { describe, expect, it } from "bun:test";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
 
-it("packaged SKILL.md matches the repo source", () => {
-  const root = join(import.meta.dir, "..");
-  const source = readFileSync(join(root, "skills", "ggsvelte", "SKILL.md"), "utf8");
-  const shipped = readFileSync(
-    join(root, "packages", "svelte", "skills", "ggsvelte", "SKILL.md"),
-    "utf8",
-  );
-  expect(shipped).toBe(source);
+const ROOT = join(import.meta.dir, "..");
+const SOURCE = join(ROOT, "skills", "ggsvelte");
+const SHIPPED = join(ROOT, "packages", "svelte", "skills", "ggsvelte");
+
+function walk(dir: string, base: string): string[] {
+  return readdirSync(dir).flatMap((name) => {
+    const path = join(dir, name);
+    if (statSync(path).isDirectory()) return walk(path, base);
+    return [relative(base, path)];
+  });
+}
+
+describe("packaged skill tree matches the repo source", () => {
+  const sourceFiles = walk(SOURCE, SOURCE).toSorted();
+  const shippedFiles = walk(SHIPPED, SHIPPED).toSorted();
+
+  it("has files to compare", () => {
+    // An empty walk would make every assertion below vacuously pass.
+    expect(sourceFiles.length).toBeGreaterThan(0);
+  });
+
+  it("ships exactly the source file set (no strays, no missing files)", () => {
+    expect(shippedFiles).toEqual(sourceFiles);
+  });
+
+  for (const file of sourceFiles) {
+    it(`${file} is byte-identical`, () => {
+      const source = readFileSync(join(SOURCE, file), "utf8");
+      const shipped = readFileSync(join(SHIPPED, file), "utf8");
+      expect(shipped).toBe(source);
+    });
+  }
 });

--- a/skills/ggsvelte/SKILL.md
+++ b/skills/ggsvelte/SKILL.md
@@ -1,169 +1,191 @@
 ---
 name: ggsvelte
-description: Build data visualizations with ggsvelte, a grammar-of-graphics charting library (ggplot2 semantics, JSON specs, Svelte 5 components, headless SVG rendering). Use whenever creating, editing, validating, or debugging charts, plots, graphs, scatter plots, bar charts, histograms, line charts, boxplots, density plots, faceted/small-multiple charts, or data visualization in a JavaScript/TypeScript/Svelte project; when code imports from "@ggsvelte/svelte", "@ggsvelte/spec", or "@ggsvelte/core"; when emitting a ggsvelte plot spec JSON; or when rendering charts server-side/headless to SVG.
+description: Build data visualizations with ggsvelte, a grammar-of-graphics charting library (ggplot2 semantics, Svelte 5 child-component composition, JSON specs, headless SVG rendering). Use whenever creating, editing, validating, or debugging charts, plots, graphs, scatter plots, bar charts, histograms, line charts, boxplots, density plots, violins, heatmaps, maps, faceted/small-multiple charts, or data visualization in a JavaScript/TypeScript/Svelte project; when code imports from "@ggsvelte/svelte", "@ggsvelte/spec", or "@ggsvelte/core"; when composing GGPlot with Geom*/Scale*/Theme*/Facet*/Coord*/Guide*/Labs children; when emitting a ggsvelte plot spec JSON; or when rendering charts server-side/headless to SVG.
 ---
 
 # ggsvelte
 
-A layered grammar of graphics with ggplot2 nomenclature. **You emit a JSON
-`PortableSpec`; a deterministic renderer draws it.** Never build SVG or
-canvas output yourself — describe the plot, let the pipeline render it.
+A layered grammar of graphics with ggplot2 nomenclature. Two ways to author the
+same grammar — never build SVG or canvas output yourself:
+
+- **Svelte apps (canonical):** `<GGPlot>` with declaration-only children —
+  `<GeomPoint/>`, `<ThemeMinimal/>`, `<ScaleXLog10/>`, `<FacetWrap/>`, `<Labs/>`.
+- **Agents / headless:** emit a JSON `PortableSpec`, check it with
+  `validate(spec)`, render with `renderToSVGString(spec, {width, height})`
+  (Node-safe), `ggsvelte-render spec.json > out.svg` (CLI), or `<GGPlot spec>`.
+  A third skin, the `gg()` builder, produces the same spec in TypeScript.
 
 ## Mental model
 
-```text
-spec = data + aes (mappings) + layers[]        one layer = { geom, stat, position, aes?, params? }
-       + scales? coord? facet? labs? theme?
+```text fragment
+spec = data + aes (mappings) + layers[]
+       + scales? coord? facet? labs? theme? guides?
+one layer = { geom, stat?, position?, positionParams?, aes?, params?, render?, data? }
 ```
 
 - **data**: `{"values": [rows]}`, `{"columns": {name: [...]}}`, or
   `{"name": "dataset"}` (resolved from `spec.datasets` or runtime data).
-- **aes**: channel → canonical form. `{"field": "col"}` maps a data column;
-  `{"value": "red"}` is a constant; `{"stat": "count"}` reads a stat output;
-  `null` unsets an inherited channel. **Bare strings are invalid in JSON
-  specs** — always `{"field": ...}`. Channels: x, y, color (strokes/points),
-  fill (bars/areas), group, label, weight, ymin, ymax, xmin, xmax, width, height.
-  Mapped size, linewidth, alpha, shape, and linetype are supported on the geoms
-  that consume them (see STYLE_AESTHETIC_GEOMS).
-- **layers**: drawn in order. Geoms: `point, line, col, bar, histogram, area,
-rule, text, smooth, boxplot, density, errorbar, rect, tile, raster, ribbon`. Each geom has a default
-  stat/position (bar → count+stack, histogram → bin+stack, col/area →
-  identity+stack, boxplot → boxplot+dodge, everything else identity).
-- **stats compute columns**: count→`count`; bin→`count, density, ncount,
-ndensity`; density→`density, scaled`; smooth→`y, ymin, ymax, se`;
-  boxplot→`ymin, lower, middle, upper, ymax`; summary→`y, ymin, ymax`.
-  A stat that computes y means you must NOT map `aes.y` to a field
-  (bar/histogram/density) — the `computed-y-mapped` error.
-- **positions**: `stack, fill` (proportions), `dodge` (side-by-side),
-  `jitter` (seeded, deterministic), `nudge`, `identity`.
-- **coord**: `{"type": "flip"}` = horizontal bars (map the category to x,
-  the value to y, then flip). Post-stat projection uses
-  `{"type":"transform","x":{"transform":"log10"},"y":{"transform":"sqrt"}}`
-  with optional semantic `limits`, `reverse`, `expand`, and plot-level `clip`.
-  Use `coordTransform`/`coord_transform`; unlike scale transforms, coordinate
-  transforms preserve stat inputs, tessellate curved render topology, and
-  invert coordinates before scales for interactions. Non-identity coordinate
-  transforms require continuous non-temporal axes. Fixed aspect uses
-  `{"type":"fixed","ratio":1}`, `coordFixed`/`coord_fixed`, or
-  `coordEqual`/`coord_equal`; ratio is physical y-unit/x-unit length. Fixed
-  coordinates fit a centered data rectangle after chart chrome and reject
-  free positional facet scales.
-- **facet**: wrap form `{"wrap": {"field": "g"}, "ncol": 3}` XOR grid form
-  `{"rows": {...}, "cols": {...}}`; `"scales": "fixed"|"free"|"free_x"|"free_y"`.
-- **scales**: canonical x/y families are `{"type": "linear"|"binned"|"time"|"band"}`.
-  Numeric continuous/binned scales accept `"transform":"identity"|"log10"|"sqrt"`,
-  semantic `domain`/`limits`, `oob:"censor"|"squish"`, `expand`, `nice`,
-  major/minor breaks, and `reverse`. Authored `type:"log"` is accepted but
-  canonicalizes to `type:"linear", transform:"log10"`; trained models never
-  report type `log`. Scale transforms run before stats and positions. Binned
-  integer ids remain private; guides, candidates, and events use semantic values.
-  Helpers include `scaleXLog10`, `scaleYSqrt`, `scaleXBinned` and binding-identical
-  `scale_x_log10`, `scale_y_sqrt`, `scale_x_binned` aliases. Time scales additionally accept `"parse"` (closed names such as `"dmy"`,
-  exact `{ "format": ... }`, or `{ "epoch": "seconds"|"milliseconds" }`),
-  `"temporalKind"`, `"timezone"`, `"disambiguation"`,
-  `"parseFailure":"error"|"censor"`, `"dateBreaks"`,
-  `"dateMinorBreaks"`, `"dateLabels"`, `"locale"`, and `"weekStart"`.
-  Color/fill families are `ordinal`, `sequential`, `binned`, `manual`, and
-  `identity`. Sequential/binned accept identity/log10/sqrt transforms,
-  semantic domains/breaks, OOB policy, temporal parser options, and explicit
-  `naValue`/`unknownValue`; `labels` accepts numeric or temporal formats for
-  colorbars and colorsteps. Manual requires one range color per domain value;
-  identity validates source hex colors and suppresses its guide by default.
-  Bounded warnings count mapped NA and unknown fallback values.
-  Use continuous/discrete/binned/log10/sqrt/date/datetime/manual/identity
-  helpers for color or fill. `color`/`colour` and ggplot2 snake-case exports
-  are binding-identical. GuidePlans are `discrete`, `colorbar`, or
-  `colorsteps`. Defaults are inferred and disclosed as advisories.
-- **guides**: top-level `guides` overrides scale-local `guide`. Use `axis`,
-  `legend`, `colorbar`, `colorsteps`, or `none` through the camelCase helpers
-  (or binding-identical snake-case aliases). Guide options style titles,
-  ticks/labels, numeric order, `auto|right|bottom` placement,
-  `auto|vertical|horizontal` direction, collision handling, force visibility,
-  and bounded theme roles without changing scale math. Auto non-position guides
-  move below when the viewport is at most 480px or a right guide would leave
-  less than 320px of panel. Exact discrete entries remain interactive; numeric
-  ticks/bins do not. Force identity/single-value manual guides explicitly.
-- **temporal defaults**: ISO dates/date-times, four-digit year strings,
-  year-months, month-years, and year-quarters infer time after bounded sampling
-  plus whole-column validation. Ambiguous ordered dates stay discrete: set
-  `"parse":"dmy"` or `"parse":"mdy"`. For year-like identifiers, force
-  `{"type":"band"}`. Never preprocess dates into indexes. Automatic temporal
-  labels use measured panel extent and calendar boundaries; inspect
-  `model.guidePlans` for the selected interval and visible/full labels.
-- **temporal override rules**: `.scaleXDate()`/`.scaleYDate()` serialize mapped
-  authoring `Date` cells as calendar dates; `.scaleXDatetime()`/
-  `.scaleYDatetime()` preserve instants; `.scaleXTime()`/`.scaleYTime()`
-  (ggplot2 `scale_*_time`) are time-of-day only — portable numbers are
-  **seconds since midnight** (mapped to epoch ms on 1970-01-01Z); `Date` cells
-  use the UTC clock portion; default labels `%H:%M:%S`.
-  Explicit `linear`/`binned` (including authored alias `log`) disables temporal inference, so numeric strings stay
-  quantitative. Explicit ordinal color/fill keeps temporal-looking labels as
-  separate groups; sequential temporal color/fill uses parsed domains and
-  calendar legend labels. Censoring is available only with an explicit parser;
-  invalid configuration and ambiguous automatic inference remain errors.
-  Use e.g. `.scaleXDatetime({ dateBreaks: "2 weeks", dateMinorBreaks: "1 day",
-dateLabels: "%e %b", locale: "en-GB", timezone: "Europe/London" })`.
-  Explicit `breaks` outrank `dateBreaks`; `dateLabels` outranks `labels`.
-  Authored labels are preserved with a diagnostic rather than silently
-  rotated, thinned, or truncated.
-- Rendering surfaces: `<GGPlot spec={...}/>` (Svelte),
-  `renderToSVGString(spec, {width, height})` (headless, Node-safe),
-  `ggsvelte-render spec.json > out.svg` (CLI; JSON-line diagnostics on stderr).
+- **layers** draw in order — later layers on top (z-order).
+- Geom defaults: bar → count+stack, histogram → bin+stack, col/area →
+  identity+stack, boxplot → boxplot+dodge, violin → ydensity+dodge,
+  jitter → point+jitter, freqpoly → bin, smooth → smooth, count → sum,
+  density → density, hex → bin_hex, everything else identity+identity.
 
-## Svelte interactions (v0.2+)
+## Aes: JSON specs vs Svelte props
 
-`@ggsvelte/svelte` requires Svelte `^5.33.1`. Interactions are opt-in props on
-`<GGPlot>`; always provide a stable `key` field when selection or linked views
-must survive filtering, reordering, or data refreshes.
+The one rule that differs between the two skins:
 
-```svelte
+| Surface                                 | `x: "displ"` bare string              | canonical                |
+| --------------------------------------- | ------------------------------------- | ------------------------ |
+| JSON `PortableSpec` (incl. `spec` prop) | INVALID                               | `{"field": "displ"}`     |
+| Svelte `aes` prop (plot or `Geom*`)     | valid shorthand, expands to `{field}` | same object form also OK |
+
+Canonical channel forms: `{"field": "col"}` maps a column, `{"value": "red"}`
+is a constant, `{"stat": "count"}` reads a stat output, `null` unsets an
+inherited channel. Layer aes merges over plot aes per channel.
+Channels (25): x, y, color, fill, size, linewidth, alpha, shape, linetype,
+group, label, weight, ymin, ymax, xmin, xmax, xend, yend, width, height, z,
+map_id, angle, radius, sample. Mapped size/linewidth/alpha/shape/linetype work
+only on the geoms in `STYLE_AESTHETIC_GEOMS`.
+
+## Svelte composition — children are canonical
+
+```svelte fragment
 <script lang="ts">
-  import { createPlotInteraction, Facet, GGPlot } from "@ggsvelte/svelte";
+  import {
+    GeomPoint,
+    GeomSmooth,
+    GGPlot,
+    Labs,
+    ScaleColorDiscrete,
+    ThemeMinimal,
+  } from "@ggsvelte/svelte";
 
-  const interaction = createPlotInteraction<number>();
-  const scope = { keys: "sales-rows", intervals: "sales-range" } as const;
+  const cars = [
+    { displ: 1.8, hwy: 29, class: "compact" },
+    { displ: 2.0, hwy: 31, class: "compact" },
+    { displ: 3.5, hwy: 26, class: "midsize" },
+    { displ: 5.3, hwy: 20, class: "suv" },
+    { displ: 5.7, hwy: 17, class: "suv" },
+    { displ: 6.2, hwy: 16, class: "suv" },
+  ];
 </script>
 
-<GGPlot
-  data={rows}
-  aes={{ x: "date", y: "value", color: "series" }}
-  layers={[{ geom: "point" }]}
-  key="id"
-  select={{ type: "interval", mode: "x", preset: "cross-panel" }}
-  legendFocus
-  legendFilter
-  {interaction}
-  interactionScope={scope}
-  oninteraction={(event) => console.log(event)}
->
-  <Facet wrap="region" ncol={3} />
+<GGPlot data={cars} aes={{ x: "displ", y: "hwy", color: "class" }} height={400}>
+  <ThemeMinimal />
+  <ScaleColorDiscrete scheme="tableau10" />
+  <Labs
+    title="Bigger engines, thirstier cars"
+    x="Displacement (l)"
+    y="Highway mpg"
+    color="Class"
+  />
+  <GeomSmooth method="loess" se={false} />
+  <GeomPoint size={3} alpha={0.85} />
 </GGPlot>
 ```
 
-- `inspect` adds tooltip, crosshair, keyboard traversal, and pinning; `select`
-  supports point or interval selection; `zoom` enables brush zoom.
-- Faceted interval presets are `independent`, `union`, and `cross-panel`.
-  After an interval or zoom commit, accessible controls accept exact bounds.
-- `legendFocus` only emphasizes a discrete group. `legendFilter` changes the
-  included rows and reruns the grammar while preserving stable color identity.
-- Share one `createPlotInteraction()` controller between plots to link semantic
-  selection, emphasis, interval, and zoom state. Give plots matching
-  `interactionScope` channels only when they should coordinate.
-- Use controlled controller methods such as `setSelection`, `setInterval`, and
-  `setZoom` for external controls. Observe all interaction kinds through
-  `oninteraction`, or use capability-specific handlers such as `onselect`,
-  `onzoom`, `onlegendfocus`, and `onlegendfilter`.
-- A handler without its matching capability prop, or `interactionScope` without
-  an `interaction` controller, is inert and emits a development advisory.
+Convention: theme → scales → guides → labs → mark layers. Grammar children
+(theme/scale/coord/facet/guides/labs/legend) render no markup and register
+declaratively; mark-layer registration order is z-order (points above smooth
+here). Every geom takes aesthetics through one `aes` object prop (bare-string
+shorthand allowed) and constant style params as direct props (`size={3}`);
+structural props are `data`, `stat`, `position`, `positionParams`, `render`.
+
+`<GGPlot>` props: `spec`, `data`, `aes`, `layers`, `key`, `width`
+(number | "container"), `height`, `a11y`, `ariaLabel`, the interaction props
+(`inspect`, `select`, `zoom`, `legendFocus`, `legendFilter`, `tool`,
+`interaction`, `interactionScope`), the `on*` handlers, and `children`.
+Instance methods: `resetScales()`, `setZoom()`.
+
+Precedence: `spec` wins over everything else. For mark layers, an explicit
+`layers` prop wins over geom children — use it for dynamic layer lists (a keyed
+`{#each}` reorder does not preserve z-order). For grammar families, children
+win over the deprecated props. Coord/facet/theme REPLACE (last wins); scales
+merge per channel; labs/guides/legend merge per key. Duplicates emit
+`DUPLICATE_PLOT_LAYER` / `DUPLICATE_SCALE_CHANNEL` / `DUPLICATE_MERGE_KEY`
+advisories — full semantics in
+[references/composition-surfaces.md](references/composition-surfaces.md).
+
+**Deprecated (since 0.11.0, planned removal in 0.13.0):** the seven `<GGPlot>`
+grammar props `facet`, `coord`, `scales`, `guides`, `legend`, `theme`, `labs`.
+Compose them as children instead; `spec`, `data`, `aes`, and `layers` stay
+first-class. Migrate existing code with `npx ggsvelte-codemod --write src`
+(dry-run without `--write`). Using a deprecated prop fires a
+`DEPRECATED_PLOT_PROP` advisory via `ondiagnostic`.
+
+## Which geom for which data
+
+| x type           | y type                                | extra              | recommend                                                    |
+| ---------------- | ------------------------------------- | ------------------ | ------------------------------------------------------------ |
+| quantitative     | quantitative                          | ≤ ~2k rows         | `point` (+ `smooth` layer for trend)                         |
+| quantitative     | quantitative                          | many rows          | `point` with `"render": "canvas"`, or `hex`/`bin_2d` density |
+| temporal         | quantitative                          | —                  | `line` (multi-series: map `color` to the series field)       |
+| nominal/ordinal  | quantitative (pre-aggregated)         | —                  | `col`; many/long labels → add a `flip` coord                 |
+| nominal/ordinal  | (none — count rows)                   | —                  | `bar` (count stat; do NOT map y)                             |
+| quantitative     | (none — distribution)                 | —                  | `histogram` (or `density` for smooth overlay)                |
+| nominal          | quantitative (distribution per group) | —                  | `boxplot` (or `violin` for shape)                            |
+| nominal          | nominal                               | —                  | `point` + `"position": "jitter"`, or counts via `count`      |
+| quantitative     | quantitative                          | uncertainty bounds | `errorbar` (map ymin/ymax) or `smooth` (se ribbon)           |
+| any of the above | + one more nominal field              | few values         | same geom + facet wrap on that field                         |
+
+Only the everyday geoms appear above. All 50 geoms (violin, hex, contour, qq,
+step, segment, sf/maps, text/label annotation, …), all 28 stats with their
+computed columns, and the position rules live in
+[references/geoms-and-stats.md](references/geoms-and-stats.md) — read it
+whenever the user wants a geom, stat, or annotation not shown here.
+
+Two rules worth keeping in working memory:
+
+- **Positions are scoped per geom** (a disallowed position is a schema error):
+  stack/fill only on bar, col, histogram, area; dodge on those plus boxplot
+  and violin; jitter on point, count, jitter; nudge on point, count, text,
+  label; identity everywhere.
+- **A stat that computes y forbids mapping `aes.y` to a field**
+  (bar/histogram/density/…) — the `computed-y-mapped` error. Read stat outputs
+  with `{"stat": "count"}` aes.
+
+## Scales, palettes, themes
+
+- x/y families: `{"type": "linear"|"binned"|"time"|"band"}` with
+  `"transform": "identity"|"log10"|"sqrt"`, `domain`/`limits`,
+  `oob: "censor"|"squish"`, `expand`, `nice`, breaks, `reverse`. Authored
+  `type:"log"` canonicalizes to linear+log10. Scale transforms run before
+  stats and positions; coord transforms run after stats.
+- color/fill families: `ordinal`, `sequential`, `binned`, `manual`,
+  `identity`. 34 named schemes — 14 categorical (`observable10`, `tableau10`,
+  `colorblind`, `Set1`…) and 20 sequential/diverging (`viridis`, `magma`,
+  `Blues`, `RdBu`…). Size/linewidth/alpha and shape/linetype have their own
+  scale families.
+- Three equivalent skins:
+  JSON `"scales": {"x": {"type": "linear", "transform": "log10"}}` ≡ helper
+  functions `scaleXLog10()` / `scale_x_log10()` (binding-identical camelCase,
+  snake_case, and Colour spellings, from `@ggsvelte/spec`) ≡ components
+  `<ScaleXLog10/>`. The `gg()` builder chains the same names:
+  `gg(rows, aes({ x: "flipper", y: "mass" })).geomPoint({ alpha: 0.7 }).scaleXLog10().spec()`.
+- Temporal: ISO dates/date-times, four-digit-year strings, year-months, and
+  year-quarters infer time automatically. Ambiguous ordered dates need
+  `"parse": "dmy"` or `"mdy"`; force `{"type": "band"}` for year-like
+  identifiers; never preprocess dates into indexes.
+- Themes: 17 names (`default`, `light`, `dark`, `minimal`, `ggplot2`,
+  `classic`, `bw`, `hrbr`, `few`, `clean`, `fivethirtyeight`, `economist`,
+  `tufte`, `linedraw`, `void`, plus `grey`/`gray` aliasing `ggplot2`) as
+  `<ThemeTufte/>`-style children or `"theme": "tufte"` in JSON.
+
+Full option surfaces — every scale option, the `Scale*` component matrix, all
+scheme tables, the whole temporal/parser system:
+[references/scales-and-palettes.md](references/scales-and-palettes.md).
+Themes, coords, facets, guides, legend order, and `Labs` in depth:
+[references/composition-surfaces.md](references/composition-surfaces.md).
 
 ## The validation contract (use it!)
 
-`validate(spec)` = schema shape. `validate(spec, { profile })` adds
-data-aware checks against a `DataProfile` —
+`validate(spec)` = schema shape. `validate(spec, { profile })` adds data-aware
+checks against a `DataProfile` —
 `{"fields": [{"name": "displ", "type": "quantitative"}], "rowCount": 234}`
 (types: quantitative | temporal | ordinal | nominal). Every error is:
 
-```json
+```json fragment
 {
   "code": "unknown-field",
   "path": "/layers/0/aes/x",
@@ -180,63 +202,79 @@ data-aware checks against a `DataProfile` —
 `validate(spec, { lint: true })` additionally returns advisories for
 valid-but-questionable specs (line over unordered categories, >10 discrete
 colors, stacked negative areas, discrete×discrete scatter, transform-domain
-mixed-sign data). Advisories never block; fix them when they match intent.
+mixed-sign data); `lintSpec(spec)` is the standalone equivalent. Advisories
+never block; fix them when they match intent. `normalize(input)` canonicalizes
+authoring sugar into a `PortableSpec`; `isPortable`/`toPortable` check and
+strip runtime-only fields. CLIs: `ggsvelte-render spec.json > out.svg`
+(JSON-line diagnostics on stderr) and `ggsvelte-codemod [--write] src`.
 
-## Which geom for which data (DataProfile → recommendation)
-
-| x type           | y type                                | extra              | recommend                                                            |
-| ---------------- | ------------------------------------- | ------------------ | -------------------------------------------------------------------- |
-| quantitative     | quantitative                          | ≤ ~2k rows         | `point` (+ `smooth` layer for trend)                                 |
-| quantitative     | quantitative                          | many rows          | `point` with `"render": "canvas"`, or `histogram`/`density` per axis |
-| temporal         | quantitative                          | —                  | `line` (multi-series: map `color` to the series field)               |
-| nominal/ordinal  | quantitative (pre-aggregated)         | —                  | `col`; many/long labels → add `"coord": {"type": "flip"}`            |
-| nominal/ordinal  | (none — count rows)                   | —                  | `bar` (count stat; do NOT map y)                                     |
-| quantitative     | (none — distribution)                 | —                  | `histogram` (or `density` for smooth overlay)                        |
-| nominal          | quantitative (distribution per group) | —                  | `boxplot`                                                            |
-| nominal          | nominal                               | —                  | `point` + `"position": "jitter"`, or counts via size                 |
-| quantitative     | quantitative                          | uncertainty bounds | `errorbar` (map ymin/ymax) or `smooth` (se ribbon)                   |
-| any of the above | + one more nominal field              | few values         | same geom + `facet.wrap` on that field                               |
-
-Annotations (reference lines): `rule` with `params.yintercept`/`xintercept`
-(no aes). Data-driven rules: map exactly ONE of aes.x / aes.y.
-
-## Recipes (canonical spec JSON — top 20)
+## Recipes (spec JSON — the everyday twelve)
 
 All specs assume inline `"data": {"values": [...]}` or a named dataset.
-`A` = aes shorthand shown expanded once, then abbreviated for space.
 
-1. **Scatter** — `{"layers":[{"geom":"point","aes":{"x":{"field":"displ"},"y":{"field":"hwy"}}}]}`
-2. **Scatter colored by category** — add `"color":{"field":"class"}` to the aes.
-3. **Scatter + trend** — `{"aes":{"x":{"field":"x"},"y":{"field":"y"}},"layers":[{"geom":"point"},{"geom":"smooth","params":{"method":"loess"}}]}` (plot-level aes inherits into both layers)
-4. **Line (time series)** — `{"layers":[{"geom":"line","aes":{"x":{"field":"date"},"y":{"field":"value"}}}]}` (ISO dates, raw four-digit years, year-months, and year-quarters infer time automatically; add `"scales":{"x":{"type":"time","parse":"dmy"}}` only for an explicit ordered parser)
-5. **Multi-series line** — map `"color":{"field":"series"}` (grouping follows).
-6. **Column chart (pre-computed heights)** — `{"layers":[{"geom":"col","aes":{"x":{"field":"category"},"y":{"field":"amount"}}}]}`
-7. **Bar chart (count rows per category)** — `{"layers":[{"geom":"bar","aes":{"x":{"field":"category"}}}]}` — never map y on bar.
-8. **Horizontal bars** — recipe 6 or 7 + `"coord":{"type":"flip"}`.
-9. **Stacked bars** — recipe 7 + `"fill":{"field":"subgroup"}` in aes (stack is the default position).
-10. **Dodged (grouped) bars** — recipe 9 + `"position":"dodge"` on the layer.
-11. **Proportion bars (100% stacked)** — recipe 9 + `"position":"fill"`.
-12. **Histogram** — `{"layers":[{"geom":"histogram","aes":{"x":{"field":"measure"}},"params":{"bins":30}}]}` (or `"binwidth"`; never both `center` and `boundary`).
-13. **Density overlay** — `{"layers":[{"geom":"density","aes":{"x":{"field":"measure"},"color":{"field":"group"}}}]}`
-14. **Boxplot by category** — `{"layers":[{"geom":"boxplot","aes":{"x":{"field":"group"},"y":{"field":"value"}}}]}` (x must be discrete)
-15. **Stacked area** — `{"layers":[{"geom":"area","aes":{"x":{"field":"date"},"y":{"field":"value"},"fill":{"field":"series"}}}]}`
-16. **Errorbar (mean ± se)** — `{"layers":[{"geom":"errorbar","stat":"summary","aes":{"x":{"field":"group"},"y":{"field":"value"}}}]}`
-17. **Reference line annotation** — add layer `{"geom":"rule","params":{"yintercept":0}}`.
-18. **Value labels on columns** — recipe 6 + layer `{"geom":"text","aes":{"x":{"field":"category"},"y":{"field":"amount"},"label":{"field":"amount"}},"params":{"dy":-8}}` (`dy`/`dx` are px offsets; `position: "nudge"` + `positionParams.x/y` offsets in DATA units)
-19. **Facets (small multiples)** — any recipe + `"facet":{"wrap":{"field":"panel"},"ncol":3}` (add `"scales":"free_y"` for per-panel y).
-20. **Big scatter (canvas)** — recipe 1 + `"render":"canvas"` on the layer (or let >2000 marks auto-switch; `"a11y":"force-svg"` at plot level overrides for assistive tech). Log10 axis: `"scales":{"x":{"type":"linear","transform":"log10"}}` (positive data only; transform runs before stats). Jittered categorical scatter: `"position":"jitter"` on a point layer.
+1. **Scatter** — `{"layers":[{"geom":"point","aes":{"x":{"field":"displ"},"y":{"field":"hwy"}}}]}`; color by category: add `"color":{"field":"class"}`.
+2. **Scatter + trend** — `{"aes":{"x":{"field":"x"},"y":{"field":"y"}},"layers":[{"geom":"point"},{"geom":"smooth","params":{"method":"loess"}}]}` (plot-level aes inherits into both layers).
+3. **Line (time series)** — `{"layers":[{"geom":"line","aes":{"x":{"field":"date"},"y":{"field":"value"}}}]}`; multi-series: map `"color":{"field":"series"}`.
+4. **Column chart (pre-computed heights)** — `{"layers":[{"geom":"col","aes":{"x":{"field":"category"},"y":{"field":"amount"}}}]}`
+5. **Bar chart (count rows)** — `{"layers":[{"geom":"bar","aes":{"x":{"field":"category"}}}]}` — never map y on bar.
+6. **Horizontal bars** — recipe 4 or 5 + `"coord":{"type":"flip"}`.
+7. **Stacked / dodged / proportion bars** — recipe 5 + `"fill":{"field":"subgroup"}` in aes (stack is the default); `"position":"dodge"` for side-by-side, `"position":"fill"` for 100% stacked.
+8. **Histogram** — `{"layers":[{"geom":"histogram","aes":{"x":{"field":"measure"}},"params":{"bins":30}}]}` (or `"binwidth"`; never both `center` and `boundary`).
+9. **Boxplot by category** — `{"layers":[{"geom":"boxplot","aes":{"x":{"field":"group"},"y":{"field":"value"}}}]}` (x must be discrete).
+10. **Facets (small multiples)** — any recipe + `"facet":{"wrap":{"field":"panel"},"ncol":3}` (add `"scales":"free_y"` for per-panel y).
+11. **Reference line annotation** — add layer `{"geom":"rule","params":{"yintercept":0}}`.
+12. **Finishing** — `"labs":{"title":...,"x":...,"y":...}`, `"width"`/`"height"` in px, `"theme":"minimal"`.
 
-Finish with `"labs": {"title": ..., "x": ..., "y": ...}` for human-readable
-labels, `"width"`/`"height"` in px, `"theme": "default"|"light"|"dark"|"minimal"`.
+The same charts as Svelte children, twice over:
 
-## References
+```svelte fragment
+<GGPlot data={sales} aes={{ x: "quarter", y: "amount", fill: "region" }}>
+  <GeomCol position="dodge" />
+</GGPlot>
+```
+
+```svelte fragment
+<GGPlot data={measurements} aes={{ x: "value" }}>
+  <FacetWrap field="site" ncol={2} />
+  <GeomHistogram bins={20} />
+</GGPlot>
+```
+
+Long-tail recipes — errorbar, value labels, canvas big-scatter, log axis,
+violin, tile heatmap, hex density, ECDF step, ribbon, flipped boxplot,
+per-layer aes override, sf/map — each as validated JSON plus a Svelte twin:
+[references/recipes.md](references/recipes.md).
+
+## Interactions (Svelte props, not spec fields)
+
+Opt-in `<GGPlot>` props: `inspect` (tooltip/crosshair/keyboard/pinning),
+`select` (point or interval), `zoom` (brush), `legendFocus` (emphasis only),
+`legendFilter` (refilters and reruns the grammar, colors stay stable). Always
+give a stable `key` when selection or linked views must survive filtering or
+refreshes. Link plots by sharing one `createPlotInteraction()` controller and
+matching `interactionScope` channels; observe everything through
+`oninteraction` or per-capability handlers. Faceted interval presets, the
+controller API, `Tooltip`, handler payloads, and diagnostics:
+[references/interactions.md](references/interactions.md) — read it before
+writing any interactive or linked-view code.
+
+## Pointers
 
 - JSON Schema (constrained decoding): `packages/spec/schema/v0.json` in the
   repo, `/schema/v0.json` on the docs site, or
   `import schema from "@ggsvelte/spec/schema/v0.json"`.
 - Full corpus for models: `/llms-full.txt` on the docs site (all guide prose
-  - every example with spec JSON and Svelte source); index at `/llms.txt`.
+  plus every example with spec JSON and Svelte source); index at `/llms.txt`.
 - Error catalog: `/guide/errors`; advisories: `/guide/advisories`;
   lifecycle/editions: `/guide/lifecycle` (specs are stamped with the current
-  appearance edition, currently 2; editions do not preserve incorrect pre-1.0
-  parser or scale execution).
+  appearance edition, currently 2). Upgrading off deprecated props:
+  `/guide/upgrading`.
+- References in this skill — read the one that matches the task:
+  [geoms-and-stats.md](references/geoms-and-stats.md) (any geom/stat/position
+  beyond the everyday set, annotations),
+  [scales-and-palettes.md](references/scales-and-palettes.md) (scale options,
+  palettes, temporal),
+  [composition-surfaces.md](references/composition-surfaces.md) (themes,
+  coords, facets, guides, merge semantics),
+  [interactions.md](references/interactions.md) (tooltips, selection, linking),
+  [recipes.md](references/recipes.md) (long-tail chart recipes).

--- a/skills/ggsvelte/SKILL.md
+++ b/skills/ggsvelte/SKILL.md
@@ -129,7 +129,7 @@ first-class. Migrate existing code with `npx ggsvelte-codemod --write src`
 | quantitative     | quantitative                          | uncertainty bounds | `errorbar` (map ymin/ymax) or `smooth` (se ribbon)           |
 | any of the above | + one more nominal field              | few values         | same geom + facet wrap on that field                         |
 
-Only the everyday geoms appear above. All 50 geoms (violin, hex, contour, qq,
+Only the everyday geoms appear above. All 49 geoms (violin, hex, contour, qq,
 step, segment, sf/maps, text/label annotation, …), all 28 stats with their
 computed columns, and the position rules live in
 [references/geoms-and-stats.md](references/geoms-and-stats.md) — read it

--- a/skills/ggsvelte/references/composition-surfaces.md
+++ b/skills/ggsvelte/references/composition-surfaces.md
@@ -1,0 +1,200 @@
+<!-- Source of truth: packages/spec/src/schema-names.ts (THEME_NAMES), packages/svelte/src/lib/index.ts (component exports), packages/svelte/src/lib/plot-props.ts, packages/svelte/src/lib/layers/ (merge semantics, grammar-families). Inventory tables are asserted complete by scripts/skill-content.test.ts. -->
+
+# Composition surfaces: themes, coords, facets, guides, labs
+
+Every surface here exists in three equivalent forms: a key in the JSON
+`PortableSpec`, a deprecated `<GGPlot>` prop (removable in 0.13.0), and a
+declaration-only child component (canonical in Svelte). Child components emit
+no markup, register on init, unregister on destroy, and are inert without a
+`<GGPlot>` ancestor.
+
+## Themes
+
+JSON form: `"theme": "minimal"` (a registered name) or a theme object —
+optional `"name"` base plus role overrides, e.g.
+`{"name": "dark", "ink": "#eee"}`. `grey` and `gray` are registered aliases of
+`ggplot2` (same token map).
+
+| Name                    | Look                                                                       |
+| ----------------------- | -------------------------------------------------------------------------- |
+| default                 | quiet hrbrthemes-style base: real typography, hairline grid, no axis frame |
+| light                   | light grid, thin panel border, x/y ticks                                   |
+| dark                    | dark paper and panel, light ink                                            |
+| minimal                 | light grid only, no ticks or border                                        |
+| ggplot2                 | classic grey panel, white grid                                             |
+| classic                 | no grid, black axis lines and ticks                                        |
+| bw                      | white panel, grey grid, black rectangular border (print/B&W)               |
+| hrbr                    | same token map as default                                                  |
+| few                     | no grid, thin panel border (Stephen Few)                                   |
+| clean                   | dashed y grid only, axis lines and ticks                                   |
+| fivethirtyeight         | grey paper and panel, white grid, blue accent                              |
+| economist               | pale blue paper, white grid, x ticks, red accent                           |
+| tufte                   | monochrome ink, no grid                                                    |
+| linedraw                | black-on-white line art: hairline black grid, black border                 |
+| void                    | no axes, grid, or panel chrome; marks and legends remain                   |
+| grey (alias of ggplot2) | UK theme_grey                                                              |
+| gray (alias of ggplot2) | US theme_gray                                                              |
+
+Svelte: one named shell per product theme — `ThemeDefault`, `ThemeLight`,
+`ThemeDark`, `ThemeMinimal`, `ThemeGgplot2`, `ThemeClassic`, `ThemeBw`,
+`ThemeHrbr`, `ThemeFew`, `ThemeClean`, `ThemeFivethirtyeight`,
+`ThemeEconomist`, `ThemeTufte`, `ThemeLinedraw`, `ThemeVoid`, `ThemeGrey`,
+`ThemeGray`. Escape hatch `<Theme name={dynamicName} />` for reactive names.
+Every shell and `<Theme>` also accepts role-override props (`ink`, `paper`,
+`accent`, `grid`, `panel`, `axisText`, `axisLine`, `tickColor`,
+`panelBorder`, tooltip/selection/focus roles, …): `<ThemeDark ink="#eee" />`.
+
+## Coords
+
+Components: `Coord` (escape hatch, `value: CoordSpec | "flip"`), `CoordFlip`,
+`CoordCartesian`, `CoordTransform`, `CoordFixed`, `CoordEqual` (alias of
+`CoordFixed`), `CoordSf`. `<CoordCartesian/>` registers `{"type":"cartesian"}`,
+which `normalize()` drops when bare — use it to clear an earlier coord under
+REPLACE. JSON forms:
+
+```json fragment
+"coord": {"type": "flip"}
+```
+
+```json fragment
+"coord": {
+  "type": "transform",
+  "x": {"transform": "log10", "limits": [1, 1000], "reverse": false, "expand": true},
+  "y": {"transform": "sqrt"},
+  "clip": true
+}
+```
+
+- Coord transform runs AFTER stats and scale training (scale `transform` runs
+  before stats). It preserves stat inputs; coordinate `limits` are a viewport —
+  they never remove rows or recompute statistics. `expand` (default true) adds
+  a 5% display expansion to explicit limits; `clip` (default true) clips marks
+  to the panel.
+- Non-identity coordinate transforms require continuous, non-temporal
+  position scales on the transformed axes.
+- `{"type": "fixed", "ratio": 1}`: ratio is physical y-unit length divided by
+  physical x-unit length (default 1). Layout fits the largest centered data
+  rectangle after chart chrome. Fixed-aspect coords reject free positional
+  facet scales (`coord-fixed-free-scales` error).
+- `{"type": "sf"}` (`<CoordSf/>`): fixed-aspect coords for already-projected
+  map data; no CRS reprojection in v1. Accepts `ratio` like fixed.
+
+## Facets
+
+Components: `Facet` (full `FacetInput` surface), `FacetWrap` (`field`,
+`ncol?`, `scales?`, `strip?`), `FacetGrid` (`rows?`, `cols?`, `scales?`,
+`strip?`). `field`/`rows`/`cols` accept a bare string or
+`{ field, levels?, labels? }` for authored panel order and strip text. Wrap
+form is mutually exclusive with rows/cols; a bare `<Facet/>` fails validate
+with `facet-form-missing`.
+
+```json fragment
+"facet": {"wrap": {"field": "region"}, "ncol": 3, "scales": "free_y",
+          "strip": {"position": "top", "show": true}}
+```
+
+- Panels partition the data BEFORE stats and positions run — each panel
+  computes its own counts, bins, and stacks.
+- `scales`: `"fixed"` (default — panels share both positional scales) |
+  `"free"` | `"free_x"` | `"free_y"`. Discrete color/fill assignments are
+  ALWAYS global (one legend), whatever `scales` says.
+- `strip`: `position` `"top"` (default) | `"bottom"` | `"left"` | `"right"`
+  (left/right strips take layout space rather than overlaying the panel);
+  `show` (default true) — set false when direct labels are authored elsewhere.
+
+## Guides, legend, labs
+
+Guides are keyed by aesthetic channel: `x`, `y`, `color`, `fill`, `size`,
+`linewidth`, `alpha`, `shape`, `linetype`. Components: `Guides`
+(escape hatch, `value: GuidesSpec`), plus one shell per guide type carrying a
+`channel` prop — `GuideAxis` (channels `x`/`y` only), `GuideLegend`,
+`GuideColorbar`, `GuideColorsteps` (non-position channels), `GuideNone` (any
+channel). `<GuideLegend channel="color" position="bottom"/>` assembles
+`guides: {"color": {"type": "legend", "position": "bottom"}}`.
+
+- Top-level `guides` override a scale-local `guide`.
+- Shared options: `title`, `theme` (bounded size/gap overrides), `collision`;
+  non-position guides add integer `order` (placement rank), `position`
+  `"auto"|"right"|"bottom"`, `direction` `"auto"|"vertical"|"horizontal"`,
+  and `force` (show a guide suppressed by default, e.g. identity scales).
+- Responsive rule: `auto`-positioned non-position guides move below the panel
+  when the viewport is 480px wide or less, or when a right guide would leave
+  under 320px of panel (after an estimated 80px of other chrome).
+- `<Legend order="stable-domain"|"present-first-seen"|"sorted"/>` is the
+  plot-wide legend ENTRY-SORT enum (default `stable-domain`; ordering never
+  changes color assignments). Distinct from `<GuideLegend order={2}/>`, a
+  per-aesthetic integer placement rank — same word, unrelated concepts.
+- `Labs` takes flat string props: `title`, `subtitle`, `caption`, `x`, `y`,
+  `color`, `fill`, `size`, `linewidth`, `alpha`, `shape`, `linetype`. The
+  spec type is re-exported from `@ggsvelte/svelte` as `LabsSpec`.
+
+```svelte fragment
+<GGPlot
+  data={rows}
+  aes={{ x: "cat", y: "val", fill: "group" }}
+  layers={[{ geom: "col" }]}
+>
+  <CoordFlip />
+  <FacetWrap field="region" ncol={2} />
+  <ThemeMinimal />
+  <Labs title="Sales by category" x="Category" y="Sales" />
+  <GuideLegend channel="fill" position="bottom" />
+  <Legend order="sorted" />
+</GGPlot>
+```
+
+Equivalent complete JSON spec:
+
+```json complete
+{
+  "data": {
+    "values": [
+      { "cat": "a", "val": 3, "group": "g1", "region": "west" },
+      { "cat": "b", "val": 5, "group": "g2", "region": "west" },
+      { "cat": "a", "val": 2, "group": "g1", "region": "east" },
+      { "cat": "b", "val": 4, "group": "g2", "region": "east" }
+    ]
+  },
+  "layers": [
+    {
+      "geom": "col",
+      "aes": {
+        "x": { "field": "cat" },
+        "y": { "field": "val" },
+        "fill": { "field": "group" }
+      }
+    }
+  ],
+  "coord": { "type": "flip" },
+  "facet": { "wrap": { "field": "region" }, "ncol": 2 },
+  "theme": "minimal",
+  "labs": { "title": "Sales by category", "x": "Category", "y": "Sales" },
+  "guides": { "fill": { "type": "legend", "position": "bottom" } },
+  "legend": { "order": "sorted" }
+}
+```
+
+## Replace-vs-merge semantics (child layers)
+
+- The `spec` prop wins over everything — when set, all other props and all
+  children are ignored.
+- Mark layers: the `layers` prop, when set, is used INSTEAD of geom children.
+  Otherwise geom children register in document order, and registration order
+  is z-order (first = bottom).
+- Grammar (non-mark) families fold onto the builder AFTER the matching
+  deprecated prop, in registration order — so a grammar child overrides its
+  prop, and later siblings beat earlier ones.
+- REPLACE families — `coord`, `facet`, `theme`: the last registration fully
+  replaces earlier ones (and any matching prop). Two or more children of one
+  kind emit a `DUPLICATE_PLOT_LAYER` advisory.
+- Scales merge per-channel; two scale children configuring the same channel
+  emit `DUPLICATE_SCALE_CHANNEL` (note British/American spellings write the
+  same channel: `<ScaleColorDiscrete/>` and `<ScaleColourContinuous/>` both
+  configure `color`).
+- `labs`, `guides`, `legend` are keyed-MERGE families: siblings touching
+  different keys all survive; a colliding key emits `DUPLICATE_MERGE_KEY` and
+  the later child's value wins. The value at a key is replaced whole — a
+  guide child never field-merges into another guide object for that channel.
+- All three advisory codes arrive through `ondiagnostic` with severity
+  `"advisory"`; the chart still renders.
+- Grammar children emit no markup and are inert without a `<GGPlot>` ancestor.

--- a/skills/ggsvelte/references/geoms-and-stats.md
+++ b/skills/ggsvelte/references/geoms-and-stats.md
@@ -1,0 +1,258 @@
+<!-- Source of truth: packages/spec/src/schema-catalog.ts (KNOWN_GEOMS, KNOWN_STATS, KNOWN_POSITIONS, GEOM_DEFAULTS), packages/spec/src/schema-declarations.ts (per-geom position unions, params), packages/svelte/src/lib/geoms/. Inventory tables are asserted complete by scripts/skill-content.test.ts. -->
+
+# Geoms, stats, and positions
+
+A JSON layer is `{ "geom": ..., "stat"?, "position"?, "positionParams"?, "aes"?, "data"?, "params"?, "render"? }`.
+Every geom is also a Svelte component (`<GeomPoint/>` inside `<GGPlot>`); the component takes
+`data`, `aes`, `stat`, `position`, `positionParams`, `render` props, and its constant style
+params (the layer's `params` keys) as DIRECT props — each component whitelists exactly its
+geom's param keys via `createGeomLayer` (`packages/svelte/src/lib/geoms/*.svelte`):
+
+```svelte fragment
+<GeomPoint
+  aes={{ x: "displ", y: "hwy" }}
+  size={3}
+  alpha={0.6}
+  position="jitter"
+  positionParams={{ seed: 7 }}
+/>
+```
+
+Omit `stat`/`position` to get the geom's defaults (normalize fills them in). Each layer
+declaration allows only its own stat and position values — anything else is a schema error.
+
+Component layer z-order equals registration order (decision 0001). Static markup, `{#if}`
+membership, and unkeyed `{#each}` keep declaration order; keyed `{#each}` reorder or
+re-mount appends re-registered layers at the END — use the props-first API
+(`layers={[...]}`) for dynamic layer composition. Components emit no markup and are inert
+outside a `<GGPlot>` ancestor.
+
+## Geom inventory
+
+All 49 geoms. "Default" is stat+position from GEOM_DEFAULTS. "Channels" lists required
+channels (all geoms also consume color/fill/alpha and group where meaningful; strokes take
+linewidth/linetype, points take size/shape). "Positions" is the layer's full allowed set.
+
+| geom                | component           | default (stat + position)    | channels                                             | key params                                                                     | positions                    |
+| ------------------- | ------------------- | ---------------------------- | ---------------------------------------------------- | ------------------------------------------------------------------------------ | ---------------------------- |
+| `point`             | GeomPoint           | identity + identity          | x, y                                                 | alpha, size, shape; summary_bin/manual add bins, binwidth, fun, funMin, funMax | identity, jitter, nudge      |
+| `line`              | GeomLine            | identity + identity          | x, y (ecdf/bin: x only)                              | linewidth, alpha, curve, connection, bins, binwidth, fun                       | identity                     |
+| `path`              | GeomPath            | identity + identity          | x, y (data order, not x-sorted)                      | linewidth, curve, connection; ellipse: level, type, segments                   | identity                     |
+| `step`              | GeomStep            | identity + identity          | x, y                                                 | direction ("hv" default, "vh", "mid")                                          | identity                     |
+| `col`               | GeomCol             | identity + stack             | x (discrete), y (height)                             | width, alpha                                                                   | stack, fill, dodge, identity |
+| `bar`               | GeomBar             | count + stack                | x only (y computed)                                  | width, alpha; stat bin adds bins, binwidth                                     | stack, fill, dodge, identity |
+| `histogram`         | GeomHistogram       | bin + stack                  | x (continuous; y computed)                           | bins (default 30), binwidth, boundary, center, closed                          | stack, fill, dodge, identity |
+| `freqpoly`          | GeomFreqpoly        | bin + identity               | x (continuous; y computed)                           | bins, binwidth, boundary, center, closed, linewidth                            | identity                     |
+| `area`              | GeomArea            | identity + stack             | x, y                                                 | alpha; stat align for mismatched x samples                                     | stack, fill, dodge, identity |
+| `ribbon`            | GeomRibbon          | identity + identity          | x+ymin+ymax OR y+xmin+xmax                           | alpha, outline, orientation                                                    | identity                     |
+| `rule`              | GeomRule            | identity + identity          | none (annotation) or exactly ONE of x / y            | xintercept, yintercept, linewidth                                              | identity                     |
+| `hline`             | GeomHline           | identity + identity          | none, or aes.y (data-driven)                         | yintercept, linewidth                                                          | identity                     |
+| `vline`             | GeomVline           | identity + identity          | none, or aes.x (data-driven)                         | xintercept, linewidth                                                          | identity                     |
+| `abline`            | GeomAbline          | identity + identity          | none (annotation only)                               | slope, intercept, linewidth                                                    | identity                     |
+| `text`              | GeomText            | identity + identity          | x, y, label                                          | size, anchor, dx, dy (px offsets)                                              | identity, nudge              |
+| `label`             | GeomLabel           | identity + identity          | x, y, label                                          | size, anchor, dx, dy, padding, radius, linewidth                               | identity, nudge              |
+| `smooth`            | GeomSmooth          | smooth + identity            | x, y (quantitative)                                  | method, se, level, span, degree, n                                             | identity                     |
+| `quantile`          | GeomQuantile        | quantile + identity          | x, y (quantitative)                                  | quantiles (default [0.25, 0.5, 0.75]), n                                       | identity                     |
+| `boxplot`           | GeomBoxplot         | boxplot + dodge              | x (discrete), y (quantitative)                       | width, coef, outlierSize, linewidth                                            | dodge, identity              |
+| `violin`            | GeomViolin          | ydensity + dodge             | x (discrete), y (continuous)                         | bw, adjust, trim, scale, width                                                 | dodge, identity              |
+| `density`           | GeomDensity         | density + identity           | x (continuous; y computed)                           | bw, adjust, n, cut                                                             | identity                     |
+| `errorbar`          | GeomErrorbar        | identity + identity          | x, ymin, ymax (identity); x, y (summary/summary_bin) | width, fun, funMin, funMax, bins, binwidth                                     | identity                     |
+| `linerange`         | GeomLinerange       | identity + identity          | x, ymin, ymax (identity); x, y (summary)             | none                                                                           | identity                     |
+| `pointrange`        | GeomPointrange      | identity + identity          | x, y, ymin, ymax (identity); x, y (summary)          | size, shape, linewidth, fun                                                    | identity                     |
+| `crossbar`          | GeomCrossbar        | identity + identity          | x, y, ymin, ymax                                     | width, fatten, fun, funMin, funMax                                             | identity                     |
+| `rect`              | GeomRect            | identity + identity          | xmin, xmax, ymin, ymax                               | linewidth, alpha                                                               | identity                     |
+| `tile`              | GeomTile            | identity + identity          | x, y (cell centers); width/height via aes or params  | width, height, linewidth                                                       | identity                     |
+| `raster`            | GeomRaster          | identity + identity          | x, y (regular grid), fill                            | hjust, vjust, interpolate                                                      | identity                     |
+| `bin_2d`            | GeomBin2d           | bin_2d + identity            | x, y (continuous; fill defaults to after-stat count) | bins, binwidth, drop                                                           | identity                     |
+| `hex`               | GeomHex             | bin_hex + identity           | x, y (continuous; fill defaults to after-stat count) | bins, drop                                                                     | identity                     |
+| `segment`           | GeomSegment         | identity + identity          | x, y, xend, yend                                     | linewidth, lineend                                                             | identity                     |
+| `curve`             | GeomCurve           | identity + identity          | x, y, xend, yend                                     | curvature, angle, ncp, lineend                                                 | identity                     |
+| `spoke`             | GeomSpoke           | identity + identity          | x, y; angle (radians) + radius via aes or params     | angle, radius, linewidth                                                       | identity                     |
+| `count`             | GeomCount           | sum + identity               | x, y (size defaults to after-stat n)                 | alpha, size, shape                                                             | identity, jitter, nudge      |
+| `jitter`            | GeomJitter          | identity + jitter            | x, y (alias; normalize → point + position jitter)    | alpha, size, shape                                                             | jitter                       |
+| `function`          | GeomFunction        | function + identity          | none (y computed from params.fun)                    | fun, n, xlim, args                                                             | identity                     |
+| `polygon`           | GeomPolygon         | identity + identity          | x, y (vertices in data order, auto-closed)           | alpha, linewidth                                                               | identity                     |
+| `contour`           | GeomContour         | contour + identity           | x, y, z (regular complete grid)                      | bins (default 10), binwidth, breaks                                            | identity                     |
+| `density_2d`        | GeomDensity2d       | density_2d + identity        | x, y (continuous)                                    | h, adjust, n, bins, binwidth, breaks                                           | identity                     |
+| `density_2d_filled` | GeomDensity2dFilled | density_2d_filled + identity | x, y (continuous; fill defaults to after-stat level) | h, adjust, n, bins, breaks                                                     | identity                     |
+| `dotplot`           | GeomDotplot         | bindot + identity            | x (continuous; y is computed stackpos)               | bins, binwidth, stackdir, stackratio, dotsize                                  | identity                     |
+| `rug`               | GeomRug             | identity + identity          | x and/or y (match params.sides)                      | sides (default "bl"), length                                                   | identity                     |
+| `map`               | GeomMap             | identity + identity          | map_id (joined to map data)                          | map (required DataRef), mapId                                                  | identity                     |
+| `sf`                | GeomSf              | sf + identity                | none (GeoJSON geometry column)                       | geometry (default "geometry"), size, linewidth                                 | identity                     |
+| `sf_text`           | GeomSfText          | sf_coordinates + identity    | label (+ geometry column; no x/y)                    | geometry, size, anchor, dx, dy                                                 | identity                     |
+| `sf_label`          | GeomSfLabel         | sf_coordinates + identity    | label (+ geometry column; no x/y)                    | geometry, padding, radius, dx, dy                                              | identity                     |
+| `blank`             | GeomBlank           | identity + identity          | any mapped channel (trains scales, draws nothing)    | none                                                                           | identity                     |
+| `qq`                | GeomQq              | qq + identity                | sample                                               | size, shape                                                                    | identity                     |
+| `qq_line`           | GeomQqLine          | qq_line + identity           | sample                                               | linewidth                                                                      | identity                     |
+
+Alias geoms (rewritten by `normalize`): `histogram` → bar + stat bin; `freqpoly` → line +
+stat bin; `jitter` → point + position jitter; `hline`/`vline` → rule. Annotation-form
+rule/hline/vline (fixed intercepts in params) inherit NO plot aes. Any geom absent from
+GEOM_DEFAULTS notes above defaults to identity + identity.
+
+## Stat inventory
+
+There are NO `Stat*` components — `stat` is a prop on geom components and a field on JSON
+layers. Stats either compute new columns (read them with the after-stat aes form
+`{"stat": "count"}`) or transform rows in place.
+
+**Computed-y rule:** when the stat computes y (bar/histogram/freqpoly, line + stat bin or
+ecdf, density, function, dotplot/bindot), `aes.y` must NOT map a field — that is the
+`computed-y-mapped` error. Leave y unmapped (the default after-stat mapping applies), map
+`{"stat": "..."}` explicitly, or unset an inherited y with `null`:
+
+```json fragment
+{
+  "geom": "histogram",
+  "aes": { "x": { "field": "hwy" }, "y": { "stat": "density" } },
+  "params": { "bins": 20 }
+}
+```
+
+**After-stat color/fill:** `{"stat": ...}` on color or fill resolves ONLY for the stats
+that publish color columns — `bin_2d` and `bin_hex` (count, density, ncount, ndensity)
+and `density_2d` / `density_2d_filled` (level, density). On every other stat an
+after-stat color mapping is dropped; those geoms already default fill to the right
+after-stat column, so usually map nothing at all.
+
+| stat                | computed columns                                          | typical geoms                                                             | key params                                               |
+| ------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------- | -------------------------------------------------------- |
+| `identity`          | none (rows drawn as-is)                                   | most geoms (default)                                                      | —                                                        |
+| `unique`            | none (dedupes rows on mapped aesthetics, first wins)      | point, line, path, col, text, rect, rule, segment, ribbon, area, errorbar | —                                                        |
+| `manual`            | none (one row per group via a named aggregate)            | point, line, path                                                         | fun (required: first, last, mean, median, min, max, sum) |
+| `connect`           | none (expands successive points into connection vertices) | path (ggplot2 default), line                                              | connection (hv, vh, mid, linear)                         |
+| `align`             | none (interpolates each group onto the union of x values) | area, line                                                                | —                                                        |
+| `count`             | count                                                     | bar                                                                       | —                                                        |
+| `bin`               | count, density, ncount, ndensity                          | histogram, bar, freqpoly, line                                            | bins (default 30), binwidth, boundary, center, closed    |
+| `bin_hex`           | count, density, ncount, ndensity                          | hex                                                                       | bins, drop                                               |
+| `bin_2d`            | count, density, ncount, ndensity                          | bin_2d                                                                    | bins, binwidth, drop                                     |
+| `smooth`            | y, ymin, ymax, se                                         | smooth                                                                    | method, se, level, span, degree, n                       |
+| `quantile`          | y (one line per quantile)                                 | quantile                                                                  | quantiles, n                                             |
+| `boxplot`           | ymin, lower, middle, upper, ymax                          | boxplot                                                                   | coef                                                     |
+| `density`           | density, count, scaled, ndensity                          | density                                                                   | bw, adjust, n, cut                                       |
+| `summary`           | y, ymin, ymax                                             | errorbar, linerange, pointrange, crossbar                                 | fun, funMin, funMax (default mean ± se)                  |
+| `summary_bin`       | y, ymin, ymax (per x bin)                                 | point, line, errorbar                                                     | fun + bins, binwidth, boundary, center, closed           |
+| `sum`               | n, prop (aggregates coincident x, y)                      | count, point                                                              | —                                                        |
+| `ydensity`          | density, count, scaled, violinwidth, y                    | violin                                                                    | bw, adjust, n, trim, scale                               |
+| `function`          | y (evaluates a portable named fun)                        | function                                                                  | fun, n, xlim, args                                       |
+| `ecdf`              | ecdf (y defaults to it)                                   | line (use params.curve "step-hv")                                         | —                                                        |
+| `contour`           | level                                                     | contour                                                                   | bins, binwidth, breaks                                   |
+| `density_2d`        | level, density (isolines; also after-stat color)          | density_2d                                                                | h, adjust, n, bins, breaks                               |
+| `density_2d_filled` | level, density (filled bands)                             | density_2d_filled                                                         | h, adjust, n, bins, breaks                               |
+| `bindot`            | stackpos (the computed y; count is NOT a valid y here)    | dotplot                                                                   | bins, binwidth, stackdir, stackratio                     |
+| `ellipse`           | none (one closed normal-ellipse ring per group)           | path                                                                      | level, type, segments                                    |
+| `sf`                | none (renders the GeoJSON geometry column)                | sf                                                                        | geometry                                                 |
+| `sf_coordinates`    | none (computes x/y anchors from geometry)                 | sf_text, sf_label                                                         | geometry                                                 |
+| `qq`                | sample, theoretical                                       | qq                                                                        | —                                                        |
+| `qq_line`           | sample, theoretical                                       | qq_line                                                                   | —                                                        |
+
+### Stat usage patterns
+
+Non-default stats go on the layer; their params share the layer's `params` object.
+
+```json fragment
+{
+  "geom": "errorbar",
+  "stat": "summary",
+  "aes": { "x": { "field": "group" }, "y": { "field": "value" } }
+}
+```
+
+```json fragment
+{
+  "geom": "line",
+  "stat": "ecdf",
+  "aes": { "x": { "field": "value" } },
+  "params": { "curve": "step-hv" }
+}
+```
+
+```json fragment
+{
+  "geom": "line",
+  "stat": "manual",
+  "aes": { "x": { "field": "month" }, "y": { "field": "value" } },
+  "params": { "fun": "mean" }
+}
+```
+
+```json fragment
+{ "geom": "function", "params": { "fun": "sin", "n": 200, "xlim": [0, 6.28] } }
+```
+
+```json fragment
+{
+  "geom": "point",
+  "stat": "summary_bin",
+  "aes": { "x": { "field": "carat" }, "y": { "field": "price" } },
+  "params": { "bins": 20, "fun": "median" }
+}
+```
+
+- `summary` / `summary_bin` default to mean ± se; override with `fun`, `funMin`, `funMax`
+  (first, last, mean, median, min, max, sum).
+- `align` fixes continuous-x stack/fill when groups sample different x values (area, line).
+- `connect` (path/line) expands point pairs into hv / vh / mid / linear connectors.
+- `unique` dedupes rows on the mapped aesthetic combination, first occurrence wins.
+- `ellipse` on path draws one closed normal-data ellipse per group (params.level default 0.95).
+
+## Position inventory
+
+All 6 positions. Each layer declaration scopes which it accepts (see the geom table); a
+disallowed position is a schema error, not a silent fallback.
+
+| position   | effect                                           | positionParams                                                                                    | allowed on                                 |
+| ---------- | ------------------------------------------------ | ------------------------------------------------------------------------------------------------- | ------------------------------------------ |
+| `identity` | leave positions unchanged                        | —                                                                                                 | every geom                                 |
+| `stack`    | pile grouped values (positive up, negative down) | —                                                                                                 | bar, col, histogram, area                  |
+| `fill`     | stack, then rescale to proportions of 1          | —                                                                                                 | bar, col, histogram, area                  |
+| `dodge`    | place groups side by side within each x band     | — (no width param)                                                                                | bar, col, histogram, area, boxplot, violin |
+| `jitter`   | seeded random offsets — ALWAYS deterministic     | width, height (data units on continuous axes, band-step fractions on discrete), seed (default 42) | point, count, jitter                       |
+| `nudge`    | fixed offset in data units / band-step fractions | x, y (default 0)                                                                                  | point, count, text, label                  |
+
+`positionParams` exists only on layers that allow jitter or nudge (point, count, jitter,
+text, label). Jitter defaults width/height to 40% of the data resolution; pass `seed` to
+vary the (reproducible) layout. Stack, fill, and dodge take no parameters.
+
+## Annotations
+
+There is no `Annotate` API — annotate with ordinary geom layers:
+
+- **Reference lines:** `rule` with `params.yintercept` / `params.xintercept` and NO aes
+  (annotation form; inherits nothing). `hline` (params.yintercept) and `vline`
+  (params.xintercept) are aliases that normalize to rule. Data-driven rules map exactly
+  ONE of aes.x / aes.y (both mapped is the `rule-both-axes` error).
+- **Sloped line:** `abline` with `params.slope` and `params.intercept` (annotation only —
+  no data-mapped slope).
+- **Text:** `text` / `label` with layer-local inline data. `params.dx`/`params.dy` are PX
+  offsets; `position: "nudge"` + `positionParams.x`/`y` offset in DATA units.
+- **Arrows and callout paths:** `segment` (straight; x, y, xend, yend) or `curve` (same
+  channels plus curvature/angle/ncp).
+- **Radial marks:** `spoke` (x, y plus angle in radians and radius from aes or params).
+
+```json complete
+{
+  "data": {
+    "values": [
+      { "x": 1, "y": 3 },
+      { "x": 2, "y": 5 },
+      { "x": 3, "y": 4 }
+    ]
+  },
+  "aes": { "x": { "field": "x" }, "y": { "field": "y" } },
+  "layers": [
+    { "geom": "point" },
+    { "geom": "rule", "params": { "yintercept": 4 } },
+    {
+      "geom": "text",
+      "data": { "values": [{ "x": 2, "y": 5, "note": "peak" }] },
+      "aes": {
+        "x": { "field": "x" },
+        "y": { "field": "y" },
+        "label": { "field": "note" }
+      },
+      "params": { "dy": -8 }
+    }
+  ]
+}
+```

--- a/skills/ggsvelte/references/interactions.md
+++ b/skills/ggsvelte/references/interactions.md
@@ -1,0 +1,135 @@
+<!-- Source of truth: packages/svelte/src/lib/plot-props.ts, packages/svelte/src/lib/interaction/ (controller, config, diagnostics), packages/svelte/src/lib/index.ts. -->
+
+# Svelte interactions
+
+`@ggsvelte/svelte` requires Svelte `^5.33.1` (peerDependency). Interactions are
+opt-in PROPS on `<GGPlot>` — they are not spec fields and never appear in a
+PortableSpec. Always pass a stable `key` when selection, legend focus, or
+coordinated intervals must survive filtering, reordering, or data refreshes.
+
+## Capability props
+
+| Prop           | Input                                                  | What it enables                                                                                                                                                                                                                                                   |
+| -------------- | ------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `inspect`      | `boolean \| InspectOptions`                            | Tooltip, semantic crosshair, keyboard traversal, pinning. Options: `mode` (`"auto" \| "exact" \| "x" \| "y" \| "xy"`), `pin`, `maxDistance` (CSS px), `contentMode` (`"informational" \| "interactive"`), `muteSiblings`, `content` (Snippet, see Tooltip below). |
+| `select`       | `false \| "point" \| "interval" \| SelectOptions`      | Point or interval selection. Options: `type` (`"point" \| "interval"`), `mode` (`"x" \| "y" \| "xy"`, interval only), `multiple`, `persistent`, `preset` (faceted intervals, below).                                                                              |
+| `zoom`         | `boolean \| ZoomOptions`                               | Brush zoom. Options: `mode` (`"x" \| "y" \| "xy"`), `trigger` (`"brush"`). Currently requires one unfaceted panel.                                                                                                                                                |
+| `legendFocus`  | `boolean \| { preview?: boolean }`                     | Discrete legend preview, focus, and linked emphasis. Emphasis only — never changes included rows. Discrete color/fill legends only; continuous ramps stay static.                                                                                                 |
+| `legendFilter` | `boolean \| LegendFilterOptions`                       | Data-changing filtering through discrete legend controls: changes the included rows and reruns the grammar while preserving stable color identity. Options: `mode` (`"exclude" \| "include"`), `multiple`.                                                        |
+| `key`          | column name or `(row, index) => PropertyKey`           | Stable semantic identity for public interaction payloads. Required for durable point selection, coordinated interval presets, and legend focus/filter. Duplicate or unstable keys are diagnostic errors.                                                          |
+| `tool`         | `"inspect" \| "point" \| "select-area" \| "zoom-area"` | Controlled initial/active tool; observe changes with `ontoolchange`.                                                                                                                                                                                              |
+| `ariaLabel`    | `string`                                               | Accessible chart name; falls back to the plot title or a generated label.                                                                                                                                                                                         |
+| `a11y`         | `A11yMode`                                             | `"force-svg"` keeps every layer as SVG marks.                                                                                                                                                                                                                     |
+
+After an interval or zoom commit, accessible controls accept exact bounds.
+
+## Faceted interval presets
+
+`select={{ type: "interval", preset }}` coordinates durable intervals across
+facet panels:
+
+- `independent` — only the matching panel consumes its interval.
+- `union` — matching rows from every stored panel interval are combined.
+- `cross-panel` — the sole origin interval is projected into compatible panels.
+
+`union` and `cross-panel` require a stable `key`; without one they combine no
+rows (warning `INTERACTION_INTERVAL_PRESET_REQUIRES_KEY`).
+
+## Controller: durable shared state
+
+`createPlotInteraction<Key>()` creates chart-independent semantic state that
+outlives any one plot. Pass the same controller to every plot that should link,
+via the `interaction` prop. The controller owns stable keys and scoped data
+domains only; each chart translates them to its own render model.
+
+- Mutation methods: `setSelection(keys, {scope, source?})`, `toggleSelection`,
+  `clearSelection`, `setEmphasis`, `clearEmphasis`, `setInterval`,
+  `clearInterval`, `clearIntervals`, `setZoom(domains, {scope, source?})`,
+  `resetZoom`, `reconcileKeys` (call after replacing rows).
+- Reads: `selected(scope)`, `emphasized(scope)`, `isSelected(key, scope)`,
+  `intervals(scope)`, `zoom(scope)`, `snapshot`, `revision` (reactive).
+- `createPlotInteraction({ onchange })` observes every transition
+  (`kind`, `source`, `revision`).
+
+`interactionScope` (`{ keys, x?, y?, intervals? }`) names the identity
+namespaces used for linking: key state crosses charts only through `keys`;
+data-space zoom crosses one positional channel only when that channel's scope
+also matches; `intervals` defaults to `keys`. Give plots matching scope
+channels only when they should coordinate.
+
+A `<GGPlot>` component instance also exports `resetScales()` and
+`setZoom(domains)` for imperative per-chart control.
+
+## Handlers
+
+`oninspect`, `onselect`, `onzoom`, `onlegendfocus`, `onlegendfilter`,
+`oninteraction` (union of all five event types), `ondiagnostic`,
+`ontoolchange`, and `onrender(model, spec)` — called after each committed
+render with the RenderModel (warnings, advisories, scales) and the normalized
+PortableSpec.
+
+A handler without its matching capability prop (for example `onselect` without
+`select`), or `interactionScope` without an `interaction` controller, is inert
+and emits a development advisory (`INTERACTION_HANDLER_WITHOUT_CAPABILITY`,
+`INTERACTION_SCOPE_WITHOUT_CONTROLLER`).
+
+## Tooltip
+
+Enabling `inspect` renders the default HTML tooltip; no extra component is
+needed. Customize its body with the `inspect.content` snippet, which receives a
+`PlotInspectionChange` (`focus`/`members` are `PlotDatum` values whose `fields`
+are `TooltipField` rows: `{ channel, field, value }`). The exported `Tooltip`
+component is the same positioned shell for advanced custom rendering.
+`TooltipContext` is a deprecated (0.1.0) alias of `PlotInspectionChange`.
+
+## Diagnostics
+
+`ondiagnostic` receives `PlotDiagnostic`, the union of three catalogs (each
+entry has `severity`, `code`, `message`, `prop`, `suggestions`, `docUrl`):
+
+- `INTERACTION_DIAGNOSTIC_CATALOG` — capability/key/lineage checks, e.g.
+  `INTERACTION_POINT_REQUIRES_KEY`, `INTERACTION_DUPLICATE_KEY`,
+  `INTERACTION_UNSTABLE_KEY`, `INTERACTION_INTERVAL_FACET_UNSUPPORTED`,
+  `INTERACTION_INTERVAL_SCALE_UNSUPPORTED` (continuous linear/log/time only),
+  `INTERACTION_LEGEND_DISCRETE_ONLY`, `INTERACTION_TOOL_UNAVAILABLE`, and the
+  two wiring advisories named above.
+- `DEPRECATION_DIAGNOSTIC_CATALOG` — one code, `DEPRECATED_PLOT_PROP`, for
+  every grammar prop deprecated in 0.11.0 (`prop` carries the name).
+- `COMPOSITION_DIAGNOSTIC_CATALOG` — child-layer composition collisions:
+  `DUPLICATE_PLOT_LAYER`, `DUPLICATE_SCALE_CHANNEL`, `DUPLICATE_MERGE_KEY`.
+
+## Worked example: linked faceted selection
+
+```svelte fragment
+<script lang="ts">
+  import {
+    createPlotInteraction,
+    Facet,
+    GeomPoint,
+    GGPlot,
+  } from "@ggsvelte/svelte";
+
+  const interaction = createPlotInteraction<number>();
+  const scope = { keys: "sales-rows", intervals: "sales-range" } as const;
+</script>
+
+<GGPlot
+  data={rows}
+  aes={{ x: "date", y: "value", color: "series" }}
+  key="id"
+  select={{ type: "interval", mode: "x", preset: "cross-panel" }}
+  legendFocus
+  legendFilter
+  {interaction}
+  interactionScope={scope}
+  oninteraction={(event) => console.log(event.type, event)}
+>
+  <Facet wrap="region" ncol={3} />
+  <GeomPoint />
+</GGPlot>
+```
+
+Any second plot given the same `interaction` controller and a matching
+`interactionScope` stays linked: brushing an interval in one panel projects it
+cross-panel, external UI can call `interaction.setSelection(...)`, and legend
+filtering reruns the grammar without reshuffling series colors.

--- a/skills/ggsvelte/references/recipes.md
+++ b/skills/ggsvelte/references/recipes.md
@@ -1,0 +1,438 @@
+<!-- Recipes adapted from examples/<category>/<name>/ where noted; hand-authored recipes are validated by scripts/skill-content.test.ts (normalize + validate on every json complete fence). -->
+
+# Long-tail recipes
+
+Each recipe pairs a validated JSON `PortableSpec` with its Svelte-children twin.
+Inline data is cut to a few rows — swap in yours. Plot-level `aes` inherits into
+every layer; a layer `aes` merges over it, and `null` unsets a channel.
+
+## Error bars from raw values (stat summary)
+
+Raw observations per group; the summary stat computes mean ± se, no preaggregation.
+<!-- adapted from examples/errorbar/mean-se/ -->
+
+```json complete
+{
+  "data": {
+    "values": [
+      { "drug": "A", "sleep": 0.7 },
+      { "drug": "A", "sleep": 1.6 },
+      { "drug": "A", "sleep": 0.2 },
+      { "drug": "B", "sleep": 1.9 },
+      { "drug": "B", "sleep": 3.4 },
+      { "drug": "B", "sleep": 2.5 }
+    ]
+  },
+  "aes": { "x": { "field": "drug" }, "y": { "field": "sleep" } },
+  "layers": [
+    {
+      "geom": "point",
+      "position": "jitter",
+      "positionParams": { "width": 0.1, "height": 0, "seed": 7 },
+      "params": { "alpha": 0.5 }
+    },
+    { "geom": "errorbar", "stat": "summary", "params": { "width": 0.3 } }
+  ]
+}
+```
+
+```svelte fragment
+<GGPlot data={rows} aes={{ x: "drug", y: "sleep" }}>
+  <GeomPoint
+    position="jitter"
+    positionParams={{ width: 0.1, height: 0, seed: 7 }}
+    alpha={0.5}
+  />
+  <GeomErrorbar stat="summary" width={0.3} />
+</GGPlot>
+```
+
+## Value labels on columns
+
+`dy`/`dx` are PIXEL offsets (negative dy = up); `position: "nudge"` + `positionParams` offsets in DATA units instead.
+<!-- adapted from examples/text/labels/ -->
+
+```json complete
+{
+  "data": {
+    "values": [
+      { "cat": "a", "n": 4 },
+      { "cat": "b", "n": 7 },
+      { "cat": "c", "n": 5 }
+    ]
+  },
+  "aes": { "x": { "field": "cat" }, "y": { "field": "n" } },
+  "layers": [
+    { "geom": "col" },
+    {
+      "geom": "text",
+      "aes": { "label": { "field": "n" } },
+      "params": { "dy": -8 }
+    }
+  ]
+}
+```
+
+```svelte fragment
+<GGPlot data={rows} aes={{ x: "cat", y: "n" }}>
+  <GeomCol />
+  <GeomText aes={{ label: "n" }} dy={-8} />
+</GGPlot>
+```
+
+## Big scatter on canvas
+
+`"render": "canvas"` forces the canvas path; layers over 2000 marks switch on their own. Plot-level `"a11y": "force-svg"` overrides for assistive tech.
+<!-- adapted from examples/point/canvas-scatter/ -->
+
+```json complete
+{
+  "data": {
+    "values": [
+      { "x": 1, "y": 2 },
+      { "x": 2, "y": 3 },
+      { "x": 3, "y": 2.5 },
+      { "x": 4, "y": 4 }
+    ]
+  },
+  "layers": [
+    {
+      "geom": "point",
+      "render": "canvas",
+      "aes": { "x": { "field": "x" }, "y": { "field": "y" } },
+      "params": { "size": 1.2, "alpha": 0.4 }
+    }
+  ],
+  "a11y": "force-svg"
+}
+```
+
+```svelte fragment
+<GGPlot data={rows} aes={{ x: "x", y: "y" }} a11y="force-svg">
+  <GeomPoint render="canvas" size={1.2} alpha={0.4} />
+</GGPlot>
+```
+
+## Log10 axis scatter
+
+Positive data only; the transform runs before stats. Authored `"type": "log"` canonicalizes to this form.
+<!-- adapted from examples/point/log-scale/ -->
+
+```json complete
+{
+  "data": {
+    "values": [
+      { "density": 10, "rate": 3 },
+      { "density": 100, "rate": 9 },
+      { "density": 1000, "rate": 30 },
+      { "density": 5000, "rate": 55 }
+    ]
+  },
+  "layers": [
+    {
+      "geom": "point",
+      "aes": { "x": { "field": "density" }, "y": { "field": "rate" } }
+    }
+  ],
+  "scales": { "x": { "type": "linear", "transform": "log10" } }
+}
+```
+
+```svelte fragment
+<GGPlot data={rows} aes={{ x: "density", y: "rate" }}>
+  <ScaleXLog10 />
+  <GeomPoint />
+</GGPlot>
+```
+
+## Violin with jittered points
+
+Distribution shape per group; needs several y values per group for the density. Seeded jitter is deterministic.
+<!-- adapted from examples/boxplot/violin/ -->
+
+```json complete
+{
+  "data": {
+    "values": [
+      { "run": "a", "v": 1 },
+      { "run": "a", "v": 2 },
+      { "run": "a", "v": 2.4 },
+      { "run": "a", "v": 3.1 },
+      { "run": "a", "v": 1.7 },
+      { "run": "b", "v": 4 },
+      { "run": "b", "v": 5.2 },
+      { "run": "b", "v": 4.4 },
+      { "run": "b", "v": 6 },
+      { "run": "b", "v": 5.1 }
+    ]
+  },
+  "aes": { "x": { "field": "run" }, "y": { "field": "v" } },
+  "layers": [
+    { "geom": "violin", "params": { "trim": true, "alpha": 0.7 } },
+    {
+      "geom": "point",
+      "position": "jitter",
+      "positionParams": { "width": 0.08, "height": 0, "seed": 3 },
+      "params": { "size": 2 }
+    }
+  ]
+}
+```
+
+```svelte fragment
+<GGPlot data={rows} aes={{ x: "run", y: "v" }}>
+  <GeomViolin trim alpha={0.7} />
+  <GeomPoint
+    position="jitter"
+    positionParams={{ width: 0.08, height: 0, seed: 3 }}
+    size={2}
+  />
+</GGPlot>
+```
+
+## Tile heatmap (discrete x/y, continuous fill)
+
+One tile per (x, y) pair; a sequential fill scale carries the value.
+<!-- adapted from examples/tile/heatmap/ -->
+
+```json complete
+{
+  "data": {
+    "values": [
+      { "day": "Mon", "hour": "am", "n": 3 },
+      { "day": "Mon", "hour": "pm", "n": 8 },
+      { "day": "Tue", "hour": "am", "n": 5 },
+      { "day": "Tue", "hour": "pm", "n": 12 }
+    ]
+  },
+  "layers": [
+    {
+      "geom": "tile",
+      "aes": {
+        "x": { "field": "day" },
+        "y": { "field": "hour" },
+        "fill": { "field": "n" }
+      }
+    }
+  ],
+  "scales": { "fill": { "type": "sequential", "scheme": "viridis" } }
+}
+```
+
+```svelte fragment
+<GGPlot data={rows} aes={{ x: "day", y: "hour", fill: "n" }}>
+  <ScaleFillContinuous scheme="viridis" />
+  <GeomTile />
+</GGPlot>
+```
+
+## Hex density heatmap
+
+Overplotted x/y pairs binned into hexagons; fill defaults to the stat's `count`. `bin_2d` is the rectangular twin.
+<!-- adapted from examples/hex/basic/ -->
+
+```json complete
+{
+  "data": {
+    "values": [
+      { "x": 1, "y": 1 },
+      { "x": 1.1, "y": 1.2 },
+      { "x": 0.9, "y": 0.8 },
+      { "x": 3, "y": 3 },
+      { "x": 3.2, "y": 2.9 },
+      { "x": 2.8, "y": 3.1 }
+    ]
+  },
+  "layers": [
+    {
+      "geom": "hex",
+      "aes": { "x": { "field": "x" }, "y": { "field": "y" } },
+      "params": { "bins": 6 }
+    }
+  ]
+}
+```
+
+```svelte fragment
+<GGPlot data={rows} aes={{ x: "x", y: "y" }}>
+  <GeomHex bins={6} />
+</GGPlot>
+```
+
+## Step chart (ECDF)
+
+Stairs through precomputed points; `direction: "hv"` is the ECDF convention. `step` takes stat `identity` only, so compute F̂(x) = i/n yourself.
+<!-- adapted from examples/step/ecdf/ -->
+
+```json complete
+{
+  "data": {
+    "values": [
+      { "x": 1.2, "y": 0.25 },
+      { "x": 2, "y": 0.5 },
+      { "x": 3.1, "y": 0.75 },
+      { "x": 4.5, "y": 1 }
+    ]
+  },
+  "layers": [
+    {
+      "geom": "step",
+      "aes": { "x": { "field": "x" }, "y": { "field": "y" } },
+      "params": { "direction": "hv" }
+    }
+  ]
+}
+```
+
+```svelte fragment
+<GGPlot data={rows} aes={{ x: "x", y: "y" }}>
+  <GeomStep direction="hv" />
+</GGPlot>
+```
+
+## Ribbon band with a center line
+
+Map ymin/ymax at plot level for the band; the line layer adds its own y.
+<!-- adapted from examples/ribbon/bounds/ -->
+
+```json complete
+{
+  "data": {
+    "values": [
+      { "t": 1, "lo": 2, "hi": 5, "mid": 3.4 },
+      { "t": 2, "lo": 3, "hi": 6, "mid": 4.5 },
+      { "t": 3, "lo": 2.5, "hi": 7, "mid": 4.8 },
+      { "t": 4, "lo": 4, "hi": 8, "mid": 6 }
+    ]
+  },
+  "aes": {
+    "x": { "field": "t" },
+    "ymin": { "field": "lo" },
+    "ymax": { "field": "hi" }
+  },
+  "layers": [
+    { "geom": "ribbon", "params": { "alpha": 0.35 } },
+    {
+      "geom": "line",
+      "aes": { "y": { "field": "mid" } },
+      "params": { "linewidth": 1.5 }
+    }
+  ]
+}
+```
+
+```svelte fragment
+<GGPlot data={rows} aes={{ x: "t", ymin: "lo", ymax: "hi" }}>
+  <GeomRibbon alpha={0.35} />
+  <GeomLine aes={{ y: "mid" }} linewidth={1.5} />
+</GGPlot>
+```
+
+## Horizontal boxplot (coord flip)
+
+Map the category to x and the value to y as usual, then flip — long labels get room.
+<!-- hand-authored; validated by skill-content test -->
+
+```json complete
+{
+  "data": {
+    "values": [
+      { "g": "a", "v": 1 },
+      { "g": "a", "v": 2 },
+      { "g": "a", "v": 3 },
+      { "g": "a", "v": 2.2 },
+      { "g": "b", "v": 4 },
+      { "g": "b", "v": 5 },
+      { "g": "b", "v": 6 },
+      { "g": "b", "v": 4.8 }
+    ]
+  },
+  "layers": [
+    {
+      "geom": "boxplot",
+      "aes": { "x": { "field": "g" }, "y": { "field": "v" } }
+    }
+  ],
+  "coord": { "type": "flip" }
+}
+```
+
+```svelte fragment
+<GGPlot data={rows} aes={{ x: "g", y: "v" }}>
+  <CoordFlip />
+  <GeomBoxplot />
+</GGPlot>
+```
+
+## Smooth trend with per-layer aes override
+
+Both layers inherit x/y; only the point layer maps size. A layer channel set to `null` would drop an inherited one instead.
+<!-- adapted from examples/smooth/loess-scatter/ -->
+
+```json complete
+{
+  "data": {
+    "values": [
+      { "year": 1, "angle": 10, "w": 1 },
+      { "year": 2, "angle": 14, "w": 3 },
+      { "year": 3, "angle": 13, "w": 2 },
+      { "year": 4, "angle": 18, "w": 4 },
+      { "year": 5, "angle": 21, "w": 2 },
+      { "year": 6, "angle": 20, "w": 5 }
+    ]
+  },
+  "aes": { "x": { "field": "year" }, "y": { "field": "angle" } },
+  "layers": [
+    { "geom": "smooth", "params": { "method": "loess", "span": 0.9 } },
+    {
+      "geom": "point",
+      "aes": { "size": { "field": "w" } },
+      "params": { "alpha": 0.85 }
+    }
+  ]
+}
+```
+
+```svelte fragment
+<GGPlot data={rows} aes={{ x: "year", y: "angle" }}>
+  <GeomSmooth method="loess" span={0.9} />
+  <GeomPoint aes={{ size: "w" }} alpha={0.85} />
+</GGPlot>
+```
+
+## Map polygons (geom sf)
+
+Rows carry a `geometry` column of GeoJSON Geometry JSON strings, already projected; map no x/y — fill carries the value.
+<!-- adapted from examples/sf/basic/ -->
+
+```json complete
+{
+  "data": {
+    "values": [
+      {
+        "region": "A",
+        "rate": 12,
+        "geometry": "{\"type\":\"Polygon\",\"coordinates\":[[[0,0],[2,0],[1,2],[0,0]]]}"
+      },
+      {
+        "region": "B",
+        "rate": 28,
+        "geometry": "{\"type\":\"Polygon\",\"coordinates\":[[[2.2,0],[4.2,0],[3.2,2],[2.2,0]]]}"
+      }
+    ]
+  },
+  "layers": [
+    {
+      "geom": "sf",
+      "aes": { "fill": { "field": "rate" } },
+      "params": { "linewidth": 0.8 }
+    }
+  ]
+}
+```
+
+```svelte fragment
+<GGPlot data={regions} aes={{ fill: "rate" }}>
+  <GeomSf linewidth={0.8} />
+</GGPlot>
+```

--- a/skills/ggsvelte/references/scales-and-palettes.md
+++ b/skills/ggsvelte/references/scales-and-palettes.md
@@ -1,0 +1,295 @@
+<!-- Source of truth: packages/spec/src/schema-names.ts (scheme/shape/linetype names), packages/spec/src/capabilities.ts (SCALE_CAPABILITIES), scripts/gen-scale-children.ts (Scale* component generation), packages/spec/src/scale-*.ts helpers. Inventory tables are asserted complete by scripts/skill-content.test.ts. -->
+
+# Scales and palettes
+
+## Scale families
+
+`SCALE_CAPABILITIES` declares seven families. `scaleTypes` are the canonical
+post-normalize types; authored aliases never survive `normalize` (e.g. authored
+`type: "log"` becomes `{ "type": "linear", "transform": "log10" }` — trained
+models never report type `log`).
+
+| Family              | Aesthetics             | Canonical types                               | Transforms            | Authored aliases |
+| ------------------- | ---------------------- | --------------------------------------------- | --------------------- | ---------------- |
+| position-continuous | x, y                   | linear                                        | identity, log10, sqrt | log              |
+| position-binned     | x, y                   | binned                                        | identity, log10, sqrt | —                |
+| position-temporal   | x, y                   | time                                          | identity              | —                |
+| position-discrete   | x, y                   | band                                          | —                     | —                |
+| color-fill          | color, fill            | ordinal, sequential, binned, manual, identity | identity, log10, sqrt | —                |
+| numeric-style       | size, linewidth, alpha | sequential, ordinal, binned, manual, identity | identity              | —                |
+| finite-style        | shape, linetype        | ordinal, binned, manual, identity             | —                     | —                |
+
+**Ordering contract**: scale transforms run before stats and positions (a
+log10 x reshapes what `stat: "smooth"` sees). Coordinate transforms
+(`coord: {"type": "transform", ...}`) run after stats and preserve stat inputs.
+
+### Position scales (x/y)
+
+Options on any position scale (`PositionScaleSpec`):
+
+| Option        | Values / default                                            | Notes                                                                           |
+| ------------- | ----------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| `type`        | linear, binned, time, band (+ authored alias log)           | Omit to infer from field type                                                   |
+| `transform`   | identity (default), log10 (values > 0), sqrt (values >= 0)  | Only identity on time scales                                                    |
+| `domain`      | `[min, max]` (continuous/time) or full category list (band) | Pins the scale; out-of-domain data drops with a warning                         |
+| `oob`         | censor (default) or squish                                  | Applied to explicit source limits, before stats                                 |
+| `nice`        | boolean, default true                                       | Rounds inferred domain to tick-friendly bounds; ignored with `domain`           |
+| `zero`        | boolean                                                     | Bars/cols/areas force true on the measure axis; set false to override           |
+| `expand`      | `{ mult, add }`                                             | Default `{mult: 0.05, add: 0}` non-temporal; time axes default to zero          |
+| `breaks`      | numbers, or ISO strings on time scales                      | Explicit ticks; on binned scales these are bin boundaries, at most 65 (64 bins) |
+| `minorBreaks` | numbers                                                     | Minor gridlines; time scales use `dateMinorBreaks` instead                      |
+| `reverse`     | boolean, default false                                      | Flips output direction                                                          |
+| `labels`      | format string                                               | Time: strftime-style; numeric: `",d"`, `".1f"`, `".0%"`, `"~s"`                 |
+| `naValue`     | number or null (default)                                    | Substitute for missing positional values, after OOB, before transform           |
+| `guide`       | GuideSpec                                                   | Axis styling; band axes accept BandAxisGuideSpec                                |
+
+Helper functions additionally accept `limits` as authoring sugar for `domain`
+(supplying both throws). `scaleXReverse`/`scaleYReverse` omit the `transform`
+and `reverse` options by type. Binned integer ids stay private; guides and
+events use semantic values.
+
+```json fragment
+"scales": { "x": { "type": "linear", "transform": "log10", "limits": [1, 1000] } }
+```
+
+### Color and fill scales
+
+Five types, each gating its own option set (`ColorScaleSpec`; forbidden
+options fail schema validation):
+
+- **ordinal** — discrete categories. `scheme` (categorical name, or a
+  sequential name for discrete sampling), `range` (explicit hex list),
+  `domain`, `domainMode` (`grow` default preserves assignments across filters;
+  `data` rebuilds), `reverse`, `onExhaust`. No transform, breaks, oob, labels.
+- **sequential** — continuous ramp. `scheme` or `range` (>= 2 colors
+  interpolated), `transform`, `domain` `[min, max]`, `breaks` (colorbar
+  reference ticks), `oob`, `labels`, temporal parser options. Guide plan:
+  `colorbar`.
+- **binned** — color steps. Same shape as sequential but `breaks` are ordered
+  boundaries (at most 65). Guide plan: `colorsteps`.
+- **manual** — explicit mapping. `range` is required and must supply one color
+  per `domain` value (mismatched lengths are the `color-manual-domain-range`
+  error). No scheme, breaks, reverse, oob, labels, onExhaust.
+- **identity** — data cells are the colors. Only `naValue`, `unknownValue`,
+  and `guide` are allowed. Each source value is validated as `#rgb`/`#rrggbb`;
+  invalid cells map to `unknownValue` with a bounded warning. The guide is
+  suppressed by default — force it with `"guide": {"type": "legend", "force": true}`.
+
+`naValue` colors null/missing cells; `unknownValue` colors invalid,
+out-of-domain, or unmapped cells. Both default to `#999999`. Bounded warnings
+count how many cells fell back. Guide plans are `discrete` (ordinal, manual,
+identity), `colorbar` (sequential), or `colorsteps` (binned); identity and
+single-entry manual guides need `force: true` to appear. When `type` is
+omitted, a named `scheme` selects its family (categorical → ordinal,
+sequential name → sequential).
+
+### Style scales
+
+- **numeric-style** (size, linewidth, alpha): sequential, ordinal, binned,
+  manual, identity — numeric output ranges instead of colors, identity
+  transform only. `sizeUnit` applies to size only (alpha's schema drops it so
+  it cannot no-op silently). Manual domain/range length mismatch is
+  `style-manual-domain-range`. Extra size helpers: `scaleSizeArea` /
+  `scale_size_area` (area-true scaling, ggplot2's recommended default),
+  `scaleSizeBinnedArea` / `scale_size_binned_area`, and `scaleRadius` /
+  `scale_radius`. Bare ggplot2 names `scale_size`, `scale_linewidth`,
+  `scale_alpha` alias the continuous helpers.
+- **finite-style** (shape, linetype): ordinal, binned, manual, identity over a
+  closed symbol set (see the tables below) — no transform. Manual ranges and
+  identity values must be members of the audited name lists.
+
+## The Scale* component system
+
+98 generated `.svelte` shells plus 28 alias exports plus the hand-written
+`<Scale>` escape hatch = 127 `Scale*` components exported from
+`@ggsvelte/svelte`. Shells are generated by `bun run scale:children:gen`
+(scripts/gen-scale-children.ts; `--check` is the drift gate). Do not edit them
+by hand.
+
+Which variants exist per channel (aliases in parentheses are extra export
+names for the same component):
+
+| Variant                          | X, Y | Color, Fill | Size                   | Linewidth                   | Alpha                   | Shape                   | Linetype                   |
+| -------------------------------- | ---- | ----------- | ---------------------- | --------------------------- | ----------------------- | ----------------------- | -------------------------- |
+| Continuous                       | yes  | yes         | yes                    | yes                         | yes                     | —                       | —                          |
+| Discrete                         | yes  | yes         | yes (ScaleSizeOrdinal) | yes (ScaleLinewidthOrdinal) | yes (ScaleAlphaOrdinal) | yes (ScaleShapeOrdinal) | yes (ScaleLinetypeOrdinal) |
+| Binned                           | yes  | yes         | yes                    | yes                         | yes                     | yes                     | yes                        |
+| Log10, Sqrt                      | yes  | yes         | —                      | —                           | —                       | —                       | —                          |
+| Reverse                          | yes  | —           | —                      | —                           | —                       | —                       | —                          |
+| Date, Datetime                   | yes  | yes         | yes                    | yes                         | yes                     | —                       | —                          |
+| Time                             | yes  | —           | —                      | —                           | —                       | —                       | —                          |
+| Manual, Identity                 | —    | yes         | yes                    | yes                         | yes                     | yes                     | yes                        |
+| Ordinal                          | —    | yes         | (alias)                | (alias)                     | (alias)                 | (alias)                 | (alias)                    |
+| Brewer, Distiller, Fermenter     | —    | yes         | —                      | —                           | —                       | —                       | —                          |
+| Steps, Steps2, Stepsn            | —    | yes         | —                      | —                           | —                       | —                       | —                          |
+| Gradient, Gradient2, Gradientn   | —    | yes         | —                      | —                           | —                       | —                       | —                          |
+| Hue, Grey                        | —    | yes         | —                      | —                           | —                       | —                       | —                          |
+| ViridisC, ViridisD, ViridisB     | —    | yes         | —                      | —                           | —                       | —                       | —                          |
+| Area, BinnedArea (+ ScaleRadius) | —    | —           | yes                    | —                           | —                       | —                       | —                          |
+
+Every `ScaleColor*` component also exports a British `ScaleColour*` alias (24
+aliases; same file, same binding). `ScaleColorOrdinal` is a distinct component
+(explicit ordinal family), unlike the style-channel Ordinal names which are
+re-exports of the Discrete shells.
+
+**Function-twin pattern.** Every shell wraps one camelCase helper from
+`@ggsvelte/spec`; the component's props are that helper's options object
+flattened (undefined props are stripped). Each camelCase helper has a
+binding-identical ggplot2 snake_case twin, and every Color helper has a
+binding-identical Colour twin: `scaleXLog10` is `scale_x_log10`;
+`scaleColourBrewer` is `scaleColorBrewer` is `scale_color_brewer` is
+`scale_colour_brewer`. Brewer/Distiller/Fermenter and Viridis helpers accept
+ggplot2's `palette`/`option` (maps to `scheme`) and `direction` (`-1` sets
+`reverse: true`).
+
+```svelte fragment
+<GGPlot
+  data={rows}
+  aes={{ x: "day", y: "kwh", color: "site" }}
+  layers={[{ geom: "line" }]}
+>
+  <ScaleXDate dateBreaks="1 month" dateLabels="%b %Y" />
+  <ScaleColorBrewer palette="Dark2" />
+</GGPlot>
+```
+
+**Escape hatch.** `<Scale value={scalesFragment} />` registers a raw `Scales`
+fragment — use it for computed scales or variable references. It is
+byte-identity-preserving: `value` is not routed through any helper.
+
+## Palettes
+
+### Categorical schemes (14)
+
+| Scheme               | Description                                                       |
+| -------------------- | ----------------------------------------------------------------- |
+| observable10         | Default: 10-hue Observable 10 palette                             |
+| ipsum                | hrbrthemes ipsum palette, published source order                  |
+| flexoki              | Flexoki light-background qualitative palette                      |
+| tableau10            | Tableau 10 qualitative palette                                    |
+| colorblind           | ggthemes 8-color colorblind-safe palette                          |
+| Set1                 | ColorBrewer qualitative, saturated primaries                      |
+| Set2                 | ColorBrewer qualitative, muted pastels                            |
+| Set3                 | ColorBrewer qualitative, light 12-class                           |
+| Dark2                | ColorBrewer qualitative, dark tones                               |
+| Paired               | ColorBrewer qualitative, light/dark pairs                         |
+| Accent               | ColorBrewer qualitative, accented mix                             |
+| hue                  | Evenly spaced HSL hues — the ggplot2-shaped `scale_*_hue` default |
+| grey                 | Greyscale discrete ramp (`scale_*_grey`)                          |
+| gray (alias of grey) | Same scheme, US spelling — identical colors                       |
+
+`grey` and `gray` are the same scheme; both spellings validate and produce
+identical output. Sequential scheme names are also legal on ordinal scales
+(discrete sampling along the ramp — what `scale_*_viridis_d` does).
+
+**Palette exhaustion** (`onExhaust`, ordinal scales only): `cycle` (default)
+restarts the palette and emits the bounded `palette-exhausted` warning once;
+`error` throws the `palette-exhausted` pipeline error instead.
+
+### Sequential schemes (20)
+
+| Scheme   | Description                                            |
+| -------- | ------------------------------------------------------ |
+| viridis  | Default sequential: perceptually uniform purple→yellow |
+| magma    | Perceptually uniform black→red→pale yellow             |
+| plasma   | Perceptually uniform blue→magenta→yellow               |
+| inferno  | Perceptually uniform black→orange→yellow               |
+| cividis  | Colorblind-optimized blue→yellow                       |
+| turbo    | Google turbo rainbow (high contrast, not uniform)      |
+| Blues    | ColorBrewer single-hue light→dark blue                 |
+| Greens   | ColorBrewer single-hue light→dark green                |
+| Reds     | ColorBrewer single-hue light→dark red                  |
+| Oranges  | ColorBrewer single-hue light→dark orange               |
+| Purples  | ColorBrewer single-hue light→dark purple               |
+| Greys    | ColorBrewer single-hue light→dark grey                 |
+| YlOrRd   | ColorBrewer multi-hue yellow→orange→red                |
+| YlGnBu   | ColorBrewer multi-hue yellow→green→blue                |
+| BuPu     | ColorBrewer multi-hue blue→purple                      |
+| RdYlBu   | ColorBrewer diverging red→yellow→blue                  |
+| RdBu     | ColorBrewer diverging red→white→blue                   |
+| BrBG     | ColorBrewer diverging brown→teal                       |
+| Spectral | ColorBrewer diverging rainbow                          |
+| PuOr     | ColorBrewer diverging purple→orange                    |
+
+### Finite symbol sets (default assignment order)
+
+| Point shapes (6) | Linetypes (6) |
+| ---------------- | ------------- |
+| circle           | solid         |
+| triangle         | dashed        |
+| square           | dotted        |
+| diamond          | dotdash       |
+| plus             | longdash      |
+| cross            | twodash       |
+
+## Temporal scales
+
+**Auto-inference.** ISO dates and date-times, four-digit-year strings,
+year-months, month-years, and year-quarters infer a time scale after bounded
+sampling plus whole-column validation. Ambiguous ordered dates (`01/02/2026`)
+stay discrete — set `"parse": "dmy"` or `"parse": "mdy"`. For year-like
+identifiers that are labels, not instants, force `{"type": "band"}`. Never
+preprocess dates into row indexes. Explicit `linear`/`binned` (including
+authored `log`) disables temporal inference, so numeric strings stay
+quantitative. Explicit ordinal color/fill keeps temporal-looking labels as
+separate groups; sequential temporal color/fill parses domains and uses
+calendar legend labels.
+
+**Time-scale options** (position and sequential/binned color scales):
+
+| Option                          | Values / default                                                                                                                                                                                                            |
+| ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `parse`                         | Named parser (`"iso"`, `"year"`, `"ym"`, `"my"`, `"yq"`, `"ymd"`, `"ydm"`, `"mdy"`, `"myd"`, `"dmy"`, `"dym"`, and their `_hm`/`_hms` variants), exact `{ "format": "..." }`, or `{ "epoch": "seconds" \| "milliseconds" }` |
+| `parseFailure`                  | `error` (default) stops with bounded evidence; `censor` drops invalid values to missing with a warning. Censoring requires an explicit parser                                                                               |
+| `temporalKind`                  | `date` (calendar dates), `datetime` (instants), `time` (position only: time of day)                                                                                                                                         |
+| `timezone`                      | IANA zone for timezone-less input; default `UTC`                                                                                                                                                                            |
+| `disambiguation`                | DST gap/fold policy: `reject` (default), `earlier`, `later`, `compatible`                                                                                                                                                   |
+| `dateBreaks`, `dateMinorBreaks` | `"<step> <unit>"`, e.g. `"2 weeks"`; units millisecond…year, step 1–1,000,000                                                                                                                                               |
+| `dateLabels`                    | Strict tokens: `%Y %y %m %b %B %d %e %a %A %H %I %M %S %L %p %q %z %Z %%`                                                                                                                                                   |
+| `locale`                        | BCP 47 tag for labels; default `en-US`                                                                                                                                                                                      |
+| `weekStart`                     | Weekday for week boundaries; default `monday`                                                                                                                                                                               |
+
+**Precedence**: explicit `breaks` outrank `dateBreaks`; `dateLabels` outranks
+`labels`. Authored labels are preserved with a diagnostic — never silently
+rotated, thinned, or truncated. Automatic temporal labels use measured panel
+extent and calendar boundaries; inspect `model.guidePlans` for the selected
+interval and labels.
+
+**Authoring surfaces.** The `gg()` builder has `.scaleXDate()`,
+`.scaleXDatetime()`, `.scaleXTime()` (and Y forms), each with component twins
+(`<ScaleXDate/>` …) and function twins (`scaleXDate`/`scale_x_date` …).
+Date helpers serialize mapped authoring `Date` cells as calendar dates;
+datetime helpers preserve instants. `scaleXTime`/`scale_x_time` is time-of-day
+only: portable numbers are **seconds since midnight** (mapped to epoch ms on
+1970-01-01Z), `Date` cells use the UTC clock portion, and default labels are
+`%H:%M:%S`.
+
+**Parser helpers** (from `@ggsvelte/spec`): `ymd`, `ydm`, `mdy`, `myd`, `dmy`,
+`dym` (each also as `_hm`/`_hms`, e.g. `dmy_hms`), `ym`, `my`, `yq`,
+`parseTemporalFormat(value, format)`, `fromEpochSeconds`,
+`fromEpochMilliseconds`. Each accepts one value or an array, returns `Date`(s),
+and throws `TemporalParseError` on failure — use them to convert columns at
+authoring time instead of hand-rolled parsing.
+
+```json complete
+{
+  "data": {
+    "values": [
+      { "day": "2026-01-05", "kwh": 12.1, "site": "north" },
+      { "day": "2026-02-02", "kwh": 14.9, "site": "north" },
+      { "day": "2026-01-05", "kwh": 13.4, "site": "south" },
+      { "day": "2026-02-02", "kwh": 16.0, "site": "south" }
+    ]
+  },
+  "aes": {
+    "x": { "field": "day" },
+    "y": { "field": "kwh" },
+    "color": { "field": "site" }
+  },
+  "layers": [{ "geom": "line" }],
+  "scales": {
+    "x": { "type": "time", "dateBreaks": "1 month", "dateLabels": "%b %Y" },
+    "color": { "type": "ordinal", "scheme": "Dark2" }
+  }
+}
+```


### PR DESCRIPTION
## What

Rewrite `skills/ggsvelte/` (shipped in the `@ggsvelte/svelte` tarball) for the current API, and add tests that keep it honest.

The old skill taught 16 of 49 geoms, 6 of 28 stats, 4 of 18 themes, and no color schemes. Its one Svelte example passed `layers` as a prop, it never mentioned child components, and it said nothing about the seven grammar props deprecated in 0.11.0.

## Changes

- **`SKILL.md`** (275 lines): child-layer composition as the canonical Svelte form; JSON `PortableSpec` + `validate()` + headless render as the agent surface; the `gg()` builder introduced; the JSON-vs-props aes rule drawn as a table; precedence and merge semantics verified against source; deprecation callout with the codemod; position scoping derived from the per-geom schema unions (the sibling prompts' "identity only elsewhere" rule is wrong — violin takes dodge, text/label take nudge).
- **`references/`** (5 new files): exhaustive inventories — all 49 geoms with components, defaults, channels, and allowed positions; all 28 stats with computed columns; every scale option and the `Scale*` component matrix; all 34 color schemes; 17 themes with the `grey`/`gray` alias; the full interaction surface; 12 long-tail recipes as validated JSON plus Svelte twins.
- **`scripts/skill-sync.test.ts`**: whole-tree recursive byte equality (was SKILL.md only); sync via `rsync -a --delete`.
- **`scripts/skill-content.test.ts`** (new): every fence flagged; every `json complete` fence passes `normalize` + `validate(spec, {})`; every Svelte fence scanned with `deprecatedGrammarPropPattern()`; structured inventory completeness against the spec catalogs — adding a geom, theme, or scheme upstream turns the skill red until documented.
- **`scripts/ci-routing.test.ts`**: pins references-path routing to the svelte lane.
- Changeset: `@ggsvelte/svelte` patch (shipped skill artifact, no API change).

## Verification

- `bun test scripts/skill-sync.test.ts scripts/skill-content.test.ts scripts/ci-routing.test.ts` — 113 pass on top of current main.
- `bun run lint:md` clean; `npm pack --dry-run` ships SKILL.md plus all five references.
- Every JSON recipe in the skill tree is machine-validated by the new test; inventory tables were copied from `schema-catalog.ts` / `schema-names.ts`, not memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
