### PR TITLE
feat(spec): export scale helper inventory from SCALE_CAPABILITIES (#1081)

### DIFF
--- a/.changeset/1081b-capabilities-hygiene.md
+++ b/.changeset/1081b-capabilities-hygiene.md
@@ -1,0 +1,14 @@
+---
+"@ggsvelte/spec": minor
+---
+
+<!-- markdownlint-disable MD041 -->
+
+feat(spec): export scale helper inventory from SCALE_CAPABILITIES (#1081)
+
+Public inventory helpers for the capability ledger: `scaleCapabilityCamelHelpers`,
+`STYLE_ORDINAL_SCALE_HELPERS`, and `builderScaleHelperNames`. Generator scripts
+(`builder:scales`, `scale:children`) now share this package surface so helper
+name sets are not re-derived by hand.
+
+Migration: none — additive

--- a/apps/docs/src/lib/generated/routes.ts
+++ b/apps/docs/src/lib/generated/routes.ts
@@ -5999,8 +5999,8 @@ export const DOCS_ROUTES = [
         level: 2,
       },
       {
-        id: "experimental-872",
-        title: "experimental (872)",
+        id: "experimental-875",
+        title: "experimental (875)",
         level: 3,
       },
       {

--- a/apps/docs/src/lib/generated/search-index.ts
+++ b/apps/docs/src/lib/generated/search-index.ts
@@ -9861,14 +9861,14 @@ export const DOCS_SEARCH_INDEX = [
     exact: ["@ggsvelte/spec"],
   },
   {
-    id: "heading:guide-lifecycle:experimental-872",
+    id: "heading:guide-lifecycle:experimental-875",
     kind: "heading",
-    title: "experimental (872)",
+    title: "experimental (875)",
     summary:
-      "experimental (872) in Lifecycle & editions. API stability tags per export, and the defaults-edition mechanism.",
-    href: "/guide/lifecycle#experimental-872",
+      "experimental (875) in Lifecycle & editions. API stability tags per export, and the defaults-edition mechanism.",
+    href: "/guide/lifecycle#experimental-875",
     keywords: ["Lifecycle & editions", "Reference"],
-    exact: ["experimental (872)"],
+    exact: ["experimental (875)"],
   },
   {
     id: "heading:guide-lifecycle:stable-intent-8",
@@ -15550,6 +15550,15 @@ export const DOCS_SEARCH_INDEX = [
     exact: ["STYLE_AESTHETIC_GEOMS"],
   },
   {
+    id: "api:ggsvelte-spec:STYLE_ORDINAL_SCALE_HELPERS",
+    kind: "api",
+    title: "STYLE_ORDINAL_SCALE_HELPERS",
+    summary: "@ggsvelte/spec · value · experimental.",
+    href: "/guide/lifecycle#ggsvelte-spec",
+    keywords: ["@ggsvelte/spec", ".", "value", "experimental"],
+    exact: ["STYLE_ORDINAL_SCALE_HELPERS"],
+  },
+  {
     id: "api:ggsvelte-spec:ScaleCapability",
     kind: "api",
     title: "ScaleCapability",
@@ -16540,6 +16549,15 @@ export const DOCS_SEARCH_INDEX = [
     exact: ["buildSchemaArtifact"],
   },
   {
+    id: "api:ggsvelte-spec:builderScaleHelperNames",
+    kind: "api",
+    title: "builderScaleHelperNames",
+    summary: "@ggsvelte/spec · value · experimental.",
+    href: "/guide/lifecycle#ggsvelte-spec",
+    keywords: ["@ggsvelte/spec", ".", "value", "experimental"],
+    exact: ["builderScaleHelperNames"],
+  },
+  {
     id: "api:ggsvelte-spec:canonicalMultiScaleChannel",
     kind: "api",
     title: "canonicalMultiScaleChannel",
@@ -17141,6 +17159,15 @@ export const DOCS_SEARCH_INDEX = [
     href: "/guide/lifecycle#ggsvelte-spec",
     keywords: ["@ggsvelte/spec", ".", "value", "experimental"],
     exact: ["scaleAlphaOrdinal"],
+  },
+  {
+    id: "api:ggsvelte-spec:scaleCapabilityCamelHelpers",
+    kind: "api",
+    title: "scaleCapabilityCamelHelpers",
+    summary: "@ggsvelte/spec · value · experimental.",
+    href: "/guide/lifecycle#ggsvelte-spec",
+    keywords: ["@ggsvelte/spec", ".", "value", "experimental"],
+    exact: ["scaleCapabilityCamelHelpers"],
   },
   {
     id: "api:ggsvelte-spec:scaleColorBinned",

--- a/lifecycle.json
+++ b/lifecycle.json
@@ -1680,6 +1680,10 @@
           "kind": "value",
           "lifecycle": "experimental"
         },
+        "STYLE_ORDINAL_SCALE_HELPERS": {
+          "kind": "value",
+          "lifecycle": "experimental"
+        },
         "ScaleCapability": {
           "kind": "type",
           "lifecycle": "experimental"
@@ -2120,6 +2124,10 @@
           "kind": "value",
           "lifecycle": "experimental"
         },
+        "builderScaleHelperNames": {
+          "kind": "value",
+          "lifecycle": "experimental"
+        },
         "canonicalMultiScaleChannel": {
           "kind": "value",
           "lifecycle": "experimental"
@@ -2385,6 +2393,10 @@
           "lifecycle": "experimental"
         },
         "scaleAlphaOrdinal": {
+          "kind": "value",
+          "lifecycle": "experimental"
+        },
+        "scaleCapabilityCamelHelpers": {
           "kind": "value",
           "lifecycle": "experimental"
         },

--- a/packages/spec/src/builder-scales.ts
+++ b/packages/spec/src/builder-scales.ts
@@ -3,7 +3,7 @@
  * Regenerate: bun run builder:scales:gen
  *
  * Fluent builder scale sugar methods (thin wrappers over scale-helpers).
- * Source of truth: SCALE_CAPABILITIES camelCase helpers + style ordinal aliases.
+ * Source of truth: builderScaleHelperNames() from SCALE_CAPABILITIES.
  * Core builder: builder-core.ts. Public GGBuilder: builder.ts.
  */
 import type { GGBuilder } from "./builder.js";

--- a/packages/spec/src/capabilities.ts
+++ b/packages/spec/src/capabilities.ts
@@ -333,6 +333,46 @@ export const SCALE_CAPABILITIES = [
 
 export type ScaleCapability = (typeof SCALE_CAPABILITIES)[number];
 
+/**
+ * CamelCase non-Colour helpers declared on `SCALE_CAPABILITIES`.
+ * Shared source for builder generation, Scale* shell completeness, and tests
+ * so helper-name sets are not re-derived by hand in each consumer (#1081 PR B).
+ */
+export function scaleCapabilityCamelHelpers(): readonly string[] {
+  const out = new Set<string>();
+  for (const cap of SCALE_CAPABILITIES) {
+    for (const h of cap.helpers) {
+      if (h.includes("_")) continue;
+      if (h.includes("Colour")) continue;
+      out.add(h);
+    }
+  }
+  return [...out].toSorted();
+}
+
+/**
+ * ggplot2-style ordinal camelCase aliases for style channels
+ * (binding-identical to the corresponding `*Discrete` helpers).
+ *
+ * Component shells re-export Ordinal names as aliases of Discrete shells
+ * (#830/#832) — they are NOT separate SHELL_MANIFEST entries, so they stay
+ * off the main ledger helper arrays. The builder mixin and package root still
+ * expose them; this constant is the single source for that extra set.
+ */
+export const STYLE_ORDINAL_SCALE_HELPERS = [
+  "scaleSizeOrdinal",
+  "scaleAlphaOrdinal",
+  "scaleLinewidthOrdinal",
+  "scaleShapeOrdinal",
+] as const;
+
+/** Helpers the GGBuilder scale mixin must wrap (ledger camel + style ordinals). */
+export function builderScaleHelperNames(): readonly string[] {
+  return [
+    ...new Set([...scaleCapabilityCamelHelpers(), ...STYLE_ORDINAL_SCALE_HELPERS]),
+  ].toSorted();
+}
+
 /** One checked geom-consumption table for mapped style channels. */
 export const STYLE_AESTHETIC_GEOMS = {
   // blank trains style scales without marks; jitter is sugar for point.

--- a/packages/spec/src/index.ts
+++ b/packages/spec/src/index.ts
@@ -274,7 +274,13 @@ export {
   HUE_PALETTE_10,
   hslToHex,
 } from "./hue-grey-palettes.js";
-export { SCALE_CAPABILITIES, STYLE_AESTHETIC_GEOMS } from "./capabilities.js";
+export {
+  SCALE_CAPABILITIES,
+  STYLE_AESTHETIC_GEOMS,
+  STYLE_ORDINAL_SCALE_HELPERS,
+  scaleCapabilityCamelHelpers,
+  builderScaleHelperNames,
+} from "./capabilities.js";
 export type { ScaleCapability, StyleAesthetic } from "./capabilities.js";
 /** @lifecycle experimental */
 export { GEOM_PARAM_KEYS } from "./geom-params.js";

--- a/packages/spec/tests/capabilities.test.ts
+++ b/packages/spec/tests/capabilities.test.ts
@@ -12,7 +12,12 @@
  */
 import { describe, expect, it } from "bun:test";
 
-import { SCALE_CAPABILITIES } from "../src/capabilities.ts";
+import {
+  SCALE_CAPABILITIES,
+  STYLE_ORDINAL_SCALE_HELPERS,
+  builderScaleHelperNames,
+  scaleCapabilityCamelHelpers,
+} from "../src/capabilities.ts";
 import * as spec from "../src/index.ts";
 import { normalize } from "../src/normalize.ts";
 import type { Scales } from "../src/schema.ts";
@@ -96,4 +101,32 @@ describe("every claimed helper normalizes to its declared family", () => {
       });
     }
   }
+});
+
+describe("capability helper inventory (#1081 PR B)", () => {
+  it("scaleCapabilityCamelHelpers lists every non-Colour camel ledger name", () => {
+    const fromApi = new Set(scaleCapabilityCamelHelpers());
+    const fromLedger = new Set<string>();
+    for (const cap of SCALE_CAPABILITIES) {
+      for (const h of cap.helpers) {
+        if (h.includes("_") || h.includes("Colour")) continue;
+        fromLedger.add(h);
+      }
+    }
+    expect(fromApi).toEqual(fromLedger);
+  });
+
+  it("STYLE_ORDINAL_SCALE_HELPERS are real exports and included in builderScaleHelperNames", () => {
+    expect(STYLE_ORDINAL_SCALE_HELPERS).toHaveLength(4);
+    for (const name of STYLE_ORDINAL_SCALE_HELPERS) {
+      expect(typeof registry[name], name).toBe("function");
+    }
+    const builder = new Set(builderScaleHelperNames());
+    for (const name of STYLE_ORDINAL_SCALE_HELPERS) {
+      expect(builder.has(name), name).toBe(true);
+    }
+    for (const name of scaleCapabilityCamelHelpers()) {
+      expect(builder.has(name), name).toBe(true);
+    }
+  });
 });

--- a/scripts/gen-builder-scales.test.ts
+++ b/scripts/gen-builder-scales.test.ts
@@ -7,28 +7,34 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
 import {
+  STYLE_ORDINAL_SCALE_HELPERS,
+  builderScaleHelperNames,
+  scaleCapabilityCamelHelpers,
+} from "@ggsvelte/spec";
+
+import {
   BUILDER_SCALES_PATH,
   builderScaleHelpers,
-  ledgerCamelHelpers,
   renderBuilderScalesSource,
-  STYLE_ORDINAL_BUILDER_HELPERS,
 } from "./gen-builder-scales.ts";
 
 const repoRoot = join(import.meta.dir, "..");
 
 describe("builder scale helper set", () => {
-  it("includes every ledger camelCase helper", () => {
-    const ledger = new Set(ledgerCamelHelpers());
+  it("includes every ledger camelCase helper from the package inventory", () => {
+    const ledger = new Set(scaleCapabilityCamelHelpers());
     const builder = new Set(builderScaleHelpers());
     for (const h of ledger) {
       expect(builder.has(h), `missing builder helper ${h}`).toBe(true);
     }
     expect(ledger.size).toBeGreaterThan(90);
+    // Generator delegates to the package export.
+    expect(builderScaleHelpers()).toEqual([...builderScaleHelperNames()]);
   });
 
-  it("includes style ordinal aliases", () => {
+  it("includes style ordinal aliases from STYLE_ORDINAL_SCALE_HELPERS", () => {
     const builder = new Set(builderScaleHelpers());
-    for (const h of STYLE_ORDINAL_BUILDER_HELPERS) {
+    for (const h of STYLE_ORDINAL_SCALE_HELPERS) {
       expect(builder.has(h), h).toBe(true);
     }
   });
@@ -48,9 +54,7 @@ describe("builder scale helper set", () => {
 describe("builder-scales.ts staleness", () => {
   it("committed file matches render (regenerate with bun run builder:scales:gen)", async () => {
     const { builderScalesArtifact } = await import("./gen-builder-scales.ts");
-    // check() throws ArtifactError when STALE/MISSING
     await builderScalesArtifact(repoRoot).check();
-    // Sanity: file exists and is non-empty
     const current = readFileSync(join(repoRoot, BUILDER_SCALES_PATH), "utf8");
     expect(current.length).toBeGreaterThan(500);
   });

--- a/scripts/gen-builder-scales.ts
+++ b/scripts/gen-builder-scales.ts
@@ -1,11 +1,9 @@
 /**
  * gen-builder-scales — generates packages/spec/src/builder-scales.ts from
- * SCALE_CAPABILITIES (#1081 PR A).
+ * SCALE_CAPABILITIES (#1081).
  *
- * Every camelCase non-Colour helper on the ledger becomes a thin GGBuilder
- * method: `return this.scales(helper(...args))`. Style-channel ggplot2
- * ordinal aliases (Size/Alpha/Linewidth/Shape) are included even when only
- * the snake_case twin is listed on the ledger.
+ * Helper names come from `builderScaleHelperNames()` in @ggsvelte/spec so the
+ * ledger (plus style ordinal aliases) is the single source of truth.
  *
  * Usage:
  *   bun scripts/gen-builder-scales.ts           # (re)write builder-scales.ts
@@ -13,41 +11,15 @@
  */
 import { join } from "node:path";
 
-import { SCALE_CAPABILITIES } from "@ggsvelte/spec";
+import { builderScaleHelperNames } from "@ggsvelte/spec";
 
 import { defineArtifact, formatGeneratedSource } from "./artifact.ts";
 
 export const BUILDER_SCALES_PATH = "packages/spec/src/builder-scales.ts";
 
-/**
- * ggplot2-style ordinal aliases kept on the builder (binding-identical to the
- * corresponding discrete helper). Component shells re-export these names too
- * (#830/#832); the capability ledger lists only snake_case for some of them.
- */
-export const STYLE_ORDINAL_BUILDER_HELPERS = [
-  "scaleSizeOrdinal",
-  "scaleAlphaOrdinal",
-  "scaleLinewidthOrdinal",
-  "scaleShapeOrdinal",
-] as const;
-
-/** CamelCase non-Colour helpers from SCALE_CAPABILITIES, sorted. */
-export function ledgerCamelHelpers(): string[] {
-  const out = new Set<string>();
-  for (const cap of SCALE_CAPABILITIES) {
-    for (const h of cap.helpers) {
-      if (h.includes("_")) continue;
-      if (h.includes("Colour")) continue;
-      out.add(h);
-    }
-  }
-  return [...out].toSorted();
-}
-
 /** Full set of helper names the builder mixin must wrap. */
 export function builderScaleHelpers(): string[] {
-  const out = new Set([...ledgerCamelHelpers(), ...STYLE_ORDINAL_BUILDER_HELPERS]);
-  return [...out].toSorted();
+  return [...builderScaleHelperNames()];
 }
 
 export function renderBuilderScalesSource(helpers: readonly string[]): string {
@@ -66,7 +38,7 @@ export function renderBuilderScalesSource(helpers: readonly string[]): string {
  * Regenerate: bun run builder:scales:gen
  *
  * Fluent builder scale sugar methods (thin wrappers over scale-helpers).
- * Source of truth: SCALE_CAPABILITIES camelCase helpers + style ordinal aliases.
+ * Source of truth: builderScaleHelperNames() from SCALE_CAPABILITIES.
  * Core builder: builder-core.ts. Public GGBuilder: builder.ts.
  */
 import type { GGBuilder } from "./builder.js";

--- a/scripts/gen-scale-children.ts
+++ b/scripts/gen-scale-children.ts
@@ -13,7 +13,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 
-import { SCALE_CAPABILITIES } from "@ggsvelte/spec";
+import { SCALE_CAPABILITIES, scaleCapabilityCamelHelpers } from "@ggsvelte/spec";
 
 import { defineArtifact, defineArtifactGroup } from "./artifact.ts";
 
@@ -563,15 +563,8 @@ export function shellRelPath(component: string): string {
 
 /** CamelCase helpers across all families, excluding Colour spellings. */
 export function expectedCamelHelpers(): Set<string> {
-  const out = new Set<string>();
-  for (const cap of SCALE_CAPABILITIES) {
-    for (const h of cap.helpers) {
-      if (h.includes("_")) continue;
-      if (h.includes("Colour")) continue;
-      out.add(h);
-    }
-  }
-  return out;
+  // Single source: packages/spec capabilities ledger (#1081 PR B).
+  return new Set(scaleCapabilityCamelHelpers());
 }
 
 /** Colour-spelled camelCase helpers → component alias names. */


### PR DESCRIPTION
## Summary

Part B of #1081 — capabilities hygiene after #1103.

- Export `scaleCapabilityCamelHelpers()`, `STYLE_ORDINAL_SCALE_HELPERS`, and `builderScaleHelperNames()` from `@ggsvelte/spec`
- `builder:scales:gen` and `scale:children` completeness checks consume the package inventory instead of hand-walking the ledger
- Style ordinal aliases stay off the main ledger helper arrays (they are Discrete shell re-exports, not separate Scale* files) but remain the single listed extra set for the builder mixin

## Test plan

- [x] RED→GREEN inventory tests in `capabilities.test.ts`
- [x] existing builder-scales parity + gen-builder-scales / gen-scale-children suites
- [x] `bun run check` + `lifecycle:gen`

Tracks #1081. Follows #1103.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1107" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->