### PR TITLE
feat(svelte): move durable row identity onto interaction surfaces

### DIFF
--- a/.changeset/interaction-surface-identity.md
+++ b/.changeset/interaction-surface-identity.md
@@ -1,0 +1,22 @@
+---
+"@ggsvelte/svelte": minor
+---
+
+<!-- markdownlint-disable MD041 -->
+
+feat: durable row identity on Inspect / Select / controller
+
+Custom durable identity now prefers interaction surfaces:
+
+- `<Inspect identity="…" />` or `inspect={{ identity: "…" }}`
+- `select={{ type: "point" | "interval", identity: "…" }}`
+- `createPlotInteraction({ identity: "…" })`
+
+Resolution order: Inspect → Select → controller → deprecated GGPlot `key` →
+auto `id` column → row index (order-stable only). Ordinary charts still omit
+identity entirely.
+
+`GGPlot key` dual-reads through 0.21.x and emits `DEPRECATED_PLOT_PROP`;
+removal lands in 0.22.0.
+
+Migration: <https://ggsvelte.sh/guide/upgrading#row-identity-on-interaction>

--- a/README.md
+++ b/README.md
@@ -81,10 +81,10 @@ and Windows.
 ```svelte
 <script lang="ts">
   import {
+    createPlotInteraction,
     GeomArea,
     GGPlot,
     GuideLegend,
-    Inspect,
     Labs,
     ScaleFillManual,
     ScaleXDate,
@@ -92,15 +92,21 @@ and Windows.
   } from "@ggsvelte/svelte";
 
   import { crimeanMortality } from "./data.js";
+
+  const interaction = createPlotInteraction({
+    identity: (row) => `${row.month}:${row.cause}`,
+  });
+  const scope = { keys: "crimean-rows" } as const;
 </script>
 
 <GGPlot
   data={crimeanMortality}
   aes={{ x: "month", y: "deaths", fill: "cause" }}
+  {interaction}
+  interactionScope={scope}
   width={640}
   height={400}
 >
-  <Inspect identity={(row) => `${row.month}:${row.cause}`} />
   <ThemeEconomist />
   <ScaleXDate labels="%b %Y" />
   <ScaleFillManual

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ and Windows.
 <script lang="ts">
   import {
     GeomArea,
+    createPlotInteraction,
     GGPlot,
     GuideLegend,
     Labs,
@@ -91,12 +92,16 @@ and Windows.
   } from "@ggsvelte/svelte";
 
   import { crimeanMortality } from "./data.js";
+
+  const interaction = createPlotInteraction({
+    identity: (row) => `${row.month}:${row.cause}`,
+  });
 </script>
 
 <GGPlot
   data={crimeanMortality}
   aes={{ x: "month", y: "deaths", fill: "cause" }}
-  key={(row) => `${row.month}:${row.cause}`}
+  {interaction}
   width={640}
   height={400}
 >
@@ -184,11 +189,10 @@ and Windows.
 <GGPlot
   data={londonCholera}
   aes={{ x: "density", y: "deathRate", color: "water" }}
-  key="district"
   width="container"
   height={400}
 >
-  <Inspect mode="xy" pin />
+  <Inspect mode="xy" pin identity="district" />
   <ThemeEconomist />
   <ScaleXLog10 labels="~s" />
   <ScaleColorManual

--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ and Windows.
 <script lang="ts">
   import {
     GeomArea,
-    createPlotInteraction,
     GGPlot,
     GuideLegend,
+    Inspect,
     Labs,
     ScaleFillManual,
     ScaleXDate,
@@ -92,19 +92,15 @@ and Windows.
   } from "@ggsvelte/svelte";
 
   import { crimeanMortality } from "./data.js";
-
-  const interaction = createPlotInteraction({
-    identity: (row) => `${row.month}:${row.cause}`,
-  });
 </script>
 
 <GGPlot
   data={crimeanMortality}
   aes={{ x: "month", y: "deaths", fill: "cause" }}
-  {interaction}
   width={640}
   height={400}
 >
+  <Inspect identity={(row) => `${row.month}:${row.cause}`} />
   <ThemeEconomist />
   <ScaleXDate labels="%b %Y" />
   <ScaleFillManual

--- a/apps/docs/src/lib/components/LessonFinishedChart.svelte
+++ b/apps/docs/src/lib/components/LessonFinishedChart.svelte
@@ -183,14 +183,14 @@
 
 <div class="finished-chart lesson-output" bind:this={host}>
   {#if LivePlot && finished}
-    <LivePlot
-      spec={finished.spec}
-      key={finished.key}
-      height={liveHeight}
-      {ariaLabel}
-    >
+    <LivePlot spec={finished.spec} height={liveHeight} {ariaLabel}>
       {#if finished.inspect && LiveInspect}
-        <LiveInspect mode="exact" pin content={sakuraTooltip} />
+        <LiveInspect
+          mode="exact"
+          pin
+          identity={finished.key}
+          content={sakuraTooltip}
+        />
       {/if}
     </LivePlot>
   {:else}

--- a/apps/docs/src/lib/components/ThemeSpecimenLive.svelte
+++ b/apps/docs/src/lib/components/ThemeSpecimenLive.svelte
@@ -174,11 +174,10 @@
   <GGPlot
     data={countries}
     aes={{ x: "gdp", y: "lifeExp", color: "region" }}
-    key="country"
     {height}
     ariaLabel={`${label} theme cholera density scatter`}
   >
-    <Inspect mode="xy" />
+    <Inspect mode="xy" identity="country" />
     {#if legendFocus}
       <GuideLegend channel="color" focus />
     {/if}

--- a/apps/docs/src/lib/generated/routes.ts
+++ b/apps/docs/src/lib/generated/routes.ts
@@ -12021,8 +12021,8 @@ export const DOCS_ROUTES = [
         level: 2,
       },
       {
-        id: "experimental-473",
-        title: "experimental (473)",
+        id: "experimental-474",
+        title: "experimental (474)",
         level: 3,
       },
       {
@@ -12058,8 +12058,8 @@ export const DOCS_ROUTES = [
         level: 2,
       },
       {
-        id: "row-identity-on-interaction-surfaces",
-        title: "Row identity on interaction surfaces",
+        id: "row-identity-on-interaction",
+        title: "Row identity on interaction",
         level: 3,
       },
       {

--- a/apps/docs/src/lib/generated/routes.ts
+++ b/apps/docs/src/lib/generated/routes.ts
@@ -12053,6 +12053,16 @@ export const DOCS_ROUTES = [
         level: 2,
       },
       {
+        id: "0-20-to-0-21",
+        title: "0.20 to 0.21",
+        level: 2,
+      },
+      {
+        id: "row-identity-on-interaction-surfaces",
+        title: "Row identity on interaction surfaces",
+        level: 3,
+      },
+      {
         id: "0-18-to-0-19",
         title: "0.18 to 0.19",
         level: 2,

--- a/apps/docs/src/lib/generated/search-index.ts
+++ b/apps/docs/src/lib/generated/search-index.ts
@@ -19912,6 +19912,26 @@ export const DOCS_SEARCH_INDEX = [
     exact: ["Five-minute path"],
   },
   {
+    id: "heading:guide-upgrading:0-20-to-0-21",
+    kind: "heading",
+    title: "0.20 to 0.21",
+    summary:
+      "0.20 to 0.21 in Upgrade guide. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
+    href: "/guide/upgrading#0-20-to-0-21",
+    keywords: ["Upgrade guide", "Release"],
+    exact: ["0.20 to 0.21"],
+  },
+  {
+    id: "heading:guide-upgrading:row-identity-on-interaction-surfaces",
+    kind: "heading",
+    title: "Row identity on interaction surfaces",
+    summary:
+      "Row identity on interaction surfaces in Upgrade guide. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
+    href: "/guide/upgrading#row-identity-on-interaction-surfaces",
+    keywords: ["Upgrade guide", "Release"],
+    exact: ["Row identity on interaction surfaces"],
+  },
+  {
     id: "heading:guide-upgrading:0-18-to-0-19",
     kind: "heading",
     title: "0.18 to 0.19",
@@ -41742,7 +41762,7 @@ export const DOCS_SEARCH_INDEX = [
     keywords: [
       "interaction",
       "warning",
-      'Omit key — defaults to an id column or row index; Override with key="id" or a stable key accessor when needed',
+      'Ordinary charts omit identity — defaults to an id column or row index; Override with <Inspect identity="id" /> or select={{ type: "point", identity: "id" }}',
     ],
     exact: ["INTERACTION_POINT_REQUIRES_KEY", "interaction:INTERACTION_POINT_REQUIRES_KEY"],
   },
@@ -41756,7 +41776,7 @@ export const DOCS_SEARCH_INDEX = [
     keywords: [
       "interaction",
       "warning",
-      'Omit key — defaults to an id column or row index; Override with key="id" or a stable key accessor when needed',
+      'Ordinary charts omit identity — defaults to an id column or row index; Override with select={{ type: "interval", identity: "id", … }} or <Inspect identity="id" />',
     ],
     exact: [
       "INTERACTION_INTERVAL_PRESET_REQUIRES_KEY",
@@ -41814,7 +41834,7 @@ export const DOCS_SEARCH_INDEX = [
     keywords: [
       "interaction",
       "warning",
-      'Omit key — defaults to an id column or row index; Override with key="id" or a stable key accessor when needed',
+      'Ordinary charts omit identity — defaults to an id column or row index; Override with <Inspect identity="id" /> or createPlotInteraction({ identity: "id" })',
     ],
     exact: ["INTERACTION_LEGEND_REQUIRES_KEY", "interaction:INTERACTION_LEGEND_REQUIRES_KEY"],
   },

--- a/apps/docs/src/lib/generated/search-index.ts
+++ b/apps/docs/src/lib/generated/search-index.ts
@@ -19873,14 +19873,14 @@ export const DOCS_SEARCH_INDEX = [
     exact: ["@ggsvelte/svelte"],
   },
   {
-    id: "heading:guide-lifecycle:experimental-473",
+    id: "heading:guide-lifecycle:experimental-474",
     kind: "heading",
-    title: "experimental (473)",
+    title: "experimental (474)",
     summary:
-      "experimental (473) in Lifecycle & editions. API stability tags per export, and the defaults-edition mechanism.",
-    href: "/guide/lifecycle#experimental-473",
+      "experimental (474) in Lifecycle & editions. API stability tags per export, and the defaults-edition mechanism.",
+    href: "/guide/lifecycle#experimental-474",
     keywords: ["Lifecycle & editions", "Reference"],
-    exact: ["experimental (473)"],
+    exact: ["experimental (474)"],
   },
   {
     id: "heading:guide-lifecycle:stable-intent-243",
@@ -19922,14 +19922,14 @@ export const DOCS_SEARCH_INDEX = [
     exact: ["0.20 to 0.21"],
   },
   {
-    id: "heading:guide-upgrading:row-identity-on-interaction-surfaces",
+    id: "heading:guide-upgrading:row-identity-on-interaction",
     kind: "heading",
-    title: "Row identity on interaction surfaces",
+    title: "Row identity on interaction",
     summary:
-      "Row identity on interaction surfaces in Upgrade guide. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
-    href: "/guide/upgrading#row-identity-on-interaction-surfaces",
+      "Row identity on interaction in Upgrade guide. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
+    href: "/guide/upgrading#row-identity-on-interaction",
     keywords: ["Upgrade guide", "Release"],
-    exact: ["Row identity on interaction surfaces"],
+    exact: ["Row identity on interaction"],
   },
   {
     id: "heading:guide-upgrading:0-18-to-0-19",
@@ -33243,6 +33243,15 @@ export const DOCS_SEARCH_INDEX = [
     href: "/guide/lifecycle#ggsvelte-svelte",
     keywords: ["@ggsvelte/svelte", ".", "type", "experimental"],
     exact: ["ContinuousPositionScaleOptions"],
+  },
+  {
+    id: "api:ggsvelte-svelte:ControllerDatumIdentity",
+    kind: "api",
+    title: "ControllerDatumIdentity",
+    summary: "@ggsvelte/svelte · type · experimental.",
+    href: "/guide/lifecycle#ggsvelte-svelte",
+    keywords: ["@ggsvelte/svelte", ".", "type", "experimental"],
+    exact: ["ControllerDatumIdentity"],
   },
   {
     id: "api:ggsvelte-svelte:Coord",

--- a/apps/docs/src/routes/__perf/interaction-100k/+page.svelte
+++ b/apps/docs/src/routes/__perf/interaction-100k/+page.svelte
@@ -38,7 +38,6 @@
     {data}
     aes={{ x: "x", y: "y", group: "series" }}
     layers={[{ geom: "point", render: "canvas", params: { size: 1 } }]}
-    key="id"
     onrender={(model: RenderModel) => {
       candidateCount = model.candidates.size;
       const seed = model.candidates.nearest(

--- a/apps/docs/src/routes/__perf/legend-focus-100k/+page.svelte
+++ b/apps/docs/src/routes/__perf/legend-focus-100k/+page.svelte
@@ -38,7 +38,6 @@
       data={navigationData}
       aes={mapping}
       layers={[{ geom: "point", render: "canvas", params: { size: 1 } }]}
-      key="id"
       interaction={navigationInteraction}
       interactionScope={navigationScope}
       width={620}
@@ -55,7 +54,6 @@
         data={linkedData}
         aes={mapping}
         layers={[{ geom: "point", render: "canvas", params: { size: 1 } }]}
-        key="id"
         {interaction}
         interactionScope={scope}
         width={620}

--- a/apps/docs/src/routes/__perf/r3-interaction/+page.svelte
+++ b/apps/docs/src/routes/__perf/r3-interaction/+page.svelte
@@ -80,7 +80,6 @@
       data={filterData}
       aes={{ ...mapping, color: "group" }}
       layers={[{ geom: "point", render: "canvas", params: { size: 1 } }]}
-      key="id"
       width={900}
       height={420}
       onrender={() => (filterPipelineCommits += 1)}
@@ -95,7 +94,6 @@
       data={facetData}
       aes={mapping}
       layers={[{ geom: "point", render: "canvas", params: { size: 1 } }]}
-      key="id"
       select={crossPanelSelect}
       interaction={facetInteraction}
       interactionScope={facetScope}
@@ -113,7 +111,6 @@
       data={facetData.slice(0, 4_000)}
       aes={mapping}
       layers={[{ geom: "point", render: "canvas", params: { size: 1 } }]}
-      key="id"
       zoom={{ mode: "x" }}
       interaction={zoomInteraction}
       interactionScope={zoomScope}

--- a/apps/docs/static/previews/provenance.json
+++ b/apps/docs/static/previews/provenance.json
@@ -8,12 +8,12 @@
     },
     "area/stacked": {
       "filename": "area-stacked-light.png",
-      "sourceSha256": "73beeccad197bd72c30c64c68ad62468d2bec24cddfc365020db44b805ec1723",
+      "sourceSha256": "e41019eee8df45aa758d6e694ae76b69ce40547fb27e2e104963e590e4ecfc1a",
       "pngSha256": "5a708d0255b3c8c56bbecc0f1dc7849420f5ca6f7cb69785954752b8adb50d1a"
     },
     "bar/dodged": {
       "filename": "bar-dodged-light.png",
-      "sourceSha256": "da8c995f706da2e14774b12fe608061e3c7001d046b2bab1faf61d47821da369",
+      "sourceSha256": "f23de7359e3fd06170a946b4f4e0cee9d7e3f12c79d4054bf4ce08bfd554f522",
       "pngSha256": "8cb6896fb9bbc0a416a68469e855b558087867d8b1930b4ad1eade6037ecd7de"
     },
     "bar/horizontal": {
@@ -28,7 +28,7 @@
     },
     "bar/stacked": {
       "filename": "bar-stacked-light.png",
-      "sourceSha256": "dfc0b7cb48dfc8d2591b0108dace3b3ed9b0221d9fce688547b576a965791a20",
+      "sourceSha256": "9be85edde15154c8167ec8b37e79db109ecb7e192521c23d86d268bbd4c24cef",
       "pngSha256": "4c0a7f0b20fcdf9adb777a3c31ec25fbf6d60f30ced058a8f00f22a52bfa4dfd"
     },
     "bin2d/basic": {
@@ -168,32 +168,32 @@
     },
     "interaction/brush-zoom": {
       "filename": "interaction-brush-zoom-light.png",
-      "sourceSha256": "6996cd045e7525f9c64c3779d13d689b382acf6498da2e038fe1b9e26a74d95e",
+      "sourceSha256": "abf36a5635c85583872693b78f4c88b89b83f3cb2e4650206d727b2dedf1f1a9",
       "pngSha256": "1a0ddcf51b7cced3e7a590249f999e3cba23a81adbaa6a95afae3a5497ae3578"
     },
     "interaction/facet-intervals": {
       "filename": "interaction-facet-intervals-light.png",
-      "sourceSha256": "b46256919a0cd1abc2b7b35b45fce728325783b5c55e8cdb9da262f6021b086b",
+      "sourceSha256": "77c1ab0270c3569ad9f1febd57fc42a9783ce1cec13baedb62d786c73cf5eace",
       "pngSha256": "ee7610ff7f47916fac2f509b89d59b89db00dfc1dd9a5efae62fc8abaae53581"
     },
     "interaction/legend-filter": {
       "filename": "interaction-legend-filter-light.png",
-      "sourceSha256": "1fc0b565fe63776cc397a21df2510b7905a1ec301ba594e7a5ccce7321fd0fe6",
+      "sourceSha256": "1cf3b51f956841e6b1b8a7cf0432a60681966c5399b31236634af833249e151d",
       "pngSha256": "83529278279ca7c4bffa4d47d2c57a57ebd8a1de13f3fc798b4971bfb4698853"
     },
     "interaction/legend-focus": {
       "filename": "interaction-legend-focus-light.png",
-      "sourceSha256": "776c12969bcd513265b2085bbf3ffba44a3a2d125595b5f79759bcdec0ca7674",
+      "sourceSha256": "81a87303f9457347c95bfbd7239b65be4ab4504bdd79c643567daad54775cd50",
       "pngSha256": "38aa3c7f47d1c3ab2807039e2377f3c93e292c47c6c19cfe3c2de80e6156091c"
     },
     "interaction/linked-views": {
       "filename": "interaction-linked-views-light.png",
-      "sourceSha256": "5c7d76bf31afd829f2c1b77cb9b77f172fd5ceaeda7cee61f565d6976ac99279",
+      "sourceSha256": "8c23fc8eeec9072b432d52ec1628b8476a0faf1bc4837689395076a5850177f1",
       "pngSha256": "e35c2b1aa843fa95b966f9e7440778d4371f925429d374c738ffaa10938c2f9f"
     },
     "interaction/tooltip": {
       "filename": "interaction-tooltip-light.png",
-      "sourceSha256": "1c09e98b169281f77aff0ff18bb72ccab54f2df0617eb0f4a24dafefdab7ced9",
+      "sourceSha256": "e4d66647873d4bd3f257c72a746939a594a3aa7fac41a43121f9cc88848db85b",
       "pngSha256": "2ada956472d13fac2b0315f486e1a30e2f80a5effd873b3d04dd87005b987940"
     },
     "jitter/basic": {
@@ -218,7 +218,7 @@
     },
     "line/multi-series": {
       "filename": "line-multi-series-light.png",
-      "sourceSha256": "67891f53015c3f32cff5b72765c418a94813df80b2ff5a69b3fe074f5377c122",
+      "sourceSha256": "8a1cb30e1a9786e47484b39472a1fa283b47499996a1e328afdfef8feae0d9db",
       "pngSha256": "da402afca8515a3005d24268f44cc037a1202ce7248675b03c9afbeac3bfc69d"
     },
     "line/time-axis": {
@@ -298,7 +298,7 @@
     },
     "point/scatter-color": {
       "filename": "point-scatter-color-light.png",
-      "sourceSha256": "5c9c94030e4bdaf24df71658225528e1befb14f5722c2da07121b7786db6ad77",
+      "sourceSha256": "210b69f49074dbc49e947ef23f75aa2f2ac17e55b9505f848b46cfc5de5ede7a",
       "pngSha256": "9bbe802827346cc004c03894c8aa27819493a6d7b6bb61ec16eb0b6120b75dd4"
     },
     "point/stat-manual-mean": {

--- a/apps/docs/static/previews/provenance.json
+++ b/apps/docs/static/previews/provenance.json
@@ -8,12 +8,12 @@
     },
     "area/stacked": {
       "filename": "area-stacked-light.png",
-      "sourceSha256": "f19cce3575ddb506cc36fb16e640bc551920712946e01e05681367d2ddac40d4",
+      "sourceSha256": "60c0187db1b1cbcc327754b0de0550030977ad9ba123070d932f3f915e85406b",
       "pngSha256": "5a708d0255b3c8c56bbecc0f1dc7849420f5ca6f7cb69785954752b8adb50d1a"
     },
     "bar/dodged": {
       "filename": "bar-dodged-light.png",
-      "sourceSha256": "0a28542509c2b0e6802162c176d4e0f9c08ca0d35015595cdf4719f28d3ff7e3",
+      "sourceSha256": "ef5159af78070f37f005d1ba52e50aa6a6fe35045426eebf3d745a988942b408",
       "pngSha256": "8cb6896fb9bbc0a416a68469e855b558087867d8b1930b4ad1eade6037ecd7de"
     },
     "bar/horizontal": {
@@ -28,7 +28,7 @@
     },
     "bar/stacked": {
       "filename": "bar-stacked-light.png",
-      "sourceSha256": "4d5a1035c982fc6d42c467ff8b500ec6358b3137156e503a5a846de240f2d060",
+      "sourceSha256": "f5b2158a5b2d0af7274fd4be414906efeab6c0691c9ef6cdaa020d67feaedd63",
       "pngSha256": "4c0a7f0b20fcdf9adb777a3c31ec25fbf6d60f30ced058a8f00f22a52bfa4dfd"
     },
     "bin2d/basic": {
@@ -218,7 +218,7 @@
     },
     "line/multi-series": {
       "filename": "line-multi-series-light.png",
-      "sourceSha256": "b984c2c19c8c0456b5d3985f99c686a27bdecc557779d4de45ca1eb92dba3a08",
+      "sourceSha256": "6befc15bf7df2c7179b3936000717e254e2d6ff2b230c417d0832104a3acd01f",
       "pngSha256": "da402afca8515a3005d24268f44cc037a1202ce7248675b03c9afbeac3bfc69d"
     },
     "line/time-axis": {
@@ -288,7 +288,7 @@
     },
     "point/log-scale": {
       "filename": "point-log-scale-light.png",
-      "sourceSha256": "65caf75369bf2b8a9a4d58f2dd77ba43c994f565fed0dea64bd8d193b31f9a7e",
+      "sourceSha256": "343d6c869b8cce2e82d8700175b000003b8b3aacfb3a156aff72a758e46b4521",
       "pngSha256": "e4cca5e252e49ced88e85a92ff84016533cbbc0fbad7d705fbecbd6e9c84c8a2"
     },
     "point/quantile-lines": {
@@ -298,7 +298,7 @@
     },
     "point/scatter-color": {
       "filename": "point-scatter-color-light.png",
-      "sourceSha256": "984edec045c4f6a57a5cdca64633a42766aef8fe6909dd25e022f05fa68900d0",
+      "sourceSha256": "bc6148b5165f3f08d125fdb95a5063d5af0bcc910bc008dbd2f25004cd39060e",
       "pngSha256": "9bbe802827346cc004c03894c8aa27819493a6d7b6bb61ec16eb0b6120b75dd4"
     },
     "point/stat-manual-mean": {

--- a/apps/docs/static/previews/provenance.json
+++ b/apps/docs/static/previews/provenance.json
@@ -8,7 +8,7 @@
     },
     "area/stacked": {
       "filename": "area-stacked-light.png",
-      "sourceSha256": "eb73d2621c04396a57136201e3c760525ec8096ba354ab5658402edc8d4177b1",
+      "sourceSha256": "73beeccad197bd72c30c64c68ad62468d2bec24cddfc365020db44b805ec1723",
       "pngSha256": "5a708d0255b3c8c56bbecc0f1dc7849420f5ca6f7cb69785954752b8adb50d1a"
     },
     "bar/dodged": {
@@ -288,7 +288,7 @@
     },
     "point/log-scale": {
       "filename": "point-log-scale-light.png",
-      "sourceSha256": "aa5f322432d15656adeb77f5592d60baa06f39c575c0f7065f0f4ba46fed270f",
+      "sourceSha256": "343d6c869b8cce2e82d8700175b000003b8b3aacfb3a156aff72a758e46b4521",
       "pngSha256": "e4cca5e252e49ced88e85a92ff84016533cbbc0fbad7d705fbecbd6e9c84c8a2"
     },
     "point/quantile-lines": {

--- a/apps/docs/static/previews/provenance.json
+++ b/apps/docs/static/previews/provenance.json
@@ -8,12 +8,12 @@
     },
     "area/stacked": {
       "filename": "area-stacked-light.png",
-      "sourceSha256": "e41019eee8df45aa758d6e694ae76b69ce40547fb27e2e104963e590e4ecfc1a",
+      "sourceSha256": "60c0187db1b1cbcc327754b0de0550030977ad9ba123070d932f3f915e85406b",
       "pngSha256": "5a708d0255b3c8c56bbecc0f1dc7849420f5ca6f7cb69785954752b8adb50d1a"
     },
     "bar/dodged": {
       "filename": "bar-dodged-light.png",
-      "sourceSha256": "f23de7359e3fd06170a946b4f4e0cee9d7e3f12c79d4054bf4ce08bfd554f522",
+      "sourceSha256": "ef5159af78070f37f005d1ba52e50aa6a6fe35045426eebf3d745a988942b408",
       "pngSha256": "8cb6896fb9bbc0a416a68469e855b558087867d8b1930b4ad1eade6037ecd7de"
     },
     "bar/horizontal": {
@@ -28,7 +28,7 @@
     },
     "bar/stacked": {
       "filename": "bar-stacked-light.png",
-      "sourceSha256": "9be85edde15154c8167ec8b37e79db109ecb7e192521c23d86d268bbd4c24cef",
+      "sourceSha256": "f5b2158a5b2d0af7274fd4be414906efeab6c0691c9ef6cdaa020d67feaedd63",
       "pngSha256": "4c0a7f0b20fcdf9adb777a3c31ec25fbf6d60f30ced058a8f00f22a52bfa4dfd"
     },
     "bin2d/basic": {
@@ -218,7 +218,7 @@
     },
     "line/multi-series": {
       "filename": "line-multi-series-light.png",
-      "sourceSha256": "8a1cb30e1a9786e47484b39472a1fa283b47499996a1e328afdfef8feae0d9db",
+      "sourceSha256": "6befc15bf7df2c7179b3936000717e254e2d6ff2b230c417d0832104a3acd01f",
       "pngSha256": "da402afca8515a3005d24268f44cc037a1202ce7248675b03c9afbeac3bfc69d"
     },
     "line/time-axis": {
@@ -298,7 +298,7 @@
     },
     "point/scatter-color": {
       "filename": "point-scatter-color-light.png",
-      "sourceSha256": "210b69f49074dbc49e947ef23f75aa2f2ac17e55b9505f848b46cfc5de5ede7a",
+      "sourceSha256": "bc6148b5165f3f08d125fdb95a5063d5af0bcc910bc008dbd2f25004cd39060e",
       "pngSha256": "9bbe802827346cc004c03894c8aa27819493a6d7b6bb61ec16eb0b6120b75dd4"
     },
     "point/stat-manual-mean": {

--- a/examples/area/stacked/Example.svelte
+++ b/examples/area/stacked/Example.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
   import {
     GeomArea,
-    createPlotInteraction,
     GGPlot,
     GuideLegend,
+    Inspect,
     Labs,
     ScaleFillManual,
     ScaleXDate,
@@ -11,19 +11,15 @@
   } from "@ggsvelte/svelte";
 
   import { crimeanMortality } from "./data.js";
-
-  const interaction = createPlotInteraction({
-    identity: (row) => `${row.month}:${row.cause}`,
-  });
 </script>
 
 <GGPlot
   data={crimeanMortality}
   aes={{ x: "month", y: "deaths", fill: "cause" }}
-  {interaction}
   width={640}
   height={400}
 >
+  <Inspect identity={(row) => `${row.month}:${row.cause}`} />
   <ThemeEconomist />
   <ScaleXDate labels="%b %Y" />
   <ScaleFillManual

--- a/examples/area/stacked/Example.svelte
+++ b/examples/area/stacked/Example.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
   import {
+    createPlotInteraction,
     GeomArea,
     GGPlot,
     GuideLegend,
-    Inspect,
     Labs,
     ScaleFillManual,
     ScaleXDate,
@@ -11,15 +11,21 @@
   } from "@ggsvelte/svelte";
 
   import { crimeanMortality } from "./data.js";
+
+  const interaction = createPlotInteraction({
+    identity: (row) => `${row.month}:${row.cause}`,
+  });
+  const scope = { keys: "crimean-rows" } as const;
 </script>
 
 <GGPlot
   data={crimeanMortality}
   aes={{ x: "month", y: "deaths", fill: "cause" }}
+  {interaction}
+  interactionScope={scope}
   width={640}
   height={400}
 >
-  <Inspect identity={(row) => `${row.month}:${row.cause}`} />
   <ThemeEconomist />
   <ScaleXDate labels="%b %Y" />
   <ScaleFillManual

--- a/examples/area/stacked/Example.svelte
+++ b/examples/area/stacked/Example.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import {
     GeomArea,
+    createPlotInteraction,
     GGPlot,
     GuideLegend,
     Labs,
@@ -10,12 +11,16 @@
   } from "@ggsvelte/svelte";
 
   import { crimeanMortality } from "./data.js";
+
+  const interaction = createPlotInteraction({
+    identity: (row) => `${row.month}:${row.cause}`,
+  });
 </script>
 
 <GGPlot
   data={crimeanMortality}
   aes={{ x: "month", y: "deaths", fill: "cause" }}
-  key={(row) => `${row.month}:${row.cause}`}
+  {interaction}
   width={640}
   height={400}
 >

--- a/examples/area/stacked/Example.svelte
+++ b/examples/area/stacked/Example.svelte
@@ -23,6 +23,8 @@
   aes={{ x: "month", y: "deaths", fill: "cause" }}
   {interaction}
   interactionScope={scope}
+  width={640}
+  height={400}
 >
   <ThemeEconomist />
   <ScaleXDate labels="%b %Y" />

--- a/examples/bar/dodged/Example.svelte
+++ b/examples/bar/dodged/Example.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import {
-    Inspect,
+    createPlotInteraction,
     GeomBar,
     GGPlot,
     GuideLegend,
@@ -10,15 +10,21 @@
   } from "@ggsvelte/svelte";
 
   import { edgeworthDeaths } from "./data.js";
+
+  const interaction = createPlotInteraction({
+    identity: (row) => `${row.year}:${row.county}`,
+  });
+  const scope = { keys: "edgeworth-rows" } as const;
 </script>
 
 <GGPlot
   data={edgeworthDeaths}
   aes={{ x: "year", fill: "county", weight: "deaths" }}
+  {interaction}
+  interactionScope={scope}
   width={640}
   height={400}
 >
-  <Inspect identity={(row) => `${row.year}:${row.county}`} />
   <ThemeFew />
   <ScaleFillDiscrete scheme="tableau10" />
   <Labs

--- a/examples/bar/dodged/Example.svelte
+++ b/examples/bar/dodged/Example.svelte
@@ -22,6 +22,8 @@
   aes={{ x: "year", fill: "county", weight: "deaths" }}
   {interaction}
   interactionScope={scope}
+  width={640}
+  height={400}
 >
   <ThemeFew />
   <ScaleFillDiscrete scheme="tableau10" />

--- a/examples/bar/dodged/Example.svelte
+++ b/examples/bar/dodged/Example.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import {
+    Inspect,
     GeomBar,
     GGPlot,
     GuideLegend,
@@ -14,10 +15,10 @@
 <GGPlot
   data={edgeworthDeaths}
   aes={{ x: "year", fill: "county", weight: "deaths" }}
-  key={(row) => `${row.year}:${row.county}`}
   width={640}
   height={400}
 >
+  <Inspect identity={(row) => `${row.year}:${row.county}`} />
   <ThemeFew />
   <ScaleFillDiscrete scheme="tableau10" />
   <Labs

--- a/examples/bar/stacked/Example.svelte
+++ b/examples/bar/stacked/Example.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import {
+    Inspect,
     GeomBar,
     GGPlot,
     GuideLegend,
@@ -15,10 +16,10 @@
 <GGPlot
   data={pyxTrial}
   aes={{ x: "bag", fill: "deviation", weight: "count" }}
-  key={(row) => `${row.bag}:${row.deviation}`}
   width={640}
   height={400}
 >
+  <Inspect identity={(row) => `${row.bag}:${row.deviation}`} />
   <ThemeLight />
   <ScaleXDiscrete
     domain={["1 and 2", "3", "4", "5", "6", "7", "8", "9", "10"]}

--- a/examples/bar/stacked/Example.svelte
+++ b/examples/bar/stacked/Example.svelte
@@ -23,6 +23,8 @@
   aes={{ x: "bag", fill: "deviation", weight: "count" }}
   {interaction}
   interactionScope={scope}
+  width={640}
+  height={400}
 >
   <ThemeLight />
   <ScaleXDiscrete

--- a/examples/bar/stacked/Example.svelte
+++ b/examples/bar/stacked/Example.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import {
-    Inspect,
+    createPlotInteraction,
     GeomBar,
     GGPlot,
     GuideLegend,
@@ -11,15 +11,21 @@
   } from "@ggsvelte/svelte";
 
   import { pyxTrial } from "./data.js";
+
+  const interaction = createPlotInteraction({
+    identity: (row) => `${row.bag}:${row.deviation}`,
+  });
+  const scope = { keys: "pyx-rows" } as const;
 </script>
 
 <GGPlot
   data={pyxTrial}
   aes={{ x: "bag", fill: "deviation", weight: "count" }}
+  {interaction}
+  interactionScope={scope}
   width={640}
   height={400}
 >
-  <Inspect identity={(row) => `${row.bag}:${row.deviation}`} />
   <ThemeLight />
   <ScaleXDiscrete
     domain={["1 and 2", "3", "4", "5", "6", "7", "8", "9", "10"]}

--- a/examples/interaction/brush-zoom/Example.svelte
+++ b/examples/interaction/brush-zoom/Example.svelte
@@ -20,7 +20,6 @@
 <GGPlot
   data={field}
   aes={{ x: "bill", y: "mass", color: "species" }}
-  key="id"
   select={{ type: "interval", mode: "xy", persistent: true }}
   zoom={{ mode: "xy" }}
   onselect={(event) => {

--- a/examples/interaction/facet-intervals/Example.svelte
+++ b/examples/interaction/facet-intervals/Example.svelte
@@ -46,7 +46,6 @@
   <GGPlot
     data={observations}
     aes={{ x: "bill", y: "mass" }}
-    key="id"
     select={{ type: "interval", mode: "xy", persistent: true, preset }}
     width="container"
     height={430}

--- a/examples/interaction/legend-filter/Example.svelte
+++ b/examples/interaction/legend-filter/Example.svelte
@@ -21,7 +21,6 @@
   <GGPlot
     data={britishFinances}
     aes={{ x: "year", y: "value", color: "series" }}
-    key="id"
     width="container"
     height={430}
     onlegendfilter={(event) => {

--- a/examples/interaction/legend-focus/Example.svelte
+++ b/examples/interaction/legend-focus/Example.svelte
@@ -40,7 +40,6 @@
     <GGPlot
       data={rows}
       aes={mapping}
-      key="id"
       {interaction}
       interactionScope={scope}
       width="container"
@@ -56,7 +55,6 @@
     <GGPlot
       data={rows}
       aes={mapping}
-      key="id"
       {interaction}
       interactionScope={scope}
       width="container"
@@ -72,7 +70,6 @@
     <GGPlot
       data={rows}
       aes={mapping}
-      key="id"
       {interaction}
       interactionScope={scope}
       width="container"

--- a/examples/interaction/linked-views/Example.svelte
+++ b/examples/interaction/linked-views/Example.svelte
@@ -74,7 +74,6 @@
     <GGPlot
       data={rows}
       aes={{ x: "flipper", y: "mass", color: "species" }}
-      key="id"
       select={{ type: "point", multiple: true }}
       zoom={{ mode: "x" }}
       {interaction}
@@ -96,7 +95,6 @@
     <GGPlot
       data={rows}
       aes={{ x: "flipper", y: "mass" }}
-      key="id"
       select={{ type: "point", multiple: true }}
       zoom={{ mode: "x" }}
       {interaction}

--- a/examples/interaction/tooltip/Example.svelte
+++ b/examples/interaction/tooltip/Example.svelte
@@ -17,7 +17,6 @@
 <GGPlot
   data={penguins}
   aes={{ x: "flipper", y: "mass", color: "species" }}
-  key="id"
   oninspect={(event) => {
     inspectionStatus =
       event.phase === "clear"

--- a/examples/line/multi-series/Example.svelte
+++ b/examples/line/multi-series/Example.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import {
+    Inspect,
     GeomLine,
     GeomPoint,
     GGPlot,
@@ -16,10 +17,10 @@
 <GGPlot
   data={wheatAndWages}
   aes={{ x: "year", y: "value", color: "series" }}
-  key={(row) => `${row.year}:${row.series}`}
   width={640}
   height={400}
 >
+  <Inspect identity={(row) => `${row.year}:${row.series}`} />
   <ThemeEconomist />
   <ScaleXContinuous
     breaks={[1600, 1650, 1700, 1750, 1800]}

--- a/examples/line/multi-series/Example.svelte
+++ b/examples/line/multi-series/Example.svelte
@@ -24,6 +24,8 @@
   aes={{ x: "year", y: "value", color: "series" }}
   {interaction}
   interactionScope={scope}
+  width={640}
+  height={400}
 >
   <ThemeEconomist />
   <ScaleXContinuous

--- a/examples/line/multi-series/Example.svelte
+++ b/examples/line/multi-series/Example.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import {
-    Inspect,
+    createPlotInteraction,
     GeomLine,
     GeomPoint,
     GGPlot,
@@ -12,15 +12,21 @@
   } from "@ggsvelte/svelte";
 
   import { wheatAndWages } from "./data.js";
+
+  const interaction = createPlotInteraction({
+    identity: (row) => `${row.year}:${row.series}`,
+  });
+  const scope = { keys: "wheat-rows" } as const;
 </script>
 
 <GGPlot
   data={wheatAndWages}
   aes={{ x: "year", y: "value", color: "series" }}
+  {interaction}
+  interactionScope={scope}
   width={640}
   height={400}
 >
-  <Inspect identity={(row) => `${row.year}:${row.series}`} />
   <ThemeEconomist />
   <ScaleXContinuous
     breaks={[1600, 1650, 1700, 1750, 1800]}

--- a/examples/point/log-scale/Example.svelte
+++ b/examples/point/log-scale/Example.svelte
@@ -16,11 +16,10 @@
 <GGPlot
   data={londonCholera}
   aes={{ x: "density", y: "deathRate", color: "water" }}
-  key="district"
   width="container"
   height={400}
 >
-  <Inspect mode="xy" pin />
+  <Inspect mode="xy" pin identity="district" />
   <ThemeEconomist />
   <ScaleXLog10 labels="~s" />
   <ScaleColorManual

--- a/examples/point/log-scale/Example.svelte
+++ b/examples/point/log-scale/Example.svelte
@@ -16,6 +16,8 @@
 <GGPlot
   data={londonCholera}
   aes={{ x: "density", y: "deathRate", color: "water" }}
+  width="container"
+  height={400}
 >
   <Inspect mode="xy" pin identity="district" />
   <ThemeEconomist />

--- a/examples/point/scatter-color/Example.svelte
+++ b/examples/point/scatter-color/Example.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import {
+    Inspect,
     GeomPoint,
     GGPlot,
     GuideLegend,
@@ -14,10 +15,10 @@
 <GGPlot
   data={guerry}
   aes={{ x: "literacy", y: "crimePersons", color: "region" }}
-  key="department"
   width={640}
   height={400}
 >
+  <Inspect identity="department" />
   <ThemeFew />
   <ScaleColorDiscrete scheme="tableau10" />
   <Labs

--- a/examples/point/scatter-color/Example.svelte
+++ b/examples/point/scatter-color/Example.svelte
@@ -22,6 +22,8 @@
   aes={{ x: "literacy", y: "crimePersons", color: "region" }}
   {interaction}
   interactionScope={scope}
+  width={640}
+  height={400}
 >
   <ThemeFew />
   <ScaleColorDiscrete scheme="tableau10" />

--- a/examples/point/scatter-color/Example.svelte
+++ b/examples/point/scatter-color/Example.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import {
-    Inspect,
+    createPlotInteraction,
     GeomPoint,
     GGPlot,
     GuideLegend,
@@ -10,15 +10,21 @@
   } from "@ggsvelte/svelte";
 
   import { guerry } from "./data.js";
+
+  const interaction = createPlotInteraction({
+    identity: "department",
+  });
+  const scope = { keys: "guerry-rows" } as const;
 </script>
 
 <GGPlot
   data={guerry}
   aes={{ x: "literacy", y: "crimePersons", color: "region" }}
+  {interaction}
+  interactionScope={scope}
   width={640}
   height={400}
 >
-  <Inspect identity="department" />
   <ThemeFew />
   <ScaleColorDiscrete scheme="tableau10" />
   <Labs

--- a/lifecycle.json
+++ b/lifecycle.json
@@ -5129,6 +5129,10 @@
           "kind": "type",
           "lifecycle": "experimental"
         },
+        "ControllerDatumIdentity": {
+          "kind": "type",
+          "lifecycle": "experimental"
+        },
         "Coord": {
           "kind": "value",
           "lifecycle": "stable-intent"

--- a/packages/svelte/skills/ggsvelte/references/interactions.md
+++ b/packages/svelte/skills/ggsvelte/references/interactions.md
@@ -6,9 +6,10 @@
 opt-in host capabilities — they are not PortableSpec fields. Prefer declaration
 children where they exist (`<Inspect>`, `<GuideLegend focus>`). Row identity for
 selection, legend focus, and coordinated intervals **defaults** to an `id`
-column when present, otherwise the row index — ordinary charts omit `key`.
-Pass `key` only as an override for a non-`id` durable field or a custom
-accessor (for example `key="year"` on a time series without an `id` column).
+column when present, otherwise the row index (order-stable only) — ordinary
+charts omit custom identity. Prefer `identity` on `<Inspect>`, object-form
+`select`, or `createPlotInteraction` for a non-`id` durable field or accessor
+(for example `<Inspect identity="year" />`). Plot-level `key` is deprecated.
 
 ## Inspect capability (preferred: child)
 
@@ -24,9 +25,9 @@ accessor (for example `key="year"` on a time series without an `id` column).
 ```
 
 Empty `<Inspect />` enables defaults. Options match `InspectOptions`: `mode`,
