### PR TITLE
feat(core): month-day axes read "Apr 1", and refuse labels they cannot fill

### DIFF
--- a/.changeset/month-day-labels.md
+++ b/.changeset/month-day-labels.md
@@ -1,0 +1,30 @@
+---
+"@ggsvelte/core": minor
+"@ggsvelte/spec": minor
+---
+
+<!-- markdownlint-disable MD041 -->
+
+feat(core): month-day axes read "Apr 1", and refuse labels they cannot fill
+
+A month-day axis carried its values correctly but formatted them through the
+datetime path, so ticks read `2000-04-01 00:00:00 UTC` — the reference year
+exposed in the one place a reader was guaranteed to look. Axis ticks, the
+crosshair, and the tooltip header now read `Apr 1`.
+
+`fullLabel` is fixed too. It is not the visible tick, which is exactly why the
+leak was quiet, and it reaches the guide plan.
+
+The automatic interval ladder drops week and year for this kind. A year tick on
+a one-year axis is the same tick twice, and a week tick implies a weekday that
+belongs to the reference year rather than to the data. Day, month, and quarter
+remain; an authored `dateBreaks` is still honoured as given.
+
+`dateLabels` now rejects tokens a month-day axis cannot fill honestly. The rule
+is that a token is legal if and only if the month and the day determine it, so
+`%m %b %B %d %e %q` are accepted and year, clock, zone, and weekday tokens are
+refused with a message naming the offending token. `%a` is refused for the same
+reason as `%Y`: 1 April fell on a different weekday in 812 than in 2001, so
+printing one would invent a fact.
+
+Migration: none — additive

--- a/packages/core/src/layout/format-temporal-labels.ts
+++ b/packages/core/src/layout/format-temporal-labels.ts
@@ -75,7 +75,9 @@ function displayParts(ms: number, options: TemporalLabelFormatOptions): Temporal
   const locale = options.locale ?? "en-US";
   // date and time-of-day are wall-clock-less / fixed UTC; datetime may carry a zone.
   const configuredTimezone =
-    options.kind === "date" || options.kind === "time" ? "UTC" : (options.timezone ?? "UTC");
+    options.kind === "date" || options.kind === "time" || options.kind === "monthDay"
+      ? "UTC"
+      : (options.timezone ?? "UTC");
   const timezone =
     configuredTimezone === "Z" || configuredTimezone === "Etc/UTC" ? "UTC" : configuredTimezone;
   const d = new Date(ms);
