### PR TITLE
perf(core): O(log B) style bin index for binned style scales

### DIFF
--- a/.changeset/style-bin-binary-search.md
+++ b/.changeset/style-bin-binary-search.md
@@ -1,0 +1,15 @@
+---
+"@ggsvelte/core": patch
+"@ggsvelte/spec": patch
+"@ggsvelte/svelte": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+perf(core): O(log B) style bin lookup for binned size/shape/group
+
+Binned style scales and style-driven grouping used linear findIndex over
+break edges on every mapped row. styleBinIndex binary-searches the same
+left-closed contract (B ≤ 64). Color binned scales already did this.
+
+Migration: none — internal speedup only

--- a/packages/core/src/pipeline/frame-group-columns.ts
+++ b/packages/core/src/pipeline/frame-group-columns.ts
@@ -7,6 +7,7 @@ import { deriveGroups, type ChannelGroupingOverrides } from "../grouping.js";
 import { cellToNumber, type CellValue, type Discreteness } from "../table.js";
 import type { ColumnTable } from "../table.js";
 
+import { styleBinIndex } from "./style-bin-index.js";
 import { positionDiscreteness } from "./temporal-position.js";
 import type { LayerBinding } from "./types.js";
 
@@ -101,9 +102,7 @@ function binnedStyleColumn(
       if (binding.binOob !== "squish") return null;
       bounded = Math.min(breaks.at(-1)!, Math.max(breaks[0]!, value));
     }
-    let bin = breaks.findIndex((upper, index) => index > 0 && bounded < upper) - 1;
-    if (bin < 0) bin = breaks.length - 2;
-    return bin;
+    return styleBinIndex(breaks, bounded);
   });
 }
 

--- a/packages/core/src/pipeline/scale-style-finite.ts
+++ b/packages/core/src/pipeline/scale-style-finite.ts
@@ -14,6 +14,7 @@ import type {
   FiniteStyleConfig,
   StyleResolution,
 } from "./scale-style-types.js";
