### PR TITLE
test(svelte): cover Theme* shells and CoordSf assembly

### DIFF
--- a/packages/svelte/tests/coord-facet/coord-facet-children.test.ts
+++ b/packages/svelte/tests/coord-facet/coord-facet-children.test.ts
@@ -56,6 +56,16 @@ describe("Coord/Facet children → assembled PortableSpec", () => {
     expect(fromChild.coord).toEqual({ type: "fixed", ratio: 2 });
   });
 
+  it('1b-sf: <CoordSf/> assembles { type: "sf" }', async () => {
+    const fromChild = await assembleWithProps({ useCoordSf: true });
+    expect(fromChild.coord).toEqual({ type: "sf" });
+  });
+
+  it("1b-sf-ratio: <CoordSf ratio={2}/> assembles sf ratio 2", async () => {
+    const fromChild = await assembleWithProps({ useCoordSf: true, sfRatio: 2 });
+    expect(fromChild.coord).toEqual({ type: "sf", ratio: 2 });
+  });
+
   it('1c: <CoordTransform x="log10"/> assembles transform coord', async () => {
     const fromChild = await assembleWithProps({
       useCoordTransform: true,

--- a/packages/svelte/tests/fixtures/CoordFacetChildrenPlot.svelte
+++ b/packages/svelte/tests/fixtures/CoordFacetChildrenPlot.svelte
@@ -15,6 +15,7 @@
   import CoordCartesian from "../../src/lib/coord/CoordCartesian.svelte";
   import CoordFixed from "../../src/lib/coord/CoordFixed.svelte";
   import CoordFlip from "../../src/lib/coord/CoordFlip.svelte";
+  import CoordSf from "../../src/lib/coord/CoordSf.svelte";
   import CoordTransform from "../../src/lib/coord/CoordTransform.svelte";
   import Facet from "../../src/lib/facet/Facet.svelte";
   import FacetGrid from "../../src/lib/facet/FacetGrid.svelte";
@@ -27,11 +28,13 @@
   const {
     useCoordFlip = false,
     useCoordFixed = false,
+    useCoordSf = false,
     useCoordTransform = false,
     useCoordCartesian = false,
     useCoordValue = false,
     coordValue,
     fixedRatio,
+    sfRatio,
     transformX,
     transformY,
     transformClip,
@@ -58,11 +61,13 @@
   }: {
     useCoordFlip?: boolean;
     useCoordFixed?: boolean;
+    useCoordSf?: boolean;
     useCoordTransform?: boolean;
     useCoordCartesian?: boolean;
     useCoordValue?: boolean;
     coordValue?: CoordSpec | "flip";
     fixedRatio?: number;
+    sfRatio?: number;
     transformX?: string;
     transformY?: string;
     transformClip?: boolean;
@@ -155,6 +160,11 @@
     {/if}
     {#if useCoordFixed}
       <CoordFixed ratio={fixedRatio} />
+    {/if}
+    {#if useCoordSf && sfRatio !== undefined}
+      <CoordSf ratio={sfRatio} />
+    {:else if useCoordSf}
+      <CoordSf />
     {/if}
     {#if useCoordTransform}
       <CoordTransform x={transformX} y={transformY} clip={transformClip} />

--- a/packages/svelte/tests/theme/theme-child-parity.test.ts
+++ b/packages/svelte/tests/theme/theme-child-parity.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Theme* shell parity: every THEME_NAMES entry has a named <Theme*> export
+ * that registers a theme layer whose value is that name (no role overrides).
+ *
+ * Export-name inventory already lives in theme-children.test.ts. This suite
+ * mounts each shell under a registry host so the shell modules and factory
+ * path run — export-only checks leave Theme* at 0% coverage.
+ */
+import type { Component } from "svelte";
+import { describe, expect, it } from "vitest";
+
+import { THEME_NAMES, type ThemeName } from "../../src/lib/index.js";
+import * as SveltePkg from "../../src/lib/index.js";
+import type { LayerRegistry } from "../../src/lib/geoms/registry.svelte.js";
+import GeomRegistryHost from "../fixtures/GeomRegistryHost.svelte";
+import { render } from "../helpers/render.js";
+
+/** THEME_NAMES entry → package export (same map as theme-children export parity). */
+const nameToExport: Record<ThemeName, string> = {
+  default: "ThemeDefault",
+  light: "ThemeLight",
+  dark: "ThemeDark",
+  minimal: "ThemeMinimal",
+  ggplot2: "ThemeGgplot2",
+  classic: "ThemeClassic",
+  bw: "ThemeBw",
+  hrbr: "ThemeHrbr",
+  few: "ThemeFew",
+  clean: "ThemeClean",
+  fivethirtyeight: "ThemeFivethirtyeight",
+  economist: "ThemeEconomist",
+  tufte: "ThemeTufte",
+  linedraw: "ThemeLinedraw",
+  void: "ThemeVoid",
+  stata: "ThemeStata",
+  stata_s1color: "ThemeStatas1color",
+  stata_mono: "ThemeStatamono",
+  solarized: "ThemeSolarized",
+  solarizeddark: "ThemeSolarizeddark",
+  economist_white: "ThemeEconomistwhite",
+  solarized_2: "ThemeSolarized2",
+  solarized_2dark: "ThemeSolarized2dark",
+  wsj: "ThemeWsj",
+  gdocs: "ThemeGdocs",
+  hc: "ThemeHc",
+  hcdark: "ThemeHcdark",
+  pander: "ThemePander",
+  calc: "ThemeCalc",
+  excel: "ThemeExcel",
+  excel_new: "ThemeExcelnew",
+  base: "ThemeBase",
+  igray: "ThemeIgray",
+  map: "ThemeMap",
+  solid: "ThemeSolid",
+  grey: "ThemeGrey",
+  gray: "ThemeGray",
+  test: "ThemeTest",
+};
+
+async function waitThemeLayer(get: () => LayerRegistry | undefined): Promise<LayerRegistry> {
+  await expect.poll(() => get() !== undefined).toBe(true);
+  await expect
+    .poll(() => get()?.layers.some((layer) => layer.kind === "theme") ?? false)
+    .toBe(true);
+  return get()!;
+}
+
+describe("theme-child parity (all THEME_NAMES shells)", () => {
+  it(`THEME_NAMES has ${String(THEME_NAMES.length)} entries`, () => {
+    expect(THEME_NAMES.length).toBeGreaterThan(0);
+    expect(Object.keys(nameToExport)).toHaveLength(THEME_NAMES.length);
+  });
+
+  for (const themeName of THEME_NAMES) {
+    const exportName = nameToExport[themeName];
+    it(`${exportName} registers theme value "${themeName}"`, async () => {
+      const Shell = (SveltePkg as Record<string, unknown>)[exportName] as Component | undefined;
+      expect(Shell, `export ${exportName}`).toBeTypeOf("function");
+
+      let host: LayerRegistry | undefined;
+      render(GeomRegistryHost, {
+        Shell,
+        shellProps: {},
+        captureRegistry: (registry: LayerRegistry) => {
+          host = registry;
+        },
+      });
+
+      const registry = await waitThemeLayer(() => host);
+      const themeLayers = registry.layers.filter((layer) => layer.kind === "theme");
+      expect(themeLayers).toHaveLength(1);
+      expect(themeLayers[0]?.value).toBe(themeName);
+    });
+  }
+
+  it('<Theme ink="#eee"/> registers a ThemeSpec object with only defined keys', async () => {
+    const Theme = (SveltePkg as Record<string, unknown>).Theme as Component;
+    let host: LayerRegistry | undefined;
+    render(GeomRegistryHost, {
+      Shell: Theme,
+      shellProps: { name: "dark", ink: "#eee" },
+      captureRegistry: (registry: LayerRegistry) => {
+        host = registry;
+      },
+    });
+    const registry = await waitThemeLayer(() => host);
+    const theme = registry.layers.find((layer) => layer.kind === "theme");
+    expect(theme?.value).toEqual({ name: "dark", ink: "#eee" });
+    expect(Object.values(theme!.value as object).every((v) => v !== undefined)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Mount every `THEME_NAMES` shell under a registry host and assert the registered theme value (export-only checks left named `Theme*` components at 0% browser coverage).
- Assemble bare `<CoordSf/>` and `<CoordSf ratio={2}/>` through the coord-facet fixture (only coord shell still at 0%).

## Coverage (browser, packages/svelte)

| Area | Before | After (focused remeasure) |
|------|--------|---------------------------|
| `lib/theme` | ~15% stmts | 100% stmts |
| `CoordSf.svelte` | 0% | 100% |
| Package total (full suite) | ~91.8% stmts | unchanged order of magnitude; theme zero drag removed |

Compile-time-only contracts (`plot-layer-contract.ts`, `data-contract.ts`) and bundled dataset tables remain intentional non-runtime zeros.

## Test plan

- [x] `bunx vitest run --project chromium tests/theme/theme-child-parity.test.ts tests/coord-facet/coord-facet-children.test.ts`
- [ ] CI component jobs green
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1225" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->