### PR TITLE
fix(docs): match grammar live Labs to SSR shell titles

### DIFF
--- a/apps/docs/src/lib/components/GrammarDemoPlot.svelte
+++ b/apps/docs/src/lib/components/GrammarDemoPlot.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { GeomPoint, GeomSmooth, GGPlot, Theme } from "@ggsvelte/svelte";
+  import { GeomPoint, GeomSmooth, GGPlot, Labs, Theme } from "@ggsvelte/svelte";
   import { palmerPenguins } from "@ggsvelte/svelte/data";
 
   import { contrastChartTheme } from "$lib/docs-appearance-state.svelte";
@@ -10,6 +10,9 @@
    *
    * Default step (Interaction): xy inspect (numeric crosshair) + legendFocus.
    * Full palmerPenguins (333 complete cases).
+   *
+   * Labs titles must match `homeGrammarStaticSvgFromData` so the shell→live
+   * upgrade does not flash raw field names onto the axes.
    */
   let {
     active,
@@ -38,6 +41,7 @@
   ariaLabel="Penguin body mass increases with flipper length, grouped by species"
 >
   <Theme name={chartTheme} />
+  <Labs x="Flipper length mm" y="Body mass g" color="species" />
   <GeomPoint alpha={0.72} />
   {#if active >= 2}
     <GeomSmooth method="loess" span={0.75} degree={1} se={false} />

--- a/apps/docs/src/lib/home-code-path.ts
+++ b/apps/docs/src/lib/home-code-path.ts
@@ -19,7 +19,7 @@
  */
 
 const HOME_CODE_PATH_SVELTE = `<script lang="ts">
-  import { GeomPoint, GeomSmooth, GGPlot } from "@ggsvelte/svelte";
+  import { GeomPoint, GeomSmooth, GGPlot, Labs } from "@ggsvelte/svelte";
   import { palmerPenguins } from "@ggsvelte/svelte/data";
 </script>
 
@@ -32,6 +32,7 @@ const HOME_CODE_PATH_SVELTE = `<script lang="ts">
   width={640}
   height={400}
 >
+  <Labs x="Flipper length mm" y="Body mass g" color="species" />
   <GeomPoint alpha={0.72} />
   <GeomSmooth method="loess" span={0.75} degree={1} se={false} />
 </GGPlot>
@@ -49,6 +50,7 @@ const HOME_CODE_PATH_BUILDER = `<script lang="ts">
   )
     .geomPoint({ alpha: 0.72 })
     .geomSmooth({ method: "loess", span: 0.75, degree: 1, se: false })
+    .labs({ x: "Flipper length mm", y: "Body mass g", color: "species" })
     .spec();
 </script>
 

--- a/tests/visual/docs-home-gallery.spec.ts
+++ b/tests/visual/docs-home-gallery.spec.ts
@@ -172,6 +172,10 @@ test("homepage grammar steps change real chart structure in place", async ({ pag
   await expect(output.locator(".gg-legend")).toHaveCount(1);
   await expect(output.locator(".gg-paths")).toHaveCount(1);
   await expect(output.locator(".gg-capture")).toBeVisible();
+  // Labs match the SSR shell — no flash of raw field names on upgrade.
+  await expect(output.locator(".gg-axis-title", { hasText: "Flipper length mm" })).toBeVisible();
+  await expect(output.locator(".gg-axis-title", { hasText: "Body mass g" })).toBeVisible();
+  await expect(output.getByText("flipperLengthMm")).toHaveCount(0);
 
   await page.getByRole("button", { name: /Data/ }).click();
   await expect(output.locator(".gg-legend")).toHaveCount(0);


### PR DESCRIPTION
## Summary

Follow-up to #1145 (Devin finding): the static grammar shell had readable axis titles, but the live `GrammarDemoPlot` did not, so labels flashed to raw field names on upgrade.

Add matching `<Labs x="Flipper length mm" y="Body mass g" color="species" />` and pin that contract in the structure journey.

## Test plan

- [ ] Load `/`: shell and live plot both show **Flipper length mm** / **Body mass g**.
- [ ] No `flipperLengthMm` / `bodyMassG` axis titles after hydrate.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1146" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->