### PR TITLE
test(svelte): cover InteractionOverlay box chrome and SceneView panel chrome

### DIFF
--- a/packages/svelte/tests/plot-props.test.ts
+++ b/packages/svelte/tests/plot-props.test.ts
@@ -78,6 +78,7 @@ describe("widenPlotProps", () => {
     const oninteraction = (): void => {
       // no-op
     };
+    /* oxlint-disable typescript/no-deprecated -- dual-read `key` widen under test */
     const props: GGPlotProps<{ id: string; x: number }> = {
       data: [{ id: "a", x: 1 }],
       height: 320,
@@ -91,6 +92,7 @@ describe("widenPlotProps", () => {
     const widened = widenPlotProps(props);
     // Six widened fields.
     expect(widened.key).toBe(key);
+    /* oxlint-enable typescript/no-deprecated */
     expect(widened.interaction).toBe(interaction);
     expect(widened.oninspect).toBe(oninspect);
     expect(widened.onselect).toBe(onselect);

--- a/packages/svelte/tests/scene/interaction-overlay-gaps.test.ts
+++ b/packages/svelte/tests/scene/interaction-overlay-gaps.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "vitest";
 
 import InteractionOverlay from "../../src/lib/scene/InteractionOverlay.svelte";
-import { CROSSHAIR_BOX_GAP_PAD, HOVER_CROSSHAIR_GAP_RADIUS } from "../../src/lib/scene/geometry.js";
+import {
+  CROSSHAIR_BOX_GAP_PAD,
+  HOVER_CROSSHAIR_GAP_RADIUS,
+  glyphHoverBox,
+} from "../../src/lib/scene/geometry.js";
 import { render } from "../helpers/render.js";
 
 function emptyDatum(anchor: { x: number; y: number }) {
@@ -17,21 +21,25 @@ function emptyDatum(anchor: { x: number; y: number }) {
   };
 }
 
+function xyInspection(focus: { x: number; y: number }) {
+  return {
+    type: "inspect" as const,
+    phase: "change" as const,
+    state: "transient" as const,
+    source: "keyboard" as const,
+    panelId: "p0",
+    mode: "xy" as const,
+    focus: emptyDatum(focus),
+    members: [emptyDatum(focus)] as const,
+  };
+}
+
 describe("InteractionOverlay crosshair glyph gaps (#1207)", () => {
   it("hard-gaps vertical guides through sibling label boxes", () => {
     const focus = { x: 120, y: 100 };
     const panel = { x: 40, y: 20, width: 200, height: 160 };
     const label = { x: 100, y: 40, width: 40, height: 14 };
-    const inspection = {
-      type: "inspect" as const,
-      phase: "change" as const,
-      state: "transient" as const,
-      source: "keyboard" as const,
-      panelId: "p0",
-      mode: "xy" as const,
-      focus: emptyDatum(focus),
-      members: [emptyDatum(focus)] as const,
-    };
+    const inspection = xyInspection(focus);
 
     const { container } = render(InteractionOverlay, {
       width: 280,
@@ -69,5 +77,84 @@ describe("InteractionOverlay crosshair glyph gaps (#1207)", () => {
         lo < focus.y + HOVER_CROSSHAIR_GAP_RADIUS && hi > focus.y - HOVER_CROSSHAIR_GAP_RADIUS;
       expect(coversFocus).toBe(false);
     }
+  });
+});
+
+describe("InteractionOverlay glyph box chrome", () => {
+  it("paints a measured hover box for glyph inspection (not a point ring)", () => {
+    const focus = { x: 80, y: 60 };
+    const panel = { x: 20, y: 10, width: 160, height: 120 };
+    const boxW = 36;
+    const boxH = 14;
+    const { container } = render(InteractionOverlay, {
+      width: 220,
+      height: 160,
+      interactive: true,
+      inspection: xyInspection(focus),
+      inspectionPanel: panel,
+      hoverChrome: "box",
+      hoverBoxWidth: boxW,
+      hoverBoxHeight: boxH,
+      hoverBoxAnchor: "middle",
+    });
+
+    expect(container.querySelector(".gg-hover-ring")).toBeNull();
+    const box = container.querySelector<SVGRectElement>(".gg-hover-box");
+    expect(box).not.toBeNull();
+    const expected = glyphHoverBox(focus, {
+      width: boxW,
+      height: boxH,
+      textAnchor: "middle",
+    });
+    expect(Number(box?.getAttribute("x"))).toBeCloseTo(expected.x, 5);
+    expect(Number(box?.getAttribute("y"))).toBeCloseTo(expected.y, 5);
+    expect(Number(box?.getAttribute("width"))).toBe(boxW);
+    expect(Number(box?.getAttribute("height"))).toBe(boxH);
+  });
+
+  it("paints selected and emphasized glyph boxes from presentation anchors", () => {
+    const selected = {
+      x: 50,
+      y: 40,
+      chrome: "box" as const,
+      width: 28,
+      height: 12,
+      textAnchor: "start" as const,
+    };
+    const emphasized = {
+      x: 90,
+      y: 70,
+      chrome: "box" as const,
+      width: 40,
+      height: 16,
+      textAnchor: "end" as const,
+    };
+    const { container } = render(InteractionOverlay, {
+      width: 200,
+      height: 140,
+      interactive: false,
+      selectedAnchors: [selected],
+      emphasizedAnchors: [emphasized],
+    });
+
+    const selectedBox = container.querySelector<SVGRectElement>(".gg-selected-box");
+    const emphasizedBox = container.querySelector<SVGRectElement>(".gg-emphasized-box");
+    expect(selectedBox).not.toBeNull();
+    expect(emphasizedBox).not.toBeNull();
+
+    const expectedSelected = glyphHoverBox(selected, {
+      width: selected.width,
+      height: selected.height,
+      textAnchor: selected.textAnchor,
+    });
+    const expectedEmphasized = glyphHoverBox(emphasized, {
+      width: emphasized.width,
+      height: emphasized.height,
+      textAnchor: emphasized.textAnchor,
+    });
+    expect(Number(selectedBox?.getAttribute("x"))).toBeCloseTo(expectedSelected.x, 5);
+    expect(Number(selectedBox?.getAttribute("width"))).toBe(selected.width);
+    expect(Number(emphasizedBox?.getAttribute("x"))).toBeCloseTo(expectedEmphasized.x, 5);
+    expect(Number(emphasizedBox?.getAttribute("width"))).toBe(emphasized.width);
   });
 });

--- a/packages/svelte/tests/scene/scene-view.test.ts
+++ b/packages/svelte/tests/scene/scene-view.test.ts
@@ -153,3 +153,52 @@ describe("SceneView focus-mask projection", () => {
     dispose();
   });
 });
+
+describe("SceneView panel chrome branches", () => {
+  it("draws minor grid lines when scales publish minorBreaks", () => {
+    const model = modelFor(
+      gg(rows, aes({ x: "x", y: "y" }))
+        .geomPoint()
+        .scaleXContinuous({ minorBreaks: [1.5] })
+        .scaleYContinuous({ minorBreaks: [15] })
+        .spec(),
+    );
+    const panel = model.scene.panels[0];
+    expect(panel?.grid.minorX?.length).toBeGreaterThan(0);
+    expect(panel?.grid.minorY?.length).toBeGreaterThan(0);
+
+    const { container } = render(SceneView, { scene: model.scene, mode: "full" });
+    const minor = container.querySelector("g.gg-grid-minor");
+    expect(minor).not.toBeNull();
+    expect(minor?.querySelectorAll("line").length).toBeGreaterThan(0);
+    model.dispose();
+  });
+
+  it("clips left facet strips with a side-band clipPath", () => {
+    const facetRows = [
+      { x: 1, y: 10, g: "alpha" },
+      { x: 2, y: 20, g: "beta" },
+    ];
+    const model = modelFor(
+      gg(facetRows, aes({ x: "x", y: "y" }))
+        .geomPoint()
+        .facet({
+          wrap: { field: "g", levels: ["alpha", "beta"] },
+          strip: { position: "left" },
+        })
+        .spec(),
+    );
+    expect(model.scene.panels.every((p) => p.stripPosition === "left")).toBe(true);
+    expect(model.scene.panels[0]?.strip).toBe("alpha");
+
+    const { container } = render(SceneView, { scene: model.scene, mode: "full" });
+    const strip = container.querySelector("g.gg-strip");
+    expect(strip).not.toBeNull();
+    // Left/right strips set clip:true so rotated labels stay in the band.
+    expect(strip?.getAttribute("clip-path")).toMatch(/^url\(#/);
+    const clipId = strip?.getAttribute("clip-path")?.match(/url\(#([^)]+)\)/)?.[1];
+    expect(clipId).toBeTruthy();
+    expect(container.querySelector(`clipPath#${CSS.escape(clipId!)}`)).not.toBeNull();
+    model.dispose();
+  });
+});


### PR DESCRIPTION
## Summary

Raise browser coverage on two scene modules that were still well below the package average:

1. **InteractionOverlay** — glyph `hoverChrome: "box"` and selected/emphasized presentation anchors with box chrome (point-ring paths were already exercised; box chrome was not).
2. **SceneView** — minor grid furniture when scales publish `minorBreaks`, and left facet strips that require a side-band `clipPath`.

## Tests

- `packages/svelte/tests/scene/interaction-overlay-gaps.test.ts` — measured hover box geometry; selected + emphasized glyph boxes.
- `packages/svelte/tests/scene/scene-view.test.ts` — minor grid lines present; left strip has a resolvable clipPath.

```bash
cd packages/svelte && bunx vitest run --project chromium   tests/scene/interaction-overlay-gaps.test.ts   tests/scene/scene-view.test.ts
```

## Coverage (browser lane, prior full suite → targeted files)

| File | Before (full suite) | After (this PR, targeted paths) |
|------|---------------------|----------------------------------|
| `InteractionOverlay.svelte` | ~85.5% lines | box chrome + glyph anchors now exercised |
| `SceneView.svelte` | ~86.2% lines | minor grid + left strip clip now exercised |

Zero-coverage compile-time contracts (`plot-layer-contract.ts`, `data-contract.ts`) remain intentionally unexecutable type guards — not runtime targets.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1263" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->