### PR TITLE
test(svelte): cover resolver channel fallbacks, clear park, reducer edges

### DIFF
--- a/packages/svelte/tests/assembly/layout.test.ts
+++ b/packages/svelte/tests/assembly/layout.test.ts
@@ -385,6 +385,31 @@ describe("resolveClearControlLayout", () => {
       top: bottomLegend.y + Math.max(0, (bottomLegend.height - CLEAR_CONTROL_HEIGHT_PX) / 2),
     });
   });
+
+  it("returns the first scene-clamped park when every candidate collides (full-scene legend)", () => {
+    // Degenerate: legend fills the scene so under/above/left all overlap after clamp.
+    const full = {
+      scale: "color",
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 100,
+      position: "right" as const,
+      direction: "vertical" as const,
+    };
+    const layout = resolveClearControlLayout({
+      legendFocusEnabled: true,
+      pressedScale: "color",
+      legends: [full],
+      sceneWidth: 100,
+      sceneHeight: 100,
+    });
+    expect(layout).not.toBeNull();
+    // Still scene-clamped; last-resort prefers the first candidate over hide.
+    expect(layout!.left).toBeGreaterThanOrEqual(CLEAR_CONTROL_GAP_PX);
+    expect(layout!.top).toBeGreaterThanOrEqual(CLEAR_CONTROL_GAP_PX);
+    expect(layout!.top + CLEAR_CONTROL_HEIGHT_PX).toBeLessThanOrEqual(100);
+  });
 });
 
 describe("shouldRevealClearControl", () => {

--- a/packages/svelte/tests/inspection/resolve-snapshot.test.ts
+++ b/packages/svelte/tests/inspection/resolve-snapshot.test.ts
@@ -225,4 +225,67 @@ describe("inspection snapshot resolve", () => {
     expect(formatted).toMatch(/2000/);
     model.dispose();
   });
+
+  it("reads non-position candidate channels when the seed has no source row", () => {
+    // Stat bins have null rowIndex; tooltip fields must still surface size /
+    // linewidth / alpha / shape / linetype from the candidate bag, and map
+    // unknown channels to null.
+    const data = [
+      { date: "2000-05-01", y: 10, s: 1 },
+      { date: "2000-05-15", y: 20, s: 2 },
+      { date: "2000-06-01", y: 30, s: 3 },
+      { date: "2000-06-15", y: 40, s: 4 },
+    ];
+    const model = runPipeline(
+      gg(data, aes({ x: "date", y: "y", size: "s" }))
+        .geomPoint({ stat: "summary_bin", fun: "median", bins: 4 })
+        .spec(),
+      { width: 400, height: 300 },
+    );
+    const seed = model.candidates.candidate(0)!;
+    expect(seed.rowIndex).toBeNull();
+    // Publish every non-position channel the candidateValue switch handles.
+    const seedWithChannels = {
+      ...seed,
+      sizeValue: 4,
+      linewidthValue: 1.5,
+      alphaValue: 0.4,
+      shapeValue: "circle",
+      linetypeValue: "dashed",
+    };
+    // Force layerFields to include each channel (plus an unknown one for null).
+    Object.defineProperty(model, "layerFields", {
+      value: [
+        [
+          { channel: "size", field: "s" },
+          { channel: "linewidth", field: "lw" },
+          { channel: "alpha", field: "a" },
+          { channel: "shape", field: "sh" },
+          { channel: "linetype", field: "lt" },
+          { channel: "fill", field: "f" },
+        ],
+      ],
+    });
+    const inspection = resolveInspection({
+      model,
+      seed: seedWithChannels,
+      mode: "exact",
+      state: "transient",
+      source: "pointer",
+      keyOf: () => null,
+    });
+    expect(inspection.focus.row).toBeNull();
+    const byChannel = Object.fromEntries(
+      inspection.focus.fields.map((field) => [field.channel, field.value]),
+    );
+    expect(byChannel).toMatchObject({
+      size: 4,
+      linewidth: 1.5,
+      alpha: 0.4,
+      shape: "circle",
+      linetype: "dashed",
+      fill: null,
+    });
+    model.dispose();
+  });
 });

--- a/packages/svelte/tests/interaction/unit.test.ts
+++ b/packages/svelte/tests/interaction/unit.test.ts
@@ -161,4 +161,41 @@ describe("chart-local interaction reducer", () => {
     // Inspect frames never bump reducer revision.
     expect(reducer.state.revision).toBe(rev);
   });
+
+  it("cancel-area idles a drag and is a no-op when already idle", () => {
+    const reducer = createInteractionReducer();
+    reducer.dispatch({ type: "set-tool", tool: "select-area" });
+    reducer.dispatch({
+      type: "begin-area",
+      point: { x: 5, y: 5 },
+      panelId: "panel:all",
+    });
+    const epoch = reducer.state.epoch;
+    reducer.dispatch({ type: "cancel-area" });
+    expect(reducer.state.area.kind).toBe("idle");
+    expect(reducer.state.epoch).toBe(epoch + 1);
+    // Second cancel while idle does not bump epoch again.
+    reducer.dispatch({ type: "cancel-area" });
+    expect(reducer.state.epoch).toBe(epoch + 1);
+  });
+
+  it("queuePointer uses queueMicrotask when no scheduleFrame is supplied", async () => {
+    const seen: number[] = [];
+    const reducer = createInteractionReducer({
+      onPointerFrame: (action) => {
+        if (action.type === "inspect" && action.candidate !== null) {
+          seen.push(action.candidate.id);
+        }
+      },
+    });
+    reducer.queuePointer({
+      type: "inspect",
+      candidate: candidate(9),
+      source: "pointer",
+    });
+    expect(seen).toEqual([]);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(seen).toEqual([9]);
+  });
 });


### PR DESCRIPTION
## Summary

- `resolveInspection`: when a seed has no source row, non-position field values come from the candidate bag (size / linewidth / alpha / shape / linetype); unknown channels stay null.
- `resolveClearControlLayout`: full-scene legend still returns a scene-clamped park (last-resort first candidate) instead of hiding Clear.
- Interaction reducer: `cancel-area` while dragging vs idle; `queuePointer` default `queueMicrotask` schedule when no `scheduleFrame` is provided.

## Coverage (browser, focused)

| File | Before | After |
|------|--------|-------|
| `resolver.ts` | ~87% lines | **100%** lines |
| `layout.ts` | ~97.8% lines | **100%** lines |
| `reducer.ts` | ~96% lines | **100%** lines |

## Test plan

- [x] `vitest run --project chromium tests/inspection/resolve-snapshot.test.ts tests/assembly/layout.test.ts tests/interaction/unit.test.ts`
- [x] `oxlint --type-aware --deny-warnings` on the three test files
- [ ] CI component-svelte + build green

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1252" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->