### PR TITLE
test(svelte): cover host-layer fold no-op and glyph extent edges

### DIFF
--- a/packages/svelte/tests/layers/fold.test.ts
+++ b/packages/svelte/tests/layers/fold.test.ts
@@ -63,6 +63,18 @@ describe("foldPlotLayer", () => {
     expect(after.theme).toEqual(before.theme);
   });
 
+  it("is a no-op for host-only legend focus/filter layers", () => {
+    // legendFocus / legendFilter never enter PortableSpec — fold must ignore them.
+    // `null` value = GuideLegend focus/filter off; kind still must not fold.
+    const themed = foldPlotLayer(base(), { kind: "theme", value: "dark" });
+    const afterFocus = foldPlotLayer(themed, { kind: "legendFocus", value: null });
+    const afterFilter = foldPlotLayer(afterFocus, { kind: "legendFilter", value: null });
+    expect(afterFocus).toBe(themed);
+    expect(afterFilter).toBe(themed);
+    expect(afterFilter.theme).toBe("dark");
+    expect(afterFilter.layers).toEqual(themed.layers);
+  });
+
   it("preserves registration order when folding multiple layers", () => {
     // Production assemble folds one layer at a time; same order semantics.
     let draft = base();

--- a/packages/svelte/tests/scene/geometry.test.ts
+++ b/packages/svelte/tests/scene/geometry.test.ts
@@ -183,6 +183,42 @@ describe("glyphHoverBox / glyphExtentsFromBatch", () => {
     expect(glyphExtentsFromBatch({ kind: "points" }, 0)).toBeNull();
   });
 
+  it("returns null when glyph extents are missing or non-positive", () => {
+    expect(glyphExtentsFromBatch(null, 0)).toBeNull();
+    expect(glyphExtentsFromBatch(undefined, 0)).toBeNull();
+    expect(
+      glyphExtentsFromBatch({ kind: "glyphs", boxWidths: [0, 10], boxHeights: [8, 8] }, 0),
+    ).toBeNull();
+    expect(
+      glyphExtentsFromBatch({ kind: "glyphs", boxWidths: [12], boxHeights: [0] }, 0),
+    ).toBeNull();
+    // Missing height at the primitive index.
+    expect(
+      glyphExtentsFromBatch({ kind: "glyphs", boxWidths: [12, 20], boxHeights: [8] }, 1),
+    ).toBeNull();
+    // Defaults textAnchor to middle when the batch omits it.
+    expect(glyphExtentsFromBatch({ kind: "glyphs", boxWidths: [12], boxHeights: [8] }, 0)).toEqual({
+      width: 12,
+      height: 8,
+      textAnchor: "middle",
+    });
+  });
+
+  it("falls back to default glyph box size when extents are omitted", () => {
+    expect(glyphHoverBox({ x: 10, y: 20 })).toEqual({
+      x: 10 - 24,
+      y: 20 - 8,
+      width: 48,
+      height: 16,
+    });
+    expect(glyphHoverBox({ x: 10, y: 20 }, { width: 0, height: -1 })).toEqual({
+      x: 10 - 24,
+      y: 20 - 8,
+      width: 48,
+      height: 16,
+    });
+  });
+
   it("sizes the crosshair gap to clear the box diagonal", () => {
     expect(crosshairGapForBox(30, 16)).toBeCloseTo(Math.hypot(15, 8) + 2);
   });


### PR DESCRIPTION
## Summary

- `foldPlotLayer` is a no-op for host-only `legendFocus` / `legendFilter` layers (they never enter PortableSpec).
- `glyphExtentsFromBatch` / `glyphHoverBox`: null batches, non-positive or missing extents, default box size, default middle textAnchor.

## Coverage (browser, focused)

| File | Before | After |
|------|--------|-------|
| `fold.ts` | ~82% lines (miss host kinds + never default) | **~88%** lines (host kinds covered; never-default remains unreachable) |
| `geometry.ts` | ~97.5% lines (miss non-positive extents) | **100%** lines |

## Test plan

- [x] `vitest run --project chromium tests/layers/fold.test.ts tests/scene/geometry.test.ts`
- [x] `oxlint --type-aware --deny-warnings` on both test files
- [ ] CI component-svelte + build green

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1247" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->