### PR TITLE
docs: drop decorative section labels on the docs index

### DIFF
--- a/apps/docs/src/lib/catalog/guide.ts
+++ b/apps/docs/src/lib/catalog/guide.ts
@@ -17,6 +17,45 @@ export function guideSectionDomId(section: string): string {
     .replaceAll(/^-+|-+$/g, "")}`;
 }
 
+/**
+ * Catalog sections still order routes, but most labels are decorative chrome.
+ * Only "Reference" keeps a visible heading on the docs index and sidebar.
+ */
+export const GUIDE_VISIBLE_SECTION_HEADINGS = new Set<string>(["Reference"]);
+
+export type GuideNavEntry = { path: string; label: string };
+
+export type GuideNavBlock =
+  | { kind: "flat"; key: string; entries: readonly GuideNavEntry[] }
+  | { kind: "section"; section: string; entries: readonly GuideNavEntry[] };
+
+/** Collapse decorative section labels into flat lists; keep Reference headed. */
+export function guideNavBlocks(
+  groups: readonly { section: string; entries: readonly GuideNavEntry[] }[],
+): GuideNavBlock[] {
+  const blocks: GuideNavBlock[] = [];
+  let flat: GuideNavEntry[] = [];
+  let flatIndex = 0;
+
+  const flushFlat = (): void => {
+    if (flat.length === 0) return;
+    blocks.push({ kind: "flat", key: `flat-${String(flatIndex)}`, entries: flat });
+    flatIndex += 1;
+    flat = [];
+  };
+
+  for (const group of groups) {
+    if (GUIDE_VISIBLE_SECTION_HEADINGS.has(group.section)) {
+      flushFlat();
+      blocks.push({ kind: "section", section: group.section, entries: group.entries });
+      continue;
+    }
+    flat.push(...group.entries);
+  }
+  flushFlat();
+  return blocks;
+}
+
 interface GuideCatalogEntryBase {
   slug: string;
   title: string;

--- a/apps/docs/src/lib/components/DocsSidebar.svelte
+++ b/apps/docs/src/lib/components/DocsSidebar.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { base } from "$app/paths";
 
-  import { guideSectionDomId } from "$lib/catalog/guide";
+  import { guideNavBlocks, guideSectionDomId } from "$lib/catalog/guide";
   import type { GuideNavigationGroup } from "$lib/route-types";
 
   const {
@@ -15,14 +15,30 @@
     label?: string;
     onNavigate?: () => void;
   } = $props();
+
+  const blocks = $derived(guideNavBlocks(groups));
 </script>
 
 <nav class="docs-sidebar" aria-label={label}>
-  {#each groups as group (group.section)}
-    <section aria-labelledby={guideSectionDomId(group.section)}>
-      <h2 id={guideSectionDomId(group.section)}>{group.section}</h2>
+  {#each blocks as block (block.kind === "section" ? block.section : block.key)}
+    {#if block.kind === "section"}
+      <section aria-labelledby={guideSectionDomId(block.section)}>
+        <h2 id={guideSectionDomId(block.section)}>{block.section}</h2>
+        <ul>
+          {#each block.entries as entry (entry.path)}
+            <li>
+              <a
+                href={`${base}${entry.path}`}
+                aria-current={entry.path === path ? "page" : undefined}
+                onclick={onNavigate}>{entry.label}</a
+              >
+            </li>
+          {/each}
+        </ul>
+      </section>
+    {:else}
       <ul>
-        {#each group.entries as entry (entry.path)}
+        {#each block.entries as entry (entry.path)}
           <li>
             <a
               href={`${base}${entry.path}`}
@@ -32,6 +48,6 @@
           </li>
         {/each}
       </ul>
-    </section>
+    {/if}
   {/each}
 </nav>

--- a/apps/docs/src/routes/docs/+page.svelte
+++ b/apps/docs/src/routes/docs/+page.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
   import { base } from "$app/paths";
 
-  import { GUIDE_CATALOG } from "$lib/catalog/guide";
+  import {
+    GUIDE_CATALOG,
+    guideNavBlocks,
+    guideSectionDomId,
+  } from "$lib/catalog/guide";
   import { GUIDE_NAVIGATION } from "$lib/routes";
 
   const descriptionByPath = new Map<string, string>([
@@ -31,34 +35,45 @@
     ],
   ]);
 
-  // Distinct from sidebar `guide-*` ids so both can sit on this page.
-  function landingSectionId(section: string): string {
-    return `docs-landing-${section
-      .trim()
-      .toLowerCase()
-      .replaceAll(/[^a-z0-9]+/g, "-")
-      .replaceAll(/^-+|-+$/g, "")}`;
-  }
-
   // Overview is this page — do not list it again under the chapter map.
   const chapters = GUIDE_NAVIGATION.map((group) => ({
     section: group.section,
     entries: group.entries.filter((entry) => entry.path !== "/docs"),
   })).filter((group) => group.entries.length > 0);
+
+  // Decorative labels (Start, Core grammar, …) are dropped; only Reference stays.
+  const blocks = guideNavBlocks(chapters);
 </script>
 
 <article class="docs-landing" aria-labelledby="docs-heading">
   <h1 id="docs-heading">Documentation</h1>
 
   <nav class="docs-chapters" aria-label="Documentation guides">
-    {#each chapters as group (group.section)}
-      <section
-        class="chapter-group"
-        aria-labelledby={landingSectionId(group.section)}
-      >
-        <h2 id={landingSectionId(group.section)}>{group.section}</h2>
-        <ul>
-          {#each group.entries as entry (entry.path)}
+    {#each blocks as block (block.kind === "section" ? block.section : block.key)}
+      {#if block.kind === "section"}
+        <section
+          class="chapter-group"
+          aria-labelledby={guideSectionDomId(`docs-landing-${block.section}`)}
+        >
+          <h2 id={guideSectionDomId(`docs-landing-${block.section}`)}>
+            {block.section}
+          </h2>
+          <ul>
+            {#each block.entries as entry (entry.path)}
+              <li>
+                <a href={`${base}${entry.path}`}>
+                  <strong>{entry.label}</strong>
+                  {#if descriptionByPath.get(entry.path)}
+                    <span>{descriptionByPath.get(entry.path)}</span>
+                  {/if}
+                </a>
+              </li>
+            {/each}
+          </ul>
+        </section>
+      {:else}
+        <ul class="chapter-flat">
+          {#each block.entries as entry (entry.path)}
             <li>
               <a href={`${base}${entry.path}`}>
                 <strong>{entry.label}</strong>
@@ -69,7 +84,7 @@
             </li>
           {/each}
         </ul>
-      </section>
+      {/if}
     {/each}
   </nav>
 
@@ -133,7 +148,10 @@
     color: inherit;
   }
 
-  .chapter-group + .chapter-group {
+  .chapter-group + .chapter-group,
+  .chapter-flat + .chapter-group,
+  .chapter-group + .chapter-flat,
+  .chapter-flat + .chapter-flat {
     margin-top: 1.75rem;
   }
 

--- a/apps/docs/src/styles/shell.css
+++ b/apps/docs/src/styles/shell.css
@@ -241,7 +241,10 @@
   min-width: 0;
 }
 
-.docs-sidebar section + section {
+.docs-sidebar section + section,
+.docs-sidebar ul + section,
+.docs-sidebar section + ul,
+.docs-sidebar ul + ul {
   margin-top: 1.75rem;
 }
 

--- a/scripts/guide-nav-blocks.test.ts
+++ b/scripts/guide-nav-blocks.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+
+import { guideNavBlocks } from "../apps/docs/src/lib/catalog/guide.ts";
+
+describe("guideNavBlocks", () => {
+  test("flattens decorative sections and keeps only Reference headed", () => {
+    const blocks = guideNavBlocks([
+      {
+        section: "Start",
+        entries: [{ path: "/guide/getting-started", label: "Getting started" }],
+      },
+      {
+        section: "Core grammar",
+        entries: [
+          { path: "/guide/statistics-positions", label: "Statistics and positions" },
+          { path: "/guide/scales-guides", label: "Scales and guides" },
+        ],
+      },
+      {
+        section: "Interaction",
+        entries: [{ path: "/guide/interactions", label: "Interactions" }],
+      },
+      {
+        section: "Production",
+        entries: [{ path: "/guide/production", label: "Production" }],
+      },
+      {
+        section: "Reference",
+        entries: [
+          { path: "/reference", label: "Reference overview" },
+          { path: "/guide/errors", label: "Errors reference" },
+        ],
+      },
+      {
+        section: "Release",
+        entries: [{ path: "/guide/upgrading", label: "Upgrade guide" }],
+      },
+    ]);
+
+    expect(blocks).toEqual([
+      {
+        kind: "flat",
+        key: "flat-0",
+        entries: [
+          { path: "/guide/getting-started", label: "Getting started" },
+          { path: "/guide/statistics-positions", label: "Statistics and positions" },
+          { path: "/guide/scales-guides", label: "Scales and guides" },
+          { path: "/guide/interactions", label: "Interactions" },
+          { path: "/guide/production", label: "Production" },
+        ],
+      },
+      {
+        kind: "section",
+        section: "Reference",
+        entries: [
+          { path: "/reference", label: "Reference overview" },
+          { path: "/guide/errors", label: "Errors reference" },
+        ],
+      },
+      {
+        kind: "flat",
+        key: "flat-1",
+        entries: [{ path: "/guide/upgrading", label: "Upgrade guide" }],
+      },
+    ]);
+  });
+});

--- a/tests/visual/docs-progressive-search.spec.ts
+++ b/tests/visual/docs-progressive-search.spec.ts
@@ -102,16 +102,14 @@ test("Docs landing and sidebar expose the full path without duplicate Reference"
   await page.setViewportSize({ width: 1280, height: 900 });
   await page.goto("/docs?theme=light");
 
-  // Single chapter index — no separate "Start here" task list.
+  // Flat chapter index — only Reference keeps a section heading.
   const index = page.getByRole("navigation", { name: "Documentation guides" });
-  await expect(index.getByRole("heading", { level: 2 })).toHaveText([
-    "Start",
-    "Core grammar",
-    "Interaction",
-    "Production",
-    "Reference",
-    "Release",
-  ]);
+  await expect(index.getByRole("heading", { level: 2 })).toHaveText(["Reference"]);
+  await expect(index.getByRole("heading", { name: "Start" })).toHaveCount(0);
+  await expect(index.getByRole("heading", { name: "Core grammar" })).toHaveCount(0);
+  await expect(index.getByRole("heading", { name: "Interaction" })).toHaveCount(0);
+  await expect(index.getByRole("heading", { name: "Production" })).toHaveCount(0);
+  await expect(index.getByRole("heading", { name: "Release" })).toHaveCount(0);
   await expect(index.getByRole("link", { name: /Getting started/ })).toBeVisible();
   await expect(index.getByRole("link", { name: /Data and mappings/ })).toHaveCount(0);
   await expect(index.getByRole("link", { name: /Dates without preprocessing/ })).toBeVisible();
@@ -123,14 +121,9 @@ test("Docs landing and sidebar expose the full path without duplicate Reference"
   await expect(index.getByRole("link", { name: /Migrating pre-0.1/ })).toHaveCount(0);
 
   const sidebar = page.getByRole("navigation", { name: "Guide chapters" });
-  await expect(sidebar.getByRole("heading", { level: 2 })).toHaveText([
-    "Start",
-    "Core grammar",
-    "Interaction",
-    "Production",
-    "Reference",
-    "Release",
-  ]);
+  await expect(sidebar.getByRole("heading", { level: 2 })).toHaveText(["Reference"]);
+  await expect(sidebar.getByRole("heading", { name: "Start" })).toHaveCount(0);
+  await expect(sidebar.getByRole("heading", { name: "Core grammar" })).toHaveCount(0);
   // Overview + consolidated guide/reference chapters.
   await expect(sidebar.getByRole("link")).toHaveCount(18);
   await expect(sidebar.getByRole("link", { name: "Dates without preprocessing" })).toBeVisible();


### PR DESCRIPTION
## Summary

- Remove the uppercase Start / Core grammar / Interaction / Production / Release labels from the docs landing list and the guide sidebar.
- Keep **Reference** as the only section heading.
- Shared `guideNavBlocks()` collapses decorative groups so landing and sidebar stay consistent; catalog section fields remain for route ordering.

## Test plan

- [x] `bun test scripts/guide-nav-blocks.test.ts scripts/guide-section-id.test.ts`
- [ ] CI docs journeys (heading expectations updated)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1121" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->