### PR TITLE
docs(skill): lock SKILL.md scheme/theme inventory to registries

### DIFF
--- a/.changeset/skill-inventory-lead-line.md
+++ b/.changeset/skill-inventory-lead-line.md
@@ -1,0 +1,13 @@
+---
+"@ggsvelte/svelte": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+docs(skill): keep SKILL.md scheme/theme lead counts in sync with registries
+
+Slim the theme lead line to representative names, and assert scheme/theme
+totals (plus reference section headers and example names) against
+`COLOR_SCHEME_NAMES` / `CATEGORICAL_SCHEME_NAMES` / `SEQUENTIAL_SCHEME_NAMES`
+and product `THEME_NAMES` in `scripts/skill-content.test.ts` so ggthemes
+port PRs cannot leave the agent skill summary stale (#1210).

--- a/packages/svelte/skills/ggsvelte/SKILL.md
+++ b/packages/svelte/skills/ggsvelte/SKILL.md
@@ -167,7 +167,8 @@ Two rules worth keeping in working memory:
   year-quarters infer time automatically. Ambiguous ordered dates need
   `"parse": "dmy"` or `"mdy"`; force `{"type": "band"}` for year-like
   identifiers; never preprocess dates into indexes.
-- Themes: 37 names (`default`, `light`, `dark`, `minimal`, `ggplot2`, `classic`, `bw`, `hrbr`, `few`, `clean`, `fivethirtyeight`, `economist`, `tufte`, `linedraw`, `void`, `stata`, `stata_s1color`, `stata_mono`, `solarized`, `solarizeddark`, `economist_white`, `solarized_2`, `solarized_2dark`, `wsj`, `gdocs`, `hc`, `hcdark`, `pander`, `calc`, `excel`, `excel_new`, `base`, `igray`, `map`, `solid`, plus `grey`/`gray` aliasing `ggplot2`) as
+- Themes: 37 names (`default`, `minimal`, `dark`, `ggplot2`, `stata`, `wsj`,
+  `excel_new`…; `grey`/`gray` aliasing `ggplot2`) as
   `<ThemeTufte/>`-style children or `"theme": "tufte"` in JSON.
 
 Full option surfaces — every scale option, the `Scale*` component matrix, all

--- a/scripts/skill-content.test.ts
+++ b/scripts/skill-content.test.ts
@@ -3,7 +3,7 @@
  *
  * The skill ships inside the ggsvelte npm package and teaches agents the
  * grammar; a stale or broken claim there produces broken charts downstream.
- * Three guards:
+ * Four guards:
  *
  * 1. Fence contract — every code fence carries exactly one of
  *    `complete`/`fragment`, and every `json complete` fence must normalize
@@ -15,6 +15,15 @@
  *    for every geom, stat, position, theme, and color scheme the spec knows.
  *    Adding one upstream turns the skill red until it is documented; this is
  *    the pre-changesets lock-step guard.
+ * 4. SKILL.md lead-line counts — the summary prose in "Scales, palettes,
+ *    themes" states totals that agents see without opening references/. Format
+ *    (keep this shape so the parser stays stable across port PRs):
+ *      `N named schemes — M categorical (…examples…) and K sequential…`
+ *      `Themes: T names (…examples…; grey/gray alias note)`
+ *    N = COLOR_SCHEME_NAMES.length, M = CATEGORICAL_SCHEME_NAMES.length,
+ *    K = SEQUENTIAL_SCHEME_NAMES.length, T = THEME_NAMES without `test`.
+ *    Reference section headers `### Categorical schemes (M)` and
+ *    `### Sequential schemes (K)` must match the same M/K.
  *
  * The `test` theme is excluded from the theme inventory on purpose: it is
  *    the internal snapshot theme, not a product surface.
@@ -25,6 +34,7 @@ import { join, relative } from "node:path";
 
 import {
   CATEGORICAL_SCHEME_NAMES,
+  COLOR_SCHEME_NAMES,
   KNOWN_GEOMS,
   KNOWN_POSITIONS,
   KNOWN_STATS,
@@ -149,4 +159,75 @@ describe("reference inventories are complete", () => {
       expect(missing).toEqual([]);
     });
   }
+});
+
+/**
+ * Product themes agents may name — every THEME_NAMES entry except the internal
+ * snapshot theme `test`. Includes `grey`/`gray` aliases of `ggplot2`.
+ */
+const PRODUCT_THEME_NAMES = THEME_NAMES.filter((name) => name !== "test");
+
+/**
+ * Lead-line inventory in SKILL.md. Table rows in references/ are already
+ * locked by the inventory suite above; this guards the short counts agents
+ * see when they only load SKILL.md (#1210).
+ */
+describe("SKILL.md lead-line scheme/theme counts match registries", () => {
+  const skillMd = readFileSync(join(SKILL_DIR, "SKILL.md"), "utf8");
+  const scalesRef = readFileSync(join(SKILL_DIR, "references", "scales-and-palettes.md"), "utf8");
+
+  it("states named scheme totals that match COLOR/CATEGORICAL/SEQUENTIAL registries", () => {
+    const match = skillMd.match(
+      /(\d+) named schemes — (\d+) categorical[\s\S]*?and (\d+) sequential/,
+    );
+    expect(match).not.toBeNull();
+    const [, total, categorical, sequential] = match!;
+    expect({
+      total: Number(total),
+      categorical: Number(categorical),
+      sequential: Number(sequential),
+    }).toEqual({
+      total: COLOR_SCHEME_NAMES.length,
+      categorical: CATEGORICAL_SCHEME_NAMES.length,
+      sequential: SEQUENTIAL_SCHEME_NAMES.length,
+    });
+  });
+
+  it("states a theme total that matches product THEME_NAMES (excludes test)", () => {
+    const match = skillMd.match(/Themes:\s*(\d+) names/);
+    expect(match).not.toBeNull();
+    expect(Number(match![1])).toBe(PRODUCT_THEME_NAMES.length);
+  });
+
+  it("reference palette section headers carry the same categorical/sequential totals", () => {
+    const cat = scalesRef.match(/### Categorical schemes \((\d+)\)/);
+    const seq = scalesRef.match(/### Sequential schemes \((\d+)\)/);
+    expect(cat).not.toBeNull();
+    expect(seq).not.toBeNull();
+    expect(Number(cat![1])).toBe(CATEGORICAL_SCHEME_NAMES.length);
+    expect(Number(seq![1])).toBe(SEQUENTIAL_SCHEME_NAMES.length);
+  });
+
+  it("lead-line example scheme names are real registry members", () => {
+    // Pull the two parenthetical example lists from the scheme lead line.
+    const match = skillMd.match(
+      /(\d+) named schemes — (\d+) categorical \(([^)]*)\)[\s\S]*?and (\d+) sequential[^(]*\(([^)]*)\)/,
+    );
+    expect(match).not.toBeNull();
+    const known = new Set<string>(COLOR_SCHEME_NAMES);
+    const examples = [...`${match![3]} ${match![5]}`.matchAll(/`([^`]+)`/g)].map((m) => m[1]!);
+    expect(examples.length).toBeGreaterThan(0);
+    const unknown = examples.filter((name) => !known.has(name));
+    expect(unknown).toEqual([]);
+  });
+
+  it("lead-line example theme names are real product themes or documented aliases", () => {
+    const match = skillMd.match(/Themes:\s*\d+ names \(([^)]*)\)/);
+    expect(match).not.toBeNull();
+    const known = new Set<string>(PRODUCT_THEME_NAMES);
+    const examples = [...match![1]!.matchAll(/`([^`]+)`/g)].map((m) => m[1]!);
+    expect(examples.length).toBeGreaterThan(0);
+    const unknown = examples.filter((name) => !known.has(name));
+    expect(unknown).toEqual([]);
+  });
 });

--- a/skills/ggsvelte/SKILL.md
+++ b/skills/ggsvelte/SKILL.md
@@ -167,7 +167,8 @@ Two rules worth keeping in working memory:
   year-quarters infer time automatically. Ambiguous ordered dates need
   `"parse": "dmy"` or `"mdy"`; force `{"type": "band"}` for year-like
   identifiers; never preprocess dates into indexes.
-- Themes: 37 names (`default`, `light`, `dark`, `minimal`, `ggplot2`, `classic`, `bw`, `hrbr`, `few`, `clean`, `fivethirtyeight`, `economist`, `tufte`, `linedraw`, `void`, `stata`, `stata_s1color`, `stata_mono`, `solarized`, `solarizeddark`, `economist_white`, `solarized_2`, `solarized_2dark`, `wsj`, `gdocs`, `hc`, `hcdark`, `pander`, `calc`, `excel`, `excel_new`, `base`, `igray`, `map`, `solid`, plus `grey`/`gray` aliasing `ggplot2`) as
+- Themes: 37 names (`default`, `minimal`, `dark`, `ggplot2`, `stata`, `wsj`,
+  `excel_new`…; `grey`/`gray` aliasing `ggplot2`) as
   `<ThemeTufte/>`-style children or `"theme": "tufte"` in JSON.
 
 Full option surfaces — every scale option, the `Scale*` component matrix, all


### PR DESCRIPTION
## Summary

Closes #1210.

- Refresh both skill `SKILL.md` copies so the theme lead line uses **counts + representative names** (full roster remains in `references/composition-surfaces.md`). Scheme lead line already matches the registries (103 / 53 categorical / 50 sequential; 37 product themes).
- Extend `scripts/skill-content.test.ts` to parse the lead lines and assert:
  - `N named schemes — M categorical … and K sequential` against `COLOR_SCHEME_NAMES` / `CATEGORICAL_SCHEME_NAMES` / `SEQUENTIAL_SCHEME_NAMES`
  - `Themes: T names` against product `THEME_NAMES` (excludes internal `test`)
  - reference headers `### Categorical schemes (M)` / `### Sequential schemes (K)`
  - backtick example names in those lead lines are real registry members
- Document the lead-line format in the test file header so port PRs know what to bump.
- Patch changeset for the shipped `packages/svelte/skills/` artifact.

## Test plan

- [x] `bun test scripts/skill-content.test.ts scripts/skill-sync.test.ts`
- [ ] CI green
- [ ] After merge, skill lead counts stay locked by the new suite when registries grow
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1220" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->