### PR TITLE
fix(docs): drop per-step chapter links on getting started

### DIFF
--- a/apps/docs/src/lib/components/GettingStartedGuide.svelte
+++ b/apps/docs/src/lib/components/GettingStartedGuide.svelte
@@ -96,7 +96,6 @@
           {#if step.explanation !== ""}
             <p>{step.explanation}</p>
           {/if}
-          <a href={`${base}${step.href}`}>Read {step.chapterTitle}</a>
         </div>
         {#if isFinish}
           <LessonFinishedChart placeholderSrc={chartSrc(index)} />

--- a/scripts/progressive-docs.test.ts
+++ b/scripts/progressive-docs.test.ts
@@ -4,7 +4,6 @@ import { DOCS_ROUTES } from "../apps/docs/src/lib/generated/routes.ts";
 import lifecycle from "../lifecycle.json";
 import { createDocsRouteInventory } from "./docs-route-inventory.ts";
 import { GETTING_STARTED_MD, guidePages, type LifecycleDoc } from "./gen-llms.ts";
-import { extractMarkdownHeadings } from "./llms-markdown.ts";
 import {
   QUICKSTART_BUILDER_FRAGMENT,
   QUICKSTART_CLI_FRAGMENT,
@@ -29,33 +28,6 @@ describe("progressive Docs journey", () => {
     );
     expect(page?.markdown).toContain("# Getting started");
     expect(page?.markdown).toContain("/reference/geoms");
-  });
-
-  it("lands a real chapter behind every lesson deep link", () => {
-    // The lesson teaches by accretion, so each step hands the reader off to
-    // the chapter that owns the element it just added. Those links are checked
-    // structurally — chapter exists, is navigable, and really has the anchor —
-    // rather than by restating step titles that the lesson is free to reword.
-    const inventory = createDocsRouteInventory();
-    const pages = guidePages(lifecycle as unknown as LifecycleDoc);
-    expect(SAKURA_STEPS.length).toBeGreaterThanOrEqual(5);
-
-    for (const step of SAKURA_STEPS) {
-      const [path, anchor] = step.href.split("#") as [string, string];
-      const route = inventory.find((entry) => entry.path === path);
-      expect(route, `no route for ${step.href}`).toBeDefined();
-      expect(route?.navigation?.label, `${path} is not navigable`).toBeTruthy();
-      expect(route?.navigation?.label).toBe(step.chapterTitle);
-
-      if (path === "/guide/getting-started") {
-        // Human walkthrough is a Svelte component, not catalog markdown.
-        continue;
-      }
-      const page = pages.find((entry) => `/guide/${entry.slug}` === path);
-      expect(page, `no guide page for ${path}`).toBeDefined();
-      const anchors = extractMarkdownHeadings(page!.markdown).map((heading) => heading.id);
-      expect(anchors, `${path} has no #${anchor}`).toContain(anchor);
-    }
   });
 
   it("publishes the consolidated interaction and production chapters", () => {

--- a/scripts/quickstart/steps.ts
+++ b/scripts/quickstart/steps.ts
@@ -154,8 +154,6 @@ export interface SakuraStep {
   readonly explanation: string;
   /** The delta the reader types, as it appears above the chart. */
   readonly fragment: string;
-  readonly chapterTitle: string;
-  readonly href: string;
   readonly spec: SakuraSpecDelta;
   readonly source: SakuraSourceDelta;
 }
@@ -195,8 +193,6 @@ export const SAKURA_STEPS: readonly SakuraStep[] = [
 <GeomLine stat="summary_bin" fun="median" binwidth={${SAKURA_BINWIDTH}}
   curve="step-hv" linewidth={1.8}
   aes={{ color: { value: "#262626" } }} />`,
-    chapterTitle: "Statistics and positions",
-    href: "/guide/statistics-positions#binned-y-summaries-summary-bin",
     spec: {
       layers: {
         points: {
@@ -253,8 +249,6 @@ export const SAKURA_STEPS: readonly SakuraStep[] = [
   domain={["${DOMAIN_BOTTOM}", "${DOMAIN_TOP}"]}
 />
 <ScaleXContinuous labels="d" domain={[800, 2030]} />`,
-    chapterTitle: "Scales and guides",
-    href: "/guide/scales-guides#date-and-time-axes",
     spec: {
       theme: "tufte",
       scales: {
@@ -313,8 +307,6 @@ export const SAKURA_STEPS: readonly SakuraStep[] = [
   values={[${EPOCH_VALUES}]}
 />
 <GuideNone channel="fill" />`,
-    chapterTitle: "Getting started",
-    href: "/guide/getting-started#add-geometry-layers",
     spec: {
       layers: {
         epochs: {
@@ -414,8 +406,6 @@ export const SAKURA_STEPS: readonly SakuraStep[] = [
 <GeomText data={records}
   aes={{ x: "labelYear", y: "labelDate", label: "label",
          color: { value: "#b3452f" } }} size={11} anchor="end" dx={-4} />`,
-    chapterTitle: "Getting started",
-    href: "/guide/getting-started#start-with-a-basic-plot",
     spec: {
       layers: {
         baseline: {
@@ -506,8 +496,6 @@ export const SAKURA_STEPS: readonly SakuraStep[] = [
 />
 key="year"
 inspect={{ mode: "exact", pin: true }}`,
-    chapterTitle: "Interactions",
-    href: "/guide/interactions#inspection",
     spec: {
       labs: {
         title: "Kyoto cherry blossom, 812–2026",

--- a/scripts/sakura-lesson.test.ts
+++ b/scripts/sakura-lesson.test.ts
@@ -231,13 +231,6 @@ describe("the sakura lesson folds to renderable specs", () => {
       expect(child, "spec-level render hint spelled as a prop").not.toContain("render=");
     }
   });
-
-  it("keeps every step's chapter link resolvable", () => {
-    for (const step of SAKURA_STEPS) {
-      expect(step.href).toMatch(/^\/guide\/[a-z-]+#[a-z-]+$/);
-      expect(step.chapterTitle.length).toBeGreaterThan(3);
-    }
-  });
 });
 
 describe("gate G1 — the reversed temporal y-axis", () => {


### PR DESCRIPTION
## Summary
- Remove the "Read Getting started / Scales and guides / …" links under each progressive step on the getting-started lesson.
- Drop the `href` and `chapterTitle` fields from `SAKURA_STEPS` that only existed for those links.
- Remove the tests that only guarded those deep links.

## Why
Several steps linked to the same page, and the anchor text was just the chapter title. Readers already get a "Where next" list at the bottom of the page.

## Test plan
- [x] `bun test scripts/progressive-docs.test.ts scripts/sakura-lesson.test.ts`
- [ ] Spot-check `/guide/getting-started`: no "Read …" links under steps; "Where next" still present
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1133" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->