### PR TITLE
docs(reference): schema-derived position API for every adjustment

### DIFF
--- a/.changeset/position-api-reference.md
+++ b/.changeset/position-api-reference.md
@@ -1,0 +1,16 @@
+---
+"@ggsvelte/spec": minor
+"@ggsvelte/core": patch
+"@ggsvelte/svelte": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+feat(spec): export schema-derived `POSITION_REFERENCE` for every position
+
+`POSITION_REFERENCE` / `positionReferenceList()` publish each position
+adjustment's summary, `positionParams` (from the PositionParams schema for
+jitter/nudge), and compatible geoms. The docs site uses this for
+`/reference/positions`.
+
+Migration: none — additive

--- a/apps/docs/src/lib/generated/routes.ts
+++ b/apps/docs/src/lib/generated/routes.ts
@@ -141,6 +141,34 @@ export const DOCS_ROUTES = [
     ],
   },
   {
+    path: "/reference/positions",
+    title: "Position reference — ggsvelte",
+    description:
+      "Schema-derived API reference for every position adjustment: positionParams and compatible geoms.",
+    canonicalPath: "/reference/positions",
+    kind: "page",
+    index: true,
+    sitemap: true,
+    shell: "docs",
+    navigation: {
+      section: "Reference",
+      label: "Position reference",
+      order: 53,
+    },
+    headings: [
+      {
+        id: "all-positions",
+        title: "All positions",
+        level: 2,
+      },
+      {
+        id: "how-to-set",
+        title: "How to set a position",
+        level: 2,
+      },
+    ],
+  },
+  {
     path: "/reference/interactions",
     title: "Search interactions — ggsvelte",
     description:
@@ -3616,6 +3644,229 @@ export const DOCS_ROUTES = [
     ],
   },
   {
+    path: "/reference/positions/identity",
+    title: "position identity — ggsvelte",
+    description:
+      'position "identity": Leave mark coordinates unchanged. Default for most geoms: each mark keeps its post-stat (x, y).',
+    canonicalPath: "/reference/positions/identity",
+    kind: "page",
+    index: true,
+    sitemap: true,
+    shell: "docs",
+    headings: [
+      {
+        id: "usage",
+        title: "Usage",
+        level: 2,
+      },
+      {
+        id: "params",
+        title: "positionParams",
+        level: 2,
+      },
+      {
+        id: "default-for",
+        title: "Default for geoms",
+        level: 2,
+      },
+      {
+        id: "compatible-geoms",
+        title: "Compatible geoms",
+        level: 2,
+      },
+      {
+        id: "examples",
+        title: "Examples",
+        level: 2,
+      },
+    ],
+  },
+  {
+    path: "/reference/positions/stack",
+    title: "position stack — ggsvelte",
+    description:
+      'position "stack": Stack groups at each x slot so heights accumulate (positive up, negative down). Default for bar, col, histogram, and area; trains the scale on stacked totals.',
+    canonicalPath: "/reference/positions/stack",
+    kind: "page",
+    index: true,
+    sitemap: true,
+    shell: "docs",
+    headings: [
+      {
+        id: "usage",
+        title: "Usage",
+        level: 2,
+      },
+      {
+        id: "params",
+        title: "positionParams",
+        level: 2,
+      },
+      {
+        id: "default-for",
+        title: "Default for geoms",
+        level: 2,
+      },
+      {
+        id: "compatible-geoms",
+        title: "Compatible geoms",
+        level: 2,
+      },
+      {
+        id: "examples",
+        title: "Examples",
+        level: 2,
+      },
+    ],
+  },
+  {
+    path: "/reference/positions/fill",
+    title: "position fill — ggsvelte",
+    description:
+      'position "fill": Stack groups then rescale each x slot to proportions (positive and negative runs separately). Same geom set as stack; y domain becomes proportions.',
+    canonicalPath: "/reference/positions/fill",
+    kind: "page",
+    index: true,
+    sitemap: true,
+    shell: "docs",
+    headings: [
+      {
+        id: "usage",
+        title: "Usage",
+        level: 2,
+      },
+      {
+        id: "params",
+        title: "positionParams",
+        level: 2,
+      },
+      {
+        id: "default-for",
+        title: "Default for geoms",
+        level: 2,
+      },
+      {
+        id: "compatible-geoms",
+        title: "Compatible geoms",
+        level: 2,
+      },
+      {
+        id: "examples",
+        title: "Examples",
+        level: 2,
+      },
+    ],
+  },
+  {
+    path: "/reference/positions/dodge",
+    title: "position dodge — ggsvelte",
+    description:
+      'position "dodge": Place groups side by side within each x band instead of overlapping. Default for boxplot and violin; used when comparing categories at the same x.',
+    canonicalPath: "/reference/positions/dodge",
+    kind: "page",
+    index: true,
+    sitemap: true,
+    shell: "docs",
+    headings: [
+      {
+        id: "usage",
+        title: "Usage",
+        level: 2,
+      },
+      {
+        id: "params",
+        title: "positionParams",
+        level: 2,
+      },
+      {
+        id: "default-for",
+        title: "Default for geoms",
+        level: 2,
+      },
+      {
+        id: "compatible-geoms",
+        title: "Compatible geoms",
+        level: 2,
+      },
+      {
+        id: "examples",
+        title: "Examples",
+        level: 2,
+      },
+    ],
+  },
+  {
+    path: "/reference/positions/jitter",
+    title: "position jitter — ggsvelte",
+    description:
+      'position "jitter": Add seeded random offsets so overplotted points separate. Configure with positionParams width/height/seed (always seeded for reproducibility).',
+    canonicalPath: "/reference/positions/jitter",
+    kind: "page",
+    index: true,
+    sitemap: true,
+    shell: "docs",
+    headings: [
+      {
+        id: "usage",
+        title: "Usage",
+        level: 2,
+      },
+      {
+        id: "params",
+        title: "positionParams",
+        level: 2,
+      },
+      {
+        id: "default-for",
+        title: "Default for geoms",
+        level: 2,
+      },
+      {
+        id: "compatible-geoms",
+        title: "Compatible geoms",
+        level: 2,
+      },
+      {
+        id: "examples",
+        title: "Examples",
+        level: 2,
+      },
+    ],
+  },
+  {
+    path: "/reference/positions/nudge",
+    title: "position nudge — ggsvelte",
+    description:
+      'position "nudge": Apply a fixed offset (positionParams.x / y) per mark — useful for labels beside points. Offsets are data units or band-step fractions.',
+    canonicalPath: "/reference/positions/nudge",
+    kind: "page",
+    index: true,
+    sitemap: true,
+    shell: "docs",
+    headings: [
+      {
+        id: "usage",
+        title: "Usage",
+        level: 2,
+      },
+      {
+        id: "params",
+        title: "positionParams",
+        level: 2,
+      },
+      {
+        id: "default-for",
+        title: "Default for geoms",
+        level: 2,
+      },
+      {
+        id: "compatible-geoms",
+        title: "Compatible geoms",
+        level: 2,
+      },
+    ],
+  },
+  {
     path: "/guide/getting-started",
     title: "Getting started — ggsvelte",
     description: "Install @ggsvelte/svelte and render one chart from a Svelte file.",
@@ -5748,8 +5999,8 @@ export const DOCS_ROUTES = [
         level: 2,
       },
       {
-        id: "experimental-868",
-        title: "experimental (868)",
+        id: "experimental-872",
+        title: "experimental (872)",
         level: 3,
       },
       {
@@ -7155,6 +7406,10 @@ export const GUIDE_NAVIGATION = [
       {
         path: "/reference/stats",
         label: "Stat reference",
+      },
+      {
+        path: "/reference/positions",
+        label: "Position reference",
       },
       {
         path: "/reference/interactions",

--- a/apps/docs/src/lib/generated/search-index.ts
+++ b/apps/docs/src/lib/generated/search-index.ts
@@ -127,6 +127,36 @@ export const DOCS_SEARCH_INDEX = [
     exact: ["How to set a stat"],
   },
   {
+    id: "page:reference-positions",
+    kind: "page",
+    title: "Position reference",
+    summary:
+      "Schema-derived API reference for every position adjustment: positionParams and compatible geoms.",
+    href: "/reference/positions",
+    keywords: ["Reference"],
+    exact: ["Position reference"],
+  },
+  {
+    id: "heading:reference-positions:all-positions",
+    kind: "heading",
+    title: "All positions",
+    summary:
+      "All positions in Position reference. Schema-derived API reference for every position adjustment: positionParams and compatible geoms.",
+    href: "/reference/positions#all-positions",
+    keywords: ["Position reference", "Reference"],
+    exact: ["All positions"],
+  },
+  {
+    id: "heading:reference-positions:how-to-set",
+    kind: "heading",
+    title: "How to set a position",
+    summary:
+      "How to set a position in Position reference. Schema-derived API reference for every position adjustment: positionParams and compatible geoms.",
+    href: "/reference/positions#how-to-set",
+    keywords: ["Position reference", "Reference"],
+    exact: ["How to set a position"],
+  },
+  {
     id: "page:reference-interactions",
     kind: "page",
     title: "Search interactions",
@@ -5737,6 +5767,356 @@ export const DOCS_SEARCH_INDEX = [
     exact: ["Compatible geoms"],
   },
   {
+    id: "page:reference-positions-identity",
+    kind: "page",
+    title: "position identity",
+    summary:
+      'position "identity": Leave mark coordinates unchanged. Default for most geoms: each mark keeps its post-stat (x, y).',
+    href: "/reference/positions/identity",
+    keywords: [],
+    exact: ["position identity"],
+  },
+  {
+    id: "heading:reference-positions-identity:usage",
+    kind: "heading",
+    title: "Usage",
+    summary:
+      'Usage in position identity. position "identity": Leave mark coordinates unchanged. Default for most geoms: each mark keeps its post-stat (x, y).',
+    href: "/reference/positions/identity#usage",
+    keywords: ["position identity", "documentation"],
+    exact: ["Usage"],
+  },
+  {
+    id: "heading:reference-positions-identity:params",
+    kind: "heading",
+    title: "positionParams",
+    summary:
+      'positionParams in position identity. position "identity": Leave mark coordinates unchanged. Default for most geoms: each mark keeps its post-stat (x, y).',
+    href: "/reference/positions/identity#params",
+    keywords: ["position identity", "documentation"],
+    exact: ["positionParams"],
+  },
+  {
+    id: "heading:reference-positions-identity:default-for",
+    kind: "heading",
+    title: "Default for geoms",
+    summary:
+      'Default for geoms in position identity. position "identity": Leave mark coordinates unchanged. Default for most geoms: each mark keeps its post-stat (x, y).',
+    href: "/reference/positions/identity#default-for",
+    keywords: ["position identity", "documentation"],
+    exact: ["Default for geoms"],
+  },
+  {
+    id: "heading:reference-positions-identity:compatible-geoms",
+    kind: "heading",
+    title: "Compatible geoms",
+    summary:
+      'Compatible geoms in position identity. position "identity": Leave mark coordinates unchanged. Default for most geoms: each mark keeps its post-stat (x, y).',
+    href: "/reference/positions/identity#compatible-geoms",
+    keywords: ["position identity", "documentation"],
+    exact: ["Compatible geoms"],
+  },
+  {
+    id: "heading:reference-positions-identity:examples",
+    kind: "heading",
+    title: "Examples",
+    summary:
+      'Examples in position identity. position "identity": Leave mark coordinates unchanged. Default for most geoms: each mark keeps its post-stat (x, y).',
+    href: "/reference/positions/identity#examples",
+    keywords: ["position identity", "documentation"],
+    exact: ["Examples"],
+  },
+  {
+    id: "page:reference-positions-stack",
+    kind: "page",
+    title: "position stack",
+    summary:
+      'position "stack": Stack groups at each x slot so heights accumulate (positive up, negative down). Default for bar, col, histogram, and area; trains the scale on stacked totals.',
+    href: "/reference/positions/stack",
+    keywords: [],
+    exact: ["position stack"],
+  },
+  {
+    id: "heading:reference-positions-stack:usage",
+    kind: "heading",
+    title: "Usage",
+    summary:
+      'Usage in position stack. position "stack": Stack groups at each x slot so heights accumulate (positive up, negative down). Default for bar, col, histogram, and area; trains the scale on stacked totals.',
+    href: "/reference/positions/stack#usage",
+    keywords: ["position stack", "documentation"],
+    exact: ["Usage"],
+  },
+  {
+    id: "heading:reference-positions-stack:params",
+    kind: "heading",
+    title: "positionParams",
+    summary:
+      'positionParams in position stack. position "stack": Stack groups at each x slot so heights accumulate (positive up, negative down). Default for bar, col, histogram, and area; trains the scale on stacked totals.',
+    href: "/reference/positions/stack#params",
+    keywords: ["position stack", "documentation"],
+    exact: ["positionParams"],
+  },
+  {
+    id: "heading:reference-positions-stack:default-for",
+    kind: "heading",
+    title: "Default for geoms",
+    summary:
+      'Default for geoms in position stack. position "stack": Stack groups at each x slot so heights accumulate (positive up, negative down). Default for bar, col, histogram, and area; trains the scale on stacked totals.',
+    href: "/reference/positions/stack#default-for",
+    keywords: ["position stack", "documentation"],
+    exact: ["Default for geoms"],
+  },
+  {
+    id: "heading:reference-positions-stack:compatible-geoms",
+    kind: "heading",
+    title: "Compatible geoms",
+    summary:
+      'Compatible geoms in position stack. position "stack": Stack groups at each x slot so heights accumulate (positive up, negative down). Default for bar, col, histogram, and area; trains the scale on stacked totals.',
+    href: "/reference/positions/stack#compatible-geoms",
+    keywords: ["position stack", "documentation"],
+    exact: ["Compatible geoms"],
+  },
+  {
+    id: "heading:reference-positions-stack:examples",
+    kind: "heading",
+    title: "Examples",
+    summary:
+      'Examples in position stack. position "stack": Stack groups at each x slot so heights accumulate (positive up, negative down). Default for bar, col, histogram, and area; trains the scale on stacked totals.',
+    href: "/reference/positions/stack#examples",
+    keywords: ["position stack", "documentation"],
+    exact: ["Examples"],
+  },
+  {
+    id: "page:reference-positions-fill",
+    kind: "page",
+    title: "position fill",
+    summary:
+      'position "fill": Stack groups then rescale each x slot to proportions (positive and negative runs separately). Same geom set as stack; y domain becomes proportions.',
+    href: "/reference/positions/fill",
+    keywords: [],
+    exact: ["position fill"],
+  },
+  {
+    id: "heading:reference-positions-fill:usage",
+    kind: "heading",
+    title: "Usage",
+    summary:
+      'Usage in position fill. position "fill": Stack groups then rescale each x slot to proportions (positive and negative runs separately). Same geom set as stack; y domain becomes proportions.',
+    href: "/reference/positions/fill#usage",
+    keywords: ["position fill", "documentation"],
+    exact: ["Usage"],
+  },
+  {
+    id: "heading:reference-positions-fill:params",
+    kind: "heading",
+    title: "positionParams",
+    summary:
+      'positionParams in position fill. position "fill": Stack groups then rescale each x slot to proportions (positive and negative runs separately). Same geom set as stack; y domain becomes proportions.',
+    href: "/reference/positions/fill#params",
+    keywords: ["position fill", "documentation"],
+    exact: ["positionParams"],
+  },
+  {
+    id: "heading:reference-positions-fill:default-for",
+    kind: "heading",
+    title: "Default for geoms",
+    summary:
+      'Default for geoms in position fill. position "fill": Stack groups then rescale each x slot to proportions (positive and negative runs separately). Same geom set as stack; y domain becomes proportions.',
+    href: "/reference/positions/fill#default-for",
+    keywords: ["position fill", "documentation"],
+    exact: ["Default for geoms"],
+  },
+  {
+    id: "heading:reference-positions-fill:compatible-geoms",
+    kind: "heading",
+    title: "Compatible geoms",
+    summary:
+      'Compatible geoms in position fill. position "fill": Stack groups then rescale each x slot to proportions (positive and negative runs separately). Same geom set as stack; y domain becomes proportions.',
+    href: "/reference/positions/fill#compatible-geoms",
+    keywords: ["position fill", "documentation"],
+    exact: ["Compatible geoms"],
+  },
+  {
+    id: "heading:reference-positions-fill:examples",
+    kind: "heading",
+    title: "Examples",
+    summary:
+      'Examples in position fill. position "fill": Stack groups then rescale each x slot to proportions (positive and negative runs separately). Same geom set as stack; y domain becomes proportions.',
+    href: "/reference/positions/fill#examples",
+    keywords: ["position fill", "documentation"],
+    exact: ["Examples"],
+  },
+  {
+    id: "page:reference-positions-dodge",
+    kind: "page",
+    title: "position dodge",
+    summary:
+      'position "dodge": Place groups side by side within each x band instead of overlapping. Default for boxplot and violin; used when comparing categories at the same x.',
+    href: "/reference/positions/dodge",
+    keywords: [],
+    exact: ["position dodge"],
+  },
+  {
+    id: "heading:reference-positions-dodge:usage",
+    kind: "heading",
+    title: "Usage",
+    summary:
+      'Usage in position dodge. position "dodge": Place groups side by side within each x band instead of overlapping. Default for boxplot and violin; used when comparing categories at the same x.',
+    href: "/reference/positions/dodge#usage",
+    keywords: ["position dodge", "documentation"],
+    exact: ["Usage"],
+  },
+  {
+    id: "heading:reference-positions-dodge:params",
+    kind: "heading",
+    title: "positionParams",
+    summary:
+      'positionParams in position dodge. position "dodge": Place groups side by side within each x band instead of overlapping. Default for boxplot and violin; used when comparing categories at the same x.',
+    href: "/reference/positions/dodge#params",
+    keywords: ["position dodge", "documentation"],
+    exact: ["positionParams"],
+  },
+  {
+    id: "heading:reference-positions-dodge:default-for",
+    kind: "heading",
+    title: "Default for geoms",
+    summary:
+      'Default for geoms in position dodge. position "dodge": Place groups side by side within each x band instead of overlapping. Default for boxplot and violin; used when comparing categories at the same x.',
+    href: "/reference/positions/dodge#default-for",
+    keywords: ["position dodge", "documentation"],
+    exact: ["Default for geoms"],
+  },
+  {
+    id: "heading:reference-positions-dodge:compatible-geoms",
+    kind: "heading",
+    title: "Compatible geoms",
+    summary:
+      'Compatible geoms in position dodge. position "dodge": Place groups side by side within each x band instead of overlapping. Default for boxplot and violin; used when comparing categories at the same x.',
+    href: "/reference/positions/dodge#compatible-geoms",
+    keywords: ["position dodge", "documentation"],
+    exact: ["Compatible geoms"],
+  },
+  {
+    id: "heading:reference-positions-dodge:examples",
+    kind: "heading",
+    title: "Examples",
+    summary:
+      'Examples in position dodge. position "dodge": Place groups side by side within each x band instead of overlapping. Default for boxplot and violin; used when comparing categories at the same x.',
+    href: "/reference/positions/dodge#examples",
+    keywords: ["position dodge", "documentation"],
+    exact: ["Examples"],
+  },
+  {
+    id: "page:reference-positions-jitter",
+    kind: "page",
+    title: "position jitter",
+    summary:
+      'position "jitter": Add seeded random offsets so overplotted points separate. Configure with positionParams width/height/seed (always seeded for reproducibility).',
+    href: "/reference/positions/jitter",
+    keywords: [],
+    exact: ["position jitter"],
+  },
+  {
+    id: "heading:reference-positions-jitter:usage",
+    kind: "heading",
+    title: "Usage",
+    summary:
+      'Usage in position jitter. position "jitter": Add seeded random offsets so overplotted points separate. Configure with positionParams width/height/seed (always seeded for reproducibility).',
+    href: "/reference/positions/jitter#usage",
+    keywords: ["position jitter", "documentation"],
+    exact: ["Usage"],
+  },
+  {
+    id: "heading:reference-positions-jitter:params",
+    kind: "heading",
+    title: "positionParams",
+    summary:
+      'positionParams in position jitter. position "jitter": Add seeded random offsets so overplotted points separate. Configure with positionParams width/height/seed (always seeded for reproducibility).',
+    href: "/reference/positions/jitter#params",
+    keywords: ["position jitter", "documentation"],
+    exact: ["positionParams"],
+  },
+  {
+    id: "heading:reference-positions-jitter:default-for",
+    kind: "heading",
+    title: "Default for geoms",
+    summary:
+      'Default for geoms in position jitter. position "jitter": Add seeded random offsets so overplotted points separate. Configure with positionParams width/height/seed (always seeded for reproducibility).',
+    href: "/reference/positions/jitter#default-for",
+    keywords: ["position jitter", "documentation"],
+    exact: ["Default for geoms"],
+  },
+  {
+    id: "heading:reference-positions-jitter:compatible-geoms",
+    kind: "heading",
+    title: "Compatible geoms",
+    summary:
+      'Compatible geoms in position jitter. position "jitter": Add seeded random offsets so overplotted points separate. Configure with positionParams width/height/seed (always seeded for reproducibility).',
+    href: "/reference/positions/jitter#compatible-geoms",
+    keywords: ["position jitter", "documentation"],
+    exact: ["Compatible geoms"],
+  },
+  {
+    id: "heading:reference-positions-jitter:examples",
+    kind: "heading",
+    title: "Examples",
+    summary:
+      'Examples in position jitter. position "jitter": Add seeded random offsets so overplotted points separate. Configure with positionParams width/height/seed (always seeded for reproducibility).',
+    href: "/reference/positions/jitter#examples",
+    keywords: ["position jitter", "documentation"],
+    exact: ["Examples"],
+  },
+  {
+    id: "page:reference-positions-nudge",
+    kind: "page",
+    title: "position nudge",
+    summary:
+      'position "nudge": Apply a fixed offset (positionParams.x / y) per mark — useful for labels beside points. Offsets are data units or band-step fractions.',
+    href: "/reference/positions/nudge",
+    keywords: [],
+    exact: ["position nudge"],
+  },
+  {
+    id: "heading:reference-positions-nudge:usage",
+    kind: "heading",
+    title: "Usage",
+    summary:
+      'Usage in position nudge. position "nudge": Apply a fixed offset (positionParams.x / y) per mark — useful for labels beside points. Offsets are data units or band-step fractions.',
+    href: "/reference/positions/nudge#usage",
+    keywords: ["position nudge", "documentation"],
+    exact: ["Usage"],
+  },
+  {
+    id: "heading:reference-positions-nudge:params",
+    kind: "heading",
+    title: "positionParams",
+    summary:
+      'positionParams in position nudge. position "nudge": Apply a fixed offset (positionParams.x / y) per mark — useful for labels beside points. Offsets are data units or band-step fractions.',
+    href: "/reference/positions/nudge#params",
+    keywords: ["position nudge", "documentation"],
+    exact: ["positionParams"],
+  },
+  {
+    id: "heading:reference-positions-nudge:default-for",
+    kind: "heading",
+    title: "Default for geoms",
+    summary:
+      'Default for geoms in position nudge. position "nudge": Apply a fixed offset (positionParams.x / y) per mark — useful for labels beside points. Offsets are data units or band-step fractions.',
+    href: "/reference/positions/nudge#default-for",
+    keywords: ["position nudge", "documentation"],
+    exact: ["Default for geoms"],
+  },
+  {
+    id: "heading:reference-positions-nudge:compatible-geoms",
+    kind: "heading",
+    title: "Compatible geoms",
+    summary:
+      'Compatible geoms in position nudge. position "nudge": Apply a fixed offset (positionParams.x / y) per mark — useful for labels beside points. Offsets are data units or band-step fractions.',
+    href: "/reference/positions/nudge#compatible-geoms",
+    keywords: ["position nudge", "documentation"],
+    exact: ["Compatible geoms"],
+  },
+  {
     id: "page:guide-getting-started",
     kind: "page",
     title: "Getting started",
@@ -9481,14 +9861,14 @@ export const DOCS_SEARCH_INDEX = [
     exact: ["@ggsvelte/spec"],
   },
   {
-    id: "heading:guide-lifecycle:experimental-868",
+    id: "heading:guide-lifecycle:experimental-872",
     kind: "heading",
-    title: "experimental (868)",
+    title: "experimental (872)",
     summary:
-      "experimental (868) in Lifecycle & editions. API stability tags per export, and the defaults-edition mechanism.",
-    href: "/guide/lifecycle#experimental-868",
+      "experimental (872) in Lifecycle & editions. API stability tags per export, and the defaults-edition mechanism.",
+    href: "/guide/lifecycle#experimental-872",
     keywords: ["Lifecycle & editions", "Reference"],
-    exact: ["experimental (868)"],
+    exact: ["experimental (872)"],
   },
   {
     id: "heading:guide-lifecycle:stable-intent-8",
@@ -14018,6 +14398,15 @@ export const DOCS_SEARCH_INDEX = [
     exact: ["POINT_SHAPE_NAMES"],
   },
   {
+    id: "api:ggsvelte-spec:POSITION_REFERENCE",
+    kind: "api",
+    title: "POSITION_REFERENCE",
+    summary: "@ggsvelte/spec · value · experimental.",
+    href: "/guide/lifecycle#ggsvelte-spec",
+    keywords: ["@ggsvelte/spec", ".", "value", "experimental"],
+    exact: ["POSITION_REFERENCE"],
+  },
+  {
     id: "api:ggsvelte-spec:PaintSpace",
     kind: "api",
     title: "PaintSpace",
@@ -14252,6 +14641,15 @@ export const DOCS_SEARCH_INDEX = [
     exact: ["PositionName"],
   },
   {
+    id: "api:ggsvelte-spec:PositionParamDoc",
+    kind: "api",
+    title: "PositionParamDoc",
+    summary: "@ggsvelte/spec · type · experimental.",
+    href: "/guide/lifecycle#ggsvelte-spec",
+    keywords: ["@ggsvelte/spec", ".", "type", "experimental"],
+    exact: ["PositionParamDoc"],
+  },
+  {
     id: "api:ggsvelte-spec:PositionParams",
     kind: "api",
     title: "PositionParams",
@@ -14259,6 +14657,15 @@ export const DOCS_SEARCH_INDEX = [
     href: "/guide/lifecycle#ggsvelte-spec",
     keywords: ["@ggsvelte/spec", ".", "type", "experimental"],
     exact: ["PositionParams"],
+  },
+  {
+    id: "api:ggsvelte-spec:PositionReferenceEntry",
+    kind: "api",
+    title: "PositionReferenceEntry",
+    summary: "@ggsvelte/spec · type · experimental.",
+    href: "/guide/lifecycle#ggsvelte-spec",
+    keywords: ["@ggsvelte/spec", ".", "type", "experimental"],
+    exact: ["PositionReferenceEntry"],
   },
   {
     id: "api:ggsvelte-spec:PositionScaleSpec",
@@ -16644,6 +17051,15 @@ export const DOCS_SEARCH_INDEX = [
     href: "/guide/lifecycle#ggsvelte-spec",
     keywords: ["@ggsvelte/spec", ".", "value", "experimental"],
     exact: ["portabilityIssues"],
+  },
+  {
+    id: "api:ggsvelte-spec:positionReferenceList",
+    kind: "api",
+    title: "positionReferenceList",
+    summary: "@ggsvelte/spec · value · experimental.",
+    href: "/guide/lifecycle#ggsvelte-spec",
+    keywords: ["@ggsvelte/spec", ".", "value", "experimental"],
+    exact: ["positionReferenceList"],
   },
   {
     id: "api:ggsvelte-spec:scaleAlpha",

--- a/apps/docs/src/routes/docs/+page.svelte
+++ b/apps/docs/src/routes/docs/+page.svelte
@@ -27,6 +27,10 @@
       "Every statistical transform: after_stat columns and compatible geoms.",
     ],
     [
+      "/reference/positions",
+      "Every position adjustment: stack, dodge, jitter params, and geoms.",
+    ],
+    [
       "/reference/cli",
       "Render, validate, and export charts from the terminal.",
     ],

--- a/apps/docs/src/routes/reference/+page.svelte
+++ b/apps/docs/src/routes/reference/+page.svelte
@@ -25,6 +25,13 @@
         >Every statistical transform: after_stat columns and compatible geoms.</span
       >
     </a>
+    <a href={`${base}/reference/positions`}>
+      <strong>Position reference</strong>
+      <span
+        >Every position adjustment: stack, dodge, jitter params, and compatible
+        geoms.</span
+      >
+    </a>
     <a href={`${base}/reference/interactions`}>
       <strong>Interaction reference</strong>
       <span>Capabilities, events, diagnostics, accessibility defaults.</span>

--- a/apps/docs/src/routes/reference/geoms/[name]/+page.svelte
+++ b/apps/docs/src/routes/reference/geoms/[name]/+page.svelte
@@ -148,7 +148,9 @@
   <ul class="token-list">
     {#each entry.allowedPositions as position (position)}
       <li>
-        <code>{position}</code>
+        <a href={`${base}/reference/positions/${position}`}
+          ><code>{position}</code></a
+        >
         {#if position === entry.defaultPosition}
           <span class="badge">default</span>
         {/if}

--- a/apps/docs/src/routes/reference/positions/+page.svelte
+++ b/apps/docs/src/routes/reference/positions/+page.svelte
@@ -1,0 +1,203 @@
+<script lang="ts">
+  import { base } from "$app/paths";
+  import {
+    POSITION_REFERENCE,
+    positionReferenceList,
+    type PositionReferenceEntry,
+  } from "@ggsvelte/spec";
+
+  let query = $state("");
+  const all = positionReferenceList();
+  const normalizedQuery = $derived(query.trim().toLocaleLowerCase());
+  const results = $derived(
+    normalizedQuery === ""
+      ? all
+      : all.filter((entry) => matchesPosition(entry, normalizedQuery)),
+  );
+
+  function matchesPosition(entry: PositionReferenceEntry, q: string): boolean {
+    const haystack = [
+      entry.name,
+      entry.summary,
+      ...entry.params.map((p) => p.name),
+      ...entry.compatibleGeoms,
+      ...entry.defaultForGeoms,
+    ]
+      .join(" ")
+      .toLocaleLowerCase();
+    return haystack.includes(q);
+  }
+</script>
+
+<main class="position-reference" aria-labelledby="reference-heading">
+  <p class="eyebrow">
+    Schema-derived · {Object.keys(POSITION_REFERENCE).length} positions
+  </p>
+  <h1 id="reference-heading">Position reference</h1>
+  <p class="intro">
+    Position adjustments control how marks share coordinate space after the stat
+    runs. Set <code>position</code> on a <code>&lt;Geom*&gt;</code> shell or
+    JSON layer — there is no separate Position component. Jitter and nudge take
+    <code>positionParams</code>
+    from the PortableSpec
+    <code>PositionParams</code> schema.
+  </p>
+
+  <label for="position-search">Search positions, params, or geoms</label>
+  <input
+    id="position-search"
+    type="search"
+    bind:value={query}
+    placeholder="Try stack, dodge, jitter, or seed"
+    autocomplete="off"
+  />
+
+  <p class="count" aria-live="polite">
+    {results.length}
+    {results.length === 1 ? "position" : "positions"}
+  </p>
+
+  <h2 id="all-positions">All positions</h2>
+  {#if results.length === 0}
+    <p class="empty">No match. Try a position name, param, or geom.</p>
+  {:else}
+    <ul class="results">
+      {#each results as entry (entry.name)}
+        <li>
+          <a href={`${base}/reference/positions/${entry.slug}`}>
+            <strong><code>{entry.name}</code></strong>
+            <span class="meta">
+              {#if entry.params.length > 0}
+                params: {entry.params.map((p) => p.name).join(", ")}
+              {:else}
+                no positionParams
+              {/if}
+              · {entry.compatibleGeoms.length}
+              {entry.compatibleGeoms.length === 1 ? "geom" : "geoms"}
+              {#if entry.defaultForGeoms.length > 0}
+                · default for {entry.defaultForGeoms.length}
+              {/if}
+            </span>
+            <span class="summary">{entry.summary}</span>
+          </a>
+        </li>
+      {/each}
+    </ul>
+  {/if}
+
+  <h2 id="how-to-set">How to set a position</h2>
+  <p>
+    Pass the <code>position</code> prop on a geom shell. Only values listed on
+    that geom's
+    <a href={`${base}/reference/geoms`}>geom reference</a> page validate. Omit it
+    to use the geom default.
+  </p>
+  <pre class="snippet"><code
+      >{`import { GGPlot, GeomBar } from "@ggsvelte/svelte";
+
+<GGPlot data={rows} aes={{ x: "category", fill: "group" }}>
+  <GeomBar position="dodge" />
+</GGPlot>`}</code
+    ></pre>
+</main>
+
+<style>
+  .position-reference {
+    max-width: 52rem;
+    margin: 2rem 0 4rem;
+  }
+
+  h1 {
+    margin: 0.15rem 0 0.6rem;
+  }
+
+  h2 {
+    margin: 2.5rem 0 0.75rem;
+  }
+
+  .intro {
+    max-width: 44rem;
+  }
+
+  .eyebrow {
+    margin: 0;
+    color: var(--muted);
+    font-size: 0.76rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  label {
+    display: block;
+    margin: 1.5rem 0 0.4rem;
+    font-weight: 600;
+  }
+
+  input[type="search"] {
+    width: min(100%, 28rem);
+    padding: 0.55rem 0.75rem;
+    border: 1px solid var(--line);
+    border-radius: 0.4rem;
+    background: var(--surface, transparent);
+    color: var(--ink);
+    font: inherit;
+  }
+
+  .count {
+    margin: 0.75rem 0 0;
+    color: var(--muted);
+    font-size: 0.9rem;
+  }
+
+  .empty {
+    color: var(--muted);
+  }
+
+  .results {
+    list-style: none;
+    margin: 1rem 0 0;
+    padding: 0;
+  }
+
+  .results li {
+    border-top: 1px solid var(--line);
+  }
+
+  .results li:last-child {
+    border-bottom: 1px solid var(--line);
+  }
+
+  .results a {
+    display: grid;
+    gap: 0.25rem;
+    padding: 0.9rem 0;
+    color: var(--ink);
+    text-decoration: none;
+  }
+
+  .results a:hover strong {
+    text-decoration: underline;
+  }
+
+  .meta {
+    color: var(--muted);
+    font-size: 0.88rem;
+  }
+
+  .summary {
+    max-width: 44rem;
+    color: var(--muted);
+    font-size: 0.92rem;
+  }
+
+  .snippet {
+    overflow-x: auto;
+    padding: 1rem 1.1rem;
+    border-radius: 0.5rem;
+    background: var(--code-bg, #1a1b26);
+    color: var(--code-fg, #c0caf5);
+    font-size: 0.88rem;
+    line-height: 1.45;
+  }
+</style>

--- a/apps/docs/src/routes/reference/positions/[name]/+page.svelte
+++ b/apps/docs/src/routes/reference/positions/[name]/+page.svelte
@@ -1,0 +1,246 @@
+<script lang="ts">
+  import { base } from "$app/paths";
+  import { componentNameForGeom } from "@ggsvelte/spec";
+
+  import type { PageProps } from "./$types";
+
+  const { data }: PageProps = $props();
+  const entry = $derived(data.entry);
+
+  const primaryGeom = $derived(
+    entry.defaultForGeoms[0] ?? entry.compatibleGeoms[0],
+  );
+  const primaryComponent = $derived(
+    primaryGeom === undefined ? "GeomBar" : componentNameForGeom(primaryGeom),
+  );
+
+  const paramPropLines = $derived(
+    entry.params.length === 0
+      ? ""
+      : "\n" +
+          entry.params
+            .slice(0, 2)
+            .map((p) => `  ${p.name}={/* … */}`)
+            .join("\n") +
+          "\n",
+  );
+
+  const svelteSnippet = $derived(
+    entry.params.length === 0
+      ? `import { GGPlot, ${primaryComponent} } from "@ggsvelte/svelte";\n\n<GGPlot data={rows} aes={{ x: "x", y: "y" }}>\n  <${primaryComponent} position="${entry.name}" />\n</GGPlot>`
+      : `import { GGPlot, ${primaryComponent} } from "@ggsvelte/svelte";\n\n<GGPlot data={rows} aes={{ x: "x", y: "y" }}>\n  <${primaryComponent}\n    position="${entry.name}"\n    positionParams={{${paramPropLines === "" ? "" : " /* see params */ "}}}\n  />\n</GGPlot>`,
+  );
+
+  const jsonSnippet = $derived(
+    entry.params.length === 0
+      ? `{\n  "geom": "${primaryGeom ?? "bar"}",\n  "position": "${entry.name}"\n}`
+      : `{\n  "geom": "${primaryGeom ?? "point"}",\n  "position": "${entry.name}",\n  "positionParams": { ${entry.params
+          .slice(0, 2)
+          .map((p) => `"${p.name}": /* … */`)
+          .join(", ")} }\n}`,
+  );
+</script>
+
+<article class="position-detail prose" aria-labelledby="position-heading">
+  <p class="crumb">
+    <a href={`${base}/reference/positions`}>Position reference</a>
+    <span aria-hidden="true">/</span>
+    <code>{entry.name}</code>
+  </p>
+
+  <h1 id="position-heading"><code>position: "{entry.name}"</code></h1>
+  <p class="lede">{entry.summary}</p>
+
+  <h2 id="usage">Usage</h2>
+  <p>
+    Positions are not components. Pass <code>position="{entry.name}"</code> on a
+    compatible <code>&lt;Geom*&gt;</code>, or set
+    <code>"position": "{entry.name}"</code> on a JSON layer.
+  </p>
+  <pre class="snippet"><code>{svelteSnippet}</code></pre>
+  <pre class="snippet"><code>{jsonSnippet}</code></pre>
+
+  <h2 id="params">positionParams</h2>
+  {#if entry.params.length === 0}
+    <p>
+      This position has no <code>positionParams</code>. Only jitter (width,
+      height, seed) and nudge (x, y) accept parameters.
+    </p>
+  {:else}
+    <dl class="param-list">
+      {#each entry.params as param (param.name)}
+        <div>
+          <dt id={`param-${param.name}`}>
+            <code>{param.name}</code>
+            {#if param.required}
+              <span class="badge">required</span>
+            {/if}
+          </dt>
+          <dd>
+            <p class="type"><code>{param.typeSummary}</code></p>
+            <p>{param.description}</p>
+          </dd>
+        </div>
+      {/each}
+    </dl>
+  {/if}
+
+  <h2 id="default-for">Default for geoms</h2>
+  {#if entry.defaultForGeoms.length === 0}
+    <p>
+      No geom uses this as its default position. Set it explicitly when needed.
+    </p>
+  {:else}
+    <ul class="token-list">
+      {#each entry.defaultForGeoms as geom (geom)}
+        <li>
+          <a href={`${base}/reference/geoms/${geom}`}
+            ><code>{componentNameForGeom(geom)}</code></a
+          >
+        </li>
+      {/each}
+    </ul>
+  {/if}
+
+  <h2 id="compatible-geoms">Compatible geoms</h2>
+  <ul class="token-list">
+    {#each entry.compatibleGeoms as geom (geom)}
+      <li>
+        <a href={`${base}/reference/geoms/${geom}`}
+          ><code>{componentNameForGeom(geom)}</code></a
+        >
+        {#if entry.defaultForGeoms.includes(geom)}
+          <span class="badge">default</span>
+        {/if}
+      </li>
+    {/each}
+  </ul>
+
+  {#if data.examples.length > 0}
+    <h2 id="examples">Examples</h2>
+    <ul class="example-list">
+      {#each data.examples as example (example.id)}
+        <li>
+          <a href={`${base}${example.href}`}>{example.title}</a>
+        </li>
+      {/each}
+    </ul>
+  {/if}
+
+  <p class="back">
+    <a href={`${base}/reference/positions`}>← All positions</a>
+    ·
+    <a href={`${base}/reference/geoms`}>Geom reference</a>
+    ·
+    <a href={`${base}/reference/stats`}>Stat reference</a>
+  </p>
+</article>
+
+<style>
+  .position-detail {
+    max-width: 52rem;
+    margin: 2rem 0 4rem;
+  }
+
+  .crumb {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    margin: 0 0 0.75rem;
+    color: var(--muted);
+    font-size: 0.9rem;
+  }
+
+  h1 {
+    margin: 0 0 0.5rem;
+  }
+
+  .lede {
+    max-width: 44rem;
+    margin: 0 0 1.5rem;
+    font-size: 1.05rem;
+  }
+
+  .snippet {
+    overflow-x: auto;
+    padding: 1rem 1.1rem;
+    border-radius: 0.5rem;
+    background: var(--code-bg, #1a1b26);
+    color: var(--code-fg, #c0caf5);
+    font-size: 0.88rem;
+    line-height: 1.45;
+  }
+
+  .snippet + .snippet {
+    margin-top: 0.75rem;
+  }
+
+  .param-list {
+    margin: 1rem 0 0;
+  }
+
+  .param-list > div {
+    display: grid;
+    grid-template-columns: minmax(8rem, 0.28fr) minmax(0, 1fr);
+    gap: 1rem;
+    padding: 0.85rem 0;
+    border-top: 1px solid var(--line);
+  }
+
+  .param-list > div:last-child {
+    border-bottom: 1px solid var(--line);
+  }
+
+  .param-list dt {
+    font-weight: 600;
+  }
+
+  .param-list dd {
+    margin: 0;
+  }
+
+  .param-list .type {
+    margin: 0 0 0.35rem;
+    color: var(--muted);
+    font-size: 0.88rem;
+  }
+
+  .param-list p {
+    margin: 0;
+  }
+
+  .badge {
+    display: inline-block;
+    margin-left: 0.35rem;
+    padding: 0.05rem 0.4rem;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--ink) 8%, transparent);
+    color: var(--muted);
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    vertical-align: middle;
+  }
+
+  .token-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem 1rem;
+    margin: 0.75rem 0 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .example-list {
+    margin: 0.75rem 0 0;
+    padding-left: 1.2rem;
+  }
+
+  .back {
+    margin-top: 2.5rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--line);
+    color: var(--muted);
+  }
+</style>

--- a/apps/docs/src/routes/reference/positions/[name]/+page.ts
+++ b/apps/docs/src/routes/reference/positions/[name]/+page.ts
@@ -1,0 +1,38 @@
+import { error } from "@sveltejs/kit";
+
+import { POSITION_REFERENCE, type PositionName, KNOWN_POSITIONS } from "@ggsvelte/spec";
+
+import { EXAMPLES } from "$lib/examples";
+
+import type { EntryGenerator, PageLoad } from "./$types";
+
+const POSITION_SET = new Set<string>(KNOWN_POSITIONS);
+
+/** Prerender one page per position (adapter-static). */
+export const entries: EntryGenerator = () => KNOWN_POSITIONS.map((name) => ({ name }));
+
+function relatedExamples(position: PositionName) {
+  return EXAMPLES.filter(
+    (entry) =>
+      entry.tags.includes(position) ||
+      entry.tags.includes(`position-${position}`) ||
+      entry.tags.includes(`position_${position}`) ||
+      entry.id.includes(position),
+  ).slice(0, 8);
+}
+
+export const load: PageLoad = ({ params }) => {
+  const name = params.name;
+  if (!POSITION_SET.has(name)) {
+    error(404, `No position reference for "${name}".`);
+  }
+  const entry = POSITION_REFERENCE[name as PositionName];
+  return {
+    entry,
+    examples: relatedExamples(entry.name).map((ex) => ({
+      id: ex.id,
+      title: ex.title,
+      href: `/examples/${ex.id}`,
+    })),
+  };
+};

--- a/lifecycle.json
+++ b/lifecycle.json
@@ -1168,6 +1168,10 @@
           "kind": "value",
           "lifecycle": "experimental"
         },
+        "POSITION_REFERENCE": {
+          "kind": "value",
+          "lifecycle": "experimental"
+        },
         "PaintSpace": {
           "kind": "type",
           "lifecycle": "experimental"
@@ -1272,7 +1276,15 @@
           "kind": "type",
           "lifecycle": "experimental"
         },
+        "PositionParamDoc": {
+          "kind": "type",
+          "lifecycle": "experimental"
+        },
         "PositionParams": {
+          "kind": "type",
+          "lifecycle": "experimental"
+        },
+        "PositionReferenceEntry": {
           "kind": "type",
           "lifecycle": "experimental"
         },
@@ -2333,6 +2345,10 @@
           "lifecycle": "experimental"
         },
         "portabilityIssues": {
+          "kind": "value",
+          "lifecycle": "experimental"
+        },
+        "positionReferenceList": {
           "kind": "value",
           "lifecycle": "experimental"
         },

--- a/packages/spec/src/index.ts
+++ b/packages/spec/src/index.ts
@@ -291,6 +291,10 @@ export type { GeomParamDoc, GeomReferenceEntry, SharedLayerPropDoc } from "./geo
 export { STAT_REFERENCE, statReferenceList } from "./stat-reference.js";
 /** @lifecycle experimental */
 export type { StatReferenceEntry } from "./stat-reference.js";
+/** @lifecycle experimental */
+export { POSITION_REFERENCE, positionReferenceList } from "./position-reference.js";
+/** @lifecycle experimental */
+export type { PositionParamDoc, PositionReferenceEntry } from "./position-reference.js";
 
 // Temporal parsing, inference, and authoring conversions
 export {

--- a/packages/spec/src/position-reference.ts
+++ b/packages/spec/src/position-reference.ts
@@ -1,0 +1,180 @@
+/**
+ * POSITION_REFERENCE — per-position API docs derived from KNOWN_POSITIONS,
+ * PositionParams (SpecDeclarations), and GEOM_REFERENCE (compatible geoms).
+ *
+ * Positions are not Svelte components: set `position` on a `<Geom*>` shell or
+ * JSON layer, and optional `positionParams` for jitter/nudge. Used by
+ * `/reference/positions`.
+ */
+import type { TSchema } from "typebox";
+
+import {
+  GEOM_DEFAULTS,
+  KNOWN_GEOMS,
+  KNOWN_POSITIONS,
+  type GeomName,
+  type PositionName,
+} from "./schema-catalog.js";
+import { SpecDeclarations } from "./schema-declarations.js";
+import { GEOM_REFERENCE } from "./geom-reference.js";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface PositionParamDoc {
+  readonly name: string;
+  readonly description: string;
+  readonly typeSummary: string;
+  readonly required: boolean;
+}
+
+export interface PositionReferenceEntry {
+  readonly name: PositionName;
+  /** Route slug — same as position name. */
+  readonly slug: string;
+  /** Short purpose text for the adjustment. */
+  readonly summary: string;
+  /**
+   * Keys of positionParams that apply to this position (from PositionParams
+   * schema, filtered by which adjustment uses them).
+   */
+  readonly params: readonly PositionParamDoc[];
+  /** Geoms whose layer schema allows this position. */
+  readonly compatibleGeoms: readonly GeomName[];
+  /** Geoms whose GEOM_DEFAULTS.position is this position. */
+  readonly defaultForGeoms: readonly GeomName[];
+}
+
+// ---------------------------------------------------------------------------
+// Summaries
+// ---------------------------------------------------------------------------
+
+const POSITION_SUMMARIES: Readonly<Record<PositionName, string>> = Object.freeze({
+  identity:
+    "Leave mark coordinates unchanged. Default for most geoms: each mark keeps its post-stat (x, y).",
+  stack:
+    "Stack groups at each x slot so heights accumulate (positive up, negative down). Default for bar, col, histogram, and area; trains the scale on stacked totals.",
+  fill: "Stack groups then rescale each x slot to proportions (positive and negative runs separately). Same geom set as stack; y domain becomes proportions.",
+  dodge:
+    "Place groups side by side within each x band instead of overlapping. Default for boxplot and violin; used when comparing categories at the same x.",
+  jitter:
+    "Add seeded random offsets so overplotted points separate. Configure with positionParams width/height/seed (always seeded for reproducibility).",
+  nudge:
+    "Apply a fixed offset (positionParams.x / y) per mark — useful for labels beside points. Offsets are data units or band-step fractions.",
+});
+
+/** PositionParams property keys that apply to each position. */
+const PARAM_KEYS_FOR_POSITION: Readonly<Record<PositionName, readonly string[]>> = Object.freeze({
+  identity: [],
+  stack: [],
+  fill: [],
+  dodge: [],
+  jitter: ["width", "height", "seed"],
+  nudge: ["x", "y"],
+});
+
+// ---------------------------------------------------------------------------
+// Schema walkers (minimal; PositionParams is a flat object)
+// ---------------------------------------------------------------------------
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function descriptionOf(node: unknown): string {
+  if (!isRecord(node)) return "";
+  const d = node["description"];
+  return typeof d === "string" ? d : "";
+}
+
+function typeSummaryOf(node: unknown): string {
+  if (!isRecord(node)) return "unknown";
+  const type = node["type"];
+  if (type === "number" || type === "integer") return type === "integer" ? "integer" : "number";
+  if (type === "string") return "string";
+  if (type === "boolean") return "boolean";
+  return "unknown";
+}
+
+function positionParamsDocs(keys: readonly string[]): readonly PositionParamDoc[] {
+  if (keys.length === 0) return Object.freeze([]);
+  const schema = SpecDeclarations.PositionParams as TSchema & {
+    properties?: Record<string, unknown>;
+    required?: string[];
+  };
+  const props = schema.properties;
+  if (props === undefined) {
+    throw new Error("POSITION_REFERENCE: PositionParams has no properties");
+  }
+  const required = new Set(Array.isArray(schema.required) ? schema.required : []);
+  const docs: PositionParamDoc[] = [];
+  for (const name of keys) {
+    const propSchema = props[name];
+    if (propSchema === undefined) {
+      throw new Error(`POSITION_REFERENCE: PositionParams missing property "${name}"`);
+    }
+    docs.push({
+      name,
+      description: descriptionOf(propSchema),
+      typeSummary: typeSummaryOf(propSchema),
+      required: required.has(name),
+    });
+  }
+  return Object.freeze(docs);
+}
+
+// ---------------------------------------------------------------------------
+// Build
+// ---------------------------------------------------------------------------
+
+function buildCompatibleGeoms(position: PositionName): readonly GeomName[] {
+  const geoms: GeomName[] = [];
+  for (const geom of KNOWN_GEOMS) {
+    if (GEOM_REFERENCE[geom].allowedPositions.includes(position)) {
+      geoms.push(geom);
+    }
+  }
+  return Object.freeze(geoms);
+}
+
+function buildDefaultForGeoms(position: PositionName): readonly GeomName[] {
+  const geoms: GeomName[] = [];
+  for (const geom of KNOWN_GEOMS) {
+    if (GEOM_DEFAULTS[geom].position === position) {
+      geoms.push(geom);
+    }
+  }
+  return Object.freeze(geoms);
+}
+
+function buildEntry(position: PositionName): PositionReferenceEntry {
+  return Object.freeze({
+    name: position,
+    slug: position,
+    summary: POSITION_SUMMARIES[position],
+    params: positionParamsDocs(PARAM_KEYS_FOR_POSITION[position]),
+    compatibleGeoms: buildCompatibleGeoms(position),
+    defaultForGeoms: buildDefaultForGeoms(position),
+  });
+}
+
+function buildPositionReference(): Readonly<Record<PositionName, PositionReferenceEntry>> {
+  const out = {} as Record<PositionName, PositionReferenceEntry>;
+  for (const position of KNOWN_POSITIONS) {
+    out[position] = buildEntry(position);
+  }
+  return Object.freeze(out);
+}
+
+/**
+ * Complete per-position API reference. Keys are exactly KNOWN_POSITIONS.
+ * Compatible geoms invert GEOM_REFERENCE; jitter/nudge params from PositionParams.
+ */
+export const POSITION_REFERENCE: Readonly<Record<PositionName, PositionReferenceEntry>> =
+  buildPositionReference();
+
+/** Stable list order matching KNOWN_POSITIONS (docs index, search, inventory). */
+export function positionReferenceList(): readonly PositionReferenceEntry[] {
+  return KNOWN_POSITIONS.map((position) => POSITION_REFERENCE[position]);
+}

--- a/packages/spec/src/position-reference.ts
+++ b/packages/spec/src/position-reference.ts
@@ -6,8 +6,6 @@
  * JSON layer, and optional `positionParams` for jitter/nudge. Used by
  * `/reference/positions`.
  */
-import type { TSchema } from "typebox";
-
 import {
   GEOM_DEFAULTS,
   KNOWN_GEOMS,
@@ -99,15 +97,15 @@ function typeSummaryOf(node: unknown): string {
 
 function positionParamsDocs(keys: readonly string[]): readonly PositionParamDoc[] {
   if (keys.length === 0) return Object.freeze([]);
-  const schema = SpecDeclarations.PositionParams as TSchema & {
+  const schema = SpecDeclarations.PositionParams as unknown as {
     properties?: Record<string, unknown>;
-    required?: string[];
+    required?: readonly string[];
   };
   const props = schema.properties;
   if (props === undefined) {
     throw new Error("POSITION_REFERENCE: PositionParams has no properties");
   }
-  const required = new Set(Array.isArray(schema.required) ? schema.required : []);
+  const required = new Set(schema.required ?? []);
   const docs: PositionParamDoc[] = [];
   for (const name of keys) {
     const propSchema = props[name];

--- a/packages/spec/tests/position-reference.test.ts
+++ b/packages/spec/tests/position-reference.test.ts
@@ -1,0 +1,92 @@
+/**
+ * POSITION_REFERENCE: per-position API docs derived from catalogs + GEOM_REFERENCE.
+ */
+import { describe, expect, it } from "bun:test";
+
+import { GEOM_DEFAULTS, KNOWN_GEOMS, KNOWN_POSITIONS } from "../src/schema-catalog.ts";
+import {
+  POSITION_REFERENCE,
+  positionReferenceList,
+  type PositionReferenceEntry,
+} from "../src/position-reference.ts";
+
+describe("POSITION_REFERENCE", () => {
+  it("covers every KNOWN_POSITIONS entry exactly once", () => {
+    expect(Object.keys(POSITION_REFERENCE).toSorted()).toEqual([...KNOWN_POSITIONS].toSorted());
+    expect(KNOWN_POSITIONS).toHaveLength(6);
+  });
+
+  it("every entry has a non-empty summary and matching slug", () => {
+    for (const position of KNOWN_POSITIONS) {
+      const entry = POSITION_REFERENCE[position];
+      expect(entry.name, position).toBe(position);
+      expect(entry.slug, position).toBe(position);
+      expect(entry.summary.trim().length, `${position} summary`).toBeGreaterThan(20);
+    }
+  });
+
+  it("compatibleGeoms are non-empty subsets of KNOWN_GEOMS that allow the position", () => {
+    const geoms = new Set<string>(KNOWN_GEOMS);
+    for (const position of KNOWN_POSITIONS) {
+      const entry = POSITION_REFERENCE[position];
+      expect(entry.compatibleGeoms.length, `${position} geoms`).toBeGreaterThan(0);
+      for (const geom of entry.compatibleGeoms) {
+        expect(geoms.has(geom), `${position} unknown geom ${geom}`).toBe(true);
+      }
+    }
+  });
+
+  it("defaultForGeoms matches GEOM_DEFAULTS and is a subset of compatibleGeoms", () => {
+    for (const position of KNOWN_POSITIONS) {
+      const entry = POSITION_REFERENCE[position];
+      const fromDefaults = KNOWN_GEOMS.filter((g) => GEOM_DEFAULTS[g].position === position);
+      expect([...entry.defaultForGeoms].toSorted(), position).toEqual([...fromDefaults].toSorted());
+      for (const geom of entry.defaultForGeoms) {
+        expect(entry.compatibleGeoms, `${position} default ${geom}`).toContain(geom);
+      }
+    }
+  });
+
+  it("stack is default for bar/col/histogram/area and has no positionParams", () => {
+    const stack = POSITION_REFERENCE.stack;
+    expect(stack.defaultForGeoms).toContain("bar");
+    expect(stack.defaultForGeoms).toContain("col");
+    expect(stack.params).toEqual([]);
+    expect(stack.summary.toLowerCase()).toMatch(/stack/);
+  });
+
+  it("jitter documents width/height/seed params from PositionParams", () => {
+    const jitter = POSITION_REFERENCE.jitter;
+    expect(jitter.params.map((p) => p.name).toSorted()).toEqual(["height", "seed", "width"]);
+    for (const param of jitter.params) {
+      expect(param.description.trim().length, param.name).toBeGreaterThan(10);
+      expect(param.typeSummary).toMatch(/number|integer/);
+    }
+    expect(jitter.compatibleGeoms).toContain("point");
+    expect(jitter.compatibleGeoms).toContain("jitter");
+  });
+
+  it("nudge documents x/y params", () => {
+    const nudge = POSITION_REFERENCE.nudge;
+    expect(nudge.params.map((p) => p.name).toSorted()).toEqual(["x", "y"]);
+    expect(nudge.defaultForGeoms).toEqual([]);
+  });
+
+  it("identity is default for most geoms and has no params", () => {
+    const identity = POSITION_REFERENCE.identity;
+    expect(identity.params).toEqual([]);
+    expect(identity.defaultForGeoms.length).toBeGreaterThan(20);
+  });
+
+  it("positionReferenceList order matches KNOWN_POSITIONS", () => {
+    expect(positionReferenceList().map((e) => e.name)).toEqual([...KNOWN_POSITIONS]);
+  });
+});
+
+describe("PositionReferenceEntry stability", () => {
+  it("entry shape is serializable JSON (docs artifact seam)", () => {
+    const sample: PositionReferenceEntry = POSITION_REFERENCE.dodge;
+    const roundTrip = JSON.parse(JSON.stringify(sample)) as PositionReferenceEntry;
+    expect(roundTrip).toEqual(sample);
+  });
+});

--- a/scripts/check-pages-links.test.ts
+++ b/scripts/check-pages-links.test.ts
@@ -28,6 +28,8 @@ describe("packed Pages link checks", () => {
     "reference/geoms/line.html",
     "reference/stats.html",
     "reference/stats/count.html",
+    "reference/positions.html",
+    "reference/positions/stack.html",
     "examples/interaction/tooltip.html",
     "interactions/brush-zoom.html",
     "interactions/linked-views.html",
@@ -106,6 +108,8 @@ describe("packed Pages link checks", () => {
     expect(requiredPages).toContain("reference/geoms/line.html");
     expect(requiredPages).toContain("reference/stats.html");
     expect(requiredPages).toContain("reference/stats/count.html");
+    expect(requiredPages).toContain("reference/positions.html");
+    expect(requiredPages).toContain("reference/positions/stack.html");
     expect(requiredPages).toContain("guide/interaction-reference.html");
     expect(requiredPages).toContain("robots.txt");
     expect(requiredPages).toContain("sitemap.xml");

--- a/scripts/check-pages-links.ts
+++ b/scripts/check-pages-links.ts
@@ -20,6 +20,8 @@ export const requiredPages = [
   "reference/geoms/line.html",
   "reference/stats.html",
   "reference/stats/count.html",
+  "reference/positions.html",
+  "reference/positions/stack.html",
   "examples/interaction/tooltip.html",
   "interactions/brush-zoom.html",
   "interactions/linked-views.html",

--- a/scripts/docs-route-inventory.test.ts
+++ b/scripts/docs-route-inventory.test.ts
@@ -40,6 +40,8 @@ describe("docs route inventory", () => {
     expect(paths.has("/reference/geoms/bin_2d")).toBe(true);
     expect(paths.has("/reference/stats")).toBe(true);
     expect(paths.has("/reference/stats/count")).toBe(true);
+    expect(paths.has("/reference/positions")).toBe(true);
+    expect(paths.has("/reference/positions/stack")).toBe(true);
     expect(paths.has("/reference/interactions")).toBe(true);
     expect(paths.has("/reference/cli")).toBe(true);
     expect(paths.has("/__perf/r3-interaction")).toBe(true);
@@ -120,6 +122,26 @@ describe("docs route inventory", () => {
     expect(details.every((entry) => entry.navigation === undefined)).toBe(true);
     expect(inventory.find((entry) => entry.path === "/reference/stats/count")?.title).toBe(
       "stat count — ggsvelte",
+    );
+  });
+
+  it("publishes the position reference inside the one Reference hierarchy", () => {
+    const inventory = createDocsRouteInventory();
+    const index = inventory.find((entry) => entry.path === "/reference/positions");
+    expect(index).toMatchObject({
+      title: "Position reference — ggsvelte",
+      canonicalPath: "/reference/positions",
+      kind: "page",
+      index: true,
+      sitemap: true,
+      shell: "docs",
+      navigation: { section: "Reference", label: "Position reference", order: 53 },
+    });
+    const details = inventory.filter((entry) => entry.path.startsWith("/reference/positions/"));
+    expect(details.length).toBe(6);
+    expect(details.every((entry) => entry.navigation === undefined)).toBe(true);
+    expect(inventory.find((entry) => entry.path === "/reference/positions/stack")?.title).toBe(
+      "position stack — ggsvelte",
     );
   });
 

--- a/scripts/docs-route-inventory.ts
+++ b/scripts/docs-route-inventory.ts
@@ -8,6 +8,7 @@ import {
 import { GUIDE_CATALOG, type GuideCatalogEntry } from "../apps/docs/src/lib/catalog/guide.ts";
 import type { DocsRouteMetadata, RouteHeading } from "../apps/docs/src/lib/route-types.ts";
 import { geomReferenceList } from "../packages/spec/src/geom-reference.ts";
+import { positionReferenceList } from "../packages/spec/src/position-reference.ts";
 import { statReferenceList } from "../packages/spec/src/stat-reference.ts";
 import { CLI_REFERENCE_OPTIONS } from "./cli-docs.ts";
 
@@ -128,6 +129,22 @@ const TOP_LEVEL_ROUTES: readonly DocsRouteRecord[] = [
     ],
   },
   {
+    path: "/reference/positions",
+    title: "Position reference — ggsvelte",
+    description:
+      "Schema-derived API reference for every position adjustment: positionParams and compatible geoms.",
+    canonicalPath: "/reference/positions",
+    kind: "page",
+    index: true,
+    sitemap: true,
+    shell: "docs",
+    navigation: { section: "Reference", label: "Position reference", order: 53 },
+    headings: [
+      { id: "all-positions", title: "All positions", level: 2 },
+      { id: "how-to-set", title: "How to set a position", level: 2 },
+    ],
+  },
+  {
     path: "/reference/interactions",
     title: "Search interactions — ggsvelte",
     description:
@@ -137,7 +154,6 @@ const TOP_LEVEL_ROUTES: readonly DocsRouteRecord[] = [
     index: true,
     sitemap: true,
     shell: "docs",
-    // order 53 reserved for /reference/positions (next follow-up)
     navigation: { section: "Reference", label: "Interaction reference", order: 54 },
   },
   {
@@ -244,6 +260,43 @@ function statDetailRoutes(): DocsRouteRecord[] {
       title: `stat ${entry.name} — ggsvelte`,
       description: `stat "${entry.name}": ${entry.summary}`,
       canonicalPath: `/reference/stats/${entry.slug}`,
+      kind: "page" as const,
+      index: true,
+      sitemap: true,
+      shell: "docs" as const,
+      headings,
+    };
+  });
+}
+
+/** Same matching rule as apps/docs reference/positions/[name] page load. */
+function positionHasRelatedExamples(position: string): boolean {
+  return EXAMPLES.some(
+    (entry) =>
+      entry.tags.includes(position) ||
+      entry.tags.includes(`position-${position}`) ||
+      entry.tags.includes(`position_${position}`) ||
+      entry.id.includes(position),
+  );
+}
+
+/** One indexable page per KNOWN_POSITIONS entry. */
+function positionDetailRoutes(): DocsRouteRecord[] {
+  return positionReferenceList().map((entry) => {
+    const headings: RouteHeading[] = [
+      { id: "usage", title: "Usage", level: 2 },
+      { id: "params", title: "positionParams", level: 2 },
+      { id: "default-for", title: "Default for geoms", level: 2 },
+      { id: "compatible-geoms", title: "Compatible geoms", level: 2 },
+    ];
+    if (positionHasRelatedExamples(entry.name)) {
+      headings.push({ id: "examples", title: "Examples", level: 2 });
+    }
+    return {
+      path: `/reference/positions/${entry.slug}`,
+      title: `position ${entry.name} — ggsvelte`,
+      description: `position "${entry.name}": ${entry.summary}`,
+      canonicalPath: `/reference/positions/${entry.slug}`,
       kind: "page" as const,
       index: true,
       sitemap: true,
@@ -394,6 +447,7 @@ export function createDocsRouteInventory(): DocsRouteRecord[] {
     ...TOP_LEVEL_ROUTES,
     ...geomDetailRoutes(),
     ...statDetailRoutes(),
+    ...positionDetailRoutes(),
     ...guides,
     ...examples,
     ...interactionExpositions,

--- a/scripts/gen-llms.ts
+++ b/scripts/gen-llms.ts
@@ -401,6 +401,7 @@ export function buildLlmsIndex(
   lines.push(
     "- [Geom reference](/reference/geoms): every Geom* component with defaults, allowed stats/positions, and params from the schema",
     "- [Stat reference](/reference/stats): every statistical transform with after_stat columns and compatible geoms",
+    "- [Position reference](/reference/positions): every position adjustment with positionParams and compatible geoms",
     "- [Search interaction reference](/reference/interactions): filter interaction capabilities, events, diagnostics, and accessibility guidance",
     "- [JSON Schema v0](/schema/v0.json): the PortableSpec schema (unstable in v0.1)",
     "- [llms-full.txt](/llms-full.txt): all docs prose plus every example (spec JSON + Svelte source)",

--- a/scripts/llms-guide-content.ts
+++ b/scripts/llms-guide-content.ts
@@ -219,6 +219,10 @@ The full list of statistical transforms lives in the
 each value. Open a specific stat, for example [count](/reference/stats/count)
 or [smooth](/reference/stats/smooth).
 
+Position adjustments are listed in the
+[position reference](/reference/positions): stack, fill, dodge, jitter, nudge,
+and identity, with \`positionParams\` for jitter and nudge.
+
 ## Statistical summaries
 
 \`\`\`svelte fragment

--- a/tests/visual/docs-progressive-search.spec.ts
+++ b/tests/visual/docs-progressive-search.spec.ts
@@ -147,7 +147,7 @@ test("Docs landing and sidebar expose the full path without duplicate Reference"
   ]);
   // Overview + guides minus deleted pre-0.1 page.
   // Overview + every navigable guide/reference chapter (includes Geom reference).
-  await expect(sidebar.getByRole("link")).toHaveCount(27);
+  await expect(sidebar.getByRole("link")).toHaveCount(28);
   await expect(sidebar.getByRole("link", { name: "Dates without preprocessing" })).toBeVisible();
   await expectNoDocumentOverflow(page);
 

--- a/tests/visual/docs-shell.spec.ts
+++ b/tests/visual/docs-shell.spec.ts
@@ -124,7 +124,7 @@ test("desktop docs shell exposes chapter, breadcrumb, contents, and sequence nav
   const chapters = page.getByRole("navigation", { name: "Guide chapters" });
   await expect(chapters).toBeVisible();
   // Overview + every navigable guide/reference chapter (includes Geom reference).
-  await expect(chapters.getByRole("link")).toHaveCount(27);
+  await expect(chapters.getByRole("link")).toHaveCount(28);
   await expect(chapters.getByRole("link", { name: "Dates without preprocessing" })).toBeVisible();
   await expect(page.getByRole("navigation", { name: "Breadcrumb" })).toContainText(
     "Getting started",


### PR DESCRIPTION
## Summary

- Export `POSITION_REFERENCE` / `positionReferenceList()` from `@ggsvelte/spec`.
- Add `/reference/positions` index + `/reference/positions/<name>` detail pages.
- Wire inventory (order 53), search, lifecycle, landings, sidebar count (28), and geom detail links to each allowed position.

## Test plan

- [x] `bun test packages/spec/tests/position-reference.test.ts`
- [x] `bun test scripts/docs-route-inventory.test.ts`
- [x] lifecycle / docs routes / search regen
- [ ] CI green
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1104" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->