### PR TITLE
perf(core): cache filled-path containment per brush rect in queryRect

### DIFF
--- a/.changeset/queryrect-fill-containment-cache.md
+++ b/.changeset/queryrect-fill-containment-cache.md
@@ -1,0 +1,7 @@
+---
+"@ggsvelte/core": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+perf(core): cache filled-path containment per brush rect in queryRect — an interior brush over a filled area/polygon ran a full point-in-polygon walk per candidate (O(K×V)); one cached walk per subpath per query (O(K+V))

--- a/packages/core/src/candidate-hit-geometry.ts
+++ b/packages/core/src/candidate-hit-geometry.ts
@@ -29,7 +29,14 @@ export type HitGeometry = {
     pathContainment: Map<string, boolean>,
   ): number | null;
   contains(id: number, px: number, py: number, pathContainment: Map<string, boolean>): boolean;
-  intersects(id: number, loX: number, loY: number, hiX: number, hiY: number): boolean;
+  intersects(
+    id: number,
+    loX: number,
+    loY: number,
+    hiX: number,
+    hiY: number,
+    rectContainment: Map<string, boolean>,
+  ): boolean;
   aabb(id: number, pathAabbCache?: Map<string, Aabb>): Aabb;
 };
 
@@ -55,6 +62,7 @@ type KindOps = {
     loY: number,
     hiX: number,
     hiY: number,
+    rectContainment: Map<string, boolean>,
   ): boolean;
   aabb(indexes: CandidateStoreIndexes, id: number, pathAabbCache?: Map<string, Aabb>): Aabb;
 };
@@ -347,7 +355,7 @@ const pathsOps: KindOps = {
       subpath === null ? batch.linewidth : (batch.linewidths?.[subpath] ?? batch.linewidth);
     return d <= linewidth / 2 + indexes.hitTolerance ? d : null;
   },
-  intersects(indexes, id, loX, loY, hiX, hiY) {
+  intersects(indexes, id, loX, loY, hiX, hiY, rectContainment) {
     const batch = batchAt(indexes, id);
     if (batch.kind !== "paths") return false;
     const panel = indexes.scene.panels[indexes.panelIds[id]!]!;
@@ -362,9 +370,19 @@ const pathsOps: KindOps = {
     )
       return true;
     if (batch.fills !== undefined) {
-      const centerX = (loX + hiX) / 2 - panel.x;
-      const centerY = (loY + hiY) / 2 - panel.y;
-      if (insidePath(batch, range[0], range[1], centerX, centerY)) return true;
+      // Rect-CENTER containment is identical for every candidate on this
+      // subpath (a batch belongs to one panel), so cache it per probe rect.
+      // rectContainment is valid for ONE rect and caches a different
+      // predicate than contains' point-containment map — never share the two.
+      const containmentKey = `${indexes.batchIds[id]}:${range[0]}:${range[1]}`;
+      let contained = rectContainment.get(containmentKey);
+      if (contained === undefined) {
+        const centerX = (loX + hiX) / 2 - panel.x;
+        const centerY = (loY + hiY) / 2 - panel.y;
+        contained = insidePath(batch, range[0], range[1], centerX, centerY);
+        rectContainment.set(containmentKey, contained);
+      }
+      if (contained) return true;
     }
     return false;
   },
@@ -426,7 +444,8 @@ export function createHitGeometry(indexes: CandidateStoreIndexes): HitGeometry {
       opsFor(id).distance(indexes, id, px, py, pathContainment),
     contains: (id, px, py, pathContainment) =>
       opsFor(id).contains(indexes, id, px, py, pathContainment),
-    intersects: (id, loX, loY, hiX, hiY) => opsFor(id).intersects(indexes, id, loX, loY, hiX, hiY),
+    intersects: (id, loX, loY, hiX, hiY, rectContainment) =>
+      opsFor(id).intersects(indexes, id, loX, loY, hiX, hiY, rectContainment),
     aabb: (id, pathAabbCache) => opsFor(id).aabb(indexes, id, pathAabbCache),
   };
 }

--- a/packages/core/src/candidate-store-build.ts
+++ b/packages/core/src/candidate-store-build.ts
@@ -278,9 +278,13 @@ export function assembleCandidateStore(
       }
       const extendedHits: number[] = [];
       query.addExtendedIntersecting(loX, loY, hiX, hiY, extendedHits);
