### PR TITLE
refactor(core): one constructor for post-stat LayerFrame (#1077)

### DIFF
--- a/.changeset/stat-layer-frame-1077.md
+++ b/.changeset/stat-layer-frame-1077.md
@@ -1,0 +1,12 @@
+---
+"@ggsvelte/core": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+refactor(core): one constructor for post-stat LayerFrame
+
+`statLayerFrame` owns the shared post-stat frame fields, yStatColumn default,
+measure forward, NO_ROW lineage, and style/extras spreads. Matching
+`frame-stats-*` adapters call it instead of hand-writing the same literal.
+function/map/manual/unique/sf stay on their own shapes until a later pass.

--- a/packages/core/src/pipeline/frame-stats-align.ts
+++ b/packages/core/src/pipeline/frame-stats-align.ts
@@ -4,11 +4,11 @@
 import type { ColumnTable } from "../table.js";
 
 import { statAlign } from "../stats/align.js";
-import { carriedColumns, emptyFrameExtras, removedStatWarning } from "./frame-helpers.js";
-import { makeColumnOf, styleColumns } from "./frame-stats-shared.js";
+import { carriedColumns, removedStatWarning } from "./frame-helpers.js";
+import { makeColumnOf } from "./frame-stats-shared.js";
+import { statLayerFrame } from "./layer-frame.js";
 import { positionColumn } from "./temporal-position.js";
 import type { LayerBinding, LayerFrame, PipelineWarning } from "./types.js";
-import { NO_ROW } from "./types.js";
 
 export function buildAlignFrame(
   binding: LayerBinding,
@@ -26,23 +26,16 @@ export function buildAlignFrame(
     carried,
   });
   removedStatWarning(result.dropped, index, "missing or non-finite x/y before align", warnings);
-  const col = columnOf(result, null);
-  return {
+  return statLayerFrame({
     binding,
     table,
     n: result.x.length,
-    xValues: null,
-    xNumeric: result.x,
-    yValues: null,
-    yNumeric: result.y,
+    x: { numeric: result.x },
+    y: { numeric: result.y },
     groups: result.groups,
     inputGroups: groups,
-    inputSourceRows: null,
-    rowIndex: Uint32Array.from({ length: result.x.length }, () => NO_ROW),
-    colorValues: col(binding.color.field),
-    fillValues: col(binding.fill.field),
-    ...styleColumns(binding, col, { x: result.x, y: result.y }),
-    labelValues: col(binding.labelField),
-    ...emptyFrameExtras(),
-  };
+    columns: { x: result.x, y: result.y },
+    columnOf: columnOf(result, null),
+    lineage: "none",
+  });
 }

