### PR TITLE
docs(skill): comprehensive themes via references/themes.md

### DIFF
--- a/.changeset/skill-themes-reference.md
+++ b/.changeset/skill-themes-reference.md
@@ -1,0 +1,12 @@
+---
+"@ggsvelte/svelte": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+docs(skill): comprehensive theme roster via references/themes.md
+
+Move the full product theme table, shells, and role overrides into
+`references/themes.md`. SKILL.md again lists every product theme name (not a
+representative subset) and points agents at the new reference. Inventory tests
+assert the lead-line list and the themes.md table against product THEME_NAMES.

--- a/packages/svelte/skills/ggsvelte/SKILL.md
+++ b/packages/svelte/skills/ggsvelte/SKILL.md
@@ -167,14 +167,22 @@ Two rules worth keeping in working memory:
   year-quarters infer time automatically. Ambiguous ordered dates need
   `"parse": "dmy"` or `"mdy"`; force `{"type": "band"}` for year-like
   identifiers; never preprocess dates into indexes.
-- Themes: 37 names (`default`, `minimal`, `dark`, `ggplot2`, `stata`, `wsj`,
-  `excel_new`…; `grey`/`gray` aliasing `ggplot2`) as
-  `<ThemeTufte/>`-style children or `"theme": "tufte"` in JSON.
+- Themes: 37 names (`default`, `light`, `dark`, `minimal`, `ggplot2`,
+  `classic`, `bw`, `hrbr`, `few`, `clean`, `fivethirtyeight`, `economist`,
+  `tufte`, `linedraw`, `void`, `stata`, `stata_s1color`, `stata_mono`,
+  `solarized`, `solarizeddark`, `economist_white`, `solarized_2`,
+  `solarized_2dark`, `wsj`, `gdocs`, `hc`, `hcdark`, `pander`, `calc`,
+  `excel`, `excel_new`, `base`, `igray`, `map`, `solid`, plus `grey`/`gray`
+  aliasing `ggplot2`) as `<ThemeTufte/>`-style children or `"theme": "tufte"`
+  in JSON. Looks, shells, and role overrides:
+  [references/themes.md](references/themes.md).
 
 Full option surfaces — every scale option, the `Scale*` component matrix, all
 scheme tables, the whole temporal/parser system:
 [references/scales-and-palettes.md](references/scales-and-palettes.md).
-Themes, coords, facets, guides, legend order, and `Labs` in depth:
+Theme roster and shells:
+[references/themes.md](references/themes.md). Coords, facets, guides, legend
+order, and `Labs`:
 [references/composition-surfaces.md](references/composition-surfaces.md).
 
 ## The validation contract (use it!)
@@ -273,7 +281,9 @@ writing any interactive or linked-view code.
   beyond the everyday set, annotations),
   [scales-and-palettes.md](references/scales-and-palettes.md) (scale options,
   palettes, temporal),
-  [composition-surfaces.md](references/composition-surfaces.md) (themes,
-  coords, facets, guides, merge semantics),
+  [themes.md](references/themes.md) (every product theme name, shells,
+  role overrides),
+  [composition-surfaces.md](references/composition-surfaces.md) (coords,
+  facets, guides, merge semantics),
   [interactions.md](references/interactions.md) (tooltips, selection, linking),
   [recipes.md](references/recipes.md) (long-tail chart recipes).

--- a/packages/svelte/skills/ggsvelte/references/composition-surfaces.md
+++ b/packages/svelte/skills/ggsvelte/references/composition-surfaces.md
@@ -1,6 +1,6 @@
-<!-- Source of truth: packages/spec/src/schema-names.ts (THEME_NAMES), packages/svelte/src/lib/index.ts (component exports), packages/svelte/src/lib/plot-props.ts, packages/svelte/src/lib/layers/ (merge semantics, grammar-families). Inventory tables are asserted complete by scripts/skill-content.test.ts. -->
+<!-- Source of truth: packages/svelte/src/lib/index.ts (component exports), packages/svelte/src/lib/plot-props.ts, packages/svelte/src/lib/layers/ (merge semantics, grammar-families). Theme roster lives in themes.md (asserted complete by scripts/skill-content.test.ts). -->
 
-# Composition surfaces: themes, coords, facets, guides, labs
+# Composition surfaces: coords, facets, guides, labs
 
 Every surface here exists in three equivalent forms: a key in the JSON
 `PortableSpec`, a deprecated `<GGPlot>` prop (removable in 0.13.0), and a
@@ -10,61 +10,9 @@ no markup, register on init, unregister on destroy, and are inert without a
 
 ## Themes
 