-`pin`, `maxDistance`, `contentMode`, `muteSiblings`, `content` (Snippet). Prefer
-the child form in new code; the GGPlot `inspect` prop is a dual-read alias, not
-the primary teaching surface.
+`pin`, `maxDistance`, `contentMode`, `muteSiblings`, `identity` (column or
+accessor), `content` (Snippet). Prefer the child form in new code; the GGPlot
+`inspect` prop is a dual-read alias, not the primary teaching surface.
 
 ### Mark eligibility (opt-out)
 
@@ -37,17 +38,18 @@ and unrelated to the host `<Inspect>` capability.
 
 ## Capability props
 
-| Prop / surface | Input                                                            | What it enables                                                                                                                                                                                                                                                                                                                                                                            |
-| -------------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `<Inspect>`    | child of `<GGPlot>` (options as props)                           | Tooltip, semantic crosshair, keyboard traversal, pinning. **Preferred.** Options: `mode` (`"auto" \| "exact" \| "x" \| "y" \| "xy"`), `pin`, `maxDistance` (CSS px), `contentMode` (`"informational" \| "interactive"`), `muteSiblings`, `content` (Snippet, see Tooltip below). Do not put `inspect=` on `<GGPlot>` in new examples.                                                      |
-| `select`       | `false \| "point" \| "interval" \| SelectOptions`                | Point or interval selection. Options: `type` (`"point" \| "interval"`), `mode` (`"x" \| "y" \| "xy"`, interval only), `multiple`, `persistent`, `preset` (faceted intervals, below).                                                                                                                                                                                                       |
-| `zoom`         | `boolean \| ZoomOptions`                                         | Brush zoom. Options: `mode` (`"x" \| "y" \| "xy"`), `trigger` (`"brush"`). Currently requires one unfaceted panel.                                                                                                                                                                                                                                                                         |
-| `focus`        | `boolean \| { preview?: boolean }` on `<GuideLegend>`            | Discrete legend preview, focus, and linked emphasis **for that aesthetic channel**. Emphasis only — never changes included rows. Discrete legends only; continuous ramps stay static. Mute de-emphasizes non-focused marks; dashed rings appear only on sparse point marks (≤48 anchors), never on paths/areas/bars/segments/text. Host-only — not a PortableSpec / `guideLegend()` field. |
-| `filter`       | `boolean \| LegendFilterOptions` on `<GuideLegend>`              | Data-changing filtering on **that aesthetic's** discrete legend: changes included rows and reruns the grammar while preserving stable color identity. Options: `mode` (`"exclude" \| "include"`), `multiple`. Combine with focus: `<GuideLegend channel="color" focus filter />`.                                                                                                          |
-| `key`          | column name or `(row, index) => PropertyKey` (optional override) | Durable row identity for public interaction payloads. **Default:** `id` column when present, else row index. Override only for a non-`id` natural key or a custom accessor. Duplicate or unstable keys are diagnostic errors.                                                                                                                                                              |
-| `tool`         | `"inspect" \| "point" \| "select-area" \| "zoom-area"`           | Controlled initial/active tool; observe changes with `ontoolchange`.                                                                                                                                                                                                                                                                                                                       |
-| `ariaLabel`    | `string`                                                         | Accessible chart name; falls back to the plot title or a generated label.                                                                                                                                                                                                                                                                                                                  |
-| `a11y`         | `A11yMode`                                                       | `"force-svg"` keeps every layer as SVG marks.                                                                                                                                                                                                                                                                                                                                              |
+| Prop / surface | Input                                                                    | What it enables                                                                                                                                                                                                                                                                                                                                                                            |
+| -------------- | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `<Inspect>`    | child of `<GGPlot>` (options as props)                                   | Tooltip, semantic crosshair, keyboard traversal, pinning. **Preferred.** Options: `mode` (`"auto" \| "exact" \| "x" \| "y" \| "xy"`), `pin`, `maxDistance` (CSS px), `contentMode` (`"informational" \| "interactive"`), `muteSiblings`, `identity` (column or accessor), `content` (Snippet, see Tooltip below). Do not put `inspect=` on `<GGPlot>` in new examples.                     |
+| `select`       | `false \| "point" \| "interval" \| SelectOptions`                        | Point or interval selection. Options: `type` (`"point" \| "interval"`), `mode` (`"x" \| "y" \| "xy"`, interval only), `multiple`, `persistent`, `preset` (faceted intervals, below), `identity` (column or accessor).                                                                                                                                                                      |
+| `zoom`         | `boolean \| ZoomOptions`                                                 | Brush zoom. Options: `mode` (`"x" \| "y" \| "xy"`), `trigger` (`"brush"`). Currently requires one unfaceted panel.                                                                                                                                                                                                                                                                         |
+| `focus`        | `boolean \| { preview?: boolean }` on `<GuideLegend>`                    | Discrete legend preview, focus, and linked emphasis **for that aesthetic channel**. Emphasis only — never changes included rows. Discrete legends only; continuous ramps stay static. Mute de-emphasizes non-focused marks; dashed rings appear only on sparse point marks (≤48 anchors), never on paths/areas/bars/segments/text. Host-only — not a PortableSpec / `guideLegend()` field. |
+| `filter`       | `boolean \| LegendFilterOptions` on `<GuideLegend>`                      | Data-changing filtering on **that aesthetic's** discrete legend: changes included rows and reruns the grammar while preserving stable color identity. Options: `mode` (`"exclude" \| "include"`), `multiple`. Combine with focus: `<GuideLegend channel="color" focus filter />`.                                                                                                          |
+| `identity`     | column or `(row, index) => PropertyKey` on Inspect / Select / controller | Durable row identity for public interaction payloads. **Default:** `id` column when present, else row index (order-stable only). Prefer this over plot-level `key`.                                                                                                                                                                                                                        |
+| `key`          | column or accessor on `<GGPlot>` (**deprecated** since 0.21)             | Dual-read until 0.22. Prefer `identity` on Inspect / Select / `createPlotInteraction`.                                                                                                                                                                                                                                                                                                     |
+| `tool`         | `"inspect" \| "point" \| "select-area" \| "zoom-area"`                   | Controlled initial/active tool; observe changes with `ontoolchange`.                                                                                                                                                                                                                                                                                                                       |
+| `ariaLabel`    | `string`                                                                 | Accessible chart name; falls back to the plot title or a generated label.                                                                                                                                                                                                                                                                                                                  |
+| `a11y`         | `A11yMode`                                                               | `"force-svg"` keeps every layer as SVG marks.                                                                                                                                                                                                                                                                                                                                              |
 
 ### Deprecated: plot-level `legendFocus` / `legendFilter`
 
