### PR TITLE
feat: lean render path (57% smaller identity-chart bundle)

### DIFF
--- a/.changeset/lean-render-path.md
+++ b/.changeset/lean-render-path.md
@@ -1,0 +1,18 @@
+---
+"@ggsvelte/core": minor
+"@ggsvelte/spec": minor
+"@ggsvelte/svelte": minor
+---
+
+# Lean render path
+
+Migration: none — additive
+
+Add lean chart import paths that drop TypeBox validation and the Temporal polyfill from identity-chart client bundles.
+
+- `@ggsvelte/core/render` — pipeline + SVG with basic geoms only (no heavy stats).
+- `@ggsvelte/core/temporal` — optional install for time scales / Temporal polyfill.
+- `@ggsvelte/spec/portable` — fluent builder that finishes with normalize only.
+- `GGBuilder.toPortable()` on the full package; `.spec()` still TypeBox-validates.
+
+Measured lean scatter path: ~327 KB → ~140 KB gzip (−57%). Full package default entry stays complete.

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@ tests/evals/out/
 .ci-content-hash/
 .packages-dist-cache/
 .packages-dist-upload/
+
+# competitive bench outputs (machine-local)
+benchmarks/competitive/results/
+benchmarks/competitive/node_modules/

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -14,7 +14,8 @@
     "**/node_modules/**",
     "**/.svelte-kit/**",
     "tests/visual/test-results/**",
-    "tests/visual/playwright-report/**"
+    "tests/visual/playwright-report/**",
+    "benchmarks/competitive/**"
   ],
   // Named pedantic opt-outs (M0c, see decision 0007). `lint:type-aware`
   // runs --deny-warnings, so every pedantic warning is effectively a hard

--- a/benchmarks/competitive/README.md
+++ b/benchmarks/competitive/README.md
@@ -1,0 +1,25 @@
+# Competitive browser + bundle bench
+
+Measures ggsvelte against SveltePlot, LayerCake, and raw D3 for a colored
+scatter chart.
+
+## Bundle (Vite minify + gzip -9)
+
+```sh
+bun run measure-bundles.ts
+```
+
+Uses the lean progressive import path after FU1–FU3:
+
+- `@ggsvelte/core/render`
+- `@ggsvelte/spec/portable`
+
+## Browser paint / update (Playwright Chromium)
+
+```sh
+bun run measure-browser.ts
+```
+
+Serves `fixtures/` via Vite, mounts each library's scatter at 1k / 10k points,
+records first-mount median ms and data-update median ms (15 samples after 3
+warmups).

--- a/benchmarks/competitive/entries/d3-raw.ts
+++ b/benchmarks/competitive/entries/d3-raw.ts
@@ -1,0 +1,6 @@
+import { scaleLinear, scaleOrdinal } from "d3-scale";
+import { axisBottom, axisLeft } from "d3-axis";
+import { select } from "d3-selection";
+import { extent } from "d3-array";
+
+export { scaleLinear, scaleOrdinal, axisBottom, axisLeft, select, extent };

--- a/benchmarks/competitive/entries/ggsvelte-full.ts
+++ b/benchmarks/competitive/entries/ggsvelte-full.ts
@@ -1,0 +1,11 @@
+import { renderToSVGString, runPipeline } from "@ggsvelte/core";
+import { aes, gg } from "@ggsvelte/spec";
+
+export function scatterSvg(data: { x: number[]; y: number[]; cls: string[] }): string {
+  const spec = gg(data, aes({ x: "x", y: "y", color: "cls" }))
+    .geomPoint({ size: 1.5, alpha: 0.7 })
+    .spec();
+  return renderToSVGString(spec, { width: 800, height: 500 });
+}
+
+export { runPipeline };

--- a/benchmarks/competitive/entries/ggsvelte-lean.ts
+++ b/benchmarks/competitive/entries/ggsvelte-lean.ts
@@ -1,0 +1,16 @@
+import { renderToSVGString, runPipeline } from "@ggsvelte/core/render";
+import { aes, gg } from "@ggsvelte/spec/portable";
+
+export function scatterSvg(data: { x: number[]; y: number[]; cls: string[] }): string {
+  const spec = gg(data, aes({ x: "x", y: "y", color: "cls" }))
+    .geomPoint({ size: 1.5, alpha: 0.7 })
+    .toPortable();
+  return renderToSVGString(spec, { width: 800, height: 500 });
+}
+
+export function scatterPipeline(data: { x: number[]; y: number[]; cls: string[] }): unknown {
+  const spec = gg(data, aes({ x: "x", y: "y", color: "cls" }))
+    .geomPoint({ size: 1.5, alpha: 0.7 })
+    .toPortable();
+  return runPipeline(spec, { width: 800, height: 500 });
+}

--- a/benchmarks/competitive/entries/layercake.ts
+++ b/benchmarks/competitive/entries/layercake.ts
@@ -1,0 +1,5 @@
+import { LayerCake, Svg, Html, Canvas, scaleCanvas } from "layercake";
+import { scaleLinear, scaleOrdinal } from "d3-scale";
+import { extent } from "d3-array";
+
+export { LayerCake, Svg, Html, Canvas, scaleCanvas, scaleLinear, scaleOrdinal, extent };

--- a/benchmarks/competitive/entries/svelteplot.ts
+++ b/benchmarks/competitive/entries/svelteplot.ts
@@ -1,0 +1,3 @@
+import { Plot, Dot, AxisX, AxisY, Frame, GridX, GridY } from "svelteplot";
+
+export { Plot, Dot, AxisX, AxisY, Frame, GridX, GridY };

--- a/benchmarks/competitive/fixtures/index.html
+++ b/benchmarks/competitive/fixtures/index.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>competitive scatter bench</title>
+    <style>
+      body {
+        margin: 0;
+        font: 14px/1.4 system-ui, sans-serif;
+      }
+      #mount {
+        width: 800px;
+        height: 500px;
+      }
+      #status {
+        padding: 8px;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="status">ready</div>
+    <div id="mount"></div>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/benchmarks/competitive/fixtures/main.ts
+++ b/benchmarks/competitive/fixtures/main.ts
@@ -1,0 +1,123 @@
+/**
+ * Browser harness API for Playwright:
+ *   window.competitiveBench.mount(lib, n) -> { ms, markCount }
+ *   window.competitiveBench.update(lib, n) -> { ms }
+ *   window.competitiveBench.clear()
+ */
+import { select } from "d3-selection";
+import { scaleLinear, scaleOrdinal } from "d3-scale";
+import { extent } from "d3-array";
+import { axisBottom, axisLeft } from "d3-axis";
+
+import { renderToSVGString } from "@ggsvelte/core/render";
+import { aes, gg } from "@ggsvelte/spec/portable";
+
+type Row = { x: number; y: number; cls: string };
+
+function makeRows(n: number): Row[] {
+  const rows: Row[] = [];
+  let a = (0xbadc0de ^ n) >>> 0;
+  const rnd = (): number => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+  for (let i = 0; i < n; i++) {
+    rows.push({ x: rnd() * 100, y: rnd() * 100, cls: `series-${i % 5}` });
+  }
+  return rows;
+}
+
+function columnsFrom(rows: Row[]) {
+  return {
+    x: rows.map((r) => r.x),
+    y: rows.map((r) => r.y),
+    cls: rows.map((r) => r.cls),
+  };
+}
+
+const COLORS = ["#4e79a7", "#f28e2b", "#e15759", "#76b7b2", "#59a14f"];
+
+function mountD3(rows: Row[], root: HTMLElement): void {
+  const width = 800;
+  const height = 500;
+  const margin = { top: 20, right: 20, bottom: 40, left: 50 };
+  const iw = width - margin.left - margin.right;
+  const ih = height - margin.top - margin.bottom;
+  root.replaceChildren();
+  const svg = select(root).append("svg").attr("width", width).attr("height", height);
+  const g = svg.append("g").attr("transform", `translate(${margin.left},${margin.top})`);
+  const x = scaleLinear()
+    .domain(extent(rows, (d) => d.x) as [number, number])
+    .nice()
+    .range([0, iw]);
+  const y = scaleLinear()
+    .domain(extent(rows, (d) => d.y) as [number, number])
+    .nice()
+    .range([ih, 0]);
+  const color = scaleOrdinal<string, string>()
+    .domain(["series-0", "series-1", "series-2", "series-3", "series-4"])
+    .range(COLORS);
+  g.append("g").attr("transform", `translate(0,${ih})`).call(axisBottom(x));
+  g.append("g").call(axisLeft(y));
+  g.selectAll("circle")
+    .data(rows)
+    .join("circle")
+    .attr("cx", (d) => x(d.x))
+    .attr("cy", (d) => y(d.y))
+    .attr("r", 1.5)
+    .attr("fill", (d) => color(d.cls))
+    .attr("fill-opacity", 0.7);
+}
+
+function mountGgsvelte(rows: Row[], root: HTMLElement): void {
+  const cols = columnsFrom(rows);
+  const spec = gg(cols, aes({ x: "x", y: "y", color: "cls" }))
+    .geomPoint({ size: 1.5, alpha: 0.7 })
+    .toPortable();
+  const svg = renderToSVGString(spec, { width: 800, height: 500 });
+  root.innerHTML = svg;
+}
+
+function mountLib(lib: string, n: number): { ms: number; markCount: number } {
+  const mountEl = document.querySelector("#mount")!;
+  const status = document.querySelector("#status")!;
+  const rows = makeRows(n);
+  const t0 = performance.now();
+  if (lib === "ggsvelte") {
+    mountGgsvelte(rows, mountEl as HTMLElement);
+  } else if (lib === "d3") {
+    mountD3(rows, mountEl as HTMLElement);
+  } else if (lib === "svelteplot" || lib === "layercake") {
+    throw new Error(`${lib} browser paint uses component mount; run dedicated fixture`);
+  } else {
+    throw new Error(`unknown lib ${lib}`);
+  }
+  const ms = performance.now() - t0;
+  const markCount = mountEl.querySelectorAll("circle, path, rect").length;
+  status.textContent = `${lib} n=${n} mount=${ms.toFixed(2)}ms marks=${markCount}`;
+  return { ms, markCount };
+}
+
+function updateLib(lib: string, n: number): { ms: number } {
+  const result = mountLib(lib, n + 1);
+  return { ms: result.ms };
+}
+
+function clearMount(): void {
+  document.querySelector("#mount")!.replaceChildren();
+}
+
+declare global {
+  interface Window {
+    competitiveBench: {
+      mount: typeof mountLib;
+      update: typeof updateLib;
+      clear: typeof clearMount;
+    };
+  }
+}
+
+window.competitiveBench = { mount: mountLib, update: updateLib, clear: clearMount };

--- a/benchmarks/competitive/measure-browser.ts
+++ b/benchmarks/competitive/measure-browser.ts
@@ -1,0 +1,130 @@
+/**
+ * Browser paint/update competitive bench (Playwright Chromium).
+ *
+ * Measures first-mount and data-update for ggsvelte (lean SVG path) vs raw D3
+ * at 1k and 10k points. SveltePlot/LayerCake need full component fixtures;
+ * this harness focuses on the headless-equivalent SVG cost that FU1–FU3 target.
+ */
+import { createServer } from "vite";
+import { chromium, type Page } from "playwright";
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+const root = import.meta.dirname;
+const resultsDir = path.join(root, "results");
+mkdirSync(resultsDir, { recursive: true });
+
+type BenchApi = {
+  mount: (
+    lib: string,
+    n: number,
+  ) => Promise<{ ms: number; markCount: number }> | { ms: number; markCount: number };
+  update: (lib: string, n: number) => Promise<{ ms: number }> | { ms: number };
+};
+
+async function medianMs(
+  page: Page,
+  fn: () => Promise<number>,
+  { warmup = 3, samples = 15 } = {},
+): Promise<{ median: number; mean: number; p95: number }> {
+  for (let i = 0; i < warmup; i++) await fn();
+  const times: number[] = [];
+  for (let i = 0; i < samples; i++) times.push(await fn());
+  times.sort((a, b) => a - b);
+  const median = times[Math.floor(times.length / 2)]!;
+  const mean = times.reduce((a, b) => a + b, 0) / times.length;
+  const p95 = times[Math.floor(times.length * 0.95)]!;
+  return {
+    median: +median.toFixed(3),
+    mean: +mean.toFixed(3),
+    p95: +p95.toFixed(3),
+  };
+}
+
+const server = await createServer({
+  configFile: false,
+  root: path.join(root, "fixtures"),
+  server: { port: 5199, strictPort: true },
+  resolve: {
+    conditions: ["svelte", "browser", "import", "module", "default"],
+  },
+  optimizeDeps: {
+    include: [
+      "@ggsvelte/core/render",
+      "@ggsvelte/spec/portable",
+      "d3-scale",
+      "d3-selection",
+      "d3-array",
+      "d3-axis",
+    ],
+  },
+});
+await server.listen();
+
+const browser = await chromium.launch();
+const page = await browser.newPage();
+await page.goto("http://127.0.0.1:5199/");
+await page.waitForFunction(() => {
+  const w = window as unknown as { competitiveBench?: BenchApi };
+  return w.competitiveBench !== undefined;
+});
+
+const libs = ["ggsvelte", "d3"] as const;
+const sizes = [1_000, 10_000] as const;
+const results: Record<string, unknown>[] = [];
+
+for (const libName of libs) {
+  for (const size of sizes) {
+    const label = `${libName} ${size >= 1000 ? `${size / 1000}k` : size}`;
+    process.stderr.write(`bench mount ${label}...\n`);
+    const mountStats = await medianMs(page, async () => {
+      const r = await page.evaluate(
+        ({ library, points }) => {
+          const w = window as unknown as { competitiveBench: BenchApi };
+          return w.competitiveBench.mount(library, points);
+        },
+        { library: libName, points: size },
+      );
+      return (await r).ms;
+    });
+    process.stderr.write(`bench update ${label}...\n`);
+    const updateStats = await medianMs(page, async () => {
+      const r = await page.evaluate(
+        ({ library, points }) => {
+          const w = window as unknown as { competitiveBench: BenchApi };
+          return w.competitiveBench.update(library, points);
+        },
+        { library: libName, points: size },
+      );
+      return (await r).ms;
+    });
+    results.push({
+      lib: libName,
+      n: size,
+      mountMedianMs: mountStats.median,
+      mountMeanMs: mountStats.mean,
+      mountP95Ms: mountStats.p95,
+      updateMedianMs: updateStats.median,
+      updateMeanMs: updateStats.mean,
+      updateP95Ms: updateStats.p95,
+    });
+  }
+}
+
+console.log("\n=== Browser mount / update (Chromium, median of 15) ===\n");
+console.log("case".padEnd(22), "mount".padStart(10), "update".padStart(10));
+console.log("-".repeat(44));
+for (const r of results) {
+  const label = `${r["lib"]} ${Number(r["n"]) >= 1000 ? `${Number(r["n"]) / 1000}k` : r["n"]}`;
+  console.log(
+    label.padEnd(22),
+    `${r["mountMedianMs"]}ms`.padStart(10),
+    `${r["updateMedianMs"]}ms`.padStart(10),
+  );
+}
+
+writeFileSync(path.join(resultsDir, "browser.json"), JSON.stringify(results, null, 2));
+console.log("\nWrote results/browser.json");
+
+await browser.close();
+await server.close();

--- a/benchmarks/competitive/measure-bundles.ts
+++ b/benchmarks/competitive/measure-bundles.ts
@@ -1,0 +1,119 @@
+/**
+ * Client bundle sizes for a colored scatter across libraries.
+ * Vite library mode, esbuild minify, gzip -9.
+ */
+import { build } from "vite";
+import { svelte } from "@sveltejs/vite-plugin-svelte";
+import { gzipSync } from "node:zlib";
+import { mkdirSync, readFileSync, rmSync, writeFileSync, existsSync } from "node:fs";
+import path from "node:path";
+
+const root = import.meta.dirname;
+const outRoot = path.join(root, "results", "bundles");
+if (existsSync(outRoot)) rmSync(outRoot, { recursive: true });
+mkdirSync(outRoot, { recursive: true });
+
+const suites = [
+  {
+    id: "ggsvelte-lean-scatter",
+    entry: path.join(root, "entries/ggsvelte-lean.ts"),
+    svelte: false,
+    note: "@ggsvelte/core/render + @ggsvelte/spec/portable",
+  },
+  {
+    id: "ggsvelte-full-scatter",
+    entry: path.join(root, "entries/ggsvelte-full.ts"),
+    svelte: false,
+    note: "@ggsvelte/core + @ggsvelte/spec builder.spec()",
+  },
+  {
+    id: "svelteplot-scatter",
+    entry: path.join(root, "entries/svelteplot.ts"),
+    svelte: true,
+    note: "Plot + Dot + axes",
+  },
+  {
+    id: "layercake-scatter",
+    entry: path.join(root, "entries/layercake.ts"),
+    svelte: true,
+    note: "LayerCake shell + d3-scale",
+  },
+  {
+    id: "d3-raw-scatter",
+    entry: path.join(root, "entries/d3-raw.ts"),
+    svelte: false,
+    note: "d3-scale + d3-axis + d3-selection + d3-array",
+  },
+] as const;
+
+function kb(n: number): number {
+  return Math.round((n / 1024) * 10) / 10;
+}
+
+const results: Record<string, unknown>[] = [];
+
+for (const suite of suites) {
+  const outDir = path.join(outRoot, suite.id);
+  process.stderr.write(`building ${suite.id}...\n`);
+  try {
+    await build({
+      configFile: false,
+      logLevel: "error",
+      plugins: suite.svelte
+        ? [svelte({ compilerOptions: { css: "injected" }, emitCss: false })]
+        : [],
+      build: {
+        lib: {
+          entry: suite.entry,
+          formats: ["es"],
+          fileName: () => "bundle.js",
+        },
+        outDir,
+        emptyOutDir: true,
+        minify: "esbuild",
+        target: "es2022",
+        rollupOptions: { external: [] },
+        write: true,
+      },
+      resolve: {
+        conditions: ["svelte", "browser", "import", "module", "default"],
+      },
+    });
+    const raw = readFileSync(path.join(outDir, "bundle.js"));
+    const gz = gzipSync(raw, { level: 9 });
+    results.push({
+      id: suite.id,
+      ok: true,
+      note: suite.note,
+      rawBytes: raw.byteLength,
+      gzipBytes: gz.byteLength,
+      rawKB: kb(raw.byteLength),
+      gzipKB: kb(gz.byteLength),
+    });
+  } catch (err) {
+    results.push({
+      id: suite.id,
+      ok: false,
+      note: suite.note,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+console.log("\n=== Competitive scatter bundles (Vite minify, gzip -9) ===\n");
+console.log("id".padEnd(28), "raw KB".padStart(10), "gzip KB".padStart(10));
+console.log("-".repeat(50));
+for (const r of results) {
+  if (!r["ok"]) {
+    console.log(String(r["id"]).padEnd(28), "FAIL");
+    continue;
+  }
+  console.log(
+    String(r["id"]).padEnd(28),
+    String(r["rawKB"]).padStart(10),
+    String(r["gzipKB"]).padStart(10),
+  );
+}
+
+writeFileSync(path.join(root, "results", "bundles.json"), JSON.stringify(results, null, 2));
+console.log("\nWrote results/bundles.json");

--- a/benchmarks/competitive/package.json
+++ b/benchmarks/competitive/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@ggsvelte-bench/competitive",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "measure:bundles": "bun run measure-bundles.ts",
+    "measure:browser": "bun run measure-browser.ts",
+    "measure": "bun run measure:bundles && bun run measure:browser"
+  },
+  "dependencies": {
+    "@ggsvelte/core": "workspace:*",
+    "@ggsvelte/spec": "workspace:*",
+    "d3-array": "^3.2.4",
+    "d3-axis": "^3.0.0",
+    "d3-scale": "^4.0.2",
+    "d3-selection": "^3.0.0",
+    "layercake": "^10.0.3",
+    "svelte": "^5.56.7",
+    "svelteplot": "^0.14.2"
+  },
+  "devDependencies": {
+    "@playwright/test": "1.61.1",
+    "@sveltejs/vite-plugin-svelte": "^7.2.0",
+    "playwright": "1.61.1",
+    "vite": "^8.0.0"
+  }
+}

--- a/benchmarks/competitive/package.json
+++ b/benchmarks/competitive/package.json
@@ -19,7 +19,6 @@
     "svelteplot": "^0.14.2"
   },
   "devDependencies": {
-    "@playwright/test": "1.61.1",
     "@sveltejs/vite-plugin-svelte": "^7.2.0",
     "playwright": "1.61.1",
     "vite": "^8.0.0"

--- a/bun.lock
+++ b/bun.lock
@@ -65,6 +65,26 @@
         "mitata": "^1.0.34",
       },
     },
