### PR TITLE
refactor(svelte): one prop surface for the plot engine (#1040)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -251,26 +251,26 @@ for job markers).
 
 The Svelte package is organized by feature under `packages/svelte/src/lib/`:
 
-| Directory / file        | Role                                                                                                                             |
-| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| `geoms/`                | Declaration-only geom children (`GeomPoint`, …) and the geom factory/registry                                                    |
-| `assembly/`             | Labels, layout helpers, chrome-adjacent pure assembly                                                                            |
-| `runtime/`              | Runtime paint, announcer, semantic-key services                                                                                  |
-| `scene/`                | SVG scene tree (`SceneView`, `Batch`, axes, legends paint, strata)                                                               |
-| `a11y/`                 | Canvas-stratum accessibility surface + row materialization                                                                       |
-| `interaction/`          | Tools, reducer, capability, controller                                                                                           |
-| `surface/`              | Capture surface controller (pointer/keyboard/brush)                                                                              |
-| `inspection/`           | Tooltip, inspection coordinator/resolver, inspection state                                                                       |
-| `selection/`            | Point-selection state                                                                                                            |
-| `interval/`             | Interval selection, bounds editor, query                                                                                         |
-| `zoom/`                 | Brush-zoom state                                                                                                                 |
-| `legend/`               | Legend filter/focus controllers, targets, pure surface helpers                                                                   |
-| `chrome/`               | Tool rail, status chrome, theme CSS, chrome state                                                                                |
-| `fonts/`                | Packaged font assets (not TypeScript sources)                                                                                    |
-| `GGPlot.svelte`         | Public component shell                                                                                                           |
-| `plot-engine.svelte.ts` | Controller wiring; owns the construction/effect-order DAG contract (read the file header before reordering factories or effects) |
-| `plot-props.ts`         | GGPlot's **internal** props contract — not re-exported from `index.ts`                                                           |
-| `index.ts`              | The **only** public package entry                                                                                                |
+| Directory / file        | Role                                                                                                                                      |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `geoms/`                | Declaration-only geom children (`GeomPoint`, …) and the geom factory/registry                                                             |
+| `assembly/`             | Labels, layout helpers, chrome-adjacent pure assembly                                                                                     |
+| `runtime/`              | Runtime paint, announcer, semantic-key services                                                                                           |
+| `scene/`                | SVG scene tree (`SceneView`, `Batch`, axes, legends paint, strata)                                                                        |
+| `a11y/`                 | Canvas-stratum accessibility surface + row materialization                                                                                |
+| `interaction/`          | Tools, reducer, capability, controller                                                                                                    |
+| `surface/`              | Capture surface controller (pointer/keyboard/brush)                                                                                       |
+| `inspection/`           | Tooltip, inspection coordinator/resolver, inspection state                                                                                |
+| `selection/`            | Point-selection state                                                                                                                     |
+| `interval/`             | Interval selection, bounds editor, query                                                                                                  |
+| `zoom/`                 | Brush-zoom state                                                                                                                          |
+| `legend/`               | Legend filter/focus controllers, targets, pure surface helpers                                                                            |
+| `chrome/`               | Tool rail, status chrome, theme CSS, chrome state                                                                                         |
+| `fonts/`                | Packaged font assets (not TypeScript sources)                                                                                             |
+| `GGPlot.svelte`         | Public component shell                                                                                                                    |
+| `plot-engine.svelte.ts` | Controller wiring; owns the construction/effect-order DAG contract (read the file header before reordering factories or effects)          |
+| `plot-props.ts`         | GGPlot's **internal** props contract + engine resolve helpers (`resolveCapabilities`, `widenPlotProps`) — not re-exported from `index.ts` |
+| `index.ts`              | The **only** public package entry                                                                                                         |
 
 ### No per-directory barrels
 

--- a/packages/svelte/src/lib/GGPlot.svelte
+++ b/packages/svelte/src/lib/GGPlot.svelte
@@ -39,14 +39,7 @@
   import type { CellValue } from "@ggsvelte/core";
   import { sceneLabel } from "@ggsvelte/core";
 
-  import type {
-    LegendFocusEvent,
-    PlotInspection,
-    PlotInteractionEvent,
-    PlotSelection,
-    ZoomDomains,
-  } from "./interaction/interaction.js";
-  import type { PlotInteractionController } from "./interaction/controller.svelte.js";
+  import type { ZoomDomains } from "./interaction/interaction.js";
   import { provideRegistry } from "./geoms/registry.svelte.js";
   import { shouldRenderInteractionLiveRegion } from "./legend/surface.js";
   import { resolveInteractionLiveText } from "./assembly/labels.js";
@@ -60,7 +53,8 @@
     tooltipViewportSize,
   } from "./assembly/layout.js";
   import BoundsEditor from "./interval/BoundsEditor.svelte";
-  import type { GGPlotProps } from "./plot-props.js";
+  import type { EnginePlotProps, GGPlotProps } from "./plot-props.js";
+  import { widenPlotProps } from "./plot-props.js";
   import { createPlotEngine } from "./plot-engine.svelte.js";
   import CaptureSurface from "./surface/CaptureSurface.svelte";
   import LegendFilters from "./legend/LegendFilters.svelte";
@@ -71,35 +65,10 @@
   import Tooltip from "./inspection/Tooltip.svelte";
   import ToolRail from "./chrome/ToolRail.svelte";
 
-  const {
-    spec,
-    data,
-    aes: mapping,
-    layers,
-    a11y,
-    width,
-    height,
-    key: datumKey,
-    inspect = false,
-    select = false,
-    zoom = false,
-    legendFocus = false,
-    legendFilter = false,
-    tool,
-    interaction,
-    interactionScope,
-    ariaLabel,
-    oninspect,
-    onselect,
-    onzoom,
-    onlegendfocus,
-    onlegendfilter,
-    oninteraction,
-    ondiagnostic,
-    ontoolchange,
-    onrender,
-    children,
-  }: GGPlotProps<Row, Identity> = $props();
+  // Do not destructure $props — later destructure freezes values (#1040 / Claude).
+  // Markup reads props.width / props.ariaLabel / props.children; engine gets a
+  // lazy widened view (six PublicKey casts live in widenPlotProps).
+  const props: GGPlotProps<Row, Identity> = $props();
 
   const registry = provideRegistry();
   let root = $state<HTMLDivElement | null>(null);
@@ -107,53 +76,17 @@
   let a11yTableOpen = $state(false);
   const plotId = $props.id();
 
