### PR TITLE
fix(changeset): demote kyoto bloomRefDate drop from major to patch

### DIFF
--- a/.changeset/kyoto-month-day-migration.md
+++ b/.changeset/kyoto-month-day-migration.md
@@ -1,11 +1,11 @@
 ---
-"@ggsvelte/svelte": major
+"@ggsvelte/svelte": patch
 "@ggsvelte/core": patch
 ---
 
 <!-- markdownlint-disable MD041 -->
 
-feat(data)!: drop `bloomRefDate` from `kyotoSakura`
+fix(data): drop `bloomRefDate` from the Kyoto teaching dataset
 
 The column projected each observation's day-of-year onto the year 2001 so a
 date axis could draw it. Two things were wrong with that. It shipped a
@@ -17,8 +17,9 @@ anything like it — and it preserved day-of-year rather than month-day, so
 `temporalKind: "monthDay"` removes the need for it. The year now collapses
 inside the scale, where it is a private implementation detail.
 
-**Migration.** Map `y: "bloomRefDate"` to `y: "bloomDate"` and give the axis a
-month-day scale:
+This is a bundled teaching/demo dataset, not a product API contract. Anyone
+still mapping `y: "bloomRefDate"` should map `y: "bloomDate"` and give the
+axis a month-day scale:
 
 ```svelte
 <GGPlot data={kyotoSakura} aes={{ x: "year", y: "bloomDate" }}>
@@ -33,4 +34,4 @@ correct answer and does not have the leap-year fault.
 The getting-started lesson migrates with it, so the spec it teaches now
 contains no year outside the `year` column itself.
 
-Migration: <https://ggsvelte.sh/guide/scales-guides#date-and-time-axes>
+Guide: <https://ggsvelte.sh/guide/scales-guides#date-and-time-axes>


### PR DESCRIPTION
## Why

Open [Version Packages](https://github.com/ljodea/ggsvelte/pull/1074) would release **1.0.0** for every package.

That is wrong. We are still on **0.14.1**. 1.0.0 is a product statement we have not made.

## Root cause

`.changeset/kyoto-month-day-migration.md` (from #1111) marked:

```yaml
"@ggsvelte/svelte": major
```

for dropping `bloomRefDate` from the **bundled Kyoto teaching dataset**.

`.changeset/config.json` uses a **fixed** version group for `@ggsvelte/spec`, `@ggsvelte/core`, and `@ggsvelte/svelte`. One `major` on any package forces all three to the next major — from `0.14.1` that is `1.0.0`.

No intentional 1.0 readiness work happened. A demo column fix was mis-tagged.

## Fix

- `"@ggsvelte/svelte": major` → `patch`
- Drop the conventional `!` / major framing in the changeset prose
- State clearly this is teaching data, not a product 1.0 contract

## After merge

The changesets GitHub Action rewrites #1074. Highest remaining bump across the fixed group is **minor** (month-day scale surface and friends), so the release PR should retarget **0.15.0**, not 1.0.0.

Do **not** merge #1074 until the bot has rewritten it.

## Test plan

- [ ] Land this PR
- [ ] Confirm #1074 updates titles/changelogs to `@ggsvelte/*@0.15.0` (or equivalent 0.x), with no `### Major Changes` for the Kyoto data drop
- [ ] Only then consider merging the Version Packages PR

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1122" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->