### PR TITLE
perf(docs): prepare search index fields once per entries array

### DIFF
--- a/apps/docs/src/lib/search.ts
+++ b/apps/docs/src/lib/search.ts
@@ -28,17 +28,17 @@ function includesToken(haystack: string, token: string): boolean {
  * identity so keystrokes do not re-run NFKD / diacritic / lower work over the
  * full index (n ≈ thousands and grows with the docs surface).
  */
-type PreparedEntry<Entry extends DocsSearchEntry> = {
-  entry: Entry;
+type PreparedEntry = {
+  entry: DocsSearchEntry;
   title: string;
   exact: readonly string[];
   titleAndExact: string;
   broad: string;
 };
 
-const preparedCache = new WeakMap<object, PreparedEntry<DocsSearchEntry>[]>();
+const preparedCache = new WeakMap<object, PreparedEntry[]>();
 
-function prepareEntry<Entry extends DocsSearchEntry>(entry: Entry): PreparedEntry<Entry> {
+function prepareEntry(entry: DocsSearchEntry): PreparedEntry {
   const title = normalize(entry.title);
   const exact = entry.exact.map(normalize);
   const titleAndExact = [title, ...exact].join(" ");
@@ -48,23 +48,18 @@ function prepareEntry<Entry extends DocsSearchEntry>(entry: Entry): PreparedEntr
   return { entry, title, exact, titleAndExact, broad };
 }
 
-function preparedFor<Entry extends DocsSearchEntry>(
-  entries: readonly Entry[],
-): readonly PreparedEntry<Entry>[] {
-  const cached = preparedCache.get(entries as object);
-  if (cached !== undefined) {
-    return cached as PreparedEntry<Entry>[];
+function preparedFor(entries: readonly DocsSearchEntry[]): PreparedEntry[] {
+  const cached = preparedCache.get(entries);
+  if (cached !== undefined) return cached;
+  const prepared: PreparedEntry[] = [];
+  for (const entry of entries) {
+    prepared.push(prepareEntry(entry));
   }
-  const prepared = entries.map((entry) => prepareEntry(entry));
-  preparedCache.set(entries as object, prepared as PreparedEntry<DocsSearchEntry>[]);
+  preparedCache.set(entries, prepared);
   return prepared;
 }
 
-function scorePrepared(
-  query: string,
-  tokens: readonly string[],
-  prepared: PreparedEntry<DocsSearchEntry>,
-): number {
+function scorePrepared(query: string, tokens: readonly string[], prepared: PreparedEntry): number {
   const { title, exact, titleAndExact, broad } = prepared;
   if (title !== query && exact.includes(query)) return 1100;
   if (title === query || exact.includes(query)) return 1000;
@@ -82,27 +77,31 @@ export function searchDocs<Entry extends DocsSearchEntry>(
   const query = normalize(queryInput);
   if (query === "" || limit <= 0) return [];
   const tokens = query.split(" ");
+  // Prepared rows keep the same order as `entries`; reclaim Entry via index.
   const prepared = preparedFor(entries);
-  const ranked = prepared
-    .map((item, order) => ({
-      entry: item.entry,
-      order,
-      score: scorePrepared(query, tokens, item),
-    }))
-    .filter((candidate) => candidate.score > 0)
-    .toSorted(
-      (left, right) =>
-        right.score - left.score ||
-        KIND_PRIORITY[right.entry.kind] - KIND_PRIORITY[left.entry.kind] ||
-        left.order - right.order,
-    );
+  const scored: { order: number; score: number; kind: DocsSearchKind }[] = [];
+  for (let order = 0; order < prepared.length; order += 1) {
+    const item = prepared[order];
+    if (item === undefined) continue;
+    const score = scorePrepared(query, tokens, item);
+    if (score <= 0) continue;
+    scored.push({ order, score, kind: item.entry.kind });
+  }
+  scored.sort(
+    (left, right) =>
+      right.score - left.score ||
+      KIND_PRIORITY[right.kind] - KIND_PRIORITY[left.kind] ||
+      left.order - right.order,
+  );
 
   const hrefs = new Set<string>();
   const results: Entry[] = [];
-  for (const candidate of ranked) {
-    if (hrefs.has(candidate.entry.href)) continue;
-    hrefs.add(candidate.entry.href);
-    results.push(candidate.entry);
+  for (const candidate of scored) {
+    const entry = entries[candidate.order];
+    if (entry === undefined) continue;
+    if (hrefs.has(entry.href)) continue;
+    hrefs.add(entry.href);
+    results.push(entry);
     if (results.length === limit) break;
   }
   return results;

--- a/apps/docs/src/lib/search.ts
+++ b/apps/docs/src/lib/search.ts
@@ -23,14 +23,49 @@ function includesToken(haystack: string, token: string): boolean {
   return haystack.includes(token);
 }
 
-function scoreEntry(query: string, tokens: readonly string[], entry: DocsSearchEntry): number {
+/**
+ * Pre-normalized fields for one search entry. Built once per entries array
+ * identity so keystrokes do not re-run NFKD / diacritic / lower work over the
+ * full index (n ≈ thousands and grows with the docs surface).
+ */
+type PreparedEntry<Entry extends DocsSearchEntry> = {
+  entry: Entry;
+  title: string;
+  exact: readonly string[];
+  titleAndExact: string;
+  broad: string;
+};
+
+const preparedCache = new WeakMap<object, PreparedEntry<DocsSearchEntry>[]>();
+
+function prepareEntry<Entry extends DocsSearchEntry>(entry: Entry): PreparedEntry<Entry> {
   const title = normalize(entry.title);
   const exact = entry.exact.map(normalize);
   const titleAndExact = [title, ...exact].join(" ");
   const broad = normalize(
     [entry.title, entry.summary, ...entry.keywords, ...entry.exact].join(" "),
   );
+  return { entry, title, exact, titleAndExact, broad };
+}
 
+function preparedFor<Entry extends DocsSearchEntry>(
+  entries: readonly Entry[],
+): readonly PreparedEntry<Entry>[] {
+  const cached = preparedCache.get(entries as object);
+  if (cached !== undefined) {
+    return cached as PreparedEntry<Entry>[];
+  }
+  const prepared = entries.map((entry) => prepareEntry(entry));
+  preparedCache.set(entries as object, prepared as PreparedEntry<DocsSearchEntry>[]);
+  return prepared;
+}
+
+function scorePrepared(
+  query: string,
+  tokens: readonly string[],
+  prepared: PreparedEntry<DocsSearchEntry>,
+): number {
+  const { title, exact, titleAndExact, broad } = prepared;
   if (title !== query && exact.includes(query)) return 1100;
   if (title === query || exact.includes(query)) return 1000;
   if (title.startsWith(query) || exact.some((term) => term.startsWith(query))) return 900;
@@ -47,8 +82,13 @@ export function searchDocs<Entry extends DocsSearchEntry>(
   const query = normalize(queryInput);
   if (query === "" || limit <= 0) return [];
   const tokens = query.split(" ");
-  const ranked = entries
-    .map((entry, order) => ({ entry, order, score: scoreEntry(query, tokens, entry) }))
+  const prepared = preparedFor(entries);
+  const ranked = prepared
+    .map((item, order) => ({
+      entry: item.entry,
+      order,
+      score: scorePrepared(query, tokens, item),
+    }))
     .filter((candidate) => candidate.score > 0)
     .toSorted(
       (left, right) =>

--- a/scripts/docs-search.test.ts
+++ b/scripts/docs-search.test.ts
@@ -34,4 +34,42 @@ describe("Docs search ranking", () => {
     expect(results.length).toBeGreaterThan(0);
     expect(new Set(results.map((result) => result.href)).size).toBe(results.length);
   });
+
+  it("keeps ranking stable across many queries on the same frozen index", () => {
+    // SiteSearch reuses one entries reference after load; prepare-once must not
+    // change winners when the same array is scored repeatedly.
+    const first = winners.map(([query]) => searchDocs(query, DOCS_SEARCH_INDEX)[0]?.href);
+    for (let i = 0; i < 20; i += 1) {
+      for (const [query] of winners) {
+        void searchDocs(query, DOCS_SEARCH_INDEX);
+      }
+    }
+    const again = winners.map(([query]) => searchDocs(query, DOCS_SEARCH_INDEX)[0]?.href);
+    expect(again).toEqual(first);
+    expect(first).toEqual(winners.map(([, href]) => href));
+  });
+
+  it("matches accented queries via the same normalize path as entry text", () => {
+    const withAccent = {
+      id: "fixture:cafe",
+      kind: "page" as const,
+      title: "Café scales",
+      summary: "Accented title fixture",
+      href: "/fixture/cafe",
+      keywords: ["café"],
+      exact: ["Café scales"],
+    };
+    const plain = {
+      id: "fixture:plain",
+      kind: "page" as const,
+      title: "Other page",
+      summary: "No accent",
+      href: "/fixture/plain",
+      keywords: [],
+      exact: ["Other page"],
+    };
+    const index = [withAccent, plain] as const;
+    expect(searchDocs("cafe", index)[0]?.href).toBe("/fixture/cafe");
+    expect(searchDocs("CAFÉ", index)[0]?.href).toBe("/fixture/cafe");
+  });
 });


### PR DESCRIPTION
## Summary

- Docs site search (`searchDocs`) re-ran NFKD / diacritic strip / lower / whitespace normalize on every static field of every search entry on every keystroke.
- Index size is ~4.3k entries and grows with the public API surface.
- Prepare normalized `title` / `exact` / `titleAndExact` / `broad` once per `entries` array identity (`WeakMap`), then score with the same rank tiers as before.
- Measured warm-path keystroke scoring drops from ~10–14 ms to ~0.7–3 ms for common queries on this machine (behavior unchanged).

## Complexity

| Before | After |
|--------|--------|
| O(n · normalize) per keystroke | O(n · normalize) once per index reference, then O(n · string match) per keystroke |

n = `DOCS_SEARCH_INDEX` length. Public ranking contract unchanged.

## Test plan

- [x] `bun test scripts/docs-search.test.ts scripts/docs-search-lazy.test.ts scripts/docs-search-icons-lazy.test.ts`
- [x] Characterization: fixed winner hrefs for the existing query set still hold after many repeated searches on the frozen index
- [x] Accent fixtures still match via the shared normalize path (`cafe` / `CAFÉ` → Café entry)

## Follow-ups

None deferred from this pass.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1227" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->