### PR TITLE
refactor(ci): split ci-routing CLI command families (#1174)

### DIFF
--- a/scripts/ci-routing.test.ts
+++ b/scripts/ci-routing.test.ts
@@ -1306,6 +1306,88 @@ describe("success-marker CLI carries shard identity", () => {
   });
 });
 
+/**
+ * GITHUB_OUTPUT append is shared via cli-io.writeGithubOutput. Spawn tests that
+ * only assert stdout cannot catch a dropped append — cover hash-inputs,
+ * emit-github-output, and validate-success-marker here (detect-changes has its
+ * own smoke in detect-changes.test.ts).
+ */
+describe("CLI GITHUB_OUTPUT writes", () => {
+  test("hash-inputs appends the same body it prints to GITHUB_OUTPUT", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "ci-routing-gh-out-"));
+    const outPath = join(dir, "github_output");
+    try {
+      const out = await spawnCiRoutingCli(
+        ["hash-inputs", "--execution", "component_svelte_fx", "--os", "Linux", "--shard", "2/3"],
+        { GITHUB_OUTPUT: outPath },
+      );
+      expect(out.exitCode).toBe(0);
+      expect(readFileSync(outPath, "utf8")).toBe(out.stdout);
+      expect(out.stdout).toContain("hash=");
+      expect(out.stdout).toContain("cache_key=");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("emit-github-output appends the routing body to GITHUB_OUTPUT", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "ci-routing-emit-out-"));
+    const outPath = join(dir, "github_output");
+    try {
+      const proc = Bun.spawn(
+        ["bun", "scripts/ci-routing.ts", "emit-github-output", "--force-all", "--stdin"],
+        {
+          cwd: join(import.meta.dir, ".."),
+          env: { ...process.env, GITHUB_OUTPUT: outPath },
+          stdin: "pipe",
+          stdout: "pipe",
+          stderr: "pipe",
+        },
+      );
+      await proc.stdin.write("packages/spec/src/index.ts\n");
+      await proc.stdin.end();
+      const [stdout, exitCode] = await Promise.all([new Response(proc.stdout).text(), proc.exited]);
+      expect(exitCode).toBe(0);
+      expect(readFileSync(outPath, "utf8")).toBe(stdout);
+      expect(stdout).toContain("unit=true");
+      expect(stdout).toContain("bypass_content_cache=");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("validate-success-marker writes hit=… to GITHUB_OUTPUT", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "ci-routing-validate-out-"));
+    const outPath = join(dir, "github_output");
+    try {
+      // Miss path: no marker file under throwaway cwd → hit=false in both sinks.
+      const proc = Bun.spawn(
+        [
+          "bun",
+          join(import.meta.dir, "ci-routing.ts"),
+          "validate-success-marker",
+          "--execution",
+          "unit",
+          "--hash",
+          "deadbeef",
+        ],
+        {
+          cwd: dir,
+          env: { ...process.env, GITHUB_OUTPUT: outPath },
+          stdout: "pipe",
+          stderr: "pipe",
+        },
+      );
+      const [stdout, exitCode] = await Promise.all([new Response(proc.stdout).text(), proc.exited]);
+      expect(exitCode).toBe(0);
+      expect(stdout).toBe("hit=false\n");
+      expect(readFileSync(outPath, "utf8")).toBe("hit=false\n");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
 describe("ci-routing module tree (split-safe)", () => {
   test("subtree files set ci_routing, force full surface, and bypass content cache", () => {
     for (const file of [
@@ -1313,6 +1395,9 @@ describe("ci-routing module tree (split-safe)", () => {
       "scripts/ci-routing/routing.ts",
       "scripts/ci-routing/content-hash.ts",
       "scripts/ci-routing/cli.ts",
+      "scripts/ci-routing/cli-io.ts",
+      "scripts/ci-routing/content-hash-cli.ts",
+      "scripts/ci-routing/detect-changes-cli.ts",
     ]) {
       const flags = classifyChangedPaths([file]);
       expect(flags.ci_routing, file).toBe(true);
@@ -1333,10 +1418,16 @@ describe("ci-routing module tree (split-safe)", () => {
         "scripts/ci-routing/routing.ts",
         "scripts/ci-routing/content-hash.ts",
         "scripts/ci-routing/cli.ts",
+        "scripts/ci-routing/cli-io.ts",
+        "scripts/ci-routing/content-hash-cli.ts",
+        "scripts/ci-routing/detect-changes-cli.ts",
       ]);
       expect(matched, execution).toContain("scripts/ci-routing/routing.ts");
       expect(matched, execution).toContain("scripts/ci-routing/content-hash.ts");
       expect(matched, execution).toContain("scripts/ci-routing/cli.ts");
+      expect(matched, execution).toContain("scripts/ci-routing/cli-io.ts");
+      expect(matched, execution).toContain("scripts/ci-routing/content-hash-cli.ts");
+      expect(matched, execution).toContain("scripts/ci-routing/detect-changes-cli.ts");
     }
   });
 

--- a/scripts/ci-routing.ts
+++ b/scripts/ci-routing.ts
@@ -7,7 +7,10 @@
  * - `scripts/ci-routing/content-hash-inputs.ts` — JOB_CONTENT_INPUTS tables
  * - `scripts/ci-routing/content-hash-markers.ts` — success markers
  * - `scripts/ci-routing/content-hash.ts` — hash, cache keys, git digests
- * - `scripts/ci-routing/cli.ts` — argv commands (not re-exported)
+ * - `scripts/ci-routing/cli.ts` — argv dispatch + plan/classify/emit + gates
+ * - `scripts/ci-routing/cli-io.ts` — shared flagValue / GITHUB_OUTPUT write
+ * - `scripts/ci-routing/content-hash-cli.ts` — hash-inputs / success markers
+ * - `scripts/ci-routing/detect-changes-cli.ts` — detect-changes production IO
  *
  * Workflows and composite actions continue to run:
  *   bun scripts/ci-routing.ts <command> …

--- a/scripts/ci-routing/cli-io.ts
+++ b/scripts/ci-routing/cli-io.ts
@@ -1,0 +1,19 @@
+/**
+ * Shared CLI I/O helpers for ci-routing command modules.
+ * GITHUB_OUTPUT writes go through writeGithubOutput so call sites stay consistent.
+ */
+import { appendFileSync } from "node:fs";
+
+/** Append a body to $GITHUB_OUTPUT when set; no-op otherwise. */
+export function writeGithubOutput(body: string): void {
+  const outPath = process.env["GITHUB_OUTPUT"];
+  if (typeof outPath === "string" && outPath.length > 0) {
+    appendFileSync(outPath, body);
+  }
+}
+
+export function flagValue(args: string[], flag: string): string | undefined {
+  const i = args.indexOf(flag);
+  if (i < 0) return undefined;
+  return args[i + 1];
+}

--- a/scripts/ci-routing/cli.ts
+++ b/scripts/ci-routing/cli.ts
@@ -1,10 +1,12 @@
 /**
- * CLI for path routing and content-hash helpers.
+ * CLI dispatcher for path routing, gates, and content-hash helpers.
  * Invoked only via `scripts/ci-routing.ts` (`import.meta.main` lives there).
+ *
+ * Command modules:
+ * - ./detect-changes-cli — detect-changes production adapter
+ * - ./content-hash-cli — hash-inputs / write / validate success markers
+ * - ./cli-io — shared flagValue / writeGithubOutput
  */
-import { appendFileSync, mkdirSync, writeFileSync } from "node:fs";
-import { spawnSync } from "node:child_process";
-
 import {
   classifyChangedPaths,
   evaluateGate,
@@ -17,24 +19,14 @@ import {
 } from "./routing";
 import { evaluateCiGate } from "./ci-gate";
 import { evaluateVrGate } from "./vr-gate";
+import { shouldBypassContentCache } from "./content-hash";
+import { flagValue, writeGithubOutput } from "./cli-io";
+import { runDetectChangesCli } from "./detect-changes-cli";
 import {
-  CACHEABLE_EXECUTIONS,
-  CONTENT_HASH_SCHEMA,
-  type CacheableExecution,
-  type ExecutionShard,
-} from "./content-hash-types";
-import {
-  parseSuccessMarker,
-  serializeSuccessMarker,
-  successMarkerPath,
-  validateSuccessMarker,
-} from "./content-hash-markers";
-import {
-  collectGitHeadInputDigests,
-  contentHashCacheKey,
-  shouldBypassContentCache,
-} from "./content-hash";
-import { runDetectChanges, type DetectChangesInput, type DetectChangesIo } from "./detect-changes";
+  runHashInputsCli,
+  runValidateSuccessMarkerCli,
+  runWriteSuccessMarkerCli,
+} from "./content-hash-cli";
 
 export async function runCiRoutingCli(argv: string[]): Promise<void> {
   const args = argv.slice(2);
@@ -65,10 +57,7 @@ export async function runCiRoutingCli(argv: string[]): Promise<void> {
     const plan = planJobs(changes, { forceAll });
     const bypassContentCache = shouldBypassContentCache(changes, { forceAll });
     const body = formatGithubOutputs(plan, { bypassContentCache });
-    const outPath = process.env["GITHUB_OUTPUT"];
-    if (typeof outPath === "string" && outPath.length > 0) {
-      appendFileSync(outPath, body);
-    }
+    writeGithubOutput(body);
     process.stdout.write(body);
     return;
   }
@@ -153,104 +142,6 @@ function printHelp(): void {
 }
 
 /**
- * Production I/O for `detect-changes` — mirrors the former ci.yml bash:
- * swallow gh/git fetch/diff failures; exact-key GITHUB_OUTPUT write.
- */
-function createDetectChangesIo(): DetectChangesIo {
-  return {
-    commandExists(name: string): boolean {
-      const r = spawnSync("bash", ["-c", `command -v ${JSON.stringify(name)}`], {
-        encoding: "utf8",
-      });
-      return r.status === 0;
-    },
-    findLastSuccessfulMainHead(repo: string, headSha: string): string | undefined {
-      // Issue #244 cumulative main range. See lastSuccessfulMainHeadJq — gh api
-      // has no jq --arg; the former bash form was a silent no-op under `|| true`.
-      const r = spawnSync(
-        "gh",
-        [
-          "api",
-          `repos/${repo}/actions/workflows/ci.yml/runs?branch=main&status=completed&per_page=20`,
-          "--jq",
-          lastSuccessfulMainHeadJq(headSha),
-        ],
-        { encoding: "utf8", maxBuffer: 10 * 1024 * 1024 },
-      );
-      if (r.status !== 0) return undefined;
-      const sha = (r.stdout ?? "").trim();
-      return sha.length > 0 ? sha : undefined;
-    },
-    gitFetchDepth1(sha: string): void {
-      spawnSync("git", ["fetch", "--no-tags", "--depth=1", "origin", sha], {
-        encoding: "utf8",
-        stdio: "ignore",
-      });
-    },
-    gitCommitExists(sha: string): boolean {
-      const r = spawnSync("git", ["cat-file", "-e", `${sha}^{commit}`], {
-        encoding: "utf8",
-        stdio: "ignore",
-      });
-      return r.status === 0;
-    },
-    gitDiffNameStatus(base: string, head: string): string[] | "error" {
-      // Large renames can exceed Node's default 1 MiB maxBuffer; treat overflow
-      // as error → force-all rather than silent checks-only.
-      const r = spawnSync("git", ["diff", "--name-status", `${base}...${head}`], {
-        encoding: "utf8",
-        maxBuffer: 50 * 1024 * 1024,
-      });
-      if (r.error || r.status !== 0) return "error";
-      const text = r.stdout ?? "";
-      return text
-        .split(/\r?\n/)
-        .map((l) => l.trimEnd())
-        .filter((l) => l.length > 0);
-    },
-    writeGithubOutput(body: string): void {
-      writeGithubOutput(body);
-      process.stdout.write(body);
-    },
-    log(msg: string): void {
-      process.stdout.write(`${msg}\n`);
-    },
-  };
-}
-
-/** jq program for last successful main CI head, excluding the current head. */
-export function lastSuccessfulMainHeadJq(headSha: string): string {
-  const headLit = JSON.stringify(headSha);
-  return `[.workflow_runs[] | select(.conclusion == "success" and .head_sha != ${headLit}) | .head_sha][0] // empty`;
-}
-
-function runDetectChangesCli(): void {
-  const env = process.env;
-  const input: DetectChangesInput = {
-    eventName: env["EVENT_NAME"] ?? "",
-    githubRef: env["GITHUB_REF"] ?? "",
-    baseSha: env["BASE_SHA"] ?? "",
-    headSha: env["HEAD_SHA"] ?? "",
-    prLabels: env["PR_LABELS"] ?? "",
-    repo: env["REPO"] ?? "",
-  };
-  if (input.eventName.length === 0) {
-    throw new Error("detect-changes requires EVENT_NAME");
-  }
-  if (input.headSha.length === 0) {
-    throw new Error("detect-changes requires HEAD_SHA");
-  }
-  if (input.repo.length === 0) {
-    throw new Error("detect-changes requires REPO");
-  }
-  const outPath = env["GITHUB_OUTPUT"];
-  if (typeof outPath !== "string" || outPath.length === 0) {
-    throw new Error("detect-changes requires GITHUB_OUTPUT (job outputs path)");
-  }
-  runDetectChanges(input, createDetectChangesIo());
-}
-
-/**
  * `ci-gate` job driver. The workflow's bash guard on `DETECT_RESULT` runs
  * before this command (see ci.yml's `ci-gate` job) — by the time this is
  * invoked, detect-changes is known to have succeeded.
@@ -320,166 +211,6 @@ function runVrGateCli(): void {
   process.stdout.write(`vr-gate ok: ${verdict.reason}\n`);
 }
 
-function parseCacheableExecution(raw: string | undefined): CacheableExecution {
-  if (raw === undefined || raw.length === 0) {
-    throw new Error("--execution <name> is required");
-  }
-  if (!(CACHEABLE_EXECUTIONS as readonly string[]).includes(raw)) {
-    throw new Error(
-      `unknown execution "${raw}"; expected one of: ${CACHEABLE_EXECUTIONS.join(", ")}`,
-    );
-  }
-  return raw as CacheableExecution;
-}
-
-/**
- * `--shard <index>/<total>` (1-based), matching the vitest / playwright CLI
- * spelling the component jobs already pass through. Absent means unsharded.
- * Fail-closed: a malformed value must not silently degrade to unsharded, or a
- * typo in a matrix leg would make every leg share one marker.
- */
-function parseShardFlag(args: string[]): ExecutionShard | undefined {
-  const raw = flagValue(args, "--shard");
-  if (raw === undefined) return undefined;
-  const match = /^(\d+)\/(\d+)$/.exec(raw);
-  if (match === null) {
-    throw new Error(`--shard must look like <index>/<total> (1-based); got "${raw}"`);
-  }
-  const index = Number(match[1]);
-  const total = Number(match[2]);
-  if (total < 1 || index < 1 || index > total) {
-    throw new Error(`--shard index must be within 1..total; got "${raw}"`);
-  }
-  return { index, total };
-}
-
-async function runHashInputsCli(args: string[]): Promise<void> {
-  const execution = parseCacheableExecution(flagValue(args, "--execution"));
-  const os = flagValue(args, "--os") ?? process.env["RUNNER_OS"] ?? "unknown";
-  const containerTag = flagValue(args, "--container-tag");
-  const shard = parseShardFlag(args);
-  const matrixNode = flagValue(args, "--matrix-node");
-  const matrixPm = flagValue(args, "--matrix-pm");
-  const matrixPmVersion = flagValue(args, "--matrix-pm-version");
-  const matrixSvelte = flagValue(args, "--matrix-svelte");
-  const runtimeNodeVersion = flagValue(args, "--runtime-node-version");
-  const runtimePmVersion = flagValue(args, "--runtime-pm-version");
-
-  const { hash, paths } = await collectGitHeadInputDigests(execution);
-  const matrix =
-    matrixNode !== undefined &&
-    matrixPm !== undefined &&
-    matrixPmVersion !== undefined &&
-    matrixSvelte !== undefined
-      ? {
-          node: matrixNode,
-          packageManager: matrixPm,
-          packageManagerVersion: matrixPmVersion,
-          svelte: matrixSvelte,
-        }
-      : undefined;
-
-  const runtime =
-    runtimeNodeVersion !== undefined &&
-    runtimeNodeVersion.length > 0 &&
-    runtimePmVersion !== undefined &&
-    runtimePmVersion.length > 0
-      ? { nodeVersion: runtimeNodeVersion, packageManagerVersion: runtimePmVersion }
-      : undefined;
-
-  if (execution === "consumer" && (matrix === undefined || runtime === undefined)) {
-    throw new Error(
-      "hash-inputs consumer requires --matrix-* and --runtime-node-version / --runtime-pm-version",
-    );
-  }
-
-  // Absent flags are omitted rather than passed as explicit `undefined`:
-  // contentHashCacheKey's optional dimensions are omit-or-provide by contract
-  // (exactOptionalPropertyTypes), and each one it sees adds a key segment.
-  const cacheKey = contentHashCacheKey({
-    execution,
-    hash,
-    os,
-    ...(containerTag === undefined ? {} : { containerTag }),
-    ...(shard === undefined ? {} : { shard }),
-    ...(matrix === undefined ? {} : { matrix }),
-    ...(runtime === undefined ? {} : { runtime }),
-  });
-  const marker = successMarkerPath(execution, shard);
-  const body = [
-    `hash=${hash}`,
-    `cache_key=${cacheKey}`,
-    `marker_path=${marker}`,
-    `path_count=${paths.length}`,
-    `execution=${execution}`,
-  ].join("\n");
-
-  const outPath = process.env["GITHUB_OUTPUT"];
-  if (typeof outPath === "string" && outPath.length > 0) {
-    appendFileSync(outPath, `${body}\n`);
-  }
-  process.stdout.write(`${body}\n`);
-}
-
-function runWriteSuccessMarkerCli(args: string[]): void {
-  const execution = parseCacheableExecution(flagValue(args, "--execution"));
-  const hash = flagValue(args, "--hash");
-  if (hash === undefined || hash.length === 0) {
-    throw new Error("write-success-marker requires --hash <hex>");
-  }
-  const shard = parseShardFlag(args);
-  const path = successMarkerPath(execution, shard);
-  const dir = path.slice(0, path.lastIndexOf("/"));
-  mkdirSync(dir, { recursive: true });
-  writeFileSync(
-    path,
-    serializeSuccessMarker({
-      schema: CONTENT_HASH_SCHEMA,
-      execution,
-      hash,
-      ...(shard === undefined ? {} : { shard }),
-    }),
-    "utf8",
-  );
-  process.stdout.write(`${path}\n`);
-}
-
-async function runValidateSuccessMarkerCli(args: string[]): Promise<void> {
-  const execution = parseCacheableExecution(flagValue(args, "--execution"));
-  const hash = flagValue(args, "--hash");
-  if (hash === undefined || hash.length === 0) {
-    throw new Error("validate-success-marker requires --hash <hex>");
-  }
-  const shard = parseShardFlag(args);
-  const path = successMarkerPath(execution, shard);
-  const file = Bun.file(path);
-  if (!(await file.exists())) {
-    process.stdout.write("hit=false\n");
-    writeGithubOutput("hit=false\n");
-    return;
-  }
-  const body = await file.text();
-  const marker = parseSuccessMarker(body);
-  const ok = validateSuccessMarker(marker, {
-    execution,
-    hash,
-    ...(shard === undefined ? {} : { shard }),
-  });
-  const line = `hit=${ok ? "true" : "false"}\n`;
-  process.stdout.write(line);
-  writeGithubOutput(line);
-  if (!ok) {
-    process.exitCode = 0; // miss is not a failure — caller runs full job
-  }
-}
-
-function writeGithubOutput(body: string): void {
-  const outPath = process.env["GITHUB_OUTPUT"];
-  if (typeof outPath === "string" && outPath.length > 0) {
-    appendFileSync(outPath, body);
-  }
-}
-
 async function resolvePlanArgs(args: string[]): Promise<{ files: string[]; forceAll: boolean }> {
   const forceAll = args.includes("--force-all");
   const files = await resolveFiles(args.filter((a) => a !== "--force-all"));
@@ -523,12 +254,6 @@ async function resolveFiles(args: string[]): Promise<string[]> {
 
   // Default: empty list (caller should pass --force-all when appropriate).
   return [];
-}
-
-function flagValue(args: string[], flag: string): string | undefined {
-  const i = args.indexOf(flag);
-  if (i < 0) return undefined;
-  return args[i + 1];
 }
 
 function readArg(path: string): Promise<string> {

--- a/scripts/ci-routing/content-hash-cli.ts
+++ b/scripts/ci-routing/content-hash-cli.ts
@@ -1,0 +1,170 @@
+/**
+ * Content-hash CLI commands: hash-inputs, write-success-marker, validate-success-marker.
+ * Pure hash/marker logic lives in content-hash*.ts; this is argv/env surface.
+ */
+import { mkdirSync, writeFileSync } from "node:fs";
+
+import {
+  CACHEABLE_EXECUTIONS,
+  CONTENT_HASH_SCHEMA,
+  type CacheableExecution,
+  type ExecutionShard,
+} from "./content-hash-types";
+import {
+  parseSuccessMarker,
+  serializeSuccessMarker,
+  successMarkerPath,
+  validateSuccessMarker,
+} from "./content-hash-markers";
+import { collectGitHeadInputDigests, contentHashCacheKey } from "./content-hash";
+import { flagValue, writeGithubOutput } from "./cli-io";
+
+function parseCacheableExecution(raw: string | undefined): CacheableExecution {
+  if (raw === undefined || raw.length === 0) {
+    throw new Error("--execution <name> is required");
+  }
+  if (!(CACHEABLE_EXECUTIONS as readonly string[]).includes(raw)) {
+    throw new Error(
+      `unknown execution "${raw}"; expected one of: ${CACHEABLE_EXECUTIONS.join(", ")}`,
+    );
+  }
+  return raw as CacheableExecution;
+}
+
+/**
+ * `--shard <index>/<total>` (1-based), matching the vitest / playwright CLI
+ * spelling the component jobs already pass through. Absent means unsharded.
+ * Fail-closed: a malformed value must not silently degrade to unsharded, or a
+ * typo in a matrix leg would make every leg share one marker.
+ */
+function parseShardFlag(args: string[]): ExecutionShard | undefined {
+  const raw = flagValue(args, "--shard");
+  if (raw === undefined) return undefined;
+  const match = /^(\d+)\/(\d+)$/.exec(raw);
+  if (match === null) {
+    throw new Error(`--shard must look like <index>/<total> (1-based); got "${raw}"`);
+  }
+  const index = Number(match[1]);
+  const total = Number(match[2]);
+  if (total < 1 || index < 1 || index > total) {
+    throw new Error(`--shard index must be within 1..total; got "${raw}"`);
+  }
+  return { index, total };
+}
+
+export async function runHashInputsCli(args: string[]): Promise<void> {
+  const execution = parseCacheableExecution(flagValue(args, "--execution"));
+  const os = flagValue(args, "--os") ?? process.env["RUNNER_OS"] ?? "unknown";
+  const containerTag = flagValue(args, "--container-tag");
+  const shard = parseShardFlag(args);
+  const matrixNode = flagValue(args, "--matrix-node");
+  const matrixPm = flagValue(args, "--matrix-pm");
+  const matrixPmVersion = flagValue(args, "--matrix-pm-version");
+  const matrixSvelte = flagValue(args, "--matrix-svelte");
+  const runtimeNodeVersion = flagValue(args, "--runtime-node-version");
+  const runtimePmVersion = flagValue(args, "--runtime-pm-version");
+
+  const { hash, paths } = await collectGitHeadInputDigests(execution);
+  const matrix =
+    matrixNode !== undefined &&
+    matrixPm !== undefined &&
+    matrixPmVersion !== undefined &&
+    matrixSvelte !== undefined
+      ? {
+          node: matrixNode,
+          packageManager: matrixPm,
+          packageManagerVersion: matrixPmVersion,
+          svelte: matrixSvelte,
+        }
+      : undefined;
+
+  const runtime =
+    runtimeNodeVersion !== undefined &&
+    runtimeNodeVersion.length > 0 &&
+    runtimePmVersion !== undefined &&
+    runtimePmVersion.length > 0
+      ? { nodeVersion: runtimeNodeVersion, packageManagerVersion: runtimePmVersion }
+      : undefined;
+
+  if (execution === "consumer" && (matrix === undefined || runtime === undefined)) {
+    throw new Error(
+      "hash-inputs consumer requires --matrix-* and --runtime-node-version / --runtime-pm-version",
+    );
+  }
+
+  // Absent flags are omitted rather than passed as explicit `undefined`:
+  // contentHashCacheKey's optional dimensions are omit-or-provide by contract
+  // (exactOptionalPropertyTypes), and each one it sees adds a key segment.
+  const cacheKey = contentHashCacheKey({
+    execution,
+    hash,
+    os,
+    ...(containerTag === undefined ? {} : { containerTag }),
+    ...(shard === undefined ? {} : { shard }),
+    ...(matrix === undefined ? {} : { matrix }),
+    ...(runtime === undefined ? {} : { runtime }),
+  });
+  const marker = successMarkerPath(execution, shard);
+  const body = [
+    `hash=${hash}`,
+    `cache_key=${cacheKey}`,
+    `marker_path=${marker}`,
+    `path_count=${paths.length}`,
+    `execution=${execution}`,
+  ].join("\n");
+
+  writeGithubOutput(`${body}\n`);
+  process.stdout.write(`${body}\n`);
+}
+
+export function runWriteSuccessMarkerCli(args: string[]): void {
+  const execution = parseCacheableExecution(flagValue(args, "--execution"));
+  const hash = flagValue(args, "--hash");
+  if (hash === undefined || hash.length === 0) {
+    throw new Error("write-success-marker requires --hash <hex>");
+  }
+  const shard = parseShardFlag(args);
+  const path = successMarkerPath(execution, shard);
+  const dir = path.slice(0, path.lastIndexOf("/"));
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    path,
+    serializeSuccessMarker({
+      schema: CONTENT_HASH_SCHEMA,
+      execution,
+      hash,
+      ...(shard === undefined ? {} : { shard }),
+    }),
+    "utf8",
+  );
+  process.stdout.write(`${path}\n`);
+}
+
+export async function runValidateSuccessMarkerCli(args: string[]): Promise<void> {
+  const execution = parseCacheableExecution(flagValue(args, "--execution"));
+  const hash = flagValue(args, "--hash");
+  if (hash === undefined || hash.length === 0) {
+    throw new Error("validate-success-marker requires --hash <hex>");
+  }
+  const shard = parseShardFlag(args);
+  const path = successMarkerPath(execution, shard);
+  const file = Bun.file(path);
+  if (!(await file.exists())) {
+    process.stdout.write("hit=false\n");
+    writeGithubOutput("hit=false\n");
+    return;
+  }
+  const body = await file.text();
+  const marker = parseSuccessMarker(body);
+  const ok = validateSuccessMarker(marker, {
+    execution,
+    hash,
+    ...(shard === undefined ? {} : { shard }),
+  });
+  const line = `hit=${ok ? "true" : "false"}\n`;
+  process.stdout.write(line);
+  writeGithubOutput(line);
+  if (!ok) {
+    process.exitCode = 0; // miss is not a failure — caller runs full job
+  }
+}

--- a/scripts/ci-routing/detect-changes-cli.ts
+++ b/scripts/ci-routing/detect-changes-cli.ts
@@ -1,0 +1,106 @@
+/**
+ * Production detect-changes CLI: env wiring + gh/git I/O adapter.
+ * Pure driver lives in ./detect-changes; this module is the spawn surface.
+ */
+import { spawnSync } from "node:child_process";
+
+import { runDetectChanges, type DetectChangesInput, type DetectChangesIo } from "./detect-changes";
+import { writeGithubOutput as appendGithubOutput } from "./cli-io";
+
+/**
+ * Production I/O for `detect-changes` — mirrors the former ci.yml bash:
+ * swallow gh/git fetch/diff failures; exact-key GITHUB_OUTPUT write.
+ */
+function createDetectChangesIo(): DetectChangesIo {
+  return {
+    commandExists(name: string): boolean {
+      const r = spawnSync("bash", ["-c", `command -v ${JSON.stringify(name)}`], {
+        encoding: "utf8",
+      });
+      return r.status === 0;
+    },
+    findLastSuccessfulMainHead(repo: string, headSha: string): string | undefined {
+      // Issue #244 cumulative main range. See lastSuccessfulMainHeadJq — gh api
+      // has no jq --arg; the former bash form was a silent no-op under `|| true`.
+      const r = spawnSync(
+        "gh",
+        [
+          "api",
+          `repos/${repo}/actions/workflows/ci.yml/runs?branch=main&status=completed&per_page=20`,
+          "--jq",
+          lastSuccessfulMainHeadJq(headSha),
+        ],
+        { encoding: "utf8", maxBuffer: 10 * 1024 * 1024 },
+      );
+      if (r.status !== 0) return undefined;
+      const sha = (r.stdout ?? "").trim();
+      return sha.length > 0 ? sha : undefined;
+    },
+    gitFetchDepth1(sha: string): void {
+      spawnSync("git", ["fetch", "--no-tags", "--depth=1", "origin", sha], {
+        encoding: "utf8",
+        stdio: "ignore",
+      });
+    },
+    gitCommitExists(sha: string): boolean {
+      const r = spawnSync("git", ["cat-file", "-e", `${sha}^{commit}`], {
+        encoding: "utf8",
+        stdio: "ignore",
+      });
+      return r.status === 0;
+    },
+    gitDiffNameStatus(base: string, head: string): string[] | "error" {
+      // Large renames can exceed Node's default 1 MiB maxBuffer; treat overflow
+      // as error → force-all rather than silent checks-only.
+      const r = spawnSync("git", ["diff", "--name-status", `${base}...${head}`], {
+        encoding: "utf8",
+        maxBuffer: 50 * 1024 * 1024,
+      });
+      if (r.error || r.status !== 0) return "error";
+      const text = r.stdout ?? "";
+      return text
+        .split(/\r?\n/)
+        .map((l) => l.trimEnd())
+        .filter((l) => l.length > 0);
+    },
+    writeGithubOutput(body: string): void {
+      appendGithubOutput(body);
+      process.stdout.write(body);
+    },
+    log(msg: string): void {
+      process.stdout.write(`${msg}\n`);
+    },
+  };
+}
+
+/** jq program for last successful main CI head, excluding the current head. */
+export function lastSuccessfulMainHeadJq(headSha: string): string {
+  const headLit = JSON.stringify(headSha);
+  return `[.workflow_runs[] | select(.conclusion == "success" and .head_sha != ${headLit}) | .head_sha][0] // empty`;
+}
+
+export function runDetectChangesCli(): void {
+  const env = process.env;
+  const input: DetectChangesInput = {
+    eventName: env["EVENT_NAME"] ?? "",
+    githubRef: env["GITHUB_REF"] ?? "",
+    baseSha: env["BASE_SHA"] ?? "",
+    headSha: env["HEAD_SHA"] ?? "",
+    prLabels: env["PR_LABELS"] ?? "",
+    repo: env["REPO"] ?? "",
+  };
+  if (input.eventName.length === 0) {
+    throw new Error("detect-changes requires EVENT_NAME");
+  }
+  if (input.headSha.length === 0) {
+    throw new Error("detect-changes requires HEAD_SHA");
+  }
+  if (input.repo.length === 0) {
+    throw new Error("detect-changes requires REPO");
+  }
+  const outPath = env["GITHUB_OUTPUT"];
+  if (typeof outPath !== "string" || outPath.length === 0) {
+    throw new Error("detect-changes requires GITHUB_OUTPUT (job outputs path)");
+  }
+  runDetectChanges(input, createDetectChangesIo());
+}

--- a/scripts/ci-routing/detect-changes.test.ts
+++ b/scripts/ci-routing/detect-changes.test.ts
@@ -373,7 +373,7 @@ describe("runDetectChanges end-to-end (injected io)", () => {
 
 describe("production adapter contracts", () => {
   test("lastSuccessfulMainHeadJq embeds head as a JSON string (no jq --arg)", async () => {
-    const { lastSuccessfulMainHeadJq } = await import("./cli");
+    const { lastSuccessfulMainHeadJq } = await import("./detect-changes-cli");
     const jq = lastSuccessfulMainHeadJq("abc123");
     expect(jq).toContain('.head_sha != "abc123"');
     expect(jq).not.toContain("--arg");


### PR DESCRIPTION
## Summary

Closes #1174. Astral-maintain pass on `scripts/ci-routing/`: split the mixed-concern CLI kitchen sink after pure modules already lived next door (#1171).

**Before:** `scripts/ci-routing/cli.ts` (~537 lines) held dispatch, plan/classify/emit path resolution, detect-changes production IO, content-hash CLI commands, and gate env adapters.

**After:**
- `cli-io.ts` — `flagValue`, `writeGithubOutput` (shared GITHUB_OUTPUT append)
- `content-hash-cli.ts` — `hash-inputs` / `write-success-marker` / `validate-success-marker`
- `detect-changes-cli.ts` — production IO adapter + exported `lastSuccessfulMainHeadJq`
- `cli.ts` — thin dispatch + plan/classify/emit + ci-gate/vr-gate/gate wrappers (~262 lines)

No pass-through re-exports. `detect-changes.test.ts` imports `lastSuccessfulMainHeadJq` from `./detect-changes-cli`. Workflow entry stays `bun scripts/ci-routing.ts <cmd>`.

Also: emit-github-output and hash-inputs now route GITHUB_OUTPUT through the shared helper (behavior identical).

## Test plan

- [x] `bun test scripts/ci-routing.test.ts scripts/ci-routing/` — 145 pass (was 142; +3 GITHUB_OUTPUT spawn guards)
- [x] pre-commit oxfmt / oxlint

## Follow-ups

None for this audit slice. Open PR #1173 (scale-children manifest) is independent.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1175" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->