### PR TITLE
refactor(scripts): split gen-llms catalog builders by domain

### DIFF
--- a/scripts/ci-routing.test.ts
+++ b/scripts/ci-routing.test.ts
@@ -125,6 +125,8 @@ describe("classifyChangedPaths", () => {
   test("llms module siblings stay on the docs lane (pages) without forcing VR", () => {
     for (const file of [
       "scripts/gen-llms.ts",
+      "scripts/llms-diagnostic-docs.ts",
+      "scripts/llms-lifecycle-docs.ts",
       "scripts/llms-markdown.ts",
       "scripts/llms-guide-content.ts",
     ]) {
@@ -249,6 +251,8 @@ describe("planJobs", () => {
   test("docs generators schedule pages (and journeys) without VR unless render-relevant", () => {
     for (const path of [
       "scripts/gen-llms.ts",
+      "scripts/llms-diagnostic-docs.ts",
+      "scripts/llms-lifecycle-docs.ts",
       "scripts/docs-seo.ts",
       "scripts/gen-docs-search.ts",
       "scripts/cli-docs.ts",
@@ -618,6 +622,8 @@ describe("JOB_CONTENT_INPUTS (split build hashes)", () => {
       expect(inputs, execution).toContain("scripts/gen-theme-static-shells.ts");
       expect(inputs, execution).toContain("scripts/docs-csp.ts");
       expect(inputs, execution).toContain("scripts/gen-llms.ts");
+      expect(inputs, execution).toContain("scripts/llms-diagnostic-docs.ts");
+      expect(inputs, execution).toContain("scripts/llms-lifecycle-docs.ts");
       expect(inputs, execution).toContain("scripts/docs-seo.ts");
       expect(inputs, execution).toContain("scripts/quickstart.ts");
       expect(inputs, execution).toContain("scripts/guide-code-contract.ts");
@@ -1137,6 +1143,8 @@ describe("component_journeys content inputs cover llms modules", () => {
     const inputs = JOB_CONTENT_INPUTS.component_journeys;
     for (const file of [
       "scripts/gen-llms.ts",
+      "scripts/llms-diagnostic-docs.ts",
+      "scripts/llms-lifecycle-docs.ts",
       "scripts/llms-markdown.ts",
       "scripts/highlight-code.ts",
       "scripts/highlight-code.test.ts",

--- a/scripts/ci-routing/content-hash-inputs.ts
+++ b/scripts/ci-routing/content-hash-inputs.ts
@@ -48,6 +48,8 @@ const DOCS_SURFACE_CONTENT_INPUTS: readonly string[] = [
   "scripts/docs-csp.ts",
   // $scripts imports used by docs routes / layout (typecheck + published site).
   "scripts/gen-llms.ts",
+  "scripts/llms-diagnostic-docs.ts",
+  "scripts/llms-lifecycle-docs.ts",
   "scripts/gen-llms.test.ts",
   "scripts/llms-markdown.ts",
   "scripts/llms-guide-content.ts",
@@ -209,6 +211,8 @@ export const JOB_CONTENT_INPUTS: Record<CacheableExecution, readonly string[]> =
     // Docs generators that schedule docs_journeys must bust this cache
     // (Codex P2: content-only scripts were omitting gen-docs-search / gallery).
     "scripts/gen-llms.ts",
+    "scripts/llms-diagnostic-docs.ts",
+    "scripts/llms-lifecycle-docs.ts",
     "scripts/gen-llms.test.ts",
     "scripts/llms-markdown.ts",
     // llms-markdown imports highlight-code for fenced-block HTML; hash it or

--- a/scripts/ci-routing/routing.ts
+++ b/scripts/ci-routing/routing.ts
@@ -89,6 +89,8 @@ export const DOCS_CONTENT_ONLY_PATHS: readonly string[] = [
  */
 export const DOCS_CONTENT_SCRIPT_PATTERNS: readonly string[] = [
   "scripts/gen-llms.ts",
+  "scripts/llms-diagnostic-docs.ts",
+  "scripts/llms-lifecycle-docs.ts",
   "scripts/gen-llms.test.ts",
   "scripts/llms-markdown.ts",
   "scripts/llms-guide-content.ts",
@@ -120,6 +122,8 @@ export const LANE_PATTERNS: Record<ChangeLane, readonly string[]> = {
     "apps/docs/**",
     // Docs app imports `$scripts/gen-llms` and ships lifecycle-driven guide content.
     "scripts/gen-llms.ts",
+    "scripts/llms-diagnostic-docs.ts",
+    "scripts/llms-lifecycle-docs.ts",
     "scripts/gen-llms.test.ts",
     "scripts/llms-markdown.ts",
     "scripts/highlight-code.ts",

--- a/scripts/gen-llms.ts
+++ b/scripts/gen-llms.ts
@@ -6,22 +6,18 @@
  * Module layout:
  * - `llms-markdown.ts` — minimal markdown renderer
  * - `llms-guide-content.ts` — guide prose constants + interaction reference
- * - this file — catalog-driven builders, guidePages, llms surfaces, re-exports
+ * - `llms-diagnostic-docs.ts` — errors + advisories catalog builders
+ * - `llms-lifecycle-docs.ts` — lifecycle guide builder + LifecycleDoc
+ * - this file — guidePages, llms surfaces, public re-exports
  *
  * Everything here is pure (data in, string out) and unit-tested in
  * scripts/gen-llms.test.ts; apps/docs imports it via the `$scripts` alias
  * for its prerendered endpoints and guide pages.
  */
-import { ADVISORY_CATALOG } from "@ggsvelte/core";
-import { CURRENT_EDITION, LINT_CATALOG, THEME_NAMES } from "@ggsvelte/spec";
+import { CURRENT_EDITION, THEME_NAMES } from "@ggsvelte/spec";
 import sveltePackage from "../packages/svelte/package.json";
 import { GUIDE_CATALOG, type GuideSlug } from "../apps/docs/src/lib/catalog/guide";
 import { interactionExpositionSlug } from "../apps/docs/src/lib/catalog/interaction-exposition";
-import {
-  buildDiagnosticDocs,
-  type DiagnosticDocEntry,
-  type DiagnosticDocSource,
-} from "./diagnostic-docs";
 import { assertGuideCodeContract } from "./guide-code-contract";
 import {
   FACETS_COORDINATES_MD,
@@ -34,6 +30,8 @@ import {
   TEMPORAL_SCALES_MD,
   UPGRADING_MD,
 } from "./llms-guide-content";
+import { buildAdvisoriesMd, buildErrorsMd } from "./llms-diagnostic-docs";
+import { buildLifecycleMd, type LifecycleDoc } from "./llms-lifecycle-docs";
 
 export { buildDiagnosticDocs } from "./diagnostic-docs";
 export { extractMarkdownHeadings, renderMarkdown, type MarkdownHeading } from "./llms-markdown";
@@ -50,208 +48,9 @@ export {
   UPGRADING_MD,
   type InteractionReferenceEntry,
 } from "./llms-guide-content";
+export { buildAdvisoriesMd, buildErrorsMd } from "./llms-diagnostic-docs";
+export { buildLifecycleMd, type LifecycleDoc } from "./llms-lifecycle-docs";
 
-function catalogSection(
-  title: string,
-  intro: string,
-  catalog: Record<string, { summary: string; fix?: string }>,
-  opts: { tierOf?: (code: string) => string } = {},
-): string {
-  const lines = [`## ${title}`, "", intro, ""];
-  for (const [code, entry] of Object.entries(catalog)) {
-    const tier = opts.tierOf === undefined ? "" : ` (${opts.tierOf(code)})`;
-    lines.push(`### \`${code}\`${tier}`, "", entry.summary, "");
-    if (entry.fix !== undefined) lines.push(`**Fix:** ${entry.fix}`, "");
-  }
-  return lines.join("\n");
-}
-
-const diagnosticSectionTitles: Record<DiagnosticDocSource, string> = {
-  validation: "Validation errors (@ggsvelte/spec)",
-  pipeline: "Render-time errors (@ggsvelte/core)",
-  warning: "Render warnings",
-  interaction: "Interaction diagnostics (@ggsvelte/svelte)",
-  cli: "CLI diagnostics (ggsvelte-render)",
-};
-
-function diagnosticHeading(entry: DiagnosticDocEntry): string {
-  const primaryAnchor = entry.code
-    .toLowerCase()
-    .replaceAll(/[^a-z0-9]+/g, "-")
-    .replaceAll(/^-|-$/g, "");
-  return entry.anchor === primaryAnchor
-    ? `### \`${entry.code}\``
-    : `### \`${entry.code}\` — ${entry.source}`;
-}
-
-function renderDiagnosticEntry(entry: DiagnosticDocEntry): string {
-  const lines = [
-    diagnosticHeading(entry),
-    "",
-    `**Code + severity:** \`${entry.code}\` · ${entry.severity}`,
-    "",
-    `**What failed:** ${entry.whatFailed}`,
-    "",
-    `**Why:** ${entry.why}`,
-    "",
-    `**Fix:** ${entry.fix}`,
-    "",
-    `**Consequence (${entry.consequence}):** ${entry.consequenceText}`,
-    "",
-    `**Stable link:** [/guide/errors#${entry.anchor}](/guide/errors#${entry.anchor})`,
-    "",
-  ];
-  if (entry.recipe !== undefined) {
-    lines.push(
-      "**Minimal illustration — copy only the relevant fragment:**",
-      "",
-      `\`\`\`${entry.recipe.language} fragment copy`,
-      entry.recipe.code,
-      "```",
-      "",
-    );
-  }
-  return lines.join("\n");
-}
-
-export function buildErrorsMd(): string {
-  const entries = buildDiagnosticDocs();
-  const sections = (Object.keys(diagnosticSectionTitles) as DiagnosticDocSource[]).map((source) => {
-    const intro =
-      source === "cli"
-        ? "SVG is written only to stdout; JSON Lines diagnostics are written only to stderr. Exit 1 means rendering failed, exit 2 means usage/input failed, and exit 3 means spec validation failed."
-        : "Each entry answers what failed, why, how to recover safely, and whether output was blocked or degraded.";
-    return [
-      `## ${diagnosticSectionTitles[source]}`,
-      "",
-      intro,
-      "",
-      ...entries
-        .filter((entry) => entry.source === source)
-        .map((entry) => renderDiagnosticEntry(entry)),
-    ].join("\n");
-  });
-
-  return `# Errors reference
-
-Diagnostics are generated from the catalogs used by validation, rendering,
-interaction, and the CLI. Identity is the pair \`(source, code)\`: a bare code
-can intentionally exist in more than one source with a different consequence.
-
-## Quickstart troubleshooting
-
-- **Collapsed or zero-width container:** the responsive plot remains
-  \`data-gg-ready="false"\` until ResizeObserver reports a positive width.
-  Give the parent a real grid/flex track width; no fixed chart width is needed.
-- **SSR and hydration:** omitted width server-renders at 832 × 400, stays
-  not-ready on the server, then measures its real container after hydration.
-- **Unexpected height:** omitted height is 400px unless the spec supplies one.
-- **TypeScript or linked-package mismatch:** install one compatible
-  \`@ggsvelte/svelte\` version and let it resolve matching core/spec packages;
-  remove stale lockfile overrides that mix versions.
-- **CLI input failure:** run \`ggsvelte-render --help\`; keep SVG stdout
-  separate from JSON Lines stderr while correcting the reported input.
-
-${sections.join("\n\n")}
-`;
-}
-
-export function buildAdvisoriesMd(): string {
-  const lint = catalogSection(
-    "Spec-lint advisories (@ggsvelte/spec lintSpec)",
-    'Valid-but-questionable specs (Hadley: "we can produce many plots that don\'t make sense, yet are grammatically valid"). Run `lintSpec(spec, { profile? })` directly, pass `{ lint: true }` to `validate()`, or read the CLI\'s stderr advisories (source "spec-lint"). Data-dependent rules skip silently without evidence.',
-    LINT_CATALOG,
-    {
-      tierOf: (code) => `needs: ${LINT_CATALOG[code as keyof typeof LINT_CATALOG].needs}`,
-    },
-  );
-  const heuristics = catalogSection(
-    "Pipeline heuristic advisories (@ggsvelte/core)",
-    "Every heuristic decision the pipeline takes is disclosed as `{ code, path, chosen, howToOverride }` on `RenderModel.advisories` — agents see the guess and can correct it.",
-    ADVISORY_CATALOG,
-  );
-  return `# Advisories
-
-Advisories never block a render. Two distinct kinds, two sources:
-
-${lint}
-
-${heuristics}
-`;
-}
-
-/** Shape of the generated lifecycle.json document (scripts/gen-lifecycle.ts). */
-export interface LifecycleDoc {
-  tags: readonly string[];
-  surfaces: readonly {
-    package: string;
-    entry: string;
-    source: string;
-    exports: Record<string, { kind: "value" | "type"; lifecycle: string }>;
-  }[];
-}
-
-export function buildLifecycleMd(lifecycle: LifecycleDoc): string {
-  const sections = lifecycle.surfaces.map((surface) => {
-    const byTag = new Map<string, string[]>();
-    for (const [name, meta] of Object.entries(surface.exports)) {
-      const list = byTag.get(meta.lifecycle) ?? [];
-      list.push(meta.kind === "type" ? `\`${name}\` (type)` : `\`${name}\``);
-      byTag.set(meta.lifecycle, list);
-    }
-    const parts = [
-      `## ${surface.package}${surface.entry === "." ? "" : ` (${surface.entry})`}`,
-      "",
-    ];
-    for (const tag of lifecycle.tags) {
-      const names = byTag.get(tag);
-      if (names === undefined) continue;
-      parts.push(`### ${tag} (${String(names.length)})`, "", names.join(", "), "");
-    }
-    return parts.join("\n");
-  });
-  return `# Lifecycle & editions
-
-## Lifecycle tags
-
-Every public export carries a lifecycle tag (generated into
-\`lifecycle.json\` from the source annotations — regenerate with
-\`bun run lifecycle:gen\`):
-
-- **experimental** — may change or disappear in any 0.x release. The default
-  for APIs not explicitly promoted.
-- **stable-intent** — committed enough that changes pay the migration tax.
-  Covers (1) the agent core path (PortableSpec, normalize, validate,
-  renderToSVGString, GGPlot and their direct result contracts) and
-  (2) the recommended Svelte composition children (\`Geom*\` shells and the
-  theme/scale/coord/facet/labs/guides/legend grammar children). Not frozen
-  pre-1.0, but changes here are treated as breaking: they get a changeset, a
-  migration note, and a deprecation window where feasible. Registry and
-  factory helpers stay experimental.
-- **stable** — committed API under semver (none in v0.1).
-- **superseded** — keeps working but stops being recommended; docs point to
-  the replacement. Protects agent-generated code from silent breakage.
-
-## Defaults editions
-
-\`normalize()\` stamps \`edition: ${String(CURRENT_EDITION)}\` onto every spec that doesn't carry one,
-freezing which generation of DEFAULT aesthetics (theme role tokens,
-categorical palette, sequential ramp) the spec was authored against. When a
-future edition ships better defaults, stamped specs keep their original look
-— old charts never reshuffle. Explicit settings (\`theme\`,
-\`scales.*.range\`, \`scales.*.scheme\`) always win over edition defaults, and
-unknown editions degrade to the latest known with an \`unknown-edition\`
-warning.
-
-${sections.join("\n")}
-`;
-}
-
-// ---------------------------------------------------------------------------
-// llms.txt / llms-full.txt
-// ---------------------------------------------------------------------------
-
-/** Manifest-entry shape consumed here (structural subset of the manifest). */
 export interface LlmsExampleEntry {
   id: string;
   title: string;

--- a/scripts/llms-diagnostic-docs.ts
+++ b/scripts/llms-diagnostic-docs.ts
@@ -1,0 +1,140 @@
+/**
+ * Catalog-driven errors and advisories guide markdown for gen-llms.
+ * Lifecycle guide markdown lives in llms-lifecycle-docs.ts.
+ */
+import { ADVISORY_CATALOG } from "@ggsvelte/core";
+import { LINT_CATALOG } from "@ggsvelte/spec";
+import {
+  buildDiagnosticDocs,
+  type DiagnosticDocEntry,
+  type DiagnosticDocSource,
+} from "./diagnostic-docs";
+
+function catalogSection(
+  title: string,
+  intro: string,
+  catalog: Record<string, { summary: string; fix?: string }>,
+  opts: { tierOf?: (code: string) => string } = {},
+): string {
+  const lines = [`## ${title}`, "", intro, ""];
+  for (const [code, entry] of Object.entries(catalog)) {
+    const tier = opts.tierOf === undefined ? "" : ` (${opts.tierOf(code)})`;
+    lines.push(`### \`${code}\`${tier}`, "", entry.summary, "");
+    if (entry.fix !== undefined) lines.push(`**Fix:** ${entry.fix}`, "");
+  }
+  return lines.join("\n");
+}
+
+const diagnosticSectionTitles: Record<DiagnosticDocSource, string> = {
+  validation: "Validation errors (@ggsvelte/spec)",
+  pipeline: "Render-time errors (@ggsvelte/core)",
+  warning: "Render warnings",
+  interaction: "Interaction diagnostics (@ggsvelte/svelte)",
+  cli: "CLI diagnostics (ggsvelte-render)",
+};
+
+function diagnosticHeading(entry: DiagnosticDocEntry): string {
+  const primaryAnchor = entry.code
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9]+/g, "-")
+    .replaceAll(/^-|-$/g, "");
+  return entry.anchor === primaryAnchor
+    ? `### \`${entry.code}\``
+    : `### \`${entry.code}\` — ${entry.source}`;
+}
+
+function renderDiagnosticEntry(entry: DiagnosticDocEntry): string {
+  const lines = [
+    diagnosticHeading(entry),
+    "",
+    `**Code + severity:** \`${entry.code}\` · ${entry.severity}`,
+    "",
+    `**What failed:** ${entry.whatFailed}`,
+    "",
+    `**Why:** ${entry.why}`,
+    "",
+    `**Fix:** ${entry.fix}`,
+    "",
+    `**Consequence (${entry.consequence}):** ${entry.consequenceText}`,
+    "",
+    `**Stable link:** [/guide/errors#${entry.anchor}](/guide/errors#${entry.anchor})`,
+    "",
+  ];
+  if (entry.recipe !== undefined) {
+    lines.push(
+      "**Minimal illustration — copy only the relevant fragment:**",
+      "",
+      `\`\`\`${entry.recipe.language} fragment copy`,
+      entry.recipe.code,
+      "```",
+      "",
+    );
+  }
+  return lines.join("\n");
+}
+
+export function buildErrorsMd(): string {
+  const entries = buildDiagnosticDocs();
+  const sections = (Object.keys(diagnosticSectionTitles) as DiagnosticDocSource[]).map((source) => {
+    const intro =
+      source === "cli"
+        ? "SVG is written only to stdout; JSON Lines diagnostics are written only to stderr. Exit 1 means rendering failed, exit 2 means usage/input failed, and exit 3 means spec validation failed."
+        : "Each entry answers what failed, why, how to recover safely, and whether output was blocked or degraded.";
+    return [
+      `## ${diagnosticSectionTitles[source]}`,
+      "",
+      intro,
+      "",
+      ...entries
+        .filter((entry) => entry.source === source)
+        .map((entry) => renderDiagnosticEntry(entry)),
+    ].join("\n");
+  });
+
+  return `# Errors reference
+
+Diagnostics are generated from the catalogs used by validation, rendering,
+interaction, and the CLI. Identity is the pair \`(source, code)\`: a bare code
+can intentionally exist in more than one source with a different consequence.
+
+## Quickstart troubleshooting
+
+- **Collapsed or zero-width container:** the responsive plot remains
+  \`data-gg-ready="false"\` until ResizeObserver reports a positive width.
+  Give the parent a real grid/flex track width; no fixed chart width is needed.
+- **SSR and hydration:** omitted width server-renders at 832 × 400, stays
+  not-ready on the server, then measures its real container after hydration.
+- **Unexpected height:** omitted height is 400px unless the spec supplies one.
+- **TypeScript or linked-package mismatch:** install one compatible
+  \`@ggsvelte/svelte\` version and let it resolve matching core/spec packages;
+  remove stale lockfile overrides that mix versions.
+- **CLI input failure:** run \`ggsvelte-render --help\`; keep SVG stdout
+  separate from JSON Lines stderr while correcting the reported input.
+
+${sections.join("\n\n")}
+`;
+}
+
+export function buildAdvisoriesMd(): string {
+  const lint = catalogSection(
+    "Spec-lint advisories (@ggsvelte/spec lintSpec)",
+    'Valid-but-questionable specs (Hadley: "we can produce many plots that don\'t make sense, yet are grammatically valid"). Run `lintSpec(spec, { profile? })` directly, pass `{ lint: true }` to `validate()`, or read the CLI\'s stderr advisories (source "spec-lint"). Data-dependent rules skip silently without evidence.',
+    LINT_CATALOG,
+    {
+      tierOf: (code) => `needs: ${LINT_CATALOG[code as keyof typeof LINT_CATALOG].needs}`,
+    },
+  );
+  const heuristics = catalogSection(
+    "Pipeline heuristic advisories (@ggsvelte/core)",
+    "Every heuristic decision the pipeline takes is disclosed as `{ code, path, chosen, howToOverride }` on `RenderModel.advisories` — agents see the guess and can correct it.",
+    ADVISORY_CATALOG,
+  );
+  return `# Advisories
+
+Advisories never block a render. Two distinct kinds, two sources:
+
+${lint}
+
+${heuristics}
+`;
+}

--- a/scripts/llms-lifecycle-docs.ts
+++ b/scripts/llms-lifecycle-docs.ts
@@ -1,0 +1,71 @@
+/**
+ * Lifecycle guide markdown builder for gen-llms (lifecycle.json → prose).
+ */
+import { CURRENT_EDITION } from "@ggsvelte/spec";
+
+/** Shape of the generated lifecycle.json document (scripts/gen-lifecycle.ts). */
+export interface LifecycleDoc {
+  tags: readonly string[];
+  surfaces: readonly {
+    package: string;
+    entry: string;
+    source: string;
+    exports: Record<string, { kind: "value" | "type"; lifecycle: string }>;
+  }[];
+}
+
+export function buildLifecycleMd(lifecycle: LifecycleDoc): string {
+  const sections = lifecycle.surfaces.map((surface) => {
+    const byTag = new Map<string, string[]>();
+    for (const [name, meta] of Object.entries(surface.exports)) {
+      const list = byTag.get(meta.lifecycle) ?? [];
+      list.push(meta.kind === "type" ? `\`${name}\` (type)` : `\`${name}\``);
+      byTag.set(meta.lifecycle, list);
+    }
+    const parts = [
+      `## ${surface.package}${surface.entry === "." ? "" : ` (${surface.entry})`}`,
+      "",
+    ];
+    for (const tag of lifecycle.tags) {
+      const names = byTag.get(tag);
+      if (names === undefined) continue;
+      parts.push(`### ${tag} (${String(names.length)})`, "", names.join(", "), "");
+    }
+    return parts.join("\n");
+  });
+  return `# Lifecycle & editions
+
+## Lifecycle tags
+
+Every public export carries a lifecycle tag (generated into
+\`lifecycle.json\` from the source annotations — regenerate with
+\`bun run lifecycle:gen\`):
+
+- **experimental** — may change or disappear in any 0.x release. The default
+  for APIs not explicitly promoted.
+- **stable-intent** — committed enough that changes pay the migration tax.
+  Covers (1) the agent core path (PortableSpec, normalize, validate,
+  renderToSVGString, GGPlot and their direct result contracts) and
+  (2) the recommended Svelte composition children (\`Geom*\` shells and the
+  theme/scale/coord/facet/labs/guides/legend grammar children). Not frozen
+  pre-1.0, but changes here are treated as breaking: they get a changeset, a
+  migration note, and a deprecation window where feasible. Registry and
+  factory helpers stay experimental.
+- **stable** — committed API under semver (none in v0.1).
+- **superseded** — keeps working but stops being recommended; docs point to
+  the replacement. Protects agent-generated code from silent breakage.
+
+## Defaults editions
+
+\`normalize()\` stamps \`edition: ${String(CURRENT_EDITION)}\` onto every spec that doesn't carry one,
+freezing which generation of DEFAULT aesthetics (theme role tokens,
+categorical palette, sequential ramp) the spec was authored against. When a
+future edition ships better defaults, stamped specs keep their original look
+— old charts never reshuffle. Explicit settings (\`theme\`,
+\`scales.*.range\`, \`scales.*.scheme\`) always win over edition defaults, and
+unknown editions degrade to the latest known with an \`unknown-edition\`
+warning.
+
+${sections.join("\n")}
+`;
+}


### PR DESCRIPTION
## Summary

Astral-maintain pass on `scripts/`: split remaining mixed concerns in `gen-llms.ts` after guide content and markdown helpers already lived next door.

**Before:** `scripts/gen-llms.ts` (~494 lines) held diagnostic/advisories catalog markdown, lifecycle guide markdown, guidePages assembly, and llms.txt / llms-full.txt surfaces.

**After:**
- `llms-diagnostic-docs.ts` — errors + advisories builders (`buildErrorsMd`, `buildAdvisoriesMd`)
- `llms-lifecycle-docs.ts` — `LifecycleDoc` + `buildLifecycleMd`
- `gen-llms.ts` — guidePages, discovery facts, llms index/full, public re-exports

Public export surface of `gen-llms` is unchanged (split-safe test still green). Named re-exports only; new path helpers stay private. CI docs lane + content-hash surfaces list both new modules so catalog-only edits cannot false-green.

## Tests

- [x] `bun test scripts/gen-llms.test.ts` — 29 pass
- [x] focused ci-routing tests for docs surface / journey llms siblings
- [x] guide-code-contract + no-code-labels still green

## Follow-ups

None. Parallel open astral PRs (#1173 scale-children, #1175 ci-routing CLI, #1176 docs-route-inventory, #1177 geom-children) are independent.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1178" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->