### PR TITLE
fix(docs): simplify getting-started step titles and basic plot

### DIFF
--- a/apps/docs/src/lib/components/GettingStartedGuide.svelte
+++ b/apps/docs/src/lib/components/GettingStartedGuide.svelte
@@ -29,8 +29,8 @@
 
   /**
    * Intermediate step charts ship as SVG the library rendered at build time
-   * (scripts/gen-lesson-charts.ts). The final "Finish it" step is the live
-   * 838-point plot in LessonFinishedChart.
+   * (scripts/gen-lesson-charts.ts). The final "Make it interactive" step is the
+   * live 838-point plot in LessonFinishedChart.
    */
   const chartSrc = (step: number): string =>
     `${base}/lesson/${step < 0 ? "first-render.svg" : `step-${String(step + 1)}.svg`}`;

--- a/apps/docs/src/lib/generated/routes.ts
+++ b/apps/docs/src/lib/generated/routes.ts
@@ -3903,7 +3903,7 @@ export const DOCS_ROUTES = [
       },
       {
         id: "add-epoch-bands",
-        title: "Add epoch bands",
+        title: "Add epochs",
         level: 3,
       },
       {
@@ -3913,7 +3913,7 @@ export const DOCS_ROUTES = [
       },
       {
         id: "finish-it",
-        title: "Finish it",
+        title: "Make it interactive",
         level: 3,
       },
       {

--- a/apps/docs/src/lib/generated/search-index.ts
+++ b/apps/docs/src/lib/generated/search-index.ts
@@ -6168,12 +6168,12 @@ export const DOCS_SEARCH_INDEX = [
   {
     id: "heading:guide-getting-started:add-epoch-bands",
     kind: "heading",
-    title: "Add epoch bands",
+    title: "Add epochs",
     summary:
-      "Add epoch bands in Getting started. Install @ggsvelte/svelte and render one chart from a Svelte file.",
+      "Add epochs in Getting started. Install @ggsvelte/svelte and render one chart from a Svelte file.",
     href: "/guide/getting-started#add-epoch-bands",
     keywords: ["Getting started", "Start"],
-    exact: ["Add epoch bands"],
+    exact: ["Add epochs"],
   },
   {
     id: "heading:guide-getting-started:annotate-record-years",
@@ -6188,12 +6188,12 @@ export const DOCS_SEARCH_INDEX = [
   {
     id: "heading:guide-getting-started:finish-it",
     kind: "heading",
-    title: "Finish it",
+    title: "Make it interactive",
     summary:
-      "Finish it in Getting started. Install @ggsvelte/svelte and render one chart from a Svelte file.",
+      "Make it interactive in Getting started. Install @ggsvelte/svelte and render one chart from a Svelte file.",
     href: "/guide/getting-started#finish-it",
     keywords: ["Getting started", "Start"],
-    exact: ["Finish it"],
+    exact: ["Make it interactive"],
   },
   {
     id: "heading:guide-getting-started:the-finished-file",

--- a/scripts/consumer-compat.ts
+++ b/scripts/consumer-compat.ts
@@ -4,7 +4,6 @@ import { basename, dirname, join, relative, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
 
 import { COMPLETE_SVELTE_SNIPPETS } from "./guide-code-contract.js";
-import { quickstartAriaLabel } from "./quickstart.js";
 import { loadSupportMatrix, type PackageManager } from "./support-matrix.js";
 
 interface CommandStep {
@@ -359,9 +358,9 @@ export function writeConsumerFixture(
 import { existsSync, readFileSync } from "node:fs";
 
 const html = readFileSync("build/index.html", "utf8");
-// Derived from the quickstart file itself: a hand-written copy of the
-// accessible name silently drifts the moment the page changes.
-assert.ok(html.includes(${JSON.stringify(`aria-label="${quickstartAriaLabel()}"`)}), "accessible name");
+// The starter file omits ariaLabel (production polish). The library still
+// emits a generated role=img aria-label from the scene.
+assert.match(html, /role="img"[^>]*aria-label="[^"]+"|aria-label="[^"]+"[^>]*role="img"/);
 assert.match(html, /class="gg-plot-root[^"]*gg-container-width"/);
 assert.match(html, /data-gg-ready="false"/);
 assert.match(html, /width="832" height="400"/);

--- a/scripts/gen-llms.test.ts
+++ b/scripts/gen-llms.test.ts
@@ -165,7 +165,8 @@ describe("guide sections cover their catalogs", () => {
     expect(QUICKSTART_PAGE_SVELTE).toContain("Labs");
     expect(QUICKSTART_PAGE_SVELTE).toContain('import { kyotoSakura } from "@ggsvelte/svelte/data"');
     expect(QUICKSTART_PAGE_SVELTE).toContain('aes={{ x: "year", y: "bloomDate" }}');
-    expect(QUICKSTART_PAGE_SVELTE).toMatch(/ariaLabel="[^"]{20,}"/);
+    // ariaLabel is production polish; the basic plot stays bare.
+    expect(QUICKSTART_PAGE_SVELTE).not.toMatch(/ariaLabel=/);
     expect(QUICKSTART_PAGE_SVELTE).not.toMatch(/\bwidth=/);
     expect(QUICKSTART_PAGE_SVELTE).not.toMatch(/\bheight=/);
   });

--- a/scripts/quickstart.ts
+++ b/scripts/quickstart.ts
@@ -15,7 +15,7 @@
  * Implementation is split for maintainability:
  * - `scripts/quickstart/steps.ts` — lesson constants, types, SAKURA_STEPS
  * - `scripts/quickstart/fold.ts` — foldSakura accumulation
- * - `scripts/quickstart/surface.ts` — page headings, title/aria, agent fragments
+ * - `scripts/quickstart/surface.ts` — page headings, agent fragments
  *
  * Consumers keep importing from this module (`$scripts/quickstart`,
  * `./quickstart.ts`). Do not add `scripts/quickstart/index.ts` (extensionless
@@ -44,7 +44,6 @@ export type { SakuraRow, SakuraFold, FoldSakuraOptions } from "./quickstart/fold
 
 export {
   GETTING_STARTED_PAGE_HEADINGS,
-  quickstartAriaLabel,
   finishedPortableSpecNamed,
   QUICKSTART_BUILDER_FRAGMENT,
   QUICKSTART_PORTABLE_SPEC_FRAGMENT,

--- a/scripts/quickstart/fold.ts
+++ b/scripts/quickstart/fold.ts
@@ -9,8 +9,6 @@ import type { GuidesSpec, Labs, LayerSpec, PortableSpec, Scales, ThemeName } fro
 
 import { SAKURA_STEPS, SAKURA_Y_LAB } from "./steps";
 
-const ARIA_LABEL = "Kyoto peak bloom, 812 to 2026: about a week earlier since 1850";
-
 /** A row of the plot-level dataset (the shape kyotoSakura rows have). */
 export type SakuraRow = Record<string, string | number>;
 
@@ -132,7 +130,9 @@ export function foldSakura(
     ...(theme !== undefined && { theme }),
   };
 
-  attrs.set("ariaLabel", `  ariaLabel="${ARIA_LABEL}"`);
+  // No ariaLabel in the lesson sources: the basic plot is for learning the
+  // grammar, and an accessible name is a production polish step — not the
+  // first thing a new reader should copy. Hosts still get a generated label.
   const imported = [...components].toSorted((a, b) => a.localeCompare(b));
   // Wrap the component import once it stops fitting on one readable line.
   const imports =

--- a/scripts/quickstart/steps.ts
+++ b/scripts/quickstart/steps.ts
@@ -268,7 +268,7 @@ export const SAKURA_STEPS: readonly SakuraStep[] = [
   },
   {
     id: "add-epoch-bands",
-    title: "Add epoch bands",
+    title: "Add epochs",
     outcome: "",
     explanation: "",
     // inspect: false — bands are labelled decoration (#1068). A full-panel
@@ -469,7 +469,7 @@ export const SAKURA_STEPS: readonly SakuraStep[] = [
   },
   {
     id: "finish-it",
-    title: "Finish it",
+    title: "Make it interactive",
     outcome: "",
     explanation: "",
     // No title/subtitle/caption: chrome would squash the data panel. Citation

--- a/scripts/quickstart/surface.ts
+++ b/scripts/quickstart/surface.ts
@@ -1,13 +1,13 @@
 /**
  * Docs / agent surface derived from the sakura lesson.
  *
- * Page headings, aria extractors, and the agent-surface fragments.
+ * Page headings and the agent-surface fragments.
  * Not part of the human walkthrough fold — see GettingStartedGuide and llms.
  */
 
 import type { PortableSpec } from "@ggsvelte/spec";
 
-import { foldSakura, QUICKSTART_PAGE_SVELTE } from "./fold";
+import { foldSakura } from "./fold";
 import { SAKURA_BINWIDTH, SAKURA_STEPS } from "./steps";
 
 /**
@@ -29,13 +29,6 @@ export const GETTING_STARTED_PAGE_HEADINGS = [
   { id: "agent-json-spec", title: "Agent JSON spec", level: 2 },
   { id: "where-next", title: "Where next", level: 2 },
 ] as const satisfies readonly { id: string; title: string; level: 2 | 3 }[];
-
-/** The chart's accessible name, read from the file itself. */
-export function quickstartAriaLabel(): string {
-  const match = /ariaLabel="([^"]+)"/.exec(QUICKSTART_PAGE_SVELTE);
-  if (match === null) throw new Error("quickstart page has no ariaLabel");
-  return match[1]!;
-}
 
 // --- the agent surface -----------------------------------------------------
 // These live on /llms.txt and in the "Built for agents" section, not in the

--- a/scripts/sakura-lesson.test.ts
+++ b/scripts/sakura-lesson.test.ts
@@ -22,7 +22,6 @@ import {
   foldSakura,
   QUICKSTART_PAGE_SVELTE,
   QUICKSTART_PORTABLE_SPEC_FRAGMENT,
-  quickstartAriaLabel,
   SAKURA_BASELINE,
   SAKURA_RECORDS,
   SAKURA_BINWIDTH,
@@ -107,12 +106,9 @@ describe("the sakura lesson folds to renderable specs", () => {
     }
   });
 
-  it("exposes aria-label from the folded starting page", () => {
-    // consumer-compat also asserts this against a packed app; keep a direct
-    // unit guard so the extractor stays covered without that harness.
-    expect(quickstartAriaLabel()).toBe(
-      "Kyoto peak bloom, 812 to 2026: about a week earlier since 1850",
-    );
+  it("keeps the basic plot free of production polish props", () => {
+    // ariaLabel is production polish — not what a new reader should copy first.
+    expect(QUICKSTART_PAGE_SVELTE).not.toContain("ariaLabel");
     expect(QUICKSTART_PAGE_SVELTE).not.toContain("<svelte:head>");
   });
 

--- a/tests/visual/docs-progressive-search.spec.ts
+++ b/tests/visual/docs-progressive-search.spec.ts
@@ -30,13 +30,13 @@ test("each step shows its own delta and the finished chart is live", async ({ pa
   await expect(steps).toHaveCount(4);
   await expect(steps.getByRole("heading", { level: 3 })).toHaveText([
     "Pick a minimal theme and add a rolling median line",
-    "Add epoch bands",
+    "Add epochs",
     "Annotate record years",
-    "Finish it",
+    "Make it interactive",
   ]);
 
-  // Intermediate steps are build-time SVGs; Finish it is the one live plot
-  // (hydrate near-viewport, #972). Before that scroll, every step is an img.
+  // Intermediate steps are build-time SVGs; Make it interactive is the one live
+  // plot (hydrate near-viewport, #972). Before that scroll, every step is an img.
   await expect(steps.locator("img.lesson-chart")).toHaveCount(4);
   await expect(steps.locator(".gg-plot-root")).toHaveCount(0);
   const finishedChart = page.locator(".finished-chart");
@@ -156,7 +156,7 @@ test("prerendered Docs and lesson source remain useful without JavaScript", asyn
     'import { kyotoSakura } from "@ggsvelte/svelte/data"',
   );
   // Every chart is a build-time SVG without JS: first render + four steps
-  // (Finish it keeps its static fallback until hydrate near-viewport, #972).
+  // (Make it interactive keeps its static fallback until hydrate near-viewport, #972).
   await expect(page.locator(".lesson-block .lesson-output")).toBeVisible();
   await expect(page.locator("img.lesson-chart")).toHaveCount(5);
   await expect(

--- a/tests/visual/docs-shell.spec.ts
+++ b/tests/visual/docs-shell.spec.ts
@@ -50,7 +50,8 @@ test("getting started presents the complete file, then the agent surface", async
   await expect(firstFile).toContainText("GGPlot");
   await expect(firstFile).toContainText("ScaleXContinuous");
   await expect(firstFile).toContainText('from "@ggsvelte/svelte/data"');
-  await expect(firstFile).toContainText("ariaLabel=");
+  // ariaLabel is production polish — not on the basic-plot starter file.
+  await expect(firstFile).not.toContainText("ariaLabel=");
   // Width follows the container and height defaults; neither belongs in the
   // file a reader copies.
   await expect(firstFile).not.toContainText("width=");


### PR DESCRIPTION
## Summary

- Drop `ariaLabel` from the "Start with a basic plot" starter file — production a11y polish, not a first-lesson detail. Hosts still get a generated accessible name.
- Rename **Add epoch bands** → **Add epochs** (bands are not a layer).
- Rename **Finish it** → **Make it interactive** (matches the `key` / `inspect` step).

## Test plan

- [x] `bun test scripts/sakura-lesson.test.ts scripts/gen-llms.test.ts scripts/getting-started-headings.test.ts scripts/gen-lesson-charts.test.ts`
- [x] `bun scripts/gen-docs-routes.ts --check` / `gen-docs-search.ts --check`
- [ ] CI green
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1137" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->