### PR TITLE
refactor(svelte): one resolved target for nearest-hit lookups (#1080)

### DIFF
--- a/packages/svelte/src/lib/inspection/frame.ts
+++ b/packages/svelte/src/lib/inspection/frame.ts
@@ -8,6 +8,7 @@
 import type { CandidateFacts, CandidateMatch } from "@ggsvelte/core";
 
 import type { InteractionSource } from "../interaction/interaction.js";
+import type { InteractionCandidateRef } from "../interaction/reducer.js";
 
 /** Host inspection lifecycle state used across pure inspection tables. */
 export type InspectionHostState = "none" | "transient" | "pinned";
@@ -141,11 +142,5 @@ export function resolveQueuedInspectFrameAction(
   return { type: "apply-pending" };
 }
 
-/** Reducer inspect payload candidate (matches InteractionCandidateRef shape). */
-type InspectionCandidateRef = {
-  readonly epoch: number;
-  readonly id: number;
-  readonly panelId: string | null;
-  readonly x: number;
-  readonly y: number;
-};
+/** Reducer inspect payload candidate — same type as InteractionCandidateRef (#1080). */
+type InspectionCandidateRef = InteractionCandidateRef;

--- a/packages/svelte/src/lib/inspection/pointer-inspect.ts
+++ b/packages/svelte/src/lib/inspection/pointer-inspect.ts
@@ -18,6 +18,7 @@ import type { CandidateFacts, RenderModel } from "@ggsvelte/core";
 
 import type { InteractionAction, InteractionFrameToken } from "../interaction/reducer.js";
 import type { InteractionSource } from "../interaction/interaction.js";
+import { resolveTarget } from "../interaction/target.js";
 import {
   buildQueuedInspectFrame,
   resolveQueuedInspectFrameAction,
@@ -89,13 +90,18 @@ export function createPointerInspectQueue(deps: PointerInspectQueueDeps): Pointe
 
   function schedule(input: SchedulePointerInspectInput): void {
     const model = deps.model();
-    // Panel-scoped nearest so faceted hover cannot seed another facet (#787).
+    // Resolved target owns panel-scoped nearest + hover distance policy (#1080 / #787).
     // panelAtOrOnly keeps single-panel axis-margin hover working.
-    const match =
-      model?.viewport.panelAtOrOnly(input.point)?.nearest(input.point, {
-        mode: input.mode,
-        maxDistance: input.maxDistance,
-      }) ?? null;
+    const target =
+      model === null
+        ? null
+        : resolveTarget({
+            model,
+            point: input.point,
+            intent: "hover",
+            inspect: { mode: input.mode, maxDistance: input.maxDistance },
+          });
+    const match = target?.match ?? null;
     const frame = buildQueuedInspectFrame({
       match,
       source: input.source,

--- a/packages/svelte/src/lib/interaction/target.ts
+++ b/packages/svelte/src/lib/interaction/target.ts
@@ -1,0 +1,148 @@
+/**
+ * Resolved target ownership (#1080).
+ *
+ * One module owns panel-scoped nearest (#787), the per-intent distance policy,
+ * and the candidate match that hover / tap / point-select all need. Callers
+ * stop each carrying their own `panelAtOrOnly().nearest()` and maxDistance.
+ *
+ * Does not own hit geometry (core) or the inspect pin lifecycle. Semantic
+ * keys stay on the host (`candidateSemanticKeys`) — this module returns the
+ * match; projection to InteractionCandidateRef is a pure field map.
+ */
+
+import type {
+  CandidateInspectMode,
+  CandidateMatch,
+  RenderModel,
+  ResolvedCandidateInspectMode,
+} from "@ggsvelte/core";
+
+import { panelBoundsFrom, type PanelBounds } from "../scene/geometry.js";
+import type { PlotPoint } from "../surface/area-brush.js";
+import type { InteractionCandidateRef } from "./reducer.js";
+
+/**
+ * Why we are resolving. Selects the distance policy so callers stop each
+ * carrying their own maxDistance.
+ */
+export type TargetIntent = "hover" | "tap" | "point-select";
+
+/**
+ * Inspect fields that feed hover/tap distance policy.
+ * Host: resolved `interactionConfig.inspect` (mode + maxDistance), or the
+ * pure-table snapshot already taken for the gesture.
+ */
+export type TargetInspectPolicy = {
+  readonly mode: CandidateInspectMode;
+  readonly maxDistance: number;
+} | null;
+
+/**
+ * Nearest-candidate radius (plot px) for point-tool click.
+ * Deliberate constant — distinct from inspect.maxDistance (default also 24,
+ * but hover/tap read config; point-select does not).
+ */
+export const POINT_SELECT_NEAREST_MAX_DISTANCE_PX = 24;
+
+/** Resolved nearest-search params for one intent. */
+export type TargetSearch = {
+  readonly mode: CandidateInspectMode;
+  readonly maxDistance: number;
+};
+
+/**
+ * Intent → nearest search params.
+ *
+ * | intent       | mode              | maxDistance                          |
+ * |--------------|-------------------|--------------------------------------|
+ * | hover        | inspect.mode      | inspect.maxDistance                  |
+ * | tap          | inspect.mode      | inspect.maxDistance                  |
+ * | point-select | always `"xy"`     | `POINT_SELECT_NEAREST_MAX_DISTANCE_PX` |
+ *
+ * Returns null when hover/tap has no inspect snapshot (nothing to resolve).
+ */
+export function targetSearch(
+  intent: TargetIntent,
+  inspect: TargetInspectPolicy,
+): TargetSearch | null {
+  if (intent === "point-select") {
+    return {
+      mode: "xy",
+      maxDistance: POINT_SELECT_NEAREST_MAX_DISTANCE_PX,
+    };
+  }
+  if (inspect === null) return null;
+  return {
+    mode: inspect.mode,
+    maxDistance: inspect.maxDistance,
+  };
+}
+
+/**
+ * The one representation of "the thing under the pointer" at resolve time.
+ * `match` is the full CandidateMatch so setInspection / semantic-keys keep
+ * working without a second store lookup. Panel bounds come from the same
+ * viewport panel that scoped the nearest call.
+ */
+export type ResolvedTarget = {
+  readonly epoch: number;
+  readonly candidateId: number;
+  readonly panelId: string;
+  readonly point: PlotPoint;
+  readonly mode: ResolvedCandidateInspectMode;
+  readonly distance: number;
+  readonly match: CandidateMatch;
+  readonly panel: PanelBounds & { readonly id: string };
+};
+
+export type ResolveTargetInput = {
+  readonly model: RenderModel;
+  readonly point: PlotPoint;
+  readonly intent: TargetIntent;
+  /**
+   * Inspect policy for hover/tap. Ignored for point-select (uses the table).
+   * Pass the pure-table snapshot when the gesture already captured mode /
+   * maxDistance so callers do not re-read live config.
+   */
+  readonly inspect: TargetInspectPolicy;
+  /**
+   * Optional explicit search override. When set, skips `targetSearch` and
+   * uses these params — for callers that already snapshotted mode/maxDistance
+   * onto a pure action payload.
+   */
+  readonly search?: TargetSearch;
+};
+
+/**
+ * Panel-scoped nearest for one intent. Sole call site of
+ * `panelAtOrOnly().nearest()` for hover / tap / point-select.
+ */
+export function resolveTarget(input: ResolveTargetInput): ResolvedTarget | null {
+  const search = input.search ?? targetSearch(input.intent, input.inspect);
+  if (search === null) return null;
+  const panel = input.model.viewport.panelAtOrOnly(input.point);
+  if (panel === null) return null;
+  const match = panel.nearest(input.point, search);
+  if (match === null) return null;
+  return {
+    epoch: match.epoch,
+    candidateId: match.id,
+    panelId: match.panelId,
+    point: { x: match.x, y: match.y },
+    mode: match.mode,
+    distance: match.distance,
+    match,
+    panel: { id: panel.id, ...panelBoundsFrom(panel.bounds) },
+  };
+}
+
+/** Project ResolvedTarget into the reducer inspect payload shape. */
+export function toInteractionCandidateRef(target: ResolvedTarget): InteractionCandidateRef {
+  return {
+    epoch: target.epoch,
+    id: target.candidateId,
+    panelId: target.panelId,
+    x: target.point.x,
+    y: target.point.y,
+  };
+}

--- a/packages/svelte/src/lib/surface/pointer.ts
+++ b/packages/svelte/src/lib/surface/pointer.ts
@@ -224,9 +224,11 @@ export const TOUCH_INSPECT_CLICK_SUPPRESS_MS = 500;
 
 /**
  * Nearest-candidate radius (plot px) for capture-surface point-tool click.
- * Host `onCaptureClick` toggle-point nearest lookup uses this radius.
+ * Owned by `interaction/target` (#1080); re-exported here for existing
+ * surface-pointer unit tests and callers that import the constant from
+ * the pointer decision-table module.
  */
-export const POINT_SELECT_NEAREST_MAX_DISTANCE_PX = 24;
+export { POINT_SELECT_NEAREST_MAX_DISTANCE_PX } from "../interaction/target.js";
 
 /**
  * Sticky OR of touch-inspect drag past threshold in plotPoint coordinates.

--- a/packages/svelte/src/lib/surface/surface-state.svelte.ts
+++ b/packages/svelte/src/lib/surface/surface-state.svelte.ts
@@ -27,6 +27,7 @@ import type {
   ResolvedInteractionConfig,
 } from "../interaction/interaction.js";
 import { createInteractionReducer } from "../interaction/reducer.js";
+import { resolveTarget } from "../interaction/target.js";
 import { resolveChooseToolAction, resolveEffectiveTool } from "../interaction/capability.js";
 import {
   resolveSurfaceBlurAction,
@@ -47,7 +48,6 @@ import {
   advanceTouchInspectMoved,
   isAreaAwaitingSecond,
   isAreaBrushing,
-  POINT_SELECT_NEAREST_MAX_DISTANCE_PX,
   resolveCaptureClickAction,
   resolveLostPointerCaptureAction,
   resolvePointerDownAction,
@@ -458,13 +458,19 @@ export function createSurfaceState(deps: SurfaceStateDeps): SurfaceState {
         touchInspectStart = null;
         touchInspectMoved = false;
         // mode/maxDistance/state from pure inspect snapshot — no re-gate.
-        // Panel-scoped nearest so faceted taps cannot seed another facet (#787).
-        const match = deps.model()?.viewport.panelAtOrOnly(endPoint)?.nearest(endPoint, {
-          mode: action.mode,
-          maxDistance: action.maxDistance,
-        });
-        if (match !== null && match !== undefined) {
-          deps.inspection().setInspection(match, "touch", action.state, match.mode);
+        // Resolved target owns panel-scoped nearest + tap distance policy (#1080 / #787).
+        const model = deps.model();
+        const target =
+          model === null
+            ? null
+            : resolveTarget({
+                model,
+                point: endPoint,
+                intent: "tap",
+                inspect: { mode: action.mode, maxDistance: action.maxDistance },
+              });
+        if (target !== null) {
+          deps.inspection().setInspection(target.match, "touch", action.state, target.mode);
           suppressClickUntil = performance.now() + TOUCH_INSPECT_CLICK_SUPPRESS_MS;
         }
         break;
@@ -588,13 +594,19 @@ export function createSurfaceState(deps: SurfaceStateDeps): SurfaceState {
         break;
       case "toggle-point": {
         const point = plotPoint(event);
-        // Panel-scoped nearest so faceted point-select cannot toggle another facet (#787).
-        const match = deps.model()?.viewport.panelAtOrOnly(point)?.nearest(point, {
-          mode: "xy",
-          maxDistance: POINT_SELECT_NEAREST_MAX_DISTANCE_PX,
-        });
-        if (match === null || match === undefined) break;
-        deps.togglePointKeys(deps.candidateSemanticKeys(match), "pointer");
+        // Resolved target owns panel-scoped nearest + point-select radius (#1080 / #787).
+        const model = deps.model();
+        const target =
+          model === null
+            ? null
+            : resolveTarget({
+                model,
+                point,
+                intent: "point-select",
+                inspect: null,
+              });
+        if (target === null) break;
+        deps.togglePointKeys(deps.candidateSemanticKeys(target.match), "pointer");
         break;
       }
       case "toggle-pin":

--- a/packages/svelte/tests/interaction/target.test.ts
+++ b/packages/svelte/tests/interaction/target.test.ts
@@ -2,7 +2,7 @@
  * Resolved-target ownership (#1080): one nearest path, one distance policy,
  * panel-scoped so faceted probes cannot seed a neighbouring facet (#787).
  */
-import { describe, expect, it, expectTypeOf } from "vitest";
+import { describe, expect, it } from "vitest";
 import { runPipeline, type RenderModel } from "@ggsvelte/core";
 import { aes, gg } from "@ggsvelte/spec";
 
@@ -12,7 +12,6 @@ import {
   resolveTarget,
   targetSearch,
   toInteractionCandidateRef,
-  type ResolvedTarget,
   type TargetIntent,
 } from "../../src/lib/interaction/target.js";
 
@@ -84,9 +83,13 @@ describe("resolveTarget panel scoping (#787)", () => {
   for (const intent of intents) {
     it(`${intent}: never resolves a mark from a neighbouring facet`, () => {
       const model = facetedStackedModel();
-      const panelA = model.scene.panels[0]!;
-      const candB = model.candidates.candidate(1)!;
-      expect(candB.panelId).toBe(model.scene.panels[1]!.id);
+      const panelA = model.scene.panels[0];
+      const panelB = model.scene.panels[1];
+      const candB = model.candidates.candidate(1);
+      if (panelA === undefined || panelB === undefined || candB === null) {
+        throw new Error("expected two faceted panels and candidate B");
+      }
+      expect(candB.panelId).toBe(panelB.id);
 
       // Probe at panel A's mid-y and candidate B's screen-x — unscoped
       // mode "x" nearest would leak B; panel-scoped must refuse.
@@ -189,19 +192,19 @@ describe("toInteractionCandidateRef", () => {
   });
 
   it("is structurally assignable to InteractionCandidateRef (type test)", () => {
-    // Compile-time only: if ResolvedTarget projection drifts from the reducer
-    // payload shape, this fails tsc / vitest typecheck.
-    const sample: ResolvedTarget = {
-      epoch: 1,
-      candidateId: 2,
-      panelId: "p",
-      point: { x: 3, y: 4 },
-      mode: "xy",
-      distance: 0,
-      match: null as unknown as ResolvedTarget["match"],
-      panel: { id: "p", x: 0, y: 0, width: 1, height: 1 },
-    };
-    const ref = toInteractionCandidateRef(sample);
-    expectTypeOf(ref).toMatchTypeOf<InteractionCandidateRef>();
+    // Compile-time only: if the projection drifts from the reducer payload
+    // shape, assigning to InteractionCandidateRef fails typecheck.
+    const model = singlePanelDistanceModel();
+    const cand = model.candidates.candidate(0);
+    if (cand === null) throw new Error("expected candidate");
+    const target = resolveTarget({
+      model,
+      point: { x: cand.x, y: cand.y },
+      intent: "point-select",
+      inspect: null,
+    });
+    if (target === null) throw new Error("expected resolved target");
+    const ref: InteractionCandidateRef = toInteractionCandidateRef(target);
+    expect(ref.id).toBe(cand.id);
   });
 });

--- a/packages/svelte/tests/interaction/target.test.ts
+++ b/packages/svelte/tests/interaction/target.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Resolved-target ownership (#1080): one nearest path, one distance policy,
+ * panel-scoped so faceted probes cannot seed a neighbouring facet (#787).
+ */
+import { describe, expect, it, expectTypeOf } from "vitest";
+import { runPipeline, type RenderModel } from "@ggsvelte/core";
+import { aes, gg } from "@ggsvelte/spec";
+
+import type { InteractionCandidateRef } from "../../src/lib/interaction/reducer.js";
+import {
+  POINT_SELECT_NEAREST_MAX_DISTANCE_PX,
+  resolveTarget,
+  targetSearch,
+  toInteractionCandidateRef,
+  type ResolvedTarget,
+  type TargetIntent,
+} from "../../src/lib/interaction/target.js";
+
+/** Stacked two-facet plot with one mark per facet — same geometry as core #787. */
+function facetedStackedModel(): RenderModel {
+  return runPipeline(
+    gg(
+      [
+        { g: "A", x: 1, y: 5 },
+        { g: "B", x: 5, y: 5 },
+      ],
+      aes({ x: "x", y: "y" }),
+    )
+      .geomPoint()
+      .facet({ wrap: "g", ncol: 1 })
+      .scales({
+        x: { domain: [0, 10], nice: false, expand: { mult: 0, add: 0 } },
+        y: { domain: [0, 10], nice: false, expand: { mult: 0, add: 0 } },
+      })
+      .spec(),
+    { width: 200, height: 400 },
+  );
+}
+
+/** Single-panel points at known screen positions for distance-policy checks. */
+function singlePanelDistanceModel(): RenderModel {
+  return runPipeline(
+    gg(
+      [
+        { id: "near", x: 5, y: 5 },
+        { id: "far", x: 9, y: 5 },
+      ],
+      aes({ x: "x", y: "y" }),
+    )
+      .geomPoint()
+      .scales({
+        x: { domain: [0, 10], nice: false, expand: { mult: 0, add: 0 } },
+        y: { domain: [0, 10], nice: false, expand: { mult: 0, add: 0 } },
+      })
+      .spec(),
+    { width: 400, height: 300 },
+  );
+}
+
+describe("targetSearch distance policy table", () => {
+  it("maps point-select to xy + the documented 24px radius", () => {
+    expect(targetSearch("point-select", null)).toEqual({
+      mode: "xy",
+      maxDistance: POINT_SELECT_NEAREST_MAX_DISTANCE_PX,
+    });
+    expect(POINT_SELECT_NEAREST_MAX_DISTANCE_PX).toBe(24);
+  });
+
+  it("maps hover and tap to the inspect snapshot mode and maxDistance", () => {
+    const inspect = { mode: "x" as const, maxDistance: 16 };
+    expect(targetSearch("hover", inspect)).toEqual({ mode: "x", maxDistance: 16 });
+    expect(targetSearch("tap", inspect)).toEqual({ mode: "x", maxDistance: 16 });
+  });
+
+  it("returns null for hover/tap when inspect is absent", () => {
+    expect(targetSearch("hover", null)).toBeNull();
+    expect(targetSearch("tap", null)).toBeNull();
+  });
+});
+
+describe("resolveTarget panel scoping (#787)", () => {
+  const intents: TargetIntent[] = ["hover", "tap", "point-select"];
+
+  for (const intent of intents) {
+    it(`${intent}: never resolves a mark from a neighbouring facet`, () => {
+      const model = facetedStackedModel();
+      const panelA = model.scene.panels[0]!;
+      const candB = model.candidates.candidate(1)!;
+      expect(candB.panelId).toBe(model.scene.panels[1]!.id);
+
+      // Probe at panel A's mid-y and candidate B's screen-x — unscoped
+      // mode "x" nearest would leak B; panel-scoped must refuse.
+      const point = { x: candB.x, y: panelA.y + panelA.height / 2 };
+      const inspect = { mode: "x" as const, maxDistance: 24 };
+      const target = resolveTarget({ model, point, intent, inspect });
+      expect(target).toBeNull();
+    });
+  }
+
+  it("resolves the in-panel mark when the probe is inside its panel", () => {
+    const model = facetedStackedModel();
+    const candA = model.candidates.candidate(0)!;
+    const target = resolveTarget({
+      model,
+      point: { x: candA.x, y: candA.y },
+      intent: "hover",
+      inspect: { mode: "xy", maxDistance: 24 },
+    });
+    expect(target).not.toBeNull();
+    expect(target!.candidateId).toBe(candA.id);
+    expect(target!.panelId).toBe(candA.panelId);
+    expect(target!.panel.id).toBe(candA.panelId);
+  });
+});
+
+describe("resolveTarget distance policy outcomes", () => {
+  it("at the same pointer, hover@16px and point-select@24px differ when a mark sits at ~20px", () => {
+    const model = singlePanelDistanceModel();
+    const near = model.candidates.candidate(0)!;
+    // Place the probe left of "near" so distance is ~20 plot px.
+    const distancePx = 20;
+    const point = { x: near.x - distancePx, y: near.y };
+    // Sanity: nearest with 24 hits, with 16 does not (via store, unscoped ok here).
+    expect(model.candidates.nearest(point.x, point.y, { mode: "xy", maxDistance: 24 })?.id).toBe(
+      near.id,
+    );
+    expect(model.candidates.nearest(point.x, point.y, { mode: "xy", maxDistance: 16 })).toBeNull();
+    // Document that 20 plot px is within 24 and outside 16.
+    expect(distancePx).toBeLessThan(POINT_SELECT_NEAREST_MAX_DISTANCE_PX);
+    expect(distancePx).toBeGreaterThan(16);
+
+    expect(
+      resolveTarget({
+        model,
+        point,
+        intent: "point-select",
+        inspect: null,
+      })?.candidateId,
+    ).toBe(near.id);
+
+    expect(
+      resolveTarget({
+        model,
+        point,
+        intent: "hover",
+        inspect: { mode: "xy", maxDistance: 16 },
+      }),
+    ).toBeNull();
+
+    expect(
+      resolveTarget({
+        model,
+        point,
+        intent: "tap",
+        inspect: { mode: "xy", maxDistance: 16 },
+      }),
+    ).toBeNull();
+
+    expect(
+      resolveTarget({
+        model,
+        point,
+        intent: "hover",
+        inspect: { mode: "xy", maxDistance: 24 },
+      })?.candidateId,
+    ).toBe(near.id);
+  });
+});
+
+describe("toInteractionCandidateRef", () => {
+  it("projects ResolvedTarget into InteractionCandidateRef without drift", () => {
+    const model = singlePanelDistanceModel();
+    const cand = model.candidates.candidate(0)!;
+    const target = resolveTarget({
+      model,
+      point: { x: cand.x, y: cand.y },
+      intent: "point-select",
+      inspect: null,
+    });
+    expect(target).not.toBeNull();
+    const ref = toInteractionCandidateRef(target!);
+    expect(ref).toEqual({
+      epoch: cand.epoch,
+      id: cand.id,
+      panelId: cand.panelId,
+      x: cand.x,
+      y: cand.y,
+    });
+  });
+
+  it("is structurally assignable to InteractionCandidateRef (type test)", () => {
+    // Compile-time only: if ResolvedTarget projection drifts from the reducer
+    // payload shape, this fails tsc / vitest typecheck.
+    const sample: ResolvedTarget = {
+      epoch: 1,
+      candidateId: 2,
+      panelId: "p",
+      point: { x: 3, y: 4 },
+      mode: "xy",
+      distance: 0,
+      match: null as unknown as ResolvedTarget["match"],
+      panel: { id: "p", x: 0, y: 0, width: 1, height: 1 },
+    };
+    const ref = toInteractionCandidateRef(sample);
+    expectTypeOf(ref).toMatchTypeOf<InteractionCandidateRef>();
+  });
+});


### PR DESCRIPTION
## Summary

- Add `packages/svelte/src/lib/interaction/target.ts` with `resolveTarget`, `targetSearch`, and `toInteractionCandidateRef` so hover, touch tap, and point-select share one panel-scoped nearest path and one distance-policy table (#1080, #787).
- Wire `pointer-inspect` schedule, surface touch-inspect tap, and capture-click point-select through that module; re-export `POINT_SELECT_NEAREST_MAX_DISTANCE_PX` from `surface/pointer` for existing imports.
- Stop re-declaring the reducer candidate payload in `inspection/frame.ts` — import `InteractionCandidateRef` instead.
- TDD tests: per-intent facet isolation, distance-policy table, and structural projection to `InteractionCandidateRef`.

### Distance policy (deliberate differences, now one table)

| Intent | mode | maxDistance |
|--------|------|-------------|
| hover | inspect.mode | inspect.maxDistance |
| tap | inspect.mode | inspect.maxDistance |
| point-select | `"xy"` | 24px constant |

### Scope vs #1080

**In this PR (deletion test for the three nearest sites):**

- One call site of `panelAtOrOnly().nearest()` for hover / tap / point-select
- Distance policy table keyed by `TargetIntent`
- `InteractionCandidateRef` no longer re-declared in frame.ts

**Not in this PR (leave #1080 open or follow up):**

- #1079 scoped store (still open)
- Live `ResolvedTarget` owner that survives pin / legend filter / zoom
- Deleting the `plot-engine` inspection-focus adapter
- Collapsing all eight encodings into one shape
- Candidate-store full-scan consolidation in coordinator/interval/selection
- Keyboard traversal through the same module

Addresses #1080 (nearest ownership slice; remaining encoding work follows).

## Test plan

- [x] `bun run test:browser -- tests/interaction/target.test.ts` (chromium; all 10)
- [x] Related: pointer-click-touch, inspection-frame, interaction-point-selection, interaction-hover-tooltip, surface-state.input-lifecycle (chromium)
- [ ] CI green on the PR