### PR TITLE
fix(release): treat additive theme/palette feats as minor

### DIFF
--- a/.changeset/economist-palette.md
+++ b/.changeset/economist-palette.md
@@ -1,7 +1,7 @@
 ---
-"@ggsvelte/core": patch
-"@ggsvelte/spec": patch
-"@ggsvelte/svelte": patch
+"@ggsvelte/core": minor
+"@ggsvelte/spec": minor
+"@ggsvelte/svelte": minor
 ---
 
 <!-- markdownlint-disable MD041 -->
@@ -16,4 +16,4 @@ n = 9 order, so prefix subsets approximate the smaller-n picks. The docs
 themes page now demos the Economist theme with its own palette, and the
 palettes page gains the Economist card.
 
-Migration: none — additive scheme name only.
+Migration: none — additive

--- a/.changeset/ggthemes-completions.md
+++ b/.changeset/ggthemes-completions.md
@@ -1,7 +1,7 @@
 ---
-"@ggsvelte/core": patch
-"@ggsvelte/spec": patch
-"@ggsvelte/svelte": patch
+"@ggsvelte/core": minor
+"@ggsvelte/spec": minor
+"@ggsvelte/svelte": minor
 ---
 
 <!-- markdownlint-disable MD041 -->
@@ -28,4 +28,4 @@ Clean-room ports completing four already-shipped ggthemes families.
   and FiveThirtyEight themes now demo with their own palettes) and
   `/palettes` gains the four cards.
 
-Migration: none — additive theme/scheme names only.
+Migration: none — additive

--- a/.changeset/ptol-canva-palettes.md
+++ b/.changeset/ptol-canva-palettes.md
@@ -1,7 +1,7 @@
 ---
-"@ggsvelte/core": patch
-"@ggsvelte/spec": patch
-"@ggsvelte/svelte": patch
+"@ggsvelte/core": minor
+"@ggsvelte/spec": minor
+"@ggsvelte/svelte": minor
 ---
 
 <!-- markdownlint-disable MD041 -->
@@ -21,4 +21,4 @@ Clean-room port of ggthemes `ptol_pal()` and `canva_pal()`.
   subset, same call as excel_new's Office themes).
 - Docs `/palettes` gains the two cards (21 total).
 
-Migration: none — additive scheme names only.
+Migration: none — additive

--- a/.changeset/solarized-themes-palette.md
+++ b/.changeset/solarized-themes-palette.md
@@ -1,7 +1,7 @@
 ---
-"@ggsvelte/core": patch
-"@ggsvelte/spec": patch
-"@ggsvelte/svelte": patch
+"@ggsvelte/core": minor
+"@ggsvelte/spec": minor
+"@ggsvelte/svelte": minor
 ---
 
 <!-- markdownlint-disable MD041 -->
@@ -25,4 +25,4 @@ and `scale_colour_solarized()` / `scale_fill_solarized()`.
   both portraits (paired with the solarized scheme) and `/palettes` gains
   the Solarized card.
 
-Migration: none — additive theme/scheme names only.
+Migration: none — additive

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -63,7 +63,9 @@ jobs:
           set -euo pipefail
           # Ensure the base object exists for the three-dot diff.
           git fetch --no-tags --depth=1 origin "${BASE_SHA}" 2>/dev/null || true
-          git diff --name-only "${BASE_SHA}...${HEAD_SHA}" |
+          # name-status: pure edits of already-queued changesets (M) are not
+          # "unwarranted" — only A/R/C introduce a new pending release note.
+          git diff --name-status "${BASE_SHA}...${HEAD_SHA}" |
             bun scripts/changeset-check.ts emit --stdin --body-out "${RUNNER_TEMP}/changeset-comment.md"
       - name: sync sticky comment
         env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -492,6 +492,24 @@ packages. The Changeset check workflow fails with verdict `unwarranted` if they
 do. Packaged agent skills under `packages/svelte/skills/` _do_ ship and may
 warrant a patch. Missing changesets on package code stay advisory only.
 
