### PR TITLE
refactor(core): paintVector + constantStyle absorb restated paint sites (#1041)

### DIFF
--- a/packages/core/src/pipeline/geometry-boxplot-body.ts
+++ b/packages/core/src/pipeline/geometry-boxplot-body.ts
@@ -6,13 +6,14 @@ import type { BoxplotParams } from "@ggsvelte/spec";
 import type { GeometryBatch, RectsBatch } from "../scene.js";
 
 import type { LayerFrame, PipelineWarning, ResolvedColorScale } from "./types.js";
-import { colorOf } from "./types.js";
+
 import type { Frame } from "./geometry-shared.js";
 import {
   DEFAULT_BOXPLOT_WIDTH,
   MAX_BOXPLOT_PANEL_FRAC,
   removedWarning,
 } from "./geometry-shared.js";
+import { constantStyle, mappedPaintVector } from "./geometry-style.js";
 
 /** Median line draws at 2× the box linewidth (ggplot2's fatten = 2). */
 const BOX_MEDIAN_FATTEN = 2;
@@ -116,12 +117,8 @@ function layoutBoxplotBody(
   if (params.width === undefined) {
     widthFrac = Math.min(widthFrac, MAX_BOXPLOT_PANEL_FRAC);
   }
-  const linewidth =
-    typeof binding.linewidth.constant === "number"
-      ? binding.linewidth.constant
-      : (params.linewidth ?? DEFAULT_BOX_LINEWIDTH);
-  const alpha =
-    typeof binding.alpha.constant === "number" ? binding.alpha.constant : (params.alpha ?? 1);
+  const linewidth = constantStyle(binding, params, "linewidth", DEFAULT_BOX_LINEWIDTH);
+  const alpha = constantStyle(binding, params, "alpha", 1);
   const yScale = fx.yScale;
 
   const centerPx: number[] = [];
@@ -191,12 +188,7 @@ function makeBoxplotRectsBatch(
     alpha,
   };
   if (fill !== null && (frame.fillValues !== null || binding.fill.scaledConstant !== null)) {
-    rectsBatchOut.fills = layout.keptRows.map((row) =>
-      colorOf(
-        fill,
-        frame.fillValues === null ? binding.fill.scaledConstant! : frame.fillValues[row]!,
-      ),
-    );
+    rectsBatchOut.fills = mappedPaintVector(frame, "fill", fill, layout.keptRows);
   }
   return rectsBatchOut;
 }

--- a/packages/core/src/pipeline/geometry-curve.ts
+++ b/packages/core/src/pipeline/geometry-curve.ts
@@ -13,12 +13,13 @@ import { linetypeIndex, type Linetype } from "../scales/style.js";
 import { tessellateCurve } from "../stats/curve.js";
 
 import type { LayerFrame, PipelineWarning, ResolvedColorScale } from "./types.js";
-import { colorOf } from "./types.js";
 import type { Frame } from "./geometry-shared.js";
 import { DEFAULT_RULE_LINEWIDTH, positionOf, removedWarning } from "./geometry-shared.js";
 import {
+  constantStyle,
   indexedStyleVector,
   numericStyleVector,
+  paintVector,
   type ResolvedStyleScales,
 } from "./geometry-style.js";
 
@@ -80,13 +81,7 @@ export function curveBatch(
     pathOffsets[s] = cursor;
     const { row, positions: pts, count } = sampled[s]!;
     styleRows.push(row);
-    let stroke: string | null = binding.color.constant;
-    if (color !== null && (frame.colorValues !== null || binding.color.scaledConstant !== null)) {
-      const value =
-        frame.colorValues === null ? binding.color.scaledConstant! : frame.colorValues[row]!;
-      stroke = colorOf(color, value);
-    }
-    strokes.push(stroke);
+    strokes.push(paintVector(frame, "color", color, [row])[0]!);
     const sourceRow = frame.rowIndex[row]!;
     for (let i = 0; i < count; i++) {
       positions[cursor * 2] = pts[i * 2]!;
@@ -117,8 +112,6 @@ export function curveBatch(
   const linetypeIndexes = indexedStyleVector(frame, "linetype", styleRows, styles, (value) =>
     linetypeIndex(value as Linetype),
   );
-  const literalLinewidth = binding.linewidth.constant;
-  const literalAlpha = binding.alpha.constant;
   const literalLinetype = binding.linetype.constant;
   // Match segment: map documented `lineend` → PathsBatch.linecap (default butt).
   const linecap = params.lineend ?? "butt";
@@ -133,17 +126,9 @@ export function curveBatch(
     strokes,
     semanticAnchors,
     semanticIndex,
-    linewidth:
-      typeof literalLinewidth === "number"
-        ? literalLinewidth
-        : (params.linewidth ?? DEFAULT_RULE_LINEWIDTH),
+    linewidth: constantStyle(binding, params, "linewidth", DEFAULT_RULE_LINEWIDTH),
     ...(linewidths !== undefined && { linewidths }),
-    alpha:
-      alphas === undefined
-        ? typeof literalAlpha === "number"
-          ? literalAlpha
-          : (params.alpha ?? 1)
-        : 1,
+    alpha: alphas === undefined ? constantStyle(binding, params, "alpha", 1) : 1,
     ...(alphas !== undefined && { alphas }),
     ...(typeof literalLinetype === "string" && { linetype: literalLinetype as Linetype }),
     ...(linetypeIndexes !== undefined && { linetypeIndexes }),

--- a/packages/core/src/pipeline/geometry-edge-rects.ts
+++ b/packages/core/src/pipeline/geometry-edge-rects.ts
@@ -12,10 +12,12 @@ import { linetypeIndex, type Linetype } from "../scales/style.js";
 import { resolution as resolutionOf } from "../stats/numeric.js";
 
 import type { LayerFrame, PipelineWarning, ResolvedColorScale } from "./types.js";
-import { colorOf, PipelineError } from "./types.js";
+import { PipelineError } from "./types.js";
 import type { Frame } from "./geometry-shared.js";
 import {
   indexedStyleVector,
+  constantStyle,
+  mappedPaintVector,
   numericStyleVector,
   type ResolvedStyleScales,
 } from "./geometry-style.js";
@@ -274,8 +276,7 @@ function styleEdgeBatch(
     rects: emitted.rects,
     rowIndex: emitted.rowIndex,
     fill: binding.fill.constant,
-    alpha:
-      typeof binding.alpha.constant === "number" ? binding.alpha.constant : (params.alpha ?? 1),
+    alpha: constantStyle(binding, params, "alpha", 1),
     anchor: "center",
   };
   const alphas = numericStyleVector(frame, "alpha", emitted.keptRows, styles);
@@ -284,14 +285,7 @@ function styleEdgeBatch(
     batch.alphas = alphas;
   }
   if (fill !== null && (frame.fillValues !== null || binding.fill.scaledConstant !== null)) {
-    batch.fills = Array.from({ length: emitted.kept }, (_, j) =>
-      colorOf(
-        fill,
-        frame.fillValues === null
-          ? binding.fill.scaledConstant!
-          : frame.fillValues[emitted.keptRows[j]!]!,
-      ),
-    );
+    batch.fills = mappedPaintVector(frame, "fill", fill, emitted.keptRows);
   }
   if (withStroke) {
     const wantsMappedStroke =
@@ -305,15 +299,8 @@ function styleEdgeBatch(
       binding.linetype?.field !== null ||
       binding.linetype?.scaledConstant !== null ||
       typeof params.linewidth === "number";
-    if (wantsMappedStroke) {
-      batch.strokes = Array.from({ length: emitted.kept }, (_, j) =>
-        colorOf(
-          color,
-          frame.colorValues === null
-            ? binding.color.scaledConstant!
-            : frame.colorValues[emitted.keptRows[j]!]!,
-        ),
-      );
+    if (wantsMappedStroke && color !== null) {
+      batch.strokes = mappedPaintVector(frame, "color", color, emitted.keptRows);
       batch.stroke = null;
     } else if (constantStroke !== null) {
       batch.stroke = constantStroke;
@@ -322,10 +309,7 @@ function styleEdgeBatch(
       batch.stroke = null;
     }
     if (batch.stroke !== undefined || batch.strokes !== undefined) {
-      batch.strokeWidth =
-        typeof binding.linewidth?.constant === "number"
-          ? binding.linewidth.constant
-          : (params.linewidth ?? DEFAULT_RULE_LINEWIDTH);
+      batch.strokeWidth = constantStyle(binding, params, "linewidth", DEFAULT_RULE_LINEWIDTH);
       const linewidths = numericStyleVector(frame, "linewidth", emitted.keptRows, styles);
       if (linewidths !== undefined) batch.strokeWidths = linewidths;
       if (typeof binding.linetype?.constant === "string") {

--- a/packages/core/src/pipeline/geometry-errorbar-rows.ts
+++ b/packages/core/src/pipeline/geometry-errorbar-rows.ts
@@ -5,9 +5,9 @@
  * dense reuses typed arrays, sparse compact slices (like rule segments/glyphs).
  */
 import type { LayerFrame, ResolvedColorScale } from "./types.js";
-import { colorOf } from "./types.js";
 import type { Frame } from "./geometry-shared.js";
 import { positionOf } from "./geometry-shared.js";
+import { mappedPaintVector } from "./geometry-style.js";
 
 export interface EmittedErrorbars {
   segments: Float32Array;
@@ -27,12 +27,11 @@ export function emitErrorbarRows(input: {
   xSpanOf: (row: number, center: number) => readonly [number, number];
 }): EmittedErrorbars {
   const { frame, fx, color, wantsColors, xSpanOf } = input;
-  const { binding, n } = frame;
+  const { n } = frame;
   // 3 segments × 4 floats per kept row; 3 row ids per kept row.
   const segments = new Float32Array(n * 12);
   const rowIndex = new Uint32Array(n * 3);
   const styleRows = new Uint32Array(n * 3);
-  const strokes = wantsColors && color !== null ? Array.from<string>({ length: n * 3 }) : null;
   let kept = 0; // kept *rows*
   let removed = 0;
 
@@ -81,14 +80,6 @@ export function emitErrorbarRows(input: {
     styleRows[ro] = row;
     styleRows[ro + 1] = row;
     styleRows[ro + 2] = row;
-    if (strokes !== null) {
-      const value =
-        frame.colorValues === null ? binding.color.scaledConstant! : frame.colorValues[row]!;
-      const c = colorOf(color!, value);
-      strokes[ro] = c;
-      strokes[ro + 1] = c;
-      strokes[ro + 2] = c;
-    }
     kept++;
   }
 
@@ -103,14 +94,24 @@ export function emitErrorbarRows(input: {
       removed,
     };
   }
+  const styleSlice = styleRows.subarray(0, keptSegments);
+  const outStrokes =
+    wantsColors && color !== null ? mappedPaintVector(frame, "color", color, styleSlice) : null;
   if (kept === n) {
-    return { segments, rowIndex, styleRows, strokes, keptSegments, removed };
+    return {
+      segments,
+      rowIndex,
+      styleRows,
+      strokes: outStrokes,
+      keptSegments,
+      removed,
+    };
   }
   return {
     segments: segments.subarray(0, kept * 12).slice(),
     rowIndex: rowIndex.subarray(0, keptSegments).slice(),
-    styleRows: styleRows.subarray(0, keptSegments).slice(),
-    strokes: strokes === null ? null : strokes.slice(0, keptSegments),
+    styleRows: styleSlice.slice(),
+    strokes: outStrokes,
     keptSegments,
     removed,
   };

--- a/packages/core/src/pipeline/geometry-errorbar.ts
+++ b/packages/core/src/pipeline/geometry-errorbar.ts
@@ -13,6 +13,7 @@ import type { LayerFrame, PipelineWarning, ResolvedColorScale } from "./types.js
 import type { Frame } from "./geometry-shared.js";
 import {
   indexedStyleVector,
+  constantStyle,
   numericStyleVector,
   type ResolvedStyleScales,
 } from "./geometry-style.js";
@@ -55,12 +56,8 @@ export function errorbarBatch(
     segments: emitted.segments,
     rowIndex: emitted.rowIndex,
     stroke: binding.color.constant,
-    linewidth:
-      typeof binding.linewidth?.constant === "number"
-        ? binding.linewidth.constant
-        : (params.linewidth ?? DEFAULT_RULE_LINEWIDTH),
-    alpha:
-      typeof binding.alpha?.constant === "number" ? binding.alpha.constant : (params.alpha ?? 1),
+    linewidth: constantStyle(binding, params, "linewidth", DEFAULT_RULE_LINEWIDTH),
+    alpha: constantStyle(binding, params, "alpha", 1),
     ...(typeof binding.linetype?.constant === "string" && {
       linetype: binding.linetype.constant as Linetype,
     }),

--- a/packages/core/src/pipeline/geometry-glyphs-pack.ts
+++ b/packages/core/src/pipeline/geometry-glyphs-pack.ts
@@ -5,9 +5,13 @@ import type { GlyphsBatch } from "../scene.js";
 import { FONT_METRICS } from "../layout/font-metrics.js";
 import { MetricsTableMeasurer } from "../layout/measure.js";
 
-import { numericStyleVector, type ResolvedStyleScales } from "./geometry-style.js";
+import {
+  constantStyle,
+  mappedPaintVector,
+  numericStyleVector,
+  type ResolvedStyleScales,
+} from "./geometry-style.js";
 import type { LayerFrame, ResolvedColorScale } from "./types.js";
-import { colorOf } from "./types.js";
 import { DEFAULT_TEXT_SIZE } from "./geometry-shared.js";
 import type { EmittedGlyphs } from "./geometry-glyphs-rows.js";
 
@@ -51,8 +55,7 @@ export function packGlyphsBatch(input: {
     color: binding.color.constant,
     size: fontSize,
     anchor: params.anchor ?? "middle",
-    alpha:
-      typeof binding.alpha?.constant === "number" ? binding.alpha.constant : (params.alpha ?? 1),
+    alpha: constantStyle(binding, params, "alpha", 1),
   };
   const sizes =
     binding.size === undefined
@@ -93,14 +96,7 @@ export function packGlyphsBatch(input: {
     const wantsFills =
       fill !== null && (frame.fillValues !== null || binding.fill.scaledConstant !== null);
     if (wantsFills && fill !== null) {
-      const fills = Array.from<string>({ length: emitted.kept });
-      for (let j = 0; j < emitted.kept; j++) {
-        const row = emitted.styleRows[j]!;
-        const value =
-          frame.fillValues === null ? binding.fill.scaledConstant! : frame.fillValues[row]!;
-        fills[j] = colorOf(fill, value);
-      }
-      batch.boxFills = fills;
+      batch.boxFills = mappedPaintVector(frame, "fill", fill, emitted.styleRows);
       batch.boxFill = null;
     } else {
       // Constant fill from binding, else theme paper at render time (null).

--- a/packages/core/src/pipeline/geometry-glyphs-rows.ts
+++ b/packages/core/src/pipeline/geometry-glyphs-rows.ts
@@ -7,8 +7,8 @@
 import { bandKey } from "../scales/train.js";
 
 import type { LayerFrame, ResolvedColorScale } from "./types.js";
-import { colorOf } from "./types.js";
 import type { Frame } from "./geometry-shared.js";
+import { mappedPaintVector } from "./geometry-style.js";
 import { positionOf } from "./geometry-shared.js";
 
 export interface EmittedGlyphs {
@@ -36,7 +36,6 @@ export function emitGlyphRows(input: {
   const rowIndex = new Uint32Array(n);
   const styleRows = new Uint32Array(n);
   const texts = Array.from<string>({ length: n });
-  const colors = wantsColors ? Array.from<string>({ length: n }) : null;
   let kept = 0;
   let removed = 0;
   for (let row = 0; row < n; row++) {
@@ -53,16 +52,15 @@ export function emitGlyphRows(input: {
     rowIndex[kept] = frame.rowIndex[row]!;
     styleRows[kept] = row;
     texts[kept] = bandKey(label);
-    if (colors !== null && color !== null) {
-      const value =
-        frame.colorValues === null ? binding.color.scaledConstant! : frame.colorValues[row]!;
-      colors[kept] = colorOf(color, value);
-    }
     kept++;
   }
 
+  const styleSlice = styleRows.subarray(0, kept);
+  const outColors =
+    wantsColors && color !== null ? mappedPaintVector(frame, "color", color, styleSlice) : null;
+
   if (kept === n) {
-    return { positions, rowIndex, styleRows, texts, colors, kept, removed };
+    return { positions, rowIndex, styleRows, texts, colors: outColors, kept, removed };
   }
   if (kept === 0) {
     return {
@@ -79,9 +77,9 @@ export function emitGlyphRows(input: {
   return {
     positions: positions.subarray(0, kept * 2).slice(),
     rowIndex: rowIndex.subarray(0, kept).slice(),
-    styleRows: styleRows.subarray(0, kept).slice(),
+    styleRows: styleSlice.slice(),
     texts: texts.slice(0, kept),
-    colors: colors === null ? null : colors.slice(0, kept),
+    colors: outColors,
     kept,
     removed,
   };

--- a/packages/core/src/pipeline/geometry-hex.ts
+++ b/packages/core/src/pipeline/geometry-hex.ts
@@ -5,9 +5,13 @@ import type { PathsBatch } from "../scene.js";
 
 import { hexVertices } from "../stats/bin-hex.js";
 import type { LayerFrame, PipelineWarning, ResolvedColorScale } from "./types.js";
-import { colorOf } from "./types.js";
 import type { Frame } from "./geometry-shared.js";
-import { numericStyleVector, type ResolvedStyleScales } from "./geometry-style.js";
+import {
+  constantStyle,
+  numericStyleVector,
+  paintVector,
+  type ResolvedStyleScales,
+} from "./geometry-style.js";
 
 /**
  * Project one data-space hex into panel-local vertices.
@@ -49,15 +53,6 @@ export function hexBatch(
   const closedFrameRows = new Uint32Array(totalVerts);
   const pathOffsets = new Uint32Array(n + 1);
   const keptRows = new Uint32Array(n);
-  const fills: (string | null)[] = [];
-  const strokes: (string | null)[] = [];
-
-  const wantsFill =
-    fill !== null && (frame.fillValues !== null || binding.fill.scaledConstant !== null);
-  const wantsStroke =
-    color !== null && (frame.colorValues !== null || binding.color.scaledConstant !== null);
-  const constantStroke = binding.color.constant;
-
   let cursor = 0;
   let subpaths = 0;
   for (let row = 0; row < n; row++) {
@@ -92,20 +87,6 @@ export function hexBatch(
       cursor = start;
       continue;
     }
-    if (wantsFill && fill !== null) {
-      const value =
-        frame.fillValues === null ? binding.fill.scaledConstant! : frame.fillValues[row]!;
-      fills.push(colorOf(fill, value));
-    } else {
-      fills.push(binding.fill.constant);
-    }
-    if (wantsStroke && color !== null) {
-      const value =
-        frame.colorValues === null ? binding.color.scaledConstant! : frame.colorValues[row]!;
-      strokes.push(colorOf(color, value));
-    } else {
-      strokes.push(constantStroke);
-    }
     keptRows[subpaths] = row;
     subpaths++;
   }
@@ -118,6 +99,8 @@ export function hexBatch(
   // centers / non-finite projected vertices leave gaps that would misalign alpha
   // and linewidth with the emitted shapes (same pattern as edge-rects keptRows).
   const styleRows = keptRows.subarray(0, subpaths);
+  const fills = paintVector(frame, "fill", fill, styleRows);
+  const strokes = paintVector(frame, "color", color, styleRows);
   const alphas = numericStyleVector(frame, "alpha", styleRows, styles);
   const linewidths = numericStyleVector(frame, "linewidth", styleRows, styles);
 
@@ -132,17 +115,9 @@ export function hexBatch(
     fills,
     closed: true,
     closedFrameRows: closedFrameRows.subarray(0, cursor).slice(),
-    linewidth:
-      typeof binding.linewidth?.constant === "number"
-        ? binding.linewidth.constant
-        : (params.linewidth ?? 0),
+    linewidth: constantStyle(binding, params, "linewidth", 0),
     ...(linewidths !== undefined && { linewidths }),
-    alpha:
-      alphas === undefined
-        ? typeof binding.alpha?.constant === "number"
-          ? binding.alpha.constant
-          : (params.alpha ?? 1)
-        : 1,
+    alpha: alphas === undefined ? constantStyle(binding, params, "alpha", 1) : 1,
     ...(alphas !== undefined && { alphas }),
     curve: "linear",
   };

--- a/packages/core/src/pipeline/geometry-paths-area-fill.ts
+++ b/packages/core/src/pipeline/geometry-paths-area-fill.ts
@@ -2,20 +2,14 @@
  * Area/density group fill color resolution.
  */
 import type { LayerFrame, ResolvedColorScale } from "./types.js";
-import { colorOf } from "./types.js";
+import { paintVector } from "./geometry-style.js";
 
 export function areaGroupFillOf(
   frame: LayerFrame,
   fill: ResolvedColorScale | null,
   rows: readonly number[],
 ): string | null {
-  const { binding } = frame;
-  let fillColor: string | null = binding.fill.constant;
-  if (fill !== null && (frame.fillValues !== null || binding.fill.scaledConstant !== null)) {
-    const first = rows[0]!;
-    const value =
-      frame.fillValues === null ? binding.fill.scaledConstant! : frame.fillValues[first]!;
-    fillColor = colorOf(fill, value);
-  }
-  return fillColor;
+  const first = rows[0];
+  if (first === undefined) return frame.binding.fill.constant;
+  return paintVector(frame, "fill", fill, [first])[0]!;
 }

--- a/packages/core/src/pipeline/geometry-paths-area.ts
+++ b/packages/core/src/pipeline/geometry-paths-area.ts
@@ -6,7 +6,7 @@ import type { PathsBatch } from "../scene.js";
 
 import type { LayerFrame, PipelineWarning, ResolvedColorScale } from "./types.js";
 import type { Frame } from "./geometry-shared.js";
-import { numericStyleVector, type ResolvedStyleScales } from "./geometry-style.js";
+import { constantStyle, numericStyleVector, type ResolvedStyleScales } from "./geometry-style.js";
 import { bucketByGroup, sortGroupRowsByX } from "./geometry-shared.js";
 import { writeClosedPathGroups } from "./geometry-paths-closed-batch.js";
 import { areaGroupFillOf } from "./geometry-paths-area-fill.js";
@@ -53,8 +53,7 @@ export function areaBatch(
     styles,
   );
   const subpathCount = pathOffsets.length - 1;
-  const constantAlpha =
-    typeof binding.alpha.constant === "number" ? binding.alpha.constant : (params.alpha ?? 1);
+  const constantAlpha = constantStyle(binding, params, "alpha", 1);
   // Multi-group closed fills must carry alpha per subpath. SVG group opacity
   // composites opaque siblings into an offscreen buffer first, so a shared
   // <g opacity> would occlude the rear distribution in the overlap region.

--- a/packages/core/src/pipeline/geometry-paths-line-write.ts
+++ b/packages/core/src/pipeline/geometry-paths-line-write.ts
@@ -2,9 +2,9 @@
  * Write sorted line subpaths into path buffers.
  */
 import type { LayerFrame, ResolvedColorScale } from "./types.js";
-import { colorOf } from "./types.js";
 import type { Frame } from "./geometry-shared.js";
 import { positionOf } from "./geometry-shared.js";
+import { paintVector } from "./geometry-style.js";
 
 export function writeLineSubpaths(input: {
   frame: LayerFrame;
@@ -20,7 +20,6 @@ export function writeLineSubpaths(input: {
   strokes: (string | null)[];
 } {
   const { frame, fx, color, subpaths, includeFrameRows = false } = input;
-  const { binding } = frame;
 
   let total = 0;
   for (const rows of subpaths) total += rows.length;
@@ -42,14 +41,7 @@ export function writeLineSubpaths(input: {
       if (frameRowIndex !== undefined) frameRowIndex[cursor] = row;
       cursor++;
     }
-    let stroke: string | null = binding.color.constant;
-    if (color !== null && (frame.colorValues !== null || binding.color.scaledConstant !== null)) {
-      const first = rows[0]!;
-      const value =
-        frame.colorValues === null ? binding.color.scaledConstant! : frame.colorValues[first]!;
-      stroke = colorOf(color, value);
-    }
-    strokes.push(stroke);
+    strokes.push(paintVector(frame, "color", color, [rows[0]!])[0]!);
   }
   pathOffsets[subpaths.length] = cursor;
   return {

--- a/packages/core/src/pipeline/geometry-paths-line.ts
+++ b/packages/core/src/pipeline/geometry-paths-line.ts
@@ -8,6 +8,7 @@ import { linetypeIndex, type Linetype } from "../scales/style.js";
 import type { LayerFrame, PipelineWarning, ResolvedColorScale } from "./types.js";
 import type { Frame } from "./geometry-shared.js";
 import {
+  constantStyle,
   indexedStyleVector,
   numericStyleVector,
   type ResolvedStyleScales,
@@ -84,11 +85,14 @@ export function lineBatch(
   const linetypeIndexes = indexedStyleVector(frame, "linetype", styleRows, styles, (value) =>
     linetypeIndex(value as Linetype),
   );
-  const literalLinewidth = binding.linewidth.constant;
-  const literalAlpha = binding.alpha.constant;
   const literalLinetype = binding.linetype.constant;
-  const paramLinewidth = "linewidth" in params ? params.linewidth : undefined;
-  const paramAlpha = "alpha" in params ? params.alpha : undefined;
+  const styleParams: { alpha?: number; linewidth?: number } = {};
+  if ("linewidth" in params && typeof params.linewidth === "number") {
+    styleParams.linewidth = params.linewidth;
+  }
+  if ("alpha" in params && typeof params.alpha === "number") {
+    styleParams.alpha = params.alpha;
+  }
   return {
     kind: "paths",
     layerIndex: binding.index,
@@ -98,17 +102,9 @@ export function lineBatch(
     ...(frameRowIndex !== undefined && { frameRowIndex }),
     pathOffsets,
     strokes,
-    linewidth:
-      typeof literalLinewidth === "number"
-        ? literalLinewidth
-        : (paramLinewidth ?? DEFAULT_LINEWIDTH),
+    linewidth: constantStyle(binding, styleParams, "linewidth", DEFAULT_LINEWIDTH),
     ...(linewidths !== undefined && { linewidths }),
-    alpha:
-      alphas === undefined
-        ? typeof literalAlpha === "number"
-          ? literalAlpha
-          : (paramAlpha ?? 1)
-        : 1,
+    alpha: alphas === undefined ? constantStyle(binding, styleParams, "alpha", 1) : 1,
     ...(alphas !== undefined && { alphas }),
     ...(typeof literalLinetype === "string" && { linetype: literalLinetype as Linetype }),
     ...(linetypeIndexes !== undefined && { linetypeIndexes }),

--- a/packages/core/src/pipeline/geometry-paths-polygon.ts
+++ b/packages/core/src/pipeline/geometry-paths-polygon.ts
@@ -7,31 +7,16 @@ import type { PathsBatch } from "../scene.js";
 import { linetypeIndex, type Linetype } from "../scales/style.js";
 
 import type { LayerFrame, PipelineWarning, ResolvedColorScale } from "./types.js";
-import { colorOf } from "./types.js";
 import type { Frame } from "./geometry-shared.js";
 import { DEFAULT_LINEWIDTH, bucketByGroup, positionOf } from "./geometry-shared.js";
 import {
+  constantStyle,
   indexedStyleVector,
   numericStyleVector,
+  paintVector,
   type ResolvedStyleScales,
 } from "./geometry-style.js";
 import { areaGroupFillOf } from "./geometry-paths-area-fill.js";
-
-function strokeOf(
-  frame: LayerFrame,
-  color: ResolvedColorScale | null,
-  rows: readonly number[],
-): string | null {
-  const { binding } = frame;
-  let stroke: string | null = binding.color.constant;
-  if (color !== null && (frame.colorValues !== null || binding.color.scaledConstant !== null)) {
-    const first = rows[0]!;
-    const value =
-      frame.colorValues === null ? binding.color.scaledConstant! : frame.colorValues[first]!;
-    stroke = colorOf(color, value);
-  }
-  return stroke;
-}
 
 export function polygonBatch(
   frame: LayerFrame,
@@ -91,7 +76,7 @@ export function polygonBatch(
       cursor++;
     }
     fills.push(areaGroupFillOf(frame, fill, rows) ?? fillPaintResolved?.fallback ?? null);
-    let stroke = strokeOf(frame, color, rows);
+    let stroke = paintVector(frame, "color", color, [rows[0]!])[0]!;
     if (stroke === null && strokePaintResolved !== undefined) {
       stroke = strokePaintResolved.fallback;
     }
@@ -110,8 +95,6 @@ export function polygonBatch(
   const linetypeIndexes = indexedStyleVector(frame, "linetype", styleRows, styles, (value) =>
     linetypeIndex(value as Linetype),
   );
-  const literalLinewidth = binding.linewidth.constant;
-  const literalAlpha = binding.alpha.constant;
   const literalLinetype = binding.linetype.constant;
 
   return {
@@ -129,17 +112,9 @@ export function polygonBatch(
     fills,
     closed: true,
     closedFrameRows,
-    linewidth:
-      typeof literalLinewidth === "number"
-        ? literalLinewidth
-        : (params.linewidth ?? DEFAULT_LINEWIDTH),
+    linewidth: constantStyle(binding, params, "linewidth", DEFAULT_LINEWIDTH),
     ...(linewidths !== undefined && { linewidths }),
-    alpha:
-      alphas === undefined
-        ? typeof literalAlpha === "number"
-          ? literalAlpha
-          : (params.alpha ?? 1)
-        : 1,
+    alpha: alphas === undefined ? constantStyle(binding, params, "alpha", 1) : 1,
     ...(alphas !== undefined && { alphas }),
     ...(typeof literalLinetype === "string" && { linetype: literalLinetype as Linetype }),
     ...(linetypeIndexes !== undefined && { linetypeIndexes }),

--- a/packages/core/src/pipeline/geometry-points.ts
+++ b/packages/core/src/pipeline/geometry-points.ts
@@ -5,10 +5,12 @@ import type { PointsBatch } from "../scene.js";
 import { pointShapeIndex, type PointShape } from "../scales/style.js";
 
 import type { LayerFrame, PipelineWarning, ResolvedColorScale } from "./types.js";
-import { colorOf } from "./types.js";
+
 import type { Frame } from "./geometry-shared.js";
 import {
   indexedStyleVector,
+  constantStyle,
+  mappedPaintVector,
   numericStyleVector,
   type ResolvedStyleScales,
 } from "./geometry-style.js";
@@ -75,7 +77,6 @@ export function pointsBatch(
       ? params.shape
       : undefined;
   const literalSize = binding.size.constant;
-  const literalAlpha = binding.alpha.constant;
   const literalShape = binding.shape.constant;
   let markSize = DEFAULT_POINT_SIZE;
   if (typeof literalSize === "number") markSize = literalSize;
@@ -92,6 +93,7 @@ export function pointsBatch(
   const paintScale = paintWithFill ? fill : color;
   const paintValues = paintWithFill ? frame.fillValues : frame.colorValues;
   const paintChannel = paintWithFill ? binding.fill : binding.color;
+  const paintKey = paintWithFill ? ("fill" as const) : ("color" as const);
 
   const batch: PointsBatch = {
     kind: "points",
@@ -100,7 +102,7 @@ export function pointsBatch(
     positions,
     rowIndex,
     size: markSize,
-    alpha: typeof literalAlpha === "number" ? literalAlpha : (params.alpha ?? 1),
+    alpha: constantStyle(binding, params, "alpha", 1),
     shape:
       typeof literalShape === "string" ? (literalShape as PointShape) : (paramShape ?? "circle"),
     fill: paintChannel.constant,
@@ -117,13 +119,7 @@ export function pointsBatch(
   }
   if (shapeIndexes !== undefined) batch.shapeIndexes = shapeIndexes;
   if (paintScale !== null && (paintValues !== null || paintChannel.scaledConstant !== null)) {
-    const colors = Array.from<string>({ length: collected.kept });
-    for (let j = 0; j < collected.kept; j++) {
-      const row = collected.keptRows[j]!;
-      const value = paintValues === null ? paintChannel.scaledConstant! : paintValues[row]!;
-      colors[j] = colorOf(paintScale, value);
-    }
-    batch.colors = colors;
+    batch.colors = mappedPaintVector(frame, paintKey, paintScale, collected.keptRows);
   }
   return batch;
 }

--- a/packages/core/src/pipeline/geometry-range.ts
+++ b/packages/core/src/pipeline/geometry-range.ts
@@ -10,7 +10,6 @@ import type { GeometryBatch, PointsBatch, RectsBatch, SegmentsBatch } from "../s
 import { linetypeIndex, pointShapeIndex, type Linetype, type PointShape } from "../scales/style.js";
 
 import type { LayerFrame, PipelineWarning, ResolvedColorScale } from "./types.js";
-import { colorOf } from "./types.js";
 import type { Frame } from "./geometry-shared.js";
 import {
   DEFAULT_POINT_SIZE,
@@ -19,7 +18,9 @@ import {
   removedWarning,
 } from "./geometry-shared.js";
 import {
+  constantStyle,
   indexedStyleVector,
+  mappedPaintVector,
   numericStyleVector,
   type ResolvedStyleScales,
 } from "./geometry-style.js";
@@ -39,10 +40,7 @@ function packStrokeBatch(
   linewidthScale = 1,
 ): SegmentsBatch {
   const { binding } = frame;
-  const baseLw =
-    typeof binding.linewidth?.constant === "number"
-      ? binding.linewidth.constant
-      : (params.linewidth ?? DEFAULT_RULE_LINEWIDTH);
+  const baseLw = constantStyle(binding, params, "linewidth", DEFAULT_RULE_LINEWIDTH);
   const batch: SegmentsBatch = {
     kind: "segments",
     layerIndex: binding.index,
@@ -51,8 +49,7 @@ function packStrokeBatch(
     rowIndex,
     stroke: binding.color.constant,
     linewidth: baseLw * linewidthScale,
-    alpha:
-      typeof binding.alpha?.constant === "number" ? binding.alpha.constant : (params.alpha ?? 1),
+    alpha: constantStyle(binding, params, "alpha", 1),
     ...(typeof binding.linetype?.constant === "string" && {
       linetype: binding.linetype.constant as Linetype,
     }),
@@ -93,7 +90,6 @@ export function linerangeBatch(
   const segments = new Float32Array(n * 4);
   const rowIndex = new Uint32Array(n);
   const styleRows = new Uint32Array(n);
-  const strokes = wantsColors && color !== null ? Array.from<string>({ length: n }) : null;
   let kept = 0;
   let removed = 0;
 
@@ -121,11 +117,6 @@ export function linerangeBatch(
     segments[so + 3] = y1;
     rowIndex[kept] = frame.rowIndex[row]!;
     styleRows[kept] = row;
-    if (strokes !== null) {
-      const value =
-        frame.colorValues === null ? binding.color.scaledConstant! : frame.colorValues[row]!;
-      strokes[kept] = colorOf(color!, value);
-    }
     kept++;
   }
 
@@ -134,7 +125,8 @@ export function linerangeBatch(
   const outSeg = kept === n ? segments : segments.subarray(0, kept * 4).slice();
   const outRows = kept === n ? rowIndex : rowIndex.subarray(0, kept).slice();
   const outStyle = kept === n ? styleRows : styleRows.subarray(0, kept).slice();
-  const outStrokes = strokes === null ? null : kept === n ? strokes : strokes.slice(0, kept);
+  const outStrokes =
+    wantsColors && color !== null ? mappedPaintVector(frame, "color", color, outStyle) : null;
   return packStrokeBatch(frame, styles, outSeg, outRows, outStyle, outStrokes, params);
 }
 
@@ -172,7 +164,6 @@ function midPointsBatch(
   const positions = new Float32Array(n * 2);
   const rowIndex = new Uint32Array(n);
   const styleRows = new Uint32Array(n);
-  const colors = wantsColors && color !== null ? Array.from<string>({ length: n }) : null;
   let kept = 0;
 
   for (let row = 0; row < n; row++) {
@@ -197,11 +188,6 @@ function midPointsBatch(
     positions[o + 1] = fx.innerHeight - ty * fx.innerHeight;
     rowIndex[kept] = frame.rowIndex[row]!;
     styleRows[kept] = row;
-    if (colors !== null) {
-      const value =
-        frame.colorValues === null ? binding.color.scaledConstant! : frame.colorValues[row]!;
-      colors[kept] = colorOf(color!, value);
-    }
     kept++;
   }
   if (kept === 0) return null;
@@ -219,8 +205,7 @@ function midPointsBatch(
       typeof binding.size?.constant === "number"
         ? binding.size.constant
         : (params.size ?? DEFAULT_POINT_SIZE),
-    alpha:
-      typeof binding.alpha?.constant === "number" ? binding.alpha.constant : (params.alpha ?? 1),
+    alpha: constantStyle(binding, params, "alpha", 1),
     shape:
       typeof binding.shape?.constant === "string"
         ? (binding.shape.constant as PointShape)
@@ -238,7 +223,9 @@ function midPointsBatch(
     batch.alphas = alphas;
   }
   if (shapeIndexes !== undefined) batch.shapeIndexes = shapeIndexes;
-  if (colors !== null) batch.colors = kept === n ? colors : colors.slice(0, kept);
+  if (wantsColors && color !== null) {
+    batch.colors = mappedPaintVector(frame, "color", color, outStyle);
+  }
   return batch;
 }
 
@@ -269,14 +256,10 @@ export function crossbarBatches(
   const rects = new Float32Array(n * 4);
   const rectRows = new Uint32Array(n);
   const rectStyle = new Uint32Array(n);
-  const fills = wantsFill && fill !== null ? Array.from<string>({ length: n }) : null;
-  const strokes = wantsStroke && color !== null ? Array.from<string>({ length: n }) : null;
-
   // Mid line: 1 segment per row
   const segs = new Float32Array(n * 4);
   const segRows = new Uint32Array(n);
   const segStyle = new Uint32Array(n);
-  const midStrokes = wantsStroke && color !== null ? Array.from<string>({ length: n }) : null;
 
   let kept = 0;
   let removed = 0;
@@ -328,19 +311,6 @@ export function crossbarBatches(
     segs[ro + 3] = midY;
     segRows[kept] = frame.rowIndex[row]!;
     segStyle[kept] = row;
-
-    if (fills !== null) {
-      const value =
-        frame.fillValues === null ? binding.fill.scaledConstant! : frame.fillValues[row]!;
-      fills[kept] = colorOf(fill!, value);
-    }
-    if (strokes !== null) {
-      const value =
-        frame.colorValues === null ? binding.color.scaledConstant! : frame.colorValues[row]!;
-      const c = colorOf(color!, value);
-      strokes[kept] = c;
-      if (midStrokes !== null) midStrokes[kept] = c;
-    }
     kept++;
   }
 
@@ -354,17 +324,18 @@ export function crossbarBatches(
   const outSegRows = kept === n ? segRows : segRows.subarray(0, kept).slice();
   const outSegStyle = kept === n ? segStyle : segStyle.subarray(0, kept).slice();
 
-  const strokeWidth =
-    typeof binding.linewidth?.constant === "number"
-      ? binding.linewidth.constant
-      : (params.linewidth ?? DEFAULT_RULE_LINEWIDTH);
+  const strokeWidth = constantStyle(binding, params, "linewidth", DEFAULT_RULE_LINEWIDTH);
+  const outFills =
+    wantsFill && fill !== null ? mappedPaintVector(frame, "fill", fill, outRectStyle) : null;
+  const outStrokes =
+    wantsStroke && color !== null ? mappedPaintVector(frame, "color", color, outRectStyle) : null;
   // ggplot2 geom_crossbar defaults fill = NA (outlined box). Match boxplot
   // body: paper fillRole when no fill is mapped/constant.
   const hasFill =
     binding.fill.constant !== null ||
     binding.fill.field !== null ||
     binding.fill.scaledConstant !== null ||
-    fills !== null;
+    outFills !== null;
   const rectBatch: RectsBatch = {
     kind: "rects",
     layerIndex: binding.index,
@@ -373,8 +344,7 @@ export function crossbarBatches(
     rowIndex: outRectRows,
     fill: binding.fill.constant,
     ...(hasFill ? {} : { fillRole: "paper" as const }),
-    alpha:
-      typeof binding.alpha?.constant === "number" ? binding.alpha.constant : (params.alpha ?? 1),
+    alpha: constantStyle(binding, params, "alpha", 1),
     stroke: binding.color.constant,
     strokeWidth,
     anchor: "center",
@@ -384,8 +354,8 @@ export function crossbarBatches(
     rectBatch.alpha = 1;
     rectBatch.alphas = alphas;
   }
-  if (fills !== null) rectBatch.fills = kept === n ? fills : fills.slice(0, kept);
-  if (strokes !== null) rectBatch.strokes = kept === n ? strokes : strokes.slice(0, kept);
+  if (outFills !== null) rectBatch.fills = outFills;
+  if (outStrokes !== null) rectBatch.strokes = outStrokes;
   // Mapped linewidth/linetype must style the box outline as well as the mid
   // line (STYLE_AESTHETIC_GEOMS enrolls crossbar on both).
   const linewidths = numericStyleVector(frame, "linewidth", outRectStyle, styles);
@@ -404,7 +374,7 @@ export function crossbarBatches(
     outSegs,
     outSegRows,
     outSegStyle,
-    midStrokes === null ? null : kept === n ? midStrokes : midStrokes.slice(0, kept),
+    outStrokes,
     params,
     fatten,
   );

--- a/packages/core/src/pipeline/geometry-rects.ts
+++ b/packages/core/src/pipeline/geometry-rects.ts
@@ -5,9 +5,13 @@ import type { RectsBatch } from "../scene.js";
 import { resolution as resolutionOf } from "../stats/numeric.js";
 
 import type { LayerFrame, PipelineWarning, ResolvedColorScale } from "./types.js";
-import { colorOf } from "./types.js";
 import type { Frame } from "./geometry-shared.js";
-import { numericStyleVector, type ResolvedStyleScales } from "./geometry-style.js";
+import {
+  constantStyle,
+  mappedPaintVector,
+  numericStyleVector,
+  type ResolvedStyleScales,
+} from "./geometry-style.js";
 import { DEFAULT_BAR_WIDTH, removedWarning } from "./geometry-shared.js";
 import { emitRectRows } from "./geometry-rects-emit.js";
 
@@ -55,8 +59,7 @@ export function rectsBatch(
     rects,
     rowIndex,
     fill: binding.fill.constant,
-    alpha:
-      typeof binding.alpha.constant === "number" ? binding.alpha.constant : (params.alpha ?? 1),
+    alpha: constantStyle(binding, params, "alpha", 1),
   };
   const alphas = numericStyleVector(frame, "alpha", keptRows, styles);
   if (alphas !== undefined) {
@@ -64,12 +67,7 @@ export function rectsBatch(
     batch.alphas = alphas;
   }
   if (fill !== null && (frame.fillValues !== null || binding.fill.scaledConstant !== null)) {
-    batch.fills = Array.from({ length: kept }, (_, j) =>
-      colorOf(
-        fill,
-        frame.fillValues === null ? binding.fill.scaledConstant! : frame.fillValues[keptRows[j]!]!,
-      ),
-    );
+    batch.fills = mappedPaintVector(frame, "fill", fill, keptRows);
   }
   return batch;
 }

--- a/packages/core/src/pipeline/geometry-ribbon.ts
+++ b/packages/core/src/pipeline/geometry-ribbon.ts
@@ -15,12 +15,14 @@ import {
   sortGroupRowsByX,
 } from "./geometry-shared.js";
 import {
+  constantStyle,
   indexedStyleVector,
   numericStyleVector,
+  paintVector,
   type ResolvedStyleScales,
 } from "./geometry-style.js";
+// paint helpers imported below
 import { areaGroupFillOf } from "./geometry-paths-area-fill.js";
-import { colorOf } from "./types.js";
 
 type Outline = "both" | "upper" | "lower" | "full";
 type LineCap = "butt" | "round" | "square";
@@ -339,13 +341,9 @@ function explicitStrokeColor(
   ) {
     return null;
   }
-  if (color !== null && (frame.colorValues !== null || binding.color.scaledConstant !== null)) {
-    const first = rows[0]!;
-    const value =
-      frame.colorValues === null ? binding.color.scaledConstant! : frame.colorValues[first]!;
-    return colorOf(color, value);
-  }
-  return binding.color.constant;
+  const first = rows[0];
+  if (first === undefined) return binding.color.constant;
+  return paintVector(frame, "color", color, [first])[0]!;
 }
 
 export function ribbonBatches(
@@ -374,9 +372,8 @@ export function ribbonBatches(
   const linetypeIndexes = indexedStyleVector(frame, "linetype", styleRows, styles, (value) =>
     linetypeIndex(value as Linetype),
   );
-  const literalAlpha = frame.binding.alpha.constant;
-  const literalLinewidth = frame.binding.linewidth.constant;
   const literalLinetype = frame.binding.linetype.constant;
+  const constantAlpha = constantStyle(frame.binding, params, "alpha", 1);
   const paint = layerPaintFromParams(frame.binding.layer.params);
   const layerIndex = frame.binding.index;
   const fillPaintResolved =
@@ -398,10 +395,7 @@ export function ribbonBatches(
   };
   const hasExplicitColor =
     strokePaintResolved !== undefined || runs.some((run) => strokeOf(run.rows) !== null);
-  const outlineWidth =
-    typeof literalLinewidth === "number"
-      ? literalLinewidth
-      : (params.linewidth ?? DEFAULT_LINEWIDTH);
+  const outlineWidth = constantStyle(frame.binding, params, "linewidth", DEFAULT_LINEWIDTH);
 
   const out: PathsBatch[] = [];
   const fullStroke = outline === "full" && hasExplicitColor;
@@ -431,12 +425,7 @@ export function ribbonBatches(
     closed: true,
     linewidth: fullStroke ? outlineWidth : 0,
     ...(fullStroke && linewidths !== undefined && { linewidths }),
-    alpha:
-      alphas === undefined
-        ? typeof literalAlpha === "number"
-          ? literalAlpha
-          : (params.alpha ?? 1)
-        : 1,
+    alpha: alphas === undefined ? constantAlpha : 1,
     ...(alphas !== undefined && { alphas }),
     ...(fullStroke &&
       typeof literalLinetype === "string" && { linetype: literalLinetype as Linetype }),
@@ -494,12 +483,7 @@ export function ribbonBatches(
       strokes: open.strokes,
       linewidth: outlineWidth,
       ...(outlineLinewidths !== undefined && { linewidths: outlineLinewidths as Float32Array }),
-      alpha:
-        outlineAlphas === undefined
-          ? typeof literalAlpha === "number"
-            ? literalAlpha
-            : (params.alpha ?? 1)
-          : 1,
+      alpha: outlineAlphas === undefined ? constantAlpha : 1,
       ...(outlineAlphas !== undefined && { alphas: outlineAlphas as Float32Array }),
       ...(typeof literalLinetype === "string" && { linetype: literalLinetype as Linetype }),
       ...(strokePaintResolved !== undefined && { strokePaint: strokePaintResolved }),

--- a/packages/core/src/pipeline/geometry-rug.ts
+++ b/packages/core/src/pipeline/geometry-rug.ts
@@ -10,10 +10,9 @@ import type { RugParams } from "@ggsvelte/spec";
 import type { SegmentsBatch } from "../scene.js";
 
 import type { LayerFrame, PipelineWarning, ResolvedColorScale } from "./types.js";
-import { colorOf } from "./types.js";
 import type { Frame } from "./geometry-shared.js";
 import { positionOf, removedWarning } from "./geometry-shared.js";
-import type { ResolvedStyleScales } from "./geometry-style.js";
+import { mappedPaintVector, type ResolvedStyleScales } from "./geometry-style.js";
 import { packSegmentsBatch } from "./geometry-segments-pack.js";
 
 const DEFAULT_SIDES = "bl";
@@ -58,7 +57,6 @@ export function rugBatch(
   const segments = new Float32Array(capacity * 4);
   const rowIndex = new Uint32Array(capacity);
   const styleRows = new Uint32Array(capacity);
-  const strokes = wantsColors ? Array.from<string>({ length: capacity }) : null;
   let kept = 0;
   let removed = 0;
 
@@ -75,11 +73,6 @@ export function rugBatch(
     segments[o + 3] = y1;
     rowIndex[kept] = frame.rowIndex[row]!;
     styleRows[kept] = row;
-    if (wantsColors && color !== null && strokes !== null) {
-      const value =
-        frame.colorValues === null ? binding.color.scaledConstant! : frame.colorValues[row]!;
-      strokes[kept] = colorOf(color, value);
-    }
     kept++;
   };
 
@@ -126,7 +119,8 @@ export function rugBatch(
   const outSegments = kept === capacity ? segments : segments.subarray(0, kept * 4).slice();
   const outRows = kept === capacity ? rowIndex : rowIndex.subarray(0, kept).slice();
   const outStyleRows = kept === capacity ? styleRows : styleRows.subarray(0, kept).slice();
-  const outStrokes = strokes === null ? null : kept === capacity ? strokes : strokes.slice(0, kept);
+  const outStrokes =
+    wantsColors && color !== null ? mappedPaintVector(frame, "color", color, outStyleRows) : null;
 
   return packSegmentsBatch({
     frame,

--- a/packages/core/src/pipeline/geometry-segment-finite.ts
+++ b/packages/core/src/pipeline/geometry-segment-finite.ts
@@ -9,10 +9,9 @@ import type { SegmentParams } from "@ggsvelte/spec";
 import type { SegmentsBatch } from "../scene.js";
 
 import type { LayerFrame, PipelineWarning, ResolvedColorScale } from "./types.js";
-import { colorOf } from "./types.js";
 import type { Frame } from "./geometry-shared.js";
 import { positionOf, removedWarning } from "./geometry-shared.js";
-import type { ResolvedStyleScales } from "./geometry-style.js";
+import { mappedPaintVector, type ResolvedStyleScales } from "./geometry-style.js";
 import { packSegmentsBatch } from "./geometry-segments-pack.js";
 
 export function finiteSegmentBatch(
@@ -31,7 +30,6 @@ export function finiteSegmentBatch(
   const segments = new Float32Array(capacity * 4);
   const rowIndex = new Uint32Array(capacity);
   const styleRows = new Uint32Array(capacity);
-  const strokes = wantsColors ? Array.from<string>({ length: capacity }) : null;
   let kept = 0;
   let removed = 0;
 
@@ -51,11 +49,6 @@ export function finiteSegmentBatch(
     segments[o + 3] = fx.innerHeight - t1y * fx.innerHeight;
     rowIndex[kept] = frame.rowIndex[row]!;
     styleRows[kept] = row;
-    if (wantsColors && color !== null && strokes !== null) {
-      const value =
-        frame.colorValues === null ? binding.color.scaledConstant! : frame.colorValues[row]!;
-      strokes[kept] = colorOf(color, value);
-    }
     kept++;
   }
 
@@ -65,7 +58,8 @@ export function finiteSegmentBatch(
   const outSegments = kept === capacity ? segments : segments.subarray(0, kept * 4).slice();
   const outRows = kept === capacity ? rowIndex : rowIndex.subarray(0, kept).slice();
   const outStyleRows = kept === capacity ? styleRows : styleRows.subarray(0, kept).slice();
-  const outStrokes = strokes === null ? null : kept === capacity ? strokes : strokes.slice(0, kept);
+  const outStrokes =
+    wantsColors && color !== null ? mappedPaintVector(frame, "color", color, outStyleRows) : null;
 
   const batch = packSegmentsBatch({
     frame,

--- a/packages/core/src/pipeline/geometry-segments-data.ts
+++ b/packages/core/src/pipeline/geometry-segments-data.ts
@@ -2,10 +2,10 @@
  * Emit data-driven vertical/horizontal rule segments with optional colors.
  */
 import type { LayerFrame, ResolvedColorScale } from "./types.js";
-import { colorOf } from "./types.js";
 import type { Frame } from "./geometry-shared.js";
 import { positionOf } from "./geometry-shared.js";
 import type { SegmentEmitBuffers } from "./geometry-segments-emit.js";
+import { mappedPaintVector } from "./geometry-style.js";
 
 export function emitDataSegments(input: {
   frame: LayerFrame;
@@ -45,9 +45,7 @@ export function emitDataSegments(input: {
     if (buffers.kept > before) {
       styleRows[before] = row;
       if (wantsColors && color !== null && strokes !== null) {
-        const value =
-          frame.colorValues === null ? binding.color.scaledConstant! : frame.colorValues[row]!;
-        strokes[before] = colorOf(color, value);
+        strokes[before] = mappedPaintVector(frame, "color", color, [row])[0]!;
       }
     }
   }

--- a/packages/core/src/pipeline/geometry-segments-pack.ts
+++ b/packages/core/src/pipeline/geometry-segments-pack.ts
@@ -8,6 +8,7 @@ import { linetypeIndex, type Linetype } from "../scales/style.js";
 
 import {
   indexedStyleVector,
+  constantStyle,
   numericStyleVector,
   type ResolvedStyleScales,
 } from "./geometry-style.js";
@@ -36,12 +37,8 @@ export function packSegmentsBatch(input: {
     segments,
     rowIndex,
     stroke: binding.color.constant,
-    linewidth:
-      typeof binding.linewidth?.constant === "number"
-        ? binding.linewidth.constant
-        : (params.linewidth ?? DEFAULT_RULE_LINEWIDTH),
-    alpha:
-      typeof binding.alpha?.constant === "number" ? binding.alpha.constant : (params.alpha ?? 1),
+    linewidth: constantStyle(binding, params, "linewidth", DEFAULT_RULE_LINEWIDTH),
+    alpha: constantStyle(binding, params, "alpha", 1),
     ...(typeof binding.linetype?.constant === "string" && {
       linetype: binding.linetype.constant as Linetype,
     }),

--- a/packages/core/src/pipeline/geometry-smooth-line.ts
+++ b/packages/core/src/pipeline/geometry-smooth-line.ts
@@ -9,6 +9,7 @@ import { linetypeIndex, type Linetype } from "../scales/style.js";
 import type { LayerFrame, ResolvedColorScale } from "./types.js";
 import type { Frame } from "./geometry-shared.js";
 import {
+  constantStyle,
   indexedStyleVector,
   numericStyleVector,
   type ResolvedStyleScales,
@@ -51,17 +52,9 @@ export function buildSmoothLineBatch(input: {
     ...(frameRowIndex !== undefined && { frameRowIndex }),
     pathOffsets,
     strokes,
-    linewidth:
-      typeof binding.linewidth.constant === "number"
-        ? binding.linewidth.constant
-        : (params.linewidth ?? DEFAULT_SMOOTH_LINEWIDTH),
+    linewidth: constantStyle(binding, params, "linewidth", DEFAULT_SMOOTH_LINEWIDTH),
     ...(linewidths !== undefined && { linewidths }),
-    alpha:
-      alphas === undefined
-        ? typeof binding.alpha.constant === "number"
-          ? binding.alpha.constant
-          : (params.alpha ?? 1)
-        : 1,
+    alpha: alphas === undefined ? constantStyle(binding, params, "alpha", 1) : 1,
     ...(alphas !== undefined && { alphas }),
     ...(typeof binding.linetype.constant === "string" && {
       linetype: binding.linetype.constant as Linetype,

--- a/packages/core/src/pipeline/geometry-smooth-ribbon.ts
+++ b/packages/core/src/pipeline/geometry-smooth-ribbon.ts
@@ -5,7 +5,7 @@ import type { GeometryBatch } from "../scene.js";
 
 import type { LayerFrame, ResolvedColorScale } from "./types.js";
 import type { Frame } from "./geometry-shared.js";
-import { numericStyleVector, type ResolvedStyleScales } from "./geometry-style.js";
+import { constantStyle, numericStyleVector, type ResolvedStyleScales } from "./geometry-style.js";
 import { writeClosedPathGroups } from "./geometry-paths-closed-batch.js";
 import { groupColor, SMOOTH_RIBBON_ALPHA } from "./geometry-smooth-shared.js";
 
@@ -76,12 +76,7 @@ export function buildSmoothRibbonBatch(input: {
     fills,
     closed: true,
     linewidth: 0,
-    alpha:
-      typeof binding.alpha.constant === "number"
-        ? binding.alpha.constant
-        : alphas === undefined
-          ? SMOOTH_RIBBON_ALPHA
-          : 1,
+    alpha: alphas === undefined ? constantStyle(binding, {}, "alpha", SMOOTH_RIBBON_ALPHA) : 1,
     ...(alphas !== undefined && { alphas }),
     curve: "linear",
   };

--- a/packages/core/src/pipeline/geometry-style.ts
+++ b/packages/core/src/pipeline/geometry-style.ts
@@ -2,9 +2,76 @@
 import type { StyleAesthetic } from "@ggsvelte/spec";
 
 import type { ResolvedStyleScale, StyleOutput } from "../scales/style.js";
-import type { LayerFrame } from "./types.js";
+import type { LayerBinding, LayerFrame, ResolvedColorScale } from "./types.js";
+import { colorOf } from "./types.js";
 
 export type ResolvedStyleScales = Readonly<Record<StyleAesthetic, ResolvedStyleScale | null>>;
+
+type PaintChannel = "color" | "fill";
+
+function paintValues(frame: LayerFrame, channel: PaintChannel): LayerFrame["colorValues"] {
+  return channel === "color" ? frame.colorValues : frame.fillValues;
+}
+
+/**
+ * Per-row paint when the caller has already proven the channel is mapped
+ * (scale non-null and values|scaledConstant present). Feeds Points/Rects/
+ * Segments `string[]` fields without null casts.
+ */
+export function mappedPaintVector(
+  frame: LayerFrame,
+  channel: PaintChannel,
+  scale: ResolvedColorScale,
+  rows: ArrayLike<number>,
+): string[] {
+  const binding = frame.binding[channel];
+  const values = paintValues(frame, channel);
+  const out = Array.from<string>({ length: rows.length });
+  for (let i = 0; i < rows.length; i++) {
+    const row = rows[i]!;
+    const value = values === null ? binding.scaledConstant! : values[row]!;
+    out[i] = colorOf(scale, value);
+  }
+  return out;
+}
+
+/**
+ * Per-subpath / per-row paint vector. Honour mapped field values ·
+ * scaledConstant · literal constant. `rows` is required: style vectors index
+ * kept subpaths/marks, never raw frame rows.
+ */
+export function paintVector(
+  frame: LayerFrame,
+  channel: PaintChannel,
+  scale: ResolvedColorScale | null,
+  rows: ArrayLike<number>,
+): (string | null)[] {
+  const binding = frame.binding[channel];
+  const values = paintValues(frame, channel);
+  if (scale !== null && (values !== null || binding.scaledConstant !== null)) {
+    return mappedPaintVector(frame, channel, scale, rows);
+  }
+  const constant = binding.constant;
+  return Array.from({ length: rows.length }, () => constant);
+}
+
+/**
+ * Literal alpha/linewidth: binding.constant → params[key] → fallback.
+ * Fallback is explicit so site-specific defaults stay behavior-identical.
+ */
+export function constantStyle(
+  binding: LayerBinding,
+  params: { alpha?: number; linewidth?: number },
+  key: "alpha" | "linewidth",
+  fallback: number,
+): number {
+  // Optional: some emit/pack tests build partial bindings without every style key.
+  const c = binding[key]?.constant;
+  if (typeof c === "number") return c;
+  const p = params[key];
+  if (typeof p === "number") return p;
+  return fallback;
+}
 
 /** Resolve a frame's per-row value column for a style aesthetic. Shared by the
  *  scale trainer (scale-style.ts) and geometry so both read the same columns. */

--- a/packages/core/src/pipeline/geometry-violin.ts
+++ b/packages/core/src/pipeline/geometry-violin.ts
@@ -9,7 +9,6 @@ import type { PathsBatch } from "../scene.js";
 import { encodeKey } from "../scales/state.js";
 
 import type { LayerFrame, PipelineWarning, ResolvedColorScale } from "./types.js";
-import { colorOf } from "./types.js";
 import type { Frame } from "./geometry-shared.js";
 import {
   DEFAULT_BOXPLOT_WIDTH,
@@ -17,7 +16,12 @@ import {
   positionOf,
   removedWarning,
 } from "./geometry-shared.js";
-import { numericStyleVector, type ResolvedStyleScales } from "./geometry-style.js";
+import {
+  constantStyle,
+  numericStyleVector,
+  paintVector,
+  type ResolvedStyleScales,
+} from "./geometry-style.js";
 import { areaGroupFillOf } from "./geometry-paths-area-fill.js";
 
 function sortRowsByY(rows: number[], y: Float64Array): number[] {
@@ -52,22 +56,6 @@ function bucketViolinRows(
   }
   removedWarning(removed, frame.binding.index, warnings);
   return order.map((k) => map.get(k)!);
-}
-
-function strokeOf(
-  frame: LayerFrame,
-  color: ResolvedColorScale | null,
-  rows: readonly number[],
-): string | null {
-  const { binding } = frame;
-  let stroke: string | null = binding.color.constant;
-  if (color !== null && (frame.colorValues !== null || binding.color.scaledConstant !== null)) {
-    const first = rows[0]!;
-    const value =
-      frame.colorValues === null ? binding.color.scaledConstant! : frame.colorValues[first]!;
-    stroke = colorOf(color, value);
-  }
-  return stroke;
 }
 
 export function violinBatch(
@@ -160,7 +148,7 @@ export function violinBatch(
       cursor++;
     }
     fills.push(areaGroupFillOf(frame, fill, rows) ?? fillPaintResolved?.fallback ?? null);
-    let stroke = strokeOf(frame, color, rows);
+    let stroke = paintVector(frame, "color", color, [rows[0]!])[0]!;
     if (stroke === null && strokePaintResolved !== undefined) {
       stroke = strokePaintResolved.fallback;
     }
@@ -175,17 +163,13 @@ export function violinBatch(
     styles,
   );
   const subpathCount = pathOffsets.length - 1;
-  const constantAlpha =
-    typeof binding.alpha.constant === "number" ? binding.alpha.constant : (params.alpha ?? 1);
+  const constantAlpha = constantStyle(binding, params, "alpha", 1);
   const alphas =
     mappedAlphas ??
     (subpathCount > 1 && constantAlpha !== 1
       ? Float32Array.from({ length: subpathCount }, () => constantAlpha)
       : undefined);
-  const linewidth =
-    typeof binding.linewidth.constant === "number"
-      ? binding.linewidth.constant
-      : (params.linewidth ?? 0.5);
+  const linewidth = constantStyle(binding, params, "linewidth", 0.5);
 
   return {
     kind: "paths",

--- a/packages/core/tests/geometry-errorbar-prealloc.test.ts
+++ b/packages/core/tests/geometry-errorbar-prealloc.test.ts
@@ -154,4 +154,32 @@ describe("emitErrorbarRows prealloc", () => {
     });
     expect(emitted.strokes).toEqual(["c:red", "c:red", "c:red"]);
   });
+
+  it("indexes mapped strokes by styleRows (3× per kept row) when a middle row drops", () => {
+    const frame = frameOf({
+      n: 3,
+      x: Float64Array.of(0.2, Number.NaN, 0.8),
+      ymin: Float64Array.of(0.1, 0.1, 0.1),
+      ymax: Float64Array.of(0.9, 0.9, 0.9),
+      colorValues: ["a", "b", "c"],
+    });
+    const color = fromAny({
+      scale: {
+        colorOf: (v: unknown) => `c:${String(v)}`,
+        naValue: null,
+        unknownValue: "#999",
+      },
+    });
+    const emitted = emitErrorbarRows({
+      frame,
+      fx: fx(),
+      color,
+      wantsColors: true,
+      xSpanOf: fullSpan,
+    });
+    // Two kept rows × three segments; middle frame row (b) never appears.
+    expect(emitted.keptSegments).toBe(6);
+    expect(emitted.strokes).toEqual(["c:a", "c:a", "c:a", "c:c", "c:c", "c:c"]);
+    expect([...emitted.styleRows]).toEqual([0, 0, 0, 2, 2, 2]);
+  });
 });

--- a/packages/core/tests/pipeline/geometry-style-paint.test.ts
+++ b/packages/core/tests/pipeline/geometry-style-paint.test.ts
@@ -11,6 +11,7 @@ import {
   paintVector,
 } from "../../src/pipeline/geometry-style.ts";
 import { DEFAULT_MISSING_COLOR } from "../../src/scales/engine.ts";
+import type { CellValue } from "../../src/table.ts";
 import type { LayerBinding, LayerFrame, ResolvedColorScale } from "../../src/pipeline/types.ts";
 
 const PALETTE: Record<string, string> = {
@@ -24,7 +25,8 @@ function stubScale(map: Record<string, string> = PALETTE): ResolvedColorScale {
   return fromPartial<ResolvedColorScale>({
     kind: "ordinal",
     scale: {
-      colorOf: (value: unknown) => (value === null ? undefined : map[String(value)]),
+      colorOf: (value: unknown) =>
+        value === null || value === undefined ? undefined : map[`${value as string | number}`],
       naValue: DEFAULT_MISSING_COLOR,
       unknownValue: DEFAULT_MISSING_COLOR,
     },
@@ -151,7 +153,8 @@ describe("constantStyle", () => {
   });
 
   it("ignores non-number binding constants", () => {
-    const binding = makeFrame({ alpha: { constant: "nope" as unknown as number } }).binding;
+    const nonNumber: CellValue = "nope";
+    const binding = makeFrame({ alpha: { constant: nonNumber } }).binding;
     expect(constantStyle(binding, { alpha: 0.2 }, "alpha", 1)).toBe(0.2);
   });
 });

--- a/packages/core/tests/pipeline/geometry-style-paint.test.ts
+++ b/packages/core/tests/pipeline/geometry-style-paint.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Unit seams for paintVector / mappedPaintVector / constantStyle (#1041).
+ * Expected colors are independent palette literals, not re-derived from colorOf.
+ */
+import { fromPartial } from "@total-typescript/shoehorn";
+import { describe, expect, it } from "bun:test";
+
+import {
+  constantStyle,
+  mappedPaintVector,
+  paintVector,
+} from "../../src/pipeline/geometry-style.ts";
+import { DEFAULT_MISSING_COLOR } from "../../src/scales/engine.ts";
+import type { LayerBinding, LayerFrame, ResolvedColorScale } from "../../src/pipeline/types.ts";
+
+const PALETTE: Record<string, string> = {
+  a: "#ff0000",
+  b: "#00ff00",
+  c: "#0000ff",
+  scaled: "#abcdef",
+};
+
+function stubScale(map: Record<string, string> = PALETTE): ResolvedColorScale {
+  return fromPartial<ResolvedColorScale>({
+    kind: "ordinal",
+    scale: {
+      colorOf: (value: unknown) => (value === null ? undefined : map[String(value)]),
+      naValue: DEFAULT_MISSING_COLOR,
+      unknownValue: DEFAULT_MISSING_COLOR,
+    },
+  });
+}
+
+function makeFrame(partial: {
+  colorValues?: LayerFrame["colorValues"];
+  fillValues?: LayerFrame["fillValues"];
+  color?: Partial<LayerBinding["color"]>;
+  fill?: Partial<LayerBinding["fill"]>;
+  alpha?: Partial<LayerBinding["alpha"]>;
+  linewidth?: Partial<LayerBinding["linewidth"]>;
+}): LayerFrame {
+  const emptyStyle = {
+    field: null,
+    statColumn: null,
+    constant: null,
+    scaledConstant: null,
+  };
+  return fromPartial<LayerFrame>({
+    colorValues: partial.colorValues ?? null,
+    fillValues: partial.fillValues ?? null,
+    binding: {
+      color: {
+        field: null,
+        constant: null,
+        scaledConstant: null,
+        ...partial.color,
+      },
+      fill: {
+        field: null,
+        constant: null,
+        scaledConstant: null,
+        ...partial.fill,
+      },
+      alpha: { ...emptyStyle, ...partial.alpha },
+      linewidth: { ...emptyStyle, ...partial.linewidth },
+    },
+  });
+}
+
+describe("mappedPaintVector", () => {
+  it("indexes mapped color values by kept-row order", () => {
+    const frame = makeFrame({ colorValues: ["a", "b", "c"] });
+    const scale = stubScale();
+    expect(mappedPaintVector(frame, "color", scale, [0, 2])).toEqual(["#ff0000", "#0000ff"]);
+  });
+
+  it("uses scaledConstant when the values column is null", () => {
+    const frame = makeFrame({
+      colorValues: null,
+      color: { scaledConstant: "scaled" },
+    });
+    expect(mappedPaintVector(frame, "color", stubScale(), [0, 1])).toEqual(["#abcdef", "#abcdef"]);
+  });
+
+  it("resolves fill channel values", () => {
+    const frame = makeFrame({ fillValues: ["a", "c"] });
+    expect(mappedPaintVector(frame, "fill", stubScale(), [1])).toEqual(["#0000ff"]);
+  });
+
+  it("maps null cells to the scale NA color", () => {
+    const frame = makeFrame({ colorValues: [null, "a"] });
+    expect(mappedPaintVector(frame, "color", stubScale(), [0, 1])).toEqual([
+      DEFAULT_MISSING_COLOR,
+      "#ff0000",
+    ]);
+  });
+});
+
+describe("paintVector", () => {
+  it("matches mappedPaintVector when the channel is mapped", () => {
+    const frame = makeFrame({ colorValues: ["a", "b", "c"] });
+    const scale = stubScale();
+    const rows = [0, 2];
+    expect(paintVector(frame, "color", scale, rows)).toEqual(
+      mappedPaintVector(frame, "color", scale, rows),
+    );
+  });
+
+  it("falls through to the literal constant when scale is null", () => {
+    const frame = makeFrame({ color: { constant: "#111111" } });
+    expect(paintVector(frame, "color", null, [0, 1])).toEqual(["#111111", "#111111"]);
+  });
+
+  it("falls through to the literal constant when scale is present but unmapped", () => {
+    const frame = makeFrame({
+      colorValues: null,
+      color: { constant: "#222222", scaledConstant: null },
+    });
+    expect(paintVector(frame, "color", stubScale(), [0])).toEqual(["#222222"]);
+  });
+
+  it("returns null constants when unmapped and constant is null", () => {
+    const frame = makeFrame({ fill: { constant: null } });
+    expect(paintVector(frame, "fill", null, [0, 1])).toEqual([null, null]);
+  });
+
+  it("uses scaledConstant over the literal constant when mapped", () => {
+    const frame = makeFrame({
+      colorValues: null,
+      color: { constant: "#111111", scaledConstant: "scaled" },
+    });
+    expect(paintVector(frame, "color", stubScale(), [0])).toEqual(["#abcdef"]);
+  });
+});
+
+describe("constantStyle", () => {
+  it("prefers a numeric binding constant over params and fallback", () => {
+    const binding = makeFrame({ alpha: { constant: 0.4 } }).binding;
+    expect(constantStyle(binding, { alpha: 0.9 }, "alpha", 1)).toBe(0.4);
+  });
+
+  it("uses params when the binding constant is not a number", () => {
+    const binding = makeFrame({ alpha: { constant: null } }).binding;
+    expect(constantStyle(binding, { alpha: 0.7 }, "alpha", 1)).toBe(0.7);
+  });
+
+  it("uses the explicit fallback when neither binding nor params provide a number", () => {
+    const binding = makeFrame({ linewidth: { constant: null } }).binding;
+    expect(constantStyle(binding, {}, "linewidth", 0)).toBe(0);
+    expect(constantStyle(binding, {}, "linewidth", 1.5)).toBe(1.5);
+  });
+
+  it("ignores non-number binding constants", () => {
+    const binding = makeFrame({ alpha: { constant: "nope" as unknown as number } }).binding;
+    expect(constantStyle(binding, { alpha: 0.2 }, "alpha", 1)).toBe(0.2);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1041.

Mechanical extract of restated paint-resolution idioms into `geometry-style.ts`:

- **`mappedPaintVector`** — predicate-guarded mapped paint for `Points`/`Rects`/`Segments` (`string[]`)
- **`paintVector`** — mapped + constant fallthrough for paths (`(string | null)[]`)
- **`constantStyle`** — `binding.constant → params → site fallback` for alpha/linewidth

Call sites across geometry builders now share one implementation. `rows` is required so style vectors index kept subpaths/marks (the hex misalignment shape).

Claude plan review incorporated: split return types (no `as string[]`), errorbar 3× `styleRows` indexing, delete local `strokeOf` helpers, defer `groupColor` fold, leave glyphs-pack label stroke width alone.

## Test plan

- [x] `bun test packages/core/tests/pipeline/geometry-style-paint.test.ts`
- [x] `bun test packages/core/tests/geometry-errorbar-prealloc.test.ts` (incl. dropped-row 3× strokes)
- [x] `bun test packages/core/tests/pipeline-geometry`
- [x] `bun test packages/core/tests/pipeline-m2/{errorbar,curve,ribbon,violin,segment,rect-tile-raster}.test.ts`
- [x] `tsc -p packages/core --noEmit`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1045" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->