### PR TITLE
docs: drop createPlotInteraction from static gallery examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,6 @@ and Windows.
 ```svelte
 <script lang="ts">
   import {
-    createPlotInteraction,
     GeomArea,
     GGPlot,
     GuideLegend,
@@ -87,18 +86,11 @@ and Windows.
   } from "@ggsvelte/svelte";
 
   import { crimeanMortality } from "./data.js";
-
-  const interaction = createPlotInteraction({
-    identity: (row) => `${row.month}:${row.cause}`,
-  });
-  const scope = { keys: "crimean-rows" } as const;
 </script>
 
 <GGPlot
   data={crimeanMortality}
   aes={{ x: "month", y: "deaths", fill: "cause" }}
-  {interaction}
-  interactionScope={scope}
 >
   <ThemeEconomist />
   <ScaleXDate labels="%b %Y" />

--- a/apps/docs/static/previews/provenance.json
+++ b/apps/docs/static/previews/provenance.json
@@ -8,12 +8,12 @@
     },
     "area/stacked": {
       "filename": "area-stacked-light.png",
-      "sourceSha256": "60c0187db1b1cbcc327754b0de0550030977ad9ba123070d932f3f915e85406b",
+      "sourceSha256": "38acc141ffcc8e171c1288a51ee56d2ceab294a8c85b205048106b8cf69f5c6c",
       "pngSha256": "5a708d0255b3c8c56bbecc0f1dc7849420f5ca6f7cb69785954752b8adb50d1a"
     },
     "bar/dodged": {
       "filename": "bar-dodged-light.png",
-      "sourceSha256": "ef5159af78070f37f005d1ba52e50aa6a6fe35045426eebf3d745a988942b408",
+      "sourceSha256": "b19e80d042b716b2f93fbe5c3711f3a75f32b8fa0277ac33b5a9957e938a40ad",
       "pngSha256": "8cb6896fb9bbc0a416a68469e855b558087867d8b1930b4ad1eade6037ecd7de"
     },
     "bar/horizontal": {
@@ -28,7 +28,7 @@
     },
     "bar/stacked": {
       "filename": "bar-stacked-light.png",
-      "sourceSha256": "f5b2158a5b2d0af7274fd4be414906efeab6c0691c9ef6cdaa020d67feaedd63",
+      "sourceSha256": "badf6ab7653c7a73ba11a107177733adba325d4d90334b7e67554a24dd627354",
       "pngSha256": "4c0a7f0b20fcdf9adb777a3c31ec25fbf6d60f30ced058a8f00f22a52bfa4dfd"
     },
     "bin2d/basic": {
@@ -218,7 +218,7 @@
     },
     "line/multi-series": {
       "filename": "line-multi-series-light.png",
-      "sourceSha256": "6befc15bf7df2c7179b3936000717e254e2d6ff2b230c417d0832104a3acd01f",
+      "sourceSha256": "084499cfea69a9af9a031becd381d011ef7a89af222b01135bbdd8b1136597d0",
       "pngSha256": "da402afca8515a3005d24268f44cc037a1202ce7248675b03c9afbeac3bfc69d"
     },
     "line/time-axis": {
@@ -298,7 +298,7 @@
     },
     "point/scatter-color": {
       "filename": "point-scatter-color-light.png",
-      "sourceSha256": "bc6148b5165f3f08d125fdb95a5063d5af0bcc910bc008dbd2f25004cd39060e",
+      "sourceSha256": "1e2581fecc4836b895314f1fe74130ff6e9900fedf3bad4bb2d459b6483e9abd",
       "pngSha256": "9bbe802827346cc004c03894c8aa27819493a6d7b6bb61ec16eb0b6120b75dd4"
     },
     "point/stat-manual-mean": {

--- a/examples/area/stacked/Example.svelte
+++ b/examples/area/stacked/Example.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import {
-    createPlotInteraction,
     GeomArea,
     GGPlot,
     GuideLegend,
@@ -11,18 +10,11 @@
   } from "@ggsvelte/svelte";
 
   import { crimeanMortality } from "./data.js";
-
-  const interaction = createPlotInteraction({
-    identity: (row) => `${row.month}:${row.cause}`,
-  });
-  const scope = { keys: "crimean-rows" } as const;
 </script>
 
 <GGPlot
   data={crimeanMortality}
   aes={{ x: "month", y: "deaths", fill: "cause" }}
-  {interaction}
-  interactionScope={scope}
   width={640}
   height={400}
 >

--- a/examples/bar/dodged/Example.svelte
+++ b/examples/bar/dodged/Example.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import {
-    createPlotInteraction,
     GeomBar,
     GGPlot,
     GuideLegend,
@@ -10,18 +9,11 @@
   } from "@ggsvelte/svelte";
 
   import { edgeworthDeaths } from "./data.js";
-
-  const interaction = createPlotInteraction({
-    identity: (row) => `${row.year}:${row.county}`,
-  });
-  const scope = { keys: "edgeworth-rows" } as const;
 </script>
 
 <GGPlot
   data={edgeworthDeaths}
   aes={{ x: "year", fill: "county", weight: "deaths" }}
-  {interaction}
-  interactionScope={scope}
   width={640}
   height={400}
 >

--- a/examples/bar/stacked/Example.svelte
+++ b/examples/bar/stacked/Example.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import {
-    createPlotInteraction,
     GeomBar,
     GGPlot,
     GuideLegend,
@@ -11,18 +10,11 @@
   } from "@ggsvelte/svelte";
 
   import { pyxTrial } from "./data.js";
-
-  const interaction = createPlotInteraction({
-    identity: (row) => `${row.bag}:${row.deviation}`,
-  });
-  const scope = { keys: "pyx-rows" } as const;
 </script>
 
 <GGPlot
   data={pyxTrial}
   aes={{ x: "bag", fill: "deviation", weight: "count" }}
-  {interaction}
-  interactionScope={scope}
   width={640}
   height={400}
 >

--- a/examples/line/multi-series/Example.svelte
+++ b/examples/line/multi-series/Example.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import {
-    createPlotInteraction,
     GeomLine,
     GeomPoint,
     GGPlot,
@@ -12,18 +11,11 @@
   } from "@ggsvelte/svelte";
 
   import { wheatAndWages } from "./data.js";
-
-  const interaction = createPlotInteraction({
-    identity: (row) => `${row.year}:${row.series}`,
-  });
-  const scope = { keys: "wheat-rows" } as const;
 </script>
 
 <GGPlot
   data={wheatAndWages}
   aes={{ x: "year", y: "value", color: "series" }}
-  {interaction}
-  interactionScope={scope}
   width={640}
   height={400}
 >

--- a/examples/point/scatter-color/Example.svelte
+++ b/examples/point/scatter-color/Example.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import {
-    createPlotInteraction,
     GeomPoint,
     GGPlot,
     GuideLegend,
@@ -10,18 +9,11 @@
   } from "@ggsvelte/svelte";
 
   import { guerry } from "./data.js";
-
-  const interaction = createPlotInteraction({
-    identity: "department",
-  });
-  const scope = { keys: "guerry-rows" } as const;
 </script>
 
 <GGPlot
   data={guerry}
   aes={{ x: "literacy", y: "crimePersons", color: "region" }}
-  {interaction}
-  interactionScope={scope}
   width={640}
   height={400}
 >

--- a/scripts/example-interaction-api.test.ts
+++ b/scripts/example-interaction-api.test.ts
@@ -72,4 +72,29 @@ describe("example interaction API (v0.20)", () => {
     expect(plotLevelInteractionOffenders(" oninspect={(e) => {}} ")).toEqual([]);
     expect(plotLevelInteractionOffenders(" interactionScope={scope} ")).toEqual([]);
   });
+
+  /**
+   * createPlotInteraction / interactionScope are for linked views and shared
+   * semantic state — not for single-plot gallery charts that only need legend
+   * focus or default row identity. Static examples under every category except
+   * `interaction/` must stay free of that boilerplate (default index/`id`
+   * identity is enough for GuideLegend focus).
+   */
+  it("keeps createPlotInteraction out of non-interaction gallery examples", () => {
+    const offenders = files
+      .map((path) => ({
+        id: relative(EXAMPLES, path).replace(/\/Example\.svelte$/, ""),
+        source: readFileSync(path, "utf8"),
+      }))
+      .filter(({ id }) => !id.startsWith("interaction/"))
+      .filter(
+        ({ source }) =>
+          source.includes("createPlotInteraction") ||
+          /\binteractionScope\s*=/.test(source) ||
+          /\{interaction\}/.test(source),
+      )
+      .map(({ id }) => id);
+
+    expect(offenders).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Summary

#1257 moved durable row identity onto interaction surfaces and wired five single-plot gallery charts with `createPlotInteraction({ identity })` + `interactionScope` so `GuideLegend focus` had custom keys. That was wrong for the front door: those charts are single-plot showcases, and default index/`id` identity is enough for legend focus (see `resolve-datum-key.ts`).

This PR strips the controller boilerplate from:

- `examples/area/stacked` (and the matching README Crimea snippet)
- `examples/bar/dodged`
- `examples/bar/stacked`
- `examples/line/multi-series`
- `examples/point/scatter-color`

`GuideLegend channel=… focus` stays. `examples/interaction/*` and Inspect-based demos keep real controllers where they share semantic state.

## Test plan

- [x] `bun test scripts/example-interaction-api.test.ts scripts/readme-showcase.test.ts`
- [x] `bun scripts/gen-gallery-previews.ts --check` (source digests restamped; PNGs unchanged)
- [x] New contract: non-`interaction/` gallery examples must not mention `createPlotInteraction` / `interactionScope` / `{interaction}`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1266" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->