### PR TITLE
docs: purge README soft teaching; lead with agents and PortableSpec

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,10 @@
 
 [![codecov](https://codecov.io/gh/ljodea/ggsvelte/branch/main/graph/badge.svg)](https://app.codecov.io/gh/ljodea/ggsvelte)
 
-A layered grammar of graphics for Svelte 5. Map data to aesthetics, add geoms, then
-compose statistics, scales, facets, coordinates, themes, and interaction.
+ggplot2's layered grammar for Svelte 5. Author with components; agents emit the
+same chart as PortableSpec JSON — validate, apply the fix, render headless.
+`@ggsvelte/svelte` ships the agent skill at
+[`skills/ggsvelte`](skills/ggsvelte/SKILL.md).
 
 [Documentation](https://ggsvelte.sh/) · [Examples](https://ggsvelte.sh/examples) ·
 [Getting started](https://ggsvelte.sh/guide/getting-started) ·
@@ -16,13 +18,20 @@ bun add @ggsvelte/svelte
 # or: npm install @ggsvelte/svelte
 ```
 
-Requires Node.js 22+ and Svelte 5.33.1+. npm, pnpm, and Bun installs are tested on
-Ubuntu and Windows.
+Requires Node.js 22+ and Svelte 5.33.1+. CI covers npm, pnpm, and Bun on Ubuntu
+and Windows.
+
+## Agents
+
+- Skill: [`skills/ggsvelte/SKILL.md`](skills/ggsvelte/SKILL.md) (also published
+  under `node_modules/@ggsvelte/svelte/skills/ggsvelte/`)
+- Schema: [`schema/v0.json`](https://ggsvelte.sh/schema/v0.json)
+- Corpus: [`llms.txt`](https://ggsvelte.sh/llms.txt) ·
+  [`llms-full.txt`](https://ggsvelte.sh/llms-full.txt)
+- `validate()` errors are `{ code, path, message, fix }` with a
+  machine-applicable `fix.example`
 
 ## Examples
-
-Each image is generated from the Svelte file shown above it. Open a chart for the
-live output and complete source.
 
 ### [Loess trend with uncertainty](https://ggsvelte.sh/examples/smooth/loess-scatter)
 
@@ -321,12 +330,11 @@ live output and complete source.
 
 [![Eleven old maps of the Great Lakes coloured by publication year against the true positions](apps/docs/static/previews/color-continuous-light.png)](https://ggsvelte.sh/examples/color/continuous)
 
-Guide presentation stays separate from scale math. Use
-`<GuideColorbar channel="color" position="bottom" />` (or
-`<GuideLegend channel="color" position="bottom" />`, `<GuideNone channel="size" />`)
-to title, orient, place, suppress, or force axes and non-position guides. Automatic
-legends use the right side only while at least 320px of panel remains, then move below
-with complete accessible labels and unchanged scale assignments.
+Guides are separate from scale math:
+`<GuideColorbar channel="color" position="bottom" />`,
+`<GuideLegend channel="color" position="bottom" />`,
+`<GuideNone channel="size" />`. Auto non-position guides sit on the right while
+≥320px of panel remains, then move below; scale assignments stay fixed.
 
 ### [Boxplots](https://ggsvelte.sh/examples/boxplot/by-category)
 
@@ -441,8 +449,7 @@ with complete accessible labels and unchanged scale assignments.
 
 ## Themes
 
-Chart themes are independent of the site's light or dark appearance. The same spec can
-use a built-in theme or explicit theme tokens.
+Plot theme tokens are independent of site light/dark.
 
 |                                                           Tufte                                                           |                                                             Economist                                                             |
 | :-----------------------------------------------------------------------------------------------------------------------: | :-------------------------------------------------------------------------------------------------------------------------------: |
@@ -452,27 +459,13 @@ use a built-in theme or explicit theme tokens.
 
 [Compare every theme and palette](https://ggsvelte.sh/themes).
 
-## Composition
-
-- Geoms share one layer model, so points, lines, intervals, summaries, annotations,
-  and text can occupy the same plot.
-- Statistics and positions include binning, density, loess and linear fits, stacking,
-  filling, dodging, and seeded jitter.
-- Scales cover continuous, discrete, temporal, binned, transformed, color/fill, size, linewidth, alpha, shape, and linetype data.
-- Facets train fixed or free panel scales; coordinates can flip axes, project final geometry after statistics, or preserve exact physical data-unit ratios with `coordFixed()`.
-- Inspection, selection, zoom, and legend controls emit semantic Svelte events.
-- Ordinary layers render as SVG. Dense point layers move to canvas while axes, text,
-  legends, and accessible descriptions remain in the DOM.
-
 ## Packages
 
-| Package                               | Surface                                                                 |
-| ------------------------------------- | ----------------------------------------------------------------------- |
-| [`@ggsvelte/svelte`](packages/svelte) | Svelte 5 components, package re-exports, and the CLI                    |
-| [`@ggsvelte/spec`](packages/spec)     | Portable types, JSON Schema, validation, normalization, and the builder |
-| [`@ggsvelte/core`](packages/core)     | Framework-independent pipeline, SVG renderer, canvas, and hit testing   |
-
-Most applications need only `@ggsvelte/svelte`.
+| Package                               | Surface                                                             |
+| ------------------------------------- | ------------------------------------------------------------------- |
+| [`@ggsvelte/svelte`](packages/svelte) | Svelte 5 components, re-exports, CLI, agent skill                   |
+| [`@ggsvelte/spec`](packages/spec)     | PortableSpec types, JSON Schema, validate/normalize, fluent builder |
+| [`@ggsvelte/core`](packages/core)     | Pipeline, headless SVG, canvas, hit testing                         |
 
 ## Reference
 
@@ -483,16 +476,10 @@ Most applications need only `@ggsvelte/svelte`.
 - [Compatibility](https://ggsvelte.sh/guide/compatibility)
 - [Upgrading](https://ggsvelte.sh/guide/upgrading)
 
-Machine-readable documentation is available at
-[`llms.txt`](https://ggsvelte.sh/llms.txt),
-[`llms-full.txt`](https://ggsvelte.sh/llms-full.txt), and
-[`schema/v0.json`](https://ggsvelte.sh/schema/v0.json).
-
 ## Release status
 
-ggsvelte remains pre-1.0. Package manifests are the version source of truth. Lifecycle
-and compatibility contracts are documented in
-[`lifecycle.json`](lifecycle.json) and the
+Pre-1.0. Package manifests are the version source of truth. Lifecycle and
+compatibility contracts live in [`lifecycle.json`](lifecycle.json) and the
 [lifecycle guide](https://ggsvelte.sh/guide/lifecycle).
 
 ## Contributing
@@ -501,5 +488,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## License
 
-[MIT](LICENSE) © Liam O'Dea. Loess reference implementation attribution is recorded in
-[NOTICE](NOTICE).
+[MIT](LICENSE) © Liam O'Dea. Loess reference attribution is in [NOTICE](NOTICE).

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -2,20 +2,16 @@
 
 [![codecov](https://codecov.io/gh/ljodea/ggsvelte/branch/main/graph/badge.svg?component=packages-core)](https://app.codecov.io/gh/ljodea/ggsvelte/tree/main/packages%2Fcore)
 
-The framework-agnostic ggsvelte engine: the grammar-of-graphics pipeline
-(stats, positions, panel-aware facets, value-stable scales, two-pass layout)
-and the pure SVG-string renderer. The main entry has no DOM dependency —
-safe in Node, edge runtimes, and workers; canvas rendering and the hit index
-live behind `@ggsvelte/core/dom`. The current API remains pre-1.0;
-correctness fixes improve defaults in place with documented direct overrides.
+Grammar pipeline (stats, positions, facets, scales, layout) and pure SVG-string
+renderer. Main entry has no DOM — Node, edge runtimes, workers. Canvas and hit
+index live under `@ggsvelte/core/dom`. Pre-1.0.
 
 ```sh
 bun add @ggsvelte/core     # or: npm install @ggsvelte/core
 ```
 
-Most apps want the [`@ggsvelte/svelte`](https://www.npmjs.com/package/@ggsvelte/svelte)
-package instead — Svelte 5 components over this engine. Use `@ggsvelte/core`
-directly for server/CLI/agent rendering.
+For server, CLI, and agent rendering. Svelte apps use
+[`@ggsvelte/svelte`](https://www.npmjs.com/package/@ggsvelte/svelte).
 
 ## Quick example
 
@@ -34,72 +30,37 @@ const spec = {
   ],
 };
 
-// Headless, deterministic, all-SVG (the export path)
 const svg = renderToSVGString(spec, { width: 640, height: 400 });
 
-// Or drive a custom renderer from the full model
 const model = runPipeline(spec, { width: 640, height: 400 });
-console.log(model.scaleDecisions); // inferred parser, precision, evidence, domain
-console.log(model.scaleDiagnostics); // bounded problem/cause/fix advisories
-console.log(model.guidePlans); // per-panel intervals, visible/full labels, fit state
-model.scene; // panels, axes, legends, geometry batches (typed arrays)
-model.advisories; // every heuristic decision, with how-to-override
-model.warnings; // degraded-but-rendered conditions
+// model.scene, model.scaleDecisions, model.guidePlans,
+// model.advisories, model.warnings
 ```
 
-Position scales preserve semantic source values while cached `identity`,
-`log10`, or `sqrt` views feed statistics and positions exactly once. The final
-trained continuous scale exposes both `normalize(semantic)` and
-`normalizeTransformed(scaleSpace)`, semantic inversion, family `linear`, and a
-separate `transform`. Binned scales retain private integer identities for
-count/stack/dodge while guides, candidates, and interactions use semantic
-centers and edges.
-
-Non-position color/fill scales resolve ordinal, sequential, binned, manual,
-and identity families through one semantic value path. Sequential and binned
-families expose semantic and transformed domains; manual/identity preserve
-explicit NA and unknown policies. Bounded warnings count fallback use, and
-numeric or temporal `labels` formats apply to colorbars and colorsteps.
-`guidePlans` includes immutable `discrete`, `colorbar`, and `colorsteps`
-payloads, while SVG, canvas, and Svelte consume the same resolved mark colors.
-
-Mapped size, linewidth, alpha, shape, and linetype share stable training,
-NA/unknown policy, immutable guide plans, and scene vectors. Size interpolates
-in symbol area; shape/linetype use finite named sets and require binning for
-quantitative data. Discrete and binned styles contribute to grouping while
-continuous numeric styles do not. Candidate hit geometry follows mapped point
-radius and stroke width, and candidate semantics retain the resolved styles.
-
-Guide appearance resolves after scale training. Automatic guides use the right zone
-only when the viewport remains readable, otherwise they move below with horizontal
-ramps and deterministic key wrapping. Explicit right and bottom zones can coexist.
-Discrete guides merge only across exact semantic identities and preserve every
-represented aesthetic for focus/filter indexing. Identity guides remain suppressed
-unless forced; representative numeric ticks and bins remain non-interactive.
-
-`coordTransform` is a separate post-stat projector. Per-panel projectors map
-trained scale-space values through identity/log10/sqrt coordinates, project
-axis ticks and grids, adaptively tessellate curved paths/segments, and expose
-the inverse used before scale inversion. Synthetic tessellation vertices are
-render topology only; `CandidateStore` retains original/stat semantic anchors.
-
-`coordFixed({ ratio: 1 })` runs after chart chrome allocation and fits the
-largest centered data rectangle whose physical y-unit/x-unit ratio is exact.
-Fixed-scale facets retain equal panel dimensions; free positional facet scales
-fail with `coord-fixed-free-scales`. Letterbox gutters use the theme paper role
-by default. Constrained scenes preserve the ratio, remove minor furniture, and
-publish one `coord-fixed-degraded` warning plus `scene.layout = "degraded"`.
-
-Browser rendering:
+Browser canvas + hit testing:
 
 ```ts
 import { drawStratum } from "@ggsvelte/core/dom";
 
-// Hit resolution uses the model-owned CandidateStore; no second index build.
 const candidate = model.candidates.hitTest(plotX, plotY);
 ```
 
-Specs are validated via [`@ggsvelte/spec`](https://www.npmjs.com/package/@ggsvelte/spec)
-(re-exported errors follow the same `{ code, path, message, fix }` contract).
+## Contract
+
+- **Scale transforms** run before statistics; **coord transforms** project after
+  statistics and invert before scale inversion for interactions.
+- Position scales keep semantic source values; cached `identity` / `log10` /
+  `sqrt` views feed stats and positions once.
+- Non-position color/fill and style channels share one training path; SVG,
+  canvas, and Svelte consume the same resolved mark styles.
+- Auto non-position guides sit on the right while the panel stays readable,
+  else move below. Identity guides stay suppressed unless forced.
+- `coordFixed({ ratio })` fits a centered data rectangle with exact physical
+  unit ratios after chrome allocation; free positional facet scales fail with
+  `coord-fixed-free-scales`.
+
+Specs validate through
+[`@ggsvelte/spec`](https://www.npmjs.com/package/@ggsvelte/spec)
+(re-exported errors keep the `{ code, path, message, fix }` shape).
 
 Repo + docs: <https://github.com/ljodea/ggsvelte> · MIT © Liam O'Dea

--- a/packages/spec/README.md
+++ b/packages/spec/README.md
@@ -2,28 +2,26 @@
 
 [![codecov](https://codecov.io/gh/ljodea/ggsvelte/branch/main/graph/badge.svg?component=packages-spec)](https://app.codecov.io/gh/ljodea/ggsvelte/tree/main/packages%2Fspec)
 
-The ggsvelte plot specification: `PortableSpec` types, the published JSON
-Schema (`schema/v0.json`), the `normalize()` canonicalizer, two-tier
-`validate()` with the agent error contract (`{ code, path, message,
-allowed?, fix }` — every fix carries a machine-applicable example),
-`lintSpec()` advisories, portability helpers, and the fluent `gg()/aes()`
-builder. Zero DOM, zero d3. The current API remains pre-1.0; correctness
-fixes improve defaults in place with documented direct overrides.
+PortableSpec types, published JSON Schema (`schema/v0.json`), `normalize()`,
+two-tier `validate()` with the agent error contract
+(`{ code, path, message, allowed?, fix }` — every fix carries a
+machine-applicable example), `lintSpec()`, and the fluent `gg()/aes()` builder.
+No DOM, no d3. Pre-1.0.
 
 ```sh
 bun add @ggsvelte/spec     # or: npm install @ggsvelte/spec
 ```
 
-Most apps want the [`@ggsvelte/svelte`](https://www.npmjs.com/package/@ggsvelte/svelte)
-package instead — it re-exports all of this. Install `@ggsvelte/spec` alone
-for validation/authoring tooling with no renderer.
+Install alone for validation and authoring without a renderer.
+`@ggsvelte/svelte` re-exports this package.
 
 ## Quick example
 
 ```ts
-import { gg, aes, normalize, validate, lintSpec } from "@ggsvelte/spec";
+import { gg, aes, validate } from "@ggsvelte/spec";
+// constrained decoding / tool schemas
+import schema from "@ggsvelte/spec/schema/v0.json";
 
-// Builder -> canonical PortableSpec (validated). Raw year strings infer time.
 const spec = gg(
   [
     { year: "1835", value: 12 },
@@ -34,90 +32,47 @@ const spec = gg(
   .geomLine()
   .spec();
 
-// Validate agent-emitted JSON against a DataProfile (no data needed)
-const result = validate(candidate, {
-  profile: { fields: [{ name: "displ", type: "quantitative" }] },
+const result = validate(spec, {
+  profile: {
+    fields: [
+      { name: "year", type: "temporal" },
+      { name: "value", type: "quantitative" },
+    ],
+  },
   lint: true,
 });
 if (!result.ok) {
-  // every error: { code, path, message, allowed?, fix: { description, example } }
+  // { code, path, message, allowed?, fix: { description, example } }
 }
-
-// JSON Schema for constrained decoding
-import schema from "@ggsvelte/spec/schema/v0.json";
 ```
 
-Temporal parsing is strict and portable. Automatic inference recognizes ISO values,
-`YYYY`, year-month, month-year, and year-quarter after bounded classification plus
-whole-column validation. Ambiguous ordered dates require an explicit parser:
+## Contract
 
-```ts
-import { dmy, scale_x_date } from "@ggsvelte/spec";
+- **Emit, validate, fix.** `validate(spec)` is shape; `validate(spec, { profile })`
+  is data-aware without shipping rows; `{ lint: true }` adds advisories. Apply
+  `fix.example` at `path` and re-validate.
+- **Temporal.** Automatic inference covers ISO, `YYYY`, year-month, month-year,
+  and year-quarter after whole-column validation. Ambiguous ordered dates need
+  an explicit parser (`parse: "dmy"`, etc.).
+- **Numeric transforms.** Closed names (`identity` | `log10` | `sqrt`) run
+  before statistics. Domains/limits are semantic; OOB censor/squish runs before
+  the transform. Authored `type: "log"` normalizes to linear + log10.
+- **Color/fill.** `ordinal`, `sequential`, `binned`, `manual`, `identity`.
+  Binned color caps at 64 intervals; manual needs one range color per domain
+  value.
+- **Style channels.** `size` / `linewidth` / `alpha` share sequential–identity
+  families. `shape` and `linetype` use finite named sets — quantitative
+  mappings require explicit binning.
+- **Guides.** Separate from scale math. Top-level `guides` wins over scale-local
+  `guide`. Invalid aesthetic/variant pairs fail validation.
+- **Coords.** `coordTransform` is post-stat projection. `coordFixed({ ratio })`
+  is physical y-unit/x-unit length; free positional facet scales are rejected.
+- **PortableSpec.** No `Date`, callbacks, or regular expressions. Builder
+  `Date` values canonicalize to ISO strings.
 
-const dates = dmy(["31/12/2024", "01/01/2025"]); // Date authoring values
-const scale = scale_x_date({
-  parse: "dmy",
-  dateBreaks: "2 weeks",
-  dateMinorBreaks: "1 day",
-  dateLabels: "%e %b",
-  locale: "en-GB",
-  weekStart: "monday",
-});
-```
-
-Temporal break intervals are closed portable strings: a positive integer plus
-millisecond, second, minute, hour, day, week, month, quarter, or year. Explicit
-`breaks` outrank `dateBreaks`; `dateLabels` outranks the legacy soft-fallback
-`labels` formatter.
-
-Numeric position transforms are also closed portable names and run before
-statistics. Canonical scales retain family `linear` or `binned` plus
-`transform: "identity" | "log10" | "sqrt"`; authored `type: "log"` normalizes
-to linear + log10. Use `scaleXLog10`, `scaleYSqrt`, `scaleXBinned`, or the
-binding-identical ggplot2 aliases (`scale_x_log10`, `scale_y_sqrt`,
-`scale_x_binned`). Domains/limits are semantic source units; OOB censor/squish
-happens before the transform and stats.
-
-Color/fill scales use the same strict contract across JSON, builder, and Svelte:
-`ordinal`, `sequential`, `binned`, `manual`, and `identity`. CamelCase helpers
-cover continuous/discrete/binned/log10/sqrt/date/datetime/manual/identity;
-`color`/`colour` and ggplot2 snake-case names are binding-identical aliases.
-Binned color is capped at 64 deterministic intervals, manual mappings require
-one range color per domain value, and temporal families reuse the parser
-registry rather than field-name inference.
-
-Mapped `size`, `linewidth`, and `alpha` add sequential, ordinal, binned, manual,
-identity, date, and datetime helpers. `shape` and `linetype` use finite named
-output sets, so quantitative mappings require explicit binning instead of
-silent interpolation. CamelCase, fluent-builder, and ggplot2 snake-case forms
-all emit the same strict JSON; callbacks and regular expressions remain
-forbidden.
-
-Guide presentation is a separate portable contract. Use top-level `guides`, a
-scale-local `guide`, fluent `.guides()`, or `guideAxis`, `guideLegend`,
-`guideColorbar`, `guideColorsteps`, and `guideNone` (plus snake-case aliases).
-Top-level entries win over scale-local entries. Non-position guides accept bounded
-right/bottom placement, direction, collision, force, and theme overrides; invalid
-aesthetic/variant combinations fail validation instead of being ignored.
-
-Post-stat coordinate transforms use the separate strict `CoordTransformSpec`.
-`coordTransform({ x: "log10", y: "sqrt" })` and its binding-identical
-`coord_transform` alias emit canonical JSON; builder `.coordTransform()` emits
-the same spec. Coordinate limits preserve stat inputs, `reverse` composes in
-coordinate space, and `clip: false` explicitly permits panel overflow.
-
-Fixed-aspect coordinates use `coordFixed({ ratio: 1 })`, builder
-`.coordFixed()`, or the identical `coord_fixed`, `coordEqual`, and `coord_equal`
-aliases. `ratio` is physical y-unit length divided by physical x-unit length.
-The strict schema rejects non-positive/non-finite ratios and rejects
-`coord_fixed` with free positional facet scales before rendering.
-
-All six orders (`ymd`, `ydm`, `mdy`, `myd`, `dmy`, `dym`), timestamp variants,
-exact closed formats, and epoch units are typed. PortableSpec never contains `Date`,
-callbacks, or regular expressions; builder Dates canonicalize to ISO strings.
-
-Render the spec with [`@ggsvelte/core`](https://www.npmjs.com/package/@ggsvelte/core)
-(headless SVG) or [`@ggsvelte/svelte`](https://www.npmjs.com/package/@ggsvelte/svelte)
-(Svelte 5 components).
+Render with [`@ggsvelte/core`](https://www.npmjs.com/package/@ggsvelte/core)
+(headless SVG) or
+[`@ggsvelte/svelte`](https://www.npmjs.com/package/@ggsvelte/svelte)
+(Svelte 5).
 
 Repo + docs: <https://github.com/ljodea/ggsvelte> · MIT © Liam O'Dea

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -2,8 +2,9 @@
 
 [![codecov](https://codecov.io/gh/ljodea/ggsvelte/branch/main/graph/badge.svg?component=packages-svelte)](https://app.codecov.io/gh/ljodea/ggsvelte/tree/main/packages%2Fsvelte)
 
-Svelte 5 components for ggsvelte's layered grammar of graphics. This package also
-re-exports the spec and core surfaces and includes the `ggsvelte-render` CLI.
+Svelte 5 components for ggsvelte. Re-exports `@ggsvelte/spec` and
+`@ggsvelte/core`, ships the `ggsvelte-render` CLI, and publishes the agent skill
+at `skills/ggsvelte`.
 
 ```sh
 bun add @ggsvelte/svelte
@@ -16,73 +17,39 @@ Requires Node.js 22+ and Svelte 5.33.1+.
 
 ```svelte
 <script lang="ts">
-  import {
-    GeomPoint,
-    GGPlot,
-    guideLegend,
-    Guides,
-    Labs,
-  } from "@ggsvelte/svelte";
-
-  const rows = [
-    { engine: 1.8, highway: 29, class: "compact" },
-    { engine: 2.4, highway: 31, class: "compact" },
-    { engine: 3.3, highway: 22, class: "midsize" },
-    { engine: 4.7, highway: 18, class: "suv" },
-    { engine: 5.7, highway: 16, class: "suv" },
-  ];
+  import { GeomPoint, GGPlot, Labs } from "@ggsvelte/svelte";
+  import { kyotoSakura } from "@ggsvelte/svelte/data";
 </script>
 
 <GGPlot
-  data={rows}
-  aes={{ x: "engine", y: "highway", color: "class" }}
+  data={kyotoSakura}
+  aes={{ x: "year", y: "bloomDoy" }}
   width="container"
   height={400}
 >
-  <Guides value={{ color: guideLegend({ position: "auto" }) }} />
   <Labs
-    title="Highway efficiency by engine size"
-    x="Engine displacement"
-    y="Highway mileage"
-    color="Class"
+    title="Kyoto cherry blossom full-bloom dates, 812–2026"
+    subtitle="Full bloom moved about ten days earlier after the industrial era"
+    x="Year"
+    y="Day of year"
   />
-  <GeomPoint size={4} />
+  <GeomPoint size={2} alpha={0.7} />
 </GGPlot>
 ```
 
-`<GGPlot>` composes geoms, statistics, positions, scales, facets, coordinates,
-themes, and semantic interaction. Ordinary layers render as SVG; dense point layers
-can render on canvas while axes, legends, text, and accessible descriptions remain in
-the DOM.
+Scale transforms change the values stats see; `coordTransform` projects after
+stats. Dense points may render on canvas; axes, legends, text, and accessible
+descriptions stay in the DOM. `<Guides>` places, titles, or suppresses guides
+without retraining scales.
 
-Add `<Coord value={coordTransform({ x: "log10" })} />` to project final geometry after
-statistics without changing the values consumed by a fit or bin. Nonlinear paths are
-tessellated without creating inspectable rows, and interval or brush inversion returns
-semantic values.
+## Agent skill
 
-Add `<Coord value={coordFixed()} />` when equal data units must remain physically equal.
-The Svelte renderer uses the same centered data rectangle and theme-owned
-letterbox gutters as headless SVG, including the `data-gg-layout="degraded"`
-state for unusually constrained allocations. `coord_fixed`, `coordEqual`, and
-`coord_equal` are re-exported aliases over the same portable implementation.
+Published path: `node_modules/@ggsvelte/svelte/skills/ggsvelte/SKILL.md`. Repo
+source: [`skills/ggsvelte/SKILL.md`](../../skills/ggsvelte/SKILL.md).
 
-Color/fill helpers are re-exported from the package root. For example,
-`<Scale value={scaleColorBinned({ breaks: [0, 10, 100], range: ["#ddd", "#222"] })} />`
-renders deterministic color steps and a colorsteps guide. Continuous,
-discrete, log10, sqrt, date, datetime, manual, and identity families use the
-same JSON accepted by `<GGPlot>`, with binding-identical `color`/`colour` and
-ggplot2 snake-case aliases.
-
-Size, linewidth, alpha, shape, and linetype helpers are also re-exported from
-the package root. Their per-mark/per-path vectors render consistently in SVG,
-canvas, and SSR; style legends retain keyboard focus and filtering behavior,
-and inspection reports resolved semantic style values.
-
-Add a `<Guides>` child to suppress or restyle axes and to place,
-orient, title, order, or force legends/colorbars/colorsteps. Automatic guides move
-from right to bottom at narrow widths without retraining scales; merged exact-value
-entries keep keyboard focus and filtering across every represented aesthetic. The
-same planned scene renders in browser SVG, headless SVG, and SSR.
+Emit PortableSpec JSON, run `validate()`, apply `fix.example` at `path`,
+re-validate, then render with `<GGPlot spec={…} />`, `renderToSVGString`, or
+`ggsvelte-render`. Schema: [schema/v0.json](https://ggsvelte.sh/schema/v0.json)
 
 ## Upgrading
 
@@ -110,7 +77,6 @@ guide](https://ggsvelte.sh/guide/upgrading), never half-migrated.
 - [Upgrading](https://ggsvelte.sh/guide/upgrading)
 - [Repository](https://github.com/ljodea/ggsvelte)
 
-The API remains pre-1.0. Lifecycle and compatibility contracts are documented in the
-repository and on the docs site.
+Pre-1.0. Lifecycle and compatibility contracts are on the docs site.
 
 [MIT](https://github.com/ljodea/ggsvelte/blob/main/LICENSE) © Liam O'Dea


### PR DESCRIPTION
## Summary

- Root README: replace ggplot2-novice lede with dual-surface claim (Svelte components + PortableSpec for agents), add Agents section (skill, schema, llms, validate/fix), delete visible-example narration, Composition soft teaching, and “Most applications need only…” speculation.
- `@ggsvelte/svelte` README: real Kyoto data instead of synthetic cars; contract lines only; agent skill path.
- `@ggsvelte/spec` / `@ggsvelte/core` READMEs: cut multi-paragraph soft essays to short contract bullets.

Named modes purged: soft teaching, ggplot2-novice address, narration of the visible, code narration, fake finding, importance inflation.

## Test plan

- [x] `bun test scripts/readme-showcase.test.ts`
- [x] `bun test scripts/support-matrix.test.ts`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1033" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->