### PR TITLE
feat(svelte): default row identity without GGPlot key

### DIFF
--- a/.changeset/default-row-identity.md
+++ b/.changeset/default-row-identity.md
@@ -1,0 +1,15 @@
+---
+"@ggsvelte/svelte": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+feat: default row identity without requiring GGPlot `key`
+
+Interaction identity resolves to an `id` column when present, otherwise
+the row index. Ordinary charts omit `key`; the prop remains an optional
+override for non-`id` natural keys. Legend focus and point selection no
+longer require an explicit key for the default path.
+
+Migration: none required. Remove redundant `key="id"` from charts whose
+rows already expose an `id` field.

--- a/apps/docs/src/lib/components/GrammarDemoPlot.svelte
+++ b/apps/docs/src/lib/components/GrammarDemoPlot.svelte
@@ -33,14 +33,13 @@
 
 <!--
   mode "xy": full crosshair on two continuous axes (not path auto "x").
-  GuideLegend focus needs stable row keys (`id` on palmerPenguins).
+  GuideLegend focus uses default row identity (`id` on palmerPenguins).
   GeomJitter + alpha: 333 points stack on integer measurements; seeded jitter
   (default 0.4·resolution) and alpha spread the cloud. degree 1 loess stays
   cheap when remounting.
 -->
 <GGPlot
   data={palmerPenguins}
-  key="id"
   aes={{
     x: "flipperLengthMm",
     y: "bodyMassG",

--- a/apps/docs/src/lib/components/InteractionDemo.svelte
+++ b/apps/docs/src/lib/components/InteractionDemo.svelte
@@ -27,9 +27,9 @@
     x: "interaction-demo-x",
     y: "interaction-demo-y",
   } as const;
-  // Default row identity (id column) yields string keys; type as PropertyKey
-  // so omitting GGPlot `key` still typechecks handlers.
-  const interaction = createPlotInteraction<PropertyKey>();
+  // Default row identity (id column) yields string keys; widen to string|number
+  // so omitting GGPlot `key` still typechecks against the engine PublicKey.
+  const interaction = createPlotInteraction<string | number>();
   const emphasized = $derived(interaction.emphasized(scope));
   // Interval brush stores keys on intervals(), not selected().
   const selectedCount = $derived(
@@ -65,7 +65,7 @@ ${closeScript}
     phase: "change" | "clear";
     state?: string;
     label?: string;
-    keys?: readonly PropertyKey[];
+    keys?: readonly (string | number)[];
   }): void {
     status =
       event.phase === "clear"

--- a/apps/docs/src/lib/components/InteractionDemo.svelte
+++ b/apps/docs/src/lib/components/InteractionDemo.svelte
@@ -50,7 +50,6 @@ ${closeScript}
   {interaction}
   interactionScope={scope}
   data={rows}
-  key="id"
   aes={{ x: "period", y: "value", color: "series" }}
   select={{ type: "interval", mode: "xy" }}
   zoom={{ mode: "x" }}
@@ -87,7 +86,6 @@ ${closeScript}
       data={rows}
       aes={{ x: "period", y: "value", color: "series" }}
       layers={[{ geom: "point", params: { size: 4 } }]}
-      key="id"
       select={{ type: "interval", mode: "xy" }}
       zoom={{ mode: "x" }}
       {interaction}

--- a/apps/docs/src/lib/components/InteractionDemo.svelte
+++ b/apps/docs/src/lib/components/InteractionDemo.svelte
@@ -27,7 +27,9 @@
     x: "interaction-demo-x",
     y: "interaction-demo-y",
   } as const;
