### PR TITLE
docs(reference): schema-derived stat API for every statistical transform

### DIFF
--- a/.changeset/stat-api-reference.md
+++ b/.changeset/stat-api-reference.md
@@ -1,0 +1,15 @@
+---
+"@ggsvelte/spec": minor
+"@ggsvelte/core": patch
+"@ggsvelte/svelte": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+feat(spec): export schema-derived `STAT_REFERENCE` for every stat
+
+`STAT_REFERENCE` / `statReferenceList()` publish each statistical transform's
+summary, after_stat columns (`STAT_COLUMNS`), and compatible geoms (inverted
+from `GEOM_REFERENCE`). The docs site uses this for `/reference/stats`.
+
+Migration: none — additive

--- a/apps/docs/src/lib/catalog/guide.ts
+++ b/apps/docs/src/lib/catalog/guide.ts
@@ -169,21 +169,22 @@ export const GUIDE_CATALOG = [
     description:
       "Understand validation, render, interaction, and CLI diagnostics and recover safely.",
     section: "Reference",
-    navigationOrder: 53,
+    // After /reference/* pages (50–55); leave 53 for positions reference.
+    navigationOrder: 56,
   },
   {
     slug: "advisories",
     title: "Advisories",
     description: "Spec-lint advisories and the pipeline's disclosed heuristics.",
     section: "Reference",
-    navigationOrder: 54,
+    navigationOrder: 57,
   },
   {
     slug: "lifecycle",
     title: "Lifecycle & editions",
     description: "API stability tags per export, and the defaults-edition mechanism.",
     section: "Reference",
-    navigationOrder: 55,
+    navigationOrder: 58,
   },
   {
     slug: "upgrading",

--- a/apps/docs/src/lib/generated/routes.ts
+++ b/apps/docs/src/lib/generated/routes.ts
@@ -153,7 +153,7 @@ export const DOCS_ROUTES = [
     navigation: {
       section: "Reference",
       label: "Interaction reference",
-      order: 53,
+      order: 54,
     },
   },
   {
@@ -169,7 +169,7 @@ export const DOCS_ROUTES = [
     navigation: {
       section: "Reference",
       label: "CLI reference",
-      order: 54,
+      order: 55,
     },
     headings: [
       {
@@ -4570,7 +4570,7 @@ export const DOCS_ROUTES = [
     navigation: {
       section: "Reference",
       label: "Errors reference",
-      order: 53,
+      order: 56,
     },
     headings: [
       {
@@ -5607,7 +5607,7 @@ export const DOCS_ROUTES = [
     navigation: {
       section: "Reference",
       label: "Advisories",
-      order: 54,
+      order: 57,
     },
     headings: [
       {
@@ -5729,7 +5729,7 @@ export const DOCS_ROUTES = [
     navigation: {
       section: "Reference",
       label: "Lifecycle & editions",
-      order: 55,
+      order: 58,
     },
     headings: [
       {
@@ -7161,12 +7161,12 @@ export const GUIDE_NAVIGATION = [
         label: "Interaction reference",
       },
       {
-        path: "/guide/errors",
-        label: "Errors reference",
-      },
-      {
         path: "/reference/cli",
         label: "CLI reference",
+      },
+      {
+        path: "/guide/errors",
+        label: "Errors reference",
       },
       {
         path: "/guide/advisories",

--- a/apps/docs/src/lib/generated/routes.ts
+++ b/apps/docs/src/lib/generated/routes.ts
@@ -113,6 +113,34 @@ export const DOCS_ROUTES = [
     ],
   },
   {
+    path: "/reference/stats",
+    title: "Stat reference — ggsvelte",
+    description:
+      "Schema-derived API reference for every statistical transform: after_stat columns and compatible geoms.",
+    canonicalPath: "/reference/stats",
+    kind: "page",
+    index: true,
+    sitemap: true,
+    shell: "docs",
+    navigation: {
+      section: "Reference",
+      label: "Stat reference",
+      order: 52,
+    },
+    headings: [
+      {
+        id: "all-stats",
+        title: "All stats",
+        level: 2,
+      },
+      {
+        id: "how-to-set",
+        title: "How to set a stat",
+        level: 2,
+      },
+    ],
+  },
+  {
     path: "/reference/interactions",
     title: "Search interactions — ggsvelte",
     description:
@@ -125,7 +153,7 @@ export const DOCS_ROUTES = [
     navigation: {
       section: "Reference",
       label: "Interaction reference",
-      order: 52,
+      order: 53,
     },
   },
   {
@@ -141,7 +169,7 @@ export const DOCS_ROUTES = [
     navigation: {
       section: "Reference",
       label: "CLI reference",
-      order: 53,
+      order: 54,
     },
     headings: [
       {
@@ -2554,6 +2582,1040 @@ export const DOCS_ROUTES = [
     ],
   },
   {
+    path: "/reference/stats/identity",
+    title: "stat identity — ggsvelte",
+    description:
+      'stat "identity": Pass rows through unchanged. Default for most geoms: each mapped row becomes one mark with no aggregation.',
+    canonicalPath: "/reference/stats/identity",
+    kind: "page",
+    index: true,
+    sitemap: true,
+    shell: "docs",
+    headings: [
+      {
+        id: "usage",
+        title: "Usage",
+        level: 2,
+      },
+      {
+        id: "generated-columns",
+        title: "Generated columns (after_stat)",
+        level: 2,
+      },
+      {
+        id: "default-for",
+        title: "Default for geoms",
+        level: 2,
+      },
+      {
+        id: "compatible-geoms",
+        title: "Compatible geoms",
+        level: 2,
+      },
+      {
+        id: "examples",
+        title: "Examples",
+        level: 2,
+      },
+    ],
+  },
+  {
+    path: "/reference/stats/unique",
+    title: "stat unique — ggsvelte",
+    description:
+      'stat "unique": Keep one row per distinct mapped (x, y) pair (and group). Use when duplicate coordinates would overplot; default for none.',
+    canonicalPath: "/reference/stats/unique",
+    kind: "page",
+    index: true,
+    sitemap: true,
+    shell: "docs",
+    headings: [
+      {
+        id: "usage",
+        title: "Usage",
+        level: 2,
+      },
+      {
+        id: "generated-columns",
+        title: "Generated columns (after_stat)",
+        level: 2,
+      },
+      {
+        id: "default-for",
+        title: "Default for geoms",
+        level: 2,
+      },
+      {
+        id: "compatible-geoms",
+        title: "Compatible geoms",
+        level: 2,
+      },
+      {
+        id: "examples",
+        title: "Examples",
+        level: 2,
+      },
+    ],
+  },
+  {
+    path: "/reference/stats/manual",
+    title: "stat manual — ggsvelte",
+    description:
+      'stat "manual": Author-supplied after_stat values via params — skip automatic transforms when you already computed summaries.',
+    canonicalPath: "/reference/stats/manual",
+    kind: "page",
+    index: true,
+    sitemap: true,
+    shell: "docs",
+    headings: [
+      {
+        id: "usage",
+        title: "Usage",
+        level: 2,
+      },
+      {
+        id: "generated-columns",
+        title: "Generated columns (after_stat)",
+        level: 2,
+      },
+      {
+        id: "default-for",
+        title: "Default for geoms",
+        level: 2,
+      },
+      {
+        id: "compatible-geoms",
+        title: "Compatible geoms",
+        level: 2,
+      },
+      {
+        id: "examples",
+        title: "Examples",
+        level: 2,
+      },
+    ],
+  },
+  {
+    path: "/reference/stats/connect",
+    title: "stat connect — ggsvelte",
+    description:
+      'stat "connect": Expand successive points into connection vertices (linear, hv, vh, mid) for stepped or path-style joins between observations.',
+    canonicalPath: "/reference/stats/connect",
+    kind: "page",
+    index: true,
+    sitemap: true,
+    shell: "docs",
+    headings: [
+      {
+        id: "usage",
+        title: "Usage",
+        level: 2,
+      },
+      {
+        id: "generated-columns",
+        title: "Generated columns (after_stat)",
+        level: 2,
+      },
+      {
+        id: "default-for",
+        title: "Default for geoms",
+        level: 2,
+      },
+      {
+        id: "compatible-geoms",
+        title: "Compatible geoms",
+        level: 2,
+      },
+      {
+        id: "examples",
+        title: "Examples",
+        level: 2,
+      },
+    ],
+  },
+  {
+    path: "/reference/stats/count",
+    title: "stat count — ggsvelte",
+    description:
+      'stat "count": Count rows (or sum weights) per distinct x within each group. Default for geom_bar; publishes after_stat count.',
+    canonicalPath: "/reference/stats/count",
+    kind: "page",
+    index: true,
+    sitemap: true,
+    shell: "docs",
+    headings: [
+      {
+        id: "usage",
+        title: "Usage",
+        level: 2,
+      },
+      {
+        id: "generated-columns",
+        title: "Generated columns (after_stat)",
+        level: 2,
+      },
+      {
+        id: "default-for",
+        title: "Default for geoms",
+        level: 2,
+      },
+      {
+        id: "compatible-geoms",
+        title: "Compatible geoms",
+        level: 2,
+      },
+      {
+        id: "examples",
+        title: "Examples",
+        level: 2,
+      },
+    ],
+  },
+  {
+    path: "/reference/stats/bin",
+    title: "stat bin — ggsvelte",
+    description:
+      'stat "bin": Bin continuous x into histogram breaks. Publishes count, density, ncount, and ndensity; default for histogram and freqpoly.',
+    canonicalPath: "/reference/stats/bin",
+    kind: "page",
+    index: true,
+    sitemap: true,
+    shell: "docs",
+    headings: [
+      {
+        id: "usage",
+        title: "Usage",
+        level: 2,
+      },
+      {
+        id: "generated-columns",
+        title: "Generated columns (after_stat)",
+        level: 2,
+      },
+      {
+        id: "default-for",
+        title: "Default for geoms",
+        level: 2,
+      },
+      {
+        id: "compatible-geoms",
+        title: "Compatible geoms",
+        level: 2,
+      },
+      {
+        id: "examples",
+        title: "Examples",
+        level: 2,
+      },
+    ],
+  },
+  {
+    path: "/reference/stats/bin_hex",
+    title: "stat bin_hex — ggsvelte",
+    description:
+      'stat "bin_hex": Hexagonal 2D binning over continuous x and y. Publishes count/density columns for geom_hex heatmaps.',
+    canonicalPath: "/reference/stats/bin_hex",
+    kind: "page",
+    index: true,
+    sitemap: true,
+    shell: "docs",
+    headings: [
+      {
+        id: "usage",
+        title: "Usage",
+        level: 2,
+      },
+      {
+        id: "generated-columns",
+        title: "Generated columns (after_stat)",
+        level: 2,
+      },
+      {
+        id: "default-for",
+        title: "Default for geoms",
+        level: 2,
+      },
+      {
+        id: "compatible-geoms",
+        title: "Compatible geoms",
+        level: 2,
+      },
+    ],
+  },
+  {
+    path: "/reference/stats/bin_2d",
+    title: "stat bin_2d — ggsvelte",
+    description:
+      'stat "bin_2d": Rectangular 2D binning over continuous x and y. Publishes count/density and bin edges for geom_bin_2d tiles.',
+    canonicalPath: "/reference/stats/bin_2d",
+    kind: "page",
+    index: true,
+    sitemap: true,
+    shell: "docs",
+    headings: [
+      {
+        id: "usage",
+        title: "Usage",
+        level: 2,
+      },
+      {
+        id: "generated-columns",
+        title: "Generated columns (after_stat)",
+        level: 2,
+      },
+      {
+        id: "default-for",
+        title: "Default for geoms",
+        level: 2,
+      },
+      {
+        id: "compatible-geoms",
+        title: "Compatible geoms",
+        level: 2,
+      },
+      {
+        id: "examples",
+        title: "Examples",
+        level: 2,
+      },
+    ],
+  },
+  {
+    path: "/reference/stats/smooth",
+    title: "stat smooth — ggsvelte",
+    description:
+      'stat "smooth": Fit a smoother (lm or loess) and evaluate along x. Publishes y, ymin, ymax, and se; default for geom_smooth.',
+    canonicalPath: "/reference/stats/smooth",
+    kind: "page",
+    index: true,
+    sitemap: true,
+    shell: "docs",
+    headings: [
+      {
+        id: "usage",
+        title: "Usage",
+        level: 2,
+      },
+      {
+        id: "generated-columns",
+        title: "Generated columns (after_stat)",
+        level: 2,
+      },
+      {
+        id: "default-for",
+        title: "Default for geoms",
+        level: 2,
+      },
+      {
+        id: "compatible-geoms",
+        title: "Compatible geoms",
+        level: 2,
+      },
+      {
+        id: "examples",
+        title: "Examples",
+        level: 2,
+      },
+    ],
+  },
+  {
+    path: "/reference/stats/quantile",
+    title: "stat quantile — ggsvelte",
+    description:
+      'stat "quantile": Estimate conditional quantiles of y given x. Publishes y at each requested probability; default for geom_quantile.',
+    canonicalPath: "/reference/stats/quantile",
+    kind: "page",
+    index: true,
+    sitemap: true,
+    shell: "docs",
+    headings: [
+      {
+        id: "usage",
+        title: "Usage",
+        level: 2,
+      },
+      {
+        id: "generated-columns",
+        title: "Generated columns (after_stat)",
+        level: 2,
+      },
+      {
+        id: "default-for",
+        title: "Default for geoms",
+        level: 2,
+      },
+      {
+        id: "compatible-geoms",
+        title: "Compatible geoms",
+        level: 2,
+      },
+      {
+        id: "examples",
+        title: "Examples",
+        level: 2,
+      },
+    ],
+  },
+  {
+    path: "/reference/stats/boxplot",
+    title: "stat boxplot — ggsvelte",
+    description:
+      'stat "boxplot": Five-number summary per group (hinges and whiskers). Publishes ymin, lower, middle, upper, ymax; default for geom_boxplot.',
+    canonicalPath: "/reference/stats/boxplot",
+    kind: "page",
+    index: true,
+    sitemap: true,
+    shell: "docs",
+    headings: [
+      {
+        id: "usage",
+        title: "Usage",
+        level: 2,
+      },
+      {
+        id: "generated-columns",
+        title: "Generated columns (after_stat)",
+        level: 2,
+      },
+      {
+        id: "default-for",
+        title: "Default for geoms",
+        level: 2,
+      },
+      {
+        id: "compatible-geoms",
+        title: "Compatible geoms",
+        level: 2,
+      },
+      {
+        id: "examples",
+        title: "Examples",
+        level: 2,
+      },
+    ],
+  },
+  {
+    path: "/reference/stats/density",
+    title: "stat density — ggsvelte",
+    description:
+      'stat "density": 1D Gaussian kernel density estimate along x. Publishes density, count, scaled, and ndensity; default for geom_density.',
+    canonicalPath: "/reference/stats/density",
+    kind: "page",
+    index: true,
+    sitemap: true,
+    shell: "docs",
+    headings: [
+      {
+        id: "usage",
+        title: "Usage",
+        level: 2,
+      },
+      {
+        id: "generated-columns",
+        title: "Generated columns (after_stat)",
+        level: 2,
+      },
+      {
+        id: "default-for",
+        title: "Default for geoms",
+        level: 2,
+      },
+      {
+        id: "compatible-geoms",
+        title: "Compatible geoms",
+        level: 2,
+      },
+      {
+        id: "examples",
+        title: "Examples",
+        level: 2,
+      },
+    ],
+  },
+  {
+    path: "/reference/stats/summary",
+    title: "stat summary — ggsvelte",
+    description:
+      'stat "summary": Collapse each discrete-x group to one summary (default mean ± se). Publishes y, ymin, ymax for error-style geoms.',
+    canonicalPath: "/reference/stats/summary",
+    kind: "page",
+    index: true,
+    sitemap: true,
+    shell: "docs",
+    headings: [
+      {
+        id: "usage",
+        title: "Usage",
+        level: 2,
+      },
+      {
+        id: "generated-columns",
+        title: "Generated columns (after_stat)",
+        level: 2,
+      },
+      {
+        id: "default-for",
+        title: "Default for geoms",
+        level: 2,
+      },
+      {
+        id: "compatible-geoms",
+        title: "Compatible geoms",
+        level: 2,
+      },
+      {
+        id: "examples",
+        title: "Examples",
+        level: 2,
+      },
+    ],
+  },
+  {
+    path: "/reference/stats/sum",
+    title: "stat sum — ggsvelte",
+    description:
+      'stat "sum": Count overlapping points at each (x, y) cell for geom_count. Publishes n and prop (not y).',
+    canonicalPath: "/reference/stats/sum",
+    kind: "page",
+    index: true,
+    sitemap: true,
+    shell: "docs",
+    headings: [
+      {
+        id: "usage",
+        title: "Usage",
+        level: 2,
+      },
+      {
+        id: "generated-columns",
+        title: "Generated columns (after_stat)",
+        level: 2,
+      },
+      {
+        id: "default-for",
+        title: "Default for geoms",
+        level: 2,
+      },
+      {
+        id: "compatible-geoms",
+        title: "Compatible geoms",
+        level: 2,
+      },
+    ],
+  },
+  {
+    path: "/reference/stats/ydensity",
+    title: "stat ydensity — ggsvelte",
+    description:
+      'stat "ydensity": Kernel density along y for violin shapes. Publishes density, count, scaled, violinwidth, and y; default for geom_violin.',
+    canonicalPath: "/reference/stats/ydensity",
+    kind: "page",
+    index: true,
+    sitemap: true,
+    shell: "docs",
+    headings: [
+      {
+        id: "usage",
+        title: "Usage",
+        level: 2,
+      },
+      {
+        id: "generated-columns",
+        title: "Generated columns (after_stat)",
+        level: 2,
+      },
+      {
+        id: "default-for",
+        title: "Default for geoms",
+        level: 2,
+      },
+      {
+        id: "compatible-geoms",
+        title: "Compatible geoms",
+        level: 2,
+      },
+    ],
+  },
+  {
+    path: "/reference/stats/function",
+    title: "stat function — ggsvelte",
+    description:
+      'stat "function": Evaluate a pure function on an x grid. Publishes y; default for geom_function when no data rows drive the mark.',
+    canonicalPath: "/reference/stats/function",
+    kind: "page",
+    index: true,
+    sitemap: true,
+    shell: "docs",
+    headings: [
+      {
+        id: "usage",
+        title: "Usage",
+        level: 2,
+      },
+      {
+        id: "generated-columns",
+        title: "Generated columns (after_stat)",
+        level: 2,
+      },
+      {
+        id: "default-for",
+        title: "Default for geoms",
+        level: 2,
+      },
+      {
+        id: "compatible-geoms",
+        title: "Compatible geoms",
+        level: 2,
+      },
+      {
+        id: "examples",
+        title: "Examples",
+        level: 2,
+      },
+    ],
+  },
+  {
+    path: "/reference/stats/ecdf",
+    title: "stat ecdf — ggsvelte",
+    description:
+      'stat "ecdf": Empirical cumulative distribution F̂(x). Publishes ecdf; pair with step or path geoms for CDF plots.',
+    canonicalPath: "/reference/stats/ecdf",
+    kind: "page",
+    index: true,
+    sitemap: true,
+    shell: "docs",
+    headings: [
+      {
+        id: "usage",
+        title: "Usage",
+        level: 2,
+      },
+      {
+        id: "generated-columns",
+        title: "Generated columns (after_stat)",
+        level: 2,
+      },
+      {
+        id: "default-for",
+        title: "Default for geoms",
+        level: 2,
+      },
+      {
+        id: "compatible-geoms",
+        title: "Compatible geoms",
+        level: 2,
+      },
+      {
+        id: "examples",
+        title: "Examples",
+        level: 2,
+      },
+    ],
+  },
+  {
+    path: "/reference/stats/summary_bin",
+    title: "stat summary_bin — ggsvelte",
+    description:
+      'stat "summary_bin": Bin continuous x, then summarize y in each bin (mean ± se by default). Publishes y, ymin, ymax for binned summaries.',
+    canonicalPath: "/reference/stats/summary_bin",
+    kind: "page",
+    index: true,
+    sitemap: true,
+    shell: "docs",
+    headings: [
+      {
+        id: "usage",
+        title: "Usage",
+        level: 2,
+      },
+      {
+        id: "generated-columns",
+        title: "Generated columns (after_stat)",
+        level: 2,
+      },
+      {
+        id: "default-for",
+        title: "Default for geoms",
+        level: 2,
+      },
+      {
+        id: "compatible-geoms",
+        title: "Compatible geoms",
+        level: 2,
+      },
+      {
+        id: "examples",
+        title: "Examples",
+        level: 2,
+      },
+    ],
+  },
+  {
+    path: "/reference/stats/contour",
+    title: "stat contour — ggsvelte",
+    description:
+      'stat "contour": Marching-squares isolines over a regular x×y×z grid. Publishes level; default for geom_contour.',
+    canonicalPath: "/reference/stats/contour",
+    kind: "page",
+    index: true,
+    sitemap: true,
+    shell: "docs",
+    headings: [
+      {
+        id: "usage",
+        title: "Usage",
+        level: 2,
+      },
+      {
+        id: "generated-columns",
+        title: "Generated columns (after_stat)",
+        level: 2,
+      },
+      {
+        id: "default-for",
+        title: "Default for geoms",
+        level: 2,
+      },
+      {
+        id: "compatible-geoms",
+        title: "Compatible geoms",
+        level: 2,
+      },
+      {
+        id: "examples",
+        title: "Examples",
+        level: 2,
+      },
+    ],
+  },
+  {
+    path: "/reference/stats/align",
+    title: "stat align — ggsvelte",
+    description:
+      'stat "align": Interpolate series onto a shared x grid so continuous-x stacks and overlays line up (stack-friendly zeros outside range).',
+    canonicalPath: "/reference/stats/align",
+    kind: "page",
+    index: true,
+    sitemap: true,
+    shell: "docs",
+    headings: [
+      {
+        id: "usage",
+        title: "Usage",
+        level: 2,
+      },
+      {
+        id: "generated-columns",
+        title: "Generated columns (after_stat)",
+        level: 2,
+      },
+      {
+        id: "default-for",
+        title: "Default for geoms",
+        level: 2,
+      },
+      {
+        id: "compatible-geoms",
+        title: "Compatible geoms",
+        level: 2,
+      },
+    ],
+  },
+  {
+    path: "/reference/stats/density_2d",
+    title: "stat density_2d — ggsvelte",
+    description:
+      'stat "density_2d": Bivariate KDE with isolines. Publishes level and density; default for geom_density_2d.',
+    canonicalPath: "/reference/stats/density_2d",
+    kind: "page",
+    index: true,
+    sitemap: true,
+    shell: "docs",
+    headings: [
+      {
+        id: "usage",
+        title: "Usage",
+        level: 2,
+      },
+      {
+        id: "generated-columns",
+        title: "Generated columns (after_stat)",
+        level: 2,
+      },
+      {
+        id: "default-for",
+        title: "Default for geoms",
+        level: 2,
+      },
+      {
+        id: "compatible-geoms",
+        title: "Compatible geoms",
+        level: 2,
+      },
+      {
+        id: "examples",
+        title: "Examples",
+        level: 2,
+      },
+    ],
+  },
+  {
+    path: "/reference/stats/density_2d_filled",
+    title: "stat density_2d_filled — ggsvelte",
+    description:
+      'stat "density_2d_filled": Bivariate KDE with closed density rings for filled contours. Publishes level and density; default for geom_density_2d_filled.',
+    canonicalPath: "/reference/stats/density_2d_filled",
+    kind: "page",
+    index: true,
+    sitemap: true,
+    shell: "docs",
+    headings: [
+      {
+        id: "usage",
+        title: "Usage",
+        level: 2,
+      },
+      {
+        id: "generated-columns",
+        title: "Generated columns (after_stat)",
+        level: 2,
+      },
+      {
+        id: "default-for",
+        title: "Default for geoms",
+        level: 2,
+      },
+      {
+        id: "compatible-geoms",
+        title: "Compatible geoms",
+        level: 2,
+      },
+      {
+        id: "examples",
+        title: "Examples",
+        level: 2,
+      },
+    ],
+  },
+  {
+    path: "/reference/stats/bindot",
+    title: "stat bindot — ggsvelte",
+    description:
+      'stat "bindot": Histodot binning for geom_dotplot: one stack position per observation. Publishes stackpos (and bin occupancy).',
+    canonicalPath: "/reference/stats/bindot",
+    kind: "page",
+    index: true,
+    sitemap: true,
+    shell: "docs",
+    headings: [
+      {
+        id: "usage",
+        title: "Usage",
+        level: 2,
+      },
+      {
+        id: "generated-columns",
+        title: "Generated columns (after_stat)",
+        level: 2,
+      },
+      {
+        id: "default-for",
+        title: "Default for geoms",
+        level: 2,
+      },
+      {
+        id: "compatible-geoms",
+        title: "Compatible geoms",
+        level: 2,
+      },
+      {
+        id: "examples",
+        title: "Examples",
+        level: 2,
+      },
+    ],
+  },
+  {
+    path: "/reference/stats/ellipse",
+    title: "stat ellipse — ggsvelte",
+    description:
+      'stat "ellipse": Confidence ellipse over bivariate points (level and type from params). Passes geometry suited to path/polygon-style marks.',
+    canonicalPath: "/reference/stats/ellipse",
+    kind: "page",
+    index: true,
+    sitemap: true,
+    shell: "docs",
+    headings: [
+      {
+        id: "usage",
+        title: "Usage",
+        level: 2,
+      },
+      {
+        id: "generated-columns",
+        title: "Generated columns (after_stat)",
+        level: 2,
+      },
+      {
+        id: "default-for",
+        title: "Default for geoms",
+        level: 2,
+      },
+      {
+        id: "compatible-geoms",
+        title: "Compatible geoms",
+        level: 2,
+      },
+      {
+        id: "examples",
+        title: "Examples",
+        level: 2,
+      },
+    ],
+  },
+  {
+    path: "/reference/stats/sf",
+    title: "stat sf — ggsvelte",
+    description:
+      'stat "sf": Simple-features geometry expansion for geom_sf: multiparts and holes become drawable rings without after_stat columns.',
+    canonicalPath: "/reference/stats/sf",
+    kind: "page",
+    index: true,
+    sitemap: true,
+    shell: "docs",
+    headings: [
+      {
+        id: "usage",
+        title: "Usage",
+        level: 2,
+      },
+      {
+        id: "generated-columns",
+        title: "Generated columns (after_stat)",
+        level: 2,
+      },
+      {
+        id: "default-for",
+        title: "Default for geoms",
+        level: 2,
+      },
+      {
+        id: "compatible-geoms",
+        title: "Compatible geoms",
+        level: 2,
+      },
+      {
+        id: "examples",
+        title: "Examples",
+        level: 2,
+      },
+    ],
+  },
+  {
+    path: "/reference/stats/sf_coordinates",
+    title: "stat sf_coordinates — ggsvelte",
+    description:
+      'stat "sf_coordinates": Label anchors from SF geometries for geom_sf_text and geom_sf_label (one point per feature or part).',
+    canonicalPath: "/reference/stats/sf_coordinates",
+    kind: "page",
+    index: true,
+    sitemap: true,
+    shell: "docs",
+    headings: [
+      {
+        id: "usage",
+        title: "Usage",
+        level: 2,
+      },
+      {
+        id: "generated-columns",
+        title: "Generated columns (after_stat)",
+        level: 2,
+      },
+      {
+        id: "default-for",
+        title: "Default for geoms",
+        level: 2,
+      },
+      {
+        id: "compatible-geoms",
+        title: "Compatible geoms",
+        level: 2,
+      },
+    ],
+  },
+  {
+    path: "/reference/stats/qq",
+    title: "stat qq — ggsvelte",
+    description:
+      'stat "qq": Sample vs theoretical quantiles for Q–Q plots. Publishes sample and theoretical; default for geom_qq.',
+    canonicalPath: "/reference/stats/qq",
+    kind: "page",
+    index: true,
+    sitemap: true,
+    shell: "docs",
+    headings: [
+      {
+        id: "usage",
+        title: "Usage",
+        level: 2,
+      },
+      {
+        id: "generated-columns",
+        title: "Generated columns (after_stat)",
+        level: 2,
+      },
+      {
+        id: "default-for",
+        title: "Default for geoms",
+        level: 2,
+      },
+      {
+        id: "compatible-geoms",
+        title: "Compatible geoms",
+        level: 2,
+      },
+      {
+        id: "examples",
+        title: "Examples",
+        level: 2,
+      },
+    ],
+  },
+  {
+    path: "/reference/stats/qq_line",
+    title: "stat qq_line — ggsvelte",
+    description:
+      'stat "qq_line": Reference line through Q–Q sample/theoretical quantiles. Publishes sample and theoretical; default for geom_qq_line.',
+    canonicalPath: "/reference/stats/qq_line",
+    kind: "page",
+    index: true,
+    sitemap: true,
+    shell: "docs",
+    headings: [
+      {
+        id: "usage",
+        title: "Usage",
+        level: 2,
+      },
+      {
+        id: "generated-columns",
+        title: "Generated columns (after_stat)",
+        level: 2,
+      },
+      {
+        id: "default-for",
+        title: "Default for geoms",
+        level: 2,
+      },
+      {
+        id: "compatible-geoms",
+        title: "Compatible geoms",
+        level: 2,
+      },
+    ],
+  },
+  {
     path: "/guide/getting-started",
     title: "Getting started — ggsvelte",
     description: "Install @ggsvelte/svelte and render one chart from a Svelte file.",
@@ -4686,8 +5748,8 @@ export const DOCS_ROUTES = [
         level: 2,
       },
       {
-        id: "experimental-865",
-        title: "experimental (865)",
+        id: "experimental-868",
+        title: "experimental (868)",
         level: 3,
       },
       {
@@ -6091,16 +7153,20 @@ export const GUIDE_NAVIGATION = [
         label: "Geom reference",
       },
       {
+        path: "/reference/stats",
+        label: "Stat reference",
+      },
+      {
         path: "/reference/interactions",
         label: "Interaction reference",
       },
       {
-        path: "/reference/cli",
-        label: "CLI reference",
-      },
-      {
         path: "/guide/errors",
         label: "Errors reference",
+      },
+      {
+        path: "/reference/cli",
+        label: "CLI reference",
       },
       {
         path: "/guide/advisories",

--- a/apps/docs/src/lib/generated/search-index.ts
+++ b/apps/docs/src/lib/generated/search-index.ts
@@ -97,6 +97,36 @@ export const DOCS_SEARCH_INDEX = [
     exact: ["Shared layer props"],
   },
   {
+    id: "page:reference-stats",
+    kind: "page",
+    title: "Stat reference",
+    summary:
+      "Schema-derived API reference for every statistical transform: after_stat columns and compatible geoms.",
+    href: "/reference/stats",
+    keywords: ["Reference"],
+    exact: ["Stat reference"],
+  },
+  {
+    id: "heading:reference-stats:all-stats",
+    kind: "heading",
+    title: "All stats",
+    summary:
+      "All stats in Stat reference. Schema-derived API reference for every statistical transform: after_stat columns and compatible geoms.",
+    href: "/reference/stats#all-stats",
+    keywords: ["Stat reference", "Reference"],
+    exact: ["All stats"],
+  },
+  {
+    id: "heading:reference-stats:how-to-set",
+    kind: "heading",
+    title: "How to set a stat",
+    summary:
+      "How to set a stat in Stat reference. Schema-derived API reference for every statistical transform: after_stat columns and compatible geoms.",
+    href: "/reference/stats#how-to-set",
+    keywords: ["Stat reference", "Reference"],
+    exact: ["How to set a stat"],
+  },
+  {
     id: "page:reference-interactions",
     kind: "page",
     title: "Search interactions",
@@ -4087,6 +4117,1626 @@ export const DOCS_SEARCH_INDEX = [
     exact: ["Allowed positions"],
   },
   {
+    id: "page:reference-stats-identity",
+    kind: "page",
+    title: "stat identity",
+    summary:
+      'stat "identity": Pass rows through unchanged. Default for most geoms: each mapped row becomes one mark with no aggregation.',
+    href: "/reference/stats/identity",
+    keywords: [],
+    exact: ["stat identity"],
+  },
+  {
+    id: "heading:reference-stats-identity:usage",
+    kind: "heading",
+    title: "Usage",
+    summary:
+      'Usage in stat identity. stat "identity": Pass rows through unchanged. Default for most geoms: each mapped row becomes one mark with no aggregation.',
+    href: "/reference/stats/identity#usage",
+    keywords: ["stat identity", "documentation"],
+    exact: ["Usage"],
+  },
+  {
+    id: "heading:reference-stats-identity:generated-columns",
+    kind: "heading",
+    title: "Generated columns (after_stat)",
+    summary:
+      'Generated columns (after_stat) in stat identity. stat "identity": Pass rows through unchanged. Default for most geoms: each mapped row becomes one mark with no aggregation.',
+    href: "/reference/stats/identity#generated-columns",
+    keywords: ["stat identity", "documentation"],
+    exact: ["Generated columns (after_stat)"],
+  },
+  {
+    id: "heading:reference-stats-identity:default-for",
+    kind: "heading",
+    title: "Default for geoms",
+    summary:
+      'Default for geoms in stat identity. stat "identity": Pass rows through unchanged. Default for most geoms: each mapped row becomes one mark with no aggregation.',
+    href: "/reference/stats/identity#default-for",
+    keywords: ["stat identity", "documentation"],
+    exact: ["Default for geoms"],
+  },
+  {
+    id: "heading:reference-stats-identity:compatible-geoms",
+    kind: "heading",
+    title: "Compatible geoms",
+    summary:
+      'Compatible geoms in stat identity. stat "identity": Pass rows through unchanged. Default for most geoms: each mapped row becomes one mark with no aggregation.',
+    href: "/reference/stats/identity#compatible-geoms",
+    keywords: ["stat identity", "documentation"],
+    exact: ["Compatible geoms"],
+  },
+  {
+    id: "heading:reference-stats-identity:examples",
+    kind: "heading",
+    title: "Examples",
+    summary:
+      'Examples in stat identity. stat "identity": Pass rows through unchanged. Default for most geoms: each mapped row becomes one mark with no aggregation.',
+    href: "/reference/stats/identity#examples",
+    keywords: ["stat identity", "documentation"],
+    exact: ["Examples"],
+  },
+  {
+    id: "page:reference-stats-unique",
+    kind: "page",
+    title: "stat unique",
+    summary:
+      'stat "unique": Keep one row per distinct mapped (x, y) pair (and group). Use when duplicate coordinates would overplot; default for none.',
+    href: "/reference/stats/unique",
+    keywords: [],
+    exact: ["stat unique"],
+  },
+  {
+    id: "heading:reference-stats-unique:usage",
+    kind: "heading",
+    title: "Usage",
+    summary:
+      'Usage in stat unique. stat "unique": Keep one row per distinct mapped (x, y) pair (and group). Use when duplicate coordinates would overplot; default for none.',
+    href: "/reference/stats/unique#usage",
+    keywords: ["stat unique", "documentation"],
+    exact: ["Usage"],
+  },
+  {
+    id: "heading:reference-stats-unique:generated-columns",
+    kind: "heading",
+    title: "Generated columns (after_stat)",
+    summary:
+      'Generated columns (after_stat) in stat unique. stat "unique": Keep one row per distinct mapped (x, y) pair (and group). Use when duplicate coordinates would overplot; default for none.',
+    href: "/reference/stats/unique#generated-columns",
+    keywords: ["stat unique", "documentation"],
+    exact: ["Generated columns (after_stat)"],
+  },
+  {
+    id: "heading:reference-stats-unique:default-for",
+    kind: "heading",
+    title: "Default for geoms",
+    summary:
+      'Default for geoms in stat unique. stat "unique": Keep one row per distinct mapped (x, y) pair (and group). Use when duplicate coordinates would overplot; default for none.',
+    href: "/reference/stats/unique#default-for",
+    keywords: ["stat unique", "documentation"],
+    exact: ["Default for geoms"],
+  },
+  {
+    id: "heading:reference-stats-unique:compatible-geoms",
+    kind: "heading",
+    title: "Compatible geoms",
+    summary:
+      'Compatible geoms in stat unique. stat "unique": Keep one row per distinct mapped (x, y) pair (and group). Use when duplicate coordinates would overplot; default for none.',
+    href: "/reference/stats/unique#compatible-geoms",
+    keywords: ["stat unique", "documentation"],
+    exact: ["Compatible geoms"],
+  },
+  {
+    id: "heading:reference-stats-unique:examples",
+    kind: "heading",
+    title: "Examples",
+    summary:
+      'Examples in stat unique. stat "unique": Keep one row per distinct mapped (x, y) pair (and group). Use when duplicate coordinates would overplot; default for none.',
+    href: "/reference/stats/unique#examples",
+    keywords: ["stat unique", "documentation"],
+    exact: ["Examples"],
+  },
+  {
+    id: "page:reference-stats-manual",
+    kind: "page",
+    title: "stat manual",
+    summary:
+      'stat "manual": Author-supplied after_stat values via params — skip automatic transforms when you already computed summaries.',
+    href: "/reference/stats/manual",
+    keywords: [],
+    exact: ["stat manual"],
+  },
+  {
+    id: "heading:reference-stats-manual:usage",
+    kind: "heading",
+    title: "Usage",
+    summary:
+      'Usage in stat manual. stat "manual": Author-supplied after_stat values via params — skip automatic transforms when you already computed summaries.',
+    href: "/reference/stats/manual#usage",
+    keywords: ["stat manual", "documentation"],
+    exact: ["Usage"],
+  },
+  {
+    id: "heading:reference-stats-manual:generated-columns",
+    kind: "heading",
+    title: "Generated columns (after_stat)",
+    summary:
+      'Generated columns (after_stat) in stat manual. stat "manual": Author-supplied after_stat values via params — skip automatic transforms when you already computed summaries.',
+    href: "/reference/stats/manual#generated-columns",
+    keywords: ["stat manual", "documentation"],
+    exact: ["Generated columns (after_stat)"],
+  },
+  {
+    id: "heading:reference-stats-manual:default-for",
+    kind: "heading",
+    title: "Default for geoms",
+    summary:
+      'Default for geoms in stat manual. stat "manual": Author-supplied after_stat values via params — skip automatic transforms when you already computed summaries.',
+    href: "/reference/stats/manual#default-for",
+    keywords: ["stat manual", "documentation"],
+    exact: ["Default for geoms"],
+  },
+  {
+    id: "heading:reference-stats-manual:compatible-geoms",
+    kind: "heading",
+    title: "Compatible geoms",
+    summary:
+      'Compatible geoms in stat manual. stat "manual": Author-supplied after_stat values via params — skip automatic transforms when you already computed summaries.',
+    href: "/reference/stats/manual#compatible-geoms",
+    keywords: ["stat manual", "documentation"],
+    exact: ["Compatible geoms"],
+  },
+  {
+    id: "heading:reference-stats-manual:examples",
+    kind: "heading",
+    title: "Examples",
+    summary:
+      'Examples in stat manual. stat "manual": Author-supplied after_stat values via params — skip automatic transforms when you already computed summaries.',
+    href: "/reference/stats/manual#examples",
+    keywords: ["stat manual", "documentation"],
+    exact: ["Examples"],
+  },
+  {
+    id: "page:reference-stats-connect",
+    kind: "page",
+    title: "stat connect",
+    summary:
+      'stat "connect": Expand successive points into connection vertices (linear, hv, vh, mid) for stepped or path-style joins between observations.',
+    href: "/reference/stats/connect",
+    keywords: [],
+    exact: ["stat connect"],
+  },
+  {
+    id: "heading:reference-stats-connect:usage",
+    kind: "heading",
+    title: "Usage",
+    summary:
+      'Usage in stat connect. stat "connect": Expand successive points into connection vertices (linear, hv, vh, mid) for stepped or path-style joins between observations.',
+    href: "/reference/stats/connect#usage",
+    keywords: ["stat connect", "documentation"],
+    exact: ["Usage"],
+  },
+  {
+    id: "heading:reference-stats-connect:generated-columns",
+    kind: "heading",
+    title: "Generated columns (after_stat)",
+    summary:
+      'Generated columns (after_stat) in stat connect. stat "connect": Expand successive points into connection vertices (linear, hv, vh, mid) for stepped or path-style joins between observations.',
+    href: "/reference/stats/connect#generated-columns",
+    keywords: ["stat connect", "documentation"],
+    exact: ["Generated columns (after_stat)"],
+  },
+  {
+    id: "heading:reference-stats-connect:default-for",
+    kind: "heading",
+    title: "Default for geoms",
+    summary:
+      'Default for geoms in stat connect. stat "connect": Expand successive points into connection vertices (linear, hv, vh, mid) for stepped or path-style joins between observations.',
+    href: "/reference/stats/connect#default-for",
+    keywords: ["stat connect", "documentation"],
+    exact: ["Default for geoms"],
+  },
+  {
+    id: "heading:reference-stats-connect:compatible-geoms",
+    kind: "heading",
+    title: "Compatible geoms",
+    summary:
+      'Compatible geoms in stat connect. stat "connect": Expand successive points into connection vertices (linear, hv, vh, mid) for stepped or path-style joins between observations.',
+    href: "/reference/stats/connect#compatible-geoms",
+    keywords: ["stat connect", "documentation"],
+    exact: ["Compatible geoms"],
+  },
+  {
+    id: "heading:reference-stats-connect:examples",
+    kind: "heading",
+    title: "Examples",
+    summary:
+      'Examples in stat connect. stat "connect": Expand successive points into connection vertices (linear, hv, vh, mid) for stepped or path-style joins between observations.',
+    href: "/reference/stats/connect#examples",
+    keywords: ["stat connect", "documentation"],
+    exact: ["Examples"],
+  },
+  {
+    id: "page:reference-stats-count",
+    kind: "page",
+    title: "stat count",
+    summary:
+      'stat "count": Count rows (or sum weights) per distinct x within each group. Default for geom_bar; publishes after_stat count.',
+    href: "/reference/stats/count",
+    keywords: [],
+    exact: ["stat count"],
+  },
+  {
+    id: "heading:reference-stats-count:usage",
+    kind: "heading",
+    title: "Usage",
+    summary:
+      'Usage in stat count. stat "count": Count rows (or sum weights) per distinct x within each group. Default for geom_bar; publishes after_stat count.',
+    href: "/reference/stats/count#usage",
+    keywords: ["stat count", "documentation"],
+    exact: ["Usage"],
+  },
+  {
+    id: "heading:reference-stats-count:generated-columns",
+    kind: "heading",
+    title: "Generated columns (after_stat)",
+    summary:
+      'Generated columns (after_stat) in stat count. stat "count": Count rows (or sum weights) per distinct x within each group. Default for geom_bar; publishes after_stat count.',
+    href: "/reference/stats/count#generated-columns",
+    keywords: ["stat count", "documentation"],
+    exact: ["Generated columns (after_stat)"],
+  },
+  {
+    id: "heading:reference-stats-count:default-for",
+    kind: "heading",
+    title: "Default for geoms",
+    summary:
+      'Default for geoms in stat count. stat "count": Count rows (or sum weights) per distinct x within each group. Default for geom_bar; publishes after_stat count.',
+    href: "/reference/stats/count#default-for",
+    keywords: ["stat count", "documentation"],
+    exact: ["Default for geoms"],
+  },
+  {
+    id: "heading:reference-stats-count:compatible-geoms",
+    kind: "heading",
+    title: "Compatible geoms",
+    summary:
+      'Compatible geoms in stat count. stat "count": Count rows (or sum weights) per distinct x within each group. Default for geom_bar; publishes after_stat count.',
+    href: "/reference/stats/count#compatible-geoms",
+    keywords: ["stat count", "documentation"],
+    exact: ["Compatible geoms"],
+  },
+  {
+    id: "heading:reference-stats-count:examples",
+    kind: "heading",
+    title: "Examples",
+    summary:
+      'Examples in stat count. stat "count": Count rows (or sum weights) per distinct x within each group. Default for geom_bar; publishes after_stat count.',
+    href: "/reference/stats/count#examples",
+    keywords: ["stat count", "documentation"],
+    exact: ["Examples"],
+  },
+  {
+    id: "page:reference-stats-bin",
+    kind: "page",
+    title: "stat bin",
+    summary:
+      'stat "bin": Bin continuous x into histogram breaks. Publishes count, density, ncount, and ndensity; default for histogram and freqpoly.',
+    href: "/reference/stats/bin",
+    keywords: [],
+    exact: ["stat bin"],
+  },
+  {
+    id: "heading:reference-stats-bin:usage",
+    kind: "heading",
+    title: "Usage",
+    summary:
+      'Usage in stat bin. stat "bin": Bin continuous x into histogram breaks. Publishes count, density, ncount, and ndensity; default for histogram and freqpoly.',
+    href: "/reference/stats/bin#usage",
+    keywords: ["stat bin", "documentation"],
+    exact: ["Usage"],
+  },
+  {
+    id: "heading:reference-stats-bin:generated-columns",
+    kind: "heading",
+    title: "Generated columns (after_stat)",
+    summary:
+      'Generated columns (after_stat) in stat bin. stat "bin": Bin continuous x into histogram breaks. Publishes count, density, ncount, and ndensity; default for histogram and freqpoly.',
+    href: "/reference/stats/bin#generated-columns",
+    keywords: ["stat bin", "documentation"],
+    exact: ["Generated columns (after_stat)"],
+  },
+  {
+    id: "heading:reference-stats-bin:default-for",
+    kind: "heading",
+    title: "Default for geoms",
+    summary:
+      'Default for geoms in stat bin. stat "bin": Bin continuous x into histogram breaks. Publishes count, density, ncount, and ndensity; default for histogram and freqpoly.',
+    href: "/reference/stats/bin#default-for",
+    keywords: ["stat bin", "documentation"],
+    exact: ["Default for geoms"],
+  },
+  {
+    id: "heading:reference-stats-bin:compatible-geoms",
+    kind: "heading",
+    title: "Compatible geoms",
+    summary:
+      'Compatible geoms in stat bin. stat "bin": Bin continuous x into histogram breaks. Publishes count, density, ncount, and ndensity; default for histogram and freqpoly.',
+    href: "/reference/stats/bin#compatible-geoms",
+    keywords: ["stat bin", "documentation"],
+    exact: ["Compatible geoms"],
+  },
+  {
+    id: "heading:reference-stats-bin:examples",
+    kind: "heading",
+    title: "Examples",
+    summary:
+      'Examples in stat bin. stat "bin": Bin continuous x into histogram breaks. Publishes count, density, ncount, and ndensity; default for histogram and freqpoly.',
+    href: "/reference/stats/bin#examples",
+    keywords: ["stat bin", "documentation"],
+    exact: ["Examples"],
+  },
+  {
+    id: "page:reference-stats-bin_hex",
+    kind: "page",
+    title: "stat bin_hex",
+    summary:
+      'stat "bin_hex": Hexagonal 2D binning over continuous x and y. Publishes count/density columns for geom_hex heatmaps.',
+    href: "/reference/stats/bin_hex",
+    keywords: [],
+    exact: ["stat bin_hex"],
+  },
+  {
+    id: "heading:reference-stats-bin_hex:usage",
+    kind: "heading",
+    title: "Usage",
+    summary:
+      'Usage in stat bin_hex. stat "bin_hex": Hexagonal 2D binning over continuous x and y. Publishes count/density columns for geom_hex heatmaps.',
+    href: "/reference/stats/bin_hex#usage",
+    keywords: ["stat bin_hex", "documentation"],
+    exact: ["Usage"],
+  },
+  {
+    id: "heading:reference-stats-bin_hex:generated-columns",
+    kind: "heading",
+    title: "Generated columns (after_stat)",
+    summary:
+      'Generated columns (after_stat) in stat bin_hex. stat "bin_hex": Hexagonal 2D binning over continuous x and y. Publishes count/density columns for geom_hex heatmaps.',
+    href: "/reference/stats/bin_hex#generated-columns",
+    keywords: ["stat bin_hex", "documentation"],
+    exact: ["Generated columns (after_stat)"],
+  },
+  {
+    id: "heading:reference-stats-bin_hex:default-for",
+    kind: "heading",
+    title: "Default for geoms",
+    summary:
+      'Default for geoms in stat bin_hex. stat "bin_hex": Hexagonal 2D binning over continuous x and y. Publishes count/density columns for geom_hex heatmaps.',
+    href: "/reference/stats/bin_hex#default-for",
+    keywords: ["stat bin_hex", "documentation"],
+    exact: ["Default for geoms"],
+  },
+  {
+    id: "heading:reference-stats-bin_hex:compatible-geoms",
+    kind: "heading",
+    title: "Compatible geoms",
+    summary:
+      'Compatible geoms in stat bin_hex. stat "bin_hex": Hexagonal 2D binning over continuous x and y. Publishes count/density columns for geom_hex heatmaps.',
+    href: "/reference/stats/bin_hex#compatible-geoms",
+    keywords: ["stat bin_hex", "documentation"],
+    exact: ["Compatible geoms"],
+  },
+  {
+    id: "page:reference-stats-bin_2d",
+    kind: "page",
+    title: "stat bin_2d",
+    summary:
+      'stat "bin_2d": Rectangular 2D binning over continuous x and y. Publishes count/density and bin edges for geom_bin_2d tiles.',
+    href: "/reference/stats/bin_2d",
+    keywords: [],
+    exact: ["stat bin_2d"],
+  },
+  {
+    id: "heading:reference-stats-bin_2d:usage",
+    kind: "heading",
+    title: "Usage",
+    summary:
+      'Usage in stat bin_2d. stat "bin_2d": Rectangular 2D binning over continuous x and y. Publishes count/density and bin edges for geom_bin_2d tiles.',
+    href: "/reference/stats/bin_2d#usage",
+    keywords: ["stat bin_2d", "documentation"],
+    exact: ["Usage"],
+  },
+  {
+    id: "heading:reference-stats-bin_2d:generated-columns",
+    kind: "heading",
+    title: "Generated columns (after_stat)",
+    summary:
+      'Generated columns (after_stat) in stat bin_2d. stat "bin_2d": Rectangular 2D binning over continuous x and y. Publishes count/density and bin edges for geom_bin_2d tiles.',
+    href: "/reference/stats/bin_2d#generated-columns",
+    keywords: ["stat bin_2d", "documentation"],
+    exact: ["Generated columns (after_stat)"],
+  },
+  {
+    id: "heading:reference-stats-bin_2d:default-for",
+    kind: "heading",
+    title: "Default for geoms",
+    summary:
+      'Default for geoms in stat bin_2d. stat "bin_2d": Rectangular 2D binning over continuous x and y. Publishes count/density and bin edges for geom_bin_2d tiles.',
+    href: "/reference/stats/bin_2d#default-for",
+    keywords: ["stat bin_2d", "documentation"],
+    exact: ["Default for geoms"],
+  },
+  {
+    id: "heading:reference-stats-bin_2d:compatible-geoms",
+    kind: "heading",
+    title: "Compatible geoms",
+    summary:
+      'Compatible geoms in stat bin_2d. stat "bin_2d": Rectangular 2D binning over continuous x and y. Publishes count/density and bin edges for geom_bin_2d tiles.',
+    href: "/reference/stats/bin_2d#compatible-geoms",
+    keywords: ["stat bin_2d", "documentation"],
+    exact: ["Compatible geoms"],
+  },
+  {
+    id: "heading:reference-stats-bin_2d:examples",
+    kind: "heading",
+    title: "Examples",
+    summary:
+      'Examples in stat bin_2d. stat "bin_2d": Rectangular 2D binning over continuous x and y. Publishes count/density and bin edges for geom_bin_2d tiles.',
+    href: "/reference/stats/bin_2d#examples",
+    keywords: ["stat bin_2d", "documentation"],
+    exact: ["Examples"],
+  },
+  {
+    id: "page:reference-stats-smooth",
+    kind: "page",
+    title: "stat smooth",
+    summary:
+      'stat "smooth": Fit a smoother (lm or loess) and evaluate along x. Publishes y, ymin, ymax, and se; default for geom_smooth.',
+    href: "/reference/stats/smooth",
+    keywords: [],
+    exact: ["stat smooth"],
+  },
+  {
+    id: "heading:reference-stats-smooth:usage",
+    kind: "heading",
+    title: "Usage",
+    summary:
+      'Usage in stat smooth. stat "smooth": Fit a smoother (lm or loess) and evaluate along x. Publishes y, ymin, ymax, and se; default for geom_smooth.',
+    href: "/reference/stats/smooth#usage",
+    keywords: ["stat smooth", "documentation"],
+    exact: ["Usage"],
+  },
+  {
+    id: "heading:reference-stats-smooth:generated-columns",
+    kind: "heading",
+    title: "Generated columns (after_stat)",
+    summary:
+      'Generated columns (after_stat) in stat smooth. stat "smooth": Fit a smoother (lm or loess) and evaluate along x. Publishes y, ymin, ymax, and se; default for geom_smooth.',
+    href: "/reference/stats/smooth#generated-columns",
+    keywords: ["stat smooth", "documentation"],
+    exact: ["Generated columns (after_stat)"],
+  },
+  {
+    id: "heading:reference-stats-smooth:default-for",
+    kind: "heading",
+    title: "Default for geoms",
+    summary:
+      'Default for geoms in stat smooth. stat "smooth": Fit a smoother (lm or loess) and evaluate along x. Publishes y, ymin, ymax, and se; default for geom_smooth.',
+    href: "/reference/stats/smooth#default-for",
+    keywords: ["stat smooth", "documentation"],
+    exact: ["Default for geoms"],
+  },
+  {
+    id: "heading:reference-stats-smooth:compatible-geoms",
+    kind: "heading",
+    title: "Compatible geoms",
+    summary:
+      'Compatible geoms in stat smooth. stat "smooth": Fit a smoother (lm or loess) and evaluate along x. Publishes y, ymin, ymax, and se; default for geom_smooth.',
+    href: "/reference/stats/smooth#compatible-geoms",
+    keywords: ["stat smooth", "documentation"],
+    exact: ["Compatible geoms"],
+  },
+  {
+    id: "heading:reference-stats-smooth:examples",
+    kind: "heading",
+    title: "Examples",
+    summary:
+      'Examples in stat smooth. stat "smooth": Fit a smoother (lm or loess) and evaluate along x. Publishes y, ymin, ymax, and se; default for geom_smooth.',
+    href: "/reference/stats/smooth#examples",
+    keywords: ["stat smooth", "documentation"],
+    exact: ["Examples"],
+  },
+  {
+    id: "page:reference-stats-quantile",
+    kind: "page",
+    title: "stat quantile",
+    summary:
+      'stat "quantile": Estimate conditional quantiles of y given x. Publishes y at each requested probability; default for geom_quantile.',
+    href: "/reference/stats/quantile",
+    keywords: [],
+    exact: ["stat quantile"],
+  },
+  {
+    id: "heading:reference-stats-quantile:usage",
+    kind: "heading",
+    title: "Usage",
+    summary:
+      'Usage in stat quantile. stat "quantile": Estimate conditional quantiles of y given x. Publishes y at each requested probability; default for geom_quantile.',
+    href: "/reference/stats/quantile#usage",
+    keywords: ["stat quantile", "documentation"],
+    exact: ["Usage"],
+  },
+  {
+    id: "heading:reference-stats-quantile:generated-columns",
+    kind: "heading",
+    title: "Generated columns (after_stat)",
+    summary:
+      'Generated columns (after_stat) in stat quantile. stat "quantile": Estimate conditional quantiles of y given x. Publishes y at each requested probability; default for geom_quantile.',
+    href: "/reference/stats/quantile#generated-columns",
+    keywords: ["stat quantile", "documentation"],
+    exact: ["Generated columns (after_stat)"],
+  },
+  {
+    id: "heading:reference-stats-quantile:default-for",
+    kind: "heading",
+    title: "Default for geoms",
+    summary:
+      'Default for geoms in stat quantile. stat "quantile": Estimate conditional quantiles of y given x. Publishes y at each requested probability; default for geom_quantile.',
+    href: "/reference/stats/quantile#default-for",
+    keywords: ["stat quantile", "documentation"],
+    exact: ["Default for geoms"],
+  },
+  {
+    id: "heading:reference-stats-quantile:compatible-geoms",
+    kind: "heading",
+    title: "Compatible geoms",
+    summary:
+      'Compatible geoms in stat quantile. stat "quantile": Estimate conditional quantiles of y given x. Publishes y at each requested probability; default for geom_quantile.',
+    href: "/reference/stats/quantile#compatible-geoms",
+    keywords: ["stat quantile", "documentation"],
+    exact: ["Compatible geoms"],
+  },
+  {
+    id: "heading:reference-stats-quantile:examples",
+    kind: "heading",
+    title: "Examples",
+    summary:
+      'Examples in stat quantile. stat "quantile": Estimate conditional quantiles of y given x. Publishes y at each requested probability; default for geom_quantile.',
+    href: "/reference/stats/quantile#examples",
+    keywords: ["stat quantile", "documentation"],
+    exact: ["Examples"],
+  },
+  {
+    id: "page:reference-stats-boxplot",
+    kind: "page",
+    title: "stat boxplot",
+    summary:
+      'stat "boxplot": Five-number summary per group (hinges and whiskers). Publishes ymin, lower, middle, upper, ymax; default for geom_boxplot.',
+    href: "/reference/stats/boxplot",
+    keywords: [],
+    exact: ["stat boxplot"],
+  },
+  {
+    id: "heading:reference-stats-boxplot:usage",
+    kind: "heading",
+    title: "Usage",
+    summary:
+      'Usage in stat boxplot. stat "boxplot": Five-number summary per group (hinges and whiskers). Publishes ymin, lower, middle, upper, ymax; default for geom_boxplot.',
+    href: "/reference/stats/boxplot#usage",
+    keywords: ["stat boxplot", "documentation"],
+    exact: ["Usage"],
+  },
+  {
+    id: "heading:reference-stats-boxplot:generated-columns",
+    kind: "heading",
+    title: "Generated columns (after_stat)",
+    summary:
+      'Generated columns (after_stat) in stat boxplot. stat "boxplot": Five-number summary per group (hinges and whiskers). Publishes ymin, lower, middle, upper, ymax; default for geom_boxplot.',
+    href: "/reference/stats/boxplot#generated-columns",
+    keywords: ["stat boxplot", "documentation"],
+    exact: ["Generated columns (after_stat)"],
+  },
+  {
+    id: "heading:reference-stats-boxplot:default-for",
+    kind: "heading",
+    title: "Default for geoms",
+    summary:
+      'Default for geoms in stat boxplot. stat "boxplot": Five-number summary per group (hinges and whiskers). Publishes ymin, lower, middle, upper, ymax; default for geom_boxplot.',
+    href: "/reference/stats/boxplot#default-for",
+    keywords: ["stat boxplot", "documentation"],
+    exact: ["Default for geoms"],
+  },
+  {
+    id: "heading:reference-stats-boxplot:compatible-geoms",
+    kind: "heading",
+    title: "Compatible geoms",
+    summary:
+      'Compatible geoms in stat boxplot. stat "boxplot": Five-number summary per group (hinges and whiskers). Publishes ymin, lower, middle, upper, ymax; default for geom_boxplot.',
+    href: "/reference/stats/boxplot#compatible-geoms",
+    keywords: ["stat boxplot", "documentation"],
+    exact: ["Compatible geoms"],
+  },
+  {
+    id: "heading:reference-stats-boxplot:examples",
+    kind: "heading",
+    title: "Examples",
+    summary:
+      'Examples in stat boxplot. stat "boxplot": Five-number summary per group (hinges and whiskers). Publishes ymin, lower, middle, upper, ymax; default for geom_boxplot.',
+    href: "/reference/stats/boxplot#examples",
+    keywords: ["stat boxplot", "documentation"],
+    exact: ["Examples"],
+  },
+  {
+    id: "page:reference-stats-density",
+    kind: "page",
+    title: "stat density",
+    summary:
+      'stat "density": 1D Gaussian kernel density estimate along x. Publishes density, count, scaled, and ndensity; default for geom_density.',
+    href: "/reference/stats/density",
+    keywords: [],
+    exact: ["stat density"],
+  },
+  {
+    id: "heading:reference-stats-density:usage",
+    kind: "heading",
+    title: "Usage",
+    summary:
+      'Usage in stat density. stat "density": 1D Gaussian kernel density estimate along x. Publishes density, count, scaled, and ndensity; default for geom_density.',
+    href: "/reference/stats/density#usage",
+    keywords: ["stat density", "documentation"],
+    exact: ["Usage"],
+  },
+  {
+    id: "heading:reference-stats-density:generated-columns",
+    kind: "heading",
+    title: "Generated columns (after_stat)",
+    summary:
+      'Generated columns (after_stat) in stat density. stat "density": 1D Gaussian kernel density estimate along x. Publishes density, count, scaled, and ndensity; default for geom_density.',
+    href: "/reference/stats/density#generated-columns",
+    keywords: ["stat density", "documentation"],
+    exact: ["Generated columns (after_stat)"],
+  },
+  {
+    id: "heading:reference-stats-density:default-for",
+    kind: "heading",
+    title: "Default for geoms",
+    summary:
+      'Default for geoms in stat density. stat "density": 1D Gaussian kernel density estimate along x. Publishes density, count, scaled, and ndensity; default for geom_density.',
+    href: "/reference/stats/density#default-for",
+    keywords: ["stat density", "documentation"],
+    exact: ["Default for geoms"],
+  },
+  {
+    id: "heading:reference-stats-density:compatible-geoms",
+    kind: "heading",
+    title: "Compatible geoms",
+    summary:
+      'Compatible geoms in stat density. stat "density": 1D Gaussian kernel density estimate along x. Publishes density, count, scaled, and ndensity; default for geom_density.',
+    href: "/reference/stats/density#compatible-geoms",
+    keywords: ["stat density", "documentation"],
+    exact: ["Compatible geoms"],
+  },
+  {
+    id: "heading:reference-stats-density:examples",
+    kind: "heading",
+    title: "Examples",
+    summary:
+      'Examples in stat density. stat "density": 1D Gaussian kernel density estimate along x. Publishes density, count, scaled, and ndensity; default for geom_density.',
+    href: "/reference/stats/density#examples",
+    keywords: ["stat density", "documentation"],
+    exact: ["Examples"],
+  },
+  {
+    id: "page:reference-stats-summary",
+    kind: "page",
+    title: "stat summary",
+    summary:
+      'stat "summary": Collapse each discrete-x group to one summary (default mean ± se). Publishes y, ymin, ymax for error-style geoms.',
+    href: "/reference/stats/summary",
+    keywords: [],
+    exact: ["stat summary"],
+  },
+  {
+    id: "heading:reference-stats-summary:usage",
+    kind: "heading",
+    title: "Usage",
+    summary:
+      'Usage in stat summary. stat "summary": Collapse each discrete-x group to one summary (default mean ± se). Publishes y, ymin, ymax for error-style geoms.',
+    href: "/reference/stats/summary#usage",
+    keywords: ["stat summary", "documentation"],
+    exact: ["Usage"],
+  },
+  {
+    id: "heading:reference-stats-summary:generated-columns",
+    kind: "heading",
+    title: "Generated columns (after_stat)",
+    summary:
+      'Generated columns (after_stat) in stat summary. stat "summary": Collapse each discrete-x group to one summary (default mean ± se). Publishes y, ymin, ymax for error-style geoms.',
+    href: "/reference/stats/summary#generated-columns",
+    keywords: ["stat summary", "documentation"],
+    exact: ["Generated columns (after_stat)"],
+  },
+  {
+    id: "heading:reference-stats-summary:default-for",
+    kind: "heading",
+    title: "Default for geoms",
+    summary:
+      'Default for geoms in stat summary. stat "summary": Collapse each discrete-x group to one summary (default mean ± se). Publishes y, ymin, ymax for error-style geoms.',
+    href: "/reference/stats/summary#default-for",
+    keywords: ["stat summary", "documentation"],
+    exact: ["Default for geoms"],
+  },
+  {
+    id: "heading:reference-stats-summary:compatible-geoms",
+    kind: "heading",
+    title: "Compatible geoms",
+    summary:
+      'Compatible geoms in stat summary. stat "summary": Collapse each discrete-x group to one summary (default mean ± se). Publishes y, ymin, ymax for error-style geoms.',
+    href: "/reference/stats/summary#compatible-geoms",
+    keywords: ["stat summary", "documentation"],
+    exact: ["Compatible geoms"],
+  },
+  {
+    id: "heading:reference-stats-summary:examples",
+    kind: "heading",
+    title: "Examples",
+    summary:
+      'Examples in stat summary. stat "summary": Collapse each discrete-x group to one summary (default mean ± se). Publishes y, ymin, ymax for error-style geoms.',
+    href: "/reference/stats/summary#examples",
+    keywords: ["stat summary", "documentation"],
+    exact: ["Examples"],
+  },
+  {
+    id: "page:reference-stats-sum",
+    kind: "page",
+    title: "stat sum",
+    summary:
+      'stat "sum": Count overlapping points at each (x, y) cell for geom_count. Publishes n and prop (not y).',
+    href: "/reference/stats/sum",
+    keywords: [],
+    exact: ["stat sum"],
+  },
+  {
+    id: "heading:reference-stats-sum:usage",
+    kind: "heading",
+    title: "Usage",
+    summary:
+      'Usage in stat sum. stat "sum": Count overlapping points at each (x, y) cell for geom_count. Publishes n and prop (not y).',
+    href: "/reference/stats/sum#usage",
+    keywords: ["stat sum", "documentation"],
+    exact: ["Usage"],
+  },
+  {
+    id: "heading:reference-stats-sum:generated-columns",
+    kind: "heading",
+    title: "Generated columns (after_stat)",
+    summary:
+      'Generated columns (after_stat) in stat sum. stat "sum": Count overlapping points at each (x, y) cell for geom_count. Publishes n and prop (not y).',
+    href: "/reference/stats/sum#generated-columns",
+    keywords: ["stat sum", "documentation"],
+    exact: ["Generated columns (after_stat)"],
+  },
+  {
+    id: "heading:reference-stats-sum:default-for",
+    kind: "heading",
+    title: "Default for geoms",
+    summary:
+      'Default for geoms in stat sum. stat "sum": Count overlapping points at each (x, y) cell for geom_count. Publishes n and prop (not y).',
+    href: "/reference/stats/sum#default-for",
+    keywords: ["stat sum", "documentation"],
+    exact: ["Default for geoms"],
+  },
+  {
+    id: "heading:reference-stats-sum:compatible-geoms",
+    kind: "heading",
+    title: "Compatible geoms",
+    summary:
+      'Compatible geoms in stat sum. stat "sum": Count overlapping points at each (x, y) cell for geom_count. Publishes n and prop (not y).',
+    href: "/reference/stats/sum#compatible-geoms",
+    keywords: ["stat sum", "documentation"],
+    exact: ["Compatible geoms"],
+  },
+  {
+    id: "page:reference-stats-ydensity",
+    kind: "page",
+    title: "stat ydensity",
+    summary:
+      'stat "ydensity": Kernel density along y for violin shapes. Publishes density, count, scaled, violinwidth, and y; default for geom_violin.',
+    href: "/reference/stats/ydensity",
+    keywords: [],
+    exact: ["stat ydensity"],
+  },
+  {
+    id: "heading:reference-stats-ydensity:usage",
+    kind: "heading",
+    title: "Usage",
+    summary:
+      'Usage in stat ydensity. stat "ydensity": Kernel density along y for violin shapes. Publishes density, count, scaled, violinwidth, and y; default for geom_violin.',
+    href: "/reference/stats/ydensity#usage",
+    keywords: ["stat ydensity", "documentation"],
+    exact: ["Usage"],
+  },
+  {
+    id: "heading:reference-stats-ydensity:generated-columns",
+    kind: "heading",
+    title: "Generated columns (after_stat)",
+    summary:
+      'Generated columns (after_stat) in stat ydensity. stat "ydensity": Kernel density along y for violin shapes. Publishes density, count, scaled, violinwidth, and y; default for geom_violin.',
+    href: "/reference/stats/ydensity#generated-columns",
+    keywords: ["stat ydensity", "documentation"],
+    exact: ["Generated columns (after_stat)"],
+  },
+  {
+    id: "heading:reference-stats-ydensity:default-for",
+    kind: "heading",
+    title: "Default for geoms",
+    summary:
+      'Default for geoms in stat ydensity. stat "ydensity": Kernel density along y for violin shapes. Publishes density, count, scaled, violinwidth, and y; default for geom_violin.',
+    href: "/reference/stats/ydensity#default-for",
+    keywords: ["stat ydensity", "documentation"],
+    exact: ["Default for geoms"],
+  },
+  {
+    id: "heading:reference-stats-ydensity:compatible-geoms",
+    kind: "heading",
+    title: "Compatible geoms",
+    summary:
+      'Compatible geoms in stat ydensity. stat "ydensity": Kernel density along y for violin shapes. Publishes density, count, scaled, violinwidth, and y; default for geom_violin.',
+    href: "/reference/stats/ydensity#compatible-geoms",
+    keywords: ["stat ydensity", "documentation"],
+    exact: ["Compatible geoms"],
+  },
+  {
+    id: "page:reference-stats-function",
+    kind: "page",
+    title: "stat function",
+    summary:
+      'stat "function": Evaluate a pure function on an x grid. Publishes y; default for geom_function when no data rows drive the mark.',
+    href: "/reference/stats/function",
+    keywords: [],
+    exact: ["stat function"],
+  },
+  {
+    id: "heading:reference-stats-function:usage",
+    kind: "heading",
+    title: "Usage",
+    summary:
+      'Usage in stat function. stat "function": Evaluate a pure function on an x grid. Publishes y; default for geom_function when no data rows drive the mark.',
+    href: "/reference/stats/function#usage",
+    keywords: ["stat function", "documentation"],
+    exact: ["Usage"],
+  },
+  {
+    id: "heading:reference-stats-function:generated-columns",
+    kind: "heading",
+    title: "Generated columns (after_stat)",
+    summary:
+      'Generated columns (after_stat) in stat function. stat "function": Evaluate a pure function on an x grid. Publishes y; default for geom_function when no data rows drive the mark.',
+    href: "/reference/stats/function#generated-columns",
+    keywords: ["stat function", "documentation"],
+    exact: ["Generated columns (after_stat)"],
+  },
+  {
+    id: "heading:reference-stats-function:default-for",
+    kind: "heading",
+    title: "Default for geoms",
+    summary:
+      'Default for geoms in stat function. stat "function": Evaluate a pure function on an x grid. Publishes y; default for geom_function when no data rows drive the mark.',
+    href: "/reference/stats/function#default-for",
+    keywords: ["stat function", "documentation"],
+    exact: ["Default for geoms"],
+  },
+  {
+    id: "heading:reference-stats-function:compatible-geoms",
+    kind: "heading",
+    title: "Compatible geoms",
+    summary:
+      'Compatible geoms in stat function. stat "function": Evaluate a pure function on an x grid. Publishes y; default for geom_function when no data rows drive the mark.',
+    href: "/reference/stats/function#compatible-geoms",
+    keywords: ["stat function", "documentation"],
+    exact: ["Compatible geoms"],
+  },
+  {
+    id: "heading:reference-stats-function:examples",
+    kind: "heading",
+    title: "Examples",
+    summary:
+      'Examples in stat function. stat "function": Evaluate a pure function on an x grid. Publishes y; default for geom_function when no data rows drive the mark.',
+    href: "/reference/stats/function#examples",
+    keywords: ["stat function", "documentation"],
+    exact: ["Examples"],
+  },
+  {
+    id: "page:reference-stats-ecdf",
+    kind: "page",
+    title: "stat ecdf",
+    summary:
+      'stat "ecdf": Empirical cumulative distribution F̂(x). Publishes ecdf; pair with step or path geoms for CDF plots.',
+    href: "/reference/stats/ecdf",
+    keywords: [],
+    exact: ["stat ecdf"],
+  },
+  {
+    id: "heading:reference-stats-ecdf:usage",
+    kind: "heading",
+    title: "Usage",
+    summary:
+      'Usage in stat ecdf. stat "ecdf": Empirical cumulative distribution F̂(x). Publishes ecdf; pair with step or path geoms for CDF plots.',
+    href: "/reference/stats/ecdf#usage",
+    keywords: ["stat ecdf", "documentation"],
+    exact: ["Usage"],
+  },
+  {
+    id: "heading:reference-stats-ecdf:generated-columns",
+    kind: "heading",
+    title: "Generated columns (after_stat)",
+    summary:
+      'Generated columns (after_stat) in stat ecdf. stat "ecdf": Empirical cumulative distribution F̂(x). Publishes ecdf; pair with step or path geoms for CDF plots.',
+    href: "/reference/stats/ecdf#generated-columns",
+    keywords: ["stat ecdf", "documentation"],
+    exact: ["Generated columns (after_stat)"],
+  },
+  {
+    id: "heading:reference-stats-ecdf:default-for",
+    kind: "heading",
+    title: "Default for geoms",
+    summary:
+      'Default for geoms in stat ecdf. stat "ecdf": Empirical cumulative distribution F̂(x). Publishes ecdf; pair with step or path geoms for CDF plots.',
+    href: "/reference/stats/ecdf#default-for",
+    keywords: ["stat ecdf", "documentation"],
+    exact: ["Default for geoms"],
+  },
+  {
+    id: "heading:reference-stats-ecdf:compatible-geoms",
+    kind: "heading",
+    title: "Compatible geoms",
+    summary:
+      'Compatible geoms in stat ecdf. stat "ecdf": Empirical cumulative distribution F̂(x). Publishes ecdf; pair with step or path geoms for CDF plots.',
+    href: "/reference/stats/ecdf#compatible-geoms",
+    keywords: ["stat ecdf", "documentation"],
+    exact: ["Compatible geoms"],
+  },
+  {
+    id: "heading:reference-stats-ecdf:examples",
+    kind: "heading",
+    title: "Examples",
+    summary:
+      'Examples in stat ecdf. stat "ecdf": Empirical cumulative distribution F̂(x). Publishes ecdf; pair with step or path geoms for CDF plots.',
+    href: "/reference/stats/ecdf#examples",
+    keywords: ["stat ecdf", "documentation"],
+    exact: ["Examples"],
+  },
+  {
+    id: "page:reference-stats-summary_bin",
+    kind: "page",
+    title: "stat summary_bin",
+    summary:
+      'stat "summary_bin": Bin continuous x, then summarize y in each bin (mean ± se by default). Publishes y, ymin, ymax for binned summaries.',
+    href: "/reference/stats/summary_bin",
+    keywords: [],
+    exact: ["stat summary_bin"],
+  },
+  {
+    id: "heading:reference-stats-summary_bin:usage",
+    kind: "heading",
+    title: "Usage",
+    summary:
+      'Usage in stat summary_bin. stat "summary_bin": Bin continuous x, then summarize y in each bin (mean ± se by default). Publishes y, ymin, ymax for binned summaries.',
+    href: "/reference/stats/summary_bin#usage",
+    keywords: ["stat summary_bin", "documentation"],
+    exact: ["Usage"],
+  },
+  {
+    id: "heading:reference-stats-summary_bin:generated-columns",
+    kind: "heading",
+    title: "Generated columns (after_stat)",
+    summary:
+      'Generated columns (after_stat) in stat summary_bin. stat "summary_bin": Bin continuous x, then summarize y in each bin (mean ± se by default). Publishes y, ymin, ymax for binned summaries.',
+    href: "/reference/stats/summary_bin#generated-columns",
+    keywords: ["stat summary_bin", "documentation"],
+    exact: ["Generated columns (after_stat)"],
+  },
+  {
+    id: "heading:reference-stats-summary_bin:default-for",
+    kind: "heading",
+    title: "Default for geoms",
+    summary:
+      'Default for geoms in stat summary_bin. stat "summary_bin": Bin continuous x, then summarize y in each bin (mean ± se by default). Publishes y, ymin, ymax for binned summaries.',
+    href: "/reference/stats/summary_bin#default-for",
+    keywords: ["stat summary_bin", "documentation"],
+    exact: ["Default for geoms"],
+  },
+  {
+    id: "heading:reference-stats-summary_bin:compatible-geoms",
+    kind: "heading",
+    title: "Compatible geoms",
+    summary:
+      'Compatible geoms in stat summary_bin. stat "summary_bin": Bin continuous x, then summarize y in each bin (mean ± se by default). Publishes y, ymin, ymax for binned summaries.',
+    href: "/reference/stats/summary_bin#compatible-geoms",
+    keywords: ["stat summary_bin", "documentation"],
+    exact: ["Compatible geoms"],
+  },
+  {
+    id: "heading:reference-stats-summary_bin:examples",
+    kind: "heading",
+    title: "Examples",
+    summary:
+      'Examples in stat summary_bin. stat "summary_bin": Bin continuous x, then summarize y in each bin (mean ± se by default). Publishes y, ymin, ymax for binned summaries.',
+    href: "/reference/stats/summary_bin#examples",
+    keywords: ["stat summary_bin", "documentation"],
+    exact: ["Examples"],
+  },
+  {
+    id: "page:reference-stats-contour",
+    kind: "page",
+    title: "stat contour",
+    summary:
+      'stat "contour": Marching-squares isolines over a regular x×y×z grid. Publishes level; default for geom_contour.',
+    href: "/reference/stats/contour",
+    keywords: [],
+    exact: ["stat contour"],
+  },
+  {
+    id: "heading:reference-stats-contour:usage",
+    kind: "heading",
+    title: "Usage",
+    summary:
+      'Usage in stat contour. stat "contour": Marching-squares isolines over a regular x×y×z grid. Publishes level; default for geom_contour.',
+    href: "/reference/stats/contour#usage",
+    keywords: ["stat contour", "documentation"],
+    exact: ["Usage"],
+  },
+  {
+    id: "heading:reference-stats-contour:generated-columns",
+    kind: "heading",
+    title: "Generated columns (after_stat)",
+    summary:
+      'Generated columns (after_stat) in stat contour. stat "contour": Marching-squares isolines over a regular x×y×z grid. Publishes level; default for geom_contour.',
+    href: "/reference/stats/contour#generated-columns",
+    keywords: ["stat contour", "documentation"],
+    exact: ["Generated columns (after_stat)"],
+  },
+  {
+    id: "heading:reference-stats-contour:default-for",
+    kind: "heading",
+    title: "Default for geoms",
+    summary:
+      'Default for geoms in stat contour. stat "contour": Marching-squares isolines over a regular x×y×z grid. Publishes level; default for geom_contour.',
+    href: "/reference/stats/contour#default-for",
+    keywords: ["stat contour", "documentation"],
+    exact: ["Default for geoms"],
+  },
+  {
+    id: "heading:reference-stats-contour:compatible-geoms",
+    kind: "heading",
+    title: "Compatible geoms",
+    summary:
+      'Compatible geoms in stat contour. stat "contour": Marching-squares isolines over a regular x×y×z grid. Publishes level; default for geom_contour.',
+    href: "/reference/stats/contour#compatible-geoms",
+    keywords: ["stat contour", "documentation"],
+    exact: ["Compatible geoms"],
+  },
+  {
+    id: "heading:reference-stats-contour:examples",
+    kind: "heading",
+    title: "Examples",
+    summary:
+      'Examples in stat contour. stat "contour": Marching-squares isolines over a regular x×y×z grid. Publishes level; default for geom_contour.',
+    href: "/reference/stats/contour#examples",
+    keywords: ["stat contour", "documentation"],
+    exact: ["Examples"],
+  },
+  {
+    id: "page:reference-stats-align",
+    kind: "page",
+    title: "stat align",
+    summary:
+      'stat "align": Interpolate series onto a shared x grid so continuous-x stacks and overlays line up (stack-friendly zeros outside range).',
+    href: "/reference/stats/align",
+    keywords: [],
+    exact: ["stat align"],
+  },
+  {
+    id: "heading:reference-stats-align:usage",
+    kind: "heading",
+    title: "Usage",
+    summary:
+      'Usage in stat align. stat "align": Interpolate series onto a shared x grid so continuous-x stacks and overlays line up (stack-friendly zeros outside range).',
+    href: "/reference/stats/align#usage",
+    keywords: ["stat align", "documentation"],
+    exact: ["Usage"],
+  },
+  {
+    id: "heading:reference-stats-align:generated-columns",
+    kind: "heading",
+    title: "Generated columns (after_stat)",
+    summary:
+      'Generated columns (after_stat) in stat align. stat "align": Interpolate series onto a shared x grid so continuous-x stacks and overlays line up (stack-friendly zeros outside range).',
+    href: "/reference/stats/align#generated-columns",
+    keywords: ["stat align", "documentation"],
+    exact: ["Generated columns (after_stat)"],
+  },
+  {
+    id: "heading:reference-stats-align:default-for",
+    kind: "heading",
+    title: "Default for geoms",
+    summary:
+      'Default for geoms in stat align. stat "align": Interpolate series onto a shared x grid so continuous-x stacks and overlays line up (stack-friendly zeros outside range).',
+    href: "/reference/stats/align#default-for",
+    keywords: ["stat align", "documentation"],
+    exact: ["Default for geoms"],
+  },
+  {
+    id: "heading:reference-stats-align:compatible-geoms",
+    kind: "heading",
+    title: "Compatible geoms",
+    summary:
+      'Compatible geoms in stat align. stat "align": Interpolate series onto a shared x grid so continuous-x stacks and overlays line up (stack-friendly zeros outside range).',
+    href: "/reference/stats/align#compatible-geoms",
+    keywords: ["stat align", "documentation"],
+    exact: ["Compatible geoms"],
+  },
+  {
+    id: "page:reference-stats-density_2d",
+    kind: "page",
+    title: "stat density_2d",
+    summary:
+      'stat "density_2d": Bivariate KDE with isolines. Publishes level and density; default for geom_density_2d.',
+    href: "/reference/stats/density_2d",
+    keywords: [],
+    exact: ["stat density_2d"],
+  },
+  {
+    id: "heading:reference-stats-density_2d:usage",
+    kind: "heading",
+    title: "Usage",
+    summary:
+      'Usage in stat density_2d. stat "density_2d": Bivariate KDE with isolines. Publishes level and density; default for geom_density_2d.',
+    href: "/reference/stats/density_2d#usage",
+    keywords: ["stat density_2d", "documentation"],
+    exact: ["Usage"],
+  },
+  {
+    id: "heading:reference-stats-density_2d:generated-columns",
+    kind: "heading",
+    title: "Generated columns (after_stat)",
+    summary:
+      'Generated columns (after_stat) in stat density_2d. stat "density_2d": Bivariate KDE with isolines. Publishes level and density; default for geom_density_2d.',
+    href: "/reference/stats/density_2d#generated-columns",
+    keywords: ["stat density_2d", "documentation"],
+    exact: ["Generated columns (after_stat)"],
+  },
+  {
+    id: "heading:reference-stats-density_2d:default-for",
+    kind: "heading",
+    title: "Default for geoms",
+    summary:
+      'Default for geoms in stat density_2d. stat "density_2d": Bivariate KDE with isolines. Publishes level and density; default for geom_density_2d.',
+    href: "/reference/stats/density_2d#default-for",
+    keywords: ["stat density_2d", "documentation"],
+    exact: ["Default for geoms"],
+  },
+  {
+    id: "heading:reference-stats-density_2d:compatible-geoms",
+    kind: "heading",
+    title: "Compatible geoms",
+    summary:
+      'Compatible geoms in stat density_2d. stat "density_2d": Bivariate KDE with isolines. Publishes level and density; default for geom_density_2d.',
+    href: "/reference/stats/density_2d#compatible-geoms",
+    keywords: ["stat density_2d", "documentation"],
+    exact: ["Compatible geoms"],
+  },
+  {
+    id: "heading:reference-stats-density_2d:examples",
+    kind: "heading",
+    title: "Examples",
+    summary:
+      'Examples in stat density_2d. stat "density_2d": Bivariate KDE with isolines. Publishes level and density; default for geom_density_2d.',
+    href: "/reference/stats/density_2d#examples",
+    keywords: ["stat density_2d", "documentation"],
+    exact: ["Examples"],
+  },
+  {
+    id: "page:reference-stats-density_2d_filled",
+    kind: "page",
+    title: "stat density_2d_filled",
+    summary:
+      'stat "density_2d_filled": Bivariate KDE with closed density rings for filled contours. Publishes level and density; default for geom_density_2d_filled.',
+    href: "/reference/stats/density_2d_filled",
+    keywords: [],
+    exact: ["stat density_2d_filled"],
+  },
+  {
+    id: "heading:reference-stats-density_2d_filled:usage",
+    kind: "heading",
+    title: "Usage",
+    summary:
+      'Usage in stat density_2d_filled. stat "density_2d_filled": Bivariate KDE with closed density rings for filled contours. Publishes level and density; default for geom_density_2d_filled.',
+    href: "/reference/stats/density_2d_filled#usage",
+    keywords: ["stat density_2d_filled", "documentation"],
+    exact: ["Usage"],
+  },
+  {
+    id: "heading:reference-stats-density_2d_filled:generated-columns",
+    kind: "heading",
+    title: "Generated columns (after_stat)",
+    summary:
+      'Generated columns (after_stat) in stat density_2d_filled. stat "density_2d_filled": Bivariate KDE with closed density rings for filled contours. Publishes level and density; default for geom_density_2d_filled.',
+    href: "/reference/stats/density_2d_filled#generated-columns",
+    keywords: ["stat density_2d_filled", "documentation"],
+    exact: ["Generated columns (after_stat)"],
+  },
+  {
+    id: "heading:reference-stats-density_2d_filled:default-for",
+    kind: "heading",
+    title: "Default for geoms",
+    summary:
+      'Default for geoms in stat density_2d_filled. stat "density_2d_filled": Bivariate KDE with closed density rings for filled contours. Publishes level and density; default for geom_density_2d_filled.',
+    href: "/reference/stats/density_2d_filled#default-for",
+    keywords: ["stat density_2d_filled", "documentation"],
+    exact: ["Default for geoms"],
+  },
+  {
+    id: "heading:reference-stats-density_2d_filled:compatible-geoms",
+    kind: "heading",
+    title: "Compatible geoms",
+    summary:
+      'Compatible geoms in stat density_2d_filled. stat "density_2d_filled": Bivariate KDE with closed density rings for filled contours. Publishes level and density; default for geom_density_2d_filled.',
+    href: "/reference/stats/density_2d_filled#compatible-geoms",
+    keywords: ["stat density_2d_filled", "documentation"],
+    exact: ["Compatible geoms"],
+  },
+  {
+    id: "heading:reference-stats-density_2d_filled:examples",
+    kind: "heading",
+    title: "Examples",
+    summary:
+      'Examples in stat density_2d_filled. stat "density_2d_filled": Bivariate KDE with closed density rings for filled contours. Publishes level and density; default for geom_density_2d_filled.',
+    href: "/reference/stats/density_2d_filled#examples",
+    keywords: ["stat density_2d_filled", "documentation"],
+    exact: ["Examples"],
+  },
+  {
+    id: "page:reference-stats-bindot",
+    kind: "page",
+    title: "stat bindot",
+    summary:
+      'stat "bindot": Histodot binning for geom_dotplot: one stack position per observation. Publishes stackpos (and bin occupancy).',
+    href: "/reference/stats/bindot",
+    keywords: [],
+    exact: ["stat bindot"],
+  },
+  {
+    id: "heading:reference-stats-bindot:usage",
+    kind: "heading",
+    title: "Usage",
+    summary:
+      'Usage in stat bindot. stat "bindot": Histodot binning for geom_dotplot: one stack position per observation. Publishes stackpos (and bin occupancy).',
+    href: "/reference/stats/bindot#usage",
+    keywords: ["stat bindot", "documentation"],
+    exact: ["Usage"],
+  },
+  {
+    id: "heading:reference-stats-bindot:generated-columns",
+    kind: "heading",
+    title: "Generated columns (after_stat)",
+    summary:
+      'Generated columns (after_stat) in stat bindot. stat "bindot": Histodot binning for geom_dotplot: one stack position per observation. Publishes stackpos (and bin occupancy).',
+    href: "/reference/stats/bindot#generated-columns",
+    keywords: ["stat bindot", "documentation"],
+    exact: ["Generated columns (after_stat)"],
+  },
+  {
+    id: "heading:reference-stats-bindot:default-for",
+    kind: "heading",
+    title: "Default for geoms",
+    summary:
+      'Default for geoms in stat bindot. stat "bindot": Histodot binning for geom_dotplot: one stack position per observation. Publishes stackpos (and bin occupancy).',
+    href: "/reference/stats/bindot#default-for",
+    keywords: ["stat bindot", "documentation"],
+    exact: ["Default for geoms"],
+  },
+  {
+    id: "heading:reference-stats-bindot:compatible-geoms",
+    kind: "heading",
+    title: "Compatible geoms",
+    summary:
+      'Compatible geoms in stat bindot. stat "bindot": Histodot binning for geom_dotplot: one stack position per observation. Publishes stackpos (and bin occupancy).',
+    href: "/reference/stats/bindot#compatible-geoms",
+    keywords: ["stat bindot", "documentation"],
+    exact: ["Compatible geoms"],
+  },
+  {
+    id: "heading:reference-stats-bindot:examples",
+    kind: "heading",
+    title: "Examples",
+    summary:
+      'Examples in stat bindot. stat "bindot": Histodot binning for geom_dotplot: one stack position per observation. Publishes stackpos (and bin occupancy).',
+    href: "/reference/stats/bindot#examples",
+    keywords: ["stat bindot", "documentation"],
+    exact: ["Examples"],
+  },
+  {
+    id: "page:reference-stats-ellipse",
+    kind: "page",
+    title: "stat ellipse",
+    summary:
+      'stat "ellipse": Confidence ellipse over bivariate points (level and type from params). Passes geometry suited to path/polygon-style marks.',
+    href: "/reference/stats/ellipse",
+    keywords: [],
+    exact: ["stat ellipse"],
+  },
+  {
+    id: "heading:reference-stats-ellipse:usage",
+    kind: "heading",
+    title: "Usage",
+    summary:
+      'Usage in stat ellipse. stat "ellipse": Confidence ellipse over bivariate points (level and type from params). Passes geometry suited to path/polygon-style marks.',
+    href: "/reference/stats/ellipse#usage",
+    keywords: ["stat ellipse", "documentation"],
+    exact: ["Usage"],
+  },
+  {
+    id: "heading:reference-stats-ellipse:generated-columns",
+    kind: "heading",
+    title: "Generated columns (after_stat)",
+    summary:
+      'Generated columns (after_stat) in stat ellipse. stat "ellipse": Confidence ellipse over bivariate points (level and type from params). Passes geometry suited to path/polygon-style marks.',
+    href: "/reference/stats/ellipse#generated-columns",
+    keywords: ["stat ellipse", "documentation"],
+    exact: ["Generated columns (after_stat)"],
+  },
+  {
+    id: "heading:reference-stats-ellipse:default-for",
+    kind: "heading",
+    title: "Default for geoms",
+    summary:
+      'Default for geoms in stat ellipse. stat "ellipse": Confidence ellipse over bivariate points (level and type from params). Passes geometry suited to path/polygon-style marks.',
+    href: "/reference/stats/ellipse#default-for",
+    keywords: ["stat ellipse", "documentation"],
+    exact: ["Default for geoms"],
+  },
+  {
+    id: "heading:reference-stats-ellipse:compatible-geoms",
+    kind: "heading",
+    title: "Compatible geoms",
+    summary:
+      'Compatible geoms in stat ellipse. stat "ellipse": Confidence ellipse over bivariate points (level and type from params). Passes geometry suited to path/polygon-style marks.',
+    href: "/reference/stats/ellipse#compatible-geoms",
+    keywords: ["stat ellipse", "documentation"],
+    exact: ["Compatible geoms"],
+  },
+  {
+    id: "heading:reference-stats-ellipse:examples",
+    kind: "heading",
+    title: "Examples",
+    summary:
+      'Examples in stat ellipse. stat "ellipse": Confidence ellipse over bivariate points (level and type from params). Passes geometry suited to path/polygon-style marks.',
+    href: "/reference/stats/ellipse#examples",
+    keywords: ["stat ellipse", "documentation"],
+    exact: ["Examples"],
+  },
+  {
+    id: "page:reference-stats-sf",
+    kind: "page",
+    title: "stat sf",
+    summary:
+      'stat "sf": Simple-features geometry expansion for geom_sf: multiparts and holes become drawable rings without after_stat columns.',
+    href: "/reference/stats/sf",
+    keywords: [],
+    exact: ["stat sf"],
+  },
+  {
+    id: "heading:reference-stats-sf:usage",
+    kind: "heading",
+    title: "Usage",
+    summary:
+      'Usage in stat sf. stat "sf": Simple-features geometry expansion for geom_sf: multiparts and holes become drawable rings without after_stat columns.',
+    href: "/reference/stats/sf#usage",
+    keywords: ["stat sf", "documentation"],
+    exact: ["Usage"],
+  },
+  {
+    id: "heading:reference-stats-sf:generated-columns",
+    kind: "heading",
+    title: "Generated columns (after_stat)",
+    summary:
+      'Generated columns (after_stat) in stat sf. stat "sf": Simple-features geometry expansion for geom_sf: multiparts and holes become drawable rings without after_stat columns.',
+    href: "/reference/stats/sf#generated-columns",
+    keywords: ["stat sf", "documentation"],
+    exact: ["Generated columns (after_stat)"],
+  },
+  {
+    id: "heading:reference-stats-sf:default-for",
+    kind: "heading",
+    title: "Default for geoms",
+    summary:
+      'Default for geoms in stat sf. stat "sf": Simple-features geometry expansion for geom_sf: multiparts and holes become drawable rings without after_stat columns.',
+    href: "/reference/stats/sf#default-for",
+    keywords: ["stat sf", "documentation"],
+    exact: ["Default for geoms"],
+  },
+  {
+    id: "heading:reference-stats-sf:compatible-geoms",
+    kind: "heading",
+    title: "Compatible geoms",
+    summary:
+      'Compatible geoms in stat sf. stat "sf": Simple-features geometry expansion for geom_sf: multiparts and holes become drawable rings without after_stat columns.',
+    href: "/reference/stats/sf#compatible-geoms",
+    keywords: ["stat sf", "documentation"],
+    exact: ["Compatible geoms"],
+  },
+  {
+    id: "heading:reference-stats-sf:examples",
+    kind: "heading",
+    title: "Examples",
+    summary:
+      'Examples in stat sf. stat "sf": Simple-features geometry expansion for geom_sf: multiparts and holes become drawable rings without after_stat columns.',
+    href: "/reference/stats/sf#examples",
+    keywords: ["stat sf", "documentation"],
+    exact: ["Examples"],
+  },
+  {
+    id: "page:reference-stats-sf_coordinates",
+    kind: "page",
+    title: "stat sf_coordinates",
+    summary:
+      'stat "sf_coordinates": Label anchors from SF geometries for geom_sf_text and geom_sf_label (one point per feature or part).',
+    href: "/reference/stats/sf_coordinates",
+    keywords: [],
+    exact: ["stat sf_coordinates"],
+  },
+  {
+    id: "heading:reference-stats-sf_coordinates:usage",
+    kind: "heading",
+    title: "Usage",
+    summary:
+      'Usage in stat sf_coordinates. stat "sf_coordinates": Label anchors from SF geometries for geom_sf_text and geom_sf_label (one point per feature or part).',
+    href: "/reference/stats/sf_coordinates#usage",
+    keywords: ["stat sf_coordinates", "documentation"],
+    exact: ["Usage"],
+  },
+  {
+    id: "heading:reference-stats-sf_coordinates:generated-columns",
+    kind: "heading",
+    title: "Generated columns (after_stat)",
+    summary:
+      'Generated columns (after_stat) in stat sf_coordinates. stat "sf_coordinates": Label anchors from SF geometries for geom_sf_text and geom_sf_label (one point per feature or part).',
+    href: "/reference/stats/sf_coordinates#generated-columns",
+    keywords: ["stat sf_coordinates", "documentation"],
+    exact: ["Generated columns (after_stat)"],
+  },
+  {
+    id: "heading:reference-stats-sf_coordinates:default-for",
+    kind: "heading",
+    title: "Default for geoms",
+    summary:
+      'Default for geoms in stat sf_coordinates. stat "sf_coordinates": Label anchors from SF geometries for geom_sf_text and geom_sf_label (one point per feature or part).',
+    href: "/reference/stats/sf_coordinates#default-for",
+    keywords: ["stat sf_coordinates", "documentation"],
+    exact: ["Default for geoms"],
+  },
+  {
+    id: "heading:reference-stats-sf_coordinates:compatible-geoms",
+    kind: "heading",
+    title: "Compatible geoms",
+    summary:
+      'Compatible geoms in stat sf_coordinates. stat "sf_coordinates": Label anchors from SF geometries for geom_sf_text and geom_sf_label (one point per feature or part).',
+    href: "/reference/stats/sf_coordinates#compatible-geoms",
+    keywords: ["stat sf_coordinates", "documentation"],
+    exact: ["Compatible geoms"],
+  },
+  {
+    id: "page:reference-stats-qq",
+    kind: "page",
+    title: "stat qq",
+    summary:
+      'stat "qq": Sample vs theoretical quantiles for Q–Q plots. Publishes sample and theoretical; default for geom_qq.',
+    href: "/reference/stats/qq",
+    keywords: [],
+    exact: ["stat qq"],
+  },
+  {
+    id: "heading:reference-stats-qq:usage",
+    kind: "heading",
+    title: "Usage",
+    summary:
+      'Usage in stat qq. stat "qq": Sample vs theoretical quantiles for Q–Q plots. Publishes sample and theoretical; default for geom_qq.',
+    href: "/reference/stats/qq#usage",
+    keywords: ["stat qq", "documentation"],
+    exact: ["Usage"],
+  },
+  {
+    id: "heading:reference-stats-qq:generated-columns",
+    kind: "heading",
+    title: "Generated columns (after_stat)",
+    summary:
+      'Generated columns (after_stat) in stat qq. stat "qq": Sample vs theoretical quantiles for Q–Q plots. Publishes sample and theoretical; default for geom_qq.',
+    href: "/reference/stats/qq#generated-columns",
+    keywords: ["stat qq", "documentation"],
+    exact: ["Generated columns (after_stat)"],
+  },
+  {
+    id: "heading:reference-stats-qq:default-for",
+    kind: "heading",
+    title: "Default for geoms",
+    summary:
+      'Default for geoms in stat qq. stat "qq": Sample vs theoretical quantiles for Q–Q plots. Publishes sample and theoretical; default for geom_qq.',
+    href: "/reference/stats/qq#default-for",
+    keywords: ["stat qq", "documentation"],
+    exact: ["Default for geoms"],
+  },
+  {
+    id: "heading:reference-stats-qq:compatible-geoms",
+    kind: "heading",
+    title: "Compatible geoms",
+    summary:
+      'Compatible geoms in stat qq. stat "qq": Sample vs theoretical quantiles for Q–Q plots. Publishes sample and theoretical; default for geom_qq.',
+    href: "/reference/stats/qq#compatible-geoms",
+    keywords: ["stat qq", "documentation"],
+    exact: ["Compatible geoms"],
+  },
+  {
+    id: "heading:reference-stats-qq:examples",
+    kind: "heading",
+    title: "Examples",
+    summary:
+      'Examples in stat qq. stat "qq": Sample vs theoretical quantiles for Q–Q plots. Publishes sample and theoretical; default for geom_qq.',
+    href: "/reference/stats/qq#examples",
+    keywords: ["stat qq", "documentation"],
+    exact: ["Examples"],
+  },
+  {
+    id: "page:reference-stats-qq_line",
+    kind: "page",
+    title: "stat qq_line",
+    summary:
+      'stat "qq_line": Reference line through Q–Q sample/theoretical quantiles. Publishes sample and theoretical; default for geom_qq_line.',
+    href: "/reference/stats/qq_line",
+    keywords: [],
+    exact: ["stat qq_line"],
+  },
+  {
+    id: "heading:reference-stats-qq_line:usage",
+    kind: "heading",
+    title: "Usage",
+    summary:
+      'Usage in stat qq_line. stat "qq_line": Reference line through Q–Q sample/theoretical quantiles. Publishes sample and theoretical; default for geom_qq_line.',
+    href: "/reference/stats/qq_line#usage",
+    keywords: ["stat qq_line", "documentation"],
+    exact: ["Usage"],
+  },
+  {
+    id: "heading:reference-stats-qq_line:generated-columns",
+    kind: "heading",
+    title: "Generated columns (after_stat)",
+    summary:
+      'Generated columns (after_stat) in stat qq_line. stat "qq_line": Reference line through Q–Q sample/theoretical quantiles. Publishes sample and theoretical; default for geom_qq_line.',
+    href: "/reference/stats/qq_line#generated-columns",
+    keywords: ["stat qq_line", "documentation"],
+    exact: ["Generated columns (after_stat)"],
+  },
+  {
+    id: "heading:reference-stats-qq_line:default-for",
+    kind: "heading",
+    title: "Default for geoms",
+    summary:
+      'Default for geoms in stat qq_line. stat "qq_line": Reference line through Q–Q sample/theoretical quantiles. Publishes sample and theoretical; default for geom_qq_line.',
+    href: "/reference/stats/qq_line#default-for",
+    keywords: ["stat qq_line", "documentation"],
+    exact: ["Default for geoms"],
+  },
+  {
+    id: "heading:reference-stats-qq_line:compatible-geoms",
+    kind: "heading",
+    title: "Compatible geoms",
+    summary:
+      'Compatible geoms in stat qq_line. stat "qq_line": Reference line through Q–Q sample/theoretical quantiles. Publishes sample and theoretical; default for geom_qq_line.',
+    href: "/reference/stats/qq_line#compatible-geoms",
+    keywords: ["stat qq_line", "documentation"],
+    exact: ["Compatible geoms"],
+  },
+  {
     id: "page:guide-getting-started",
     kind: "page",
     title: "Getting started",
@@ -7831,14 +9481,14 @@ export const DOCS_SEARCH_INDEX = [
     exact: ["@ggsvelte/spec"],
   },
   {
-    id: "heading:guide-lifecycle:experimental-865",
+    id: "heading:guide-lifecycle:experimental-868",
     kind: "heading",
-    title: "experimental (865)",
+    title: "experimental (868)",
     summary:
-      "experimental (865) in Lifecycle & editions. API stability tags per export, and the defaults-edition mechanism.",
-    href: "/guide/lifecycle#experimental-865",
+      "experimental (868) in Lifecycle & editions. API stability tags per export, and the defaults-edition mechanism.",
+    href: "/guide/lifecycle#experimental-868",
     keywords: ["Lifecycle & editions", "Reference"],
-    exact: ["experimental (865)"],
+    exact: ["experimental (868)"],
   },
   {
     id: "heading:guide-lifecycle:stable-intent-8",
@@ -13475,6 +15125,15 @@ export const DOCS_SEARCH_INDEX = [
     exact: ["STAT_COLUMNS"],
   },
   {
+    id: "api:ggsvelte-spec:STAT_REFERENCE",
+    kind: "api",
+    title: "STAT_REFERENCE",
+    summary: "@ggsvelte/spec · value · experimental.",
+    href: "/guide/lifecycle#ggsvelte-spec",
+    keywords: ["@ggsvelte/spec", ".", "value", "experimental"],
+    exact: ["STAT_REFERENCE"],
+  },
+  {
     id: "api:ggsvelte-spec:STYLE_AESTHETIC_GEOMS",
     kind: "api",
     title: "STYLE_AESTHETIC_GEOMS",
@@ -13851,6 +15510,15 @@ export const DOCS_SEARCH_INDEX = [
     href: "/guide/lifecycle#ggsvelte-spec",
     keywords: ["@ggsvelte/spec", ".", "type", "experimental"],
     exact: ["StatName"],
+  },
+  {
+    id: "api:ggsvelte-spec:StatReferenceEntry",
+    kind: "api",
+    title: "StatReferenceEntry",
+    summary: "@ggsvelte/spec · type · experimental.",
+    href: "/guide/lifecycle#ggsvelte-spec",
+    keywords: ["@ggsvelte/spec", ".", "type", "experimental"],
+    exact: ["StatReferenceEntry"],
   },
   {
     id: "api:ggsvelte-spec:StepLayer",
@@ -17469,6 +19137,15 @@ export const DOCS_SEARCH_INDEX = [
     href: "/guide/lifecycle#ggsvelte-spec",
     keywords: ["@ggsvelte/spec", ".", "value", "experimental"],
     exact: ["schemaArtifactJSON"],
+  },
+  {
+    id: "api:ggsvelte-spec:statReferenceList",
+    kind: "api",
+    title: "statReferenceList",
+    summary: "@ggsvelte/spec · value · experimental.",
+    href: "/guide/lifecycle#ggsvelte-spec",
+    keywords: ["@ggsvelte/spec", ".", "value", "experimental"],
+    exact: ["statReferenceList"],
   },
   {
     id: "api:ggsvelte-spec:strokePaintLinear",

--- a/apps/docs/src/routes/docs/+page.svelte
+++ b/apps/docs/src/routes/docs/+page.svelte
@@ -23,6 +23,10 @@
       "Every Geom* component: defaults, stats, positions, and params.",
     ],
     [
+      "/reference/stats",
+      "Every statistical transform: after_stat columns and compatible geoms.",
+    ],
+    [
       "/reference/cli",
       "Render, validate, and export charts from the terminal.",
     ],

--- a/apps/docs/src/routes/reference/+page.svelte
+++ b/apps/docs/src/routes/reference/+page.svelte
@@ -19,6 +19,12 @@
         schema.</span
       >
     </a>
+    <a href={`${base}/reference/stats`}>
+      <strong>Stat reference</strong>
+      <span
+        >Every statistical transform: after_stat columns and compatible geoms.</span
+      >
+    </a>
     <a href={`${base}/reference/interactions`}>
       <strong>Interaction reference</strong>
       <span>Capabilities, events, diagnostics, accessibility defaults.</span>

--- a/apps/docs/src/routes/reference/geoms/[name]/+page.svelte
+++ b/apps/docs/src/routes/reference/geoms/[name]/+page.svelte
@@ -136,7 +136,7 @@
   <ul class="token-list">
     {#each entry.allowedStats as stat (stat)}
       <li>
-        <code>{stat}</code>
+        <a href={`${base}/reference/stats/${stat}`}><code>{stat}</code></a>
         {#if stat === entry.defaultStat}
           <span class="badge">default</span>
         {/if}

--- a/apps/docs/src/routes/reference/stats/+page.svelte
+++ b/apps/docs/src/routes/reference/stats/+page.svelte
@@ -1,0 +1,202 @@
+<script lang="ts">
+  import { base } from "$app/paths";
+  import {
+    STAT_REFERENCE,
+    statReferenceList,
+    type StatReferenceEntry,
+  } from "@ggsvelte/spec";
+
+  let query = $state("");
+  const all = statReferenceList();
+  const normalizedQuery = $derived(query.trim().toLocaleLowerCase());
+  const results = $derived(
+    normalizedQuery === ""
+      ? all
+      : all.filter((entry) => matchesStat(entry, normalizedQuery)),
+  );
+
+  function matchesStat(entry: StatReferenceEntry, q: string): boolean {
+    const haystack = [
+      entry.name,
+      entry.summary,
+      ...entry.generatedColumns,
+      ...entry.compatibleGeoms,
+      ...entry.defaultForGeoms,
+    ]
+      .join(" ")
+      .toLocaleLowerCase();
+    return haystack.includes(q);
+  }
+</script>
+
+<main class="stat-reference" aria-labelledby="reference-heading">
+  <p class="eyebrow">
+    Schema-derived · {Object.keys(STAT_REFERENCE).length} stats
+  </p>
+  <h1 id="reference-heading">Stat reference</h1>
+  <p class="intro">
+    Statistical transforms applied before drawing. Set
+    <code>stat</code> on a <code>&lt;Geom*&gt;</code> shell or JSON layer —
+    there is no separate Stat component. Generated from
+    <code>KNOWN_STATS</code>, <code>STAT_COLUMNS</code>, and which geoms allow
+    each value in the PortableSpec schema.
+  </p>
+
+  <label for="stat-search">Search stats, columns, or geoms</label>
+  <input
+    id="stat-search"
+    type="search"
+    bind:value={query}
+    placeholder="Try count, density, bin, or smooth"
+    autocomplete="off"
+  />
+
+  <p class="count" aria-live="polite">
+    {results.length}
+    {results.length === 1 ? "stat" : "stats"}
+  </p>
+
+  <h2 id="all-stats">All stats</h2>
+  {#if results.length === 0}
+    <p class="empty">No match. Try a stat name, after_stat column, or geom.</p>
+  {:else}
+    <ul class="results">
+      {#each results as entry (entry.name)}
+        <li>
+          <a href={`${base}/reference/stats/${entry.slug}`}>
+            <strong><code>{entry.name}</code></strong>
+            <span class="meta">
+              {#if entry.generatedColumns.length > 0}
+                after_stat: {entry.generatedColumns.join(", ")}
+              {:else}
+                no after_stat columns
+              {/if}
+              · {entry.compatibleGeoms.length}
+              {entry.compatibleGeoms.length === 1 ? "geom" : "geoms"}
+              {#if entry.defaultForGeoms.length > 0}
+                · default for {entry.defaultForGeoms.length}
+              {/if}
+            </span>
+            <span class="summary">{entry.summary}</span>
+          </a>
+        </li>
+      {/each}
+    </ul>
+  {/if}
+
+  <h2 id="how-to-set">How to set a stat</h2>
+  <p>
+    On any geom shell, pass the <code>stat</code> prop. Only values listed on
+    that geom's
+    <a href={`${base}/reference/geoms`}>geom reference</a> page validate. Omit it
+    to use the geom default.
+  </p>
+  <pre class="snippet"><code
+      >{`import { GGPlot, GeomBar } from "@ggsvelte/svelte";
+
+<GGPlot data={rows} aes={{ x: "category" }}>
+  <GeomBar stat="count" />
+</GGPlot>`}</code
+    ></pre>
+</main>
+
+<style>
+  .stat-reference {
+    max-width: 52rem;
+    margin: 2rem 0 4rem;
+  }
+
+  h1 {
+    margin: 0.15rem 0 0.6rem;
+  }
+
+  h2 {
+    margin: 2.5rem 0 0.75rem;
+  }
+
+  .intro {
+    max-width: 44rem;
+  }
+
+  .eyebrow {
+    margin: 0;
+    color: var(--muted);
+    font-size: 0.76rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  label {
+    display: block;
+    margin: 1.5rem 0 0.4rem;
+    font-weight: 600;
+  }
+
+  input[type="search"] {
+    width: min(100%, 28rem);
+    padding: 0.55rem 0.75rem;
+    border: 1px solid var(--line);
+    border-radius: 0.4rem;
+    background: var(--surface, transparent);
+    color: var(--ink);
+    font: inherit;
+  }
+
+  .count {
+    margin: 0.75rem 0 0;
+    color: var(--muted);
+    font-size: 0.9rem;
+  }
+
+  .empty {
+    color: var(--muted);
+  }
+
+  .results {
+    list-style: none;
+    margin: 1rem 0 0;
+    padding: 0;
+  }
+
+  .results li {
+    border-top: 1px solid var(--line);
+  }
+
+  .results li:last-child {
+    border-bottom: 1px solid var(--line);
+  }
+
+  .results a {
+    display: grid;
+    gap: 0.25rem;
+    padding: 0.9rem 0;
+    color: var(--ink);
+    text-decoration: none;
+  }
+
+  .results a:hover strong {
+    text-decoration: underline;
+  }
+
+  .meta {
+    color: var(--muted);
+    font-size: 0.88rem;
+  }
+
+  .summary {
+    max-width: 44rem;
+    color: var(--muted);
+    font-size: 0.92rem;
+  }
+
+  .snippet {
+    overflow-x: auto;
+    padding: 1rem 1.1rem;
+    border-radius: 0.5rem;
+    background: var(--code-bg, #1a1b26);
+    color: var(--code-fg, #c0caf5);
+    font-size: 0.88rem;
+    line-height: 1.45;
+  }
+</style>

--- a/apps/docs/src/routes/reference/stats/[name]/+page.svelte
+++ b/apps/docs/src/routes/reference/stats/[name]/+page.svelte
@@ -1,0 +1,187 @@
+<script lang="ts">
+  import { base } from "$app/paths";
+  import { componentNameForGeom } from "@ggsvelte/spec";
+
+  import type { PageProps } from "./$types";
+
+  const { data }: PageProps = $props();
+  const entry = $derived(data.entry);
+
+  const primaryGeom = $derived(
+    entry.defaultForGeoms[0] ?? entry.compatibleGeoms[0],
+  );
+  const primaryComponent = $derived(
+    primaryGeom === undefined ? "GeomBar" : componentNameForGeom(primaryGeom),
+  );
+
+  const svelteSnippet = $derived(
+    `import { GGPlot, ${primaryComponent} } from "@ggsvelte/svelte";\n\n<GGPlot data={rows} aes={{ x: "x", y: "y" }}>\n  <${primaryComponent} stat="${entry.name}" />\n</GGPlot>`,
+  );
+  const jsonSnippet = $derived(
+    `{\n  "geom": "${primaryGeom ?? "bar"}",\n  "stat": "${entry.name}"\n}`,
+  );
+</script>
+
+<article class="stat-detail prose" aria-labelledby="stat-heading">
+  <p class="crumb">
+    <a href={`${base}/reference/stats`}>Stat reference</a>
+    <span aria-hidden="true">/</span>
+    <code>{entry.name}</code>
+  </p>
+
+  <h1 id="stat-heading"><code>stat: "{entry.name}"</code></h1>
+  <p class="lede">{entry.summary}</p>
+
+  <h2 id="usage">Usage</h2>
+  <p>
+    Stats are not components. Pass <code>stat="{entry.name}"</code> on a
+    compatible <code>&lt;Geom*&gt;</code>, or set
+    <code>"stat": "{entry.name}"</code> on a JSON layer. Only geoms that list this
+    value in their allowed stats accept it.
+  </p>
+  <pre class="snippet"><code>{svelteSnippet}</code></pre>
+  <pre class="snippet"><code>{jsonSnippet}</code></pre>
+
+  <h2 id="generated-columns">Generated columns (after_stat)</h2>
+  {#if entry.generatedColumns.length === 0}
+    <p>
+      This stat does not publish named after_stat columns in
+      <code>STAT_COLUMNS</code>. It may still rewrite positions or filter rows;
+      map aesthetics to data fields as usual.
+    </p>
+  {:else}
+    <p>
+      Resolve these with channel objects such as
+      <code>{`{ stat: "${entry.generatedColumns[0]}" }`}</code> in
+      <code>aes</code>.
+    </p>
+    <ul class="token-list">
+      {#each entry.generatedColumns as col (col)}
+        <li><code>{col}</code></li>
+      {/each}
+    </ul>
+  {/if}
+
+  <h2 id="default-for">Default for geoms</h2>
+  {#if entry.defaultForGeoms.length === 0}
+    <p>No geom uses this as its default stat. Set it explicitly when needed.</p>
+  {:else}
+    <ul class="token-list">
+      {#each entry.defaultForGeoms as geom (geom)}
+        <li>
+          <a href={`${base}/reference/geoms/${geom}`}
+            ><code>{componentNameForGeom(geom)}</code></a
+          >
+        </li>
+      {/each}
+    </ul>
+  {/if}
+
+  <h2 id="compatible-geoms">Compatible geoms</h2>
+  <ul class="token-list">
+    {#each entry.compatibleGeoms as geom (geom)}
+      <li>
+        <a href={`${base}/reference/geoms/${geom}`}
+          ><code>{componentNameForGeom(geom)}</code></a
+        >
+        {#if entry.defaultForGeoms.includes(geom)}
+          <span class="badge">default</span>
+        {/if}
+      </li>
+    {/each}
+  </ul>
+
+  {#if data.examples.length > 0}
+    <h2 id="examples">Examples</h2>
+    <ul class="example-list">
+      {#each data.examples as example (example.id)}
+        <li>
+          <a href={`${base}${example.href}`}>{example.title}</a>
+        </li>
+      {/each}
+    </ul>
+  {/if}
+
+  <p class="back">
+    <a href={`${base}/reference/stats`}>← All stats</a>
+    ·
+    <a href={`${base}/reference/geoms`}>Geom reference</a>
+    ·
+    <a href={`${base}/guide/layers-marks`}>Layers and marks guide</a>
+  </p>
+</article>
+
+<style>
+  .stat-detail {
+    max-width: 52rem;
+    margin: 2rem 0 4rem;
+  }
+
+  .crumb {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    margin: 0 0 0.75rem;
+    color: var(--muted);
+    font-size: 0.9rem;
+  }
+
+  h1 {
+    margin: 0 0 0.5rem;
+  }
+
+  .lede {
+    max-width: 44rem;
+    margin: 0 0 1.5rem;
+    font-size: 1.05rem;
+  }
+
+  .snippet {
+    overflow-x: auto;
+    padding: 1rem 1.1rem;
+    border-radius: 0.5rem;
+    background: var(--code-bg, #1a1b26);
+    color: var(--code-fg, #c0caf5);
+    font-size: 0.88rem;
+    line-height: 1.45;
+  }
+
+  .snippet + .snippet {
+    margin-top: 0.75rem;
+  }
+
+  .badge {
+    display: inline-block;
+    margin-left: 0.35rem;
+    padding: 0.05rem 0.4rem;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--ink) 8%, transparent);
+    color: var(--muted);
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    vertical-align: middle;
+  }
+
+  .token-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem 1rem;
+    margin: 0.75rem 0 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .example-list {
+    margin: 0.75rem 0 0;
+    padding-left: 1.2rem;
+  }
+
+  .back {
+    margin-top: 2.5rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--line);
+    color: var(--muted);
+  }
+</style>

--- a/apps/docs/src/routes/reference/stats/[name]/+page.ts
+++ b/apps/docs/src/routes/reference/stats/[name]/+page.ts
@@ -1,0 +1,40 @@
+import { error } from "@sveltejs/kit";
+
+import { STAT_REFERENCE, type StatName, KNOWN_STATS } from "@ggsvelte/spec";
+
+import { EXAMPLES } from "$lib/examples";
+
+import type { EntryGenerator, PageLoad } from "./$types";
+
+const STAT_SET = new Set<string>(KNOWN_STATS);
+
+/** Prerender one page per stat (adapter-static). */
+export const entries: EntryGenerator = () => KNOWN_STATS.map((name) => ({ name }));
+
+function relatedExamples(stat: StatName) {
+  return EXAMPLES.filter(
+    (entry) =>
+      entry.category === stat ||
+      entry.category === stat.replaceAll("_", "") ||
+      entry.tags.includes(stat) ||
+      entry.tags.includes(stat.replaceAll("_", "-")) ||
+      entry.tags.includes(`stat-${stat}`) ||
+      entry.tags.includes(`stat_${stat}`),
+  ).slice(0, 8);
+}
+
+export const load: PageLoad = ({ params }) => {
+  const name = params.name;
+  if (!STAT_SET.has(name)) {
+    error(404, `No stat reference for "${name}".`);
+  }
+  const entry = STAT_REFERENCE[name as StatName];
+  return {
+    entry,
+    examples: relatedExamples(entry.name).map((ex) => ({
+      id: ex.id,
+      title: ex.title,
+      href: `/examples/${ex.id}`,
+    })),
+  };
+};

--- a/lifecycle.json
+++ b/lifecycle.json
@@ -1660,6 +1660,10 @@
           "kind": "value",
           "lifecycle": "experimental"
         },
+        "STAT_REFERENCE": {
+          "kind": "value",
+          "lifecycle": "experimental"
+        },
         "STYLE_AESTHETIC_GEOMS": {
           "kind": "value",
           "lifecycle": "experimental"
@@ -1825,6 +1829,10 @@
           "lifecycle": "experimental"
         },
         "StatName": {
+          "kind": "type",
+          "lifecycle": "experimental"
+        },
+        "StatReferenceEntry": {
           "kind": "type",
           "lifecycle": "experimental"
         },
@@ -3433,6 +3441,10 @@
           "lifecycle": "experimental"
         },
         "schemaArtifactJSON": {
+          "kind": "value",
+          "lifecycle": "experimental"
+        },
+        "statReferenceList": {
           "kind": "value",
           "lifecycle": "experimental"
         },

--- a/packages/spec/src/index.ts
+++ b/packages/spec/src/index.ts
@@ -287,6 +287,10 @@ export {
 } from "./geom-reference.js";
 /** @lifecycle experimental */
 export type { GeomParamDoc, GeomReferenceEntry, SharedLayerPropDoc } from "./geom-reference.js";
+/** @lifecycle experimental */
+export { STAT_REFERENCE, statReferenceList } from "./stat-reference.js";
+/** @lifecycle experimental */
+export type { StatReferenceEntry } from "./stat-reference.js";
 
 // Temporal parsing, inference, and authoring conversions
 export {

--- a/packages/spec/src/stat-reference.ts
+++ b/packages/spec/src/stat-reference.ts
@@ -1,0 +1,156 @@
+/**
+ * STAT_REFERENCE — per-stat API docs derived from KNOWN_STATS, STAT_COLUMNS,
+ * and GEOM_REFERENCE (compatible geoms / defaults).
+ *
+ * Stats are not Svelte components: set `stat` on a `<Geom*>` shell or JSON
+ * layer. This catalog is the docs-site source for `/reference/stats` so
+ * after_stat columns and geom pairings stay in step with the schema.
+ */
+import {
+  GEOM_DEFAULTS,
+  KNOWN_GEOMS,
+  KNOWN_STATS,
+  type GeomName,
+  type StatName,
+} from "./schema-catalog.js";
+import { GEOM_REFERENCE } from "./geom-reference.js";
+import { STAT_COLUMNS } from "./validate-data-checks-layer.js";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface StatReferenceEntry {
+  readonly name: StatName;
+  /** Route slug — same as stat name (snake_case). */
+  readonly slug: string;
+  /** Short purpose text for the stat transform. */
+  readonly summary: string;
+  /**
+   * Columns this stat publishes for `{ stat: "…" }` channel resolution
+   * (after_stat). Empty when the stat passes rows through or only rewrites
+   * positions without new after_stat names in STAT_COLUMNS.
+   */
+  readonly generatedColumns: readonly string[];
+  /** Geoms whose layer schema allows this stat. */
+  readonly compatibleGeoms: readonly GeomName[];
+  /** Geoms whose GEOM_DEFAULTS.stat is this stat. */
+  readonly defaultForGeoms: readonly GeomName[];
+}
+
+// ---------------------------------------------------------------------------
+// Hand-authored summaries (module contracts; not inventable from TypeBox alone)
+// ---------------------------------------------------------------------------
+
+/**
+ * One-paragraph purpose for each KNOWN_STATS entry. Source notes live in
+ * packages/core/src/stats/* module headers; keep these short for the index.
+ */
+const STAT_SUMMARIES: Readonly<Record<StatName, string>> = Object.freeze({
+  identity:
+    "Pass rows through unchanged. Default for most geoms: each mapped row becomes one mark with no aggregation.",
+  unique:
+    "Keep one row per distinct mapped (x, y) pair (and group). Use when duplicate coordinates would overplot; default for none.",
+  manual:
+    "Author-supplied after_stat values via params — skip automatic transforms when you already computed summaries.",
+  connect:
+    "Expand successive points into connection vertices (linear, hv, vh, mid) for stepped or path-style joins between observations.",
+  count:
+    "Count rows (or sum weights) per distinct x within each group. Default for geom_bar; publishes after_stat count.",
+  bin: "Bin continuous x into histogram breaks. Publishes count, density, ncount, and ndensity; default for histogram and freqpoly.",
+  bin_hex:
+    "Hexagonal 2D binning over continuous x and y. Publishes count/density columns for geom_hex heatmaps.",
+  bin_2d:
+    "Rectangular 2D binning over continuous x and y. Publishes count/density and bin edges for geom_bin_2d tiles.",
+  smooth:
+    "Fit a smoother (lm or loess) and evaluate along x. Publishes y, ymin, ymax, and se; default for geom_smooth.",
+  quantile:
+    "Estimate conditional quantiles of y given x. Publishes y at each requested probability; default for geom_quantile.",
+  boxplot:
+    "Five-number summary per group (hinges and whiskers). Publishes ymin, lower, middle, upper, ymax; default for geom_boxplot.",
+  density:
+    "1D Gaussian kernel density estimate along x. Publishes density, count, scaled, and ndensity; default for geom_density.",
+  summary:
+    "Collapse each discrete-x group to one summary (default mean ± se). Publishes y, ymin, ymax for error-style geoms.",
+  sum: "Count overlapping points at each (x, y) cell for geom_count. Publishes n and prop (not y).",
+  ydensity:
+    "Kernel density along y for violin shapes. Publishes density, count, scaled, violinwidth, and y; default for geom_violin.",
+  function:
+    "Evaluate a pure function on an x grid. Publishes y; default for geom_function when no data rows drive the mark.",
+  ecdf: "Empirical cumulative distribution F̂(x). Publishes ecdf; pair with step or path geoms for CDF plots.",
+  summary_bin:
+    "Bin continuous x, then summarize y in each bin (mean ± se by default). Publishes y, ymin, ymax for binned summaries.",
+  contour:
+    "Marching-squares isolines over a regular x×y×z grid. Publishes level; default for geom_contour.",
+  align:
+    "Interpolate series onto a shared x grid so continuous-x stacks and overlays line up (stack-friendly zeros outside range).",
+  density_2d:
+    "Bivariate KDE with isolines. Publishes level and density; default for geom_density_2d.",
+  density_2d_filled:
+    "Bivariate KDE with closed density rings for filled contours. Publishes level and density; default for geom_density_2d_filled.",
+  bindot:
+    "Histodot binning for geom_dotplot: one stack position per observation. Publishes stackpos (and bin occupancy).",
+  ellipse:
+    "Confidence ellipse over bivariate points (level and type from params). Passes geometry suited to path/polygon-style marks.",
+  sf: "Simple-features geometry expansion for geom_sf: multiparts and holes become drawable rings without after_stat columns.",
+  sf_coordinates:
+    "Label anchors from SF geometries for geom_sf_text and geom_sf_label (one point per feature or part).",
+  qq: "Sample vs theoretical quantiles for Q–Q plots. Publishes sample and theoretical; default for geom_qq.",
+  qq_line:
+    "Reference line through Q–Q sample/theoretical quantiles. Publishes sample and theoretical; default for geom_qq_line.",
+});
+
+// ---------------------------------------------------------------------------
+// Build
+// ---------------------------------------------------------------------------
+
+function buildCompatibleGeoms(stat: StatName): readonly GeomName[] {
+  const geoms: GeomName[] = [];
+  for (const geom of KNOWN_GEOMS) {
+    if (GEOM_REFERENCE[geom].allowedStats.includes(stat)) {
+      geoms.push(geom);
+    }
+  }
+  return Object.freeze(geoms);
+}
+
+function buildDefaultForGeoms(stat: StatName): readonly GeomName[] {
+  const geoms: GeomName[] = [];
+  for (const geom of KNOWN_GEOMS) {
+    if (GEOM_DEFAULTS[geom].stat === stat) {
+      geoms.push(geom);
+    }
+  }
+  return Object.freeze(geoms);
+}
+
+function buildEntry(stat: StatName): StatReferenceEntry {
+  const columns = STAT_COLUMNS[stat] ?? [];
+  return Object.freeze({
+    name: stat,
+    slug: stat,
+    summary: STAT_SUMMARIES[stat],
+    generatedColumns: Object.freeze([...columns]),
+    compatibleGeoms: buildCompatibleGeoms(stat),
+    defaultForGeoms: buildDefaultForGeoms(stat),
+  });
+}
+
+function buildStatReference(): Readonly<Record<StatName, StatReferenceEntry>> {
+  const out = {} as Record<StatName, StatReferenceEntry>;
+  for (const stat of KNOWN_STATS) {
+    out[stat] = buildEntry(stat);
+  }
+  return Object.freeze(out);
+}
+
+/**
+ * Complete per-stat API reference. Keys are exactly KNOWN_STATS.
+ * Compatible geoms invert GEOM_REFERENCE; columns come from STAT_COLUMNS.
+ */
+export const STAT_REFERENCE: Readonly<Record<StatName, StatReferenceEntry>> = buildStatReference();
+
+/** Stable list order matching KNOWN_STATS (docs index, search, inventory). */
+export function statReferenceList(): readonly StatReferenceEntry[] {
+  return KNOWN_STATS.map((stat) => STAT_REFERENCE[stat]);
+}

--- a/packages/spec/tests/stat-reference.test.ts
+++ b/packages/spec/tests/stat-reference.test.ts
@@ -1,0 +1,94 @@
+/**
+ * STAT_REFERENCE: per-stat API docs derived from catalogs + GEOM_REFERENCE.
+ * Completeness and shape tests — the public seam for schema-driven stat reference.
+ */
+import { describe, expect, it } from "bun:test";
+
+import { GEOM_DEFAULTS, KNOWN_GEOMS, KNOWN_STATS } from "../src/schema-catalog.ts";
+import { STAT_COLUMNS } from "../src/validate-data-checks-layer.ts";
+import {
+  STAT_REFERENCE,
+  statReferenceList,
+  type StatReferenceEntry,
+} from "../src/stat-reference.ts";
+
+describe("STAT_REFERENCE", () => {
+  it("covers every KNOWN_STATS entry exactly once", () => {
+    expect(Object.keys(STAT_REFERENCE).toSorted()).toEqual([...KNOWN_STATS].toSorted());
+    expect(KNOWN_STATS).toHaveLength(28);
+  });
+
+  it("every entry has a non-empty summary and matching slug", () => {
+    for (const stat of KNOWN_STATS) {
+      const entry = STAT_REFERENCE[stat];
+      expect(entry.name, stat).toBe(stat);
+      expect(entry.slug, stat).toBe(stat);
+      expect(entry.summary.trim().length, `${stat} summary`).toBeGreaterThan(20);
+    }
+  });
+
+  it("generatedColumns match STAT_COLUMNS when present, else empty", () => {
+    for (const stat of KNOWN_STATS) {
+      const entry = STAT_REFERENCE[stat];
+      const expected = STAT_COLUMNS[stat] ?? [];
+      expect([...entry.generatedColumns], stat).toEqual([...expected]);
+    }
+  });
+
+  it("compatibleGeoms are non-empty subsets of KNOWN_GEOMS that allow the stat", () => {
+    const geoms = new Set<string>(KNOWN_GEOMS);
+    for (const stat of KNOWN_STATS) {
+      const entry = STAT_REFERENCE[stat];
+      expect(entry.compatibleGeoms.length, `${stat} geoms`).toBeGreaterThan(0);
+      for (const geom of entry.compatibleGeoms) {
+        expect(geoms.has(geom), `${stat} unknown geom ${geom}`).toBe(true);
+        expect(GEOM_DEFAULTS[geom], `${stat}→${geom}`).toBeDefined();
+      }
+    }
+  });
+
+  it("defaultForGeoms matches GEOM_DEFAULTS and is a subset of compatibleGeoms", () => {
+    for (const stat of KNOWN_STATS) {
+      const entry = STAT_REFERENCE[stat];
+      const fromDefaults = KNOWN_GEOMS.filter((g) => GEOM_DEFAULTS[g].stat === stat);
+      expect([...entry.defaultForGeoms].toSorted(), stat).toEqual([...fromDefaults].toSorted());
+      for (const geom of entry.defaultForGeoms) {
+        expect(entry.compatibleGeoms, `${stat} default ${geom}`).toContain(geom);
+      }
+    }
+  });
+
+  it("count documents bar default and generated count column", () => {
+    const count = STAT_REFERENCE.count;
+    expect(count.defaultForGeoms).toContain("bar");
+    expect(count.compatibleGeoms).toContain("bar");
+    expect([...count.generatedColumns]).toEqual(["count"]);
+    expect(count.summary.toLowerCase()).toMatch(/count|row/);
+  });
+
+  it("bin documents histogram/freqpoly defaults and density columns", () => {
+    const bin = STAT_REFERENCE.bin;
+    expect(bin.defaultForGeoms).toContain("histogram");
+    expect(bin.defaultForGeoms).toContain("freqpoly");
+    expect(bin.generatedColumns).toContain("count");
+    expect(bin.generatedColumns).toContain("density");
+  });
+
+  it("identity is the default for most geoms and has no generated columns", () => {
+    const identity = STAT_REFERENCE.identity;
+    expect(identity.generatedColumns).toEqual([]);
+    expect(identity.defaultForGeoms.length).toBeGreaterThan(20);
+  });
+
+  it("statReferenceList order matches KNOWN_STATS", () => {
+    expect(statReferenceList().map((e) => e.name)).toEqual([...KNOWN_STATS]);
+  });
+});
+
+describe("StatReferenceEntry stability", () => {
+  it("entry shape is serializable JSON (docs artifact seam)", () => {
+    const sample: StatReferenceEntry = STAT_REFERENCE.smooth;
+    const roundTrip = JSON.parse(JSON.stringify(sample)) as StatReferenceEntry;
+    expect(roundTrip).toEqual(sample);
+  });
+});

--- a/scripts/check-pages-links.test.ts
+++ b/scripts/check-pages-links.test.ts
@@ -26,6 +26,8 @@ describe("packed Pages link checks", () => {
     "reference/geoms.html",
     "reference/geoms/point.html",
     "reference/geoms/line.html",
+    "reference/stats.html",
+    "reference/stats/count.html",
     "examples/interaction/tooltip.html",
     "interactions/brush-zoom.html",
     "interactions/linked-views.html",
@@ -102,6 +104,8 @@ describe("packed Pages link checks", () => {
     expect(requiredPages).toContain("reference/geoms.html");
     expect(requiredPages).toContain("reference/geoms/point.html");
     expect(requiredPages).toContain("reference/geoms/line.html");
+    expect(requiredPages).toContain("reference/stats.html");
+    expect(requiredPages).toContain("reference/stats/count.html");
     expect(requiredPages).toContain("guide/interaction-reference.html");
     expect(requiredPages).toContain("robots.txt");
     expect(requiredPages).toContain("sitemap.xml");

--- a/scripts/check-pages-links.ts
+++ b/scripts/check-pages-links.ts
@@ -18,6 +18,8 @@ export const requiredPages = [
   "reference/geoms.html",
   "reference/geoms/point.html",
   "reference/geoms/line.html",
+  "reference/stats.html",
+  "reference/stats/count.html",
   "examples/interaction/tooltip.html",
   "interactions/brush-zoom.html",
   "interactions/linked-views.html",

--- a/scripts/docs-route-inventory.test.ts
+++ b/scripts/docs-route-inventory.test.ts
@@ -132,7 +132,7 @@ describe("docs route inventory", () => {
       index: true,
       sitemap: true,
       shell: "docs",
-      navigation: { section: "Reference", label: "CLI reference", order: 54 },
+      navigation: { section: "Reference", label: "CLI reference", order: 55 },
     });
     expect(cliRoute?.headings?.filter((heading) => heading.level === 3)).toEqual(
       CLI_REFERENCE_OPTIONS.map((option) => ({

--- a/scripts/docs-route-inventory.test.ts
+++ b/scripts/docs-route-inventory.test.ts
@@ -38,6 +38,8 @@ describe("docs route inventory", () => {
     expect(paths.has("/reference/geoms")).toBe(true);
     expect(paths.has("/reference/geoms/point")).toBe(true);
     expect(paths.has("/reference/geoms/bin_2d")).toBe(true);
+    expect(paths.has("/reference/stats")).toBe(true);
+    expect(paths.has("/reference/stats/count")).toBe(true);
     expect(paths.has("/reference/interactions")).toBe(true);
     expect(paths.has("/reference/cli")).toBe(true);
     expect(paths.has("/__perf/r3-interaction")).toBe(true);
@@ -101,6 +103,26 @@ describe("docs route inventory", () => {
     );
   });
 
+  it("publishes the stat reference inside the one Reference hierarchy", () => {
+    const inventory = createDocsRouteInventory();
+    const index = inventory.find((entry) => entry.path === "/reference/stats");
+    expect(index).toMatchObject({
+      title: "Stat reference — ggsvelte",
+      canonicalPath: "/reference/stats",
+      kind: "page",
+      index: true,
+      sitemap: true,
+      shell: "docs",
+      navigation: { section: "Reference", label: "Stat reference", order: 52 },
+    });
+    const details = inventory.filter((entry) => entry.path.startsWith("/reference/stats/"));
+    expect(details.length).toBe(28);
+    expect(details.every((entry) => entry.navigation === undefined)).toBe(true);
+    expect(inventory.find((entry) => entry.path === "/reference/stats/count")?.title).toBe(
+      "stat count — ggsvelte",
+    );
+  });
+
   it("publishes the CLI reference inside the one Reference hierarchy", () => {
     const cliRoute = createDocsRouteInventory().find((entry) => entry.path === "/reference/cli");
     expect(cliRoute).toMatchObject({
@@ -110,7 +132,7 @@ describe("docs route inventory", () => {
       index: true,
       sitemap: true,
       shell: "docs",
-      navigation: { section: "Reference", label: "CLI reference", order: 53 },
+      navigation: { section: "Reference", label: "CLI reference", order: 54 },
     });
     expect(cliRoute?.headings?.filter((heading) => heading.level === 3)).toEqual(
       CLI_REFERENCE_OPTIONS.map((option) => ({

--- a/scripts/docs-route-inventory.ts
+++ b/scripts/docs-route-inventory.ts
@@ -8,6 +8,7 @@ import {
 import { GUIDE_CATALOG, type GuideCatalogEntry } from "../apps/docs/src/lib/catalog/guide.ts";
 import type { DocsRouteMetadata, RouteHeading } from "../apps/docs/src/lib/route-types.ts";
 import { geomReferenceList } from "../packages/spec/src/geom-reference.ts";
+import { statReferenceList } from "../packages/spec/src/stat-reference.ts";
 import { CLI_REFERENCE_OPTIONS } from "./cli-docs.ts";
 
 /** Script-side name for the shared route metadata contract (`DocsRouteMetadata`). */
@@ -111,6 +112,22 @@ const TOP_LEVEL_ROUTES: readonly DocsRouteRecord[] = [
     ],
   },
   {
+    path: "/reference/stats",
+    title: "Stat reference — ggsvelte",
+    description:
+      "Schema-derived API reference for every statistical transform: after_stat columns and compatible geoms.",
+    canonicalPath: "/reference/stats",
+    kind: "page",
+    index: true,
+    sitemap: true,
+    shell: "docs",
+    navigation: { section: "Reference", label: "Stat reference", order: 52 },
+    headings: [
+      { id: "all-stats", title: "All stats", level: 2 },
+      { id: "how-to-set", title: "How to set a stat", level: 2 },
+    ],
+  },
+  {
     path: "/reference/interactions",
     title: "Search interactions — ggsvelte",
     description:
@@ -120,7 +137,7 @@ const TOP_LEVEL_ROUTES: readonly DocsRouteRecord[] = [
     index: true,
     sitemap: true,
     shell: "docs",
-    navigation: { section: "Reference", label: "Interaction reference", order: 52 },
+    navigation: { section: "Reference", label: "Interaction reference", order: 53 },
   },
   {
     path: "/reference/cli",
@@ -132,7 +149,7 @@ const TOP_LEVEL_ROUTES: readonly DocsRouteRecord[] = [
     index: true,
     sitemap: true,
     shell: "docs",
-    navigation: { section: "Reference", label: "CLI reference", order: 53 },
+    navigation: { section: "Reference", label: "CLI reference", order: 54 },
     headings: [
       { id: "input-and-output", title: "Input and output", level: 2 },
       { id: "options", title: "Options", level: 2 },
@@ -185,6 +202,47 @@ function geomDetailRoutes(): DocsRouteRecord[] {
       // summaries share phrasing across aliases or related marks.
       description: `${entry.component}: ${entry.summary}`,
       canonicalPath: `/reference/geoms/${entry.slug}`,
+      kind: "page" as const,
+      index: true,
+      sitemap: true,
+      shell: "docs" as const,
+      headings,
+    };
+  });
+}
+
+/** Same matching rule as apps/docs reference/stats/[name] page load. */
+function statHasRelatedExamples(stat: string): boolean {
+  const compact = stat.replaceAll("_", "");
+  const dashed = stat.replaceAll("_", "-");
+  return EXAMPLES.some(
+    (entry) =>
+      entry.category === stat ||
+      entry.category === compact ||
+      entry.tags.includes(stat) ||
+      entry.tags.includes(dashed) ||
+      entry.tags.includes(`stat-${stat}`) ||
+      entry.tags.includes(`stat_${stat}`),
+  );
+}
+
+/** One indexable page per KNOWN_STATS entry. */
+function statDetailRoutes(): DocsRouteRecord[] {
+  return statReferenceList().map((entry) => {
+    const headings: RouteHeading[] = [
+      { id: "usage", title: "Usage", level: 2 },
+      { id: "generated-columns", title: "Generated columns (after_stat)", level: 2 },
+      { id: "default-for", title: "Default for geoms", level: 2 },
+      { id: "compatible-geoms", title: "Compatible geoms", level: 2 },
+    ];
+    if (statHasRelatedExamples(entry.name)) {
+      headings.push({ id: "examples", title: "Examples", level: 2 });
+    }
+    return {
+      path: `/reference/stats/${entry.slug}`,
+      title: `stat ${entry.name} — ggsvelte`,
+      description: `stat "${entry.name}": ${entry.summary}`,
+      canonicalPath: `/reference/stats/${entry.slug}`,
       kind: "page" as const,
       index: true,
       sitemap: true,
@@ -334,6 +392,7 @@ export function createDocsRouteInventory(): DocsRouteRecord[] {
   return validateRouteInventory([
     ...TOP_LEVEL_ROUTES,
     ...geomDetailRoutes(),
+    ...statDetailRoutes(),
     ...guides,
     ...examples,
     ...interactionExpositions,

--- a/scripts/docs-route-inventory.ts
+++ b/scripts/docs-route-inventory.ts
@@ -137,7 +137,8 @@ const TOP_LEVEL_ROUTES: readonly DocsRouteRecord[] = [
     index: true,
     sitemap: true,
     shell: "docs",
-    navigation: { section: "Reference", label: "Interaction reference", order: 53 },
+    // order 53 reserved for /reference/positions (next follow-up)
+    navigation: { section: "Reference", label: "Interaction reference", order: 54 },
   },
   {
     path: "/reference/cli",
@@ -149,7 +150,7 @@ const TOP_LEVEL_ROUTES: readonly DocsRouteRecord[] = [
     index: true,
     sitemap: true,
     shell: "docs",
-    navigation: { section: "Reference", label: "CLI reference", order: 54 },
+    navigation: { section: "Reference", label: "CLI reference", order: 55 },
     headings: [
       { id: "input-and-output", title: "Input and output", level: 2 },
       { id: "options", title: "Options", level: 2 },

--- a/scripts/gen-llms.ts
+++ b/scripts/gen-llms.ts
@@ -400,6 +400,7 @@ export function buildLlmsIndex(
   }
   lines.push(
     "- [Geom reference](/reference/geoms): every Geom* component with defaults, allowed stats/positions, and params from the schema",
+    "- [Stat reference](/reference/stats): every statistical transform with after_stat columns and compatible geoms",
     "- [Search interaction reference](/reference/interactions): filter interaction capabilities, events, diagnostics, and accessibility guidance",
     "- [JSON Schema v0](/schema/v0.json): the PortableSpec schema (unstable in v0.1)",
     "- [llms-full.txt](/llms-full.txt): all docs prose plus every example (spec JSON + Svelte source)",

--- a/scripts/llms-guide-content.ts
+++ b/scripts/llms-guide-content.ts
@@ -214,6 +214,11 @@ export const STATISTICS_POSITIONS_MD = `# Statistics and positions
 Stats derive marks from mapped rows. Positions control how derived marks share
 coordinate space.
 
+The full list of statistical transforms lives in the
+[stat reference](/reference/stats): after_stat columns and which geoms accept
+each value. Open a specific stat, for example [count](/reference/stats/count)
+or [smooth](/reference/stats/smooth).
+
 ## Statistical summaries
 
 \`\`\`svelte fragment

--- a/tests/visual/docs-progressive-search.spec.ts
+++ b/tests/visual/docs-progressive-search.spec.ts
@@ -147,7 +147,7 @@ test("Docs landing and sidebar expose the full path without duplicate Reference"
   ]);
   // Overview + guides minus deleted pre-0.1 page.
   // Overview + every navigable guide/reference chapter (includes Geom reference).
-  await expect(sidebar.getByRole("link")).toHaveCount(26);
+  await expect(sidebar.getByRole("link")).toHaveCount(27);
   await expect(sidebar.getByRole("link", { name: "Dates without preprocessing" })).toBeVisible();
   await expectNoDocumentOverflow(page);
 

--- a/tests/visual/docs-shell.spec.ts
+++ b/tests/visual/docs-shell.spec.ts
@@ -124,7 +124,7 @@ test("desktop docs shell exposes chapter, breadcrumb, contents, and sequence nav
   const chapters = page.getByRole("navigation", { name: "Guide chapters" });
   await expect(chapters).toBeVisible();
   // Overview + every navigable guide/reference chapter (includes Geom reference).
-  await expect(chapters.getByRole("link")).toHaveCount(26);
+  await expect(chapters.getByRole("link")).toHaveCount(27);
   await expect(chapters.getByRole("link", { name: "Dates without preprocessing" })).toBeVisible();
   await expect(page.getByRole("navigation", { name: "Breadcrumb" })).toContainText(
     "Getting started",


### PR DESCRIPTION
## Summary

- Export `STAT_REFERENCE` / `statReferenceList()` from `@ggsvelte/spec` (summaries, `STAT_COLUMNS` after_stat list, compatible geoms inverted from `GEOM_REFERENCE`).
- Add `/reference/stats` index + `/reference/stats/<name>` detail pages (Svelte/JSON usage, columns, geom links).
- Wire route inventory, search, lifecycle, llms index, docs/reference landings, sidebar count (27), and geom detail links to each allowed stat.

## Test plan

- [x] `bun test packages/spec/tests/stat-reference.test.ts`
- [x] `bun test scripts/docs-route-inventory.test.ts`
- [x] `bun run lifecycle:gen` / `docs:routes:gen` / `docs:search:gen`
- [ ] CI green
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1100" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->