### PR TITLE
docs: teach v0.20 Inspect and GuideLegend interaction API

### DIFF
--- a/.changeset/v020-interaction-docs.md
+++ b/.changeset/v020-interaction-docs.md
@@ -1,0 +1,15 @@
+---
+"@ggsvelte/svelte": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+docs(skill): teach v0.20 Inspect / GuideLegend interaction API
+
+Agent skill and site copy preferred the deprecated GGPlot `inspect`,
+`legendFocus`, and `legendFilter` props. Prefer `<Inspect>` and
+`<GuideLegend channel focus|filter />` in skill fences, homepage JSON, and
+the guides reference. Gallery examples already use the children; a contract
+test keeps them that way.
+
+Migration: none — teaching only.

--- a/apps/docs/src/lib/home-code-path.ts
+++ b/apps/docs/src/lib/home-code-path.ts
@@ -16,8 +16,8 @@
  * - Svelte: `<Inspect>` child; `focus` on <GuideLegend>
  * - Builder + spec: same host children; inspect via `<Inspect>`
  * - Row identity defaults to the `id` column on palmerPenguins (no `key` prop)
- * - JSON: agent envelope `{ interactions, spec }` still accepts legendFocus
- *   (deprecated host map until 0.20.0)
+ * - JSON: agent envelope `{ interactions, spec }` may flag inspect; legend
+ *   focus/filter are Svelte GuideLegend children, not envelope fields.
  */
 
 const HOME_CODE_PATH_SVELTE = `<script lang="ts">
@@ -68,14 +68,13 @@ const HOME_CODE_PATH_BUILDER = `<script lang="ts">
 /**
  * Agent envelope: host interaction flags + named-data PortableSpec.
  * `spec` alone is valid PortableSpec; interactions are applied by the host.
- * `inspect: true` still defaults mode "auto"; the homepage host opts into xy
- * via `<Inspect mode="xy" … />` in the Svelte tabs above.
- * `legendFocus` remains in the envelope as a deprecated host map (0.19–0.20).
+ * Envelope `inspect: true` defaults mode "auto"; the live homepage uses xy
+ * via `<Inspect mode="xy" … />` in the Svelte tabs. Legend focus is not an
+ * envelope field — use `<GuideLegend channel="color" focus />` in Svelte.
  */
 const HOME_CODE_PATH_SPEC_JSON = `{
   "interactions": {
-    "inspect": true,
-    "legendFocus": true
+    "inspect": true
   },
   "spec": {
     "edition": 2,

--- a/apps/docs/src/routes/reference/guides/+page.svelte
+++ b/apps/docs/src/routes/reference/guides/+page.svelte
@@ -112,12 +112,12 @@ guides({ color: guideLegend({ position: "bottom" }) })
   <p>
     Discrete color and fill legends can host interaction controls when
     <code>&lt;GuideLegend focus /&gt;</code> or
-    <code>&lt;GuideLegend filter /&gt;</code> is enabled for that aesthetic
-    (deprecated plot props <code>legendFocus</code> /
-    <code>legendFilter</code> still work plot-wide until 0.20). Focus is
-    presentation emphasis only; Clear legend focus restores the unfocused view
-    without changing data. Filter changes included rows. Authoring the guide
-    itself is separate — see
+    <code>&lt;GuideLegend filter /&gt;</code> is enabled for that aesthetic. Do
+    not put <code>legendFocus</code> / <code>legendFilter</code> on
+    <code>&lt;GGPlot&gt;</code> — those plot props are deprecated dual-reads.
+    Focus is presentation emphasis only; Clear legend focus restores the
+    unfocused view without changing data. Filter changes included rows.
+    Authoring the guide itself is separate — see
     <a href={`${base}/reference/guides/legend`}><code>GuideLegend</code></a>,
     the
     <a href={`${base}/guide/interaction-reference#legendfocus`}

--- a/packages/svelte/skills/ggsvelte/SKILL.md
+++ b/packages/svelte/skills/ggsvelte/SKILL.md
@@ -114,10 +114,11 @@ direct props (`size={3}`); structural props are `data`, `stat`, `position`,
 
 `<GGPlot>` props: `spec`, `data`, `aes`, `layers`, `key`, `width`
 (number | "container"), `height`, `a11y`, `ariaLabel`, the interaction props
-(`inspect`, `select`, `zoom`, `tool`, `interaction`,
-`interactionScope`; `legendFocus` / `legendFilter` are deprecated — use
-`<GuideLegend channel focus>` / `<GuideLegend channel filter>`), the `on*`
-handlers, and `children`.
+(`select`, `zoom`, `tool`, `interaction`, `interactionScope`; prefer
+`<Inspect>` for inspection and `<GuideLegend channel focus>` /
+`<GuideLegend channel filter>` for legend interaction — do not put
+`inspect` / `legendFocus` / `legendFilter` on `<GGPlot>` in new code), the
+`on*` handlers, and `children`.
 Instance methods: `resetScales()`, `setZoom()`.
 
 Precedence: `spec` wins over everything else. For mark layers, an explicit
