### PR TITLE
refactor(svelte): own presentation focus on inspection (#1080)

### DIFF
--- a/packages/svelte/src/lib/inspection/inspection-state.svelte.ts
+++ b/packages/svelte/src/lib/inspection/inspection-state.svelte.ts
@@ -35,6 +35,10 @@ import type {
 import { inspectionLiveText as inspectionLiveTextFor } from "../assembly/labels.js";
 import { plotTooltipDomId } from "../assembly/layout.js";
 import {
+  presentationFocusFromInspection,
+  type PresentationInspectionFocus,
+} from "../selection/selection.js";
+import {
   resolveInspectionCompleteness,
   resolveInspectionMode,
   resolveSetInspectionAction,
@@ -105,6 +109,11 @@ export type InspectionState = {
   readonly inspectionPanel: InspectionPanelBounds | null;
   /** Seed candidate for presentation chrome (kind); not emitted on public events. */
   readonly inspectionSeed: CandidateFacts | null;
+  /**
+   * Presentation focus for semantic masks / mute-siblings (#1080).
+   * Owned here so plot-engine does not re-assemble focus + seed fields.
+   */
+  readonly presentationFocus: PresentationInspectionFocus | null;
   setInspection(
     candidate: CandidateFacts | null,
     source: InteractionSource,
@@ -200,6 +209,10 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
     if (viewportPanel === null) return null;
     return { id: viewportPanel.id, ...panelBoundsFrom(viewportPanel.bounds) };
   });
+
+  // Single owner for the presentation-focus shape (#1080). Survives pin toggle
+  // when seed + focus keys are stable; consumers stop rebuilding the projection.
+  const presentationFocus = $derived(presentationFocusFromInspection(inspection, inspectionSeed));
 
   // Coordinator closes over keyAt — handler-only invocation (deferred).
   const inspectionCoordinator = createInspectionCoordinator<Record<string, CellValue>, PropertyKey>(
@@ -564,6 +577,9 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
     /** Internal seed for presentation chrome (kind); not part of the public inspection event. */
     get inspectionSeed() {
       return inspectionSeed;
+    },
+    get presentationFocus() {
+      return presentationFocus;
     },
     setInspection,
     toggleInspectionPin,

--- a/packages/svelte/src/lib/plot-engine.svelte.ts
+++ b/packages/svelte/src/lib/plot-engine.svelte.ts
@@ -567,25 +567,8 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
     intervals: () => intervalState.effectiveIntervals,
     emphasisKeys: () => legendFocusState.effectiveEmphasisKeys,
     muteSiblingsOnInspect: () => interactionConfig.inspect?.muteSiblings === true,
-    inspectionFocus: () => {
-      const current = inspectionState.inspection;
-      const seed = inspectionState.inspectionSeed;
-      if (current === null) return null;
-      return {
-        sourceKeys: current.focus.sourceKeys,
-        key: current.focus.key,
-        kind: seed?.kind ?? null,
-        primitives:
-          seed === null
-            ? []
-            : Object.freeze([
-                {
-                  batchIndex: seed.batchIndex,
-                  primitiveIndex: seed.primitiveIndex,
-                },
-              ]),
-      };
-    },
+    // Inspection owns the projection (#1080); wiring no longer re-assembles it.
+    inspectionFocus: () => inspectionState.presentationFocus,
   });
   // ------------------------------------------------- plot chrome
   // All host bindings earlier-declared. Pure construction-time deriveds —
@@ -676,9 +659,10 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
       return semanticCandidateProjection.emphasizedAnchors;
     },
     get hoverChrome() {
-      // Read inspection $state so chrome updates with seed (plain let).
-      if (inspectionState.inspection === null) return "ring";
-      return presentationChromeForKind(inspectionState.inspectionSeed?.kind);
+      // presentationFocus carries seed kind; null inspection → default ring.
+      const focus = inspectionState.presentationFocus;
+      if (focus === null) return "ring";
+      return presentationChromeForKind(focus.kind);
     },
     get interactionMasks() {
       return semanticCandidateProjection.interactionMasks;

--- a/packages/svelte/src/lib/selection/selection.ts
+++ b/packages/svelte/src/lib/selection/selection.ts
@@ -202,6 +202,47 @@ export type PresentationInspectionFocus = {
   }[];
 };
 
+/**
+ * Minimal seed facts for presentation projection (#1080).
+ * Inspection owns the full CandidateFacts; consumers only need kind + primitive.
+ */
+export type PresentationSeedFacts = {
+  readonly kind: string;
+  readonly batchIndex: number;
+  readonly primitiveIndex: number;
+} | null;
+
+/**
+ * One owner for the plot-engine → semantic-projection focus shape (#1080).
+ * Projects live inspection + seed into PresentationInspectionFocus so wiring
+ * files do not re-assemble the same fields.
+ */
+export function presentationFocusFromInspection(
+  inspection: {
+    readonly focus: {
+      readonly sourceKeys: readonly PropertyKey[];
+      readonly key: PropertyKey | null;
+    };
+  } | null,
+  seed: PresentationSeedFacts,
+): PresentationInspectionFocus | null {
+  if (inspection === null) return null;
+  return {
+    sourceKeys: inspection.focus.sourceKeys,
+    key: inspection.focus.key,
+    kind: seed?.kind ?? null,
+    primitives:
+      seed === null
+        ? []
+        : Object.freeze([
+            {
+              batchIndex: seed.batchIndex,
+              primitiveIndex: seed.primitiveIndex,
+            },
+          ]),
+  };
+}
+
 export type MergePresentationFocusOptions = {
   /**
    * When true, empty-emphasis rect inspection contributes focus keys so

--- a/packages/svelte/tests/inspection/inspection-state.pin-queue.test.ts
+++ b/packages/svelte/tests/inspection/inspection-state.pin-queue.test.ts
@@ -26,6 +26,40 @@ import {
   type InspectCb,
 } from "./inspection-state.harness.js";
 
+describe("createInspectionState presentationFocus (#1080)", () => {
+  it("owns the presentation focus projection so plot-engine does not re-assemble it", () => {
+    const model = modelFor(continuousSpec());
+    const { state, destroy } = mountInspectionController({ model: () => model });
+
+    expect(state.presentationFocus).toBeNull();
+
+    const { candidate } = candidateHit(model);
+    state.setInspection(candidate, "pointer", "transient", "xy");
+    flushSync();
+
+    const focus = state.presentationFocus;
+    expect(focus).not.toBeNull();
+    expect(focus!.sourceKeys).toEqual(state.inspection!.focus.sourceKeys);
+    expect(focus!.key).toBe(state.inspection!.focus.key);
+    expect(focus!.kind).toBe(candidate.kind);
+    expect(focus!.primitives).toEqual([
+      { batchIndex: candidate.batchIndex, primitiveIndex: candidate.primitiveIndex },
+    ]);
+
+    // Pin flips state; presentation fields from seed + focus stay stable.
+    state.toggleInspectionPin("pointer");
+    flushSync();
+    expect(state.inspection?.state).toBe("pinned");
+    expect(state.presentationFocus).toEqual(focus);
+
+    // Pinned null-clear is ignored; dismiss ends the session.
+    state.dismissInspection("close", "pointer");
+    flushSync();
+    expect(state.presentationFocus).toBeNull();
+    destroy();
+  });
+});
+
 describe("createInspectionState setInspection", () => {
   it("applies a transient snapshot and gates re-emits by fingerprint", () => {
     const model = modelFor(continuousSpec());

--- a/packages/svelte/tests/selection/selection.test.ts
+++ b/packages/svelte/tests/selection/selection.test.ts
@@ -7,6 +7,7 @@ import {
   iterateCandidates,
   mergePresentationFocusKeys,
   nextPointSelectionKeys,
+  presentationFocusFromInspection,
   rowIndexesForCandidate,
   sameOrderedPropertyKeys,
   uniqueKeysFromRowIndexes,
@@ -246,6 +247,58 @@ describe("buildPointSelectionEvent", () => {
     expect(event.phase).toBe("clear");
     expect(event.keys).toEqual([]);
     expect(Object.isFrozen(event.keys)).toBe(true);
+  });
+});
+
+describe("presentationFocusFromInspection (#1080)", () => {
+  it("returns null when inspection is null", () => {
+    expect(
+      presentationFocusFromInspection(null, {
+        kind: "points",
+        batchIndex: 0,
+        primitiveIndex: 1,
+      }),
+    ).toBeNull();
+  });
+
+  it("projects focus keys and seed kind/primitives into PresentationInspectionFocus", () => {
+    const focus = presentationFocusFromInspection(
+      {
+        focus: { sourceKeys: ["a", "b"], key: "a" },
+      },
+      { kind: "rects", batchIndex: 2, primitiveIndex: 4 },
+    );
+    expect(focus).toEqual({
+      sourceKeys: ["a", "b"],
+      key: "a",
+      kind: "rects",
+      primitives: [{ batchIndex: 2, primitiveIndex: 4 }],
+    });
+    expect(Object.isFrozen(focus!.primitives)).toBe(true);
+  });
+
+  it("uses null kind and empty primitives when seed is absent", () => {
+    expect(
+      presentationFocusFromInspection({ focus: { sourceKeys: ["k"], key: null } }, null),
+    ).toEqual({
+      sourceKeys: ["k"],
+      key: null,
+      kind: null,
+      primitives: [],
+    });
+  });
+
+  it("keeps the same projection across pin state (seed stable, focus keys stable)", () => {
+    const seed = { kind: "points", batchIndex: 0, primitiveIndex: 0 };
+    const transient = presentationFocusFromInspection(
+      { focus: { sourceKeys: ["row-1"], key: "row-1" } },
+      seed,
+    );
+    const pinned = presentationFocusFromInspection(
+      { focus: { sourceKeys: ["row-1"], key: "row-1" } },
+      seed,
+    );
+    expect(transient).toEqual(pinned);
   });
 });
 


### PR DESCRIPTION
## Summary

Closes #1080.

### Why #1080 stayed open

| Piece | Status before this PR |
|-------|------------------------|
| Three nearest-hit lookups → `resolveTarget` | Done in #1095 |
| Distance-policy table | Done in #1095 |
| `InteractionCandidateRef` not re-declared | Done in #1095 |
| #1079 scoped store (sequencing prerequisite) | Done in #1096 |
| Delete plot-engine `inspectionFocus` adapter | **Still open** |
| Live presentation projection owned by inspection | **Still open** |

#1093 fixed `chromeState!` construction order (#1082), not this issue. #1095 intentionally left encoding / plot-engine work as follow-up once #1079 landed.

### What this PR does

- Add pure `presentationFocusFromInspection` (inspection + seed → `PresentationInspectionFocus`)
- Expose `InspectionState.presentationFocus` as a `$derived`
- Delete the 19-line plot-engine adapter; wire `inspectionFocus: () => inspectionState.presentationFocus`
- `hoverChrome` reads `presentationFocus.kind` instead of reaching into `inspectionSeed`

### Out of scope (deliberately not #1080 anymore)

These were listed on the original issue / #1095 residual list but are a different job:

1. **Candidate-store full-scan consolidation** (coordinator / interval / selection) — index / projection work, not “thing under the pointer”
2. **Keyboard through `resolveTarget`** — keyboard uses traversal (`activeCandidateId`), not nearest; a `TargetIntent: "keyboard"` would be the wrong API
3. **Collapsing internal inspect queue / seed / id into one runtime object** — temporal queue state is not the same as live focus; further collapse is optional cleanup, not a deletion test failure

## Test plan

- [x] `bun run test:browser -- tests/selection/selection.test.ts tests/inspection/inspection-state.pin-queue.test.ts` (chromium/webkit/firefox)
- [x] `bun run check` (0 errors / 0 warnings)
- [ ] CI green on this PR
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1102" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->