### PR TITLE
fix(docs): keep DOCS_ROUTES off the client layout graph

### DIFF
--- a/apps/docs/src/lib/components/DocsShell.svelte
+++ b/apps/docs/src/lib/components/DocsShell.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { Snippet } from "svelte";
 
-  import { GUIDE_NAVIGATION, primaryNavigationOwner } from "$lib/routes";
+  import { GUIDE_NAVIGATION, primaryNavigationOwner } from "$lib/routes-nav";
   import type { DocsRouteMetadata } from "$lib/route-types";
 
   import Breadcrumbs from "./Breadcrumbs.svelte";

--- a/apps/docs/src/lib/components/SiteHeader.svelte
+++ b/apps/docs/src/lib/components/SiteHeader.svelte
@@ -9,7 +9,7 @@
     type DocsAppearance,
   } from "$lib/docs-appearance";
   import { primaryNavLinks } from "$lib/primary-nav-links";
-  import { primaryNavigationOwner } from "$lib/routes";
+  import { primaryNavigationOwner } from "$lib/routes-nav";
   import type { DocsRouteMetadata } from "$lib/route-types";
   import type { Component } from "svelte";
 

--- a/apps/docs/src/lib/routes-nav.ts
+++ b/apps/docs/src/lib/routes-nav.ts
@@ -1,0 +1,28 @@
+/**
+ * Client-safe route navigation surface.
+ *
+ * Imports only GUIDE_NAVIGATION from the generated projection — never
+ * DOCS_ROUTES (~120KB of per-route metadata). Server load already serializes
+ * the current route onto page data; chrome only needs the guide sidebar map
+ * and a pure helper for primary-nav ownership.
+ */
+import { GUIDE_NAVIGATION } from "./generated/routes.js";
+import type { DocsRouteMetadata } from "./route-types.js";
+
+export { GUIDE_NAVIGATION };
+
+export type PrimaryNavigationOwner = "docs" | "reference";
+
+export function primaryNavigationOwner(
+  route: DocsRouteMetadata | undefined,
+): PrimaryNavigationOwner | undefined {
+  if (route === undefined) return undefined;
+  if (
+    route.primaryNavigationOwner === "reference" ||
+    route.path.startsWith("/reference") ||
+    route.navigation?.section === "Reference"
+  ) {
+    return "reference";
+  }
+  return route.shell === "docs" ? "docs" : undefined;
+}

--- a/apps/docs/src/lib/routes.ts
+++ b/apps/docs/src/lib/routes.ts
@@ -1,7 +1,15 @@
-import { DOCS_ROUTES, GUIDE_NAVIGATION } from "./generated/routes.js";
+import { DOCS_ROUTES } from "./generated/routes.js";
 import type { DocsRouteMetadata } from "./route-types.js";
 
