### PR TITLE
perf(svelte): cache candidate semantic keys by lineage membership

### DIFF
--- a/.changeset/candidate-keys-lineage-cache.md
+++ b/.changeset/candidate-keys-lineage-cache.md
@@ -1,0 +1,15 @@
+---
+"@ggsvelte/core": patch
+"@ggsvelte/spec": patch
+"@ggsvelte/svelte": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+perf(svelte): cache candidate semantic keys by lineage membership
+
+Interval, selection, and mask projection walk every candidate. Marks that
+share a lineage (smooth eval grids) now expand membership once and reuse
+the key bag. Single-candidate paths stay O(L) on first hit.
+
+Migration: none — internal speedup only

--- a/packages/svelte/src/lib/runtime/semantic-keys.svelte.ts
+++ b/packages/svelte/src/lib/runtime/semantic-keys.svelte.ts
@@ -9,8 +9,11 @@ import type { CandidateFacts, CellValue, RenderModel } from "@ggsvelte/core";
 import type { PortableSpec } from "@ggsvelte/spec";
 
 import type { InteractionDiagnostic } from "../interaction/interaction.js";
-import { rowIndexesForCandidate, uniqueKeysFromRowIndexes } from "../selection/selection.js";
-import { resolveSemanticKeysForPlot } from "./semantic-keys.js";
+import {
+  candidateSemanticKeysFromCache,
+  createCandidateKeysProjectionCache,
+  resolveSemanticKeysForPlot,
+} from "./semantic-keys.js";
 
 export type SemanticKeyServiceDeps = {
   model: () => RenderModel | null;
@@ -78,9 +81,10 @@ export function createSemanticKeyService(deps: SemanticKeyServiceDeps): Semantic
    * Interval, selection anchors, and interaction masks all used to re-walk
    * lineage independently (~3× O(C×L) per reactive turn). Entries fill lazily
    * on first lookup so single-candidate paths (point toggle) stay O(L); full
-   * store consumers still share one projection after the first walk. The Map
-   * is mutated after the derived produces it — intentional memoization, not
-   * reactive state. Fresh bag when model or row keys change.
+   * store consumers share one projection after the first walk. Smooth
+   * eval-grid marks that share a lineage expand membership once, not once
+   * per mark. Cache bags are mutated after the derived produces them —
+   * intentional memoization, not reactive state. Fresh bag when model/keys change.
    */
   const candidateKeysEpoch = $derived.by(() => {
     const model = deps.model();
@@ -89,19 +93,19 @@ export function createSemanticKeyService(deps: SemanticKeyServiceDeps): Semantic
     return {
       model,
       rowKeys,
-      cache: new Map<number, PropertyKey[]>(),
+      cache: createCandidateKeysProjectionCache(),
     };
   });
 
   function candidateSemanticKeys(candidate: CandidateFacts): PropertyKey[] {
     const { model, rowKeys, cache } = candidateKeysEpoch;
     if (model === null) return [];
-    const hit = cache.get(candidate.id);
-    if (hit !== undefined) return hit;
-    const rows = rowIndexesForCandidate(candidate, model.lineage.keys(candidate.lineage));
-    const keys = uniqueKeysFromRowIndexes(rows, (rowIndex) => rowKeys.get(rowIndex) ?? null);
-    cache.set(candidate.id, keys);
-    return keys;
+    return candidateSemanticKeysFromCache(
+      candidate,
+      cache,
+      (lineageId) => model.lineage.keys(lineageId),
+      (rowIndex) => rowKeys.get(rowIndex) ?? null,
+    );
   }
 
   return {

--- a/packages/svelte/src/lib/runtime/semantic-keys.ts
+++ b/packages/svelte/src/lib/runtime/semantic-keys.ts
@@ -7,6 +7,7 @@ import type { CellValue } from "@ggsvelte/core";
 
 import type { InteractionDiagnostic } from "../interaction/interaction.js";
 import { INTERACTION_DIAGNOSTIC_CATALOG } from "../interaction/interaction.js";
+import { uniqueKeysFromRowIndexes } from "../selection/selection.js";
 
 /**
  * Source-identity tracker owned by one GGPlot instance for the component
@@ -397,4 +398,73 @@ export function resolveSemanticKeys(input: ResolveSemanticKeysInput): ResolveSem
     }
   }
   return { keys, diagnostics };
+}
+
+// ---------------------------------------------------------------------------
+// Candidate → semantic-keys projection cache (interval / selection / masks)
+// ---------------------------------------------------------------------------
+
+/**
+ * Epoch-local cache for projecting candidates into semantic key bags.
+ * Smooth eval-grid marks share one lineage of L rows across C candidates —
+ * membership is computed once per (lineage, extra-row) bag, not once per mark.
+ */
+export type CandidateKeysProjectionCache = {
+  /** Repeat lookup for the same candidate id. */
+  readonly byCandidate: Map<number, PropertyKey[]>;
+  /** Expanded lineage membership (rows + Set) once per lineage id. */
+  readonly lineageRows: Map<number, { rows: readonly number[]; set: ReadonlySet<number> }>;
+  /** Key bag for a membership identity string. */
+  readonly byMembership: Map<string, PropertyKey[]>;
+};
+
+export function createCandidateKeysProjectionCache(): CandidateKeysProjectionCache {
+  return {
+    byCandidate: new Map(),
+    lineageRows: new Map(),
+    byMembership: new Map(),
+  };
+}
+
+export type CandidateKeysMembershipRef = {
+  readonly id: number;
+  readonly lineage: number;
+  readonly rowIndex: number | null;
+};
+
+/**
+ * Resolve semantic keys for one candidate via the epoch cache.
+ * `lineageKeys` is invoked at most once per distinct lineage id in the cache.
+ */
+export function candidateSemanticKeysFromCache(
+  candidate: CandidateKeysMembershipRef,
+  cache: CandidateKeysProjectionCache,
+  lineageKeys: (lineageId: number) => Iterable<number>,
+  keyForRow: (rowIndex: number) => PropertyKey | null,
+): PropertyKey[] {
+  const hit = cache.byCandidate.get(candidate.id);
+  if (hit !== undefined) return hit;
+
+  let bag = cache.lineageRows.get(candidate.lineage);
+  if (bag === undefined) {
+    const rows = [...lineageKeys(candidate.lineage)];
+    bag = { rows, set: new Set(rows) };
+    cache.lineageRows.set(candidate.lineage, bag);
+  }
+
+  const rowIndex = candidate.rowIndex;
+  const membershipKey =
+    rowIndex === null || bag.set.has(rowIndex)
+      ? `L${String(candidate.lineage)}`
+      : `L${String(candidate.lineage)}+${String(rowIndex)}`;
+
+  let keys = cache.byMembership.get(membershipKey);
+  if (keys === undefined) {
+    const rowList = rowIndex === null || bag.set.has(rowIndex) ? bag.rows : [...bag.rows, rowIndex];
+    keys = uniqueKeysFromRowIndexes(rowList, keyForRow);
+    cache.byMembership.set(membershipKey, keys);
+  }
+
+  cache.byCandidate.set(candidate.id, keys);
+  return keys;
 }

--- a/packages/svelte/tests/runtime/semantic-keys-pure.test.ts
+++ b/packages/svelte/tests/runtime/semantic-keys-pure.test.ts
@@ -9,6 +9,8 @@ import type { CellValue } from "@ggsvelte/core";
 
 import { INTERACTION_DIAGNOSTIC_CATALOG } from "../../src/lib/interaction/interaction.js";
 import {
+  candidateSemanticKeysFromCache,
+  createCandidateKeysProjectionCache,
   createSourceIdentityTracker,
   dataContentOrderToken,
   dataIdentityEpochToken,
@@ -589,6 +591,73 @@ describe("resolveSemanticKeys", () => {
       { layerIndex: 1, candidateId: 0 },
       { layerIndex: 1, candidateId: 1 },
     ]);
+  });
+});
+
+describe("candidateSemanticKeysFromCache", () => {
+  it("expands a shared lineage once across many candidates", () => {
+    const sharedRows = Array.from({ length: 60 }, (_, i) => i);
+    const keyForRow = (rowIndex: number): PropertyKey => `k${String(rowIndex)}`;
+    let lineageCalls = 0;
+    const lineageKeys = (lineageId: number) => {
+      lineageCalls += 1;
+      return lineageId === 9 ? sharedRows : [];
+    };
+    const cache = createCandidateKeysProjectionCache();
+    const keys: PropertyKey[][] = [];
+    for (let id = 0; id < 15; id++) {
+      keys.push(
+        candidateSemanticKeysFromCache(
+          { id, lineage: 9, rowIndex: null },
+          cache,
+          lineageKeys,
+          keyForRow,
+        ),
+      );
+    }
+    expect(lineageCalls).toBe(1);
+    expect(keys[0]).toEqual(sharedRows.map(keyForRow));
+    expect(keys[14]).toBe(keys[0]); // same bag reference
+  });
+
+  it("does not re-call lineageKeys for a candidate-local row already in the bag", () => {
+    let lineageCalls = 0;
+    const cache = createCandidateKeysProjectionCache();
+    const lineageKeys = (lineageId: number) => {
+      lineageCalls += 1;
+      return lineageId === 1 ? [0, 1, 2] : [];
+    };
+    const a = candidateSemanticKeysFromCache(
+      { id: 0, lineage: 1, rowIndex: 1 },
+      cache,
+      lineageKeys,
+      (r) => `k${String(r)}`,
+    );
+    const b = candidateSemanticKeysFromCache(
+      { id: 1, lineage: 1, rowIndex: 2 },
+      cache,
+      lineageKeys,
+      (r) => `k${String(r)}`,
+    );
+    expect(lineageCalls).toBe(1);
+    expect(a).toEqual(["k0", "k1", "k2"]);
+    expect(b).toBe(a);
+  });
+
+  it("appends a candidate row that is outside the shared lineage", () => {
+    let lineageCalls = 0;
+    const cache = createCandidateKeysProjectionCache();
+    const keys = candidateSemanticKeysFromCache(
+      { id: 0, lineage: 1, rowIndex: 99 },
+      cache,
+      (lineageId) => {
+        lineageCalls += 1;
+        return lineageId === 1 ? [0, 1] : [];
+      },
+      (r) => `k${String(r)}`,
+    );
+    expect(lineageCalls).toBe(1);
+    expect(keys).toEqual(["k0", "k1", "k99"]);
   });
 });
 

