### PR TITLE
perf(spec): one field-evidence pass for validate + dataChecks

### DIFF
--- a/.changeset/single-evidence-pass.md
+++ b/.changeset/single-evidence-pass.md
@@ -1,0 +1,16 @@
+---
+"@ggsvelte/spec": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+perf(spec): one field-evidence pass for validate + dataChecks
+
+`validate(spec, options)` now builds plot and layer field evidence once via
+`resolveLayerFieldEvidence` and shares it with data-aware checks and lint,
+instead of pivoting/type-scanning plot tables twice.
+
+When aggregate plot+layer tables exceed maxRows/maxBytes, data-backed lint
+advisories are skipped (no plot-only evidence handoff on that error path).
+
+Migration: none for valid under-limit specs

--- a/packages/spec/src/validate-data-checks.ts
+++ b/packages/spec/src/validate-data-checks.ts
@@ -14,18 +14,17 @@
  * position (#609 / #844): multi-table layers that share a field name keep their
  * own type evidence. The last-wins union `fields` map remains a fallback only.
  *
- * Consumes a FieldEvidenceMap built by validate-data-evidence.ts (or builds one
- * when not pre-resolved).
+ * Evidence is one `resolveLayerFieldEvidence` pass (plot + per-layer tables).
+ * validate() may pre-resolve and pass the result so lint shares the same pass.
  */
 import type { SpecError } from "./errors.js";
 import type { Aes, ChannelName } from "./schema.js";
 import type { ValidateLimits, ValidateOptions } from "./validate-data.js";
 import type { TemporalDecision } from "./temporal-column.js";
 import {
-  resolveFieldEvidence,
   resolveLayerFieldEvidence,
   type FieldEvidenceMap,
-  type ResolveFieldEvidenceResult,
+  type ResolveLayerFieldEvidenceResult,
 } from "./validate-data-evidence.js";
 import { checkColorScaleDataCompatibility } from "./validate-data-checks-color.js";
 import { collectLayerDataChecks, STAT_COLUMNS } from "./validate-data-checks-layer.js";
@@ -49,8 +48,11 @@ export function dataChecks(
   spec: Record<string, unknown>,
   options: ValidateOptions,
   limits: ValidateLimits,
-  /** Pre-resolved evidence from validate() so lint can share the same pass. */
-  preResolved?: ResolveFieldEvidenceResult,
+  /**
+   * Pre-resolved layer evidence from validate() so the pivot/type pass runs
+   * once and can be shared with lintSpec.
+   */
+  preResolvedLayer?: ResolveLayerFieldEvidenceResult,
 ): SpecError[] {
   const errors: SpecError[] = [];
   // One cache per dataChecks call — shared by position, color, and style checkers.
@@ -62,20 +64,13 @@ export function dataChecks(
   errors.push(...temporalConfig.errors);
   const { invalidTemporalAxes } = temporalConfig;
 
-  // Prefer per-layer evidence when available (#589); fall back to plot-level
-  // resolveFieldEvidence for preResolved/lint sharing and profile mode.
-  const layerResolved = resolveLayerFieldEvidence(spec, options, limits);
+  // One pass over plot + layer tables (#589 multi-table evidence).
+  const layerResolved = preResolvedLayer ?? resolveLayerFieldEvidence(spec, options, limits);
   if (layerResolved.status === "errors") return [...errors, ...layerResolved.errors];
+  if (layerResolved.status === "none") return errors;
 
-  const resolved = preResolved ?? resolveFieldEvidence(spec, options, limits);
-  if (resolved.status === "errors") return [...errors, ...resolved.errors];
-  if (resolved.status === "none" && layerResolved.status === "none") return errors;
-  const plotFields: FieldEvidenceMap | null =
-    layerResolved.status === "ok"
-      ? layerResolved.plot
-      : resolved.status === "ok"
-        ? resolved.fields
-        : null;
+  const plotFields: FieldEvidenceMap | null = layerResolved.plot;
+  const layerMaps = layerResolved.layers;
 
   const plotAes = isRecord(spec["aes"]) ? (spec["aes"] as Aes) : undefined;
   const layers = Array.isArray(spec["layers"]) ? (spec["layers"] as unknown[]) : [];
@@ -89,7 +84,6 @@ export function dataChecks(
     return axis !== null && scaleRequestsTime(scales, axis);
   };
 
-  const layerMaps = layerResolved.status === "ok" ? layerResolved.layers : null;
   const walk = collectLayerDataChecks({
     layers,
     plotAes,
@@ -104,18 +98,13 @@ export function dataChecks(
   // style, and color scale checks prefer per-layer evidence via evidenceForUse
   // so same field names on different tables stay independent (#609 / #844).
   const fields: FieldEvidenceMap = new Map(plotFields ?? undefined);
-  if (layerResolved.status === "ok") {
-    for (const layerMap of layerResolved.layers) {
-      if (layerMap === null) continue;
-      for (const [name, entry] of layerMap) fields.set(name, entry);
-    }
-  }
-  if (fields.size === 0 && resolved.status === "ok") {
-    for (const [name, entry] of resolved.fields) fields.set(name, entry);
+  for (const layerMap of layerMaps) {
+    if (layerMap === null) continue;
+    for (const [name, entry] of layerMap) fields.set(name, entry);
   }
   const evidenceForUse = (use: { field: string; path: string }) => {
     const match = /^\/layers\/(\d+)\//.exec(use.path);
-    if (match !== null && layerMaps !== null) {
+    if (match !== null) {
       const layerMap = layerMaps[Number(match[1])];
       if (layerMap !== null && layerMap !== undefined) {
         const hit = layerMap.get(use.field);

--- a/packages/spec/src/validate-data-evidence.ts
+++ b/packages/spec/src/validate-data-evidence.ts
@@ -1,10 +1,11 @@
 /**
  * Field-evidence construction for tier-2 validation and lint.
  *
- * Builds a FieldEvidenceMap once per validate()/lintSpec() call from either a
- * DataProfile or inline data (pivot + type inference), under input limits.
- * Shared so large inline data is not scanned twice when both dataChecks and
- * lintSpec run.
+ * `resolveLayerFieldEvidence` builds plot + per-layer maps in one pass
+ * (pivot + type inference, under input limits). validate() runs that once and
+ * shares the result with dataChecks and lintSpec so large inline data is not
+ * scanned twice. Standalone lintSpec / resolveFieldEvidence still use the
+ * plot-only path.
  */
 import type { SpecError } from "./errors.js";
 import type { Aes, CellValue, ChannelName } from "./schema.js";
@@ -35,6 +36,12 @@ export type FieldEvidenceMap = Map<string, FieldEvidenceEntry>;
 /** Result of resolving profile/inline data into a field evidence map. */
 export type ResolveFieldEvidenceResult =
   | { status: "ok"; fields: FieldEvidenceMap }
+  | { status: "none" }
+  | { status: "errors"; errors: SpecError[] };
+
+/** Plot + per-layer field evidence from one pass over inline tables / profile. */
+export type ResolveLayerFieldEvidenceResult =
+  | { status: "ok"; plot: FieldEvidenceMap | null; layers: Array<FieldEvidenceMap | null> }
   | { status: "none" }
   | { status: "errors"; errors: SpecError[] };
 
@@ -183,10 +190,7 @@ export function resolveLayerFieldEvidence(
   spec: Record<string, unknown>,
   options: ValidateOptions,
   limits: ValidateLimits,
-):
-  | { status: "ok"; plot: FieldEvidenceMap | null; layers: Array<FieldEvidenceMap | null> }
-  | { status: "none" }
-  | { status: "errors"; errors: SpecError[] } {
+): ResolveLayerFieldEvidenceResult {
   if (options.profile !== undefined) {
     const bad = profileErrors(options.profile);
     if (bad.length > 0) return { status: "errors", errors: bad };

--- a/packages/spec/src/validate-data.ts
+++ b/packages/spec/src/validate-data.ts
@@ -106,8 +106,11 @@ export function jsonDepth(value: unknown, cap: number): number {
 export {
   effectiveChannel,
   resolveFieldEvidence,
+  resolveLayerFieldEvidence,
   type FieldEvidenceEntry,
   type FieldEvidenceMap,
+  type ResolveFieldEvidenceResult,
+  type ResolveLayerFieldEvidenceResult,
 } from "./validate-data-evidence.js";
 
 export { dataChecks, STAT_COLUMNS } from "./validate-data-checks.js";

--- a/packages/spec/src/validate-data.ts
+++ b/packages/spec/src/validate-data.ts
@@ -109,8 +109,6 @@ export {
   resolveLayerFieldEvidence,
   type FieldEvidenceEntry,
   type FieldEvidenceMap,
-  type ResolveFieldEvidenceResult,
-  type ResolveLayerFieldEvidenceResult,
 } from "./validate-data-evidence.js";
 
 export { dataChecks, STAT_COLUMNS } from "./validate-data-checks.js";

--- a/packages/spec/src/validate.ts
+++ b/packages/spec/src/validate.ts
@@ -30,7 +30,7 @@ import {
   dataChecks,
   DEFAULT_VALIDATE_LIMITS,
   jsonDepth,
-  resolveFieldEvidence,
+  resolveLayerFieldEvidence,
 } from "./validate-data.js";
 import { collectSchemaShapeErrors, GEOM_BRANCHES } from "./validate-schema-shape.js";
 import {
@@ -167,17 +167,15 @@ export function validate(input: unknown, options?: ValidateOptions): ValidateRes
     }
 
     // --- tier 2 (opt-in): data-aware checks + optional lint --------------------
-    // Resolve field evidence once so dataChecks and lintSpec share the same
-    // pivot + type-inference pass over large inline data. Still runs on record
-    // roots even when schema/structural errors already accumulated.
+    // One resolveLayerFieldEvidence pass for plot + layer tables; dataChecks and
+    // lintSpec share it. On limit/profile errors, lint gets no shared map so it
+    // does not re-scan data that data-aware validation already refused.
     let advisories: SpecAdvisory[] | undefined;
     if (options !== undefined && isRecord(input)) {
-      const resolved = resolveFieldEvidence(input, options, limits);
-      errors.push(...dataChecks(input, options, limits, resolved));
+      const layerResolved = resolveLayerFieldEvidence(input, options, limits);
+      errors.push(...dataChecks(input, options, limits, layerResolved));
       if (options.lint === true) {
-        // Reuse the map on success; on none/errors pass null so lint does not
-        // re-scan data that data-aware validation already refused or lacked.
-        const shared = resolved.status === "ok" ? resolved.fields : null;
+        const shared = layerResolved.status === "ok" ? layerResolved.plot : null;
         advisories = lintSpec(input, options, shared);
       }
     }

--- a/packages/spec/tests/validate-evidence-once.test.ts
+++ b/packages/spec/tests/validate-evidence-once.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Single field-evidence pass for validate()/dataChecks (no double plot pivot).
+ * Production: validate.ts + validate-data-checks.ts + validate-data-evidence.ts.
+ */
+import { afterEach, describe, expect, it, spyOn } from "bun:test";
+
+import * as evidence from "../src/validate-data-evidence.ts";
+import { dataChecks, DEFAULT_VALIDATE_LIMITS } from "../src/validate-data.ts";
+import { validate } from "../src/validate.ts";
+
+describe("tier 2 — single field-evidence pass", () => {
+  const spies: Array<{ mockRestore: () => void }> = [];
+  afterEach(() => {
+    while (spies.length > 0) spies.pop()!.mockRestore();
+  });
+
+  it("validate resolves layer evidence once and never re-runs plot-only resolve", () => {
+    const layerSpy = spyOn(evidence, "resolveLayerFieldEvidence");
+    const fieldSpy = spyOn(evidence, "resolveFieldEvidence");
+    spies.push(layerSpy, fieldSpy);
+
+    const n = 500;
+    const x = Array.from({ length: n }, (_, i) => i);
+    const y = Array.from({ length: n }, (_, i) => i * 2);
+    const result = validate(
+      {
+        data: { columns: { x, y } },
+        layers: [{ geom: "point", aes: { x: { field: "x" }, y: { field: "y" } } }],
+      },
+      { lint: true },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(layerSpy).toHaveBeenCalledTimes(1);
+    expect(fieldSpy).toHaveBeenCalledTimes(0);
+  });
+
+  it("dataChecks with pre-resolved layer evidence does not call resolvers", () => {
+    const pre = evidence.resolveLayerFieldEvidence(
+      {
+        data: { columns: { x: [1, 2], y: [3, 4] } },
+        layers: [{ geom: "point", aes: { x: { field: "x" }, y: { field: "y" } } }],
+      },
+      {},
+      DEFAULT_VALIDATE_LIMITS,
+    );
+    expect(pre.status).toBe("ok");
+
+    const layerSpy = spyOn(evidence, "resolveLayerFieldEvidence").mockImplementation(() => {
+      throw new Error("dataChecks must not re-resolve when preResolvedLayer is provided");
+    });
+    const fieldSpy = spyOn(evidence, "resolveFieldEvidence").mockImplementation(() => {
+      throw new Error("dataChecks must not call plot-only resolveFieldEvidence");
+    });
+    spies.push(layerSpy, fieldSpy);
+
+    const errors = dataChecks(
+      {
+        data: { columns: { x: [1, 2], y: [3, 4] } },
+        layers: [{ geom: "point", aes: { x: { field: "x" }, y: { field: "y" } } }],
+      },
+      {},
+      DEFAULT_VALIDATE_LIMITS,
+      pre,
+    );
+    expect(errors).toEqual([]);
+  });
+
+  it("aggregate maxRows failure skips data-backed lint advisories", () => {
+    // Plot alone is under the limit; plot + distinct layer table exceeds it.
+    // Shared layer evidence is status "errors", so lint must not get plot values.
+    const plotX = Array.from({ length: 3 }, (_, i) => i);
+    const plotY = Array.from({ length: 3 }, (_, i) => i);
+    const layerX = Array.from({ length: 3 }, (_, i) => i + 10);
+    const layerY = Array.from({ length: 3 }, (_, i) => -(i + 1)); // negatives for stacked-area
+
+    const result = validate(
+      {
+        data: { columns: { x: plotX, y: plotY } },
+        layers: [
+          {
+            geom: "area",
+            position: "stack",
+            data: { columns: { x: layerX, y: layerY } },
+            aes: { x: { field: "x" }, y: { field: "y" } },
+          },
+        ],
+      },
+      { lint: true, limits: { maxRows: 5 } },
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors.some((e) => e.code === "validation-limit")).toBe(true);
+    // Without shared evidence, stacked-area-negative cannot fire on layer y.
+    expect(result.advisories ?? []).toEqual([]);
+  });
+
+  it("layer-only inline data keeps plot-scoped lint without layer values", () => {
+    const result = validate(
+      {
+        layers: [
+          {
+            geom: "area",
+            position: "stack",
+            data: {
+              columns: {
+                x: [1, 2, 3],
+                y: [1, -2, 3],
+              },
+            },
+            aes: { x: { field: "x" }, y: { field: "y" } },
+          },
+        ],
+      },
+      { lint: true },
+    );
+    // Layer-only data: plot evidence is null, so lint has no values for the
+    // layer field (plot-scoped shared map). This matches prior plot-only lint
+    // handoff; dataChecks still sees per-layer evidence for tier-2 errors.
+    expect(result.ok).toBe(true);
+    expect(result.advisories ?? []).toEqual([]);
+  });
+
+  it("plot-level under-limit data still shares evidence with lint", () => {
+    const result = validate(
+      {
+        data: {
+          columns: {
+            x: [1, 2, 3],
+            y: [1, -2, 3],
+            cat: ["a", "b", "c"],
+          },
+        },
+        layers: [
+          {
+            geom: "area",
+            position: "stack",
+            aes: { x: { field: "x" }, y: { field: "y" } },
+          },
+        ],
+      },
+      { lint: true },
+    );
+    expect(result.ok).toBe(true);
+    expect(result.advisories?.some((a) => a.code === "stacked-area-negative")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- **Target:** `packages/spec/src` complexity audit of data-aware validation paths.
- **Finding:** Pattern #5 (repeated expensive work). Every `validate(spec, options)` built plot field evidence with `resolveFieldEvidence`, then `dataChecks` always ran `resolveLayerFieldEvidence` again — so plot pivot + type inference + temporal column work ran twice.
- **n:** plot cells (rows × columns), up to `maxRows` 100_000.
- **Fix:** One `resolveLayerFieldEvidence` pass in `validate()`, shared with `dataChecks` and `lintSpec`. Drop the dead plot-only resolve inside `dataChecks`.

## Behavior note

When aggregate plot+layer tables exceed `maxRows`/`maxBytes`, lint no longer receives a plot-only evidence map. Data-backed advisories are skipped on that path (stricter; matches the “do not re-scan refused data” comment). Under-limit plot data still shares evidence with lint as before.

## Test plan

- [x] `bun test packages/spec/tests/validate-evidence-once.test.ts`
- [x] `bun test packages/spec` (695 pass)
- New contract tests: single layer resolve / no plot-only re-resolve; pre-resolved `dataChecks` does not re-resolve; aggregate limit × lint; plot-level lint still fires.

## Follow-ups

None. Other audit hits were fixed/tiny n or already memoized.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1223" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->