### PR TITLE
perf(docs): keep chart stack off layout and pure guide routes

### DIFF
--- a/apps/docs/src/lib/examples-manifest.ts
+++ b/apps/docs/src/lib/examples-manifest.ts
@@ -1,0 +1,10 @@
+/**
+ * Thin re-export of the example corpus metadata.
+ *
+ * Import this (not `$lib/examples`) from gallery, index, and other pages that
+ * only need ids/titles/tags. `$lib/examples` also registers `import.meta.glob`
+ * loaders for every Example.svelte; those loaders keep the chart stack on the
+ * critical path of any module that imports them.
+ */
+export { EXAMPLES } from "$examples/manifest";
+export type { ExampleManifestEntry } from "$examples/manifest";

--- a/apps/docs/src/lib/examples.ts
+++ b/apps/docs/src/lib/examples.ts
@@ -3,14 +3,16 @@
  * example modules themselves. Vite's import.meta.glob provides lazy module
  * access plus ?raw sources for the code triptych (spec JSON / builder /
  * Svelte — plan: "docs triptychs").
+ *
+ * Metadata-only consumers should import `$lib/examples-manifest` instead so
+ * they do not register the Example.svelte globs (and their chart deps).
  */
 import type { PortableSpec } from "@ggsvelte/spec";
 import type { Component } from "svelte";
 
 import { indexExampleModulesById, requireExampleModule } from "./example-module-index.js";
 
-export { EXAMPLES } from "$examples/manifest";
-export type { ExampleManifestEntry } from "$examples/manifest";
+export { EXAMPLES, type ExampleManifestEntry } from "./examples-manifest.js";
 
 const components = import.meta.glob<{ default: Component }>("$examples/*/*/Example.svelte");
 const specs = import.meta.glob<{ default: PortableSpec }>("$examples/*/*/spec.ts");

--- a/apps/docs/src/routes/+page.svelte
+++ b/apps/docs/src/routes/+page.svelte
@@ -7,7 +7,7 @@
   import CopyCode from "$lib/components/CopyCode.svelte";
   import GrammarDemo from "$lib/components/GrammarDemo.svelte";
   import UiButton from "$lib/components/UiButton.svelte";
-  import { EXAMPLES } from "$lib/examples";
+  import { EXAMPLES } from "$lib/examples-manifest";
   import { HOME_CODE_PATH_TABS } from "$lib/home-code-path";
 
   import type { PageProps } from "./$types";

--- a/apps/docs/src/routes/examples/+page.svelte
+++ b/apps/docs/src/routes/examples/+page.svelte
@@ -9,7 +9,7 @@
     serializeGalleryFilter,
     type GalleryFilterState,
   } from "$lib/gallery-filter";
-  import { EXAMPLES } from "$lib/examples";
+  import { EXAMPLES } from "$lib/examples-manifest";
 
   // One flat grid; the former featured six lead, the rest follow in
   // manifest order. Interaction expositions are not gallery specimens.

--- a/apps/docs/src/routes/examples/[category]/[name]/+page.svelte
+++ b/apps/docs/src/routes/examples/[category]/[name]/+page.svelte
@@ -3,7 +3,7 @@
 
   import CodeTabs from "$lib/CodeTabs.svelte";
   import { galleryCatalog } from "$lib/catalog/gallery";
-  import { EXAMPLES } from "$lib/examples";
+  import { EXAMPLES } from "$lib/examples-manifest";
   import { rankRelatedExamples } from "$lib/gallery-filter";
 
   import type { PageProps } from "./$types";

--- a/apps/docs/src/routes/guide/[slug]/+page.server.ts
+++ b/apps/docs/src/routes/guide/[slug]/+page.server.ts
@@ -6,10 +6,20 @@ import { renderMarkdown } from "$scripts/gen-llms";
 
 import type { EntryGenerator, PageServerLoad } from "./$types";
 
