### PR TITLE
fix(svelte): gap xy inspect guides around sibling GeomText boxes

### DIFF
--- a/.changeset/crosshair-glyph-gaps.md
+++ b/.changeset/crosshair-glyph-gaps.md
@@ -1,0 +1,14 @@
+---
+"@ggsvelte/svelte": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+fix: gap xy inspect guides around nearby GeomText boxes
+
+Hard-gap vertical and horizontal crosshairs through measured sibling
+label AABBs in the focus panel so continuous scatter+text charts
+(Langren/Tufte-style) keep both guides without bisecting name labels.
+
+Migration: none — presentation only when inspect mode draws axis guides
+and the panel has GeomText/GeomLabel glyphs.

--- a/packages/svelte/src/lib/GGPlot.svelte
+++ b/packages/svelte/src/lib/GGPlot.svelte
@@ -234,6 +234,7 @@
       hoverBoxWidth={engine.hoverBoxWidth}
       hoverBoxHeight={engine.hoverBoxHeight}
       hoverBoxAnchor={engine.hoverBoxAnchor}
+      crosshairGapObstacles={engine.crosshairGapObstacles}
       selectedAnchors={engine.selectedAnchors}
       emphasizedAnchors={engine.emphasizedAnchors}
       brushRect={surfaceState.brushRect}

--- a/packages/svelte/src/lib/plot-engine.svelte.ts
+++ b/packages/svelte/src/lib/plot-engine.svelte.ts
@@ -124,7 +124,11 @@ import {
   type PresentationAnchor,
   type PresentationChrome,
 } from "./selection/selection.js";
-import { glyphExtentsFromBatch } from "./scene/geometry.js";
+import {
+  crosshairGlyphObstacles,
+  glyphExtentsFromBatch,
+  type CrosshairGapBox,
+} from "./scene/geometry.js";
 import { createSurfaceState } from "./surface/surface-state.svelte.js";
 import type { SurfaceState } from "./surface/surface-state.svelte.js";
 import { createPlotZoomState } from "./zoom/zoom-state.svelte.js";
@@ -185,6 +189,12 @@ export type PlotEngine = {
   readonly hoverBoxWidth: number | undefined;
   readonly hoverBoxHeight: number | undefined;
   readonly hoverBoxAnchor: "start" | "middle" | "end" | undefined;
+  /**
+   * Sibling GeomText AABBs in the focus panel for crosshair hard-gaps (#1207).
+   * Derived from scene batches (not candidate store) so uninspectable labels
+   * still clear the guide.
+   */
+  readonly crosshairGapObstacles: readonly CrosshairGapBox[];
   readonly interactionMasks: readonly (BatchInteractionMask | null)[];
   readonly interactiveLegendEntries: InteractiveLegendEntry[];
   readonly effectiveLegendPressed: LegendEntryIdentity | null;
@@ -804,6 +814,18 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
     return glyphExtentsFromBatch(batch, seed.primitiveIndex);
   }
 
+  // Scene walk (not candidate store): uninspectable label layers still paint
+  // and still need guide gaps (#1065 / #1207). Depends on (scene, panelId)
+  // only — not the focus anchor — so this is a real $derived, not a per-read
+  // getter like hoverGlyphExtents.
+  const EMPTY_CROSSHAIR_GAP_OBSTACLES: readonly CrosshairGapBox[] = Object.freeze([]);
+  const crosshairGapObstacles = $derived.by((): readonly CrosshairGapBox[] => {
+    const model = runtime.model;
+    const panel = inspectionState.inspectionPanel;
+    if (model === null || panel === null) return EMPTY_CROSSHAIR_GAP_OBSTACLES;
+    return crosshairGlyphObstacles(model.scene.batches, model.scene.panels, panel.id);
+  });
+
   // After host entry deriveds exist (irreducible late data for legend focus).
   legendFocusState.installHostDerivedEffects();
 
