### PR TITLE
fix(docs): stop chart mega-chunk preload on intent-only pages

### DIFF
--- a/apps/docs/src/lib/catalog/palette-tables.ts
+++ b/apps/docs/src/lib/catalog/palette-tables.ts
@@ -7,5 +7,5 @@
  * These deep source paths match the higher-priority `ggsvelte-palette-tables`
  * codeSplitting group instead.
  */
-export { CATEGORICAL_SCHEMES } from "../../../../../packages/core/src/scales/categorical-palettes.ts";
-export { VIRIDIS_RAMP_10 } from "../../../../../packages/core/src/scales/viridis-ramp.ts";
+export { CATEGORICAL_SCHEMES } from "../../../../../packages/core/src/scales/categorical-palettes.js";
+export { VIRIDIS_RAMP_10 } from "../../../../../packages/core/src/scales/viridis-ramp.js";

--- a/apps/docs/src/lib/catalog/palette-tables.ts
+++ b/apps/docs/src/lib/catalog/palette-tables.ts
@@ -1,0 +1,11 @@
+/**
+ * Pure palette / ramp tables for docs chrome (pickers, swatches).
+ *
+ * Do not re-export these through `@ggsvelte/core`: the docs vite config puts
+ * the whole core package into one shared chunk, so a barrel import of hex
+ * tables would modulepreload the full chart stack on /themes and /palettes.
+ * These deep source paths match the higher-priority `ggsvelte-palette-tables`
+ * codeSplitting group instead.
+ */
+export { CATEGORICAL_SCHEMES } from "../../../../../packages/core/src/scales/categorical-palettes.ts";
+export { VIRIDIS_RAMP_10 } from "../../../../../packages/core/src/scales/viridis-ramp.ts";

--- a/apps/docs/src/lib/catalog/themes.ts
+++ b/apps/docs/src/lib/catalog/themes.ts
@@ -1,10 +1,16 @@
-import { CATEGORICAL_SCHEMES, VIRIDIS_RAMP_10 } from "@ggsvelte/core";
-import {
-  CATEGORICAL_SCHEME_NAMES,
-  THEME_NAME_ALIASES,
-  THEME_NAMES,
-  type ThemeName,
-} from "@ggsvelte/spec";
+import type { ThemeName } from "@ggsvelte/spec";
+
+import { CATEGORICAL_SCHEMES, VIRIDIS_RAMP_10 } from "./palette-tables.js";
+
+/**
+ * Docs-local mirror of package aliases (grey/gray → ggplot2). Kept as a plain
+ * object so this module never value-imports `@ggsvelte/spec` / TypeBox — that
+ * barrel lands in the chart mega-chunk and was modulepreloaded on /themes.
+ */
+const THEME_NAME_ALIASES = {
+  grey: "ggplot2",
+  gray: "ggplot2",
+} as const satisfies Partial<Record<ThemeName, ThemeName>>;
 
 /** Canonical picker themes — grey/gray alias ggplot2 and stay out of the list. */
 type ThemeOptionName = Exclude<ThemeName, keyof typeof THEME_NAME_ALIASES>;
@@ -17,11 +23,11 @@ type ThemeOptionName = Exclude<ThemeName, keyof typeof THEME_NAME_ALIASES>;
 const CATEGORICAL_SCHEME_DISPLAY_ALIASES = {
   gray: "grey",
 } as const satisfies Partial<
-  Record<(typeof CATEGORICAL_SCHEME_NAMES)[number], (typeof CATEGORICAL_SCHEME_NAMES)[number]>
+  Record<keyof typeof CATEGORICAL_SCHEMES, keyof typeof CATEGORICAL_SCHEMES>
 >;
 
 type PaletteOptionName = Exclude<
-  (typeof CATEGORICAL_SCHEME_NAMES)[number],
+  keyof typeof CATEGORICAL_SCHEMES,
   keyof typeof CATEGORICAL_SCHEME_DISPLAY_ALIASES
 >;
 
@@ -131,28 +137,31 @@ const THEME_DEMO_SCHEMES = {
   hcdark: "hc_dark",
   pander: "pander",
   test: "colorblind",
-} as const satisfies Record<ThemeOptionName, (typeof CATEGORICAL_SCHEME_NAMES)[number]>;
+} as const satisfies Record<ThemeOptionName, keyof typeof CATEGORICAL_SCHEMES>;
 