-/** Prerender one page per guide entry (adapter-static). */
-export const entries: EntryGenerator = () => GUIDE_PAGES.map((p) => ({ slug: p.slug }));
+/**
+ * Prerender markdown guide chapters only. `/guide/getting-started` is a
+ * dedicated static route so its client graph stays off every other chapter.
+ */
+export const entries: EntryGenerator = () =>
+  GUIDE_PAGES.filter((p) => p.slug !== "getting-started").map((p) => ({
+    slug: p.slug,
+  }));
 
 export const load: PageServerLoad = ({ params }) => {
+  if (params.slug === "getting-started") {
+    // Static segment `guide/getting-started` owns this URL; never dual-emit.
+    error(404, `No guide page "${params.slug}".`);
+  }
   const page = GUIDE_PAGES.find((p) => p.slug === params.slug);
   if (page === undefined) {
     error(404, `No guide page "${params.slug}".`);

--- a/apps/docs/src/routes/guide/[slug]/+page.svelte
+++ b/apps/docs/src/routes/guide/[slug]/+page.svelte
@@ -1,17 +1,17 @@
 <script lang="ts">
-  import GettingStartedGuide from "$lib/components/GettingStartedGuide.svelte";
+  /**
+   * Markdown guide chapters only. Getting started lives at
+   * `guide/getting-started/` so this client module stays free of the lesson
+   * chart dependency graph.
+   */
   import { attachGuideCodeCopy } from "$lib/guide-code-copy";
   import type { PageProps } from "./$types";
 
   const { data }: PageProps = $props();
 </script>
 
-{#if data.page.slug === "getting-started"}
-  <GettingStartedGuide />
-{:else}
-  <!-- Guide markdown is repository-authored catalog content, never user input. -->
-  <article class="guide prose" {@attach attachGuideCodeCopy}>
-    <!-- eslint-disable-next-line svelte/no-at-html-tags -->
-    {@html data.html}
-  </article>
-{/if}
+<!-- Guide markdown is repository-authored catalog content, never user input. -->
+<article class="guide prose" {@attach attachGuideCodeCopy}>
+  <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+  {@html data.html}
+</article>

--- a/apps/docs/src/routes/guide/getting-started/+page.server.ts
+++ b/apps/docs/src/routes/guide/getting-started/+page.server.ts
@@ -1,0 +1,14 @@
+import { GUIDE_PAGES } from "$lib/guide";
+
+import type { PageServerLoad } from "./$types";
+
+/** Keep layout SEO/title wired the same way as other guide chapters. */
+export const load: PageServerLoad = () => {
+  const page = GUIDE_PAGES.find((entry) => entry.slug === "getting-started");
+  if (page === undefined) {
+    throw new Error("getting-started guide page missing from GUIDE_PAGES");
+  }
+  return {
+    page: { slug: page.slug, title: page.title, description: page.description },
+  };
+};

--- a/apps/docs/src/routes/guide/getting-started/+page.svelte
+++ b/apps/docs/src/routes/guide/getting-started/+page.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  /**
+   * Dedicated route so pure markdown guide chapters under `guide/[slug]` do not
+   * share a client module with the lesson chart / copy-heavy getting-started
+   * graph. URL stays `/guide/getting-started` (static segment wins over [slug]).
+   */
+  import GettingStartedGuide from "$lib/components/GettingStartedGuide.svelte";
+</script>
+
+<GettingStartedGuide />

--- a/apps/docs/src/routes/interactions/+page.svelte
+++ b/apps/docs/src/routes/interactions/+page.svelte
@@ -3,7 +3,7 @@
 
   import { INTERACTION_EXPOSITION_IDS } from "$lib/catalog/interaction-exposition";
   import InteractionDemo from "$lib/components/InteractionDemo.svelte";
-  import { EXAMPLES } from "$lib/examples";
+  import { EXAMPLES } from "$lib/examples-manifest";
 
   const demos = INTERACTION_EXPOSITION_IDS.map((id) => {
     const entry = EXAMPLES.find((example) => example.id === id);

--- a/apps/docs/src/routes/llms-full.txt/+server.ts
+++ b/apps/docs/src/routes/llms-full.txt/+server.ts
@@ -10,7 +10,7 @@ import type { PortableSpec } from "@ggsvelte/spec";
 import type { LlmsFullExample } from "$scripts/gen-llms";
 import { buildLlmsFull, docsDiscoveryFacts, pruneSpecData } from "$scripts/gen-llms";
 
-import { EXAMPLES } from "$lib/examples";
+import { EXAMPLES } from "$lib/examples-manifest";
 import { indexExampleModulesById, requireExampleModule } from "$lib/example-module-index";
 import { docsBuildConfig } from "$lib/server/build-config";
 import { GUIDE_PAGES } from "$lib/guide";

--- a/apps/docs/src/routes/llms.txt/+server.ts
+++ b/apps/docs/src/routes/llms.txt/+server.ts
@@ -6,7 +6,7 @@
  */
 import { buildLlmsIndex, docsDiscoveryFacts } from "$scripts/gen-llms";
 
-import { EXAMPLES } from "$lib/examples";
+import { EXAMPLES } from "$lib/examples-manifest";
 import { docsBuildConfig } from "$lib/server/build-config";
 import { GUIDE_PAGES } from "$lib/guide";
 

--- a/apps/docs/src/routes/reference/geoms/[name]/+page.ts
+++ b/apps/docs/src/routes/reference/geoms/[name]/+page.ts
@@ -2,7 +2,7 @@ import { error } from "@sveltejs/kit";
 
 import { GEOM_REFERENCE, type GeomName, KNOWN_GEOMS } from "@ggsvelte/spec";
 
-import { EXAMPLES } from "$lib/examples";
+import { EXAMPLES } from "$lib/examples-manifest";
 
 import type { EntryGenerator, PageLoad } from "./$types";
 

--- a/apps/docs/src/routes/reference/positions/[name]/+page.ts
+++ b/apps/docs/src/routes/reference/positions/[name]/+page.ts
@@ -2,7 +2,7 @@ import { error } from "@sveltejs/kit";
 
 import { POSITION_REFERENCE, type PositionName, KNOWN_POSITIONS } from "@ggsvelte/spec";
 
-import { EXAMPLES } from "$lib/examples";
+import { EXAMPLES } from "$lib/examples-manifest";
 
 import type { EntryGenerator, PageLoad } from "./$types";
 

--- a/apps/docs/src/routes/reference/stats/[name]/+page.ts
+++ b/apps/docs/src/routes/reference/stats/[name]/+page.ts
@@ -2,7 +2,7 @@ import { error } from "@sveltejs/kit";
 
 import { STAT_REFERENCE, type StatName, KNOWN_STATS } from "@ggsvelte/spec";
 
-import { EXAMPLES } from "$lib/examples";
+import { EXAMPLES } from "$lib/examples-manifest";
 
 import type { EntryGenerator, PageLoad } from "./$types";
 

--- a/apps/docs/vite.config.ts
+++ b/apps/docs/vite.config.ts
@@ -1,9 +1,52 @@
 import { sveltekit } from "@sveltejs/kit/vite";
 import { defineConfig } from "vite";
 
+/**
+ * Keep the chart stack out of the root layout's shared chunks.
+ *
+ * Vite 8 uses Rolldown. Prefer `output.codeSplitting.groups` over deprecated
+ * `manualChunks` (which SvelteKit's own codeSplitting config can ignore).
+ *
+ * Without this, layout chrome co-chunks with `@ggsvelte/core` / GGPlot
+ * (~120–340KB decoded on every page). Chart pages still load these groups via
+ * their own imports.
+ */
 export default defineConfig({
   plugins: [sveltekit()],
   // The example corpus, shared doc generators (scripts/), and lifecycle.json
   // live outside the app root at the repo level.
   server: { fs: { allow: ["../.."] } },
+  build: {
+    rolldownOptions: {
+      output: {
+        codeSplitting: {
+          groups: [
+            // Higher priority than ggsvelte groups so Svelte runtime helpers
+            // stay out of the chart package chunks. Without this, layout loads
+            // ~360KB of ggsvelte-svelte just for attr/escape_html.
+            {
+              name: "svelte-runtime",
+              test: /[\\/]node_modules[\\/]svelte[\\/]/,
+              priority: 30,
+            },
+            {
+              name: "ggsvelte-core",
+              test: /(?:[\\/]node_modules[\\/]@ggsvelte[\\/]core[\\/]|[\\/]packages[\\/]core[\\/])/,
+              priority: 20,
+            },
+            {
+              name: "ggsvelte-svelte",
+              test: /(?:[\\/]node_modules[\\/]@ggsvelte[\\/]svelte[\\/]|[\\/]packages[\\/]svelte[\\/])/,
+              priority: 20,
+            },
+            {
+              name: "ggsvelte-spec",
+              test: /(?:[\\/]node_modules[\\/]@ggsvelte[\\/]spec[\\/]|[\\/]packages[\\/]spec[\\/])/,
+              priority: 20,
+            },
+          ],
+        },
+      },
+    },
+  },
 });

--- a/scripts/docs-chart-stack-isolation.test.ts
+++ b/scripts/docs-chart-stack-isolation.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Guards for docs PR1: chart stack stays off pure list/prose client modules.
+ *
+ * Source-level only (no full vite build) so unit CI stays cheap. Complements
+ * production benchmarks in .gstack/benchmark-reports/.
+ */
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+const root = path.join(import.meta.dirname, "..");
+const docsSrc = path.join(root, "apps/docs/src");
+
+function read(rel: string): string {
+  return readFileSync(path.join(docsSrc, rel), "utf8");
+}
+
+describe("docs chart stack isolation (PR1)", () => {
+  it("keeps gallery and pure list pages on the thin examples manifest", () => {
+    const gallery = read("routes/examples/+page.svelte");
+    const home = read("routes/+page.svelte");
+    const interactionsIndex = read("routes/interactions/+page.svelte");
+    for (const [label, source] of [
+      ["gallery", gallery],
+      ["home", home],
+      ["interactions index", interactionsIndex],
+    ] as const) {
+      expect(source, label).toContain("$lib/examples-manifest");
+      expect(source, label).not.toMatch(
+        /from\s*["']\$lib\/examples["']|from\s*["']\$lib\/examples\.js["']/,
+      );
+    }
+  });
+
+  it("does not put GettingStartedGuide on the shared markdown guide module", () => {
+    const markdownGuide = read("routes/guide/[slug]/+page.svelte");
+    expect(markdownGuide).not.toContain("GettingStartedGuide");
+    expect(markdownGuide).toContain("attachGuideCodeCopy");
+
+    const lesson = read("routes/guide/getting-started/+page.svelte");
+    expect(lesson).toContain("GettingStartedGuide");
+  });
+
+  it("excludes getting-started from the dynamic guide [slug] entries", () => {
+    const server = read("routes/guide/[slug]/+page.server.ts");
+    expect(server).toContain('p.slug !== "getting-started"');
+  });
+
+  it("isolates @ggsvelte packages via vite/rolldown codeSplitting groups", () => {
+    const vite = readFileSync(path.join(root, "apps/docs/vite.config.ts"), "utf8");
+    expect(vite).toContain("codeSplitting");
+    expect(vite).toContain("svelte-runtime");
+    expect(vite).toContain("ggsvelte-core");
+    expect(vite).toContain("ggsvelte-svelte");
+    expect(vite).toContain("ggsvelte-spec");
+    expect(vite).toContain("priority: 30");
+  });
+
+  it("keeps root layout free of static @ggsvelte chart imports", () => {
+    const layout = read("routes/+layout.svelte");
+    expect(layout).not.toMatch(/from\s*["']@ggsvelte\/(?:svelte|core)["']/);
+  });
+});


### PR DESCRIPTION
## Summary

First PR in a six-step docs performance experiment (baseline: production `ggsvelte.sh` before this change).

**Problem:** Root layout client code co-chunked Svelte runtime helpers with `@ggsvelte/svelte`, so *every* page downloaded ~350KB of chart package JS for `attr` / `escape_html`. Markdown guide chapters also shared a client module with Getting started’s lesson graph.

**Changes:**
1. Rolldown `codeSplitting.groups`: high-priority `svelte-runtime` group, then isolated `ggsvelte-{core,svelte,spec}` groups (Vite 8 / Rolldown; hash chunk names still apply).
2. Dedicated `/guide/getting-started` route so pure markdown chapters under `guide/[slug]` stay free of the lesson chart graph.
3. Thin `$lib/examples-manifest` for metadata-only pages (gallery, home, etc.) so they do not register Example.svelte globs.
4. Guard tests in `scripts/docs-chart-stack-isolation.test.ts`.

## Local measurements (built artifact)

| Signal | Before (prod / prior build) | After (this PR, local build) |
|--------|----------------------------|------------------------------|
| Layout deps named `ggsvelte-*` | ~353 KB | **0** |
| Layout total shared chunk deps | ~508 KB | ~211 KB |
| `/guide/interactions` JS decoded | ~407–417 KB (prod) | **~250 KB** |
| `/examples` JS decoded | ~348–357 KB (prod) | ~302 KB |
| Chart-heavy pages (getting-started, example detail, themes) | still load chart stack | still load chart stack (expected) |

Production re-benchmark after merge/deploy will confirm the marginal win on the edge CDN.

## Test plan

- [x] `bun test scripts/docs-chart-stack-isolation.test.ts`
- [x] `bun run build:docs` (full docs artifact)
- [ ] CI green
- [ ] After merge: re-benchmark production vs `.gstack/benchmark-reports/baselines/baseline-pre-docs-perf-experiment.json`

## Experiment series

1. **This PR** — isolate chart stack from layout / pure routes
2. Lazy-load search + icon bulk
3. Example pages: PNG first, live chart second
4. `csr = false` where nothing interactive runs
5. Shrink monster HTML (themes, getting-started)
6. HTML edge cache polish (`s-maxage`)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1152" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->