### PR TITLE
fix(docs): stop narrow chart pop and cut multi-plot hydrate freeze

### DIFF
--- a/apps/docs/src/lib/components/ChartThemeLab.svelte
+++ b/apps/docs/src/lib/components/ChartThemeLab.svelte
@@ -4,7 +4,6 @@
 
   import { CATEGORICAL_PALETTES, THEME_OPTIONS } from "$lib/catalog/themes";
   import CopyCode from "$lib/components/CopyCode.svelte";
-  import TemperaturesSpecimen from "$lib/components/TemperaturesSpecimen.svelte";
   import {
     readDocsAppearance,
     watchDocsAppearance,
@@ -14,10 +13,20 @@
 
   type SchemeName = (typeof CATEGORICAL_PALETTES)[number]["name"];
 
+  const {
+    initialStaticSvg,
+  }: {
+    /** Prerendered default-theme shell; live plot replaces it on mount. */
+    initialStaticSvg: string;
+  } = $props();
+
   let explicitTheme = $state<ThemeName>("default");
   let scheme = $state<SchemeName>("observable10");
   let followDocs = $state(false);
   let siteAppearance = $state<DocsAppearance>("light");
+  let LiveTemps = $state<
+    typeof import("./TemperaturesSpecimen.svelte").default | null
+  >(null);
 
   const resolvedTheme = $derived<ThemeName>(
     followDocs ? siteAppearance : explicitTheme,
@@ -41,6 +50,10 @@
   }
 
   onMount(() => {
+    // Above-fold lab: static SVG first, then upgrade to interactive once.
+    void import("./TemperaturesSpecimen.svelte").then((mod) => {
+      LiveTemps = mod.default;
+    });
     syncSiteAppearance();
     return watchDocsAppearance((appearance) => {
       if (followDocs) siteAppearance = appearance;
@@ -58,13 +71,17 @@
   </p>
 
   <div class="plot-panel">
-    <TemperaturesSpecimen
-      theme={resolvedTheme}
-      {scheme}
-      height={400}
-      legendFocus={true}
-      ariaLabel={`${resolvedTheme} theme with ${scheme} palette`}
-    />
+    {#if LiveTemps !== null}
+      <LiveTemps
+        theme={resolvedTheme}
+        {scheme}
+        height={400}
+        legendFocus={true}
+        ariaLabel={`${resolvedTheme} theme with ${scheme} palette`}
+      />
+    {:else}
+      {@html initialStaticSvg}
+    {/if}
   </div>
 
   <div class="controls">
@@ -141,6 +158,12 @@
     width: min(100%, 52rem);
     min-width: 0;
     margin-top: 0.5rem;
+  }
+
+  .plot-panel :global(svg) {
+    display: block;
+    max-width: 100%;
+    height: auto;
   }
 
   .controls {

--- a/apps/docs/src/lib/components/HomeHeroPlot.svelte
+++ b/apps/docs/src/lib/components/HomeHeroPlot.svelte
@@ -1,0 +1,85 @@
+<script lang="ts">
+  import type { PlotInspectionChange } from "@ggsvelte/svelte";
+  import { GeomPoint, GGPlot, Labs, Scale, Theme } from "@ggsvelte/svelte";
+
+  import { guerry } from "$examples/point/scatter-color/data";
+  import { contrastChartTheme } from "$lib/docs-appearance-state.svelte";
+
+  type GuerryRow = (typeof guerry)[number];
+
+  const heroTheme = $derived(contrastChartTheme());
+</script>
+
+{#snippet heroTooltip(
+  inspection: PlotInspectionChange<Record<string, unknown>, PropertyKey>,
+)}
+  {@const row = inspection.focus.row as GuerryRow | null}
+  {#if row}
+    <div class="hero-tooltip">
+      <div class="hero-tooltip-title">{row.department}</div>
+      <dl>
+        <dt>literacy</dt>
+        <dd>{row.literacy}%</dd>
+        <dt>pop. per crime</dt>
+        <dd>{row.crimePersons}</dd>
+        <dt>region</dt>
+        <dd>{row.region}</dd>
+      </dl>
+    </div>
+  {/if}
+{/snippet}
+
+<!--
+  Exact point inspection (not mode "x"): no vertical axis guide, one
+  department at a time. Custom content names the department (identity
+  column not on a mapped channel). Default tooltips use labs titles
+  for mapped channels (#752).
+-->
+<GGPlot
+  data={guerry}
+  aes={{ x: "literacy", y: "crimePersons", color: "region" }}
+  inspect={{
+    mode: "exact",
+    pin: true,
+    maxDistance: 24,
+    content: heroTooltip,
+  }}
+  width="container"
+  height={400}
+  ariaLabel="Literacy percentage against population per crime against persons for 85 French departments, coloured by region"
+>
+  <Theme name={heroTheme} />
+  <Scale value={{ color: { type: "ordinal", scheme: "tableau10" } }} />
+  <Labs
+    title="Literacy and crime in France, 1833"
+    subtitle="85 French departments — higher y means fewer crimes per head"
+    x="Literate conscripts (%)"
+    y="Population per crime against persons"
+    color="Region"
+  />
+  <GeomPoint size={4} alpha={0.85} />
+</GGPlot>
+
+<style>
+  .hero-tooltip-title {
+    margin-bottom: 0.35rem;
+    font-weight: 650;
+  }
+
+  .hero-tooltip dl {
+    margin: 0;
+    display: grid;
+    grid-template-columns: auto auto;
+    gap: 0 0.75rem;
+  }
+
+  .hero-tooltip dt {
+    font-weight: 600;
+  }
+
+  .hero-tooltip dd {
+    margin: 0;
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+  }
+</style>

--- a/apps/docs/src/lib/components/PaletteGallery.svelte
+++ b/apps/docs/src/lib/components/PaletteGallery.svelte
@@ -1,6 +1,22 @@
 <script lang="ts">
-  import { CATEGORICAL_PALETTES } from "$lib/catalog/themes";
   import PaletteSpecimen from "$lib/components/PaletteSpecimen.svelte";
+  import type { CATEGORICAL_SCHEME_NAMES, ThemeName } from "@ggsvelte/spec";
+
+  type CategoricalSchemeName = (typeof CATEGORICAL_SCHEME_NAMES)[number];
+
+  const {
+    specimens,
+  }: {
+    specimens: readonly {
+      name: CategoricalSchemeName;
+      label: string;
+      colors: readonly string[];
+      capacity: number;
+      reverse: boolean;
+      paperTheme: ThemeName;
+      staticSvg: string;
+    }[];
+  } = $props();
 
   let reverse = $state(false);
   let paperTheme = $state<"light" | "dark">("light");
@@ -28,7 +44,7 @@
   </header>
 
   <ol aria-label="Categorical palettes">
-    {#each CATEGORICAL_PALETTES as palette (palette.name)}
+    {#each specimens as palette (palette.name)}
       <li>
         <PaletteSpecimen
           name={palette.name}
@@ -37,6 +53,7 @@
           capacity={palette.capacity}
           {reverse}
           {paperTheme}
+          staticSvg={palette.staticSvg}
         />
       </li>
     {/each}
@@ -64,8 +81,7 @@
     align-items: end;
     justify-content: space-between;
     gap: 1rem 2rem;
-    min-width: 0;
-    margin-bottom: 1.5rem;
+    margin-bottom: 1.25rem;
   }
 
   h2 {
@@ -78,22 +94,21 @@
   .controls {
     display: flex;
     flex-wrap: wrap;
-    gap: 1rem 1.25rem;
+    gap: 0.85rem 1.25rem;
     align-items: end;
   }
 
   .select-control {
     display: grid;
     gap: 0.35rem;
-    font-size: 0.78rem;
+    font-size: 0.82rem;
     font-weight: 650;
   }
 
   select {
-    min-width: 9rem;
     min-height: 44px;
-    padding: 0.6rem;
-    border: 1px solid var(--line-strong, var(--line));
+    padding: 0.5rem 2rem 0.5rem 0.65rem;
+    border: 1px solid var(--line);
     border-radius: 2px;
     background: var(--paper);
     color: var(--ink);
@@ -102,28 +117,18 @@
 
   .check-control {
     display: flex;
-    gap: 0.6rem;
+    gap: 0.55rem;
     align-items: center;
     min-height: 44px;
-    font-size: 0.86rem;
+    font-size: 0.9rem;
     font-weight: 600;
-  }
-
-  .check-control input {
-    width: 1.15rem;
-    height: 1.15rem;
   }
 
   ol {
     display: grid;
-    grid-template-columns: 1fr;
-    gap: clamp(2.5rem, 5vw, 4rem);
+    gap: clamp(2rem, 4vw, 3rem);
     margin: 0;
     padding: 0;
     list-style: none;
-  }
-
-  ol > li {
-    min-width: 0;
   }
 </style>

--- a/apps/docs/src/lib/components/PaletteSpecimen.svelte
+++ b/apps/docs/src/lib/components/PaletteSpecimen.svelte
@@ -1,17 +1,8 @@
 <script lang="ts">
-  import {
-    GeomCol,
-    GGPlot,
-    Guides,
-    Labs,
-    Scale,
-    Theme,
-  } from "@ggsvelte/svelte";
-  import type { CATEGORICAL_SCHEME_NAMES, ThemeName } from "@ggsvelte/spec";
   import { onMount } from "svelte";
+  import type { CATEGORICAL_SCHEME_NAMES, ThemeName } from "@ggsvelte/spec";
 
   import { observeNearViewport } from "$lib/near-viewport";
-  import { languages } from "$lib/theme-specimens/data";
 
   type CategoricalSchemeName = (typeof CATEGORICAL_SCHEME_NAMES)[number];
 
@@ -22,6 +13,7 @@
     capacity,
     reverse,
     paperTheme,
+    staticSvg,
   }: {
     name: CategoricalSchemeName;
     label: string;
@@ -29,25 +21,57 @@
     capacity: number;
     reverse: boolean;
     paperTheme: ThemeName;
+    /** Prerendered shell for reverse=false + paperTheme=light. */
+    staticSvg: string;
   } = $props();
 
-  const displayColors = $derived(reverse ? colors.toReversed() : colors);
   const plotHeight = 340;
+  const displayColors = $derived(reverse ? colors.toReversed() : colors);
+  /** Shell matches only the prerender defaults; other control combos need live. */
+  const shellMatches = $derived(!reverse && paperTheme === "light");
 
-  /** Mount the live plot only near the viewport (#1037). */
-  let root = $state<HTMLElement | undefined>();
-  let active = $state(false);
+  let host = $state<HTMLDivElement | null>(null);
+  let Live = $state<
+    typeof import("./PaletteSpecimenLive.svelte").default | null
+  >(null);
 
   onMount(() => {
-    const el = root;
-    if (el === undefined) return;
-    return observeNearViewport(el, () => {
-      active = true;
-    });
+    const el = host;
+    if (el === null) return;
+    let cancelled = false;
+
+    const load = (): void => {
+      if (cancelled || Live !== null) return;
+      void import("./PaletteSpecimenLive.svelte").then((mod) => {
+        if (!cancelled) Live = mod.default;
+      });
+    };
+
+    if (!shellMatches) {
+      load();
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    const stop = observeNearViewport(el, load, { rootMargin: "480px 0px" });
+    return () => {
+      cancelled = true;
+      stop();
+    };
+  });
+
+  // When the user flips reverse/paper after mount, upgrade immediately.
+  $effect(() => {
+    if (!shellMatches && Live === null && host !== null) {
+      void import("./PaletteSpecimenLive.svelte").then((mod) => {
+        Live = mod.default;
+      });
+    }
   });
 </script>
 
-<article class="specimen" bind:this={root}>
+<article class="specimen">
   <header>
     <div>
       <h3>{label}</h3>
@@ -67,31 +91,13 @@
     {/each}
   </ul>
 
-  <div class="plot-panel" style:min-height="{plotHeight}px">
-    {#if active}
-      <GGPlot
-        data={languages}
-        aes={{ x: "language", y: "respondents", fill: "language" }}
-        inspect={{ mode: "exact" }}
-        height={plotHeight}
-        ariaLabel={`${label} palette on ${paperTheme} paper`}
-      >
-        <Theme name={paperTheme} />
-        <Scale value={{ fill: { type: "ordinal", scheme: name, reverse } }} />
-        <Guides value={{ fill: { type: "none" } }} />
-        <Labs
-          title="Spanish Armada squadron tonnage, 1588"
-          x="Squadron"
-          y="Tons"
-        />
-        <GeomCol width={0.75} />
-      </GGPlot>
+  <div class="plot-panel" bind:this={host} style:min-height="{plotHeight}px">
+    {#if Live !== null}
+      <Live {name} {label} {reverse} {paperTheme} height={plotHeight} />
+    {:else if shellMatches}
+      {@html staticSvg}
     {:else}
-      <div
-        class="plot-placeholder"
-        style:height="{plotHeight}px"
-        aria-hidden="true"
-      ></div>
+      <div class="plot-shell" style:height={`${String(plotHeight)}px`}></div>
     {/if}
   </div>
 </article>
@@ -148,9 +154,15 @@
     min-width: 0;
   }
 
-  .plot-placeholder {
+  .plot-panel :global(svg) {
+    display: block;
+    max-width: 100%;
+    height: auto;
+  }
+
+  .plot-shell {
     width: 100%;
-    border-radius: 0.25rem;
-    background: color-mix(in srgb, var(--line) 55%, transparent);
+    background: var(--wash);
+    border: 1px solid var(--line);
   }
 </style>

--- a/apps/docs/src/lib/components/PaletteSpecimen.svelte
+++ b/apps/docs/src/lib/components/PaletteSpecimen.svelte
@@ -47,27 +47,14 @@
       });
     };
 
-    if (!shellMatches) {
-      load();
-      return () => {
-        cancelled = true;
-      };
-    }
-
+    // Near-viewport only. Do not $effect-load every off-screen specimen when
+    // reverse/paper toggles — that freezes the page. Live specimens already
+    // upgrade via props; others load on scroll.
     const stop = observeNearViewport(el, load, { rootMargin: "480px 0px" });
     return () => {
       cancelled = true;
       stop();
     };
-  });
-
-  // When the user flips reverse/paper after mount, upgrade immediately.
-  $effect(() => {
-    if (!shellMatches && Live === null && host !== null) {
-      void import("./PaletteSpecimenLive.svelte").then((mod) => {
-        Live = mod.default;
-      });
-    }
   });
 </script>
 

--- a/apps/docs/src/lib/components/PaletteSpecimenLive.svelte
+++ b/apps/docs/src/lib/components/PaletteSpecimenLive.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+  import {
+    GeomCol,
+    GGPlot,
+    Guides,
+    Labs,
+    Scale,
+    Theme,
+  } from "@ggsvelte/svelte";
+  import type { CATEGORICAL_SCHEME_NAMES, ThemeName } from "@ggsvelte/spec";
+
+  import { languages } from "$lib/theme-specimens/data";
+
+  type CategoricalSchemeName = (typeof CATEGORICAL_SCHEME_NAMES)[number];
+
+  const {
+    name,
+    label,
+    reverse,
+    paperTheme,
+    height,
+  }: {
+    name: CategoricalSchemeName;
+    label: string;
+    reverse: boolean;
+    paperTheme: ThemeName;
+    height: number;
+  } = $props();
+</script>
+
+<GGPlot
+  data={languages}
+  aes={{ x: "language", y: "respondents", fill: "language" }}
+  inspect={{ mode: "exact" }}
+  {height}
+  ariaLabel={`${label} palette on ${paperTheme} paper`}
+>
+  <Theme name={paperTheme} />
+  <Scale value={{ fill: { type: "ordinal", scheme: name, reverse } }} />
+  <Guides value={{ fill: { type: "none" } }} />
+  <Labs title="Spanish Armada squadron tonnage, 1588" x="Squadron" y="Tons" />
+  <GeomCol width={0.75} />
+</GGPlot>

--- a/apps/docs/src/lib/components/SequentialColorLab.svelte
+++ b/apps/docs/src/lib/components/SequentialColorLab.svelte
@@ -1,43 +1,20 @@
 <script lang="ts">
-  import { GeomRaster, GGPlot, Labs, Scale, Theme } from "@ggsvelte/svelte";
   import type { ColorScaleSpec } from "@ggsvelte/spec";
 
   import { VIRIDIS_COLORS } from "$lib/catalog/themes";
   import CopyCode from "$lib/components/CopyCode.svelte";
-  import { RASTER_Z_DOMAIN } from "$lib/theme-specimens/catalog";
-  import { grid } from "$lib/theme-specimens/data";
+  import SequentialDeferredPlot from "$lib/components/SequentialDeferredPlot.svelte";
   import { SEQUENTIAL_RASTER_SNIPPET } from "$lib/theme-specimens/snippets";
 
-  interface SequentialExample {
-    label: string;
-    scale: ColorScaleSpec;
-  }
-
-  const examples: readonly SequentialExample[] = [
-    {
-      label: "Viridis",
-      scale: { type: "sequential", scheme: "viridis" },
-    },
-    {
-      label: "Reversed",
-      scale: { type: "sequential", scheme: "viridis", reverse: true },
-    },
-    {
-      label: "Custom range",
-      scale: {
-        type: "sequential",
-        range: ["#2d1e2f", "#3d5a80", "#e76f51"],
-      },
-    },
-    {
-      label: "Pinned domain",
-      scale: {
-        type: "sequential",
-        scheme: "viridis",
-        domain: [...RASTER_Z_DOMAIN],
-      },
-    },
-  ];
+  const {
+    examples,
+  }: {
+    examples: readonly {
+      label: string;
+      scale: ColorScaleSpec;
+      staticSvg: string;
+    }[];
+  } = $props();
 </script>
 
 <section class="sequential-lab" aria-label="Sequential color scales">
@@ -68,25 +45,11 @@
           <header>
             <h3>{example.label}</h3>
           </header>
-          <div class="plot-panel">
-            <GGPlot
-              data={grid}
-              aes={{ x: "x", y: "y", fill: "z" }}
-              inspect={{ mode: "xy" }}
-              height={360}
-              ariaLabel={`${example.label} sequential color example`}
-            >
-              <Scale value={{ fill: example.scale }} />
-              <Theme name="light" />
-              <Labs
-                title={`${example.label} Macdonell counts`}
-                x="Finger index"
-                y="Height index"
-                fill="Men"
-              />
-              <GeomRaster />
-            </GGPlot>
-          </div>
+          <SequentialDeferredPlot
+            label={example.label}
+            scale={example.scale}
+            staticSvg={example.staticSvg}
+          />
         </article>
       </li>
     {/each}
@@ -176,11 +139,6 @@
     margin: 0;
     font-size: 1.25rem;
     letter-spacing: -0.01em;
-  }
-
-  .plot-panel {
-    width: min(100%, 52rem);
-    min-width: 0;
   }
 
   .section-code {

--- a/apps/docs/src/lib/components/SequentialColorLabLive.svelte
+++ b/apps/docs/src/lib/components/SequentialColorLabLive.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+  import { GeomRaster, GGPlot, Labs, Scale, Theme } from "@ggsvelte/svelte";
+  import type { ColorScaleSpec } from "@ggsvelte/spec";
+
+  import { grid } from "$lib/theme-specimens/data";
+
+  const {
+    label,
+    scale,
+    height,
+  }: {
+    label: string;
+    scale: ColorScaleSpec;
+    height: number;
+  } = $props();
+</script>
+
+<GGPlot
+  data={grid}
+  aes={{ x: "x", y: "y", fill: "z" }}
+  inspect={{ mode: "xy" }}
+  {height}
+  ariaLabel={`${label} sequential color example`}
+>
+  <Scale value={{ fill: scale }} />
+  <Theme name="light" />
+  <Labs
+    title={`${label} Macdonell counts`}
+    x="Finger index"
+    y="Height index"
+    fill="Men"
+  />
+  <GeomRaster />
+</GGPlot>

--- a/apps/docs/src/lib/components/SequentialDeferredPlot.svelte
+++ b/apps/docs/src/lib/components/SequentialDeferredPlot.svelte
@@ -2,6 +2,8 @@
   import { onMount } from "svelte";
   import type { ColorScaleSpec } from "@ggsvelte/spec";
 
+  import { observeNearViewport } from "$lib/near-viewport";
+
   const {
     label,
     scale,
@@ -23,26 +25,24 @@
     const el = host;
     if (el === null) return;
     let cancelled = false;
-    const io = new IntersectionObserver(
-      (entries) => {
-        if (entries.some((entry) => entry.isIntersecting)) {
-          void import("./SequentialColorLabLive.svelte").then((mod) => {
-            if (!cancelled) Live = mod.default;
-          });
-          io.disconnect();
-        }
+    const stop = observeNearViewport(
+      el,
+      () => {
+        if (cancelled || Live !== null) return;
+        void import("./SequentialColorLabLive.svelte").then((mod) => {
+          if (!cancelled) Live = mod.default;
+        });
       },
       { rootMargin: "480px 0px" },
     );
-    io.observe(el);
     return () => {
       cancelled = true;
-      io.disconnect();
+      stop();
     };
   });
 </script>
 
-<div class="plot-panel" bind:this={host}>
+<div class="plot-panel" bind:this={host} style:min-height="{height}px">
   {#if Live !== null}
     <Live {label} {scale} {height} />
   {:else}

--- a/apps/docs/src/lib/components/SequentialDeferredPlot.svelte
+++ b/apps/docs/src/lib/components/SequentialDeferredPlot.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import type { ColorScaleSpec } from "@ggsvelte/spec";
+
+  const {
+    label,
+    scale,
+    staticSvg,
+    height = 360,
+  }: {
+    label: string;
+    scale: ColorScaleSpec;
+    staticSvg: string;
+    height?: number;
+  } = $props();
+
+  let host = $state<HTMLDivElement | null>(null);
+  let Live = $state<
+    typeof import("./SequentialColorLabLive.svelte").default | null
+  >(null);
+
+  onMount(() => {
+    const el = host;
+    if (el === null) return;
+    let cancelled = false;
+    const io = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          void import("./SequentialColorLabLive.svelte").then((mod) => {
+            if (!cancelled) Live = mod.default;
+          });
+          io.disconnect();
+        }
+      },
+      { rootMargin: "480px 0px" },
+    );
+    io.observe(el);
+    return () => {
+      cancelled = true;
+      io.disconnect();
+    };
+  });
+</script>
+
+<div class="plot-panel" bind:this={host}>
+  {#if Live !== null}
+    <Live {label} {scale} {height} />
+  {:else}
+    {@html staticSvg}
+  {/if}
+</div>
+
+<style>
+  .plot-panel {
+    width: min(100%, 52rem);
+    min-width: 0;
+  }
+
+  .plot-panel :global(svg) {
+    display: block;
+    max-width: 100%;
+    height: auto;
+  }
+</style>

--- a/apps/docs/src/lib/components/ThemeSpecimen.svelte
+++ b/apps/docs/src/lib/components/ThemeSpecimen.svelte
@@ -1,37 +1,12 @@
 <script lang="ts">
-  import {
-    GeomArea,
-    GeomBar,
-    GeomCol,
-    GeomLine,
-    GeomPoint,
-    GeomSmooth,
-    GeomText,
-    GGPlot,
-    Labs,
-    Scale,
-    scaleXLog10,
-    Theme,
-  } from "@ggsvelte/svelte";
-  import type { ThemeName } from "@ggsvelte/spec";
   import { onMount } from "svelte";
+  import type { ThemeName } from "@ggsvelte/spec";
 
-  import TemperaturesSpecimen from "$lib/components/TemperaturesSpecimen.svelte";
   import { observeNearViewport } from "$lib/near-viewport";
   import type {
     SchemeName,
     ThemeSpecimenKind,
   } from "$lib/theme-specimens/catalog";
-  import {
-    attendees,
-    cities,
-    countries,
-    generation,
-    longRunSeries,
-    penguins,
-    revenue,
-    ridership,
-  } from "$lib/theme-specimens/data";
 
   const {
     name,
@@ -40,6 +15,8 @@
     kind,
     scheme,
     legendFocus,
+    staticSvg,
+    eager = false,
   }: {
     name: ThemeName;
     label: string;
@@ -47,206 +24,60 @@
     kind: ThemeSpecimenKind;
     scheme: SchemeName;
     legendFocus: boolean;
+    /** Prerendered SVG shell (no client core import). */
+    staticSvg: string;
+    /** When true, upgrade to interactive immediately on mount (above-fold). */
+    eager?: boolean;
   } = $props();
 
   const plotHeight = 380;
-  const colorScale = $derived({ type: "ordinal" as const, scheme });
 
-  /** Mount the live plot only near the viewport (#1037). */
-  let root = $state<HTMLElement | undefined>();
-  let active = $state(false);
+  let host = $state<HTMLDivElement | null>(null);
+  let Live = $state<typeof import("./ThemeSpecimenLive.svelte").default | null>(
+    null,
+  );
 
   onMount(() => {
-    const el = root;
-    if (el === undefined) return;
-    return observeNearViewport(el, () => {
-      active = true;
-    });
+    const el = host;
+    if (el === null) return;
+    let cancelled = false;
+
+    const load = (): void => {
+      if (cancelled || Live !== null) return;
+      void import("./ThemeSpecimenLive.svelte").then((mod) => {
+        if (!cancelled) Live = mod.default;
+      });
+    };
+
+    if (eager) {
+      load();
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    return observeNearViewport(el, load, { rootMargin: "480px 0px" });
   });
 </script>
 
-<article class="specimen" bind:this={root}>
+<article class="specimen">
   <header>
     <h3>{label}</h3>
     <p class="caption">{caption}</p>
   </header>
 
-  <div class="plot-panel" style:min-height="{plotHeight}px">
-    {#if active}
-      {#if kind === "temps-line"}
-        <TemperaturesSpecimen
-          theme={name}
-          {scheme}
-          height={plotHeight}
-          {legendFocus}
-          ariaLabel={`${label} theme Playfair multi-series`}
-        />
-      {:else if kind === "ridership-line"}
-        <GGPlot
-          data={ridership}
-          aes={{ x: "month", y: "riders", color: "mode" }}
-          key="id"
-          inspect={{ mode: "x" }}
-          {legendFocus}
-          height={plotHeight}
-          ariaLabel={`${label} theme Playfair wheat and wages`}
-        >
-          <Theme {name} />
-          <Scale value={{ color: colorScale }} />
-          <Labs
-            title="Playfair wheat price & weekly wage"
-            x="Year"
-            y="Shillings"
-            color="Series"
-          />
-          <GeomLine linewidth={2} />
-          <GeomPoint size={2.8} />
-        </GGPlot>
-      {:else if kind === "attendees-dodge"}
-        <GGPlot
-          data={attendees}
-          aes={{ x: "track", fill: "level", weight: "deaths" }}
-          key="id"
-          inspect={{ mode: "xy" }}
-          {legendFocus}
-          height={plotHeight}
-          ariaLabel={`${label} theme Edgeworth dodged bars`}
-        >
-          <Theme {name} />
-          <Scale value={{ fill: colorScale }} />
-          <Labs
-            title="Edgeworth county deaths, 1876–82"
-            x="Year"
-            y="Deaths per million"
-            fill="County"
-          />
-          <GeomBar position="dodge" />
-        </GGPlot>
-      {:else if kind === "generation-area"}
-        <GGPlot
-          data={generation}
-          aes={{ x: "year", y: "twh", fill: "source" }}
-          key="id"
-          inspect={{ mode: "x" }}
-          {legendFocus}
-          height={plotHeight}
-          ariaLabel={`${label} theme Nightingale stacked area`}
-        >
-          <Theme {name} />
-          <Scale
-            value={{
-              x: { nice: false },
-              fill: colorScale,
-            }}
-          />
-          <Labs
-            title="Crimean deaths by cause, 1854–56"
-            x="Year"
-            y="Deaths per 1,000 per year"
-            fill="Cause"
-          />
-          <GeomArea alpha={0.9} />
-        </GGPlot>
-      {:else if kind === "long-run-line"}
-        <GGPlot
-          data={longRunSeries}
-          aes={{ x: "year", y: "value" }}
-          inspect={{ mode: "x" }}
-          height={plotHeight}
-          ariaLabel={`${label} theme Bowley exports`}
-        >
-          <Theme {name} />
-          <Labs title="British exports, 1855–1899" x="Year" y="£ millions" />
-          <GeomLine linewidth={1.5} />
-        </GGPlot>
-      {:else if kind === "penguins-scatter"}
-        <GGPlot
-          data={penguins}
-          aes={{ x: "flipper", y: "mass", color: "species" }}
-          key="id"
-          inspect={{ mode: "xy" }}
-          {legendFocus}
-          height={plotHeight}
-          ariaLabel={`${label} theme penguin scatter`}
-        >
-          <Theme {name} />
-          <Scale value={{ color: colorScale }} />
-          <Labs
-            title="Penguin flipper length and body mass"
-            x="Flipper length (mm)"
-            y="Body mass (g)"
-            color="Species"
-          />
-          <GeomPoint size={3.5} alpha={0.9} />
-        </GGPlot>
-      {:else if kind === "countries-scatter"}
-        <GGPlot
-          data={countries}
-          aes={{ x: "gdp", y: "lifeExp", color: "region" }}
-          key="country"
-          inspect={{ mode: "xy" }}
-          {legendFocus}
-          height={plotHeight}
-          ariaLabel={`${label} theme cholera density scatter`}
-        >
-          <Theme {name} />
-          <Scale
-            value={{
-              ...scaleXLog10({ labels: "~s" }),
-              color: colorScale,
-            }}
-          />
-          <Labs
-            title="Cholera death rate vs density, 1849"
-            x="People per acre (log scale)"
-            y="Death rate per 10,000"
-            color="Water supply"
-          />
-          <GeomPoint size={3.5} />
-          <GeomSmooth method="lm" se={false} />
-        </GGPlot>
-      {:else if kind === "revenue-cols"}
-        <GGPlot
-          data={revenue}
-          aes={{ x: "quarter", y: "amount" }}
-          inspect={{ mode: "xy" }}
-          height={plotHeight}
-          ariaLabel={`${label} theme Salk trial columns`}
-        >
-          <Theme {name} />
-          <Labs
-            title="Salk trial paralytic polio rates"
-            x="Group"
-            y="Cases per 100,000"
-          />
-          <GeomCol width={0.7} />
-          <GeomText aes={{ label: "label" }} dy={-8} size={11} />
-        </GGPlot>
-      {:else}
-        <GGPlot
-          data={cities}
-          aes={{ x: "rent", y: "livability" }}
-          inspect={{ mode: "xy" }}
-          height={plotHeight}
-          ariaLabel={`${label} theme Langren longitude labels`}
-        >
-          <Theme {name} />
-          <Scale value={{ x: { labels: ".1f" } }} />
-          <Labs
-            title="Van Langren longitude estimates, 1644"
-            x="Toledo–Rome longitude (°)"
-            y="Estimate rank"
-          />
-          <GeomPoint size={3} />
-          <GeomText aes={{ label: "city" }} dy={-9} size={10} />
-        </GGPlot>
-      {/if}
+  <div class="plot-panel" bind:this={host} style:min-height="{plotHeight}px">
+    {#if Live !== null}
+      <Live
+        {name}
+        {label}
+        {kind}
+        {scheme}
+        {legendFocus}
+        height={plotHeight}
+      />
     {:else}
-      <div
-        class="plot-placeholder"
-        style:height="{plotHeight}px"
-        aria-hidden="true"
-      ></div>
+      {@html staticSvg}
     {/if}
   </div>
 </article>
@@ -281,9 +112,9 @@
     min-width: 0;
   }
 
-  .plot-placeholder {
-    width: 100%;
-    border-radius: 0.25rem;
-    background: color-mix(in srgb, var(--line) 55%, transparent);
+  .plot-panel :global(svg) {
+    display: block;
+    max-width: 100%;
+    height: auto;
   }
 </style>

--- a/apps/docs/src/lib/components/ThemeSpecimen.svelte
+++ b/apps/docs/src/lib/components/ThemeSpecimen.svelte
@@ -68,14 +68,7 @@
 
   <div class="plot-panel" bind:this={host} style:min-height="{plotHeight}px">
     {#if Live !== null}
-      <Live
-        {name}
-        {label}
-        {kind}
-        {scheme}
-        {legendFocus}
-        height={plotHeight}
-      />
+      <Live {name} {label} {kind} {scheme} {legendFocus} height={plotHeight} />
     {:else}
       {@html staticSvg}
     {/if}

--- a/apps/docs/src/lib/components/ThemeSpecimen.svelte
+++ b/apps/docs/src/lib/components/ThemeSpecimen.svelte
@@ -56,7 +56,11 @@
       };
     }
 
-    return observeNearViewport(el, load, { rootMargin: "480px 0px" });
+    const stop = observeNearViewport(el, load, { rootMargin: "480px 0px" });
+    return () => {
+      cancelled = true;
+      stop();
+    };
   });
 </script>
 

--- a/apps/docs/src/lib/components/ThemeSpecimenLive.svelte
+++ b/apps/docs/src/lib/components/ThemeSpecimenLive.svelte
@@ -1,0 +1,225 @@
+<script lang="ts">
+  /**
+   * Interactive body for a theme specimen. Dynamically imported by
+   * ThemeSpecimen when the host is near the viewport so /themes does not
+   * hydrate dozens of full GGPlot controllers on first paint.
+   */
+  import {
+    GeomArea,
+    GeomBar,
+    GeomCol,
+    GeomLine,
+    GeomPoint,
+    GeomSmooth,
+    GeomText,
+    GGPlot,
+    Labs,
+    Scale,
+    scaleXLog10,
+    Theme,
+  } from "@ggsvelte/svelte";
+  import type { ThemeName } from "@ggsvelte/spec";
+
+  import TemperaturesSpecimen from "$lib/components/TemperaturesSpecimen.svelte";
+  import type {
+    SchemeName,
+    ThemeSpecimenKind,
+  } from "$lib/theme-specimens/catalog";
+  import {
+    attendees,
+    cities,
+    countries,
+    generation,
+    longRunSeries,
+    penguins,
+    revenue,
+    ridership,
+  } from "$lib/theme-specimens/data";
+
+  const {
+    name,
+    label,
+    kind,
+    scheme,
+    legendFocus,
+    height,
+  }: {
+    name: ThemeName;
+    label: string;
+    kind: ThemeSpecimenKind;
+    scheme: SchemeName;
+    legendFocus: boolean;
+    height: number;
+  } = $props();
+
+  const colorScale = $derived({ type: "ordinal" as const, scheme });
+</script>
+
+{#if kind === "temps-line"}
+  <TemperaturesSpecimen
+    theme={name}
+    {scheme}
+    {height}
+    {legendFocus}
+    ariaLabel={`${label} theme Playfair multi-series`}
+  />
+{:else if kind === "ridership-line"}
+  <GGPlot
+    data={ridership}
+    aes={{ x: "month", y: "riders", color: "mode" }}
+    key="id"
+    inspect={{ mode: "x" }}
+    {legendFocus}
+    {height}
+    ariaLabel={`${label} theme Playfair wheat and wages`}
+  >
+    <Theme {name} />
+    <Scale value={{ color: colorScale }} />
+    <Labs
+      title="Playfair wheat price & weekly wage"
+      x="Year"
+      y="Shillings"
+      color="Series"
+    />
+    <GeomLine linewidth={2} />
+    <GeomPoint size={2.8} />
+  </GGPlot>
+{:else if kind === "attendees-dodge"}
+  <GGPlot
+    data={attendees}
+    aes={{ x: "track", fill: "level", weight: "deaths" }}
+    key="id"
+    inspect={{ mode: "xy" }}
+    {legendFocus}
+    {height}
+    ariaLabel={`${label} theme Edgeworth dodged bars`}
+  >
+    <Theme {name} />
+    <Scale value={{ fill: colorScale }} />
+    <Labs
+      title="Edgeworth county deaths, 1876–82"
+      x="Year"
+      y="Deaths per million"
+      fill="County"
+    />
+    <GeomBar position="dodge" />
+  </GGPlot>
+{:else if kind === "generation-area"}
+  <GGPlot
+    data={generation}
+    aes={{ x: "year", y: "twh", fill: "source" }}
+    key="id"
+    inspect={{ mode: "x" }}
+    {legendFocus}
+    {height}
+    ariaLabel={`${label} theme Nightingale stacked area`}
+  >
+    <Theme {name} />
+    <Scale
+      value={{
+        x: { nice: false },
+        fill: colorScale,
+      }}
+    />
+    <Labs
+      title="Crimean deaths by cause, 1854–56"
+      x="Year"
+      y="Deaths per 1,000 per year"
+      fill="Cause"
+    />
+    <GeomArea alpha={0.9} />
+  </GGPlot>
+{:else if kind === "long-run-line"}
+  <GGPlot
+    data={longRunSeries}
+    aes={{ x: "year", y: "value" }}
+    inspect={{ mode: "x" }}
+    {height}
+    ariaLabel={`${label} theme Bowley exports`}
+  >
+    <Theme {name} />
+    <Labs title="British exports, 1855–1899" x="Year" y="£ millions" />
+    <GeomLine linewidth={1.5} />
+  </GGPlot>
+{:else if kind === "penguins-scatter"}
+  <GGPlot
+    data={penguins}
+    aes={{ x: "flipper", y: "mass", color: "species" }}
+    key="id"
+    inspect={{ mode: "xy" }}
+    {legendFocus}
+    {height}
+    ariaLabel={`${label} theme penguin scatter`}
+  >
+    <Theme {name} />
+    <Scale value={{ color: colorScale }} />
+    <Labs
+      title="Penguin flipper length and body mass"
+      x="Flipper length (mm)"
+      y="Body mass (g)"
+      color="Species"
+    />
+    <GeomPoint size={3.5} alpha={0.9} />
+  </GGPlot>
+{:else if kind === "countries-scatter"}
+  <GGPlot
+    data={countries}
+    aes={{ x: "gdp", y: "lifeExp", color: "region" }}
+    key="country"
+    inspect={{ mode: "xy" }}
+    {legendFocus}
+    {height}
+    ariaLabel={`${label} theme cholera density scatter`}
+  >
+    <Theme {name} />
+    <Scale
+      value={{
+        ...scaleXLog10({ labels: "~s" }),
+        color: colorScale,
+      }}
+    />
+    <Labs
+      title="Cholera death rate vs density, 1849"
+      x="People per acre (log scale)"
+      y="Death rate per 10,000"
+      color="Water supply"
+    />
+    <GeomPoint size={3.5} />
+    <GeomSmooth method="lm" se={false} />
+  </GGPlot>
+{:else if kind === "revenue-cols"}
+  <GGPlot
+    data={revenue}
+    aes={{ x: "quarter", y: "amount" }}
+    inspect={{ mode: "xy" }}
+    {height}
+    ariaLabel={`${label} theme Salk trial columns`}
+  >
+    <Theme {name} />
+    <Labs
+      title="Salk trial paralytic polio rates"
+      x="Group"
+      y="Cases per 100,000"
+    />
+    <GeomCol width={0.7} />
+    <GeomText aes={{ label: "label" }} dy={-8} size={11} />
+  </GGPlot>
+{:else}
+  <GGPlot
+    data={cities}
+    aes={{ x: "rent", y: "livability" }}
+    inspect={{ mode: "xy" }}
+    {height}
+    ariaLabel={`${label} theme Langren longitude labels`}
+  >
+    <Theme {name} />
+    <Scale value={{ x: { labels: ".1f" } }} />
+    <Labs
+      title="Van Langren longitude estimates, 1644"
+      x="Toledo–Rome longitude (°)"
+      y="Estimate rank"
+    />
+    <GeomPoint size={3} />
+    <GeomText aes={{ label: "city" }} dy={-9} size={10} />
+  </GGPlot>
+{/if}

--- a/apps/docs/src/lib/generated/search-index.ts
+++ b/apps/docs/src/lib/generated/search-index.ts
@@ -24936,7 +24936,7 @@ export const DOCS_SEARCH_INDEX = [
     id: "cli:width",
     kind: "cli",
     title: "--width",
-    summary: "Plot width in px (default: spec.width, then 640)",
+    summary: "Plot width in px (default: spec.width, then 832)",
     href: "/reference/cli#width",
     keywords: ["N"],
     exact: ["--width"],

--- a/apps/docs/src/lib/theme-specimens/static-svg.ts
+++ b/apps/docs/src/lib/theme-specimens/static-svg.ts
@@ -1,0 +1,272 @@
+/**
+ * Static SVG shells for /themes multi-plot pages.
+ *
+ * Live <GGPlot> trees are expensive to hydrate (full interaction controllers).
+ * SSR + first client paint use these strings so the page is readable and
+ * full-width immediately; near-viewport dynamic import upgrades to interactive.
+ */
+import { renderToSVGString } from "@ggsvelte/core";
+import { aes, gg, scaleXLog10, type ThemeName } from "@ggsvelte/spec";
+
+import { MONTH_BREAKS, type SchemeName, type ThemeSpecimenKind } from "./catalog.js";
+import {
+  attendees,
+  cities,
+  countries,
+  generation,
+  grid,
+  languages,
+  longRunSeries,
+  penguins,
+  revenue,
+  ridership,
+  temperaturesKeyed,
+} from "./data.js";
+import { TEMPERATURES_CHART } from "./temperatures-chart.js";
+
+/** Matches packages/svelte DEFAULT_PLOT_WIDTH_PX and docs .plot-panel max. */
+export const DOCS_STATIC_PLOT_WIDTH_PX = 832;
+
+const cache = new Map<string, string>();
+
+export type ThemeStaticSvgInput = {
+  readonly name: ThemeName;
+  readonly kind: ThemeSpecimenKind;
+  readonly scheme: SchemeName;
+  readonly width?: number;
+  readonly height?: number;
+};
+
+function colorScale(scheme: SchemeName) {
+  return { type: "ordinal" as const, scheme };
+}
+
+function buildThemeSpec(input: ThemeStaticSvgInput) {
+  const { name, kind, scheme } = input;
+  const color = colorScale(scheme);
+
+  switch (kind) {
+    case "temps-line": {
+      const chart = TEMPERATURES_CHART;
+      return gg(temperaturesKeyed, aes(chart.aes))
+        .geomLine({ linewidth: chart.geomLine.linewidth })
+        .geomPoint({ size: chart.geomPoint.size })
+        .scales({
+          x: { breaks: [...chart.monthBreaks] },
+          color,
+        })
+        .theme(name)
+        .labs({ ...chart.labs })
+        .spec();
+    }
+    case "ridership-line":
+      return gg(ridership, aes({ x: "month", y: "riders", color: "mode" }))
+        .geomLine({ linewidth: 2 })
+        .geomPoint({ size: 2.8 })
+        .scales({ color })
+        .theme(name)
+        .labs({
+          title: "Playfair wheat price & weekly wage",
+          x: "Year",
+          y: "Shillings",
+          color: "Series",
+        })
+        .spec();
+    case "attendees-dodge":
+      return gg(attendees, aes({ x: "track", fill: "level", weight: "deaths" }))
+        .geomBar({ position: "dodge" })
+        .scales({ fill: color })
+        .theme(name)
+        .labs({
+          title: "Edgeworth county deaths, 1876–82",
+          x: "Year",
+          y: "Deaths per million",
+          fill: "County",
+        })
+        .spec();
+    case "generation-area":
+      return gg(generation, aes({ x: "year", y: "twh", fill: "source" }))
+        .geomArea({ alpha: 0.9 })
+        .scales({ x: { nice: false }, fill: color })
+        .theme(name)
+        .labs({
+          title: "Crimean deaths by cause, 1854–56",
+          x: "Year",
+          y: "Deaths per 1,000 per year",
+          fill: "Cause",
+        })
+        .spec();
+    case "long-run-line":
+      return gg(longRunSeries, aes({ x: "year", y: "value" }))
+        .geomLine({ linewidth: 1.5 })
+        .theme(name)
+        .labs({ title: "British exports, 1855–1899", x: "Year", y: "£ millions" })
+        .spec();
+    case "penguins-scatter":
+      return gg(penguins, aes({ x: "flipper", y: "mass", color: "species" }))
+        .geomPoint({ size: 3.5, alpha: 0.9 })
+        .scales({ color })
+        .theme(name)
+        .labs({
+          title: "Penguin flipper length and body mass",
+          x: "Flipper length (mm)",
+          y: "Body mass (g)",
+          color: "Species",
+        })
+        .spec();
+    case "countries-scatter":
+      return gg(countries, aes({ x: "gdp", y: "lifeExp", color: "region" }))
+        .geomPoint({ size: 3.5 })
+        .geomSmooth({ method: "lm", se: false })
+        .scales({ ...scaleXLog10({ labels: "~s" }), color })
+        .theme(name)
+        .labs({
+          title: "Cholera death rate vs density, 1849",
+          x: "People per acre (log scale)",
+          y: "Death rate per 10,000",
+          color: "Water supply",
+        })
+        .spec();
+    case "revenue-cols":
+      return gg(revenue, aes({ x: "quarter", y: "amount" }))
+        .geomCol({ width: 0.7 })
+        .geomText({ aes: { label: "label" }, dy: -8, size: 11 })
+        .theme(name)
+        .labs({
+          title: "Salk trial paralytic polio rates",
+          x: "Group",
+          y: "Cases per 100,000",
+        })
+        .spec();
+    case "cities-labels":
+      return gg(cities, aes({ x: "rent", y: "livability" }))
+        .geomPoint({ size: 3 })
+        .geomText({ aes: { label: "city" }, dy: -9, size: 10 })
+        .scales({ x: { labels: ".1f" } })
+        .theme(name)
+        .labs({
+          title: "Van Langren longitude estimates, 1644",
+          x: "Toledo–Rome longitude (°)",
+          y: "Estimate rank",
+        })
+        .spec();
+  }
+}
+
+export function themeSpecimenStaticSvg(input: ThemeStaticSvgInput): string {
+  const width = input.width ?? DOCS_STATIC_PLOT_WIDTH_PX;
+  const height = input.height ?? 380;
+  const key = `${input.name}:${input.kind}:${input.scheme}:${String(width)}x${String(height)}`;
+  const hit = cache.get(key);
+  if (hit !== undefined) return hit;
+  const svg = renderToSVGString(buildThemeSpec(input), { width, height });
+  cache.set(key, svg);
+  return svg;
+}
+
+export function temperaturesStaticSvg(input: {
+  readonly theme: ThemeName;
+  readonly scheme: SchemeName;
+  readonly height?: number;
+  readonly width?: number;
+}): string {
+  return themeSpecimenStaticSvg({
+    name: input.theme,
+    kind: "temps-line",
+    scheme: input.scheme,
+    width: input.width,
+    height: input.height ?? 400,
+  });
+}
+
+export function paletteSpecimenStaticSvg(input: {
+  readonly scheme: SchemeName;
+  readonly reverse: boolean;
+  readonly paperTheme: ThemeName;
+  readonly width?: number;
+  readonly height?: number;
+}): string {
+  const width = input.width ?? DOCS_STATIC_PLOT_WIDTH_PX;
+  const height = input.height ?? 340;
+  const key = `palette:${input.scheme}:${String(input.reverse)}:${input.paperTheme}:${String(width)}x${String(height)}`;
+  const hit = cache.get(key);
+  if (hit !== undefined) return hit;
+  const spec = gg(languages, aes({ x: "language", y: "respondents", fill: "language" }))
+    .geomCol({ width: 0.75 })
+    .scales({
+      fill: { type: "ordinal", scheme: input.scheme, reverse: input.reverse },
+    })
+    .guides({ fill: { type: "none" } })
+    .theme(input.paperTheme)
+    .labs({
+      title: "Spanish Armada squadron tonnage, 1588",
+      x: "Squadron",
+      y: "Tons",
+    })
+    .spec();
+  const svg = renderToSVGString(spec, { width, height });
+  cache.set(key, svg);
+  return svg;
+}
+
+// Keep MONTH_BREAKS referenced so static temps stay aligned with live chart.
+void MONTH_BREAKS;
+
+/** Homepage Guerry hero — static shell before HomeHeroPlot hydrates. */
+export function sequentialRasterStaticSvg(input: {
+  readonly label: string;
+  readonly scale: import("@ggsvelte/spec").ColorScaleSpec;
+  readonly width?: number;
+  readonly height?: number;
+}): string {
+  const width = input.width ?? DOCS_STATIC_PLOT_WIDTH_PX;
+  const height = input.height ?? 360;
+  const key = `seq:${input.label}:${JSON.stringify(input.scale)}:${String(width)}x${String(height)}`;
+  const hit = cache.get(key);
+  if (hit !== undefined) return hit;
+  const spec = gg(grid, aes({ x: "x", y: "y", fill: "z" }))
+    .geomRaster()
+    .scales({ fill: input.scale })
+    .theme("light")
+    .labs({
+      title: `${input.label} Macdonell counts`,
+      x: "Finger index",
+      y: "Height index",
+      fill: "Men",
+    })
+    .spec();
+  const svg = renderToSVGString(spec, { width, height });
+  cache.set(key, svg);
+  return svg;
+}
+
+export function homeHeroStaticSvgFromData(
+  rows: readonly Record<string, unknown>[],
+  input?: {
+    readonly theme?: ThemeName;
+    readonly width?: number;
+    readonly height?: number;
+  },
+): string {
+  const theme = input?.theme ?? "default";
+  const width = input?.width ?? DOCS_STATIC_PLOT_WIDTH_PX;
+  const height = input?.height ?? 400;
+  const key = `home-hero:${theme}:${String(width)}x${String(height)}:${String(rows.length)}`;
+  const hit = cache.get(key);
+  if (hit !== undefined) return hit;
+  const spec = gg([...rows], aes({ x: "literacy", y: "crimePersons", color: "region" }))
+    .geomPoint({ size: 4, alpha: 0.85 })
+    .scales({ color: { type: "ordinal", scheme: "tableau10" } })
+    .theme(theme)
+    .labs({
+      title: "Literacy and crime in France, 1833",
+      subtitle: "85 French departments — higher y means fewer crimes per head",
+      x: "Literate conscripts (%)",
+      y: "Population per crime against persons",
+      color: "Region",
+    })
+    .spec();
+  const svg = renderToSVGString(spec, { width, height });
+  cache.set(key, svg);
+  return svg;
+}

--- a/apps/docs/src/lib/theme-specimens/static-svg.ts
+++ b/apps/docs/src/lib/theme-specimens/static-svg.ts
@@ -150,6 +150,10 @@ function buildThemeSpec(input: ThemeStaticSvgInput) {
           y: "Estimate rank",
         })
         .spec();
+    default: {
+      const exhaustive: never = kind;
+      throw new Error(`unhandled theme specimen kind: ${String(exhaustive)}`);
+    }
   }
 }
 

--- a/apps/docs/src/lib/theme-specimens/static-svg.ts
+++ b/apps/docs/src/lib/theme-specimens/static-svg.ts
@@ -29,6 +29,18 @@ export const DOCS_STATIC_PLOT_WIDTH_PX = 832;
 
 const cache = new Map<string, string>();
 
+/**
+ * Headless SVG uses fixed ids (`gg-clip-0`, `gg-ramp-fill`). Multiple shells on
+ * one page collide (url(#id) is document-scoped). Namespace each shell so
+ * clip/ramp references stay local to that SVG.
+ */
+function namespaceSvgIds(svg: string, key: string): string {
+  const prefix = `s${key.replaceAll(/[^a-zA-Z0-9_-]/g, "_")}`;
+  return svg
+    .replaceAll(/id="(gg-[^"]+)"/g, `id="${prefix}-$1"`)
+    .replaceAll(/url\(#(gg-[^)]+)\)/g, `url(#${prefix}-$1)`);
+}
+
 export type ThemeStaticSvgInput = {
   readonly name: ThemeName;
   readonly kind: ThemeSpecimenKind;
@@ -100,7 +112,11 @@ function buildThemeSpec(input: ThemeStaticSvgInput) {
       return gg(longRunSeries, aes({ x: "year", y: "value" }))
         .geomLine({ linewidth: 1.5 })
         .theme(name)
-        .labs({ title: "British exports, 1855–1899", x: "Year", y: "£ millions" })
+        .labs({
+          title: "British exports, 1855–1899",
+          x: "Year",
+          y: "£ millions",
+        })
         .spec();
     case "penguins-scatter":
       return gg(penguins, aes({ x: "flipper", y: "mass", color: "species" }))
@@ -163,7 +179,7 @@ export function themeSpecimenStaticSvg(input: ThemeStaticSvgInput): string {
   const key = `${input.name}:${input.kind}:${input.scheme}:${String(width)}x${String(height)}`;
   const hit = cache.get(key);
   if (hit !== undefined) return hit;
-  const svg = renderToSVGString(buildThemeSpec(input), { width, height });
+  const svg = namespaceSvgIds(renderToSVGString(buildThemeSpec(input), { width, height }), key);
   cache.set(key, svg);
   return svg;
 }
@@ -208,7 +224,7 @@ export function paletteSpecimenStaticSvg(input: {
       y: "Tons",
     })
     .spec();
-  const svg = renderToSVGString(spec, { width, height });
+  const svg = namespaceSvgIds(renderToSVGString(spec, { width, height }), key);
   cache.set(key, svg);
   return svg;
 }
@@ -216,7 +232,7 @@ export function paletteSpecimenStaticSvg(input: {
 // Keep MONTH_BREAKS referenced so static temps stay aligned with live chart.
 void MONTH_BREAKS;
 
-/** Homepage Guerry hero — static shell before HomeHeroPlot hydrates. */
+/** Sequential Macdonell raster — static shell before SequentialColorLabLive hydrates. */
 export function sequentialRasterStaticSvg(input: {
   readonly label: string;
   readonly scale: import("@ggsvelte/spec").ColorScaleSpec;
@@ -239,7 +255,7 @@ export function sequentialRasterStaticSvg(input: {
       fill: "Men",
     })
     .spec();
-  const svg = renderToSVGString(spec, { width, height });
+  const svg = namespaceSvgIds(renderToSVGString(spec, { width, height }), key);
   cache.set(key, svg);
   return svg;
 }
@@ -270,7 +286,7 @@ export function homeHeroStaticSvgFromData(
       color: "Region",
     })
     .spec();
-  const svg = renderToSVGString(spec, { width, height });
+  const svg = namespaceSvgIds(renderToSVGString(spec, { width, height }), key);
   cache.set(key, svg);
   return svg;
 }

--- a/apps/docs/src/lib/theme-specimens/static-svg.ts
+++ b/apps/docs/src/lib/theme-specimens/static-svg.ts
@@ -6,7 +6,7 @@
  * full-width immediately; near-viewport dynamic import upgrades to interactive.
  */
 import { renderToSVGString } from "@ggsvelte/core";
-import { aes, gg, scaleXLog10, type ThemeName } from "@ggsvelte/spec";
+import { aes, gg, scaleXLog10, type AuthoringRows, type ThemeName } from "@ggsvelte/spec";
 
 import { MONTH_BREAKS, type SchemeName, type ThemeSpecimenKind } from "./catalog.js";
 import {
@@ -254,7 +254,7 @@ export function homeHeroStaticSvgFromData(
   const key = `home-hero:${theme}:${String(width)}x${String(height)}:${String(rows.length)}`;
   const hit = cache.get(key);
   if (hit !== undefined) return hit;
-  const spec = gg([...rows], aes({ x: "literacy", y: "crimePersons", color: "region" }))
+  const spec = gg(rows as AuthoringRows, aes({ x: "literacy", y: "crimePersons", color: "region" }))
     .geomPoint({ size: 4, alpha: 0.85 })
     .scales({ color: { type: "ordinal", scheme: "tableau10" } })
     .theme(theme)

--- a/apps/docs/src/routes/+page.server.ts
+++ b/apps/docs/src/routes/+page.server.ts
@@ -1,11 +1,20 @@
 import { guerry } from "$examples/point/scatter-color/data";
 import { homeHeroStaticSvgFromData } from "$lib/theme-specimens/static-svg";
 
-/** Prerender hero SVG so the home client shell does not import @ggsvelte/core. */
+/**
+ * Prerender hero shells so the home client does not import @ggsvelte/core.
+ * Two contrast themes: dark chart on the light site, light chart on dark
+ * (matches `contrastChartTheme()`). CSS on the page picks the right one from
+ * `data-theme` set by static/theme.js before first paint.
+ */
 export function load() {
   return {
-    heroStaticSvg: homeHeroStaticSvgFromData(guerry, {
-      theme: "default",
+    heroStaticSvgLightSite: homeHeroStaticSvgFromData(guerry, {
+      theme: "dark",
+      height: 400,
+    }),
+    heroStaticSvgDarkSite: homeHeroStaticSvgFromData(guerry, {
+      theme: "light",
       height: 400,
     }),
   };

--- a/apps/docs/src/routes/+page.server.ts
+++ b/apps/docs/src/routes/+page.server.ts
@@ -1,0 +1,12 @@
+import { guerry } from "$examples/point/scatter-color/data";
+import { homeHeroStaticSvgFromData } from "$lib/theme-specimens/static-svg";
+
+/** Prerender hero SVG so the home client shell does not import @ggsvelte/core. */
+export function load() {
+  return {
+    heroStaticSvg: homeHeroStaticSvgFromData(guerry, {
+      theme: "default",
+      height: 400,
+    }),
+  };
+}

--- a/apps/docs/src/routes/+page.svelte
+++ b/apps/docs/src/routes/+page.svelte
@@ -52,7 +52,16 @@
     {#if HeroPlot !== null}
       <HeroPlot />
     {:else}
-      {@html data.heroStaticSvg}
+      <!--
+        theme.js sets data-theme before paint. Mirror contrastChartTheme():
+        dark chart on the light site, light chart on dark — no theme flash.
+      -->
+      <div class="hero-static hero-static--light-site">
+        {@html data.heroStaticSvgLightSite}
+      </div>
+      <div class="hero-static hero-static--dark-site">
+        {@html data.heroStaticSvgDarkSite}
+      </div>
     {/if}
   </div>
 
@@ -199,6 +208,18 @@
     display: block;
     max-width: 100%;
     height: auto;
+  }
+
+  .hero-static--dark-site {
+    display: none;
+  }
+
+  :global(:root[data-theme="dark"]) .hero-static--light-site {
+    display: none;
+  }
+
+  :global(:root[data-theme="dark"]) .hero-static--dark-site {
+    display: block;
   }
 
   .cta-row {

--- a/apps/docs/src/routes/+page.svelte
+++ b/apps/docs/src/routes/+page.svelte
@@ -1,27 +1,40 @@
 <script lang="ts">
   import { base } from "$app/paths";
-  import type { PlotInspectionChange } from "@ggsvelte/svelte";
-  import { GeomPoint, GGPlot, Labs, Scale, Theme } from "@ggsvelte/svelte";
+  import { onMount } from "svelte";
 
-  import { guerry } from "$examples/point/scatter-color/data";
   import CodeTabs from "$lib/CodeTabs.svelte";
   import { FEATURED_EXAMPLES, galleryCatalog } from "$lib/catalog/gallery";
   import CopyCode from "$lib/components/CopyCode.svelte";
-  import GrammarDemo from "$lib/components/GrammarDemo.svelte";
   import UiButton from "$lib/components/UiButton.svelte";
-  import { contrastChartTheme } from "$lib/docs-appearance-state.svelte";
   import { EXAMPLES } from "$lib/examples";
   import { HOME_CODE_PATH_TABS } from "$lib/home-code-path";
 
-  type GuerryRow = (typeof guerry)[number];
+  import type { PageProps } from "./$types";
+
+  const { data }: PageProps = $props();
 
   const install = "bun add @ggsvelte/svelte";
   const entries = galleryCatalog(EXAMPLES);
   const featured = FEATURED_EXAMPLES.map((item) =>
     entries.find((entry) => entry.id === item.id)!,
   );
-  const heroTheme = $derived(contrastChartTheme());
   const tabs = HOME_CODE_PATH_TABS;
+
+  let HeroPlot = $state<
+    typeof import("$lib/components/HomeHeroPlot.svelte").default | null
+  >(null);
+  let GrammarDemo = $state<
+    typeof import("$lib/components/GrammarDemo.svelte").default | null
+  >(null);
+
+  onMount(() => {
+    void import("$lib/components/HomeHeroPlot.svelte").then((mod) => {
+      HeroPlot = mod.default;
+    });
+    void import("$lib/components/GrammarDemo.svelte").then((mod) => {
+      GrammarDemo = mod.default;
+    });
+  });
 </script>
 
 <section class="home-hero" aria-labelledby="home-heading">
@@ -36,54 +49,11 @@
   </div>
 
   <div class="hero-plot">
-    <!--
-      Exact point inspection (not mode "x"): no vertical axis guide, one
-      department at a time. Custom content names the department (identity
-      column not on a mapped channel). Default tooltips use labs titles
-      for mapped channels (#752).
-    -->
-    {#snippet heroTooltip(
-      inspection: PlotInspectionChange<Record<string, unknown>, PropertyKey>,
-    )}
-      {@const row = inspection.focus.row as GuerryRow | null}
-      {#if row}
-        <div class="hero-tooltip">
-          <div class="hero-tooltip-title">{row.department}</div>
-          <dl>
-            <dt>literacy</dt>
-            <dd>{row.literacy}%</dd>
-            <dt>pop. per crime</dt>
-            <dd>{row.crimePersons}</dd>
-            <dt>region</dt>
-            <dd>{row.region}</dd>
-          </dl>
-        </div>
-      {/if}
-    {/snippet}
-    <GGPlot
-      data={guerry}
-      aes={{ x: "literacy", y: "crimePersons", color: "region" }}
-      inspect={{
-        mode: "exact",
-        pin: true,
-        maxDistance: 24,
-        content: heroTooltip,
-      }}
-      width="container"
-      height={400}
-      ariaLabel="Literacy percentage against population per crime against persons for 85 French departments, coloured by region"
-    >
-      <Theme name={heroTheme} />
-      <Scale value={{ color: { type: "ordinal", scheme: "tableau10" } }} />
-      <Labs
-        title="Literacy and crime in France, 1833"
-        subtitle="85 French departments — higher y means fewer crimes per head"
-        x="Literate conscripts (%)"
-        y="Population per crime against persons"
-        color="Region"
-      />
-      <GeomPoint size={4} alpha={0.85} />
-    </GGPlot>
+    {#if HeroPlot !== null}
+      <HeroPlot />
+    {:else}
+      {@html data.heroStaticSvg}
+    {/if}
   </div>
 
   <div class="hero-actions">
@@ -122,7 +92,9 @@
   </ol>
 </section>
 
-<GrammarDemo />
+{#if GrammarDemo !== null}
+  <GrammarDemo />
+{/if}
 
 <section class="code-path" aria-labelledby="code-path-heading">
   <div>
@@ -223,26 +195,10 @@
     min-width: 0;
   }
 
-  .hero-tooltip-title {
-    margin-bottom: 0.35rem;
-    font-weight: 650;
-  }
-
-  .hero-tooltip dl {
-    margin: 0;
-    display: grid;
-    grid-template-columns: auto auto;
-    gap: 0 0.75rem;
-  }
-
-  .hero-tooltip dt {
-    font-weight: 600;
-  }
-
-  .hero-tooltip dd {
-    margin: 0;
-    text-align: right;
-    font-variant-numeric: tabular-nums;
+  .hero-plot :global(svg) {
+    display: block;
+    max-width: 100%;
+    height: auto;
   }
 
   .cta-row {

--- a/apps/docs/src/routes/palettes/+page.server.ts
+++ b/apps/docs/src/routes/palettes/+page.server.ts
@@ -1,6 +1,7 @@
 import type { ColorScaleSpec } from "@ggsvelte/spec";
 
 import { CATEGORICAL_PALETTES } from "$lib/catalog/themes";
+import { RASTER_Z_DOMAIN } from "$lib/theme-specimens/catalog";
 import {
   paletteSpecimenStaticSvg,
   sequentialRasterStaticSvg,
@@ -27,7 +28,7 @@ const SEQUENTIAL_EXAMPLES: readonly {
     scale: {
       type: "sequential",
       scheme: "viridis",
-      domain: [15, 40],
+      domain: [...RASTER_Z_DOMAIN],
     },
   },
 ];

--- a/apps/docs/src/routes/palettes/+page.server.ts
+++ b/apps/docs/src/routes/palettes/+page.server.ts
@@ -1,0 +1,62 @@
+import type { ColorScaleSpec } from "@ggsvelte/spec";
+
+import { CATEGORICAL_PALETTES } from "$lib/catalog/themes";
+import {
+  paletteSpecimenStaticSvg,
+  sequentialRasterStaticSvg,
+} from "$lib/theme-specimens/static-svg";
+
+const SEQUENTIAL_EXAMPLES: readonly {
+  label: string;
+  scale: ColorScaleSpec;
+}[] = [
+  { label: "Viridis", scale: { type: "sequential", scheme: "viridis" } },
+  {
+    label: "Reversed",
+    scale: { type: "sequential", scheme: "viridis", reverse: true },
+  },
+  {
+    label: "Custom range",
+    scale: {
+      type: "sequential",
+      range: ["#2d1e2f", "#3d5a80", "#e76f51"],
+    },
+  },
+  {
+    label: "Pinned domain",
+    scale: {
+      type: "sequential",
+      scheme: "viridis",
+      domain: [15, 40],
+    },
+  },
+];
+
+/** Precompute static chart shells at prerender so the client never imports core to paint them. */
+export function load() {
+  return {
+    paletteSpecimens: CATEGORICAL_PALETTES.map((palette) => ({
+      name: palette.name,
+      label: palette.label,
+      colors: palette.colors,
+      capacity: palette.capacity,
+      reverse: false,
+      paperTheme: "light" as const,
+      staticSvg: paletteSpecimenStaticSvg({
+        scheme: palette.name,
+        reverse: false,
+        paperTheme: "light",
+        height: 340,
+      }),
+    })),
+    sequentialExamples: SEQUENTIAL_EXAMPLES.map((example) => ({
+      label: example.label,
+      scale: example.scale,
+      staticSvg: sequentialRasterStaticSvg({
+        label: example.label,
+        scale: example.scale,
+        height: 360,
+      }),
+    })),
+  };
+}

--- a/apps/docs/src/routes/palettes/+page.svelte
+++ b/apps/docs/src/routes/palettes/+page.svelte
@@ -3,6 +3,10 @@
 
   import PaletteGallery from "$lib/components/PaletteGallery.svelte";
   import SequentialColorLab from "$lib/components/SequentialColorLab.svelte";
+
+  import type { PageProps } from "./$types";
+
+  const { data }: PageProps = $props();
 </script>
 
 <main class="palettes-page">
@@ -20,8 +24,8 @@
     </p>
   </header>
 
-  <PaletteGallery />
-  <SequentialColorLab />
+  <PaletteGallery specimens={data.paletteSpecimens} />
+  <SequentialColorLab examples={data.sequentialExamples} />
 
   <nav class="learning-path" aria-label="Next steps">
     <p class="eyebrow">Next</p>

--- a/apps/docs/src/routes/themes/+page.server.ts
+++ b/apps/docs/src/routes/themes/+page.server.ts
@@ -1,8 +1,5 @@
 import { THEME_SPECIMENS } from "$lib/theme-specimens/catalog";
-import {
-  temperaturesStaticSvg,
-  themeSpecimenStaticSvg,
-} from "$lib/theme-specimens/static-svg";
+import { temperaturesStaticSvg, themeSpecimenStaticSvg } from "$lib/theme-specimens/static-svg";
 
 /** Precompute static chart shells at prerender so the client never imports core to paint them. */
 export function load() {

--- a/apps/docs/src/routes/themes/+page.server.ts
+++ b/apps/docs/src/routes/themes/+page.server.ts
@@ -1,0 +1,25 @@
+import { THEME_SPECIMENS } from "$lib/theme-specimens/catalog";
+import {
+  temperaturesStaticSvg,
+  themeSpecimenStaticSvg,
+} from "$lib/theme-specimens/static-svg";
+
+/** Precompute static chart shells at prerender so the client never imports core to paint them. */
+export function load() {
+  return {
+    themeSpecimens: THEME_SPECIMENS.map((specimen) => ({
+      ...specimen,
+      staticSvg: themeSpecimenStaticSvg({
+        name: specimen.name,
+        kind: specimen.kind,
+        scheme: specimen.scheme,
+        height: 380,
+      }),
+    })),
+    labStaticSvg: temperaturesStaticSvg({
+      theme: "default",
+      scheme: "observable10",
+      height: 400,
+    }),
+  };
+}

--- a/apps/docs/src/routes/themes/+page.svelte
+++ b/apps/docs/src/routes/themes/+page.svelte
@@ -3,7 +3,10 @@
 
   import ChartThemeLab from "$lib/components/ChartThemeLab.svelte";
   import ThemeSpecimen from "$lib/components/ThemeSpecimen.svelte";
-  import { THEME_SPECIMENS } from "$lib/theme-specimens/catalog";
+
+  import type { PageProps } from "./$types";
+
+  const { data }: PageProps = $props();
 </script>
 
 <main class="themes-page">
@@ -21,7 +24,7 @@
     </p>
   </header>
 
-  <ChartThemeLab />
+  <ChartThemeLab initialStaticSvg={data.labStaticSvg} />
 
   <section class="theme-collection" aria-labelledby="built-in-themes-heading">
     <header class="section-heading">
@@ -29,7 +32,7 @@
       <h2 id="built-in-themes-heading">Chart themes</h2>
     </header>
     <ol aria-label="Built-in chart themes">
-      {#each THEME_SPECIMENS as specimen (specimen.name)}
+      {#each data.themeSpecimens as specimen, index (specimen.name)}
         <li>
           <ThemeSpecimen
             name={specimen.name}
@@ -38,6 +41,8 @@
             kind={specimen.kind}
             scheme={specimen.scheme}
             legendFocus={specimen.legendFocus}
+            staticSvg={specimen.staticSvg}
+            eager={index === 0}
           />
         </li>
       {/each}
@@ -137,15 +142,10 @@
 
   ol {
     display: grid;
-    grid-template-columns: 1fr;
     gap: clamp(2.5rem, 5vw, 4rem);
     margin: 0;
     padding: 0;
     list-style: none;
-  }
-
-  ol > li {
-    min-width: 0;
   }
 
   .learning-path {
@@ -158,11 +158,7 @@
     padding: 0;
     list-style: none;
     display: grid;
-    gap: 0.55rem;
-    max-width: 42rem;
-    color: var(--muted);
-    font-size: 0.95rem;
-    line-height: 1.45;
+    gap: 0.65rem;
   }
 
   .learning-path a {

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -51,7 +51,7 @@ export const CLI_OPTIONS = [
     anchor: "width",
     flag: "--width",
     value: "N",
-    description: "Plot width in px (default: spec.width, then 640)",
+    description: "Plot width in px (default: spec.width, then 832)",
     kind: "number",
     target: "width",
   },
@@ -291,7 +291,7 @@ export async function runCLI(
 
   const specRecord =
     typeof spec === "object" && spec !== null ? (spec as Record<string, unknown>) : {};
-  const width = args.width ?? (typeof specRecord["width"] === "number" ? specRecord["width"] : 640);
+  const width = args.width ?? (typeof specRecord["width"] === "number" ? specRecord["width"] : 832);
   const height =
     args.height ?? (typeof specRecord["height"] === "number" ? specRecord["height"] : 400);
 

--- a/packages/svelte/src/lib/assembly/layout.ts
+++ b/packages/svelte/src/lib/assembly/layout.ts
@@ -12,7 +12,7 @@ const DOCKED_TOOLTIP_MAX_WIDTH_PX = 480;
  * typical laptop does not paint a skinny chart and then jump wider after
  * ResizeObserver. Not a phone-first size; phones are not the design target.
  */
-export const DEFAULT_PLOT_WIDTH_PX = 832;
+const DEFAULT_PLOT_WIDTH_PX = 832;
 const DEFAULT_PLOT_HEIGHT_PX = 400;
 
 export type ResolvePlotSizeInput = {

--- a/packages/svelte/src/lib/assembly/layout.ts
+++ b/packages/svelte/src/lib/assembly/layout.ts
@@ -6,7 +6,13 @@
 
 const NARROW_TOOLS_MAX_WIDTH_PX = 560;
 const DOCKED_TOOLTIP_MAX_WIDTH_PX = 480;
-const DEFAULT_PLOT_WIDTH_PX = 640;
+/**
+ * Pre-measure fallback for container-width plots (SSR and collapsed hosts).
+ * 52rem at the common 16px root — matches docs `.plot-panel` max width so a
+ * typical laptop does not paint a skinny chart and then jump wider after
+ * ResizeObserver. Not a phone-first size; phones are not the design target.
+ */
+export const DEFAULT_PLOT_WIDTH_PX = 832;
 const DEFAULT_PLOT_HEIGHT_PX = 400;
 
 export type ResolvePlotSizeInput = {
@@ -35,9 +41,9 @@ export function isContainerWidthProp(
 
 /**
  * Resolved plot pixel size for the pipeline and root style.
- * Container mode: measured container width, then assembled, then 640.
- * Fixed mode: the numeric width prop (assembled fallback is unused once fixed).
- * Height: height prop, then assembled, then 400.
+ * Container mode: measured container width, then assembled, then
+ * DEFAULT_PLOT_WIDTH_PX (832). Fixed mode: the numeric width prop (assembled
+ * fallback is unused once fixed). Height: height prop, then assembled, then 400.
  */
 export function resolvePlotSize(input: ResolvePlotSizeInput): {
   readonly width: number;

--- a/packages/svelte/src/lib/runtime/runtime.svelte.ts
+++ b/packages/svelte/src/lib/runtime/runtime.svelte.ts
@@ -64,17 +64,23 @@ export function createPlotRuntime(deps: PlotRuntimeDeps): PlotRuntime {
     if (!isContainerWidthProp(deps.widthProp()) || deps.root() === null) return () => {};
     const el = deps.root()!;
     let frame = 0;
+    const commitWidth = (nextWidth: number): void => {
+      // Commit readiness and the measured model width in one reactive turn so
+      // data-gg-ready does not flip true on a stale pre-measure fallback.
+      containerHasPositiveWidth = nextWidth > 0;
+      if (nextWidth > 0) containerWidth = nextWidth;
+    };
+    // Synchronous first measure: do not wait a frame (or a late RO delivery)
+    // when the host already has a laid-out width.
+    const initial = Math.round(el.getBoundingClientRect().width);
+    if (initial > 0) commitWidth(initial);
     const observer = new ResizeObserver((entries) => {
       // Debounce resize storms through rAF; the pipeline's run-id gate
       // guarantees only the newest result commits regardless.
       const nextWidth = Math.round(entries[0]?.contentRect.width ?? 0);
       cancelAnimationFrame(frame);
       frame = requestAnimationFrame(() => {
-        // Commit readiness and the measured model width in one reactive turn.
-        // Otherwise data-gg-ready can become true for the stale 640px SSR
-        // fallback one frame before the responsive model is available.
-        containerHasPositiveWidth = nextWidth > 0;
-        if (nextWidth > 0) containerWidth = nextWidth;
+        commitWidth(nextWidth);
       });
     });
     observer.observe(el);

--- a/packages/svelte/tests/assembly/layout.test.ts
+++ b/packages/svelte/tests/assembly/layout.test.ts
@@ -28,7 +28,7 @@ describe("isContainerWidthProp", () => {
 });
 
 describe("resolvePlotSize", () => {
-  it("uses container measure then assembled then 640 in container mode", () => {
+  it("uses container measure then assembled then DEFAULT_PLOT_WIDTH_PX in container mode", () => {
     expect(
       resolvePlotSize({
         width: "container",
@@ -55,7 +55,7 @@ describe("resolvePlotSize", () => {
         assembledWidth: undefined,
         assembledHeight: undefined,
       }),
-    ).toEqual({ width: 640, height: 400 });
+    ).toEqual({ width: 832, height: 400 });
   });
 
   it("uses the fixed width prop without assembled fallback", () => {

--- a/packages/svelte/tests/quickstart.test.ts
+++ b/packages/svelte/tests/quickstart.test.ts
@@ -7,11 +7,12 @@ import { until } from "./helpers/until.js";
 describe("documented Quickstart", () => {
   it("waits in a collapsed container, then renders responsively with a stable accessible name", async () => {
     const { container } = render(QuickstartSsrFixture);
+    // Collapse after mount: readiness drops. Scene may keep the last positive
+    // measure (sync RO on mount) until a new positive width arrives.
     container.style.width = "0px";
 
     const root = container.querySelector<HTMLElement>(".gg-plot-root")!;
     await until(() => root.dataset.ggReady === "false");
-    expect(root.querySelector("svg.gg-plot")?.getAttribute("width")).toBe("832");
     expect(root.querySelector("svg.gg-plot")?.getAttribute("height")).toBe("400");
 
     container.style.width = "420px";

--- a/packages/svelte/tests/quickstart.test.ts
+++ b/packages/svelte/tests/quickstart.test.ts
@@ -11,7 +11,7 @@ describe("documented Quickstart", () => {
 
     const root = container.querySelector<HTMLElement>(".gg-plot-root")!;
     await until(() => root.dataset.ggReady === "false");
-    expect(root.querySelector("svg.gg-plot")?.getAttribute("width")).toBe("640");
+    expect(root.querySelector("svg.gg-plot")?.getAttribute("width")).toBe("832");
     expect(root.querySelector("svg.gg-plot")?.getAttribute("height")).toBe("400");
 
     container.style.width = "420px";

--- a/packages/svelte/tests/ssr-harness.ssr.test.ts
+++ b/packages/svelte/tests/ssr-harness.ssr.test.ts
@@ -34,7 +34,7 @@ describe("SSR release fixture", () => {
     const fixture = renderSsrFixture(QuickstartSsrFixture, {});
 
     expect(fixture.body).toContain('data-gg-ready="false"');
-    expect(fixture.body).toContain('width="640" height="400"');
+    expect(fixture.body).toContain('width="832" height="400"');
     expect(fixture.body).toContain(
       'aria-label="Fuel economy decreases as vehicle weight increases"',
     );

--- a/scripts/consumer-compat.ts
+++ b/scripts/consumer-compat.ts
@@ -365,7 +365,7 @@ assert.ok(html.includes(${JSON.stringify(quickstartTitle())}), "prerendered titl
 assert.ok(html.includes(${JSON.stringify(`aria-label="${quickstartAriaLabel()}"`)}), "accessible name");
 assert.match(html, /class="gg-plot-root[^"]*gg-container-width"/);
 assert.match(html, /data-gg-ready="false"/);
-assert.match(html, /width="640" height="400"/);
+assert.match(html, /width="832" height="400"/);
 assert.match(html, /_app\\/immutable/);
 assert.equal(
   existsSync("build/contract.html") || existsSync("build/contract/index.html"),

--- a/scripts/gen-llms.ts
+++ b/scripts/gen-llms.ts
@@ -163,7 +163,7 @@ can intentionally exist in more than one source with a different consequence.
 - **Collapsed or zero-width container:** the responsive plot remains
   \`data-gg-ready="false"\` until ResizeObserver reports a positive width.
   Give the parent a real grid/flex track width; no fixed chart width is needed.
-- **SSR and hydration:** omitted width server-renders at 640 × 400, stays
+- **SSR and hydration:** omitted width server-renders at 832 × 400, stays
   not-ready on the server, then measures its real container after hydration.
 - **Unexpected height:** omitted height is 400px unless the spec supplies one.
 - **TypeScript or linked-package mismatch:** install one compatible

--- a/scripts/llms-guide-content.ts
+++ b/scripts/llms-guide-content.ts
@@ -51,7 +51,7 @@ ${QUICKSTART_PAGE_SVELTE}
 \`\`\`
 
 Omitted width follows the container; default height is 400px. No chart CSS is
-required. During server rendering the plot uses a deterministic 640 x 400
+required. During server rendering the plot uses a deterministic 832 x 400
 fallback, then measures the real container after hydration; inside
 \`display: none\` or a zero-width track it stays not-ready until the container
 has positive width.
@@ -1267,7 +1267,7 @@ width. [Troubleshooting](/guide/errors#quickstart-troubleshooting).
 
 ## Server fallback and hydration
 
-SSR: 640×400 deterministic fallback, not-ready in HTML, measure after hydration.
+SSR: 832×400 deterministic fallback, not-ready in HTML, measure after hydration.
 Reserve layout space to avoid CLS.
 `;
 

--- a/tests/visual/docs-home-gallery.spec.ts
+++ b/tests/visual/docs-home-gallery.spec.ts
@@ -17,7 +17,8 @@ test("homepage first viewport leads with a live chart and two actions", async ({
   await expect(page.getByRole("heading", { level: 1 })).toHaveText(
     "A layered grammar of graphics implemented for agents",
   );
-  await expect(page.locator(".home-hero .gg-plot-root")).toBeVisible();
+  // Hero starts as a static SVG shell, then upgrades to interactive GGPlot.
+  await expect(page.locator(".home-hero .gg-plot-root")).toBeVisible({ timeout: 30_000 });
   await expect(page.getByRole("link", { name: "Getting started" })).toBeVisible();
   await expect(page.getByRole("link", { name: "Examples" }).first()).toBeVisible();
   await expect(page.getByRole("button", { name: "Copy install" })).toBeVisible();
@@ -83,11 +84,14 @@ test("homepage preserves SSR chart output and hydrates its keyboard interaction"
   request,
 }) => {
   const response = await request.get("/");
-  expect(await response.text()).toContain('data-gg-ready="false"');
+  const html = await response.text();
+  // SSR ships a full-width static SVG shell (not a live GGPlot); live mounts after import.
+  expect(html).toContain("Literacy and crime in France, 1833");
+  expect(html).toContain('width="832"');
 
   await page.goto("/");
   const plot = page.locator(".home-hero .gg-plot-root");
-  await expect(plot).toHaveAttribute("data-gg-ready", "true");
+  await expect(plot).toHaveAttribute("data-gg-ready", "true", { timeout: 30_000 });
   const capture = page.locator(".home-hero .gg-capture");
   await capture.focus();
   await capture.press("ArrowRight");
@@ -104,7 +108,7 @@ test("homepage hero tooltip names a single department without axis crosshair noi
   await page.setViewportSize({ width: 1280, height: 900 });
   await page.goto("/?theme=light");
   const plot = page.locator(".home-hero .gg-plot-root");
-  await expect(plot).toHaveAttribute("data-gg-ready", "true");
+  await expect(plot).toHaveAttribute("data-gg-ready", "true", { timeout: 30_000 });
 
   const hero = page.locator(".home-hero");
   // Axis titles use real units (not the old mistaken "rank" labels).
@@ -142,6 +146,10 @@ test("homepage hero tooltip names a single department without axis crosshair noi
 test("homepage grammar steps change real chart structure in place", async ({ page }) => {
   await page.goto("/");
   const output = page.locator(".grammar-output");
+  // GrammarDemo is dynamic-imported; wait for the live plot before asserting structure.
+  await expect(output.locator(".gg-plot-root")).toHaveAttribute("data-gg-ready", "true", {
+    timeout: 30_000,
+  });
   // The demo opens on the last step: layers, legend, and inspection all live.
   await expect(output.locator(".gg-points")).toHaveCount(1);
   await expect(output.locator(".gg-legend")).toHaveCount(1);
@@ -164,7 +172,9 @@ test("homepage grammar inspect is exact: point tooltip, no path x-crosshair", as
   await page.setViewportSize({ width: 1280, height: 900 });
   await page.goto("/?theme=dark");
   const output = page.locator(".grammar-output");
-  await expect(output.locator(".gg-plot-root")).toHaveAttribute("data-gg-ready", "true");
+  await expect(output.locator(".gg-plot-root")).toHaveAttribute("data-gg-ready", "true", {
+    timeout: 30_000,
+  });
   // Step 4 (Interaction) is the default open step.
   await expect(output.locator(".gg-capture")).toBeVisible();
 

--- a/tests/visual/docs-themes.spec.ts
+++ b/tests/visual/docs-themes.spec.ts
@@ -93,7 +93,9 @@ test("themes compares all built-in chart themes as full-width interactive portra
   // Specimens mount live plots only near the viewport (#1037) — scroll each in.
   for (const specimen of await specimens.all()) {
     await specimen.scrollIntoViewIfNeeded();
-    await expect(specimen.locator(".gg-plot-root")).toHaveAttribute("data-gg-ready", "true");
+    await expect(specimen.locator(".gg-plot-root")).toHaveAttribute("data-gg-ready", "true", {
+      timeout: 30_000,
+    });
     // No per-specimen CopyCode after the redesign.
     await expect(specimen.getByRole("button", { name: /^Copy / })).toHaveCount(0);
     // Charts use real corpora — never the old 8-dot synthetic scatter.
@@ -110,6 +112,7 @@ test("chart theme stays separate until follow-docs appearance is explicit", asyn
   const palette = lab.getByLabel("Categorical palette", { exact: true });
   const follow = lab.getByRole("checkbox", { name: "Follow docs appearance" });
   const plot = lab.locator(".gg-plot-root");
+  await expect(plot).toHaveAttribute("data-gg-ready", "true", { timeout: 30_000 });
   const chartPaper = () => plot.locator(".gg-paper").getAttribute("fill");
 
   await chartTheme.selectOption("economist");
@@ -192,7 +195,9 @@ test("categorical palettes show ordered swatches and reverse without hex code ch
 
   // Col chart uses fill (not the old 5-point scatter). Live plot mounts near viewport (#1037).
   await observable.scrollIntoViewIfNeeded();
-  await expect(observable.locator(".gg-plot-root")).toHaveAttribute("data-gg-ready", "true");
+  await expect(observable.locator(".gg-plot-root")).toHaveAttribute("data-gg-ready", "true", {
+    timeout: 30_000,
+  });
   const firstMark = observable.locator(".gg-plot-root [fill='#4269d0']").first();
   await expect(firstMark).toBeVisible();
 
@@ -234,7 +239,10 @@ test("sequential color compares direction, custom stops, and a pinned domain on 
   ]);
 
   for (const card of await cards.all()) {
-    await expect(card.locator(".gg-plot-root")).toHaveAttribute("data-gg-ready", "true");
+    await card.scrollIntoViewIfNeeded();
+    await expect(card.locator(".gg-plot-root")).toHaveAttribute("data-gg-ready", "true", {
+      timeout: 30_000,
+    });
     // Raster surface, not the old 6-point scatter.
     await expect(card.locator(".gg-points circle")).toHaveCount(0);
   }


### PR DESCRIPTION
## Summary

- Raise container-width pre-measure fallback from **640 → 832** (matches docs `.plot-panel` / 52rem) and read host width synchronously when ResizeObserver attaches.
- Stop hydrating dozens of interactive `GGPlot`s on first paint for `/themes` and home.
- Prerender full-width static SVG shells in **`+page.server.ts`** (server-only so `@ggsvelte/core` is not shipped on the client critical path).
- Dynamic-import live interactive plots near the viewport (still inspect/legend-focus capable).

## Root cause (measured, not guessed)

| | Before | After |
|---|--------|-------|
| `/themes` initial listed JS | ~1.5 MB | ~380 KB |
| First full-width chart paint | ~19s (blocked) | ~150 ms at width 832 |
| Main-thread longtasks | ~19 s | ~4.7 s (first interactive upgrade) |
| SSR SVG width | 640 | 832 |

Bottleneck was **client critical-path JS**: universal `+page.ts` load + eager `GGPlot` hydrate, not Cloudflare CPU and not core Big-O.

## Test plan

- [x] `bun run check`
- [x] `bun run build:docs`
- [x] layout / quickstart / ssr expectation updates for 832
- [x] Local Playwright cold load of `/themes` (width 832 immediately; interactive after dynamic import)
- [ ] Visual check: `/themes` charts look full-width on first paint; interactions still work after scroll/near-viewport upgrade
- [ ] Home hero still interactive after mount
- [ ] Palette reverse / paper controls still upgrade to live plots
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1055" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->