### PR TITLE
test(svelte): cover per-layer data snapshot and mask union

### DIFF
--- a/packages/svelte/tests/assembly/assemble.test.ts
+++ b/packages/svelte/tests/assembly/assemble.test.ts
@@ -105,6 +105,13 @@ describe("toLayerInput", () => {
     const other = fromAny({ rows: [{ x: 1 }] });
     expect(toLayerInput({ geom: "point", data: other }).data).toEqual({ columns: other });
   });
+
+  it("falls back to empty values for non-array non-object data", () => {
+    // Runtime guard when a geom data prop is neither rows nor a column bag.
+    expect(toLayerInput({ geom: "point", data: fromAny(null) }).data).toEqual({ values: [] });
+    expect(toLayerInput({ geom: "point", data: fromAny(42) }).data).toEqual({ values: [] });
+    expect(toLayerInput({ geom: "point", data: fromAny("rows") }).data).toEqual({ values: [] });
+  });
 });
 
 describe("assemblePortableSpec", () => {
@@ -326,6 +333,44 @@ describe("assemblePortableSpec", () => {
     expect(row).toBeDefined();
     expect(typeof row.t).toBe("string");
     expect(row.t).toContain("2020-01-15");
+  });
+
+  it("snapshots per-layer data so later mutation does not leak into the layer", () => {
+    const layerRows = [
+      { x: 1, y: 2 },
+      { x: 3, y: 4 },
+    ];
+    const assembled = assemblePortableSpec({
+      aes: { x: "x", y: "y" },
+      layers: [{ geom: "point", data: layerRows }],
+    });
+    expect(assembled).not.toBeNull();
+    const first = layerRows[0];
+    expect(first).toBeDefined();
+    first.x = 99;
+    expect(assembled!.layers[0]?.data).toEqual({
+      values: [
+        { x: 1, y: 2 },
+        { x: 3, y: 4 },
+      ],
+    });
+    // Plot-level data stays absent when only layer data is supplied.
+    expect(assembled!.data).toBeUndefined();
+  });
+
+  it("materializes Date cells in per-layer data to portable ISO strings", () => {
+    const day = new Date("2020-06-01T00:00:00.000Z");
+    const assembled = assemblePortableSpec({
+      aes: { x: "t", y: "y" },
+      layers: [{ geom: "point", data: [{ t: day, y: 7 }] }],
+    });
+    expect(assembled).not.toBeNull();
+    const layerData = assembled!.layers[0]?.data as { values: { t: string; y: number }[] };
+    const row = layerData.values[0];
+    expect(row).toBeDefined();
+    expect(typeof row.t).toBe("string");
+    expect(row.t).toContain("2020-06-01");
+    expect(row.y).toBe(7);
   });
 });
 

--- a/packages/svelte/tests/runtime/semantic-candidate-projection.test.ts
+++ b/packages/svelte/tests/runtime/semantic-candidate-projection.test.ts
@@ -211,6 +211,130 @@ describe("createSemanticCandidateProjection", () => {
     destroy();
   });
 
