### PR TITLE
feat(inspect): let a layer opt out of inspection

### DIFF
--- a/.changeset/layer-inspect-opt-out.md
+++ b/.changeset/layer-inspect-opt-out.md
@@ -1,0 +1,21 @@
+---
+"@ggsvelte/spec": minor
+"@ggsvelte/core": minor
+"@ggsvelte/svelte": minor
+---
+
+<!-- markdownlint-disable MD041 -->
+
+feat(inspect): let a layer opt out of inspection
+
+An area mark reports distance 0 everywhere it is painted, so a full-panel
+background band outranks every point and stroke beneath it: the tooltip binds to
+the band and the reader can never reach the data. Set `inspect={false}` on that
+layer (or `"inspect": false` in the spec) and its marks never become tooltip,
+hover, or keyboard-traversal candidates.
+
+It travels with the spec, so a JSON round trip and a headless render agree with
+the browser. Rect hit maths is unchanged, so layers that want an area tooltip —
+bars, tiles, heatmaps — keep one.
+
+Migration: none. Omitting the field keeps today's behaviour.

--- a/.changeset/layer-inspect-opt-out.md
+++ b/.changeset/layer-inspect-opt-out.md
@@ -18,4 +18,4 @@ It travels with the spec, so a JSON round trip and a headless render agree with
 the browser. Rect hit maths is unchanged, so layers that want an area tooltip —
 bars, tiles, heatmaps — keep one.
 
-Migration: none. Omitting the field keeps today's behaviour.
+Migration: none — additive

--- a/packages/core/src/candidate-store-indexes.ts
+++ b/packages/core/src/candidate-store-indexes.ts
@@ -122,10 +122,14 @@ export function buildCandidateStoreIndexes(
     return id;
   };
 
+  const uninspectable = options.uninspectableLayers;
+
   for (let batchIndex = 0; batchIndex < scene.batches.length; batchIndex++) {
     const batch = scene.batches[batchIndex]!;
     const panel = scene.panels[batch.panelIndex];
     if (panel === undefined) continue;
+    // Layer opted out of inspection (#1065) — paint it, never target it.
+    if (uninspectable?.has(batch.layerIndex) === true) continue;
     for (let primitiveIndex = 0; primitiveIndex < primitiveCount(batch); primitiveIndex++) {
       if (!isCandidatePrimitive(batch, primitiveIndex)) continue;
       const candidateIndex = batchList.length;

--- a/packages/core/src/candidate-store-types.ts
+++ b/packages/core/src/candidate-store-types.ts
@@ -48,6 +48,18 @@ export interface CandidateStoreOptions {
   readonly flip?: boolean;
   /** Pointer hit slop around points and strokes in plot pixels (default 3). */
   readonly hitTolerance?: number;
+  /**
+   * Layer indexes the author marked `inspect: false`. Their marks never become
+   * candidates, so they cannot be hit-tested, hovered, or reached by keyboard.
+   *
+   * Filtering here rather than in each query is deliberate: an area mark
+   * reports distance 0 everywhere it is painted, so a full-panel band outranks
+   * every point and stroke beneath it in `nearest`. Dropping the marks at the
+   * single enumeration point covers hitTest, nearest, grouping and traversal
+   * together, and leaves rect hit math alone for the layers that want it
+   * (bars, tiles, heatmaps).
+   */
+  readonly uninspectableLayers?: ReadonlySet<number>;
   readonly datum?: (facts: CandidateBuildFacts) => CandidateDatum | undefined;
 }
 export interface CandidateFacts extends CandidateBuildFacts {

--- a/packages/core/src/pipeline/build-candidates.ts
+++ b/packages/core/src/pipeline/build-candidates.ts
@@ -92,6 +92,18 @@ function createRawCandidateDatumResolver(
   };
 }
 
+/**
+ * Layers the author marked `inspect: false` (#1065). Both candidate strategies
+ * pass this through, so the opt-out holds whichever one a spec takes.
+ */
+function uninspectableLayers(bindings: readonly LayerBinding[]): ReadonlySet<number> {
+  const opted = new Set<number>();
+  for (const [index, binding] of bindings.entries()) {
+    if (binding.layer.inspect === false) opted.add(index);
+  }
+  return opted;
+}
+
 // ---------------------------------------------------------------------------
 // Source-backed strategy
 // ---------------------------------------------------------------------------
@@ -118,6 +130,7 @@ function buildSourceBackedCandidates(input: {
   return buildCandidateStore(scene, {
     epoch: runId,
     flip,
+    uninspectableLayers: uninspectableLayers(bindings),
     datum: createRawCandidateDatumResolver(bindings, sources, color, fill, lineage),
   });
 }
@@ -156,6 +169,7 @@ function buildIdentityIndexedCandidates(input: {
   return buildCandidateStore(scene, {
     epoch: runId,
     flip,
+    uninspectableLayers: uninspectableLayers(bindings),
     datum: createIdentityCandidateDatumResolver({
       scene,
       bindings,

--- a/packages/core/tests/candidates-layer-inspect-opt-out.test.ts
+++ b/packages/core/tests/candidates-layer-inspect-opt-out.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Layer-level `inspect: false` keeps decorative marks out of inspection (#1065).
+ *
+ * A full-panel background rect reports distance 0 for any pointer inside it
+ * (`candidate-hit-geometry.ts` rectsOps.distance), so it beats every point and
+ * every stroke everywhere on the panel. On the getting-started chart that made
+ * the tooltip unable to reach a single observation or the trend line — the two
+ * things the chart is about (#1068, gap D of #727).
+ *
+ * The fix is an author opt-out, not a change to rect hit math: intentional area
+ * tooltips (bars, tiles, heatmaps) depend on that distance 0.
+ */
+import { describe, expect, it } from "bun:test";
+
+import { runPipeline } from "../src/pipeline/run-pipeline.js";
+
+const observations = [
+  { year: 1000, value: 10 },
+  { year: 1400, value: 14 },
+  { year: 1800, value: 11 },
+  { year: 2000, value: 4 },
+];
+
+/** One band covering the whole panel, the shape that swallows the pointer. */
+const bands = [{ from: 800, to: 2100, low: 0, high: 20, epoch: "all" }];
+
+const bandLayer = (inspect?: false) => ({
+  geom: "rect",
+  data: { values: bands },
+  aes: {
+    x: null,
+    y: null,
+    xmin: { field: "from" },
+    xmax: { field: "to" },
+    ymin: { field: "low" },
+    ymax: { field: "high" },
+    fill: { field: "epoch" },
+  },
+  params: { alpha: 0.5 },
+  ...(inspect !== undefined && { inspect }),
+});
+
+const specWith = (inspect?: false) => ({
+  data: { values: observations },
+  aes: { x: { field: "year" }, y: { field: "value" } },
+  layers: [bandLayer(inspect), { geom: "point" }],
+  scales: { fill: { type: "manual", domain: ["all"], range: ["#eee"] } },
+});
+
+const size = { width: 600, height: 400 };
+
+/** Layer index of every candidate the store holds. */
+function layerIndexes(model: ReturnType<typeof runPipeline>): number[] {
+  return Array.from({ length: model.candidates.size }, (_, id) => model.candidates.candidate(id))
+    .filter((candidate) => candidate !== null)
+    .map((candidate) => candidate.layerIndex);
+}
+
+describe("layer inspect: false", () => {
+  it("keeps the opted-out layer out of the candidate store entirely", () => {
+    const model = runPipeline(specWith(false) as never, size);
+    const layers = layerIndexes(model);
+
+    expect(layers).not.toContain(0);
+    expect(layers.filter((index) => index === 1)).toHaveLength(observations.length);
+  });
+
+  // Off any mark, which is where the pointer spends nearly all its time.
+  // `hitTest` is not the failing path: it resolves topmost, so a point painted
+  // above the band already wins on its own anchor. `nearest` is what
+  // pointer-inspect calls, and that is where distance 0 wins.
+  const probe = { x: size.width / 2, y: size.height / 2 };
+  // Finite: the spatial shortlist builds its query rect from maxDistance, so
+  // an infinite bound yields no candidates at all.
+  const reach = size.width;
+
+  it("stops the band answering for empty space in exact mode", () => {
+    const control = runPipeline(specWith() as never, size);
+    const opted = runPipeline(specWith(false) as never, size);
+    const query = { mode: "exact", maxDistance: reach } as const;
+
+    // Exact mode wants a real hit, and a point only gives one when the pointer
+    // is on it. The band was giving one everywhere it was painted. So the
+    // opt-out's job here is to return nothing off-mark, not to substitute a
+    // distant point.
+    expect(control.candidates.nearest(probe.x, probe.y, query)?.layerIndex).toBe(0);
+    expect(opted.candidates.nearest(probe.x, probe.y, query)).toBeNull();
+  });
+
+  it("leaves the axis modes finding points", () => {
+    const opted = runPipeline(specWith(false) as never, size);
+
+    // Axis modes bucket by axis value rather than by distance, so the band
+    // never captured them the way it captures exact mode. The opt-out must not
+    // cost them their answer.
+    for (const mode of ["x", "y", "xy"] as const) {
+      expect(
+        opted.candidates.nearest(probe.x, probe.y, { mode, maxDistance: reach })?.layerIndex,
+      ).toBe(1);
+    }
+  });
+
+  it("keeps the band inspectable when the field is omitted", () => {
+    const model = runPipeline(specWith() as never, size);
+    const layers = layerIndexes(model);
+
+    expect(layers).toContain(0);
+    expect(layers.filter((index) => index === 1)).toHaveLength(observations.length);
+  });
+
+  it("skips the opted-out layer in keyboard traversal", () => {
+    const model = runPipeline(specWith(false) as never, size);
+
+    const visited: number[] = [];
+    let id = model.candidates.traverse(null, "first");
+    while (id !== null && visited.length <= model.candidates.size) {
+      visited.push(model.candidates.candidate(id)!.layerIndex);
+      id = model.candidates.traverse(id, "next");
+    }
+
+    expect(visited).not.toContain(0);
+    expect(visited.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/spec/schema/v0.json
+++ b/packages/spec/schema/v0.json
@@ -2465,6 +2465,11 @@
         },
         "params": {
           "$ref": "#/$defs/AblineParams"
+        },
+        "inspect": {
+          "type": "boolean",
+          "const": false,
+          "description": "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree."
         }
       },
       "additionalProperties": false,
@@ -2866,6 +2871,11 @@
         },
         "params": {
           "$ref": "#/$defs/PointParams"
+        },
+        "inspect": {
+          "type": "boolean",
+          "const": false,
+          "description": "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree."
         }
       },
       "additionalProperties": false,
@@ -2944,6 +2954,11 @@
         },
         "params": {
           "$ref": "#/$defs/LineParams"
+        },
+        "inspect": {
+          "type": "boolean",
+          "const": false,
+          "description": "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree."
         }
       },
       "additionalProperties": false,
@@ -2982,6 +2997,11 @@
         },
         "params": {
           "$ref": "#/$defs/StepParams"
+        },
+        "inspect": {
+          "type": "boolean",
+          "const": false,
+          "description": "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree."
         }
       },
       "additionalProperties": false,
@@ -3045,6 +3065,11 @@
         },
         "params": {
           "$ref": "#/$defs/PathParams"
+        },
+        "inspect": {
+          "type": "boolean",
+          "const": false,
+          "description": "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree."
         }
       },
       "additionalProperties": false,
@@ -3079,6 +3104,11 @@
         },
         "params": {
           "$ref": "#/$defs/ColParams"
+        },
+        "inspect": {
+          "type": "boolean",
+          "const": false,
+          "description": "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree."
         }
       },
       "additionalProperties": false,
@@ -3123,6 +3153,11 @@
         },
         "params": {
           "$ref": "#/$defs/BarParams"
+        },
+        "inspect": {
+          "type": "boolean",
+          "const": false,
+          "description": "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree."
         }
       },
       "additionalProperties": false,
@@ -3159,6 +3194,11 @@
         },
         "params": {
           "$ref": "#/$defs/BarParams"
+        },
+        "inspect": {
+          "type": "boolean",
+          "const": false,
+          "description": "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree."
         }
       },
       "additionalProperties": false,
