### PR TITLE
fix(svelte): drop chromeState! from plot-engine surface wiring

### DIFF
--- a/packages/svelte/src/lib/chrome/chrome-state.svelte.ts
+++ b/packages/svelte/src/lib/chrome/chrome-state.svelte.ts
@@ -19,10 +19,11 @@ import {
 } from "../interaction/interaction.js";
 import {
   bandChannelsForZoom,
+  canPublishPointSelection as canPublishPointSelectionFromSelect,
   capabilityStatusText,
-  filterAvailableTools,
   isEmptyPlotScene,
   legendFocusDiscreteOnlyDiagnostics,
+  resolveFilteredAvailableTools,
   shouldShowToolRail,
   zoomScaleDiagnosticsFromChannels,
   zoomSupportsChannel,
@@ -100,10 +101,16 @@ export function createPlotChromeState(deps: PlotChromeStateDeps): PlotChromeStat
   });
 
   const availableTools = $derived(
-    filterAvailableTools(deps.configuredAvailableTools(), zoomHasSupportedChannel),
+    resolveFilteredAvailableTools(
+      deps.configuredAvailableTools(),
+      deps.zoomConfig(),
+      deps.model()?.scales ?? null,
+    ),
   );
 
-  const canPublishPointSelection = $derived(deps.selectConfig()?.type === "point");
+  const canPublishPointSelection = $derived(
+    canPublishPointSelectionFromSelect(deps.selectConfig()),
+  );
 
   // Shared by tool-rail visibility and ToolRail recovery props (avoid dual calc).
   const hasPointSelection = $derived(

--- a/packages/svelte/src/lib/interaction/capability.ts
+++ b/packages/svelte/src/lib/interaction/capability.ts
@@ -18,6 +18,29 @@ export function filterAvailableTools(
 }
 
 /**
+ * Filter configured tools using live zoom mode + model scales.
+ * When zoom or scales are not yet available, zoom-area is kept (same as
+ * chrome's pre-model construction path). Shared by plot-engine surface
+ * enablement and chrome-state so the two cannot drift (#1082).
+ */
+export function resolveFilteredAvailableTools(
+  tools: readonly InteractionTool[],
+  zoom: { readonly mode: ZoomAreaMode } | null,
+  scales: ScaleTypeRef | null,
+): InteractionTool[] {
+  const zoomHasSupportedChannel =
+    zoom === null || scales === null || zoomSupportsChannel(zoom.mode, scales);
+  return filterAvailableTools(tools, zoomHasSupportedChannel);
+}
+
+/** True when select config publishes point selection. */
+export function canPublishPointSelection(
+  select: { readonly type: string } | null | undefined,
+): boolean {
+  return select?.type === "point";
+}
+
+/**
  * Resolve the tool the host should sync into the reducer.
  * Priority: requested if available → first available → `"inspect"`.
  *

--- a/packages/svelte/src/lib/plot-engine.svelte.ts
+++ b/packages/svelte/src/lib/plot-engine.svelte.ts
@@ -16,6 +16,19 @@
  * the runtime cycles (surface ↔ inspection ↔ interval ↔ selection). This
  * module preserves the pre-S11 top-to-bottom declaration order from GGPlot.
  *
+ * Residual late bindings (definite-assignment / late hooks only where the
+ * cycle is real):
+ * - surfaceState! — inspection needs the surface reducer; surface needs
+ *   inspection handlers
+ * - semanticCandidateProjection! — interval consumptionCandidates close over
+ *   the projection built after legend focus
+ * - legendFocusState.installHostDerivedEffects() — host $derived entry lists
+ *   require this factory's compute* methods (#627)
+ *
+ * Surface tool enablement (`availableTools`, point-select) is host-derived
+ * before surface construction so chrome is not a surface construction-time
+ * dep (#1082). Chrome recomputes the same pure formulas for UI consumers.
+ *
  * Cross-module transition side effects (e.g. inspection dismiss → brush/tool)
  * are applied via `applyInspectionDismissSideEffects` at the surface call site
  * (#627). Leaf modules register their own effects at construction; the engine
@@ -42,6 +55,10 @@ import {
 } from "./diagnostics/composition.js";
 import type { PlotDiagnostic } from "./diagnostics/deprecation.js";
 import type { LayerRegistry } from "./geoms/registry.svelte.js";
+import {
+  canPublishPointSelection,
+  resolveFilteredAvailableTools,
+} from "./interaction/capability.js";
 import {
   normalizeInteractionConfig,
   type InteractionDiagnostic,
@@ -489,17 +506,25 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
 
   // ------------------------------------------------- surface
   // Inspection + interval + selection already constructed — no sibling TDZ
-  // getters for those. Chrome availableTools / pointSelect still late.
-  let chromeState!: ReturnType<typeof createPlotChromeState>;
+  // getters for those. Tool enablement is host-derived (same pure formulas as
+  // chrome) so surface does not close over later chromeState (#1082).
+  const surfaceAvailableTools = $derived(
+    resolveFilteredAvailableTools(
+      interactionConfig.availableTools,
+      interactionConfig.zoom,
+      runtime.model?.scales ?? null,
+    ),
+  );
+  const surfacePointSelectEnabled = $derived(canPublishPointSelection(interactionConfig.select));
   surfaceState = createSurfaceState({
     model: () => runtime.model,
     root: host.root,
     toolProp: () => host.props.tool,
     initialTool: () => interactionConfig.initialTool,
-    availableTools: () => chromeState.availableTools,
+    availableTools: () => surfaceAvailableTools,
     inspectConfig: () => interactionConfig.inspect,
     selectConfig: () => interactionConfig.select,
-    pointSelectEnabled: () => chromeState.canPublishPointSelection,
+    pointSelectEnabled: () => surfacePointSelectEnabled,
     ontoolchange: () => host.props.ontoolchange,
     surfaceInteractive: () => surfaceInteractive,
     candidateSemanticKeys: (candidate) => candidateSemanticKeys(candidate),
@@ -564,8 +589,10 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
   });
   // ------------------------------------------------- plot chrome
   // All host bindings earlier-declared. Pure construction-time deriveds —
-  // no $state/handlers/effects.
-  chromeState = createPlotChromeState({
+  // no $state/handlers/effects. No longer a surface construction-time dep
+  // (#1082); availableTools / canPublishPointSelection stay chrome-owned for
+  // UI, recomputed with the same pure helpers as surfaceAvailableTools above.
+  const chromeState = createPlotChromeState({
     model: () => runtime.model,
     zoomConfig: () => interactionConfig.zoom,
     selectConfig: () => interactionConfig.select,

--- a/packages/svelte/src/lib/surface/surface-state.svelte.ts
+++ b/packages/svelte/src/lib/surface/surface-state.svelte.ts
@@ -83,8 +83,9 @@ export type SurfaceStateDeps = {
   inspectConfig: () => ResolvedInteractionConfig["inspect"];
   selectConfig: () => ResolvedInteractionConfig["select"];
   /**
-   * Host's `canPublishPointSelection` derived (declared after this factory —
-   * handler-only). Single source of truth with ToolRail/chrome consumers.
+   * Host point-select enablement (`select?.type === "point"`). Host-derived
+   * before this factory so surface does not close over later chromeState
+   * (#1082). Same formula as chrome `canPublishPointSelection`.
    */
   pointSelectEnabled: () => boolean;
   ontoolchange: () => ((tool: InteractionTool) => void) | undefined;

--- a/packages/svelte/tests/interaction/capability.test.ts
+++ b/packages/svelte/tests/interaction/capability.test.ts
@@ -2,11 +2,13 @@ import { describe, expect, it } from "vitest";
 
 import {
   bandChannelsForZoom,
+  canPublishPointSelection,
   capabilityStatusText,
   filterAvailableTools,
   legendFocusDiscreteOnlyDiagnostics,
   resolveChooseToolAction,
   resolveEffectiveTool,
+  resolveFilteredAvailableTools,
   isEmptyPlotScene,
   shouldShowInertSelectionOverlay,
   shouldShowToolRail,
@@ -70,6 +72,33 @@ describe("filterAvailableTools", () => {
   it("leaves non-zoom tools untouched when zoom is unsupported", () => {
     expect(filterAvailableTools(["inspect", "point"], false)).toEqual(["inspect", "point"]);
     expect(filterAvailableTools(["zoom-area"], false)).toEqual([]);
+  });
+});
+
+describe("resolveFilteredAvailableTools", () => {
+  const all = ["inspect", "point", "select-area", "zoom-area"] as const;
+
+  it("keeps zoom-area when zoom or scales are unavailable (pre-model path)", () => {
+    expect(resolveFilteredAvailableTools(all, null, continuous)).toEqual([...all]);
+    expect(resolveFilteredAvailableTools(all, { mode: "xy" }, null)).toEqual([...all]);
+  });
+
+  it("drops zoom-area when every requested channel is band", () => {
+    expect(resolveFilteredAvailableTools(all, { mode: "xy" }, bandBoth)).toEqual([
+      "inspect",
+      "point",
+      "select-area",
+    ]);
+    expect(resolveFilteredAvailableTools(all, { mode: "xy" }, continuous)).toEqual([...all]);
+  });
+});
+
+describe("canPublishPointSelection", () => {
+  it("is true only for point select configs", () => {
+    expect(canPublishPointSelection({ type: "point" })).toBe(true);
+    expect(canPublishPointSelection({ type: "interval" })).toBe(false);
+    expect(canPublishPointSelection(null)).toBe(false);
+    expect(canPublishPointSelection(undefined)).toBe(false);
   });
 });
 

--- a/packages/svelte/tests/interaction/capability.test.ts
+++ b/packages/svelte/tests/interaction/capability.test.ts
@@ -98,7 +98,6 @@ describe("canPublishPointSelection", () => {
     expect(canPublishPointSelection({ type: "point" })).toBe(true);
     expect(canPublishPointSelection({ type: "interval" })).toBe(false);
     expect(canPublishPointSelection(null)).toBe(false);
-    expect(canPublishPointSelection(undefined)).toBe(false);
   });
 });
 

