### PR TITLE
perf(docs): example pages PNG-first, live chart second

### DIFF
--- a/apps/docs/src/lib/catalog/gallery.ts
+++ b/apps/docs/src/lib/catalog/gallery.ts
@@ -23,10 +23,19 @@ const previewById = new Map<string, string>(
   GALLERY_PREVIEWS.map((preview) => [preview.id, preview.path]),
 );
 
+/** Resolved static preview path for an example id (including interaction demos). */
+export function previewPathFor(id: string): string {
+  const previewPath = previewById.get(id);
+  if (previewPath === undefined) throw new Error(`Missing generated preview for ${id}`);
+  return previewPath;
+}
+
 export function galleryEntryFor(entry: ExampleManifestEntry): GalleryEntry {
-  const previewPath = previewById.get(entry.id);
-  if (previewPath === undefined) throw new Error(`Missing generated preview for ${entry.id}`);
-  return { ...entry, previewPath, featured: featuredIds.has(entry.id) };
+  return {
+    ...entry,
+    previewPath: previewPathFor(entry.id),
+    featured: featuredIds.has(entry.id),
+  };
 }
 
 /** Manifest entries that belong on the public gallery (not interaction expositions). */

--- a/apps/docs/src/lib/components/ExampleLiveFrame.svelte
+++ b/apps/docs/src/lib/components/ExampleLiveFrame.svelte
@@ -32,31 +32,40 @@
 
   let host = $state<HTMLDivElement | null>(null);
   let Live = $state<Component | null>(null);
