### PR TITLE
fix(docs): lighten homepage jitter alpha to 0.88

### DIFF
--- a/apps/docs/src/lib/components/GrammarDemoPlot.svelte
+++ b/apps/docs/src/lib/components/GrammarDemoPlot.svelte
@@ -50,7 +50,7 @@
 >
   <Theme name={chartTheme} />
   <Labs x="Flipper length mm" y="Body mass g" color="species" />
-  <GeomJitter alpha={0.55} />
+  <GeomJitter alpha={0.88} />
   {#if active >= 2}
     <GeomSmooth method="loess" span={0.75} degree={1} se={false} />
   {/if}

--- a/apps/docs/src/lib/home-code-path.ts
+++ b/apps/docs/src/lib/home-code-path.ts
@@ -33,7 +33,7 @@ const HOME_CODE_PATH_SVELTE = `<script lang="ts">
   height={400}
 >
   <Labs x="Flipper length mm" y="Body mass g" color="species" />
-  <GeomJitter alpha={0.55} />
+  <GeomJitter alpha={0.88} />
   <GeomSmooth method="loess" span={0.75} degree={1} se={false} />
 </GGPlot>
 `;
@@ -48,7 +48,7 @@ const HOME_CODE_PATH_BUILDER = `<script lang="ts">
     palmerPenguins,
     aes({ x: "flipperLengthMm", y: "bodyMassG", color: "species" }),
   )
-    .geomJitter({ alpha: 0.55 })
+    .geomJitter({ alpha: 0.88 })
     .geomSmooth({ method: "loess", span: 0.75, degree: 1, se: false })
     .labs({ x: "Flipper length mm", y: "Body mass g", color: "species" })
     .spec();
@@ -87,7 +87,7 @@ const HOME_CODE_PATH_SPEC_JSON = `{
           "y": { "field": "bodyMassG" },
           "color": { "field": "species" }
         },
-        "params": { "alpha": 0.55 }
+        "params": { "alpha": 0.88 }
       },
       {
         "geom": "smooth",

--- a/apps/docs/src/lib/theme-specimens/static-svg.ts
+++ b/apps/docs/src/lib/theme-specimens/static-svg.ts
@@ -314,7 +314,7 @@ export function homeGrammarStaticSvgFromData(
     rows as AuthoringRows,
     aes({ x: "flipperLengthMm", y: "bodyMassG", color: "species" }),
   )
-    .geomJitter({ alpha: 0.55 })
+    .geomJitter({ alpha: 0.88 })
     .geomSmooth({ method: "loess", span: 0.75, degree: 1, se: false })
     .theme(theme)
     .labs({


### PR DESCRIPTION
## Summary

Homepage penguins `GeomJitter` alpha was **0.55** (too washed out). Raise it to **0.88** on the live plot, SSR shell, and code-path tabs.

## Test plan

- [ ] `/` grammar chart: points look nearly solid, only a slight transparency.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1156" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->