### PR TITLE
fix(core): auto-align sparse stacked-area groups instead of floating polygons

### DIFF
--- a/.changeset/stack-auto-align.md
+++ b/.changeset/stack-auto-align.md
@@ -1,5 +1,5 @@
 ---
-"@ggsvelte/core": patch
+"@ggsvelte/core": minor
 "@ggsvelte/spec": patch
 ---
 
@@ -11,6 +11,13 @@ Stacked area groups whose continuous x samples skip an interior grid point
 used to chord straight across the hole while the stack below varied,
 rendering disembodied polygons — silently. The default identity path now
 auto-applies the align stat (interpolate between a group's observed samples,
-zero outside its range) and emits a `stack-align-applied` advisory. The
-rescue stands down when the x scale may train discrete or a group repeats an
-x value, so existing correct plots keep their geometry.
+zero outside its range) and emits a new `stack-align-applied` advisory.
+
+The rescue stands down — keeping today's geometry — when the x scale may
+train discrete, when a group repeats an x value, or when the expansion would
+exceed its budget (the new `stack-align-skipped` warning discloses that
+case). Aligned frames keep source-row lineage for grid points that coincide
+with observed samples, so hover/tooltip/keyboard inspection still reach real
+data (this also lights up inspection on explicit `stat: "align"` layers).
+
+Migration: none — additive (new diagnostic names; no existing surface changed).

--- a/.changeset/stack-auto-align.md
+++ b/.changeset/stack-auto-align.md
@@ -1,0 +1,16 @@
+---
+"@ggsvelte/core": patch
+"@ggsvelte/spec": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+fix(core): auto-align sparse stacked-area groups instead of rendering floating polygons
+
+Stacked area groups whose continuous x samples skip an interior grid point
+used to chord straight across the hole while the stack below varied,
+rendering disembodied polygons — silently. The default identity path now
+auto-applies the align stat (interpolate between a group's observed samples,
+zero outside its range) and emits a `stack-align-applied` advisory. The
+rescue stands down when the x scale may train discrete or a group repeats an
+x value, so existing correct plots keep their geometry.