+  let loadStarted = false;
+  let cancelled = false;
+
+  function startLoad(): void {
+    if (loadStarted || Live !== null) return;
+    loadStarted = true;
+    void loadExampleComponent(exampleId).then((component) => {
+      if (!cancelled) Live = component;
+    });
+  }
+
+  // Kick off the VR import as soon as the client module runs (before paint
+  // settles). onMount still owns near-viewport upgrades for normal visits.
+  if (typeof window !== "undefined") {
+    const params = new URLSearchParams(window.location.search);
+    if (params.has("vr")) startLoad();
+  }
 
   onMount(() => {
-    const el = host;
-    if (el === null) return;
-    let cancelled = false;
-
-    const load = (): void => {
-      if (cancelled || Live !== null) return;
-      void loadExampleComponent(exampleId).then((component) => {
-        if (!cancelled) Live = component;
-      });
-    };
-
-    const eager =
-      typeof window !== "undefined" &&
-      new URLSearchParams(window.location.search).has("vr");
-
-    if (eager) {
-      load();
+    cancelled = false;
+    if (Live !== null || loadStarted) {
       return () => {
         cancelled = true;
       };
     }
-
-    const stop = observeNearViewport(el, load, { rootMargin: "480px 0px" });
+    const el = host;
+    if (el === null) {
+      return () => {
+        cancelled = true;
+      };
+    }
+    const stop = observeNearViewport(el, startLoad, {
+      rootMargin: "480px 0px",
+    });
     return () => {
       cancelled = true;
       stop();

--- a/apps/docs/src/lib/components/ExampleLiveFrame.svelte
+++ b/apps/docs/src/lib/components/ExampleLiveFrame.svelte
@@ -1,0 +1,106 @@
+<script lang="ts">
+  /**
+   * Example detail frame: paint the gallery PNG first, then upgrade to the
+   * live Example.svelte chart near the viewport so first paint / LCP do not
+   * wait on the chart stack.
+   *
+   * `?vr` forces an immediate upgrade so visual regression can wait on
+   * `.gg-plot-root[data-gg-ready]` without racing IntersectionObserver.
+   */
+  import { base } from "$app/paths";
+  import { onMount } from "svelte";
+  import type { Component } from "svelte";
+
+  import { loadExampleComponent } from "$lib/examples";
+  import { observeNearViewport } from "$lib/near-viewport";
+
+  const {
+    exampleId,
+    previewPath,
+    title,
+    width,
+    height,
+    fullWidth = false,
+  }: {
+    exampleId: string;
+    previewPath: string;
+    title: string;
+    width: number;
+    height: number;
+    fullWidth?: boolean;
+  } = $props();
+
+  let host = $state<HTMLDivElement | null>(null);
+  let Live = $state<Component | null>(null);
+
+  onMount(() => {
+    const el = host;
+    if (el === null) return;
+    let cancelled = false;
+
+    const load = (): void => {
+      if (cancelled || Live !== null) return;
+      void loadExampleComponent(exampleId).then((component) => {
+        if (!cancelled) Live = component;
+      });
+    };
+
+    const eager =
+      typeof window !== "undefined" &&
+      new URLSearchParams(window.location.search).has("vr");
+
+    if (eager) {
+      load();
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    const stop = observeNearViewport(el, load, { rootMargin: "480px 0px" });
+    return () => {
+      cancelled = true;
+      stop();
+    };
+  });
+</script>
+
+<div
+  class="gg-example-frame"
+  class:full-width={fullWidth}
+  bind:this={host}
+  style={`--example-vr-width:${String(width)}px;--example-vr-height:${String(height)}px`}
+>
+  {#if Live !== null}
+    <Live />
+  {:else}
+    <img
+      class="example-preview"
+      src={`${base}${previewPath}`}
+      alt={title}
+      {width}
+      {height}
+      decoding="async"
+      fetchpriority="high"
+    />
+  {/if}
+</div>
+
+<style>
+  .gg-example-frame {
+    margin: 2.5rem 0;
+    width: 100%;
+    max-width: var(--example-vr-width);
+    min-width: 0;
+  }
+
+  .gg-example-frame.full-width {
+    max-width: none;
+  }
+
+  .example-preview {
+    display: block;
+    width: 100%;
+    height: auto;
+    background: #fff;
+  }
+</style>

--- a/apps/docs/src/lib/examples.ts
+++ b/apps/docs/src/lib/examples.ts
@@ -31,25 +31,44 @@ const specsById = indexExampleModulesById(specs, "spec.ts");
 const specSourcesById = indexExampleModulesById(specSources, "spec.ts");
 const svelteSourcesById = indexExampleModulesById(svelteSources, "Example.svelte");
 
-export interface LoadedExample {
-  component: Component;
+export interface ExampleSources {
   spec: PortableSpec;
   specSource: string;
   svelteSource: string;
 }
 
-/** Load one example's live component, canonical spec, and raw sources. */
-export async function loadExample(id: string): Promise<LoadedExample> {
-  const [component, spec, specSource, svelteSource] = await Promise.all([
-    requireExampleModule(componentsById, id, "Example.svelte")(),
+export interface LoadedExample extends ExampleSources {
+  component: Component;
+}
+
+/**
+ * Load code-tab sources only (no Example.svelte / chart stack).
+ * Use on example pages that paint a PNG first and upgrade client-side.
+ */
+export async function loadExampleSources(id: string): Promise<ExampleSources> {
+  const [spec, specSource, svelteSource] = await Promise.all([
     requireExampleModule(specsById, id, "spec.ts")(),
     requireExampleModule(specSourcesById, id, "spec.ts")(),
     requireExampleModule(svelteSourcesById, id, "Example.svelte")(),
   ]);
   return {
-    component: component.default,
     spec: spec.default,
     specSource,
     svelteSource,
   };
+}
+
+/** Dynamically import one example's live Svelte chart component. */
+export async function loadExampleComponent(id: string): Promise<Component> {
+  const component = await requireExampleModule(componentsById, id, "Example.svelte")();
+  return component.default;
+}
+
+/** Load one example's live component, canonical spec, and raw sources. */
+export async function loadExample(id: string): Promise<LoadedExample> {
+  const [component, sources] = await Promise.all([
+    loadExampleComponent(id),
+    loadExampleSources(id),
+  ]);
+  return { component, ...sources };
 }

--- a/apps/docs/src/routes/examples/[category]/[name]/+page.svelte
+++ b/apps/docs/src/routes/examples/[category]/[name]/+page.svelte
@@ -3,13 +3,13 @@
 
   import CodeTabs from "$lib/CodeTabs.svelte";
   import { galleryCatalog } from "$lib/catalog/gallery";
+  import ExampleLiveFrame from "$lib/components/ExampleLiveFrame.svelte";
   import { EXAMPLES } from "$lib/examples-manifest";
   import { rankRelatedExamples } from "$lib/gallery-filter";
 
   import type { PageProps } from "./$types";
 
   const { data }: PageProps = $props();
-  const Example = $derived(data.component);
   const frameWidth = $derived(data.entry.vrWidth ?? 640);
   const frameHeight = $derived(data.entry.vrHeight ?? 400);
   const galleryEntries = galleryCatalog(EXAMPLES);
@@ -61,13 +61,14 @@
     </section>
   {/if}
 
-  <div
-    class="gg-example-frame"
-    class:full-width={data.entry.journey?.fullWidth}
-    style={`--example-vr-width:${String(frameWidth)}px;--example-vr-height:${String(frameHeight)}px`}
-  >
-    <Example />
-  </div>
+  <ExampleLiveFrame
+    exampleId={data.entry.id}
+    previewPath={data.previewPath}
+    title={data.entry.title}
+    width={frameWidth}
+    height={frameHeight}
+    fullWidth={data.entry.journey?.fullWidth ?? false}
+  />
 
   <section
     class="example-prose code-section"
@@ -190,17 +191,6 @@
     max-width: 45rem;
     color: var(--muted);
     font-size: 1.1rem;
-  }
-
-  .gg-example-frame {
-    margin: 2.5rem 0;
-    width: 100%;
-    max-width: var(--example-vr-width);
-    min-width: 0;
-  }
-
-  .gg-example-frame.full-width {
-    max-width: none;
   }
 
   .try-it {

--- a/apps/docs/src/routes/examples/[category]/[name]/+page.svelte
+++ b/apps/docs/src/routes/examples/[category]/[name]/+page.svelte
@@ -61,14 +61,16 @@
     </section>
   {/if}
 
-  <ExampleLiveFrame
-    exampleId={data.entry.id}
-    previewPath={data.previewPath}
-    title={data.entry.title}
-    width={frameWidth}
-    height={frameHeight}
-    fullWidth={data.entry.journey?.fullWidth ?? false}
-  />
+  {#key data.entry.id}
+    <ExampleLiveFrame
+      exampleId={data.entry.id}
+      previewPath={data.previewPath}
+      title={data.entry.title}
+      width={frameWidth}
+      height={frameHeight}
+      fullWidth={data.entry.journey?.fullWidth ?? false}
+    />
+  {/key}
 
   <section
     class="example-prose code-section"

--- a/apps/docs/src/routes/examples/[category]/[name]/+page.ts
+++ b/apps/docs/src/routes/examples/[category]/[name]/+page.ts
@@ -1,7 +1,8 @@
 import { error } from "@sveltejs/kit";
 
+import { previewPathFor } from "$lib/catalog/gallery";
 import { EXAMPLE_ALIASES, resolveExampleId } from "$lib/example-aliases";
-import { EXAMPLES, loadExample } from "$lib/examples";
+import { EXAMPLES, loadExampleSources } from "$lib/examples";
 
 import type { EntryGenerator, PageLoad } from "./$types";
 
@@ -24,5 +25,11 @@ export const load: PageLoad = async ({ params }) => {
   if (entry === undefined) {
     error(404, `No example "${requestedId}" — see /examples for the gallery.`);
   }
-  return { entry, ...(await loadExample(id)) };
+  // Sources only — live Example.svelte mounts client-side after the PNG paints
+  // (see ExampleLiveFrame). Avoids blocking page load on the chart stack.
+  return {
+    entry,
+    previewPath: previewPathFor(id),
+    ...(await loadExampleSources(id)),
+  };
 };

--- a/scripts/docs-example-png-first.test.ts
+++ b/scripts/docs-example-png-first.test.ts
@@ -26,6 +26,8 @@ describe("docs example PNG-first (PR3)", () => {
     expect(page).toContain("ExampleLiveFrame");
     expect(page).not.toMatch(/\bdata\.component\b/);
     expect(page).not.toMatch(/<\s*Example\s*\/>/);
+    // Remount on client nav so Live state does not stick to the prior id.
+    expect(page).toContain("{#key data.entry.id}");
   });
 
   it("defers Example.svelte via near-viewport or ?vr eager load", () => {

--- a/scripts/docs-example-png-first.test.ts
+++ b/scripts/docs-example-png-first.test.ts
@@ -35,6 +35,8 @@ describe("docs example PNG-first (PR3)", () => {
     expect(frame).toContain('has("vr")');
     expect(frame).toContain("example-preview");
     expect(frame).toContain("previewPath");
+    // VR starts the import at module init, not only in onMount.
+    expect(frame).toContain('typeof window !== "undefined"');
   });
 
   it("keeps loadExample for callers that still need the full bundle", () => {

--- a/scripts/docs-example-png-first.test.ts
+++ b/scripts/docs-example-png-first.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Guards for docs PR3: example detail pages paint the gallery PNG first and
+ * only load Example.svelte (chart stack) via a deferred client import.
+ */
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+const root = path.join(import.meta.dirname, "..");
+const docsSrc = path.join(root, "apps/docs/src");
+
+function read(rel: string): string {
+  return readFileSync(path.join(docsSrc, rel), "utf8");
+}
+
+describe("docs example PNG-first (PR3)", () => {
+  it("loads sources only in the example page load function", () => {
+    const pageLoad = read("routes/examples/[category]/[name]/+page.ts");
+    expect(pageLoad).toContain("loadExampleSources");
+    expect(pageLoad).toContain("previewPathFor");
+    expect(pageLoad).not.toMatch(/loadExample\b(?!Sources)|loadExampleComponent/);
+  });
+
+  it("mounts the live chart only through ExampleLiveFrame", () => {
+    const page = read("routes/examples/[category]/[name]/+page.svelte");
+    expect(page).toContain("ExampleLiveFrame");
+    expect(page).not.toMatch(/\bdata\.component\b/);
+    expect(page).not.toMatch(/<\s*Example\s*\/>/);
+  });
+
+  it("defers Example.svelte via near-viewport or ?vr eager load", () => {
+    const frame = read("lib/components/ExampleLiveFrame.svelte");
+    expect(frame).toContain("loadExampleComponent");
+    expect(frame).toContain("observeNearViewport");
+    expect(frame).toContain('has("vr")');
+    expect(frame).toContain("example-preview");
+    expect(frame).toContain("previewPath");
+  });
+
+  it("keeps loadExample for callers that still need the full bundle", () => {
+    const examples = read("lib/examples.ts");
+    expect(examples).toContain("export async function loadExampleSources");
+    expect(examples).toContain("export async function loadExampleComponent");
+    expect(examples).toContain("export async function loadExample");
+  });
+});

--- a/tests/visual/helpers/deterministic.ts
+++ b/tests/visual/helpers/deterministic.ts
@@ -18,5 +18,10 @@ export async function settleVisualState(page: Page, expectedPlots = 1): Promise<
       });
     });
   });
-  await expect(page.locator('.gg-plot-root[data-gg-ready="true"]')).toHaveCount(expectedPlots);
+  // 30s: example pages may cold-import the chart stack after a PNG placeholder
+  // (ExampleLiveFrame / near-viewport upgrade). First smoke case after a fresh
+  // worker is the slow path; cached modules keep later cases well under this.
+  await expect(page.locator('.gg-plot-root[data-gg-ready="true"]')).toHaveCount(expectedPlots, {
+    timeout: 30_000,
+  });
 }


### PR DESCRIPTION
## Summary

- Example detail pages (`/examples/...`) no longer await `Example.svelte` in the page load.
- First paint uses the existing gallery PNG; live chart upgrades near the viewport via `ExampleLiveFrame`.
- `?vr` still eager-loads the live chart so VR can wait on `.gg-plot-root[data-gg-ready]`.
- Split `loadExampleSources` / `loadExampleComponent`; `loadExample` remains for interaction demos.

## Context

Docs perf experiment PR3 of 6 (after #1152 chart isolation, #1154 lazy search/icons). Target metric: `/examples/point/scatter-color` JS/first paint without blocking on the chart stack.

## Test plan

- [x] `bun test scripts/docs-example-png-first.test.ts` (and PR1/PR2 structural suites)
- [x] `bun run check:docs` (svelte-check clean)
- [x] knip clean
- [ ] CI unit + docs jobs
- [ ] After merge: re-benchmark production vs post-PR1 baseline

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1160" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->