### PR TITLE
fix(inspect): drop duplicate columns from default tooltips

### DIFF
--- a/.changeset/tooltip-dedupe-identical-fields.md
+++ b/.changeset/tooltip-dedupe-identical-fields.md
@@ -1,0 +1,15 @@
+---
+"@ggsvelte/svelte": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+fix(inspect): drop duplicate columns from default tooltips
+
+When fill or color remaps the same column as a position channel (common on
+categorical bars: `aes(x = cat, fill = cat)`), the default tooltip listed that
+column twice — once under the labs title and again under the raw field name.
+Default tooltips now keep the first row per column name, matching a11y
+live-text. Distinct color/fill columns still appear.
+
+Migration: none

--- a/packages/svelte/src/lib/inspection/display-members.ts
+++ b/packages/svelte/src/lib/inspection/display-members.ts
@@ -100,13 +100,25 @@ export function tooltipFieldLabel(
  * Fields shown in the default tooltip body for a member (#754).
  * Axis-mode inspections already print the shared axis value as a header, so
  * repeating the matching channel under every member is pure noise.
+ *
+ * Also drops later channels that re-list the same column name. Position
+ * channels are listed first in layer field maps, so `aes(x = cat, fill = cat)`
+ * on categorical bars keeps the x row (labs-titled) and drops the fill echo.
+ * A11y live-text already dedupes by field name in `labels.ts`; default
+ * tooltips match that contract so paint-only remaps never invent a third row.
  */
 export function fieldsForDefaultTooltip(
   fields: readonly TooltipField[],
   mode: "exact" | "xy" | "x" | "y",
 ): readonly TooltipField[] {
-  if (mode !== "x" && mode !== "y") return fields;
-  return fields.filter((field) => field.channel !== mode);
+  const withoutAxis =
+    mode === "x" || mode === "y" ? fields.filter((field) => field.channel !== mode) : fields;
+  const seenColumns = new Set<string>();
+  return withoutAxis.filter((field) => {
+    if (seenColumns.has(field.field)) return false;
+    seenColumns.add(field.field);
+    return true;
+  });
 }
 
 /**

--- a/packages/svelte/tests/inspection/display-members.test.ts
+++ b/packages/svelte/tests/inspection/display-members.test.ts
@@ -116,6 +116,27 @@ describe("fieldsForDefaultTooltip (#754)", () => {
     expect(fieldsForDefaultTooltip(fields, "exact")).toEqual(fields);
     expect(fieldsForDefaultTooltip(fields, "xy")).toEqual(fields);
   });
+
+  it("collapses later channels that re-list the same column (aes x=cat, fill=cat)", () => {
+    // Palette-style bars: fill maps the category column for paint only.
+    // A11y live-text already dedupes by field name; default tooltips must too
+    // so users never see a third row repeating Squadron under "language".
+    const barFields = [
+      field("x", "language", "Hulks"),
+      field("y", "respondents", 10271),
+      field("fill", "language", "Hulks"),
+    ];
+    const exact = fieldsForDefaultTooltip(barFields, "exact");
+    expect(exact.map((f) => f.channel)).toEqual(["x", "y"]);
+    expect(exact.map((f) => f.field)).toEqual(["language", "respondents"]);
+
+    // Distinct columns stay even when values happen to match.
+    const distinct = [field("x", "name", "Adelie"), field("color", "species", "Adelie")];
+    expect(fieldsForDefaultTooltip(distinct, "exact").map((f) => f.field)).toEqual([
+      "name",
+      "species",
+    ]);
+  });
 });
 
 describe("tooltipDisplayPayloadToken", () => {


### PR DESCRIPTION
## Summary

Default tooltips on categorical bar charts with `aes(x = cat, fill = cat)` listed the category column twice: once under the labs title (e.g. Squadron) and again under the raw field name (e.g. language). That showed up on every chart on `/palettes`.

**Root cause:** `fieldsForDefaultTooltip` returned every mapped channel. Layer field maps push position channels before color/fill, so fill remapping the same column as x became a second row. A11y live-text in `labels.ts` already deduped by field name; the visual tooltip did not.

**Fix:** Collapse later channels that re-list a column already shown. Position channels keep their labs-titled row; paint-only remaps drop out.

## Test plan

- [x] RED: unit test for `aes(x=cat, fill=cat)` fails without the fix
- [x] GREEN: `bun x vitest run tests/inspection/display-members.test.ts --project chromium` — 21 passed
- [ ] Hover a categorical bar on `/palettes` — tooltip shows Squadron + Tons only (no `language` row)
- [ ] Charts with distinct color/fill columns still show that channel
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1057" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->