### PR TITLE
perf(ci): shard the component jobs off the critical path (#1035)

### DIFF
--- a/.github/actions/ci-content-hash-restore/action.yml
+++ b/.github/actions/ci-content-hash-restore/action.yml
@@ -22,6 +22,13 @@ inputs:
     description: Optional Playwright container tag for component shards
     required: false
     default: ""
+  shard:
+    description: >
+      Optional matrix fan-out leg as "<index>/<total>" (1-based), matching the
+      vitest / playwright --shard spelling. Legs of one execution hash the same
+      content but run disjoint test files, so each needs its own marker.
+    required: false
+    default: ""
   matrix_node:
     description: Optional consumer matrix node major (with other matrix_* inputs)
     required: false
@@ -71,6 +78,7 @@ runs:
         DISABLE: ${{ inputs.disable }}
         EXECUTION: ${{ inputs.execution }}
         CONTAINER_TAG: ${{ inputs.container_tag }}
+        SHARD: ${{ inputs.shard }}
         MATRIX_NODE: ${{ inputs.matrix_node }}
         MATRIX_PM: ${{ inputs.matrix_pm }}
         MATRIX_PM_VERSION: ${{ inputs.matrix_pm_version }}
@@ -91,6 +99,9 @@ runs:
         args=(--execution "${EXECUTION}" --os "${RUNNER_OS}")
         if [ -n "${CONTAINER_TAG}" ]; then
           args+=(--container-tag "${CONTAINER_TAG}")
+        fi
+        if [ -n "${SHARD}" ]; then
+          args+=(--shard "${SHARD}")
         fi
         if [ -n "${MATRIX_NODE}" ]; then
           args+=(
@@ -113,7 +124,7 @@ runs:
       if: steps.compute.outputs.bypass != 'true'
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
-        path: .ci-content-hash/${{ inputs.execution }}.ok
+        path: ${{ steps.compute.outputs.marker_path }}
         # Exact key only (no restore-keys) — incomplete or wrong-tree hits are unsafe.
         key: ${{ steps.compute.outputs.cache_key }}
 
@@ -125,7 +136,11 @@ runs:
         # env-indirection: step outputs must not expand into the script body (zizmor).
         CONTENT_HASH: ${{ steps.compute.outputs.hash }}
         EXECUTION: ${{ inputs.execution }}
+        SHARD: ${{ inputs.shard }}
       run: |
         set -euo pipefail
-        bun scripts/ci-routing.ts validate-success-marker \
-          --execution "${EXECUTION}" --hash "${CONTENT_HASH}"
+        args=(--execution "${EXECUTION}" --hash "${CONTENT_HASH}")
+        if [ -n "${SHARD}" ]; then
+          args+=(--shard "${SHARD}")
+        fi
+        bun scripts/ci-routing.ts validate-success-marker "${args[@]}"

--- a/.github/actions/ci-content-hash-write/action.yml
+++ b/.github/actions/ci-content-hash-write/action.yml
@@ -12,6 +12,13 @@ inputs:
   hash:
     description: Content hash from ci-content-hash-restore
     required: true
+  shard:
+    description: >
+      Optional matrix fan-out leg as "<index>/<total>" (1-based). Must match the
+      value passed to ci-content-hash-restore, or the leg writes a marker it can
+      never restore.
+    required: false
+    default: ""
 
 runs:
   using: composite
@@ -22,7 +29,11 @@ runs:
         # env-indirection: inputs must not expand into the script body (zizmor).
         CONTENT_HASH: ${{ inputs.hash }}
         EXECUTION: ${{ inputs.execution }}
+        SHARD: ${{ inputs.shard }}
       run: |
         set -euo pipefail
-        bun scripts/ci-routing.ts write-success-marker \
-          --execution "${EXECUTION}" --hash "${CONTENT_HASH}"
+        args=(--execution "${EXECUTION}" --hash "${CONTENT_HASH}")
+        if [ -n "${SHARD}" ]; then
+          args+=(--shard "${SHARD}")
+        fi
+        bun scripts/ci-routing.ts write-success-marker "${args[@]}"

--- a/.github/workflows/ci-component-journeys.yml
+++ b/.github/workflows/ci-component-journeys.yml
@@ -25,7 +25,22 @@ jobs:
   component-journeys:
     # Non-pixel docs/structure/a11y journeys. Routed via docs_journeys so
     # content-only PRs still get structure coverage without VR pixels.
-    name: component-journeys (docs a11y playwright)
+    #
+    # Sharded fan-out (issue #1035): 97 journey tests ran ~8min on two workers,
+    # the longest job on the critical path. Playwright shards natively and each
+    # leg gets its own runner, so per-test speed is preserved — unlike raising
+    # `workers`, which splits one runner's cores across more concurrent browsers
+    # and pushes cold-hydrate tests toward the 60s project budget (#944).
+    #
+    # The static docs build is repeated per leg rather than built once and
+    # fanned out: at ~70s it is cheaper to redo in parallel than to serialise a
+    # build job plus artifact upload/download ahead of every shard.
+    name: component-journeys (docs a11y playwright ${{ matrix.shard }}/4)
+    strategy:
+      # Report every failing leg in one run rather than cancelling siblings.
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
 
     runs-on: ubuntu-latest
     timeout-minutes: 25
@@ -54,6 +69,10 @@ jobs:
           bypass: ${{ inputs.bypass_content_cache }}
           disable: ${{ vars.CI_DISABLE_CONTENT_HASH }}
           container_tag: ${{ inputs.playwright_container_tag }}
+          # No collect job aggregates these legs, so each shard owns its own
+          # marker. A shared one would let a passing leg green-cache a failing
+          # sibling on the next run with identical content.
+          shard: ${{ matrix.shard }}/4
       - uses: ./.github/actions/ci-bun-install
         if: steps.content_hash.outputs.hit != 'true'
         with:
@@ -95,16 +114,18 @@ jobs:
           bun run test:visual --
           --project journeys
           --grep-invert 'visual contract'
+          --shard=${{ matrix.shard }}/4
       - uses: ./.github/actions/ci-content-hash-write
         if: steps.content_hash.outputs.hit != 'true' && steps.content_hash.outputs.bypass != 'true'
         with:
           execution: component_journeys
           hash: ${{ steps.content_hash.outputs.hash }}
+          shard: ${{ matrix.shard }}/4
       - name: upload journey failure artifacts
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: component-journeys-failure-artifacts
+          name: component-journeys-failure-artifacts-${{ matrix.shard }}
           path: |
             tests/visual/test-results/
             tests/visual/playwright-report/

--- a/.github/workflows/ci-component-svelte-fx.yml
+++ b/.github/workflows/ci-component-svelte-fx.yml
@@ -23,7 +23,16 @@ env:
 
 jobs:
   component-svelte-fx:
-    name: component-svelte-fx (packages/svelte firefox + webkit)
+    # Sharded fan-out (issue #1035). 122 test files x 2 engines = 244 file-runs,
+    # and vitest --shard splits that (file x project) task list, so a leg runs
+    # ~61 file-runs of mixed firefox/webkit. Coverage-free, so no merge step.
+    name: component-svelte-fx (firefox + webkit ${{ matrix.shard }}/4)
+    strategy:
+      # Report every failing leg in one run: a shard that dies on a browser
+      # harness flake must not hide a real failure in a sibling.
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
 
     runs-on: ubuntu-latest
     timeout-minutes: 25
@@ -52,6 +61,10 @@ jobs:
           bypass: ${{ inputs.bypass_content_cache }}
           disable: ${{ vars.CI_DISABLE_CONTENT_HASH }}
           container_tag: ${{ inputs.playwright_container_tag }}
+          # No collect job aggregates these legs, so each shard owns its own
+          # marker. A shared one would let a passing leg green-cache a failing
+          # sibling on the next run with identical content.
+          shard: ${{ matrix.shard }}/4
       - uses: ./.github/actions/ci-bun-install
         if: steps.content_hash.outputs.hit != 'true'
         with:
@@ -69,17 +82,18 @@ jobs:
       - name: component tests (packages/svelte, firefox + webkit)
         if: steps.content_hash.outputs.hit != 'true'
         working-directory: packages/svelte
-        run: bunx --bun vitest run --project firefox --project webkit
+        run: bunx --bun vitest run --project firefox --project webkit --shard=${{ matrix.shard }}/4
       - uses: ./.github/actions/ci-content-hash-write
         if: success() && steps.content_hash.outputs.hit != 'true' && steps.content_hash.outputs.bypass != 'true'
         with:
           execution: component_svelte_fx
           hash: ${{ steps.content_hash.outputs.hash }}
+          shard: ${{ matrix.shard }}/4
       - name: upload packages/svelte-fx failure artifacts
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: component-svelte-fx-failure-artifacts
+          name: component-svelte-fx-failure-artifacts-${{ matrix.shard }}
           path: packages/svelte/test-results/
           if-no-files-found: ignore
           retention-days: 7

--- a/.github/workflows/ci-component-svelte.yml
+++ b/.github/workflows/ci-component-svelte.yml
@@ -118,6 +118,10 @@ jobs:
         with:
           name: component-svelte-blob-${{ matrix.shard }}
           path: packages/svelte/.vitest-reports/
+          # `.vitest-reports` is a dotted directory and upload-artifact's glob
+          # skips hidden entries by default, so without this the upload finds
+          # nothing and the collect job starves for blobs.
+          include-hidden-files: true
           if-no-files-found: error
           retention-days: 1
       - name: upload packages/svelte failure artifacts

--- a/.github/workflows/ci-component-svelte.yml
+++ b/.github/workflows/ci-component-svelte.yml
@@ -25,8 +25,31 @@ env:
   PLAYWRIGHT_CONTAINER_TAG: ${{ inputs.playwright_container_tag }}
 
 jobs:
+  # Sharded chromium fan-out (issue #1035). Each leg runs ~41 of the 122 test
+  # files and emits a vitest blob report; the collect job below merges those
+  # blobs into one coverage report, enforces the thresholds, and uploads it.
+  #
+  # Why shard rather than raise maxWorkers: the suite spends ~95% of its time in
+  # per-file module import, not in test bodies (measured on this suite: `tests
+  # 22s` against `import 669s`). Those imports are served by ONE vite dev server
+  # per vitest process, so extra workers contend on it — 2→4 workers measured
+  # only 1.41x while cumulative import time rose. A shard gets its own runner
+  # and its own vite server, so it scales near-linearly (measured 2.48x on 3).
+  #
+  # Content-hash: every leg here — shards and collect — restores the SAME
+  # unsharded `component_svelte` marker, and only collect writes it (after all
+  # shards passed). One marker for one indivisible execution: the legs cannot
+  # disagree about whether to skip, so collect can never wake up to a cache hit
+  # with no blobs to merge. component-svelte-fx and component-journeys have no
+  # collect job and so use per-shard markers instead.
   component-svelte:
-    name: component-svelte (packages/svelte chromium + coverage + ssr)
+    name: component-svelte (chromium + coverage ${{ matrix.shard }}/3)
+    strategy:
+      # Report every failing leg in one run: a shard that dies on a browser
+      # harness flake must not hide a real failure in a sibling.
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
 
     runs-on: ubuntu-latest
     timeout-minutes: 25
@@ -65,29 +88,112 @@ jobs:
           package: playwright
           scope: packages/svelte
           container_tag: ${{ inputs.playwright_container_tag }}
-      # Chromium collects browser v8 coverage (CDP; works under bun) and enforces
-      # thresholds. SSR runs under bun without --coverage: @vitest/coverage-v8
-      # needs Node inspector Coverage APIs that bun does not implement
-      # ("Coverage APIs are not supported"). Local `test:coverage` can still
-      # collect SSR lcov under node for offline use. Firefox/webkit run in the
-      # parallel component-svelte-fx job (coverage-free).
+      # Chromium collects browser v8 coverage (CDP; works under bun). Thresholds
+      # are forced to 0 HERE and enforced once in the collect job: a shard sees
+      # only its own third of the suite, so the configured gate would fail on
+      # every leg. The blob report carries this shard's raw coverage forward.
       #
       # One shell retry: vitest `retry` only re-runs failed *tests*, not suite
       # import / iframe / coverage-v8 dynamic-import harness failures (PR #440).
       - name: component tests (packages/svelte, chromium + coverage)
         if: steps.content_hash.outputs.hit != 'true'
         working-directory: packages/svelte
+        env:
+          SHARD: ${{ matrix.shard }}/3
         run: |
           set -euo pipefail
-          if bunx --bun vitest run --coverage --project chromium; then
+          shard_args=(
+            --coverage --project chromium "--shard=${SHARD}" --reporter=blob
+            --coverage.thresholds.statements=0 --coverage.thresholds.branches=0
+            --coverage.thresholds.functions=0 --coverage.thresholds.lines=0
+          )
+          if bunx --bun vitest run "${shard_args[@]}"; then
             exit 0
           fi
-          echo "::warning::chromium+coverage failed once; retrying once for browser harness flake"
-          bunx --bun vitest run --coverage --project chromium
+          echo "::warning::chromium+coverage shard ${SHARD} failed once; retrying once for browser harness flake"
+          bunx --bun vitest run "${shard_args[@]}"
+      - name: upload chromium blob report
+        if: success() && steps.content_hash.outputs.hit != 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: component-svelte-blob-${{ matrix.shard }}
+          path: packages/svelte/.vitest-reports/
+          if-no-files-found: error
+          retention-days: 1
+      - name: upload packages/svelte failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: component-svelte-failure-artifacts-${{ matrix.shard }}
+          path: packages/svelte/test-results/
+          if-no-files-found: ignore
+          retention-days: 7
+
+  # Merge the shards' blob reports into one coverage report, enforce the
+  # thresholds the shards skipped, and upload the combined lcov. Also runs the
+  # SSR lane, which is ~15s and needs no browser — cheaper here than paying for
+  # it on a shard. Owns the content-hash marker for the whole execution.
+  component-svelte-coverage:
+    name: component-svelte (coverage merge + ssr)
+    needs: component-svelte
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    container:
+      # Keep in sync with inputs.playwright_container_tag above.
+      image: ghcr.io/${{ github.repository }}/ci-runner:${{ inputs.playwright_container_tag }}
+    defaults:
+      run:
+        shell: bash
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/ci-setup-bun
+      - uses: ./.github/actions/ci-content-hash-restore
+        id: content_hash
+        with:
+          execution: component_svelte
+          bypass: ${{ inputs.bypass_content_cache }}
+          disable: ${{ vars.CI_DISABLE_CONTENT_HASH }}
+          container_tag: ${{ inputs.playwright_container_tag }}
+      - uses: ./.github/actions/ci-bun-install
+        if: steps.content_hash.outputs.hit != 'true'
+        with:
+          cache_key_prefix: bun-container
+      - uses: ./.github/actions/ci-download-packages-dist
+        if: steps.content_hash.outputs.hit != 'true'
+      - name: download chromium blob reports
+        if: steps.content_hash.outputs.hit != 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: component-svelte-blob-*
+          merge-multiple: true
+          path: packages/svelte/.vitest-reports/
+      # SSR runs under bun without --coverage: @vitest/coverage-v8 needs Node
+      # inspector Coverage APIs that bun does not implement ("Coverage APIs are
+      # not supported"). Local `test:coverage` can still collect SSR lcov under
+      # node for offline use.
       - name: component tests (packages/svelte, SSR)
         if: steps.content_hash.outputs.hit != 'true'
         working-directory: packages/svelte
         run: bunx --bun vitest run --config vitest.ssr.config.ts
+      # --project chromium keeps coverage-v8 from rejecting the firefox/webkit
+      # instances the config also declares; it does not re-run anything. This is
+      # the ONLY place the configured thresholds are enforced.
+      - name: merge shard coverage and enforce thresholds
+        if: steps.content_hash.outputs.hit != 'true'
+        working-directory: packages/svelte
+        run: |
+          set -euo pipefail
+          shards=$(find .vitest-reports -name 'blob-*.json' | wc -l)
+          if [ "${shards}" -eq 0 ]; then
+            echo "::error::no blob reports to merge — shard artifacts missing"
+            exit 1
+          fi
+          echo "merging ${shards} chromium blob report(s)"
+          bunx --bun vitest --merge-reports --project chromium --coverage
       - name: rewrite svelte lcov paths to monorepo root
         # vitest writes SF:src/lib/... relative to packages/svelte; Codecov
         # components filter packages/svelte/** so paths must be repo-rooted.
@@ -127,18 +233,11 @@ jobs:
           fail_ci_if_error: true
       - uses: ./.github/actions/ci-content-hash-write
         # Require success so a Codecov upload failure cannot green-cache the job.
+        # `needs: component-svelte` already guarantees every shard passed.
         if: success() && steps.content_hash.outputs.hit != 'true' && steps.content_hash.outputs.bypass != 'true'
         with:
           execution: component_svelte
           hash: ${{ steps.content_hash.outputs.hash }}
-      - name: upload packages/svelte failure artifacts
-        if: failure()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: component-svelte-failure-artifacts
-          path: packages/svelte/test-results/
-          if-no-files-found: ignore
-          retention-days: 7
 
   # Parallel sibling of component-svelte: firefox + webkit only (no coverage).
   # Distinct content-hash execution so a chromium cache hit cannot skip these

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ apps/docs/test-results/
 spikes/browser/test-results/
 benchmarks/results/
 .vitest-attachments/
+# vitest --reporter=blob output; written by sharded component runs (issue #1035)
+.vitest-reports/
 spikes/**/__screenshots__/
 packages/svelte/tests/__screenshots__/
 *.tsbuildinfo

--- a/scripts/ci-composites.test.ts
+++ b/scripts/ci-composites.test.ts
@@ -26,6 +26,9 @@ const PLAYWRIGHT_VERSION_SYNC_JOBS = [
 const PACKAGES_DIST_CONSUMERS = [
   "consumer-compat",
   "component-svelte",
+  // The collect job runs the SSR lane and resolves the config for the coverage
+  // merge, so it needs packages/*/dist just as its shards do (issue #1035).
+  "component-svelte-coverage",
   "component-svelte-fx",
   "component-spikes",
   "component-journeys",
@@ -41,6 +44,7 @@ const SETUP_BUN_JOBS = [
   "compatibility-matrix",
   "consumer-compat",
   "component-svelte",
+  "component-svelte-coverage",
   "component-svelte-fx",
   "component-spikes",
   "component-journeys",
@@ -60,6 +64,7 @@ const BUN_INSTALL_JOBS = [
   "checks",
   "unit",
   "component-svelte",
+  "component-svelte-coverage",
   "component-svelte-fx",
   "component-spikes",
   "component-journeys",
@@ -73,6 +78,7 @@ const BUN_INSTALL_JOBS = [
 
 const CONTAINER_BUN_INSTALL_JOBS = new Set([
   "component-svelte",
+  "component-svelte-coverage",
   "component-svelte-fx",
   "component-spikes",
   "component-journeys",
@@ -136,9 +142,10 @@ describe("ci-download-packages-dist composite", () => {
         /download-artifact@[0-9a-f]+[\s\S]{0,120}name:\s*packages-dist/,
       );
     }
-    // Exactly six uses in ci.yml (component-svelte split into chromium + fx).
+    // One use per consumer, and no others: component-svelte is chromium shards
+    // plus a coverage-merge collect job, alongside fx / spikes / journeys.
     const uses = ci.match(/uses: \.\/\.github\/actions\/ci-download-packages-dist/g) ?? [];
-    expect(uses.length).toBe(6);
+    expect(uses.length).toBe(PACKAGES_DIST_CONSUMERS.length);
   });
 });
 

--- a/scripts/ci-routing.test.ts
+++ b/scripts/ci-routing.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { readdirSync, readFileSync } from "node:fs";
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import {
@@ -24,6 +25,7 @@ import {
   requireJobInputDigests,
   serializeSuccessMarker,
   shouldBypassContentCache,
+  successMarkerPath,
   validateSuccessMarker,
   type JobName,
 } from "./ci-routing.ts";
@@ -1000,6 +1002,81 @@ describe("contentHashCacheKey", () => {
   });
 });
 
+describe("sharded executions cache independently", () => {
+  // Component suites fan out over matrix shards (vitest --shard / playwright
+  // --shard). Each leg runs on its own runner but hashes the same content, so
+  // shard identity MUST reach the cache key and the success marker. Without it
+  // a passing shard 1 would write the marker that a failing shard 2 later
+  // restores as a hit — a false green on the next run with identical content.
+  test("shard index and total change the cache key", () => {
+    const base = { execution: "component_svelte_fx" as const, hash: "abc123", os: "Linux" };
+    const unsharded = contentHashCacheKey(base);
+    const one = contentHashCacheKey({ ...base, shard: { index: 1, total: 3 } });
+    const two = contentHashCacheKey({ ...base, shard: { index: 2, total: 3 } });
+    const twoOfFour = contentHashCacheKey({ ...base, shard: { index: 2, total: 4 } });
+
+    expect(one).toContain("shard1of3");
+    expect(one).not.toBe(two);
+    expect(one).not.toBe(unsharded);
+    // Re-shaping the fan-out must not let an old leg's marker validate.
+    expect(two).not.toBe(twoOfFour);
+    // The unsharded key stays byte-identical so unsharded executions keep
+    // their existing caches when this dimension is added.
+    expect(unsharded).toBe(`ggsvelte-ch-v${CONTENT_HASH_SCHEMA}-component_svelte_fx-Linux-abc123`);
+  });
+
+  test("shard gets its own success-marker path", () => {
+    expect(successMarkerPath("component_svelte_fx")).toBe(
+      ".ci-content-hash/component_svelte_fx.ok",
+    );
+    expect(successMarkerPath("component_svelte_fx", { index: 2, total: 3 })).toBe(
+      ".ci-content-hash/component_svelte_fx-2of3.ok",
+    );
+  });
+
+  test("a marker from another shard does not validate", () => {
+    const marker = parseSuccessMarker(
+      serializeSuccessMarker({
+        schema: CONTENT_HASH_SCHEMA,
+        execution: "component_svelte_fx",
+        hash: "abc",
+        shard: { index: 1, total: 3 },
+      }),
+    );
+    expect(marker).toEqual({
+      schema: CONTENT_HASH_SCHEMA,
+      execution: "component_svelte_fx",
+      hash: "abc",
+      shard: { index: 1, total: 3 },
+    });
+
+    const expected = { execution: "component_svelte_fx" as const, hash: "abc" };
+    expect(validateSuccessMarker(marker, { ...expected, shard: { index: 1, total: 3 } })).toBe(
+      true,
+    );
+    // The false-green this guards: shard 1's marker satisfying shard 2.
+    expect(validateSuccessMarker(marker, { ...expected, shard: { index: 2, total: 3 } })).toBe(
+      false,
+    );
+    expect(validateSuccessMarker(marker, { ...expected, shard: { index: 1, total: 4 } })).toBe(
+      false,
+    );
+    // An unsharded expectation must not accept a sharded marker, or vice versa.
+    expect(validateSuccessMarker(marker, expected)).toBe(false);
+    const unsharded = parseSuccessMarker(
+      serializeSuccessMarker({
+        schema: CONTENT_HASH_SCHEMA,
+        execution: "component_svelte_fx",
+        hash: "abc",
+      }),
+    );
+    expect(validateSuccessMarker(unsharded, { ...expected, shard: { index: 1, total: 3 } })).toBe(
+      false,
+    );
+    expect(validateSuccessMarker(unsharded, expected)).toBe(true);
+  });
+});
+
 describe("git ls-tree digests include mode", () => {
   test("mode-only change changes the entry digest", () => {
     const blob = parseGitLsTreeLine(
@@ -1124,6 +1201,102 @@ async function spawnCiRoutingCli(
   ]);
   return { stdout, stderr, exitCode };
 }
+
+/**
+ * Spawn the routing CLI in a throwaway cwd so marker writes land there rather
+ * than in the repo tree.
+ */
+async function spawnCiRoutingCliIn(
+  cwd: string,
+  args: string[],
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const proc = Bun.spawn(["bun", join(import.meta.dir, "ci-routing.ts"), ...args], {
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { stdout, stderr, exitCode };
+}
+
+describe("success-marker CLI carries shard identity", () => {
+  test("a shard validates only its own marker", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "ci-routing-shard-"));
+    try {
+      const write = await spawnCiRoutingCliIn(cwd, [
+        "write-success-marker",
+        "--execution",
+        "component_svelte_fx",
+        "--hash",
+        "abc123",
+        "--shard",
+        "1/3",
+      ]);
+      expect(write.exitCode).toBe(0);
+      expect(write.stdout.trim()).toBe(".ci-content-hash/component_svelte_fx-1of3.ok");
+
+      const own = await spawnCiRoutingCliIn(cwd, [
+        "validate-success-marker",
+        "--execution",
+        "component_svelte_fx",
+        "--hash",
+        "abc123",
+        "--shard",
+        "1/3",
+      ]);
+      expect(own.stdout).toContain("hit=true");
+
+      // Shard 2 has written no marker of its own: it must miss, not inherit
+      // shard 1's success.
+      const other = await spawnCiRoutingCliIn(cwd, [
+        "validate-success-marker",
+        "--execution",
+        "component_svelte_fx",
+        "--hash",
+        "abc123",
+        "--shard",
+        "2/3",
+      ]);
+      expect(other.stdout).toContain("hit=false");
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  test("hash-inputs emits a shard-scoped cache key and marker path", async () => {
+    const out = await spawnCiRoutingCli([
+      "hash-inputs",
+      "--execution",
+      "component_svelte_fx",
+      "--os",
+      "Linux",
+      "--shard",
+      "2/3",
+    ]);
+    expect(out.exitCode).toBe(0);
+    expect(out.stdout).toContain("shard2of3");
+    expect(out.stdout).toContain("marker_path=.ci-content-hash/component_svelte_fx-2of3.ok");
+  });
+
+  test("a malformed --shard is rejected rather than silently unsharded", async () => {
+    for (const bad of ["0/3", "4/3", "1", "x/3", "1/0"]) {
+      const out = await spawnCiRoutingCli([
+        "write-success-marker",
+        "--execution",
+        "component_svelte_fx",
+        "--hash",
+        "abc123",
+        "--shard",
+        bad,
+      ]);
+      expect(out.exitCode, bad).not.toBe(0);
+    }
+  });
+});
 
 describe("ci-routing module tree (split-safe)", () => {
   test("subtree files set ci_routing, force full surface, and bypass content cache", () => {

--- a/scripts/ci-routing/cli.ts
+++ b/scripts/ci-routing/cli.ts
@@ -28,6 +28,7 @@ import {
   successMarkerPath,
   validateSuccessMarker,
   type CacheableExecution,
+  type ExecutionShard,
 } from "./content-hash";
 import { runDetectChanges, type DetectChangesInput, type DetectChangesIo } from "./detect-changes";
 
@@ -125,9 +126,9 @@ function printHelp(): void {
   bun scripts/ci-routing.ts plan [--files ... | --from-git --base <ref> | --stdin] [--force-all]
   bun scripts/ci-routing.ts emit-github-output [--files ... | --from-git --base <ref> | --stdin] [--force-all]
   bun scripts/ci-routing.ts detect-changes
-  bun scripts/ci-routing.ts hash-inputs --execution <name> [--os <runner.os>] [--container-tag <tag>] [--matrix-node N --matrix-pm NAME --matrix-pm-version V --matrix-svelte V] [--runtime-node-version V --runtime-pm-version V]
-  bun scripts/ci-routing.ts write-success-marker --execution <name> --hash <hex>
-  bun scripts/ci-routing.ts validate-success-marker --execution <name> --hash <hex>
+  bun scripts/ci-routing.ts hash-inputs --execution <name> [--os <runner.os>] [--container-tag <tag>] [--shard I/N] [--matrix-node N --matrix-pm NAME --matrix-pm-version V --matrix-svelte V] [--runtime-node-version V --runtime-pm-version V]
+  bun scripts/ci-routing.ts write-success-marker --execution <name> --hash <hex> [--shard I/N]
+  bun scripts/ci-routing.ts validate-success-marker --execution <name> --hash <hex> [--shard I/N]
   bun scripts/ci-routing.ts gate --required <file|-> --results <file|->
   bun scripts/ci-routing.ts ci-gate
   bun scripts/ci-routing.ts vr-gate
@@ -327,10 +328,32 @@ function parseCacheableExecution(raw: string | undefined): CacheableExecution {
   return raw as CacheableExecution;
 }
 
+/**
+ * `--shard <index>/<total>` (1-based), matching the vitest / playwright CLI
+ * spelling the component jobs already pass through. Absent means unsharded.
+ * Fail-closed: a malformed value must not silently degrade to unsharded, or a
+ * typo in a matrix leg would make every leg share one marker.
+ */
+function parseShardFlag(args: string[]): ExecutionShard | undefined {
+  const raw = flagValue(args, "--shard");
+  if (raw === undefined) return undefined;
+  const match = /^(\d+)\/(\d+)$/.exec(raw);
+  if (match === null) {
+    throw new Error(`--shard must look like <index>/<total> (1-based); got "${raw}"`);
+  }
+  const index = Number(match[1]);
+  const total = Number(match[2]);
+  if (total < 1 || index < 1 || index > total) {
+    throw new Error(`--shard index must be within 1..total; got "${raw}"`);
+  }
+  return { index, total };
+}
+
 async function runHashInputsCli(args: string[]): Promise<void> {
   const execution = parseCacheableExecution(flagValue(args, "--execution"));
   const os = flagValue(args, "--os") ?? process.env["RUNNER_OS"] ?? "unknown";
   const containerTag = flagValue(args, "--container-tag");
+  const shard = parseShardFlag(args);
   const matrixNode = flagValue(args, "--matrix-node");
   const matrixPm = flagValue(args, "--matrix-pm");
   const matrixPmVersion = flagValue(args, "--matrix-pm-version");
@@ -374,10 +397,11 @@ async function runHashInputsCli(args: string[]): Promise<void> {
     hash,
     os,
     ...(containerTag === undefined ? {} : { containerTag }),
+    ...(shard === undefined ? {} : { shard }),
     ...(matrix === undefined ? {} : { matrix }),
     ...(runtime === undefined ? {} : { runtime }),
   });
-  const marker = successMarkerPath(execution);
+  const marker = successMarkerPath(execution, shard);
   const body = [
     `hash=${hash}`,
     `cache_key=${cacheKey}`,
@@ -399,12 +423,18 @@ function runWriteSuccessMarkerCli(args: string[]): void {
   if (hash === undefined || hash.length === 0) {
     throw new Error("write-success-marker requires --hash <hex>");
   }
-  const path = successMarkerPath(execution);
+  const shard = parseShardFlag(args);
+  const path = successMarkerPath(execution, shard);
   const dir = path.slice(0, path.lastIndexOf("/"));
   mkdirSync(dir, { recursive: true });
   writeFileSync(
     path,
-    serializeSuccessMarker({ schema: CONTENT_HASH_SCHEMA, execution, hash }),
+    serializeSuccessMarker({
+      schema: CONTENT_HASH_SCHEMA,
+      execution,
+      hash,
+      ...(shard === undefined ? {} : { shard }),
+    }),
     "utf8",
   );
   process.stdout.write(`${path}\n`);
@@ -416,7 +446,8 @@ async function runValidateSuccessMarkerCli(args: string[]): Promise<void> {
   if (hash === undefined || hash.length === 0) {
     throw new Error("validate-success-marker requires --hash <hex>");
   }
-  const path = successMarkerPath(execution);
+  const shard = parseShardFlag(args);
+  const path = successMarkerPath(execution, shard);
   const file = Bun.file(path);
   if (!(await file.exists())) {
     process.stdout.write("hit=false\n");
@@ -425,7 +456,11 @@ async function runValidateSuccessMarkerCli(args: string[]): Promise<void> {
   }
   const body = await file.text();
   const marker = parseSuccessMarker(body);
-  const ok = validateSuccessMarker(marker, { execution, hash });
+  const ok = validateSuccessMarker(marker, {
+    execution,
+    hash,
+    ...(shard === undefined ? {} : { shard }),
+  });
   const line = `hit=${ok ? "true" : "false"}\n`;
   process.stdout.write(line);
   writeGithubOutput(line);

--- a/scripts/ci-routing/content-hash.ts
+++ b/scripts/ci-routing/content-hash.ts
@@ -399,10 +399,26 @@ export function shouldBypassContentCache(changes: ChangeFlags, options: PlanOpti
   if (options.forceAll === true) return true;
   return changes.lockfile || changes.ci_workflow || changes.ci_routing || changes.ci_actions;
 }
+/**
+ * One leg of a matrixed fan-out (vitest / playwright `--shard=index/total`).
+ * 1-based `index`, matching both runners' CLI convention.
+ *
+ * Shard identity is part of cache identity: the legs hash the same content but
+ * execute disjoint test files, so a marker written by one leg must never
+ * satisfy another. `total` is included so re-shaping the fan-out (3 → 4 legs)
+ * misses every old marker instead of reusing legs that now cover other files.
+ */
+export type ExecutionShard = {
+  index: number;
+  total: number;
+};
+
 export type ContentHashCacheKeyInput = {
   execution: CacheableExecution;
   hash: string;
   os: string;
+  /** Fan-out leg for sharded component executions. */
+  shard?: ExecutionShard;
   /** Extra dimensions for matrixed jobs (consumer). */
   matrix?: {
     node: string;
@@ -427,6 +443,9 @@ export function contentHashCacheKey(input: ContentHashCacheKeyInput): string {
   if (input.containerTag !== undefined && input.containerTag.length > 0) {
     parts.push(sanitizeKeyPart(input.containerTag));
   }
+  if (input.shard !== undefined) {
+    parts.push(formatShardKeyPart(input.shard));
+  }
   if (input.matrix !== undefined) {
     parts.push(
       `node${sanitizeKeyPart(input.matrix.node)}`,
@@ -449,10 +468,34 @@ function sanitizeKeyPart(value: string): string {
   return value.replaceAll(/[^a-zA-Z0-9._-]+/g, "");
 }
 
+/** `shard1of3` — stable in both cache keys and marker filenames. */
+function formatShardKeyPart(shard: ExecutionShard): string {
+  return `shard${shard.index}of${shard.total}`;
+}
+
+function parseShard(value: unknown): ExecutionShard | null {
+  if (value === null || typeof value !== "object") return null;
+  const obj = value as Record<string, unknown>;
+  const index = obj["index"];
+  const total = obj["total"];
+  if (!Number.isInteger(index) || !Number.isInteger(total)) return null;
+  const i = index as number;
+  const t = total as number;
+  if (i < 1 || t < 1 || i > t) return null;
+  return { index: i, total: t };
+}
+
+function sameShard(a: ExecutionShard | undefined, b: ExecutionShard | undefined): boolean {
+  if (a === undefined || b === undefined) return a === undefined && b === undefined;
+  return a.index === b.index && a.total === b.total;
+}
+
 export type SuccessMarker = {
   schema: number;
   execution: CacheableExecution;
   hash: string;
+  /** Present only for legs of a sharded execution. */
+  shard?: ExecutionShard;
 };
 
 export function serializeSuccessMarker(marker: SuccessMarker): string {
@@ -468,11 +511,17 @@ export function parseSuccessMarker(body: string): SuccessMarker | null {
     if (typeof obj["execution"] !== "string") return null;
     if (typeof obj["hash"] !== "string" || obj["hash"].length === 0) return null;
     if (!(CACHEABLE_EXECUTIONS as readonly string[]).includes(obj["execution"])) return null;
-    return {
+    const base = {
       schema: obj["schema"],
       execution: obj["execution"] as CacheableExecution,
       hash: obj["hash"],
     };
+    if (obj["shard"] === undefined) return base;
+    // A shard field that is present but unreadable is a corrupt marker, not an
+    // unsharded one — fail closed rather than validating against the wrong leg.
+    const shard = parseShard(obj["shard"]);
+    if (shard === null) return null;
+    return { ...base, shard };
   } catch {
     return null;
   }
@@ -480,20 +529,27 @@ export function parseSuccessMarker(body: string): SuccessMarker | null {
 
 export function validateSuccessMarker(
   marker: SuccessMarker | null,
-  expected: { execution: CacheableExecution; hash: string; schema?: number },
+  expected: {
+    execution: CacheableExecution;
+    hash: string;
+    schema?: number;
+    shard?: ExecutionShard;
+  },
 ): boolean {
   if (marker === null) return false;
   const schema = expected.schema ?? CONTENT_HASH_SCHEMA;
   return (
     marker.schema === schema &&
     marker.execution === expected.execution &&
-    marker.hash === expected.hash
+    marker.hash === expected.hash &&
+    sameShard(marker.shard, expected.shard)
   );
 }
 
 /** Success-marker path relative to repo root (actions/cache path). */
-export function successMarkerPath(execution: CacheableExecution): string {
-  return `.ci-content-hash/${execution}.ok`;
+export function successMarkerPath(execution: CacheableExecution, shard?: ExecutionShard): string {
+  const leg = shard === undefined ? "" : `-${shard.index}of${shard.total}`;
+  return `.ci-content-hash/${execution}${leg}.ok`;
 }
 
 /** Parse one `git ls-tree -r` line into mode/type/oid/path. */

--- a/scripts/release-wiring.test.ts
+++ b/scripts/release-wiring.test.ts
@@ -394,6 +394,11 @@ describe("R0 release wiring", () => {
     expect(svelteShards).toContain("matrix:");
     expect(svelteShards).toContain("--reporter=blob");
     expect(svelteShards).not.toContain("uses: ./.github/actions/ci-content-hash-write");
+    // vitest writes blob reports to `.vitest-reports/`, and upload-artifact's
+    // glob skips dotfiles unless told otherwise — without this the upload finds
+    // nothing, fails on `if-no-files-found: error`, and the collect job is
+    // skipped for want of blobs. Cost one CI round on PR #1036.
+    expect(svelteShards).toContain("include-hidden-files: true");
     const svelteCollect = ciJob(ci, "component-svelte-coverage");
     expect(svelteCollect.length).toBeGreaterThan(0);
     expect(svelteCollect).toContain("needs: component-svelte");

--- a/scripts/release-wiring.test.ts
+++ b/scripts/release-wiring.test.ts
@@ -309,11 +309,14 @@ describe("R0 release wiring", () => {
     // Protocol lives in composites (single source of truth).
     expect(restore).toContain("hash-inputs");
     expect(restore).toContain("validate-success-marker");
-    expect(restore).toContain(".ci-content-hash/");
     expect(restore).toContain("shell: bash");
+    // The cached path is whatever hash-inputs computed, not a fixed name:
+    // sharded executions get one marker per matrix leg (issue #1035), so a
+    // hardcoded `.ci-content-hash/<execution>.ok` would cache the wrong file.
+    expect(restore).toContain("path: ${{ steps.compute.outputs.marker_path }}");
     // Exact key only — no restore-keys on the success-marker cache step.
     const markerCache = restore.slice(
-      restore.indexOf("path: .ci-content-hash/"),
+      restore.indexOf("id: marker_cache"),
       restore.indexOf("validate-success-marker"),
     );
     expect(markerCache).toContain("key:");
@@ -351,8 +354,6 @@ describe("R0 release wiring", () => {
     expect(unitJob).toContain("CI_DISABLE_CONTENT_HASH");
 
     // Distinct physical keys for component shards (Codex P1).
-    // component-svelte is longer (coverage + Codecov upload steps) — use a
-    // generous window so the content-hash write is still inside the slice.
     for (const [job, execution] of [
       ["component-svelte", "component_svelte"],
       ["component-svelte-fx", "component_svelte_fx"],
@@ -364,8 +365,41 @@ describe("R0 release wiring", () => {
       expect(slice).toContain("uses: ./.github/actions/ci-content-hash-restore");
       expect(slice).toContain(`execution: ${execution}`);
       expect(slice).toContain("container_tag:");
-      expect(slice).toContain("uses: ./.github/actions/ci-content-hash-write");
     }
+
+    // Sharded executions (issue #1035) must not let one matrix leg's success
+    // green-cache a failing sibling. Two shapes are valid, and each component
+    // execution must use exactly one of them:
+    //   - self-marking: the leg writes its own per-shard marker (--shard I/N)
+    //   - collect-marked: a downstream job that `needs` every leg writes the
+    //     single unsharded marker once they have all passed
+    for (const [job, execution] of [
+      ["component-svelte-fx", "component_svelte_fx"],
+      ["component-journeys", "component_journeys"],
+    ] as const) {
+      const slice = ciJob(ci, job);
+      expect(slice, job).toContain("matrix:");
+      expect(slice, job).toContain("uses: ./.github/actions/ci-content-hash-write");
+      // Both the restore and the write must carry the leg identity, or the
+      // legs would share one marker.
+      const shardArgs = slice.match(/shard: \$\{\{ matrix\.shard }}\/\d+/g) ?? [];
+      expect(shardArgs.length, `${execution} passes shard to restore and write`).toBe(2);
+      // The CLI shard and the marker shard must agree.
+      expect(slice, job).toContain("--shard=${{ matrix.shard }}");
+    }
+
+    // component-svelte is collect-marked: shards emit blob reports and write no
+    // marker; the collect job merges them, gates coverage, and marks success.
+    const svelteShards = ciJob(ci, "component-svelte");
+    expect(svelteShards).toContain("matrix:");
+    expect(svelteShards).toContain("--reporter=blob");
+    expect(svelteShards).not.toContain("uses: ./.github/actions/ci-content-hash-write");
+    const svelteCollect = ciJob(ci, "component-svelte-coverage");
+    expect(svelteCollect.length).toBeGreaterThan(0);
+    expect(svelteCollect).toContain("needs: component-svelte");
+    expect(svelteCollect).toContain("--merge-reports");
+    expect(svelteCollect).toContain("uses: ./.github/actions/ci-content-hash-write");
+    expect(svelteCollect).toContain("execution: component_svelte");
 
     // Consumer: runtime resolution stays in the job; matrix dims pass into restore composite.
     const consumerJob = ciJob(ci, "consumer-compat");


### PR DESCRIPTION
Closes #1035.

## The bottleneck

The three component jobs were the entire critical path of `ci.yml`. From run [30301236617](https://github.com/ljodea/ggsvelte/actions/runs/30301236617), a green run on `main`:

| job | wall | test step |
|---|---|---|
| component-journeys | 10m07s | 8m06s |
| component-svelte-fx | 9m44s | 8m50s |
| component-svelte (chromium + coverage) | 7m29s | 6m16s |
| everything else | done by 3m38s | |

Total 12m15s. Setup was never the problem — each job was ready to test within 50s.

## Why it is slow

Vitest says so directly. Chromium:

```
Test Files  122 passed (122)
  Duration  374.79s (transform 0ms, setup 0ms, import 669.14s, tests 22.16s)
```

Test bodies take 22 seconds; per-file module import takes 669. Browser mode gives every test file its own iframe, and each iframe re-imports the module graph.

## What I measured before changing anything

- **`optimizeDeps.exclude` is not the cause.** Swapping it for `include` moved the legend subset 26.4s → 25.5s. Ruled out.
- **`isolate: false` is not safe.** It cuts that subset 25.5s → 11.6s, but the full suite dies at file 26 of 122 with `Browser connection was closed while running tests`. The existing config comment holds.
- **More workers scale badly.** 2 → 4 workers took the full chromium suite 104s → 74s: 1.41x for double the workers, and cumulative import time *rose* 166s → 223s. Every worker in one vitest process shares one vite dev server and they contend on it.
- **Sharding scales.** Three shards at the CI worker count ran 35.7s / 40.0s / 41.9s against 104s unsharded — 2.48x, evenly balanced. Each shard is its own runner with its own server.

## The change

Matrix legs: chromium 3, firefox+webkit 4, journeys 4. All `fail-fast: false`, so one flaky leg no longer hides a real failure in a sibling.

**Coverage** needs a collect step. Shards run `--reporter=blob` with thresholds forced to 0 — a shard sees a third of the suite, so the configured gate would fail on every leg. A downstream `component-svelte-coverage` job merges the blobs with `vitest --merge-reports`, enforces the real thresholds once, runs the SSR lane, and uploads the combined lcov.

**Success markers** grow a shard dimension, and this is the part worth reviewing closely. Legs of one execution hash the same content but run disjoint files, so without shard identity a passing leg writes the marker a failing sibling later restores as a hit — a false green on the next run with identical content. `total` is in the key too, so re-shaping a fan-out misses every old marker rather than reusing legs that now cover other files.

Two shapes are allowed, and `release-wiring.test.ts` pins that each execution uses exactly one:

- **self-marking** — the leg carries `--shard I/N` into its own marker (fx, journeys)
- **collect-marked** — shards write nothing; the collect job writes the single unsharded marker after `needs` guarantees they all passed (component-svelte). This also means the legs cannot disagree about whether to skip, so collect never wakes to a cache hit with no blobs to merge.

`ci.yml` and `ci-gate` are untouched: sharding happens inside the reusable workflows, so caller job names and branch protection are unchanged.

## Measured result

Fully green run [30307295118](https://github.com/ljodea/ggsvelte/actions/runs/30307295118):

| job | before | after | shards |
|---|---|---|---|
| component-svelte-fx | 9m44s | **3m33s** | 177 / 213 / 153 / 179s |
| component-svelte | 7m29s | **4m56s** | 175 / 219 / 209s + 77s merge |
| component-journeys | 10m07s | **7m35s** | 206 / 159 / **455** / 214s |
| **whole run** | **12m15s** | **9m28s** | |

The merge is verified in CI, not just locally — `merging 3 chromium blob report(s)` → `Test Files 122 passed (122)`, coverage 91.74 / 88.96 / 91.90 / 93.49 against the 90 / 80 / 90 / 90 gate, combined lcov uploaded to Codecov.

**I have to correct my own earlier estimate.** I predicted roughly 5m30s. The real number is 9m28s, and the reason is visible in the journeys row: shard 3 takes 455s while its siblings take ~200s. Playwright balances shards by test *count*, not duration, and `docs-themes` is **503s of the 963s of journey time in 14 of ~97 tests** — every one of its tests loads `/themes`, which renders every built-in theme as a live interactive chart. Sharding cannot fix that; it needs ~8 shards to buy 2 minutes, which is a poor trade for four more runners each rebuilding the docs site.

So `component-journeys` is now the bottleneck on its own, and the remaining win lives in #1037, which carries the full per-spec profile and three concrete options.

## Not done here

Journeys are the one suite where raising `workers` scales — they serve a prebuilt static site, and 2 → 4 workers measured 4.5m → 2.7m locally. I left it alone deliberately: `docs-themes` tests already average 36s against the journeys project's 60s budget (#944), and putting four browsers on a four-core runner would eat that margin. That is the timeout-flake class this PR is meant to reduce, not feed. Worth revisiting with measurement, not assumption.

## One flake, seen and re-run

The first CI attempt hit `playground.spec.ts:178 › initial candidate keeps the pending status until promotion` — a 5s predicate timeout. That is the exact test from #352, fixed in #383, and documented there as runner-load-sensitive. It passed on the next run with no change to it. I am flagging it rather than burying it: sharding changes which tests share a runner, so this class deserves watching. Noted on #352.

## Verification

- `bun test scripts/` — 1318 pass, 0 fail
- `bun run lint:actions` — 28 workflow files clean
- `uvx zizmor==1.26.1 .github/workflows .github/actions` — no findings
- `bun run fmt:check`, `oxlint --type-aware --deny-warnings scripts/`, `tsc -p scripts/ci-routing` — clean
- CI: all 12 component legs green, ci-gate green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