-JSON form: `"theme": "minimal"` (a registered name) or a theme object —
-optional `"name"` base plus role overrides, e.g.
-`{"name": "dark", "ink": "#eee"}`. `grey` and `gray` are registered aliases of
-`ggplot2` (same token map).
-
-| Name                    | Look                                                                       |
-| ----------------------- | -------------------------------------------------------------------------- |
-| default                 | quiet hrbrthemes-style base: real typography, hairline grid, no axis frame |
-| light                   | light grid, thin panel border, x/y ticks                                   |
-| dark                    | dark paper and panel, light ink                                            |
-| minimal                 | light grid only, no ticks or border                                        |
-| ggplot2                 | classic grey panel, white grid                                             |
-| classic                 | no grid, black axis lines and ticks                                        |
-| bw                      | white panel, grey grid, black rectangular border (print/B&W)               |
-| hrbr                    | same token map as default                                                  |
-| few                     | no grid, thin panel border (Stephen Few)                                   |
-| clean                   | dashed y grid only, axis lines and ticks                                   |
-| fivethirtyeight         | grey paper and panel, white grid, blue accent                              |
-| economist               | pale blue paper, white grid, x ticks, red accent                           |
-| tufte                   | monochrome ink, no grid                                                    |
-| linedraw                | black-on-white line art: hairline black grid, black border                 |
-| void                    | no axes, grid, or panel chrome; marks and legends remain                   |
-| stata                   | Stata s2color: bluish-gray plot region, white panel, y-grid                |
-| stata_s1color           | Stata s1color: white panel with black border, light y-grid                 |
-| stata_mono              | Stata s2mono: gray plot region, monochrome y-grid                          |
-| solarized               | Solarized light: cream panel, muted base1 chrome, blue accent              |
-| solarizeddark           | Solarized dark: deep teal panel, muted base01 chrome, blue accent          |
-| economist_white         | Economist Graphic Detail: white panel, gray grid, light-gray paper         |
-| solarized_2             | Solarized grey-style variant: base2 panel, base3 grid, no frame            |
-| solarized_2dark         | solarized_2 on dark base tones                                             |
-| wsj                     | Wall Street Journal: brown paper, dotted black y-grid, x line + ticks      |
-| gdocs                   | Google Docs: black x line, no ticks, light-gray grid, plain 20px title     |
-| hc                      | Highcharts default: y-only #D8D8D8 grid on white, no border                |
-| hcdark                  | Highcharts darkunica: #2a2a2b paper, #707073 y-grid                        |
-| pander                  | pander: dashed grey grid and ticks, bold title on white                    |
-| calc                    | LibreOffice Calc: white panel, gray70 border + y-grid, no axis lines       |
-| excel                   | Excel 97 classic: gray panel, black y-grid + border (horizontal=TRUE)      |
-| excel_new               | modern Excel: dark-gray ink, hairline #bfbfbf y-grid, no ticks or border   |
-| base                    | base R: black frame and ticks, no grid, bold title                         |
-| igray                   | inverse gray: white panel, gray90 surround and grid                        |
-| map                     | every axis/panel/grid element blank — marks only, for maps                 |
-| solid                   | nothing but marks — every non-geom element removed                         |
-| grey (alias of ggplot2) | UK theme_grey                                                              |
-| gray (alias of ggplot2) | US theme_gray                                                              |
-
-Svelte: one named shell per product theme — `ThemeDefault`, `ThemeLight`,
-`ThemeDark`, `ThemeMinimal`, `ThemeGgplot2`, `ThemeClassic`, `ThemeBw`,
-`ThemeHrbr`, `ThemeFew`, `ThemeClean`, `ThemeFivethirtyeight`,
-`ThemeEconomist`, `ThemeTufte`, `ThemeLinedraw`, `ThemeVoid`, `ThemeStata`, `ThemeStatas1color`, `ThemeStatamono`, `ThemeSolarized`,
-`ThemeSolarizeddark`, `ThemeEconomistwhite`, `ThemeSolarized2`, `ThemeSolarized2dark`,
-`ThemeWsj`, `ThemeGdocs`, `ThemeHc`, `ThemeHcdark`, `ThemePander`, `ThemeCalc`, `ThemeExcel`, `ThemeExcelnew`, `ThemeBase`, `ThemeIgray`, `ThemeMap`, `ThemeSolid`, `ThemeGrey`, `ThemeGray`. Escape hatch `<Theme name={dynamicName} />` for
-reactive names.
-Every shell and `<Theme>` also accepts role-override props (`ink`, `paper`,
-`accent`, `grid`, `panel`, `axisText`, `axisLine`, `tickColor`,
-`panelBorder`, tooltip/selection/focus roles, …): `<ThemeDark ink="#eee" />`.
+Full product roster (37 names), shells, and role overrides:
+[themes.md](themes.md). Theme is a REPLACE family (last registration wins) —
+see replace-vs-merge below.
 
 ## Coords
 

