### PR TITLE
feat(core): warn when every connected-mark group has one observation

### DIFF
--- a/.changeset/singleton-group-warning.md
+++ b/.changeset/singleton-group-warning.md
@@ -1,0 +1,15 @@
+---
+"@ggsvelte/core": minor
+---
+
+<!-- markdownlint-disable MD041 -->
+
+feat(core): warn when every connected-mark group has one observation
+
+Band/discrete x joins the default grouping interaction (ggplot2 parity), so
+an area or line with a discrete series aesthetic can derive one group per
+(category, series) cell and silently degenerate every ribbon or stroke. Line
+and area batches now emit `group-single-observation` — ggplot2's geom_path
+warning, extended to area — naming the aes.group remedy.
+
+Migration: none — additive (new warning name; no existing surface changed).

--- a/apps/docs/src/lib/generated/routes.ts
+++ b/apps/docs/src/lib/generated/routes.ts
@@ -11552,6 +11552,11 @@ export const DOCS_ROUTES = [
         level: 3,
       },
       {
+        id: "group-single-observation",
+        title: "group-single-observation",
+        level: 3,
+      },
+      {
         id: "stack-align-skipped",
         title: "stack-align-skipped",
         level: 3,

--- a/apps/docs/src/lib/generated/search-index.ts
+++ b/apps/docs/src/lib/generated/search-index.ts
@@ -41396,7 +41396,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "diagnostic",
     title: "group-single-observation · warning",
     summary:
-      "Connected path/area marks derived one observation per group (a discrete x joins default grouping), so each stroke or ribbon degenerates; map aes.group to join categories into series.",
+      "Connected path/area marks derived one observation per group (often a discrete x joining default grouping), so each stroke or ribbon degenerates; map aes.group to join rows into series.",
     href: "/guide/errors#group-single-observation",
     keywords: [
       "warning",

--- a/apps/docs/src/lib/generated/search-index.ts
+++ b/apps/docs/src/lib/generated/search-index.ts
@@ -18985,6 +18985,16 @@ export const DOCS_SEARCH_INDEX = [
     exact: ["map-region-missing"],
   },
   {
+    id: "heading:guide-errors:group-single-observation",
+    kind: "heading",
+    title: "group-single-observation",
+    summary:
+      "group-single-observation in Errors reference. Understand validation, render, interaction, and CLI diagnostics and recover safely.",
+    href: "/guide/errors#group-single-observation",
+    keywords: ["Errors reference", "Reference"],
+    exact: ["group-single-observation"],
+  },
+  {
     id: "heading:guide-errors:stack-align-skipped",
     kind: "heading",
     title: "stack-align-skipped",
@@ -41380,6 +41390,20 @@ export const DOCS_SEARCH_INDEX = [
       "Inspect the warning message for its path and count, then correct the named data, scale, or option.",
     ],
     exact: ["map-region-missing", "warning:map-region-missing"],
+  },
+  {
+    id: "diagnostic:warning:group-single-observation",
+    kind: "diagnostic",
+    title: "group-single-observation · warning",
+    summary:
+      "Connected path/area marks derived one observation per group (a discrete x joins default grouping), so each stroke or ribbon degenerates; map aes.group to join categories into series.",
+    href: "/guide/errors#group-single-observation",
+    keywords: [
+      "warning",
+      "warning",
+      "Inspect the warning message for its path and count, then correct the named data, scale, or option.",
+    ],
+    exact: ["group-single-observation", "warning:group-single-observation"],
   },
   {
     id: "diagnostic:warning:stack-align-skipped",

--- a/packages/core/src/diagnostics-emission-registry.ts
+++ b/packages/core/src/diagnostics-emission-registry.ts
@@ -69,6 +69,7 @@ export const WARNING_EMISSION_REGISTRY = {
   "density-2d-filled-open-dropped": { channel: "warning" },
   "sf-coordinates-dropped": { channel: "warning" },
   "map-region-missing": { channel: "warning" },
+  "group-single-observation": { channel: "warning" },
   "stack-align-skipped": { channel: "warning" },
   "smooth-group-dropped": { channel: "warning" },
   "quantile-empty": { channel: "warning" },

--- a/packages/core/src/diagnostics-warning-catalog.ts
+++ b/packages/core/src/diagnostics-warning-catalog.ts
@@ -116,6 +116,10 @@ export const PIPELINE_WARNING_CATALOG = {
   "map-region-missing": {
     summary: "One or more value rows had no matching map region and were dropped.",
   },
+  "group-single-observation": {
+    summary:
+      "Connected path/area marks derived one observation per group (often a discrete x joining default grouping), so each stroke or ribbon degenerates; map aes.group to join rows into series.",
+  },
   "stack-align-skipped": {
     summary:
       "Sparse stacked-area groups were left unaligned because the shared-grid expansion exceeds the auto-rescue budget; bands with interior gaps may render as floating polygons.",

--- a/packages/core/src/pipeline/geometry-paths-area.ts
+++ b/packages/core/src/pipeline/geometry-paths-area.ts
@@ -7,7 +7,7 @@ import type { PathsBatch } from "../scene.js";
 import type { LayerFrame, PipelineWarning, ResolvedColorScale } from "./types.js";
 import type { Frame } from "./geometry-shared.js";
 import { constantStyle, numericStyleVector, type ResolvedStyleScales } from "./geometry-style.js";
-import { bucketByGroup, sortGroupRowsByX } from "./geometry-shared.js";
+import { bucketByGroup, sortGroupRowsByX, warnSingleObservationGroups } from "./geometry-shared.js";
 import { writeClosedPathGroups } from "./geometry-paths-closed-batch.js";
 import { areaGroupFillOf } from "./geometry-paths-area-fill.js";
 
@@ -22,6 +22,7 @@ export function areaBatch(
   if (frame.ymin === null || frame.ymax === null) return null;
   const groupRows = bucketByGroup(frame, fx, frame.ymax, warnings);
   if (groupRows.length === 0) return null;
+  warnSingleObservationGroups(groupRows, frame, warnings);
   sortGroupRowsByX(groupRows, frame, fx);
 
   const paint = layerPaintFromParams(binding.layer.params);

--- a/packages/core/src/pipeline/geometry-paths-line.ts
+++ b/packages/core/src/pipeline/geometry-paths-line.ts
@@ -13,7 +13,12 @@ import {
   numericStyleVector,
   type ResolvedStyleScales,
 } from "./geometry-style.js";
-import { DEFAULT_LINEWIDTH, bucketByGroup, sortGroupRowsByX } from "./geometry-shared.js";
+import {
+  DEFAULT_LINEWIDTH,
+  bucketByGroup,
+  sortGroupRowsByX,
+  warnSingleObservationGroups,
+} from "./geometry-shared.js";
 import { writeLineSubpaths } from "./geometry-paths-line-write.js";
 import { splitStyleSubpaths } from "./geometry-paths-style-subpaths.js";
 
@@ -28,6 +33,7 @@ export function lineBatch(
   const { binding } = frame;
   const groupedRows = bucketByGroup(frame, fx, null, warnings);
   if (groupedRows.length === 0) return null;
+  warnSingleObservationGroups(groupedRows, frame, warnings);
   // geom_line sorts by x; geom_path keeps data/row order (#788).
   if (options.sortByX !== false && binding.layer.geom !== "path") {
     sortGroupRowsByX(groupedRows, frame, fx);

--- a/packages/core/src/pipeline/geometry-shared-bucket.ts
+++ b/packages/core/src/pipeline/geometry-shared-bucket.ts
@@ -33,6 +33,29 @@ export function bucketByGroup(
 }
 
 /**
+ * ggplot2's geom_path parity warning, extended to area (#1271): when ≥2
+ * drawable groups exist and EVERY group holds exactly one observation, each
+ * connected stroke or ribbon degenerates to a point-width mark — usually a
+ * discrete x joining the default grouping interaction (decision 0005).
+ * Message is layer-stable (no per-panel counts) so facets dedupe to one.
+ */
+export function warnSingleObservationGroups(
+  groupRows: readonly number[][],
+  frame: LayerFrame,
+  warnings: PipelineWarning[],
+): void {
+  // ≥2 groups: a legitimately single-point layer (one 1-row group) stays
+  // silent — unlike ggplot2, which also warns there; that case is usually
+  // intentional data, not a grouping accident.
+  if (groupRows.length < 2) return;
+  if (!groupRows.every((rows) => rows.length === 1)) return;
+  warnings.push({
+    code: "group-single-observation",
+    message: `Layer ${frame.binding.index}: each group consists of only one observation, so every connected mark degenerates — often a discrete x or an all-distinct series aesthetic joining the default grouping. Map aes.group (the series field, or a constant for one series) to join rows into ribbons/strokes.`,
+  });
+}
+
+/**
  * Sort each group's row indices by ascending x (path/line/area/smooth).
  *
  * Callers pass groups already filtered by {@link bucketByGroup} (finite x/y).

--- a/packages/core/src/pipeline/geometry-shared.ts
+++ b/packages/core/src/pipeline/geometry-shared.ts
@@ -14,4 +14,8 @@ export {
   removedWarning,
   type Frame,
 } from "./geometry-shared-position.js";
-export { bucketByGroup, sortGroupRowsByX } from "./geometry-shared-bucket.js";
+export {
+  bucketByGroup,
+  sortGroupRowsByX,
+  warnSingleObservationGroups,
+} from "./geometry-shared-bucket.js";

--- a/packages/core/tests/pipeline-geometry/single-observation-groups.test.ts
+++ b/packages/core/tests/pipeline-geometry/single-observation-groups.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Connected marks with all-singleton groups — parity warning (#1271).
+ *
+ * A discrete x joins default grouping (decision 0005, ggplot2 parity), so
+ * band-x area/line with a discrete fill/color derives one group per
+ * (category, series) cell and each ribbon/stroke degenerates to a single
+ * observation — silently. ggplot2's geom_path warns here; ggsvelte now warns
+ * for line AND area (`group-single-observation`), naming the aes.group
+ * remedy. Mixed group sizes, single groups, and explicit aes.group stay
+ * silent.
+ */
+import { describe, expect, it } from "bun:test";
+import { aes, gg } from "@ggsvelte/spec";
+import { runPipeline } from "../../src/pipeline.ts";
+
+const size = { width: 640, height: 400 };
+
+function singletonWarnings(model: ReturnType<typeof runPipeline>) {
+  return model.warnings.filter((w) => w.code === "group-single-observation");
+}
+
+describe("group-single-observation warning (#1271)", () => {
+  const bandData = {
+    x: ["m1", "m3", "m0", "m1", "m2", "m3", "m4"],
+    y: [2, 2, 3, 3, 0.5, 3, 3],
+    g: ["b", "b", "a", "a", "a", "a", "a"],
+  };
+
+  it("warns for band-x stacked area with a discrete fill", () => {
+    const model = runPipeline(
+      gg(bandData, aes({ x: "x", y: "y", fill: "g" }))
+        .geomArea()
+        .spec(),
+      size,
+    );
+    expect(singletonWarnings(model).length).toBe(1);
+  });
+
+  it("warns for a line whose derived groups are all singletons", () => {
+    const model = runPipeline(
+      gg(
+        {
+          x: ["a", "b", "c"],
+          y: [1, 2, 3],
+          c: ["r", "s", "t"],
+        },
+        aes({ x: "x", y: "y", color: "c" }),
+      )
+        .geomLine()
+        .spec(),
+      size,
+    );
+    expect(singletonWarnings(model).length).toBe(1);
+  });
+
+  it("stays silent when aes.group joins the categories into series", () => {
+    const model = runPipeline(
+      gg(bandData, aes({ x: "x", y: "y", fill: "g", group: "g" }))
+        .geomArea()
+        .spec(),
+      size,
+    );
+    expect(singletonWarnings(model).length).toBe(0);
+  });
+
+  it("stays silent for continuous-x multi-row groups", () => {
+    const model = runPipeline(
+      gg(
+        {
+          x: [0, 1, 2, 0, 1, 2],
+          y: [1, 2, 1, 3, 3, 3],
+          g: ["b", "b", "b", "a", "a", "a"],
+        },
+        aes({ x: "x", y: "y", fill: "g" }),
+      )
+        .geomArea()
+        .spec(),
+      size,
+    );
+    expect(singletonWarnings(model).length).toBe(0);
+  });
+
+  it("stays silent when group sizes are mixed", () => {
+    // ggplot2 warns only when EVERY group is a single observation.
+    const model = runPipeline(
+      gg(
+        {
+          x: [0, 1, 2, 5],
+          y: [1, 2, 1, 4],
+          g: ["a", "a", "a", "b"],
+        },
+        aes({ x: "x", y: "y", color: "g" }),
+      )
+        .geomLine()
+        .spec(),
+      size,
+    );
+    expect(singletonWarnings(model).length).toBe(0);
+  });
+
+  it("stays silent for a single group with many rows", () => {
+    const model = runPipeline(
+      gg({ x: [0, 1, 2], y: [1, 2, 1] }, aes({ x: "x", y: "y" }))
+        .geomLine()
+        .spec(),
+      size,
+    );
+    expect(singletonWarnings(model).length).toBe(0);
+  });
+
+  it("warns once on the final model under facets", () => {
+    const model = runPipeline(
+      gg(
+        {
+          x: ["m0", "m1", "m0", "m1"],
+          y: [1, 2, 3, 4],
+          g: ["a", "b", "a", "b"],
+          p: ["p1", "p1", "p2", "p2"],
+        },
+        aes({ x: "x", y: "y", fill: "g" }),
+      )
+        .geomArea()
+        .facet({ wrap: "p" })
+        .spec(),
+      size,
+    );
+    expect(singletonWarnings(model).length).toBe(1);
+  });
+});

--- a/scripts/llms-guide-content.ts
+++ b/scripts/llms-guide-content.ts
@@ -583,6 +583,12 @@ gg(data, aes({ x: "t", y: "v", fill: "series" }))
 Available on **area** and **line** only (not point or shared identity-only
 geoms). Outside a group's x span y is 0 (stack-friendly).
 
+Discrete x joins the default grouping interaction (ggplot2 parity), so a
+band-x area/line with a discrete series field derives one group per
+(category, series) cell — every ribbon degenerates and a
+\`group-single-observation\` warning fires. Map \`aes.group\` to the
+series field to join categories into ribbons.
+
 Stacked **area** rescues sparse groups on its own: when a group's continuous x
 samples skip an interior grid point (a shape that would render as a floating
 band chorded over the stack below), the default identity stat auto-applies


### PR DESCRIPTION
Addresses #1271 — band-x stacked areas silently render degenerate per-category slivers.

## Root cause (validated) — and why the geometry stays

Discrete x joins the default grouping interaction (decision 0005, R-fixture-pinned ggplot2 parity): `aes(x: category, y, fill: g)` derives one group per (category, series) cell, so each area ribbon collapses to a 2-vertex vertical segment. ggplot2 behaves identically — `geom_area(aes(factor(x), y, fill = g))` degenerates the same way, and the canonical remedy is an explicit `aes.group`. Changing the grouping would break the executable parity spec, so the geometry is intentionally unchanged.

What ggplot2 has that ggsvelte lacked is the disclosure: geom_path warns "Each group consists of only one observation." ggsvelte emitted nothing.

## The change

Line and area batches now emit a `group-single-observation` warning after group bucketing when ≥2 drawable groups exist and every group holds exactly one observation — ggplot2's geom_path warning, extended to area (where the silent failure was reported). The message names the `aes.group` remedy and stays panel-independent so facets dedupe to one disclosure per layer. Single-group single-point layers stay silent (usually intentional data, documented in the helper). The docs guide notes that discrete x joins default grouping.

## Tests

`packages/core/tests/pipeline-geometry/single-observation-groups.test.ts` (7 tests, red first): band-x area warns; all-singleton line warns; explicit `aes.group` renders contiguous ribbons with no warning; continuous-x groups, mixed group sizes, and single many-row groups stay silent; facets emit exactly one warning.

- `bun run test`: 4060 pass, 0 fail
- `bun run check`: clean

## Follow-up noted in review

Ribbon can hit the same interaction; not wired here — will file if it shows up in practice (the reported surface is area/line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1277" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->