### PR TITLE
fix(docs): strip themes page slop and mismatched hero code block

### DIFF
--- a/apps/docs/src/lib/components/ChartThemeLab.svelte
+++ b/apps/docs/src/lib/components/ChartThemeLab.svelte
@@ -3,13 +3,11 @@
   import { onMount } from "svelte";
 
   import { CATEGORICAL_PALETTES, THEME_OPTIONS } from "$lib/catalog/themes";
-  import CopyCode from "$lib/components/CopyCode.svelte";
   import {
     readDocsAppearance,
     watchDocsAppearance,
     type DocsAppearance,
   } from "$lib/docs-appearance";
-  import { heroThemePaletteSnippet } from "$lib/theme-specimens/snippets";
 
   type SchemeName = (typeof CATEGORICAL_PALETTES)[number]["name"];
 
@@ -31,8 +29,6 @@
   const resolvedTheme = $derived<ThemeName>(
     followDocs ? siteAppearance : explicitTheme,
   );
-
-  const code = $derived(heroThemePaletteSnippet(resolvedTheme, scheme));
 
   const statusText = $derived(
     followDocs
@@ -62,14 +58,6 @@
 </script>
 
 <section class="theme-lab" aria-label="Chart theme and palette lab">
-  <p class="eyebrow">Live</p>
-  <h2>Try theme and palette</h2>
-  <p class="lede">
-    <code>theme</code> styles paper, grid, axes, and type.
-    <code>scales.color.scheme</code> colors series. Docs light/dark only applies when
-    Follow docs appearance is on.
-  </p>
-
   <div class="plot-panel">
     {#if LiveTemps !== null}
       <LiveTemps
@@ -108,14 +96,6 @@
   </div>
 
   <p class="resolved" role="status">{statusText}</p>
-
-  <div class="code-footer">
-    <CopyCode
-      {code}
-      language="svelte"
-      accessibleLabel="Copy selected theme and palette code"
-    />
-  </div>
 </section>
 
 <style>
@@ -126,38 +106,9 @@
     padding-block: clamp(1.5rem, 4vw, 2.5rem) clamp(2.5rem, 6vw, 4rem);
   }
 
-  .eyebrow {
-    margin: 0;
-    color: var(--muted);
-    font-size: 0.72rem;
-    font-weight: 650;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-  }
-
-  h2 {
-    margin: 0;
-    font-size: clamp(1.5rem, 3vw, 2rem);
-    line-height: 1.05;
-    letter-spacing: -0.02em;
-  }
-
-  .lede {
-    margin: 0;
-    max-width: 40rem;
-    color: var(--muted);
-    font-size: 0.98rem;
-    line-height: 1.45;
-  }
-
-  .lede code {
-    font-size: 0.9em;
-  }
-
   .plot-panel {
     width: min(100%, 52rem);
     min-width: 0;
-    margin-top: 0.5rem;
   }
 
   .plot-panel :global(svg) {
@@ -219,10 +170,5 @@
     color: var(--muted);
     font-size: 0.82rem;
     font-family: var(--code-font);
-  }
-
-  .code-footer {
-    width: min(100%, 52rem);
-    min-width: 0;
   }
 </style>

--- a/apps/docs/src/lib/components/TemperaturesSpecimen.svelte
+++ b/apps/docs/src/lib/components/TemperaturesSpecimen.svelte
@@ -4,7 +4,8 @@
     GeomPoint,
     GGPlot,
     Labs,
-    Scale,
+    ScaleColorDiscrete,
+    ScaleXContinuous,
     Theme,
   } from "@ggsvelte/svelte";
   import type { ThemeName } from "@ggsvelte/spec";
@@ -40,12 +41,8 @@
   {ariaLabel}
 >
   <Theme name={theme} />
-  <Scale
-    value={{
-      x: { breaks: [...chart.monthBreaks] },
-      color: { type: "ordinal", scheme },
-    }}
-  />
+  <ScaleXContinuous breaks={[...chart.monthBreaks]} />
+  <ScaleColorDiscrete {scheme} />
   <Labs
     title={chart.labs.title}
     x={chart.labs.x}

