### PR TITLE
fix(docs): grammar families are layers — kill inverted #1200 framing

### DIFF
--- a/.changeset/layer-ontology-skill.md
+++ b/.changeset/layer-ontology-skill.md
@@ -1,0 +1,11 @@
+---
+"@ggsvelte/svelte": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+fix(docs): grammar families are layers in the agent skill
+
+Scale/Theme/Guide/Labs/Coord/Facet/Legend are Layer kinds in Svelte.
+PortableSpec `layers[]` holds marks only as serialization, not ontology.
+Closes the #1200 inverted framing path.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,5 +1,31 @@
 # Domain glossary
 
+## Layer
+
+In ggsvelte, a **layer** is any declaration-only child that registers into the
+plot layer registry. The Svelte `Layer` union is:
+
+- `mark` — geom/stat/position marks (`<GeomPoint>`, …)
+- `scale` — `<Scale*>`, escape-hatch `<Scale>`
+- `theme` — `<Theme*>`, escape-hatch `<Theme>`
+- `coord` — `<Coord*>`, escape-hatch `<Coord>`
+- `facet` — `<Facet*>`, escape-hatch `<Facet>`
+- `labs` — `<Labs>`
+- `guides` — `<Guide*>`, escape-hatch `<Guides>`
+- `legend` — plot-wide `<Legend>` entry-sort options
+
+All of those are layers. “Non-mark” / “grammar family” means “not a geom mark,”
+not “not a layer.” Component comments and `#659` upgrade anchors say “child
+layer” on purpose.
+
+**PortableSpec dual vocabulary:** JSON `PortableSpec.layers[]` holds **mark
+layers only**. Scales, theme, coord, facet, labs, guides, and legend fold into
+sibling top-level keys. That is serialization shape for the agent/headless
+path — not a claim that those families are outside the layer model.
+
+Never write “non-layer grammar components” for Scale/Theme/Guide/Labs/Coord/
+Facet/Legend. Prefer “grammar layers” or “non-mark layers.”
+
 ## Semantic viewport
 
 The plot-owned mapping between panel pixels and semantic axis values. It owns panel identity, coordinate transforms, axis reversal, coordinate flipping, and panel-local scale selection so interaction callers do not reconstruct that mapping from rendering details.

--- a/packages/svelte/skills/ggsvelte/SKILL.md
+++ b/packages/svelte/skills/ggsvelte/SKILL.md
@@ -17,15 +17,34 @@ same grammar — never build SVG or canvas output yourself:
 
 ## Mental model
 
+**Everything that composes a plot is a layer in Svelte.** Marks _and_ the
+seven grammar families (scale, theme, coord, facet, labs, guides, legend)
+register as `Layer` kinds via `createPlotLayer` / geom factories. Never call
+Scale/Theme/Guide/Labs/Coord/Facet/Legend “non-layers.”
+
+Two serializations of the same grammar:
+
 ```text fragment
-spec = data + aes (mappings) + layers[]
-       + scales? coord? facet? labs? theme? guides?
-one layer = { geom, stat?, position?, positionParams?, aes?, params?, render?, data? }
+# Svelte composition (canonical product model)
+plot children = mark layers + grammar layers
+  mark    = Geom*  → Layer.kind "mark"
+  grammar = Scale* | Theme* | Coord* | Facet* | Labs | Guide* | Legend
+            → Layer.kind "scale"|"theme"|"coord"|"facet"|"labs"|"guides"|"legend"
+
+# PortableSpec JSON (agent / headless wire format)
+spec = data + aes + layers[]          # layers[] = MARKS ONLY
+       + scales? coord? facet? labs? theme? guides? legend?
+one mark layer = { geom, stat?, position?, positionParams?, aes?, params?, render?, data? }
 ```
+
+PortableSpec puts grammar pieces in top-level keys because that is how the
+JSON schema folds them — **not** because they are outside the layer model.
+“Non-mark layer” / “grammar layer” is correct; “non-layer grammar component”
+is wrong and must never appear in issues, docs, or comments.
 
 - **data**: `{"values": [rows]}`, `{"columns": {name: [...]}}`, or
   `{"name": "dataset"}` (resolved from `spec.datasets` or runtime data).
-- **layers** draw in order — later layers on top (z-order).
+- **mark `layers[]`** draw in order — later marks on top (z-order).
 - Geom defaults: bar → count+stack, histogram → bin+stack, col/area →
   identity+stack, boxplot → boxplot+dodge, violin → ydensity+dodge,
   jitter → point+jitter, freqpoly → bin, smooth → smooth, count → sum,