@@ -274,10 +275,10 @@ violin, tile heatmap, hex density, ECDF step, ribbon, flipped boxplot,
 per-layer aes override, sf/map — each as validated JSON plus a Svelte twin:
 [references/recipes.md](references/recipes.md).
 
-## Interactions (host props, not PortableSpec fields)
+## Interactions (host props / children, not PortableSpec fields)
 
-Opt-in host capabilities: `inspect` / `select` / `zoom` on `<GGPlot>`; legend
-emphasis and data-changing filter via
+Opt-in host capabilities: `<Inspect />` for tooltips and crosshairs;
+`select` / `zoom` on `<GGPlot>`; legend emphasis and data-changing filter via
 `<GuideLegend channel="color" focus />` / `filter` (per aesthetic; host-only,
 not in `guideLegend()` / PortableSpec). Always give a stable `key` when
 selection or linked views must survive filtering or refreshes. Link plots by

--- a/packages/svelte/skills/ggsvelte/references/interactions.md
+++ b/packages/svelte/skills/ggsvelte/references/interactions.md
@@ -23,9 +23,10 @@ accessor (for example `key="year"` on a time series without an `id` column).
 </GGPlot>
 ```
 
-Empty `<Inspect />` enables defaults (same as the legacy `inspect={true}` prop).
-Options match `InspectOptions`: `mode`, `pin`, `maxDistance`, `contentMode`,
-`muteSiblings`, `content` (Snippet). The GGPlot `inspect` prop still works.
+Empty `<Inspect />` enables defaults. Options match `InspectOptions`: `mode`,
+`pin`, `maxDistance`, `contentMode`, `muteSiblings`, `content` (Snippet). Prefer
+the child form in new code; the GGPlot `inspect` prop is a dual-read alias, not
+the primary teaching surface.
 
 ### Mark eligibility (opt-out)
 
@@ -38,20 +39,21 @@ and unrelated to the host `<Inspect>` capability.
 
 | Prop / surface | Input                                                            | What it enables                                                                                                                                                                                                                                                                                                                                                                            |
 | -------------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `inspect`      | `boolean \| InspectOptions` on `<GGPlot>`, or `<Inspect>` child  | Tooltip, semantic crosshair, keyboard traversal, pinning. Prefer `<Inspect>`. Options: `mode` (`"auto" \| "exact" \| "x" \| "y" \| "xy"`), `pin`, `maxDistance` (CSS px), `contentMode` (`"informational" \| "interactive"`), `muteSiblings`, `content` (Snippet, see Tooltip below).                                                                                                      |
+| `<Inspect>`    | child of `<GGPlot>` (options as props)                           | Tooltip, semantic crosshair, keyboard traversal, pinning. **Preferred.** Options: `mode` (`"auto" \| "exact" \| "x" \| "y" \| "xy"`), `pin`, `maxDistance` (CSS px), `contentMode` (`"informational" \| "interactive"`), `muteSiblings`, `content` (Snippet, see Tooltip below). Do not put `inspect=` on `<GGPlot>` in new examples.                                                      |
 | `select`       | `false \| "point" \| "interval" \| SelectOptions`                | Point or interval selection. Options: `type` (`"point" \| "interval"`), `mode` (`"x" \| "y" \| "xy"`, interval only), `multiple`, `persistent`, `preset` (faceted intervals, below).                                                                                                                                                                                                       |
 | `zoom`         | `boolean \| ZoomOptions`                                         | Brush zoom. Options: `mode` (`"x" \| "y" \| "xy"`), `trigger` (`"brush"`). Currently requires one unfaceted panel.                                                                                                                                                                                                                                                                         |
 | `focus`        | `boolean \| { preview?: boolean }` on `<GuideLegend>`            | Discrete legend preview, focus, and linked emphasis **for that aesthetic channel**. Emphasis only — never changes included rows. Discrete legends only; continuous ramps stay static. Mute de-emphasizes non-focused marks; dashed rings appear only on sparse point marks (≤48 anchors), never on paths/areas/bars/segments/text. Host-only — not a PortableSpec / `guideLegend()` field. |
-| `legendFilter` | `boolean \| LegendFilterOptions` on `<GGPlot>`                   | Data-changing filtering through discrete legend controls: changes the included rows and reruns the grammar while preserving stable color identity. Options: `mode` (`"exclude" \| "include"`), `multiple`.                                                                                                                                                                                 |
+| `filter`       | `boolean \| LegendFilterOptions` on `<GuideLegend>`              | Data-changing filtering on **that aesthetic's** discrete legend: changes included rows and reruns the grammar while preserving stable color identity. Options: `mode` (`"exclude" \| "include"`), `multiple`. Combine with focus: `<GuideLegend channel="color" focus filter />`.                                                                                                          |
 | `key`          | column name or `(row, index) => PropertyKey` (optional override) | Durable row identity for public interaction payloads. **Default:** `id` column when present, else row index. Override only for a non-`id` natural key or a custom accessor. Duplicate or unstable keys are diagnostic errors.                                                                                                                                                              |
 | `tool`         | `"inspect" \| "point" \| "select-area" \| "zoom-area"`           | Controlled initial/active tool; observe changes with `ontoolchange`.                                                                                                                                                                                                                                                                                                                       |
 | `ariaLabel`    | `string`                                                         | Accessible chart name; falls back to the plot title or a generated label.                                                                                                                                                                                                                                                                                                                  |
 | `a11y`         | `A11yMode`                                                       | `"force-svg"` keeps every layer as SVG marks.                                                                                                                                                                                                                                                                                                                                              |
 
-### Deprecated: `legendFocus` on `<GGPlot>`
+### Deprecated: plot-level `legendFocus` / `legendFilter`
 
-Since 0.19.0, prefer `<GuideLegend channel="color" focus />`. The plot prop
-still enables focus plot-wide until 0.20.0 and emits `DEPRECATED_PLOT_PROP`.
+Since 0.19.0, use `<GuideLegend channel="color" focus />` and
+`<GuideLegend channel="color" filter />`. The old GGPlot props still dual-read
+and emit `DEPRECATED_PLOT_PROP` — never teach them as the current API.
 
 After an interval or zoom commit, accessible controls accept exact bounds.
 
@@ -110,13 +112,12 @@ Two `<Inspect>` children last-win with
 
 ## Tooltip
 
-Enabling inspect (`<Inspect />` or the `inspect` prop) renders the default HTML
-tooltip; no extra component is needed. Customize its body with the
-`content` prop on `<Inspect>` (or `inspect.content` on the prop form), which
-receives a `PlotInspectionChange` (`focus`/`members` are `PlotDatum` values
-whose `fields` are `TooltipField` rows: `{ channel, field, value }`). The
-exported `Tooltip` component is the same positioned shell for advanced custom
-rendering. `TooltipContext` is a deprecated (0.1.0) alias of
+Enabling inspect with `<Inspect />` renders the default HTML tooltip; no extra
+component is needed. Customize its body with the `content` prop on `<Inspect>`,
+which receives a `PlotInspectionChange` (`focus`/`members` are `PlotDatum`
+values whose `fields` are `TooltipField` rows: `{ channel, field, value }`).
+The exported `Tooltip` component is the same positioned shell for advanced
+custom rendering. `TooltipContext` is a deprecated (0.1.0) alias of
 `PlotInspectionChange`.
 
 ## Diagnostics
@@ -158,12 +159,11 @@ entry has `severity`, `code`, `message`, `prop`, `suggestions`, `docUrl`):
   data={rows}
   aes={{ x: "date", y: "value", color: "series" }}
   select={{ type: "interval", mode: "x", preset: "cross-panel" }}
-  legendFilter
   {interaction}
   interactionScope={scope}
   oninteraction={(event) => console.log(event.type, event)}
 >
-  <GuideLegend channel="color" focus />
+  <GuideLegend channel="color" focus filter />
   <Facet wrap="region" ncol={3} />
   <GeomPoint />
 </GGPlot>

--- a/scripts/example-interaction-api.test.ts
+++ b/scripts/example-interaction-api.test.ts
@@ -61,7 +61,15 @@ describe("example interaction API (v0.20)", () => {
     expect(plotLevelInteractionOffenders(attrs[0]!)).toEqual([
       "legendFocus",
       "legendFilter",
-      "inspect=",
+      "inspect",
     ]);
+  });
+
+  it("flags bare and braced inspect shorthand", () => {
+    expect(plotLevelInteractionOffenders(" data={rows} inspect ")).toEqual(["inspect"]);
+    expect(plotLevelInteractionOffenders(" {inspect} ")).toEqual(["inspect"]);
+    // Handlers and unrelated identifiers stay clean.
+    expect(plotLevelInteractionOffenders(" oninspect={(e) => {}} ")).toEqual([]);
+    expect(plotLevelInteractionOffenders(" interactionScope={scope} ")).toEqual([]);
   });
 });

--- a/scripts/example-interaction-api.test.ts
+++ b/scripts/example-interaction-api.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Gallery examples must teach the v0.20 host interaction API:
+ * - inspection via <Inspect>, not GGPlot inspect=
+ * - legend focus/filter via <GuideLegend … focus/filter>, not GGPlot props
+ *
+ * Mark-level inspect={false} (opt-out of hit testing) remains valid.
+ */
+import { describe, expect, it } from "bun:test";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const ROOT = join(import.meta.dir, "..");
+const EXAMPLES = join(ROOT, "examples");
+
+function walkExampleSvelte(dir: string): string[] {
+  return readdirSync(dir).flatMap((name) => {
+    const path = join(dir, name);
+    if (statSync(path).isDirectory()) return walkExampleSvelte(path);
+    return name === "Example.svelte" ? [path] : [];
+  });
+}
+
+/** Attributes on opening <GGPlot …> tags only (not children / handlers body). */
+function ggplotOpenAttrs(source: string): string[] {
+  const attrs: string[] = [];
+  const re = /<GGPlot\b([^>]*)>/g;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(source)) !== null) {
+    attrs.push(match[1] ?? "");
+  }
+  return attrs;
+}
+
+const files = walkExampleSvelte(EXAMPLES);
+
+describe("example interaction API (v0.20)", () => {
+  it("finds gallery Example.svelte files", () => {
+    expect(files.length).toBeGreaterThan(20);
+  });
+
+  for (const path of files) {
+    const id = relative(EXAMPLES, path);
+    it(`${id}: no plot-level inspect / legendFocus / legendFilter`, () => {
+      const source = readFileSync(path, "utf8");
+      const offenders: string[] = [];
+      for (const attrs of ggplotOpenAttrs(source)) {
+        if (/\blegendFocus\b/.test(attrs)) offenders.push("legendFocus");
+        if (/\blegendFilter\b/.test(attrs)) offenders.push("legendFilter");
+        // Bare inspect= on GGPlot. oninspect= is a handler (prefix keeps it out).
+        if (/(?<![\w])inspect\s*=/.test(attrs)) offenders.push("inspect=");
+      }
+      expect(offenders).toEqual([]);
+    });
+  }
+});

--- a/scripts/example-interaction-api.test.ts
+++ b/scripts/example-interaction-api.test.ts
@@ -9,6 +9,8 @@ import { describe, expect, it } from "bun:test";
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join, relative } from "node:path";
 
+import { ggplotOpenAttrs, plotLevelInteractionOffenders } from "./ggplot-open-attrs.ts";
+
 const ROOT = join(import.meta.dir, "..");
 const EXAMPLES = join(ROOT, "examples");
 
@@ -18,17 +20,6 @@ function walkExampleSvelte(dir: string): string[] {
     if (statSync(path).isDirectory()) return walkExampleSvelte(path);
     return name === "Example.svelte" ? [path] : [];
   });
-}
-
-/** Attributes on opening <GGPlot …> tags only (not children / handlers body). */
-function ggplotOpenAttrs(source: string): string[] {
-  const attrs: string[] = [];
-  const re = /<GGPlot\b([^>]*)>/g;
-  let match: RegExpExecArray | null;
-  while ((match = re.exec(source)) !== null) {
-    attrs.push(match[1] ?? "");
-  }
-  return attrs;
 }
 
 const files = walkExampleSvelte(EXAMPLES);
@@ -42,14 +33,33 @@ describe("example interaction API (v0.20)", () => {
     const id = relative(EXAMPLES, path);
     it(`${id}: no plot-level inspect / legendFocus / legendFilter`, () => {
       const source = readFileSync(path, "utf8");
-      const offenders: string[] = [];
-      for (const attrs of ggplotOpenAttrs(source)) {
-        if (/\blegendFocus\b/.test(attrs)) offenders.push("legendFocus");
-        if (/\blegendFilter\b/.test(attrs)) offenders.push("legendFilter");
-        // Bare inspect= on GGPlot. oninspect= is a handler (prefix keeps it out).
-        if (/(?<![\w])inspect\s*=/.test(attrs)) offenders.push("inspect=");
-      }
+      const offenders = ggplotOpenAttrs(source).flatMap(plotLevelInteractionOffenders);
       expect(offenders).toEqual([]);
     });
   }
+
+  it("scans attributes after arrow-function handlers (=> regression)", () => {
+    // Devin: /<GGPlot\b([^>]*)>/g stopped at the `>` inside `=>`, so props
+    // after handlers were never scanned.
+    const source = `
+<GGPlot
+  data={rows}
+  onlegendfilter={(event) => {
+    status = event.phase;
+  }}
+  legendFocus
+  legendFilter
+  inspect={true}
+>
+  <GeomPoint />
+</GGPlot>
+`;
+    const attrs = ggplotOpenAttrs(source);
+    expect(attrs).toHaveLength(1);
+    expect(plotLevelInteractionOffenders(attrs[0]!)).toEqual([
+      "legendFocus",
+      "legendFilter",
+      "inspect=",
+    ]);
+  });
 });

--- a/scripts/example-interaction-api.test.ts
+++ b/scripts/example-interaction-api.test.ts
@@ -33,7 +33,9 @@ describe("example interaction API (v0.20)", () => {
     const id = relative(EXAMPLES, path);
     it(`${id}: no plot-level inspect / legendFocus / legendFilter`, () => {
       const source = readFileSync(path, "utf8");
-      const offenders = ggplotOpenAttrs(source).flatMap(plotLevelInteractionOffenders);
+      const offenders = ggplotOpenAttrs(source).flatMap((attrs) =>
+        plotLevelInteractionOffenders(attrs),
+      );
       expect(offenders).toEqual([]);
     });
   }

--- a/scripts/ggplot-open-attrs.ts
+++ b/scripts/ggplot-open-attrs.ts
@@ -68,7 +68,14 @@ export function plotLevelInteractionOffenders(attrs: string): string[] {
   const offenders: string[] = [];
   if (/\blegendFocus\b/.test(attrs)) offenders.push("legendFocus");
   if (/\blegendFilter\b/.test(attrs)) offenders.push("legendFilter");
-  // Bare inspect= on GGPlot. oninspect= is a handler (prefix keeps it out).
-  if (/(?<![\w])inspect\s*=/.test(attrs)) offenders.push("inspect=");
+  // Plot-level inspect: value form, boolean bare, or {inspect} shorthand.
+  // Not oninspect= handlers (prefix keeps them out of the bare form).
+  if (
+    /(?<![\w])inspect\s*=/.test(attrs) ||
+    /(?<![\w])\{inspect\}/.test(attrs) ||
+    /(?<![\w])inspect(?=\s|$|\/)/.test(attrs)
+  ) {
+    offenders.push("inspect");
+  }
   return offenders;
 }

--- a/scripts/ggplot-open-attrs.ts
+++ b/scripts/ggplot-open-attrs.ts
@@ -1,0 +1,74 @@
+/**
+ * Extract attribute text from opening `<GGPlot …>` tags.
+ *
+ * Must not stop at `>` inside attribute values (e.g. `onselect={(e) => …}`),
+ * so the scanner tracks brace and quote nesting.
+ */
+
+/** Attributes on every opening `<GGPlot …>` tag (not children). */
+export function ggplotOpenAttrs(source: string): string[] {
+  const attrs: string[] = [];
+  let i = 0;
+  while (i < source.length) {
+    const start = source.indexOf("<GGPlot", i);
+    if (start === -1) break;
+    // Word boundary: avoid matching a longer tag name if one appears later.
+    const after = start + "<GGPlot".length;
+    if (after < source.length && /[\w-]/.test(source[after]!)) {
+      i = after;
+      continue;
+    }
+    // Scan from after the tag name for the real closing `>`.
+    let j = after;
+    let depth = 0;
+    let quote: '"' | "'" | null = null;
+    while (j < source.length) {
+      const ch = source[j]!;
+      if (quote !== null) {
+        if (ch === "\\") {
+          j += 2;
+          continue;
+        }
+        if (ch === quote) quote = null;
+        j += 1;
+        continue;
+      }
+      if (ch === '"' || ch === "'") {
+        quote = ch;
+        j += 1;
+        continue;
+      }
+      if (ch === "{") {
+        depth += 1;
+        j += 1;
+        continue;
+      }
+      if (ch === "}") {
+        depth = Math.max(0, depth - 1);
+        j += 1;
+        continue;
+      }
+      if (ch === ">" && depth === 0) {
+        attrs.push(source.slice(after, j));
+        i = j + 1;
+        break;
+      }
+      j += 1;
+    }
+    if (j >= source.length) {
+      // Unclosed tag — stop scanning rather than hang.
+      break;
+    }
+  }
+  return attrs;
+}
+
+/** Forbidden plot-level interaction props on a GGPlot open-tag attribute string. */
+export function plotLevelInteractionOffenders(attrs: string): string[] {
+  const offenders: string[] = [];
+  if (/\blegendFocus\b/.test(attrs)) offenders.push("legendFocus");
+  if (/\blegendFilter\b/.test(attrs)) offenders.push("legendFilter");
+  // Bare inspect= on GGPlot. oninspect= is a handler (prefix keeps it out).
+  if (/(?<![\w])inspect\s*=/.test(attrs)) offenders.push("inspect=");
+  return offenders;
+}

--- a/scripts/skill-content.test.ts
+++ b/scripts/skill-content.test.ts
@@ -108,6 +108,40 @@ describe("skill Svelte fences use child layers, not deprecated grammar props", (
 });
 
 /**
+ * v0.20 host interaction API: teach <Inspect> and GuideLegend focus/filter,
+ * not the deprecated plot-level inspect / legendFocus / legendFilter props.
+ * Mark-level inspect={false} remains valid (hit-test opt-out).
+ */
+describe("skill Svelte fences use v0.20 interaction children", () => {
+  for (const file of FILES) {
+    it(`${file.name} shows no plot-level inspect / legendFocus / legendFilter`, () => {
+      const offenders = codeBlocks(file.markdown)
+        .filter((block) => block.language === "svelte")
+        .flatMap((block) => {
+          const hits: string[] = [];
+          // Only scan GGPlot open tags — not prose comments about the old API.
+          for (const match of block.source.matchAll(/<GGPlot\b([^>]*)>/g)) {
+            const attrs = match[1] ?? "";
+            if (/\blegendFocus\b/.test(attrs)) hits.push("legendFocus");
+            if (/\blegendFilter\b/.test(attrs)) hits.push("legendFilter");
+            if (/(?<![\w])inspect\s*=/.test(attrs)) hits.push("inspect=");
+          }
+          return hits;
+        });
+      expect(offenders).toEqual([]);
+    });
+  }
+
+  it("interactions.md capability table prefers GuideLegend filter, not plot legendFilter", () => {
+    const interactions = FILES.find((f) => f.name === "references/interactions.md");
+    expect(interactions).toBeDefined();
+    // Table row for filter should name GuideLegend, not GGPlot.
+    expect(interactions!.markdown).toMatch(/`filter`\s*\|\s*`boolean[^`]*` on `<GuideLegend>`/);
+    expect(interactions!.markdown).not.toMatch(/\| `legendFilter`\s*\|[^|]*on `<GGPlot>`/);
+  });
+});
+
+/**
  * #1200 postmortem: an agent read PortableSpec.layers[] (marks only) plus a
  * false "are not layers" comment and filed issues claiming Scale/Theme/Guide/
  * Labs/Coord/Facet/Legend were "non-layer grammar components." They are Layer

--- a/scripts/skill-content.test.ts
+++ b/scripts/skill-content.test.ts
@@ -118,7 +118,9 @@ describe("skill Svelte fences use v0.20 interaction children", () => {
     it(`${file.name} shows no plot-level inspect / legendFocus / legendFilter`, () => {
       const offenders = codeBlocks(file.markdown)
         .filter((block) => block.language === "svelte")
-        .flatMap((block) => ggplotOpenAttrs(block.source).flatMap(plotLevelInteractionOffenders));
+        .flatMap((block) =>
+          ggplotOpenAttrs(block.source).flatMap((attrs) => plotLevelInteractionOffenders(attrs)),
+        );
       expect(offenders).toEqual([]);
     });
   }

--- a/scripts/skill-content.test.ts
+++ b/scripts/skill-content.test.ts
@@ -130,7 +130,8 @@ describe("skill Svelte fences use v0.20 interaction children", () => {
     expect(interactions).toBeDefined();
     // Table row for filter should name GuideLegend, not GGPlot.
     expect(interactions!.markdown).toMatch(/`filter`\s*\|\s*`boolean[^`]*` on `<GuideLegend>`/);
-    expect(interactions!.markdown).not.toMatch(/\| `legendFilter`\s*\|[^|]*on `<GGPlot>`/);
+    // Middle cell may contain markdown-escaped pipes (`\|`); do not use [^|].
+    expect(interactions!.markdown).not.toMatch(/\| `legendFilter`\s*\|[^\n]*on `<GGPlot>`/);
   });
 });
 

--- a/scripts/skill-content.test.ts
+++ b/scripts/skill-content.test.ts
@@ -47,6 +47,7 @@ import {
 } from "@ggsvelte/spec";
 import type { SpecInput } from "@ggsvelte/spec";
 import { deprecatedGrammarPropPattern } from "../packages/svelte/src/lib/layers/grammar-families.ts";
+import { ggplotOpenAttrs, plotLevelInteractionOffenders } from "./ggplot-open-attrs.ts";
 import { codeBlocks } from "./guide-code-contract.ts";
 
 const ROOT = join(import.meta.dir, "..");
@@ -117,17 +118,7 @@ describe("skill Svelte fences use v0.20 interaction children", () => {
     it(`${file.name} shows no plot-level inspect / legendFocus / legendFilter`, () => {
       const offenders = codeBlocks(file.markdown)
         .filter((block) => block.language === "svelte")
-        .flatMap((block) => {
-          const hits: string[] = [];
-          // Only scan GGPlot open tags — not prose comments about the old API.
-          for (const match of block.source.matchAll(/<GGPlot\b([^>]*)>/g)) {
-            const attrs = match[1] ?? "";
-            if (/\blegendFocus\b/.test(attrs)) hits.push("legendFocus");
-            if (/\blegendFilter\b/.test(attrs)) hits.push("legendFilter");
-            if (/(?<![\w])inspect\s*=/.test(attrs)) hits.push("inspect=");
-          }
-          return hits;
-        });
+        .flatMap((block) => ggplotOpenAttrs(block.source).flatMap(plotLevelInteractionOffenders));
       expect(offenders).toEqual([]);
     });
   }

--- a/skills/ggsvelte/SKILL.md
+++ b/skills/ggsvelte/SKILL.md
@@ -114,10 +114,11 @@ direct props (`size={3}`); structural props are `data`, `stat`, `position`,
 
 `<GGPlot>` props: `spec`, `data`, `aes`, `layers`, `key`, `width`
 (number | "container"), `height`, `a11y`, `ariaLabel`, the interaction props
-(`inspect`, `select`, `zoom`, `tool`, `interaction`,
-`interactionScope`; `legendFocus` / `legendFilter` are deprecated — use
-`<GuideLegend channel focus>` / `<GuideLegend channel filter>`), the `on*`
-handlers, and `children`.
+(`select`, `zoom`, `tool`, `interaction`, `interactionScope`; prefer
+`<Inspect>` for inspection and `<GuideLegend channel focus>` /
+`<GuideLegend channel filter>` for legend interaction — do not put
+`inspect` / `legendFocus` / `legendFilter` on `<GGPlot>` in new code), the
+`on*` handlers, and `children`.
 Instance methods: `resetScales()`, `setZoom()`.
 
 Precedence: `spec` wins over everything else. For mark layers, an explicit
@@ -274,10 +275,10 @@ violin, tile heatmap, hex density, ECDF step, ribbon, flipped boxplot,
 per-layer aes override, sf/map — each as validated JSON plus a Svelte twin:
 [references/recipes.md](references/recipes.md).
 
-## Interactions (host props, not PortableSpec fields)
+## Interactions (host props / children, not PortableSpec fields)
 
-Opt-in host capabilities: `inspect` / `select` / `zoom` on `<GGPlot>`; legend
-emphasis and data-changing filter via
+Opt-in host capabilities: `<Inspect />` for tooltips and crosshairs;
+`select` / `zoom` on `<GGPlot>`; legend emphasis and data-changing filter via
 `<GuideLegend channel="color" focus />` / `filter` (per aesthetic; host-only,
 not in `guideLegend()` / PortableSpec). Always give a stable `key` when
 selection or linked views must survive filtering or refreshes. Link plots by

--- a/skills/ggsvelte/references/interactions.md
+++ b/skills/ggsvelte/references/interactions.md
@@ -23,9 +23,10 @@ accessor (for example `key="year"` on a time series without an `id` column).
 </GGPlot>
 ```
 
-Empty `<Inspect />` enables defaults (same as the legacy `inspect={true}` prop).
-Options match `InspectOptions`: `mode`, `pin`, `maxDistance`, `contentMode`,
-`muteSiblings`, `content` (Snippet). The GGPlot `inspect` prop still works.
+Empty `<Inspect />` enables defaults. Options match `InspectOptions`: `mode`,
+`pin`, `maxDistance`, `contentMode`, `muteSiblings`, `content` (Snippet). Prefer
+the child form in new code; the GGPlot `inspect` prop is a dual-read alias, not
+the primary teaching surface.
 
 ### Mark eligibility (opt-out)
 
@@ -38,20 +39,21 @@ and unrelated to the host `<Inspect>` capability.
 
 | Prop / surface | Input                                                            | What it enables                                                                                                                                                                                                                                                                                                                                                                            |
 | -------------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `inspect`      | `boolean \| InspectOptions` on `<GGPlot>`, or `<Inspect>` child  | Tooltip, semantic crosshair, keyboard traversal, pinning. Prefer `<Inspect>`. Options: `mode` (`"auto" \| "exact" \| "x" \| "y" \| "xy"`), `pin`, `maxDistance` (CSS px), `contentMode` (`"informational" \| "interactive"`), `muteSiblings`, `content` (Snippet, see Tooltip below).                                                                                                      |
+| `<Inspect>`    | child of `<GGPlot>` (options as props)                           | Tooltip, semantic crosshair, keyboard traversal, pinning. **Preferred.** Options: `mode` (`"auto" \| "exact" \| "x" \| "y" \| "xy"`), `pin`, `maxDistance` (CSS px), `contentMode` (`"informational" \| "interactive"`), `muteSiblings`, `content` (Snippet, see Tooltip below). Do not put `inspect=` on `<GGPlot>` in new examples.                                                      |
 | `select`       | `false \| "point" \| "interval" \| SelectOptions`                | Point or interval selection. Options: `type` (`"point" \| "interval"`), `mode` (`"x" \| "y" \| "xy"`, interval only), `multiple`, `persistent`, `preset` (faceted intervals, below).                                                                                                                                                                                                       |
 | `zoom`         | `boolean \| ZoomOptions`                                         | Brush zoom. Options: `mode` (`"x" \| "y" \| "xy"`), `trigger` (`"brush"`). Currently requires one unfaceted panel.                                                                                                                                                                                                                                                                         |
 | `focus`        | `boolean \| { preview?: boolean }` on `<GuideLegend>`            | Discrete legend preview, focus, and linked emphasis **for that aesthetic channel**. Emphasis only — never changes included rows. Discrete legends only; continuous ramps stay static. Mute de-emphasizes non-focused marks; dashed rings appear only on sparse point marks (≤48 anchors), never on paths/areas/bars/segments/text. Host-only — not a PortableSpec / `guideLegend()` field. |
-| `legendFilter` | `boolean \| LegendFilterOptions` on `<GGPlot>`                   | Data-changing filtering through discrete legend controls: changes the included rows and reruns the grammar while preserving stable color identity. Options: `mode` (`"exclude" \| "include"`), `multiple`.                                                                                                                                                                                 |
+| `filter`       | `boolean \| LegendFilterOptions` on `<GuideLegend>`              | Data-changing filtering on **that aesthetic's** discrete legend: changes included rows and reruns the grammar while preserving stable color identity. Options: `mode` (`"exclude" \| "include"`), `multiple`. Combine with focus: `<GuideLegend channel="color" focus filter />`.                                                                                                          |
 | `key`          | column name or `(row, index) => PropertyKey` (optional override) | Durable row identity for public interaction payloads. **Default:** `id` column when present, else row index. Override only for a non-`id` natural key or a custom accessor. Duplicate or unstable keys are diagnostic errors.                                                                                                                                                              |
 | `tool`         | `"inspect" \| "point" \| "select-area" \| "zoom-area"`           | Controlled initial/active tool; observe changes with `ontoolchange`.                                                                                                                                                                                                                                                                                                                       |
 | `ariaLabel`    | `string`                                                         | Accessible chart name; falls back to the plot title or a generated label.                                                                                                                                                                                                                                                                                                                  |
 | `a11y`         | `A11yMode`                                                       | `"force-svg"` keeps every layer as SVG marks.                                                                                                                                                                                                                                                                                                                                              |
 
-### Deprecated: `legendFocus` on `<GGPlot>`
+### Deprecated: plot-level `legendFocus` / `legendFilter`
 
-Since 0.19.0, prefer `<GuideLegend channel="color" focus />`. The plot prop
-still enables focus plot-wide until 0.20.0 and emits `DEPRECATED_PLOT_PROP`.
+Since 0.19.0, use `<GuideLegend channel="color" focus />` and
+`<GuideLegend channel="color" filter />`. The old GGPlot props still dual-read
+and emit `DEPRECATED_PLOT_PROP` — never teach them as the current API.
 
 After an interval or zoom commit, accessible controls accept exact bounds.
 
@@ -110,13 +112,12 @@ Two `<Inspect>` children last-win with
 
 ## Tooltip
 
-Enabling inspect (`<Inspect />` or the `inspect` prop) renders the default HTML
-tooltip; no extra component is needed. Customize its body with the
-`content` prop on `<Inspect>` (or `inspect.content` on the prop form), which
-receives a `PlotInspectionChange` (`focus`/`members` are `PlotDatum` values
-whose `fields` are `TooltipField` rows: `{ channel, field, value }`). The
-exported `Tooltip` component is the same positioned shell for advanced custom
-rendering. `TooltipContext` is a deprecated (0.1.0) alias of
+Enabling inspect with `<Inspect />` renders the default HTML tooltip; no extra
+component is needed. Customize its body with the `content` prop on `<Inspect>`,
+which receives a `PlotInspectionChange` (`focus`/`members` are `PlotDatum`
+values whose `fields` are `TooltipField` rows: `{ channel, field, value }`).
+The exported `Tooltip` component is the same positioned shell for advanced
+custom rendering. `TooltipContext` is a deprecated (0.1.0) alias of
 `PlotInspectionChange`.
 
 ## Diagnostics
@@ -158,12 +159,11 @@ entry has `severity`, `code`, `message`, `prop`, `suggestions`, `docUrl`):
   data={rows}
   aes={{ x: "date", y: "value", color: "series" }}
   select={{ type: "interval", mode: "x", preset: "cross-panel" }}
-  legendFilter
   {interaction}
   interactionScope={scope}
   oninteraction={(event) => console.log(event.type, event)}
 >
-  <GuideLegend channel="color" focus />
+  <GuideLegend channel="color" focus filter />
   <Facet wrap="region" ncol={3} />
   <GeomPoint />
 </GGPlot>


### PR DESCRIPTION
## Summary

- **Gallery examples** already used `<Inspect>` and `<GuideLegend focus|filter />` (not plot-level `inspect` / `legendFocus` / `legendFilter`). This PR **locks that** with `scripts/example-interaction-api.test.ts`.
- **Agent skill** still taught plot-level `legendFilter` and listed `inspect` as the primary surface. Capability table and worked example now prefer `<Inspect>` and `<GuideLegend channel filter />`.
- **Homepage JSON** no longer shows deprecated `legendFocus` in the agent envelope.
- **Guides reference** no longer claims deprecated plot props are current “until 0.20.”

## Correct v0.20 API (teaching)

```svelte
<GGPlot data={rows} aes={{ x: "x", y: "y", color: "series" }}>
  <Inspect mode="xy" />
  <GuideLegend channel="color" focus filter />
  <GeomPoint />
</GGPlot>
```

## Test plan

- [x] `bun test scripts/example-interaction-api.test.ts scripts/skill-content.test.ts scripts/skill-sync.test.ts`
- [ ] CI green
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1258" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->