### PR TITLE
fix(svelte): interval bounds editor shows month-day as MM-DD

### DIFF
--- a/.changeset/1114-month-day-bounds-editor.md
+++ b/.changeset/1114-month-day-bounds-editor.md
@@ -1,0 +1,15 @@
+---
+"@ggsvelte/svelte": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+fix(svelte): interval bounds editor shows month-day as MM-DD
+
+`temporalKind: "monthDay"` resolves values into a fixed leap reference year.
+The bounds editor was printing that year via `toISOString()`, so authors saw
+`2000-04-01T00:00:00.000Z` instead of the `04-01` form they write and the axis
+shows. Drafts now format and parse as month-day (`MM-DD`) when the axis kind is
+`monthDay`.
+
+Closes #1114.

--- a/packages/svelte/src/lib/interval/BoundsEditor.svelte
+++ b/packages/svelte/src/lib/interval/BoundsEditor.svelte
@@ -37,7 +37,9 @@
   const fieldsetLabel = $derived(`Edit ${axisName} ${actionName} bounds`);
   const hint = $derived(
     input.scale === "time"
-      ? "Enter an ISO 8601 date, or a date-time with Z or an explicit offset."
+      ? input.temporalKind === "monthDay"
+        ? "Enter a month-day as MM-DD (for example 04-01)."
+        : "Enter an ISO 8601 date, or a date-time with Z or an explicit offset."
       : input.scale === "band"
         ? "Endpoints include both selected categories."
         : input.transform === "log10"

--- a/packages/svelte/src/lib/interval/bounds-editor.ts
+++ b/packages/svelte/src/lib/interval/bounds-editor.ts
@@ -1,4 +1,5 @@
 import type { PositionTransformName } from "@ggsvelte/core";
+import { parseTemporal, type TemporalScaleKind } from "@ggsvelte/spec";
 
 export type BoundsAxis = "x" | "y";
 export type BoundsAction = "select" | "zoom";
@@ -31,6 +32,11 @@ interface TimeBoundsEditorInput extends BoundsEditorInputBase {
   readonly scale: "time";
   /** UTC epoch milliseconds. */
   readonly bounds: readonly [number, number];
+  /**
+   * Position scale temporal intent. When `"monthDay"`, drafts format and parse
+   * as `MM-DD` so the leap reference year stays an implementation detail.
+   */
+  readonly temporalKind?: TemporalScaleKind | null;
 }
 
 interface BandBoundsEditorInput extends BoundsEditorInputBase {
@@ -92,11 +98,17 @@ function categoryIndex(input: BandBoundsEditorInput, value: BoundsCategoryValue)
   return input.categories.findIndex((category) => sameCategory(category.value, value));
 }
 
+function formatTimeBound(ms: number, temporalKind: TemporalScaleKind | null | undefined): string {
+  // monthDay values live in a fixed leap reference year; authors write MM-DD.
+  if (temporalKind === "monthDay") return new Date(ms).toISOString().slice(5, 10);
+  return new Date(ms).toISOString();
+}
+
 export function formatBoundsDraft(input: BoundsEditorInput): BoundsDraft {
   if (input.scale === "time") {
     return {
-      lower: new Date(input.bounds[0]).toISOString(),
-      upper: new Date(input.bounds[1]).toISOString(),
+      lower: formatTimeBound(input.bounds[0], input.temporalKind),
+      upper: formatTimeBound(input.bounds[1], input.temporalKind),
     };
   }
   if (input.scale === "band") {
@@ -135,7 +147,24 @@ function parseNumber(draft: string, label: string): number | string {
 const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/u;
 const ISO_DATE_TIME = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?(?:Z|[+-]\d{2}:?\d{2})$/u;
 
-function parseTime(draft: string, label: string): number | string {
+function parseMonthDay(draft: string, label: string): number | string {
+  const trimmed = draft.trim();
+  if (trimmed === "") return `${label} is required.`;
+  // Same surface as the md parser / monthDay domain authoring: MM-DD,
+  // --MM-DD, or a full date whose year is discarded into the reference year.
+  const parsed = parseTemporal(trimmed, "md");
+  if (!parsed.ok) {
+    return `${label} must be a month-day (MM-DD).`;
+  }
+  return parsed.epochMs;
+}
+
+function parseTime(
+  draft: string,
+  label: string,
+  temporalKind: TemporalScaleKind | null | undefined,
+): number | string {
+  if (temporalKind === "monthDay") return parseMonthDay(draft, label);
   const trimmed = draft.trim();
   if (!ISO_DATE.test(trimmed) && !ISO_DATE_TIME.test(trimmed)) {
     return `${label} must be an ISO 8601 date or date-time with a timezone.`;
@@ -186,11 +215,11 @@ export function validateBoundsDraft(
 
   const lower =
     input.scale === "time"
-      ? parseTime(lowerDraft, "Lower bound")
+      ? parseTime(lowerDraft, "Lower bound", input.temporalKind)
       : parseNumber(lowerDraft, "Lower bound");
   const upper =
     input.scale === "time"
-      ? parseTime(upperDraft, "Upper bound")
+      ? parseTime(upperDraft, "Upper bound", input.temporalKind)
       : parseNumber(upperDraft, "Upper bound");
   const errors: { lower?: string; upper?: string } = {};
   if (typeof lower === "string") errors.lower = lower;

--- a/packages/svelte/src/lib/interval/interval-state.svelte.ts
+++ b/packages/svelte/src/lib/interval/interval-state.svelte.ts
@@ -269,6 +269,12 @@ export function createIntervalState(deps: IntervalStateDeps): IntervalState {
   const boundsEditorInput = $derived.by((): BoundsEditorInput | null => {
     if (boundsEditor === null || deps.model() === null) return null;
     const model = deps.model()!;
+    // Axis guide plans carry temporalKind (including monthDay); the trained
+    // continuous scale does not. Use the first matching axis plan so the
+    // bounds editor can format drafts without the reference year.
+    const temporalKind =
+      model.guidePlans.find((plan) => plan.type === "axis" && plan.aesthetic === boundsEditor.axis)
+        ?.temporalKind ?? null;
     if (boundsEditor.action === "zoom") {
       const viewportPanel = model.viewport.panels[0];
       if (viewportPanel === undefined) return null;
@@ -280,6 +286,7 @@ export function createIntervalState(deps: IntervalStateDeps): IntervalState {
         action: "zoom",
         scale,
         bounds,
+        temporalKind,
       });
     }
     const record = currentIntervalRecord;
@@ -297,6 +304,7 @@ export function createIntervalState(deps: IntervalStateDeps): IntervalState {
       axis: boundsEditor.axis,
       action: "select",
       scale,
+      temporalKind,
       ...(bounds !== undefined && { bounds }),
     });
   });

--- a/packages/svelte/src/lib/interval/interval-state.svelte.ts
+++ b/packages/svelte/src/lib/interval/interval-state.svelte.ts
@@ -26,6 +26,7 @@ import {
   type ScenePanel,
   type SemanticViewportSelection,
 } from "@ggsvelte/core";
+import type { TemporalScaleKind } from "@ggsvelte/spec";
 
 import type { PlotInteractionController } from "../interaction/controller.svelte.js";
 import type {
@@ -267,22 +268,27 @@ export function createIntervalState(deps: IntervalStateDeps): IntervalState {
   });
 
   const boundsEditorInput = $derived.by((): BoundsEditorInput | null => {
-    if (boundsEditor === null || deps.model() === null) return null;
+    const editor = boundsEditor;
+    if (editor === null || deps.model() === null) return null;
     const model = deps.model()!;
     // Axis guide plans carry temporalKind (including monthDay); the trained
     // continuous scale does not. Use the first matching axis plan so the
     // bounds editor can format drafts without the reference year.
-    const temporalKind =
-      model.guidePlans.find((plan) => plan.type === "axis" && plan.aesthetic === boundsEditor.axis)
-        ?.temporalKind ?? null;
-    if (boundsEditor.action === "zoom") {
+    let temporalKind: TemporalScaleKind | null = null;
+    for (const plan of model.guidePlans) {
+      if (plan.type === "axis" && plan.aesthetic === editor.axis) {
+        temporalKind = plan.temporalKind;
+        break;
+      }
+    }
+    if (editor.action === "zoom") {
       const viewportPanel = model.viewport.panels[0];
       if (viewportPanel === undefined) return null;
-      const scale = viewportPanel.axisEditModel(boundsEditor.axis);
+      const scale = viewportPanel.axisEditModel(editor.axis);
       if (scale.kind === "band") return null;
-      const bounds = deps.effectiveZoomDomains()?.[boundsEditor.axis] ?? scale.domain;
+      const bounds = deps.effectiveZoomDomains()?.[editor.axis] ?? scale.domain;
       return boundsEditorInputForScale({
-        axis: boundsEditor.axis,
+        axis: editor.axis,
         action: "zoom",
         scale,
         bounds,
@@ -290,18 +296,18 @@ export function createIntervalState(deps: IntervalStateDeps): IntervalState {
       });
     }
     const record = currentIntervalRecord;
-    const targetPanelId = record?.panelId ?? boundsEditor.panelId;
+    const targetPanelId = record?.panelId ?? editor.panelId;
     if (targetPanelId === undefined) return null;
     const viewportPanel = model.viewport.panel(targetPanelId);
     if (viewportPanel === null) return null;
-    const scale = viewportPanel.axisEditModel(boundsEditor.axis);
-    const semantic = record?.domains[boundsEditor.axis];
+    const scale = viewportPanel.axisEditModel(editor.axis);
+    const semantic = record?.domains[editor.axis];
     const bounds =
       semantic?.kind === "band"
         ? ([semantic.values[0] ?? "", semantic.values.at(-1) ?? ""] as const)
         : semantic?.domain;
     return boundsEditorInputForScale({
-      axis: boundsEditor.axis,
+      axis: editor.axis,
       action: "select",
       scale,
       temporalKind,

--- a/packages/svelte/src/lib/interval/precise-bounds.ts
+++ b/packages/svelte/src/lib/interval/precise-bounds.ts
@@ -4,6 +4,7 @@ import {
   type AxisEditModel,
   type PositionTransformName,
 } from "@ggsvelte/core";
+import type { TemporalScaleKind } from "@ggsvelte/spec";
 
 import type {
   BoundsAction,
@@ -20,6 +21,8 @@ export interface BoundsEditorInputForScaleOptions {
   readonly scale: AxisEditModel;
   readonly bounds?: readonly [number, number] | readonly [BoundsCategoryValue, BoundsCategoryValue];
   readonly reversed?: boolean;
+  /** From the axis guide plan; monthDay drafts format/parse as MM-DD. */
+  readonly temporalKind?: TemporalScaleKind | null;
 }
 
 export function boundsEditorInputForScale(
@@ -75,6 +78,7 @@ export function boundsEditorInputForScale(
       scale: "time",
       bounds,
       reversed: options.reversed ?? scale.reversed,
+      ...(options.temporalKind !== undefined && { temporalKind: options.temporalKind }),
     };
   }
   return {

--- a/packages/svelte/tests/interval/bounds-editor-unit.test.ts
+++ b/packages/svelte/tests/interval/bounds-editor-unit.test.ts
@@ -30,6 +30,47 @@ describe("precise bounds drafts", () => {
     ).toEqual({ lower: "2025-01-02T00:00:00.000Z", upper: "2025-01-03T12:30:00.000Z" });
   });
 
+  it("formats monthDay bounds as MM-DD without the reference year", () => {
+    // temporalKind: "monthDay" resolves into year 2000 so values share one
+    // position — that year is an implementation detail, never typed by authors.
+    expect(
+      formatBoundsDraft(
+        input({
+          scale: "time",
+          temporalKind: "monthDay",
+          bounds: [Date.UTC(2000, 3, 1), Date.UTC(2000, 4, 10)],
+        }),
+      ),
+    ).toEqual({ lower: "04-01", upper: "05-10" });
+  });
+
+  it("accepts MM-DD drafts on a monthDay time scale and emits reference-year epochs", () => {
+    const monthDay = input({
+      axis: "y",
+      action: "zoom",
+      scale: "time",
+      temporalKind: "monthDay",
+      bounds: [Date.UTC(2000, 2, 18), Date.UTC(2000, 4, 10)],
+    });
+    expect(validateBoundsDraft(monthDay, "04-01", "05-10")).toEqual({
+      ok: true,
+      event: {
+        source: "precise-bounds",
+        inputSource: "keyboard",
+        action: "zoom",
+        axis: "y",
+        scale: "time",
+        bounds: [Date.UTC(2000, 3, 1), Date.UTC(2000, 4, 10)],
+        reversed: false,
+      },
+    });
+    // Slash form is accepted by the md parser; refuse free-text month names.
+    const invalid = validateBoundsDraft(monthDay, "April 1", "05-10");
+    expect(invalid.ok).toBe(false);
+    if (invalid.ok) throw new Error("expected invalid month-day bound");
+    expect(invalid.errors.lower).toMatch(/month-day|MM-DD/i);
+  });
+
   it("keeps reversed linear domains semantic and ascending", () => {
     const result = validateBoundsDraft(input({ reversed: true }), "3", "7");
     expect(result).toEqual({

--- a/packages/svelte/tests/interval/bounds-editor.test.ts
+++ b/packages/svelte/tests/interval/bounds-editor.test.ts
@@ -11,6 +11,24 @@ function write(input: HTMLInputElement, value: string): void {
 }
 
 describe("<BoundsEditor>", () => {
+  it("shows monthDay bounds as MM-DD and a month-day hint", async () => {
+    const { container } = render(BoundsEditor, {
+      input: {
+        axis: "y",
+        action: "select",
+        scale: "time",
+        temporalKind: "monthDay",
+        bounds: [Date.UTC(2000, 3, 1), Date.UTC(2000, 4, 10)],
+      },
+      onapply: vi.fn(),
+    });
+    await tick();
+    const [lower, upper] = [...container.querySelectorAll("input")];
+    expect(lower.value).toBe("04-01");
+    expect(upper.value).toBe("05-10");
+    expect(container.querySelector(".gg-bounds-hint")?.textContent).toMatch(/MM-DD/);
+  });
+
   it("is an inline labelled fieldset with 44px controls", async () => {
     const { container } = render(BoundsEditor, {
       input: {

--- a/packages/svelte/tests/interval/interval-state.bounds-editor.test.ts
+++ b/packages/svelte/tests/interval/interval-state.bounds-editor.test.ts
@@ -7,7 +7,7 @@ import { describe, expect, it } from "vitest";
 
 import type { RenderModel } from "@ggsvelte/core";
 import { encodeKey } from "@ggsvelte/core";
-import { aes, gg } from "@ggsvelte/spec";
+import { aes, gg, scaleYMonthDay } from "@ggsvelte/spec";
 
 import { reactiveBox } from "../helpers/reactive-box.svelte.js";
 import {
@@ -27,6 +27,49 @@ import {
 } from "./interval-state.harness.js";
 
 describe("createIntervalState bounds editor select path", () => {
+  it("threads monthDay temporalKind so drafts can omit the reference year", () => {
+    // Full dates (any year) are the common monthDay input; the scale collapses
+    // the year. Bare "MM-DD" needs an explicit md parser and is a different path.
+    const model = modelFor(
+      gg(
+        [
+          { year: 812, bloom: "0812-04-01" },
+          { year: 2026, bloom: "2026-03-29" },
+        ],
+        aes({ x: "year", y: "bloom" }),
+      )
+        .geomPoint()
+        .scales(scaleYMonthDay())
+        .spec(),
+    );
+    const trigger = document.createElement("button");
+    const { state, destroy } = mountIntervalController({
+      model: () => model,
+      selectConfig: persistentSelect,
+    });
+
+    state.finishBrushSelect(
+      brushEvent(model, {
+        domain: {
+          x: [800, 2100],
+          y: [Date.UTC(2000, 2, 29), Date.UTC(2000, 3, 1)],
+        },
+        keys: ["0", "1"],
+      }),
+      "pointer",
+    );
+    flushSync();
+    state.openBoundsEditor("select", "y", trigger);
+    flushSync();
+
+    expect(state.boundsEditorInput).toMatchObject({
+      scale: "time",
+      temporalKind: "monthDay",
+    });
+
+    destroy();
+  });
+
   it("band precise-bounds emit typed domain endpoints from encoded identities", () => {
     // semanticAxis stores encodeKey tokens; eventDomain must decode them back
     // to typed rawDomain values for the public IntervalSelection.domain payload.

--- a/packages/svelte/tests/interval/precise-bounds.test.ts
+++ b/packages/svelte/tests/interval/precise-bounds.test.ts
@@ -55,6 +55,20 @@ describe("precise plot bounds adapters", () => {
     },
   );
 
+  it("forwards temporalKind on time scales so monthDay drafts can omit the year", () => {
+    const input = boundsEditorInputForScale({
+      axis: "y",
+      action: "zoom",
+      scale: continuousEdit("time", "identity", [Date.UTC(2000, 3, 1), Date.UTC(2000, 4, 10)]),
+      temporalKind: "monthDay",
+    });
+    expect(input).toMatchObject({
+      scale: "time",
+      temporalKind: "monthDay",
+      bounds: [Date.UTC(2000, 3, 1), Date.UTC(2000, 4, 10)],
+    });
+  });
+
   it("builds inclusive categorical inputs from band domains", () => {
     const input = boundsEditorInputForScale({
       axis: "y",


### PR DESCRIPTION
## Summary

- `formatBoundsDraft` / `validateBoundsDraft` treat `temporalKind: "monthDay"` as `MM-DD` (no reference year in the editor).
- Interval state threads `temporalKind` from the axis guide plan into the bounds editor input.
- Hint copy and unit/component/state tests cover format, parse, and wiring.

Closes #1114.

## Test plan

- [x] `packages/svelte` vitest (chromium): bounds-editor-unit, precise-bounds, bounds-editor, interval-state.bounds-editor
- [ ] CI green on the PR
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1128" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->