### PR TITLE
fix(docs): drop double separator under reference landing list

### DIFF
--- a/apps/docs/src/routes/reference/+page.svelte
+++ b/apps/docs/src/routes/reference/+page.svelte
@@ -92,15 +92,24 @@
     margin-top: 2rem;
   }
 
+  /*
+   * Borders between list rows only. The last link must not draw a bottom
+   * rule — DocsShell's .prev-next already has border-top, and a trailing
+   * row border stacked a second separator under PortableSpec (and every
+   * other final reference entry).
+   */
   nav a {
     display: grid;
     min-height: 5rem;
     align-content: center;
     padding: 1rem 0;
-    border-bottom: 1px solid var(--line);
     color: var(--ink);
     text-decoration: none;
     gap: 0.35rem;
+  }
+
+  nav a + a {
+    border-top: 1px solid var(--line);
   }
 
   nav strong {


### PR DESCRIPTION
## Summary

On `/reference`, the last section link (PortableSpec JSON Schema) sat above **two** horizontal rules before Previous/Next.

**Why:** every `nav a` used `border-bottom`, including the last row, and DocsShell `.prev-next` also uses `border-top` (`shell.css`). Stacked lines with a large gap looked like two separator divs.

**Fix:** draw borders only *between* list rows (`nav a + a { border-top }`). The prev-next top rule is the single separator before chapter navigation.

## Test plan

- [ ] Open `/reference` and scroll to the bottom
- [ ] Confirm one rule under PortableSpec JSON Schema, then Previous (Production) / Next (Geoms)
- [ ] Confirm rules still appear between each reference section link
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1195" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->