### PR TITLE
refactor(spec): split layer structural checks by form family

### DIFF
--- a/packages/spec/src/validate-structure-facet.ts
+++ b/packages/spec/src/validate-structure-facet.ts
@@ -1,6 +1,6 @@
 /**
  * Data-free structural checks for facet wrap XOR grid form.
- * Layer grammar: validate-structure-layers.ts. Color schemes: validate-structure-scales.ts.
+ * Layer grammar: validate-structure-layers.ts (+ layer-rule/ribbon/computed-y). Color schemes: validate-structure-scales.ts.
  */
 import type { SpecError } from "./errors.js";
 

--- a/packages/spec/src/validate-structure-layer-computed-y.ts
+++ b/packages/spec/src/validate-structure-layer-computed-y.ts
@@ -1,0 +1,92 @@
+/**
+ * computed-y-mapped structural checks for geoms/stats that own y.
+ * Orchestrated by validate-structure-layers.ts.
+ *
+ * Each geom/stat family is checked independently (same as the pre-split
+ * sequential ifs) so an odd pairing can still emit more than one error.
+ */
+import type { SpecError } from "./errors.js";
+import type { ChannelName } from "./schema.js";
+
+/** Reject data-mapped y when the geom/stat computes y. */
+export function computedYMappedErrors(
+  geom: string,
+  stat: string,
+  layerPath: string,
+  mapped: (channel: ChannelName) => unknown,
+): SpecError[] {
+  const errors: SpecError[] = [];
+  const y = mapped("y");
+  if (y === undefined || "stat" in y) return errors;
+
+  if (
+    geom === "bar" ||
+    geom === "histogram" ||
+    geom === "freqpoly" ||
+    (geom === "line" && stat === "bin")
+  ) {
+    errors.push({
+      code: "computed-y-mapped",
+      path: `${layerPath}/aes/y`,
+      message: `The ${geom} geom computes y with the ${stat} stat, so aes.y must not map data. Use geom "col" for pre-computed heights, or unset y with null.`,
+      fix: {
+        description: 'Switch the layer to geom "col" (identity stat) to draw mapped y values.',
+        example: { geom: "col" },
+      },
+    });
+  }
+
+  if (geom === "density") {
+    errors.push({
+      code: "computed-y-mapped",
+      path: `${layerPath}/aes/y`,
+      message:
+        "The density geom computes y with the density stat, so aes.y must not map data. Map only x, or unset y with null.",
+      fix: {
+        description: "Remove the y mapping (or unset an inherited one with null).",
+        example: { geom: "density", aes: { y: null } },
+      },
+    });
+  }
+
+  if (geom === "function" || stat === "function") {
+    errors.push({
+      code: "computed-y-mapped",
+      path: `${layerPath}/aes/y`,
+      message:
+        "The function geom/stat computes y from the named function, so aes.y must not map data. Unset y with null.",
+      fix: {
+        description: "Remove the y mapping (or unset an inherited one with null).",
+        example: { geom: "function", aes: { y: null }, params: { fun: "dnorm", xlim: [-3, 3] } },
+      },
+    });
+  }
+
+  if (geom === "dotplot" || stat === "bindot") {
+    errors.push({
+      code: "computed-y-mapped",
+      path: `${layerPath}/aes/y`,
+      message:
+        "The dotplot geom computes y stack positions with the bindot stat, so aes.y must not map data. Map only x, or unset y with null.",
+      fix: {
+        description: "Remove the y mapping (or unset an inherited one with null).",
+        example: { geom: "dotplot", aes: { y: null } },
+      },
+    });
+  }
+
+  if (geom === "line" && stat === "ecdf") {
+    errors.push({
+      code: "computed-y-mapped",
+      path: `${layerPath}/aes/y`,
+      message:
+        'The ecdf stat computes y (cumulative proportion), so aes.y must not map data. Map only x, or use y: { stat: "ecdf" }.',
+      fix: {
+        description: 'Remove the y mapping (or set y: { stat: "ecdf" }).',
+        example: { geom: "line", stat: "ecdf", aes: { y: null } },
+      },
+    });
+  }
+
+  return errors;
+}

