### PR TITLE
fix(docs): use squadron/tons on Armada palette specimen

### DIFF
--- a/apps/docs/src/lib/components/PaletteSpecimenLive.svelte
+++ b/apps/docs/src/lib/components/PaletteSpecimenLive.svelte
@@ -9,7 +9,7 @@
   } from "@ggsvelte/svelte";
   import type { CATEGORICAL_SCHEME_NAMES, ThemeName } from "@ggsvelte/spec";
 
-  import { languages } from "$lib/theme-specimens/data";
+  import { armadaTonnage } from "$lib/theme-specimens/data";
 
   type CategoricalSchemeName = (typeof CATEGORICAL_SCHEME_NAMES)[number];
 
@@ -29,8 +29,8 @@
 </script>
 
 <GGPlot
-  data={languages}
-  aes={{ x: "language", y: "respondents", fill: "language" }}
+  data={armadaTonnage}
+  aes={{ x: "squadron", y: "tons", fill: "squadron" }}
   inspect={{ mode: "exact" }}
   {height}
   ariaLabel={`${label} palette on ${paperTheme} paper`}

--- a/apps/docs/src/lib/theme-specimens/data.ts
+++ b/apps/docs/src/lib/theme-specimens/data.ts
@@ -20,17 +20,17 @@
 /**
  * Spanish Armada squadron tonnage, 1588 (Medina Sidonia muster).
  * HistData::Armada (see NOTICE); zero-ton squadrons omitted for the palette bars.
- * Field names match the palette specimen (`language` / `respondents`).
+ * English squadron labels match examples/bar/horizontal (HistData Fleet is abbreviated).
  */
-export const languages: { language: string; respondents: number }[] = [
-  { language: "Pataches", respondents: 1221 },
-  { language: "Biscay", respondents: 6567 },
-  { language: "Guipúzcoa", respondents: 6991 },
-  { language: "Levant", respondents: 7705 },
-  { language: "Portugal", respondents: 7737 },
-  { language: "Castile", respondents: 8714 },
-  { language: "Andalusia", respondents: 8762 },
-  { language: "Hulks", respondents: 10271 },
+export const armadaTonnage: { squadron: string; tons: number }[] = [
+  { squadron: "Pataches", tons: 1221 },
+  { squadron: "Biscay", tons: 6567 },
+  { squadron: "Guipúzcoa", tons: 6991 },
+  { squadron: "Levant", tons: 7705 },
+  { squadron: "Portugal", tons: 7737 },
+  { squadron: "Castile", tons: 8714 },
+  { squadron: "Andalusia", tons: 8762 },
+  { squadron: "Hulks", tons: 10271 },
 ];
 
 /**

--- a/apps/docs/src/lib/theme-specimens/static-svg.ts
+++ b/apps/docs/src/lib/theme-specimens/static-svg.ts
@@ -15,7 +15,7 @@ import {
   countries,
   generation,
   grid,
-  languages,
+  armadaTonnage,
   longRunSeries,
   penguins,
   revenue,
@@ -211,7 +211,7 @@ export function paletteSpecimenStaticSvg(input: {
   const key = `palette:${input.scheme}:${String(input.reverse)}:${input.paperTheme}:${String(width)}x${String(height)}`;
   const hit = cache.get(key);
   if (hit !== undefined) return hit;
-  const spec = gg(languages, aes({ x: "language", y: "respondents", fill: "language" }))
+  const spec = gg(armadaTonnage, aes({ x: "squadron", y: "tons", fill: "squadron" }))
     .geomCol({ width: 0.75 })
     .scales({
       fill: { type: "ordinal", scheme: input.scheme, reverse: input.reverse },


### PR DESCRIPTION
Palette specimen data used leftover `language`/`respondents` keys after values became Armada tonnage. Rename to `squadron`/`tons`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1060" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->