@@ -164,7 +166,7 @@ export function compileTemporalLabelFormat(
   pattern: string,
   options: TemporalLabelFormatOptions,
 ): (ms: number) => string {
-  const error = temporalLabelConfigurationError(pattern);
+  const error = temporalLabelConfigurationError(pattern, options.kind);
   if (error !== null) throw new Error(error);
   return (ms: number) => {
     const d = displayParts(ms, options);
@@ -254,13 +256,18 @@ export function formatTemporalTickSequence(
   const full = compileTemporalLabelFormat(
     options.kind === "date"
       ? "%Y-%m-%d"
-      : options.kind === "time"
-        ? needsMilliseconds
-          ? "%H:%M:%S.%L"
-          : "%H:%M:%S"
-        : needsMilliseconds
-          ? "%Y-%m-%d %H:%M:%S.%L %Z"
-          : "%Y-%m-%d %H:%M:%S %Z",
+      : // monthDay values sit in a reference year that is an implementation
+        // detail. fullLabel is not the visible tick, so a leak here is quiet —
+        // and it reaches the guide plan.
+        options.kind === "monthDay"
+        ? "%b %e"
+        : options.kind === "time"
+          ? needsMilliseconds
+            ? "%H:%M:%S.%L"
+            : "%H:%M:%S"
+          : needsMilliseconds
+            ? "%Y-%m-%d %H:%M:%S.%L %Z"
+            : "%Y-%m-%d %H:%M:%S %Z",
     options,
   );
   if (options.pattern !== undefined) {
@@ -288,9 +295,16 @@ export function formatTemporalTickSequence(
     let label: string;
     switch (options.interval.unit) {
       case "year":
-        // time-of-day (#831) lives on 1970-01-01Z — never emit a calendar year.
+        // Neither cyclical kind has a year to show: time-of-day (#831) lives on
+        // 1970-01-01Z and monthDay on the reference year. A year interval still
+        // reaches here — it is the fallback when an author gives fewer than two
+        // explicit breaks — so it has to answer with something truthful.
         label =
-          options.kind === "time" ? `${pad2(part.hour)}:${pad2(part.minute)}` : String(part.year);
+          options.kind === "time"
+            ? `${pad2(part.hour)}:${pad2(part.minute)}`
+            : options.kind === "monthDay"
+              ? `${part.monthShort} ${String(part.day)}`
+              : String(part.year);
         break;
       case "quarter": {
         if (options.kind === "time") {

--- a/packages/core/src/layout/temporal-axis-candidates.ts
+++ b/packages/core/src/layout/temporal-axis-candidates.ts
@@ -61,7 +61,9 @@ export function temporalOptions(input: TemporalAxisPlanInput) {
     kind: input.kind,
     locale: input.config.locale ?? "en-US",
     timezone:
-      input.kind === "date" || input.kind === "time" ? "UTC" : (input.config.timezone ?? "UTC"),
+      input.kind === "date" || input.kind === "time" || input.kind === "monthDay"
+        ? "UTC"
+        : (input.config.timezone ?? "UTC"),
     weekStart: input.config.weekStart ?? "monday",
     ...(input.config.disambiguation !== undefined && {
       disambiguation: input.config.disambiguation,
@@ -206,7 +208,15 @@ export function automaticCandidate(input: TemporalAxisPlanInput): TemporalCandid
         ? AUTOMATIC_INTERVALS.filter((candidate) =>
             ["millisecond", "second", "minute", "hour"].includes(candidate.unit),
           )
-        : AUTOMATIC_INTERVALS;
+        : // A yearless axis holds one year, so a year tick is the same tick
+          // twice. A week tick is worse than useless: it implies a weekday, and
+          // the weekday belongs to the reference year rather than to the data.
+          // Below a day there is nothing left to resolve.
+          input.kind === "monthDay"
+          ? AUTOMATIC_INTERVALS.filter((candidate) =>
+              ["day", "month", "quarter"].includes(candidate.unit),
+            )
+          : AUTOMATIC_INTERVALS;
   const span = Math.max(1, input.domain[1] - input.domain[0]);
   const previousApprox =
     input.previousInterval === undefined || input.previousInterval === null

--- a/packages/core/src/layout/temporal-guide.ts
+++ b/packages/core/src/layout/temporal-guide.ts
@@ -116,7 +116,9 @@ export function planTemporalAxis(input: TemporalAxisPlanInput): AxisGuidePlan {
     interval: source === "explicit" ? null : selected.interval.key,
     locale: input.config.locale ?? "en-US",
     timezone:
-      input.kind === "date" || input.kind === "time" ? "UTC" : (input.config.timezone ?? "UTC"),
+      input.kind === "date" || input.kind === "time" || input.kind === "monthDay"
+        ? "UTC"
+        : (input.config.timezone ?? "UTC"),
     ticks: Object.freeze([...selected.ticks, ...minorTicks].map((tick) => Object.freeze(tick))),
     ...(input.sourceBreaks !== undefined && {
       sourceBreaks: Object.freeze([...input.sourceBreaks]),

--- a/packages/core/src/pipeline/layout-helpers.ts
+++ b/packages/core/src/pipeline/layout-helpers.ts
@@ -111,7 +111,15 @@ export function makeAxisFormatter(
     if (scale.type !== "time") return undefined;
     const kind = resolvedTemporalKind ?? config?.temporalKind ?? "datetime";
     const defaultPattern =
-      kind === "date" ? "%Y-%m-%d" : kind === "time" ? "%H:%M:%S" : "%Y-%m-%d %H:%M:%S %Z";
+      kind === "date"
+        ? "%Y-%m-%d"
+        : kind === "time"
+          ? "%H:%M:%S"
+          : // The crosshair and tooltip header read through here, so this is
+            // where a month-day axis says "Apr 1" rather than a stamped date.
+            kind === "monthDay"
+            ? "%b %e"
+            : "%Y-%m-%d %H:%M:%S %Z";
     const format = compileTemporalLabelFormat(defaultPattern, {
       kind,
       locale: config?.locale ?? "en-US",

--- a/packages/core/src/pipeline/setup-run-normalize.ts
+++ b/packages/core/src/pipeline/setup-run-normalize.ts
@@ -41,7 +41,7 @@ function preflightTemporalLabels(spec: PortableSpec): void {
   for (const axis of ["x", "y"] as const) {
     const dateLabels = spec.scales?.[axis]?.dateLabels;
     if (typeof dateLabels !== "string") continue;
-    const error = temporalLabelConfigurationError(dateLabels);
+    const error = temporalLabelConfigurationError(dateLabels, spec.scales?.[axis]?.temporalKind);
     if (error === null) continue;
     const path = `/scales/${axis}/dateLabels`;
     throw new PipelineError("invalid-temporal-labels", path, error, {

--- a/packages/core/tests/pipeline/month-day-position.test.ts
+++ b/packages/core/tests/pipeline/month-day-position.test.ts
@@ -15,6 +15,7 @@ import { MONTH_DAY_REFERENCE_YEAR, aes, gg, scaleXMonthDay, scaleYMonthDay } fro
 
 import { ColumnTable } from "../../src/table.ts";
 import { runPipeline } from "../../src/pipeline.ts";
+import { axisGuideFor } from "../pipeline-temporal/fixtures.ts";
 import {
   positionColumn,
   positionConversionContext,
@@ -158,6 +159,33 @@ describe("month-day full pipeline", () => {
     expect(yPixels(binned)).toHaveLength(blooms.length);
     for (const [index, y] of yPixels(binned).entries()) {
       expect(y).toBeCloseTo(yPixels(raw)[index]!, 6);
+    }
+  });
+});
+
+describe("month-day labels through the pipeline", () => {
+  const model = runPipeline(
+    gg(blooms, aes({ x: "year", y: "bloom" }))
+      .geomPoint()
+      .scales(scaleYMonthDay({ reverse: true, domain: ["03-18", "05-10"] }))
+      .spec(),
+    size,
+  );
+
+  it("reads back a calendar day, which is the point of the kind", () => {
+    // This is what the crosshair and the tooltip header show. Before the kind
+    // existed it would have read "2000-04-01 00:00:00 UTC" — the reference
+    // year, in the one place a reader was guaranteed to see it.
+    expect(model.axisFormatters.y(Date.UTC(REF, 3, 1))).toBe("Apr 1");
+  });
+
+  it("puts no year on any axis tick, visible label or full", () => {
+    const guide = axisGuideFor(model.guidePlans, "y");
+    expect(guide).toBeDefined();
+    expect(guide?.ticks.length).toBeGreaterThan(0);
+    for (const tick of guide?.ticks ?? []) {
+      expect(tick.label).not.toContain(String(REF));
+      expect(tick.fullLabel).not.toContain(String(REF));
     }
   });
 });

--- a/packages/core/tests/temporal-guide/label-formatting.test.ts
+++ b/packages/core/tests/temporal-guide/label-formatting.test.ts
@@ -184,3 +184,56 @@ describe("temporal label formatting", () => {
     ).toThrow(/%Q/);
   });
 });
+
+describe("month-day labels", () => {
+  const REF = 2000;
+  const options = { kind: "monthDay", locale: "en-US", timezone: "UTC" } as const;
+  const day = { unit: "day", step: 1, key: "1 day" } as const;
+
+  it("names the day without a year", () => {
+    const labels = formatTemporalTickSequence(
+      [Date.UTC(REF, 3, 5), Date.UTC(REF, 3, 15), Date.UTC(REF, 3, 25)],
+      { ...options, interval: day },
+    );
+    expect(labels.map((label) => label.label)).toEqual(["Apr 5", "Apr 15", "Apr 25"]);
+  });
+
+  it("keeps the year out of the full label too", () => {
+    // fullLabel is not the visible tick, so a leak here is easy to miss — it
+    // reaches the guide plan and anything reading it. The datetime default
+    // would render "2000-04-05 00:00:00 UTC", exposing the reference year the
+    // whole kind exists to hide.
+    const [label] = formatTemporalTickSequence([Date.UTC(REF, 3, 5)], {
+      ...options,
+      interval: day,
+    });
+    expect(label!.fullLabel).not.toContain("2000");
+    expect(label!.fullLabel).toBe("Apr 5");
+  });
+
+  it("never emits a bare year, whatever interval it is handed", () => {
+    // A year interval is the fallback when an author gives fewer than two
+    // explicit breaks, so it is reachable without anyone asking for it.
+    for (const unit of ["year", "quarter", "month", "week", "day"] as const) {
+      const [label] = formatTemporalTickSequence([Date.UTC(REF, 3, 5)], {
+        ...options,
+        interval: { unit, step: 1, key: `1 ${unit}` },
+      });
+      expect(label!.label, unit).not.toBe(String(REF));
+      expect(label!.label, unit).not.toContain("2000");
+    }
+  });
+
+  it("still names the month and the quarter, which stand alone without a year", () => {
+    const month = formatTemporalTickSequence([Date.UTC(REF, 3, 1)], {
+      ...options,
+      interval: { unit: "month", step: 1, key: "1 month" },
+    });
+    expect(month[0]!.label).toBe("Apr");
+    const quarter = formatTemporalTickSequence([Date.UTC(REF, 3, 1)], {
+      ...options,
+      interval: { unit: "quarter", step: 1, key: "1 quarter" },
+    });
+    expect(quarter[0]!.label).toBe("Q2");
+  });
+});

--- a/packages/core/tests/temporal-guide/measured-axis-plan.test.ts
+++ b/packages/core/tests/temporal-guide/measured-axis-plan.test.ts
@@ -230,3 +230,52 @@ describe("measured temporal axis GuidePlan", () => {
     expect(minor.every((tick) => !major.has(tick.value))).toBe(true);
   });
 });
+
+describe("month-day axis plan", () => {
+  const REF = 2000;
+  const planBloom = (config = {}, extentPx = 420) =>
+    planTemporalAxis({
+      aesthetic: "y",
+      panelIndex: 0,
+      // The Kyoto bloom window: mid-March to mid-May, one year wide.
+      domain: [Date.UTC(REF, 2, 18), Date.UTC(REF, 4, 10)],
+      kind: "monthDay",
+      orient: "vertical",
+      extentPx,
+      reverse: true,
+      measurer,
+      fontSize: 11,
+      marginCapPx: 160,
+      config,
+    });
+
+  it("labels every tick with a month and a day, never a year", () => {
+    const plan = planBloom();
+    const majors = plan.ticks.filter((tick) => tick.kind === "major");
+    expect(majors.length).toBeGreaterThanOrEqual(2);
+    for (const tick of majors) {
+      // A month name alone ("Apr") is a legitimate pick at a coarse interval;
+      // what must never appear is a year.
+      expect(tick.label).toMatch(/^[A-Z][a-z]{2}( \d{1,2})?$/);
+      expect(tick.label).not.toContain(String(REF));
+    }
+  });
+
+  it("never picks an interval a yearless axis cannot mean", () => {
+    // A year tick would be the same tick twice over, and a week tick implies a
+    // weekday — which belongs to the reference year, not to the data.
+    for (const extentPx of [200, 420, 900]) {
+      const { interval } = planBloom({}, extentPx);
+      expect(interval, String(extentPx)).not.toContain("year");
+      expect(interval, String(extentPx)).not.toContain("week");
+    }
+  });
+
+  it("honours an authored interval and keeps its labels year-free", () => {
+    const plan = planBloom({ dateBreaks: "10 days" });
+    expect(plan.interval).toContain("day");
+    for (const tick of plan.ticks.filter((candidate) => candidate.kind === "major")) {
+      expect(tick.label).not.toContain(String(REF));
+    }
+  });
+});

--- a/packages/spec/src/temporal-interval.ts
+++ b/packages/spec/src/temporal-interval.ts
@@ -5,6 +5,8 @@
 
 import Type, { type Static, type TLiteral } from "typebox";
 
+import type { TemporalScaleKind } from "./temporal-parse-core.js";
+
 export const TEMPORAL_INTERVAL_UNITS = [
   "millisecond",
   "second",
@@ -126,7 +128,19 @@ export const TemporalLabelSpecSchema = Type.String({
     "Strict temporal label format. Supported tokens: %Y %y %m %b %B %d %e %a %A %H %I %M %S %L %p %q %z %Z %%.",
 });
 
-export function temporalLabelConfigurationError(pattern: string): string | null {
+/**
+ * Tokens a month-day axis can fill truthfully: those the month and the day
+ * determine. A year is absent by construction; the clock and zone would print
+ * the same midnight-UTC zeros for every tick; and the weekday belongs to the
+ * reference year, not to the observation — 1 April fell on different weekdays
+ * in 812 and 2001, so printing one would invent a fact.
+ */
+const MONTH_DAY_LABEL_TOKENS = new Set(["m", "b", "B", "d", "e", "q", "%"]);
+
+export function temporalLabelConfigurationError(
+  pattern: string,
+  kind?: TemporalScaleKind,
+): string | null {
   if (pattern.length === 0 || pattern.length > 128) {
     return "dateLabels must contain 1 through 128 characters";
   }
@@ -135,6 +149,9 @@ export function temporalLabelConfigurationError(pattern: string): string | null 
     const token = pattern[++index];
     if (token === undefined || !LABEL_TOKEN_SET.has(token)) {
       return `unsupported dateLabels token %${token ?? ""}`;
+    }
+    if (kind === "monthDay" && !MONTH_DAY_LABEL_TOKENS.has(token)) {
+      return `dateLabels token %${token} has no meaning on a monthDay axis, which knows only a month and a day; use one of %m %b %B %d %e %q`;
     }
   }
   return null;

--- a/packages/spec/src/validate-data-checks-position.ts
+++ b/packages/spec/src/validate-data-checks-position.ts
@@ -101,7 +101,7 @@ export function validateTemporalAxisConfiguration(scales: Record<string, unknown
       }
     }
     if (configurationError === null && config?.dateLabels !== undefined) {
-      configurationError = temporalLabelConfigurationError(config.dateLabels);
+      configurationError = temporalLabelConfigurationError(config.dateLabels, config.temporalKind);
     }
     if (configurationError === null && config?.locale !== undefined) {
       configurationError = temporalLocaleConfigurationError(config.locale);

--- a/packages/spec/tests/temporal-interval-grammar.test.ts
+++ b/packages/spec/tests/temporal-interval-grammar.test.ts
@@ -4,7 +4,7 @@
  */
 import { describe, expect, it } from "bun:test";
 
-import { parseTemporalInterval } from "../src/index.ts";
+import { parseTemporalInterval, temporalLabelConfigurationError } from "../src/index.ts";
 
 describe("temporal interval grammar", () => {
   it("canonicalizes positive integer calendar intervals", () => {
@@ -47,5 +47,44 @@ describe("temporal interval grammar", () => {
     ]) {
       expect(() => parseTemporalInterval(value), value).toThrow();
     }
+  });
+});
+
+describe("month-day label tokens", () => {
+  // The rule: a token is legal on a month-day axis if and only if the month and
+  // the day determine it. Everything else would be reporting the reference
+  // year's properties as though they belonged to the data.
+  it("accepts the tokens month and day actually determine", () => {
+    for (const pattern of ["%b %e", "%B %d", "%m-%d", "Q%q", "%b %e (%%)"]) {
+      expect(temporalLabelConfigurationError(pattern, "monthDay"), pattern).toBeNull();
+    }
+  });
+
+  it("rejects year tokens, because there is no year to show", () => {
+    for (const pattern of ["%Y-%m-%d", "%b %e %Y", "%y"]) {
+      expect(temporalLabelConfigurationError(pattern, "monthDay"), pattern).toContain("monthDay");
+    }
+  });
+
+  it("rejects clock and zone tokens, which would all print the same zero", () => {
+    for (const pattern of ["%H:%M", "%I %p", "%S", "%L", "%z", "%Z"]) {
+      expect(temporalLabelConfigurationError(pattern, "monthDay"), pattern).not.toBeNull();
+    }
+  });
+
+  it("rejects weekday tokens, which describe the reference year and not the data", () => {
+    // 1 April fell on a different weekday in 812 than in 2001. Printing one
+    // would be inventing a fact.
+    for (const pattern of ["%a %e %b", "%A"]) {
+      expect(temporalLabelConfigurationError(pattern, "monthDay"), pattern).not.toBeNull();
+    }
+  });
+
+  it("leaves every other kind alone", () => {
+    expect(temporalLabelConfigurationError("%Y-%m-%d", "date")).toBeNull();
+    expect(temporalLabelConfigurationError("%H:%M:%S", "time")).toBeNull();
+    expect(temporalLabelConfigurationError("%Y-%m-%d %H:%M %Z", "datetime")).toBeNull();
+    // Omitting the kind stays permissive, so existing callers do not change.
+    expect(temporalLabelConfigurationError("%Y-%m-%d")).toBeNull();
   });
 });

--- a/packages/spec/tests/validate-tier2-temporal-position.test.ts
+++ b/packages/spec/tests/validate-tier2-temporal-position.test.ts
@@ -51,6 +51,19 @@ describe("tier 2 — temporal position scale data checks", () => {
       ).toBe(true);
     });
 
+    it("refuses a label format it cannot fill honestly", () => {
+      const withLabels = (dateLabels: string) =>
+        validate(
+          { ...blooms, scales: { y: { type: "time", temporalKind: "monthDay", dateLabels } } },
+          {},
+        );
+      expect(withLabels("%b %e").ok).toBe(true);
+      for (const pattern of ["%Y-%m-%d", "%b %e %Y", "%H:%M", "%a %e %b"]) {
+        const result = withLabels(pattern);
+        expect(result.ok, pattern).toBe(false);
+      }
+    });
+
     it("is a position kind only — colour has no use for it", () => {
       const result = validate(
         {


### PR DESCRIPTION
Stacked on #1106. Last library PR before the Kyoto chart migrates.

#1106 got month-day values into the right place. They were then formatted through the datetime path, so ticks read `2000-04-01 00:00:00 UTC` — the reference year exposed in the one place a reader was guaranteed to look.

Axis ticks, the crosshair, and the tooltip header now read **`Apr 1`**.

## What changed

**`fullLabel` too.** It is not the visible tick, which is exactly why the leak was quiet, and it flows into the guide plan and anything reading it.

**The year interval needed handling, not banning.** `interval("year", 1)` is the fallback whenever an author supplies fewer than two explicit breaks, so it is reachable without anyone asking for it. It now answers with a month and a day rather than `"2000"`.

**The automatic ladder drops week and year.** A year tick on a one-year axis is the same tick twice. A week tick is worse than useless: it implies a weekday, and the weekday belongs to the reference year rather than to the observation. Day, month and quarter remain, and an authored `dateBreaks` is honoured exactly as given.

**`dateLabels` refuses tokens it cannot fill honestly.** The rule is that a token is legal if and only if the month and the day determine it:

| accepted | refused | why |
|---|---|---|
| `%m %b %B %d %e %q` | `%Y %y` | there is no year |
| | `%H %I %M %S %L %p` | every tick is midnight, so all would print the same zero |
| | `%z %Z` | always UTC |
| | `%a %A` | the weekday belongs to the reference year, not the data |

`%a` is refused for the same reason as `%Y`, and it is the one worth arguing about — 1 April fell on a different weekday in 812 than in 2001, so printing one would invent a fact rather than merely repeat a useless one.

The kind threads through all three callers, so the refusal reaches tier-2 `validate()` and the pipeline alike. Passing no kind stays permissive, so nothing else changes.

## Two things the tests corrected

**Forcing `multiYear` false is a no-op.** It was in my plan as the fix. Every month-day tick already sits in one year, so `multiYear` is false without anything being done — the real leaks were `fullLabel` and the `year` interval branch, neither of which `multiYear` touches.

**`"Apr"` alone is a legitimate label, not a bug.** At a coarse interval the planner picks months, and a bare month name is year-free and honest. My first assertion demanded a day on every tick and failed against correct output. The assertion now says what actually matters: no year appears anywhere.

## Tests

Label formatting: month-day naming, the `fullLabel` pin (`not.toContain("2000")`), no bare year across *every* interval unit, and month/quarter still standing alone.

Axis planning: labels match `Mmm` or `Mmm D` and never a year; the ladder never selects week or year at 200/420/900px; an authored `10 days` is honoured and stays year-free. The fixture is the real Kyoto bloom window, mid-March to mid-May.

Through the pipeline: `model.axisFormatters.y(Date.UTC(2000, 3, 1))` is `"Apr 1"` — that formatter is what the crosshair and tooltip header call — plus no year on any tick's `label` **or** `fullLabel`.

Token grammar: seven cases over accepted, year, clock/zone, and weekday tokens, plus a check that the other three kinds are untouched.

Full suite green: 3640 spec+core+scripts, 163 svelte SSR, plus `check`, `check:svelte`, lint, format.

## Next

The Kyoto lesson migrates to `y: "bloomDate"` with `<ScaleYMonthDay>`, and `bloomRefDate` — the fabricated column that started this — comes out of the published dataset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1108" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->