### PR TITLE
fix(docs): cut docs-themes journey CI cost (#1037)

### DIFF
--- a/apps/docs/src/lib/components/PaletteSpecimen.svelte
+++ b/apps/docs/src/lib/components/PaletteSpecimen.svelte
@@ -8,7 +8,9 @@
     Theme,
   } from "@ggsvelte/svelte";
   import type { CATEGORICAL_SCHEME_NAMES, ThemeName } from "@ggsvelte/spec";
+  import { onMount } from "svelte";
 
+  import { observeNearViewport } from "$lib/near-viewport";
   import { languages } from "$lib/theme-specimens/data";
 
   type CategoricalSchemeName = (typeof CATEGORICAL_SCHEME_NAMES)[number];
@@ -30,9 +32,22 @@
   } = $props();
 
   const displayColors = $derived(reverse ? colors.toReversed() : colors);
+  const plotHeight = 340;
+
+  /** Mount the live plot only near the viewport (#1037). */
+  let root = $state<HTMLElement | undefined>();
+  let active = $state(false);
+
+  onMount(() => {
+    const el = root;
+    if (el === undefined) return;
+    return observeNearViewport(el, () => {
+      active = true;
+    });
+  });
 </script>
 
-<article class="specimen">
+<article class="specimen" bind:this={root}>
   <header>
     <div>
       <h3>{label}</h3>
@@ -52,24 +67,32 @@
     {/each}
   </ul>
 
-  <div class="plot-panel">
-    <GGPlot
-      data={languages}
-      aes={{ x: "language", y: "respondents", fill: "language" }}
-      inspect={{ mode: "exact" }}
-      height={340}
-      ariaLabel={`${label} palette on ${paperTheme} paper`}
-    >
-      <Theme name={paperTheme} />
-      <Scale value={{ fill: { type: "ordinal", scheme: name, reverse } }} />
-      <Guides value={{ fill: { type: "none" } }} />
-      <Labs
-        title="Spanish Armada squadron tonnage, 1588"
-        x="Squadron"
-        y="Tons"
-      />
-      <GeomCol width={0.75} />
-    </GGPlot>
+  <div class="plot-panel" style:min-height="{plotHeight}px">
+    {#if active}
+      <GGPlot
+        data={languages}
+        aes={{ x: "language", y: "respondents", fill: "language" }}
+        inspect={{ mode: "exact" }}
+        height={plotHeight}
+        ariaLabel={`${label} palette on ${paperTheme} paper`}
+      >
+        <Theme name={paperTheme} />
+        <Scale value={{ fill: { type: "ordinal", scheme: name, reverse } }} />
+        <Guides value={{ fill: { type: "none" } }} />
+        <Labs
+          title="Spanish Armada squadron tonnage, 1588"
+          x="Squadron"
+          y="Tons"
+        />
+        <GeomCol width={0.75} />
+      </GGPlot>
+    {:else}
+      <div
+        class="plot-placeholder"
+        style:height="{plotHeight}px"
+        aria-hidden="true"
+      ></div>
+    {/if}
   </div>
 </article>
 
@@ -123,5 +146,11 @@
   .plot-panel {
     width: min(100%, 52rem);
     min-width: 0;
+  }
+
+  .plot-placeholder {
+    width: 100%;
+    border-radius: 0.25rem;
+    background: color-mix(in srgb, var(--line) 55%, transparent);
   }
 </style>

--- a/apps/docs/src/lib/components/ThemeSpecimen.svelte
+++ b/apps/docs/src/lib/components/ThemeSpecimen.svelte
@@ -14,8 +14,10 @@
     Theme,
   } from "@ggsvelte/svelte";
   import type { ThemeName } from "@ggsvelte/spec";
+  import { onMount } from "svelte";
 
   import TemperaturesSpecimen from "$lib/components/TemperaturesSpecimen.svelte";