--- a/packages/svelte/skills/ggsvelte/references/themes.md
+++ b/packages/svelte/skills/ggsvelte/references/themes.md
@@ -1,0 +1,96 @@
+<!-- Source of truth: packages/spec/src/schema-names.ts (THEME_NAMES, THEME_NAME_ALIASES), packages/core/src/theme-builtins.ts (token maps), packages/svelte/src/lib (Theme* shells). Inventory table is asserted complete by scripts/skill-content.test.ts. -->
+
+# Themes
+
+JSON form: `"theme": "minimal"` (a registered name) or a theme object —
+optional `"name"` base plus role overrides, e.g.
+`{"name": "dark", "ink": "#eee"}`. `grey` and `gray` are registered aliases of
+`ggplot2` (same token map). Theme is a REPLACE grammar family on `<GGPlot>`
+(last child wins) — merge rules live in
+[composition-surfaces.md](composition-surfaces.md).
+
+## Product themes (37)
+
+| Name                    | Look                                                                       |
+| ----------------------- | -------------------------------------------------------------------------- |
+| default                 | quiet hrbrthemes-style base: real typography, hairline grid, no axis frame |
+| light                   | light grid, thin panel border, x/y ticks                                   |
+| dark                    | dark paper and panel, light ink                                            |
+| minimal                 | light grid only, no ticks or border                                        |
+| ggplot2                 | classic grey panel, white grid                                             |
+| classic                 | no grid, black axis lines and ticks                                        |
+| bw                      | white panel, grey grid, black rectangular border (print/B&W)               |
+| hrbr                    | same token map as default                                                  |
+| few                     | no grid, thin panel border (Stephen Few)                                   |
+| clean                   | dashed y grid only, axis lines and ticks                                   |
+| fivethirtyeight         | grey paper and panel, white grid, blue accent                              |
+| economist               | pale blue paper, white grid, x ticks, red accent                           |
+| tufte                   | monochrome ink, no grid                                                    |
+| linedraw                | black-on-white line art: hairline black grid, black border                 |
+| void                    | no axes, grid, or panel chrome; marks and legends remain                   |
+| stata                   | Stata s2color: bluish-gray plot region, white panel, y-grid                |
+| stata_s1color           | Stata s1color: white panel with black border, light y-grid                 |
+| stata_mono              | Stata s2mono: gray plot region, monochrome y-grid                          |
+| solarized               | Solarized light: cream panel, muted base1 chrome, blue accent              |
+| solarizeddark           | Solarized dark: deep teal panel, muted base01 chrome, blue accent          |
+| economist_white         | Economist Graphic Detail: white panel, gray grid, light-gray paper         |
+| solarized_2             | Solarized grey-style variant: base2 panel, base3 grid, no frame            |
+| solarized_2dark         | solarized_2 on dark base tones                                             |
+| wsj                     | Wall Street Journal: brown paper, dotted black y-grid, x line + ticks      |
+| gdocs                   | Google Docs: black x line, no ticks, light-gray grid, plain 20px title     |
+| hc                      | Highcharts default: y-only #D8D8D8 grid on white, no border                |
+| hcdark                  | Highcharts darkunica: #2a2a2b paper, #707073 y-grid                        |
+| pander                  | pander: dashed grey grid and ticks, bold title on white                    |
+| calc                    | LibreOffice Calc: white panel, gray70 border + y-grid, no axis lines       |
+| excel                   | Excel 97 classic: gray panel, black y-grid + border (horizontal=TRUE)      |
+| excel_new               | modern Excel: dark-gray ink, hairline #bfbfbf y-grid, no ticks or border   |
+| base                    | base R: black frame and ticks, no grid, bold title                         |
+| igray                   | inverse gray: white panel, gray90 surround and grid                        |
+| map                     | every axis/panel/grid element blank — marks only, for maps                 |
+| solid                   | nothing but marks — every non-geom element removed                         |
+| grey (alias of ggplot2) | UK theme_grey                                                              |
+| gray (alias of ggplot2) | US theme_gray                                                              |
+
+The internal `test` theme exists for snapshots only — not a product surface;
+do not document or recommend it.
+
+## Svelte shells and overrides
+
+One named shell per product theme — `ThemeDefault`, `ThemeLight`,
+`ThemeDark`, `ThemeMinimal`, `ThemeGgplot2`, `ThemeClassic`, `ThemeBw`,
+`ThemeHrbr`, `ThemeFew`, `ThemeClean`, `ThemeFivethirtyeight`,
+`ThemeEconomist`, `ThemeTufte`, `ThemeLinedraw`, `ThemeVoid`, `ThemeStata`,
+`ThemeStatas1color`, `ThemeStatamono`, `ThemeSolarized`,
+`ThemeSolarizeddark`, `ThemeEconomistwhite`, `ThemeSolarized2`,
+`ThemeSolarized2dark`, `ThemeWsj`, `ThemeGdocs`, `ThemeHc`, `ThemeHcdark`,
+`ThemePander`, `ThemeCalc`, `ThemeExcel`, `ThemeExcelnew`, `ThemeBase`,
+`ThemeIgray`, `ThemeMap`, `ThemeSolid`, `ThemeGrey`, `ThemeGray`. Escape
+hatch `<Theme name={dynamicName} />` for reactive names.
+
+Every shell and `<Theme>` also accepts role-override props (`ink`, `paper`,
+`accent`, `grid`, `panel`, `axisText`, `axisLine`, `tickColor`,
+`panelBorder`, tooltip/selection/focus roles, …): `<ThemeDark ink="#eee" />`.
+
+```svelte fragment
+<GGPlot data={rows} aes={{ x: "displ", y: "hwy" }} layers={[{ geom: "point" }]}>
+  <ThemeEconomist />
+</GGPlot>
+```
+
+```json complete
+{
+  "data": {
+    "values": [
+      { "displ": 1.8, "hwy": 29 },
+      { "displ": 3.5, "hwy": 26 }
+    ]
+  },
+  "layers": [
+    {
+      "geom": "point",
+      "aes": { "x": { "field": "displ" }, "y": { "field": "hwy" } }
+    }
+  ],
+  "theme": "economist"
+}
+```

