### PR TITLE
fix(docs): fit install code width and restore grammar demo copy

### DIFF
--- a/apps/docs/src/lib/components/CopyCode.svelte
+++ b/apps/docs/src/lib/components/CopyCode.svelte
@@ -58,9 +58,9 @@
 <style>
   .copy-code {
     position: relative;
-    /* Bound width so long pre lines scroll inside .code-body and the absolute
-       copy trigger stays inside the visible card (not past document edge). */
-    width: 100%;
+    /* Fit the snippet; cap at the parent so long pre lines scroll inside
+       .code-body and the absolute copy trigger stays on-card. */
+    width: fit-content;
     max-width: 100%;
     min-width: 0;
     overflow: hidden;

--- a/apps/docs/src/lib/components/GrammarDemo.svelte
+++ b/apps/docs/src/lib/components/GrammarDemo.svelte
@@ -11,7 +11,7 @@
     { label: "Data", note: "Rows as plain objects." },
     { label: "Mappings", note: "aes for x, y, and color." },
     { label: "Layers", note: "GeomSmooth over GeomPoint." },
-    { label: "Interaction", note: "inspect and pin." },
+    { label: "Interaction", note: "just one more layer" },
   ] as const;
   let active = $state(steps.length - 1);
   const chartTheme = $derived(contrastChartTheme());
@@ -19,8 +19,8 @@
 
 <section class="grammar-demo" aria-labelledby="grammar-heading">
   <div class="grammar-copy">
-    <h2 id="grammar-heading">Inspect and pin are plot props.</h2>
-    <p>No D3 — not a second interaction library.</p>
+    <h2 id="grammar-heading">Interaction is a layer.</h2>
+    <p>Zero D3.js. Inspect and pin are plot props.</p>
     <ol>
       {#each steps as step, index (step.label)}
         <li class:active={active === index}>
@@ -76,7 +76,7 @@
   }
 
   h2 {
-    max-width: 18ch;
+    max-width: 12ch;
     margin: 0.25rem 0 1rem;
     font-size: clamp(2.5rem, 5vw, 4.5rem);
     line-height: 0.95;

--- a/apps/docs/src/routes/+page.svelte
+++ b/apps/docs/src/routes/+page.svelte
@@ -131,7 +131,7 @@
     <h2 id="code-path-heading">
       Svelte for builders, JSON for embedded agents.
     </h2>
-    <p>Author in Svelte. Agents emit the same chart as PortableSpec JSON.</p>
+    <p>Same chart as Svelte, builder TypeScript, or Spec (JSON).</p>
   </div>
   <CodeTabs {tabs} />
 </section>

--- a/apps/docs/src/routes/+page.svelte
+++ b/apps/docs/src/routes/+page.svelte
@@ -132,9 +132,8 @@
       Svelte for builders, JSON for embedded agents.
     </h2>
     <p>
-      Svelte components help human-agent teams reason about visualizations
-      together. JSON specs allow agents operating in webapps to make interactive
-      charts on demand for rendering on-the-fly.
+      Human-agent pairs get Svelte components for clarity. Embedded agents can
+      use JSON specs for interactive charts on demand.
     </p>
   </div>
   <CodeTabs {tabs} />

--- a/apps/docs/src/routes/+page.svelte
+++ b/apps/docs/src/routes/+page.svelte
@@ -131,7 +131,11 @@
     <h2 id="code-path-heading">
       Svelte for builders, JSON for embedded agents.
     </h2>
-    <p>Same chart as Svelte, builder TypeScript, or Spec (JSON).</p>
+    <p>
+      Svelte components help human-agent teams reason about visualizations
+      together. JSON specs allow agents operating in webapps to make interactive
+      charts on demand for rendering on-the-fly.
+    </p>
   </div>
   <CodeTabs {tabs} />
 </section>


### PR DESCRIPTION
## Summary

- **Install code blocks** on `/` and Getting started were full-width for a one-line `bun add @ggsvelte/svelte`. `CopyCode` now uses `width: fit-content` (still `max-width: 100%`) so short snippets hug content and long fences still scroll inside the card.
- **Grammar demo copy** regressed in #1030 (`docs: purge narration\ldots`). That PR swapped the section for AI-cadence slop: *Inspect and pin are plot props.* / *No D3 — not a second interaction library.* Restored **Interaction is a layer.** with a plain *Zero D3.js* lead-in and the pre-#1030 step note (*just one more layer*).

### Investigation

| Fact | Evidence |
|------|----------|
| Who wrote the slop | PR #1030, commit `d9e43886` / `947f97f9`, closing #690 |
| What it replaced | *The missing layer.* + *Zero D3.js. Built for human-agent teams\ldots* (itself from #756/#758) |
| Exact phrase *Interaction is a layer* | Never landed in git history; closest prior headings were *Interaction is declarative.* and *The missing layer.* Restored the heading you named. |

## Test plan

- [ ] Homepage install card width matches the command (+ copy control), no full-column empty strip
- [ ] Getting started install card same treatment
- [ ] Multi-line `CopyCode` (lesson files, theme lab) still caps at parent width and scrolls long lines
- [ ] Grammar demo reads: **Interaction is a layer.** / Zero D3.js. Inspect and pin are plot props.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1044" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->