### PR TITLE
docs(palettes): drop bar crosshairs, keep tooltips

### DIFF
--- a/apps/docs/src/lib/components/PaletteSpecimen.svelte
+++ b/apps/docs/src/lib/components/PaletteSpecimen.svelte
@@ -56,7 +56,7 @@
     <GGPlot
       data={languages}
       aes={{ x: "language", y: "respondents", fill: "language" }}
-      inspect={{ mode: "xy" }}
+      inspect={{ mode: "exact" }}
       height={340}
       ariaLabel={`${label} palette on ${paperTheme} paper`}
     >

--- a/tests/visual/docs-themes.spec.ts
+++ b/tests/visual/docs-themes.spec.ts
@@ -193,6 +193,14 @@ test("categorical palettes show ordered swatches and reverse without hex code ch
   const firstMark = observable.locator(".gg-plot-root [fill='#4269d0']").first();
   await expect(firstMark).toBeVisible();
 
+  // Exact inspect: tooltip on the bar, no full-panel crosshair guides.
+  const capture = observable.locator(".gg-capture");
+  await capture.focus();
+  await capture.press("ArrowRight");
+  const tooltip = observable.locator(".gg-tooltip");
+  await expect(tooltip).toBeVisible();
+  await expect(observable.locator(".gg-crosshair")).toHaveCount(0);
+
   await region.getByRole("checkbox", { name: "Reverse" }).check();
   await expect(swatches.first()).toHaveAttribute("aria-label", "1: #9498a0");
   await expect(swatches.last()).toHaveAttribute("aria-label", "10: #4269d0");


### PR DESCRIPTION
## Summary

- Categorical palette specimens on `/palettes` used `inspect={{ mode: "xy" }}`, which draws full-panel vertical and horizontal crosshair guides on hover.
- Switch to `mode: "exact"` so bar tooltips stay and the crosshair guides go.
- Journey test: keyboard-inspect a palette col chart → tooltip visible, `.gg-crosshair` count 0.

## Test plan

- [x] docs-themes journey asserts tooltip + no crosshair on first categorical specimen
- [ ] CI component-journeys green
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1054" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->