### PR TITLE
perf(docs): defer SiteSearch and drop phosphor-svelte

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -17,7 +17,6 @@
     "@ggsvelte/spec": "workspace:*",
     "@ggsvelte/svelte": "workspace:*",
     "bits-ui": "^2.18.1",
-    "phosphor-svelte": "^3.1.0",
     "svelte-highlight": "^7.16.0"
   },
   "devDependencies": {

--- a/apps/docs/src/lib/CodeTabs.svelte
+++ b/apps/docs/src/lib/CodeTabs.svelte
@@ -4,8 +4,6 @@
    * spec JSON (what agents emit), fluent-builder TypeScript (spec.ts), and
    * idiomatic Svelte components (Example.svelte) — each with a copy button.
    */
-  import CheckIcon from "phosphor-svelte/lib/CheckIcon";
-  import CopyIcon from "phosphor-svelte/lib/CopyIcon";
   import Highlight from "svelte-highlight";
 
   import { briefCopyStatus, COPIED_STATUS, copyText } from "$lib/clipboard";
@@ -13,6 +11,7 @@
     languageFromCodeTabLabel,
     resolveCodeLanguage,
   } from "$lib/code-languages";
+  import { CHECK_ICON_SVG, COPY_ICON_SVG } from "$lib/copy-icons";
   import { nextRovingTabIndex } from "$lib/tab-roving";
 
   interface Tab {
@@ -103,9 +102,11 @@
       onclick={copy}
     >
       {#if copied}
-        <CheckIcon size={18} weight="bold" aria-hidden="true" />
+        <!-- eslint-disable-next-line svelte/no-at-html-tags -- trusted static SVG -->
+        {@html CHECK_ICON_SVG}
       {:else}
-        <CopyIcon size={18} weight="regular" aria-hidden="true" />
+        <!-- eslint-disable-next-line svelte/no-at-html-tags -- trusted static SVG -->
+        {@html COPY_ICON_SVG}
       {/if}
     </button>
     <span class="visually-hidden" role="status">{copyStatus}</span>

--- a/apps/docs/src/lib/components/CopyCode.svelte
+++ b/apps/docs/src/lib/components/CopyCode.svelte
@@ -1,10 +1,9 @@
 <script lang="ts">
-  import CheckIcon from "phosphor-svelte/lib/CheckIcon";
-  import CopyIcon from "phosphor-svelte/lib/CopyIcon";
   import Highlight from "svelte-highlight";
 
   import { briefCopyStatus, COPIED_STATUS, copyText } from "$lib/clipboard";
   import { resolveCodeLanguage } from "$lib/code-languages";
+  import { CHECK_ICON_SVG, COPY_ICON_SVG } from "$lib/copy-icons";
 
   const {
     code,
@@ -44,9 +43,11 @@
     onclick={copy}
   >
     {#if copied}
-      <CheckIcon size={18} weight="bold" aria-hidden="true" />
+      <!-- eslint-disable-next-line svelte/no-at-html-tags -- trusted static SVG -->
+      {@html CHECK_ICON_SVG}
     {:else}
-      <CopyIcon size={18} weight="regular" aria-hidden="true" />
+      <!-- eslint-disable-next-line svelte/no-at-html-tags -- trusted static SVG -->
+      {@html COPY_ICON_SVG}
     {/if}
   </button>
   <div class="code-body" bind:this={source}>

--- a/apps/docs/src/lib/components/SiteHeader.svelte
+++ b/apps/docs/src/lib/components/SiteHeader.svelte
@@ -11,14 +11,19 @@
   import { primaryNavLinks } from "$lib/primary-nav-links";
   import { primaryNavigationOwner } from "$lib/routes";
   import type { DocsRouteMetadata } from "$lib/route-types";
+  import type { Component } from "svelte";
 
-  import SiteSearch from "./SiteSearch.svelte";
+  type SiteSearchApi = { open: (trigger: HTMLElement) => void };
 
   const { path, route }: { path: string; route?: DocsRouteMetadata } = $props();
   const owner = $derived(primaryNavigationOwner(route));
 
   let menu = $state<HTMLDialogElement>();
-  let search = $state<{ open: (trigger: HTMLElement) => void }>();
+  let search = $state<SiteSearchApi | undefined>();
+  // Dynamic component; bind:this is narrowed via $effect after mount.
+  let SiteSearch = $state<Component | null>(null);
+  /** Open target while SiteSearch is mounting (first open only). */
+  let pendingSearchTrigger = $state<HTMLElement | null>(null);
   let appearance = $state<DocsAppearance>("light");
 
   const links = $derived(primaryNavLinks(path, owner));
@@ -37,10 +42,31 @@
     menu?.showModal();
   }
 
-  function openSearch(event: MouseEvent): void {
-    if (event.currentTarget instanceof HTMLElement)
-      search?.open(event.currentTarget);
+  /**
+   * Search UI + index stay off the first-paint graph. Mount the dialog on the
+   * first open, then call open() once bind:this is set.
+   */
+  async function openSearch(event: MouseEvent): Promise<void> {
+    if (!(event.currentTarget instanceof HTMLElement)) return;
+    const trigger = event.currentTarget;
+    if (search !== undefined) {
+      search.open(trigger);
+      return;
+    }
+    pendingSearchTrigger = trigger;
+    if (SiteSearch === null) {
+      const mod = await import("./SiteSearch.svelte");
+      SiteSearch = mod.default;
+    }
   }
+
+  $effect(() => {
+    const api = search;
+    const trigger = pendingSearchTrigger;
+    if (api === undefined || trigger === null) return;
+    pendingSearchTrigger = null;
+    api.open(trigger);
+  });
 
   function closeMenu(): void {
     menu?.close();
@@ -135,4 +161,13 @@
   </div>
 </dialog>
 
-<SiteSearch bind:this={search} />
+{#if SiteSearch}
+  <SiteSearch
+    bind:this={
+      () => search,
+      (value) => {
+        search = value as unknown as SiteSearchApi | undefined;
+      }
+    }
+  />
+{/if}

--- a/apps/docs/src/lib/copy-icons.ts
+++ b/apps/docs/src/lib/copy-icons.ts
@@ -1,0 +1,9 @@
+/**
+ * Inline copy/check icons (Phosphor paths). Shared by CopyCode, CodeTabs, and
+ * guide fence controls so pages do not pull `phosphor-svelte` on first paint.
+ */
+export const COPY_ICON_SVG =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor" viewBox="0 0 256 256" aria-hidden="true"><path d="M216,32H88a8,8,0,0,0-8,8V80H40a8,8,0,0,0-8,8V216a8,8,0,0,0,8,8H168a8,8,0,0,0,8-8V176h40a8,8,0,0,0,8-8V40A8,8,0,0,0,216,32ZM160,208H48V96H160Zm48-48H176V88a8,8,0,0,0-8-8H96V48H208Z"/></svg>';
+
+export const CHECK_ICON_SVG =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor" viewBox="0 0 256 256" aria-hidden="true"><path d="M229.66,77.66l-128,128a8,8,0,0,1-11.32,0l-56-56a8,8,0,0,1,11.32-11.32L96,188.69,218.34,66.34a8,8,0,0,1,11.32,11.32Z"/></svg>';

--- a/apps/docs/src/lib/guide-code-copy.ts
+++ b/apps/docs/src/lib/guide-code-copy.ts
@@ -6,14 +6,13 @@
  * (Svelte attachment). Everything else is module-private.
  */
 import { copyText, MANUAL_COPY_STATUS } from "./clipboard";
+import { CHECK_ICON_SVG, COPY_ICON_SVG } from "./copy-icons";
 
 /** Phosphor Copy (regular) — must match static HTML from llms-markdown. */
-export const GUIDE_COPY_ICON_SVG =
-  '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor" viewBox="0 0 256 256" aria-hidden="true"><path d="M216,32H88a8,8,0,0,0-8,8V80H40a8,8,0,0,0-8,8V216a8,8,0,0,0,8,8H168a8,8,0,0,0,8-8V176h40a8,8,0,0,0,8-8V40A8,8,0,0,0,216,32ZM160,208H48V96H160Zm48-48H176V88a8,8,0,0,0-8-8H96V48H208Z"/></svg>';
+export const GUIDE_COPY_ICON_SVG = COPY_ICON_SVG;
 
 /** Phosphor Check (bold) — client-only feedback after successful copy. */
-const GUIDE_CHECK_ICON_SVG =
-  '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor" viewBox="0 0 256 256" aria-hidden="true"><path d="M229.66,77.66l-128,128a8,8,0,0,1-11.32,0l-56-56a8,8,0,0,1,11.32-11.32L96,188.69,218.34,66.34a8,8,0,0,1,11.32,11.32Z"/></svg>';
+const GUIDE_CHECK_ICON_SVG = CHECK_ICON_SVG;
 
 const GUIDE_COPY_RESET_MS = 2000;
 

--- a/bun.lock
+++ b/bun.lock
@@ -38,7 +38,6 @@
         "@ggsvelte/spec": "workspace:*",
         "@ggsvelte/svelte": "workspace:*",
         "bits-ui": "^2.18.1",
-        "phosphor-svelte": "^3.1.0",
         "svelte-highlight": "^7.16.0",
       },
       "devDependencies": {
@@ -80,9 +79,9 @@
     },
     "packages/core": {
       "name": "@ggsvelte/core",
-      "version": "0.12.0",
+      "version": "0.15.1",
       "dependencies": {
-        "@ggsvelte/spec": "^0.12.0",
+        "@ggsvelte/spec": "^0.15.1",
       },
       "devDependencies": {
         "typescript": "^6.0.3",
@@ -90,7 +89,7 @@
     },
     "packages/spec": {
       "name": "@ggsvelte/spec",
-      "version": "0.12.0",
+      "version": "0.15.1",
       "dependencies": {
         "@js-temporal/polyfill": "^0.5.1",
         "typebox": "^1.3.6",
@@ -102,14 +101,14 @@
     },
     "packages/svelte": {
       "name": "@ggsvelte/svelte",
-      "version": "0.12.0",
+      "version": "0.15.1",
       "bin": {
         "ggsvelte-codemod": "bin/ggsvelte-codemod.js",
         "ggsvelte-render": "bin/ggsvelte-render.js",
       },
       "dependencies": {
-        "@ggsvelte/core": "^0.12.0",
-        "@ggsvelte/spec": "^0.12.0",
+        "@ggsvelte/core": "^0.15.1",
+        "@ggsvelte/spec": "^0.15.1",
       },
       "devDependencies": {
         "@sveltejs/package": "^2.5.8",
@@ -1073,8 +1072,6 @@
     "path-type": ["path-type@4.0.0", "", {}, "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="],
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
-
-    "phosphor-svelte": ["phosphor-svelte@3.1.0", "", { "dependencies": { "estree-walker": "^3.0.3", "magic-string": "^0.30.13" }, "peerDependencies": { "svelte": "^5.0.0 || ^5.0.0-next.96", "vite": ">=5" }, "optionalPeers": ["vite"] }, "sha512-nldtxx+XCgNREvrb7O5xgDsefytXpSkPTx8Rnu3f2qQCUZLDV1rLxYSd2Jcwckuo9lZB1qKMqGR17P4UDC0PrA=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -75,8 +75,8 @@
       "entry": ["src/routes/**/+*.ts", "src/lib/**/*.ts", "tests/**/*.test.ts"],
       "project": ["src/**/*.ts", "tests/**/*.ts", "*.{js,ts}"],
       // Imported only from .svelte files / the $examples alias, which knip
-      // does not trace. phosphor-svelte / bits-ui are deep-imported only from .svelte.
-      "ignoreDependencies": ["@ggsvelte/examples", "phosphor-svelte", "bits-ui"],
+      // does not trace. bits-ui is deep-imported only from .svelte.
+      "ignoreDependencies": ["@ggsvelte/examples", "bits-ui"],
     },
   },
 }

--- a/scripts/docs-search-icons-lazy.test.ts
+++ b/scripts/docs-search-icons-lazy.test.ts
@@ -1,0 +1,50 @@
+/**
+ * PR2 guards: search UI and phosphor stay off the default docs chrome graph.
+ */
+import { describe, expect, it } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+const docsSrc = path.join(import.meta.dirname, "../apps/docs/src");
+
+function walkFiles(root: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    const full = path.join(root, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "generated") continue;
+      out.push(...walkFiles(full));
+      continue;
+    }
+    if (/\.(svelte|ts|js)$/.test(entry.name)) out.push(full);
+  }
+  return out;
+}
+
+describe("docs search + icons lazy path (PR2)", () => {
+  it("does not statically import phosphor-svelte from docs UI", () => {
+    const offenders: string[] = [];
+    for (const file of walkFiles(docsSrc)) {
+      const source = readFileSync(file, "utf8");
+      if (/from\s*["']phosphor-svelte/.test(source)) {
+        offenders.push(path.relative(docsSrc, file));
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it("loads SiteSearch only via dynamic import from the header", () => {
+    const header = readFileSync(path.join(docsSrc, "lib/components/SiteHeader.svelte"), "utf8");
+    expect(header).not.toMatch(/import\s+SiteSearch\s+from\s*["']\.\/SiteSearch\.svelte["']/);
+    expect(header).toContain('import("./SiteSearch.svelte")');
+  });
+
+  it("shares inline copy icons for CopyCode and guide fences", () => {
+    const icons = readFileSync(path.join(docsSrc, "lib/copy-icons.ts"), "utf8");
+    expect(icons).toContain("COPY_ICON_SVG");
+    expect(icons).toContain("CHECK_ICON_SVG");
+    const copyCode = readFileSync(path.join(docsSrc, "lib/components/CopyCode.svelte"), "utf8");
+    expect(copyCode).toContain("$lib/copy-icons");
+    expect(copyCode).not.toContain("phosphor-svelte");
+  });
+});


### PR DESCRIPTION
## Summary

PR2 of the docs performance experiment (after #1152).

- SiteSearch is dynamically imported on first open, so the search dialog leaves the default layout graph.
- phosphor-svelte removed; CopyCode and CodeTabs share inline copy/check SVGs with guide fences (lib/copy-icons).
- Search index was already lazy; this finishes the chrome side.

## Test plan

- [x] bun test scripts/docs-search-icons-lazy.test.ts scripts/guide-code-copy.test.ts scripts/docs-search-lazy.test.ts
- [x] svelte-check clean for apps/docs
- [ ] CI green
- [ ] After merge: production re-benchmark vs post-PR1

## Experiment series

1. Isolate chart stack (#1152) — done
2. This PR — lazy search chrome + drop phosphor
3. Example pages: PNG first, live chart second
4. csr = false where nothing interactive runs
5. Shrink monster HTML
6. HTML edge cache polish

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1154" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->