### PR TITLE
docs: show <Inspect> child in site code blocks and demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ and Windows.
     GeomPoint,
     GGPlot,
     GuideLegend,
+    Inspect,
     Labs,
     ScaleColorManual,
     ScaleXLog10,
@@ -184,10 +185,10 @@ and Windows.
   data={londonCholera}
   aes={{ x: "density", y: "deathRate", color: "water" }}
   key="district"
-  inspect={{ mode: "xy", pin: true }}
   width="container"
   height={400}
 >
+  <Inspect mode="xy" pin />
   <ThemeEconomist />
   <ScaleXLog10 labels="~s" />
   <ScaleColorManual

--- a/apps/docs/src/lib/components/GrammarDemoPlot.svelte
+++ b/apps/docs/src/lib/components/GrammarDemoPlot.svelte
@@ -4,6 +4,7 @@
     GeomSmooth,
     GGPlot,
     GuideLegend,
+    Inspect,
     Labs,
     Theme,
   } from "@ggsvelte/svelte";
@@ -45,9 +46,11 @@
     y: "bodyMassG",
     ...(active >= 1 && { color: "species" }),
   }}
-  inspect={active >= 3 ? { mode: "xy", pin: true, maxDistance: 24 } : false}
   ariaLabel="Penguin body mass increases with flipper length, grouped by species"
 >
+  {#if active >= 3}
+    <Inspect mode="xy" pin maxDistance={24} />
+  {/if}
   <Theme name={chartTheme} />
   <Labs x="Flipper length mm" y="Body mass g" color="species" />
   {#if active >= 1}

--- a/apps/docs/src/lib/components/InteractionDemo.svelte
+++ b/apps/docs/src/lib/components/InteractionDemo.svelte
@@ -4,6 +4,7 @@
     GeomPoint,
     GGPlot,
     GuideLegend,
+    Inspect,
     Labs,
     Scale,
   } from "@ggsvelte/svelte";
@@ -39,7 +40,7 @@
 
   const closeScript = ["</", "script>"].join("");
   const code = `<script lang="ts">
-  import { createPlotInteraction, GeomPoint, GGPlot, GuideLegend } from "@ggsvelte/svelte";
+  import { createPlotInteraction, GeomPoint, GGPlot, GuideLegend, Inspect } from "@ggsvelte/svelte";
 
   const interaction = createPlotInteraction<string>();
   const scope = { keys: "rows", x: "x", y: "y" } as const;
@@ -51,10 +52,10 @@ ${closeScript}
   data={rows}
   key="id"
   aes={{ x: "period", y: "value", color: "series" }}
-  inspect
   select={{ type: "interval", mode: "xy" }}
   zoom={{ mode: "x" }}
 >
+  <Inspect />
   <GuideLegend channel="color" focus />
   <GeomPoint size={4} />
 </GGPlot>`;
@@ -87,7 +88,6 @@ ${closeScript}
       aes={{ x: "period", y: "value", color: "series" }}
       layers={[{ geom: "point", params: { size: 4 } }]}
       key="id"
-      inspect
       select={{ type: "interval", mode: "xy" }}
       zoom={{ mode: "x" }}
       {interaction}
@@ -96,6 +96,7 @@ ${closeScript}
       ariaLabel="Interactive series with inspect, select, zoom, and legend focus"
       onlegendfocus={describeLegend}
     >
+      <Inspect />
       <GuideLegend channel="color" focus />
       <Scale value={{ color: { type: "ordinal", scheme: "observable10" } }} />
       <Labs x="Period" y="Value" color="Series" />

--- a/apps/docs/src/lib/components/LessonFinishedChart.svelte
+++ b/apps/docs/src/lib/components/LessonFinishedChart.svelte
@@ -23,7 +23,7 @@
     sakuraFinishedHeight,
   } from "$lib/generated/lesson-charts";
   import { observeNearViewport } from "$lib/near-viewport";
