### PR TITLE
test(svelte): cover layerDataRef wrapping via toLayerInput

### DIFF
--- a/packages/svelte/tests/assembly/assemble.test.ts
+++ b/packages/svelte/tests/assembly/assemble.test.ts
@@ -84,25 +84,26 @@ describe("toLayerInput", () => {
     const multi = { values: [{ x: 1 }], y: [2] };
     expect(toLayerInput({ geom: "point", data: multi }).data).toEqual({ columns: multi });
     // Single-key but wrong value types → not a DataRef; wrap as columns.
-    const nameNotString = { name: 12 };
-    expect(toLayerInput({ geom: "point", data: nameNotString as never }).data).toEqual({
+    // Intentionally wrong shapes use fromAny (CONTRIBUTING fixture rule).
+    const nameNotString = fromAny({ name: 12 });
+    expect(toLayerInput({ geom: "point", data: nameNotString }).data).toEqual({
       columns: nameNotString,
     });
-    const valuesNotArray = { values: { x: 1 } };
-    expect(toLayerInput({ geom: "point", data: valuesNotArray as never }).data).toEqual({
+    const valuesNotArray = fromAny({ values: { x: 1 } });
+    expect(toLayerInput({ geom: "point", data: valuesNotArray }).data).toEqual({
       columns: valuesNotArray,
     });
     const columnsIsArray = { columns: [1, 2] };
     expect(toLayerInput({ geom: "point", data: columnsIsArray }).data).toEqual({
       columns: columnsIsArray,
     });
-    const columnsNull = { columns: null };
-    expect(toLayerInput({ geom: "point", data: columnsNull as never }).data).toEqual({
+    const columnsNull = fromAny({ columns: null });
+    expect(toLayerInput({ geom: "point", data: columnsNull }).data).toEqual({
       columns: columnsNull,
     });
     // Unknown single key is not a DataRef.
-    const other = { rows: [{ x: 1 }] };
-    expect(toLayerInput({ geom: "point", data: other as never }).data).toEqual({ columns: other });
+    const other = fromAny({ rows: [{ x: 1 }] });
+    expect(toLayerInput({ geom: "point", data: other }).data).toEqual({ columns: other });
   });
 });
 

--- a/packages/svelte/tests/assembly/assemble.test.ts
+++ b/packages/svelte/tests/assembly/assemble.test.ts
@@ -55,6 +55,55 @@ describe("toLayerInput", () => {
       params: { method: "lm" },
     });
   });
+
+  /**
+   * layerDataRef / isWrappedDataRef: geom `data` props must round-trip as
+   * DataRef shapes without double-wrapping already-valid bags.
+   */
+  it("wraps row arrays as { values } and bare column maps as { columns }", () => {
+    const rows = [
+      { x: 1, y: 2 },
+      { x: 3, y: 4 },
+    ];
+    expect(toLayerInput({ geom: "point", data: rows }).data).toEqual({ values: rows });
+    const columns = { x: [1, 3], y: [2, 4] };
+    expect(toLayerInput({ geom: "point", data: columns }).data).toEqual({ columns });
+  });
+
+  it("passes through single-key DataRef bags without double wrapping", () => {
+    const valuesBag = { values: [{ x: 1 }] };
+    expect(toLayerInput({ geom: "point", data: valuesBag }).data).toBe(valuesBag);
+    const columnsBag = { columns: { x: [1], y: [2] } };
+    expect(toLayerInput({ geom: "point", data: columnsBag }).data).toBe(columnsBag);
+    const nameBag = { name: "mpg" };
+    expect(toLayerInput({ geom: "point", data: nameBag }).data).toBe(nameBag);
+  });
+
+  it("does not treat multi-key or malformed single-key objects as DataRefs", () => {
+    // Multi-key object is a bare column map (or mixed) — wrap as columns.
+    const multi = { values: [{ x: 1 }], y: [2] };
+    expect(toLayerInput({ geom: "point", data: multi }).data).toEqual({ columns: multi });
+    // Single-key but wrong value types → not a DataRef; wrap as columns.
+    const nameNotString = { name: 12 };
+    expect(toLayerInput({ geom: "point", data: nameNotString as never }).data).toEqual({
+      columns: nameNotString,
+    });
+    const valuesNotArray = { values: { x: 1 } };
+    expect(toLayerInput({ geom: "point", data: valuesNotArray as never }).data).toEqual({
+      columns: valuesNotArray,
+    });
+    const columnsIsArray = { columns: [1, 2] };
+    expect(toLayerInput({ geom: "point", data: columnsIsArray as never }).data).toEqual({
+      columns: columnsIsArray,
+    });
+    const columnsNull = { columns: null };
+    expect(toLayerInput({ geom: "point", data: columnsNull as never }).data).toEqual({
+      columns: columnsNull,
+    });
+    // Unknown single key is not a DataRef.
+    const other = { rows: [{ x: 1 }] };
+    expect(toLayerInput({ geom: "point", data: other as never }).data).toEqual({ columns: other });
+  });
 });
 
 describe("assemblePortableSpec", () => {

--- a/packages/svelte/tests/assembly/assemble.test.ts
+++ b/packages/svelte/tests/assembly/assemble.test.ts
@@ -93,7 +93,7 @@ describe("toLayerInput", () => {
       columns: valuesNotArray,
     });
     const columnsIsArray = { columns: [1, 2] };
-    expect(toLayerInput({ geom: "point", data: columnsIsArray as never }).data).toEqual({
+    expect(toLayerInput({ geom: "point", data: columnsIsArray }).data).toEqual({
       columns: columnsIsArray,
     });
     const columnsNull = { columns: null };


### PR DESCRIPTION
## Summary

- Add browser unit cases for `toLayerInput` data wrapping so private `layerDataRef` / `isWrappedDataRef` paths are exercised: row arrays → `{ values }`, bare column maps → `{ columns }`, pass-through of valid single-key DataRefs, and no false-positive wrap for multi-key / malformed single-key objects.

## Coverage (browser)

| File | Before (full suite) | After (focused) |
|------|---------------------|-----------------|
| `assemble.ts` | ~71% stmts | **~91.5%** stmts |

## Test plan

- [x] `vitest run --project chromium tests/assembly/assemble.test.ts`
- [x] `oxlint --type-aware --deny-warnings` on the test file
- [ ] CI component-svelte + build green
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1245" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->