### PR TITLE
perf(svelte): legend entry index expands each lineage once

### DIFF
--- a/.changeset/legend-lineage-expand-once.md
+++ b/.changeset/legend-lineage-expand-once.md
@@ -1,0 +1,16 @@
+---
+"@ggsvelte/core": patch
+"@ggsvelte/spec": patch
+"@ggsvelte/svelte": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+perf(svelte): expand legend lineages once per lineage id
+
+buildLegendEntryKeyIndex shared membership Sets across candidates with the
+same lineage id (smooth eval grids). Lineage is no longer re-walked once
+per mark. Candidate-local rowIndex still attaches without mutating the
+shared bag.
+
+Migration: none — internal speedup only

--- a/packages/svelte/src/lib/legend/entry-key-index.ts
+++ b/packages/svelte/src/lib/legend/entry-key-index.ts
@@ -244,8 +244,7 @@ export function buildLegendEntryKeyIndex(
           // Copy only when we must attach a candidate-local row not already
           // in the shared membership (identity marks). Shared smooth bags
           // stay one Set for every eval-grid mark.
-          sourceRows = new Set(shared);
-          sourceRows.add(candidate.rowIndex);
+          sourceRows = new Set([...shared, candidate.rowIndex]);
         } else {
           sourceRows = shared;
         }

--- a/packages/svelte/src/lib/legend/entry-key-index.ts
+++ b/packages/svelte/src/lib/legend/entry-key-index.ts
@@ -77,7 +77,8 @@ export type LegendKeyIndexAdapter = {
  * - Match entry values via pre-built token→index maps (legendValueEqual
  *   semantics: NaN, Date, -0/0); O(E) prep + O(1) per row, not findIndex.
  * - Layer field maps built once per layer (first non-stat channel → field);
- *   lineage Sets once per candidate when any discrete legend applies.
+ *   lineage Sets once per lineage id when any discrete legend applies
+ *   (smooth eval-grid marks share membership — not once per candidate).
  * - Final keys are first-seen unique order, frozen.
  */
 /** Row field value or scaled constant; `skip` when the row is missing. */
@@ -222,14 +223,32 @@ export function buildLegendEntryKeyIndex(
     }
   };
 
+  // Lineage membership once per lineage id (smooth shares one bag across
+  // the eval grid). Candidates may still append their own rowIndex.
+  const rowsByLineage = new Map<number, Set<number>>();
+  const lineageRows = (lineageId: number): Set<number> => {
+    let rows = rowsByLineage.get(lineageId);
+    if (rows === undefined) {
+      rows = new Set(adapter.lineageKeys(lineageId));
+      rowsByLineage.set(lineageId, rows);
+    }
+    return rows;
+  };
+
   for (const candidate of adapter.candidates()) {
-    // Lineage Set once per candidate when any discrete legend applies —
-    // not once per legend (was O(C·L·R) Set construction).
     let sourceRows: Set<number> | null = null;
     const rowsForCandidate = (): Set<number> => {
       if (sourceRows === null) {
-        sourceRows = new Set(adapter.lineageKeys(candidate.lineage));
-        if (candidate.rowIndex !== null) sourceRows.add(candidate.rowIndex);
+        const shared = lineageRows(candidate.lineage);
+        if (candidate.rowIndex !== null && !shared.has(candidate.rowIndex)) {
+          // Copy only when we must attach a candidate-local row not already
+          // in the shared membership (identity marks). Shared smooth bags
+          // stay one Set for every eval-grid mark.
+          sourceRows = new Set(shared);
+          sourceRows.add(candidate.rowIndex);
+        } else {
+          sourceRows = shared;
+        }
       }
       return sourceRows;
     };

--- a/packages/svelte/tests/legend/focus-entry-key-index-pure.test.ts
+++ b/packages/svelte/tests/legend/focus-entry-key-index-pure.test.ts
@@ -444,7 +444,7 @@ describe("buildLegendEntryKeyIndex", () => {
     expect(index.get("color:0")).toEqual([]);
   });
 
-  it("calls layerFields once per distinct layer and lineageKeys once per applicable candidate", () => {
+  it("calls layerFields once per distinct layer and lineageKeys once per unique lineage", () => {
     let layerFieldsCalls = 0;
     let lineageKeysCalls = 0;
     const dualLegend: SceneLegend = {
@@ -482,8 +482,28 @@ describe("buildLegendEntryKeyIndex", () => {
     expect(index.get("color:0")).toEqual(["a", "b", "c"]);
     // One layerFields call per distinct layerIndex (0 and 1), not per candidate×legend.
     expect(layerFieldsCalls).toBe(2);
-    // One lineageKeys call per candidate (all three apply at least one legend).
+    // One lineageKeys call per unique lineage id (1, 2, 3).
     expect(lineageKeysCalls).toBe(3);
+  });
+
+  it("expands a shared lineage once across many candidates (smooth eval grid)", () => {
+    let lineageKeysCalls = 0;
+    const sharedRows = Array.from({ length: 40 }, (_, i) => i);
+    const index = buildLegendEntryKeyIndex({
+      legends: [discreteFill],
+      candidates: () =>
+        Array.from({ length: 12 }, () => ({ layerIndex: 0, lineage: 7, rowIndex: null })),
+      layerFields: () => [{ channel: "fill", field: "channel" }],
+      lineageKeys(lineageId) {
+        lineageKeysCalls += 1;
+        return lineageId === 7 ? sharedRows : [];
+      },
+      row: (rowIndex) => ({ channel: rowIndex % 2 === 0 ? "web" : "store" }),
+      semanticKey: (rowIndex) => `k${String(rowIndex)}`,
+    });
+    expect(lineageKeysCalls).toBe(1);
+    expect(index.get("fill:0")?.length).toBe(20);
+    expect(index.get("fill:1")?.length).toBe(20);
   });
 
   it("does not call lineageKeys when no discrete legend applies to the candidate", () => {


### PR DESCRIPTION
## Summary

- **Audit target:** `packages` (core/svelte hot paths; prior passes: #1141 density_2d, #1143 semantic/interval lineage)
- **Finding:** `buildLegendEntryKeyIndex` built a lineage `Set` once per candidate, not once per lineage id — smooth eval grids re-walk O(C·L)
- **Fix:** Cache membership Sets by lineage id; copy only when attaching a candidate-local `rowIndex` absent from the shared bag
- **n =** C candidates sharing a lineage of L source rows

## Tests

```
cd packages/svelte && bun x vitest run --project chromium \
  tests/legend/focus-entry-key-index-pure.test.ts
```

20 pass (shared-lineage call-count pin).

## Notes

- Codex plan review blocked (ChatGPT usage limit); plan self-reviewed.
- No open follow-ups filed: remaining style-binned `findIndex` (B ≤ 64) is a bounded constant-factor micro-opt, not deferred as an issue.


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1144" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->