### PR TITLE
docs(reference): strip index chrome slop

### DIFF
--- a/apps/docs/src/routes/reference/geoms/+page.svelte
+++ b/apps/docs/src/routes/reference/geoms/+page.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { base } from "$app/paths";
   import {
-    GEOM_REFERENCE,
     SHARED_LAYER_PROPS,
     geomReferenceList,
     type GeomReferenceEntry,
@@ -42,23 +41,14 @@
 </script>
 
 <main class="geom-reference" aria-labelledby="reference-heading">
-  <p class="eyebrow">
-    Schema-derived · {Object.keys(GEOM_REFERENCE).length} geoms
-  </p>
   <h1 id="reference-heading">Geoms</h1>
-  <p class="intro">
-    Every <code>&lt;Geom*&gt;</code> component and its JSON layer form,
-    generated from the PortableSpec TypeBox schema so props stay in step with
-    <a href={`${base}/schema/v0.json`}>schema/v0.json</a>. Layer params appear
-    as direct Svelte props; shared layer props are listed once below.
-  </p>
 
-  <label for="geom-search">Search geoms, components, stats, or params</label>
+  <label for="geom-search">Search</label>
   <input
     id="geom-search"
     type="search"
     bind:value={query}
-    placeholder="Try point, GeomLine, summary_bin, or linewidth"
+    placeholder="bar, point, line…"
     autocomplete="off"
   />
 
@@ -69,9 +59,7 @@
 
   <h2 id="all-geoms">All geoms</h2>
   {#if results.length === 0}
-    <p class="empty">
-      No match. Try a geom name, component, stat, or param key.
-    </p>
+    <p class="empty">No match.</p>
   {:else}
     <ul class="results">
       {#each results as entry (entry.name)}
@@ -137,19 +125,6 @@
 
   h2 {
     margin: 2.5rem 0 0.75rem;
-  }
-
-  .intro {
-    max-width: 44rem;
-  }
-
-  .eyebrow {
-    margin: 0;
-    color: var(--muted);
-    font-size: 0.76rem;
-    font-weight: 700;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
   }
 
   label {

--- a/apps/docs/src/routes/reference/positions/+page.svelte
+++ b/apps/docs/src/routes/reference/positions/+page.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { base } from "$app/paths";
   import {
-    POSITION_REFERENCE,
     positionReferenceList,
     type PositionReferenceEntry,
   } from "@ggsvelte/spec";
@@ -30,25 +29,14 @@
 </script>
 
 <main class="position-reference" aria-labelledby="reference-heading">
-  <p class="eyebrow">
-    Schema-derived · {Object.keys(POSITION_REFERENCE).length} positions
-  </p>
   <h1 id="reference-heading">Positions</h1>
-  <p class="intro">
-    Position adjustments control how marks share coordinate space after the stat
-    runs. Set <code>position</code> on a <code>&lt;Geom*&gt;</code> shell or
-    JSON layer — there is no separate Position component. Jitter and nudge take
-    <code>positionParams</code>
-    from the PortableSpec
-    <code>PositionParams</code> schema.
-  </p>
 
-  <label for="position-search">Search positions, params, or geoms</label>
+  <label for="position-search">Search</label>
   <input
     id="position-search"
     type="search"
     bind:value={query}
-    placeholder="Try stack, dodge, jitter, or seed"
+    placeholder="stack, dodge, jitter…"
     autocomplete="off"
   />
 
@@ -59,7 +47,7 @@
 
   <h2 id="all-positions">All positions</h2>
   {#if results.length === 0}
-    <p class="empty">No match. Try a position name, param, or geom.</p>
+    <p class="empty">No match.</p>
   {:else}
     <ul class="results">
       {#each results as entry (entry.name)}
@@ -113,19 +101,6 @@
 
   h2 {
     margin: 2.5rem 0 0.75rem;
-  }
-
-  .intro {
-    max-width: 44rem;
-  }
-
-  .eyebrow {
-    margin: 0;
-    color: var(--muted);
-    font-size: 0.76rem;
-    font-weight: 700;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
   }
 
   label {

--- a/apps/docs/src/routes/reference/stats/+page.svelte
+++ b/apps/docs/src/routes/reference/stats/+page.svelte
@@ -1,10 +1,6 @@
 <script lang="ts">
   import { base } from "$app/paths";
-  import {
-    STAT_REFERENCE,
-    statReferenceList,
-    type StatReferenceEntry,
-  } from "@ggsvelte/spec";
+  import { statReferenceList, type StatReferenceEntry } from "@ggsvelte/spec";
 
   let query = $state("");
   const all = statReferenceList();
@@ -30,24 +26,14 @@
 </script>
 
 <main class="stat-reference" aria-labelledby="reference-heading">
-  <p class="eyebrow">
-    Schema-derived · {Object.keys(STAT_REFERENCE).length} stats
-  </p>
   <h1 id="reference-heading">Stats</h1>
-  <p class="intro">
-    Statistical transforms applied before drawing. Set
-    <code>stat</code> on a <code>&lt;Geom*&gt;</code> shell or JSON layer —
-    there is no separate Stat component. Generated from
-    <code>KNOWN_STATS</code>, <code>STAT_COLUMNS</code>, and which geoms allow
-    each value in the PortableSpec schema.
-  </p>
 
-  <label for="stat-search">Search stats, columns, or geoms</label>
+  <label for="stat-search">Search</label>
   <input
     id="stat-search"
     type="search"
     bind:value={query}
-    placeholder="Try count, density, bin, or smooth"
+    placeholder="count, bin, density…"
     autocomplete="off"
   />
 
@@ -58,7 +44,7 @@
 
   <h2 id="all-stats">All stats</h2>
   {#if results.length === 0}
-    <p class="empty">No match. Try a stat name, after_stat column, or geom.</p>
+    <p class="empty">No match.</p>
   {:else}
     <ul class="results">
       {#each results as entry (entry.name)}
@@ -112,19 +98,6 @@
 
   h2 {
     margin: 2.5rem 0 0.75rem;
-  }
-
-  .intro {
-    max-width: 44rem;
-  }
-
-  .eyebrow {
-    margin: 0;
-    color: var(--muted);
-    font-size: 0.76rem;
-    font-weight: 700;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
   }
 
   label {


### PR DESCRIPTION
## Summary

On Geoms / Stats / Positions index pages:

- Remove **Schema-derived · N …** eyebrows
- Remove PortableSpec / TypeBox intro paragraphs
- Search label is just **Search**; short placeholders (`bar, point, line…`); empty state **No match.**

## Test plan

- [ ] `/reference/geoms` is title + search + list (no schema lede)
- [ ] Same for stats and positions
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1120" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->