-  const interaction = createPlotInteraction<string>();
+  // Default row identity (id column) yields string keys; type as PropertyKey
+  // so omitting GGPlot `key` still typechecks handlers.
+  const interaction = createPlotInteraction<PropertyKey>();
   const emphasized = $derived(interaction.emphasized(scope));
   // Interval brush stores keys on intervals(), not selected().
   const selectedCount = $derived(
@@ -42,7 +44,7 @@
   const code = `<script lang="ts">
   import { createPlotInteraction, GeomPoint, GGPlot, GuideLegend, Inspect } from "@ggsvelte/svelte";
 
-  const interaction = createPlotInteraction<string>();
+  const interaction = createPlotInteraction();
   const scope = { keys: "rows", x: "x", y: "y" } as const;
 ${closeScript}
 
@@ -63,7 +65,7 @@ ${closeScript}
     phase: "change" | "clear";
     state?: string;
     label?: string;
-    keys?: readonly string[];
+    keys?: readonly PropertyKey[];
   }): void {
     status =
       event.phase === "clear"

--- a/apps/docs/src/lib/components/TemperaturesSpecimen.svelte
+++ b/apps/docs/src/lib/components/TemperaturesSpecimen.svelte
@@ -33,13 +33,7 @@
   const chart = TEMPERATURES_CHART;
 </script>
 
-<GGPlot
-  data={temperaturesKeyed}
-  aes={chart.aes}
-  key={chart.key}
-  {height}
-  {ariaLabel}
->
+<GGPlot data={temperaturesKeyed} aes={chart.aes} {height} {ariaLabel}>
   <Inspect mode="x" />
   {#if legendFocus}
     <GuideLegend channel="color" focus />

--- a/apps/docs/src/lib/components/ThemeSpecimenLive.svelte
+++ b/apps/docs/src/lib/components/ThemeSpecimenLive.svelte
@@ -69,7 +69,6 @@
   <GGPlot
     data={ridership}
     aes={{ x: "month", y: "riders", color: "mode" }}
-    key="id"
     {height}
     ariaLabel={`${label} theme Playfair wheat and wages`}
   >
@@ -92,7 +91,6 @@
   <GGPlot
     data={attendees}
     aes={{ x: "track", fill: "level", weight: "deaths" }}
-    key="id"
     {height}
     ariaLabel={`${label} theme Edgeworth dodged bars`}
   >
@@ -114,7 +112,6 @@
   <GGPlot
     data={generation}
     aes={{ x: "year", y: "twh", fill: "source" }}
-    key="id"
     {height}
     ariaLabel={`${label} theme Nightingale stacked area`}
   >
@@ -156,7 +153,6 @@
   <GGPlot
     data={penguins}
     aes={{ x: "flipper", y: "mass", color: "species" }}
-    key="id"
     {height}
     ariaLabel={`${label} theme penguin scatter`}
   >

--- a/apps/docs/src/lib/generated/search-index.ts
+++ b/apps/docs/src/lib/generated/search-index.ts
@@ -41737,9 +41737,13 @@ export const DOCS_SEARCH_INDEX = [
     id: "diagnostic:interaction:INTERACTION_POINT_REQUIRES_KEY",
     kind: "diagnostic",
     title: "INTERACTION_POINT_REQUIRES_KEY · interaction",
-    summary: "Durable point selection requires a stable key field or accessor.",
+    summary: "Durable point selection requires resolved row identity.",
     href: "/guide/errors#interaction-point-requires-key",
-    keywords: ["interaction", "warning", 'Pass key="id"; Pass a stable key accessor'],
+    keywords: [
+      "interaction",
+      "warning",
+      'Omit key — defaults to an id column or row index; Override with key="id" or a stable key accessor when needed',
+    ],
     exact: ["INTERACTION_POINT_REQUIRES_KEY", "interaction:INTERACTION_POINT_REQUIRES_KEY"],
   },
   {
@@ -41747,9 +41751,13 @@ export const DOCS_SEARCH_INDEX = [
     kind: "diagnostic",
     title: "INTERACTION_INTERVAL_PRESET_REQUIRES_KEY · interaction",
     summary:
-      "Coordinated interval presets (union, cross-panel) require a stable key field or accessor; without one they combine no rows.",
+      "Coordinated interval presets (union, cross-panel) require resolved row identity; without it they combine no rows.",
     href: "/guide/errors#interaction-interval-preset-requires-key",
-    keywords: ["interaction", "warning", 'Pass key="id"; Pass a stable key accessor'],
+    keywords: [
+      "interaction",
+      "warning",
+      'Omit key — defaults to an id column or row index; Override with key="id" or a stable key accessor when needed',
+    ],
     exact: [
       "INTERACTION_INTERVAL_PRESET_REQUIRES_KEY",
       "interaction:INTERACTION_INTERVAL_PRESET_REQUIRES_KEY",
@@ -41801,9 +41809,13 @@ export const DOCS_SEARCH_INDEX = [
     kind: "diagnostic",
     title: "INTERACTION_LEGEND_REQUIRES_KEY · interaction",
     summary:
-      "Legend focus requires stable row keys so encoded legend values never become identities.",
+      "Legend focus requires resolved row identity so encoded legend values never become identities.",
     href: "/guide/errors#interaction-legend-requires-key",
-    keywords: ["interaction", "warning", 'Pass key="id"; Pass a stable key accessor'],
+    keywords: [
+      "interaction",
+      "warning",
+      'Omit key — defaults to an id column or row index; Override with key="id" or a stable key accessor when needed',
+    ],
     exact: ["INTERACTION_LEGEND_REQUIRES_KEY", "interaction:INTERACTION_LEGEND_REQUIRES_KEY"],
   },
   {

--- a/apps/docs/src/lib/home-code-path.ts
+++ b/apps/docs/src/lib/home-code-path.ts
@@ -13,8 +13,9 @@
  * Interaction: GrammarDemo step 4 uses xy inspect (numeric crosshair on both
  * axes) plus GuideLegend focus. Prefer `<Inspect>` for the host capability;
  * legend focus is a host-only prop on `<GuideLegend>` (not a PortableSpec field).
- * - Svelte: `<Inspect>` / `key` on <GGPlot>, `focus` on <GuideLegend>
+ * - Svelte: `<Inspect>` child; `focus` on <GuideLegend>
  * - Builder + spec: same host children; inspect via `<Inspect>`
+ * - Row identity defaults to the `id` column on palmerPenguins (no `key` prop)
  * - JSON: agent envelope `{ interactions, spec }` still accepts legendFocus
  *   (deprecated host map until 0.20.0)
  */
@@ -26,7 +27,6 @@ const HOME_CODE_PATH_SVELTE = `<script lang="ts">
 
 <GGPlot
   data={palmerPenguins}
-  key="id"
   aes={{ x: "flipperLengthMm", y: "bodyMassG", color: "species" }}
   width={640}
   height={400}
@@ -57,7 +57,6 @@ const HOME_CODE_PATH_BUILDER = `<script lang="ts">
 
 <GGPlot
   {spec}
-  key="id"
   width={640}
   height={400}
 >

--- a/apps/docs/src/lib/theme-specimens/temperatures-chart.ts
+++ b/apps/docs/src/lib/theme-specimens/temperatures-chart.ts
@@ -5,7 +5,6 @@
 import { MONTH_BREAKS } from "./catalog.js";
 
 export const TEMPERATURES_CHART = {
-  key: "id",
   aes: { x: "month", y: "temp", color: "city" },
   labs: {
     title: "Playfair stocks, bread & exports, 1770–1824",

--- a/packages/svelte/skills/ggsvelte/references/interactions.md
+++ b/packages/svelte/skills/ggsvelte/references/interactions.md
@@ -4,9 +4,11 @@
 
 `@ggsvelte/svelte` requires Svelte `^5.33.1` (peerDependency). Interactions are
 opt-in host capabilities — they are not PortableSpec fields. Prefer declaration
-children where they exist (`<Inspect>`, `<GuideLegend focus>`). Always pass a
-stable `key` when selection, legend focus, or coordinated intervals must survive
-filtering, reordering, or data refreshes.
+children where they exist (`<Inspect>`, `<GuideLegend focus>`). Row identity for
+selection, legend focus, and coordinated intervals **defaults** to an `id`
+column when present, otherwise the row index — ordinary charts omit `key`.
+Pass `key` only as an override for a non-`id` durable field or a custom
+accessor (for example `key="year"` on a time series without an `id` column).
 
 ## Inspect capability (preferred: child)
 
@@ -34,17 +36,17 @@ and unrelated to the host `<Inspect>` capability.
 
 ## Capability props
 
-| Prop / surface | Input                                                           | What it enables                                                                                                                                                                                                                                                                                                                                                                            |
-| -------------- | --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `inspect`      | `boolean \| InspectOptions` on `<GGPlot>`, or `<Inspect>` child | Tooltip, semantic crosshair, keyboard traversal, pinning. Prefer `<Inspect>`. Options: `mode` (`"auto" \| "exact" \| "x" \| "y" \| "xy"`), `pin`, `maxDistance` (CSS px), `contentMode` (`"informational" \| "interactive"`), `muteSiblings`, `content` (Snippet, see Tooltip below).                                                                                                      |
-| `select`       | `false \| "point" \| "interval" \| SelectOptions`               | Point or interval selection. Options: `type` (`"point" \| "interval"`), `mode` (`"x" \| "y" \| "xy"`, interval only), `multiple`, `persistent`, `preset` (faceted intervals, below).                                                                                                                                                                                                       |
-| `zoom`         | `boolean \| ZoomOptions`                                        | Brush zoom. Options: `mode` (`"x" \| "y" \| "xy"`), `trigger` (`"brush"`). Currently requires one unfaceted panel.                                                                                                                                                                                                                                                                         |
-| `focus`        | `boolean \| { preview?: boolean }` on `<GuideLegend>`           | Discrete legend preview, focus, and linked emphasis **for that aesthetic channel**. Emphasis only — never changes included rows. Discrete legends only; continuous ramps stay static. Mute de-emphasizes non-focused marks; dashed rings appear only on sparse point marks (≤48 anchors), never on paths/areas/bars/segments/text. Host-only — not a PortableSpec / `guideLegend()` field. |
-| `legendFilter` | `boolean \| LegendFilterOptions` on `<GGPlot>`                  | Data-changing filtering through discrete legend controls: changes the included rows and reruns the grammar while preserving stable color identity. Options: `mode` (`"exclude" \| "include"`), `multiple`.                                                                                                                                                                                 |
-| `key`          | column name or `(row, index) => PropertyKey`                    | Stable semantic identity for public interaction payloads. Required for durable point selection, coordinated interval presets, and legend focus/filter. Duplicate or unstable keys are diagnostic errors.                                                                                                                                                                                   |
-| `tool`         | `"inspect" \| "point" \| "select-area" \| "zoom-area"`          | Controlled initial/active tool; observe changes with `ontoolchange`.                                                                                                                                                                                                                                                                                                                       |
-| `ariaLabel`    | `string`                                                        | Accessible chart name; falls back to the plot title or a generated label.                                                                                                                                                                                                                                                                                                                  |
-| `a11y`         | `A11yMode`                                                      | `"force-svg"` keeps every layer as SVG marks.                                                                                                                                                                                                                                                                                                                                              |
+| Prop / surface | Input                                                            | What it enables                                                                                                                                                                                                                                                                                                                                                                            |
+| -------------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `inspect`      | `boolean \| InspectOptions` on `<GGPlot>`, or `<Inspect>` child  | Tooltip, semantic crosshair, keyboard traversal, pinning. Prefer `<Inspect>`. Options: `mode` (`"auto" \| "exact" \| "x" \| "y" \| "xy"`), `pin`, `maxDistance` (CSS px), `contentMode` (`"informational" \| "interactive"`), `muteSiblings`, `content` (Snippet, see Tooltip below).                                                                                                      |
+| `select`       | `false \| "point" \| "interval" \| SelectOptions`                | Point or interval selection. Options: `type` (`"point" \| "interval"`), `mode` (`"x" \| "y" \| "xy"`, interval only), `multiple`, `persistent`, `preset` (faceted intervals, below).                                                                                                                                                                                                       |
+| `zoom`         | `boolean \| ZoomOptions`                                         | Brush zoom. Options: `mode` (`"x" \| "y" \| "xy"`), `trigger` (`"brush"`). Currently requires one unfaceted panel.                                                                                                                                                                                                                                                                         |
+| `focus`        | `boolean \| { preview?: boolean }` on `<GuideLegend>`            | Discrete legend preview, focus, and linked emphasis **for that aesthetic channel**. Emphasis only — never changes included rows. Discrete legends only; continuous ramps stay static. Mute de-emphasizes non-focused marks; dashed rings appear only on sparse point marks (≤48 anchors), never on paths/areas/bars/segments/text. Host-only — not a PortableSpec / `guideLegend()` field. |
+| `legendFilter` | `boolean \| LegendFilterOptions` on `<GGPlot>`                   | Data-changing filtering through discrete legend controls: changes the included rows and reruns the grammar while preserving stable color identity. Options: `mode` (`"exclude" \| "include"`), `multiple`.                                                                                                                                                                                 |
+| `key`          | column name or `(row, index) => PropertyKey` (optional override) | Durable row identity for public interaction payloads. **Default:** `id` column when present, else row index. Override only for a non-`id` natural key or a custom accessor. Duplicate or unstable keys are diagnostic errors.                                                                                                                                                              |
+| `tool`         | `"inspect" \| "point" \| "select-area" \| "zoom-area"`           | Controlled initial/active tool; observe changes with `ontoolchange`.                                                                                                                                                                                                                                                                                                                       |
+| `ariaLabel`    | `string`                                                         | Accessible chart name; falls back to the plot title or a generated label.                                                                                                                                                                                                                                                                                                                  |
+| `a11y`         | `A11yMode`                                                       | `"force-svg"` keeps every layer as SVG marks.                                                                                                                                                                                                                                                                                                                                              |
 
 ### Deprecated: `legendFocus` on `<GGPlot>`
 
@@ -62,8 +64,9 @@ facet panels:
 - `union` — matching rows from every stored panel interval are combined.
 - `cross-panel` — the sole origin interval is projected into compatible panels.
 
-`union` and `cross-panel` require a stable `key`; without one they combine no
-rows (warning `INTERACTION_INTERVAL_PRESET_REQUIRES_KEY`).
+`union` and `cross-panel` use the resolved row identity (default `id` / index,
+or an explicit `key` override). The engine always supplies an identity, so
+these presets no longer fail solely because `key` was omitted.
 
 ## Controller: durable shared state
 
@@ -154,7 +157,6 @@ entry has `severity`, `code`, `message`, `prop`, `suggestions`, `docUrl`):
 <GGPlot
   data={rows}
   aes={{ x: "date", y: "value", color: "series" }}
-  key="id"
   select={{ type: "interval", mode: "x", preset: "cross-panel" }}
   legendFilter
   {interaction}

--- a/packages/svelte/src/lib/interaction/interaction-diagnostics.ts
+++ b/packages/svelte/src/lib/interaction/interaction-diagnostics.ts
@@ -64,18 +64,24 @@ export const INTERACTION_DIAGNOSTIC_CATALOG: Readonly<
   INTERACTION_POINT_REQUIRES_KEY: {
     severity: "warning",
     code: "INTERACTION_POINT_REQUIRES_KEY",
-    message: "Durable point selection requires a stable key field or accessor.",
+    message: "Durable point selection requires resolved row identity.",
     prop: "key",
-    suggestions: ['Pass key="id"', "Pass a stable key accessor"],
+    suggestions: [
+      "Omit key — defaults to an id column or row index",
+      'Override with key="id" or a stable key accessor when needed',
+    ],
     docUrl: "https://ggsvelte.sh/guide/interaction-reference#interaction-point-requires-key",
   },
   INTERACTION_INTERVAL_PRESET_REQUIRES_KEY: {
     severity: "warning",
     code: "INTERACTION_INTERVAL_PRESET_REQUIRES_KEY",
     message:
-      "Coordinated interval presets (union, cross-panel) require a stable key field or accessor; without one they combine no rows.",
+      "Coordinated interval presets (union, cross-panel) require resolved row identity; without it they combine no rows.",
     prop: "key",
-    suggestions: ['Pass key="id"', "Pass a stable key accessor"],
+    suggestions: [
+      "Omit key — defaults to an id column or row index",
+      'Override with key="id" or a stable key accessor when needed',
+    ],
     docUrl:
       "https://ggsvelte.sh/guide/interaction-reference#interaction-interval-preset-requires-key",
   },
@@ -116,9 +122,12 @@ export const INTERACTION_DIAGNOSTIC_CATALOG: Readonly<
     severity: "warning",
     code: "INTERACTION_LEGEND_REQUIRES_KEY",
     message:
-      "Legend focus requires stable row keys so encoded legend values never become identities.",
+      "Legend focus requires resolved row identity so encoded legend values never become identities.",
     prop: "key",
-    suggestions: ['Pass key="id"', "Pass a stable key accessor"],
+    suggestions: [
+      "Omit key — defaults to an id column or row index",
+      'Override with key="id" or a stable key accessor when needed',
+    ],
     docUrl: "https://ggsvelte.sh/guide/interaction-reference#interaction-legend-requires-key",
   },
   INTERACTION_LEGEND_DISCRETE_ONLY: {

--- a/packages/svelte/src/lib/plot-engine.svelte.ts
+++ b/packages/svelte/src/lib/plot-engine.svelte.ts
@@ -278,7 +278,7 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
     const embedded = assembled()?.data;
     return resolveDatumKey({
       explicit: host.props.key,
-      data: data !== undefined ? data : embedded,
+      data: data ?? embedded,
     });
   }
   const resolvedDatumKeyDerived = $derived.by(resolvedDatumKeyNow);

--- a/packages/svelte/src/lib/plot-engine.svelte.ts
+++ b/packages/svelte/src/lib/plot-engine.svelte.ts
@@ -48,6 +48,7 @@ import {
   resolveInteractionScope,
   toLayerInput,
 } from "./assembly/assemble.js";
+import { resolveDatumKey } from "./runtime/resolve-datum-key.js";
 import {
   collectCompositionDiagnostics,
   compositionAdvisoryDedupKey,
@@ -267,18 +268,35 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
     }),
   );
 
+  /**
+   * Durable row identity: explicit GGPlot `key` override, else auto `id`
+   * column, else row index. Always defined — interaction never requires
+   * authors to pass `key` for ordinary charts.
+   */
+  function resolvedDatumKeyNow() {
+    const data = host.props.data;
+    const embedded = assembled()?.data;
+    return resolveDatumKey({
+      explicit: host.props.key,
+      data: data !== undefined ? data : embedded,
+    });
+  }
+  const resolvedDatumKeyDerived = $derived.by(resolvedDatumKeyNow);
+  const resolvedDatumKey = () =>
+    typeof window === "undefined" ? resolvedDatumKeyNow() : resolvedDatumKeyDerived;
+
   const resolvedInteractionScope: PlotInteractionScope = $derived(
     (() => {
       const interaction = host.props.interaction;
       const interactionScope = host.props.interactionScope;
-      const datumKey = host.props.key;
+      const datumKey = resolvedDatumKey();
       return resolveInteractionScope({
         interaction,
         ...(interactionScope !== undefined && { interactionScope }),
         // Single-field default — do not call caps() (would subscribe all five).
         zoom: host.props.zoom ?? false,
         faceted: facetedPlot,
-        ...(datumKey !== undefined && { datumKey }),
+        datumKey,
         assembled: assembled(),
       });
     })(),
@@ -345,7 +363,8 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
       },
       {
         faceted: facetedPlot,
-        hasKey: host.props.key !== undefined,
+        // Defaults always resolve a datum key (id column or row index).
+        hasKey: true,
       },
     );
   }
@@ -583,7 +602,7 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
   const semanticKeys = createSemanticKeyService({
     model: () => runtime.model,
     assembled,
-    datumKey: () => host.props.key,
+    datumKey: () => resolvedDatumKey(),
     data: () => host.props.data,
     spec: () => host.props.spec,
     sourceIdentity: (value: unknown) => identityTracker.sourceIdentity(value),

--- a/packages/svelte/src/lib/plot-props.ts
+++ b/packages/svelte/src/lib/plot-props.ts
@@ -67,7 +67,11 @@ export interface GGPlotProps<
   width?: number | "container";
   /** Plot height in px (falls back to spec.height, then 400). */
   height?: number;
-  /** Stable semantic identity used by public interaction payloads. */
+  /**
+   * Optional override for durable row identity (selection, legend focus, pin
+   * rebind, linked controllers). Default: use an `id` column when present,
+   * otherwise the row index. Ordinary charts should omit this prop.
+   */
   key?: Identity;
   /** Opt into inspection, its semantic crosshair, tooltip, and pinning. */
   inspect?: InspectInput;

--- a/packages/svelte/src/lib/runtime/resolve-datum-key.ts
+++ b/packages/svelte/src/lib/runtime/resolve-datum-key.ts
@@ -25,14 +25,12 @@ export type ResolveDatumKeyInput = {
 };
 
 /** Row-index identity — default when no `id` column and no explicit key. */
-export function rowIndexDatumKey(_row: Record<string, CellValue>, index: number): PropertyKey {
+function rowIndexDatumKey(_row: Record<string, CellValue>, index: number): PropertyKey {
   return index;
 }
 
-/**
- * True when `value` is a legal PropertyKey for semantic row identity.
- */
-export function isPropertyKeyIdentity(value: unknown): value is PropertyKey {
+/** True when `value` is a legal PropertyKey for semantic row identity. */
+function isPropertyKeyIdentity(value: unknown): value is PropertyKey {
   return typeof value === "string" || typeof value === "number" || typeof value === "symbol";
 }
 
@@ -41,7 +39,7 @@ export function isPropertyKeyIdentity(value: unknown): value is PropertyKey {
  * Does not scan every row for uniqueness — invalid/duplicate keys still emit
  * INTERACTION_* key diagnostics at resolve time.
  */
-export function dataHasIdIdentityColumn(data: unknown): boolean {
+function dataHasIdIdentityColumn(data: unknown): boolean {
   if (data === null || data === undefined) return false;
 
   if (Array.isArray(data)) {

--- a/packages/svelte/src/lib/runtime/resolve-datum-key.ts
+++ b/packages/svelte/src/lib/runtime/resolve-datum-key.ts
@@ -1,0 +1,80 @@
+/**
+ * Resolve durable row identity for interaction (selection, legend focus, pin
+ * rebind, linked controllers).
+ *
+ * Plot authors should not need a `key` prop for ordinary charts:
+ * 1. Explicit `key` / accessor on GGPlot wins when provided (override).
+ * 2. Else if plot data exposes a PropertyKey-valued `id` column → use `"id"`.
+ * 3. Else use the row index (unique within the current row order).
+ *
+ * Index identity is enough for single-plot legend focus / inspect / local
+ * selection. Custom durable identity across reorders or non-`id` natural keys
+ * still uses the explicit `key` override (future: interaction-surface only).
+ */
+import type { CellValue } from "@ggsvelte/core";
+
+export type DatumKey =
+  | PropertyKey
+  | ((row: Record<string, CellValue>, index: number) => PropertyKey);
+
+export type ResolveDatumKeyInput = {
+  /** Explicit GGPlot `key` prop when the author opts into a custom identity. */
+  readonly explicit?: DatumKey | undefined;
+  /** Plot data input (row array, DataRef, or bare columns map). */
+  readonly data?: unknown;
+};
+
+/** Row-index identity — default when no `id` column and no explicit key. */
+export function rowIndexDatumKey(_row: Record<string, CellValue>, index: number): PropertyKey {
+  return index;
+}
+
+/**
+ * True when `value` is a legal PropertyKey for semantic row identity.
+ */
+export function isPropertyKeyIdentity(value: unknown): value is PropertyKey {
+  return typeof value === "string" || typeof value === "number" || typeof value === "symbol";
+}
+
+/**
+ * Detect a usable `id` column on plot data (first cell must be PropertyKey).
+ * Does not scan every row for uniqueness — invalid/duplicate keys still emit
+ * INTERACTION_* key diagnostics at resolve time.
+ */
+export function dataHasIdIdentityColumn(data: unknown): boolean {
+  if (data === null || data === undefined) return false;
+
+  if (Array.isArray(data)) {
+    if (data.length === 0) return false;
+    const row = data[0];
+    if (row === null || typeof row !== "object" || Array.isArray(row)) return false;
+    return isPropertyKeyIdentity((row as Record<string, unknown>)["id"]);
+  }
+
+  if (typeof data !== "object") return false;
+  const record = data as Record<string, unknown>;
+
+  // DataRef { values: Row[] }
+  if (Array.isArray(record["values"])) return dataHasIdIdentityColumn(record["values"]);
+
+  // DataRef { columns: { id: [...] } } or bare column map with id array
+  const columns =
+    record["columns"] !== null &&
+    typeof record["columns"] === "object" &&
+    !Array.isArray(record["columns"])
+      ? (record["columns"] as Record<string, unknown>)
+      : record;
+  const idColumn = columns["id"];
+  if (!Array.isArray(idColumn) || idColumn.length === 0) return false;
+  return isPropertyKeyIdentity(idColumn[0]);
+}
+
+/**
+ * Resolve the datum-key used by the plot engine.
+ * Always returns a key strategy — never `undefined`.
+ */
+export function resolveDatumKey(input: ResolveDatumKeyInput): DatumKey {
+  if (input.explicit !== undefined) return input.explicit;
+  if (dataHasIdIdentityColumn(input.data)) return "id";
+  return rowIndexDatumKey;
+}

--- a/packages/svelte/src/lib/runtime/resolve-datum-key.ts
+++ b/packages/svelte/src/lib/runtime/resolve-datum-key.ts
@@ -46,7 +46,7 @@ export function dataHasIdIdentityColumn(data: unknown): boolean {
 
   if (Array.isArray(data)) {
     if (data.length === 0) return false;
-    const row = data[0];
+    const row: unknown = data[0];
     if (row === null || typeof row !== "object" || Array.isArray(row)) return false;
     return isPropertyKeyIdentity((row as Record<string, unknown>)["id"]);
   }

--- a/packages/svelte/tests/final-evidence.test.ts
+++ b/packages/svelte/tests/final-evidence.test.ts
@@ -178,7 +178,7 @@ describe("final R-1/R0 evidence locks", () => {
     outside.remove();
   });
 
-  it("clears keyless state for equal-valued new references and in-place reorders but preserves layout-only changes", async () => {
+  it("default identity: layout-only and equal-valued replace rebind pin", async () => {
     const data = [
       { x: 1, y: 2 },
       { x: 2, y: 4 },
@@ -199,27 +199,10 @@ describe("final R-1/R0 evidence locks", () => {
     await view.rerender(fromPartial({ height: 360 }));
     expect(view.container.querySelector(".gg-tooltip")?.classList).toContain("gg-tooltip-pinned");
 
+    // Default row-index identity rebinds across equal-valued new row objects.
     await view.rerender(fromPartial({ data: data.map((row) => ({ ...row })) }));
-    await expect.poll(() => view.container.querySelector(".gg-tooltip")).toBeNull();
-
-    const reorderData = [
-      { x: 1, y: 2 },
-      { x: 2, y: 4 },
-    ];
-    const reorderView = render(GGPlot, {
-      data: reorderData,
-      aes: { x: "x", y: "y" },
-      layers: [{ geom: "point" }],
-      inspect: true,
-      ...size,
-    });
-    const reorderSurface = reorderView.container.querySelector<HTMLElement>(".gg-capture")!;
-    reorderSurface.focus();
-    keydown(reorderSurface, "Enter");
-    await expect.poll(() => reorderView.container.querySelector(".gg-tooltip")).not.toBeNull();
-    reorderData.reverse();
-    await reorderView.rerender(fromPartial({ data: reorderData }));
-    await expect.poll(() => reorderView.container.querySelector(".gg-tooltip")).toBeNull();
+    await expect.poll(() => view.container.querySelector(".gg-tooltip")).not.toBeNull();
+    expect(view.container.querySelector(".gg-tooltip")?.classList).toContain("gg-tooltip-pinned");
   });
 
   it("diagnoses an unstable key accessor for a surviving source row", async () => {

--- a/packages/svelte/tests/interaction/brush-zoom/precise-bounds.test.ts
+++ b/packages/svelte/tests/interaction/brush-zoom/precise-bounds.test.ts
@@ -250,7 +250,8 @@ describe("brush precise bounds", () => {
     expect(selections[0]).toEqual(
       expect.objectContaining({
         domain: { x: [1.5, 2.5], y: [10, 30] },
-        keys: [],
+        // Default row-index identity fills source-row keys for the hit.
+        keys: [1],
         lineageCount: 1,
       }),
     );

--- a/packages/svelte/tests/interaction/plot-layer-epoch.test.ts
+++ b/packages/svelte/tests/interaction/plot-layer-epoch.test.ts
@@ -76,15 +76,15 @@ describe("#609 epoch with non-mark layers registered", () => {
     expect(fixed).toEqual([rowsA]);
   });
 
-  it("pinned inspection clears when geom-child layer-local data is replaced (markLayers epoch path)", async () => {
+  it("markLayers data replace bumps epoch; default identity rebinds pin", async () => {
     // Production path: plot-engine fingerprints
     // inputs.registry.markLayers when the layers prop is absent. Only mark
     // descriptors expose .data — so a geom child's layer-local replacement
-    // must bump dataIdentityEpoch. reconcilePinned returns null on epoch
-    // change for keyless pins, which clears the inspection.
+    // must bump dataIdentityEpoch (new RenderModel). Default row-index
+    // identity then rebinds the pin across that epoch when geometry matches.
     //
     // Setup: no plot `data`/`spec` prop (layer-local only), a non-mark theme
-    // sibling registered, inspect pin enabled, no key (keyless pin).
+    // sibling registered, inspect pin enabled, no explicit key.
     let model: RenderModel | null = null;
     const inspectEvents: Array<{ phase: string; state?: string }> = [];
     const view = render(PlotLayerHost, {
@@ -118,9 +118,8 @@ describe("#609 epoch with non-mark layers registered", () => {
 
     const pinnedModel = model;
     // Swap to a *new array of new row objects* with identical field values.
-    // That bumps the markLayers source-identity fingerprint (epoch) while
-    // leaving candidate axis tokens equal — so a broken registry.layers
-    // epoch would revalidate the keyless pin and leave the tooltip up.
+    // That bumps the markLayers source-identity fingerprint (epoch). Default
+    // row-index keys rebind the pin so the tooltip stays up.
     await view.rerender({
       aes: { x: "x", y: "y" },
       markData: rowsAPrime,
@@ -135,8 +134,7 @@ describe("#609 epoch with non-mark layers registered", () => {
     });
 
     await expect.poll(() => model !== pinnedModel).toBe(true);
-    await expect.poll(() => inspectEvents.some((event) => event.phase === "clear")).toBe(true);
-    expect(view.container.querySelector(".gg-tooltip")).toBeNull();
+    expect(view.container.querySelector(".gg-tooltip")).not.toBeNull();
   });
 
   it("isFacetedPlotIntent host path: facet plot layer disables brush zoom with diagnostic", async () => {

--- a/packages/svelte/tests/legend/focus-interaction.test.ts
+++ b/packages/svelte/tests/legend/focus-interaction.test.ts
@@ -237,7 +237,7 @@ describe("legend focus capability edges", () => {
     expect(interactions).toEqual([]);
   });
 
-  it("diagnoses a missing stable key without exposing inert legend controls", async () => {
+  it("enables legend focus without an explicit key when rows carry id", async () => {
     const diagnostics: Array<{ code: string }> = [];
     const { container } = render(GGPlot, {
       data: rows,
@@ -249,11 +249,32 @@ describe("legend focus capability edges", () => {
       height: 260,
     });
 
-    await until(() =>
+    await until(() => container.querySelectorAll(".gg-legend-target").length === 2);
+    expect(
       diagnostics.some((diagnostic) => diagnostic.code === "INTERACTION_LEGEND_REQUIRES_KEY"),
-    );
-    expect(container.querySelector(".gg-legend-target")).toBeNull();
+    ).toBe(false);
     expect(container.querySelector(".gg-capture")).toBeNull();
+  });
+
+  it("enables legend focus without an explicit key via row-index default", async () => {
+    const diagnostics: Array<{ code: string }> = [];
+    const { container } = render(GGPlot, {
+      data: [
+        { x: 1, y: 2, group: "North" },
+        { x: 2, y: 3, group: "South" },
+      ],
+      aes: { x: "x", y: "y", color: "group" },
+      layers: [{ geom: "point" }],
+      legendFocus: true,
+      ondiagnostic: (diagnostic: { code: string }) => diagnostics.push(diagnostic),
+      width: 360,
+      height: 260,
+    });
+
+    await until(() => container.querySelectorAll(".gg-legend-target").length === 2);
+    expect(
+      diagnostics.some((diagnostic) => diagnostic.code === "INTERACTION_LEGEND_REQUIRES_KEY"),
+    ).toBe(false);
   });
 
   it("keeps hover and DOM focus inert when preview is disabled", async () => {

--- a/packages/svelte/tests/r0-evidence/pointer-inspect.test.ts
+++ b/packages/svelte/tests/r0-evidence/pointer-inspect.test.ts
@@ -210,7 +210,7 @@ describe("R0 pointer-inspect evidence", () => {
     expect(view.container.querySelector(".gg-tooltip")).toBeNull();
   });
 
-  it("clears reducer ownership when a keyless pin cannot reconcile to a fresh data identity", async () => {
+  it("clears reducer ownership when pin keys cannot reconcile to a fresh data identity", async () => {
     let model: RenderModel | null = null;
     const view = render(GGPlot, {
       data: rows,
@@ -231,7 +231,12 @@ describe("R0 pointer-inspect evidence", () => {
       )
       .toBe(true);
 
-    await view.rerender(fromPartial({ data: rows.map((row) => ({ ...row })) }));
+    // New row identities (fresh id values) — default id keys cannot rebind the pin.
+    await view.rerender(
+      fromPartial({
+        data: rows.map((row, index) => ({ ...row, id: `fresh-${String(index)}` })),
+      }),
+    );
     await expect.poll(() => view.container.querySelector(".gg-tooltip")).toBeNull();
     const second = model!.candidates.candidate(1)!;
     pointEvent(capture, "pointermove", second.x, second.y);

--- a/packages/svelte/tests/runtime/resolve-datum-key.test.ts
+++ b/packages/svelte/tests/runtime/resolve-datum-key.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Default row identity for durable interaction — pure resolve.
+ *
+ * Authors should not pass GGPlot `key` for ordinary charts: prefer an `id`
+ * column when present, otherwise stable row index. Explicit `key` overrides.
+ */
+import { describe, expect, it } from "vitest";
+
+import { resolveDatumKey } from "../../src/lib/runtime/resolve-datum-key.js";
+
+describe("resolveDatumKey", () => {
+  it("uses an explicit column name when provided", () => {
+    expect(
+      resolveDatumKey({
+        explicit: "year",
+        data: [{ year: 2020, id: "x" }],
+      }),
+    ).toBe("year");
+  });
+
+  it("uses an explicit accessor when provided", () => {
+    const accessor = (row: { a: number }, index: number) => `${row.a}:${index}`;
+    expect(resolveDatumKey({ explicit: accessor, data: [] })).toBe(accessor);
+  });
+
+  it("defaults to the id column when row objects expose a PropertyKey id", () => {
+    expect(
+      resolveDatumKey({
+        data: [
+          { id: "adelie-001", species: "Adelie" },
+          { id: "adelie-002", species: "Adelie" },
+        ],
+      }),
+    ).toBe("id");
+  });
+
+  it("defaults to the id column for column-oriented { columns: { id } } data", () => {
+    expect(
+      resolveDatumKey({
+        data: {
+          columns: {
+            id: ["a", "b"],
+            x: [1, 2],
+          },
+        },
+      }),
+    ).toBe("id");
+  });
+
+  it("defaults to the id column for DataRef { values }", () => {
+    expect(
+      resolveDatumKey({
+        data: {
+          values: [
+            { id: 1, x: 0 },
+            { id: 2, x: 1 },
+          ],
+        },
+      }),
+    ).toBe("id");
+  });
+
+  it("defaults to a row-index accessor when no id field is available", () => {
+    const key = resolveDatumKey({
+      data: [
+        { manufacturer: "audi", model: "a4", hwy: 29 },
+        { manufacturer: "audi", model: "a4", hwy: 29 },
+      ],
+    });
+    expect(typeof key).toBe("function");
+    if (typeof key !== "function") throw new Error("expected index accessor");
+    expect(key({ manufacturer: "audi", model: "a4", hwy: 29 }, 0)).toBe(0);
+    expect(key({ manufacturer: "audi", model: "a4", hwy: 29 }, 1)).toBe(1);
+  });
+
+  it("defaults to a row-index accessor when data is empty or absent", () => {
+    const empty = resolveDatumKey({ data: [] });
+    const missing = resolveDatumKey({});
+    expect(typeof empty).toBe("function");
+    expect(typeof missing).toBe("function");
+    if (typeof empty !== "function" || typeof missing !== "function")
+      throw new Error("expected index accessors");
+    expect(empty({}, 3)).toBe(3);
+    expect(missing({}, 7)).toBe(7);
+  });
+
+  it("does not treat a non-PropertyKey id as an identity column", () => {
+    const key = resolveDatumKey({
+      data: [{ id: { nested: true }, x: 1 }],
+    });
+    expect(typeof key).toBe("function");
+  });
+
+  it("prefers explicit key over an auto id column", () => {
+    expect(
+      resolveDatumKey({
+        explicit: "year",
+        data: [{ id: "row-1", year: 812 }],
+      }),
+    ).toBe("year");
+  });
+});

--- a/scripts/themes-page.test.ts
+++ b/scripts/themes-page.test.ts
@@ -139,8 +139,9 @@ describe("themes catalog", () => {
 });
 
 describe("hero temperatures chart config", () => {
-  it("keeps key and month breaks stable for TemperaturesSpecimen", () => {
-    expect(TEMPERATURES_CHART.key).toBe("id");
+  it("keeps month breaks stable for TemperaturesSpecimen (no plot key)", () => {
+    // Row identity defaults to id/index — chart config no longer carries key.
+    expect("key" in TEMPERATURES_CHART).toBe(false);
     expect([...TEMPERATURES_CHART.monthBreaks]).toEqual([...MONTH_BREAKS]);
   });
 });

--- a/skills/ggsvelte/references/interactions.md
+++ b/skills/ggsvelte/references/interactions.md
@@ -4,9 +4,11 @@
 
 `@ggsvelte/svelte` requires Svelte `^5.33.1` (peerDependency). Interactions are
 opt-in host capabilities — they are not PortableSpec fields. Prefer declaration
-children where they exist (`<Inspect>`, `<GuideLegend focus>`). Always pass a
-stable `key` when selection, legend focus, or coordinated intervals must survive
-filtering, reordering, or data refreshes.
+children where they exist (`<Inspect>`, `<GuideLegend focus>`). Row identity for
+selection, legend focus, and coordinated intervals **defaults** to an `id`
+column when present, otherwise the row index — ordinary charts omit `key`.
+Pass `key` only as an override for a non-`id` durable field or a custom
+accessor (for example `key="year"` on a time series without an `id` column).
 
 ## Inspect capability (preferred: child)
 
@@ -34,17 +36,17 @@ and unrelated to the host `<Inspect>` capability.
 
 ## Capability props
 
-| Prop / surface | Input                                                           | What it enables                                                                                                                                                                                                                                                                                                                                                                            |
-| -------------- | --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `inspect`      | `boolean \| InspectOptions` on `<GGPlot>`, or `<Inspect>` child | Tooltip, semantic crosshair, keyboard traversal, pinning. Prefer `<Inspect>`. Options: `mode` (`"auto" \| "exact" \| "x" \| "y" \| "xy"`), `pin`, `maxDistance` (CSS px), `contentMode` (`"informational" \| "interactive"`), `muteSiblings`, `content` (Snippet, see Tooltip below).                                                                                                      |
-| `select`       | `false \| "point" \| "interval" \| SelectOptions`               | Point or interval selection. Options: `type` (`"point" \| "interval"`), `mode` (`"x" \| "y" \| "xy"`, interval only), `multiple`, `persistent`, `preset` (faceted intervals, below).                                                                                                                                                                                                       |
-| `zoom`         | `boolean \| ZoomOptions`                                        | Brush zoom. Options: `mode` (`"x" \| "y" \| "xy"`), `trigger` (`"brush"`). Currently requires one unfaceted panel.                                                                                                                                                                                                                                                                         |
-| `focus`        | `boolean \| { preview?: boolean }` on `<GuideLegend>`           | Discrete legend preview, focus, and linked emphasis **for that aesthetic channel**. Emphasis only — never changes included rows. Discrete legends only; continuous ramps stay static. Mute de-emphasizes non-focused marks; dashed rings appear only on sparse point marks (≤48 anchors), never on paths/areas/bars/segments/text. Host-only — not a PortableSpec / `guideLegend()` field. |
-| `legendFilter` | `boolean \| LegendFilterOptions` on `<GGPlot>`                  | Data-changing filtering through discrete legend controls: changes the included rows and reruns the grammar while preserving stable color identity. Options: `mode` (`"exclude" \| "include"`), `multiple`.                                                                                                                                                                                 |
-| `key`          | column name or `(row, index) => PropertyKey`                    | Stable semantic identity for public interaction payloads. Required for durable point selection, coordinated interval presets, and legend focus/filter. Duplicate or unstable keys are diagnostic errors.                                                                                                                                                                                   |
-| `tool`         | `"inspect" \| "point" \| "select-area" \| "zoom-area"`          | Controlled initial/active tool; observe changes with `ontoolchange`.                                                                                                                                                                                                                                                                                                                       |
-| `ariaLabel`    | `string`                                                        | Accessible chart name; falls back to the plot title or a generated label.                                                                                                                                                                                                                                                                                                                  |
-| `a11y`         | `A11yMode`                                                      | `"force-svg"` keeps every layer as SVG marks.                                                                                                                                                                                                                                                                                                                                              |
+| Prop / surface | Input                                                            | What it enables                                                                                                                                                                                                                                                                                                                                                                            |
+| -------------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `inspect`      | `boolean \| InspectOptions` on `<GGPlot>`, or `<Inspect>` child  | Tooltip, semantic crosshair, keyboard traversal, pinning. Prefer `<Inspect>`. Options: `mode` (`"auto" \| "exact" \| "x" \| "y" \| "xy"`), `pin`, `maxDistance` (CSS px), `contentMode` (`"informational" \| "interactive"`), `muteSiblings`, `content` (Snippet, see Tooltip below).                                                                                                      |
+| `select`       | `false \| "point" \| "interval" \| SelectOptions`                | Point or interval selection. Options: `type` (`"point" \| "interval"`), `mode` (`"x" \| "y" \| "xy"`, interval only), `multiple`, `persistent`, `preset` (faceted intervals, below).                                                                                                                                                                                                       |
+| `zoom`         | `boolean \| ZoomOptions`                                         | Brush zoom. Options: `mode` (`"x" \| "y" \| "xy"`), `trigger` (`"brush"`). Currently requires one unfaceted panel.                                                                                                                                                                                                                                                                         |
+| `focus`        | `boolean \| { preview?: boolean }` on `<GuideLegend>`            | Discrete legend preview, focus, and linked emphasis **for that aesthetic channel**. Emphasis only — never changes included rows. Discrete legends only; continuous ramps stay static. Mute de-emphasizes non-focused marks; dashed rings appear only on sparse point marks (≤48 anchors), never on paths/areas/bars/segments/text. Host-only — not a PortableSpec / `guideLegend()` field. |
+| `legendFilter` | `boolean \| LegendFilterOptions` on `<GGPlot>`                   | Data-changing filtering through discrete legend controls: changes the included rows and reruns the grammar while preserving stable color identity. Options: `mode` (`"exclude" \| "include"`), `multiple`.                                                                                                                                                                                 |
+| `key`          | column name or `(row, index) => PropertyKey` (optional override) | Durable row identity for public interaction payloads. **Default:** `id` column when present, else row index. Override only for a non-`id` natural key or a custom accessor. Duplicate or unstable keys are diagnostic errors.                                                                                                                                                              |
+| `tool`         | `"inspect" \| "point" \| "select-area" \| "zoom-area"`           | Controlled initial/active tool; observe changes with `ontoolchange`.                                                                                                                                                                                                                                                                                                                       |
+| `ariaLabel`    | `string`                                                         | Accessible chart name; falls back to the plot title or a generated label.                                                                                                                                                                                                                                                                                                                  |
+| `a11y`         | `A11yMode`                                                       | `"force-svg"` keeps every layer as SVG marks.                                                                                                                                                                                                                                                                                                                                              |
 
 ### Deprecated: `legendFocus` on `<GGPlot>`
 
@@ -62,8 +64,9 @@ facet panels:
 - `union` — matching rows from every stored panel interval are combined.
 - `cross-panel` — the sole origin interval is projected into compatible panels.
 
-`union` and `cross-panel` require a stable `key`; without one they combine no
-rows (warning `INTERACTION_INTERVAL_PRESET_REQUIRES_KEY`).
+`union` and `cross-panel` use the resolved row identity (default `id` / index,
+or an explicit `key` override). The engine always supplies an identity, so
+these presets no longer fail solely because `key` was omitted.
 
 ## Controller: durable shared state
 
@@ -154,7 +157,6 @@ entry has `severity`, `code`, `message`, `prop`, `suggestions`, `docUrl`):
 <GGPlot
   data={rows}
   aes={{ x: "date", y: "value", color: "series" }}
-  key="id"
   select={{ type: "interval", mode: "x", preset: "cross-panel" }}
   legendFilter
   {interaction}


### PR DESCRIPTION
## Summary

Ordinary charts no longer need `key` on `<GGPlot>`.

Row identity for durable interaction now resolves as:

1. explicit `key` override (optional)
2. else an `id` column when present
3. else row index

Legend focus and point selection work without the prop. Docs home and demos drop `key="id"`. Plot-level `key` remains only as an optional override for non-`id` natural keys.

Follow-up: #1253 — move durable custom identity onto interaction surfaces and remove the plot prop.

## Test plan

- [x] `resolve-datum-key` pure tests (explicit / id / columns / values / index default)
- [x] Legend focus without explicit key (id rows + index-only rows)
- [x] normalize + point-selection + focus-interaction suite green
- [x] `tsc --noEmit` green on `@ggsvelte/svelte`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1254" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->