### PR TITLE
refactor(docs): extract live finished chart from getting-started guide

### DIFF
--- a/apps/docs/src/lib/components/GettingStartedGuide.svelte
+++ b/apps/docs/src/lib/components/GettingStartedGuide.svelte
@@ -6,131 +6,33 @@
    * — the same fold that produces the fragments above them and the finished
    * file at the end. Nothing here re-derives a spec, so nothing here can drift
    * from what the reader copies.
+   *
+   * The live finished chart lives in LessonFinishedChart so this file stays
+   * page structure only (prose, static step images, copy blocks).
    */
   import { base } from "$app/paths";
-  import { kyotoSakura } from "@ggsvelte/svelte/data";
-  import { onMount } from "svelte";
 
   import {
-    foldSakura,
     QUICKSTART_PAGE_SVELTE,
     QUICKSTART_PORTABLE_SPEC_FRAGMENT,
     SAKURA_FINISHED_SVELTE,
-    SAKURA_RECORDS,
     SAKURA_STEPS,
   } from "$scripts/quickstart";
   import {
     LESSON_CHART_HEIGHT,
     LESSON_CHART_WIDTH,
-    sakuraFinishedHeight,
   } from "$lib/generated/lesson-charts";
 
   import CopyCode from "./CopyCode.svelte";
-
-  const rows = kyotoSakura.map((row) => ({ ...row }));
-
-  /**
-   * Below this chart width, hand-placed callouts collide with the data, so the
-   * records move into the aria-label only (bands, trend and points never move).
-   * Measured on the chart container, never on the viewport.
-   */
-  const NARROW_CHART = 560;
-
-  /**
-   * Assume narrow until the finished-chart container is measured. Starting at
-   * `false` forced a wide fold on first paint, then a second 838-point fold
-   * when ResizeObserver fired — on mobile that double work blocked chrome for
-   * ~17s before "Open site menu" was tappable (#972). Desktop still flips once
-   * (narrow → wide) when the container is actually wide enough for callouts.
-   *
-   * First paint uses the narrow probe height from the generated size table so
-   * we do not reserve a desktop-tall plot before ResizeObserver fires.
-   */
-  let narrowChart = $state(true);
-  /** Measured container width; drives live plot height via build-time chrome table. */
-  let chartWidth = $state(0);
-  let finishedChart = $state<HTMLElement>();
-  /** Live plot component — dynamically imported when near the viewport (#972). */
-  let LivePlot = $state<null | (typeof import("@ggsvelte/svelte"))["GGPlot"]>(
-    null,
-  );
-
-  /**
-   * Fold only when the live plot is mounted. Computing the 838-point spec
-   * during first hydrate (even behind a placeholder) blocked mobile chrome
-   * for ~20s (#972).
-   */
-  const finished = $derived(
-    LivePlot === null
-      ? null
-      : foldSakura(SAKURA_STEPS.length, rows, { annotations: !narrowChart }),
-  );
-
-  /**
-   * Outer plot height from the build-time size table (pipeline-measured chrome
-   * so the *data panel* stays ~2.5:1). Never invent chrome constants here —
-   * regenerating lesson charts refreshes the table.
-   */
-  const liveHeight = $derived(
-    sakuraFinishedHeight(chartWidth > 0 ? chartWidth : NARROW_CHART),
-  );
-
-  const recordNames = SAKURA_RECORDS.map((record) => record.label).join("; ");
+  import LessonFinishedChart from "./LessonFinishedChart.svelte";
 
   /**
    * Intermediate step charts ship as SVG the library rendered at build time
    * (scripts/gen-lesson-charts.ts). The final "Finish it" step is the live
-   * 838-point plot — loaded when near the viewport so mobile chrome stays
-   * tappable (#972).
+   * 838-point plot in LessonFinishedChart.
    */
   const chartSrc = (step: number): string =>
     `${base}/lesson/${step < 0 ? "first-render.svg" : `step-${String(step + 1)}.svg`}`;