--- a/packages/svelte/tests/plot-engine.lifecycle.test.ts
+++ b/packages/svelte/tests/plot-engine.lifecycle.test.ts
@@ -207,3 +207,100 @@ describe("createPlotEngine chart lifecycle", () => {
     destroy();
   });
 });
+
+/**
+ * Construction-order contract (#1082).
+ *
+ * The engine wires sibling controllers with deferred thunks; three residual
+ * cycles still need declaration order (surface ↔ inspection, interval ↔
+ * projection, legend late host deriveds). These tests pin that a full
+ * interaction graph constructs without TDZ / early-read failures, and that
+ * surface tool enablement stays aligned with chrome without surface closing
+ * over a later-declared chrome controller.
+ */
+describe("createPlotEngine construction-order contract (#1082)", () => {
+  const fullInteractionProps = {
+    data: rows,
+    aes: { x: "x", y: "y", color: "cls" },
+    layers: [{ geom: "point" as const }],
+    width: 480,
+    height: 320,
+    // Unique per row so point select does not emit INTERACTION_DUPLICATE_KEY.
+    key: "x",
+    inspect: true,
+    select: "point" as const,
+    zoom: true,
+    legendFocus: true,
+    legendFilter: true,
+  } satisfies EnginePlotProps;
+
+  it("constructs the full controller graph without TDZ throws (before first flush)", () => {
+    // If any factory reads a later binding at construction time, createPlotEngine
+    // throws ReferenceError (or surfaces undefined behind !) before return.
+    const { value: engine, destroy } = withEffectRoot(() =>
+      createPlotEngine(engineHost({ props: fullInteractionProps })),
+    );
+
+    expect(() => {
+      void engine.zoomState.effectiveSpec;
+      void engine.legendFilterState.filters;
+      void engine.runtime.model;
+      void engine.selectionState.effectiveSelectedKeys;
+      void engine.inspectionState.inspection;
+      void engine.intervalState.effectiveIntervals;
+      void engine.surfaceState.activeTool;
+      void engine.legendFocusState.effectiveEmphasisKeys;
+      void engine.chromeState.availableTools;
+      void engine.chromeState.canPublishPointSelection;
+      void engine.announcer;
+    }).not.toThrow();
+
+    destroy();
+  });
+
+  it("keeps surface activeTool inside chrome availableTools when select/zoom toggle", () => {
+    // select is "point" | false — boolean true is not a valid SelectInput.
+    const select = reactiveBox<"point" | false>("point");
+    const zoom = reactiveBox(true);
+    const { value: engine, destroy } = withFlushedEffectRoot(() =>
+      createPlotEngine(
+        engineHost({
+          props: {
+            data: rows,
+            aes: { x: "x", y: "y", color: "cls" },
+            layers: [{ geom: "point" }],
+            width: 480,
+            height: 320,
+            key: "x",
+            inspect: true,
+            get select() {
+              return select.value;
+            },
+            get zoom() {
+              return zoom.value;
+            },
+          },
+        }),
+      ),
+    );
+
+    expect(engine.chromeState.canPublishPointSelection).toBe(true);
+    expect(engine.chromeState.availableTools).toEqual(
+      expect.arrayContaining(["inspect", "point", "zoom-area"]),
+    );
+    expect(engine.chromeState.availableTools).toContain(engine.surfaceState.activeTool);
+
+    select.set(false);
+    flushSync();
+    expect(engine.chromeState.canPublishPointSelection).toBe(false);
+    expect(engine.chromeState.availableTools).not.toContain("point");
+    expect(engine.chromeState.availableTools).toContain(engine.surfaceState.activeTool);
+
+    zoom.set(false);
+    flushSync();
+    expect(engine.chromeState.availableTools).toEqual(["inspect"]);
+    expect(engine.surfaceState.activeTool).toBe("inspect");
+
+    destroy();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1082 for the unblocked slice of the construction-order risk.

**Investigation** (see issue open questions):

1. **#1079 / #1080 still open** — full remeasure and a structural redesign (typed two-phase / builder) stay deferred.
2. **Irreducible cycles remain:** surface ↔ inspection, interval ↔ projection, legend `installHostDerivedEffects` late host data. Those stay as `!` / late hooks with deferred thunks.
3. **Chrome ↔ surface was partly accidental ownership:** surface only needed chrome for `availableTools` + `canPublishPointSelection`. Both are pure functions of config + model scales, not chrome-owned state.
4. **Test vs redesign:** engine-level construction-order tests + ownership lift give most of the safety without redesigning the Svelte `$derived` graph.

**What shipped**

- Host `$derived` surface tool enablement before `createSurfaceState`, so chrome is no longer a surface construction-time dep.
- Shared pure helpers `resolveFilteredAvailableTools` / `canPublishPointSelection` in `capability.ts` used by both plot-engine and chrome (no formula drift).
- Removed `let chromeState!`; chrome is a normal `const` after surface.
- Construction-order contract tests: full interaction graph constructible before flush; surface `activeTool` stays inside chrome `availableTools` across select/zoom toggles.

**Not in this PR** (still tracked by #1082 / upstreams)

- Two-phase construct-all/wire-all protocol
- Remeasure after #1079/#1080
- Splitting `capability.ts`
- Removing `surfaceState!` / `semanticCandidateProjection!` / legend late hook

## Test plan

- [x] `bun run test:browser -- tests/plot-engine.lifecycle.test.ts tests/interaction/capability.test.ts tests/chrome/chrome-state.test.ts` (117 passed)
- [ ] CI green on this PR
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1093" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->