### PR TITLE
test(svelte): run pure identity and inspect advisories in browser

### DIFF
--- a/packages/svelte/tests/interaction/inspect-geom-advisories.test.ts
+++ b/packages/svelte/tests/interaction/inspect-geom-advisories.test.ts
@@ -1,11 +1,15 @@
 /**
  * Guardrails when inspect axis guides fight bar/col geometry or value labels.
+ *
+ * Browser lane: these pure collectors feed plot-engine advisories. CI coverage
+ * is browser-only (SSR vitest does not collect), so the suite lives here.
  */
 import { describe, expect, it } from "vitest";
 
 import {
   INTERACTION_DIAGNOSTIC_CATALOG,
   inspectAxisOnBarColDiagnostics,
+  layerGeomsFromSpecLayers,
 } from "../../src/lib/interaction/interaction.js";
 
 describe("inspectAxisOnBarColDiagnostics", () => {
@@ -89,5 +93,30 @@ describe("inspectAxisOnBarColDiagnostics", () => {
     ] as const) {
       expect(INTERACTION_DIAGNOSTIC_CATALOG[code].code).toBe(code);
     }
+  });
+});
+
+describe("layerGeomsFromSpecLayers", () => {
+  it("returns an empty list for non-arrays and empty layers", () => {
+    expect(layerGeomsFromSpecLayers(undefined)).toEqual([]);
+    expect(layerGeomsFromSpecLayers(null)).toEqual([]);
+    expect(layerGeomsFromSpecLayers("col")).toEqual([]);
+    expect(layerGeomsFromSpecLayers({})).toEqual([]);
+    expect(layerGeomsFromSpecLayers([])).toEqual([]);
+  });
+
+  it("collects non-empty geom strings and skips junk entries", () => {
+    expect(
+      layerGeomsFromSpecLayers([
+        { geom: "col" },
+        null,
+        "skip",
+        { geom: "" },
+        { geom: 12 },
+        ["not-object"],
+        { geom: "text" },
+        { noGeom: true },
+      ]),
+    ).toEqual(["col", "text"]);
   });
 });