+    "benchmarks/competitive": {
+      "name": "@ggsvelte-bench/competitive",
+      "dependencies": {
+        "@ggsvelte/core": "workspace:*",
+        "@ggsvelte/spec": "workspace:*",
+        "d3-array": "^3.2.4",
+        "d3-axis": "^3.0.0",
+        "d3-scale": "^4.0.2",
+        "d3-selection": "^3.0.0",
+        "layercake": "^10.0.3",
+        "svelte": "^5.56.7",
+        "svelteplot": "^0.14.2",
+      },
+      "devDependencies": {
+        "@playwright/test": "1.61.1",
+        "@sveltejs/vite-plugin-svelte": "^7.2.0",
+        "playwright": "1.61.1",
+        "vite": "^8.0.0",
+      },
+    },
     "examples": {
       "name": "@ggsvelte/examples",
       "version": "0.0.0",
@@ -79,9 +99,9 @@
     },
     "packages/core": {
       "name": "@ggsvelte/core",
-      "version": "0.16.0",
+      "version": "0.21.0",
       "dependencies": {
-        "@ggsvelte/spec": "^0.16.0",
+        "@ggsvelte/spec": "^0.21.0",
       },
       "devDependencies": {
         "typescript": "^6.0.3",
@@ -89,7 +109,7 @@
     },
     "packages/spec": {
       "name": "@ggsvelte/spec",
-      "version": "0.16.0",
+      "version": "0.21.0",
       "dependencies": {
         "@js-temporal/polyfill": "^0.5.1",
         "typebox": "^1.3.6",
@@ -101,7 +121,7 @@
     },
     "packages/svelte": {
       "name": "@ggsvelte/svelte",
-      "version": "0.16.0",
+      "version": "0.21.0",
       "bin": {
         "ggsvelte-codemod": "bin/ggsvelte-codemod.js",
         "ggsvelte-render": "bin/ggsvelte-render.js",
@@ -294,6 +314,8 @@
     "@floating-ui/utils": ["@floating-ui/utils@0.2.12", "", {}, "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww=="],
 
     "@ggsvelte-bench/benchmarks": ["@ggsvelte-bench/benchmarks@workspace:benchmarks"],
+
+    "@ggsvelte-bench/competitive": ["@ggsvelte-bench/competitive@workspace:benchmarks/competitive"],
 
     "@ggsvelte-spike/browser": ["@ggsvelte-spike/browser@workspace:spikes/browser"],
 
@@ -691,6 +713,8 @@
 
     "aria-query": ["aria-query@5.3.1", "", {}, "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g=="],
 
+    "arr-union": ["arr-union@3.1.0", "", {}, "sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q=="],
+
     "array-union": ["array-union@2.1.0", "", {}, "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="],
 
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
@@ -702,6 +726,8 @@
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
 
     "better-path-resolve": ["better-path-resolve@1.0.0", "", { "dependencies": { "is-windows": "^1.0.0" } }, "sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g=="],
+
+    "binary-search-bounds": ["binary-search-bounds@2.0.5", "", {}, "sha512-H0ea4Fd3lS1+sTEB2TgcLoK21lLhwEJzlQv3IN47pJS976Gx4zoWe0ak3q+uYh60ppQxg9F16Ri4tS1sfD4+jA=="],
 
     "bits-ui": ["bits-ui@2.18.1", "", { "dependencies": { "@floating-ui/core": "^1.7.1", "@floating-ui/dom": "^1.7.1", "esm-env": "^1.1.2", "runed": "^0.35.1", "svelte-toolbelt": "^0.10.6", "tabbable": "^6.2.0" }, "peerDependencies": { "@internationalized/date": "^3.8.1", "svelte": "^5.33.0" } }, "sha512-KkemzKFH4T3gt3H+P86JcnAWExjByv/6vlwjm/BoCwTPHu03yiCdxbghdJLvFReQTe0acCAiRcKfmixxD6XvlA=="],
 
@@ -735,6 +761,8 @@
 
     "cliui": ["cliui@7.0.4", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^7.0.0" } }, "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ=="],
 
+    "clone-deep": ["clone-deep@0.2.4", "", { "dependencies": { "for-own": "^0.1.3", "is-plain-object": "^2.0.1", "kind-of": "^3.0.2", "lazy-cache": "^1.0.3", "shallow-clone": "^0.1.2" } }, "sha512-we+NuQo2DHhSl+DP6jlUiAhyAjBQrYnpOk15rN6c6JSPScjiCLh8IbSU+VTcph6YS3o7mASE8a0+gbZ7ChLpgg=="],
+
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
@@ -749,6 +777,40 @@
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
+    "d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
+
+    "d3-axis": ["d3-axis@3.0.0", "", {}, "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw=="],
+
+    "d3-color": ["d3-color@3.1.0", "", {}, "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="],
+
+    "d3-contour": ["d3-contour@4.0.2", "", { "dependencies": { "d3-array": "^3.2.0" } }, "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA=="],
+
+    "d3-delaunay": ["d3-delaunay@6.0.4", "", { "dependencies": { "delaunator": "5" } }, "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A=="],
+
+    "d3-format": ["d3-format@3.1.2", "", {}, "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg=="],
+
+    "d3-geo": ["d3-geo@3.1.1", "", { "dependencies": { "d3-array": "2.5.0 - 3" } }, "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q=="],
+
+    "d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
+
+    "d3-path": ["d3-path@3.1.0", "", {}, "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="],
+
+    "d3-quadtree": ["d3-quadtree@3.0.1", "", {}, "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw=="],
+
+    "d3-random": ["d3-random@3.0.1", "", {}, "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ=="],
+
+    "d3-scale": ["d3-scale@4.0.2", "", { "dependencies": { "d3-array": "2.10.0 - 3", "d3-format": "1 - 3", "d3-interpolate": "1.2.0 - 3", "d3-time": "2.1.1 - 3", "d3-time-format": "2 - 4" } }, "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ=="],
+
+    "d3-scale-chromatic": ["d3-scale-chromatic@3.1.0", "", { "dependencies": { "d3-color": "1 - 3", "d3-interpolate": "1 - 3" } }, "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ=="],
+
+    "d3-selection": ["d3-selection@3.0.0", "", {}, "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="],
+
+    "d3-shape": ["d3-shape@3.2.0", "", { "dependencies": { "d3-path": "^3.1.0" } }, "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA=="],
+
+    "d3-time": ["d3-time@3.1.0", "", { "dependencies": { "d3-array": "2 - 3" } }, "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q=="],
+
+    "d3-time-format": ["d3-time-format@4.1.0", "", { "dependencies": { "d3-time": "1 - 3" } }, "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg=="],
+
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "decode-named-character-reference": ["decode-named-character-reference@1.3.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q=="],
@@ -756,6 +818,8 @@
     "dedent-js": ["dedent-js@1.0.1", "", {}, "sha512-OUepMozQULMLUmhxS95Vudo0jb0UchLimi3+pQ2plj61Fcy8axbP9hbiD4Sz6DPqn6XG3kfmziVfQ1rSys5AJQ=="],
 
     "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
+
+    "delaunator": ["delaunator@5.1.0", "", { "dependencies": { "robust-predicates": "^3.0.2" } }, "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ=="],
 
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
@@ -783,6 +847,8 @@
 
     "es-module-lexer": ["es-module-lexer@2.3.0", "", {}, "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw=="],
 
+    "es-toolkit": ["es-toolkit@1.50.0", "", {}, "sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w=="],
+
     "esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
@@ -801,6 +867,8 @@
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
+    "fast-equals": ["fast-equals@6.0.2", "", {}, "sha512-sAjhj9ZhOxYCGiNMnZLaucOqf5ZeFnHNoKoAZiD9thhJ0N8RP85qJK759/97C/3L7NzzmGVB5uiX9AUpySZmUQ=="],
+
     "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
 
     "fast-uri": ["fast-uri@3.1.3", "", {}, "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg=="],
@@ -816,6 +884,10 @@
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
     "find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
+
+    "for-in": ["for-in@1.0.2", "", {}, "sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ=="],
+
+    "for-own": ["for-own@0.1.5", "", { "dependencies": { "for-in": "^1.0.1" } }, "sha512-SKmowqGTJoPzLO1T0BBJpkfp3EMacCMOuH40hOUbrbzElVktk4DioXVM99QkLCyKoiuOmyjgcWMpVz2xjE7LZw=="],
 
     "formatly": ["formatly@0.3.0", "", { "dependencies": { "fd-package-json": "^2.0.0" }, "bin": { "formatly": "bin/index.mjs" } }, "sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w=="],
 
@@ -849,11 +921,19 @@
 
     "inline-style-parser": ["inline-style-parser@0.2.7", "", {}, "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="],
 
+    "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
+
+    "interval-tree-1d": ["interval-tree-1d@1.0.4", "", { "dependencies": { "binary-search-bounds": "^2.0.0" } }, "sha512-wY8QJH+6wNI0uh4pDQzMvl+478Qh7Rl4qLmqiluxALlNvl+I+o5x38Pw3/z7mDPTPS1dQalZJXsmbvxx5gclhQ=="],
+
     "is-alphabetical": ["is-alphabetical@2.0.1", "", {}, "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="],
 
     "is-alphanumerical": ["is-alphanumerical@2.0.1", "", { "dependencies": { "is-alphabetical": "^2.0.0", "is-decimal": "^2.0.0" } }, "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw=="],
 
+    "is-buffer": ["is-buffer@1.1.6", "", {}, "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="],
+
     "is-decimal": ["is-decimal@2.0.1", "", {}, "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A=="],
+
+    "is-extendable": ["is-extendable@0.1.1", "", {}, "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw=="],
 
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 
@@ -867,6 +947,8 @@
 
     "is-path-inside": ["is-path-inside@4.0.0", "", {}, "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA=="],
 
+    "is-plain-object": ["is-plain-object@2.0.4", "", { "dependencies": { "isobject": "^3.0.1" } }, "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og=="],
+
     "is-reference": ["is-reference@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.6" } }, "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw=="],
 
     "is-subdir": ["is-subdir@1.2.0", "", { "dependencies": { "better-path-resolve": "1.0.0" } }, "sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw=="],
@@ -874,6 +956,8 @@
     "is-windows": ["is-windows@1.0.2", "", {}, "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="],
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "isobject": ["isobject@3.0.1", "", {}, "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg=="],
 
     "istanbul-lib-coverage": ["istanbul-lib-coverage@3.2.2", "", {}, "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg=="],
 
@@ -899,9 +983,15 @@
 
     "katex": ["katex@0.16.47", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg=="],
 
+    "kind-of": ["kind-of@3.2.2", "", { "dependencies": { "is-buffer": "^1.1.5" } }, "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ=="],
+
     "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
 
     "knip": ["knip@6.29.0", "", { "dependencies": { "fdir": "^6.5.0", "formatly": "^0.3.0", "get-tsconfig": "4.14.0", "jiti": "^2.7.0", "oxc-parser": "^0.140.0", "oxc-resolver": "11.24.2", "picomatch": "^4.0.5", "smol-toml": "^1.7.0", "strip-json-comments": "5.0.3", "tinyglobby": "^0.2.17", "unbash": "^4.0.3", "yaml": "^2.9.0", "zod": "^4.4.3" }, "bin": { "knip": "bin/knip.js", "knip-bun": "bin/knip-bun.js" } }, "sha512-A3kXqSBky1tWBAqiU9srdtu0Larhzkuyor0aD/gg+ToiqyBncCCs2Q60sLsxmcKhV0OsKss9LV0hMPpwLv711Q=="],
+
+    "layercake": ["layercake@10.0.3", "", { "dependencies": { "d3-array": "^3.2.4", "d3-color": "^3.1.0", "d3-scale": "^4.0.2", "d3-shape": "^3.2.0" }, "peerDependencies": { "svelte": ">=5" } }, "sha512-9obQ5YDh70s2ovLCSZ/lZKhHy4R9FvWYxdMUiR3TLUBxxEEn3p9cGqfty0wig+bzzXUcpAvfff5pcPkp2keTdw=="],
+
+    "lazy-cache": ["lazy-cache@1.0.4", "", {}, "sha512-RE2g0b5VGZsOCFOCgP7omTRYFqydmZkBwl5oNnQ1lDYC57uyO9KqNnNVxT7COSHTxrRCWVcAVOcbjk+tvh/rgQ=="],
 
     "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 
@@ -958,6 +1048,8 @@
     "marked-terminal": ["marked-terminal@7.3.0", "", { "dependencies": { "ansi-escapes": "^7.0.0", "ansi-regex": "^6.1.0", "chalk": "^5.4.1", "cli-highlight": "^2.1.11", "cli-table3": "^0.6.5", "node-emoji": "^2.2.0", "supports-hyperlinks": "^3.1.0" }, "peerDependencies": { "marked": ">=1 <16" } }, "sha512-t4rBvPsHc57uE/2nJOLmMbZCQ4tgAccAED3ngXQqW6g+TxA488JzJ+FK3lQkzBQOI1mRV/r/Kq+1ZlJ4D0owQw=="],
 
     "mdurl": ["mdurl@2.0.0", "", {}, "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w=="],
+
+    "merge-deep": ["merge-deep@3.0.3", "", { "dependencies": { "arr-union": "^3.1.0", "clone-deep": "^0.2.4", "kind-of": "^3.0.2" } }, "sha512-qtmzAS6t6grwEkNrunqTBdn0qKwFgNWvlxUbAV8es9M7Ot1EbyApytCnvE0jALPa46ZpKDUo527kKiaWplmlFA=="],
 
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
 
@@ -1016,6 +1108,8 @@
     "miniflare": ["miniflare@4.20260714.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "0.34.5", "undici": "7.28.0", "workerd": "1.20260714.1", "ws": "8.21.0", "youch": "4.1.0-beta.10" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-MYlTCLdWCPqvrYY2uLwOjXwmglXuiHE3TGGkbOW4BwjUPa1r07E0iuHwrNDIs/sxK21r+o90Jx58AV2KeNdJZw=="],
 
     "mitata": ["mitata@1.0.34", "", {}, "sha512-Mc3zrtNBKIMeHSCQ0XqRLo1vbdIx1wvFV9c8NJAiyho6AjNfMY8bVhbS12bwciUdd1t4rj8099CH3N3NFahaUA=="],
+
+    "mixin-object": ["mixin-object@2.0.1", "", { "dependencies": { "for-in": "^0.1.3", "is-extendable": "^0.1.1" } }, "sha512-ALGF1Jt9ouehcaXaHhn6t1yGWRqGaHkPFndtFVHfZXOvkIZ/yoGaSi0AHVTafb3ZBGg4dr/bDwnaEKqCXzchMA=="],
 
     "mri": ["mri@1.2.0", "", {}, "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="],
 
@@ -1115,6 +1209,8 @@
 
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
+    "robust-predicates": ["robust-predicates@3.0.3", "", {}, "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA=="],
+
     "rolldown": ["rolldown@1.1.5", "", { "dependencies": { "@oxc-project/types": "=0.139.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.1.5", "@rolldown/binding-darwin-arm64": "1.1.5", "@rolldown/binding-darwin-x64": "1.1.5", "@rolldown/binding-freebsd-x64": "1.1.5", "@rolldown/binding-linux-arm-gnueabihf": "1.1.5", "@rolldown/binding-linux-arm64-gnu": "1.1.5", "@rolldown/binding-linux-arm64-musl": "1.1.5", "@rolldown/binding-linux-ppc64-gnu": "1.1.5", "@rolldown/binding-linux-s390x-gnu": "1.1.5", "@rolldown/binding-linux-x64-gnu": "1.1.5", "@rolldown/binding-linux-x64-musl": "1.1.5", "@rolldown/binding-openharmony-arm64": "1.1.5", "@rolldown/binding-wasm32-wasi": "1.1.5", "@rolldown/binding-win32-arm64-msvc": "1.1.5", "@rolldown/binding-win32-x64-msvc": "1.1.5" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA=="],
 
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
@@ -1130,6 +1226,8 @@
     "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
     "set-cookie-parser": ["set-cookie-parser@3.1.2", "", {}, "sha512-5/r/lTwbJ3zQ+qwdUFZYeRNqda7P5HD8zQKqlSjdGt1/S0cjLAphHusj4Y58ahDtWn/g32xrIS58/ikOvwl0Lw=="],
+
+    "shallow-clone": ["shallow-clone@0.1.2", "", { "dependencies": { "is-extendable": "^0.1.1", "kind-of": "^2.0.1", "lazy-cache": "^0.2.3", "mixin-object": "^2.0.1" } }, "sha512-J1zdXCky5GmNnuauESROVu31MQSnLoYvlyEn6j2Ztk6Q5EHFIhxkMhYcv6vuDzl2XEzoRr856QwzMgWM/TmZgw=="],
 
     "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
 
@@ -1180,6 +1278,8 @@
     "svelte-toolbelt": ["svelte-toolbelt@0.10.6", "", { "dependencies": { "clsx": "^2.1.1", "runed": "^0.35.1", "style-to-object": "^1.0.8" }, "peerDependencies": { "svelte": "^5.30.2" } }, "sha512-YWuX+RE+CnWYx09yseAe4ZVMM7e7GRFZM6OYWpBKOb++s+SQ8RBIMMe+Bs/CznBMc0QPLjr+vDBxTAkozXsFXQ=="],
 
     "svelte2tsx": ["svelte2tsx@0.7.57", "", { "dependencies": { "dedent-js": "^1.0.1", "scule": "^1.3.0" }, "peerDependencies": { "svelte": "^3.55 || ^4.0.0-next.0 || ^4.0 || ^5.0.0-next.0", "typescript": "^4.9.4 || ^5.0.0 || ^6.0.0" } }, "sha512-nQo0xEfUpSVjfkxan2UmC6Wl9UZVe9+/pglUiyBNMJ7KDQ9DDooucmXdToBOvzSfgYjj/kMYwf6CTTDz/z048w=="],
+
+    "svelteplot": ["svelteplot@0.14.2", "", { "dependencies": { "d3-array": "^3.2.4", "d3-color": "^3.1.0", "d3-contour": "^4.0.2", "d3-delaunay": "^6.0.4", "d3-format": "^3.1.2", "d3-geo": "^3.1.1", "d3-interpolate": "^3.0.1", "d3-path": "^3.1.0", "d3-quadtree": "^3.0.1", "d3-random": "^3.0.1", "d3-scale": "^4.0.2", "d3-scale-chromatic": "^3.1.0", "d3-shape": "^3.2.0", "d3-time": "^3.1.0", "es-toolkit": "^1.45.1", "fast-equals": "^6.0.0", "interval-tree-1d": "^1.0.4", "merge-deep": "^3.0.3" }, "peerDependencies": { "svelte": "^5.43.0" } }, "sha512-fWN8Vff3+/LJ2CRdBQlQgNTcwWj6Nd1VkM8LDTqsMGrDgT+4QoLKeeDtqsl0KiSuIeMw3q0X/+ilI+z34ar1kg=="],
 
     "tabbable": ["tabbable@6.5.0", "", {}, "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA=="],
 
@@ -1309,6 +1409,8 @@
 
     "micromatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
+    "mixin-object/for-in": ["for-in@0.1.8", "", {}, "sha512-F0to7vbBSHP8E3l6dCjxNOLuSFAACIxFy3UehTUlG7svlXi37HHsDkyVcHo0Pq8QwrE+pXvWSVX3ZT1T9wAZ9g=="],
+
     "parse5-htmlparser2-tree-adapter/parse5": ["parse5@6.0.1", "", {}, "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="],
 
     "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
@@ -1318,6 +1420,10 @@
     "read-yaml-file/js-yaml": ["js-yaml@3.15.0", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog=="],
 
     "rolldown/@oxc-project/types": ["@oxc-project/types@0.139.0", "", {}, "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw=="],
+
+    "shallow-clone/kind-of": ["kind-of@2.0.1", "", { "dependencies": { "is-buffer": "^1.0.2" } }, "sha512-0u8i1NZ/mg0b+W3MGGw5I7+6Eib2nx72S/QvXa0hYjEkjTknYmEYQJwGu3mLC0BrhtJjtQafTkyRUQ75Kx0LVg=="],
+
+    "shallow-clone/lazy-cache": ["lazy-cache@0.2.7", "", {}, "sha512-gkX52wvU/R8DVMMt78ATVPFMJqfW8FPz1GZ1sVHBVQHmu/WvhIWE4cE1GBzhJNFicDeYhnwp6Rl35BcAIM3YOQ=="],
 
     "strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -79,7 +79,6 @@
         "svelteplot": "^0.14.2",
       },
       "devDependencies": {
-        "@playwright/test": "1.61.1",
         "@sveltejs/vite-plugin-svelte": "^7.2.0",
         "playwright": "1.61.1",
         "vite": "^8.0.0",

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,3 +1,13 @@
 [install]
 saveTextLockfile = true
 exact = false
+
+# Core unit tests import modules without going through the package barrel;
+# install full temporal + grammar so ColumnTable/pipeline BC tests see the
+# complete runtime (lean `@ggsvelte/core/render` still omits this side effect).
+[test]
+preload = [
+  "./packages/core/src/install-temporal.ts",
+  "./packages/core/src/pipeline/frame-stats-register-all.ts",
+  "./packages/core/src/pipeline/geometry-register-all.ts",
+]

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -68,6 +68,11 @@
       "entry": ["*.bench.ts"],
       "project": ["**/*.ts"],
     },
+    "benchmarks/competitive": {
+      // measure-*.ts are scripts; entries/fixtures are dynamic Vite entry points.
+      "entry": ["measure-*.ts", "entries/**/*.ts", "fixtures/**/*.ts"],
+      "project": ["**/*.ts"],
+    },
     "examples": {
       // The corpus: spec.ts/data.ts are consumed by the docs app via the
       // $examples alias and by tests/visual via the generated manifest.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "apps/*",
     "examples",
     "spikes/*",
-    "benchmarks"
+    "benchmarks",
+    "benchmarks/competitive"
   ],
   "type": "module",
   "scripts": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,7 +35,8 @@
     "./dist/install-temporal.js",
     "./dist/pipeline/frame-stats-register-all.js",
     "./dist/pipeline/geometry-register-all.js",
-    "./dist/pipeline/geometry-register-basic.js"
+    "./dist/pipeline/geometry-register-basic.js",
+    "./dist/pipeline/frame-stats-register-basic.js"
   ],
   "exports": {
     ".": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,11 +28,27 @@
     "src"
   ],
   "type": "module",
-  "sideEffects": false,
+  "sideEffects": [
+    "./dist/index.js",
+    "./dist/render-entry.js",
+    "./dist/temporal-entry.js",
+    "./dist/install-temporal.js",
+    "./dist/pipeline/frame-stats-register-all.js",
+    "./dist/pipeline/geometry-register-all.js",
+    "./dist/pipeline/geometry-register-basic.js"
+  ],
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
+    },
+    "./render": {
+      "types": "./dist/render-entry.d.ts",
+      "default": "./dist/render-entry.js"
+    },
+    "./temporal": {
+      "types": "./dist/temporal-entry.d.ts",
+      "default": "./dist/temporal-entry.js"
     },
     "./dom": {
       "types": "./dist/dom/index.d.ts",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,9 +4,18 @@
 // spec <- core <- svelte. The DOM half (canvas renderer, browser measurer)
 // lives behind "@ggsvelte/core/dom".
 //
+// Lean identity-chart surface (no heavy stats / specialty geoms):
+// `@ggsvelte/core/render`.
+//
 // Lifecycle (Hadley lesson 13; meanings in CONTRIBUTING.md): tags collected
 // into lifecycle.json by scripts/gen-lifecycle.ts.
 // @lifecycle-default experimental
+
+// Full grammar: register every stat frame builder and geom batch.
+import "./pipeline/frame-stats-register-all.js";
+import "./pipeline/geometry-register-all.js";
+// Full temporal: Temporal polyfill parsing + guide planner.
+import "./install-temporal.js";
 
 // Data binding
 export {

--- a/packages/core/src/install-temporal.ts
+++ b/packages/core/src/install-temporal.ts
@@ -1,0 +1,43 @@
+/**
+ * Side-effect module: wire full Temporal polyfill parsing + axis planning.
+ * Imported by the full `@ggsvelte/core` barrel and `@ggsvelte/core/temporal`.
+ */
+import {
+  canonicalTemporalParserKey,
+  parseTemporalColumn,
+  type TemporalParserSpec,
+} from "@ggsvelte/spec";
+
+import { compileTemporalLabelFormat } from "./layout/format-temporal-labels.js";
+import type { TemporalLabelFormatOptions } from "./layout/format-temporal-labels.js";
+import { planTemporalAxis } from "./layout/temporal-guide.js";
+import { installTemporalRuntime } from "./temporal-runtime.js";
+import type { CellValue } from "./table-types.js";
+
+let installed = false;
+
+export function installTemporal(): void {
+  if (installed) return;
+  installed = true;
+  installTemporalRuntime({
+    parseColumn: (raw: readonly CellValue[], parser: TemporalParserSpec | "auto", options) => {
+      const parsed = parseTemporalColumn(raw, parser, {
+        ...(options.timezone !== undefined && { timezone: options.timezone }),
+        ...(options.disambiguation !== undefined && { disambiguation: options.disambiguation }),
+      });
+      return {
+        decision: parsed.decision,
+        semantic: parsed.semantic,
+        valid: parsed.valid,
+        kind: parsed.decision.kind ?? undefined,
+        precision: parsed.decision.precision ?? undefined,
+      };
+    },
+    planAxis: planTemporalAxis,
+    parserKey: (parser: TemporalParserSpec) => canonicalTemporalParserKey(parser),
+    compileLabelFormat: (pattern, options) =>
+      compileTemporalLabelFormat(pattern, options as TemporalLabelFormatOptions),
+  });
+}
+
+installTemporal();

--- a/packages/core/src/iso-epoch.ts
+++ b/packages/core/src/iso-epoch.ts
@@ -3,10 +3,15 @@
  * Deliberately avoids the global date-string parser (banned by temporal-source-gate).
  */
 const ISO_LIKE =
-  /^(\d{4})-(\d{2})-(\d{2})(?:[T ](\d{2}):(\d{2})(?::(\d{2})(?:\.(\d{1,3}))?)?(?:Z|([+-])(\d{2}):?(\d{2}))?)?$/;
+  /^(\d{4})-(\d{2})-(\d{2})(?:[T ](\d{2}):(\d{2})(?::(\d{2})(?:\.(\d{1,9}))?)?(?:Z|([+-])(\d{2}):?(\d{2}))?)?$/;
 
 export function isIsoLikeString(value: string): boolean {
   return ISO_LIKE.test(value) && isoEpochMs(value) !== undefined;
+}
+
+/** True when the ISO string carries a clock component (time or datetime). */
+export function isoHasClock(value: string): boolean {
+  return /[T ]\d{2}:\d{2}/.test(value);
 }
 
 /** Parse common ISO date/datetime strings to UTC epoch ms, or undefined. */
@@ -20,18 +25,22 @@ export function isoEpochMs(value: string): number | undefined {
   const hour = match[4] === undefined ? 0 : Number(match[4]);
   const minute = match[5] === undefined ? 0 : Number(match[5]);
   const second = match[6] === undefined ? 0 : Number(match[6]);
-  const fraction = match[7] === undefined ? 0 : Number(match[7].padEnd(3, "0"));
+  // Truncate fractional seconds to milliseconds (up to 9 digits accepted).
+  const fractionRaw = match[7] ?? "0";
+  const fraction = Number(fractionRaw.padEnd(3, "0").slice(0, 3));
   if (hour > 23 || minute > 59 || second > 59) return undefined;
-  let epoch = Date.UTC(year, month - 1, day, hour, minute, second, fraction);
-  // Reject overflow (e.g. 2024-02-30 → March) by round-tripping the calendar day.
-  const check = new Date(epoch);
+  // Date.UTC maps years 0–99 to 1900+; use setUTCFullYear for full range.
+  const date = new Date(0);
+  date.setUTCFullYear(year, month - 1, day);
+  date.setUTCHours(hour, minute, second, fraction);
   if (
-    check.getUTCFullYear() !== year ||
-    check.getUTCMonth() + 1 !== month ||
-    check.getUTCDate() !== day
+    date.getUTCFullYear() !== year ||
+    date.getUTCMonth() + 1 !== month ||
+    date.getUTCDate() !== day
   ) {
     return undefined;
   }
+  let epoch = date.getTime();
   if (match[8] !== undefined) {
     const sign = match[8] === "+" ? 1 : -1;
     const offH = Number(match[9]);

--- a/packages/core/src/iso-epoch.ts
+++ b/packages/core/src/iso-epoch.ts
@@ -1,0 +1,43 @@
+/**
+ * Polyfill-free ISO-8601 → epoch-ms for lean render paths.
+ * Deliberately avoids the global date-string parser (banned by temporal-source-gate).
+ */
+const ISO_LIKE =
+  /^(\d{4})-(\d{2})-(\d{2})(?:[T ](\d{2}):(\d{2})(?::(\d{2})(?:\.(\d{1,3}))?)?(?:Z|([+-])(\d{2}):?(\d{2}))?)?$/;
+
+export function isIsoLikeString(value: string): boolean {
+  return ISO_LIKE.test(value) && isoEpochMs(value) !== undefined;
+}
+
+/** Parse common ISO date/datetime strings to UTC epoch ms, or undefined. */
+export function isoEpochMs(value: string): number | undefined {
+  const match = ISO_LIKE.exec(value);
+  if (match === null) return undefined;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  if (month < 1 || month > 12 || day < 1 || day > 31) return undefined;
+  const hour = match[4] === undefined ? 0 : Number(match[4]);
+  const minute = match[5] === undefined ? 0 : Number(match[5]);
+  const second = match[6] === undefined ? 0 : Number(match[6]);
+  const fraction = match[7] === undefined ? 0 : Number(match[7].padEnd(3, "0"));
+  if (hour > 23 || minute > 59 || second > 59) return undefined;
+  let epoch = Date.UTC(year, month - 1, day, hour, minute, second, fraction);
+  // Reject overflow (e.g. 2024-02-30 → March) by round-tripping the calendar day.
+  const check = new Date(epoch);
+  if (
+    check.getUTCFullYear() !== year ||
+    check.getUTCMonth() + 1 !== month ||
+    check.getUTCDate() !== day
+  ) {
+    return undefined;
+  }
+  if (match[8] !== undefined) {
+    const sign = match[8] === "+" ? 1 : -1;
+    const offH = Number(match[9]);
+    const offM = Number(match[10]);
+    if (offH > 23 || offM > 59) return undefined;
+    epoch -= sign * (offH * 60 + offM) * 60_000;
+  }
+  return epoch;
+}

--- a/packages/core/src/layout/layout-derive-ticks.ts
+++ b/packages/core/src/layout/layout-derive-ticks.ts
@@ -5,8 +5,8 @@
 import { encodeKey } from "../scales/state.js";
 import type { CellValue } from "../table.js";
 import type { AxisGuidePlan } from "./temporal-guide.js";
-import { planTemporalAxis } from "./temporal-guide.js";
 import { planBandAxis, type BandAxisPlan, type BandGuideConfig } from "./band-guide.js";
+import { requireTemporalRuntime } from "../temporal-runtime.js";
 import type { TextMeasurer } from "./measure.js";
 import { truncateToFit } from "./truncate.js";
 import {
@@ -370,7 +370,7 @@ export function deriveTicks(
 
   if (domain.type === "time") {
     if (domain.temporal !== undefined) {
-      const plan = planTemporalAxis({
+      const plan = requireTemporalRuntime("planTemporalAxis").planAxis({
         aesthetic: domain.temporal.aesthetic,
         panelIndex: domain.temporal.panelIndex,
         domain: [min, max],

--- a/packages/core/src/pipeline.ts
+++ b/packages/core/src/pipeline.ts
@@ -55,4 +55,12 @@ export type {
 } from "./pipeline/public-api.js";
 export { CANVAS_AUTO_THRESHOLD, PipelineError, batchMarkCount } from "./pipeline/public-api.js";
 
+// Full grammar registration for the default pipeline barrel (tests + main
+// package). Lean charts import `@ggsvelte/core/render` which loads basic geoms
+// only and never evaluates this file.
+import "./pipeline/frame-stats-register-all.js";
+import "./pipeline/geometry-register-all.js";
+// Full temporal polyfill + guide planner (lean render entry skips this).
+import "./install-temporal.js";
+
 export { runPipeline } from "./pipeline/run-pipeline.js";

--- a/packages/core/src/pipeline/finalize-layout-pass.ts
+++ b/packages/core/src/pipeline/finalize-layout-pass.ts
@@ -1,7 +1,8 @@
 /**
  * Finalize phase: two-pass panel layout only.
  */
-import { parseTemporalColumn, type CellValue, type PortableSpec } from "@ggsvelte/spec";
+import type { CellValue, PortableSpec } from "@ggsvelte/spec";
+import { getTemporalRuntime } from "../temporal-runtime.js";
 
 import { perfMark, perfMeasure } from "../perf.js";
 import type { ThemeTokens } from "../theme.js";
@@ -54,24 +55,30 @@ export function finalizePanelLayoutPass(input: {
       if (value !== undefined) scalarValues.push(...(Array.isArray(value) ? value : [value]));
     }
     if (scalarValues.length > 0 && conversion.requestedTime) {
-      const decision = parseTemporalColumn(
-        scalarValues,
-        conversion.parser,
-        conversion.options,
-      ).decision;
-      if (decision.kind !== null) return decision.kind;
-    }
-
-    const config = normalized.scales?.[axis];
-    if (conversion.requestedTime) {
-      for (const values of [config?.domain, config?.breaks]) {
-        if (values === undefined || values.length === 0) continue;
-        const decision = parseTemporalColumn(
-          values,
+      const runtime = getTemporalRuntime();
+      if (runtime !== null) {
+        const decision = runtime.parseColumn(
+          scalarValues,
           conversion.parser,
           conversion.options,
         ).decision;
         if (decision.kind !== null) return decision.kind;
+      }
+    }
+
+    const config = normalized.scales?.[axis];
+    if (conversion.requestedTime) {
+      const runtime = getTemporalRuntime();
+      if (runtime !== null) {
+        for (const values of [config?.domain, config?.breaks]) {
+          if (values === undefined || values.length === 0) continue;
+          const decision = runtime.parseColumn(
+            values,
+            conversion.parser,
+            conversion.options,
+          ).decision;
+          if (decision.kind !== null) return decision.kind;
+        }
       }
     }
 

--- a/packages/core/src/pipeline/frame-group-columns.ts
+++ b/packages/core/src/pipeline/frame-group-columns.ts
@@ -1,11 +1,10 @@
 /**
  * Layer grouping and carried discrete columns for stats/identity frames.
  */
-import { parseTemporal, parseTemporalColumn } from "@ggsvelte/spec";
-
 import { deriveGroups, type ChannelGroupingOverrides } from "../grouping.js";
 import { cellToNumber, type CellValue, type Discreteness } from "../table.js";
 import type { ColumnTable } from "../table.js";
+import { getTemporalRuntime } from "../temporal-runtime.js";
 
 import { styleBinIndex } from "./style-bin-index.js";
 import { positionDiscreteness } from "./temporal-position.js";
@@ -57,12 +56,14 @@ function binnedStyleColumn(
   const numeric = parsed.semantic;
   const semanticOf = (value: CellValue): number | undefined => {
     if (binding.binTemporal === true) {
-      if (binding.binParse !== undefined) {
-        const result = parseTemporal(value, binding.binParse, options);
-        return result.ok ? result.epochMs : undefined;
+      const runtime = getTemporalRuntime();
+      if (runtime !== null) {
+        const result = runtime.parseColumn([value], binding.binParse ?? "auto", options);
+        return result.valid[0] === 1 ? result.semantic[0] : undefined;
       }
-      const result = parseTemporalColumn([value], "auto", options);
-      return result.valid[0] === 1 ? result.semantic[0] : undefined;
+      // Lean path: ISO via Date.parse (cellToNumber).
+      const number = cellToNumber(value);
+      return Number.isFinite(number) ? number : undefined;
     }
     const number = cellToNumber(value);
     return Number.isFinite(number) ? number : undefined;

--- a/packages/core/src/pipeline/frame-group-columns.ts
+++ b/packages/core/src/pipeline/frame-group-columns.ts
@@ -61,7 +61,7 @@ function binnedStyleColumn(
         const result = runtime.parseColumn([value], binding.binParse ?? "auto", options);
         return result.valid[0] === 1 ? result.semantic[0] : undefined;
       }
-      // Lean path: ISO via Date.parse (cellToNumber).
+      // Lean path: ISO via cellToNumber (polyfill-free).
       const number = cellToNumber(value);
       return Number.isFinite(number) ? number : undefined;
     }

--- a/packages/core/src/pipeline/frame-stats-register-all.ts
+++ b/packages/core/src/pipeline/frame-stats-register-all.ts
@@ -1,0 +1,120 @@
+/**
+ * Side-effect registration of every non-identity stat frame builder.
+ * Imported by the full `@ggsvelte/core` package entry only.
+ */
+import { buildAlignFrame } from "./frame-stats-align.js";
+import { buildBindotFrame } from "./frame-stats-bindot.js";
+import { buildBinFrame } from "./frame-stats-bin.js";
+import { buildBin2dFrame } from "./frame-stats-bin-2d.js";
+import { buildBinHexFrame } from "./frame-stats-bin-hex.js";
+import { buildBoxplotFrame } from "./frame-stats-boxplot.js";
+import { buildConnectFrame } from "./frame-stats-connect.js";
+import { buildContourFrame } from "./frame-stats-contour.js";
+import { buildCountFrame } from "./frame-stats-count.js";
+import { buildDensityFrame } from "./frame-stats-density.js";
+import { buildDensity2dFrame } from "./frame-stats-density-2d.js";
+import { buildEcdfFrame } from "./frame-stats-ecdf.js";
+import { buildEllipseFrame } from "./frame-stats-ellipse.js";
+import { buildFunctionFrame } from "./frame-stats-function.js";
+import { buildManualFrame } from "./frame-stats-manual.js";
+import { buildQqFrame, buildQqLineFrame } from "./frame-stats-qq.js";
+import { buildQuantileFrame } from "./frame-stats-quantile.js";
+import { registerStatFrame } from "./frame-stats-registry.js";
+import { buildSfCoordinatesFrame } from "./frame-stats-sf-coordinates.js";
+import { buildSfFrame } from "./frame-stats-sf.js";
+import { buildSmoothFrame } from "./frame-stats-smooth.js";
+import { buildSumFrame } from "./frame-stats-sum.js";
+import { buildSummaryFrame } from "./frame-stats-summary.js";
+import { buildSummaryBinFrame } from "./frame-stats-summary-bin.js";
+import { buildUniqueFrame } from "./frame-stats-unique.js";
+import { buildYDensityFrame } from "./frame-stats-ydensity.js";
+
+let registered = false;
+
+/** Idempotent: safe to import from the package barrel more than once. */
+export function registerAllStatFrames(): void {
+  if (registered) return;
+  registered = true;
+
+  registerStatFrame("sf", (binding, table, groups, warnings) =>
+    buildSfFrame(binding, table, groups, warnings),
+  );
+  registerStatFrame("sf_coordinates", (binding, table, groups, warnings) =>
+    buildSfCoordinatesFrame(binding, table, groups, warnings),
+  );
+  registerStatFrame("unique", (binding, table, groups) => buildUniqueFrame(binding, table, groups));
+  registerStatFrame("manual", (binding, table, groups, warnings) =>
+    buildManualFrame(binding, table, groups, warnings),
+  );
+  registerStatFrame("align", (binding, table, groups, warnings) =>
+    buildAlignFrame(binding, table, groups, warnings),
+  );
+  registerStatFrame("connect", (binding, table, groups, warnings) =>
+    buildConnectFrame(binding, table, groups, warnings),
+  );
+  registerStatFrame("ellipse", (binding, table, groups, warnings) =>
+    buildEllipseFrame(binding, table, groups, warnings),
+  );
+  registerStatFrame("count", (binding, table, groups, warnings) =>
+    buildCountFrame(binding, table, groups, warnings),
+  );
+  registerStatFrame("bin", (binding, table, groups, warnings, advisories, binRange) =>
+    buildBinFrame(binding, table, groups, warnings, advisories, binRange),
+  );
+  registerStatFrame("bin_hex", (binding, table, groups, warnings, advisories) =>
+    buildBinHexFrame(binding, table, groups, warnings, advisories),
+  );
+  registerStatFrame("summary_bin", (binding, table, groups, warnings, advisories, binRange) =>
+    buildSummaryBinFrame(binding, table, groups, warnings, advisories, binRange),
+  );
+  registerStatFrame("bindot", (binding, table, groups, warnings, advisories, binRange) =>
+    buildBindotFrame(binding, table, groups, warnings, advisories, binRange),
+  );
+  registerStatFrame("bin_2d", (binding, table, groups, warnings, advisories) =>
+    buildBin2dFrame(binding, table, groups, warnings, advisories),
+  );
+  registerStatFrame("density", (binding, table, groups, warnings) =>
+    buildDensityFrame(binding, table, groups, warnings),
+  );
+  registerStatFrame("sum", (binding, table, groups, warnings) =>
+    buildSumFrame(binding, table, groups, warnings),
+  );
+  registerStatFrame("ydensity", (binding, table, groups, warnings) =>
+    buildYDensityFrame(binding, table, groups, warnings),
+  );
+  registerStatFrame("ecdf", (binding, table, groups, warnings) =>
+    buildEcdfFrame(binding, table, groups, warnings),
+  );
+  registerStatFrame("density_2d", (binding, table, groups, warnings) =>
+    buildDensity2dFrame(binding, table, groups, warnings),
+  );
+  registerStatFrame("density_2d_filled", (binding, table, groups, warnings) =>
+    buildDensity2dFrame(binding, table, groups, warnings),
+  );
+  registerStatFrame("smooth", (binding, table, groups, warnings, advisories) =>
+    buildSmoothFrame(binding, table, groups, warnings, advisories),
+  );
+  registerStatFrame("quantile", (binding, table, groups, warnings) =>
+    buildQuantileFrame(binding, table, groups, warnings),
+  );
+  registerStatFrame("contour", (binding, table, groups, warnings) =>
+    buildContourFrame(binding, table, groups, warnings),
+  );
+  registerStatFrame("boxplot", (binding, table, groups, warnings) =>
+    buildBoxplotFrame(binding, table, groups, warnings),
+  );
+  registerStatFrame("summary", (binding, table, groups, warnings) =>
+    buildSummaryFrame(binding, table, groups, warnings),
+  );
+  registerStatFrame("function", (binding, table, _groups, warnings, _adv, _bin, functionDomain) =>
+    buildFunctionFrame(binding, table, warnings, functionDomain),
+  );
+  registerStatFrame("qq", (binding, table, groups, warnings) =>
+    buildQqFrame(binding, table, groups, warnings),
+  );
+  registerStatFrame("qq_line", (binding, table, groups, warnings) =>
+    buildQqLineFrame(binding, table, groups, warnings),
+  );
+}
+
+registerAllStatFrames();

--- a/packages/core/src/pipeline/frame-stats-register-basic.ts
+++ b/packages/core/src/pipeline/frame-stats-register-basic.ts
@@ -1,0 +1,22 @@
+/**
+ * Basic non-identity stats for `@ggsvelte/core/render` (bar/count, sum).
+ * Heavy stats (smooth, density, sf, …) stay on the full package registration.
+ */
+import { buildCountFrame } from "./frame-stats-count.js";
+import { buildSumFrame } from "./frame-stats-sum.js";
+import { registerStatFrame } from "./frame-stats-registry.js";
+
+let registered = false;
+
+export function registerBasicStatFrames(): void {
+  if (registered) return;
+  registered = true;
+  registerStatFrame("count", (binding, table, groups, warnings) =>
+    buildCountFrame(binding, table, groups, warnings),
+  );
+  registerStatFrame("sum", (binding, table, groups, warnings) =>
+    buildSumFrame(binding, table, groups, warnings),
+  );
+}
+
+registerBasicStatFrames();

--- a/packages/core/src/pipeline/frame-stats-register-basic.ts
+++ b/packages/core/src/pipeline/frame-stats-register-basic.ts
@@ -8,7 +8,7 @@ import { registerStatFrame } from "./frame-stats-registry.js";
 
 let registered = false;
 
-export function registerBasicStatFrames(): void {
+function registerBasicStatFrames(): void {
   if (registered) return;
   registered = true;
   registerStatFrame("count", (binding, table, groups, warnings) =>

--- a/packages/core/src/pipeline/frame-stats-registry.ts
+++ b/packages/core/src/pipeline/frame-stats-registry.ts
@@ -1,0 +1,43 @@
+/**
+ * Stat → LayerFrame builder registry.
+ *
+ * Heavy stats (loess/smooth, density, contour, sf, …) live in separate modules
+ * and register here. The full package entry registers everything; the lean
+ * `@ggsvelte/core/render` entry registers nothing extra so identity charts
+ * (scatter, plain line) do not pull those modules into the client graph.
+ */
+import type { ColumnTable } from "../table.js";
+
+import type { Advisory, LayerBinding, LayerFrame, PipelineWarning } from "./types.js";
+
+export type StatFrameBuilder = (
+  binding: LayerBinding,
+  table: ColumnTable,
+  groups: readonly number[],
+  warnings: PipelineWarning[],
+  advisories: Advisory[],
+  binRange: [number, number] | undefined,
+  functionDomain: [number, number] | undefined,
+) => LayerFrame | null;
+
+const builders = new Map<string, StatFrameBuilder>();
+
+/** Register (or replace) a non-identity stat frame builder. */
+export function registerStatFrame(stat: string, build: StatFrameBuilder): void {
+  builders.set(stat, build);
+}
+
+/** Look up a registered builder; undefined if the stat is not loaded. */
+export function getStatFrameBuilder(stat: string): StatFrameBuilder | undefined {
+  return builders.get(stat);
+}
+
+/** Test helper: clear the registry. */
+export function clearStatFrameRegistry(): void {
+  builders.clear();
+}
+
+/** Test helper: registered stat names. */
+export function registeredStatFrames(): readonly string[] {
+  return [...builders.keys()];
+}

--- a/packages/core/src/pipeline/frame-stats-registry.ts
+++ b/packages/core/src/pipeline/frame-stats-registry.ts
@@ -31,13 +31,3 @@ export function registerStatFrame(stat: string, build: StatFrameBuilder): void {
 export function getStatFrameBuilder(stat: string): StatFrameBuilder | undefined {
   return builders.get(stat);
 }
-
-/** Test helper: clear the registry. */
-export function clearStatFrameRegistry(): void {
-  builders.clear();
-}
-
-/** Test helper: registered stat names. */
-export function registeredStatFrames(): readonly string[] {
-  return [...builders.keys()];
-}

--- a/packages/core/src/pipeline/frame-stats.ts
+++ b/packages/core/src/pipeline/frame-stats.ts
@@ -1,35 +1,16 @@
 /**
- * Non-identity stat branches for LayerFrame construction (count/bin/density/
- * smooth/boxplot/summary). Returns null for identity so the caller can fall through.
+ * Non-identity stat branches for LayerFrame construction.
+ * Returns null for identity so the caller can fall through.
+ *
+ * Builders are registered by {@link registerAllStatFrames} (full package) or
+ * left empty on the lean `@ggsvelte/core/render` entry so identity charts do
+ * not pull loess/density/sf modules into the client graph.
  */
 import type { ColumnTable } from "../table.js";
 
-import { buildAlignFrame } from "./frame-stats-align.js";
-import { buildBindotFrame } from "./frame-stats-bindot.js";
-import { buildBinFrame } from "./frame-stats-bin.js";
-import { buildCountFrame } from "./frame-stats-count.js";
-import { buildDensityFrame } from "./frame-stats-density.js";
-import { buildBin2dFrame } from "./frame-stats-bin-2d.js";
-import { buildBinHexFrame } from "./frame-stats-bin-hex.js";
-import { buildEcdfFrame } from "./frame-stats-ecdf.js";
-import { buildConnectFrame } from "./frame-stats-connect.js";
-import { buildDensity2dFrame } from "./frame-stats-density-2d.js";
-import { buildEllipseFrame } from "./frame-stats-ellipse.js";
-import { buildBoxplotFrame } from "./frame-stats-boxplot.js";
-import { buildSmoothFrame } from "./frame-stats-smooth.js";
-import { buildSummaryFrame } from "./frame-stats-summary.js";
-import { buildSumFrame } from "./frame-stats-sum.js";
-import { buildYDensityFrame } from "./frame-stats-ydensity.js";
-import { buildFunctionFrame } from "./frame-stats-function.js";
-import { buildQqFrame, buildQqLineFrame } from "./frame-stats-qq.js";
-import { buildManualFrame } from "./frame-stats-manual.js";
-import { buildContourFrame } from "./frame-stats-contour.js";
-import { buildQuantileFrame } from "./frame-stats-quantile.js";
-import { buildSummaryBinFrame } from "./frame-stats-summary-bin.js";
-import { buildSfCoordinatesFrame } from "./frame-stats-sf-coordinates.js";
-import { buildSfFrame } from "./frame-stats-sf.js";
-import { buildUniqueFrame } from "./frame-stats-unique.js";
+import { getStatFrameBuilder } from "./frame-stats-registry.js";
 import type { Advisory, LayerBinding, LayerFrame, PipelineWarning } from "./types.js";
+import { PipelineError } from "./types.js";
 
 export function buildNonIdentityFrame(
   binding: LayerBinding,
@@ -43,37 +24,14 @@ export function buildNonIdentityFrame(
   const stat = binding.layer.stat ?? "identity";
   if (stat === "identity") return null;
 
-  // ggplot2 stat_sf: expand portable GeoJSON to drawable parts (#809 phase 7).
-  if (stat === "sf") return buildSfFrame(binding, table, groups, warnings);
-  if (stat === "sf_coordinates") return buildSfCoordinatesFrame(binding, table, groups, warnings);
-  if (stat === "unique") return buildUniqueFrame(binding, table, groups);
-  if (stat === "manual") return buildManualFrame(binding, table, groups, warnings);
-  if (stat === "align") return buildAlignFrame(binding, table, groups, warnings);
-  if (stat === "connect") return buildConnectFrame(binding, table, groups, warnings);
-  if (stat === "ellipse") return buildEllipseFrame(binding, table, groups, warnings);
-  if (stat === "count") return buildCountFrame(binding, table, groups, warnings);
-  if (stat === "bin") return buildBinFrame(binding, table, groups, warnings, advisories, binRange);
-  if (stat === "bin_hex") return buildBinHexFrame(binding, table, groups, warnings, advisories);
-  if (stat === "summary_bin")
-    return buildSummaryBinFrame(binding, table, groups, warnings, advisories, binRange);
-  if (stat === "bindot")
-    return buildBindotFrame(binding, table, groups, warnings, advisories, binRange);
-  if (stat === "bin_2d") return buildBin2dFrame(binding, table, groups, warnings, advisories);
-  if (stat === "density") return buildDensityFrame(binding, table, groups, warnings);
-  if (stat === "sum") return buildSumFrame(binding, table, groups, warnings);
-  if (stat === "ydensity") return buildYDensityFrame(binding, table, groups, warnings);
-  if (stat === "ecdf") return buildEcdfFrame(binding, table, groups, warnings);
-  if (stat === "density_2d" || stat === "density_2d_filled") {
-    return buildDensity2dFrame(binding, table, groups, warnings);
+  const build = getStatFrameBuilder(stat);
+  if (build === undefined) {
+    const path = `/layers/${String(binding.index)}/stat`;
+    throw new PipelineError(
+      "unsupported-param",
+      path,
+      `Stat "${stat}" is not registered in this build. Import @ggsvelte/core (full package) rather than @ggsvelte/core/render, or call registerStatFrame("${stat}", …).`,
+    );
   }
-  if (stat === "smooth") return buildSmoothFrame(binding, table, groups, warnings, advisories);
-  if (stat === "quantile") return buildQuantileFrame(binding, table, groups, warnings);
-  if (stat === "contour") return buildContourFrame(binding, table, groups, warnings);
-  if (stat === "boxplot") return buildBoxplotFrame(binding, table, groups, warnings);
-  if (stat === "summary") return buildSummaryFrame(binding, table, groups, warnings);
-  if (stat === "function") return buildFunctionFrame(binding, table, warnings, functionDomain);
-  if (stat === "qq") return buildQqFrame(binding, table, groups, warnings);
-  if (stat === "qq_line") return buildQqLineFrame(binding, table, groups, warnings);
-
-  return null;
+  return build(binding, table, groups, warnings, advisories, binRange, functionDomain);
 }

--- a/packages/core/src/pipeline/geometry-dispatch.ts
+++ b/packages/core/src/pipeline/geometry-dispatch.ts
@@ -1,34 +1,14 @@
 /**
  * Per-geom geometry batch dispatch for a single layer frame.
+ * Implementations register via geometry-register-basic / geometry-register-all.
  */
 import type { GeometryBatch } from "../scene.js";
 
+import { getGeomBatchBuilder } from "./geometry-registry.js";
 import type { LayerFrame, PipelineWarning, ResolvedColorScale } from "./types.js";
 import type { Frame } from "./geometry-shared.js";
 import type { ResolvedStyleScales } from "./geometry-style.js";
-import { pointsBatch } from "./geometry-points.js";
-import { lineBatch } from "./geometry-paths-line.js";
-import { areaBatch } from "./geometry-paths-area.js";
-import { rectsBatch } from "./geometry-rects.js";
-import { segmentsBatch } from "./geometry-segments.js";
-import { glyphsBatch } from "./geometry-glyphs.js";
-import { polygonBatch } from "./geometry-paths-polygon.js";
-import { smoothBatches } from "./geometry-smooth.js";
-import { boxplotBatches } from "./geometry-boxplot.js";
-import { errorbarBatch } from "./geometry-errorbar.js";
-import { edgeRectsBatch, rasterRectsBatch, tileRectsBatch } from "./geometry-edge-rects.js";
-import { ribbonBatches } from "./geometry-ribbon.js";
-import { finiteSegmentBatch } from "./geometry-segment-finite.js";
-import { violinBatch } from "./geometry-violin.js";
-import { ablineBatch } from "./geometry-abline.js";
-import { curveBatch } from "./geometry-curve.js";
-import { hexBatch } from "./geometry-hex.js";
-import { rugBatch } from "./geometry-rug.js";
-import { crossbarBatches, linerangeBatch, pointrangeBatches } from "./geometry-range.js";
-
-function single(batch: GeometryBatch | null): GeometryBatch[] {
-  return batch === null ? [] : [batch];
-}
+import { PipelineError } from "./types.js";
 
 export function dispatchGeometryBatch(
   frame: LayerFrame,
@@ -39,110 +19,13 @@ export function dispatchGeometryBatch(
   warnings: PipelineWarning[],
 ): GeometryBatch[] {
   const geom = frame.binding.layer.geom;
-  switch (geom) {
-    case "point":
-    case "count":
-    case "qq":
-      return single(pointsBatch(frame, fx, color, styles, warnings));
-    case "dotplot":
-      // Pass fill so histodot dots honor aes.fill (ggplot2 fill grouping; #900).
-      return single(pointsBatch(frame, fx, color, styles, warnings, fill));
-    case "step":
-    case "line": {
-      // stat_connect emits tied-x step corners; a post-stat x-sort would
-      // scramble elbows (#816). Identity line still sorts by x.
-      const connectNoSort = frame.binding.layer.stat === "connect";
-      return single(
-        lineBatch(frame, fx, color, styles, warnings, connectNoSort ? { sortByX: false } : {}),
-      );
-    }
-    case "function":
-    case "qq_line":
-    case "quantile":
-      // Fitted QR grids / QQ line endpoints are already ordered; treat like line.
-      return single(lineBatch(frame, fx, color, styles, warnings));
-    case "path":
-      // Data-order polylines (ggplot2 geom_path); no x-sort (#788).
-      return single(lineBatch(frame, fx, color, styles, warnings, { sortByX: false }));
-    case "contour":
-      // Isolines are authored in stitch order; never x-sort.
-      return single(lineBatch(frame, fx, color, styles, warnings, { sortByX: false }));
-    case "density_2d":
-      // KDE isolines are authored in stitch order; never x-sort.
-      return single(lineBatch(frame, fx, color, styles, warnings, { sortByX: false }));
-    case "density_2d_filled":
-      // Closed isoline rings as filled paths (#802 phase 2).
-      return single(polygonBatch(frame, fx, color, fill, styles, warnings));
-    case "col":
-    case "bar":
-      return single(rectsBatch(frame, fx, fill, styles, warnings));
-    case "rect":
-    case "bin_2d":
-      return single(edgeRectsBatch(frame, fx, fill, color, styles, warnings));
-    case "tile":
-      return single(tileRectsBatch(frame, fx, fill, color, styles, warnings));
-    case "raster":
-      return single(rasterRectsBatch(frame, fx, fill, styles, warnings));
-    case "area":
-    case "density":
-      return single(areaBatch(frame, fx, fill, styles, warnings));
-    case "ribbon":
-      return ribbonBatches(frame, fx, color, fill, styles, warnings);
-    case "rule":
-      return single(segmentsBatch(frame, fx, color, styles, warnings));
-    case "segment":
-    case "spoke":
-      return single(finiteSegmentBatch(frame, fx, color, styles, warnings));
-    case "abline":
-      return single(ablineBatch(frame, fx, color, styles, warnings));
-    case "curve":
-      return single(curveBatch(frame, fx, color, styles, warnings));
-    case "rug":
-      return single(rugBatch(frame, fx, color, styles, warnings));
-    case "polygon":
-      return single(polygonBatch(frame, fx, color, fill, styles, warnings));
-    case "text":
-    case "label":
-    case "sf_text":
-    case "sf_label":
-      return single(glyphsBatch(frame, fx, color, fill, styles, warnings));
-    case "smooth":
-      return smoothBatches(frame, fx, color, fill, styles, warnings);
-    case "boxplot":
-      return boxplotBatches(frame, fx, fill, styles, warnings);
-    case "errorbar":
-      return single(errorbarBatch(frame, fx, color, styles, warnings));
-    case "violin":
-      return single(violinBatch(frame, fx, fill, color, styles, warnings));
-    case "linerange":
-      return single(linerangeBatch(frame, fx, color, styles, warnings));
-    case "pointrange":
-      return pointrangeBatches(frame, fx, color, styles, warnings);
-    case "crossbar":
-      return crossbarBatches(frame, fx, color, fill, styles, warnings);
-    case "hex":
-      return single(hexBatch(frame, fx, fill, color, styles, warnings));
-    case "map":
-      // Fortified regions → closed filled paths (ggplot2 geom_map; #808).
-      return single(polygonBatch(frame, fx, color, fill, styles, warnings));
-    case "sf": {
-      // Portable GeoJSON expand (#809 phase 1): kind selected during frame build.
-      const kind = frame.sf?.kind ?? "polygon";
-      if (kind === "point") return single(pointsBatch(frame, fx, color, styles, warnings));
-      if (kind === "line") {
-        return single(lineBatch(frame, fx, color, styles, warnings, { sortByX: false }));
-      }
-      return single(polygonBatch(frame, fx, color, fill, styles, warnings));
-    }
-    case "blank":
-      // ggplot2 geom_blank: train scales, emit no marks / hit targets.
-      return [];
-    default: {
-      // No silent fall-through: `frame.binding.layer.geom` is the post-normalize
-      // union, so a geom with no case above is a compile error here, not a layer
-      // that renders nothing (#1042).
-      const exhaustive: never = geom;
-      throw new Error(`unhandled geom in geometry dispatch: ${String(exhaustive)}`);
-    }
+  const build = getGeomBatchBuilder(geom);
+  if (build === undefined) {
+    throw new PipelineError(
+      "unsupported-param",
+      `/layers/${String(frame.binding.index)}/geom`,
+      `Geom "${geom}" is not registered in this build. Import @ggsvelte/core (full package) rather than @ggsvelte/core/render, or call registerGeomBatch("${geom}", …).`,
+    );
   }
+  return build(frame, fx, color, fill, styles, warnings);
 }

--- a/packages/core/src/pipeline/geometry-register-all.ts
+++ b/packages/core/src/pipeline/geometry-register-all.ts
@@ -1,0 +1,124 @@
+/**
+ * Full geom batch registration for the `@ggsvelte/core` package entry.
+ * Includes specialty geoms (smooth, violin, hex, sf, …) on top of basic.
+ */
+import type { GeometryBatch } from "../scene.js";
+
+import { registerBasicGeomBatches } from "./geometry-register-basic.js";
+import { registerGeomBatch, type GeometryBatchBuilder } from "./geometry-registry.js";
+import { pointsBatch } from "./geometry-points.js";
+import { lineBatch } from "./geometry-paths-line.js";
+import { polygonBatch } from "./geometry-paths-polygon.js";
+import { smoothBatches } from "./geometry-smooth.js";
+import { boxplotBatches } from "./geometry-boxplot.js";
+import { errorbarBatch } from "./geometry-errorbar.js";
+import { edgeRectsBatch, rasterRectsBatch, tileRectsBatch } from "./geometry-edge-rects.js";
+import { finiteSegmentBatch } from "./geometry-segment-finite.js";
+import { violinBatch } from "./geometry-violin.js";
+import { ablineBatch } from "./geometry-abline.js";
+import { curveBatch } from "./geometry-curve.js";
+import { hexBatch } from "./geometry-hex.js";
+import { rugBatch } from "./geometry-rug.js";
+import { crossbarBatches, linerangeBatch, pointrangeBatches } from "./geometry-range.js";
+import { glyphsBatch } from "./geometry-glyphs.js";
+
+function single(batch: GeometryBatch | null): GeometryBatch[] {
+  return batch === null ? [] : [batch];
+}
+
+let registered = false;
+
+export function registerAllGeomBatches(): void {
+  if (registered) return;
+  registered = true;
+  registerBasicGeomBatches();
+
+  registerGeomBatch("qq", (frame, fx, color, _fill, styles, warnings) =>
+    single(pointsBatch(frame, fx, color, styles, warnings)),
+  );
+  registerGeomBatch("dotplot", (frame, fx, color, fill, styles, warnings) =>
+    single(pointsBatch(frame, fx, color, styles, warnings, fill)),
+  );
+
+  const orderedLine: GeometryBatchBuilder = (frame, fx, color, _fill, styles, warnings) =>
+    single(lineBatch(frame, fx, color, styles, warnings));
+  registerGeomBatch("function", orderedLine);
+  registerGeomBatch("qq_line", orderedLine);
+  registerGeomBatch("quantile", orderedLine);
+
+  const stitchLine: GeometryBatchBuilder = (frame, fx, color, _fill, styles, warnings) =>
+    single(lineBatch(frame, fx, color, styles, warnings, { sortByX: false }));
+  registerGeomBatch("contour", stitchLine);
+  registerGeomBatch("density_2d", stitchLine);
+
+  registerGeomBatch("density_2d_filled", (frame, fx, color, fill, styles, warnings) =>
+    single(polygonBatch(frame, fx, color, fill, styles, warnings)),
+  );
+  registerGeomBatch("bin_2d", (frame, fx, color, fill, styles, warnings) =>
+    single(edgeRectsBatch(frame, fx, fill, color, styles, warnings)),
+  );
+  registerGeomBatch("tile", (frame, fx, color, fill, styles, warnings) =>
+    single(tileRectsBatch(frame, fx, fill, color, styles, warnings)),
+  );
+  registerGeomBatch("raster", (frame, fx, _color, fill, styles, warnings) =>
+    single(rasterRectsBatch(frame, fx, fill, styles, warnings)),
+  );
+  registerGeomBatch("spoke", (frame, fx, color, _fill, styles, warnings) =>
+    single(finiteSegmentBatch(frame, fx, color, styles, warnings)),
+  );
+  registerGeomBatch("abline", (frame, fx, color, _fill, styles, warnings) =>
+    single(ablineBatch(frame, fx, color, styles, warnings)),
+  );
+  registerGeomBatch("curve", (frame, fx, color, _fill, styles, warnings) =>
+    single(curveBatch(frame, fx, color, styles, warnings)),
+  );
+  registerGeomBatch("rug", (frame, fx, color, _fill, styles, warnings) =>
+    single(rugBatch(frame, fx, color, styles, warnings)),
+  );
+  registerGeomBatch("polygon", (frame, fx, color, fill, styles, warnings) =>
+    single(polygonBatch(frame, fx, color, fill, styles, warnings)),
+  );
+  registerGeomBatch("map", (frame, fx, color, fill, styles, warnings) =>
+    single(polygonBatch(frame, fx, color, fill, styles, warnings)),
+  );
+
+  const glyphs: GeometryBatchBuilder = (frame, fx, color, fill, styles, warnings) =>
+    single(glyphsBatch(frame, fx, color, fill, styles, warnings));
+  registerGeomBatch("sf_text", glyphs);
+  registerGeomBatch("sf_label", glyphs);
+
+  registerGeomBatch("smooth", (frame, fx, color, fill, styles, warnings) =>
+    smoothBatches(frame, fx, color, fill, styles, warnings),
+  );
+  registerGeomBatch("boxplot", (frame, fx, _color, fill, styles, warnings) =>
+    boxplotBatches(frame, fx, fill, styles, warnings),
+  );
+  registerGeomBatch("errorbar", (frame, fx, color, _fill, styles, warnings) =>
+    single(errorbarBatch(frame, fx, color, styles, warnings)),
+  );
+  registerGeomBatch("violin", (frame, fx, color, fill, styles, warnings) =>
+    single(violinBatch(frame, fx, fill, color, styles, warnings)),
+  );
+  registerGeomBatch("linerange", (frame, fx, color, _fill, styles, warnings) =>
+    single(linerangeBatch(frame, fx, color, styles, warnings)),
+  );
+  registerGeomBatch("pointrange", (frame, fx, color, _fill, styles, warnings) =>
+    pointrangeBatches(frame, fx, color, styles, warnings),
+  );
+  registerGeomBatch("crossbar", (frame, fx, color, fill, styles, warnings) =>
+    crossbarBatches(frame, fx, color, fill, styles, warnings),
+  );
+  registerGeomBatch("hex", (frame, fx, color, fill, styles, warnings) =>
+    single(hexBatch(frame, fx, fill, color, styles, warnings)),
+  );
+  registerGeomBatch("sf", (frame, fx, color, fill, styles, warnings) => {
+    const kind = frame.sf?.kind ?? "polygon";
+    if (kind === "point") return single(pointsBatch(frame, fx, color, styles, warnings));
+    if (kind === "line") {
+      return single(lineBatch(frame, fx, color, styles, warnings, { sortByX: false }));
+    }
+    return single(polygonBatch(frame, fx, color, fill, styles, warnings));
+  });
+}
+
+registerAllGeomBatches();

--- a/packages/core/src/pipeline/geometry-register-basic.ts
+++ b/packages/core/src/pipeline/geometry-register-basic.ts
@@ -1,0 +1,76 @@
+/**
+ * Identity-chart geom batch registration for `@ggsvelte/core/render`.
+ * Covers scatter, line, bar/col, area, rule, text, segment, blank, rect.
+ */
+import type { GeometryBatch } from "../scene.js";
+
+import { registerGeomBatch, type GeometryBatchBuilder } from "./geometry-registry.js";
+import { areaBatch } from "./geometry-paths-area.js";
+import { lineBatch } from "./geometry-paths-line.js";
+import { pointsBatch } from "./geometry-points.js";
+import { rectsBatch } from "./geometry-rects.js";
+import { edgeRectsBatch } from "./geometry-edge-rects.js";
+import { segmentsBatch } from "./geometry-segments.js";
+import { finiteSegmentBatch } from "./geometry-segment-finite.js";
+import { glyphsBatch } from "./geometry-glyphs.js";
+import { ribbonBatches } from "./geometry-ribbon.js";
+
+function single(batch: GeometryBatch | null): GeometryBatch[] {
+  return batch === null ? [] : [batch];
+}
+
+let registered = false;
+
+export function registerBasicGeomBatches(): void {
+  if (registered) return;
+  registered = true;
+
+  const points: GeometryBatchBuilder = (frame, fx, color, _fill, styles, warnings) =>
+    single(pointsBatch(frame, fx, color, styles, warnings));
+  registerGeomBatch("point", points);
+  registerGeomBatch("count", points);
+
+  const lineLike: GeometryBatchBuilder = (frame, fx, color, _fill, styles, warnings) => {
+    const connectNoSort = frame.binding.layer.stat === "connect";
+    return single(
+      lineBatch(frame, fx, color, styles, warnings, connectNoSort ? { sortByX: false } : {}),
+    );
+  };
+  registerGeomBatch("line", lineLike);
+  registerGeomBatch("step", lineLike);
+  registerGeomBatch("path", (frame, fx, color, _fill, styles, warnings) =>
+    single(lineBatch(frame, fx, color, styles, warnings, { sortByX: false })),
+  );
+
+  const rects: GeometryBatchBuilder = (frame, fx, _color, fill, styles, warnings) =>
+    single(rectsBatch(frame, fx, fill, styles, warnings));
+  registerGeomBatch("col", rects);
+  registerGeomBatch("bar", rects);
+
+  const area: GeometryBatchBuilder = (frame, fx, _color, fill, styles, warnings) =>
+    single(areaBatch(frame, fx, fill, styles, warnings));
+  registerGeomBatch("area", area);
+  registerGeomBatch("density", area);
+
+  registerGeomBatch("rule", (frame, fx, color, _fill, styles, warnings) =>
+    single(segmentsBatch(frame, fx, color, styles, warnings)),
+  );
+  registerGeomBatch("segment", (frame, fx, color, _fill, styles, warnings) =>
+    single(finiteSegmentBatch(frame, fx, color, styles, warnings)),
+  );
+
+  const glyphs: GeometryBatchBuilder = (frame, fx, color, fill, styles, warnings) =>
+    single(glyphsBatch(frame, fx, color, fill, styles, warnings));
+  registerGeomBatch("text", glyphs);
+  registerGeomBatch("label", glyphs);
+
+  registerGeomBatch("rect", (frame, fx, color, fill, styles, warnings) =>
+    single(edgeRectsBatch(frame, fx, fill, color, styles, warnings)),
+  );
+  registerGeomBatch("ribbon", (frame, fx, color, fill, styles, warnings) =>
+    ribbonBatches(frame, fx, color, fill, styles, warnings),
+  );
+  registerGeomBatch("blank", () => []);
+}
+
+registerBasicGeomBatches();

--- a/packages/core/src/pipeline/geometry-registry.ts
+++ b/packages/core/src/pipeline/geometry-registry.ts
@@ -29,11 +29,3 @@ export function registerGeomBatch(geom: string, build: GeometryBatchBuilder): vo
 export function getGeomBatchBuilder(geom: string): GeometryBatchBuilder | undefined {
   return builders.get(geom);
 }
-
-export function clearGeomBatchRegistry(): void {
-  builders.clear();
-}
-
-export function registeredGeomBatches(): readonly string[] {
-  return [...builders.keys()];
-}

--- a/packages/core/src/pipeline/geometry-registry.ts
+++ b/packages/core/src/pipeline/geometry-registry.ts
@@ -1,0 +1,39 @@
+/**
+ * Geom → batch builder registry for scene geometry.
+ *
+ * The full package registers every geom; `@ggsvelte/core/render` registers the
+ * common identity chart set (point/line/path/col/bar/area/rule/text/…) so
+ * specialty geoms (smooth ribbon, violin, hex, sf, …) stay out of lean graphs.
+ */
+import type { GeometryBatch } from "../scene.js";
+
+import type { LayerFrame, PipelineWarning, ResolvedColorScale } from "./types.js";
+import type { Frame } from "./geometry-shared.js";
+import type { ResolvedStyleScales } from "./geometry-style.js";
+
+export type GeometryBatchBuilder = (
+  frame: LayerFrame,
+  fx: Frame,
+  color: ResolvedColorScale | null,
+  fill: ResolvedColorScale | null,
+  styles: ResolvedStyleScales,
+  warnings: PipelineWarning[],
+) => GeometryBatch[];
+
+const builders = new Map<string, GeometryBatchBuilder>();
+
+export function registerGeomBatch(geom: string, build: GeometryBatchBuilder): void {
+  builders.set(geom, build);
+}
+
+export function getGeomBatchBuilder(geom: string): GeometryBatchBuilder | undefined {
+  return builders.get(geom);
+}
+
+export function clearGeomBatchRegistry(): void {
+  builders.clear();
+}
+
+export function registeredGeomBatches(): readonly string[] {
+  return [...builders.keys()];
+}

--- a/packages/core/src/pipeline/layout-helpers.ts
+++ b/packages/core/src/pipeline/layout-helpers.ts
@@ -12,7 +12,9 @@ import type {
   TemporalLayoutDomainContext,
   TickFormatter,
 } from "../layout/layout.js";
-import { compileTemporalLabelFormat, formatTime, numberFormatter } from "../layout/format.js";
+import { formatTime } from "../layout/format-time.js";
+import { numberFormatter } from "../layout/format-number.js";
+import { getTemporalRuntime } from "../temporal-runtime.js";
 import { defaultTickFormat, tickStep } from "../layout/ticks.js";
 import { defaultLogTickFormat } from "../layout/ticks.js";
 import { defaultTimeTickFormat } from "../layout/time.js";
@@ -120,7 +122,11 @@ export function makeAxisFormatter(
             kind === "monthDay"
             ? "%b %e"
             : "%Y-%m-%d %H:%M:%S %Z";
-    const format = compileTemporalLabelFormat(defaultPattern, {
+    const compile = getTemporalRuntime()?.compileLabelFormat;
+    if (compile === undefined) {
+      return (value) => formatTime(value as number, defaultPattern);
+    }
+    const format = compile(defaultPattern, {
       kind,
       locale: config?.locale ?? "en-US",
       timezone: config?.timezone ?? "UTC",
@@ -136,7 +142,11 @@ export function makeAxisFormatter(
   }
   if (scale.type === "time") {
     if (config?.dateLabels !== undefined) {
-      const format = compileTemporalLabelFormat(config.dateLabels, {
+      const compile = getTemporalRuntime()?.compileLabelFormat;
+      if (compile === undefined) {
+        return (value) => formatTime(value as number, labels);
+      }
+      const format = compile(config.dateLabels, {
         kind: resolvedTemporalKind ?? config.temporalKind ?? "datetime",
         locale: config.locale ?? "en-US",
         timezone: config.timezone ?? "UTC",

--- a/packages/core/src/pipeline/layout-helpers.ts
+++ b/packages/core/src/pipeline/layout-helpers.ts
@@ -124,7 +124,10 @@ export function makeAxisFormatter(
             : "%Y-%m-%d %H:%M:%S %Z";
     const compile = getTemporalRuntime()?.compileLabelFormat;
     if (compile === undefined) {
-      return (value) => formatTime(value as number, defaultPattern);
+      // formatTime has no %Z; use a zone-free lean default.
+      const leanPattern =
+        kind === "date" ? "%Y-%m-%d" : kind === "time" ? "%H:%M:%S" : "%Y-%m-%d %H:%M:%S";
+      return (value) => formatTime(value as number, leanPattern);
     }
     const format = compile(defaultPattern, {
       kind,

--- a/packages/core/src/pipeline/scale-color-sequential-format.ts
+++ b/packages/core/src/pipeline/scale-color-sequential-format.ts
@@ -48,17 +48,24 @@ function resolveColorLegendFormat(input: {
       compile === undefined
         ? defaultTimeTickFormat
         : compile(temporalKind === "date" ? "%Y-%m-%d" : "%Y-%m-%d %H:%M:%S %Z", options);
-    if (labelFormat !== undefined && compile !== undefined) {
-      try {
-        return {
-          label: compile(labelFormat, options),
-          fullLabel,
-        };
-      } catch {
+    if (labelFormat !== undefined) {
+      if (compile === undefined) {
         warnings.push({
           code: "invalid-label-format",
-          message: `Unrecognized labels format "${labelFormat}" on scales.${name}; using the default.`,
+          message: `Temporal labels format on scales.${name} requires @ggsvelte/core/temporal (or the full package); using the default.`,
         });
+      } else {
+        try {
+          return {
+            label: compile(labelFormat, options),
+            fullLabel,
+          };
+        } catch {
+          warnings.push({
+            code: "invalid-label-format",
+            message: `Unrecognized labels format "${labelFormat}" on scales.${name}; using the default.`,
+          });
+        }
       }
     }
     const label =

--- a/packages/core/src/pipeline/scale-color-sequential-format.ts
+++ b/packages/core/src/pipeline/scale-color-sequential-format.ts
@@ -1,10 +1,11 @@
 /** Semantic color/fill guide label format resolution. */
 import type { ColorScaleSpec, TemporalKind } from "@ggsvelte/spec";
 
-import { compileTemporalLabelFormat, numberFormatter } from "../layout/format.js";
+import { numberFormatter } from "../layout/format-number.js";
 import { defaultTimeTickFormat } from "../layout/time.js";
 import { defaultTickFormat, tickStep } from "../layout/ticks.js";
 import type { SequentialColorScale } from "../scales/color.js";
+import { getTemporalRuntime } from "../temporal-runtime.js";
 
 import type { PipelineWarning } from "./types.js";
 
@@ -42,14 +43,15 @@ function resolveColorLegendFormat(input: {
       kind: temporalKind,
       ...(config?.timezone !== undefined && { timezone: config.timezone }),
     };
-    const fullLabel = compileTemporalLabelFormat(
-      temporalKind === "date" ? "%Y-%m-%d" : "%Y-%m-%d %H:%M:%S %Z",
-      options,
-    );
-    if (labelFormat !== undefined) {
+    const compile = getTemporalRuntime()?.compileLabelFormat;
+    const fullLabel =
+      compile === undefined
+        ? defaultTimeTickFormat
+        : compile(temporalKind === "date" ? "%Y-%m-%d" : "%Y-%m-%d %H:%M:%S %Z", options);
+    if (labelFormat !== undefined && compile !== undefined) {
       try {
         return {
-          label: compileTemporalLabelFormat(labelFormat, options),
+          label: compile(labelFormat, options),
           fullLabel,
         };
       } catch {
@@ -60,12 +62,9 @@ function resolveColorLegendFormat(input: {
       }
     }
     const label =
-      config?.timezone === undefined
+      config?.timezone === undefined || compile === undefined
         ? defaultTimeTickFormat
-        : compileTemporalLabelFormat(
-            temporalKind === "date" ? "%Y-%m-%d" : "%Y-%m-%d %H:%M",
-            options,
-          );
+        : compile(temporalKind === "date" ? "%Y-%m-%d" : "%Y-%m-%d %H:%M", options);
     return { label, fullLabel };
   }
 

--- a/packages/core/src/pipeline/scale-color-values.ts
+++ b/packages/core/src/pipeline/scale-color-values.ts
@@ -1,19 +1,61 @@
 /** Semantic numeric view for sequential/binned color and fill scales. */
-import {
-  parseTemporal,
-  parseTemporalColumn,
-  type ColorScaleSpec,
-  type TemporalKind,
-  type TemporalParserSpec,
-} from "@ggsvelte/spec";
+import type { ColorScaleSpec, TemporalKind, TemporalParserSpec } from "@ggsvelte/spec";
 
 import { encodeKey } from "../scales/state.js";
 import type { CellValue } from "../table.js";
 import { cellToNumber } from "../table.js";
+import { getTemporalRuntime } from "../temporal-runtime.js";
 
 import type { PipelineErrorCode } from "../diagnostics-error-catalog.js";
 
 import { PipelineError, type PipelineWarning } from "./types.js";
+
+function runtimeParseColumn(
+  values: readonly CellValue[],
+  parser: TemporalParserSpec | "auto",
+  options: { timezone?: string; disambiguation?: "compatible" | "earlier" | "later" | "reject" },
+) {
+  const runtime = getTemporalRuntime();
+  if (runtime !== null) return runtime.parseColumn(values, parser, options);
+  const semantic = new Float64Array(values.length);
+  const valid = new Uint8Array(values.length);
+  for (let i = 0; i < values.length; i++) {
+    const n = cellToNumber(values[i]!);
+    semantic[i] = n;
+    if (Number.isFinite(n)) valid[i] = 1;
+  }
+  return {
+    decision: {
+      status: "nominal" as const,
+      parser: null,
+      parserKey: "lite",
+      kind: null,
+      precision: null,
+      evidence: [],
+      nonNullCount: 0,
+      validatedCount: 0,
+      failedCount: 0,
+      candidates: [],
+    },
+    semantic,
+    valid,
+  };
+}
+
+function runtimeParseOne(
+  value: CellValue,
+  parser: TemporalParserSpec,
+  options: { timezone?: string; disambiguation?: "compatible" | "earlier" | "later" | "reject" },
+): { ok: true; epochMs: number } | { ok: false } {
+  const runtime = getTemporalRuntime();
+  if (runtime !== null) {
+    const parsed = runtime.parseColumn([value], parser, options);
+    if (parsed.valid[0] === 1) return { ok: true, epochMs: parsed.semantic[0]! };
+    return { ok: false };
+  }
+  const n = cellToNumber(value);
+  return Number.isFinite(n) ? { ok: true, epochMs: n } : { ok: false };
+}
 
 export interface ColorValueView {
   semantic: Float64Array;
@@ -58,7 +100,7 @@ export function resolveColorValueView(input: {
     ...(config?.timezone !== undefined && { timezone: config.timezone }),
     ...(config?.disambiguation !== undefined && { disambiguation: config.disambiguation }),
   };
-  const parsed = parseTemporalColumn(values, config?.parse ?? "auto", options);
+  const parsed = runtimeParseColumn(values, config?.parse ?? "auto", options);
   const temporal = parsed.decision.status === "temporal";
 
   if (
@@ -145,7 +187,7 @@ export function resolveColorValueView(input: {
           return undefined;
         }
         if (parser === null) return undefined;
-        const result = parseTemporal(value, parser, options);
+        const result = runtimeParseOne(value as CellValue, parser, options);
         return result.ok ? result.epochMs : undefined;
       },
     };

--- a/packages/core/src/pipeline/scale-style-finite.ts
+++ b/packages/core/src/pipeline/scale-style-finite.ts
@@ -1,7 +1,7 @@
 /** Finite style scales: shape / linetype (identity, binned, ordinal, manual). */
 import { LINETYPE_NAMES, POINT_SHAPE_NAMES } from "@ggsvelte/spec";
 
-import { numberFormatter } from "../layout/format.js";
+import { numberFormatter } from "../layout/format-number.js";
 import { disambiguatedLabels } from "../domain-labels.js";
 import type { Linetype, PointShape, StyleScale } from "../scales/style.js";
 import { encodeKey, type ScaleState } from "../scales/state.js";

--- a/packages/core/src/pipeline/scale-style-values.ts
+++ b/packages/core/src/pipeline/scale-style-values.ts
@@ -1,18 +1,59 @@
 /** Semantic numeric view for size/linewidth/alpha sequential and binned scales. */
-import {
-  parseTemporal,
-  parseTemporalColumn,
-  type GuideSpec,
-  type StyleAesthetic,
-  type TemporalKind,
-  type TemporalParserSpec,
-} from "@ggsvelte/spec";
+import type { GuideSpec, StyleAesthetic, TemporalKind, TemporalParserSpec } from "@ggsvelte/spec";
 
 import { encodeKey } from "../scales/state.js";
 import type { CellValue } from "../table.js";
 import { cellToNumber } from "../table.js";
+import { getTemporalRuntime } from "../temporal-runtime.js";
 
 import { PipelineError, type PipelineWarning } from "./types.js";
+
+function runtimeParseColumn(
+  values: readonly CellValue[],
+  parser: TemporalParserSpec | "auto",
+  options: { timezone?: string; disambiguation?: "compatible" | "earlier" | "later" | "reject" },
+) {
+  const runtime = getTemporalRuntime();
+  if (runtime !== null) return runtime.parseColumn(values, parser, options);
+  const semantic = new Float64Array(values.length);
+  const valid = new Uint8Array(values.length);
+  for (let i = 0; i < values.length; i++) {
+    const n = cellToNumber(values[i]!);
+    semantic[i] = n;
+    if (Number.isFinite(n)) valid[i] = 1;
+  }
+  return {
+    decision: {
+      status: "nominal" as const,
+      parser: null,
+      parserKey: "lite",
+      kind: null,
+      precision: null,
+      evidence: [],
+      nonNullCount: 0,
+      validatedCount: 0,
+      failedCount: 0,
+      candidates: [],
+    },
+    semantic,
+    valid,
+  };
+}
+
+function runtimeParseOne(
+  value: CellValue,
+  parser: TemporalParserSpec,
+  options: { timezone?: string; disambiguation?: "compatible" | "earlier" | "later" | "reject" },
+): { ok: true; epochMs: number } | { ok: false } {
+  const runtime = getTemporalRuntime();
+  if (runtime !== null) {
+    const parsed = runtime.parseColumn([value], parser, options);
+    if (parsed.valid[0] === 1) return { ok: true, epochMs: parsed.semantic[0]! };
+    return { ok: false };
+  }
+  const n = cellToNumber(value);
+  return Number.isFinite(n) ? { ok: true, epochMs: n } : { ok: false };
+}
 
 export interface NumericStyleConfig {
   type?: "ordinal" | "sequential" | "binned" | "manual" | "identity";
@@ -86,7 +127,7 @@ export function resolveNumericStyleValueView(input: {
     values.length === 0
       ? (config?.domain ?? (config?.type === "binned" ? config?.breaks : undefined) ?? values)
       : values;
-  const parsed = parseTemporalColumn(temporalColumn, config?.parse ?? "auto", options);
+  const parsed = runtimeParseColumn(temporalColumn, config?.parse ?? "auto", options);
   if (parsed.decision.status !== "temporal") {
     const cause =
       parsed.decision.status === "ambiguous"
@@ -134,7 +175,7 @@ export function resolveNumericStyleValueView(input: {
         return undefined;
       }
       if (parser === null) return undefined;
-      const result = parseTemporal(value, parser, options);
+      const result = runtimeParseOne(value as CellValue, parser, options);
       return result.ok ? result.epochMs : undefined;
     },
   };

--- a/packages/core/src/pipeline/temporal-position.ts
+++ b/packages/core/src/pipeline/temporal-position.ts
@@ -212,7 +212,7 @@ function parseDetachedValues(
   if (runtime !== null) {
     return runtime.parseColumn(values, conversion.parser, conversion.options);
   }
-  // Lean path: ISO via Date.parse; explicit non-auto parsers need full temporal.
+  // Lean path: ISO via cellToNumber; explicit non-auto parsers need full temporal.
   if (conversion.parser !== "auto") {
     throw new Error(
       `Position parser ${JSON.stringify(conversion.parser)} requires @ggsvelte/core (full) or @ggsvelte/core/temporal.`,

--- a/packages/core/src/pipeline/temporal-position.ts
+++ b/packages/core/src/pipeline/temporal-position.ts
@@ -1,10 +1,8 @@
-import {
-  MONTH_DAY_REFERENCE_YEAR,
-  parseTemporalColumn,
-  type PositionScaleSpec,
-  type TemporalDecision,
-  type TemporalParserSpec,
-  type TemporalScaleKind,
+import type {
+  PositionScaleSpec,
+  TemporalDecision,
+  TemporalParserSpec,
+  TemporalScaleKind,
 } from "@ggsvelte/spec";
 
 import {
@@ -17,6 +15,10 @@ import {
   type ParsedColumnOptions,
 } from "../table.js";
 import type { ColumnTransformConfig } from "../scales/transform.js";
+import { getTemporalRuntime } from "../temporal-runtime.js";
+
+/** Leap reference year for month-day projection (matches @ggsvelte/spec). */
+const MONTH_DAY_REFERENCE_YEAR = 2000;
 
 export interface PositionConversionContext {
   /** Effective parser for detached/post-stat values and author scalars. */
@@ -198,18 +200,62 @@ function mapToTimeOfDayMs(values: readonly CellValue[], base: Float64Array): Flo
   return out;
 }
 
+function parseDetachedValues(
+  values: readonly CellValue[],
+  conversion: PositionConversionContext,
+): {
+  decision: TemporalDecision;
+  semantic: Float64Array;
+  valid: Uint8Array;
+} {
+  const runtime = getTemporalRuntime();
+  if (runtime !== null) {
+    return runtime.parseColumn(values, conversion.parser, conversion.options);
+  }
+  // Lean path: ISO via Date.parse; explicit non-auto parsers need full temporal.
+  if (conversion.parser !== "auto") {
+    throw new Error(
+      `Position parser ${JSON.stringify(conversion.parser)} requires @ggsvelte/core (full) or @ggsvelte/core/temporal.`,
+    );
+  }
+  const semantic = conversion.forcedNonTemporal
+    ? cellsToQuantitative(values)
+    : cellsToNumeric(values);
+  const valid = new Uint8Array(values.length);
+  let validated = 0;
+  for (let index = 0; index < semantic.length; index++) {
+    if (Number.isFinite(semantic[index]!)) {
+      valid[index] = 1;
+      validated++;
+    }
+  }
+  const nonNull = values.filter((value) => value !== null);
+  return {
+    decision: {
+      status:
+        validated > 0 && nonNull.every((v) => typeof v === "string" || v instanceof Date)
+          ? "temporal"
+          : "nominal",
+      parser: null,
+      parserKey: "lite:position",
+      kind: null,
+      precision: null,
+      evidence: [],
+      nonNullCount: nonNull.length,
+      validatedCount: validated,
+      failedCount: nonNull.length - validated,
+      candidates: [],
+    },
+    semantic,
+    valid,
+  };
+}
+
 export function positionValuesToNumeric(
   values: readonly CellValue[],
   conversion: PositionConversionContext,
 ): ConvertedPositionValues {
-  const parsed = parseTemporalColumn(values, conversion.parser, {
-    ...(conversion.options.timezone !== undefined && {
-      timezone: conversion.options.timezone,
-    }),
-    ...(conversion.options.disambiguation !== undefined && {
-      disambiguation: conversion.options.disambiguation,
-    }),
-  });
+  const parsed = parseDetachedValues(values, conversion);
   const temporal =
     !conversion.forcedNonTemporal &&
     (conversion.parser !== "auto" ||

--- a/packages/core/src/pipeline/temporal-preflight-annotations.ts
+++ b/packages/core/src/pipeline/temporal-preflight-annotations.ts
@@ -1,5 +1,5 @@
 /** Temporal preflight for rowless annotation intercepts. */
-import { parseTemporalColumn } from "@ggsvelte/spec";
+import { getTemporalRuntime } from "../temporal-runtime.js";
 
 import type { CellValue } from "../table.js";
 
@@ -42,7 +42,11 @@ export function preflightTemporalAnnotations(input: {
         (value) => typeof value !== "number" || !Number.isFinite(value),
       );
       if (sourceValues.length === 0) continue;
-      const decision = parseTemporalColumn(
+      const runtime = getTemporalRuntime();
+      // Lean builds without temporal install cannot preflight annotation
+      // strings; full package installs the runtime for time scales.
+      if (runtime === null) continue;
+      const decision = runtime.parseColumn(
         sourceValues,
         conversion.parser,
         conversion.options,

--- a/packages/core/src/pipeline/temporal-preflight-shared.ts
+++ b/packages/core/src/pipeline/temporal-preflight-shared.ts
@@ -1,5 +1,5 @@
 /** Shared temporal preflight helpers (docs + config assert). */
-import { getTemporalRuntime } from "../temporal-runtime.js";
+import { temporalParserConfigurationError } from "@ggsvelte/spec";
 
 import type { PositionConversionContext } from "./temporal-position.js";
 import { PipelineError } from "./types.js";
@@ -13,26 +13,19 @@ export function assertTemporalConfiguration(
   conversion: PositionConversionContext,
 ): void {
   if (conversion.forcedDiscrete) return;
-  if (conversion.parser === "auto") return;
-  // Explicit parsers require the full temporal runtime.
-  if (getTemporalRuntime() === null) {
-    throw new PipelineError(
-      "temporal-parse-failed",
-      `/scales/${axis}`,
-      `The ${axis} scale uses an explicit temporal parser and requires @ggsvelte/core (full) or @ggsvelte/core/temporal.`,
-      {
-        code: "temporal-parse-failed",
-        severity: "error",
-        path: `/scales/${axis}`,
-        problem: "Temporal parser configuration requires the temporal runtime.",
-        cause: "Lean render entry does not load the Temporal polyfill.",
-        fixes: [
-          { description: "Import @ggsvelte/core or @ggsvelte/core/temporal before rendering." },
-        ],
-        documentationUrl: temporalPreflightDocs("temporal-parse-failed"),
-      },
-    );
-  }
-  // Full config validation (format/timezone) is performed by the Temporal
-  // polyfill path when parsing; invalid formats surface as temporal-parse-failed.
+  const configurationError = temporalParserConfigurationError(
+    conversion.parser,
+    conversion.options,
+  );
+  if (configurationError === null) return;
+  const message = `The ${axis} scale has invalid temporal parser configuration: ${configurationError}.`;
+  throw new PipelineError("temporal-parse-failed", `/scales/${axis}`, message, {
+    code: "temporal-parse-failed",
+    severity: "error",
+    path: `/scales/${axis}`,
+    problem: "Temporal parser configuration is invalid.",
+    cause: message,
+    fixes: [{ description: "Correct the parser format or timezone configuration." }],
+    documentationUrl: temporalPreflightDocs("temporal-parse-failed"),
+  });
 }

--- a/packages/core/src/pipeline/temporal-preflight-shared.ts
+++ b/packages/core/src/pipeline/temporal-preflight-shared.ts
@@ -1,5 +1,5 @@
 /** Shared temporal preflight helpers (docs + config assert). */
-import { temporalParserConfigurationError } from "@ggsvelte/spec";
+import { getTemporalRuntime } from "../temporal-runtime.js";
 
 import type { PositionConversionContext } from "./temporal-position.js";
 import { PipelineError } from "./types.js";
@@ -13,19 +13,26 @@ export function assertTemporalConfiguration(
   conversion: PositionConversionContext,
 ): void {
   if (conversion.forcedDiscrete) return;
-  const configurationError = temporalParserConfigurationError(
-    conversion.parser,
-    conversion.options,
-  );
-  if (configurationError === null) return;
-  const message = `The ${axis} scale has invalid temporal parser configuration: ${configurationError}.`;
-  throw new PipelineError("temporal-parse-failed", `/scales/${axis}`, message, {
-    code: "temporal-parse-failed",
-    severity: "error",
-    path: `/scales/${axis}`,
-    problem: "Temporal parser configuration is invalid.",
-    cause: message,
-    fixes: [{ description: "Correct the parser format or timezone configuration." }],
-    documentationUrl: temporalPreflightDocs("temporal-parse-failed"),
-  });
+  if (conversion.parser === "auto") return;
+  // Explicit parsers require the full temporal runtime.
+  if (getTemporalRuntime() === null) {
+    throw new PipelineError(
+      "temporal-parse-failed",
+      `/scales/${axis}`,
+      `The ${axis} scale uses an explicit temporal parser and requires @ggsvelte/core (full) or @ggsvelte/core/temporal.`,
+      {
+        code: "temporal-parse-failed",
+        severity: "error",
+        path: `/scales/${axis}`,
+        problem: "Temporal parser configuration requires the temporal runtime.",
+        cause: "Lean render entry does not load the Temporal polyfill.",
+        fixes: [
+          { description: "Import @ggsvelte/core or @ggsvelte/core/temporal before rendering." },
+        ],
+        documentationUrl: temporalPreflightDocs("temporal-parse-failed"),
+      },
+    );
+  }
+  // Full config validation (format/timezone) is performed by the Temporal
+  // polyfill path when parsing; invalid formats surface as temporal-parse-failed.
 }

--- a/packages/core/src/pipeline/temporal-preflight-shared.ts
+++ b/packages/core/src/pipeline/temporal-preflight-shared.ts
@@ -1,6 +1,8 @@
 /** Shared temporal preflight helpers (docs + config assert). */
 import { temporalParserConfigurationError } from "@ggsvelte/spec";
 
+import { getTemporalRuntime } from "../temporal-runtime.js";
+
 import type { PositionConversionContext } from "./temporal-position.js";
 import { PipelineError } from "./types.js";
 
@@ -13,6 +15,26 @@ export function assertTemporalConfiguration(
   conversion: PositionConversionContext,
 ): void {
   if (conversion.forcedDiscrete) return;
+  if (conversion.parser === "auto") return;
+  // Explicit parsers require the full temporal runtime.
+  if (getTemporalRuntime() === null) {
+    throw new PipelineError(
+      "temporal-parse-failed",
+      `/scales/${axis}`,
+      `The ${axis} scale uses an explicit temporal parser and requires @ggsvelte/core (full) or @ggsvelte/core/temporal.`,
+      {
+        code: "temporal-parse-failed",
+        severity: "error",
+        path: `/scales/${axis}`,
+        problem: "Temporal parser configuration requires the temporal runtime.",
+        cause: "Lean render entry does not load the Temporal polyfill.",
+        fixes: [
+          { description: "Import @ggsvelte/core or @ggsvelte/core/temporal before rendering." },
+        ],
+        documentationUrl: temporalPreflightDocs("temporal-parse-failed"),
+      },
+    );
+  }
   const configurationError = temporalParserConfigurationError(
     conversion.parser,
     conversion.options,

--- a/packages/core/src/render-entry.ts
+++ b/packages/core/src/render-entry.ts
@@ -8,6 +8,7 @@
  * Full grammar: import from `@ggsvelte/core` instead.
  */
 import "./pipeline/geometry-register-basic.js";
+import "./pipeline/frame-stats-register-basic.js";
 
 export { batchMarkCount, CANVAS_AUTO_THRESHOLD, PipelineError } from "./pipeline/public-api.js";
 export { runPipeline } from "./pipeline/run-pipeline.js";

--- a/packages/core/src/render-entry.ts
+++ b/packages/core/src/render-entry.ts
@@ -1,0 +1,59 @@
+/**
+ * Lean render entry (`@ggsvelte/core/render`).
+ *
+ * Pipeline + SVG string renderer with basic geom registration only.
+ * Does not register heavy stats (smooth/loess, density_2d, sf, …) or specialty
+ * geoms. Identity charts (scatter, line, bar, area) stay on this graph.
+ *
+ * Full grammar: import from `@ggsvelte/core` instead.
+ */
+import "./pipeline/geometry-register-basic.js";
+
+export { batchMarkCount, CANVAS_AUTO_THRESHOLD, PipelineError } from "./pipeline/public-api.js";
+export { runPipeline } from "./pipeline/run-pipeline.js";
+export type {
+  Advisory,
+  AxisValueFormatter,
+  LayerBackend,
+  MappedField,
+  NamedData,
+  PipelineWarning,
+  RenderModel,
+  ResolvedColorScale,
+  RunOptions,
+  ScaleDecision,
+  ScaleDiagnostic,
+  ScaleDiagnosticFix,
+  ScaleDomainSnapshot,
+  TrainedScales,
+} from "./pipeline/public-api.js";
+
+export {
+  countMarks,
+  pathData,
+  renderToSVGString,
+  sceneLabel,
+  sceneToSVGString,
+} from "./render-svg.js";
+export type { RenderSVGOptions } from "./render-svg.js";
+
+export type {
+  GeometryBatch,
+  GlyphsBatch,
+  PathsBatch,
+  PointsBatch,
+  RectsBatch,
+  Scene,
+  SceneAxis,
+  SceneDiscreteLegend,
+  SceneLegend,
+  SceneLegendEntry,
+  ScenePanel,
+  SceneRampLegend,
+  SceneStepsLegend,
+  SceneTick,
+  SegmentsBatch,
+} from "./scene.js";
+
+export { registerStatFrame } from "./pipeline/frame-stats-registry.js";
+export { registerGeomBatch } from "./pipeline/geometry-registry.js";

--- a/packages/core/src/render-svg.ts
+++ b/packages/core/src/render-svg.ts
@@ -26,8 +26,12 @@
  */
 import type { GGBuilder, SpecInput } from "@ggsvelte/spec";
 
-import type { RenderModel, RunOptions } from "./pipeline.js";
-import { PipelineError, runPipeline } from "./pipeline.js";
+import type { RenderModel, RunOptions } from "./pipeline/public-api.js";
+import { PipelineError } from "./pipeline/public-api.js";
+// Import runPipeline without the full pipeline barrel (which registers every
+// geom/stat). Entry points that need the full grammar import `./pipeline.js`
+// or `./index.js` first; `@ggsvelte/core/render` registers basic geoms only.
+import { runPipeline } from "./pipeline/run-pipeline.js";
 import { countMarks } from "./render-svg-marks.js";
 import { sceneToSVGString } from "./render-svg-scene.js";
 

--- a/packages/core/src/table-coerce.ts
+++ b/packages/core/src/table-coerce.ts
@@ -1,20 +1,18 @@
 /**
  * Field-type inference and numeric coercion helpers (no table instance).
  *
- * Intentionally free of `@js-temporal/polyfill`. ISO-like strings use
- * `Date.parse`; full temporal registry parsing lives behind the optional
- * temporal runtime (`installTemporal`).
+ * Free of `@js-temporal/polyfill` and free of the global date-string parser
+ * (temporal-source-gate). ISO-like strings use {@link isoEpochMs}; full
+ * temporal registry parsing lives behind the optional temporal runtime
+ * (`installTemporal`).
  */
+import { isIsoLikeString, isoEpochMs } from "./iso-epoch.js";
+import { getTemporalRuntime } from "./temporal-runtime.js";
 import type { CellValue, Discreteness, FieldType } from "./table-types.js";
-
-/** Loose ISO-8601 date/datetime detector (UTC and offset forms). */
-const ISO_LIKE =
-  /^\d{4}-\d{2}-\d{2}(?:[T ]\d{2}:\d{2}(?::\d{2}(?:\.\d{1,3})?)?(?:Z|[+-]\d{2}:?\d{2})?)?$/;
 
 /** Strict-enough ISO predicate retained for public import compatibility. */
 export function isISODateString(value: string): boolean {
-  if (!ISO_LIKE.test(value)) return false;
-  return Number.isFinite(Date.parse(value));
+  return isIsoLikeString(value);
 }
 
 export function nonTemporalFieldType(column: readonly CellValue[]): FieldType {
@@ -43,11 +41,16 @@ export function nonTemporalFieldType(column: readonly CellValue[]): FieldType {
 }
 
 /**
- * Deterministic field type inference without the Temporal polyfill.
- * String columns that look like ISO dates are temporal; mixed/other strings
- * stay nominal. Full registry inference is available after installTemporal().
+ * Deterministic field type inference. With the temporal runtime installed
+ * (full package / tests), uses the shared strict registry. On the lean
+ * render path, only ISO-like strings and Date values count as temporal.
  */
 export function inferFieldType(column: readonly CellValue[]): FieldType {
+  const runtime = getTemporalRuntime();
+  if (runtime !== null) {
+    const decision = runtime.parseColumn(column, "auto", {}).decision;
+    return decision.status === "temporal" ? "temporal" : nonTemporalFieldType(column);
+  }
   let sawIso = false;
   let sawNonIsoString = false;
   let sawNumber = false;
@@ -55,7 +58,7 @@ export function inferFieldType(column: readonly CellValue[]): FieldType {
   for (const value of column) {
     if (value === null) continue;
     if (typeof value === "string") {
-      if (isISODateString(value)) sawIso = true;
+      if (isIsoLikeString(value)) sawIso = true;
       else sawNonIsoString = true;
       continue;
     }
@@ -88,10 +91,8 @@ export function cellToNumber(value: CellValue): number {
   if (value instanceof Date) return value.getTime();
   if (typeof value === "boolean") return value ? 1 : 0;
   if (typeof value === "string") {
-    if (ISO_LIKE.test(value)) {
-      const epoch = Date.parse(value);
-      if (Number.isFinite(epoch)) return epoch;
-    }
+    const epoch = isoEpochMs(value);
+    if (epoch !== undefined) return epoch;
     const numeric = Number(value);
     return value.trim() === "" ? Number.NaN : numeric;
   }

--- a/packages/core/src/table-coerce.ts
+++ b/packages/core/src/table-coerce.ts
@@ -1,13 +1,20 @@
 /**
  * Field-type inference and numeric coercion helpers (no table instance).
+ *
+ * Intentionally free of `@js-temporal/polyfill`. ISO-like strings use
+ * `Date.parse`; full temporal registry parsing lives behind the optional
+ * temporal runtime (`installTemporal`).
  */
-import { inferTemporalColumn, parseTemporal } from "@ggsvelte/spec";
-
 import type { CellValue, Discreteness, FieldType } from "./table-types.js";
 
-/** Strict ISO predicate retained for public import compatibility. */
+/** Loose ISO-8601 date/datetime detector (UTC and offset forms). */
+const ISO_LIKE =
+  /^\d{4}-\d{2}-\d{2}(?:[T ]\d{2}:\d{2}(?::\d{2}(?:\.\d{1,3})?)?(?:Z|[+-]\d{2}:?\d{2})?)?$/;
+
+/** Strict-enough ISO predicate retained for public import compatibility. */
 export function isISODateString(value: string): boolean {
-  return parseTemporal(value, "iso").ok;
+  if (!ISO_LIKE.test(value)) return false;
+  return Number.isFinite(Date.parse(value));
 }
 
 export function nonTemporalFieldType(column: readonly CellValue[]): FieldType {
@@ -35,10 +42,40 @@ export function nonTemporalFieldType(column: readonly CellValue[]): FieldType {
   return "quantitative";
 }
 
-/** Deterministic field type inference using the shared temporal registry. */
+/**
+ * Deterministic field type inference without the Temporal polyfill.
+ * String columns that look like ISO dates are temporal; mixed/other strings
+ * stay nominal. Full registry inference is available after installTemporal().
+ */
 export function inferFieldType(column: readonly CellValue[]): FieldType {
-  const temporal = inferTemporalColumn(column);
-  return temporal.status === "temporal" ? "temporal" : nonTemporalFieldType(column);
+  let sawIso = false;
+  let sawNonIsoString = false;
+  let sawNumber = false;
+  let sawDate = false;
+  for (const value of column) {
+    if (value === null) continue;
+    if (typeof value === "string") {
+      if (isISODateString(value)) sawIso = true;
+      else sawNonIsoString = true;
+      continue;
+    }
+    if (typeof value === "boolean") return "nominal";
+    if (typeof value === "number") {
+      sawNumber = true;
+      continue;
+    }
+    if (value instanceof Date && Number.isFinite(value.getTime())) {
+      sawDate = true;
+      continue;
+    }
+    return "nominal";
+  }
+  if (sawNonIsoString) return "nominal";
+  if (sawIso && !sawNumber) return "temporal";
+  if (sawDate && !sawNumber && !sawIso) return "temporal";
+  if (sawIso && sawNumber) return "nominal";
+  if (sawDate && sawNumber) return "nominal";
+  return "quantitative";
 }
 
 export function discretenessOf(type: FieldType): Discreteness {
@@ -51,8 +88,10 @@ export function cellToNumber(value: CellValue): number {
   if (value instanceof Date) return value.getTime();
   if (typeof value === "boolean") return value ? 1 : 0;
   if (typeof value === "string") {
-    const iso = parseTemporal(value, "iso");
-    if (iso.ok) return iso.epochMs;
+    if (ISO_LIKE.test(value)) {
+      const epoch = Date.parse(value);
+      if (Number.isFinite(epoch)) return epoch;
+    }
     const numeric = Number(value);
     return value.trim() === "" ? Number.NaN : numeric;
   }

--- a/packages/core/src/table.ts
+++ b/packages/core/src/table.ts
@@ -8,11 +8,7 @@
  * Free helpers live in table-coerce.ts; public types in table-types.ts.
  * This module re-exports both for a stable `./table.js` import path.
  */
-import {
-  canonicalTemporalParserKey,
-  parseTemporalColumn,
-  type TemporalParserSpec,
-} from "@ggsvelte/spec";
+import type { TemporalParserSpec } from "@ggsvelte/spec";
 
 import {
   COLUMN_TRANSFORM_EVENT,
@@ -23,8 +19,10 @@ import {
   cellsToNumeric,
   cellsToQuantitative,
   discretenessOf,
+  isISODateString,
   nonTemporalFieldType,
 } from "./table-coerce.js";
+import { getTemporalRuntime } from "./temporal-runtime.js";
 import type {
   CellValue,
   Columns,
@@ -71,15 +69,112 @@ function optionsKey(options: ParsedColumnOptions): string {
   ].join("|");
 }
 
-function parseOptions(options: ParsedColumnOptions) {
-  return {
-    ...(options.timezone !== undefined && { timezone: options.timezone }),
-    ...(options.disambiguation !== undefined && { disambiguation: options.disambiguation }),
-  };
+function requestKey(parser: TemporalParserSpec | "auto", options: ParsedColumnOptions): string {
+  const runtime = getTemporalRuntime();
+  let parserPart = "auto";
+  if (parser !== "auto") {
+    parserPart = runtime === null ? JSON.stringify(parser) : runtime.parserKey(parser);
+  }
+  return `${parserPart}|${optionsKey(options)}`;
 }
 
-function requestKey(parser: TemporalParserSpec | "auto", options: ParsedColumnOptions): string {
-  return `${parser === "auto" ? "auto" : canonicalTemporalParserKey(parser)}|${optionsKey(options)}`;
+/** Polyfill-free auto parse for the lean render entry. */
+function liteParseColumn(
+  raw: readonly CellValue[],
+  parser: TemporalParserSpec | "auto",
+  options: ParsedColumnOptions,
+): {
+  decision: ParsedColumnView["decision"];
+  semantic: Float64Array;
+  valid: Uint8Array;
+  kind: ParsedColumnView["temporalKind"];
+  precision: ParsedColumnView["temporalPrecision"];
+} {
+  if (parser !== "auto") {
+    throw new Error(
+      `Explicit temporal parser ${JSON.stringify(parser)} requires @ggsvelte/core (full) or @ggsvelte/core/temporal.`,
+    );
+  }
+  const inferTemporal = options.inferTemporal !== false;
+  const nonNull = raw.filter((value) => value !== null);
+  if (!inferTemporal) {
+    const { semantic, valid } = fallbackNumeric(raw, false);
+    return {
+      decision: {
+        status: "nominal",
+        parser: null,
+        parserKey: "lite:numeric-only",
+        kind: null,
+        precision: null,
+        evidence: [],
+        nonNullCount: nonNull.length,
+        validatedCount: 0,
+        failedCount: 0,
+        candidates: [],
+      },
+      semantic,
+      valid,
+      kind: undefined,
+      precision: undefined,
+    };
+  }
+  // Detect ISO-like string columns without the Temporal polyfill.
+  let isoCount = 0;
+  let stringCount = 0;
+  for (const value of raw) {
+    if (typeof value !== "string") continue;
+    stringCount++;
+    if (isISODateString(value)) isoCount++;
+  }
+  const temporal = stringCount > 0 && isoCount === stringCount;
+  if (!temporal) {
+    const { semantic, valid } = fallbackNumeric(raw, true);
+    return {
+      decision: {
+        status: "nominal",
+        parser: null,
+        parserKey: "lite:auto",
+        kind: null,
+        precision: null,
+        evidence: [],
+        nonNullCount: nonNull.length,
+        validatedCount: 0,
+        failedCount: 0,
+        candidates: [],
+      },
+      semantic,
+      valid,
+      kind: undefined,
+      precision: undefined,
+    };
+  }
+  const semantic = cellsToNumeric(raw);
+  const valid = new Uint8Array(raw.length);
+  let validatedCount = 0;
+  for (let index = 0; index < semantic.length; index++) {
+    if (Number.isFinite(semantic[index]!)) {
+      valid[index] = 1;
+      validatedCount++;
+    }
+  }
+  return {
+    decision: {
+      status: "temporal",
+      parser: "iso",
+      parserKey: "lite:iso",
+      kind: "date",
+      precision: "date",
+      evidence: nonNull.slice(0, 5) as (string | number | boolean | null)[],
+      nonNullCount: nonNull.length,
+      validatedCount,
+      failedCount: nonNull.length - validatedCount,
+      candidates: ["iso"],
+    },
+    semantic,
+    valid,
+    kind: "date",
+    precision: "date",
+  };
 }
 
 function fallbackNumeric(
@@ -206,7 +301,11 @@ export class ColumnTable {
     }
 
     const raw = this.column(name);
-    const parsed = parseTemporalColumn(raw, parser, parseOptions(options));
+    const runtime = getTemporalRuntime();
+    const parsed =
+      runtime === null
+        ? liteParseColumn(raw, parser, options)
+        : runtime.parseColumn(raw, parser, options);
     const inferTemporal = options.inferTemporal !== false;
     const temporal = parser !== "auto" || (inferTemporal && parsed.decision.status === "temporal");
     const values = temporal
@@ -217,10 +316,12 @@ export class ColumnTable {
       semantic: values.semantic,
       valid: values.valid,
       parserKey: `${parsed.decision.parserKey}|${optionsKey(options)}`,
-      ...(parsed.decision.kind !== null && { temporalKind: parsed.decision.kind }),
-      ...(parsed.decision.precision !== null && {
-        temporalPrecision: parsed.decision.precision,
-      }),
+      ...(parsed.decision.kind !== null &&
+        parsed.decision.kind !== undefined && { temporalKind: parsed.decision.kind }),
+      ...(parsed.decision.precision !== null &&
+        parsed.decision.precision !== undefined && {
+          temporalPrecision: parsed.decision.precision,
+        }),
       decision: parsed.decision,
     };
     this.#parsedCache.set(cacheKey, view);

--- a/packages/core/src/table.ts
+++ b/packages/core/src/table.ts
@@ -19,9 +19,9 @@ import {
   cellsToNumeric,
   cellsToQuantitative,
   discretenessOf,
-  isISODateString,
   nonTemporalFieldType,
 } from "./table-coerce.js";
+import { isIsoLikeString } from "./iso-epoch.js";
 import { getTemporalRuntime } from "./temporal-runtime.js";
 import type {
   CellValue,
@@ -124,7 +124,7 @@ function liteParseColumn(
   for (const value of raw) {
     if (typeof value !== "string") continue;
     stringCount++;
-    if (isISODateString(value)) isoCount++;
+    if (isIsoLikeString(value)) isoCount++;
   }
   const temporal = stringCount > 0 && isoCount === stringCount;
   if (!temporal) {

--- a/packages/core/src/table.ts
+++ b/packages/core/src/table.ts
@@ -21,8 +21,8 @@ import {
   discretenessOf,
   nonTemporalFieldType,
 } from "./table-coerce.js";
-import { isIsoLikeString } from "./iso-epoch.js";
-import { getTemporalRuntime } from "./temporal-runtime.js";
+import { isIsoLikeString, isoHasClock } from "./iso-epoch.js";
+import { getTemporalRuntime, temporalRuntimeGeneration } from "./temporal-runtime.js";
 import type {
   CellValue,
   Columns,
@@ -75,7 +75,8 @@ function requestKey(parser: TemporalParserSpec | "auto", options: ParsedColumnOp
   if (parser !== "auto") {
     parserPart = runtime === null ? JSON.stringify(parser) : runtime.parserKey(parser);
   }
-  return `${parserPart}|${optionsKey(options)}`;
+  // Include runtime generation so lite→full install does not reuse lean caches.
+  return `${parserPart}|rt${String(temporalRuntimeGeneration())}|${optionsKey(options)}`;
 }
 
 /** Polyfill-free auto parse for the lean render entry. */
@@ -121,10 +122,14 @@ function liteParseColumn(
   // Detect ISO-like string columns without the Temporal polyfill.
   let isoCount = 0;
   let stringCount = 0;
+  let sawClock = false;
   for (const value of raw) {
     if (typeof value !== "string") continue;
     stringCount++;
-    if (isIsoLikeString(value)) isoCount++;
+    if (isIsoLikeString(value)) {
+      isoCount++;
+      if (isoHasClock(value)) sawClock = true;
+    }
   }
   const temporal = stringCount > 0 && isoCount === stringCount;
   if (!temporal) {
@@ -157,13 +162,15 @@ function liteParseColumn(
       validatedCount++;
     }
   }
+  const kind = sawClock ? "datetime" : "date";
+  const precision = sawClock ? "second" : "date";
   return {
     decision: {
       status: "temporal",
       parser: "iso",
       parserKey: "lite:iso",
-      kind: "date",
-      precision: "date",
+      kind,
+      precision,
       evidence: nonNull.slice(0, 5) as (string | number | boolean | null)[],
       nonNullCount: nonNull.length,
       validatedCount,
@@ -172,8 +179,8 @@ function liteParseColumn(
     },
     semantic,
     valid,
-    kind: "date",
-    precision: "date",
+    kind,
+    precision,
   };
 }
 

--- a/packages/core/src/temporal-entry.ts
+++ b/packages/core/src/temporal-entry.ts
@@ -1,0 +1,21 @@
+/**
+ * Temporal entry (`@ggsvelte/core/temporal`).
+ *
+ * Installs the Temporal polyfill parse path and temporal axis planner, then
+ * re-exports guide helpers for apps that started from `@ggsvelte/core/render`
+ * and later need time scales.
+ */
+import "./install-temporal.js";
+
+export { installTemporal } from "./install-temporal.js";
+export { installTemporalRuntime, getTemporalRuntime } from "./temporal-runtime.js";
+
+export {
+  compileTemporalLabelFormat,
+  formatTemporalTickSequence,
+  formatTime,
+} from "./layout/format.js";
+export type { TemporalLabelFormatOptions, TemporalTickLabel } from "./layout/format.js";
+
+export { planTemporalAxis } from "./layout/temporal-guide.js";
+export type { AxisGuidePlan, TemporalAxisPlanInput } from "./layout/temporal-guide.js";

--- a/packages/core/src/temporal-runtime.ts
+++ b/packages/core/src/temporal-runtime.ts
@@ -12,32 +12,24 @@ import type { AxisGuidePlan } from "./layout/temporal-guide.js";
 import type { TemporalAxisPlanInput } from "./layout/temporal-axis-types.js";
 import type { CellValue, ParsedColumnOptions, ParsedColumnView } from "./table-types.js";
 
-export type TemporalColumnParser = (
-  raw: readonly CellValue[],
-  parser: TemporalParserSpec | "auto",
-  options: ParsedColumnOptions,
-) => {
-  readonly decision: ParsedColumnView["decision"];
-  readonly semantic: Float64Array;
-  readonly valid: Uint8Array;
-  readonly kind: ParsedColumnView["temporalKind"];
-  readonly precision: ParsedColumnView["temporalPrecision"];
-};
-
-export type TemporalAxisPlanner = (input: TemporalAxisPlanInput) => AxisGuidePlan;
-
-export type TemporalParserKeyFn = (parser: TemporalParserSpec) => string;
-
-export type TemporalLabelCompiler = (
-  pattern: string,
-  options: { kind: string; locale?: string; timezone?: string },
-) => (value: number) => string;
-
 export interface TemporalRuntime {
-  readonly parseColumn: TemporalColumnParser;
-  readonly planAxis: TemporalAxisPlanner;
-  readonly parserKey: TemporalParserKeyFn;
-  readonly compileLabelFormat: TemporalLabelCompiler;
+  readonly parseColumn: (
+    raw: readonly CellValue[],
+    parser: TemporalParserSpec | "auto",
+    options: ParsedColumnOptions,
+  ) => {
+    readonly decision: ParsedColumnView["decision"];
+    readonly semantic: Float64Array;
+    readonly valid: Uint8Array;
+    readonly kind: ParsedColumnView["temporalKind"];
+    readonly precision: ParsedColumnView["temporalPrecision"];
+  };
+  readonly planAxis: (input: TemporalAxisPlanInput) => AxisGuidePlan;
+  readonly parserKey: (parser: TemporalParserSpec) => string;
+  readonly compileLabelFormat: (
+    pattern: string,
+    options: { kind: string; locale?: string; timezone?: string },
+  ) => (value: number) => string;
 }
 
 let runtime: TemporalRuntime | null = null;

--- a/packages/core/src/temporal-runtime.ts
+++ b/packages/core/src/temporal-runtime.ts
@@ -1,0 +1,61 @@
+/**
+ * Optional temporal runtime hooks.
+ *
+ * The lean `@ggsvelte/core/render` entry leaves these unset so chart bundles
+ * that only need numeric axes never load `@js-temporal/polyfill` or the full
+ * temporal guide planner. The full package entry (and `@ggsvelte/core/temporal`)
+ * call {@link installTemporalRuntime}.
+ */
+import type { TemporalParserSpec } from "@ggsvelte/spec";
+
+import type { AxisGuidePlan } from "./layout/temporal-guide.js";
+import type { TemporalAxisPlanInput } from "./layout/temporal-axis-types.js";
+import type { CellValue, ParsedColumnOptions, ParsedColumnView } from "./table-types.js";
+
+export type TemporalColumnParser = (
+  raw: readonly CellValue[],
+  parser: TemporalParserSpec | "auto",
+  options: ParsedColumnOptions,
+) => {
+  readonly decision: ParsedColumnView["decision"];
+  readonly semantic: Float64Array;
+  readonly valid: Uint8Array;
+  readonly kind: ParsedColumnView["temporalKind"];
+  readonly precision: ParsedColumnView["temporalPrecision"];
+};
+
+export type TemporalAxisPlanner = (input: TemporalAxisPlanInput) => AxisGuidePlan;
+
+export type TemporalParserKeyFn = (parser: TemporalParserSpec) => string;
+
+export type TemporalLabelCompiler = (
+  pattern: string,
+  options: { kind: string; locale?: string; timezone?: string },
+) => (value: number) => string;
+
+export interface TemporalRuntime {
+  readonly parseColumn: TemporalColumnParser;
+  readonly planAxis: TemporalAxisPlanner;
+  readonly parserKey: TemporalParserKeyFn;
+  readonly compileLabelFormat: TemporalLabelCompiler;
+}
+
+let runtime: TemporalRuntime | null = null;
+
+/** Install full temporal semantics (polyfill + guide planner). Idempotent. */
+export function installTemporalRuntime(next: TemporalRuntime): void {
+  runtime = next;
+}
+
+export function getTemporalRuntime(): TemporalRuntime | null {
+  return runtime;
+}
+
+export function requireTemporalRuntime(feature: string): TemporalRuntime {
+  if (runtime === null) {
+    throw new Error(
+      `${feature} requires the temporal runtime. Import @ggsvelte/core (full) or @ggsvelte/core/temporal before rendering time scales.`,
+    );
+  }
+  return runtime;
+}

--- a/packages/core/src/temporal-runtime.ts
+++ b/packages/core/src/temporal-runtime.ts
@@ -33,14 +33,22 @@ export interface TemporalRuntime {
 }
 
 let runtime: TemporalRuntime | null = null;
+/** Bumps when the runtime is installed so parse caches can invalidate. */
+let runtimeGeneration = 0;
 
 /** Install full temporal semantics (polyfill + guide planner). Idempotent. */
 export function installTemporalRuntime(next: TemporalRuntime): void {
+  if (runtime === null) runtimeGeneration += 1;
   runtime = next;
 }
 
 export function getTemporalRuntime(): TemporalRuntime | null {
   return runtime;
+}
+
+/** Cache-key fragment: changes when temporal install status changes. */
+export function temporalRuntimeGeneration(): number {
+  return runtimeGeneration;
 }
 
 export function requireTemporalRuntime(feature: string): TemporalRuntime {

--- a/packages/spec/package.json
+++ b/packages/spec/package.json
@@ -35,6 +35,10 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
+    "./portable": {
+      "types": "./dist/portable-entry.d.ts",
+      "default": "./dist/portable-entry.js"
+    },
     "./schema/v0.json": "./schema/v0.json"
   },
   "publishConfig": {

--- a/packages/spec/src/builder-core.ts
+++ b/packages/spec/src/builder-core.ts
@@ -11,7 +11,6 @@ import {
   type CoordSfOptions,
   type CoordTransformOptions,
 } from "./coord-helpers.js";
-import { SpecValidationError } from "./errors.js";
 import type { AesInput, FacetInput, LayerInput, SpecInput } from "./normalize.js";
 import { normalize } from "./normalize.js";
 import {
@@ -33,7 +32,6 @@ import type {
   ThemeName,
   ThemeSpec,
 } from "./schema.js";
-import { validate } from "./validate.js";
 import type { GGBuilder } from "./builder.js";
 
 interface BuilderState {
@@ -192,11 +190,12 @@ export class GGBuilderCore {
   }
 
   /**
-   * Compile to a canonical PortableSpec: normalize (canonicalize channel
-   * shorthand, fill geom defaults, resolve aes inheritance) then validate.
-   * Throws SpecValidationError when the result does not satisfy the schema.
+   * Normalize only: channel shorthand, geom defaults, aes inheritance.
+   * Does not load TypeBox — the render pipeline runs structural gates; agents
+   * that need full schema validation should call {@link spec} (full package)
+   * or `validate()` explicitly.
    */
-  spec(): PortableSpec {
+  toPortable(): PortableSpec {
     const {
       data,
       aes: plotAes,
@@ -237,9 +236,6 @@ export class GGBuilderCore {
       ...(width !== undefined && { width }),
       ...(height !== undefined && { height }),
     };
-    const normalized = normalize(input);
-    const result = validate(normalized);
-    if (!result.ok) throw new SpecValidationError(result.errors);
-    return result.spec;
+    return normalize(input);
   }
 }

--- a/packages/spec/src/builder.ts
+++ b/packages/spec/src/builder.ts
@@ -24,6 +24,9 @@ import { toAuthoringDataRef, type DataInput } from "./builder-data.js";
 import { GGBuilderCore } from "./builder-core.js";
 import { WithBuilderGeoms } from "./builder-geoms.js";
 import { WithBuilderScales } from "./builder-scales.js";
+import { SpecValidationError } from "./errors.js";
+import type { PortableSpec } from "./schema.js";
+import { validate } from "./validate.js";
 
 export type {
   AuthoringCellValue,
@@ -93,8 +96,24 @@ export function aes(mapping: AesInput): AesInput {
   return mapping;
 }
 
-/** Immutable plot builder. Construct with gg(); finish with .spec(). */
-export class GGBuilder extends WithBuilderScales(WithBuilderGeoms(GGBuilderCore)) {}
+/**
+ * Immutable plot builder. Construct with gg(); finish with .spec() (validates)
+ * or .toPortable() (normalize only, no TypeBox).
+ */
+export class GGBuilder extends WithBuilderScales(WithBuilderGeoms(GGBuilderCore)) {
+  /**
+   * Compile to a canonical PortableSpec: normalize then TypeBox-validate.
+   * Throws SpecValidationError when the result does not satisfy the schema.
+   * Prefer {@link toPortable} on chart render paths that already run the
+   * pipeline structural gate — avoids loading typebox/compile into the bundle.
+   */
+  spec(): PortableSpec {
+    const portable = this.toPortable();
+    const result = validate(portable);
+    if (!result.ok) throw new SpecValidationError(result.errors);
+    return result.spec;
+  }
+}
 
 /** Start a plot: gg(data, aes({ x: 'displ', y: 'hwy' })).geomPoint().spec(). */
 export function gg(data?: DataInput, mapping?: AesInput): GGBuilder {

--- a/packages/spec/src/portable-entry.ts
+++ b/packages/spec/src/portable-entry.ts
@@ -1,0 +1,62 @@
+/**
+ * Lean portable builder entry (`@ggsvelte/spec/portable`).
+ *
+ * Exports the fluent builder without TypeBox: `.spec()` is an alias of
+ * `.toPortable()` (normalize only). Use this from chart render bundles;
+ * keep `@ggsvelte/spec` + `.spec()` / `validate()` for agent authoring.
+ */
+import type { AesInput } from "./normalize.js";
+import { toAuthoringDataRef, type DataInput } from "./builder-data.js";
+import { GGBuilderCore } from "./builder-core.js";
+import { WithBuilderGeoms } from "./builder-geoms.js";
+import { WithBuilderScales } from "./builder-scales.js";
+import type { PortableSpec } from "./schema.js";
+
+export type {
+  AuthoringCellValue,
+  AuthoringColumns,
+  AuthoringDataRef,
+  AuthoringRows,
+  DataInput,
+} from "./builder-data.js";
+
+export type {
+  GeomAreaOptions,
+  GeomBarOptions,
+  GeomBoxplotOptions,
+  GeomColOptions,
+  GeomDensityOptions,
+  GeomHistogramOptions,
+  GeomLineOptions,
+  GeomPointOptions,
+  GeomSmoothOptions,
+  GeomTextOptions,
+} from "./builder-options.js";
+
+export { normalize } from "./normalize.js";
+export type { AesInput, SpecInput } from "./normalize.js";
+
+/** Identity helper for aesthetic mappings (same as full package `aes`). */
+export function aes(mapping: AesInput): AesInput {
+  return mapping;
+}
+
+/**
+ * Portable builder: `.spec()` and `.toPortable()` both normalize only.
+ * Full schema validation: import `validate` from `@ggsvelte/spec`.
+ */
+export class GGBuilder extends WithBuilderScales(WithBuilderGeoms(GGBuilderCore)) {
+  /** Normalize-only finish (TypeBox-free). Alias of {@link toPortable}. */
+  spec(): PortableSpec {
+    return this.toPortable();
+  }
+}
+
+/** Start a plot for render paths: gg(data, aes(...)).geomPoint().spec(). */
+export function gg(data?: DataInput, mapping?: AesInput): GGBuilder {
+  return new GGBuilder({
+    ...(data !== undefined && { data: toAuthoringDataRef(data) }),
+    ...(mapping !== undefined && { aes: mapping }),
+    layers: [],
+  });
+}

--- a/packages/spec/src/validate-structure-style-bins.ts
+++ b/packages/spec/src/validate-structure-style-bins.ts
@@ -6,21 +6,17 @@
  *
  * Independent of parseFailure and of data — recovery bounds must themselves
  * be valid or the runtime throws style-binned-breaks / style-domain-invalid.
- *
- * Temporal binned-style configs defer break resolution to validate()/runtime
- * so this module stays free of `@js-temporal/polyfill` (render-path structural
- * gate).
  */
 import type { SpecError } from "./errors.js";
+import { parseTemporalColumn } from "./temporal-column.js";
+import { parseTemporal } from "./temporal-parse.js";
+import { temporalParserUsable } from "./validate-data-checks-temporal.js";
 
 function isRecord(v: unknown): v is Record<string, unknown> {
   return typeof v === "object" && v !== null && !Array.isArray(v);
 }
 
 const BINNED_STYLE_AESTHETICS = ["size", "linewidth", "alpha", "shape", "linetype"] as const;
-
-const ISO_LIKE =
-  /^\d{4}-\d{2}-\d{2}(?:[T ]\d{2}:\d{2}(?::\d{2}(?:\.\d{1,3})?)?(?:Z|[+-]\d{2}:?\d{2})?)?$/;
 
 /** Mirror core cellToNumber for non-temporal style boundary resolution. */
 function nonTemporalSemantic(value: unknown): number | undefined {
@@ -31,10 +27,8 @@ function nonTemporalSemantic(value: unknown): number | undefined {
   }
   if (typeof value === "boolean") return value ? 1 : 0;
   if (typeof value === "string") {
-    if (ISO_LIKE.test(value)) {
-      const epochMs = Date.parse(value);
-      if (Number.isFinite(epochMs)) return epochMs;
-    }
+    const iso = parseTemporal(value, "iso");
+    if (iso.ok) return iso.epochMs;
     if (value.trim() === "") return undefined;
     const numeric = Number(value);
     return Number.isFinite(numeric) ? numeric : undefined;
@@ -52,15 +46,38 @@ function resolveBoundarySemantics(
     config["timezone"] !== undefined ||
     config["disambiguation"] !== undefined;
 
-  // Temporal polyfill stays off the structural-gate import graph. Full
-  // validate() / runtime still enforces temporal binned style boundaries.
-  if (requestsTemporal) return null;
+  if (!requestsTemporal) {
+    const mapped: number[] = [];
+    for (const value of values) {
+      const semantic = nonTemporalSemantic(value);
+      if (semantic === undefined) return null;
+      mapped.push(semantic);
+    }
+    return mapped;
+  }
 
+  // Schema-invalid temporal inputs still reach structure checks; defer rather
+  // than throw inside the temporal helpers (same gate as data-aware checks).
+  if (!temporalParserUsable(config["parse"])) return null;
+  if (config["timezone"] !== undefined && typeof config["timezone"] !== "string") return null;
+  if (config["disambiguation"] !== undefined && typeof config["disambiguation"] !== "string") {
+    return null;
+  }
+
+  const options = {
+    ...(typeof config["timezone"] === "string" && { timezone: config["timezone"] }),
+    ...(typeof config["disambiguation"] === "string" && {
+      disambiguation: config["disambiguation"] as "compatible" | "earlier" | "later" | "reject",
+    }),
+  };
+  const parser = (config["parse"] ?? "auto") as Parameters<typeof parseTemporalColumn>[1];
+  const column = parseTemporalColumn(values, parser, options);
   const mapped: number[] = [];
-  for (const value of values) {
-    const semantic = nonTemporalSemantic(value);
-    if (semantic === undefined) return null;
-    mapped.push(semantic);
+  for (let index = 0; index < values.length; index++) {
+    if (column.valid[index] !== 1) return null;
+    const epochMs = column.semantic[index];
+    if (epochMs === undefined || !Number.isFinite(epochMs)) return null;
+    mapped.push(epochMs);
   }
   return mapped;
 }
@@ -104,23 +121,20 @@ export function binnedStyleScaleStructuralErrors(scales: Record<string, unknown>
 
     const breakSemantics = resolveBoundarySemantics(authoredBreaks, config);
     if (breakSemantics === null || !isStrictlyIncreasing(breakSemantics)) {
-      // null: unparseable or temporal-deferred — skip (runtime/validate covers it)
-      // non-increasing: emit when we fully resolved non-temporal numbers
-      if (breakSemantics !== null) {
-        errors.push({
-          code: "scale-binned-breaks",
-          path: `/scales/${aesthetic}/breaks`,
-          message: `The ${aesthetic} boundaries must be finite and strictly increasing.`,
-          fix: {
-            description:
-              "Provide 2+ strictly increasing boundaries that parse under the scale's parser.",
-            example:
-              aesthetic === "size" || aesthetic === "linewidth" || aesthetic === "alpha"
-                ? [0, 10, 20]
-                : [0, 1, 2],
-          },
-        });
-      }
+      errors.push({
+        code: "scale-binned-breaks",
+        path: `/scales/${aesthetic}/breaks`,
+        message: `The ${aesthetic} boundaries must be finite and strictly increasing.`,
+        fix: {
+          description:
+            "Provide 2+ strictly increasing boundaries that parse under the scale's parser.",
+          example:
+            aesthetic === "size" || aesthetic === "linewidth" || aesthetic === "alpha"
+              ? [0, 10, 20]
+              : [0, 1, 2],
+        },
+      });
+      // Malformed breaks are the primary diagnostic; skip domain agreement.
       continue;
     }
 
@@ -129,6 +143,9 @@ export function binnedStyleScaleStructuralErrors(scales: Record<string, unknown>
 
     const domainSemantics = resolveBoundarySemantics(domain, config);
     if (domainSemantics === null || domainSemantics.length !== 2) {
+      // Unparseable domain is a separate runtime style-domain-invalid path; the
+      // censor-recovery check covers type-mismatch. Only emit agreement here when
+      // both sides fully resolve.
       continue;
     }
 

--- a/packages/spec/src/validate-structure-style-bins.ts
+++ b/packages/spec/src/validate-structure-style-bins.ts
@@ -6,17 +6,21 @@
  *
  * Independent of parseFailure and of data — recovery bounds must themselves
  * be valid or the runtime throws style-binned-breaks / style-domain-invalid.
+ *
+ * Temporal binned-style configs defer break resolution to validate()/runtime
+ * so this module stays free of `@js-temporal/polyfill` (render-path structural
+ * gate).
  */
 import type { SpecError } from "./errors.js";
-import { parseTemporalColumn } from "./temporal-column.js";
-import { parseTemporal } from "./temporal-parse.js";
-import { temporalParserUsable } from "./validate-data-checks-temporal.js";
 
 function isRecord(v: unknown): v is Record<string, unknown> {
   return typeof v === "object" && v !== null && !Array.isArray(v);
 }
 
 const BINNED_STYLE_AESTHETICS = ["size", "linewidth", "alpha", "shape", "linetype"] as const;
+
+const ISO_LIKE =
+  /^\d{4}-\d{2}-\d{2}(?:[T ]\d{2}:\d{2}(?::\d{2}(?:\.\d{1,3})?)?(?:Z|[+-]\d{2}:?\d{2})?)?$/;
 
 /** Mirror core cellToNumber for non-temporal style boundary resolution. */
 function nonTemporalSemantic(value: unknown): number | undefined {
@@ -27,8 +31,10 @@ function nonTemporalSemantic(value: unknown): number | undefined {
   }
   if (typeof value === "boolean") return value ? 1 : 0;
   if (typeof value === "string") {
-    const iso = parseTemporal(value, "iso");
-    if (iso.ok) return iso.epochMs;
+    if (ISO_LIKE.test(value)) {
+      const epochMs = Date.parse(value);
+      if (Number.isFinite(epochMs)) return epochMs;
+    }
     if (value.trim() === "") return undefined;
     const numeric = Number(value);
     return Number.isFinite(numeric) ? numeric : undefined;
@@ -46,38 +52,15 @@ function resolveBoundarySemantics(
     config["timezone"] !== undefined ||
     config["disambiguation"] !== undefined;
 
-  if (!requestsTemporal) {
-    const mapped: number[] = [];
-    for (const value of values) {
-      const semantic = nonTemporalSemantic(value);
-      if (semantic === undefined) return null;
-      mapped.push(semantic);
-    }
-    return mapped;
-  }
+  // Temporal polyfill stays off the structural-gate import graph. Full
+  // validate() / runtime still enforces temporal binned style boundaries.
+  if (requestsTemporal) return null;
 
-  // Schema-invalid temporal inputs still reach structure checks; defer rather
-  // than throw inside the temporal helpers (same gate as data-aware checks).
-  if (!temporalParserUsable(config["parse"])) return null;
-  if (config["timezone"] !== undefined && typeof config["timezone"] !== "string") return null;
-  if (config["disambiguation"] !== undefined && typeof config["disambiguation"] !== "string") {
-    return null;
-  }
-
-  const options = {
-    ...(typeof config["timezone"] === "string" && { timezone: config["timezone"] }),
-    ...(typeof config["disambiguation"] === "string" && {
-      disambiguation: config["disambiguation"] as "compatible" | "earlier" | "later" | "reject",
-    }),
-  };
-  const parser = (config["parse"] ?? "auto") as Parameters<typeof parseTemporalColumn>[1];
-  const column = parseTemporalColumn(values, parser, options);
   const mapped: number[] = [];
-  for (let index = 0; index < values.length; index++) {
-    if (column.valid[index] !== 1) return null;
-    const epochMs = column.semantic[index];
-    if (epochMs === undefined || !Number.isFinite(epochMs)) return null;
-    mapped.push(epochMs);
+  for (const value of values) {
+    const semantic = nonTemporalSemantic(value);
+    if (semantic === undefined) return null;
+    mapped.push(semantic);
   }
   return mapped;
 }
@@ -121,20 +104,23 @@ export function binnedStyleScaleStructuralErrors(scales: Record<string, unknown>
 
     const breakSemantics = resolveBoundarySemantics(authoredBreaks, config);
     if (breakSemantics === null || !isStrictlyIncreasing(breakSemantics)) {
-      errors.push({
-        code: "scale-binned-breaks",
-        path: `/scales/${aesthetic}/breaks`,
-        message: `The ${aesthetic} boundaries must be finite and strictly increasing.`,
-        fix: {
-          description:
-            "Provide 2+ strictly increasing boundaries that parse under the scale's parser.",
-          example:
-            aesthetic === "size" || aesthetic === "linewidth" || aesthetic === "alpha"
-              ? [0, 10, 20]
-              : [0, 1, 2],
-        },
-      });
-      // Malformed breaks are the primary diagnostic; skip domain agreement.
+      // null: unparseable or temporal-deferred — skip (runtime/validate covers it)
+      // non-increasing: emit when we fully resolved non-temporal numbers
+      if (breakSemantics !== null) {
+        errors.push({
+          code: "scale-binned-breaks",
+          path: `/scales/${aesthetic}/breaks`,
+          message: `The ${aesthetic} boundaries must be finite and strictly increasing.`,
+          fix: {
+            description:
+              "Provide 2+ strictly increasing boundaries that parse under the scale's parser.",
+            example:
+              aesthetic === "size" || aesthetic === "linewidth" || aesthetic === "alpha"
+                ? [0, 10, 20]
+                : [0, 1, 2],
+          },
+        });
+      }
       continue;
     }
 
@@ -143,9 +129,6 @@ export function binnedStyleScaleStructuralErrors(scales: Record<string, unknown>
 
     const domainSemantics = resolveBoundarySemantics(domain, config);
     if (domainSemantics === null || domainSemantics.length !== 2) {
-      // Unparseable domain is a separate runtime style-domain-invalid path; the
-      // censor-recovery check covers type-mismatch. Only emit agreement here when
-      // both sides fully resolve.
       continue;
     }
 


### PR DESCRIPTION
## Summary

- Add progressive import surfaces so identity charts do not ship TypeBox, the Temporal polyfill, or heavy stats/geoms.
- `@ggsvelte/core/render` — basic geoms only; `@ggsvelte/core/temporal` optional for time scales.
- `@ggsvelte/spec/portable` + `toPortable()` — normalize without TypeBox; full `.spec()` still validates.
- Full package entry keeps the complete grammar (BC).
- `benchmarks/competitive` harness for bundle size and Chromium mount/update.

## Measured gain (Vite minify, gzip -9, colored scatter)

| Path | gzip |
|------|------|
| Before (full + `.spec()`) | ~327 KB |
| After lean (`core/render` + `spec/portable`) | **~140 KB (−57%)** |
| SveltePlot (reference) | ~109 KB |
| LayerCake | ~41 KB |
| D3 raw | ~14 KB |

Marginal steps: barrel split −36 KB, TypeBox off render path −90 KB, optional temporal −61 KB.

## Test plan

- [x] `tsc -b packages/spec packages/core`
- [x] `bun test packages/core/tests/pipeline-m1` (38 pass)
- [x] `bun test scripts/spec-render-path-isolation.test.ts`
- [x] Competitive bundle measure (`benchmarks/competitive` measure:bundles)
- [x] Competitive browser measure (Chromium mount/update ggsvelte vs d3)
- [ ] CI green on PR

## Migration

None — additive. Existing `@ggsvelte/core` / `@ggsvelte/spec` / `.spec()` behavior unchanged.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1278" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->