+      // One probe rect per call, so rect-center fill containment per subpath
+      // is shared across candidates. Distinct from the point-containment maps
+      // nearest/hitTest build — the two cache different predicates.
+      const rectContainment = new Map<string, boolean>();
       for (const id of extendedHits) {
         if (panelId !== undefined && scene.panels[panelIds[id]!]!.id !== panelId) continue;
-        if (query.intersects(id, loX, loY, hiX, hiY)) hits.push(id);
+        if (query.intersects(id, loX, loY, hiX, hiY, rectContainment)) hits.push(id);
       }
       hits.sort((a, b) => traversalRank[a]! - traversalRank[b]!);
       return Uint32Array.from(hits);

--- a/packages/core/src/candidate-store-spatial-refine.ts
+++ b/packages/core/src/candidate-store-spatial-refine.ts
@@ -12,7 +12,14 @@ export type SpatialRefine = {
     py: number,
     pathContainment: Map<string, boolean>,
   ): number | null;
-  intersects(id: number, loX: number, loY: number, hiX: number, hiY: number): boolean;
+  intersects(
+    id: number,
+    loX: number,
+    loY: number,
+    hiX: number,
+    hiY: number,
+    rectContainment: Map<string, boolean>,
+  ): boolean;
 };
 
 /** Build exactDistance / intersects closed over store indexes. */
@@ -20,6 +27,7 @@ export function createSpatialRefine(indexes: CandidateStoreIndexes): SpatialRefi
   const hit = createHitGeometry(indexes);
   return {
     exactDistance: (id, px, py, pathContainment) => hit.distance(id, px, py, pathContainment),
-    intersects: (id, loX, loY, hiX, hiY) => hit.intersects(id, loX, loY, hiX, hiY),
+    intersects: (id, loX, loY, hiX, hiY, rectContainment) =>
+      hit.intersects(id, loX, loY, hiX, hiY, rectContainment),
   };
 }

--- a/packages/core/src/candidate-store-spatial.ts
+++ b/packages/core/src/candidate-store-spatial.ts
@@ -26,7 +26,8 @@ export function buildCandidateSpatialQuery(indexes: CandidateStoreIndexes): Cand
     },
     exactDistance: (id, px, py, pathContainment) =>
       refine.exactDistance(id, px, py, pathContainment),
-    intersects: (id, loX, loY, hiX, hiY) => refine.intersects(id, loX, loY, hiX, hiY),
+    intersects: (id, loX, loY, hiX, hiY, rectContainment) =>
+      refine.intersects(id, loX, loY, hiX, hiY, rectContainment),
     shortlistNearest: (px, py, mode, maxDistance) =>
       index.shortlistNearest(px, py, mode, maxDistance),
   };

