### PR TITLE
perf(core): density_2d KDE sorted-x sliding window

### DIFF
--- a/.changeset/density-2d-sorted-x-window.md
+++ b/.changeset/density-2d-sorted-x-window.md
@@ -1,0 +1,15 @@
+---
+"@ggsvelte/core": patch
+"@ggsvelte/spec": patch
+"@ggsvelte/svelte": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+perf(core): density_2d KDE uses a sorted-x sliding window
+
+Product-Gaussian grid evaluation sorts samples by x once and slides an
+x-window across each grid row, so far-away points are not examined when
+bandwidth is local. Same ±8σ product kernel and isoline path as before.
+
+Migration: none — internal speedup only

--- a/packages/core/src/stats/density-2d.ts
+++ b/packages/core/src/stats/density-2d.ts
@@ -7,6 +7,8 @@
  * Bandwidth: MASS::bandwidth.nrd then kde2d's h/4 scaling (fixture-oriented).
  * Grid: n×n over data range expanded by 5% each side (approx ggplot expand).
  * Contour levels: contourLevels(breaks | bins | binwidth) of the density surface.
+ * KDE surface: sorted-x sliding window (same ±8σ product kernel as a full
+ * G²·n scan; fewer examinations when bandwidth is local).
  *
  * Filled v1 (#802 phase 2): closed isoline rings only (open rings dropped).
  * True isobands between consecutive levels deferred.
@@ -83,6 +85,88 @@ const INV_SQRT_2PI = 1 / Math.sqrt(2 * Math.PI);
 
 function dnorm(u: number): number {
   return INV_SQRT_2PI * Math.exp(-0.5 * u * u);
+}
+
+export type ProductKdeGridOptions = {
+  /**
+   * When true, also return how many (grid-cell, sample) pairs the inner loop
+   * examined (post x-window admission). Used by complexity tests only.
+   */
+  countExaminations?: boolean;
+};
+
+export type ProductKdeGridResult = number[][] & {
+  examinations?: number;
+};
+
+/**
+ * Product-Gaussian KDE on a regular grid.
+ *
+ * Samples are sorted once by x; each grid row slides an x-window across
+ * ascending `gx` so far-away points are never visited — O(G·n + work) average
+ * vs a full O(G²·n) scan of every sample at every cell. Same ±8σ truncation
+ * and invN scaling as the historical direct product (MASS::kde2d-shaped).
+ */
+export function productKdeGrid(
+  xs: Float64Array,
+  ys: Float64Array,
+  gx: Float64Array,
+  gy: Float64Array,
+  hx: number,
+  hy: number,
+  options: ProductKdeGridOptions = {},
+): ProductKdeGridResult {
+  const nx = xs.length;
+  const gridNX = gx.length;
+  const gridNY = gy.length;
+  const z: ProductKdeGridResult = Array.from({ length: gridNY }, () =>
+    Array.from({ length: gridNX }, () => 0),
+  );
+  if (nx === 0 || gridNX === 0 || gridNY === 0 || !(hx > 0) || !(hy > 0)) {
+    if (options.countExaminations === true) z.examinations = 0;
+    return z;
+  }
+
+  const order = Array.from({ length: nx }, (_, i) => i).toSorted(
+    (a, b) => xs[a]! - xs[b]! || a - b,
+  );
+  const sortedX = new Float64Array(nx);
+  const sortedY = new Float64Array(nx);
+  for (let i = 0; i < nx; i++) {
+    sortedX[i] = xs[order[i]!]!;
+    sortedY[i] = ys[order[i]!]!;
+  }
+
+  const wx = 8 * hx;
+  const wy = 8 * hy;
+  const invN = 1 / (nx * hx * hy);
+  let examinations = 0;
+  const count = options.countExaminations === true;
+
+  for (let j = 0; j < gridNY; j++) {
+    const yj = gy[j]!;
+    let lo = 0;
+    for (let i = 0; i < gridNX; i++) {
+      const xi = gx[i]!;
+      const xLo = xi - wx;
+      const xHi = xi + wx;
+      while (lo < nx && sortedX[lo]! < xLo) lo++;
+      let s = 0;
+      for (let k = lo; k < nx; k++) {
+        const xv = sortedX[k]!;
+        if (xv > xHi) break;
+        if (count) examinations++;
+        const dy = yj - sortedY[k]!;
+        if (Math.abs(dy) > wy) continue;
+        const dx = xi - xv;
+        s += dnorm(dx / hx) * dnorm(dy / hy);
+      }
+      z[j]![i] = s * invN;
+    }
+  }
+
+  if (count) z.examinations = examinations;
+  return z;
 }
 
 function expandRange(min: number, max: number, mul = 0.05): [number, number] {
@@ -216,31 +300,8 @@ export function statDensity2d(input: Density2dStatInput): Density2dStatResult {
     const [y0, y1] = expandRange(ymin, ymax, 0.05);
     const gx = linspace(x0, x1, gridN);
     const gy = linspace(y0, y1, gridN);
-    const z: number[][] = Array.from({ length: gridN }, () =>
-      Array.from({ length: gridN }, () => 0),
-    );
-
-    // Direct product kernel; window ±8σ for exactness at double precision.
-    const wx = 8 * hx;
-    const wy = 8 * hy;
-    const invN = 1 / (nx * hx * hy);
-    const kernelSum = (xi: number, yj: number): number => {
-      let s = 0;
-      for (let k = 0; k < nx; k++) {
-        const dx = xi - xs[k]!;
-        if (Math.abs(dx) > wx) continue;
-        const dy = yj - ys[k]!;
-        if (Math.abs(dy) > wy) continue;
-        s += dnorm(dx / hx) * dnorm(dy / hy);
-      }
-      return s * invN;
-    };
-    for (let j = 0; j < gridN; j++) {
-      const yj = gy[j]!;
-      for (let i = 0; i < gridN; i++) {
-        z[j]![i] = kernelSum(gx[i]!, yj);
-      }
-    }
+    // Sorted-x sliding window (same ±8σ / invN contract as the direct product).
+    const z = productKdeGrid(xs, ys, gx, gy, hx, hy);
 
     let zmin = Infinity;
     let zmax = -Infinity;

--- a/packages/core/tests/stats-density-2d.test.ts
+++ b/packages/core/tests/stats-density-2d.test.ts
@@ -3,12 +3,98 @@
  */
 import { describe, expect, it } from "bun:test";
 
-import { bandwidthNRD, statDensity2d } from "../src/stats/density-2d.ts";
+import { bandwidthNRD, productKdeGrid, statDensity2d } from "../src/stats/density-2d.ts";
 
 describe("bandwidthNRD", () => {
   it("returns positive bandwidth for a spread sample", () => {
     const x = Float64Array.from([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
     expect(bandwidthNRD(x)).toBeGreaterThan(0);
+  });
+});
+
+/**
+ * Direct-product KDE (unsorted scan) — independent reference for the public
+ * productKdeGrid surface. Same ±8σ window and invN scaling as production.
+ */
+function naiveProductKdeGrid(
+  xs: Float64Array,
+  ys: Float64Array,
+  gx: Float64Array,
+  gy: Float64Array,
+  hx: number,
+  hy: number,
+): number[][] {
+  const invSqrt2pi = 1 / Math.sqrt(2 * Math.PI);
+  const dnorm = (u: number) => invSqrt2pi * Math.exp(-0.5 * u * u);
+  const nx = xs.length;
+  const wx = 8 * hx;
+  const wy = 8 * hy;
+  const invN = 1 / (nx * hx * hy);
+  const z: number[][] = Array.from({ length: gy.length }, () =>
+    Array.from({ length: gx.length }, () => 0),
+  );
+  for (let j = 0; j < gy.length; j++) {
+    const yj = gy[j]!;
+    for (let i = 0; i < gx.length; i++) {
+      const xi = gx[i]!;
+      let s = 0;
+      for (let k = 0; k < nx; k++) {
+        const dx = xi - xs[k]!;
+        if (Math.abs(dx) > wx) continue;
+        const dy = yj - ys[k]!;
+        if (Math.abs(dy) > wy) continue;
+        s += dnorm(dx / hx) * dnorm(dy / hy);
+      }
+      z[j]![i] = s * invN;
+    }
+  }
+  return z;
+}
+
+describe("productKdeGrid", () => {
+  it("matches the direct-product reference surface on a small cloud", () => {
+    // Irregular x spacing so sorted-window order differs from input order.
+    const xs = Float64Array.from([0.4, -1.2, 2.1, 0.0, 1.5, -0.3, 0.8, -1.8, 1.1, 0.2]);
+    const ys = Float64Array.from([0.1, 0.9, -0.4, 1.2, 0.0, -0.8, 0.5, 0.3, -1.0, 0.7]);
+    const gx = Float64Array.from([-2, -1, 0, 1, 2]);
+    const gy = Float64Array.from([-1.5, -0.5, 0.5, 1.5]);
+    const hx = 0.4;
+    const hy = 0.35;
+    const got = productKdeGrid(xs, ys, gx, gy, hx, hy);
+    const want = naiveProductKdeGrid(xs, ys, gx, gy, hx, hy);
+    expect(got.length).toBe(want.length);
+    for (let j = 0; j < want.length; j++) {
+      expect(got[j]!.length).toBe(want[j]!.length);
+      for (let i = 0; i < want[j]!.length; i++) {
+        // Sum order may differ after the x-sort; stay well under isoline sensitivity.
+        expect(Math.abs(got[j]![i]! - want[j]![i]!)).toBeLessThan(1e-12);
+      }
+    }
+  });
+
+  it("visits fewer point-cell pairs than a full G²·n scan when bandwidth is local", () => {
+    // Wide scatter, tight bandwidth: sliding window must skip far x cells.
+    const n = 200;
+    const xs = new Float64Array(n);
+    const ys = new Float64Array(n);
+    for (let i = 0; i < n; i++) {
+      xs[i] = (i / (n - 1)) * 20 - 10;
+      ys[i] = Math.sin(i) * 2;
+    }
+    const G = 40;
+    const gx = new Float64Array(G);
+    const gy = new Float64Array(G);
+    for (let i = 0; i < G; i++) {
+      gx[i] = (i / (G - 1)) * 20 - 10;
+      gy[i] = (i / (G - 1)) * 6 - 3;
+    }
+    const hx = 0.15;
+    const hy = 0.15;
+    const full = G * G * n;
+    const { examinations } = productKdeGrid(xs, ys, gx, gy, hx, hy, { countExaminations: true });
+    // Local bandwidth should examine far fewer than the naive full product.
+    expect(examinations).toBeLessThan(full * 0.25);
+    expect(examinations).toBeGreaterThan(0);
   });
 });
 


### PR DESCRIPTION
## Summary

- **Audit target:** `packages` (narrowed to `packages/core` data-scale hot paths; full tree ≫ 80 files)
- **Finding:** `statDensity2d` evaluated product-Gaussian KDE with a full O(G²·n) sample scan at every grid cell (`density-2d.ts`)
- **Fix:** Sort samples by x once; slide an x-window across ascending `gx` per grid row — same ±8σ / invN contract as the direct product (matches 1d `density.ts` pattern)
- **n =** finite points in a density_2d group; **G =** `params.n` (default 100)

## Tests

```
cd packages/core && bun test tests/stats-density-2d.test.ts   tests/pipeline-m2/density-2d.test.ts   tests/pipeline-m2/density-2d-filled.test.ts
```

16 pass (includes surface match vs naive reference within 1e-12, and examination count ≪ G²·n for local bandwidth).

## Notes

- Codex plan review blocked: ChatGPT Codex usage limit until 2026-08-24; plan self-reviewed for float sum-order (1d density already sorts) and isoline stability (existing pipeline tests).
- Worst case when bandwidth covers the full x span remains O(G²·n); average case with local bandwidth drops examinations sharply.

## Follow-ups

- https://github.com/ljodea/ggsvelte/issues/1140 — `resolveSemanticKeys` re-expands shared smooth lineages O(C·L)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1141" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->