-/** Picker/specimen themes only — API still accepts grey/gray via THEME_NAME_ALIASES. */
-export const THEME_OPTIONS = THEME_NAMES.filter(
-  (name): name is ThemeOptionName => !(name in THEME_NAME_ALIASES),
-).map((name) => ({
+/**
+ * Picker/specimen themes only. Built from THEME_LABELS (not THEME_NAMES from
+ * `@ggsvelte/spec`) so the client never loads the TypeBox schema graph.
+ */
+export const THEME_OPTIONS = (Object.keys(THEME_LABELS) as ThemeOptionName[]).map((name) => ({
   name,
   label: THEME_LABELS[name],
   scheme: THEME_DEMO_SCHEMES[name],
 }));
 
 /** Picker/specimen palettes only — API still accepts gray via the same GREY_PALETTE_10. */
-export const CATEGORICAL_PALETTES = CATEGORICAL_SCHEME_NAMES.filter(
-  (name): name is PaletteOptionName => !(name in CATEGORICAL_SCHEME_DISPLAY_ALIASES),
-).map((name) => {
-  const colors = CATEGORICAL_SCHEMES[name];
-  return {
-    name,
-    label: PALETTE_LABELS[name],
-    capacity: colors.length,
-    colors,
-  };
-});
+export const CATEGORICAL_PALETTES = (
+  Object.keys(CATEGORICAL_SCHEMES) as (keyof typeof CATEGORICAL_SCHEMES)[]
+)
+  .filter((name): name is PaletteOptionName => !(name in CATEGORICAL_SCHEME_DISPLAY_ALIASES))
+  .map((name) => {
+    const colors = CATEGORICAL_SCHEMES[name];
+    return {
+      name,
+      label: PALETTE_LABELS[name],
+      capacity: colors.length,
+      colors,
+    };
+  });
 
 export const VIRIDIS_COLORS = VIRIDIS_RAMP_10;

--- a/apps/docs/vite.config.ts
+++ b/apps/docs/vite.config.ts
@@ -10,6 +10,12 @@ import { defineConfig } from "vite";
  * Without this, layout chrome co-chunks with `@ggsvelte/core` / GGPlot
  * (~120–340KB decoded on every page). Chart pages still load these groups via
  * their own imports.
+ *
+ * Named package groups put *every* matching module into one shared chunk. A
+ * tiny static import of palette hex tables (`catalog/themes`) or teaching
+ * datasets (`@ggsvelte/svelte/data`) then modulepreloads the full ~1MB chart
+ * stack on intent-only pages. Higher-priority carve-outs keep pure data in
+ * their own small chunks so those pages stay light until live charts load.
  */
 export default defineConfig({
   plugins: [sveltekit()],
@@ -28,6 +34,18 @@ export default defineConfig({
               name: "svelte-runtime",
               test: /[\\/]node_modules[\\/]svelte[\\/]/,
               priority: 30,
+            },
+            // Pure teaching datasets — not the GGPlot runtime.
+            {
+              name: "ggsvelte-data",
+              test: /(?:[\\/]node_modules[\\/]@ggsvelte[\\/]svelte[\\/]data[\\/]|[\\/]packages[\\/]svelte[\\/](?:src[\\/]lib[\\/]|dist[\\/])?data[\\/])/,
+              priority: 40,
+            },
+            // Pure palette / ramp tables — not pipeline, render, or scales engine.
+            {
+              name: "ggsvelte-palette-tables",
+              test: /[\\/](?:categorical-palettes|colorbrewer-palettes|viridis-ramp)\.[cm]?[jt]s$/,
+              priority: 40,
             },
             {
               name: "ggsvelte-core",

--- a/scripts/docs-chart-stack-isolation.test.ts
+++ b/scripts/docs-chart-stack-isolation.test.ts
@@ -56,6 +56,56 @@ describe("docs chart stack isolation (PR1)", () => {
     expect(vite).toContain("priority: 30");
   });
 
+  it("splits pure data out of the chart mega-chunks (priority > package groups)", () => {
+    // Named package groups put every matching module into one shared chunk. A
+    // one-line import of palette colors or kyotoSakura then modulepreloads the
+    // full ~1MB chart stack on /themes, /palettes, and getting-started.
+    // Higher-priority groups must carve pure data out of those mega-chunks.
+    const vite = readFileSync(path.join(root, "apps/docs/vite.config.ts"), "utf8");
+    expect(vite).toContain("ggsvelte-data");
+    expect(vite).toContain("ggsvelte-palette-tables");
+    expect(vite).toMatch(/name:\s*["']ggsvelte-data["'][\s\S]*?priority:\s*40/);
+    expect(vite).toMatch(/name:\s*["']ggsvelte-palette-tables["'][\s\S]*?priority:\s*40/);
+    // Data/palette carve-outs must match the thin modules, not the whole package.
+    expect(vite).toMatch(/data[\\/]|[\\/]data[\\/]|svelte[\\/]data/);
+    expect(vite).toMatch(/categorical-palettes|colorbrewer-palettes|viridis-ramp/);
+  });
+
+  it("keeps intent-shell components free of static @ggsvelte/svelte main imports", () => {
+    // Type-only is fine; a value import of the main entry pulls ggsvelte-svelte.
+    for (const rel of [
+      "lib/components/ThemeSpecimen.svelte",
+      "lib/components/PaletteSpecimen.svelte",
+      "lib/components/GrammarDemo.svelte",
+      "lib/components/ChartThemeLab.svelte",
+      "lib/components/SequentialDeferredPlot.svelte",
+    ] as const) {
+      const source = read(rel);
+      expect(source, rel).not.toMatch(/import\s+[^;]*\s+from\s*["']@ggsvelte\/svelte["']/);
+      expect(source, rel).not.toMatch(/import\s+[^;]*\s+from\s*["']@ggsvelte\/core["']/);
+    }
+  });
+
+  it("loads the lesson chart package only via dynamic import (not static main)", () => {
+    const lesson = read("lib/components/LessonFinishedChart.svelte");
+    // Dynamic path is required so the page can paint without chart JS.
+    expect(lesson).toMatch(/import\s*\(\s*["']@ggsvelte\/svelte["']\s*\)/);
+    // No static value import of the main entry (type-only import type is OK).
+    expect(lesson).not.toMatch(
+      /(?:^|\n)\s*import\s+(?!type\b)[^;]*\s+from\s*["']@ggsvelte\/svelte["']/,
+    );
+  });
+
+  it("keeps the docs palette catalog free of chart package value imports", () => {
+    // The catalog is statically imported by ChartThemeLab / SequentialColorLab.
+    // Value imports of @ggsvelte/core or @ggsvelte/spec pull package mega-chunks
+    // (TypeBox schemas, pipeline) onto /themes and /palettes before intent.
+    const catalog = read("lib/catalog/themes.ts");
+    expect(catalog).not.toMatch(/from\s*["']@ggsvelte\/core["']/);
+    expect(catalog).not.toMatch(/import\s+(?!type\b)[^;]*\s+from\s*["']@ggsvelte\/spec["']/);
+    expect(catalog).toMatch(/palette-tables|CATEGORICAL_SCHEMES|VIRIDIS_RAMP/);
+  });
+
   it("keeps root layout free of static @ggsvelte chart imports", () => {
     const layout = read("routes/+layout.svelte");
     expect(layout).not.toMatch(/from\s*["']@ggsvelte\/(?:svelte|core)["']/);


### PR DESCRIPTION
## Summary

Intent-gated chart hydration (#1193) stopped auto-mounting live plots, but Vite still **modulepreloaded** the full ~1MB chart stack on first paint of Getting Started, Themes, and Palettes.

Root cause: Rolldown `codeSplitting.groups` put every `@ggsvelte/{core,svelte,spec}` module into one shared chunk. A tiny static import of palette hex tables (`catalog/themes` → `@ggsvelte/core`) or teaching data (`@ggsvelte/svelte/data`) made the page depend on that mega-chunk.

### Changes

1. Higher-priority carve-outs: `ggsvelte-data` (teaching datasets) and `ggsvelte-palette-tables` (hex tables / viridis).
2. Docs catalog imports palette tables via a thin bridge (no `@ggsvelte/core` or value `@ggsvelte/spec` / TypeBox).
3. Source guards in `scripts/docs-chart-stack-isolation.test.ts`.

## Benchmark (local production build vs live baseline)

| Page | Before (modulepreload) | After | Delta |
|------|------------------------|-------|-------|
| `/guide/getting-started` | 1676 KB (mega chart) | 458 KB | **−1.2 MB** |
| `/themes` | 1265 KB | 252 KB | **−1.0 MB** |
| `/palettes` | 1370 KB | 357 KB | **−1.0 MB** |
| `/` | 395 KB | 395 KB | 0 |
| `/examples` | 285 KB | 285 KB | 0 |

No page above still modulepreloads a ≥800 KB chart chunk. Live charts still load on intent / near-viewport via dynamic import.

## Test plan

- [x] `bun test scripts/docs-chart-stack-isolation.test.ts scripts/docs-chart-intent-load.test.ts scripts/themes-page.test.ts`
- [x] `bun run build:docs` — measure modulepreload graphs
- [ ] After deploy: production `/themes`, `/palettes`, `/guide/getting-started` have no ≥800 KB modulepreload
- [ ] Hover/focus still upgrades theme specimens and lesson finished chart
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1209" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->