### PR TITLE
docs(reference): clean geom prose, minimal snippets, one breadcrumb trail

### DIFF
--- a/.changeset/reference-prose-cleanup.md
+++ b/.changeset/reference-prose-cleanup.md
@@ -1,0 +1,12 @@
+---
+"@ggsvelte/spec": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+docs(reference): clean geom prose and minimal code samples
+
+Schema layer descriptions no longer cite ggplot2 or GitHub issue numbers on
+user-facing geom and param docs. Reference pages use minimal required-only
+snippets, a single breadcrumb trail (Reference → Geoms/Stats/Positions → name),
+and short section labels.

--- a/apps/docs/src/lib/components/Breadcrumbs.svelte
+++ b/apps/docs/src/lib/components/Breadcrumbs.svelte
@@ -1,17 +1,25 @@
 <script lang="ts">
   import { base } from "$app/paths";
 
-  const { title, reference = false }: { title: string; reference?: boolean } =
-    $props();
+  type Crumb = {
+    label: string;
+    /** Omit href (or leave undefined) for the current page. */
+    href?: string;
+  };
+
+  const { crumbs }: { crumbs: readonly Crumb[] } = $props();
 </script>
 
 <nav class="breadcrumbs" aria-label="Breadcrumb">
   <ol>
-    <li>
-      <a href={`${base}${reference ? "/reference" : "/docs"}`}>
-        {reference ? "Reference" : "Docs"}
-      </a>
-    </li>
-    <li aria-current="page">{title}</li>
+    {#each crumbs as crumb, index (crumb.label + String(index))}
+      <li aria-current={index === crumbs.length - 1 ? "page" : undefined}>
+        {#if crumb.href !== undefined && index < crumbs.length - 1}
+          <a href={`${base}${crumb.href}`}>{crumb.label}</a>
+        {:else}
+          {crumb.label}
+        {/if}
+      </li>
+    {/each}
   </ol>
 </nav>

--- a/apps/docs/src/lib/components/DocsShell.svelte
+++ b/apps/docs/src/lib/components/DocsShell.svelte
@@ -52,7 +52,7 @@
       return [{ label: "Reference" }];
     }
 
-    const segments = currentPath.replace(/^\/+|\/+$/g, "").split("/");
+    const segments = currentPath.replaceAll(/^\/+|\/+$/g, "").split("/");
     // ["reference", "geoms"] or ["reference", "geoms", "col"]
     if (segments[0] !== "reference" || segments.length < 2) {
       return [root, { label: title }];

--- a/apps/docs/src/lib/components/DocsShell.svelte
+++ b/apps/docs/src/lib/components/DocsShell.svelte
@@ -9,6 +9,8 @@
   import OnThisPage from "./OnThisPage.svelte";
   import PrevNext from "./PrevNext.svelte";
 
+  type Crumb = { label: string; href?: string };
+
   const {
     route,
     path,
@@ -29,6 +31,64 @@
     route.navigation?.label ?? route.title.replace(" — ggsvelte", ""),
   );
   const reference = $derived(primaryNavigationOwner(route) === "reference");
+  const crumbs = $derived(buildCrumbs(path, displayTitle, reference));
+
+  function buildCrumbs(
+    currentPath: string,
+    title: string,
+    isReference: boolean,
+  ): readonly Crumb[] {
+    const root: Crumb = {
+      label: isReference ? "Reference" : "Docs",
+      href: isReference ? "/reference" : "/docs",
+    };
+
+    if (!isReference) {
+      return [root, { label: title }];
+    }
+
+    // /reference → just "Reference"
+    if (currentPath === "/reference" || currentPath === "/reference/") {
+      return [{ label: "Reference" }];
+    }
+
+    const segments = currentPath.replace(/^\/+|\/+$/g, "").split("/");
+    // ["reference", "geoms"] or ["reference", "geoms", "col"]
+    if (segments[0] !== "reference" || segments.length < 2) {
+      return [root, { label: title }];
+    }
+
+    const section = segments[1] ?? "";
+    const sectionLabel = referenceSectionLabel(section);
+    if (sectionLabel === undefined) {
+      return [root, { label: title }];
+    }
+
+    const sectionHref = `/reference/${section}`;
+    if (segments.length === 2) {
+      return [root, { label: sectionLabel }];
+    }
+
+    // Detail page: Reference / Geoms / GeomCol (title already component name)
+    return [root, { label: sectionLabel, href: sectionHref }, { label: title }];
+  }
+
+  function referenceSectionLabel(section: string): string | undefined {
+    switch (section) {
+      case "geoms":
+        return "Geoms";
+      case "stats":
+        return "Stats";
+      case "positions":
+        return "Positions";
+      case "interactions":
+        return "Interactions";
+      case "cli":
+        return "CLI";
+      default:
+        return undefined;
+    }
+  }
 
   function openChapters(): void {
     chapterDialog?.showModal();
@@ -68,7 +128,7 @@
   </aside>
 
   <div class="docs-article">
-    <Breadcrumbs title={displayTitle} {reference} />
+    <Breadcrumbs {crumbs} />
     {@render children()}
     <PrevNext {previous} {next} />
   </div>

--- a/apps/docs/src/lib/generated/routes.ts
+++ b/apps/docs/src/lib/generated/routes.ts
@@ -86,7 +86,7 @@ export const DOCS_ROUTES = [
   },
   {
     path: "/reference/geoms",
-    title: "Geom reference — ggsvelte",
+    title: "Geoms — ggsvelte",
     description:
       "Schema-derived API reference for every Geom* component: defaults, allowed stats and positions, and params.",
     canonicalPath: "/reference/geoms",
@@ -96,7 +96,7 @@ export const DOCS_ROUTES = [
     shell: "docs",
     navigation: {
       section: "Reference",
-      label: "Geom reference",
+      label: "Geoms",
       order: 51,
     },
     headings: [
@@ -114,7 +114,7 @@ export const DOCS_ROUTES = [
   },
   {
     path: "/reference/stats",
-    title: "Stat reference — ggsvelte",
+    title: "Stats — ggsvelte",
     description:
       "Schema-derived API reference for every statistical transform: after_stat columns and compatible geoms.",
     canonicalPath: "/reference/stats",
@@ -124,7 +124,7 @@ export const DOCS_ROUTES = [
     shell: "docs",
     navigation: {
       section: "Reference",
-      label: "Stat reference",
+      label: "Stats",
       order: 52,
     },
     headings: [
@@ -142,7 +142,7 @@ export const DOCS_ROUTES = [
   },
   {
     path: "/reference/positions",
-    title: "Position reference — ggsvelte",
+    title: "Positions — ggsvelte",
     description:
       "Schema-derived API reference for every position adjustment: positionParams and compatible geoms.",
     canonicalPath: "/reference/positions",
@@ -152,7 +152,7 @@ export const DOCS_ROUTES = [
     shell: "docs",
     navigation: {
       section: "Reference",
-      label: "Position reference",
+      label: "Positions",
       order: 53,
     },
     headings: [
@@ -256,7 +256,7 @@ export const DOCS_ROUTES = [
     path: "/reference/geoms/point",
     title: "GeomPoint — ggsvelte",
     description:
-      "GeomPoint: Point geometry: one mark per data row. Use for scatter plots, dot plots, bubbles, correlation views. With summary_bin (#817) or manual (#814).",
+      "GeomPoint: Point geometry: one mark per data row. Use for scatter plots, dot plots, bubbles, and correlation views.",
     canonicalPath: "/reference/geoms/point",
     kind: "page",
     index: true,
@@ -304,7 +304,7 @@ export const DOCS_ROUTES = [
     path: "/reference/geoms/line",
     title: "GeomLine — ggsvelte",
     description:
-      "GeomLine: Line geometry: connects points in x order, one line per group (groups derive from discrete aesthetics such as color, or from aes.group). Use for time series, trends, line charts, and ECDFs (stat ecdf + curve step-hv; #811). With stat bin (freqpoly alias), y is computed from counts/density. With stat connect, successive points expand into named connection vertices (#816).",
+      "GeomLine: Line geometry: connects points in x order, one line per group (groups derive from discrete aesthetics such as color, or from aes.group). Use for time series, trends, and line charts. With stat ecdf, pair with step curves; with stat bin (freqpoly alias), y is computed from counts/density; with stat connect, successive points expand into connection vertices.",
     canonicalPath: "/reference/geoms/line",
     kind: "page",
     index: true,
@@ -352,7 +352,7 @@ export const DOCS_ROUTES = [
     path: "/reference/geoms/path",
     title: "GeomPath — ggsvelte",
     description:
-      "GeomPath: Path geometry: connects points in data (row) order within each group — unlike line, which sorts by x. Use for trajectories, loops, connected scatterplots (ggplot2 geom_path), and ellipse rings (stat ellipse). With stat connect, successive points expand into named connection vertices (#816).",
+      "GeomPath: Path geometry: connects points in data (row) order within each group — unlike line, which sorts by x. Use for trajectories, loops, connected scatterplots, and ellipse rings (stat ellipse). With stat connect, successive points expand into connection vertices.",
     canonicalPath: "/reference/geoms/path",
     kind: "page",
     index: true,
@@ -400,7 +400,7 @@ export const DOCS_ROUTES = [
     path: "/reference/geoms/col",
     title: "GeomCol — ggsvelte",
     description:
-      "GeomCol: Column geometry: one rectangle per data row, from the y baseline (zero) to the row's y value. Use when the data already contains the bar heights (ggplot2's geom_col).",
+      "GeomCol: Column geometry: one rectangle per data row, from the y baseline (zero) to the row's y value. Use when the data already contains the bar heights — prefer over GeomBar, which counts or bins.",
     canonicalPath: "/reference/geoms/col",
     kind: "page",
     index: true,
@@ -448,7 +448,7 @@ export const DOCS_ROUTES = [
     path: "/reference/geoms/bar",
     title: "GeomBar — ggsvelte",
     description:
-      "GeomBar: Bar geometry with counting or binning: one rectangle per distinct x value (stat count, discrete x) or per bin (stat bin, continuous x). Do NOT map aes.y — the stat computes it (ggplot2's geom_bar / geom_histogram).",
+      "GeomBar: Bar geometry with counting or binning: one rectangle per distinct x value (stat count, discrete x) or per bin (stat bin, continuous x). Do not map aes.y — the stat computes it. Prefer GeomCol when bar heights are already in the data.",
     canonicalPath: "/reference/geoms/bar",
     kind: "page",
     index: true,
@@ -496,7 +496,7 @@ export const DOCS_ROUTES = [
     path: "/reference/geoms/histogram",
     title: "GeomHistogram — ggsvelte",
     description:
-      "GeomHistogram: Histogram geometry: a continuous x variable divided into bins, one bar per bin whose height is the count of rows (or the sum of aes.weight). Do NOT map aes.y — the bin stat computes it. Canonicalized by normalize() to a bar layer with stat bin.",
+      "GeomHistogram: Histogram geometry: a continuous x variable divided into bins, one bar per bin whose height is the count of rows (or the sum of aes.weight). Do not map aes.y — the bin stat computes it. Canonicalized by normalize() to a bar layer with stat bin.",
     canonicalPath: "/reference/geoms/histogram",
     kind: "page",
     index: true,
@@ -549,7 +549,7 @@ export const DOCS_ROUTES = [
     path: "/reference/geoms/freqpoly",
     title: "GeomFreqpoly — ggsvelte",
     description:
-      "GeomFreqpoly: Frequency polygon (ggplot2 geom_freqpoly): continuous x binned like a histogram, drawn as a line through bin centers. Do NOT map aes.y — the bin stat computes it. Canonicalized by normalize() to a line layer with stat bin.",
+      "GeomFreqpoly: Frequency polygon: continuous x binned like a histogram, drawn as a line through bin centers. Do not map aes.y — the bin stat computes it. Canonicalized by normalize() to a line layer with stat bin.",
     canonicalPath: "/reference/geoms/freqpoly",
     kind: "page",
     index: true,
@@ -650,7 +650,7 @@ export const DOCS_ROUTES = [
     path: "/reference/geoms/rule",
     title: "GeomRule — ggsvelte",
     description:
-      "GeomRule: Rule geometry: reference lines spanning the panel. TWO HONEST FORMS: (1) annotation — set params.xintercept and/or params.yintercept to fixed data values and map neither aes.x nor aes.y; (2) data-driven — map exactly ONE of aes.x (vertical rules) or aes.y (horizontal rules) to a field. Never mix the forms in one layer.",
+      "GeomRule: Rule geometry: reference lines spanning the panel. Two forms: (1) annotation — set params.xintercept and/or params.yintercept to fixed data values and map neither aes.x nor aes.y; (2) data-driven — map exactly one of aes.x (vertical rules) or aes.y (horizontal rules) to a field. Never mix the forms in one layer.",
     canonicalPath: "/reference/geoms/rule",
     kind: "page",
     index: true,
@@ -698,7 +698,7 @@ export const DOCS_ROUTES = [
     path: "/reference/geoms/hline",
     title: "GeomHline — ggsvelte",
     description:
-      "GeomHline: Horizontal reference-line alias (ggplot2's geom_hline). Canonicalized by normalize() to a rule layer. Annotation form: set params.yintercept. Data-driven form: map aes.y (inherited plot x is dropped so the one-axis rule contract holds).",
+      "GeomHline: Horizontal reference-line alias. Canonicalized by normalize() to a rule layer. Annotation form: set params.yintercept. Data-driven form: map aes.y (inherited plot x is dropped so the one-axis rule contract holds).",
     canonicalPath: "/reference/geoms/hline",
     kind: "page",
     index: true,
@@ -751,7 +751,7 @@ export const DOCS_ROUTES = [
     path: "/reference/geoms/vline",
     title: "GeomVline — ggsvelte",
     description:
-      "GeomVline: Vertical reference-line alias (ggplot2's geom_vline). Canonicalized by normalize() to a rule layer. Annotation form: set params.xintercept. Data-driven form: map aes.x (inherited plot y is dropped so the one-axis rule contract holds).",
+      "GeomVline: Vertical reference-line alias. Canonicalized by normalize() to a rule layer. Annotation form: set params.xintercept. Data-driven form: map aes.x (inherited plot y is dropped so the one-axis rule contract holds).",
     canonicalPath: "/reference/geoms/vline",
     kind: "page",
     index: true,
@@ -852,7 +852,7 @@ export const DOCS_ROUTES = [
     path: "/reference/geoms/label",
     title: "GeomLabel — ggsvelte",
     description:
-      "GeomLabel: Label geometry: text with a rounded rectangular background box (ggplot2 geom_label). Requires x, y, and label channels. No collision detection.",
+      "GeomLabel: Label geometry: text with a rounded rectangular background box. Requires x, y, and label channels. No collision detection.",
     canonicalPath: "/reference/geoms/label",
     kind: "page",
     index: true,
@@ -900,7 +900,7 @@ export const DOCS_ROUTES = [
     path: "/reference/geoms/smooth",
     title: "GeomSmooth — ggsvelte",
     description:
-      "GeomSmooth: Smooth geometry: a fitted trend line (with an optional confidence ribbon) over an x/y scatter, one fit per group. Use to reveal trends (ggplot2's geom_smooth).",
+      "GeomSmooth: Smooth geometry: a fitted trend line (with an optional confidence ribbon) over an x/y scatter, one fit per group. Use to reveal trends.",
     canonicalPath: "/reference/geoms/smooth",
     kind: "page",
     index: true,
@@ -948,7 +948,7 @@ export const DOCS_ROUTES = [
     path: "/reference/geoms/quantile",
     title: "GeomQuantile — ggsvelte",
     description:
-      "GeomQuantile: Quantile geometry: linear quantile regression lines (y ~ x) at one or more conditional quantiles of y, one line per quantile per group (ggplot2 geom_quantile / #805).",
+      "GeomQuantile: Quantile geometry: linear quantile regression lines (y ~ x) at one or more conditional quantiles of y, one line per quantile per group.",
     canonicalPath: "/reference/geoms/quantile",
     kind: "page",
     index: true,
@@ -1140,7 +1140,7 @@ export const DOCS_ROUTES = [
     path: "/reference/geoms/linerange",
     title: "GeomLinerange — ggsvelte",
     description:
-      "GeomLinerange: Linerange geometry: a vertical stem from ymin to ymax without end caps (ggplot2 geom_linerange).",
+      "GeomLinerange: Linerange geometry: a vertical stem from ymin to ymax without end caps.",
     canonicalPath: "/reference/geoms/linerange",
     kind: "page",
     index: true,
@@ -1183,7 +1183,7 @@ export const DOCS_ROUTES = [
     path: "/reference/geoms/pointrange",
     title: "GeomPointrange — ggsvelte",
     description:
-      "GeomPointrange: Pointrange geometry: vertical stem from ymin to ymax plus a point at (x, y) (ggplot2 geom_pointrange).",
+      "GeomPointrange: Pointrange geometry: vertical stem from ymin to ymax plus a point at (x, y).",
     canonicalPath: "/reference/geoms/pointrange",
     kind: "page",
     index: true,
@@ -1226,7 +1226,7 @@ export const DOCS_ROUTES = [
     path: "/reference/geoms/crossbar",
     title: "GeomCrossbar — ggsvelte",
     description:
-      "GeomCrossbar: Crossbar geometry: a vertical interval box from ymin to ymax with a mid horizontal line at y (ggplot2 geom_crossbar).",
+      "GeomCrossbar: Crossbar geometry: a vertical interval box from ymin to ymax with a mid horizontal line at y.",
     canonicalPath: "/reference/geoms/crossbar",
     kind: "page",
     index: true,
@@ -1413,7 +1413,7 @@ export const DOCS_ROUTES = [
     path: "/reference/geoms/ribbon",
     title: "GeomRibbon — ggsvelte",
     description:
-      "GeomRibbon: Ribbon geometry: a filled interval between two varying boundaries along a running coordinate (ggplot2's geom_ribbon). Map x+ymin+ymax (x orientation) or y+xmin+xmax (y orientation). Not a zero-baseline area.",
+      "GeomRibbon: Ribbon geometry: a filled interval between two varying boundaries along a running coordinate. Map x+ymin+ymax (x orientation) or y+xmin+xmax (y orientation). Not a zero-baseline area.",
     canonicalPath: "/reference/geoms/ribbon",
     kind: "page",
     index: true,
@@ -1509,7 +1509,7 @@ export const DOCS_ROUTES = [
     path: "/reference/geoms/count",
     title: "GeomCount — ggsvelte",
     description:
-      "GeomCount: Count geometry (ggplot2 geom_count): point marks at unique (x, y) with size scaled by after_stat n (stat sum). Use for overplotting density on discrete or rounded coordinates.",
+      "GeomCount: Count geometry: point marks at unique (x, y) with size scaled by after_stat n (stat sum). Use for overplotting density on discrete or rounded coordinates.",
     canonicalPath: "/reference/geoms/count",
     kind: "page",
     index: true,
@@ -1557,7 +1557,7 @@ export const DOCS_ROUTES = [
     path: "/reference/geoms/violin",
     title: "GeomViolin — ggsvelte",
     description:
-      "GeomViolin: Violin geometry: mirrored kernel density of continuous y at each discrete x (ggplot2 geom_violin / stat_ydensity). One polygon per x×group. Default position dodge.",
+      "GeomViolin: Violin geometry: mirrored kernel density of continuous y at each discrete x (stat ydensity). One polygon per x×group. Default position dodge.",
     canonicalPath: "/reference/geoms/violin",
     kind: "page",
     index: true,
@@ -1605,7 +1605,7 @@ export const DOCS_ROUTES = [
     path: "/reference/geoms/function",
     title: "GeomFunction — ggsvelte",
     description:
-      "GeomFunction: Function geometry: evaluate a named portable function y = f(x) on a grid and draw a path (ggplot2 geom_function / stat_function). Requires params.fun; domain from params.xlim, mapped x, or peer layers.",
+      "GeomFunction: Function geometry: evaluate a named portable function y = f(x) on a grid and draw a path. Requires params.fun; domain from params.xlim, mapped x, or peer layers.",
     canonicalPath: "/reference/geoms/function",
     kind: "page",
     index: true,
@@ -1653,7 +1653,7 @@ export const DOCS_ROUTES = [
     path: "/reference/geoms/polygon",
     title: "GeomPolygon — ggsvelte",
     description:
-      "GeomPolygon: Polygon geometry: closed filled paths from (x, y) vertices in data/row order within each group (ggplot2's geom_polygon). Groups form separate polygons. No x-sort (unlike line/area). Holes/subgroup omitted in v1.",
+      "GeomPolygon: Polygon geometry: closed filled paths from (x, y) vertices in data/row order within each group. Groups form separate polygons. No x-sort (unlike line/area). Holes/subgroup omitted in v1.",
     canonicalPath: "/reference/geoms/polygon",
     kind: "page",
     index: true,
@@ -1701,7 +1701,7 @@ export const DOCS_ROUTES = [
     path: "/reference/geoms/hex",
     title: "GeomHex — ggsvelte",
     description:
-      "GeomHex: Hexagonal bin heatmap (ggplot2 geom_hex / stat_bin_hex): partitions continuous x×y into a hexagonal lattice and maps fill to bin count by default.",
+      "GeomHex: Hexagonal bin heatmap: partitions continuous x×y into a hexagonal lattice and maps fill to bin count by default.",
     canonicalPath: "/reference/geoms/hex",
     kind: "page",
     index: true,
@@ -1749,7 +1749,7 @@ export const DOCS_ROUTES = [
     path: "/reference/geoms/bin_2d",
     title: "GeomBin2d — ggsvelte",
     description:
-      "GeomBin2d: 2D rectangular bin heatmap (ggplot2 geom_bin2d / stat_bin_2d): partitions continuous x×y into a grid and maps fill to bin count by default. Empty bins are dropped unless params.drop is false.",
+      "GeomBin2d: 2D rectangular bin heatmap: partitions continuous x×y into a grid and maps fill to bin count by default. Empty bins are dropped unless params.drop is false.",
     canonicalPath: "/reference/geoms/bin_2d",
     kind: "page",
     index: true,
@@ -1797,7 +1797,7 @@ export const DOCS_ROUTES = [
     path: "/reference/geoms/abline",
     title: "GeomAbline — ggsvelte",
     description:
-      "GeomAbline: Abline geometry: one infinite reference line y = intercept + slope · x, clipped to the panel (ggplot2 geom_abline). Annotation form: fixed slope/intercept in params; does not inherit plot aes.",
+      "GeomAbline: Abline geometry: one infinite reference line y = intercept + slope · x, clipped to the panel. Annotation form: fixed slope/intercept in params; does not inherit plot aes.",
     canonicalPath: "/reference/geoms/abline",
     kind: "page",
     index: true,
@@ -1845,7 +1845,7 @@ export const DOCS_ROUTES = [
     path: "/reference/geoms/curve",
     title: "GeomCurve — ggsvelte",
     description:
-      "GeomCurve: Curve geometry (ggplot2 geom_curve): one curved connector per row from (x, y) to (xend, yend). Tessellated as a quadratic Bezier (curvature/angle/ncp). Requires field-mapped x, y, xend, and yend.",
+      "GeomCurve: Curve geometry: one curved connector per row from (x, y) to (xend, yend). Tessellated as a quadratic Bezier (curvature/angle/ncp). Requires field-mapped x, y, xend, and yend.",
     canonicalPath: "/reference/geoms/curve",
     kind: "page",
     index: true,
@@ -1893,7 +1893,7 @@ export const DOCS_ROUTES = [
     path: "/reference/geoms/contour",
     title: "GeomContour — ggsvelte",
     description:
-      "GeomContour: Contour geometry: isolines of a continuous z surface over a regular x×y grid (ggplot2 geom_contour; #801). v1 draws open path polylines only (not filled bands).",
+      "GeomContour: Contour geometry: isolines of a continuous z surface over a regular x×y grid. v1 draws open path polylines only (not filled bands).",
     canonicalPath: "/reference/geoms/contour",
     kind: "page",
     index: true,
@@ -1941,7 +1941,7 @@ export const DOCS_ROUTES = [
     path: "/reference/geoms/density_2d",
     title: "GeomDensity2d — ggsvelte",
     description:
-      "GeomDensity2d: 2D density geometry: bivariate KDE isolines over continuous x and y (ggplot2 geom_density_2d; #802). Open path contours.",
+      "GeomDensity2d: 2D density geometry: bivariate KDE isolines over continuous x and y. Open path contours.",
     canonicalPath: "/reference/geoms/density_2d",
     kind: "page",
     index: true,
@@ -1989,7 +1989,7 @@ export const DOCS_ROUTES = [
     path: "/reference/geoms/density_2d_filled",
     title: "GeomDensity2dFilled — ggsvelte",
     description:
-      "GeomDensity2dFilled: 2D density filled bands: bivariate KDE closed isoline rings filled by density level (ggplot2 geom_density_2d_filled; #802 phase 2). Open rings dropped. Defaults fill to after_stat(level).",
+      "GeomDensity2dFilled: 2D density filled bands: bivariate KDE closed isoline rings filled by density level. Open rings dropped. Defaults fill to after_stat(level).",
     canonicalPath: "/reference/geoms/density_2d_filled",
     kind: "page",
     index: true,
@@ -2037,7 +2037,7 @@ export const DOCS_ROUTES = [
     path: "/reference/geoms/dotplot",
     title: "GeomDotplot — ggsvelte",
     description:
-      "GeomDotplot: Dotplot geometry: stacked dots along a continuous x axis (ggplot2 geom_dotplot, histodot subset). Do NOT map aes.y — the bindot stat computes stack positions.",
+      "GeomDotplot: Dotplot geometry: stacked dots along a continuous x axis (histodot subset). Do not map aes.y — the bindot stat computes stack positions.",
     canonicalPath: "/reference/geoms/dotplot",
     kind: "page",
     index: true,
@@ -2085,7 +2085,7 @@ export const DOCS_ROUTES = [
     path: "/reference/geoms/map",
     title: "GeomMap — ggsvelte",
     description:
-      "GeomMap: Map geometry (ggplot2 geom_map): join fortified region borders to value rows via aes.map_id and params.map. Renders closed filled paths per region (#808).",
+      "GeomMap: Map geometry: join fortified region borders to value rows via aes.map_id and params.map. Renders closed filled paths per region.",
     canonicalPath: "/reference/geoms/map",
     kind: "page",
     index: true,
@@ -2133,7 +2133,7 @@ export const DOCS_ROUTES = [
     path: "/reference/geoms/sf",
     title: "GeomSf — ggsvelte",
     description:
-      "GeomSf: Simple-features geometry (ggplot2 geom_sf; #809): already-projected GeoJSON Geometry JSON strings in a data column. Point/line/polygon families (incl. GeometryCollection of one family) with even-odd holes; use coord_sf for fixed-aspect (CRS reproject deferred).",
+      "GeomSf: Simple-features geometry: already-projected GeoJSON Geometry JSON strings in a data column. Point/line/polygon families (incl. GeometryCollection of one family) with even-odd holes; use coord_sf for fixed-aspect (CRS reproject deferred).",
     canonicalPath: "/reference/geoms/sf",
     kind: "page",
     index: true,
@@ -2181,7 +2181,7 @@ export const DOCS_ROUTES = [
     path: "/reference/geoms/sf_text",
     title: "GeomSfText — ggsvelte",
     description:
-      "GeomSfText: Simple-features text labels (ggplot2 geom_sf_text; #809): places aes.label at representative geometry points (Multi* → one label per part; stat_sf_coordinates).",
+      "GeomSfText: Simple-features text labels: places aes.label at representative geometry points (Multi* → one label per part; stat_sf_coordinates).",
     canonicalPath: "/reference/geoms/sf_text",
     kind: "page",
     index: true,
@@ -2229,7 +2229,7 @@ export const DOCS_ROUTES = [
     path: "/reference/geoms/sf_label",
     title: "GeomSfLabel — ggsvelte",
     description:
-      "GeomSfLabel: Simple-features labels with background boxes (ggplot2 geom_sf_label; #809): places aes.label at representative geometry points with a measured rounded rect (Multi* → one label per part). color=ink+box stroke; fill=box background.",
+      "GeomSfLabel: Simple-features labels with background boxes: places aes.label at representative geometry points with a measured rounded rect (Multi* → one label per part). color=ink+box stroke; fill=box background.",
     canonicalPath: "/reference/geoms/sf_label",
     kind: "page",
     index: true,
@@ -2277,7 +2277,7 @@ export const DOCS_ROUTES = [
     path: "/reference/geoms/blank",
     title: "GeomBlank — ggsvelte",
     description:
-      "GeomBlank: Blank geometry (ggplot2's geom_blank): contributes mapped aesthetics to scale training and layout without drawing marks or hit targets. No channels are required; whatever is mapped trains its scale.",
+      "GeomBlank: Blank geometry: contributes mapped aesthetics to scale training and layout without drawing marks or hit targets. No channels are required; whatever is mapped trains its scale.",
     canonicalPath: "/reference/geoms/blank",
     kind: "page",
     index: true,
@@ -2325,7 +2325,7 @@ export const DOCS_ROUTES = [
     path: "/reference/geoms/jitter",
     title: "GeomJitter — ggsvelte",
     description:
-      "GeomJitter: Jittered point alias (ggplot2's geom_jitter). Canonicalized by normalize() to a point layer with position jitter. Configure jitter amount via positionParams.width/height/seed.",
+      "GeomJitter: Jittered point alias. Canonicalized by normalize() to a point layer with position jitter. Configure jitter amount via positionParams.width/height/seed.",
     canonicalPath: "/reference/geoms/jitter",
     kind: "page",
     index: true,
@@ -2378,7 +2378,7 @@ export const DOCS_ROUTES = [
     path: "/reference/geoms/spoke",
     title: "GeomSpoke — ggsvelte",
     description:
-      "GeomSpoke: Spoke geometry (ggplot2 geom_spoke): one finite segment per row from (x, y) in direction angle (radians) with length radius. Endpoints are derived as xend = x + radius·cos(angle), yend = y + radius·sin(angle) in data space, then transformed like x/y. Requires continuous x and y.",
+      "GeomSpoke: Spoke geometry: one finite segment per row from (x, y) in direction angle (radians) with length radius. Endpoints are derived as xend = x + radius·cos(angle), yend = y + radius·sin(angle) in data space, then transformed like x/y. Requires continuous x and y.",
     canonicalPath: "/reference/geoms/spoke",
     kind: "page",
     index: true,
@@ -2426,7 +2426,7 @@ export const DOCS_ROUTES = [
     path: "/reference/geoms/rug",
     title: "GeomRug — ggsvelte",
     description:
-      "GeomRug: Rug geometry: short ticks along panel edges for each observation (ggplot2 geom_rug). Map aes.x for bottom/top sides and/or aes.y for left/right sides.",
+      "GeomRug: Rug geometry: short ticks along panel edges for each observation. Map aes.x for bottom/top sides and/or aes.y for left/right sides.",
     canonicalPath: "/reference/geoms/rug",
     kind: "page",
     index: true,
@@ -2474,7 +2474,7 @@ export const DOCS_ROUTES = [
     path: "/reference/geoms/step",
     title: "GeomStep — ggsvelte",
     description:
-      "GeomStep: Step-line geometry: connect points with hv/vh/mid stairs (ggplot2 geom_step). Same channels as line; ordered by x within groups.",
+      "GeomStep: Step-line geometry: connect points with hv/vh/mid stairs. Same channels as line; ordered by x within groups.",
     canonicalPath: "/reference/geoms/step",
     kind: "page",
     index: true,
@@ -2522,7 +2522,7 @@ export const DOCS_ROUTES = [
     path: "/reference/geoms/qq",
     title: "GeomQq — ggsvelte",
     description:
-      "GeomQq: Q–Q scatter (ggplot2 geom_qq / stat_qq): sample quantiles vs theoretical normal quantiles. Requires aes.sample.",
+      "GeomQq: Q–Q scatter: sample quantiles vs theoretical normal quantiles. Requires aes.sample.",
     canonicalPath: "/reference/geoms/qq",
     kind: "page",
     index: true,
@@ -2570,7 +2570,7 @@ export const DOCS_ROUTES = [
     path: "/reference/geoms/qq_line",
     title: "GeomQqLine — ggsvelte",
     description:
-      "GeomQqLine: Q–Q reference line (ggplot2 geom_qq_line / stat_qq_line): line through sample/theoretical quartile match, spanning the theoretical range of the Q–Q cloud. Requires aes.sample.",
+      "GeomQqLine: Q–Q reference line: line through sample/theoretical quartile match, spanning the theoretical range of the Q–Q cloud. Requires aes.sample.",
     canonicalPath: "/reference/geoms/qq_line",
     kind: "page",
     index: true,
@@ -7401,15 +7401,15 @@ export const GUIDE_NAVIGATION = [
       },
       {
         path: "/reference/geoms",
-        label: "Geom reference",
+        label: "Geoms",
       },
       {
         path: "/reference/stats",
-        label: "Stat reference",
+        label: "Stats",
       },
       {
         path: "/reference/positions",
-        label: "Position reference",
+        label: "Positions",
       },
       {
         path: "/reference/interactions",

--- a/apps/docs/src/lib/generated/search-index.ts
+++ b/apps/docs/src/lib/generated/search-index.ts
@@ -69,21 +69,21 @@ export const DOCS_SEARCH_INDEX = [
   {
     id: "page:reference-geoms",
     kind: "page",
-    title: "Geom reference",
+    title: "Geoms",
     summary:
       "Schema-derived API reference for every Geom* component: defaults, allowed stats and positions, and params.",
     href: "/reference/geoms",
     keywords: ["Reference"],
-    exact: ["Geom reference"],
+    exact: ["Geoms"],
   },
   {
     id: "heading:reference-geoms:all-geoms",
     kind: "heading",
     title: "All geoms",
     summary:
-      "All geoms in Geom reference. Schema-derived API reference for every Geom* component: defaults, allowed stats and positions, and params.",
+      "All geoms in Geoms. Schema-derived API reference for every Geom* component: defaults, allowed stats and positions, and params.",
     href: "/reference/geoms#all-geoms",
-    keywords: ["Geom reference", "Reference"],
+    keywords: ["Geoms", "Reference"],
     exact: ["All geoms"],
   },
   {
@@ -91,29 +91,29 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Shared layer props",
     summary:
-      "Shared layer props in Geom reference. Schema-derived API reference for every Geom* component: defaults, allowed stats and positions, and params.",
+      "Shared layer props in Geoms. Schema-derived API reference for every Geom* component: defaults, allowed stats and positions, and params.",
     href: "/reference/geoms#shared-layer-props",
-    keywords: ["Geom reference", "Reference"],
+    keywords: ["Geoms", "Reference"],
     exact: ["Shared layer props"],
   },
   {
     id: "page:reference-stats",
     kind: "page",
-    title: "Stat reference",
+    title: "Stats",
     summary:
       "Schema-derived API reference for every statistical transform: after_stat columns and compatible geoms.",
     href: "/reference/stats",
     keywords: ["Reference"],
-    exact: ["Stat reference"],
+    exact: ["Stats"],
   },
   {
     id: "heading:reference-stats:all-stats",
     kind: "heading",
     title: "All stats",
     summary:
-      "All stats in Stat reference. Schema-derived API reference for every statistical transform: after_stat columns and compatible geoms.",
+      "All stats in Stats. Schema-derived API reference for every statistical transform: after_stat columns and compatible geoms.",
     href: "/reference/stats#all-stats",
-    keywords: ["Stat reference", "Reference"],
+    keywords: ["Stats", "Reference"],
     exact: ["All stats"],
   },
   {
@@ -121,29 +121,29 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "How to set a stat",
     summary:
-      "How to set a stat in Stat reference. Schema-derived API reference for every statistical transform: after_stat columns and compatible geoms.",
+      "How to set a stat in Stats. Schema-derived API reference for every statistical transform: after_stat columns and compatible geoms.",
     href: "/reference/stats#how-to-set",
-    keywords: ["Stat reference", "Reference"],
+    keywords: ["Stats", "Reference"],
     exact: ["How to set a stat"],
   },
   {
     id: "page:reference-positions",
     kind: "page",
-    title: "Position reference",
+    title: "Positions",
     summary:
       "Schema-derived API reference for every position adjustment: positionParams and compatible geoms.",
     href: "/reference/positions",
     keywords: ["Reference"],
-    exact: ["Position reference"],
+    exact: ["Positions"],
   },
   {
     id: "heading:reference-positions:all-positions",
     kind: "heading",
     title: "All positions",
     summary:
-      "All positions in Position reference. Schema-derived API reference for every position adjustment: positionParams and compatible geoms.",
+      "All positions in Positions. Schema-derived API reference for every position adjustment: positionParams and compatible geoms.",
     href: "/reference/positions#all-positions",
-    keywords: ["Position reference", "Reference"],
+    keywords: ["Positions", "Reference"],
     exact: ["All positions"],
   },
   {
@@ -151,9 +151,9 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "How to set a position",
     summary:
-      "How to set a position in Position reference. Schema-derived API reference for every position adjustment: positionParams and compatible geoms.",
+      "How to set a position in Positions. Schema-derived API reference for every position adjustment: positionParams and compatible geoms.",
     href: "/reference/positions#how-to-set",
-    keywords: ["Position reference", "Reference"],
+    keywords: ["Positions", "Reference"],
     exact: ["How to set a position"],
   },
   {
@@ -221,7 +221,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "page",
     title: "GeomPoint",
     summary:
-      "GeomPoint: Point geometry: one mark per data row. Use for scatter plots, dot plots, bubbles, correlation views. With summary_bin (#817) or manual (#814).",
+      "GeomPoint: Point geometry: one mark per data row. Use for scatter plots, dot plots, bubbles, and correlation views.",
     href: "/reference/geoms/point",
     keywords: [],
     exact: ["GeomPoint"],
@@ -231,7 +231,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Defaults",
     summary:
-      "Defaults in GeomPoint. GeomPoint: Point geometry: one mark per data row. Use for scatter plots, dot plots, bubbles, correlation views. With summary_bin (#817) or manual (#814).",
+      "Defaults in GeomPoint. GeomPoint: Point geometry: one mark per data row. Use for scatter plots, dot plots, bubbles, and correlation views.",
     href: "/reference/geoms/point#defaults",
     keywords: ["GeomPoint", "documentation"],
     exact: ["Defaults"],
@@ -241,7 +241,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Svelte component",
     summary:
-      "Svelte component in GeomPoint. GeomPoint: Point geometry: one mark per data row. Use for scatter plots, dot plots, bubbles, correlation views. With summary_bin (#817) or manual (#814).",
+      "Svelte component in GeomPoint. GeomPoint: Point geometry: one mark per data row. Use for scatter plots, dot plots, bubbles, and correlation views.",
     href: "/reference/geoms/point#svelte",
     keywords: ["GeomPoint", "documentation"],
     exact: ["Svelte component"],
@@ -251,7 +251,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "JSON layer",
     summary:
-      "JSON layer in GeomPoint. GeomPoint: Point geometry: one mark per data row. Use for scatter plots, dot plots, bubbles, correlation views. With summary_bin (#817) or manual (#814).",
+      "JSON layer in GeomPoint. GeomPoint: Point geometry: one mark per data row. Use for scatter plots, dot plots, bubbles, and correlation views.",
     href: "/reference/geoms/point#json",
     keywords: ["GeomPoint", "documentation"],
     exact: ["JSON layer"],
@@ -261,7 +261,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Params",
     summary:
-      "Params in GeomPoint. GeomPoint: Point geometry: one mark per data row. Use for scatter plots, dot plots, bubbles, correlation views. With summary_bin (#817) or manual (#814).",
+      "Params in GeomPoint. GeomPoint: Point geometry: one mark per data row. Use for scatter plots, dot plots, bubbles, and correlation views.",
     href: "/reference/geoms/point#params",
     keywords: ["GeomPoint", "documentation"],
     exact: ["Params"],
@@ -271,7 +271,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed stats",
     summary:
-      "Allowed stats in GeomPoint. GeomPoint: Point geometry: one mark per data row. Use for scatter plots, dot plots, bubbles, correlation views. With summary_bin (#817) or manual (#814).",
+      "Allowed stats in GeomPoint. GeomPoint: Point geometry: one mark per data row. Use for scatter plots, dot plots, bubbles, and correlation views.",
     href: "/reference/geoms/point#allowed-stats",
     keywords: ["GeomPoint", "documentation"],
     exact: ["Allowed stats"],
@@ -281,7 +281,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed positions",
     summary:
-      "Allowed positions in GeomPoint. GeomPoint: Point geometry: one mark per data row. Use for scatter plots, dot plots, bubbles, correlation views. With summary_bin (#817) or manual (#814).",
+      "Allowed positions in GeomPoint. GeomPoint: Point geometry: one mark per data row. Use for scatter plots, dot plots, bubbles, and correlation views.",
     href: "/reference/geoms/point#allowed-positions",
     keywords: ["GeomPoint", "documentation"],
     exact: ["Allowed positions"],
@@ -291,7 +291,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Examples",
     summary:
-      "Examples in GeomPoint. GeomPoint: Point geometry: one mark per data row. Use for scatter plots, dot plots, bubbles, correlation views. With summary_bin (#817) or manual (#814).",
+      "Examples in GeomPoint. GeomPoint: Point geometry: one mark per data row. Use for scatter plots, dot plots, bubbles, and correlation views.",
     href: "/reference/geoms/point#examples",
     keywords: ["GeomPoint", "documentation"],
     exact: ["Examples"],
@@ -301,7 +301,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "page",
     title: "GeomLine",
     summary:
-      "GeomLine: Line geometry: connects points in x order, one line per group (groups derive from discrete aesthetics such as color, or from aes.group). Use for time series, trends, line charts, and ECDFs (stat ecdf + curve step-hv; #811). With stat bin (freqpoly alias), y is computed from counts/density. With stat connect, successive points expand into named connection vertices (#816).",
+      "GeomLine: Line geometry: connects points in x order, one line per group (groups derive from discrete aesthetics such as color, or from aes.group). Use for time series, trends, and line charts. With stat ecdf, pair with step curves; with stat bin (freqpoly alias), y is computed from counts/density; with stat connect, successive points expand into connection vertices.",
     href: "/reference/geoms/line",
     keywords: [],
     exact: ["GeomLine"],
@@ -311,7 +311,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Defaults",
     summary:
-      "Defaults in GeomLine. GeomLine: Line geometry: connects points in x order, one line per group (groups derive from discrete aesthetics such as color, or from aes.group). Use for time series, trends, line charts, and ECDFs (stat ecdf + curve step-hv; #811). With stat bin (freqpoly alias), y is computed from counts/density. With stat connect, successive points expand into named connection vertices (#816).",
+      "Defaults in GeomLine. GeomLine: Line geometry: connects points in x order, one line per group (groups derive from discrete aesthetics such as color, or from aes.group). Use for time series, trends, and line charts. With stat ecdf, pair with step curves; with stat bin (freqpoly alias), y is computed from counts/density; with stat connect, successive points expand into connection vertices.",
     href: "/reference/geoms/line#defaults",
     keywords: ["GeomLine", "documentation"],
     exact: ["Defaults"],
@@ -321,7 +321,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Svelte component",
     summary:
-      "Svelte component in GeomLine. GeomLine: Line geometry: connects points in x order, one line per group (groups derive from discrete aesthetics such as color, or from aes.group). Use for time series, trends, line charts, and ECDFs (stat ecdf + curve step-hv; #811). With stat bin (freqpoly alias), y is computed from counts/density. With stat connect, successive points expand into named connection vertices (#816).",
+      "Svelte component in GeomLine. GeomLine: Line geometry: connects points in x order, one line per group (groups derive from discrete aesthetics such as color, or from aes.group). Use for time series, trends, and line charts. With stat ecdf, pair with step curves; with stat bin (freqpoly alias), y is computed from counts/density; with stat connect, successive points expand into connection vertices.",
     href: "/reference/geoms/line#svelte",
     keywords: ["GeomLine", "documentation"],
     exact: ["Svelte component"],
@@ -331,7 +331,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "JSON layer",
     summary:
-      "JSON layer in GeomLine. GeomLine: Line geometry: connects points in x order, one line per group (groups derive from discrete aesthetics such as color, or from aes.group). Use for time series, trends, line charts, and ECDFs (stat ecdf + curve step-hv; #811). With stat bin (freqpoly alias), y is computed from counts/density. With stat connect, successive points expand into named connection vertices (#816).",
+      "JSON layer in GeomLine. GeomLine: Line geometry: connects points in x order, one line per group (groups derive from discrete aesthetics such as color, or from aes.group). Use for time series, trends, and line charts. With stat ecdf, pair with step curves; with stat bin (freqpoly alias), y is computed from counts/density; with stat connect, successive points expand into connection vertices.",
     href: "/reference/geoms/line#json",
     keywords: ["GeomLine", "documentation"],
     exact: ["JSON layer"],
@@ -341,7 +341,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Params",
     summary:
-      "Params in GeomLine. GeomLine: Line geometry: connects points in x order, one line per group (groups derive from discrete aesthetics such as color, or from aes.group). Use for time series, trends, line charts, and ECDFs (stat ecdf + curve step-hv; #811). With stat bin (freqpoly alias), y is computed from counts/density. With stat connect, successive points expand into named connection vertices (#816).",
+      "Params in GeomLine. GeomLine: Line geometry: connects points in x order, one line per group (groups derive from discrete aesthetics such as color, or from aes.group). Use for time series, trends, and line charts. With stat ecdf, pair with step curves; with stat bin (freqpoly alias), y is computed from counts/density; with stat connect, successive points expand into connection vertices.",
     href: "/reference/geoms/line#params",
     keywords: ["GeomLine", "documentation"],
     exact: ["Params"],
@@ -351,7 +351,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed stats",
     summary:
-      "Allowed stats in GeomLine. GeomLine: Line geometry: connects points in x order, one line per group (groups derive from discrete aesthetics such as color, or from aes.group). Use for time series, trends, line charts, and ECDFs (stat ecdf + curve step-hv; #811). With stat bin (freqpoly alias), y is computed from counts/density. With stat connect, successive points expand into named connection vertices (#816).",
+      "Allowed stats in GeomLine. GeomLine: Line geometry: connects points in x order, one line per group (groups derive from discrete aesthetics such as color, or from aes.group). Use for time series, trends, and line charts. With stat ecdf, pair with step curves; with stat bin (freqpoly alias), y is computed from counts/density; with stat connect, successive points expand into connection vertices.",
     href: "/reference/geoms/line#allowed-stats",
     keywords: ["GeomLine", "documentation"],
     exact: ["Allowed stats"],
@@ -361,7 +361,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed positions",
     summary:
-      "Allowed positions in GeomLine. GeomLine: Line geometry: connects points in x order, one line per group (groups derive from discrete aesthetics such as color, or from aes.group). Use for time series, trends, line charts, and ECDFs (stat ecdf + curve step-hv; #811). With stat bin (freqpoly alias), y is computed from counts/density. With stat connect, successive points expand into named connection vertices (#816).",
+      "Allowed positions in GeomLine. GeomLine: Line geometry: connects points in x order, one line per group (groups derive from discrete aesthetics such as color, or from aes.group). Use for time series, trends, and line charts. With stat ecdf, pair with step curves; with stat bin (freqpoly alias), y is computed from counts/density; with stat connect, successive points expand into connection vertices.",
     href: "/reference/geoms/line#allowed-positions",
     keywords: ["GeomLine", "documentation"],
     exact: ["Allowed positions"],
@@ -371,7 +371,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Examples",
     summary:
-      "Examples in GeomLine. GeomLine: Line geometry: connects points in x order, one line per group (groups derive from discrete aesthetics such as color, or from aes.group). Use for time series, trends, line charts, and ECDFs (stat ecdf + curve step-hv; #811). With stat bin (freqpoly alias), y is computed from counts/density. With stat connect, successive points expand into named connection vertices (#816).",
+      "Examples in GeomLine. GeomLine: Line geometry: connects points in x order, one line per group (groups derive from discrete aesthetics such as color, or from aes.group). Use for time series, trends, and line charts. With stat ecdf, pair with step curves; with stat bin (freqpoly alias), y is computed from counts/density; with stat connect, successive points expand into connection vertices.",
     href: "/reference/geoms/line#examples",
     keywords: ["GeomLine", "documentation"],
     exact: ["Examples"],
@@ -381,7 +381,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "page",
     title: "GeomPath",
     summary:
-      "GeomPath: Path geometry: connects points in data (row) order within each group — unlike line, which sorts by x. Use for trajectories, loops, connected scatterplots (ggplot2 geom_path), and ellipse rings (stat ellipse). With stat connect, successive points expand into named connection vertices (#816).",
+      "GeomPath: Path geometry: connects points in data (row) order within each group — unlike line, which sorts by x. Use for trajectories, loops, connected scatterplots, and ellipse rings (stat ellipse). With stat connect, successive points expand into connection vertices.",
     href: "/reference/geoms/path",
     keywords: [],
     exact: ["GeomPath"],
@@ -391,7 +391,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Defaults",
     summary:
-      "Defaults in GeomPath. GeomPath: Path geometry: connects points in data (row) order within each group — unlike line, which sorts by x. Use for trajectories, loops, connected scatterplots (ggplot2 geom_path), and ellipse rings (stat ellipse). With stat connect, successive points expand into named connection vertices (#816).",
+      "Defaults in GeomPath. GeomPath: Path geometry: connects points in data (row) order within each group — unlike line, which sorts by x. Use for trajectories, loops, connected scatterplots, and ellipse rings (stat ellipse). With stat connect, successive points expand into connection vertices.",
     href: "/reference/geoms/path#defaults",
     keywords: ["GeomPath", "documentation"],
     exact: ["Defaults"],
@@ -401,7 +401,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Svelte component",
     summary:
-      "Svelte component in GeomPath. GeomPath: Path geometry: connects points in data (row) order within each group — unlike line, which sorts by x. Use for trajectories, loops, connected scatterplots (ggplot2 geom_path), and ellipse rings (stat ellipse). With stat connect, successive points expand into named connection vertices (#816).",
+      "Svelte component in GeomPath. GeomPath: Path geometry: connects points in data (row) order within each group — unlike line, which sorts by x. Use for trajectories, loops, connected scatterplots, and ellipse rings (stat ellipse). With stat connect, successive points expand into connection vertices.",
     href: "/reference/geoms/path#svelte",
     keywords: ["GeomPath", "documentation"],
     exact: ["Svelte component"],
@@ -411,7 +411,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "JSON layer",
     summary:
-      "JSON layer in GeomPath. GeomPath: Path geometry: connects points in data (row) order within each group — unlike line, which sorts by x. Use for trajectories, loops, connected scatterplots (ggplot2 geom_path), and ellipse rings (stat ellipse). With stat connect, successive points expand into named connection vertices (#816).",
+      "JSON layer in GeomPath. GeomPath: Path geometry: connects points in data (row) order within each group — unlike line, which sorts by x. Use for trajectories, loops, connected scatterplots, and ellipse rings (stat ellipse). With stat connect, successive points expand into connection vertices.",
     href: "/reference/geoms/path#json",
     keywords: ["GeomPath", "documentation"],
     exact: ["JSON layer"],
@@ -421,7 +421,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Params",
     summary:
-      "Params in GeomPath. GeomPath: Path geometry: connects points in data (row) order within each group — unlike line, which sorts by x. Use for trajectories, loops, connected scatterplots (ggplot2 geom_path), and ellipse rings (stat ellipse). With stat connect, successive points expand into named connection vertices (#816).",
+      "Params in GeomPath. GeomPath: Path geometry: connects points in data (row) order within each group — unlike line, which sorts by x. Use for trajectories, loops, connected scatterplots, and ellipse rings (stat ellipse). With stat connect, successive points expand into connection vertices.",
     href: "/reference/geoms/path#params",
     keywords: ["GeomPath", "documentation"],
     exact: ["Params"],
@@ -431,7 +431,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed stats",
     summary:
-      "Allowed stats in GeomPath. GeomPath: Path geometry: connects points in data (row) order within each group — unlike line, which sorts by x. Use for trajectories, loops, connected scatterplots (ggplot2 geom_path), and ellipse rings (stat ellipse). With stat connect, successive points expand into named connection vertices (#816).",
+      "Allowed stats in GeomPath. GeomPath: Path geometry: connects points in data (row) order within each group — unlike line, which sorts by x. Use for trajectories, loops, connected scatterplots, and ellipse rings (stat ellipse). With stat connect, successive points expand into connection vertices.",
     href: "/reference/geoms/path#allowed-stats",
     keywords: ["GeomPath", "documentation"],
     exact: ["Allowed stats"],
@@ -441,7 +441,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed positions",
     summary:
-      "Allowed positions in GeomPath. GeomPath: Path geometry: connects points in data (row) order within each group — unlike line, which sorts by x. Use for trajectories, loops, connected scatterplots (ggplot2 geom_path), and ellipse rings (stat ellipse). With stat connect, successive points expand into named connection vertices (#816).",
+      "Allowed positions in GeomPath. GeomPath: Path geometry: connects points in data (row) order within each group — unlike line, which sorts by x. Use for trajectories, loops, connected scatterplots, and ellipse rings (stat ellipse). With stat connect, successive points expand into connection vertices.",
     href: "/reference/geoms/path#allowed-positions",
     keywords: ["GeomPath", "documentation"],
     exact: ["Allowed positions"],
@@ -451,7 +451,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Examples",
     summary:
-      "Examples in GeomPath. GeomPath: Path geometry: connects points in data (row) order within each group — unlike line, which sorts by x. Use for trajectories, loops, connected scatterplots (ggplot2 geom_path), and ellipse rings (stat ellipse). With stat connect, successive points expand into named connection vertices (#816).",
+      "Examples in GeomPath. GeomPath: Path geometry: connects points in data (row) order within each group — unlike line, which sorts by x. Use for trajectories, loops, connected scatterplots, and ellipse rings (stat ellipse). With stat connect, successive points expand into connection vertices.",
     href: "/reference/geoms/path#examples",
     keywords: ["GeomPath", "documentation"],
     exact: ["Examples"],
@@ -461,7 +461,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "page",
     title: "GeomCol",
     summary:
-      "GeomCol: Column geometry: one rectangle per data row, from the y baseline (zero) to the row's y value. Use when the data already contains the bar heights (ggplot2's geom_col).",
+      "GeomCol: Column geometry: one rectangle per data row, from the y baseline (zero) to the row's y value. Use when the data already contains the bar heights — prefer over GeomBar, which counts or bins.",
     href: "/reference/geoms/col",
     keywords: [],
     exact: ["GeomCol"],
@@ -471,7 +471,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Defaults",
     summary:
-      "Defaults in GeomCol. GeomCol: Column geometry: one rectangle per data row, from the y baseline (zero) to the row's y value. Use when the data already contains the bar heights (ggplot2's geom_col).",
+      "Defaults in GeomCol. GeomCol: Column geometry: one rectangle per data row, from the y baseline (zero) to the row's y value. Use when the data already contains the bar heights — prefer over GeomBar, which counts or bins.",
     href: "/reference/geoms/col#defaults",
     keywords: ["GeomCol", "documentation"],
     exact: ["Defaults"],
@@ -481,7 +481,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Svelte component",
     summary:
-      "Svelte component in GeomCol. GeomCol: Column geometry: one rectangle per data row, from the y baseline (zero) to the row's y value. Use when the data already contains the bar heights (ggplot2's geom_col).",
+      "Svelte component in GeomCol. GeomCol: Column geometry: one rectangle per data row, from the y baseline (zero) to the row's y value. Use when the data already contains the bar heights — prefer over GeomBar, which counts or bins.",
     href: "/reference/geoms/col#svelte",
     keywords: ["GeomCol", "documentation"],
     exact: ["Svelte component"],
@@ -491,7 +491,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "JSON layer",
     summary:
-      "JSON layer in GeomCol. GeomCol: Column geometry: one rectangle per data row, from the y baseline (zero) to the row's y value. Use when the data already contains the bar heights (ggplot2's geom_col).",
+      "JSON layer in GeomCol. GeomCol: Column geometry: one rectangle per data row, from the y baseline (zero) to the row's y value. Use when the data already contains the bar heights — prefer over GeomBar, which counts or bins.",
     href: "/reference/geoms/col#json",
     keywords: ["GeomCol", "documentation"],
     exact: ["JSON layer"],
@@ -501,7 +501,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Params",
     summary:
-      "Params in GeomCol. GeomCol: Column geometry: one rectangle per data row, from the y baseline (zero) to the row's y value. Use when the data already contains the bar heights (ggplot2's geom_col).",
+      "Params in GeomCol. GeomCol: Column geometry: one rectangle per data row, from the y baseline (zero) to the row's y value. Use when the data already contains the bar heights — prefer over GeomBar, which counts or bins.",
     href: "/reference/geoms/col#params",
     keywords: ["GeomCol", "documentation"],
     exact: ["Params"],
@@ -511,7 +511,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed stats",
     summary:
-      "Allowed stats in GeomCol. GeomCol: Column geometry: one rectangle per data row, from the y baseline (zero) to the row's y value. Use when the data already contains the bar heights (ggplot2's geom_col).",
+      "Allowed stats in GeomCol. GeomCol: Column geometry: one rectangle per data row, from the y baseline (zero) to the row's y value. Use when the data already contains the bar heights — prefer over GeomBar, which counts or bins.",
     href: "/reference/geoms/col#allowed-stats",
     keywords: ["GeomCol", "documentation"],
     exact: ["Allowed stats"],
@@ -521,7 +521,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed positions",
     summary:
-      "Allowed positions in GeomCol. GeomCol: Column geometry: one rectangle per data row, from the y baseline (zero) to the row's y value. Use when the data already contains the bar heights (ggplot2's geom_col).",
+      "Allowed positions in GeomCol. GeomCol: Column geometry: one rectangle per data row, from the y baseline (zero) to the row's y value. Use when the data already contains the bar heights — prefer over GeomBar, which counts or bins.",
     href: "/reference/geoms/col#allowed-positions",
     keywords: ["GeomCol", "documentation"],
     exact: ["Allowed positions"],
@@ -531,7 +531,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Examples",
     summary:
-      "Examples in GeomCol. GeomCol: Column geometry: one rectangle per data row, from the y baseline (zero) to the row's y value. Use when the data already contains the bar heights (ggplot2's geom_col).",
+      "Examples in GeomCol. GeomCol: Column geometry: one rectangle per data row, from the y baseline (zero) to the row's y value. Use when the data already contains the bar heights — prefer over GeomBar, which counts or bins.",
     href: "/reference/geoms/col#examples",
     keywords: ["GeomCol", "documentation"],
     exact: ["Examples"],
@@ -541,7 +541,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "page",
     title: "GeomBar",
     summary:
-      "GeomBar: Bar geometry with counting or binning: one rectangle per distinct x value (stat count, discrete x) or per bin (stat bin, continuous x). Do NOT map aes.y — the stat computes it (ggplot2's geom_bar / geom_histogram).",
+      "GeomBar: Bar geometry with counting or binning: one rectangle per distinct x value (stat count, discrete x) or per bin (stat bin, continuous x). Do not map aes.y — the stat computes it. Prefer GeomCol when bar heights are already in the data.",
     href: "/reference/geoms/bar",
     keywords: [],
     exact: ["GeomBar"],
@@ -551,7 +551,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Defaults",
     summary:
-      "Defaults in GeomBar. GeomBar: Bar geometry with counting or binning: one rectangle per distinct x value (stat count, discrete x) or per bin (stat bin, continuous x). Do NOT map aes.y — the stat computes it (ggplot2's geom_bar / geom_histogram).",
+      "Defaults in GeomBar. GeomBar: Bar geometry with counting or binning: one rectangle per distinct x value (stat count, discrete x) or per bin (stat bin, continuous x). Do not map aes.y — the stat computes it. Prefer GeomCol when bar heights are already in the data.",
     href: "/reference/geoms/bar#defaults",
     keywords: ["GeomBar", "documentation"],
     exact: ["Defaults"],
@@ -561,7 +561,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Svelte component",
     summary:
-      "Svelte component in GeomBar. GeomBar: Bar geometry with counting or binning: one rectangle per distinct x value (stat count, discrete x) or per bin (stat bin, continuous x). Do NOT map aes.y — the stat computes it (ggplot2's geom_bar / geom_histogram).",
+      "Svelte component in GeomBar. GeomBar: Bar geometry with counting or binning: one rectangle per distinct x value (stat count, discrete x) or per bin (stat bin, continuous x). Do not map aes.y — the stat computes it. Prefer GeomCol when bar heights are already in the data.",
     href: "/reference/geoms/bar#svelte",
     keywords: ["GeomBar", "documentation"],
     exact: ["Svelte component"],
@@ -571,7 +571,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "JSON layer",
     summary:
-      "JSON layer in GeomBar. GeomBar: Bar geometry with counting or binning: one rectangle per distinct x value (stat count, discrete x) or per bin (stat bin, continuous x). Do NOT map aes.y — the stat computes it (ggplot2's geom_bar / geom_histogram).",
+      "JSON layer in GeomBar. GeomBar: Bar geometry with counting or binning: one rectangle per distinct x value (stat count, discrete x) or per bin (stat bin, continuous x). Do not map aes.y — the stat computes it. Prefer GeomCol when bar heights are already in the data.",
     href: "/reference/geoms/bar#json",
     keywords: ["GeomBar", "documentation"],
     exact: ["JSON layer"],
@@ -581,7 +581,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Params",
     summary:
-      "Params in GeomBar. GeomBar: Bar geometry with counting or binning: one rectangle per distinct x value (stat count, discrete x) or per bin (stat bin, continuous x). Do NOT map aes.y — the stat computes it (ggplot2's geom_bar / geom_histogram).",
+      "Params in GeomBar. GeomBar: Bar geometry with counting or binning: one rectangle per distinct x value (stat count, discrete x) or per bin (stat bin, continuous x). Do not map aes.y — the stat computes it. Prefer GeomCol when bar heights are already in the data.",
     href: "/reference/geoms/bar#params",
     keywords: ["GeomBar", "documentation"],
     exact: ["Params"],
@@ -591,7 +591,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed stats",
     summary:
-      "Allowed stats in GeomBar. GeomBar: Bar geometry with counting or binning: one rectangle per distinct x value (stat count, discrete x) or per bin (stat bin, continuous x). Do NOT map aes.y — the stat computes it (ggplot2's geom_bar / geom_histogram).",
+      "Allowed stats in GeomBar. GeomBar: Bar geometry with counting or binning: one rectangle per distinct x value (stat count, discrete x) or per bin (stat bin, continuous x). Do not map aes.y — the stat computes it. Prefer GeomCol when bar heights are already in the data.",
     href: "/reference/geoms/bar#allowed-stats",
     keywords: ["GeomBar", "documentation"],
     exact: ["Allowed stats"],
@@ -601,7 +601,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed positions",
     summary:
-      "Allowed positions in GeomBar. GeomBar: Bar geometry with counting or binning: one rectangle per distinct x value (stat count, discrete x) or per bin (stat bin, continuous x). Do NOT map aes.y — the stat computes it (ggplot2's geom_bar / geom_histogram).",
+      "Allowed positions in GeomBar. GeomBar: Bar geometry with counting or binning: one rectangle per distinct x value (stat count, discrete x) or per bin (stat bin, continuous x). Do not map aes.y — the stat computes it. Prefer GeomCol when bar heights are already in the data.",
     href: "/reference/geoms/bar#allowed-positions",
     keywords: ["GeomBar", "documentation"],
     exact: ["Allowed positions"],
@@ -611,7 +611,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Examples",
     summary:
-      "Examples in GeomBar. GeomBar: Bar geometry with counting or binning: one rectangle per distinct x value (stat count, discrete x) or per bin (stat bin, continuous x). Do NOT map aes.y — the stat computes it (ggplot2's geom_bar / geom_histogram).",
+      "Examples in GeomBar. GeomBar: Bar geometry with counting or binning: one rectangle per distinct x value (stat count, discrete x) or per bin (stat bin, continuous x). Do not map aes.y — the stat computes it. Prefer GeomCol when bar heights are already in the data.",
     href: "/reference/geoms/bar#examples",
     keywords: ["GeomBar", "documentation"],
     exact: ["Examples"],
@@ -621,7 +621,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "page",
     title: "GeomHistogram",
     summary:
-      "GeomHistogram: Histogram geometry: a continuous x variable divided into bins, one bar per bin whose height is the count of rows (or the sum of aes.weight). Do NOT map aes.y — the bin stat computes it. Canonicalized by normalize() to a bar layer with stat bin.",
+      "GeomHistogram: Histogram geometry: a continuous x variable divided into bins, one bar per bin whose height is the count of rows (or the sum of aes.weight). Do not map aes.y — the bin stat computes it. Canonicalized by normalize() to a bar layer with stat bin.",
     href: "/reference/geoms/histogram",
     keywords: [],
     exact: ["GeomHistogram"],
@@ -631,7 +631,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Defaults",
     summary:
-      "Defaults in GeomHistogram. GeomHistogram: Histogram geometry: a continuous x variable divided into bins, one bar per bin whose height is the count of rows (or the sum of aes.weight). Do NOT map aes.y — the bin stat computes it. Canonicalized by normalize() to a bar layer with stat bin.",
+      "Defaults in GeomHistogram. GeomHistogram: Histogram geometry: a continuous x variable divided into bins, one bar per bin whose height is the count of rows (or the sum of aes.weight). Do not map aes.y — the bin stat computes it. Canonicalized by normalize() to a bar layer with stat bin.",
     href: "/reference/geoms/histogram#defaults",
     keywords: ["GeomHistogram", "documentation"],
     exact: ["Defaults"],
@@ -641,7 +641,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Alias",
     summary:
-      "Alias in GeomHistogram. GeomHistogram: Histogram geometry: a continuous x variable divided into bins, one bar per bin whose height is the count of rows (or the sum of aes.weight). Do NOT map aes.y — the bin stat computes it. Canonicalized by normalize() to a bar layer with stat bin.",
+      "Alias in GeomHistogram. GeomHistogram: Histogram geometry: a continuous x variable divided into bins, one bar per bin whose height is the count of rows (or the sum of aes.weight). Do not map aes.y — the bin stat computes it. Canonicalized by normalize() to a bar layer with stat bin.",
     href: "/reference/geoms/histogram#alias",
     keywords: ["GeomHistogram", "documentation"],
     exact: ["Alias"],
@@ -651,7 +651,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Svelte component",
     summary:
-      "Svelte component in GeomHistogram. GeomHistogram: Histogram geometry: a continuous x variable divided into bins, one bar per bin whose height is the count of rows (or the sum of aes.weight). Do NOT map aes.y — the bin stat computes it. Canonicalized by normalize() to a bar layer with stat bin.",
+      "Svelte component in GeomHistogram. GeomHistogram: Histogram geometry: a continuous x variable divided into bins, one bar per bin whose height is the count of rows (or the sum of aes.weight). Do not map aes.y — the bin stat computes it. Canonicalized by normalize() to a bar layer with stat bin.",
     href: "/reference/geoms/histogram#svelte",
     keywords: ["GeomHistogram", "documentation"],
     exact: ["Svelte component"],
@@ -661,7 +661,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "JSON layer",
     summary:
-      "JSON layer in GeomHistogram. GeomHistogram: Histogram geometry: a continuous x variable divided into bins, one bar per bin whose height is the count of rows (or the sum of aes.weight). Do NOT map aes.y — the bin stat computes it. Canonicalized by normalize() to a bar layer with stat bin.",
+      "JSON layer in GeomHistogram. GeomHistogram: Histogram geometry: a continuous x variable divided into bins, one bar per bin whose height is the count of rows (or the sum of aes.weight). Do not map aes.y — the bin stat computes it. Canonicalized by normalize() to a bar layer with stat bin.",
     href: "/reference/geoms/histogram#json",
     keywords: ["GeomHistogram", "documentation"],
     exact: ["JSON layer"],
@@ -671,7 +671,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Params",
     summary:
-      "Params in GeomHistogram. GeomHistogram: Histogram geometry: a continuous x variable divided into bins, one bar per bin whose height is the count of rows (or the sum of aes.weight). Do NOT map aes.y — the bin stat computes it. Canonicalized by normalize() to a bar layer with stat bin.",
+      "Params in GeomHistogram. GeomHistogram: Histogram geometry: a continuous x variable divided into bins, one bar per bin whose height is the count of rows (or the sum of aes.weight). Do not map aes.y — the bin stat computes it. Canonicalized by normalize() to a bar layer with stat bin.",
     href: "/reference/geoms/histogram#params",
     keywords: ["GeomHistogram", "documentation"],
     exact: ["Params"],
@@ -681,7 +681,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed stats",
     summary:
-      "Allowed stats in GeomHistogram. GeomHistogram: Histogram geometry: a continuous x variable divided into bins, one bar per bin whose height is the count of rows (or the sum of aes.weight). Do NOT map aes.y — the bin stat computes it. Canonicalized by normalize() to a bar layer with stat bin.",
+      "Allowed stats in GeomHistogram. GeomHistogram: Histogram geometry: a continuous x variable divided into bins, one bar per bin whose height is the count of rows (or the sum of aes.weight). Do not map aes.y — the bin stat computes it. Canonicalized by normalize() to a bar layer with stat bin.",
     href: "/reference/geoms/histogram#allowed-stats",
     keywords: ["GeomHistogram", "documentation"],
     exact: ["Allowed stats"],
@@ -691,7 +691,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed positions",
     summary:
-      "Allowed positions in GeomHistogram. GeomHistogram: Histogram geometry: a continuous x variable divided into bins, one bar per bin whose height is the count of rows (or the sum of aes.weight). Do NOT map aes.y — the bin stat computes it. Canonicalized by normalize() to a bar layer with stat bin.",
+      "Allowed positions in GeomHistogram. GeomHistogram: Histogram geometry: a continuous x variable divided into bins, one bar per bin whose height is the count of rows (or the sum of aes.weight). Do not map aes.y — the bin stat computes it. Canonicalized by normalize() to a bar layer with stat bin.",
     href: "/reference/geoms/histogram#allowed-positions",
     keywords: ["GeomHistogram", "documentation"],
     exact: ["Allowed positions"],
@@ -701,7 +701,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Examples",
     summary:
-      "Examples in GeomHistogram. GeomHistogram: Histogram geometry: a continuous x variable divided into bins, one bar per bin whose height is the count of rows (or the sum of aes.weight). Do NOT map aes.y — the bin stat computes it. Canonicalized by normalize() to a bar layer with stat bin.",
+      "Examples in GeomHistogram. GeomHistogram: Histogram geometry: a continuous x variable divided into bins, one bar per bin whose height is the count of rows (or the sum of aes.weight). Do not map aes.y — the bin stat computes it. Canonicalized by normalize() to a bar layer with stat bin.",
     href: "/reference/geoms/histogram#examples",
     keywords: ["GeomHistogram", "documentation"],
     exact: ["Examples"],
@@ -711,7 +711,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "page",
     title: "GeomFreqpoly",
     summary:
-      "GeomFreqpoly: Frequency polygon (ggplot2 geom_freqpoly): continuous x binned like a histogram, drawn as a line through bin centers. Do NOT map aes.y — the bin stat computes it. Canonicalized by normalize() to a line layer with stat bin.",
+      "GeomFreqpoly: Frequency polygon: continuous x binned like a histogram, drawn as a line through bin centers. Do not map aes.y — the bin stat computes it. Canonicalized by normalize() to a line layer with stat bin.",
     href: "/reference/geoms/freqpoly",
     keywords: [],
     exact: ["GeomFreqpoly"],
@@ -721,7 +721,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Defaults",
     summary:
-      "Defaults in GeomFreqpoly. GeomFreqpoly: Frequency polygon (ggplot2 geom_freqpoly): continuous x binned like a histogram, drawn as a line through bin centers. Do NOT map aes.y — the bin stat computes it. Canonicalized by normalize() to a line layer with stat bin.",
+      "Defaults in GeomFreqpoly. GeomFreqpoly: Frequency polygon: continuous x binned like a histogram, drawn as a line through bin centers. Do not map aes.y — the bin stat computes it. Canonicalized by normalize() to a line layer with stat bin.",
     href: "/reference/geoms/freqpoly#defaults",
     keywords: ["GeomFreqpoly", "documentation"],
     exact: ["Defaults"],
@@ -731,7 +731,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Alias",
     summary:
-      "Alias in GeomFreqpoly. GeomFreqpoly: Frequency polygon (ggplot2 geom_freqpoly): continuous x binned like a histogram, drawn as a line through bin centers. Do NOT map aes.y — the bin stat computes it. Canonicalized by normalize() to a line layer with stat bin.",
+      "Alias in GeomFreqpoly. GeomFreqpoly: Frequency polygon: continuous x binned like a histogram, drawn as a line through bin centers. Do not map aes.y — the bin stat computes it. Canonicalized by normalize() to a line layer with stat bin.",
     href: "/reference/geoms/freqpoly#alias",
     keywords: ["GeomFreqpoly", "documentation"],
     exact: ["Alias"],
@@ -741,7 +741,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Svelte component",
     summary:
-      "Svelte component in GeomFreqpoly. GeomFreqpoly: Frequency polygon (ggplot2 geom_freqpoly): continuous x binned like a histogram, drawn as a line through bin centers. Do NOT map aes.y — the bin stat computes it. Canonicalized by normalize() to a line layer with stat bin.",
+      "Svelte component in GeomFreqpoly. GeomFreqpoly: Frequency polygon: continuous x binned like a histogram, drawn as a line through bin centers. Do not map aes.y — the bin stat computes it. Canonicalized by normalize() to a line layer with stat bin.",
     href: "/reference/geoms/freqpoly#svelte",
     keywords: ["GeomFreqpoly", "documentation"],
     exact: ["Svelte component"],
@@ -751,7 +751,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "JSON layer",
     summary:
-      "JSON layer in GeomFreqpoly. GeomFreqpoly: Frequency polygon (ggplot2 geom_freqpoly): continuous x binned like a histogram, drawn as a line through bin centers. Do NOT map aes.y — the bin stat computes it. Canonicalized by normalize() to a line layer with stat bin.",
+      "JSON layer in GeomFreqpoly. GeomFreqpoly: Frequency polygon: continuous x binned like a histogram, drawn as a line through bin centers. Do not map aes.y — the bin stat computes it. Canonicalized by normalize() to a line layer with stat bin.",
     href: "/reference/geoms/freqpoly#json",
     keywords: ["GeomFreqpoly", "documentation"],
     exact: ["JSON layer"],
@@ -761,7 +761,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Params",
     summary:
-      "Params in GeomFreqpoly. GeomFreqpoly: Frequency polygon (ggplot2 geom_freqpoly): continuous x binned like a histogram, drawn as a line through bin centers. Do NOT map aes.y — the bin stat computes it. Canonicalized by normalize() to a line layer with stat bin.",
+      "Params in GeomFreqpoly. GeomFreqpoly: Frequency polygon: continuous x binned like a histogram, drawn as a line through bin centers. Do not map aes.y — the bin stat computes it. Canonicalized by normalize() to a line layer with stat bin.",
     href: "/reference/geoms/freqpoly#params",
     keywords: ["GeomFreqpoly", "documentation"],
     exact: ["Params"],
@@ -771,7 +771,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed stats",
     summary:
-      "Allowed stats in GeomFreqpoly. GeomFreqpoly: Frequency polygon (ggplot2 geom_freqpoly): continuous x binned like a histogram, drawn as a line through bin centers. Do NOT map aes.y — the bin stat computes it. Canonicalized by normalize() to a line layer with stat bin.",
+      "Allowed stats in GeomFreqpoly. GeomFreqpoly: Frequency polygon: continuous x binned like a histogram, drawn as a line through bin centers. Do not map aes.y — the bin stat computes it. Canonicalized by normalize() to a line layer with stat bin.",
     href: "/reference/geoms/freqpoly#allowed-stats",
     keywords: ["GeomFreqpoly", "documentation"],
     exact: ["Allowed stats"],
@@ -781,7 +781,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed positions",
     summary:
-      "Allowed positions in GeomFreqpoly. GeomFreqpoly: Frequency polygon (ggplot2 geom_freqpoly): continuous x binned like a histogram, drawn as a line through bin centers. Do NOT map aes.y — the bin stat computes it. Canonicalized by normalize() to a line layer with stat bin.",
+      "Allowed positions in GeomFreqpoly. GeomFreqpoly: Frequency polygon: continuous x binned like a histogram, drawn as a line through bin centers. Do not map aes.y — the bin stat computes it. Canonicalized by normalize() to a line layer with stat bin.",
     href: "/reference/geoms/freqpoly#allowed-positions",
     keywords: ["GeomFreqpoly", "documentation"],
     exact: ["Allowed positions"],
@@ -791,7 +791,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Examples",
     summary:
-      "Examples in GeomFreqpoly. GeomFreqpoly: Frequency polygon (ggplot2 geom_freqpoly): continuous x binned like a histogram, drawn as a line through bin centers. Do NOT map aes.y — the bin stat computes it. Canonicalized by normalize() to a line layer with stat bin.",
+      "Examples in GeomFreqpoly. GeomFreqpoly: Frequency polygon: continuous x binned like a histogram, drawn as a line through bin centers. Do not map aes.y — the bin stat computes it. Canonicalized by normalize() to a line layer with stat bin.",
     href: "/reference/geoms/freqpoly#examples",
     keywords: ["GeomFreqpoly", "documentation"],
     exact: ["Examples"],
@@ -881,7 +881,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "page",
     title: "GeomRule",
     summary:
-      "GeomRule: Rule geometry: reference lines spanning the panel. TWO HONEST FORMS: (1) annotation — set params.xintercept and/or params.yintercept to fixed data values and map neither aes.x nor aes.y; (2) data-driven — map exactly ONE of aes.x (vertical rules) or aes.y (horizontal rules) to a field. Never mix the forms in one layer.",
+      "GeomRule: Rule geometry: reference lines spanning the panel. Two forms: (1) annotation — set params.xintercept and/or params.yintercept to fixed data values and map neither aes.x nor aes.y; (2) data-driven — map exactly one of aes.x (vertical rules) or aes.y (horizontal rules) to a field. Never mix the forms in one layer.",
     href: "/reference/geoms/rule",
     keywords: [],
     exact: ["GeomRule"],
@@ -891,7 +891,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Defaults",
     summary:
-      "Defaults in GeomRule. GeomRule: Rule geometry: reference lines spanning the panel. TWO HONEST FORMS: (1) annotation — set params.xintercept and/or params.yintercept to fixed data values and map neither aes.x nor aes.y; (2) data-driven — map exactly ONE of aes.x (vertical rules) or aes.y (horizontal rules) to a field. Never mix the forms in one layer.",
+      "Defaults in GeomRule. GeomRule: Rule geometry: reference lines spanning the panel. Two forms: (1) annotation — set params.xintercept and/or params.yintercept to fixed data values and map neither aes.x nor aes.y; (2) data-driven — map exactly one of aes.x (vertical rules) or aes.y (horizontal rules) to a field. Never mix the forms in one layer.",
     href: "/reference/geoms/rule#defaults",
     keywords: ["GeomRule", "documentation"],
     exact: ["Defaults"],
@@ -901,7 +901,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Svelte component",
     summary:
-      "Svelte component in GeomRule. GeomRule: Rule geometry: reference lines spanning the panel. TWO HONEST FORMS: (1) annotation — set params.xintercept and/or params.yintercept to fixed data values and map neither aes.x nor aes.y; (2) data-driven — map exactly ONE of aes.x (vertical rules) or aes.y (horizontal rules) to a field. Never mix the forms in one layer.",
+      "Svelte component in GeomRule. GeomRule: Rule geometry: reference lines spanning the panel. Two forms: (1) annotation — set params.xintercept and/or params.yintercept to fixed data values and map neither aes.x nor aes.y; (2) data-driven — map exactly one of aes.x (vertical rules) or aes.y (horizontal rules) to a field. Never mix the forms in one layer.",
     href: "/reference/geoms/rule#svelte",
     keywords: ["GeomRule", "documentation"],
     exact: ["Svelte component"],
@@ -911,7 +911,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "JSON layer",
     summary:
-      "JSON layer in GeomRule. GeomRule: Rule geometry: reference lines spanning the panel. TWO HONEST FORMS: (1) annotation — set params.xintercept and/or params.yintercept to fixed data values and map neither aes.x nor aes.y; (2) data-driven — map exactly ONE of aes.x (vertical rules) or aes.y (horizontal rules) to a field. Never mix the forms in one layer.",
+      "JSON layer in GeomRule. GeomRule: Rule geometry: reference lines spanning the panel. Two forms: (1) annotation — set params.xintercept and/or params.yintercept to fixed data values and map neither aes.x nor aes.y; (2) data-driven — map exactly one of aes.x (vertical rules) or aes.y (horizontal rules) to a field. Never mix the forms in one layer.",
     href: "/reference/geoms/rule#json",
     keywords: ["GeomRule", "documentation"],
     exact: ["JSON layer"],
@@ -921,7 +921,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Params",
     summary:
-      "Params in GeomRule. GeomRule: Rule geometry: reference lines spanning the panel. TWO HONEST FORMS: (1) annotation — set params.xintercept and/or params.yintercept to fixed data values and map neither aes.x nor aes.y; (2) data-driven — map exactly ONE of aes.x (vertical rules) or aes.y (horizontal rules) to a field. Never mix the forms in one layer.",
+      "Params in GeomRule. GeomRule: Rule geometry: reference lines spanning the panel. Two forms: (1) annotation — set params.xintercept and/or params.yintercept to fixed data values and map neither aes.x nor aes.y; (2) data-driven — map exactly one of aes.x (vertical rules) or aes.y (horizontal rules) to a field. Never mix the forms in one layer.",
     href: "/reference/geoms/rule#params",
     keywords: ["GeomRule", "documentation"],
     exact: ["Params"],
@@ -931,7 +931,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed stats",
     summary:
-      "Allowed stats in GeomRule. GeomRule: Rule geometry: reference lines spanning the panel. TWO HONEST FORMS: (1) annotation — set params.xintercept and/or params.yintercept to fixed data values and map neither aes.x nor aes.y; (2) data-driven — map exactly ONE of aes.x (vertical rules) or aes.y (horizontal rules) to a field. Never mix the forms in one layer.",
+      "Allowed stats in GeomRule. GeomRule: Rule geometry: reference lines spanning the panel. Two forms: (1) annotation — set params.xintercept and/or params.yintercept to fixed data values and map neither aes.x nor aes.y; (2) data-driven — map exactly one of aes.x (vertical rules) or aes.y (horizontal rules) to a field. Never mix the forms in one layer.",
     href: "/reference/geoms/rule#allowed-stats",
     keywords: ["GeomRule", "documentation"],
     exact: ["Allowed stats"],
@@ -941,7 +941,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed positions",
     summary:
-      "Allowed positions in GeomRule. GeomRule: Rule geometry: reference lines spanning the panel. TWO HONEST FORMS: (1) annotation — set params.xintercept and/or params.yintercept to fixed data values and map neither aes.x nor aes.y; (2) data-driven — map exactly ONE of aes.x (vertical rules) or aes.y (horizontal rules) to a field. Never mix the forms in one layer.",
+      "Allowed positions in GeomRule. GeomRule: Rule geometry: reference lines spanning the panel. Two forms: (1) annotation — set params.xintercept and/or params.yintercept to fixed data values and map neither aes.x nor aes.y; (2) data-driven — map exactly one of aes.x (vertical rules) or aes.y (horizontal rules) to a field. Never mix the forms in one layer.",
     href: "/reference/geoms/rule#allowed-positions",
     keywords: ["GeomRule", "documentation"],
     exact: ["Allowed positions"],
@@ -951,7 +951,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Examples",
     summary:
-      "Examples in GeomRule. GeomRule: Rule geometry: reference lines spanning the panel. TWO HONEST FORMS: (1) annotation — set params.xintercept and/or params.yintercept to fixed data values and map neither aes.x nor aes.y; (2) data-driven — map exactly ONE of aes.x (vertical rules) or aes.y (horizontal rules) to a field. Never mix the forms in one layer.",
+      "Examples in GeomRule. GeomRule: Rule geometry: reference lines spanning the panel. Two forms: (1) annotation — set params.xintercept and/or params.yintercept to fixed data values and map neither aes.x nor aes.y; (2) data-driven — map exactly one of aes.x (vertical rules) or aes.y (horizontal rules) to a field. Never mix the forms in one layer.",
     href: "/reference/geoms/rule#examples",
     keywords: ["GeomRule", "documentation"],
     exact: ["Examples"],
@@ -961,7 +961,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "page",
     title: "GeomHline",
     summary:
-      "GeomHline: Horizontal reference-line alias (ggplot2's geom_hline). Canonicalized by normalize() to a rule layer. Annotation form: set params.yintercept. Data-driven form: map aes.y (inherited plot x is dropped so the one-axis rule contract holds).",
+      "GeomHline: Horizontal reference-line alias. Canonicalized by normalize() to a rule layer. Annotation form: set params.yintercept. Data-driven form: map aes.y (inherited plot x is dropped so the one-axis rule contract holds).",
     href: "/reference/geoms/hline",
     keywords: [],
     exact: ["GeomHline"],
@@ -971,7 +971,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Defaults",
     summary:
-      "Defaults in GeomHline. GeomHline: Horizontal reference-line alias (ggplot2's geom_hline). Canonicalized by normalize() to a rule layer. Annotation form: set params.yintercept. Data-driven form: map aes.y (inherited plot x is dropped so the one-axis rule contract holds).",
+      "Defaults in GeomHline. GeomHline: Horizontal reference-line alias. Canonicalized by normalize() to a rule layer. Annotation form: set params.yintercept. Data-driven form: map aes.y (inherited plot x is dropped so the one-axis rule contract holds).",
     href: "/reference/geoms/hline#defaults",
     keywords: ["GeomHline", "documentation"],
     exact: ["Defaults"],
@@ -981,7 +981,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Alias",
     summary:
-      "Alias in GeomHline. GeomHline: Horizontal reference-line alias (ggplot2's geom_hline). Canonicalized by normalize() to a rule layer. Annotation form: set params.yintercept. Data-driven form: map aes.y (inherited plot x is dropped so the one-axis rule contract holds).",
+      "Alias in GeomHline. GeomHline: Horizontal reference-line alias. Canonicalized by normalize() to a rule layer. Annotation form: set params.yintercept. Data-driven form: map aes.y (inherited plot x is dropped so the one-axis rule contract holds).",
     href: "/reference/geoms/hline#alias",
     keywords: ["GeomHline", "documentation"],
     exact: ["Alias"],
@@ -991,7 +991,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Svelte component",
     summary:
-      "Svelte component in GeomHline. GeomHline: Horizontal reference-line alias (ggplot2's geom_hline). Canonicalized by normalize() to a rule layer. Annotation form: set params.yintercept. Data-driven form: map aes.y (inherited plot x is dropped so the one-axis rule contract holds).",
+      "Svelte component in GeomHline. GeomHline: Horizontal reference-line alias. Canonicalized by normalize() to a rule layer. Annotation form: set params.yintercept. Data-driven form: map aes.y (inherited plot x is dropped so the one-axis rule contract holds).",
     href: "/reference/geoms/hline#svelte",
     keywords: ["GeomHline", "documentation"],
     exact: ["Svelte component"],
@@ -1001,7 +1001,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "JSON layer",
     summary:
-      "JSON layer in GeomHline. GeomHline: Horizontal reference-line alias (ggplot2's geom_hline). Canonicalized by normalize() to a rule layer. Annotation form: set params.yintercept. Data-driven form: map aes.y (inherited plot x is dropped so the one-axis rule contract holds).",
+      "JSON layer in GeomHline. GeomHline: Horizontal reference-line alias. Canonicalized by normalize() to a rule layer. Annotation form: set params.yintercept. Data-driven form: map aes.y (inherited plot x is dropped so the one-axis rule contract holds).",
     href: "/reference/geoms/hline#json",
     keywords: ["GeomHline", "documentation"],
     exact: ["JSON layer"],
@@ -1011,7 +1011,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Params",
     summary:
-      "Params in GeomHline. GeomHline: Horizontal reference-line alias (ggplot2's geom_hline). Canonicalized by normalize() to a rule layer. Annotation form: set params.yintercept. Data-driven form: map aes.y (inherited plot x is dropped so the one-axis rule contract holds).",
+      "Params in GeomHline. GeomHline: Horizontal reference-line alias. Canonicalized by normalize() to a rule layer. Annotation form: set params.yintercept. Data-driven form: map aes.y (inherited plot x is dropped so the one-axis rule contract holds).",
     href: "/reference/geoms/hline#params",
     keywords: ["GeomHline", "documentation"],
     exact: ["Params"],
@@ -1021,7 +1021,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed stats",
     summary:
-      "Allowed stats in GeomHline. GeomHline: Horizontal reference-line alias (ggplot2's geom_hline). Canonicalized by normalize() to a rule layer. Annotation form: set params.yintercept. Data-driven form: map aes.y (inherited plot x is dropped so the one-axis rule contract holds).",
+      "Allowed stats in GeomHline. GeomHline: Horizontal reference-line alias. Canonicalized by normalize() to a rule layer. Annotation form: set params.yintercept. Data-driven form: map aes.y (inherited plot x is dropped so the one-axis rule contract holds).",
     href: "/reference/geoms/hline#allowed-stats",
     keywords: ["GeomHline", "documentation"],
     exact: ["Allowed stats"],
@@ -1031,7 +1031,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed positions",
     summary:
-      "Allowed positions in GeomHline. GeomHline: Horizontal reference-line alias (ggplot2's geom_hline). Canonicalized by normalize() to a rule layer. Annotation form: set params.yintercept. Data-driven form: map aes.y (inherited plot x is dropped so the one-axis rule contract holds).",
+      "Allowed positions in GeomHline. GeomHline: Horizontal reference-line alias. Canonicalized by normalize() to a rule layer. Annotation form: set params.yintercept. Data-driven form: map aes.y (inherited plot x is dropped so the one-axis rule contract holds).",
     href: "/reference/geoms/hline#allowed-positions",
     keywords: ["GeomHline", "documentation"],
     exact: ["Allowed positions"],
@@ -1041,7 +1041,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Examples",
     summary:
-      "Examples in GeomHline. GeomHline: Horizontal reference-line alias (ggplot2's geom_hline). Canonicalized by normalize() to a rule layer. Annotation form: set params.yintercept. Data-driven form: map aes.y (inherited plot x is dropped so the one-axis rule contract holds).",
+      "Examples in GeomHline. GeomHline: Horizontal reference-line alias. Canonicalized by normalize() to a rule layer. Annotation form: set params.yintercept. Data-driven form: map aes.y (inherited plot x is dropped so the one-axis rule contract holds).",
     href: "/reference/geoms/hline#examples",
     keywords: ["GeomHline", "documentation"],
     exact: ["Examples"],
@@ -1051,7 +1051,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "page",
     title: "GeomVline",
     summary:
-      "GeomVline: Vertical reference-line alias (ggplot2's geom_vline). Canonicalized by normalize() to a rule layer. Annotation form: set params.xintercept. Data-driven form: map aes.x (inherited plot y is dropped so the one-axis rule contract holds).",
+      "GeomVline: Vertical reference-line alias. Canonicalized by normalize() to a rule layer. Annotation form: set params.xintercept. Data-driven form: map aes.x (inherited plot y is dropped so the one-axis rule contract holds).",
     href: "/reference/geoms/vline",
     keywords: [],
     exact: ["GeomVline"],
@@ -1061,7 +1061,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Defaults",
     summary:
-      "Defaults in GeomVline. GeomVline: Vertical reference-line alias (ggplot2's geom_vline). Canonicalized by normalize() to a rule layer. Annotation form: set params.xintercept. Data-driven form: map aes.x (inherited plot y is dropped so the one-axis rule contract holds).",
+      "Defaults in GeomVline. GeomVline: Vertical reference-line alias. Canonicalized by normalize() to a rule layer. Annotation form: set params.xintercept. Data-driven form: map aes.x (inherited plot y is dropped so the one-axis rule contract holds).",
     href: "/reference/geoms/vline#defaults",
     keywords: ["GeomVline", "documentation"],
     exact: ["Defaults"],
@@ -1071,7 +1071,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Alias",
     summary:
-      "Alias in GeomVline. GeomVline: Vertical reference-line alias (ggplot2's geom_vline). Canonicalized by normalize() to a rule layer. Annotation form: set params.xintercept. Data-driven form: map aes.x (inherited plot y is dropped so the one-axis rule contract holds).",
+      "Alias in GeomVline. GeomVline: Vertical reference-line alias. Canonicalized by normalize() to a rule layer. Annotation form: set params.xintercept. Data-driven form: map aes.x (inherited plot y is dropped so the one-axis rule contract holds).",
     href: "/reference/geoms/vline#alias",
     keywords: ["GeomVline", "documentation"],
     exact: ["Alias"],
@@ -1081,7 +1081,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Svelte component",
     summary:
-      "Svelte component in GeomVline. GeomVline: Vertical reference-line alias (ggplot2's geom_vline). Canonicalized by normalize() to a rule layer. Annotation form: set params.xintercept. Data-driven form: map aes.x (inherited plot y is dropped so the one-axis rule contract holds).",
+      "Svelte component in GeomVline. GeomVline: Vertical reference-line alias. Canonicalized by normalize() to a rule layer. Annotation form: set params.xintercept. Data-driven form: map aes.x (inherited plot y is dropped so the one-axis rule contract holds).",
     href: "/reference/geoms/vline#svelte",
     keywords: ["GeomVline", "documentation"],
     exact: ["Svelte component"],
@@ -1091,7 +1091,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "JSON layer",
     summary:
-      "JSON layer in GeomVline. GeomVline: Vertical reference-line alias (ggplot2's geom_vline). Canonicalized by normalize() to a rule layer. Annotation form: set params.xintercept. Data-driven form: map aes.x (inherited plot y is dropped so the one-axis rule contract holds).",
+      "JSON layer in GeomVline. GeomVline: Vertical reference-line alias. Canonicalized by normalize() to a rule layer. Annotation form: set params.xintercept. Data-driven form: map aes.x (inherited plot y is dropped so the one-axis rule contract holds).",
     href: "/reference/geoms/vline#json",
     keywords: ["GeomVline", "documentation"],
     exact: ["JSON layer"],
@@ -1101,7 +1101,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Params",
     summary:
-      "Params in GeomVline. GeomVline: Vertical reference-line alias (ggplot2's geom_vline). Canonicalized by normalize() to a rule layer. Annotation form: set params.xintercept. Data-driven form: map aes.x (inherited plot y is dropped so the one-axis rule contract holds).",
+      "Params in GeomVline. GeomVline: Vertical reference-line alias. Canonicalized by normalize() to a rule layer. Annotation form: set params.xintercept. Data-driven form: map aes.x (inherited plot y is dropped so the one-axis rule contract holds).",
     href: "/reference/geoms/vline#params",
     keywords: ["GeomVline", "documentation"],
     exact: ["Params"],
@@ -1111,7 +1111,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed stats",
     summary:
-      "Allowed stats in GeomVline. GeomVline: Vertical reference-line alias (ggplot2's geom_vline). Canonicalized by normalize() to a rule layer. Annotation form: set params.xintercept. Data-driven form: map aes.x (inherited plot y is dropped so the one-axis rule contract holds).",
+      "Allowed stats in GeomVline. GeomVline: Vertical reference-line alias. Canonicalized by normalize() to a rule layer. Annotation form: set params.xintercept. Data-driven form: map aes.x (inherited plot y is dropped so the one-axis rule contract holds).",
     href: "/reference/geoms/vline#allowed-stats",
     keywords: ["GeomVline", "documentation"],
     exact: ["Allowed stats"],
@@ -1121,7 +1121,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed positions",
     summary:
-      "Allowed positions in GeomVline. GeomVline: Vertical reference-line alias (ggplot2's geom_vline). Canonicalized by normalize() to a rule layer. Annotation form: set params.xintercept. Data-driven form: map aes.x (inherited plot y is dropped so the one-axis rule contract holds).",
+      "Allowed positions in GeomVline. GeomVline: Vertical reference-line alias. Canonicalized by normalize() to a rule layer. Annotation form: set params.xintercept. Data-driven form: map aes.x (inherited plot y is dropped so the one-axis rule contract holds).",
     href: "/reference/geoms/vline#allowed-positions",
     keywords: ["GeomVline", "documentation"],
     exact: ["Allowed positions"],
@@ -1131,7 +1131,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Examples",
     summary:
-      "Examples in GeomVline. GeomVline: Vertical reference-line alias (ggplot2's geom_vline). Canonicalized by normalize() to a rule layer. Annotation form: set params.xintercept. Data-driven form: map aes.x (inherited plot y is dropped so the one-axis rule contract holds).",
+      "Examples in GeomVline. GeomVline: Vertical reference-line alias. Canonicalized by normalize() to a rule layer. Annotation form: set params.xintercept. Data-driven form: map aes.x (inherited plot y is dropped so the one-axis rule contract holds).",
     href: "/reference/geoms/vline#examples",
     keywords: ["GeomVline", "documentation"],
     exact: ["Examples"],
@@ -1221,7 +1221,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "page",
     title: "GeomLabel",
     summary:
-      "GeomLabel: Label geometry: text with a rounded rectangular background box (ggplot2 geom_label). Requires x, y, and label channels. No collision detection.",
+      "GeomLabel: Label geometry: text with a rounded rectangular background box. Requires x, y, and label channels. No collision detection.",
     href: "/reference/geoms/label",
     keywords: [],
     exact: ["GeomLabel"],
@@ -1231,7 +1231,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Defaults",
     summary:
-      "Defaults in GeomLabel. GeomLabel: Label geometry: text with a rounded rectangular background box (ggplot2 geom_label). Requires x, y, and label channels. No collision detection.",
+      "Defaults in GeomLabel. GeomLabel: Label geometry: text with a rounded rectangular background box. Requires x, y, and label channels. No collision detection.",
     href: "/reference/geoms/label#defaults",
     keywords: ["GeomLabel", "documentation"],
     exact: ["Defaults"],
@@ -1241,7 +1241,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Svelte component",
     summary:
-      "Svelte component in GeomLabel. GeomLabel: Label geometry: text with a rounded rectangular background box (ggplot2 geom_label). Requires x, y, and label channels. No collision detection.",
+      "Svelte component in GeomLabel. GeomLabel: Label geometry: text with a rounded rectangular background box. Requires x, y, and label channels. No collision detection.",
     href: "/reference/geoms/label#svelte",
     keywords: ["GeomLabel", "documentation"],
     exact: ["Svelte component"],
@@ -1251,7 +1251,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "JSON layer",
     summary:
-      "JSON layer in GeomLabel. GeomLabel: Label geometry: text with a rounded rectangular background box (ggplot2 geom_label). Requires x, y, and label channels. No collision detection.",
+      "JSON layer in GeomLabel. GeomLabel: Label geometry: text with a rounded rectangular background box. Requires x, y, and label channels. No collision detection.",
     href: "/reference/geoms/label#json",
     keywords: ["GeomLabel", "documentation"],
     exact: ["JSON layer"],
@@ -1261,7 +1261,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Params",
     summary:
-      "Params in GeomLabel. GeomLabel: Label geometry: text with a rounded rectangular background box (ggplot2 geom_label). Requires x, y, and label channels. No collision detection.",
+      "Params in GeomLabel. GeomLabel: Label geometry: text with a rounded rectangular background box. Requires x, y, and label channels. No collision detection.",
     href: "/reference/geoms/label#params",
     keywords: ["GeomLabel", "documentation"],
     exact: ["Params"],
@@ -1271,7 +1271,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed stats",
     summary:
-      "Allowed stats in GeomLabel. GeomLabel: Label geometry: text with a rounded rectangular background box (ggplot2 geom_label). Requires x, y, and label channels. No collision detection.",
+      "Allowed stats in GeomLabel. GeomLabel: Label geometry: text with a rounded rectangular background box. Requires x, y, and label channels. No collision detection.",
     href: "/reference/geoms/label#allowed-stats",
     keywords: ["GeomLabel", "documentation"],
     exact: ["Allowed stats"],
@@ -1281,7 +1281,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed positions",
     summary:
-      "Allowed positions in GeomLabel. GeomLabel: Label geometry: text with a rounded rectangular background box (ggplot2 geom_label). Requires x, y, and label channels. No collision detection.",
+      "Allowed positions in GeomLabel. GeomLabel: Label geometry: text with a rounded rectangular background box. Requires x, y, and label channels. No collision detection.",
     href: "/reference/geoms/label#allowed-positions",
     keywords: ["GeomLabel", "documentation"],
     exact: ["Allowed positions"],
@@ -1291,7 +1291,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Examples",
     summary:
-      "Examples in GeomLabel. GeomLabel: Label geometry: text with a rounded rectangular background box (ggplot2 geom_label). Requires x, y, and label channels. No collision detection.",
+      "Examples in GeomLabel. GeomLabel: Label geometry: text with a rounded rectangular background box. Requires x, y, and label channels. No collision detection.",
     href: "/reference/geoms/label#examples",
     keywords: ["GeomLabel", "documentation"],
     exact: ["Examples"],
@@ -1301,7 +1301,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "page",
     title: "GeomSmooth",
     summary:
-      "GeomSmooth: Smooth geometry: a fitted trend line (with an optional confidence ribbon) over an x/y scatter, one fit per group. Use to reveal trends (ggplot2's geom_smooth).",
+      "GeomSmooth: Smooth geometry: a fitted trend line (with an optional confidence ribbon) over an x/y scatter, one fit per group. Use to reveal trends.",
     href: "/reference/geoms/smooth",
     keywords: [],
     exact: ["GeomSmooth"],
@@ -1311,7 +1311,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Defaults",
     summary:
-      "Defaults in GeomSmooth. GeomSmooth: Smooth geometry: a fitted trend line (with an optional confidence ribbon) over an x/y scatter, one fit per group. Use to reveal trends (ggplot2's geom_smooth).",
+      "Defaults in GeomSmooth. GeomSmooth: Smooth geometry: a fitted trend line (with an optional confidence ribbon) over an x/y scatter, one fit per group. Use to reveal trends.",
     href: "/reference/geoms/smooth#defaults",
     keywords: ["GeomSmooth", "documentation"],
     exact: ["Defaults"],
@@ -1321,7 +1321,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Svelte component",
     summary:
-      "Svelte component in GeomSmooth. GeomSmooth: Smooth geometry: a fitted trend line (with an optional confidence ribbon) over an x/y scatter, one fit per group. Use to reveal trends (ggplot2's geom_smooth).",
+      "Svelte component in GeomSmooth. GeomSmooth: Smooth geometry: a fitted trend line (with an optional confidence ribbon) over an x/y scatter, one fit per group. Use to reveal trends.",
     href: "/reference/geoms/smooth#svelte",
     keywords: ["GeomSmooth", "documentation"],
     exact: ["Svelte component"],
@@ -1331,7 +1331,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "JSON layer",
     summary:
-      "JSON layer in GeomSmooth. GeomSmooth: Smooth geometry: a fitted trend line (with an optional confidence ribbon) over an x/y scatter, one fit per group. Use to reveal trends (ggplot2's geom_smooth).",
+      "JSON layer in GeomSmooth. GeomSmooth: Smooth geometry: a fitted trend line (with an optional confidence ribbon) over an x/y scatter, one fit per group. Use to reveal trends.",
     href: "/reference/geoms/smooth#json",
     keywords: ["GeomSmooth", "documentation"],
     exact: ["JSON layer"],
@@ -1341,7 +1341,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Params",
     summary:
-      "Params in GeomSmooth. GeomSmooth: Smooth geometry: a fitted trend line (with an optional confidence ribbon) over an x/y scatter, one fit per group. Use to reveal trends (ggplot2's geom_smooth).",
+      "Params in GeomSmooth. GeomSmooth: Smooth geometry: a fitted trend line (with an optional confidence ribbon) over an x/y scatter, one fit per group. Use to reveal trends.",
     href: "/reference/geoms/smooth#params",
     keywords: ["GeomSmooth", "documentation"],
     exact: ["Params"],
@@ -1351,7 +1351,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed stats",
     summary:
-      "Allowed stats in GeomSmooth. GeomSmooth: Smooth geometry: a fitted trend line (with an optional confidence ribbon) over an x/y scatter, one fit per group. Use to reveal trends (ggplot2's geom_smooth).",
+      "Allowed stats in GeomSmooth. GeomSmooth: Smooth geometry: a fitted trend line (with an optional confidence ribbon) over an x/y scatter, one fit per group. Use to reveal trends.",
     href: "/reference/geoms/smooth#allowed-stats",
     keywords: ["GeomSmooth", "documentation"],
     exact: ["Allowed stats"],
@@ -1361,7 +1361,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed positions",
     summary:
-      "Allowed positions in GeomSmooth. GeomSmooth: Smooth geometry: a fitted trend line (with an optional confidence ribbon) over an x/y scatter, one fit per group. Use to reveal trends (ggplot2's geom_smooth).",
+      "Allowed positions in GeomSmooth. GeomSmooth: Smooth geometry: a fitted trend line (with an optional confidence ribbon) over an x/y scatter, one fit per group. Use to reveal trends.",
     href: "/reference/geoms/smooth#allowed-positions",
     keywords: ["GeomSmooth", "documentation"],
     exact: ["Allowed positions"],
@@ -1371,7 +1371,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Examples",
     summary:
-      "Examples in GeomSmooth. GeomSmooth: Smooth geometry: a fitted trend line (with an optional confidence ribbon) over an x/y scatter, one fit per group. Use to reveal trends (ggplot2's geom_smooth).",
+      "Examples in GeomSmooth. GeomSmooth: Smooth geometry: a fitted trend line (with an optional confidence ribbon) over an x/y scatter, one fit per group. Use to reveal trends.",
     href: "/reference/geoms/smooth#examples",
     keywords: ["GeomSmooth", "documentation"],
     exact: ["Examples"],
@@ -1381,7 +1381,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "page",
     title: "GeomQuantile",
     summary:
-      "GeomQuantile: Quantile geometry: linear quantile regression lines (y ~ x) at one or more conditional quantiles of y, one line per quantile per group (ggplot2 geom_quantile / #805).",
+      "GeomQuantile: Quantile geometry: linear quantile regression lines (y ~ x) at one or more conditional quantiles of y, one line per quantile per group.",
     href: "/reference/geoms/quantile",
     keywords: [],
     exact: ["GeomQuantile"],
@@ -1391,7 +1391,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Defaults",
     summary:
-      "Defaults in GeomQuantile. GeomQuantile: Quantile geometry: linear quantile regression lines (y ~ x) at one or more conditional quantiles of y, one line per quantile per group (ggplot2 geom_quantile / #805).",
+      "Defaults in GeomQuantile. GeomQuantile: Quantile geometry: linear quantile regression lines (y ~ x) at one or more conditional quantiles of y, one line per quantile per group.",
     href: "/reference/geoms/quantile#defaults",
     keywords: ["GeomQuantile", "documentation"],
     exact: ["Defaults"],
@@ -1401,7 +1401,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Svelte component",
     summary:
-      "Svelte component in GeomQuantile. GeomQuantile: Quantile geometry: linear quantile regression lines (y ~ x) at one or more conditional quantiles of y, one line per quantile per group (ggplot2 geom_quantile / #805).",
+      "Svelte component in GeomQuantile. GeomQuantile: Quantile geometry: linear quantile regression lines (y ~ x) at one or more conditional quantiles of y, one line per quantile per group.",
     href: "/reference/geoms/quantile#svelte",
     keywords: ["GeomQuantile", "documentation"],
     exact: ["Svelte component"],
@@ -1411,7 +1411,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "JSON layer",
     summary:
-      "JSON layer in GeomQuantile. GeomQuantile: Quantile geometry: linear quantile regression lines (y ~ x) at one or more conditional quantiles of y, one line per quantile per group (ggplot2 geom_quantile / #805).",
+      "JSON layer in GeomQuantile. GeomQuantile: Quantile geometry: linear quantile regression lines (y ~ x) at one or more conditional quantiles of y, one line per quantile per group.",
     href: "/reference/geoms/quantile#json",
     keywords: ["GeomQuantile", "documentation"],
     exact: ["JSON layer"],
@@ -1421,7 +1421,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Params",
     summary:
-      "Params in GeomQuantile. GeomQuantile: Quantile geometry: linear quantile regression lines (y ~ x) at one or more conditional quantiles of y, one line per quantile per group (ggplot2 geom_quantile / #805).",
+      "Params in GeomQuantile. GeomQuantile: Quantile geometry: linear quantile regression lines (y ~ x) at one or more conditional quantiles of y, one line per quantile per group.",
     href: "/reference/geoms/quantile#params",
     keywords: ["GeomQuantile", "documentation"],
     exact: ["Params"],
@@ -1431,7 +1431,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed stats",
     summary:
-      "Allowed stats in GeomQuantile. GeomQuantile: Quantile geometry: linear quantile regression lines (y ~ x) at one or more conditional quantiles of y, one line per quantile per group (ggplot2 geom_quantile / #805).",
+      "Allowed stats in GeomQuantile. GeomQuantile: Quantile geometry: linear quantile regression lines (y ~ x) at one or more conditional quantiles of y, one line per quantile per group.",
     href: "/reference/geoms/quantile#allowed-stats",
     keywords: ["GeomQuantile", "documentation"],
     exact: ["Allowed stats"],
@@ -1441,7 +1441,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed positions",
     summary:
-      "Allowed positions in GeomQuantile. GeomQuantile: Quantile geometry: linear quantile regression lines (y ~ x) at one or more conditional quantiles of y, one line per quantile per group (ggplot2 geom_quantile / #805).",
+      "Allowed positions in GeomQuantile. GeomQuantile: Quantile geometry: linear quantile regression lines (y ~ x) at one or more conditional quantiles of y, one line per quantile per group.",
     href: "/reference/geoms/quantile#allowed-positions",
     keywords: ["GeomQuantile", "documentation"],
     exact: ["Allowed positions"],
@@ -1451,7 +1451,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Examples",
     summary:
-      "Examples in GeomQuantile. GeomQuantile: Quantile geometry: linear quantile regression lines (y ~ x) at one or more conditional quantiles of y, one line per quantile per group (ggplot2 geom_quantile / #805).",
+      "Examples in GeomQuantile. GeomQuantile: Quantile geometry: linear quantile regression lines (y ~ x) at one or more conditional quantiles of y, one line per quantile per group.",
     href: "/reference/geoms/quantile#examples",
     keywords: ["GeomQuantile", "documentation"],
     exact: ["Examples"],
@@ -1701,7 +1701,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "page",
     title: "GeomLinerange",
     summary:
-      "GeomLinerange: Linerange geometry: a vertical stem from ymin to ymax without end caps (ggplot2 geom_linerange).",
+      "GeomLinerange: Linerange geometry: a vertical stem from ymin to ymax without end caps.",
     href: "/reference/geoms/linerange",
     keywords: [],
     exact: ["GeomLinerange"],
@@ -1711,7 +1711,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Defaults",
     summary:
-      "Defaults in GeomLinerange. GeomLinerange: Linerange geometry: a vertical stem from ymin to ymax without end caps (ggplot2 geom_linerange).",
+      "Defaults in GeomLinerange. GeomLinerange: Linerange geometry: a vertical stem from ymin to ymax without end caps.",
     href: "/reference/geoms/linerange#defaults",
     keywords: ["GeomLinerange", "documentation"],
     exact: ["Defaults"],
@@ -1721,7 +1721,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Svelte component",
     summary:
-      "Svelte component in GeomLinerange. GeomLinerange: Linerange geometry: a vertical stem from ymin to ymax without end caps (ggplot2 geom_linerange).",
+      "Svelte component in GeomLinerange. GeomLinerange: Linerange geometry: a vertical stem from ymin to ymax without end caps.",
     href: "/reference/geoms/linerange#svelte",
     keywords: ["GeomLinerange", "documentation"],
     exact: ["Svelte component"],
@@ -1731,7 +1731,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "JSON layer",
     summary:
-      "JSON layer in GeomLinerange. GeomLinerange: Linerange geometry: a vertical stem from ymin to ymax without end caps (ggplot2 geom_linerange).",
+      "JSON layer in GeomLinerange. GeomLinerange: Linerange geometry: a vertical stem from ymin to ymax without end caps.",
     href: "/reference/geoms/linerange#json",
     keywords: ["GeomLinerange", "documentation"],
     exact: ["JSON layer"],
@@ -1741,7 +1741,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Params",
     summary:
-      "Params in GeomLinerange. GeomLinerange: Linerange geometry: a vertical stem from ymin to ymax without end caps (ggplot2 geom_linerange).",
+      "Params in GeomLinerange. GeomLinerange: Linerange geometry: a vertical stem from ymin to ymax without end caps.",
     href: "/reference/geoms/linerange#params",
     keywords: ["GeomLinerange", "documentation"],
     exact: ["Params"],
@@ -1751,7 +1751,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed stats",
     summary:
-      "Allowed stats in GeomLinerange. GeomLinerange: Linerange geometry: a vertical stem from ymin to ymax without end caps (ggplot2 geom_linerange).",
+      "Allowed stats in GeomLinerange. GeomLinerange: Linerange geometry: a vertical stem from ymin to ymax without end caps.",
     href: "/reference/geoms/linerange#allowed-stats",
     keywords: ["GeomLinerange", "documentation"],
     exact: ["Allowed stats"],
@@ -1761,7 +1761,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed positions",
     summary:
-      "Allowed positions in GeomLinerange. GeomLinerange: Linerange geometry: a vertical stem from ymin to ymax without end caps (ggplot2 geom_linerange).",
+      "Allowed positions in GeomLinerange. GeomLinerange: Linerange geometry: a vertical stem from ymin to ymax without end caps.",
     href: "/reference/geoms/linerange#allowed-positions",
     keywords: ["GeomLinerange", "documentation"],
     exact: ["Allowed positions"],
@@ -1771,7 +1771,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "page",
     title: "GeomPointrange",
     summary:
-      "GeomPointrange: Pointrange geometry: vertical stem from ymin to ymax plus a point at (x, y) (ggplot2 geom_pointrange).",
+      "GeomPointrange: Pointrange geometry: vertical stem from ymin to ymax plus a point at (x, y).",
     href: "/reference/geoms/pointrange",
     keywords: [],
     exact: ["GeomPointrange"],
@@ -1781,7 +1781,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Defaults",
     summary:
-      "Defaults in GeomPointrange. GeomPointrange: Pointrange geometry: vertical stem from ymin to ymax plus a point at (x, y) (ggplot2 geom_pointrange).",
+      "Defaults in GeomPointrange. GeomPointrange: Pointrange geometry: vertical stem from ymin to ymax plus a point at (x, y).",
     href: "/reference/geoms/pointrange#defaults",
     keywords: ["GeomPointrange", "documentation"],
     exact: ["Defaults"],
@@ -1791,7 +1791,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Svelte component",
     summary:
-      "Svelte component in GeomPointrange. GeomPointrange: Pointrange geometry: vertical stem from ymin to ymax plus a point at (x, y) (ggplot2 geom_pointrange).",
+      "Svelte component in GeomPointrange. GeomPointrange: Pointrange geometry: vertical stem from ymin to ymax plus a point at (x, y).",
     href: "/reference/geoms/pointrange#svelte",
     keywords: ["GeomPointrange", "documentation"],
     exact: ["Svelte component"],
@@ -1801,7 +1801,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "JSON layer",
     summary:
-      "JSON layer in GeomPointrange. GeomPointrange: Pointrange geometry: vertical stem from ymin to ymax plus a point at (x, y) (ggplot2 geom_pointrange).",
+      "JSON layer in GeomPointrange. GeomPointrange: Pointrange geometry: vertical stem from ymin to ymax plus a point at (x, y).",
     href: "/reference/geoms/pointrange#json",
     keywords: ["GeomPointrange", "documentation"],
     exact: ["JSON layer"],
@@ -1811,7 +1811,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Params",
     summary:
-      "Params in GeomPointrange. GeomPointrange: Pointrange geometry: vertical stem from ymin to ymax plus a point at (x, y) (ggplot2 geom_pointrange).",
+      "Params in GeomPointrange. GeomPointrange: Pointrange geometry: vertical stem from ymin to ymax plus a point at (x, y).",
     href: "/reference/geoms/pointrange#params",
     keywords: ["GeomPointrange", "documentation"],
     exact: ["Params"],
@@ -1821,7 +1821,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed stats",
     summary:
-      "Allowed stats in GeomPointrange. GeomPointrange: Pointrange geometry: vertical stem from ymin to ymax plus a point at (x, y) (ggplot2 geom_pointrange).",
+      "Allowed stats in GeomPointrange. GeomPointrange: Pointrange geometry: vertical stem from ymin to ymax plus a point at (x, y).",
     href: "/reference/geoms/pointrange#allowed-stats",
     keywords: ["GeomPointrange", "documentation"],
     exact: ["Allowed stats"],
@@ -1831,7 +1831,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed positions",
     summary:
-      "Allowed positions in GeomPointrange. GeomPointrange: Pointrange geometry: vertical stem from ymin to ymax plus a point at (x, y) (ggplot2 geom_pointrange).",
+      "Allowed positions in GeomPointrange. GeomPointrange: Pointrange geometry: vertical stem from ymin to ymax plus a point at (x, y).",
     href: "/reference/geoms/pointrange#allowed-positions",
     keywords: ["GeomPointrange", "documentation"],
     exact: ["Allowed positions"],
@@ -1841,7 +1841,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "page",
     title: "GeomCrossbar",
     summary:
-      "GeomCrossbar: Crossbar geometry: a vertical interval box from ymin to ymax with a mid horizontal line at y (ggplot2 geom_crossbar).",
+      "GeomCrossbar: Crossbar geometry: a vertical interval box from ymin to ymax with a mid horizontal line at y.",
     href: "/reference/geoms/crossbar",
     keywords: [],
     exact: ["GeomCrossbar"],
@@ -1851,7 +1851,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Defaults",
     summary:
-      "Defaults in GeomCrossbar. GeomCrossbar: Crossbar geometry: a vertical interval box from ymin to ymax with a mid horizontal line at y (ggplot2 geom_crossbar).",
+      "Defaults in GeomCrossbar. GeomCrossbar: Crossbar geometry: a vertical interval box from ymin to ymax with a mid horizontal line at y.",
     href: "/reference/geoms/crossbar#defaults",
     keywords: ["GeomCrossbar", "documentation"],
     exact: ["Defaults"],
@@ -1861,7 +1861,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Svelte component",
     summary:
-      "Svelte component in GeomCrossbar. GeomCrossbar: Crossbar geometry: a vertical interval box from ymin to ymax with a mid horizontal line at y (ggplot2 geom_crossbar).",
+      "Svelte component in GeomCrossbar. GeomCrossbar: Crossbar geometry: a vertical interval box from ymin to ymax with a mid horizontal line at y.",
     href: "/reference/geoms/crossbar#svelte",
     keywords: ["GeomCrossbar", "documentation"],
     exact: ["Svelte component"],
@@ -1871,7 +1871,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "JSON layer",
     summary:
-      "JSON layer in GeomCrossbar. GeomCrossbar: Crossbar geometry: a vertical interval box from ymin to ymax with a mid horizontal line at y (ggplot2 geom_crossbar).",
+      "JSON layer in GeomCrossbar. GeomCrossbar: Crossbar geometry: a vertical interval box from ymin to ymax with a mid horizontal line at y.",
     href: "/reference/geoms/crossbar#json",
     keywords: ["GeomCrossbar", "documentation"],
     exact: ["JSON layer"],
@@ -1881,7 +1881,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Params",
     summary:
-      "Params in GeomCrossbar. GeomCrossbar: Crossbar geometry: a vertical interval box from ymin to ymax with a mid horizontal line at y (ggplot2 geom_crossbar).",
+      "Params in GeomCrossbar. GeomCrossbar: Crossbar geometry: a vertical interval box from ymin to ymax with a mid horizontal line at y.",
     href: "/reference/geoms/crossbar#params",
     keywords: ["GeomCrossbar", "documentation"],
     exact: ["Params"],
@@ -1891,7 +1891,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed stats",
     summary:
-      "Allowed stats in GeomCrossbar. GeomCrossbar: Crossbar geometry: a vertical interval box from ymin to ymax with a mid horizontal line at y (ggplot2 geom_crossbar).",
+      "Allowed stats in GeomCrossbar. GeomCrossbar: Crossbar geometry: a vertical interval box from ymin to ymax with a mid horizontal line at y.",
     href: "/reference/geoms/crossbar#allowed-stats",
     keywords: ["GeomCrossbar", "documentation"],
     exact: ["Allowed stats"],
@@ -1901,7 +1901,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed positions",
     summary:
-      "Allowed positions in GeomCrossbar. GeomCrossbar: Crossbar geometry: a vertical interval box from ymin to ymax with a mid horizontal line at y (ggplot2 geom_crossbar).",
+      "Allowed positions in GeomCrossbar. GeomCrossbar: Crossbar geometry: a vertical interval box from ymin to ymax with a mid horizontal line at y.",
     href: "/reference/geoms/crossbar#allowed-positions",
     keywords: ["GeomCrossbar", "documentation"],
     exact: ["Allowed positions"],
@@ -2151,7 +2151,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "page",
     title: "GeomRibbon",
     summary:
-      "GeomRibbon: Ribbon geometry: a filled interval between two varying boundaries along a running coordinate (ggplot2's geom_ribbon). Map x+ymin+ymax (x orientation) or y+xmin+xmax (y orientation). Not a zero-baseline area.",
+      "GeomRibbon: Ribbon geometry: a filled interval between two varying boundaries along a running coordinate. Map x+ymin+ymax (x orientation) or y+xmin+xmax (y orientation). Not a zero-baseline area.",
     href: "/reference/geoms/ribbon",
     keywords: [],
     exact: ["GeomRibbon"],
@@ -2161,7 +2161,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Defaults",
     summary:
-      "Defaults in GeomRibbon. GeomRibbon: Ribbon geometry: a filled interval between two varying boundaries along a running coordinate (ggplot2's geom_ribbon). Map x+ymin+ymax (x orientation) or y+xmin+xmax (y orientation). Not a zero-baseline area.",
+      "Defaults in GeomRibbon. GeomRibbon: Ribbon geometry: a filled interval between two varying boundaries along a running coordinate. Map x+ymin+ymax (x orientation) or y+xmin+xmax (y orientation). Not a zero-baseline area.",
     href: "/reference/geoms/ribbon#defaults",
     keywords: ["GeomRibbon", "documentation"],
     exact: ["Defaults"],
@@ -2171,7 +2171,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Svelte component",
     summary:
-      "Svelte component in GeomRibbon. GeomRibbon: Ribbon geometry: a filled interval between two varying boundaries along a running coordinate (ggplot2's geom_ribbon). Map x+ymin+ymax (x orientation) or y+xmin+xmax (y orientation). Not a zero-baseline area.",
+      "Svelte component in GeomRibbon. GeomRibbon: Ribbon geometry: a filled interval between two varying boundaries along a running coordinate. Map x+ymin+ymax (x orientation) or y+xmin+xmax (y orientation). Not a zero-baseline area.",
     href: "/reference/geoms/ribbon#svelte",
     keywords: ["GeomRibbon", "documentation"],
     exact: ["Svelte component"],
@@ -2181,7 +2181,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "JSON layer",
     summary:
-      "JSON layer in GeomRibbon. GeomRibbon: Ribbon geometry: a filled interval between two varying boundaries along a running coordinate (ggplot2's geom_ribbon). Map x+ymin+ymax (x orientation) or y+xmin+xmax (y orientation). Not a zero-baseline area.",
+      "JSON layer in GeomRibbon. GeomRibbon: Ribbon geometry: a filled interval between two varying boundaries along a running coordinate. Map x+ymin+ymax (x orientation) or y+xmin+xmax (y orientation). Not a zero-baseline area.",
     href: "/reference/geoms/ribbon#json",
     keywords: ["GeomRibbon", "documentation"],
     exact: ["JSON layer"],
@@ -2191,7 +2191,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Params",
     summary:
-      "Params in GeomRibbon. GeomRibbon: Ribbon geometry: a filled interval between two varying boundaries along a running coordinate (ggplot2's geom_ribbon). Map x+ymin+ymax (x orientation) or y+xmin+xmax (y orientation). Not a zero-baseline area.",
+      "Params in GeomRibbon. GeomRibbon: Ribbon geometry: a filled interval between two varying boundaries along a running coordinate. Map x+ymin+ymax (x orientation) or y+xmin+xmax (y orientation). Not a zero-baseline area.",
     href: "/reference/geoms/ribbon#params",
     keywords: ["GeomRibbon", "documentation"],
     exact: ["Params"],
@@ -2201,7 +2201,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed stats",
     summary:
-      "Allowed stats in GeomRibbon. GeomRibbon: Ribbon geometry: a filled interval between two varying boundaries along a running coordinate (ggplot2's geom_ribbon). Map x+ymin+ymax (x orientation) or y+xmin+xmax (y orientation). Not a zero-baseline area.",
+      "Allowed stats in GeomRibbon. GeomRibbon: Ribbon geometry: a filled interval between two varying boundaries along a running coordinate. Map x+ymin+ymax (x orientation) or y+xmin+xmax (y orientation). Not a zero-baseline area.",
     href: "/reference/geoms/ribbon#allowed-stats",
     keywords: ["GeomRibbon", "documentation"],
     exact: ["Allowed stats"],
@@ -2211,7 +2211,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed positions",
     summary:
-      "Allowed positions in GeomRibbon. GeomRibbon: Ribbon geometry: a filled interval between two varying boundaries along a running coordinate (ggplot2's geom_ribbon). Map x+ymin+ymax (x orientation) or y+xmin+xmax (y orientation). Not a zero-baseline area.",
+      "Allowed positions in GeomRibbon. GeomRibbon: Ribbon geometry: a filled interval between two varying boundaries along a running coordinate. Map x+ymin+ymax (x orientation) or y+xmin+xmax (y orientation). Not a zero-baseline area.",
     href: "/reference/geoms/ribbon#allowed-positions",
     keywords: ["GeomRibbon", "documentation"],
     exact: ["Allowed positions"],
@@ -2221,7 +2221,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Examples",
     summary:
-      "Examples in GeomRibbon. GeomRibbon: Ribbon geometry: a filled interval between two varying boundaries along a running coordinate (ggplot2's geom_ribbon). Map x+ymin+ymax (x orientation) or y+xmin+xmax (y orientation). Not a zero-baseline area.",
+      "Examples in GeomRibbon. GeomRibbon: Ribbon geometry: a filled interval between two varying boundaries along a running coordinate. Map x+ymin+ymax (x orientation) or y+xmin+xmax (y orientation). Not a zero-baseline area.",
     href: "/reference/geoms/ribbon#examples",
     keywords: ["GeomRibbon", "documentation"],
     exact: ["Examples"],
@@ -2311,7 +2311,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "page",
     title: "GeomCount",
     summary:
-      "GeomCount: Count geometry (ggplot2 geom_count): point marks at unique (x, y) with size scaled by after_stat n (stat sum). Use for overplotting density on discrete or rounded coordinates.",
+      "GeomCount: Count geometry: point marks at unique (x, y) with size scaled by after_stat n (stat sum). Use for overplotting density on discrete or rounded coordinates.",
     href: "/reference/geoms/count",
     keywords: [],
     exact: ["GeomCount"],
@@ -2321,7 +2321,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Defaults",
     summary:
-      "Defaults in GeomCount. GeomCount: Count geometry (ggplot2 geom_count): point marks at unique (x, y) with size scaled by after_stat n (stat sum). Use for overplotting density on discrete or rounded coordinates.",
+      "Defaults in GeomCount. GeomCount: Count geometry: point marks at unique (x, y) with size scaled by after_stat n (stat sum). Use for overplotting density on discrete or rounded coordinates.",
     href: "/reference/geoms/count#defaults",
     keywords: ["GeomCount", "documentation"],
     exact: ["Defaults"],
@@ -2331,7 +2331,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Svelte component",
     summary:
-      "Svelte component in GeomCount. GeomCount: Count geometry (ggplot2 geom_count): point marks at unique (x, y) with size scaled by after_stat n (stat sum). Use for overplotting density on discrete or rounded coordinates.",
+      "Svelte component in GeomCount. GeomCount: Count geometry: point marks at unique (x, y) with size scaled by after_stat n (stat sum). Use for overplotting density on discrete or rounded coordinates.",
     href: "/reference/geoms/count#svelte",
     keywords: ["GeomCount", "documentation"],
     exact: ["Svelte component"],
@@ -2341,7 +2341,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "JSON layer",
     summary:
-      "JSON layer in GeomCount. GeomCount: Count geometry (ggplot2 geom_count): point marks at unique (x, y) with size scaled by after_stat n (stat sum). Use for overplotting density on discrete or rounded coordinates.",
+      "JSON layer in GeomCount. GeomCount: Count geometry: point marks at unique (x, y) with size scaled by after_stat n (stat sum). Use for overplotting density on discrete or rounded coordinates.",
     href: "/reference/geoms/count#json",
     keywords: ["GeomCount", "documentation"],
     exact: ["JSON layer"],
@@ -2351,7 +2351,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Params",
     summary:
-      "Params in GeomCount. GeomCount: Count geometry (ggplot2 geom_count): point marks at unique (x, y) with size scaled by after_stat n (stat sum). Use for overplotting density on discrete or rounded coordinates.",
+      "Params in GeomCount. GeomCount: Count geometry: point marks at unique (x, y) with size scaled by after_stat n (stat sum). Use for overplotting density on discrete or rounded coordinates.",
     href: "/reference/geoms/count#params",
     keywords: ["GeomCount", "documentation"],
     exact: ["Params"],
@@ -2361,7 +2361,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed stats",
     summary:
-      "Allowed stats in GeomCount. GeomCount: Count geometry (ggplot2 geom_count): point marks at unique (x, y) with size scaled by after_stat n (stat sum). Use for overplotting density on discrete or rounded coordinates.",
+      "Allowed stats in GeomCount. GeomCount: Count geometry: point marks at unique (x, y) with size scaled by after_stat n (stat sum). Use for overplotting density on discrete or rounded coordinates.",
     href: "/reference/geoms/count#allowed-stats",
     keywords: ["GeomCount", "documentation"],
     exact: ["Allowed stats"],
@@ -2371,7 +2371,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed positions",
     summary:
-      "Allowed positions in GeomCount. GeomCount: Count geometry (ggplot2 geom_count): point marks at unique (x, y) with size scaled by after_stat n (stat sum). Use for overplotting density on discrete or rounded coordinates.",
+      "Allowed positions in GeomCount. GeomCount: Count geometry: point marks at unique (x, y) with size scaled by after_stat n (stat sum). Use for overplotting density on discrete or rounded coordinates.",
     href: "/reference/geoms/count#allowed-positions",
     keywords: ["GeomCount", "documentation"],
     exact: ["Allowed positions"],
@@ -2381,7 +2381,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Examples",
     summary:
-      "Examples in GeomCount. GeomCount: Count geometry (ggplot2 geom_count): point marks at unique (x, y) with size scaled by after_stat n (stat sum). Use for overplotting density on discrete or rounded coordinates.",
+      "Examples in GeomCount. GeomCount: Count geometry: point marks at unique (x, y) with size scaled by after_stat n (stat sum). Use for overplotting density on discrete or rounded coordinates.",
     href: "/reference/geoms/count#examples",
     keywords: ["GeomCount", "documentation"],
     exact: ["Examples"],
@@ -2391,7 +2391,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "page",
     title: "GeomViolin",
     summary:
-      "GeomViolin: Violin geometry: mirrored kernel density of continuous y at each discrete x (ggplot2 geom_violin / stat_ydensity). One polygon per x×group. Default position dodge.",
+      "GeomViolin: Violin geometry: mirrored kernel density of continuous y at each discrete x (stat ydensity). One polygon per x×group. Default position dodge.",
     href: "/reference/geoms/violin",
     keywords: [],
     exact: ["GeomViolin"],
@@ -2401,7 +2401,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Defaults",
     summary:
-      "Defaults in GeomViolin. GeomViolin: Violin geometry: mirrored kernel density of continuous y at each discrete x (ggplot2 geom_violin / stat_ydensity). One polygon per x×group. Default position dodge.",
+      "Defaults in GeomViolin. GeomViolin: Violin geometry: mirrored kernel density of continuous y at each discrete x (stat ydensity). One polygon per x×group. Default position dodge.",
     href: "/reference/geoms/violin#defaults",
     keywords: ["GeomViolin", "documentation"],
     exact: ["Defaults"],
@@ -2411,7 +2411,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Svelte component",
     summary:
-      "Svelte component in GeomViolin. GeomViolin: Violin geometry: mirrored kernel density of continuous y at each discrete x (ggplot2 geom_violin / stat_ydensity). One polygon per x×group. Default position dodge.",
+      "Svelte component in GeomViolin. GeomViolin: Violin geometry: mirrored kernel density of continuous y at each discrete x (stat ydensity). One polygon per x×group. Default position dodge.",
     href: "/reference/geoms/violin#svelte",
     keywords: ["GeomViolin", "documentation"],
     exact: ["Svelte component"],
@@ -2421,7 +2421,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "JSON layer",
     summary:
-      "JSON layer in GeomViolin. GeomViolin: Violin geometry: mirrored kernel density of continuous y at each discrete x (ggplot2 geom_violin / stat_ydensity). One polygon per x×group. Default position dodge.",
+      "JSON layer in GeomViolin. GeomViolin: Violin geometry: mirrored kernel density of continuous y at each discrete x (stat ydensity). One polygon per x×group. Default position dodge.",
     href: "/reference/geoms/violin#json",
     keywords: ["GeomViolin", "documentation"],
     exact: ["JSON layer"],
@@ -2431,7 +2431,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Params",
     summary:
-      "Params in GeomViolin. GeomViolin: Violin geometry: mirrored kernel density of continuous y at each discrete x (ggplot2 geom_violin / stat_ydensity). One polygon per x×group. Default position dodge.",
+      "Params in GeomViolin. GeomViolin: Violin geometry: mirrored kernel density of continuous y at each discrete x (stat ydensity). One polygon per x×group. Default position dodge.",
     href: "/reference/geoms/violin#params",
     keywords: ["GeomViolin", "documentation"],
     exact: ["Params"],
@@ -2441,7 +2441,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed stats",
     summary:
-      "Allowed stats in GeomViolin. GeomViolin: Violin geometry: mirrored kernel density of continuous y at each discrete x (ggplot2 geom_violin / stat_ydensity). One polygon per x×group. Default position dodge.",
+      "Allowed stats in GeomViolin. GeomViolin: Violin geometry: mirrored kernel density of continuous y at each discrete x (stat ydensity). One polygon per x×group. Default position dodge.",
     href: "/reference/geoms/violin#allowed-stats",
     keywords: ["GeomViolin", "documentation"],
     exact: ["Allowed stats"],
@@ -2451,7 +2451,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed positions",
     summary:
-      "Allowed positions in GeomViolin. GeomViolin: Violin geometry: mirrored kernel density of continuous y at each discrete x (ggplot2 geom_violin / stat_ydensity). One polygon per x×group. Default position dodge.",
+      "Allowed positions in GeomViolin. GeomViolin: Violin geometry: mirrored kernel density of continuous y at each discrete x (stat ydensity). One polygon per x×group. Default position dodge.",
     href: "/reference/geoms/violin#allowed-positions",
     keywords: ["GeomViolin", "documentation"],
     exact: ["Allowed positions"],
@@ -2461,7 +2461,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Examples",
     summary:
-      "Examples in GeomViolin. GeomViolin: Violin geometry: mirrored kernel density of continuous y at each discrete x (ggplot2 geom_violin / stat_ydensity). One polygon per x×group. Default position dodge.",
+      "Examples in GeomViolin. GeomViolin: Violin geometry: mirrored kernel density of continuous y at each discrete x (stat ydensity). One polygon per x×group. Default position dodge.",
     href: "/reference/geoms/violin#examples",
     keywords: ["GeomViolin", "documentation"],
     exact: ["Examples"],
@@ -2471,7 +2471,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "page",
     title: "GeomFunction",
     summary:
-      "GeomFunction: Function geometry: evaluate a named portable function y = f(x) on a grid and draw a path (ggplot2 geom_function / stat_function). Requires params.fun; domain from params.xlim, mapped x, or peer layers.",
+      "GeomFunction: Function geometry: evaluate a named portable function y = f(x) on a grid and draw a path. Requires params.fun; domain from params.xlim, mapped x, or peer layers.",
     href: "/reference/geoms/function",
     keywords: [],
     exact: ["GeomFunction"],
@@ -2481,7 +2481,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Defaults",
     summary:
-      "Defaults in GeomFunction. GeomFunction: Function geometry: evaluate a named portable function y = f(x) on a grid and draw a path (ggplot2 geom_function / stat_function). Requires params.fun; domain from params.xlim, mapped x, or peer layers.",
+      "Defaults in GeomFunction. GeomFunction: Function geometry: evaluate a named portable function y = f(x) on a grid and draw a path. Requires params.fun; domain from params.xlim, mapped x, or peer layers.",
     href: "/reference/geoms/function#defaults",
     keywords: ["GeomFunction", "documentation"],
     exact: ["Defaults"],
@@ -2491,7 +2491,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Svelte component",
     summary:
-      "Svelte component in GeomFunction. GeomFunction: Function geometry: evaluate a named portable function y = f(x) on a grid and draw a path (ggplot2 geom_function / stat_function). Requires params.fun; domain from params.xlim, mapped x, or peer layers.",
+      "Svelte component in GeomFunction. GeomFunction: Function geometry: evaluate a named portable function y = f(x) on a grid and draw a path. Requires params.fun; domain from params.xlim, mapped x, or peer layers.",
     href: "/reference/geoms/function#svelte",
     keywords: ["GeomFunction", "documentation"],
     exact: ["Svelte component"],
@@ -2501,7 +2501,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "JSON layer",
     summary:
-      "JSON layer in GeomFunction. GeomFunction: Function geometry: evaluate a named portable function y = f(x) on a grid and draw a path (ggplot2 geom_function / stat_function). Requires params.fun; domain from params.xlim, mapped x, or peer layers.",
+      "JSON layer in GeomFunction. GeomFunction: Function geometry: evaluate a named portable function y = f(x) on a grid and draw a path. Requires params.fun; domain from params.xlim, mapped x, or peer layers.",
     href: "/reference/geoms/function#json",
     keywords: ["GeomFunction", "documentation"],
     exact: ["JSON layer"],
@@ -2511,7 +2511,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Params",
     summary:
-      "Params in GeomFunction. GeomFunction: Function geometry: evaluate a named portable function y = f(x) on a grid and draw a path (ggplot2 geom_function / stat_function). Requires params.fun; domain from params.xlim, mapped x, or peer layers.",
+      "Params in GeomFunction. GeomFunction: Function geometry: evaluate a named portable function y = f(x) on a grid and draw a path. Requires params.fun; domain from params.xlim, mapped x, or peer layers.",
     href: "/reference/geoms/function#params",
     keywords: ["GeomFunction", "documentation"],
     exact: ["Params"],
@@ -2521,7 +2521,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed stats",
     summary:
-      "Allowed stats in GeomFunction. GeomFunction: Function geometry: evaluate a named portable function y = f(x) on a grid and draw a path (ggplot2 geom_function / stat_function). Requires params.fun; domain from params.xlim, mapped x, or peer layers.",
+      "Allowed stats in GeomFunction. GeomFunction: Function geometry: evaluate a named portable function y = f(x) on a grid and draw a path. Requires params.fun; domain from params.xlim, mapped x, or peer layers.",
     href: "/reference/geoms/function#allowed-stats",
     keywords: ["GeomFunction", "documentation"],
     exact: ["Allowed stats"],
@@ -2531,7 +2531,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed positions",
     summary:
-      "Allowed positions in GeomFunction. GeomFunction: Function geometry: evaluate a named portable function y = f(x) on a grid and draw a path (ggplot2 geom_function / stat_function). Requires params.fun; domain from params.xlim, mapped x, or peer layers.",
+      "Allowed positions in GeomFunction. GeomFunction: Function geometry: evaluate a named portable function y = f(x) on a grid and draw a path. Requires params.fun; domain from params.xlim, mapped x, or peer layers.",
     href: "/reference/geoms/function#allowed-positions",
     keywords: ["GeomFunction", "documentation"],
     exact: ["Allowed positions"],
@@ -2541,7 +2541,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Examples",
     summary:
-      "Examples in GeomFunction. GeomFunction: Function geometry: evaluate a named portable function y = f(x) on a grid and draw a path (ggplot2 geom_function / stat_function). Requires params.fun; domain from params.xlim, mapped x, or peer layers.",
+      "Examples in GeomFunction. GeomFunction: Function geometry: evaluate a named portable function y = f(x) on a grid and draw a path. Requires params.fun; domain from params.xlim, mapped x, or peer layers.",
     href: "/reference/geoms/function#examples",
     keywords: ["GeomFunction", "documentation"],
     exact: ["Examples"],
@@ -2551,7 +2551,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "page",
     title: "GeomPolygon",
     summary:
-      "GeomPolygon: Polygon geometry: closed filled paths from (x, y) vertices in data/row order within each group (ggplot2's geom_polygon). Groups form separate polygons. No x-sort (unlike line/area). Holes/subgroup omitted in v1.",
+      "GeomPolygon: Polygon geometry: closed filled paths from (x, y) vertices in data/row order within each group. Groups form separate polygons. No x-sort (unlike line/area). Holes/subgroup omitted in v1.",
     href: "/reference/geoms/polygon",
     keywords: [],
     exact: ["GeomPolygon"],
@@ -2561,7 +2561,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Defaults",
     summary:
-      "Defaults in GeomPolygon. GeomPolygon: Polygon geometry: closed filled paths from (x, y) vertices in data/row order within each group (ggplot2's geom_polygon). Groups form separate polygons. No x-sort (unlike line/area). Holes/subgroup omitted in v1.",
+      "Defaults in GeomPolygon. GeomPolygon: Polygon geometry: closed filled paths from (x, y) vertices in data/row order within each group. Groups form separate polygons. No x-sort (unlike line/area). Holes/subgroup omitted in v1.",
     href: "/reference/geoms/polygon#defaults",
     keywords: ["GeomPolygon", "documentation"],
     exact: ["Defaults"],
@@ -2571,7 +2571,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Svelte component",
     summary:
-      "Svelte component in GeomPolygon. GeomPolygon: Polygon geometry: closed filled paths from (x, y) vertices in data/row order within each group (ggplot2's geom_polygon). Groups form separate polygons. No x-sort (unlike line/area). Holes/subgroup omitted in v1.",
+      "Svelte component in GeomPolygon. GeomPolygon: Polygon geometry: closed filled paths from (x, y) vertices in data/row order within each group. Groups form separate polygons. No x-sort (unlike line/area). Holes/subgroup omitted in v1.",
     href: "/reference/geoms/polygon#svelte",
     keywords: ["GeomPolygon", "documentation"],
     exact: ["Svelte component"],
@@ -2581,7 +2581,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "JSON layer",
     summary:
-      "JSON layer in GeomPolygon. GeomPolygon: Polygon geometry: closed filled paths from (x, y) vertices in data/row order within each group (ggplot2's geom_polygon). Groups form separate polygons. No x-sort (unlike line/area). Holes/subgroup omitted in v1.",
+      "JSON layer in GeomPolygon. GeomPolygon: Polygon geometry: closed filled paths from (x, y) vertices in data/row order within each group. Groups form separate polygons. No x-sort (unlike line/area). Holes/subgroup omitted in v1.",
     href: "/reference/geoms/polygon#json",
     keywords: ["GeomPolygon", "documentation"],
     exact: ["JSON layer"],
@@ -2591,7 +2591,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Params",
     summary:
-      "Params in GeomPolygon. GeomPolygon: Polygon geometry: closed filled paths from (x, y) vertices in data/row order within each group (ggplot2's geom_polygon). Groups form separate polygons. No x-sort (unlike line/area). Holes/subgroup omitted in v1.",
+      "Params in GeomPolygon. GeomPolygon: Polygon geometry: closed filled paths from (x, y) vertices in data/row order within each group. Groups form separate polygons. No x-sort (unlike line/area). Holes/subgroup omitted in v1.",
     href: "/reference/geoms/polygon#params",
     keywords: ["GeomPolygon", "documentation"],
     exact: ["Params"],
@@ -2601,7 +2601,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed stats",
     summary:
-      "Allowed stats in GeomPolygon. GeomPolygon: Polygon geometry: closed filled paths from (x, y) vertices in data/row order within each group (ggplot2's geom_polygon). Groups form separate polygons. No x-sort (unlike line/area). Holes/subgroup omitted in v1.",
+      "Allowed stats in GeomPolygon. GeomPolygon: Polygon geometry: closed filled paths from (x, y) vertices in data/row order within each group. Groups form separate polygons. No x-sort (unlike line/area). Holes/subgroup omitted in v1.",
     href: "/reference/geoms/polygon#allowed-stats",
     keywords: ["GeomPolygon", "documentation"],
     exact: ["Allowed stats"],
@@ -2611,7 +2611,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed positions",
     summary:
-      "Allowed positions in GeomPolygon. GeomPolygon: Polygon geometry: closed filled paths from (x, y) vertices in data/row order within each group (ggplot2's geom_polygon). Groups form separate polygons. No x-sort (unlike line/area). Holes/subgroup omitted in v1.",
+      "Allowed positions in GeomPolygon. GeomPolygon: Polygon geometry: closed filled paths from (x, y) vertices in data/row order within each group. Groups form separate polygons. No x-sort (unlike line/area). Holes/subgroup omitted in v1.",
     href: "/reference/geoms/polygon#allowed-positions",
     keywords: ["GeomPolygon", "documentation"],
     exact: ["Allowed positions"],
@@ -2621,7 +2621,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Examples",
     summary:
-      "Examples in GeomPolygon. GeomPolygon: Polygon geometry: closed filled paths from (x, y) vertices in data/row order within each group (ggplot2's geom_polygon). Groups form separate polygons. No x-sort (unlike line/area). Holes/subgroup omitted in v1.",
+      "Examples in GeomPolygon. GeomPolygon: Polygon geometry: closed filled paths from (x, y) vertices in data/row order within each group. Groups form separate polygons. No x-sort (unlike line/area). Holes/subgroup omitted in v1.",
     href: "/reference/geoms/polygon#examples",
     keywords: ["GeomPolygon", "documentation"],
     exact: ["Examples"],
@@ -2631,7 +2631,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "page",
     title: "GeomHex",
     summary:
-      "GeomHex: Hexagonal bin heatmap (ggplot2 geom_hex / stat_bin_hex): partitions continuous x×y into a hexagonal lattice and maps fill to bin count by default.",
+      "GeomHex: Hexagonal bin heatmap: partitions continuous x×y into a hexagonal lattice and maps fill to bin count by default.",
     href: "/reference/geoms/hex",
     keywords: [],
     exact: ["GeomHex"],
@@ -2641,7 +2641,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Defaults",
     summary:
-      "Defaults in GeomHex. GeomHex: Hexagonal bin heatmap (ggplot2 geom_hex / stat_bin_hex): partitions continuous x×y into a hexagonal lattice and maps fill to bin count by default.",
+      "Defaults in GeomHex. GeomHex: Hexagonal bin heatmap: partitions continuous x×y into a hexagonal lattice and maps fill to bin count by default.",
     href: "/reference/geoms/hex#defaults",
     keywords: ["GeomHex", "documentation"],
     exact: ["Defaults"],
@@ -2651,7 +2651,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Svelte component",
     summary:
-      "Svelte component in GeomHex. GeomHex: Hexagonal bin heatmap (ggplot2 geom_hex / stat_bin_hex): partitions continuous x×y into a hexagonal lattice and maps fill to bin count by default.",
+      "Svelte component in GeomHex. GeomHex: Hexagonal bin heatmap: partitions continuous x×y into a hexagonal lattice and maps fill to bin count by default.",
     href: "/reference/geoms/hex#svelte",
     keywords: ["GeomHex", "documentation"],
     exact: ["Svelte component"],
@@ -2661,7 +2661,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "JSON layer",
     summary:
-      "JSON layer in GeomHex. GeomHex: Hexagonal bin heatmap (ggplot2 geom_hex / stat_bin_hex): partitions continuous x×y into a hexagonal lattice and maps fill to bin count by default.",
+      "JSON layer in GeomHex. GeomHex: Hexagonal bin heatmap: partitions continuous x×y into a hexagonal lattice and maps fill to bin count by default.",
     href: "/reference/geoms/hex#json",
     keywords: ["GeomHex", "documentation"],
     exact: ["JSON layer"],
@@ -2671,7 +2671,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Params",
     summary:
-      "Params in GeomHex. GeomHex: Hexagonal bin heatmap (ggplot2 geom_hex / stat_bin_hex): partitions continuous x×y into a hexagonal lattice and maps fill to bin count by default.",
+      "Params in GeomHex. GeomHex: Hexagonal bin heatmap: partitions continuous x×y into a hexagonal lattice and maps fill to bin count by default.",
     href: "/reference/geoms/hex#params",
     keywords: ["GeomHex", "documentation"],
     exact: ["Params"],
@@ -2681,7 +2681,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed stats",
     summary:
-      "Allowed stats in GeomHex. GeomHex: Hexagonal bin heatmap (ggplot2 geom_hex / stat_bin_hex): partitions continuous x×y into a hexagonal lattice and maps fill to bin count by default.",
+      "Allowed stats in GeomHex. GeomHex: Hexagonal bin heatmap: partitions continuous x×y into a hexagonal lattice and maps fill to bin count by default.",
     href: "/reference/geoms/hex#allowed-stats",
     keywords: ["GeomHex", "documentation"],
     exact: ["Allowed stats"],
@@ -2691,7 +2691,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed positions",
     summary:
-      "Allowed positions in GeomHex. GeomHex: Hexagonal bin heatmap (ggplot2 geom_hex / stat_bin_hex): partitions continuous x×y into a hexagonal lattice and maps fill to bin count by default.",
+      "Allowed positions in GeomHex. GeomHex: Hexagonal bin heatmap: partitions continuous x×y into a hexagonal lattice and maps fill to bin count by default.",
     href: "/reference/geoms/hex#allowed-positions",
     keywords: ["GeomHex", "documentation"],
     exact: ["Allowed positions"],
@@ -2701,7 +2701,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Examples",
     summary:
-      "Examples in GeomHex. GeomHex: Hexagonal bin heatmap (ggplot2 geom_hex / stat_bin_hex): partitions continuous x×y into a hexagonal lattice and maps fill to bin count by default.",
+      "Examples in GeomHex. GeomHex: Hexagonal bin heatmap: partitions continuous x×y into a hexagonal lattice and maps fill to bin count by default.",
     href: "/reference/geoms/hex#examples",
     keywords: ["GeomHex", "documentation"],
     exact: ["Examples"],
@@ -2711,7 +2711,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "page",
     title: "GeomBin2d",
     summary:
-      "GeomBin2d: 2D rectangular bin heatmap (ggplot2 geom_bin2d / stat_bin_2d): partitions continuous x×y into a grid and maps fill to bin count by default. Empty bins are dropped unless params.drop is false.",
+      "GeomBin2d: 2D rectangular bin heatmap: partitions continuous x×y into a grid and maps fill to bin count by default. Empty bins are dropped unless params.drop is false.",
     href: "/reference/geoms/bin_2d",
     keywords: [],
     exact: ["GeomBin2d"],
@@ -2721,7 +2721,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Defaults",
     summary:
-      "Defaults in GeomBin2d. GeomBin2d: 2D rectangular bin heatmap (ggplot2 geom_bin2d / stat_bin_2d): partitions continuous x×y into a grid and maps fill to bin count by default. Empty bins are dropped unless params.drop is false.",
+      "Defaults in GeomBin2d. GeomBin2d: 2D rectangular bin heatmap: partitions continuous x×y into a grid and maps fill to bin count by default. Empty bins are dropped unless params.drop is false.",
     href: "/reference/geoms/bin_2d#defaults",
     keywords: ["GeomBin2d", "documentation"],
     exact: ["Defaults"],
@@ -2731,7 +2731,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Svelte component",
     summary:
-      "Svelte component in GeomBin2d. GeomBin2d: 2D rectangular bin heatmap (ggplot2 geom_bin2d / stat_bin_2d): partitions continuous x×y into a grid and maps fill to bin count by default. Empty bins are dropped unless params.drop is false.",
+      "Svelte component in GeomBin2d. GeomBin2d: 2D rectangular bin heatmap: partitions continuous x×y into a grid and maps fill to bin count by default. Empty bins are dropped unless params.drop is false.",
     href: "/reference/geoms/bin_2d#svelte",
     keywords: ["GeomBin2d", "documentation"],
     exact: ["Svelte component"],
@@ -2741,7 +2741,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "JSON layer",
     summary:
-      "JSON layer in GeomBin2d. GeomBin2d: 2D rectangular bin heatmap (ggplot2 geom_bin2d / stat_bin_2d): partitions continuous x×y into a grid and maps fill to bin count by default. Empty bins are dropped unless params.drop is false.",
+      "JSON layer in GeomBin2d. GeomBin2d: 2D rectangular bin heatmap: partitions continuous x×y into a grid and maps fill to bin count by default. Empty bins are dropped unless params.drop is false.",
     href: "/reference/geoms/bin_2d#json",
     keywords: ["GeomBin2d", "documentation"],
     exact: ["JSON layer"],
@@ -2751,7 +2751,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Params",
     summary:
-      "Params in GeomBin2d. GeomBin2d: 2D rectangular bin heatmap (ggplot2 geom_bin2d / stat_bin_2d): partitions continuous x×y into a grid and maps fill to bin count by default. Empty bins are dropped unless params.drop is false.",
+      "Params in GeomBin2d. GeomBin2d: 2D rectangular bin heatmap: partitions continuous x×y into a grid and maps fill to bin count by default. Empty bins are dropped unless params.drop is false.",
     href: "/reference/geoms/bin_2d#params",
     keywords: ["GeomBin2d", "documentation"],
     exact: ["Params"],
@@ -2761,7 +2761,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed stats",
     summary:
-      "Allowed stats in GeomBin2d. GeomBin2d: 2D rectangular bin heatmap (ggplot2 geom_bin2d / stat_bin_2d): partitions continuous x×y into a grid and maps fill to bin count by default. Empty bins are dropped unless params.drop is false.",
+      "Allowed stats in GeomBin2d. GeomBin2d: 2D rectangular bin heatmap: partitions continuous x×y into a grid and maps fill to bin count by default. Empty bins are dropped unless params.drop is false.",
     href: "/reference/geoms/bin_2d#allowed-stats",
     keywords: ["GeomBin2d", "documentation"],
     exact: ["Allowed stats"],
@@ -2771,7 +2771,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed positions",
     summary:
-      "Allowed positions in GeomBin2d. GeomBin2d: 2D rectangular bin heatmap (ggplot2 geom_bin2d / stat_bin_2d): partitions continuous x×y into a grid and maps fill to bin count by default. Empty bins are dropped unless params.drop is false.",
+      "Allowed positions in GeomBin2d. GeomBin2d: 2D rectangular bin heatmap: partitions continuous x×y into a grid and maps fill to bin count by default. Empty bins are dropped unless params.drop is false.",
     href: "/reference/geoms/bin_2d#allowed-positions",
     keywords: ["GeomBin2d", "documentation"],
     exact: ["Allowed positions"],
@@ -2781,7 +2781,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Examples",
     summary:
-      "Examples in GeomBin2d. GeomBin2d: 2D rectangular bin heatmap (ggplot2 geom_bin2d / stat_bin_2d): partitions continuous x×y into a grid and maps fill to bin count by default. Empty bins are dropped unless params.drop is false.",
+      "Examples in GeomBin2d. GeomBin2d: 2D rectangular bin heatmap: partitions continuous x×y into a grid and maps fill to bin count by default. Empty bins are dropped unless params.drop is false.",
     href: "/reference/geoms/bin_2d#examples",
     keywords: ["GeomBin2d", "documentation"],
     exact: ["Examples"],
@@ -2791,7 +2791,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "page",
     title: "GeomAbline",
     summary:
-      "GeomAbline: Abline geometry: one infinite reference line y = intercept + slope · x, clipped to the panel (ggplot2 geom_abline). Annotation form: fixed slope/intercept in params; does not inherit plot aes.",
+      "GeomAbline: Abline geometry: one infinite reference line y = intercept + slope · x, clipped to the panel. Annotation form: fixed slope/intercept in params; does not inherit plot aes.",
     href: "/reference/geoms/abline",
     keywords: [],
     exact: ["GeomAbline"],
@@ -2801,7 +2801,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Defaults",
     summary:
-      "Defaults in GeomAbline. GeomAbline: Abline geometry: one infinite reference line y = intercept + slope · x, clipped to the panel (ggplot2 geom_abline). Annotation form: fixed slope/intercept in params; does not inherit plot aes.",
+      "Defaults in GeomAbline. GeomAbline: Abline geometry: one infinite reference line y = intercept + slope · x, clipped to the panel. Annotation form: fixed slope/intercept in params; does not inherit plot aes.",
     href: "/reference/geoms/abline#defaults",
     keywords: ["GeomAbline", "documentation"],
     exact: ["Defaults"],
@@ -2811,7 +2811,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Svelte component",
     summary:
-      "Svelte component in GeomAbline. GeomAbline: Abline geometry: one infinite reference line y = intercept + slope · x, clipped to the panel (ggplot2 geom_abline). Annotation form: fixed slope/intercept in params; does not inherit plot aes.",
+      "Svelte component in GeomAbline. GeomAbline: Abline geometry: one infinite reference line y = intercept + slope · x, clipped to the panel. Annotation form: fixed slope/intercept in params; does not inherit plot aes.",
     href: "/reference/geoms/abline#svelte",
     keywords: ["GeomAbline", "documentation"],
     exact: ["Svelte component"],
@@ -2821,7 +2821,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "JSON layer",
     summary:
-      "JSON layer in GeomAbline. GeomAbline: Abline geometry: one infinite reference line y = intercept + slope · x, clipped to the panel (ggplot2 geom_abline). Annotation form: fixed slope/intercept in params; does not inherit plot aes.",
+      "JSON layer in GeomAbline. GeomAbline: Abline geometry: one infinite reference line y = intercept + slope · x, clipped to the panel. Annotation form: fixed slope/intercept in params; does not inherit plot aes.",
     href: "/reference/geoms/abline#json",
     keywords: ["GeomAbline", "documentation"],
     exact: ["JSON layer"],
@@ -2831,7 +2831,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Params",
     summary:
-      "Params in GeomAbline. GeomAbline: Abline geometry: one infinite reference line y = intercept + slope · x, clipped to the panel (ggplot2 geom_abline). Annotation form: fixed slope/intercept in params; does not inherit plot aes.",
+      "Params in GeomAbline. GeomAbline: Abline geometry: one infinite reference line y = intercept + slope · x, clipped to the panel. Annotation form: fixed slope/intercept in params; does not inherit plot aes.",
     href: "/reference/geoms/abline#params",
     keywords: ["GeomAbline", "documentation"],
     exact: ["Params"],
@@ -2841,7 +2841,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed stats",
     summary:
-      "Allowed stats in GeomAbline. GeomAbline: Abline geometry: one infinite reference line y = intercept + slope · x, clipped to the panel (ggplot2 geom_abline). Annotation form: fixed slope/intercept in params; does not inherit plot aes.",
+      "Allowed stats in GeomAbline. GeomAbline: Abline geometry: one infinite reference line y = intercept + slope · x, clipped to the panel. Annotation form: fixed slope/intercept in params; does not inherit plot aes.",
     href: "/reference/geoms/abline#allowed-stats",
     keywords: ["GeomAbline", "documentation"],
     exact: ["Allowed stats"],
@@ -2851,7 +2851,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed positions",
     summary:
-      "Allowed positions in GeomAbline. GeomAbline: Abline geometry: one infinite reference line y = intercept + slope · x, clipped to the panel (ggplot2 geom_abline). Annotation form: fixed slope/intercept in params; does not inherit plot aes.",
+      "Allowed positions in GeomAbline. GeomAbline: Abline geometry: one infinite reference line y = intercept + slope · x, clipped to the panel. Annotation form: fixed slope/intercept in params; does not inherit plot aes.",
     href: "/reference/geoms/abline#allowed-positions",
     keywords: ["GeomAbline", "documentation"],
     exact: ["Allowed positions"],
@@ -2861,7 +2861,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Examples",
     summary:
-      "Examples in GeomAbline. GeomAbline: Abline geometry: one infinite reference line y = intercept + slope · x, clipped to the panel (ggplot2 geom_abline). Annotation form: fixed slope/intercept in params; does not inherit plot aes.",
+      "Examples in GeomAbline. GeomAbline: Abline geometry: one infinite reference line y = intercept + slope · x, clipped to the panel. Annotation form: fixed slope/intercept in params; does not inherit plot aes.",
     href: "/reference/geoms/abline#examples",
     keywords: ["GeomAbline", "documentation"],
     exact: ["Examples"],
@@ -2871,7 +2871,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "page",
     title: "GeomCurve",
     summary:
-      "GeomCurve: Curve geometry (ggplot2 geom_curve): one curved connector per row from (x, y) to (xend, yend). Tessellated as a quadratic Bezier (curvature/angle/ncp). Requires field-mapped x, y, xend, and yend.",
+      "GeomCurve: Curve geometry: one curved connector per row from (x, y) to (xend, yend). Tessellated as a quadratic Bezier (curvature/angle/ncp). Requires field-mapped x, y, xend, and yend.",
     href: "/reference/geoms/curve",
     keywords: [],
     exact: ["GeomCurve"],
@@ -2881,7 +2881,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Defaults",
     summary:
-      "Defaults in GeomCurve. GeomCurve: Curve geometry (ggplot2 geom_curve): one curved connector per row from (x, y) to (xend, yend). Tessellated as a quadratic Bezier (curvature/angle/ncp). Requires field-mapped x, y, xend, and yend.",
+      "Defaults in GeomCurve. GeomCurve: Curve geometry: one curved connector per row from (x, y) to (xend, yend). Tessellated as a quadratic Bezier (curvature/angle/ncp). Requires field-mapped x, y, xend, and yend.",
     href: "/reference/geoms/curve#defaults",
     keywords: ["GeomCurve", "documentation"],
     exact: ["Defaults"],
@@ -2891,7 +2891,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Svelte component",
     summary:
-      "Svelte component in GeomCurve. GeomCurve: Curve geometry (ggplot2 geom_curve): one curved connector per row from (x, y) to (xend, yend). Tessellated as a quadratic Bezier (curvature/angle/ncp). Requires field-mapped x, y, xend, and yend.",
+      "Svelte component in GeomCurve. GeomCurve: Curve geometry: one curved connector per row from (x, y) to (xend, yend). Tessellated as a quadratic Bezier (curvature/angle/ncp). Requires field-mapped x, y, xend, and yend.",
     href: "/reference/geoms/curve#svelte",
     keywords: ["GeomCurve", "documentation"],
     exact: ["Svelte component"],
@@ -2901,7 +2901,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "JSON layer",
     summary:
-      "JSON layer in GeomCurve. GeomCurve: Curve geometry (ggplot2 geom_curve): one curved connector per row from (x, y) to (xend, yend). Tessellated as a quadratic Bezier (curvature/angle/ncp). Requires field-mapped x, y, xend, and yend.",
+      "JSON layer in GeomCurve. GeomCurve: Curve geometry: one curved connector per row from (x, y) to (xend, yend). Tessellated as a quadratic Bezier (curvature/angle/ncp). Requires field-mapped x, y, xend, and yend.",
     href: "/reference/geoms/curve#json",
     keywords: ["GeomCurve", "documentation"],
     exact: ["JSON layer"],
@@ -2911,7 +2911,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Params",
     summary:
-      "Params in GeomCurve. GeomCurve: Curve geometry (ggplot2 geom_curve): one curved connector per row from (x, y) to (xend, yend). Tessellated as a quadratic Bezier (curvature/angle/ncp). Requires field-mapped x, y, xend, and yend.",
+      "Params in GeomCurve. GeomCurve: Curve geometry: one curved connector per row from (x, y) to (xend, yend). Tessellated as a quadratic Bezier (curvature/angle/ncp). Requires field-mapped x, y, xend, and yend.",
     href: "/reference/geoms/curve#params",
     keywords: ["GeomCurve", "documentation"],
     exact: ["Params"],
@@ -2921,7 +2921,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed stats",
     summary:
-      "Allowed stats in GeomCurve. GeomCurve: Curve geometry (ggplot2 geom_curve): one curved connector per row from (x, y) to (xend, yend). Tessellated as a quadratic Bezier (curvature/angle/ncp). Requires field-mapped x, y, xend, and yend.",
+      "Allowed stats in GeomCurve. GeomCurve: Curve geometry: one curved connector per row from (x, y) to (xend, yend). Tessellated as a quadratic Bezier (curvature/angle/ncp). Requires field-mapped x, y, xend, and yend.",
     href: "/reference/geoms/curve#allowed-stats",
     keywords: ["GeomCurve", "documentation"],
     exact: ["Allowed stats"],
@@ -2931,7 +2931,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed positions",
     summary:
-      "Allowed positions in GeomCurve. GeomCurve: Curve geometry (ggplot2 geom_curve): one curved connector per row from (x, y) to (xend, yend). Tessellated as a quadratic Bezier (curvature/angle/ncp). Requires field-mapped x, y, xend, and yend.",
+      "Allowed positions in GeomCurve. GeomCurve: Curve geometry: one curved connector per row from (x, y) to (xend, yend). Tessellated as a quadratic Bezier (curvature/angle/ncp). Requires field-mapped x, y, xend, and yend.",
     href: "/reference/geoms/curve#allowed-positions",
     keywords: ["GeomCurve", "documentation"],
     exact: ["Allowed positions"],
@@ -2941,7 +2941,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Examples",
     summary:
-      "Examples in GeomCurve. GeomCurve: Curve geometry (ggplot2 geom_curve): one curved connector per row from (x, y) to (xend, yend). Tessellated as a quadratic Bezier (curvature/angle/ncp). Requires field-mapped x, y, xend, and yend.",
+      "Examples in GeomCurve. GeomCurve: Curve geometry: one curved connector per row from (x, y) to (xend, yend). Tessellated as a quadratic Bezier (curvature/angle/ncp). Requires field-mapped x, y, xend, and yend.",
     href: "/reference/geoms/curve#examples",
     keywords: ["GeomCurve", "documentation"],
     exact: ["Examples"],
@@ -2951,7 +2951,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "page",
     title: "GeomContour",
     summary:
-      "GeomContour: Contour geometry: isolines of a continuous z surface over a regular x×y grid (ggplot2 geom_contour; #801). v1 draws open path polylines only (not filled bands).",
+      "GeomContour: Contour geometry: isolines of a continuous z surface over a regular x×y grid. v1 draws open path polylines only (not filled bands).",
     href: "/reference/geoms/contour",
     keywords: [],
     exact: ["GeomContour"],
@@ -2961,7 +2961,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Defaults",
     summary:
-      "Defaults in GeomContour. GeomContour: Contour geometry: isolines of a continuous z surface over a regular x×y grid (ggplot2 geom_contour; #801). v1 draws open path polylines only (not filled bands).",
+      "Defaults in GeomContour. GeomContour: Contour geometry: isolines of a continuous z surface over a regular x×y grid. v1 draws open path polylines only (not filled bands).",
     href: "/reference/geoms/contour#defaults",
     keywords: ["GeomContour", "documentation"],
     exact: ["Defaults"],
@@ -2971,7 +2971,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Svelte component",
     summary:
-      "Svelte component in GeomContour. GeomContour: Contour geometry: isolines of a continuous z surface over a regular x×y grid (ggplot2 geom_contour; #801). v1 draws open path polylines only (not filled bands).",
+      "Svelte component in GeomContour. GeomContour: Contour geometry: isolines of a continuous z surface over a regular x×y grid. v1 draws open path polylines only (not filled bands).",
     href: "/reference/geoms/contour#svelte",
     keywords: ["GeomContour", "documentation"],
     exact: ["Svelte component"],
@@ -2981,7 +2981,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "JSON layer",
     summary:
-      "JSON layer in GeomContour. GeomContour: Contour geometry: isolines of a continuous z surface over a regular x×y grid (ggplot2 geom_contour; #801). v1 draws open path polylines only (not filled bands).",
+      "JSON layer in GeomContour. GeomContour: Contour geometry: isolines of a continuous z surface over a regular x×y grid. v1 draws open path polylines only (not filled bands).",
     href: "/reference/geoms/contour#json",
     keywords: ["GeomContour", "documentation"],
     exact: ["JSON layer"],
@@ -2991,7 +2991,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Params",
     summary:
-      "Params in GeomContour. GeomContour: Contour geometry: isolines of a continuous z surface over a regular x×y grid (ggplot2 geom_contour; #801). v1 draws open path polylines only (not filled bands).",
+      "Params in GeomContour. GeomContour: Contour geometry: isolines of a continuous z surface over a regular x×y grid. v1 draws open path polylines only (not filled bands).",
     href: "/reference/geoms/contour#params",
     keywords: ["GeomContour", "documentation"],
     exact: ["Params"],
@@ -3001,7 +3001,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed stats",
     summary:
-      "Allowed stats in GeomContour. GeomContour: Contour geometry: isolines of a continuous z surface over a regular x×y grid (ggplot2 geom_contour; #801). v1 draws open path polylines only (not filled bands).",
+      "Allowed stats in GeomContour. GeomContour: Contour geometry: isolines of a continuous z surface over a regular x×y grid. v1 draws open path polylines only (not filled bands).",
     href: "/reference/geoms/contour#allowed-stats",
     keywords: ["GeomContour", "documentation"],
     exact: ["Allowed stats"],
@@ -3011,7 +3011,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed positions",
     summary:
-      "Allowed positions in GeomContour. GeomContour: Contour geometry: isolines of a continuous z surface over a regular x×y grid (ggplot2 geom_contour; #801). v1 draws open path polylines only (not filled bands).",
+      "Allowed positions in GeomContour. GeomContour: Contour geometry: isolines of a continuous z surface over a regular x×y grid. v1 draws open path polylines only (not filled bands).",
     href: "/reference/geoms/contour#allowed-positions",
     keywords: ["GeomContour", "documentation"],
     exact: ["Allowed positions"],
@@ -3021,7 +3021,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Examples",
     summary:
-      "Examples in GeomContour. GeomContour: Contour geometry: isolines of a continuous z surface over a regular x×y grid (ggplot2 geom_contour; #801). v1 draws open path polylines only (not filled bands).",
+      "Examples in GeomContour. GeomContour: Contour geometry: isolines of a continuous z surface over a regular x×y grid. v1 draws open path polylines only (not filled bands).",
     href: "/reference/geoms/contour#examples",
     keywords: ["GeomContour", "documentation"],
     exact: ["Examples"],
@@ -3031,7 +3031,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "page",
     title: "GeomDensity2d",
     summary:
-      "GeomDensity2d: 2D density geometry: bivariate KDE isolines over continuous x and y (ggplot2 geom_density_2d; #802). Open path contours.",
+      "GeomDensity2d: 2D density geometry: bivariate KDE isolines over continuous x and y. Open path contours.",
     href: "/reference/geoms/density_2d",
     keywords: [],
     exact: ["GeomDensity2d"],
@@ -3041,7 +3041,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Defaults",
     summary:
-      "Defaults in GeomDensity2d. GeomDensity2d: 2D density geometry: bivariate KDE isolines over continuous x and y (ggplot2 geom_density_2d; #802). Open path contours.",
+      "Defaults in GeomDensity2d. GeomDensity2d: 2D density geometry: bivariate KDE isolines over continuous x and y. Open path contours.",
     href: "/reference/geoms/density_2d#defaults",
     keywords: ["GeomDensity2d", "documentation"],
     exact: ["Defaults"],
@@ -3051,7 +3051,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Svelte component",
     summary:
-      "Svelte component in GeomDensity2d. GeomDensity2d: 2D density geometry: bivariate KDE isolines over continuous x and y (ggplot2 geom_density_2d; #802). Open path contours.",
+      "Svelte component in GeomDensity2d. GeomDensity2d: 2D density geometry: bivariate KDE isolines over continuous x and y. Open path contours.",
     href: "/reference/geoms/density_2d#svelte",
     keywords: ["GeomDensity2d", "documentation"],
     exact: ["Svelte component"],
@@ -3061,7 +3061,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "JSON layer",
     summary:
-      "JSON layer in GeomDensity2d. GeomDensity2d: 2D density geometry: bivariate KDE isolines over continuous x and y (ggplot2 geom_density_2d; #802). Open path contours.",
+      "JSON layer in GeomDensity2d. GeomDensity2d: 2D density geometry: bivariate KDE isolines over continuous x and y. Open path contours.",
     href: "/reference/geoms/density_2d#json",
     keywords: ["GeomDensity2d", "documentation"],
     exact: ["JSON layer"],
@@ -3071,7 +3071,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Params",
     summary:
-      "Params in GeomDensity2d. GeomDensity2d: 2D density geometry: bivariate KDE isolines over continuous x and y (ggplot2 geom_density_2d; #802). Open path contours.",
+      "Params in GeomDensity2d. GeomDensity2d: 2D density geometry: bivariate KDE isolines over continuous x and y. Open path contours.",
     href: "/reference/geoms/density_2d#params",
     keywords: ["GeomDensity2d", "documentation"],
     exact: ["Params"],
@@ -3081,7 +3081,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed stats",
     summary:
-      "Allowed stats in GeomDensity2d. GeomDensity2d: 2D density geometry: bivariate KDE isolines over continuous x and y (ggplot2 geom_density_2d; #802). Open path contours.",
+      "Allowed stats in GeomDensity2d. GeomDensity2d: 2D density geometry: bivariate KDE isolines over continuous x and y. Open path contours.",
     href: "/reference/geoms/density_2d#allowed-stats",
     keywords: ["GeomDensity2d", "documentation"],
     exact: ["Allowed stats"],
@@ -3091,7 +3091,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed positions",
     summary:
-      "Allowed positions in GeomDensity2d. GeomDensity2d: 2D density geometry: bivariate KDE isolines over continuous x and y (ggplot2 geom_density_2d; #802). Open path contours.",
+      "Allowed positions in GeomDensity2d. GeomDensity2d: 2D density geometry: bivariate KDE isolines over continuous x and y. Open path contours.",
     href: "/reference/geoms/density_2d#allowed-positions",
     keywords: ["GeomDensity2d", "documentation"],
     exact: ["Allowed positions"],
@@ -3101,7 +3101,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Examples",
     summary:
-      "Examples in GeomDensity2d. GeomDensity2d: 2D density geometry: bivariate KDE isolines over continuous x and y (ggplot2 geom_density_2d; #802). Open path contours.",
+      "Examples in GeomDensity2d. GeomDensity2d: 2D density geometry: bivariate KDE isolines over continuous x and y. Open path contours.",
     href: "/reference/geoms/density_2d#examples",
     keywords: ["GeomDensity2d", "documentation"],
     exact: ["Examples"],
@@ -3111,7 +3111,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "page",
     title: "GeomDensity2dFilled",
     summary:
-      "GeomDensity2dFilled: 2D density filled bands: bivariate KDE closed isoline rings filled by density level (ggplot2 geom_density_2d_filled; #802 phase 2). Open rings dropped. Defaults fill to after_stat(level).",
+      "GeomDensity2dFilled: 2D density filled bands: bivariate KDE closed isoline rings filled by density level. Open rings dropped. Defaults fill to after_stat(level).",
     href: "/reference/geoms/density_2d_filled",
     keywords: [],
     exact: ["GeomDensity2dFilled"],
@@ -3121,7 +3121,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Defaults",
     summary:
-      "Defaults in GeomDensity2dFilled. GeomDensity2dFilled: 2D density filled bands: bivariate KDE closed isoline rings filled by density level (ggplot2 geom_density_2d_filled; #802 phase 2). Open rings dropped. Defaults fill to after_stat(level).",
+      "Defaults in GeomDensity2dFilled. GeomDensity2dFilled: 2D density filled bands: bivariate KDE closed isoline rings filled by density level. Open rings dropped. Defaults fill to after_stat(level).",
     href: "/reference/geoms/density_2d_filled#defaults",
     keywords: ["GeomDensity2dFilled", "documentation"],
     exact: ["Defaults"],
@@ -3131,7 +3131,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Svelte component",
     summary:
-      "Svelte component in GeomDensity2dFilled. GeomDensity2dFilled: 2D density filled bands: bivariate KDE closed isoline rings filled by density level (ggplot2 geom_density_2d_filled; #802 phase 2). Open rings dropped. Defaults fill to after_stat(level).",
+      "Svelte component in GeomDensity2dFilled. GeomDensity2dFilled: 2D density filled bands: bivariate KDE closed isoline rings filled by density level. Open rings dropped. Defaults fill to after_stat(level).",
     href: "/reference/geoms/density_2d_filled#svelte",
     keywords: ["GeomDensity2dFilled", "documentation"],
     exact: ["Svelte component"],
@@ -3141,7 +3141,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "JSON layer",
     summary:
-      "JSON layer in GeomDensity2dFilled. GeomDensity2dFilled: 2D density filled bands: bivariate KDE closed isoline rings filled by density level (ggplot2 geom_density_2d_filled; #802 phase 2). Open rings dropped. Defaults fill to after_stat(level).",
+      "JSON layer in GeomDensity2dFilled. GeomDensity2dFilled: 2D density filled bands: bivariate KDE closed isoline rings filled by density level. Open rings dropped. Defaults fill to after_stat(level).",
     href: "/reference/geoms/density_2d_filled#json",
     keywords: ["GeomDensity2dFilled", "documentation"],
     exact: ["JSON layer"],
@@ -3151,7 +3151,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Params",
     summary:
-      "Params in GeomDensity2dFilled. GeomDensity2dFilled: 2D density filled bands: bivariate KDE closed isoline rings filled by density level (ggplot2 geom_density_2d_filled; #802 phase 2). Open rings dropped. Defaults fill to after_stat(level).",
+      "Params in GeomDensity2dFilled. GeomDensity2dFilled: 2D density filled bands: bivariate KDE closed isoline rings filled by density level. Open rings dropped. Defaults fill to after_stat(level).",
     href: "/reference/geoms/density_2d_filled#params",
     keywords: ["GeomDensity2dFilled", "documentation"],
     exact: ["Params"],
@@ -3161,7 +3161,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed stats",
     summary:
-      "Allowed stats in GeomDensity2dFilled. GeomDensity2dFilled: 2D density filled bands: bivariate KDE closed isoline rings filled by density level (ggplot2 geom_density_2d_filled; #802 phase 2). Open rings dropped. Defaults fill to after_stat(level).",
+      "Allowed stats in GeomDensity2dFilled. GeomDensity2dFilled: 2D density filled bands: bivariate KDE closed isoline rings filled by density level. Open rings dropped. Defaults fill to after_stat(level).",
     href: "/reference/geoms/density_2d_filled#allowed-stats",
     keywords: ["GeomDensity2dFilled", "documentation"],
     exact: ["Allowed stats"],
@@ -3171,7 +3171,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed positions",
     summary:
-      "Allowed positions in GeomDensity2dFilled. GeomDensity2dFilled: 2D density filled bands: bivariate KDE closed isoline rings filled by density level (ggplot2 geom_density_2d_filled; #802 phase 2). Open rings dropped. Defaults fill to after_stat(level).",
+      "Allowed positions in GeomDensity2dFilled. GeomDensity2dFilled: 2D density filled bands: bivariate KDE closed isoline rings filled by density level. Open rings dropped. Defaults fill to after_stat(level).",
     href: "/reference/geoms/density_2d_filled#allowed-positions",
     keywords: ["GeomDensity2dFilled", "documentation"],
     exact: ["Allowed positions"],
@@ -3181,7 +3181,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Examples",
     summary:
-      "Examples in GeomDensity2dFilled. GeomDensity2dFilled: 2D density filled bands: bivariate KDE closed isoline rings filled by density level (ggplot2 geom_density_2d_filled; #802 phase 2). Open rings dropped. Defaults fill to after_stat(level).",
+      "Examples in GeomDensity2dFilled. GeomDensity2dFilled: 2D density filled bands: bivariate KDE closed isoline rings filled by density level. Open rings dropped. Defaults fill to after_stat(level).",
     href: "/reference/geoms/density_2d_filled#examples",
     keywords: ["GeomDensity2dFilled", "documentation"],
     exact: ["Examples"],
@@ -3191,7 +3191,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "page",
     title: "GeomDotplot",
     summary:
-      "GeomDotplot: Dotplot geometry: stacked dots along a continuous x axis (ggplot2 geom_dotplot, histodot subset). Do NOT map aes.y — the bindot stat computes stack positions.",
+      "GeomDotplot: Dotplot geometry: stacked dots along a continuous x axis (histodot subset). Do not map aes.y — the bindot stat computes stack positions.",
     href: "/reference/geoms/dotplot",
     keywords: [],
     exact: ["GeomDotplot"],
@@ -3201,7 +3201,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Defaults",
     summary:
-      "Defaults in GeomDotplot. GeomDotplot: Dotplot geometry: stacked dots along a continuous x axis (ggplot2 geom_dotplot, histodot subset). Do NOT map aes.y — the bindot stat computes stack positions.",
+      "Defaults in GeomDotplot. GeomDotplot: Dotplot geometry: stacked dots along a continuous x axis (histodot subset). Do not map aes.y — the bindot stat computes stack positions.",
     href: "/reference/geoms/dotplot#defaults",
     keywords: ["GeomDotplot", "documentation"],
     exact: ["Defaults"],
@@ -3211,7 +3211,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Svelte component",
     summary:
-      "Svelte component in GeomDotplot. GeomDotplot: Dotplot geometry: stacked dots along a continuous x axis (ggplot2 geom_dotplot, histodot subset). Do NOT map aes.y — the bindot stat computes stack positions.",
+      "Svelte component in GeomDotplot. GeomDotplot: Dotplot geometry: stacked dots along a continuous x axis (histodot subset). Do not map aes.y — the bindot stat computes stack positions.",
     href: "/reference/geoms/dotplot#svelte",
     keywords: ["GeomDotplot", "documentation"],
     exact: ["Svelte component"],
@@ -3221,7 +3221,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "JSON layer",
     summary:
-      "JSON layer in GeomDotplot. GeomDotplot: Dotplot geometry: stacked dots along a continuous x axis (ggplot2 geom_dotplot, histodot subset). Do NOT map aes.y — the bindot stat computes stack positions.",
+      "JSON layer in GeomDotplot. GeomDotplot: Dotplot geometry: stacked dots along a continuous x axis (histodot subset). Do not map aes.y — the bindot stat computes stack positions.",
     href: "/reference/geoms/dotplot#json",
     keywords: ["GeomDotplot", "documentation"],
     exact: ["JSON layer"],
@@ -3231,7 +3231,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Params",
     summary:
-      "Params in GeomDotplot. GeomDotplot: Dotplot geometry: stacked dots along a continuous x axis (ggplot2 geom_dotplot, histodot subset). Do NOT map aes.y — the bindot stat computes stack positions.",
+      "Params in GeomDotplot. GeomDotplot: Dotplot geometry: stacked dots along a continuous x axis (histodot subset). Do not map aes.y — the bindot stat computes stack positions.",
     href: "/reference/geoms/dotplot#params",
     keywords: ["GeomDotplot", "documentation"],
     exact: ["Params"],
@@ -3241,7 +3241,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed stats",
     summary:
-      "Allowed stats in GeomDotplot. GeomDotplot: Dotplot geometry: stacked dots along a continuous x axis (ggplot2 geom_dotplot, histodot subset). Do NOT map aes.y — the bindot stat computes stack positions.",
+      "Allowed stats in GeomDotplot. GeomDotplot: Dotplot geometry: stacked dots along a continuous x axis (histodot subset). Do not map aes.y — the bindot stat computes stack positions.",
     href: "/reference/geoms/dotplot#allowed-stats",
     keywords: ["GeomDotplot", "documentation"],
     exact: ["Allowed stats"],
@@ -3251,7 +3251,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed positions",
     summary:
-      "Allowed positions in GeomDotplot. GeomDotplot: Dotplot geometry: stacked dots along a continuous x axis (ggplot2 geom_dotplot, histodot subset). Do NOT map aes.y — the bindot stat computes stack positions.",
+      "Allowed positions in GeomDotplot. GeomDotplot: Dotplot geometry: stacked dots along a continuous x axis (histodot subset). Do not map aes.y — the bindot stat computes stack positions.",
     href: "/reference/geoms/dotplot#allowed-positions",
     keywords: ["GeomDotplot", "documentation"],
     exact: ["Allowed positions"],
@@ -3261,7 +3261,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Examples",
     summary:
-      "Examples in GeomDotplot. GeomDotplot: Dotplot geometry: stacked dots along a continuous x axis (ggplot2 geom_dotplot, histodot subset). Do NOT map aes.y — the bindot stat computes stack positions.",
+      "Examples in GeomDotplot. GeomDotplot: Dotplot geometry: stacked dots along a continuous x axis (histodot subset). Do not map aes.y — the bindot stat computes stack positions.",
     href: "/reference/geoms/dotplot#examples",
     keywords: ["GeomDotplot", "documentation"],
     exact: ["Examples"],
@@ -3271,7 +3271,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "page",
     title: "GeomMap",
     summary:
-      "GeomMap: Map geometry (ggplot2 geom_map): join fortified region borders to value rows via aes.map_id and params.map. Renders closed filled paths per region (#808).",
+      "GeomMap: Map geometry: join fortified region borders to value rows via aes.map_id and params.map. Renders closed filled paths per region.",
     href: "/reference/geoms/map",
     keywords: [],
     exact: ["GeomMap"],
@@ -3281,7 +3281,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Defaults",
     summary:
-      "Defaults in GeomMap. GeomMap: Map geometry (ggplot2 geom_map): join fortified region borders to value rows via aes.map_id and params.map. Renders closed filled paths per region (#808).",
+      "Defaults in GeomMap. GeomMap: Map geometry: join fortified region borders to value rows via aes.map_id and params.map. Renders closed filled paths per region.",
     href: "/reference/geoms/map#defaults",
     keywords: ["GeomMap", "documentation"],
     exact: ["Defaults"],
@@ -3291,7 +3291,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Svelte component",
     summary:
-      "Svelte component in GeomMap. GeomMap: Map geometry (ggplot2 geom_map): join fortified region borders to value rows via aes.map_id and params.map. Renders closed filled paths per region (#808).",
+      "Svelte component in GeomMap. GeomMap: Map geometry: join fortified region borders to value rows via aes.map_id and params.map. Renders closed filled paths per region.",
     href: "/reference/geoms/map#svelte",
     keywords: ["GeomMap", "documentation"],
     exact: ["Svelte component"],
@@ -3301,7 +3301,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "JSON layer",
     summary:
-      "JSON layer in GeomMap. GeomMap: Map geometry (ggplot2 geom_map): join fortified region borders to value rows via aes.map_id and params.map. Renders closed filled paths per region (#808).",
+      "JSON layer in GeomMap. GeomMap: Map geometry: join fortified region borders to value rows via aes.map_id and params.map. Renders closed filled paths per region.",
     href: "/reference/geoms/map#json",
     keywords: ["GeomMap", "documentation"],
     exact: ["JSON layer"],
@@ -3311,7 +3311,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Params",
     summary:
-      "Params in GeomMap. GeomMap: Map geometry (ggplot2 geom_map): join fortified region borders to value rows via aes.map_id and params.map. Renders closed filled paths per region (#808).",
+      "Params in GeomMap. GeomMap: Map geometry: join fortified region borders to value rows via aes.map_id and params.map. Renders closed filled paths per region.",
     href: "/reference/geoms/map#params",
     keywords: ["GeomMap", "documentation"],
     exact: ["Params"],
@@ -3321,7 +3321,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed stats",
     summary:
-      "Allowed stats in GeomMap. GeomMap: Map geometry (ggplot2 geom_map): join fortified region borders to value rows via aes.map_id and params.map. Renders closed filled paths per region (#808).",
+      "Allowed stats in GeomMap. GeomMap: Map geometry: join fortified region borders to value rows via aes.map_id and params.map. Renders closed filled paths per region.",
     href: "/reference/geoms/map#allowed-stats",
     keywords: ["GeomMap", "documentation"],
     exact: ["Allowed stats"],
@@ -3331,7 +3331,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed positions",
     summary:
-      "Allowed positions in GeomMap. GeomMap: Map geometry (ggplot2 geom_map): join fortified region borders to value rows via aes.map_id and params.map. Renders closed filled paths per region (#808).",
+      "Allowed positions in GeomMap. GeomMap: Map geometry: join fortified region borders to value rows via aes.map_id and params.map. Renders closed filled paths per region.",
     href: "/reference/geoms/map#allowed-positions",
     keywords: ["GeomMap", "documentation"],
     exact: ["Allowed positions"],
@@ -3341,7 +3341,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Examples",
     summary:
-      "Examples in GeomMap. GeomMap: Map geometry (ggplot2 geom_map): join fortified region borders to value rows via aes.map_id and params.map. Renders closed filled paths per region (#808).",
+      "Examples in GeomMap. GeomMap: Map geometry: join fortified region borders to value rows via aes.map_id and params.map. Renders closed filled paths per region.",
     href: "/reference/geoms/map#examples",
     keywords: ["GeomMap", "documentation"],
     exact: ["Examples"],
@@ -3351,7 +3351,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "page",
     title: "GeomSf",
     summary:
-      "GeomSf: Simple-features geometry (ggplot2 geom_sf; #809): already-projected GeoJSON Geometry JSON strings in a data column. Point/line/polygon families (incl. GeometryCollection of one family) with even-odd holes; use coord_sf for fixed-aspect (CRS reproject deferred).",
+      "GeomSf: Simple-features geometry: already-projected GeoJSON Geometry JSON strings in a data column. Point/line/polygon families (incl. GeometryCollection of one family) with even-odd holes; use coord_sf for fixed-aspect (CRS reproject deferred).",
     href: "/reference/geoms/sf",
     keywords: [],
     exact: ["GeomSf"],
@@ -3361,7 +3361,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Defaults",
     summary:
-      "Defaults in GeomSf. GeomSf: Simple-features geometry (ggplot2 geom_sf; #809): already-projected GeoJSON Geometry JSON strings in a data column. Point/line/polygon families (incl. GeometryCollection of one family) with even-odd holes; use coord_sf for fixed-aspect (CRS reproject deferred).",
+      "Defaults in GeomSf. GeomSf: Simple-features geometry: already-projected GeoJSON Geometry JSON strings in a data column. Point/line/polygon families (incl. GeometryCollection of one family) with even-odd holes; use coord_sf for fixed-aspect (CRS reproject deferred).",
     href: "/reference/geoms/sf#defaults",
     keywords: ["GeomSf", "documentation"],
     exact: ["Defaults"],
@@ -3371,7 +3371,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Svelte component",
     summary:
-      "Svelte component in GeomSf. GeomSf: Simple-features geometry (ggplot2 geom_sf; #809): already-projected GeoJSON Geometry JSON strings in a data column. Point/line/polygon families (incl. GeometryCollection of one family) with even-odd holes; use coord_sf for fixed-aspect (CRS reproject deferred).",
+      "Svelte component in GeomSf. GeomSf: Simple-features geometry: already-projected GeoJSON Geometry JSON strings in a data column. Point/line/polygon families (incl. GeometryCollection of one family) with even-odd holes; use coord_sf for fixed-aspect (CRS reproject deferred).",
     href: "/reference/geoms/sf#svelte",
     keywords: ["GeomSf", "documentation"],
     exact: ["Svelte component"],
@@ -3381,7 +3381,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "JSON layer",
     summary:
-      "JSON layer in GeomSf. GeomSf: Simple-features geometry (ggplot2 geom_sf; #809): already-projected GeoJSON Geometry JSON strings in a data column. Point/line/polygon families (incl. GeometryCollection of one family) with even-odd holes; use coord_sf for fixed-aspect (CRS reproject deferred).",
+      "JSON layer in GeomSf. GeomSf: Simple-features geometry: already-projected GeoJSON Geometry JSON strings in a data column. Point/line/polygon families (incl. GeometryCollection of one family) with even-odd holes; use coord_sf for fixed-aspect (CRS reproject deferred).",
     href: "/reference/geoms/sf#json",
     keywords: ["GeomSf", "documentation"],
     exact: ["JSON layer"],
@@ -3391,7 +3391,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Params",
     summary:
-      "Params in GeomSf. GeomSf: Simple-features geometry (ggplot2 geom_sf; #809): already-projected GeoJSON Geometry JSON strings in a data column. Point/line/polygon families (incl. GeometryCollection of one family) with even-odd holes; use coord_sf for fixed-aspect (CRS reproject deferred).",
+      "Params in GeomSf. GeomSf: Simple-features geometry: already-projected GeoJSON Geometry JSON strings in a data column. Point/line/polygon families (incl. GeometryCollection of one family) with even-odd holes; use coord_sf for fixed-aspect (CRS reproject deferred).",
     href: "/reference/geoms/sf#params",
     keywords: ["GeomSf", "documentation"],
     exact: ["Params"],
@@ -3401,7 +3401,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed stats",
     summary:
-      "Allowed stats in GeomSf. GeomSf: Simple-features geometry (ggplot2 geom_sf; #809): already-projected GeoJSON Geometry JSON strings in a data column. Point/line/polygon families (incl. GeometryCollection of one family) with even-odd holes; use coord_sf for fixed-aspect (CRS reproject deferred).",
+      "Allowed stats in GeomSf. GeomSf: Simple-features geometry: already-projected GeoJSON Geometry JSON strings in a data column. Point/line/polygon families (incl. GeometryCollection of one family) with even-odd holes; use coord_sf for fixed-aspect (CRS reproject deferred).",
     href: "/reference/geoms/sf#allowed-stats",
     keywords: ["GeomSf", "documentation"],
     exact: ["Allowed stats"],
@@ -3411,7 +3411,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed positions",
     summary:
-      "Allowed positions in GeomSf. GeomSf: Simple-features geometry (ggplot2 geom_sf; #809): already-projected GeoJSON Geometry JSON strings in a data column. Point/line/polygon families (incl. GeometryCollection of one family) with even-odd holes; use coord_sf for fixed-aspect (CRS reproject deferred).",
+      "Allowed positions in GeomSf. GeomSf: Simple-features geometry: already-projected GeoJSON Geometry JSON strings in a data column. Point/line/polygon families (incl. GeometryCollection of one family) with even-odd holes; use coord_sf for fixed-aspect (CRS reproject deferred).",
     href: "/reference/geoms/sf#allowed-positions",
     keywords: ["GeomSf", "documentation"],
     exact: ["Allowed positions"],
@@ -3421,7 +3421,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Examples",
     summary:
-      "Examples in GeomSf. GeomSf: Simple-features geometry (ggplot2 geom_sf; #809): already-projected GeoJSON Geometry JSON strings in a data column. Point/line/polygon families (incl. GeometryCollection of one family) with even-odd holes; use coord_sf for fixed-aspect (CRS reproject deferred).",
+      "Examples in GeomSf. GeomSf: Simple-features geometry: already-projected GeoJSON Geometry JSON strings in a data column. Point/line/polygon families (incl. GeometryCollection of one family) with even-odd holes; use coord_sf for fixed-aspect (CRS reproject deferred).",
     href: "/reference/geoms/sf#examples",
     keywords: ["GeomSf", "documentation"],
     exact: ["Examples"],
@@ -3431,7 +3431,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "page",
     title: "GeomSfText",
     summary:
-      "GeomSfText: Simple-features text labels (ggplot2 geom_sf_text; #809): places aes.label at representative geometry points (Multi* → one label per part; stat_sf_coordinates).",
+      "GeomSfText: Simple-features text labels: places aes.label at representative geometry points (Multi* → one label per part; stat_sf_coordinates).",
     href: "/reference/geoms/sf_text",
     keywords: [],
     exact: ["GeomSfText"],
@@ -3441,7 +3441,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Defaults",
     summary:
-      "Defaults in GeomSfText. GeomSfText: Simple-features text labels (ggplot2 geom_sf_text; #809): places aes.label at representative geometry points (Multi* → one label per part; stat_sf_coordinates).",
+      "Defaults in GeomSfText. GeomSfText: Simple-features text labels: places aes.label at representative geometry points (Multi* → one label per part; stat_sf_coordinates).",
     href: "/reference/geoms/sf_text#defaults",
     keywords: ["GeomSfText", "documentation"],
     exact: ["Defaults"],
@@ -3451,7 +3451,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Svelte component",
     summary:
-      "Svelte component in GeomSfText. GeomSfText: Simple-features text labels (ggplot2 geom_sf_text; #809): places aes.label at representative geometry points (Multi* → one label per part; stat_sf_coordinates).",
+      "Svelte component in GeomSfText. GeomSfText: Simple-features text labels: places aes.label at representative geometry points (Multi* → one label per part; stat_sf_coordinates).",
     href: "/reference/geoms/sf_text#svelte",
     keywords: ["GeomSfText", "documentation"],
     exact: ["Svelte component"],
@@ -3461,7 +3461,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "JSON layer",
     summary:
-      "JSON layer in GeomSfText. GeomSfText: Simple-features text labels (ggplot2 geom_sf_text; #809): places aes.label at representative geometry points (Multi* → one label per part; stat_sf_coordinates).",
+      "JSON layer in GeomSfText. GeomSfText: Simple-features text labels: places aes.label at representative geometry points (Multi* → one label per part; stat_sf_coordinates).",
     href: "/reference/geoms/sf_text#json",
     keywords: ["GeomSfText", "documentation"],
     exact: ["JSON layer"],
@@ -3471,7 +3471,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Params",
     summary:
-      "Params in GeomSfText. GeomSfText: Simple-features text labels (ggplot2 geom_sf_text; #809): places aes.label at representative geometry points (Multi* → one label per part; stat_sf_coordinates).",
+      "Params in GeomSfText. GeomSfText: Simple-features text labels: places aes.label at representative geometry points (Multi* → one label per part; stat_sf_coordinates).",
     href: "/reference/geoms/sf_text#params",
     keywords: ["GeomSfText", "documentation"],
     exact: ["Params"],
@@ -3481,7 +3481,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed stats",
     summary:
-      "Allowed stats in GeomSfText. GeomSfText: Simple-features text labels (ggplot2 geom_sf_text; #809): places aes.label at representative geometry points (Multi* → one label per part; stat_sf_coordinates).",
+      "Allowed stats in GeomSfText. GeomSfText: Simple-features text labels: places aes.label at representative geometry points (Multi* → one label per part; stat_sf_coordinates).",
     href: "/reference/geoms/sf_text#allowed-stats",
     keywords: ["GeomSfText", "documentation"],
     exact: ["Allowed stats"],
@@ -3491,7 +3491,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed positions",
     summary:
-      "Allowed positions in GeomSfText. GeomSfText: Simple-features text labels (ggplot2 geom_sf_text; #809): places aes.label at representative geometry points (Multi* → one label per part; stat_sf_coordinates).",
+      "Allowed positions in GeomSfText. GeomSfText: Simple-features text labels: places aes.label at representative geometry points (Multi* → one label per part; stat_sf_coordinates).",
     href: "/reference/geoms/sf_text#allowed-positions",
     keywords: ["GeomSfText", "documentation"],
     exact: ["Allowed positions"],
@@ -3501,7 +3501,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Examples",
     summary:
-      "Examples in GeomSfText. GeomSfText: Simple-features text labels (ggplot2 geom_sf_text; #809): places aes.label at representative geometry points (Multi* → one label per part; stat_sf_coordinates).",
+      "Examples in GeomSfText. GeomSfText: Simple-features text labels: places aes.label at representative geometry points (Multi* → one label per part; stat_sf_coordinates).",
     href: "/reference/geoms/sf_text#examples",
     keywords: ["GeomSfText", "documentation"],
     exact: ["Examples"],
@@ -3511,7 +3511,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "page",
     title: "GeomSfLabel",
     summary:
-      "GeomSfLabel: Simple-features labels with background boxes (ggplot2 geom_sf_label; #809): places aes.label at representative geometry points with a measured rounded rect (Multi* → one label per part). color=ink+box stroke; fill=box background.",
+      "GeomSfLabel: Simple-features labels with background boxes: places aes.label at representative geometry points with a measured rounded rect (Multi* → one label per part). color=ink+box stroke; fill=box background.",
     href: "/reference/geoms/sf_label",
     keywords: [],
     exact: ["GeomSfLabel"],
@@ -3521,7 +3521,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Defaults",
     summary:
-      "Defaults in GeomSfLabel. GeomSfLabel: Simple-features labels with background boxes (ggplot2 geom_sf_label; #809): places aes.label at representative geometry points with a measured rounded rect (Multi* → one label per part). color=ink+box stroke; fill=box background.",
+      "Defaults in GeomSfLabel. GeomSfLabel: Simple-features labels with background boxes: places aes.label at representative geometry points with a measured rounded rect (Multi* → one label per part). color=ink+box stroke; fill=box background.",
     href: "/reference/geoms/sf_label#defaults",
     keywords: ["GeomSfLabel", "documentation"],
     exact: ["Defaults"],
@@ -3531,7 +3531,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Svelte component",
     summary:
-      "Svelte component in GeomSfLabel. GeomSfLabel: Simple-features labels with background boxes (ggplot2 geom_sf_label; #809): places aes.label at representative geometry points with a measured rounded rect (Multi* → one label per part). color=ink+box stroke; fill=box background.",
+      "Svelte component in GeomSfLabel. GeomSfLabel: Simple-features labels with background boxes: places aes.label at representative geometry points with a measured rounded rect (Multi* → one label per part). color=ink+box stroke; fill=box background.",
     href: "/reference/geoms/sf_label#svelte",
     keywords: ["GeomSfLabel", "documentation"],
     exact: ["Svelte component"],
@@ -3541,7 +3541,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "JSON layer",
     summary:
-      "JSON layer in GeomSfLabel. GeomSfLabel: Simple-features labels with background boxes (ggplot2 geom_sf_label; #809): places aes.label at representative geometry points with a measured rounded rect (Multi* → one label per part). color=ink+box stroke; fill=box background.",
+      "JSON layer in GeomSfLabel. GeomSfLabel: Simple-features labels with background boxes: places aes.label at representative geometry points with a measured rounded rect (Multi* → one label per part). color=ink+box stroke; fill=box background.",
     href: "/reference/geoms/sf_label#json",
     keywords: ["GeomSfLabel", "documentation"],
     exact: ["JSON layer"],
@@ -3551,7 +3551,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Params",
     summary:
-      "Params in GeomSfLabel. GeomSfLabel: Simple-features labels with background boxes (ggplot2 geom_sf_label; #809): places aes.label at representative geometry points with a measured rounded rect (Multi* → one label per part). color=ink+box stroke; fill=box background.",
+      "Params in GeomSfLabel. GeomSfLabel: Simple-features labels with background boxes: places aes.label at representative geometry points with a measured rounded rect (Multi* → one label per part). color=ink+box stroke; fill=box background.",
     href: "/reference/geoms/sf_label#params",
     keywords: ["GeomSfLabel", "documentation"],
     exact: ["Params"],
@@ -3561,7 +3561,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed stats",
     summary:
-      "Allowed stats in GeomSfLabel. GeomSfLabel: Simple-features labels with background boxes (ggplot2 geom_sf_label; #809): places aes.label at representative geometry points with a measured rounded rect (Multi* → one label per part). color=ink+box stroke; fill=box background.",
+      "Allowed stats in GeomSfLabel. GeomSfLabel: Simple-features labels with background boxes: places aes.label at representative geometry points with a measured rounded rect (Multi* → one label per part). color=ink+box stroke; fill=box background.",
     href: "/reference/geoms/sf_label#allowed-stats",
     keywords: ["GeomSfLabel", "documentation"],
     exact: ["Allowed stats"],
@@ -3571,7 +3571,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed positions",
     summary:
-      "Allowed positions in GeomSfLabel. GeomSfLabel: Simple-features labels with background boxes (ggplot2 geom_sf_label; #809): places aes.label at representative geometry points with a measured rounded rect (Multi* → one label per part). color=ink+box stroke; fill=box background.",
+      "Allowed positions in GeomSfLabel. GeomSfLabel: Simple-features labels with background boxes: places aes.label at representative geometry points with a measured rounded rect (Multi* → one label per part). color=ink+box stroke; fill=box background.",
     href: "/reference/geoms/sf_label#allowed-positions",
     keywords: ["GeomSfLabel", "documentation"],
     exact: ["Allowed positions"],
@@ -3581,7 +3581,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Examples",
     summary:
-      "Examples in GeomSfLabel. GeomSfLabel: Simple-features labels with background boxes (ggplot2 geom_sf_label; #809): places aes.label at representative geometry points with a measured rounded rect (Multi* → one label per part). color=ink+box stroke; fill=box background.",
+      "Examples in GeomSfLabel. GeomSfLabel: Simple-features labels with background boxes: places aes.label at representative geometry points with a measured rounded rect (Multi* → one label per part). color=ink+box stroke; fill=box background.",
     href: "/reference/geoms/sf_label#examples",
     keywords: ["GeomSfLabel", "documentation"],
     exact: ["Examples"],
@@ -3591,7 +3591,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "page",
     title: "GeomBlank",
     summary:
-      "GeomBlank: Blank geometry (ggplot2's geom_blank): contributes mapped aesthetics to scale training and layout without drawing marks or hit targets. No channels are required; whatever is mapped trains its scale.",
+      "GeomBlank: Blank geometry: contributes mapped aesthetics to scale training and layout without drawing marks or hit targets. No channels are required; whatever is mapped trains its scale.",
     href: "/reference/geoms/blank",
     keywords: [],
     exact: ["GeomBlank"],
@@ -3601,7 +3601,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Defaults",
     summary:
-      "Defaults in GeomBlank. GeomBlank: Blank geometry (ggplot2's geom_blank): contributes mapped aesthetics to scale training and layout without drawing marks or hit targets. No channels are required; whatever is mapped trains its scale.",
+      "Defaults in GeomBlank. GeomBlank: Blank geometry: contributes mapped aesthetics to scale training and layout without drawing marks or hit targets. No channels are required; whatever is mapped trains its scale.",
     href: "/reference/geoms/blank#defaults",
     keywords: ["GeomBlank", "documentation"],
     exact: ["Defaults"],
@@ -3611,7 +3611,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Svelte component",
     summary:
-      "Svelte component in GeomBlank. GeomBlank: Blank geometry (ggplot2's geom_blank): contributes mapped aesthetics to scale training and layout without drawing marks or hit targets. No channels are required; whatever is mapped trains its scale.",
+      "Svelte component in GeomBlank. GeomBlank: Blank geometry: contributes mapped aesthetics to scale training and layout without drawing marks or hit targets. No channels are required; whatever is mapped trains its scale.",
     href: "/reference/geoms/blank#svelte",
     keywords: ["GeomBlank", "documentation"],
     exact: ["Svelte component"],
@@ -3621,7 +3621,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "JSON layer",
     summary:
-      "JSON layer in GeomBlank. GeomBlank: Blank geometry (ggplot2's geom_blank): contributes mapped aesthetics to scale training and layout without drawing marks or hit targets. No channels are required; whatever is mapped trains its scale.",
+      "JSON layer in GeomBlank. GeomBlank: Blank geometry: contributes mapped aesthetics to scale training and layout without drawing marks or hit targets. No channels are required; whatever is mapped trains its scale.",
     href: "/reference/geoms/blank#json",
     keywords: ["GeomBlank", "documentation"],
     exact: ["JSON layer"],
@@ -3631,7 +3631,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Params",
     summary:
-      "Params in GeomBlank. GeomBlank: Blank geometry (ggplot2's geom_blank): contributes mapped aesthetics to scale training and layout without drawing marks or hit targets. No channels are required; whatever is mapped trains its scale.",
+      "Params in GeomBlank. GeomBlank: Blank geometry: contributes mapped aesthetics to scale training and layout without drawing marks or hit targets. No channels are required; whatever is mapped trains its scale.",
     href: "/reference/geoms/blank#params",
     keywords: ["GeomBlank", "documentation"],
     exact: ["Params"],
@@ -3641,7 +3641,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed stats",
     summary:
-      "Allowed stats in GeomBlank. GeomBlank: Blank geometry (ggplot2's geom_blank): contributes mapped aesthetics to scale training and layout without drawing marks or hit targets. No channels are required; whatever is mapped trains its scale.",
+      "Allowed stats in GeomBlank. GeomBlank: Blank geometry: contributes mapped aesthetics to scale training and layout without drawing marks or hit targets. No channels are required; whatever is mapped trains its scale.",
     href: "/reference/geoms/blank#allowed-stats",
     keywords: ["GeomBlank", "documentation"],
     exact: ["Allowed stats"],
@@ -3651,7 +3651,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed positions",
     summary:
-      "Allowed positions in GeomBlank. GeomBlank: Blank geometry (ggplot2's geom_blank): contributes mapped aesthetics to scale training and layout without drawing marks or hit targets. No channels are required; whatever is mapped trains its scale.",
+      "Allowed positions in GeomBlank. GeomBlank: Blank geometry: contributes mapped aesthetics to scale training and layout without drawing marks or hit targets. No channels are required; whatever is mapped trains its scale.",
     href: "/reference/geoms/blank#allowed-positions",
     keywords: ["GeomBlank", "documentation"],
     exact: ["Allowed positions"],
@@ -3661,7 +3661,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Examples",
     summary:
-      "Examples in GeomBlank. GeomBlank: Blank geometry (ggplot2's geom_blank): contributes mapped aesthetics to scale training and layout without drawing marks or hit targets. No channels are required; whatever is mapped trains its scale.",
+      "Examples in GeomBlank. GeomBlank: Blank geometry: contributes mapped aesthetics to scale training and layout without drawing marks or hit targets. No channels are required; whatever is mapped trains its scale.",
     href: "/reference/geoms/blank#examples",
     keywords: ["GeomBlank", "documentation"],
     exact: ["Examples"],
@@ -3671,7 +3671,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "page",
     title: "GeomJitter",
     summary:
-      "GeomJitter: Jittered point alias (ggplot2's geom_jitter). Canonicalized by normalize() to a point layer with position jitter. Configure jitter amount via positionParams.width/height/seed.",
+      "GeomJitter: Jittered point alias. Canonicalized by normalize() to a point layer with position jitter. Configure jitter amount via positionParams.width/height/seed.",
     href: "/reference/geoms/jitter",
     keywords: [],
     exact: ["GeomJitter"],
@@ -3681,7 +3681,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Defaults",
     summary:
-      "Defaults in GeomJitter. GeomJitter: Jittered point alias (ggplot2's geom_jitter). Canonicalized by normalize() to a point layer with position jitter. Configure jitter amount via positionParams.width/height/seed.",
+      "Defaults in GeomJitter. GeomJitter: Jittered point alias. Canonicalized by normalize() to a point layer with position jitter. Configure jitter amount via positionParams.width/height/seed.",
     href: "/reference/geoms/jitter#defaults",
     keywords: ["GeomJitter", "documentation"],
     exact: ["Defaults"],
@@ -3691,7 +3691,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Alias",
     summary:
-      "Alias in GeomJitter. GeomJitter: Jittered point alias (ggplot2's geom_jitter). Canonicalized by normalize() to a point layer with position jitter. Configure jitter amount via positionParams.width/height/seed.",
+      "Alias in GeomJitter. GeomJitter: Jittered point alias. Canonicalized by normalize() to a point layer with position jitter. Configure jitter amount via positionParams.width/height/seed.",
     href: "/reference/geoms/jitter#alias",
     keywords: ["GeomJitter", "documentation"],
     exact: ["Alias"],
@@ -3701,7 +3701,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Svelte component",
     summary:
-      "Svelte component in GeomJitter. GeomJitter: Jittered point alias (ggplot2's geom_jitter). Canonicalized by normalize() to a point layer with position jitter. Configure jitter amount via positionParams.width/height/seed.",
+      "Svelte component in GeomJitter. GeomJitter: Jittered point alias. Canonicalized by normalize() to a point layer with position jitter. Configure jitter amount via positionParams.width/height/seed.",
     href: "/reference/geoms/jitter#svelte",
     keywords: ["GeomJitter", "documentation"],
     exact: ["Svelte component"],
@@ -3711,7 +3711,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "JSON layer",
     summary:
-      "JSON layer in GeomJitter. GeomJitter: Jittered point alias (ggplot2's geom_jitter). Canonicalized by normalize() to a point layer with position jitter. Configure jitter amount via positionParams.width/height/seed.",
+      "JSON layer in GeomJitter. GeomJitter: Jittered point alias. Canonicalized by normalize() to a point layer with position jitter. Configure jitter amount via positionParams.width/height/seed.",
     href: "/reference/geoms/jitter#json",
     keywords: ["GeomJitter", "documentation"],
     exact: ["JSON layer"],
@@ -3721,7 +3721,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Params",
     summary:
-      "Params in GeomJitter. GeomJitter: Jittered point alias (ggplot2's geom_jitter). Canonicalized by normalize() to a point layer with position jitter. Configure jitter amount via positionParams.width/height/seed.",
+      "Params in GeomJitter. GeomJitter: Jittered point alias. Canonicalized by normalize() to a point layer with position jitter. Configure jitter amount via positionParams.width/height/seed.",
     href: "/reference/geoms/jitter#params",
     keywords: ["GeomJitter", "documentation"],
     exact: ["Params"],
@@ -3731,7 +3731,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed stats",
     summary:
-      "Allowed stats in GeomJitter. GeomJitter: Jittered point alias (ggplot2's geom_jitter). Canonicalized by normalize() to a point layer with position jitter. Configure jitter amount via positionParams.width/height/seed.",
+      "Allowed stats in GeomJitter. GeomJitter: Jittered point alias. Canonicalized by normalize() to a point layer with position jitter. Configure jitter amount via positionParams.width/height/seed.",
     href: "/reference/geoms/jitter#allowed-stats",
     keywords: ["GeomJitter", "documentation"],
     exact: ["Allowed stats"],
@@ -3741,7 +3741,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed positions",
     summary:
-      "Allowed positions in GeomJitter. GeomJitter: Jittered point alias (ggplot2's geom_jitter). Canonicalized by normalize() to a point layer with position jitter. Configure jitter amount via positionParams.width/height/seed.",
+      "Allowed positions in GeomJitter. GeomJitter: Jittered point alias. Canonicalized by normalize() to a point layer with position jitter. Configure jitter amount via positionParams.width/height/seed.",
     href: "/reference/geoms/jitter#allowed-positions",
     keywords: ["GeomJitter", "documentation"],
     exact: ["Allowed positions"],
@@ -3751,7 +3751,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Examples",
     summary:
-      "Examples in GeomJitter. GeomJitter: Jittered point alias (ggplot2's geom_jitter). Canonicalized by normalize() to a point layer with position jitter. Configure jitter amount via positionParams.width/height/seed.",
+      "Examples in GeomJitter. GeomJitter: Jittered point alias. Canonicalized by normalize() to a point layer with position jitter. Configure jitter amount via positionParams.width/height/seed.",
     href: "/reference/geoms/jitter#examples",
     keywords: ["GeomJitter", "documentation"],
     exact: ["Examples"],
@@ -3761,7 +3761,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "page",
     title: "GeomSpoke",
     summary:
-      "GeomSpoke: Spoke geometry (ggplot2 geom_spoke): one finite segment per row from (x, y) in direction angle (radians) with length radius. Endpoints are derived as xend = x + radius·cos(angle), yend = y + radius·sin(angle) in data space, then transformed like x/y. Requires continuous x and y.",
+      "GeomSpoke: Spoke geometry: one finite segment per row from (x, y) in direction angle (radians) with length radius. Endpoints are derived as xend = x + radius·cos(angle), yend = y + radius·sin(angle) in data space, then transformed like x/y. Requires continuous x and y.",
     href: "/reference/geoms/spoke",
     keywords: [],
     exact: ["GeomSpoke"],
@@ -3771,7 +3771,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Defaults",
     summary:
-      "Defaults in GeomSpoke. GeomSpoke: Spoke geometry (ggplot2 geom_spoke): one finite segment per row from (x, y) in direction angle (radians) with length radius. Endpoints are derived as xend = x + radius·cos(angle), yend = y + radius·sin(angle) in data space, then transformed like x/y. Requires continuous x and y.",
+      "Defaults in GeomSpoke. GeomSpoke: Spoke geometry: one finite segment per row from (x, y) in direction angle (radians) with length radius. Endpoints are derived as xend = x + radius·cos(angle), yend = y + radius·sin(angle) in data space, then transformed like x/y. Requires continuous x and y.",
     href: "/reference/geoms/spoke#defaults",
     keywords: ["GeomSpoke", "documentation"],
     exact: ["Defaults"],
@@ -3781,7 +3781,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Svelte component",
     summary:
-      "Svelte component in GeomSpoke. GeomSpoke: Spoke geometry (ggplot2 geom_spoke): one finite segment per row from (x, y) in direction angle (radians) with length radius. Endpoints are derived as xend = x + radius·cos(angle), yend = y + radius·sin(angle) in data space, then transformed like x/y. Requires continuous x and y.",
+      "Svelte component in GeomSpoke. GeomSpoke: Spoke geometry: one finite segment per row from (x, y) in direction angle (radians) with length radius. Endpoints are derived as xend = x + radius·cos(angle), yend = y + radius·sin(angle) in data space, then transformed like x/y. Requires continuous x and y.",
     href: "/reference/geoms/spoke#svelte",
     keywords: ["GeomSpoke", "documentation"],
     exact: ["Svelte component"],
@@ -3791,7 +3791,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "JSON layer",
     summary:
-      "JSON layer in GeomSpoke. GeomSpoke: Spoke geometry (ggplot2 geom_spoke): one finite segment per row from (x, y) in direction angle (radians) with length radius. Endpoints are derived as xend = x + radius·cos(angle), yend = y + radius·sin(angle) in data space, then transformed like x/y. Requires continuous x and y.",
+      "JSON layer in GeomSpoke. GeomSpoke: Spoke geometry: one finite segment per row from (x, y) in direction angle (radians) with length radius. Endpoints are derived as xend = x + radius·cos(angle), yend = y + radius·sin(angle) in data space, then transformed like x/y. Requires continuous x and y.",
     href: "/reference/geoms/spoke#json",
     keywords: ["GeomSpoke", "documentation"],
     exact: ["JSON layer"],
@@ -3801,7 +3801,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Params",
     summary:
-      "Params in GeomSpoke. GeomSpoke: Spoke geometry (ggplot2 geom_spoke): one finite segment per row from (x, y) in direction angle (radians) with length radius. Endpoints are derived as xend = x + radius·cos(angle), yend = y + radius·sin(angle) in data space, then transformed like x/y. Requires continuous x and y.",
+      "Params in GeomSpoke. GeomSpoke: Spoke geometry: one finite segment per row from (x, y) in direction angle (radians) with length radius. Endpoints are derived as xend = x + radius·cos(angle), yend = y + radius·sin(angle) in data space, then transformed like x/y. Requires continuous x and y.",
     href: "/reference/geoms/spoke#params",
     keywords: ["GeomSpoke", "documentation"],
     exact: ["Params"],
@@ -3811,7 +3811,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed stats",
     summary:
-      "Allowed stats in GeomSpoke. GeomSpoke: Spoke geometry (ggplot2 geom_spoke): one finite segment per row from (x, y) in direction angle (radians) with length radius. Endpoints are derived as xend = x + radius·cos(angle), yend = y + radius·sin(angle) in data space, then transformed like x/y. Requires continuous x and y.",
+      "Allowed stats in GeomSpoke. GeomSpoke: Spoke geometry: one finite segment per row from (x, y) in direction angle (radians) with length radius. Endpoints are derived as xend = x + radius·cos(angle), yend = y + radius·sin(angle) in data space, then transformed like x/y. Requires continuous x and y.",
     href: "/reference/geoms/spoke#allowed-stats",
     keywords: ["GeomSpoke", "documentation"],
     exact: ["Allowed stats"],
@@ -3821,7 +3821,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed positions",
     summary:
-      "Allowed positions in GeomSpoke. GeomSpoke: Spoke geometry (ggplot2 geom_spoke): one finite segment per row from (x, y) in direction angle (radians) with length radius. Endpoints are derived as xend = x + radius·cos(angle), yend = y + radius·sin(angle) in data space, then transformed like x/y. Requires continuous x and y.",
+      "Allowed positions in GeomSpoke. GeomSpoke: Spoke geometry: one finite segment per row from (x, y) in direction angle (radians) with length radius. Endpoints are derived as xend = x + radius·cos(angle), yend = y + radius·sin(angle) in data space, then transformed like x/y. Requires continuous x and y.",
     href: "/reference/geoms/spoke#allowed-positions",
     keywords: ["GeomSpoke", "documentation"],
     exact: ["Allowed positions"],
@@ -3831,7 +3831,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Examples",
     summary:
-      "Examples in GeomSpoke. GeomSpoke: Spoke geometry (ggplot2 geom_spoke): one finite segment per row from (x, y) in direction angle (radians) with length radius. Endpoints are derived as xend = x + radius·cos(angle), yend = y + radius·sin(angle) in data space, then transformed like x/y. Requires continuous x and y.",
+      "Examples in GeomSpoke. GeomSpoke: Spoke geometry: one finite segment per row from (x, y) in direction angle (radians) with length radius. Endpoints are derived as xend = x + radius·cos(angle), yend = y + radius·sin(angle) in data space, then transformed like x/y. Requires continuous x and y.",
     href: "/reference/geoms/spoke#examples",
     keywords: ["GeomSpoke", "documentation"],
     exact: ["Examples"],
@@ -3841,7 +3841,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "page",
     title: "GeomRug",
     summary:
-      "GeomRug: Rug geometry: short ticks along panel edges for each observation (ggplot2 geom_rug). Map aes.x for bottom/top sides and/or aes.y for left/right sides.",
+      "GeomRug: Rug geometry: short ticks along panel edges for each observation. Map aes.x for bottom/top sides and/or aes.y for left/right sides.",
     href: "/reference/geoms/rug",
     keywords: [],
     exact: ["GeomRug"],
@@ -3851,7 +3851,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Defaults",
     summary:
-      "Defaults in GeomRug. GeomRug: Rug geometry: short ticks along panel edges for each observation (ggplot2 geom_rug). Map aes.x for bottom/top sides and/or aes.y for left/right sides.",
+      "Defaults in GeomRug. GeomRug: Rug geometry: short ticks along panel edges for each observation. Map aes.x for bottom/top sides and/or aes.y for left/right sides.",
     href: "/reference/geoms/rug#defaults",
     keywords: ["GeomRug", "documentation"],
     exact: ["Defaults"],
@@ -3861,7 +3861,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Svelte component",
     summary:
-      "Svelte component in GeomRug. GeomRug: Rug geometry: short ticks along panel edges for each observation (ggplot2 geom_rug). Map aes.x for bottom/top sides and/or aes.y for left/right sides.",
+      "Svelte component in GeomRug. GeomRug: Rug geometry: short ticks along panel edges for each observation. Map aes.x for bottom/top sides and/or aes.y for left/right sides.",
     href: "/reference/geoms/rug#svelte",
     keywords: ["GeomRug", "documentation"],
     exact: ["Svelte component"],
@@ -3871,7 +3871,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "JSON layer",
     summary:
-      "JSON layer in GeomRug. GeomRug: Rug geometry: short ticks along panel edges for each observation (ggplot2 geom_rug). Map aes.x for bottom/top sides and/or aes.y for left/right sides.",
+      "JSON layer in GeomRug. GeomRug: Rug geometry: short ticks along panel edges for each observation. Map aes.x for bottom/top sides and/or aes.y for left/right sides.",
     href: "/reference/geoms/rug#json",
     keywords: ["GeomRug", "documentation"],
     exact: ["JSON layer"],
@@ -3881,7 +3881,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Params",
     summary:
-      "Params in GeomRug. GeomRug: Rug geometry: short ticks along panel edges for each observation (ggplot2 geom_rug). Map aes.x for bottom/top sides and/or aes.y for left/right sides.",
+      "Params in GeomRug. GeomRug: Rug geometry: short ticks along panel edges for each observation. Map aes.x for bottom/top sides and/or aes.y for left/right sides.",
     href: "/reference/geoms/rug#params",
     keywords: ["GeomRug", "documentation"],
     exact: ["Params"],
@@ -3891,7 +3891,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed stats",
     summary:
-      "Allowed stats in GeomRug. GeomRug: Rug geometry: short ticks along panel edges for each observation (ggplot2 geom_rug). Map aes.x for bottom/top sides and/or aes.y for left/right sides.",
+      "Allowed stats in GeomRug. GeomRug: Rug geometry: short ticks along panel edges for each observation. Map aes.x for bottom/top sides and/or aes.y for left/right sides.",
     href: "/reference/geoms/rug#allowed-stats",
     keywords: ["GeomRug", "documentation"],
     exact: ["Allowed stats"],
@@ -3901,7 +3901,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed positions",
     summary:
-      "Allowed positions in GeomRug. GeomRug: Rug geometry: short ticks along panel edges for each observation (ggplot2 geom_rug). Map aes.x for bottom/top sides and/or aes.y for left/right sides.",
+      "Allowed positions in GeomRug. GeomRug: Rug geometry: short ticks along panel edges for each observation. Map aes.x for bottom/top sides and/or aes.y for left/right sides.",
     href: "/reference/geoms/rug#allowed-positions",
     keywords: ["GeomRug", "documentation"],
     exact: ["Allowed positions"],
@@ -3911,7 +3911,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Examples",
     summary:
-      "Examples in GeomRug. GeomRug: Rug geometry: short ticks along panel edges for each observation (ggplot2 geom_rug). Map aes.x for bottom/top sides and/or aes.y for left/right sides.",
+      "Examples in GeomRug. GeomRug: Rug geometry: short ticks along panel edges for each observation. Map aes.x for bottom/top sides and/or aes.y for left/right sides.",
     href: "/reference/geoms/rug#examples",
     keywords: ["GeomRug", "documentation"],
     exact: ["Examples"],
@@ -3921,7 +3921,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "page",
     title: "GeomStep",
     summary:
-      "GeomStep: Step-line geometry: connect points with hv/vh/mid stairs (ggplot2 geom_step). Same channels as line; ordered by x within groups.",
+      "GeomStep: Step-line geometry: connect points with hv/vh/mid stairs. Same channels as line; ordered by x within groups.",
     href: "/reference/geoms/step",
     keywords: [],
     exact: ["GeomStep"],
@@ -3931,7 +3931,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Defaults",
     summary:
-      "Defaults in GeomStep. GeomStep: Step-line geometry: connect points with hv/vh/mid stairs (ggplot2 geom_step). Same channels as line; ordered by x within groups.",
+      "Defaults in GeomStep. GeomStep: Step-line geometry: connect points with hv/vh/mid stairs. Same channels as line; ordered by x within groups.",
     href: "/reference/geoms/step#defaults",
     keywords: ["GeomStep", "documentation"],
     exact: ["Defaults"],
@@ -3941,7 +3941,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Svelte component",
     summary:
-      "Svelte component in GeomStep. GeomStep: Step-line geometry: connect points with hv/vh/mid stairs (ggplot2 geom_step). Same channels as line; ordered by x within groups.",
+      "Svelte component in GeomStep. GeomStep: Step-line geometry: connect points with hv/vh/mid stairs. Same channels as line; ordered by x within groups.",
     href: "/reference/geoms/step#svelte",
     keywords: ["GeomStep", "documentation"],
     exact: ["Svelte component"],
@@ -3951,7 +3951,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "JSON layer",
     summary:
-      "JSON layer in GeomStep. GeomStep: Step-line geometry: connect points with hv/vh/mid stairs (ggplot2 geom_step). Same channels as line; ordered by x within groups.",
+      "JSON layer in GeomStep. GeomStep: Step-line geometry: connect points with hv/vh/mid stairs. Same channels as line; ordered by x within groups.",
     href: "/reference/geoms/step#json",
     keywords: ["GeomStep", "documentation"],
     exact: ["JSON layer"],
@@ -3961,7 +3961,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Params",
     summary:
-      "Params in GeomStep. GeomStep: Step-line geometry: connect points with hv/vh/mid stairs (ggplot2 geom_step). Same channels as line; ordered by x within groups.",
+      "Params in GeomStep. GeomStep: Step-line geometry: connect points with hv/vh/mid stairs. Same channels as line; ordered by x within groups.",
     href: "/reference/geoms/step#params",
     keywords: ["GeomStep", "documentation"],
     exact: ["Params"],
@@ -3971,7 +3971,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed stats",
     summary:
-      "Allowed stats in GeomStep. GeomStep: Step-line geometry: connect points with hv/vh/mid stairs (ggplot2 geom_step). Same channels as line; ordered by x within groups.",
+      "Allowed stats in GeomStep. GeomStep: Step-line geometry: connect points with hv/vh/mid stairs. Same channels as line; ordered by x within groups.",
     href: "/reference/geoms/step#allowed-stats",
     keywords: ["GeomStep", "documentation"],
     exact: ["Allowed stats"],
@@ -3981,7 +3981,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed positions",
     summary:
-      "Allowed positions in GeomStep. GeomStep: Step-line geometry: connect points with hv/vh/mid stairs (ggplot2 geom_step). Same channels as line; ordered by x within groups.",
+      "Allowed positions in GeomStep. GeomStep: Step-line geometry: connect points with hv/vh/mid stairs. Same channels as line; ordered by x within groups.",
     href: "/reference/geoms/step#allowed-positions",
     keywords: ["GeomStep", "documentation"],
     exact: ["Allowed positions"],
@@ -3991,7 +3991,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Examples",
     summary:
-      "Examples in GeomStep. GeomStep: Step-line geometry: connect points with hv/vh/mid stairs (ggplot2 geom_step). Same channels as line; ordered by x within groups.",
+      "Examples in GeomStep. GeomStep: Step-line geometry: connect points with hv/vh/mid stairs. Same channels as line; ordered by x within groups.",
     href: "/reference/geoms/step#examples",
     keywords: ["GeomStep", "documentation"],
     exact: ["Examples"],
@@ -4001,7 +4001,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "page",
     title: "GeomQq",
     summary:
-      "GeomQq: Q–Q scatter (ggplot2 geom_qq / stat_qq): sample quantiles vs theoretical normal quantiles. Requires aes.sample.",
+      "GeomQq: Q–Q scatter: sample quantiles vs theoretical normal quantiles. Requires aes.sample.",
     href: "/reference/geoms/qq",
     keywords: [],
     exact: ["GeomQq"],
@@ -4011,7 +4011,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Defaults",
     summary:
-      "Defaults in GeomQq. GeomQq: Q–Q scatter (ggplot2 geom_qq / stat_qq): sample quantiles vs theoretical normal quantiles. Requires aes.sample.",
+      "Defaults in GeomQq. GeomQq: Q–Q scatter: sample quantiles vs theoretical normal quantiles. Requires aes.sample.",
     href: "/reference/geoms/qq#defaults",
     keywords: ["GeomQq", "documentation"],
     exact: ["Defaults"],
@@ -4021,7 +4021,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Svelte component",
     summary:
-      "Svelte component in GeomQq. GeomQq: Q–Q scatter (ggplot2 geom_qq / stat_qq): sample quantiles vs theoretical normal quantiles. Requires aes.sample.",
+      "Svelte component in GeomQq. GeomQq: Q–Q scatter: sample quantiles vs theoretical normal quantiles. Requires aes.sample.",
     href: "/reference/geoms/qq#svelte",
     keywords: ["GeomQq", "documentation"],
     exact: ["Svelte component"],
@@ -4031,7 +4031,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "JSON layer",
     summary:
-      "JSON layer in GeomQq. GeomQq: Q–Q scatter (ggplot2 geom_qq / stat_qq): sample quantiles vs theoretical normal quantiles. Requires aes.sample.",
+      "JSON layer in GeomQq. GeomQq: Q–Q scatter: sample quantiles vs theoretical normal quantiles. Requires aes.sample.",
     href: "/reference/geoms/qq#json",
     keywords: ["GeomQq", "documentation"],
     exact: ["JSON layer"],
@@ -4041,7 +4041,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Params",
     summary:
-      "Params in GeomQq. GeomQq: Q–Q scatter (ggplot2 geom_qq / stat_qq): sample quantiles vs theoretical normal quantiles. Requires aes.sample.",
+      "Params in GeomQq. GeomQq: Q–Q scatter: sample quantiles vs theoretical normal quantiles. Requires aes.sample.",
     href: "/reference/geoms/qq#params",
     keywords: ["GeomQq", "documentation"],
     exact: ["Params"],
@@ -4051,7 +4051,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed stats",
     summary:
-      "Allowed stats in GeomQq. GeomQq: Q–Q scatter (ggplot2 geom_qq / stat_qq): sample quantiles vs theoretical normal quantiles. Requires aes.sample.",
+      "Allowed stats in GeomQq. GeomQq: Q–Q scatter: sample quantiles vs theoretical normal quantiles. Requires aes.sample.",
     href: "/reference/geoms/qq#allowed-stats",
     keywords: ["GeomQq", "documentation"],
     exact: ["Allowed stats"],
@@ -4061,7 +4061,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed positions",
     summary:
-      "Allowed positions in GeomQq. GeomQq: Q–Q scatter (ggplot2 geom_qq / stat_qq): sample quantiles vs theoretical normal quantiles. Requires aes.sample.",
+      "Allowed positions in GeomQq. GeomQq: Q–Q scatter: sample quantiles vs theoretical normal quantiles. Requires aes.sample.",
     href: "/reference/geoms/qq#allowed-positions",
     keywords: ["GeomQq", "documentation"],
     exact: ["Allowed positions"],
@@ -4071,7 +4071,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Examples",
     summary:
-      "Examples in GeomQq. GeomQq: Q–Q scatter (ggplot2 geom_qq / stat_qq): sample quantiles vs theoretical normal quantiles. Requires aes.sample.",
+      "Examples in GeomQq. GeomQq: Q–Q scatter: sample quantiles vs theoretical normal quantiles. Requires aes.sample.",
     href: "/reference/geoms/qq#examples",
     keywords: ["GeomQq", "documentation"],
     exact: ["Examples"],
@@ -4081,7 +4081,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "page",
     title: "GeomQqLine",
     summary:
-      "GeomQqLine: Q–Q reference line (ggplot2 geom_qq_line / stat_qq_line): line through sample/theoretical quartile match, spanning the theoretical range of the Q–Q cloud. Requires aes.sample.",
+      "GeomQqLine: Q–Q reference line: line through sample/theoretical quartile match, spanning the theoretical range of the Q–Q cloud. Requires aes.sample.",
     href: "/reference/geoms/qq_line",
     keywords: [],
     exact: ["GeomQqLine"],
@@ -4091,7 +4091,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Defaults",
     summary:
-      "Defaults in GeomQqLine. GeomQqLine: Q–Q reference line (ggplot2 geom_qq_line / stat_qq_line): line through sample/theoretical quartile match, spanning the theoretical range of the Q–Q cloud. Requires aes.sample.",
+      "Defaults in GeomQqLine. GeomQqLine: Q–Q reference line: line through sample/theoretical quartile match, spanning the theoretical range of the Q–Q cloud. Requires aes.sample.",
     href: "/reference/geoms/qq_line#defaults",
     keywords: ["GeomQqLine", "documentation"],
     exact: ["Defaults"],
@@ -4101,7 +4101,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Svelte component",
     summary:
-      "Svelte component in GeomQqLine. GeomQqLine: Q–Q reference line (ggplot2 geom_qq_line / stat_qq_line): line through sample/theoretical quartile match, spanning the theoretical range of the Q–Q cloud. Requires aes.sample.",
+      "Svelte component in GeomQqLine. GeomQqLine: Q–Q reference line: line through sample/theoretical quartile match, spanning the theoretical range of the Q–Q cloud. Requires aes.sample.",
     href: "/reference/geoms/qq_line#svelte",
     keywords: ["GeomQqLine", "documentation"],
     exact: ["Svelte component"],
@@ -4111,7 +4111,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "JSON layer",
     summary:
-      "JSON layer in GeomQqLine. GeomQqLine: Q–Q reference line (ggplot2 geom_qq_line / stat_qq_line): line through sample/theoretical quartile match, spanning the theoretical range of the Q–Q cloud. Requires aes.sample.",
+      "JSON layer in GeomQqLine. GeomQqLine: Q–Q reference line: line through sample/theoretical quartile match, spanning the theoretical range of the Q–Q cloud. Requires aes.sample.",
     href: "/reference/geoms/qq_line#json",
     keywords: ["GeomQqLine", "documentation"],
     exact: ["JSON layer"],
@@ -4121,7 +4121,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Params",
     summary:
-      "Params in GeomQqLine. GeomQqLine: Q–Q reference line (ggplot2 geom_qq_line / stat_qq_line): line through sample/theoretical quartile match, spanning the theoretical range of the Q–Q cloud. Requires aes.sample.",
+      "Params in GeomQqLine. GeomQqLine: Q–Q reference line: line through sample/theoretical quartile match, spanning the theoretical range of the Q–Q cloud. Requires aes.sample.",
     href: "/reference/geoms/qq_line#params",
     keywords: ["GeomQqLine", "documentation"],
     exact: ["Params"],
@@ -4131,7 +4131,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed stats",
     summary:
-      "Allowed stats in GeomQqLine. GeomQqLine: Q–Q reference line (ggplot2 geom_qq_line / stat_qq_line): line through sample/theoretical quartile match, spanning the theoretical range of the Q–Q cloud. Requires aes.sample.",
+      "Allowed stats in GeomQqLine. GeomQqLine: Q–Q reference line: line through sample/theoretical quartile match, spanning the theoretical range of the Q–Q cloud. Requires aes.sample.",
     href: "/reference/geoms/qq_line#allowed-stats",
     keywords: ["GeomQqLine", "documentation"],
     exact: ["Allowed stats"],
@@ -4141,7 +4141,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "heading",
     title: "Allowed positions",
     summary:
-      "Allowed positions in GeomQqLine. GeomQqLine: Q–Q reference line (ggplot2 geom_qq_line / stat_qq_line): line through sample/theoretical quartile match, spanning the theoretical range of the Q–Q cloud. Requires aes.sample.",
+      "Allowed positions in GeomQqLine. GeomQqLine: Q–Q reference line: line through sample/theoretical quartile match, spanning the theoretical range of the Q–Q cloud. Requires aes.sample.",
     href: "/reference/geoms/qq_line#allowed-positions",
     keywords: ["GeomQqLine", "documentation"],
     exact: ["Allowed positions"],

--- a/apps/docs/src/routes/reference/+page.svelte
+++ b/apps/docs/src/routes/reference/+page.svelte
@@ -13,20 +13,20 @@
 
   <nav aria-label="Reference sections">
     <a href={`${base}/reference/geoms`}>
-      <strong>Geom reference</strong>
+      <strong>Geoms</strong>
       <span
         >Every Geom* component: defaults, stats, positions, and params from the
         schema.</span
       >
     </a>
     <a href={`${base}/reference/stats`}>
-      <strong>Stat reference</strong>
+      <strong>Stats</strong>
       <span
         >Every statistical transform: after_stat columns and compatible geoms.</span
       >
     </a>
     <a href={`${base}/reference/positions`}>
-      <strong>Position reference</strong>
+      <strong>Positions</strong>
       <span
         >Every position adjustment: stack, dodge, jitter params, and compatible
         geoms.</span

--- a/apps/docs/src/routes/reference/geoms/+page.svelte
+++ b/apps/docs/src/routes/reference/geoms/+page.svelte
@@ -38,7 +38,7 @@
   <p class="eyebrow">
     Schema-derived · {Object.keys(GEOM_REFERENCE).length} geoms
   </p>
-  <h1 id="reference-heading">Geom reference</h1>
+  <h1 id="reference-heading">Geoms</h1>
   <p class="intro">
     Every <code>&lt;Geom*&gt;</code> component and its JSON layer form,
     generated from the PortableSpec TypeBox schema so props stay in step with

--- a/apps/docs/src/routes/reference/geoms/[name]/+page.svelte
+++ b/apps/docs/src/routes/reference/geoms/[name]/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { base } from "$app/paths";
-  import { SHARED_LAYER_PROPS } from "@ggsvelte/spec";
 
   import type { PageProps } from "./$types";
 
@@ -8,41 +7,35 @@
   const entry = $derived(data.entry);
 
   const svelteSnippet = $derived(
-    buildSvelteSnippet(
-      entry.component,
-      entry.params.map((p) => p.name),
-    ),
+    buildSvelteSnippet(entry.component, entry.params),
   );
   const jsonSnippet = $derived(
-    buildJsonSnippet(
-      entry.name,
-      entry.defaultStat,
-      entry.params.map((p) => p.name),
-    ),
+    buildJsonSnippet(entry.name, entry.defaultStat, entry.params),
   );
 
   function buildSvelteSnippet(
     component: string,
-    paramNames: readonly string[],
+    params: readonly { name: string; required: boolean }[],
   ): string {
-    const sampleParams = paramNames.slice(0, 2);
+    const required = params.filter((p) => p.required).map((p) => p.name);
+    if (required.length === 0) {
+      return `import { GGPlot, ${component} } from "@ggsvelte/svelte";\n\n<GGPlot data={rows} aes={{ x: "x", y: "y" }}>\n  <${component} />\n</GGPlot>`;
+    }
     const props =
-      sampleParams.length === 0
-        ? ""
-        : "\n" + sampleParams.map((p) => `  ${p}={/* … */}`).join("\n") + "\n";
-    return `import { GGPlot, ${component} } from "@ggsvelte/svelte";\n\n<GGPlot data={rows} aes={{ x: "x", y: "y" }}>\n  <${component}${props === "" ? " " : props}/>\n</GGPlot>`;
+      "\n" + required.map((p) => `  ${p}={/* … */}`).join("\n") + "\n";
+    return `import { GGPlot, ${component} } from "@ggsvelte/svelte";\n\n<GGPlot data={rows} aes={{ x: "x", y: "y" }}>\n  <${component}${props}/>\n</GGPlot>`;
   }
 
   function buildJsonSnippet(
     geom: string,
     defaultStat: string,
-    paramNames: readonly string[],
+    params: readonly { name: string; required: boolean }[],
   ): string {
+    const required = params.filter((p) => p.required).map((p) => p.name);
     const paramsObj =
-      paramNames.length === 0
+      required.length === 0
         ? ""
-        : `,\n  "params": { ${paramNames
-            .slice(0, 2)
+        : `,\n  "params": { ${required
             .map((p) => `"${p}": /* … */`)
             .join(", ")} }`;
     return `{\n  "geom": "${geom}"${defaultStat === "identity" ? "" : `,\n  "stat": "${defaultStat}"`}${paramsObj}\n}`;
@@ -50,12 +43,6 @@
 </script>
 
 <article class="geom-detail prose" aria-labelledby="geom-heading">
-  <p class="crumb">
-    <a href={`${base}/reference/geoms`}>Geom reference</a>
-    <span aria-hidden="true">/</span>
-    <code>{entry.name}</code>
-  </p>
-
   <h1 id="geom-heading"><code>{entry.component}</code></h1>
   <p class="lede">{entry.summary}</p>
 
@@ -86,28 +73,15 @@
       <a href={`${base}/reference/geoms/${entry.aliasOf}`}
         ><code>{entry.aliasOf}</code></a
       >
-      (with the default stat/position of this alias). Prefer the canonical geom in
-      new code; the alias remains for ggplot2 familiarity.
+      (with this alias's default stat and position). Prefer the canonical geom in
+      new code.
     </p>
   {/if}
 
   <h2 id="svelte">Svelte component</h2>
-  <p>
-    Import <code>{entry.component}</code> from <code>@ggsvelte/svelte</code>.
-    Constant style params are <strong>direct props</strong> (not a nested
-    <code>params</code> object). Plus the
-    <a href={`${base}/reference/geoms#shared-layer-props`}>shared layer props</a
-    >
-    (<code>{SHARED_LAYER_PROPS.map((p) => p.name).join(", ")}</code>).
-  </p>
   <pre class="snippet"><code>{svelteSnippet}</code></pre>
 
   <h2 id="json">JSON layer</h2>
-  <p>
-    PortableSpec form: <code>geom</code> plus optional
-    <code>stat</code>, <code>position</code>, <code>params</code>,
-    <code>aes</code>, and <code>data</code>.
-  </p>
   <pre class="snippet"><code>{jsonSnippet}</code></pre>
 
   <h2 id="params">Params</h2>
@@ -180,15 +154,6 @@
   .geom-detail {
     max-width: 52rem;
     margin: 2rem 0 4rem;
-  }
-
-  .crumb {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.4rem;
-    margin: 0 0 0.75rem;
-    color: var(--muted);
-    font-size: 0.9rem;
   }
 
   h1 {

--- a/apps/docs/src/routes/reference/positions/+page.svelte
+++ b/apps/docs/src/routes/reference/positions/+page.svelte
@@ -33,7 +33,7 @@
   <p class="eyebrow">
     Schema-derived · {Object.keys(POSITION_REFERENCE).length} positions
   </p>
-  <h1 id="reference-heading">Position reference</h1>
+  <h1 id="reference-heading">Positions</h1>
   <p class="intro">
     Position adjustments control how marks share coordinate space after the stat
     runs. Set <code>position</code> on a <code>&lt;Geom*&gt;</code> shell or
@@ -89,8 +89,8 @@
   <p>
     Pass the <code>position</code> prop on a geom shell. Only values listed on
     that geom's
-    <a href={`${base}/reference/geoms`}>geom reference</a> page validate. Omit it
-    to use the geom default.
+    <a href={`${base}/reference/geoms`}>Geoms</a> page validate. Omit it to use the
+    geom default.
   </p>
   <pre class="snippet"><code
       >{`import { GGPlot, GeomBar } from "@ggsvelte/svelte";

--- a/apps/docs/src/routes/reference/positions/[name]/+page.svelte
+++ b/apps/docs/src/routes/reference/positions/[name]/+page.svelte
@@ -14,49 +14,21 @@
     primaryGeom === undefined ? "GeomBar" : componentNameForGeom(primaryGeom),
   );
 
-  const paramPropLines = $derived(
-    entry.params.length === 0
-      ? ""
-      : "\n" +
-          entry.params
-            .slice(0, 2)
-            .map((p) => `  ${p.name}={/* … */}`)
-            .join("\n") +
-          "\n",
-  );
-
+  // Minimal: position name only. Optional positionParams live in the table below.
   const svelteSnippet = $derived(
-    entry.params.length === 0
-      ? `import { GGPlot, ${primaryComponent} } from "@ggsvelte/svelte";\n\n<GGPlot data={rows} aes={{ x: "x", y: "y" }}>\n  <${primaryComponent} position="${entry.name}" />\n</GGPlot>`
-      : `import { GGPlot, ${primaryComponent} } from "@ggsvelte/svelte";\n\n<GGPlot data={rows} aes={{ x: "x", y: "y" }}>\n  <${primaryComponent}\n    position="${entry.name}"\n    positionParams={{${paramPropLines === "" ? "" : " /* see params */ "}}}\n  />\n</GGPlot>`,
+    `import { GGPlot, ${primaryComponent} } from "@ggsvelte/svelte";\n\n<GGPlot data={rows} aes={{ x: "x", y: "y" }}>\n  <${primaryComponent} position="${entry.name}" />\n</GGPlot>`,
   );
 
   const jsonSnippet = $derived(
-    entry.params.length === 0
-      ? `{\n  "geom": "${primaryGeom ?? "bar"}",\n  "position": "${entry.name}"\n}`
-      : `{\n  "geom": "${primaryGeom ?? "point"}",\n  "position": "${entry.name}",\n  "positionParams": { ${entry.params
-          .slice(0, 2)
-          .map((p) => `"${p.name}": /* … */`)
-          .join(", ")} }\n}`,
+    `{\n  "geom": "${primaryGeom ?? "bar"}",\n  "position": "${entry.name}"\n}`,
   );
 </script>
 
 <article class="position-detail prose" aria-labelledby="position-heading">
-  <p class="crumb">
-    <a href={`${base}/reference/positions`}>Position reference</a>
-    <span aria-hidden="true">/</span>
-    <code>{entry.name}</code>
-  </p>
-
   <h1 id="position-heading"><code>position: "{entry.name}"</code></h1>
   <p class="lede">{entry.summary}</p>
 
   <h2 id="usage">Usage</h2>
-  <p>
-    Positions are not components. Pass <code>position="{entry.name}"</code> on a
-    compatible <code>&lt;Geom*&gt;</code>, or set
-    <code>"position": "{entry.name}"</code> on a JSON layer.
-  </p>
   <pre class="snippet"><code>{svelteSnippet}</code></pre>
   <pre class="snippet"><code>{jsonSnippet}</code></pre>
 
@@ -130,9 +102,9 @@
   <p class="back">
     <a href={`${base}/reference/positions`}>← All positions</a>
     ·
-    <a href={`${base}/reference/geoms`}>Geom reference</a>
+    <a href={`${base}/reference/geoms`}>Geoms</a>
     ·
-    <a href={`${base}/reference/stats`}>Stat reference</a>
+    <a href={`${base}/reference/stats`}>Stats</a>
   </p>
 </article>
 
@@ -140,15 +112,6 @@
   .position-detail {
     max-width: 52rem;
     margin: 2rem 0 4rem;
-  }
-
-  .crumb {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.4rem;
-    margin: 0 0 0.75rem;
-    color: var(--muted);
-    font-size: 0.9rem;
   }
 
   h1 {

--- a/apps/docs/src/routes/reference/stats/+page.svelte
+++ b/apps/docs/src/routes/reference/stats/+page.svelte
@@ -33,7 +33,7 @@
   <p class="eyebrow">
     Schema-derived · {Object.keys(STAT_REFERENCE).length} stats
   </p>
-  <h1 id="reference-heading">Stat reference</h1>
+  <h1 id="reference-heading">Stats</h1>
   <p class="intro">
     Statistical transforms applied before drawing. Set
     <code>stat</code> on a <code>&lt;Geom*&gt;</code> shell or JSON layer —
@@ -88,8 +88,8 @@
   <p>
     On any geom shell, pass the <code>stat</code> prop. Only values listed on
     that geom's
-    <a href={`${base}/reference/geoms`}>geom reference</a> page validate. Omit it
-    to use the geom default.
+    <a href={`${base}/reference/geoms`}>Geoms</a> page validate. Omit it to use the
+    geom default.
   </p>
   <pre class="snippet"><code
       >{`import { GGPlot, GeomBar } from "@ggsvelte/svelte";

--- a/apps/docs/src/routes/reference/stats/[name]/+page.svelte
+++ b/apps/docs/src/routes/reference/stats/[name]/+page.svelte
@@ -23,22 +23,10 @@
 </script>
 
 <article class="stat-detail prose" aria-labelledby="stat-heading">
-  <p class="crumb">
-    <a href={`${base}/reference/stats`}>Stat reference</a>
-    <span aria-hidden="true">/</span>
-    <code>{entry.name}</code>
-  </p>
-
   <h1 id="stat-heading"><code>stat: "{entry.name}"</code></h1>
   <p class="lede">{entry.summary}</p>
 
   <h2 id="usage">Usage</h2>
-  <p>
-    Stats are not components. Pass <code>stat="{entry.name}"</code> on a
-    compatible <code>&lt;Geom*&gt;</code>, or set
-    <code>"stat": "{entry.name}"</code> on a JSON layer. Only geoms that list this
-    value in their allowed stats accept it.
-  </p>
   <pre class="snippet"><code>{svelteSnippet}</code></pre>
   <pre class="snippet"><code>{jsonSnippet}</code></pre>
 
@@ -105,7 +93,7 @@
   <p class="back">
     <a href={`${base}/reference/stats`}>← All stats</a>
     ·
-    <a href={`${base}/reference/geoms`}>Geom reference</a>
+    <a href={`${base}/reference/geoms`}>Geoms</a>
     ·
     <a href={`${base}/guide/layers-marks`}>Layers and marks guide</a>
   </p>
@@ -115,15 +103,6 @@
   .stat-detail {
     max-width: 52rem;
     margin: 2rem 0 4rem;
-  }
-
-  .crumb {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.4rem;
-    margin: 0 0 0.75rem;
-    color: var(--muted);
-    font-size: 0.9rem;
   }
 
   h1 {

--- a/packages/spec/schema/v0.json
+++ b/packages/spec/schema/v0.json
@@ -151,7 +151,7 @@
       "properties": {
         "stat": {
           "type": "string",
-          "description": "Name of a stat-generated column computed after the layer's stat runs (e.g. \"count\" for the count stat). ggplot2's after_stat()."
+          "description": "Name of a stat-generated column computed after the layer's stat runs (e.g. \"count\" for the count stat). after_stat."
         }
       },
       "additionalProperties": false,
@@ -227,7 +227,7 @@
         },
         "sample": {
           "$ref": "#/$defs/ChannelValue",
-          "description": "Sample distribution channel for Q–Q plots (ggplot2 aes.sample). The qq / qq_line stats read this column; x/y become theoretical and sample quantiles after the stat. Never participates in grouping."
+          "description": "Sample distribution channel for Q–Q plots. The qq / qq_line stats read this column; x/y become theoretical and sample quantiles after the stat. Never participates in grouping."
         },
         "ymin": {
           "$ref": "#/$defs/ChannelValue",
@@ -263,11 +263,11 @@
         },
         "z": {
           "$ref": "#/$defs/ChannelValue",
-          "description": "Surface height for geom contour / stat contour (quantitative grid values over continuous x×y; #801)."
+          "description": "Surface height for geom contour / stat contour (quantitative grid values over continuous x×y;)."
         },
         "map_id": {
           "$ref": "#/$defs/ChannelValue",
-          "description": "Region join key for geom_map (value-table column matched to the map data id column; #808)."
+          "description": "Region join key for geom_map (value-table column matched to the map data id column;)."
         },
         "angle": {
           "$ref": "#/$defs/ChannelValue",
@@ -514,7 +514,7 @@
         "bins": {
           "type": "integer",
           "minimum": 1,
-          "description": "STAT SUMMARY_BIN ONLY (#817): number of bins (integer ≥ 1). Default 30 — advisory. Overridden by binwidth."
+          "description": "STAT SUMMARY_BIN ONLY: number of bins (integer ≥ 1). Default 30 — advisory. Overridden by binwidth."
         },
         "binwidth": {
           "type": "number",
@@ -573,7 +573,7 @@
               "const": "sum"
             }
           ],
-          "description": "SUMMARY_BIN center fun (mean/median/sum; #817) or MANUAL named transform (first|last|mean|median|min|max|sum; #814). Required when stat is \"manual\"."
+          "description": "SUMMARY_BIN center fun (mean/median/sum;) or MANUAL named transform (first|last|mean|median|min|max|sum;). Required when stat is \"manual\"."
         },
         "funMin": {
           "$ref": "#/$defs/SummaryFun",
@@ -585,7 +585,7 @@
         }
       },
       "additionalProperties": false,
-      "description": "Styling parameters for the point geom, plus summary_bin (#817) and/or manual (#814) controls."
+      "description": "Styling parameters for the point geom, plus summary_bin and/or manual controls."
     },
     "LineParams": {
       "type": "object",
@@ -624,7 +624,7 @@
         },
         "pad": {
           "type": "boolean",
-          "description": "With stat ecdf: when true (default), prepend (xmin, 0) so step stairs start at zero. Finite-clamped (ggplot2 uses ±Inf)."
+          "description": "With stat ecdf: when true (default), prepend (xmin, 0) so step stairs start at zero. Finite-clamped."
         },
         "n": {
           "type": "integer",
@@ -654,7 +654,7 @@
               "description": "STAT CONNECT: straight segment (identity vertices)."
             }
           ],
-          "description": "STAT CONNECT ONLY (#816): how successive points join — \"hv\" (default), \"vh\", \"mid\", or \"linear\". Ignored for other stats."
+          "description": "STAT CONNECT ONLY: how successive points join — \"hv\" (default), \"vh\", \"mid\", or \"linear\". Ignored for other stats."
         },
         "bins": {
           "type": "integer",
@@ -718,7 +718,7 @@
               "const": "sum"
             }
           ],
-          "description": "SUMMARY_BIN center fun (mean/median/sum; #817) or MANUAL named transform (first|last|mean|median|min|max|sum; #814). Required when stat is \"manual\"."
+          "description": "SUMMARY_BIN center fun (mean/median/sum;) or MANUAL named transform (first|last|mean|median|min|max|sum;). Required when stat is \"manual\"."
         },
         "funMin": {
           "$ref": "#/$defs/SummaryFun",
@@ -738,7 +738,7 @@
         }
       },
       "additionalProperties": false,
-      "description": "Styling parameters for the line geom, plus optional stat-bin (freqpoly), summary_bin (#817), manual (#814), or ecdf pad/n (#811) controls."
+      "description": "Styling parameters for the line geom, plus optional stat-bin (freqpoly), summary_bin, manual, or ecdf pad/n controls."
     },
     "StepParams": {
       "type": "object",
@@ -769,7 +769,7 @@
               "const": "mid"
             }
           ],
-          "description": "Step corner placement (ggplot2 geom_step): \"hv\" horizontal then vertical (default), \"vh\" vertical then horizontal, \"mid\" change at the midpoint between x positions."
+          "description": "Step corner placement: \"hv\" horizontal then vertical (default), \"vh\" vertical then horizontal, \"mid\" change at the midpoint between x positions."
         },
         "strokePaint": {
           "$ref": "#/$defs/GradientPaint",
@@ -781,7 +781,7 @@
         }
       },
       "additionalProperties": false,
-      "description": "Styling parameters for the step geom (ggplot2 geom_step)."
+      "description": "Styling parameters for the step geom."
     },
     "PathParams": {
       "type": "object",
@@ -833,7 +833,7 @@
               "description": "STAT CONNECT: straight segment (identity vertices)."
             }
           ],
-          "description": "STAT CONNECT ONLY (#816): how successive points join — \"hv\" (default), \"vh\", \"mid\", or \"linear\". Ignored for other stats."
+          "description": "STAT CONNECT ONLY: how successive points join — \"hv\" (default), \"vh\", \"mid\", or \"linear\". Ignored for other stats."
         },
         "fun": {
           "anyOf": [
@@ -866,7 +866,7 @@
               "const": "sum"
             }
           ],
-          "description": "STAT MANUAL ONLY (#814): portable named transform (first|last|mean|median|min|max|sum). Required when stat is \"manual\"."
+          "description": "STAT MANUAL ONLY: portable named transform (first|last|mean|median|min|max|sum). Required when stat is \"manual\"."
         },
         "level": {
           "type": "number",
@@ -968,7 +968,7 @@
               "const": "left"
             }
           ],
-          "description": "STAT BIN ONLY: which edge of each bin is inclusive: \"right\" (default, matches ggplot2) or \"left\"."
+          "description": "STAT BIN ONLY: which edge of each bin is inclusive: \"right\" (default, matches) or \"left\"."
         },
         "fillPaint": {
           "$ref": "#/$defs/GradientPaint",
@@ -1097,7 +1097,7 @@
         }
       },
       "additionalProperties": false,
-      "description": "Parameters for the quantile geom (linear y~x quantile regression lines; #805). method rqss is intentionally omitted in v1."
+      "description": "Parameters for the quantile geom (linear y~x quantile regression lines;). method rqss is intentionally omitted in v1."
     },
     "QqParams": {
       "type": "object",
@@ -1198,7 +1198,7 @@
         }
       },
       "additionalProperties": false,
-      "description": "Parameters for geom_contour isolines (#801). v1: regular grid only; contour_filled deferred."
+      "description": "Parameters for geom_contour isolines. v1: regular grid only; contour_filled deferred."
     },
     "ViolinParams": {
       "type": "object",
@@ -1280,7 +1280,7 @@
           "type": "number",
           "exclusiveMinimum": 0,
           "maximum": 1,
-          "description": "Box width as a fraction of the band step. Must be greater than 0 and at most 1. Default 0.75 (ggplot2). When omitted, width is also capped at 15% of the panel so few categories do not read as slabs."
+          "description": "Box width as a fraction of the band step. Must be greater than 0 and at most 1. Default 0.75. When omitted, width is also capped at 15% of the panel so few categories do not read as slabs."
         },
         "coef": {
           "type": "number",
@@ -1511,7 +1511,7 @@
         }
       },
       "additionalProperties": false,
-      "description": "Parameters for geom_dotplot (histodot binning + stacked dots; #803). method=dotdensity and binaxis=y are not in v1."
+      "description": "Parameters for geom_dotplot (histodot binning + stacked dots;). method=dotdensity and binaxis=y are not in v1."
     },
     "DensityParams": {
       "type": "object",
@@ -1618,7 +1618,7 @@
         }
       },
       "additionalProperties": false,
-      "description": "Parameters for geom_density_2d / geom_density_2d_filled (bivariate KDE; #802). contour_var density only."
+      "description": "Parameters for geom_density_2d / geom_density_2d_filled (bivariate KDE;). contour_var density only."
     },
     "SummaryFun": {
       "anyOf": [
@@ -1680,7 +1680,7 @@
               "const": "sum"
             }
           ],
-          "description": "STAT SUMMARY ONLY: the center summary of y per x group: \"mean\" (default), \"median\", or \"sum\". With \"mean\" and no funMin/funMax, the bounds default to mean ± standard error (ggplot2's mean_se)."
+          "description": "STAT SUMMARY ONLY: the center summary of y per x group: \"mean\" (default), \"median\", or \"sum\". With \"mean\" and no funMin/funMax, the bounds default to mean ± standard error."
         },
         "funMin": {
           "$ref": "#/$defs/SummaryFun",
@@ -1693,7 +1693,7 @@
         "bins": {
           "type": "integer",
           "minimum": 1,
-          "description": "STAT SUMMARY_BIN ONLY (#817): number of bins (integer ≥ 1). Default 30 — advisory. Overridden by binwidth."
+          "description": "STAT SUMMARY_BIN ONLY: number of bins (integer ≥ 1). Default 30 — advisory. Overridden by binwidth."
         },
         "binwidth": {
           "type": "number",
@@ -1723,7 +1723,7 @@
         }
       },
       "additionalProperties": false,
-      "description": "Parameters for the errorbar geom: styling plus summary / summary_bin functions and summary_bin binning controls (#817)."
+      "description": "Parameters for the errorbar geom: styling plus summary / summary_bin functions and summary_bin binning controls."
     },
     "LinerangeParams": {
       "$ref": "#/$defs/ErrorbarParams"
@@ -1817,7 +1817,7 @@
         "fatten": {
           "type": "number",
           "exclusiveMinimum": 0,
-          "description": "Multiplier for the mid-line linewidth relative to params.linewidth / aes.linewidth. Default 2.5 (ggplot2 geom_crossbar)."
+          "description": "Multiplier for the mid-line linewidth relative to params.linewidth / aes.linewidth. Default 2.5."
         },
         "linewidth": {
           "type": "number",
@@ -1895,7 +1895,7 @@
         "bins": {
           "type": "number",
           "exclusiveMinimum": 0,
-          "description": "Number of bins on each axis (ggplot2 bins). Default 30. Applies equally to x and y in v1."
+          "description": "Number of bins on each axis. Default 30. Applies equally to x and y in v1."
         },
         "binwidth": {
           "type": "number",
@@ -1904,7 +1904,7 @@
         },
         "drop": {
           "type": "boolean",
-          "description": "When true (default), omit zero-count bins from the output (ggplot2 drop=TRUE)."
+          "description": "When true (default), omit zero-count bins from the output."
         },
         "alpha": {
           "type": "number",
@@ -1997,7 +1997,7 @@
         "bins": {
           "type": "number",
           "exclusiveMinimum": 0,
-          "description": "Approximate number of hex bins across the x range (ggplot2 bins). Default 30."
+          "description": "Approximate number of hex bins across the x range. Default 30."
         },
         "drop": {
           "type": "boolean",
@@ -2034,7 +2034,7 @@
         "seed": {
           "type": "integer",
           "minimum": 0,
-          "description": "JITTER ONLY: RNG seed (a non-negative integer). Default 42. ggsvelte jitter is ALWAYS seeded so renders are reproducible (deliberate divergence from ggplot2's random jitter)."
+          "description": "JITTER ONLY: RNG seed (a non-negative integer). Default 42. ggsvelte jitter is ALWAYS seeded so renders are reproducible (deliberate divergence from random jitter)."
         },
         "x": {
           "type": "number",
@@ -2254,7 +2254,7 @@
         }
       },
       "additionalProperties": false,
-      "description": "Parameters for the hline alias (ggplot2 geom_hline). Annotation form sets yintercept; data-driven form maps aes.y. Canonicalized by normalize() to a rule layer."
+      "description": "Parameters for the hline alias. Annotation form sets yintercept; data-driven form maps aes.y. Canonicalized by normalize to a rule layer."
     },
     "VlineParams": {
       "type": "object",
@@ -2284,7 +2284,7 @@
         }
       },
       "additionalProperties": false,
-      "description": "Parameters for the vline alias (ggplot2 geom_vline). Annotation form sets xintercept; data-driven form maps aes.x. Canonicalized by normalize() to a rule layer."
+      "description": "Parameters for the vline alias. Annotation form sets xintercept; data-driven form maps aes.x. Canonicalized by normalize to a rule layer."
     },
     "SegmentParams": {
       "type": "object",
@@ -2342,7 +2342,7 @@
           "type": "number",
           "exclusiveMinimum": 0,
           "maximum": 1,
-          "description": "Tick length as a fraction of the panel size along the tick axis (panel-fraction npc analogue of ggplot2 unit(0.03, \"npc\")). Default 0.03."
+          "description": "Tick length as a fraction of the panel size along the tick axis (panel-fraction npc analogue of unit(0.03, \"npc\")). Default 0.03."
         },
         "alpha": {
           "type": "number",
@@ -2446,7 +2446,7 @@
         "geom": {
           "type": "string",
           "const": "abline",
-          "description": "Abline geometry: one infinite reference line y = intercept + slope · x, clipped to the panel (ggplot2 geom_abline). Annotation form: fixed slope/intercept in params; does not inherit plot aes."
+          "description": "Abline geometry: one infinite reference line y = intercept + slope · x, clipped to the panel. Annotation form: fixed slope/intercept in params; does not inherit plot aes."
         },
         "stat": {
           "type": "string",
@@ -2478,24 +2478,24 @@
         }
       },
       "additionalProperties": false,
-      "description": "A slope/intercept reference-line layer (ggplot2 geom_abline). Annotation-only: set params.slope and params.intercept."
+      "description": "A slope/intercept reference-line layer. Annotation-only: set params.slope and params.intercept."
     },
     "CurveParams": {
       "type": "object",
       "properties": {
         "curvature": {
           "type": "number",
-          "description": "Amount of bend away from the straight chord. 0 is a straight line; ggplot2 default 0.5. Positive bows to the right of the start→end direction when angle is 90."
+          "description": "Amount of bend away from the straight chord. 0 is a straight line; default 0.5. Positive bows to the right of the start→end direction when angle is 90."
         },
         "angle": {
           "type": "number",
-          "description": "Control-point direction relative to the chord, in degrees. ggplot2 default 90 (perpendicular)."
+          "description": "Control-point direction relative to the chord, in degrees. default 90 (perpendicular)."
         },
         "ncp": {
           "type": "integer",
           "minimum": 1,
           "maximum": 50,
-          "description": "Smoothness density knob (ggplot2 ncp). Maps to tessellation sample count = max(8, ncp×8); not multi-control xspline. Default 5."
+          "description": "Smoothness density knob. Maps to tessellation sample count = max(8, ncp×8); not multi-control xspline. Default 5."
         },
         "alpha": {
           "type": "number",
@@ -2607,7 +2607,7 @@
         }
       },
       "additionalProperties": false,
-      "description": "Parameters for geom_map (#808): fortified map DataRef plus optional join column and polygon styling."
+      "description": "Parameters for geom_map: fortified map DataRef plus optional join column and polygon styling."
     },
     "SfParams": {
       "type": "object",
@@ -2615,7 +2615,7 @@
         "geometry": {
           "type": "string",
           "minLength": 1,
-          "description": "Name of the data column holding GeoJSON Geometry JSON strings. Default \"geometry\". Already-projected coordinates only (#809 phase 1)."
+          "description": "Name of the data column holding GeoJSON Geometry JSON strings. Default \"geometry\". Already-projected coordinates only."
         },
         "alpha": {
           "type": "number",
@@ -2647,7 +2647,7 @@
         }
       },
       "additionalProperties": false,
-      "description": "Parameters for geom_sf (#809): portable GeoJSON Geometry column plus styling. Interior rings are even-odd holes; GeometryCollection expands. Use coord_sf for fixed-aspect maps (CRS reproject deferred)."
+      "description": "Parameters for geom_sf: portable GeoJSON Geometry column plus styling. Interior rings are even-odd holes; GeometryCollection expands. Use coord_sf for fixed-aspect maps (CRS reproject deferred)."
     },
     "TextParams": {
       "type": "object",
@@ -2734,17 +2734,17 @@
         "padding": {
           "type": "number",
           "exclusiveMinimum": 0,
-          "description": "Uniform box padding around the text in px (ggplot2 label.padding). Default 3."
+          "description": "Uniform box padding around the text in px. Default 3."
         },
         "radius": {
           "type": "number",
           "minimum": 0,
-          "description": "Corner radius of the background box in px (ggplot2 label.r). Default 3."
+          "description": "Corner radius of the background box in px. Default 3."
         },
         "linewidth": {
           "type": "number",
           "minimum": 0,
-          "description": "Box outline stroke width in px (ggplot2 label.size analogue). Default 0.5."
+          "description": "Box outline stroke width in px. Default 0.5."
         }
       },
       "additionalProperties": false,
@@ -2798,7 +2798,7 @@
         {
           "type": "string",
           "const": "unique",
-          "description": "Drop duplicate rows on the combination of mapped aesthetic fields before drawing; first occurrence wins (ggplot2's stat_unique). Panel-local."
+          "description": "Drop duplicate rows on the combination of mapped aesthetic fields before drawing; first occurrence wins. Panel-local."
         }
       ],
       "description": "Layer stat: \"identity\" (default) or \"unique\" (dedupe mapped aesthetics, first wins)."
@@ -2812,7 +2812,7 @@
         "geom": {
           "type": "string",
           "const": "point",
-          "description": "Point geometry: one mark per data row. Use for scatter plots, dot plots, bubbles, correlation views. With summary_bin (#817) or manual (#814)."
+          "description": "Point geometry: one mark per data row. Use for scatter plots, dot plots, bubbles, and correlation views."
         },
         "stat": {
           "anyOf": [
@@ -2824,25 +2824,25 @@
             {
               "type": "string",
               "const": "unique",
-              "description": "Drop duplicate rows on mapped aesthetics before drawing; first wins (#813)."
+              "description": "Drop duplicate rows on mapped aesthetics before drawing; first wins."
             },
             {
               "type": "string",
               "const": "summary_bin",
-              "description": "Bin continuous x and summarize y per (group × bin); default mean ± se (#817)."
+              "description": "Bin continuous x and summarize y per (group × bin); default mean ± se."
             },
             {
               "type": "string",
               "const": "manual",
-              "description": "Portable named per-group transform (params.fun required: first|last|mean|median|min|max|sum; #814)."
+              "description": "Portable named per-group transform (params.fun required: first|last|mean|median|min|max|sum;)."
             },
             {
               "type": "string",
               "const": "sum",
-              "description": "Aggregate coincident (x, y); size defaults to {stat:\"n\"} (geom_count / #795)."
+              "description": "Aggregate coincident (x, y); size defaults to {stat:\"n\"} (geom_count)."
             }
           ],
-          "description": "Point stat: \"identity\" (default), \"unique\", \"summary_bin\" (#817), \"manual\" (#814), or \"sum\" (#795)."
+          "description": "Point stat: \"identity\" (default), \"unique\", \"summary_bin\", \"manual\", or \"sum\"."
         },
         "position": {
           "anyOf": [
@@ -2895,7 +2895,7 @@
         "geom": {
           "type": "string",
           "const": "line",
-          "description": "Line geometry: connects points in x order, one line per group (groups derive from discrete aesthetics such as color, or from aes.group). Use for time series, trends, line charts, and ECDFs (stat ecdf + curve step-hv; #811). With stat bin (freqpoly alias), y is computed from counts/density. With stat connect, successive points expand into named connection vertices (#816)."
+          "description": "Line geometry: connects points in x order, one line per group (groups derive from discrete aesthetics such as color, or from aes.group). Use for time series, trends, and line charts. With stat ecdf, pair with step curves; with stat bin (freqpoly alias), y is computed from counts/density; with stat connect, successive points expand into connection vertices."
         },
         "stat": {
           "anyOf": [
@@ -2907,7 +2907,7 @@
             {
               "type": "string",
               "const": "unique",
-              "description": "Drop duplicate rows on mapped aesthetics before drawing (first wins; #813)."
+              "description": "Drop duplicate rows on mapped aesthetics before drawing (first wins;)."
             },
             {
               "type": "string",
@@ -2917,30 +2917,30 @@
             {
               "type": "string",
               "const": "align",
-              "description": "Interpolate each group onto the union of finite x values so continuous-x stack/fill aligns (#815). Outside a group's x range y is 0."
+              "description": "Interpolate each group onto the union of finite x values so continuous-x stack/fill aligns. Outside a group's x range y is 0."
             },
             {
               "type": "string",
               "const": "connect",
-              "description": "Expand successive points into connection vertices (params.connection: hv|vh|mid|linear; #816). Expands in x order; geometry does not re-sort after connect."
+              "description": "Expand successive points into connection vertices (params.connection: hv|vh|mid|linear;). Expands in x order; geometry does not re-sort after connect."
             },
             {
               "type": "string",
               "const": "summary_bin",
-              "description": "Bin continuous x and summarize y per (group × bin); default mean ± se; connect centers in x order (#817)."
+              "description": "Bin continuous x and summarize y per (group × bin); default mean ± se; connect centers in x order."
             },
             {
               "type": "string",
               "const": "manual",
-              "description": "Portable named per-group transform (params.fun required: first|last|mean|median|min|max|sum; #814)."
+              "description": "Portable named per-group transform (params.fun required: first|last|mean|median|min|max|sum;)."
             },
             {
               "type": "string",
               "const": "ecdf",
-              "description": "Empirical CDF of x; y defaults to {\"stat\": \"ecdf\"} — do NOT map aes.y to a field. Prefer params.curve \"step-hv\" for ECDF stairs (#811)."
+              "description": "Empirical CDF of x; y defaults to {\"stat\": \"ecdf\"} — do NOT map aes.y to a field. Prefer params.curve \"step-hv\" for ECDF stairs."
             }
           ],
-          "description": "Line stat: \"identity\" (default), \"unique\", \"bin\", \"align\", \"connect\", \"summary_bin\" (#817), \"manual\" (#814), or \"ecdf\" (#811)."
+          "description": "Line stat: \"identity\" (default), \"unique\", \"bin\", \"align\", \"connect\", \"summary_bin\", \"manual\", or \"ecdf\"."
         },
         "position": {
           "type": "string",
@@ -2978,7 +2978,7 @@
         "geom": {
           "type": "string",
           "const": "step",
-          "description": "Step-line geometry: connect points with hv/vh/mid stairs (ggplot2 geom_step). Same channels as line; ordered by x within groups."
+          "description": "Step-line geometry: connect points with hv/vh/mid stairs. Same channels as line; ordered by x within groups."
         },
         "stat": {
           "type": "string",
@@ -3010,7 +3010,7 @@
         }
       },
       "additionalProperties": false,
-      "description": "A step-line layer (ggplot2 geom_step). Requires x and y. params.direction is hv (default), vh, or mid."
+      "description": "A step-line layer. Requires x and y. params.direction is hv (default), vh, or mid."
     },
     "PathLayer": {
       "type": "object",
@@ -3021,7 +3021,7 @@
         "geom": {
           "type": "string",
           "const": "path",
-          "description": "Path geometry: connects points in data (row) order within each group — unlike line, which sorts by x. Use for trajectories, loops, connected scatterplots (ggplot2 geom_path), and ellipse rings (stat ellipse). With stat connect, successive points expand into named connection vertices (#816)."
+          "description": "Path geometry: connects points in data (row) order within each group — unlike line, which sorts by x. Use for trajectories, loops, connected scatterplots, and ellipse rings (stat ellipse). With stat connect, successive points expand into connection vertices."
         },
         "stat": {
           "anyOf": [
@@ -3033,25 +3033,25 @@
             {
               "type": "string",
               "const": "unique",
-              "description": "Drop duplicate rows on mapped aesthetics before drawing (first wins; #813)."
+              "description": "Drop duplicate rows on mapped aesthetics before drawing (first wins;)."
             },
             {
               "type": "string",
               "const": "connect",
-              "description": "Expand successive points into connection vertices (params.connection: hv|vh|mid|linear; default hv; #816). ggplot2 stat_connect default geom is path."
+              "description": "Expand successive points into connection vertices (params.connection: hv|vh|mid|linear; default hv;). stat_connect default geom is path."
             },
             {
               "type": "string",
               "const": "manual",
-              "description": "Portable named per-group transform (params.fun required: first|last|mean|median|min|max|sum; #814)."
+              "description": "Portable named per-group transform (params.fun required: first|last|mean|median|min|max|sum;)."
             },
             {
               "type": "string",
               "const": "ellipse",
-              "description": "Bivariate normal confidence ellipse per group (ggplot2 stat_ellipse, type norm). Emits perimeter samples suitable for path; requires quantitative x and y (#812)."
+              "description": "Bivariate normal confidence ellipse per group. Emits perimeter samples suitable for path; requires quantitative x and y."
             }
           ],
-          "description": "Path stat: \"identity\" (default), \"unique\", \"connect\", \"manual\" (#814), or \"ellipse\" (#812)."
+          "description": "Path stat: \"identity\" (default), \"unique\", \"connect\", \"manual\", or \"ellipse\"."
         },
         "position": {
           "type": "string",
@@ -3089,7 +3089,7 @@
         "geom": {
           "type": "string",
           "const": "col",
-          "description": "Column geometry: one rectangle per data row, from the y baseline (zero) to the row's y value. Use when the data already contains the bar heights (ggplot2's geom_col)."
+          "description": "Column geometry: one rectangle per data row, from the y baseline (zero) to the row's y value. Use when the data already contains the bar heights — prefer over GeomBar, which counts or bins."
         },
         "stat": {
           "$ref": "#/$defs/IdentityOrUniqueStat"
@@ -3128,7 +3128,7 @@
         "geom": {
           "type": "string",
           "const": "bar",
-          "description": "Bar geometry with counting or binning: one rectangle per distinct x value (stat count, discrete x) or per bin (stat bin, continuous x). Do NOT map aes.y — the stat computes it (ggplot2's geom_bar / geom_histogram)."
+          "description": "Bar geometry with counting or binning: one rectangle per distinct x value (stat count, discrete x) or per bin (stat bin, continuous x). Do not map aes.y — the stat computes it. Prefer GeomCol when bar heights are already in the data."
         },
         "stat": {
           "anyOf": [
@@ -3177,7 +3177,7 @@
         "geom": {
           "type": "string",
           "const": "histogram",
-          "description": "Histogram geometry: a continuous x variable divided into bins, one bar per bin whose height is the count of rows (or the sum of aes.weight). Do NOT map aes.y — the bin stat computes it. Canonicalized by normalize() to a bar layer with stat bin."
+          "description": "Histogram geometry: a continuous x variable divided into bins, one bar per bin whose height is the count of rows (or the sum of aes.weight). Do not map aes.y — the bin stat computes it. Canonicalized by normalize() to a bar layer with stat bin."
         },
         "stat": {
           "type": "string",
@@ -3218,7 +3218,7 @@
         "geom": {
           "type": "string",
           "const": "freqpoly",
-          "description": "Frequency polygon (ggplot2 geom_freqpoly): continuous x binned like a histogram, drawn as a line through bin centers. Do NOT map aes.y — the bin stat computes it. Canonicalized by normalize() to a line layer with stat bin."
+          "description": "Frequency polygon: continuous x binned like a histogram, drawn as a line through bin centers. Do not map aes.y — the bin stat computes it. Canonicalized by normalize() to a line layer with stat bin."
         },
         "stat": {
           "type": "string",
@@ -3261,7 +3261,7 @@
         "geom": {
           "type": "string",
           "const": "smooth",
-          "description": "Smooth geometry: a fitted trend line (with an optional confidence ribbon) over an x/y scatter, one fit per group. Use to reveal trends (ggplot2's geom_smooth)."
+          "description": "Smooth geometry: a fitted trend line (with an optional confidence ribbon) over an x/y scatter, one fit per group. Use to reveal trends."
         },
         "stat": {
           "type": "string",
@@ -3304,7 +3304,7 @@
         "geom": {
           "type": "string",
           "const": "quantile",
-          "description": "Quantile geometry: linear quantile regression lines (y ~ x) at one or more conditional quantiles of y, one line per quantile per group (ggplot2 geom_quantile / #805)."
+          "description": "Quantile geometry: linear quantile regression lines (y ~ x) at one or more conditional quantiles of y, one line per quantile per group."
         },
         "stat": {
           "type": "string",
@@ -3347,7 +3347,7 @@
         "geom": {
           "type": "string",
           "const": "qq",
-          "description": "Q–Q scatter (ggplot2 geom_qq / stat_qq): sample quantiles vs theoretical normal quantiles. Requires aes.sample."
+          "description": "Q–Q scatter: sample quantiles vs theoretical normal quantiles. Requires aes.sample."
         },
         "stat": {
           "type": "string",
@@ -3390,7 +3390,7 @@
         "geom": {
           "type": "string",
           "const": "qq_line",
-          "description": "Q–Q reference line (ggplot2 geom_qq_line / stat_qq_line): line through sample/theoretical quartile match, spanning the theoretical range of the Q–Q cloud. Requires aes.sample."
+          "description": "Q–Q reference line: line through sample/theoretical quartile match, spanning the theoretical range of the Q–Q cloud. Requires aes.sample."
         },
         "stat": {
           "type": "string",
@@ -3433,7 +3433,7 @@
         "geom": {
           "type": "string",
           "const": "contour",
-          "description": "Contour geometry: isolines of a continuous z surface over a regular x×y grid (ggplot2 geom_contour; #801). v1 draws open path polylines only (not filled bands)."
+          "description": "Contour geometry: isolines of a continuous z surface over a regular x×y grid. v1 draws open path polylines only (not filled bands)."
         },
         "stat": {
           "type": "string",
@@ -3476,7 +3476,7 @@
         "geom": {
           "type": "string",
           "const": "violin",
-          "description": "Violin geometry: mirrored kernel density of continuous y at each discrete x (ggplot2 geom_violin / stat_ydensity). One polygon per x×group. Default position dodge."
+          "description": "Violin geometry: mirrored kernel density of continuous y at each discrete x (stat ydensity). One polygon per x×group. Default position dodge."
         },
         "stat": {
           "type": "string",
@@ -3578,7 +3578,7 @@
         "geom": {
           "type": "string",
           "const": "count",
-          "description": "Count geometry (ggplot2 geom_count): point marks at unique (x, y) with size scaled by after_stat n (stat sum). Use for overplotting density on discrete or rounded coordinates."
+          "description": "Count geometry: point marks at unique (x, y) with size scaled by after_stat n (stat sum). Use for overplotting density on discrete or rounded coordinates."
         },
         "stat": {
           "type": "string",
@@ -3636,7 +3636,7 @@
         "geom": {
           "type": "string",
           "const": "dotplot",
-          "description": "Dotplot geometry: stacked dots along a continuous x axis (ggplot2 geom_dotplot, histodot subset). Do NOT map aes.y — the bindot stat computes stack positions."
+          "description": "Dotplot geometry: stacked dots along a continuous x axis (histodot subset). Do not map aes.y — the bindot stat computes stack positions."
         },
         "stat": {
           "type": "string",
@@ -3722,7 +3722,7 @@
         "geom": {
           "type": "string",
           "const": "density_2d",
-          "description": "2D density geometry: bivariate KDE isolines over continuous x and y (ggplot2 geom_density_2d; #802). Open path contours."
+          "description": "2D density geometry: bivariate KDE isolines over continuous x and y. Open path contours."
         },
         "stat": {
           "type": "string",
@@ -3765,7 +3765,7 @@
         "geom": {
           "type": "string",
           "const": "density_2d_filled",
-          "description": "2D density filled bands: bivariate KDE closed isoline rings filled by density level (ggplot2 geom_density_2d_filled; #802 phase 2). Open rings dropped. Defaults fill to after_stat(level)."
+          "description": "2D density filled bands: bivariate KDE closed isoline rings filled by density level. Open rings dropped. Defaults fill to after_stat(level)."
         },
         "stat": {
           "type": "string",
@@ -3825,15 +3825,15 @@
             {
               "type": "string",
               "const": "summary",
-              "description": "Compute y/ymin/ymax per x group from aes.y; default mean ± standard error (ggplot2 mean_se)."
+              "description": "Compute y/ymin/ymax per x group from aes.y; default mean ± standard error."
             },
             {
               "type": "string",
               "const": "summary_bin",
-              "description": "Bin continuous x and summarize y per (group × bin); default mean ± se (#817)."
+              "description": "Bin continuous x and summarize y per (group × bin); default mean ± se."
             }
           ],
-          "description": "The errorbar's stat: \"identity\" (default), \"unique\", \"summary\" (per x group), or \"summary_bin\" (per bin; #817)."
+          "description": "The errorbar's stat: \"identity\" (default), \"unique\", \"summary\" (per x group), or \"summary_bin\" (per bin;)."
         },
         "position": {
           "type": "string",
@@ -3871,7 +3871,7 @@
         "geom": {
           "type": "string",
           "const": "linerange",
-          "description": "Linerange geometry: a vertical stem from ymin to ymax without end caps (ggplot2 geom_linerange)."
+          "description": "Linerange geometry: a vertical stem from ymin to ymax without end caps."
         },
         "stat": {
           "anyOf": [
@@ -3921,7 +3921,7 @@
         "geom": {
           "type": "string",
           "const": "pointrange",
-          "description": "Pointrange geometry: vertical stem from ymin to ymax plus a point at (x, y) (ggplot2 geom_pointrange)."
+          "description": "Pointrange geometry: vertical stem from ymin to ymax plus a point at (x, y)."
         },
         "stat": {
           "anyOf": [
@@ -3971,7 +3971,7 @@
         "geom": {
           "type": "string",
           "const": "crossbar",
-          "description": "Crossbar geometry: a vertical interval box from ymin to ymax with a mid horizontal line at y (ggplot2 geom_crossbar)."
+          "description": "Crossbar geometry: a vertical interval box from ymin to ymax with a mid horizontal line at y."
         },
         "stat": {
           "anyOf": [
@@ -4105,7 +4105,7 @@
         "geom": {
           "type": "string",
           "const": "bin_2d",
-          "description": "2D rectangular bin heatmap (ggplot2 geom_bin2d / stat_bin_2d): partitions continuous x×y into a grid and maps fill to bin count by default. Empty bins are dropped unless params.drop is false."
+          "description": "2D rectangular bin heatmap: partitions continuous x×y into a grid and maps fill to bin count by default. Empty bins are dropped unless params.drop is false."
         },
         "stat": {
           "type": "string",
@@ -4191,7 +4191,7 @@
         "geom": {
           "type": "string",
           "const": "hex",
-          "description": "Hexagonal bin heatmap (ggplot2 geom_hex / stat_bin_hex): partitions continuous x×y into a hexagonal lattice and maps fill to bin count by default."
+          "description": "Hexagonal bin heatmap: partitions continuous x×y into a hexagonal lattice and maps fill to bin count by default."
         },
         "stat": {
           "type": "string",
@@ -4251,7 +4251,7 @@
             {
               "type": "string",
               "const": "align",
-              "description": "Interpolate each group onto the union of finite x values so continuous-x stack/fill aligns (#815). Outside a group's x range y is 0."
+              "description": "Interpolate each group onto the union of finite x values so continuous-x stack/fill aligns. Outside a group's x range y is 0."
             }
           ],
           "description": "Area stat: \"identity\" (default), \"unique\" (first-wins dedupe), or \"align\" (shared x grid for stacking)."
@@ -4290,7 +4290,7 @@
         "geom": {
           "type": "string",
           "const": "ribbon",
-          "description": "Ribbon geometry: a filled interval between two varying boundaries along a running coordinate (ggplot2's geom_ribbon). Map x+ymin+ymax (x orientation) or y+xmin+xmax (y orientation). Not a zero-baseline area."
+          "description": "Ribbon geometry: a filled interval between two varying boundaries along a running coordinate. Map x+ymin+ymax (x orientation) or y+xmin+xmax (y orientation). Not a zero-baseline area."
         },
         "stat": {
           "$ref": "#/$defs/IdentityOrUniqueStat"
@@ -4331,7 +4331,7 @@
         "geom": {
           "type": "string",
           "const": "rule",
-          "description": "Rule geometry: reference lines spanning the panel. TWO HONEST FORMS: (1) annotation — set params.xintercept and/or params.yintercept to fixed data values and map neither aes.x nor aes.y; (2) data-driven — map exactly ONE of aes.x (vertical rules) or aes.y (horizontal rules) to a field. Never mix the forms in one layer."
+          "description": "Rule geometry: reference lines spanning the panel. Two forms: (1) annotation — set params.xintercept and/or params.yintercept to fixed data values and map neither aes.x nor aes.y; (2) data-driven — map exactly one of aes.x (vertical rules) or aes.y (horizontal rules) to a field. Never mix the forms in one layer."
         },
         "stat": {
           "$ref": "#/$defs/IdentityOrUniqueStat"
@@ -4361,7 +4361,7 @@
         }
       },
       "additionalProperties": false,
-      "description": "A reference-line layer (ggplot2's geom_vline/geom_hline, unified). Annotation form: fixed intercepts in params. Data-driven form: map aes.x OR aes.y."
+      "description": "A reference-line layer. Annotation form: fixed intercepts in params. Data-driven form: map aes.x OR aes.y."
     },
     "HlineLayer": {
       "type": "object",
@@ -4372,7 +4372,7 @@
         "geom": {
           "type": "string",
           "const": "hline",
-          "description": "Horizontal reference-line alias (ggplot2's geom_hline). Canonicalized by normalize() to a rule layer. Annotation form: set params.yintercept. Data-driven form: map aes.y (inherited plot x is dropped so the one-axis rule contract holds)."
+          "description": "Horizontal reference-line alias. Canonicalized by normalize() to a rule layer. Annotation form: set params.yintercept. Data-driven form: map aes.y (inherited plot x is dropped so the one-axis rule contract holds)."
         },
         "stat": {
           "type": "string",
@@ -4415,7 +4415,7 @@
         "geom": {
           "type": "string",
           "const": "vline",
-          "description": "Vertical reference-line alias (ggplot2's geom_vline). Canonicalized by normalize() to a rule layer. Annotation form: set params.xintercept. Data-driven form: map aes.x (inherited plot y is dropped so the one-axis rule contract holds)."
+          "description": "Vertical reference-line alias. Canonicalized by normalize() to a rule layer. Annotation form: set params.xintercept. Data-driven form: map aes.x (inherited plot y is dropped so the one-axis rule contract holds)."
         },
         "stat": {
           "type": "string",
@@ -4458,7 +4458,7 @@
         "geom": {
           "type": "string",
           "const": "jitter",
-          "description": "Jittered point alias (ggplot2's geom_jitter). Canonicalized by normalize() to a point layer with position jitter. Configure jitter amount via positionParams.width/height/seed."
+          "description": "Jittered point alias. Canonicalized by normalize() to a point layer with position jitter. Configure jitter amount via positionParams.width/height/seed."
         },
         "stat": {
           "type": "string",
@@ -4556,7 +4556,7 @@
         "geom": {
           "type": "string",
           "const": "label",
-          "description": "Label geometry: text with a rounded rectangular background box (ggplot2 geom_label). Requires x, y, and label channels. No collision detection."
+          "description": "Label geometry: text with a rounded rectangular background box. Requires x, y, and label channels. No collision detection."
         },
         "stat": {
           "type": "string",
@@ -4640,7 +4640,7 @@
         }
       },
       "additionalProperties": false,
-      "description": "A finite segment layer (ggplot2's geom_segment). Requires x, y, xend, and yend channels."
+      "description": "A finite segment layer. Requires x, y, xend, and yend channels."
     },
     "FunctionLayer": {
       "type": "object",
@@ -4652,7 +4652,7 @@
         "geom": {
           "type": "string",
           "const": "function",
-          "description": "Function geometry: evaluate a named portable function y = f(x) on a grid and draw a path (ggplot2 geom_function / stat_function). Requires params.fun; domain from params.xlim, mapped x, or peer layers."
+          "description": "Function geometry: evaluate a named portable function y = f(x) on a grid and draw a path. Requires params.fun; domain from params.xlim, mapped x, or peer layers."
         },
         "stat": {
           "type": "string",
@@ -4685,7 +4685,7 @@
         }
       },
       "additionalProperties": false,
-      "description": "An analytic function layer (ggplot2's geom_function). y is computed as { stat: y }; do not map data y. Portable fun names only (no JS closures)."
+      "description": "An analytic function layer. y is computed as { stat: y }; do not map data y. Portable fun names only (no JS closures)."
     },
     "CurveLayer": {
       "type": "object",
@@ -4696,7 +4696,7 @@
         "geom": {
           "type": "string",
           "const": "curve",
-          "description": "Curve geometry (ggplot2 geom_curve): one curved connector per row from (x, y) to (xend, yend). Tessellated as a quadratic Bezier (curvature/angle/ncp). Requires field-mapped x, y, xend, and yend."
+          "description": "Curve geometry: one curved connector per row from (x, y) to (xend, yend). Tessellated as a quadratic Bezier (curvature/angle/ncp). Requires field-mapped x, y, xend, and yend."
         },
         "stat": {
           "type": "string",
@@ -4739,7 +4739,7 @@
         "geom": {
           "type": "string",
           "const": "polygon",
-          "description": "Polygon geometry: closed filled paths from (x, y) vertices in data/row order within each group (ggplot2's geom_polygon). Groups form separate polygons. No x-sort (unlike line/area). Holes/subgroup omitted in v1."
+          "description": "Polygon geometry: closed filled paths from (x, y) vertices in data/row order within each group. Groups form separate polygons. No x-sort (unlike line/area). Holes/subgroup omitted in v1."
         },
         "stat": {
           "type": "string",
@@ -4771,7 +4771,7 @@
         }
       },
       "additionalProperties": false,
-      "description": "A closed polygon layer (ggplot2's geom_polygon). Requires x and y channels; vertices connect in data order per group and close implicitly."
+      "description": "A closed polygon layer. Requires x and y channels; vertices connect in data order per group and close implicitly."
     },
     "MapLayer": {
       "type": "object",
@@ -4783,7 +4783,7 @@
         "geom": {
           "type": "string",
           "const": "map",
-          "description": "Map geometry (ggplot2 geom_map): join fortified region borders to value rows via aes.map_id and params.map. Renders closed filled paths per region (#808)."
+          "description": "Map geometry: join fortified region borders to value rows via aes.map_id and params.map. Renders closed filled paths per region."
         },
         "stat": {
           "type": "string",
@@ -4826,12 +4826,12 @@
         "geom": {
           "type": "string",
           "const": "sf",
-          "description": "Simple-features geometry (ggplot2 geom_sf; #809): already-projected GeoJSON Geometry JSON strings in a data column. Point/line/polygon families (incl. GeometryCollection of one family) with even-odd holes; use coord_sf for fixed-aspect (CRS reproject deferred)."
+          "description": "Simple-features geometry: already-projected GeoJSON Geometry JSON strings in a data column. Point/line/polygon families (incl. GeometryCollection of one family) with even-odd holes; use coord_sf for fixed-aspect (CRS reproject deferred)."
         },
         "stat": {
           "type": "string",
           "const": "sf",
-          "description": "Geometry expand (ggplot2 stat_sf; #809): portable GeoJSON → drawable point/line/polygon parts."
+          "description": "Geometry expand: portable GeoJSON → drawable point/line/polygon parts."
         },
         "position": {
           "type": "string",
@@ -4906,7 +4906,7 @@
         }
       },
       "additionalProperties": false,
-      "description": "Parameters for geom_sf_text (#809 phase 2): geometry column plus text styling."
+      "description": "Parameters for geom_sf_text: geometry column plus text styling."
     },
     "SfTextLayer": {
       "type": "object",
@@ -4917,7 +4917,7 @@
         "geom": {
           "type": "string",
           "const": "sf_text",
-          "description": "Simple-features text labels (ggplot2 geom_sf_text; #809): places aes.label at representative geometry points (Multi* → one label per part; stat_sf_coordinates)."
+          "description": "Simple-features text labels: places aes.label at representative geometry points (Multi* → one label per part; stat_sf_coordinates)."
         },
         "stat": {
           "type": "string",
@@ -5012,7 +5012,7 @@
         }
       },
       "additionalProperties": false,
-      "description": "Parameters for geom_sf_label (#809 phase 3): geometry column, text styling, and label box chrome."
+      "description": "Parameters for geom_sf_label: geometry column, text styling, and label box chrome."
     },
     "SfLabelLayer": {
       "type": "object",
@@ -5023,7 +5023,7 @@
         "geom": {
           "type": "string",
           "const": "sf_label",
-          "description": "Simple-features labels with background boxes (ggplot2 geom_sf_label; #809): places aes.label at representative geometry points with a measured rounded rect (Multi* → one label per part). color=ink+box stroke; fill=box background."
+          "description": "Simple-features labels with background boxes: places aes.label at representative geometry points with a measured rounded rect (Multi* → one label per part). color=ink+box stroke; fill=box background."
         },
         "stat": {
           "type": "string",
@@ -5072,7 +5072,7 @@
         "geom": {
           "type": "string",
           "const": "blank",
-          "description": "Blank geometry (ggplot2's geom_blank): contributes mapped aesthetics to scale training and layout without drawing marks or hit targets. No channels are required; whatever is mapped trains its scale."
+          "description": "Blank geometry: contributes mapped aesthetics to scale training and layout without drawing marks or hit targets. No channels are required; whatever is mapped trains its scale."
         },
         "stat": {
           "type": "string",
@@ -5104,7 +5104,7 @@
         }
       },
       "additionalProperties": false,
-      "description": "An empty layer that trains scales from mapped aesthetics without emitting geometry (ggplot2's geom_blank)."
+      "description": "An empty layer that trains scales from mapped aesthetics without emitting geometry."
     },
     "RugLayer": {
       "type": "object",
@@ -5115,7 +5115,7 @@
         "geom": {
           "type": "string",
           "const": "rug",
-          "description": "Rug geometry: short ticks along panel edges for each observation (ggplot2 geom_rug). Map aes.x for bottom/top sides and/or aes.y for left/right sides."
+          "description": "Rug geometry: short ticks along panel edges for each observation. Map aes.x for bottom/top sides and/or aes.y for left/right sides."
         },
         "stat": {
           "type": "string",
@@ -5158,7 +5158,7 @@
         "geom": {
           "type": "string",
           "const": "spoke",
-          "description": "Spoke geometry (ggplot2 geom_spoke): one finite segment per row from (x, y) in direction angle (radians) with length radius. Endpoints are derived as xend = x + radius·cos(angle), yend = y + radius·sin(angle) in data space, then transformed like x/y. Requires continuous x and y."
+          "description": "Spoke geometry: one finite segment per row from (x, y) in direction angle (radians) with length radius. Endpoints are derived as xend = x + radius·cos(angle), yend = y + radius·sin(angle) in data space, then transformed like x/y. Requires continuous x and y."
         },
         "stat": {
           "type": "string",
@@ -6164,12 +6164,12 @@
             "naValue": {
               "type": "string",
               "pattern": "^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$",
-              "description": "Color for null/missing values. Default #999999."
+              "description": "Color for null/missing values. Default9."
             },
             "unknownValue": {
               "type": "string",
               "pattern": "^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$",
-              "description": "Color for invalid, out-of-domain, or unmapped values. Default #999999."
+              "description": "Color for invalid, out-of-domain, or unmapped values. Default9."
             },
             "onExhaust": {
               "anyOf": [
@@ -6594,7 +6594,7 @@
                   "const": "area_zero"
                 }
               ],
-              "description": "Size encoding unit (size aesthetic only). \"area\" (default) interpolates by area between range endpoints; \"radius\" maps linearly to radius; \"area_zero\" maps value proportionally to area with zero→zero (ggplot2 scale_size_area / scale_size_binned_area)."
+              "description": "Size encoding unit (size aesthetic only). \"area\" (default) interpolates by area between range endpoints; \"radius\" maps linearly to radius; \"area_zero\" maps value proportionally to area with zero→zero."
             }
           },
           "additionalProperties": false,
@@ -8837,15 +8837,15 @@
       "properties": {
         "wrap": {
           "$ref": "#/$defs/FacetFieldRef",
-          "description": "Facet WRAP form: partition rows by this data field's distinct values, one panel per value, wrapped into a grid ncol wide (ggplot2's facet_wrap). Mutually exclusive with rows/cols. Optional levels/labels control order and strip text."
+          "description": "Facet WRAP form: partition rows by this data field's distinct values, one panel per value, wrapped into a grid ncol wide. Mutually exclusive with rows/cols. Optional levels/labels control order and strip text."
         },
         "rows": {
           "$ref": "#/$defs/FacetFieldRef",
-          "description": "Facet GRID form: the field whose distinct values become grid rows (ggplot2's facet_grid rows). Combine with cols; mutually exclusive with wrap. Optional levels/labels control order and strip text."
+          "description": "Facet GRID form: the field whose distinct values become grid rows. Combine with cols; mutually exclusive with wrap. Optional levels/labels control order and strip text."
         },
         "cols": {
           "$ref": "#/$defs/FacetFieldRef",
-          "description": "Facet GRID form: the field whose distinct values become grid columns (ggplot2's facet_grid cols). Combine with rows; mutually exclusive with wrap. Optional levels/labels control order and strip text."
+          "description": "Facet GRID form: the field whose distinct values become grid columns. Combine with rows; mutually exclusive with wrap. Optional levels/labels control order and strip text."
         },
         "ncol": {
           "type": "integer",
@@ -8927,7 +8927,7 @@
         }
       },
       "additionalProperties": false,
-      "description": "The plot's Cartesian coordinate system. {\"type\": \"flip\"} turns any vertical composition into its horizontal counterpart (ggplot2's coord_flip)."
+      "description": "The plot's Cartesian coordinate system. {\"type\": \"flip\"} turns any vertical composition into its horizontal counterpart."
     },
     "CoordTransformSpec": {
       "type": "object",
@@ -8983,7 +8983,7 @@
         "type": {
           "type": "string",
           "const": "sf",
-          "description": "Simple-features coordinates for already-projected map data (ggplot2 coord_sf; #809). Fixed-aspect layout; no CRS transform in v1."
+          "description": "Simple-features coordinates for already-projected map data. Fixed-aspect layout; no CRS transform in v1."
         },
         "ratio": {
           "type": "number",
@@ -9103,7 +9103,7 @@
         }
       },
       "additionalProperties": false,
-      "description": "A complete ggsvelte plot specification: data + aesthetic mapping + one or more layers, in ggplot2's layered grammar. Strictly JSON (PortableSpec)."
+      "description": "A complete ggsvelte plot specification: data + aesthetic mapping + one or more layers, in layered grammar. Strictly JSON (PortableSpec)."
     }
   },
   "$ref": "#/$defs/PlotSpec"

--- a/packages/spec/src/schema-declarations.ts
+++ b/packages/spec/src/schema-declarations.ts
@@ -49,7 +49,7 @@ const sizeUnitField = {
   sizeUnit: Type.Optional(
     Type.Union([Type.Literal("area"), Type.Literal("radius"), Type.Literal("area_zero")], {
       description:
-        'Size encoding unit (size aesthetic only). "area" (default) interpolates by area between range endpoints; "radius" maps linearly to radius; "area_zero" maps value proportionally to area with zero→zero (ggplot2 scale_size_area / scale_size_binned_area).',
+        'Size encoding unit (size aesthetic only). "area" (default) interpolates by area between range endpoints; "radius" maps linearly to radius; "area_zero" maps value proportionally to area with zero→zero.',
     }),
   ),
 };
@@ -331,7 +331,7 @@ export const SpecDeclarations = {
     {
       stat: Type.String({
         description:
-          "Name of a stat-generated column computed after the layer's stat runs (e.g. \"count\" for the count stat). ggplot2's after_stat().",
+          'Name of a stat-generated column computed after the layer\'s stat runs (e.g. "count" for the count stat). after_stat.',
       }),
     },
     {
@@ -413,7 +413,7 @@ export const SpecDeclarations = {
       sample: Type.Optional(
         Type.Ref("ChannelValue", {
           description:
-            "Sample distribution channel for Q–Q plots (ggplot2 aes.sample). The qq / qq_line stats read this column; x/y become theoretical and sample quantiles after the stat. Never participates in grouping.",
+            "Sample distribution channel for Q–Q plots. The qq / qq_line stats read this column; x/y become theoretical and sample quantiles after the stat. Never participates in grouping.",
         }),
       ),
       ymin: Type.Optional(
@@ -467,13 +467,13 @@ export const SpecDeclarations = {
       z: Type.Optional(
         Type.Ref("ChannelValue", {
           description:
-            "Surface height for geom contour / stat contour (quantitative grid values over continuous x×y; #801).",
+            "Surface height for geom contour / stat contour (quantitative grid values over continuous x×y;).",
         }),
       ),
       map_id: Type.Optional(
         Type.Ref("ChannelValue", {
           description:
-            "Region join key for geom_map (value-table column matched to the map data id column; #808).",
+            "Region join key for geom_map (value-table column matched to the map data id column;).",
         }),
       ),
       angle: Type.Optional(
@@ -632,7 +632,7 @@ export const SpecDeclarations = {
         Type.Integer({
           minimum: 1,
           description:
-            "STAT SUMMARY_BIN ONLY (#817): number of bins (integer ≥ 1). Default 30 — advisory. Overridden by binwidth.",
+            "STAT SUMMARY_BIN ONLY: number of bins (integer ≥ 1). Default 30 — advisory. Overridden by binwidth.",
         }),
       ),
       binwidth: Type.Optional(
@@ -673,7 +673,7 @@ export const SpecDeclarations = {
           ],
           {
             description:
-              'SUMMARY_BIN center fun (mean/median/sum; #817) or MANUAL named transform (first|last|mean|median|min|max|sum; #814). Required when stat is "manual".',
+              'SUMMARY_BIN center fun (mean/median/sum;) or MANUAL named transform (first|last|mean|median|min|max|sum;). Required when stat is "manual".',
           },
         ),
       ),
@@ -691,7 +691,7 @@ export const SpecDeclarations = {
     {
       additionalProperties: false,
       description:
-        "Styling parameters for the point geom, plus summary_bin (#817) and/or manual (#814) controls.",
+        "Styling parameters for the point geom, plus summary_bin and/or manual controls.",
     },
   ),
 
@@ -727,7 +727,7 @@ export const SpecDeclarations = {
       pad: Type.Optional(
         Type.Boolean({
           description:
-            "With stat ecdf: when true (default), prepend (xmin, 0) so step stairs start at zero. Finite-clamped (ggplot2 uses ±Inf).",
+            "With stat ecdf: when true (default), prepend (xmin, 0) so step stairs start at zero. Finite-clamped.",
         }),
       ),
       n: Type.Optional(
@@ -755,7 +755,7 @@ export const SpecDeclarations = {
           ],
           {
             description:
-              'STAT CONNECT ONLY (#816): how successive points join — "hv" (default), "vh", "mid", or "linear". Ignored for other stats.',
+              'STAT CONNECT ONLY: how successive points join — "hv" (default), "vh", "mid", or "linear". Ignored for other stats.',
           },
         ),
       ),
@@ -804,7 +804,7 @@ export const SpecDeclarations = {
           ],
           {
             description:
-              'SUMMARY_BIN center fun (mean/median/sum; #817) or MANUAL named transform (first|last|mean|median|min|max|sum; #814). Required when stat is "manual".',
+              'SUMMARY_BIN center fun (mean/median/sum;) or MANUAL named transform (first|last|mean|median|min|max|sum;). Required when stat is "manual".',
           },
         ),
       ),
@@ -833,7 +833,7 @@ export const SpecDeclarations = {
     {
       additionalProperties: false,
       description:
-        "Styling parameters for the line geom, plus optional stat-bin (freqpoly), summary_bin (#817), manual (#814), or ecdf pad/n (#811) controls.",
+        "Styling parameters for the line geom, plus optional stat-bin (freqpoly), summary_bin, manual, or ecdf pad/n controls.",
     },
   ),
 
@@ -856,7 +856,7 @@ export const SpecDeclarations = {
       direction: Type.Optional(
         Type.Union([Type.Literal("hv"), Type.Literal("vh"), Type.Literal("mid")], {
           description:
-            'Step corner placement (ggplot2 geom_step): "hv" horizontal then vertical (default), "vh" vertical then horizontal, "mid" change at the midpoint between x positions.',
+            'Step corner placement: "hv" horizontal then vertical (default), "vh" vertical then horizontal, "mid" change at the midpoint between x positions.',
         }),
       ),
       strokePaint: Type.Optional(
@@ -873,7 +873,7 @@ export const SpecDeclarations = {
     },
     {
       additionalProperties: false,
-      description: "Styling parameters for the step geom (ggplot2 geom_step).",
+      description: "Styling parameters for the step geom.",
     },
   ),
 
@@ -916,7 +916,7 @@ export const SpecDeclarations = {
           ],
           {
             description:
-              'STAT CONNECT ONLY (#816): how successive points join — "hv" (default), "vh", "mid", or "linear". Ignored for other stats.',
+              'STAT CONNECT ONLY: how successive points join — "hv" (default), "vh", "mid", or "linear". Ignored for other stats.',
           },
         ),
       ),
@@ -933,7 +933,7 @@ export const SpecDeclarations = {
           ],
           {
             description:
-              'STAT MANUAL ONLY (#814): portable named transform (first|last|mean|median|min|max|sum). Required when stat is "manual".',
+              'STAT MANUAL ONLY: portable named transform (first|last|mean|median|min|max|sum). Required when stat is "manual".',
           },
         ),
       ),
@@ -1059,7 +1059,7 @@ export const SpecDeclarations = {
       closed: Type.Optional(
         Type.Union([Type.Literal("right"), Type.Literal("left")], {
           description:
-            'STAT BIN ONLY: which edge of each bin is inclusive: "right" (default, matches ggplot2) or "left".',
+            'STAT BIN ONLY: which edge of each bin is inclusive: "right" (default, matches) or "left".',
         }),
       ),
       fillPaint: Type.Optional(
@@ -1204,7 +1204,7 @@ export const SpecDeclarations = {
     {
       additionalProperties: false,
       description:
-        "Parameters for the quantile geom (linear y~x quantile regression lines; #805). method rqss is intentionally omitted in v1.",
+        "Parameters for the quantile geom (linear y~x quantile regression lines;). method rqss is intentionally omitted in v1.",
     },
   ),
   QqParams: Type.Object(
@@ -1298,7 +1298,7 @@ export const SpecDeclarations = {
     {
       additionalProperties: false,
       description:
-        "Parameters for geom_contour isolines (#801). v1: regular grid only; contour_filled deferred.",
+        "Parameters for geom_contour isolines. v1: regular grid only; contour_filled deferred.",
     },
   ),
 
@@ -1388,7 +1388,7 @@ export const SpecDeclarations = {
           exclusiveMinimum: 0,
           maximum: 1,
           description:
-            "Box width as a fraction of the band step. Must be greater than 0 and at most 1. Default 0.75 (ggplot2). When omitted, width is also capped at 15% of the panel so few categories do not read as slabs.",
+            "Box width as a fraction of the band step. Must be greater than 0 and at most 1. Default 0.75. When omitted, width is also capped at 15% of the panel so few categories do not read as slabs.",
         }),
       ),
       coef: Type.Optional(
@@ -1599,7 +1599,7 @@ export const SpecDeclarations = {
     {
       additionalProperties: false,
       description:
-        "Parameters for geom_dotplot (histodot binning + stacked dots; #803). method=dotdensity and binaxis=y are not in v1.",
+        "Parameters for geom_dotplot (histodot binning + stacked dots;). method=dotdensity and binaxis=y are not in v1.",
     },
   ),
 
@@ -1723,7 +1723,7 @@ export const SpecDeclarations = {
     {
       additionalProperties: false,
       description:
-        "Parameters for geom_density_2d / geom_density_2d_filled (bivariate KDE; #802). contour_var density only.",
+        "Parameters for geom_density_2d / geom_density_2d_filled (bivariate KDE;). contour_var density only.",
     },
   ),
 
@@ -1766,7 +1766,7 @@ export const SpecDeclarations = {
       fun: Type.Optional(
         Type.Union([Type.Literal("mean"), Type.Literal("median"), Type.Literal("sum")], {
           description:
-            'STAT SUMMARY ONLY: the center summary of y per x group: "mean" (default), "median", or "sum". With "mean" and no funMin/funMax, the bounds default to mean ± standard error (ggplot2\'s mean_se).',
+            'STAT SUMMARY ONLY: the center summary of y per x group: "mean" (default), "median", or "sum". With "mean" and no funMin/funMax, the bounds default to mean ± standard error.',
         }),
       ),
       funMin: Type.Optional(
@@ -1785,7 +1785,7 @@ export const SpecDeclarations = {
         Type.Integer({
           minimum: 1,
           description:
-            "STAT SUMMARY_BIN ONLY (#817): number of bins (integer ≥ 1). Default 30 — advisory. Overridden by binwidth.",
+            "STAT SUMMARY_BIN ONLY: number of bins (integer ≥ 1). Default 30 — advisory. Overridden by binwidth.",
         }),
       ),
       binwidth: Type.Optional(
@@ -1817,7 +1817,7 @@ export const SpecDeclarations = {
     {
       additionalProperties: false,
       description:
-        "Parameters for the errorbar geom: styling plus summary / summary_bin functions and summary_bin binning controls (#817).",
+        "Parameters for the errorbar geom: styling plus summary / summary_bin functions and summary_bin binning controls.",
     },
   ),
 
@@ -1889,7 +1889,7 @@ export const SpecDeclarations = {
         Type.Number({
           exclusiveMinimum: 0,
           description:
-            "Multiplier for the mid-line linewidth relative to params.linewidth / aes.linewidth. Default 2.5 (ggplot2 geom_crossbar).",
+            "Multiplier for the mid-line linewidth relative to params.linewidth / aes.linewidth. Default 2.5.",
         }),
       ),
       linewidth: Type.Optional(
@@ -1973,8 +1973,7 @@ export const SpecDeclarations = {
       bins: Type.Optional(
         Type.Number({
           exclusiveMinimum: 0,
-          description:
-            "Number of bins on each axis (ggplot2 bins). Default 30. Applies equally to x and y in v1.",
+          description: "Number of bins on each axis. Default 30. Applies equally to x and y in v1.",
         }),
       ),
       binwidth: Type.Optional(
@@ -1986,8 +1985,7 @@ export const SpecDeclarations = {
       ),
       drop: Type.Optional(
         Type.Boolean({
-          description:
-            "When true (default), omit zero-count bins from the output (ggplot2 drop=TRUE).",
+          description: "When true (default), omit zero-count bins from the output.",
         }),
       ),
       alpha: Type.Optional(
@@ -2107,8 +2105,7 @@ export const SpecDeclarations = {
       bins: Type.Optional(
         Type.Number({
           exclusiveMinimum: 0,
-          description:
-            "Approximate number of hex bins across the x range (ggplot2 bins). Default 30.",
+          description: "Approximate number of hex bins across the x range. Default 30.",
         }),
       ),
       drop: Type.Optional(
@@ -2157,7 +2154,7 @@ export const SpecDeclarations = {
         Type.Integer({
           minimum: 0,
           description:
-            "JITTER ONLY: RNG seed (a non-negative integer). Default 42. ggsvelte jitter is ALWAYS seeded so renders are reproducible (deliberate divergence from ggplot2's random jitter).",
+            "JITTER ONLY: RNG seed (a non-negative integer). Default 42. ggsvelte jitter is ALWAYS seeded so renders are reproducible (deliberate divergence from random jitter).",
         }),
       ),
       x: Type.Optional(
@@ -2371,7 +2368,7 @@ export const SpecDeclarations = {
     {
       additionalProperties: false,
       description:
-        "Parameters for the hline alias (ggplot2 geom_hline). Annotation form sets yintercept; data-driven form maps aes.y. Canonicalized by normalize() to a rule layer.",
+        "Parameters for the hline alias. Annotation form sets yintercept; data-driven form maps aes.y. Canonicalized by normalize to a rule layer.",
     },
   ),
 
@@ -2411,7 +2408,7 @@ export const SpecDeclarations = {
     {
       additionalProperties: false,
       description:
-        "Parameters for the vline alias (ggplot2 geom_vline). Annotation form sets xintercept; data-driven form maps aes.x. Canonicalized by normalize() to a rule layer.",
+        "Parameters for the vline alias. Annotation form sets xintercept; data-driven form maps aes.x. Canonicalized by normalize to a rule layer.",
     },
   ),
 
@@ -2469,7 +2466,7 @@ export const SpecDeclarations = {
           exclusiveMinimum: 0,
           maximum: 1,
           description:
-            'Tick length as a fraction of the panel size along the tick axis (panel-fraction npc analogue of ggplot2 unit(0.03, "npc")). Default 0.03.',
+            'Tick length as a fraction of the panel size along the tick axis (panel-fraction npc analogue of unit(0.03, "npc")). Default 0.03.',
         }),
       ),
       alpha: Type.Optional(
@@ -2582,7 +2579,7 @@ export const SpecDeclarations = {
     {
       geom: Type.Literal("abline", {
         description:
-          "Abline geometry: one infinite reference line y = intercept + slope · x, clipped to the panel (ggplot2 geom_abline). Annotation form: fixed slope/intercept in params; does not inherit plot aes.",
+          "Abline geometry: one infinite reference line y = intercept + slope · x, clipped to the panel. Annotation form: fixed slope/intercept in params; does not inherit plot aes.",
       }),
       stat: Type.Optional(
         Type.Literal("identity", { description: "Abline layers use fixed params as-is." }),
@@ -2608,7 +2605,7 @@ export const SpecDeclarations = {
     {
       additionalProperties: false,
       description:
-        "A slope/intercept reference-line layer (ggplot2 geom_abline). Annotation-only: set params.slope and params.intercept.",
+        "A slope/intercept reference-line layer. Annotation-only: set params.slope and params.intercept.",
     },
   ),
 
@@ -2617,13 +2614,13 @@ export const SpecDeclarations = {
       curvature: Type.Optional(
         Type.Number({
           description:
-            "Amount of bend away from the straight chord. 0 is a straight line; ggplot2 default 0.5. Positive bows to the right of the start→end direction when angle is 90.",
+            "Amount of bend away from the straight chord. 0 is a straight line; default 0.5. Positive bows to the right of the start→end direction when angle is 90.",
         }),
       ),
       angle: Type.Optional(
         Type.Number({
           description:
-            "Control-point direction relative to the chord, in degrees. ggplot2 default 90 (perpendicular).",
+            "Control-point direction relative to the chord, in degrees. default 90 (perpendicular).",
         }),
       ),
       ncp: Type.Optional(
@@ -2631,7 +2628,7 @@ export const SpecDeclarations = {
           minimum: 1,
           maximum: 50,
           description:
-            "Smoothness density knob (ggplot2 ncp). Maps to tessellation sample count = max(8, ncp×8); not multi-control xspline. Default 5.",
+            "Smoothness density knob. Maps to tessellation sample count = max(8, ncp×8); not multi-control xspline. Default 5.",
         }),
       ),
       alpha: Type.Optional(
@@ -2758,7 +2755,7 @@ export const SpecDeclarations = {
     {
       additionalProperties: false,
       description:
-        "Parameters for geom_map (#808): fortified map DataRef plus optional join column and polygon styling.",
+        "Parameters for geom_map: fortified map DataRef plus optional join column and polygon styling.",
     },
   ),
 
@@ -2768,7 +2765,7 @@ export const SpecDeclarations = {
         Type.String({
           minLength: 1,
           description:
-            'Name of the data column holding GeoJSON Geometry JSON strings. Default "geometry". Already-projected coordinates only (#809 phase 1).',
+            'Name of the data column holding GeoJSON Geometry JSON strings. Default "geometry". Already-projected coordinates only.',
         }),
       ),
       alpha: Type.Optional(
@@ -2809,7 +2806,7 @@ export const SpecDeclarations = {
     {
       additionalProperties: false,
       description:
-        "Parameters for geom_sf (#809): portable GeoJSON Geometry column plus styling. Interior rings are even-odd holes; GeometryCollection expands. Use coord_sf for fixed-aspect maps (CRS reproject deferred).",
+        "Parameters for geom_sf: portable GeoJSON Geometry column plus styling. Interior rings are even-odd holes; GeometryCollection expands. Use coord_sf for fixed-aspect maps (CRS reproject deferred).",
     },
   ),
 
@@ -2888,20 +2885,19 @@ export const SpecDeclarations = {
       padding: Type.Optional(
         Type.Number({
           exclusiveMinimum: 0,
-          description:
-            "Uniform box padding around the text in px (ggplot2 label.padding). Default 3.",
+          description: "Uniform box padding around the text in px. Default 3.",
         }),
       ),
       radius: Type.Optional(
         Type.Number({
           minimum: 0,
-          description: "Corner radius of the background box in px (ggplot2 label.r). Default 3.",
+          description: "Corner radius of the background box in px. Default 3.",
         }),
       ),
       linewidth: Type.Optional(
         Type.Number({
           minimum: 0,
-          description: "Box outline stroke width in px (ggplot2 label.size analogue). Default 0.5.",
+          description: "Box outline stroke width in px. Default 0.5.",
         }),
       ),
     },
@@ -2937,7 +2933,7 @@ export const SpecDeclarations = {
       }),
       Type.Literal("unique", {
         description:
-          "Drop duplicate rows on the combination of mapped aesthetic fields before drawing; first occurrence wins (ggplot2's stat_unique). Panel-local.",
+          "Drop duplicate rows on the combination of mapped aesthetic fields before drawing; first occurrence wins. Panel-local.",
       }),
     ],
     {
@@ -2952,7 +2948,7 @@ export const SpecDeclarations = {
     {
       geom: Type.Literal("point", {
         description:
-          "Point geometry: one mark per data row. Use for scatter plots, dot plots, bubbles, correlation views. With summary_bin (#817) or manual (#814).",
+          "Point geometry: one mark per data row. Use for scatter plots, dot plots, bubbles, and correlation views.",
       }),
       stat: Type.Optional(
         Type.Union(
@@ -2961,25 +2957,22 @@ export const SpecDeclarations = {
               description: "Draw each data row as-is (default).",
             }),
             Type.Literal("unique", {
-              description:
-                "Drop duplicate rows on mapped aesthetics before drawing; first wins (#813).",
+              description: "Drop duplicate rows on mapped aesthetics before drawing; first wins.",
             }),
             Type.Literal("summary_bin", {
-              description:
-                "Bin continuous x and summarize y per (group × bin); default mean ± se (#817).",
+              description: "Bin continuous x and summarize y per (group × bin); default mean ± se.",
             }),
             Type.Literal("manual", {
               description:
-                "Portable named per-group transform (params.fun required: first|last|mean|median|min|max|sum; #814).",
+                "Portable named per-group transform (params.fun required: first|last|mean|median|min|max|sum;).",
             }),
             Type.Literal("sum", {
-              description:
-                'Aggregate coincident (x, y); size defaults to {stat:"n"} (geom_count / #795).',
+              description: 'Aggregate coincident (x, y); size defaults to {stat:"n"} (geom_count).',
             }),
           ],
           {
             description:
-              'Point stat: "identity" (default), "unique", "summary_bin" (#817), "manual" (#814), or "sum" (#795).',
+              'Point stat: "identity" (default), "unique", "summary_bin", "manual", or "sum".',
           },
         ),
       ),
@@ -3017,7 +3010,7 @@ export const SpecDeclarations = {
     {
       geom: Type.Literal("line", {
         description:
-          "Line geometry: connects points in x order, one line per group (groups derive from discrete aesthetics such as color, or from aes.group). Use for time series, trends, line charts, and ECDFs (stat ecdf + curve step-hv; #811). With stat bin (freqpoly alias), y is computed from counts/density. With stat connect, successive points expand into named connection vertices (#816).",
+          "Line geometry: connects points in x order, one line per group (groups derive from discrete aesthetics such as color, or from aes.group). Use for time series, trends, and line charts. With stat ecdf, pair with step curves; with stat bin (freqpoly alias), y is computed from counts/density; with stat connect, successive points expand into connection vertices.",
       }),
       stat: Type.Optional(
         Type.Union(
@@ -3026,8 +3019,7 @@ export const SpecDeclarations = {
               description: "Draw each data row as-is (default — map aes.y).",
             }),
             Type.Literal("unique", {
-              description:
-                "Drop duplicate rows on mapped aesthetics before drawing (first wins; #813).",
+              description: "Drop duplicate rows on mapped aesthetics before drawing (first wins;).",
             }),
             Type.Literal("bin", {
               description:
@@ -3035,28 +3027,28 @@ export const SpecDeclarations = {
             }),
             Type.Literal("align", {
               description:
-                "Interpolate each group onto the union of finite x values so continuous-x stack/fill aligns (#815). Outside a group's x range y is 0.",
+                "Interpolate each group onto the union of finite x values so continuous-x stack/fill aligns. Outside a group's x range y is 0.",
             }),
             Type.Literal("connect", {
               description:
-                "Expand successive points into connection vertices (params.connection: hv|vh|mid|linear; #816). Expands in x order; geometry does not re-sort after connect.",
+                "Expand successive points into connection vertices (params.connection: hv|vh|mid|linear;). Expands in x order; geometry does not re-sort after connect.",
             }),
             Type.Literal("summary_bin", {
               description:
-                "Bin continuous x and summarize y per (group × bin); default mean ± se; connect centers in x order (#817).",
+                "Bin continuous x and summarize y per (group × bin); default mean ± se; connect centers in x order.",
             }),
             Type.Literal("manual", {
               description:
-                "Portable named per-group transform (params.fun required: first|last|mean|median|min|max|sum; #814).",
+                "Portable named per-group transform (params.fun required: first|last|mean|median|min|max|sum;).",
             }),
             Type.Literal("ecdf", {
               description:
-                'Empirical CDF of x; y defaults to {"stat": "ecdf"} — do NOT map aes.y to a field. Prefer params.curve "step-hv" for ECDF stairs (#811).',
+                'Empirical CDF of x; y defaults to {"stat": "ecdf"} — do NOT map aes.y to a field. Prefer params.curve "step-hv" for ECDF stairs.',
             }),
           ],
           {
             description:
-              'Line stat: "identity" (default), "unique", "bin", "align", "connect", "summary_bin" (#817), "manual" (#814), or "ecdf" (#811).',
+              'Line stat: "identity" (default), "unique", "bin", "align", "connect", "summary_bin", "manual", or "ecdf".',
           },
         ),
       ),
@@ -3090,7 +3082,7 @@ export const SpecDeclarations = {
     {
       geom: Type.Literal("step", {
         description:
-          "Step-line geometry: connect points with hv/vh/mid stairs (ggplot2 geom_step). Same channels as line; ordered by x within groups.",
+          "Step-line geometry: connect points with hv/vh/mid stairs. Same channels as line; ordered by x within groups.",
       }),
       stat: Type.Optional(
         Type.Literal("identity", { description: "Step layers draw the data as-is." }),
@@ -3117,7 +3109,7 @@ export const SpecDeclarations = {
     {
       additionalProperties: false,
       description:
-        "A step-line layer (ggplot2 geom_step). Requires x and y. params.direction is hv (default), vh, or mid.",
+        "A step-line layer. Requires x and y. params.direction is hv (default), vh, or mid.",
     },
   ),
 
@@ -3125,7 +3117,7 @@ export const SpecDeclarations = {
     {
       geom: Type.Literal("path", {
         description:
-          "Path geometry: connects points in data (row) order within each group — unlike line, which sorts by x. Use for trajectories, loops, connected scatterplots (ggplot2 geom_path), and ellipse rings (stat ellipse). With stat connect, successive points expand into named connection vertices (#816).",
+          "Path geometry: connects points in data (row) order within each group — unlike line, which sorts by x. Use for trajectories, loops, connected scatterplots, and ellipse rings (stat ellipse). With stat connect, successive points expand into connection vertices.",
       }),
       stat: Type.Optional(
         Type.Union(
@@ -3134,25 +3126,24 @@ export const SpecDeclarations = {
               description: "Draw each data row as-is (default).",
             }),
             Type.Literal("unique", {
-              description:
-                "Drop duplicate rows on mapped aesthetics before drawing (first wins; #813).",
+              description: "Drop duplicate rows on mapped aesthetics before drawing (first wins;).",
             }),
             Type.Literal("connect", {
               description:
-                "Expand successive points into connection vertices (params.connection: hv|vh|mid|linear; default hv; #816). ggplot2 stat_connect default geom is path.",
+                "Expand successive points into connection vertices (params.connection: hv|vh|mid|linear; default hv;). stat_connect default geom is path.",
             }),
             Type.Literal("manual", {
               description:
-                "Portable named per-group transform (params.fun required: first|last|mean|median|min|max|sum; #814).",
+                "Portable named per-group transform (params.fun required: first|last|mean|median|min|max|sum;).",
             }),
             Type.Literal("ellipse", {
               description:
-                "Bivariate normal confidence ellipse per group (ggplot2 stat_ellipse, type norm). Emits perimeter samples suitable for path; requires quantitative x and y (#812).",
+                "Bivariate normal confidence ellipse per group. Emits perimeter samples suitable for path; requires quantitative x and y.",
             }),
           ],
           {
             description:
-              'Path stat: "identity" (default), "unique", "connect", "manual" (#814), or "ellipse" (#812).',
+              'Path stat: "identity" (default), "unique", "connect", "manual", or "ellipse".',
           },
         ),
       ),
@@ -3186,7 +3177,7 @@ export const SpecDeclarations = {
     {
       geom: Type.Literal("col", {
         description:
-          "Column geometry: one rectangle per data row, from the y baseline (zero) to the row's y value. Use when the data already contains the bar heights (ggplot2's geom_col).",
+          "Column geometry: one rectangle per data row, from the y baseline (zero) to the row's y value. Use when the data already contains the bar heights — prefer over GeomBar, which counts or bins.",
       }),
       stat: Type.Optional(Type.Ref("IdentityOrUniqueStat")),
       position: Type.Optional(Type.Ref("StackablePosition")),
@@ -3217,7 +3208,7 @@ export const SpecDeclarations = {
     {
       geom: Type.Literal("bar", {
         description:
-          "Bar geometry with counting or binning: one rectangle per distinct x value (stat count, discrete x) or per bin (stat bin, continuous x). Do NOT map aes.y — the stat computes it (ggplot2's geom_bar / geom_histogram).",
+          "Bar geometry with counting or binning: one rectangle per distinct x value (stat count, discrete x) or per bin (stat bin, continuous x). Do not map aes.y — the stat computes it. Prefer GeomCol when bar heights are already in the data.",
       }),
       stat: Type.Optional(
         Type.Union([Type.Literal("count"), Type.Literal("bin")], {
@@ -3253,7 +3244,7 @@ export const SpecDeclarations = {
     {
       geom: Type.Literal("histogram", {
         description:
-          "Histogram geometry: a continuous x variable divided into bins, one bar per bin whose height is the count of rows (or the sum of aes.weight). Do NOT map aes.y — the bin stat computes it. Canonicalized by normalize() to a bar layer with stat bin.",
+          "Histogram geometry: a continuous x variable divided into bins, one bar per bin whose height is the count of rows (or the sum of aes.weight). Do not map aes.y — the bin stat computes it. Canonicalized by normalize() to a bar layer with stat bin.",
       }),
       stat: Type.Optional(
         Type.Literal("bin", {
@@ -3289,7 +3280,7 @@ export const SpecDeclarations = {
     {
       geom: Type.Literal("freqpoly", {
         description:
-          "Frequency polygon (ggplot2 geom_freqpoly): continuous x binned like a histogram, drawn as a line through bin centers. Do NOT map aes.y — the bin stat computes it. Canonicalized by normalize() to a line layer with stat bin.",
+          "Frequency polygon: continuous x binned like a histogram, drawn as a line through bin centers. Do not map aes.y — the bin stat computes it. Canonicalized by normalize() to a line layer with stat bin.",
       }),
       stat: Type.Optional(
         Type.Literal("bin", {
@@ -3327,7 +3318,7 @@ export const SpecDeclarations = {
     {
       geom: Type.Literal("smooth", {
         description:
-          "Smooth geometry: a fitted trend line (with an optional confidence ribbon) over an x/y scatter, one fit per group. Use to reveal trends (ggplot2's geom_smooth).",
+          "Smooth geometry: a fitted trend line (with an optional confidence ribbon) over an x/y scatter, one fit per group. Use to reveal trends.",
       }),
       stat: Type.Optional(
         Type.Literal("smooth", {
@@ -3365,7 +3356,7 @@ export const SpecDeclarations = {
     {
       geom: Type.Literal("quantile", {
         description:
-          "Quantile geometry: linear quantile regression lines (y ~ x) at one or more conditional quantiles of y, one line per quantile per group (ggplot2 geom_quantile / #805).",
+          "Quantile geometry: linear quantile regression lines (y ~ x) at one or more conditional quantiles of y, one line per quantile per group.",
       }),
       stat: Type.Optional(
         Type.Literal("quantile", {
@@ -3402,7 +3393,7 @@ export const SpecDeclarations = {
     {
       geom: Type.Literal("qq", {
         description:
-          "Q–Q scatter (ggplot2 geom_qq / stat_qq): sample quantiles vs theoretical normal quantiles. Requires aes.sample.",
+          "Q–Q scatter: sample quantiles vs theoretical normal quantiles. Requires aes.sample.",
       }),
       stat: Type.Optional(
         Type.Literal("qq", { description: "Q–Q quantile pairing (default for this geom)." }),
@@ -3435,7 +3426,7 @@ export const SpecDeclarations = {
     {
       geom: Type.Literal("qq_line", {
         description:
-          "Q–Q reference line (ggplot2 geom_qq_line / stat_qq_line): line through sample/theoretical quartile match, spanning the theoretical range of the Q–Q cloud. Requires aes.sample.",
+          "Q–Q reference line: line through sample/theoretical quartile match, spanning the theoretical range of the Q–Q cloud. Requires aes.sample.",
       }),
       stat: Type.Optional(
         Type.Literal("qq_line", {
@@ -3471,7 +3462,7 @@ export const SpecDeclarations = {
     {
       geom: Type.Literal("contour", {
         description:
-          "Contour geometry: isolines of a continuous z surface over a regular x×y grid (ggplot2 geom_contour; #801). v1 draws open path polylines only (not filled bands).",
+          "Contour geometry: isolines of a continuous z surface over a regular x×y grid. v1 draws open path polylines only (not filled bands).",
       }),
       stat: Type.Optional(
         Type.Literal("contour", {
@@ -3509,7 +3500,7 @@ export const SpecDeclarations = {
     {
       geom: Type.Literal("violin", {
         description:
-          "Violin geometry: mirrored kernel density of continuous y at each discrete x (ggplot2 geom_violin / stat_ydensity). One polygon per x×group. Default position dodge.",
+          "Violin geometry: mirrored kernel density of continuous y at each discrete x (stat ydensity). One polygon per x×group. Default position dodge.",
       }),
       stat: Type.Optional(
         Type.Literal("ydensity", {
@@ -3588,7 +3579,7 @@ export const SpecDeclarations = {
     {
       geom: Type.Literal("count", {
         description:
-          "Count geometry (ggplot2 geom_count): point marks at unique (x, y) with size scaled by after_stat n (stat sum). Use for overplotting density on discrete or rounded coordinates.",
+          "Count geometry: point marks at unique (x, y) with size scaled by after_stat n (stat sum). Use for overplotting density on discrete or rounded coordinates.",
       }),
       stat: Type.Optional(
         Type.Literal("sum", {
@@ -3628,7 +3619,7 @@ export const SpecDeclarations = {
     {
       geom: Type.Literal("dotplot", {
         description:
-          "Dotplot geometry: stacked dots along a continuous x axis (ggplot2 geom_dotplot, histodot subset). Do NOT map aes.y — the bindot stat computes stack positions.",
+          "Dotplot geometry: stacked dots along a continuous x axis (histodot subset). Do not map aes.y — the bindot stat computes stack positions.",
       }),
       stat: Type.Optional(
         Type.Literal("bindot", {
@@ -3704,7 +3695,7 @@ export const SpecDeclarations = {
     {
       geom: Type.Literal("density_2d", {
         description:
-          "2D density geometry: bivariate KDE isolines over continuous x and y (ggplot2 geom_density_2d; #802). Open path contours.",
+          "2D density geometry: bivariate KDE isolines over continuous x and y. Open path contours.",
       }),
       stat: Type.Optional(
         Type.Literal("density_2d", {
@@ -3742,7 +3733,7 @@ export const SpecDeclarations = {
     {
       geom: Type.Literal("density_2d_filled", {
         description:
-          "2D density filled bands: bivariate KDE closed isoline rings filled by density level (ggplot2 geom_density_2d_filled; #802 phase 2). Open rings dropped. Defaults fill to after_stat(level).",
+          "2D density filled bands: bivariate KDE closed isoline rings filled by density level. Open rings dropped. Defaults fill to after_stat(level).",
       }),
       stat: Type.Optional(
         Type.Literal("density_2d_filled", {
@@ -3795,16 +3786,15 @@ export const SpecDeclarations = {
             }),
             Type.Literal("summary", {
               description:
-                "Compute y/ymin/ymax per x group from aes.y; default mean ± standard error (ggplot2 mean_se).",
+                "Compute y/ymin/ymax per x group from aes.y; default mean ± standard error.",
             }),
             Type.Literal("summary_bin", {
-              description:
-                "Bin continuous x and summarize y per (group × bin); default mean ± se (#817).",
+              description: "Bin continuous x and summarize y per (group × bin); default mean ± se.",
             }),
           ],
           {
             description:
-              'The errorbar\'s stat: "identity" (default), "unique", "summary" (per x group), or "summary_bin" (per bin; #817).',
+              'The errorbar\'s stat: "identity" (default), "unique", "summary" (per x group), or "summary_bin" (per bin;).',
           },
         ),
       ),
@@ -3837,8 +3827,7 @@ export const SpecDeclarations = {
   LinerangeLayer: Type.Object(
     {
       geom: Type.Literal("linerange", {
-        description:
-          "Linerange geometry: a vertical stem from ymin to ymax without end caps (ggplot2 geom_linerange).",
+        description: "Linerange geometry: a vertical stem from ymin to ymax without end caps.",
       }),
       stat: Type.Optional(
         Type.Union([Type.Literal("identity"), Type.Literal("summary")], {
@@ -3870,8 +3859,7 @@ export const SpecDeclarations = {
   PointrangeLayer: Type.Object(
     {
       geom: Type.Literal("pointrange", {
-        description:
-          "Pointrange geometry: vertical stem from ymin to ymax plus a point at (x, y) (ggplot2 geom_pointrange).",
+        description: "Pointrange geometry: vertical stem from ymin to ymax plus a point at (x, y).",
       }),
       stat: Type.Optional(
         Type.Union([Type.Literal("identity"), Type.Literal("summary")], {
@@ -3904,7 +3892,7 @@ export const SpecDeclarations = {
     {
       geom: Type.Literal("crossbar", {
         description:
-          "Crossbar geometry: a vertical interval box from ymin to ymax with a mid horizontal line at y (ggplot2 geom_crossbar).",
+          "Crossbar geometry: a vertical interval box from ymin to ymax with a mid horizontal line at y.",
       }),
       stat: Type.Optional(
         Type.Union([Type.Literal("identity"), Type.Literal("summary")], {
@@ -4005,7 +3993,7 @@ export const SpecDeclarations = {
     {
       geom: Type.Literal("bin_2d", {
         description:
-          "2D rectangular bin heatmap (ggplot2 geom_bin2d / stat_bin_2d): partitions continuous x×y into a grid and maps fill to bin count by default. Empty bins are dropped unless params.drop is false.",
+          "2D rectangular bin heatmap: partitions continuous x×y into a grid and maps fill to bin count by default. Empty bins are dropped unless params.drop is false.",
       }),
       stat: Type.Optional(
         Type.Literal("bin_2d", {
@@ -4077,7 +4065,7 @@ export const SpecDeclarations = {
     {
       geom: Type.Literal("hex", {
         description:
-          "Hexagonal bin heatmap (ggplot2 geom_hex / stat_bin_hex): partitions continuous x×y into a hexagonal lattice and maps fill to bin count by default.",
+          "Hexagonal bin heatmap: partitions continuous x×y into a hexagonal lattice and maps fill to bin count by default.",
       }),
       stat: Type.Optional(
         Type.Literal("bin_hex", {
@@ -4127,7 +4115,7 @@ export const SpecDeclarations = {
             }),
             Type.Literal("align", {
               description:
-                "Interpolate each group onto the union of finite x values so continuous-x stack/fill aligns (#815). Outside a group's x range y is 0.",
+                "Interpolate each group onto the union of finite x values so continuous-x stack/fill aligns. Outside a group's x range y is 0.",
             }),
           ],
           {
@@ -4164,7 +4152,7 @@ export const SpecDeclarations = {
     {
       geom: Type.Literal("ribbon", {
         description:
-          "Ribbon geometry: a filled interval between two varying boundaries along a running coordinate (ggplot2's geom_ribbon). Map x+ymin+ymax (x orientation) or y+xmin+xmax (y orientation). Not a zero-baseline area.",
+          "Ribbon geometry: a filled interval between two varying boundaries along a running coordinate. Map x+ymin+ymax (x orientation) or y+xmin+xmax (y orientation). Not a zero-baseline area.",
       }),
       stat: Type.Optional(Type.Ref("IdentityOrUniqueStat")),
       position: Type.Optional(
@@ -4197,7 +4185,7 @@ export const SpecDeclarations = {
     {
       geom: Type.Literal("rule", {
         description:
-          "Rule geometry: reference lines spanning the panel. TWO HONEST FORMS: (1) annotation — set params.xintercept and/or params.yintercept to fixed data values and map neither aes.x nor aes.y; (2) data-driven — map exactly ONE of aes.x (vertical rules) or aes.y (horizontal rules) to a field. Never mix the forms in one layer.",
+          "Rule geometry: reference lines spanning the panel. Two forms: (1) annotation — set params.xintercept and/or params.yintercept to fixed data values and map neither aes.x nor aes.y; (2) data-driven — map exactly one of aes.x (vertical rules) or aes.y (horizontal rules) to a field. Never mix the forms in one layer.",
       }),
       stat: Type.Optional(Type.Ref("IdentityOrUniqueStat")),
       position: Type.Optional(
@@ -4222,7 +4210,7 @@ export const SpecDeclarations = {
     {
       additionalProperties: false,
       description:
-        "A reference-line layer (ggplot2's geom_vline/geom_hline, unified). Annotation form: fixed intercepts in params. Data-driven form: map aes.x OR aes.y.",
+        "A reference-line layer. Annotation form: fixed intercepts in params. Data-driven form: map aes.x OR aes.y.",
     },
   ),
 
@@ -4230,7 +4218,7 @@ export const SpecDeclarations = {
     {
       geom: Type.Literal("hline", {
         description:
-          "Horizontal reference-line alias (ggplot2's geom_hline). Canonicalized by normalize() to a rule layer. Annotation form: set params.yintercept. Data-driven form: map aes.y (inherited plot x is dropped so the one-axis rule contract holds).",
+          "Horizontal reference-line alias. Canonicalized by normalize() to a rule layer. Annotation form: set params.yintercept. Data-driven form: map aes.y (inherited plot x is dropped so the one-axis rule contract holds).",
       }),
       stat: Type.Optional(
         Type.Literal("identity", { description: "Hline layers draw the given positions as-is." }),
@@ -4265,7 +4253,7 @@ export const SpecDeclarations = {
     {
       geom: Type.Literal("vline", {
         description:
-          "Vertical reference-line alias (ggplot2's geom_vline). Canonicalized by normalize() to a rule layer. Annotation form: set params.xintercept. Data-driven form: map aes.x (inherited plot y is dropped so the one-axis rule contract holds).",
+          "Vertical reference-line alias. Canonicalized by normalize() to a rule layer. Annotation form: set params.xintercept. Data-driven form: map aes.x (inherited plot y is dropped so the one-axis rule contract holds).",
       }),
       stat: Type.Optional(
         Type.Literal("identity", { description: "Vline layers draw the given positions as-is." }),
@@ -4300,7 +4288,7 @@ export const SpecDeclarations = {
     {
       geom: Type.Literal("jitter", {
         description:
-          "Jittered point alias (ggplot2's geom_jitter). Canonicalized by normalize() to a point layer with position jitter. Configure jitter amount via positionParams.width/height/seed.",
+          "Jittered point alias. Canonicalized by normalize() to a point layer with position jitter. Configure jitter amount via positionParams.width/height/seed.",
       }),
       stat: Type.Optional(
         Type.Literal("identity", { description: "Jitter layers draw the data as-is." }),
@@ -4374,7 +4362,7 @@ export const SpecDeclarations = {
     {
       geom: Type.Literal("label", {
         description:
-          "Label geometry: text with a rounded rectangular background box (ggplot2 geom_label). Requires x, y, and label channels. No collision detection.",
+          "Label geometry: text with a rounded rectangular background box. Requires x, y, and label channels. No collision detection.",
       }),
       stat: Type.Optional(
         Type.Literal("identity", { description: "Label layers draw the data as-is." }),
@@ -4437,8 +4425,7 @@ export const SpecDeclarations = {
     },
     {
       additionalProperties: false,
-      description:
-        "A finite segment layer (ggplot2's geom_segment). Requires x, y, xend, and yend channels.",
+      description: "A finite segment layer. Requires x, y, xend, and yend channels.",
     },
   ),
 
@@ -4446,7 +4433,7 @@ export const SpecDeclarations = {
     {
       geom: Type.Literal("function", {
         description:
-          "Function geometry: evaluate a named portable function y = f(x) on a grid and draw a path (ggplot2 geom_function / stat_function). Requires params.fun; domain from params.xlim, mapped x, or peer layers.",
+          "Function geometry: evaluate a named portable function y = f(x) on a grid and draw a path. Requires params.fun; domain from params.xlim, mapped x, or peer layers.",
       }),
       stat: Type.Optional(
         Type.Literal("function", {
@@ -4477,7 +4464,7 @@ export const SpecDeclarations = {
     {
       additionalProperties: false,
       description:
-        "An analytic function layer (ggplot2's geom_function). y is computed as { stat: y }; do not map data y. Portable fun names only (no JS closures).",
+        "An analytic function layer. y is computed as { stat: y }; do not map data y. Portable fun names only (no JS closures).",
     },
   ),
 
@@ -4485,7 +4472,7 @@ export const SpecDeclarations = {
     {
       geom: Type.Literal("curve", {
         description:
-          "Curve geometry (ggplot2 geom_curve): one curved connector per row from (x, y) to (xend, yend). Tessellated as a quadratic Bezier (curvature/angle/ncp). Requires field-mapped x, y, xend, and yend.",
+          "Curve geometry: one curved connector per row from (x, y) to (xend, yend). Tessellated as a quadratic Bezier (curvature/angle/ncp). Requires field-mapped x, y, xend, and yend.",
       }),
       stat: Type.Optional(
         Type.Literal("identity", { description: "Curve layers draw the data as-is." }),
@@ -4520,7 +4507,7 @@ export const SpecDeclarations = {
     {
       geom: Type.Literal("polygon", {
         description:
-          "Polygon geometry: closed filled paths from (x, y) vertices in data/row order within each group (ggplot2's geom_polygon). Groups form separate polygons. No x-sort (unlike line/area). Holes/subgroup omitted in v1.",
+          "Polygon geometry: closed filled paths from (x, y) vertices in data/row order within each group. Groups form separate polygons. No x-sort (unlike line/area). Holes/subgroup omitted in v1.",
       }),
       stat: Type.Optional(
         Type.Literal("identity", { description: "Polygon layers draw the data as-is." }),
@@ -4547,7 +4534,7 @@ export const SpecDeclarations = {
     {
       additionalProperties: false,
       description:
-        "A closed polygon layer (ggplot2's geom_polygon). Requires x and y channels; vertices connect in data order per group and close implicitly.",
+        "A closed polygon layer. Requires x and y channels; vertices connect in data order per group and close implicitly.",
     },
   ),
 
@@ -4555,7 +4542,7 @@ export const SpecDeclarations = {
     {
       geom: Type.Literal("map", {
         description:
-          "Map geometry (ggplot2 geom_map): join fortified region borders to value rows via aes.map_id and params.map. Renders closed filled paths per region (#808).",
+          "Map geometry: join fortified region borders to value rows via aes.map_id and params.map. Renders closed filled paths per region.",
       }),
       stat: Type.Optional(
         Type.Literal("identity", { description: "Map layers expand joins then draw as-is." }),
@@ -4590,12 +4577,11 @@ export const SpecDeclarations = {
     {
       geom: Type.Literal("sf", {
         description:
-          "Simple-features geometry (ggplot2 geom_sf; #809): already-projected GeoJSON Geometry JSON strings in a data column. Point/line/polygon families (incl. GeometryCollection of one family) with even-odd holes; use coord_sf for fixed-aspect (CRS reproject deferred).",
+          "Simple-features geometry: already-projected GeoJSON Geometry JSON strings in a data column. Point/line/polygon families (incl. GeometryCollection of one family) with even-odd holes; use coord_sf for fixed-aspect (CRS reproject deferred).",
       }),
       stat: Type.Optional(
         Type.Literal("sf", {
-          description:
-            "Geometry expand (ggplot2 stat_sf; #809): portable GeoJSON → drawable point/line/polygon parts.",
+          description: "Geometry expand: portable GeoJSON → drawable point/line/polygon parts.",
         }),
       ),
       position: Type.Optional(
@@ -4666,7 +4652,7 @@ export const SpecDeclarations = {
     },
     {
       additionalProperties: false,
-      description: "Parameters for geom_sf_text (#809 phase 2): geometry column plus text styling.",
+      description: "Parameters for geom_sf_text: geometry column plus text styling.",
     },
   ),
 
@@ -4674,7 +4660,7 @@ export const SpecDeclarations = {
     {
       geom: Type.Literal("sf_text", {
         description:
-          "Simple-features text labels (ggplot2 geom_sf_text; #809): places aes.label at representative geometry points (Multi* → one label per part; stat_sf_coordinates).",
+          "Simple-features text labels: places aes.label at representative geometry points (Multi* → one label per part; stat_sf_coordinates).",
       }),
       stat: Type.Optional(
         Type.Literal("sf_coordinates", {
@@ -4769,7 +4755,7 @@ export const SpecDeclarations = {
     {
       additionalProperties: false,
       description:
-        "Parameters for geom_sf_label (#809 phase 3): geometry column, text styling, and label box chrome.",
+        "Parameters for geom_sf_label: geometry column, text styling, and label box chrome.",
     },
   ),
 
@@ -4777,7 +4763,7 @@ export const SpecDeclarations = {
     {
       geom: Type.Literal("sf_label", {
         description:
-          "Simple-features labels with background boxes (ggplot2 geom_sf_label; #809): places aes.label at representative geometry points with a measured rounded rect (Multi* → one label per part). color=ink+box stroke; fill=box background.",
+          "Simple-features labels with background boxes: places aes.label at representative geometry points with a measured rounded rect (Multi* → one label per part). color=ink+box stroke; fill=box background.",
       }),
       stat: Type.Optional(
         Type.Literal("sf_coordinates", {
@@ -4824,7 +4810,7 @@ export const SpecDeclarations = {
     {
       geom: Type.Literal("blank", {
         description:
-          "Blank geometry (ggplot2's geom_blank): contributes mapped aesthetics to scale training and layout without drawing marks or hit targets. No channels are required; whatever is mapped trains its scale.",
+          "Blank geometry: contributes mapped aesthetics to scale training and layout without drawing marks or hit targets. No channels are required; whatever is mapped trains its scale.",
       }),
       stat: Type.Optional(
         Type.Literal("identity", {
@@ -4853,7 +4839,7 @@ export const SpecDeclarations = {
     {
       additionalProperties: false,
       description:
-        "An empty layer that trains scales from mapped aesthetics without emitting geometry (ggplot2's geom_blank).",
+        "An empty layer that trains scales from mapped aesthetics without emitting geometry.",
     },
   ),
 
@@ -4861,7 +4847,7 @@ export const SpecDeclarations = {
     {
       geom: Type.Literal("rug", {
         description:
-          "Rug geometry: short ticks along panel edges for each observation (ggplot2 geom_rug). Map aes.x for bottom/top sides and/or aes.y for left/right sides.",
+          "Rug geometry: short ticks along panel edges for each observation. Map aes.x for bottom/top sides and/or aes.y for left/right sides.",
       }),
       stat: Type.Optional(
         Type.Literal("identity", { description: "Rug layers draw the data as-is." }),
@@ -4896,7 +4882,7 @@ export const SpecDeclarations = {
     {
       geom: Type.Literal("spoke", {
         description:
-          "Spoke geometry (ggplot2 geom_spoke): one finite segment per row from (x, y) in direction angle (radians) with length radius. Endpoints are derived as xend = x + radius·cos(angle), yend = y + radius·sin(angle) in data space, then transformed like x/y. Requires continuous x and y.",
+          "Spoke geometry: one finite segment per row from (x, y) in direction angle (radians) with length radius. Endpoints are derived as xend = x + radius·cos(angle), yend = y + radius·sin(angle) in data space, then transformed like x/y. Requires continuous x and y.",
       }),
       stat: Type.Optional(
         Type.Literal("identity", { description: "Spoke layers draw the data as-is." }),
@@ -5295,13 +5281,13 @@ export const SpecDeclarations = {
         naValue: Type.Optional(
           Type.String({
             pattern: "^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$",
-            description: "Color for null/missing values. Default #999999.",
+            description: "Color for null/missing values. Default9.",
           }),
         ),
         unknownValue: Type.Optional(
           Type.String({
             pattern: "^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$",
-            description: "Color for invalid, out-of-domain, or unmapped values. Default #999999.",
+            description: "Color for invalid, out-of-domain, or unmapped values. Default9.",
           }),
         ),
         onExhaust: Type.Optional(
@@ -5874,19 +5860,19 @@ export const SpecDeclarations = {
       wrap: Type.Optional(
         Type.Ref("FacetFieldRef", {
           description:
-            "Facet WRAP form: partition rows by this data field's distinct values, one panel per value, wrapped into a grid ncol wide (ggplot2's facet_wrap). Mutually exclusive with rows/cols. Optional levels/labels control order and strip text.",
+            "Facet WRAP form: partition rows by this data field's distinct values, one panel per value, wrapped into a grid ncol wide. Mutually exclusive with rows/cols. Optional levels/labels control order and strip text.",
         }),
       ),
       rows: Type.Optional(
         Type.Ref("FacetFieldRef", {
           description:
-            "Facet GRID form: the field whose distinct values become grid rows (ggplot2's facet_grid rows). Combine with cols; mutually exclusive with wrap. Optional levels/labels control order and strip text.",
+            "Facet GRID form: the field whose distinct values become grid rows. Combine with cols; mutually exclusive with wrap. Optional levels/labels control order and strip text.",
         }),
       ),
       cols: Type.Optional(
         Type.Ref("FacetFieldRef", {
           description:
-            "Facet GRID form: the field whose distinct values become grid columns (ggplot2's facet_grid cols). Combine with rows; mutually exclusive with wrap. Optional levels/labels control order and strip text.",
+            "Facet GRID form: the field whose distinct values become grid columns. Combine with rows; mutually exclusive with wrap. Optional levels/labels control order and strip text.",
         }),
       ),
       ncol: Type.Optional(
@@ -5953,7 +5939,7 @@ export const SpecDeclarations = {
     {
       additionalProperties: false,
       description:
-        'The plot\'s Cartesian coordinate system. {"type": "flip"} turns any vertical composition into its horizontal counterpart (ggplot2\'s coord_flip).',
+        'The plot\'s Cartesian coordinate system. {"type": "flip"} turns any vertical composition into its horizontal counterpart.',
     },
   ),
 
@@ -6002,7 +5988,7 @@ export const SpecDeclarations = {
     {
       type: Type.Literal("sf", {
         description:
-          "Simple-features coordinates for already-projected map data (ggplot2 coord_sf; #809). Fixed-aspect layout; no CRS transform in v1.",
+          "Simple-features coordinates for already-projected map data. Fixed-aspect layout; no CRS transform in v1.",
       }),
       ratio: Type.Optional(
         Type.Number({
@@ -6099,7 +6085,7 @@ export const SpecDeclarations = {
     {
       additionalProperties: false,
       description:
-        "A complete ggsvelte plot specification: data + aesthetic mapping + one or more layers, in ggplot2's layered grammar. Strictly JSON (PortableSpec).",
+        "A complete ggsvelte plot specification: data + aesthetic mapping + one or more layers, in layered grammar. Strictly JSON (PortableSpec).",
     },
   ),
 };

--- a/packages/spec/tests/geom-reference.test.ts
+++ b/packages/spec/tests/geom-reference.test.ts
@@ -120,6 +120,19 @@ describe("GEOM_REFERENCE", () => {
     expect(missing, `params missing descriptions: ${missing.join(", ")}`).toEqual([]);
   });
 
+  it("user-facing summaries and param descriptions omit ggplot2 and issue numbers", () => {
+    const dirty = /ggplot2|#\d{3,5}\b/i;
+    const hits: string[] = [];
+    for (const geom of KNOWN_GEOMS) {
+      const entry = GEOM_REFERENCE[geom];
+      if (dirty.test(entry.summary)) hits.push(`${geom} summary`);
+      for (const param of entry.params) {
+        if (dirty.test(param.description)) hits.push(`${geom}.${param.name}`);
+      }
+    }
+    expect(hits, `dirty prose: ${hits.join(", ")}`).toEqual([]);
+  });
+
   it("SHARED_LAYER_PROPS documents the props common to every Geom* shell", () => {
     const names = SHARED_LAYER_PROPS.map((p) => p.name);
     expect(names).toEqual([

--- a/scripts/docs-route-inventory.test.ts
+++ b/scripts/docs-route-inventory.test.ts
@@ -89,13 +89,13 @@ describe("docs route inventory", () => {
     const inventory = createDocsRouteInventory();
     const index = inventory.find((entry) => entry.path === "/reference/geoms");
     expect(index).toMatchObject({
-      title: "Geom reference — ggsvelte",
+      title: "Geoms — ggsvelte",
       canonicalPath: "/reference/geoms",
       kind: "page",
       index: true,
       sitemap: true,
       shell: "docs",
-      navigation: { section: "Reference", label: "Geom reference", order: 51 },
+      navigation: { section: "Reference", label: "Geoms", order: 51 },
     });
     const details = inventory.filter((entry) => entry.path.startsWith("/reference/geoms/"));
     expect(details.length).toBe(49);
@@ -109,13 +109,13 @@ describe("docs route inventory", () => {
     const inventory = createDocsRouteInventory();
     const index = inventory.find((entry) => entry.path === "/reference/stats");
     expect(index).toMatchObject({
-      title: "Stat reference — ggsvelte",
+      title: "Stats — ggsvelte",
       canonicalPath: "/reference/stats",
       kind: "page",
       index: true,
       sitemap: true,
       shell: "docs",
-      navigation: { section: "Reference", label: "Stat reference", order: 52 },
+      navigation: { section: "Reference", label: "Stats", order: 52 },
     });
     const details = inventory.filter((entry) => entry.path.startsWith("/reference/stats/"));
     expect(details.length).toBe(28);
@@ -129,13 +129,13 @@ describe("docs route inventory", () => {
     const inventory = createDocsRouteInventory();
     const index = inventory.find((entry) => entry.path === "/reference/positions");
     expect(index).toMatchObject({
-      title: "Position reference — ggsvelte",
+      title: "Positions — ggsvelte",
       canonicalPath: "/reference/positions",
       kind: "page",
       index: true,
       sitemap: true,
       shell: "docs",
-      navigation: { section: "Reference", label: "Position reference", order: 53 },
+      navigation: { section: "Reference", label: "Positions", order: 53 },
     });
     const details = inventory.filter((entry) => entry.path.startsWith("/reference/positions/"));
     expect(details.length).toBe(6);

--- a/scripts/docs-route-inventory.ts
+++ b/scripts/docs-route-inventory.ts
@@ -98,7 +98,7 @@ const TOP_LEVEL_ROUTES: readonly DocsRouteRecord[] = [
   },
   {
     path: "/reference/geoms",
-    title: "Geom reference — ggsvelte",
+    title: "Geoms — ggsvelte",
     description:
       "Schema-derived API reference for every Geom* component: defaults, allowed stats and positions, and params.",
     canonicalPath: "/reference/geoms",
@@ -106,7 +106,7 @@ const TOP_LEVEL_ROUTES: readonly DocsRouteRecord[] = [
     index: true,
     sitemap: true,
     shell: "docs",
-    navigation: { section: "Reference", label: "Geom reference", order: 51 },
+    navigation: { section: "Reference", label: "Geoms", order: 51 },
     headings: [
       { id: "all-geoms", title: "All geoms", level: 2 },
       { id: "shared-layer-props", title: "Shared layer props", level: 2 },
@@ -114,7 +114,7 @@ const TOP_LEVEL_ROUTES: readonly DocsRouteRecord[] = [
   },
   {
     path: "/reference/stats",
-    title: "Stat reference — ggsvelte",
+    title: "Stats — ggsvelte",
     description:
       "Schema-derived API reference for every statistical transform: after_stat columns and compatible geoms.",
     canonicalPath: "/reference/stats",
@@ -122,7 +122,7 @@ const TOP_LEVEL_ROUTES: readonly DocsRouteRecord[] = [
     index: true,
     sitemap: true,
     shell: "docs",
-    navigation: { section: "Reference", label: "Stat reference", order: 52 },
+    navigation: { section: "Reference", label: "Stats", order: 52 },
     headings: [
       { id: "all-stats", title: "All stats", level: 2 },
       { id: "how-to-set", title: "How to set a stat", level: 2 },
@@ -130,7 +130,7 @@ const TOP_LEVEL_ROUTES: readonly DocsRouteRecord[] = [
   },
   {
     path: "/reference/positions",
-    title: "Position reference — ggsvelte",
+    title: "Positions — ggsvelte",
     description:
       "Schema-derived API reference for every position adjustment: positionParams and compatible geoms.",
     canonicalPath: "/reference/positions",
@@ -138,7 +138,7 @@ const TOP_LEVEL_ROUTES: readonly DocsRouteRecord[] = [
     index: true,
     sitemap: true,
     shell: "docs",
-    navigation: { section: "Reference", label: "Position reference", order: 53 },
+    navigation: { section: "Reference", label: "Positions", order: 53 },
     headings: [
       { id: "all-positions", title: "All positions", level: 2 },
       { id: "how-to-set", title: "How to set a position", level: 2 },

--- a/scripts/gen-llms.ts
+++ b/scripts/gen-llms.ts
@@ -399,9 +399,9 @@ export function buildLlmsIndex(
     lines.push(`- [${page.title}](/guide/${page.slug}): ${page.description}`);
   }
   lines.push(
-    "- [Geom reference](/reference/geoms): every Geom* component with defaults, allowed stats/positions, and params from the schema",
-    "- [Stat reference](/reference/stats): every statistical transform with after_stat columns and compatible geoms",
-    "- [Position reference](/reference/positions): every position adjustment with positionParams and compatible geoms",
+    "- [Geoms](/reference/geoms): every Geom* component with defaults, allowed stats/positions, and params from the schema",
+    "- [Stats](/reference/stats): every statistical transform with after_stat columns and compatible geoms",
+    "- [Positions](/reference/positions): every position adjustment with positionParams and compatible geoms",
     "- [Search interaction reference](/reference/interactions): filter interaction capabilities, events, diagnostics, and accessibility guidance",
     "- [JSON Schema v0](/schema/v0.json): the PortableSpec schema (unstable in v0.1)",
     "- [llms-full.txt](/llms-full.txt): all docs prose plus every example (spec JSON + Svelte source)",

--- a/scripts/llms-guide-content.ts
+++ b/scripts/llms-guide-content.ts
@@ -198,7 +198,7 @@ stable discrete color scale. [Examples](/examples) for every mark on real data.
 ## Look up a geom
 
 The full Svelte and JSON API for every mark lives in the
-[geom reference](/reference/geoms): defaults, allowed stats and positions, and
+[Geoms](/reference/geoms): defaults, allowed stats and positions, and
 every param with its schema description. That catalog is generated from the
 PortableSpec TypeBox schema (the same source as \`schema/v0.json\`), so it cannot
 drift from validation.


### PR DESCRIPTION
## Summary

- Scrub ggplot2 name-drops and GitHub issue numbers from schema layer/param descriptions that feed geom reference pages (B2: schema is source of truth).
- Reference detail snippets are required-only (almost always bare `<GeomCol />` / `"geom": "col"`).
- Drop stock “import / direct props / PortableSpec form” commentary that restates the snippet.
- One breadcrumb trail: Reference → Geoms / Stats / Positions → GeomCol (component name, not slug).
- Short section labels: Geoms, Stats, Positions.

## Test plan

- [x] `bun test packages/spec/tests/geom-reference.test.ts` (includes dirty-prose guard)
- [x] `bun test packages/spec/tests/stat-reference.test.ts packages/spec/tests/position-reference.test.ts`
- [x] `bun test scripts/docs-route-inventory.test.ts`
- [x] `bun test packages/spec/tests/artifact.test.ts` after `schema:emit`
- [ ] CI green
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1109" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->