### PR TITLE
fix(ci): block changesets on docs/examples-only PRs

### DIFF
--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -1,16 +1,20 @@
-# Changeset visibility — non-blocking, in-repo changeset-bot equivalent.
+# Changeset visibility — in-repo changeset-bot equivalent.
 # All third-party actions pinned by full commit SHA (zizmor-enforced).
 #
 # Changesets only records PRs that add a .changeset/*.md file; every other PR
 # merges silently with no CHANGELOG entry and no version-bump influence
 # (release PR #45 shipped ~200 PRs with 4 entries). Decision logic and the
 # comment body live in scripts/changeset-check.ts (unit tested by
-# scripts/changeset-check.test.ts); this workflow only computes the PR diff
-# and syncs one sticky comment.
+# scripts/changeset-check.test.ts); this workflow only computes the PR diff,
+# syncs one sticky comment, and fails when a changeset is unwarranted.
 #
-# Deliberately NOT a merge gate: internal-only changes are the common case in
-# this repo, and forcing contributors to commit empty changesets is worse
-# than an ignorable comment. The job succeeds on every verdict.
+# Two policies, deliberately asymmetric:
+# - missing (package code, no changeset): advisory sticky comment only.
+#   Internal-only package changes are common; forcing empty changesets is
+#   worse than an ignorable comment.
+# - unwarranted (changeset, no shipped package paths): sticky comment AND
+#   job failure. Docs/examples-only changesets have polluted Version Packages
+#   and bumped core/spec/svelte with notes that change nothing for consumers.
 name: Changeset check
 
 on:
@@ -76,13 +80,13 @@ jobs:
             --jq '.[] | select(.body | contains("<!-- ggsvelte-changeset-check -->")) | .id' |
             head -n1)
           body_file="${RUNNER_TEMP}/changeset-comment.md"
-          if [ "${VERDICT}" = "missing" ]; then
+          if [ "${VERDICT}" = "missing" ] || [ "${VERDICT}" = "unwarranted" ]; then
             if [ -n "${existing_id}" ]; then
               gh api --method PATCH "repos/${REPO}/issues/comments/${existing_id}" -F "body=@${body_file}" > /dev/null
             else
               gh api --method POST "repos/${REPO}/issues/${PR_NUMBER}/comments" -F "body=@${body_file}" > /dev/null
             fi
-            echo "verdict=missing — sticky comment synced"
+            echo "verdict=${VERDICT} — sticky comment synced"
           elif [ -n "${existing_id}" ]; then
             # A comment from an earlier push is stale — update it to the
             # resolved wording instead of leaving a false warning.
@@ -91,3 +95,9 @@ jobs:
           else
             echo "verdict=${VERDICT} — nothing to comment"
           fi
+      - name: fail when changeset is unwarranted
+        if: steps.decide.outputs.verdict == 'unwarranted'
+        shell: bash
+        run: |
+          echo "::error::Changeset present but no shipped package paths changed (verdict=unwarranted). Delete the .changeset/*.md file(s)."
+          exit 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -474,6 +474,21 @@ PR gets one opened rather than a silent skip. The three-way decision
 (skip / open the PR / render, push, open the PR) lives in
 `scripts/vr-approve-decision.ts` and is unit-tested.
 
+## Changesets (when to add one)
+
+Add a `.changeset/*.md` **only** when the PR changes an npm-published package
+surface — the same paths `scripts/changeset-check.ts` treats as shipped
+(`package.json` or that package’s `files` entries under `packages/{core,spec,svelte}`).
+Spec, core, and svelte version in **fixed lockstep**, so one real (or spurious)
+changeset advances all three package versions.
+
+**Do not** add a changeset for docs site, examples, scripts, tests, CI, or
+guide content alone (`apps/docs/**`, `examples/**`, `scripts/quickstart/**`,
+lesson SVGs, gallery previews, VR baselines, …). Those PRs must not bump
+packages. The Changeset check workflow fails with verdict `unwarranted` if they
+do. Packaged agent skills under `packages/svelte/skills/` _do_ ship and may
+warrant a patch. Missing changesets on package code stay advisory only.
+
 ## Lifecycle policy (Hadley lesson 13)
 
 Every public export of `@ggsvelte/spec`, `@ggsvelte/core` (both entries), and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -478,9 +478,12 @@ PR gets one opened rather than a silent skip. The three-way decision
 
 Add a `.changeset/*.md` **only** when the PR changes an npm-published package
 surface — the same paths `scripts/changeset-check.ts` treats as shipped
