### PR TITLE
fix(docs): fivethirtyeight homepage charts and full penguins data

### DIFF
--- a/apps/docs/src/lib/components/GrammarDemo.svelte
+++ b/apps/docs/src/lib/components/GrammarDemo.svelte
@@ -59,7 +59,8 @@
       <Theme name={chartTheme} />
       <GeomPoint alpha={0.72} />
       {#if active >= 2}
-        <GeomSmooth method="loess" span={0.75} se={false} />
+        <!-- degree 1: local-linear loess stays cheap when remounting on 333 rows. -->
+        <GeomSmooth method="loess" span={0.75} degree={1} se={false} />
       {/if}
     </GGPlot>
   </div>

--- a/apps/docs/src/lib/components/GrammarDemo.svelte
+++ b/apps/docs/src/lib/components/GrammarDemo.svelte
@@ -1,10 +1,7 @@
 <script lang="ts">
   import { GeomPoint, GeomSmooth, GGPlot, Theme } from "@ggsvelte/svelte";
+  import { palmerPenguins } from "@ggsvelte/svelte/data";
 
-  // Docs-owned specimen corpus, not the gallery example: point/scatter-color
-  // now carries Guerry's 1833 moral statistics, and the hero wants a scatter
-  // with three colour groups. See lib/theme-specimens/data.ts.
-  import { penguins } from "$lib/theme-specimens/data";
   import { contrastChartTheme } from "$lib/docs-appearance-state.svelte";
 
   const steps = [
@@ -44,25 +41,25 @@
     <!--
       Exact inspect (not auto/x): smooth layers auto-mode to "x" and draw a
       vertical guide that steals hits from points. Homepage needs point
-      tooltips only. degree 1 + wider span: specimen has ~10 rows/species;
-      default degree-2 loess at span 0.75 overfits and looks jagged.
+      tooltips only. Full palmerPenguins (333 complete cases) — not the
+      30-row theme-specimen subset.
     -->
     <GGPlot
-      data={penguins}
+      data={palmerPenguins}
       aes={{
-        x: "flipper",
-        y: "mass",
+        x: "flipperLengthMm",
+        y: "bodyMassG",
         ...(active >= 1 && { color: "species" }),
       }}
       inspect={active >= 3
         ? { mode: "exact", pin: true, maxDistance: 24 }
         : false}
-      ariaLabel="Penguin mass increases with flipper length, grouped by species"
+      ariaLabel="Penguin body mass increases with flipper length, grouped by species"
     >
       <Theme name={chartTheme} />
       <GeomPoint alpha={0.72} />
       {#if active >= 2}
-        <GeomSmooth method="loess" span={0.9} degree={1} se={false} />
+        <GeomSmooth method="loess" span={0.75} se={false} />
       {/if}
     </GGPlot>
   </div>

--- a/apps/docs/src/lib/docs-appearance-state.svelte.ts
+++ b/apps/docs/src/lib/docs-appearance-state.svelte.ts
@@ -1,7 +1,7 @@
 /**
  * Reactive view of the site appearance (data-theme on <html>) for components
- * that must invert chart themes against the page: a dark chart on the light
- * site needs no border to read as a plot, and vice versa.
+ * that pick a chart theme against the page: FiveThirtyEight on the light site,
+ * light chart paper on the dark site.
  */
 import { browser } from "$app/environment";
 
@@ -18,7 +18,11 @@ if (browser) {
   });
 }
 
-/** Chart theme that contrasts with the current site appearance. */
-export function contrastChartTheme(): "light" | "dark" {
-  return docsAppearance.current === "light" ? "dark" : "light";
+/**
+ * Chart theme for homepage hero / grammar demo plots.
+ * Light site → fivethirtyeight (light paper, editorial chrome).
+ * Dark site → light (so the plot still reads as a chart on a dark frame).
+ */
+export function contrastChartTheme(): "fivethirtyeight" | "light" {
+  return docsAppearance.current === "light" ? "fivethirtyeight" : "light";
 }

--- a/apps/docs/src/lib/home-code-path.ts
+++ b/apps/docs/src/lib/home-code-path.ts
@@ -6,32 +6,32 @@
  * never dump every row into a mile-tall panel. Matches the interactive demo
  * above the fold — not the hero Guerry chart.
  *
+ * Data: bundled `palmerPenguins` from `@ggsvelte/svelte/data` (333 complete
+ * cases). Field names match the published dataset, not the short theme-specimen
+ * aliases.
+ *
  * Interaction: GrammarDemo step 4 uses exact inspect (nearest-point hover/pin
  * tooltips, no vertical axis guide). That is a GGPlot host prop — not a
  * PortableSpec field and not a builder method.
  * - Svelte / builder: set `inspect` on <GGPlot>
  * - JSON: agent envelope `{ interactions, spec }` (host maps interactions onto
  *   GGPlot props; bare PortableSpec is also accepted and defaults inspect on)
- *
- * Smooth params: local-linear loess (degree 1, span 0.9). The specimen has
- * ~10 rows per species; default degree-2 / span 0.75 overfits and jaggeds.
  */
 
 const HOME_CODE_PATH_SVELTE = `<script lang="ts">
   import { GeomPoint, GeomSmooth, GGPlot } from "@ggsvelte/svelte";
-
-  import { penguins } from "./penguins.js";
+  import { palmerPenguins } from "@ggsvelte/svelte/data";
 </script>
 
 <GGPlot
-  data={penguins}
-  aes={{ x: "flipper", y: "mass", color: "species" }}
+  data={palmerPenguins}
+  aes={{ x: "flipperLengthMm", y: "bodyMassG", color: "species" }}
   inspect={{ mode: "exact", pin: true, maxDistance: 24 }}
   width={640}
   height={400}
 >
   <GeomPoint alpha={0.72} />
-  <GeomSmooth method="loess" span={0.9} degree={1} se={false} />
+  <GeomSmooth method="loess" span={0.75} se={false} />
 </GGPlot>
 `;
 
@@ -39,15 +39,14 @@ const HOME_CODE_PATH_SVELTE = `<script lang="ts">
 const HOME_CODE_PATH_BUILDER = `<script lang="ts">
   import { aes, gg } from "@ggsvelte/spec";
   import { GGPlot } from "@ggsvelte/svelte";
-
-  import { penguins } from "./penguins.js";
+  import { palmerPenguins } from "@ggsvelte/svelte/data";
 
   const spec = gg(
-    penguins,
-    aes({ x: "flipper", y: "mass", color: "species" }),
+    palmerPenguins,
+    aes({ x: "flipperLengthMm", y: "bodyMassG", color: "species" }),
   )
     .geomPoint({ alpha: 0.72 })
-    .geomSmooth({ method: "loess", span: 0.9, degree: 1, se: false })
+    .geomSmooth({ method: "loess", span: 0.75, se: false })
     .spec();
 </script>
 
@@ -71,15 +70,15 @@ const HOME_CODE_PATH_SPEC_JSON = `{
   },
   "spec": {
     "edition": 2,
-    "data": { "name": "penguins" },
+    "data": { "name": "palmerPenguins" },
     "layers": [
       {
         "geom": "point",
         "stat": "identity",
         "position": "identity",
         "aes": {
-          "x": { "field": "flipper" },
-          "y": { "field": "mass" },
+          "x": { "field": "flipperLengthMm" },
+          "y": { "field": "bodyMassG" },
           "color": { "field": "species" }
         },
         "params": { "alpha": 0.72 }
@@ -89,14 +88,13 @@ const HOME_CODE_PATH_SPEC_JSON = `{
         "stat": "smooth",
         "position": "identity",
         "aes": {
-          "x": { "field": "flipper" },
-          "y": { "field": "mass" },
+          "x": { "field": "flipperLengthMm" },
+          "y": { "field": "bodyMassG" },
           "color": { "field": "species" }
         },
         "params": {
           "method": "loess",
-          "span": 0.9,
-          "degree": 1,
+          "span": 0.75,
           "se": false
         }
       }

--- a/apps/docs/src/lib/home-code-path.ts
+++ b/apps/docs/src/lib/home-code-path.ts
@@ -31,7 +31,7 @@ const HOME_CODE_PATH_SVELTE = `<script lang="ts">
   height={400}
 >
   <GeomPoint alpha={0.72} />
-  <GeomSmooth method="loess" span={0.75} se={false} />
+  <GeomSmooth method="loess" span={0.75} degree={1} se={false} />
 </GGPlot>
 `;
 
@@ -46,7 +46,7 @@ const HOME_CODE_PATH_BUILDER = `<script lang="ts">
     aes({ x: "flipperLengthMm", y: "bodyMassG", color: "species" }),
   )
     .geomPoint({ alpha: 0.72 })
-    .geomSmooth({ method: "loess", span: 0.75, se: false })
+    .geomSmooth({ method: "loess", span: 0.75, degree: 1, se: false })
     .spec();
 </script>
 
@@ -95,6 +95,7 @@ const HOME_CODE_PATH_SPEC_JSON = `{
         "params": {
           "method": "loess",
           "span": 0.75,
+          "degree": 1,
           "se": false
         }
       }

--- a/apps/docs/src/routes/+page.server.ts
+++ b/apps/docs/src/routes/+page.server.ts
@@ -3,14 +3,14 @@ import { homeHeroStaticSvgFromData } from "$lib/theme-specimens/static-svg";
 
 /**
  * Prerender hero shells so the home client does not import @ggsvelte/core.
- * Two contrast themes: dark chart on the light site, light chart on dark
- * (matches `contrastChartTheme()`). CSS on the page picks the right one from
- * `data-theme` set by static/theme.js before first paint.
+ * Matches `contrastChartTheme()`: fivethirtyeight on the light site, light on
+ * dark. CSS on the page picks the right shell from `data-theme` set by
+ * static/theme.js before first paint.
  */
 export function load() {
   return {
     heroStaticSvgLightSite: homeHeroStaticSvgFromData(guerry, {
-      theme: "dark",
+      theme: "fivethirtyeight",
       height: 400,
     }),
     heroStaticSvgDarkSite: homeHeroStaticSvgFromData(guerry, {

--- a/apps/docs/src/routes/+page.svelte
+++ b/apps/docs/src/routes/+page.svelte
@@ -55,7 +55,7 @@
     {:else}
       <!--
         theme.js sets data-theme before paint. Mirror contrastChartTheme():
-        dark chart on the light site, light chart on dark — no theme flash.
+        fivethirtyeight on the light site, light chart on dark — no theme flash.
       -->
       <div class="hero-static hero-static--light-site">
         {@html data.heroStaticSvgLightSite}

--- a/tests/visual/docs-home-gallery.spec.ts
+++ b/tests/visual/docs-home-gallery.spec.ts
@@ -144,11 +144,15 @@ test("homepage hero tooltip names a single department without axis crosshair noi
 });
 
 test("homepage grammar steps change real chart structure in place", async ({ page }) => {
+  // Full palmerPenguins (333) + loess on step toggles is heavier than the old
+  // 30-row specimen; cold CI hydrate already sits near the 60s project budget.
+  test.setTimeout(120_000);
   await page.goto("/");
   const output = page.locator(".grammar-output");
+  const plot = output.locator(".gg-plot-root");
   // GrammarDemo is dynamic-imported; wait for the live plot before asserting structure.
-  await expect(output.locator(".gg-plot-root")).toHaveAttribute("data-gg-ready", "true", {
-    timeout: 30_000,
+  await expect(plot).toHaveAttribute("data-gg-ready", "true", {
+    timeout: 60_000,
   });
   // The demo opens on the last step: layers, legend, and inspection all live.
   await expect(output.locator(".gg-points")).toHaveCount(1);
@@ -165,7 +169,9 @@ test("homepage grammar steps change real chart structure in place", async ({ pag
   await expect(output.locator(".gg-paths")).toHaveCount(0);
 
   await page.getByRole("button", { name: /Layers/ }).click();
-  await expect(output.locator(".gg-paths")).toHaveCount(1);
+  // Remounting GeomSmooth re-runs loess per species; wait for ready then paths.
+  await expect(plot).toHaveAttribute("data-gg-ready", "true", { timeout: 60_000 });
+  await expect(output.locator(".gg-paths")).toHaveCount(1, { timeout: 30_000 });
 });
 
 test("homepage grammar inspect is exact: point tooltip, no path x-crosshair", async ({ page }) => {


### PR DESCRIPTION
## Summary

- Homepage hero and mid-page grammar demo use **fivethirtyeight** on the light site (still **light** on the dark site) instead of the inverted **dark** chart theme.
- Grammar demo (and the matching code-path tabs) plot the bundled **`palmerPenguins`** dataset (333 complete cases from `@ggsvelte/svelte/data`) with real field names (`flipperLengthMm`, `bodyMassG`), not the 30-row theme-specimen subset.

## Test plan

- [ ] Open `/` in light mode: hero Guerry chart and mid-page penguins chart use FiveThirtyEight chrome (grey paper, white grid), not dark theme.
- [ ] Toggle site to dark mode: both charts still use the light chart theme.
- [ ] Penguins scatter shows the full three-species cloud (~333 points), not ~10 per species.
- [ ] Grammar steps still switch Data → Mappings → Layers → Interaction correctly.
- [ ] Code-path tabs show `palmerPenguins` / `flipperLengthMm` / `bodyMassG`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1142" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->