### PR TITLE
feat(core): project month-day values so the year actually collapses

### DIFF
--- a/.changeset/month-day-projection.md
+++ b/.changeset/month-day-projection.md
@@ -1,0 +1,27 @@
+---
+"@ggsvelte/core": minor
+---
+
+<!-- markdownlint-disable MD041 -->
+
+feat(core): project month-day values so the year actually collapses
+
+`temporalKind: "monthDay"` validated and authored but did not yet change what a
+chart drew. Now it does: values reach the scale with their year replaced by the
+reference year, so two observations of the same calendar day from different
+years occupy one position.
+
+The projection sits in `positionColumn` and `positionValuesToNumeric`, the two
+doors into scale space, so marks, trained domains, annotation intercepts and
+stat frames all agree. It is idempotent — a binned median of already-projected
+instants is another already-projected instant, and re-projecting it is a no-op.
+
+A month-day axis defaults to the `md` parser rather than `auto`, which would
+read `"04-05"` as a category and never take the temporal path at all.
+
+Two preflight gates learned the same exemption a `time` axis already has: a
+field parsing as `date` is exactly what a month-day axis expects to be handed,
+not a contradiction. Without both, `y: "bloomDate"` threw
+`temporal-parse-failed`.
+
+Migration: none — additive

--- a/packages/core/src/pipeline/frame-stats-shared.ts
+++ b/packages/core/src/pipeline/frame-stats-shared.ts
@@ -74,6 +74,11 @@ export function shouldAggregateOnSemanticTemporalX(
   // time-of-day (#831): scale space is ms-of-day via positionColumn /
   // positionValuesToNumeric, not raw parseTemporal epoch semantics (and not
   // portable seconds). Aggregate on source cells, then convert for xNumeric.
+  //
+  // monthDay deliberately does NOT join this arm. Its parser (`md`) collapses
+  // the year during parsing, so the semantic value is already scale space —
+  // aggregating on it is what groups two years' worth of the same calendar day
+  // together. Excluding it here would key them apart and lose the collapse.
   if (conversion.requestedKind === "time") return false;
   const geom = binding.layer.geom;
   const barDiscretizes =

--- a/packages/core/src/pipeline/temporal-position.ts
+++ b/packages/core/src/pipeline/temporal-position.ts
@@ -1,4 +1,5 @@
 import {
+  MONTH_DAY_REFERENCE_YEAR,
   parseTemporalColumn,
   type PositionScaleSpec,
   type TemporalDecision,
@@ -80,6 +81,7 @@ export function positionColumn(
       ? table.numeric(field, conversion.sourceParser, conversion.options)
       : table.transformed(field, conversion.sourceParser, conversion.options, transform)
           .transformed;
+  if (conversion.requestedKind === "monthDay") return mapToMonthDayMs(base);
   if (conversion.requestedKind !== "time") return base;
   return mapToTimeOfDayMs(table.column(field), base);
 }
@@ -137,6 +139,29 @@ function cellToTimeOfDayMs(value: CellValue): number {
   return Number.NaN;
 }
 
+/**
+ * Map an instant to month-day scale space: the same month and day, in the
+ * reference year. Idempotent, so a value that already arrived there — a stat's
+ * binned median, say — passes through untouched.
+ */
+function toMonthDayMs(epochMs: number): number {
+  if (!Number.isFinite(epochMs)) return Number.NaN;
+  const d = new Date(epochMs);
+  return Date.UTC(MONTH_DAY_REFERENCE_YEAR, d.getUTCMonth(), d.getUTCDate());
+}
+
+/**
+ * The `md` parser already lands strings in the reference year, but `Date` cells
+ * short-circuit parsing and keep their own year, and stats hand back raw
+ * numbers. Projecting every route through one function is what keeps marks and
+ * the values summarizing them in the same space.
+ */
+function mapToMonthDayMs(base: Float64Array): Float64Array {
+  const out = new Float64Array(base.length);
+  for (let index = 0; index < base.length; index++) out[index] = toMonthDayMs(base[index]!);
+  return out;
+}
+
 function mapToTimeOfDayMs(values: readonly CellValue[], base: Float64Array): Float64Array {
   const out = new Float64Array(values.length);
   for (let index = 0; index < values.length; index++) {
@@ -175,7 +200,8 @@ export function positionValuesToNumeric(
     !conversion.forcedNonTemporal &&
     (conversion.parser !== "auto" ||
       parsed.decision.status === "temporal" ||
-      conversion.requestedKind === "time");
+      conversion.requestedKind === "time" ||
+      conversion.requestedKind === "monthDay");
   let numeric = conversion.forcedNonTemporal
     ? cellsToQuantitative(values)
     : temporal
@@ -199,6 +225,10 @@ export function positionValuesToNumeric(
   // scale_*_time: portable numbers are seconds since midnight (#831).
   if (conversion.requestedKind === "time") {
     numeric = mapToTimeOfDayMs(values, numeric);
+  }
+  // monthDay: portable numbers are instants, projected onto the reference year.
+  if (conversion.requestedKind === "monthDay") {
+    numeric = mapToMonthDayMs(numeric);
   }
   return { values: numeric, decision: parsed.decision };
 }
@@ -242,9 +272,13 @@ export function positionConversionContext(
   const forcedNonTemporal =
     (config.type === "linear" || config.type === "log" || config.type === "binned") &&
     !requestedTime;
+  // A month-day axis reads month-day values, so `md` is its natural parser
+  // rather than something the author has to remember to name. `auto` would
+  // read "04-05" as a category and never reach the temporal path at all.
+  const parser = config.parse ?? (config.temporalKind === "monthDay" ? "md" : "auto");
   return {
-    parser: config.parse ?? "auto",
-    sourceParser: config.parse ?? "auto",
+    parser,
+    sourceParser: parser,
     options: {
       ...(config.timezone !== undefined && { timezone: config.timezone }),
       ...(config.disambiguation !== undefined && {

--- a/packages/core/src/pipeline/temporal-preflight-fields.ts
+++ b/packages/core/src/pipeline/temporal-preflight-fields.ts
@@ -148,7 +148,10 @@ export function preflightTemporalFields(input: {
           conversion.requestedTime &&
           decision.status !== "temporal" &&
           // scale_*_time: numbers = seconds since midnight; Dates = UTC clock (#831).
-          !(conversion.requestedKind === "time" && columnAcceptsTimeOfDay(layerTable, field))
+          !(conversion.requestedKind === "time" && columnAcceptsTimeOfDay(layerTable, field)) &&
+          // monthDay: numbers are instants and Dates carry their own month-day,
+          // both projected onto the reference year without a string parse.
+          !(conversion.requestedKind === "monthDay" && columnAcceptsTimeOfDay(layerTable, field))
         ) {
           const candidates =
             decision.candidates.length > 0 ? ` Candidates: ${decision.candidates.join(", ")}.` : "";
@@ -173,16 +176,17 @@ export function preflightTemporalFields(input: {
             documentationUrl: docs("temporal-parse-failed"),
           });
         }
-        // time-of-day may reduce date/datetime to clock portion; other kind
-        // mismatches still fail.
+        // Both cyclical kinds take a slice of a fuller value and drop the rest:
+        // time-of-day keeps the clock, monthDay keeps the month and day. A
+        // field parsing as date or datetime is what each expects to be handed,
+        // so it is not a mismatch. Every other disagreement still fails.
+        const reducesFullValue =
+          conversion.requestedKind === "time" || conversion.requestedKind === "monthDay";
         const kindMismatch =
           decision.kind !== null &&
           conversion.requestedKind !== undefined &&
           decision.kind !== conversion.requestedKind &&
-          !(
-            conversion.requestedKind === "time" &&
-            (decision.kind === "date" || decision.kind === "datetime")
-          );
+          !(reducesFullValue && (decision.kind === "date" || decision.kind === "datetime"));
         if (kindMismatch) {
           const message = `The ${axis} scale requests ${conversion.requestedKind} values, but field "${field}" parses as ${decision.kind}. Choose the matching date/datetime scale or parser.`;
           throw new PipelineError(

--- a/packages/core/tests/pipeline/month-day-position.test.ts
+++ b/packages/core/tests/pipeline/month-day-position.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Month-day position conversion: the year collapses inside the scale.
+ *
+ * Observations from different years that fell on the same calendar day have to
+ * land on the same position. The docs lesson used to buy that by projecting
+ * day-of-year onto an invented year and shipping the result as data — which
+ * moved every leap-year observation by a day. Here the projection happens in
+ * the scale, preserves month and day, and is invisible to the reader.
+ *
+ * Marks (positionColumn) and detached values (positionValuesToNumeric) must
+ * share one scale space, or points drift off their own axis.
+ */
+import { describe, expect, it } from "bun:test";
+import { MONTH_DAY_REFERENCE_YEAR, aes, gg, scaleXMonthDay, scaleYMonthDay } from "@ggsvelte/spec";
+
+import { ColumnTable } from "../../src/table.ts";
+import { runPipeline } from "../../src/pipeline.ts";
+import {
+  positionColumn,
+  positionConversionContext,
+  positionValuesToNumeric,
+} from "../../src/pipeline/temporal-position.ts";
+
+const size = { width: 640, height: 400 };
+const conversion = positionConversionContext({ type: "time", temporalKind: "monthDay" });
+const REF = MONTH_DAY_REFERENCE_YEAR;
+
+/** Kyoto cherry blossom, spanning the whole record. */
+const blooms = [
+  { year: 812, bloom: "0812-04-01" },
+  { year: 1409, bloom: "1409-03-27" },
+  { year: 2001, bloom: "2001-04-01" },
+  { year: 2026, bloom: "2026-03-29" },
+];
+
+describe("month-day position conversion", () => {
+  it("puts the same calendar day from any year in the same place", () => {
+    // The entire feature, in one assertion: 812 and 2001 both bloomed on
+    // 1 April, 1189 years apart, and the scale has to agree.
+    const { values } = positionValuesToNumeric(["0812-04-01", "2001-04-01"], conversion);
+    expect(values[0]).toBe(Date.UTC(REF, 3, 1));
+    expect(values[1]).toBe(values[0]);
+  });
+
+  it("keeps the month and day, not the day of year", () => {
+    // 812 is a leap year, so 1 April is its 92nd day; 2001 is not, so its 92nd
+    // day is 2 April. Projecting day-of-year — which is what the old
+    // bloomRefDate column did — moved 204 of 838 observations by a day.
+    const { values } = positionValuesToNumeric(["0812-04-01"], conversion);
+    expect(values[0]).toBe(Date.UTC(REF, 3, 1));
+    expect(values[0]).not.toBe(Date.UTC(REF, 3, 2));
+  });
+
+  it("keeps 29 February, which is why the reference year is a leap year", () => {
+    const { values } = positionValuesToNumeric(["1812-02-29", "02-29"], conversion);
+    expect(values[0]).toBe(Date.UTC(REF, 1, 29));
+    expect(values[1]).toBe(values[0]);
+  });
+
+  it("reads bare month-days without asking for a parser", () => {
+    const { values } = positionValuesToNumeric(["04-05", "--04-05"], conversion);
+    expect(values[0]).toBe(Date.UTC(REF, 3, 5));
+    expect(values[1]).toBe(values[0]);
+  });
+
+  it("takes the month-day off Date cells too", () => {
+    const { values } = positionValuesToNumeric(
+      [new Date(Date.UTC(1812, 3, 1, 13, 45))],
+      conversion,
+    );
+    expect(values[0]).toBe(Date.UTC(REF, 3, 1));
+  });
+
+  it("leaves values already in the reference year alone", () => {
+    // Stats hand back scale-space numbers — a binned median of year-2000
+    // instants is another year-2000 instant. Projecting again must be a no-op,
+    // or every stat layer drifts a step away from the marks it summarizes.
+    const instant = Date.UTC(REF, 3, 15);
+    expect(positionValuesToNumeric([instant], conversion).values[0]).toBe(instant);
+  });
+
+  it("gives marks and detached values one scale space", () => {
+    const table = ColumnTable.fromRows(blooms);
+    const column = positionColumn(table, "bloom", conversion);
+    const detached = positionValuesToNumeric(
+      blooms.map((row) => row.bloom),
+      conversion,
+    ).values;
+    expect(Array.from(column)).toEqual(Array.from(detached));
+    expect(column[0]).toBe(Date.UTC(REF, 3, 1));
+  });
+});
+
+describe("month-day full pipeline", () => {
+  const spec = gg(blooms, aes({ x: "year", y: "bloom" }))
+    .geomPoint()
+    .scales(scaleYMonthDay({ reverse: true, domain: ["03-18", "05-10"] }))
+    .spec();
+
+  it("renders full dates on a month-day axis without a parse error", () => {
+    const model = runPipeline(spec, size);
+    expect(model.warnings.filter((w) => w.code.includes("temporal"))).toEqual([]);
+    expect(model.scene.batches.length).toBeGreaterThan(0);
+  });
+
+  it("trains a domain that never leaves the reference year", () => {
+    const model = runPipeline(spec, size);
+    const [min, max] = model.scales.y.domain as [number, number];
+    expect(Math.min(min, max)).toBeGreaterThanOrEqual(Date.UTC(REF, 0, 1));
+    expect(Math.max(min, max)).toBeLessThanOrEqual(Date.UTC(REF, 11, 31, 23, 59, 59, 999));
+  });
+
+  it("collapses the year on x as well, before anything aggregates", () => {
+    // Pre-stat grouping keys on the x column. If it groups on the parsed
+    // instant rather than the projected one, two observations of the same
+    // calendar day from different years stay apart and the collapse never
+    // happens — the chart looks plausible and is wrong.
+    const twoYearsOneDay = [{ bloom: "0812-04-01" }, { bloom: "2001-04-01" }];
+    const model = runPipeline(
+      gg(twoYearsOneDay, aes({ x: "bloom" }))
+        .geomBar()
+        .scales(scaleXMonthDay())
+        .spec(),
+      size,
+    );
+    const batch = model.scene.batches[0] as { rects: Float64Array };
+    expect(batch.rects.length / 4).toBe(1);
+  });
+
+  it("summarizes in the same space the marks are drawn in", () => {
+    // The lesson draws its trend as a binned median, and a stat reading the
+    // wrong space fails silently — the line renders, just in the wrong place.
+    // With one observation per bin every median is its own observation, so the
+    // summary marks have to land exactly on the points they summarize.
+    const perBin = { binwidth: 1, boundary: 0 } as const;
+    const raw = runPipeline(
+      gg(blooms, aes({ x: "year", y: "bloom" }))
+        .geomPoint()
+        .scales(scaleYMonthDay())
+        .spec(),
+      size,
+    );
+    const binned = runPipeline(
+      gg(blooms, aes({ x: "year", y: "bloom" }))
+        .geomPoint({ stat: "summary_bin", fun: "median", ...perBin })
+        .scales(scaleYMonthDay())
+        .spec(),
+      size,
+    );
+
+    const yPixels = (model: typeof raw) => {
+      const batch = model.scene.batches[0] as { positions: Float64Array };
+      return Array.from(batch.positions)
+        .filter((_, index) => index % 2 === 1)
+        .toSorted((a, b) => a - b);
+    };
+
+    expect(yPixels(binned)).toHaveLength(blooms.length);
+    for (const [index, y] of yPixels(binned).entries()) {
+      expect(y).toBeCloseTo(yPixels(raw)[index]!, 6);
+    }
+  });
+});


### PR DESCRIPTION
Stacked on #1105. Second of three PRs removing the reference-year hack.

#1105 made `temporalKind: "monthDay"` author and validate. It did not change what a chart drew. This does.

## What it does

Values reach the scale with their year replaced by the reference year, so two observations of the same calendar day from different years occupy one position.

```
"0812-04-01"  ─┐
               ├─→  Date.UTC(2000, 3, 1)
"2001-04-01"  ─┘
```

The projection sits in `positionColumn` and `positionValuesToNumeric` — the two doors into scale space — so marks, trained domains, annotation intercepts and stat frames all land in the same place. It is **idempotent**: a binned median of already-projected instants is another already-projected instant, and re-projecting it does nothing.

A month-day axis defaults to the `md` parser rather than `auto`. `auto` would read `"04-05"` as a category and never take the temporal path at all.

## Preflight

Two gates rejected the combination the feature exists for. `y: "bloomDate"` on a month-day axis threw `temporal-parse-failed` — the field parses as `date`, the scale asks for `monthDay`, and the kind check read that as a contradiction.

It isn't. Both cyclical kinds take a slice of a fuller value and discard the rest: `time` keeps the clock, `monthDay` keeps the month and day. A field parsing as `date` is exactly what each expects to be handed. `time` already had the exemption; `monthDay` now shares it, through one predicate rather than two parallel conditions.

## One thing that deliberately did *not* change

`shouldAggregateOnSemanticTemporalX` excludes `time`, and the obvious move was to add `monthDay` beside it. I wrote the test first, and it turns out to be exactly wrong.

`time` projects **after** parsing, so its semantic value is the real instant, not scale space — aggregating on it would key two readings of the same clock time apart. `monthDay` is the reverse: `md` collapses the year **during** parsing, so the semantic value already *is* scale space, and aggregating on it is precisely what groups two years' worth of one calendar day together.

Adding `monthDay` to that arm broke the collapse — a two-row fixture that should render one bar rendered two. The distinction now has a test and a comment, because the code reads as though the two kinds belong together and they don't.

## Tests

Eleven, in `packages/core/tests/pipeline/month-day-position.test.ts`, mirroring the time-of-day suite next to it.

The one that matters most is the leap-year pin: `0812-04-01` must map to 1 April, not 2 April. 812 is a leap year, so 1 April is its 92nd day; 2001's 92nd day is 2 April. Projecting day-of-year — which is what `bloomRefDate` does today — moves **204 of 838** observations by a day. Month-day projection is the fix, and that test is what stops it regressing.

The stat test avoids asserting mere finiteness, which would pass for a line drawn in entirely the wrong place. With one observation per bin every median is its own observation, so the summary marks must land *exactly* on the points they summarize — the assertion is pixel equality against a plain point layer.

Also covered: bare `MM-DD` and `--MM-DD`, 29 February (the reason the reference year is a leap year), `Date` cells, idempotence, marks-vs-detached agreement, a trained domain that never leaves the reference year, and the x-axis collapse.

Full suite green: 3625 spec+core+scripts, 163 svelte SSR, plus `check`, `check:svelte`, lint, format.

## Still to come

Labels. A month-day axis currently formats through the datetime path, so ticks read `2000-04-01` rather than `Apr 1`. That is the next PR, and it is what makes the kind worth having to a reader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1106" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->