--- a/apps/docs/src/lib/theme-specimens/snippets.ts
+++ b/apps/docs/src/lib/theme-specimens/snippets.ts
@@ -1,55 +1,7 @@
 /**
- * Consumer-facing code fragments for the themes page.
+ * Consumer-facing code fragments for the palettes page.
  * Kept outside .svelte so the compiler never sees a literal </script> close tag.
- *
- * The hero temperatures snippet is built from TEMPERATURES_CHART so it cannot
- * drift from what TemperaturesSpecimen renders (#990).
  */
-
-import { formatMonthBreaksLiteral, TEMPERATURES_CHART } from "./temperatures-chart.js";
-
-export function heroThemePaletteSnippet(theme: string, scheme: string): string {
-  const chart = TEMPERATURES_CHART;
-  const breaks = formatMonthBreaksLiteral(chart.monthBreaks);
-  return `<script lang="ts">
-  import { GeomLine, GeomPoint, GGPlot, Labs, Scale, Theme } from "@ggsvelte/svelte";
-
-  const temperatures = [
-    { city: "Price of stocks", month: 1770, temp: 79.6 },
-    { city: "Price of stocks", month: 1820, temp: 68.59 },
-    { city: "Price of bread", month: 1770, temp: 23.47 },
-    { city: "Price of bread", month: 1820, temp: 48.39 },
-    { city: "Exports", month: 1770, temp: 11.58 },
-    { city: "Exports", month: 1820, temp: 50.18 },
-    // …full series in your app
-  ];
-</script>
-
-<GGPlot
-  data={temperatures}
-  aes={{ x: "${chart.aes.x}", y: "${chart.aes.y}", color: "${chart.aes.color}" }}
-  key="${chart.key}"
-  inspect={{ mode: "${chart.inspect.mode}" }}
-  legendFocus
-  height={400}
->
-  <Theme name="${theme}" />
-  <Scale
-    value={{
-      x: { breaks: ${breaks} },
-      color: { type: "ordinal", scheme: "${scheme}" },
-    }}
-  />
-  <Labs
-    title="${chart.labs.title}"
-    x="${chart.labs.x}"
-    y="${chart.labs.y}"
-    color="${chart.labs.color}"
-  />
-  <GeomLine linewidth={${String(chart.geomLine.linewidth)}} />
-  <GeomPoint size={${String(chart.geomPoint.size)}} />
-</GGPlot>`;
-}
 
 export const SEQUENTIAL_RASTER_SNIPPET = `<script lang="ts">
   import { GeomRaster, GGPlot, Labs, Scale } from "@ggsvelte/svelte";

--- a/apps/docs/src/lib/theme-specimens/temperatures-chart.ts
+++ b/apps/docs/src/lib/theme-specimens/temperatures-chart.ts
@@ -1,7 +1,6 @@
 /**
  * Single source of truth for the themes-page multi-series chart (Playfair 1824).
- * The live `<TemperaturesSpecimen>` and the copyable `heroThemePaletteSnippet`
- * both read from here so the snippet cannot drift from what the page renders.
+ * Live `<TemperaturesSpecimen>` and static SVG prerender both read from here.
  */
 import { MONTH_BREAKS } from "./catalog.js";
 
@@ -20,10 +19,3 @@ export const TEMPERATURES_CHART = {
   /** Year axis breaks shared with the rendered charts. */
   monthBreaks: MONTH_BREAKS,
 } as const;
-
-/** Format year breaks for a consumer-facing Scale value literal. */
-export function formatMonthBreaksLiteral(
-  breaks: readonly number[] = TEMPERATURES_CHART.monthBreaks,
-): string {
-  return `[${breaks.join(", ")}]`;
-}

--- a/apps/docs/src/routes/themes/+page.svelte
+++ b/apps/docs/src/routes/themes/+page.svelte
@@ -13,15 +13,6 @@
   <header class="themes-intro">
     <p class="eyebrow">Themes</p>
     <h1>Chart themes</h1>
-    <p>
-      Chart themes style paper, grids, axes, and type. Data color lives on
-      <a href={`${base}/palettes`}>palettes</a>. Site light/dark is separate
-      unless you wire them yourself.
-    </p>
-    <p class="guide-link">
-      Scale and color channel reference:
-      <a href={`${base}/guide/scales-guides`}>Scales and guides</a>.
-    </p>
   </header>
 
   <ChartThemeLab initialStaticSvg={data.labStaticSvg} />
@@ -89,30 +80,10 @@
   }
 
   .themes-intro h1 {
-    margin: 0.25rem 0 0.75rem;
+    margin: 0.25rem 0 0;
     font-size: clamp(2.25rem, 5vw, 3.5rem);
     line-height: 0.95;
     letter-spacing: -0.03em;
-  }
-
-  .themes-intro > p:not(.eyebrow, .guide-link) {
-    margin: 0;
-    color: var(--muted);
-    font-size: 1.02rem;
-  }
-
-  .themes-intro a {
-    color: var(--ink);
-  }
-
-  .guide-link {
-    margin: 0.85rem 0 0;
-    color: var(--muted);
-    font-size: 0.92rem;
-  }
-
-  .guide-link a {
-    color: var(--ink);
   }
 
   .eyebrow {

--- a/scripts/repo-child-layers.test.ts
+++ b/scripts/repo-child-layers.test.ts
@@ -27,10 +27,7 @@ import { deprecatedGrammarPropPattern } from "../packages/svelte/src/lib/layers/
 import { guidePages, type LifecycleDoc } from "./gen-llms.ts";
 import { codeBlocks } from "./guide-code-contract.ts";
 import { foldSakura, QUICKSTART_PAGE_FILENAME, SAKURA_STEPS } from "./quickstart.ts";
-import {
-  heroThemePaletteSnippet,
-  SEQUENTIAL_RASTER_SNIPPET,
-} from "../apps/docs/src/lib/theme-specimens/snippets.ts";
+import { SEQUENTIAL_RASTER_SNIPPET } from "../apps/docs/src/lib/theme-specimens/snippets.ts";
 
 const ROOT = join(import.meta.dir, "..");
 
@@ -77,16 +74,15 @@ describe("the repo's own charts use child layers, not deprecated grammar props",
     });
   }
 
-  // Whole files the themes page offers for copying, assembled as strings so
+  // Whole files the palettes page offers for copying, assembled as strings so
   // the Svelte compiler never sees their literal </script> tags — which also
   // puts them out of reach of the .svelte walk above.
   const SNIPPETS: readonly (readonly [string, string])[] = [
-    ["heroThemePaletteSnippet", heroThemePaletteSnippet("tufte", "observable10")],
     ["SEQUENTIAL_RASTER_SNIPPET", SEQUENTIAL_RASTER_SNIPPET],
   ];
 
   for (const [name, source] of SNIPPETS) {
-    it(`the ${name} the themes page offers for copying needs no migration`, () => {
+    it(`the ${name} the docs offer for copying needs no migration`, () => {
       const result = migratePlotProps(source);
       expect({
         rewritable: result.changes.map((c) => c.prop),

--- a/scripts/themes-page.test.ts
+++ b/scripts/themes-page.test.ts
@@ -11,11 +11,7 @@ import {
   RASTER_Z_DOMAIN,
   THEME_SPECIMENS,
 } from "../apps/docs/src/lib/theme-specimens/catalog.ts";
-import { heroThemePaletteSnippet } from "../apps/docs/src/lib/theme-specimens/snippets.ts";
-import {
-  formatMonthBreaksLiteral,
-  TEMPERATURES_CHART,
-} from "../apps/docs/src/lib/theme-specimens/temperatures-chart.ts";
+import { TEMPERATURES_CHART } from "../apps/docs/src/lib/theme-specimens/temperatures-chart.ts";
 
 describe("themes catalog", () => {
   it("projects every public theme and categorical palette without docs-owned colors", () => {
@@ -335,14 +331,8 @@ describe("themes catalog", () => {
   });
 });
 
-describe("hero temperatures chart and copy snippet stay aligned (#990)", () => {
-  it("generates a snippet with the same key and month breaks the component renders", () => {
-    const snippet = heroThemePaletteSnippet("tufte", "observable10");
-    expect(snippet).toContain(`key="${TEMPERATURES_CHART.key}"`);
-    expect(snippet).toContain(
-      `x: { breaks: ${formatMonthBreaksLiteral(TEMPERATURES_CHART.monthBreaks)} }`,
-    );
-    // Shared config is what TemperaturesSpecimen spreads into Scale/GGPlot.
+describe("hero temperatures chart config", () => {
+  it("keeps key and month breaks stable for TemperaturesSpecimen", () => {
     expect(TEMPERATURES_CHART.key).toBe("id");
     expect([...TEMPERATURES_CHART.monthBreaks]).toEqual([...MONTH_BREAKS]);
   });

--- a/tests/visual/docs-themes.spec.ts
+++ b/tests/visual/docs-themes.spec.ts
@@ -43,25 +43,6 @@ test("palettes is a first-class route from site navigation and the homepage", as
   ).toHaveAttribute("href", /\/palettes$/);
 });
 
-test("theme code uses the shared manual-copy fallback", async ({ page }) => {
-  await page.addInitScript(() => {
-    Object.defineProperty(navigator, "clipboard", {
-      configurable: true,
-      value: { writeText: () => Promise.reject(new DOMException("Denied", "NotAllowedError")) },
-    });
-  });
-  await page.goto("/themes?theme=light");
-  // Only the hero lab retains a CopyCode block after the showcase overhaul.
-  const lab = page.getByRole("region", { name: "Chart theme and palette lab" });
-  await lab.getByRole("button", { name: "Copy selected theme and palette code" }).click();
-  await expect(lab.getByRole("status").filter({ hasText: "Clipboard unavailable" })).toHaveText(
-    "Clipboard unavailable. Code selected for manual copy.",
-  );
-  expect(await page.evaluate(() => getSelection()?.toString())).toContain(
-    '<Theme name="default" />',
-  );
-});
-
 test("themes compares all built-in chart themes as full-width interactive portraits", async ({
   page,
 }) => {
@@ -116,12 +97,12 @@ test("chart theme stays separate until follow-docs appearance is explicit", asyn
   const chartPaper = () => plot.locator(".gg-paper").getAttribute("fill");
 
   await chartTheme.selectOption("economist");
-  await expect(lab.locator(".copy-code code")).toContainText('<Theme name="economist" />');
+  await expect(lab.getByRole("status")).toContainText('theme="economist"');
   await expect.poll(chartPaper).toBe("var(--gg-paper, #d5e4eb)");
   // Palette is independent of theme.
   await palette.selectOption("tableau10");
-  await expect(lab.locator(".copy-code code")).toContainText('scheme: "tableau10"');
-  await expect(lab.locator(".copy-code code")).toContainText('<Theme name="economist" />');
+  await expect(lab.getByRole("status")).toContainText('scheme="tableau10"');
+  await expect(lab.getByRole("status")).toContainText('theme="economist"');
 
   await page.getByRole("button", { name: "Dark appearance" }).click();
   await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
@@ -131,7 +112,6 @@ test("chart theme stays separate until follow-docs appearance is explicit", asyn
   await expect(lab.getByRole("status").filter({ hasText: "follows site" })).toContainText(
     'scheme="tableau10"',
   );
-  await expect(lab.locator(".copy-code code")).toContainText('<Theme name="dark" />');
   await expect.poll(chartPaper).toBe("var(--gg-paper, #16181d)");
   await page.getByRole("button", { name: "Light appearance" }).click();
   await expect.poll(chartPaper).toBe("var(--gg-paper, #ffffff)");


### PR DESCRIPTION
## Summary
- Delete the mismatched hero `CopyCode` block and the stubbed temperature inline data that never matched the chart above it.
- Remove the LIVE / Try theme / lede / site-vs-chart / Scales-and-guides slop from the themes route.
- Point the live Playfair specimen at `ScaleXContinuous` + `ScaleColorDiscrete` instead of a raw `<Scale value={…}>` bag.

## Test plan
- [x] `bun test scripts/themes-page.test.ts scripts/repo-child-layers.test.ts`
- [ ] Themes lab still swaps chart theme and categorical palette
- [ ] Follow docs appearance still drives light/dark paper without a code footer
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1131" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->