### PR TITLE
docs(reference): square gallery thumbnails on the Geoms index

### DIFF
--- a/apps/docs/src/lib/geom-thumbnails.ts
+++ b/apps/docs/src/lib/geom-thumbnails.ts
@@ -1,0 +1,90 @@
+/**
+ * Curated gallery preview per geom for the /reference/geoms index.
+ *
+ * Each entry points at a gallery example id whose static PNG lives under
+ * /previews/ (see GALLERY_PREVIEWS). Prefer a chart that makes the mark
+ * itself obvious over multi-layer demos.
+ */
+import type { GeomName } from "@ggsvelte/spec";
+import { KNOWN_GEOMS } from "@ggsvelte/spec";
+
+import { GALLERY_PREVIEWS } from "./generated/gallery-previews.js";
+
+/**
+ * One representative gallery example id per geom.
+ * Values must exist in GALLERY_PREVIEWS (enforced by tests).
+ */
+export const GEOM_THUMBNAIL_EXAMPLE = {
+  point: "point/scatter-color",
+  line: "line/multi-series",
+  path: "path/trajectory",
+  col: "col/basic",
+  bar: "bar/dodged",
+  histogram: "histogram/basic",
+  freqpoly: "freqpoly/basic",
+  area: "area/basic",
+  rule: "rule/annotation",
+  hline: "hline/threshold",
+  vline: "vline/cutoff",
+  text: "text/labels",
+  label: "label/basic",
+  smooth: "smooth/loess-scatter",
+  quantile: "point/quantile-lines",
+  boxplot: "boxplot/by-category",
+  density: "density/overlay",
+  errorbar: "errorbar/mean-se",
+  // Interval family shares the errorbar specimen until dedicated examples land.
+  linerange: "errorbar/mean-se",
+  pointrange: "errorbar/mean-se",
+  crossbar: "errorbar/mean-se",
+  rect: "rect/regions",
+  tile: "tile/heatmap",
+  raster: "raster/grid",
+  ribbon: "ribbon/bounds",
+  segment: "segment/annotations",
+  count: "point/count",
+  violin: "boxplot/violin",
+  function: "line/function",
+  polygon: "polygon/regions",
+  hex: "hex/basic",
+  bin_2d: "bin2d/basic",
+  abline: "point/abline-identity",
+  curve: "curve/connectors",
+  contour: "contour/basic",
+  density_2d: "density/kde-2d",
+  density_2d_filled: "density/kde-2d-filled",
+  dotplot: "dotplot/histodot",
+  map: "map/choropleth",
+  sf: "sf/basic",
+  sf_text: "sf/labels",
+  sf_label: "sf/boxed-labels",
+  blank: "blank/axes-only",
+  jitter: "jitter/basic",
+  spoke: "spoke/vector-field",
+  // Van Langren longitude rug (rules along x) is the closest mark shape.
+  rug: "rule/data-driven",
+  step: "step/ecdf",
+  qq: "qq/normal",
+  qq_line: "qq/normal",
+} as const satisfies Record<GeomName, string>;
+
+const previewPathById = new Map(
+  GALLERY_PREVIEWS.map((preview) => [preview.id, preview.path] as const),
+);
+
+/** Static path under the site base for the geom's index thumbnail, or undefined if missing. */
+export function thumbnailPathForGeom(geom: GeomName): string | undefined {
+  const exampleId = GEOM_THUMBNAIL_EXAMPLE[geom];
+  return previewPathById.get(exampleId);
+}
+
+/** Every KNOWN_GEOMS entry must have a resolvable gallery preview. */
+export function missingGeomThumbnails(): readonly string[] {
+  const missing: string[] = [];
+  for (const geom of KNOWN_GEOMS) {
+    if (thumbnailPathForGeom(geom) === undefined) {
+      missing.push(`${geom} → ${GEOM_THUMBNAIL_EXAMPLE[geom]}`);
+    }
+  }
+  return missing;
+}

--- a/apps/docs/src/routes/reference/geoms/+page.svelte
+++ b/apps/docs/src/routes/reference/geoms/+page.svelte
@@ -7,6 +7,8 @@
     type GeomReferenceEntry,
   } from "@ggsvelte/spec";
 
+  import { thumbnailPathForGeom } from "$lib/geom-thumbnails";
+
   let query = $state("");
   const all = geomReferenceList();
   const normalizedQuery = $derived(query.trim().toLocaleLowerCase());
@@ -31,6 +33,11 @@
       .join(" ")
       .toLocaleLowerCase();
     return haystack.includes(q);
+  }
+
+  function thumbSrc(entry: GeomReferenceEntry): string | undefined {
+    const path = thumbnailPathForGeom(entry.name);
+    return path === undefined ? undefined : `${base}${path}`;
   }
 </script>
 
