### PR TITLE
docs: drop homepage hero chart and install CTA

### DIFF
--- a/apps/docs/src/lib/home-code-path.ts
+++ b/apps/docs/src/lib/home-code-path.ts
@@ -3,8 +3,8 @@
  * Svelte children, the TypeScript builder, and agent JSON.
  *
  * Hand-authored (not loadExample) so the JSON tab can use data: { name } and
- * never dump every row into a mile-tall panel. Matches the interactive demo
- * above the fold — not the hero Guerry chart.
+ * never dump every row into a mile-tall panel. Matches the interactive
+ * grammar demo on the homepage.
  *
  * Data: bundled `palmerPenguins` from `@ggsvelte/svelte/data` (333 complete
  * cases). Field names match the published dataset, not the short theme-specimen

--- a/apps/docs/src/lib/theme-specimens/static-svg.ts
+++ b/apps/docs/src/lib/theme-specimens/static-svg.ts
@@ -265,37 +265,6 @@ export function sequentialRasterStaticSvg(input: {
   return svg;
 }
 
-export function homeHeroStaticSvgFromData(
-  rows: readonly Record<string, unknown>[],
-  input?: {
-    readonly theme?: ThemeName;
-    readonly width?: number;
-    readonly height?: number;
-  },
-): string {
-  const theme = input?.theme ?? "default";
-  const width = input?.width ?? DOCS_STATIC_PLOT_WIDTH_PX;
-  const height = input?.height ?? 400;
-  const key = `home-hero:${theme}:${String(width)}x${String(height)}:${String(rows.length)}`;
-  const hit = cache.get(key);
-  if (hit !== undefined) return hit;
-  const spec = gg(rows as AuthoringRows, aes({ x: "literacy", y: "crimePersons", color: "region" }))
-    .geomPoint({ size: 4, alpha: 0.85 })
-    .scales({ color: { type: "ordinal", scheme: "tableau10" } })
-    .theme(theme)
-    .labs({
-      title: "Literacy and crime in France, 1833",
-      subtitle: "85 French departments — higher y means fewer crimes per head",
-      x: "Literate conscripts (%)",
-      y: "Population per crime against persons",
-      color: "Region",
-    })
-    .spec();
-  const svg = namespaceSvgIds(renderToSVGString(spec, { width, height }), key);
-  cache.set(key, svg);
-  return svg;
-}
-
 /**
  * Homepage grammar-demo shell: full palmerPenguins scatter + loess, default
  * interaction step (color + smooth). Static only — no inspect/legendFocus.

--- a/apps/docs/src/routes/+page.server.ts
+++ b/apps/docs/src/routes/+page.server.ts
@@ -1,28 +1,16 @@
-import { guerry } from "$examples/point/scatter-color/data";
 import { palmerPenguins } from "@ggsvelte/svelte/data";
 
-import {
-  homeGrammarStaticSvgFromData,
-  homeHeroStaticSvgFromData,
-} from "$lib/theme-specimens/static-svg";
+import { homeGrammarStaticSvgFromData } from "$lib/theme-specimens/static-svg";
 
 /**
- * Prerender hero + grammar shells so the home client does not need
- * @ggsvelte/core for first paint. Matches `contrastChartTheme()`:
- * fivethirtyeight on the light site, light on dark. CSS picks the shell from
- * `data-theme` set by static/theme.js before first paint.
+ * Prerender grammar shells so the home client does not need @ggsvelte/core
+ * for first paint. Matches `contrastChartTheme()`: fivethirtyeight on the
+ * light site, light on dark. CSS picks the shell from `data-theme` set by
+ * static/theme.js before first paint.
  */
 export function load() {
   const penguins = palmerPenguins as readonly Record<string, unknown>[];
   return {
-    heroStaticSvgLightSite: homeHeroStaticSvgFromData(guerry, {
-      theme: "fivethirtyeight",
-      height: 400,
-    }),
-    heroStaticSvgDarkSite: homeHeroStaticSvgFromData(guerry, {
-      theme: "light",
-      height: 400,
-    }),
     grammarStaticSvgLightSite: homeGrammarStaticSvgFromData(penguins, {
       theme: "fivethirtyeight",
       height: 400,

--- a/apps/docs/src/routes/+page.svelte
+++ b/apps/docs/src/routes/+page.svelte
@@ -3,9 +3,7 @@
 
   import CodeTabs from "$lib/CodeTabs.svelte";
   import { FEATURED_EXAMPLES, galleryCatalog } from "$lib/catalog/gallery";
-  import CopyCode from "$lib/components/CopyCode.svelte";
   import GrammarDemo from "$lib/components/GrammarDemo.svelte";
-  import UiButton from "$lib/components/UiButton.svelte";
   import { EXAMPLES } from "$lib/examples-manifest";
   import { HOME_CODE_PATH_TABS } from "$lib/home-code-path";
 
@@ -13,52 +11,17 @@
 
   const { data }: PageProps = $props();
 
-  const install = "bun add @ggsvelte/svelte";
   const entries = galleryCatalog(EXAMPLES);
   const featured = FEATURED_EXAMPLES.map((item) =>
     entries.find((entry) => entry.id === item.id)!,
   );
   const tabs = HOME_CODE_PATH_TABS;
-
-  // Hero stays on the prerendered static SVG shell. Auto-upgrading to live
-  // GGPlot on mount pulled ~1MB of chart stack and locked clicks for seconds.
-  // Interactive demos live on /examples and /interactions.
 </script>
 
 <section class="home-hero" aria-labelledby="home-heading">
-  <div class="hero-claim">
-    <h1 id="home-heading">
-      A layered grammar of graphics implemented for agents
-    </h1>
-    <p>
-      The declarative ggplot2 mental model: Instead of picking a preset
-      "BarChart" or "LineChart" component, you compose plots out of independent
-      structural layers.
-    </p>
-  </div>
-
-  <div class="hero-plot">
-    <!--
-      theme.js sets data-theme before paint. Mirror contrastChartTheme():
-      fivethirtyeight on the light site, light chart on dark — no theme flash.
-    -->
-    <div class="hero-static hero-static--light-site">
-      {@html data.heroStaticSvgLightSite}
-    </div>
-    <div class="hero-static hero-static--dark-site">
-      {@html data.heroStaticSvgDarkSite}
-    </div>
-  </div>
-
-  <div class="hero-actions">
-    <CopyCode code={install} language="bash" accessibleLabel="Copy install" />
-    <div class="cta-row">
-      <UiButton variant="primary" href={`${base}/guide/getting-started`}>
-        Getting started
-      </UiButton>
-      <UiButton href={`${base}/examples`}>Examples</UiButton>
-    </div>
-  </div>
+  <h1 id="home-heading">
+    A layered grammar of graphics implemented for agents
+  </h1>
 </section>
 
 <section class="home-featured" aria-labelledby="home-featured-heading">
@@ -145,77 +108,20 @@
 </section>
 
 <style>
-  /*
-   * Stack by default: the chart is the hero and owns a full-width row until
-   * the viewport is wide enough for a true two-column composition.
-   * Never pin min-height to 100svh — a two-row grid under that rule stretches
-   * empty space between claim and actions into a multi-hundred-px void.
-   */
   .home-hero {
-    display: grid;
-    grid-template-areas: "claim" "plot" "actions";
-    grid-template-columns: 1fr;
-    gap: 1.5rem;
-    align-items: start;
-    padding: clamp(2rem, 5vw, 4rem) 0 3rem;
+    padding: clamp(2rem, 5vw, 4rem) 0 0;
   }
 
-  .hero-claim {
-    grid-area: claim;
-  }
-
-  .hero-claim h1 {
+  .home-hero h1 {
     max-width: 16ch;
-    margin: 0.35rem 0 1.25rem;
+    margin: 0;
     font-size: clamp(2.8rem, 5.5vw, 4.75rem);
     line-height: 0.95;
     letter-spacing: -0.04em;
   }
 
-  .hero-claim > p:last-child {
-    max-width: 36rem;
-    color: var(--muted);
-    font-size: 1.08rem;
-  }
-
-  .hero-actions {
-    grid-area: actions;
-    max-width: 34rem;
-  }
-
-  .hero-plot {
-    grid-area: plot;
-    min-width: 0;
-  }
-
-  .hero-plot :global(svg) {
-    display: block;
-    max-width: 100%;
-    height: auto;
-  }
-
-  .hero-static--dark-site {
-    display: none;
-  }
-
-  :global(:root[data-theme="dark"]) .hero-static--light-site {
-    display: none;
-  }
-
-  :global(:root[data-theme="dark"]) .hero-static--dark-site {
-    display: block;
-  }
-
-  .cta-row {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.75rem;
-    margin-top: 1rem;
-  }
-
   .home-featured {
-    padding-block: clamp(4rem, 8vw, 7rem);
-    border-top: 1px solid var(--line);
+    padding-block: clamp(2.5rem, 6vw, 5rem) clamp(4rem, 8vw, 7rem);
   }
 
   .home-featured header,
@@ -315,15 +221,6 @@
     color: var(--muted);
   }
 
-  /* Side-by-side only when claim + chart can coexist without squeezing the hero. */
-  @media (min-width: 72rem) {
-    .home-hero {
-      grid-template-areas: "claim plot" "actions plot";
-      grid-template-columns: minmax(16rem, 0.85fr) minmax(0, 1.15fr);
-      gap: 1.25rem clamp(1.5rem, 3vw, 3rem);
-    }
-  }
-
   @media (max-width: 64rem) {
     .home-featured ol {
       grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -335,7 +232,7 @@
       padding-top: 1.5rem;
     }
 
-    .hero-claim h1 {
+    .home-hero h1 {
       font-size: clamp(2.4rem, 11vw, 3.5rem);
     }
 

--- a/scripts/docs-chart-intent-load.test.ts
+++ b/scripts/docs-chart-intent-load.test.ts
@@ -14,9 +14,10 @@ function read(rel: string): string {
 }
 
 describe("docs chart intent-gated load", () => {
-  it("keeps the homepage hero on the static shell (no HomeHeroPlot mount)", () => {
+  it("homepage has no live chart stack import on the hero", () => {
     const page = read("routes/+page.svelte");
-    expect(page).toContain("heroStaticSvgLightSite");
+    // Title + featured examples only — no Guerry hero plot or HomeHeroPlot.
+    expect(page).not.toContain("heroStaticSvg");
     expect(page).not.toContain("HomeHeroPlot");
     expect(page).not.toMatch(/onMount\s*\(/);
   });

--- a/tests/visual/docs-contrast.spec.ts
+++ b/tests/visual/docs-contrast.spec.ts
@@ -44,44 +44,4 @@ for (const theme of ["light", "dark"] as const) {
       ).toBeGreaterThanOrEqual(4.5);
     }
   });
-
-  test(`homepage primary CTA preserves theme color after visiting in ${theme} mode`, async ({
-    page,
-  }) => {
-    await page.goto(`/?theme=${theme}`);
-    const cta = page.getByRole("link", {
-      name: "Getting started",
-      exact: true,
-    });
-    await cta.click();
-    await page.goBack();
-    await expect(cta).toBeVisible();
-
-    const colors = await cta.evaluate((link) => {
-      const style = getComputedStyle(link);
-      const visitedRules = [...document.styleSheets].flatMap((sheet) => {
-        try {
-          return [...sheet.cssRules]
-            .filter(
-              (rule): rule is CSSStyleRule =>
-                rule instanceof CSSStyleRule &&
-                rule.selectorText.includes("a.ui-button--primary:visited"),
-            )
-            .map((rule) => rule.style.color);
-        } catch {
-          return [];
-        }
-      });
-      return {
-        foreground: style.color,
-        background: style.backgroundColor,
-        visitedRules,
-      };
-    });
-
-    expect(contrastRatio(colors.foreground, colors.background)).toBeGreaterThanOrEqual(4.5);
-    expect(colors.visitedRules).toContain(
-      theme === "dark" ? "rgb(11, 16, 32)" : "rgb(255, 255, 255)",
-    );
-  });
 }

--- a/tests/visual/docs-home-gallery.spec.ts
+++ b/tests/visual/docs-home-gallery.spec.ts
@@ -11,113 +11,37 @@ async function expectNoOverflow(page: import("@playwright/test").Page): Promise<
   );
 }
 
-test("homepage first viewport leads with a static chart shell and two actions", async ({
-  page,
-}) => {
+test("homepage first viewport leads with title then featured examples", async ({ page }) => {
   await page.setViewportSize({ width: 1280, height: 900 });
   await page.goto("/?theme=light");
   await expect(page.getByRole("heading", { level: 1 })).toHaveText(
     "A layered grammar of graphics implemented for agents",
   );
-  // Hero stays on the prerendered static SVG — no chart-stack import on load.
-  // CSS shows the light-site shell under ?theme=light.
-  await expect(page.locator(".home-hero .hero-static--light-site svg.gg-plot")).toBeVisible();
-  await expect(page.locator(".home-hero .gg-plot-root")).toHaveCount(0);
-  await expect(page.getByRole("link", { name: "Getting started" })).toBeVisible();
-  await expect(page.getByRole("link", { name: "Examples" }).first()).toBeVisible();
-  await expect(page.getByRole("button", { name: "Copy install" })).toBeVisible();
+  // No Guerry hero, install strip, or CTA pair above the fold.
+  await expect(page.locator(".home-hero svg")).toHaveCount(0);
+  await expect(page.getByRole("button", { name: "Copy install" })).toHaveCount(0);
+  await expect(page.getByRole("link", { name: "Getting started" })).toHaveCount(0);
+  await expect(page.getByRole("heading", { name: "Examples", level: 2 })).toBeVisible();
+  await expect(page.locator(".home-featured ol li")).toHaveCount(6);
+  await expect(page.locator(".home-featured header a")).toHaveText("Gallery");
   await expectNoOverflow(page);
 });
 
-/**
- * Narrow-ish desktop (below the wide side-by-side breakpoint): the hero chart
- * is the product, so it owns a full-width row instead of sharing a horizontal
- * plane with the claim. Also: the hero must size to content — a viewport-tall
- * min-height stretched a two-row grid and left a multi-hundred-px void between
- * claim and install.
- */
-test("homepage mid-width stacks the hero chart full-width without empty void", async ({ page }) => {
+test("homepage title sits above the featured gallery without hero chrome", async ({ page }) => {
   await page.setViewportSize({ width: 960, height: 900 });
   await page.goto("/?theme=light");
-  const metrics = await page.locator(".home-hero").evaluate((hero) => {
-    const claim = hero.querySelector(".hero-claim")!.getBoundingClientRect();
-    const plot = hero.querySelector(".hero-plot")!.getBoundingClientRect();
-    const actions = hero.querySelector(".hero-actions")!.getBoundingClientRect();
-    const box = hero.getBoundingClientRect();
+  const metrics = await page.evaluate(() => {
+    const title = document.querySelector(".home-hero h1")!.getBoundingClientRect();
+    const featured = document.querySelector(".home-featured")!.getBoundingClientRect();
     return {
-      claimBottom: claim.bottom,
-      claimLeft: claim.left,
-      plotTop: plot.top,
-      plotLeft: plot.left,
-      plotWidth: plot.width,
-      actionsTop: actions.top,
-      heroWidth: box.width,
-      gapAfterPlot: actions.top - plot.bottom,
+      titleBottom: title.bottom,
+      featuredTop: featured.top,
+      gap: featured.top - title.bottom,
     };
   });
-  // Chart sits below the claim on its own horizontal plane.
-  expect(metrics.plotTop).toBeGreaterThan(metrics.claimBottom - 1);
-  expect(Math.abs(metrics.plotLeft - metrics.claimLeft)).toBeLessThan(24);
-  expect(metrics.plotWidth / metrics.heroWidth).toBeGreaterThan(0.9);
-  // Install follows the chart tightly — no viewport-filling void.
-  // (Hero height itself can exceed the viewport when claim + 400px plot stack;
-  // the failure mode was empty space between plot and actions, not total height.)
-  expect(metrics.gapAfterPlot).toBeLessThan(64);
-});
-
-/** Wide layout may share a row with claim, but must not invent empty vertical space. */
-test("homepage wide layout keeps install adjacent to claim without hero void", async ({ page }) => {
-  await page.setViewportSize({ width: 1440, height: 900 });
-  await page.goto("/?theme=light");
-  const metrics = await page.locator(".home-hero").evaluate((hero) => {
-    const claim = hero.querySelector(".hero-claim")!.getBoundingClientRect();
-    const actions = hero.querySelector(".hero-actions")!.getBoundingClientRect();
-    return {
-      claimBottom: claim.bottom,
-      actionsTop: actions.top,
-      gapClaimToActions: actions.top - claim.bottom,
-    };
-  });
-  // claim → actions is a short stack on the left; no 100svh stretch between them.
-  expect(metrics.gapClaimToActions).toBeLessThan(96);
-  expect(metrics.actionsTop).toBeGreaterThan(metrics.claimBottom - 1);
-});
-
-test("homepage preserves SSR hero chart shell without auto-hydrating the chart stack", async ({
-  page,
-  request,
-}) => {
-  const response = await request.get("/");
-  const html = await response.text();
-  // SSR ships a full-width static SVG shell (not a live GGPlot).
-  expect(html).toContain("Literacy and crime in France, 1833");
-  expect(html).toContain('width="832"');
-
-  await page.goto("/?theme=light");
-  const hero = page.locator(".home-hero");
-  // CSS shows the light-site shell; both shells remain in the DOM.
-  const shell = hero.locator(".hero-static--light-site svg.gg-plot");
-  await expect(shell).toBeVisible();
-  // No auto-upgrade: chart stack stays off the homepage until grammar intent.
-  await expect(hero.locator(".gg-plot-root")).toHaveCount(0);
-  await expect(hero.locator(".gg-capture")).toHaveCount(0);
-
-  // Axis titles use real units (not the old mistaken "rank" labels).
-  await expect(
-    shell.locator(".gg-axis-title", { hasText: "Literate conscripts (%)" }),
-  ).toBeVisible();
-  await expect(
-    shell.locator(".gg-axis-title", {
-      hasText: "Population per crime against persons",
-    }),
-  ).toBeVisible();
-
-  // Readable tick size floor (light/dark themes were 8.8px on several presets).
-  const axisFontSize = await shell
-    .locator(".gg-axis .gg-tick text")
-    .first()
-    .evaluate((el) => Number(el.getAttribute("font-size") ?? "0"));
-  expect(axisFontSize).toBeGreaterThanOrEqual(11);
+  expect(metrics.featuredTop).toBeGreaterThan(metrics.titleBottom - 1);
+  // Title → examples should be a short stack (no chart/install block between).
+  expect(metrics.gap).toBeLessThan(160);
 });
 
 test("homepage grammar section SSRs chrome and a static chart shell", async ({ request }) => {
@@ -201,26 +125,20 @@ test("homepage grammar inspect draws xy crosshair and supports legend focus", as
   await expect(legendTarget).toBeFocused();
 });
 
-test("homepage mobile order is claim, specimen, then install", async ({ page }) => {
+test("homepage mobile order is title then featured examples", async ({ page }) => {
   await page.setViewportSize({ width: 375, height: 812 });
   await page.goto("/?theme=light");
-  const order = await page.locator(".home-hero > div").evaluateAll((nodes) =>
-    nodes.map((node) => ({
-      classes: [...node.classList],
-      top: node.getBoundingClientRect().top,
-    })),
-  );
-  const topFor = (className: string): number => {
-    const item = order.find((candidate) => candidate.classes.includes(className));
-    expect(item, `${className} is present`).toBeDefined();
-    return item?.top ?? Number.POSITIVE_INFINITY;
-  };
-  expect(topFor("hero-claim")).toBeLessThan(topFor("hero-plot"));
-  expect(topFor("hero-plot")).toBeLessThan(topFor("hero-actions"));
+  const metrics = await page.evaluate(() => {
+    const title = document.querySelector(".home-hero h1")!.getBoundingClientRect();
+    const featured = document.querySelector(".home-featured")!.getBoundingClientRect();
+    return { titleTop: title.top, featuredTop: featured.top };
+  });
+  expect(metrics.titleTop).toBeLessThan(metrics.featuredTop);
+  await expect(page.locator(".home-featured ol li")).toHaveCount(6);
   await expectNoOverflow(page);
 });
 
-test("install copy and code tabs share the manual-copy fallback", async ({ page }) => {
+test("code tabs share the manual-copy fallback", async ({ page }) => {
   await page.addInitScript(() => {
     Object.defineProperty(navigator, "clipboard", {
       configurable: true,
@@ -230,15 +148,12 @@ test("install copy and code tabs share the manual-copy fallback", async ({ page 
     });
   });
   await page.goto("/");
-  await page.getByRole("button", { name: "Copy install" }).click();
-  await expect(page.locator(".hero-actions [role=status]")).toHaveText(
-    "Clipboard unavailable. Code selected for manual copy.",
-  );
-  expect(await page.evaluate(() => getSelection()?.toString())).toContain(
-    "bun add @ggsvelte/svelte",
-  );
   const tabs = page.getByRole("tablist", { name: "Code representations" }).getByRole("tab");
   await expect(tabs.first()).toHaveText("Svelte");
+  await page.getByRole("button", { name: "Copy code" }).first().click();
+  await expect(page.locator(".code-path [role=status]")).toHaveText(
+    "Clipboard unavailable. Code selected for manual copy.",
+  );
 });
 
 test("gallery exposes every generated preview exactly once", async ({ page }) => {


### PR DESCRIPTION
## Summary

- Remove the homepage hero block (mental-model paragraph, Guerry scatter shell, `bun add` install strip, Getting started / Examples buttons).
- Keep the page title, then the six featured examples and Gallery link.
- Drop unused `homeHeroStaticSvgFromData` prerender path and update homepage visual/unit tests.

## Test plan

- [x] `bun test scripts/docs-chart-intent-load.test.ts`
- [x] `bun run check` (packages/scripts)
- [ ] CI visual docs-home-gallery specs
- [ ] Spot-check `/` in browser: title → Examples grid → Gallery
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1259" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->