### PR TITLE
fix(core): honor strokePaint and glow on segment, rule, and spoke

### DIFF
--- a/.changeset/1112-segment-family-stroke-paint.md
+++ b/.changeset/1112-segment-family-stroke-paint.md
@@ -1,0 +1,16 @@
+---
+"@ggsvelte/core": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+fix(core): honor strokePaint and glow on segment, rule, and spoke
+
+`SegmentParams`, `RuleParams`, and `SpokeParams` already declared `strokePaint`
+and `glow`, and `SegmentsBatch` already had slots for both, but packing never
+called `layerPaintFromParams`. Authored gradients and glow validated then
+disappeared. Shared segment packing now resolves paint the way line/curve/ribbon
+do, SVG and canvas draw it, and solid fallbacks land when stroke is otherwise
+null.
+
+Migration: none — params that previously did nothing now render

--- a/packages/core/src/dom/canvas-marks-segments.ts
+++ b/packages/core/src/dom/canvas-marks-segments.ts
@@ -1,7 +1,9 @@
 /// <reference lib="dom" />
 /**
  * Canvas segment drawers with run-length stroke batching.
+ * strokePaint/glow follow the paths batch contract (#1112).
  */
+import { canvasGradientStyle, subpathBounds, type ResolvedGradientPaint } from "../mark-paint.js";
 import type { SegmentsBatch } from "../scene.js";
 import type { ThemeTokens } from "../theme.js";
 import { themeVar } from "../theme.js";
@@ -24,14 +26,66 @@ function traceSegment(ctx: CanvasRenderingContext2D, batch: SegmentsBatch, j: nu
   ctx.lineTo(batch.segments[o + 2]!, batch.segments[o + 3]!);
 }
 