@@ -3197,6 +3237,11 @@
         },
         "params": {
           "$ref": "#/$defs/LineParams"
+        },
+        "inspect": {
+          "type": "boolean",
+          "const": false,
+          "description": "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree."
         }
       },
       "additionalProperties": false,
@@ -3235,6 +3280,11 @@
         },
         "params": {
           "$ref": "#/$defs/SmoothParams"
+        },
+        "inspect": {
+          "type": "boolean",
+          "const": false,
+          "description": "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree."
         }
       },
       "additionalProperties": false,
@@ -3273,6 +3323,11 @@
         },
         "params": {
           "$ref": "#/$defs/QuantileParams"
+        },
+        "inspect": {
+          "type": "boolean",
+          "const": false,
+          "description": "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree."
         }
       },
       "additionalProperties": false,
@@ -3311,6 +3366,11 @@
         },
         "params": {
           "$ref": "#/$defs/QqParams"
+        },
+        "inspect": {
+          "type": "boolean",
+          "const": false,
+          "description": "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree."
         }
       },
       "additionalProperties": false,
@@ -3349,6 +3409,11 @@
         },
         "params": {
           "$ref": "#/$defs/QqLineParams"
+        },
+        "inspect": {
+          "type": "boolean",
+          "const": false,
+          "description": "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree."
         }
       },
       "additionalProperties": false,
@@ -3387,6 +3452,11 @@
         },
         "params": {
           "$ref": "#/$defs/ContourParams"
+        },
+        "inspect": {
+          "type": "boolean",
+          "const": false,
+          "description": "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree."
         }
       },
       "additionalProperties": false,
@@ -3433,6 +3503,11 @@
         },
         "params": {
           "$ref": "#/$defs/ViolinParams"
+        },
+        "inspect": {
+          "type": "boolean",
+          "const": false,
+          "description": "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree."
         }
       },
       "additionalProperties": false,
@@ -3479,6 +3554,11 @@
         },
         "params": {
           "$ref": "#/$defs/BoxplotParams"
+        },
+        "inspect": {
+          "type": "boolean",
+          "const": false,
+          "description": "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree."
         }
       },
       "additionalProperties": false,
@@ -3532,6 +3612,11 @@
         },
         "params": {
           "$ref": "#/$defs/PointParams"
+        },
+        "inspect": {
+          "type": "boolean",
+          "const": false,
+          "description": "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree."
         }
       },
       "additionalProperties": false,
