### PR TITLE
docs(readme): drop GGPlot size props from showcased examples

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -365,9 +365,13 @@ Authoring a new example:
      the canonical `PortableSpec`; it is validated at tier 2 on import, and
      its JSON is the docs "Spec" tab.
    - **`Example.svelte`** — idiomatic component usage (`<GGPlot ...>` with
-     `<GeomX>` children), importing data from `./data.js`. Render at an
-     explicit `width={640} height={400}` (or `height={vrHeight}` if you set
-     one) — VR needs fixed sizes.
+     `<GeomX>` children), importing data from `./data.js`. Give the corpus
+     file an explicit `width={640} height={400}` (or `height={vrHeight}` if
+     you set one) so VR captures at a fixed size. These props are VR
+     plumbing, not the recommended authoring style: README and npm snippets
+     omit them (`scripts/readme-showcase.test.ts` strips root size props
+     before comparing), and user code should too — omitted width is
+     container-responsive, omitted height is 400.
    - **`meta.json`** — `{ title, description, tags, docsSection, vrHeight? }`
      (validated by the generator; `docsSection` groups the gallery).
    - **`data.ts`** (optional) — static rows or `mulberry32`-seeded

--- a/README.md
+++ b/README.md
@@ -51,12 +51,7 @@ and Windows.
   import { gammaVirginis } from "./data.js";
 </script>
 
-<GGPlot
-  data={gammaVirginis}
-  aes={{ x: "year", y: "angle" }}
-  width={640}
-  height={400}
->
+<GGPlot data={gammaVirginis} aes={{ x: "year", y: "angle" }}>
   <ThemeTufte />
   <ScaleXContinuous labels="d" />
   <ScaleSizeContinuous range={[3, 8]} />
@@ -97,8 +92,6 @@ and Windows.
   data={crimeanMortality}
   aes={{ x: "month", y: "deaths", fill: "cause" }}
   key={(row) => `${row.month}:${row.cause}`}
-  width={640}
-  height={400}
 >
   <ThemeEconomist />
   <ScaleXDate labels="%b %Y" />
@@ -137,12 +130,7 @@ and Windows.
   import { galtonChildren } from "./data.js";
 </script>
 
-<GGPlot
-  data={galtonChildren}
-  aes={{ x: "height", fill: "gender" }}
-  width={640}
-  height={400}
->
+<GGPlot data={galtonChildren} aes={{ x: "height", fill: "gender" }}>
   <ThemeMinimal />
   <ScaleFillManual
     domain={["Daughters", "Sons"]}
@@ -185,8 +173,6 @@ and Windows.
   data={londonCholera}
   aes={{ x: "density", y: "deathRate", color: "water" }}
   key="district"
-  width="container"
-  height={400}
 >
   <Inspect mode="xy" pin />
   <ThemeEconomist />
@@ -226,12 +212,7 @@ and Windows.
   import { familyHeights } from "./data.js";
 </script>
 
-<GGPlot
-  data={familyHeights}
-  aes={{ x: "child", weight: "n" }}
-  width={640}
-  height={400}
->
+<GGPlot data={familyHeights} aes={{ x: "child", weight: "n" }}>
   <ThemeGgplot2 />
   <FacetWrap field="pair" ncol={2} />
   <Labs
@@ -264,12 +245,7 @@ and Windows.
   import { armadaCrews } from "./data.js";
 </script>
 
-<GGPlot
-  data={armadaCrews}
-  aes={{ x: "squadron", fill: "role", weight: "men" }}
-  width={640}
-  height={400}
->
+<GGPlot data={armadaCrews} aes={{ x: "squadron", fill: "role", weight: "men" }}>
   <ThemeFivethirtyeight />
   <ScaleYContinuous labels=".0%" />
   <ScaleFillManual
@@ -307,12 +283,7 @@ and Windows.
   import { greatLakesSurveys, greatLakesTruth } from "./data.js";
 </script>
 
-<GGPlot
-  data={greatLakesSurveys}
-  aes={{ x: "long", y: "lat", color: "year" }}
-  width={640}
-  height={400}
->
+<GGPlot data={greatLakesSurveys} aes={{ x: "long", y: "lat", color: "year" }}>
   <ThemeDark />
   <CoordFixed />
   <ScaleColorContinuous scheme="viridis" labels="d" />
@@ -358,12 +329,7 @@ Guides are separate from scale math:
   import { michelsonRuns } from "./data.js";
 </script>
 
