### PR TITLE
perf(docs): csr=false on pure prose and static reference routes

### DIFF
--- a/apps/docs/src/lib/components/DocsShell.svelte
+++ b/apps/docs/src/lib/components/DocsShell.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { Snippet } from "svelte";
 
+  import { attachGuideCodeCopy } from "$lib/guide-code-copy";
   import { GUIDE_NAVIGATION, primaryNavigationOwner } from "$lib/routes";
   import type { DocsRouteMetadata } from "$lib/route-types";
 
@@ -127,7 +128,7 @@
     <DocsSidebar groups={GUIDE_NAVIGATION} {path} />
   </aside>
 
-  <div class="docs-article">
+  <div class="docs-article" {@attach attachGuideCodeCopy}>
     <Breadcrumbs {crumbs} />
     {@render children()}
     <PrevNext {previous} {next} />

--- a/apps/docs/src/routes/docs/+page.ts
+++ b/apps/docs/src/routes/docs/+page.ts
@@ -1,0 +1,2 @@
+/** Docs hub is static links only — no page-level client interactivity. */
+export const csr = false;

--- a/apps/docs/src/routes/guide/[slug]/+page.server.ts
+++ b/apps/docs/src/routes/guide/[slug]/+page.server.ts
@@ -7,6 +7,12 @@ import { renderMarkdown } from "$scripts/gen-llms";
 import type { EntryGenerator, PageServerLoad } from "./$types";
 
 /**
+ * Pure prerendered HTML — no page hydration. Layout/DocsShell still hydrate
+ * for nav, appearance, and guide fence copy (attachGuideCodeCopy on shell).
+ */
+export const csr = false;
+
+/**
  * Prerender markdown guide chapters only. `/guide/getting-started` is a
  * dedicated static route so its client graph stays off every other chapter.
  */

--- a/apps/docs/src/routes/guide/[slug]/+page.svelte
+++ b/apps/docs/src/routes/guide/[slug]/+page.svelte
@@ -3,15 +3,17 @@
    * Markdown guide chapters only. Getting started lives at
    * `guide/getting-started/` so this client module stays free of the lesson
    * chart dependency graph.
+   *
+   * csr=false: pure prerendered HTML. Code-fence copy is handled by DocsShell
+   * (layout still hydrates for chrome). Getting-started stays csr=true.
    */
-  import { attachGuideCodeCopy } from "$lib/guide-code-copy";
   import type { PageProps } from "./$types";
 
   const { data }: PageProps = $props();
 </script>
 
 <!-- Guide markdown is repository-authored catalog content, never user input. -->
-<article class="guide prose" {@attach attachGuideCodeCopy}>
+<article class="guide prose">
   <!-- eslint-disable-next-line svelte/no-at-html-tags -->
   {@html data.html}
 </article>

--- a/apps/docs/src/routes/reference/+page.ts
+++ b/apps/docs/src/routes/reference/+page.ts
@@ -1,0 +1,2 @@
+/** Reference hub is static links only — no page-level client interactivity. */
+export const csr = false;

--- a/apps/docs/src/routes/reference/geoms/[name]/+page.ts
+++ b/apps/docs/src/routes/reference/geoms/[name]/+page.ts
@@ -8,6 +8,9 @@ import type { EntryGenerator, PageLoad } from "./$types";
 
 const GEOM_SET = new Set<string>(KNOWN_GEOMS);
 
+/** Static API card — no page hydration (layout chrome still hydrates). */
+export const csr = false;
+
 /** Prerender one page per geom (adapter-static). */
 export const entries: EntryGenerator = () => KNOWN_GEOMS.map((name) => ({ name }));
 

--- a/apps/docs/src/routes/reference/positions/[name]/+page.ts
+++ b/apps/docs/src/routes/reference/positions/[name]/+page.ts
@@ -8,6 +8,9 @@ import type { EntryGenerator, PageLoad } from "./$types";
 
 const POSITION_SET = new Set<string>(KNOWN_POSITIONS);
 
+/** Static API card — no page hydration (layout chrome still hydrates). */
+export const csr = false;
+
 /** Prerender one page per position (adapter-static). */
 export const entries: EntryGenerator = () => KNOWN_POSITIONS.map((name) => ({ name }));
 

