### PR TITLE
fix(spec): close REQUIRED_CHANNELS and AES_CHANNEL_KEYS drift (#1078)

### DIFF
--- a/.changeset/1078-required-channels-drift.md
+++ b/.changeset/1078-required-channels-drift.md
@@ -1,0 +1,17 @@
+---
+"@ggsvelte/spec": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+fix(spec): require channels for label, hex, bin_2d, qq, and qq_line
+
+Tier-2 validation listed only 43 of 49 geoms in `REQUIRED_CHANNELS`, so
+`label` (unlike `text`) accepted a missing `label` channel, and `hex`,
+`bin_2d`, `qq`, and `qq_line` required nothing. The table is now total over
+`GeomName`; `AES_CHANNEL_KEYS` is derived from `CHANNELS` so path mapping
+cannot lag the catalog.
+
+Migration: specs that omit required channels for those geoms will start
+failing `validate(spec, {})` with `missing-required-channel` — map the
+channels (or fix the geom). Annotation-only `abline` is unchanged.

--- a/packages/spec/src/validate-map-forms.ts
+++ b/packages/spec/src/validate-map-forms.ts
@@ -4,32 +4,16 @@
  */
 import type { TLocalizedValidationError } from "typebox/error";
 
+import { CHANNELS } from "./schema-catalog.js";
 import { isRecord, pathSegments, type UnionMemberInfo } from "./validate-schema-walk.js";
 
 export const CHANNEL_FIX_EXAMPLE = { field: "column_name" };
 
-/** Channel names that live under aes (plot- or layer-level). */
-const AES_CHANNEL_KEYS = new Set([
-  "x",
-  "y",
-  "color",
-  "fill",
-  "size",
-  "linewidth",
-  "alpha",
-  "shape",
-  "linetype",
-  "group",
-  "label",
-  "weight",
-  "sample",
-  "ymin",
-  "ymax",
-  "xmin",
-  "xmax",
-  "xend",
-  "yend",
-]);
+/**
+ * Channel names that live under aes (plot- or layer-level).
+ * Derived from CHANNELS so path classification cannot drift behind the catalog (#1078).
+ */
+const AES_CHANNEL_KEYS = new Set<string>(CHANNELS);
 
 /** True only for the channel node itself (`…/aes/<channel>`), not nested paths. */
 export function isChannelPath(path: string): boolean {

--- a/packages/spec/src/validate-structure-layers.ts
+++ b/packages/spec/src/validate-structure-layers.ts
@@ -5,7 +5,7 @@
  * Barrel: validate-structure.ts.
  */
 import type { SpecError } from "./errors.js";
-import type { Aes, ChannelName } from "./schema.js";
+import type { Aes, ChannelName, GeomName } from "./schema.js";
 import { GEOM_DEFAULTS } from "./schema.js";
 import { STYLE_AESTHETIC_GEOMS, type StyleAesthetic } from "./capabilities.js";
 import { effectiveChannel } from "./validate-data.js";
@@ -17,8 +17,12 @@ function isRecord(v: unknown): v is Record<string, unknown> {
   return typeof v === "object" && v !== null && !Array.isArray(v);
 }
 
-/** Channels every geom needs mapped (after plot-aes inheritance). */
-const REQUIRED_CHANNELS: Record<string, ChannelName[]> = {
+/**
+ * Channels every geom needs mapped (after plot-aes inheritance).
+ * Total over GeomName — a missing geom is a type error, not a silent `?? []`
+ * (#1078). Empty lists are deliberate (form-checked elsewhere or annotation-only).
+ */
+const REQUIRED_CHANNELS: Record<GeomName, readonly ChannelName[]> = {
   point: ["x", "y"],
   count: ["x", "y"],
   jitter: ["x", "y"],
@@ -34,6 +38,7 @@ const REQUIRED_CHANNELS: Record<string, ChannelName[]> = {
   hline: [], // form-checked like rule (yintercept / aes.y)
   vline: [], // form-checked like rule (xintercept / aes.x)
   text: ["x", "y", "label"],
+  label: ["x", "y", "label"], // same contract as text (#1078)
   sf_text: ["label"], // x/y come from stat_sf_coordinates (#809 phase 2)
   sf_label: ["label"],
   sf: [], // geometry column, not aes
@@ -59,6 +64,11 @@ const REQUIRED_CHANNELS: Record<string, ChannelName[]> = {
   quantile: ["x", "y"],
   density_2d: ["x", "y"],
   density_2d_filled: ["x", "y"],
+  hex: ["x", "y"],
+  bin_2d: ["x", "y"],
+  abline: [], // annotation-only: slope/intercept in params
+  qq: ["sample"],
+  qq_line: ["sample"],
   dotplot: ["x"],
   map: ["map_id"],
   blank: [], // trains whatever is mapped; nothing required
@@ -471,7 +481,7 @@ export function layerStructuralErrors(
 
   errors.push(...paintStructuralErrors(layer, layerPath, plotAes));
 
-  for (const channel of REQUIRED_CHANNELS[geom] ?? []) {
+  for (const channel of REQUIRED_CHANNELS[geom as GeomName]) {
     if (
       (geom === "bar" ||
         geom === "histogram" ||

--- a/packages/spec/tests/validate-map-errors.test.ts
+++ b/packages/spec/tests/validate-map-errors.test.ts
@@ -10,6 +10,8 @@
  */
 import { describe, expect, it } from "bun:test";
 
+import { CHANNELS } from "../src/schema-catalog.ts";
+import { isChannelPath } from "../src/validate-map-forms.ts";
 import { validate } from "../src/validate.ts";
 
 function errorsOf(input: unknown) {
@@ -115,6 +117,31 @@ describe("validate — TypeBox 1.x error mapping (Codex P2 regressions)", () => 
           e.message.includes("mixes"),
       ),
     ).toBe(true);
+  });
+
+  // #1078: AES_CHANNEL_KEYS must cover every CHANNELS entry (was 19 of 25).
+  it("isChannelPath recognizes every CHANNELS name under /aes/", () => {
+    for (const channel of CHANNELS) {
+      expect(isChannelPath(`/layers/0/aes/${channel}`), channel).toBe(true);
+      expect(isChannelPath(`/aes/${channel}`), `plot ${channel}`).toBe(true);
+    }
+    expect(isChannelPath("/layers/0/aes/z/field")).toBe(false);
+    expect(isChannelPath("/layers/0/data")).toBe(false);
+  });
+
+  it("bare-string aes.z gets the friendly channel-form message, not raw union noise", () => {
+    const errors = errorsOf({
+      layers: [
+        {
+          geom: "contour",
+          aes: { x: { field: "a" }, y: { field: "b" }, z: "height" },
+        },
+      ],
+    });
+    expect(errors.some((e) => e.code === "invalid-type" && e.path === "")).toBe(false);
+    const zErr = errors.find((e) => e.path === "/layers/0/aes/z");
+    expect(zErr?.code).toBe("invalid-channel-value");
+    expect(zErr?.message).toContain('canonical form {"field": "height"}');
   });
 
   it("field form with scale (ValueRef-only key) reports unexpected-property", () => {

--- a/packages/spec/tests/validate-tier2-structure.test.ts
+++ b/packages/spec/tests/validate-tier2-structure.test.ts
@@ -35,6 +35,71 @@ describe("tier 2 — structural grammar checks (opt-in, data-free)", () => {
     expect(errors[0]?.path).toBe("/layers/0/aes/label");
   });
 
+  // #1078: REQUIRED_CHANNELS drifted — six geoms were unlisted and required nothing.
+  it("label requires x, y, and label (same contract as text)", () => {
+    const spec = {
+      aes: { x: { field: "city" }, y: { field: "temp" } },
+      layers: [{ geom: "label" }],
+    };
+    const errors = errorsOf(spec);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.code).toBe("missing-required-channel");
+    expect(errors[0]?.path).toBe("/layers/0/aes/label");
+  });
+
+  it("hex and bin_2d require continuous x and y", () => {
+    expect(codesOf({ layers: [{ geom: "hex" }] })).toEqual([
+      "missing-required-channel",
+      "missing-required-channel",
+    ]);
+    expect(codesOf({ layers: [{ geom: "bin_2d" }] })).toEqual([
+      "missing-required-channel",
+      "missing-required-channel",
+    ]);
+    // x/y present → tier-2 accepts (no data profile needed for channel presence)
+    expect(
+      validate(
+        {
+          aes: { x: { field: "a" }, y: { field: "b" } },
+          layers: [{ geom: "hex" }, { geom: "bin_2d" }],
+        },
+        {},
+      ).ok,
+    ).toBe(true);
+  });
+
+  it("qq and qq_line require the sample channel", () => {
+    const qq = errorsOf({ layers: [{ geom: "qq" }] });
+    expect(
+      qq.some((e) => e.code === "missing-required-channel" && e.path === "/layers/0/aes/sample"),
+    ).toBe(true);
+    const line = errorsOf({ layers: [{ geom: "qq_line" }] });
+    expect(
+      line.some((e) => e.code === "missing-required-channel" && e.path === "/layers/0/aes/sample"),
+    ).toBe(true);
+    expect(
+      validate(
+        {
+          aes: { sample: { field: "value" } },
+          layers: [{ geom: "qq" }, { geom: "qq_line" }],
+        },
+        {},
+      ).ok,
+    ).toBe(true);
+  });
+
+  it("abline is annotation-only: no required aes channels", () => {
+    // Listed in REQUIRED_CHANNELS as [] so the table is total over GeomName;
+    // params carry slope/intercept (not aes). Missing params is not a channel error.
+    const withParams = validate(
+      { layers: [{ geom: "abline", params: { slope: 1, intercept: 0 } }] },
+      {},
+    );
+    expect(withParams.ok).toBe(true);
+    const bare = validate({ layers: [{ geom: "abline" }] }, {});
+    expect(bare.ok).toBe(true);
+  });
+
   it("bar with mapped y is rejected with a col suggestion", () => {
     const errors = errorsOf({
       aes: { x: { field: "city" }, y: { field: "temp" } },


### PR DESCRIPTION
## Summary

Closes the **live validation gap** from #1078 step 1 (drift first; full geom table is later PRs).

- **`REQUIRED_CHANNELS`**: typed as `Record<GeomName, readonly ChannelName[]>`, fills the six missing geoms (`label` → x/y/label; `hex`/`bin_2d` → x/y; `qq`/`qq_line` → sample; `abline` → `[]` annotation-only), drops the silent `?? []` so unlisted geoms cannot require nothing.
- **`AES_CHANNEL_KEYS`**: derived from `CHANNELS` so path classification stays total over the catalog (was 19 of 25).

## Tests (TDD)

- Red then green: `label` without `label` channel fails; `hex`/`bin_2d` require x/y; `qq`/`qq_line` require `sample`; `abline` needs no aes channels.
- `isChannelPath` is true for every `CHANNELS` name; bare-string `aes.z` keeps the friendly channel-form message.

## Out of scope (later PRs per #1078)

- One geom table + emitted/derived lists
- `schema-declarations.ts` field builders
- `runtime.ts` / builder mixin work (#1081)

Does not close #1078 — the full geom table remains open; this is the shippable drift fix the issue sequences first.

## Test plan

- [x] `bun test packages/spec/tests/validate-tier2-structure.test.ts packages/spec/tests/validate-map-errors.test.ts`
- [x] `tsc -p packages/spec --noEmit`
- [ ] CI green
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1090" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->