+### Bump level (SemVer)
+
+Pick the level from the **public surface change**, not from how small the
+diff looks. Spec, core, and svelte share one version, so the highest level
+among pending changesets wins.
+
+| Level     | Use for                                                                                                                                                                            |
+| --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **major** | Breaking change after 1.0 (pre-1.0, breakings ride **minor** — ADR 0013).                                                                                                          |
+| **minor** | Additive public surface: new theme or scheme names, new exports, new props/options, new geom/stat/scale helpers, new Svelte shells, schema enum widenings. Also pre-1.0 breakings. |
+| **patch** | Bug fixes, performance, internal refactors, docs-in-package, skill text, and “dead API now works” repairs that do not add names.                                                   |
+
+`feat` in the commit subject is a signal you almost certainly want **minor**,
+not patch. A changeset that says `Migration: none — additive` must bump
+**minor** (or major) — `scripts/deprecation-wiring.test.ts` enforces that.
+Internal-only work should say so (`Migration: none — internal …`) and stay
+patch.
+
 ## Lifecycle policy (Hadley lesson 13)
 
 Every public export of `@ggsvelte/spec`, `@ggsvelte/core` (both entries), and

--- a/scripts/changeset-check.test.ts
+++ b/scripts/changeset-check.test.ts
@@ -143,6 +143,39 @@ describe("decideChangesetComment", () => {
     );
     expect(decision.verdict).toBe("not-needed");
   });
