### PR TITLE
docs(home): drop oversized Examples section title

### DIFF
--- a/apps/docs/src/routes/+page.svelte
+++ b/apps/docs/src/routes/+page.svelte
@@ -24,9 +24,8 @@
   </h1>
 </section>
 
-<section class="home-featured" aria-labelledby="home-featured-heading">
+<section class="home-featured" aria-label="Examples">
   <header>
-    <h2 id="home-featured-heading">Examples</h2>
     <a href={`${base}/examples`}>Gallery</a>
   </header>
   <ol>
@@ -124,7 +123,12 @@
     padding-block: clamp(2.5rem, 6vw, 5rem) clamp(4rem, 8vw, 7rem);
   }
 
-  .home-featured header,
+  .home-featured header {
+    display: flex;
+    justify-content: flex-end;
+    margin-bottom: 1rem;
+  }
+
   .evidence header {
     display: flex;
     align-items: end;
@@ -133,7 +137,6 @@
     margin-bottom: 2rem;
   }
 
-  .home-featured h2,
   .evidence h2 {
     max-width: 13ch;
     margin: 0.25rem 0 0;

--- a/tests/visual/docs-home-gallery.spec.ts
+++ b/tests/visual/docs-home-gallery.spec.ts
@@ -21,7 +21,7 @@ test("homepage first viewport leads with title then featured examples", async ({
   await expect(page.locator(".home-hero svg")).toHaveCount(0);
   await expect(page.getByRole("button", { name: "Copy install" })).toHaveCount(0);
   await expect(page.getByRole("link", { name: "Getting started" })).toHaveCount(0);
-  await expect(page.getByRole("heading", { name: "Examples", level: 2 })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Examples", level: 2 })).toHaveCount(0);
   await expect(page.locator(".home-featured ol li")).toHaveCount(6);
   await expect(page.locator(".home-featured header a")).toHaveText("Gallery");
   await expectNoOverflow(page);


### PR DESCRIPTION
## Summary
- Remove the oversized "Examples" h2 on the docs homepage featured gallery
- Keep the Gallery link and section `aria-label`
- Update the homepage visual regression assertion accordingly

## Test plan
- [x] Updated `tests/visual/docs-home-gallery.spec.ts` to expect no level-2 "Examples" heading
- [ ] Spot-check homepage: title → featured grid with Gallery link, no giant Examples label
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1265" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->