+  import { observeNearViewport } from "$lib/near-viewport";
   import type {
     SchemeName,
     ThemeSpecimenKind,
@@ -49,182 +51,202 @@
 
   const plotHeight = 380;
   const colorScale = $derived({ type: "ordinal" as const, scheme });
+
+  /** Mount the live plot only near the viewport (#1037). */
+  let root = $state<HTMLElement | undefined>();
+  let active = $state(false);
+
+  onMount(() => {
+    const el = root;
+    if (el === undefined) return;
+    return observeNearViewport(el, () => {
+      active = true;
+    });
+  });
 </script>
 
-<article class="specimen">
+<article class="specimen" bind:this={root}>
   <header>
     <h3>{label}</h3>
     <p class="caption">{caption}</p>
   </header>
 
-  <div class="plot-panel">
-    {#if kind === "temps-line"}
-      <TemperaturesSpecimen
-        theme={name}
-        {scheme}
-        height={plotHeight}
-        {legendFocus}
-        ariaLabel={`${label} theme Playfair multi-series`}
-      />
-    {:else if kind === "ridership-line"}
-      <GGPlot
-        data={ridership}
-        aes={{ x: "month", y: "riders", color: "mode" }}
-        key="id"
-        inspect={{ mode: "x" }}
-        {legendFocus}
-        height={plotHeight}
-        ariaLabel={`${label} theme Playfair wheat and wages`}
-      >
-        <Theme {name} />
-        <Scale value={{ color: colorScale }} />
-        <Labs
-          title="Playfair wheat price & weekly wage"
-          x="Year"
-          y="Shillings"
-          color="Series"
+  <div class="plot-panel" style:min-height="{plotHeight}px">
+    {#if active}
+      {#if kind === "temps-line"}
+        <TemperaturesSpecimen
+          theme={name}
+          {scheme}
+          height={plotHeight}
+          {legendFocus}
+          ariaLabel={`${label} theme Playfair multi-series`}
         />
-        <GeomLine linewidth={2} />
-        <GeomPoint size={2.8} />
-      </GGPlot>
-    {:else if kind === "attendees-dodge"}
-      <GGPlot
-        data={attendees}
-        aes={{ x: "track", fill: "level", weight: "deaths" }}
-        key="id"
-        inspect={{ mode: "xy" }}
-        {legendFocus}
-        height={plotHeight}
-        ariaLabel={`${label} theme Edgeworth dodged bars`}
-      >
-        <Theme {name} />
-        <Scale value={{ fill: colorScale }} />
-        <Labs
-          title="Edgeworth county deaths, 1876–82"
-          x="Year"
-          y="Deaths per million"
-          fill="County"
-        />
-        <GeomBar position="dodge" />
-      </GGPlot>
-    {:else if kind === "generation-area"}
-      <GGPlot
-        data={generation}
-        aes={{ x: "year", y: "twh", fill: "source" }}
-        key="id"
-        inspect={{ mode: "x" }}
-        {legendFocus}
-        height={plotHeight}
-        ariaLabel={`${label} theme Nightingale stacked area`}
-      >
-        <Theme {name} />
-        <Scale
-          value={{
-            x: { nice: false },
-            fill: colorScale,
-          }}
-        />
-        <Labs
-          title="Crimean deaths by cause, 1854–56"
-          x="Year"
-          y="Deaths per 1,000 per year"
-          fill="Cause"
-        />
-        <GeomArea alpha={0.9} />
-      </GGPlot>
-    {:else if kind === "long-run-line"}
-      <GGPlot
-        data={longRunSeries}
-        aes={{ x: "year", y: "value" }}
-        inspect={{ mode: "x" }}
-        height={plotHeight}
-        ariaLabel={`${label} theme Bowley exports`}
-      >
-        <Theme {name} />
-        <Labs title="British exports, 1855–1899" x="Year" y="£ millions" />
-        <GeomLine linewidth={1.5} />
-      </GGPlot>
-    {:else if kind === "penguins-scatter"}
-      <GGPlot
-        data={penguins}
-        aes={{ x: "flipper", y: "mass", color: "species" }}
-        key="id"
-        inspect={{ mode: "xy" }}
-        {legendFocus}
-        height={plotHeight}
-        ariaLabel={`${label} theme penguin scatter`}
-      >
-        <Theme {name} />
-        <Scale value={{ color: colorScale }} />
-        <Labs
-          title="Penguin flipper length and body mass"
-          x="Flipper length (mm)"
-          y="Body mass (g)"
-          color="Species"
-        />
-        <GeomPoint size={3.5} alpha={0.9} />
-      </GGPlot>
-    {:else if kind === "countries-scatter"}
-      <GGPlot
-        data={countries}
-        aes={{ x: "gdp", y: "lifeExp", color: "region" }}
-        key="country"
-        inspect={{ mode: "xy" }}
-        {legendFocus}
-        height={plotHeight}
-        ariaLabel={`${label} theme cholera density scatter`}
-      >
-        <Theme {name} />
-        <Scale
-          value={{
-            ...scaleXLog10({ labels: "~s" }),
-            color: colorScale,
-          }}
-        />
-        <Labs
-          title="Cholera death rate vs density, 1849"
-          x="People per acre (log scale)"
-          y="Death rate per 10,000"
-          color="Water supply"
-        />
-        <GeomPoint size={3.5} />
-        <GeomSmooth method="lm" se={false} />
-      </GGPlot>
-    {:else if kind === "revenue-cols"}
-      <GGPlot
-        data={revenue}
-        aes={{ x: "quarter", y: "amount" }}
-        inspect={{ mode: "xy" }}
-        height={plotHeight}
-        ariaLabel={`${label} theme Salk trial columns`}
-      >
-        <Theme {name} />
-        <Labs
-          title="Salk trial paralytic polio rates"
-          x="Group"
-          y="Cases per 100,000"
-        />
-        <GeomCol width={0.7} />
-        <GeomText aes={{ label: "label" }} dy={-8} size={11} />
-      </GGPlot>
+      {:else if kind === "ridership-line"}
+        <GGPlot
+          data={ridership}
+          aes={{ x: "month", y: "riders", color: "mode" }}
+          key="id"
+          inspect={{ mode: "x" }}
+          {legendFocus}
+          height={plotHeight}
+          ariaLabel={`${label} theme Playfair wheat and wages`}
+        >
+          <Theme {name} />
+          <Scale value={{ color: colorScale }} />
+          <Labs
+            title="Playfair wheat price & weekly wage"
+            x="Year"
+            y="Shillings"
+            color="Series"
+          />
+          <GeomLine linewidth={2} />
+          <GeomPoint size={2.8} />
+        </GGPlot>
+      {:else if kind === "attendees-dodge"}
+        <GGPlot
+          data={attendees}
+          aes={{ x: "track", fill: "level", weight: "deaths" }}
+          key="id"
+          inspect={{ mode: "xy" }}
+          {legendFocus}
+          height={plotHeight}
+          ariaLabel={`${label} theme Edgeworth dodged bars`}
+        >
+          <Theme {name} />
+          <Scale value={{ fill: colorScale }} />
+          <Labs
+            title="Edgeworth county deaths, 1876–82"
+            x="Year"
+            y="Deaths per million"
+            fill="County"
+          />
+          <GeomBar position="dodge" />
+        </GGPlot>
+      {:else if kind === "generation-area"}
+        <GGPlot
+          data={generation}
+          aes={{ x: "year", y: "twh", fill: "source" }}
+          key="id"
+          inspect={{ mode: "x" }}
+          {legendFocus}
+          height={plotHeight}
+          ariaLabel={`${label} theme Nightingale stacked area`}
+        >
+          <Theme {name} />
+          <Scale
+            value={{
+              x: { nice: false },
+              fill: colorScale,
+            }}
+          />
+          <Labs
+            title="Crimean deaths by cause, 1854–56"
+            x="Year"
+            y="Deaths per 1,000 per year"
+            fill="Cause"
+          />
+          <GeomArea alpha={0.9} />
+        </GGPlot>
+      {:else if kind === "long-run-line"}
+        <GGPlot
+          data={longRunSeries}
+          aes={{ x: "year", y: "value" }}
+          inspect={{ mode: "x" }}
+          height={plotHeight}
+          ariaLabel={`${label} theme Bowley exports`}
+        >
+          <Theme {name} />
+          <Labs title="British exports, 1855–1899" x="Year" y="£ millions" />
+          <GeomLine linewidth={1.5} />
+        </GGPlot>
+      {:else if kind === "penguins-scatter"}
+        <GGPlot
+          data={penguins}
+          aes={{ x: "flipper", y: "mass", color: "species" }}
+          key="id"
+          inspect={{ mode: "xy" }}
+          {legendFocus}
+          height={plotHeight}
+          ariaLabel={`${label} theme penguin scatter`}
+        >
+          <Theme {name} />
+          <Scale value={{ color: colorScale }} />
+          <Labs
+            title="Penguin flipper length and body mass"
+            x="Flipper length (mm)"
+            y="Body mass (g)"
+            color="Species"
+          />
+          <GeomPoint size={3.5} alpha={0.9} />
+        </GGPlot>
+      {:else if kind === "countries-scatter"}
+        <GGPlot
+          data={countries}
+          aes={{ x: "gdp", y: "lifeExp", color: "region" }}
+          key="country"
+          inspect={{ mode: "xy" }}
+          {legendFocus}
+          height={plotHeight}
+          ariaLabel={`${label} theme cholera density scatter`}
+        >
+          <Theme {name} />
+          <Scale
+            value={{
+              ...scaleXLog10({ labels: "~s" }),
+              color: colorScale,
+            }}
+          />
+          <Labs
+            title="Cholera death rate vs density, 1849"
+            x="People per acre (log scale)"
+            y="Death rate per 10,000"
+            color="Water supply"
+          />
+          <GeomPoint size={3.5} />
+          <GeomSmooth method="lm" se={false} />
+        </GGPlot>
+      {:else if kind === "revenue-cols"}
+        <GGPlot
+          data={revenue}
+          aes={{ x: "quarter", y: "amount" }}
+          inspect={{ mode: "xy" }}
+          height={plotHeight}
+          ariaLabel={`${label} theme Salk trial columns`}
+        >
+          <Theme {name} />
+          <Labs
+            title="Salk trial paralytic polio rates"
+            x="Group"
+            y="Cases per 100,000"
+          />
+          <GeomCol width={0.7} />
+          <GeomText aes={{ label: "label" }} dy={-8} size={11} />
+        </GGPlot>
+      {:else}
+        <GGPlot
+          data={cities}
+          aes={{ x: "rent", y: "livability" }}
+          inspect={{ mode: "xy" }}
+          height={plotHeight}
+          ariaLabel={`${label} theme Langren longitude labels`}
+        >
+          <Theme {name} />
+          <Scale value={{ x: { labels: ".1f" } }} />
+          <Labs
+            title="Van Langren longitude estimates, 1644"
+            x="Toledo–Rome longitude (°)"
+            y="Estimate rank"
+          />
+          <GeomPoint size={3} />
+          <GeomText aes={{ label: "city" }} dy={-9} size={10} />
+        </GGPlot>
+      {/if}
     {:else}
-      <GGPlot
-        data={cities}
-        aes={{ x: "rent", y: "livability" }}
-        inspect={{ mode: "xy" }}
-        height={plotHeight}
-        ariaLabel={`${label} theme Langren longitude labels`}
-      >
-        <Theme {name} />
-        <Scale value={{ x: { labels: ".1f" } }} />
-        <Labs
-          title="Van Langren longitude estimates, 1644"
-          x="Toledo–Rome longitude (°)"
-          y="Estimate rank"
-        />
-        <GeomPoint size={3} />
-        <GeomText aes={{ label: "city" }} dy={-9} size={10} />
-      </GGPlot>
+      <div
+        class="plot-placeholder"
+        style:height="{plotHeight}px"
+        aria-hidden="true"
+      ></div>
     {/if}
   </div>
 </article>
@@ -257,5 +279,11 @@
   .plot-panel {
     width: min(100%, 52rem);
     min-width: 0;
+  }
+
+  .plot-placeholder {
+    width: 100%;
+    border-radius: 0.25rem;
+    background: color-mix(in srgb, var(--line) 55%, transparent);
   }
 </style>

--- a/apps/docs/src/lib/near-viewport.ts
+++ b/apps/docs/src/lib/near-viewport.ts
@@ -1,0 +1,43 @@
+/**
+ * Fire `onNear` once when `target` is near the viewport, then disconnect.
+ *
+ * Used to defer heavy live charts (theme/palette specimens) so first paint
+ * and above-the-fold work stay cheap (#1037). Mirrors the getting-started
+ * near-viewport load pattern (#972): no idle-load, only intersection.
+ *
+ * When `IntersectionObserver` is missing, fires immediately so SSR/test
+ * environments without IO still mount content.
+ */
+export function observeNearViewport(
+  target: Element,
+  onNear: () => void,
+  options?: { rootMargin?: string },
+): () => void {
+  const rootMargin = options?.rootMargin ?? "240px 0px";
+
+  if (typeof IntersectionObserver === "undefined") {
+    onNear();
+    return () => {};
+  }
+
+  let done = false;
+  const fire = (): void => {
+    if (done) return;
+    done = true;
+    onNear();
+    io.disconnect();
+  };
+
+  const io = new IntersectionObserver(
+    (entries) => {
+      if (entries.some((entry) => entry.isIntersecting)) fire();
+    },
+    { rootMargin },
+  );
+  io.observe(target);
+
+  return () => {
+    done = true;
+    io.disconnect();
+  };
+}

--- a/scripts/near-viewport.test.ts
+++ b/scripts/near-viewport.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, it } from "bun:test";
+
+import { observeNearViewport } from "../apps/docs/src/lib/near-viewport.ts";
+
+type ObserverCallback = (entries: Array<{ isIntersecting: boolean }>) => void;
+
+const originalIO = globalThis.IntersectionObserver;
+
+afterEach(() => {
+  globalThis.IntersectionObserver = originalIO;
+});
+
+describe("observeNearViewport", () => {
+  it("fires immediately when IntersectionObserver is unavailable", () => {
+    // @ts-expect-error intentional removal for the no-IO path
+    delete globalThis.IntersectionObserver;
+    const target = {} as Element;
+    let calls = 0;
+    const stop = observeNearViewport(target, () => {
+      calls += 1;
+    });
+    expect(calls).toBe(1);
+    stop();
+    expect(calls).toBe(1);
+  });
+
+  it("observes the target and fires once when it intersects", () => {
+    let observed: Element | null = null;
+    let callback: ObserverCallback | null = null;
+    let disconnected = 0;
+    let observedRootMargin: string | undefined;
+
+    globalThis.IntersectionObserver = class {
+      constructor(cb: IntersectionObserverCallback, options?: IntersectionObserverInit) {
+        callback = cb as unknown as ObserverCallback;
+        observedRootMargin = options?.rootMargin;
+      }
+      observe(el: Element): void {
+        observed = el;
+      }
+      disconnect(): void {
+        disconnected += 1;
+      }
+      unobserve(): void {}
+      takeRecords(): IntersectionObserverEntry[] {
+        return [];
+      }
+      readonly root = null;
+      readonly rootMargin = "";
+      readonly thresholds = [];
+    } as unknown as typeof IntersectionObserver;
+
+    const target = { id: "specimen" } as unknown as Element;
+    let calls = 0;
+    const stop = observeNearViewport(target, () => {
+      calls += 1;
+    });
+
+    expect(observed).toBe(target);
+    expect(observedRootMargin).toBe("240px 0px");
+    expect(calls).toBe(0);
+
+    callback?.([{ isIntersecting: false }]);
+    expect(calls).toBe(0);
+
+    callback?.([{ isIntersecting: true }]);
+    expect(calls).toBe(1);
+    expect(disconnected).toBe(1);
+
+    // Second intersect is a no-op (already fired + disconnected).
+    callback?.([{ isIntersecting: true }]);
+    expect(calls).toBe(1);
+
+    stop();
+  });
+
+  it("accepts a custom rootMargin and cleans up on stop before fire", () => {
+    let disconnected = 0;
+    let observedRootMargin: string | undefined;
+
+    globalThis.IntersectionObserver = class {
+      constructor(_cb: IntersectionObserverCallback, options?: IntersectionObserverInit) {
+        observedRootMargin = options?.rootMargin;
+      }
+      observe(): void {}
+      disconnect(): void {
+        disconnected += 1;
+      }
+      unobserve(): void {}
+      takeRecords(): IntersectionObserverEntry[] {
+        return [];
+      }
+      readonly root = null;
+      readonly rootMargin = "";
+      readonly thresholds = [];
+    } as unknown as typeof IntersectionObserver;
+
+    let calls = 0;
+    const stop = observeNearViewport(
+      {} as Element,
+      () => {
+        calls += 1;
+      },
+      { rootMargin: "100px 0px" },
+    );
+    expect(observedRootMargin).toBe("100px 0px");
+    stop();
+    expect(disconnected).toBe(1);
+    expect(calls).toBe(0);
+  });
+});

--- a/scripts/near-viewport.test.ts
+++ b/scripts/near-viewport.test.ts
@@ -10,6 +10,33 @@ afterEach(() => {
   globalThis.IntersectionObserver = originalIO;
 });
 
+function installMockIO(state: {
+  observed: Element | null;
+  callback: ObserverCallback | null;
+  disconnected: number;
+  rootMargin: string | undefined;
+}): void {
+  globalThis.IntersectionObserver = class {
+    constructor(cb: IntersectionObserverCallback, options?: IntersectionObserverInit) {
+      state.callback = cb as unknown as ObserverCallback;
+      state.rootMargin = options?.rootMargin;
+    }
+    observe(el: Element): void {
+      state.observed = el;
+    }
+    disconnect(): void {
+      state.disconnected += 1;
+    }
+    unobserve(): void {}
+    takeRecords(): IntersectionObserverEntry[] {
+      return [];
+    }
+    readonly root = null;
+    readonly rootMargin = "";
+    readonly thresholds = [];
+  } as unknown as typeof IntersectionObserver;
+}
+
 describe("observeNearViewport", () => {
   it("fires immediately when IntersectionObserver is unavailable", () => {
     // @ts-expect-error intentional removal for the no-IO path
@@ -25,30 +52,13 @@ describe("observeNearViewport", () => {
   });
 
   it("observes the target and fires once when it intersects", () => {
-    let observed: Element | null = null;
-    let callback: ObserverCallback | null = null;
-    let disconnected = 0;
-    let observedRootMargin: string | undefined;
-
-    globalThis.IntersectionObserver = class {
-      constructor(cb: IntersectionObserverCallback, options?: IntersectionObserverInit) {
-        callback = cb as unknown as ObserverCallback;
-        observedRootMargin = options?.rootMargin;
-      }
-      observe(el: Element): void {
-        observed = el;
-      }
-      disconnect(): void {
-        disconnected += 1;
-      }
-      unobserve(): void {}
-      takeRecords(): IntersectionObserverEntry[] {
-        return [];
-      }
-      readonly root = null;
-      readonly rootMargin = "";
-      readonly thresholds = [];
-    } as unknown as typeof IntersectionObserver;
+    const state = {
+      observed: null as Element | null,
+      callback: null as ObserverCallback | null,
+      disconnected: 0,
+      rootMargin: undefined as string | undefined,
+    };
+    installMockIO(state);
 
     const target = { id: "specimen" } as unknown as Element;
     let calls = 0;
@@ -56,44 +66,33 @@ describe("observeNearViewport", () => {
       calls += 1;
     });
 
-    expect(observed).toBe(target);
-    expect(observedRootMargin).toBe("240px 0px");
+    expect(state.observed).toBe(target);
+    expect(state.rootMargin).toBe("240px 0px");
+    expect(calls).toBe(0);
+    expect(state.callback).not.toBeNull();
+
+    state.callback?.([{ isIntersecting: false }]);
     expect(calls).toBe(0);
 
-    callback?.([{ isIntersecting: false }]);
-    expect(calls).toBe(0);
-
-    callback?.([{ isIntersecting: true }]);
+    state.callback?.([{ isIntersecting: true }]);
     expect(calls).toBe(1);
-    expect(disconnected).toBe(1);
+    expect(state.disconnected).toBe(1);
 
     // Second intersect is a no-op (already fired + disconnected).
-    callback?.([{ isIntersecting: true }]);
+    state.callback?.([{ isIntersecting: true }]);
     expect(calls).toBe(1);
 
     stop();
   });
 
   it("accepts a custom rootMargin and cleans up on stop before fire", () => {
-    let disconnected = 0;
-    let observedRootMargin: string | undefined;
-
-    globalThis.IntersectionObserver = class {
-      constructor(_cb: IntersectionObserverCallback, options?: IntersectionObserverInit) {
-        observedRootMargin = options?.rootMargin;
-      }
-      observe(): void {}
-      disconnect(): void {
-        disconnected += 1;
-      }
-      unobserve(): void {}
-      takeRecords(): IntersectionObserverEntry[] {
-        return [];
-      }
-      readonly root = null;
-      readonly rootMargin = "";
-      readonly thresholds = [];
-    } as unknown as typeof IntersectionObserver;
+    const state = {
+      observed: null as Element | null,
+      callback: null as ObserverCallback | null,
+      disconnected: 0,
+      rootMargin: undefined as string | undefined,
+    };
+    installMockIO(state);
 
     let calls = 0;
     const stop = observeNearViewport(
@@ -103,9 +102,9 @@ describe("observeNearViewport", () => {
       },
       { rootMargin: "100px 0px" },
     );
-    expect(observedRootMargin).toBe("100px 0px");
+    expect(state.rootMargin).toBe("100px 0px");
     stop();
-    expect(disconnected).toBe(1);
+    expect(state.disconnected).toBe(1);
     expect(calls).toBe(0);
   });
 });

--- a/tests/visual/docs-themes.spec.ts
+++ b/tests/visual/docs-themes.spec.ts
@@ -90,7 +90,9 @@ test("themes compares all built-in chart themes as full-width interactive portra
     "Test",
   ]);
 
+  // Specimens mount live plots only near the viewport (#1037) — scroll each in.
   for (const specimen of await specimens.all()) {
+    await specimen.scrollIntoViewIfNeeded();
     await expect(specimen.locator(".gg-plot-root")).toHaveAttribute("data-gg-ready", "true");
     // No per-specimen CopyCode after the redesign.
     await expect(specimen.getByRole("button", { name: /^Copy / })).toHaveCount(0);
@@ -188,7 +190,8 @@ test("categorical palettes show ordered swatches and reverse without hex code ch
   await expect(swatches.last()).toHaveAttribute("aria-label", "10: #9498a0");
   await expect(swatches.first().locator("code")).toHaveCount(0);
 
-  // Col chart uses fill (not the old 5-point scatter).
+  // Col chart uses fill (not the old 5-point scatter). Live plot mounts near viewport (#1037).
+  await observable.scrollIntoViewIfNeeded();
   await expect(observable.locator(".gg-plot-root")).toHaveAttribute("data-gg-ready", "true");
   const firstMark = observable.locator(".gg-plot-root [fill='#4269d0']").first();
   await expect(firstMark).toBeVisible();
@@ -252,31 +255,40 @@ test("sequential color compares direction, custom stops, and a pinned domain on 
   await expect(region.locator(".copy-code code")).toContainText("GeomRaster");
 });
 
-for (const width of [375, 768, 1024, 1280, 1600]) {
-  test(`themes has no horizontal overflow at ${String(width)}px`, async ({ page }) => {
-    await page.setViewportSize({ width, height: 900 });
-    await page.goto("/themes?theme=light");
-    // Wait for the themes specimen list so layout is past first paint/fonts;
-    // a one-shot scrollWidth check races chart/font settling on CI.
-    await expect(page.getByRole("list", { name: "Built-in chart themes" })).toBeVisible();
-    await page.waitForFunction(
-      () => document.documentElement.scrollWidth <= window.innerWidth,
-      undefined,
-      { timeout: 10_000 },
-    );
-  });
+// One navigation per page, then resize — five separate gotos re-hydrated every
+// theme/palette portrait (~38s each on CI). Shared load keeps the five-width
+// contract without reloading the heavy page (#1037).
+const OVERFLOW_WIDTHS = [375, 768, 1024, 1280, 1600] as const;
 
-  test(`palettes has no horizontal overflow at ${String(width)}px`, async ({ page }) => {
+test("themes has no horizontal overflow at all five widths", async ({ page }) => {
+  await page.goto("/themes?theme=light");
+  // Wait for the themes specimen list so layout is past first paint/fonts;
+  // a one-shot scrollWidth check races chart/font settling on CI.
+  await expect(page.getByRole("list", { name: "Built-in chart themes" })).toBeVisible();
+
+  for (const width of OVERFLOW_WIDTHS) {
     await page.setViewportSize({ width, height: 900 });
-    await page.goto("/palettes?theme=light");
-    await expect(page.getByRole("list", { name: "Categorical palettes" })).toBeVisible();
     await page.waitForFunction(
       () => document.documentElement.scrollWidth <= window.innerWidth,
       undefined,
       { timeout: 10_000 },
     );
-  });
-}
+  }
+});
+
+test("palettes has no horizontal overflow at all five widths", async ({ page }) => {
+  await page.goto("/palettes?theme=light");
+  await expect(page.getByRole("list", { name: "Categorical palettes" })).toBeVisible();
+
+  for (const width of OVERFLOW_WIDTHS) {
+    await page.setViewportSize({ width, height: 900 });
+    await page.waitForFunction(
+      () => document.documentElement.scrollWidth <= window.innerWidth,
+      undefined,
+      { timeout: 10_000 },
+    );
+  }
+});
 
 test("themes controls remain legible in forced colors with reduced motion", async ({ page }) => {
   await page.emulateMedia({ forcedColors: "active", reducedMotion: "reduce" });


### PR DESCRIPTION
## Summary

`docs-themes` was 52% of journey CI time (503s in 14 tests). Root cause: every `/themes` load hydrated all 16 interactive theme portraits, and the five overflow tests each did a full reload (~38s each).

1. **Defer offscreen specimens** — `ThemeSpecimen` and `PaletteSpecimen` mount live plots only near the viewport via `observeNearViewport` (same pattern as getting-started #972). Placeholders keep layout height for overflow checks.
2. **One page load for five widths** — overflow journeys navigate once, then resize, so the five-width contract stays without five heavy reloads.

Local wall clock for the whole `docs-themes` journeys file: ~26s (was hundreds of seconds of serial test time on CI).

## Test plan

- [x] `bun test scripts/near-viewport.test.ts` — IntersectionObserver helper contract
- [x] `bun test scripts/themes-page.test.ts` — catalog unchanged
- [x] Rebuild docs + `playwright test --project=journeys docs-themes.spec.ts` — 12 passed
- [ ] CI `component-journeys` worst shard within ~2x of fastest (acceptance from #1037)

Closes #1037

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1056" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->