### PR TITLE
docs: hub cleanup — drop Getting started noise, kill pre-0.1 guide, rename Upgrade guide

### DIFF
--- a/apps/docs/src/lib/catalog/guide.ts
+++ b/apps/docs/src/lib/catalog/guide.ts
@@ -187,17 +187,10 @@ export const GUIDE_CATALOG = [
   },
   {
     slug: "upgrading",
-    title: "Upgrade in five minutes",
+    title: "Upgrade guide",
     description: "Check versions, apply fixture-backed changes, and verify each 0.x transition.",
     section: "Release",
     navigationOrder: 60,
-  },
-  {
-    slug: "migrating-pre-0-1",
-    title: "Migrating pre-0.1 interactions",
-    description: "Move from tooltip and brush props to semantic interaction capabilities.",
-    section: "Release",
-    navigationOrder: 61,
   },
 ] as const satisfies readonly GuideCatalogEntry[];
 

--- a/apps/docs/src/lib/generated/routes.ts
+++ b/apps/docs/src/lib/generated/routes.ts
@@ -2350,7 +2350,7 @@ export const DOCS_ROUTES = [
   },
   {
     path: "/guide/upgrading",
-    title: "Upgrade in five minutes — ggsvelte",
+    title: "Upgrade guide — ggsvelte",
     description: "Check versions, apply fixture-backed changes, and verify each 0.x transition.",
     canonicalPath: "/guide/upgrading",
     kind: "page",
@@ -2359,7 +2359,7 @@ export const DOCS_ROUTES = [
     shell: "docs",
     navigation: {
       section: "Release",
-      label: "Upgrade in five minutes",
+      label: "Upgrade guide",
       order: 60,
     },
     headings: [
@@ -2507,38 +2507,6 @@ export const DOCS_ROUTES = [
         id: "deprecated-type-aliases",
         title: "Deprecated type aliases",
         level: 3,
-      },
-    ],
-  },
-  {
-    path: "/guide/migrating-pre-0-1",
-    title: "Migrating pre-0.1 interactions — ggsvelte",
-    description: "Move from tooltip and brush props to semantic interaction capabilities.",
-    canonicalPath: "/guide/migrating-pre-0-1",
-    kind: "page",
-    index: true,
-    sitemap: true,
-    shell: "docs",
-    navigation: {
-      section: "Release",
-      label: "Migrating pre-0.1 interactions",
-      order: 61,
-    },
-    headings: [
-      {
-        id: "rename-the-props-and-callbacks",
-        title: "Rename the props and callbacks",
-        level: 2,
-      },
-      {
-        id: "migrate-payload-handling",
-        title: "Migrate payload handling",
-        level: 2,
-      },
-      {
-        id: "migrate-custom-tooltip-snippets",
-        title: "Migrate custom tooltip snippets",
-        level: 2,
       },
     ],
   },
@@ -3651,11 +3619,7 @@ export const GUIDE_NAVIGATION = [
     entries: [
       {
         path: "/guide/upgrading",
-        label: "Upgrade in five minutes",
-      },
-      {
-        path: "/guide/migrating-pre-0-1",
-        label: "Migrating pre-0.1 interactions",
+        label: "Upgrade guide",
       },
     ],
   },

--- a/apps/docs/src/lib/generated/search-index.ts
+++ b/apps/docs/src/lib/generated/search-index.ts
@@ -3964,20 +3964,20 @@ export const DOCS_SEARCH_INDEX = [
   {
     id: "page:guide-upgrading",
     kind: "page",
-    title: "Upgrade in five minutes",
+    title: "Upgrade guide",
     summary: "Check versions, apply fixture-backed changes, and verify each 0.x transition.",
     href: "/guide/upgrading",
     keywords: ["Release"],
-    exact: ["Upgrade in five minutes"],
+    exact: ["Upgrade guide"],
   },
   {
     id: "heading:guide-upgrading:five-minute-path",
     kind: "heading",
     title: "Five-minute path",
     summary:
-      "Five-minute path in Upgrade in five minutes. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
+      "Five-minute path in Upgrade guide. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
     href: "/guide/upgrading#five-minute-path",
-    keywords: ["Upgrade in five minutes", "Release"],
+    keywords: ["Upgrade guide", "Release"],
     exact: ["Five-minute path"],
   },
   {
@@ -3985,9 +3985,9 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "0.11 to 0.12",
     summary:
-      "0.11 to 0.12 in Upgrade in five minutes. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
+      "0.11 to 0.12 in Upgrade guide. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
     href: "/guide/upgrading#0-11-to-0-12",
-    keywords: ["Upgrade in five minutes", "Release"],
+    keywords: ["Upgrade guide", "Release"],
     exact: ["0.11 to 0.12"],
   },
   {
@@ -3995,9 +3995,9 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Manual color domain/range diagnostic code",
     summary:
-      "Manual color domain/range diagnostic code in Upgrade in five minutes. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
+      "Manual color domain/range diagnostic code in Upgrade guide. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
     href: "/guide/upgrading#manual-color-domain-range-diagnostic-code",
-    keywords: ["Upgrade in five minutes", "Release"],
+    keywords: ["Upgrade guide", "Release"],
     exact: ["Manual color domain/range diagnostic code"],
   },
   {
@@ -4005,9 +4005,9 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "0.10 to 0.11",
     summary:
-      "0.10 to 0.11 in Upgrade in five minutes. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
+      "0.10 to 0.11 in Upgrade guide. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
     href: "/guide/upgrading#0-10-to-0-11",
-    keywords: ["Upgrade in five minutes", "Release"],
+    keywords: ["Upgrade guide", "Release"],
     exact: ["0.10 to 0.11"],
   },
   {
@@ -4015,9 +4015,9 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Compose the theme as a child layer",
     summary:
-      "Compose the theme as a child layer in Upgrade in five minutes. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
+      "Compose the theme as a child layer in Upgrade guide. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
     href: "/guide/upgrading#compose-the-theme-as-a-child-layer",
-    keywords: ["Upgrade in five minutes", "Release"],
+    keywords: ["Upgrade guide", "Release"],
     exact: ["Compose the theme as a child layer"],
   },
   {
@@ -4025,9 +4025,9 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Compose scales as child layers",
     summary:
-      "Compose scales as child layers in Upgrade in five minutes. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
+      "Compose scales as child layers in Upgrade guide. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
     href: "/guide/upgrading#compose-scales-as-child-layers",
-    keywords: ["Upgrade in five minutes", "Release"],
+    keywords: ["Upgrade guide", "Release"],
     exact: ["Compose scales as child layers"],
   },
   {
@@ -4035,9 +4035,9 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Compose coord as a child layer",
     summary:
-      "Compose coord as a child layer in Upgrade in five minutes. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
+      "Compose coord as a child layer in Upgrade guide. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
     href: "/guide/upgrading#compose-coord-as-a-child-layer",
-    keywords: ["Upgrade in five minutes", "Release"],
+    keywords: ["Upgrade guide", "Release"],
     exact: ["Compose coord as a child layer"],
   },
   {
@@ -4045,9 +4045,9 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Compose facet as a child layer",
     summary:
-      "Compose facet as a child layer in Upgrade in five minutes. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
+      "Compose facet as a child layer in Upgrade guide. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
     href: "/guide/upgrading#compose-facet-as-a-child-layer",
-    keywords: ["Upgrade in five minutes", "Release"],
+    keywords: ["Upgrade guide", "Release"],
     exact: ["Compose facet as a child layer"],
   },
   {
@@ -4055,9 +4055,9 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Compose labs as a child layer",
     summary:
-      "Compose labs as a child layer in Upgrade in five minutes. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
+      "Compose labs as a child layer in Upgrade guide. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
     href: "/guide/upgrading#compose-labs-as-a-child-layer",
-    keywords: ["Upgrade in five minutes", "Release"],
+    keywords: ["Upgrade guide", "Release"],
     exact: ["Compose labs as a child layer"],
   },
   {
@@ -4065,9 +4065,9 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Compose guides as child layers",
     summary:
-      "Compose guides as child layers in Upgrade in five minutes. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
+      "Compose guides as child layers in Upgrade guide. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
     href: "/guide/upgrading#compose-guides-as-child-layers",
-    keywords: ["Upgrade in five minutes", "Release"],
+    keywords: ["Upgrade guide", "Release"],
     exact: ["Compose guides as child layers"],
   },
   {
@@ -4075,9 +4075,9 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Compose legend as a child layer",
     summary:
-      "Compose legend as a child layer in Upgrade in five minutes. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
+      "Compose legend as a child layer in Upgrade guide. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
     href: "/guide/upgrading#compose-legend-as-a-child-layer",
-    keywords: ["Upgrade in five minutes", "Release"],
+    keywords: ["Upgrade guide", "Release"],
     exact: ["Compose legend as a child layer"],
   },
   {
@@ -4085,9 +4085,9 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Migrate the grammar props with the codemod",
     summary:
-      "Migrate the grammar props with the codemod in Upgrade in five minutes. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
+      "Migrate the grammar props with the codemod in Upgrade guide. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
     href: "/guide/upgrading#migrate-the-grammar-props-with-the-codemod",
-    keywords: ["Upgrade in five minutes", "Release"],
+    keywords: ["Upgrade guide", "Release"],
     exact: ["Migrate the grammar props with the codemod"],
   },
   {
@@ -4095,9 +4095,9 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Diagnostic handlers receive PlotDiagnostic",
     summary:
-      "Diagnostic handlers receive PlotDiagnostic in Upgrade in five minutes. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
+      "Diagnostic handlers receive PlotDiagnostic in Upgrade guide. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
     href: "/guide/upgrading#diagnostic-handlers-receive-plotdiagnostic",
-    keywords: ["Upgrade in five minutes", "Release"],
+    keywords: ["Upgrade guide", "Release"],
     exact: ["Diagnostic handlers receive PlotDiagnostic"],
   },
   {
@@ -4105,9 +4105,9 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "0.7 to 0.8",
     summary:
-      "0.7 to 0.8 in Upgrade in five minutes. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
+      "0.7 to 0.8 in Upgrade guide. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
     href: "/guide/upgrading#0-7-to-0-8",
-    keywords: ["Upgrade in five minutes", "Release"],
+    keywords: ["Upgrade guide", "Release"],
     exact: ["0.7 to 0.8"],
   },
   {
@@ -4115,9 +4115,9 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Map style semantics instead of precomputing outputs",
     summary:
-      "Map style semantics instead of precomputing outputs in Upgrade in five minutes. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
+      "Map style semantics instead of precomputing outputs in Upgrade guide. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
     href: "/guide/upgrading#map-style-semantics-instead-of-precomputing-outputs",
-    keywords: ["Upgrade in five minutes", "Release"],
+    keywords: ["Upgrade guide", "Release"],
     exact: ["Map style semantics instead of precomputing outputs"],
   },
   {
@@ -4125,9 +4125,9 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Move guide layout into the guide API",
     summary:
-      "Move guide layout into the guide API in Upgrade in five minutes. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
+      "Move guide layout into the guide API in Upgrade guide. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
     href: "/guide/upgrading#move-guide-layout-into-the-guide-api",
-    keywords: ["Upgrade in five minutes", "Release"],
+    keywords: ["Upgrade guide", "Release"],
     exact: ["Move guide layout into the guide API"],
   },
   {
@@ -4135,9 +4135,9 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "0.8 to 0.9",
     summary:
-      "0.8 to 0.9 in Upgrade in five minutes. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
+      "0.8 to 0.9 in Upgrade guide. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
     href: "/guide/upgrading#0-8-to-0-9",
-    keywords: ["Upgrade in five minutes", "Release"],
+    keywords: ["Upgrade guide", "Release"],
     exact: ["0.8 to 0.9"],
   },
   {
@@ -4145,9 +4145,9 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Constrain the data rectangle instead of the outer box",
     summary:
-      "Constrain the data rectangle instead of the outer box in Upgrade in five minutes. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
+      "Constrain the data rectangle instead of the outer box in Upgrade guide. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
     href: "/guide/upgrading#constrain-the-data-rectangle-instead-of-the-outer-box",
-    keywords: ["Upgrade in five minutes", "Release"],
+    keywords: ["Upgrade guide", "Release"],
     exact: ["Constrain the data rectangle instead of the outer box"],
   },
   {
@@ -4155,9 +4155,9 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "0.6 to 0.7",
     summary:
-      "0.6 to 0.7 in Upgrade in five minutes. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
+      "0.6 to 0.7 in Upgrade guide. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
     href: "/guide/upgrading#0-6-to-0-7",
-    keywords: ["Upgrade in five minutes", "Release"],
+    keywords: ["Upgrade guide", "Release"],
     exact: ["0.6 to 0.7"],
   },
   {
@@ -4165,9 +4165,9 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Choose explicit color/fill families",
     summary:
-      "Choose explicit color/fill families in Upgrade in five minutes. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
+      "Choose explicit color/fill families in Upgrade guide. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
     href: "/guide/upgrading#choose-explicit-color-fill-families",
-    keywords: ["Upgrade in five minutes", "Release"],
+    keywords: ["Upgrade guide", "Release"],
     exact: ["Choose explicit color/fill families"],
   },
   {
@@ -4175,9 +4175,9 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "0.5 to 0.6",
     summary:
-      "0.5 to 0.6 in Upgrade in five minutes. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
+      "0.5 to 0.6 in Upgrade guide. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
     href: "/guide/upgrading#0-5-to-0-6",
-    keywords: ["Upgrade in five minutes", "Release"],
+    keywords: ["Upgrade guide", "Release"],
     exact: ["0.5 to 0.6"],
   },
   {
@@ -4185,9 +4185,9 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Move position transforms before statistics",
     summary:
-      "Move position transforms before statistics in Upgrade in five minutes. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
+      "Move position transforms before statistics in Upgrade guide. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
     href: "/guide/upgrading#move-position-transforms-before-statistics",
-    keywords: ["Upgrade in five minutes", "Release"],
+    keywords: ["Upgrade guide", "Release"],
     exact: ["Move position transforms before statistics"],
   },
   {
@@ -4195,9 +4195,9 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Review limits, zoom, and transformed units",
     summary:
-      "Review limits, zoom, and transformed units in Upgrade in five minutes. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
+      "Review limits, zoom, and transformed units in Upgrade guide. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
     href: "/guide/upgrading#review-limits-zoom-and-transformed-units",
-    keywords: ["Upgrade in five minutes", "Release"],
+    keywords: ["Upgrade guide", "Release"],
     exact: ["Review limits, zoom, and transformed units"],
   },
   {
@@ -4205,9 +4205,9 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Update scale and interaction inspection",
     summary:
-      "Update scale and interaction inspection in Upgrade in five minutes. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
+      "Update scale and interaction inspection in Upgrade guide. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
     href: "/guide/upgrading#update-scale-and-interaction-inspection",
-    keywords: ["Upgrade in five minutes", "Release"],
+    keywords: ["Upgrade guide", "Release"],
     exact: ["Update scale and interaction inspection"],
   },
   {
@@ -4215,9 +4215,9 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "0.2 to 0.3",
     summary:
-      "0.2 to 0.3 in Upgrade in five minutes. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
+      "0.2 to 0.3 in Upgrade guide. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
     href: "/guide/upgrading#0-2-to-0-3",
-    keywords: ["Upgrade in five minutes", "Release"],
+    keywords: ["Upgrade guide", "Release"],
     exact: ["0.2 to 0.3"],
   },
   {
@@ -4225,9 +4225,9 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Replace custom hit indexes with CandidateStore",
     summary:
-      "Replace custom hit indexes with CandidateStore in Upgrade in five minutes. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
+      "Replace custom hit indexes with CandidateStore in Upgrade guide. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
     href: "/guide/upgrading#replace-custom-hit-indexes-with-candidatestore",
-    keywords: ["Upgrade in five minutes", "Release"],
+    keywords: ["Upgrade guide", "Release"],
     exact: ["Replace custom hit indexes with CandidateStore"],
   },
   {
@@ -4235,9 +4235,9 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "0.1 to 0.2",
     summary:
-      "0.1 to 0.2 in Upgrade in five minutes. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
+      "0.1 to 0.2 in Upgrade guide. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
     href: "/guide/upgrading#0-1-to-0-2",
-    keywords: ["Upgrade in five minutes", "Release"],
+    keywords: ["Upgrade guide", "Release"],
     exact: ["0.1 to 0.2"],
   },
   {
@@ -4245,9 +4245,9 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Optional: shared interaction state with a controller",
     summary:
-      "Optional: shared interaction state with a controller in Upgrade in five minutes. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
+      "Optional: shared interaction state with a controller in Upgrade guide. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
     href: "/guide/upgrading#optional-shared-interaction-state-with-a-controller",
-    keywords: ["Upgrade in five minutes", "Release"],
+    keywords: ["Upgrade guide", "Release"],
     exact: ["Optional: shared interaction state with a controller"],
   },
   {
@@ -4255,49 +4255,10 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Deprecated type aliases",
     summary:
-      "Deprecated type aliases in Upgrade in five minutes. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
+      "Deprecated type aliases in Upgrade guide. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
     href: "/guide/upgrading#deprecated-type-aliases",
-    keywords: ["Upgrade in five minutes", "Release"],
+    keywords: ["Upgrade guide", "Release"],
     exact: ["Deprecated type aliases"],
-  },
-  {
-    id: "page:guide-migrating-pre-0-1",
-    kind: "page",
-    title: "Migrating pre-0.1 interactions",
-    summary: "Move from tooltip and brush props to semantic interaction capabilities.",
-    href: "/guide/migrating-pre-0-1",
-    keywords: ["Release"],
-    exact: ["Migrating pre-0.1 interactions"],
-  },
-  {
-    id: "heading:guide-migrating-pre-0-1:rename-the-props-and-callbacks",
-    kind: "heading",
-    title: "Rename the props and callbacks",
-    summary:
-      "Rename the props and callbacks in Migrating pre-0.1 interactions. Move from tooltip and brush props to semantic interaction capabilities.",
-    href: "/guide/migrating-pre-0-1#rename-the-props-and-callbacks",
-    keywords: ["Migrating pre-0.1 interactions", "Release"],
-    exact: ["Rename the props and callbacks"],
-  },
-  {
-    id: "heading:guide-migrating-pre-0-1:migrate-payload-handling",
-    kind: "heading",
-    title: "Migrate payload handling",
-    summary:
-      "Migrate payload handling in Migrating pre-0.1 interactions. Move from tooltip and brush props to semantic interaction capabilities.",
-    href: "/guide/migrating-pre-0-1#migrate-payload-handling",
-    keywords: ["Migrating pre-0.1 interactions", "Release"],
-    exact: ["Migrate payload handling"],
-  },
-  {
-    id: "heading:guide-migrating-pre-0-1:migrate-custom-tooltip-snippets",
-    kind: "heading",
-    title: "Migrate custom tooltip snippets",
-    summary:
-      "Migrate custom tooltip snippets in Migrating pre-0.1 interactions. Move from tooltip and brush props to semantic interaction capabilities.",
-    href: "/guide/migrating-pre-0-1#migrate-custom-tooltip-snippets",
-    keywords: ["Migrating pre-0.1 interactions", "Release"],
-    exact: ["Migrate custom tooltip snippets"],
   },
   {
     id: "page:interactions-brush-zoom",

--- a/apps/docs/src/routes/docs/+page.svelte
+++ b/apps/docs/src/routes/docs/+page.svelte
@@ -38,10 +38,13 @@
       .replaceAll(/^-+|-+$/g, "")}`;
   }
 
-  // Overview is this page; omit it from the chapter list.
+  // Overview is this page; Getting started is already in Start here.
   const chapters = GUIDE_NAVIGATION.map((group) => ({
     section: group.section,
-    entries: group.entries.filter((entry) => entry.path !== "/docs"),
+    entries: group.entries.filter(
+      (entry) =>
+        entry.path !== "/docs" && entry.path !== "/guide/getting-started",
+    ),
   })).filter((group) => group.entries.length > 0);
 </script>
 

--- a/apps/docs/static/previews/provenance.json
+++ b/apps/docs/static/previews/provenance.json
@@ -193,7 +193,7 @@
     },
     "interaction/tooltip": {
       "filename": "interaction-tooltip-light.png",
-      "sourceSha256": "5861e092e890a84b4169e79d50e5c74108b642070fcf325449b3e3da6ab07142",
+      "sourceSha256": "d1d0166c68b1f7687b1dc89cd9c6d4c85f660503779a5db19ef634920b5dab3f",
       "pngSha256": "be96a7eebfea75f5a8f6beaee4e8322b5c51ee8726656fe840f2040f67784348"
     },
     "jitter/basic": {

--- a/examples/interaction/tooltip/meta.json
+++ b/examples/interaction/tooltip/meta.json
@@ -15,10 +15,6 @@
       {
         "label": "Linked controlled-state example",
         "href": "/interactions/linked-views"
-      },
-      {
-        "label": "Pre-0.1 interaction migration",
-        "href": "/guide/migrating-pre-0-1"
       }
     ],
     "svelteFirst": true,

--- a/examples/manifest.ts
+++ b/examples/manifest.ts
@@ -499,7 +499,6 @@ export const EXAMPLES: readonly ExampleManifestEntry[] = [
       references: [
         { label: "Interaction guide and event reference", href: "/guide/interactions" },
         { label: "Linked controlled-state example", href: "/interactions/linked-views" },
-        { label: "Pre-0.1 interaction migration", href: "/guide/migrating-pre-0-1" },
       ],
       svelteFirst: true,
       fullWidth: true,

--- a/packages/svelte/src/lib/interaction/interaction.ts
+++ b/packages/svelte/src/lib/interaction/interaction.ts
@@ -287,12 +287,12 @@ export interface PlotInteractionTransition<Key extends PropertyKey> {
 
 /**
  * @deprecated since 0.1.0 — use IntervalSelection. Kept as a source migration
- * alias only: https://ggsvelte.sh/guide/migrating-pre-0-1#migrate-custom-tooltip-snippets
+ * alias only: https://ggsvelte.sh/guide/upgrading#deprecated-type-aliases
  */
 export type BrushSelection = IntervalSelection;
 /**
  * @deprecated since 0.1.0 — use PlotInspectionChange. Kept as a source
- * migration alias only: https://ggsvelte.sh/guide/migrating-pre-0-1#migrate-custom-tooltip-snippets
+ * migration alias only: https://ggsvelte.sh/guide/upgrading#deprecated-type-aliases
  */
 export type TooltipContext<
   Row = Record<string, CellValue>,
@@ -300,6 +300,6 @@ export type TooltipContext<
 > = PlotInspectionChange<Row, Key>;
 /**
  * @deprecated since 0.1.0 — use ReadonlyZoomDomains. Kept as a source
- * migration alias only: https://ggsvelte.sh/guide/migrating-pre-0-1#migrate-custom-tooltip-snippets
+ * migration alias only: https://ggsvelte.sh/guide/upgrading#deprecated-type-aliases
  */
 export type ZoomDomains = { x?: [number, number]; y?: [number, number] };

--- a/scripts/check-pages-links.test.ts
+++ b/scripts/check-pages-links.test.ts
@@ -20,7 +20,6 @@ describe("packed Pages link checks", () => {
     "reference.html",
     "guide/interactions.html",
     "guide/interaction-reference.html",
-    "guide/migrating-pre-0-1.html",
     "guide/upgrading.html",
     "playground.html",
     "themes.html",
@@ -45,7 +44,7 @@ describe("packed Pages link checks", () => {
         "guide/interactions.html",
         [
           "../examples/interaction/tooltip",
-          "../guide/migrating-pre-0-1#payloads",
+          "../guide/upgrading#deprecated-type-aliases",
           "../llms.txt",
           "../_app/app.js",
           "../",

--- a/scripts/check-pages-links.ts
+++ b/scripts/check-pages-links.ts
@@ -10,7 +10,6 @@ export const requiredPages = [
   "reference.html",
   "guide/interactions.html",
   "guide/interaction-reference.html",
-  "guide/migrating-pre-0-1.html",
   "guide/upgrading.html",
   "playground.html",
   "themes.html",

--- a/scripts/gen-llms.test.ts
+++ b/scripts/gen-llms.test.ts
@@ -29,7 +29,6 @@ import {
   INTERACTIONS_MD,
   INTERACTION_REFERENCE_MD,
   INTERACTION_REFERENCE_INDEX,
-  MIGRATING_PRE_0_1_MD,
   TEMPORAL_SCALES_MD,
   UPGRADING_MD,
   guidePages,
@@ -302,15 +301,6 @@ describe("guide sections cover their catalogs", () => {
     }
   });
 
-  it("provides a pre-0.1 source migration for every superseded interaction prop", () => {
-    expect(MIGRATING_PRE_0_1_MD).toContain("`tooltip` → `inspect`");
-    expect(MIGRATING_PRE_0_1_MD).toContain('`brush` → `select={{ type: "interval" }}`');
-    expect(MIGRATING_PRE_0_1_MD).toContain("`onhover` → `oninspect`");
-    expect(MIGRATING_PRE_0_1_MD).toContain("`onbrush` → `onselect`");
-    expect(MIGRATING_PRE_0_1_MD).toContain("`TooltipContext` → `PlotInspectionChange`");
-    expect(MIGRATING_PRE_0_1_MD).toContain("`BrushSelection` → `IntervalSelection`");
-  });
-
   it("provides a rolling upgrading guide with a stable per-transition anchor", () => {
     // One section per release transition; changesets link these anchors, so
     // heading ids must come from the same renderer the docs site uses.
@@ -343,12 +333,13 @@ describe("guide sections cover their catalogs", () => {
     // Controller adoption is optional — both APIs remain supported.
     expect(UPGRADING_MD).toContain("createPlotInteraction");
     expect(UPGRADING_MD).toContain("optional");
-    // Deprecated aliases predate 0.2 and point at their own migration page.
+    // Deprecated aliases predate 0.2; guidance stays on this page.
     expect(UPGRADING_MD).toContain("`BrushSelection` → `IntervalSelection`");
     expect(UPGRADING_MD).toContain("`TooltipContext` → `PlotInspectionChange`");
     expect(UPGRADING_MD).toContain("`ZoomDomains` → `ReadonlyZoomDomains`");
     expect(UPGRADING_MD).toContain("deprecated since 0.1.0");
-    expect(UPGRADING_MD).toContain("/guide/migrating-pre-0-1");
+    expect(UPGRADING_MD).toContain("# Upgrade guide");
+    expect(UPGRADING_MD).not.toContain("migrating-pre-0-1");
   });
 });
 
@@ -420,7 +411,7 @@ describe("llms surfaces", () => {
     }
     expect(pages.map((page) => page.slug)).toContain("interactions");
     expect(pages.map((page) => page.slug)).toContain("interaction-reference");
-    expect(pages.map((page) => page.slug)).toContain("migrating-pre-0-1");
+    expect(pages.map((page) => page.slug)).not.toContain("migrating-pre-0-1");
     expect(pages.map((page) => page.slug)).toContain("upgrading");
     expect(pages.map((page) => page.slug)).toContain("compatibility");
   });
@@ -501,7 +492,6 @@ describe("public export surface (split-safe)", () => {
       "INTERACTION_REFERENCE_MD",
       "LAYERS_MARKS_MD",
       "LINKED_VIEWS_MD",
-      "MIGRATING_PRE_0_1_MD",
       "RENDERING_PERFORMANCE_MD",
       "RESPONSIVE_CHARTS_MD",
       "SCALES_GUIDES_MD",

--- a/scripts/gen-llms.ts
+++ b/scripts/gen-llms.ts
@@ -34,7 +34,6 @@ import {
   INTERACTION_REFERENCE_MD,
   LAYERS_MARKS_MD,
   LINKED_VIEWS_MD,
-  MIGRATING_PRE_0_1_MD,
   RENDERING_PERFORMANCE_MD,
   RESPONSIVE_CHARTS_MD,
   SCALES_GUIDES_MD,
@@ -60,7 +59,6 @@ export {
   INTERACTION_REFERENCE_MD,
   LAYERS_MARKS_MD,
   LINKED_VIEWS_MD,
-  MIGRATING_PRE_0_1_MD,
   RENDERING_PERFORMANCE_MD,
   RESPONSIVE_CHARTS_MD,
   SCALES_GUIDES_MD,
@@ -319,7 +317,6 @@ export function guidePages(lifecycle: LifecycleDoc): GuidePage[] {
     errors: buildErrorsMd(),
     advisories: buildAdvisoriesMd(),
     lifecycle: buildLifecycleMd(lifecycle),
-    "migrating-pre-0-1": MIGRATING_PRE_0_1_MD,
     upgrading: UPGRADING_MD,
   };
 

--- a/scripts/gen-manifest.test.ts
+++ b/scripts/gen-manifest.test.ts
@@ -53,7 +53,7 @@ describe("meta validation", () => {
       touch: "Tap a mark to pin it.",
       references: [
         { label: "Interactions guide", href: "/guide/interactions" },
-        { label: "Migration guide", href: "/guide/migrating-pre-0-1" },
+        { label: "Upgrade guide", href: "/guide/upgrading" },
       ],
       svelteFirst: true,
       fullWidth: true,

--- a/scripts/llms-guide-content.ts
+++ b/scripts/llms-guide-content.ts
@@ -2058,87 +2058,12 @@ export const INTERACTION_REFERENCE_INDEX: readonly InteractionReferenceEntry[] =
   },
 ];
 
-export const MIGRATING_PRE_0_1_MD = `# Migrating pre-0.1 interactions
-
-Pre-0.1 props named presentation; current props name intent. Update props,
-callback payloads, and custom tooltip snippets together — no runtime shim.
-
-## Rename the props and callbacks
-
-- \`tooltip\` → \`inspect\`
-- \`brush\` → \`select={{ type: "interval" }}\`
-- \`onhover\` → \`oninspect\`
-- \`onbrush\` → \`onselect\`
-- \`onzoom={(domains) => ...}\` → \`onzoom={(event) => ...}\`
-
-Before:
-
-\`\`\`svelte fragment
-<GGPlot
-  tooltip={true}
-  brush={true}
-  zoom={true}
-  onhover={(hit) => (hovered = hit)}
-  onbrush={(selection) => (brushed = selection)}
-  onzoom={(domains) => (zoomed = domains)}
-/>
-\`\`\`
-
-After:
-
-\`\`\`svelte fragment
-<GGPlot
-  key="id"
-  inspect={true}
-  select={{ type: "interval" }}
-  zoom={true}
-  oninspect={(event) => (inspection = event)}
-  onselect={(event) => (selection = event)}
-  onzoom={(event) => (zoomed = event.domains)}
-/>
-\`\`\`
-
-## Migrate payload handling
-
-\`oninspect\` is a lifecycle. Narrow on \`event.phase === "change"\` before
-reading \`focus\`, \`members\`, or \`mode\`; a clear event deliberately carries
-only its type, phase, and source. Use \`event.focus.row\` instead of resolving a
-renderer hit index yourself.
-
-\`onselect\` also has phases. Interval callbacks receive domain and pixel
-bounds on \`event.domain\` and \`event.pixels\`, and return stable semantic
-\`event.keys\` instead of source-row indices and renderer hits. Point selection
-uses the same callback with \`event.mode === "point"\`.
-
-\`onzoom\` now reports an event. Read \`event.domains\` after an \`end\` phase;
-the \`clear\` phase carries \`domains: null\`.
-
-## Migrate custom tooltip snippets
-
-The snippet argument changed from one renderer hit to a semantic inspection:
-
-- \`TooltipContext\` → \`PlotInspectionChange\`
-- \`context.row\` → \`inspection.focus.row\`
-- \`context.fields\` → \`inspection.focus.fields\`
-- \`BrushSelection\` → \`IntervalSelection\`
-- \`ZoomDomains\` → \`ReadonlyZoomDomains\`
-
-The old type names remain deprecated aliases where a safe alias is possible,
-but the old component props and old callback shapes are removed. Pre-0.1 means
-there is no runtime compatibility shim: TypeScript errors should point directly
-at every source change you need to make.
-
-See [Interactions](/guide/interactions) for current options, event shapes,
-keyboard behavior, and identity requirements.
-`;
-
-export const UPGRADING_MD = `# Upgrade in five minutes
+export const UPGRADING_MD = `# Upgrade guide
 
 One section per released 0.x transition, newest first. Each heading is a
 stable anchor that changesets and release notes link to. Pre-1.0, breaking
 changes ride minor releases; every deprecation or removal ships with a
-migration note here. The pre-release API has its own page:
-[Migrating pre-0.1 interactions](/guide/migrating-pre-0-1).
+migration note here.
 
 ## Five-minute path
 
@@ -2969,6 +2894,6 @@ still compile. Replace them when convenient:
 - \`TooltipContext\` → \`PlotInspectionChange\`
 - \`ZoomDomains\` → \`ReadonlyZoomDomains\`
 
-The payload changes behind these renames are documented in
-[Migrating pre-0.1 interactions](/guide/migrating-pre-0-1#migrate-custom-tooltip-snippets).
+See [Interactions](/guide/interactions) for current options, event shapes,
+and identity requirements.
 `;

--- a/tests/visual/docs-progressive-search.spec.ts
+++ b/tests/visual/docs-progressive-search.spec.ts
@@ -122,17 +122,19 @@ test("Docs landing and sidebar expose the full path without duplicate Reference"
   // Full chapter index on the landing page (not just the four task hubs).
   const index = page.getByRole("navigation", { name: "All documentation guides" });
   await expect(index.getByRole("heading", { level: 3 })).toHaveText([
-    "Start",
     "Core grammar",
     "Interaction",
     "Production",
     "Reference",
     "Release",
   ]);
+  // Getting started lives in Start here only — not repeated under All guides.
+  await expect(index.getByRole("link", { name: /Getting started/ })).toHaveCount(0);
   await expect(index.getByRole("link", { name: /Data and mappings/ })).toBeVisible();
   await expect(index.getByRole("link", { name: /Dates without preprocessing/ })).toBeVisible();
   await expect(index.getByRole("link", { name: /Errors reference/ })).toBeVisible();
-  await expect(index.getByRole("link", { name: /Upgrade in five minutes/ })).toBeVisible();
+  await expect(index.getByRole("link", { name: /Upgrade guide/ })).toBeVisible();
+  await expect(index.getByRole("link", { name: /Migrating pre-0.1/ })).toHaveCount(0);
 
   const sidebar = page.getByRole("navigation", { name: "Guide chapters" });
   await expect(sidebar.getByRole("heading", { level: 2 })).toHaveText([
@@ -143,7 +145,8 @@ test("Docs landing and sidebar expose the full path without duplicate Reference"
     "Reference",
     "Release",
   ]);
-  await expect(sidebar.getByRole("link")).toHaveCount(26);
+  // Overview + guides minus deleted pre-0.1 page.
+  await expect(sidebar.getByRole("link")).toHaveCount(25);
   await expect(sidebar.getByRole("link", { name: "Dates without preprocessing" })).toBeVisible();
   await expectNoDocumentOverflow(page);
 
@@ -216,7 +219,7 @@ for (const chapter of [
   {
     group: "release",
     path: "/guide/upgrading",
-    heading: "Upgrade in five minutes",
+    heading: "Upgrade guide",
     evidence: "/guide/lifecycle#lifecycle-tags",
   },
 ] as const) {

--- a/tests/visual/docs-shell.spec.ts
+++ b/tests/visual/docs-shell.spec.ts
@@ -124,7 +124,7 @@ test("desktop docs shell exposes chapter, breadcrumb, contents, and sequence nav
 
   const chapters = page.getByRole("navigation", { name: "Guide chapters" });
   await expect(chapters).toBeVisible();
-  await expect(chapters.getByRole("link")).toHaveCount(26);
+  await expect(chapters.getByRole("link")).toHaveCount(25);
   await expect(chapters.getByRole("link", { name: "Dates without preprocessing" })).toBeVisible();
   await expect(page.getByRole("navigation", { name: "Breadcrumb" })).toContainText(
     "Getting started",


### PR DESCRIPTION
## Summary

- **All guides:** stop repeating Getting started (already in Start here); the empty Start chapter disappears from that list.
- **Delete** `/guide/migrating-pre-0-1` (catalog, prose, search, routes, example refs, required packed page). Nobody used pre-0.1 charts.
- **Rename** "Upgrade in five minutes" → **Upgrade guide** on the hub, sidebar, page H1, and search index.
- Point deprecated-type-alias JSDoc at `/guide/upgrading#deprecated-type-aliases`.

## Test plan

- [x] `bun test scripts/gen-llms.test.ts scripts/check-pages-links.test.ts scripts/gen-manifest.test.ts scripts/docs-tasks.test.ts scripts/gen-docs-routes.test.ts scripts/gen-docs-search.test.ts`
- [x] `bun run docs:routes:check` / `docs:search:check`
- [ ] CI visual docs shell + progressive-search specs (sidebar count 25, Upgrade guide title)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1032" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->