### PR TITLE
fix(docs): SSR grammar shell, xy crosshair, and legend focus

### DIFF
--- a/apps/docs/src/lib/components/GrammarDemo.svelte
+++ b/apps/docs/src/lib/components/GrammarDemo.svelte
@@ -1,8 +1,18 @@
 <script lang="ts">
-  import { GeomPoint, GeomSmooth, GGPlot, Theme } from "@ggsvelte/svelte";
-  import { palmerPenguins } from "@ggsvelte/svelte/data";
+  import { onMount } from "svelte";
 
-  import { contrastChartTheme } from "$lib/docs-appearance-state.svelte";
+  /**
+   * Homepage grammar section: chrome always SSR'd; plot upgrades from a static
+   * SVG shell (server-rendered) to live GGPlot after a dynamic import so the
+   * mid-page never sits empty while ~1.3MB of @ggsvelte downloads.
+   */
+  let {
+    staticSvgLightSite,
+    staticSvgDarkSite,
+  }: {
+    staticSvgLightSite: string;
+    staticSvgDarkSite: string;
+  } = $props();
 
   const steps = [
     { label: "Data", note: "Rows as plain objects." },
@@ -11,7 +21,15 @@
     { label: "Interaction", note: "just one more layer" },
   ] as const;
   let active = $state(steps.length - 1);
-  const chartTheme = $derived(contrastChartTheme());
+  let Plot = $state<
+    typeof import("$lib/components/GrammarDemoPlot.svelte").default | null
+  >(null);
+
+  onMount(() => {
+    void import("$lib/components/GrammarDemoPlot.svelte").then((mod) => {
+      Plot = mod.default;
+    });
+  });
 </script>
 
 <section class="grammar-demo" aria-labelledby="grammar-heading">
@@ -27,6 +45,7 @@
           <button
             type="button"
             aria-pressed={active === index}
+            disabled={Plot === null}
             onclick={() => (active = index)}
           >
             <span>{String(index + 1).padStart(2, "0")}</span>
@@ -38,31 +57,20 @@
     </ol>
   </div>
   <div class="grammar-output">
