### PR TITLE
perf(svelte): expand each lineage id once (#1140)

### DIFF
--- a/.changeset/lineage-expand-once.md
+++ b/.changeset/lineage-expand-once.md
@@ -1,0 +1,17 @@
+---
+"@ggsvelte/core": patch
+"@ggsvelte/spec": patch
+"@ggsvelte/svelte": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+perf(svelte): expand each lineage id once for key and interval resolve
+
+Smooth and other aggregate eval-grid marks share one lineage membership
+across many candidates. resolveSemanticKeys and
+lineageRowIndexesFromCandidates now walk each lineage id once instead of
+re-spreading O(C·L) times. Diagnostics for empty lineages still fire per
+candidate.
+
+Migration: none — internal speedup only

--- a/packages/svelte/src/lib/interval/interval.ts
+++ b/packages/svelte/src/lib/interval/interval.ts
@@ -108,14 +108,20 @@ export type LineageCandidate = {
 /**
  * Collect source row indexes covered by interval candidates via lineage.
  * Order is insertion order (first candidate, then lineage key order).
+ * Each lineage id is expanded once (#1140) — shared smooth/aggregate
+ * memberships must not re-walk L rows per coincident mark.
  */
 export function lineageRowIndexesFromCandidates(
   candidates: Iterable<LineageCandidate>,
   lineageKeys: (lineageId: number) => Iterable<number>,
 ): Set<number> {
   const sourceRows = new Set<number>();
+  const seenLineages = new Set<number>();
   for (const candidate of candidates) {
-    for (const rowIndex of lineageKeys(candidate.lineage)) sourceRows.add(rowIndex);
+    const lineageId = candidate.lineage;
+    if (seenLineages.has(lineageId)) continue;
+    seenLineages.add(lineageId);
+    for (const rowIndex of lineageKeys(lineageId)) sourceRows.add(rowIndex);
   }
   return sourceRows;
 }

--- a/packages/svelte/src/lib/runtime/semantic-keys.ts
+++ b/packages/svelte/src/lib/runtime/semantic-keys.ts
@@ -323,12 +323,25 @@ export function resolveSemanticKeys(input: ResolveSemanticKeysInput): ResolveSem
       actual: "synthetic rule has no source rows",
     });
 
