### PR TITLE
chore(svelte): remove unused rowIndexesForCandidate helper

### DIFF
--- a/packages/svelte/src/lib/selection/selection.ts
+++ b/packages/svelte/src/lib/selection/selection.ts
@@ -22,10 +22,6 @@ export function presentationChromeForKind(kind: string | null | undefined): Pres
   return kind === "rects" ? "none" : "ring";
 }
 
-export type CandidateRowRef = {
-  readonly rowIndex: number | null;
-};
-
 /**
  * Ordered equality for PropertyKey sequences (length + Object.is per index).
  * Distinct Symbols never equal. Does not dedupe — callers normalize first.
@@ -53,20 +49,6 @@ export function buildPointSelectionEvent(
     keys: Object.freeze([...keys]),
     source,
   });
-}
-
-/**
- * Union lineage row indexes with the candidate's own rowIndex when set.
- * Lineage order is preserved; the candidate row is appended only if absent.
- */
-export function rowIndexesForCandidate(
-  candidate: CandidateRowRef,
-  lineageRowIndexes: Iterable<number>,
-): number[] {
-  const rows = [...lineageRowIndexes];
-  if (candidate.rowIndex !== null && !rows.includes(candidate.rowIndex))
-    rows.push(candidate.rowIndex);
-  return rows;
 }
 
 /**

--- a/packages/svelte/tests/selection/selection.test.ts
+++ b/packages/svelte/tests/selection/selection.test.ts
@@ -8,7 +8,6 @@ import {
   mergePresentationFocusKeys,
   nextPointSelectionKeys,
   presentationFocusFromInspection,
-  rowIndexesForCandidate,
   sameOrderedPropertyKeys,
   uniqueKeysFromRowIndexes,
 } from "../../src/lib/selection/selection.js";
@@ -150,14 +149,6 @@ describe("anchorsFromCandidateKeys", () => {
         ["a"],
       ),
     ).toEqual([{ x: 1, y: 2, chrome: "ring" }]);
-  });
-});
-
-describe("rowIndexesForCandidate", () => {
-  it("preserves lineage order and appends rowIndex only if absent", () => {
-    expect(rowIndexesForCandidate({ rowIndex: 9 }, [3, 1, 4])).toEqual([3, 1, 4, 9]);
-    expect(rowIndexesForCandidate({ rowIndex: 1 }, [3, 1, 4])).toEqual([3, 1, 4]);
-    expect(rowIndexesForCandidate({ rowIndex: null }, [3, 1])).toEqual([3, 1]);
   });
 });
 


### PR DESCRIPTION
## Summary

Remove `rowIndexesForCandidate` and `CandidateRowRef` from selection helpers. No production callers; live path is inline in `candidateSemanticKeysFromCache` (semantic-keys-projection).

## Evidence

- `rg` shows no production callers after removal
- Not a package root / lifecycle public export
- Unit tests for the helper deleted; remaining `uniqueKeysFromRowIndexes` coverage kept

## Validation

Local vitest browser is blocked on this host (Node 18 / `node:util.styleText`). CI package suite is the gate.

## Test plan

- [ ] CI component-svelte / unit paths green
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1190" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->