### PR TITLE
test(examples): gate createPlotInteraction out of static gallery corpus

### DIFF
--- a/scripts/example-interaction-api.test.ts
+++ b/scripts/example-interaction-api.test.ts
@@ -72,4 +72,30 @@ describe("example interaction API (v0.20)", () => {
     expect(plotLevelInteractionOffenders(" oninspect={(e) => {}} ")).toEqual([]);
     expect(plotLevelInteractionOffenders(" interactionScope={scope} ")).toEqual([]);
   });
+
+  /**
+   * createPlotInteraction / interactionScope are for linked views and shared
+   * semantic state — not for single-plot gallery charts that only need legend
+   * focus or default row identity. Static examples under every category except
+   * `interaction/` must stay free of that boilerplate (default index/`id`
+   * identity is enough for GuideLegend focus). README snippets are also gated
+   * by scripts/readme-showcase.test.ts; this covers the corpus itself.
+   */
+  it("keeps createPlotInteraction out of non-interaction gallery examples", () => {
+    const offenders = files
+      .map((path) => ({
+        id: relative(EXAMPLES, path).replace(/\/Example\.svelte$/, ""),
+        source: readFileSync(path, "utf8"),
+      }))
+      .filter(({ id }) => !id.startsWith("interaction/"))
+      .filter(
+        ({ source }) =>
+          source.includes("createPlotInteraction") ||
+          source.includes("interactionScope=") ||
+          source.includes("{interaction}"),
+      )
+      .map(({ id }) => id);
+
+    expect(offenders).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Summary

#1264 removed `createPlotInteraction` / `interactionScope` from static gallery examples and README. That PR only gates **README** snippets.

This adds the same rule to every non-`interaction/` `Example.svelte` so the corpus itself cannot re-teach controller boilerplate on single-plot charts (the original Crimea / stacked-area failure mode).

## Test plan

- [x] `bun test scripts/example-interaction-api.test.ts`
- [x] Controllers remain allowed under `examples/interaction/*`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1267" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->