-(`package.json` or that package’s `files` entries under `packages/{core,spec,svelte}`).
-Spec, core, and svelte version in **fixed lockstep**, so one real (or spurious)
-changeset advances all three package versions.
+(`package.json`, that package’s npm `files` entries under
+`packages/{core,spec,svelte}`, and — for packages that publish compiled
+`dist` without listing `src` — the package’s `src/` tree that builds into
+`dist`, e.g. `packages/svelte/src/**`). Spec, core, and svelte version in
+**fixed lockstep**, so one real (or spurious) changeset advances all three
+package versions.
 
 **Do not** add a changeset for docs site, examples, scripts, tests, CI, or
 guide content alone (`apps/docs/**`, `examples/**`, `scripts/quickstart/**`,

--- a/scripts/changeset-check.test.ts
+++ b/scripts/changeset-check.test.ts
@@ -83,6 +83,27 @@ describe("decideChangesetComment", () => {
     expect(decision.verdict).toBe("changeset-present");
   });
 
+  // Regression: Devin review on #1132 — @ggsvelte/svelte publishes compiled
+  // dist/ (gitignored), so files is [dist, bin, skills] with no src. Without
+  // mapping src → shipped surface, real svelte fixes + changesets got
+  // unwarranted and the new gate blocked them.
+  it("treats svelte src as shipped when package only lists dist (compiled)", () => {
+    const decision = decideChangesetComment(
+      [".changeset/interval-bounds-editor.md", "packages/svelte/src/lib/interval/bounds-editor.ts"],
+      PACKAGES,
+    );
+    expect(decision.verdict).toBe("changeset-present");
+  });
+
+  it("reports missing for svelte src-only edits without a changeset", () => {
+    const decision = decideChangesetComment(
+      ["packages/svelte/src/lib/interval/bounds-editor.ts"],
+      PACKAGES,
+    );
+    expect(decision.verdict).toBe("missing");
+    expect(decision.touched).toEqual(["packages/svelte/src/lib/interval/bounds-editor.ts"]);
+  });
+
   it("stays quiet for changes outside shipped package surfaces", () => {
     const decision = decideChangesetComment(
       [

--- a/scripts/changeset-check.test.ts
+++ b/scripts/changeset-check.test.ts
@@ -21,12 +21,40 @@ const PACKAGES = [
 ];
 
 describe("decideChangesetComment", () => {
-  it("reports changeset-present when the PR adds a changeset file", () => {
+  it("reports changeset-present when the PR adds a changeset and shipped code", () => {
     const decision = decideChangesetComment(
       [".changeset/my-change.md", "packages/core/src/scales.ts"],
       PACKAGES,
     );
     expect(decision.verdict).toBe("changeset-present");
+  });
+
+  it("reports unwarranted when a changeset lands without shipped package paths", () => {
+    // Regression: #1116 quickstart-only + kyoto-annotation-polish changeset.
+    const decision = decideChangesetComment(
+      [
+        ".changeset/kyoto-annotation-polish.md",
+        "apps/docs/src/lib/generated/lesson-charts.ts",
+        "scripts/quickstart/steps.ts",
+        "tests/visual/docs-progressive-search.spec.ts",
+      ],
+      PACKAGES,
+    );
+    expect(decision.verdict).toBe("unwarranted");
+    expect(decision.touched).toEqual([]);
+  });
+
+  it("reports unwarranted for examples-only changesets (canvas-scatter VR budget)", () => {
+    const decision = decideChangesetComment(
+      [
+        ".changeset/926-canvas-scatter-vr-budget.md",
+        "examples/point/canvas-scatter/Example.svelte",
+        "examples/point/canvas-scatter/data.ts",
+        "examples/manifest.ts",
+      ],
+      PACKAGES,
+    );
+    expect(decision.verdict).toBe("unwarranted");
   });
 
   it("reports missing when shipped package code changes without a changeset", () => {
@@ -45,6 +73,14 @@ describe("decideChangesetComment", () => {
     const decision = decideChangesetComment(["packages/svelte/package.json"], PACKAGES);
     expect(decision.verdict).toBe("missing");
     expect(decision.touched).toEqual(["packages/svelte/package.json"]);
+  });
+
+  it("treats packaged agent skills as shipped (changeset ok)", () => {
+    const decision = decideChangesetComment(
+      [".changeset/skill-rewrite.md", "packages/svelte/skills/ggsvelte/SKILL.md"],
+      PACKAGES,
+    );
+    expect(decision.verdict).toBe("changeset-present");
   });
 
   it("stays quiet for changes outside shipped package surfaces", () => {
@@ -78,6 +114,14 @@ describe("decideChangesetComment", () => {
     );
     expect(decision.verdict).toBe("missing");
   });
+
+  it("unwarranted ignores .changeset/README.md alone", () => {
+    const decision = decideChangesetComment(
+      [".changeset/README.md", "apps/docs/src/routes/+page.svelte"],
+      PACKAGES,
+    );
+    expect(decision.verdict).toBe("not-needed");
+  });
 });
 
 describe("changeset-check workflow wiring", () => {
@@ -100,9 +144,16 @@ describe("changeset-check workflow wiring", () => {
     );
   });
 
-  it("stays non-blocking and syncs one sticky comment via the shared marker", () => {
-    expect(workflow).not.toContain("exit 1");
+  it("syncs sticky comments for missing and unwarranted; fails only on unwarranted", () => {
     expect(workflow).toContain(COMMENT_MARKER);
+    // Comment both advisory-missing and blocking-unwarranted.
+    expect(workflow).toContain('"${VERDICT}" = "missing"');
+    expect(workflow).toContain('"${VERDICT}" = "unwarranted"');
+    // Hard fail only for the docs/examples false-positive path.
+    expect(workflow).toContain("steps.decide.outputs.verdict == 'unwarranted'");
+    expect(workflow).toContain("exit 1");
+    // Missing remains advisory — the fail step is gated on unwarranted only.
+    expect(workflow).not.toContain("steps.decide.outputs.verdict == 'missing'");
   });
 });
 
@@ -127,6 +178,29 @@ describe("emit CLI", () => {
     expect(result.exitCode).toBe(0);
     expect(readFileSync(outputFile, "utf8")).toContain("verdict=missing");
     expect(readFileSync(bodyFile, "utf8")).toContain("packages/core/src/scales.ts");
+  });
+
+  it("emits unwarranted for docs-only + changeset without failing the emit process", () => {
+    // Fail happens in the workflow after the sticky comment syncs.
+    const dir = mkdtempSync(join(tmpdir(), "changeset-check-unw-"));
+    const outputFile = join(dir, "github-output");
+    const bodyFile = join(dir, "comment.md");
+    writeFileSync(outputFile, "");
+    const result = Bun.spawnSync({
+      cmd: [
+        "bun",
+        join(root, "scripts/changeset-check.ts"),
+        "emit",
+        "--stdin",
+        "--body-out",
+        bodyFile,
+      ],
+      stdin: Buffer.from(".changeset/docs-only.md\napps/docs/src/routes/+page.svelte\n"),
+      env: { ...process.env, GITHUB_OUTPUT: outputFile },
+    });
+    expect(result.exitCode).toBe(0);
+    expect(readFileSync(outputFile, "utf8")).toContain("verdict=unwarranted");
+    expect(readFileSync(bodyFile, "utf8")).toContain("Changeset not allowed");
   });
 });
 
@@ -158,7 +232,7 @@ describe("renderComment", () => {
     expect(body).toContain("4 more");
   });
 
-  it("acknowledges a changeset once one is added", () => {
+  it("acknowledges a changeset once one is added with shipped code", () => {
     const body = renderComment({ verdict: "changeset-present", touched: [] });
     expect(body).toContain(COMMENT_MARKER);
     expect(body).toContain("Changeset detected");
@@ -168,5 +242,13 @@ describe("renderComment", () => {
     const body = renderComment({ verdict: "not-needed", touched: [] });
     expect(body).toContain(COMMENT_MARKER);
     expect(body).toContain("No changeset needed");
+  });
+
+  it("explains and blocks an unwarranted docs/examples changeset", () => {
+    const body = renderComment({ verdict: "unwarranted", touched: [] });
+    expect(body).toContain(COMMENT_MARKER);
+    expect(body).toContain("Changeset not allowed");
+    expect(body).toContain("delete the `.changeset/*.md`");
+    expect(body).toContain("blocks");
   });
 });

--- a/scripts/changeset-check.ts
+++ b/scripts/changeset-check.ts
@@ -1,14 +1,22 @@
 /**
- * Changeset visibility check — non-blocking changeset-bot equivalent.
+ * Changeset visibility check — in-repo changeset-bot equivalent.
  *
  * Changesets only records PRs that add a `.changeset/*.md` file; a PR without
  * one merges silently and never reaches the CHANGELOG or a version bump
  * (release PR #45 shipped ~200 PRs with 4 changelog entries). This script
- * decides whether a PR touches npm-published code without declaring a
- * changeset so the workflow can leave a sticky informational comment.
+ * classifies a PR so the workflow can leave a sticky comment — and fail when
+ * a changeset would pollute Version Packages for docs/examples-only work.
  *
- * Deliberately NOT a merge gate: internal-only changes are the common case in
- * this repo and forcing empty changesets is worse than an ignorable comment.
+ * Verdicts:
+ * - `changeset-present` — has a changeset and touches shipped package code
+ * - `missing` — touches shipped package code, no changeset (advisory only)
+ * - `not-needed` — no shipped package code, no changeset
+ * - `unwarranted` — has a changeset but no shipped package code (blocks merge)
+ *
+ * Missing stays non-blocking: internal-only package changes are common and
+ * forcing empty changesets is worse than an ignorable comment. Unwarranted
+ * blocks: docs/examples/script-only changesets have repeatedly bumped
+ * core/spec/svelte with notes that change nothing consumers import.
  */
 
 import { appendFileSync, existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
@@ -22,11 +30,11 @@ export type PublishedPackage = {
   shipped: string[];
 };
 
-export type Verdict = "changeset-present" | "not-needed" | "missing";
+export type Verdict = "changeset-present" | "not-needed" | "missing" | "unwarranted";
 
 export type Decision = {
   verdict: Verdict;
-  /** Published files the PR touches (empty unless verdict is "missing"). */
+  /** Published files the PR touches (set for `missing`; empty otherwise). */
   touched: string[];
 };
 
@@ -68,6 +76,28 @@ export function renderComment(decision: Decision): string {
   if (decision.verdict === "not-needed") {
     return `${COMMENT_MARKER}\n**No changeset needed.** This PR does not touch npm-published package code.\n`;
   }
+  if (decision.verdict === "unwarranted") {
+    return [
+      COMMENT_MARKER,
+      "🚫 **Changeset not allowed here.** This PR adds a `.changeset/*.md` file",
+      "but does **not** change any npm-published package surface.",
+      "",
+      "Docs site, examples, scripts, tests, and CI-only paths must not carry a",
+      "changeset — they pollute the next Version Packages PR and bump",
+      "`@ggsvelte/core` / `@ggsvelte/spec` / `@ggsvelte/svelte` (fixed lockstep)",
+      "with notes that do not change what consumers install.",
+      "",
+      "**Fix:** delete the `.changeset/*.md` file(s) from this PR.",
+      "",
+      "Add a changeset only when the diff touches a published package's",
+      "`files` entries (or its `package.json`) — same rule as",
+      "`scripts/changeset-check.ts`. Packaged agent skills under",
+      "`packages/svelte/skills/` *do* ship and may warrant a patch.",
+      "",
+      "This check **blocks** merging until the unwarranted changeset is removed.",
+      "",
+    ].join("\n");
+  }
   const shown = decision.touched.slice(0, LISTING_CAP).map((f) => `- \`${f}\``);
   const rest = decision.touched.length - LISTING_CAP;
   if (rest > 0) {
@@ -87,8 +117,9 @@ export function renderComment(decision: Decision): string {
     "bun changeset",
     "```",
     "",
-    "This check does **not block** merging — internal-only or",
-    "not-worth-announcing changes can ignore it.",
+    "This check does **not block** merging for a missing changeset — internal-only",
+    "or not-worth-announcing package changes can ignore it. A changeset on a",
+    "docs/examples-only PR *does* block (verdict `unwarranted`).",
     "",
   ].join("\n");
 }
@@ -109,10 +140,14 @@ export function decideChangesetComment(
   changedFiles: string[],
   packages: PublishedPackage[],
 ): Decision {
-  if (changedFiles.some((path) => isChangesetFile(path))) {
-    return { verdict: "changeset-present", touched: [] };
-  }
+  const hasChangeset = changedFiles.some((path) => isChangesetFile(path));
   const touched = changedFiles.filter((path) => packages.some((pkg) => isShippedPath(path, pkg)));
+  if (hasChangeset) {
+    if (touched.length > 0) {
+      return { verdict: "changeset-present", touched: [] };
+    }
+    return { verdict: "unwarranted", touched: [] };
+  }
   if (touched.length > 0) {
     return { verdict: "missing", touched };
   }

--- a/scripts/changeset-check.ts
+++ b/scripts/changeset-check.ts
@@ -133,7 +133,20 @@ function isShippedPath(path: string, pkg: PublishedPackage): boolean {
   // Colocated test files live under src/ but are not part of the consumer
   // surface a changelog entry describes.
   if (/\.(test|spec)\.[jt]sx?$/.test(path)) return false;
-  return pkg.shipped.some((dir) => path.startsWith(`${pkg.dir}/${dir}/`));
+  if (pkg.shipped.some((dir) => path.startsWith(`${pkg.dir}/${dir}/`))) return true;
+  // Packages that publish compiled dist (not source) still change consumers
+  // via src/. dist/ is usually gitignored, so git diffs never list it —
+  // map src/ → shipped surface when files lists dist but not src.
+  // (@ggsvelte/svelte: files=["dist","bin","skills"]; build = svelte-package
+  // -i src/lib -o dist.)
+  if (
+    pkg.shipped.includes("dist") &&
+    !pkg.shipped.includes("src") &&
+    path.startsWith(`${pkg.dir}/src/`)
+  ) {
+    return true;
+  }
+  return false;
 }
 
 export function decideChangesetComment(


### PR DESCRIPTION
## Summary

- Extend `scripts/changeset-check.ts` with verdict **`unwarranted`**: a `.changeset/*.md` is present but the PR does not touch any npm-published package surface (`package.json` or each package’s `files` entries).
- Workflow sticky-comments that verdict and **fails the job** so docs/examples-only changesets cannot merge. `missing` (package code without a changeset) stays advisory.
- Document the rule under **Changesets (when to add one)** in `CONTRIBUTING.md`.
- Tests cover the #1116 quickstart regression, examples-only changesets, skills as shipped surface, and workflow fail gating.

## Why

Docs-site and example PRs repeatedly shipped package version notes that did not change consumer APIs. Fixed lockstep then advanced core/spec/svelte together. The old check only pushed people to *add* changesets; it never rejected a spurious one.

## Test plan

- [x] `bun test scripts/changeset-check.test.ts` (22 pass)
- [ ] On this PR: Changeset check job is green (`not-needed` — no package files, no changeset)
- [ ] Follow-up smoke: open a docs-only branch with a dummy `.changeset/*.md` and confirm red job + sticky comment (optional)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1132" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->