@@ -85,12 +104,13 @@ only on the geoms in `STYLE_AESTHETIC_GEOMS`.
 </GGPlot>
 ```
 
-Convention: theme → scales → guides → labs → mark layers. Grammar children
+Convention: theme → scales → guides → labs → mark layers. Grammar **layers**
 (theme/scale/coord/facet/guides/labs/legend) render no markup and register
-declaratively; mark-layer registration order is z-order (points above smooth
-here). Every geom takes aesthetics through one `aes` object prop (bare-string
-shorthand allowed) and constant style params as direct props (`size={3}`);
-structural props are `data`, `stat`, `position`, `positionParams`, `render`.
+declaratively as non-mark `Layer` kinds; mark-layer registration order is
+z-order (points above smooth here). Every geom takes aesthetics through one
+`aes` object prop (bare-string shorthand allowed) and constant style params as
+direct props (`size={3}`); structural props are `data`, `stat`, `position`,
+`positionParams`, `render`.
 
 `<GGPlot>` props: `spec`, `data`, `aes`, `layers`, `key`, `width`
 (number | "container"), `height`, `a11y`, `ariaLabel`, the interaction props

--- a/packages/svelte/skills/ggsvelte/references/composition-surfaces.md
+++ b/packages/svelte/skills/ggsvelte/references/composition-surfaces.md
@@ -2,11 +2,16 @@
 
 # Composition surfaces: coords, facets, guides, labs
 
-Every surface here exists in three equivalent forms: a key in the JSON
-`PortableSpec`, a deprecated `<GGPlot>` prop (removable in 0.13.0), and a
-declaration-only child component (canonical in Svelte). Child components emit
-no markup, register on init, unregister on destroy, and are inert without a
-`<GGPlot>` ancestor.
+Every surface here is a **grammar layer** (non-mark `Layer` kind). Each exists
+in three equivalent forms: a key in the JSON `PortableSpec`, a deprecated
+`<GGPlot>` prop (removable in 0.13.0), and a declaration-only child component
+(canonical in Svelte). Child components emit no markup, register on init via
+`createPlotLayer` / `registerPlotLayer`, unregister on destroy, and are inert
+without a `<GGPlot>` ancestor.
+
+**Ontology:** scale, theme, coord, facet, labs, guides, and legend **are
+layers**. PortableSpec’s top-level `layers[]` array holds marks only; these
+families fold into sibling keys. That is wire format, not “not a layer.”
 
 ## Themes
 

--- a/scripts/quickstart/steps.ts
+++ b/scripts/quickstart/steps.ts
@@ -123,19 +123,25 @@ export interface SakuraSourceDelta {
   /** `<GGPlot>` attributes, keyed by attribute name; a repeat replaces it. */
   readonly attrs?: Readonly<Record<string, string>>;
   /**
-   * Declaration-only grammar children (`<ScaleYMonthDay>`, `<Labs>`,
+   * Declaration-only **grammar layers** (`<ScaleYMonthDay>`, `<Labs>`,
    * `<GuideLegend>`, `<ThemeTufte>`, …), keyed by the grammar piece they
    * carry; a repeat replaces it.
    *
-   * Held apart from {@link children} because they are not layers: they never
-   * appear in `childOrder`, and they are emitted ahead of every geom so that a
-   * later step adding a geom cannot silently reorder them (#659 D2 — child
-   * layers apply in registration order).
+   * These **are** plot layers (`Layer.kind` scale/theme/coord/facet/labs/
+   * guides/legend via `createPlotLayer`). They are held apart from
+   * {@link children} only because they are **not mark layers**: they never
+   * appear in `childOrder` (geom z-order), and they are emitted ahead of every
+   * geom so a later step adding a geom cannot silently reorder them
+   * (#659 D2 — child layers apply in registration order).
+   *
+   * Do not call them “non-layers.” PortableSpec puts marks in `layers[]` and
+   * folds these families into top-level keys; that is serialization, not
+   * ontology.
    */
   readonly grammar?: Readonly<Record<string, string>>;
-  /** Child elements keyed by the layer they draw; a repeat replaces it. */
+  /** Mark/geom child elements keyed by the layer they draw; a repeat replaces it. */
   readonly children?: Readonly<Record<string, string>>;
-  /** Full bottom-to-top child order after this step. */
+  /** Full bottom-to-top mark child order after this step. */
   readonly childOrder?: readonly string[];
 }
 

--- a/scripts/sakura-lesson.test.ts
+++ b/scripts/sakura-lesson.test.ts
@@ -147,8 +147,9 @@ describe("the sakura lesson folds to renderable specs", () => {
     const lastChild = new Map<string, string>();
     for (const step of SAKURA_STEPS) {
       for (const [key, text] of Object.entries(step.source.attrs ?? {})) lastAttr.set(key, text);
-      // Grammar children ride with the attrs they replaced (#659 slice 8):
-      // they are not layers, so they must stay out of the layer count below.
+      // Grammar children ride with the attrs they replaced (#659 slice 8).
+      // They are plot layers (scale/theme/labs/guides/…), but not mark layers,
+      // so they must stay out of the PortableSpec `layers[]` / mark count below.
       for (const [key, text] of Object.entries(step.source.grammar ?? {})) lastAttr.set(key, text);
       for (const [key, text] of Object.entries(step.source.children ?? {}))
         lastChild.set(key, text);

--- a/scripts/skill-content.test.ts
+++ b/scripts/skill-content.test.ts
@@ -108,6 +108,37 @@ describe("skill Svelte fences use child layers, not deprecated grammar props", (
 });
 
 /**
+ * #1200 postmortem: an agent read PortableSpec.layers[] (marks only) plus a
+ * false "are not layers" comment and filed issues claiming Scale/Theme/Guide/
+ * Labs/Coord/Facet/Legend were "non-layer grammar components." They are Layer
+ * kinds in Svelte. Keep the skill and quickstart from reintroducing that claim.
+ */
+describe("layer ontology (grammar families are layers)", () => {
+  it("SKILL.md states Svelte Layer union and PortableSpec dual vocabulary", () => {
+    const skill = readFileSync(join(SKILL_DIR, "SKILL.md"), "utf8");
+    expect(skill).toMatch(/Everything that composes a plot is a layer/i);
+    expect(skill).toMatch(/layers\[\] = MARKS ONLY/);
+    expect(skill).toMatch(/non-layer grammar component/);
+    expect(skill).toMatch(/is wrong/);
+    // Affirmative inverted claim must not reappear.
+    expect(skill).not.toMatch(/that are not themselves/);
+    expect(skill).not.toMatch(/because they are not layers/i);
+  });
+
+  it("composition-surfaces.md calls grammar surfaces layers", () => {
+    const prose = readFileSync(join(SKILL_DIR, "references", "composition-surfaces.md"), "utf8");
+    expect(prose).toMatch(/grammar layer/i);
+    expect(prose).not.toMatch(/because they are not layers/i);
+  });
+
+  it("quickstart holds grammar children as plot layers, not non-layers", () => {
+    const steps = readFileSync(join(ROOT, "scripts", "quickstart", "steps.ts"), "utf8");
+    expect(steps).toMatch(/are\*\* plot layers|\*\*are\*\* plot layers|are plot layers/);
+    expect(steps).not.toMatch(/because they are not layers/);
+  });
+});
+
+/**
  * A name counts as documented only when it appears as its own table cell
  * (`| name |`) or leads one (`| name (…` for annotations like aliases) in the
  * expected reference file — prose mentions and substrings do not count.

--- a/skills/ggsvelte/SKILL.md
+++ b/skills/ggsvelte/SKILL.md
@@ -17,15 +17,34 @@ same grammar — never build SVG or canvas output yourself:
 
 ## Mental model
 
+**Everything that composes a plot is a layer in Svelte.** Marks _and_ the
+seven grammar families (scale, theme, coord, facet, labs, guides, legend)
+register as `Layer` kinds via `createPlotLayer` / geom factories. Never call
+Scale/Theme/Guide/Labs/Coord/Facet/Legend “non-layers.”
+
+Two serializations of the same grammar:
+
 ```text fragment
-spec = data + aes (mappings) + layers[]
-       + scales? coord? facet? labs? theme? guides?
-one layer = { geom, stat?, position?, positionParams?, aes?, params?, render?, data? }
+# Svelte composition (canonical product model)
+plot children = mark layers + grammar layers
+  mark    = Geom*  → Layer.kind "mark"
+  grammar = Scale* | Theme* | Coord* | Facet* | Labs | Guide* | Legend
+            → Layer.kind "scale"|"theme"|"coord"|"facet"|"labs"|"guides"|"legend"
+
+# PortableSpec JSON (agent / headless wire format)
+spec = data + aes + layers[]          # layers[] = MARKS ONLY
+       + scales? coord? facet? labs? theme? guides? legend?
+one mark layer = { geom, stat?, position?, positionParams?, aes?, params?, render?, data? }
 ```
+
+PortableSpec puts grammar pieces in top-level keys because that is how the
+JSON schema folds them — **not** because they are outside the layer model.
+“Non-mark layer” / “grammar layer” is correct; “non-layer grammar component”
+is wrong and must never appear in issues, docs, or comments.
 
 - **data**: `{"values": [rows]}`, `{"columns": {name: [...]}}`, or
   `{"name": "dataset"}` (resolved from `spec.datasets` or runtime data).
-- **layers** draw in order — later layers on top (z-order).
+- **mark `layers[]`** draw in order — later marks on top (z-order).
 - Geom defaults: bar → count+stack, histogram → bin+stack, col/area →
   identity+stack, boxplot → boxplot+dodge, violin → ydensity+dodge,
   jitter → point+jitter, freqpoly → bin, smooth → smooth, count → sum,
@@ -85,12 +104,13 @@ only on the geoms in `STYLE_AESTHETIC_GEOMS`.
 </GGPlot>
 ```
 
-Convention: theme → scales → guides → labs → mark layers. Grammar children
+Convention: theme → scales → guides → labs → mark layers. Grammar **layers**
 (theme/scale/coord/facet/guides/labs/legend) render no markup and register
-declaratively; mark-layer registration order is z-order (points above smooth
-here). Every geom takes aesthetics through one `aes` object prop (bare-string
-shorthand allowed) and constant style params as direct props (`size={3}`);
-structural props are `data`, `stat`, `position`, `positionParams`, `render`.
+declaratively as non-mark `Layer` kinds; mark-layer registration order is
+z-order (points above smooth here). Every geom takes aesthetics through one
+`aes` object prop (bare-string shorthand allowed) and constant style params as
+direct props (`size={3}`); structural props are `data`, `stat`, `position`,
+`positionParams`, `render`.
 
 `<GGPlot>` props: `spec`, `data`, `aes`, `layers`, `key`, `width`
 (number | "container"), `height`, `a11y`, `ariaLabel`, the interaction props

--- a/skills/ggsvelte/references/composition-surfaces.md
+++ b/skills/ggsvelte/references/composition-surfaces.md
@@ -2,11 +2,16 @@
 
 # Composition surfaces: coords, facets, guides, labs
 
-Every surface here exists in three equivalent forms: a key in the JSON
-`PortableSpec`, a deprecated `<GGPlot>` prop (removable in 0.13.0), and a
-declaration-only child component (canonical in Svelte). Child components emit
-no markup, register on init, unregister on destroy, and are inert without a
-`<GGPlot>` ancestor.
+Every surface here is a **grammar layer** (non-mark `Layer` kind). Each exists
+in three equivalent forms: a key in the JSON `PortableSpec`, a deprecated
+`<GGPlot>` prop (removable in 0.13.0), and a declaration-only child component
+(canonical in Svelte). Child components emit no markup, register on init via
+`createPlotLayer` / `registerPlotLayer`, unregister on destroy, and are inert
+without a `<GGPlot>` ancestor.
+
+**Ontology:** scale, theme, coord, facet, labs, guides, and legend **are
+layers**. PortableSpec’s top-level `layers[]` array holds marks only; these
+families fold into sibling keys. That is wire format, not “not a layer.”
 
 ## Themes
 


### PR DESCRIPTION
## Summary

Issue #1200 was filed under a **false ontology**: that Scale/Theme/Guide/Labs/Coord/Facet/Legend are “non-layer grammar components.” In ggsvelte they are all `Layer` kinds (`createPlotLayer` / `registerPlotLayer`).

### Root cause

1. **PortableSpec dual vocabulary.** JSON `layers[]` holds **marks only**; grammar families fold into top-level keys. That is serialization, not “not a layer.”
2. **Smoking-gun comment** in `scripts/quickstart/steps.ts`: grammar children “are not layers” (meant: not mark layers / not in `childOrder`).
3. **Agent skill mental model** led with PortableSpec shape and never stated the Svelte `Layer` union.
4. ggplot2 literature reserves “layer” for geom+stat+position — agents over-applied it.

### Fixes

- Rewrite quickstart + sakura test comments to say grammar pieces **are** plot layers, held apart only from mark z-order.
- Skill `SKILL.md` + `composition-surfaces.md`: dual vocabulary; forbid “non-layer grammar components.”
- `CONTEXT.md` glossary entry for **Layer**.
- Regression tests in `skill-content.test.ts` so the inverted claim cannot re-enter skill or quickstart.

Issue #1200 body/title already rewritten on GitHub to correct the record. Child docs issues #1196–#1199 were valid and completed.

Closes #1200.

## Test plan

- [x] `bun test scripts/skill-content.test.ts scripts/skill-sync.test.ts scripts/sakura-lesson.test.ts`
- [x] skill package byte-identical to `skills/ggsvelte/`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1231" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->