-  import type { PlotInspectionChange } from "@ggsvelte/svelte";
+  import { Inspect, type PlotInspectionChange } from "@ggsvelte/svelte";
   import { kyotoSakura } from "@ggsvelte/svelte/data";
 
   const {
@@ -180,14 +180,13 @@
     <LivePlot
       spec={finished.spec}
       key={finished.key}
-      inspect={{
-        mode: "exact",
-        pin: true,
-        content: sakuraTooltip,
-      }}
       height={liveHeight}
       {ariaLabel}
-    />
+    >
+      {#if finished.inspect}
+        <Inspect mode="exact" pin content={sakuraTooltip} />
+      {/if}
+    </LivePlot>
   {:else}
     <img
       class="lesson-chart"

--- a/apps/docs/src/lib/components/LessonFinishedChart.svelte
+++ b/apps/docs/src/lib/components/LessonFinishedChart.svelte
@@ -23,7 +23,7 @@
     sakuraFinishedHeight,
   } from "$lib/generated/lesson-charts";
   import { observeNearViewport } from "$lib/near-viewport";
-  import { Inspect, type PlotInspectionChange } from "@ggsvelte/svelte";
+  import type { PlotInspectionChange } from "@ggsvelte/svelte";
   import { kyotoSakura } from "@ggsvelte/svelte/data";
 
   const {
@@ -56,10 +56,13 @@
   /** Measured container width; drives live plot height via build-time chrome table. */
   let chartWidth = $state(0);
   let host = $state<HTMLElement>();
-  /** Live plot component — dynamically imported when near the viewport (#972). */
+  /** Live plot + Inspect — dynamically imported when near the viewport (#972). */
   let LivePlot = $state<null | (typeof import("@ggsvelte/svelte"))["GGPlot"]>(
     null,
   );
+  let LiveInspect = $state<
+    null | (typeof import("@ggsvelte/svelte"))["Inspect"]
+  >(null);
 
   /**
    * Fold only when the live plot is mounted. Computing the 838-point spec
@@ -142,7 +145,10 @@
       if (loadStarted || cancelled) return;
       loadStarted = true;
       void import("@ggsvelte/svelte").then((mod) => {
-        if (!cancelled) LivePlot = mod.GGPlot;
+        if (!cancelled) {
+          LivePlot = mod.GGPlot;
+          LiveInspect = mod.Inspect;
+        }
       });
     };
 
@@ -183,8 +189,8 @@
       height={liveHeight}
       {ariaLabel}
     >
-      {#if finished.inspect}
-        <Inspect mode="exact" pin content={sakuraTooltip} />
+      {#if finished.inspect && LiveInspect}
+        <LiveInspect mode="exact" pin content={sakuraTooltip} />
       {/if}
     </LivePlot>
   {:else}

--- a/apps/docs/src/lib/components/PaletteSpecimenLive.svelte
+++ b/apps/docs/src/lib/components/PaletteSpecimenLive.svelte
@@ -4,6 +4,7 @@
     GeomCol,
     GGPlot,
     Guides,
+    Inspect,
     Labs,
     Scale,
     Theme,
@@ -36,10 +37,10 @@
 <GGPlot
   data={chart.rows}
   aes={{ x: "category", y: "value", fill: "category" }}
-  inspect={{ mode: "exact" }}
   {height}
   ariaLabel={`${label} palette on ${paperTheme} paper`}
 >
+  <Inspect mode="exact" />
   <Theme name={paperTheme} />
   <Scale value={{ fill: { type: "ordinal", scheme: name, reverse } }} />
   <Guides value={{ fill: { type: "none" } }} />

--- a/apps/docs/src/lib/components/SequentialColorLabLive.svelte
+++ b/apps/docs/src/lib/components/SequentialColorLabLive.svelte
@@ -1,5 +1,12 @@
 <script lang="ts">
-  import { GeomRaster, GGPlot, Labs, Scale, Theme } from "@ggsvelte/svelte";
+  import {
+    GeomRaster,
+    GGPlot,
+    Inspect,
+    Labs,
+    Scale,
+    Theme,
+  } from "@ggsvelte/svelte";
   import type { ColorScaleSpec } from "@ggsvelte/spec";
 
   import { grid } from "$lib/theme-specimens/data";
@@ -18,10 +25,10 @@
 <GGPlot
   data={grid}
   aes={{ x: "x", y: "y", fill: "z" }}
-  inspect={{ mode: "xy" }}
   {height}
   ariaLabel={`${label} sequential color example`}
 >
+  <Inspect mode="xy" />
   <Scale value={{ fill: scale }} />
   <Theme name="light" />
   <Labs

--- a/apps/docs/src/lib/components/TemperaturesSpecimen.svelte
+++ b/apps/docs/src/lib/components/TemperaturesSpecimen.svelte
@@ -4,6 +4,7 @@
     GeomPoint,
     GGPlot,
     GuideLegend,
+    Inspect,
     Labs,
     ScaleColorDiscrete,
     ScaleXContinuous,
@@ -36,10 +37,10 @@
   data={temperaturesKeyed}
   aes={chart.aes}
   key={chart.key}
-  inspect={chart.inspect}
   {height}
   {ariaLabel}
 >
+  <Inspect mode="x" />
   {#if legendFocus}
     <GuideLegend channel="color" focus />
   {/if}

--- a/apps/docs/src/lib/components/ThemeSpecimenLive.svelte
+++ b/apps/docs/src/lib/components/ThemeSpecimenLive.svelte
@@ -14,6 +14,7 @@
     GeomText,
     GGPlot,
     GuideLegend,
+    Inspect,
     Labs,
     Scale,
     scaleXLog10,
@@ -69,10 +70,10 @@
     data={ridership}
     aes={{ x: "month", y: "riders", color: "mode" }}
     key="id"
-    inspect={{ mode: "x" }}
     {height}
     ariaLabel={`${label} theme Playfair wheat and wages`}
   >
+    <Inspect mode="x" />
     {#if legendFocus}
       <GuideLegend channel="color" focus />
     {/if}
@@ -92,10 +93,10 @@
     data={attendees}
     aes={{ x: "track", fill: "level", weight: "deaths" }}
     key="id"
-    inspect={{ mode: "exact" }}
     {height}
     ariaLabel={`${label} theme Edgeworth dodged bars`}
   >
+    <Inspect mode="exact" />
     {#if legendFocus}
       <GuideLegend channel="fill" focus />
     {/if}
@@ -114,10 +115,10 @@
     data={generation}
     aes={{ x: "year", y: "twh", fill: "source" }}
     key="id"
-    inspect={{ mode: "x" }}
     {height}
     ariaLabel={`${label} theme Nightingale stacked area`}
   >
+    <Inspect mode="x" />
     {#if legendFocus}
       <GuideLegend channel="fill" focus />
     {/if}
@@ -140,10 +141,10 @@
   <GGPlot
     data={longRunSeries}
     aes={{ x: "year", y: "value" }}
-    inspect={{ mode: "x" }}
     {height}
     ariaLabel={`${label} theme Bowley exports`}
   >
+    <Inspect mode="x" />
     {#if legendFocus}
       <GuideLegend channel="color" focus />
     {/if}
@@ -156,10 +157,10 @@
     data={penguins}
     aes={{ x: "flipper", y: "mass", color: "species" }}
     key="id"
-    inspect={{ mode: "xy" }}
     {height}
     ariaLabel={`${label} theme penguin scatter`}
   >
+    <Inspect mode="xy" />
     {#if legendFocus}
       <GuideLegend channel="color" focus />
     {/if}
@@ -178,10 +179,10 @@
     data={countries}
     aes={{ x: "gdp", y: "lifeExp", color: "region" }}
     key="country"
-    inspect={{ mode: "xy" }}
     {height}
     ariaLabel={`${label} theme cholera density scatter`}
   >
+    <Inspect mode="xy" />
     {#if legendFocus}
       <GuideLegend channel="color" focus />
     {/if}
@@ -205,10 +206,10 @@
   <GGPlot
     data={revenue}
     aes={{ x: "quarter", y: "amount" }}
-    inspect={{ mode: "exact" }}
     {height}
     ariaLabel={`${label} theme Salk trial columns`}
   >
+    <Inspect mode="exact" />
     {#if legendFocus}
       <GuideLegend channel="color" focus />
     {/if}
@@ -225,10 +226,10 @@
   <GGPlot
     data={cities}
     aes={{ x: "rent", y: "livability" }}
-    inspect={{ mode: "xy" }}
     {height}
     ariaLabel={`${label} theme Langren longitude labels`}
   >
+    <Inspect mode="xy" />
     {#if legendFocus}
       <GuideLegend channel="color" focus />
     {/if}

--- a/apps/docs/src/lib/generated/routes.ts
+++ b/apps/docs/src/lib/generated/routes.ts
@@ -10574,8 +10574,8 @@ export const DOCS_ROUTES = [
         level: 2,
       },
       {
-        id: "inspect-inspect",
-        title: "inspect / <Inspect>",
+        id: "inspect",
+        title: "inspect",
         level: 3,
       },
       {

--- a/apps/docs/src/lib/generated/routes.ts
+++ b/apps/docs/src/lib/generated/routes.ts
@@ -10574,8 +10574,8 @@ export const DOCS_ROUTES = [
         level: 2,
       },
       {
-        id: "inspect",
-        title: "inspect",
+        id: "inspect-inspect",
+        title: "inspect / <Inspect>",
         level: 3,
       },
       {

--- a/apps/docs/src/lib/generated/search-index.ts
+++ b/apps/docs/src/lib/generated/search-index.ts
@@ -17056,14 +17056,14 @@ export const DOCS_SEARCH_INDEX = [
     exact: ["Capability props"],
   },
   {
-    id: "heading:guide-interaction-reference:inspect",
+    id: "heading:guide-interaction-reference:inspect-inspect",
     kind: "heading",
-    title: "inspect",
+    title: "inspect / <Inspect>",
     summary:
-      "inspect in Interaction reference. Search interaction props, callbacks, event phases, and diagnostic codes.",
-    href: "/guide/interaction-reference#inspect",
+      "inspect / <Inspect> in Interaction reference. Search interaction props, callbacks, event phases, and diagnostic codes.",
+    href: "/guide/interaction-reference#inspect-inspect",
     keywords: ["Interaction reference", "documentation"],
-    exact: ["inspect"],
+    exact: ["inspect / <Inspect>"],
   },
   {
     id: "heading:guide-interaction-reference:point-selection",

--- a/apps/docs/src/lib/generated/search-index.ts
+++ b/apps/docs/src/lib/generated/search-index.ts
@@ -17056,14 +17056,14 @@ export const DOCS_SEARCH_INDEX = [
     exact: ["Capability props"],
   },
   {
-    id: "heading:guide-interaction-reference:inspect-inspect",
+    id: "heading:guide-interaction-reference:inspect",
     kind: "heading",
-    title: "inspect / <Inspect>",
+    title: "inspect",
     summary:
-      "inspect / <Inspect> in Interaction reference. Search interaction props, callbacks, event phases, and diagnostic codes.",
-    href: "/guide/interaction-reference#inspect-inspect",
+      "inspect in Interaction reference. Search interaction props, callbacks, event phases, and diagnostic codes.",
+    href: "/guide/interaction-reference#inspect",
     keywords: ["Interaction reference", "documentation"],
-    exact: ["inspect / <Inspect>"],
+    exact: ["inspect"],
   },
   {
     id: "heading:guide-interaction-reference:point-selection",

--- a/apps/docs/src/lib/home-code-path.ts
+++ b/apps/docs/src/lib/home-code-path.ts
@@ -11,16 +11,16 @@
  * aliases.
  *
  * Interaction: GrammarDemo step 4 uses xy inspect (numeric crosshair on both
- * axes) plus GuideLegend focus. Inspect stays a GGPlot host prop; legend focus
- * is a host-only prop on `<GuideLegend>` (not a PortableSpec field).
- * - Svelte: `inspect` / `key` on <GGPlot>, `focus` on <GuideLegend>
- * - Builder + spec: same host children for focus; inspect still on <GGPlot>
+ * axes) plus GuideLegend focus. Prefer `<Inspect>` for the host capability;
+ * legend focus is a host-only prop on `<GuideLegend>` (not a PortableSpec field).
+ * - Svelte: `<Inspect>` / `key` on <GGPlot>, `focus` on <GuideLegend>
+ * - Builder + spec: same host children; inspect via `<Inspect>`
  * - JSON: agent envelope `{ interactions, spec }` still accepts legendFocus
  *   (deprecated host map until 0.20.0)
  */
 
 const HOME_CODE_PATH_SVELTE = `<script lang="ts">
-  import { GeomJitter, GeomSmooth, GGPlot, GuideLegend, Labs } from "@ggsvelte/svelte";
+  import { GeomJitter, GeomSmooth, GGPlot, GuideLegend, Inspect, Labs } from "@ggsvelte/svelte";
   import { palmerPenguins } from "@ggsvelte/svelte/data";
 </script>
 
@@ -28,10 +28,10 @@ const HOME_CODE_PATH_SVELTE = `<script lang="ts">
   data={palmerPenguins}
   key="id"
   aes={{ x: "flipperLengthMm", y: "bodyMassG", color: "species" }}
-  inspect={{ mode: "xy", pin: true, maxDistance: 24 }}
   width={640}
   height={400}
 >
+  <Inspect mode="xy" pin maxDistance={24} />
   <GuideLegend channel="color" focus />
   <Labs x="Flipper length mm" y="Body mass g" color="species" />
   <GeomJitter alpha={0.88} />
@@ -39,10 +39,10 @@ const HOME_CODE_PATH_SVELTE = `<script lang="ts">
 </GGPlot>
 `;
 
-/** Builder produces PortableSpec; inspect is a host GGPlot prop; focus is GuideLegend. */
+/** Builder produces PortableSpec; inspect is a host `<Inspect>` child; focus is GuideLegend. */
 const HOME_CODE_PATH_BUILDER = `<script lang="ts">
   import { aes, gg } from "@ggsvelte/spec";
-  import { GGPlot, GuideLegend } from "@ggsvelte/svelte";
+  import { GGPlot, GuideLegend, Inspect } from "@ggsvelte/svelte";
   import { palmerPenguins } from "@ggsvelte/svelte/data";
 
   const spec = gg(
@@ -58,10 +58,10 @@ const HOME_CODE_PATH_BUILDER = `<script lang="ts">
 <GGPlot
   {spec}
   key="id"
-  inspect={{ mode: "xy", pin: true, maxDistance: 24 }}
   width={640}
   height={400}
 >
+  <Inspect mode="xy" pin maxDistance={24} />
   <GuideLegend channel="color" focus />
 </GGPlot>
 `;
@@ -69,7 +69,8 @@ const HOME_CODE_PATH_BUILDER = `<script lang="ts">
 /**
  * Agent envelope: host interaction flags + named-data PortableSpec.
  * `spec` alone is valid PortableSpec; interactions are applied by the host.
- * `inspect: true` still defaults mode "auto"; the homepage host opts into xy.
+ * `inspect: true` still defaults mode "auto"; the homepage host opts into xy
+ * via `<Inspect mode="xy" … />` in the Svelte tabs above.
  * `legendFocus` remains in the envelope as a deprecated host map (0.19–0.20).
  */
 const HOME_CODE_PATH_SPEC_JSON = `{

--- a/apps/docs/src/lib/theme-specimens/temperatures-chart.ts
+++ b/apps/docs/src/lib/theme-specimens/temperatures-chart.ts
@@ -7,7 +7,6 @@ import { MONTH_BREAKS } from "./catalog.js";
 export const TEMPERATURES_CHART = {
   key: "id",
   aes: { x: "month", y: "temp", color: "city" },
-  inspect: { mode: "x" as const },
   labs: {
     title: "Playfair stocks, bread & exports, 1770–1824",
     x: "Year",

--- a/apps/docs/src/routes/__perf/interaction-100k/+page.svelte
+++ b/apps/docs/src/routes/__perf/interaction-100k/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { RenderModel } from "@ggsvelte/core";
-  import { GGPlot } from "@ggsvelte/svelte";
+  import { GGPlot, Inspect } from "@ggsvelte/svelte";
 
   type Row = Readonly<{
     id: number;
@@ -39,7 +39,6 @@
     aes={{ x: "x", y: "y", group: "series" }}
     layers={[{ geom: "point", render: "canvas", params: { size: 1 } }]}
     key="id"
-    inspect={{ mode: "x", maxDistance: 24 }}
     onrender={(model: RenderModel) => {
       candidateCount = model.candidates.size;
       const seed = model.candidates.nearest(
@@ -58,7 +57,9 @@
     }}
     width={800}
     height={500}
-  />
+  >
+    <Inspect mode="x" maxDistance={24} />
+  </GGPlot>
 </main>
 
 <style>

--- a/apps/docs/static/previews/provenance.json
+++ b/apps/docs/static/previews/provenance.json
@@ -168,7 +168,7 @@
     },
     "interaction/brush-zoom": {
       "filename": "interaction-brush-zoom-light.png",
-      "sourceSha256": "b299345430be2bb4712083c06d1e861bce1be79bdff1fca7495944cdb44996a7",
+      "sourceSha256": "6996cd045e7525f9c64c3779d13d689b382acf6498da2e038fe1b9e26a74d95e",
       "pngSha256": "1a0ddcf51b7cced3e7a590249f999e3cba23a81adbaa6a95afae3a5497ae3578"
     },
     "interaction/facet-intervals": {
@@ -193,7 +193,7 @@
     },
     "interaction/tooltip": {
       "filename": "interaction-tooltip-light.png",
-      "sourceSha256": "f5553593d7f92780bed8b2d8e448bba4e9c851aab640edfc51a1d2407b86e6b9",
+      "sourceSha256": "1c09e98b169281f77aff0ff18bb72ccab54f2df0617eb0f4a24dafefdab7ced9",
       "pngSha256": "2ada956472d13fac2b0315f486e1a30e2f80a5effd873b3d04dd87005b987940"
     },
     "jitter/basic": {
@@ -288,7 +288,7 @@
     },
     "point/log-scale": {
       "filename": "point-log-scale-light.png",
-      "sourceSha256": "4376eae6453a1497330a5f68fb1625aec2343be593244141476a50160c761699",
+      "sourceSha256": "aa5f322432d15656adeb77f5592d60baa06f39c575c0f7065f0f4ba46fed270f",
       "pngSha256": "e4cca5e252e49ced88e85a92ff84016533cbbc0fbad7d705fbecbd6e9c84c8a2"
     },
     "point/quantile-lines": {

--- a/examples/interaction/brush-zoom/Example.svelte
+++ b/examples/interaction/brush-zoom/Example.svelte
@@ -1,5 +1,11 @@
 <script lang="ts">
-  import { GeomPoint, GGPlot, Labs, ThemeLight } from "@ggsvelte/svelte";
+  import {
+    GeomPoint,
+    GGPlot,
+    Inspect,
+    Labs,
+    ThemeLight,
+  } from "@ggsvelte/svelte";
 
   import { field } from "./data.js";
 
@@ -15,7 +21,6 @@
   data={field}
   aes={{ x: "bill", y: "mass", color: "species" }}
   key="id"
-  inspect={true}
   select={{ type: "interval", mode: "xy", persistent: true }}
   zoom={{ mode: "xy" }}
   onselect={(event) => {
@@ -35,6 +40,7 @@
   width="container"
   height={400}
 >
+  <Inspect />
   <ThemeLight />
   <Labs title="Select an interval or brush to zoom" x="x" y="y" color="Group" />
   <GeomPoint size={2.5} alpha={0.8} />

--- a/examples/interaction/tooltip/Example.svelte
+++ b/examples/interaction/tooltip/Example.svelte
@@ -1,5 +1,11 @@
 <script lang="ts">
-  import { GeomPoint, GGPlot, Labs, ThemeLight } from "@ggsvelte/svelte";
+  import {
+    GeomPoint,
+    GGPlot,
+    Inspect,
+    Labs,
+    ThemeLight,
+  } from "@ggsvelte/svelte";
 
   import { penguins } from "./data.js";
 
@@ -12,7 +18,6 @@
   data={penguins}
   aes={{ x: "flipper", y: "mass", color: "species" }}
   key="id"
-  inspect={{ mode: "x", pin: true, maxDistance: 24 }}
   oninspect={(event) => {
     inspectionStatus =
       event.phase === "clear"
@@ -22,6 +27,7 @@
   width="container"
   height={400}
 >
+  <Inspect mode="x" pin maxDistance={24} />
   <ThemeLight />
   <Labs
     title="Inspect a shared x value, then pin"

--- a/examples/point/log-scale/Example.svelte
+++ b/examples/point/log-scale/Example.svelte
@@ -3,6 +3,7 @@
     GeomPoint,
     GGPlot,
     GuideLegend,
+    Inspect,
     Labs,
     ScaleColorManual,
     ScaleXLog10,
@@ -16,10 +17,10 @@
   data={londonCholera}
   aes={{ x: "density", y: "deathRate", color: "water" }}
   key="district"
-  inspect={{ mode: "xy", pin: true }}
   width="container"
   height={400}
 >
+  <Inspect mode="xy" pin />
   <ThemeEconomist />
   <ScaleXLog10 labels="~s" />
   <ScaleColorManual

--- a/packages/svelte/tests/migrations/candidate-store-hit-testing.svelte
+++ b/packages/svelte/tests/migrations/candidate-store-hit-testing.svelte
@@ -1,5 +1,10 @@
 <script lang="ts">
-  import { GeomPoint, GGPlot, type RenderModel } from "../../src/lib/index.js";
+  import {
+    GeomPoint,
+    GGPlot,
+    Inspect,
+    type RenderModel,
+  } from "../../src/lib/index.js";
 
   const rows = [
     { id: "a", x: 1, y: 3 },
@@ -17,9 +22,9 @@
   data={rows}
   aes={{ x: "x", y: "y" }}
   key="id"
-  inspect
   onrender={(next) => (model = next)}
 >
+  <Inspect />
   <GeomPoint />
 </GGPlot>
 

--- a/scripts/diagnostic-docs.ts
+++ b/scripts/diagnostic-docs.ts
@@ -69,16 +69,18 @@ const recipes = new Map<string, DiagnosticDocEntry["recipe"]>([
       code: `<GGPlot
   data={rows}
   aes={{ x: "weight", y: "economy" }}
-  inspect={true}
   tool="inspect"
-/>`,
+>
+  <Inspect />
+</GGPlot>`,
     },
   ],
   [
     "interaction:INTERACTION_INSPECT_X_ON_COL",
     {
       language: "svelte",
-      code: `<GGPlot data={rows} aes={{ x: "group", y: "amount" }} inspect={{ mode: "exact" }}>
+      code: `<GGPlot data={rows} aes={{ x: "group", y: "amount" }}>
+  <Inspect mode="exact" />
   <GeomCol />
 </GGPlot>`,
     },
@@ -87,7 +89,8 @@ const recipes = new Map<string, DiagnosticDocEntry["recipe"]>([
     "interaction:INTERACTION_INSPECT_X_BISECTS_COL_LABELS",
     {
       language: "svelte",
-      code: `<GGPlot data={rows} aes={{ x: "group", y: "amount" }} inspect={{ mode: "exact" }}>
+      code: `<GGPlot data={rows} aes={{ x: "group", y: "amount" }}>
+  <Inspect mode="exact" />
   <GeomCol />
   <GeomText aes={{ label: "label" }} dy={-8} />
 </GGPlot>`,

--- a/scripts/gen-llms.test.ts
+++ b/scripts/gen-llms.test.ts
@@ -239,7 +239,7 @@ describe("guide sections cover their catalogs", () => {
     expect(INTERACTIONS_MD).toContain("/examples/interactions/inspection");
     expect(INTERACTIONS_MD).toContain("/interactions/linked-views");
     expect(INTERACTIONS_MD).not.toContain("/playground");
-    expect(INTERACTIONS_MD).toContain('inspect={{ mode: "x",');
+    expect(INTERACTIONS_MD).toContain('<Inspect mode="x" pin maxDistance={24} />');
     expect(INTERACTIONS_MD).toContain('select={{ type: "interval", mode: "xy",');
     expect(INTERACTIONS_MD).toContain('key="id"');
     expect(INTERACTIONS_MD).toContain("oninspect");

--- a/scripts/llms-guide-content.ts
+++ b/scripts/llms-guide-content.ts
@@ -1612,12 +1612,13 @@ Page scroll is not hijacked by unused tools.
 
 ## Capability props
 
-### \`inspect\` / \`<Inspect>\`
+### \`inspect\`
 
 Prefer the declaration child \`<Inspect />\` (or \`<Inspect mode="x" pin />\`,
 etc.). Options match the legacy GGPlot prop: \`mode\`, \`pin\`, \`maxDistance\`,
 \`content\`, \`contentMode\`, \`muteSiblings\`. Empty \`<Inspect />\` equals
-\`inspect={true}\`. The GGPlot \`inspect\` prop still works.
+\`inspect={true}\`. The GGPlot \`inspect\` prop still works. The heading id stays
+\`inspect\` for stable deep links.
 
 ### Point selection
 

--- a/scripts/llms-guide-content.ts
+++ b/scripts/llms-guide-content.ts
@@ -1283,10 +1283,10 @@ timestamp helpers, exact-format parser, and epoch helpers return authoring Dates
 
 export const INTERACTIONS_MD = `# Interactions
 
-Static by default. Opt in with \`inspect\`, \`select\`, \`zoom\`, and GuideLegend
-\`focus\` / \`filter\` (or deprecated plot props \`legendFocus\` /
-\`legendFilter\`). With more than one draw tool, an accessible tool rail keeps
-gestures from competing.
+Static by default. Opt in with \`<Inspect>\`, \`select\`, \`zoom\`, and GuideLegend
+\`focus\` / \`filter\` (or the legacy GGPlot \`inspect\` prop, and deprecated plot
+props \`legendFocus\` / \`legendFilter\`). With more than one draw tool, an
+accessible tool rail keeps gestures from competing.
 
 Without a controller, state is private to one chart and callbacks report
 changes. Pass \`createPlotInteraction()\` when plots, controls, or tables share
@@ -1302,18 +1302,23 @@ Contracts: [interaction reference](/guide/interaction-reference).
 
 ## Inspection
 
-\`inspect={true}\` enables the default HTML tooltip, semantic crosshair,
-keyboard traversal, and click-or-Enter pinning. Configure it when the chart
-has a natural comparison axis:
+\`<Inspect />\` enables the default HTML tooltip, semantic crosshair, keyboard
+traversal, and click-or-Enter pinning (same as the legacy \`inspect={true}\`
+prop on \`<GGPlot>\`). Configure it when the chart has a natural comparison
+axis:
 
 \`\`\`svelte fragment
+<script lang="ts">
+  import { GeomLine, GeomPoint, GGPlot, Inspect } from "@ggsvelte/svelte";
+</script>
+
 <GGPlot
   {data}
   aes={{ x: "date", y: "value", color: "series" }}
   key="id"
-  inspect={{ mode: "x", pin: true, maxDistance: 24 }}
   oninspect={(event) => console.log(event)}
 >
+  <Inspect mode="x" pin maxDistance={24} />
   <GeomLine />
   <GeomPoint />
 </GGPlot>
@@ -1326,11 +1331,11 @@ representative per semantic series at the focused axis value; \`exact\` and
 dominant axis for \`x\` or \`y\`, Euclidean distance for \`xy\`, and geometry
 containment plus tolerance for \`exact\`. Rect marks (\`geom_col\` / \`geom_bar\`)
 never draw a point ring; default hover is tooltip-only. Pass
-\`muteSiblings: true\` to mute non-focused bars via the interaction mask.
+\`muteSiblings\` on \`<Inspect>\` to mute non-focused bars via the interaction mask.
 
-For custom HTML, pass a Svelte 5 snippet. Informational content is the default;
-choose \`contentMode: "interactive"\` only when the pinned tooltip contains
-controls that need focus.
+For custom HTML, pass a Svelte 5 snippet on \`content\`. Informational content is
+the default; choose \`contentMode="interactive"\` only when the pinned tooltip
+contains controls that need focus.
 
 \`\`\`svelte fragment
 {#snippet details(inspection)}
@@ -1338,7 +1343,9 @@ controls that need focus.
   <span>{inspection.members.length} series at this value</span>
 {/snippet}
 
-<GGPlot inspect={{ mode: "x", content: details }} />
+<GGPlot {data} aes={{ x: "date", y: "value" }} key="id">
+  <Inspect mode="x" content={details} />
+</GGPlot>
 \`\`\`
 
 ## Point and interval selection
@@ -1605,11 +1612,12 @@ Page scroll is not hijacked by unused tools.
 
 ## Capability props
 
-### \`inspect\`
+### \`inspect\` / \`<Inspect>\`
 
-Enables inspection, the default HTML tooltip, semantic crosshair, keyboard
-traversal, and optional pinning. Inputs are \`true\` or options with \`mode\`,
-\`pin\`, \`maxDistance\`, \`content\`, and \`contentMode\`.
+Prefer the declaration child \`<Inspect />\` (or \`<Inspect mode="x" pin />\`,
+etc.). Options match the legacy GGPlot prop: \`mode\`, \`pin\`, \`maxDistance\`,
+\`content\`, \`contentMode\`, \`muteSiblings\`. Empty \`<Inspect />\` equals
+\`inspect={true}\`. The GGPlot \`inspect\` prop still works.
 
 ### Point selection
 
@@ -1664,17 +1672,18 @@ plot tool rail must stay synchronized:
 
 \`\`\`svelte fragment
 <script lang="ts">
-  import type { InteractionTool } from "@ggsvelte/svelte";
+  import { GGPlot, Inspect, type InteractionTool } from "@ggsvelte/svelte";
 
   let activeTool = $state<InteractionTool>("inspect");
 </script>
 
 <GGPlot
-  inspect={true}
   select={{ type: "interval" }}
   tool={activeTool}
   ontoolchange={(next) => (activeTool = next)}
-/>
+>
+  <Inspect />
+</GGPlot>
 \`\`\`
 
 A controlled unavailable tool requests a change and emits a diagnostic; it
@@ -2760,7 +2769,7 @@ queries remain available as \`model.candidates.queryRect(...)\` candidate ids.
 
 \`\`\`svelte fragment
 <script lang="ts">
-  import { GeomPoint, GGPlot, type RenderModel } from "@ggsvelte/svelte";
+  import { GeomPoint, GGPlot, Inspect, type RenderModel } from "@ggsvelte/svelte";
 
   const rows = [
     { id: "a", x: 1, y: 3 },
@@ -2778,9 +2787,9 @@ queries remain available as \`model.candidates.queryRect(...)\` candidate ids.
   data={rows}
   aes={{ x: "x", y: "y" }}
   key="id"
-  inspect
   onrender={(next) => (model = next)}
 >
+  <Inspect />
   <GeomPoint />
 </GGPlot>
 

--- a/scripts/llms-guide-content.ts
+++ b/scripts/llms-guide-content.ts
@@ -2770,7 +2770,12 @@ queries remain available as \`model.candidates.queryRect(...)\` candidate ids.
 
 \`\`\`svelte fragment
 <script lang="ts">
-  import { GeomPoint, GGPlot, Inspect, type RenderModel } from "@ggsvelte/svelte";
+  import {
+    GeomPoint,
+    GGPlot,
+    Inspect,
+    type RenderModel,
+  } from "@ggsvelte/svelte";
 
   const rows = [
     { id: "a", x: 1, y: 3 },

--- a/scripts/quickstart/fold.ts
+++ b/scripts/quickstart/fold.ts
@@ -56,7 +56,15 @@ const BASE_COMPONENTS = [
  * chart looks, then how values map to the page, then what it is called. None
  * of these can override another, so this is readability only.
  */
-const GRAMMAR_ORDER = ["theme", "scaleY", "scaleX", "scaleFill", "guides", "labs"] as const;
+const GRAMMAR_ORDER = [
+  "inspect",
+  "theme",
+  "scaleY",
+  "scaleX",
+  "scaleFill",
+  "guides",
+  "labs",
+] as const;
 
 /** Layers that only make sense when the chart is wide enough to place text. */
 export const SAKURA_ANNOTATION_LAYERS = ["leaders", "callouts"] as const;
@@ -159,7 +167,8 @@ ${[...GRAMMAR_ORDER.filter((name) => grammar[name] !== undefined).map((name) => 
     spec,
     source,
     key: attrs.has("key") ? "year" : undefined,
-    inspect: attrs.has("inspect") ? { mode: "exact", pin: true } : undefined,
+    // Host capability: preferred as `<Inspect>` child (not a PortableSpec field).
+    inspect: components.has("Inspect") ? { mode: "exact", pin: true } : undefined,
   };
 }
 

--- a/scripts/quickstart/steps.ts
+++ b/scripts/quickstart/steps.ts
@@ -481,12 +481,15 @@ export const SAKURA_STEPS: readonly SakuraStep[] = [
     // No title/subtitle/caption: chrome would squash the data panel. Citation
     // and the dashed-rule note live as a page footnote instead.
     fragment: `key="year"
-inspect={{ mode: "exact", pin: true }}`,
+  <Inspect mode="exact" pin />`,
     spec: {},
     source: {
+      components: ["Inspect"],
       attrs: {
         key: `  key="year"`,
-        inspect: `  inspect={{ mode: "exact", pin: true }}`,
+      },
+      grammar: {
+        inspect: `  <Inspect mode="exact" pin />`,
       },
     },
   },

--- a/scripts/quickstart/surface.ts
+++ b/scripts/quickstart/surface.ts
@@ -56,7 +56,7 @@ const spec = gg(kyotoSakura, aes({ x: "year", y: "bloomDate" }))
  * data is a named ref (`kyotoSakura`) — hosts resolve it from
  * `@ggsvelte/svelte/data`. Small annotation tables (epochs, records) stay as
  * inline `values` because they are chart decoration, not the 838-row series.
- * `key` / `inspect` are GGPlot host props, not PortableSpec fields.
+ * `key` and `<Inspect>` are host-only; not PortableSpec fields.
  */
 export function finishedPortableSpecNamed(): PortableSpec {
   const { spec } = foldSakura(SAKURA_STEPS.length);


### PR DESCRIPTION
## Summary

- Replace legacy GGPlot `inspect` prop in every user-facing docs code block and matching live demo with the preferred `<Inspect>` capability child
- Covers homepage code path, interactions guide/llms content, gallery examples, sakura getting-started lesson fold, diagnostic fix recipes, theme/palette specimens, and interaction demo copy blocks
- Leaves mark eligibility `inspect={false}`, agent-envelope `"inspect": true`, and consumer-compat prop coverage unchanged

## Test plan

- [x] `bun test scripts/sakura-lesson.test.ts scripts/gen-llms.test.ts scripts/themes-page.test.ts`
- [x] `bun test scripts/repo-child-layers.test.ts`
- [ ] CI green on PR
- [ ] Spot-check homepage Svelte tab and `/examples/interaction/tooltip` after deploy
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1248" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->