-    <!--
-      Exact inspect (not auto/x): smooth layers auto-mode to "x" and draw a
-      vertical guide that steals hits from points. Homepage needs point
-      tooltips only. Full palmerPenguins (333 complete cases) — not the
-      30-row theme-specimen subset.
-    -->
-    <GGPlot
-      data={palmerPenguins}
-      aes={{
-        x: "flipperLengthMm",
-        y: "bodyMassG",
-        ...(active >= 1 && { color: "species" }),
-      }}
-      inspect={active >= 3
-        ? { mode: "exact", pin: true, maxDistance: 24 }
-        : false}
-      ariaLabel="Penguin body mass increases with flipper length, grouped by species"
-    >
-      <Theme name={chartTheme} />
-      <GeomPoint alpha={0.72} />
-      {#if active >= 2}
-        <!-- degree 1: local-linear loess stays cheap when remounting on 333 rows. -->
-        <GeomSmooth method="loess" span={0.75} degree={1} se={false} />
-      {/if}
-    </GGPlot>
+    {#if Plot !== null}
+      <Plot {active} />
+    {:else}
+      <!--
+        theme.js sets data-theme before paint. Mirror contrastChartTheme():
+        fivethirtyeight on the light site, light chart on dark — no theme flash.
+      -->
+      <div class="grammar-static grammar-static--light-site">
+        {@html staticSvgLightSite}
+      </div>
+      <div class="grammar-static grammar-static--dark-site">
+        {@html staticSvgDarkSite}
+      </div>
+    {/if}
   </div>
 </section>
 
@@ -88,6 +96,24 @@
   .grammar-output {
     grid-area: output;
     min-width: 0;
+  }
+
+  .grammar-output :global(svg) {
+    display: block;
+    max-width: 100%;
+    height: auto;
+  }
+
+  .grammar-static--dark-site {
+    display: none;
+  }
+
+  :global(:root[data-theme="dark"]) .grammar-static--light-site {
+    display: none;
+  }
+
+  :global(:root[data-theme="dark"]) .grammar-static--dark-site {
+    display: block;
   }
 
   h2 {
@@ -127,6 +153,10 @@
     cursor: pointer;
   }
 
+  button:disabled {
+    cursor: default;
+  }
+
   button > span {
     grid-row: 1 / 3;
     font: 600 0.75rem/1.4 var(--code-font);
@@ -138,7 +168,7 @@
     font-size: 1.2rem;
   }
 
-  button:hover strong {
+  button:hover:not(:disabled) strong {
     text-decoration: underline;
   }
 

--- a/apps/docs/src/lib/components/GrammarDemoPlot.svelte
+++ b/apps/docs/src/lib/components/GrammarDemoPlot.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+  import { GeomPoint, GeomSmooth, GGPlot, Theme } from "@ggsvelte/svelte";
+  import { palmerPenguins } from "@ggsvelte/svelte/data";
+
+  import { contrastChartTheme } from "$lib/docs-appearance-state.svelte";
+
+  /**
+   * Live homepage grammar plot. Dynamically imported so the section chrome +
+   * static SVG shell can SSR without pulling @ggsvelte into the home node.
+   *
+   * Default step (Interaction): xy inspect (numeric crosshair) + legendFocus.
+   * Full palmerPenguins (333 complete cases).
+   */
+  let {
+    active,
+  }: {
+    active: number;
+  } = $props();
+
+  const chartTheme = $derived(contrastChartTheme());
+</script>
+
+<!--
+  mode "xy": full crosshair on two continuous axes (not path auto "x").
+  legendFocus needs stable row keys (`id` on palmerPenguins).
+  degree 1: local-linear loess stays cheap when remounting on 333 rows.
+-->
+<GGPlot
+  data={palmerPenguins}
+  key="id"
+  aes={{
+    x: "flipperLengthMm",
+    y: "bodyMassG",
+    ...(active >= 1 && { color: "species" }),
+  }}
+  inspect={active >= 3 ? { mode: "xy", pin: true, maxDistance: 24 } : false}
+  legendFocus={active >= 1}
+  ariaLabel="Penguin body mass increases with flipper length, grouped by species"
+>
+  <Theme name={chartTheme} />
+  <GeomPoint alpha={0.72} />
+  {#if active >= 2}
+    <GeomSmooth method="loess" span={0.75} degree={1} se={false} />
+  {/if}
+</GGPlot>

--- a/apps/docs/src/lib/home-code-path.ts
+++ b/apps/docs/src/lib/home-code-path.ts
@@ -10,10 +10,10 @@
  * cases). Field names match the published dataset, not the short theme-specimen
  * aliases.
  *
- * Interaction: GrammarDemo step 4 uses exact inspect (nearest-point hover/pin
- * tooltips, no vertical axis guide). That is a GGPlot host prop — not a
- * PortableSpec field and not a builder method.
- * - Svelte / builder: set `inspect` on <GGPlot>
+ * Interaction: GrammarDemo step 4 uses xy inspect (numeric crosshair on both
+ * axes) plus legendFocus. Those are GGPlot host props — not PortableSpec
+ * fields and not builder methods.
+ * - Svelte / builder: set `inspect` / `legendFocus` / `key` on <GGPlot>
  * - JSON: agent envelope `{ interactions, spec }` (host maps interactions onto
  *   GGPlot props; bare PortableSpec is also accepted and defaults inspect on)
  */
@@ -25,8 +25,10 @@ const HOME_CODE_PATH_SVELTE = `<script lang="ts">
 
 <GGPlot
   data={palmerPenguins}
+  key="id"
   aes={{ x: "flipperLengthMm", y: "bodyMassG", color: "species" }}
-  inspect={{ mode: "exact", pin: true, maxDistance: 24 }}
+  inspect={{ mode: "xy", pin: true, maxDistance: 24 }}
+  legendFocus
   width={640}
   height={400}
 >
@@ -35,7 +37,7 @@ const HOME_CODE_PATH_SVELTE = `<script lang="ts">
 </GGPlot>
 `;
 
-/** Builder produces PortableSpec; inspect is enabled on the host GGPlot. */
+/** Builder produces PortableSpec; inspect/legendFocus are host GGPlot props. */
 const HOME_CODE_PATH_BUILDER = `<script lang="ts">
   import { aes, gg } from "@ggsvelte/spec";
   import { GGPlot } from "@ggsvelte/svelte";
@@ -52,7 +54,9 @@ const HOME_CODE_PATH_BUILDER = `<script lang="ts">
 
 <GGPlot
   {spec}
-  inspect={{ mode: "exact", pin: true, maxDistance: 24 }}
+  key="id"
+  inspect={{ mode: "xy", pin: true, maxDistance: 24 }}
+  legendFocus
   width={640}
   height={400}
 />
@@ -61,12 +65,12 @@ const HOME_CODE_PATH_BUILDER = `<script lang="ts">
 /**
  * Agent envelope: host interaction flags + named-data PortableSpec.
  * `spec` alone is valid PortableSpec; interactions are applied by the host.
- * `inspect: true` still defaults mode "auto" (path layers use x-crosshair);
- * the homepage host opts into exact via the Svelte/builder tabs above.
+ * `inspect: true` still defaults mode "auto"; the homepage host opts into xy.
  */
 const HOME_CODE_PATH_SPEC_JSON = `{
   "interactions": {
-    "inspect": true
+    "inspect": true,
+    "legendFocus": true
   },
   "spec": {
     "edition": 2,

--- a/apps/docs/src/lib/theme-specimens/static-svg.ts
+++ b/apps/docs/src/lib/theme-specimens/static-svg.ts
@@ -290,3 +290,40 @@ export function homeHeroStaticSvgFromData(
   cache.set(key, svg);
   return svg;
 }
+
+/**
+ * Homepage grammar-demo shell: full palmerPenguins scatter + loess, default
+ * interaction step (color + smooth). Static only — no inspect/legendFocus.
+ * Matches GrammarDemoPlot at active step 3 (Interaction).
+ */
+export function homeGrammarStaticSvgFromData(
+  rows: readonly Record<string, unknown>[],
+  input?: {
+    readonly theme?: ThemeName;
+    readonly width?: number;
+    readonly height?: number;
+  },
+): string {
+  const theme = input?.theme ?? "default";
+  const width = input?.width ?? DOCS_STATIC_PLOT_WIDTH_PX;
+  const height = input?.height ?? 400;
+  const key = `home-grammar:${theme}:${String(width)}x${String(height)}:${String(rows.length)}`;
+  const hit = cache.get(key);
+  if (hit !== undefined) return hit;
+  const spec = gg(
+    rows as AuthoringRows,
+    aes({ x: "flipperLengthMm", y: "bodyMassG", color: "species" }),
+  )
+    .geomPoint({ alpha: 0.72 })
+    .geomSmooth({ method: "loess", span: 0.75, degree: 1, se: false })
+    .theme(theme)
+    .labs({
+      x: "Flipper length mm",
+      y: "Body mass g",
+      color: "species",
+    })
+    .spec();
+  const svg = namespaceSvgIds(renderToSVGString(spec, { width, height }), key);
+  cache.set(key, svg);
+  return svg;
+}

--- a/apps/docs/src/routes/+page.server.ts
+++ b/apps/docs/src/routes/+page.server.ts
@@ -1,19 +1,33 @@
 import { guerry } from "$examples/point/scatter-color/data";
-import { homeHeroStaticSvgFromData } from "$lib/theme-specimens/static-svg";
+import { palmerPenguins } from "@ggsvelte/svelte/data";
+
+import {
+  homeGrammarStaticSvgFromData,
+  homeHeroStaticSvgFromData,
+} from "$lib/theme-specimens/static-svg";
 
 /**
- * Prerender hero shells so the home client does not import @ggsvelte/core.
- * Matches `contrastChartTheme()`: fivethirtyeight on the light site, light on
- * dark. CSS on the page picks the right shell from `data-theme` set by
- * static/theme.js before first paint.
+ * Prerender hero + grammar shells so the home client does not need
+ * @ggsvelte/core for first paint. Matches `contrastChartTheme()`:
+ * fivethirtyeight on the light site, light on dark. CSS picks the shell from
+ * `data-theme` set by static/theme.js before first paint.
  */
 export function load() {
+  const penguins = palmerPenguins as readonly Record<string, unknown>[];
   return {
     heroStaticSvgLightSite: homeHeroStaticSvgFromData(guerry, {
       theme: "fivethirtyeight",
       height: 400,
     }),
     heroStaticSvgDarkSite: homeHeroStaticSvgFromData(guerry, {
+      theme: "light",
+      height: 400,
+    }),
+    grammarStaticSvgLightSite: homeGrammarStaticSvgFromData(penguins, {
+      theme: "fivethirtyeight",
+      height: 400,
+    }),
+    grammarStaticSvgDarkSite: homeGrammarStaticSvgFromData(penguins, {
       theme: "light",
       height: 400,
     }),

--- a/apps/docs/src/routes/+page.svelte
+++ b/apps/docs/src/routes/+page.svelte
@@ -5,6 +5,7 @@
   import CodeTabs from "$lib/CodeTabs.svelte";
   import { FEATURED_EXAMPLES, galleryCatalog } from "$lib/catalog/gallery";
   import CopyCode from "$lib/components/CopyCode.svelte";
+  import GrammarDemo from "$lib/components/GrammarDemo.svelte";
   import UiButton from "$lib/components/UiButton.svelte";
   import { EXAMPLES } from "$lib/examples";
   import { HOME_CODE_PATH_TABS } from "$lib/home-code-path";
@@ -23,16 +24,10 @@
   let HeroPlot = $state<
     typeof import("$lib/components/HomeHeroPlot.svelte").default | null
   >(null);
-  let GrammarDemo = $state<
-    typeof import("$lib/components/GrammarDemo.svelte").default | null
-  >(null);
 
   onMount(() => {
     void import("$lib/components/HomeHeroPlot.svelte").then((mod) => {
       HeroPlot = mod.default;
-    });
-    void import("$lib/components/GrammarDemo.svelte").then((mod) => {
-      GrammarDemo = mod.default;
     });
   });
 </script>
@@ -102,9 +97,10 @@
   </ol>
 </section>
 
-{#if GrammarDemo !== null}
-  <GrammarDemo />
-{/if}
+<GrammarDemo
+  staticSvgLightSite={data.grammarStaticSvgLightSite}
+  staticSvgDarkSite={data.grammarStaticSvgDarkSite}
+/>
 
 <section class="code-path" aria-labelledby="code-path-heading">
   <div>

--- a/tests/visual/docs-home-gallery.spec.ts
+++ b/tests/visual/docs-home-gallery.spec.ts
@@ -143,14 +143,27 @@ test("homepage hero tooltip names a single department without axis crosshair noi
   await expect(tooltip.locator(".hero-tooltip")).toHaveCount(1);
 });
 
+test("homepage grammar section SSRs chrome and a static chart shell", async ({ request }) => {
+  const response = await request.get("/");
+  const html = await response.text();
+  // Section chrome is not gated on the dynamic plot import.
+  expect(html).toContain("Declare a layer interactive");
+  expect(html).toContain('id="grammar-heading"');
+  // Static shell ships before live GGPlot hydrates (same pattern as hero).
+  expect(html).toContain("grammar-static");
+  expect(html).toContain("Flipper length mm");
+});
+
 test("homepage grammar steps change real chart structure in place", async ({ page }) => {
   // Full palmerPenguins (333) + loess on step toggles is heavier than the old
   // 30-row specimen; cold CI hydrate already sits near the 60s project budget.
   test.setTimeout(120_000);
   await page.goto("/");
+  // Chrome is SSR'd immediately — not blocked on the dynamic plot chunk.
+  await expect(page.getByRole("heading", { name: "Declare a layer interactive" })).toBeVisible();
   const output = page.locator(".grammar-output");
   const plot = output.locator(".gg-plot-root");
-  // GrammarDemo is dynamic-imported; wait for the live plot before asserting structure.
+  // Live plot upgrades from the static shell after dynamic import.
   await expect(plot).toHaveAttribute("data-gg-ready", "true", {
     timeout: 60_000,
   });
@@ -174,12 +187,12 @@ test("homepage grammar steps change real chart structure in place", async ({ pag
   await expect(output.locator(".gg-paths")).toHaveCount(1, { timeout: 30_000 });
 });
 
-test("homepage grammar inspect is exact: point tooltip, no path x-crosshair", async ({ page }) => {
+test("homepage grammar inspect draws xy crosshair and supports legend focus", async ({ page }) => {
   await page.setViewportSize({ width: 1280, height: 900 });
   await page.goto("/?theme=dark");
   const output = page.locator(".grammar-output");
   await expect(output.locator(".gg-plot-root")).toHaveAttribute("data-gg-ready", "true", {
-    timeout: 30_000,
+    timeout: 60_000,
   });
   // Step 4 (Interaction) is the default open step.
   await expect(output.locator(".gg-capture")).toBeVisible();
@@ -193,8 +206,14 @@ test("homepage grammar inspect is exact: point tooltip, no path x-crosshair", as
   // path under auto mode "x" instead of a point.
   await expect(tooltip.getByText("species")).toBeVisible();
   await expect(tooltip.getByText("-")).toHaveCount(0);
-  // Exact mode: no full-panel vertical guide from path auto-mode "x".
-  await expect(output.locator(".gg-crosshair")).toHaveCount(0);
+  // mode "xy": full numeric crosshair — one line per continuous axis.
+  await expect(output.locator(".gg-crosshair")).toHaveCount(2);
+
+  // legendFocus: discrete color entries are keyboard-reachable targets.
+  const legendTarget = output.locator("[data-gg-legend-target]").first();
+  await expect(legendTarget).toBeVisible();
+  await legendTarget.focus();
+  await expect(legendTarget).toBeFocused();
 });
 
 test("homepage mobile order is claim, specimen, then install", async ({ page }) => {


### PR DESCRIPTION
## Summary

- **SSR shell for the mid-page grammar demo** (hero pattern): section chrome + static SVG ship in HTML so the block is never blank while the live plot chunk loads. Only `GrammarDemoPlot` is dynamically imported.
- **xy inspect** on the default Interaction step: full numeric crosshair on both continuous axes (not exact/no-guide).
- **`legendFocus`** with stable `key="id"` so species legend entries preview/pin like the interactions page.
- Static shells and live plot still use **fivethirtyeight** (light site) / **light** (dark site) and full **palmerPenguins**.

## Test plan

- [ ] Load `/` cold: grammar heading + chart shell visible immediately (no empty hole before code tabs).
- [ ] Live plot upgrades without flash of wrong theme.
- [ ] Interaction step: hover/keyboard shows **both** crosshair lines + tooltip; legend entry focuses and dims other series.
- [ ] Step accordion still switches Data → Mappings → Layers → Interaction.
- [ ] Code-path tabs show `inspect` xy + `legendFocus` + `key="id"`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1145" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->