-<GGPlot
-  data={michelsonRuns}
-  aes={{ x: "run", y: "velocity" }}
-  width={640}
-  height={400}
->
+<GGPlot data={michelsonRuns} aes={{ x: "run", y: "velocity" }}>
   <ThemeFew />
   <ScaleXDiscrete domain={["Jun 5", "Jun 7", "Jun 9", "Jun 12", "Jul 2"]} />
   <Labs
@@ -394,12 +360,7 @@ Guides are separate from scale math:
   import { britishExports } from "./data.js";
 </script>
 
-<GGPlot
-  data={britishExports}
-  aes={{ x: "year", y: "value" }}
-  width="container"
-  height={400}
->
+<GGPlot data={britishExports} aes={{ x: "year", y: "value" }}>
   <ThemeFivethirtyeight />
   <Labs
     title="British and Irish exports, 1855–1899"
@@ -431,12 +392,7 @@ Guides are separate from scale math:
   import { polioTrial } from "./data.js";
 </script>
 
-<GGPlot
-  data={polioTrial}
-  aes={{ x: "group", y: "rate" }}
-  width={640}
-  height={400}
->
+<GGPlot data={polioTrial} aes={{ x: "group", y: "rate" }}>
   <ThemeFivethirtyeight />
   <ScaleXDiscrete domain={["Vaccinated", "Placebo", "Not inoculated"]} />
   <Labs

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -21,12 +21,7 @@ Requires Node.js 22+ and Svelte 5.33.1+.
   import { kyotoSakura } from "@ggsvelte/svelte/data";
 </script>
 
-<GGPlot
-  data={kyotoSakura}
-  aes={{ x: "year", y: "bloomDoy" }}
-  width="container"
-  height={400}
->
+<GGPlot data={kyotoSakura} aes={{ x: "year", y: "bloomDoy" }}>
   <Labs
     title="Kyoto cherry blossom full-bloom dates, 812–2026"
     subtitle="Full bloom moved about ten days earlier after the industrial era"