+import { styleBinIndex } from "./style-bin-index.js";
 import { PipelineError, type PipelineWarning } from "./types.js";
 
 function finiteResolution(input: {
@@ -203,9 +204,7 @@ function finiteResolution(input: {
         value > boundaries.at(-1)!
       )
         return unknownValue;
-      let index = boundaries.findIndex((upper, i) => i > 0 && value < upper) - 1;
-      if (index < 0) index = boundaries.length - 2;
-      return range[index]!;
+      return range[styleBinIndex(boundaries, value)]!;
     };
     const scale: StyleScale = Object.freeze({
       aesthetic,

--- a/packages/core/src/pipeline/scale-style-numeric.ts
+++ b/packages/core/src/pipeline/scale-style-numeric.ts
@@ -10,6 +10,7 @@ import { minAdjacentWidth, resolveStyleLegendFormat } from "./scale-color-sequen
 import { discreteStyleResolution, styleGuideEntry } from "./scale-style-discrete.js";
 import type { NumericStyleAesthetic, StyleResolution } from "./scale-style-types.js";
 import { resolveNumericStyleValueView, type NumericStyleConfig } from "./scale-style-values.js";
+import { styleBinIndex } from "./style-bin-index.js";
 import { PipelineError, type PipelineWarning } from "./types.js";
 
 const NUMERIC_DEFAULT_RANGE: Record<NumericStyleAesthetic, readonly [number, number]> = {
@@ -198,8 +199,7 @@ function numericSequentialResolution(input: {
     }
     let t: number;
     if (kind === "binned") {
-      let bin = boundaries.findIndex((upper, index) => index > 0 && bounded < upper) - 1;
-      if (bin < 0) bin = boundaries.length - 2;
+      const bin = styleBinIndex(boundaries, bounded);
       t = boundaries.length <= 2 ? 0.5 : bin / (boundaries.length - 2);
     } else {
       t = high === low ? 0.5 : (bounded - low) / (high - low);

--- a/packages/core/src/pipeline/style-bin-index.ts
+++ b/packages/core/src/pipeline/style-bin-index.ts
@@ -1,0 +1,30 @@
+/**
+ * Bin membership for style/group binned scales (size, alpha, shape, …).
+ *
+ * Contract matches the historical
+ * `boundaries.findIndex((upper, i) => i > 0 && value < upper) - 1`
+ * with a last-bin fallback when value equals the final boundary:
+ * bins are [b0, b1), [b1, b2), … and the last bin is closed on its upper edge.
+ *
+ * Binary search: O(log B) vs linear findIndex O(B) per mapped row (B ≤ 64).
+ */
+
+/**
+ * Return the bin index for a finite value already known to lie in
+ * [boundaries[0], boundaries.at(-1)] (callers handle OOB / NA).
+ */
+export function styleBinIndex(boundaries: readonly number[], value: number): number {
+  const lastBin = boundaries.length - 2;
+  if (lastBin < 0) return 0;
+  // First index i ∈ [1, length) with boundaries[i] > value (strict upper bound).
+  let lo = 1;
+  let hi = boundaries.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if (value < boundaries[mid]!) hi = mid;
+    else lo = mid + 1;
+  }
+  const bin = lo - 1;
+  if (bin < 0) return 0;
+  return bin > lastBin ? lastBin : bin;
+}

--- a/packages/core/tests/pipeline-style-bin-index.test.ts
+++ b/packages/core/tests/pipeline-style-bin-index.test.ts
@@ -1,0 +1,44 @@
+/**
+ * styleBinIndex — O(log B) membership matching the legacy findIndex contract.
+ */
+import { describe, expect, it } from "bun:test";
+
+import { styleBinIndex } from "../src/pipeline/style-bin-index.ts";
+
+/** Historical linear lookup used by binned style scales / group columns. */
+function legacyStyleBinIndex(boundaries: readonly number[], value: number): number {
+  let bin = boundaries.findIndex((upper, index) => index > 0 && value < upper) - 1;
+  if (bin < 0) bin = boundaries.length - 2;
+  return bin;
+}
+
+describe("styleBinIndex", () => {
+  it("matches findIndex on a dense break grid including edges and midpoints", () => {
+    const boundaries = Array.from({ length: 33 }, (_, i) => i * 0.5); // 0 … 16
+    const samples: number[] = [];
+    for (let i = 0; i < boundaries.length; i++) {
+      samples.push(boundaries[i]!);
+      if (i + 1 < boundaries.length) {
+        samples.push((boundaries[i]! + boundaries[i + 1]!) / 2);
+      }
+    }
+    samples.push(boundaries[0]! - 1, boundaries.at(-1)! + 1);
+    for (const value of samples) {
+      expect(styleBinIndex(boundaries, value)).toBe(legacyStyleBinIndex(boundaries, value));
+    }
+  });
+
+  it("places exact internal boundaries in the higher bin (left-closed intervals)", () => {
+    const b = [0, 1, 2, 3];
+    expect(styleBinIndex(b, 0)).toBe(0);
+    expect(styleBinIndex(b, 1)).toBe(1);
+    expect(styleBinIndex(b, 2)).toBe(2);
+    expect(styleBinIndex(b, 3)).toBe(2); // closed upper of last bin
+  });
+
+  it("handles a two-edge single bin", () => {
+    expect(styleBinIndex([0, 10], 0)).toBe(0);
+    expect(styleBinIndex([0, 10], 5)).toBe(0);
+    expect(styleBinIndex([0, 10], 10)).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- **Audit target:** `packages` (core/svelte hot paths after #1141/#1143/#1144)
- **Finding:** binned style `valueOf` and style-group columns used linear `findIndex` over break edges on every mapped row
- **Fix:** shared `styleBinIndex` binary search (same left-closed / last-bin-closed contract); used from numeric style, finite style, and frame-group columns
- **n =** data rows with binned size/linewidth/alpha/shape/linetype; **B ≤ 64** (`MAX_BINNED_BREAKS`)

## Tests

```
cd packages/core && bun test tests/pipeline-style-bin-index.test.ts tests/pipeline-style-families/
```

41 pass (legacy findIndex parity on dense grids + full style family suite).

## Notes

- Codex plan review blocked (usage limit); plan self-reviewed against color-binned binary search.
- No deferred issues: remaining candidateSemanticKeys per-candidate lineage expand is already lazily cached by candidate id; full-store shared-lineage key cache is optional polish, not filed.


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1150" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->