### PR TITLE
docs: add themes and palettes reference pages (#1198)

### DIFF
--- a/apps/docs/src/lib/catalog/guide.ts
+++ b/apps/docs/src/lib/catalog/guide.ts
@@ -134,22 +134,22 @@ export const GUIDE_CATALOG = [
     description:
       "Understand validation, render, interaction, and CLI diagnostics and recover safely.",
     section: "Reference",
-    // After /reference/* pages (50–55); leave 53 for positions reference.
-    navigationOrder: 56,
+    // After /reference/* pages (50–58: overview through CLI, themes, palettes).
+    navigationOrder: 59,
   },
   {
     slug: "advisories",
     title: "Advisories",
     description: "Spec-lint advisories and the pipeline's disclosed heuristics.",
     section: "Reference",
-    navigationOrder: 57,
+    navigationOrder: 60,
   },
   {
     slug: "lifecycle",
     title: "Lifecycle & editions",
     description: "API stability tags per export, and the defaults-edition mechanism.",
     section: "Reference",
-    navigationOrder: 58,
+    navigationOrder: 61,
   },
   {
     slug: "upgrading",

--- a/apps/docs/src/lib/catalog/palette-reference.ts
+++ b/apps/docs/src/lib/catalog/palette-reference.ts
@@ -1,0 +1,188 @@
+/**
+ * Palette → scale helper mapping for /reference/palettes.
+ *
+ * Scheme names come from the PortableSpec registries. Scale children pass
+ * `scheme` into color/fill scales (or use a family-specific shell).
+ */
+import { CATEGORICAL_SCHEME_NAMES, SEQUENTIAL_SCHEME_NAMES } from "@ggsvelte/spec";
+
+export type PaletteFamily = "categorical" | "sequential";
+
+export interface PaletteSchemeRef {
+  readonly name: string;
+  readonly family: PaletteFamily;
+  /** Primary Svelte shells that accept this scheme (or set it by construction). */
+  readonly helpers: readonly string[];
+  readonly notes?: string;
+}
+
+/** Shared discrete color/fill shells for named categorical schemes. */
+const DISCRETE_HELPERS = [
+  "ScaleColorDiscrete",
+  "ScaleFillDiscrete",
+  "ScaleColorOrdinal",
+  "ScaleFillOrdinal",
+] as const;
+
+/** Shared continuous color/fill shells for named sequential schemes. */
+const CONTINUOUS_HELPERS = [
+  "ScaleColorContinuous",
+  "ScaleFillContinuous",
+  "ScaleColorBinned",
+  "ScaleFillBinned",
+] as const;
+
+const COLORBREWER_QUALITATIVE = new Set(["Set1", "Set2", "Set3", "Dark2", "Paired", "Accent"]);
+
+const VIRIDIS_FAMILY = new Set(["viridis", "magma", "plasma", "inferno", "cividis", "turbo"]);
+
+const COLORBREWER_SEQUENTIAL = new Set([
+  "Blues",
+  "Greens",
+  "Reds",
+  "Oranges",
+  "Purples",
+  "Greys",
+  "YlOrRd",
+  "YlGnBu",
+  "BuPu",
+  "RdYlBu",
+  "RdBu",
+  "BrBG",
+  "Spectral",
+  "PuOr",
+]);
+
+function categoricalHelpers(name: string): readonly string[] {
+  if (name === "hue") {
+    return ["ScaleColorHue", "ScaleFillHue", ...DISCRETE_HELPERS];
+  }
+  if (name === "grey" || name === "gray") {
+    return ["ScaleColorGrey", "ScaleFillGrey", ...DISCRETE_HELPERS];
+  }
+  if (COLORBREWER_QUALITATIVE.has(name)) {
+    return ["ScaleColorBrewer", "ScaleFillBrewer", ...DISCRETE_HELPERS];
+  }
+  return DISCRETE_HELPERS;
+}
+
+function categoricalNotes(name: string): string | undefined {
+  if (name === "hue") return 'Default discrete path; also scheme="hue" on ordinal scales.';
+  if (name === "grey" || name === "gray") {
+    return "Same greyscale ramp; US and UK spellings both accepted.";
+  }
+  if (COLORBREWER_QUALITATIVE.has(name)) {
+    return `ColorBrewer qualitative — prefer <ScaleColorBrewer palette="${name}" /> (maps to scheme).`;
+  }
+  if (name === "observable10") return "Default categorical scheme when none is set.";
+  return undefined;
+}
+
+function sequentialHelpers(name: string): readonly string[] {
+  if (VIRIDIS_FAMILY.has(name)) {
+    return [
+      "ScaleColorViridisC",
+      "ScaleColorViridisD",
+      "ScaleColorViridisB",
+      "ScaleFillViridisC",
+      "ScaleFillViridisD",
+      "ScaleFillViridisB",
+      ...CONTINUOUS_HELPERS,
+      "ScaleColorDiscrete",
+      "ScaleFillDiscrete",
+    ];
+  }
+  if (COLORBREWER_SEQUENTIAL.has(name)) {
+    return [
+      "ScaleColorDistiller",
+      "ScaleFillDistiller",
+      "ScaleColorFermenter",
+      "ScaleFillFermenter",
+      ...CONTINUOUS_HELPERS,
+    ];
+  }
+  return CONTINUOUS_HELPERS;
+}
+
+function sequentialNotes(name: string): string | undefined {
+  if (VIRIDIS_FAMILY.has(name)) {
+    return `Viridis family — <ScaleColorViridisC option="${name}" /> or scheme on continuous/discrete.`;
+  }
+  if (COLORBREWER_SEQUENTIAL.has(name)) {
+    return `ColorBrewer ramp — Distiller (continuous), Fermenter (binned), or scheme on continuous.`;
+  }
+  if (name.startsWith("tableau_seq_") || name.startsWith("tableau_div_")) {
+    return "Tableau gradient ramp (ggthemes tableau_gradient_pal set).";
+  }
+  return undefined;
+}
+
+/** All registered categorical schemes with scale helper tips. */
+export const CATEGORICAL_SCHEME_REFS: readonly PaletteSchemeRef[] = CATEGORICAL_SCHEME_NAMES.map(
+  (name) => {
+    const notes = categoricalNotes(name);
+    return {
+      name,
+      family: "categorical" as const,
+      helpers: categoricalHelpers(name),
+      ...(notes !== undefined && { notes }),
+    };
+  },
+);
+
+/** All registered sequential / diverging schemes with scale helper tips. */
+export const SEQUENTIAL_SCHEME_REFS: readonly PaletteSchemeRef[] = SEQUENTIAL_SCHEME_NAMES.map(
+  (name) => {
+    const notes = sequentialNotes(name);
+    return {
+      name,
+      family: "sequential" as const,
+      helpers: sequentialHelpers(name),
+      ...(notes !== undefined && { notes }),
+    };
+  },
+);
+
+/** High-level helper groups for the reference index (not every shell). */
+export const PALETTE_HELPER_GROUPS = [
+  {
+    id: "discrete",
+    title: "Discrete (categorical schemes)",
+    shells: [
+      "ScaleColorDiscrete",
+      "ScaleFillDiscrete",
+      "ScaleColorOrdinal",
+      "ScaleFillOrdinal",
+      "ScaleColorBrewer",
+      "ScaleFillBrewer",
+      "ScaleColorHue",
+      "ScaleFillHue",
+      "ScaleColorGrey",
+      "ScaleFillGrey",
+      "ScaleColorManual",
+      "ScaleFillManual",
+    ],
+    summary:
+      'Pass scheme="tableau10" (or another categorical name) on discrete/ordinal shells. Brewer, hue, and grey set the scheme by construction.',
+  },
+  {
+    id: "continuous",
+    title: "Continuous and binned (sequential schemes)",
+    shells: [
+      "ScaleColorContinuous",
+      "ScaleFillContinuous",
+      "ScaleColorBinned",
+      "ScaleFillBinned",
+      "ScaleColorViridisC",
+      "ScaleColorViridisD",
+      "ScaleColorViridisB",
+      "ScaleColorDistiller",
+      "ScaleColorFermenter",
+      "ScaleColorGradient",
+      "ScaleColorGradient2",
+      "ScaleColorGradientn",
+    ],
+    summary:
+      'Pass scheme="viridis" (or another sequential name) on continuous/binned shells. Gradient* helpers take explicit color stops instead of a name.',
+  },
+] as const;

--- a/apps/docs/src/lib/catalog/theme-reference.ts
+++ b/apps/docs/src/lib/catalog/theme-reference.ts
@@ -1,0 +1,390 @@
+/**
+ * Theme API reference tables for /reference/themes.
+ *
+ * Role keys match ThemeSpec / NamedThemeLayerProps (factory.svelte.ts).
+ * CSS custom properties match themeVar() (`--gg-*`) and interaction chrome
+ * tokens from themeTokensToCss() (`--gg-theme-*`).
+ */
+import { THEME_NAME_ALIASES, THEME_NAMES, type ThemeName } from "@ggsvelte/spec";
+
+export type ThemeRoleKind = "color" | "opacity" | "type" | "length" | "boolean" | "dash";
+
+export interface ThemeRoleRef {
+  readonly name: string;
+  readonly kind: ThemeRoleKind;
+  /** What this role paints or controls in the chart. */
+  readonly affects: string;
+  /**
+   * CSS custom property(s) hosts may set on the plot root (or an ancestor).
+   * Chart paint uses `--gg-{role}`; interaction chrome also publishes
+   * `--gg-theme-{role}` for a subset of roles.
+   */
+  readonly css: string;
+}
+
+/** Color + interaction roles that feed marks, paper, axes, and recovery chrome. */
+export const THEME_COLOR_ROLES = [
+  {
+    name: "ink",
+    kind: "color",
+    affects: "Axis lines, tick labels, titles, unmapped line/point/text marks, legend labels.",
+    css: "--gg-ink",
+  },
+  {
+    name: "paper",
+    kind: "color",
+    affects: 'Plot-wide background. Use "none" for transparent.',
+    css: "--gg-paper",
+  },
+  {
+    name: "accent",
+    kind: "color",
+    affects: "Default fill for unmapped bars, columns, and areas.",
+    css: "--gg-accent",
+  },
+  {
+    name: "grid",
+    kind: "color",
+    affects: "Panel major grid lines.",
+    css: "--gg-grid",
+  },
+  {
+    name: "panel",
+    kind: "color",
+    affects: "Panel background (separate from paper).",
+    css: "--gg-panel",
+  },
+  {
+    name: "letterboxFill",
+    kind: "color",
+    affects: "Fixed-aspect gutter fill. Defaults to paper when unset.",
+    css: "--gg-letterboxFill",
+  },
+  {
+    name: "axisText",
+    kind: "color",
+    affects: "Axis tick-label color.",
+    css: "--gg-axisText",
+  },
+  {
+    name: "axisLine",
+    kind: "color",
+    affects: "Axis baseline color.",
+    css: "--gg-axisLine",
+  },
+  {
+    name: "tickColor",
+    kind: "color",
+    affects: "Axis tick-mark color.",
+    css: "--gg-tickColor",
+  },
+  {
+    name: "panelBorder",
+    kind: "color",
+    affects: "Panel frame color when showPanelBorder is true.",
+    css: "--gg-panelBorder",
+  },
+  {
+    name: "interactionInk",
+    kind: "color",
+    affects: "Primary interaction-control and overlay ink (tool rail, clear, overlays).",
+    css: "--gg-interactionInk / --gg-theme-interactionInk",
+  },
+  {
+    name: "interactionMuted",
+    kind: "opacity",
+    affects:
+      "Opacity for marks de-emphasized by legend focus or selection (0–1 number, not a color).",
+    css: "--gg-interactionMuted / --gg-theme-interactionMuted (numeric alpha)",
+  },
+  {
+    name: "focusRing",
+    kind: "color",
+    affects: "Keyboard-focus and active-mark halo.",
+    css: "--gg-focusRing / --gg-theme-focusRing",
+  },
+  {
+    name: "crosshair",
+    kind: "color",
+    affects: "Crosshair guide color.",
+    css: "--gg-crosshair / --gg-theme-crosshair",
+  },
+  {
+    name: "selectionFill",
+    kind: "color",
+    affects: "Interval-selection fill (normally translucent).",
+    css: "--gg-selectionFill / --gg-theme-selectionFill",
+  },
+  {
+    name: "selectionStroke",
+    kind: "color",
+    affects: "Interval-selection and zoom-target stroke.",
+    css: "--gg-selectionStroke / --gg-theme-selectionStroke",
+  },
+  {
+    name: "tooltipPaper",
+    kind: "color",
+    affects: "Opaque tooltip surface.",
+    css: "--gg-tooltipPaper / --gg-theme-tooltipPaper",
+  },
+  {
+    name: "tooltipInk",
+    kind: "color",
+    affects: "Tooltip foreground text.",
+    css: "--gg-tooltipInk / --gg-theme-tooltipInk",
+  },
+  {
+    name: "tooltipBorder",
+    kind: "color",
+    affects: "Tooltip keyline.",
+    css: "--gg-tooltipBorder / --gg-theme-tooltipBorder",
+  },
+  {
+    name: "toolActive",
+    kind: "color",
+    affects: "Active tool text and underline on the tool rail.",
+    css: "--gg-toolActive / --gg-theme-toolActive",
+  },
+] as const satisfies readonly ThemeRoleRef[];
+
+/** Typography, spacing, and chrome geometry roles (numbers unless noted). */
+export const THEME_TYPE_AND_GEOMETRY_ROLES = [
+  {
+    name: "fontFamily",
+    kind: "type",
+    affects: "Chart typeface stack.",
+    css: "via resolved tokens (SVG font-family attribute)",
+  },
+  {
+    name: "fontSize",
+    kind: "length",
+    affects: "Base and tick-label size in px.",
+    css: "resolved tokens",
+  },
+  {
+    name: "axisTextSize",
+    kind: "length",
+    affects: "Axis tick-label size in px.",
+    css: "resolved tokens",
+  },
+  {
+    name: "fontWeight",
+    kind: "length",
+    affects: "Base font weight (1–1000).",
+    css: "resolved tokens",
+  },
+  {
+    name: "titleSize",
+    kind: "length",
+    affects: "Plot title size in px.",
+    css: "resolved tokens",
+  },
+  {
+    name: "titleWeight",
+    kind: "length",
+    affects: "Plot title weight.",
+    css: "resolved tokens",
+  },
+  {
+    name: "subtitleSize",
+    kind: "length",
+    affects: "Plot subtitle size in px.",
+    css: "resolved tokens",
+  },
+  {
+    name: "subtitleWeight",
+    kind: "length",
+    affects: "Plot subtitle weight.",
+    css: "resolved tokens",
+  },
+  {
+    name: "axisTitleSize",
+    kind: "length",
+    affects: "Axis title size in px.",
+    css: "resolved tokens",
+  },
+  {
+    name: "axisTitleWeight",
+    kind: "length",
+    affects: "Axis title weight.",
+    css: "resolved tokens",
+  },
+  {
+    name: "guideTitleSize",
+    kind: "length",
+    affects: "Legend / guide title size in px.",
+    css: "resolved tokens",
+  },
+  {
+    name: "legendKeySize",
+    kind: "length",
+    affects: "Legend swatch size in px.",
+    css: "resolved tokens",
+  },
+  {
+    name: "legendKeyGap",
+    kind: "length",
+    affects: "Gap between legend swatch and label.",
+    css: "resolved tokens",
+  },
+  {
+    name: "legendRowGap",
+    kind: "length",
+    affects: "Vertical gap between legend rows.",
+    css: "resolved tokens",
+  },
+  {
+    name: "guideBlockGap",
+    kind: "length",
+    affects: "Gap between stacked guide blocks.",
+    css: "resolved tokens",
+  },
+  {
+    name: "colorbarThickness",
+    kind: "length",
+    affects: "Continuous colorbar thickness in px.",
+    css: "resolved tokens",
+  },
+  {
+    name: "colorbarLengthMin",
+    kind: "length",
+    affects: "Minimum colorbar length in px.",
+    css: "resolved tokens",
+  },
+  {
+    name: "captionSize",
+    kind: "length",
+    affects: "Caption text size in px.",
+    css: "resolved tokens",
+  },
+  {
+    name: "stripSize",
+    kind: "length",
+    affects: "Facet strip label size in px.",
+    css: "resolved tokens",
+  },
+  {
+    name: "stripWeight",
+    kind: "length",
+    affects: "Facet strip label weight.",
+    css: "resolved tokens",
+  },
+  {
+    name: "axisLineWidth",
+    kind: "length",
+    affects: "Axis baseline stroke width.",
+    css: "resolved tokens",
+  },
+  {
+    name: "tickWidth",
+    kind: "length",
+    affects: "Tick-mark stroke width.",
+    css: "resolved tokens",
+  },
+  {
+    name: "tickLength",
+    kind: "length",
+    affects: "Tick-mark length in px.",
+    css: "resolved tokens",
+  },
+  {
+    name: "gridWidth",
+    kind: "length",
+    affects: "Grid-line stroke width.",
+    css: "resolved tokens",
+  },
+  {
+    name: "panelBorderWidth",
+    kind: "length",
+    affects: "Panel border stroke width.",
+    css: "resolved tokens",
+  },
+  {
+    name: "gridDasharray",
+    kind: "dash",
+    affects: "SVG stroke-dasharray for major grid lines.",
+    css: "resolved tokens",
+  },
+  {
+    name: "axisLineX",
+    kind: "boolean",
+    affects: "Draw the x-axis baseline.",
+    css: "resolved tokens",
+  },
+  {
+    name: "axisLineY",
+    kind: "boolean",
+    affects: "Draw the y-axis baseline.",
+    css: "resolved tokens",
+  },
+  {
+    name: "ticksX",
+    kind: "boolean",
+    affects: "Draw x-axis ticks.",
+    css: "resolved tokens",
+  },
+  {
+    name: "ticksY",
+    kind: "boolean",
+    affects: "Draw y-axis ticks.",
+    css: "resolved tokens",
+  },
+  {
+    name: "labelsX",
+    kind: "boolean",
+    affects: "Show x-axis tick labels (false for theme_void-style blanking).",
+    css: "resolved tokens",
+  },
+  {
+    name: "labelsY",
+    kind: "boolean",
+    affects: "Show y-axis tick labels.",
+    css: "resolved tokens",
+  },
+  {
+    name: "gridX",
+    kind: "boolean",
+    affects: "Draw vertical grid lines.",
+    css: "resolved tokens",
+  },
+  {
+    name: "gridY",
+    kind: "boolean",
+    affects: "Draw horizontal grid lines.",
+    css: "resolved tokens",
+  },
+  {
+    name: "showPanelBorder",
+    kind: "boolean",
+    affects: "Draw the panel frame.",
+    css: "resolved tokens",
+  },
+] as const satisfies readonly ThemeRoleRef[];
+
+export const ALL_THEME_ROLES = [
+  ...THEME_COLOR_ROLES,
+  ...THEME_TYPE_AND_GEOMETRY_ROLES,
+] as const satisfies readonly ThemeRoleRef[];
+
+/** PortableSpec theme name → Svelte shell component (ThemeDefault, …). */
+export function themeComponentName(name: ThemeName): string {
+  const body = name.replaceAll("_", "");
+  return `Theme${body.charAt(0).toUpperCase()}${body.slice(1)}`;
+}
+
+export interface ThemeShellRef {
+  readonly name: ThemeName;
+  readonly component: string;
+  /** When set, this name shares tokens with the canonical theme. */
+  readonly aliasOf?: ThemeName;
+}
+
+/** Every registered theme shell, including grey/gray aliases of ggplot2. */
+export const THEME_SHELLS: readonly ThemeShellRef[] = THEME_NAMES.map((name) => {
+  const aliasOf = (THEME_NAME_ALIASES as Partial<Record<ThemeName, ThemeName>>)[name];
+  return {
+    name,
+    component: themeComponentName(name),
+    ...(aliasOf !== undefined && { aliasOf }),
+  };
+});

--- a/apps/docs/src/lib/generated/routes.ts
+++ b/apps/docs/src/lib/generated/routes.ts
@@ -4858,7 +4858,7 @@ export const DOCS_ROUTES = [
     navigation: {
       section: "Reference",
       label: "Errors reference",
-      order: 56,
+      order: 59,
     },
     headings: [
       {
@@ -5915,7 +5915,7 @@ export const DOCS_ROUTES = [
     navigation: {
       section: "Reference",
       label: "Advisories",
-      order: 57,
+      order: 60,
     },
     headings: [
       {
@@ -6037,7 +6037,7 @@ export const DOCS_ROUTES = [
     navigation: {
       section: "Reference",
       label: "Lifecycle & editions",
-      order: 58,
+      order: 61,
     },
     headings: [
       {
@@ -7441,20 +7441,20 @@ export const GUIDE_NAVIGATION = [
         label: "Themes",
       },
       {
-        path: "/guide/errors",
-        label: "Errors reference",
-      },
-      {
         path: "/reference/palettes",
         label: "Palettes",
       },
       {
-        path: "/guide/advisories",
-        label: "Advisories",
-      },
-      {
         path: "/reference/cli",
         label: "CLI reference",
+      },
+      {
+        path: "/guide/errors",
+        label: "Errors reference",
+      },
+      {
+        path: "/guide/advisories",
+        label: "Advisories",
       },
       {
         path: "/guide/lifecycle",

--- a/apps/docs/src/lib/generated/routes.ts
+++ b/apps/docs/src/lib/generated/routes.ts
@@ -219,6 +219,107 @@ export const DOCS_ROUTES = [
     },
   },
   {
+    path: "/reference/themes",
+    title: "Themes — ggsvelte",
+    description:
+      "Theme components, role tokens, CSS variables, and safe overrides for paper, ink, and interaction chrome.",
+    canonicalPath: "/reference/themes",
+    kind: "page",
+    index: true,
+    sitemap: true,
+    shell: "docs",
+    navigation: {
+      section: "Reference",
+      label: "Themes",
+      order: 56,
+    },
+    headings: [
+      {
+        id: "components",
+        title: "Components",
+        level: 2,
+      },
+      {
+        id: "usage",
+        title: "Usage",
+        level: 2,
+      },
+      {
+        id: "color-and-interaction-roles",
+        title: "Color and interaction roles",
+        level: 2,
+      },
+      {
+        id: "type-and-geometry-roles",
+        title: "Type and geometry roles",
+        level: 2,
+      },
+      {
+        id: "safe-overrides",
+        title: "Safe overrides",
+        level: 2,
+      },
+      {
+        id: "see-also",
+        title: "See also",
+        level: 2,
+      },
+    ],
+  },
+  {
+    path: "/reference/palettes",
+    title: "Palettes — ggsvelte",
+    description:
+      "Named color schemes as scale inputs: categorical and sequential scheme catalogs mapped to ScaleColor* / ScaleFill* helpers.",
+    canonicalPath: "/reference/palettes",
+    kind: "page",
+    index: true,
+    sitemap: true,
+    shell: "docs",
+    navigation: {
+      section: "Reference",
+      label: "Palettes",
+      order: 57,
+    },
+    headings: [
+      {
+        id: "using-schemes",
+        title: "Using schemes",
+        level: 2,
+      },
+      {
+        id: "helper-map",
+        title: "Scale helpers",
+        level: 2,
+      },
+      {
+        id: "discrete",
+        title: "Discrete (categorical schemes)",
+        level: 3,
+      },
+      {
+        id: "continuous",
+        title: "Continuous and binned (sequential schemes)",
+        level: 3,
+      },
+      {
+        id: "categorical-schemes",
+        title: "Categorical schemes",
+        level: 2,
+      },
+      {
+        id: "sequential-schemes",
+        title: "Sequential schemes",
+        level: 2,
+      },
+      {
+        id: "see-also",
+        title: "See also",
+        level: 2,
+      },
+    ],
+  },
+  {
     path: "/reference/cli",
     title: "Command-line reference — ggsvelte",
     description:
@@ -231,7 +332,7 @@ export const DOCS_ROUTES = [
     navigation: {
       section: "Reference",
       label: "CLI reference",
-      order: 56,
+      order: 58,
     },
     headings: [
       {
@@ -7336,16 +7437,24 @@ export const GUIDE_NAVIGATION = [
         label: "Interaction reference",
       },
       {
-        path: "/reference/cli",
-        label: "CLI reference",
+        path: "/reference/themes",
+        label: "Themes",
       },
       {
         path: "/guide/errors",
         label: "Errors reference",
       },
       {
+        path: "/reference/palettes",
+        label: "Palettes",
+      },
+      {
         path: "/guide/advisories",
         label: "Advisories",
+      },
+      {
+        path: "/reference/cli",
+        label: "CLI reference",
       },
       {
         path: "/guide/lifecycle",

--- a/apps/docs/src/lib/generated/search-index.ts
+++ b/apps/docs/src/lib/generated/search-index.ts
@@ -207,6 +207,156 @@ export const DOCS_SEARCH_INDEX = [
     exact: ["Search interactions"],
   },
   {
+    id: "page:reference-themes",
+    kind: "page",
+    title: "Themes",
+    summary:
+      "Theme components, role tokens, CSS variables, and safe overrides for paper, ink, and interaction chrome.",
+    href: "/reference/themes",
+    keywords: ["Reference"],
+    exact: ["Themes"],
+  },
+  {
+    id: "heading:reference-themes:components",
+    kind: "heading",
+    title: "Components",
+    summary:
+      "Components in Themes. Theme components, role tokens, CSS variables, and safe overrides for paper, ink, and interaction chrome.",
+    href: "/reference/themes#components",
+    keywords: ["Themes", "Reference"],
+    exact: ["Components"],
+  },
+  {
+    id: "heading:reference-themes:usage",
+    kind: "heading",
+    title: "Usage",
+    summary:
+      "Usage in Themes. Theme components, role tokens, CSS variables, and safe overrides for paper, ink, and interaction chrome.",
+    href: "/reference/themes#usage",
+    keywords: ["Themes", "Reference"],
+    exact: ["Usage"],
+  },
+  {
+    id: "heading:reference-themes:color-and-interaction-roles",
+    kind: "heading",
+    title: "Color and interaction roles",
+    summary:
+      "Color and interaction roles in Themes. Theme components, role tokens, CSS variables, and safe overrides for paper, ink, and interaction chrome.",
+    href: "/reference/themes#color-and-interaction-roles",
+    keywords: ["Themes", "Reference"],
+    exact: ["Color and interaction roles"],
+  },
+  {
+    id: "heading:reference-themes:type-and-geometry-roles",
+    kind: "heading",
+    title: "Type and geometry roles",
+    summary:
+      "Type and geometry roles in Themes. Theme components, role tokens, CSS variables, and safe overrides for paper, ink, and interaction chrome.",
+    href: "/reference/themes#type-and-geometry-roles",
+    keywords: ["Themes", "Reference"],
+    exact: ["Type and geometry roles"],
+  },
+  {
+    id: "heading:reference-themes:safe-overrides",
+    kind: "heading",
+    title: "Safe overrides",
+    summary:
+      "Safe overrides in Themes. Theme components, role tokens, CSS variables, and safe overrides for paper, ink, and interaction chrome.",
+    href: "/reference/themes#safe-overrides",
+    keywords: ["Themes", "Reference"],
+    exact: ["Safe overrides"],
+  },
+  {
+    id: "heading:reference-themes:see-also",
+    kind: "heading",
+    title: "See also",
+    summary:
+      "See also in Themes. Theme components, role tokens, CSS variables, and safe overrides for paper, ink, and interaction chrome.",
+    href: "/reference/themes#see-also",
+    keywords: ["Themes", "Reference"],
+    exact: ["See also"],
+  },
+  {
+    id: "page:reference-palettes",
+    kind: "page",
+    title: "Palettes",
+    summary:
+      "Named color schemes as scale inputs: categorical and sequential scheme catalogs mapped to ScaleColor* / ScaleFill* helpers.",
+    href: "/reference/palettes",
+    keywords: ["Reference"],
+    exact: ["Palettes"],
+  },
+  {
+    id: "heading:reference-palettes:using-schemes",
+    kind: "heading",
+    title: "Using schemes",
+    summary:
+      "Using schemes in Palettes. Named color schemes as scale inputs: categorical and sequential scheme catalogs mapped to ScaleColor* / ScaleFill* helpers.",
+    href: "/reference/palettes#using-schemes",
+    keywords: ["Palettes", "Reference"],
+    exact: ["Using schemes"],
+  },
+  {
+    id: "heading:reference-palettes:helper-map",
+    kind: "heading",
+    title: "Scale helpers",
+    summary:
+      "Scale helpers in Palettes. Named color schemes as scale inputs: categorical and sequential scheme catalogs mapped to ScaleColor* / ScaleFill* helpers.",
+    href: "/reference/palettes#helper-map",
+    keywords: ["Palettes", "Reference"],
+    exact: ["Scale helpers"],
+  },
+  {
+    id: "heading:reference-palettes:discrete",
+    kind: "heading",
+    title: "Discrete (categorical schemes)",
+    summary:
+      "Discrete (categorical schemes) in Palettes. Named color schemes as scale inputs: categorical and sequential scheme catalogs mapped to ScaleColor* / ScaleFill* helpers.",
+    href: "/reference/palettes#discrete",
+    keywords: ["Palettes", "Reference"],
+    exact: ["Discrete (categorical schemes)"],
+  },
+  {
+    id: "heading:reference-palettes:continuous",
+    kind: "heading",
+    title: "Continuous and binned (sequential schemes)",
+    summary:
+      "Continuous and binned (sequential schemes) in Palettes. Named color schemes as scale inputs: categorical and sequential scheme catalogs mapped to ScaleColor* / ScaleFill* helpers.",
+    href: "/reference/palettes#continuous",
+    keywords: ["Palettes", "Reference"],
+    exact: ["Continuous and binned (sequential schemes)"],
+  },
+  {
+    id: "heading:reference-palettes:categorical-schemes",
+    kind: "heading",
+    title: "Categorical schemes",
+    summary:
+      "Categorical schemes in Palettes. Named color schemes as scale inputs: categorical and sequential scheme catalogs mapped to ScaleColor* / ScaleFill* helpers.",
+    href: "/reference/palettes#categorical-schemes",
+    keywords: ["Palettes", "Reference"],
+    exact: ["Categorical schemes"],
+  },
+  {
+    id: "heading:reference-palettes:sequential-schemes",
+    kind: "heading",
+    title: "Sequential schemes",
+    summary:
+      "Sequential schemes in Palettes. Named color schemes as scale inputs: categorical and sequential scheme catalogs mapped to ScaleColor* / ScaleFill* helpers.",
+    href: "/reference/palettes#sequential-schemes",
+    keywords: ["Palettes", "Reference"],
+    exact: ["Sequential schemes"],
+  },
+  {
+    id: "heading:reference-palettes:see-also",
+    kind: "heading",
+    title: "See also",
+    summary:
+      "See also in Palettes. Named color schemes as scale inputs: categorical and sequential scheme catalogs mapped to ScaleColor* / ScaleFill* helpers.",
+    href: "/reference/palettes#see-also",
+    keywords: ["Palettes", "Reference"],
+    exact: ["See also"],
+  },
+  {
     id: "page:reference-cli",
     kind: "page",
     title: "Command-line reference",

--- a/apps/docs/src/routes/docs/+page.svelte
+++ b/apps/docs/src/routes/docs/+page.svelte
@@ -37,6 +37,14 @@
       "/reference/interactions",
       "Search interaction props, callbacks, event phases, and diagnostic codes.",
     ],
+    [
+      "/reference/themes",
+      "Theme components, role tokens, and safe chrome overrides.",
+    ],
+    [
+      "/reference/palettes",
+      "Named color schemes mapped to ScaleColor* / ScaleFill* helpers.",
+    ],
   ]);
 
   // Overview is this page — do not list it again under the chapter map.

--- a/apps/docs/src/routes/palettes/+page.svelte
+++ b/apps/docs/src/routes/palettes/+page.svelte
@@ -19,7 +19,9 @@
       <a href={`${base}/themes`}>Themes</a>.
     </p>
     <p class="guide-link">
-      Scale and color channel reference:
+      Scheme names as scale inputs:
+      <a href={`${base}/reference/palettes`}>Palettes reference</a>. Scale and
+      color channels:
       <a href={`${base}/guide/scales-guides`}>Scales and guides</a>.
     </p>
   </header>
@@ -30,6 +32,10 @@
   <nav class="learning-path" aria-label="Next steps">
     <p class="eyebrow">Next</p>
     <ul>
+      <li>
+        <a href={`${base}/reference/palettes`}>Palettes reference</a>
+        — scheme → ScaleColor* / ScaleFill* mapping
+      </li>
       <li>
         <a href={`${base}/themes`}>Themes</a>
         — paper, grids, axes, and type

--- a/apps/docs/src/routes/reference/+page.svelte
+++ b/apps/docs/src/routes/reference/+page.svelte
@@ -43,6 +43,18 @@
       <strong>Interaction reference</strong>
       <span>Capabilities, events, diagnostics, accessibility defaults.</span>
     </a>
+    <a href={`${base}/reference/themes`}>
+      <strong>Themes</strong>
+      <span
+        >Theme* components, role tokens, CSS variables, and interaction chrome.</span
+      >
+    </a>
+    <a href={`${base}/reference/palettes`}>
+      <strong>Palettes</strong>
+      <span
+        >Named schemes as scale inputs: categorical and sequential catalogs.</span
+      >
+    </a>
     <a href={`${base}/reference/cli`}>
       <strong>CLI reference</strong>
       <span>Flags, streams, diagnostics, exit classes.</span>

--- a/apps/docs/src/routes/reference/palettes/+page.svelte
+++ b/apps/docs/src/routes/reference/palettes/+page.svelte
@@ -8,27 +8,32 @@
   } from "$lib/catalog/palette-reference";
   import CopyCode from "$lib/components/CopyCode.svelte";
 
-  const discreteExample = `<script lang="ts">
-  import {
-    GeomPoint,
-    GGPlot,
-    ScaleColorDiscrete,
-  } from "@ggsvelte/svelte";
+  // Join so the example's closing script tag does not terminate this module.
+  const discreteExample = [
+    '<script lang="ts">',
+    "  import {",
+    "    GeomPoint,",
+    "    GGPlot,",
+    "    ScaleColorDiscrete,",
+    '  } from "@ggsvelte/svelte";',
+    "",
+    "  const rows = [",
+    '    { x: 1, y: 2, species: "a" },',
+    '    { x: 2, y: 4, species: "b" },',
+    "  ];",
+    ["</", "script>"].join(""),
+    "",
+    '<GGPlot data={rows} aes={{ x: "x", y: "y", color: "species" }}>',
+    '  <ScaleColorDiscrete scheme="tableau10" />',
+    "  <GeomPoint />",
+    "</GGPlot>",
+  ].join("\n");
 
-  const rows = [
-    { x: 1, y: 2, species: "a" },
-    { x: 2, y: 4, species: "b" },
-  ];
-<\/script>
-
-<GGPlot data={rows} aes={{ x: "x", y: "y", color: "species" }}>
-  <ScaleColorDiscrete scheme="tableau10" />
-  <GeomPoint />
-</GGPlot>`;
-
-  const sequentialExample = `<ScaleColorContinuous scheme="viridis" />
-<!-- or family shell: -->
-<ScaleColorViridisC option="magma" />`;
+  const sequentialExample = [
+    `<ScaleColorContinuous scheme="viridis" />`,
+    `<!-- or family shell: -->`,
+    `<ScaleColorViridisC option="magma" />`,
+  ].join("\n");
 </script>
 
 <article class="palette-reference prose" aria-labelledby="palette-ref-heading">

--- a/apps/docs/src/routes/reference/palettes/+page.svelte
+++ b/apps/docs/src/routes/reference/palettes/+page.svelte
@@ -1,0 +1,238 @@
+<script lang="ts">
+  import { base } from "$app/paths";
+
+  import {
+    CATEGORICAL_SCHEME_REFS,
+    PALETTE_HELPER_GROUPS,
+    SEQUENTIAL_SCHEME_REFS,
+  } from "$lib/catalog/palette-reference";
+  import CopyCode from "$lib/components/CopyCode.svelte";
+
+  const discreteExample = `<script lang="ts">
+  import {
+    GeomPoint,
+    GGPlot,
+    ScaleColorDiscrete,
+  } from "@ggsvelte/svelte";
+
+  const rows = [
+    { x: 1, y: 2, species: "a" },
+    { x: 2, y: 4, species: "b" },
+  ];
+<\/script>
+
+<GGPlot data={rows} aes={{ x: "x", y: "y", color: "species" }}>
+  <ScaleColorDiscrete scheme="tableau10" />
+  <GeomPoint />
+</GGPlot>`;
+
+  const sequentialExample = `<ScaleColorContinuous scheme="viridis" />
+<!-- or family shell: -->
+<ScaleColorViridisC option="magma" />`;
+</script>
+
+<article class="palette-reference prose" aria-labelledby="palette-ref-heading">
+  <h1 id="palette-ref-heading">Palettes</h1>
+  <p>
+    Named color schemes are <strong>scale inputs</strong>, not themes. Pass a
+    scheme name into a color or fill scale child to encode data series. Chart
+    paper and axes stay on
+    <a href={`${base}/reference/themes`}>themes</a>.
+  </p>
+  <p>
+    Swatches and ramps for every scheme live on the
+    <a href={`${base}/palettes`}>Palettes showcase</a>.
+  </p>
+
+  <h2 id="using-schemes">Using schemes</h2>
+  <p>
+    Categorical names pair with discrete / ordinal scales. Sequential names pair
+    with continuous, binned, or discrete-sampled viridis shells. A scheme from
+    the wrong family is a validation error (<code>scale-scheme-type</code>).
+  </p>
+  <CopyCode
+    language="svelte"
+    accessibleLabel="Copy discrete palette example"
+    code={discreteExample}
+  />
+  <CopyCode
+    language="svelte"
+    accessibleLabel="Copy sequential palette example"
+    code={sequentialExample}
+  />
+
+  <h2 id="helper-map">Scale helpers</h2>
+  {#each PALETTE_HELPER_GROUPS as group (group.id)}
+    <h3 id={group.id}>{group.title}</h3>
+    <p>{group.summary}</p>
+    <ul class="shell-list">
+      {#each group.shells as shell (shell)}
+        <li><code>&lt;{shell} /&gt;</code></li>
+      {/each}
+    </ul>
+  {/each}
+  <p>
+    British <code>Colour</code> aliases export the same components (<code
+      >ScaleColourDiscrete</code
+    >, …). Snake_case builder helpers (<code>scale_color_discrete</code>) accept
+    the same options.
+  </p>
+
+  <h2 id="categorical-schemes">Categorical schemes</h2>
+  <p>
+    Use with <code>ScaleColorDiscrete</code>, <code>ScaleFillDiscrete</code>,
+    ordinal shells, or family-specific helpers. Default when unset:
+    <code>observable10</code>.
+  </p>
+  <div class="table-wrap">
+    <table>
+      <thead>
+        <tr>
+          <th scope="col">scheme</th>
+          <th scope="col">Primary helpers</th>
+          <th scope="col">Notes</th>
+        </tr>
+      </thead>
+      <tbody>
+        {#each CATEGORICAL_SCHEME_REFS as entry (entry.name)}
+          <tr>
+            <td><code>{entry.name}</code></td>
+            <td>
+              {#each entry.helpers.slice(0, 4) as helper, i (helper)}
+                {#if i > 0},
+                {/if}<code>{helper}</code>
+              {/each}
+              {#if entry.helpers.length > 4}
+                <span class="more">+{entry.helpers.length - 4}</span>
+              {/if}
+            </td>
+            <td>{entry.notes ?? "—"}</td>
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+  </div>
+
+  <h2 id="sequential-schemes">Sequential schemes</h2>
+  <p>
+    Use with continuous / binned color scales, viridis family shells,
+    ColorBrewer distiller/fermenter, or discrete sampling of a viridis ramp (<code
+      >ScaleColorViridisD</code
+    >).
+  </p>
+  <div class="table-wrap">
+    <table>
+      <thead>
+        <tr>
+          <th scope="col">scheme</th>
+          <th scope="col">Primary helpers</th>
+          <th scope="col">Notes</th>
+        </tr>
+      </thead>
+      <tbody>
+        {#each SEQUENTIAL_SCHEME_REFS as entry (entry.name)}
+          <tr>
+            <td><code>{entry.name}</code></td>
+            <td>
+              {#each entry.helpers.slice(0, 4) as helper, i (helper)}
+                {#if i > 0},
+                {/if}<code>{helper}</code>
+              {/each}
+              {#if entry.helpers.length > 4}
+                <span class="more">+{entry.helpers.length - 4}</span>
+              {/if}
+            </td>
+            <td>{entry.notes ?? "—"}</td>
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+  </div>
+
+  <h2 id="see-also">See also</h2>
+  <ul>
+    <li>
+      <a href={`${base}/palettes`}>Palettes showcase</a> — swatches and sequential
+      lab
+    </li>
+    <li>
+      <a href={`${base}/reference/themes`}>Themes reference</a> — paper, ink, and
+      interaction chrome
+    </li>
+    <li>
+      <a href={`${base}/guide/scales-guides`}>Scales and guides</a> — channels, exhaustion,
+      and guide presentation
+    </li>
+    <li>
+      <a href={`${base}/guide/errors#palette-exhausted`}>palette-exhausted</a> — when
+      a discrete domain outruns the finite palette
+    </li>
+  </ul>
+</article>
+
+<style>
+  .palette-reference {
+    max-width: 52rem;
+    margin: 2rem 0 4rem;
+  }
+
+  .shell-list {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.35rem 1rem;
+    margin: 0.75rem 0 1.5rem;
+    padding: 0;
+    list-style: none;
+  }
+
+  .shell-list li {
+    margin: 0;
+  }
+
+  .table-wrap {
+    overflow-x: auto;
+    margin: 1.25rem 0 1.75rem;
+  }
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.92rem;
+  }
+
+  th,
+  td {
+    text-align: left;
+    vertical-align: top;
+    padding: 0.55rem 0.65rem 0.55rem 0;
+    border-top: 1px solid var(--line);
+  }
+
+  thead th {
+    border-top: none;
+    color: var(--muted);
+    font-size: 0.78rem;
+    font-weight: 650;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  tbody tr:last-child td {
+    border-bottom: 1px solid var(--line);
+  }
+
+  td code {
+    white-space: nowrap;
+  }
+
+  .more {
+    color: var(--muted);
+    margin-left: 0.25rem;
+  }
+
+  @media (max-width: 40rem) {
+    .shell-list {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/apps/docs/src/routes/reference/themes/+page.svelte
+++ b/apps/docs/src/routes/reference/themes/+page.svelte
@@ -8,19 +8,22 @@
   } from "$lib/catalog/theme-reference";
   import CopyCode from "$lib/components/CopyCode.svelte";
 
-  const namedExample = `<script lang="ts">
-  import { GeomPoint, GGPlot, ThemeDark } from "@ggsvelte/svelte";
-
-  const rows = [
-    { x: 1, y: 2 },
-    { x: 2, y: 4 },
-  ];
-<\/script>
-
-<GGPlot data={rows} aes={{ x: "x", y: "y" }}>
-  <ThemeDark ink="#f5f5f5" tooltipPaper="#1a1a1a" tooltipInk="#f5f5f5" />
-  <GeomPoint />
-</GGPlot>`;
+  // Join so the example's closing script tag does not terminate this module.
+  const namedExample = [
+    '<script lang="ts">',
+    '  import { GeomPoint, GGPlot, ThemeDark } from "@ggsvelte/svelte";',
+    "",
+    "  const rows = [",
+    "    { x: 1, y: 2 },",
+    "    { x: 2, y: 4 },",
+    "  ];",
+    ["</", "script>"].join(""),
+    "",
+    '<GGPlot data={rows} aes={{ x: "x", y: "y" }}>',
+    '  <ThemeDark ink="#f5f5f5" tooltipPaper="#1a1a1a" tooltipInk="#f5f5f5" />',
+    "  <GeomPoint />",
+    "</GGPlot>",
+  ].join("\n");
 
   const genericExample = `<Theme name={activeTheme} paper="none" focusRing="#ffcc00" />`;
 </script>

--- a/apps/docs/src/routes/reference/themes/+page.svelte
+++ b/apps/docs/src/routes/reference/themes/+page.svelte
@@ -1,0 +1,252 @@
+<script lang="ts">
+  import { base } from "$app/paths";
+
+  import {
+    THEME_COLOR_ROLES,
+    THEME_SHELLS,
+    THEME_TYPE_AND_GEOMETRY_ROLES,
+  } from "$lib/catalog/theme-reference";
+  import CopyCode from "$lib/components/CopyCode.svelte";
+
+  const namedExample = `<script lang="ts">
+  import { GeomPoint, GGPlot, ThemeDark } from "@ggsvelte/svelte";
+
+  const rows = [
+    { x: 1, y: 2 },
+    { x: 2, y: 4 },
+  ];
+<\/script>
+
+<GGPlot data={rows} aes={{ x: "x", y: "y" }}>
+  <ThemeDark ink="#f5f5f5" tooltipPaper="#1a1a1a" tooltipInk="#f5f5f5" />
+  <GeomPoint />
+</GGPlot>`;
+
+  const genericExample = `<Theme name={activeTheme} paper="none" focusRing="#ffcc00" />`;
+</script>
+
+<article class="theme-reference prose" aria-labelledby="theme-ref-heading">
+  <h1 id="theme-ref-heading">Themes</h1>
+  <p>
+    Chart themes style paper, ink, axes, type, and interaction chrome. Compose a
+    declaration-only child under <code>&lt;GGPlot&gt;</code> — a named shell
+    such as
+    <code>&lt;ThemeMinimal /&gt;</code>, or the generic
+    <code>&lt;Theme name=&#123;…&#125; /&gt;</code> escape hatch. Themes do not
+    encode data colors; those come from
+    <a href={`${base}/reference/palettes`}>palette schemes on color scales</a>.
+  </p>
+  <p>
+    Visual portraits of every built-in live on the
+    <a href={`${base}/themes`}>Themes showcase</a>.
+  </p>
+
+  <h2 id="components">Components</h2>
+  <p>
+    Named shells fix the base theme. Every shell accepts the same optional role
+    overrides as props (<code>ink</code>, <code>paper</code>,
+    <code>tooltipPaper</code>, …). The generic <code>&lt;Theme&gt;</code> also
+    accepts <code>name</code> for a reactive base.
+  </p>
+  <div class="table-wrap">
+    <table>
+      <thead>
+        <tr>
+          <th scope="col">PortableSpec name</th>
+          <th scope="col">Svelte component</th>
+          <th scope="col">Notes</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>(dynamic)</code></td>
+          <td><code>Theme</code></td>
+          <td>Escape hatch: <code>name</code> + role overrides.</td>
+        </tr>
+        {#each THEME_SHELLS as shell (shell.name)}
+          <tr>
+            <td><code>{shell.name}</code></td>
+            <td><code>{shell.component}</code></td>
+            <td>
+              {#if shell.aliasOf !== undefined}
+                Alias of <code>{shell.aliasOf}</code> (same token map).
+              {:else}
+                Named base.
+              {/if}
+            </td>
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+  </div>
+
+  <h2 id="usage">Usage</h2>
+  <p>
+    One theme child per plot. Composition is <strong>replace</strong>: if you
+    declare two theme children, the last one wins. Role overrides merge onto the
+    named base — unset roles keep the built-in values.
+  </p>
+  <CopyCode
+    language="svelte"
+    accessibleLabel="Copy theme override example"
+    code={namedExample}
+  />
+  <p>Reactive base name:</p>
+  <CopyCode
+    language="svelte"
+    accessibleLabel="Copy generic Theme example"
+    code={genericExample}
+  />
+
+  <h2 id="color-and-interaction-roles">Color and interaction roles</h2>
+  <p>
+    These props are CSS colors (or, for <code>interactionMuted</code>, a 0–1
+    opacity). Color roles ride <code>--gg-*</code> custom properties so a host
+    can restyle without re-authoring the plot. Interaction roles also publish
+    <code>--gg-theme-*</code> on the plot root for tool rails, tooltips, focus
+    rings, and selection chrome — keep <code>tooltipPaper</code> /
+    <code>tooltipInk</code> and <code>interactionInk</code> contrasty so
+    recovery controls like legend <strong>Clear</strong> stay readable on dark bases.
+  </p>
+  <div class="table-wrap">
+    <table>
+      <thead>
+        <tr>
+          <th scope="col">Prop</th>
+          <th scope="col">Kind</th>
+          <th scope="col">Affects</th>
+          <th scope="col">CSS</th>
+        </tr>
+      </thead>
+      <tbody>
+        {#each THEME_COLOR_ROLES as role (role.name)}
+          <tr>
+            <td><code>{role.name}</code></td>
+            <td>{role.kind}</td>
+            <td>{role.affects}</td>
+            <td><code>{role.css}</code></td>
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+  </div>
+
+  <h2 id="type-and-geometry-roles">Type and geometry roles</h2>
+  <p>
+    Sizes are in CSS px unless noted. Boolean flags blank axis/grid pieces
+    (void-style themes turn labels and grids off).
+  </p>
+  <div class="table-wrap">
+    <table>
+      <thead>
+        <tr>
+          <th scope="col">Prop</th>
+          <th scope="col">Kind</th>
+          <th scope="col">Affects</th>
+        </tr>
+      </thead>
+      <tbody>
+        {#each THEME_TYPE_AND_GEOMETRY_ROLES as role (role.name)}
+          <tr>
+            <td><code>{role.name}</code></td>
+            <td>{role.kind}</td>
+            <td>{role.affects}</td>
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+  </div>
+
+  <h2 id="safe-overrides">Safe overrides</h2>
+  <ul>
+    <li>
+      Prefer typed theme props (<code>&lt;ThemeDark paper="#0b0b0b" /&gt;</code
+      >) when authoring in Svelte — values land in PortableSpec and stay
+      edition-stable.
+    </li>
+    <li>
+      Host CSS on <code>--gg-ink</code>, <code>--gg-paper</code>, and the other
+      <code>--gg-*</code> roles works without a re-render; only override roles you
+      intend to change.
+    </li>
+    <li>
+      Never treat <code>interactionMuted</code> as a color — it is a numeric alpha
+      applied to de-emphasized marks.
+    </li>
+    <li>
+      When you darken <code>paper</code> / <code>panel</code>, also set
+      <code>tooltipPaper</code>, <code>tooltipInk</code>,
+      <code>interactionInk</code>, and <code>focusRing</code> so inspect chrome and
+      legend Clear keep contrast.
+    </li>
+    <li>
+      Themes style chrome only. Data series colors use
+      <a href={`${base}/reference/palettes`}>named palette schemes</a> on
+      <code>ScaleColor*</code> / <code>ScaleFill*</code> children.
+    </li>
+  </ul>
+
+  <h2 id="see-also">See also</h2>
+  <ul>
+    <li>
+      <a href={`${base}/themes`}>Themes showcase</a> — live portraits of every built-in
+    </li>
+    <li>
+      <a href={`${base}/reference/palettes`}>Palettes reference</a> — scheme names
+      as scale inputs
+    </li>
+    <li>
+      <a href={`${base}/guide/scales-guides`}>Scales and guides</a> — position, color,
+      and legend channels
+    </li>
+    <li>
+      <a href={`${base}/guide/upgrading#compose-the-theme-as-a-child-layer`}
+        >Upgrade guide</a
+      >
+      — theme child migration
+    </li>
+  </ul>
+</article>
+
+<style>
+  .theme-reference {
+    max-width: 52rem;
+    margin: 2rem 0 4rem;
+  }
+
+  .table-wrap {
+    overflow-x: auto;
+    margin: 1.25rem 0 1.75rem;
+  }
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.92rem;
+  }
+
+  th,
+  td {
+    text-align: left;
+    vertical-align: top;
+    padding: 0.55rem 0.65rem 0.55rem 0;
+    border-top: 1px solid var(--line);
+  }
+
+  thead th {
+    border-top: none;
+    color: var(--muted);
+    font-size: 0.78rem;
+    font-weight: 650;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  tbody tr:last-child td {
+    border-bottom: 1px solid var(--line);
+  }
+
+  td code {
+    white-space: nowrap;
+  }
+</style>

--- a/apps/docs/src/routes/themes/+page.svelte
+++ b/apps/docs/src/routes/themes/+page.svelte
@@ -13,6 +13,11 @@
   <header class="themes-intro">
     <p class="eyebrow">Themes</p>
     <h1>Chart themes</h1>
+    <p class="lede">
+      Live portraits of paper, grids, axes, and type. Props, role tokens, and
+      CSS variables:
+      <a href={`${base}/reference/themes`}>Themes reference</a>.
+    </p>
   </header>
 
   <ChartThemeLab initialStaticSrc={data.labStaticSrc} />
@@ -42,6 +47,10 @@
   <nav class="learning-path" aria-label="Next steps">
     <p class="eyebrow">Next</p>
     <ul>
+      <li>
+        <a href={`${base}/reference/themes`}>Themes reference</a>
+        — components, role tokens, CSS variables
+      </li>
       <li>
         <a href={`${base}/palettes`}>Palettes</a>
         — categorical schemes and sequential ramps
@@ -83,6 +92,17 @@
     font-size: clamp(2.25rem, 5vw, 3.5rem);
     line-height: 0.95;
     letter-spacing: -0.03em;
+  }
+
+  .themes-intro .lede {
+    max-width: 42rem;
+    margin: 0.85rem 0 0;
+    color: var(--muted);
+    font-size: 1.02rem;
+  }
+
+  .themes-intro .lede a {
+    color: var(--ink);
   }
 
   .eyebrow {

--- a/scripts/check-pages-links.test.ts
+++ b/scripts/check-pages-links.test.ts
@@ -22,6 +22,8 @@ describe("packed Pages link checks", () => {
     "palettes.html",
     "interactions.html",
     "reference/interactions.html",
+    "reference/themes.html",
+    "reference/palettes.html",
     "reference/cli.html",
     "reference/geoms.html",
     "reference/geoms/point.html",
@@ -105,6 +107,8 @@ describe("packed Pages link checks", () => {
     expect(requiredPages).toContain("palettes.html");
     expect(requiredPages).toContain("interactions.html");
     expect(requiredPages).toContain("reference/interactions.html");
+    expect(requiredPages).toContain("reference/themes.html");
+    expect(requiredPages).toContain("reference/palettes.html");
     expect(requiredPages).toContain("reference/cli.html");
     expect(requiredPages).toContain("reference/geoms.html");
     expect(requiredPages).toContain("reference/geoms/point.html");

--- a/scripts/check-pages-links.ts
+++ b/scripts/check-pages-links.ts
@@ -14,6 +14,8 @@ export const requiredPages = [
   "palettes.html",
   "interactions.html",
   "reference/interactions.html",
+  "reference/themes.html",
+  "reference/palettes.html",
   "reference/cli.html",
   "reference/geoms.html",
   "reference/geoms/point.html",

--- a/scripts/docs-route-inventory-pages.ts
+++ b/scripts/docs-route-inventory-pages.ts
@@ -163,6 +163,47 @@ export const TOP_LEVEL_ROUTES: readonly DocsRouteRecord[] = [
     navigation: { section: "Reference", label: "Interaction reference", order: 55 },
   },
   {
+    path: "/reference/themes",
+    title: "Themes — ggsvelte",
+    description:
+      "Theme components, role tokens, CSS variables, and safe overrides for paper, ink, and interaction chrome.",
+    canonicalPath: "/reference/themes",
+    kind: "page",
+    index: true,
+    sitemap: true,
+    shell: "docs",
+    navigation: { section: "Reference", label: "Themes", order: 56 },
+    headings: [
+      { id: "components", title: "Components", level: 2 },
+      { id: "usage", title: "Usage", level: 2 },
+      { id: "color-and-interaction-roles", title: "Color and interaction roles", level: 2 },
+      { id: "type-and-geometry-roles", title: "Type and geometry roles", level: 2 },
+      { id: "safe-overrides", title: "Safe overrides", level: 2 },
+      { id: "see-also", title: "See also", level: 2 },
+    ],
+  },
+  {
+    path: "/reference/palettes",
+    title: "Palettes — ggsvelte",
+    description:
+      "Named color schemes as scale inputs: categorical and sequential scheme catalogs mapped to ScaleColor* / ScaleFill* helpers.",
+    canonicalPath: "/reference/palettes",
+    kind: "page",
+    index: true,
+    sitemap: true,
+    shell: "docs",
+    navigation: { section: "Reference", label: "Palettes", order: 57 },
+    headings: [
+      { id: "using-schemes", title: "Using schemes", level: 2 },
+      { id: "helper-map", title: "Scale helpers", level: 2 },
+      { id: "discrete", title: "Discrete (categorical schemes)", level: 3 },
+      { id: "continuous", title: "Continuous and binned (sequential schemes)", level: 3 },
+      { id: "categorical-schemes", title: "Categorical schemes", level: 2 },
+      { id: "sequential-schemes", title: "Sequential schemes", level: 2 },
+      { id: "see-also", title: "See also", level: 2 },
+    ],
+  },
+  {
     path: "/reference/cli",
     title: "Command-line reference — ggsvelte",
     description:
@@ -172,7 +213,7 @@ export const TOP_LEVEL_ROUTES: readonly DocsRouteRecord[] = [
     index: true,
     sitemap: true,
     shell: "docs",
-    navigation: { section: "Reference", label: "CLI reference", order: 56 },
+    navigation: { section: "Reference", label: "CLI reference", order: 58 },
     headings: [
       { id: "input-and-output", title: "Input and output", level: 2 },
       { id: "options", title: "Options", level: 2 },

--- a/scripts/docs-route-inventory.test.ts
+++ b/scripts/docs-route-inventory.test.ts
@@ -45,6 +45,8 @@ describe("docs route inventory", () => {
     expect(paths.has("/reference/guides")).toBe(true);
     expect(paths.has("/reference/guides/legend")).toBe(true);
     expect(paths.has("/reference/interactions")).toBe(true);
+    expect(paths.has("/reference/themes")).toBe(true);
+    expect(paths.has("/reference/palettes")).toBe(true);
     expect(paths.has("/reference/cli")).toBe(true);
     expect(paths.has("/__perf/r3-interaction")).toBe(true);
     expect(paths.has("/sitemap.xml")).toBe(true);
@@ -205,6 +207,28 @@ describe("docs route inventory", () => {
     expect(ids("/reference/guides/none")).toEqual(["channels", "svelte", "json", "props"]);
   });
 
+  it("publishes themes and palettes reference inside the one Reference hierarchy", () => {
+    const inventory = createDocsRouteInventory();
+    expect(inventory.find((entry) => entry.path === "/reference/themes")).toMatchObject({
+      title: "Themes — ggsvelte",
+      canonicalPath: "/reference/themes",
+      kind: "page",
+      index: true,
+      sitemap: true,
+      shell: "docs",
+      navigation: { section: "Reference", label: "Themes", order: 56 },
+    });
+    expect(inventory.find((entry) => entry.path === "/reference/palettes")).toMatchObject({
+      title: "Palettes — ggsvelte",
+      canonicalPath: "/reference/palettes",
+      kind: "page",
+      index: true,
+      sitemap: true,
+      shell: "docs",
+      navigation: { section: "Reference", label: "Palettes", order: 57 },
+    });
+  });
+
   it("publishes the CLI reference inside the one Reference hierarchy", () => {
     const cliRoute = createDocsRouteInventory().find((entry) => entry.path === "/reference/cli");
     expect(cliRoute).toMatchObject({
@@ -214,7 +238,7 @@ describe("docs route inventory", () => {
       index: true,
       sitemap: true,
       shell: "docs",
-      navigation: { section: "Reference", label: "CLI reference", order: 56 },
+      navigation: { section: "Reference", label: "CLI reference", order: 58 },
     });
     expect(cliRoute?.headings?.filter((heading) => heading.level === 3)).toEqual(
       CLI_REFERENCE_OPTIONS.map((option) => ({

--- a/scripts/llms-guide-content.ts
+++ b/scripts/llms-guide-content.ts
@@ -154,6 +154,7 @@ as JSON under the same name on the docs site):
 - [Scales and guides](/guide/scales-guides) — continuous, discrete, manual, temporal
 - [Facets and coordinates](/guide/facets-coordinates) — small multiples, flip, fixed aspect
 - [Chart themes](/themes) and [palettes](/palettes) — paper/ink chrome and data color
+- [Themes reference](/reference/themes) and [palettes reference](/reference/palettes) — props, tokens, scheme → scale helpers
 - [Interactions](/guide/interactions) — inspect, pin, selection, zoom, linked views
 - [Production](/guide/production) — sizing, SVG/canvas, SSR, export, support matrix
 - [Lifecycle](/guide/lifecycle) — what is stable and what is not

--- a/scripts/theme-palette-reference.test.ts
+++ b/scripts/theme-palette-reference.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  CATEGORICAL_SCHEME_REFS,
+  PALETTE_HELPER_GROUPS,
+  SEQUENTIAL_SCHEME_REFS,
+} from "../apps/docs/src/lib/catalog/palette-reference.ts";
+import {
+  ALL_THEME_ROLES,
+  THEME_COLOR_ROLES,
+  THEME_SHELLS,
+  themeComponentName,
+} from "../apps/docs/src/lib/catalog/theme-reference.ts";
+import {
+  CATEGORICAL_SCHEME_NAMES,
+  SEQUENTIAL_SCHEME_NAMES,
+  THEME_NAMES,
+} from "../packages/spec/src/schema-names.ts";
+
+describe("theme reference catalog", () => {
+  it("lists a shell for every registered theme name", () => {
+    expect(THEME_SHELLS.map((s) => s.name)).toEqual([...THEME_NAMES]);
+    expect(themeComponentName("economist_white")).toBe("ThemeEconomistwhite");
+    expect(themeComponentName("solarized_2dark")).toBe("ThemeSolarized2dark");
+    expect(themeComponentName("excel_new")).toBe("ThemeExcelnew");
+    expect(THEME_SHELLS.find((s) => s.name === "grey")?.aliasOf).toBe("ggplot2");
+    expect(THEME_SHELLS.find((s) => s.name === "gray")?.aliasOf).toBe("ggplot2");
+  });
+
+  it("covers color/interaction roles used for chrome recovery", () => {
+    const names = new Set(THEME_COLOR_ROLES.map((r) => r.name));
+    const required = [
+      "ink",
+      "paper",
+      "interactionInk",
+      "interactionMuted",
+      "focusRing",
+      "tooltipPaper",
+      "tooltipInk",
+      "tooltipBorder",
+    ] as const;
+    for (const role of required) {
+      expect(names.has(role), role).toBe(true);
+    }
+    expect(ALL_THEME_ROLES.length).toBeGreaterThan(THEME_COLOR_ROLES.length);
+  });
+});
+
+describe("palette reference catalog", () => {
+  it("covers every registered scheme name", () => {
+    expect(CATEGORICAL_SCHEME_REFS.map((s) => s.name)).toEqual([...CATEGORICAL_SCHEME_NAMES]);
+    expect(SEQUENTIAL_SCHEME_REFS.map((s) => s.name)).toEqual([...SEQUENTIAL_SCHEME_NAMES]);
+  });
+
+  it("maps categorical schemes to discrete scale helpers", () => {
+    const tableau = CATEGORICAL_SCHEME_REFS.find((s) => s.name === "tableau10");
+    expect(tableau?.helpers).toContain("ScaleColorDiscrete");
+    expect(tableau?.helpers).toContain("ScaleFillDiscrete");
+
+    const set2 = CATEGORICAL_SCHEME_REFS.find((s) => s.name === "Set2");
+    expect(set2?.helpers).toContain("ScaleColorBrewer");
+
+    const hue = CATEGORICAL_SCHEME_REFS.find((s) => s.name === "hue");
+    expect(hue?.helpers).toContain("ScaleColorHue");
+  });
+
+  it("maps sequential schemes to continuous helpers", () => {
+    const viridis = SEQUENTIAL_SCHEME_REFS.find((s) => s.name === "viridis");
+    expect(viridis?.helpers).toContain("ScaleColorViridisC");
+    expect(viridis?.helpers).toContain("ScaleColorContinuous");
+
+    const blues = SEQUENTIAL_SCHEME_REFS.find((s) => s.name === "Blues");
+    expect(blues?.helpers).toContain("ScaleColorDistiller");
+  });
+
+  it("documents helper groups for discrete and continuous families", () => {
+    expect(PALETTE_HELPER_GROUPS.map((g) => g.id)).toEqual(["discrete", "continuous"]);
+  });
+});

--- a/tests/visual/docs-progressive-search.spec.ts
+++ b/tests/visual/docs-progressive-search.spec.ts
@@ -125,7 +125,7 @@ test("Docs landing and sidebar expose the full path without duplicate Reference"
   await expect(sidebar.getByRole("heading", { name: "Start" })).toHaveCount(0);
   await expect(sidebar.getByRole("heading", { name: "Core grammar" })).toHaveCount(0);
   // Overview + consolidated guide/reference chapters.
-  await expect(sidebar.getByRole("link")).toHaveCount(19);
+  await expect(sidebar.getByRole("link")).toHaveCount(21);
   await expect(sidebar.getByRole("link", { name: "Dates without preprocessing" })).toBeVisible();
   await expectNoDocumentOverflow(page);
 

--- a/tests/visual/docs-shell.spec.ts
+++ b/tests/visual/docs-shell.spec.ts
@@ -122,7 +122,7 @@ test("desktop docs shell exposes chapter, breadcrumb, contents, and sequence nav
   const chapters = page.getByRole("navigation", { name: "Guide chapters" });
   await expect(chapters).toBeVisible();
   // Overview + consolidated guide/reference chapters.
-  await expect(chapters.getByRole("link")).toHaveCount(19);
+  await expect(chapters.getByRole("link")).toHaveCount(21);
   await expect(chapters.getByRole("link", { name: "Dates without preprocessing" })).toBeVisible();
   await expect(page.getByRole("navigation", { name: "Breadcrumb" })).toContainText(
     "Getting started",


### PR DESCRIPTION
## Summary

- Add `/reference/themes` with Theme* component catalog, color/interaction and type/geometry role tables, CSS custom properties, safe override guidance, and interaction chrome notes (tooltip paper/ink, focus ring, legend Clear contrast).
- Add `/reference/palettes` with scheme→`ScaleColor*`/`ScaleFill*` helper maps for every categorical and sequential scheme, plus usage examples.
- Keep `/themes` and `/palettes` showcases; link them as demos from reference and link reference from showcases, docs landing, and the Reference index.
- Register routes in the docs inventory (nav + search + required packed pages) and cover catalogs with unit tests.

Closes #1198

## Test plan

- [x] `bun test scripts/theme-palette-reference.test.ts scripts/docs-route-inventory.test.ts scripts/check-pages-links.test.ts`
- [x] `bun run docs:routes:check` / `docs:search:check`
- [x] `cd apps/docs && bun run --bun check` (svelte-check 0 errors)
- [ ] CI green on the PR
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1215" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->