### PR TITLE
feat(svelte): move legend filter opt-in to GuideLegend.filter

### DIFF
--- a/.changeset/guide-legend-filter.md
+++ b/.changeset/guide-legend-filter.md
@@ -1,0 +1,38 @@
+---
+"@ggsvelte/svelte": minor
+---
+
+<!-- markdownlint-disable MD041 -->
+
+feat(svelte): move legend filter opt-in to `<GuideLegend filter>`
+
+Legend filter is now a host-only prop on `<GuideLegend channel="…" filter />`
+(boolean or `{ mode?, multiple? }`), not a PortableSpec / guideLegend field.
+Only channels with an active filter child get Show-group checkboxes
+(merged legends match via `aesthetics[]`).
+
+`<GGPlot legendFilter>` still works plot-wide until 0.20.0 and emits
+`DEPRECATED_PLOT_PROP` with migration guidance.
+
+Migration: <https://ggsvelte.sh/guide/upgrading#legend-filter-on-guidelegend>
+
+Replace:
+
+```svelte
+<GGPlot legendFilter key="id" …>
+  <GeomPoint />
+</GGPlot>
+```
+
+with:
+
+```svelte
+<GGPlot key="id" …>
+  <GuideLegend channel="color" filter />
+  <GeomPoint />
+</GGPlot>
+```
+
+Use the aesthetic that owns the discrete legend (`color`, `fill`, `shape`, …).
+Focus and filter can share one GuideLegend:
+`<GuideLegend channel="color" focus filter />`.