@@ -3570,6 +3655,11 @@
         },
         "params": {
           "$ref": "#/$defs/DotplotParams"
+        },
+        "inspect": {
+          "type": "boolean",
+          "const": false,
+          "description": "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree."
         }
       },
       "additionalProperties": false,
@@ -3608,6 +3698,11 @@
         },
         "params": {
           "$ref": "#/$defs/DensityParams"
+        },
+        "inspect": {
+          "type": "boolean",
+          "const": false,
+          "description": "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree."
         }
       },
       "additionalProperties": false,
@@ -3646,6 +3741,11 @@
         },
         "params": {
           "$ref": "#/$defs/Density2dParams"
+        },
+        "inspect": {
+          "type": "boolean",
+          "const": false,
+          "description": "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree."
         }
       },
       "additionalProperties": false,
@@ -3684,6 +3784,11 @@
         },
         "params": {
           "$ref": "#/$defs/Density2dParams"
+        },
+        "inspect": {
+          "type": "boolean",
+          "const": false,
+          "description": "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree."
         }
       },
       "additionalProperties": false,
@@ -3742,6 +3847,11 @@
         },
         "params": {
           "$ref": "#/$defs/ErrorbarParams"
+        },
+        "inspect": {
+          "type": "boolean",
+          "const": false,
+          "description": "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree."
         }
       },
       "additionalProperties": false,
@@ -3787,6 +3897,11 @@
         },
         "params": {
           "$ref": "#/$defs/LinerangeParams"
+        },
+        "inspect": {
+          "type": "boolean",
+          "const": false,
+          "description": "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree."
         }
       },
       "additionalProperties": false,
@@ -3832,6 +3947,11 @@
         },
         "params": {
           "$ref": "#/$defs/PointrangeParams"
+        },
+        "inspect": {
+          "type": "boolean",
+          "const": false,
+          "description": "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree."
         }
       },
       "additionalProperties": false,
@@ -3877,6 +3997,11 @@
         },
         "params": {
           "$ref": "#/$defs/CrossbarParams"
+        },
+        "inspect": {
+          "type": "boolean",
+          "const": false,
+          "description": "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree."
         }
       },
       "additionalProperties": false,
@@ -3913,6 +4038,11 @@
         },
         "params": {
           "$ref": "#/$defs/RectParams"
+        },
+        "inspect": {
+          "type": "boolean",
+          "const": false,
+          "description": "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree."
         }
       },
       "additionalProperties": false,
@@ -3951,6 +4081,11 @@
         },
         "params": {
           "$ref": "#/$defs/TileParams"
+        },
+        "inspect": {
+          "type": "boolean",
+          "const": false,
+          "description": "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree."
         }
       },
       "additionalProperties": false,
@@ -3989,6 +4124,11 @@
         },
         "params": {
           "$ref": "#/$defs/Bin2dParams"
+        },
+        "inspect": {
+          "type": "boolean",
+          "const": false,
+          "description": "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree."
         }
       },
       "additionalProperties": false,
@@ -4027,6 +4167,11 @@
         },
         "params": {
           "$ref": "#/$defs/RasterParams"
+        },
+        "inspect": {
+          "type": "boolean",
+          "const": false,
+          "description": "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree."
         }
       },
       "additionalProperties": false,
@@ -4065,6 +4210,11 @@
         },
         "params": {
           "$ref": "#/$defs/HexParams"
+        },
+        "inspect": {
+          "type": "boolean",
+          "const": false,
+          "description": "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree."
         }
       },
       "additionalProperties": false,
@@ -4116,6 +4266,11 @@
         },
         "params": {
           "$ref": "#/$defs/AreaParams"
+        },
+        "inspect": {
+          "type": "boolean",
+          "const": false,
+          "description": "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree."
         }
       },
       "additionalProperties": false,
@@ -4152,6 +4307,11 @@
         },
         "params": {
           "$ref": "#/$defs/RibbonParams"
+        },
+        "inspect": {
+          "type": "boolean",
+          "const": false,
+          "description": "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree."
         }
       },
       "additionalProperties": false,
@@ -4188,6 +4348,11 @@
         },
         "params": {
           "$ref": "#/$defs/RuleParams"
+        },
+        "inspect": {
+          "type": "boolean",
+          "const": false,
+          "description": "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree."
         }
       },
       "additionalProperties": false,
@@ -4226,6 +4391,11 @@
         },
         "params": {
           "$ref": "#/$defs/HlineParams"
+        },
+        "inspect": {
+          "type": "boolean",
+          "const": false,
+          "description": "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree."
         }
       },
       "additionalProperties": false,
@@ -4264,6 +4434,11 @@
         },
         "params": {
           "$ref": "#/$defs/VlineParams"
+        },
+        "inspect": {
+          "type": "boolean",
+          "const": false,
+          "description": "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree."
         }
       },
       "additionalProperties": false,
@@ -4305,6 +4480,11 @@
         },
         "params": {
           "$ref": "#/$defs/PointParams"
+        },
+        "inspect": {
+          "type": "boolean",
+          "const": false,
+          "description": "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree."
         }
       },
       "additionalProperties": false,
@@ -4352,6 +4532,11 @@
         },
         "params": {
           "$ref": "#/$defs/TextParams"
+        },
+        "inspect": {
+          "type": "boolean",
+          "const": false,
+          "description": "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree."
         }
       },
       "additionalProperties": false,
@@ -4401,6 +4586,11 @@
         },
         "params": {
           "$ref": "#/$defs/LabelParams"
+        },
+        "inspect": {
+          "type": "boolean",
+          "const": false,
+          "description": "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree."
         }
       },
       "additionalProperties": false,
@@ -4437,6 +4627,11 @@
         },
         "params": {
           "$ref": "#/$defs/SegmentParams"
+        },
+        "inspect": {
+          "type": "boolean",
+          "const": false,
+          "description": "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree."
         }
       },
       "additionalProperties": false,
@@ -4477,6 +4672,11 @@
         "params": {
           "$ref": "#/$defs/FunctionParams",
           "description": "Function parameters (fun is required)."
+        },
+        "inspect": {
+          "type": "boolean",
+          "const": false,
+          "description": "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree."
         }
       },
       "additionalProperties": false,
@@ -4515,6 +4715,11 @@
         },
         "params": {
           "$ref": "#/$defs/CurveParams"
+        },
+        "inspect": {
+          "type": "boolean",
+          "const": false,
+          "description": "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree."
         }
       },
       "additionalProperties": false,
@@ -4553,6 +4758,11 @@
         },
         "params": {
           "$ref": "#/$defs/PolygonParams"
+        },
+        "inspect": {
+          "type": "boolean",
+          "const": false,
+          "description": "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree."
         }
       },
       "additionalProperties": false,
@@ -4592,6 +4802,11 @@
         },
         "params": {
           "$ref": "#/$defs/MapParams"
+        },
+        "inspect": {
+          "type": "boolean",
+          "const": false,
+          "description": "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree."
         }
       },
       "additionalProperties": false,
@@ -4630,6 +4845,11 @@
         },
         "params": {
           "$ref": "#/$defs/SfParams"
+        },
+        "inspect": {
+          "type": "boolean",
+          "const": false,
+          "description": "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree."
         }
       },
       "additionalProperties": false,
@@ -4716,6 +4936,11 @@
         },
         "params": {
           "$ref": "#/$defs/SfTextParams"
+        },
+        "inspect": {
+          "type": "boolean",
+          "const": false,
+          "description": "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree."
         }
       },
       "additionalProperties": false,