@@ -67,8 +69,9 @@ facet panels:
 - `cross-panel` — the sole origin interval is projected into compatible panels.
 
 `union` and `cross-panel` use the resolved row identity (default `id` / index,
-or an explicit `key` override). The engine always supplies an identity, so
-these presets no longer fail solely because `key` was omitted.
+or an explicit `identity` override on Select / Inspect / controller). The
+engine always supplies an identity, so these presets no longer fail solely
+because identity was omitted.
 
 ## Controller: durable shared state
 
@@ -82,9 +85,10 @@ domains only; each chart translates them to its own render model.
   `clearInterval`, `clearIntervals`, `setZoom(domains, {scope, source?})`,
   `resetZoom`, `reconcileKeys` (call after replacing rows).
 - Reads: `selected(scope)`, `emphasized(scope)`, `isSelected(key, scope)`,
-  `intervals(scope)`, `zoom(scope)`, `snapshot`, `revision` (reactive).
-- `createPlotInteraction({ onchange })` observes every transition
-  (`kind`, `source`, `revision`).
+  `intervals(scope)`, `zoom(scope)`, `snapshot`, `revision` (reactive),
+  `identity` (optional, from create options).
+- `createPlotInteraction({ onchange, identity })` observes every transition
+  (`kind`, `source`, `revision`) and may set a shared row-identity override.
 
 `interactionScope` (`{ keys, x?, y?, intervals? }`) names the identity
 namespaces used for linking: key state crosses charts only through `keys`;