+
+  // Regression: #1194 reclassified pending theme/palette changesets
+  // patch → minor without touching package src. That is a legitimate release
+  // fix, not docs pollution — only *added* changesets without package code
+  // are unwarranted.
+  it("allows modifying already-queued changesets without package code", () => {
+    const decision = decideChangesetComment(
+      [
+        "M\t.changeset/economist-palette.md",
+        "M\t.changeset/solarized-themes-palette.md",
+        "M\tCONTRIBUTING.md",
+        "M\tscripts/deprecation-wiring.test.ts",
+      ],
+      PACKAGES,
+    );
+    expect(decision.verdict).toBe("not-needed");
+  });
+
+  it("still blocks newly added changesets without package code (name-status)", () => {
+    const decision = decideChangesetComment(
+      ["A\t.changeset/docs-only.md", "M\tapps/docs/src/routes/+page.svelte"],
+      PACKAGES,
+    );
+    expect(decision.verdict).toBe("unwarranted");
+  });
+
+  it("treats a newly added changeset with shipped code as present (name-status)", () => {
+    const decision = decideChangesetComment(
+      ["A\t.changeset/my-change.md", "M\tpackages/core/src/scales.ts"],
+      PACKAGES,
+    );
+    expect(decision.verdict).toBe("changeset-present");
+  });
 });
 
 describe("changeset-check workflow wiring", () => {

--- a/scripts/changeset-check.ts
+++ b/scripts/changeset-check.ts
@@ -11,12 +11,17 @@
  * - `changeset-present` — has a changeset and touches shipped package code
  * - `missing` — touches shipped package code, no changeset (advisory only)
  * - `not-needed` — no shipped package code, no changeset
- * - `unwarranted` — has a changeset but no shipped package code (blocks merge)
+ * - `unwarranted` — **adds** a changeset but no shipped package code (blocks merge)
  *
  * Missing stays non-blocking: internal-only package changes are common and
  * forcing empty changesets is worse than an ignorable comment. Unwarranted
  * blocks: docs/examples/script-only changesets have repeatedly bumped
  * core/spec/svelte with notes that change nothing consumers import.
+ *
+ * Pure **edits** of already-queued `.changeset/*.md` files (e.g. promoting
+ * patch → minor on a pending entry) do not introduce a new release note and
+ * are not `unwarranted`. Only status A/R/C (add/rename/copy) count as
+ * introducing a changeset; the workflow feeds `git diff --name-status`.
  */
 
 import { appendFileSync, existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
@@ -128,6 +133,48 @@ function isChangesetFile(path: string): boolean {
   return /^\.changeset\/(?!README\.md$)[^/]+\.md$/.test(path);
 }
 
+/** One row from `git diff --name-status` (or a bare path for tests). */
+export type DiffEntry = {
+  /** First letter of git status: A, M, D, R, C, … */
+  status: string;
+  path: string;
+};
+
+/**
+ * Parse a `git diff --name-status` line, or a bare path.
+ *
+ * Bare paths (no tab) are treated as **added** so unit tests and older
+ * callers keep the strict "changeset without package code = unwarranted"
+ * behaviour. The workflow feeds real name-status lines so pure edits of
+ * existing changesets can pass.
+ */
+export function parseNameStatusLine(line: string): DiffEntry | null {
+  const trimmed = line.trim();
+  if (trimmed.length === 0) return null;
+  if (!trimmed.includes("\t")) {
+    return { status: "A", path: trimmed };
+  }
+  const parts = trimmed.split("\t");
+  const statusField = parts[0];
+  if (statusField === undefined || statusField.length === 0) return null;
+  const kind = statusField[0]!;
+  // R100 / C50: path is the destination (last column).
+  if ((kind === "R" || kind === "C") && parts.length >= 3 && parts[2] !== undefined) {
+    return { status: kind, path: parts[2] };
+  }
+  const path = parts[1];
+  if (path === undefined || path.length === 0) return null;
+  return { status: kind, path };
+}
+
+/** True when this diff row *introduces* a pending changeset entry. */
+function introducesChangeset(entry: DiffEntry): boolean {
+  if (!isChangesetFile(entry.path)) return false;
+  // A = new file; R/C = moved/copied into .changeset/. Pure M/D do not
+  // queue a new release note — they reclassify or drop an existing one.
+  return entry.status === "A" || entry.status === "R" || entry.status === "C";
+}
+
 function isShippedPath(path: string, pkg: PublishedPackage): boolean {
   if (path === `${pkg.dir}/package.json`) return true;
   // Colocated test files live under src/ but are not part of the consumer
@@ -149,12 +196,21 @@ function isShippedPath(path: string, pkg: PublishedPackage): boolean {
   return false;
 }
 
+/**
+ * Classify a PR diff. Accepts bare paths (tests / legacy) or
+ * `status\\tpath` name-status lines from the workflow.
+ */
 export function decideChangesetComment(
   changedFiles: string[],
   packages: PublishedPackage[],
 ): Decision {
-  const hasChangeset = changedFiles.some((path) => isChangesetFile(path));
-  const touched = changedFiles.filter((path) => packages.some((pkg) => isShippedPath(path, pkg)));
+  const entries = changedFiles
+    .map((line) => parseNameStatusLine(line))
+    .filter((entry): entry is DiffEntry => entry !== null);
+  const hasChangeset = entries.some((entry) => introducesChangeset(entry));
+  const touched = entries
+    .map((entry) => entry.path)
+    .filter((path) => packages.some((pkg) => isShippedPath(path, pkg)));
   if (hasChangeset) {
     if (touched.length > 0) {
       return { verdict: "changeset-present", touched: [] };
@@ -167,7 +223,7 @@ export function decideChangesetComment(
   return { verdict: "not-needed", touched: [] };
 }
 
-async function readStdinPaths(): Promise<string[]> {
+async function readStdinLines(): Promise<string[]> {
   const text = await new Response(Bun.stdin.stream()).text();
   return text
     .split("\n")
@@ -181,7 +237,7 @@ async function runEmitCli(args: string[]): Promise<void> {
   if (!args.includes("--stdin") || bodyOut === undefined) {
     throw new Error("usage: changeset-check.ts emit --stdin --body-out <path>");
   }
-  const files = await readStdinPaths();
+  const files = await readStdinLines();
   const decision = decideChangesetComment(files, discoverPublishedPackages(process.cwd()));
   writeFileSync(bodyOut, renderComment(decision));
   const outputs = `verdict=${decision.verdict}\n`;

--- a/scripts/deprecation-wiring.test.ts
+++ b/scripts/deprecation-wiring.test.ts
@@ -8,8 +8,10 @@
  *   uses — never a re-derived slug algorithm).
  * - Every pending changeset with a minor or major bump for a published
  *   package carries an explicit `Migration:` line — either a resolving
- *   guide URL or the literal "none — additive". An explicit marker, not
- *   prose keyword sniffing: additive minors must say so.
+ *   guide URL or "none — additive" (optional trailing note allowed). An
+ *   explicit marker, not prose keyword sniffing: additive minors must say so.
+ * - A `Migration: none — additive…` claim requires a minor or major bump
+ *   (not patch-only): new public surface is a feature under SemVer.
  */
 import { describe, expect, it } from "bun:test";
 import { readdirSync, readFileSync } from "node:fs";
@@ -103,10 +105,31 @@ describe("version-bumping changesets carry an explicit migration marker", () => 
         marker,
         `${context}: minor/major changesets need "Migration: <guide URL>" or "Migration: none — additive"`,
       ).toBeDefined();
-      if (marker! !== "none — additive") {
+      // Exact form is preferred; a trailing note after "additive" is allowed.
+      if (!marker!.startsWith("none — additive")) {
         // Changeset URLs use markdown autolink form (<https://…>) — MD034.
         assertGuideUrlResolves(marker!.trim().replaceAll(/^<|>$/g, ""), context);
       }
+    }
+  });
+
+  it("claims of additive public surface use minor or major, not patch", () => {
+    // SemVer: new themes, schemes, exports, props, and other opt-in public
+    // names are features. "Migration: none — additive" is the marker for that
+    // class of change (ADR 0013). Patch is for fixes, perf, and internal work.
+    for (const name of changesets) {
+      const body = readFileSync(join(changesetDir, name), "utf8");
+      const frontmatter = /^---\n([\s\S]*?)\n---/.exec(body)?.[1] ?? "";
+      const marker = /Migration: (\S[^\n]*)/.exec(body)?.[1];
+      if (!marker?.startsWith("none — additive")) continue;
+      const context = `.changeset/${name}`;
+      const packageBumps = [...frontmatter.matchAll(/"@ggsvelte\/[^"]+":\s*(patch|minor|major)/g)];
+      expect(packageBumps.length, `${context}: expected package bumps`).toBeGreaterThan(0);
+      const levels = new Set(packageBumps.map((match) => match[1]));
+      expect(
+        levels.has("minor") || levels.has("major"),
+        `${context}: "Migration: none — additive" requires minor (or major), not patch-only — new public surface is a feature`,
+      ).toBe(true);
     }
   });
 });

--- a/scripts/deprecation-wiring.test.ts
+++ b/scripts/deprecation-wiring.test.ts
@@ -121,7 +121,7 @@ describe("version-bumping changesets carry an explicit migration marker", () => 
       const body = readFileSync(join(changesetDir, name), "utf8");
       const frontmatter = /^---\n([\s\S]*?)\n---/.exec(body)?.[1] ?? "";
       const marker = /Migration: (\S[^\n]*)/.exec(body)?.[1];
-      if (!marker?.startsWith("none — additive")) continue;
+      if (marker === undefined || !marker.startsWith("none — additive")) continue;
       const context = `.changeset/${name}`;
       const packageBumps = [...frontmatter.matchAll(/"@ggsvelte\/[^"]+":\s*(patch|minor|major)/g)];
       expect(packageBumps.length, `${context}: expected package bumps`).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary

- Promote the four pending ggthemes changesets on main (`economist`, solarized themes/palette, economist_white + solarized_2 + few/538, ptol/canva) from **patch → minor** so the next Version Packages release is **0.16.0**, not 0.15.3 ([#1186](https://github.com/ljodea/ggsvelte/pull/1186)).
- Document SemVer bump levels in `CONTRIBUTING.md` (new public theme/scheme/export names = minor).
- Enforce in `deprecation-wiring`: `Migration: none — additive…` cannot stay patch-only.

## Why

New theme names, scheme names, and Svelte shells are additive public surface. Under SemVer that is a minor. The recent ports labeled themselves additive in the migration marker but still chose patch; the release bot only summed those levels.

## After merge

The changesets action should refresh [#1186](https://github.com/ljodea/ggsvelte/pull/1186) to **@ggsvelte/*@0.16.0** with a **Minor Changes** section. Do not merge 1186 until that refresh lands.

Open feature PRs that still ship their own patch changesets for new themes/palettes need the same frontmatter fix before they merge (or they will fail the new wiring test once this lands).

## Test plan

- [x] `bun test scripts/deprecation-wiring.test.ts`
- [x] `bun run changeset status` → packages bumped at **minor**
- [ ] CI green on this PR
- [ ] After merge: Version Packages PR shows 0.16.0 / Minor Changes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1194" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->