@@ -4817,6 +5042,11 @@
         },
         "params": {
           "$ref": "#/$defs/SfLabelParams"
+        },
+        "inspect": {
+          "type": "boolean",
+          "const": false,
+          "description": "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree."
         }
       },
       "additionalProperties": false,
@@ -4861,6 +5091,11 @@
         },
         "params": {
           "$ref": "#/$defs/BlankParams"
+        },
+        "inspect": {
+          "type": "boolean",
+          "const": false,
+          "description": "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree."
         }
       },
       "additionalProperties": false,
@@ -4899,6 +5134,11 @@
         },
         "params": {
           "$ref": "#/$defs/RugParams"
+        },
+        "inspect": {
+          "type": "boolean",
+          "const": false,
+          "description": "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree."
         }
       },
       "additionalProperties": false,
@@ -4937,6 +5177,11 @@
         },
         "params": {
           "$ref": "#/$defs/SpokeParams"
+        },
+        "inspect": {
+          "type": "boolean",
+          "const": false,
+          "description": "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree."
         }
       },
       "additionalProperties": false,

--- a/packages/spec/src/normalize.ts
+++ b/packages/spec/src/normalize.ts
@@ -276,6 +276,9 @@ function normalizeLayer(layer: LayerInput, plotAes: Aes | undefined): Normalized
     ...(render !== undefined && { render }),
     ...(aes !== undefined && { aes }),
     ...(layer.data !== undefined && { data: layer.data }),
+    // Only `false` is expressible, so `true` has nothing to canonicalize to
+    // but the default — omitted (#1065).
+    ...("inspect" in layer && layer.inspect === false && { inspect: false as const }),
     ...(params !== undefined && { params }),
   };
   return out as NormalizedLayerSpec;

--- a/packages/spec/src/schema-declarations.ts
+++ b/packages/spec/src/schema-declarations.ts
@@ -2573,6 +2573,12 @@ export const SpecDeclarations = {
         }),
       ),
       params: Type.Optional(Type.Ref("AblineParams")),
+      inspect: Type.Optional(
+        Type.Literal(false, {
+          description:
+            "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree.",
+        }),
+      ),
     },
     {
       additionalProperties: false,
@@ -2968,6 +2974,12 @@ export const SpecDeclarations = {
         }),
       ),
       params: Type.Optional(Type.Ref("PointParams")),
+      inspect: Type.Optional(
+        Type.Literal(false, {
+          description:
+            "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree.",
+        }),
+      ),
     },
     {
       additionalProperties: false,
@@ -3035,6 +3047,12 @@ export const SpecDeclarations = {
         }),
       ),
       params: Type.Optional(Type.Ref("LineParams")),
+      inspect: Type.Optional(
+        Type.Literal(false, {
+          description:
+            "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree.",
+        }),
+      ),
     },
     {
       additionalProperties: false,
@@ -3064,6 +3082,12 @@ export const SpecDeclarations = {
         }),
       ),
       params: Type.Optional(Type.Ref("StepParams")),
+      inspect: Type.Optional(
+        Type.Literal(false, {
+          description:
+            "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree.",
+        }),
+      ),
     },
     {
       additionalProperties: false,
@@ -3119,6 +3143,12 @@ export const SpecDeclarations = {
         }),
       ),
       params: Type.Optional(Type.Ref("PathParams")),
+      inspect: Type.Optional(
+        Type.Literal(false, {
+          description:
+            "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree.",
+        }),
+      ),
     },
     {
       additionalProperties: false,
@@ -3144,6 +3174,12 @@ export const SpecDeclarations = {
         }),
       ),
       params: Type.Optional(Type.Ref("ColParams")),
+      inspect: Type.Optional(
+        Type.Literal(false, {
+          description:
+            "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree.",
+        }),
+      ),
     },
     {
       additionalProperties: false,
@@ -3174,6 +3210,12 @@ export const SpecDeclarations = {
         }),
       ),
       params: Type.Optional(Type.Ref("BarParams")),
+      inspect: Type.Optional(
+        Type.Literal(false, {
+          description:
+            "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree.",
+        }),
+      ),
     },
     {
       additionalProperties: false,
@@ -3204,6 +3246,12 @@ export const SpecDeclarations = {
         }),
       ),
       params: Type.Optional(Type.Ref("BarParams")),
+      inspect: Type.Optional(
+        Type.Literal(false, {
+          description:
+            "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree.",
+        }),
+      ),
     },
     {
       additionalProperties: false,
@@ -3236,6 +3284,12 @@ export const SpecDeclarations = {
         }),
       ),
       params: Type.Optional(Type.Ref("LineParams")),
+      inspect: Type.Optional(
+        Type.Literal(false, {
+          description:
+            "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree.",
+        }),
+      ),
     },
     {
       additionalProperties: false,
@@ -3268,6 +3322,12 @@ export const SpecDeclarations = {
         }),
       ),
       params: Type.Optional(Type.Ref("SmoothParams")),
+      inspect: Type.Optional(
+        Type.Literal(false, {
+          description:
+            "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree.",
+        }),
+      ),
     },
     {
       additionalProperties: false,
@@ -3300,6 +3360,12 @@ export const SpecDeclarations = {
         }),
       ),
       params: Type.Optional(Type.Ref("QuantileParams")),
+      inspect: Type.Optional(
+        Type.Literal(false, {
+          description:
+            "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree.",
+        }),
+      ),
     },
     {
       additionalProperties: false,
@@ -3328,6 +3394,12 @@ export const SpecDeclarations = {
         }),
       ),
       params: Type.Optional(Type.Ref("QqParams")),
+      inspect: Type.Optional(
+        Type.Literal(false, {
+          description:
+            "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree.",
+        }),
+      ),
     },
     {
       additionalProperties: false,
@@ -3357,6 +3429,12 @@ export const SpecDeclarations = {
         }),
       ),
       params: Type.Optional(Type.Ref("QqLineParams")),
+      inspect: Type.Optional(
+        Type.Literal(false, {
+          description:
+            "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree.",
+        }),
+      ),
     },
     {
       additionalProperties: false,
@@ -3388,6 +3466,12 @@ export const SpecDeclarations = {
         }),
       ),
       params: Type.Optional(Type.Ref("ContourParams")),
+      inspect: Type.Optional(
+        Type.Literal(false, {
+          description:
+            "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree.",
+        }),
+      ),
     },
     {
       additionalProperties: false,
@@ -3421,6 +3505,12 @@ export const SpecDeclarations = {
         }),
       ),
       params: Type.Optional(Type.Ref("ViolinParams")),
+      inspect: Type.Optional(
+        Type.Literal(false, {
+          description:
+            "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree.",
+        }),
+      ),
     },
     {
       additionalProperties: false,
@@ -3456,6 +3546,12 @@ export const SpecDeclarations = {
         }),
       ),
       params: Type.Optional(Type.Ref("BoxplotParams")),
+      inspect: Type.Optional(
+        Type.Literal(false, {
+          description:
+            "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree.",
+        }),
+      ),
     },
     {
       additionalProperties: false,
@@ -3490,6 +3586,12 @@ export const SpecDeclarations = {
         }),
       ),
       params: Type.Optional(Type.Ref("PointParams")),