-export { DOCS_ROUTES, GUIDE_NAVIGATION };
+// Re-export the thin client surface so server tests and scripts can keep one
+// import path. Client chrome must import from `$lib/routes-nav` instead so
+// DOCS_ROUTES stays out of the layout graph.
+export {
+  GUIDE_NAVIGATION,
+  primaryNavigationOwner,
+  type PrimaryNavigationOwner,
+} from "./routes-nav.js";
+export { DOCS_ROUTES };
 
 const ROUTES: readonly DocsRouteMetadata[] = DOCS_ROUTES;
 const ROUTES_BY_PATH = new Map<string, DocsRouteMetadata>(
@@ -25,22 +33,6 @@ export function canonicalUrl(route: DocsRouteMetadata, canonicalBase: string): s
 
 export function sitemapRoutes(): DocsRouteMetadata[] {
   return ROUTES.filter((route) => route.sitemap);
-}
-
-export type PrimaryNavigationOwner = "docs" | "reference";
-
-export function primaryNavigationOwner(
-  route: DocsRouteMetadata | undefined,
-): PrimaryNavigationOwner | undefined {
-  if (route === undefined) return undefined;
-  if (
-    route.primaryNavigationOwner === "reference" ||
-    route.path.startsWith("/reference") ||
-    route.navigation?.section === "Reference"
-  ) {
-    return "reference";
-  }
-  return route.shell === "docs" ? "docs" : undefined;
 }
 
 export function guideSequence(path: string): {

--- a/apps/docs/src/routes/docs/+page.svelte
+++ b/apps/docs/src/routes/docs/+page.svelte
@@ -6,7 +6,7 @@
     guideNavBlocks,
     guideSectionDomId,
   } from "$lib/catalog/guide";
-  import { GUIDE_NAVIGATION } from "$lib/routes";
+  import { GUIDE_NAVIGATION } from "$lib/routes-nav";
 
   const descriptionByPath = new Map<string, string>([
     ...GUIDE_CATALOG.map(

--- a/scripts/docs-routes-client-thin.test.ts
+++ b/scripts/docs-routes-client-thin.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Guards: client shell must not pull the full DOCS_ROUTES catalog (~120KB).
+ * Server layout load already serializes the current route; chrome only needs
+ * GUIDE_NAVIGATION + primaryNavigationOwner.
+ */
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+const root = path.join(import.meta.dirname, "..");
+const docsSrc = path.join(root, "apps/docs/src");
+
+function read(rel: string): string {
+  return readFileSync(path.join(docsSrc, rel), "utf8");
+}
+
+describe("docs routes client thin catalog", () => {
+  it("keeps routes-nav free of DOCS_ROUTES value imports", () => {
+    const nav = read("lib/routes-nav.ts");
+    expect(nav).toContain("GUIDE_NAVIGATION");
+    expect(nav).toContain("primaryNavigationOwner");
+    // Comments may name DOCS_ROUTES; ban value imports only.
+    expect(nav).not.toMatch(/import\s*\{[^}]*\bDOCS_ROUTES\b[^}]*\}\s*from/);
+    expect(nav).not.toMatch(/findDocsRoute|guideSequence|sitemapRoutes/);
+  });
+
+  it("loads DocsShell and SiteHeader from routes-nav, not the full routes module", () => {
+    const shell = read("lib/components/DocsShell.svelte");
+    expect(shell).toContain("$lib/routes-nav");
+    expect(shell).not.toMatch(/from\s*["']\$lib\/routes["']/);
+
+    const header = read("lib/components/SiteHeader.svelte");
+    expect(header).toContain("$lib/routes-nav");
+    expect(header).not.toMatch(/from\s*["']\$lib\/routes["']/);
+  });
+
+  it("loads docs overview chapters from routes-nav", () => {
+    const page = read("routes/docs/+page.svelte");
+    expect(page).toContain("$lib/routes-nav");
+    expect(page).not.toMatch(/from\s*["']\$lib\/routes["']/);
+  });
+
+  it("keeps full route helpers on the server-facing routes module", () => {
+    const routes = read("lib/routes.ts");
+    expect(routes).toContain("DOCS_ROUTES");
+    expect(routes).toContain("findDocsRoute");
+    expect(routes).toContain("guideSequence");
+  });
+});


### PR DESCRIPTION
## Summary

Every docs page modulepreloaded ~120KB of `DOCS_ROUTES` because client chrome imported navigation helpers from `$lib/routes`, which value-imports the full generated catalog.

Server layout load already serializes the current route. Client chrome only needs `GUIDE_NAVIGATION` and `primaryNavigationOwner`.

### Changes

- New `$lib/routes-nav` thin client surface
- DocsShell, SiteHeader, docs overview import from routes-nav
- `$lib/routes` keeps find/sitemap/sequence for the server
- Source guards in `scripts/docs-routes-client-thin.test.ts`

## Benchmark (local production build, post #1209 base)

| Page | Before | After | Delta |
|------|--------|-------|-------|
| `/` | 395 KB | 280 KB | **−115 KB** |
| `/guide/getting-started` | 458 KB | 342 KB | **−116 KB** |
| `/themes` | 252 KB | 137 KB | **−115 KB** |
| `/examples` | 285 KB | 170 KB | **−115 KB** |

## Test plan

- [x] `bun test scripts/docs-routes-client-thin.test.ts scripts/docs-routes.test.ts`
- [x] `bun run build:docs` + measure modulepreload graphs
- [ ] After deploy: production pages no longer modulepreload a ~120KB routes catalog chunk
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1212" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->