### PR TITLE
perf(spec): skip interpreted per-layer schema re-check on valid specs

### DIFF
--- a/.changeset/validate-skip-layer-check.md
+++ b/.changeset/validate-skip-layer-check.md
@@ -1,0 +1,7 @@
+---
+"@ggsvelte/spec": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+perf(spec): skip interpreted per-layer schema re-check on valid specs

--- a/packages/spec/src/validate-schema-shape.ts
+++ b/packages/spec/src/validate-schema-shape.ts
@@ -2,7 +2,10 @@
  * Tier-1 schema shape walk: discriminator-aware layer branches + plot shell.
  *
  * Shared geom branch lookup (`GEOM_BRANCHES`) is also used by validate() to
- * gate tier-2 structural checks with Value.Check on known geoms.
+ * recognise known geoms for the tier-2 structural gate. Branch validity for
+ * that gate comes from the compiled plot check (valid path) or from this
+ * walk's per-layer `Value.Errors` result (invalid path) — not a second
+ * interpreted `Value.Check` per layer (#1279).
  *
  * Orchestrator: validate.ts. Error mapping: validate-map-errors.ts.
  */
@@ -121,39 +124,65 @@ function isRecord(v: unknown): v is Record<string, unknown> {
   return typeof v === "object" && v !== null && !Array.isArray(v);
 }
 
+/** One layer's tier-1 shape errors plus whether its geom branch was clean. */
+type LayerShapeResult = {
+  errors: SpecError[];
+  /** True when `Value.Errors(branch, layer)` was empty (branch-valid). */
+  branchOk: boolean;
+};
+
 /** Discriminator-aware layer walk — one layer's tier-1 shape errors. */
-function mapLayerShapeErrors(layer: unknown, layerPath: string): SpecError[] {
+function mapLayerShapeErrors(layer: unknown, layerPath: string): LayerShapeResult {
   if (!isRecord(layer)) {
-    return [
-      {
-        code: "invalid-layer",
-        path: layerPath,
-        message: `Each layer must be an object with a "geom" (got ${typeof layer}).`,
-        fix: { description: "Replace with a layer object.", example: { geom: "point" } },
-      },
-    ];
+    return {
+      branchOk: false,
+      errors: [
+        {
+          code: "invalid-layer",
+          path: layerPath,
+          message: `Each layer must be an object with a "geom" (got ${typeof layer}).`,
+          fix: { description: "Replace with a layer object.", example: { geom: "point" } },
+        },
+      ],
+    };
   }
   const geom = layer["geom"];
   // Own-key check: `in` walks the prototype chain, so a geom named
   // "constructor" would pass this guard and hand Value.Errors a function
   // instead of a schema — reporting invalid-type rather than the did-you-mean.
   if (typeof geom !== "string" || !Object.hasOwn(GEOM_BRANCHES, geom)) {
-    return [unknownGeomError(geom, layerPath)];
+    return { branchOk: false, errors: [unknownGeomError(geom, layerPath)] };
   }
   const branch = GEOM_BRANCHES[geom as keyof typeof GEOM_BRANCHES];
-  return mapValueErrors(Value.Errors(branch, layer), {
-    schema: branch,
-    value: layer,
-    pathPrefix: layerPath,
-  });
+  const raw = Value.Errors(branch, layer);
+  return {
+    branchOk: raw.length === 0,
+    errors: mapValueErrors(raw, {
+      schema: branch,
+      value: layer,
+      pathPrefix: layerPath,
+    }),
+  };
 }
+
+/** Result of the tier-1 shape walk for one invalid plot. */
+export type SchemaShapeResult = {
+  errors: SpecError[];
+  /**
+   * Layer indices whose geom-branch `Value.Errors` walk was empty. Used by
+   * validate() so the tier-2 structural gate does not re-run interpreted
+   * `Value.Check` on the same layers.
+   */
+  branchOkLayerIndices: ReadonlySet<number>;
+};
 
 /**
  * Tier-1 schema walk (caller must set TypeBox Settings for the process).
  * Layer branch walk + plot-level shell so layer noise is not double-reported.
  */
-export function collectSchemaShapeErrors(input: Record<string, unknown>): SpecError[] {
+export function collectSchemaShapeErrors(input: Record<string, unknown>): SchemaShapeResult {
   const errors: SpecError[] = [];
+  const branchOkLayerIndices = new Set<number>();
   const layers = input["layers"];
   if (!Array.isArray(layers)) {
     errors.push({
@@ -174,7 +203,9 @@ export function collectSchemaShapeErrors(input: Record<string, unknown>): SpecEr
     });
   } else {
     for (let i = 0; i < layers.length; i++) {
-      errors.push(...mapLayerShapeErrors(layers[i], `/layers/${i}`));
+      const layerResult = mapLayerShapeErrors(layers[i], `/layers/${i}`);
+      if (layerResult.branchOk) branchOkLayerIndices.add(i);
+      errors.push(...layerResult.errors);
     }
   }
 
@@ -190,12 +221,12 @@ export function collectSchemaShapeErrors(input: Record<string, unknown>): SpecEr
   );
 
   if (errors.length === 0) {
-    // Value.Check failed but neither walk produced a mapped error.
+    // Compiled plot Check failed but neither walk produced a mapped error.
     errors.push({
       code: "invalid-type",
       path: "",
       message: "The spec does not match the schema.",
     });
   }
-  return errors;
+  return { errors, branchOkLayerIndices };
 }

--- a/packages/spec/src/validate.ts
+++ b/packages/spec/src/validate.ts
@@ -5,7 +5,8 @@
  * Tier-1 mechanism (decision 0004): TypeBox 1.x compiled checks plus
  * `Value.Errors` over the same schemas that emit `schema/v0.json` — one
  * artifact, no drift.
- * Layer/plot shape walks: validate-schema-shape.ts (shared GEOM_BRANCHES).
+ * Layer/plot shape walks: validate-schema-shape.ts (shared GEOM_BRANCHES;
+ * also hands per-layer branch-ok indices to the tier-2 structural gate).
  * Raw TypeBox union noise is mapped to the agent error contract in
  * validate-map-errors.ts (schema walk: validate-schema-walk.ts; channel/data
  * form classification: validate-map-forms.ts).
@@ -18,7 +19,6 @@
  */
 import Compile from "typebox/compile";
 import { Settings } from "typebox/system";
-import { Value } from "typebox/value";
 
 import type { SpecError } from "./errors.js";
 import type { SpecAdvisory } from "./lint.js";
@@ -90,10 +90,17 @@ export function validate(input: unknown, options?: ValidateOptions): ValidateRes
     exactOptionalPropertyTypes: true,
   });
   try {
-    // TypeBox's interpreted Value.Check walks the cyclic schema graph repeatedly
-    // for every inline row. Reuse its compiled validator so large plots remain
-    // interactive while preserving Value.Errors for detailed invalid diagnostics.
+    // TypeBox's interpreted Value.Check / Value.Errors walk the cyclic schema
+    // graph for every inline row. Use the compiled plot validator for the
+    // common valid path, and Value.Errors only when building invalid diagnostics.
     const schemaValid: boolean = PLOT_SPEC_VALIDATOR.Check(input);
+
+    // Tier-2 structural gate: run layerStructuralErrors only on branch-valid
+    // layers. When the compiled plot check passed, LayerSpec's geom-discriminated
+    // union already proves every layer matches its GEOM_BRANCHES member — skip
+    // a second interpreted walk. When it failed, reuse the shape walk's per-layer
+    // Value.Errors emptiness set (#1279).
+    let branchOkLayers: ReadonlySet<number> | "all" = "all";
 
     if (!schemaValid) {
       if (!isRecord(input)) {
@@ -115,7 +122,9 @@ export function validate(input: unknown, options?: ValidateOptions): ValidateRes
         };
       }
 
-      errors.push(...collectSchemaShapeErrors(input));
+      const shape = collectSchemaShapeErrors(input);
+      errors.push(...shape.errors);
+      branchOkLayers = shape.branchOkLayerIndices;
     }
 
     // TypeBox-free structural gates (shared with pipeline render path).