+      inspect: Type.Optional(
+        Type.Literal(false, {
+          description:
+            "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree.",
+        }),
+      ),
     },
     {
       additionalProperties: false,
@@ -3521,6 +3623,12 @@ export const SpecDeclarations = {
         }),
       ),
       params: Type.Optional(Type.Ref("DotplotParams")),
+      inspect: Type.Optional(
+        Type.Literal(false, {
+          description:
+            "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree.",
+        }),
+      ),
     },
     {
       additionalProperties: false,
@@ -3553,6 +3661,12 @@ export const SpecDeclarations = {
         }),
       ),
       params: Type.Optional(Type.Ref("DensityParams")),
+      inspect: Type.Optional(
+        Type.Literal(false, {
+          description:
+            "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree.",
+        }),
+      ),
     },
     {
       additionalProperties: false,
@@ -3585,6 +3699,12 @@ export const SpecDeclarations = {
         }),
       ),
       params: Type.Optional(Type.Ref("Density2dParams")),
+      inspect: Type.Optional(
+        Type.Literal(false, {
+          description:
+            "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree.",
+        }),
+      ),
     },
     {
       additionalProperties: false,
@@ -3619,6 +3739,12 @@ export const SpecDeclarations = {
         }),
       ),
       params: Type.Optional(Type.Ref("Density2dParams")),
+      inspect: Type.Optional(
+        Type.Literal(false, {
+          description:
+            "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree.",
+        }),
+      ),
     },
     {
       additionalProperties: false,
@@ -3669,6 +3795,12 @@ export const SpecDeclarations = {
         }),
       ),
       params: Type.Optional(Type.Ref("ErrorbarParams")),
+      inspect: Type.Optional(
+        Type.Literal(false, {
+          description:
+            "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree.",
+        }),
+      ),
     },
     {
       additionalProperties: false,
@@ -3696,6 +3828,12 @@ export const SpecDeclarations = {
       aes: Type.Optional(Type.Ref("Aes")),
       data: Type.Optional(Type.Ref("DataRef")),
       params: Type.Optional(Type.Ref("LinerangeParams")),
+      inspect: Type.Optional(
+        Type.Literal(false, {
+          description:
+            "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree.",
+        }),
+      ),
     },
     {
       additionalProperties: false,
@@ -3723,6 +3861,12 @@ export const SpecDeclarations = {
       aes: Type.Optional(Type.Ref("Aes")),
       data: Type.Optional(Type.Ref("DataRef")),
       params: Type.Optional(Type.Ref("PointrangeParams")),
+      inspect: Type.Optional(
+        Type.Literal(false, {
+          description:
+            "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree.",
+        }),
+      ),
     },
     {
       additionalProperties: false,
@@ -3750,6 +3894,12 @@ export const SpecDeclarations = {
       aes: Type.Optional(Type.Ref("Aes")),
       data: Type.Optional(Type.Ref("DataRef")),
       params: Type.Optional(Type.Ref("CrossbarParams")),
+      inspect: Type.Optional(
+        Type.Literal(false, {
+          description:
+            "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree.",
+        }),
+      ),
     },
     {
       additionalProperties: false,
@@ -3777,6 +3927,12 @@ export const SpecDeclarations = {
         }),
       ),
       params: Type.Optional(Type.Ref("RectParams")),
+      inspect: Type.Optional(
+        Type.Literal(false, {
+          description:
+            "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree.",
+        }),
+      ),
     },
     {
       additionalProperties: false,
@@ -3806,6 +3962,12 @@ export const SpecDeclarations = {
         }),
       ),
       params: Type.Optional(Type.Ref("TileParams")),
+      inspect: Type.Optional(
+        Type.Literal(false, {
+          description:
+            "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree.",
+        }),
+      ),
     },
     {
       additionalProperties: false,
@@ -3837,6 +3999,12 @@ export const SpecDeclarations = {
         }),
       ),
       params: Type.Optional(Type.Ref("Bin2dParams")),
+      inspect: Type.Optional(
+        Type.Literal(false, {
+          description:
+            "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree.",
+        }),
+      ),
     },
     {
       additionalProperties: false,
@@ -3866,6 +4034,12 @@ export const SpecDeclarations = {
         }),
       ),
       params: Type.Optional(Type.Ref("RasterParams")),
+      inspect: Type.Optional(
+        Type.Literal(false, {
+          description:
+            "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree.",
+        }),
+      ),
     },
     {
       additionalProperties: false,
@@ -3897,6 +4071,12 @@ export const SpecDeclarations = {
         }),
       ),
       params: Type.Optional(Type.Ref("HexParams")),
+      inspect: Type.Optional(
+        Type.Literal(false, {
+          description:
+            "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree.",
+        }),
+      ),
     },
     {
       additionalProperties: false,
@@ -3941,6 +4121,12 @@ export const SpecDeclarations = {
         }),
       ),
       params: Type.Optional(Type.Ref("AreaParams")),
+      inspect: Type.Optional(
+        Type.Literal(false, {
+          description:
+            "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree.",
+        }),
+      ),
     },
     {
       additionalProperties: false,
@@ -3968,6 +4154,12 @@ export const SpecDeclarations = {
         }),
       ),
       params: Type.Optional(Type.Ref("RibbonParams")),
+      inspect: Type.Optional(
+        Type.Literal(false, {
+          description:
+            "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree.",
+        }),
+      ),
     },
     {
       additionalProperties: false,
@@ -3995,6 +4187,12 @@ export const SpecDeclarations = {
         }),
       ),
       params: Type.Optional(Type.Ref("RuleParams")),
+      inspect: Type.Optional(
+        Type.Literal(false, {
+          description:
+            "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree.",
+        }),
+      ),
     },
     {
       additionalProperties: false,
@@ -4024,6 +4222,12 @@ export const SpecDeclarations = {
         }),
       ),
       params: Type.Optional(Type.Ref("HlineParams")),
+      inspect: Type.Optional(
+        Type.Literal(false, {
+          description:
+            "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree.",
+        }),
+      ),
     },
     {
       additionalProperties: false,
@@ -4053,6 +4257,12 @@ export const SpecDeclarations = {
         }),
       ),
       params: Type.Optional(Type.Ref("VlineParams")),
+      inspect: Type.Optional(
+        Type.Literal(false, {
+          description:
+            "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree.",
+        }),
+      ),
     },
     {
       additionalProperties: false,
@@ -4085,6 +4295,12 @@ export const SpecDeclarations = {
         }),
       ),
       params: Type.Optional(Type.Ref("PointParams")),
+      inspect: Type.Optional(
+        Type.Literal(false, {
+          description:
+            "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree.",
+        }),
+      ),
     },
     {
       additionalProperties: false,
@@ -4116,6 +4332,12 @@ export const SpecDeclarations = {
         }),
       ),
       params: Type.Optional(Type.Ref("TextParams")),
+      inspect: Type.Optional(
+        Type.Literal(false, {
+          description:
+            "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree.",
+        }),
+      ),
     },
     {
       additionalProperties: false,
@@ -4148,6 +4370,12 @@ export const SpecDeclarations = {
         }),
       ),
       params: Type.Optional(Type.Ref("LabelParams")),
+      inspect: Type.Optional(
+        Type.Literal(false, {
+          description:
+            "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree.",
+        }),
+      ),
     },
     {
       additionalProperties: false,
@@ -4175,6 +4403,12 @@ export const SpecDeclarations = {
         }),
       ),
       params: Type.Optional(Type.Ref("SegmentParams")),