--- a/packages/core/tests/candidate/hit-geometry.test.ts
+++ b/packages/core/tests/candidate/hit-geometry.test.ts
@@ -26,14 +26,14 @@ describe("Mark hit-geometry table", () => {
     expect(hit.distance(0, 20, 20, containment)).toBe(0);
     expect(hit.contains(0, 5, 20, containment)).toBe(false);
     expect(hit.distance(0, 5, 20, containment)).toBeNull();
-    expect(hit.intersects(0, 15, 15, 25, 25)).toBe(true);
-    expect(hit.intersects(0, 0, 0, 5, 5)).toBe(false);
+    expect(hit.intersects(0, 15, 15, 25, 25, containment)).toBe(true);
+    expect(hit.intersects(0, 0, 0, 5, 5, containment)).toBe(false);
     expect(hit.aabb(0)).toEqual([10, 10, 50, 50]);
 
     // Negative width/height still forms the same axis-aligned box.
     expect(hit.contains(1, 20, 20, containment)).toBe(true);
     expect(hit.aabb(1)).toEqual([10, 10, 50, 50]);
-    expect(hit.intersects(1, 15, 15, 25, 25)).toBe(true);
+    expect(hit.intersects(1, 15, 15, 25, 25, containment)).toBe(true);
   });
 
   it("points: circle distance respects size + tolerance; glyphs never hit", () => {
@@ -70,12 +70,12 @@ describe("Mark hit-geometry table", () => {
     expect(hit.distance(0, 16, 20, containment)).toBe(6);
     expect(hit.distance(0, 18, 20, containment)).toBeNull();
     expect(hit.contains(0, 10, 20, containment)).toBe(false);
-    expect(hit.intersects(0, 9, 19, 11, 21)).toBe(true);
+    expect(hit.intersects(0, 9, 19, 11, 21, containment)).toBe(true);
     expect(hit.aabb(0)).toEqual([3, 13, 17, 27]);
 
     expect(hit.distance(1, 40, 20, containment)).toBeNull();
     expect(hit.contains(1, 40, 20, containment)).toBe(false);
-    expect(hit.intersects(1, 39, 19, 41, 21)).toBe(true);
+    expect(hit.intersects(1, 39, 19, 41, 21, containment)).toBe(true);
     expect(hit.aabb(1)).toEqual([26, 6, 54, 34]);
   });
 
@@ -99,9 +99,9 @@ describe("Mark hit-geometry table", () => {
 
     expect(hit.distance(0, 5, 5, containment)).toBe(0);
     expect(hit.distance(0, 5, 7, containment)).toBeNull();
-    expect(hit.intersects(0, 4, 4, 6, 6)).toBe(true);
+    expect(hit.intersects(0, 4, 4, 6, 6, containment)).toBe(true);
     // Axis-aligned brush in the segment AABB corner that misses the diagonal.
-    expect(hit.intersects(0, 0, 9, 1, 10)).toBe(false);
+    expect(hit.intersects(0, 0, 9, 1, 10, containment)).toBe(false);
     expect(hit.aabb(0)).toEqual([-1, -1, 11, 11]);
   });
 
@@ -150,7 +150,48 @@ describe("Mark hit-geometry table", () => {
     // Midpoint of a false cross-subpath edge must not hit.
     expect(strokedHit.distance(1, 10, 25, strokeContainment)).toBeNull();
     expect(strokedHit.distance(1, 10, 1, strokeContainment)).not.toBeNull();
-    expect(strokedHit.intersects(1, 8, -2, 12, 2)).toBe(true);
-    expect(strokedHit.intersects(1, 8, 20, 12, 30)).toBe(false);
+    expect(strokedHit.intersects(1, 8, -2, 12, 2, strokeContainment)).toBe(true);
+    expect(strokedHit.intersects(1, 8, 20, 12, 30, strokeContainment)).toBe(false);
+  });
+
+  it("paths: intersects memoizes fill containment per subpath for one probe rect", () => {
+    const filled = scene();
+    filled.batches = [
+      {
+        kind: "paths",
+        layerIndex: 0,
+        panelIndex: 0,
+        positions: new Float32Array([20, 20, 80, 20, 50, 80]),
+        rowIndex: new Uint32Array([0, 1, 2]),
+        pathOffsets: new Uint32Array([0, 3]),
+        strokes: [null],
+        fills: [null],
+        closed: true,
+        linewidth: 0,
+        alpha: 1,
+        curve: "linear",
+      },
+    ];
+    const hit = createHitGeometry(buildCandidateStoreIndexes(filled));
+
+    // Rect (40,40)-(60,50): center inside the fill, no anchor or edge in rect.
+    // Two candidates on the same subpath share one cache entry.
+    const containment = new Map<string, boolean>();
+    expect(hit.intersects(0, 40, 40, 60, 50, containment)).toBe(true);
+    expect(hit.intersects(1, 40, 40, 60, 50, containment)).toBe(true);
+    expect(containment.size).toBe(1);
+    expect(containment.get("0:0:3")).toBe(true);
+
+    // The cached value is consulted, not recomputed: poison both directions.
+    const poisonedFalse = new Map<string, boolean>([["0:0:3", false]]);
+    expect(hit.intersects(0, 40, 40, 60, 50, poisonedFalse)).toBe(false);
+    // Center (74,74) is outside the fill, but a poisoned true wins.
+    const poisonedTrue = new Map<string, boolean>([["0:0:3", true]]);
+    expect(hit.intersects(0, 70, 70, 78, 78, poisonedTrue)).toBe(true);
+
+    // Anchor-in-rect early return never touches the fill cache.
+    const untouched = new Map<string, boolean>();
+    expect(hit.intersects(0, 15, 15, 25, 25, untouched)).toBe(true);
+    expect(untouched.size).toBe(0);
   });
 });