--- a/packages/svelte/src/lib/index.ts
+++ b/packages/svelte/src/lib/index.ts
@@ -23,6 +23,7 @@ export type {
 } from "./legend/filter.js";
 export { createPlotInteraction } from "./interaction/controller.svelte.js";
 export type {
+  ControllerDatumIdentity,
   CreatePlotInteractionOptions,
   PlotInteractionController,
   PlotInteractionMutationOptions,

--- a/packages/svelte/src/lib/inspection/Inspect.svelte
+++ b/packages/svelte/src/lib/inspection/Inspect.svelte
@@ -29,6 +29,13 @@
     maxDistance?: number;
     contentMode?: "informational" | "interactive";
     muteSiblings?: boolean;
+    /**
+     * Durable row identity (column or accessor). Preferred over deprecated
+     * GGPlot `key`. Default when omitted: `id` column or row index.
+     */
+    identity?:
+      | PropertyKey
+      | ((row: Record<string, CellValue>, index: number) => PropertyKey);
     /** Row/Key widen at the non-generic registry boundary (same as engine). */
     content?: Snippet<
       [PlotInspectionChange<Record<string, CellValue>, PropertyKey>]
@@ -42,6 +49,7 @@
     "maxDistance",
     "contentMode",
     "muteSiblings",
+    "identity",
     "content",
   ]);
 