+      inspect: Type.Optional(
+        Type.Literal(false, {
+          description:
+            "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree.",
+        }),
+      ),
     },
     {
       additionalProperties: false,
@@ -4208,6 +4442,12 @@ export const SpecDeclarations = {
       params: Type.Ref("FunctionParams", {
         description: "Function parameters (fun is required).",
       }),
+      inspect: Type.Optional(
+        Type.Literal(false, {
+          description:
+            "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree.",
+        }),
+      ),
     },
     {
       additionalProperties: false,
@@ -4237,6 +4477,12 @@ export const SpecDeclarations = {
         }),
       ),
       params: Type.Optional(Type.Ref("CurveParams")),
+      inspect: Type.Optional(
+        Type.Literal(false, {
+          description:
+            "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree.",
+        }),
+      ),
     },
     {
       additionalProperties: false,
@@ -4266,6 +4512,12 @@ export const SpecDeclarations = {
         }),
       ),
       params: Type.Optional(Type.Ref("PolygonParams")),
+      inspect: Type.Optional(
+        Type.Literal(false, {
+          description:
+            "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree.",
+        }),
+      ),
     },
     {
       additionalProperties: false,
@@ -4295,6 +4547,12 @@ export const SpecDeclarations = {
         }),
       ),
       params: Type.Ref("MapParams"),
+      inspect: Type.Optional(
+        Type.Literal(false, {
+          description:
+            "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree.",
+        }),
+      ),
     },
     {
       additionalProperties: false,
@@ -4327,6 +4585,12 @@ export const SpecDeclarations = {
         }),
       ),
       params: Type.Optional(Type.Ref("SfParams")),
+      inspect: Type.Optional(
+        Type.Literal(false, {
+          description:
+            "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree.",
+        }),
+      ),
     },
     {
       additionalProperties: false,
@@ -4405,6 +4669,12 @@ export const SpecDeclarations = {
         }),
       ),
       params: Type.Optional(Type.Ref("SfTextParams")),
+      inspect: Type.Optional(
+        Type.Literal(false, {
+          description:
+            "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree.",
+        }),
+      ),
     },
     {
       additionalProperties: false,
@@ -4502,6 +4772,12 @@ export const SpecDeclarations = {
         }),
       ),
       params: Type.Optional(Type.Ref("SfLabelParams")),
+      inspect: Type.Optional(
+        Type.Literal(false, {
+          description:
+            "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree.",
+        }),
+      ),
     },
     {
       additionalProperties: false,
@@ -4542,6 +4818,12 @@ export const SpecDeclarations = {
         }),
       ),
       params: Type.Optional(Type.Ref("BlankParams")),
+      inspect: Type.Optional(
+        Type.Literal(false, {
+          description:
+            "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree.",
+        }),
+      ),
     },
     {
       additionalProperties: false,
@@ -4571,6 +4853,12 @@ export const SpecDeclarations = {
         }),
       ),
       params: Type.Optional(Type.Ref("RugParams")),
+      inspect: Type.Optional(
+        Type.Literal(false, {
+          description:
+            "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree.",
+        }),
+      ),
     },
     {
       additionalProperties: false,
@@ -4600,6 +4888,12 @@ export const SpecDeclarations = {
         }),
       ),
       params: Type.Optional(Type.Ref("SpokeParams")),