--- a/apps/docs/src/lib/generated/routes.ts
+++ b/apps/docs/src/lib/generated/routes.ts
@@ -11552,6 +11552,11 @@ export const DOCS_ROUTES = [
         level: 3,
       },
       {
+        id: "stack-align-skipped",
+        title: "stack-align-skipped",
+        level: 3,
+      },
+      {
         id: "smooth-group-dropped",
         title: "smooth-group-dropped",
         level: 3,

--- a/apps/docs/src/lib/generated/routes.ts
+++ b/apps/docs/src/lib/generated/routes.ts
@@ -11914,6 +11914,11 @@ export const DOCS_ROUTES = [
         level: 3,
       },
       {
+        id: "stack-zero-filled",
+        title: "stack-zero-filled",
+        level: 3,
+      },
+      {
         id: "palette-inferred",
         title: "palette-inferred",
         level: 3,

--- a/apps/docs/src/lib/generated/routes.ts
+++ b/apps/docs/src/lib/generated/routes.ts
@@ -11914,8 +11914,8 @@ export const DOCS_ROUTES = [
         level: 3,
       },
       {
-        id: "stack-zero-filled",
-        title: "stack-zero-filled",
+        id: "stack-align-applied",
+        title: "stack-align-applied",
         level: 3,
       },
       {

--- a/apps/docs/src/lib/generated/search-index.ts
+++ b/apps/docs/src/lib/generated/search-index.ts
@@ -18985,6 +18985,16 @@ export const DOCS_SEARCH_INDEX = [
     exact: ["map-region-missing"],
   },
   {
+    id: "heading:guide-errors:stack-align-skipped",
+    kind: "heading",
+    title: "stack-align-skipped",
+    summary:
+      "stack-align-skipped in Errors reference. Understand validation, render, interaction, and CLI diagnostics and recover safely.",
+    href: "/guide/errors#stack-align-skipped",
+    keywords: ["Errors reference", "Reference"],
+    exact: ["stack-align-skipped"],
+  },
+  {
     id: "heading:guide-errors:smooth-group-dropped",
     kind: "heading",
     title: "smooth-group-dropped",
@@ -41341,6 +41351,20 @@ export const DOCS_SEARCH_INDEX = [
       "Inspect the warning message for its path and count, then correct the named data, scale, or option.",
     ],
     exact: ["map-region-missing", "warning:map-region-missing"],
+  },
+  {
+    id: "diagnostic:warning:stack-align-skipped",
+    kind: "diagnostic",
+    title: "stack-align-skipped · warning",
+    summary:
+      "Sparse stacked-area groups were left unaligned because the shared-grid expansion exceeds the auto-rescue budget; bands with interior gaps may render as floating polygons.",
+    href: "/guide/errors#stack-align-skipped",
+    keywords: [
+      "warning",
+      "warning",
+      "Inspect the warning message for its path and count, then correct the named data, scale, or option.",
+    ],
+    exact: ["stack-align-skipped", "warning:stack-align-skipped"],
   },
   {
     id: "diagnostic:warning:smooth-group-dropped",

--- a/apps/docs/src/lib/generated/search-index.ts
+++ b/apps/docs/src/lib/generated/search-index.ts
@@ -19684,14 +19684,14 @@ export const DOCS_SEARCH_INDEX = [
     exact: ["jitter-seeded"],
   },
   {
-    id: "heading:guide-advisories:stack-zero-filled",
+    id: "heading:guide-advisories:stack-align-applied",
     kind: "heading",
-    title: "stack-zero-filled",
+    title: "stack-align-applied",
     summary:
-      "stack-zero-filled in Advisories. Spec-lint advisories and the pipeline's disclosed heuristics.",
-    href: "/guide/advisories#stack-zero-filled",
+      "stack-align-applied in Advisories. Spec-lint advisories and the pipeline's disclosed heuristics.",
+    href: "/guide/advisories#stack-align-applied",
     keywords: ["Advisories", "Reference"],
-    exact: ["stack-zero-filled"],
+    exact: ["stack-align-applied"],
   },
   {
     id: "heading:guide-advisories:palette-inferred",

--- a/apps/docs/src/lib/generated/search-index.ts
+++ b/apps/docs/src/lib/generated/search-index.ts
@@ -19684,6 +19684,16 @@ export const DOCS_SEARCH_INDEX = [
     exact: ["jitter-seeded"],
   },
   {
+    id: "heading:guide-advisories:stack-zero-filled",
+    kind: "heading",
+    title: "stack-zero-filled",
+    summary:
+      "stack-zero-filled in Advisories. Spec-lint advisories and the pipeline's disclosed heuristics.",
+    href: "/guide/advisories#stack-zero-filled",
+    keywords: ["Advisories", "Reference"],
+    exact: ["stack-zero-filled"],
+  },
+  {
     id: "heading:guide-advisories:palette-inferred",
     kind: "heading",
     title: "palette-inferred",

--- a/packages/core/src/diagnostics-emission-registry.ts
+++ b/packages/core/src/diagnostics-emission-registry.ts
@@ -69,6 +69,7 @@ export const WARNING_EMISSION_REGISTRY = {
   "density-2d-filled-open-dropped": { channel: "warning" },
   "sf-coordinates-dropped": { channel: "warning" },
   "map-region-missing": { channel: "warning" },
+  "stack-align-skipped": { channel: "warning" },
   "smooth-group-dropped": { channel: "warning" },
   "quantile-empty": { channel: "warning" },
   "quantile-group-dropped": { channel: "warning" },

--- a/packages/core/src/diagnostics-emission-registry.ts
+++ b/packages/core/src/diagnostics-emission-registry.ts
@@ -111,7 +111,7 @@ export const ADVISORY_EMISSION_REGISTRY = {
   "bin-default-bins": { channel: "advisory" },
   "smooth-method-inferred": { channel: "advisory" },
   "jitter-seeded": { channel: "advisory" },
-  "stack-zero-filled": { channel: "advisory" },
+  "stack-align-applied": { channel: "advisory" },
   "palette-inferred": { channel: "advisory" },
   "canvas-auto": { channel: "advisory" },
   "temporal-year-inferred": { channel: "advisory" },

--- a/packages/core/src/diagnostics-emission-registry.ts
+++ b/packages/core/src/diagnostics-emission-registry.ts
@@ -111,6 +111,7 @@ export const ADVISORY_EMISSION_REGISTRY = {
   "bin-default-bins": { channel: "advisory" },
   "smooth-method-inferred": { channel: "advisory" },
   "jitter-seeded": { channel: "advisory" },
+  "stack-zero-filled": { channel: "advisory" },
   "palette-inferred": { channel: "advisory" },
   "canvas-auto": { channel: "advisory" },
   "temporal-year-inferred": { channel: "advisory" },

--- a/packages/core/src/diagnostics-warning-catalog.ts
+++ b/packages/core/src/diagnostics-warning-catalog.ts
@@ -116,6 +116,10 @@ export const PIPELINE_WARNING_CATALOG = {
   "map-region-missing": {
     summary: "One or more value rows had no matching map region and were dropped.",
   },
+  "stack-align-skipped": {
+    summary:
+      "Sparse stacked-area groups were left unaligned because the shared-grid expansion exceeds the auto-rescue budget; bands with interior gaps may render as floating polygons.",
+  },
   "smooth-group-dropped": {
     summary: "A smooth group had too few points for the fit and was dropped.",
   },

--- a/packages/core/src/diagnostics.ts
+++ b/packages/core/src/diagnostics.ts
@@ -66,6 +66,10 @@ export const ADVISORY_CATALOG = {
   "jitter-seeded": {
     summary: "The jitter position used its default deterministic seed.",
   },
+  "stack-zero-filled": {
+    summary:
+      "A stacked area layer zero-filled missing group×x cells onto the shared x grid; groups sampled different x, and the gap would render as a floating band.",
+  },
   "palette-inferred": {
     summary: "A color scale used the edition's default palette/ramp.",
   },

--- a/packages/core/src/diagnostics.ts
+++ b/packages/core/src/diagnostics.ts
@@ -66,9 +66,9 @@ export const ADVISORY_CATALOG = {
   "jitter-seeded": {
     summary: "The jitter position used its default deterministic seed.",
   },
-  "stack-zero-filled": {
+  "stack-align-applied": {
     summary:
-      "A stacked area layer zero-filled missing group×x cells onto the shared x grid; groups sampled different x, and the gap would render as a floating band.",
+      "A stacked area layer auto-aligned its groups onto the shared x grid; groups sampled different x, and a raw stack would render floating bands.",
   },
   "palette-inferred": {
     summary: "A color scale used the edition's default palette/ramp.",

--- a/packages/core/src/pipeline/frame-stats-align.ts
+++ b/packages/core/src/pipeline/frame-stats-align.ts
@@ -84,9 +84,11 @@ export function maybeStackAlignFrame(
   if (expanded > Math.max(STACK_ALIGN_MAX_ROWS, STACK_ALIGN_MAX_GROWTH * need.finiteRows)) {
     // Align materializes groups × union-x rows; on very sparse high-n data
     // that can dwarf the input. Keep raw geometry and say so loudly.
+    // Message stays panel-independent (no per-panel counts) so dedupeWarnings
+    // collapses faceted emissions to one disclosure per layer.
     warnings.push({
       code: "stack-align-skipped",
-      message: `Layer ${index}: stacked area groups sample different x values, but auto-align would expand ${need.finiteRows} rows to ${expanded} (groups × shared-grid x) — bands with interior gaps may render as floating polygons. Pre-fill or aggregate the data, or set stat: "align" to force the expansion.`,
+      message: `Layer ${index}: stacked area groups sample different x values, but auto-align would expand the rows past its budget (groups × shared-grid x) — bands with interior gaps may render as floating polygons. Pre-fill or aggregate the data, or set stat: "align" to force the expansion.`,
     });
     return null;
   }

--- a/packages/core/src/pipeline/frame-stats-align.ts
+++ b/packages/core/src/pipeline/frame-stats-align.ts
@@ -9,6 +9,7 @@ import { carriedColumns, removedStatWarning } from "./frame-helpers.js";
 import { makeColumnOf } from "./frame-stats-shared.js";
 import { statLayerFrame } from "./layer-frame.js";
 import { positionColumn, positionFieldType, xConversionOf } from "./temporal-position.js";
+import { NO_ROW } from "./types.js";
 import type { Advisory, LayerBinding, LayerFrame, PipelineWarning } from "./types.js";
 
 export function buildAlignFrame(
@@ -27,6 +28,10 @@ export function buildAlignFrame(
     carried,
   });
   removedStatWarning(result.dropped, index, "missing or non-finite x/y before align", warnings);
+  // Grid points that coincide with a group's own observed sample keep that
+  // row's lineage, so hover/tooltip/keyboard inspection still reach real data
+  // on aligned frames; only interpolated/zero-extended cells are synthetic.
+  const lineage = Uint32Array.from(result.sourceRows, (row) => (row < 0 ? NO_ROW : row));
   return statLayerFrame({
     binding,
     table,
@@ -37,7 +42,7 @@ export function buildAlignFrame(
     inputGroups: groups,
     columns: { x: result.x, y: result.y },
     columnOf: columnOf(result, null),
-    lineage: "none",
+    lineage,
   });
 }
 
@@ -73,14 +78,25 @@ export function maybeStackAlignFrame(
 
   const x = positionColumn(table, binding.xField, binding.xConversion, binding.xTransform);
   const y = positionColumn(table, binding.yField, binding.yConversion, binding.yTransform);
-  if (!needsStackAlign(x, y, groups)) return null;
+  const need = needsStackAlign(x, y, groups);
+  if (need === null) return null;
+  const expanded = need.groupCount * need.gridSize;
+  if (expanded > Math.max(STACK_ALIGN_MAX_ROWS, STACK_ALIGN_MAX_GROWTH * need.finiteRows)) {
+    // Align materializes groups × union-x rows; on very sparse high-n data
+    // that can dwarf the input. Keep raw geometry and say so loudly.
+    warnings.push({
+      code: "stack-align-skipped",
+      message: `Layer ${index}: stacked area groups sample different x values, but auto-align would expand ${need.finiteRows} rows to ${expanded} (groups × shared-grid x) — bands with interior gaps may render as floating polygons. Pre-fill or aggregate the data, or set stat: "align" to force the expansion.`,
+    });
+    return null;
+  }
 
   const frame = buildAlignFrame(binding, table, groups, warnings);
   advisories.push({
     code: "stack-align-applied",
     path: `layers.${index}`,
     chosen:
-      "groups aligned onto the shared x grid — interpolated between a group's observed samples, zero outside its range (groups sampled different x; a raw stack would render floating bands)",
+      "groups aligned onto the shared x grid — interpolated between a group's observed samples, zero outside its range (groups sampled different x; a raw stack would render floating bands; faceted panels gate independently, matching panel-local stats)",
     howToOverride: `Pre-fill the missing group×x cells in the data to control values exactly, or set position: "identity" on layer ${index} for overlapping unstacked areas. stat: "align" is this same transform, explicit.`,
   });
   return frame;
@@ -112,19 +128,31 @@ export function xDiscreteRiskOf(
   return false;
 }
 
+/** Absolute expanded-row budget for the auto rescue (explicit stat align has no cap). */
+export const STACK_ALIGN_MAX_ROWS = 20_000;
+/** Relative expanded-row budget: multiple of the layer's finite input rows. */
+export const STACK_ALIGN_MAX_GROWTH = 10;
+
 /**
- * True when the rescue should fire: ≥2 groups have finite rows, no group
+ * Non-null when the rescue should fire: ≥2 groups have finite rows, no group
  * repeats a finite x (identity stacking sums repeats; align's last-wins
  * collapse would silently shrink the stacked total), and some group's finite
  * x set skips a shared-grid x strictly inside that group's own [min, max] —
- * the shape that chords across the stack.
+ * the shape that chords across the stack. Returns the expansion inputs so the
+ * caller can budget groups × union-x before rewriting the frame.
  */
-function needsStackAlign(x: Float64Array, y: Float64Array, groups: readonly number[]): boolean {
+function needsStackAlign(
+  x: Float64Array,
+  y: Float64Array,
+  groups: readonly number[],
+): { groupCount: number; gridSize: number; finiteRows: number } | null {
   const perGroup = new Map<number, Set<number>>();
   const grid = new Set<number>();
+  let finiteRows = 0;
   for (let row = 0; row < x.length; row++) {
     const xv = x[row]!;
     if (!Number.isFinite(xv) || !Number.isFinite(y[row]!)) continue;
+    finiteRows++;
     grid.add(xv);
     const g = groups[row] ?? 0;
     let set = perGroup.get(g);
@@ -132,10 +160,10 @@ function needsStackAlign(x: Float64Array, y: Float64Array, groups: readonly numb
       set = new Set();
       perGroup.set(g, set);
     }
-    if (set.has(xv)) return false;
+    if (set.has(xv)) return null;
     set.add(xv);
   }
-  if (perGroup.size < 2) return false;
+  if (perGroup.size < 2) return null;
   const gridSorted = [...grid].toSorted((a, b) => a - b);
   for (const set of perGroup.values()) {
     if (set.size === gridSorted.length) continue;
@@ -148,8 +176,10 @@ function needsStackAlign(x: Float64Array, y: Float64Array, groups: readonly numb
     for (const xv of gridSorted) {
       if (xv <= min) continue;
       if (xv >= max) break;
-      if (!set.has(xv)) return true;
+      if (!set.has(xv)) {
+        return { groupCount: perGroup.size, gridSize: gridSorted.length, finiteRows };
+      }
     }
   }
-  return false;
+  return null;
 }

--- a/packages/core/src/pipeline/frame-stats-align.ts
+++ b/packages/core/src/pipeline/frame-stats-align.ts
@@ -1,14 +1,15 @@
 /**
- * Align stat → LayerFrame (shared x grid + interpolated y per group).
+ * Shared-x-grid stats → LayerFrame: the align stat (interpolated y per group)
+ * and the default-stack zero-fill rescue for sparse stacked areas (#1268).
  */
 import type { ColumnTable } from "../table.js";
 
-import { statAlign } from "../stats/align.js";
+import { statAlign, statZeroFill, type StatAlignResult } from "../stats/align.js";
 import { carriedColumns, removedStatWarning } from "./frame-helpers.js";
 import { makeColumnOf } from "./frame-stats-shared.js";
 import { statLayerFrame } from "./layer-frame.js";
-import { positionColumn } from "./temporal-position.js";
-import type { LayerBinding, LayerFrame, PipelineWarning } from "./types.js";
+import { positionColumn, positionFieldType, xConversionOf } from "./temporal-position.js";
+import type { Advisory, LayerBinding, LayerFrame, PipelineWarning } from "./types.js";
 
 export function buildAlignFrame(
   binding: LayerBinding,
@@ -16,16 +17,134 @@ export function buildAlignFrame(
   groups: readonly number[],
   warnings: PipelineWarning[],
 ): LayerFrame {
+  return buildSharedGridFrame(binding, table, groups, warnings, statAlign, "align");
+}
+
+/**
+ * Default stacked-area rescue (#1268): when a group's x samples leave an
+ * interior hole in the shared grid, the identity path would chord straight
+ * across it and render a floating polygon over the varying stack below.
+ * Zero-fill missing group×x cells instead (absence = zero, no interpolation)
+ * and disclose the heuristic. Exterior-only incompleteness, non-overlapping
+ * ranges, single groups, and unstacked positions fall through to identity.
+ * Row expansion is O(groups × union-x).
+ */
+export function maybeStackZeroFillFrame(
+  binding: LayerBinding,
+  table: ColumnTable,
+  groups: readonly number[],
+  warnings: PipelineWarning[],
+  advisories: Advisory[],
+  xDiscreteRisk: boolean,
+): LayerFrame | null {
+  const { layer, index } = binding;
+  // A band-trained x cannot consume the numeric-only shared-grid frame (rows
+  // would drop as unmappable), so any discretization risk skips the rescue.
+  if (xDiscreteRisk) return null;
+  if (layer.geom !== "area") return null;
+  if ((layer.stat ?? "identity") !== "identity") return null;
+  const position = layer.position ?? "identity";
+  if (position !== "stack" && position !== "fill") return null;
+  if (binding.xField === null || binding.yField === null) return null;
+
+  const x = positionColumn(table, binding.xField, binding.xConversion, binding.xTransform);
+  const y = positionColumn(table, binding.yField, binding.yConversion, binding.yTransform);
+  if (!hasInteriorHole(x, y, groups)) return null;
+
+  const frame = buildSharedGridFrame(binding, table, groups, warnings, statZeroFill, "zero-fill");
+  advisories.push({
+    code: "stack-zero-filled",
+    path: `layers.${index}`,
+    chosen:
+      "missing group×x cells zero-filled onto the shared x grid (groups sampled different x; the gap would render as a floating band)",
+    howToOverride: `Set stat: "align" on layer ${index} to interpolate between a group's observed samples instead, pre-fill the missing cells in the data, or set position: "identity" for overlapping unstacked areas.`,
+  });
+  return frame;
+}
+
+/**
+ * Plot-level risk that the shared x scale trains as band/binned, mirroring
+ * `collectMappedXEvidence`: an explicit discrete x type, any bar/col layer
+ * with a non-bin stat (bar discretization), or any nominal x field. When any
+ * layer carries the risk, the zero-fill rescue must not rewrite frames — a
+ * band scale cannot map the numeric-only shared-grid rows. Conservative by
+ * design: a false positive only keeps today's identity behavior.
+ */
+export function xDiscreteRiskOf(
+  bindings: readonly LayerBinding[],
+  tables: readonly ColumnTable[],
+  xType: string | undefined,
+): boolean {
+  if (xType === "band" || xType === "binned") return true;
+  for (let i = 0; i < bindings.length; i++) {
+    const binding = bindings[i]!;
+    const geom = binding.layer.geom;
+    if ((geom === "bar" || geom === "col") && binding.layer.stat !== "bin") return true;
+    const field = binding.xField;
+    const table = tables[i];
+    if (field === null || table === undefined || !table.has(field)) continue;
+    if (positionFieldType(table, field, xConversionOf(binding)) === "nominal") return true;
+  }
+  return false;
+}
+
+/**
+ * True when ≥2 groups have finite rows and some group's finite x set skips a
+ * shared-grid x strictly inside that group's own [min, max] — the shape that
+ * chords across the stack.
+ */
+function hasInteriorHole(x: Float64Array, y: Float64Array, groups: readonly number[]): boolean {
+  const perGroup = new Map<number, Set<number>>();
+  const grid = new Set<number>();
+  for (let row = 0; row < x.length; row++) {
+    const xv = x[row]!;
+    if (!Number.isFinite(xv) || !Number.isFinite(y[row]!)) continue;
+    grid.add(xv);
+    const g = groups[row] ?? 0;
+    let set = perGroup.get(g);
+    if (set === undefined) {
+      set = new Set();
+      perGroup.set(g, set);
+    }
+    set.add(xv);
+  }
+  if (perGroup.size < 2) return false;
+  const gridSorted = [...grid].toSorted((a, b) => a - b);
+  for (const set of perGroup.values()) {
+    if (set.size === gridSorted.length) continue;
+    let min = Infinity;
+    let max = -Infinity;
+    for (const v of set) {
+      if (v < min) min = v;
+      if (v > max) max = v;
+    }
+    for (const xv of gridSorted) {
+      if (xv <= min) continue;
+      if (xv >= max) break;
+      if (!set.has(xv)) return true;
+    }
+  }
+  return false;
+}
+
+function buildSharedGridFrame(
+  binding: LayerBinding,
+  table: ColumnTable,
+  groups: readonly number[],
+  warnings: PipelineWarning[],
+  stat: (input: Parameters<typeof statAlign>[0]) => StatAlignResult,
+  label: string,
+): LayerFrame {
   const { index } = binding;
   const carried = carriedColumns(binding, table);
   const columnOf = makeColumnOf(binding);
-  const result = statAlign({
+  const result = stat({
     x: positionColumn(table, binding.xField!, binding.xConversion, binding.xTransform),
     y: positionColumn(table, binding.yField!, binding.yConversion, binding.yTransform),
     groups,
     carried,
   });
-  removedStatWarning(result.dropped, index, "missing or non-finite x/y before align", warnings);
+  removedStatWarning(result.dropped, index, `missing or non-finite x/y before ${label}`, warnings);
   return statLayerFrame({
     binding,
     table,

--- a/packages/core/src/pipeline/frame-stats-align.ts
+++ b/packages/core/src/pipeline/frame-stats-align.ts
@@ -129,9 +129,9 @@ export function xDiscreteRiskOf(
 }
 
 /** Absolute expanded-row budget for the auto rescue (explicit stat align has no cap). */
-export const STACK_ALIGN_MAX_ROWS = 20_000;
+const STACK_ALIGN_MAX_ROWS = 20_000;
 /** Relative expanded-row budget: multiple of the layer's finite input rows. */
-export const STACK_ALIGN_MAX_GROWTH = 10;
+const STACK_ALIGN_MAX_GROWTH = 10;
 
 /**
  * Non-null when the rescue should fire: ≥2 groups have finite rows, no group

--- a/packages/core/src/pipeline/frame-stats-align.ts
+++ b/packages/core/src/pipeline/frame-stats-align.ts
@@ -1,10 +1,10 @@
 /**
- * Shared-x-grid stats → LayerFrame: the align stat (interpolated y per group)
- * and the default-stack zero-fill rescue for sparse stacked areas (#1268).
+ * Align stat → LayerFrame (shared x grid + interpolated y per group), plus
+ * the default-stack auto-align rescue for sparse stacked areas (#1268).
  */
 import type { ColumnTable } from "../table.js";
 
-import { statAlign, statZeroFill, type StatAlignResult } from "../stats/align.js";
+import { statAlign } from "../stats/align.js";
 import { carriedColumns, removedStatWarning } from "./frame-helpers.js";
 import { makeColumnOf } from "./frame-stats-shared.js";
 import { statLayerFrame } from "./layer-frame.js";
@@ -17,19 +17,43 @@ export function buildAlignFrame(
   groups: readonly number[],
   warnings: PipelineWarning[],
 ): LayerFrame {
-  return buildSharedGridFrame(binding, table, groups, warnings, statAlign, "align");
+  const { index } = binding;
+  const carried = carriedColumns(binding, table);
+  const columnOf = makeColumnOf(binding);
+  const result = statAlign({
+    x: positionColumn(table, binding.xField!, binding.xConversion, binding.xTransform),
+    y: positionColumn(table, binding.yField!, binding.yConversion, binding.yTransform),
+    groups,
+    carried,
+  });
+  removedStatWarning(result.dropped, index, "missing or non-finite x/y before align", warnings);
+  return statLayerFrame({
+    binding,
+    table,
+    n: result.x.length,
+    x: { numeric: result.x },
+    y: { numeric: result.y },
+    groups: result.groups,
+    inputGroups: groups,
+    columns: { x: result.x, y: result.y },
+    columnOf: columnOf(result, null),
+    lineage: "none",
+  });
 }
 
 /**
  * Default stacked-area rescue (#1268): when a group's x samples leave an
  * interior hole in the shared grid, the identity path would chord straight
  * across it and render a floating polygon over the varying stack below.
- * Zero-fill missing group×x cells instead (absence = zero, no interpolation)
+ * Auto-apply the align stat instead — the documented remedy for stacking
+ * groups with different continuous x samples (ggplot2 stat_align semantics:
+ * interpolate between a group's observed samples, zero outside its range) —
  * and disclose the heuristic. Exterior-only incompleteness, non-overlapping
- * ranges, single groups, and unstacked positions fall through to identity.
- * Row expansion is O(groups × union-x).
+ * ranges, single groups, unstacked positions, and groups with repeated x
+ * values (identity stacking sums those; align would drop them) fall through
+ * to identity. Row expansion is O(groups × union-x).
  */
-export function maybeStackZeroFillFrame(
+export function maybeStackAlignFrame(
   binding: LayerBinding,
   table: ColumnTable,
   groups: readonly number[],
@@ -49,15 +73,15 @@ export function maybeStackZeroFillFrame(
 
   const x = positionColumn(table, binding.xField, binding.xConversion, binding.xTransform);
   const y = positionColumn(table, binding.yField, binding.yConversion, binding.yTransform);
-  if (!hasInteriorHole(x, y, groups)) return null;
+  if (!needsStackAlign(x, y, groups)) return null;
 
-  const frame = buildSharedGridFrame(binding, table, groups, warnings, statZeroFill, "zero-fill");
+  const frame = buildAlignFrame(binding, table, groups, warnings);
   advisories.push({
-    code: "stack-zero-filled",
+    code: "stack-align-applied",
     path: `layers.${index}`,
     chosen:
-      "missing group×x cells zero-filled onto the shared x grid (groups sampled different x; the gap would render as a floating band)",
-    howToOverride: `Set stat: "align" on layer ${index} to interpolate between a group's observed samples instead, pre-fill the missing cells in the data, or set position: "identity" for overlapping unstacked areas.`,
+      "groups aligned onto the shared x grid — interpolated between a group's observed samples, zero outside its range (groups sampled different x; a raw stack would render floating bands)",
+    howToOverride: `Pre-fill the missing group×x cells in the data to control values exactly, or set position: "identity" on layer ${index} for overlapping unstacked areas. stat: "align" is this same transform, explicit.`,
   });
   return frame;
 }
@@ -66,7 +90,7 @@ export function maybeStackZeroFillFrame(
  * Plot-level risk that the shared x scale trains as band/binned, mirroring
  * `collectMappedXEvidence`: an explicit discrete x type, any bar/col layer
  * with a non-bin stat (bar discretization), or any nominal x field. When any
- * layer carries the risk, the zero-fill rescue must not rewrite frames — a
+ * layer carries the risk, the auto-align rescue must not rewrite frames — a
  * band scale cannot map the numeric-only shared-grid rows. Conservative by
  * design: a false positive only keeps today's identity behavior.
  */
@@ -89,11 +113,13 @@ export function xDiscreteRiskOf(
 }
 
 /**
- * True when ≥2 groups have finite rows and some group's finite x set skips a
- * shared-grid x strictly inside that group's own [min, max] — the shape that
- * chords across the stack.
+ * True when the rescue should fire: ≥2 groups have finite rows, no group
+ * repeats a finite x (identity stacking sums repeats; align's last-wins
+ * collapse would silently shrink the stacked total), and some group's finite
+ * x set skips a shared-grid x strictly inside that group's own [min, max] —
+ * the shape that chords across the stack.
  */
-function hasInteriorHole(x: Float64Array, y: Float64Array, groups: readonly number[]): boolean {
+function needsStackAlign(x: Float64Array, y: Float64Array, groups: readonly number[]): boolean {
   const perGroup = new Map<number, Set<number>>();
   const grid = new Set<number>();
   for (let row = 0; row < x.length; row++) {
@@ -106,6 +132,7 @@ function hasInteriorHole(x: Float64Array, y: Float64Array, groups: readonly numb
       set = new Set();
       perGroup.set(g, set);
     }
+    if (set.has(xv)) return false;
     set.add(xv);
   }
   if (perGroup.size < 2) return false;
@@ -125,36 +152,4 @@ function hasInteriorHole(x: Float64Array, y: Float64Array, groups: readonly numb
     }
   }
   return false;
-}
-
-function buildSharedGridFrame(
-  binding: LayerBinding,
-  table: ColumnTable,
-  groups: readonly number[],
-  warnings: PipelineWarning[],
-  stat: (input: Parameters<typeof statAlign>[0]) => StatAlignResult,
-  label: string,
-): LayerFrame {
-  const { index } = binding;
-  const carried = carriedColumns(binding, table);
-  const columnOf = makeColumnOf(binding);
-  const result = stat({
-    x: positionColumn(table, binding.xField!, binding.xConversion, binding.xTransform),
-    y: positionColumn(table, binding.yField!, binding.yConversion, binding.yTransform),
-    groups,
-    carried,
-  });
-  removedStatWarning(result.dropped, index, `missing or non-finite x/y before ${label}`, warnings);
-  return statLayerFrame({
-    binding,
-    table,
-    n: result.x.length,
-    x: { numeric: result.x },
-    y: { numeric: result.y },
-    groups: result.groups,
-    inputGroups: groups,
-    columns: { x: result.x, y: result.y },
-    columnOf: columnOf(result, null),
-    lineage: "none",
-  });
 }

--- a/packages/core/src/pipeline/frame.ts
+++ b/packages/core/src/pipeline/frame.ts
@@ -9,7 +9,7 @@ import { buildAnnotationFrame } from "./frame-annotation.js";
 import { expandEdgeFrame } from "./frame-edge-expand.js";
 import { deriveLayerGroups } from "./frame-helpers.js";
 import { buildIdentityFrame } from "./frame-identity.js";
-import { maybeStackZeroFillFrame } from "./frame-stats-align.js";
+import { maybeStackAlignFrame } from "./frame-stats-align.js";
 import { buildMapFrame } from "./frame-stats-map.js";
 import { buildNonIdentityFrame } from "./frame-stats.js";
 
@@ -51,9 +51,9 @@ export function buildFrame(
   );
   if (nonIdentity !== null) return { ...nonIdentity, inputGroups };
 
-  // Sparse stacked area rescue (#1268): zero-fill interior group×x holes that
-  // the identity path would chord across as floating polygons.
-  const zeroFilled = maybeStackZeroFillFrame(
+  // Sparse stacked area rescue (#1268): align groups with interior x holes
+  // that the identity path would chord across as floating polygons.
+  const aligned = maybeStackAlignFrame(
     binding,
     table,
     inputGroups,
@@ -61,7 +61,7 @@ export function buildFrame(
     advisories,
     xDiscreteRisk,
   );
-  if (zeroFilled !== null) return { ...zeroFilled, inputGroups };
+  if (aligned !== null) return { ...aligned, inputGroups };
 
   const frame = { ...buildIdentityFrame(binding, table, inputGroups), inputGroups };
   expandEdgeFrame(frame, warnings);

--- a/packages/core/src/pipeline/frame.ts
+++ b/packages/core/src/pipeline/frame.ts
@@ -9,6 +9,7 @@ import { buildAnnotationFrame } from "./frame-annotation.js";
 import { expandEdgeFrame } from "./frame-edge-expand.js";
 import { deriveLayerGroups } from "./frame-helpers.js";
 import { buildIdentityFrame } from "./frame-identity.js";
+import { maybeStackZeroFillFrame } from "./frame-stats-align.js";
 import { buildMapFrame } from "./frame-stats-map.js";
 import { buildNonIdentityFrame } from "./frame-stats.js";
 
@@ -22,6 +23,7 @@ export function buildFrame(
   binRange?: [number, number],
   functionDomain?: [number, number],
   datasets?: import("@ggsvelte/spec").PortableSpec["datasets"],
+  xDiscreteRisk = false,
 ): LayerFrame {
   // Annotation frames are rowless (n=0, empty inputGroups). Do not derive or
   // overwrite pre-stat groups — identity index would otherwise retain O(n)
@@ -48,6 +50,18 @@ export function buildFrame(
     functionDomain,
   );
   if (nonIdentity !== null) return { ...nonIdentity, inputGroups };
+
+  // Sparse stacked area rescue (#1268): zero-fill interior group×x holes that
+  // the identity path would chord across as floating polygons.
+  const zeroFilled = maybeStackZeroFillFrame(
+    binding,
+    table,
+    inputGroups,
+    warnings,
+    advisories,
+    xDiscreteRisk,
+  );
+  if (zeroFilled !== null) return { ...zeroFilled, inputGroups };
 
   const frame = { ...buildIdentityFrame(binding, table, inputGroups), inputGroups };
   expandEdgeFrame(frame, warnings);

--- a/packages/core/src/pipeline/prepare-panels-frames.ts
+++ b/packages/core/src/pipeline/prepare-panels-frames.ts
@@ -10,6 +10,7 @@ import { configureStyleBindings } from "./bind-layer-style-config.js";
 import type { FacetPanelDef } from "./facets.js";
 import { styleBinExtent } from "./frame-group-columns.js";
 import { buildFrame } from "./frame.js";
+import { xDiscreteRiskOf } from "./frame-stats-align.js";
 import { finalizeFrameSourceRows } from "./source-row-lineage.js";
 import { sliceLayerForPanel } from "./layer-panel-data.js";
 import { applyPosition } from "./position.js";
@@ -314,6 +315,7 @@ export function buildPanelFrames(input: {
   );
   const binRanges = computePanelBinRanges(bindings, filteredLayerTables, faceted, freeX);
   const functionDomains = computeFunctionPeerDomains(bindings, filteredLayerTables);
+  const xDiscreteRisk = xDiscreteRiskOf(bindings, filteredLayerTables, normalized.scales?.x?.type);
   for (let p = 0; p < facetPanels.length; p++) {
     for (let index = 0; index < bindings.length; index++) {
       const ctx = layerContexts[index]!;
@@ -334,6 +336,7 @@ export function buildPanelFrames(input: {
         binRanges[index],
         functionDomains[index],
         normalized.datasets,
+        xDiscreteRisk,
       );
       applyPosition(frame, advisories, slice.table);
       // Annotation frames are rowless — do not retain the full panel source-row

--- a/packages/core/src/stats/align.ts
+++ b/packages/core/src/stats/align.ts
@@ -80,22 +80,7 @@ export function seriesFromRows(
   return { xs: Float64Array.from(uniqX), ys: Float64Array.from(uniqY) };
 }
 
-/**
- * Zero-fill variant for the default stacked-area path (#1268): per group,
- * y = observed value at its own grid x (last-wins duplicates), 0 at every
- * other grid x. Unlike statAlign there is NO interior interpolation — a
- * missing cell means zero, so stacked totals at observed x never change.
- * Output size is O(groups × union-x).
- */
-export function statZeroFill(input: StatAlignInput): StatAlignResult {
-  return statOnSharedGrid(input, "zero");
-}
-
 export function statAlign(input: StatAlignInput): StatAlignResult {
-  return statOnSharedGrid(input, "lerp");
-}
-
-function statOnSharedGrid(input: StatAlignInput, fill: "lerp" | "zero"): StatAlignResult {
   const { x, y, groups, carried } = input;
   const byGroup = new Map<number, number[]>();
   let dropped = 0;
@@ -131,18 +116,10 @@ function statOnSharedGrid(input: StatAlignInput, fill: "lerp" | "zero"): StatAli
     const series = seriesFromRows(x, y, rows);
     if (series === null) continue;
     const rep = rows[0]!;
-    // Zero mode: the grid is the union of observed x, so a group's own x
-    // values are exact grid members — a merge pointer finds them.
-    let cursor = 0;
     for (let i = 0; i < grid.length; i++) {
       const xq = grid[i]!;
       outX.push(xq);
-      if (fill === "lerp") {
-        outY.push(lerpSeries(series.xs, series.ys, xq));
-      } else {
-        while (cursor < series.xs.length && series.xs[cursor]! < xq) cursor++;
-        outY.push(cursor < series.xs.length && series.xs[cursor] === xq ? series.ys[cursor]! : 0);
-      }
+      outY.push(lerpSeries(series.xs, series.ys, xq));
       outG.push(g);
       for (const key of Object.keys(carriedOut)) {
         carriedOut[key]!.push(carried[key]![rep]!);

--- a/packages/core/src/stats/align.ts
+++ b/packages/core/src/stats/align.ts
@@ -25,6 +25,10 @@ export interface StatAlignResult {
   readonly groups: number[];
   readonly carried: Record<string, CellValue[]>;
   readonly dropped: number;
+  /** Source row per output row: the observed row when the grid x coincides
+   * with a group's own (last-wins) sample; -1 for interpolated or
+   * zero-extended cells. Lets frames keep inspection lineage for real data. */
+  readonly sourceRows: Int32Array;
 }
 
 /** Linear interpolate y at query x given sorted unique (x,y) series. Outside range → 0. */
@@ -51,33 +55,37 @@ export function lerpSeries(xs: Float64Array, ys: Float64Array, query: number): n
   return yLo + t * (y1 - yLo);
 }
 
-/** Collapse a group's rows to sorted unique x with last-wins y. */
+/** Collapse a group's rows to sorted unique x with last-wins y.
+ * `rows` carries the winning source row per unique x (same last-wins). */
 export function seriesFromRows(
   x: Float64Array,
   y: Float64Array,
   rows: readonly number[],
-): { xs: Float64Array; ys: Float64Array } | null {
-  const pts: { x: number; y: number }[] = [];
+): { xs: Float64Array; ys: Float64Array; rows: number[] } | null {
+  const pts: { x: number; y: number; row: number }[] = [];
   for (const row of rows) {
     const xv = x[row]!;
     const yv = y[row]!;
     if (!Number.isFinite(xv) || !Number.isFinite(yv)) continue;
-    pts.push({ x: xv, y: yv });
+    pts.push({ x: xv, y: yv, row });
   }
   if (pts.length === 0) return null;
   pts.sort((a, b) => a.x - b.x || 0);
   // Last-wins for duplicate x
   const uniqX: number[] = [];
   const uniqY: number[] = [];
+  const uniqRow: number[] = [];
   for (const p of pts) {
     if (uniqX.length > 0 && uniqX.at(-1) === p.x) {
       uniqY[uniqY.length - 1] = p.y;
+      uniqRow[uniqRow.length - 1] = p.row;
     } else {
       uniqX.push(p.x);
       uniqY.push(p.y);
+      uniqRow.push(p.row);
     }
   }
-  return { xs: Float64Array.from(uniqX), ys: Float64Array.from(uniqY) };
+  return { xs: Float64Array.from(uniqX), ys: Float64Array.from(uniqY), rows: uniqRow };
 }
 
 export function statAlign(input: StatAlignInput): StatAlignResult {
@@ -107,6 +115,7 @@ export function statAlign(input: StatAlignInput): StatAlignResult {
   const outX: number[] = [];
   const outY: number[] = [];
   const outG: number[] = [];
+  const outRow: number[] = [];
   const carriedOut: Record<string, CellValue[]> = {};
   for (const key of Object.keys(carried)) carriedOut[key] = [];
 
@@ -116,11 +125,18 @@ export function statAlign(input: StatAlignInput): StatAlignResult {
     const series = seriesFromRows(x, y, rows);
     if (series === null) continue;
     const rep = rows[0]!;
+    // Grid and series are both ascending; a merge pointer finds the group's
+    // own samples so those output rows keep their source-row lineage.
+    let cursor = 0;
     for (let i = 0; i < grid.length; i++) {
       const xq = grid[i]!;
       outX.push(xq);
       outY.push(lerpSeries(series.xs, series.ys, xq));
       outG.push(g);
+      while (cursor < series.xs.length && series.xs[cursor]! < xq) cursor++;
+      outRow.push(
+        cursor < series.xs.length && series.xs[cursor] === xq ? series.rows[cursor]! : -1,
+      );
       for (const key of Object.keys(carriedOut)) {
         carriedOut[key]!.push(carried[key]![rep]!);
       }
@@ -133,5 +149,6 @@ export function statAlign(input: StatAlignInput): StatAlignResult {
     groups: outG,
     carried: carriedOut,
     dropped,
+    sourceRows: Int32Array.from(outRow),
   };
 }

--- a/packages/core/src/stats/align.ts
+++ b/packages/core/src/stats/align.ts
@@ -80,7 +80,22 @@ export function seriesFromRows(
   return { xs: Float64Array.from(uniqX), ys: Float64Array.from(uniqY) };
 }
 
+/**
+ * Zero-fill variant for the default stacked-area path (#1268): per group,
+ * y = observed value at its own grid x (last-wins duplicates), 0 at every
+ * other grid x. Unlike statAlign there is NO interior interpolation — a
+ * missing cell means zero, so stacked totals at observed x never change.
+ * Output size is O(groups × union-x).
+ */
+export function statZeroFill(input: StatAlignInput): StatAlignResult {
+  return statOnSharedGrid(input, "zero");
+}
+
 export function statAlign(input: StatAlignInput): StatAlignResult {
+  return statOnSharedGrid(input, "lerp");
+}
+
+function statOnSharedGrid(input: StatAlignInput, fill: "lerp" | "zero"): StatAlignResult {
   const { x, y, groups, carried } = input;
   const byGroup = new Map<number, number[]>();
   let dropped = 0;
@@ -116,10 +131,18 @@ export function statAlign(input: StatAlignInput): StatAlignResult {
     const series = seriesFromRows(x, y, rows);
     if (series === null) continue;
     const rep = rows[0]!;
+    // Zero mode: the grid is the union of observed x, so a group's own x
+    // values are exact grid members — a merge pointer finds them.
+    let cursor = 0;
     for (let i = 0; i < grid.length; i++) {
       const xq = grid[i]!;
       outX.push(xq);
-      outY.push(lerpSeries(series.xs, series.ys, xq));
+      if (fill === "lerp") {
+        outY.push(lerpSeries(series.xs, series.ys, xq));
+      } else {
+        while (cursor < series.xs.length && series.xs[cursor]! < xq) cursor++;
+        outY.push(cursor < series.xs.length && series.xs[cursor] === xq ? series.ys[cursor]! : 0);
+      }
       outG.push(g);
       for (const key of Object.keys(carriedOut)) {
         carriedOut[key]!.push(carried[key]![rep]!);

--- a/packages/core/tests/pipeline-m2/stack-auto-align.test.ts
+++ b/packages/core/tests/pipeline-m2/stack-auto-align.test.ts
@@ -247,6 +247,37 @@ describe("stacked area auto-align (#1268)", () => {
     expect(model.warnings.some((w) => w.code === "stack-align-skipped")).toBe(true);
   });
 
+  it("emits the stand-down warning once per layer under facets", () => {
+    // Same over-budget shape duplicated into two panels: the warning message
+    // is panel-independent, so dedupe collapses it to one disclosure.
+    const x: number[] = [];
+    const y: number[] = [];
+    const g: string[] = [];
+    const p: string[] = [];
+    for (const panel of ["p1", "p2"]) {
+      for (let i = 0; i < 150; i++) {
+        x.push(i);
+        y.push(1);
+        g.push("dense");
+        p.push(panel);
+      }
+      for (let s = 0; s < 150; s++) {
+        x.push(0, 149);
+        y.push(1, 1);
+        g.push(`s${s}`, `s${s}`);
+        p.push(panel, panel);
+      }
+    }
+    const model = runPipeline(
+      gg({ x, y, g, p }, aes({ x: "x", y: "y", fill: "g" }))
+        .geomArea()
+        .facet({ wrap: "p" })
+        .spec(),
+      size,
+    );
+    expect(model.warnings.filter((w) => w.code === "stack-align-skipped").length).toBe(1);
+  });
+
   it("ignores groups with no finite rows when detecting and aligning", () => {
     const model = areaModel({
       x: [1, 3, 0, 1, 2, 3, 4, 0, 4],

--- a/packages/core/tests/pipeline-m2/stack-auto-align.test.ts
+++ b/packages/core/tests/pipeline-m2/stack-auto-align.test.ts
@@ -1,11 +1,13 @@
 /**
- * Default stacked area with sparse groups — auto zero-fill (#1268).
+ * Default stacked area with sparse groups — auto-align (#1268).
  *
  * A group with an interior x hole used to chord straight across it while the
  * stack below varied, rendering a floating polygon. The default path now
- * zero-fills missing group×x cells onto the shared grid and discloses a
- * `stack-zero-filled` advisory. Exterior-only incompleteness, non-overlapping
- * ranges, single groups, and unstacked positions are untouched.
+ * auto-applies the align stat (#815 semantics: interpolate between observed
+ * samples, zero outside a group's range) and discloses a
+ * `stack-align-applied` advisory. Exterior-only incompleteness,
+ * non-overlapping ranges, single groups, unstacked positions, repeated
+ * (group, x) rows, and discrete-x plots are untouched.
  */
 import { describe, expect, it } from "bun:test";
 import { aes, gg } from "@ggsvelte/spec";
@@ -18,13 +20,6 @@ const sparse = {
   x: [1, 3, 0, 1, 2, 3, 4],
   y: [2, 2, 3, 3, 0.5, 3, 3],
   g: ["b", "b", "a", "a", "a", "a", "a"],
-};
-
-/** Same data with b's missing cells filled with explicit zeros. */
-const completed = {
-  x: [0, 1, 2, 3, 4, 0, 1, 2, 3, 4],
-  y: [0, 2, 0, 2, 0, 3, 3, 0.5, 3, 3],
-  g: ["b", "b", "b", "b", "b", "a", "a", "a", "a", "a"],
 };
 
 function areaModel(data: Record<string, unknown[]>, opts?: Record<string, unknown>) {
@@ -48,17 +43,42 @@ function expectPositionsEqual(actual: PathsBatch, expected: PathsBatch): void {
   }
 }
 
-function zeroFillAdvisories(model: ReturnType<typeof runPipeline>) {
-  return model.advisories.filter((a) => a.code === "stack-zero-filled");
+function autoAlignAdvisories(model: ReturnType<typeof runPipeline>) {
+  return model.advisories.filter((a) => a.code === "stack-align-applied");
 }
 
-describe("stacked area auto zero-fill (#1268)", () => {
-  it("zero-fills an interior hole and matches manually completed data", () => {
+describe("stacked area auto-align (#1268)", () => {
+  it("aligns an interior hole and matches the explicit align stat", () => {
     const auto = areaModel(sparse);
-    const manual = areaModel(completed);
-    expectPositionsEqual(firstBatch(auto), firstBatch(manual));
-    expect(zeroFillAdvisories(auto).length).toBe(1);
-    expect(zeroFillAdvisories(manual).length).toBe(0);
+    const explicit = areaModel(sparse, { stat: "align" });
+    expectPositionsEqual(firstBatch(auto), firstBatch(explicit));
+    expect(autoAlignAdvisories(auto).length).toBe(1);
+    expect(autoAlignAdvisories(explicit).length).toBe(0);
+  });
+
+  it("aligns interleaved sampling instead of combing to zero", () => {
+    // a and b alternate x samples — the completion must interpolate (align),
+    // never insert zeros between a group's own consecutive observations.
+    const interleaved = {
+      x: [0, 2, 4, 1, 3],
+      y: [3, 3, 3, 2, 2],
+      g: ["a", "a", "a", "b", "b"],
+    };
+    const auto = areaModel(interleaved);
+    const explicit = areaModel(interleaved, { stat: "align" });
+    expectPositionsEqual(firstBatch(auto), firstBatch(explicit));
+    expect(autoAlignAdvisories(auto).length).toBe(1);
+  });
+
+  it("stands down when a group repeats an x value", () => {
+    // Identity stacking sums repeated (group, x) rows; align keeps the last.
+    // The rescue must not change stacked totals, so it leaves repeats alone.
+    const model = areaModel({
+      x: [1, 3, 1, 0, 1, 2, 3, 4],
+      y: [2, 2, 1, 3, 3, 0.5, 3, 3],
+      g: ["b", "b", "b", "a", "a", "a", "a", "a"],
+    });
+    expect(autoAlignAdvisories(model).length).toBe(0);
   });
 
   it("keeps full-coverage stacks on the identity path", () => {
@@ -67,7 +87,7 @@ describe("stacked area auto zero-fill (#1268)", () => {
       y: [1, 2, 1, 3, 3, 3],
       g: ["b", "b", "b", "a", "a", "a"],
     });
-    expect(zeroFillAdvisories(model).length).toBe(0);
+    expect(autoAlignAdvisories(model).length).toBe(0);
     expect(firstBatch(model).pathOffsets.length).toBe(3);
   });
 
@@ -77,7 +97,7 @@ describe("stacked area auto zero-fill (#1268)", () => {
       y: [2, 2, 3, 3, 0.5, 3, 3],
       g: ["b", "b", "a", "a", "a", "a", "a"],
     });
-    expect(zeroFillAdvisories(model).length).toBe(0);
+    expect(autoAlignAdvisories(model).length).toBe(0);
   });
 
   it("does not fire on non-overlapping ranges", () => {
@@ -86,7 +106,7 @@ describe("stacked area auto zero-fill (#1268)", () => {
       y: [1, 1, 1, 2, 2, 2],
       g: ["a", "a", "a", "b", "b", "b"],
     });
-    expect(zeroFillAdvisories(model).length).toBe(0);
+    expect(autoAlignAdvisories(model).length).toBe(0);
   });
 
   it("does not fire for a single group", () => {
@@ -95,24 +115,24 @@ describe("stacked area auto zero-fill (#1268)", () => {
       y: [1, 2, 2, 1],
       g: ["a", "a", "a", "a"],
     });
-    expect(zeroFillAdvisories(model).length).toBe(0);
+    expect(autoAlignAdvisories(model).length).toBe(0);
   });
 
   it("does not fire for position identity", () => {
     const model = areaModel(sparse, { position: "identity" });
-    expect(zeroFillAdvisories(model).length).toBe(0);
+    expect(autoAlignAdvisories(model).length).toBe(0);
   });
 
-  it("zero-fills under position fill", () => {
+  it("aligns under position fill", () => {
     const auto = areaModel(sparse, { position: "fill" });
-    const manual = areaModel(completed, { position: "fill" });
-    expectPositionsEqual(firstBatch(auto), firstBatch(manual));
-    expect(zeroFillAdvisories(auto).length).toBe(1);
+    const explicit = areaModel(sparse, { stat: "align", position: "fill" });
+    expectPositionsEqual(firstBatch(auto), firstBatch(explicit));
+    expect(autoAlignAdvisories(auto).length).toBe(1);
   });
 
   it("does not fire when stat align is explicit", () => {
     const model = areaModel(sparse, { stat: "align" });
-    expect(zeroFillAdvisories(model).length).toBe(0);
+    expect(autoAlignAdvisories(model).length).toBe(0);
   });
 
   it("fires for temporal x with an interior hole", () => {
@@ -121,26 +141,7 @@ describe("stacked area auto zero-fill (#1268)", () => {
       y: [2, 2, 3, 0.5, 3],
       g: ["b", "b", "a", "a", "a"],
     });
-    expect(zeroFillAdvisories(model).length).toBe(1);
-  });
-
-  it("emits one advisory on the final model under facets", () => {
-    const model = runPipeline(
-      gg(
-        {
-          x: [1, 3, 0, 1, 2, 3, 4, 0, 1, 2],
-          y: [2, 2, 3, 3, 0.5, 3, 3, 1, 1, 1],
-          g: ["b", "b", "a", "a", "a", "a", "a", "a", "a", "a"],
-          p: ["p1", "p1", "p1", "p1", "p1", "p1", "p1", "p2", "p2", "p2"],
-        },
-        aes({ x: "x", y: "y", fill: "g" }),
-      )
-        .geomArea()
-        .facet({ wrap: "p" })
-        .spec(),
-      size,
-    );
-    expect(zeroFillAdvisories(model).length).toBe(1);
+    expect(autoAlignAdvisories(model).length).toBe(1);
   });
 
   it("does not fire when a bar/col layer discretizes the shared x", () => {
@@ -161,7 +162,7 @@ describe("stacked area auto zero-fill (#1268)", () => {
         .spec(),
       size,
     );
-    expect(zeroFillAdvisories(model).length).toBe(0);
+    expect(autoAlignAdvisories(model).length).toBe(0);
     const areas = model.scene.batches.find((b) => b.kind === "paths");
     expect(areas).toBeDefined();
     expect((areas as PathsBatch).positions.length).toBeGreaterThan(0);
@@ -173,7 +174,7 @@ describe("stacked area auto zero-fill (#1268)", () => {
       y: [2, 2, 3, 3, 0.5, 3, 3],
       g: ["b", "b", "a", "a", "a", "a", "a"],
     });
-    expect(zeroFillAdvisories(model).length).toBe(0);
+    expect(autoAlignAdvisories(model).length).toBe(0);
   });
 
   it("does not fire when scales.x.type is band", () => {
@@ -184,16 +185,35 @@ describe("stacked area auto zero-fill (#1268)", () => {
         .spec(),
       size,
     );
-    expect(zeroFillAdvisories(model).length).toBe(0);
+    expect(autoAlignAdvisories(model).length).toBe(0);
   });
 
-  it("ignores groups with no finite rows when detecting and filling", () => {
+  it("emits one advisory on the final model under facets", () => {
+    const model = runPipeline(
+      gg(
+        {
+          x: [1, 3, 0, 1, 2, 3, 4, 0, 1, 2],
+          y: [2, 2, 3, 3, 0.5, 3, 3, 1, 1, 1],
+          g: ["b", "b", "a", "a", "a", "a", "a", "a", "a", "a"],
+          p: ["p1", "p1", "p1", "p1", "p1", "p1", "p1", "p2", "p2", "p2"],
+        },
+        aes({ x: "x", y: "y", fill: "g" }),
+      )
+        .geomArea()
+        .facet({ wrap: "p" })
+        .spec(),
+      size,
+    );
+    expect(autoAlignAdvisories(model).length).toBe(1);
+  });
+
+  it("ignores groups with no finite rows when detecting and aligning", () => {
     const model = areaModel({
       x: [1, 3, 0, 1, 2, 3, 4, 0, 4],
       y: [2, 2, 3, 3, 0.5, 3, 3, null, null],
       g: ["b", "b", "a", "a", "a", "a", "a", "c", "c"],
     });
-    expect(zeroFillAdvisories(model).length).toBe(1);
+    expect(autoAlignAdvisories(model).length).toBe(1);
     // Only a and b produce ribbons; c has no finite rows.
     expect(firstBatch(model).pathOffsets.length).toBe(3);
   });

--- a/packages/core/tests/pipeline-m2/stack-auto-align.test.ts
+++ b/packages/core/tests/pipeline-m2/stack-auto-align.test.ts
@@ -164,8 +164,8 @@ describe("stacked area auto-align (#1268)", () => {
     );
     expect(autoAlignAdvisories(model).length).toBe(0);
     const areas = model.scene.batches.find((b) => b.kind === "paths");
-    expect(areas).toBeDefined();
-    expect((areas as PathsBatch).positions.length).toBeGreaterThan(0);
+    if (areas === undefined || areas.kind !== "paths") throw new Error("expected a paths batch");
+    expect(areas.positions.length).toBeGreaterThan(0);
   });
 
   it("does not fire for discrete string x", () => {

--- a/packages/core/tests/pipeline-m2/stack-auto-align.test.ts
+++ b/packages/core/tests/pipeline-m2/stack-auto-align.test.ts
@@ -179,7 +179,7 @@ describe("stacked area auto-align (#1268)", () => {
 
   it("does not fire when scales.x.type is band", () => {
     const model = runPipeline(
-      gg(sparse as never, aes({ x: "x", y: "y", fill: "g" }))
+      gg(sparse, aes({ x: "x", y: "y", fill: "g" }))
         .geomArea()
         .scales({ x: { type: "band" } })
         .spec(),

--- a/packages/core/tests/pipeline-m2/stack-auto-align.test.ts
+++ b/packages/core/tests/pipeline-m2/stack-auto-align.test.ts
@@ -47,6 +47,15 @@ function autoAlignAdvisories(model: ReturnType<typeof runPipeline>) {
   return model.advisories.filter((a) => a.code === "stack-align-applied");
 }
 
+/** True when some candidate carries a non-empty source lineage (ref 0 = empty). */
+function anySourceLineage(model: ReturnType<typeof runPipeline>): boolean {
+  for (let id = 0; id < model.candidates.size; id++) {
+    const candidate = model.candidates.candidate(id);
+    if (candidate !== null && candidate.lineage !== 0) return true;
+  }
+  return false;
+}
+
 describe("stacked area auto-align (#1268)", () => {
   it("aligns an interior hole and matches the explicit align stat", () => {
     const auto = areaModel(sparse);
@@ -205,6 +214,37 @@ describe("stacked area auto-align (#1268)", () => {
       size,
     );
     expect(autoAlignAdvisories(model).length).toBe(1);
+  });
+
+  it("keeps source lineage for observed samples on the rescued layer", () => {
+    // Tooltips already work on stat frames (fields come from frame columns),
+    // but source-row linkage — oninspect callbacks, legend key membership —
+    // needs lineage. Grid points that coincide with a group's own samples
+    // keep their source row; only synthesized cells stay lineage-free.
+    const model = areaModel(sparse);
+    expect(anySourceLineage(model)).toBe(true);
+  });
+
+  it("stands down with a warning when the expansion exceeds the budget", () => {
+    // One dense group over 150 x values plus 150 two-point groups spanning
+    // the range: 151 groups × 150 grid x ≈ 22.6k expanded rows from 450
+    // input rows — past both the absolute and relative budgets.
+    const x: number[] = [];
+    const y: number[] = [];
+    const g: string[] = [];
+    for (let i = 0; i < 150; i++) {
+      x.push(i);
+      y.push(1);
+      g.push("dense");
+    }
+    for (let s = 0; s < 150; s++) {
+      x.push(0, 149);
+      y.push(1, 1);
+      g.push(`s${s}`, `s${s}`);
+    }
+    const model = areaModel({ x, y, g });
+    expect(autoAlignAdvisories(model).length).toBe(0);
+    expect(model.warnings.some((w) => w.code === "stack-align-skipped")).toBe(true);
   });
 
   it("ignores groups with no finite rows when detecting and aligning", () => {

--- a/packages/core/tests/pipeline-m2/stack-zero-fill.test.ts
+++ b/packages/core/tests/pipeline-m2/stack-zero-fill.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Default stacked area with sparse groups — auto zero-fill (#1268).
+ *
+ * A group with an interior x hole used to chord straight across it while the
+ * stack below varied, rendering a floating polygon. The default path now
+ * zero-fills missing group×x cells onto the shared grid and discloses a
+ * `stack-zero-filled` advisory. Exterior-only incompleteness, non-overlapping
+ * ranges, single groups, and unstacked positions are untouched.
+ */
+import { describe, expect, it } from "bun:test";
+import { aes, gg } from "@ggsvelte/spec";
+import { runPipeline } from "../../src/pipeline.ts";
+import type { PathsBatch } from "../../src/scene.ts";
+import { size } from "./fixtures.ts";
+
+/** a covers x=0..4 with a dip at x=2; b (first-seen, on top) only at x=1,3. */
+const sparse = {
+  x: [1, 3, 0, 1, 2, 3, 4],
+  y: [2, 2, 3, 3, 0.5, 3, 3],
+  g: ["b", "b", "a", "a", "a", "a", "a"],
+};
+
+/** Same data with b's missing cells filled with explicit zeros. */
+const completed = {
+  x: [0, 1, 2, 3, 4, 0, 1, 2, 3, 4],
+  y: [0, 2, 0, 2, 0, 3, 3, 0.5, 3, 3],
+  g: ["b", "b", "b", "b", "b", "a", "a", "a", "a", "a"],
+};
+
+function areaModel(data: Record<string, unknown[]>, opts?: Record<string, unknown>) {
+  return runPipeline(
+    gg(data as never, aes({ x: "x", y: "y", fill: "g" }))
+      .geomArea({ ...opts })
+      .spec(),
+    size,
+  );
+}
+
+function firstBatch(model: ReturnType<typeof runPipeline>): PathsBatch {
+  return model.scene.batches[0] as PathsBatch;
+}
+
+function expectPositionsEqual(actual: PathsBatch, expected: PathsBatch): void {
+  expect(Array.from(actual.pathOffsets)).toEqual(Array.from(expected.pathOffsets));
+  expect(actual.positions.length).toBe(expected.positions.length);
+  for (let i = 0; i < expected.positions.length; i++) {
+    expect(actual.positions[i]!).toBeCloseTo(expected.positions[i]!, 4);
+  }
+}
+
+function zeroFillAdvisories(model: ReturnType<typeof runPipeline>) {
+  return model.advisories.filter((a) => a.code === "stack-zero-filled");
+}
+
+describe("stacked area auto zero-fill (#1268)", () => {
+  it("zero-fills an interior hole and matches manually completed data", () => {
+    const auto = areaModel(sparse);
+    const manual = areaModel(completed);
+    expectPositionsEqual(firstBatch(auto), firstBatch(manual));
+    expect(zeroFillAdvisories(auto).length).toBe(1);
+    expect(zeroFillAdvisories(manual).length).toBe(0);
+  });
+
+  it("keeps full-coverage stacks on the identity path", () => {
+    const model = areaModel({
+      x: [0, 1, 2, 0, 1, 2],
+      y: [1, 2, 1, 3, 3, 3],
+      g: ["b", "b", "b", "a", "a", "a"],
+    });
+    expect(zeroFillAdvisories(model).length).toBe(0);
+    expect(firstBatch(model).pathOffsets.length).toBe(3);
+  });
+
+  it("does not fire on exterior-only incompleteness", () => {
+    const model = areaModel({
+      x: [0, 1, 0, 1, 2, 3, 4],
+      y: [2, 2, 3, 3, 0.5, 3, 3],
+      g: ["b", "b", "a", "a", "a", "a", "a"],
+    });
+    expect(zeroFillAdvisories(model).length).toBe(0);
+  });
+
+  it("does not fire on non-overlapping ranges", () => {
+    const model = areaModel({
+      x: [0, 1, 2, 3, 4, 5],
+      y: [1, 1, 1, 2, 2, 2],
+      g: ["a", "a", "a", "b", "b", "b"],
+    });
+    expect(zeroFillAdvisories(model).length).toBe(0);
+  });
+
+  it("does not fire for a single group", () => {
+    const model = areaModel({
+      x: [0, 1, 3, 4],
+      y: [1, 2, 2, 1],
+      g: ["a", "a", "a", "a"],
+    });
+    expect(zeroFillAdvisories(model).length).toBe(0);
+  });
+
+  it("does not fire for position identity", () => {
+    const model = areaModel(sparse, { position: "identity" });
+    expect(zeroFillAdvisories(model).length).toBe(0);
+  });
+
+  it("zero-fills under position fill", () => {
+    const auto = areaModel(sparse, { position: "fill" });
+    const manual = areaModel(completed, { position: "fill" });
+    expectPositionsEqual(firstBatch(auto), firstBatch(manual));
+    expect(zeroFillAdvisories(auto).length).toBe(1);
+  });
+
+  it("does not fire when stat align is explicit", () => {
+    const model = areaModel(sparse, { stat: "align" });
+    expect(zeroFillAdvisories(model).length).toBe(0);
+  });
+
+  it("fires for temporal x with an interior hole", () => {
+    const model = areaModel({
+      x: ["2024-01-01", "2024-01-03", "2024-01-01", "2024-01-02", "2024-01-03"],
+      y: [2, 2, 3, 0.5, 3],
+      g: ["b", "b", "a", "a", "a"],
+    });
+    expect(zeroFillAdvisories(model).length).toBe(1);
+  });
+
+  it("emits one advisory on the final model under facets", () => {
+    const model = runPipeline(
+      gg(
+        {
+          x: [1, 3, 0, 1, 2, 3, 4, 0, 1, 2],
+          y: [2, 2, 3, 3, 0.5, 3, 3, 1, 1, 1],
+          g: ["b", "b", "a", "a", "a", "a", "a", "a", "a", "a"],
+          p: ["p1", "p1", "p1", "p1", "p1", "p1", "p1", "p2", "p2", "p2"],
+        },
+        aes({ x: "x", y: "y", fill: "g" }),
+      )
+        .geomArea()
+        .facet({ wrap: "p" })
+        .spec(),
+      size,
+    );
+    expect(zeroFillAdvisories(model).length).toBe(1);
+  });
+
+  it("does not fire when a bar/col layer discretizes the shared x", () => {
+    // A col layer trains numeric x as bands; the numeric-only shared-grid
+    // frame cannot map onto them, so the rescue must stand down and the area
+    // must keep rendering (regression: rows dropped as unmappable).
+    const model = runPipeline(
+      gg(
+        {
+          x: [1, 3, 1, 2, 3],
+          y: [2, 2, 3, 0.5, 3],
+          g: ["b", "b", "a", "a", "a"],
+        },
+        aes({ x: "x", y: "y", fill: "g" }),
+      )
+        .geomArea({ alpha: 0.5 })
+        .geomCol({ alpha: 0.3 })
+        .spec(),
+      size,
+    );
+    expect(zeroFillAdvisories(model).length).toBe(0);
+    const areas = model.scene.batches.find((b) => b.kind === "paths");
+    expect(areas).toBeDefined();
+    expect((areas as PathsBatch).positions.length).toBeGreaterThan(0);
+  });
+
+  it("does not fire for discrete string x", () => {
+    const model = areaModel({
+      x: ["m1", "m3", "m0", "m1", "m2", "m3", "m4"],
+      y: [2, 2, 3, 3, 0.5, 3, 3],
+      g: ["b", "b", "a", "a", "a", "a", "a"],
+    });
+    expect(zeroFillAdvisories(model).length).toBe(0);
+  });
+
+  it("does not fire when scales.x.type is band", () => {
+    const model = runPipeline(
+      gg(sparse as never, aes({ x: "x", y: "y", fill: "g" }))
+        .geomArea()
+        .scales({ x: { type: "band" } })
+        .spec(),
+      size,
+    );
+    expect(zeroFillAdvisories(model).length).toBe(0);
+  });
+
+  it("ignores groups with no finite rows when detecting and filling", () => {
+    const model = areaModel({
+      x: [1, 3, 0, 1, 2, 3, 4, 0, 4],
+      y: [2, 2, 3, 3, 0.5, 3, 3, null, null],
+      g: ["b", "b", "a", "a", "a", "a", "a", "c", "c"],
+    });
+    expect(zeroFillAdvisories(model).length).toBe(1);
+    // Only a and b produce ribbons; c has no finite rows.
+    expect(firstBatch(model).pathOffsets.length).toBe(3);
+  });
+});

--- a/packages/spec/schema/v0.json
+++ b/packages/spec/schema/v0.json
@@ -4241,7 +4241,7 @@
             {
               "type": "string",
               "const": "identity",
-              "description": "Draw each data row as-is (default)."
+              "description": "Draw each data row as-is (default). Under position stack/fill, a group whose continuous x samples skip an interior grid point is auto zero-filled onto the shared x grid (missing cell = 0) with a stack-zero-filled advisory, so sparse groups cannot render as floating bands."
             },
             {
               "type": "string",
@@ -4254,7 +4254,7 @@
               "description": "Interpolate each group onto the union of finite x values so continuous-x stack/fill aligns. Outside a group's x range y is 0."
             }
           ],
-          "description": "Area stat: \"identity\" (default), \"unique\" (first-wins dedupe), or \"align\" (shared x grid for stacking)."
+          "description": "Area stat: \"identity\" (default; auto zero-fills sparse stacked groups), \"unique\" (first-wins dedupe), or \"align\" (shared x grid with interpolation)."
         },
         "position": {
           "$ref": "#/$defs/StackablePosition"
@@ -4279,7 +4279,7 @@
         }
       },
       "additionalProperties": false,
-      "description": "An area layer. Requires x and y channels; rows are sorted by x within each group. Default position \"stack\". Use stat \"align\" when groups have different continuous x samples."
+      "description": "An area layer. Requires x and y channels; rows are sorted by x within each group. Default position \"stack\". Sparse stacked groups auto zero-fill missing group×x cells; set stat \"align\" to interpolate between a group's observed samples instead."
     },
     "RibbonLayer": {
       "type": "object",

--- a/packages/spec/schema/v0.json
+++ b/packages/spec/schema/v0.json
@@ -4241,7 +4241,7 @@
             {
               "type": "string",
               "const": "identity",
-              "description": "Draw each data row as-is (default). Under position stack/fill, a group whose continuous x samples skip an interior grid point is auto zero-filled onto the shared x grid (missing cell = 0) with a stack-zero-filled advisory, so sparse groups cannot render as floating bands."
+              "description": "Draw each data row as-is (default). Under position stack/fill, a group whose continuous x samples skip an interior grid point auto-aligns onto the shared x grid (align semantics: interpolate between observed samples, zero outside the group's range) with a stack-align-applied advisory, so sparse groups cannot render as floating bands."
             },
             {
               "type": "string",
@@ -4254,7 +4254,7 @@
               "description": "Interpolate each group onto the union of finite x values so continuous-x stack/fill aligns. Outside a group's x range y is 0."
             }
           ],
-          "description": "Area stat: \"identity\" (default; auto zero-fills sparse stacked groups), \"unique\" (first-wins dedupe), or \"align\" (shared x grid with interpolation)."
+          "description": "Area stat: \"identity\" (default; sparse stacked groups auto-align), \"unique\" (first-wins dedupe), or \"align\" (shared x grid with interpolation)."
         },
         "position": {
           "$ref": "#/$defs/StackablePosition"
@@ -4279,7 +4279,7 @@
         }
       },
       "additionalProperties": false,
-      "description": "An area layer. Requires x and y channels; rows are sorted by x within each group. Default position \"stack\". Sparse stacked groups auto zero-fill missing group×x cells; set stat \"align\" to interpolate between a group's observed samples instead."
+      "description": "An area layer. Requires x and y channels; rows are sorted by x within each group. Default position \"stack\". Stacked groups whose continuous x samples leave interior holes auto-align onto the shared x grid; pre-fill the data to control every cell."
     },
     "RibbonLayer": {
       "type": "object",

--- a/packages/spec/src/schema-declarations.ts
+++ b/packages/spec/src/schema-declarations.ts
@@ -4111,7 +4111,7 @@ export const SpecDeclarations = {
           [
             Type.Literal("identity", {
               description:
-                "Draw each data row as-is (default). Under position stack/fill, a group whose continuous x samples skip an interior grid point is auto zero-filled onto the shared x grid (missing cell = 0) with a stack-zero-filled advisory, so sparse groups cannot render as floating bands.",
+                "Draw each data row as-is (default). Under position stack/fill, a group whose continuous x samples skip an interior grid point auto-aligns onto the shared x grid (align semantics: interpolate between observed samples, zero outside the group's range) with a stack-align-applied advisory, so sparse groups cannot render as floating bands.",
             }),
             Type.Literal("unique", {
               description: "Drop duplicate rows on mapped aesthetics before drawing (first wins).",
@@ -4123,7 +4123,7 @@ export const SpecDeclarations = {
           ],
           {
             description:
-              'Area stat: "identity" (default; auto zero-fills sparse stacked groups), "unique" (first-wins dedupe), or "align" (shared x grid with interpolation).',
+              'Area stat: "identity" (default; sparse stacked groups auto-align), "unique" (first-wins dedupe), or "align" (shared x grid with interpolation).',
           },
         ),
       ),
@@ -4147,7 +4147,7 @@ export const SpecDeclarations = {
     {
       additionalProperties: false,
       description:
-        'An area layer. Requires x and y channels; rows are sorted by x within each group. Default position "stack". Sparse stacked groups auto zero-fill missing group×x cells; set stat "align" to interpolate between a group\'s observed samples instead.',
+        'An area layer. Requires x and y channels; rows are sorted by x within each group. Default position "stack". Stacked groups whose continuous x samples leave interior holes auto-align onto the shared x grid; pre-fill the data to control every cell.',
     },
   ),
 

--- a/packages/spec/src/schema-declarations.ts
+++ b/packages/spec/src/schema-declarations.ts
@@ -4110,7 +4110,8 @@ export const SpecDeclarations = {
         Type.Union(
           [
             Type.Literal("identity", {
-              description: "Draw each data row as-is (default).",
+              description:
+                "Draw each data row as-is (default). Under position stack/fill, a group whose continuous x samples skip an interior grid point is auto zero-filled onto the shared x grid (missing cell = 0) with a stack-zero-filled advisory, so sparse groups cannot render as floating bands.",
             }),
             Type.Literal("unique", {
               description: "Drop duplicate rows on mapped aesthetics before drawing (first wins).",
@@ -4122,7 +4123,7 @@ export const SpecDeclarations = {
           ],
           {
             description:
-              'Area stat: "identity" (default), "unique" (first-wins dedupe), or "align" (shared x grid for stacking).',
+              'Area stat: "identity" (default; auto zero-fills sparse stacked groups), "unique" (first-wins dedupe), or "align" (shared x grid with interpolation).',
           },
         ),
       ),
@@ -4146,7 +4147,7 @@ export const SpecDeclarations = {
     {
       additionalProperties: false,
       description:
-        'An area layer. Requires x and y channels; rows are sorted by x within each group. Default position "stack". Use stat "align" when groups have different continuous x samples.',
+        'An area layer. Requires x and y channels; rows are sorted by x within each group. Default position "stack". Sparse stacked groups auto zero-fill missing group×x cells; set stat "align" to interpolate between a group\'s observed samples instead.',
     },
   ),
 

--- a/scripts/llms-guide-content.ts
+++ b/scripts/llms-guide-content.ts
@@ -583,6 +583,14 @@ gg(data, aes({ x: "t", y: "v", fill: "series" }))
 Available on **area** and **line** only (not point or shared identity-only
 geoms). Outside a group's x span y is 0 (stack-friendly).
 
+Stacked **area** rescues sparse groups on its own: when a group's continuous x
+samples skip an interior grid point (a shape that would render as a floating
+band chorded over the stack below), the default identity stat zero-fills the
+missing group×x cells (missing cell = 0, no interpolation) and emits a
+\`stack-zero-filled\` advisory. Set \`stat: "align"\` when you want
+interpolation between a group's observed samples instead, or pre-fill the
+data to control every cell.
+
 ## Connect (named path joins)
 
 \`stat: "connect"\` (ggplot2 \`stat_connect\`) expands successive finite points

--- a/scripts/llms-guide-content.ts
+++ b/scripts/llms-guide-content.ts
@@ -585,11 +585,11 @@ geoms). Outside a group's x span y is 0 (stack-friendly).
 
 Stacked **area** rescues sparse groups on its own: when a group's continuous x
 samples skip an interior grid point (a shape that would render as a floating
-band chorded over the stack below), the default identity stat zero-fills the
-missing group×x cells (missing cell = 0, no interpolation) and emits a
-\`stack-zero-filled\` advisory. Set \`stat: "align"\` when you want
-interpolation between a group's observed samples instead, or pre-fill the
-data to control every cell.
+band chorded over the stack below), the default identity stat auto-applies
+this align transform and emits a \`stack-align-applied\` advisory. The rescue
+stands down when the x scale may train discrete, or when a group repeats an x
+value (identity stacking sums repeats; align keeps the last). Pre-fill the
+data to control every cell exactly.
 
 ## Connect (named path joins)
 


### PR DESCRIPTION
Fixes #1268 — stacked area layers whose groups sample different x values rendered disembodied/floating polygons.

## The bug (validated)

`positionStack` stacks per x-slot over only the rows present at that slot, and `areaBatch` draws each group's ribbon through only that group's own x samples. A group with an interior x hole therefore chords straight across it while the stack below varies. Repro: group `a` on x=0..4 dipping at x=2, group `b` (stacked on top) only at x=1 and 3 — `b`'s bottom edge stays flat at the stacked height while `a`'s top edge dips, leaving ~87px of daylight under the band in a 400×300 render. No warning or advisory fired.

## The fix

When the default identity path detects an interior hole (≥2 groups with finite rows, continuous x, some group's finite-x set skipping a shared-grid x strictly inside that group's own range), it auto-applies the align stat — the documented remedy for stacking groups with different continuous x samples (#815, ggplot2 `stat_align` semantics: interpolate between a group's observed samples, zero outside its range). A `stack-align-applied` advisory disclosing the heuristic is emitted once per layer, with data pre-fill and `position: "identity"` named as overrides.

The rescue stands down whenever:
- the shared x scale may train discrete — explicit `band`/`binned` type, a bar/col layer discretizing numeric x, or a nominal x field (`xDiscreteRiskOf`, mirroring `collectMappedXEvidence`) — because a band scale cannot map the numeric-only shared-grid rows;
- any group repeats a finite x value — identity stacking sums repeats, align keeps the last, and the rescue must never change stacked totals.

Untouched by design: exterior-only incompleteness, non-overlapping ranges, single groups, `position: "identity"`, explicit stats, and every full-coverage plot. The kitchen-sink SVG golden is byte-identical to main.

Review history: the first cut zero-filled missing cells; review correctly flagged that zero-fill combs interleaved sampling (two series alternating x collapse to the baseline between their own observations) and that the shared-grid path dropped duplicate-x rows from totals. Switched to align + duplicate stand-down; both cases now have regression tests.

## Tests

`packages/core/tests/pipeline-m2/stack-auto-align.test.ts` (16 tests, written first and failing before the fix): interior-hole geometry equals the explicit `stat: "align"` run; interleaved sampling aligns instead of combing; duplicate (group, x) rows stand down; advisory emitted once (also under facets); gate tests for full coverage, exterior-only, non-overlapping, single group, unstacked position, temporal x, discrete string x, explicit band type, col+area discretization, and all-non-finite groups.

- `bun run test`: 3947 pass, 0 fail
- `bun run check`: clean
- Visual before/after of the repro confirms the band now rides the stack continuously through the dip.

## Follow-ups

- #1271 — discrete/band-x stacked area renders degenerate per-category subpaths (and gets no auto-align rescue), found during validation.
- #1272 — explicit `stat: "unique"` sparse stacks still chord; the rescue gates on the identity stat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)