--- a/packages/svelte/src/lib/interaction/controller.svelte.ts
+++ b/packages/svelte/src/lib/interaction/controller.svelte.ts
@@ -1,3 +1,5 @@
+import type { CellValue } from "@ggsvelte/core";
+
 import type {
   InteractionSource,
   PlotInteractionChange,
@@ -35,13 +37,29 @@ export interface PlotInteractionZoomOptions {
   readonly source?: InteractionSource;
 }
 
+/** Row identity override shared by plots bound to this controller. */
+export type ControllerDatumIdentity<Key extends PropertyKey> =
+  | PropertyKey
+  | ((row: Record<string, CellValue>, index: number) => Key);
+
 export interface CreatePlotInteractionOptions<Key extends PropertyKey> {
   readonly onchange?: (transition: PlotInteractionTransition<Key>) => void;
+  /**
+   * Preferred durable row identity for plots that bind this controller.
+   * Per-plot Inspect / Select `identity` overrides this. Prefer these
+   * surfaces over the deprecated GGPlot `key` prop.
+   */
+  readonly identity?: ControllerDatumIdentity<Key>;
 }
 
 export interface PlotInteractionController<Key extends PropertyKey> {
   readonly revision: number;
   readonly snapshot: PlotInteractionSnapshot<Key>;
+  /**
+   * Optional row identity from {@link createPlotInteraction} options.
+   * Plots read this when resolving datum keys; never mutated after create.
+   */
+  readonly identity?: ControllerDatumIdentity<Key>;
   selected(scope: KeyScope): ReadonlyArray<Key>;
   emphasized(scope: KeyScope): ReadonlyArray<Key>;
   isSelected(key: Key, scope: KeyScope): boolean;
@@ -195,6 +213,7 @@ export function createPlotInteraction<Key extends PropertyKey = PropertyKey>(
     get snapshot() {
       return currentSnapshot();
     },
+    ...(options.identity !== undefined && { identity: options.identity }),
     selected(scope) {
       void revision;
       return selections.get(keyScope(scope)) ?? EMPTY_KEYS;

--- a/packages/svelte/src/lib/interaction/interaction-diagnostics.ts
+++ b/packages/svelte/src/lib/interaction/interaction-diagnostics.ts
@@ -65,10 +65,10 @@ export const INTERACTION_DIAGNOSTIC_CATALOG: Readonly<
     severity: "warning",
     code: "INTERACTION_POINT_REQUIRES_KEY",
     message: "Durable point selection requires resolved row identity.",
-    prop: "key",
+    prop: "identity",
     suggestions: [
-      "Omit key — defaults to an id column or row index",
-      'Override with key="id" or a stable key accessor when needed',
+      "Ordinary charts omit identity — defaults to an id column or row index",
+      'Override with <Inspect identity="id" /> or select={{ type: "point", identity: "id" }}',
     ],
     docUrl: "https://ggsvelte.sh/guide/interaction-reference#interaction-point-requires-key",
   },
@@ -77,10 +77,10 @@ export const INTERACTION_DIAGNOSTIC_CATALOG: Readonly<
     code: "INTERACTION_INTERVAL_PRESET_REQUIRES_KEY",
     message:
       "Coordinated interval presets (union, cross-panel) require resolved row identity; without it they combine no rows.",
-    prop: "key",
+    prop: "identity",
     suggestions: [
-      "Omit key — defaults to an id column or row index",
-      'Override with key="id" or a stable key accessor when needed',
+      "Ordinary charts omit identity — defaults to an id column or row index",
+      'Override with select={{ type: "interval", identity: "id", … }} or <Inspect identity="id" />',
     ],
     docUrl:
       "https://ggsvelte.sh/guide/interaction-reference#interaction-interval-preset-requires-key",
@@ -89,7 +89,7 @@ export const INTERACTION_DIAGNOSTIC_CATALOG: Readonly<
     severity: "error",
     code: "INTERACTION_INVALID_KEY",
     message: "A key accessor returned null, undefined, or a non-PropertyKey value.",
-    prop: "key",
+    prop: "identity",
     suggestions: ["Return a stable string, number, or symbol for every row"],
     docUrl: "https://ggsvelte.sh/guide/interaction-reference#interaction-invalid-key",
   },
@@ -98,7 +98,7 @@ export const INTERACTION_DIAGNOSTIC_CATALOG: Readonly<
     code: "INTERACTION_DUPLICATE_KEY",
     message:
       "The key accessor returned a duplicate value; durable interaction is disabled for that value.",
-    prop: "key",
+    prop: "identity",
     suggestions: ["Use a field that uniquely identifies each source row"],
     docUrl: "https://ggsvelte.sh/guide/interaction-reference#interaction-duplicate-key",
   },
@@ -106,7 +106,7 @@ export const INTERACTION_DIAGNOSTIC_CATALOG: Readonly<
     severity: "error",
     code: "INTERACTION_UNSTABLE_KEY",
     message: "The key accessor returned a different value for the same source row.",
-    prop: "key",
+    prop: "identity",
     suggestions: ["Return an immutable field that uniquely identifies each row"],
     docUrl: "https://ggsvelte.sh/guide/interaction-reference#interaction-unstable-key",
   },
@@ -123,10 +123,10 @@ export const INTERACTION_DIAGNOSTIC_CATALOG: Readonly<
     code: "INTERACTION_LEGEND_REQUIRES_KEY",
     message:
       "Legend focus requires resolved row identity so encoded legend values never become identities.",
-    prop: "key",
+    prop: "identity",
     suggestions: [
-      "Omit key — defaults to an id column or row index",
-      'Override with key="id" or a stable key accessor when needed',
+      "Ordinary charts omit identity — defaults to an id column or row index",
+      'Override with <Inspect identity="id" /> or createPlotInteraction({ identity: "id" })',
     ],
     docUrl: "https://ggsvelte.sh/guide/interaction-reference#interaction-legend-requires-key",
   },

--- a/packages/svelte/src/lib/interaction/interaction.ts
+++ b/packages/svelte/src/lib/interaction/interaction.ts
@@ -145,6 +145,12 @@ export interface InspectOptions<Row = Record<string, CellValue>, Key = PropertyK
    * flicker when the pointer crosses gaps between rect marks (#633).
    */
   readonly muteSiblings?: boolean;
+  /**
+   * Durable row identity for interaction payloads (pin rebind, selection
+   * keys, legend focus). Preferred over the deprecated GGPlot `key` prop.
+   * Default when omitted: `id` column if present, else row index.
+   */
+  readonly identity?: Key | ((row: Row, index: number) => Key);
   readonly content?: Snippet<[PlotInspectionChange<Row, Key>]>;
 }
 
@@ -155,6 +161,14 @@ export interface SelectOptions {
   readonly persistent?: boolean;
   /** Facet coordination semantics for durable interval selections. */
   readonly preset?: FacetIntervalPreset;
+  /**
+   * Durable row identity for selection keys (and shared plot interaction).
+   * Preferred over the deprecated GGPlot `key` prop. Not selection semantics —
+   * omitted from the resolved select config.
+   */
+  readonly identity?:
+    | PropertyKey
+    | ((row: Record<string, CellValue>, index: number) => PropertyKey);
 }
 
 export interface ZoomOptions {
@@ -176,9 +190,11 @@ export type LegendFocusInput = boolean | LegendFocusOptions;
 export interface ResolvedInteractionConfig<Row = Record<string, CellValue>, Key = PropertyKey> {
   readonly interactive: boolean;
   readonly inspect: Readonly<
-    Required<Omit<InspectOptions<Row, Key>, "content">> & Pick<InspectOptions<Row, Key>, "content">
+    Required<Omit<InspectOptions<Row, Key>, "content" | "identity">> &
+      Pick<InspectOptions<Row, Key>, "content">
   > | null;
-  readonly select: Readonly<Required<SelectOptions>> | null;
+  /** Select config without `identity` (identity is resolved separately for row keys). */
+  readonly select: Readonly<Required<Omit<SelectOptions, "identity">>> | null;
   readonly zoom: Readonly<Required<ZoomOptions>> | null;
   readonly legendFocus: Readonly<Required<LegendFocusOptions>> | null;
   readonly initialTool: InteractionTool;

--- a/packages/svelte/src/lib/plot-engine.svelte.ts
+++ b/packages/svelte/src/lib/plot-engine.svelte.ts
@@ -48,7 +48,12 @@ import {
   resolveInteractionScope,
   toLayerInput,
 } from "./assembly/assemble.js";
-import { resolveDatumKey } from "./runtime/resolve-datum-key.js";
+import {
+  identityFromInspectInput,
+  identityFromSelectInput,
+  pickExplicitDatumKey,
+  resolveDatumKey,
+} from "./runtime/resolve-datum-key.js";
 import {
   collectCompositionDiagnostics,
   compositionAdvisoryDedupKey,
@@ -98,6 +103,7 @@ import type { PlotChromeState } from "./chrome/chrome-state.svelte.js";
 import { isHostPlotLayer } from "./layers/types.js";
 import { deprecatedPropDiagnostic } from "./diagnostics/deprecation.js";
 import {
+  readLegacyPlotKey,
   readLegacyPlotLegendFilter,
   readLegacyPlotLegendFocus,
   resolveCapabilities,
@@ -269,15 +275,21 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
   );
 
   /**
-   * Durable row identity: explicit GGPlot `key` override, else auto `id`
-   * column, else row index. Always defined — interaction never requires
-   * authors to pass `key` for ordinary charts.
+   * Durable row identity: Inspect / Select / controller `identity` first,
+   * then deprecated GGPlot `key`, else auto `id` column, else row index.
+   * Always defined — ordinary charts need no custom identity.
    */
   function resolvedDatumKeyNow() {
     const data = host.props.data;
     const embedded = assembled()?.data;
+    const explicit = pickExplicitDatumKey({
+      inspect: identityFromInspectInput(inspectResolved().input),
+      select: identityFromSelectInput(host.props.select),
+      controller: host.props.interaction?.identity,
+      legacy: readLegacyPlotKey(host.props),
+    });
     return resolveDatumKey({
-      explicit: host.props.key,
+      ...(explicit !== undefined && { explicit }),
       data: data ?? embedded,
     });
   }
@@ -442,6 +454,27 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
       deliveredAdvisories.add(dedupKey);
       deliverDiagnostic(diagnostic);
     }
+  });
+
+  // Deprecated plot-level key → Inspect / Select / controller identity.
+  $effect(() => {
+    const plotProp = readLegacyPlotKey(host.props);
+    if (plotProp === undefined) return;
+    const diagnostic = deprecatedPropDiagnostic({
+      prop: "key",
+      since: "0.21.0",
+      removeIn: "0.22.0",
+      suggestions: [
+        'Use <Inspect identity="year" /> (or inspect={{ identity: "year" }})',
+        'Use select={{ type: "point", identity: "year" }} when selection owns the key',
+        'Use createPlotInteraction({ identity: "year" }) for linked controllers',
+      ],
+      anchor: "row-identity-on-interaction",
+    });
+    const dedupKey = `${diagnostic.code}:${diagnostic.prop}`;
+    if (deliveredAdvisories.has(dedupKey)) return;
+    deliveredAdvisories.add(dedupKey);
+    deliverDiagnostic(diagnostic);
   });
 
   // Deprecated plot-level legendFocus → GuideLegend.focus (one minor window).

