### PR TITLE
feat(svelte): move legend focus opt-in to GuideLegend.focus

### DIFF
--- a/.changeset/guide-legend-focus.md
+++ b/.changeset/guide-legend-focus.md
@@ -14,7 +14,7 @@ Only channels with an active focus child get interactive legend targets
 `<GGPlot legendFocus>` still works plot-wide until 0.20.0 and emits
 `DEPRECATED_PLOT_PROP` with migration guidance.
 
-Migration: <https://ggsvelte.sh/guide/upgrading#legend-focus-on-guide-legend>
+Migration: <https://ggsvelte.sh/guide/upgrading#legend-focus-on-guidelegend>
 
 Replace:
 

--- a/.changeset/guide-legend-focus.md
+++ b/.changeset/guide-legend-focus.md
@@ -1,0 +1,38 @@
+---
+"@ggsvelte/svelte": minor
+---
+
+<!-- markdownlint-disable MD041 -->
+
+feat(svelte): move legend focus opt-in to `<GuideLegend focus>`
+
+Legend focus is now a host-only prop on `<GuideLegend channel="…" focus />`
+(boolean or `{ preview?: boolean }`), not a PortableSpec / guideLegend field.
+Only channels with an active focus child get interactive legend targets
+(merged legends match via `aesthetics[]`).
+
+`<GGPlot legendFocus>` still works plot-wide until 0.20.0 and emits
+`DEPRECATED_PLOT_PROP` with migration guidance.
+
+Migration: <https://ggsvelte.sh/guide/upgrading#legend-focus-on-guide-legend>
+
+Replace:
+
+```svelte
+<GGPlot legendFocus key="id" …>
+  <GeomPoint />
+</GGPlot>
+```
+
+with:
+
+```svelte
+<GGPlot key="id" …>
+  <GuideLegend channel="color" focus />
+  <GeomPoint />
+</GGPlot>
+```
+
+Use the aesthetic that owns the discrete legend (`color`, `fill`, `shape`, …).
+Focus-only GuideLegend children do not force a `type: "legend"` guide, so
+continuous colour scales keep their colorbar.

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ and Windows.
   import {
     GeomArea,
     GGPlot,
+    GuideLegend,
     Labs,
     ScaleFillManual,
     ScaleXDate,
@@ -96,7 +97,6 @@ and Windows.
   data={crimeanMortality}
   aes={{ x: "month", y: "deaths", fill: "cause" }}
   key={(row) => `${row.month}:${row.cause}`}
-  legendFocus
   width={640}
   height={400}
 >
@@ -113,6 +113,7 @@ and Windows.
     y="Deaths per 1,000 per year"
     fill="Cause"
   />
+  <GuideLegend channel="fill" focus />
   <GeomArea alpha={0.9} />
 </GGPlot>
 ```
@@ -169,6 +170,7 @@ and Windows.
   import {
     GeomPoint,
     GGPlot,
+    GuideLegend,
     Labs,
     ScaleColorManual,
     ScaleXLog10,
@@ -182,7 +184,6 @@ and Windows.
   data={londonCholera}
   aes={{ x: "density", y: "deathRate", color: "water" }}
   key="district"
-  legendFocus
   inspect={{ mode: "xy", pin: true }}
   width="container"
   height={400}
@@ -200,6 +201,7 @@ and Windows.
     y="Cholera deaths per 10,000"
     color="Water supply"
   />
+  <GuideLegend channel="color" focus />
   <GeomPoint size={3.5} />
 </GGPlot>
 ```

--- a/apps/docs/src/lib/components/GrammarDemoPlot.svelte
+++ b/apps/docs/src/lib/components/GrammarDemoPlot.svelte
@@ -3,6 +3,7 @@
     GeomJitter,
     GeomSmooth,
     GGPlot,
+    GuideLegend,
     Labs,
     Theme,
   } from "@ggsvelte/svelte";
@@ -14,7 +15,7 @@
    * Live homepage grammar plot. Dynamically imported so the section chrome +
    * static SVG shell can SSR without pulling @ggsvelte into the home node.
    *
-   * Default step (Interaction): xy inspect (numeric crosshair) + legendFocus.
+   * Default step (Interaction): xy inspect (numeric crosshair) + GuideLegend focus.
    * Full palmerPenguins (333 complete cases).
    *
    * Labs titles must match `homeGrammarStaticSvgFromData` so the shell→live
@@ -31,7 +32,7 @@
 
 <!--
   mode "xy": full crosshair on two continuous axes (not path auto "x").
-  legendFocus needs stable row keys (`id` on palmerPenguins).
+  GuideLegend focus needs stable row keys (`id` on palmerPenguins).
   GeomJitter + alpha: 333 points stack on integer measurements; seeded jitter
   (default 0.4·resolution) and alpha spread the cloud. degree 1 loess stays
   cheap when remounting.
@@ -45,11 +46,13 @@
     ...(active >= 1 && { color: "species" }),
   }}
   inspect={active >= 3 ? { mode: "xy", pin: true, maxDistance: 24 } : false}
-  legendFocus={active >= 1}
   ariaLabel="Penguin body mass increases with flipper length, grouped by species"
 >
   <Theme name={chartTheme} />
   <Labs x="Flipper length mm" y="Body mass g" color="species" />