-function segmentStrokeAt(
+function segmentSolidAt(batch: SegmentsBatch, j: number, themeInk: string): string {
+  const stroke = batch.strokes?.[j] ?? batch.stroke;
+  return stroke === null || stroke === undefined ? themeInk : stroke;
+}
+
+function segmentBounds(
   batch: SegmentsBatch,
   j: number,
-  themeInk: string,
+): { x: number; y: number; width: number; height: number } {
+  if (batch.renderPositions !== undefined && batch.renderPathOffsets !== undefined) {
+    return subpathBounds(
+      batch.renderPositions,
+      batch.renderPathOffsets[j]!,
+      batch.renderPathOffsets[j + 1]!,
+    );
+  }
+  const o = j * 4;
+  const x1 = batch.segments[o]!;
+  const y1 = batch.segments[o + 1]!;
+  const x2 = batch.segments[o + 2]!;
+  const y2 = batch.segments[o + 3]!;
+  const minX = Math.min(x1, x2);
+  const minY = Math.min(y1, y2);
+  return {
+    x: minX,
+    y: minY,
+    width: Math.max(Math.abs(x2 - x1), 1e-6),
+    height: Math.max(Math.abs(y2 - y1), 1e-6),
+  };
+}
+
+function resolveSegmentStroke(
+  ctx: CanvasRenderingContext2D,
+  solid: string,
+  paint: ResolvedGradientPaint | undefined,
+  bounds: { x: number; y: number; width: number; height: number },
   resolve: ColorResolver,
-): string {
-  const stroke = batch.strokes?.[j] ?? batch.stroke;
-  return stroke === null || stroke === undefined ? themeInk : resolve(stroke);
+): string | CanvasGradient {
+  if (paint === undefined) return resolve(solid);
+  return canvasGradientStyle(ctx, paint, bounds);
+}
+
+function applyGlow(ctx: CanvasRenderingContext2D, glow: SegmentsBatch["glow"]): () => void {
+  if (glow === undefined) return () => {};
+  const prevShadowColor = ctx.shadowColor;
+  const prevShadowBlur = ctx.shadowBlur;
+  ctx.shadowColor = glow.color;
+  ctx.shadowBlur = glow.radius;
+  if (glow.opacity < 1) {
+    const hex = glow.color;
+    const full = hex.length === 4 ? `#${hex[1]}${hex[1]}${hex[2]}${hex[2]}${hex[3]}${hex[3]}` : hex;
+    const r = Number.parseInt(full.slice(1, 3), 16);
+    const g = Number.parseInt(full.slice(3, 5), 16);
+    const b = Number.parseInt(full.slice(5, 7), 16);
+    ctx.shadowColor = `rgba(${String(r)},${String(g)},${String(b)},${String(glow.opacity)})`;
+  }
+  return () => {
+    ctx.shadowColor = prevShadowColor;
+    ctx.shadowBlur = prevShadowBlur;
+  };
 }
 
 /**
@@ -59,6 +113,9 @@ export function drawSegments(
     return;
   }
 
+  const restoreGlow = applyGlow(ctx, batch.glow);
+  const paint = batch.strokePaint;
+
   const mappedStyle =
     batch.linewidths !== undefined ||
     batch.alphas !== undefined ||
@@ -67,7 +124,8 @@ export function drawSegments(
     const baseAlpha = ctx.globalAlpha;
     for (let j = 0; j < n; j++) {
       if (includes !== undefined && !includes(j)) continue;
-      ctx.strokeStyle = segmentStrokeAt(batch, j, themeInk, resolve);
+      const solid = segmentSolidAt(batch, j, themeInk);
+      ctx.strokeStyle = resolveSegmentStroke(ctx, solid, paint, segmentBounds(batch, j), resolve);
       ctx.lineWidth = batch.linewidths?.[j] ?? batch.linewidth;
       ctx.globalAlpha = baseAlpha * (batch.alphas?.[j] ?? 1);
       applyDash(ctx, linetypeAt(batch, j));
@@ -77,12 +135,44 @@ export function drawSegments(
     }
     ctx.globalAlpha = baseAlpha;
     applyDash(ctx, "solid");
+    restoreGlow();
     ctx.lineCap = previousLineCap;
     return;
   }
 
   if (batch.strokes === undefined) {
-    ctx.strokeStyle = segmentStrokeAt(batch, 0, themeInk, resolve);
+    // Mono stroke: one gradient over the union of traced segments when paint is set.
+    if (paint !== undefined) {
+      let minX = Infinity;
+      let minY = Infinity;
+      let maxX = -Infinity;
+      let maxY = -Infinity;
+      for (let j = 0; j < n; j++) {
+        if (includes !== undefined && !includes(j)) continue;
+        const b = segmentBounds(batch, j);
+        minX = Math.min(minX, b.x);
+        minY = Math.min(minY, b.y);
+        maxX = Math.max(maxX, b.x + b.width);
+        maxY = Math.max(maxY, b.y + b.height);
+      }
+      const bounds = Number.isFinite(minX)
+        ? {
+            x: minX,
+            y: minY,
+            width: Math.max(maxX - minX, 1e-6),
+            height: Math.max(maxY - minY, 1e-6),
+          }
+        : { x: 0, y: 0, width: 1, height: 1 };
+      ctx.strokeStyle = resolveSegmentStroke(
+        ctx,
+        segmentSolidAt(batch, 0, themeInk),
+        paint,
+        bounds,
+        resolve,
+      );
+    } else {
+      ctx.strokeStyle = resolve(segmentSolidAt(batch, 0, themeInk));
+    }
     ctx.beginPath();
     let traced = false;
     for (let j = 0; j < n; j++) {
@@ -92,6 +182,7 @@ export function drawSegments(
     }
     if (traced) ctx.stroke();
     applyDash(ctx, "solid");
+    restoreGlow();
     ctx.lineCap = previousLineCap;
     return;
   }
@@ -102,10 +193,35 @@ export function drawSegments(
       runStart++;
       continue;
     }
-    const color = segmentStrokeAt(batch, runStart, themeInk, resolve);
+    const color = segmentSolidAt(batch, runStart, themeInk);
     let runEnd = runStart + 1;
-    while (runEnd < n && segmentStrokeAt(batch, runEnd, themeInk, resolve) === color) runEnd++;
-    ctx.strokeStyle = color;
+    while (runEnd < n && segmentSolidAt(batch, runEnd, themeInk) === color) runEnd++;
+    // Gradient paint is layer-constant; solid run color still drives fallback.
+    if (paint !== undefined) {
+      let minX = Infinity;
+      let minY = Infinity;
+      let maxX = -Infinity;
+      let maxY = -Infinity;
+      for (let j = runStart; j < runEnd; j++) {
+        if (includes !== undefined && !includes(j)) continue;
+        const b = segmentBounds(batch, j);
+        minX = Math.min(minX, b.x);
+        minY = Math.min(minY, b.y);
+        maxX = Math.max(maxX, b.x + b.width);
+        maxY = Math.max(maxY, b.y + b.height);
+      }
+      const bounds = Number.isFinite(minX)
+        ? {
+            x: minX,
+            y: minY,
+            width: Math.max(maxX - minX, 1e-6),
+            height: Math.max(maxY - minY, 1e-6),
+          }
+        : { x: 0, y: 0, width: 1, height: 1 };
+      ctx.strokeStyle = resolveSegmentStroke(ctx, color, paint, bounds, resolve);
+    } else {
+      ctx.strokeStyle = resolve(color);
+    }
     ctx.beginPath();
     let traced = false;
     for (let j = runStart; j < runEnd; j++) {
@@ -117,5 +233,6 @@ export function drawSegments(
     runStart = runEnd;
   }
   applyDash(ctx, "solid");
+  restoreGlow();
   ctx.lineCap = previousLineCap;
 }

--- a/packages/core/src/dom/canvas-marks-segments.ts
+++ b/packages/core/src/dom/canvas-marks-segments.ts
@@ -2,6 +2,9 @@
 /**
  * Canvas segment drawers with run-length stroke batching.
  * strokePaint/glow follow the paths batch contract (#1112).
+ *
+ * Mark-space gradients use per-segment bounds so canvas matches SVG
+ * objectBoundingBox mapping (one gradient box per <line>/<path>).
  */
 import { canvasGradientStyle, subpathBounds, type ResolvedGradientPaint } from "../mark-paint.js";
 import type { SegmentsBatch } from "../scene.js";
@@ -28,7 +31,7 @@ function traceSegment(ctx: CanvasRenderingContext2D, batch: SegmentsBatch, j: nu
 
 function segmentSolidAt(batch: SegmentsBatch, j: number, themeInk: string): string {
   const stroke = batch.strokes?.[j] ?? batch.stroke;
-  return stroke === null || stroke === undefined ? themeInk : stroke;
+  return stroke ?? themeInk;
 }
 
 function segmentBounds(
@@ -92,6 +95,9 @@ function applyGlow(ctx: CanvasRenderingContext2D, glow: SegmentsBatch["glow"]): 
  * Draw segments with Θ(runs) stroke() calls: mono batches (no per-segment
  * `strokes`) are one path; per-segment colors collapse contiguous same-color
  * runs. Optional `includes` skips primitives for focus-mask subset passes.
+ *
+ * Mark-space strokePaint forces per-segment strokes so each segment gets the
+ * same objectBoundingBox gradient mapping as SVG.
  */
 export function drawSegments(
   ctx: CanvasRenderingContext2D,
@@ -115,12 +121,15 @@ export function drawSegments(
 
   const restoreGlow = applyGlow(ctx, batch.glow);
   const paint = batch.strokePaint;
+  // Mark-space gradients need per-segment bounds (SVG objectBoundingBox parity).
+  // Panel-space ignores bounds, so the batched solid/panel path stays valid.
+  const perSegmentPaint = paint !== undefined && paint.space === "mark";
 
   const mappedStyle =
     batch.linewidths !== undefined ||
     batch.alphas !== undefined ||
     batch.linetypeIndexes !== undefined;
-  if (mappedStyle) {
+  if (mappedStyle || perSegmentPaint) {
     const baseAlpha = ctx.globalAlpha;
     for (let j = 0; j < n; j++) {
       if (includes !== undefined && !includes(j)) continue;
@@ -140,38 +149,20 @@ export function drawSegments(
     return;
   }
 
+  // Solid mono path, or panel-space paint (bounds unused for panel mapping).
   if (batch.strokes === undefined) {
-    // Mono stroke: one gradient over the union of traced segments when paint is set.
-    if (paint !== undefined) {
-      let minX = Infinity;
-      let minY = Infinity;
-      let maxX = -Infinity;
-      let maxY = -Infinity;
-      for (let j = 0; j < n; j++) {
-        if (includes !== undefined && !includes(j)) continue;
-        const b = segmentBounds(batch, j);
-        minX = Math.min(minX, b.x);
-        minY = Math.min(minY, b.y);
-        maxX = Math.max(maxX, b.x + b.width);
-        maxY = Math.max(maxY, b.y + b.height);
-      }
-      const bounds = Number.isFinite(minX)
-        ? {
-            x: minX,
-            y: minY,
-            width: Math.max(maxX - minX, 1e-6),
-            height: Math.max(maxY - minY, 1e-6),
-          }
-        : { x: 0, y: 0, width: 1, height: 1 };
+    const monoSolid = segmentSolidAt(batch, 0, themeInk);
+    if (paint) {
+      // Panel-space ignores bounds; placeholder is unused for mapping.
       ctx.strokeStyle = resolveSegmentStroke(
         ctx,
-        segmentSolidAt(batch, 0, themeInk),
+        monoSolid,
         paint,
-        bounds,
+        { x: 0, y: 0, width: 1, height: 1 },
         resolve,
       );
     } else {
-      ctx.strokeStyle = resolve(segmentSolidAt(batch, 0, themeInk));
+      ctx.strokeStyle = resolve(monoSolid);
     }
     ctx.beginPath();
     let traced = false;
@@ -196,29 +187,14 @@ export function drawSegments(
     const color = segmentSolidAt(batch, runStart, themeInk);
     let runEnd = runStart + 1;
     while (runEnd < n && segmentSolidAt(batch, runEnd, themeInk) === color) runEnd++;
-    // Gradient paint is layer-constant; solid run color still drives fallback.
-    if (paint !== undefined) {
-      let minX = Infinity;
-      let minY = Infinity;
-      let maxX = -Infinity;
-      let maxY = -Infinity;
-      for (let j = runStart; j < runEnd; j++) {
-        if (includes !== undefined && !includes(j)) continue;
-        const b = segmentBounds(batch, j);
-        minX = Math.min(minX, b.x);
-        minY = Math.min(minY, b.y);
-        maxX = Math.max(maxX, b.x + b.width);
-        maxY = Math.max(maxY, b.y + b.height);
-      }
-      const bounds = Number.isFinite(minX)
-        ? {
-            x: minX,
-            y: minY,
-            width: Math.max(maxX - minX, 1e-6),
-            height: Math.max(maxY - minY, 1e-6),
-          }
-        : { x: 0, y: 0, width: 1, height: 1 };
-      ctx.strokeStyle = resolveSegmentStroke(ctx, color, paint, bounds, resolve);
+    if (paint) {
+      ctx.strokeStyle = resolveSegmentStroke(
+        ctx,
+        color,
+        paint,
+        { x: 0, y: 0, width: 1, height: 1 },
+        resolve,
+      );
     } else {
       ctx.strokeStyle = resolve(color);
     }

--- a/packages/core/src/pipeline/geometry-segments-pack.ts
+++ b/packages/core/src/pipeline/geometry-segments-pack.ts
@@ -2,7 +2,9 @@
  * Pack preallocated segment buffers into a SegmentsBatch.
  *
  * Callers pass already-compact typed arrays (dense as-is or sparse-sliced).
+ * strokePaint/glow come from layer params via layerPaintFromParams (#1112).
  */
+import { layerPaintFromParams, resolveGlow, resolveGradientPaint } from "../mark-paint.js";
 import type { SegmentsBatch } from "../scene.js";
 import { linetypeIndex, type Linetype } from "../scales/style.js";
 
@@ -30,18 +32,38 @@ export function packSegmentsBatch(input: {
   if (rowIndex.length === 0) return null;
   const { binding } = frame;
   const params = (binding.layer.params ?? {}) as { linewidth?: number; alpha?: number };
+  const paint = layerPaintFromParams(binding.layer.params);
+  const strokePaintResolved =
+    paint.strokePaint === null
+      ? undefined
+      : resolveGradientPaint(paint.strokePaint, binding.index, "stroke");
+  const glowResolved = paint.glow === null ? undefined : resolveGlow(paint.glow, binding.index);
+
+  let stroke = binding.color.constant;
+  // strokePaint solid fallback when stroke is still null/theme-default.
+  if (stroke === null && strokePaintResolved !== undefined) {
+    stroke = strokePaintResolved.fallback;
+  }
+  if (strokePaintResolved !== undefined && strokes !== null) {
+    for (let i = 0; i < strokes.length; i++) {
+      strokes[i] ??= strokePaintResolved.fallback;
+    }
+  }
+
   const batch: SegmentsBatch = {
     kind: "segments",
     layerIndex: binding.index,
     panelIndex: 0,
     segments,
     rowIndex,
-    stroke: binding.color.constant,
+    stroke,
     linewidth: constantStyle(binding, params, "linewidth", DEFAULT_RULE_LINEWIDTH),
     alpha: constantStyle(binding, params, "alpha", 1),
     ...(typeof binding.linetype?.constant === "string" && {
       linetype: binding.linetype.constant as Linetype,
     }),
+    ...(strokePaintResolved !== undefined && { strokePaint: strokePaintResolved }),
+    ...(glowResolved !== undefined && { glow: glowResolved }),
   };
   const linewidths = numericStyleVector(frame, "linewidth", styleRows, styles);
   const alphas = numericStyleVector(frame, "alpha", styleRows, styles);

--- a/packages/core/src/render-svg-marks.ts
+++ b/packages/core/src/render-svg-marks.ts
@@ -256,14 +256,19 @@ function renderRects(batch: RectsBatch, theme: ThemeTokens): string {
   return parts.join("");
 }
 
-function renderSegments(batch: SegmentsBatch, theme: ThemeTokens): string {
+function renderSegments(
+  batch: SegmentsBatch,
+  theme: ThemeTokens,
+  mode: PaintRenderMode = "full",
+): string {
   const parts: string[] = [
-    `<g class="gg-batch gg-segments" data-layer="${batch.layerIndex}"${alphaAttr(batch.alpha)}>`,
+    `<g class="gg-batch gg-segments" data-layer="${batch.layerIndex}"${alphaAttr(batch.alpha)}${glowAttr(batch.glow, mode)}>`,
   ];
   const n = batch.segments.length / 4;
   const themeInk = themeVar("ink", theme);
   for (let j = 0; j < n; j++) {
-    const stroke = batch.strokes?.[j] ?? batch.stroke ?? themeInk;
+    const solid = batch.strokes?.[j] ?? batch.stroke ?? themeInk;
+    const stroke = paintStroke(solid, batch.strokePaint, mode);
     const linewidth = batch.linewidths?.[j] ?? batch.linewidth;
     const alpha = batch.alphas?.[j];
     const linecap = batch.linecap === undefined ? "" : ` stroke-linecap="${batch.linecap}"`;
@@ -352,7 +357,7 @@ export function renderBatch(
     case "rects":
       return renderRects(batch, theme);
     case "segments":
-      return renderSegments(batch, theme);
+      return renderSegments(batch, theme, mode);
     case "glyphs":
       return renderGlyphs(batch, theme);
     default: {

--- a/packages/core/tests/mark-paint.test.ts
+++ b/packages/core/tests/mark-paint.test.ts
@@ -1,15 +1,31 @@
 /**
  * Within-mark paint: pipeline resolution + SVG determinism + fallback mode (#591).
+ * Segment/rule/spoke packing + SVG: #1112.
  */
 import { describe, expect, it } from "bun:test";
 import { aes, fillPaintLinear, gg, glow, strokePaintLinear } from "@ggsvelte/spec";
 
 import { runPipeline } from "../src/pipeline.ts";
 import { renderToSVGString } from "../src/render-svg.ts";
-import type { PathsBatch } from "../src/scene.ts";
+import type { PathsBatch, SegmentsBatch } from "../src/scene.ts";
 import { paintResourceId } from "../src/mark-paint.ts";
 
 const size = { width: 320, height: 200 };
+
+const segmentStrokePaint = strokePaintLinear({
+  x1: 0,
+  y1: 0,
+  x2: 1,
+  y2: 0,
+  space: "panel",
+  stops: [
+    { offset: 0, color: "#111111" },
+    { offset: 1, color: "#eeeeee" },
+  ],
+  fallback: "#111111",
+});
+
+const segmentGlow = glow({ color: "#00aaff", radius: 6, opacity: 0.4 });
 
 function ribbonWithPaint() {
   return gg(
@@ -45,6 +61,28 @@ function ribbonWithPaint() {
       glow: glow({ color: "#00aaff", radius: 6, opacity: 0.4 }),
     })
     .spec();
+}
+
+function segmentFamilySpecs() {
+  return {
+    segment: gg(
+      { x: [0], y: [0], xend: [1], yend: [1] },
+      aes({ x: "x", y: "y", xend: "xend", yend: "yend" }),
+    )
+      .geomSegment({ strokePaint: segmentStrokePaint, glow: segmentGlow })
+      .spec(),
+    rule: gg({ x: [0, 1], y: [0, 1] }, aes({ x: "x", y: "y" }))
+      .geomRule({ yintercept: 0.5, strokePaint: segmentStrokePaint, glow: segmentGlow })
+      .spec(),
+    spoke: gg({ x: [0], y: [0] }, aes({ x: "x", y: "y" }))
+      .geomSpoke({
+        angle: 0,
+        radius: 1,
+        strokePaint: segmentStrokePaint,
+        glow: segmentGlow,
+      })
+      .spec(),
+  } as const;
 }
 
 describe("mark paint pipeline", () => {
@@ -144,4 +182,47 @@ describe("mark paint SVG", () => {
     expect(svg).toContain('clip-path="url(#gg-clip-0)"');
     expect(svg).toContain("gg-paint-l0");
   });
+});
+
+describe("mark paint on segment family (#1112)", () => {
+  for (const geom of ["segment", "rule", "spoke"] as const) {
+    it(`${geom} attaches resolved strokePaint and glow with stable ids`, () => {
+      const model = runPipeline(segmentFamilySpecs()[geom], size);
+      const batch = model.scene.batches.find((b): b is SegmentsBatch => b.kind === "segments");
+      expect(batch).toBeDefined();
+      expect(batch!.strokePaint).toMatchObject({
+        kind: "linear",
+        fallback: "#111111",
+        id: paintResourceId(0, "stroke"),
+      });
+      expect(batch!.glow).toMatchObject({
+        color: "#00aaff",
+        radius: 6,
+        id: paintResourceId(0, "glow"),
+      });
+      // Solid fallback lands when stroke is otherwise theme-default/null.
+      expect(batch!.stroke).toBe("#111111");
+    });
+
+    it(`${geom} SVG emits gradient stroke and glow filter`, () => {
+      const svg = renderToSVGString(segmentFamilySpecs()[geom], size);
+      expect(svg).toContain('id="gg-paint-l0-p0-stroke"');
+      expect(svg).toContain('id="gg-paint-l0-p0-glow"');
+      expect(svg).toContain("linearGradient");
+      expect(svg).toContain("feGaussianBlur");
+      expect(svg).toContain('stroke="url(#gg-paint-l0-p0-stroke)"');
+      expect(svg).toContain('filter="url(#gg-paint-l0-p0-glow)"');
+    });
+
+    it(`${geom} fallback paint mode uses solid stroke and omits glow`, () => {
+      const fallback = renderToSVGString(segmentFamilySpecs()[geom], {
+        ...size,
+        paintMode: "fallback",
+      });
+      expect(fallback).not.toContain("linearGradient");
+      expect(fallback).not.toContain("feGaussianBlur");
+      expect(fallback).not.toContain('filter="url(#gg-paint-l0-p0-glow)"');
+      expect(fallback).toContain('stroke="#111111"');
+    });
+  }
 });


### PR DESCRIPTION
## Summary

Closes #1112.

`SegmentParams`, `RuleParams`, and `SpokeParams` declared `strokePaint` and `glow`, and `SegmentsBatch` already had slots, but packing never called `layerPaintFromParams`. Authored gradients and glow validated, then silently did nothing.

This wires paint through the shared segment packer (segment, rule, spoke, and other pack consumers), SVG stroke/glow rendering, and canvas stroke/glow drawing — matching line/curve/ribbon.

## Validation

- Confirmed `geometry-segments-pack.ts` never called `layerPaintFromParams` while sibling stroke geoms did.
- Confirmed `collectPaintResources` already collected segment paints, but `renderSegments` and canvas drawers never applied them.

## What changed

- `packSegmentsBatch` resolves `strokePaint`/`glow` and applies solid fallbacks when stroke is null.
- SVG segment emitter uses gradient stroke URLs and glow filters (with fallback mode).
- Canvas segment drawer applies gradient strokes and glow shadows.

## Test plan

- [x] `bun test packages/core/tests/mark-paint.test.ts` — segment/rule/spoke attach paint + SVG full/fallback
- [x] segment/spoke/rule regression suites still pass
- [ ] CI green
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1125" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->