+      inspect: Type.Optional(
+        Type.Literal(false, {
+          description:
+            "Set false to exclude this layer from inspection: its marks never become tooltip, hover, or keyboard-traversal candidates. For decorative layers (background bands, reference shading) whose marks would otherwise capture the pointer — an area mark contains the pointer everywhere it is painted, so it outranks every point and stroke beneath it. Portable: it travels with the spec, so headless renders and re-imported JSON agree.",
+        }),
+      ),
     },
     {
       additionalProperties: false,

--- a/packages/spec/tests/artifact.test.ts
+++ b/packages/spec/tests/artifact.test.ts
@@ -71,104 +71,114 @@ describe("schema/v0.json artifact", () => {
     for (const ref of refs) expect(ref).toContain("#/$defs/");
   });
 
-  it("compiles under ajv 2020-12 and matches TypeBox verdicts", () => {
-    const ajv = new Ajv2020({ strict: false });
-    const validateAjv = ajv.compile(JSON.parse(committed) as object);
-    const fixtures: [unknown, boolean][] = [
-      [{ layers: [{ geom: "point" }] }, true],
-      [
-        {
-          data: { columns: { x: [1, "a", null] } },
-          aes: { x: { field: "x" }, y: { value: 2, scale: true } },
-          layers: [
-            { geom: "point", params: { alpha: 0.2, shape: "triangle" } },
-            { geom: "line", aes: { color: null }, params: { curve: "step" } },
-          ],
-          labs: { title: "T" },
-          width: 100,
-        },
-        true,
-      ],
-      [{ layers: [] }, false],
-      [{ layers: [{ geom: "bar" }] }, true],
-      [{ layers: [{ geom: "boxplot" }] }, true],
-      [{ layers: [{ geom: "violin" }] }, true],
-      [{ layers: [{ geom: "violin", params: { scale: "width", trim: true, n: 64 } }] }, true],
-      [{ layers: [{ geom: "violin", params: { scale: "volume" } }] }, false],
-      [{ layers: [{ geom: "violin", position: "stack" }] }, false],
-      [{ layers: [{ geom: "bar", stat: "identity" }] }, false],
-      [{ layers: [{ geom: "bar", stat: "bin", params: { binwidth: 0.5, boundary: 0 } }] }, true],
-      [{ layers: [{ geom: "histogram", params: { bins: 20, closed: "left" } }] }, true],
-      [{ layers: [{ geom: "histogram", stat: "count" }] }, false],
-      [{ layers: [{ geom: "col", stat: "count" }] }, false],
-      [{ layers: [{ geom: "col", params: { bins: 10 } }] }, false],
-      [{ layers: [{ geom: "smooth", params: { method: "loess", span: 0.5, se: true } }] }, true],
-      [{ layers: [{ geom: "smooth", params: { method: "gam" } }] }, false],
-      [{ layers: [{ geom: "smooth", params: { span: 1.5 } }] }, false],
-      [{ layers: [{ geom: "boxplot", params: { coef: 3, outlierSize: 2 } }] }, true],
-      [{ layers: [{ geom: "boxplot", position: "stack" }] }, false],
-      [{ layers: [{ geom: "density", params: { adjust: 0.5, n: 256, cut: 3 } }] }, true],
-      [{ layers: [{ geom: "density", params: { bw: 0 } }] }, false],
-      [{ layers: [{ geom: "errorbar", stat: "summary", params: { fun: "median" } }] }, true],
-      [{ layers: [{ geom: "errorbar", params: { fun: "min" } }] }, false],
-      [
-        {
-          aes: { x: { field: "a" }, ymin: { field: "lo" }, ymax: { field: "hi" } },
-          layers: [{ geom: "errorbar" }],
-        },
-        true,
-      ],
-      [
-        {
-          layers: [{ geom: "point", position: "jitter", positionParams: { width: 0.2, seed: 7 } }],
-        },
-        true,
-      ],
-      [{ layers: [{ geom: "point", position: "jitter", positionParams: { seed: -1 } }] }, false],
-      [{ layers: [{ geom: "point", position: "stack" }] }, false],
-      [{ layers: [{ geom: "text", position: "nudge", positionParams: { y: -0.5 } }] }, true],
-      [{ layers: [{ geom: "line", position: "nudge" }] }, false],
-      [{ layers: [{ geom: "rule", params: { yintercept: 3 } }] }, true],
-      [{ layers: [{ geom: "text", params: { anchor: "left" } }] }, false],
-      [{ scales: { y: { type: "log", zero: false } }, layers: [{ geom: "point" }] }, true],
-      [
-        {
-          scales: { x: { type: "time", dateLabels: "literal %Y %% %m" } },
-          layers: [{ geom: "point" }],
-        },
-        true,
-      ],
-      [
-        {
-          scales: { x: { type: "time", dateLabels: "%Q" } },
-          layers: [{ geom: "point" }],
-        },
-        false,
-      ],
-      [
-        {
-          scales: { x: { type: "time", dateLabels: "trailing %" } },
-          layers: [{ geom: "point" }],
-        },
-        false,
-      ],
-      [{ scales: { y: { type: "exp" } }, layers: [{ geom: "point" }] }, false],
-      [{ scales: { color: { range: ["#abc", "#123456"] } }, layers: [{ geom: "point" }] }, true],
-      [{ scales: { color: { range: ["tomato"] } }, layers: [{ geom: "point" }] }, false],
-      [{ theme: "dark", layers: [{ geom: "point" }] }, true],
-      [{ theme: "darkk", layers: [{ geom: "point" }] }, false],
-      [{ theme: { name: "dark", accent: "#f00" }, layers: [{ geom: "point" }] }, true],
-      [{ legend: { order: "sorted" }, layers: [{ geom: "point" }] }, true],
-      [{ legend: { order: "reverse" }, layers: [{ geom: "point" }] }, false],
-      [{ aes: { x: "bare-string" }, layers: [{ geom: "point" }] }, false],
-      [{ layers: [{ geom: "point", params: { alpha: 2 } }] }, false],
-      [{ layers: [{ geom: "line", params: { size: 1 } }] }, false],
-      [{ extra: 1, layers: [{ geom: "point" }] }, false],
-      [{ data: { name: 7 }, layers: [{ geom: "point" }] }, false],
-    ];
-    for (const [fixture, expected] of fixtures) {
-      expect(validateAjv(fixture)).toBe(expected);
-      expect(Value.Check(PlotSpecSchema, fixture)).toBe(expected);
-    }
-  });
+  // AJV compile of the full PlotSpec is multi-second on cold CI runners; the
+  // default 5s bun timeout flakes when schema growth (e.g. a field on every
+  // layer) pushes compile just over the limit. Cap generously — the suite still
+  // fails loudly on real regressions.
+  it(
+    "compiles under ajv 2020-12 and matches TypeBox verdicts",
+    () => {
+      const ajv = new Ajv2020({ strict: false });
+      const validateAjv = ajv.compile(JSON.parse(committed) as object);
+      const fixtures: [unknown, boolean][] = [
+        [{ layers: [{ geom: "point" }] }, true],
+        [
+          {
+            data: { columns: { x: [1, "a", null] } },
+            aes: { x: { field: "x" }, y: { value: 2, scale: true } },
+            layers: [
+              { geom: "point", params: { alpha: 0.2, shape: "triangle" } },
+              { geom: "line", aes: { color: null }, params: { curve: "step" } },
+            ],
+            labs: { title: "T" },
+            width: 100,
+          },
+          true,
+        ],
+        [{ layers: [] }, false],
+        [{ layers: [{ geom: "bar" }] }, true],
+        [{ layers: [{ geom: "boxplot" }] }, true],
+        [{ layers: [{ geom: "violin" }] }, true],
+        [{ layers: [{ geom: "violin", params: { scale: "width", trim: true, n: 64 } }] }, true],
+        [{ layers: [{ geom: "violin", params: { scale: "volume" } }] }, false],
+        [{ layers: [{ geom: "violin", position: "stack" }] }, false],
+        [{ layers: [{ geom: "bar", stat: "identity" }] }, false],
+        [{ layers: [{ geom: "bar", stat: "bin", params: { binwidth: 0.5, boundary: 0 } }] }, true],
+        [{ layers: [{ geom: "histogram", params: { bins: 20, closed: "left" } }] }, true],
+        [{ layers: [{ geom: "histogram", stat: "count" }] }, false],
+        [{ layers: [{ geom: "col", stat: "count" }] }, false],
+        [{ layers: [{ geom: "col", params: { bins: 10 } }] }, false],
+        [{ layers: [{ geom: "smooth", params: { method: "loess", span: 0.5, se: true } }] }, true],
+        [{ layers: [{ geom: "smooth", params: { method: "gam" } }] }, false],
+        [{ layers: [{ geom: "smooth", params: { span: 1.5 } }] }, false],
+        [{ layers: [{ geom: "boxplot", params: { coef: 3, outlierSize: 2 } }] }, true],
+        [{ layers: [{ geom: "boxplot", position: "stack" }] }, false],
+        [{ layers: [{ geom: "density", params: { adjust: 0.5, n: 256, cut: 3 } }] }, true],
+        [{ layers: [{ geom: "density", params: { bw: 0 } }] }, false],
+        [{ layers: [{ geom: "errorbar", stat: "summary", params: { fun: "median" } }] }, true],
+        [{ layers: [{ geom: "errorbar", params: { fun: "min" } }] }, false],
+        [
+          {
+            aes: { x: { field: "a" }, ymin: { field: "lo" }, ymax: { field: "hi" } },
+            layers: [{ geom: "errorbar" }],
+          },
+          true,
+        ],
+        [
+          {
+            layers: [
+              { geom: "point", position: "jitter", positionParams: { width: 0.2, seed: 7 } },
+            ],
+          },
+          true,
+        ],
+        [{ layers: [{ geom: "point", position: "jitter", positionParams: { seed: -1 } }] }, false],
+        [{ layers: [{ geom: "point", position: "stack" }] }, false],
+        [{ layers: [{ geom: "text", position: "nudge", positionParams: { y: -0.5 } }] }, true],
+        [{ layers: [{ geom: "line", position: "nudge" }] }, false],
+        [{ layers: [{ geom: "rule", params: { yintercept: 3 } }] }, true],
+        [{ layers: [{ geom: "text", params: { anchor: "left" } }] }, false],
+        [{ scales: { y: { type: "log", zero: false } }, layers: [{ geom: "point" }] }, true],
+        [
+          {
+            scales: { x: { type: "time", dateLabels: "literal %Y %% %m" } },
+            layers: [{ geom: "point" }],
+          },
+          true,
+        ],
+        [
+          {
+            scales: { x: { type: "time", dateLabels: "%Q" } },
+            layers: [{ geom: "point" }],
+          },
+          false,
+        ],
+        [
+          {
+            scales: { x: { type: "time", dateLabels: "trailing %" } },
+            layers: [{ geom: "point" }],
+          },
+          false,
+        ],
+        [{ scales: { y: { type: "exp" } }, layers: [{ geom: "point" }] }, false],
+        [{ scales: { color: { range: ["#abc", "#123456"] } }, layers: [{ geom: "point" }] }, true],
+        [{ scales: { color: { range: ["tomato"] } }, layers: [{ geom: "point" }] }, false],
+        [{ theme: "dark", layers: [{ geom: "point" }] }, true],
+        [{ theme: "darkk", layers: [{ geom: "point" }] }, false],
+        [{ theme: { name: "dark", accent: "#f00" }, layers: [{ geom: "point" }] }, true],
+        [{ legend: { order: "sorted" }, layers: [{ geom: "point" }] }, true],
+        [{ legend: { order: "reverse" }, layers: [{ geom: "point" }] }, false],
+        [{ aes: { x: "bare-string" }, layers: [{ geom: "point" }] }, false],
+        [{ layers: [{ geom: "point", params: { alpha: 2 } }] }, false],
+        [{ layers: [{ geom: "line", params: { size: 1 } }] }, false],
+        [{ extra: 1, layers: [{ geom: "point" }] }, false],
+        [{ data: { name: 7 }, layers: [{ geom: "point" }] }, false],
+      ];
+      for (const [fixture, expected] of fixtures) {
+        expect(validateAjv(fixture)).toBe(expected);
+        expect(Value.Check(PlotSpecSchema, fixture)).toBe(expected);
+      }
+    },
+    { timeout: 30_000 },
+  );
 });