--- a/apps/docs/src/routes/reference/stats/[name]/+page.ts
+++ b/apps/docs/src/routes/reference/stats/[name]/+page.ts
@@ -8,6 +8,9 @@ import type { EntryGenerator, PageLoad } from "./$types";
 
 const STAT_SET = new Set<string>(KNOWN_STATS);
 
+/** Static API card — no page hydration (layout chrome still hydrates). */
+export const csr = false;
+
 /** Prerender one page per stat (adapter-static). */
 export const entries: EntryGenerator = () => KNOWN_STATS.map((name) => ({ name }));
 

--- a/scripts/docs-chart-stack-isolation.test.ts
+++ b/scripts/docs-chart-stack-isolation.test.ts
@@ -35,7 +35,9 @@ describe("docs chart stack isolation (PR1)", () => {
   it("does not put GettingStartedGuide on the shared markdown guide module", () => {
     const markdownGuide = read("routes/guide/[slug]/+page.svelte");
     expect(markdownGuide).not.toContain("GettingStartedGuide");
-    expect(markdownGuide).toContain("attachGuideCodeCopy");
+    // Fence copy lives on DocsShell so guide/[slug] can use csr=false (PR4).
+    expect(markdownGuide).not.toContain("attachGuideCodeCopy");
+    expect(read("lib/components/DocsShell.svelte")).toContain("attachGuideCodeCopy");
 
     const lesson = read("routes/guide/getting-started/+page.svelte");
     expect(lesson).toContain("GettingStartedGuide");

--- a/scripts/docs-csr-false.test.ts
+++ b/scripts/docs-csr-false.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Guards for docs PR4: pure prose / static list routes skip page hydration
+ * (csr=false) while layout chrome and guide fence copy stay interactive.
+ */
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+const docsSrc = path.join(import.meta.dirname, "../apps/docs/src");
+
+function read(rel: string): string {
+  return readFileSync(path.join(docsSrc, rel), "utf8");
+}
+
+describe("docs csr=false on inert routes (PR4)", () => {
+  it("disables page CSR on pure markdown guide chapters", () => {
+    const server = read("routes/guide/[slug]/+page.server.ts");
+    expect(server).toMatch(/export\s+const\s+csr\s*=\s*false/);
+    const page = read("routes/guide/[slug]/+page.svelte");
+    expect(page).not.toContain("attachGuideCodeCopy");
+    expect(page).not.toContain("GettingStartedGuide");
+  });
+
+  it("keeps getting-started hydratable (live lesson chart)", () => {
+    const lesson = read("routes/guide/getting-started/+page.svelte");
+    expect(lesson).toContain("GettingStartedGuide");
+    // No csr=false colocated with getting-started.
+    try {
+      const server = read("routes/guide/getting-started/+page.server.ts");
+      expect(server).not.toMatch(/export\s+const\s+csr\s*=\s*false/);
+    } catch {
+      // optional server file
+    }
+  });
+
+  it("attaches guide fence copy on DocsShell so csr=false guides still copy", () => {
+    const shell = read("lib/components/DocsShell.svelte");
+    expect(shell).toContain("attachGuideCodeCopy");
+    expect(shell).toContain("{@attach attachGuideCodeCopy}");
+  });
+
+  it("disables page CSR on static hubs and reference detail cards", () => {
+    for (const rel of [
+      "routes/docs/+page.ts",
+      "routes/reference/+page.ts",
+      "routes/reference/geoms/[name]/+page.ts",
+      "routes/reference/stats/[name]/+page.ts",
+      "routes/reference/positions/[name]/+page.ts",
+    ]) {
+      expect(read(rel), rel).toMatch(/export\s+const\s+csr\s*=\s*false/);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- `export const csr = false` on pure prose / static routes:
  - `/guide/[slug]` (markdown chapters; not getting-started)
  - `/docs`, `/reference` hubs
  - `/reference/geoms|stats|positions/[name]` detail cards
- Move guide fence copy attachment to `DocsShell` so csr=false guides still copy code.
- Layout chrome (search, theme, nav) still hydrates.

## Context

Docs perf experiment PR4 of 6 (after #1152, #1154, #1160). Win surface: pure prose guides and static lists — less page hydration work. Chart pages stay client-interactive.

## Test plan

- [x] `bun test scripts/docs-csr-false.test.ts` (+ updated PR1 isolation guard)
- [x] `bun run check:docs`
- [ ] CI
- [ ] After merge: re-benchmark production


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1162" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->