@@ -128,8 +137,8 @@ export function validate(input: unknown, options?: ValidateOptions): ValidateRes
     // of the tier-2 contract (the pipeline enforces them at render time with
     // equivalent structured errors); tier 1 stays schema-shape-only so partial
     // specs remain composable.
-    // Eligibility: only record layers with a known geom whose branch passes
-    // Value.Check (shape errors already reported above). Uses shared GEOM_BRANCHES.
+    // Eligibility: record layers with a known geom whose branch is valid
+    // (see branchOkLayers above). Uses shared GEOM_BRANCHES for known-geom keys.
     if (options !== undefined && isRecord(input) && Array.isArray(input["layers"])) {
       const plotAes = isRecord(input["aes"]) ? (input["aes"] as Aes) : undefined;
       const layers = input["layers"] as unknown[];
@@ -138,11 +147,9 @@ export function validate(input: unknown, options?: ValidateOptions): ValidateRes
         if (!isRecord(layer)) continue;
         const geom = layer["geom"];
         // Own-key check, as in validate-schema-shape: `in` walks the prototype
-        // chain, so a geom named "constructor" would reach Value.Check with a
-        // function in place of a schema.
+        // chain, so a geom named "constructor" would look like a known key.
         if (typeof geom !== "string" || !Object.hasOwn(GEOM_BRANCHES, geom)) continue;
-        const branch = GEOM_BRANCHES[geom as keyof typeof GEOM_BRANCHES];
-        if (!Value.Check(branch, layer)) continue; // shape errors already reported
+        if (branchOkLayers !== "all" && !branchOkLayers.has(i)) continue;
         errors.push(...layerStructuralErrors(layer, geom, i, plotAes));
       }
     }