--- a/packages/core/tests/candidate/spatial/paths-fill-brush.test.ts
+++ b/packages/core/tests/candidate/spatial/paths-fill-brush.test.ts
@@ -84,7 +84,7 @@ describe("queryRect over filled paths (fill containment refine)", () => {
     batch.positions = new Proxy(positions, {
       get(target, prop) {
         if (typeof prop === "string" && /^\d+$/.test(prop)) reads += 1;
-        return Reflect.get(target, prop);
+        return Reflect.get(target, prop) as unknown;
       },
     });
     // Brush (95,55)-(105,65): center (100,60) inside; anchors and edges sit on

--- a/packages/core/tests/candidate/spatial/paths-fill-brush.test.ts
+++ b/packages/core/tests/candidate/spatial/paths-fill-brush.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "bun:test";
+
+import { buildCandidateStore } from "../../../src/candidate-store.ts";
+import type { PathsBatch, Scene } from "../../../src/scene.ts";
+import { scene } from "../fixtures.ts";
+
+/** Filled triangle A: (20,20) (80,20) (50,80). Interior spans x∈[40,60] at y=60. */
+function filledTriangleScene(): Scene {
+  const plot = scene();
+  plot.batches = [
+    {
+      kind: "paths",
+      layerIndex: 0,
+      panelIndex: 0,
+      positions: new Float32Array([20, 20, 80, 20, 50, 80]),
+      rowIndex: new Uint32Array([0, 1, 2]),
+      pathOffsets: new Uint32Array([0, 3]),
+      strokes: [null],
+      fills: [null],
+      closed: true,
+      linewidth: 0,
+      alpha: 1,
+      curve: "linear",
+    },
+  ];
+  return plot;
+}
+
+function store(plot: Scene) {
+  return buildCandidateStore(plot, {
+    datum: () => ({ xValue: 1, yValue: 2, autoMode: "exact" }),
+  });
+}
+
+describe("queryRect over filled paths (fill containment refine)", () => {
+  it("interior brush with no anchor or edge in the rect hits every subpath candidate", () => {
+    const candidates = store(filledTriangleScene());
+    // Rect (40,40)-(60,50): center (50,45) is inside the triangle; the three
+    // anchors and all edges stay outside the rect, so only the fill test hits.
+    const hits = Array.from(candidates.queryRect(40, 40, 60, 50)).toSorted((a, b) => a - b);
+    expect(hits).toEqual([0, 1, 2]);
+  });
+
+  it("brush overlapping the subpath AABB with center outside the fill hits nothing", () => {
+    const candidates = store(filledTriangleScene());
+    // Rect (70,70)-(78,78) sits inside the triangle's AABB corner but its
+    // center (74,74) is outside the fill; no anchor or edge in the rect.
+    // Pins the existing contract: fill∩rect is tested at the rect center.
+    expect(candidates.queryRect(70, 70, 78, 78)).toEqual(new Uint32Array(0));
+  });
+
+  it("interior brush refine reads subpath vertices once per query, not once per candidate", () => {
+    // Regular 200-gon centered (100,60), radius 50: every render vertex is a
+    // candidate (K = V = 200). An interior brush shortlists all of them via the
+    // shared subpath AABB, and each one reaches the fill-containment test.
+    const V = 200;
+    const positions = new Float32Array(V * 2);
+    for (let i = 0; i < V; i++) {
+      const angle = (2 * Math.PI * i) / V;
+      positions[i * 2] = 100 + 50 * Math.cos(angle);
+      positions[i * 2 + 1] = 60 + 50 * Math.sin(angle);
+    }
+    const plot = scene();
+    const batch: PathsBatch = {
+      kind: "paths",
+      layerIndex: 0,
+      panelIndex: 0,
+      positions,
+      rowIndex: Uint32Array.from({ length: V }, (_, i) => i),
+      pathOffsets: new Uint32Array([0, V]),
+      strokes: [null],
+      fills: [null],
+      closed: true,
+      linewidth: 0,
+      alpha: 1,
+      curve: "linear",
+    };
+    plot.batches = [batch];
+    const candidates = store(plot);
+    // First query forces the lazy store build (construction reads are free).
+    expect(candidates.queryRect(95, 55, 105, 65)).toHaveLength(V);
+
+    let reads = 0;
+    batch.positions = new Proxy(positions, {
+      get(target, prop) {
+        if (typeof prop === "string" && /^\d+$/.test(prop)) reads += 1;
+        return Reflect.get(target, prop);
+      },
+    });
+    // Brush (95,55)-(105,65): center (100,60) inside; anchors and edges sit on
+    // the radius-50 ring, far from the rect, so every candidate takes the fill
+    // branch. Reads are deterministic: one insidePath walk (4 reads x V edges)
+    // plus ~8 reads per candidate edge check ≈ 12V. The 15V bound fails if
+    // even one extra full walk sneaks back in (16V), let alone the K×V ≈ 160k
+    // of per-candidate recompute.
+    expect(candidates.queryRect(95, 55, 105, 65)).toHaveLength(V);
+    expect(reads).toBeGreaterThan(0);
+    expect(reads).toBeLessThan(15 * V);
+  });
+
+  it("two filled subpaths resolve containment independently", () => {
+    const plot = scene();
+    plot.batches = [
+      {
+        kind: "paths",
+        layerIndex: 0,
+        panelIndex: 0,
+        // Subpath A: triangle (20,20) (80,20) (50,80).
+        // Subpath B: triangle (20,90) (180,90) (180,30) — its AABB covers the
+        // brush below, but the brush center is outside its fill.
+        positions: new Float32Array([20, 20, 80, 20, 50, 80, 20, 90, 180, 90, 180, 30]),
+        rowIndex: new Uint32Array([0, 1, 2, 3, 4, 5]),
+        pathOffsets: new Uint32Array([0, 3, 6]),
+        strokes: [null, null],
+        fills: [null, null],
+        closed: true,
+        linewidth: 0,
+        alpha: 1,
+        curve: "linear",
+      },
+    ];
+    const candidates = store(plot);
+    // Brush (40,40)-(60,50): center (50,45) inside A, outside B; B is
+    // shortlisted via its AABB but must not hit.
+    const hits = Array.from(candidates.queryRect(40, 40, 60, 50)).toSorted((a, b) => a - b);
+    expect(hits).toEqual([0, 1, 2]);
+  });
+});


### PR DESCRIPTION
## What

A complexity audit of `packages/core/src/` found that `pathsOps.intersects` re-runs `insidePath` — a full point-in-polygon walk, O(V) over subpath render vertices plus O(R) over batch ring starts — once per shortlisted candidate during `queryRect`, even though the rect center and subpath range are identical for every candidate on the same subpath.

For a filled area or polygon, every semantic vertex is a candidate, and all of them share one subpath AABB. An interior brush therefore shortlists all K of them and pays K full polygon walks: **worst-case O(K × V) per `queryRect` call** (K ≈ V for areas and polygons), on the brush-drag path exposed through `semantic-viewport.query`. The hover path (`hitTest`/`nearest`) already caches this via `pathContainment`; `intersects` was the one path op without a cache.

## Fix

Thread the same per-probe cache shape that `contains` and `aabb` already use (key `${batchId}:${start}:${end}`, one `Map` per `queryRect` call — a batch belongs to exactly one panel, so the key is sound). One `insidePath` walk per distinct subpath per query: **O(K + V)**. The map is named `rectContainment` because it caches rect-center containment, a different predicate from the point-containment maps `nearest`/`hitTest` build; the two must never share a Map.

No behavior change: the fill test stays "rect center inside polygon", and the new characterization tests pin that contract (interior brush, center-outside brush, two-subpath isolation).

## Evidence

New guard test reads the fixture's `positions` array through a counting Proxy across a `queryRect` over a 200-gon (K = V = 200, interior brush, no anchor or edge in the rect):

- before: **161,592** reads (K × V recompute)
- after: **2,392** reads; the bound `reads < 15 * V` fails if even one extra full walk returns

Unit tests on the op table prove memoization directly: two same-subpath candidates produce one cache entry; poisoned entries in both directions are consulted rather than recomputed; the anchor-in-rect early return never touches the cache.

```
bun test packages/core   # 1961 pass, 0 fail
bun run check            # tsc -b spec+core + contract checks clean
bun test packages/spec benchmarks scripts tests/evals   # 2109 pass, 0 fail
```

## Follow-ups

Deferred hotspots from the same audit, filed separately:

- #1287 — O(B²) peer scan in `buildInteractionMasks` outline focus resolution
- #1288 — `pathRingRanges` scans every batch ringStart per `insidePath` call

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1289" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->