+  it("unions key-based masks with rect inspection seed primitives", () => {
+    // When legend emphasis matches real candidates AND inspection seeds a
+    // different rect, both stay focused (OR merge of the two mask sources).
+    const colModel = modelFor(
+      gg(
+        [
+          { category: "A", count: 10 },
+          { category: "B", count: 20 },
+          { category: "C", count: 15 },
+        ],
+        aes({ x: "category", y: "count" }),
+      )
+        .geomCol()
+        .spec(),
+    );
+    const byRow = (rowIndex: number) => {
+      for (let id = 0; id < colModel.candidates.size; id++) {
+        const candidate = colModel.candidates.candidate(id);
+        if (candidate?.rowIndex === rowIndex) return candidate;
+      }
+      throw new Error(`missing col candidate for row ${String(rowIndex)}`);
+    };
+    const first = byRow(0);
+    const second = byRow(1);
+    const keysForCol = (candidate: CandidateFacts): PropertyKey[] =>
+      candidate.rowIndex === null ? [] : [String(candidate.rowIndex)];
+    const { value, destroy } = withFlushedEffectRoot(() =>
+      createSemanticCandidateProjection({
+        model: () => colModel,
+        candidateSemanticKeys: keysForCol,
+        selectedKeys: () => [],
+        intervalKeys: () => [],
+        intervals: () => [],
+        // Emphasis key matches row 0; inspection seeds row 1's primitive.
+        emphasisKeys: () => ["0"],
+        muteSiblingsOnInspect: () => true,
+        inspectionFocus: () => ({
+          sourceKeys: [],
+          key: null,
+          kind: second.kind,
+          primitives: [
+            {
+              batchIndex: second.batchIndex,
+              primitiveIndex: second.primitiveIndex,
+            },
+          ],
+        }),
+      }),
+    );
+
+    expect(first.kind).toBe("rects");
+    const mask = value.interactionMasks.find((entry) => entry !== null);
+    expect(mask).toBeDefined();
+    expect(mask?.isFocused(first.primitiveIndex)).toBe(true);
+    expect(mask?.isFocused(second.primitiveIndex)).toBe(true);
+    expect(mask?.focusedCount).toBeGreaterThanOrEqual(2);
+    destroy();
+  });
+
+  it("keeps key masks for batches that rect inspection does not touch", () => {
+    // Dual-geom scene: emphasis keys land on points; rect seed is only on cols.
+    // unionInteractionMasks must preserve the key-only batch (b === null path).
+    const dualModel = modelFor(
+      gg(
+        [
+          { category: "A", count: 10, y2: 1 },
+          { category: "B", count: 20, y2: 2 },
+          { category: "C", count: 15, y2: 3 },
+        ],
+        aes({ x: "category", y: "count" }),
+      )
+        .geomCol()
+        .geomPoint({ aes: { y: "y2" } })
+        .spec(),
+    );
+    const rectCandidate = (() => {
+      for (let id = 0; id < dualModel.candidates.size; id++) {
+        const candidate = dualModel.candidates.candidate(id);
+        if (candidate?.kind === "rects" && candidate.rowIndex === 0) return candidate;
+      }
+      throw new Error("missing rect candidate");
+    })();
+    const pointCandidate = (() => {
+      for (let id = 0; id < dualModel.candidates.size; id++) {
+        const candidate = dualModel.candidates.candidate(id);
+        if (candidate?.kind === "points" && candidate.rowIndex === 1) return candidate;
+      }
+      throw new Error("missing point candidate");
+    })();
+    const keysForDual = (candidate: CandidateFacts): PropertyKey[] => {
+      if (candidate.kind === "points" && candidate.rowIndex === 1) return ["point-1"];
+      return [];
+    };
+    const { value, destroy } = withFlushedEffectRoot(() =>
+      createSemanticCandidateProjection({
+        model: () => dualModel,
+        candidateSemanticKeys: keysForDual,
+        selectedKeys: () => [],
+        intervalKeys: () => [],
+        intervals: () => [],
+        emphasisKeys: () => ["point-1"],
+        muteSiblingsOnInspect: () => true,
+        inspectionFocus: () => ({
+          sourceKeys: [],
+          key: null,
+          kind: rectCandidate.kind,
+          primitives: [
+            {
+              batchIndex: rectCandidate.batchIndex,
+              primitiveIndex: rectCandidate.primitiveIndex,
+            },
+          ],
+        }),
+      }),
+    );
+
+    expect(pointCandidate.batchIndex).not.toBe(rectCandidate.batchIndex);
+    const pointMask = value.interactionMasks[pointCandidate.batchIndex];
+    const rectMask = value.interactionMasks[rectCandidate.batchIndex];
+    expect(pointMask?.isFocused(pointCandidate.primitiveIndex)).toBe(true);
+    expect(rectMask?.isFocused(rectCandidate.primitiveIndex)).toBe(true);
+    destroy();
+  });
+
   it("serves anchors and masks from one semantic Candidate walk", () => {
     let keyCalls = 0;
     const first = candidateForRow(0);


### PR DESCRIPTION
## Summary

- `assemblePortableSpec`: per-layer data is snapshotted (caller mutation does not leak) and Date cells materialize to portable ISO strings; `toLayerInput` falls back to `{ values: [] }` for non-array non-object data.
- `createSemanticCandidateProjection`: key-based masks OR with rect inspection seed primitives; dual-geom scenes keep key masks on batches that inspection does not touch.

## Coverage (browser, focused)

| File | Before | After |
|------|--------|-------|
| `assemble.ts` | ~91.5% lines (miss 54, 127–128, 147–148) | **100%** lines |
| `semantic-candidate-projection.svelte.ts` | ~80% lines (union path open) | **100%** lines |

## Test plan

- [x] `vitest run --project chromium tests/assembly/assemble.test.ts tests/runtime/semantic-candidate-projection.test.ts`
- [x] `oxlint --type-aware --deny-warnings` on both test files
- [ ] CI component-svelte + build green

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1246" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->