@@ -68,17 +75,32 @@
   {:else}
     <ul class="results">
       {#each results as entry (entry.name)}
+        {@const thumb = thumbSrc(entry)}
         <li>
           <a href={`${base}/reference/geoms/${entry.slug}`}>
-            <strong><code>{entry.component}</code></strong>
-            <span class="meta">
-              <code>{entry.name}</code>
-              · {entry.defaultStat} + {entry.defaultPosition}
-              {#if entry.aliasOf !== undefined}
-                · alias of <code>{entry.aliasOf}</code>
-              {/if}
+            {#if thumb !== undefined}
+              <span class="thumb" aria-hidden="true">
+                <img
+                  src={thumb}
+                  alt=""
+                  width="96"
+                  height="96"
+                  loading="lazy"
+                  decoding="async"
+                />
+              </span>
+            {/if}
+            <span class="body">
+              <strong><code>{entry.component}</code></strong>
+              <span class="meta">
+                <code>{entry.name}</code>
+                · {entry.defaultStat} + {entry.defaultPosition}
+                {#if entry.aliasOf !== undefined}
+                  · alias of <code>{entry.aliasOf}</code>
+                {/if}
+              </span>
+              <span class="summary">{entry.summary}</span>
             </span>
-            <span class="summary">{entry.summary}</span>
           </a>
         </li>
       {/each}
@@ -172,7 +194,9 @@
 
   .results a {
     display: grid;
-    gap: 0.25rem;
+    grid-template-columns: 5.5rem minmax(0, 1fr);
+    gap: 0.9rem 1rem;
+    align-items: start;
     padding: 0.9rem 0;
     color: var(--ink);
     text-decoration: none;
@@ -180,6 +204,31 @@
 
   .results a:hover strong {
     text-decoration: underline;
+  }
+
+  .thumb {
+    display: block;
+    width: 5.5rem;
+    aspect-ratio: 1;
+    overflow: hidden;
+    border: 1px solid var(--line);
+    border-radius: 0.45rem;
+    background: color-mix(in srgb, var(--ink) 3%, transparent);
+  }
+
+  .thumb img {
+    display: block;
+    width: 100%;
+    height: 100%;
+    /* Crop title/legend chrome; bias into the panel so the mark is central. */
+    object-fit: cover;
+    object-position: center 58%;
+  }
+
+  .body {
+    display: grid;
+    gap: 0.25rem;
+    min-width: 0;
   }
 
   .meta {
@@ -191,6 +240,17 @@
     max-width: 44rem;
     color: var(--muted);
     font-size: 0.92rem;
+  }
+
+  @media (max-width: 36rem) {
+    .results a {
+      grid-template-columns: 4.25rem minmax(0, 1fr);
+      gap: 0.75rem;
+    }
+
+    .thumb {
+      width: 4.25rem;
+    }
   }
 
   .shared-props {

--- a/apps/docs/tests/geom-thumbnails.test.ts
+++ b/apps/docs/tests/geom-thumbnails.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  GEOM_THUMBNAIL_EXAMPLE,
+  missingGeomThumbnails,
+  thumbnailPathForGeom,
+} from "../src/lib/geom-thumbnails";
+import { GALLERY_PREVIEWS } from "../src/lib/generated/gallery-previews";
+
+describe("GEOM_THUMBNAIL_EXAMPLE", () => {
+  it("covers every known geom with a real gallery preview", () => {
+    expect(missingGeomThumbnails()).toEqual([]);
+  });
+
+  it("resolves point and bar to known preview paths", () => {
+    expect(thumbnailPathForGeom("point")).toBe("/previews/point-scatter-color-light.png");
+    expect(thumbnailPathForGeom("bar")).toBe("/previews/bar-dodged-light.png");
+  });
+
+  it("only references ids present in GALLERY_PREVIEWS", () => {
+    const ids = new Set(GALLERY_PREVIEWS.map((p) => p.id));
+    for (const [geom, exampleId] of Object.entries(GEOM_THUMBNAIL_EXAMPLE)) {
+      expect(ids.has(exampleId), `${geom} → ${exampleId}`).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Every row on `/reference/geoms` shows a **square** thumbnail from a curated gallery specimen so readers can recognize marks by sight.
- Mapping is total over `KNOWN_GEOMS` (linerange/pointrange/crossbar share the errorbar specimen; rug uses the Van Langren rule rug; qq_line shares qq/normal).
- CSS `object-fit: cover` + `object-position: center 58%` crops title/legend chrome toward the plot panel.

## Test plan

- [x] `apps/docs` vitest: `geom-thumbnails` (coverage + path resolution)
- [x] oxlint --type-aware on touched files
- [ ] Open `/reference/geoms` and confirm thumbs load for point, bar, col, histogram, sf, blank
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1118" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->