--- a/packages/svelte/src/lib/assembly/assemble.ts
+++ b/packages/svelte/src/lib/assembly/assemble.ts
@@ -66,6 +66,7 @@ export function toLayerInput(descriptor: MarkLayerDescriptorLike): LayerInput {
       positionParams: descriptor.positionParams,
     }),
     ...(descriptor.render !== undefined && { render: descriptor.render }),
+    ...(descriptor.inspect === false && { inspect: false as const }),
     ...(descriptor.aes !== undefined && { aes: descriptor.aes }),
     ...(descriptor.data !== undefined && { data: layerDataRef(descriptor.data) }),
     ...(descriptor.params !== undefined && { params: descriptor.params }),

--- a/packages/svelte/src/lib/geoms/factory.svelte.ts
+++ b/packages/svelte/src/lib/geoms/factory.svelte.ts
@@ -36,6 +36,13 @@ export interface GeomProps {
   positionParams?: PositionParams;
   /** Rendering backend hint ("svg" | "canvas" | "auto"). */
   render?: RenderBackend;
+  /**
+   * `false` excludes this layer from inspection (#1065): its marks never
+   * become tooltip, hover, or keyboard candidates. For background bands and
+   * other decoration, which otherwise capture the pointer everywhere they are
+   * painted.
+   */
+  inspect?: false;
 }
 
 /**
@@ -68,6 +75,9 @@ export function createGeomLayer(geom: GeomName, getProps: () => GeomProps): void
     },
     get render() {
       return getProps().render;
+    },
+    get inspect() {
+      return getProps().inspect;
     },
     get params() {
       const props = getProps() as Record<string, unknown>;

--- a/packages/svelte/src/lib/layers/types.ts
+++ b/packages/svelte/src/lib/layers/types.ts
@@ -38,6 +38,8 @@ export interface MarkLayerDescriptor {
   readonly position?: PositionName | undefined;
   readonly positionParams?: PositionParams | undefined;
   readonly render?: RenderBackend | undefined;
+  /** `false` keeps a decorative layer out of inspection (#1065). */
+  readonly inspect?: false | undefined;
   readonly params?: Record<string, unknown> | undefined;
 }
 

--- a/packages/svelte/tests/layers/layer-inspect-prop.ssr.test.ts
+++ b/packages/svelte/tests/layers/layer-inspect-prop.ssr.test.ts
@@ -1,0 +1,35 @@
+/**
+ * `inspect={false}` on a geom component reaches the portable spec (#1065).
+ *
+ * The core opt-out is worthless to a component author if the prop stops at the
+ * registry: the getting-started lesson is written in components, and the
+ * portable spec it teaches has to carry the same intent as the JSON.
+ */
+import { describe, expect, it } from "vitest";
+
+import { toLayerInput } from "../../src/lib/assembly/assemble.js";
+import type { MarkLayerDescriptor } from "../../src/lib/layers/types.js";
+
+const band: MarkLayerDescriptor = {
+  geom: "rect",
+  aes: { xmin: "from", xmax: "to", ymin: "low", ymax: "high" },
+  inspect: false,
+};
+
+describe("layer inspect prop", () => {
+  it("carries inspect: false into the layer input", () => {
+    expect(toLayerInput(band)).toMatchObject({ geom: "rect", inspect: false });
+  });
+
+  it("omits the key entirely when the prop is not set", () => {
+    const { inspect: _dropped, ...withoutInspect } = band;
+
+    expect(toLayerInput(withoutInspect)).not.toHaveProperty("inspect");
+  });
+
+  it("omits the key when the prop is explicitly undefined", () => {
+    // Svelte passes undefined for an absent prop, which must not become a
+    // literal `inspect: undefined` in a spec that claims to be strict JSON.
+    expect(toLayerInput({ ...band, inspect: undefined })).not.toHaveProperty("inspect");
+  });
+});


### PR DESCRIPTION
Closes #1065. Gap D of #727.

## The problem

A rect reports distance `0` for any pointer inside it:

```ts
// packages/core/src/candidate-hit-geometry.ts:155-156
distance(indexes, id, px, py, pathContainment) {
  return rectsOps.contains(indexes, id, px, py, pathContainment) ? 0 : null;
},
```

A full-panel background band therefore contains the pointer everywhere, and
outranks every point and stroke beneath it in `nearest` — which is the call
pointer-inspect makes. On the getting-started chart the tooltip bound to the
epoch band wherever the reader moved, and never to an observation or the trend
line, which are the two things that chart is about.

`InspectOptions` had nothing that could exclude a layer.

## The fix

`inspect: false` on a layer. Its marks never become candidates, so they cannot
be hit-tested, hovered, or reached by keyboard.

- **spec** — the field on all 49 layer schemas, carried through `normalize`,
  which rebuilds layers field by field and was dropping it.
- **core** — both candidate strategies pass the opted-out layer indexes to
  `buildCandidateStore`, which skips those batches at the single enumeration
  point (`candidate-store-indexes.ts`). One seam covers `hitTest`, `nearest`,
  grouping and traversal together.
- **svelte** — `inspect` forwarded from the geom props proxy through the
  registry descriptor into the layer input, so the docs lesson can be written in
  component form.

## Why the layer, not `InspectOptions`

The spec is sold as a portable JSON document. "This layer is decoration" is
author intent and has to survive a JSON round trip and `renderToSVGString`; a
runtime prop would not. A runtime override could still be added later.

Rect hit maths is untouched, so layers that want an area tooltip — bars, tiles,
heatmaps — keep one. This is an opt-out, not a redesign of the hit model.

## Two corrections the tests forced on the original diagnosis

- **`hitTest` was never the failing path.** It resolves topmost, so a point
  painted above the band already wins on its own anchor. `nearest` is where the
  band wins.
- **In `exact` mode the opt-out returns nothing off-mark rather than a distant
  point**, because exact mode wants a real hit and a point only gives one when
  the pointer is on it. That is correct, and better than a false hit, but it
  means #1068 should also reconsider the chart's inspect mode rather than only
  opting the bands out. Noted there.

## Tests

Five in core (`candidates-layer-inspect-opt-out.test.ts`): candidates excluded,
`exact` no longer answers off-mark, axis modes still find points, omitting the
field is a no-op, traversal skips the layer. Three in svelte for the prop
reaching the spec, including that an absent prop does not become a literal
`inspect: undefined` in a spec that claims to be strict JSON.

Full suite green: 2415 core+spec, 159 svelte SSR, plus `check`, `check:svelte`,
lint and format. `schema/v0.json` regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1071" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->