--- a/packages/core/src/pipeline/frame-stats-bin-2d.ts
+++ b/packages/core/src/pipeline/frame-stats-bin-2d.ts
@@ -62,6 +62,7 @@ export function buildBin2dFrame(
     columns,
     columnOf: columnOf(result, null),
     lineage: "none",
+    afterStatColor: true,
     extras: {
       xmin: result.xmin,
       xmax: result.xmax,

--- a/packages/core/src/pipeline/frame-stats-bin-2d.ts
+++ b/packages/core/src/pipeline/frame-stats-bin-2d.ts
@@ -5,11 +5,11 @@ import type { ColumnTable } from "../table.js";
 
 import { statBin2d } from "../stats/bin-2d.js";
 
-import { carriedColumns, emptyFrameExtras, removedStatWarning } from "./frame-helpers.js";
-import { colorColumns, makeColumnOf, styleColumns } from "./frame-stats-shared.js";
+import { carriedColumns, removedStatWarning } from "./frame-helpers.js";
+import { makeColumnOf } from "./frame-stats-shared.js";
+import { statLayerFrame } from "./layer-frame.js";
 import { positionColumn } from "./temporal-position.js";
 import type { Advisory, LayerBinding, LayerFrame, PipelineWarning } from "./types.js";
-import { NO_ROW } from "./types.js";
 
 export function buildBin2dFrame(
   binding: LayerBinding,
@@ -50,28 +50,23 @@ export function buildBin2dFrame(
     ncount: result.ncount,
     ndensity: result.ndensity,
   };
-  const col = columnOf(result, null);
 
-  return {
+  return statLayerFrame({
     binding,
     table,
     n: result.x.length,
-    xValues: null,
-    xNumeric: result.x,
-    yValues: null,
-    yNumeric: result.y,
+    x: { numeric: result.x },
+    y: { numeric: result.y },
     groups: result.groups,
     inputGroups: groups,
-    inputSourceRows: null,
-    rowIndex: Uint32Array.from({ length: result.x.length }, () => NO_ROW),
-    // after_stat color/fill (default fill = count; #799 / #953).
-    ...colorColumns(binding, col, columns),
-    ...styleColumns(binding, col, columns),
-    labelValues: col(binding.labelField),
-    ...emptyFrameExtras(),
-    xmin: result.xmin,
-    xmax: result.xmax,
-    ymin: result.ymin,
-    ymax: result.ymax,
-  };
+    columns,
+    columnOf: columnOf(result, null),
+    lineage: "none",
+    extras: {
+      xmin: result.xmin,
+      xmax: result.xmax,
+      ymin: result.ymin,
+      ymax: result.ymax,
+    },
+  });
 }

--- a/packages/core/src/pipeline/frame-stats-bin-frame.ts
+++ b/packages/core/src/pipeline/frame-stats-bin-frame.ts
@@ -3,11 +3,9 @@
  */
 import type { ColumnTable } from "../table.js";
 
-import { emptyFrameExtras } from "./frame-helpers.js";
-import { colorColumns, styleColumns, type makeColumnOf } from "./frame-stats-shared.js";
-import { forwardMeasureOnce } from "./stat-measure-transform.js";
+import { type makeColumnOf } from "./frame-stats-shared.js";
+import { statLayerFrame } from "./layer-frame.js";
 import type { LayerBinding, LayerFrame } from "./types.js";
-import { NO_ROW } from "./types.js";
 
 type BinResult = {
   x: Float64Array;
@@ -35,29 +33,22 @@ export function packBinLayerFrame(
     ncount: result.ncount,
     ndensity: result.ndensity,
   };
-  const col = columnOf(result, null);
-  return {
+  return statLayerFrame({
     binding,
     table,
     n: result.x.length,
-    xValues: null,
-    xNumeric: result.x,
-    yValues: null,
-    yNumeric: forwardMeasureOnce(
-      columns[binding.yStatColumn ?? "count"] ?? result.count,
-      binding.yTransform,
-    ),
+    x: { numeric: result.x },
+    y: { column: "count", fallback: result.count },
     groups: result.groups,
     inputGroups,
-    inputSourceRows: null,
-    rowIndex: Uint32Array.from({ length: result.x.length }, () => NO_ROW),
-    ...colorColumns(binding, col, columns),
-    ...styleColumns(binding, col, columns),
-    labelValues: col(binding.labelField),
-    ...emptyFrameExtras(),
-    // Lineage replays the stat's own cut instead of re-deriving from edges (#905).
-    binCut: result.cut,
-    xmin: result.xmin,
-    xmax: result.xmax,
-  };
+    columns,
+    columnOf: columnOf(result, null),
+    lineage: "none",
+    extras: {
+      // Lineage replays the stat's own cut instead of re-deriving from edges (#905).
+      binCut: result.cut,
+      xmin: result.xmin,
+      xmax: result.xmax,
+    },
+  });
 }

--- a/packages/core/src/pipeline/frame-stats-bin-frame.ts
+++ b/packages/core/src/pipeline/frame-stats-bin-frame.ts
@@ -44,6 +44,7 @@ export function packBinLayerFrame(
     columns,
     columnOf: columnOf(result, null),
     lineage: "none",
+    afterStatColor: true,
     extras: {
       // Lineage replays the stat's own cut instead of re-deriving from edges (#905).
       binCut: result.cut,

--- a/packages/core/src/pipeline/frame-stats-bin-hex.ts
+++ b/packages/core/src/pipeline/frame-stats-bin-hex.ts
@@ -5,11 +5,11 @@ import type { ColumnTable } from "../table.js";
 
 import { statBinHex } from "../stats/bin-hex.js";
 
-import { carriedColumns, emptyFrameExtras, removedStatWarning } from "./frame-helpers.js";
-import { colorColumns, makeColumnOf, styleColumns } from "./frame-stats-shared.js";
+import { carriedColumns, removedStatWarning } from "./frame-helpers.js";
+import { makeColumnOf } from "./frame-stats-shared.js";
+import { statLayerFrame } from "./layer-frame.js";
 import { positionColumn } from "./temporal-position.js";
 import type { Advisory, LayerBinding, LayerFrame, PipelineWarning } from "./types.js";
-import { NO_ROW } from "./types.js";
 
 export function buildBinHexFrame(
   binding: LayerBinding,
@@ -48,26 +48,21 @@ export function buildBinHexFrame(
     width: result.width,
     height: result.height,
   };
-  const col = columnOf(result, null);
 
-  return {
+  return statLayerFrame({
     binding,
     table,
     n: result.x.length,
-    xValues: null,
-    xNumeric: result.x,
-    yValues: null,
-    yNumeric: result.y,
+    x: { numeric: result.x },
+    y: { numeric: result.y },
     groups: result.groups,
     inputGroups: groups,
-    inputSourceRows: null,
-    rowIndex: Uint32Array.from({ length: result.x.length }, () => NO_ROW),
-    // after_stat color/fill (default fill = count; #800 / #953).
-    ...colorColumns(binding, col, columns),
-    ...styleColumns(binding, col, columns),
-    labelValues: col(binding.labelField),
-    ...emptyFrameExtras(),
-    hexWidth: result.width,
-    hexHeight: result.height,
-  };
+    columns,
+    columnOf: columnOf(result, null),
+    lineage: "none",
+    extras: {
+      hexWidth: result.width,
+      hexHeight: result.height,
+    },
+  });
 }

--- a/packages/core/src/pipeline/frame-stats-bin-hex.ts
+++ b/packages/core/src/pipeline/frame-stats-bin-hex.ts
@@ -60,6 +60,7 @@ export function buildBinHexFrame(
     columns,
     columnOf: columnOf(result, null),
     lineage: "none",
+    afterStatColor: true,
     extras: {
       hexWidth: result.width,
       hexHeight: result.height,

--- a/packages/core/src/pipeline/frame-stats-bindot.ts
+++ b/packages/core/src/pipeline/frame-stats-bindot.ts
@@ -5,9 +5,9 @@ import type { ColumnTable } from "../table.js";
 
 import { statBindot } from "../stats/bindot.js";
 
-import { carriedColumns, emptyFrameExtras, removedStatWarning } from "./frame-helpers.js";
-import { makeColumnOf, styleColumns } from "./frame-stats-shared.js";
-import { forwardMeasureOnce } from "./stat-measure-transform.js";
+import { carriedColumns, removedStatWarning } from "./frame-helpers.js";
+import { makeColumnOf } from "./frame-stats-shared.js";
+import { statLayerFrame } from "./layer-frame.js";
 import { positionColumn } from "./temporal-position.js";
 import type { Advisory, LayerBinding, LayerFrame, PipelineWarning } from "./types.js";
 
@@ -44,11 +44,6 @@ export function buildBindotFrame(
     count: result.count,
   };
   const col = columnOf(result, null);
-  const outN = result.x.length;
-  const yNumeric = forwardMeasureOnce(
-    columns[binding.yStatColumn ?? "stackpos"] ?? result.stackpos,
-    binding.yTransform,
-  );
 
   // Per-observation aesthetics from source rows (not group-constant only).
   const colorField = binding.color.field;
@@ -58,24 +53,22 @@ export function buildBindotFrame(
   const fillValues =
     fillField === null ? null : result.sourceRows.map((row) => table.column(fillField)[row]!);
 
-  return {
+  return statLayerFrame({
     binding,
     table,
-    n: outN,
-    xValues: null,
-    xNumeric: result.x,
-    yValues: null,
-    yNumeric,
+    n: result.x.length,
+    x: { numeric: result.x },
+    y: { column: "stackpos", fallback: result.stackpos },
     groups: result.groups,
     inputGroups: groups,
-    inputSourceRows: null,
-    rowIndex: Uint32Array.from(result.sourceRows),
-    colorValues: colorField === null ? col(null) : colorValues,
-    fillValues: fillField === null ? col(null) : fillValues,
-    ...styleColumns(binding, col, columns),
-    labelValues: col(binding.labelField),
-    ...emptyFrameExtras(),
-    xmin: result.xmin,
-    xmax: result.xmax,
-  };
+    columns,
+    columnOf: col,
+    lineage: Uint32Array.from(result.sourceRows),
+    extras: {
+      colorValues: colorField === null ? col(null) : colorValues,
+      fillValues: fillField === null ? col(null) : fillValues,
+      xmin: result.xmin,
+      xmax: result.xmax,
+    },
+  });
 }

--- a/packages/core/src/pipeline/frame-stats-boxplot.ts
+++ b/packages/core/src/pipeline/frame-stats-boxplot.ts
@@ -6,11 +6,11 @@ import type { BoxplotParams } from "@ggsvelte/spec";
 import { statBoxplot } from "../stats/boxplot.js";
 import type { ColumnTable } from "../table.js";
 
-import { carriedColumns, emptyFrameExtras, removedStatWarning } from "./frame-helpers.js";
-import { makeColumnOf, styleColumns } from "./frame-stats-shared.js";
+import { carriedColumns, removedStatWarning } from "./frame-helpers.js";
+import { makeColumnOf } from "./frame-stats-shared.js";
+import { statLayerFrame } from "./layer-frame.js";
 import { positionColumn } from "./temporal-position.js";
 import type { LayerBinding, LayerFrame, PipelineWarning } from "./types.js";
-import { NO_ROW } from "./types.js";
 
 export function buildBoxplotFrame(
   binding: LayerBinding,
@@ -30,40 +30,35 @@ export function buildBoxplotFrame(
     carried,
   });
   removedStatWarning(result.dropped, index, "missing or non-finite y", warnings);
-  const col = columnOf(result, result.x);
-  return {
+  return statLayerFrame({
     binding,
     table,
     n: result.x.length,
-    xValues: result.x,
-    xNumeric: null,
-    yValues: null,
-    yNumeric: null,
+    x: { values: result.x, numeric: null },
+    y: { numeric: null, values: null },
     groups: result.groups,
     inputGroups: groups,
-    inputSourceRows: null,
-    rowIndex: Uint32Array.from({ length: result.x.length }, () => NO_ROW),
-    colorValues: col(binding.color.field),
-    fillValues: col(binding.fill.field),
-    ...styleColumns(binding, col, {
+    columns: {
       ymin: result.ymin,
       lower: result.lower,
       middle: result.middle,
       upper: result.upper,
       ymax: result.ymax,
-    }),
-    labelValues: col(binding.labelField),
-    ...emptyFrameExtras(),
-    ymin: result.ymin,
-    ymax: result.ymax,
-    box: {
-      lower: result.lower,
-      middle: result.middle,
-      upper: result.upper,
-      outlierX: result.outliers.map((o) => o.x),
-      outlierY: Float64Array.from(result.outliers.map((o) => o.y)),
-      outlierBox: Uint32Array.from(result.outliers.map((o) => o.boxRow)),
-      outlierRow: Uint32Array.from(result.outliers.map((o) => o.sourceRow)),
     },
-  };
+    columnOf: columnOf(result, result.x),
+    lineage: "none",
+    extras: {
+      ymin: result.ymin,
+      ymax: result.ymax,
+      box: {
+        lower: result.lower,
+        middle: result.middle,
+        upper: result.upper,
+        outlierX: result.outliers.map((o) => o.x),
+        outlierY: Float64Array.from(result.outliers.map((o) => o.y)),
+        outlierBox: Uint32Array.from(result.outliers.map((o) => o.boxRow)),
+        outlierRow: Uint32Array.from(result.outliers.map((o) => o.sourceRow)),
+      },
+    },
+  });
 }

--- a/packages/core/src/pipeline/frame-stats-connect.ts
+++ b/packages/core/src/pipeline/frame-stats-connect.ts
@@ -4,11 +4,11 @@
 import type { ColumnTable } from "../table.js";
 
 import { statConnect, type ConnectConnection } from "../stats/connect.js";
-import { carriedColumns, emptyFrameExtras, removedStatWarning } from "./frame-helpers.js";
-import { makeColumnOf, styleColumns } from "./frame-stats-shared.js";
+import { carriedColumns, removedStatWarning } from "./frame-helpers.js";
+import { makeColumnOf } from "./frame-stats-shared.js";
+import { statLayerFrame } from "./layer-frame.js";
 import { positionColumn } from "./temporal-position.js";
 import type { LayerBinding, LayerFrame, PipelineWarning } from "./types.js";
-import { NO_ROW } from "./types.js";
 
 const CONNECTIONS = new Set<ConnectConnection>(["hv", "vh", "mid", "linear"]);
 
@@ -43,23 +43,16 @@ export function buildConnectFrame(
     carried,
   });
   removedStatWarning(result.dropped, index, "missing or non-finite x/y before connect", warnings);
-  const col = columnOf(result, null);
-  return {
+  return statLayerFrame({
     binding,
     table,
     n: result.x.length,
-    xValues: null,
-    xNumeric: result.x,
-    yValues: null,
-    yNumeric: result.y,
+    x: { numeric: result.x },
+    y: { numeric: result.y },
     groups: result.groups,
     inputGroups: groups,
-    inputSourceRows: null,
-    rowIndex: Uint32Array.from({ length: result.x.length }, () => NO_ROW),
-    colorValues: col(binding.color.field),
-    fillValues: col(binding.fill.field),
-    ...styleColumns(binding, col, { x: result.x, y: result.y }),
-    labelValues: col(binding.labelField),
-    ...emptyFrameExtras(),
-  };
+    columns: { x: result.x, y: result.y },
+    columnOf: columnOf(result, null),
+    lineage: "none",
+  });
 }

--- a/packages/core/src/pipeline/frame-stats-contour.ts
+++ b/packages/core/src/pipeline/frame-stats-contour.ts
@@ -10,11 +10,11 @@ import type { ContourParams } from "@ggsvelte/spec";
 import { statContour } from "../stats/contour.js";
 import type { ColumnTable } from "../table.js";
 
-import { carriedColumns, emptyFrameExtras, removedStatWarning } from "./frame-helpers.js";
-import { makeColumnOf, styleColumns } from "./frame-stats-shared.js";
+import { carriedColumns, removedStatWarning } from "./frame-helpers.js";
+import { makeColumnOf } from "./frame-stats-shared.js";
+import { statLayerFrame } from "./layer-frame.js";
 import { positionColumn } from "./temporal-position.js";
 import type { LayerBinding, LayerFrame, PipelineWarning } from "./types.js";
-import { NO_ROW } from "./types.js";
 
 export function buildContourFrame(
   binding: LayerBinding,
@@ -56,24 +56,16 @@ export function buildContourFrame(
     outGroups.push(id);
   }
 
-  const col = columnOf(result, null);
-  const outN = result.x.length;
-  return {
+  return statLayerFrame({
     binding,
     table,
-    n: outN,
-    xValues: null,
-    xNumeric: result.x,
-    yValues: null,
-    yNumeric: result.y,
+    n: result.x.length,
+    x: { numeric: result.x },
+    y: { numeric: result.y },
     groups: outGroups,
     inputGroups: groups,
-    inputSourceRows: null,
-    rowIndex: Uint32Array.from({ length: outN }, () => NO_ROW),
-    colorValues: col(binding.color.field),
-    fillValues: col(binding.fill.field),
-    ...styleColumns(binding, col, { level: result.level }),
-    labelValues: col(binding.labelField),
-    ...emptyFrameExtras(),
-  };
+    columns: { level: result.level },
+    columnOf: columnOf(result, null),
+    lineage: "none",
+  });
 }

--- a/packages/core/src/pipeline/frame-stats-count.ts
+++ b/packages/core/src/pipeline/frame-stats-count.ts
@@ -5,18 +5,13 @@ import { statCount } from "../stats/count.js";
 import { ColumnTable, type CellValue } from "../table.js";
 import { scaleTransform } from "../scales/transform.js";
 
-import { carriedColumns, emptyFrameExtras, removedStatWarning } from "./frame-helpers.js";
+import { carriedColumns, removedStatWarning } from "./frame-helpers.js";
 import { binIdColumn } from "./binned-scale.js";
-import {
-  colorColumns,
-  makeColumnOf,
-  shouldAggregateOnSemanticTemporalX,
-  styleColumns,
-} from "./frame-stats-shared.js";
+import { makeColumnOf, shouldAggregateOnSemanticTemporalX } from "./frame-stats-shared.js";
+import { statLayerFrame } from "./layer-frame.js";
 import { forwardMeasureOnce } from "./stat-measure-transform.js";
 import { positionColumn, positionValuesToNumeric } from "./temporal-position.js";
 import type { LayerBinding, LayerFrame, PipelineWarning } from "./types.js";
-import { NO_ROW } from "./types.js";
 
 /**
  * Binned count: aggregate by STABLE INTEGER BIN ID (the discrete key), then
@@ -92,30 +87,35 @@ export function buildCountFrame(
         ? result.x
         : result.x.map((value) => xInverse.inverse(value as number))
       : result.x.map((id) => xInverse.inverse(centers![id as number]!));
-  const col = columnOf(result, displayX);
-  return {
+  // Count only forwards y when y is explicitly after_stat(count) — not as a default.
+  const yNumeric =
+    binding.yStatColumn === "count" ? forwardMeasureOnce(result.count, binding.yTransform) : null;
+  return statLayerFrame({
     binding,
     table,
     n: result.x.length,
-    xValues: displayX,
-    xNumeric:
-      binned === null
-        ? temporalX || transformedContinuousX !== null
-          ? Float64Array.from(result.x, (value) => (typeof value === "number" ? value : Number.NaN))
-          : positionValuesToNumeric(result.x, binding.xConversion).values
-        : Float64Array.from(result.x, (id) => centers![id as number]!),
-    yValues: null,
-    yNumeric:
-      binding.yStatColumn === "count" ? forwardMeasureOnce(result.count, binding.yTransform) : null,
+    x: {
+      values: displayX,
+      numeric:
+        binned === null
+          ? temporalX || transformedContinuousX !== null
+            ? Float64Array.from(result.x, (value) =>
+                typeof value === "number" ? value : Number.NaN,
+              )
+            : positionValuesToNumeric(result.x, binding.xConversion).values
+          : Float64Array.from(result.x, (id) => centers![id as number]!),
+    },
+    y: { numeric: yNumeric },
     groups: result.groups,
     inputGroups: groups,
-    inputSourceRows: null,
-    rowIndex: Uint32Array.from({ length: result.x.length }, () => NO_ROW),
-    ...colorColumns(binding, col, { count: result.count }),
-    ...styleColumns(binding, col, { count: result.count }),
-    labelValues: col(binding.labelField),
-    ...emptyFrameExtras(),
-    bin:
-      binned === null ? null : { xId: Int32Array.from(result.x, (id) => id as number), yId: null },
-  };
+    columns: { count: result.count },
+    columnOf: columnOf(result, displayX),
+    lineage: "none",
+    extras: {
+      bin:
+        binned === null
+          ? null
+          : { xId: Int32Array.from(result.x, (id) => id as number), yId: null },
+    },
+  });
 }

--- a/packages/core/src/pipeline/frame-stats-count.ts
+++ b/packages/core/src/pipeline/frame-stats-count.ts
@@ -111,6 +111,7 @@ export function buildCountFrame(
     columns: { count: result.count },
     columnOf: columnOf(result, displayX),
     lineage: "none",
+    afterStatColor: true,
     extras: {
       bin:
         binned === null

--- a/packages/core/src/pipeline/frame-stats-density-2d.ts
+++ b/packages/core/src/pipeline/frame-stats-density-2d.ts
@@ -8,11 +8,11 @@ import type { Density2dParams } from "@ggsvelte/spec";
 import { statDensity2d } from "../stats/density-2d.js";
 import type { ColumnTable } from "../table.js";
 
-import { carriedColumns, emptyFrameExtras, removedStatWarning } from "./frame-helpers.js";
-import { colorColumns, makeColumnOf, styleColumns } from "./frame-stats-shared.js";
+import { carriedColumns, removedStatWarning } from "./frame-helpers.js";
+import { makeColumnOf } from "./frame-stats-shared.js";
+import { statLayerFrame } from "./layer-frame.js";
 import { positionColumn } from "./temporal-position.js";
 import type { LayerBinding, LayerFrame, PipelineWarning } from "./types.js";
-import { NO_ROW } from "./types.js";
 
 export function buildDensity2dFrame(
   binding: LayerBinding,
@@ -68,24 +68,17 @@ export function buildDensity2dFrame(
     outGroups.push(id);
   }
 
-  const col = columnOf(result, null);
   const computed = { level: result.level, density: result.density };
-  const outN = result.x.length;
-  return {
+  return statLayerFrame({
     binding,
     table,
-    n: outN,
-    xValues: null,
-    xNumeric: result.x,
-    yValues: null,
-    yNumeric: result.y,
+    n: result.x.length,
+    x: { numeric: result.x },
+    y: { numeric: result.y },
     groups: outGroups,
     inputGroups: groups,
-    inputSourceRows: null,
-    rowIndex: Uint32Array.from({ length: outN }, () => NO_ROW),
-    ...colorColumns(binding, col, computed),
-    ...styleColumns(binding, col, computed),
-    labelValues: col(binding.labelField),
-    ...emptyFrameExtras(),
-  };
+    columns: computed,
+    columnOf: columnOf(result, null),
+    lineage: "none",
+  });
 }

--- a/packages/core/src/pipeline/frame-stats-density-2d.ts
+++ b/packages/core/src/pipeline/frame-stats-density-2d.ts
@@ -80,5 +80,6 @@ export function buildDensity2dFrame(
     columns: computed,
     columnOf: columnOf(result, null),
     lineage: "none",
+    afterStatColor: true,
   });
 }

--- a/packages/core/src/pipeline/frame-stats-density.ts
+++ b/packages/core/src/pipeline/frame-stats-density.ts
@@ -58,6 +58,7 @@ export function buildDensityFrame(
     columns,
     columnOf: columnOf(result, null),
     lineage: "none",
+    afterStatColor: true,
     extras: {
       // Density renders as an area from the shared transformed-origin baseline.
       ymin: Float64Array.from({ length: outN }, () =>

--- a/packages/core/src/pipeline/frame-stats-density.ts
+++ b/packages/core/src/pipeline/frame-stats-density.ts
@@ -5,13 +5,13 @@ import { statDensity } from "../stats/density.js";
 import type { ColumnTable } from "../table.js";
 import { scaleTransform } from "../scales/transform.js";
 
-import { carriedColumns, emptyFrameExtras, removedStatWarning } from "./frame-helpers.js";
-import { colorColumns, makeColumnOf, styleColumns } from "./frame-stats-shared.js";
+import { carriedColumns, removedStatWarning } from "./frame-helpers.js";
+import { makeColumnOf } from "./frame-stats-shared.js";
+import { statLayerFrame } from "./layer-frame.js";
 import { transformedZeroBaseline } from "./position-baseline.js";
 import { forwardMeasureOnce } from "./stat-measure-transform.js";
 import { positionColumn } from "./temporal-position.js";
 import type { LayerBinding, LayerFrame, PipelineWarning } from "./types.js";
-import { NO_ROW } from "./types.js";
 
 export function buildDensityFrame(
   binding: LayerBinding,
@@ -42,32 +42,28 @@ export function buildDensityFrame(
     scaled: result.scaled,
     ndensity: result.ndensity,
   };
+  const outN = result.x.length;
   const yNumeric = forwardMeasureOnce(
     columns[binding.yStatColumn ?? "density"] ?? result.density,
     binding.yTransform,
   );
-  const col = columnOf(result, null);
-  const outN = result.x.length;
-  return {
+  return statLayerFrame({
     binding,
     table,
     n: outN,
-    xValues: null,
-    xNumeric: result.x,
-    yValues: null,
-    yNumeric,
+    x: { numeric: result.x },
+    y: { numeric: yNumeric },
     groups: result.groups,
     inputGroups: groups,
-    inputSourceRows: null,
-    rowIndex: Uint32Array.from({ length: outN }, () => NO_ROW),
-    ...colorColumns(binding, col, columns),
-    ...styleColumns(binding, col, columns),
-    labelValues: col(binding.labelField),
-    ...emptyFrameExtras(),
-    // Density renders as an area from the shared transformed-origin baseline.
-    ymin: Float64Array.from({ length: outN }, () =>
-      transformedZeroBaseline(binding.yTransform?.transform ?? scaleTransform("identity")),
-    ),
-    ymax: yNumeric,
-  };
+    columns,
+    columnOf: columnOf(result, null),
+    lineage: "none",
+    extras: {
+      // Density renders as an area from the shared transformed-origin baseline.
+      ymin: Float64Array.from({ length: outN }, () =>
+        transformedZeroBaseline(binding.yTransform?.transform ?? scaleTransform("identity")),
+      ),
+      ymax: yNumeric,
+    },
+  });
 }

--- a/packages/core/src/pipeline/frame-stats-ecdf.ts
+++ b/packages/core/src/pipeline/frame-stats-ecdf.ts
@@ -4,12 +4,11 @@
 import { statEcdf } from "../stats/ecdf.js";
 import type { ColumnTable } from "../table.js";
 
-import { carriedColumns, emptyFrameExtras, removedStatWarning } from "./frame-helpers.js";
-import { makeColumnOf, styleColumns } from "./frame-stats-shared.js";
-import { forwardMeasureOnce } from "./stat-measure-transform.js";
+import { carriedColumns, removedStatWarning } from "./frame-helpers.js";
+import { makeColumnOf } from "./frame-stats-shared.js";
+import { statLayerFrame } from "./layer-frame.js";
 import { positionColumn } from "./temporal-position.js";
 import type { LayerBinding, LayerFrame, PipelineWarning } from "./types.js";
-import { NO_ROW } from "./types.js";
 
 export function buildEcdfFrame(
   binding: LayerBinding,
@@ -29,28 +28,16 @@ export function buildEcdfFrame(
   });
   removedStatWarning(result.dropped, index, "missing or non-finite x", warnings);
   const columns: Record<string, Float64Array> = { ecdf: result.ecdf };
-  const yNumeric = forwardMeasureOnce(
-    columns[binding.yStatColumn ?? "ecdf"] ?? result.ecdf,
-    binding.yTransform,
-  );
-  const col = columnOf(result, null);
-  const outN = result.x.length;
-  return {
+  return statLayerFrame({
     binding,
     table,
-    n: outN,
-    xValues: null,
-    xNumeric: result.x,
-    yValues: null,
-    yNumeric,
+    n: result.x.length,
+    x: { numeric: result.x },
+    y: { column: "ecdf", fallback: result.ecdf },
     groups: result.groups,
     inputGroups: groups,
-    inputSourceRows: null,
-    rowIndex: Uint32Array.from({ length: outN }, () => NO_ROW),
-    colorValues: col(binding.color.field),
-    fillValues: col(binding.fill.field),
-    ...styleColumns(binding, col, columns),
-    labelValues: col(binding.labelField),
-    ...emptyFrameExtras(),
-  };
+    columns,
+    columnOf: columnOf(result, null),
+    lineage: "none",
+  });
 }

--- a/packages/core/src/pipeline/frame-stats-ellipse.ts
+++ b/packages/core/src/pipeline/frame-stats-ellipse.ts
@@ -4,11 +4,11 @@
 import type { ColumnTable } from "../table.js";
 
 import { statEllipse, type StatEllipseParams } from "../stats/ellipse.js";
-import { carriedColumns, emptyFrameExtras, removedStatWarning } from "./frame-helpers.js";
-import { makeColumnOf, styleColumns } from "./frame-stats-shared.js";
+import { carriedColumns, removedStatWarning } from "./frame-helpers.js";
+import { makeColumnOf } from "./frame-stats-shared.js";
+import { statLayerFrame } from "./layer-frame.js";
 import { positionColumn } from "./temporal-position.js";
 import type { LayerBinding, LayerFrame, PipelineWarning } from "./types.js";
-import { NO_ROW } from "./types.js";
 
 export function buildEllipseFrame(
   binding: LayerBinding,
@@ -34,23 +34,16 @@ export function buildEllipseFrame(
       message: `Layer ${index} (ellipse): ${result.droppedGroups} group(s) with fewer than two finite points (or zero variance) have been dropped.`,
     });
   }
-  const col = columnOf(result, null);
-  return {
+  return statLayerFrame({
     binding,
     table,
     n: result.x.length,
-    xValues: null,
-    xNumeric: result.x,
-    yValues: null,
-    yNumeric: result.y,
+    x: { numeric: result.x },
+    y: { numeric: result.y },
     groups: result.groups,
     inputGroups: groups,
-    inputSourceRows: null,
-    rowIndex: Uint32Array.from({ length: result.x.length }, () => NO_ROW),
-    colorValues: col(binding.color.field),
-    fillValues: col(binding.fill.field),
-    ...styleColumns(binding, col, { x: result.x, y: result.y }),
-    labelValues: col(binding.labelField),
-    ...emptyFrameExtras(),
-  };
+    columns: { x: result.x, y: result.y },
+    columnOf: columnOf(result, null),
+    lineage: "none",
+  });
 }

--- a/packages/core/src/pipeline/frame-stats-function.ts
+++ b/packages/core/src/pipeline/frame-stats-function.ts
@@ -1,5 +1,8 @@
 /**
  * Function stat → LayerFrame (path/line from evaluated y = f(x) grid).
+ *
+ * Not yet on statLayerFrame (#1077): no carried aesthetics, empty inputGroups,
+ * and both axes are independently measure-forwarded.
  */
 import { statFunction } from "../stats/function.js";
 import type { ColumnTable } from "../table.js";

--- a/packages/core/src/pipeline/frame-stats-manual.ts
+++ b/packages/core/src/pipeline/frame-stats-manual.ts
@@ -4,6 +4,8 @@
  * first/last: slice identity frame (real rowIndex).
  * aggregate funs: one synthetic row per group (NO_ROW); x/y aggregated in
  * transformed numeric space; discrete aesthetics from sample row.
+ *
+ * Not yet on statLayerFrame (#1077): slices identity or builds synthetic rows.
  */
 import type { CellValue, ColumnTable } from "../table.js";
 

--- a/packages/core/src/pipeline/frame-stats-map.ts
+++ b/packages/core/src/pipeline/frame-stats-map.ts
@@ -7,6 +7,8 @@
  *
  * Fortified map table + byKey index are memoized per LayerBinding for the run
  * so faceted panels do not rebuild the map join (#910).
+ *
+ * Not yet on statLayerFrame (#1077): join expansion is a different shape.
  */
 import type { DataRef, PortableSpec } from "@ggsvelte/spec";
 

--- a/packages/core/src/pipeline/frame-stats-qq.ts
+++ b/packages/core/src/pipeline/frame-stats-qq.ts
@@ -5,10 +5,10 @@ import type { ColumnTable } from "../table.js";
 
 import { statQq, statQqLine } from "../stats/qq.js";
 
-import { carriedColumns, emptyFrameExtras, removedStatWarning } from "./frame-helpers.js";
-import { makeColumnOf, styleColumns } from "./frame-stats-shared.js";
+import { carriedColumns, removedStatWarning } from "./frame-helpers.js";
+import { makeColumnOf } from "./frame-stats-shared.js";
+import { statLayerFrame } from "./layer-frame.js";
 import type { LayerBinding, LayerFrame, PipelineWarning } from "./types.js";
-import { NO_ROW } from "./types.js";
 
 function packQqFrame(
   binding: LayerBinding,
@@ -30,26 +30,18 @@ function packQqFrame(
     theoretical: result.theoretical,
     sample: result.sample,
   };
-  const col = columnOf(result, null);
-  const n = result.theoretical.length;
-  return {
+  return statLayerFrame({
     binding,
     table,
-    n,
-    xValues: null,
-    xNumeric: result.theoretical,
-    yValues: null,
-    yNumeric: result.sample,
+    n: result.theoretical.length,
+    x: { numeric: result.theoretical },
+    y: { numeric: result.sample },
     groups: result.groups,
     inputGroups: groups,
-    inputSourceRows: null,
-    rowIndex: Uint32Array.from({ length: n }, () => NO_ROW),
-    colorValues: col(binding.color.field),
-    fillValues: col(binding.fill.field),
-    ...styleColumns(binding, col, columns),
-    labelValues: col(binding.labelField),
-    ...emptyFrameExtras(),
-  };
+    columns,
+    columnOf: columnOf(result, null),
+    lineage: "none",
+  });
 }
 
 export function buildQqFrame(

--- a/packages/core/src/pipeline/frame-stats-quantile.ts
+++ b/packages/core/src/pipeline/frame-stats-quantile.ts
@@ -6,11 +6,11 @@ import type { QuantileParams } from "@ggsvelte/spec";
 import { normalizeQuantiles, statQuantile } from "../stats/quantile.js";
 import type { ColumnTable } from "../table.js";
 
-import { carriedColumns, emptyFrameExtras, removedStatWarning } from "./frame-helpers.js";
-import { makeColumnOf, styleColumns } from "./frame-stats-shared.js";
+import { carriedColumns, removedStatWarning } from "./frame-helpers.js";
+import { makeColumnOf } from "./frame-stats-shared.js";
+import { statLayerFrame } from "./layer-frame.js";
 import { positionColumn } from "./temporal-position.js";
 import type { LayerBinding, LayerFrame, PipelineWarning } from "./types.js";
-import { NO_ROW } from "./types.js";
 
 export function buildQuantileFrame(
   binding: LayerBinding,
@@ -44,23 +44,16 @@ export function buildQuantileFrame(
       message: `Layer ${index} (quantile): ${result.droppedGroups} group(s) too small or degenerate (constant x) were dropped.`,
     });
   }
-  const col = columnOf(result, null);
-  return {
+  return statLayerFrame({
     binding,
     table,
     n: result.x.length,
-    xValues: null,
-    xNumeric: result.x,
-    yValues: null,
-    yNumeric: result.y,
+    x: { numeric: result.x },
+    y: { numeric: result.y },
     groups: result.groups,
     inputGroups: groups,
-    inputSourceRows: null,
-    rowIndex: Uint32Array.from({ length: result.x.length }, () => NO_ROW),
-    colorValues: col(binding.color.field),
-    fillValues: col(binding.fill.field),
-    ...styleColumns(binding, col, { x: result.x, y: result.y }),
-    labelValues: col(binding.labelField),
-    ...emptyFrameExtras(),
-  };
+    columns: { x: result.x, y: result.y },
+    columnOf: columnOf(result, null),
+    lineage: "none",
+  });
 }

--- a/packages/core/src/pipeline/frame-stats-sf-coordinates.ts
+++ b/packages/core/src/pipeline/frame-stats-sf-coordinates.ts
@@ -1,6 +1,8 @@
 /**
  * stat_sf_coordinates (#809 phase 2 + multi-part labels phase 5):
  * one (x,y) per geometry part from portable GeoJSON (Multi* expands).
+ *
+ * Not yet on statLayerFrame (#1077): geometry expand is a different shape.
  */
 import { ColumnTable, type CellValue } from "../table.js";
 

--- a/packages/core/src/pipeline/frame-stats-sf.ts
+++ b/packages/core/src/pipeline/frame-stats-sf.ts
@@ -4,6 +4,8 @@
  * ringIndex for even-odd holes. Already-projected coordinates only (no CRS /
  * coord_sf). Geometry lives as a JSON string in a data column (CellValue
  * cannot hold nested objects).
+ *
+ * Not yet on statLayerFrame (#1077): geometry expansion is a different shape.
  */
 import { ColumnTable, type CellValue } from "../table.js";
 

--- a/packages/core/src/pipeline/frame-stats-smooth-frame.ts
+++ b/packages/core/src/pipeline/frame-stats-smooth-frame.ts
@@ -4,10 +4,9 @@
 import type { ColumnTable } from "../table.js";
 import type { CellValue } from "../table.js";
 
-import { emptyFrameExtras } from "./frame-helpers.js";
-import { styleColumns, type CarriedColumnOf } from "./frame-stats-shared.js";
+import { type CarriedColumnOf } from "./frame-stats-shared.js";
+import { statLayerFrame } from "./layer-frame.js";
 import type { LayerBinding, LayerFrame } from "./types.js";
-import { NO_ROW } from "./types.js";
 
 type SmoothResult = {
   x: Float64Array;
@@ -27,31 +26,26 @@ export function packSmoothLayerFrame(
   columnOf: CarriedColumnOf,
   inputGroups: readonly number[],
 ): LayerFrame {
-  const col = columnOf(result, null);
-  return {
+  return statLayerFrame({
     binding,
     table,
     n: result.x.length,
-    xValues: null,
-    xNumeric: result.x,
-    yValues: null,
-    yNumeric: result.y,
+    x: { numeric: result.x },
+    y: { numeric: result.y },
     groups: result.groups,
     inputGroups,
-    inputSourceRows: null,
-    rowIndex: Uint32Array.from({ length: result.x.length }, () => NO_ROW),
-    colorValues: col(binding.color.field),
-    fillValues: col(binding.fill.field),
-    ...styleColumns(binding, col, {
+    columns: {
       y: result.y,
       ...(result.ymin !== null && { ymin: result.ymin }),
       ...(result.ymax !== null && { ymax: result.ymax }),
       se: result.se,
-    }),
-    labelValues: col(binding.labelField),
-    ...emptyFrameExtras(),
-    ymin: result.ymin,
-    ymax: result.ymax,
-    smooth: { band: result.hasBand },
-  };
+    },
+    columnOf: columnOf(result, null),
+    lineage: "none",
+    extras: {
+      ymin: result.ymin,
+      ymax: result.ymax,
+      smooth: { band: result.hasBand },
+    },
+  });
 }

--- a/packages/core/src/pipeline/frame-stats-sum.ts
+++ b/packages/core/src/pipeline/frame-stats-sum.ts
@@ -4,15 +4,15 @@
 import { statSum } from "../stats/sum.js";
 import type { ColumnTable, CellValue } from "../table.js";
 
-import { carriedColumns, emptyFrameExtras, removedStatWarning } from "./frame-helpers.js";
-import { makeColumnOf, styleColumns } from "./frame-stats-shared.js";
+import { carriedColumns, removedStatWarning } from "./frame-helpers.js";
+import { makeColumnOf } from "./frame-stats-shared.js";
+import { statLayerFrame } from "./layer-frame.js";
 import {
   positionColumn,
   positionDiscreteness,
   positionValuesToNumeric,
 } from "./temporal-position.js";
 import type { LayerBinding, LayerFrame, PipelineWarning } from "./types.js";
-import { NO_ROW } from "./types.js";
 
 function positionCells(
   binding: LayerBinding,
@@ -67,25 +67,17 @@ export function buildSumFrame(
   const xNumeric = positionValuesToNumeric(result.x, binding.xConversion).values;
   const yNumeric = positionValuesToNumeric(result.y, binding.yConversion).values;
   const columns: Record<string, Float64Array> = { n: result.n, prop: result.prop };
-  const col = columnOf(result, result.x);
-  const outN = result.x.length;
 
-  return {
+  return statLayerFrame({
     binding,
     table,
-    n: outN,
-    xValues: result.x,
-    xNumeric,
-    yValues: result.y,
-    yNumeric,
+    n: result.x.length,
+    x: { values: result.x, numeric: xNumeric },
+    y: { values: result.y, numeric: yNumeric },
     groups: result.groups,
     inputGroups: groups,
-    inputSourceRows: null,
-    rowIndex: Uint32Array.from({ length: outN }, () => NO_ROW),
-    colorValues: col(binding.color.field),
-    fillValues: col(binding.fill.field),
-    ...styleColumns(binding, col, columns),
-    labelValues: col(binding.labelField),
-    ...emptyFrameExtras(),
-  };
+    columns,
+    columnOf: columnOf(result, result.x),
+    lineage: "none",
+  });
 }

--- a/packages/core/src/pipeline/frame-stats-summary-bin.ts
+++ b/packages/core/src/pipeline/frame-stats-summary-bin.ts
@@ -9,11 +9,11 @@ import type { ColumnTable } from "../table.js";
 
 import { statSummaryBin, type SummaryBinParamsInput } from "../stats/summary-bin.js";
 
-import { carriedColumns, emptyFrameExtras, removedStatWarning } from "./frame-helpers.js";
-import { makeColumnOf, styleColumns } from "./frame-stats-shared.js";
+import { carriedColumns, removedStatWarning } from "./frame-helpers.js";
+import { makeColumnOf } from "./frame-stats-shared.js";
+import { statLayerFrame } from "./layer-frame.js";
 import { positionColumn } from "./temporal-position.js";
 import type { Advisory, LayerBinding, LayerFrame, PipelineWarning } from "./types.js";
-import { NO_ROW } from "./types.js";
 
 export function buildSummaryBinFrame(
   binding: LayerBinding,
@@ -48,34 +48,28 @@ export function buildSummaryBinFrame(
       howToOverride: `Set params.binwidth (preferred) or params.bins on layer ${index}.`,
     });
   }
-  const col = columnOf(result, null);
-  const outN = result.x.length;
-  return {
+  return statLayerFrame({
     binding,
     table,
-    n: outN,
-    xValues: null,
-    xNumeric: result.x,
-    yValues: null,
-    yNumeric: result.y,
+    n: result.x.length,
+    x: { numeric: result.x },
+    y: { numeric: result.y },
     groups: result.groups,
     inputGroups: groups,
-    inputSourceRows: null,
-    rowIndex: Uint32Array.from({ length: outN }, () => NO_ROW),
-    colorValues: col(binding.color.field),
-    fillValues: col(binding.fill.field),
-    ...styleColumns(binding, col, {
+    columns: {
       y: result.y,
       ymin: result.ymin,
       ymax: result.ymax,
-    }),
-    labelValues: col(binding.labelField),
-    ...emptyFrameExtras(),
-    // Lineage replays the stat's own cut instead of re-deriving from edges (#905).
-    binCut: result.cut,
-    ymin: result.ymin,
-    ymax: result.ymax,
-    xmin: result.xmin,
-    xmax: result.xmax,
-  };
+    },
+    columnOf: columnOf(result, null),
+    lineage: "none",
+    extras: {
+      // Lineage replays the stat's own cut instead of re-deriving from edges (#905).
+      binCut: result.cut,
+      ymin: result.ymin,
+      ymax: result.ymax,
+      xmin: result.xmin,
+      xmax: result.xmax,
+    },
+  });
 }

--- a/packages/core/src/pipeline/frame-stats-summary.ts
+++ b/packages/core/src/pipeline/frame-stats-summary.ts
@@ -4,17 +4,13 @@
 import type { ErrorbarParams } from "@ggsvelte/spec";
 
 import { statSummary } from "../stats/summary.js";
-import { ColumnTable, type CellValue } from "../table.js";
+import type { CellValue, ColumnTable } from "../table.js";
 
-import { carriedColumns, emptyFrameExtras, removedStatWarning } from "./frame-helpers.js";
-import {
-  makeColumnOf,
-  shouldAggregateOnSemanticTemporalX,
-  styleColumns,
-} from "./frame-stats-shared.js";
+import { carriedColumns, removedStatWarning } from "./frame-helpers.js";
+import { makeColumnOf, shouldAggregateOnSemanticTemporalX } from "./frame-stats-shared.js";
+import { statLayerFrame } from "./layer-frame.js";
 import { positionColumn, positionValuesToNumeric } from "./temporal-position.js";
 import type { LayerBinding, LayerFrame, PipelineWarning } from "./types.js";
-import { NO_ROW } from "./types.js";
 
 export function buildSummaryFrame(
   binding: LayerBinding,
@@ -56,32 +52,30 @@ export function buildSummaryFrame(
     transformedContinuousX === null
       ? result.x
       : result.x.map((value) => binding.xTransform!.transform.inverse(value as number));
-  const col = columnOf(result, displayX);
-  return {
+  return statLayerFrame({
     binding,
     table,
     n: result.x.length,
-    xValues: displayX,
-    xNumeric:
-      temporalX || transformedContinuousX !== null
-        ? Float64Array.from(result.x, (value) => (typeof value === "number" ? value : Number.NaN))
-        : positionValuesToNumeric(result.x, binding.xConversion).values,
-    yValues: null,
-    yNumeric: result.y,
+    x: {
+      values: displayX,
+      numeric:
+        temporalX || transformedContinuousX !== null
+          ? Float64Array.from(result.x, (value) => (typeof value === "number" ? value : Number.NaN))
+          : positionValuesToNumeric(result.x, binding.xConversion).values,
+    },
+    y: { numeric: result.y },
     groups: result.groups,
     inputGroups: groups,
-    inputSourceRows: null,
-    rowIndex: Uint32Array.from({ length: result.x.length }, () => NO_ROW),
-    colorValues: col(binding.color.field),
-    fillValues: col(binding.fill.field),
-    ...styleColumns(binding, col, {
+    columns: {
       y: result.y,
       ymin: result.ymin,
       ymax: result.ymax,
-    }),
-    labelValues: col(binding.labelField),
-    ...emptyFrameExtras(),
-    ymin: result.ymin,
-    ymax: result.ymax,
-  };
+    },
+    columnOf: columnOf(result, displayX),
+    lineage: "none",
+    extras: {
+      ymin: result.ymin,
+      ymax: result.ymax,
+    },
+  });
 }

--- a/packages/core/src/pipeline/frame-stats-unique.ts
+++ b/packages/core/src/pipeline/frame-stats-unique.ts
@@ -3,6 +3,8 @@
  * aesthetic fields (#813). Builds a full identity frame, then slices every
  * post-stat column to the kept panel-local rows so segment/rect/ribbon
  * extras stay aligned with frame-identity.ts.
+ *
+ * Not yet on statLayerFrame (#1077): slices an identity frame, not a stat pack.
  */
 import type { CellValue, ColumnTable } from "../table.js";
 

--- a/packages/core/src/pipeline/frame-stats-ydensity.ts
+++ b/packages/core/src/pipeline/frame-stats-ydensity.ts
@@ -6,11 +6,11 @@ import type { ViolinParams } from "@ggsvelte/spec";
 import { statYDensity } from "../stats/ydensity.js";
 import type { ColumnTable } from "../table.js";
 
-import { carriedColumns, emptyFrameExtras, removedStatWarning } from "./frame-helpers.js";
-import { makeColumnOf, styleColumns } from "./frame-stats-shared.js";
+import { carriedColumns, removedStatWarning } from "./frame-helpers.js";
+import { makeColumnOf } from "./frame-stats-shared.js";
+import { statLayerFrame } from "./layer-frame.js";
 import { positionColumn } from "./temporal-position.js";
 import type { LayerBinding, LayerFrame, PipelineWarning } from "./types.js";
-import { NO_ROW } from "./types.js";
 
 export function buildYDensityFrame(
   binding: LayerBinding,
@@ -42,34 +42,28 @@ export function buildYDensityFrame(
       message: `Layer ${index} (ydensity): ${result.droppedGroups} group(s) with fewer than two data points have been dropped.`,
     });
   }
-  const col = columnOf(result, result.x);
-  const outN = result.y.length;
-  return {
+  return statLayerFrame({
     binding,
     table,
-    n: outN,
-    xValues: result.x,
-    xNumeric: null,
-    yValues: null,
-    yNumeric: result.y,
+    n: result.y.length,
+    x: { values: result.x, numeric: null },
+    y: { numeric: result.y },
     groups: result.groups,
     inputGroups: groups,
-    inputSourceRows: null,
-    rowIndex: Uint32Array.from({ length: outN }, () => NO_ROW),
-    colorValues: col(binding.color.field),
-    fillValues: col(binding.fill.field),
-    ...styleColumns(binding, col, {
+    columns: {
       density: result.density,
       scaled: result.scaled,
       count: result.count,
       violinwidth: result.violinwidth,
-    }),
-    labelValues: col(binding.labelField),
-    ...emptyFrameExtras(),
-    // ymin stashes violinwidth (unitless 0–1 × scale factor) for geometry-violin.
-    xmin: null,
-    xmax: null,
-    ymin: result.violinwidth,
-    ymax: result.violinwidth,
-  };
+    },
+    columnOf: columnOf(result, result.x),
+    lineage: "none",
+    extras: {
+      // ymin stashes violinwidth (unitless 0–1 × scale factor) for geometry-violin.
+      xmin: null,
+      xmax: null,
+      ymin: result.violinwidth,
+      ymax: result.violinwidth,
+    },
+  });
 }

--- a/packages/core/src/pipeline/layer-frame.ts
+++ b/packages/core/src/pipeline/layer-frame.ts
@@ -86,6 +86,13 @@ type StatLayerFrameInput = {
    * post-stat row is synthesized (filled with NO_ROW).
    */
   readonly lineage: Uint32Array | "none";
+  /**
+   * When true, resolve color/fill through after_stat computed columns
+   * (`colorColumns`). Default false: field lookup only — matches pre-#1077
+   * adapters that ignored after_stat color on stats outside STAT_COLOR_COLUMNS
+   * (boxplot, summary, smooth, ecdf, …).
+   */
+  readonly afterStatColor?: boolean;
   readonly extras?: StatLayerFrameExtras;
 };
 
@@ -126,10 +133,17 @@ export function statLayerFrame(input: StatLayerFrameInput): LayerFrame {
     columns = {},
     columnOf,
     lineage,
+    afterStatColor = false,
     extras,
   } = input;
   const { yNumeric, yValues } = resolveY(binding, y, columns);
   const rowIndex = lineage === "none" ? Uint32Array.from({ length: n }, () => NO_ROW) : lineage;
+  const colorFill = afterStatColor
+    ? colorColumns(binding, columnOf, columns)
+    : {
+        colorValues: columnOf(binding.color.field),
+        fillValues: columnOf(binding.fill.field),
+      };
 
   return {
     binding,
@@ -143,7 +157,7 @@ export function statLayerFrame(input: StatLayerFrameInput): LayerFrame {
     inputGroups,
     inputSourceRows: null,
     rowIndex,
-    ...colorColumns(binding, columnOf, columns),
+    ...colorFill,
     ...styleColumns(binding, columnOf, columns),
     labelValues: columnOf(binding.labelField),
     ...emptyFrameExtras(),

--- a/packages/core/src/pipeline/layer-frame.ts
+++ b/packages/core/src/pipeline/layer-frame.ts
@@ -17,7 +17,7 @@ import type { LayerBinding, LayerFrame } from "./types.js";
 import { NO_ROW } from "./types.js";
 
 /** Resolved x/y axes, or a y measure column default for forwardMeasureOnce. */
-export type FrameYAxis =
+type FrameYAxis =
   | {
       readonly numeric?: Float64Array | null;
       readonly values?: readonly CellValue[] | null;
@@ -29,13 +29,13 @@ export type FrameYAxis =
       readonly fallback?: Float64Array;
     };
 
-export type FrameXAxis = {
+type FrameXAxis = {
   readonly numeric?: Float64Array | null;
   readonly values?: readonly CellValue[] | null;
 };
 
 /** Optional geom payloads and overrides applied after emptyFrameExtras. */
-export type StatLayerFrameExtras = Partial<
+type StatLayerFrameExtras = Partial<
   Pick<
     LayerFrame,
     | "ymin"
@@ -69,7 +69,7 @@ export type StatLayerFrameExtras = Partial<
   >
 >;
 
-export type StatLayerFrameInput = {
+type StatLayerFrameInput = {
   readonly binding: LayerBinding;
   readonly table: ColumnTable;
   readonly n: number;

--- a/packages/core/src/pipeline/layer-frame.ts
+++ b/packages/core/src/pipeline/layer-frame.ts
@@ -1,0 +1,152 @@
+/**
+ * Single constructor for post-stat LayerFrame (#1077).
+ *
+ * Owns the shared field set, yStatColumn default + forwardMeasureOnce,
+ * NO_ROW lineage, and style/color/extras spreads. Adapters keep only which
+ * stat to call and which columns come back.
+ *
+ * Not used by frame-stats-function, frame-stats-map, frame-stats-manual,
+ * frame-stats-unique, or the sf family — those shapes genuinely differ.
+ */
+import type { CellValue, ColumnTable } from "../table.js";
+
+import { emptyFrameExtras } from "./frame-helpers.js";
+import { colorColumns, styleColumns } from "./frame-stats-shared.js";
+import { forwardMeasureOnce } from "./stat-measure-transform.js";
+import type { LayerBinding, LayerFrame } from "./types.js";
+import { NO_ROW } from "./types.js";
+
+/** Resolved x/y axes, or a y measure column default for forwardMeasureOnce. */
+export type FrameYAxis =
+  | {
+      readonly numeric?: Float64Array | null;
+      readonly values?: readonly CellValue[] | null;
+    }
+  | {
+      /** Default yStatColumn name when binding.yStatColumn is null. */
+      readonly column: string;
+      /** Fallback series if columns[resolved] is missing. */
+      readonly fallback?: Float64Array;
+    };
+
+export type FrameXAxis = {
+  readonly numeric?: Float64Array | null;
+  readonly values?: readonly CellValue[] | null;
+};
+
+/** Optional geom payloads and overrides applied after emptyFrameExtras. */
+export type StatLayerFrameExtras = Partial<
+  Pick<
+    LayerFrame,
+    | "ymin"
+    | "ymax"
+    | "xmin"
+    | "xmax"
+    | "xend"
+    | "yend"
+    | "xendValues"
+    | "yendValues"
+    | "offsetX"
+    | "offsetY"
+    | "xIntercepts"
+    | "yIntercepts"
+    | "hexWidth"
+    | "hexHeight"
+    | "bin"
+    | "binCut"
+    | "dodge"
+    | "box"
+    | "smooth"
+    | "sf"
+    | "colorValues"
+    | "fillValues"
+    | "sizeValues"
+    | "linewidthValues"
+    | "alphaValues"
+    | "shapeValues"
+    | "linetypeValues"
+    | "labelValues"
+  >
+>;
+
+export type StatLayerFrameInput = {
+  readonly binding: LayerBinding;
+  readonly table: ColumnTable;
+  readonly n: number;
+  readonly x: FrameXAxis;
+  readonly y: FrameYAxis;
+  readonly groups: readonly number[];
+  readonly inputGroups: readonly number[];
+  /** Stat output columns for style/color channels and y-column default. */
+  readonly columns?: Readonly<Record<string, Float64Array | readonly CellValue[]>>;
+  /** Resolve carried/source aesthetic fields (from makeColumnOf). */
+  readonly columnOf: (field: string | null) => readonly CellValue[] | null;
+  /**
+   * Lineage: source rows when the stat preserves them, `"none"` when every
+   * post-stat row is synthesized (filled with NO_ROW).
+   */
+  readonly lineage: Uint32Array | "none";
+  readonly extras?: StatLayerFrameExtras;
+};
+
+function resolveY(
+  binding: LayerBinding,
+  y: FrameYAxis,
+  columns: Readonly<Record<string, Float64Array | readonly CellValue[]>> | undefined,
+): { yNumeric: Float64Array | null; yValues: readonly CellValue[] | null } {
+  if ("column" in y) {
+    const name = binding.yStatColumn ?? y.column;
+    const series = columns?.[name] ?? y.fallback;
+    if (series === undefined || !(series instanceof Float64Array)) {
+      return { yNumeric: y.fallback ?? null, yValues: null };
+    }
+    return {
+      yNumeric: forwardMeasureOnce(series, binding.yTransform),
+      yValues: null,
+    };
+  }
+  return {
+    yNumeric: y.numeric ?? null,
+    yValues: y.values ?? null,
+  };
+}
+
+/**
+ * The one place a post-stat LayerFrame is constructed for matching adapters.
+ */
+export function statLayerFrame(input: StatLayerFrameInput): LayerFrame {
+  const {
+    binding,
+    table,
+    n,
+    x,
+    y,
+    groups,
+    inputGroups,
+    columns = {},
+    columnOf,
+    lineage,
+    extras,
+  } = input;
+  const { yNumeric, yValues } = resolveY(binding, y, columns);
+  const rowIndex = lineage === "none" ? Uint32Array.from({ length: n }, () => NO_ROW) : lineage;
+
+  return {
+    binding,
+    table,
+    n,
+    xValues: x.values ?? null,
+    xNumeric: x.numeric ?? null,
+    yValues,
+    yNumeric,
+    groups,
+    inputGroups,
+    inputSourceRows: null,
+    rowIndex,
+    ...colorColumns(binding, columnOf, columns),
+    ...styleColumns(binding, columnOf, columns),
+    labelValues: columnOf(binding.labelField),
+    ...emptyFrameExtras(),
+    ...extras,
+  };
+}

--- a/packages/core/tests/pipeline-scale-stage.test.ts
+++ b/packages/core/tests/pipeline-scale-stage.test.ts
@@ -76,6 +76,10 @@ describe("positional-read space inventory", () => {
  * Every stat output role. `semantic-measure` = a stat-invented mapped measure
  * forwarded through the axis transform exactly once. `scale-space` = derived
  * FROM already-transformed inputs, never forwarded again.
+ *
+ * After #1077, column-mode y (`y: { column }`) is forwarded inside
+ * `layer-frame.ts` via `statLayerFrame`; adapters may either call
+ * `forwardMeasureOnce` directly or hand off via column mode.
  */
 const PROVENANCE_INVENTORY = [
   { file: "frame-stats-count.ts", role: "semantic-measure", outputs: ["count"] },
@@ -89,27 +93,50 @@ const PROVENANCE_INVENTORY = [
     role: "semantic-measure",
     outputs: ["density", "count", "scaled", "ndensity"],
   },
+  {
+    file: "layer-frame.ts",
+    role: "semantic-measure",
+    outputs: ["yStatColumn column-mode default"],
+  },
   { file: "frame-stats-smooth.ts", role: "scale-space", outputs: ["smooth x/y/bands"] },
   { file: "frame-stats-summary.ts", role: "scale-space", outputs: ["summary aggregates"] },
   { file: "frame-stats-boxplot.ts", role: "scale-space", outputs: ["boxplot aggregates"] },
 ] as const;
 
+/** Direct call or column-mode handoff that layer-frame forwards once. */
+function forwardsSemanticMeasure(src: string): boolean {
+  return src.includes("forwardMeasureOnce") || /y:\s*\{\s*column:/.test(src);
+}
+
 describe("stat-output provenance inventory", () => {
   for (const { file, role } of PROVENANCE_INVENTORY) {
     it(`${file} (${role}) ${role === "semantic-measure" ? "forwards once" : "never re-forwards"}`, () => {
-      const calls = code(file).includes("forwardMeasureOnce");
-      expect(calls).toBe(role === "semantic-measure");
+      const src = code(file);
+      if (role === "semantic-measure") {
+        expect(forwardsSemanticMeasure(src)).toBe(true);
+      } else {
+        expect(src.includes("forwardMeasureOnce")).toBe(false);
+      }
     });
   }
 
-  it("forwardMeasureOnce is called by exactly the semantic-measure producers", () => {
-    const expected = PROVENANCE_INVENTORY.filter((e) => e.role === "semantic-measure")
-      .map((e) => e.file)
-      .toSorted();
+  it("forwardMeasureOnce lives on the known semantic-measure call sites", () => {
+    // Independent list of direct call sites; bin-frame uses column mode instead.
+    const expected = [
+      "frame-stats-count.ts",
+      "frame-stats-density.ts",
+      "layer-frame.ts",
+    ].toSorted();
     const actual = PROVENANCE_INVENTORY.filter((e) => code(e.file).includes("forwardMeasureOnce"))
       .map((e) => e.file)
       .toSorted();
     expect(actual).toEqual(expected);
+  });
+
+  it("bin-frame hands column-mode y to layer-frame instead of calling forwardMeasureOnce", () => {
+    const src = code("frame-stats-bin-frame.ts");
+    expect(src.includes("forwardMeasureOnce")).toBe(false);
+    expect(/y:\s*\{\s*column:\s*"count"/.test(src)).toBe(true);
   });
 
   it("the public MappedField.source flag is not a transform-decision key", () => {

--- a/packages/core/tests/pipeline/layer-frame.test.ts
+++ b/packages/core/tests/pipeline/layer-frame.test.ts
@@ -153,15 +153,16 @@ describe("statLayerFrame (#1077)", () => {
     expect(Array.from(frame.yNumeric!)).toEqual([10, 20]);
   });
 
-  it("spreads style and after_stat color columns from computed series", () => {
+  it("spreads after_stat color only when afterStatColor is opted in", () => {
     const count = new Float64Array([1, 3, 5]);
     const b = binding({
       colorStat: "count",
       sizeStat: "count",
     });
-    const carried = (_field: string | null) => ["a", "b", "c"] as const;
+    // Real makeColumnOf returns null when field is null.
+    const columnOf = (field: string | null) => (field === null ? null : (["a", "b", "c"] as const));
 
-    const frame = statLayerFrame({
+    const ignored = statLayerFrame({
       binding: b,
       table,
       n: 3,
@@ -170,12 +171,28 @@ describe("statLayerFrame (#1077)", () => {
       groups: [0, 0, 0],
       inputGroups: [0],
       columns: { count },
-      columnOf: carried,
+      columnOf,
       lineage: "none",
     });
+    // Default: field lookup only — color.field is null so colorValues stay null
+    // even though color.statColumn is set (boxplot/summary/ecdf parity).
+    expect(ignored.colorValues).toBeNull();
+    expect(Array.from(ignored.sizeValues as Float64Array)).toEqual([1, 3, 5]);
 
-    expect(Array.from(frame.colorValues as number[])).toEqual([1, 3, 5]);
-    expect(Array.from(frame.sizeValues as Float64Array)).toEqual([1, 3, 5]);
+    const applied = statLayerFrame({
+      binding: b,
+      table,
+      n: 3,
+      x: { numeric: new Float64Array([0, 1, 2]) },
+      y: { column: "count", fallback: count },
+      groups: [0, 0, 0],
+      inputGroups: [0],
+      columns: { count },
+      columnOf,
+      lineage: "none",
+      afterStatColor: true,
+    });
+    expect(Array.from(applied.colorValues as number[])).toEqual([1, 3, 5]);
   });
 
   it("uses explicit lineage row indices when provided", () => {

--- a/packages/core/tests/pipeline/layer-frame.test.ts
+++ b/packages/core/tests/pipeline/layer-frame.test.ts
@@ -1,0 +1,366 @@
+/**
+ * Contract for the single post-stat LayerFrame constructor (#1077).
+ * Expected values are independent literals / known transforms, not re-derived
+ * from the implementation under test.
+ */
+import { describe, expect, it } from "bun:test";
+import { fromPartial } from "@total-typescript/shoehorn";
+
+import { NO_ROW } from "../../src/pipeline/types.ts";
+import type { LayerBinding } from "../../src/pipeline/types.ts";
+import { ColumnTable } from "../../src/table.ts";
+import { scaleTransform } from "../../src/scales/transform.ts";
+import { statLayerFrame } from "../../src/pipeline/layer-frame.ts";
+
+const emptyStyle = {
+  field: null,
+  statColumn: null,
+  constant: null,
+  scaledConstant: null,
+};
+
+function binding(partial: {
+  yStatColumn?: string | null;
+  yTransform?: LayerBinding["yTransform"];
+  colorField?: string | null;
+  colorStat?: string | null;
+  sizeField?: string | null;
+  sizeStat?: string | null;
+  labelField?: string | null;
+}): LayerBinding {
+  return fromPartial<LayerBinding>({
+    layer: { geom: "point", aes: {} },
+    index: 0,
+    yStatColumn: partial.yStatColumn ?? null,
+    yTransform: partial.yTransform,
+    color: {
+      field: partial.colorField ?? null,
+      statColumn: partial.colorStat ?? null,
+      constant: null,
+      scaledConstant: null,
+    },
+    fill: { field: null, constant: null, scaledConstant: null },
+    size: { ...emptyStyle, field: partial.sizeField ?? null, statColumn: partial.sizeStat ?? null },
+    linewidth: emptyStyle,
+    alpha: emptyStyle,
+    shape: emptyStyle,
+    linetype: emptyStyle,
+    labelField: partial.labelField ?? null,
+  });
+}
+
+const table = ColumnTable.fromRows([{ x: 1 }, { x: 2 }]);
+const nullColumnOf = (_field: string | null) => null;
+
+describe("statLayerFrame (#1077)", () => {
+  it("builds a core frame with NO_ROW lineage and empty extras", () => {
+    const x = new Float64Array([1, 2, 3]);
+    const y = new Float64Array([0.1, 0.5, 0.9]);
+    const groups = [0, 0, 1];
+    const inputGroups = [0, 1];
+    const b = binding({});
+
+    const frame = statLayerFrame({
+      binding: b,
+      table,
+      n: 3,
+      x: { numeric: x },
+      y: { numeric: y },
+      groups,
+      inputGroups,
+      columnOf: nullColumnOf,
+      lineage: "none",
+    });
+
+    expect(frame.binding).toBe(b);
+    expect(frame.table).toBe(table);
+    expect(frame.n).toBe(3);
+    expect(frame.xValues).toBeNull();
+    expect(frame.xNumeric).toBe(x);
+    expect(frame.yValues).toBeNull();
+    expect(frame.yNumeric).toBe(y);
+    expect(frame.groups).toEqual(groups);
+    expect(frame.inputGroups).toEqual(inputGroups);
+    expect(frame.inputSourceRows).toBeNull();
+    expect(Array.from(frame.rowIndex)).toEqual([NO_ROW, NO_ROW, NO_ROW]);
+    expect(frame.colorValues).toBeNull();
+    expect(frame.fillValues).toBeNull();
+    expect(frame.sizeValues).toBeNull();
+    expect(frame.linewidthValues).toBeNull();
+    expect(frame.alphaValues).toBeNull();
+    expect(frame.shapeValues).toBeNull();
+    expect(frame.linetypeValues).toBeNull();
+    expect(frame.labelValues).toBeNull();
+    expect(frame.ymin).toBeNull();
+    expect(frame.ymax).toBeNull();
+    expect(frame.xmin).toBeNull();
+    expect(frame.xmax).toBeNull();
+    expect(frame.bin).toBeNull();
+    expect(frame.box).toBeNull();
+    expect(frame.smooth).toBeNull();
+    expect(frame.sf).toBeNull();
+    expect(frame.xIntercepts).toEqual([]);
+    expect(frame.yIntercepts).toEqual([]);
+  });
+
+  it("resolves y via yStatColumn default and forwards the measure once", () => {
+    const ecdf = new Float64Array([0.25, 0.5, 1]);
+    const b = binding({
+      yStatColumn: null,
+      yTransform: {
+        transform: scaleTransform("sqrt"),
+        sourceLimits: null,
+        oob: "censor",
+        naValue: null,
+      },
+    });
+
+    const frame = statLayerFrame({
+      binding: b,
+      table,
+      n: 3,
+      x: { numeric: new Float64Array([1, 2, 3]) },
+      y: { column: "ecdf", fallback: ecdf },
+      groups: [0, 0, 0],
+      inputGroups: [0, 0],
+      columns: { ecdf },
+      columnOf: nullColumnOf,
+      lineage: "none",
+    });
+
+    // sqrt of [0.25, 0.5, 1] = [0.5, ~0.707, 1]
+    expect(Array.from(frame.yNumeric!)).toEqual([Math.sqrt(0.25), Math.sqrt(0.5), Math.sqrt(1)]);
+  });
+
+  it("prefers binding.yStatColumn over the column default name", () => {
+    const density = new Float64Array([2, 4]);
+    const count = new Float64Array([10, 20]);
+    const b = binding({ yStatColumn: "count" });
+
+    const frame = statLayerFrame({
+      binding: b,
+      table,
+      n: 2,
+      x: { numeric: new Float64Array([0, 1]) },
+      y: { column: "density", fallback: density },
+      groups: [0, 0],
+      inputGroups: [0],
+      columns: { density, count },
+      columnOf: nullColumnOf,
+      lineage: "none",
+    });
+
+    expect(Array.from(frame.yNumeric!)).toEqual([10, 20]);
+  });
+
+  it("spreads style and after_stat color columns from computed series", () => {
+    const count = new Float64Array([1, 3, 5]);
+    const b = binding({
+      colorStat: "count",
+      sizeStat: "count",
+    });
+    const carried = (_field: string | null) => ["a", "b", "c"] as const;
+
+    const frame = statLayerFrame({
+      binding: b,
+      table,
+      n: 3,
+      x: { numeric: new Float64Array([0, 1, 2]) },
+      y: { column: "count", fallback: count },
+      groups: [0, 0, 0],
+      inputGroups: [0],
+      columns: { count },
+      columnOf: carried,
+      lineage: "none",
+    });
+
+    expect(Array.from(frame.colorValues as number[])).toEqual([1, 3, 5]);
+    expect(Array.from(frame.sizeValues as Float64Array)).toEqual([1, 3, 5]);
+  });
+
+  it("uses explicit lineage row indices when provided", () => {
+    const lineage = new Uint32Array([4, 7, 9]);
+    const frame = statLayerFrame({
+      binding: binding({}),
+      table,
+      n: 3,
+      x: { numeric: new Float64Array([0, 1, 2]) },
+      y: { numeric: new Float64Array([0, 0, 0]) },
+      groups: [0, 0, 0],
+      inputGroups: [0],
+      columnOf: nullColumnOf,
+      lineage,
+    });
+    expect(frame.rowIndex).toBe(lineage);
+    expect(Array.from(frame.rowIndex)).toEqual([4, 7, 9]);
+  });
+
+  it("applies extras over emptyFrameExtras", () => {
+    const ymin = new Float64Array([0, 0]);
+    const ymax = new Float64Array([1, 2]);
+    const frame = statLayerFrame({
+      binding: binding({}),
+      table,
+      n: 2,
+      x: { values: ["a", "b"], numeric: null },
+      y: { numeric: null, values: null },
+      groups: [0, 1],
+      inputGroups: [0, 1],
+      columnOf: nullColumnOf,
+      lineage: "none",
+      extras: {
+        ymin,
+        ymax,
+        box: {
+          lower: new Float64Array([0.2, 0.3]),
+          middle: new Float64Array([0.5, 0.6]),
+          upper: new Float64Array([0.8, 0.9]),
+          outlierX: [],
+          outlierY: new Float64Array(0),
+          outlierBox: new Uint32Array(0),
+          outlierRow: new Uint32Array(0),
+        },
+      },
+    });
+    expect(frame.xValues).toEqual(["a", "b"]);
+    expect(frame.xNumeric).toBeNull();
+    expect(frame.ymin).toBe(ymin);
+    expect(frame.ymax).toBe(ymax);
+    expect(frame.box?.middle[0]).toBe(0.5);
+  });
+
+  it("resolves labelValues through columnOf", () => {
+    const labels = ["p1", "p2"];
+    const frame = statLayerFrame({
+      binding: binding({ labelField: "lab" }),
+      table,
+      n: 2,
+      x: { numeric: new Float64Array([0, 1]) },
+      y: { numeric: new Float64Array([0, 1]) },
+      groups: [0, 0],
+      inputGroups: [0],
+      columnOf: (field) => (field === "lab" ? labels : null),
+      lineage: "none",
+    });
+    expect(frame.labelValues).toEqual(labels);
+  });
+});
+
+/**
+ * Per-adapter smoke: converted builders produce frames whose n, groups, and
+ * rowIndex match the kernel contract they wrap (#1077 coverage gap).
+ */
+describe("converted frame-stats adapters smoke (#1077)", () => {
+  it("buildEcdfFrame: n matches kernel x, NO_ROW lineage", async () => {
+    const { buildEcdfFrame } = await import("../../src/pipeline/frame-stats-ecdf.ts");
+    const { AUTO_POSITION_CONVERSION } = await import("../../src/pipeline/temporal-position.ts");
+    const data = ColumnTable.fromRows([{ x: 1 }, { x: 2 }, { x: 2 }, { x: 3 }]);
+    const groups = [0, 0, 0, 0];
+    const b = fromPartial<LayerBinding>({
+      layer: { geom: "line", stat: "ecdf", aes: { x: { field: "x" } }, params: { pad: false } },
+      index: 0,
+      xField: "x",
+      yField: null,
+      yStatColumn: "ecdf",
+      xConversion: AUTO_POSITION_CONVERSION,
+      yConversion: AUTO_POSITION_CONVERSION,
+      color: { field: null, constant: null, scaledConstant: null },
+      fill: { field: null, constant: null, scaledConstant: null },
+      size: emptyStyle,
+      linewidth: emptyStyle,
+      alpha: emptyStyle,
+      shape: emptyStyle,
+      linetype: emptyStyle,
+      labelField: null,
+      weightField: null,
+    });
+    const warnings: { code: string; message: string }[] = [];
+    const frame = buildEcdfFrame(b, data, groups, warnings);
+    expect(frame.n).toBe(frame.xNumeric!.length);
+    expect(frame.n).toBe(frame.groups.length);
+    expect(frame.inputGroups).toEqual(groups);
+    expect(frame.inputSourceRows).toBeNull();
+    expect(frame.rowIndex.every((r) => r === NO_ROW)).toBe(true);
+    expect(frame.yNumeric).not.toBeNull();
+    expect(frame.yNumeric!.length).toBe(frame.n);
+  });
+
+  it("buildDensityFrame: n/groups aligned and area baseline set", async () => {
+    const { buildDensityFrame } = await import("../../src/pipeline/frame-stats-density.ts");
+    const { AUTO_POSITION_CONVERSION } = await import("../../src/pipeline/temporal-position.ts");
+    const data = ColumnTable.fromRows(
+      Array.from({ length: 40 }, (_, i) => ({ x: Math.sin(i) + i * 0.1 })),
+    );
+    const groups = Array.from({ length: data.rowCount }, () => 0);
+    const b = fromPartial<LayerBinding>({
+      layer: { geom: "density", aes: { x: { field: "x" } } },
+      index: 0,
+      xField: "x",
+      yField: null,
+      yStatColumn: "density",
+      xConversion: AUTO_POSITION_CONVERSION,
+      yConversion: AUTO_POSITION_CONVERSION,
+      color: { field: null, constant: null, scaledConstant: null },
+      fill: { field: null, constant: null, scaledConstant: null },
+      size: emptyStyle,
+      linewidth: emptyStyle,
+      alpha: emptyStyle,
+      shape: emptyStyle,
+      linetype: emptyStyle,
+      labelField: null,
+      weightField: null,
+    });
+    const frame = buildDensityFrame(b, data, groups, []);
+    expect(frame.n).toBe(frame.xNumeric!.length);
+    expect(frame.n).toBe(frame.groups.length);
+    expect(frame.rowIndex.every((r) => r === NO_ROW)).toBe(true);
+    expect(frame.ymin).not.toBeNull();
+    expect(frame.ymax).toBe(frame.yNumeric);
+  });
+
+  it("packBinLayerFrame: n/groups/rowIndex contract", async () => {
+    const { packBinLayerFrame } = await import("../../src/pipeline/frame-stats-bin-frame.ts");
+    const { makeColumnOf } = await import("../../src/pipeline/frame-stats-shared.ts");
+    const { AUTO_POSITION_CONVERSION } = await import("../../src/pipeline/temporal-position.ts");
+    const data = ColumnTable.fromRows([{ x: 1 }, { x: 2 }]);
+    const b = fromPartial<LayerBinding>({
+      layer: { geom: "bar", stat: "bin", aes: { x: { field: "x" } } },
+      index: 0,
+      xField: "x",
+      yField: null,
+      yStatColumn: "count",
+      xConversion: AUTO_POSITION_CONVERSION,
+      yConversion: AUTO_POSITION_CONVERSION,
+      color: { field: null, constant: null, scaledConstant: null },
+      fill: { field: null, constant: null, scaledConstant: null },
+      size: emptyStyle,
+      linewidth: emptyStyle,
+      alpha: emptyStyle,
+      shape: emptyStyle,
+      linetype: emptyStyle,
+      labelField: null,
+      weightField: null,
+    });
+    const n = 3;
+    const result = {
+      x: new Float64Array([0.5, 1.5, 2.5]),
+      count: new Float64Array([1, 2, 1]),
+      density: new Float64Array([0.1, 0.2, 0.1]),
+      ncount: new Float64Array([0.5, 1, 0.5]),
+      ndensity: new Float64Array([0.5, 1, 0.5]),
+      groups: [0, 0, 0],
+      xmin: new Float64Array([0, 1, 2]),
+      xmax: new Float64Array([1, 2, 3]),
+      carried: {},
+      cut: { fuzzy: [0, 1, 2, 3], rightClosed: true, binIndex: new Int32Array([0, 1, 2]) },
+    };
+    const inputGroups = [0, 0];
+    const frame = packBinLayerFrame(b, data, result, makeColumnOf(b), inputGroups);
+    expect(frame.n).toBe(n);
+    expect(frame.groups).toEqual(result.groups);
+    expect(frame.inputGroups).toEqual(inputGroups);
+    expect(frame.rowIndex.every((r) => r === NO_ROW)).toBe(true);
+    expect(Array.from(frame.yNumeric!)).toEqual([1, 2, 1]);
+    expect(frame.binCut).toEqual(result.cut);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `statLayerFrame` in `packages/core/src/pipeline/layer-frame.ts` — the single constructor for post-stat `LayerFrame` fields, `yStatColumn` default + `forwardMeasureOnce`, `NO_ROW` lineage, and style/extras spreads.
- Convert matching `frame-stats-*` adapters (and the bin/smooth pack helpers) to call it; leave function/map/manual/unique/sf on their own shapes with explicit `#1077` comments.
- Unit tests own the constructor contract; adapter smoke tests cover ecdf/density/bin packing; existing pipeline-m2 / after-stat / stats suites stay green.

Closes #1077.

## Test plan

- [x] `bun test packages/core/tests/pipeline/layer-frame.test.ts`
- [x] `bun test packages/core/tests/pipeline-m2 packages/core/tests/pipeline-after-stat-color*.test.ts packages/core/tests/stats`
- [x] `tsc -b packages/core`
- [ ] CI green on this PR
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1094" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->