### PR TITLE
fix(theme): flat tooltip chrome for gridless themes (#1069)

### DIFF
--- a/.changeset/1069-theme-aware-tooltip-chrome.md
+++ b/.changeset/1069-theme-aware-tooltip-chrome.md
@@ -1,0 +1,16 @@
+---
+"@ggsvelte/core": patch
+"@ggsvelte/svelte": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+fix(theme): flat tooltip chrome for gridless themes
+
+Gridless themes (tufte, void) derive a transparent tooltip keyline and omit the
+default "Click to pin" affordance so minimal-ink charts keep flat interaction
+chrome (#1069). Pinning still works; only the instructional footer is silent.
+Themes that draw a grid keep the hairline border and pin hint. Inspect configs
+with `pin: false` also omit the affordance.
+
+Migration: none — additive visual for gridless themes only

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -149,18 +149,18 @@ Interaction is an editorial extension of the active chart theme. These roles are
 available on every resolved `ThemeTokens` object and through matching `--gg-*` custom
 properties:
 
-| Role               | Meaning                             | Built-in relationship   |
-| ------------------ | ----------------------------------- | ----------------------- |
-| `interactionInk`   | Controls and overlay ink            | theme ink               |
-| `interactionMuted` | De-emphasized mark opacity          | `0.36`                  |
-| `focusRing`        | Keyboard focus and active-mark halo | theme accent            |
-| `crosshair`        | Crosshair guides                    | axis text               |
-| `selectionFill`    | Selected interval interior          | accent at 18% opacity   |
-| `selectionStroke`  | Selection and zoom outline          | theme accent            |
-| `tooltipPaper`     | Opaque tooltip surface              | paper, then panel       |
-| `tooltipInk`       | Tooltip foreground                  | theme ink               |
-| `tooltipBorder`    | Tooltip hairline keyline            | grid, then panel border |
-| `toolActive`       | Active tool text and underline      | theme ink               |
+| Role               | Meaning                             | Built-in relationship                                                      |
+| ------------------ | ----------------------------------- | -------------------------------------------------------------------------- |
+| `interactionInk`   | Controls and overlay ink            | theme ink                                                                  |
+| `interactionMuted` | De-emphasized mark opacity          | `0.36`                                                                     |
+| `focusRing`        | Keyboard focus and active-mark halo | theme accent                                                               |
+| `crosshair`        | Crosshair guides                    | axis text                                                                  |
+| `selectionFill`    | Selected interval interior          | accent at 18% opacity                                                      |
+| `selectionStroke`  | Selection and zoom outline          | theme accent                                                               |
+| `tooltipPaper`     | Opaque tooltip surface              | paper, then panel                                                          |
+| `tooltipInk`       | Tooltip foreground                  | theme ink                                                                  |
+| `tooltipBorder`    | Tooltip hairline keyline            | grid color; `transparent` when grid is `none` (flat chrome for tufte/void) |
+| `toolActive`       | Active tool text and underline      | theme ink                                                                  |
 
 `interactionMuted` is a **number** (mark alpha). Host pages that restyle the
 tool rail / status chrome should override **`--gg-toolActive`** and
@@ -188,7 +188,9 @@ universal black, white, or blue because each theme must remain internally cohere
 - Use HTML tooltips with theme paper/ink, a hairline border, 2–3px radius, compact
   field/value alignment, selectable text, and an instructional footer separated by
   whitespace. Add only a restrained 1–3px elevation when the active theme needs surface
-  separation.
+  separation. Gridless themes (`grid: "none"`, e.g. tufte/void) derive a transparent
+  keyline so the tooltip is text on paper, and omit the pin affordance — pinning still
+  works; the theme just does not advertise it (#1069).
 
 ## Layout and responsive composition
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -149,18 +149,18 @@ Interaction is an editorial extension of the active chart theme. These roles are
 available on every resolved `ThemeTokens` object and through matching `--gg-*` custom
 properties:
 
-| Role               | Meaning                             | Built-in relationship                                                      |
-| ------------------ | ----------------------------------- | -------------------------------------------------------------------------- |
-| `interactionInk`   | Controls and overlay ink            | theme ink                                                                  |
-| `interactionMuted` | De-emphasized mark opacity          | `0.36`                                                                     |
-| `focusRing`        | Keyboard focus and active-mark halo | theme accent                                                               |
-| `crosshair`        | Crosshair guides                    | axis text                                                                  |
-| `selectionFill`    | Selected interval interior          | accent at 18% opacity                                                      |
-| `selectionStroke`  | Selection and zoom outline          | theme accent                                                               |
-| `tooltipPaper`     | Opaque tooltip surface              | paper, then panel                                                          |
-| `tooltipInk`       | Tooltip foreground                  | theme ink                                                                  |
-| `tooltipBorder`    | Tooltip hairline keyline            | grid color; `transparent` when grid is `none` (flat chrome for tufte/void) |
-| `toolActive`       | Active tool text and underline      | theme ink                                                                  |
+| Role               | Meaning                             | Built-in relationship                                                                                                    |
+| ------------------ | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `interactionInk`   | Controls and overlay ink            | theme ink                                                                                                                |
+| `interactionMuted` | De-emphasized mark opacity          | `0.36`                                                                                                                   |
+| `focusRing`        | Keyboard focus and active-mark halo | theme accent                                                                                                             |
+| `crosshair`        | Crosshair guides                    | axis text                                                                                                                |
+| `selectionFill`    | Selected interval interior          | accent at 18% opacity                                                                                                    |
+| `selectionStroke`  | Selection and zoom outline          | theme accent                                                                                                             |
+| `tooltipPaper`     | Opaque tooltip surface              | paper, then panel                                                                                                        |
+| `tooltipInk`       | Tooltip foreground                  | theme ink                                                                                                                |
+| `tooltipBorder`    | Tooltip hairline keyline            | grid color; `transparent` only for unframed gridless themes (tufte/void); framed gridless (few/classic) keep panelBorder |
+| `toolActive`       | Active tool text and underline      | theme ink                                                                                                                |
 
 `interactionMuted` is a **number** (mark alpha). Host pages that restyle the
 tool rail / status chrome should override **`--gg-toolActive`** and
@@ -188,9 +188,10 @@ universal black, white, or blue because each theme must remain internally cohere
 - Use HTML tooltips with theme paper/ink, a hairline border, 2–3px radius, compact
   field/value alignment, selectable text, and an instructional footer separated by
   whitespace. Add only a restrained 1–3px elevation when the active theme needs surface
-  separation. Gridless themes (`grid: "none"`, e.g. tufte/void) derive a transparent
-  keyline so the tooltip is text on paper, and omit the pin affordance — pinning still
-  works; the theme just does not advertise it (#1069).
+  separation. Unframed gridless themes (tufte/void: no grid, no panel border, no axis
+  lines) derive a transparent keyline so the tooltip is text on paper, and omit the pin
+  affordance — pinning still works; the theme just does not advertise it. Framed
+  gridless themes (few/classic) keep a panelBorder keyline and the pin hint (#1069).
 
 ## Layout and responsive composition
 

--- a/packages/core/src/theme-builtins.ts
+++ b/packages/core/src/theme-builtins.ts
@@ -183,6 +183,10 @@ export function themed(
     : foundation.ink === "currentColor"
       ? "#1f2328"
       : foundation.ink;
+  // Gridless themes (tufte, void) chose no panel structure. Do not invent a
+  // panelBorder keyline for their tooltips — text on paper (#1069). Themes that
+  // still draw a grid keep a hairline from that grid color.
+  const tooltipBorder = foundation.grid === "none" ? "transparent" : foundation.grid;
   return Object.freeze({
     ...foundation,
     letterboxFill: letterboxFill ?? foundation.paper,
@@ -194,7 +198,7 @@ export function themed(
     selectionStroke: foundation.accent,
     tooltipPaper,
     tooltipInk,
-    tooltipBorder: foundation.grid === "none" ? foundation.panelBorder : foundation.grid,
+    tooltipBorder,
     toolActive: foundation.ink,
   });
 }

--- a/packages/core/src/theme-builtins.ts
+++ b/packages/core/src/theme-builtins.ts
@@ -183,10 +183,20 @@ export function themed(
     : foundation.ink === "currentColor"
       ? "#1f2328"
       : foundation.ink;
-  // Gridless themes (tufte, void) chose no panel structure. Do not invent a
-  // panelBorder keyline for their tooltips — text on paper (#1069). Themes that
-  // still draw a grid keep a hairline from that grid color.
-  const tooltipBorder = foundation.grid === "none" ? "transparent" : foundation.grid;
+  // Flat tooltip chrome only when the theme also draws no frame (#1069).
+  // Tufte/void: grid none, no panel border, no axis lines → transparent keyline.
+  // few/classic: grid none but framed (panel border or axis lines) → keep
+  // panelBorder so boxed themes do not lose their tooltip outline + pin hint.
+  const flatTooltipChrome =
+    foundation.grid === "none" &&
+    !foundation.showPanelBorder &&
+    !foundation.axisLineX &&
+    !foundation.axisLineY;
+  const tooltipBorder = flatTooltipChrome
+    ? "transparent"
+    : foundation.grid === "none"
+      ? foundation.panelBorder
+      : foundation.grid;
   return Object.freeze({
     ...foundation,
     letterboxFill: letterboxFill ?? foundation.paper,

--- a/packages/core/tests/scales-m1/sequential-and-theme.test.ts
+++ b/packages/core/tests/scales-m1/sequential-and-theme.test.ts
@@ -254,4 +254,23 @@ describe("theme registry", () => {
     expect(BUILTIN_THEMES.default.selectionFill).toContain("rgba(");
     expect(BUILTIN_THEMES.dark.selectionFill).toContain("rgba(");
   });
+
+  // #1069 — gridless themes must not invent a panelBorder keyline for tooltips.
+  // A minimal-ink chart (tufte/void) should surface data as text on paper, not
+  // a boxed interaction panel.
+  it("gridless themes derive a flat tooltip keyline (transparent, not panelBorder)", () => {
+    expect(BUILTIN_THEMES.tufte.grid).toBe("none");
+    expect(BUILTIN_THEMES.tufte.tooltipBorder).toBe("transparent");
+    expect(BUILTIN_THEMES.tufte.tooltipBorder).not.toBe(BUILTIN_THEMES.tufte.panelBorder);
+    expect(BUILTIN_THEMES.void.grid).toBe("none");
+    expect(BUILTIN_THEMES.void.tooltipBorder).toBe("transparent");
+
+    // Themes that still draw a grid keep a visible hairline from the grid color.
+    expect(BUILTIN_THEMES.default.tooltipBorder).toBe(BUILTIN_THEMES.default.grid);
+    expect(BUILTIN_THEMES.default.tooltipBorder).not.toBe("transparent");
+    expect(BUILTIN_THEMES.light.tooltipBorder).toBe(BUILTIN_THEMES.light.grid);
+
+    // Object overrides still win over the derivation.
+    expect(resolveTheme({ name: "tufte", tooltipBorder: "#aabbcc" }).tooltipBorder).toBe("#aabbcc");
+  });
 });

--- a/packages/core/tests/scales-m1/sequential-and-theme.test.ts
+++ b/packages/core/tests/scales-m1/sequential-and-theme.test.ts
@@ -255,15 +255,26 @@ describe("theme registry", () => {
     expect(BUILTIN_THEMES.dark.selectionFill).toContain("rgba(");
   });
 
-  // #1069 — gridless themes must not invent a panelBorder keyline for tooltips.
-  // A minimal-ink chart (tufte/void) should surface data as text on paper, not
-  // a boxed interaction panel.
-  it("gridless themes derive a flat tooltip keyline (transparent, not panelBorder)", () => {
+  // #1069 — flat tooltip chrome only for unframed gridless themes (tufte/void).
+  // Framed gridless themes (few/classic) keep panelBorder keylines.
+  it("unframed gridless themes derive a flat tooltip keyline; framed ones keep panelBorder", () => {
     expect(BUILTIN_THEMES.tufte.grid).toBe("none");
     expect(BUILTIN_THEMES.tufte.tooltipBorder).toBe("transparent");
     expect(BUILTIN_THEMES.tufte.tooltipBorder).not.toBe(BUILTIN_THEMES.tufte.panelBorder);
     expect(BUILTIN_THEMES.void.grid).toBe("none");
     expect(BUILTIN_THEMES.void.tooltipBorder).toBe("transparent");
+
+    // few: gridless but showPanelBorder — keep the panel border keyline.
+    expect(BUILTIN_THEMES.few.grid).toBe("none");
+    expect(BUILTIN_THEMES.few.showPanelBorder).toBe(true);
+    expect(BUILTIN_THEMES.few.tooltipBorder).toBe(BUILTIN_THEMES.few.panelBorder);
+    expect(BUILTIN_THEMES.few.tooltipBorder).not.toBe("transparent");
+
+    // classic: gridless but axis lines — keep the panel border keyline.
+    expect(BUILTIN_THEMES.classic.grid).toBe("none");
+    expect(BUILTIN_THEMES.classic.axisLineX).toBe(true);
+    expect(BUILTIN_THEMES.classic.tooltipBorder).toBe(BUILTIN_THEMES.classic.panelBorder);
+    expect(BUILTIN_THEMES.classic.tooltipBorder).not.toBe("transparent");
 
     // Themes that still draw a grid keep a visible hairline from the grid color.
     expect(BUILTIN_THEMES.default.tooltipBorder).toBe(BUILTIN_THEMES.default.grid);

--- a/packages/svelte/src/lib/GGPlot.svelte
+++ b/packages/svelte/src/lib/GGPlot.svelte
@@ -287,6 +287,8 @@
           })}
           labs={engine.assembled?.labs ?? null}
           fontSizePx={currentModel.scene.theme.fontSize}
+          pin={engine.interactionConfig.inspect?.pin ?? true}
+          tooltipBorder={currentModel.scene.theme.tooltipBorder}
           onenter={() => (engine.tooltipHovered = true)}
           onleave={() => {
             engine.tooltipHovered = false;

--- a/packages/svelte/src/lib/inspection/Tooltip.svelte
+++ b/packages/svelte/src/lib/inspection/Tooltip.svelte
@@ -11,6 +11,7 @@
     tooltipFieldLabel,
     type TooltipFieldLabs,
   } from "./display-members.js";
+  import { shouldShowTooltipPinHint } from "./tooltip-chrome.js";
 
   const {
     inspection,
@@ -25,6 +26,13 @@
     docked = false,
     labs = null,
     fontSizePx = 12.5,
+    /** Whether inspect pinning is enabled (drives instructional footers). */
+    pin = true,
+    /**
+     * Resolved theme tooltip keyline. Flat (gridless) themes pass
+     * `"transparent"` so default content stays silent (#1069).
+     */
+    tooltipBorder = "#b8b8b8",
   }: {
     inspection: PlotInspectionChange<Record<string, CellValue>, PropertyKey>;
     width: number;
@@ -45,7 +53,13 @@
      * than a hard-coded 16px scale (#753 residual).
      */
     fontSizePx?: number;
+    pin?: boolean;
+    tooltipBorder?: string;
   } = $props();
+
+  const showPinHint = $derived(
+    shouldShowTooltipPinHint({ pin, tooltipBorder }),
+  );
 
   const anchor = $derived(inspection.focus.anchor);
   const OFFSET = 10;
@@ -156,11 +170,11 @@
         </dl>
       {/each}
     </div>
-    {#if inspection.state === "transient" && displayMembers.length > 8}
+    {#if showPinHint && inspection.state === "transient" && displayMembers.length > 8}
       <p class="gg-tooltip-more">
         +{displayMembers.length - 8} more · pin to inspect all
       </p>
-    {:else if inspection.state === "transient"}
+    {:else if showPinHint && inspection.state === "transient"}
       <p class="gg-tooltip-hint">Click to pin</p>
     {/if}
   {/if}

--- a/packages/svelte/src/lib/inspection/Tooltip.svelte
+++ b/packages/svelte/src/lib/inspection/Tooltip.svelte
@@ -170,9 +170,15 @@
         </dl>
       {/each}
     </div>
-    {#if showPinHint && inspection.state === "transient" && displayMembers.length > 8}
+    {#if inspection.state === "transient" && displayMembers.length > 8}
+      <!-- Overflow is a data-completeness signal; keep it even when the pin
+           affordance is silent for flat chrome (#1069 / Devin). -->
       <p class="gg-tooltip-more">
-        +{displayMembers.length - 8} more · pin to inspect all
+        {#if showPinHint}
+          +{displayMembers.length - 8} more · pin to inspect all
+        {:else}
+          +{displayMembers.length - 8} more
+        {/if}
       </p>
     {:else if showPinHint && inspection.state === "transient"}
       <p class="gg-tooltip-hint">Click to pin</p>

--- a/packages/svelte/src/lib/inspection/tooltip-chrome.ts
+++ b/packages/svelte/src/lib/inspection/tooltip-chrome.ts
@@ -1,0 +1,26 @@
+/**
+ * Tooltip chrome policy for theme-aware default content (#1069).
+ *
+ * Visual roles (paper / ink / border) live on the theme. This helper decides
+ * whether the default instructional footer ("Click to pin", overflow pin hint)
+ * belongs with that chrome — flat (gridless) themes drop to text on paper and
+ * stay silent; pinned-disabled inspect configs never advertise pinning.
+ */
+
+export type TooltipPinHintInput = {
+  /** Whether inspect pinning is enabled on the plot. */
+  readonly pin: boolean;
+  /**
+   * Resolved theme tooltip keyline. Gridless themes derive `"transparent"`;
+   * a concrete color means the theme still wants a boxed panel.
+   */
+  readonly tooltipBorder: string;
+};
+
+/** True when the default tooltip should show pin-related instructional footers. */
+export function shouldShowTooltipPinHint(input: TooltipPinHintInput): boolean {
+  if (!input.pin) return false;
+  const border = input.tooltipBorder.trim().toLowerCase();
+  if (border === "transparent" || border === "none") return false;
+  return true;
+}

--- a/packages/svelte/tests/inspection/tooltip-chrome.test.ts
+++ b/packages/svelte/tests/inspection/tooltip-chrome.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldShowTooltipPinHint } from "../../src/lib/inspection/tooltip-chrome.js";
+
+describe("shouldShowTooltipPinHint (#1069)", () => {
+  it("shows the pin footer when pin is on and the theme draws a keyline", () => {
+    expect(shouldShowTooltipPinHint({ pin: true, tooltipBorder: "#cccccc" })).toBe(true);
+    expect(shouldShowTooltipPinHint({ pin: true, tooltipBorder: "  #ebebeb  " })).toBe(true);
+  });
+
+  it("hides the pin footer when pin is disabled", () => {
+    expect(shouldShowTooltipPinHint({ pin: false, tooltipBorder: "#cccccc" })).toBe(false);
+  });
+
+  it("hides the pin footer for flat (gridless) tooltip chrome", () => {
+    expect(shouldShowTooltipPinHint({ pin: true, tooltipBorder: "transparent" })).toBe(false);
+    expect(shouldShowTooltipPinHint({ pin: true, tooltipBorder: "none" })).toBe(false);
+    expect(shouldShowTooltipPinHint({ pin: true, tooltipBorder: " Transparent " })).toBe(false);
+  });
+});

--- a/packages/svelte/tests/interaction/interaction-hover-tooltip.test.ts
+++ b/packages/svelte/tests/interaction/interaction-hover-tooltip.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import type { RenderModel } from "@ggsvelte/core";
 import GGPlot from "../../src/lib/GGPlot.svelte";
+import { withGrammarAsSpec } from "../helpers/ggplot-input.js";
 import { render } from "../helpers/render.js";
 import { until } from "../helpers/until.js";
 import { requireModel, rows, size } from "./interaction-harness.js";
@@ -356,5 +357,80 @@ describe("hover + tooltip (overlays, never a pipeline re-run)", () => {
       });
     });
     expect(container.querySelector(".gg-tooltip")).not.toBeNull();
+  });
+
+  // #1069 — ThemeTufte is gridless: flat tooltip chrome (no keyline invent, no
+  // "Click to pin" affordance). Default themes keep the instructional footer.
+  // Theme is children/spec-only after #704 — fold via withGrammarAsSpec.
+  it("tufte tooltips stay silent; default themes keep the pin affordance (#1069)", async () => {
+    let tufteModel: RenderModel | null = null;
+    const tuftePlot = render(
+      GGPlot,
+      withGrammarAsSpec({
+        data: rows,
+        aes: { x: "x", y: "y" },
+        layers: [{ geom: "point", params: { size: 5 } }],
+        theme: "tufte",
+        inspect: true,
+        onrender: (m: RenderModel) => {
+          tufteModel = m;
+        },
+        ...size,
+      }),
+    );
+    expect(tufteModel!.scene.theme.tooltipBorder).toBe("transparent");
+    const tufteCandidate = tufteModel!.candidates.candidate(0)!;
+    pointerMoveAt(
+      tuftePlot.container.querySelector(".gg-capture")!,
+      tufteCandidate.x,
+      tufteCandidate.y,
+    );
+    await until(() => tuftePlot.container.querySelector(".gg-tooltip") !== null);
+    const tufteTooltip = tuftePlot.container.querySelector(".gg-tooltip")!;
+    expect(tufteTooltip.querySelector(".gg-tooltip-hint")).toBeNull();
+    expect(tufteTooltip.textContent).not.toContain("Click to pin");
+
+    let defaultModel: RenderModel | null = null;
+    const defaultPlot = render(GGPlot, {
+      data: rows,
+      aes: { x: "x", y: "y" },
+      layers: [{ geom: "point", params: { size: 5 } }],
+      inspect: true,
+      onrender: (m: RenderModel) => {
+        defaultModel = m;
+      },
+      ...size,
+    });
+    expect(defaultModel!.scene.theme.tooltipBorder).not.toBe("transparent");
+    const defaultCandidate = defaultModel!.candidates.candidate(0)!;
+    pointerMoveAt(
+      defaultPlot.container.querySelector(".gg-capture")!,
+      defaultCandidate.x,
+      defaultCandidate.y,
+    );
+    await until(() => defaultPlot.container.querySelector(".gg-tooltip") !== null);
+    const defaultTooltip = defaultPlot.container.querySelector(".gg-tooltip")!;
+    expect(defaultTooltip.querySelector(".gg-tooltip-hint")).not.toBeNull();
+    expect(defaultTooltip.textContent).toContain("Click to pin");
+  });
+
+  it("omits pin affordance when inspect.pin is false (#1069)", async () => {
+    let model: RenderModel | null = null;
+    const { container } = render(GGPlot, {
+      data: rows,
+      aes: { x: "x", y: "y" },
+      layers: [{ geom: "point", params: { size: 5 } }],
+      inspect: { pin: false },
+      onrender: (m: RenderModel) => {
+        model = m;
+      },
+      ...size,
+    });
+    const candidate = model!.candidates.candidate(0)!;
+    pointerMoveAt(container.querySelector(".gg-capture")!, candidate.x, candidate.y);
+    await until(() => container.querySelector(".gg-tooltip") !== null);
+    const tooltip = container.querySelector(".gg-tooltip")!;
+    expect(tooltip.querySelector(".gg-tooltip-hint")).toBeNull();
+    expect(tooltip.textContent).not.toContain("Click to pin");
   });
 });


### PR DESCRIPTION
## Summary

Fixes #1069. Minimal-ink themes (`ThemeTufte`, void) were still painting a
boxed default tooltip: a `panelBorder` keyline and a "Click to pin" footer on
top of a chart that deliberately has no grid.

- **Core:** when `grid === "none"`, derive `tooltipBorder: "transparent"` instead
  of inventing a panel-border keyline.
- **Svelte:** default tooltip pin affordances only when pin is enabled and the
  theme draws a keyline (`shouldShowTooltipPinHint`). Pinning still works under
  tufte; the instructional footer is silent.
- **DESIGN.md:** document the gridless flat-chrome rule.

## Test plan

- [x] Core: `gridless themes derive a flat tooltip keyline` (tufte/void
  transparent; default keeps grid hairline; object override wins)
- [x] Unit: `shouldShowTooltipPinHint` (pin off / transparent / none → silent)
- [x] Browser: tufte hover has no "Click to pin"; default theme still shows it
- [x] Browser: `inspect: { pin: false }` omits the affordance

## Notes

Closes #1069. Deploy must land before prod `/guide/getting-started` reflects the
flat chrome.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1098" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->