### PR TITLE
perf(spec): scan stacked-area-negative y column once per field, not per layer

### DIFF
--- a/.changeset/lint-stacked-area-scan.md
+++ b/.changeset/lint-stacked-area-scan.md
@@ -1,0 +1,7 @@
+---
+"@ggsvelte/spec": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+perf(spec): scan stacked-area-negative y column once per field, not per layer

--- a/packages/spec/src/lint-layer-rules.ts
+++ b/packages/spec/src/lint-layer-rules.ts
@@ -40,6 +40,12 @@ export function collectLayerLintAdvisories(input: {
   // for many-discrete-colors are memoized across layers/channels that share a
   // field so a high-cardinality column is scanned O(n), not O(L·n).
   const distinctNonNullByField = new Map<string, number>();
+  // Same contract for stacked-area-negative: one scan per y field, not per
+  // layer. Field name is a safe key because lint evidence is one plot-level
+  // map per pass (lintSpec builds or receives a single FieldEvidenceMap), so
+  // a field name always resolves to the same values array within one call.
+  // If lint ever gains layer-scoped evidence, key on the values array instead.
+  const hasNegativeByField = new Map<string, boolean>();
 
   for (let i = 0; i < layers.length; i++) {
     const layer = layers[i];
@@ -99,7 +105,11 @@ export function collectLayerLintAdvisories(input: {
       const y = fieldOf(layerAes, "y");
       const values = y?.info.values;
       if (y !== null && values !== null && values !== undefined) {
-        const hasNegative = values.some((v) => typeof v === "number" && v < 0);
+        let hasNegative = hasNegativeByField.get(y.field);
+        if (hasNegative === undefined) {
+          hasNegative = values.some((v) => typeof v === "number" && v < 0);
+          hasNegativeByField.set(y.field, hasNegative);
+        }
         if (hasNegative) {
           advisories.push({
             code: "stacked-area-negative",

--- a/packages/spec/tests/lint-rules.test.ts
+++ b/packages/spec/tests/lint-rules.test.ts
@@ -109,6 +109,54 @@ describe("stacked-area-negative", () => {
     expect(lintSpec(spec([1, -2, 3], "identity"))).toEqual([]);
     expect(lintSpec(spec([1, 2, 3]))).toEqual([]);
   });
+
+  /**
+   * Characterization for negative-scan memoization: layers sharing a y field
+   * must still emit one advisory per layer path, while the column is scanned
+   * once underneath (same contract as distinctNonNullByField above).
+   */
+  it("emits per-layer advisories when stacked layers share a negative y field", () => {
+    const advisories = lintSpec({
+      data: { columns: { x: [1, 2, 3], y: [1, -2, 3], g: ["a", "b", "a"] } },
+      aes: { x: { field: "x" }, y: { field: "y" }, fill: { field: "g" } },
+      layers: [{ geom: "area" }, { geom: "area", position: "fill" }],
+    }).filter((a) => a.code === "stacked-area-negative");
+    expect(advisories.map((a) => a.path)).toEqual(["/layers/0/aes/y", "/layers/1/aes/y"]);
+  });
+
+  it("silent when stacked layers share an all-positive y field", () => {
+    // Worst case for the scan (no early exit): must stay silent across layers.
+    const advisories = lintSpec({
+      data: { columns: { x: [1, 2, 3], y: [1, 2, 3], g: ["a", "b", "a"] } },
+      aes: { x: { field: "x" }, y: { field: "y" }, fill: { field: "g" } },
+      layers: [{ geom: "area" }, { geom: "area", position: "fill" }],
+    });
+    expect(advisories).toEqual([]);
+  });
+
+  it("keeps per-field results independent across layers with different y fields", () => {
+    const advisories = lintSpec({
+      data: {
+        columns: { x: [1, 2, 3], neg: [1, -2, 3], pos: [1, 2, 3], g: ["a", "b", "a"] },
+      },
+      aes: { x: { field: "x" }, fill: { field: "g" } },
+      layers: [
+        { geom: "area", aes: { y: { field: "neg" } } },
+        { geom: "area", aes: { y: { field: "pos" } } },
+      ],
+    }).filter((a) => a.code === "stacked-area-negative");
+    expect(advisories.map((a) => a.path)).toEqual(["/layers/0/aes/y"]);
+    expect(advisories[0]!.message).toContain('"neg"');
+  });
+
+  it("fires only on the stacked layer when an identity layer shares the negative field", () => {
+    const advisories = lintSpec({
+      data: { columns: { x: [1, 2, 3], y: [1, -2, 3], g: ["a", "b", "a"] } },
+      aes: { x: { field: "x" }, y: { field: "y" }, fill: { field: "g" } },
+      layers: [{ geom: "area", position: "identity" }, { geom: "area" }],
+    }).filter((a) => a.code === "stacked-area-negative");
+    expect(advisories.map((a) => a.path)).toEqual(["/layers/1/aes/y"]);
+  });
 });
 
 describe("many-discrete-colors", () => {

--- a/packages/spec/tests/lint-rules.test.ts
+++ b/packages/spec/tests/lint-rules.test.ts
@@ -149,6 +149,20 @@ describe("stacked-area-negative", () => {
     expect(advisories[0]!.message).toContain('"neg"');
   });
 
+  it("uses plot-level evidence even when a layer carries its own same-named column", () => {
+    // Lint evidence is one plot-level map per pass (validate.ts shares
+    // layerResolved.plot only), so a layer's own data never feeds this rule.
+    // The per-field memo in collectLayerLintAdvisories depends on exactly this
+    // contract; if lint gains layer-scoped evidence, this test must change
+    // along with the memo key.
+    const advisories = lintSpec({
+      data: { columns: { x: [1, 2, 3], y: [1, 2, 3], g: ["a", "b", "a"] } },
+      aes: { x: { field: "x" }, y: { field: "y" }, fill: { field: "g" } },
+      layers: [{ geom: "area", data: { columns: { y: [-1, -2, -3] } } }],
+    });
+    expect(advisories).toEqual([]);
+  });
+
   it("fires only on the stacked layer when an identity layer shares the negative field", () => {
     const advisories = lintSpec({
       data: { columns: { x: [1, 2, 3], y: [1, -2, 3], g: ["a", "b", "a"] } },


### PR DESCRIPTION
## What

`collectLayerLintAdvisories` rescanned the full y column for every stacked or filled area layer. Layers that inherit plot-level `aes.y` resolve to the same field and the same values array, so with no negative value present each layer paid a full O(n) scan — O(L·n) total, where n = inline data rows (up to the documented 100k maxRows) and L = qualifying area layers.

This memoizes the per-field result the same way the sibling `many-discrete-colors` rule already does (`distinctNonNullByField`), so a shared column is scanned once: O(n + L) per distinct field. `stacked-area-negative` was the one rule in the file left un-memoized.

Sizing this honestly: multi-series stacked areas usually come from one layer plus fill grouping, so L>1 is the generated-spec case. This is a small consistency fix with a better complexity bound, not a hot-path rescue.

## Why the memo key is safe

Field name keys the memo. Lint evidence is one plot-level map per pass: `lintSpec` builds or receives a single `FieldEvidenceMap`, and `validate({ lint: true })` shares `layerResolved.plot` only. A field name therefore always resolves to the same values array within one call. The code comment records this assumption, and a new test pins the contract (a layer's own same-named column does not feed the rule), so layer-scoped lint evidence cannot land without breaking that test.

## Behavior

Unchanged: one advisory per offending layer, same paths, same order. New characterization tests cover:

- per-layer emission when stacked layers share a negative y field
- the all-positive silent path (worst case for the scan)
- per-field independence across layers with different y fields
- the stack/identity position gate on a shared negative field
- plot-level evidence winning over a layer's own same-named column

## Verification

- `bun test packages/spec` — 700 pass, 0 fail
- `tsc -p packages/spec` clean; oxlint and oxfmt clean (pre-commit hooks)

## Follow-ups

Two larger findings from the same audit are filed separately rather than expanding this PR:

- #1279 — `validate()` re-walks every layer with interpreted TypeBox checks it already has answers for
- #1280 — builder geom sugar deep-copies layer data twice per call

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1281" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->