-
-  onMount(() => {
-    const target = finishedChart;
-    if (target === undefined) return;
-    let cancelled = false;
-    let loadStarted = false;
-
-    const observer =
-      typeof ResizeObserver === "undefined"
-        ? undefined
-        : new ResizeObserver((entries) => {
-            const width = entries[0]?.contentRect.width;
-            if (width !== undefined) {
-              narrowChart = width < NARROW_CHART;
-              chartWidth = width;
-            }
-          });
-    observer?.observe(target);
-
-    const loadLivePlot = (): void => {
-      if (loadStarted || cancelled) return;
-      loadStarted = true;
-      void import("@ggsvelte/svelte").then((mod) => {
-        if (!cancelled) LivePlot = mod.GGPlot;
-      });
-    };
-
-    // Near-viewport only — do not idle-load. An early dynamic import + fold
-    // still monopolizes the main thread and stalls header clicks (#972).
-    const io = new IntersectionObserver(
-      (entries) => {
-        if (entries.some((entry) => entry.isIntersecting)) {
-          loadLivePlot();
-          io.disconnect();
-        }
-      },
-      { rootMargin: "240px 0px" },
-    );
-    io.observe(target);
-
-    return () => {
-      cancelled = true;
-      observer?.disconnect();
-      io.disconnect();
-    };
-  });
 </script>
 
 <article class="guide getting-started-guide">