@@ -858,6 +880,9 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
     },
     get hoverBoxAnchor() {
       return hoverGlyphExtents()?.textAnchor;
+    },
+    get crosshairGapObstacles() {
+      return crosshairGapObstacles;
     },
     get interactionMasks() {
       return semanticCandidateProjection.interactionMasks;

--- a/packages/svelte/src/lib/scene/InteractionOverlay.svelte
+++ b/packages/svelte/src/lib/scene/InteractionOverlay.svelte
@@ -12,11 +12,12 @@
   } from "../selection/selection.js";
   import {
     crosshairGapForBox,
-    gappedCrosshairSegments,
+    gappedCrosshairSegmentsWithObstacles,
     glyphHoverBox,
     HOVER_CROSSHAIR_GAP_RADIUS,
     HOVER_RING_RADIUS,
     normalizedRect,
+    type CrosshairGapBox,
   } from "./geometry.js";
   type Panel = {
     readonly x: number;
@@ -42,6 +43,7 @@
     hoverBoxWidth,
     hoverBoxHeight,
     hoverBoxAnchor = "middle",
+    crosshairGapObstacles = [],
     selectedAnchors = [],
     emphasizedAnchors = [],
     brushRect = null,
@@ -64,6 +66,11 @@
     hoverBoxWidth?: number | undefined;
     hoverBoxHeight?: number | undefined;
     hoverBoxAnchor?: "start" | "middle" | "end" | undefined;
+    /**
+     * Sibling GeomText/GeomLabel AABBs in the focus panel. Guides hard-gap
+     * through boxes the line intersects so labels stay readable (#1207).
+     */
+    crosshairGapObstacles?: readonly CrosshairGapBox[];
     selectedAnchors?: readonly PresentationAnchor[];
     emphasizedAnchors?: readonly PresentationAnchor[];
     brushRect?: BrushRect | null;
@@ -82,8 +89,10 @@
       : null,
   );
 
