### PR TITLE
docs: purge svelte-highlight for shared highlight.js path

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -16,8 +16,7 @@
     "@ggsvelte/examples": "workspace:*",
     "@ggsvelte/spec": "workspace:*",
     "@ggsvelte/svelte": "workspace:*",
-    "bits-ui": "^2.18.1",
-    "svelte-highlight": "^7.16.0"
+    "bits-ui": "^2.18.1"
   },
   "devDependencies": {
     "@sveltejs/adapter-static": "^3.0.10",

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -16,7 +16,8 @@
     "@ggsvelte/examples": "workspace:*",
     "@ggsvelte/spec": "workspace:*",
     "@ggsvelte/svelte": "workspace:*",
-    "bits-ui": "^2.18.1"
+    "bits-ui": "^2.18.1",
+    "highlight.js": "^11.11.1"
   },
   "devDependencies": {
     "@sveltejs/adapter-static": "^3.0.10",

--- a/apps/docs/src/app.css
+++ b/apps/docs/src/app.css
@@ -6,7 +6,7 @@
 @import "./styles/base.css";
 @import "./styles/shell.css";
 /* Code blocks are always dark (see --code-paper); atom-one-dark token colors. */
-@import "svelte-highlight/styles/atom-one-dark.css";
+@import "highlight.js/styles/atom-one-dark.css";
 
 .app-contents {
   display: contents;

--- a/apps/docs/src/lib/CodeTabs.svelte
+++ b/apps/docs/src/lib/CodeTabs.svelte
@@ -4,12 +4,10 @@
    * spec JSON (what agents emit), fluent-builder TypeScript (spec.ts), and
    * idiomatic Svelte components (Example.svelte) — each with a copy button.
    */
-  import Highlight from "svelte-highlight";
-
   import { briefCopyStatus, COPIED_STATUS, copyText } from "$lib/clipboard";
   import {
+    highlightDocsBlock,
     languageFromCodeTabLabel,
-    resolveCodeLanguage,
   } from "$lib/code-languages";
   import { CHECK_ICON_SVG, COPY_ICON_SVG } from "$lib/copy-icons";
   import { nextRovingTabIndex } from "$lib/tab-roving";
@@ -30,8 +28,9 @@
   let copyTimer: ReturnType<typeof setTimeout> | undefined;
 
   const activeTab = $derived(tabs[active]);
-  const languageModule = $derived(
-    resolveCodeLanguage(
+  const highlighted = $derived(
+    highlightDocsBlock(
+      activeTab?.code ?? "",
       activeTab?.language ?? languageFromCodeTabLabel(activeTab?.label),
     ),
   );
@@ -70,11 +69,7 @@
 
 <div class="code-tabs">
   <div class="bar">
-    <div
-      class="representations"
-      role="tablist"
-      aria-label="Code representations"
-    >
+    <div class="tabs" role="tablist" aria-label="Code representations">
       {#each tabs as tab, i (tab.label)}
         <button
           id={`${tabsetId}-tab-${String(i)}`}
@@ -124,7 +119,8 @@
       tabindex="0"
       bind:this={codeNode}
     >
-      <Highlight code={activeTab?.code ?? ""} language={languageModule} />
+      <!-- eslint-disable-next-line svelte/no-at-html-tags -- highlight.js token spans; plaintext is escaped -->
+      {@html highlighted}
     </div>
   </div>
 </div>
@@ -147,7 +143,7 @@
     background: var(--bg);
   }
 
-  .representations {
+  .tabs {
     display: flex;
     min-width: 0;
     gap: 0.15rem;

--- a/apps/docs/src/lib/code-languages.ts
+++ b/apps/docs/src/lib/code-languages.ts
@@ -1,8 +1,15 @@
 /**
  * Docs code-block language helpers. Highlighting uses the shared highlight.js
- * allowlist in `$scripts/highlight-code` (same as guide markdown fences).
+ * allowlist in scripts/highlight-code (same as guide markdown fences).
+ *
+ * Relative import (not `$scripts/…`): `scripts/tsconfig.json` typechecks this
+ * module via `scripts/code-languages.test.ts`, and that project has no SvelteKit
+ * path aliases.
  */
-import { highlightCodeToHtml, resolveHighlightLanguage } from "$scripts/highlight-code";
+import {
+  highlightCodeToHtml,
+  resolveHighlightLanguage,
+} from "../../../../scripts/highlight-code.ts";
 
 /**
  * Infer a highlight language from a code-tab label when no explicit language prop is set

--- a/apps/docs/src/lib/code-languages.ts
+++ b/apps/docs/src/lib/code-languages.ts
@@ -1,40 +1,8 @@
 /**
- * Language modules for svelte-highlight, keyed by the fence / prop aliases
- * used across docs call sites.
+ * Docs code-block language helpers. Highlighting uses the shared highlight.js
+ * allowlist in `$scripts/highlight-code` (same as guide markdown fences).
  */
-import type { LanguageType } from "svelte-highlight/languages";
-import bash from "svelte-highlight/languages/bash";
-import css from "svelte-highlight/languages/css";
-import javascript from "svelte-highlight/languages/javascript";
-import json from "svelte-highlight/languages/json";
-import plaintext from "svelte-highlight/languages/plaintext";
-import svelte from "svelte-highlight/languages/svelte";
-import typescript from "svelte-highlight/languages/typescript";
-import xml from "svelte-highlight/languages/xml";
-
-const LANGUAGE_MODULES: Record<string, LanguageType<string>> = {
-  bash,
-  sh: bash,
-  shell: bash,
-  zsh: bash,
-  css,
-  js: javascript,
-  javascript,
-  json,
-  plaintext,
-  text: plaintext,
-  svelte,
-  ts: typescript,
-  typescript,
-  html: xml,
-  xml,
-};
-
-/** Resolve a language name (or empty) to a svelte-highlight language module. */
-export function resolveCodeLanguage(lang?: string): LanguageType<string> {
-  if (lang === undefined || lang.trim() === "") return plaintext;
-  return LANGUAGE_MODULES[lang.trim().toLowerCase()] ?? plaintext;
-}
+import { highlightCodeToHtml, resolveHighlightLanguage } from "$scripts/highlight-code";
 
 /**
  * Infer a highlight language from a code-tab label when no explicit language prop is set
@@ -49,4 +17,28 @@ export function languageFromCodeTabLabel(label?: string): string {
     return "typescript";
   }
   return "plaintext";
+}
+
+/**
+ * Normalize a fence / prop language to a stable id. Unknown or empty names
+ * become `"plaintext"` (escaped, no tokens).
+ */
+export function resolveCodeLanguage(lang?: string): string {
+  if (lang === undefined || lang.trim() === "") return "plaintext";
+  const key = lang.trim().toLowerCase();
+  if (key === "plaintext" || key === "text") return "plaintext";
+  if (resolveHighlightLanguage(key) !== undefined) return key;
+  return "plaintext";
+}
+
+/**
+ * Full `<pre><code class="hljs …">` HTML for docs CopyCode / CodeTabs.
+ * Token spans come from highlight.js; unknown languages are escaped plaintext.
+ */
+export function highlightDocsBlock(source: string, lang?: string): string {
+  const id = resolveCodeLanguage(lang);
+  const fenceLang = id === "plaintext" ? "" : id;
+  const body = highlightCodeToHtml(source, fenceLang);
+  const languageClass = fenceLang === "" ? ' class="hljs"' : ` class="hljs language-${fenceLang}"`;
+  return `<pre class="hljs"><code${languageClass}>${body}</code></pre>`;
 }

--- a/apps/docs/src/lib/code-languages.ts
+++ b/apps/docs/src/lib/code-languages.ts
@@ -6,10 +6,7 @@
  * module via `scripts/code-languages.test.ts`, and that project has no SvelteKit
  * path aliases.
  */
-import {
-  highlightCodeToHtml,
-  resolveHighlightLanguage,
-} from "../../../../scripts/highlight-code.ts";
+import { highlightCodeToHtml, resolveHighlightLanguage } from "../../../../scripts/highlight-code";
 
 /**
  * Infer a highlight language from a code-tab label when no explicit language prop is set

--- a/apps/docs/src/lib/components/CopyCode.svelte
+++ b/apps/docs/src/lib/components/CopyCode.svelte
@@ -1,8 +1,6 @@
 <script lang="ts">
-  import Highlight from "svelte-highlight";
-
   import { briefCopyStatus, COPIED_STATUS, copyText } from "$lib/clipboard";
-  import { resolveCodeLanguage } from "$lib/code-languages";
+  import { highlightDocsBlock } from "$lib/code-languages";
   import { CHECK_ICON_SVG, COPY_ICON_SVG } from "$lib/copy-icons";
 
   const {
@@ -23,7 +21,7 @@
   let source = $state<HTMLElement>();
   let status = $state("");
   let timer: ReturnType<typeof setTimeout> | undefined;
-  const languageModule = $derived(resolveCodeLanguage(language));
+  const highlighted = $derived(highlightDocsBlock(code, language));
   const copied = $derived(status === COPIED_STATUS);
 
   async function copy(): Promise<void> {
@@ -51,7 +49,8 @@
     {/if}
   </button>
   <div class="code-body" bind:this={source}>
-    <Highlight {code} language={languageModule} />
+    <!-- eslint-disable-next-line svelte/no-at-html-tags -- highlight.js token spans; plaintext is escaped -->
+    {@html highlighted}
   </div>
   <span class="visually-hidden" role="status">{status}</span>
 </div>

--- a/apps/docs/src/styles/base.css
+++ b/apps/docs/src/styles/base.css
@@ -186,7 +186,7 @@ pre {
   margin: 1.5rem 0;
 }
 
-/* highlight.js / svelte-highlight: keep our dark code surface, keep theme tokens */
+/* highlight.js: keep our dark code surface, keep theme tokens */
 .prose pre code.hljs,
 .prose pre.hljs,
 .copy-code pre.hljs,

--- a/bun.lock
+++ b/bun.lock
@@ -38,6 +38,7 @@
         "@ggsvelte/spec": "workspace:*",
         "@ggsvelte/svelte": "workspace:*",
         "bits-ui": "^2.18.1",
+        "highlight.js": "^11.11.1",
       },
       "devDependencies": {
         "@sveltejs/adapter-static": "^3.0.10",

--- a/bun.lock
+++ b/bun.lock
@@ -38,7 +38,6 @@
         "@ggsvelte/spec": "workspace:*",
         "@ggsvelte/svelte": "workspace:*",
         "bits-ui": "^2.18.1",
-        "svelte-highlight": "^7.16.0",
       },
       "devDependencies": {
         "@sveltejs/adapter-static": "^3.0.10",
@@ -79,9 +78,9 @@
     },
     "packages/core": {
       "name": "@ggsvelte/core",
-      "version": "0.15.1",
+      "version": "0.16.0",
       "dependencies": {
-        "@ggsvelte/spec": "^0.15.1",
+        "@ggsvelte/spec": "^0.16.0",
       },
       "devDependencies": {
         "typescript": "^6.0.3",
@@ -89,7 +88,7 @@
     },
     "packages/spec": {
       "name": "@ggsvelte/spec",
-      "version": "0.15.1",
+      "version": "0.16.0",
       "dependencies": {
         "@js-temporal/polyfill": "^0.5.1",
         "typebox": "^1.3.6",
@@ -101,14 +100,14 @@
     },
     "packages/svelte": {
       "name": "@ggsvelte/svelte",
-      "version": "0.15.1",
+      "version": "0.16.0",
       "bin": {
         "ggsvelte-codemod": "bin/ggsvelte-codemod.js",
         "ggsvelte-render": "bin/ggsvelte-render.js",
       },
       "dependencies": {
-        "@ggsvelte/core": "^0.15.1",
-        "@ggsvelte/spec": "^0.15.1",
+        "@ggsvelte/core": "^0.16.0",
+        "@ggsvelte/spec": "^0.16.0",
       },
       "devDependencies": {
         "@sveltejs/package": "^2.5.8",
@@ -1176,8 +1175,6 @@
     "svelte": ["svelte@5.56.8", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.10", "@types/estree": "^1.0.5", "@types/trusted-types": "^2.0.7", "acorn": "^8.12.1", "aria-query": "5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "devalue": "^5.8.1", "esm-env": "^1.2.1", "esrap": "^2.2.12", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-PY8LOw7xP6c8IOiVqdo0sbbZVYhXRSfklOQLAUyGBKqjTX0wx/z4l/9J+PmBpmlLnxzEb1NqltxQ5/wZme/Cmg=="],
 
     "svelte-check": ["svelte-check@4.7.3", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.25", "@sveltejs/load-config": "^0.2.0", "chokidar": "^4.0.1", "fdir": "^6.2.0", "picocolors": "^1.0.0", "sade": "^1.7.4" }, "peerDependencies": { "svelte": "^4.0.0 || ^5.0.0-next.0", "typescript": ">=5.0.0" }, "bin": { "svelte-check": "bin/svelte-check" } }, "sha512-DHdTCGX62R0fCxBEaT+USdASAnoaRBaaNczkRJl0K7o3WyoCeVUbVxo6fKqpOll/B+WMWCsiFK0eFrJSNBKZIg=="],
-
-    "svelte-highlight": ["svelte-highlight@7.16.0", "", { "dependencies": { "magic-string": "^0.30.17" } }, "sha512-0H7RwC+mvV/aZ7gFsg5bEDtFHsWlirKFlpw7HImjMQTclq3/bWjgtYV2sgMma90DU9H72G3J8n7fTlTUFWk76w=="],
 
     "svelte-toolbelt": ["svelte-toolbelt@0.10.6", "", { "dependencies": { "clsx": "^2.1.1", "runed": "^0.35.1", "style-to-object": "^1.0.8" }, "peerDependencies": { "svelte": "^5.30.2" } }, "sha512-YWuX+RE+CnWYx09yseAe4ZVMM7e7GRFZM6OYWpBKOb++s+SQ8RBIMMe+Bs/CznBMc0QPLjr+vDBxTAkozXsFXQ=="],
 

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -79,7 +79,9 @@
       "project": ["src/**/*.ts", "tests/**/*.ts", "*.{js,ts}"],
       // Imported only from .svelte files / the $examples alias, which knip
       // does not trace. bits-ui is deep-imported only from .svelte.
-      "ignoreDependencies": ["@ggsvelte/examples", "bits-ui"],
+      // highlight.js: atom-one-dark CSS via app.css + shared scripts/highlight-code
+      // (relative import from code-languages.ts). Knip does not follow either.
+      "ignoreDependencies": ["@ggsvelte/examples", "bits-ui", "highlight.js"],
     },
   },
 }

--- a/scripts/code-languages.test.ts
+++ b/scripts/code-languages.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
-import { languageFromCodeTabLabel, resolveCodeLanguage } from "../apps/docs/src/lib/code-languages";
+import {
+  highlightDocsBlock,
+  languageFromCodeTabLabel,
+  resolveCodeLanguage,
+} from "../apps/docs/src/lib/code-languages";
 
 describe("languageFromCodeTabLabel", () => {
   test("maps triptych labels to highlight languages", () => {
@@ -15,10 +19,30 @@ describe("languageFromCodeTabLabel", () => {
 
 describe("resolveCodeLanguage", () => {
   test("resolves aliases and falls back to plaintext", () => {
-    expect(typeof resolveCodeLanguage("ts")).toBe("object");
-    expect(resolveCodeLanguage("ts")).toBe(resolveCodeLanguage("typescript"));
-    expect(resolveCodeLanguage("")).toBe(resolveCodeLanguage("plaintext"));
-    expect(resolveCodeLanguage()).toBe(resolveCodeLanguage("plaintext"));
-    expect(resolveCodeLanguage("nope-not-a-lang")).toBe(resolveCodeLanguage("plaintext"));
+    expect(resolveCodeLanguage("ts")).toBe("ts");
+    expect(resolveCodeLanguage("typescript")).toBe("typescript");
+    expect(resolveCodeLanguage("")).toBe("plaintext");
+    expect(resolveCodeLanguage()).toBe("plaintext");
+    expect(resolveCodeLanguage("nope-not-a-lang")).toBe("plaintext");
+    expect(resolveCodeLanguage("text")).toBe("plaintext");
+  });
+});
+
+describe("highlightDocsBlock", () => {
+  test("emits hljs pre/code with token spans for known languages", () => {
+    const html = highlightDocsBlock("const answer = 42;", "ts");
+    expect(html).toContain('<pre class="hljs">');
+    expect(html).toContain('class="hljs language-ts"');
+    expect(html).toContain("hljs-");
+    expect(html).toContain("const");
+    expect(html).not.toContain("<script");
+  });
+
+  test("escapes plaintext for unknown languages", () => {
+    const html = highlightDocsBlock("<b>x</b>", "not-a-language");
+    expect(html).toContain('<pre class="hljs">');
+    expect(html).toContain('class="hljs"');
+    expect(html).not.toContain("language-");
+    expect(html).toContain("&lt;b&gt;x&lt;/b&gt;");
   });
 });


### PR DESCRIPTION
## Summary

- Remove `svelte-highlight` from the docs app (large wrapper, poor load feel, duplicate of work we already do elsewhere).
- Point `CopyCode` / `CodeTabs` at the existing allowlisted `highlight.js` helper in `scripts/highlight-code.ts` (same path as guide markdown fences).
- Import `atom-one-dark` styles from `highlight.js` instead of `svelte-highlight`.
- Extend `code-languages` tests for `highlightDocsBlock` (token spans + XSS-safe plaintext escape).

### Why not Shiki?

Guide fences already run on a small core+languages `highlight.js` allowlist. Reusing it avoids a second highlighter, keeps client and SSR consistent, and purges the dep entirely (preferred over swapping to Shiki).

## Test plan

- [x] `bun test scripts/code-languages.test.ts scripts/highlight-code.test.ts`
- [x] `bun test scripts/docs-search-icons-lazy.test.ts scripts/code-surface-design-tokens.test.ts scripts/gen-llms.test.ts`
- [ ] CI docs / unit jobs green
- [ ] Spot-check docs home + example page: code tabs + copy buttons still highlight and copy
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1218" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->