--- a/packages/spec/src/validate-structure-layer-computed-y.ts
+++ b/packages/spec/src/validate-structure-layer-computed-y.ts
@@ -6,17 +6,19 @@
  * sequential ifs) so an odd pairing can still emit more than one error.
  */
 import type { SpecError } from "./errors.js";
-import type { ChannelName } from "./schema.js";
+import type { ChannelName, ChannelValue } from "./schema.js";
 
 /** Reject data-mapped y when the geom/stat computes y. */
 export function computedYMappedErrors(
   geom: string,
   stat: string,
   layerPath: string,
-  mapped: (channel: ChannelName) => unknown,
+  /** Same shape as `effectiveChannel` — null unset already collapsed to undefined. */
+  mapped: (channel: ChannelName) => Exclude<ChannelValue, null> | undefined,
 ): SpecError[] {
   const errors: SpecError[] = [];
   const y = mapped("y");
+  // Unmapped or after_stat form ({ stat }) is fine; data-mapped y is not.
   if (y === undefined || "stat" in y) return errors;
 
   if (

--- a/packages/spec/src/validate-structure-layer-ribbon.ts
+++ b/packages/spec/src/validate-structure-layer-ribbon.ts
@@ -1,0 +1,61 @@
+/**
+ * Ribbon geom structural form checks (orientation contracts).
+ * Orchestrated by validate-structure-layers.ts.
+ */
+import type { SpecError } from "./errors.js";
+import type { ChannelName } from "./schema.js";
+import { isRecord, pushMissingChannel } from "./validate-structure-layer-shared.js";
+
+export function ribbonStructuralErrors(
+  layer: Record<string, unknown>,
+  layerPath: string,
+  mapped: (channel: ChannelName) => unknown,
+): SpecError[] {
+  const errors: SpecError[] = [];
+  const params = isRecord(layer["params"]) ? layer["params"] : {};
+  const pinned =
+    params["orientation"] === "x" || params["orientation"] === "y" ? params["orientation"] : null;
+  const xContract =
+    mapped("x") !== undefined && mapped("ymin") !== undefined && mapped("ymax") !== undefined;
+  const yContract =
+    mapped("y") !== undefined && mapped("xmin") !== undefined && mapped("xmax") !== undefined;
+
+  if (pinned === null && xContract && yContract) {
+    errors.push({
+      code: "ribbon-orientation-ambiguous",
+      path: `${layerPath}/params/orientation`,
+      message:
+        'This ribbon layer maps both x-orientation (x+ymin+ymax) and y-orientation (y+xmin+xmax) contracts. Set params.orientation to "x" or "y".',
+      fix: {
+        description: "Pin orientation explicitly.",
+        example: { params: { orientation: "x" } },
+      },
+    });
+    return errors;
+  }
+
+  const orientation: "x" | "y" | null =
+    pinned === "x" || pinned === "y" ? pinned : xContract ? "x" : yContract ? "y" : null;
+
+  const needed: ChannelName[] =
+    orientation === "y" ||
+    (orientation === null &&
+      (mapped("y") !== undefined || mapped("xmin") !== undefined || mapped("xmax") !== undefined))
+      ? ["y", "xmin", "xmax"]
+      : orientation === "x" || orientation === null
+        ? ["x", "ymin", "ymax"]
+        : ["x", "ymin", "ymax"];
+
+  for (const channel of needed) {
+    if (mapped(channel) !== undefined) continue;
+    const suffix =
+      orientation === null ? "for its interval contract" : `with orientation "${orientation}"`;
+    pushMissingChannel(
+      errors,
+      layerPath,
+      channel,
+      `The ribbon geom ${suffix} requires a "${channel}" channel; map it in the layer's aes or the plot-level aes.`,
+    );
+  }
+  return errors;
+}

--- a/packages/spec/src/validate-structure-layer-rule.ts
+++ b/packages/spec/src/validate-structure-layer-rule.ts
@@ -1,0 +1,94 @@
+/**
+ * Rule / hline / vline annotation vs data-driven form checks.
+ * Orchestrated by validate-structure-layers.ts.
+ */
+import type { SpecError } from "./errors.js";
+import type { Aes } from "./schema.js";
+import { isRecord } from "./validate-structure-layer-shared.js";
+
+/** Asymmetric intercept presence for rule / hline / vline form checks. */
+export function hasGeomIntercepts(geom: string, layer: Record<string, unknown>): boolean {
+  const params = layer["params"];
+  if (!isRecord(params)) return false;
+  if (geom === "hline") return params["yintercept"] !== undefined;
+  if (geom === "vline") return params["xintercept"] !== undefined;
+  return params["xintercept"] !== undefined || params["yintercept"] !== undefined;
+}
+
+/**
+ * Structural errors for rule-family geoms. Caller returns these immediately
+ * (no further layer checks apply to the rule family).
+ */
+export function ruleFamilyStructuralErrors(
+  layer: Record<string, unknown>,
+  geom: string,
+  layerPath: string,
+  layerAes: Aes | undefined,
+  mapped: (channel: "x" | "y") => unknown,
+): SpecError[] {
+  const errors: SpecError[] = [];
+  const intercepts = hasGeomIntercepts(geom, layer);
+  // The annotation form inherits NO plot aes (normalize drops it, matching
+  // ggplot2's inherit.aes = FALSE) — only the layer's OWN x/y mappings
+  // conflict with intercepts. Data-driven hline/vline sugar also nulls the
+  // orthogonal axis during normalize; pre-normalize validation still sees
+  // raw layer aes here.
+  const own = (channel: "x" | "y") => layerAes?.[channel] ?? undefined;
+  let x = intercepts ? own("x") : mapped("x");
+  let y = intercepts ? own("y") : mapped("y");
+  // Pre-normalize data-driven aliases: orthogonal axis is not part of the form.
+  if (!intercepts && geom === "hline") x = undefined;
+  if (!intercepts && geom === "vline") y = undefined;
+  const interceptHint =
+    geom === "hline"
+      ? "params.yintercept"
+      : geom === "vline"
+        ? "params.xintercept"
+        : "params.xintercept/yintercept";
+  const dataHint = geom === "hline" ? "aes.y" : geom === "vline" ? "aes.x" : "aes.x/aes.y";
+  if (intercepts && (x !== undefined || y !== undefined)) {
+    errors.push({
+      code: "rule-form-ambiguous",
+      path: layerPath,
+      message: `This ${geom} layer mixes the annotation form (${interceptHint}) with mapped ${dataHint}. Use fixed intercepts OR a data mapping, never both.`,
+      fix: {
+        description:
+          "Remove the intercept params (data-driven form), or unset the position aes with null (annotation form).",
+        example:
+          geom === "vline"
+            ? { geom: "vline", params: { xintercept: 0 } }
+            : { geom: geom === "hline" ? "hline" : "rule", params: { yintercept: 0 } },
+      },
+    });
+  } else if (!intercepts && x === undefined && y === undefined) {
+    errors.push({
+      code: "rule-form-missing",
+      path: layerPath,
+      message: `This ${geom} layer has neither fixed intercepts (${interceptHint}) nor a mapped ${dataHint} — nothing to draw.`,
+      fix: {
+        description:
+          geom === "hline"
+            ? "Set params.yintercept for an annotation, or map aes.y for data-driven rules."
+            : geom === "vline"
+              ? "Set params.xintercept for an annotation, or map aes.x for data-driven rules."
+              : "Set params.yintercept (or xintercept) for an annotation, or map aes.x/aes.y to a field for data-driven rules.",
+        example:
+          geom === "vline"
+            ? { geom: "vline", params: { xintercept: 0 } }
+            : { geom: geom === "hline" ? "hline" : "rule", params: { yintercept: 0 } },
+      },
+    });
+  } else if (!intercepts && x !== undefined && y !== undefined) {
+    errors.push({
+      code: "rule-both-axes",
+      path: layerPath,
+      message:
+        "This rule layer maps BOTH aes.x and aes.y; a data-driven rule is either vertical (map x) or horizontal (map y). Unset the other channel with null.",
+      fix: {
+        description: "Keep one direction and unset the other channel with null.",
+        example: { geom: "rule", aes: { y: null } },
+      },
+    });
+  }
+  return errors;
+}

--- a/packages/spec/src/validate-structure-layer-shared.ts
+++ b/packages/spec/src/validate-structure-layer-shared.ts
@@ -1,0 +1,29 @@
+/**
+ * Shared helpers for layer structural grammar checks.
+ */
+import type { SpecError } from "./errors.js";
+import type { ChannelName } from "./schema.js";
+
+/** Same shape as sibling validate-structure-* modules (local, not schema-walk). */
+export function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+export const CHANNEL_FIX_EXAMPLE = { field: "column_name" };
+
+export function pushMissingChannel(
+  errors: SpecError[],
+  layerPath: string,
+  channel: ChannelName,
+  message: string,
+): void {
+  errors.push({
+    code: "missing-required-channel",
+    path: `${layerPath}/aes/${channel}`,
+    message,
+    fix: {
+      description: `Map "${channel}" to a data field.`,
+      example: { [channel]: CHANNEL_FIX_EXAMPLE },
+    },
+  });
+}

--- a/packages/spec/src/validate-structure-layers.ts
+++ b/packages/spec/src/validate-structure-layers.ts
@@ -2,6 +2,7 @@
  * Data-free structural grammar checks for layers (required channels, rule forms,
  * computed-y bans, bin center/boundary, errorbar stat channels).
  * Color-scheme rules: validate-structure-scales.ts. Facet form: validate-structure-facet.ts.
+ * Form families: validate-structure-layer-{rule,ribbon,computed-y,shared}.ts.
  * Barrel: validate-structure.ts.
  */
 import type { SpecError } from "./errors.js";
@@ -10,12 +11,14 @@ import { GEOM_DEFAULTS } from "./schema.js";
 import { STYLE_AESTHETIC_GEOMS, type StyleAesthetic } from "./capabilities.js";
 import { effectiveChannel } from "./validate-data.js";
 import { paintStructuralErrors } from "./validate-structure-paint.js";
-
-const CHANNEL_FIX_EXAMPLE = { field: "column_name" };
-
-function isRecord(v: unknown): v is Record<string, unknown> {
-  return typeof v === "object" && v !== null && !Array.isArray(v);
-}
+import { computedYMappedErrors } from "./validate-structure-layer-computed-y.js";
+import { hasGeomIntercepts, ruleFamilyStructuralErrors } from "./validate-structure-layer-rule.js";
+import { ribbonStructuralErrors } from "./validate-structure-layer-ribbon.js";
+import {
+  CHANNEL_FIX_EXAMPLE,
+  isRecord,
+  pushMissingChannel,
+} from "./validate-structure-layer-shared.js";
 
 /**
  * Channels every geom needs mapped (after plot-aes inheritance).
@@ -74,86 +77,6 @@ const REQUIRED_CHANNELS: Record<GeomName, readonly ChannelName[]> = {
   blank: [], // trains whatever is mapped; nothing required
 };
 
-/** Asymmetric intercept presence for rule / hline / vline form checks. */
-function hasGeomIntercepts(geom: string, layer: Record<string, unknown>): boolean {
-  const params = layer["params"];
-  if (!isRecord(params)) return false;
-  if (geom === "hline") return params["yintercept"] !== undefined;
-  if (geom === "vline") return params["xintercept"] !== undefined;
-  return params["xintercept"] !== undefined || params["yintercept"] !== undefined;
-}
-
-function pushMissingChannel(
-  errors: SpecError[],
-  layerPath: string,
-  channel: ChannelName,
-  message: string,
-): void {
-  errors.push({
-    code: "missing-required-channel",
-    path: `${layerPath}/aes/${channel}`,
-    message,
-    fix: {
-      description: `Map "${channel}" to a data field.`,
-      example: { [channel]: CHANNEL_FIX_EXAMPLE },
-    },
-  });
-}
-
-function ribbonStructuralErrors(
-  layer: Record<string, unknown>,
-  layerPath: string,
-  mapped: (channel: ChannelName) => unknown,
-): SpecError[] {
-  const errors: SpecError[] = [];
-  const params = isRecord(layer["params"]) ? layer["params"] : {};
-  const pinned =
-    params["orientation"] === "x" || params["orientation"] === "y" ? params["orientation"] : null;
-  const xContract =
-    mapped("x") !== undefined && mapped("ymin") !== undefined && mapped("ymax") !== undefined;
-  const yContract =
-    mapped("y") !== undefined && mapped("xmin") !== undefined && mapped("xmax") !== undefined;
-
-  if (pinned === null && xContract && yContract) {
-    errors.push({
-      code: "ribbon-orientation-ambiguous",
-      path: `${layerPath}/params/orientation`,
-      message:
-        'This ribbon layer maps both x-orientation (x+ymin+ymax) and y-orientation (y+xmin+xmax) contracts. Set params.orientation to "x" or "y".',
-      fix: {
-        description: "Pin orientation explicitly.",
-        example: { params: { orientation: "x" } },
-      },
-    });
-    return errors;
-  }
-
-  const orientation: "x" | "y" | null =
-    pinned === "x" || pinned === "y" ? pinned : xContract ? "x" : yContract ? "y" : null;
-
-  const needed: ChannelName[] =
-    orientation === "y" ||
-    (orientation === null &&
-      (mapped("y") !== undefined || mapped("xmin") !== undefined || mapped("xmax") !== undefined))
-      ? ["y", "xmin", "xmax"]
-      : orientation === "x" || orientation === null
-        ? ["x", "ymin", "ymax"]
-        : ["x", "ymin", "ymax"];
-
-  for (const channel of needed) {
-    if (mapped(channel) !== undefined) continue;
-    const suffix =
-      orientation === null ? "for its interval contract" : `with orientation "${orientation}"`;
-    pushMissingChannel(
-      errors,
-      layerPath,
-      channel,
-      `The ribbon geom ${suffix} requires a "${channel}" channel; map it in the layer's aes or the plot-level aes.`,
-    );
-  }
-  return errors;
-}
-
 /** Grammar checks for one schema-valid layer. */
 export function layerStructuralErrors(
   layer: Record<string, unknown>,
@@ -188,70 +111,7 @@ export function layerStructuralErrors(
   }
 
   if (isRuleFamily) {
-    const intercepts = hasGeomIntercepts(geom, layer);
-    // The annotation form inherits NO plot aes (normalize drops it, matching
-    // ggplot2's inherit.aes = FALSE) — only the layer's OWN x/y mappings
-    // conflict with intercepts. Data-driven hline/vline sugar also nulls the
-    // orthogonal axis during normalize; pre-normalize validation still sees
-    // raw layer aes here.
-    const own = (channel: "x" | "y") => layerAes?.[channel] ?? undefined;
-    let x = intercepts ? own("x") : mapped("x");
-    let y = intercepts ? own("y") : mapped("y");
-    // Pre-normalize data-driven aliases: orthogonal axis is not part of the form.
-    if (!intercepts && geom === "hline") x = undefined;
-    if (!intercepts && geom === "vline") y = undefined;
-    const interceptHint =
-      geom === "hline"
-        ? "params.yintercept"
-        : geom === "vline"
-          ? "params.xintercept"
-          : "params.xintercept/yintercept";
-    const dataHint = geom === "hline" ? "aes.y" : geom === "vline" ? "aes.x" : "aes.x/aes.y";
-    if (intercepts && (x !== undefined || y !== undefined)) {
-      errors.push({
-        code: "rule-form-ambiguous",
-        path: layerPath,
-        message: `This ${geom} layer mixes the annotation form (${interceptHint}) with mapped ${dataHint}. Use fixed intercepts OR a data mapping, never both.`,
-        fix: {
-          description:
-            "Remove the intercept params (data-driven form), or unset the position aes with null (annotation form).",
-          example:
-            geom === "vline"
-              ? { geom: "vline", params: { xintercept: 0 } }
-              : { geom: geom === "hline" ? "hline" : "rule", params: { yintercept: 0 } },
-        },
-      });
-    } else if (!intercepts && x === undefined && y === undefined) {
-      errors.push({
-        code: "rule-form-missing",
-        path: layerPath,
-        message: `This ${geom} layer has neither fixed intercepts (${interceptHint}) nor a mapped ${dataHint} — nothing to draw.`,
-        fix: {
-          description:
-            geom === "hline"
-              ? "Set params.yintercept for an annotation, or map aes.y for data-driven rules."
-              : geom === "vline"
-                ? "Set params.xintercept for an annotation, or map aes.x for data-driven rules."
-                : "Set params.yintercept (or xintercept) for an annotation, or map aes.x/aes.y to a field for data-driven rules.",
-          example:
-            geom === "vline"
-              ? { geom: "vline", params: { xintercept: 0 } }
-              : { geom: geom === "hline" ? "hline" : "rule", params: { yintercept: 0 } },
-        },
-      });
-    } else if (!intercepts && x !== undefined && y !== undefined) {
-      errors.push({
-        code: "rule-both-axes",
-        path: layerPath,
-        message:
-          "This rule layer maps BOTH aes.x and aes.y; a data-driven rule is either vertical (map x) or horizontal (map y). Unset the other channel with null.",
-        fix: {
-          description: "Keep one direction and unset the other channel with null.",
-          example: { geom: "rule", aes: { y: null } },
-        },
-      });
-    }
-    return errors;
+    return ruleFamilyStructuralErrors(layer, geom, layerPath, layerAes, mapped);
   }
 
   const stat =
@@ -259,89 +119,7 @@ export function layerStructuralErrors(
       ? layer["stat"]
       : (GEOM_DEFAULTS[geom as keyof typeof GEOM_DEFAULTS]?.stat ?? "identity");
 
-  if (
-    geom === "bar" ||
-    geom === "histogram" ||
-    geom === "freqpoly" ||
-    (geom === "line" && stat === "bin")
-  ) {
-    const y = mapped("y");
-    if (y !== undefined && !("stat" in y)) {
-      errors.push({
-        code: "computed-y-mapped",
-        path: `${layerPath}/aes/y`,
-        message: `The ${geom} geom computes y with the ${stat} stat, so aes.y must not map data. Use geom "col" for pre-computed heights, or unset y with null.`,
-        fix: {
-          description: 'Switch the layer to geom "col" (identity stat) to draw mapped y values.',
-          example: { geom: "col" },
-        },
-      });
-    }
-  }
-
-  if (geom === "density") {
-    const y = mapped("y");
-    if (y !== undefined && !("stat" in y)) {
-      errors.push({
-        code: "computed-y-mapped",
-        path: `${layerPath}/aes/y`,
-        message:
-          "The density geom computes y with the density stat, so aes.y must not map data. Map only x, or unset y with null.",
-        fix: {
-          description: "Remove the y mapping (or unset an inherited one with null).",
-          example: { geom: "density", aes: { y: null } },
-        },
-      });
-    }
-  }
-
-  if (geom === "function" || stat === "function") {
-    const y = mapped("y");
-    if (y !== undefined && !("stat" in y)) {
-      errors.push({
-        code: "computed-y-mapped",
-        path: `${layerPath}/aes/y`,
-        message:
-          "The function geom/stat computes y from the named function, so aes.y must not map data. Unset y with null.",
-        fix: {
-          description: "Remove the y mapping (or unset an inherited one with null).",
-          example: { geom: "function", aes: { y: null }, params: { fun: "dnorm", xlim: [-3, 3] } },
-        },
-      });
-    }
-  }
-
-  if (geom === "dotplot" || stat === "bindot") {
-    const y = mapped("y");
-    if (y !== undefined && !("stat" in y)) {
-      errors.push({
-        code: "computed-y-mapped",
-        path: `${layerPath}/aes/y`,
-        message:
-          "The dotplot geom computes y stack positions with the bindot stat, so aes.y must not map data. Map only x, or unset y with null.",
-        fix: {
-          description: "Remove the y mapping (or unset an inherited one with null).",
-          example: { geom: "dotplot", aes: { y: null } },
-        },
-      });
-    }
-  }
-
-  if (geom === "line" && stat === "ecdf") {
-    const y = mapped("y");
-    if (y !== undefined && !("stat" in y)) {
-      errors.push({
-        code: "computed-y-mapped",
-        path: `${layerPath}/aes/y`,
-        message:
-          'The ecdf stat computes y (cumulative proportion), so aes.y must not map data. Map only x, or use y: { stat: "ecdf" }.',
-        fix: {
-          description: 'Remove the y mapping (or set y: { stat: "ecdf" }).',
-          example: { geom: "line", stat: "ecdf", aes: { y: null } },
-        },
-      });
-    }
-  }
+  errors.push(...computedYMappedErrors(geom, stat, layerPath, mapped));
 
   if (
     geom === "bar" ||

--- a/packages/spec/src/validate-structure-layers.ts
+++ b/packages/spec/src/validate-structure-layers.ts
@@ -111,7 +111,10 @@ export function layerStructuralErrors(
   }
 
   if (isRuleFamily) {
-    return ruleFamilyStructuralErrors(layer, geom, layerPath, layerAes, mapped);
+    // Keep unsupported-geom-aesthetic errors already pushed above; rule form
+    // checks append. Returning only the form-check array would drop them.
+    errors.push(...ruleFamilyStructuralErrors(layer, geom, layerPath, layerAes, mapped));
+    return errors;
   }
 
   const stat =

--- a/packages/spec/src/validate-structure-scales.ts
+++ b/packages/spec/src/validate-structure-scales.ts
@@ -1,6 +1,6 @@
 /**
  * Data-free structural checks for named color/fill schemes vs scale family.
- * Layer grammar: validate-structure-layers.ts. Facet: validate-structure-facet.ts.
+ * Layer grammar: validate-structure-layers.ts (+ layer-rule/ribbon/computed-y). Facet: validate-structure-facet.ts.
  */
 import type { SpecError } from "./errors.js";
 import { CATEGORICAL_SCHEME_NAMES, SEQUENTIAL_SCHEME_NAMES } from "./schema.js";

--- a/packages/spec/src/validate-structure.ts
+++ b/packages/spec/src/validate-structure.ts
@@ -2,7 +2,7 @@
  * Data-free structural grammar checks (tier-2, opt-in via validate options).
  *
  * Implementation:
- *  - validate-structure-layers.ts — geom channels, rule forms, M2 layer rules
+ *  - validate-structure-layers.ts — geom channels, rule/ribbon/computed-y forms, M2 layer rules
  *  - validate-structure-scales.ts — named color/fill scheme vs family
  *  - validate-structure-style-bins.ts — binned style breaks/domain well-formedness
  *  - validate-structure-facet.ts — wrap XOR grid form

--- a/packages/spec/tests/validate-tier2-structure.test.ts
+++ b/packages/spec/tests/validate-tier2-structure.test.ts
@@ -150,6 +150,22 @@ describe("tier 2 — structural grammar checks (opt-in, data-free)", () => {
     expect(result.ok).toBe(true);
   });
 
+  it("rule: layer-own unsupported style aes is kept with form checks (not discarded)", () => {
+    // Regression: early return of ruleFamilyStructuralErrors alone must not
+    // drop unsupported-geom-aesthetic errors already pushed for the layer.
+    expect(
+      codesOf({
+        layers: [
+          {
+            geom: "rule",
+            aes: { size: { field: "pop" } },
+            params: { yintercept: 0 },
+          },
+        ],
+      }),
+    ).toEqual(["unsupported-geom-aesthetic"]);
+  });
+
   it("rule: neither form is an error", () => {
     expect(codesOf({ layers: [{ geom: "rule" }] })).toEqual(["rule-form-missing"]);
   });


### PR DESCRIPTION
## Summary

Astral-maintain pass on `packages/spec`: split mixed-concern layer structural validation.

**Before:** `validate-structure-layers.ts` (~540 lines) held required-channel tables, rule/hline/vline form checks, ribbon orientation, five computed-y families, bin/errorbar/spoke/rug checks, and the orchestrator.

**After:**
- `validate-structure-layer-shared.ts` — `isRecord`, `CHANNEL_FIX_EXAMPLE`, `pushMissingChannel`
- `validate-structure-layer-rule.ts` — `hasGeomIntercepts`, `ruleFamilyStructuralErrors`
- `validate-structure-layer-ribbon.ts` — `ribbonStructuralErrors`
- `validate-structure-layer-computed-y.ts` — `computedYMappedErrors`
- `validate-structure-layers.ts` — required-channel table + remaining checks + orchestrator

Public export remains `layerStructuralErrors` via `validate-structure.ts`. Error push order preserved. Independent computed-y `if`s preserved (odd pairings can still emit multiple errors).

## Tests

- [x] `bun test packages/spec/tests` — 672 pass (61 snapshots)

## Follow-ups

None. Parallel open astral PRs on scripts/ and codemod are independent.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1180" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->