@@ -197,25 +99,7 @@
           <a href={`${base}${step.href}`}>Read {step.chapterTitle}</a>
         </div>
         {#if isFinish}
-          <div class="finished-chart lesson-output" bind:this={finishedChart}>
-            {#if LivePlot && finished}
-              <LivePlot
-                spec={finished.spec}
-                key={finished.key}
-                inspect={finished.inspect}
-                height={liveHeight}
-                ariaLabel={`Kyoto cherry blossom, finished. Called out: ${recordNames}.`}
-              />
-            {:else}
-              <img
-                class="lesson-chart"
-                src={chartSrc(index)}
-                width={LESSON_CHART_WIDTH}
-                height={LESSON_CHART_HEIGHT}
-                alt={`Kyoto cherry blossom, finished. Called out: ${recordNames}.`}
-              />
-            {/if}
-          </div>
+          <LessonFinishedChart placeholderSrc={chartSrc(index)} />
         {:else}
           <div class="lesson-output">
             <img
@@ -267,14 +151,21 @@
     border-block: 1px solid var(--line);
   }
 
+  /*
+   * Static step panels are plain divs in this component. The finished chart is
+   * a child component whose root carries .finished-chart — style it with
+   * :global so scoped CSS still pads and separates that slot.
+   */
   .lesson-block > section,
-  .progressive-step > div {
+  .progressive-step > div,
+  .progressive-step > :global(.finished-chart) {
     min-width: 0;
     padding: 1rem;
   }
 
   .lesson-block > section + section,
-  .progressive-step > div + div {
+  .progressive-step > div + div,
+  .progressive-step > div + :global(.finished-chart) {
     border-top: 1px solid var(--line);
   }
 
@@ -289,15 +180,6 @@
     overflow: hidden;
     background: #fff;
     color: #172033;
-  }
-
-  /*
-   * The finished chart gains a tooltip and a pinned-value rail on hydration.
-   * Floor matches the narrow probe height (~280–320px), not the desktop one —
-   * over-reserving leaves empty space under a phone chart.
-   */
-  .finished-chart {
-    min-height: 18rem;
   }
 
   .lesson-label {
@@ -327,7 +209,7 @@
   /*
    * Translucent band fills do not survive forced-colors mode. Epoch names
    * remain available via the bottom legend (and the aria-label on the live
-   * chart).
+   * chart). The live finished chart carries the same rule in its own file.
    */
   @media (forced-colors: active) {
     .lesson-output :global(.gg-marks rect) {

--- a/apps/docs/src/lib/components/LessonFinishedChart.svelte
+++ b/apps/docs/src/lib/components/LessonFinishedChart.svelte
@@ -1,0 +1,176 @@
+<script lang="ts">
+  /**
+   * Live finished sakura chart for the getting-started lesson.
+   *
+   * Owns the 838-point fold lifecycle: measure the host, drop callouts when
+   * narrow, and load GGPlot only when near the viewport so mobile chrome stays
+   * tappable (#972). Intermediate step charts stay static SVGs in the guide.
+   */
+  import { onMount } from "svelte";
+
+  import {
+    foldSakura,
+    SAKURA_RECORDS,
+    SAKURA_STEPS,
+  } from "$scripts/quickstart";
+  import {
+    LESSON_CHART_HEIGHT,
+    LESSON_CHART_WIDTH,
+    sakuraFinishedHeight,
+  } from "$lib/generated/lesson-charts";
+  import { observeNearViewport } from "$lib/near-viewport";
+  import { kyotoSakura } from "@ggsvelte/svelte/data";
+
+  const {
+    placeholderSrc,
+  }: {
+    /** Build-time SVG shown until the live plot mounts. */
+    placeholderSrc: string;
+  } = $props();
+
+  const rows = kyotoSakura.map((row) => ({ ...row }));
+
+  /**
+   * Below this chart width, hand-placed callouts collide with the data, so the
+   * records move into the aria-label only (bands, trend and points never move).
+   * Measured on the chart container, never on the viewport.
+   */
+  const NARROW_CHART = 560;
+
+  /**
+   * Assume narrow until the host is measured. Starting at `false` forced a wide
+   * fold on first paint, then a second 838-point fold when ResizeObserver fired
+   * — on mobile that double work blocked chrome for ~17s before "Open site
+   * menu" was tappable (#972). Desktop still flips once (narrow → wide) when
+   * the container is actually wide enough for callouts.
+   *
+   * First paint uses the narrow probe height from the generated size table so
+   * we do not reserve a desktop-tall plot before ResizeObserver fires.
+   */
+  let narrowChart = $state(true);
+  /** Measured container width; drives live plot height via build-time chrome table. */
+  let chartWidth = $state(0);
+  let host = $state<HTMLElement>();
+  /** Live plot component — dynamically imported when near the viewport (#972). */
+  let LivePlot = $state<null | (typeof import("@ggsvelte/svelte"))["GGPlot"]>(
+    null,
+  );
+
+  /**
+   * Fold only when the live plot is mounted. Computing the 838-point spec
+   * during first hydrate (even behind a placeholder) blocked mobile chrome
+   * for ~20s (#972).
+   */
+  const finished = $derived(
+    LivePlot === null
+      ? null
+      : foldSakura(SAKURA_STEPS.length, rows, { annotations: !narrowChart }),
+  );
+
+  /**
+   * Outer plot height from the build-time size table (pipeline-measured chrome
+   * so the *data panel* stays ~2.5:1). Never invent chrome constants here —
+   * regenerating lesson charts refreshes the table.
+   */
+  const liveHeight = $derived(
+    sakuraFinishedHeight(chartWidth > 0 ? chartWidth : NARROW_CHART),
+  );
+
+  const recordNames = SAKURA_RECORDS.map((record) => record.label).join("; ");
+  const ariaLabel = `Kyoto cherry blossom, finished. Called out: ${recordNames}.`;
+
+  onMount(() => {
+    const target = host;
+    if (target === undefined) return;
+    let cancelled = false;
+    let loadStarted = false;
+
+    const observer =
+      typeof ResizeObserver === "undefined"
+        ? undefined
+        : new ResizeObserver((entries) => {
+            const width = entries[0]?.contentRect.width;
+            if (width !== undefined) {
+              narrowChart = width < NARROW_CHART;
+              chartWidth = width;
+            }
+          });
+    observer?.observe(target);
+
+    const loadLivePlot = (): void => {
+      if (loadStarted || cancelled) return;
+      loadStarted = true;
+      void import("@ggsvelte/svelte").then((mod) => {
+        if (!cancelled) LivePlot = mod.GGPlot;
+      });
+    };
+
+    // Shared helper — no idle-load. An early dynamic import + fold still
+    // monopolizes the main thread and stalls header clicks (#972).
+    // When IntersectionObserver is missing (SSR/tests), observeNearViewport
+    // fires immediately so the chart still upgrades, matching ThemeSpecimen.
+    const stopNear = observeNearViewport(target, loadLivePlot, {
+      rootMargin: "240px 0px",
+    });
+
+    return () => {
+      cancelled = true;
+      observer?.disconnect();
+      stopNear();
+    };
+  });
+</script>
+
+<div class="finished-chart lesson-output" bind:this={host}>
+  {#if LivePlot && finished}
+    <LivePlot
+      spec={finished.spec}
+      key={finished.key}
+      inspect={finished.inspect}
+      height={liveHeight}
+      {ariaLabel}
+    />
+  {:else}
+    <img
+      class="lesson-chart"
+      src={placeholderSrc}
+      width={LESSON_CHART_WIDTH}
+      height={LESSON_CHART_HEIGHT}
+      alt={ariaLabel}
+    />
+  {/if}
+</div>
+
+<style>
+  .lesson-output {
+    min-width: 0;
+    overflow: hidden;
+    background: #fff;
+    color: #172033;
+  }
+
+  /*
+   * The finished chart gains a tooltip and a pinned-value rail on hydration.
+   * Floor matches the narrow probe height (~280–320px), not the desktop one —
+   * over-reserving leaves empty space under a phone chart.
+   */
+  .finished-chart {
+    min-height: 18rem;
+  }
+
+  .lesson-chart {
+    display: block;
+    width: 100%;
+    height: auto;
+  }
+
+  /*
+   * Translucent band fills do not survive forced-colors mode. Epoch names
+   * remain available via the aria-label on the live chart.
+   */
+  @media (forced-colors: active) {
+    .lesson-output :global(.gg-marks rect) {
+      fill: none;
+    }
+  }
+</style>

--- a/scripts/ci-routing.test.ts
+++ b/scripts/ci-routing.test.ts
@@ -144,6 +144,7 @@ describe("classifyChangedPaths", () => {
       "apps/docs/src/lib/catalog/guide.ts",
       "apps/docs/src/lib/guide.ts",
       "apps/docs/src/lib/components/GettingStartedGuide.svelte",
+      "apps/docs/src/lib/components/LessonFinishedChart.svelte",
       "apps/docs/src/lib/catalog/docs-tasks.ts",
       // Sibling generated inventory modules are content-only (#784 lesson-charts).
       "apps/docs/src/lib/generated/lesson-charts.ts",
@@ -232,6 +233,7 @@ describe("planJobs", () => {
       "scripts/llms-guide-content.ts",
       "apps/docs/src/lib/catalog/guide.ts",
       "apps/docs/src/lib/components/GettingStartedGuide.svelte",
+      "apps/docs/src/lib/components/LessonFinishedChart.svelte",
     ]) {
       const plan = planJobs(classifyChangedPaths([path]));
       expect(plan.unit, path).toBe(true);

--- a/scripts/ci-routing/routing.ts
+++ b/scripts/ci-routing/routing.ts
@@ -72,6 +72,7 @@ export const DOCS_CONTENT_ONLY_PATHS: readonly string[] = [
   "apps/docs/src/lib/catalog/themes.ts",
   "apps/docs/src/lib/guide.ts",
   "apps/docs/src/lib/components/GettingStartedGuide.svelte",
+  "apps/docs/src/lib/components/LessonFinishedChart.svelte",
   "apps/docs/src/lib/generated/search-index.ts",
   "apps/docs/src/lib/generated/routes.ts",
   "apps/docs/src/lib/generated/gallery-previews.ts",


### PR DESCRIPTION
## Summary

- Pull the live finished Kyoto chart (838-point fold, ResizeObserver, near-viewport GGPlot load) out of `GettingStartedGuide.svelte` into `LessonFinishedChart.svelte`.
- Reuse `$lib/near-viewport` so the guide matches theme/palette specimens instead of a hand-rolled IntersectionObserver.
- Keep the `.finished-chart` root class for progressive-search VR and register the new file as docs content-only (no VR on prose-only edits).

## Why

The guide mixed page structure with the expensive live-plot lifecycle. That made layout edits and chart-lifecycle edits fight in one file. The guide is now prose + static step images; the finished chart owns its own mount path.

## Test plan

- [x] `bun test scripts/ci-routing.test.ts scripts/getting-started-headings.test.ts scripts/sakura-lesson.test.ts scripts/near-viewport.test.ts`
- [ ] CI green on this PR
- [ ] Getting-started: finish step still shows placeholder then upgrades near viewport; `.finished-chart` present for VR

## Follow-ups (same workstream)

After this lands: fix the corrupted first two lesson charts (missing month-day y scale on early folds) and move epoch names above the band rects without shrinking data coverage.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1129" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->