### PR TITLE
feat(svelte): add declaration-only <Inspect> capability child

### DIFF
--- a/apps/docs/src/lib/generated/routes.ts
+++ b/apps/docs/src/lib/generated/routes.ts
@@ -12021,8 +12021,8 @@ export const DOCS_ROUTES = [
         level: 2,
       },
       {
-        id: "experimental-472",
-        title: "experimental (472)",
+        id: "experimental-473",
+        title: "experimental (473)",
         level: 3,
       },
       {

--- a/apps/docs/src/lib/generated/search-index.ts
+++ b/apps/docs/src/lib/generated/search-index.ts
@@ -19873,14 +19873,14 @@ export const DOCS_SEARCH_INDEX = [
     exact: ["@ggsvelte/svelte"],
   },
   {
-    id: "heading:guide-lifecycle:experimental-472",
+    id: "heading:guide-lifecycle:experimental-473",
     kind: "heading",
-    title: "experimental (472)",
+    title: "experimental (473)",
     summary:
-      "experimental (472) in Lifecycle & editions. API stability tags per export, and the defaults-edition mechanism.",
-    href: "/guide/lifecycle#experimental-472",
+      "experimental (473) in Lifecycle & editions. API stability tags per export, and the defaults-edition mechanism.",
+    href: "/guide/lifecycle#experimental-473",
     keywords: ["Lifecycle & editions", "Reference"],
-    exact: ["experimental (472)"],
+    exact: ["experimental (473)"],
   },
   {
     id: "heading:guide-lifecycle:stable-intent-243",
@@ -34221,6 +34221,15 @@ export const DOCS_SEARCH_INDEX = [
     href: "/guide/lifecycle#ggsvelte-svelte",
     keywords: ["@ggsvelte/svelte", ".", "type", "experimental"],
     exact: ["IdentityNumericStyleScaleOptions"],
+  },
+  {
+    id: "api:ggsvelte-svelte:Inspect",
+    kind: "api",
+    title: "Inspect",
+    summary: "@ggsvelte/svelte · value · experimental.",
+    href: "/guide/lifecycle#ggsvelte-svelte",
+    keywords: ["@ggsvelte/svelte", ".", "value", "experimental"],
+    exact: ["Inspect"],
   },
   {
     id: "api:ggsvelte-svelte:InspectInput",

--- a/lifecycle.json
+++ b/lifecycle.json
@@ -5577,6 +5577,10 @@
           "kind": "type",
           "lifecycle": "experimental"
         },
+        "Inspect": {
+          "kind": "value",
+          "lifecycle": "experimental"
+        },
         "InspectInput": {
           "kind": "type",
           "lifecycle": "experimental"

--- a/packages/svelte/src/lib/index.ts
+++ b/packages/svelte/src/lib/index.ts
@@ -13,6 +13,8 @@
 /** @lifecycle stable-intent */
 export { default as GGPlot } from "./GGPlot.svelte";
 export { default as Tooltip } from "./inspection/Tooltip.svelte";
+/** @lifecycle experimental */
+export { default as Inspect } from "./inspection/Inspect.svelte";
 export type {
   LegendFilterClause,
   LegendFilterEvent,

--- a/packages/svelte/src/lib/inspection/Inspect.svelte
+++ b/packages/svelte/src/lib/inspection/Inspect.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+  /**
+   * <Inspect> — declaration-only host inspect capability for <GGPlot>.
+   *
+   * Presence enables inspection (tooltip, crosshair, pin, keyboard). Props
+   * match InspectOptions (mode, pin, maxDistance, contentMode, muteSiblings,
+   * content). Empty `<Inspect />` ≡ `inspect={true}` on GGPlot.
+   *
+   * Host-only: not folded into PortableSpec. Mark eligibility remains
+   * `inspect={false}` on individual geoms.
+   *
+   * Emits NO markup; registers a live capability during component init and
+   * unregisters on destroy. Inert without a <GGPlot> ancestor.
+   */
+  import type { Snippet } from "svelte";
+
+  import type { CellValue } from "@ggsvelte/core";
+
+  import type {
+    InspectMode,
+    PlotInspectionChange,
+  } from "../interaction/interaction.js";
+  import { definedProps } from "../layers/plot-layer.svelte.js";
+  import { registerHostCapability } from "../geoms/registry.svelte.js";
+
+  type Props = {
+    mode?: InspectMode;
+    pin?: boolean;
+    maxDistance?: number;
+    contentMode?: "informational" | "interactive";
+    muteSiblings?: boolean;
+    /** Row/Key widen at the non-generic registry boundary (same as engine). */
+    content?: Snippet<
+      [PlotInspectionChange<Record<string, CellValue>, PropertyKey>]
+    >;
+  };
+
+  /** Known InspectOptions keys — typo props never reach normalize silently. */
+  const KNOWN = new Set([
+    "mode",
+    "pin",
+    "maxDistance",
+    "contentMode",
+    "muteSiblings",
+    "content",
+  ]);
+
+  const props: Props = $props();
+
+  registerHostCapability("inspect", () => {
+    const bag = definedProps(props) as Record<string, unknown>;
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(bag)) {
+      if (KNOWN.has(key)) out[key] = bag[key];
+    }
+    return out as Props;
+  });
+</script>

--- a/packages/svelte/tests/fixtures/InspectChildPlot.svelte
+++ b/packages/svelte/tests/fixtures/InspectChildPlot.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+  /**
+   * Host for <Inspect> capability-child tests.
+   * Captures registry and onrender interaction via diagnostics / callbacks.
+   */
+  import type { PlotDiagnostic } from "../../src/lib/diagnostics/deprecation.js";
+  import type { PortableSpec } from "../../src/lib/index.js";
+  import GGPlot from "../../src/lib/GGPlot.svelte";
+  import GeomPoint from "../../src/lib/geoms/GeomPoint.svelte";
+  import Inspect from "../../src/lib/inspection/Inspect.svelte";
+  import type { LayerRegistry } from "../../src/lib/geoms/registry.svelte.js";
+  import type { InspectMode } from "../../src/lib/interaction/interaction.js";
+  import ThemeRegistryCapture from "./ThemeRegistryCapture.svelte";
+
+  const {
+    useInspect = false,
+    inspectMode,
+    useSecondInspect = false,
+    secondInspectMode,
+    propInspect,
+    captureRegistry,
+    onrender,
+    ondiagnostic,
+    oninspect,
+  }: {
+    useInspect?: boolean;
+    inspectMode?: InspectMode;
+    useSecondInspect?: boolean;
+    secondInspectMode?: InspectMode;
+    propInspect?: boolean | { mode?: InspectMode };
+    captureRegistry?: (registry: LayerRegistry) => void;
+    onrender?: (model: unknown, spec: PortableSpec) => void;
+    ondiagnostic?: (diagnostic: PlotDiagnostic) => void;
+    oninspect?: (event: unknown) => void;
+  } = $props();
+
+  const data = [
+    { x: 1, y: 2 },
+    { x: 2, y: 3 },
+  ];
+</script>
+
+<GGPlot
+  {data}
+  aes={{ x: "x", y: "y" }}
+  width={200}
+  height={150}
+  inspect={propInspect}
+  {onrender}
+  {ondiagnostic}
+  {oninspect}
+>
+  {#if captureRegistry}
+    <ThemeRegistryCapture capture={captureRegistry} />
+  {/if}
+  {#if useInspect}
+    <Inspect mode={inspectMode} />
+  {/if}
+  {#if useSecondInspect}
+    <Inspect mode={secondInspectMode} />
+  {/if}
+  <GeomPoint />
+</GGPlot>

--- a/packages/svelte/tests/inspection/inspect-child.test.ts
+++ b/packages/svelte/tests/inspection/inspect-child.test.ts
@@ -91,7 +91,9 @@ describe("<Inspect> capability child", () => {
     });
     flushSync();
     // Wiring effect runs after children register (ADR 0001 order).
-    await new Promise((r) => setTimeout(r, 50));
+    await new Promise<void>((resolve) => {
+      setTimeout(() => resolve(), 50);
+    });
     expect(diagnostics.some((d) => d.code === "INTERACTION_HANDLER_WITHOUT_CAPABILITY")).toBe(
       false,
     );

--- a/packages/svelte/tests/inspection/inspect-child.test.ts
+++ b/packages/svelte/tests/inspection/inspect-child.test.ts
@@ -1,0 +1,99 @@
+/**
+ * <Inspect> declaration-only host capability child.
+ */
+import { flushSync } from "svelte";
+import { describe, expect, it } from "vitest";
+
+import type { PlotDiagnostic } from "../../src/lib/diagnostics/deprecation.js";
+import type { LayerRegistry } from "../../src/lib/geoms/registry.svelte.js";
+import { normalizeInteractionConfig } from "../../src/lib/interaction/interaction.js";
+import { resolveInspectCapability } from "../../src/lib/interaction/resolve-inspect-capability.js";
+import InspectChildPlot from "../fixtures/InspectChildPlot.svelte";
+import { render } from "../helpers/render.js";
+
+describe("<Inspect> capability child", () => {
+  it("registers an inspect capability on the plot registry", () => {
+    let registry: LayerRegistry | undefined;
+    render(InspectChildPlot, {
+      useInspect: true,
+      inspectMode: "xy",
+      captureRegistry: (r: LayerRegistry) => {
+        registry = r;
+      },
+    });
+    expect(registry).toBeDefined();
+    expect(registry!.capabilities("inspect")).toEqual([{ mode: "xy" }]);
+    // Host-only: never a grammar Layer kind
+    expect(registry!.layers.map((l) => l.kind)).not.toContain("inspect");
+  });
+
+  it("enables inspect config from child alone (no GGPlot inspect prop)", () => {
+    let registry: LayerRegistry | undefined;
+    render(InspectChildPlot, {
+      useInspect: true,
+      inspectMode: "exact",
+      captureRegistry: (r: LayerRegistry) => {
+        registry = r;
+      },
+    });
+    const resolved = resolveInspectCapability({
+      children: registry!.capabilities("inspect"),
+    });
+    expect(resolved.input).toEqual({ mode: "exact" });
+    const config = normalizeInteractionConfig({ inspect: resolved.input });
+    expect(config.inspect).not.toBeNull();
+    expect(config.inspect?.mode).toBe("exact");
+    expect(config.availableTools).toContain("inspect");
+  });
+
+  it("child options override the inspect prop whole bag", () => {
+    let registry: LayerRegistry | undefined;
+    render(InspectChildPlot, {
+      useInspect: true,
+      inspectMode: "xy",
+      propInspect: { mode: "x" },
+      captureRegistry: (r: LayerRegistry) => {
+        registry = r;
+      },
+    });
+    const resolved = resolveInspectCapability({
+      prop: { mode: "x" },
+      children: registry!.capabilities("inspect"),
+    });
+    expect(resolved.input).toEqual({ mode: "xy" });
+    expect(resolved.multiChild).toBe(false);
+  });
+
+  it("emits multi-Inspect advisory when two children register", async () => {
+    const diagnostics: PlotDiagnostic[] = [];
+    render(InspectChildPlot, {
+      useInspect: true,
+      inspectMode: "x",
+      useSecondInspect: true,
+      secondInspectMode: "y",
+      ondiagnostic: (d: PlotDiagnostic) => {
+        diagnostics.push(d);
+      },
+    });
+    await expect
+      .poll(() => diagnostics.some((d) => d.code === "INTERACTION_DUPLICATE_INSPECT_CAPABILITY"))
+      .toBe(true);
+  });
+
+  it("oninspect with child-only inspect does not emit HANDLER_WITHOUT_CAPABILITY", async () => {
+    const diagnostics: PlotDiagnostic[] = [];
+    render(InspectChildPlot, {
+      useInspect: true,
+      oninspect: () => {},
+      ondiagnostic: (d: PlotDiagnostic) => {
+        diagnostics.push(d);
+      },
+    });
+    flushSync();
+    // Wiring effect runs after children register (ADR 0001 order).
+    await new Promise((r) => setTimeout(r, 50));
+    expect(diagnostics.some((d) => d.code === "INTERACTION_HANDLER_WITHOUT_CAPABILITY")).toBe(
+      false,
+    );
+  });
+});

--- a/packages/svelte/tests/inspection/inspect-child.test.ts
+++ b/packages/svelte/tests/inspection/inspect-child.test.ts
@@ -92,7 +92,9 @@ describe("<Inspect> capability child", () => {
     flushSync();
     // Wiring effect runs after children register (ADR 0001 order).
     await new Promise<void>((resolve) => {
-      setTimeout(() => resolve(), 50);
+      setTimeout(() => {
+        resolve();
+      }, 50);
     });
     expect(diagnostics.some((d) => d.code === "INTERACTION_HANDLER_WITHOUT_CAPABILITY")).toBe(
       false,


### PR DESCRIPTION
## Summary

Adds declaration-only `<Inspect>` for host inspect policy (tooltip, crosshair, pin). Registers on the capability map from #1238; not part of PortableSpec.

```svelte
<GGPlot data={rows} aes={{ x: "x", y: "y" }}>
  <Inspect mode="xy" />
  <GeomPoint />
</GGPlot>
```

Mark eligibility remains `inspect={false}` opt-out on geoms.

## Stack

1. #1238 — registry + resolve + engine
2. **This PR** — component + export + tests
3. #1240 — skill docs + changeset

## Test plan

- [x] `bun run test:browser -- tests/inspection/inspect-child.test.ts`
- [x] `bun run check`
- [ ] CI green