### PR TITLE
refactor(svelte): one ScopedStore behind local-vs-controller forks

### DIFF
--- a/packages/svelte/src/lib/interaction/scoped-store.svelte.ts
+++ b/packages/svelte/src/lib/interaction/scoped-store.svelte.ts
@@ -75,7 +75,8 @@ export type CreateScopedStoreInput<T> = {
 export function createScopedStore<T>(input: CreateScopedStoreInput<T>): ScopedStore<T> {
   let local = $state.raw(input.initial);
   const same = input.same ?? ((a: T, b: T) => Object.is(a, b));
-  const empty = input.empty !== undefined ? input.empty : input.initial;
+  // `empty` may be null (zoom); hasOwn keeps null distinct from "not provided".
+  const empty = Object.hasOwn(input, "empty") ? (input.empty as T) : input.initial;
 
   const value: T = $derived.by(() => {
     const controller = input.controller();

--- a/packages/svelte/src/lib/interaction/scoped-store.svelte.ts
+++ b/packages/svelte/src/lib/interaction/scoped-store.svelte.ts
@@ -1,0 +1,184 @@
+/**
+ * Channel state that lives either in the shared interaction controller or
+ * locally in this plot. Callers never learn which. Subscribes to the
+ * controller revision internally (#1079).
+ */
+import type { PlotInteractionController } from "./controller.svelte.js";
+import type {
+  InteractionSource,
+  PlotInteractionInterval,
+  PlotInteractionScope,
+} from "./interaction.js";
+import { nextLocalIntervalRecords } from "../interval/consumption.js";
+
+/**
+ * Successful write result. Wrapped so a committed `null` (e.g. cleared zoom)
+ * is not confused with a no-op rejection.
+ */
+export type ScopedStoreWrite<T> = { readonly value: T };
+
+export interface ScopedStore<T> {
+  readonly value: T;
+  /**
+   * Replace the value. Returns `{ value }` on commit, or `null` when the write
+   * was a no-op (same local value, or controller rejected the transition).
+   */
+  set(next: T, source: InteractionSource): ScopedStoreWrite<T> | null;
+  /**
+   * Clear to the store's empty value. Returns `false` when already empty
+   * (or the controller rejected a no-op clear).
+   */
+  clear(source: InteractionSource): boolean;
+}
+
+export type CreateScopedStoreInput<T> = {
+  readonly initial: T;
+  readonly controller: () => PlotInteractionController<PropertyKey> | undefined;
+  readonly scope: () => PlotInteractionScope;
+  /** Read channel state from a live controller. */
+  readonly read: (
+    controller: PlotInteractionController<PropertyKey>,
+    scope: PlotInteractionScope,
+  ) => T;
+  /**
+   * Write channel state to a live controller. Return `{ value }` on commit, or
+   * `null` when the controller treated the write as a no-op.
+   */
+  readonly write: (
+    controller: PlotInteractionController<PropertyKey>,
+    next: T,
+    scope: PlotInteractionScope,
+    source: InteractionSource,
+  ) => ScopedStoreWrite<T> | null;
+  /**
+   * Clear channel state on a live controller. Return `false` when the clear
+   * was a no-op.
+   */
+  readonly clearShared: (
+    controller: PlotInteractionController<PropertyKey>,
+    scope: PlotInteractionScope,
+    source: InteractionSource,
+  ) => boolean;
+  /** Equality for local no-op detection. Defaults to `Object.is`. */
+  readonly same?: (a: T, b: T) => boolean;
+  /**
+   * Value after `clear` in local mode. Defaults to `initial`.
+   * (e.g. zoom uses `null`; key lists use `[]`.)
+   */
+  readonly empty?: T;
+};
+
+/**
+ * Create a scoped store. Construction registers a `$derived` that tracks the
+ * controller revision when shared mode is active.
+ */
+export function createScopedStore<T>(input: CreateScopedStoreInput<T>): ScopedStore<T> {
+  let local = $state.raw(input.initial);
+  const same = input.same ?? ((a: T, b: T) => Object.is(a, b));
+  const empty = input.empty !== undefined ? input.empty : input.initial;
+
+  const value: T = $derived.by(() => {
+    const controller = input.controller();
+    if (controller === undefined) return local;
+    // Subscribe to revision so external controller writes invalidate readers.
+    void controller.revision;
+    return input.read(controller, input.scope());
+  });
+
+  function set(next: T, source: InteractionSource): ScopedStoreWrite<T> | null {
+    const controller = input.controller();
+    if (controller === undefined) {
+      if (same(local, next)) return null;
+      local = next;
+      return { value: local };
+    }
+    return input.write(controller, next, input.scope(), source);
+  }
+
+  function clear(source: InteractionSource): boolean {
+    const controller = input.controller();
+    if (controller === undefined) {
+      if (same(local, empty)) return false;
+      local = empty;
+      return true;
+    }
+    return input.clearShared(controller, input.scope(), source);
+  }
+
+  return {
+    get value() {
+      return value;
+    },
+    set,
+    clear,
+  };
+}
+
+/**
+ * Interval channel store. The controller exposes upsert/remove/clear-all
+ * rather than whole-array replace, so this surface mirrors those ops while
+ * still hiding local vs shared storage.
+ */
+export interface IntervalScopedStore {
+  readonly value: readonly PlotInteractionInterval<PropertyKey>[];
+  upsert(record: PlotInteractionInterval<PropertyKey>, source: InteractionSource): void;
+  remove(panelId: string, source: InteractionSource): boolean;
+  clear(source: InteractionSource): boolean;
+}
+
+export type CreateIntervalScopedStoreInput = {
+  readonly controller: () => PlotInteractionController<PropertyKey> | undefined;
+  readonly scope: () => PlotInteractionScope;
+};
+
+export function createIntervalScopedStore(
+  input: CreateIntervalScopedStoreInput,
+): IntervalScopedStore {
+  let local = $state.raw<readonly PlotInteractionInterval<PropertyKey>[]>([]);
+
+  const value: readonly PlotInteractionInterval<PropertyKey>[] = $derived.by(() => {
+    const controller = input.controller();
+    if (controller === undefined) return local;
+    void controller.revision;
+    return controller.intervals(input.scope());
+  });
+
+  function upsert(record: PlotInteractionInterval<PropertyKey>, source: InteractionSource): void {
+    const controller = input.controller();
+    if (controller === undefined) {
+      local = [...nextLocalIntervalRecords(local, record)];
+      return;
+    }
+    controller.setInterval(record, { scope: input.scope(), source });
+  }
+
+  function remove(panelId: string, source: InteractionSource): boolean {
+    const controller = input.controller();
+    if (controller === undefined) {
+      const next = local.filter((interval) => interval.panelId !== panelId);
+      if (next.length === local.length) return false;
+      local = next;
+      return true;
+    }
+    return controller.clearInterval(panelId, { scope: input.scope(), source }) !== null;
+  }
+
+  function clear(source: InteractionSource): boolean {
+    const controller = input.controller();
+    if (controller === undefined) {
+      if (local.length === 0) return false;
+      local = [];
+      return true;
+    }
+    return controller.clearIntervals({ scope: input.scope(), source }) !== null;
+  }
+
+  return {
+    get value() {
+      return value;
+    },
+    upsert,
+    remove,
+    clear,
+  };
+}

--- a/packages/svelte/src/lib/interaction/scoped-store.svelte.ts
+++ b/packages/svelte/src/lib/interaction/scoped-store.svelte.ts
@@ -15,7 +15,7 @@ import { nextLocalIntervalRecords } from "../interval/consumption.js";
  * Successful write result. Wrapped so a committed `null` (e.g. cleared zoom)
  * is not confused with a no-op rejection.
  */
-export type ScopedStoreWrite<T> = { readonly value: T };
+type ScopedStoreWrite<T> = { readonly value: T };
 
 export interface ScopedStore<T> {
   readonly value: T;

--- a/packages/svelte/src/lib/interval/consumption.ts
+++ b/packages/svelte/src/lib/interval/consumption.ts
@@ -77,7 +77,7 @@ function prepareAxisContains(
  * Hot paths — cross-panel consumption, panel recompute, lineage counts —
  * must call this once per domains object, then test each candidate.
  */
-export function prepareCandidateInInterval(
+function prepareCandidateInInterval(
   domains: ReadonlyIntervalDomains,
 ): (candidate: Pick<IntervalConsumptionCandidate<PropertyKey>, "xValue" | "yValue">) => boolean {
   const xContains = domains.x === undefined ? undefined : prepareAxisContains(domains.x);

--- a/packages/svelte/src/lib/interval/interval-state.svelte.ts
+++ b/packages/svelte/src/lib/interval/interval-state.svelte.ts
@@ -1,11 +1,11 @@
 /**
  * Interval-selection + bounds-editor controller extracted from GGPlot for S5.
  *
- * Owns the five $state fields (committedInterval, committedIntervalRecord,
- * localCommittedIntervals, boundsEditor, boundsReturnFocus), construction-time
- * deriveds (effectiveIntervals, effectiveIntervalKeys, currentInterval* family,
- * boundsEditorInput), both effects (interval-reconcile + bounds-cancel), private
- * helpers, and the public clear/commit/bounds methods.
+ * Owns committedInterval / committedIntervalRecord / boundsEditor /
+ * boundsReturnFocus, the interval ScopedStore (local vs controller records),
+ * construction-time deriveds (effectiveIntervals, effectiveIntervalKeys,
+ * currentInterval* family, boundsEditorInput), both effects (interval-reconcile
+ * + bounds-cancel), private helpers, and the public clear/commit/bounds methods.
  *
  * Construction-time deriveds may legitimately read model / effectiveZoomDomains
  * (factory sits after the runtime). Armed later-declared / handler-only deps
@@ -38,6 +38,7 @@ import type {
   ResolvedInteractionConfig,
   SemanticIntervalAxis,
 } from "../interaction/interaction.js";
+import { createIntervalScopedStore } from "../interaction/scoped-store.svelte.js";
 import type { BoundsEditorInput, PreciseBoundsApplyEvent } from "./bounds-editor.js";
 import { frozenZoomDomains, type ContinuousZoomDomains } from "../scene/geometry.js";
 import {
@@ -47,10 +48,10 @@ import {
 } from "./interval.js";
 import {
   consumeIntervalKeys,
-  nextLocalIntervalRecords,
-  prepareCandidateInInterval,
+  recomputePanelIntervalProjection,
   sameIntervalRecord,
   type IntervalConsumptionCandidate,
+  type RecomputePanelIntervalProjectionInput,
 } from "./consumption.js";
 import { boundsEditorInputForScale, semanticAxisFromBounds } from "./precise-bounds.js";
 
@@ -164,7 +165,10 @@ export function createIntervalState(deps: IntervalStateDeps): IntervalState {
   // Semantic snapshot of the record backing `committedInterval`, so external
   // same-panel replacements are detected by content, not just presence.
   let committedIntervalRecord = $state<PlotInteractionInterval<PropertyKey> | null>(null);
-  let localCommittedIntervals = $state<PlotInteractionInterval<PropertyKey>[]>([]);
+  const committedIntervals = createIntervalScopedStore({
+    controller: deps.interaction,
+    scope: deps.resolvedInteractionScope,
+  });
   let boundsEditor = $state<{
     action: "select" | "zoom";
     axis: "x" | "y";
@@ -173,14 +177,7 @@ export function createIntervalState(deps: IntervalStateDeps): IntervalState {
   } | null>(null);
   let boundsReturnFocus = $state<HTMLElement | null>(null);
 
-  const effectiveIntervals = $derived.by(() => {
-    // Equivalent dependency to the host `controllerRevision` derived —
-    // read interaction revision directly (no extra dep).
-    void (deps.interaction()?.revision ?? 0);
-    return (
-      deps.interaction()?.intervals(deps.resolvedInteractionScope()) ?? localCommittedIntervals
-    );
-  });
+  const effectiveIntervals = $derived(committedIntervals.value);
 
   const effectiveIntervalKeys: readonly PropertyKey[] = $derived.by(() => {
     const model = deps.model();
@@ -325,14 +322,7 @@ export function createIntervalState(deps: IntervalStateDeps): IntervalState {
   function clearIntervalSelection(source: InteractionSource): void {
     const current = committedInterval;
     if (current === null && effectiveIntervals.length === 0) return;
-    if (deps.interaction() === undefined) {
-      localCommittedIntervals = [];
-    } else {
-      deps.interaction()!.clearIntervals({
-        scope: deps.resolvedInteractionScope(),
-        source,
-      });
-    }
+    committedIntervals.clear(source);
     const event = clearIntervalSelectionEvent(
       current ?? {
         mode: deps.selectConfig()?.mode ?? "xy",
@@ -349,16 +339,7 @@ export function createIntervalState(deps: IntervalStateDeps): IntervalState {
   function clearCurrentPanelInterval(source: InteractionSource): void {
     const intervalPanelId = committedInterval?.panelId ?? currentIntervalRecord?.panelId;
     if (intervalPanelId === null || intervalPanelId === undefined) return;
-    if (deps.interaction() === undefined) {
-      localCommittedIntervals = localCommittedIntervals.filter(
-        (interval) => interval.panelId !== intervalPanelId,
-      );
-    } else {
-      deps.interaction()!.clearInterval(intervalPanelId, {
-        scope: deps.resolvedInteractionScope(),
-        source,
-      });
-    }
+    committedIntervals.remove(intervalPanelId, source);
     const event = clearIntervalSelectionEvent(
       committedInterval ?? {
         mode: deps.selectConfig()?.mode ?? "xy",
@@ -397,8 +378,9 @@ export function createIntervalState(deps: IntervalStateDeps): IntervalState {
 
   /**
    * One full-store pass for precise-bounds apply: semantic keys + lineage row
-   * count for the target panel/domains. Was two walks (consumption bag then
-   * intervalLineageCount) with intermediate rowIndexesForCandidate arrays.
+   * count for the target panel/domains. Projects the live CandidateStore into
+   * the pure consumption port (always with sourceRows so lineageCount tracks
+   * unique rows — the live path never omits them).
    */
   function recomputePanelIntervalSelection(
     targetPanelId: string,
@@ -406,18 +388,29 @@ export function createIntervalState(deps: IntervalStateDeps): IntervalState {
   ): { readonly keys: readonly PropertyKey[]; readonly lineageCount: number } {
     const model = deps.model();
     if (model === null) return { keys: Object.freeze([]), lineageCount: 0 };
-    const inInterval = prepareCandidateInInterval(domains);
-    const keys = new Set<PropertyKey>();
-    const rows = new Set<number>();
+    type ProjectionCandidate =
+      RecomputePanelIntervalProjectionInput<PropertyKey>["candidates"][number];
+    const candidates: ProjectionCandidate[] = [];
     for (let id = 0; id < model.candidates.size; id++) {
       const candidate = model.candidates.candidate(id);
-      if (candidate === null || candidate.panelId !== targetPanelId || !inInterval(candidate))
-        continue;
-      for (const key of deps.candidateSemanticKeys(candidate)) keys.add(key);
-      for (const rowIndex of model.lineage.keys(candidate.lineage)) rows.add(rowIndex);
-      if (candidate.rowIndex !== null) rows.add(candidate.rowIndex);
+      if (candidate === null || candidate.panelId !== targetPanelId) continue;
+      const sourceRows = [
+        ...model.lineage.keys(candidate.lineage),
+        ...(candidate.rowIndex !== null ? [candidate.rowIndex] : []),
+      ];
+      candidates.push({
+        panelId: candidate.panelId,
+        xValue: candidate.xValue,
+        yValue: candidate.yValue,
+        keys: deps.candidateSemanticKeys(candidate),
+        sourceRows,
+      });
     }
-    return { keys: Object.freeze([...keys]), lineageCount: rows.size };
+    return recomputePanelIntervalProjection({
+      panelId: targetPanelId,
+      domains,
+      candidates,
+    });
   }
 
   /** Private — no remaining external consumer (codex P2-7). */
@@ -442,14 +435,7 @@ export function createIntervalState(deps: IntervalStateDeps): IntervalState {
       keys: Object.freeze([...event.keys]),
     });
     committedIntervalRecord = record;
-    if (deps.interaction() === undefined) {
-      localCommittedIntervals = [...nextLocalIntervalRecords(localCommittedIntervals, record)];
-    } else {
-      deps.interaction()!.setInterval(record, {
-        scope: deps.resolvedInteractionScope(),
-        source,
-      });
-    }
+    committedIntervals.upsert(record, source);
   }
 
   function finishBrushSelect(eventValue: IntervalSelection, source: InteractionSource): void {
@@ -534,14 +520,7 @@ export function createIntervalState(deps: IntervalStateDeps): IntervalState {
     const persistent = deps.selectConfig()?.persistent === true;
     if (persistent) {
       committedIntervalRecord = next;
-      if (deps.interaction() === undefined) {
-        localCommittedIntervals = [...nextLocalIntervalRecords(localCommittedIntervals, next)];
-      } else {
-        deps.interaction()!.setInterval(next, {
-          scope: deps.resolvedInteractionScope(),
-          source: event.inputSource,
-        });
-      }
+      committedIntervals.upsert(next, event.inputSource);
     }
     const viewportPanel = model.viewport.panel(targetPanelId);
     if (viewportPanel === null) return;

--- a/packages/svelte/src/lib/interval/interval-state.svelte.ts
+++ b/packages/svelte/src/lib/interval/interval-state.svelte.ts
@@ -396,7 +396,7 @@ export function createIntervalState(deps: IntervalStateDeps): IntervalState {
       if (candidate === null || candidate.panelId !== targetPanelId) continue;
       const sourceRows = [
         ...model.lineage.keys(candidate.lineage),
-        ...(candidate.rowIndex !== null ? [candidate.rowIndex] : []),
+        ...(candidate.rowIndex === null ? [] : [candidate.rowIndex]),
       ];
       candidates.push({
         panelId: candidate.panelId,

--- a/packages/svelte/src/lib/legend/focus-state.svelte.ts
+++ b/packages/svelte/src/lib/legend/focus-state.svelte.ts
@@ -16,6 +16,7 @@ import type {
   PlotInteractionEvent,
   PlotInteractionScope,
 } from "../interaction/interaction.js";
+import { createScopedStore } from "../interaction/scoped-store.svelte.js";
 import { legendFocusAnnouncement } from "../assembly/labels.js";
 import {
   buildInteractiveLegendEntries,
@@ -115,7 +116,24 @@ export type LegendFocusState = {
  * declares entry/pressed deriveds that this factory's compute* methods feed.
  */
 export function createLegendFocusState(deps: LegendFocusStateDeps): LegendFocusState {
-  let localEmphasisKeys = $state<PropertyKey[]>([]);
+  const emphasisKeys = createScopedStore<readonly PropertyKey[]>({
+    initial: [],
+    controller: deps.interaction,
+    scope: deps.resolvedInteractionScope,
+    read: (controller, scope) => controller.emphasized(scope),
+    write: (controller, next, scope, source) => {
+      const transition = controller.setEmphasis(next, { scope, source });
+      if (transition === null) return null;
+      return {
+        value:
+          transition.snapshot.emphases.find((emphasis) => emphasis.scope === scope.keys)?.keys ??
+          [],
+      };
+    },
+    clearShared: (controller, scope, source) =>
+      controller.clearEmphasis({ scope, source }) !== null,
+    same: samePropertyKeySet,
+  });
   let legendPreview = $state<{
     action: LegendEntryAction;
     keys: readonly PropertyKey[];
@@ -131,17 +149,13 @@ export function createLegendFocusState(deps: LegendFocusStateDeps): LegendFocusS
   let suppressLegendFocusPreview = false;
 
   const effectiveEmphasisKeys: readonly PropertyKey[] = $derived.by(() => {
-    // Equivalent dependency to the host `controllerRevision` derived —
-    // read interaction revision directly (no extra dep).
-    void (deps.interaction()?.revision ?? 0);
+    const baseKeys = emphasisKeys.value;
     return resolveLegendEmphasisKeys({
       legendFocusEnabled: deps.legendFocusEnabled(),
       previewKeys: legendPreview?.keys ?? null,
-      controllerKeys:
-        deps.interaction() === undefined
-          ? null
-          : deps.interaction()!.emphasized(deps.resolvedInteractionScope()),
-      localKeys: localEmphasisKeys,
+      // Shared: baseKeys are controller-backed. Local: baseKeys fill localKeys.
+      controllerKeys: deps.interaction() !== undefined ? baseKeys : null,
+      localKeys: baseKeys,
     });
   });
 
@@ -158,9 +172,7 @@ export function createLegendFocusState(deps: LegendFocusStateDeps): LegendFocusS
       // Pure table maps preview source → InteractionSource on non-none actions.
       const dismiss = resolveLegendPreviewDismissAction({
         previewSource: legendPreview?.action.source ?? null,
-        committedEmphasisEmpty:
-          (deps.interaction()?.emphasized(deps.resolvedInteractionScope()) ?? localEmphasisKeys)
-            .length === 0,
+        committedEmphasisEmpty: emphasisKeys.value.length === 0,
       });
       if (dismiss.type === "none") return;
       legendPreview = null;
@@ -202,12 +214,7 @@ export function createLegendFocusState(deps: LegendFocusStateDeps): LegendFocusS
     });
     legendPreview = null;
     legendCommitted = null;
-    if (deps.interaction() === undefined) localEmphasisKeys = [];
-    else
-      deps.interaction()!.clearEmphasis({
-        scope: deps.resolvedInteractionScope(),
-        source,
-      });
+    emphasisKeys.clear(source);
     if (emitClear) emitLegendFocus({ type: "legend-focus", phase: "clear", source });
   }
 
@@ -235,8 +242,7 @@ export function createLegendFocusState(deps: LegendFocusStateDeps): LegendFocusS
   }
 
   function computeLegendPressed(model: RenderModel | null): LegendEntryIdentity | null {
-    const keys =
-      deps.interaction()?.emphasized(deps.resolvedInteractionScope()) ?? localEmphasisKeys;
+    const keys = emphasisKeys.value;
     if (keys.length === 0 || model === null) return null;
     // Match against all discrete scene legends (not only interactive targets).
     return findLegendPressedIdentity({
@@ -267,12 +273,7 @@ export function createLegendFocusState(deps: LegendFocusStateDeps): LegendFocusS
       case "commit":
         legendPreview = null;
         legendCommitted = { identity: action.identity, keys };
-        if (deps.interaction() === undefined) localEmphasisKeys = [...keys];
-        else
-          deps.interaction()!.setEmphasis(keys, {
-            scope: deps.resolvedInteractionScope(),
-            source: commit.source,
-          });
+        emphasisKeys.set([...keys], commit.source);
         emitLegendFocus({
           type: "legend-focus",
           phase: "change",
@@ -440,12 +441,14 @@ export function createLegendFocusState(deps: LegendFocusStateDeps): LegendFocusS
     });
 
     $effect(() => {
+      const usesLocalEmphasis = deps.interaction() === undefined;
       const plan = planLegendCommittedReconcile({
         committed: legendCommitted,
         entries: deps.entries(),
         keyIndex: deps.entryKeys().legendEntryKeyIndex,
-        usesLocalEmphasis: deps.interaction() === undefined,
-        localEmphasisCount: localEmphasisKeys.length,
+        usesLocalEmphasis,
+        // Only consulted when usesLocalEmphasis; store value is the local shadow.
+        localEmphasisCount: usesLocalEmphasis ? emphasisKeys.value.length : 0,
       });
       switch (plan.type) {
         case "noop":
@@ -455,7 +458,7 @@ export function createLegendFocusState(deps: LegendFocusStateDeps): LegendFocusS
           break;
         case "clear-committed-local-emit":
           legendCommitted = null;
-          localEmphasisKeys = [];
+          emphasisKeys.clear("programmatic");
           emitLegendFocus({
             type: "legend-focus",
             phase: "clear",
@@ -486,13 +489,15 @@ export function createLegendFocusState(deps: LegendFocusStateDeps): LegendFocusS
     });
 
     // Drop chart-local emphasis when legend focus is turned off at runtime.
+    // Shared controller emphasis is intentionally retained (clear-host only).
     $effect(() => {
+      const usesLocalEmphasis = deps.interaction() === undefined;
       const plan = planLegendFocusDisabledClear({
         legendFocusEnabled: deps.legendFocusEnabled(),
         hasPreview: legendPreview !== null,
         hasCommitted: legendCommitted !== null,
-        hasLocalEmphasis: localEmphasisKeys.length > 0,
-        usesLocalEmphasis: deps.interaction() === undefined,
+        hasLocalEmphasis: usesLocalEmphasis && emphasisKeys.value.length > 0,
+        usesLocalEmphasis,
       });
       switch (plan.type) {
         case "noop":
@@ -504,7 +509,7 @@ export function createLegendFocusState(deps: LegendFocusStateDeps): LegendFocusS
         case "clear-host-local":
           legendPreview = null;
           legendCommitted = null;
-          localEmphasisKeys = [];
+          emphasisKeys.clear("programmatic");
           break;
       }
     });

--- a/packages/svelte/src/lib/legend/focus-state.svelte.ts
+++ b/packages/svelte/src/lib/legend/focus-state.svelte.ts
@@ -154,7 +154,7 @@ export function createLegendFocusState(deps: LegendFocusStateDeps): LegendFocusS
       legendFocusEnabled: deps.legendFocusEnabled(),
       previewKeys: legendPreview?.keys ?? null,
       // Shared: baseKeys are controller-backed. Local: baseKeys fill localKeys.
-      controllerKeys: deps.interaction() !== undefined ? baseKeys : null,
+      controllerKeys: deps.interaction() === undefined ? null : baseKeys,
       localKeys: baseKeys,
     });
   });

--- a/packages/svelte/src/lib/selection/selection-state.svelte.ts
+++ b/packages/svelte/src/lib/selection/selection-state.svelte.ts
@@ -18,6 +18,7 @@ import type {
   PlotSelection,
   ResolvedInteractionConfig,
 } from "../interaction/interaction.js";
+import { createScopedStore } from "../interaction/scoped-store.svelte.js";
 import { selectionAnnouncement } from "../assembly/labels.js";
 import {
   buildPointSelectionEvent,
@@ -59,40 +60,35 @@ export type SelectionState = {
  * `effectiveSelectedKeys` derived over interaction and scope.
  */
 export function createSelectionState(deps: SelectionStateDeps): SelectionState {
-  let localSelectedKeys = $state<PropertyKey[]>([]);
-
-  const effectiveSelectedKeys: readonly PropertyKey[] = $derived.by(() => {
-    // Equivalent dependency to the former host `controllerRevision` derived —
-    // read interaction revision directly (S3–S5 pattern).
-    void (deps.interaction()?.revision ?? 0);
-    return deps.interaction()?.selected(deps.resolvedInteractionScope()) ?? localSelectedKeys;
+  const selectedKeys = createScopedStore<readonly PropertyKey[]>({
+    initial: [],
+    controller: deps.interaction,
+    scope: deps.resolvedInteractionScope,
+    read: (controller, scope) => controller.selected(scope),
+    write: (controller, next, scope, source) => {
+      const transition = controller.setSelection(next, { scope, source });
+      if (transition === null) return null;
+      return {
+        value:
+          transition.snapshot.selections.find((selection) => selection.scope === scope.keys)
+            ?.keys ?? [],
+      };
+    },
+    clearShared: (controller, scope, source) =>
+      controller.clearSelection({ scope, source }) !== null,
+    same: sameOrderedPropertyKeys,
   });
 
   /** Private — only clear/toggle call this; no external caller (P2-7). */
   function commitPointSelection(keys: readonly PropertyKey[], source: InteractionSource): void {
-    let committed: readonly PropertyKey[];
-    const interaction = deps.interaction();
-    if (interaction === undefined) {
-      const next = [...new Set(keys)];
-      if (sameOrderedPropertyKeys(next, localSelectedKeys)) return;
-      localSelectedKeys = next;
-      committed = localSelectedKeys;
-    } else {
-      const transition = interaction.setSelection(keys, {
-        scope: deps.resolvedInteractionScope(),
-        source,
-      });
-      if (transition === null) return;
-      committed =
-        transition.snapshot.selections.find(
-          (selection) => selection.scope === deps.resolvedInteractionScope().keys,
-        )?.keys ?? [];
-    }
-    emitSelection(buildPointSelectionEvent(committed, source));
+    // Dedup for local storage; controller canonicalizes independently.
+    const committed = selectedKeys.set([...new Set(keys)], source);
+    if (committed === null) return;
+    emitSelection(buildPointSelectionEvent(committed.value, source));
   }
 
   function clearPointSelection(source: InteractionSource): void {
-    if (effectiveSelectedKeys.length === 0) return;
+    if (selectedKeys.value.length === 0) return;
     commitPointSelection([], source);
   }
 
@@ -106,7 +102,7 @@ export function createSelectionState(deps: SelectionStateDeps): SelectionState {
   function togglePointKeys(keys: readonly PropertyKey[], source: InteractionSource): void {
     if (keys.length === 0) return;
     const next = nextPointSelectionKeys(
-      effectiveSelectedKeys,
+      selectedKeys.value,
       keys,
       deps.selectConfig()?.multiple ?? false,
     );
@@ -115,7 +111,7 @@ export function createSelectionState(deps: SelectionStateDeps): SelectionState {
 
   return {
     get effectiveSelectedKeys() {
-      return effectiveSelectedKeys;
+      return selectedKeys.value;
     },
     clearPointSelection,
     togglePointKeys,

--- a/packages/svelte/src/lib/zoom/zoom-state.svelte.ts
+++ b/packages/svelte/src/lib/zoom/zoom-state.svelte.ts
@@ -17,6 +17,7 @@ import type {
   ResolvedInteractionConfig,
   ZoomEvent,
 } from "../interaction/interaction.js";
+import { createScopedStore } from "../interaction/scoped-store.svelte.js";
 import { frozenZoomDomains, type ContinuousZoomDomains } from "../scene/geometry.js";
 import { zoomAnnouncement } from "../assembly/labels.js";
 import {
@@ -84,26 +85,46 @@ export type PlotZoomState = {
  * deferred getters (`model`, `announce`).
  */
 export function createPlotZoomState(deps: PlotZoomStateDeps): PlotZoomState {
-  let localZoomDomains = $state<ContinuousZoomDomains | null>(null);
   // Memoize prior bag so selection/emphasis revisions do not retrain zoom.
   let previousEffectiveZoomDomains: ContinuousZoomDomains | null = null;
 
-  const effectiveZoomDomains: ContinuousZoomDomains | null = $derived.by(() => {
-    // Equivalent dependency to the host `controllerRevision` derived —
-    // read interaction revision directly (no extra dep).
-    void (deps.interaction()?.revision ?? 0);
-    let next: ContinuousZoomDomains | null;
-    if (deps.interaction() === undefined) {
-      next = localZoomDomains;
-    } else {
+  const zoomDomains = createScopedStore<ContinuousZoomDomains | null>({
+    initial: null,
+    empty: null,
+    controller: deps.interaction,
+    scope: deps.resolvedInteractionScope,
+    read: (controller, scope) =>
       // Gate shared domains by this plot's resolved zoom mode (null when
       // disabled / faceted-unsupported) so x-only plots ignore y domains.
-      next = filterZoomDomainsByMode(
-        deps.interaction()!.zoom(deps.resolvedInteractionScope()),
-        deps.zoomConfig()?.mode ?? null,
-      );
-    }
-    next = stableZoomDomains(previousEffectiveZoomDomains, next);
+      filterZoomDomainsByMode(controller.zoom(scope), deps.zoomConfig()?.mode ?? null),
+    write: (controller, next, scope, source) => {
+      // Match filterZoomDomainsByMode: x-only plots must not mutate shared y.
+      const mutationScope = filterScopeChannelsByZoomMode(scope, deps.zoomConfig()?.mode ?? null);
+      if (next === null) {
+        const transition = controller.resetZoom({ scope: mutationScope, source });
+        return transition === null ? null : { value: null };
+      }
+      const transition = controller.setZoom(next, { scope: mutationScope, source });
+      if (transition === null) return null;
+      return {
+        value: frozenZoomDomains(
+          continuousZoomDomainsFromScopes(
+            transition.snapshot.zoom,
+            mutationScope.x,
+            mutationScope.y,
+          ),
+        ),
+      };
+    },
+    clearShared: (controller, scope, source) =>
+      controller.resetZoom({
+        scope: filterScopeChannelsByZoomMode(scope, deps.zoomConfig()?.mode ?? null),
+        source,
+      }) !== null,
+  });
+
+  const effectiveZoomDomains: ContinuousZoomDomains | null = $derived.by(() => {
+    const next = stableZoomDomains(previousEffectiveZoomDomains, zoomDomains.value);
     previousEffectiveZoomDomains = next;
     return next;
   });
@@ -116,36 +137,10 @@ export function createPlotZoomState(deps: PlotZoomStateDeps): PlotZoomState {
   const effectiveSpec: PortableSpec | null = $derived.by(resolveEffectiveSpec);
 
   function commitZoom(domains: ContinuousZoomDomains | null, source: InteractionSource): void {
-    let committed: ContinuousZoomDomains | null = domains;
-    if (deps.interaction() === undefined) {
-      if (domains === null && localZoomDomains === null) return;
-      localZoomDomains = domains;
-    } else {
-      // Match filterZoomDomainsByMode: x-only plots must not mutate shared y.
-      const mutationScope = filterScopeChannelsByZoomMode(
-        deps.resolvedInteractionScope(),
-        deps.zoomConfig()?.mode ?? null,
-      );
-      const transition =
-        domains === null
-          ? deps.interaction()!.resetZoom({ scope: mutationScope, source })
-          : deps.interaction()!.setZoom(domains, {
-              scope: mutationScope,
-              source,
-            });
-      if (transition === null) return;
-      if (domains !== null) {
-        committed = frozenZoomDomains(
-          continuousZoomDomainsFromScopes(
-            transition.snapshot.zoom,
-            mutationScope.x,
-            mutationScope.y,
-          ),
-        );
-      }
-    }
-    const event = buildZoomEvent(committed, source);
-    deps.announce(zoomAnnouncement(committed));
+    const committed = zoomDomains.set(domains, source);
+    if (committed === null) return;
+    const event = buildZoomEvent(committed.value, source);
+    deps.announce(zoomAnnouncement(committed.value));
     deps.onzoom()?.(event);
     deps.oninteraction()?.(event);
   }
@@ -193,14 +188,9 @@ export function createPlotZoomState(deps: PlotZoomStateDeps): PlotZoomState {
   }
 
   function resetForScales(): void {
-    if (deps.interaction() === undefined) localZoomDomains = null;
-    else
-      deps.interaction()!.resetZoom({
-        scope: filterScopeChannelsByZoomMode(
-          deps.resolvedInteractionScope(),
-          deps.zoomConfig()?.mode ?? null,
-        ),
-      });
+    // Silent path: no event / announcement. Prefer clear() so local and shared
+    // storage stay interchangeable without an interaction fork at the call site.
+    zoomDomains.clear("programmatic");
   }
 
   return {

--- a/packages/svelte/tests/interaction/scoped-store.test.ts
+++ b/packages/svelte/tests/interaction/scoped-store.test.ts
@@ -28,9 +28,15 @@ const defaultScope: PlotInteractionScope = {
 
 type KeyStore = ScopedStore<readonly PropertyKey[]>;
 
+type MaybeController = ReturnType<typeof createPlotInteraction> | undefined;
+/** Chart-local mode: no shared interaction controller. */
+const noController = (): MaybeController => {
+  /* intentionally empty — returns undefined */
+};
+
 function mountKeyStore(
   options: {
-    controller?: () => ReturnType<typeof createPlotInteraction> | undefined;
+    controller?: () => MaybeController;
     scope?: () => PlotInteractionScope;
     initial?: readonly PropertyKey[];
   } = {},
@@ -38,7 +44,7 @@ function mountKeyStore(
   const { value: store, destroy } = withFlushedEffectRoot(() =>
     createScopedStore<readonly PropertyKey[]>({
       initial: options.initial ?? [],
-      controller: options.controller ?? (() => undefined),
+      controller: options.controller ?? noController,
       scope: options.scope ?? (() => defaultScope),
       read: (controller, scope) => controller.selected(scope),
       write: (controller, next, scope, source) => {
@@ -116,9 +122,7 @@ describe("createScopedStore controller mode", () => {
 
 describe("createScopedStore mid-life controller arrival", () => {
   it("switches from local to controller-backed reads when controller appears", () => {
-    const controllerBox = reactiveBox<ReturnType<typeof createPlotInteraction> | undefined>(
-      undefined,
-    );
+    const controllerBox = reactiveBox<MaybeController>(noController());
     const { store, destroy } = mountKeyStore({
       controller: () => controllerBox.value,
     });
@@ -166,7 +170,7 @@ describe("createIntervalScopedStore", () => {
   it("upserts, removes, and clears in local mode", () => {
     const { value: store, destroy } = withFlushedEffectRoot(() =>
       createIntervalScopedStore({
-        controller: () => undefined,
+        controller: noController,
         scope: () => defaultScope,
       }),
     );

--- a/packages/svelte/tests/interaction/scoped-store.test.ts
+++ b/packages/svelte/tests/interaction/scoped-store.test.ts
@@ -1,0 +1,210 @@
+/**
+ * createScopedStore — local vs controller-backed channel storage (#1079).
+ * Factories own deriveds — instantiate under `$effect.root` and destroy.
+ */
+import { flushSync } from "svelte";
+import { describe, expect, it } from "vitest";
+
+import { createPlotInteraction } from "../../src/lib/interaction/controller.svelte.js";
+import type {
+  InteractionSource,
+  PlotInteractionScope,
+} from "../../src/lib/interaction/interaction.js";
+import {
+  createIntervalScopedStore,
+  createScopedStore,
+  type ScopedStore,
+} from "../../src/lib/interaction/scoped-store.svelte.js";
+import type { PlotInteractionInterval } from "../../src/lib/interaction/interaction.js";
+import { withFlushedEffectRoot } from "../helpers/effect-root.svelte.js";
+import { reactiveBox } from "../helpers/reactive-box.svelte.js";
+
+const defaultScope: PlotInteractionScope = {
+  keys: "plot",
+  x: "x",
+  y: "y",
+  intervals: "plot",
+};
+
+type KeyStore = ScopedStore<readonly PropertyKey[]>;
+
+function mountKeyStore(
+  options: {
+    controller?: () => ReturnType<typeof createPlotInteraction> | undefined;
+    scope?: () => PlotInteractionScope;
+    initial?: readonly PropertyKey[];
+  } = {},
+): { store: KeyStore; destroy: () => void } {
+  const { value: store, destroy } = withFlushedEffectRoot(() =>
+    createScopedStore<readonly PropertyKey[]>({
+      initial: options.initial ?? [],
+      controller: options.controller ?? (() => undefined),
+      scope: options.scope ?? (() => defaultScope),
+      read: (controller, scope) => controller.selected(scope),
+      write: (controller, next, scope, source) => {
+        const transition = controller.setSelection(next, { scope, source });
+        if (transition === null) return null;
+        return {
+          value:
+            transition.snapshot.selections.find((selection) => selection.scope === scope.keys)
+              ?.keys ?? [],
+        };
+      },
+      clearShared: (controller, scope, source) =>
+        controller.clearSelection({ scope, source }) !== null,
+      same: (a, b) => a.length === b.length && a.every((key, i) => key === b[i]),
+    }),
+  );
+  return { store, destroy };
+}
+
+describe("createScopedStore local mode", () => {
+  it("starts at initial and set/clear mutate local value with source ignored for storage", () => {
+    const sources: InteractionSource[] = [];
+    const { store, destroy } = mountKeyStore();
+    expect(store.value).toEqual([]);
+
+    const committed = store.set(["a", "b"], "keyboard");
+    expect(committed).toEqual({ value: ["a", "b"] });
+    expect(store.value).toEqual(["a", "b"]);
+    sources.push("keyboard");
+
+    expect(store.set(["a", "b"], "pointer")).toBeNull();
+    expect(store.value).toEqual(["a", "b"]);
+
+    expect(store.clear("touch")).toBe(true);
+    expect(store.value).toEqual([]);
+    expect(store.clear("programmatic")).toBe(false);
+
+    // Source is a required argument on the public surface (call sites above).
+    expect(sources).toEqual(["keyboard"]);
+    destroy();
+  });
+});
+
+describe("createScopedStore controller mode", () => {
+  it("reads and writes through the shared controller", () => {
+    const controller = createPlotInteraction();
+    const { store, destroy } = mountKeyStore({
+      controller: () => controller,
+    });
+
+    expect(store.value).toEqual([]);
+    const committed = store.set(["x", "y"], "pointer");
+    expect(committed).toEqual({ value: ["x", "y"] });
+    expect(store.value).toEqual(["x", "y"]);
+    expect(controller.selected(defaultScope)).toEqual(["x", "y"]);
+
+    expect(store.clear("keyboard")).toBe(true);
+    expect(store.value).toEqual([]);
+    expect(controller.selected(defaultScope)).toEqual([]);
+    destroy();
+  });
+
+  it("returns null when the controller rejects a no-op set", () => {
+    const controller = createPlotInteraction();
+    controller.setSelection(["a"], { scope: defaultScope, source: "programmatic" });
+    const { store, destroy } = mountKeyStore({
+      controller: () => controller,
+    });
+
+    expect(store.set(["a"], "pointer")).toBeNull();
+    expect(store.value).toEqual(["a"]);
+    destroy();
+  });
+});
+
+describe("createScopedStore mid-life controller arrival", () => {
+  it("switches from local to controller-backed reads when controller appears", () => {
+    const controllerBox = reactiveBox<ReturnType<typeof createPlotInteraction> | undefined>(
+      undefined,
+    );
+    const { store, destroy } = mountKeyStore({
+      controller: () => controllerBox.value,
+    });
+
+    store.set(["local"], "programmatic");
+    expect(store.value).toEqual(["local"]);
+
+    const controller = createPlotInteraction();
+    controller.setSelection(["shared"], { scope: defaultScope, source: "programmatic" });
+    controllerBox.set(controller);
+    flushSync();
+
+    // Shared mode prefers controller state over the prior local shadow.
+    expect(store.value).toEqual(["shared"]);
+    destroy();
+  });
+});
+
+describe("createScopedStore revision subscription", () => {
+  it("invalidates value when the controller mutates outside the store", () => {
+    const controller = createPlotInteraction();
+    const { store, destroy } = mountKeyStore({
+      controller: () => controller,
+    });
+
+    expect(store.value).toEqual([]);
+    controller.setSelection(["external"], { scope: defaultScope, source: "programmatic" });
+    flushSync();
+    expect(store.value).toEqual(["external"]);
+    destroy();
+  });
+});
+
+const sampleInterval = (panelId: string): PlotInteractionInterval<PropertyKey> =>
+  Object.freeze({
+    panelId,
+    preset: "independent" as const,
+    domains: Object.freeze({
+      x: Object.freeze({ kind: "linear" as const, domain: [0, 1] as const }),
+    }),
+    keys: Object.freeze(["k"] as PropertyKey[]),
+  });
+
+describe("createIntervalScopedStore", () => {
+  it("upserts, removes, and clears in local mode", () => {
+    const { value: store, destroy } = withFlushedEffectRoot(() =>
+      createIntervalScopedStore({
+        controller: () => undefined,
+        scope: () => defaultScope,
+      }),
+    );
+
+    expect(store.value).toEqual([]);
+    store.upsert(sampleInterval("p1"), "pointer");
+    store.upsert(sampleInterval("p2"), "keyboard");
+    expect(store.value.map((record) => record.panelId)).toEqual(["p1", "p2"]);
+
+    expect(store.remove("p1", "touch")).toBe(true);
+    expect(store.value.map((record) => record.panelId)).toEqual(["p2"]);
+    expect(store.remove("missing", "programmatic")).toBe(false);
+
+    expect(store.clear("pointer")).toBe(true);
+    expect(store.value).toEqual([]);
+    expect(store.clear("pointer")).toBe(false);
+    destroy();
+  });
+
+  it("mirrors controller interval ops and source propagation", () => {
+    const controller = createPlotInteraction();
+    const sources: string[] = [];
+    const { value: store, destroy } = withFlushedEffectRoot(() =>
+      createIntervalScopedStore({
+        controller: () => controller,
+        scope: () => defaultScope,
+      }),
+    );
+
+    store.upsert(sampleInterval("panel-a"), "keyboard");
+    sources.push("keyboard");
+    expect(store.value).toHaveLength(1);
+    expect(controller.intervals(defaultScope)).toHaveLength(1);
+
+    store.remove("panel-a", "touch");
+    sources.push("touch");
+    expect(store.value).toEqual([]);
+    expect(sources).toEqual(["keyboard", "touch"]);
+    destroy();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1079. Interaction channels no longer each re-implement local vs shared storage.

- **`createScopedStore`**: value-replace channels (selection keys, zoom domains, emphasis keys). Owns the controller `revision` subscription and the local/shared write fork. `set` returns `{ value } | null` so a committed `null` (cleared zoom) is not a no-op.
- **`createIntervalScopedStore`**: upsert / remove / clear-all, matching the controller's interval ops rather than whole-array replace.
- **Converted**: selection, zoom, legend focus emphasis, interval committed records.
- **Not converted**: legend filter remains chart-local only (no controller adapter).
- **Fossil fix**: live precise-bounds recompute projects the CandidateStore into `recomputePanelIntervalProjection` with `sourceRows` always filled, so one algorithm owns keys + `lineageCount`.

## Tests (TDD)

- `tests/interaction/scoped-store.test.ts` — local mode, controller mode, mid-life controller arrival, external revision invalidation, interval upsert/remove/clear, source arguments.
- Existing selection / zoom / interval / focus-state suites stay green (243 tests across those paths).

## Out of scope

- Interaction controller public API (#1079).
- surface / inspection (no `local*` shadow).
- filter-state (local-only; no shared fork).
- Harness line-count reduction (optional follow-up; stores make simpler harnesses possible).

## Test plan

- [x] `cd packages/svelte && bun run test:browser -- tests/interaction/scoped-store.test.ts tests/selection/selection-state.test.ts tests/zoom/ tests/interval/interval-state tests/legend/focus-state`
- [x] `svelte-autofixer` clean on `scoped-store.svelte.ts`
- [ ] CI green
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1096" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->