--- a/scripts/skill-content.test.ts
+++ b/scripts/skill-content.test.ts
@@ -15,13 +15,15 @@
  *    for every geom, stat, position, theme, and color scheme the spec knows.
  *    Adding one upstream turns the skill red until it is documented; this is
  *    the pre-changesets lock-step guard.
- * 4. SKILL.md lead-line counts — the summary prose in "Scales, palettes,
- *    themes" states totals that agents see without opening references/. Format
- *    (keep this shape so the parser stays stable across port PRs):
+ * 4. SKILL.md lead-line inventory — the summary prose in "Scales, palettes,
+ *    themes" states totals (and for themes, the **full product name list**)
+ *    that agents see without opening references/. Format:
  *      `N named schemes — M categorical (…examples…) and K sequential…`
- *      `Themes: T names (…examples…; grey/gray alias note)`
+ *      `Themes: T names (`name`, `name`, … plus `grey`/`gray` alias note)`
  *    N = COLOR_SCHEME_NAMES.length, M = CATEGORICAL_SCHEME_NAMES.length,
  *    K = SEQUENTIAL_SCHEME_NAMES.length, T = THEME_NAMES without `test`.
+ *    Theme lead line must name every product theme (comprehensive — not a
+ *    representative subset). Full looks/shells live in references/themes.md.
  *    Reference section headers `### Categorical schemes (M)` and
  *    `### Sequential schemes (K)` must match the same M/K.
  *
