### PR TITLE
fix(core): make bind-layer-required exhaustive over NormalizedGeomName (#1042)

### DIFF
--- a/packages/core/src/pipeline/bind-layer-required.ts
+++ b/packages/core/src/pipeline/bind-layer-required.ts
@@ -1,5 +1,11 @@
 /**
  * Required-channel checks for bindLayer by geom/stat.
+ *
+ * Exhaustive over {@link NormalizedGeomName}: a geom with no arm is a compile
+ * error, not a silent "require nothing" fall-through (#1042). Geoms that truly
+ * need no x/y channels (function, abline, map, sf*, blank, qq*) have explicit
+ * empty arms with comments — other channels are enforced elsewhere
+ * (sample / map_id / label in bind-layer-extras, geometry in frame-stats-sf).
  */
 import type { NormalizedGeomName, StatName } from "@ggsvelte/spec";
 
@@ -48,92 +54,141 @@ export function assertRequiredChannels(input: {
     rugSides,
   } = input;
 
-  if (
-    geom === "point" ||
-    geom === "count" ||
-    geom === "line" ||
-    geom === "path" ||
-    geom === "step" ||
-    geom === "col" ||
-    geom === "area" ||
-    geom === "polygon" ||
-    geom === "text" ||
-    geom === "label" ||
-    geom === "smooth" ||
-    geom === "quantile" ||
-    geom === "boxplot" ||
-    geom === "violin" ||
-    geom === "tile" ||
-    geom === "raster" ||
-    geom === "hex" ||
-    geom === "density_2d" ||
-    geom === "density_2d_filled" ||
-    geom === "bin_2d"
-  ) {
-    requireField(xField, "x", index, geom);
-    // yStatColumn set (e.g. ecdf) means y is computed — skip field requirement.
-    if (yStatColumn === null) requireField(yField, "y", index, geom);
-  }
-  if (geom === "bar" || geom === "density" || geom === "contour" || geom === "dotplot")
-    requireField(xField, "x", index, geom);
-  if (geom === "contour") {
-    requireField(yField, "y", index, geom);
-  }
-  if (geom === "errorbar" || geom === "linerange" || geom === "pointrange" || geom === "crossbar") {
-    requireField(xField, "x", index, geom);
-    if (stat === "summary" || stat === "summary_bin") {
-      requireField(yField, "y", index, geom);
-    } else {
-      requireField(yminField, "ymin", index, geom);
-      requireField(ymaxField, "ymax", index, geom);
-      if (geom === "pointrange" || geom === "crossbar") {
-        requireField(yField, "y", index, geom);
-      }
-    }
-  }
-  if (geom === "rect") {
-    requireField(xminField, "xmin", index, geom);
-    requireField(xmaxField, "xmax", index, geom);
-    requireField(yminField, "ymin", index, geom);
-    requireField(ymaxField, "ymax", index, geom);
-  }
-  if (geom === "ribbon") {
-    const orientation = ribbonOrientation ?? "x";
-    if (orientation === "x") {
+  switch (geom) {
+    case "point":
+    case "count":
+    case "line":
+    case "path":
+    case "step":
+    case "col":
+    case "area":
+    case "polygon":
+    case "text":
+    case "label":
+    case "smooth":
+    case "quantile":
+    case "boxplot":
+    case "violin":
+    case "tile":
+    case "raster":
+    case "hex":
+    case "density_2d":
+    case "density_2d_filled":
+    case "bin_2d": {
       requireField(xField, "x", index, geom);
-      requireField(yminField, "ymin", index, geom);
-      requireField(ymaxField, "ymax", index, geom);
-    } else {
+      // yStatColumn set (e.g. ecdf) means y is computed — skip field requirement.
+      if (yStatColumn === null) requireField(yField, "y", index, geom);
+      break;
+    }
+    case "bar":
+    case "density":
+    case "dotplot": {
+      requireField(xField, "x", index, geom);
+      break;
+    }
+    case "contour": {
+      requireField(xField, "x", index, geom);
       requireField(yField, "y", index, geom);
+      break;
+    }
+    case "errorbar":
+    case "linerange":
+    case "pointrange":
+    case "crossbar": {
+      requireField(xField, "x", index, geom);
+      if (stat === "summary" || stat === "summary_bin") {
+        requireField(yField, "y", index, geom);
+      } else {
+        requireField(yminField, "ymin", index, geom);
+        requireField(ymaxField, "ymax", index, geom);
+        if (geom === "pointrange" || geom === "crossbar") {
+          requireField(yField, "y", index, geom);
+        }
+      }
+      break;
+    }
+    case "rect": {
       requireField(xminField, "xmin", index, geom);
       requireField(xmaxField, "xmax", index, geom);
+      requireField(yminField, "ymin", index, geom);
+      requireField(ymaxField, "ymax", index, geom);
+      break;
     }
-  }
-  if (geom === "rule" && ruleForm === "vertical") requireField(xField, "x", index, geom);
-  if (geom === "rule" && ruleForm === "horizontal") requireField(yField, "y", index, geom);
-  if (geom === "segment" || geom === "curve") {
-    requireField(xField, "x", index, geom);
-    requireField(yField, "y", index, geom);
-    requireField(xendField, "xend", index, geom);
-    requireField(yendField, "yend", index, geom);
-  }
-  if (geom === "spoke") {
-    requireField(xField, "x", index, geom);
-    requireField(yField, "y", index, geom);
-    const params =
-      typeof layerParams === "object" && layerParams !== null
-        ? (layerParams as Record<string, unknown>)
-        : {};
-    if (angleField === null && params["angle"] === undefined) {
-      requireField(angleField, "angle", index, geom);
+    case "ribbon": {
+      const orientation = ribbonOrientation ?? "x";
+      if (orientation === "x") {
+        requireField(xField, "x", index, geom);
+        requireField(yminField, "ymin", index, geom);
+        requireField(ymaxField, "ymax", index, geom);
+      } else {
+        requireField(yField, "y", index, geom);
+        requireField(xminField, "xmin", index, geom);
+        requireField(xmaxField, "xmax", index, geom);
+      }
+      break;
     }
-    if (radiusField === null && params["radius"] === undefined) {
-      requireField(radiusField, "radius", index, geom);
+    case "rule": {
+      if (ruleForm === "vertical") requireField(xField, "x", index, geom);
+      if (ruleForm === "horizontal") requireField(yField, "y", index, geom);
+      // annotation form: intercepts live on params (resolveRuleForm already ran).
+      break;
     }
-  }
-  if (geom === "rug") {
-    const sides = rugSides !== undefined && rugSides.length > 0 ? rugSides : "bl";
-    if (/[bt]/.test(sides)) requireField(xField, "x", index, geom);
-    if (/[lr]/.test(sides)) requireField(yField, "y", index, geom);
+    case "segment":
+    case "curve": {
+      requireField(xField, "x", index, geom);
+      requireField(yField, "y", index, geom);
+      requireField(xendField, "xend", index, geom);
+      requireField(yendField, "yend", index, geom);
+      break;
+    }
+    case "spoke": {
+      requireField(xField, "x", index, geom);
+      requireField(yField, "y", index, geom);
+      const params =
+        typeof layerParams === "object" && layerParams !== null
+          ? (layerParams as Record<string, unknown>)
+          : {};
+      if (angleField === null && params["angle"] === undefined) {
+        requireField(angleField, "angle", index, geom);
+      }
+      if (radiusField === null && params["radius"] === undefined) {
+        requireField(radiusField, "radius", index, geom);
+      }
+      break;
+    }
+    case "rug": {
+      const sides = rugSides !== undefined && rugSides.length > 0 ? rugSides : "bl";
+      if (/[bt]/.test(sides)) requireField(xField, "x", index, geom);
+      if (/[lr]/.test(sides)) requireField(yField, "y", index, geom);
+      break;
+    }
+    // --- intentional no x/y requirements (channels elsewhere or params) ---
+    case "function":
+      // Domain from params.xlim / peer layers; y from fun (stat_function).
+      break;
+    case "abline":
+      // Annotation slope/intercept params only.
+      break;
+    case "map":
+      // map_id required in bind-layer-extras; geometry from fortified map.
+      break;
+    case "sf":
+    case "sf_text":
+    case "sf_label":
+      // Geometry column in frame-stats-sf; label for text/label in extras.
+      break;
+    case "blank":
+      // Scale training only; no marks.
+      break;
+    case "qq":
+    case "qq_line":
+      // sample channel required in bind-layer-extras.
+      break;
+    default: {
+      // No silent fall-through: a geom with no arm above is a compile error
+      // here, not a layer that quietly requires nothing (#1042).
+      const exhaustive: never = geom;
+      throw new Error(`unhandled geom in required channels: ${String(exhaustive)}`);
+    }
   }
 }

--- a/packages/core/tests/pipeline-bind-required.test.ts
+++ b/packages/core/tests/pipeline-bind-required.test.ts
@@ -37,6 +37,12 @@ const NO_XY_REQUIRED: readonly NormalizedGeomName[] = [
   "qq_line",
 ];
 
+/**
+ * Catalog-walk set: NO_XY_REQUIRED plus rule (annotation form needs no mapped
+ * channel; vertical/horizontal still require an axis — covered separately).
+ */
+const UNCONSTRAINED_ON_NULL_FIELDS: ReadonlySet<string> = new Set([...NO_XY_REQUIRED, "rule"]);
+
 function base(geom: NormalizedGeomName, overrides: Record<string, unknown> = {}) {
   return {
     geom,
@@ -71,149 +77,157 @@ function expectMissingChannel(run: () => void, channel: string): void {
 
 describe("assertRequiredChannels (#1042)", () => {
   it("requires x and y for point when y is not stat-computed", () => {
-    expectMissingChannel(() => assertRequiredChannels(base("point", { yField: "y" })), "x");
-    expectMissingChannel(() => assertRequiredChannels(base("point", { xField: "x" })), "y");
-    expect(() => assertRequiredChannels(base("point", { xField: "x", yField: "y" }))).not.toThrow();
+    expectMissingChannel(() => {
+      assertRequiredChannels(base("point", { yField: "y" }));
+    }, "x");
+    expectMissingChannel(() => {
+      assertRequiredChannels(base("point", { xField: "x" }));
+    }, "y");
+    expect(() => {
+      assertRequiredChannels(base("point", { xField: "x", yField: "y" }));
+    }).not.toThrow();
   });
 
   it("skips y when yStatColumn is set (e.g. ecdf)", () => {
-    expect(() =>
-      assertRequiredChannels(base("point", { xField: "x", yStatColumn: "ecdf" })),
-    ).not.toThrow();
+    expect(() => {
+      assertRequiredChannels(base("point", { xField: "x", yStatColumn: "ecdf" }));
+    }).not.toThrow();
   });
 
   it("requires only x for bar", () => {
-    expectMissingChannel(() => assertRequiredChannels(base("bar")), "x");
-    expect(() => assertRequiredChannels(base("bar", { xField: "g" }))).not.toThrow();
+    expectMissingChannel(() => {
+      assertRequiredChannels(base("bar"));
+    }, "x");
+    expect(() => {
+      assertRequiredChannels(base("bar", { xField: "g" }));
+    }).not.toThrow();
   });
 
   it("requires x and y for contour", () => {
-    expectMissingChannel(() => assertRequiredChannels(base("contour", { yField: "y" })), "x");
-    expectMissingChannel(() => assertRequiredChannels(base("contour", { xField: "x" })), "y");
+    expectMissingChannel(() => {
+      assertRequiredChannels(base("contour", { yField: "y" }));
+    }, "x");
+    expectMissingChannel(() => {
+      assertRequiredChannels(base("contour", { xField: "x" }));
+    }, "y");
   });
 
   it("requires ymin/ymax for errorbar identity form", () => {
-    expectMissingChannel(
-      () => assertRequiredChannels(base("errorbar", { xField: "x", ymaxField: "hi" })),
-      "ymin",
-    );
+    expectMissingChannel(() => {
+      assertRequiredChannels(base("errorbar", { xField: "x", ymaxField: "hi" }));
+    }, "ymin");
   });
 
   it("requires y (not ymin/ymax) for errorbar under summary stats", () => {
-    expectMissingChannel(
-      () => assertRequiredChannels(base("errorbar", { stat: "summary", xField: "x" })),
-      "y",
-    );
-    expect(() =>
-      assertRequiredChannels(base("errorbar", { stat: "summary", xField: "x", yField: "y" })),
-    ).not.toThrow();
+    expectMissingChannel(() => {
+      assertRequiredChannels(base("errorbar", { stat: "summary", xField: "x" }));
+    }, "y");
+    expect(() => {
+      assertRequiredChannels(base("errorbar", { stat: "summary", xField: "x", yField: "y" }));
+    }).not.toThrow();
   });
 
   it("requires edge channels for rect", () => {
-    expectMissingChannel(
-      () =>
-        assertRequiredChannels(
-          base("rect", {
-            xmaxField: "x1",
-            yminField: "y0",
-            ymaxField: "y1",
-          }),
-        ),
-      "xmin",
-    );
+    expectMissingChannel(() => {
+      assertRequiredChannels(
+        base("rect", {
+          xmaxField: "x1",
+          yminField: "y0",
+          ymaxField: "y1",
+        }),
+      );
+    }, "xmin");
   });
 
   it("requires ribbon channels by orientation", () => {
-    expectMissingChannel(
-      () =>
-        assertRequiredChannels(
-          base("ribbon", {
-            ribbonOrientation: "x",
-            yminField: "lo",
-            ymaxField: "hi",
-          }),
-        ),
-      "x",
-    );
-    expectMissingChannel(
-      () =>
-        assertRequiredChannels(
-          base("ribbon", {
-            ribbonOrientation: "y",
-            xminField: "lo",
-            xmaxField: "hi",
-          }),
-        ),
-      "y",
-    );
+    expectMissingChannel(() => {
+      assertRequiredChannels(
+        base("ribbon", {
+          ribbonOrientation: "x",
+          yminField: "lo",
+          ymaxField: "hi",
+        }),
+      );
+    }, "x");
+    expectMissingChannel(() => {
+      assertRequiredChannels(
+        base("ribbon", {
+          ribbonOrientation: "y",
+          xminField: "lo",
+          xmaxField: "hi",
+        }),
+      );
+    }, "y");
   });
 
   it("requires the active axis for data-driven rule forms", () => {
-    expectMissingChannel(() => assertRequiredChannels(base("rule", { ruleForm: "vertical" })), "x");
-    expectMissingChannel(
-      () => assertRequiredChannels(base("rule", { ruleForm: "horizontal" })),
-      "y",
-    );
-    expect(() => assertRequiredChannels(base("rule", { ruleForm: "annotation" }))).not.toThrow();
+    expectMissingChannel(() => {
+      assertRequiredChannels(base("rule", { ruleForm: "vertical" }));
+    }, "x");
+    expectMissingChannel(() => {
+      assertRequiredChannels(base("rule", { ruleForm: "horizontal" }));
+    }, "y");
+    expect(() => {
+      assertRequiredChannels(base("rule", { ruleForm: "annotation" }));
+    }).not.toThrow();
   });
 
   it("requires x/y/xend/yend for segment and curve", () => {
     for (const geom of ["segment", "curve"] as const) {
-      expectMissingChannel(
-        () =>
-          assertRequiredChannels(
-            base(geom, {
-              yField: "y",
-              xendField: "x2",
-              yendField: "y2",
-            }),
-          ),
-        "x",
-      );
+      expectMissingChannel(() => {
+        assertRequiredChannels(
+          base(geom, {
+            yField: "y",
+            xendField: "x2",
+            yendField: "y2",
+          }),
+        );
+      }, "x");
     }
   });
 
   it("requires angle and radius for spoke when params omit them", () => {
-    expectMissingChannel(
-      () =>
-        assertRequiredChannels(
-          base("spoke", {
-            xField: "x",
-            yField: "y",
-            radiusField: "r",
-          }),
-        ),
-      "angle",
-    );
-    expect(() =>
+    expectMissingChannel(() => {
+      assertRequiredChannels(
+        base("spoke", {
+          xField: "x",
+          yField: "y",
+          radiusField: "r",
+        }),
+      );
+    }, "angle");
+    expect(() => {
       assertRequiredChannels(
         base("spoke", {
           xField: "x",
           yField: "y",
           layerParams: { angle: 0, radius: 1 },
         }),
-      ),
-    ).not.toThrow();
+      );
+    }).not.toThrow();
   });
 
   it("requires rug channels from sides", () => {
-    expectMissingChannel(() => assertRequiredChannels(base("rug", { rugSides: "b" })), "x");
-    expectMissingChannel(() => assertRequiredChannels(base("rug", { rugSides: "l" })), "y");
-    expect(() => assertRequiredChannels(base("rug", { rugSides: "b", xField: "x" }))).not.toThrow();
+    expectMissingChannel(() => {
+      assertRequiredChannels(base("rug", { rugSides: "b" }));
+    }, "x");
+    expectMissingChannel(() => {
+      assertRequiredChannels(base("rug", { rugSides: "l" }));
+    }, "y");
+    expect(() => {
+      assertRequiredChannels(base("rug", { rugSides: "b", xField: "x" }));
+    }).not.toThrow();
   });
 
   it("pins the nine geoms that intentionally require no x/y channels", () => {
     for (const geom of NO_XY_REQUIRED) {
-      expect(() => assertRequiredChannels(base(geom))).not.toThrow();
+      expect(() => {
+        assertRequiredChannels(base(geom));
+      }).not.toThrow();
     }
   });
 
   it("every normalized geom either requires a channel or is listed as unconstrained", () => {
-    const unconstrained = new Set<string>(NO_XY_REQUIRED);
-    // Rule annotation form needs no mapped channel (intercepts are params).
-    // Vertical/horizontal rule still require an axis — covered above.
-    unconstrained.add("rule");
-
     for (const geom of normalizedGeoms) {
       try {
         assertRequiredChannels(
@@ -221,8 +235,7 @@ describe("assertRequiredChannels (#1042)", () => {
             // Give rule a form that does not force a channel so the fall-through
             // check still sees annotation-style rule as unconstrained.
             ruleForm: geom === "rule" ? "annotation" : null,
-            // Rug with no sides that need axes would be empty; use sides that
-            // need none by testing the unconstrained list only via throw/no-throw.
+            // Rug with sides that need x so throw/no-throw still classifies it.
             rugSides: geom === "rug" ? "b" : undefined,
           }),
         );
@@ -231,11 +244,11 @@ describe("assertRequiredChannels (#1042)", () => {
           // rug with side b needs x — should have thrown.
           expect.unreachable("rug with sides b should require x");
         }
-        expect(unconstrained.has(geom)).toBe(true);
+        expect(UNCONSTRAINED_ON_NULL_FIELDS.has(geom)).toBe(true);
       } catch (e) {
         expect(e).toBeInstanceOf(PipelineError);
         expect((e as PipelineError).code).toBe("missing-channel");
-        expect(unconstrained.has(geom)).toBe(false);
+        expect(UNCONSTRAINED_ON_NULL_FIELDS.has(geom)).toBe(false);
       }
     }
   });

--- a/packages/core/tests/pipeline-bind-required.test.ts
+++ b/packages/core/tests/pipeline-bind-required.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Required-channel checks for bindLayer by geom (#1042 remainder).
+ *
+ * Before this change `assertRequiredChannels` was an if-chain with no else, so
+ * a geom named in none of the arms required nothing and rendered empty instead
+ * of erroring. The nine post-alias geoms that fall through today do so for
+ * real reasons (params, sample/map_id/geometry, scale training only); those
+ * decisions are pinned here. The switch itself ends in `never`, so a new geom
+ * is a compile error until someone picks an arm.
+ */
+import { describe, expect, it } from "bun:test";
+import { ALIAS_GEOMS, KNOWN_GEOMS, type NormalizedGeomName } from "@ggsvelte/spec";
+
+import { assertRequiredChannels } from "../src/pipeline/bind-layer-required.ts";
+import { PipelineError } from "../src/pipeline/types.ts";
+
+const normalizedGeoms = KNOWN_GEOMS.filter(
+  (geom): geom is NormalizedGeomName => !(ALIAS_GEOMS as readonly string[]).includes(geom),
+);
+
+/** Geoms that intentionally require no x/y (or edge) channels here. */
+const NO_XY_REQUIRED: readonly NormalizedGeomName[] = [
+  // Analytic curve: domain from params.xlim / peer layers; y from fun.
+  "function",
+  // Annotation: slope/intercept params, not mapped channels.
+  "abline",
+  // Region join: map_id + fortified map (checked in bind-layer-extras / frame).
+  "map",
+  // GeoJSON geometry column (checked in frame-stats-sf).
+  "sf",
+  "sf_text",
+  "sf_label",
+  // Scale training only; no marks.
+  "blank",
+  // sample channel (checked in bind-layer-extras); theoretical/sample computed.
+  "qq",
+  "qq_line",
+];
+
+function base(geom: NormalizedGeomName, overrides: Record<string, unknown> = {}) {
+  return {
+    geom,
+    stat: "identity" as const,
+    index: 0,
+    ruleForm: null,
+    xField: null,
+    yField: null,
+    yStatColumn: null,
+    yminField: null,
+    ymaxField: null,
+    xminField: null,
+    xmaxField: null,
+    xendField: null,
+    yendField: null,
+    angleField: null,
+    radiusField: null,
+    ...overrides,
+  };
+}
+
+function expectMissingChannel(run: () => void, channel: string): void {
+  try {
+    run();
+    expect.unreachable(`expected missing-channel for ${channel}`);
+  } catch (e) {
+    expect(e).toBeInstanceOf(PipelineError);
+    expect((e as PipelineError).code).toBe("missing-channel");
+    expect((e as PipelineError).path).toContain(channel);
+  }
+}
+
+describe("assertRequiredChannels (#1042)", () => {
+  it("requires x and y for point when y is not stat-computed", () => {
+    expectMissingChannel(() => assertRequiredChannels(base("point", { yField: "y" })), "x");
+    expectMissingChannel(() => assertRequiredChannels(base("point", { xField: "x" })), "y");
+    expect(() => assertRequiredChannels(base("point", { xField: "x", yField: "y" }))).not.toThrow();
+  });
+
+  it("skips y when yStatColumn is set (e.g. ecdf)", () => {
+    expect(() =>
+      assertRequiredChannels(base("point", { xField: "x", yStatColumn: "ecdf" })),
+    ).not.toThrow();
+  });
+
+  it("requires only x for bar", () => {
+    expectMissingChannel(() => assertRequiredChannels(base("bar")), "x");
+    expect(() => assertRequiredChannels(base("bar", { xField: "g" }))).not.toThrow();
+  });
+
+  it("requires x and y for contour", () => {
+    expectMissingChannel(() => assertRequiredChannels(base("contour", { yField: "y" })), "x");
+    expectMissingChannel(() => assertRequiredChannels(base("contour", { xField: "x" })), "y");
+  });
+
+  it("requires ymin/ymax for errorbar identity form", () => {
+    expectMissingChannel(
+      () => assertRequiredChannels(base("errorbar", { xField: "x", ymaxField: "hi" })),
+      "ymin",
+    );
+  });
+
+  it("requires y (not ymin/ymax) for errorbar under summary stats", () => {
+    expectMissingChannel(
+      () => assertRequiredChannels(base("errorbar", { stat: "summary", xField: "x" })),
+      "y",
+    );
+    expect(() =>
+      assertRequiredChannels(base("errorbar", { stat: "summary", xField: "x", yField: "y" })),
+    ).not.toThrow();
+  });
+
+  it("requires edge channels for rect", () => {
+    expectMissingChannel(
+      () =>
+        assertRequiredChannels(
+          base("rect", {
+            xmaxField: "x1",
+            yminField: "y0",
+            ymaxField: "y1",
+          }),
+        ),
+      "xmin",
+    );
+  });
+
+  it("requires ribbon channels by orientation", () => {
+    expectMissingChannel(
+      () =>
+        assertRequiredChannels(
+          base("ribbon", {
+            ribbonOrientation: "x",
+            yminField: "lo",
+            ymaxField: "hi",
+          }),
+        ),
+      "x",
+    );
+    expectMissingChannel(
+      () =>
+        assertRequiredChannels(
+          base("ribbon", {
+            ribbonOrientation: "y",
+            xminField: "lo",
+            xmaxField: "hi",
+          }),
+        ),
+      "y",
+    );
+  });
+
+  it("requires the active axis for data-driven rule forms", () => {
+    expectMissingChannel(() => assertRequiredChannels(base("rule", { ruleForm: "vertical" })), "x");
+    expectMissingChannel(
+      () => assertRequiredChannels(base("rule", { ruleForm: "horizontal" })),
+      "y",
+    );
+    expect(() => assertRequiredChannels(base("rule", { ruleForm: "annotation" }))).not.toThrow();
+  });
+
+  it("requires x/y/xend/yend for segment and curve", () => {
+    for (const geom of ["segment", "curve"] as const) {
+      expectMissingChannel(
+        () =>
+          assertRequiredChannels(
+            base(geom, {
+              yField: "y",
+              xendField: "x2",
+              yendField: "y2",
+            }),
+          ),
+        "x",
+      );
+    }
+  });
+
+  it("requires angle and radius for spoke when params omit them", () => {
+    expectMissingChannel(
+      () =>
+        assertRequiredChannels(
+          base("spoke", {
+            xField: "x",
+            yField: "y",
+            radiusField: "r",
+          }),
+        ),
+      "angle",
+    );
+    expect(() =>
+      assertRequiredChannels(
+        base("spoke", {
+          xField: "x",
+          yField: "y",
+          layerParams: { angle: 0, radius: 1 },
+        }),
+      ),
+    ).not.toThrow();
+  });
+
+  it("requires rug channels from sides", () => {
+    expectMissingChannel(() => assertRequiredChannels(base("rug", { rugSides: "b" })), "x");
+    expectMissingChannel(() => assertRequiredChannels(base("rug", { rugSides: "l" })), "y");
+    expect(() => assertRequiredChannels(base("rug", { rugSides: "b", xField: "x" }))).not.toThrow();
+  });
+
+  it("pins the nine geoms that intentionally require no x/y channels", () => {
+    for (const geom of NO_XY_REQUIRED) {
+      expect(() => assertRequiredChannels(base(geom))).not.toThrow();
+    }
+  });
+
+  it("every normalized geom either requires a channel or is listed as unconstrained", () => {
+    const unconstrained = new Set<string>(NO_XY_REQUIRED);
+    // Rule annotation form needs no mapped channel (intercepts are params).
+    // Vertical/horizontal rule still require an axis — covered above.
+    unconstrained.add("rule");
+
+    for (const geom of normalizedGeoms) {
+      try {
+        assertRequiredChannels(
+          base(geom, {
+            // Give rule a form that does not force a channel so the fall-through
+            // check still sees annotation-style rule as unconstrained.
+            ruleForm: geom === "rule" ? "annotation" : null,
+            // Rug with no sides that need axes would be empty; use sides that
+            // need none by testing the unconstrained list only via throw/no-throw.
+            rugSides: geom === "rug" ? "b" : undefined,
+          }),
+        );
+        // No throw: must be intentionally unconstrained (or rule annotation).
+        if (geom === "rug") {
+          // rug with side b needs x — should have thrown.
+          expect.unreachable("rug with sides b should require x");
+        }
+        expect(unconstrained.has(geom)).toBe(true);
+      } catch (e) {
+        expect(e).toBeInstanceOf(PipelineError);
+        expect((e as PipelineError).code).toBe("missing-channel");
+        expect(unconstrained.has(geom)).toBe(false);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Convert `assertRequiredChannels` from an if-chain with silent fall-through to a `switch` over `NormalizedGeomName` ending in `const exhaustive: never`.
- Explicit empty arms for the nine post-alias geoms that intentionally require no x/y here: `function`, `abline`, `map`, `sf` / `sf_text` / `sf_label`, `blank`, `qq` / `qq_line` (their real requirements live in extras / frame builders / params).
- Unit tests pin every family contract and the nine unconstrained decisions, plus a catalog walk so a new geom cannot slip into “require nothing” without being listed.

Addresses the `bind-layer-required` remainder of #1042 (the spine landed in #1052). Behaviour is unchanged for all existing geoms.

## Test plan

- [x] `bun test packages/core/tests/pipeline-bind-required.test.ts`
- [x] `bun test packages/core/tests` (1805 pass)
- [x] `tsc -b packages/spec packages/core`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1059" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->