### PR TITLE
fix(tooltip): format stat position values with axis formatters (#1113)

### DIFF
--- a/.changeset/1113-stat-tooltip-axis-formatters.md
+++ b/.changeset/1113-stat-tooltip-axis-formatters.md
@@ -1,0 +1,15 @@
+---
+"@ggsvelte/svelte": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+fix(tooltip): format stat-layer position values with axis formatters
+
+Default tooltip field rows for stat layers (no source row) now route x/y
+through the same scale-aware axis formatters as the axis header. Temporal
+stats no longer dump raw epoch milliseconds (#1113). Live-region text
+matches. Non-position channels and identity rows keep the plain cell path
+when formatters are absent.
+
+Migration: none — display-only for default tooltips and keyboard live text

--- a/packages/svelte/src/lib/GGPlot.svelte
+++ b/packages/svelte/src/lib/GGPlot.svelte
@@ -289,6 +289,7 @@
           fontSizePx={currentModel.scene.theme.fontSize}
           pin={engine.interactionConfig.inspect?.pin ?? true}
           tooltipBorder={currentModel.scene.theme.tooltipBorder}
+          axisFormatters={currentModel.axisFormatters}
           onenter={() => (engine.tooltipHovered = true)}
           onleave={() => {
             engine.tooltipHovered = false;

--- a/packages/svelte/src/lib/assembly/labels.ts
+++ b/packages/svelte/src/lib/assembly/labels.ts
@@ -89,6 +89,9 @@ export function inspectionLiveText(
   const state = value.state === "pinned" ? ", pinned" : "";
   if (value.mode !== "x" && value.mode !== "y")
     return `${datumLabel(model, value.focus.row)}; ${countLabel(count)}${state}`;
+  // Stat focus (no source row) formats x/y with axis formatters; identity keeps
+  // precise cell values (#1113).
+  const focusFormatters = value.focus.row === null ? axisFormatters : null;
   const seen = new Set<string>();
   const focused = value.focus.fields
     .filter((field) => {
@@ -99,7 +102,7 @@ export function inspectionLiveText(
     .map((field) => {
       const display = formatTooltipCell(field.value, {
         channel: field.channel,
-        axisFormatters,
+        axisFormatters: focusFormatters,
       });
       return `${field.field} ${display}`;
     })

--- a/packages/svelte/src/lib/assembly/labels.ts
+++ b/packages/svelte/src/lib/assembly/labels.ts
@@ -6,7 +6,10 @@ import type {
   PlotSelection,
   ReadonlyZoomDomains,
 } from "../interaction/interaction.js";
-import { collapseIdenticalDisplayMembers } from "../inspection/display-members.js";
+import {
+  collapseIdenticalDisplayMembers,
+  formatTooltipCell,
+} from "../inspection/display-members.js";
 
 /** Shared a11y count phrase: "1 datum" / "N data". */
 export function countLabel(count: number): string {
@@ -81,7 +84,8 @@ export function inspectionLiveText(
 ): string {
   // Count distinct default-tooltip payloads so line+point same-data does not
   // announce "2 data" for one observation (#385).
-  const count = collapseIdenticalDisplayMembers(value.members, value.focus).length;
+  const axisFormatters = model?.axisFormatters ?? null;
+  const count = collapseIdenticalDisplayMembers(value.members, value.focus, axisFormatters).length;
   const state = value.state === "pinned" ? ", pinned" : "";
   if (value.mode !== "x" && value.mode !== "y")
     return `${datumLabel(model, value.focus.row)}; ${countLabel(count)}${state}`;
@@ -92,7 +96,13 @@ export function inspectionLiveText(
       seen.add(field.field);
       return true;
     })
-    .map((field) => `${field.field} ${String(field.value ?? "")}`)
+    .map((field) => {
+      const display = formatTooltipCell(field.value, {
+        channel: field.channel,
+        axisFormatters,
+      });
+      return `${field.field} ${display}`;
+    })
     .join(", ");
   return `${value.mode} ${value.axisLabel}; ${countLabel(count)}${focused ? `; focused ${focused}` : ""}${state}`;
 }

--- a/packages/svelte/src/lib/inspection/Tooltip.svelte
+++ b/packages/svelte/src/lib/inspection/Tooltip.svelte
@@ -179,7 +179,7 @@
             <dd>
               {formatTooltipCell(field.value, {
                 channel: field.channel,
-                axisFormatters,
+                axisFormatters: member.row === null ? axisFormatters : null,
               })}
             </dd>
           {/each}

--- a/packages/svelte/src/lib/inspection/Tooltip.svelte
+++ b/packages/svelte/src/lib/inspection/Tooltip.svelte
@@ -9,6 +9,7 @@
     fieldsForDefaultTooltip,
     formatTooltipCell,
     tooltipFieldLabel,
+    type TooltipAxisFormatters,
     type TooltipFieldLabs,
   } from "./display-members.js";
   import { shouldShowTooltipPinHint } from "./tooltip-chrome.js";
@@ -33,6 +34,11 @@
      * `"transparent"` so default content stays silent (#1069).
      */
     tooltipBorder = "#b8b8b8",
+    /**
+     * Scale-aware x/y formatters from the render model. Position field rows
+     * use these so stat-layer temporal values match the axis header (#1113).
+     */
+    axisFormatters = null,
   }: {
     inspection: PlotInspectionChange<Record<string, CellValue>, PropertyKey>;
     width: number;
@@ -55,6 +61,7 @@
     fontSizePx?: number;
     pin?: boolean;
     tooltipBorder?: string;
+    axisFormatters?: TooltipAxisFormatters | null;
   } = $props();
 
   const showPinHint = $derived(
@@ -119,7 +126,11 @@
   // Collapse identical field blocks for default rendering only (#385). Public
   // `inspection.members` stays full for custom content / oninspect.
   const displayMembers = $derived(
-    collapseIdenticalDisplayMembers(inspection.members, inspection.focus),
+    collapseIdenticalDisplayMembers(
+      inspection.members,
+      inspection.focus,
+      axisFormatters,
+    ),
   );
 
   const shownMembers = $derived(
@@ -165,7 +176,12 @@
             <dt>
               {tooltipFieldLabel(field.field, { channel: field.channel, labs })}
             </dt>
-            <dd>{formatTooltipCell(field.value)}</dd>
+            <dd>
+              {formatTooltipCell(field.value, {
+                channel: field.channel,
+                axisFormatters,
+              })}
+            </dd>
           {/each}
         </dl>
       {/each}

--- a/packages/svelte/src/lib/inspection/display-members.ts
+++ b/packages/svelte/src/lib/inspection/display-members.ts
@@ -26,13 +26,14 @@ export type FormatTooltipCellOptions = {
  *
  * Position channels (`x`/`y`) route through `axisFormatters` when provided —
  * the same path as the axis header — so stat-frame temporal values print as
- * dates rather than raw epoch milliseconds (#1113). Non-position channels and
- * callers without formatters keep the plain cell path.
+ * dates rather than raw epoch milliseconds (#1113). Callers should pass
+ * formatters only for members with no source row (`row === null`); identity
+ * rows keep the plain cell path so linear points keep full precision.
  */
 export function formatTooltipCell(value: CellValue, options?: FormatTooltipCellOptions): string {
   const channel = options?.channel;
   const formatters = options?.axisFormatters;
-  if (formatters != null && (channel === "x" || channel === "y")) {
+  if (formatters !== null && formatters !== undefined && (channel === "x" || channel === "y")) {
     return formatters[channel](value);
   }
   if (value === null) return "–";
@@ -181,13 +182,18 @@ export function collapseIdenticalDisplayMembers<Row, Key>(
 ): NonEmptyReadonlyArray<PlotDatum<Row, Key>> {
   if (members.length === 0) return [focus];
 
+  // Stat members (no source row) use axis formatters for position display;
+  // identity members keep precise cell formatting (#1113).
+  const formattersFor = (member: PlotDatum<Row, Key>): TooltipAxisFormatters | null =>
+    member.row === null ? axisFormatters : null;
+
   const chosen = new Map<string, PlotDatum<Row, Key>>();
   const order: string[] = [];
   let focusInMembers = false;
 
   for (const member of members) {
     if (member === focus) focusInMembers = true;
-    const token = tooltipDisplayPayloadToken(member.fields, axisFormatters);
+    const token = tooltipDisplayPayloadToken(member.fields, formattersFor(member));
     const existing = chosen.get(token);
     if (existing === undefined) {
       chosen.set(token, member);
@@ -198,7 +204,7 @@ export function collapseIdenticalDisplayMembers<Row, Key>(
     if (member === focus) chosen.set(token, member);
   }
 
-  const focusToken = tooltipDisplayPayloadToken(focus.fields, axisFormatters);
+  const focusToken = tooltipDisplayPayloadToken(focus.fields, formattersFor(focus));
   if (chosen.has(focusToken)) {
     // Same display as a retained member — always surface focus for styling.
     chosen.set(focusToken, focus);

--- a/packages/svelte/src/lib/inspection/display-members.ts
+++ b/packages/svelte/src/lib/inspection/display-members.ts
@@ -10,8 +10,31 @@ import { spaceFieldName, type CellValue } from "@ggsvelte/core";
 
 import type { NonEmptyReadonlyArray, PlotDatum, TooltipField } from "../interaction/interaction.js";
 
-/** Shared with Tooltip.svelte so equality matches what the user sees. */
-export function formatTooltipCell(value: CellValue): string {
+/** Position-axis formatters from `RenderModel.axisFormatters` (scale-aware). */
+export type TooltipAxisFormatters = Readonly<{
+  x: (value: CellValue) => string;
+  y: (value: CellValue) => string;
+}>;
+
+export type FormatTooltipCellOptions = {
+  readonly channel?: string;
+  readonly axisFormatters?: TooltipAxisFormatters | null;
+};
+
+/**
+ * Shared with Tooltip.svelte so equality matches what the user sees.
+ *
+ * Position channels (`x`/`y`) route through `axisFormatters` when provided —
+ * the same path as the axis header — so stat-frame temporal values print as
+ * dates rather than raw epoch milliseconds (#1113). Non-position channels and
+ * callers without formatters keep the plain cell path.
+ */
+export function formatTooltipCell(value: CellValue, options?: FormatTooltipCellOptions): string {
+  const channel = options?.channel;
+  const formatters = options?.axisFormatters;
+  if (formatters != null && (channel === "x" || channel === "y")) {
+    return formatters[channel](value);
+  }
   if (value === null) return "–";
   if (value instanceof Date) {
     // Invalid Date throws on toISOString — keyboard live-text tokens must not.
@@ -126,12 +149,18 @@ export function fieldsForDefaultTooltip(
  * Uses field *names* (dt text) + formatted values (dd text), not channel —
  * channels are not shown and must not split visually identical rows.
  */
-export function tooltipDisplayPayloadToken(fields: readonly TooltipField[]): string {
+export function tooltipDisplayPayloadToken(
+  fields: readonly TooltipField[],
+  axisFormatters?: TooltipAxisFormatters | null,
+): string {
   // Length-prefix each segment so field names / values cannot forge delimiters.
   const parts: string[] = [];
   for (const field of fields) {
     const name = field.field;
-    const display = formatTooltipCell(field.value);
+    const display = formatTooltipCell(field.value, {
+      channel: field.channel,
+      axisFormatters,
+    });
     parts.push(`${name.length}:${name}|${display.length}:${display}`);
   }
   return parts.join("\n");
@@ -148,6 +177,7 @@ export function tooltipDisplayPayloadToken(fields: readonly TooltipField[]): str
 export function collapseIdenticalDisplayMembers<Row, Key>(
   members: readonly PlotDatum<Row, Key>[],
   focus: PlotDatum<Row, Key>,
+  axisFormatters?: TooltipAxisFormatters | null,
 ): NonEmptyReadonlyArray<PlotDatum<Row, Key>> {
   if (members.length === 0) return [focus];
 
@@ -157,7 +187,7 @@ export function collapseIdenticalDisplayMembers<Row, Key>(
 
   for (const member of members) {
     if (member === focus) focusInMembers = true;
-    const token = tooltipDisplayPayloadToken(member.fields);
+    const token = tooltipDisplayPayloadToken(member.fields, axisFormatters);
     const existing = chosen.get(token);
     if (existing === undefined) {
       chosen.set(token, member);
@@ -168,7 +198,7 @@ export function collapseIdenticalDisplayMembers<Row, Key>(
     if (member === focus) chosen.set(token, member);
   }
 
-  const focusToken = tooltipDisplayPayloadToken(focus.fields);
+  const focusToken = tooltipDisplayPayloadToken(focus.fields, axisFormatters);
   if (chosen.has(focusToken)) {
     // Same display as a retained member — always surface focus for styling.
     chosen.set(focusToken, focus);

--- a/packages/svelte/src/lib/inspection/display-members.ts
+++ b/packages/svelte/src/lib/inspection/display-members.ts
@@ -151,7 +151,7 @@ export function fieldsForDefaultTooltip(
  */
 export function tooltipDisplayPayloadToken(
   fields: readonly TooltipField[],
-  axisFormatters?: TooltipAxisFormatters | null,
+  axisFormatters: TooltipAxisFormatters | null = null,
 ): string {
   // Length-prefix each segment so field names / values cannot forge delimiters.
   const parts: string[] = [];
@@ -177,7 +177,7 @@ export function tooltipDisplayPayloadToken(
 export function collapseIdenticalDisplayMembers<Row, Key>(
   members: readonly PlotDatum<Row, Key>[],
   focus: PlotDatum<Row, Key>,
-  axisFormatters?: TooltipAxisFormatters | null,
+  axisFormatters: TooltipAxisFormatters | null = null,
 ): NonEmptyReadonlyArray<PlotDatum<Row, Key>> {
   if (members.length === 0) return [focus];
 

--- a/packages/svelte/tests/inspection/display-members.test.ts
+++ b/packages/svelte/tests/inspection/display-members.test.ts
@@ -55,7 +55,8 @@ describe("formatTooltipCell", () => {
   it("routes position channels through axis formatters when provided (#1113)", () => {
     // Stat-derived candidates store temporal positions as epoch ms. Default
     // cell formatting would print the raw number; axis formatters already know
-    // the scale (same path as the axis header).
+    // the scale (same path as the axis header). Callers pass formatters only
+    // for members with no source row so identity points keep precision.
     const epoch = Date.UTC(2000, 4, 1);
     const axisFormatters = {
       x: (value: CellValue) =>
@@ -67,6 +68,8 @@ describe("formatTooltipCell", () => {
     expect(formatTooltipCell(12.3456, { channel: "y", axisFormatters })).toBe("y:12.3456");
     // Non-position channels keep the plain cell path even with formatters present.
     expect(formatTooltipCell(epoch, { channel: "color", axisFormatters })).toBe(String(epoch));
+    // Without formatters (identity path), numbers keep full cell precision.
+    expect(formatTooltipCell(23.7, { channel: "x" })).toBe("23.7");
   });
 });
 

--- a/packages/svelte/tests/inspection/display-members.test.ts
+++ b/packages/svelte/tests/inspection/display-members.test.ts
@@ -51,6 +51,23 @@ describe("formatTooltipCell", () => {
   it("does not throw on invalid Date (live-text tokens)", () => {
     expect(formatTooltipCell(new Date(Number.NaN))).toBe("–");
   });
+
+  it("routes position channels through axis formatters when provided (#1113)", () => {
+    // Stat-derived candidates store temporal positions as epoch ms. Default
+    // cell formatting would print the raw number; axis formatters already know
+    // the scale (same path as the axis header).
+    const epoch = Date.UTC(2000, 4, 1);
+    const axisFormatters = {
+      x: (value: CellValue) =>
+        value === null ? "–" : new Date(Number(value)).toISOString().slice(0, 10),
+      y: (value: CellValue) => (value === null ? "–" : `y:${String(value)}`),
+    };
+    expect(formatTooltipCell(epoch)).toBe(String(epoch));
+    expect(formatTooltipCell(epoch, { channel: "x", axisFormatters })).toBe("2000-05-01");
+    expect(formatTooltipCell(12.3456, { channel: "y", axisFormatters })).toBe("y:12.3456");
+    // Non-position channels keep the plain cell path even with formatters present.
+    expect(formatTooltipCell(epoch, { channel: "color", axisFormatters })).toBe(String(epoch));
+  });
 });
 
 describe("tooltipFieldLabel (#752)", () => {

--- a/packages/svelte/tests/inspection/resolve-snapshot.test.ts
+++ b/packages/svelte/tests/inspection/resolve-snapshot.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import { runPipeline } from "@ggsvelte/core";
 import { aes, gg } from "@ggsvelte/spec";
 
+import { formatTooltipCell } from "../../src/lib/inspection/display-members.js";
 // Barrel path characterization: production + tests historically import via resolver.js
 import { resolveInspection } from "../../src/lib/inspection/resolver.js";
 
@@ -177,5 +178,51 @@ describe("inspection snapshot resolve", () => {
       globalThis.Set = RealSet;
       model.dispose();
     }
+  });
+
+  it("formats stat-layer temporal position fields with axis formatters (#1113)", () => {
+    // Binned median over a date axis has no source row — candidate.xValue is
+    // epoch ms. The axis header already formats it; default field rows must too.
+    const data = [
+      { date: "2000-05-01", y: 10 },
+      { date: "2000-05-15", y: 20 },
+      { date: "2000-06-01", y: 30 },
+      { date: "2000-06-15", y: 40 },
+    ];
+    const model = runPipeline(
+      gg(data, aes({ x: "date", y: "y" }))
+        .geomLine({ stat: "summary_bin", fun: "median", bins: 4 })
+        .spec(),
+      { width: 400, height: 300 },
+    );
+    const seed = model.candidates.candidate(0)!;
+    expect(seed.rowIndex).toBeNull();
+    expect(typeof seed.xValue).toBe("number");
+    expect(seed.xValue).toBeGreaterThan(1e11); // epoch ms, not a calendar year
+
+    const inspection = resolveInspection({
+      model,
+      seed,
+      mode: "exact",
+      state: "transient",
+      source: "pointer",
+      keyOf: () => null,
+    });
+    expect(inspection.focus.row).toBeNull();
+    const xField = inspection.focus.fields.find((field) => field.channel === "x");
+    expect(xField).toBeDefined();
+    expect(xField!.value).toBe(seed.xValue);
+
+    // Plain cell path still dumps the epoch — the bug before the formatter route.
+    expect(formatTooltipCell(xField!.value)).toBe(String(seed.xValue));
+    // With axis formatters (Tooltip / live-text path), match the axis header.
+    const formatted = formatTooltipCell(xField!.value, {
+      channel: "x",
+      axisFormatters: model.axisFormatters,
+    });
+    expect(formatted).toBe(model.axisFormatters.x(seed.xValue));
+    expect(formatted).not.toBe(String(seed.xValue));
+    expect(formatted).toMatch(/2000/);
+    model.dispose();
   });
 });


### PR DESCRIPTION
## Summary

- Fixes #1113: default tooltips on stat layers (no source row) were printing raw epoch milliseconds for temporal position fields.
- Route `x`/`y` field cells through `model.axisFormatters` — the same path as the axis header — in `formatTooltipCell`, Tooltip, and keyboard live text.
- Identity rows and non-position channels keep the plain cell path when formatters are not applicable.

## Validation

Reproduced with `summary_bin` over a date axis: candidate `xValue` is epoch ms (`957139200000`), `axisFormatters.x` yields `2000-05-01`, but `formatTooltipCell` previously returned the raw number string.

## Test plan

- [x] RED then GREEN unit test: position channels use axis formatters (`display-members.test.ts`)
- [x] Integration: stat-layer temporal field display matches `axisFormatters` (`resolve-snapshot.test.ts`)
- [x] Existing `labels.test.ts` / collapse tests still pass
- [ ] CI green
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1127" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->