--- a/packages/svelte/tests/interaction/inspect-geom-advisories.test.ts
+++ b/packages/svelte/tests/interaction/inspect-geom-advisories.test.ts
@@ -98,7 +98,9 @@ describe("inspectAxisOnBarColDiagnostics", () => {
 
 describe("layerGeomsFromSpecLayers", () => {
   it("returns an empty list for non-arrays and empty layers", () => {
-    expect(layerGeomsFromSpecLayers(undefined)).toEqual([]);
+    // void 0 — oxlint unicorn/no-useless-undefined rejects an undefined literal arg.
+    const missing: unknown = void 0;
+    expect(layerGeomsFromSpecLayers(missing)).toEqual([]);
     expect(layerGeomsFromSpecLayers(null)).toEqual([]);
     expect(layerGeomsFromSpecLayers("col")).toEqual([]);
     expect(layerGeomsFromSpecLayers({})).toEqual([]);

--- a/packages/svelte/tests/runtime/semantic-keys-epoch-input.test.ts
+++ b/packages/svelte/tests/runtime/semantic-keys-epoch-input.test.ts
@@ -1,11 +1,14 @@
 /**
- * #852 — pure host-side data-identity epoch input assembly.
- * SSR lane: markLayers vs layers-prop, ready-without-assembled, content pick.
+ * #852 — pure host-side data-identity epoch input assembly + content tokens.
+ *
+ * Browser lane: plot-engine imports these helpers; CI coverage is browser-only
+ * (SSR vitest does not collect), so the suite lives here.
  */
 import { describe, expect, it } from "vitest";
 
 import {
   buildDataIdentityEpochInput,
+  dataContentOrderToken,
   dataIdentityEpochToken,
 } from "../../src/lib/runtime/semantic-data-identity.js";
 import { createSourceIdentityTracker } from "../../src/lib/runtime/semantic-source-identity.js";
@@ -161,5 +164,88 @@ describe("buildDataIdentityEpochInput", () => {
     expect(first.specToken).toBe(second.specToken);
     expect(first.dataToken).toBe(id(data));
     expect(first.specToken).toBe(id(spec));
+  });
+});
+
+describe("dataContentOrderToken edge forms", () => {
+  it("fingerprints named DataRefs, single-key values bags, and non-row primitives", () => {
+    const tracker = createSourceIdentityTracker();
+    const id = (value: unknown) => tracker.sourceIdentity(value);
+    expect(dataContentOrderToken(null, id)).toBe("null");
+    expect(dataContentOrderToken(undefined, id)).toBe("null");
+    expect(dataContentOrderToken({ name: "mpg" }, id)).toBe("n:mpg");
+    const rowA = { x: 1 };
+    const rowB = { x: 2 };
+    const valuesBag = { values: [rowA, rowB] };
+    const valuesToken = dataContentOrderToken(valuesBag, id);
+    expect(valuesToken).toBe(`v:2:${id(rowA)}:${id(rowB)}`);
+    // Same row refs → stable; reverse bumps order.
+    valuesBag.values.reverse();
+    expect(dataContentOrderToken(valuesBag, id)).toBe(`v:2:${id(rowB)}:${id(rowA)}`);
+    expect(dataContentOrderToken("inline", id)).toBe("p:inline");
+    expect(dataContentOrderToken(42, id)).toBe("p:42");
+    expect(dataContentOrderToken(true, id)).toBe("p:true");
+    expect(dataContentOrderToken(10n, id)).toBe("p:10");
+    // Non-JSON primitives (symbol) fall through to sourceIdentity.
+    const sym = Symbol("row");
+    expect(dataContentOrderToken(sym, id)).toBe(`p:${id(sym)}`);
+  });
+
+  it("falls back to source identity for non-column objects and bare columns wrapper", () => {
+    const tracker = createSourceIdentityTracker();
+    const id = (value: unknown) => tracker.sourceIdentity(value);
+    const odd = { notRows: 1, meta: "x" };
+    expect(dataContentOrderToken(odd, id)).toBe(`o:${id(odd)}`);
+    // Single-key { columns } uses the column-map path.
+    const x = [1, 2];
+    const y = [3, 4];
+    const wrapped = dataContentOrderToken({ columns: { x, y } }, id);
+    expect(wrapped.startsWith("c:")).toBe(true);
+    expect(wrapped).toContain(id(x));
+    expect(wrapped).toContain(id(y));
+  });
+
+  it("includes named datasets in the epoch via datasetsOrderToken", () => {
+    const tracker = createSourceIdentityTracker();
+    const id = (value: unknown) => tracker.sourceIdentity(value);
+    const rowsA = [{ x: 1 }];
+    const rowsB = [{ x: 2 }];
+    const withA = dataIdentityEpochToken({
+      ready: true,
+      dataToken: "d",
+      specToken: "s",
+      data: null,
+      datasets: { a: rowsA },
+      sourceIdentity: id,
+    });
+    const withB = dataIdentityEpochToken({
+      ready: true,
+      dataToken: "d",
+      specToken: "s",
+      data: null,
+      datasets: { a: rowsB },
+      sourceIdentity: id,
+    });
+    const withBoth = dataIdentityEpochToken({
+      ready: true,
+      dataToken: "d",
+      specToken: "s",
+      data: null,
+      datasets: { a: rowsA, b: rowsB },
+      sourceIdentity: id,
+    });
+    expect(withA).not.toBe(withB);
+    expect(withBoth).not.toBe(withA);
+    // Non-object datasets fall through to source identity.
+    expect(
+      dataIdentityEpochToken({
+        ready: true,
+        dataToken: "d",
+        specToken: "s",
+        data: null,
+        datasets: "named-bag",
+        sourceIdentity: id,
+      }),
+    ).toContain(id("named-bag"));
   });
 });


### PR DESCRIPTION
## Summary

- Move pure unit suites for inspect-geom advisories and data-identity epoch input from `*.ssr.test.ts` into the browser lane. CI coverage collects only under chromium browser vitest; SSR vitest does not feed the gate, so those paths stayed under-covered despite having tests.
- Cover `layerGeomsFromSpecLayers` non-array / junk-entry cases used by plot-engine.
- Fill remaining `dataContentOrderToken` / datasets fingerprint branches (named DataRef, `{ values }`, primitives, bigint, symbol, multi-dataset bags).

## Coverage (browser, focused remeasure)

| File | Before (full browser suite) | After (focused + pure suite) |
|------|-----------------------------|------------------------------|
| `inspect-geom-advisories.ts` | ~66% stmts | **100%** stmts |
| `semantic-data-identity.ts` | ~78% stmts | **100%** stmts |

Package total was ~93.6% stmts before this change; these two were the largest pure-module holes still taxied by the browser gate.

## Test plan

- [x] `bunx vitest run --project chromium tests/interaction/inspect-geom-advisories.test.ts tests/runtime/semantic-keys-epoch-input.test.ts`
- [ ] CI component-svelte jobs green
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1229" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->