+  // Expand each lineage id once. Smooth / aggregate eval-grid marks share one
+  // membership array across C marks (#1140) — re-spreading was O(C·L).
+  // Map value: true when the lineage has no source rows (empty-lineage diag).
+  const lineageEmpty = new Map<number, boolean>();
   for (let id = 0; id < model.candidateCount; id++) {
     const candidate = model.candidate(id);
     if (candidate === null) continue;
     if (candidate.rowIndex !== null) sourceRows.add(candidate.rowIndex);
-    const lineageRows = [...model.lineageKeys(candidate.lineage)];
-    if (candidate.rowIndex === null && lineageRows.length === 0)
+    const lineageId = candidate.lineage;
+    let empty = lineageEmpty.get(lineageId);
+    if (empty === undefined) {
+      empty = true;
+      for (const rowIndex of model.lineageKeys(lineageId)) {
+        empty = false;
+        sourceRows.add(rowIndex);
+      }
+      lineageEmpty.set(lineageId, empty);
+    }
+    if (candidate.rowIndex === null && empty)
       diagnostics.push({
         ...INTERACTION_DIAGNOSTIC_CATALOG.INTERACTION_MISSING_LINEAGE,
         actual: {
@@ -336,7 +349,6 @@ export function resolveSemanticKeys(input: ResolveSemanticKeysInput): ResolveSem
           candidateId: candidate.id,
         },
       });
-    for (const rowIndex of lineageRows) sourceRows.add(rowIndex);
   }
 
   for (const rowIndex of sourceRows) {

--- a/packages/svelte/tests/interval/interval.test.ts
+++ b/packages/svelte/tests/interval/interval.test.ts
@@ -135,6 +135,23 @@ describe("lineageRowIndexesFromCandidates", () => {
   it("returns empty set when there are no candidates", () => {
     expect([...lineageRowIndexesFromCandidates([], () => [1])]).toEqual([]);
   });
+
+  it("calls lineageKeys once per unique lineage id (#1140)", () => {
+    const lineage = new Map<number, number[]>([
+      [1, Array.from({ length: 40 }, (_, i) => i)],
+      [2, [100, 101]],
+    ]);
+    const calls: number[] = [];
+    const rows = lineageRowIndexesFromCandidates(
+      [{ lineage: 1 }, { lineage: 1 }, { lineage: 1 }, { lineage: 2 }, { lineage: 1 }],
+      (id) => {
+        calls.push(id);
+        return lineage.get(id) ?? [];
+      },
+    );
+    expect(calls).toEqual([1, 2]);
+    expect([...rows]).toEqual([...Array.from({ length: 40 }, (_, i) => i), 100, 101]);
+  });
 });
 
 describe("intervalSelectionFromRows", () => {

--- a/packages/svelte/tests/runtime/semantic-keys-pure.test.ts
+++ b/packages/svelte/tests/runtime/semantic-keys-pure.test.ts
@@ -522,6 +522,74 @@ describe("resolveSemanticKeys", () => {
     expect(priorKeys.get("dataB:0")).toBe("b");
     expect(priorKeys.get("dataA:0")).toBe("a");
   });
+
+  it("expands each lineage id once when many candidates share membership (#1140)", () => {
+    // Smooth eval-grid marks share one lineage of all finite-y source rows.
+    const sharedRows = Array.from({ length: 50 }, (_, i) => i);
+    const lineageCalls: number[] = [];
+    const base = modelView({
+      candidates: Array.from({ length: 8 }, (_, id) => ({
+        id,
+        rowIndex: null as number | null,
+        layerIndex: 0,
+        lineage: 7,
+      })),
+      rows: sharedRows.map((i) => ({ id: `k${String(i)}` })),
+      lineage: new Map([[7, sharedRows]]),
+    });
+    const model: SemanticKeyModelView = {
+      ...base,
+      lineageKeys(lineageId: number) {
+        lineageCalls.push(lineageId);
+        return base.lineageKeys(lineageId);
+      },
+    };
+    const result = resolveSemanticKeys({
+      model,
+      datumKey: "id",
+      priorKeys: new Map(),
+      rowIdentity: (rowIndex) => `r:${rowIndex}`,
+    });
+    expect(lineageCalls).toEqual([7]);
+    expect(result.keys.size).toBe(50);
+    expect(result.keys.get(0)).toBe("k0");
+    expect(result.keys.get(49)).toBe("k49");
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still emits missing-lineage once per empty-lineage candidate after dedupe", () => {
+    const lineageCalls: number[] = [];
+    const base = modelView({
+      candidates: [
+        { id: 0, rowIndex: null, layerIndex: 1, lineage: 0 },
+        { id: 1, rowIndex: null, layerIndex: 1, lineage: 0 },
+      ],
+      rows: [],
+      lineage: new Map([[0, []]]),
+    });
+    const model: SemanticKeyModelView = {
+      ...base,
+      lineageKeys(lineageId: number) {
+        lineageCalls.push(lineageId);
+        return base.lineageKeys(lineageId);
+      },
+    };
+    const result = resolveSemanticKeys({
+      model,
+      datumKey: "id",
+      priorKeys: new Map(),
+      rowIdentity: (rowIndex) => `r:${rowIndex}`,
+    });
+    expect(lineageCalls).toEqual([0]);
+    expect(result.diagnostics.map((d) => d.code)).toEqual([
+      "INTERACTION_MISSING_LINEAGE",
+      "INTERACTION_MISSING_LINEAGE",
+    ]);
+    expect(result.diagnostics.map((d) => d.actual)).toEqual([
+      { layerIndex: 1, candidateId: 0 },
+      { layerIndex: 1, candidateId: 1 },
+    ]);
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Audit target:** `packages` (narrowed; prior pass fixed density_2d in #1141)
- **Finding / issue:** #1140 — `resolveSemanticKeys` re-spread shared lineage membership once per candidate (O(C · L))
- **Fix:** Expand each lineage id once into `sourceRows` (`lineageEmpty` map caches emptiness for per-candidate missing-lineage diagnostics). Same for `lineageRowIndexesFromCandidates`.
- **n =** C candidates sharing a lineage of L source rows (smooth eval grid ~80 marks over thousands of input rows)

## Tests

```
cd packages/svelte && bun x vitest run --project chromium \
  tests/runtime/semantic-keys-pure.test.ts tests/interval/interval.test.ts
```

39 pass (includes lineageKeys call-count pins and empty-lineage diag per candidate).

## Notes

- Codex plan review blocked (ChatGPT usage limit); plan self-reviewed.
- Closes #1140.

## Follow-ups

None from this loop (deferred item from #1141 is this PR).

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1143" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->