### PR TITLE
fix(core): type diagnostic codes at emit sites (#1043)

### DIFF
--- a/.changeset/1043-typed-diagnostic-codes.md
+++ b/.changeset/1043-typed-diagnostic-codes.md
@@ -1,0 +1,11 @@
+---
+"@ggsvelte/core": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+fix(core): type diagnostic codes at emit sites
+
+PipelineWarning, Advisory, PipelineError, ScaleConfigError, and
+ScaleDiagnostic code fields are catalog unions. Wrong codes fail at
+compile time; the regex source scanner is retired (#1043).

--- a/apps/docs/src/lib/generated/routes.ts
+++ b/apps/docs/src/lib/generated/routes.ts
@@ -1907,6 +1907,11 @@ export const DOCS_ROUTES = [
         level: 3,
       },
       {
+        id: "stat-channel-unsupported-warning",
+        title: "stat-channel-unsupported — warning",
+        level: 3,
+      },
+      {
         id: "palette-exhausted-warning",
         title: "palette-exhausted — warning",
         level: 3,
@@ -2296,8 +2301,8 @@ export const DOCS_ROUTES = [
         level: 2,
       },
       {
-        id: "experimental-289",
-        title: "experimental (289)",
+        id: "experimental-290",
+        title: "experimental (290)",
         level: 3,
       },
       {

--- a/apps/docs/src/lib/generated/search-index.ts
+++ b/apps/docs/src/lib/generated/search-index.ts
@@ -3144,6 +3144,16 @@ export const DOCS_SEARCH_INDEX = [
     exact: ["ellipse-group-dropped"],
   },
   {
+    id: "heading:guide-errors:stat-channel-unsupported-warning",
+    kind: "heading",
+    title: "stat-channel-unsupported — warning",
+    summary:
+      "stat-channel-unsupported — warning in Errors reference. Understand validation, render, interaction, and CLI diagnostics and recover safely.",
+    href: "/guide/errors#stat-channel-unsupported-warning",
+    keywords: ["Errors reference", "Reference"],
+    exact: ["stat-channel-unsupported — warning"],
+  },
+  {
     id: "heading:guide-errors:palette-exhausted-warning",
     kind: "heading",
     title: "palette-exhausted — warning",
@@ -3872,14 +3882,14 @@ export const DOCS_SEARCH_INDEX = [
     exact: ["@ggsvelte/core"],
   },
   {
-    id: "heading:guide-lifecycle:experimental-289",
+    id: "heading:guide-lifecycle:experimental-290",
     kind: "heading",
-    title: "experimental (289)",
+    title: "experimental (290)",
     summary:
-      "experimental (289) in Lifecycle & editions. API stability tags per export, and the defaults-edition mechanism.",
-    href: "/guide/lifecycle#experimental-289",
+      "experimental (290) in Lifecycle & editions. API stability tags per export, and the defaults-edition mechanism.",
+    href: "/guide/lifecycle#experimental-290",
     keywords: ["Lifecycle & editions", "Reference"],
-    exact: ["experimental (289)"],
+    exact: ["experimental (290)"],
   },
   {
     id: "heading:guide-lifecycle:stable-intent-2",
@@ -13824,6 +13834,15 @@ export const DOCS_SEARCH_INDEX = [
     href: "/guide/lifecycle#ggsvelte-core",
     keywords: ["@ggsvelte/core", ".", "type", "experimental"],
     exact: ["DeclaredDiscreteness"],
+  },
+  {
+    id: "api:ggsvelte-core:DiagnosticCode",
+    kind: "api",
+    title: "DiagnosticCode",
+    summary: "@ggsvelte/core · type · experimental.",
+    href: "/guide/lifecycle#ggsvelte-core",
+    keywords: ["@ggsvelte/core", ".", "type", "experimental"],
+    exact: ["DiagnosticCode"],
   },
   {
     id: "api:ggsvelte-core:DiscreteGuideEntry",
@@ -24275,6 +24294,20 @@ export const DOCS_SEARCH_INDEX = [
       "Inspect the warning message for its path and count, then correct the named data, scale, or option.",
     ],
     exact: ["ellipse-group-dropped", "warning:ellipse-group-dropped"],
+  },
+  {
+    id: "diagnostic:warning:stat-channel-unsupported",
+    kind: "diagnostic",
+    title: "stat-channel-unsupported · warning",
+    summary:
+      "A color/fill after-stat mapping names an output the selected stat does not publish; the mapping is ignored (style channels throw the same code as an error).",
+    href: "/guide/errors#stat-channel-unsupported-warning",
+    keywords: [
+      "warning",
+      "warning",
+      "Inspect the warning message for its path and count, then correct the named data, scale, or option.",
+    ],
+    exact: ["stat-channel-unsupported", "warning:stat-channel-unsupported"],
   },
   {
     id: "diagnostic:warning:palette-exhausted",

--- a/lifecycle.json
+++ b/lifecycle.json
@@ -3671,6 +3671,10 @@
           "kind": "type",
           "lifecycle": "experimental"
         },
+        "DiagnosticCode": {
+          "kind": "type",
+          "lifecycle": "experimental"
+        },
         "DiscreteGuideEntry": {
           "kind": "type",
           "lifecycle": "experimental"

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -26,6 +26,7 @@
 import type { SpecInput } from "@ggsvelte/spec";
 import { lintSpec, SpecValidationError } from "@ggsvelte/spec";
 
+import type { CLIDiagnosticCode } from "./diagnostics.js";
 import type { NamedData } from "./pipeline.js";
 import { PipelineError, runPipeline } from "./pipeline.js";
 import { countMarks, sceneToSVGString } from "./render-svg.js";
@@ -178,19 +179,24 @@ function parseArgs(argv: readonly string[]): ParsedArgs {
   return out;
 }
 
-function errLine(io: CLIIO, payload: Record<string, unknown>): void {
+function errLine(io: CLIIO, payload: object): void {
   io.writeErr(JSON.stringify(payload));
+}
+
+/** CLI-catalogued error line — code is checked against CLI_DIAGNOSTIC_CATALOG. */
+function cliError(io: CLIIO, code: CLIDiagnosticCode, message: string): void {
+  errLine(io, { kind: "error", code, message });
 }
 
 function parseJSON(io: CLIIO, text: string, what: string): { value: unknown } | null {
   try {
     return { value: JSON.parse(text) as unknown };
   } catch (error) {
-    errLine(io, {
-      kind: "error",
-      code: "invalid-json",
-      message: `${what} is not valid JSON: ${error instanceof Error ? error.message : String(error)}`,
-    });
+    cliError(
+      io,
+      "invalid-json",
+      `${what} is not valid JSON: ${error instanceof Error ? error.message : String(error)}`,
+    );
     return null;
   }
 }
@@ -210,7 +216,7 @@ export async function runCLI(
   try {
     args = parseArgs(argv);
   } catch (error) {
-    errLine(io, { kind: "error", code: "usage", message: (error as Error).message });
+    cliError(io, "usage", (error as Error).message);
     io.writeErr(USAGE);
     return 2;
   }
@@ -223,13 +229,13 @@ export async function runCLI(
       args.dataPath !== null ||
       args.maxMarks !== null;
     if (hasOtherArguments || options.version === undefined) {
-      errLine(io, {
-        kind: "error",
-        code: "usage",
-        message: hasOtherArguments
+      cliError(
+        io,
+        "usage",
+        hasOtherArguments
           ? "--version must be used without a spec or other options"
           : "--version is unavailable from this programmatic runner",
-      });
+      );
       io.writeErr(USAGE);
       return 2;
     }
@@ -245,11 +251,11 @@ export async function runCLI(
   try {
     specText = args.specPath === null ? await io.readStdin() : io.readFile(args.specPath);
   } catch (error) {
-    errLine(io, {
-      kind: "error",
-      code: "unreadable-input",
-      message: `Cannot read ${args.specPath ?? "stdin"}: ${error instanceof Error ? error.message : String(error)}`,
-    });
+    cliError(
+      io,
+      "unreadable-input",
+      `Cannot read ${args.specPath ?? "stdin"}: ${error instanceof Error ? error.message : String(error)}`,
+    );
     return 2;
   }
   const parsedSpec = parseJSON(io, specText, args.specPath ?? "stdin");
@@ -262,22 +268,22 @@ export async function runCLI(
     try {
       dataText = io.readFile(args.dataPath);
     } catch (error) {
-      errLine(io, {
-        kind: "error",
-        code: "unreadable-input",
-        message: `Cannot read ${args.dataPath}: ${error instanceof Error ? error.message : String(error)}`,
-      });
+      cliError(
+        io,
+        "unreadable-input",
+        `Cannot read ${args.dataPath}: ${error instanceof Error ? error.message : String(error)}`,
+      );
       return 2;
     }
     const parsedData = parseJSON(io, dataText, args.dataPath);
     if (parsedData === null) return 2;
     const parsed = parsedData.value;
     if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
-      errLine(io, {
-        kind: "error",
-        code: "invalid-data-file",
-        message: "--data must be a JSON object mapping dataset names to inline data.",
-      });
+      cliError(
+        io,
+        "invalid-data-file",
+        "--data must be a JSON object mapping dataset names to inline data.",
+      );
       return 2;
     }
     data = parsed as Record<string, NamedData>;
@@ -314,11 +320,11 @@ export async function runCLI(
     const limit = args.maxMarks ?? 100_000;
     const marks = countMarks(model.scene);
     if (marks > limit) {
-      errLine(io, {
-        kind: "error",
-        code: "max-marks-exceeded",
-        message: `The plot renders ${marks} marks, more than --max-marks (${limit}).`,
-      });
+      cliError(
+        io,
+        "max-marks-exceeded",
+        `The plot renders ${marks} marks, more than --max-marks (${limit}).`,
+      );
       return 1;
     }
     io.writeOut(sceneToSVGString(model.scene) + "\n");
@@ -340,11 +346,7 @@ export async function runCLI(
       });
       return 1;
     }
-    errLine(io, {
-      kind: "error",
-      code: "internal",
-      message: error instanceof Error ? error.message : String(error),
-    });
+    cliError(io, "internal", error instanceof Error ? error.message : String(error));
     return 1;
   }
 }

--- a/packages/core/src/coord-projector.ts
+++ b/packages/core/src/coord-projector.ts
@@ -1,5 +1,6 @@
 import type { CoordTransformAxisSpec } from "@ggsvelte/spec";
 
+import type { PipelineErrorCode } from "./diagnostics-error-catalog.js";
 import { PipelineError } from "./pipeline/types.js";
 import type { PositionScale } from "./scales/train.js";
 import { scaleTransform } from "./scales/transform.js";
@@ -15,12 +16,12 @@ export interface CoordAxisProjector {
   invertFraction(fraction: number): number;
 }
 
-function docs(code: string): string {
+function docs(code: PipelineErrorCode): string {
   return `https://ggsvelte.sh/guide/errors#${code}`;
 }
 
 function failure(
-  code: string,
+  code: PipelineErrorCode,
   axis: "x" | "y",
   problem: string,
   cause: string,

--- a/packages/core/src/diagnostics-emission-registry.ts
+++ b/packages/core/src/diagnostics-emission-registry.ts
@@ -74,6 +74,7 @@ export const WARNING_EMISSION_REGISTRY = {
   "quantile-group-dropped": { channel: "warning" },
   "manual-group-dropped": { channel: "warning" },
   "ellipse-group-dropped": { channel: "warning" },
+  "stat-channel-unsupported": { channel: "warning" },
   "palette-exhausted": { channel: "warning" },
   "fingerprint-mismatch": { channel: "warning" },
   "version-mismatch": { channel: "warning" },

--- a/packages/core/src/diagnostics-warning-catalog.ts
+++ b/packages/core/src/diagnostics-warning-catalog.ts
@@ -132,6 +132,10 @@ export const PIPELINE_WARNING_CATALOG = {
     summary:
       "An ellipse group had fewer than two finite (x,y) points or zero variance and was dropped.",
   },
+  "stat-channel-unsupported": {
+    summary:
+      "A color/fill after-stat mapping names an output the selected stat does not publish; the mapping is ignored (style channels throw the same code as an error).",
+  },
   "palette-exhausted": {
     summary:
       "A discrete color scale ran out of palette entries and cycled (the default onExhaust).",

--- a/packages/core/src/diagnostics.ts
+++ b/packages/core/src/diagnostics.ts
@@ -17,8 +17,10 @@
  * Naming note: `palette-exhausted` appears as BOTH an error and a warning by
  * design (the palette-exhaustion contract): the default `onExhaust: "cycle"`
  * emits the warning; opt-in `onExhaust: "error"` throws the error.
- * `max-marks-exceeded` likewise exists as a PipelineError (renderToSVGString)
- * and a CLI diagnostic (the CLI's own --max-marks check).
+ * `stat-channel-unsupported` is likewise dual-channel: style bindings throw
+ * the error; color/fill bindings warn and ignore the mapping (#915 / #1043).
+ * `max-marks-exceeded` exists as a PipelineError (renderToSVGString) and a CLI
+ * diagnostic (the CLI's own --max-marks check).
  */
 
 export {
@@ -30,6 +32,9 @@ export {
   PIPELINE_WARNING_CATALOG,
   type PipelineWarningCode,
 } from "./diagnostics-warning-catalog.js";
+
+import type { PipelineErrorCode } from "./diagnostics-error-catalog.js";
+import type { PipelineWarningCode } from "./diagnostics-warning-catalog.js";
 
 /**
  * Advisories (`RenderModel.advisories`, Hadley lesson 12): every heuristic
@@ -105,3 +110,14 @@ export const CLI_DIAGNOSTIC_CATALOG = {
 } as const satisfies Record<string, { summary: string }>;
 
 export type CLIDiagnosticCode = keyof typeof CLI_DIAGNOSTIC_CATALOG;
+
+/**
+ * Every catalogued diagnostic code (error, warning, advisory, CLI).
+ * Used on rich `ScaleDiagnostic.code` where dual-channel and multi-channel
+ * codes are legal (`palette-exhausted`, `max-marks-exceeded`, …).
+ */
+export type DiagnosticCode =
+  | PipelineErrorCode
+  | PipelineWarningCode
+  | AdvisoryCode
+  | CLIDiagnosticCode;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -158,6 +158,7 @@ export {
 export type {
   AdvisoryCode,
   CLIDiagnosticCode,
+  DiagnosticCode,
   PipelineErrorCatalogEntry,
   PipelineErrorCode,
   PipelineWarningCode,

--- a/packages/core/src/layout/band-guide-types.ts
+++ b/packages/core/src/layout/band-guide-types.ts
@@ -1,6 +1,7 @@
 /**
  * Band axis guide plan types — shared by the planner and guide-plan contracts.
  */
+import type { GuideDegradedCode } from "./guide-degraded-codes.js";
 import type { TextMeasurer } from "./measure.js";
 
 export type BandLabelMode = "single-line" | "wrapped" | "rotated";
@@ -85,7 +86,7 @@ export interface BandAxisPlan {
   leftOverhang: number;
   overlap: boolean;
   marginOverflow: boolean;
-  degraded: string[];
+  degraded: GuideDegradedCode[];
   /**
    * True when `scales.*.guide.mode` forced the presentation (not auto).
    * Suppresses heuristic wrap/rotate advisories that would re-suggest the pin.

--- a/packages/core/src/layout/band-guide.ts
+++ b/packages/core/src/layout/band-guide.ts
@@ -38,6 +38,7 @@ import {
   wrapLabel,
   type BandLayoutEntry,
 } from "./band-label-layout.js";
+import type { GuideDegradedCode } from "./guide-degraded-codes.js";
 import { truncateToFit } from "./truncate.js";
 
 export type {
@@ -134,7 +135,7 @@ export function planBandAxis(input: BandAxisPlanInput): BandAxisPlan {
       ellipsis,
       true,
     );
-    const degraded: string[] = [];
+    const degraded: GuideDegradedCode[] = [];
     if (marginOverflow) degraded.push("band-label-margin-overflow");
     let overlap = false;
     if (opts?.reportOverlap === true && entries.length > 0) {
@@ -226,7 +227,7 @@ export function planBandAxis(input: BandAxisPlanInput): BandAxisPlan {
     if (!force && (wrapLeft > marginCapPx + 1e-6 || wrapRight > marginCapPx + 1e-6)) {
       return null;
     }
-    const degraded: string[] = [];
+    const degraded: GuideDegradedCode[] = [];
     let marginOverflow = false;
     if (force) {
       if (wrapOverlap) degraded.push("band-label-overlap");
@@ -300,7 +301,7 @@ export function planBandAxis(input: BandAxisPlanInput): BandAxisPlan {
   };
 
   const rotatedPlan = (angle: number, hybrid?: RotatedLineSource): BandAxisPlan => {
-    const degraded: string[] = [];
+    const degraded: GuideDegradedCode[] = [];
     let labelEvery = 1;
     let overlap = false;
     let marginOverflow = false;

--- a/packages/core/src/layout/guide-degraded-codes.ts
+++ b/packages/core/src/layout/guide-degraded-codes.ts
@@ -5,7 +5,7 @@
 import type { PipelineWarningCode } from "../diagnostics-warning-catalog.js";
 
 /** Exhaustive list; `satisfies` proves each member is a catalogued warning. */
-export const GUIDE_DEGRADED_CODES = [
+const GUIDE_DEGRADED_CODES = [
   "band-label-overlap",
   "band-label-margin-overflow",
   "temporal-label-overlap",

--- a/packages/core/src/layout/guide-degraded-codes.ts
+++ b/packages/core/src/layout/guide-degraded-codes.ts
@@ -1,0 +1,16 @@
+/**
+ * Guide-plan degradation codes re-emitted as pipeline warnings / scale
+ * diagnostics. Closed set of literals from band-guide / temporal-guide (#1043).
+ */
+import type { PipelineWarningCode } from "../diagnostics-warning-catalog.js";
+
+/** Exhaustive list; `satisfies` proves each member is a catalogued warning. */
+export const GUIDE_DEGRADED_CODES = [
+  "band-label-overlap",
+  "band-label-margin-overflow",
+  "temporal-label-overlap",
+  "temporal-label-margin-overflow",
+  "temporal-break-outside-domain",
+] as const satisfies readonly PipelineWarningCode[];
+
+export type GuideDegradedCode = (typeof GUIDE_DEGRADED_CODES)[number];

--- a/packages/core/src/layout/guide-plan-types.ts
+++ b/packages/core/src/layout/guide-plan-types.ts
@@ -10,8 +10,6 @@ import type { CellValue } from "../table.js";
 import type { BandLabelMode } from "./band-guide.js";
 import type { GuideDegradedCode } from "./guide-degraded-codes.js";
 
-export type { GuideDegradedCode } from "./guide-degraded-codes.js";
-
 export interface AxisGuideTick {
   value: number | CellValue;
   label: string;

--- a/packages/core/src/layout/guide-plan-types.ts
+++ b/packages/core/src/layout/guide-plan-types.ts
@@ -8,6 +8,9 @@ import type { StyleAesthetic, TemporalKind } from "@ggsvelte/spec";
 
 import type { CellValue } from "../table.js";
 import type { BandLabelMode } from "./band-guide.js";
+import type { GuideDegradedCode } from "./guide-degraded-codes.js";
+
+export type { GuideDegradedCode } from "./guide-degraded-codes.js";
 
 export interface AxisGuideTick {
   value: number | CellValue;
@@ -35,7 +38,7 @@ export interface AxisGuidePlan {
   sourceBreaks?: readonly CellValue[];
   overlap: boolean;
   marginOverflow: boolean;
-  degraded: readonly string[];
+  degraded: readonly GuideDegradedCode[];
   /** Band label layout (measured horizontal band axes only). */
   bandLabelMode?: BandLabelMode;
   /** Band rotation in degrees (auto chooses −45/−90; authors may pin any finite angle). */

--- a/packages/core/src/layout/temporal-guide.ts
+++ b/packages/core/src/layout/temporal-guide.ts
@@ -17,6 +17,7 @@ import {
   explicitCandidate,
   temporalOptions,
 } from "./temporal-axis-candidates.js";
+import type { GuideDegradedCode } from "./guide-degraded-codes.js";
 import type { AxisGuidePlan, AxisGuideTick } from "./guide-plan-types.js";
 import type { TemporalAxisPlanInput, TemporalCandidateEvaluation } from "./temporal-axis-types.js";
 
@@ -92,13 +93,13 @@ export function planTemporalAxis(input: TemporalAxisPlanInput): AxisGuidePlan {
     }
   }
 
-  const degraded = [
-    ...(selected.overlap ? ["temporal-label-overlap"] : []),
-    ...(selected.marginOverflow ? ["temporal-label-margin-overflow"] : []),
+  const degraded: GuideDegradedCode[] = [
+    ...(selected.overlap ? (["temporal-label-overlap"] as const) : []),
+    ...(selected.marginOverflow ? (["temporal-label-margin-overflow"] as const) : []),
     ...(source === "explicit" &&
     input.sourceBreaks !== undefined &&
     input.sourceBreaks.length > selected.ticks.length
-      ? ["temporal-break-outside-domain"]
+      ? (["temporal-break-outside-domain"] as const)
       : []),
   ];
   return Object.freeze({

--- a/packages/core/src/pipeline/assemble-render-model.ts
+++ b/packages/core/src/pipeline/assemble-render-model.ts
@@ -2,9 +2,10 @@
  * Assemble the public RenderModel (scene, scales, contracts, dispose/row).
  */
 import type { PanelCoordProjector } from "../coord-projector.js";
+import type { BandLabelMode } from "../layout/band-guide.js";
+import type { GuideDegradedCode } from "../layout/guide-degraded-codes.js";
 import type { TickFormatter } from "../layout/layout.js";
 import type { GuidePlan } from "../layout/temporal-guide.js";
-import type { BandLabelMode } from "../layout/band-guide.js";
 import type { ResolvedStyleScale } from "../scales/style.js";
 import type { ScaleState } from "../scales/state.js";
 import type { PositionScale } from "../scales/train.js";
@@ -13,6 +14,7 @@ import type { CellValue, ColumnTable } from "../table.js";
 import type { CandidateStore } from "../candidate-store.js";
 import type { LineageStore } from "../identity.js";
 import { createSemanticViewport } from "../semantic-viewport.js";
+import type { AdvisoryCode } from "../diagnostics.js";
 
 import {
   dedupeRenderModelDiagnostics,
@@ -79,7 +81,20 @@ const COORD_FLIP_FIX = {
   portable: { coord: { type: "flip" } },
 } as const;
 
-function bandGuideDiagnostic(code: string, aesthetic: "x" | "y", mode: BandLabelMode | undefined) {
+type BandGuideDegradedCode = Extract<
+  GuideDegradedCode,
+  "band-label-overlap" | "band-label-margin-overflow"
+>;
+type TemporalGuideDegradedCode = Extract<
+  GuideDegradedCode,
+  "temporal-label-overlap" | "temporal-label-margin-overflow" | "temporal-break-outside-domain"
+>;
+
+function bandGuideDiagnostic(
+  code: BandGuideDegradedCode,
+  aesthetic: "x" | "y",
+  mode: BandLabelMode | undefined,
+): ScaleDiagnostic {
   const margin = code === "band-label-margin-overflow";
   // A margin overflow on a single-line axis is a HORIZONTAL end-cap problem (a
   // wide end label past the panel edge), not a rotated-label bottom-margin one —
@@ -122,7 +137,10 @@ function bandGuideDiagnostic(code: string, aesthetic: "x" | "y", mode: BandLabel
   };
 }
 
-function temporalGuideDiagnostic(code: string, aesthetic: "x" | "y") {
+function temporalGuideDiagnostic(
+  code: TemporalGuideDegradedCode,
+  aesthetic: "x" | "y",
+): ScaleDiagnostic {
   const margin = code === "temporal-label-margin-overflow";
   const outside = code === "temporal-break-outside-domain";
   return {
@@ -160,22 +178,27 @@ function guidePlanDiagnostics(input: AssembleRenderModelInput): RenderModel["sca
           const key = `${code}:${plan.aesthetic}`;
           if (seen.has(key)) return [];
           seen.add(key);
-          return [
-            plan.scaleType === "band"
-              ? bandGuideDiagnostic(code, plan.aesthetic, plan.bandLabelMode)
-              : temporalGuideDiagnostic(code, plan.aesthetic),
-          ];
+          if (plan.scaleType === "band") {
+            if (code !== "band-label-overlap" && code !== "band-label-margin-overflow") return [];
+            return [bandGuideDiagnostic(code, plan.aesthetic, plan.bandLabelMode)];
+          }
+          if (
+            code !== "temporal-label-overlap" &&
+            code !== "temporal-label-margin-overflow" &&
+            code !== "temporal-break-outside-domain"
+          ) {
+            return [];
+          }
+          return [temporalGuideDiagnostic(code, plan.aesthetic)];
         })
       : [],
   );
 }
 
 /** Advisories for the heuristic band label layout the planner chose (Hadley lesson 12). */
-function bandLabelAdvisories(
-  guidePlans: AssembleRenderModelInput["guidePlans"],
-): { code: string; path: string; chosen: string; howToOverride: string }[] {
+function bandLabelAdvisories(guidePlans: AssembleRenderModelInput["guidePlans"]): Advisory[] {
   const seen = new Set<string>();
-  const out: { code: string; path: string; chosen: string; howToOverride: string }[] = [];
+  const out: Advisory[] = [];
   for (const plan of guidePlans) {
     if (plan.type !== "axis" || plan.scaleType !== "band") continue;
     // Author-pinned modes are intentional — do not emit heuristic wrap/rotate advisories.
@@ -185,16 +208,17 @@ function bandLabelAdvisories(
     const key = `${mode}:${plan.aesthetic}`;
     if (seen.has(key)) continue;
     seen.add(key);
+    const code: AdvisoryCode = mode === "wrapped" ? "band-labels-wrapped" : "band-labels-rotated";
     out.push(
       mode === "wrapped"
         ? {
-            code: "band-labels-wrapped",
+            code,
             path: `/scales/${plan.aesthetic}`,
             chosen: "wrapped long labels onto multiple lines",
             howToOverride: `Set scales.${plan.aesthetic}.guide.mode ("single"|"wrap"|"rotate"|"off") or .guide.wrap, use shorter labels, or coordFlip() for horizontal bars.`,
           }
         : {
-            code: "band-labels-rotated",
+            code,
             path: `/scales/${plan.aesthetic}`,
             chosen: `rotated long labels ${String(plan.bandLabelAngle ?? -90)}°`,
             howToOverride: `Set scales.${plan.aesthetic}.guide.mode ("single"|"wrap"|"rotate"|"off") or .guide.angle, or coordFlip() for horizontal category rows.`,

--- a/packages/core/src/pipeline/scale-color-values.ts
+++ b/packages/core/src/pipeline/scale-color-values.ts
@@ -11,6 +11,8 @@ import { encodeKey } from "../scales/state.js";
 import type { CellValue } from "../table.js";
 import { cellToNumber } from "../table.js";
 
+import type { PipelineErrorCode } from "../diagnostics-error-catalog.js";
+
 import { PipelineError, type PipelineWarning } from "./types.js";
 
 export interface ColorValueView {
@@ -22,7 +24,7 @@ export interface ColorValueView {
 
 function colorScaleError(
   name: "color" | "fill",
-  code: string,
+  code: PipelineErrorCode,
   problem: string,
   cause: string,
   fixes: readonly { description: string }[],

--- a/packages/core/src/pipeline/scale-style-discrete.ts
+++ b/packages/core/src/pipeline/scale-style-discrete.ts
@@ -12,6 +12,7 @@ import {
 import type { CellValue } from "../table.js";
 
 import type { StyleResolution } from "./scale-style-types.js";
+import { styleWarningCode } from "./style-warning-code.js";
 import { PipelineError, type PipelineWarning } from "./types.js";
 
 export function styleGuideEntry(
@@ -88,7 +89,10 @@ export function discreteStyleResolution(input: {
     throw error;
   }
   for (const warning of trained.warnings) {
-    warnings.push({ code: `style-${warning.code}`, message: `${aesthetic}: ${warning.message}` });
+    warnings.push({
+      code: styleWarningCode(warning.code),
+      message: `${aesthetic}: ${warning.message}`,
+    });
   }
   const resolvedDomain = trained.domain as CellValue[];
   const scale: StyleScale = Object.freeze({

--- a/packages/core/src/pipeline/style-warning-code.ts
+++ b/packages/core/src/pipeline/style-warning-code.ts
@@ -12,7 +12,7 @@ const STYLE_PREFIXED = {
   "out-of-domain": "style-out-of-domain",
 } as const satisfies Record<ScaleWarningCode, PipelineWarningCode>;
 
-export type StylePrefixedWarningCode = (typeof STYLE_PREFIXED)[ScaleWarningCode];
+type StylePrefixedWarningCode = (typeof STYLE_PREFIXED)[ScaleWarningCode];
 
 export function styleWarningCode(code: ScaleWarningCode): StylePrefixedWarningCode {
   return STYLE_PREFIXED[code];

--- a/packages/core/src/pipeline/style-warning-code.ts
+++ b/packages/core/src/pipeline/style-warning-code.ts
@@ -1,0 +1,19 @@
+/**
+ * Map pure-scale ScaleWarningCode → pipeline warning catalog code (#1043).
+ * A missing map entry or uncatalogued style-* value fails at compile time.
+ */
+import type { PipelineWarningCode } from "../diagnostics-warning-catalog.js";
+import type { ScaleWarningCode } from "../scales/state.js";
+
+const STYLE_PREFIXED = {
+  "palette-exhausted": "style-palette-exhausted",
+  "fingerprint-mismatch": "style-fingerprint-mismatch",
+  "version-mismatch": "style-version-mismatch",
+  "out-of-domain": "style-out-of-domain",
+} as const satisfies Record<ScaleWarningCode, PipelineWarningCode>;
+
+export type StylePrefixedWarningCode = (typeof STYLE_PREFIXED)[ScaleWarningCode];
+
+export function styleWarningCode(code: ScaleWarningCode): StylePrefixedWarningCode {
+  return STYLE_PREFIXED[code];
+}

--- a/packages/core/src/pipeline/types-advisory.ts
+++ b/packages/core/src/pipeline/types-advisory.ts
@@ -1,10 +1,17 @@
 /**
  * Pipeline diagnostics: advisories, warnings, structured errors, and canvas threshold.
+ *
+ * Code fields are catalog unions (#1043) so emit sites get compile-time
+ * completion and typos fail at `tsc`, not via the retired source scanner.
  */
+import type { AdvisoryCode } from "../diagnostics.js";
+import type { PipelineErrorCode } from "../diagnostics-error-catalog.js";
+import type { PipelineWarningCode } from "../diagnostics-warning-catalog.js";
+
 import type { ScaleDiagnostic } from "./types-scale-diagnostics.js";
 
 export interface Advisory {
-  code: string;
+  code: AdvisoryCode;
   /** Where the decision applies (e.g. "scales.x"). */
   path: string;
   /** What was chosen. */
@@ -15,17 +22,22 @@ export interface Advisory {
 
 /** A data-level problem that did not stop the render. */
 export interface PipelineWarning {
-  code: string;
+  code: PipelineWarningCode;
   message: string;
 }
 
 /** A spec- or input-level problem that stops the render (structured). */
 export class PipelineError extends Error {
-  readonly code: string;
+  readonly code: PipelineErrorCode;
   readonly path: string;
   readonly diagnostic: ScaleDiagnostic | undefined;
 
-  constructor(code: string, path: string, message: string, diagnostic?: ScaleDiagnostic) {
+  constructor(
+    code: PipelineErrorCode,
+    path: string,
+    message: string,
+    diagnostic?: ScaleDiagnostic,
+  ) {
     super(message);
     this.name = "PipelineError";
     this.code = code;

--- a/packages/core/src/pipeline/types-scale-diagnostics.ts
+++ b/packages/core/src/pipeline/types-scale-diagnostics.ts
@@ -1,5 +1,7 @@
 import type { PositionScaleSpec } from "@ggsvelte/spec";
 
+import type { DiagnosticCode } from "../diagnostics.js";
+
 export interface ScaleDiagnosticFix {
   description: string;
   portable?: unknown;
@@ -7,7 +9,8 @@ export interface ScaleDiagnosticFix {
 }
 
 export interface ScaleDiagnostic {
-  code: string;
+  /** Catalogued code (any channel; dual-channel codes are legal). */
+  code: DiagnosticCode;
   severity: "advisory" | "warning" | "error";
   path: string;
   problem: string;

--- a/packages/core/src/scales/scale-error.ts
+++ b/packages/core/src/scales/scale-error.ts
@@ -5,10 +5,12 @@
  * same `code`. Lives in its own leaf module so the transform registry and the
  * trainer can both depend on it without a cycle.
  */
-export class ScaleConfigError extends Error {
-  readonly code: string;
+import type { PipelineErrorCode } from "../diagnostics-error-catalog.js";
 
-  constructor(code: string, message: string) {
+export class ScaleConfigError extends Error {
+  readonly code: PipelineErrorCode;
+
+  constructor(code: PipelineErrorCode, message: string) {
     super(message);
     this.name = "ScaleConfigError";
     this.code = code;

--- a/packages/core/tests/diagnostics.test.ts
+++ b/packages/core/tests/diagnostics.test.ts
@@ -1,17 +1,16 @@
 /**
- * Diagnostics catalog completeness (#628 / M3 audit).
+ * Diagnostics catalog completeness (#628 / M3 audit; #1043).
  *
- * Primary: typed emission registries match catalogs 1:1 (`satisfies Record`).
+ * Typed emission registries match catalogs 1:1 (`satisfies Record`).
  * Dual-channel codes must declare a structured emit module — evidence is never
  * recovered from message text for those paths.
  *
- * Secondary: constructor/literal inventory still catches uncatalogued new codes
- * at emission sites that have not yet migrated to typed factories. That scan is
- * not the source of truth for "is this catalog entry intentional?"
+ * Emit-site code fields are catalog unions (`PipelineWarningCode`,
+ * `PipelineErrorCode`, `AdvisoryCode`, `DiagnosticCode`), so uncatalogued
+ * literals fail at compile time. The previous regex source-tree scanner is
+ * retired.
  */
 import { describe, expect, it } from "bun:test";
-import { readdirSync, readFileSync } from "node:fs";
-import { basename, join } from "node:path";
 
 import {
   ADVISORY_CATALOG,
@@ -26,77 +25,8 @@ import {
   WARNING_EMISSION_REGISTRY,
 } from "../src/diagnostics-emission-registry.ts";
 
-const SRC = join(import.meta.dir, "..", "src");
-
-function sourceFiles(dir: string): string[] {
-  const out: string[] = [];
-  for (const entry of readdirSync(dir, { withFileTypes: true })) {
-    const path = join(dir, entry.name);
-    if (entry.isDirectory()) out.push(...sourceFiles(path));
-    else if (entry.name.endsWith(".ts")) out.push(path);
-  }
-  return out;
-}
-
-/** Catalog + registry modules are not emission sites. */
-function isCatalogSource(path: string): boolean {
-  const name = basename(path);
-  return (
-    name === "diagnostics.ts" ||
-    name === "diagnostics-error-catalog.ts" ||
-    name === "diagnostics-warning-catalog.ts" ||
-    name === "diagnostics-emission-registry.ts" ||
-    name === "diagnostics-emit.ts"
-  );
-}
-
-const files = sourceFiles(SRC).map((path) => ({ path, text: readFileSync(path, "utf8") }));
-const emissionFiles = files.filter((f) => !isCatalogSource(f.path));
-
-/** Codes thrown as PipelineError / ScaleConfigError (constructor literals). */
-function emittedErrorCodes(): Set<string> {
-  const codes = new Set<string>();
-  for (const { text } of emissionFiles) {
-    for (const m of text.matchAll(
-      /new (?:PipelineError|ScaleConfigError)\(\s*\n?\s*"([a-z0-9-]+)"/g,
-    )) {
-      codes.add(m[1]!);
-    }
-  }
-  return codes;
-}
-
-/** `code: "..."` literals in warnings.push / advisories.push / errLine sites. */
-function emittedCodeLiterals(): Set<string> {
-  const codes = new Set<string>();
-  for (const { text } of emissionFiles) {
-    for (const m of text.matchAll(/code: "([a-z0-9-]+)"/g)) codes.add(m[1]!);
-  }
-  return codes;
-}
-
-/** ScaleWarningCode union members (state.ts) surface via scale.warnings. */
-function scaleWarningCodes(): Set<string> {
-  const state = readFileSync(join(SRC, "scales", "state.ts"), "utf8");
-  const union = /export type ScaleWarningCode =([^;]+);/.exec(state)?.[1] ?? "";
-  return new Set([...union.matchAll(/"([a-z0-9-]+)"/g)].map((m) => m[1]!));
-}
-
-/**
- * Discrete style training rewrites ScaleWarningCode as `style-${code}`
- * (see pipeline/scale-style-discrete.ts). Those full codes never appear as
- * quoted literals at the emit site.
- */
-function stylePrefixedScaleWarningCodes(): Set<string> {
-  const hasStyleTemplate = emissionFiles.some((f) => /code:\s*`style-\$\{/.test(f.text));
-  if (!hasStyleTemplate) return new Set();
-  return new Set([...scaleWarningCodes()].map((c) => `style-${c}`));
-}
-
-const errorCatalog = new Set(Object.keys(PIPELINE_ERROR_CATALOG));
-const warningCatalog = new Set(Object.keys(PIPELINE_WARNING_CATALOG));
 const advisoryCatalog = new Set(Object.keys(ADVISORY_CATALOG));
-const cliCatalog = new Set(Object.keys(CLI_DIAGNOSTIC_CATALOG));
+const warningCatalog = new Set(Object.keys(PIPELINE_WARNING_CATALOG));
 
 function sortedKeys(record: Record<string, unknown>): string[] {
   return Object.keys(record).toSorted();
@@ -131,28 +61,5 @@ describe("diagnostics emission registry (primary completeness, #628)", () => {
   it("advisory and warning namespaces do not overlap (one code, one channel)", () => {
     const overlap = [...advisoryCatalog].filter((c) => warningCatalog.has(c));
     expect(overlap).toEqual([]);
-  });
-});
-
-describe("diagnostics emission inventory (secondary, untyped sites)", () => {
-  it("every thrown PipelineError/ScaleConfigError code is cataloged", () => {
-    const missing = [...emittedErrorCodes()].filter((c) => !errorCatalog.has(c));
-    expect(missing).toEqual([]);
-  });
-
-  it("every `code:` literal is cataloged somewhere (warning/advisory/error/cli)", () => {
-    const known = new Set([...errorCatalog, ...warningCatalog, ...advisoryCatalog, ...cliCatalog]);
-    const missing = [...emittedCodeLiterals()].filter((c) => !known.has(c));
-    expect(missing).toEqual([]);
-  });
-
-  it("every ScaleWarningCode is in the warning catalog", () => {
-    const missing = [...scaleWarningCodes()].filter((c) => !warningCatalog.has(c));
-    expect(missing).toEqual([]);
-  });
-
-  it("style-prefixed ScaleWarningCode emissions are cataloged as warnings", () => {
-    const missing = [...stylePrefixedScaleWarningCodes()].filter((c) => !warningCatalog.has(c));
-    expect(missing).toEqual([]);
   });
 });

--- a/packages/core/tests/pipeline-types.test.ts
+++ b/packages/core/tests/pipeline-types.test.ts
@@ -13,10 +13,10 @@ describe("pipeline types contract", () => {
   });
 
   it("PipelineError is a structured tier-1 error", () => {
-    const err = new PipelineError("test-code", "/path", "message");
+    const err = new PipelineError("renderer-failure", "/path", "message");
     expect(err).toBeInstanceOf(Error);
     expect(err.name).toBe("PipelineError");
-    expect(err.code).toBe("test-code");
+    expect(err.code).toBe("renderer-failure");
     expect(err.path).toBe("/path");
     expect(err.message).toBe("message");
   });


### PR DESCRIPTION
## Summary

Closes #1043. Narrow emit-site diagnostic `code` fields to the existing catalog unions so a wrong code is a compile error, then retire the regex source-tree scanner in `diagnostics.test.ts`.

### Changes

- **Typed emit fields:** `PipelineWarning.code`, `Advisory.code`, `PipelineError` / `ScaleConfigError`, `ScaleDiagnostic.code` (`DiagnosticCode` union).
- **Prep helpers Claude review required:** typed `failure` / `colorScaleError` / guide diagnostics / band label advisories; closed `GuideDegradedCode` for guide-plan `degraded` (layout `degradations` strings stay separate).
- **`styleWarningCode`:** maps `ScaleWarningCode` → catalogued `style-*` via a `satisfies Record` table (no template hole).
- **CLI:** `cliError(code: CLIDiagnosticCode, …)` for catalogued CLI lines before deleting the scanner.
- **Dual-channel discovery:** `stat-channel-unsupported` was emitted as a color/fill **warning** but only catalogued as an **error**. Catalogued as dual-channel (same pattern as `palette-exhausted`); style bindings still throw.
- **Tests:** keep registry ↔ catalog primary suite; delete regex inventory helpers.

### Plan review

Claude consult (outside voice) rejected the first plan for missing helpers, `degraded` cascade, CLI coverage, and lifecycle regen. This PR incorporates those fixes.

### Verification

- `tsc -b packages/spec packages/core` clean
- `bun test packages/core` — 1763 pass
- `bun test packages/core/tests/diagnostics*.ts scripts/gen-llms.test.ts` green
- `bun run lifecycle:gen` (DiagnosticCode export)

## Test plan

- [x] Typecheck packages/spec + packages/core
- [x] Core unit suite
- [x] Diagnostics + gen-llms catalog coverage
- [ ] CI green on PR
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1048" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->