### PR TITLE
fix(docs): geom snippet aes + link related Geom* in ledes

### DIFF
--- a/apps/docs/src/lib/components/ReferenceLede.svelte
+++ b/apps/docs/src/lib/components/ReferenceLede.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+  import { base } from "$app/paths";
+  import { KNOWN_GEOMS, KNOWN_STATS } from "@ggsvelte/spec";
+
+  import { segmentReferenceLede } from "$lib/reference-lede";
+
+  interface Props {
+    text: string;
+  }
+
+  let { text }: Props = $props();
+
+  const known = {
+    geoms: new Set<string>(KNOWN_GEOMS),
+    stats: new Set<string>(KNOWN_STATS),
+  };
+
+  const segments = $derived(segmentReferenceLede(text, known));
+</script>
+
+<p class="lede">
+  {#each segments as seg, i (i)}
+    {#if seg.kind === "link"}
+      <a href={`${base}${seg.href}`}><code>{seg.label}</code></a>
+    {:else}
+      {seg.value}
+    {/if}
+  {/each}
+</p>
+
+<style>
+  .lede {
+    max-width: 44rem;
+    margin: 0 0 1.5rem;
+    font-size: 1.05rem;
+  }
+
+  .lede a {
+    text-decoration: underline;
+    text-underline-offset: 0.12em;
+  }
+</style>

--- a/apps/docs/src/lib/reference-lede.ts
+++ b/apps/docs/src/lib/reference-lede.ts
@@ -1,0 +1,83 @@
+/**
+ * Split reference ledes so Geom* (and Stat* when present) tokens become links
+ * to their reference pages. Plain text stays plain; no markdown or {@html}.
+ */
+
+export type LedeSegment =
+  | { readonly kind: "text"; readonly value: string }
+  | {
+      readonly kind: "link";
+      readonly label: string;
+      /** Path under the site base, e.g. /reference/geoms/col */
+      readonly href: string;
+    };
+
+const TOKEN_RE = /\b(Geom|Stat)([A-Z][A-Za-z0-9]*)\b/g;
+
+/**
+ * PascalCase body after the Geom/Stat prefix → snake_case catalog slug.
+ * GeomCol → col, GeomDensity2dFilled → density_2d_filled, GeomQqLine → qq_line.
+ */
+export function pascalBodyToSlug(body: string): string {
+  return body
+    .replaceAll(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .replaceAll(/([A-Za-z])(\d)/g, "$1_$2")
+    .toLowerCase();
+}
+
+/**
+ * Segment a summary into text + links. Only tokens whose slug is in
+ * `knownSlugs` for that family become links (so typos stay plain text).
+ */
+export function segmentReferenceLede(
+  text: string,
+  known: {
+    readonly geoms: ReadonlySet<string>;
+    readonly stats: ReadonlySet<string>;
+  },
+): readonly LedeSegment[] {
+  const out: LedeSegment[] = [];
+  let last = 0;
+  TOKEN_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = TOKEN_RE.exec(text)) !== null) {
+    const [full, family, body] = match;
+    if (body === undefined || family === undefined) continue;
+    const start = match.index;
+    if (start > last) {
+      out.push({ kind: "text", value: text.slice(last, start) });
+    }
+    const slug = pascalBodyToSlug(body);
+    const isGeom = family === "Geom";
+    const allowed = isGeom ? known.geoms : known.stats;
+    if (allowed.has(slug)) {
+      out.push({
+        kind: "link",
+        label: full,
+        href: isGeom ? `/reference/geoms/${slug}` : `/reference/stats/${slug}`,
+      });
+    } else {
+      // Unknown token — keep as plain text (merge with previous text segment).
+      const prev = out.at(-1);
+      if (prev?.kind === "text") {
+        out[out.length - 1] = { kind: "text", value: prev.value + full };
+      } else {
+        out.push({ kind: "text", value: full });
+      }
+    }
+    last = start + full.length;
+  }
+  if (last < text.length) {
+    const tail = text.slice(last);
+    const prev = out.at(-1);
+    if (prev?.kind === "text") {
+      out[out.length - 1] = { kind: "text", value: prev.value + tail };
+    } else {
+      out.push({ kind: "text", value: tail });
+    }
+  }
+  if (out.length === 0) {
+    out.push({ kind: "text", value: text });
+  }
+  return out;
+}

--- a/apps/docs/src/lib/reference-snippets.ts
+++ b/apps/docs/src/lib/reference-snippets.ts
@@ -1,0 +1,73 @@
+/**
+ * Minimal reference-page code snippets for geom / stat / position detail pages.
+ *
+ * Plot-level aes must match what the layer's default stat actually consumes —
+ * bar/count/bin geoms publish y, so mapping aes.y in the sample contradicts the
+ * lede ("Do not map aes.y").
+ */
+
+/** Default stats that compute y (or stack height) from x alone. */
+const X_ONLY_STATS = new Set(["count", "bin", "density", "bindot", "ecdf"]);
+
+/**
+ * Plot-level aes object literal for a geom reference snippet.
+ * Prefer the channels the default stat needs; never invent a y when the
+ * description tells authors not to map one.
+ */
+export function plotAesLiteral(geom: string, defaultStat: string): string {
+  if (geom === "qq" || geom === "qq_line") {
+    return 'aes={{ sample: "sample" }}';
+  }
+  if (geom === "hline") {
+    // Annotation form uses params.yintercept; plot aes is optional.
+    return "";
+  }
+  if (geom === "vline") {
+    return "";
+  }
+  if (geom === "blank") {
+    return 'aes={{ x: "x", y: "y" }}';
+  }
+  if (X_ONLY_STATS.has(defaultStat)) {
+    return 'aes={{ x: "x" }}';
+  }
+  return 'aes={{ x: "x", y: "y" }}';
+}
+
+function plotOpenTag(aesLiteral: string): string {
+  if (aesLiteral === "") {
+    return "<GGPlot data={rows}>";
+  }
+  return `<GGPlot data={rows} ${aesLiteral}>`;
+}
+
+/** Svelte import + plot shell for a geom detail page. */
+export function buildGeomSvelteSnippet(
+  component: string,
+  geom: string,
+  defaultStat: string,
+  params: readonly { name: string; required: boolean }[],
+): string {
+  const required = params.filter((p) => p.required).map((p) => p.name);
+  const aes = plotAesLiteral(geom, defaultStat);
+  const open = plotOpenTag(aes);
+  if (required.length === 0) {
+    return `import { GGPlot, ${component} } from "@ggsvelte/svelte";\n\n${open}\n  <${component} />\n</GGPlot>`;
+  }
+  const props = "\n" + required.map((p) => `  ${p}={/* … */}`).join("\n") + "\n";
+  return `import { GGPlot, ${component} } from "@ggsvelte/svelte";\n\n${open}\n  <${component}${props}/>\n</GGPlot>`;
+}
+
+/** JSON layer object for a geom detail page (required params only). */
+export function buildGeomJsonSnippet(
+  geom: string,
+  defaultStat: string,
+  params: readonly { name: string; required: boolean }[],
+): string {
+  const required = params.filter((p) => p.required).map((p) => p.name);
+  const paramsObj =
+    required.length === 0
+      ? ""
+      : `,\n  "params": { ${required.map((p) => `"${p}": /* … */`).join(", ")} }`;
+  return `{\n  "geom": "${geom}"${defaultStat === "identity" ? "" : `,\n  "stat": "${defaultStat}"`}${paramsObj}\n}`;
+}

--- a/apps/docs/src/routes/reference/geoms/[name]/+page.svelte
+++ b/apps/docs/src/routes/reference/geoms/[name]/+page.svelte
@@ -1,50 +1,33 @@
 <script lang="ts">
   import { base } from "$app/paths";
 
+  import ReferenceLede from "$lib/components/ReferenceLede.svelte";
+  import {
+    buildGeomJsonSnippet,
+    buildGeomSvelteSnippet,
+  } from "$lib/reference-snippets";
+
   import type { PageProps } from "./$types";
 
   const { data }: PageProps = $props();
   const entry = $derived(data.entry);
 
   const svelteSnippet = $derived(
-    buildSvelteSnippet(entry.component, entry.params),
+    buildGeomSvelteSnippet(
+      entry.component,
+      entry.name,
+      entry.defaultStat,
+      entry.params,
+    ),
   );
   const jsonSnippet = $derived(
-    buildJsonSnippet(entry.name, entry.defaultStat, entry.params),
+    buildGeomJsonSnippet(entry.name, entry.defaultStat, entry.params),
   );
-
-  function buildSvelteSnippet(
-    component: string,
-    params: readonly { name: string; required: boolean }[],
-  ): string {
-    const required = params.filter((p) => p.required).map((p) => p.name);
-    if (required.length === 0) {
-      return `import { GGPlot, ${component} } from "@ggsvelte/svelte";\n\n<GGPlot data={rows} aes={{ x: "x", y: "y" }}>\n  <${component} />\n</GGPlot>`;
-    }
-    const props =
-      "\n" + required.map((p) => `  ${p}={/* … */}`).join("\n") + "\n";
-    return `import { GGPlot, ${component} } from "@ggsvelte/svelte";\n\n<GGPlot data={rows} aes={{ x: "x", y: "y" }}>\n  <${component}${props}/>\n</GGPlot>`;
-  }
-
-  function buildJsonSnippet(
-    geom: string,
-    defaultStat: string,
-    params: readonly { name: string; required: boolean }[],
-  ): string {
-    const required = params.filter((p) => p.required).map((p) => p.name);
-    const paramsObj =
-      required.length === 0
-        ? ""
-        : `,\n  "params": { ${required
-            .map((p) => `"${p}": /* … */`)
-            .join(", ")} }`;
-    return `{\n  "geom": "${geom}"${defaultStat === "identity" ? "" : `,\n  "stat": "${defaultStat}"`}${paramsObj}\n}`;
-  }
 </script>
 
 <article class="geom-detail prose" aria-labelledby="geom-heading">
   <h1 id="geom-heading"><code>{entry.component}</code></h1>
-  <p class="lede">{entry.summary}</p>
+  <ReferenceLede text={entry.summary} />
 
   <h2 id="defaults">Defaults</h2>
   <dl class="defaults">
@@ -158,12 +141,6 @@
 
   h1 {
     margin: 0 0 0.5rem;
-  }
-
-  .lede {
-    max-width: 44rem;
-    margin: 0 0 1.5rem;
-    font-size: 1.05rem;
   }
 
   .defaults {

--- a/apps/docs/src/routes/reference/positions/[name]/+page.svelte
+++ b/apps/docs/src/routes/reference/positions/[name]/+page.svelte
@@ -1,6 +1,13 @@
 <script lang="ts">
   import { base } from "$app/paths";
-  import { componentNameForGeom } from "@ggsvelte/spec";
+  import {
+    componentNameForGeom,
+    GEOM_DEFAULTS,
+    type GeomName,
+  } from "@ggsvelte/spec";
+
+  import ReferenceLede from "$lib/components/ReferenceLede.svelte";
+  import { plotAesLiteral } from "$lib/reference-snippets";
 
   import type { PageProps } from "./$types";
 
@@ -13,20 +20,28 @@
   const primaryComponent = $derived(
     primaryGeom === undefined ? "GeomBar" : componentNameForGeom(primaryGeom),
   );
+  const geomName = $derived(primaryGeom ?? "bar");
+  const defaultStat = $derived(
+    GEOM_DEFAULTS[geomName as GeomName]?.stat ?? "identity",
+  );
+  const plotAes = $derived(plotAesLiteral(geomName, defaultStat));
+  const plotOpen = $derived(
+    plotAes === "" ? "<GGPlot data={rows}>" : `<GGPlot data={rows} ${plotAes}>`,
+  );
 
   // Minimal: position name only. Optional positionParams live in the table below.
   const svelteSnippet = $derived(
-    `import { GGPlot, ${primaryComponent} } from "@ggsvelte/svelte";\n\n<GGPlot data={rows} aes={{ x: "x", y: "y" }}>\n  <${primaryComponent} position="${entry.name}" />\n</GGPlot>`,
+    `import { GGPlot, ${primaryComponent} } from "@ggsvelte/svelte";\n\n${plotOpen}\n  <${primaryComponent} position="${entry.name}" />\n</GGPlot>`,
   );
 
   const jsonSnippet = $derived(
-    `{\n  "geom": "${primaryGeom ?? "bar"}",\n  "position": "${entry.name}"\n}`,
+    `{\n  "geom": "${geomName}",\n  "position": "${entry.name}"\n}`,
   );
 </script>
 
 <article class="position-detail prose" aria-labelledby="position-heading">
   <h1 id="position-heading"><code>position: "{entry.name}"</code></h1>
-  <p class="lede">{entry.summary}</p>
+  <ReferenceLede text={entry.summary} />
 
   <h2 id="usage">Usage</h2>
   <pre class="snippet"><code>{svelteSnippet}</code></pre>
@@ -116,12 +131,6 @@
 
   h1 {
     margin: 0 0 0.5rem;
-  }
-
-  .lede {
-    max-width: 44rem;
-    margin: 0 0 1.5rem;
-    font-size: 1.05rem;
   }
 
   .snippet {

--- a/apps/docs/src/routes/reference/stats/[name]/+page.svelte
+++ b/apps/docs/src/routes/reference/stats/[name]/+page.svelte
@@ -2,6 +2,9 @@
   import { base } from "$app/paths";
   import { componentNameForGeom } from "@ggsvelte/spec";
 
+  import ReferenceLede from "$lib/components/ReferenceLede.svelte";
+  import { plotAesLiteral } from "$lib/reference-snippets";
+
   import type { PageProps } from "./$types";
 
   const { data }: PageProps = $props();
@@ -13,18 +16,23 @@
   const primaryComponent = $derived(
     primaryGeom === undefined ? "GeomBar" : componentNameForGeom(primaryGeom),
   );
+  const geomName = $derived(primaryGeom ?? "bar");
+  const plotAes = $derived(plotAesLiteral(geomName, entry.name));
+  const plotOpen = $derived(
+    plotAes === "" ? "<GGPlot data={rows}>" : `<GGPlot data={rows} ${plotAes}>`,
+  );
 
   const svelteSnippet = $derived(
-    `import { GGPlot, ${primaryComponent} } from "@ggsvelte/svelte";\n\n<GGPlot data={rows} aes={{ x: "x", y: "y" }}>\n  <${primaryComponent} stat="${entry.name}" />\n</GGPlot>`,
+    `import { GGPlot, ${primaryComponent} } from "@ggsvelte/svelte";\n\n${plotOpen}\n  <${primaryComponent} stat="${entry.name}" />\n</GGPlot>`,
   );
   const jsonSnippet = $derived(
-    `{\n  "geom": "${primaryGeom ?? "bar"}",\n  "stat": "${entry.name}"\n}`,
+    `{\n  "geom": "${geomName}",\n  "stat": "${entry.name}"\n}`,
   );
 </script>
 
 <article class="stat-detail prose" aria-labelledby="stat-heading">
   <h1 id="stat-heading"><code>stat: "{entry.name}"</code></h1>
-  <p class="lede">{entry.summary}</p>
+  <ReferenceLede text={entry.summary} />
 
   <h2 id="usage">Usage</h2>
   <pre class="snippet"><code>{svelteSnippet}</code></pre>
@@ -107,12 +115,6 @@
 
   h1 {
     margin: 0 0 0.5rem;
-  }
-
-  .lede {
-    max-width: 44rem;
-    margin: 0 0 1.5rem;
-    font-size: 1.05rem;
   }
 
   .snippet {

--- a/apps/docs/tests/reference-lede.test.ts
+++ b/apps/docs/tests/reference-lede.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { pascalBodyToSlug, segmentReferenceLede } from "../src/lib/reference-lede";
+
+const known = {
+  geoms: new Set(["col", "bar", "density_2d_filled", "qq_line", "bin_2d"]),
+  stats: new Set(["count", "bin"]),
+};
+
+describe("pascalBodyToSlug", () => {
+  it("maps PascalCase bodies to catalog slugs", () => {
+    expect(pascalBodyToSlug("Col")).toBe("col");
+    expect(pascalBodyToSlug("Density2dFilled")).toBe("density_2d_filled");
+    expect(pascalBodyToSlug("QqLine")).toBe("qq_line");
+    expect(pascalBodyToSlug("Bin2d")).toBe("bin_2d");
+  });
+});
+
+describe("segmentReferenceLede", () => {
+  it("links GeomCol and GeomBar in the bar/col cross-references", () => {
+    const bar =
+      "Do not map aes.y — the stat computes it. Prefer GeomCol when bar heights are already in the data.";
+    const segs = segmentReferenceLede(bar, known);
+    expect(segs).toEqual([
+      {
+        kind: "text",
+        value: "Do not map aes.y — the stat computes it. Prefer ",
+      },
+      { kind: "link", label: "GeomCol", href: "/reference/geoms/col" },
+      {
+        kind: "text",
+        value: " when bar heights are already in the data.",
+      },
+    ]);
+  });
+
+  it("links GeomBar from the col lede", () => {
+    const col =
+      "Use when the data already contains the bar heights — prefer over GeomBar, which counts or bins.";
+    const segs = segmentReferenceLede(col, known);
+    const link = segs.find((s) => s.kind === "link");
+    expect(link).toEqual({
+      kind: "link",
+      label: "GeomBar",
+      href: "/reference/geoms/bar",
+    });
+  });
+
+  it("leaves unknown Geom tokens as text", () => {
+    const segs = segmentReferenceLede("See GeomNoSuch for details.", known);
+    expect(segs).toEqual([{ kind: "text", value: "See GeomNoSuch for details." }]);
+  });
+
+  it("returns a single text segment when there are no tokens", () => {
+    expect(segmentReferenceLede("Point marks at (x, y).", known)).toEqual([
+      { kind: "text", value: "Point marks at (x, y)." },
+    ]);
+  });
+});

--- a/apps/docs/tests/reference-snippets.test.ts
+++ b/apps/docs/tests/reference-snippets.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { buildGeomSvelteSnippet, plotAesLiteral } from "../src/lib/reference-snippets";
+
+describe("plotAesLiteral", () => {
+  it("omits y when the default stat computes it (bar / count)", () => {
+    expect(plotAesLiteral("bar", "count")).toBe('aes={{ x: "x" }}');
+    expect(plotAesLiteral("histogram", "bin")).toBe('aes={{ x: "x" }}');
+    expect(plotAesLiteral("freqpoly", "bin")).toBe('aes={{ x: "x" }}');
+    expect(plotAesLiteral("density", "density")).toBe('aes={{ x: "x" }}');
+    expect(plotAesLiteral("dotplot", "bindot")).toBe('aes={{ x: "x" }}');
+  });
+
+  it("keeps x and y for identity geoms that need both", () => {
+    expect(plotAesLiteral("col", "identity")).toBe('aes={{ x: "x", y: "y" }}');
+    expect(plotAesLiteral("point", "identity")).toBe('aes={{ x: "x", y: "y" }}');
+  });
+
+  it("uses sample for qq geoms", () => {
+    expect(plotAesLiteral("qq", "qq")).toBe('aes={{ sample: "sample" }}');
+  });
+});
+
+describe("buildGeomSvelteSnippet", () => {
+  it("bar sample maps only x — matches Do not map aes.y lede", () => {
+    const snip = buildGeomSvelteSnippet("GeomBar", "bar", "count", []);
+    expect(snip).toContain('aes={{ x: "x" }}');
+    expect(snip).not.toMatch(/aes=\{\{[^}]*\by:/);
+    expect(snip).toContain("<GeomBar />");
+  });
+
+  it("col sample still maps x and y", () => {
+    const snip = buildGeomSvelteSnippet("GeomCol", "col", "identity", []);
+    expect(snip).toContain('aes={{ x: "x", y: "y" }}');
+  });
+});


### PR DESCRIPTION
## Summary

- **GeomBar contradiction:** Svelte samples for bar/histogram/freqpoly/density/dotplot map only `aes.x` when the default stat publishes y, matching the lede ("Do not map aes.y").
- **Cross-links:** `ReferenceLede` turns known `Geom*` / `Stat*` tokens in summaries into links to their reference pages (e.g. Prefer [GeomCol](…/geoms/col)).
- Same snippet aes helper applied on stats/positions detail pages when the primary geom defaults to a y-computing stat.

## Test plan

- [x] `apps/docs` vitest: `reference-snippets` + `reference-lede`
- [x] oxlint --type-aware on touched files
- [ ] Check GeomBar page: sample has `aes={{ x: "x" }}` only; lede links GeomCol
- [ ] Check GeomCol page: lede links GeomBar
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1117" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->