--- a/apps/docs/src/lib/generated/routes.ts
+++ b/apps/docs/src/lib/generated/routes.ts
@@ -12063,6 +12063,11 @@ export const DOCS_ROUTES = [
         level: 3,
       },
       {
+        id: "legend-filter-on-guidelegend",
+        title: "Legend filter on GuideLegend",
+        level: 3,
+      },
+      {
         id: "0-11-to-0-12",
         title: "0.11 to 0.12",
         level: 2,

--- a/apps/docs/src/lib/generated/search-index.ts
+++ b/apps/docs/src/lib/generated/search-index.ts
@@ -19932,6 +19932,16 @@ export const DOCS_SEARCH_INDEX = [
     exact: ["Legend focus on GuideLegend"],
   },
   {
+    id: "heading:guide-upgrading:legend-filter-on-guidelegend",
+    kind: "heading",
+    title: "Legend filter on GuideLegend",
+    summary:
+      "Legend filter on GuideLegend in Upgrade guide. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
+    href: "/guide/upgrading#legend-filter-on-guidelegend",
+    keywords: ["Upgrade guide", "Release"],
+    exact: ["Legend filter on GuideLegend"],
+  },
+  {
     id: "heading:guide-upgrading:0-11-to-0-12",
     kind: "heading",
     title: "0.11 to 0.12",

--- a/apps/docs/src/routes/__perf/r3-interaction/+page.svelte
+++ b/apps/docs/src/routes/__perf/r3-interaction/+page.svelte
@@ -1,5 +1,11 @@
 <script lang="ts">
-  import { createPlotInteraction, Facet, GGPlot, Labs } from "@ggsvelte/svelte";
+  import {
+    createPlotInteraction,
+    Facet,
+    GGPlot,
+    GuideLegend,
+    Labs,
+  } from "@ggsvelte/svelte";
 
   const FILTER_ROWS = 20_000;
   const FACET_ROWS = 12_000;
@@ -75,11 +81,11 @@
       aes={{ ...mapping, color: "group" }}
       layers={[{ geom: "point", render: "canvas", params: { size: 1 } }]}
       key="id"
-      legendFilter
       width={900}
       height={420}
       onrender={() => (filterPipelineCommits += 1)}
     >
+      <GuideLegend channel="color" filter />
       <Labs title="R3 legend filter pipeline" color="Group" />
     </GGPlot>
   </section>

--- a/apps/docs/src/routes/reference/guides/+page.svelte
+++ b/apps/docs/src/routes/reference/guides/+page.svelte
@@ -108,13 +108,16 @@ guides({ color: guideLegend({ position: "bottom" }) })
     <a href={`${base}/reference/guides/none`}><code>GuideNone</code></a>.
   </p>
 
-  <h2 id="legend-focus">Legend focus and clear recovery</h2>
+  <h2 id="legend-focus">Legend focus, filter, and clear recovery</h2>
   <p>
     Discrete color and fill legends can host interaction controls when
-    <code>legendFocus</code> or <code>legendFilter</code> is enabled on the
-    plot. Focus is presentation emphasis only; Clear legend focus restores the
-    unfocused view without changing data. Authoring the guide itself is separate
-    — see
+    <code>&lt;GuideLegend focus /&gt;</code> or
+    <code>&lt;GuideLegend filter /&gt;</code> is enabled for that aesthetic
+    (deprecated plot props <code>legendFocus</code> /
+    <code>legendFilter</code> still work plot-wide until 0.20). Focus is
+    presentation emphasis only; Clear legend focus restores the unfocused view
+    without changing data. Filter changes included rows. Authoring the guide
+    itself is separate — see
     <a href={`${base}/reference/guides/legend`}><code>GuideLegend</code></a>,
     the
     <a href={`${base}/guide/interaction-reference#legendfocus`}

--- a/apps/docs/src/routes/reference/guides/[name]/+page.svelte
+++ b/apps/docs/src/routes/reference/guides/[name]/+page.svelte
@@ -196,12 +196,14 @@
   {/if}
 
   {#if entry.name === "legend"}
-    <h2 id="legend-focus">Legend focus</h2>
+    <h2 id="legend-focus">Legend focus and filter</h2>
     <p>
-      When the plot enables <code>legendFocus</code>, discrete color and fill
-      legends host HTML controls for preview and commit. Clear legend focus
-      removes presentation emphasis only — it does not reset
-      <code>legendFilter</code> or data. See the
+      Opt in per aesthetic with <code>focus</code> and/or
+      <code>filter</code> on this component (for example
+      <code>&lt;GuideLegend channel="color" focus filter /&gt;</code>). Discrete
+      color and fill legends host HTML controls for preview/commit focus and
+      Show-group filter checkboxes. Clear legend focus removes presentation
+      emphasis only — it does not reset filter clauses or data. See the
       <a href={`${base}/guide/interaction-reference#legendfocus`}
         >interaction reference</a
       >

--- a/apps/docs/static/previews/provenance.json
+++ b/apps/docs/static/previews/provenance.json
@@ -178,7 +178,7 @@
     },
     "interaction/legend-filter": {
       "filename": "interaction-legend-filter-light.png",
-      "sourceSha256": "7a2b35c33f1ceb0cef0349540e2d6733c2ea7d9f4b154a03e61a4e2cc0a1e652",
+      "sourceSha256": "1fc0b565fe63776cc397a21df2510b7905a1ec301ba594e7a5ccce7321fd0fe6",
       "pngSha256": "83529278279ca7c4bffa4d47d2c57a57ebd8a1de13f3fc798b4971bfb4698853"
     },
     "interaction/legend-focus": {

--- a/examples/interaction/legend-filter/Example.svelte
+++ b/examples/interaction/legend-filter/Example.svelte
@@ -3,6 +3,7 @@
     GeomLine,
     GeomPoint,
     GGPlot,
+    GuideLegend,
     Labs,
     ScaleXContinuous,
     ThemeFivethirtyeight,
@@ -21,7 +22,6 @@
     data={britishFinances}
     aes={{ x: "year", y: "value", color: "series" }}
     key="id"
-    legendFilter
     width="container"
     height={430}
     onlegendfilter={(event) => {
@@ -40,13 +40,14 @@
       y="Playfair's index units"
       color="Series"
     />
+    <GuideLegend channel="color" filter />
     <GeomLine linewidth={2.2} />
     <GeomPoint size={3.2} />
   </GGPlot>
   <p class="note gg-demo-chrome">
     <strong>Why this is filtering:</strong> statistics, facets, and domains see
     only the visible rows. For visual comparison without changing data, use
-    <code>legendFocus</code> instead.
+    <code>&lt;GuideLegend focus /&gt;</code> instead.
   </p>
 </div>
 

--- a/packages/svelte/skills/ggsvelte/SKILL.md
+++ b/packages/svelte/skills/ggsvelte/SKILL.md
@@ -114,9 +114,10 @@ direct props (`size={3}`); structural props are `data`, `stat`, `position`,
 
 `<GGPlot>` props: `spec`, `data`, `aes`, `layers`, `key`, `width`
 (number | "container"), `height`, `a11y`, `ariaLabel`, the interaction props
-(`inspect`, `select`, `zoom`, `legendFilter`, `tool`, `interaction`,
-`interactionScope`; `legendFocus` is deprecated — use
-`<GuideLegend channel focus>`), the `on*` handlers, and `children`.
+(`inspect`, `select`, `zoom`, `tool`, `interaction`,
+`interactionScope`; `legendFocus` / `legendFilter` are deprecated — use
+`<GuideLegend channel focus>` / `<GuideLegend channel filter>`), the `on*`
+handlers, and `children`.
 Instance methods: `resetScales()`, `setZoom()`.
 
 Precedence: `spec` wins over everything else. For mark layers, an explicit
@@ -275,14 +276,15 @@ per-layer aes override, sf/map — each as validated JSON plus a Svelte twin:
 
 ## Interactions (host props, not PortableSpec fields)
 
-Opt-in host capabilities: `inspect` / `select` / `zoom` / `legendFilter` on
-`<GGPlot>`; legend emphasis via `<GuideLegend channel="color" focus />`
-(per aesthetic; host-only, not in `guideLegend()` / PortableSpec). Always give
-a stable `key` when selection or linked views must survive filtering or
-refreshes. Link plots by sharing one `createPlotInteraction()` controller and
-matching `interactionScope` channels; observe everything through
-`oninteraction` or per-capability handlers. Faceted interval presets, the
-controller API, `Tooltip`, handler payloads, and diagnostics:
+Opt-in host capabilities: `inspect` / `select` / `zoom` on `<GGPlot>`; legend
+emphasis and data-changing filter via
+`<GuideLegend channel="color" focus />` / `filter` (per aesthetic; host-only,
+not in `guideLegend()` / PortableSpec). Always give a stable `key` when
+selection or linked views must survive filtering or refreshes. Link plots by
+sharing one `createPlotInteraction()` controller and matching
+`interactionScope` channels; observe everything through `oninteraction` or
+per-capability handlers. Faceted interval presets, the controller API,
+`Tooltip`, handler payloads, and diagnostics:
 [references/interactions.md](references/interactions.md) — read it before
 writing any interactive or linked-view code.
 

--- a/packages/svelte/skills/ggsvelte/references/interactions.md
+++ b/packages/svelte/skills/ggsvelte/references/interactions.md
@@ -15,16 +15,17 @@ coordinated intervals must survive filtering, reordering, or data refreshes.
 | `select`       | `false \| "point" \| "interval" \| SelectOptions`      | Point or interval selection. Options: `type` (`"point" \| "interval"`), `mode` (`"x" \| "y" \| "xy"`, interval only), `multiple`, `persistent`, `preset` (faceted intervals, below).                                                                                                                                                                                                       |
 | `zoom`         | `boolean \| ZoomOptions`                               | Brush zoom. Options: `mode` (`"x" \| "y" \| "xy"`), `trigger` (`"brush"`). Currently requires one unfaceted panel.                                                                                                                                                                                                                                                                         |
 | `focus`        | `boolean \| { preview?: boolean }` on `<GuideLegend>`  | Discrete legend preview, focus, and linked emphasis **for that aesthetic channel**. Emphasis only — never changes included rows. Discrete legends only; continuous ramps stay static. Mute de-emphasizes non-focused marks; dashed rings appear only on sparse point marks (≤48 anchors), never on paths/areas/bars/segments/text. Host-only — not a PortableSpec / `guideLegend()` field. |
-| `legendFilter` | `boolean \| LegendFilterOptions` on `<GGPlot>`         | Data-changing filtering through discrete legend controls: changes the included rows and reruns the grammar while preserving stable color identity. Options: `mode` (`"exclude" \| "include"`), `multiple`.                                                                                                                                                                                 |
+| `filter`       | `boolean \| LegendFilterOptions` on `<GuideLegend>`    | Data-changing filtering through discrete legend controls **for that aesthetic channel**: changes the included rows and reruns the grammar while preserving stable color identity. Options: `mode` (`"exclude" \| "include"`), `multiple`. Host-only — not a PortableSpec / `guideLegend()` field.                                                                                          |
 | `key`          | column name or `(row, index) => PropertyKey`           | Stable semantic identity for public interaction payloads. Required for durable point selection, coordinated interval presets, and legend focus/filter. Duplicate or unstable keys are diagnostic errors.                                                                                                                                                                                   |
 | `tool`         | `"inspect" \| "point" \| "select-area" \| "zoom-area"` | Controlled initial/active tool; observe changes with `ontoolchange`.                                                                                                                                                                                                                                                                                                                       |
 | `ariaLabel`    | `string`                                               | Accessible chart name; falls back to the plot title or a generated label.                                                                                                                                                                                                                                                                                                                  |
 | `a11y`         | `A11yMode`                                             | `"force-svg"` keeps every layer as SVG marks.                                                                                                                                                                                                                                                                                                                                              |
 
-### Deprecated: `legendFocus` on `<GGPlot>`
+### Deprecated: `legendFocus` / `legendFilter` on `<GGPlot>`
 
-Since 0.19.0, prefer `<GuideLegend channel="color" focus />`. The plot prop
-still enables focus plot-wide until 0.20.0 and emits `DEPRECATED_PLOT_PROP`.
+Since 0.19.0, prefer `<GuideLegend channel="color" focus />` and
+`<GuideLegend channel="color" filter />`. The plot props still enable each
+capability plot-wide until 0.20.0 and emit `DEPRECATED_PLOT_PROP`.
 
 After an interval or zoom commit, accessible controls accept exact bounds.
 
@@ -127,12 +128,11 @@ entry has `severity`, `code`, `message`, `prop`, `suggestions`, `docUrl`):
   aes={{ x: "date", y: "value", color: "series" }}
   key="id"
   select={{ type: "interval", mode: "x", preset: "cross-panel" }}
-  legendFilter
   {interaction}
   interactionScope={scope}
   oninteraction={(event) => console.log(event.type, event)}
 >
-  <GuideLegend channel="color" focus />
+  <GuideLegend channel="color" focus filter />
   <Facet wrap="region" ncol={3} />
   <GeomPoint />
 </GGPlot>

--- a/packages/svelte/src/lib/guides/GuideLegend.svelte
+++ b/packages/svelte/src/lib/guides/GuideLegend.svelte
@@ -4,12 +4,13 @@
    * (#659 slice 6). Presentation of one aesthetic's legend: title, position,
    * direction, key size, collision, and the INTEGER placement rank `order`.
    *
-   * Host interaction: `focus` opts this channel into discrete legend
-   * preview/pin emphasis. It is NOT a PortableSpec field — stripped before
-   * guideLegend() and registered as host layer kind `legendFocus`.
-   * Focus-only children (no presentation options) do not force a guides
-   * entry, so continuous colour scales keep their colorbar without a
-   * guide-aesthetic-incompatible pipeline error.
+   * Host interaction: `focus` and `filter` opt this channel into discrete
+   * legend emphasis / data-changing checkboxes. They are NOT PortableSpec
+   * fields — stripped before guideLegend() and registered as host layer
+   * kinds `legendFocus` / `legendFilter`. Focus- or filter-only children
+   * (no presentation options) do not force a guides entry, so continuous
+   * colour scales keep their colorbar without a guide-aesthetic-incompatible
+   * pipeline error.
    *
    * Not to be confused with <Legend order="sorted"/>, which is the plot-wide
    * entry-SORT enum (LegendSpec). Same word, unrelated concepts.
@@ -18,6 +19,11 @@
   import { guideLegend, type LegendGuideOptions } from "@ggsvelte/spec";
 
   import type { LegendFocusInput } from "../interaction/interaction.js";
+  import type { LegendFilterInput } from "../legend/filter.js";
+  import {
+    isLegendFilterPropEnabled,
+    type LegendFilterLayerValue,
+  } from "../legend/resolve-legend-filter.js";
   import {
     isLegendFocusPropEnabled,
     type LegendFocusLayerValue,
@@ -38,18 +44,24 @@
      * emphasis. Host-only — never appears in PortableSpec.
      */
     focus?: LegendFocusInput;
+    /**
+     * Opt this channel into data-changing filtering through discrete legend
+     * checkboxes. Host-only — never appears in PortableSpec.
+     */
+    filter?: LegendFilterInput;
   };
 
   const props: Props = $props();
 
   createPlotLayer("guides", () => {
     const defined = definedProps(props) as Props;
-    const { focus: _focus, ...withoutFocus } = defined;
-    const { channel, options } = splitChannel(withoutFocus);
-    // Focus-only: do not force type:"legend" (breaks continuous ramps).
+    const { focus: _focus, filter: _filter, ...withoutHost } = defined;
+    const { channel, options } = splitChannel(withoutHost);
+    // Focus/filter-only: do not force type:"legend" (breaks continuous ramps).
     if (
       Object.keys(options).length === 0 &&
-      isLegendFocusPropEnabled(defined.focus)
+      (isLegendFocusPropEnabled(defined.focus) ||
+        isLegendFilterPropEnabled(defined.filter))
     ) {
       return {};
     }
@@ -63,6 +75,16 @@
     return {
       channel: defined.channel,
       input: focus === true ? true : focus,
+    };
+  });
+
+  createPlotLayer("legendFilter", (): LegendFilterLayerValue => {
+    const defined = definedProps(props) as Props;
+    const filter = defined.filter;
+    if (!isLegendFilterPropEnabled(filter)) return null;
+    return {
+      channel: defined.channel,
+      input: filter === true ? true : filter,
     };
   });
 </script>

--- a/packages/svelte/src/lib/layers/fold.ts
+++ b/packages/svelte/src/lib/layers/fold.ts
@@ -47,7 +47,7 @@ export function foldPlotLayer(draft: AssembleDraft, layer: PlotLayerLike): Assem
     return draft;
   }
   // Host-only interaction contributions never fold into PortableSpec.
-  if (layer.kind === "legendFocus") {
+  if (layer.kind === "legendFocus" || layer.kind === "legendFilter") {
     return draft;
   }
   // Index via string map so unforeseen runtime kinds are undefined (not a

--- a/packages/svelte/src/lib/layers/types.ts
+++ b/packages/svelte/src/lib/layers/types.ts
@@ -20,6 +20,7 @@ import type {
   ThemeSpec,
 } from "@ggsvelte/spec";
 
+import type { LegendFilterLayerValue } from "../legend/resolve-legend-filter.js";
 import type { LegendFocusLayerValue } from "../legend/resolve-legend-focus.js";
 
 /**
@@ -64,10 +65,12 @@ export type Layer =
   | { readonly kind: "guides"; get value(): GuidesSpec }
   | { readonly kind: "legend"; get value(): LegendSpec }
   /** Host-only interaction contribution from `<GuideLegend focus>` — not PortableSpec. */
-  | { readonly kind: "legendFocus"; get value(): LegendFocusLayerValue };
+  | { readonly kind: "legendFocus"; get value(): LegendFocusLayerValue }
+  /** Host-only interaction contribution from `<GuideLegend filter>` — not PortableSpec. */
+  | { readonly kind: "legendFilter"; get value(): LegendFilterLayerValue };
 
 /** Non-mark grammar layer kinds (the seven #659 families). Host-only kinds excluded. */
-export type GrammarLayerKind = Exclude<Layer["kind"], "mark" | "legendFocus">;
+export type GrammarLayerKind = Exclude<Layer["kind"], "mark" | "legendFocus" | "legendFilter">;
 
 /**
  * Structural form accepted by fold/assemble: `value` may be a live getter or a
@@ -82,9 +85,10 @@ export type PlotLayerLike =
   | { readonly kind: "labs"; readonly value: Labs }
   | { readonly kind: "guides"; readonly value: GuidesSpec }
   | { readonly kind: "legend"; readonly value: LegendSpec }
-  | { readonly kind: "legendFocus"; readonly value: LegendFocusLayerValue };
+  | { readonly kind: "legendFocus"; readonly value: LegendFocusLayerValue }
+  | { readonly kind: "legendFilter"; readonly value: LegendFilterLayerValue };
 
 /** True for host-only registry kinds that assemble/fold must ignore. */
 export function isHostPlotLayer(layer: { readonly kind: string }): boolean {
-  return layer.kind === "legendFocus";
+  return layer.kind === "legendFocus" || layer.kind === "legendFilter";
 }

--- a/packages/svelte/src/lib/legend/resolve-legend-filter.ts
+++ b/packages/svelte/src/lib/legend/resolve-legend-filter.ts
@@ -1,0 +1,152 @@
+/**
+ * Resolve legend-filter capability from host-only GuideLegend `filter` layers
+ * and the deprecated plot-level `legendFilter` prop.
+ *
+ * Interactions stay off PortableSpec: `filter` is stripped before guideLegend()
+ * and travels as registry layer kind `legendFilter`.
+ */
+import type { LegendFilterInput } from "./filter.js";
+
+/** Aesthetic channel a GuideLegend may enable for filter (non-position). */
+type LegendFilterChannel = "color" | "fill" | "size" | "linewidth" | "alpha" | "shape" | "linetype";
+
+/** One GuideLegend's host-only filter contribution (null when filter is off). */
+export type LegendFilterLayerValue = {
+  readonly channel: LegendFilterChannel;
+  readonly input: Exclude<LegendFilterInput, false>;
+} | null;
+
+export type LegendFilterChannelSet = ReadonlySet<string> | "all";
+
+export type ResolvedLegendFilterCapability = {
+  /**
+   * Requested opt-in for wiring advisories (truthy when any child or plot
+   * prop enables filter).
+   */
+  readonly requested: LegendFilterInput | false;
+  /** Value fed to createLegendFilterState / capability resolve. */
+  readonly configInput: LegendFilterInput | false;
+  /**
+   * `"all"` = deprecated plot prop only (every discrete filterable legend).
+   * Otherwise only legends whose aesthetics intersect this set get checkboxes.
+   */
+  readonly channels: LegendFilterChannelSet;
+};
+
+/** Minimal entry shape for channel filtering (avoids importing .svelte.ts). */
+type FilterableEntryLike = {
+  readonly legend: {
+    readonly scale: string;
+    readonly aesthetics?: readonly string[];
+  };
+};
+
+type LegendFilterLayerLike = {
+  readonly kind: string;
+  /** Live getter or plain field — only read when kind is legendFilter. */
+  readonly value?: unknown;
+};
+
+function isEnabledInput(
+  input: LegendFilterInput | undefined,
+): input is Exclude<LegendFilterInput, false> {
+  return input !== undefined && input !== false;
+}
+
+function readChildLayers(
+  layers: readonly LegendFilterLayerLike[],
+): ReadonlyArray<{ channel: string; input: Exclude<LegendFilterInput, false> }> {
+  const out: Array<{ channel: string; input: Exclude<LegendFilterInput, false> }> = [];
+  for (const layer of layers) {
+    if (layer.kind !== "legendFilter") continue;
+    // Layer values may be live getters (registry) — read via property access.
+    const value = (layer as { value: LegendFilterLayerValue }).value;
+    if (value === null || value === undefined) continue;
+    if (!isEnabledInput(value.input)) continue;
+    out.push({ channel: value.channel, input: value.input });
+  }
+  return out;
+}
+
+/**
+ * Merge mode/multiple from plot prop + children. Last explicit field wins
+ * (plot first, then children in registry order).
+ */
+function resolveConfigInput(
+  plotProp: LegendFilterInput | undefined,
+  children: ReadonlyArray<{ input: Exclude<LegendFilterInput, false> }>,
+): Exclude<LegendFilterInput, false> {
+  let mode: "exclude" | "include" | undefined;
+  let multiple: boolean | undefined;
+
+  const consider = (input: Exclude<LegendFilterInput, false>): void => {
+    if (input === true) return;
+    if (input.mode !== undefined) mode = input.mode;
+    if (input.multiple !== undefined) multiple = input.multiple;
+  };
+
+  if (isEnabledInput(plotProp)) consider(plotProp);
+  for (const child of children) consider(child.input);
+
+  if (mode === undefined && multiple === undefined) return true;
+  return {
+    ...(mode !== undefined ? { mode } : {}),
+    ...(multiple !== undefined ? { multiple } : {}),
+  };
+}
+
+/**
+ * Combine deprecated plot prop + GuideLegend filter children into one capability.
+ * Children define per-channel enablement when present; plot prop alone is `"all"`.
+ */
+export function resolveLegendFilterCapability(input: {
+  readonly plotProp: LegendFilterInput | undefined;
+  readonly layers: readonly LegendFilterLayerLike[];
+}): ResolvedLegendFilterCapability {
+  const children = readChildLayers(input.layers);
+  const plotOn = isEnabledInput(input.plotProp);
+
+  if (children.length === 0 && !plotOn) {
+    return { requested: false, configInput: false, channels: new Set() };
+  }
+
+  const configInput = resolveConfigInput(input.plotProp, children);
+
+  if (children.length > 0) {
+    return {
+      requested: configInput,
+      configInput,
+      channels: new Set(children.map((child) => child.channel)),
+    };
+  }
+
+  return {
+    requested: input.plotProp ?? false,
+    configInput: input.plotProp ?? false,
+    channels: "all",
+  };
+}
+
+/**
+ * Keep filterable targets whose scene legend aesthetics intersect the
+ * enabled channel set. Merged legends expose all aesthetics on
+ * `legend.aesthetics` (primary `scale` alone is not enough).
+ */
+export function filterFilterableLegendEntries<T extends FilterableEntryLike>(
+  entries: readonly T[],
+  channels: LegendFilterChannelSet,
+): T[] {
+  if (channels === "all") return entries.slice();
+  if (channels.size === 0) return [];
+  return entries.filter((entry) => {
+    const aesthetics = entry.legend.aesthetics ?? [entry.legend.scale];
+    return aesthetics.some((aesthetic) => channels.has(aesthetic));
+  });
+}
+
+/** True when `filter` is an active opt-in (boolean true or options object). */
+export function isLegendFilterPropEnabled(
+  filter: LegendFilterInput | undefined,
+): filter is Exclude<LegendFilterInput, false> {
+  return isEnabledInput(filter);
+}

--- a/packages/svelte/src/lib/legend/resolve-legend-filter.ts
+++ b/packages/svelte/src/lib/legend/resolve-legend-filter.ts
@@ -90,8 +90,8 @@ function resolveConfigInput(
 
   if (mode === undefined && multiple === undefined) return true;
   return {
-    ...(mode !== undefined ? { mode } : {}),
-    ...(multiple !== undefined ? { multiple } : {}),
+    ...(mode === undefined ? {} : { mode }),
+    ...(multiple === undefined ? {} : { multiple }),
   };
 }
 

--- a/packages/svelte/src/lib/plot-engine.svelte.ts
+++ b/packages/svelte/src/lib/plot-engine.svelte.ts
@@ -83,6 +83,11 @@ import type { InteractiveLegendEntry, LegendEntryIdentity } from "./legend/focus
 import { createLegendFocusState } from "./legend/focus-state.svelte.js";
 import type { LegendFocusState } from "./legend/focus-state.svelte.js";
 import {
+  filterFilterableLegendEntries,
+  resolveLegendFilterCapability,
+  type ResolvedLegendFilterCapability,
+} from "./legend/resolve-legend-filter.js";
+import {
   filterInteractiveLegendEntries,
   resolveLegendFocusCapability,
   type ResolvedLegendFocusCapability,
@@ -92,6 +97,7 @@ import type { PlotChromeState } from "./chrome/chrome-state.svelte.js";
 import { isHostPlotLayer } from "./layers/types.js";
 import { deprecatedPropDiagnostic } from "./diagnostics/deprecation.js";
 import {
+  readLegacyPlotLegendFilter,
   readLegacyPlotLegendFocus,
   resolveCapabilities,
   type EnginePlotProps,
@@ -283,19 +289,33 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
   const legendFocusResolved = (): ResolvedLegendFocusCapability =>
     typeof window === "undefined" ? resolveLegendFocusNow() : legendFocusResolvedDerived;
 
+  /**
+   * Legend filter from `<GuideLegend filter>` (and deprecated plot prop).
+   * Same SSR recompute path as focus — empty registry on first SSR pass.
+   */
+  function resolveLegendFilterNow(): ResolvedLegendFilterCapability {
+    return resolveLegendFilterCapability({
+      plotProp: readLegacyPlotLegendFilter(host.props),
+      layers: host.registry.layers,
+    });
+  }
+  const legendFilterResolvedDerived = $derived.by(resolveLegendFilterNow);
+  const legendFilterResolved = (): ResolvedLegendFilterCapability =>
+    typeof window === "undefined" ? resolveLegendFilterNow() : legendFilterResolvedDerived;
+
   // Capability defaults for wiring — inspect from prop + <Inspect> children;
-  // legendFocus "requested" from GuideLegend / legacy prop (not host.props.legendFocus
-  // direct — that prop is deprecated and type-aware lint denies it).
+  // legendFocus/legendFilter "requested" from GuideLegend / legacy prop
+  // (not host.props.legendFocus/legendFilter direct — type-aware lint denies
+  // deprecated dual-read outside the isolated readers).
   const caps = (): ResolvedPlotCapabilities => {
     const select = host.props.select;
     const zoom = host.props.zoom;
-    const legendFilter = host.props.legendFilter;
     return resolveCapabilities({
       inspect: inspectResolved().input,
       legendFocus: legendFocusResolved().requested,
+      legendFilter: legendFilterResolved().requested,
       ...(select !== undefined && { select }),
       ...(zoom !== undefined && { zoom }),
-      ...(legendFilter !== undefined && { legendFilter }),
     });
   };
 
@@ -362,7 +382,9 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
         select: capabilities.select,
         zoom: capabilities.zoom,
         legendFocus: legendFocusResolved().requested,
-        legendFilter: capabilities.legendFilter,
+        // legendFilter "requested" is GuideLegend/child (or deprecated prop)
+        // opt-in — not resolveCapabilities(plot prop alone).
+        legendFilter: legendFilterResolved().requested,
       },
     });
   });
@@ -406,6 +428,26 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
         "focus={{ preview: false }} on GuideLegend replaces legendFocus={{ preview: false }}",
       ],
       anchor: "legend-focus-on-guidelegend",
+    });
+    const dedupKey = `${diagnostic.code}:${diagnostic.prop}`;
+    if (deliveredAdvisories.has(dedupKey)) return;
+    deliveredAdvisories.add(dedupKey);
+    deliverDiagnostic(diagnostic);
+  });
+
+  // Deprecated plot-level legendFilter → GuideLegend.filter (one minor window).
+  $effect(() => {
+    const plotProp = readLegacyPlotLegendFilter(host.props);
+    if (plotProp === undefined || plotProp === false) return;
+    const diagnostic = deprecatedPropDiagnostic({
+      prop: "legendFilter",
+      since: "0.19.0",
+      removeIn: "0.20.0",
+      suggestions: [
+        'Use <GuideLegend channel="color" filter /> (or the aesthetic that owns the discrete legend)',
+        'filter={{ mode: "include", multiple: false }} on GuideLegend replaces legendFilter={{ … }}',
+      ],
+      anchor: "legend-filter-on-guidelegend",
     });
     const dedupKey = `${diagnostic.code}:${diagnostic.prop}`;
     if (deliveredAdvisories.has(dedupKey)) return;
@@ -498,8 +540,8 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
   // model is deferred (declared after the runtime).
   const legendFilterState = createLegendFilterState({
     effectiveSpec: () => zoomState.effectiveSpec,
-    // Single-field default — avoid caps() so this derived only tracks legendFilter.
-    legendFilterProp: () => host.props.legendFilter ?? false,
+    // GuideLegend children (or deprecated plot prop) — not plot prop alone.
+    legendFilterProp: () => legendFilterResolved().configInput,
     onlegendfilter: () => host.props.onlegendfilter,
     oninteraction: () => host.props.oninteraction,
     announce: announceSink,
@@ -740,7 +782,14 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
   const legendClearActive = $derived(legendFocusEnabled && effectiveLegendPressed !== null);
 
   // Host-side derived for catalog reconcile (closes over runtime.model).
-  const filterableLegendEntries = $derived(legendFilterState.computeEntries(runtime.model));
+  // Channel filter: only aesthetics with GuideLegend filter (merged legends
+  // match via aesthetics[], not primary scale alone).
+  const filterableLegendEntries = $derived(
+    filterFilterableLegendEntries(
+      legendFilterState.computeEntries(runtime.model),
+      legendFilterResolved().channels,
+    ),
+  );
 
   function hoverGlyphExtents(): {
     readonly width: number;

--- a/packages/svelte/src/lib/plot-props.ts
+++ b/packages/svelte/src/lib/plot-props.ts
@@ -81,7 +81,11 @@ export interface GGPlotProps<
    * Migration: https://ggsvelte.sh/guide/upgrading#legend-focus-on-guidelegend
    */
   legendFocus?: LegendFocusInput;
-  /** Opt into data-changing filtering through discrete legend controls. */
+  /**
+   * @deprecated since 0.19.0 — use `<GuideLegend channel="…" filter />` instead.
+   * Still honoured (plot-wide enablement) until 0.20.0; emits DEPRECATED_PLOT_PROP.
+   * Migration: https://ggsvelte.sh/guide/upgrading#legend-filter-on-guidelegend
+   */
   legendFilter?: LegendFilterInput;
   /** Controlled initial/active tool. */
   tool?: InteractionTool;
@@ -120,8 +124,9 @@ export type ResolvedPlotCapabilities = {
  * and reference-equality consumers).
  *
  * Input is a plain bag (not `Pick<GGPlotProps, …>`) so dual-read of the
- * deprecated `legendFocus` prop does not trip `typescript/no-deprecated`
- * at every resolveCapabilities call site during the 0.19→0.20 window.
+ * deprecated `legendFocus` / `legendFilter` props does not trip
+ * `typescript/no-deprecated` at every resolveCapabilities call site during
+ * the 0.19→0.20 window.
  */
 export function resolveCapabilities(props: {
   readonly inspect?: InspectInput;
@@ -149,6 +154,18 @@ export function readLegacyPlotLegendFocus(
   // Dual-read until 0.20.0 — prefer <GuideLegend focus>.
   // oxlint-disable-next-line typescript/no-deprecated -- intentional dual-read
   return props.legendFocus;
+}
+
+/**
+ * Read the deprecated plot-level `legendFilter` prop during the dual-read
+ * window. Isolate the deprecation access so call sites stay clean.
+ */
+export function readLegacyPlotLegendFilter(
+  props: EnginePlotProps | GGPlotProps,
+): LegendFilterInput | undefined {
+  // Dual-read until 0.20.0 — prefer <GuideLegend filter>.
+  // oxlint-disable-next-line typescript/no-deprecated -- intentional dual-read
+  return props.legendFilter;
 }
 
 /**

--- a/packages/svelte/tests/fixtures/LegendFilterPlot.svelte
+++ b/packages/svelte/tests/fixtures/LegendFilterPlot.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-  import { GGPlot, type LegendFilterEvent } from "../../src/lib/index.js";
+  import {
+    GGPlot,
+    GuideLegend,
+    type LegendFilterEvent,
+  } from "../../src/lib/index.js";
 
   const {
     backend = "svg",
@@ -35,7 +39,6 @@
     data={rows}
     aes={{ x: "x", y: "y", color: "group" }}
     layers={[{ geom: "point", render: backend }]}
-    legendFilter={{ mode, multiple }}
     width={360}
     height={260}
     ariaLabel="Legend filter plot"
@@ -55,5 +58,7 @@
           ? legend.entries.map((entry) => entry.color).join(",")
           : "";
     }}
-  />
+  >
+    <GuideLegend channel="color" filter={{ mode, multiple }} />
+  </GGPlot>
 </div>

--- a/packages/svelte/tests/fixtures/LegendFocusAndFilterPlot.svelte
+++ b/packages/svelte/tests/fixtures/LegendFocusAndFilterPlot.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import { GGPlot, GuideLegend } from "../../src/lib/index.js";
+
+  const rows = [
+    { id: "a", x: 1, y: 1, group: "north" },
+    { id: "b", x: 2, y: 2, group: "south" },
+  ];
+</script>
+
+<GGPlot
+  data={rows}
+  aes={{ x: "x", y: "y", color: "group" }}
+  layers={[{ geom: "point" }]}
+  key="id"
+  width={360}
+  height={260}
+>
+  <GuideLegend channel="color" focus filter />
+</GGPlot>

--- a/packages/svelte/tests/layers/grammar-prop-removal.ssr.test.ts
+++ b/packages/svelte/tests/layers/grammar-prop-removal.ssr.test.ts
@@ -29,16 +29,17 @@ describe("#704 grammar prop removal", () => {
   it("engine no longer emits DEPRECATED_PLOT_PROP for grammar props", () => {
     const source = readFileSync(join(root, "plot-engine.svelte.ts"), "utf8");
     // Grammar-prop emit path removed with the props (#704). Catalog types and
-    // a single dual-read path for the separate legendFocus migration may still
-    // call deprecatedPropDiagnostic — that is not a grammar-prop regression.
+    // dual-read paths for legendFocus/legendFilter migrations may still call
+    // deprecatedPropDiagnostic — that is not a grammar-prop regression.
     expect(source).not.toContain("deprecationDiagnostics");
     for (const prop of GRAMMAR_PROP_NAMES) {
       expect(source, `grammar prop ${prop} still wired for deprecation emit`).not.toMatch(
         new RegExp(`prop:\\s*["']${prop}["']`),
       );
     }
-    // legendFocus dual-read (0.19→0.20) is the only remaining emit site.
+    // legendFocus / legendFilter dual-read (0.19→0.20) emit sites.
     expect(source).toContain('prop: "legendFocus"');
+    expect(source).toContain('prop: "legendFilter"');
   });
 
   it("LayerDescriptor alias is removed (use MarkLayerDescriptor)", () => {

--- a/packages/svelte/tests/legend/filter-state.test.ts
+++ b/packages/svelte/tests/legend/filter-state.test.ts
@@ -468,20 +468,10 @@ describe("runtime + legend-filter real cycle", () => {
 });
 
 describe("LegendFilters component layout and pointer source", () => {
-  it("combined legend-focus clear + filters reserves both rows", async () => {
-    const view = render(GGPlot, {
-      data: [
-        { id: "a", x: 1, y: 1, group: "north" },
-        { id: "b", x: 2, y: 2, group: "south" },
-      ],
-      aes: { x: "x", y: "y", color: "group" },
-      layers: [{ geom: "point" as const }],
-      key: "id",
-      legendFilter: true,
-      legendFocus: true,
-      width: 360,
-      height: 260,
-    });
+  it("combined GuideLegend focus + filter reserves both rows", async () => {
+    const { default: LegendFocusAndFilterPlot } =
+      await import("../fixtures/LegendFocusAndFilterPlot.svelte");
+    const view = render(LegendFocusAndFilterPlot);
     await until(() => view.container.querySelectorAll(".gg-legend-filters input").length === 2);
     await until(() => view.container.querySelector(".gg-legend-target") !== null);
 

--- a/packages/svelte/tests/legend/resolve-legend-filter.test.ts
+++ b/packages/svelte/tests/legend/resolve-legend-filter.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  filterFilterableLegendEntries,
+  isLegendFilterPropEnabled,
+  resolveLegendFilterCapability,
+} from "../../src/lib/legend/resolve-legend-filter.js";
+
+describe("resolveLegendFilterCapability", () => {
+  it("is off when neither plot prop nor children request filter", () => {
+    expect(
+      resolveLegendFilterCapability({
+        plotProp: undefined,
+        layers: [],
+      }),
+    ).toEqual({
+      requested: false,
+      configInput: false,
+      channels: new Set(),
+    });
+  });
+
+  it("uses plot prop alone as all-channel enablement", () => {
+    const resolved = resolveLegendFilterCapability({
+      plotProp: true,
+      layers: [],
+    });
+    expect(resolved.requested).toBe(true);
+    expect(resolved.configInput).toBe(true);
+    expect(resolved.channels).toBe("all");
+  });
+
+  it("collects channels from GuideLegend filter layers", () => {
+    const resolved = resolveLegendFilterCapability({
+      plotProp: undefined,
+      layers: [
+        { kind: "guides", value: { color: { type: "legend" } } },
+        {
+          kind: "legendFilter",
+          value: { channel: "color", input: true },
+        },
+        {
+          kind: "legendFilter",
+          value: { channel: "fill", input: { mode: "include", multiple: false } },
+        },
+        { kind: "legendFilter", value: null },
+      ],
+    });
+    expect(resolved.requested).toEqual({ mode: "include", multiple: false });
+    expect(resolved.configInput).toEqual({ mode: "include", multiple: false });
+    expect(resolved.channels).toEqual(new Set(["color", "fill"]));
+  });
+
+  it("prefers child channels when both prop and children are set", () => {
+    const resolved = resolveLegendFilterCapability({
+      plotProp: true,
+      layers: [{ kind: "legendFilter", value: { channel: "fill", input: true } }],
+    });
+    expect(resolved.channels).toEqual(new Set(["fill"]));
+    expect(resolved.configInput).toBe(true);
+  });
+
+  it("merges mode and multiple from plot prop and children (last wins)", () => {
+    const resolved = resolveLegendFilterCapability({
+      plotProp: { mode: "exclude", multiple: true },
+      layers: [
+        {
+          kind: "legendFilter",
+          value: { channel: "color", input: { mode: "include", multiple: false } },
+        },
+      ],
+    });
+    expect(resolved.configInput).toEqual({ mode: "include", multiple: false });
+    expect(resolved.channels).toEqual(new Set(["color"]));
+  });
+
+  it("keeps plot options when children only pass boolean true", () => {
+    const resolved = resolveLegendFilterCapability({
+      plotProp: { mode: "include", multiple: false },
+      layers: [{ kind: "legendFilter", value: { channel: "color", input: true } }],
+    });
+    expect(resolved.configInput).toEqual({ mode: "include", multiple: false });
+  });
+});
+
+describe("filterFilterableLegendEntries", () => {
+  const colorLegend = {
+    type: "discrete" as const,
+    scale: "color" as const,
+    title: "Color",
+    x: 0,
+    y: 0,
+    width: 1,
+    height: 1,
+    entries: [],
+    swatchSize: 8,
+  };
+  const shapeOnMerged = {
+    type: "discrete" as const,
+    scale: "color" as const,
+    aesthetics: ["color", "shape"] as const,
+    title: "Merged",
+    x: 0,
+    y: 0,
+    width: 1,
+    height: 1,
+    entries: [],
+    swatchSize: 8,
+  };
+
+  const entries = [
+    {
+      legend: colorLegend,
+      entry: { label: "a", value: "a", y: 0 },
+      field: "series",
+      visible: true,
+    },
+    {
+      legend: shapeOnMerged,
+      entry: { label: "b", value: "b", y: 0 },
+      field: "series",
+      visible: true,
+    },
+  ];
+
+  it("keeps every entry when channels is all", () => {
+    expect(filterFilterableLegendEntries(entries, "all")).toHaveLength(2);
+  });
+
+  it("matches merged legends via aesthetics, not only primary scale", () => {
+    const filtered = filterFilterableLegendEntries(entries, new Set(["shape"]));
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0]?.legend.title).toBe("Merged");
+  });
+
+  it("drops entries when the channel set is empty", () => {
+    expect(filterFilterableLegendEntries(entries, new Set())).toEqual([]);
+  });
+});
+
+describe("isLegendFilterPropEnabled", () => {
+  it("treats true and options objects as enabled", () => {
+    expect(isLegendFilterPropEnabled(true)).toBe(true);
+    expect(isLegendFilterPropEnabled({ mode: "include" })).toBe(true);
+    expect(isLegendFilterPropEnabled(false)).toBe(false);
+  });
+});

--- a/packages/svelte/tests/migrations/legend-filter-after.svelte
+++ b/packages/svelte/tests/migrations/legend-filter-after.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  import { GeomPoint, GGPlot, GuideLegend } from "../../src/lib/index.js";
+
+  const rows = [
+    { id: "a", x: 1, y: 2, series: "North" },
+    { id: "b", x: 2, y: 3, series: "South" },
+  ];
+</script>
+
+<!-- After 0.19: filter lives on GuideLegend for that aesthetic. -->
+<GGPlot data={rows} aes={{ x: "x", y: "y", color: "series" }} key="id">
+  <GuideLegend channel="color" filter />
+  <GeomPoint />
+</GGPlot>

--- a/packages/svelte/tests/migrations/legend-filter-before.svelte
+++ b/packages/svelte/tests/migrations/legend-filter-before.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import { GeomPoint, GGPlot } from "../../src/lib/index.js";
+
+  const rows = [
+    { id: "a", x: 1, y: 2, series: "North" },
+    { id: "b", x: 2, y: 3, series: "South" },
+  ];
+</script>
+
+<!-- Before 0.19: legendFilter was a plot-host prop. -->
+<GGPlot
+  data={rows}
+  aes={{ x: "x", y: "y", color: "series" }}
+  key="id"
+  legendFilter
+>
+  <GeomPoint />
+</GGPlot>

--- a/packages/svelte/tests/plot-engine.lifecycle.test.ts
+++ b/packages/svelte/tests/plot-engine.lifecycle.test.ts
@@ -230,9 +230,10 @@ describe("createPlotEngine construction-order contract (#1082)", () => {
     inspect: true,
     select: "point" as const,
     zoom: true,
-    // Dual-read fixture for deprecated plot prop (removed 0.20.0).
+    // Dual-read fixture for deprecated plot props (removed 0.20.0).
     /* oxlint-disable-next-line typescript/no-deprecated -- intentional dual-read */
     legendFocus: true,
+    /* oxlint-disable-next-line typescript/no-deprecated -- intentional dual-read */
     legendFilter: true,
   } as EnginePlotProps;
 

--- a/scripts/llms-guide-content.ts
+++ b/scripts/llms-guide-content.ts
@@ -1283,9 +1283,9 @@ timestamp helpers, exact-format parser, and epoch helpers return authoring Dates
 
 export const INTERACTIONS_MD = `# Interactions
 
-Static by default. Opt in with \`inspect\`, \`select\`, \`zoom\`, GuideLegend
-\`focus\` (or deprecated \`legendFocus\`),
-\`legendFilter\`. With more than one draw tool, an accessible tool rail keeps
+Static by default. Opt in with \`inspect\`, \`select\`, \`zoom\`, and GuideLegend
+\`focus\` / \`filter\` (or deprecated plot props \`legendFocus\` /
+\`legendFilter\`). With more than one draw tool, an accessible tool rail keeps
 gestures from competing.
 
 Without a controller, state is private to one chart and callbacks report
@@ -1455,18 +1455,19 @@ colors. Author discrete legend appearance with
 
 ## Legend filtering
 
-\`legendFocus\` is presentation emphasis only — it does not change data.
-\`legendFilter={true}\` adds Show-group checkboxes on discrete color/fill
-legends and filters rows before facets, stats, scales, layout, and render.
-Hidden groups stay in the legend catalog and keep the same categorical color
-when shown again.
+GuideLegend \`focus\` is presentation emphasis only — it does not change data.
+\`<GuideLegend channel="color" filter />\` adds Show-group checkboxes on that
+aesthetic's discrete legend and filters rows before facets, stats, scales,
+layout, and render. Hidden groups stay in the legend catalog and keep the same
+categorical color when shown again.
 
-Use \`legendFilter={{ mode: "exclude", multiple: true }}\` for the default
-independent checkboxes. \`mode: "include"\` stores the shown values instead;
-\`multiple: false\` makes a toggle isolate one group. \`onlegendfilter\` reports
-the raw typed values and field in a \`LegendFilterClause\`. Reset legend filters
+Use \`filter={{ mode: "exclude", multiple: true }}\` for the default independent
+checkboxes. \`mode: "include"\` stores the shown values instead; \`multiple:
+false\` makes a toggle isolate one group. \`onlegendfilter\` reports the raw
+typed values and field in a \`LegendFilterClause\`. Reset legend filters
 restores the data pipeline; Clear legend focus only removes presentation
-emphasis. See the [stable-color example](/examples/interaction/legend-filter).
+emphasis. The plot prop \`legendFilter\` is deprecated since 0.19.0. See the
+[stable-color example](/examples/interaction/legend-filter).
 
 ## Brush zoom
 
@@ -1643,12 +1644,17 @@ The plot prop \`legendFocus={true}\` is deprecated since 0.19.0 (removed in
 
 ### \`legendFilter\`
 
-\`legendFilter={true}\` adds native Show-group checkboxes to discrete color and
-fill legends. It changes the rows supplied to facets, statistics, scales, and
-rendering while preserving the full legend catalog and categorical color
-identity. Configure \`mode: "exclude" | "include"\` and \`multiple\`; receive
-typed clauses through \`onlegendfilter\`. It is independent of
-presentation-only GuideLegend \`focus\`.
+Prefer \`<GuideLegend channel="color" filter />\` (boolean or
+\`{ mode?: "exclude" | "include", multiple?: boolean }\`) for data-changing
+checkboxes on that aesthetic's discrete legend. Host-only — never a
+PortableSpec / \`guideLegend()\` field. It changes the rows supplied to facets,
+statistics, scales, and rendering while preserving the full legend catalog and
+categorical color identity. Receive typed clauses through \`onlegendfilter\`.
+Independent of presentation-only GuideLegend \`focus\`.
+
+The plot prop \`legendFilter={true}\` is deprecated since 0.19.0 (removed in
+0.20.0) and still enables filter plot-wide during the dual-read window — see
+[Legend filter on GuideLegend](/guide/upgrading#legend-filter-on-guidelegend).
 
 ## Controlled tool
 
@@ -1837,7 +1843,14 @@ export const INTERACTION_REFERENCE_INDEX: readonly InteractionReferenceEntry[] =
     name: "Legend filtering",
     summary: "Include or exclude groups before stats/scales; color identity stable.",
     href: "/guide/interaction-reference#legendfilter",
-    keywords: ["legendFilter", "onlegendfilter", "filter", "checkbox", "stable color"],
+    keywords: [
+      "legendFilter",
+      "filter",
+      "GuideLegend",
+      "onlegendfilter",
+      "checkbox",
+      "stable color",
+    ],
   },
   {
     id: "controlled-tool",
@@ -1956,6 +1969,61 @@ guide child that owns the aesthetic:
 - \`<GGPlot legendFocus>\` still works plot-wide through 0.19.x and emits
   \`DEPRECATED_PLOT_PROP\`; it is removed in 0.20.0.
 - Handlers stay plot-level: \`onlegendfocus\`, \`oninteraction\`, and \`key\`.
+
+### Legend filter on GuideLegend
+
+Discrete legend filter is no longer a plot-host capability prop. Opt in on the
+guide child that owns the aesthetic:
+
+\`\`\`svelte fragment
+<script lang="ts">
+  import { GeomPoint, GGPlot } from "@ggsvelte/svelte";
+
+  const rows = [
+    { id: "a", x: 1, y: 2, series: "North" },
+    { id: "b", x: 2, y: 3, series: "South" },
+  ];
+</script>
+
+<!-- Before 0.19: legendFilter was a plot-host prop. -->
+<GGPlot
+  data={rows}
+  aes={{ x: "x", y: "y", color: "series" }}
+  key="id"
+  legendFilter
+>
+  <GeomPoint />
+</GGPlot>
+\`\`\`
+
+\`\`\`svelte fragment
+<script lang="ts">
+  import { GeomPoint, GGPlot, GuideLegend } from "@ggsvelte/svelte";
+
+  const rows = [
+    { id: "a", x: 1, y: 2, series: "North" },
+    { id: "b", x: 2, y: 3, series: "South" },
+  ];
+</script>
+
+<!-- After 0.19: filter lives on GuideLegend for that aesthetic. -->
+<GGPlot data={rows} aes={{ x: "x", y: "y", color: "series" }} key="id">
+  <GuideLegend channel="color" filter />
+  <GeomPoint />
+</GGPlot>
+\`\`\`
+
+- \`filter\` accepts \`true\` or \`{ mode?, multiple? }\` (same shape as the old
+  plot prop). It is host-only — not a PortableSpec / \`guideLegend()\` field.
+- Only channels with an active \`<GuideLegend filter>\` get filter checkboxes.
+  Enable multiple aesthetics with multiple GuideLegend children.
+- A filter-only GuideLegend (no presentation options) does not force
+  \`type: "legend"\`, so continuous colour scales keep their colorbar.
+- \`<GGPlot legendFilter>\` still works plot-wide through 0.19.x and emits
+  \`DEPRECATED_PLOT_PROP\`; it is removed in 0.20.0.
+- Handlers stay plot-level: \`onlegendfilter\`, \`oninteraction\`, and \`key\`.
+- Focus and filter coexist on one GuideLegend:
+  \`<GuideLegend channel="color" focus filter />\`.
 
 ## 0.11 to 0.12
 

--- a/skills/ggsvelte/SKILL.md
+++ b/skills/ggsvelte/SKILL.md
@@ -114,9 +114,10 @@ direct props (`size={3}`); structural props are `data`, `stat`, `position`,
 
 `<GGPlot>` props: `spec`, `data`, `aes`, `layers`, `key`, `width`
 (number | "container"), `height`, `a11y`, `ariaLabel`, the interaction props
-(`inspect`, `select`, `zoom`, `legendFilter`, `tool`, `interaction`,
-`interactionScope`; `legendFocus` is deprecated — use
-`<GuideLegend channel focus>`), the `on*` handlers, and `children`.
+(`inspect`, `select`, `zoom`, `tool`, `interaction`,
+`interactionScope`; `legendFocus` / `legendFilter` are deprecated — use
+`<GuideLegend channel focus>` / `<GuideLegend channel filter>`), the `on*`
+handlers, and `children`.
 Instance methods: `resetScales()`, `setZoom()`.
 
 Precedence: `spec` wins over everything else. For mark layers, an explicit
@@ -275,14 +276,15 @@ per-layer aes override, sf/map — each as validated JSON plus a Svelte twin:
 
 ## Interactions (host props, not PortableSpec fields)
 
-Opt-in host capabilities: `inspect` / `select` / `zoom` / `legendFilter` on
-`<GGPlot>`; legend emphasis via `<GuideLegend channel="color" focus />`
-(per aesthetic; host-only, not in `guideLegend()` / PortableSpec). Always give
-a stable `key` when selection or linked views must survive filtering or
-refreshes. Link plots by sharing one `createPlotInteraction()` controller and
-matching `interactionScope` channels; observe everything through
-`oninteraction` or per-capability handlers. Faceted interval presets, the
-controller API, `Tooltip`, handler payloads, and diagnostics:
+Opt-in host capabilities: `inspect` / `select` / `zoom` on `<GGPlot>`; legend
+emphasis and data-changing filter via
+`<GuideLegend channel="color" focus />` / `filter` (per aesthetic; host-only,
+not in `guideLegend()` / PortableSpec). Always give a stable `key` when
+selection or linked views must survive filtering or refreshes. Link plots by
+sharing one `createPlotInteraction()` controller and matching
+`interactionScope` channels; observe everything through `oninteraction` or
+per-capability handlers. Faceted interval presets, the controller API,
+`Tooltip`, handler payloads, and diagnostics:
 [references/interactions.md](references/interactions.md) — read it before
 writing any interactive or linked-view code.
 

--- a/skills/ggsvelte/references/interactions.md
+++ b/skills/ggsvelte/references/interactions.md
@@ -15,16 +15,17 @@ coordinated intervals must survive filtering, reordering, or data refreshes.
 | `select`       | `false \| "point" \| "interval" \| SelectOptions`      | Point or interval selection. Options: `type` (`"point" \| "interval"`), `mode` (`"x" \| "y" \| "xy"`, interval only), `multiple`, `persistent`, `preset` (faceted intervals, below).                                                                                                                                                                                                       |
 | `zoom`         | `boolean \| ZoomOptions`                               | Brush zoom. Options: `mode` (`"x" \| "y" \| "xy"`), `trigger` (`"brush"`). Currently requires one unfaceted panel.                                                                                                                                                                                                                                                                         |
 | `focus`        | `boolean \| { preview?: boolean }` on `<GuideLegend>`  | Discrete legend preview, focus, and linked emphasis **for that aesthetic channel**. Emphasis only — never changes included rows. Discrete legends only; continuous ramps stay static. Mute de-emphasizes non-focused marks; dashed rings appear only on sparse point marks (≤48 anchors), never on paths/areas/bars/segments/text. Host-only — not a PortableSpec / `guideLegend()` field. |
-| `legendFilter` | `boolean \| LegendFilterOptions` on `<GGPlot>`         | Data-changing filtering through discrete legend controls: changes the included rows and reruns the grammar while preserving stable color identity. Options: `mode` (`"exclude" \| "include"`), `multiple`.                                                                                                                                                                                 |
+| `filter`       | `boolean \| LegendFilterOptions` on `<GuideLegend>`    | Data-changing filtering through discrete legend controls **for that aesthetic channel**: changes the included rows and reruns the grammar while preserving stable color identity. Options: `mode` (`"exclude" \| "include"`), `multiple`. Host-only — not a PortableSpec / `guideLegend()` field.                                                                                          |
 | `key`          | column name or `(row, index) => PropertyKey`           | Stable semantic identity for public interaction payloads. Required for durable point selection, coordinated interval presets, and legend focus/filter. Duplicate or unstable keys are diagnostic errors.                                                                                                                                                                                   |
 | `tool`         | `"inspect" \| "point" \| "select-area" \| "zoom-area"` | Controlled initial/active tool; observe changes with `ontoolchange`.                                                                                                                                                                                                                                                                                                                       |
 | `ariaLabel`    | `string`                                               | Accessible chart name; falls back to the plot title or a generated label.                                                                                                                                                                                                                                                                                                                  |
 | `a11y`         | `A11yMode`                                             | `"force-svg"` keeps every layer as SVG marks.                                                                                                                                                                                                                                                                                                                                              |
 
-### Deprecated: `legendFocus` on `<GGPlot>`
+### Deprecated: `legendFocus` / `legendFilter` on `<GGPlot>`
 
-Since 0.19.0, prefer `<GuideLegend channel="color" focus />`. The plot prop
-still enables focus plot-wide until 0.20.0 and emits `DEPRECATED_PLOT_PROP`.
+Since 0.19.0, prefer `<GuideLegend channel="color" focus />` and
+`<GuideLegend channel="color" filter />`. The plot props still enable each
+capability plot-wide until 0.20.0 and emit `DEPRECATED_PLOT_PROP`.
 
 After an interval or zoom commit, accessible controls accept exact bounds.
 
@@ -127,12 +128,11 @@ entry has `severity`, `code`, `message`, `prop`, `suggestions`, `docUrl`):
   aes={{ x: "date", y: "value", color: "series" }}
   key="id"
   select={{ type: "interval", mode: "x", preset: "cross-panel" }}
-  legendFilter
   {interaction}
   interactionScope={scope}
   oninteraction={(event) => console.log(event.type, event)}
 >
-  <GuideLegend channel="color" focus />
+  <GuideLegend channel="color" focus filter />
   <Facet wrap="region" ncol={3} />
   <GeomPoint />
 </GGPlot>


### PR DESCRIPTION
## Summary

- Move `legendFilter` opt-in from `<GGPlot>` to host-only `<GuideLegend channel filter />` (boolean or `{ mode?, multiple? }`), matching the #1236 focus migration.
- Engine dual-reads deprecated plot prop until 0.20.0; scopes checkboxes by channel (merged legends via `aesthetics[]`); SSR empty-registry recompute path mirrors focus.
- Skills, interactions reference, upgrade guide, example, and migration fixtures updated. Closes #1235.

## Test plan

- [x] `resolve-legend-filter` unit tests (capability resolve + channel filter + prop enabled)
- [x] filter-state / filter-component browser tests (GuideLegend path + dual-read deprecation path)
- [x] GuideLegend focus+filter co-existence layout test
- [x] grammar-prop-removal allows legendFilter dual-read emit
- [x] docs routes/search regen + gallery provenance restamp
- [ ] CI green on PR
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1244" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->