@@ -135,7 +137,7 @@ describe("reference inventories are complete", () => {
     { file: "geoms-and-stats.md", label: "stats", names: KNOWN_STATS },
     { file: "geoms-and-stats.md", label: "positions", names: KNOWN_POSITIONS },
     {
-      file: "composition-surfaces.md",
+      file: "themes.md",
       label: "themes",
       // `test` is the internal snapshot theme — deliberately undocumented.
       names: THEME_NAMES.filter((name) => name !== "test"),
@@ -169,12 +171,14 @@ const PRODUCT_THEME_NAMES = THEME_NAMES.filter((name) => name !== "test");
 
 /**
  * Lead-line inventory in SKILL.md. Table rows in references/ are already
- * locked by the inventory suite above; this guards the short counts agents
- * see when they only load SKILL.md (#1210).
+ * locked by the inventory suite above; this guards the counts (and the
+ * comprehensive theme name list) agents see when they only load SKILL.md
+ * (#1210).
  */
-describe("SKILL.md lead-line scheme/theme counts match registries", () => {
+describe("SKILL.md lead-line scheme/theme inventory matches registries", () => {
   const skillMd = readFileSync(join(SKILL_DIR, "SKILL.md"), "utf8");
   const scalesRef = readFileSync(join(SKILL_DIR, "references", "scales-and-palettes.md"), "utf8");
+  const themesRef = readFileSync(join(SKILL_DIR, "references", "themes.md"), "utf8");
 
   it("states named scheme totals that match COLOR/CATEGORICAL/SEQUENTIAL registries", () => {
     const match = skillMd.match(
@@ -208,6 +212,12 @@ describe("SKILL.md lead-line scheme/theme counts match registries", () => {
     expect(Number(seq![1])).toBe(SEQUENTIAL_SCHEME_NAMES.length);
   });
 
+  it("themes.md product-theme heading carries the product theme total", () => {
+    const match = themesRef.match(/## Product themes \((\d+)\)/);
+    expect(match).not.toBeNull();
+    expect(Number(match![1])).toBe(PRODUCT_THEME_NAMES.length);
+  });
+
   it("lead-line example scheme names are real registry members", () => {
     // Pull the two parenthetical example lists from the scheme lead line.
     const match = skillMd.match(
@@ -221,13 +231,14 @@ describe("SKILL.md lead-line scheme/theme counts match registries", () => {
     expect(unknown).toEqual([]);
   });
 
-  it("lead-line example theme names are real product themes or documented aliases", () => {
-    const match = skillMd.match(/Themes:\s*\d+ names \(([^)]*)\)/);
+  it("SKILL.md theme lead lists every product theme name (comprehensive)", () => {
+    // Themes: T names (`a`, `b`, … plus `grey`/`gray` aliasing `ggplot2`)
+    // Allow multi-line parentheticals: stop at the first `) as` that closes
+    // the lead (the alias note uses `grey`/`gray` without a bare `)`).
+    const match = skillMd.match(/Themes:\s*\d+ names \(([\s\S]*?)\) as/);
     expect(match).not.toBeNull();
-    const known = new Set<string>(PRODUCT_THEME_NAMES);
-    const examples = [...match![1]!.matchAll(/`([^`]+)`/g)].map((m) => m[1]!);
-    expect(examples.length).toBeGreaterThan(0);
-    const unknown = examples.filter((name) => !known.has(name));
-    expect(unknown).toEqual([]);
+    const listed = new Set([...match![1]!.matchAll(/`([^`]+)`/g)].map((m) => m[1]!));
+    const missing = PRODUCT_THEME_NAMES.filter((name) => !listed.has(name));
+    expect(missing).toEqual([]);
   });
 });

--- a/skills/ggsvelte/SKILL.md
+++ b/skills/ggsvelte/SKILL.md
@@ -167,14 +167,22 @@ Two rules worth keeping in working memory:
   year-quarters infer time automatically. Ambiguous ordered dates need
   `"parse": "dmy"` or `"mdy"`; force `{"type": "band"}` for year-like
   identifiers; never preprocess dates into indexes.
-- Themes: 37 names (`default`, `minimal`, `dark`, `ggplot2`, `stata`, `wsj`,
-  `excel_new`…; `grey`/`gray` aliasing `ggplot2`) as
-  `<ThemeTufte/>`-style children or `"theme": "tufte"` in JSON.
+- Themes: 37 names (`default`, `light`, `dark`, `minimal`, `ggplot2`,
+  `classic`, `bw`, `hrbr`, `few`, `clean`, `fivethirtyeight`, `economist`,
+  `tufte`, `linedraw`, `void`, `stata`, `stata_s1color`, `stata_mono`,
+  `solarized`, `solarizeddark`, `economist_white`, `solarized_2`,
+  `solarized_2dark`, `wsj`, `gdocs`, `hc`, `hcdark`, `pander`, `calc`,
+  `excel`, `excel_new`, `base`, `igray`, `map`, `solid`, plus `grey`/`gray`
+  aliasing `ggplot2`) as `<ThemeTufte/>`-style children or `"theme": "tufte"`
+  in JSON. Looks, shells, and role overrides:
+  [references/themes.md](references/themes.md).
 
 Full option surfaces — every scale option, the `Scale*` component matrix, all
 scheme tables, the whole temporal/parser system:
 [references/scales-and-palettes.md](references/scales-and-palettes.md).
-Themes, coords, facets, guides, legend order, and `Labs` in depth:
+Theme roster and shells:
+[references/themes.md](references/themes.md). Coords, facets, guides, legend
+order, and `Labs`:
 [references/composition-surfaces.md](references/composition-surfaces.md).
 
 ## The validation contract (use it!)
@@ -273,7 +281,9 @@ writing any interactive or linked-view code.
   beyond the everyday set, annotations),
   [scales-and-palettes.md](references/scales-and-palettes.md) (scale options,
   palettes, temporal),
-  [composition-surfaces.md](references/composition-surfaces.md) (themes,
-  coords, facets, guides, merge semantics),
+  [themes.md](references/themes.md) (every product theme name, shells,
+  role overrides),
+  [composition-surfaces.md](references/composition-surfaces.md) (coords,
+  facets, guides, merge semantics),
   [interactions.md](references/interactions.md) (tooltips, selection, linking),
   [recipes.md](references/recipes.md) (long-tail chart recipes).

--- a/skills/ggsvelte/references/composition-surfaces.md
+++ b/skills/ggsvelte/references/composition-surfaces.md
@@ -1,6 +1,6 @@
-<!-- Source of truth: packages/spec/src/schema-names.ts (THEME_NAMES), packages/svelte/src/lib/index.ts (component exports), packages/svelte/src/lib/plot-props.ts, packages/svelte/src/lib/layers/ (merge semantics, grammar-families). Inventory tables are asserted complete by scripts/skill-content.test.ts. -->
+<!-- Source of truth: packages/svelte/src/lib/index.ts (component exports), packages/svelte/src/lib/plot-props.ts, packages/svelte/src/lib/layers/ (merge semantics, grammar-families). Theme roster lives in themes.md (asserted complete by scripts/skill-content.test.ts). -->
 
-# Composition surfaces: themes, coords, facets, guides, labs
+# Composition surfaces: coords, facets, guides, labs
 
 Every surface here exists in three equivalent forms: a key in the JSON
 `PortableSpec`, a deprecated `<GGPlot>` prop (removable in 0.13.0), and a
@@ -10,61 +10,9 @@ no markup, register on init, unregister on destroy, and are inert without a
 
 ## Themes
 
-JSON form: `"theme": "minimal"` (a registered name) or a theme object —
-optional `"name"` base plus role overrides, e.g.
-`{"name": "dark", "ink": "#eee"}`. `grey` and `gray` are registered aliases of
-`ggplot2` (same token map).
-
-| Name                    | Look                                                                       |
-| ----------------------- | -------------------------------------------------------------------------- |
-| default                 | quiet hrbrthemes-style base: real typography, hairline grid, no axis frame |
-| light                   | light grid, thin panel border, x/y ticks                                   |
-| dark                    | dark paper and panel, light ink                                            |
-| minimal                 | light grid only, no ticks or border                                        |
-| ggplot2                 | classic grey panel, white grid                                             |
-| classic                 | no grid, black axis lines and ticks                                        |
-| bw                      | white panel, grey grid, black rectangular border (print/B&W)               |
-| hrbr                    | same token map as default                                                  |
-| few                     | no grid, thin panel border (Stephen Few)                                   |
-| clean                   | dashed y grid only, axis lines and ticks                                   |
-| fivethirtyeight         | grey paper and panel, white grid, blue accent                              |
-| economist               | pale blue paper, white grid, x ticks, red accent                           |
-| tufte                   | monochrome ink, no grid                                                    |
-| linedraw                | black-on-white line art: hairline black grid, black border                 |
-| void                    | no axes, grid, or panel chrome; marks and legends remain                   |
-| stata                   | Stata s2color: bluish-gray plot region, white panel, y-grid                |
-| stata_s1color           | Stata s1color: white panel with black border, light y-grid                 |
-| stata_mono              | Stata s2mono: gray plot region, monochrome y-grid                          |
-| solarized               | Solarized light: cream panel, muted base1 chrome, blue accent              |
-| solarizeddark           | Solarized dark: deep teal panel, muted base01 chrome, blue accent          |
-| economist_white         | Economist Graphic Detail: white panel, gray grid, light-gray paper         |
-| solarized_2             | Solarized grey-style variant: base2 panel, base3 grid, no frame            |
-| solarized_2dark         | solarized_2 on dark base tones                                             |
-| wsj                     | Wall Street Journal: brown paper, dotted black y-grid, x line + ticks      |
-| gdocs                   | Google Docs: black x line, no ticks, light-gray grid, plain 20px title     |
-| hc                      | Highcharts default: y-only #D8D8D8 grid on white, no border                |
-| hcdark                  | Highcharts darkunica: #2a2a2b paper, #707073 y-grid                        |
-| pander                  | pander: dashed grey grid and ticks, bold title on white                    |
-| calc                    | LibreOffice Calc: white panel, gray70 border + y-grid, no axis lines       |
-| excel                   | Excel 97 classic: gray panel, black y-grid + border (horizontal=TRUE)      |
-| excel_new               | modern Excel: dark-gray ink, hairline #bfbfbf y-grid, no ticks or border   |
-| base                    | base R: black frame and ticks, no grid, bold title                         |
-| igray                   | inverse gray: white panel, gray90 surround and grid                        |
-| map                     | every axis/panel/grid element blank — marks only, for maps                 |
-| solid                   | nothing but marks — every non-geom element removed                         |
-| grey (alias of ggplot2) | UK theme_grey                                                              |
-| gray (alias of ggplot2) | US theme_gray                                                              |
-
-Svelte: one named shell per product theme — `ThemeDefault`, `ThemeLight`,
-`ThemeDark`, `ThemeMinimal`, `ThemeGgplot2`, `ThemeClassic`, `ThemeBw`,
-`ThemeHrbr`, `ThemeFew`, `ThemeClean`, `ThemeFivethirtyeight`,
-`ThemeEconomist`, `ThemeTufte`, `ThemeLinedraw`, `ThemeVoid`, `ThemeStata`, `ThemeStatas1color`, `ThemeStatamono`, `ThemeSolarized`,
-`ThemeSolarizeddark`, `ThemeEconomistwhite`, `ThemeSolarized2`, `ThemeSolarized2dark`,
-`ThemeWsj`, `ThemeGdocs`, `ThemeHc`, `ThemeHcdark`, `ThemePander`, `ThemeCalc`, `ThemeExcel`, `ThemeExcelnew`, `ThemeBase`, `ThemeIgray`, `ThemeMap`, `ThemeSolid`, `ThemeGrey`, `ThemeGray`. Escape hatch `<Theme name={dynamicName} />` for
-reactive names.
-Every shell and `<Theme>` also accepts role-override props (`ink`, `paper`,
-`accent`, `grid`, `panel`, `axisText`, `axisLine`, `tickColor`,
-`panelBorder`, tooltip/selection/focus roles, …): `<ThemeDark ink="#eee" />`.
+Full product roster (37 names), shells, and role overrides:
+[themes.md](themes.md). Theme is a REPLACE family (last registration wins) —
+see replace-vs-merge below.
 
 ## Coords
 

--- a/skills/ggsvelte/references/themes.md
+++ b/skills/ggsvelte/references/themes.md
@@ -1,0 +1,96 @@
+<!-- Source of truth: packages/spec/src/schema-names.ts (THEME_NAMES, THEME_NAME_ALIASES), packages/core/src/theme-builtins.ts (token maps), packages/svelte/src/lib (Theme* shells). Inventory table is asserted complete by scripts/skill-content.test.ts. -->
+
+# Themes
+
+JSON form: `"theme": "minimal"` (a registered name) or a theme object —
+optional `"name"` base plus role overrides, e.g.
+`{"name": "dark", "ink": "#eee"}`. `grey` and `gray` are registered aliases of
+`ggplot2` (same token map). Theme is a REPLACE grammar family on `<GGPlot>`
+(last child wins) — merge rules live in
+[composition-surfaces.md](composition-surfaces.md).
+
+## Product themes (37)
+
+| Name                    | Look                                                                       |
+| ----------------------- | -------------------------------------------------------------------------- |
+| default                 | quiet hrbrthemes-style base: real typography, hairline grid, no axis frame |
+| light                   | light grid, thin panel border, x/y ticks                                   |
+| dark                    | dark paper and panel, light ink                                            |
+| minimal                 | light grid only, no ticks or border                                        |
+| ggplot2                 | classic grey panel, white grid                                             |
+| classic                 | no grid, black axis lines and ticks                                        |
+| bw                      | white panel, grey grid, black rectangular border (print/B&W)               |
+| hrbr                    | same token map as default                                                  |
+| few                     | no grid, thin panel border (Stephen Few)                                   |
+| clean                   | dashed y grid only, axis lines and ticks                                   |
+| fivethirtyeight         | grey paper and panel, white grid, blue accent                              |
+| economist               | pale blue paper, white grid, x ticks, red accent                           |
+| tufte                   | monochrome ink, no grid                                                    |
+| linedraw                | black-on-white line art: hairline black grid, black border                 |
+| void                    | no axes, grid, or panel chrome; marks and legends remain                   |
+| stata                   | Stata s2color: bluish-gray plot region, white panel, y-grid                |
+| stata_s1color           | Stata s1color: white panel with black border, light y-grid                 |
+| stata_mono              | Stata s2mono: gray plot region, monochrome y-grid                          |
+| solarized               | Solarized light: cream panel, muted base1 chrome, blue accent              |
+| solarizeddark           | Solarized dark: deep teal panel, muted base01 chrome, blue accent          |
+| economist_white         | Economist Graphic Detail: white panel, gray grid, light-gray paper         |
+| solarized_2             | Solarized grey-style variant: base2 panel, base3 grid, no frame            |
+| solarized_2dark         | solarized_2 on dark base tones                                             |
+| wsj                     | Wall Street Journal: brown paper, dotted black y-grid, x line + ticks      |
+| gdocs                   | Google Docs: black x line, no ticks, light-gray grid, plain 20px title     |
+| hc                      | Highcharts default: y-only #D8D8D8 grid on white, no border                |
+| hcdark                  | Highcharts darkunica: #2a2a2b paper, #707073 y-grid                        |
+| pander                  | pander: dashed grey grid and ticks, bold title on white                    |
+| calc                    | LibreOffice Calc: white panel, gray70 border + y-grid, no axis lines       |
+| excel                   | Excel 97 classic: gray panel, black y-grid + border (horizontal=TRUE)      |
+| excel_new               | modern Excel: dark-gray ink, hairline #bfbfbf y-grid, no ticks or border   |
+| base                    | base R: black frame and ticks, no grid, bold title                         |
+| igray                   | inverse gray: white panel, gray90 surround and grid                        |
+| map                     | every axis/panel/grid element blank — marks only, for maps                 |
+| solid                   | nothing but marks — every non-geom element removed                         |
+| grey (alias of ggplot2) | UK theme_grey                                                              |
+| gray (alias of ggplot2) | US theme_gray                                                              |
+
+The internal `test` theme exists for snapshots only — not a product surface;
+do not document or recommend it.
+
+## Svelte shells and overrides
+
+One named shell per product theme — `ThemeDefault`, `ThemeLight`,
+`ThemeDark`, `ThemeMinimal`, `ThemeGgplot2`, `ThemeClassic`, `ThemeBw`,
+`ThemeHrbr`, `ThemeFew`, `ThemeClean`, `ThemeFivethirtyeight`,
+`ThemeEconomist`, `ThemeTufte`, `ThemeLinedraw`, `ThemeVoid`, `ThemeStata`,
+`ThemeStatas1color`, `ThemeStatamono`, `ThemeSolarized`,
+`ThemeSolarizeddark`, `ThemeEconomistwhite`, `ThemeSolarized2`,
+`ThemeSolarized2dark`, `ThemeWsj`, `ThemeGdocs`, `ThemeHc`, `ThemeHcdark`,
+`ThemePander`, `ThemeCalc`, `ThemeExcel`, `ThemeExcelnew`, `ThemeBase`,
+`ThemeIgray`, `ThemeMap`, `ThemeSolid`, `ThemeGrey`, `ThemeGray`. Escape
+hatch `<Theme name={dynamicName} />` for reactive names.
+
+Every shell and `<Theme>` also accepts role-override props (`ink`, `paper`,
+`accent`, `grid`, `panel`, `axisText`, `axisLine`, `tickColor`,
+`panelBorder`, tooltip/selection/focus roles, …): `<ThemeDark ink="#eee" />`.
+
+```svelte fragment
+<GGPlot data={rows} aes={{ x: "displ", y: "hwy" }} layers={[{ geom: "point" }]}>
+  <ThemeEconomist />
+</GGPlot>
+```
+
+```json complete
+{
+  "data": {
+    "values": [
+      { "displ": 1.8, "hwy": 29 },
+      { "displ": 3.5, "hwy": 26 }
+    ]
+  },
+  "layers": [
+    {
+      "geom": "point",
+      "aes": { "x": { "field": "displ" }, "y": { "field": "hwy" } }
+    }
+  ],
+  "theme": "economist"
+}
+```


### PR DESCRIPTION
## Summary

Follow-up to #1220: the "representative" theme lead was the wrong call.

- New **`references/themes.md`**: full product roster (37 names), looks, `Theme*` shells, role overrides, JSON/Svelte examples.
- **`SKILL.md`** again lists **every** product theme name and points at `themes.md`.
- **`composition-surfaces.md`**: theme detail removed; short pointer + REPLACE-family note.
- **Tests**: inventory themes from `themes.md`; assert the SKILL.md theme lead is a **comprehensive** product-name list (missing names fail); heading count on `## Product themes (N)`.

## Test plan

- [x] `bun test scripts/skill-content.test.ts scripts/skill-sync.test.ts`
- [ ] CI green
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1221" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->