--- a/packages/svelte/src/lib/plot-engine.svelte.ts
+++ b/packages/svelte/src/lib/plot-engine.svelte.ts
@@ -282,11 +282,16 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
   function resolvedDatumKeyNow() {
     const data = host.props.data;
     const embedded = assembled()?.data;
+    const inspectIdentity = identityFromInspectInput(inspectResolved().input);
+    const selectIdentity = identityFromSelectInput(host.props.select);
+    const controllerIdentity = host.props.interaction?.identity;
+    const legacyKey = readLegacyPlotKey(host.props);
+    // exactOptionalPropertyTypes: omit keys rather than pass `undefined`.
     const explicit = pickExplicitDatumKey({
-      inspect: identityFromInspectInput(inspectResolved().input),
-      select: identityFromSelectInput(host.props.select),
-      controller: host.props.interaction?.identity,
-      legacy: readLegacyPlotKey(host.props),
+      ...(inspectIdentity !== undefined && { inspect: inspectIdentity }),
+      ...(selectIdentity !== undefined && { select: selectIdentity }),
+      ...(controllerIdentity !== undefined && { controller: controllerIdentity }),
+      ...(legacyKey !== undefined && { legacy: legacyKey }),
     });
     return resolveDatumKey({
       ...(explicit !== undefined && { explicit }),

--- a/packages/svelte/src/lib/plot-props.ts
+++ b/packages/svelte/src/lib/plot-props.ts
@@ -216,7 +216,11 @@ export function widenPlotProps<
   const handler: ProxyHandler<GGPlotProps<Row, Identity>> = {
     get(target, prop, receiver) {
       // Six precise casts — only these fields change assignability.
-      if (prop === "key") return target.key as EnginePlotProps["key"];
+      if (prop === "key") {
+        // Dual-read until 0.22.0 — prefer interaction-surface identity.
+        // oxlint-disable-next-line typescript/no-deprecated -- intentional dual-read
+        return target.key as EnginePlotProps["key"];
+      }
       if (prop === "interaction") {
         return target.interaction as EnginePlotProps["interaction"];
       }

--- a/packages/svelte/src/lib/plot-props.ts
+++ b/packages/svelte/src/lib/plot-props.ts
@@ -68,9 +68,12 @@ export interface GGPlotProps<
   /** Plot height in px (falls back to spec.height, then 400). */
   height?: number;
   /**
-   * Optional override for durable row identity (selection, legend focus, pin
-   * rebind, linked controllers). Default: use an `id` column when present,
-   * otherwise the row index. Ordinary charts should omit this prop.
+   * @deprecated since 0.21.0 — use `identity` on `<Inspect>`, object-form
+   * `select={{ type, identity }}`, or `createPlotInteraction({ identity })`.
+   * Still honoured (dual-read) until 0.22.0; emits DEPRECATED_PLOT_PROP.
+   * Default when no surface sets identity: `id` column when present, else
+   * row index. Ordinary charts should omit identity entirely.
+   * Migration: https://ggsvelte.sh/guide/upgrading#row-identity-on-interaction
    */
   key?: Identity;
   /** Opt into inspection, its semantic crosshair, tooltip, and pinning. */
@@ -146,6 +149,18 @@ export function resolveCapabilities(props: {
     legendFocus: props.legendFocus ?? false,
     legendFilter: props.legendFilter ?? false,
   };
+}
+
+/**
+ * Read the deprecated plot-level `key` prop during the dual-read window.
+ * Prefer Inspect / Select / createPlotInteraction `identity` instead.
+ */
+export function readLegacyPlotKey(
+  props: EnginePlotProps | GGPlotProps,
+): EnginePlotProps["key"] | undefined {
+  // Dual-read until 0.22.0 — prefer interaction-surface identity.
+  // oxlint-disable-next-line typescript/no-deprecated -- intentional dual-read
+  return props.key;
 }
 
 /**

--- a/packages/svelte/src/lib/runtime/resolve-datum-key.ts
+++ b/packages/svelte/src/lib/runtime/resolve-datum-key.ts
@@ -29,7 +29,7 @@ export type ExplicitDatumKeySources = {
   readonly select?: DatumKey | undefined;
   /** `createPlotInteraction({ identity })` when bound via `interaction=`. */
   readonly controller?: DatumKey | undefined;
-  /** @deprecated GGPlot `key` — dual-read until removal. */
+  /** Deprecated GGPlot `key` dual-read (prefer interaction-surface identity). */
   readonly legacy?: DatumKey | undefined;
 };
 

--- a/packages/svelte/src/lib/runtime/resolve-datum-key.ts
+++ b/packages/svelte/src/lib/runtime/resolve-datum-key.ts
@@ -2,14 +2,15 @@
  * Resolve durable row identity for interaction (selection, legend focus, pin
  * rebind, linked controllers).
  *
- * Plot authors should not need a `key` prop for ordinary charts:
- * 1. Explicit `key` / accessor on GGPlot wins when provided (override).
- * 2. Else if plot data exposes a PropertyKey-valued `id` column → use `"id"`.
- * 3. Else use the row index (unique within the current row order).
+ * Plot authors should not need a custom identity for ordinary charts:
+ * 1. Interaction-surface identity (Inspect / Select / controller) when set.
+ * 2. Deprecated GGPlot `key` dual-read (until removal).
+ * 3. Else if plot data exposes a PropertyKey-valued `id` column → use `"id"`.
+ * 4. Else use the row index (order-stable only — not reorder-safe).
  *
  * Index identity is enough for single-plot legend focus / inspect / local
  * selection. Custom durable identity across reorders or non-`id` natural keys
- * still uses the explicit `key` override (future: interaction-surface only).
+ * belongs on Inspect / Select / createPlotInteraction — not plot grammar.
  */
 import type { CellValue } from "@ggsvelte/core";
 
@@ -17,12 +18,58 @@ export type DatumKey =
   | PropertyKey
   | ((row: Record<string, CellValue>, index: number) => PropertyKey);
 
+/**
+ * Explicit identity sources. Prefer interaction surfaces over the deprecated
+ * plot-level `key` prop. First defined wins in this order.
+ */
+export type ExplicitDatumKeySources = {
+  /** `<Inspect identity=…>` or `inspect={{ identity: … }}`. */
+  readonly inspect?: DatumKey | undefined;
+  /** `select={{ type, identity: … }}`. */
+  readonly select?: DatumKey | undefined;
+  /** `createPlotInteraction({ identity })` when bound via `interaction=`. */
+  readonly controller?: DatumKey | undefined;
+  /** @deprecated GGPlot `key` — dual-read until removal. */
+  readonly legacy?: DatumKey | undefined;
+};
+
 export type ResolveDatumKeyInput = {
-  /** Explicit GGPlot `key` prop when the author opts into a custom identity. */
+  /**
+   * Already-picked explicit identity (from {@link pickExplicitDatumKey} or a
+   * single override). Wins over auto `id` / row-index defaults.
+   */
   readonly explicit?: DatumKey | undefined;
   /** Plot data input (row array, DataRef, or bare columns map). */
   readonly data?: unknown;
 };
+
+/**
+ * Pick the first defined identity from interaction surfaces, then legacy
+ * GGPlot `key`. Returns `undefined` when no surface supplies an override.
+ */
+export function pickExplicitDatumKey(sources: ExplicitDatumKeySources): DatumKey | undefined {
+  if (sources.inspect !== undefined) return sources.inspect;
+  if (sources.select !== undefined) return sources.select;
+  if (sources.controller !== undefined) return sources.controller;
+  if (sources.legacy !== undefined) return sources.legacy;
+  return undefined;
+}
+
+/** Read `identity` from `inspect` prop / resolved inspect capability input. */
+export function identityFromInspectInput(
+  input: boolean | { readonly identity?: DatumKey } | undefined,
+): DatumKey | undefined {
+  if (input === undefined || input === false || input === true) return undefined;
+  return input.identity;
+}
+
+/** Read `identity` from object-form `select` (string shorthand has none). */
+export function identityFromSelectInput(
+  input: false | string | { readonly identity?: DatumKey } | undefined,
+): DatumKey | undefined {
+  if (input === undefined || input === false || typeof input === "string") return undefined;
+  return input.identity;
+}
 
 /** Row-index identity — default when no `id` column and no explicit key. */
 function rowIndexDatumKey(_row: Record<string, CellValue>, index: number): PropertyKey {

--- a/packages/svelte/src/lib/runtime/resolve-datum-key.ts
+++ b/packages/svelte/src/lib/runtime/resolve-datum-key.ts
@@ -24,13 +24,13 @@ export type DatumKey =
  */
 export type ExplicitDatumKeySources = {
   /** `<Inspect identity=…>` or `inspect={{ identity: … }}`. */
-  readonly inspect?: DatumKey | undefined;
+  readonly inspect?: DatumKey;
   /** `select={{ type, identity: … }}`. */
-  readonly select?: DatumKey | undefined;
+  readonly select?: DatumKey;
   /** `createPlotInteraction({ identity })` when bound via `interaction=`. */
-  readonly controller?: DatumKey | undefined;
+  readonly controller?: DatumKey;
   /** Deprecated GGPlot `key` dual-read (prefer interaction-surface identity). */
-  readonly legacy?: DatumKey | undefined;
+  readonly legacy?: DatumKey;
 };
 
 export type ResolveDatumKeyInput = {
@@ -38,7 +38,7 @@ export type ResolveDatumKeyInput = {
    * Already-picked explicit identity (from {@link pickExplicitDatumKey} or a
    * single override). Wins over auto `id` / row-index defaults.
    */
-  readonly explicit?: DatumKey | undefined;
+  readonly explicit?: DatumKey;
   /** Plot data input (row array, DataRef, or bare columns map). */
   readonly data?: unknown;
 };

--- a/packages/svelte/tests/interaction/controller.test.ts
+++ b/packages/svelte/tests/interaction/controller.test.ts
@@ -11,6 +11,13 @@ const scope = {
 } as const;
 
 describe("createPlotInteraction", () => {
+  it("exposes optional identity for plots bound to the controller", () => {
+    expect(createPlotInteraction().identity).toBeUndefined();
+    expect(createPlotInteraction({ identity: "year" }).identity).toBe("year");
+    const accessor = (row: { id: string }) => row.id;
+    expect(createPlotInteraction({ identity: accessor }).identity).toBe(accessor);
+  });
+
   it("stores frozen semantic intervals per stable panel identity", () => {
     const controller = createPlotInteraction<string>();
     const intervalScope = { ...scope, intervals: "penguin-facets" } as const;

--- a/packages/svelte/tests/interaction/normalize-interaction-config.test.ts
+++ b/packages/svelte/tests/interaction/normalize-interaction-config.test.ts
@@ -57,7 +57,7 @@ describe("interaction capability normalization", () => {
     expect(withoutKey.diagnostics).toContainEqual(
       expect.objectContaining({
         code: "INTERACTION_LEGEND_REQUIRES_KEY",
-        prop: "key",
+        prop: "identity",
       }),
     );
     expect(withoutKey.legendFocus).toBeNull();
@@ -76,7 +76,7 @@ describe("interaction capability normalization", () => {
       expect(withoutKey.diagnostics).toContainEqual(
         expect.objectContaining({
           code: "INTERACTION_INTERVAL_PRESET_REQUIRES_KEY",
-          prop: "key",
+          prop: "identity",
         }),
       );
     }

--- a/packages/svelte/tests/interaction/wiring-diagnostics.test.ts
+++ b/packages/svelte/tests/interaction/wiring-diagnostics.test.ts
@@ -22,7 +22,7 @@ const base = {
   data: rows,
   aes: { x: "x", y: "y" },
   layers: [{ geom: "point" as const }],
-  key: "id",
+  // Default identity: rows expose `id` — no plot-level `key` (deprecated).
   ...size,
 };
 
@@ -167,5 +167,42 @@ describe("handler-without-capability advisory", () => {
     } finally {
       warn.mockRestore();
     }
+  });
+});
+
+describe("deprecated plot-level key advisory", () => {
+  it("advises DEPRECATED_PLOT_PROP when GGPlot key is set", async () => {
+    const { diagnostics, ondiagnostic } = collect();
+    render(GGPlot, {
+      ...base,
+      // oxlint-disable-next-line typescript/no-deprecated -- dual-read under test
+      key: "id",
+      ondiagnostic,
+    });
+    await expect
+      .poll(() => diagnostics.find((d) => d.code === "DEPRECATED_PLOT_PROP" && d.prop === "key"))
+      .toMatchObject({
+        severity: "advisory",
+        prop: "key",
+        since: "0.21.0",
+        removeIn: "0.22.0",
+      });
+  });
+
+  it("stays silent when identity comes from createPlotInteraction", async () => {
+    const { diagnostics, ondiagnostic } = collect();
+    const interaction = createPlotInteraction<string>({ identity: "id" });
+    const { container } = render(GGPlot, {
+      ...base,
+      interaction,
+      interactionScope: { keys: "row-id" },
+      ondiagnostic,
+    });
+    await settled(container);
+    expect(
+      diagnostics.filter(
+        (d) => d.code === "DEPRECATED_PLOT_PROP" && "prop" in d && d.prop === "key",
+      ),
+    ).toHaveLength(0);
   });
 });

--- a/packages/svelte/tests/migrations/row-identity-after.svelte
+++ b/packages/svelte/tests/migrations/row-identity-after.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  import { GeomPoint, GGPlot, Inspect } from "../../src/lib/index.js";
+
+  const rows = [
+    { country: "Japan", year: 812, temp: 6.1 },
+    { country: "Korea", year: 900, temp: 5.8 },
+  ];
+</script>
+
+<!-- After 0.21: identity on Inspect (or select / createPlotInteraction). -->
+<GGPlot data={rows} aes={{ x: "year", y: "temp" }}>
+  <Inspect identity="country" />
+  <GeomPoint />
+</GGPlot>

--- a/packages/svelte/tests/migrations/row-identity-before.svelte
+++ b/packages/svelte/tests/migrations/row-identity-before.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  import { GeomPoint, GGPlot, Inspect } from "../../src/lib/index.js";
+
+  const rows = [
+    { country: "Japan", year: 812, temp: 6.1 },
+    { country: "Korea", year: 900, temp: 5.8 },
+  ];
+</script>
+
+<!-- Before 0.21: plot-level key. -->
+<GGPlot data={rows} aes={{ x: "year", y: "temp" }} key="country">
+  <Inspect />
+  <GeomPoint />
+</GGPlot>

--- a/packages/svelte/tests/runtime/resolve-datum-key.test.ts
+++ b/packages/svelte/tests/runtime/resolve-datum-key.test.ts
@@ -153,7 +153,7 @@ describe("pickExplicitDatumKey", () => {
 
 describe("identityFromInspectInput", () => {
   it("returns undefined for absent, false, or true inspect", () => {
-    expect(identityFromInspectInput(undefined)).toBeUndefined();
+    expect(identityFromInspectInput()).toBeUndefined();
     expect(identityFromInspectInput(false)).toBeUndefined();
     expect(identityFromInspectInput(true)).toBeUndefined();
   });
@@ -165,7 +165,7 @@ describe("identityFromInspectInput", () => {
 
 describe("identityFromSelectInput", () => {
   it("returns undefined for absent, false, or string shorthand", () => {
-    expect(identityFromSelectInput(undefined)).toBeUndefined();
+    expect(identityFromSelectInput()).toBeUndefined();
     expect(identityFromSelectInput(false)).toBeUndefined();
     expect(identityFromSelectInput("point")).toBeUndefined();
   });

--- a/packages/svelte/tests/runtime/resolve-datum-key.test.ts
+++ b/packages/svelte/tests/runtime/resolve-datum-key.test.ts
@@ -6,7 +6,12 @@
  */
 import { describe, expect, it } from "vitest";
 
-import { resolveDatumKey } from "../../src/lib/runtime/resolve-datum-key.js";
+import {
+  identityFromInspectInput,
+  identityFromSelectInput,
+  pickExplicitDatumKey,
+  resolveDatumKey,
+} from "../../src/lib/runtime/resolve-datum-key.js";
 
 describe("resolveDatumKey", () => {
   it("uses an explicit column name when provided", () => {
@@ -98,5 +103,74 @@ describe("resolveDatumKey", () => {
         data: [{ id: "row-1", year: 812 }],
       }),
     ).toBe("year");
+  });
+});
+
+describe("pickExplicitDatumKey", () => {
+  it("prefers inspect identity over select, controller, and legacy key", () => {
+    expect(
+      pickExplicitDatumKey({
+        inspect: "year",
+        select: "country",
+        controller: "id",
+        legacy: "region",
+      }),
+    ).toBe("year");
+  });
+
+  it("prefers select identity over controller and legacy when inspect is absent", () => {
+    expect(
+      pickExplicitDatumKey({
+        select: "country",
+        controller: "id",
+        legacy: "region",
+      }),
+    ).toBe("country");
+  });
+
+  it("prefers controller identity over legacy plot key", () => {
+    expect(
+      pickExplicitDatumKey({
+        controller: "id",
+        legacy: "region",
+      }),
+    ).toBe("id");
+  });
+
+  it("falls back to legacy GGPlot key when no interaction surface sets identity", () => {
+    expect(pickExplicitDatumKey({ legacy: "region" })).toBe("region");
+  });
+
+  it("returns undefined when no surface provides identity", () => {
+    expect(pickExplicitDatumKey({})).toBeUndefined();
+  });
+
+  it("treats only undefined as absent — allows accessor functions", () => {
+    const accessor = (row: { a: number }, index: number) => `${row.a}:${index}`;
+    expect(pickExplicitDatumKey({ inspect: accessor })).toBe(accessor);
+  });
+});
+
+describe("identityFromInspectInput", () => {
+  it("returns undefined for absent, false, or true inspect", () => {
+    expect(identityFromInspectInput(undefined)).toBeUndefined();
+    expect(identityFromInspectInput(false)).toBeUndefined();
+    expect(identityFromInspectInput(true)).toBeUndefined();
+  });
+
+  it("reads identity from an InspectOptions bag", () => {
+    expect(identityFromInspectInput({ identity: "year", mode: "xy" })).toBe("year");
+  });
+});
+
+describe("identityFromSelectInput", () => {
+  it("returns undefined for absent, false, or string shorthand", () => {
+    expect(identityFromSelectInput(undefined)).toBeUndefined();
+    expect(identityFromSelectInput(false)).toBeUndefined();
+    expect(identityFromSelectInput("point")).toBeUndefined();
+  });
+
+  it("reads identity from a SelectOptions bag", () => {
+    expect(identityFromSelectInput({ type: "point", identity: "country" })).toBe("country");
   });
 });

--- a/scripts/gen-llms.test.ts
+++ b/scripts/gen-llms.test.ts
@@ -241,7 +241,7 @@ describe("guide sections cover their catalogs", () => {
     expect(INTERACTIONS_MD).not.toContain("/playground");
     expect(INTERACTIONS_MD).toContain('<Inspect mode="x" pin maxDistance={24} />');
     expect(INTERACTIONS_MD).toContain('select={{ type: "interval", mode: "xy",');
-    expect(INTERACTIONS_MD).toContain('key="id"');
+    expect(INTERACTIONS_MD).toContain('identity: "id"');
     expect(INTERACTIONS_MD).toContain("oninspect");
     expect(INTERACTIONS_MD).toContain("onselect");
     expect(INTERACTIONS_MD).toContain("oninteraction");

--- a/scripts/llms-guide-content.ts
+++ b/scripts/llms-guide-content.ts
@@ -1315,7 +1315,6 @@ axis:
 <GGPlot
   {data}
   aes={{ x: "date", y: "value", color: "series" }}
-  key="id"
   oninspect={(event) => console.log(event)}
 >
   <Inspect mode="x" pin maxDistance={24} />
@@ -1343,20 +1342,20 @@ contains controls that need focus.
   <span>{inspection.members.length} series at this value</span>
 {/snippet}
 
-<GGPlot {data} aes={{ x: "date", y: "value" }} key="id">
+<GGPlot {data} aes={{ x: "date", y: "value" }}>
   <Inspect mode="x" content={details} />
 </GGPlot>
 \`\`\`
 
 ## Point and interval selection
 
-Point selection is durable identity, not a renderer index. Supply a unique,
-stable string, number, or symbol for every source row:
+Point selection is durable identity, not a renderer index. Identity defaults
+to an \`id\` column or row index; override with \`identity\` on Select / Inspect
+for a non-\`id\` natural key:
 
 \`\`\`svelte fragment
 <GGPlot
-  key="id"
-  select={{ type: "point", multiple: true }}
+  select={{ type: "point", multiple: true, identity: "id" }}
   onselect={(event) => {
     if (event.mode === "point") selectedKeys = event.keys;
   }}
@@ -1369,7 +1368,6 @@ count for aggregate marks.
 
 \`\`\`svelte fragment
 <GGPlot
-  key="id"
   select={{ type: "interval", mode: "xy", persistent: true }}
   onselect={(event) => {
     if (event.mode !== "point" && event.phase === "end") {
@@ -1404,21 +1402,19 @@ emitting the callback again. Controlled plots never infer channel names: add an
 <script lang="ts">
   import { createPlotInteraction } from "@ggsvelte/svelte";
 
-  const interaction = createPlotInteraction<string>();
+  const interaction = createPlotInteraction<string>({ identity: "id" });
   const scope = { keys: "penguin-id", x: "flipper-mm", y: "mass-g" } as const;
   const selected = $derived(interaction.selected(scope));
 </script>
 
 <GGPlot
   {data}
-  key="id"
   select={{ type: "point", multiple: true }}
   {interaction}
   interactionScope={scope}
 />
 <GGPlot
   {data}
-  key="id"
   select={{ type: "point", multiple: true }}
   {interaction}
   interactionScope={scope}
@@ -1580,11 +1576,14 @@ description path.
 
 ## Identity and diagnostics
 
-Use \`key="id"\` when the row has a field, or \`key={(row) => row.id}\` for an
-accessor. Keys must be non-null unique \`PropertyKey\` values and stable across
-updates. Invalid or duplicate keys emit structured diagnostics through
-\`ondiagnostic\`; they never silently fall back to array positions. Stable keys
-let pinned inspection and point selection follow a datum when data is updated.
+Ordinary charts omit custom identity: the engine uses an \`id\` column when
+present, otherwise the row index (order-stable only). For a non-\`id\` natural
+key or accessor, set \`identity\` on \`<Inspect>\`, object-form \`select\`, or
+\`createPlotInteraction({ identity })\` — not plot-level \`key\` (deprecated).
+Keys must be non-null unique \`PropertyKey\` values and stable across updates.
+Invalid or duplicate keys emit structured diagnostics through \`ondiagnostic\`.
+Stable identity lets pinned inspection and point selection follow a datum when
+data is updated.
 `;
 
 const interactionDiagnostics = Object.values(INTERACTION_DIAGNOSTIC_CATALOG)
@@ -1623,7 +1622,8 @@ etc.). Options match the legacy GGPlot prop: \`mode\`, \`pin\`, \`maxDistance\`,
 ### Point selection
 
 \`select={{ type: "point", multiple: true }}\` stores stable semantic keys.
-Supply \`key\` for every row.
+Identity defaults to an \`id\` column or row index; override with
+\`select={{ type: "point", identity: "…" }}\` or \`<Inspect identity="…" />\`.
 
 ### Interval selection
 
@@ -1924,6 +1924,62 @@ migration note here.
 The accepted lifecycle and deprecation policy remains in
 [Lifecycle and editions](/guide/lifecycle#lifecycle-tags); this page applies it
 rather than creating a second policy.
+
+## 0.20 to 0.21
+
+### Row identity on interaction surfaces
+
+Durable row identity no longer belongs on the grammar root. Ordinary charts
+omit identity entirely: the engine uses an \`id\` column when present, otherwise
+the **row index** (order-stable only — not reorder-safe across data refresh).
+
+Custom durable identity (non-\`id\` natural keys, composite accessors, pin
+rebind across reorder) lives on interaction surfaces:
+
+\`\`\`svelte fragment
+<script lang="ts">
+  import { GeomPoint, GGPlot, Inspect } from "@ggsvelte/svelte";
+
+  const rows = [
+    { country: "Japan", year: 812, temp: 6.1 },
+    { country: "Korea", year: 900, temp: 5.8 },
+  ];
+</script>
+
+<!-- Before 0.21: plot-level key. -->
+<GGPlot data={rows} aes={{ x: "year", y: "temp" }} key="country">
+  <Inspect />
+  <GeomPoint />
+</GGPlot>
+\`\`\`
+
+\`\`\`svelte fragment
+<script lang="ts">
+  import { GeomPoint, GGPlot, Inspect } from "@ggsvelte/svelte";
+
+  const rows = [
+    { country: "Japan", year: 812, temp: 6.1 },
+    { country: "Korea", year: 900, temp: 5.8 },
+  ];
+</script>
+
+<!-- After 0.21: identity on Inspect (or select / createPlotInteraction). -->
+<GGPlot data={rows} aes={{ x: "year", y: "temp" }}>
+  <Inspect identity="country" />
+  <GeomPoint />
+</GGPlot>
+\`\`\`
+
+- Prefer \`<Inspect identity="…" />\` or \`inspect={{ identity: "…" }}\` when
+  inspect is enabled.
+- Prefer \`select={{ type: "point", identity: "…" }}\` (or interval) when
+  selection owns the key without inspect.
+- Prefer \`createPlotInteraction({ identity: "…" })\` when linked plots share
+  one controller and the same identity field.
+- Resolution order: Inspect → Select → controller → deprecated \`key\` →
+  auto \`id\` → row index.
+- \`<GGPlot key>\` still dual-reads through 0.21.x and emits
+  \`DEPRECATED_PLOT_PROP\`; it is removed in 0.22.0.
 
 ## 0.18 to 0.19
 

--- a/scripts/llms-guide-content.ts
+++ b/scripts/llms-guide-content.ts
@@ -1927,7 +1927,7 @@ rather than creating a second policy.
 
 ## 0.20 to 0.21
 
-### Row identity on interaction surfaces
+### Row identity on interaction
 
 Durable row identity no longer belongs on the grammar root. Ordinary charts
 omit identity entirely: the engine uses an \`id\` column when present, otherwise

--- a/skills/ggsvelte/references/interactions.md
+++ b/skills/ggsvelte/references/interactions.md
@@ -6,9 +6,10 @@
 opt-in host capabilities — they are not PortableSpec fields. Prefer declaration
 children where they exist (`<Inspect>`, `<GuideLegend focus>`). Row identity for
 selection, legend focus, and coordinated intervals **defaults** to an `id`
-column when present, otherwise the row index — ordinary charts omit `key`.
-Pass `key` only as an override for a non-`id` durable field or a custom
-accessor (for example `key="year"` on a time series without an `id` column).
+column when present, otherwise the row index (order-stable only) — ordinary
+charts omit custom identity. Prefer `identity` on `<Inspect>`, object-form
+`select`, or `createPlotInteraction` for a non-`id` durable field or accessor
+(for example `<Inspect identity="year" />`). Plot-level `key` is deprecated.
 
 ## Inspect capability (preferred: child)
 
@@ -24,9 +25,9 @@ accessor (for example `key="year"` on a time series without an `id` column).
 ```
 
 Empty `<Inspect />` enables defaults. Options match `InspectOptions`: `mode`,
-`pin`, `maxDistance`, `contentMode`, `muteSiblings`, `content` (Snippet). Prefer
-the child form in new code; the GGPlot `inspect` prop is a dual-read alias, not
-the primary teaching surface.
+`pin`, `maxDistance`, `contentMode`, `muteSiblings`, `identity` (column or
+accessor), `content` (Snippet). Prefer the child form in new code; the GGPlot
+`inspect` prop is a dual-read alias, not the primary teaching surface.
 
 ### Mark eligibility (opt-out)
 
@@ -37,17 +38,18 @@ and unrelated to the host `<Inspect>` capability.
 
 ## Capability props
 
-| Prop / surface | Input                                                            | What it enables                                                                                                                                                                                                                                                                                                                                                                            |
-| -------------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `<Inspect>`    | child of `<GGPlot>` (options as props)                           | Tooltip, semantic crosshair, keyboard traversal, pinning. **Preferred.** Options: `mode` (`"auto" \| "exact" \| "x" \| "y" \| "xy"`), `pin`, `maxDistance` (CSS px), `contentMode` (`"informational" \| "interactive"`), `muteSiblings`, `content` (Snippet, see Tooltip below). Do not put `inspect=` on `<GGPlot>` in new examples.                                                      |
-| `select`       | `false \| "point" \| "interval" \| SelectOptions`                | Point or interval selection. Options: `type` (`"point" \| "interval"`), `mode` (`"x" \| "y" \| "xy"`, interval only), `multiple`, `persistent`, `preset` (faceted intervals, below).                                                                                                                                                                                                       |
-| `zoom`         | `boolean \| ZoomOptions`                                         | Brush zoom. Options: `mode` (`"x" \| "y" \| "xy"`), `trigger` (`"brush"`). Currently requires one unfaceted panel.                                                                                                                                                                                                                                                                         |
-| `focus`        | `boolean \| { preview?: boolean }` on `<GuideLegend>`            | Discrete legend preview, focus, and linked emphasis **for that aesthetic channel**. Emphasis only — never changes included rows. Discrete legends only; continuous ramps stay static. Mute de-emphasizes non-focused marks; dashed rings appear only on sparse point marks (≤48 anchors), never on paths/areas/bars/segments/text. Host-only — not a PortableSpec / `guideLegend()` field. |
-| `filter`       | `boolean \| LegendFilterOptions` on `<GuideLegend>`              | Data-changing filtering on **that aesthetic's** discrete legend: changes included rows and reruns the grammar while preserving stable color identity. Options: `mode` (`"exclude" \| "include"`), `multiple`. Combine with focus: `<GuideLegend channel="color" focus filter />`.                                                                                                          |
-| `key`          | column name or `(row, index) => PropertyKey` (optional override) | Durable row identity for public interaction payloads. **Default:** `id` column when present, else row index. Override only for a non-`id` natural key or a custom accessor. Duplicate or unstable keys are diagnostic errors.                                                                                                                                                              |
-| `tool`         | `"inspect" \| "point" \| "select-area" \| "zoom-area"`           | Controlled initial/active tool; observe changes with `ontoolchange`.                                                                                                                                                                                                                                                                                                                       |
-| `ariaLabel`    | `string`                                                         | Accessible chart name; falls back to the plot title or a generated label.                                                                                                                                                                                                                                                                                                                  |
-| `a11y`         | `A11yMode`                                                       | `"force-svg"` keeps every layer as SVG marks.                                                                                                                                                                                                                                                                                                                                              |
+| Prop / surface | Input                                                                    | What it enables                                                                                                                                                                                                                                                                                                                                                                            |
+| -------------- | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `<Inspect>`    | child of `<GGPlot>` (options as props)                                   | Tooltip, semantic crosshair, keyboard traversal, pinning. **Preferred.** Options: `mode` (`"auto" \| "exact" \| "x" \| "y" \| "xy"`), `pin`, `maxDistance` (CSS px), `contentMode` (`"informational" \| "interactive"`), `muteSiblings`, `identity` (column or accessor), `content` (Snippet, see Tooltip below). Do not put `inspect=` on `<GGPlot>` in new examples.                     |
+| `select`       | `false \| "point" \| "interval" \| SelectOptions`                        | Point or interval selection. Options: `type` (`"point" \| "interval"`), `mode` (`"x" \| "y" \| "xy"`, interval only), `multiple`, `persistent`, `preset` (faceted intervals, below), `identity` (column or accessor).                                                                                                                                                                      |
+| `zoom`         | `boolean \| ZoomOptions`                                                 | Brush zoom. Options: `mode` (`"x" \| "y" \| "xy"`), `trigger` (`"brush"`). Currently requires one unfaceted panel.                                                                                                                                                                                                                                                                         |
+| `focus`        | `boolean \| { preview?: boolean }` on `<GuideLegend>`                    | Discrete legend preview, focus, and linked emphasis **for that aesthetic channel**. Emphasis only — never changes included rows. Discrete legends only; continuous ramps stay static. Mute de-emphasizes non-focused marks; dashed rings appear only on sparse point marks (≤48 anchors), never on paths/areas/bars/segments/text. Host-only — not a PortableSpec / `guideLegend()` field. |
+| `filter`       | `boolean \| LegendFilterOptions` on `<GuideLegend>`                      | Data-changing filtering on **that aesthetic's** discrete legend: changes included rows and reruns the grammar while preserving stable color identity. Options: `mode` (`"exclude" \| "include"`), `multiple`. Combine with focus: `<GuideLegend channel="color" focus filter />`.                                                                                                          |
+| `identity`     | column or `(row, index) => PropertyKey` on Inspect / Select / controller | Durable row identity for public interaction payloads. **Default:** `id` column when present, else row index (order-stable only). Prefer this over plot-level `key`.                                                                                                                                                                                                                        |
+| `key`          | column or accessor on `<GGPlot>` (**deprecated** since 0.21)             | Dual-read until 0.22. Prefer `identity` on Inspect / Select / `createPlotInteraction`.                                                                                                                                                                                                                                                                                                     |
+| `tool`         | `"inspect" \| "point" \| "select-area" \| "zoom-area"`                   | Controlled initial/active tool; observe changes with `ontoolchange`.                                                                                                                                                                                                                                                                                                                       |
+| `ariaLabel`    | `string`                                                                 | Accessible chart name; falls back to the plot title or a generated label.                                                                                                                                                                                                                                                                                                                  |
+| `a11y`         | `A11yMode`                                                               | `"force-svg"` keeps every layer as SVG marks.                                                                                                                                                                                                                                                                                                                                              |
 
 ### Deprecated: plot-level `legendFocus` / `legendFilter`
 
@@ -67,8 +69,9 @@ facet panels:
 - `cross-panel` — the sole origin interval is projected into compatible panels.
 
 `union` and `cross-panel` use the resolved row identity (default `id` / index,
-or an explicit `key` override). The engine always supplies an identity, so
-these presets no longer fail solely because `key` was omitted.
+or an explicit `identity` override on Select / Inspect / controller). The
+engine always supplies an identity, so these presets no longer fail solely
+because identity was omitted.
 
 ## Controller: durable shared state
 
@@ -82,9 +85,10 @@ domains only; each chart translates them to its own render model.
   `clearInterval`, `clearIntervals`, `setZoom(domains, {scope, source?})`,
   `resetZoom`, `reconcileKeys` (call after replacing rows).
 - Reads: `selected(scope)`, `emphasized(scope)`, `isSelected(key, scope)`,
-  `intervals(scope)`, `zoom(scope)`, `snapshot`, `revision` (reactive).
-- `createPlotInteraction({ onchange })` observes every transition
-  (`kind`, `source`, `revision`).
+  `intervals(scope)`, `zoom(scope)`, `snapshot`, `revision` (reactive),
+  `identity` (optional, from create options).
+- `createPlotInteraction({ onchange, identity })` observes every transition
+  (`kind`, `source`, `revision`) and may set a shared row-identity override.
 
 `interactionScope` (`{ keys, x?, y?, intervals? }`) names the identity
 namespaces used for linking: key state crosses charts only through `keys`;


### PR DESCRIPTION
## Summary

Closes #1253. Custom durable row identity moves off plot-level `GGPlot key` onto interaction surfaces:

- `<Inspect identity="…" />` / `inspect={{ identity: "…" }}`
- `select={{ type: "point" | "interval", identity: "…" }}`
- `createPlotInteraction({ identity: "…" })`

Resolution order: Inspect → Select → controller → deprecated `key` → auto `id` column → row index (order-stable only). Ordinary charts still omit identity entirely.

`GGPlot key` dual-reads through 0.21.x and emits `DEPRECATED_PLOT_PROP`; hard removal is 0.22.0.

## Test plan

- [x] TDD: `pickExplicitDatumKey` priority + inspect/select extract helpers
- [x] Controller exposes `identity` from create options
- [x] Wiring diagnostics: deprecated `key` advisory; silence when identity is on the controller
- [x] Focused vitest (chromium): resolve-datum-key, controller, normalize, wiring-diagnostics
- [x] Package `tsc --noEmit`
- [ ] CI green on the PR

## Migration

https://ggsvelte.sh/guide/upgrading#row-identity-on-interaction
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1257" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->