--- a/packages/svelte/tests/runtime/semantic-keys-pure.test.ts
+++ b/packages/svelte/tests/runtime/semantic-keys-pure.test.ts
@@ -616,7 +616,7 @@ describe("candidateSemanticKeysFromCache", () => {
       );
     }
     expect(lineageCalls).toBe(1);
-    expect(keys[0]).toEqual(sharedRows.map(keyForRow));
+    expect(keys[0]).toEqual(sharedRows.map((rowIndex) => keyForRow(rowIndex)));
     expect(keys[14]).toBe(keys[0]); // same bag reference
   });
 

--- a/packages/svelte/tests/runtime/semantic-keys-service.test.ts
+++ b/packages/svelte/tests/runtime/semantic-keys-service.test.ts
@@ -259,7 +259,7 @@ describe("createSemanticKeyService", () => {
     const first = walkAll();
     const callsAfterFirstWalk = keysSpy.mock.calls.length;
     expect(first).toEqual([["a"], ["b"]]);
-    // At least one lineage resolution per candidate on the cold walk.
+    // Distinct point lineages: one cold expansion per candidate membership.
     expect(callsAfterFirstWalk).toBeGreaterThanOrEqual(model.candidates.size);
 
     // Two more full walks (interval + selection consumers) must reuse the
@@ -271,6 +271,69 @@ describe("createSemanticKeyService", () => {
     keysSpy.mockRestore();
     destroy();
     model.dispose();
+  });
+
+  it("expands a shared lineage once on a full-store cold walk (smooth-shaped)", () => {
+    // Smooth eval grids share one lineage of L rows across C marks. The service
+    // must not call lineage.keys once per mark on the first projection walk.
+    const sharedRows = Array.from({ length: 40 }, (_, i) => i);
+    const lineage = {
+      keys: vi.fn((id: number) => (id === 7 ? sharedRows : [])),
+    };
+    const candidates = {
+      size: 12,
+      candidate(id: number) {
+        if (id < 0 || id >= 12) return null;
+        return {
+          id,
+          lineage: 7,
+          rowIndex: null,
+          layerIndex: 0,
+          x: 0,
+          y: 0,
+          kind: "points",
+          batchIndex: 0,
+          primitiveIndex: id,
+          panelId: "p0",
+        };
+      },
+    };
+    const model = {
+      candidates,
+      lineage,
+      row: (index: number) => ({ id: `k${String(index)}` }),
+      dispose() {},
+    } as unknown as RenderModel;
+
+    const tracker = createSourceIdentityTracker();
+    const { value: service, destroy } = withFlushedEffectRoot(() =>
+      createSemanticKeyService({
+        model: () => model,
+        assembled: () => null,
+        datumKey: () => "id",
+        data: () => sharedRows.map((i) => ({ id: `k${String(i)}` })),
+        spec: () => null,
+        sourceIdentity: (value) => tracker.sourceIdentity(value),
+        deliverDiagnostic: () => {},
+      }),
+    );
+
+    // resolveSemanticKeys already expanded lineage once at construction.
+    const afterResolve = lineage.keys.mock.calls.length;
+    expect(afterResolve).toBeGreaterThanOrEqual(1);
+
+    const bags: PropertyKey[][] = [];
+    for (let id = 0; id < 12; id++) {
+      const c = candidates.candidate(id);
+      expect(c).not.toBeNull();
+      bags.push(service.candidateSemanticKeys(c as never));
+    }
+    // Projection expands the shared lineage once more (not once per mark).
+    expect(lineage.keys.mock.calls.length - afterResolve).toBe(1);
+    expect(bags[0]?.length).toBe(40);
+    expect(bags[11]).toBe(bags[0]);
+
+    destroy();
   });
 
   it("rebuilds the candidate projection when the model is replaced", () => {


### PR DESCRIPTION
## Summary

- **Audit target:** `packages` (core/svelte hot paths after #1141/#1143/#1144/#1150)
- **Finding:** `candidateSemanticKeys` re-expanded shared lineage membership once per candidate on full-store walks (interval + selection + masks)
- **Fix:** `candidateSemanticKeysFromCache` expands each lineage once and reuses key bags for the same membership; service wires it into the epoch cache
- **n =** C candidates sharing a lineage of L source rows (smooth eval grid)

## Tests

```
cd packages/svelte && bun x vitest run --project chromium \
  tests/runtime/semantic-keys-pure.test.ts \
  tests/runtime/semantic-keys-service.test.ts
```

36 pass (shared-lineage call-count pins pure + service).

## Notes

- Codex plan review blocked (usage limit); plan self-reviewed.
- No deferred issues from this loop.


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1153" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->