+  {#if active >= 1}
+    <GuideLegend channel="color" focus />
+  {/if}
   <GeomJitter alpha={0.88} />
   {#if active >= 2}
     <GeomSmooth method="loess" span={0.75} degree={1} se={false} />

--- a/apps/docs/src/lib/components/InteractionDemo.svelte
+++ b/apps/docs/src/lib/components/InteractionDemo.svelte
@@ -3,6 +3,7 @@
     createPlotInteraction,
     GeomPoint,
     GGPlot,
+    GuideLegend,
     Labs,
     Scale,
   } from "@ggsvelte/svelte";
@@ -38,7 +39,7 @@
 
   const closeScript = ["</", "script>"].join("");
   const code = `<script lang="ts">
-  import { createPlotInteraction, GeomPoint, GGPlot } from "@ggsvelte/svelte";
+  import { createPlotInteraction, GeomPoint, GGPlot, GuideLegend } from "@ggsvelte/svelte";
 
   const interaction = createPlotInteraction<string>();
   const scope = { keys: "rows", x: "x", y: "y" } as const;
@@ -51,10 +52,10 @@ ${closeScript}
   key="id"
   aes={{ x: "period", y: "value", color: "series" }}
   inspect
-  legendFocus
   select={{ type: "interval", mode: "xy" }}
   zoom={{ mode: "x" }}
 >
+  <GuideLegend channel="color" focus />
   <GeomPoint size={4} />
 </GGPlot>`;
 
@@ -89,13 +90,13 @@ ${closeScript}
       inspect
       select={{ type: "interval", mode: "xy" }}
       zoom={{ mode: "x" }}
-      legendFocus
       {interaction}
       interactionScope={scope}
       height={420}
       ariaLabel="Interactive series with inspect, select, zoom, and legend focus"
       onlegendfocus={describeLegend}
     >
+      <GuideLegend channel="color" focus />
       <Scale value={{ color: { type: "ordinal", scheme: "observable10" } }} />
       <Labs x="Period" y="Value" color="Series" />
       <GeomPoint size={4} />

--- a/apps/docs/src/lib/components/TemperaturesSpecimen.svelte
+++ b/apps/docs/src/lib/components/TemperaturesSpecimen.svelte
@@ -3,6 +3,7 @@
     GeomLine,
     GeomPoint,
     GGPlot,
+    GuideLegend,
     Labs,
     ScaleColorDiscrete,
     ScaleXContinuous,
@@ -36,10 +37,12 @@
   aes={chart.aes}
   key={chart.key}
   inspect={chart.inspect}
-  {legendFocus}
   {height}
   {ariaLabel}
 >
+  {#if legendFocus}
+    <GuideLegend channel="color" focus />
+  {/if}
   <Theme name={theme} />
   <ScaleXContinuous breaks={[...chart.monthBreaks]} />
   <ScaleColorDiscrete {scheme} />

--- a/apps/docs/src/lib/components/ThemeSpecimenLive.svelte
+++ b/apps/docs/src/lib/components/ThemeSpecimenLive.svelte
@@ -13,6 +13,7 @@
     GeomSmooth,
     GeomText,
     GGPlot,
+    GuideLegend,
     Labs,
     Scale,
     scaleXLog10,
@@ -69,10 +70,12 @@
     aes={{ x: "month", y: "riders", color: "mode" }}
     key="id"
     inspect={{ mode: "x" }}
-    {legendFocus}
     {height}
     ariaLabel={`${label} theme Playfair wheat and wages`}
   >
+    {#if legendFocus}
+      <GuideLegend channel="color" focus />
+    {/if}
     <Theme {name} />
     <Scale value={{ color: colorScale }} />
     <Labs
@@ -90,10 +93,12 @@
     aes={{ x: "track", fill: "level", weight: "deaths" }}
     key="id"
     inspect={{ mode: "exact" }}
-    {legendFocus}
     {height}
     ariaLabel={`${label} theme Edgeworth dodged bars`}
   >
+    {#if legendFocus}
+      <GuideLegend channel="fill" focus />
+    {/if}
     <Theme {name} />
     <Scale value={{ fill: colorScale }} />
     <Labs
@@ -110,10 +115,12 @@
     aes={{ x: "year", y: "twh", fill: "source" }}
     key="id"
     inspect={{ mode: "x" }}
-    {legendFocus}
     {height}
     ariaLabel={`${label} theme Nightingale stacked area`}
   >
+    {#if legendFocus}
+      <GuideLegend channel="fill" focus />
+    {/if}
     <Theme {name} />
     <Scale
       value={{
@@ -137,6 +144,9 @@
     {height}
     ariaLabel={`${label} theme Bowley exports`}
   >
+    {#if legendFocus}
+      <GuideLegend channel="color" focus />
+    {/if}
     <Theme {name} />
     <Labs title="British exports, 1855–1899" x="Year" y="£ millions" />
     <GeomLine linewidth={1.5} />
@@ -147,10 +157,12 @@
     aes={{ x: "flipper", y: "mass", color: "species" }}
     key="id"
     inspect={{ mode: "xy" }}
-    {legendFocus}
     {height}
     ariaLabel={`${label} theme penguin scatter`}
   >
+    {#if legendFocus}
+      <GuideLegend channel="color" focus />
+    {/if}
     <Theme {name} />
     <Scale value={{ color: colorScale }} />
     <Labs
@@ -167,10 +179,12 @@
     aes={{ x: "gdp", y: "lifeExp", color: "region" }}
     key="country"
     inspect={{ mode: "xy" }}
-    {legendFocus}
     {height}
     ariaLabel={`${label} theme cholera density scatter`}
   >
+    {#if legendFocus}
+      <GuideLegend channel="color" focus />
+    {/if}
     <Theme {name} />
     <Scale
       value={{
@@ -195,6 +209,9 @@
     {height}
     ariaLabel={`${label} theme Salk trial columns`}
   >
+    {#if legendFocus}
+      <GuideLegend channel="color" focus />
+    {/if}
     <Theme {name} />
     <Labs
       title="Salk trial paralytic polio rates"
@@ -212,6 +229,9 @@
     {height}
     ariaLabel={`${label} theme Langren longitude labels`}
   >
+    {#if legendFocus}
+      <GuideLegend channel="color" focus />
+    {/if}
     <Theme {name} />
     <Scale value={{ x: { labels: ".1f" } }} />
     <Labs

--- a/apps/docs/src/lib/generated/routes.ts
+++ b/apps/docs/src/lib/generated/routes.ts
@@ -10594,8 +10594,8 @@ export const DOCS_ROUTES = [
         level: 3,
       },
       {
-        id: "focus-on-guidelegend",
-        title: "focus on <GuideLegend>",
+        id: "legendfocus",
+        title: "legendFocus",
         level: 3,
       },
       {

--- a/apps/docs/src/lib/generated/routes.ts
+++ b/apps/docs/src/lib/generated/routes.ts
@@ -10594,8 +10594,8 @@ export const DOCS_ROUTES = [
         level: 3,
       },
       {
-        id: "legendfocus",
-        title: "legendFocus",
+        id: "focus-on-guidelegend",
+        title: "focus on <GuideLegend>",
         level: 3,
       },
       {
@@ -12041,6 +12041,16 @@ export const DOCS_ROUTES = [
         id: "five-minute-path",
         title: "Five-minute path",
         level: 2,
+      },
+      {
+        id: "0-18-to-0-19",
+        title: "0.18 to 0.19",
+        level: 2,
+      },
+      {
+        id: "legend-focus-on-guidelegend",
+        title: "Legend focus on GuideLegend",
+        level: 3,
       },
       {
         id: "0-11-to-0-12",

--- a/apps/docs/src/lib/generated/search-index.ts
+++ b/apps/docs/src/lib/generated/search-index.ts
@@ -17096,14 +17096,14 @@ export const DOCS_SEARCH_INDEX = [
     exact: ["zoom"],
   },
   {
-    id: "heading:guide-interaction-reference:focus-on-guidelegend",
+    id: "heading:guide-interaction-reference:legendfocus",
     kind: "heading",
-    title: "focus on <GuideLegend>",
+    title: "legendFocus",
     summary:
-      "focus on <GuideLegend> in Interaction reference. Search interaction props, callbacks, event phases, and diagnostic codes.",
-    href: "/guide/interaction-reference#focus-on-guidelegend",
+      "legendFocus in Interaction reference. Search interaction props, callbacks, event phases, and diagnostic codes.",
+    href: "/guide/interaction-reference#legendfocus",
     keywords: ["Interaction reference", "documentation"],
-    exact: ["focus on <GuideLegend>"],
+    exact: ["legendFocus"],
   },
   {
     id: "heading:guide-interaction-reference:legendfilter",

--- a/apps/docs/src/lib/generated/search-index.ts
+++ b/apps/docs/src/lib/generated/search-index.ts
@@ -17096,14 +17096,14 @@ export const DOCS_SEARCH_INDEX = [
     exact: ["zoom"],
   },
   {
-    id: "heading:guide-interaction-reference:legendfocus",
+    id: "heading:guide-interaction-reference:focus-on-guidelegend",
     kind: "heading",
-    title: "legendFocus",
+    title: "focus on <GuideLegend>",
     summary:
-      "legendFocus in Interaction reference. Search interaction props, callbacks, event phases, and diagnostic codes.",
-    href: "/guide/interaction-reference#legendfocus",
+      "focus on <GuideLegend> in Interaction reference. Search interaction props, callbacks, event phases, and diagnostic codes.",
+    href: "/guide/interaction-reference#focus-on-guidelegend",
     keywords: ["Interaction reference", "documentation"],
-    exact: ["legendFocus"],
+    exact: ["focus on <GuideLegend>"],
   },
   {
     id: "heading:guide-interaction-reference:legendfilter",
@@ -19890,6 +19890,26 @@ export const DOCS_SEARCH_INDEX = [
     href: "/guide/upgrading#five-minute-path",
     keywords: ["Upgrade guide", "Release"],
     exact: ["Five-minute path"],
+  },
+  {
+    id: "heading:guide-upgrading:0-18-to-0-19",
+    kind: "heading",
+    title: "0.18 to 0.19",
+    summary:
+      "0.18 to 0.19 in Upgrade guide. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
+    href: "/guide/upgrading#0-18-to-0-19",
+    keywords: ["Upgrade guide", "Release"],
+    exact: ["0.18 to 0.19"],
+  },
+  {
+    id: "heading:guide-upgrading:legend-focus-on-guidelegend",
+    kind: "heading",
+    title: "Legend focus on GuideLegend",
+    summary:
+      "Legend focus on GuideLegend in Upgrade guide. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
+    href: "/guide/upgrading#legend-focus-on-guidelegend",
+    keywords: ["Upgrade guide", "Release"],
+    exact: ["Legend focus on GuideLegend"],
   },
   {
     id: "heading:guide-upgrading:0-11-to-0-12",
@@ -41757,7 +41777,7 @@ export const DOCS_SEARCH_INDEX = [
     keywords: [
       "interaction",
       "advisory",
-      "Use a discrete color or fill mapping; Keep the continuous ramp static",
+      'Enable focus on a discrete guide: <GuideLegend channel="color" focus />; Use a discrete color or fill mapping; Keep the continuous ramp static',
     ],
     exact: ["INTERACTION_LEGEND_DISCRETE_ONLY", "interaction:INTERACTION_LEGEND_DISCRETE_ONLY"],
   },

--- a/apps/docs/src/lib/home-code-path.ts
+++ b/apps/docs/src/lib/home-code-path.ts
@@ -11,15 +11,16 @@
  * aliases.
  *
  * Interaction: GrammarDemo step 4 uses xy inspect (numeric crosshair on both
- * axes) plus legendFocus. Those are GGPlot host props — not PortableSpec
- * fields and not builder methods.
- * - Svelte / builder: set `inspect` / `legendFocus` / `key` on <GGPlot>
- * - JSON: agent envelope `{ interactions, spec }` (host maps interactions onto
- *   GGPlot props; bare PortableSpec is also accepted and defaults inspect on)
+ * axes) plus GuideLegend focus. Inspect stays a GGPlot host prop; legend focus
+ * is a host-only prop on `<GuideLegend>` (not a PortableSpec field).
+ * - Svelte: `inspect` / `key` on <GGPlot>, `focus` on <GuideLegend>
+ * - Builder + spec: same host children for focus; inspect still on <GGPlot>
+ * - JSON: agent envelope `{ interactions, spec }` still accepts legendFocus
+ *   (deprecated host map until 0.20.0)
  */
 
 const HOME_CODE_PATH_SVELTE = `<script lang="ts">
-  import { GeomJitter, GeomSmooth, GGPlot, Labs } from "@ggsvelte/svelte";
+  import { GeomJitter, GeomSmooth, GGPlot, GuideLegend, Labs } from "@ggsvelte/svelte";
   import { palmerPenguins } from "@ggsvelte/svelte/data";
 </script>
 
@@ -28,20 +29,20 @@ const HOME_CODE_PATH_SVELTE = `<script lang="ts">
   key="id"
   aes={{ x: "flipperLengthMm", y: "bodyMassG", color: "species" }}
   inspect={{ mode: "xy", pin: true, maxDistance: 24 }}
-  legendFocus
   width={640}
   height={400}
 >
+  <GuideLegend channel="color" focus />
   <Labs x="Flipper length mm" y="Body mass g" color="species" />
   <GeomJitter alpha={0.88} />
   <GeomSmooth method="loess" span={0.75} degree={1} se={false} />
 </GGPlot>
 `;
 
-/** Builder produces PortableSpec; inspect/legendFocus are host GGPlot props. */
+/** Builder produces PortableSpec; inspect is a host GGPlot prop; focus is GuideLegend. */
 const HOME_CODE_PATH_BUILDER = `<script lang="ts">
   import { aes, gg } from "@ggsvelte/spec";
-  import { GGPlot } from "@ggsvelte/svelte";
+  import { GGPlot, GuideLegend } from "@ggsvelte/svelte";
   import { palmerPenguins } from "@ggsvelte/svelte/data";
 
   const spec = gg(
@@ -58,16 +59,18 @@ const HOME_CODE_PATH_BUILDER = `<script lang="ts">
   {spec}
   key="id"
   inspect={{ mode: "xy", pin: true, maxDistance: 24 }}
-  legendFocus
   width={640}
   height={400}
-/>
+>
+  <GuideLegend channel="color" focus />
+</GGPlot>
 `;
 
 /**
  * Agent envelope: host interaction flags + named-data PortableSpec.
  * `spec` alone is valid PortableSpec; interactions are applied by the host.
  * `inspect: true` still defaults mode "auto"; the homepage host opts into xy.
+ * `legendFocus` remains in the envelope as a deprecated host map (0.19–0.20).
  */
 const HOME_CODE_PATH_SPEC_JSON = `{
   "interactions": {

--- a/apps/docs/src/routes/__perf/legend-focus-100k/+page.svelte
+++ b/apps/docs/src/routes/__perf/legend-focus-100k/+page.svelte
@@ -1,5 +1,10 @@
 <script lang="ts">
-  import { createPlotInteraction, GGPlot, Labs } from "@ggsvelte/svelte";
+  import {
+    createPlotInteraction,
+    GGPlot,
+    GuideLegend,
+    Labs,
+  } from "@ggsvelte/svelte";
 
   const navigationData = Array.from({ length: 100_000 }, (_, id) => ({
     id,
@@ -34,13 +39,13 @@
       aes={mapping}
       layers={[{ geom: "point", render: "canvas", params: { size: 1 } }]}
       key="id"
-      legendFocus={{ preview: false }}
       interaction={navigationInteraction}
       interactionScope={navigationScope}
       width={620}
       height={360}
       onrender={() => (commitsNavigation += 1)}
     >
+      <GuideLegend channel="color" focus={{ preview: false }} />
       <Labs title="100k navigation view" color="Group" />
     </GGPlot>
   </div>
@@ -51,7 +56,6 @@
         aes={mapping}
         layers={[{ geom: "point", render: "canvas", params: { size: 1 } }]}
         key="id"
-        legendFocus={{ preview: false }}
         {interaction}
         interactionScope={scope}
         width={620}
@@ -62,6 +66,7 @@
           else commitsC += 1;
         }}
       >
+        <GuideLegend channel="color" focus={{ preview: false }} />
         <Labs title={`Linked view ${name}`} color="Group" />
       </GGPlot>
     </div>

--- a/apps/docs/static/previews/provenance.json
+++ b/apps/docs/static/previews/provenance.json
@@ -8,12 +8,12 @@
     },
     "area/stacked": {
       "filename": "area-stacked-light.png",
-      "sourceSha256": "cf224e6eb23c3364fd7ce91191fba0c2c498da69e9754913ee49a24aa339281d",
+      "sourceSha256": "eb73d2621c04396a57136201e3c760525ec8096ba354ab5658402edc8d4177b1",
       "pngSha256": "5a708d0255b3c8c56bbecc0f1dc7849420f5ca6f7cb69785954752b8adb50d1a"
     },
     "bar/dodged": {
       "filename": "bar-dodged-light.png",
-      "sourceSha256": "092c88ce39dbf2f00907ced437954139cc1d74573931d712678abfe22ad53388",
+      "sourceSha256": "da8c995f706da2e14774b12fe608061e3c7001d046b2bab1faf61d47821da369",
       "pngSha256": "8cb6896fb9bbc0a416a68469e855b558087867d8b1930b4ad1eade6037ecd7de"
     },
     "bar/horizontal": {
@@ -28,7 +28,7 @@
     },
     "bar/stacked": {
       "filename": "bar-stacked-light.png",
-      "sourceSha256": "f6f985fc2566316cee5ab7fcf4ff9b2700141a0bfc355e66ae3cd43f2e68b514",
+      "sourceSha256": "dfc0b7cb48dfc8d2591b0108dace3b3ed9b0221d9fce688547b576a965791a20",
       "pngSha256": "4c0a7f0b20fcdf9adb777a3c31ec25fbf6d60f30ced058a8f00f22a52bfa4dfd"
     },
     "bin2d/basic": {
@@ -183,7 +183,7 @@
     },
     "interaction/legend-focus": {
       "filename": "interaction-legend-focus-light.png",
-      "sourceSha256": "dab5f5b760418f15e286fc6d95b336dbeedf14ad1b4eeb06e32f8a5bcbead9cd",
+      "sourceSha256": "776c12969bcd513265b2085bbf3ffba44a3a2d125595b5f79759bcdec0ca7674",
       "pngSha256": "38aa3c7f47d1c3ab2807039e2377f3c93e292c47c6c19cfe3c2de80e6156091c"
     },
     "interaction/linked-views": {
@@ -218,7 +218,7 @@
     },
     "line/multi-series": {
       "filename": "line-multi-series-light.png",
-      "sourceSha256": "b3d2c1e6f012dedbdd6b8b01bf4081e3e1b116f2b9229e2bc487be88f354380d",
+      "sourceSha256": "67891f53015c3f32cff5b72765c418a94813df80b2ff5a69b3fe074f5377c122",
       "pngSha256": "da402afca8515a3005d24268f44cc037a1202ce7248675b03c9afbeac3bfc69d"
     },
     "line/time-axis": {
@@ -288,7 +288,7 @@
     },
     "point/log-scale": {
       "filename": "point-log-scale-light.png",
-      "sourceSha256": "bee3a418adfa9b9d0a407a796be9fbcd68d68cd6390385f81ab9462711e188b0",
+      "sourceSha256": "4376eae6453a1497330a5f68fb1625aec2343be593244141476a50160c761699",
       "pngSha256": "e4cca5e252e49ced88e85a92ff84016533cbbc0fbad7d705fbecbd6e9c84c8a2"
     },
     "point/quantile-lines": {
@@ -298,7 +298,7 @@
     },
     "point/scatter-color": {
       "filename": "point-scatter-color-light.png",
-      "sourceSha256": "d1344f0d75c319ee825d797e657968bb05d1f88cb9ad0148543b1dc228b1201d",
+      "sourceSha256": "5c9c94030e4bdaf24df71658225528e1befb14f5722c2da07121b7786db6ad77",
       "pngSha256": "9bbe802827346cc004c03894c8aa27819493a6d7b6bb61ec16eb0b6120b75dd4"
     },
     "point/stat-manual-mean": {

--- a/examples/area/stacked/Example.svelte
+++ b/examples/area/stacked/Example.svelte
@@ -2,6 +2,7 @@
   import {
     GeomArea,
     GGPlot,
+    GuideLegend,
     Labs,
     ScaleFillManual,
     ScaleXDate,
@@ -15,7 +16,6 @@
   data={crimeanMortality}
   aes={{ x: "month", y: "deaths", fill: "cause" }}
   key={(row) => `${row.month}:${row.cause}`}
-  legendFocus
   width={640}
   height={400}
 >
@@ -32,5 +32,6 @@
     y="Deaths per 1,000 per year"
     fill="Cause"
   />
+  <GuideLegend channel="fill" focus />
   <GeomArea alpha={0.9} />
 </GGPlot>

--- a/examples/bar/dodged/Example.svelte
+++ b/examples/bar/dodged/Example.svelte
@@ -2,6 +2,7 @@
   import {
     GeomBar,
     GGPlot,
+    GuideLegend,
     Labs,
     ScaleFillDiscrete,
     ThemeFew,
@@ -14,7 +15,6 @@
   data={edgeworthDeaths}
   aes={{ x: "year", fill: "county", weight: "deaths" }}
   key={(row) => `${row.year}:${row.county}`}
-  legendFocus
   width={640}
   height={400}
 >
@@ -27,5 +27,6 @@
     y="Deaths per million"
     fill="County"
   />
+  <GuideLegend channel="fill" focus />
   <GeomBar position="dodge" />
 </GGPlot>

--- a/examples/bar/stacked/Example.svelte
+++ b/examples/bar/stacked/Example.svelte
@@ -2,6 +2,7 @@
   import {
     GeomBar,
     GGPlot,
+    GuideLegend,
     Labs,
     ScaleFillDiscrete,
     ScaleXDiscrete,
@@ -15,7 +16,6 @@
   data={pyxTrial}
   aes={{ x: "bag", fill: "deviation", weight: "count" }}
   key={(row) => `${row.bag}:${row.deviation}`}
-  legendFocus
   width={640}
   height={400}
 >
@@ -43,5 +43,6 @@
     y="Sovereigns"
     fill="Deviation"
   />
+  <GuideLegend channel="fill" focus />
   <GeomBar />
 </GGPlot>

--- a/examples/interaction/legend-focus/Example.svelte
+++ b/examples/interaction/legend-focus/Example.svelte
@@ -4,6 +4,7 @@
     GeomLine,
     GeomPoint,
     GGPlot,
+    GuideLegend,
     Labs,
     ScaleXContinuous,
     ThemeFew,
@@ -40,13 +41,13 @@
       data={rows}
       aes={mapping}
       key="id"
-      legendFocus
       {interaction}
       interactionScope={scope}
       width="container"
       height={310}
       onlegendfocus={describe}
     >
+      <GuideLegend channel="color" focus />
       <ThemeFew />
       <ScaleXContinuous labels="d" />
       <Labs title="SVG points" x="Year" y="Index units" color="Series" />
@@ -56,13 +57,13 @@
       data={rows}
       aes={mapping}
       key="id"
-      legendFocus
       {interaction}
       interactionScope={scope}
       width="container"
       height={310}
       onlegendfocus={describe}
     >
+      <GuideLegend channel="color" focus />
       <ThemeFew />
       <ScaleXContinuous labels="d" />
       <Labs title="Canvas points" x="Year" y="Index units" color="Series" />
@@ -72,13 +73,13 @@
       data={rows}
       aes={mapping}
       key="id"
-      legendFocus
       {interaction}
       interactionScope={scope}
       width="container"
       height={310}
       onlegendfocus={describe}
     >
+      <GuideLegend channel="color" focus />
       <ThemeFew />
       <ScaleXContinuous labels="d" />
       <Labs title="SVG lines" x="Year" y="Index units" color="Series" />

--- a/examples/line/multi-series/Example.svelte
+++ b/examples/line/multi-series/Example.svelte
@@ -3,6 +3,7 @@
     GeomLine,
     GeomPoint,
     GGPlot,
+    GuideLegend,
     Labs,
     ScaleColorManual,
     ScaleXContinuous,
@@ -16,7 +17,6 @@
   data={wheatAndWages}
   aes={{ x: "year", y: "value", color: "series" }}
   key={(row) => `${row.year}:${row.series}`}
-  legendFocus
   width={640}
   height={400}
 >
@@ -37,6 +37,7 @@
     y="Shillings"
     color="Series"
   />
+  <GuideLegend channel="color" focus />
   <GeomLine linewidth={2} />
   <GeomPoint size={1.6} />
 </GGPlot>

--- a/examples/point/log-scale/Example.svelte
+++ b/examples/point/log-scale/Example.svelte
@@ -2,6 +2,7 @@
   import {
     GeomPoint,
     GGPlot,
+    GuideLegend,
     Labs,
     ScaleColorManual,
     ScaleXLog10,
@@ -15,7 +16,6 @@
   data={londonCholera}
   aes={{ x: "density", y: "deathRate", color: "water" }}
   key="district"
-  legendFocus
   inspect={{ mode: "xy", pin: true }}
   width="container"
   height={400}
@@ -33,5 +33,6 @@
     y="Cholera deaths per 10,000"
     color="Water supply"
   />
+  <GuideLegend channel="color" focus />
   <GeomPoint size={3.5} />
 </GGPlot>

--- a/examples/point/scatter-color/Example.svelte
+++ b/examples/point/scatter-color/Example.svelte
@@ -2,6 +2,7 @@
   import {
     GeomPoint,
     GGPlot,
+    GuideLegend,
     Labs,
     ScaleColorDiscrete,
     ThemeFew,
@@ -14,7 +15,6 @@
   data={guerry}
   aes={{ x: "literacy", y: "crimePersons", color: "region" }}
   key="department"
-  legendFocus
   width={640}
   height={400}
 >
@@ -27,5 +27,6 @@
     y="Population per crime against persons"
     color="Region"
   />
+  <GuideLegend channel="color" focus />
   <GeomPoint size={3} />
 </GGPlot>

--- a/packages/svelte/skills/ggsvelte/SKILL.md
+++ b/packages/svelte/skills/ggsvelte/SKILL.md
@@ -114,8 +114,9 @@ direct props (`size={3}`); structural props are `data`, `stat`, `position`,
 
 `<GGPlot>` props: `spec`, `data`, `aes`, `layers`, `key`, `width`
 (number | "container"), `height`, `a11y`, `ariaLabel`, the interaction props
-(`inspect`, `select`, `zoom`, `legendFocus`, `legendFilter`, `tool`,
-`interaction`, `interactionScope`), the `on*` handlers, and `children`.
+(`inspect`, `select`, `zoom`, `legendFilter`, `tool`, `interaction`,
+`interactionScope`; `legendFocus` is deprecated — use
+`<GuideLegend channel focus>`), the `on*` handlers, and `children`.
 Instance methods: `resetScales()`, `setZoom()`.
 
 Precedence: `spec` wins over everything else. For mark layers, an explicit
@@ -272,12 +273,12 @@ violin, tile heatmap, hex density, ECDF step, ribbon, flipped boxplot,
 per-layer aes override, sf/map — each as validated JSON plus a Svelte twin:
 [references/recipes.md](references/recipes.md).
 
-## Interactions (Svelte props, not spec fields)
+## Interactions (host props, not PortableSpec fields)
 
-Opt-in `<GGPlot>` props: `inspect` (tooltip/crosshair/keyboard/pinning),
-`select` (point or interval), `zoom` (brush), `legendFocus` (emphasis only),
-`legendFilter` (refilters and reruns the grammar, colors stay stable). Always
-give a stable `key` when selection or linked views must survive filtering or
+Opt-in host capabilities: `inspect` / `select` / `zoom` / `legendFilter` on
+`<GGPlot>`; legend emphasis via `<GuideLegend channel="color" focus />`
+(per aesthetic; host-only, not in `guideLegend()` / PortableSpec). Always give
+a stable `key` when selection or linked views must survive filtering or
 refreshes. Link plots by sharing one `createPlotInteraction()` controller and
 matching `interactionScope` channels; observe everything through
 `oninteraction` or per-capability handlers. Faceted interval presets, the

--- a/packages/svelte/skills/ggsvelte/references/interactions.md
+++ b/packages/svelte/skills/ggsvelte/references/interactions.md
@@ -3,23 +3,28 @@
 # Svelte interactions
 
 `@ggsvelte/svelte` requires Svelte `^5.33.1` (peerDependency). Interactions are
-opt-in PROPS on `<GGPlot>` — they are not spec fields and never appear in a
-PortableSpec. Always pass a stable `key` when selection, legend focus, or
+opt-in host capabilities — they are not PortableSpec fields (never serialise
+into a plot JSON). Always pass a stable `key` when selection, legend focus, or
 coordinated intervals must survive filtering, reordering, or data refreshes.
 
 ## Capability props
 
-| Prop           | Input                                                  | What it enables                                                                                                                                                                                                                                                                                                |
-| -------------- | ------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `inspect`      | `boolean \| InspectOptions`                            | Tooltip, semantic crosshair, keyboard traversal, pinning. Options: `mode` (`"auto" \| "exact" \| "x" \| "y" \| "xy"`), `pin`, `maxDistance` (CSS px), `contentMode` (`"informational" \| "interactive"`), `muteSiblings`, `content` (Snippet, see Tooltip below).                                              |
-| `select`       | `false \| "point" \| "interval" \| SelectOptions`      | Point or interval selection. Options: `type` (`"point" \| "interval"`), `mode` (`"x" \| "y" \| "xy"`, interval only), `multiple`, `persistent`, `preset` (faceted intervals, below).                                                                                                                           |
-| `zoom`         | `boolean \| ZoomOptions`                               | Brush zoom. Options: `mode` (`"x" \| "y" \| "xy"`), `trigger` (`"brush"`). Currently requires one unfaceted panel.                                                                                                                                                                                             |
-| `legendFocus`  | `boolean \| { preview?: boolean }`                     | Discrete legend preview, focus, and linked emphasis. Emphasis only — never changes included rows. Discrete color/fill legends only; continuous ramps stay static. Mute de-emphasizes non-focused marks; dashed rings appear only on sparse point marks (≤48 anchors), never on paths/areas/bars/segments/text. |
-| `legendFilter` | `boolean \| LegendFilterOptions`                       | Data-changing filtering through discrete legend controls: changes the included rows and reruns the grammar while preserving stable color identity. Options: `mode` (`"exclude" \| "include"`), `multiple`.                                                                                                     |
-| `key`          | column name or `(row, index) => PropertyKey`           | Stable semantic identity for public interaction payloads. Required for durable point selection, coordinated interval presets, and legend focus/filter. Duplicate or unstable keys are diagnostic errors.                                                                                                       |
-| `tool`         | `"inspect" \| "point" \| "select-area" \| "zoom-area"` | Controlled initial/active tool; observe changes with `ontoolchange`.                                                                                                                                                                                                                                           |
-| `ariaLabel`    | `string`                                               | Accessible chart name; falls back to the plot title or a generated label.                                                                                                                                                                                                                                      |
-| `a11y`         | `A11yMode`                                             | `"force-svg"` keeps every layer as SVG marks.                                                                                                                                                                                                                                                                  |
+| Prop / surface | Input                                                  | What it enables                                                                                                                                                                                                                                                                                                                                                                            |
+| -------------- | ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `inspect`      | `boolean \| InspectOptions` on `<GGPlot>`              | Tooltip, semantic crosshair, keyboard traversal, pinning. Options: `mode` (`"auto" \| "exact" \| "x" \| "y" \| "xy"`), `pin`, `maxDistance` (CSS px), `contentMode` (`"informational" \| "interactive"`), `muteSiblings`, `content` (Snippet, see Tooltip below).                                                                                                                          |
+| `select`       | `false \| "point" \| "interval" \| SelectOptions`      | Point or interval selection. Options: `type` (`"point" \| "interval"`), `mode` (`"x" \| "y" \| "xy"`, interval only), `multiple`, `persistent`, `preset` (faceted intervals, below).                                                                                                                                                                                                       |
+| `zoom`         | `boolean \| ZoomOptions`                               | Brush zoom. Options: `mode` (`"x" \| "y" \| "xy"`), `trigger` (`"brush"`). Currently requires one unfaceted panel.                                                                                                                                                                                                                                                                         |
+| `focus`        | `boolean \| { preview?: boolean }` on `<GuideLegend>`  | Discrete legend preview, focus, and linked emphasis **for that aesthetic channel**. Emphasis only — never changes included rows. Discrete legends only; continuous ramps stay static. Mute de-emphasizes non-focused marks; dashed rings appear only on sparse point marks (≤48 anchors), never on paths/areas/bars/segments/text. Host-only — not a PortableSpec / `guideLegend()` field. |
+| `legendFilter` | `boolean \| LegendFilterOptions` on `<GGPlot>`         | Data-changing filtering through discrete legend controls: changes the included rows and reruns the grammar while preserving stable color identity. Options: `mode` (`"exclude" \| "include"`), `multiple`.                                                                                                                                                                                 |
+| `key`          | column name or `(row, index) => PropertyKey`           | Stable semantic identity for public interaction payloads. Required for durable point selection, coordinated interval presets, and legend focus/filter. Duplicate or unstable keys are diagnostic errors.                                                                                                                                                                                   |
+| `tool`         | `"inspect" \| "point" \| "select-area" \| "zoom-area"` | Controlled initial/active tool; observe changes with `ontoolchange`.                                                                                                                                                                                                                                                                                                                       |
+| `ariaLabel`    | `string`                                               | Accessible chart name; falls back to the plot title or a generated label.                                                                                                                                                                                                                                                                                                                  |
+| `a11y`         | `A11yMode`                                             | `"force-svg"` keeps every layer as SVG marks.                                                                                                                                                                                                                                                                                                                                              |
+
+### Deprecated: `legendFocus` on `<GGPlot>`
+
+Since 0.19.0, prefer `<GuideLegend channel="color" focus />`. The plot prop
+still enables focus plot-wide until 0.20.0 and emits `DEPRECATED_PLOT_PROP`.
 
 After an interval or zoom commit, accessible controls accept exact bounds.
 
@@ -110,6 +115,7 @@ entry has `severity`, `code`, `message`, `prop`, `suggestions`, `docUrl`):
     Facet,
     GeomPoint,
     GGPlot,
+    GuideLegend,
   } from "@ggsvelte/svelte";
 
   const interaction = createPlotInteraction<number>();
@@ -121,12 +127,12 @@ entry has `severity`, `code`, `message`, `prop`, `suggestions`, `docUrl`):
   aes={{ x: "date", y: "value", color: "series" }}
   key="id"
   select={{ type: "interval", mode: "x", preset: "cross-panel" }}
-  legendFocus
   legendFilter
   {interaction}
   interactionScope={scope}
   oninteraction={(event) => console.log(event.type, event)}
 >
+  <GuideLegend channel="color" focus />
   <Facet wrap="region" ncol={3} />
   <GeomPoint />
 </GGPlot>

--- a/packages/svelte/src/lib/guides/GuideLegend.svelte
+++ b/packages/svelte/src/lib/guides/GuideLegend.svelte
@@ -4,23 +4,65 @@
    * (#659 slice 6). Presentation of one aesthetic's legend: title, position,
    * direction, key size, collision, and the INTEGER placement rank `order`.
    *
+   * Host interaction: `focus` opts this channel into discrete legend
+   * preview/pin emphasis. It is NOT a PortableSpec field — stripped before
+   * guideLegend() and registered as host layer kind `legendFocus`.
+   * Focus-only children (no presentation options) do not force a guides
+   * entry, so continuous colour scales keep their colorbar without a
+   * guide-aesthetic-incompatible pipeline error.
+   *
    * Not to be confused with <Legend order="sorted"/>, which is the plot-wide
    * entry-SORT enum (LegendSpec). Same word, unrelated concepts.
    * Emits NO markup.
    */
   import { guideLegend, type LegendGuideOptions } from "@ggsvelte/spec";
 
-  import { createPlotLayer } from "../layers/plot-layer.svelte.js";
+  import type { LegendFocusInput } from "../interaction/interaction.js";
+  import {
+    isLegendFocusPropEnabled,
+    type LegendFocusLayerValue,
+  } from "../legend/resolve-legend-focus.js";
+  import {
+    createPlotLayer,
+    definedProps,
+  } from "../layers/plot-layer.svelte.js";
   import {
     splitChannel,
     type NonPositionGuideChannel,
   } from "./factory.svelte.js";
 
-  type Props = LegendGuideOptions & { channel: NonPositionGuideChannel };
+  type Props = LegendGuideOptions & {
+    channel: NonPositionGuideChannel;
+    /**
+     * Opt this channel into discrete legend preview, focus, and linked
+     * emphasis. Host-only — never appears in PortableSpec.
+     */
+    focus?: LegendFocusInput;
+  };
 
   const props: Props = $props();
+
   createPlotLayer("guides", () => {
-    const { channel, options } = splitChannel(props);
+    const defined = definedProps(props) as Props;
+    const { focus: _focus, ...withoutFocus } = defined;
+    const { channel, options } = splitChannel(withoutFocus);
+    // Focus-only: do not force type:"legend" (breaks continuous ramps).
+    if (
+      Object.keys(options).length === 0 &&
+      isLegendFocusPropEnabled(defined.focus)
+    ) {
+      return {};
+    }
     return { [channel]: guideLegend(options) };
+  });
+
+  createPlotLayer("legendFocus", (): LegendFocusLayerValue => {
+    const defined = definedProps(props) as Props;
+    const focus = defined.focus;
+    if (!isLegendFocusPropEnabled(focus)) return null;
+    return {
+      channel: defined.channel,
+      input: focus === true ? true : focus,
+    };
   });
 </script>

--- a/packages/svelte/src/lib/interaction/interaction-diagnostics.ts
+++ b/packages/svelte/src/lib/interaction/interaction-diagnostics.ts
@@ -125,8 +125,12 @@ export const INTERACTION_DIAGNOSTIC_CATALOG: Readonly<
     code: "INTERACTION_LEGEND_DISCRETE_ONLY",
     message:
       "Legend focus currently applies to discrete color and fill legends; continuous ramps remain static.",
-    prop: "legendFocus",
-    suggestions: ["Use a discrete color or fill mapping", "Keep the continuous ramp static"],
+    prop: "focus",
+    suggestions: [
+      'Enable focus on a discrete guide: <GuideLegend channel="color" focus />',
+      "Use a discrete color or fill mapping",
+      "Keep the continuous ramp static",
+    ],
     docUrl: "https://ggsvelte.sh/guide/interaction-reference#interaction-legend-discrete-only",
   },
   INTERACTION_INTERVAL_SCALE_UNSUPPORTED: {

--- a/packages/svelte/src/lib/layers/fold.ts
+++ b/packages/svelte/src/lib/layers/fold.ts
@@ -46,6 +46,10 @@ export function foldPlotLayer(draft: AssembleDraft, layer: PlotLayerLike): Assem
   if (layer.kind === "mark") {
     return draft;
   }
+  // Host-only interaction contributions never fold into PortableSpec.
+  if (layer.kind === "legendFocus") {
+    return draft;
+  }
   // Index via string map so unforeseen runtime kinds are undefined (not a
   // silent miss). Typed callers already exhaust GrammarLayerKind.
   const family = (GRAMMAR_FAMILIES as Readonly<Record<string, GrammarFamilyMeta | undefined>>)[

--- a/packages/svelte/src/lib/layers/types.ts
+++ b/packages/svelte/src/lib/layers/types.ts
@@ -20,6 +20,8 @@ import type {
   ThemeSpec,
 } from "@ggsvelte/spec";
 
+import type { LegendFocusLayerValue } from "../legend/resolve-legend-focus.js";
+
 /**
  * A live mark-layer descriptor: properties are getters over the child's
  * `$props`, so prop updates flow into the plot's derived spec without
@@ -60,10 +62,15 @@ export type Layer =
   | { readonly kind: "facet"; get value(): FacetInput }
   | { readonly kind: "labs"; get value(): Labs }
   | { readonly kind: "guides"; get value(): GuidesSpec }
-  | { readonly kind: "legend"; get value(): LegendSpec };
+  | { readonly kind: "legend"; get value(): LegendSpec }
+  /** Host-only interaction contribution from `<GuideLegend focus>` — not PortableSpec. */
+  | { readonly kind: "legendFocus"; get value(): LegendFocusLayerValue };
 
-/** Non-mark grammar layer kinds (the seven #659 families). */
-export type GrammarLayerKind = Exclude<Layer["kind"], "mark">;
+/** Non-mark grammar layer kinds (the seven #659 families). Host-only kinds excluded. */
+export type GrammarLayerKind = Exclude<Layer["kind"], "mark" | "legendFocus">;
+
+/** Host-only layer kinds that must not fold into PortableSpec. */
+export type HostLayerKind = Extract<Layer["kind"], "legendFocus">;
 
 /**
  * Structural form accepted by fold/assemble: `value` may be a live getter or a
@@ -77,4 +84,10 @@ export type PlotLayerLike =
   | { readonly kind: "facet"; readonly value: FacetInput }
   | { readonly kind: "labs"; readonly value: Labs }
   | { readonly kind: "guides"; readonly value: GuidesSpec }
-  | { readonly kind: "legend"; readonly value: LegendSpec };
+  | { readonly kind: "legend"; readonly value: LegendSpec }
+  | { readonly kind: "legendFocus"; readonly value: LegendFocusLayerValue };
+
+/** True for host-only registry kinds that assemble/fold must ignore. */
+export function isHostPlotLayer(layer: { readonly kind: string }): boolean {
+  return layer.kind === "legendFocus";
+}

--- a/packages/svelte/src/lib/layers/types.ts
+++ b/packages/svelte/src/lib/layers/types.ts
@@ -69,9 +69,6 @@ export type Layer =
 /** Non-mark grammar layer kinds (the seven #659 families). Host-only kinds excluded. */
 export type GrammarLayerKind = Exclude<Layer["kind"], "mark" | "legendFocus">;
 
-/** Host-only layer kinds that must not fold into PortableSpec. */
-export type HostLayerKind = Extract<Layer["kind"], "legendFocus">;
-
 /**
  * Structural form accepted by fold/assemble: `value` may be a live getter or a
  * plain field. Compatible with registry `Layer` objects and test literals.

--- a/packages/svelte/src/lib/legend/resolve-legend-focus.ts
+++ b/packages/svelte/src/lib/legend/resolve-legend-focus.ts
@@ -9,14 +9,7 @@ import type { LegendFocusInput } from "../interaction/interaction.js";
 import type { InteractiveLegendEntry } from "./focus.js";
 
 /** Aesthetic channel a GuideLegend may enable for focus (non-position). */
-export type LegendFocusChannel =
-  | "color"
-  | "fill"
-  | "size"
-  | "linewidth"
-  | "alpha"
-  | "shape"
-  | "linetype";
+type LegendFocusChannel = "color" | "fill" | "size" | "linewidth" | "alpha" | "shape" | "linetype";
 
 /** One GuideLegend's host-only focus contribution (null when focus is off). */
 export type LegendFocusLayerValue = {

--- a/packages/svelte/src/lib/legend/resolve-legend-focus.ts
+++ b/packages/svelte/src/lib/legend/resolve-legend-focus.ts
@@ -1,0 +1,142 @@
+/**
+ * Resolve legend-focus capability from host-only GuideLegend `focus` layers
+ * and the deprecated plot-level `legendFocus` prop.
+ *
+ * Interactions stay off PortableSpec: `focus` is stripped before guideLegend()
+ * and travels as registry layer kind `legendFocus`.
+ */
+import type { LegendFocusInput } from "../interaction/interaction.js";
+import type { InteractiveLegendEntry } from "./focus.js";
+
+/** Aesthetic channel a GuideLegend may enable for focus (non-position). */
+export type LegendFocusChannel =
+  | "color"
+  | "fill"
+  | "size"
+  | "linewidth"
+  | "alpha"
+  | "shape"
+  | "linetype";
+
+/** One GuideLegend's host-only focus contribution (null when focus is off). */
+export type LegendFocusLayerValue = {
+  readonly channel: LegendFocusChannel;
+  readonly input: Exclude<LegendFocusInput, false>;
+} | null;
+
+export type LegendFocusChannelSet = ReadonlySet<string> | "all";
+
+export type ResolvedLegendFocusCapability = {
+  /**
+   * Requested opt-in for wiring advisories (truthy even when keyless
+   * degradation later nulls the resolved config).
+   */
+  readonly requested: LegendFocusInput | false;
+  /** Value fed to normalizeInteractionConfig. */
+  readonly configInput: LegendFocusInput | false;
+  /**
+   * `"all"` = deprecated plot prop only (every discrete interactive legend).
+   * Otherwise only legends whose aesthetics intersect this set get targets.
+   */
+  readonly channels: LegendFocusChannelSet;
+};
+
+type LegendFocusLayerLike = {
+  readonly kind: string;
+  /** Live getter or plain field — only read when kind is legendFocus. */
+  readonly value?: unknown;
+};
+
+function isEnabledInput(
+  input: LegendFocusInput | undefined,
+): input is Exclude<LegendFocusInput, false> {
+  return input !== undefined && input !== false;
+}
+
+function readChildLayers(
+  layers: readonly LegendFocusLayerLike[],
+): ReadonlyArray<{ channel: string; input: Exclude<LegendFocusInput, false> }> {
+  const out: Array<{ channel: string; input: Exclude<LegendFocusInput, false> }> = [];
+  for (const layer of layers) {
+    if (layer.kind !== "legendFocus") continue;
+    // Layer values may be live getters (registry) — read via property access.
+    const value = (layer as { value: LegendFocusLayerValue }).value;
+    if (value === null || value === undefined) continue;
+    if (!isEnabledInput(value.input)) continue;
+    out.push({ channel: value.channel, input: value.input });
+  }
+  return out;
+}
+
+/** Merge preview flags: any explicit `preview: false` disables preview. */
+function resolvePreview(
+  plotProp: LegendFocusInput | undefined,
+  children: ReadonlyArray<{ input: Exclude<LegendFocusInput, false> }>,
+): boolean {
+  if (typeof plotProp === "object" && plotProp.preview === false) return false;
+  for (const child of children) {
+    if (typeof child.input === "object" && child.input.preview === false) return false;
+  }
+  return true;
+}
+
+function toConfigInput(preview: boolean): Exclude<LegendFocusInput, false> {
+  return preview ? true : { preview: false };
+}
+
+/**
+ * Combine deprecated plot prop + GuideLegend focus children into one capability.
+ * Children define per-channel enablement when present; plot prop alone is `"all"`.
+ */
+export function resolveLegendFocusCapability(input: {
+  readonly plotProp: LegendFocusInput | undefined;
+  readonly layers: readonly LegendFocusLayerLike[];
+}): ResolvedLegendFocusCapability {
+  const children = readChildLayers(input.layers);
+  const plotOn = isEnabledInput(input.plotProp);
+
+  if (children.length === 0 && !plotOn) {
+    return { requested: false, configInput: false, channels: new Set() };
+  }
+
+  const preview = resolvePreview(input.plotProp, children);
+  const configInput = toConfigInput(preview);
+
+  if (children.length > 0) {
+    return {
+      requested: configInput,
+      configInput,
+      channels: new Set(children.map((child) => child.channel)),
+    };
+  }
+
+  return {
+    requested: input.plotProp ?? false,
+    configInput: input.plotProp ?? false,
+    channels: "all",
+  };
+}
+
+/**
+ * Keep interactive targets whose scene legend aesthetics intersect the
+ * enabled channel set. Merged legends expose all aesthetics on
+ * `legend.aesthetics` (primary `scale` alone is not enough).
+ */
+export function filterInteractiveLegendEntries(
+  entries: readonly InteractiveLegendEntry[],
+  channels: LegendFocusChannelSet,
+): InteractiveLegendEntry[] {
+  if (channels === "all") return entries.slice();
+  if (channels.size === 0) return [];
+  return entries.filter((entry) => {
+    const aesthetics = entry.legend.aesthetics ?? [entry.legend.scale];
+    return aesthetics.some((aesthetic) => channels.has(aesthetic));
+  });
+}
+
+/** True when `focus` is an active opt-in (boolean true or options object). */
+export function isLegendFocusPropEnabled(
+  focus: LegendFocusInput | undefined,
+): focus is Exclude<LegendFocusInput, false> {
+  return isEnabledInput(focus);
+}

--- a/packages/svelte/src/lib/plot-engine.svelte.ts
+++ b/packages/svelte/src/lib/plot-engine.svelte.ts
@@ -78,8 +78,15 @@ import type { FilterableLegendEntry, LegendFilterState } from "./legend/filter-s
 import type { InteractiveLegendEntry, LegendEntryIdentity } from "./legend/focus.js";
 import { createLegendFocusState } from "./legend/focus-state.svelte.js";
 import type { LegendFocusState } from "./legend/focus-state.svelte.js";
+import {
+  filterInteractiveLegendEntries,
+  resolveLegendFocusCapability,
+  type ResolvedLegendFocusCapability,
+} from "./legend/resolve-legend-focus.js";
 import { createPlotChromeState } from "./chrome/chrome-state.svelte.js";
 import type { PlotChromeState } from "./chrome/chrome-state.svelte.js";
+import { isHostPlotLayer } from "./layers/types.js";
+import { deprecatedPropDiagnostic } from "./diagnostics/deprecation.js";
 import {
   resolveCapabilities,
   type EnginePlotProps,
@@ -203,7 +210,10 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
       // Mark layers only: a `layers={[…]}` prop suppresses registry marks, not
       // non-mark plot layers (theme/scale/coord/facet/labs/guides/legend).
       layers: layers ?? host.registry.markLayers.map(toLayerInput),
-      plotLayers: host.registry.layers.filter((layer) => layer.kind !== "mark"),
+      // Grammar only — host-only kinds (legendFocus) never fold into PortableSpec.
+      plotLayers: host.registry.layers.filter(
+        (layer) => layer.kind !== "mark" && !isHostPlotLayer(layer),
+      ),
       ...(a11y !== undefined && { a11y }),
     });
   }
@@ -243,17 +253,33 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
     })(),
   );
 
+  /**
+   * Legend focus from `<GuideLegend focus>` (and deprecated plot prop).
+   * SSR recompute: same one-pass empty-registry trap as assembleCurrentSpec —
+   * children register after construction-time $derived may snapshot.
+   */
+  function resolveLegendFocusNow(): ResolvedLegendFocusCapability {
+    return resolveLegendFocusCapability({
+      plotProp: host.props.legendFocus,
+      layers: host.registry.layers,
+    });
+  }
+  const legendFocusResolvedDerived = $derived.by(resolveLegendFocusNow);
+  const legendFocusResolved = (): ResolvedLegendFocusCapability =>
+    typeof window === "undefined" ? resolveLegendFocusNow() : legendFocusResolvedDerived;
+
   const interactionConfig = $derived(
     (() => {
       const tool = host.props.tool;
       // Four fields only — legendFilter is not part of normalizeInteractionConfig.
       // Reading it via caps() re-delivered config diagnostics on every filter toggle.
+      // legendFocus comes from GuideLegend children (host registry), not only the plot prop.
       return normalizeInteractionConfig(
         {
           inspect: host.props.inspect ?? false,
           select: host.props.select ?? false,
           zoom: host.props.zoom ?? false,
-          legendFocus: host.props.legendFocus ?? false,
+          legendFocus: legendFocusResolved().configInput,
           ...(tool !== undefined && { tool }),
         },
         {
@@ -284,6 +310,9 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
   // taken inside this derived so late-bound handlers still recompute.
   const wiringDiagnostics = $derived.by((): InteractionDiagnostic[] => {
     const capabilities = caps();
+    // legendFocus "requested" is the GuideLegend/child (or deprecated prop)
+    // opt-in — not the post-key-check resolved config — so keyless focus does
+    // not double-advise HANDLER_WITHOUT_CAPABILITY + LEGEND_REQUIRES_KEY.
     return collectWiringDiagnostics({
       interactionScope: host.props.interactionScope,
       interaction: host.props.interaction,
@@ -298,12 +327,12 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
         inspect: capabilities.inspect,
         select: capabilities.select,
         zoom: capabilities.zoom,
-        legendFocus: capabilities.legendFocus,
+        legendFocus: legendFocusResolved().requested,
         legendFilter: capabilities.legendFilter,
       },
     });
   });
-  // Shared once-per-code-per-prop Set for wiring + composition.
+  // Shared once-per-code-per-prop Set for wiring + composition + deprecations.
   // Delivery order is fixed: config effect (above) → wiring → composition.
   // Grammar-prop deprecation emission removed in 0.13.0 (#704) — props gone.
   const deliveredAdvisories = new Set<string>();
@@ -314,6 +343,26 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
       deliveredAdvisories.add(dedupKey);
       deliverDiagnostic(diagnostic);
     }
+  });
+
+  // Deprecated plot-level legendFocus → GuideLegend.focus (one minor window).
+  $effect(() => {
+    const plotProp = host.props.legendFocus;
+    if (plotProp === undefined || plotProp === false) return;
+    const diagnostic = deprecatedPropDiagnostic({
+      prop: "legendFocus",
+      since: "0.19.0",
+      removeIn: "0.20.0",
+      suggestions: [
+        'Use <GuideLegend channel="color" focus /> (or the aesthetic that owns the discrete legend)',
+        "focus={{ preview: false }} on GuideLegend replaces legendFocus={{ preview: false }}",
+      ],
+      anchor: "legend-focus-on-guide-legend",
+    });
+    const dedupKey = `${diagnostic.code}:${diagnostic.prop}`;
+    if (deliveredAdvisories.has(dedupKey)) return;
+    deliveredAdvisories.add(dedupKey);
+    deliverDiagnostic(diagnostic);
   });
 
   // Composition advisories (#659 slices 3+5+6): pure collect over
@@ -625,9 +674,13 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
   });
 
   // Host-side deriveds kept outside the factory (construction-time free of
-  // the model read).
+  // the model read). Channel filter: only aesthetics with GuideLegend focus
+  // (merged legends match via aesthetics[], not primary scale alone).
   const interactiveLegendEntries = $derived(
-    legendFocusState.computeInteractiveEntries(runtime.model),
+    filterInteractiveLegendEntries(
+      legendFocusState.computeInteractiveEntries(runtime.model),
+      legendFocusResolved().channels,
+    ),
   );
 
   const effectiveLegendPressed: LegendEntryIdentity | null = $derived(

--- a/packages/svelte/src/lib/plot-engine.svelte.ts
+++ b/packages/svelte/src/lib/plot-engine.svelte.ts
@@ -88,6 +88,7 @@ import type { PlotChromeState } from "./chrome/chrome-state.svelte.js";
 import { isHostPlotLayer } from "./layers/types.js";
 import { deprecatedPropDiagnostic } from "./diagnostics/deprecation.js";
 import {
+  readLegacyPlotLegendFocus,
   resolveCapabilities,
   type EnginePlotProps,
   type ResolvedPlotCapabilities,
@@ -260,7 +261,7 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
    */
   function resolveLegendFocusNow(): ResolvedLegendFocusCapability {
     return resolveLegendFocusCapability({
-      plotProp: host.props.legendFocus,
+      plotProp: readLegacyPlotLegendFocus(host.props),
       layers: host.registry.layers,
     });
   }
@@ -347,7 +348,7 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
 
   // Deprecated plot-level legendFocus → GuideLegend.focus (one minor window).
   $effect(() => {
-    const plotProp = host.props.legendFocus;
+    const plotProp = readLegacyPlotLegendFocus(host.props);
     if (plotProp === undefined || plotProp === false) return;
     const diagnostic = deprecatedPropDiagnostic({
       prop: "legendFocus",
@@ -357,7 +358,7 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
         'Use <GuideLegend channel="color" focus /> (or the aesthetic that owns the discrete legend)',
         "focus={{ preview: false }} on GuideLegend replaces legendFocus={{ preview: false }}",
       ],
-      anchor: "legend-focus-on-guide-legend",
+      anchor: "legend-focus-on-guidelegend",
     });
     const dedupKey = `${diagnostic.code}:${diagnostic.prop}`;
     if (deliveredAdvisories.has(dedupKey)) return;

--- a/packages/svelte/src/lib/plot-props.ts
+++ b/packages/svelte/src/lib/plot-props.ts
@@ -78,6 +78,7 @@ export interface GGPlotProps<
   /**
    * @deprecated since 0.19.0 — use `<GuideLegend channel="…" focus />` instead.
    * Still honoured (plot-wide enablement) until 0.20.0; emits DEPRECATED_PLOT_PROP.
+   * Migration: https://ggsvelte.sh/guide/upgrading#legend-focus-on-guidelegend
    */
   legendFocus?: LegendFocusInput;
   /** Opt into data-changing filtering through discrete legend controls. */
@@ -117,10 +118,18 @@ export type ResolvedPlotCapabilities = {
  * Defaults the five interaction capability props to `false` when omitted.
  * Pure — does not clone object-form configs (identity preserved for epoch
  * and reference-equality consumers).
+ *
+ * Input is a plain bag (not `Pick<GGPlotProps, …>`) so dual-read of the
+ * deprecated `legendFocus` prop does not trip `typescript/no-deprecated`
+ * at every resolveCapabilities call site during the 0.19→0.20 window.
  */
-export function resolveCapabilities(
-  props: Pick<GGPlotProps, "inspect" | "select" | "zoom" | "legendFocus" | "legendFilter">,
-): ResolvedPlotCapabilities {
+export function resolveCapabilities(props: {
+  readonly inspect?: InspectInput;
+  readonly select?: SelectInput;
+  readonly zoom?: ZoomInput;
+  readonly legendFocus?: LegendFocusInput;
+  readonly legendFilter?: LegendFilterInput;
+}): ResolvedPlotCapabilities {
   return {
     inspect: props.inspect ?? false,
     select: props.select ?? false,
@@ -128,6 +137,18 @@ export function resolveCapabilities(
     legendFocus: props.legendFocus ?? false,
     legendFilter: props.legendFilter ?? false,
   };
+}
+
+/**
+ * Read the deprecated plot-level `legendFocus` prop during the dual-read
+ * window. Isolate the deprecation access so call sites stay clean.
+ */
+export function readLegacyPlotLegendFocus(
+  props: EnginePlotProps | GGPlotProps,
+): LegendFocusInput | undefined {
+  // Dual-read until 0.20.0 — prefer <GuideLegend focus>.
+  // oxlint-disable-next-line typescript/no-deprecated -- intentional dual-read
+  return props.legendFocus;
 }
 
 /**

--- a/packages/svelte/src/lib/plot-props.ts
+++ b/packages/svelte/src/lib/plot-props.ts
@@ -75,7 +75,10 @@ export interface GGPlotProps<
   select?: SelectInput;
   /** Opt into brush zoom. */
   zoom?: ZoomInput;
-  /** Opt into discrete legend preview, focus, and linked emphasis. */
+  /**
+   * @deprecated since 0.19.0 — use `<GuideLegend channel="…" focus />` instead.
+   * Still honoured (plot-wide enablement) until 0.20.0; emits DEPRECATED_PLOT_PROP.
+   */
   legendFocus?: LegendFocusInput;
   /** Opt into data-changing filtering through discrete legend controls. */
   legendFilter?: LegendFilterInput;

--- a/packages/svelte/tests/fixtures/CoincidentLegendFocusPlot.svelte
+++ b/packages/svelte/tests/fixtures/CoincidentLegendFocusPlot.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { createPlotInteraction, GGPlot } from "../../src/lib/index.js";
+  import GuideLegend from "../../src/lib/guides/GuideLegend.svelte";
 
   const scope = { keys: "row-id" } as const;
   const rows = [
@@ -32,11 +33,13 @@
     layers={[{ geom: "point" }]}
     key="id"
     inspect
-    legendFocus
     {interaction}
     interactionScope={scope}
     width={420}
     height={280}
     ariaLabel="Coincident color and fill legends"
-  />
+  >
+    <GuideLegend channel="color" focus />
+    <GuideLegend channel="fill" focus />
+  </GGPlot>
 </div>

--- a/packages/svelte/tests/fixtures/LegendClearGeometryPlot.svelte
+++ b/packages/svelte/tests/fixtures/LegendClearGeometryPlot.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { GGPlot, Labs } from "../../src/lib/index.js";
+  import GuideLegend from "../../src/lib/guides/GuideLegend.svelte";
 
   const rows = [
     { id: "a", x: 1, y: 4, group: "north", region: "west" },
@@ -13,7 +14,6 @@
   aes={{ x: "x", y: "y", color: "group", fill: "region" }}
   layers={[{ geom: "point" }]}
   key="id"
-  legendFocus
   width={420}
   height={280}
   ariaLabel="Legend clear geometry plot"
@@ -24,4 +24,6 @@
     color="Group"
     fill="Region"
   />
+  <GuideLegend channel="color" focus />
+  <GuideLegend channel="fill" focus />
 </GGPlot>

--- a/packages/svelte/tests/fixtures/LinkedLegendFocusPlot.svelte
+++ b/packages/svelte/tests/fixtures/LinkedLegendFocusPlot.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { createPlotInteraction, GGPlot } from "../../src/lib/index.js";
+  import GuideLegend from "../../src/lib/guides/GuideLegend.svelte";
 
   const scope = { keys: "row-id" } as const;
   const otherScope = { keys: "other-row-id" } as const;
@@ -39,7 +40,6 @@
       aes={mapping}
       layers={[{ geom: "point" }]}
       key="id"
-      legendFocus
       {interaction}
       interactionScope={scope}
       width={360}
@@ -47,7 +47,9 @@
       ariaLabel="Legend focus plot A"
       onlegendfocus={() => (callbacksA += 1)}
       onrender={() => (rendersA += 1)}
-    />
+    >
+      <GuideLegend channel="color" focus />
+    </GGPlot>
   </div>
   <div data-plot-b>
     <GGPlot
@@ -55,7 +57,6 @@
       aes={mapping}
       layers={[{ geom: "point", render: "canvas" }]}
       key="id"
-      legendFocus
       {interaction}
       interactionScope={scope}
       width={360}
@@ -63,7 +64,9 @@
       ariaLabel="Legend focus plot B"
       onlegendfocus={() => (callbacksB += 1)}
       onrender={() => (rendersB += 1)}
-    />
+    >
+      <GuideLegend channel="color" focus />
+    </GGPlot>
   </div>
   <div data-plot-c>
     <GGPlot
@@ -71,7 +74,6 @@
       aes={mapping}
       layers={[{ geom: "point" }]}
       key="id"
-      legendFocus
       {interaction}
       interactionScope={scope}
       width={360}
@@ -79,7 +81,9 @@
       ariaLabel="Legend focus plot C"
       onlegendfocus={() => (callbacksC += 1)}
       onrender={() => (rendersC += 1)}
-    />
+    >
+      <GuideLegend channel="color" focus />
+    </GGPlot>
   </div>
   <div data-plot-other>
     <GGPlot
@@ -87,12 +91,13 @@
       aes={mapping}
       layers={[{ geom: "point" }]}
       key="id"
-      legendFocus
       {interaction}
       interactionScope={otherScope}
       width={360}
       height={260}
       ariaLabel="Mismatched legend focus plot"
-    />
+    >
+      <GuideLegend channel="color" focus />
+    </GGPlot>
   </div>
 </div>

--- a/packages/svelte/tests/fixtures/LocalLegendFocusPlot.svelte
+++ b/packages/svelte/tests/fixtures/LocalLegendFocusPlot.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { GGPlot } from "../../src/lib/index.js";
+  import GuideLegend from "../../src/lib/guides/GuideLegend.svelte";
 
   const rows = [
     { id: "a", x: 1, y: 4, group: "north" },
@@ -16,7 +17,6 @@
     aes={{ x: "x", y: "y", color: "group" }}
     layers={[{ geom: "point" }]}
     key="id"
-    legendFocus
     width={360}
     height={260}
     ariaLabel="Local legend focus plot"
@@ -24,5 +24,7 @@
       lastEvent = JSON.stringify(event);
     }}
     onrender={() => (renders += 1)}
-  />
+  >
+    <GuideLegend channel="color" focus />
+  </GGPlot>
 </div>

--- a/packages/svelte/tests/interaction/capability.test.ts
+++ b/packages/svelte/tests/interaction/capability.test.ts
@@ -370,7 +370,7 @@ describe("legendFocusDiscreteOnlyDiagnostics", () => {
     expect(rampDiag).toMatchObject({
       code: "INTERACTION_LEGEND_DISCRETE_ONLY",
       severity: "advisory",
-      prop: "legendFocus",
+      prop: "focus",
       actual: ["ramp"],
     });
     expect(typeof rampDiag.message).toBe("string");

--- a/packages/svelte/tests/layers/grammar-prop-removal.ssr.test.ts
+++ b/packages/svelte/tests/layers/grammar-prop-removal.ssr.test.ts
@@ -28,10 +28,17 @@ describe("#704 grammar prop removal", () => {
 
   it("engine no longer emits DEPRECATED_PLOT_PROP for grammar props", () => {
     const source = readFileSync(join(root, "plot-engine.svelte.ts"), "utf8");
-    // Runtime emit path removed with the props (#704); catalog types remain
-    // for ondiagnostic consumers and the codemod/upgrade guide.
+    // Grammar-prop emit path removed with the props (#704). Catalog types and
+    // a single dual-read path for the separate legendFocus migration may still
+    // call deprecatedPropDiagnostic — that is not a grammar-prop regression.
     expect(source).not.toContain("deprecationDiagnostics");
-    expect(source).not.toContain("deprecatedPropDiagnostic");
+    for (const prop of GRAMMAR_PROP_NAMES) {
+      expect(source, `grammar prop ${prop} still wired for deprecation emit`).not.toMatch(
+        new RegExp(`prop:\\s*["']${prop}["']`),
+      );
+    }
+    // legendFocus dual-read (0.19→0.20) is the only remaining emit site.
+    expect(source).toContain('prop: "legendFocus"');
   });
 
   it("LayerDescriptor alias is removed (use MarkLayerDescriptor)", () => {

--- a/packages/svelte/tests/legend/focus-interaction.test.ts
+++ b/packages/svelte/tests/legend/focus-interaction.test.ts
@@ -299,7 +299,7 @@ describe("legend focus capability edges", () => {
     expect(diagnostics).toContainEqual(
       expect.objectContaining({
         code: "INTERACTION_LEGEND_DISCRETE_ONLY",
-        prop: "legendFocus",
+        prop: "focus",
         actual: ["ramp"],
       }),
     );

--- a/packages/svelte/tests/legend/resolve-legend-focus.test.ts
+++ b/packages/svelte/tests/legend/resolve-legend-focus.test.ts
@@ -128,6 +128,5 @@ describe("isLegendFocusPropEnabled", () => {
     expect(isLegendFocusPropEnabled(true)).toBe(true);
     expect(isLegendFocusPropEnabled({ preview: false })).toBe(true);
     expect(isLegendFocusPropEnabled(false)).toBe(false);
-    expect(isLegendFocusPropEnabled(undefined)).toBe(false);
   });
 });

--- a/packages/svelte/tests/legend/resolve-legend-focus.test.ts
+++ b/packages/svelte/tests/legend/resolve-legend-focus.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+
+import type { InteractiveLegendEntry } from "../../src/lib/legend/focus.js";
+import {
+  filterInteractiveLegendEntries,
+  isLegendFocusPropEnabled,
+  resolveLegendFocusCapability,
+} from "../../src/lib/legend/resolve-legend-focus.js";
+
+describe("resolveLegendFocusCapability", () => {
+  it("is off when neither plot prop nor children request focus", () => {
+    expect(
+      resolveLegendFocusCapability({
+        plotProp: undefined,
+        layers: [],
+      }),
+    ).toEqual({
+      requested: false,
+      configInput: false,
+      channels: new Set(),
+    });
+  });
+
+  it("uses plot prop alone as all-channel enablement", () => {
+    const resolved = resolveLegendFocusCapability({
+      plotProp: true,
+      layers: [],
+    });
+    expect(resolved.requested).toBe(true);
+    expect(resolved.configInput).toBe(true);
+    expect(resolved.channels).toBe("all");
+  });
+
+  it("collects channels from GuideLegend focus layers", () => {
+    const resolved = resolveLegendFocusCapability({
+      plotProp: undefined,
+      layers: [
+        { kind: "guides", value: { color: { type: "legend" } } },
+        {
+          kind: "legendFocus",
+          value: { channel: "color", input: true },
+        },
+        {
+          kind: "legendFocus",
+          value: { channel: "shape", input: { preview: false } },
+        },
+        { kind: "legendFocus", value: null },
+      ],
+    });
+    expect(resolved.requested).toEqual({ preview: false });
+    expect(resolved.configInput).toEqual({ preview: false });
+    expect(resolved.channels).toEqual(new Set(["color", "shape"]));
+  });
+
+  it("prefers child channels when both prop and children are set", () => {
+    const resolved = resolveLegendFocusCapability({
+      plotProp: true,
+      layers: [{ kind: "legendFocus", value: { channel: "fill", input: true } }],
+    });
+    expect(resolved.channels).toEqual(new Set(["fill"]));
+    expect(resolved.configInput).toBe(true);
+  });
+
+  it("disables preview when the plot prop sets preview false", () => {
+    const resolved = resolveLegendFocusCapability({
+      plotProp: { preview: false },
+      layers: [],
+    });
+    expect(resolved.configInput).toEqual({ preview: false });
+  });
+});
+
+describe("filterInteractiveLegendEntries", () => {
+  const colorLegend = {
+    type: "discrete" as const,
+    scale: "color" as const,
+    title: "Color",
+    x: 0,
+    y: 0,
+    width: 1,
+    height: 1,
+    entries: [],
+    swatchSize: 8,
+  };
+  const shapeOnMerged = {
+    type: "discrete" as const,
+    scale: "color" as const,
+    aesthetics: ["color", "shape"] as const,
+    title: "Merged",
+    x: 0,
+    y: 0,
+    width: 1,
+    height: 1,
+    entries: [],
+    swatchSize: 8,
+  };
+
+  const entries: InteractiveLegendEntry[] = [
+    {
+      legend: colorLegend,
+      entry: { label: "a", value: "a", y: 0 },
+      identity: { scale: "color", entryIndex: 0 },
+    },
+    {
+      legend: shapeOnMerged,
+      entry: { label: "b", value: "b", y: 0 },
+      identity: { scale: "color", entryIndex: 0 },
+    },
+  ];
+
+  it("keeps every entry when channels is all", () => {
+    expect(filterInteractiveLegendEntries(entries, "all")).toHaveLength(2);
+  });
+
+  it("matches merged legends via aesthetics, not only primary scale", () => {
+    const filtered = filterInteractiveLegendEntries(entries, new Set(["shape"]));
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0]?.legend.title).toBe("Merged");
+  });
+
+  it("drops entries when the channel set is empty", () => {
+    expect(filterInteractiveLegendEntries(entries, new Set())).toEqual([]);
+  });
+});
+
+describe("isLegendFocusPropEnabled", () => {
+  it("treats true and options objects as enabled", () => {
+    expect(isLegendFocusPropEnabled(true)).toBe(true);
+    expect(isLegendFocusPropEnabled({ preview: false })).toBe(true);
+    expect(isLegendFocusPropEnabled(false)).toBe(false);
+    expect(isLegendFocusPropEnabled(undefined)).toBe(false);
+  });
+});

--- a/packages/svelte/tests/migrations/legend-focus-after.svelte
+++ b/packages/svelte/tests/migrations/legend-focus-after.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  import { GeomPoint, GGPlot, GuideLegend } from "../../src/lib/index.js";
+
+  const rows = [
+    { id: "a", x: 1, y: 2, series: "North" },
+    { id: "b", x: 2, y: 3, series: "South" },
+  ];
+</script>
+
+<!-- After 0.19: focus lives on GuideLegend for that aesthetic. -->
+<GGPlot data={rows} aes={{ x: "x", y: "y", color: "series" }} key="id">
+  <GuideLegend channel="color" focus />
+  <GeomPoint />
+</GGPlot>

--- a/packages/svelte/tests/migrations/legend-focus-before.svelte
+++ b/packages/svelte/tests/migrations/legend-focus-before.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import { GeomPoint, GGPlot } from "../../src/lib/index.js";
+
+  const rows = [
+    { id: "a", x: 1, y: 2, series: "North" },
+    { id: "b", x: 2, y: 3, series: "South" },
+  ];
+</script>
+
+<!-- Before 0.19: legendFocus was a plot-host prop. -->
+<GGPlot
+  data={rows}
+  aes={{ x: "x", y: "y", color: "series" }}
+  key="id"
+  legendFocus
+>
+  <GeomPoint />
+</GGPlot>

--- a/packages/svelte/tests/plot-engine.lifecycle.test.ts
+++ b/packages/svelte/tests/plot-engine.lifecycle.test.ts
@@ -230,9 +230,11 @@ describe("createPlotEngine construction-order contract (#1082)", () => {
     inspect: true,
     select: "point" as const,
     zoom: true,
+    // Dual-read fixture for deprecated plot prop (removed 0.20.0).
+    /* oxlint-disable-next-line typescript/no-deprecated -- intentional dual-read */
     legendFocus: true,
     legendFilter: true,
-  } satisfies EnginePlotProps;
+  } as EnginePlotProps;
 
   it("constructs the full controller graph without TDZ throws (before first flush)", () => {
     // If any factory reads a later binding at construction time, createPlotEngine

--- a/scripts/llms-guide-content.ts
+++ b/scripts/llms-guide-content.ts
@@ -1626,12 +1626,16 @@ panels.
 \`zoom={{ mode: "x" | "y" | "xy" }}\` enables the explicit Zoom area tool.
 Reset zoom and double-click return to the natural domains.
 
-### \`legendFocus\`
+### \`focus\` on \`<GuideLegend>\`
 
-\`legendFocus={true}\` enables discrete legend preview and committed focus.
-Use \`legendFocus={{ preview: false }}\` to disable hover/focus preview while
-retaining click, touch, Enter, Space, Escape, and arrow-key controls. It
-requires stable row \`key\` values and does not make continuous ramps interactive.
+\`<GuideLegend channel="color" focus />\` enables discrete legend preview and
+committed focus for that aesthetic. Use \`focus={{ preview: false }}\` to
+disable hover/focus preview while retaining click, touch, Enter, Space,
+Escape, and arrow-key controls. It requires stable row \`key\` values and does
+not make continuous ramps interactive. Host-only — never a PortableSpec field.
+
+The plot prop \`legendFocus\` is deprecated since 0.19.0 (removed in 0.20.0);
+see [Legend focus on GuideLegend](/guide/upgrading#legend-focus-on-guidelegend).
 
 ### \`legendFilter\`
 
@@ -1640,7 +1644,7 @@ fill legends. It changes the rows supplied to facets, statistics, scales, and
 rendering while preserving the full legend catalog and categorical color
 identity. Configure \`mode: "exclude" | "include"\` and \`multiple\`; receive
 typed clauses through \`onlegendfilter\`. It is independent of
-presentation-only \`legendFocus\`.
+presentation-only GuideLegend \`focus\`.
 
 ## Controlled tool
 
@@ -1893,6 +1897,61 @@ migration note here.
 The accepted lifecycle and deprecation policy remains in
 [Lifecycle and editions](/guide/lifecycle#lifecycle-tags); this page applies it
 rather than creating a second policy.
+
+## 0.18 to 0.19
+
+### Legend focus on GuideLegend
+
+Discrete legend focus is no longer a plot-host capability prop. Opt in on the
+guide child that owns the aesthetic:
+
+\`\`\`svelte fragment
+<script lang="ts">
+  import { GeomPoint, GGPlot } from "@ggsvelte/svelte";
+
+  const rows = [
+    { id: "a", x: 1, y: 2, series: "North" },
+    { id: "b", x: 2, y: 3, series: "South" },
+  ];
+</script>
+
+<!-- Before 0.19: legendFocus was a plot-host prop. -->
+<GGPlot
+  data={rows}
+  aes={{ x: "x", y: "y", color: "series" }}
+  key="id"
+  legendFocus
+>
+  <GeomPoint />
+</GGPlot>
+\`\`\`
+
+\`\`\`svelte fragment
+<script lang="ts">
+  import { GeomPoint, GGPlot, GuideLegend } from "@ggsvelte/svelte";
+
+  const rows = [
+    { id: "a", x: 1, y: 2, series: "North" },
+    { id: "b", x: 2, y: 3, series: "South" },
+  ];
+</script>
+
+<!-- After 0.19: focus lives on GuideLegend for that aesthetic. -->
+<GGPlot data={rows} aes={{ x: "x", y: "y", color: "series" }} key="id">
+  <GuideLegend channel="color" focus />
+  <GeomPoint />
+</GGPlot>
+\`\`\`
+
+- \`focus\` accepts \`true\` or \`{ preview?: boolean }\` (same shape as the old
+  plot prop). It is host-only — not a PortableSpec / \`guideLegend()\` field.
+- Only channels with an active \`<GuideLegend focus>\` get interactive legend
+  targets. Enable multiple aesthetics with multiple GuideLegend children.
+- A focus-only GuideLegend (no presentation options) does not force
+  \`type: "legend"\`, so continuous colour scales keep their colorbar.
+- \`<GGPlot legendFocus>\` still works plot-wide through 0.19.x and emits
+  \`DEPRECATED_PLOT_PROP\`; it is removed in 0.20.0.
+- Handlers stay plot-level: \`onlegendfocus\`, \`oninteraction\`, and \`key\`.
 
 ## 0.11 to 0.12
 

--- a/scripts/llms-guide-content.ts
+++ b/scripts/llms-guide-content.ts
@@ -1283,7 +1283,8 @@ timestamp helpers, exact-format parser, and epoch helpers return authoring Dates
 
 export const INTERACTIONS_MD = `# Interactions
 
-Static by default. Opt in with \`inspect\`, \`select\`, \`zoom\`, \`legendFocus\`,
+Static by default. Opt in with \`inspect\`, \`select\`, \`zoom\`, GuideLegend
+\`focus\` (or deprecated \`legendFocus\`),
 \`legendFilter\`. With more than one draw tool, an accessible tool rail keeps
 gestures from competing.
 
@@ -1435,21 +1436,22 @@ pixels or renderer indices.
 
 ## Legend focus
 
-\`legendFocus={true}\` adds real HTML controls over discrete color and fill
-legends. Hover and DOM focus preview one chart without mutating shared state.
-Click, touch, Enter, or Space commits the matching stable row keys; the active
-entry or Escape clears them. Arrow keys traverse entries in rendered legend
-order, with Home and End moving to the boundaries.
+\`<GuideLegend channel="color" focus />\` adds real HTML controls over that
+aesthetic's discrete legend. Hover and DOM focus preview one chart without
+mutating shared state. Click, touch, Enter, or Space commits the matching
+stable row keys; the active entry or Escape clears them. Arrow keys traverse
+entries in rendered legend order, with Home and End moving to the boundaries.
 
-\`legendFocus={{ preview: false }}\` keeps committed activation but disables
-transient previews. Continuous ramps remain static. A stable \`key\` is required:
-encoded legend values are reported as values, never used as controller keys.
-Focused and muted marks share one semantic mask across SVG and canvas, and the
-mask does not retrain scales, recompute statistics, change layout, or reassign
+\`focus={{ preview: false }}\` keeps committed activation but disables transient
+previews. Continuous ramps remain static. A stable \`key\` is required: encoded
+legend values are reported as values, never used as controller keys. Focused
+and muted marks share one semantic mask across SVG and canvas, and the mask
+does not retrain scales, recompute statistics, change layout, or reassign
 colors. Author discrete legend appearance with
 [GuideLegend](/reference/guides/legend); see the full
 [guides reference](/reference/guides) and the
-[runnable three-view example](/examples/interaction/legend-focus).
+[runnable three-view example](/examples/interaction/legend-focus). The plot prop
+\`legendFocus\` is deprecated since 0.19.0.
 
 ## Legend filtering
 
@@ -1626,16 +1628,18 @@ panels.
 \`zoom={{ mode: "x" | "y" | "xy" }}\` enables the explicit Zoom area tool.
 Reset zoom and double-click return to the natural domains.
 
-### \`focus\` on \`<GuideLegend>\`
+### \`legendFocus\`
 
-\`<GuideLegend channel="color" focus />\` enables discrete legend preview and
-committed focus for that aesthetic. Use \`focus={{ preview: false }}\` to
-disable hover/focus preview while retaining click, touch, Enter, Space,
-Escape, and arrow-key controls. It requires stable row \`key\` values and does
-not make continuous ramps interactive. Host-only — never a PortableSpec field.
+Prefer \`<GuideLegend channel="color" focus />\` (boolean or
+\`{ preview?: boolean }\`) for discrete legend preview and committed focus on
+that aesthetic. Host-only — never a PortableSpec / \`guideLegend()\` field. Use
+\`focus={{ preview: false }}\` to disable hover/focus preview while retaining
+click, touch, Enter, Space, Escape, and arrow-key controls. Requires stable
+row \`key\` values; continuous ramps stay static.
 
-The plot prop \`legendFocus\` is deprecated since 0.19.0 (removed in 0.20.0);
-see [Legend focus on GuideLegend](/guide/upgrading#legend-focus-on-guidelegend).
+The plot prop \`legendFocus={true}\` is deprecated since 0.19.0 (removed in
+0.20.0) and still enables focus plot-wide during the dual-read window — see
+[Legend focus on GuideLegend](/guide/upgrading#legend-focus-on-guidelegend).
 
 ### \`legendFilter\`
 

--- a/skills/ggsvelte/SKILL.md
+++ b/skills/ggsvelte/SKILL.md
@@ -114,8 +114,9 @@ direct props (`size={3}`); structural props are `data`, `stat`, `position`,
 
 `<GGPlot>` props: `spec`, `data`, `aes`, `layers`, `key`, `width`
 (number | "container"), `height`, `a11y`, `ariaLabel`, the interaction props
-(`inspect`, `select`, `zoom`, `legendFocus`, `legendFilter`, `tool`,
-`interaction`, `interactionScope`), the `on*` handlers, and `children`.
+(`inspect`, `select`, `zoom`, `legendFilter`, `tool`, `interaction`,
+`interactionScope`; `legendFocus` is deprecated — use
+`<GuideLegend channel focus>`), the `on*` handlers, and `children`.
 Instance methods: `resetScales()`, `setZoom()`.
 
 Precedence: `spec` wins over everything else. For mark layers, an explicit
@@ -272,12 +273,12 @@ violin, tile heatmap, hex density, ECDF step, ribbon, flipped boxplot,
 per-layer aes override, sf/map — each as validated JSON plus a Svelte twin:
 [references/recipes.md](references/recipes.md).
 
-## Interactions (Svelte props, not spec fields)
+## Interactions (host props, not PortableSpec fields)
 
-Opt-in `<GGPlot>` props: `inspect` (tooltip/crosshair/keyboard/pinning),
-`select` (point or interval), `zoom` (brush), `legendFocus` (emphasis only),
-`legendFilter` (refilters and reruns the grammar, colors stay stable). Always
-give a stable `key` when selection or linked views must survive filtering or
+Opt-in host capabilities: `inspect` / `select` / `zoom` / `legendFilter` on
+`<GGPlot>`; legend emphasis via `<GuideLegend channel="color" focus />`
+(per aesthetic; host-only, not in `guideLegend()` / PortableSpec). Always give
+a stable `key` when selection or linked views must survive filtering or
 refreshes. Link plots by sharing one `createPlotInteraction()` controller and
 matching `interactionScope` channels; observe everything through
 `oninteraction` or per-capability handlers. Faceted interval presets, the

--- a/skills/ggsvelte/references/interactions.md
+++ b/skills/ggsvelte/references/interactions.md
@@ -3,23 +3,28 @@
 # Svelte interactions
 
 `@ggsvelte/svelte` requires Svelte `^5.33.1` (peerDependency). Interactions are
-opt-in PROPS on `<GGPlot>` — they are not spec fields and never appear in a
-PortableSpec. Always pass a stable `key` when selection, legend focus, or
+opt-in host capabilities — they are not PortableSpec fields (never serialise
+into a plot JSON). Always pass a stable `key` when selection, legend focus, or
 coordinated intervals must survive filtering, reordering, or data refreshes.
 
 ## Capability props
 
-| Prop           | Input                                                  | What it enables                                                                                                                                                                                                                                                                                                |
-| -------------- | ------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `inspect`      | `boolean \| InspectOptions`                            | Tooltip, semantic crosshair, keyboard traversal, pinning. Options: `mode` (`"auto" \| "exact" \| "x" \| "y" \| "xy"`), `pin`, `maxDistance` (CSS px), `contentMode` (`"informational" \| "interactive"`), `muteSiblings`, `content` (Snippet, see Tooltip below).                                              |
-| `select`       | `false \| "point" \| "interval" \| SelectOptions`      | Point or interval selection. Options: `type` (`"point" \| "interval"`), `mode` (`"x" \| "y" \| "xy"`, interval only), `multiple`, `persistent`, `preset` (faceted intervals, below).                                                                                                                           |
-| `zoom`         | `boolean \| ZoomOptions`                               | Brush zoom. Options: `mode` (`"x" \| "y" \| "xy"`), `trigger` (`"brush"`). Currently requires one unfaceted panel.                                                                                                                                                                                             |
-| `legendFocus`  | `boolean \| { preview?: boolean }`                     | Discrete legend preview, focus, and linked emphasis. Emphasis only — never changes included rows. Discrete color/fill legends only; continuous ramps stay static. Mute de-emphasizes non-focused marks; dashed rings appear only on sparse point marks (≤48 anchors), never on paths/areas/bars/segments/text. |
-| `legendFilter` | `boolean \| LegendFilterOptions`                       | Data-changing filtering through discrete legend controls: changes the included rows and reruns the grammar while preserving stable color identity. Options: `mode` (`"exclude" \| "include"`), `multiple`.                                                                                                     |
-| `key`          | column name or `(row, index) => PropertyKey`           | Stable semantic identity for public interaction payloads. Required for durable point selection, coordinated interval presets, and legend focus/filter. Duplicate or unstable keys are diagnostic errors.                                                                                                       |
-| `tool`         | `"inspect" \| "point" \| "select-area" \| "zoom-area"` | Controlled initial/active tool; observe changes with `ontoolchange`.                                                                                                                                                                                                                                           |
-| `ariaLabel`    | `string`                                               | Accessible chart name; falls back to the plot title or a generated label.                                                                                                                                                                                                                                      |
-| `a11y`         | `A11yMode`                                             | `"force-svg"` keeps every layer as SVG marks.                                                                                                                                                                                                                                                                  |
+| Prop / surface | Input                                                  | What it enables                                                                                                                                                                                                                                                                                                                                                                            |
+| -------------- | ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `inspect`      | `boolean \| InspectOptions` on `<GGPlot>`              | Tooltip, semantic crosshair, keyboard traversal, pinning. Options: `mode` (`"auto" \| "exact" \| "x" \| "y" \| "xy"`), `pin`, `maxDistance` (CSS px), `contentMode` (`"informational" \| "interactive"`), `muteSiblings`, `content` (Snippet, see Tooltip below).                                                                                                                          |
+| `select`       | `false \| "point" \| "interval" \| SelectOptions`      | Point or interval selection. Options: `type` (`"point" \| "interval"`), `mode` (`"x" \| "y" \| "xy"`, interval only), `multiple`, `persistent`, `preset` (faceted intervals, below).                                                                                                                                                                                                       |
+| `zoom`         | `boolean \| ZoomOptions`                               | Brush zoom. Options: `mode` (`"x" \| "y" \| "xy"`), `trigger` (`"brush"`). Currently requires one unfaceted panel.                                                                                                                                                                                                                                                                         |
+| `focus`        | `boolean \| { preview?: boolean }` on `<GuideLegend>`  | Discrete legend preview, focus, and linked emphasis **for that aesthetic channel**. Emphasis only — never changes included rows. Discrete legends only; continuous ramps stay static. Mute de-emphasizes non-focused marks; dashed rings appear only on sparse point marks (≤48 anchors), never on paths/areas/bars/segments/text. Host-only — not a PortableSpec / `guideLegend()` field. |
+| `legendFilter` | `boolean \| LegendFilterOptions` on `<GGPlot>`         | Data-changing filtering through discrete legend controls: changes the included rows and reruns the grammar while preserving stable color identity. Options: `mode` (`"exclude" \| "include"`), `multiple`.                                                                                                                                                                                 |
+| `key`          | column name or `(row, index) => PropertyKey`           | Stable semantic identity for public interaction payloads. Required for durable point selection, coordinated interval presets, and legend focus/filter. Duplicate or unstable keys are diagnostic errors.                                                                                                                                                                                   |
+| `tool`         | `"inspect" \| "point" \| "select-area" \| "zoom-area"` | Controlled initial/active tool; observe changes with `ontoolchange`.                                                                                                                                                                                                                                                                                                                       |
+| `ariaLabel`    | `string`                                               | Accessible chart name; falls back to the plot title or a generated label.                                                                                                                                                                                                                                                                                                                  |
+| `a11y`         | `A11yMode`                                             | `"force-svg"` keeps every layer as SVG marks.                                                                                                                                                                                                                                                                                                                                              |
+
+### Deprecated: `legendFocus` on `<GGPlot>`
+
+Since 0.19.0, prefer `<GuideLegend channel="color" focus />`. The plot prop
+still enables focus plot-wide until 0.20.0 and emits `DEPRECATED_PLOT_PROP`.
 
 After an interval or zoom commit, accessible controls accept exact bounds.
 
@@ -110,6 +115,7 @@ entry has `severity`, `code`, `message`, `prop`, `suggestions`, `docUrl`):
     Facet,
     GeomPoint,
     GGPlot,
+    GuideLegend,
   } from "@ggsvelte/svelte";
 
   const interaction = createPlotInteraction<number>();
@@ -121,12 +127,12 @@ entry has `severity`, `code`, `message`, `prop`, `suggestions`, `docUrl`):
   aes={{ x: "date", y: "value", color: "series" }}
   key="id"
   select={{ type: "interval", mode: "x", preset: "cross-panel" }}
-  legendFocus
   legendFilter
   {interaction}
   interactionScope={scope}
   oninteraction={(event) => console.log(event.type, event)}
 >
+  <GuideLegend channel="color" focus />
   <Facet wrap="region" ncol={3} />
   <GeomPoint />
 </GGPlot>


### PR DESCRIPTION
## Summary

- Move discrete legend **focus** opt-in from `<GGPlot legendFocus>` to `<GuideLegend channel focus />` (boolean or `{ preview?: boolean }`).
- Host-only (not PortableSpec / `guideLegend()`): stripped before validation; registered as layer kind `legendFocus`.
- Focus-only GuideLegend children do not force `type: "legend"`, so continuous colour scales keep their colorbar.
- Interactive targets are channel-scoped; merged legends match via `aesthetics[]` (not primary `scale` alone).
- `<GGPlot legendFocus>` still works plot-wide until **0.20.0** with `DEPRECATED_PLOT_PROP`.
- Skills, examples, docs demos, and legend fixtures updated. Follow-up for `legendFilter`: #1235.

## Claude plan review

Outside-voice review (**APPROVE WITH CHANGES**) incorporated:

- No silent hard-remove of the plot prop (deprecation window)
- Host kind excluded from grammar families / fold / assemble
- SSR escape hatch for registry-derived capability
- Wiring uses **requested** capability (not post-key resolved config)
- Channel filter uses `aesthetics ?? [scale]`
- Focus-only guide registration avoids continuous-scale pipeline errors

## Test plan

- [x] `bun run check` (packages/spec, core, scripts)
- [x] `packages/svelte` `svelte-check`
- [x] chromium `tests/legend/**` (206 tests)
- [ ] CI on PR

## Migration

```svelte
<!-- before -->
<GGPlot legendFocus key="id" …>
  <GeomPoint />
</GGPlot>

<!-- after -->
<GGPlot key="id" …>
  <GuideLegend channel="color" focus />
  <GeomPoint />
</GGPlot>
```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1236" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->