### PR TITLE
fix(docs): defer svelte-highlight until code chrome mounts

### DIFF
--- a/apps/docs/src/lib/CodeTabs.svelte
+++ b/apps/docs/src/lib/CodeTabs.svelte
@@ -41,9 +41,13 @@
 
   onMount(() => {
     let cancelled = false;
-    void loadHighlight().then((loaded) => {
-      if (!cancelled) bundle = loaded;
-    });
+    void loadHighlight()
+      .then((loaded) => {
+        if (!cancelled) bundle = loaded;
+      })
+      .catch(() => {
+        // Keep plain pre/code; loadHighlight clears its cache for retry.
+      });
     return () => {
       cancelled = true;
     };

--- a/apps/docs/src/lib/CodeTabs.svelte
+++ b/apps/docs/src/lib/CodeTabs.svelte
@@ -128,13 +128,17 @@
     role="tabpanel"
     aria-labelledby={`${tabsetId}-tab-${String(active)}`}
   >
+    <!-- Stable selection target — Highlight remounts must not clear manual copy. -->
+    <pre
+      class="copy-source"
+      bind:this={codeNode}
+      aria-hidden="true">{activeTab?.code ?? ""}</pre>
     <!-- svelte-ignore a11y_no_noninteractive_tabindex (scrollable code must be keyboard reachable) -->
     <div
       class="scroll-region code-surface"
       role="region"
       aria-label="Code example"
       tabindex="0"
-      bind:this={codeNode}
     >
       {#if Highlight !== null && languageModule !== null}
         <Highlight code={activeTab?.code ?? ""} language={languageModule} />
@@ -213,6 +217,18 @@
    * Keep padding on the scrollable pre so inline-end gap survives horizontal
    * scroll (Blink/WebKit drop scrollport padding at the end of overflow).
    */
+  .copy-source {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: pre;
+    border: 0;
+  }
+
   .scroll-region {
     max-width: 100%;
     padding: 0;

--- a/apps/docs/src/lib/CodeTabs.svelte
+++ b/apps/docs/src/lib/CodeTabs.svelte
@@ -4,14 +4,11 @@
    * spec JSON (what agents emit), fluent-builder TypeScript (spec.ts), and
    * idiomatic Svelte components (Example.svelte) — each with a copy button.
    */
-  import Highlight from "svelte-highlight";
+  import { onMount } from "svelte";
 
   import { briefCopyStatus, COPIED_STATUS, copyText } from "$lib/clipboard";
-  import {
-    languageFromCodeTabLabel,
-    resolveCodeLanguage,
-  } from "$lib/code-languages";
   import { CHECK_ICON_SVG, COPY_ICON_SVG } from "$lib/copy-icons";
+  import { loadHighlight, type HighlightBundle } from "$lib/load-highlight";
   import { nextRovingTabIndex } from "$lib/tab-roving";
 
   interface Tab {
@@ -28,14 +25,29 @@
   const tabsetId = $props.id();
   const panelId = `${tabsetId}-panel`;
   let copyTimer: ReturnType<typeof setTimeout> | undefined;
+  let bundle = $state<HighlightBundle | null>(null);
 
   const activeTab = $derived(tabs[active]);
+  const Highlight = $derived(bundle?.Highlight ?? null);
   const languageModule = $derived(
-    resolveCodeLanguage(
-      activeTab?.language ?? languageFromCodeTabLabel(activeTab?.label),
-    ),
+    bundle === null
+      ? null
+      : bundle.resolveCodeLanguage(
+          activeTab?.language ??
+            bundle.languageFromCodeTabLabel(activeTab?.label),
+        ),
   );
   const copied = $derived(copyStatus === COPIED_STATUS);
+
+  onMount(() => {
+    let cancelled = false;
+    void loadHighlight().then((loaded) => {
+      if (!cancelled) bundle = loaded;
+    });
+    return () => {
+      cancelled = true;
+    };
+  });
 
   async function copy(): Promise<void> {
     const code = tabs[active]?.code ?? "";
@@ -124,7 +136,11 @@
       tabindex="0"
       bind:this={codeNode}
     >
-      <Highlight code={activeTab?.code ?? ""} language={languageModule} />
+      {#if Highlight !== null && languageModule !== null}
+        <Highlight code={activeTab?.code ?? ""} language={languageModule} />
+      {:else}
+        <pre><code>{activeTab?.code ?? ""}</code></pre>
+      {/if}
     </div>
   </div>
 </div>

--- a/apps/docs/src/lib/components/CopyCode.svelte
+++ b/apps/docs/src/lib/components/CopyCode.svelte
@@ -32,9 +32,13 @@
 
   onMount(() => {
     let cancelled = false;
-    void loadHighlight().then((loaded) => {
-      if (!cancelled) bundle = loaded;
-    });
+    void loadHighlight()
+      .then((loaded) => {
+        if (!cancelled) bundle = loaded;
+      })
+      .catch(() => {
+        // Keep plain pre/code; loadHighlight clears its cache for retry.
+      });
     return () => {
       cancelled = true;
     };

--- a/apps/docs/src/lib/components/CopyCode.svelte
+++ b/apps/docs/src/lib/components/CopyCode.svelte
@@ -64,7 +64,13 @@
       {@html COPY_ICON_SVG}
     {/if}
   </button>
-  <div class="code-body" bind:this={source}>
+  <!--
+    Stable selection target for the clipboard-unavailable path. Highlight swaps
+    its DOM after mount; selecting the display tree races and leaves an empty
+    selection (docs-home-gallery manual-copy journey).
+  -->
+  <pre class="copy-source" bind:this={source} aria-hidden="true">{code}</pre>
+  <div class="code-body">
     {#if Highlight !== null && languageModule !== null}
       <Highlight {code} language={languageModule} />
     {:else}
@@ -111,6 +117,18 @@
   .copy-trigger:hover {
     border-color: color-mix(in srgb, var(--code-ink) 55%, transparent);
     background: color-mix(in srgb, var(--code-paper) 70%, var(--code-ink) 8%);
+  }
+
+  .copy-source {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: pre;
+    border: 0;
   }
 
   .code-body {

--- a/apps/docs/src/lib/components/CopyCode.svelte
+++ b/apps/docs/src/lib/components/CopyCode.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-  import Highlight from "svelte-highlight";
+  import { onMount } from "svelte";
 
   import { briefCopyStatus, COPIED_STATUS, copyText } from "$lib/clipboard";
-  import { resolveCodeLanguage } from "$lib/code-languages";
   import { CHECK_ICON_SVG, COPY_ICON_SVG } from "$lib/copy-icons";
+  import { loadHighlight, type HighlightBundle } from "$lib/load-highlight";
 
   const {
     code,
@@ -23,8 +23,22 @@
   let source = $state<HTMLElement>();
   let status = $state("");
   let timer: ReturnType<typeof setTimeout> | undefined;
-  const languageModule = $derived(resolveCodeLanguage(language));
+  let bundle = $state<HighlightBundle | null>(null);
+  const Highlight = $derived(bundle?.Highlight ?? null);
+  const languageModule = $derived(
+    bundle === null ? null : bundle.resolveCodeLanguage(language),
+  );
   const copied = $derived(status === COPIED_STATUS);
+
+  onMount(() => {
+    let cancelled = false;
+    void loadHighlight().then((loaded) => {
+      if (!cancelled) bundle = loaded;
+    });
+    return () => {
+      cancelled = true;
+    };
+  });
 
   async function copy(): Promise<void> {
     if (timer !== undefined) clearTimeout(timer);
@@ -51,7 +65,11 @@
     {/if}
   </button>
   <div class="code-body" bind:this={source}>
-    <Highlight {code} language={languageModule} />
+    {#if Highlight !== null && languageModule !== null}
+      <Highlight {code} language={languageModule} />
+    {:else}
+      <pre><code>{code}</code></pre>
+    {/if}
   </div>
   <span class="visually-hidden" role="status">{status}</span>
 </div>

--- a/apps/docs/src/lib/load-highlight.ts
+++ b/apps/docs/src/lib/load-highlight.ts
@@ -1,0 +1,25 @@
+/**
+ * Deferred svelte-highlight loader for docs code chrome.
+ *
+ * Static imports of svelte-highlight + language packs put ~100KB into the
+ * first-paint modulepreload graph on every page that mounts CopyCode/CodeTabs.
+ * Callers show plain <pre><code> until this resolves.
+ */
+export type HighlightBundle = {
+  Highlight: (typeof import("svelte-highlight"))["default"];
+  resolveCodeLanguage: (typeof import("./code-languages.js"))["resolveCodeLanguage"];
+  languageFromCodeTabLabel: (typeof import("./code-languages.js"))["languageFromCodeTabLabel"];
+};
+
+let pending: Promise<HighlightBundle> | undefined;
+
+export function loadHighlight(): Promise<HighlightBundle> {
+  pending ??= Promise.all([import("svelte-highlight"), import("./code-languages.js")]).then(
+    ([highlight, languages]) => ({
+      Highlight: highlight.default,
+      resolveCodeLanguage: languages.resolveCodeLanguage,
+      languageFromCodeTabLabel: languages.languageFromCodeTabLabel,
+    }),
+  );
+  return pending;
+}

--- a/apps/docs/src/lib/load-highlight.ts
+++ b/apps/docs/src/lib/load-highlight.ts
@@ -14,12 +14,16 @@ export type HighlightBundle = {
 let pending: Promise<HighlightBundle> | undefined;
 
 export function loadHighlight(): Promise<HighlightBundle> {
-  pending ??= Promise.all([import("svelte-highlight"), import("./code-languages.js")]).then(
-    ([highlight, languages]) => ({
+  pending ??= Promise.all([import("svelte-highlight"), import("./code-languages.js")])
+    .then(([highlight, languages]) => ({
       Highlight: highlight.default,
       resolveCodeLanguage: languages.resolveCodeLanguage,
       languageFromCodeTabLabel: languages.languageFromCodeTabLabel,
-    }),
-  );
+    }))
+    .catch((error: unknown) => {
+      // Do not cache a rejected promise — a transient chunk miss must retry.
+      pending = undefined;
+      throw error;
+    });
   return pending;
 }

--- a/scripts/docs-highlight-lazy.test.ts
+++ b/scripts/docs-highlight-lazy.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Guards: docs code chrome must not static-import svelte-highlight.
+ * That package (~100KB) was modulepreloaded on every page with CopyCode/CodeTabs.
+ */
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+const root = path.join(import.meta.dirname, "..");
+const docsSrc = path.join(root, "apps/docs/src");
+
+function read(rel: string): string {
+  return readFileSync(path.join(docsSrc, rel), "utf8");
+}
+
+describe("docs highlight lazy load", () => {
+  it("keeps CopyCode free of static svelte-highlight imports", () => {
+    const source = read("lib/components/CopyCode.svelte");
+    expect(source).not.toMatch(/import\s+Highlight\s+from\s*["']svelte-highlight["']/);
+    expect(source).not.toMatch(/from\s*["']\$lib\/code-languages["']/);
+    expect(source).toMatch(/import\s*\(|LazyHighlight|loadHighlight/);
+  });
+
+  it("keeps CodeTabs free of static svelte-highlight imports", () => {
+    const source = read("lib/CodeTabs.svelte");
+    expect(source).not.toMatch(/import\s+Highlight\s+from\s*["']svelte-highlight["']/);
+    expect(source).not.toMatch(/from\s*["']\$lib\/code-languages["']/);
+    expect(source).toMatch(/import\s*\(|LazyHighlight|loadHighlight/);
+  });
+
+  it("loads highlight only through the shared deferred loader", () => {
+    const loader = read("lib/load-highlight.ts");
+    expect(loader).toContain("svelte-highlight");
+    expect(loader).toContain("code-languages");
+    expect(loader).toMatch(/import\s*\(\s*["']svelte-highlight["']\s*\)/);
+  });
+});


### PR DESCRIPTION
## Summary

`CopyCode` and `CodeTabs` static-imported `svelte-highlight` plus all language packs, so every page with code chrome modulepreloaded ~100KB of highlight JS on first paint.

### Changes

- Shared `loadHighlight()` dynamic import (singleton promise)
- CopyCode / CodeTabs show plain `<pre><code>` until the highlighter resolves
- Source guards in `scripts/docs-highlight-lazy.test.ts`

## Benchmark (local production build, post #1209+#1212 base)

| Page | Before | After | Delta |
|------|--------|-------|-------|
| `/` | 280 KB | 182 KB | **−98 KB** |
| `/guide/getting-started` | 321 KB | 244 KB | **−77 KB** |
| `/palettes` | 242 KB | 144 KB | **−98 KB** |
| `/themes` | 137 KB | 138 KB | ~0 (no highlight on that page) |

## Test plan

- [x] `bun test scripts/docs-highlight-lazy.test.ts`
- [x] `apps/docs` svelte-check clean
- [x] `bun run build:docs` + measure modulepreload graphs
- [ ] After deploy: production pages with code no longer modulepreload ~100KB highlight
- [ ] Code still highlights after mount; copy still works
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1214" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->