### PR TITLE
feat(svelte): host inspect capability registry + resolve for <Inspect> children

### DIFF
--- a/apps/docs/src/lib/generated/routes.ts
+++ b/apps/docs/src/lib/generated/routes.ts
@@ -10754,6 +10754,11 @@ export const DOCS_ROUTES = [
         level: 3,
       },
       {
+        id: "interaction-duplicate-inspect-capability",
+        title: "INTERACTION_DUPLICATE_INSPECT_CAPABILITY",
+        level: 3,
+      },
+      {
         id: "accessibility",
         title: "Accessibility",
         level: 2,
@@ -11779,6 +11784,11 @@ export const DOCS_ROUTES = [
       {
         id: "interaction-inspect-x-bisects-bar-labels",
         title: "INTERACTION_INSPECT_X_BISECTS_BAR_LABELS",
+        level: 3,
+      },
+      {
+        id: "interaction-duplicate-inspect-capability",
+        title: "INTERACTION_DUPLICATE_INSPECT_CAPABILITY",
         level: 3,
       },
       {

--- a/apps/docs/src/lib/generated/search-index.ts
+++ b/apps/docs/src/lib/generated/search-index.ts
@@ -17416,6 +17416,16 @@ export const DOCS_SEARCH_INDEX = [
     exact: ["INTERACTION_INSPECT_X_BISECTS_BAR_LABELS"],
   },
   {
+    id: "heading:guide-interaction-reference:interaction-duplicate-inspect-capability",
+    kind: "heading",
+    title: "INTERACTION_DUPLICATE_INSPECT_CAPABILITY",
+    summary:
+      "INTERACTION_DUPLICATE_INSPECT_CAPABILITY in Interaction reference. Search interaction props, callbacks, event phases, and diagnostic codes.",
+    href: "/guide/interaction-reference#interaction-duplicate-inspect-capability",
+    keywords: ["Interaction reference", "documentation"],
+    exact: ["INTERACTION_DUPLICATE_INSPECT_CAPABILITY"],
+  },
+  {
     id: "heading:guide-interaction-reference:accessibility",
     kind: "heading",
     title: "Accessibility",
@@ -19443,6 +19453,16 @@ export const DOCS_SEARCH_INDEX = [
     href: "/guide/errors#interaction-inspect-x-bisects-bar-labels",
     keywords: ["Errors reference", "Reference"],
     exact: ["INTERACTION_INSPECT_X_BISECTS_BAR_LABELS"],
+  },
+  {
+    id: "heading:guide-errors:interaction-duplicate-inspect-capability",
+    kind: "heading",
+    title: "INTERACTION_DUPLICATE_INSPECT_CAPABILITY",
+    summary:
+      "INTERACTION_DUPLICATE_INSPECT_CAPABILITY in Errors reference. Understand validation, render, interaction, and CLI diagnostics and recover safely.",
+    href: "/guide/errors#interaction-duplicate-inspect-capability",
+    keywords: ["Errors reference", "Reference"],
+    exact: ["INTERACTION_DUPLICATE_INSPECT_CAPABILITY"],
   },
   {
     id: "heading:guide-errors:cli-diagnostics-ggsvelte-render",
@@ -41904,6 +41924,23 @@ export const DOCS_SEARCH_INDEX = [
     exact: [
       "INTERACTION_INSPECT_X_BISECTS_BAR_LABELS",
       "interaction:INTERACTION_INSPECT_X_BISECTS_BAR_LABELS",
+    ],
+  },
+  {
+    id: "diagnostic:interaction:INTERACTION_DUPLICATE_INSPECT_CAPABILITY",
+    kind: "diagnostic",
+    title: "INTERACTION_DUPLICATE_INSPECT_CAPABILITY · interaction",
+    summary:
+      "Multiple <Inspect> children are registered; only the last one's options apply (REPLACE).",
+    href: "/guide/errors#interaction-duplicate-inspect-capability",
+    keywords: [
+      "interaction",
+      "advisory",
+      "Keep a single <Inspect> child; Merge options onto one <Inspect> instead of stacking siblings",
+    ],
+    exact: [
+      "INTERACTION_DUPLICATE_INSPECT_CAPABILITY",
+      "interaction:INTERACTION_DUPLICATE_INSPECT_CAPABILITY",
     ],
   },
   {

--- a/packages/svelte/src/lib/geoms/registry.svelte.ts
+++ b/packages/svelte/src/lib/geoms/registry.svelte.ts
@@ -26,12 +26,32 @@ import { getContext, onDestroy, setContext } from "svelte";
 // LayerDescriptor alias removed in 0.13.0 (#704) — use MarkLayerDescriptor.
 export type { Layer, MarkLayerDescriptor } from "../layers/types.js";
 import type { Layer, MarkLayerDescriptor } from "../layers/types.js";
+import type { InspectCapabilityChild } from "../interaction/resolve-inspect-capability.js";
+
+/**
+ * Host-only interaction capabilities registered by declaration children
+ * (`<Inspect>`, later select/zoom/…). Not members of the grammar `Layer`
+ * union and never folded into PortableSpec.
+ */
+export type HostCapabilityKind = "inspect";
+
+/** Value bags per capability kind (extend when more children land). */
+export type HostCapabilityValue = {
+  readonly inspect: InspectCapabilityChild;
+};
+
+type CapabilityEntry<K extends HostCapabilityKind = HostCapabilityKind> = {
+  readonly kind: K;
+  get value(): HostCapabilityValue[K];
+};
 
 let nextId = 0;
 let globalVersion = 0;
 
 export class LayerRegistry {
   readonly #byId = new Map<number, Layer>();
+  /** Host capabilities — separate from grammar layers (never plotLayers). */
+  readonly #capabilities = new Map<number, CapabilityEntry>();
   #version = $state(0);
   /** Monotonic register count (never decrements). For ADR 0001 test assertions. */
   #registrationCount = 0;
@@ -50,8 +70,30 @@ export class LayerRegistry {
     return id;
   }
 
+  /**
+   * Register a host-only capability (inspect, later select/zoom/…).
+   * Live `value` getter is load-bearing (ADR 0001). Returns entry id.
+   */
+  registerCapability<K extends HostCapabilityKind>(
+    kind: K,
+    getValue: () => HostCapabilityValue[K],
+  ): number {
+    const id = nextId++;
+    const entry: CapabilityEntry<K> = {
+      kind,
+      get value() {
+        return getValue();
+      },
+    };
+    this.#capabilities.set(id, entry as CapabilityEntry);
+    this.#registrationCount += 1;
+    this.#version = ++globalVersion;
+    return id;
+  }
+
   unregister(id: number): void {
     this.#byId.delete(id);
+    this.#capabilities.delete(id);
     this.#version = ++globalVersion;
   }
 
@@ -75,9 +117,23 @@ export class LayerRegistry {
   }
 
   /**
-   * Monotonic count of successful `register` / `registerPlotLayer` calls.
-   * Unregister does not decrement. Tests use this to assert ADR 0001's
-   * zero-re-registration guarantee under live prop updates.
+   * Host capability values of `kind` in registration order (reactive).
+   * Multiple entries of the same kind are all returned so resolve can last-win
+   * and multi-child diagnostics can fire.
+   */
+  capabilities<K extends HostCapabilityKind>(kind: K): readonly HostCapabilityValue[K][] {
+    void this.#version;
+    const out: HostCapabilityValue[K][] = [];
+    for (const entry of this.#capabilities.values()) {
+      if (entry.kind === kind) out.push(entry.value as HostCapabilityValue[K]);
+    }
+    return out;
+  }
+
+  /**
+   * Monotonic count of successful `register` / `registerPlotLayer` /
+   * `registerCapability` calls. Unregister does not decrement. Tests use this
+   * to assert ADR 0001's zero-re-registration guarantee under live prop updates.
    */
   get registrationCount(): number {
     return this.#registrationCount;
@@ -123,6 +179,22 @@ export function registerPlotLayer(layer: Layer): void {
   const registry = getContext<LayerRegistry | undefined>(KEY);
   if (!registry) return;
   const id = registry.registerPlotLayer(layer);
+  onDestroy(() => {
+    registry.unregister(id);
+  });
+}
+
+/**
+ * Register a host-only capability during component init (e.g. `<Inspect>`).
+ * Inert without a <GGPlot> ancestor. Live getter over child props (ADR 0001).
+ */
+export function registerHostCapability<K extends HostCapabilityKind>(
+  kind: K,
+  getValue: () => HostCapabilityValue[K],
+): void {
+  const registry = getContext<LayerRegistry | undefined>(KEY);
+  if (!registry) return;
+  const id = registry.registerCapability(kind, getValue);
   onDestroy(() => {
     registry.unregister(id);
   });

--- a/packages/svelte/src/lib/geoms/registry.svelte.ts
+++ b/packages/svelte/src/lib/geoms/registry.svelte.ts
@@ -52,7 +52,15 @@ export class LayerRegistry {
   readonly #byId = new Map<number, Layer>();
   /** Host capabilities — separate from grammar layers (never plotLayers). */
   readonly #capabilities = new Map<number, CapabilityEntry>();
+  /** Bumps only on mark/grammar layer register/unregister. */
   #version = $state(0);
+  /**
+   * Bumps only on host-capability register/unregister. Kept separate from
+   * `#version` so geom mount/unmount does not re-run inspect resolve →
+   * interactionConfig diagnostics (config diagnostics re-deliver per recompute
+   * and must not fire on unrelated layer churn).
+   */
+  #capabilityVersion = $state(0);
   /** Monotonic register count (never decrements). For ADR 0001 test assertions. */
   #registrationCount = 0;
 
@@ -87,14 +95,15 @@ export class LayerRegistry {
     };
     this.#capabilities.set(id, entry);
     this.#registrationCount += 1;
-    this.#version = ++globalVersion;
+    this.#capabilityVersion = ++globalVersion;
     return id;
   }
 
   unregister(id: number): void {
-    this.#byId.delete(id);
-    this.#capabilities.delete(id);
-    this.#version = ++globalVersion;
+    const removedLayer = this.#byId.delete(id);
+    const removedCapability = this.#capabilities.delete(id);
+    if (removedLayer) this.#version = ++globalVersion;
+    if (removedCapability) this.#capabilityVersion = ++globalVersion;
   }
 
   /** Every registered layer in registration order (reactive read). */
@@ -120,9 +129,12 @@ export class LayerRegistry {
    * Host capability values of `kind` in registration order (reactive).
    * Multiple entries of the same kind are all returned so resolve can last-win
    * and multi-child diagnostics can fire.
+   *
+   * Depends on `#capabilityVersion` only — mark/grammar churn must not invalidate
+   * capability readers (see field comment).
    */
   capabilities<K extends HostCapabilityKind>(kind: K): readonly HostCapabilityValue[K][] {
-    void this.#version;
+    void this.#capabilityVersion;
     const out: HostCapabilityValue[K][] = [];
     for (const entry of this.#capabilities.values()) {
       if (entry.kind === kind) {

--- a/packages/svelte/src/lib/geoms/registry.svelte.ts
+++ b/packages/svelte/src/lib/geoms/registry.svelte.ts
@@ -85,7 +85,7 @@ export class LayerRegistry {
         return getValue();
       },
     };
-    this.#capabilities.set(id, entry as CapabilityEntry);
+    this.#capabilities.set(id, entry);
     this.#registrationCount += 1;
     this.#version = ++globalVersion;
     return id;
@@ -125,7 +125,11 @@ export class LayerRegistry {
     void this.#version;
     const out: HostCapabilityValue[K][] = [];
     for (const entry of this.#capabilities.values()) {
-      if (entry.kind === kind) out.push(entry.value as HostCapabilityValue[K]);
+      if (entry.kind === kind) {
+        // entry is CapabilityEntry; kind narrow leaves value as the union of all
+        // capability values. Only inspect exists today so this is the inspect bag.
+        out.push(entry.value);
+      }
     }
     return out;
   }

--- a/packages/svelte/src/lib/interaction/interaction-diagnostics.ts
+++ b/packages/svelte/src/lib/interaction/interaction-diagnostics.ts
@@ -238,6 +238,7 @@ export const INTERACTION_DIAGNOSTIC_CATALOG: Readonly<
       "Keep a single <Inspect> child",
       "Merge options onto one <Inspect> instead of stacking siblings",
     ],
-    docUrl: "https://ggsvelte.sh/guide/upgrading#compose-inspect-as-a-child-layer",
+    docUrl:
+      "https://ggsvelte.sh/guide/interaction-reference#interaction-duplicate-inspect-capability",
   },
 });

--- a/packages/svelte/src/lib/interaction/interaction-diagnostics.ts
+++ b/packages/svelte/src/lib/interaction/interaction-diagnostics.ts
@@ -24,7 +24,8 @@ export type InteractionDiagnosticCode =
   | "INTERACTION_INSPECT_X_ON_COL"
   | "INTERACTION_INSPECT_X_ON_BAR"
   | "INTERACTION_INSPECT_X_BISECTS_COL_LABELS"
-  | "INTERACTION_INSPECT_X_BISECTS_BAR_LABELS";
+  | "INTERACTION_INSPECT_X_BISECTS_BAR_LABELS"
+  | "INTERACTION_DUPLICATE_INSPECT_CAPABILITY";
 
 export interface InteractionDiagnostic {
   readonly severity: "error" | "warning" | "advisory";
@@ -226,5 +227,17 @@ export const INTERACTION_DIAGNOSTIC_CATALOG: Readonly<
     ],
     docUrl:
       "https://ggsvelte.sh/guide/interaction-reference#interaction-inspect-x-bisects-bar-labels",
+  },
+  INTERACTION_DUPLICATE_INSPECT_CAPABILITY: {
+    severity: "advisory",
+    code: "INTERACTION_DUPLICATE_INSPECT_CAPABILITY",
+    message:
+      "Multiple <Inspect> children are registered; only the last one's options apply (REPLACE).",
+    prop: "Inspect",
+    suggestions: [
+      "Keep a single <Inspect> child",
+      "Merge options onto one <Inspect> instead of stacking siblings",
+    ],
+    docUrl: "https://ggsvelte.sh/guide/upgrading#compose-inspect-as-a-child-layer",
   },
 });

--- a/packages/svelte/src/lib/interaction/resolve-inspect-capability.ts
+++ b/packages/svelte/src/lib/interaction/resolve-inspect-capability.ts
@@ -44,7 +44,7 @@ export function resolveInspectCapability(
       multiChild: false,
     };
   }
-  const last = children[children.length - 1]!;
+  const last = children.at(-1)!;
   return {
     input: childToInput(last),
     multiChild: children.length > 1,

--- a/packages/svelte/src/lib/interaction/resolve-inspect-capability.ts
+++ b/packages/svelte/src/lib/interaction/resolve-inspect-capability.ts
@@ -1,0 +1,60 @@
+/**
+ * Resolve host inspect capability from the GGPlot prop and registered
+ * capability children (declaration-only `<Inspect>`). Pure — no registry I/O.
+ *
+ * Child presence enables inspect; empty child bag ≡ `inspect={true}`.
+ * When any child is registered, the last child's options replace the prop
+ * whole (no deep-merge). Multiple children set `multiChild` for diagnostics.
+ */
+import type { InspectInput, InspectOptions } from "./interaction.js";
+import {
+  INTERACTION_DIAGNOSTIC_CATALOG,
+  type InteractionDiagnostic,
+} from "./interaction-diagnostics.js";
+
+/** Options bag registered by one `<Inspect>` (empty object = defaults). */
+export type InspectCapabilityChild = InspectOptions;
+
+export type ResolveInspectCapabilityInput = {
+  readonly prop?: InspectInput | undefined;
+  readonly children?: readonly InspectCapabilityChild[] | undefined;
+};
+
+export type ResolveInspectCapabilityResult = {
+  /** Value for normalizeInteractionConfig / resolveCapabilities override. */
+  readonly input: InspectInput;
+  /** True when more than one inspect capability child is registered. */
+  readonly multiChild: boolean;
+};
+
+function childToInput(child: InspectCapabilityChild): InspectInput {
+  return Object.keys(child).length === 0 ? true : child;
+}
+
+/**
+ * Prefer the last capability child over the prop. No children → prop ?? false.
+ */
+export function resolveInspectCapability(
+  input: ResolveInspectCapabilityInput,
+): ResolveInspectCapabilityResult {
+  const children = input.children ?? [];
+  if (children.length === 0) {
+    return {
+      input: input.prop ?? false,
+      multiChild: false,
+    };
+  }
+  const last = children[children.length - 1]!;
+  return {
+    input: childToInput(last),
+    multiChild: children.length > 1,
+  };
+}
+
+/** Zero or one multi-Inspect advisory from a resolve result. */
+export function duplicateInspectCapabilityDiagnostics(
+  multiChild: boolean,
+): InteractionDiagnostic[] {
+  if (!multiChild) return [];
+  return [{ ...INTERACTION_DIAGNOSTIC_CATALOG.INTERACTION_DUPLICATE_INSPECT_CAPABILITY }];
+}

--- a/packages/svelte/src/lib/plot-engine.svelte.ts
+++ b/packages/svelte/src/lib/plot-engine.svelte.ts
@@ -67,6 +67,10 @@ import {
   type PlotInteractionScope,
   type ResolvedInteractionConfig,
 } from "./interaction/interaction.js";
+import {
+  duplicateInspectCapabilityDiagnostics,
+  resolveInspectCapability,
+} from "./interaction/resolve-inspect-capability.js";
 import { collectWiringDiagnostics } from "./interaction/wiring-advisories.js";
 import { createInspectionState } from "./inspection/inspection-state.svelte.js";
 import type { InspectionState } from "./inspection/inspection-state.svelte.js";
@@ -190,9 +194,35 @@ export type PlotEngine = {
 // ---------------------------------------------------------------------------
 
 export function createPlotEngine(host: PlotEngineHost): PlotEngine {
-  // Capability defaults — pure, lazy per read (do not materialize a full
-  // props snapshot; per-field deps stay on host.props).
-  const caps = (): ResolvedPlotCapabilities => resolveCapabilities(host.props);
+  // Inspect capability: prop + host capability registry children. Pure resolve
+  // stays props-agnostic of registry; engine is the seam (plot-props stays
+  // props-only). SSR: recompute from the plain registry like assembled (#982)
+  // so one-pass construction does not latch empty children as inspect-off.
+  function resolveInspectCurrent() {
+    return resolveInspectCapability({
+      prop: host.props.inspect,
+      children: host.registry.capabilities("inspect"),
+    });
+  }
+  const inspectResolvedDerived = $derived.by(resolveInspectCurrent);
+  const inspectResolved = () =>
+    typeof window === "undefined" ? resolveInspectCurrent() : inspectResolvedDerived;
+
+  // Capability defaults — pure, lazy per read. Inspect uses resolved prop+child
+  // so wiring advisories see declaration-only <Inspect> as enabled.
+  const caps = (): ResolvedPlotCapabilities => {
+    const select = host.props.select;
+    const zoom = host.props.zoom;
+    const legendFocus = host.props.legendFocus;
+    const legendFilter = host.props.legendFilter;
+    return resolveCapabilities({
+      inspect: inspectResolved().input,
+      ...(select !== undefined && { select }),
+      ...(zoom !== undefined && { zoom }),
+      ...(legendFocus !== undefined && { legendFocus }),
+      ...(legendFilter !== undefined && { legendFilter }),
+    });
+  };
 
   // Reading descriptors through toLayerInput goes through live getters, so
   // geom prop changes flow into this $derived without re-registration.
@@ -269,27 +299,29 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
   const legendFocusResolved = (): ResolvedLegendFocusCapability =>
     typeof window === "undefined" ? resolveLegendFocusNow() : legendFocusResolvedDerived;
 
-  const interactionConfig = $derived(
-    (() => {
-      const tool = host.props.tool;
-      // Four fields only — legendFilter is not part of normalizeInteractionConfig.
-      // Reading it via caps() re-delivered config diagnostics on every filter toggle.
-      // legendFocus comes from GuideLegend children (host registry), not only the plot prop.
-      return normalizeInteractionConfig(
-        {
-          inspect: host.props.inspect ?? false,
-          select: host.props.select ?? false,
-          zoom: host.props.zoom ?? false,
-          legendFocus: legendFocusResolved().configInput,
-          ...(tool !== undefined && { tool }),
-        },
-        {
-          faceted: facetedPlot,
-          hasKey: host.props.key !== undefined,
-        },
-      );
-    })(),
-  );
+  // interactionConfig: inspect from prop + <Inspect> children; legendFocus from
+  // GuideLegend (host registry). SSR hatch matches assembled / inspectResolved.
+  function interactionConfigCurrent(): ResolvedInteractionConfig {
+    const tool = host.props.tool;
+    // Four fields only — legendFilter is not part of normalizeInteractionConfig.
+    // Reading it via caps() re-delivered config diagnostics on every filter toggle.
+    return normalizeInteractionConfig(
+      {
+        inspect: inspectResolved().input,
+        select: host.props.select ?? false,
+        zoom: host.props.zoom ?? false,
+        legendFocus: legendFocusResolved().configInput,
+        ...(tool !== undefined && { tool }),
+      },
+      {
+        faceted: facetedPlot,
+        hasKey: host.props.key !== undefined,
+      },
+    );
+  }
+  const interactionConfigDerived = $derived.by(interactionConfigCurrent);
+  const interactionConfig = (): ResolvedInteractionConfig =>
+    typeof window === "undefined" ? interactionConfigCurrent() : interactionConfigDerived;
 
   function deliverDiagnostic(diagnostic: PlotDiagnostic): void {
     const ondiagnostic = host.props.ondiagnostic;
@@ -301,7 +333,7 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
   }
 
   $effect(() => {
-    for (const diagnostic of interactionConfig.diagnostics) deliverDiagnostic(diagnostic);
+    for (const diagnostic of interactionConfig().diagnostics) deliverDiagnostic(diagnostic);
   });
 
   // Wiring advisories (ADR 0013 audit): prop combinations that silently do
@@ -309,6 +341,7 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
   // fire once per prop per plot instance — a later capability toggle must
   // not re-advise. Pure collect lives in wiring-advisories.ts; snapshot is
   // taken inside this derived so late-bound handlers still recompute.
+  // capabilities.inspect is resolved (prop + <Inspect> children), not raw prop.
   const wiringDiagnostics = $derived.by((): InteractionDiagnostic[] => {
     const capabilities = caps();
     // legendFocus "requested" is the GuideLegend/child (or deprecated prop)
@@ -333,12 +366,26 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
       },
     });
   });
-  // Shared once-per-code-per-prop Set for wiring + composition + deprecations.
-  // Delivery order is fixed: config effect (above) → wiring → composition.
+  // Shared once-per-code-per-prop Set for wiring + composition + multi-Inspect
+  // + deprecations. Order: config → wiring → multi-inspect → legendFocus
+  // deprecation → composition.
   // Grammar-prop deprecation emission removed in 0.13.0 (#704) — props gone.
   const deliveredAdvisories = new Set<string>();
   $effect(() => {
     for (const diagnostic of wiringDiagnostics) {
+      const dedupKey = `${diagnostic.code}:${diagnostic.prop}`;
+      if (deliveredAdvisories.has(dedupKey)) continue;
+      deliveredAdvisories.add(dedupKey);
+      deliverDiagnostic(diagnostic);
+    }
+  });
+
+  // Multiple <Inspect> children: last wins; advisory once per mount.
+  const multiInspectDiagnostics = $derived.by((): InteractionDiagnostic[] =>
+    duplicateInspectCapabilityDiagnostics(inspectResolved().multiChild),
+  );
+  $effect(() => {
+    for (const diagnostic of multiInspectDiagnostics) {
       const dedupKey = `${diagnostic.code}:${diagnostic.prop}`;
       if (deliveredAdvisories.has(dedupKey)) continue;
       deliveredAdvisories.add(dedupKey);
@@ -384,7 +431,7 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
   // Inspect axis guides that fight bar/col geometry (or bisect on-bar labels).
   // Needs assembled layers + resolved inspect.mode; once-per-code:prop like wiring.
   const inspectGeomDiagnostics = $derived.by((): InteractionDiagnostic[] => {
-    const mode = interactionConfig.inspect?.mode;
+    const mode = interactionConfig().inspect?.mode;
     if (mode === undefined) return [];
     return inspectAxisOnBarColDiagnostics(mode, layerGeomsFromSpecLayers(assembled()?.layers));
   });
@@ -414,7 +461,7 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
   const zoomState = createPlotZoomState({
     interaction: () => host.props.interaction,
     resolvedInteractionScope: () => resolvedInteractionScope,
-    zoomConfig: () => interactionConfig.zoom,
+    zoomConfig: () => interactionConfig().zoom,
     assembled,
     // Model is declared after the runtime; handlers only.
     model: () => runtime.model,
@@ -507,12 +554,12 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
   // source rows/spec -> pipeline/scene + CandidateStore -> semantic resolver
   // -> chart-local reducer -> tooltip/crosshair/tools/callbacks. Presentation
   // consumes one resolved inspection and never reconstructs grouping itself.
-  const interactive = $derived(interactionConfig.interactive);
-  const surfaceInteractive = $derived(interactionConfig.availableTools.length > 0);
+  const interactive = $derived(interactionConfig().interactive);
+  const surfaceInteractive = $derived(interactionConfig().availableTools.length > 0);
 
   // Shared enablement predicates (avoid re-typing the same config gates).
-  const inspectEnabled = $derived(interactionConfig.inspect !== null);
-  const legendFocusEnabled = $derived(interactionConfig.legendFocus !== null);
+  const inspectEnabled = $derived(interactionConfig().inspect !== null);
+  const legendFocusEnabled = $derived(interactionConfig().legendFocus !== null);
   const coordFlipped = $derived(assembled()?.coord?.type === "flip");
   let tooltipHovered = $state(false);
 
@@ -521,7 +568,7 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
   const selectionState = createSelectionState({
     interaction: () => host.props.interaction,
     resolvedInteractionScope: () => resolvedInteractionScope,
-    selectConfig: () => interactionConfig.select,
+    selectConfig: () => interactionConfig().select,
     onselect: () => host.props.onselect,
     oninteraction: () => host.props.oninteraction,
     announce: announceSink,
@@ -535,7 +582,7 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
   const inspectionState = createInspectionState({
     model: () => runtime.model,
     reducer: () => surfaceState.reducer,
-    inspectConfig: () => interactionConfig.inspect,
+    inspectConfig: () => interactionConfig().inspect,
     inspectEnabled: () => inspectEnabled,
     dataIdentityEpoch: () => dataIdentityEpoch,
     keyAt: (index) => semanticKeys.keyAt(index),
@@ -562,7 +609,7 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
     model: () => runtime.model,
     interaction: () => host.props.interaction,
     resolvedInteractionScope: () => resolvedInteractionScope,
-    selectConfig: () => interactionConfig.select,
+    selectConfig: () => interactionConfig().select,
     effectiveZoomDomains: () => zoomState.effectiveZoomDomains,
     commitZoom: (...args: Parameters<PlotZoomState["commitZoom"]>) => {
       zoomState.commitZoom(...args);
@@ -583,20 +630,20 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
   // chrome) so surface does not close over later chromeState (#1082).
   const surfaceAvailableTools = $derived(
     resolveFilteredAvailableTools(
-      interactionConfig.availableTools,
-      interactionConfig.zoom,
+      interactionConfig().availableTools,
+      interactionConfig().zoom,
       runtime.model?.scales ?? null,
     ),
   );
-  const surfacePointSelectEnabled = $derived(canPublishPointSelection(interactionConfig.select));
+  const surfacePointSelectEnabled = $derived(canPublishPointSelection(interactionConfig().select));
   surfaceState = createSurfaceState({
     model: () => runtime.model,
     root: host.root,
     toolProp: () => host.props.tool,
-    initialTool: () => interactionConfig.initialTool,
+    initialTool: () => interactionConfig().initialTool,
     availableTools: () => surfaceAvailableTools,
-    inspectConfig: () => interactionConfig.inspect,
-    selectConfig: () => interactionConfig.select,
+    inspectConfig: () => interactionConfig().inspect,
+    selectConfig: () => interactionConfig().select,
     pointSelectEnabled: () => surfacePointSelectEnabled,
     ontoolchange: () => host.props.ontoolchange,
     surfaceInteractive: () => surfaceInteractive,
@@ -623,7 +670,7 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
     interaction: () => host.props.interaction,
     resolvedInteractionScope: () => resolvedInteractionScope,
     legendFocusEnabled: () => legendFocusEnabled,
-    legendFocusPreviewEnabled: () => interactionConfig.legendFocus?.preview === true,
+    legendFocusPreviewEnabled: () => interactionConfig().legendFocus?.preview === true,
     root: host.root,
     entryKeys: () => legendEntryKeys,
     entries: () => interactiveLegendEntries,
@@ -639,7 +686,7 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
     intervalKeys: () => intervalState.effectiveIntervalKeys,
     intervals: () => intervalState.effectiveIntervals,
     emphasisKeys: () => legendFocusState.effectiveEmphasisKeys,
-    muteSiblingsOnInspect: () => interactionConfig.inspect?.muteSiblings === true,
+    muteSiblingsOnInspect: () => interactionConfig().inspect?.muteSiblings === true,
     // Inspection owns the projection (#1080); wiring no longer re-assembles it.
     inspectionFocus: () => inspectionState.presentationFocus,
   });
@@ -650,10 +697,10 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
   // UI, recomputed with the same pure helpers as surfaceAvailableTools above.
   const chromeState = createPlotChromeState({
     model: () => runtime.model,
-    zoomConfig: () => interactionConfig.zoom,
-    selectConfig: () => interactionConfig.select,
-    configuredAvailableTools: () => interactionConfig.availableTools,
-    interactionDiagnostics: () => interactionConfig.diagnostics,
+    zoomConfig: () => interactionConfig().zoom,
+    selectConfig: () => interactionConfig().select,
+    configuredAvailableTools: () => interactionConfig().availableTools,
+    interactionDiagnostics: () => interactionConfig().diagnostics,
     interactive: () => interactive,
     effectiveZoomDomains: () => zoomState.effectiveZoomDomains,
     effectiveIntervals: () => intervalState.effectiveIntervals,
@@ -727,7 +774,7 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
       return assembled();
     },
     get interactionConfig() {
-      return interactionConfig;
+      return interactionConfig();
     },
     get interactive() {
       return interactive;

--- a/packages/svelte/src/lib/plot-engine.svelte.ts
+++ b/packages/svelte/src/lib/plot-engine.svelte.ts
@@ -208,22 +208,6 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
   const inspectResolved = () =>
     typeof window === "undefined" ? resolveInspectCurrent() : inspectResolvedDerived;
 
-  // Capability defaults — pure, lazy per read. Inspect uses resolved prop+child
-  // so wiring advisories see declaration-only <Inspect> as enabled.
-  const caps = (): ResolvedPlotCapabilities => {
-    const select = host.props.select;
-    const zoom = host.props.zoom;
-    const legendFocus = host.props.legendFocus;
-    const legendFilter = host.props.legendFilter;
-    return resolveCapabilities({
-      inspect: inspectResolved().input,
-      ...(select !== undefined && { select }),
-      ...(zoom !== undefined && { zoom }),
-      ...(legendFocus !== undefined && { legendFocus }),
-      ...(legendFilter !== undefined && { legendFilter }),
-    });
-  };
-
   // Reading descriptors through toLayerInput goes through live getters, so
   // geom prop changes flow into this $derived without re-registration.
   // Explicit `spec` short-circuits before registry/children so ignored props
@@ -298,6 +282,22 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
   const legendFocusResolvedDerived = $derived.by(resolveLegendFocusNow);
   const legendFocusResolved = (): ResolvedLegendFocusCapability =>
     typeof window === "undefined" ? resolveLegendFocusNow() : legendFocusResolvedDerived;
+
+  // Capability defaults for wiring — inspect from prop + <Inspect> children;
+  // legendFocus "requested" from GuideLegend / legacy prop (not host.props.legendFocus
+  // direct — that prop is deprecated and type-aware lint denies it).
+  const caps = (): ResolvedPlotCapabilities => {
+    const select = host.props.select;
+    const zoom = host.props.zoom;
+    const legendFilter = host.props.legendFilter;
+    return resolveCapabilities({
+      inspect: inspectResolved().input,
+      legendFocus: legendFocusResolved().requested,
+      ...(select !== undefined && { select }),
+      ...(zoom !== undefined && { zoom }),
+      ...(legendFilter !== undefined && { legendFilter }),
+    });
+  };
 
   // interactionConfig: inspect from prop + <Inspect> children; legendFocus from
   // GuideLegend (host registry). SSR hatch matches assembled / inspectResolved.

--- a/packages/svelte/tests/interaction/capability-registry.test.ts
+++ b/packages/svelte/tests/interaction/capability-registry.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Host capability registry on LayerRegistry (inspect children, not Layer union).
+ */
+import { describe, expect, it } from "vitest";
+
+import { LayerRegistry } from "../../src/lib/geoms/registry.svelte.js";
+import { resolveInspectCapability } from "../../src/lib/interaction/resolve-inspect-capability.js";
+
+describe("LayerRegistry capabilities", () => {
+  it("returns inspect values in registration order", () => {
+    const registry = new LayerRegistry();
+    const id1 = registry.registerCapability("inspect", () => ({ mode: "x" as const }));
+    const id2 = registry.registerCapability("inspect", () => ({ mode: "xy" as const }));
+    expect(registry.capabilities("inspect")).toEqual([{ mode: "x" }, { mode: "xy" }]);
+    registry.unregister(id1);
+    expect(registry.capabilities("inspect")).toEqual([{ mode: "xy" }]);
+    registry.unregister(id2);
+    expect(registry.capabilities("inspect")).toEqual([]);
+  });
+
+  it("does not put capabilities on layers / markLayers", () => {
+    const registry = new LayerRegistry();
+    registry.registerCapability("inspect", () => ({}));
+    expect(registry.layers).toEqual([]);
+    expect(registry.markLayers).toEqual([]);
+  });
+
+  it("live getters re-read on each capabilities() call", () => {
+    const registry = new LayerRegistry();
+    let mode: "x" | "y" = "x";
+    registry.registerCapability("inspect", () => ({ mode }));
+    expect(registry.capabilities("inspect")[0]).toEqual({ mode: "x" });
+    mode = "y";
+    expect(registry.capabilities("inspect")[0]).toEqual({ mode: "y" });
+  });
+
+  it("resolveInspectCapability last-wins over multi registration", () => {
+    const registry = new LayerRegistry();
+    registry.registerCapability("inspect", () => ({ mode: "x" as const }));
+    registry.registerCapability("inspect", () => ({ mode: "y" as const }));
+    const resolved = resolveInspectCapability({
+      prop: { mode: "xy" },
+      children: registry.capabilities("inspect"),
+    });
+    expect(resolved).toEqual({ input: { mode: "y" }, multiChild: true });
+  });
+});

--- a/packages/svelte/tests/interaction/capability-registry.test.ts
+++ b/packages/svelte/tests/interaction/capability-registry.test.ts
@@ -11,6 +11,18 @@ describe("LayerRegistry capabilities", () => {
     expect(typeof registerHostCapability).toBe("function");
   });
 
+  it("keeps inspect capabilities across mark register/unregister", () => {
+    // capabilities() uses #capabilityVersion only — mark churn must not drop
+    // host capability entries (interactionConfig must not re-deliver diagnostics).
+    const registry = new LayerRegistry();
+    registry.registerCapability("inspect", () => ({ mode: "xy" as const }));
+    const markId = registry.register({ geom: "point" });
+    expect(registry.capabilities("inspect")).toEqual([{ mode: "xy" }]);
+    registry.unregister(markId);
+    expect(registry.capabilities("inspect")).toEqual([{ mode: "xy" }]);
+    expect(registry.markLayers).toEqual([]);
+  });
+
   it("returns inspect values in registration order", () => {
     const registry = new LayerRegistry();
     const id1 = registry.registerCapability("inspect", () => ({ mode: "x" as const }));

--- a/packages/svelte/tests/interaction/capability-registry.test.ts
+++ b/packages/svelte/tests/interaction/capability-registry.test.ts
@@ -3,10 +3,14 @@
  */
 import { describe, expect, it } from "vitest";
 
-import { LayerRegistry } from "../../src/lib/geoms/registry.svelte.js";
+import { LayerRegistry, registerHostCapability } from "../../src/lib/geoms/registry.svelte.js";
 import { resolveInspectCapability } from "../../src/lib/interaction/resolve-inspect-capability.js";
 
 describe("LayerRegistry capabilities", () => {
+  it("exports registerHostCapability for declaration children (ADR 0001 helper)", () => {
+    expect(typeof registerHostCapability).toBe("function");
+  });
+
   it("returns inspect values in registration order", () => {
     const registry = new LayerRegistry();
     const id1 = registry.registerCapability("inspect", () => ({ mode: "x" as const }));

--- a/packages/svelte/tests/interaction/resolve-inspect-capability.test.ts
+++ b/packages/svelte/tests/interaction/resolve-inspect-capability.test.ts
@@ -76,6 +76,6 @@ describe("duplicateInspectCapabilityDiagnostics", () => {
     expect(duplicateInspectCapabilityDiagnostics(false)).toEqual([]);
     const list = duplicateInspectCapabilityDiagnostics(true);
     expect(list).toHaveLength(1);
-    expect(list[0]!.code).toBe("INTERACTION_DUPLICATE_INSPECT_CAPABILITY");
+    expect(list.at(0)?.code).toBe("INTERACTION_DUPLICATE_INSPECT_CAPABILITY");
   });
 });

--- a/packages/svelte/tests/interaction/resolve-inspect-capability.test.ts
+++ b/packages/svelte/tests/interaction/resolve-inspect-capability.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Pure resolve of host inspect capability from prop + capability children.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  duplicateInspectCapabilityDiagnostics,
+  resolveInspectCapability,
+  type InspectCapabilityChild,
+} from "../../src/lib/interaction/resolve-inspect-capability.js";
+
+describe("resolveInspectCapability", () => {
+  it("is off when prop and children are absent", () => {
+    expect(resolveInspectCapability({})).toEqual({ input: false, multiChild: false });
+    expect(resolveInspectCapability({ prop: undefined, children: [] })).toEqual({
+      input: false,
+      multiChild: false,
+    });
+  });
+
+  it("passes through prop true and object when no children", () => {
+    expect(resolveInspectCapability({ prop: true })).toEqual({
+      input: true,
+      multiChild: false,
+    });
+    const options = { mode: "xy" as const, pin: false };
+    expect(resolveInspectCapability({ prop: options })).toEqual({
+      input: options,
+      multiChild: false,
+    });
+  });
+
+  it("treats prop false as off when no children", () => {
+    expect(resolveInspectCapability({ prop: false })).toEqual({
+      input: false,
+      multiChild: false,
+    });
+  });
+
+  it("enables from an empty child bag (≡ inspect={true})", () => {
+    expect(resolveInspectCapability({ children: [{}] })).toEqual({
+      input: true,
+      multiChild: false,
+    });
+  });
+
+  it("uses the last child's options bag whole (no deep-merge with prop)", () => {
+    const child: InspectCapabilityChild = { mode: "xy", pin: false };
+    expect(
+      resolveInspectCapability({
+        prop: { mode: "x", pin: true, muteSiblings: true },
+        children: [child],
+      }),
+    ).toEqual({ input: child, multiChild: false });
+  });
+
+  it("child wins over prop false", () => {
+    expect(resolveInspectCapability({ prop: false, children: [{ mode: "exact" }] })).toEqual({
+      input: { mode: "exact" },
+      multiChild: false,
+    });
+  });
+
+  it("last of multiple children wins and multiChild is true", () => {
+    const last: InspectCapabilityChild = { mode: "y" };
+    expect(
+      resolveInspectCapability({
+        children: [{ mode: "x" }, last],
+      }),
+    ).toEqual({ input: last, multiChild: true });
+  });
+});
+
+describe("duplicateInspectCapabilityDiagnostics", () => {
+  it("emits only when multiChild", () => {
+    expect(duplicateInspectCapabilityDiagnostics(false)).toEqual([]);
+    const list = duplicateInspectCapabilityDiagnostics(true);
+    expect(list).toHaveLength(1);
+    expect(list[0]!.code).toBe("INTERACTION_DUPLICATE_INSPECT_CAPABILITY");
+  });
+});

--- a/scripts/diagnostic-docs.ts
+++ b/scripts/diagnostic-docs.ts
@@ -94,6 +94,16 @@ const recipes = new Map<string, DiagnosticDocEntry["recipe"]>([
     },
   ],
   [
+    "interaction:INTERACTION_DUPLICATE_INSPECT_CAPABILITY",
+    {
+      language: "svelte",
+      code: `<GGPlot data={rows} aes={{ x: "x", y: "y" }}>
+  <Inspect mode="xy" />
+  <GeomPoint />
+</GGPlot>`,
+    },
+  ],
+  [
     "cli:invalid-json",
     {
       language: "sh",


### PR DESCRIPTION
## Summary

Bottom of the Inspect hybrid stack. Host inspect capability can be declared via a future `<Inspect>` child (and is already resolvable when children register on the capability map).

- `LayerRegistry.registerCapability` / `capabilities(kind)` — separate from grammar `Layer` union (never PortableSpec)
- Pure `resolveInspectCapability` (child whole-bag wins over prop; multi-child last-wins)
- Engine feeds resolved inspect into `normalizeInteractionConfig` **and** wiring advisories
- SSR recompute guard for inspect resolve + interactionConfig (same class as assembled)
- `INTERACTION_DUPLICATE_INSPECT_CAPABILITY` advisory

## Stack

1. **This PR** — registry + resolve + engine
2. #1239 — `<Inspect>` component + export
3. #1240 — skill docs + changeset

## Test plan

- [x] `bun run test:browser -- tests/interaction/resolve-inspect-capability.test.ts tests/interaction/capability-registry.test.ts`
- [x] `bun run check` in packages/svelte
- [ ] CI green