### PR TITLE
refactor(core): give panel layout one owner and a test surface (#1076)

### DIFF
--- a/packages/core/src/layout/panels.ts
+++ b/packages/core/src/layout/panels.ts
@@ -6,11 +6,7 @@
  * under pipeline/panel-layout*.ts; this module is the stable public seam
  * (#1076). ADR-0003 two-pass layout is unchanged.
  */
-export {
-  layoutPanels,
-  computePanelLayout,
-  type PanelLayoutInput,
-} from "../pipeline/panel-layout.js";
+export { layoutPanels, type PanelLayoutInput } from "../pipeline/panel-layout.js";
 export type {
   FacetScaleFreedom,
   PanelLayout,

--- a/packages/core/src/layout/panels.ts
+++ b/packages/core/src/layout/panels.ts
@@ -1,0 +1,19 @@
+/**
+ * Panel layout owner: placement, chrome, guides, and fixed-aspect fitting.
+ *
+ * Callers (finalize-layout-pass, direct tests) use `layoutPanels` and read
+ * `PanelLayout.guides` rather than re-resolving axis guides. Internals stay
+ * under pipeline/panel-layout*.ts; this module is the stable public seam
+ * (#1076). ADR-0003 two-pass layout is unchanged.
+ */
+export {
+  layoutPanels,
+  computePanelLayout,
+  type PanelLayoutInput,
+} from "../pipeline/panel-layout.js";
+export type {
+  FacetScaleFreedom,
+  PanelLayout,
+  PanelLayoutResult,
+  PanelPlacement,
+} from "../pipeline/panel-layout-types.js";

--- a/packages/core/src/layout/panels.ts
+++ b/packages/core/src/layout/panels.ts
@@ -6,10 +6,12 @@
  * under pipeline/panel-layout*.ts; this module is the stable public seam
  * (#1076). ADR-0003 two-pass layout is unchanged.
  */
-export { layoutPanels, type PanelLayoutInput } from "../pipeline/panel-layout.js";
-export type {
-  FacetScaleFreedom,
-  PanelLayout,
-  PanelLayoutResult,
-  PanelPlacement,
-} from "../pipeline/panel-layout-types.js";
+export {
+  layoutPanels,
+  type PanelLayoutInput,
+  type FacetScaleFreedom,
+  type PanelPlacement,
+} from "../pipeline/panel-layout.js";
+
+/** Public name for the layout-owned result (#1076). */
+export type { PanelLayoutResult as PanelLayout } from "../pipeline/panel-layout.js";

--- a/packages/core/src/layout/temporal-guide.ts
+++ b/packages/core/src/layout/temporal-guide.ts
@@ -1,6 +1,7 @@
 /**
- * Temporal axis guide planning and stable re-exports for guide plan types,
- * basic (non-temporal) axis assembly, and temporal interval planning.
+ * Temporal axis guide planning and stable re-exports for guide plan types
+ * and temporal interval planning. Non-temporal axis assembly lives in
+ * `basic-axis.ts` (import `planBasicAxis` from there).
  *
  * Guide plan type contracts live in `guide-plan-types.ts`.
  */
@@ -34,7 +35,6 @@ export type {
 } from "./guide-plan-types.js";
 
 export type { TemporalAxisPlanInput } from "./temporal-axis-types.js";
-export { planBasicAxis } from "./basic-axis.js";
 
 export class TemporalGuideIntervalError extends Error {
   override readonly cause: TemporalIntervalError;

--- a/packages/core/src/pipeline/assemble-scene-legends.ts
+++ b/packages/core/src/pipeline/assemble-scene-legends.ts
@@ -4,25 +4,9 @@
 import type { SceneLegend } from "../scene.js";
 
 import { LEGEND_EDGE_PAD } from "./layout-helpers.js";
+import { containedRightLegendY } from "./legend-right-y.js";
 
-export function containedRightLegendY(input: {
-  legends: readonly SceneLegend[];
-  panelY: number;
-  minimumY: number;
-  sceneHeight: number;
-  bottomInset: number;
-}): number {
-  const rightExtent = input.legends.reduce(
-    (extent, legend) =>
-      legend.position === "right" ? Math.max(extent, legend.y + legend.height) : extent,
-    0,
-  );
-  if (rightExtent === 0) return input.panelY;
-  return Math.max(
-    input.minimumY,
-    Math.min(input.panelY, input.sceneHeight - input.bottomInset - rightExtent),
-  );
-}
+export { containedRightLegendY } from "./legend-right-y.js";
 
 export function placeSceneLegends(input: {
   legends: readonly SceneLegend[];

--- a/packages/core/src/pipeline/assemble-scene-legends.ts
+++ b/packages/core/src/pipeline/assemble-scene-legends.ts
@@ -6,8 +6,6 @@ import type { SceneLegend } from "../scene.js";
 import { LEGEND_EDGE_PAD } from "./layout-helpers.js";
 import { containedRightLegendY } from "./legend-right-y.js";
 
-export { containedRightLegendY } from "./legend-right-y.js";
-
 export function placeSceneLegends(input: {
   legends: readonly SceneLegend[];
   legendWidth: number;

--- a/packages/core/src/pipeline/finalize-geometry-scene.ts
+++ b/packages/core/src/pipeline/finalize-geometry-scene.ts
@@ -10,7 +10,6 @@ import type { ThemeTokens } from "../theme.js";
 
 import { buildGeometryBatches } from "./assemble-geometry-batches.js";
 import { assembleScene } from "./assemble-scene-build.js";
-import { resolveAxisGuide } from "./guide-config.js";
 import type { PanelLayoutResult } from "./panel-layout.js";
 import type { PreparedPanels } from "./prepare-panels.js";
 import type { TrainedPipelineScales } from "./train-pipeline-scales.js";
@@ -66,8 +65,8 @@ export function finalizeGeometryAndScene(input: {
   perfMark("ggsvelte:geometry:end");
   perfMeasure("ggsvelte:geometry", "ggsvelte:geometry:start", "ggsvelte:geometry:end");
 
-  const xGuide = resolveAxisGuide("x", trained.scalesConfig, normalized.guides, theme);
-  const yGuide = resolveAxisGuide("y", trained.scalesConfig, normalized.guides, theme);
+  // Guides were resolved once in finalizePanelLayoutPass / layoutPanels and
+  // carried on panelLayout — do not call resolveAxisGuide again (#1076).
   return assembleScene({
     width: options.width,
     height: options.height,
@@ -78,8 +77,8 @@ export function finalizeGeometryAndScene(input: {
     displayScales: panelLayout.displayScales,
     hTitle: panelLayout.hTitle,
     vTitle: panelLayout.vTitle,
-    hGuide: flip ? yGuide : xGuide,
-    vGuide: flip ? xGuide : yGuide,
+    hGuide: panelLayout.guides.h,
+    vGuide: panelLayout.guides.v,
     coordProjectors,
     ...(options.measureText !== undefined && { measureText: options.measureText }),
     axisTextSize: theme.axisTextSize,

--- a/packages/core/src/pipeline/finalize-layout-pass.ts
+++ b/packages/core/src/pipeline/finalize-layout-pass.ts
@@ -8,7 +8,7 @@ import type { ThemeTokens } from "../theme.js";
 
 import { TemporalGuideIntervalError } from "../layout/temporal-guide.js";
 import { prepareLegendInputs, resolveAxisGuide } from "./guide-config.js";
-import { computePanelLayout } from "./panel-layout.js";
+import { layoutPanels } from "./panel-layout.js";
 import type { PanelLayoutResult } from "./panel-layout.js";
 import type { PreparedPanels } from "./prepare-panels.js";
 import type { TrainedPipelineScales } from "./train-pipeline-scales.js";
@@ -105,11 +105,10 @@ export function finalizePanelLayoutPass(input: {
   perfMark("ggsvelte:layout:start");
   let panelLayout: PanelLayoutResult;
   try {
-    panelLayout = computePanelLayout({
+    panelLayout = layoutPanels({
       flip,
       faceted,
-      freeX,
-      freeY,
+      freedom: { freeX, freeY },
       ...((normalized.coord?.type === "fixed" || normalized.coord?.type === "sf") && {
         coordFixed: normalized.coord,
       }),

--- a/packages/core/src/pipeline/legend-right-y.ts
+++ b/packages/core/src/pipeline/legend-right-y.ts
@@ -1,0 +1,23 @@
+/**
+ * Vertical placement helper for right-edge legends.
+ * Shared by panel layout (fit check) and scene legend placement — neither owns the other.
+ */
+
+export function containedRightLegendY(input: {
+  legends: readonly { position?: string; y: number; height: number }[];
+  panelY: number;
+  minimumY: number;
+  sceneHeight: number;
+  bottomInset: number;
+}): number {
+  const rightExtent = input.legends.reduce(
+    (extent, legend) =>
+      legend.position === "right" ? Math.max(extent, legend.y + legend.height) : extent,
+    0,
+  );
+  if (rightExtent === 0) return input.panelY;
+  return Math.max(
+    input.minimumY,
+    Math.min(input.panelY, input.sceneHeight - input.bottomInset - rightExtent),
+  );
+}

--- a/packages/core/src/pipeline/panel-layout-chrome.ts
+++ b/packages/core/src/pipeline/panel-layout-chrome.ts
@@ -102,7 +102,7 @@ interface PanelLayoutLabs {
   axisTitleBand: number;
 }
 
-export function flipDisplayTitles(
+function flipDisplayTitles(
   flip: boolean,
   xTitle: string,
   yTitle: string,
@@ -129,7 +129,7 @@ function flipDisplayBreaks(
   return flip ? { hBreaks: yBreaks, vBreaks: xBreaks } : { hBreaks: xBreaks, vBreaks: yBreaks };
 }
 
-export function flipDisplayFreeFlags(
+function flipDisplayFreeFlags(
   flip: boolean,
   freeX: boolean,
   freeY: boolean,

--- a/packages/core/src/pipeline/panel-layout-types.ts
+++ b/packages/core/src/pipeline/panel-layout-types.ts
@@ -11,6 +11,14 @@ import type { AxisGuidePlan } from "../layout/temporal-guide.js";
 import type { PositionScale } from "../scales/train.js";
 import { buildLegends } from "../legend.js";
 
+import type { AxisGuideAppearance } from "./guide-config.js";
+
+/** Owned free-scale flags for facet position scales (derived once at facet resolve). */
+export type FacetScaleFreedom = {
+  readonly freeX: boolean;
+  readonly freeY: boolean;
+};
+
 export interface PanelPlacement {
   x: number;
   y: number;
@@ -26,6 +34,10 @@ export interface PanelPlacement {
   allocation?: { x: number; y: number; width: number; height: number };
 }
 
+/**
+ * Result of `layoutPanels`: placements, chrome, and axis guides resolved once.
+ * Scene assembly reads `guides` rather than calling resolveAxisGuide again.
+ */
 export interface PanelLayoutResult {
   placements: PanelPlacement[];
   title: string;
@@ -39,6 +51,13 @@ export interface PanelLayoutResult {
   bottomBand: number;
   formatX: TickFormatter | undefined;
   formatY: TickFormatter | undefined;
+  /** Display-space formatters (already flipped when coord_flip is on). */
+  formatters: { readonly h: TickFormatter | undefined; readonly v: TickFormatter | undefined };
+  /** Display-space free flags (already flipped when coord_flip is on). */
+  freeH: boolean;
+  freeV: boolean;
+  /** Resolved once in layout; scene assembly must not re-resolve. */
+  guides: { readonly h: AxisGuideAppearance; readonly v: AxisGuideAppearance };
   displayScales: (p: number) => { h: PositionScale; v: PositionScale };
   legendBlock: ReturnType<typeof buildLegends>;
   guidePlans: readonly AxisGuidePlan[];
@@ -48,6 +67,9 @@ export interface PanelLayoutResult {
   /** Measured strip band size in px (0 when hidden / unfaceted). */
   stripBand: number;
 }
+
+/** Public name for the layout-owned result (#1076). */
+export type PanelLayout = PanelLayoutResult;
 
 export type DisplayScalesFn = (p: number) => { h: PositionScale; v: PositionScale };
 export type DisplayTemporalFn = (p: number) => {

--- a/packages/core/src/pipeline/panel-layout-types.ts
+++ b/packages/core/src/pipeline/panel-layout-types.ts
@@ -68,9 +68,6 @@ export interface PanelLayoutResult {
   stripBand: number;
 }
 
-/** Public name for the layout-owned result (#1076). */
-export type PanelLayout = PanelLayoutResult;
-
 export type DisplayScalesFn = (p: number) => { h: PositionScale; v: PositionScale };
 export type DisplayTemporalFn = (p: number) => {
   h?: TemporalLayoutDomainContext;

--- a/packages/core/src/pipeline/panel-layout.ts
+++ b/packages/core/src/pipeline/panel-layout.ts
@@ -1,12 +1,14 @@
 /**
  * Two-pass panel layout: facet grids and single-panel plots, including
  * axis-title/legend chrome and free-scale edge axes.
+ *
+ * Public entry: `layoutPanels` (also re-exported from `layout/panels.ts`).
+ * Owns placement, chrome, and the resolved axis guides for the run so scene
+ * assembly does not re-resolve them (ADR-0003 two-pass layout stands).
  */
 import type { PortableSpec, TemporalKind } from "@ggsvelte/spec";
 
-import type { FixedAspectCoordSpec } from "./panel-layout-fixed.js";
-import { planBasicAxis } from "../layout/temporal-guide.js";
-
+import { planBasicAxis } from "../layout/basic-axis.js";
 import {
   assertLegendBlockFitsPlacedArea,
   LegendLayoutError,
@@ -19,22 +21,57 @@ import type { ThemeTokens } from "../theme.js";
 import type { FacetPanelDef, FacetStripConfig } from "./facets.js";
 import { DEFAULT_FACET_STRIP } from "./facets.js";
 import { measureFacetStripBand } from "./facets-strip.js";
-import { LEGEND_EDGE_PAD } from "./layout-helpers.js";
 import type { AxisGuideAppearance } from "./guide-config.js";
+import { LEGEND_EDGE_PAD } from "./layout-helpers.js";
+import { containedRightLegendY } from "./legend-right-y.js";
 import { resolvePanelLayoutChrome, type PanelLayoutChrome } from "./panel-layout-chrome.js";
-import { containedRightLegendY } from "./assemble-scene-legends.js";
-import { applyFixedAspectLayout } from "./panel-layout-fixed.js";
+import { applyFixedAspectLayout, type FixedAspectCoordSpec } from "./panel-layout-fixed.js";
 import { buildPanelPlacements } from "./panel-layout-placements.js";
-import type { PanelLayoutResult, PanelPlacement } from "./panel-layout-types.js";
+import type { FacetScaleFreedom, PanelLayoutResult, PanelPlacement } from "./panel-layout-types.js";
 import { PipelineError, type LayerFrame, type PipelineWarning, type RunOptions } from "./types.js";
 
-export type { PanelPlacement, PanelLayoutResult } from "./panel-layout-types.js";
+export type {
+  FacetScaleFreedom,
+  PanelLayout,
+  PanelLayoutResult,
+  PanelPlacement,
+} from "./panel-layout-types.js";
+
+/** Input to the panel-layout owner. Freedom is one value, not freeX/freeY per hop. */
+export interface PanelLayoutInput {
+  flip: boolean;
+  faceted: boolean;
+  freedom: FacetScaleFreedom;
+  coordFixed?: FixedAspectCoordSpec | undefined;
+  nrow: number;
+  ncol: number;
+  facetPanels: readonly FacetPanelDef[];
+  strip?: FacetStripConfig;
+  panelScales: readonly { x: PositionScale; y: PositionScale }[];
+  allFrames: readonly LayerFrame[];
+  hGuide: AxisGuideAppearance;
+  vGuide: AxisGuideAppearance;
+  labs: NonNullable<PortableSpec["labs"]>;
+  scalesConfig: NonNullable<PortableSpec["scales"]>;
+  xScale: PositionScale;
+  yScale: PositionScale;
+  xTemporalKind: TemporalKind | null;
+  yTemporalKind: TemporalKind | null;
+  legendInputs: readonly LegendInput[];
+  legendOrder: LegendOrder;
+  theme: ThemeTokens;
+  layoutAxisTitleSize: number;
+  layoutAxisTextSize: number;
+  options: Pick<RunOptions, "width" | "height" | "measureText">;
+  warnings: PipelineWarning[];
+}
 
 function panelLayoutResultFromChrome(
   chrome: PanelLayoutChrome,
   placements: PanelPlacement[],
   strip: import("./facets-types.js").FacetStripConfig,
   stripBand: number,
+  guides: { readonly h: AxisGuideAppearance; readonly v: AxisGuideAppearance },
   degraded = false,
 ): PanelLayoutResult {
   const guidePlans = placements.flatMap((placement, panelIndex) => {
@@ -81,6 +118,10 @@ function panelLayoutResultFromChrome(
     bottomBand: chrome.bottomBand,
     formatX: chrome.formatX,
     formatY: chrome.formatY,
+    formatters: { h: chrome.formatH, v: chrome.formatV },
+    freeH: chrome.freeH,
+    freeV: chrome.freeV,
+    guides,
     displayScales: chrome.displayScales,
     legendBlock: chrome.legendBlock,
     guidePlans: Object.freeze(guidePlans),
@@ -90,38 +131,36 @@ function panelLayoutResultFromChrome(
   };
 }
 
-export function computePanelLayout(input: {
-  flip: boolean;
-  faceted: boolean;
-  freeX: boolean;
-  freeY: boolean;
-  coordFixed?: FixedAspectCoordSpec | undefined;
-  nrow: number;
-  ncol: number;
-  facetPanels: readonly FacetPanelDef[];
-  strip?: FacetStripConfig;
-  panelScales: readonly { x: PositionScale; y: PositionScale }[];
-  allFrames: readonly LayerFrame[];
-  hGuide: AxisGuideAppearance;
-  vGuide: AxisGuideAppearance;
-  labs: NonNullable<PortableSpec["labs"]>;
-  scalesConfig: NonNullable<PortableSpec["scales"]>;
-  xScale: PositionScale;
-  yScale: PositionScale;
-  xTemporalKind: TemporalKind | null;
-  yTemporalKind: TemporalKind | null;
-  legendInputs: readonly LegendInput[];
-  legendOrder: LegendOrder;
-  theme: ThemeTokens;
-  layoutAxisTitleSize: number;
-  layoutAxisTextSize: number;
-  options: Pick<RunOptions, "width" | "height" | "measureText">;
-  warnings: PipelineWarning[];
-}): PanelLayoutResult {
-  const { faceted, nrow, ncol, facetPanels, options } = input;
+/**
+ * Panel placement, chrome, and resolved axis guides.
+ * Owns the two-pass layout (ADR-0003) end to end for this plot run.
+ */
+export function layoutPanels(input: PanelLayoutInput): PanelLayoutResult {
+  const { faceted, nrow, ncol, facetPanels, options, freedom } = input;
   const strip = input.strip ?? DEFAULT_FACET_STRIP;
+  const freeX = freedom.freeX;
+  const freeY = freedom.freeY;
 
-  const chrome = resolvePanelLayoutChrome(input);
+  const chrome = resolvePanelLayoutChrome({
+    flip: input.flip,
+    freeX,
+    freeY,
+    panelScales: input.panelScales,
+    allFrames: input.allFrames,
+    labs: input.labs,
+    scalesConfig: input.scalesConfig,
+    xScale: input.xScale,
+    yScale: input.yScale,
+    xTemporalKind: input.xTemporalKind,
+    yTemporalKind: input.yTemporalKind,
+    legendInputs: input.legendInputs,
+    legendOrder: input.legendOrder,
+    theme: input.theme,
+    layoutAxisTitleSize: input.layoutAxisTitleSize,
+    layoutAxisTextSize: input.layoutAxisTextSize,
+    options: input.options,
+    warnings: input.warnings,
+  });
   let stripBand = measureFacetStripBand({
     faceted,
     strip,
@@ -188,8 +227,8 @@ export function computePanelLayout(input: {
       panelScales: input.panelScales,
       coord: input.coordFixed,
       faceted,
-      freeX: input.freeX,
-      freeY: input.freeY,
+      freeX,
+      freeY,
       scalesConfig: input.scalesConfig,
       warnings: input.warnings,
     });
@@ -224,5 +263,15 @@ export function computePanelLayout(input: {
     );
   }
 
-  return panelLayoutResultFromChrome(chrome, placements, strip, stripBand, degraded);
+  return panelLayoutResultFromChrome(
+    chrome,
+    placements,
+    strip,
+    stripBand,
+    { h: input.hGuide, v: input.vGuide },
+    degraded,
+  );
 }
+
+/** @deprecated Prefer {@link layoutPanels}. */
+export const computePanelLayout = layoutPanels;

--- a/packages/core/src/pipeline/panel-layout.ts
+++ b/packages/core/src/pipeline/panel-layout.ts
@@ -30,12 +30,7 @@ import { buildPanelPlacements } from "./panel-layout-placements.js";
 import type { FacetScaleFreedom, PanelLayoutResult, PanelPlacement } from "./panel-layout-types.js";
 import { PipelineError, type LayerFrame, type PipelineWarning, type RunOptions } from "./types.js";
 
-export type {
-  FacetScaleFreedom,
-  PanelLayout,
-  PanelLayoutResult,
-  PanelPlacement,
-} from "./panel-layout-types.js";
+export type { FacetScaleFreedom, PanelLayoutResult, PanelPlacement } from "./panel-layout-types.js";
 
 /** Input to the panel-layout owner. Freedom is one value, not freeX/freeY per hop. */
 export interface PanelLayoutInput {

--- a/packages/core/src/pipeline/panel-layout.ts
+++ b/packages/core/src/pipeline/panel-layout.ts
@@ -272,6 +272,3 @@ export function layoutPanels(input: PanelLayoutInput): PanelLayoutResult {
     degraded,
   );
 }
-
-/** @deprecated Prefer {@link layoutPanels}. */
-export const computePanelLayout = layoutPanels;

--- a/packages/core/tests/layout/panels.test.ts
+++ b/packages/core/tests/layout/panels.test.ts
@@ -8,8 +8,13 @@ import { describe, expect, it, spyOn } from "bun:test";
 import { aes, gg } from "@ggsvelte/spec";
 import type { PortableSpec } from "@ggsvelte/spec";
 
-import { layoutPanels } from "../../src/layout/panels.ts";
-import type { PanelLayoutInput } from "../../src/layout/panels.ts";
+import {
+  layoutPanels,
+  type FacetScaleFreedom,
+  type PanelLayout,
+  type PanelLayoutInput,
+  type PanelPlacement,
+} from "../../src/layout/panels.ts";
 import * as guideConfig from "../../src/pipeline/guide-config.ts";
 import type { AxisGuideAppearance } from "../../src/pipeline/guide-config.ts";
 import { runPipeline } from "../../src/pipeline.ts";
@@ -66,10 +71,12 @@ function baseInput(over: Partial<PanelLayoutInput> = {}): PanelLayoutInput {
 
 describe("layoutPanels", () => {
   it("is callable with a hand-built input (no runPipeline, no scene)", () => {
-    const result = layoutPanels(baseInput());
+    const freedom: FacetScaleFreedom = { freeX: false, freeY: false };
+    const result: PanelLayout = layoutPanels(baseInput({ freedom }));
+    const panel: PanelPlacement = result.placements[0]!;
     expect(result.placements).toHaveLength(1);
-    expect(result.placements[0]!.width).toBeGreaterThan(200);
-    expect(result.placements[0]!.height).toBeGreaterThan(150);
+    expect(panel.width).toBeGreaterThan(200);
+    expect(panel.height).toBeGreaterThan(150);
     expect(result.guides.h.visible).toBe(true);
     expect(result.guides.v.visible).toBe(true);
     expect(result.hTitle).toBe("X");

--- a/packages/core/tests/layout/panels.test.ts
+++ b/packages/core/tests/layout/panels.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Direct tests for layoutPanels — the single owner of panel placement,
+ * chrome, and axis guides (#1076). No runPipeline; no scene assembly
+ * except the one end-to-end call-count check.
+ */
+import { describe, expect, it, spyOn } from "bun:test";
+
+import { aes, gg } from "@ggsvelte/spec";
+import type { PortableSpec } from "@ggsvelte/spec";
+
+import { layoutPanels } from "../../src/layout/panels.ts";
+import type { PanelLayoutInput } from "../../src/layout/panels.ts";
+import * as guideConfig from "../../src/pipeline/guide-config.ts";
+import type { AxisGuideAppearance } from "../../src/pipeline/guide-config.ts";
+import { runPipeline } from "../../src/pipeline.ts";
+import { trainLinear } from "../../src/scales/train.ts";
+import { resolveTheme } from "../../src/theme.ts";
+
+const guide = (over: Partial<AxisGuideAppearance> = {}): AxisGuideAppearance => ({
+  visible: true,
+  showTicks: true,
+  showLabels: true,
+  collision: "auto",
+  ...over,
+});
+
+function linearScale(min = 0, max = 10) {
+  return trainLinear([new Float64Array([min, max])]).scale;
+}
+
+function baseInput(over: Partial<PanelLayoutInput> = {}): PanelLayoutInput {
+  const xScale = linearScale();
+  const yScale = linearScale(0, 100);
+  const labs: NonNullable<PortableSpec["labs"]> = {
+    x: "X",
+    y: "Y",
+    ...over.labs,
+  };
+  return {
+    flip: false,
+    faceted: false,
+    freedom: { freeX: false, freeY: false },
+    nrow: 1,
+    ncol: 1,
+    facetPanels: [],
+    panelScales: [{ x: xScale, y: yScale }],
+    allFrames: [],
+    hGuide: guide(),
+    vGuide: guide(),
+    scalesConfig: {},
+    xScale,
+    yScale,
+    xTemporalKind: null,
+    yTemporalKind: null,
+    legendInputs: [],
+    legendOrder: "stable-domain",
+    theme: resolveTheme("default"),
+    layoutAxisTitleSize: 12,
+    layoutAxisTextSize: 10,
+    options: { width: 640, height: 400 },
+    warnings: [],
+    ...over,
+    labs,
+  };
+}
+
+describe("layoutPanels", () => {
+  it("is callable with a hand-built input (no runPipeline, no scene)", () => {
+    const result = layoutPanels(baseInput());
+    expect(result.placements).toHaveLength(1);
+    expect(result.placements[0]!.width).toBeGreaterThan(200);
+    expect(result.placements[0]!.height).toBeGreaterThan(150);
+    expect(result.guides.h.visible).toBe(true);
+    expect(result.guides.v.visible).toBe(true);
+    expect(result.hTitle).toBe("X");
+    expect(result.vTitle).toBe("Y");
+    expect(result.freeH).toBe(false);
+    expect(result.freeV).toBe(false);
+    expect(result.degraded).toBe(false);
+  });
+
+  it("swaps titles, free flags, formatters, and guide assignment under coord flip", () => {
+    const xGuide = guide({ title: "guide-x" });
+    const yGuide = guide({ title: "guide-y" });
+    // Display guides are already flipped by the caller (finalize-layout-pass).
+    const result = layoutPanels(
+      baseInput({
+        flip: true,
+        freedom: { freeX: true, freeY: false },
+        labs: { x: "X", y: "Y" },
+        hGuide: yGuide,
+        vGuide: xGuide,
+        scalesConfig: {
+          x: { labels: ".1f" },
+          y: { labels: ".3f" },
+        },
+      }),
+    );
+    expect(result.hTitle).toBe("Y");
+    expect(result.vTitle).toBe("X");
+    // freeX true, freeY false + flip → freeH = freeY = false, freeV = freeX = true
+    expect(result.freeH).toBe(false);
+    expect(result.freeV).toBe(true);
+    expect(result.guides.h).toBe(yGuide);
+    expect(result.guides.v).toBe(xGuide);
+    // Aesthetic formatters stay on formatX/Y; display formatters flip with the coord.
+    expect(result.formatters.h).toBe(result.formatY);
+    expect(result.formatters.v).toBe(result.formatX);
+    expect(typeof result.formatters.h).toBe("function");
+    expect(typeof result.formatters.v).toBe("function");
+    expect(result.formatters.h?.(1, 0.001)).toBe(result.formatY?.(1, 0.001));
+    expect(result.formatters.v?.(1, 0.1)).toBe(result.formatX?.(1, 0.1));
+  });
+
+  it("carries free_x freedom into display free flags without flip", () => {
+    const result = layoutPanels(
+      baseInput({
+        freedom: { freeX: true, freeY: false },
+      }),
+    );
+    expect(result.freeH).toBe(true);
+    expect(result.freeV).toBe(false);
+  });
+
+  it("fits the largest exact centred fixed-aspect rectangle", () => {
+    // Equal scale-space spans so ratio:1 yields a square data rectangle.
+    const xScale = linearScale(0, 10);
+    const yScale = linearScale(0, 10);
+    const result = layoutPanels(
+      baseInput({
+        xScale,
+        yScale,
+        panelScales: [{ x: xScale, y: yScale }],
+        coordFixed: { type: "fixed", ratio: 1 },
+        options: { width: 640, height: 400 },
+      }),
+    );
+    const panel = result.placements[0]!;
+    expect(panel.allocation).toBeDefined();
+    const allocation = panel.allocation!;
+    expect(panel.height / panel.width).toBeCloseTo(1, 10);
+    expect(panel.x).toBeCloseTo(allocation.x + (allocation.width - panel.width) / 2, 10);
+    expect(panel.y).toBeCloseTo(allocation.y + (allocation.height - panel.height) / 2, 10);
+    expect(result.degraded).toBe(false);
+  });
+
+  it("marks degraded when the fixed-aspect rectangle falls below 64px readable minimum", () => {
+    const warnings: { code: string }[] = [];
+    const result = layoutPanels(
+      baseInput({
+        coordFixed: { type: "fixed", ratio: 1 },
+        // Tiny plot → chrome leaves a sub-64px data rectangle.
+        options: { width: 80, height: 80 },
+        warnings: warnings as never,
+      }),
+    );
+    expect(result.degraded).toBe(true);
+    expect(warnings.some((w) => w.code === "coord-fixed-degraded")).toBe(true);
+  });
+
+  it("resolveAxisGuide is called once per axis per runPipeline (not again in scene assembly)", () => {
+    const spy = spyOn(guideConfig, "resolveAxisGuide");
+    try {
+      runPipeline(
+        gg(
+          [
+            { x: 1, y: 10 },
+            { x: 2, y: 20 },
+          ],
+          aes({ x: "x", y: "y" }),
+        )
+          .geomPoint()
+          .spec(),
+        { width: 640, height: 400 },
+      );
+      const xCalls = spy.mock.calls.filter((call) => call[0] === "x");
+      const yCalls = spy.mock.calls.filter((call) => call[0] === "y");
+      expect(xCalls).toHaveLength(1);
+      expect(yCalls).toHaveLength(1);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});

--- a/packages/core/tests/pipeline-geometry/flip-and-positions.test.ts
+++ b/packages/core/tests/pipeline-geometry/flip-and-positions.test.ts
@@ -71,13 +71,3 @@ describe("collectPointPositions", () => {
     expect([...collected.keptRows.subarray(0, 2)]).toEqual([0, 2]);
   });
 });
-
-describe("flipDisplayTitles / flipDisplayFreeFlags", () => {
-  it("swaps titles and free flags under coord flip", async () => {
-    const { flipDisplayTitles, flipDisplayFreeFlags } =
-      await import("../../src/pipeline/panel-layout-chrome.ts");
-    expect(flipDisplayTitles(true, "X", "Y")).toEqual({ hTitle: "Y", vTitle: "X" });
-    expect(flipDisplayTitles(false, "X", "Y")).toEqual({ hTitle: "X", vTitle: "Y" });
-    expect(flipDisplayFreeFlags(true, true, false)).toEqual({ freeH: false, freeV: true });
-  });
-});


### PR DESCRIPTION
## Summary

- Introduce `layoutPanels` (`packages/core/src/layout/panels.ts`) as the single panel-layout owner: placements, chrome, guides, formatters, and free flags on one result.
- Scene assembly reads `panelLayout.guides` instead of calling `resolveAxisGuide` a second time.
- Break the layout → scene-assembly reverse edge: `containedRightLegendY` lives in `legend-right-y.ts`.
- Import `planBasicAxis` from `basic-axis.ts` (not the temporal-guide barrel).
- Layout input takes `freedom: FacetScaleFreedom` rather than loose `freeX`/`freeY` at the layout seam.
- Direct TDD tests replace the ternary-only `flipDisplayTitles` export tests.

Closes #1076.

## Not in this PR

- #1075 (collapse finalize chain) — still open; this change does not require it.
- Rewriting `freeX` across all 21 pipeline files — only the layout input owns `FacetScaleFreedom` here.
- Merging `panel-layout-facet.ts` into the public module (stays an internal).

## Test plan

- [x] `bun test packages/core/tests/layout/panels.test.ts`
- [x] `bun test packages/core/tests/pipeline-panel-layout.test.ts packages/core/tests/pipeline-coord-fixed.test.ts packages/core/tests/pipeline-geometry/flip-and-positions.test.ts`
- [x] `bunx tsc -b packages/spec packages/core`
- [x] Full `bun test packages/core` (layout-related green; unrelated layer-inspect / bin-smoke flakes under load pass in isolation)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1092" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->