-  // Gap guides at the hover ring/box so they never bisect the focused mark.
-  // Rect chrome keeps continuous guides (`gapRadius = 0`).
+  // Gap guides at the hover ring/box and any intersecting sibling glyph boxes
+  // so they never bisect the focused mark or nearby labels (#1207).
+  // Rect chrome keeps continuous guides at the focus (`gapRadius = 0`) but
+  // still holes through painted text boxes.
   const crosshairGap = $derived(
     hoverChrome === "ring"
       ? HOVER_CROSSHAIR_GAP_RADIUS
@@ -93,21 +102,23 @@
   );
   const verticalCrosshair = $derived(
     inspection !== null && inspectionPanel !== null
-      ? gappedCrosshairSegments(
+      ? gappedCrosshairSegmentsWithObstacles(
           "vertical",
           inspection.focus.anchor,
           inspectionPanel,
           crosshairGap,
+          crosshairGapObstacles,
         )
       : [],
   );
   const horizontalCrosshair = $derived(
     inspection !== null && inspectionPanel !== null
-      ? gappedCrosshairSegments(
+      ? gappedCrosshairSegmentsWithObstacles(
           "horizontal",
           inspection.focus.anchor,
           inspectionPanel,
           crosshairGap,
+          crosshairGapObstacles,
         )
       : [],
   );

--- a/packages/svelte/src/lib/scene/SceneOverlays.svelte
+++ b/packages/svelte/src/lib/scene/SceneOverlays.svelte
@@ -19,6 +19,7 @@
   } from "../selection/selection.js";
   import InteractionOverlay from "./InteractionOverlay.svelte";
   import { shouldShowInertSelectionOverlay } from "../interaction/capability.js";
+  import type { CrosshairGapBox } from "./geometry.js";
   type Panel = {
     readonly x: number;
     readonly y: number;
@@ -44,6 +45,7 @@
     hoverBoxWidth,
     hoverBoxHeight,
     hoverBoxAnchor,
+    crosshairGapObstacles = [],
     selectedAnchors = [],
     emphasizedAnchors = [],
     brushRect = null,
@@ -67,6 +69,8 @@
     hoverBoxWidth?: number | undefined;
     hoverBoxHeight?: number | undefined;
     hoverBoxAnchor?: "start" | "middle" | "end" | undefined;
+    /** Sibling glyph AABBs for crosshair hard-gaps (#1207). */
+    crosshairGapObstacles?: readonly CrosshairGapBox[];
     selectedAnchors?: readonly PresentationAnchor[];
     emphasizedAnchors?: readonly PresentationAnchor[];
     brushRect?: BrushRect | null;
@@ -95,6 +99,7 @@
     {hoverBoxWidth}
     {hoverBoxHeight}
     {hoverBoxAnchor}
+    {crosshairGapObstacles}
     {selectedAnchors}
     {emphasizedAnchors}
     {brushRect}

--- a/packages/svelte/src/lib/scene/geometry.ts
+++ b/packages/svelte/src/lib/scene/geometry.ts
@@ -148,6 +148,125 @@ export type CrosshairSegment = {
   readonly y2: number;
 };
 
+/** Axis-aligned box in plot px (same space as focus anchors / glyphHoverBox). */
+export type CrosshairGapBox = GlyphHoverBox;
+
+/**
+ * Extra pad when cutting a guide through a glyph AABB so stroke does not
+ * kiss the label edge. Kept separate from measured boxWidths (which already
+ * include geom_label boxPadding).
+ */
+export const CROSSHAIR_BOX_GAP_PAD = 2;
+
+type GapInterval = { lo: number; hi: number };
+
+function mergeGapIntervals(intervals: GapInterval[]): GapInterval[] {
+  if (intervals.length === 0) return [];
+  const sorted = intervals.toSorted((a, b) => a.lo - b.lo);
+  const out: GapInterval[] = [{ lo: sorted[0]!.lo, hi: sorted[0]!.hi }];
+  for (let i = 1; i < sorted.length; i++) {
+    const cur = sorted[i]!;
+    const last = out.at(-1)!;
+    if (cur.lo <= last.hi) {
+      last.hi = Math.max(last.hi, cur.hi);
+    } else {
+      out.push({ lo: cur.lo, hi: cur.hi });
+    }
+  }
+  return out;
+}
+
+/**
+ * Solid segments along [rangeLo, rangeHi] with holes at each merged gap.
+ * Uses strict endpoints (gap starts exactly at rangeLo drop the leading piece)
+ * to match the historical `gapTop > panel.y` comparison.
+ */
+function segmentsAroundGaps(
+  rangeLo: number,
+  rangeHi: number,
+  gaps: readonly GapInterval[],
+  project: (a: number, b: number) => CrosshairSegment,
+): CrosshairSegment[] {
+  if (!(rangeHi > rangeLo)) return [];
+  const clamped: GapInterval[] = [];
+  for (const gap of gaps) {
+    const lo = Math.max(gap.lo, rangeLo);
+    const hi = Math.min(gap.hi, rangeHi);
+    if (hi > lo) clamped.push({ lo, hi });
+  }
+  const merged = mergeGapIntervals(clamped);
+  if (merged.length === 0) return [project(rangeLo, rangeHi)];
+
+  const segments: CrosshairSegment[] = [];
+  let cursor = rangeLo;
+  for (const gap of merged) {
+    if (gap.lo > cursor) {
+      segments.push(project(cursor, gap.lo));
+    }
+    cursor = Math.max(cursor, gap.hi);
+  }
+  if (cursor < rangeHi) {
+    segments.push(project(cursor, rangeHi));
+  }
+  return segments;
+}
+
+/**
+ * Panel-spanning axis guide with a circular focus gap and rectangular holes
+ * for any obstacle boxes the guide line intersects (sibling GeomText labels).
+ * `gapRadius <= 0` still applies box obstacles (rect hover chrome path).
+ * Empty obstacles degrades to the focus-only path.
+ */
+export function gappedCrosshairSegmentsWithObstacles(
+  axis: "vertical" | "horizontal",
+  focus: { readonly x: number; readonly y: number },
+  panel: PanelBounds,
+  gapRadius: number,
+  obstacles: readonly CrosshairGapBox[],
+): readonly CrosshairSegment[] {
+  const panelBottom = panel.y + panel.height;
+  const panelRight = panel.x + panel.width;
+  const pad = CROSSHAIR_BOX_GAP_PAD;
+  const gaps: GapInterval[] = [];
+
+  if (gapRadius > 0) {
+    if (axis === "vertical") {
+      gaps.push({ lo: focus.y - gapRadius, hi: focus.y + gapRadius });
+    } else {
+      gaps.push({ lo: focus.x - gapRadius, hi: focus.x + gapRadius });
+    }
+  }
+
+  for (const box of obstacles) {
+    const bx0 = box.x - pad;
+    const by0 = box.y - pad;
+    const bx1 = box.x + box.width + pad;
+    const by1 = box.y + box.height + pad;
+    if (axis === "vertical") {
+      if (focus.x >= bx0 && focus.x <= bx1) {
+        gaps.push({ lo: by0, hi: by1 });
+      }
+    } else if (focus.y >= by0 && focus.y <= by1) {
+      gaps.push({ lo: bx0, hi: bx1 });
+    }
+  }
+
+  if (axis === "vertical") {
+    return segmentsAroundGaps(panel.y, panelBottom, gaps, (y1, y2) => ({
+      x1: focus.x,
+      y1,
+      x2: focus.x,
+      y2,
+    }));
+  }
+  return segmentsAroundGaps(panel.x, panelRight, gaps, (x1, x2) => ({
+    x1,
+    y1: focus.y,
+    x2,
+    y2: focus.y,
+  }));
+}
+
 /**
  * Panel-spanning axis guide broken into segments that leave a circular gap
  * around the focus anchor. `gapRadius <= 0` yields one continuous segment
@@ -159,45 +278,85 @@ export function gappedCrosshairSegments(
   panel: PanelBounds,
   gapRadius: number,
 ): readonly CrosshairSegment[] {
-  const panelBottom = panel.y + panel.height;
-  const panelRight = panel.x + panel.width;
+  return gappedCrosshairSegmentsWithObstacles(axis, focus, panel, gapRadius, []);
+}
 
-  if (!(gapRadius > 0)) {
-    return axis === "vertical"
-      ? [{ x1: focus.x, y1: panel.y, x2: focus.x, y2: panelBottom }]
-      : [{ x1: panel.x, y1: focus.y, x2: panelRight, y2: focus.y }];
-  }
+/**
+ * Minimal batch surface for crosshair obstacle collection.
+ * Structural (not core Scene types) so geometry stays free of @ggsvelte/core.
+ * Wide enough to accept GeometryBatch[] (rects may carry a different `anchor`
+ * vocabulary — only `kind === "glyphs"` is read).
+ * Walk scene batches, not the candidate store: uninspectable layers (#1065)
+ * still paint and still need gaps even when they never become targets.
+ */
+export type GlyphObstacleBatch = {
+  readonly kind: string;
+  readonly panelIndex: number;
+  /** Interleaved panel-local x,y (dx/dy already applied). Present on glyphs. */
+  readonly positions?: ArrayLike<number>;
+  readonly boxWidths?: ArrayLike<number>;
+  readonly boxHeights?: ArrayLike<number>;
+  /** Glyph text-anchor; other batch kinds may use different vocabularies. */
+  readonly anchor?: string;
+};
 
-  const segments: CrosshairSegment[] = [];
-  if (axis === "vertical") {
-    const gapTop = focus.y - gapRadius;
-    const gapBottom = focus.y + gapRadius;
-    if (gapTop > panel.y) {
-      segments.push({ x1: focus.x, y1: panel.y, x2: focus.x, y2: gapTop });
+/** Minimal panel surface: id + plot origin (matches scene.panels[i]). */
+export type GlyphObstaclePanel = {
+  readonly id: string;
+  readonly x: number;
+  readonly y: number;
+};
+
+function glyphTextAnchor(anchor: string | undefined): "start" | "middle" | "end" | undefined {
+  if (anchor === "start" || anchor === "middle" || anchor === "end") return anchor;
+  return undefined;
+}
+
+/**
+ * Plot-space glyph AABBs for every measured text/label in `panelId`.
+ * Positions are panel-local; add panel origin so boxes share coordinates with
+ * `inspection.focus.anchor` / viewport panel bounds (viewport is built from
+ * the same scene panels).
+ */
+export function crosshairGlyphObstacles(
+  batches: readonly GlyphObstacleBatch[],
+  panels: readonly GlyphObstaclePanel[],
+  panelId: string,
+): CrosshairGapBox[] {
+  const boxes: CrosshairGapBox[] = [];
+  for (const batch of batches) {
+    if (batch.kind !== "glyphs") continue;
+    const positions = batch.positions;
+    if (positions === undefined) continue;
+    const panel = panels[batch.panelIndex];
+    if (panel === undefined || panel.id !== panelId) continue;
+    const textAnchor = glyphTextAnchor(batch.anchor);
+    const count = Math.floor(positions.length / 2);
+    for (let i = 0; i < count; i++) {
+      const extents = glyphExtentsFromBatch(
+        {
+          kind: batch.kind,
+          boxWidths: batch.boxWidths,
+          boxHeights: batch.boxHeights,
+          anchor: textAnchor,
+        },
+        i,
+      );
+      if (extents === null) continue;
+      const lx = positions[2 * i];
+      const ly = positions[2 * i + 1];
+      if (lx === undefined || ly === undefined) continue;
+      boxes.push(
+        glyphHoverBox(
+          { x: panel.x + lx, y: panel.y + ly },
+          {
+            width: extents.width,
+            height: extents.height,
+            textAnchor: extents.textAnchor,
+          },
+        ),
+      );
     }
-    if (gapBottom < panelBottom) {
-      segments.push({
-        x1: focus.x,
-        y1: gapBottom,
-        x2: focus.x,
-        y2: panelBottom,
-      });
-    }
-    return segments;
   }
-
-  const gapLeft = focus.x - gapRadius;
-  const gapRight = focus.x + gapRadius;
-  if (gapLeft > panel.x) {
-    segments.push({ x1: panel.x, y1: focus.y, x2: gapLeft, y2: focus.y });
-  }
-  if (gapRight < panelRight) {
-    segments.push({
-      x1: gapRight,
-      y1: focus.y,
-      x2: panelRight,
-      y2: focus.y,
-    });
-  }
-  return segments;
+  return boxes;
 }

--- a/packages/svelte/tests/scene/geometry.test.ts
+++ b/packages/svelte/tests/scene/geometry.test.ts
@@ -2,9 +2,12 @@ import { describe, expect, it } from "vitest";
 
 import {
   clamp,
+  CROSSHAIR_BOX_GAP_PAD,
   crosshairGapForBox,
+  crosshairGlyphObstacles,
   frozenZoomDomains,
   gappedCrosshairSegments,
+  gappedCrosshairSegmentsWithObstacles,
   glyphExtentsFromBatch,
   glyphHoverBox,
   HOVER_CROSSHAIR_GAP_RADIUS,
@@ -143,6 +146,190 @@ describe("gappedCrosshairSegments", () => {
         }
       }
     }
+  });
+
+  // Interval rewrite pin: strict `gapTop > panel.y` drops the leading segment when
+  // the hole starts exactly at the panel edge (not when it starts one px below).
+  it("drops the leading segment when the focus gap starts exactly at the panel edge", () => {
+    const edgeFocus = { x: 120, y: panel.y + HOVER_CROSSHAIR_GAP_RADIUS };
+    const segs = gappedCrosshairSegments("vertical", edgeFocus, panel, HOVER_CROSSHAIR_GAP_RADIUS);
+    expect(segs).toHaveLength(1);
+    expect(segs[0]).toEqual({
+      x1: 120,
+      y1: edgeFocus.y + HOVER_CROSSHAIR_GAP_RADIUS,
+      x2: 120,
+      y2: 180,
+    });
+  });
+});
+
+describe("gappedCrosshairSegmentsWithObstacles", () => {
+  const panel = { x: 40, y: 20, width: 200, height: 160 };
+  const focus = { x: 120, y: 100 };
+
+  it("matches the focus-only path when obstacles are empty", () => {
+    expect(
+      gappedCrosshairSegmentsWithObstacles(
+        "vertical",
+        focus,
+        panel,
+        HOVER_CROSSHAIR_GAP_RADIUS,
+        [],
+      ),
+    ).toEqual(gappedCrosshairSegments("vertical", focus, panel, HOVER_CROSSHAIR_GAP_RADIUS));
+  });
+
+  it("cuts a vertical guide around a sibling label box above the focus", () => {
+    // Label offset above the point (dy < 0); guide still at focus.x.
+    const label = { x: 100, y: 40, width: 40, height: 14 };
+    const segs = gappedCrosshairSegmentsWithObstacles(
+      "vertical",
+      focus,
+      panel,
+      HOVER_CROSSHAIR_GAP_RADIUS,
+      [label],
+    );
+    const pad = CROSSHAIR_BOX_GAP_PAD;
+    // Hole spans the padded label y-range; no segment may cover y in that range.
+    const holeLo = label.y - pad;
+    const holeHi = label.y + label.height + pad;
+    for (const seg of segs) {
+      const lo = Math.min(seg.y1, seg.y2);
+      const hi = Math.max(seg.y1, seg.y2);
+      const overlaps = lo < holeHi && hi > holeLo;
+      expect(overlaps).toBe(false);
+    }
+    // Focus gap still present.
+    for (const seg of segs) {
+      const lo = Math.min(seg.y1, seg.y2);
+      const hi = Math.max(seg.y1, seg.y2);
+      expect(
+        lo >= focus.y + HOVER_CROSSHAIR_GAP_RADIUS || hi <= focus.y - HOVER_CROSSHAIR_GAP_RADIUS,
+      ).toBe(true);
+    }
+    // Both guides remain (label hole + focus hole → at least 3 vertical pieces when interior).
+    expect(segs.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("ignores boxes the guide line does not intersect", () => {
+    const far = { x: 200, y: 40, width: 30, height: 12 };
+    expect(
+      gappedCrosshairSegmentsWithObstacles("vertical", focus, panel, HOVER_CROSSHAIR_GAP_RADIUS, [
+        far,
+      ]),
+    ).toEqual(gappedCrosshairSegments("vertical", focus, panel, HOVER_CROSSHAIR_GAP_RADIUS));
+  });
+
+  it("merges overlapping obstacle holes into one gap", () => {
+    const a = { x: 110, y: 30, width: 20, height: 20 };
+    const b = { x: 105, y: 40, width: 30, height: 20 }; // overlaps a in y
+    const segs = gappedCrosshairSegmentsWithObstacles("vertical", focus, panel, 0, [a, b]);
+    // gapRadius 0: only obstacle holes. Merged hole → two segments (above + below).
+    expect(segs).toHaveLength(2);
+    expect(segs[0]!.y1).toBe(panel.y);
+    expect(segs[1]!.y2).toBe(panel.y + panel.height);
+  });
+
+  it("gaps a horizontal guide around an intersecting box", () => {
+    const label = { x: 150, y: 90, width: 40, height: 20 };
+    const segs = gappedCrosshairSegmentsWithObstacles(
+      "horizontal",
+      focus,
+      panel,
+      HOVER_CROSSHAIR_GAP_RADIUS,
+      [label],
+    );
+    const pad = CROSSHAIR_BOX_GAP_PAD;
+    const holeLo = label.x - pad;
+    const holeHi = label.x + label.width + pad;
+    for (const seg of segs) {
+      const lo = Math.min(seg.x1, seg.x2);
+      const hi = Math.max(seg.x1, seg.x2);
+      expect(lo < holeHi && hi > holeLo).toBe(false);
+    }
+  });
+
+  it("union of focus box diagonal gap and the focus glyph obstacle is a no-op widen", () => {
+    // hoverChrome === "box": crosshairGapForBox already clears the half-diagonal;
+    // the same glyph also lands in the obstacle list. Union must not shrink the hole.
+    const box = { x: focus.x - 20, y: focus.y - 8, width: 40, height: 16 };
+    const gap = crosshairGapForBox(box.width, box.height);
+    const withObstacles = gappedCrosshairSegmentsWithObstacles("vertical", focus, panel, gap, [
+      box,
+    ]);
+    const focusOnly = gappedCrosshairSegments("vertical", focus, panel, gap);
+    // Same outer endpoints (panel edge → hole edge).
+    expect(withObstacles[0]?.y1).toBe(focusOnly[0]?.y1);
+    expect(withObstacles[withObstacles.length - 1]?.y2).toBe(focusOnly[focusOnly.length - 1]?.y2);
+    // Obstacle pad is smaller than the diagonal gap, so segment count matches.
+    expect(withObstacles).toHaveLength(focusOnly.length);
+  });
+});
+
+describe("crosshairGlyphObstacles", () => {
+  const panels = [
+    { id: "p0", x: 10, y: 20 },
+    { id: "p1", x: 300, y: 20 },
+  ];
+
+  it("converts panel-local glyph positions to plot-space boxes for the focus panel only", () => {
+    const batches = [
+      {
+        kind: "glyphs",
+        panelIndex: 0,
+        positions: new Float32Array([50, 30, 80, 60]),
+        boxWidths: new Float32Array([40, 20]),
+        boxHeights: new Float32Array([12, 10]),
+        anchor: "middle" as const,
+      },
+      {
+        kind: "glyphs",
+        panelIndex: 1,
+        positions: new Float32Array([5, 5]),
+        boxWidths: new Float32Array([10]),
+        boxHeights: new Float32Array([8]),
+        anchor: "middle" as const,
+      },
+      {
+        kind: "points",
+        panelIndex: 0,
+        positions: new Float32Array([1, 2]),
+      },
+    ];
+    const boxes = crosshairGlyphObstacles(batches, panels, "p0");
+    expect(boxes).toHaveLength(2);
+    expect(boxes[0]).toEqual(glyphHoverBox({ x: 10 + 50, y: 20 + 30 }, { width: 40, height: 12 }));
+    expect(boxes[1]).toEqual(glyphHoverBox({ x: 10 + 80, y: 20 + 60 }, { width: 20, height: 10 }));
+  });
+
+  it("skips glyphs without measured extents", () => {
+    const batches = [
+      {
+        kind: "glyphs",
+        panelIndex: 0,
+        positions: new Float32Array([10, 10]),
+        // no boxWidths / boxHeights
+      },
+    ];
+    expect(crosshairGlyphObstacles(batches, panels, "p0")).toEqual([]);
+  });
+
+  it("includes uninspectable-capable glyphs via scene walk (not candidate store)", () => {
+    // Doc contract: collector must see every painted glyph batch. Candidate store
+    // skips uninspectable layers (#1065); scene walk must not.
+    const batches = [
+      {
+        kind: "glyphs",
+        panelIndex: 0,
+        positions: new Float32Array([0, 0]),
+        boxWidths: new Float32Array([24]),
+        boxHeights: new Float32Array([10]),
+        anchor: "start" as const,
+      },
+    ];
+    expect(crosshairGlyphObstacles(batches, panels, "p0")).toEqual([
+      glyphHoverBox({ x: 10, y: 20 }, { width: 24, height: 10, textAnchor: "start" }),
+    ]);
   });
 });
 

--- a/packages/svelte/tests/scene/geometry.test.ts
+++ b/packages/svelte/tests/scene/geometry.test.ts
@@ -226,8 +226,8 @@ describe("gappedCrosshairSegmentsWithObstacles", () => {
     const segs = gappedCrosshairSegmentsWithObstacles("vertical", focus, panel, 0, [a, b]);
     // gapRadius 0: only obstacle holes. Merged hole → two segments (above + below).
     expect(segs).toHaveLength(2);
-    expect(segs[0]!.y1).toBe(panel.y);
-    expect(segs[1]!.y2).toBe(panel.y + panel.height);
+    expect(segs[0]?.y1).toBe(panel.y);
+    expect(segs[1]?.y2).toBe(panel.y + panel.height);
   });
 
   it("gaps a horizontal guide around an intersecting box", () => {
@@ -260,7 +260,7 @@ describe("gappedCrosshairSegmentsWithObstacles", () => {
     const focusOnly = gappedCrosshairSegments("vertical", focus, panel, gap);
     // Same outer endpoints (panel edge → hole edge).
     expect(withObstacles[0]?.y1).toBe(focusOnly[0]?.y1);
-    expect(withObstacles[withObstacles.length - 1]?.y2).toBe(focusOnly[focusOnly.length - 1]?.y2);
+    expect(withObstacles.at(-1)?.y2).toBe(focusOnly.at(-1)?.y2);
     // Obstacle pad is smaller than the diagonal gap, so segment count matches.
     expect(withObstacles).toHaveLength(focusOnly.length);
   });

--- a/packages/svelte/tests/scene/interaction-overlay-gaps.test.ts
+++ b/packages/svelte/tests/scene/interaction-overlay-gaps.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import InteractionOverlay from "../../src/lib/scene/InteractionOverlay.svelte";
+import { CROSSHAIR_BOX_GAP_PAD, HOVER_CROSSHAIR_GAP_RADIUS } from "../../src/lib/scene/geometry.js";
+import { render } from "../helpers/render.js";
+
+function emptyDatum(anchor: { x: number; y: number }) {
+  return {
+    key: "a",
+    row: { id: "a" },
+    sourceKeys: ["a"] as const,
+    lineageCount: 1,
+    layerIndex: 0,
+    panelId: "p0",
+    fields: [],
+    anchor,
+  };
+}
+
+describe("InteractionOverlay crosshair glyph gaps (#1207)", () => {
+  it("hard-gaps vertical guides through sibling label boxes", () => {
+    const focus = { x: 120, y: 100 };
+    const panel = { x: 40, y: 20, width: 200, height: 160 };
+    const label = { x: 100, y: 40, width: 40, height: 14 };
+    const inspection = {
+      type: "inspect" as const,
+      phase: "change" as const,
+      state: "transient" as const,
+      source: "keyboard" as const,
+      panelId: "p0",
+      mode: "xy" as const,
+      focus: emptyDatum(focus),
+      members: [emptyDatum(focus)] as const,
+    };
+
+    const { container } = render(InteractionOverlay, {
+      width: 280,
+      height: 220,
+      interactive: true,
+      inspection,
+      inspectionPanel: panel,
+      hoverChrome: "ring",
+      crosshairGapObstacles: [label],
+    });
+
+    const vertical = [...container.querySelectorAll<SVGLineElement>(".gg-crosshair")].filter(
+      (line) => Number(line.getAttribute("x1")) === Number(line.getAttribute("x2")),
+    );
+    expect(vertical.length).toBeGreaterThanOrEqual(3);
+
+    const pad = CROSSHAIR_BOX_GAP_PAD;
+    const holeLo = label.y - pad;
+    const holeHi = label.y + label.height + pad;
+    for (const line of vertical) {
+      const y1 = Number(line.getAttribute("y1"));
+      const y2 = Number(line.getAttribute("y2"));
+      const lo = Math.min(y1, y2);
+      const hi = Math.max(y1, y2);
+      expect(lo < holeHi && hi > holeLo).toBe(false);
+    }
+
+    // Focus ring gap still present.
+    for (const line of vertical) {
+      const y1 = Number(line.getAttribute("y1"));
+      const y2 = Number(line.getAttribute("y2"));
+      const lo = Math.min(y1, y2);
+      const hi = Math.max(y1, y2);
+      const coversFocus =
+        lo < focus.y + HOVER_CROSSHAIR_GAP_RADIUS && hi > focus.y - HOVER_CROSSHAIR_GAP_RADIUS;
+      expect(coversFocus).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Hard-gap `x`/`y`/`xy` inspect guides through measured sibling `GeomText`/`GeomLabel` AABBs in the focus panel (#1207)
- Pure multi-interval segmenter in `geometry.ts` (focus ring/box hole ∪ intersecting glyph boxes); existing `gappedCrosshairSegments` is a no-obstacle wrapper
- Obstacle collection walks **scene batches** (not the candidate store) so uninspectable label layers still clear the guide (#1065)
- `$derived` obstacles in plot-engine (depends on scene + panel id only); wired through SceneOverlays → InteractionOverlay

**Not translucent fade.** Forced-colors flattens opacity tricks; geometric holes survive every color mode.

**Out of scope:** axis tick/title labels drawn by the overlay itself still sit under the perpendicular guide (same pre-existing chrome).

## Claude plan review

Approve with changes — adopted: panel **id** matching, scene walk, pure collector + `$derived`, edge-gap regression test, no VR/browser font path, focus-box ∪ obstacle no-op case.

## Test plan

- [x] `packages/svelte` chromium: `tests/scene/geometry.test.ts` (25)
- [x] `packages/svelte` chromium: `tests/scene/interaction-overlay-gaps.test.ts` (1)
- [x] `packages/svelte` chromium: presentation + scene-overlays smoke
- [x] `bun run check` in packages/svelte (0 errors)
- [ ] CI on PR

Closes #1207
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1249" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->