### PR TITLE
fix(svelte): no point-circle hover chrome on filled area stacks

### DIFF
--- a/.changeset/area-hover-chrome.md
+++ b/.changeset/area-hover-chrome.md
@@ -1,0 +1,13 @@
+---
+"@ggsvelte/svelte": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+fix(svelte): no point-circle hover chrome on filled area stacks
+
+Hovering or pinning a stacked area band drew the translucent hover ring — a
+point-mark affordance — at the anchor. Closed path fills (area, density,
+polygon) now use the same mute/continuous-crosshair chrome as rects, matching
+the selection/legend emphasis rules. Open path strokes (lines) keep the ring,
+which gaps the crosshair at the focused vertex.

--- a/packages/svelte/src/lib/plot-engine.svelte.ts
+++ b/packages/svelte/src/lib/plot-engine.svelte.ts
@@ -923,11 +923,15 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
       return semanticCandidateProjection.emphasizedAnchors;
     },
     get hoverChrome() {
-      // Hover chrome is separate from selection/emphasis anchor rings: paths
-      // still gap the crosshair; only rects mute. Null inspection → default ring.
+      // Hover chrome is separate from selection/emphasis anchor rings: open
+      // path strokes still gap the crosshair; rects and closed path fills
+      // (areas) mute (#1270). Null inspection → default ring.
       const focus = inspectionState.presentationFocus;
       if (focus === null) return "ring";
-      return hoverChromeForKind(focus.kind);
+      const seed = inspectionState.inspectionSeed;
+      const batch = seed === null ? undefined : runtime.model?.scene.batches[seed.batchIndex];
+      const closedPath = batch?.kind === "paths" && batch.closed === true;
+      return hoverChromeForKind(focus.kind, closedPath);
     },
     get hoverBoxWidth() {
       return hoverGlyphExtents()?.width;

--- a/packages/svelte/src/lib/selection/selection.ts
+++ b/packages/svelte/src/lib/selection/selection.ts
@@ -51,12 +51,15 @@ export function presentationChromeForKind(kind?: string | null): PresentationChr
 
 /**
  * Hover overlay chrome (hover ring/box + gapped crosshair).
- * Keep rings for strokes and points so path/line inspect still gaps guides at
- * the focus. Glyphs use a box. Rect marks stay mute-only.
+ * Keep rings for points and OPEN path strokes (line inspect anchors at a
+ * vertex, and the ring gaps the guides there). Closed path fills (area,
+ * density, polygon) are region marks like rects — mute-only, continuous
+ * crosshair, no point-circle (#1270). Glyphs use a box.
  * Missing kind keeps ring so crosshair gap works before the seed attaches.
  */
-export function hoverChromeForKind(kind?: string | null): PresentationChrome {
+export function hoverChromeForKind(kind?: string | null, closedPath = false): PresentationChrome {
   if (kind === "rects") return "none";
+  if (kind === "paths" && closedPath) return "none";
   if (kind === "glyphs") return "box";
   return "ring";
 }

--- a/packages/svelte/tests/interaction/interaction-hover-tooltip.test.ts
+++ b/packages/svelte/tests/interaction/interaction-hover-tooltip.test.ts
@@ -165,6 +165,75 @@ describe("hover + tooltip (overlays, never a pipeline re-run)", () => {
     }
   });
 
+  it("stacked area hover shows no point ring — closed fills are region marks (#1270)", async () => {
+    let model: RenderModel | null = null;
+    const areaRows = [
+      { x: 0, y: 3, g: "a" },
+      { x: 1, y: 3, g: "a" },
+      { x: 2, y: 3, g: "a" },
+      { x: 0, y: 2, g: "b" },
+      { x: 1, y: 2, g: "b" },
+      { x: 2, y: 2, g: "b" },
+    ];
+    const { container } = render(GGPlot, {
+      data: areaRows,
+      aes: { x: "x", y: "y", fill: "g" },
+      layers: [{ geom: "area" }],
+      inspect: true,
+      onrender: (m: RenderModel) => {
+        model = m;
+      },
+      ...size,
+    });
+    const m = requireModel(model);
+    let seed = null;
+    for (let id = 0; id < m.candidates.size; id++) {
+      const candidate = m.candidates.candidate(id);
+      if (candidate?.kind === "paths") {
+        seed = candidate;
+        break;
+      }
+    }
+    if (seed === null) throw new Error("expected a paths candidate");
+    const capture = container.querySelector(".gg-capture")!;
+    pointerMoveAt(capture, seed.x, seed.y);
+    await until(() => container.querySelector(".gg-tooltip") !== null);
+    expect(container.querySelector(".gg-hover-ring")).toBeNull();
+  });
+
+  it("line hover keeps the point ring — open strokes anchor at a vertex (#1270)", async () => {
+    let model: RenderModel | null = null;
+    const lineRows = [
+      { x: 0, y: 1 },
+      { x: 1, y: 3 },
+      { x: 2, y: 2 },
+    ];
+    const { container } = render(GGPlot, {
+      data: lineRows,
+      aes: { x: "x", y: "y" },
+      layers: [{ geom: "line" }],
+      inspect: true,
+      onrender: (m: RenderModel) => {
+        model = m;
+      },
+      ...size,
+    });
+    const m = requireModel(model);
+    let seed = null;
+    for (let id = 0; id < m.candidates.size; id++) {
+      const candidate = m.candidates.candidate(id);
+      if (candidate?.kind === "paths") {
+        seed = candidate;
+        break;
+      }
+    }
+    if (seed === null) throw new Error("expected a paths candidate");
+    const capture = container.querySelector(".gg-capture")!;
+    pointerMoveAt(capture, seed.x, seed.y);
+    await until(() => container.querySelector(".gg-tooltip") !== null);
+    expect(container.querySelector(".gg-hover-ring")).not.toBeNull();
+  });
+
   it("keyboard navigation on the single chart surface shows the tooltip", async () => {
     const { container } = render(GGPlot, {
       data: rows,

--- a/packages/svelte/tests/interaction/interaction-hover-tooltip.test.ts
+++ b/packages/svelte/tests/interaction/interaction-hover-tooltip.test.ts
@@ -199,6 +199,10 @@ describe("hover + tooltip (overlays, never a pipeline re-run)", () => {
     pointerMoveAt(capture, seed.x, seed.y);
     await until(() => container.querySelector(".gg-tooltip") !== null);
     expect(container.querySelector(".gg-hover-ring")).toBeNull();
+    // Pinning the same band must not resurrect the point ring either.
+    capture.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await until(() => container.querySelector(".gg-tooltip-pinned") !== null);
+    expect(container.querySelector(".gg-hover-ring")).toBeNull();
   });
 
   it("line hover keeps the point ring — open strokes anchor at a vertex (#1270)", async () => {

--- a/packages/svelte/tests/selection/selection.test.ts
+++ b/packages/svelte/tests/selection/selection.test.ts
@@ -121,6 +121,14 @@ describe("hoverChromeForKind", () => {
     expect(hoverChromeForKind(null)).toBe("ring");
     expect(hoverChromeForKind("rects")).toBe("none");
   });
+
+  it("mutes closed path fills; open paths keep the ring (#1270)", () => {
+    expect(hoverChromeForKind("paths", true)).toBe("none");
+    expect(hoverChromeForKind("paths", false)).toBe("ring");
+    // closedPath only applies to paths — other kinds are unchanged.
+    expect(hoverChromeForKind("points", true)).toBe("ring");
+    expect(hoverChromeForKind("rects", true)).toBe("none");
+  });
 });
 
 describe("anchorsFromCandidateKeys", () => {


### PR DESCRIPTION
Fixes #1270 — hovering or pinning a stacked area band drew a translucent point-ring at the anchor, point-mark language on a region mark.

## The bug (validated)

`hoverChromeForKind` returned `"ring"` for every batch kind except rects ("none") and glyphs ("box"), so filled-area `paths` batches rendered the `.gg-hover-ring` circle on hover and pin. The selection/legend emphasis rules already avoid this (`presentationChromeForKind` rings only points; paths/rects/segments are mute-only) — hover chrome was the outlier.

The ring is right for OPEN path strokes: line inspection anchors at a vertex and the ring gaps the crosshair guides there. The bug is scoped to CLOSED fills (area, density, polygon — `PathsBatch.closed === true`), where the pointer sits inside a region.

## The fix

`hoverChromeForKind(kind, closedPath)` returns `"none"` for closed paths; the plot engine resolves the focused batch from the inspection seed (same lookup as glyph extents) and passes `closed`. Stacked areas now get the same mute/continuous-crosshair chrome as bars; lines keep the ring. Pin and keyboard share the same presentation-focus path, so all three modes agree.

On the issue's second acceptance item (pin/tooltip agree on the focused series): the tooltip focus is the band under the pointer — force-included and rendered bold — so with the misleading circle gone, the remaining chrome (crosshair, bold tooltip focus, muting) is consistent.

## Tests

Written first and verified failing against the unfixed code:
- Unit: `hoverChromeForKind("paths", true)` → `"none"`, `("paths", false)` → `"ring"`, other kinds unchanged.
- Component: stacked-area hover shows tooltip with no `.gg-hover-ring`, and pinning keeps it absent; line hover still renders the ring.

Full `packages/svelte` suite (browser chromium/firefox/webkit + SSR): green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1276" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->