--- a/scripts/readme-showcase.test.ts
+++ b/scripts/readme-showcase.test.ts
@@ -50,8 +50,8 @@ function stripRootSizeProps(source: string): string {
  */
 function normalizeSnippet(source: string): string {
   return source
-    .replace(/\s+/g, " ")
-    .replace(/\s(\/?>)/g, "$1")
+    .replaceAll(/\s+/g, " ")
+    .replaceAll(/\s(\/?>)/g, "$1")
     .trim();
 }
 

--- a/scripts/readme-showcase.test.ts
+++ b/scripts/readme-showcase.test.ts
@@ -28,6 +28,33 @@ function bothCaptures(match: RegExpExecArray): readonly [string, string] {
   return [first, second];
 }
 
+/**
+ * README snippets are the GitHub front door; the corpus files are the VR
+ * matrix's render targets. VR needs explicit `width`/`height` on `<GGPlot>`,
+ * the front door does not (omitted width is container-responsive, omitted
+ * height defaults to 400) — so snippets drop the root size props and this
+ * comparison strips them from the corpus side before checking sync. Only
+ * whole-line attributes go: geom-level sizes like `<GeomCol width={0.7} />`
+ * share a line with their tag and stay.
+ */
+function stripRootSizeProps(source: string): string {
+  return source
+    .split("\n")
+    .filter((line) => !/^\s*(?:width|height)=(?:\{[^}]*\}|"[^"]*")$/.test(line))
+    .join("\n");
+}
+
+/**
+ * Whitespace-insensitive form: prettier may fold a `<GGPlot …>` open tag onto
+ * one line once the size props are gone, while the corpus keeps it multi-line.
+ */
+function normalizeSnippet(source: string): string {
+  return source
+    .replace(/\s+/g, " ")
+    .replace(/\s(\/?>)/g, "$1")
+    .trim();
+}
+
 function readmeExamples(): readonly ReadmeExample[] {
   return [
     ...readme.matchAll(/<!-- example-source: ([^ ]+) -->\n\n```svelte\n([\s\S]*?)\n```/g),
@@ -75,10 +102,12 @@ describe("README visual showcase", () => {
     }
   });
 
-  it("keeps every showcased snippet identical to its real Svelte example", () => {
+  it("keeps every showcased snippet in sync with its real Svelte example, minus size props", () => {
     for (const { id, source } of readmeExamples()) {
       const exampleSource = readFileSync(join(root, "examples", id, "Example.svelte"), "utf8");
-      expect(source.trim(), id).toBe(exampleSource.trim());
+      expect(normalizeSnippet(source), id).toBe(
+        normalizeSnippet(stripRootSizeProps(exampleSource)),
+      );
       expect(source).toContain('from "@ggsvelte/svelte"');
       expect(source).toContain("<GGPlot");
       expect(source).not.toContain('from "@ggsvelte/spec"');

--- a/scripts/readme-showcase.test.ts
+++ b/scripts/readme-showcase.test.ts
@@ -33,15 +33,26 @@ function bothCaptures(match: RegExpExecArray): readonly [string, string] {
  * matrix's render targets. VR needs explicit `width`/`height` on `<GGPlot>`,
  * the front door does not (omitted width is container-responsive, omitted
  * height defaults to 400) — so snippets drop the root size props and this
- * comparison strips them from the corpus side before checking sync. Only
- * whole-line attributes go: geom-level sizes like `<GeomCol width={0.7} />`
- * share a line with their tag and stay.
+ * comparison strips them from the corpus side before checking sync. The
+ * strip is scoped to the root `<GGPlot` open tag (an unindented `<GGPlot`
+ * line through its closing `>`): size props on geoms or nested plots — even
+ * when prettier wraps them onto their own line, as in
+ * `examples/errorbar/summary-bin` — must still appear in README snippets.
  */
 function stripRootSizeProps(source: string): string {
-  return source
-    .split("\n")
-    .filter((line) => !/^\s*(?:width|height)=(?:\{[^}]*\}|"[^"]*")$/.test(line))
-    .join("\n");
+  const sizeAttribute = /^\s*(?:width|height)=(?:\{[^}]*\}|"[^"]*")$/;
+  const out: string[] = [];
+  let inRootOpenTag = false;
+  for (const line of source.split("\n")) {
+    if (line === "<GGPlot") {
+      inRootOpenTag = true;
+    } else if (inRootOpenTag) {
+      if (sizeAttribute.test(line)) continue;
+      if (line.trimEnd().endsWith(">")) inRootOpenTag = false;
+    }
+    out.push(line);
+  }
+  return out.join("\n");
 }
 
 /**
@@ -76,6 +87,36 @@ function linkedPreviews(): ReadonlyMap<string, string> {
     }),
   );
 }
+
+describe("stripRootSizeProps", () => {
+  it("strips size props from the root GGPlot open tag only", () => {
+    const fixture = [
+      "<GGPlot",
+      "  data={rows}",
+      "  width={640}",
+      "  height={400}",
+      ">",
+      "  <GeomErrorbar",
+      '    stat="summary_bin"',
+      "    width={0.35}",
+      "    linewidth={1.4}",
+      "  />",
+      "  <GGPlot",
+      "    data={inner}",
+      "    width={320}",
+      "  >",
+      "    <GeomPoint />",
+      "  </GGPlot>",
+      "</GGPlot>",
+    ].join("\n");
+
+    const stripped = stripRootSizeProps(fixture);
+    expect(stripped).not.toContain("width={640}");
+    expect(stripped).not.toContain("height={400}");
+    expect(stripped).toContain("width={0.35}");
+    expect(stripped).toContain("width={320}");
+  });
+});
 
 describe("README visual showcase", () => {
   it("shows broad example range through trusted generated previews", () => {


### PR DESCRIPTION
## What

Removes the fixed `width`/`height` props from every showcased example in README.md and packages/svelte/README.md, and decouples the README showcase test from the VR corpus's fixed sizes.

## Why

The size props were VR-capture plumbing, not recommended usage. On the GitHub front door they read as required boilerplate and give a false first impression. Omitted width is container-responsive and omitted height is 400 (`packages/svelte/src/lib/assembly/layout.ts`), so the snippets stay correct and get better as user code.

## How

- `scripts/readme-showcase.test.ts` now strips root size props from each corpus `Example.svelte` (whole-line attributes only, so `<GeomCol width={0.7} />` stays) and compares whitespace-insensitively. Snippets stay in sync with the corpus; VR keeps its fixed sizes.
- CONTRIBUTING.md now frames the corpus size props as VR plumbing that READMEs and user code omit.
- Corpus files, VR baselines, and gallery previews are untouched.

Pre-existing (untouched): 4 failures in `scripts/theme-palette-reference.test.ts` and `scripts/skill-content.test.ts` also fail on main — palette inventory drift, unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1261" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->