### PR TITLE
test(svelte): cover interaction normalize diagnostics and empty inspect frame

### DIFF
--- a/packages/svelte/tests/inspection/inspection-frame.test.ts
+++ b/packages/svelte/tests/inspection/inspection-frame.test.ts
@@ -219,6 +219,24 @@ describe("buildQueuedInspectFrame", () => {
     });
   });
 
+  it("clears the queue when nearest and fallback both miss", () => {
+    let fallbackCalls = 0;
+    const built = buildQueuedInspectFrame({
+      match: null,
+      source: "keyboard",
+      epoch: 3,
+      fallbackCandidate: () => {
+        fallbackCalls += 1;
+        return null;
+      },
+    });
+    expect(fallbackCalls).toBe(1);
+    expect(built).toEqual({
+      queued: { candidate: null, source: "keyboard" },
+      candidate: null,
+    });
+  });
+
   it("builds queued mode + candidate from match without calling fallback", () => {
     let fallbackCalls = 0;
     const built = buildQueuedInspectFrame({

--- a/packages/svelte/tests/interaction/normalize-interaction-config.test.ts
+++ b/packages/svelte/tests/interaction/normalize-interaction-config.test.ts
@@ -143,4 +143,43 @@ describe("interaction capability normalization", () => {
       expect(entry.code).toBe(key);
     }
   });
+
+  it("diagnoses non-finite or negative inspect maxDistance and drops inspect", () => {
+    for (const maxDistance of [Number.NaN, -1, Number.POSITIVE_INFINITY] as const) {
+      const resolved = normalizeInteractionConfig({ inspect: { maxDistance } });
+      expect(resolved.inspect).toBeNull();
+      expect(resolved.diagnostics).toContainEqual(
+        expect.objectContaining({
+          code: "INTERACTION_INVALID_MAX_DISTANCE",
+          actual: maxDistance,
+        }),
+      );
+    }
+    // Finite non-negative keeps inspect (including zero).
+    expect(normalizeInteractionConfig({ inspect: { maxDistance: 0 } }).inspect).toMatchObject({
+      maxDistance: 0,
+    });
+  });
+
+  it("diagnoses keyless point selection and unavailable tools", () => {
+    const point = normalizeInteractionConfig({ select: "point" }, { hasKey: false });
+    expect(point.select).toMatchObject({ type: "point" });
+    expect(point.diagnostics).toContainEqual(
+      expect.objectContaining({ code: "INTERACTION_POINT_REQUIRES_KEY" }),
+    );
+
+    // Point-only available tools; requesting zoom-area falls back to point.
+    const tool = normalizeInteractionConfig(
+      { select: "point", tool: "zoom-area" },
+      { hasKey: true },
+    );
+    expect(tool.availableTools).toEqual(["point"]);
+    expect(tool.initialTool).toBe("point");
+    expect(tool.diagnostics).toContainEqual(
+      expect.objectContaining({
+        code: "INTERACTION_TOOL_UNAVAILABLE",
+        actual: "zoom-area",
+      }),
+    );
+  });
 });


### PR DESCRIPTION
## Summary

- `normalizeInteractionConfig`: invalid/negative `maxDistance` diagnostic + drop inspect; keyless `select: "point"` requires key; unavailable `tool` falls back and diagnoses.
- `buildQueuedInspectFrame`: when nearest and fallback both miss, clear the queue (null candidate).

## Coverage (browser, focused)

| File | Before | After |
|------|--------|-------|
| `normalize-interaction-config.ts` | ~92.7% lines | **100%** lines |
| `frame.ts` | ~93.3% lines | **100%** lines |

## Test plan

- [x] `vitest run --project chromium tests/interaction/normalize-interaction-config.test.ts tests/inspection/inspection-frame.test.ts`
- [x] `oxlint --type-aware --deny-warnings` on both test files
- [ ] CI component-svelte + build green

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1250" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->