### PR TITLE
fix(docs): jitter + alpha on homepage penguins chart

### DIFF
--- a/apps/docs/src/lib/components/GrammarDemo.svelte
+++ b/apps/docs/src/lib/components/GrammarDemo.svelte
@@ -17,7 +17,7 @@
   const steps = [
     { label: "Data", note: "Rows as plain objects." },
     { label: "Mappings", note: "aes for x, y, and color." },
-    { label: "Layers", note: "GeomSmooth over GeomPoint." },
+    { label: "Layers", note: "GeomSmooth over GeomJitter." },
     { label: "Interaction", note: "just one more layer" },
   ] as const;
   let active = $state(steps.length - 1);

--- a/apps/docs/src/lib/components/GrammarDemoPlot.svelte
+++ b/apps/docs/src/lib/components/GrammarDemoPlot.svelte
@@ -1,5 +1,11 @@
 <script lang="ts">
-  import { GeomPoint, GeomSmooth, GGPlot, Labs, Theme } from "@ggsvelte/svelte";
+  import {
+    GeomJitter,
+    GeomSmooth,
+    GGPlot,
+    Labs,
+    Theme,
+  } from "@ggsvelte/svelte";
   import { palmerPenguins } from "@ggsvelte/svelte/data";
 
   import { contrastChartTheme } from "$lib/docs-appearance-state.svelte";
@@ -26,7 +32,9 @@
 <!--
   mode "xy": full crosshair on two continuous axes (not path auto "x").
   legendFocus needs stable row keys (`id` on palmerPenguins).
-  degree 1: local-linear loess stays cheap when remounting on 333 rows.
+  GeomJitter + alpha: 333 points stack on integer measurements; seeded jitter
+  (default 0.4·resolution) and alpha spread the cloud. degree 1 loess stays
+  cheap when remounting.
 -->
 <GGPlot
   data={palmerPenguins}
@@ -42,7 +50,7 @@
 >
   <Theme name={chartTheme} />
   <Labs x="Flipper length mm" y="Body mass g" color="species" />
-  <GeomPoint alpha={0.72} />
+  <GeomJitter alpha={0.55} />
   {#if active >= 2}
     <GeomSmooth method="loess" span={0.75} degree={1} se={false} />
   {/if}

--- a/apps/docs/src/lib/home-code-path.ts
+++ b/apps/docs/src/lib/home-code-path.ts
@@ -19,7 +19,7 @@
  */
 
 const HOME_CODE_PATH_SVELTE = `<script lang="ts">
-  import { GeomPoint, GeomSmooth, GGPlot, Labs } from "@ggsvelte/svelte";
+  import { GeomJitter, GeomSmooth, GGPlot, Labs } from "@ggsvelte/svelte";
   import { palmerPenguins } from "@ggsvelte/svelte/data";
 </script>
 
@@ -33,7 +33,7 @@ const HOME_CODE_PATH_SVELTE = `<script lang="ts">
   height={400}
 >
   <Labs x="Flipper length mm" y="Body mass g" color="species" />
-  <GeomPoint alpha={0.72} />
+  <GeomJitter alpha={0.55} />
   <GeomSmooth method="loess" span={0.75} degree={1} se={false} />
 </GGPlot>
 `;
@@ -48,7 +48,7 @@ const HOME_CODE_PATH_BUILDER = `<script lang="ts">
     palmerPenguins,
     aes({ x: "flipperLengthMm", y: "bodyMassG", color: "species" }),
   )
-    .geomPoint({ alpha: 0.72 })
+    .geomJitter({ alpha: 0.55 })
     .geomSmooth({ method: "loess", span: 0.75, degree: 1, se: false })
     .labs({ x: "Flipper length mm", y: "Body mass g", color: "species" })
     .spec();
@@ -79,15 +79,15 @@ const HOME_CODE_PATH_SPEC_JSON = `{
     "data": { "name": "palmerPenguins" },
     "layers": [
       {
-        "geom": "point",
+        "geom": "jitter",
         "stat": "identity",
-        "position": "identity",
+        "position": "jitter",
         "aes": {
           "x": { "field": "flipperLengthMm" },
           "y": { "field": "bodyMassG" },
           "color": { "field": "species" }
         },
-        "params": { "alpha": 0.72 }
+        "params": { "alpha": 0.55 }
       },
       {
         "geom": "smooth",

--- a/apps/docs/src/lib/theme-specimens/static-svg.ts
+++ b/apps/docs/src/lib/theme-specimens/static-svg.ts
@@ -314,7 +314,7 @@ export function homeGrammarStaticSvgFromData(
     rows as AuthoringRows,
     aes({ x: "flipperLengthMm", y: "bodyMassG", color: "species" }),
   )
-    .geomPoint({ alpha: 0.72 })
+    .geomJitter({ alpha: 0.55 })
     .geomSmooth({ method: "loess", span: 0.75, degree: 1, se: false })
     .theme(theme)
     .labs({


### PR DESCRIPTION
## Summary

Homepage grammar penguins chart (live plot, SSR shell, and code-path tabs) now uses **`GeomJitter`** with **`alpha={0.55}`** instead of opaque `GeomPoint`, so the 333-row cloud is easier to read where measurements stack.

## Test plan

- [ ] `/` grammar chart: points are jittered, slightly transparent.
- [ ] Shell and live plot match (no geometry flash beyond jitter seed).
- [ ] Code tabs show `GeomJitter` / `geomJitter` / `"geom": "jitter"`.
- [ ] Smooth, xy crosshair, and legend focus still work on Interaction step.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1149" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->