-  const engine = createPlotEngine<Row, Identity>({
+  // Getter so construction does not snapshot $props (state_referenced_locally).
+  // The widened proxy is memoized once; field access stays lazy on the source.
+  let engineProps: EnginePlotProps | undefined;
+  const engine = createPlotEngine({
     registry,
     plotId,
     root: () => root,
     captureSurface: () => captureSurface,
-    spec: () => spec,
-    data: () => data,
-    mapping: () => mapping,
-    layers: () => layers,
-    a11y: () => a11y,
-    width: () => width,
-    height: () => height,
-    datumKey: () => datumKey,
-    inspect: () => inspect,
-    select: () => select,
-    zoom: () => zoom,
-    legendFocus: () => legendFocus,
-    legendFilter: () => legendFilter,
-    tool: () => tool,
-    // The PublicKey → PropertyKey widening casts live HERE (component-local
-    // generic erased at the engine boundary; same widening the pre-S11
-    // factory* aliases performed).
-    interaction: () =>
-      interaction as PlotInteractionController<PropertyKey> | undefined,
-    interactionScope: () => interactionScope,
-    oninspect: () =>
-      oninspect as
-        | ((
-            event: PlotInspection<Record<string, CellValue>, PropertyKey>,
-          ) => void)
-        | undefined,
-    onselect: () =>
-      onselect as ((event: PlotSelection<PropertyKey>) => void) | undefined,
-    onzoom: () => onzoom,
-    onlegendfocus: () =>
-      onlegendfocus as
-        ((event: LegendFocusEvent<PropertyKey>) => void) | undefined,
-    onlegendfilter: () => onlegendfilter,
-    oninteraction: () =>
-      oninteraction as
-        | ((
-            event: PlotInteractionEvent<Record<string, CellValue>, PropertyKey>,
-          ) => void)
-        | undefined,
-    ondiagnostic: () => ondiagnostic,
-    ontoolchange: () => ontoolchange,
-    onrender: () => onrender,
+    get props() {
+      return (engineProps ??= widenPlotProps(props));
+    },
   });
 
   const {
@@ -189,7 +122,7 @@
      the root so SSR registers every layer before root attributes read derived
      plot state; placing them inside the root is too late in Svelte's one-pass
      server evaluation even when they appear first in source order. -->
-{@render children?.()}
+{@render props.children?.()}
 
 <!-- The root div is the plot's stable mount point and carries the
      data-gg-ready readiness signal. Compositing (decision 0006): ordered
@@ -198,7 +131,7 @@
 <div
   bind:this={root}
   class="gg-plot-root"
-  class:gg-container-width={isContainerWidthProp(width)}
+  class:gg-container-width={isContainerWidthProp(props.width)}
   class:gg-with-tool-rail={chromeState.showToolRail}
   class:gg-with-legend-clear={engine.legendClearActive}
   class:gg-with-legend-filters={engine.filterableLegendEntries.length > 0}
@@ -251,7 +184,7 @@
     <MarkStrata
       model={currentModel}
       strata={runtime.strata}
-      {ariaLabel}
+      ariaLabel={props.ariaLabel}
       markLabel={chromeState.markLabel}
       interactionMasks={engine.interactionMasks}
       {a11yTableOpen}
@@ -310,7 +243,7 @@
         bind:element={captureSurface}
         {plotId}
         activeTool={surfaceState.activeTool}
-        ariaLabel={ariaLabel ??
+        ariaLabel={props.ariaLabel ??
           engine.assembled?.labs?.title ??
           sceneLabel(currentModel.scene)}
         ariaControls={resolveCaptureAriaControls({

--- a/packages/svelte/src/lib/plot-engine.svelte.ts
+++ b/packages/svelte/src/lib/plot-engine.svelte.ts
@@ -26,15 +26,8 @@
  * registers in the component effect tree. No `$props`, `$props.id()`, or
  * context calls live here.
  */
-import type { BatchInteractionMask, CellValue, RenderModel } from "@ggsvelte/core";
-import type {
-  A11yMode,
-  AesInput,
-  DataInput,
-  LayerInput,
-  PortableSpec,
-  SpecInput,
-} from "@ggsvelte/spec";
+import type { BatchInteractionMask } from "@ggsvelte/core";
+import type { PortableSpec } from "@ggsvelte/spec";
 
 import {
   assemblePortableSpec,
@@ -49,29 +42,17 @@ import {
 } from "./diagnostics/composition.js";
 import type { PlotDiagnostic } from "./diagnostics/deprecation.js";
 import type { LayerRegistry } from "./geoms/registry.svelte.js";
-import type { PlotInteractionController } from "./interaction/controller.svelte.js";
 import {
   normalizeInteractionConfig,
-  type InspectInput,
   type InteractionDiagnostic,
-  type InteractionTool,
-  type LegendFocusEvent,
-  type LegendFocusInput,
-  type PlotInspection,
-  type PlotInteractionEvent,
   type PlotInteractionScope,
-  type PlotSelection,
   type ResolvedInteractionConfig,
-  type SelectInput,
-  type ZoomEvent,
-  type ZoomInput,
 } from "./interaction/interaction.js";
 import { collectWiringDiagnostics } from "./interaction/wiring-advisories.js";
 import { createInspectionState } from "./inspection/inspection-state.svelte.js";
 import type { InspectionState } from "./inspection/inspection-state.svelte.js";
 import { createIntervalState } from "./interval/interval-state.svelte.js";
 import type { IntervalState } from "./interval/interval-state.svelte.js";
-import type { LegendFilterEvent, LegendFilterInput } from "./legend/filter.js";
 import { createLegendEntryKeyIndex } from "./legend/entry-key-index.svelte.js";
 import { createLegendFilterState } from "./legend/filter-state.svelte.js";
 import type { FilterableLegendEntry, LegendFilterState } from "./legend/filter-state.svelte.js";
@@ -80,6 +61,11 @@ import { createLegendFocusState } from "./legend/focus-state.svelte.js";
 import type { LegendFocusState } from "./legend/focus-state.svelte.js";
 import { createPlotChromeState } from "./chrome/chrome-state.svelte.js";
 import type { PlotChromeState } from "./chrome/chrome-state.svelte.js";
+import {
+  resolveCapabilities,
+  type EnginePlotProps,
+  type ResolvedPlotCapabilities,
+} from "./plot-props.js";
 import { createPlotAnnouncer } from "./runtime/announcer.svelte.js";
 import type { PlotAnnouncer } from "./runtime/announcer.svelte.js";
 import { createPlotRuntime } from "./runtime/runtime.svelte.js";
@@ -107,51 +93,23 @@ import { createPlotZoomState } from "./zoom/zoom-state.svelte.js";
 import type { PlotZoomState } from "./zoom/zoom-state.svelte.js";
 
 // ---------------------------------------------------------------------------
-// Inputs / return type
+// Host / return type
 // ---------------------------------------------------------------------------
 
-export type PlotEngineInputs<
-  Row extends Record<string, CellValue> = Record<string, CellValue>,
-  Identity extends keyof Row | ((row: Row, index: number) => PropertyKey) = keyof Row,
-> = {
+/**
+ * Host binding for the plot engine (#1040). Props are a single lazy
+ * `EnginePlotProps` surface (GGPlotProps with PublicKey fields widened) —
+ * not a per-field thunk bag. Capability defaults live in `resolveCapabilities`.
+ */
+export type PlotEngineHost = {
   /** Value — created by `provideRegistry()` in GGPlot (context stays there). */
   registry: LayerRegistry;
   /** Plain string from `$props.id()` in GGPlot. */
   plotId: string;
   root: () => HTMLDivElement | null;
   captureSurface: () => HTMLDivElement | null;
-
-  // Reactive props / callbacks as getter thunks (post-destructure names).
-  // Grammar (theme/scales/coord/facet/labs/guides/legend) is children-only (#704).
-  spec: () => SpecInput | undefined;
-  data: () => DataInput | readonly Row[] | undefined;
-  mapping: () => AesInput | undefined;
-  layers: () => LayerInput[] | undefined;
-  a11y: () => A11yMode | undefined;
-  width: () => number | "container" | undefined;
-  height: () => number | undefined;
-  datumKey: () => Identity | undefined;
-  /** Defaulted non-optional after destructure. */
-  inspect: () => InspectInput;
-  select: () => SelectInput;
-  zoom: () => ZoomInput;
-  legendFocus: () => LegendFocusInput;
-  legendFilter: () => LegendFilterInput;
-  tool: () => InteractionTool | undefined;
-  // Widened to PropertyKey at the boundary — PublicKey is component-local.
-  interaction: () => PlotInteractionController<PropertyKey> | undefined;
-  interactionScope: () => PlotInteractionScope | undefined;
-  oninspect: () => ((event: PlotInspection<Record<string, CellValue>>) => void) | undefined;
-  onselect: () => ((event: PlotSelection) => void) | undefined;
-  onzoom: () => ((event: ZoomEvent) => void) | undefined;
-  onlegendfocus: () => ((event: LegendFocusEvent) => void) | undefined;
-  onlegendfilter: () => ((event: LegendFilterEvent) => void) | undefined;
-  oninteraction: () =>
-    | ((event: PlotInteractionEvent<Record<string, CellValue>>) => void)
-    | undefined;
-  ondiagnostic: () => ((diagnostic: PlotDiagnostic) => void) | undefined;
-  ontoolchange: () => ((tool: InteractionTool) => void) | undefined;
-  onrender: () => ((model: RenderModel, spec: PortableSpec) => void) | undefined;
+  /** Live props proxy (or widenPlotProps view). Grammar is children-only (#704). */
+  props: EnginePlotProps;
 };
 
 /**
@@ -199,28 +157,29 @@ export type PlotEngine = {
 // Factory
 // ---------------------------------------------------------------------------
 
-export function createPlotEngine<
-  Row extends Record<string, CellValue> = Record<string, CellValue>,
-  Identity extends keyof Row | ((row: Row, index: number) => PropertyKey) = keyof Row,
->(inputs: PlotEngineInputs<Row, Identity>): PlotEngine {
+export function createPlotEngine(host: PlotEngineHost): PlotEngine {
+  // Capability defaults — pure, lazy per read (do not materialize a full
+  // props snapshot; per-field deps stay on host.props).
+  const caps = (): ResolvedPlotCapabilities => resolveCapabilities(host.props);
+
   // Reading descriptors through toLayerInput goes through live getters, so
   // geom prop changes flow into this $derived without re-registration.
   // Explicit `spec` short-circuits before registry/children so ignored props
   // do not become reactive dependencies of the assembled plot.
   function assembleCurrentSpec(): PortableSpec | null {
-    const spec = inputs.spec();
+    const spec = host.props.spec;
     if (spec !== undefined) return assemblePortableSpec({ spec, layers: [] });
-    const data = inputs.data();
-    const mapping = inputs.mapping();
-    const layers = inputs.layers();
-    const a11y = inputs.a11y();
+    const data = host.props.data;
+    const mapping = host.props.aes;
+    const layers = host.props.layers;
+    const a11y = host.props.a11y;
     return assemblePortableSpec({
       ...(data !== undefined && { data }),
       ...(mapping !== undefined && { aes: mapping }),
       // Mark layers only: a `layers={[…]}` prop suppresses registry marks, not
       // non-mark plot layers (theme/scale/coord/facet/labs/guides/legend).
-      layers: layers ?? inputs.registry.markLayers.map(toLayerInput),
-      plotLayers: inputs.registry.layers.filter((layer) => layer.kind !== "mark"),
+      layers: layers ?? host.registry.markLayers.map(toLayerInput),
+      plotLayers: host.registry.layers.filter((layer) => layer.kind !== "mark"),
       ...(a11y !== undefined && { a11y }),
     });
   }
@@ -238,21 +197,21 @@ export function createPlotEngine<
   // OR assembled.facet (portable-spec embeds). Grammar props removed in 0.13.0 (#704).
   const facetedPlot = $derived(
     isFacetedPlotIntent({
-      plotLayers: inputs.registry.layers,
+      plotLayers: host.registry.layers,
       assembled: assembled(),
     }),
   );
 
   const resolvedInteractionScope: PlotInteractionScope = $derived(
     (() => {
-      const interaction = inputs.interaction();
-      const interactionScope = inputs.interactionScope();
-      const zoom = inputs.zoom();
-      const datumKey = inputs.datumKey();
+      const interaction = host.props.interaction;
+      const interactionScope = host.props.interactionScope;
+      const capabilities = caps();
+      const datumKey = host.props.key;
       return resolveInteractionScope({
         interaction,
         ...(interactionScope !== undefined && { interactionScope }),
-        zoom,
+        zoom: capabilities.zoom,
         faceted: facetedPlot,
         ...(datumKey !== undefined && { datumKey }),
         assembled: assembled(),
@@ -262,25 +221,26 @@ export function createPlotEngine<
 
   const interactionConfig = $derived(
     (() => {
-      const tool = inputs.tool();
+      const tool = host.props.tool;
+      const capabilities = caps();
       return normalizeInteractionConfig(
         {
-          inspect: inputs.inspect(),
-          select: inputs.select(),
-          zoom: inputs.zoom(),
-          legendFocus: inputs.legendFocus(),
+          inspect: capabilities.inspect,
+          select: capabilities.select,
+          zoom: capabilities.zoom,
+          legendFocus: capabilities.legendFocus,
           ...(tool !== undefined && { tool }),
         },
         {
           faceted: facetedPlot,
-          hasKey: inputs.datumKey() !== undefined,
+          hasKey: host.props.key !== undefined,
         },
       );
     })(),
   );
 
   function deliverDiagnostic(diagnostic: PlotDiagnostic): void {
-    const ondiagnostic = inputs.ondiagnostic();
+    const ondiagnostic = host.props.ondiagnostic;
     ondiagnostic?.(diagnostic);
     const nodeEnvironment = (globalThis as { process?: { env?: { NODE_ENV?: string } } }).process
       ?.env?.NODE_ENV;
@@ -297,26 +257,27 @@ export function createPlotEngine<
   // fire once per prop per plot instance — a later capability toggle must
   // not re-advise. Pure collect lives in wiring-advisories.ts; snapshot is
   // taken inside this derived so late-bound handlers still recompute.
-  const wiringDiagnostics = $derived.by((): InteractionDiagnostic[] =>
-    collectWiringDiagnostics({
-      interactionScope: inputs.interactionScope(),
-      interaction: inputs.interaction(),
+  const wiringDiagnostics = $derived.by((): InteractionDiagnostic[] => {
+    const capabilities = caps();
+    return collectWiringDiagnostics({
+      interactionScope: host.props.interactionScope,
+      interaction: host.props.interaction,
       handlers: {
-        oninspect: inputs.oninspect(),
-        onselect: inputs.onselect(),
-        onzoom: inputs.onzoom(),
-        onlegendfocus: inputs.onlegendfocus(),
-        onlegendfilter: inputs.onlegendfilter(),
+        oninspect: host.props.oninspect,
+        onselect: host.props.onselect,
+        onzoom: host.props.onzoom,
+        onlegendfocus: host.props.onlegendfocus,
+        onlegendfilter: host.props.onlegendfilter,
       },
       capabilities: {
-        inspect: inputs.inspect(),
-        select: inputs.select(),
-        zoom: inputs.zoom(),
-        legendFocus: inputs.legendFocus(),
-        legendFilter: inputs.legendFilter(),
+        inspect: capabilities.inspect,
+        select: capabilities.select,
+        zoom: capabilities.zoom,
+        legendFocus: capabilities.legendFocus,
+        legendFilter: capabilities.legendFilter,
       },
-    }),
-  );
+    });
+  });
   // Shared once-per-code-per-prop Set for wiring + composition.
   // Delivery order is fixed: config effect (above) → wiring → composition.
   // Grammar-prop deprecation emission removed in 0.13.0 (#704) — props gone.
@@ -334,7 +295,7 @@ export function createPlotEngine<
   // registry.layers. Last child still wins (shallow merge / last write);
   // delivery is once-per-dedup-key via compositionAdvisoryDedupKey.
   const compositionDiagnostics = $derived.by((): CompositionDiagnostic[] =>
-    collectCompositionDiagnostics(inputs.registry.layers),
+    collectCompositionDiagnostics(host.registry.layers),
   );
   $effect(() => {
     for (const diagnostic of compositionDiagnostics) {
@@ -345,10 +306,8 @@ export function createPlotEngine<
     }
   });
 
-  // The PublicKey → PropertyKey widening casts live at the GGPlot call site;
-  // PlotEngineInputs is already declared in the widened form, so controller
-  // deps consume inputs.interaction / inputs.oninteraction / inputs.oninspect
-  // directly (handler contravariance covers the narrower per-event deps).
+  // PublicKey → PropertyKey widening lives in widenPlotProps (plot-props.ts).
+  // Controllers read host.props handlers directly (already widened).
   // Announcer is declared later; the sink is handler-only (never construction).
   const announceSink = (message: string): void => {
     announcer.announce(message);
@@ -362,14 +321,14 @@ export function createPlotEngine<
   // Construction-time deriveds read interaction/scope/zoomConfig/assembled
   // only — model/announce are deferred getters (later-declared).
   const zoomState = createPlotZoomState({
-    interaction: inputs.interaction,
+    interaction: () => host.props.interaction,
     resolvedInteractionScope: () => resolvedInteractionScope,
     zoomConfig: () => interactionConfig.zoom,
     assembled,
     // Model is declared after the runtime; handlers only.
     model: () => runtime.model,
-    onzoom: () => inputs.onzoom(),
-    oninteraction: inputs.oninteraction,
+    onzoom: () => host.props.onzoom,
+    oninteraction: () => host.props.oninteraction,
     announce: announceSink,
   });
 
@@ -383,11 +342,11 @@ export function createPlotEngine<
   const dataIdentityEpoch = $derived.by(() =>
     dataIdentityEpochToken(
       buildDataIdentityEpochInput({
-        data: inputs.data(),
-        spec: inputs.spec(),
-        layers: inputs.layers(),
+        data: host.props.data,
+        spec: host.props.spec,
+        layers: host.props.layers,
         // Declaration children: markLayers only (not registry.layers) — #609.
-        registryMarkLayers: inputs.registry.markLayers,
+        registryMarkLayers: host.registry.markLayers,
         sourceIdentity: (value: unknown) => identityTracker.sourceIdentity(value),
       }),
     ),
@@ -401,9 +360,9 @@ export function createPlotEngine<
   // model is deferred (declared after the runtime).
   const legendFilterState = createLegendFilterState({
     effectiveSpec: () => zoomState.effectiveSpec,
-    legendFilterProp: () => inputs.legendFilter(),
-    onlegendfilter: () => inputs.onlegendfilter(),
-    oninteraction: inputs.oninteraction,
+    legendFilterProp: () => caps().legendFilter,
+    onlegendfilter: () => host.props.onlegendfilter,
+    oninteraction: () => host.props.oninteraction,
     announce: announceSink,
     // model / catalogEntries close over later bindings (effect-only; not
     // construction-time reads).
@@ -415,17 +374,17 @@ export function createPlotEngine<
   // Factory sits after zoom-respec and legend-filter so every direct
   // construction-time dep is already initialized (TDZ).
   const runtime = createPlotRuntime({
-    widthProp: () => inputs.width(),
-    heightProp: () => inputs.height(),
+    widthProp: () => host.props.width,
+    heightProp: () => host.props.height,
     assembled,
     effectiveSpec: () => zoomState.effectiveSpec,
     effectiveZoomDomains: () => zoomState.effectiveZoomDomains,
     effectiveLegendFilters: () => legendFilterState.filters,
-    root: inputs.root,
+    root: host.root,
     resetZoom: () => {
       zoomState.resetForScales();
     },
-    onrender: () => inputs.onrender(),
+    onrender: () => host.props.onrender,
   });
   // Semantic resolution as soon as the runtime model exists. Early
   // construction makes interval projection safe when a shared controller
@@ -433,9 +392,9 @@ export function createPlotEngine<
   const semanticKeys = createSemanticKeyService({
     model: () => runtime.model,
     assembled,
-    datumKey: () => inputs.datumKey(),
-    data: () => inputs.data(),
-    spec: () => inputs.spec(),
+    datumKey: () => host.props.key,
+    data: () => host.props.data,
+    spec: () => host.props.spec,
     sourceIdentity: (value: unknown) => identityTracker.sourceIdentity(value),
     deliverDiagnostic,
   });
@@ -468,11 +427,11 @@ export function createPlotEngine<
   // ------------------------------------------------- selection
   // Before surface so emit/toggle are direct (not deferred sibling getters).
   const selectionState = createSelectionState({
-    interaction: inputs.interaction,
+    interaction: () => host.props.interaction,
     resolvedInteractionScope: () => resolvedInteractionScope,
     selectConfig: () => interactionConfig.select,
-    onselect: inputs.onselect,
-    oninteraction: inputs.oninteraction,
+    onselect: () => host.props.onselect,
+    oninteraction: () => host.props.oninteraction,
     announce: announceSink,
   });
 
@@ -488,15 +447,15 @@ export function createPlotEngine<
     inspectEnabled: () => inspectEnabled,
     dataIdentityEpoch: () => dataIdentityEpoch,
     keyAt: (index) => semanticKeys.keyAt(index),
-    root: inputs.root,
-    captureSurface: inputs.captureSurface,
-    plotId: () => inputs.plotId,
+    root: host.root,
+    captureSurface: host.captureSurface,
+    plotId: () => host.plotId,
     tooltipHovered: () => tooltipHovered,
     clearTooltipHovered: () => {
       tooltipHovered = false;
     },
-    oninspect: inputs.oninspect,
-    oninteraction: inputs.oninteraction,
+    oninspect: () => host.props.oninspect,
+    oninteraction: () => host.props.oninteraction,
     announce: announceSink,
     clearAnnouncement: () => {
       announcer.clear();
@@ -509,14 +468,14 @@ export function createPlotEngine<
   let semanticCandidateProjection!: ReturnType<typeof createSemanticCandidateProjection>;
   const intervalState = createIntervalState({
     model: () => runtime.model,
-    interaction: inputs.interaction,
+    interaction: () => host.props.interaction,
     resolvedInteractionScope: () => resolvedInteractionScope,
     selectConfig: () => interactionConfig.select,
     effectiveZoomDomains: () => zoomState.effectiveZoomDomains,
     commitZoom: (...args: Parameters<PlotZoomState["commitZoom"]>) => {
       zoomState.commitZoom(...args);
     },
-    captureSurface: inputs.captureSurface,
+    captureSurface: host.captureSurface,
     candidateSemanticKeys: (candidate) => candidateSemanticKeys(candidate),
     consumptionCandidates: () => semanticCandidateProjection.intervalConsumptionCandidates,
     inspectionPanel: () => inspectionState.inspectionPanel,
@@ -532,14 +491,14 @@ export function createPlotEngine<
   let chromeState!: ReturnType<typeof createPlotChromeState>;
   surfaceState = createSurfaceState({
     model: () => runtime.model,
-    root: inputs.root,
-    toolProp: () => inputs.tool(),
+    root: host.root,
+    toolProp: () => host.props.tool,
     initialTool: () => interactionConfig.initialTool,
     availableTools: () => chromeState.availableTools,
     inspectConfig: () => interactionConfig.inspect,
     selectConfig: () => interactionConfig.select,
     pointSelectEnabled: () => chromeState.canPublishPointSelection,
-    ontoolchange: () => inputs.ontoolchange(),
+    ontoolchange: () => host.props.ontoolchange,
     surfaceInteractive: () => surfaceInteractive,
     candidateSemanticKeys: (candidate) => candidateSemanticKeys(candidate),
     inspection: () => inspectionState,
@@ -561,16 +520,16 @@ export function createPlotEngine<
   // them install via installHostDerivedEffects (irreducible late data, not a
   // sibling-controller cycle — #627).
   const legendFocusState = createLegendFocusState({
-    interaction: inputs.interaction,
+    interaction: () => host.props.interaction,
     resolvedInteractionScope: () => resolvedInteractionScope,
     legendFocusEnabled: () => legendFocusEnabled,
     legendFocusPreviewEnabled: () => interactionConfig.legendFocus?.preview === true,
-    root: inputs.root,
+    root: host.root,
     entryKeys: () => legendEntryKeys,
     entries: () => interactiveLegendEntries,
     pressed: () => effectiveLegendPressed,
-    onlegendfocus: inputs.onlegendfocus,
-    oninteraction: inputs.oninteraction,
+    onlegendfocus: () => host.props.onlegendfocus,
+    oninteraction: () => host.props.oninteraction,
     announce: announceSink,
   });
   semanticCandidateProjection = createSemanticCandidateProjection({
@@ -602,7 +561,7 @@ export function createPlotEngine<
     },
   });
   // ------------------------------------------------- plot chrome
-  // All inputs earlier-declared. Pure construction-time deriveds —
+  // All host bindings earlier-declared. Pure construction-time deriveds —
   // no $state/handlers/effects.
   chromeState = createPlotChromeState({
     model: () => runtime.model,
@@ -617,7 +576,7 @@ export function createPlotEngine<
     effectiveEmphasisKeys: () => legendFocusState.effectiveEmphasisKeys,
     legendFocusEnabled: () => legendFocusEnabled,
     hasCanvas: () => runtime.hasCanvas,
-    width: () => inputs.width(),
+    width: () => host.props.width,
     resolvedWidth: () => runtime.resolvedWidth,
     resolvedHeight: () => runtime.resolvedHeight,
   });

--- a/packages/svelte/src/lib/plot-engine.svelte.ts
+++ b/packages/svelte/src/lib/plot-engine.svelte.ts
@@ -222,13 +222,14 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
   const interactionConfig = $derived(
     (() => {
       const tool = host.props.tool;
-      const capabilities = caps();
+      // Four fields only — legendFilter is not part of normalizeInteractionConfig.
+      // Reading it via caps() re-delivered config diagnostics on every filter toggle.
       return normalizeInteractionConfig(
         {
-          inspect: capabilities.inspect,
-          select: capabilities.select,
-          zoom: capabilities.zoom,
-          legendFocus: capabilities.legendFocus,
+          inspect: host.props.inspect ?? false,
+          select: host.props.select ?? false,
+          zoom: host.props.zoom ?? false,
+          legendFocus: host.props.legendFocus ?? false,
           ...(tool !== undefined && { tool }),
         },
         {

--- a/packages/svelte/src/lib/plot-engine.svelte.ts
+++ b/packages/svelte/src/lib/plot-engine.svelte.ts
@@ -206,12 +206,12 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
     (() => {
       const interaction = host.props.interaction;
       const interactionScope = host.props.interactionScope;
-      const capabilities = caps();
       const datumKey = host.props.key;
       return resolveInteractionScope({
         interaction,
         ...(interactionScope !== undefined && { interactionScope }),
-        zoom: capabilities.zoom,
+        // Single-field default — do not call caps() (would subscribe all five).
+        zoom: host.props.zoom ?? false,
         faceted: facetedPlot,
         ...(datumKey !== undefined && { datumKey }),
         assembled: assembled(),
@@ -360,7 +360,8 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
   // model is deferred (declared after the runtime).
   const legendFilterState = createLegendFilterState({
     effectiveSpec: () => zoomState.effectiveSpec,
-    legendFilterProp: () => caps().legendFilter,
+    // Single-field default — avoid caps() so this derived only tracks legendFilter.
+    legendFilterProp: () => host.props.legendFilter ?? false,
     onlegendfilter: () => host.props.onlegendfilter,
     oninteraction: () => host.props.oninteraction,
     announce: announceSink,

--- a/packages/svelte/src/lib/plot-props.ts
+++ b/packages/svelte/src/lib/plot-props.ts
@@ -1,6 +1,10 @@
 /**
- * Internal props type for <GGPlot>. Not part of the public package surface —
- * the component never exported this type before S11; keep it module-local.
+ * Internal props contract for <GGPlot> + the plot engine (#1040).
+ * Not part of the public package surface — never export from the package root.
+ *
+ * Runtime helpers here own:
+ * - capability defaults (`resolveCapabilities`)
+ * - PublicKey → PropertyKey widening for engine controllers (`widenPlotProps`)
  */
 import type { Snippet } from "svelte";
 
@@ -95,4 +99,97 @@ export interface GGPlotProps<
    *  advisories, scales) and the normalized PortableSpec. */
   onrender?: (model: RenderModel, spec: PortableSpec) => void;
   children?: Snippet;
+}
+
+/** Capability defaults after optional props resolve (engine-facing). */
+export type ResolvedPlotCapabilities = {
+  inspect: InspectInput;
+  select: SelectInput;
+  zoom: ZoomInput;
+  legendFocus: LegendFocusInput;
+  legendFilter: LegendFilterInput;
+};
+
+/**
+ * Defaults the five interaction capability props to `false` when omitted.
+ * Pure — does not clone object-form configs (identity preserved for epoch
+ * and reference-equality consumers).
+ */
+export function resolveCapabilities(
+  props: Pick<GGPlotProps, "inspect" | "select" | "zoom" | "legendFocus" | "legendFilter">,
+): ResolvedPlotCapabilities {
+  return {
+    inspect: props.inspect ?? false,
+    select: props.select ?? false,
+    zoom: props.zoom ?? false,
+    legendFocus: props.legendFocus ?? false,
+    legendFilter: props.legendFilter ?? false,
+  };
+}
+
+/**
+ * Engine-facing props: same surface as `GGPlotProps` with the six
+ * PublicKey-generic fields widened to PropertyKey (controller deps).
+ * Derived via `Omit` — not a hand-restated 30-field mirror (#1040).
+ */
+export type EnginePlotProps = Omit<
+  GGPlotProps,
+  "key" | "interaction" | "oninspect" | "onselect" | "onlegendfocus" | "oninteraction"
+> & {
+  key?: PropertyKey | ((row: Record<string, CellValue>, index: number) => PropertyKey);
+  interaction?: PlotInteractionController<PropertyKey>;
+  oninspect?: (event: PlotInspection<Record<string, CellValue>>) => void;
+  onselect?: (event: PlotSelection) => void;
+  onlegendfocus?: (event: LegendFocusEvent) => void;
+  oninteraction?: (event: PlotInteractionEvent<Record<string, CellValue>>) => void;
+};
+
+const WIDENED_KEYS = new Set([
+  "key",
+  "interaction",
+  "oninspect",
+  "onselect",
+  "onlegendfocus",
+  "oninteraction",
+] as const);
+
+type WidenedKey =
+  | "key"
+  | "interaction"
+  | "oninspect"
+  | "onselect"
+  | "onlegendfocus"
+  | "oninteraction";
+
+/**
+ * Stable lazy view of plot props for the engine. Non-widened fields forward
+ * through the source proxy (per-field reactive deps). The six PublicKey
+ * fields cast once here instead of at the GGPlot call site.
+ */
+export function widenPlotProps<
+  Row extends Record<string, CellValue>,
+  Identity extends keyof Row | ((row: Row, index: number) => PropertyKey),
+>(props: GGPlotProps<Row, Identity>): EnginePlotProps {
+  return new Proxy(props as object, {
+    get(target, prop, receiver) {
+      if (typeof prop === "string" && WIDENED_KEYS.has(prop as WidenedKey)) {
+        // Six precise casts — checked return type is EnginePlotProps.
+        switch (prop as WidenedKey) {
+          case "key":
+            return props.key as EnginePlotProps["key"];
+          case "interaction":
+            return props.interaction as EnginePlotProps["interaction"];
+          case "oninspect":
+            return props.oninspect as EnginePlotProps["oninspect"];
+          case "onselect":
+            return props.onselect as EnginePlotProps["onselect"];
+          case "onlegendfocus":
+            return props.onlegendfocus as EnginePlotProps["onlegendfocus"];
+          case "oninteraction":
+            return props.oninteraction as EnginePlotProps["oninteraction"];
+        }
+      }
+      return Reflect.get(target, prop, receiver);
+    },
+  }) as EnginePlotProps;
 }

--- a/packages/svelte/src/lib/plot-props.ts
+++ b/packages/svelte/src/lib/plot-props.ts
@@ -144,23 +144,6 @@ export type EnginePlotProps = Omit<
   oninteraction?: (event: PlotInteractionEvent<Record<string, CellValue>>) => void;
 };
 
-const WIDENED_KEYS = new Set([
-  "key",
-  "interaction",
-  "oninspect",
-  "onselect",
-  "onlegendfocus",
-  "oninteraction",
-] as const);
-
-type WidenedKey =
-  | "key"
-  | "interaction"
-  | "oninspect"
-  | "onselect"
-  | "onlegendfocus"
-  | "oninteraction";
-
 /**
  * Stable lazy view of plot props for the engine. Non-widened fields forward
  * through the source proxy (per-field reactive deps). The six PublicKey
@@ -170,26 +153,28 @@ export function widenPlotProps<
   Row extends Record<string, CellValue>,
   Identity extends keyof Row | ((row: Row, index: number) => PropertyKey),
 >(props: GGPlotProps<Row, Identity>): EnginePlotProps {
-  return new Proxy(props as object, {
+  const handler: ProxyHandler<GGPlotProps<Row, Identity>> = {
     get(target, prop, receiver) {
-      if (typeof prop === "string" && WIDENED_KEYS.has(prop as WidenedKey)) {
-        // Six precise casts — checked return type is EnginePlotProps.
-        switch (prop as WidenedKey) {
-          case "key":
-            return props.key as EnginePlotProps["key"];
-          case "interaction":
-            return props.interaction as EnginePlotProps["interaction"];
-          case "oninspect":
-            return props.oninspect as EnginePlotProps["oninspect"];
-          case "onselect":
-            return props.onselect as EnginePlotProps["onselect"];
-          case "onlegendfocus":
-            return props.onlegendfocus as EnginePlotProps["onlegendfocus"];
-          case "oninteraction":
-            return props.oninteraction as EnginePlotProps["oninteraction"];
-        }
+      // Six precise casts — only these fields change assignability.
+      if (prop === "key") return target.key as EnginePlotProps["key"];
+      if (prop === "interaction") {
+        return target.interaction as EnginePlotProps["interaction"];
       }
-      return Reflect.get(target, prop, receiver);
+      if (prop === "oninspect") {
+        return target.oninspect as EnginePlotProps["oninspect"];
+      }
+      if (prop === "onselect") {
+        return target.onselect as EnginePlotProps["onselect"];
+      }
+      if (prop === "onlegendfocus") {
+        return target.onlegendfocus as EnginePlotProps["onlegendfocus"];
+      }
+      if (prop === "oninteraction") {
+        return target.oninteraction as EnginePlotProps["oninteraction"];
+      }
+      return Reflect.get(target, prop, receiver) as EnginePlotProps[keyof EnginePlotProps];
     },
-  }) as EnginePlotProps;
+  };
+  // Proxy of GGPlotProps is the EnginePlotProps view; bridge via unknown once.
+  return new Proxy(props, handler) as unknown as EnginePlotProps;
 }

--- a/packages/svelte/tests/layers/grammar-prop-removal.ssr.test.ts
+++ b/packages/svelte/tests/layers/grammar-prop-removal.ssr.test.ts
@@ -2,7 +2,7 @@
  * #704: single removal clock for the seven grammar props deprecated in 0.11.0.
  * After 0.13.0 they are gone from GGPlot types, runtime wiring, and exports.
  *
- * Seams: plot-props source, PlotEngineInputs, LayerDescriptor public export.
+ * Seams: plot-props source, engine host (no PlotEngineInputs mirror), LayerDescriptor.
  */
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
@@ -20,18 +20,10 @@ describe("#704 grammar prop removal", () => {
     }
   });
 
-  it("PlotEngineInputs no longer reads the seven deprecated grammar props", () => {
+  it("PlotEngineInputs is deleted — single prop surface is GGPlotProps/EnginePlotProps (#1040)", () => {
     const source = readFileSync(join(root, "plot-engine.svelte.ts"), "utf8");
-    // The Inputs type block ends before createPlotEngine; props must not appear as thunk fields.
-    const inputsBlock = source.slice(
-      source.indexOf("export type PlotEngineInputs"),
-      source.indexOf("export type PlotEngine"),
-    );
-    for (const prop of GRAMMAR_PROP_NAMES) {
-      expect(inputsBlock, `${prop} still on PlotEngineInputs`).not.toMatch(
-        new RegExp(`\\b${prop}:`),
-      );
-    }
+    expect(source).not.toContain("PlotEngineInputs");
+    expect(source).toContain("PlotEngineHost");
   });
 
   it("engine no longer emits DEPRECATED_PLOT_PROP for grammar props", () => {

--- a/packages/svelte/tests/plot-engine.lifecycle.test.ts
+++ b/packages/svelte/tests/plot-engine.lifecycle.test.ts
@@ -1,16 +1,17 @@
 /**
  * Behaviour coverage for the plot engine factory: assemble → model →
  * interaction config across a chart lifecycle. Guards the #982 merge of
- * orchestrator + interaction assembly (no layout/substring tests).
+ * orchestrator + interaction assembly and the #1040 host.props surface
+ * (no layout/substring tests).
  */
 import { flushSync } from "svelte";
 import { describe, expect, it } from "vitest";
 
 import type { RenderModel } from "@ggsvelte/core";
-import type { PortableSpec } from "@ggsvelte/spec";
 
 import { LayerRegistry } from "../src/lib/geoms/registry.svelte.js";
 import { createPlotEngine } from "../src/lib/plot-engine.svelte.js";
+import type { EnginePlotProps } from "../src/lib/plot-props.js";
 import { withEffectRoot, withFlushedEffectRoot } from "./helpers/effect-root.svelte.js";
 import { reactiveBox } from "./helpers/reactive-box.svelte.js";
 
@@ -21,56 +22,29 @@ const rows = [
   { x: 4, y: 25, cls: "b" },
 ];
 
-function engineInputs(opts: {
-  registry?: LayerRegistry;
-  data?: () => readonly (typeof rows)[number][] | undefined;
-  mapping?: () => { x: string; y: string; color?: string } | undefined;
-  layers?: () => { geom: "point" }[] | undefined;
-  width?: () => number | undefined;
-  height?: () => number | undefined;
-  inspect?: () => boolean;
-  select?: () => boolean;
-  zoom?: () => boolean;
-  onrender?: () => ((model: RenderModel, spec: PortableSpec) => void) | undefined;
-}) {
-  const noop = () => {};
+/** Minimal host: registry + plot id + DOM thunks + lazy props bag (#1040). */
+function engineHost(opts: { registry?: LayerRegistry; props?: EnginePlotProps }) {
   return {
     registry: opts.registry ?? new LayerRegistry(),
     plotId: "plot-engine-lifecycle",
     root: () => null as HTMLDivElement | null,
     captureSurface: () => null as HTMLDivElement | null,
-    spec: () => {},
-    data: opts.data ?? (() => rows),
-    mapping: opts.mapping ?? (() => ({ x: "x", y: "y" })),
-    layers: opts.layers ?? (() => [{ geom: "point" as const }]),
-    a11y: noop,
-    width: opts.width ?? (() => 480),
-    height: opts.height ?? (() => 320),
-    datumKey: noop,
-    inspect: opts.inspect ?? (() => false),
-    select: opts.select ?? (() => false),
-    zoom: opts.zoom ?? (() => false),
-    legendFocus: () => false,
-    legendFilter: () => false,
-    tool: noop,
-    interaction: noop,
-    interactionScope: noop,
-    oninspect: noop,
-    onselect: noop,
-    onzoom: noop,
-    onlegendfocus: noop,
-    onlegendfilter: noop,
-    oninteraction: noop,
-    ondiagnostic: noop,
-    ontoolchange: noop,
-    onrender: opts.onrender ?? noop,
+    props:
+      opts.props ??
+      ({
+        data: rows,
+        aes: { x: "x", y: "y" },
+        layers: [{ geom: "point" as const }],
+        width: 480,
+        height: 320,
+      } satisfies EnginePlotProps),
   };
 }
 
 describe("createPlotEngine chart lifecycle", () => {
   it("assembles a portable spec and produces a render model from data/layers", () => {
     const { value: engine, destroy } = withFlushedEffectRoot(() =>
-      createPlotEngine(engineInputs({})),
+      createPlotEngine(engineHost({})),
     );
 
     expect(engine.assembled).not.toBeNull();
@@ -100,10 +74,18 @@ describe("createPlotEngine chart lifecycle", () => {
     const models: RenderModel[] = [];
     const { value: engine, destroy } = withFlushedEffectRoot(() =>
       createPlotEngine(
-        engineInputs({
-          data: () => data.value,
-          onrender: () => (model) => {
-            models.push(model);
+        engineHost({
+          props: {
+            get data() {
+              return data.value;
+            },
+            aes: { x: "x", y: "y" },
+            layers: [{ geom: "point" }],
+            width: 480,
+            height: 320,
+            onrender: (model: RenderModel) => {
+              models.push(model);
+            },
           },
         }),
       ),
@@ -133,10 +115,23 @@ describe("createPlotEngine chart lifecycle", () => {
     const zoom = reactiveBox(false);
     const { value: engine, destroy } = withFlushedEffectRoot(() =>
       createPlotEngine(
-        engineInputs({
-          inspect: () => inspect.value,
-          select: () => select.value,
-          zoom: () => zoom.value,
+        engineHost({
+          props: {
+            data: rows,
+            aes: { x: "x", y: "y" },
+            layers: [{ geom: "point" }],
+            width: 480,
+            height: 320,
+            get inspect() {
+              return inspect.value;
+            },
+            get select() {
+              return select.value;
+            },
+            get zoom() {
+              return zoom.value;
+            },
+          },
         }),
       ),
     );
@@ -163,10 +158,52 @@ describe("createPlotEngine chart lifecycle", () => {
 
   it("registers effects only under an effect root (no orphan effects at construct)", () => {
     // Construction must not throw effect_orphan; effects own via $effect.root.
-    const { value: engine, destroy } = withEffectRoot(() => createPlotEngine(engineInputs({})));
+    const { value: engine, destroy } = withEffectRoot(() => createPlotEngine(engineHost({})));
     expect(engine.assembled).not.toBeNull();
     // Before flush, model production may not have committed yet — factory must still exist.
     expect(engine.runtime).toBeDefined();
+    destroy();
+  });
+
+  it("spec short-circuit: data changes do not re-assemble when spec is set", () => {
+    // Pins the #1040 lazy-props invariant: assembleCurrentSpec must not
+    // depend on data/aes/layers when an explicit spec is present.
+    const data = reactiveBox(rows);
+    const { value: engine, destroy } = withFlushedEffectRoot(() =>
+      createPlotEngine(
+        engineHost({
+          props: {
+            get data() {
+              return data.value;
+            },
+            aes: { x: "x", y: "y" },
+            layers: [{ geom: "point" }],
+            spec: {
+              data: { values: rows },
+              aes: { x: "x", y: "y" },
+              layers: [{ geom: "point" }],
+            },
+            width: 480,
+            height: 320,
+          },
+        }),
+      ),
+    );
+
+    const firstAssembled = engine.assembled;
+    expect(firstAssembled).not.toBeNull();
+    expect(engine.runtime.model).not.toBeNull();
+    expect(engine.runtime.model!.candidates.size).toBe(4);
+
+    data.set(rows.slice(0, 1));
+    flushSync();
+
+    // Same assembled identity: data was never a dependency under the spec path.
+    expect(engine.assembled).toBe(firstAssembled);
+    // Spec path still renders from the embedded values, not the data prop.
+    expect(engine.runtime.model).not.toBeNull();
+    expect(engine.runtime.model!.candidates.size).toBe(4);
+
     destroy();
   });
 });

--- a/packages/svelte/tests/plot-props-resolve.ssr.test.ts
+++ b/packages/svelte/tests/plot-props-resolve.ssr.test.ts
@@ -1,0 +1,59 @@
+/**
+ * #1040: capability defaults own one pure owner (`resolveCapabilities`).
+ * Seam: plot-props resolve helpers — no runes, no engine.
+ */
+import { describe, expect, it } from "vitest";
+
+import { resolveCapabilities } from "../src/lib/plot-props.js";
+
+describe("resolveCapabilities", () => {
+  it("defaults the five capability props to false when omitted", () => {
+    expect(resolveCapabilities({})).toEqual({
+      inspect: false,
+      select: false,
+      zoom: false,
+      legendFocus: false,
+      legendFilter: false,
+    });
+  });
+
+  it("passes through explicit false and true", () => {
+    expect(
+      resolveCapabilities({
+        inspect: false,
+        select: true,
+        zoom: false,
+        legendFocus: true,
+        legendFilter: false,
+      }),
+    ).toEqual({
+      inspect: false,
+      select: true,
+      zoom: false,
+      legendFocus: true,
+      legendFilter: false,
+    });
+  });
+
+  it("passes through object-form capability configs without cloning", () => {
+    const inspect = { muteSiblings: true as const };
+    const select = "point" as const;
+    const zoom = true as const;
+    const legendFocus = { preview: true as const };
+    const legendFilter = true as const;
+
+    const resolved = resolveCapabilities({
+      inspect,
+      select,
+      zoom,
+      legendFocus,
+      legendFilter,
+    });
+
+    expect(resolved.inspect).toBe(inspect);
+    expect(resolved.select).toBe(select);
+    expect(resolved.zoom).toBe(zoom);
+    expect(resolved.legendFocus).toBe(legendFocus);
+    expect(resolved.legendFilter).toBe(legendFilter);
+  });
+});


### PR DESCRIPTION
## Summary

- Delete `PlotEngineInputs` and the GGPlot 30-entry getter-thunk bag so adding a plot prop is a one-file edit (`plot-props.ts`).
- Engine host is `{ registry, plotId, root, captureSurface, props }`; props stay lazy so per-field reactive deps (including the `spec` short-circuit) still hold.
- Capability defaults own one pure helper (`resolveCapabilities`); six PublicKey→PropertyKey casts collapse into `widenPlotProps` (typed via `Omit`, not a whole-object erase).

Closes #1040.

## Claude pre-implementation review

Consult mode approved with changes. Applied blockers:
- No eagerly materialised props snapshot (lazy proxy / field getters only)
- No post-`$props` destructure for markup (use `props.width` etc.)
- Six precise casts in one checked function, not one blind cast
- `resolveCapabilities` for the five defaults only (not a 30-field restate)
- Added lifecycle test for the `spec` short-circuit invariant

## Test plan

- [x] `packages/svelte` ssr: plot-props-resolve, grammar-prop-removal, layers/*
- [x] `packages/svelte` browser: plot-engine.lifecycle, component, quickstart (chromium/webkit/firefox)
- [x] `bun run check` in packages/svelte
- [x] oxlint on changed files
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1046" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->