--- a/packages/spec/tests/validate-tier2-branch-gate.test.ts
+++ b/packages/spec/tests/validate-tier2-branch-gate.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Tier-2 eligibility gate: skip interpreted per-layer Value.Check when the
+ * compiled plot check already proved branches (valid path), and reuse the
+ * shape walk's per-layer Errors result when it did not (invalid path).
+ * Production: validate.ts + validate-schema-shape.ts. Issue #1279.
+ */
+import { afterEach, describe, expect, it, spyOn } from "bun:test";
+import { Value } from "typebox/value";
+
+import { validate } from "../src/validate.ts";
+
+describe("tier 2 — layer branch gate (#1279)", () => {
+  const spies: Array<{ mockRestore: () => void }> = [];
+  afterEach(() => {
+    while (spies.length > 0) spies.pop()!.mockRestore();
+  });
+
+  it("does not call interpreted Value.Check on a schema-valid tier-2 path", () => {
+    const checkSpy = spyOn(Value, "Check");
+    spies.push(checkSpy);
+
+    const values = Array.from({ length: 200 }, (_, i) => ({ x: i, y: i % 10 }));
+    const result = validate(
+      {
+        data: { values },
+        aes: { x: { field: "x" }, y: { field: "y" } },
+        layers: [
+          { geom: "point" },
+          { geom: "line" },
+          { geom: "point", data: { values: values.slice(0, 50) } },
+        ],
+      },
+      {},
+    );
+
+    expect(result.ok).toBe(true);
+    // Compiled PLOT_SPEC_VALIDATOR.Check already proved every layer branch.
+    // The tier-2 gate must not re-walk layers with the interpreted checker.
+    expect(checkSpy).toHaveBeenCalledTimes(0);
+  });
+
+  it("still runs structural checks on branch-ok layers when the plot is schema-invalid", () => {
+    // Layer 0: known geom, branch-valid, missing y → tier-2 structural error.
+    // Layer 1: known geom, branch-invalid (bad stat) → shape error only; no
+    // structural missing-channel for that layer (gate skips dirty branches).
+    const result = validate(
+      {
+        layers: [
+          { geom: "point", aes: { x: { field: "x" } } },
+          { geom: "point", stat: "not-a-stat", aes: { x: { field: "x" }, y: { field: "y" } } },
+        ],
+      },
+      {},
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    const structural = result.errors.filter((e) => e.code === "missing-required-channel");
+    expect(structural.map((e) => e.path)).toEqual(["/layers/0/aes/y"]);
+    // Shape still reported the invalid branch on layer 1.
+    expect(result.errors.some((e) => e.path.startsWith("/layers/1"))).toBe(true);
+  });
+
+  it("validates a multi-thousand-row layer-local dataset under tier-2 without the old Check walk", () => {
+    // Characterization of the #1279 win: before the gate skip, interpreted
+    // Value.Check re-walked every inline row per layer (tens of seconds at
+    // 20k). After, compiled plot Check + structural rules stay interactive.
+    const n = 5_000;
+    const values = Array.from({ length: n }, (_, i) => ({ x: i, y: i % 100 }));
+    const startedAt = performance.now();
+    const result = validate(
+      {
+        layers: [
+          {
+            geom: "point",
+            aes: { x: { field: "x" }, y: { field: "y" } },
+            data: { values },
+          },
+        ],
+      },
+      {},
+    );
+    const elapsed = performance.now() - startedAt;
+    expect(result.ok).toBe(true);
+    // Loose ceiling: the old path was ~seconds per thousand rows; the new path
+    // must stay well under interactive budgets on CI hardware.
+    expect(elapsed).toBeLessThan(2_000);
+  });
+});


### PR DESCRIPTION
## Summary

- **Problem:** `validate()` with tier-2 options re-ran TypeBox's interpreted `Value.Check` on every layer after the compiled plot validator (or the shape walk's `Value.Errors`) already knew each layer's branch validity. That second walk scaled with inline `data.values` rows and the cyclic schema graph — multi-second on large layer-local datasets.
- **Fix:** On the valid path, skip the re-check: `LayerSpec`'s geom-discriminated union already proves every known-geom layer matches its `GEOM_BRANCHES` member. On the invalid path, reuse the shape walk's per-layer `Value.Errors` emptiness set so structural checks still run only on branch-ok layers.
- **Result:** Same diagnostics and structural eligibility; no interpreted per-layer walk on the common valid-spec path. Closes #1279.

## Complexity

| Path | Before | After |
|------|--------|--------|
| Valid tier-2 | Compiled plot `Check` + interpreted `Value.Check` per layer (walks layer JSON including inline rows) | Compiled plot `Check` only for branch proof |
| Invalid tier-2 | Shape `Value.Errors` per layer + interpreted `Value.Check` per layer | Shape `Value.Errors` only; gate reuses emptiness |

n = spec JSON nodes, dominated by inline data rows × columns (documented up to 100k rows).

## Test plan

- [x] New characterization suite `validate-tier2-branch-gate.test.ts`:
  - spy: `Value.Check` call count is 0 on a schema-valid tier-2 path
  - invalid plot with one branch-ok and one dirty layer still emits structural errors only for the ok layer
  - 5k-row layer-local tier-2 validate under 2s (old path was multi-second per thousand rows)
- [x] Full `bun test packages/spec` — 703 pass, snapshots unchanged
- [x] Existing tier-2 structure/ordering/validate suites green

## Verification

```
bun test packages/spec/tests/validate-tier2-branch-gate.test.ts
# 3 pass; 5k-row case ~4–6ms locally

bun test packages/spec
# 703 pass, 0 fail
```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1284" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->