### PR TITLE
test(svelte): run pure wiring/composition/inspect prop tests in browser

### DIFF
--- a/packages/svelte/tests/diagnostics/composition-collect.test.ts
+++ b/packages/svelte/tests/diagnostics/composition-collect.test.ts
@@ -1,7 +1,8 @@
 /**
  * Pure composition-diagnostic collection (extracted from plot assembly).
- * Node lane — no browser/GGPlot. Expected values are independent of
- * implementation structure (codes, channels, emit order).
+ * Browser lane: CI coverage is browser-only (SSR vitest does not collect).
+ * Expected values are independent of implementation structure (codes,
+ * channels, emit order).
  */
 import { describe, expect, it } from "vitest";
 

--- a/packages/svelte/tests/interaction/wiring-advisories.test.ts
+++ b/packages/svelte/tests/interaction/wiring-advisories.test.ts
@@ -1,6 +1,6 @@
 /**
  * Pure wiring-advisory collection (extracted from plot assembly).
- * Node lane — no browser/GGPlot.
+ * Browser lane: CI coverage is browser-only (SSR vitest does not collect).
  */
 import { describe, expect, it } from "vitest";
 

--- a/packages/svelte/tests/layers/layer-inspect-prop.test.ts
+++ b/packages/svelte/tests/layers/layer-inspect-prop.test.ts
@@ -4,6 +4,8 @@
  * The core opt-out is worthless to a component author if the prop stops at the
  * registry: the getting-started lesson is written in components, and the
  * portable spec it teaches has to carry the same intent as the JSON.
+ *
+ * Browser lane: CI coverage is browser-only (SSR vitest does not collect).
  */
 import { describe, expect, it } from "vitest";
 


### PR DESCRIPTION
## Summary

- Move pure unit suites for wiring advisories, composition diagnostics, and geom `inspect={false}` → `toLayerInput` from `*.ssr.test.ts` into the browser lane.
- CI coverage collects only under chromium browser vitest; SSR vitest does not feed the gate, so these collectors stayed under-counted despite existing tests.

## Coverage (browser, focused remeasure)

| File | After focused suite |
|------|---------------------|
| `wiring-advisories.ts` | **100%** stmts |
| `composition.ts` | **~95%** stmts |
| `toLayerInput` inspect path | exercised via browser lane |

## Test plan

- [x] `vitest run --project chromium tests/interaction/wiring-advisories.test.ts tests/diagnostics/composition-collect.test.ts tests/layers/layer-inspect-prop.test.ts`
- [x] `oxlint --type-aware --deny-warnings` on the three files
- [ ] CI component-svelte + build green
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1242" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->