### PR TITLE
refactor(svelte): one capability resolution seam behind the layer registry

### DIFF
--- a/.changeset/capability-resolution-seam.md
+++ b/.changeset/capability-resolution-seam.md
@@ -1,0 +1,13 @@
+---
+"@ggsvelte/svelte": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+refactor: one capability resolution seam behind the layer registry
+
+Internal only — no public API or behavior change. Legend focus/filter
+resolution shares one channel-capability core; the plot engine reads
+inspect/legendFocus/legendFilter through a single resolution factory with
+three independent SSR-safe deriveds, and advisory delivery goes through one
+once-per-diagnostic helper.

--- a/packages/svelte/src/lib/interaction/capability-resolution.svelte.ts
+++ b/packages/svelte/src/lib/interaction/capability-resolution.svelte.ts
@@ -1,0 +1,94 @@
+/**
+ * Host capability resolution — the one seam between the layer registry /
+ * plot props and the engine for interaction capabilities (inspect from
+ * `<Inspect>` children + prop, legendFocus / legendFilter from GuideLegend
+ * layers + deprecated plot props).
+ *
+ * THREE independent deriveds — never one combined bag. The inspect resolve
+ * reads only `registry.capabilities("inspect")` (`#capabilityVersion`), so
+ * geom/mark layer churn must not re-run it: interactionConfig diagnostics
+ * re-deliver per recompute (registry contract). The legend resolves read
+ * `registry.layers` (`#version`).
+ *
+ * `interactionConfig` normalization stays in the engine — it must NOT read
+ * `caps()` (legendFilter is not a normalizeInteractionConfig input; reading
+ * it there re-delivered config diagnostics on every filter toggle).
+ */
+import type { LayerRegistry } from "../geoms/registry.svelte.js";
+import {
+  resolveLegendFilterCapability,
+  type ResolvedLegendFilterCapability,
+} from "../legend/resolve-legend-filter.js";
+import {
+  resolveLegendFocusCapability,
+  type ResolvedLegendFocusCapability,
+} from "../legend/resolve-legend-focus.js";
+import {
+  readLegacyPlotLegendFilter,
+  readLegacyPlotLegendFocus,
+  resolveCapabilities,
+  type EnginePlotProps,
+  type ResolvedPlotCapabilities,
+} from "../plot-props.js";
+import {
+  resolveInspectCapability,
+  type ResolveInspectCapabilityResult,
+} from "./resolve-inspect-capability.js";
+
+/**
+ * SSR-safe derived: Svelte 5.33's one-pass SSR can cache a construction-time
+ * empty registry before declaration children initialize. The server branch
+ * recomputes on EVERY read (never caches); client reads keep normal rune
+ * dependency tracking. Call during component init (or an effect root) only.
+ */
+export function ssrSafeDerived<T>(compute: () => T): () => T {
+  const derived = $derived.by(compute);
+  return () => (typeof window === "undefined" ? compute() : derived);
+}
+
+export type CapabilityResolution = {
+  /** Inspect from prop + `<Inspect>` capability children (last child wins). */
+  inspect(): ResolveInspectCapabilityResult;
+  /** Legend focus from GuideLegend layers + deprecated plot prop. */
+  legendFocus(): ResolvedLegendFocusCapability;
+  /** Legend filter from GuideLegend layers + deprecated plot prop. */
+  legendFilter(): ResolvedLegendFilterCapability;
+  /** All five capability defaults for wiring advisories. */
+  caps(): ResolvedPlotCapabilities;
+};
+
+export function createCapabilityResolution(host: {
+  registry: LayerRegistry;
+  props: EnginePlotProps;
+}): CapabilityResolution {
+  const inspect = ssrSafeDerived(() =>
+    resolveInspectCapability({
+      prop: host.props.inspect,
+      children: host.registry.capabilities("inspect"),
+    }),
+  );
+  const legendFocus = ssrSafeDerived(() =>
+    resolveLegendFocusCapability({
+      plotProp: readLegacyPlotLegendFocus(host.props),
+      layers: host.registry.layers,
+    }),
+  );
+  const legendFilter = ssrSafeDerived(() =>
+    resolveLegendFilterCapability({
+      plotProp: readLegacyPlotLegendFilter(host.props),
+      layers: host.registry.layers,
+    }),
+  );
+  const caps = (): ResolvedPlotCapabilities => {
+    const select = host.props.select;
+    const zoom = host.props.zoom;
+    return resolveCapabilities({
+      inspect: inspect().input,
+      legendFocus: legendFocus().requested,
+      legendFilter: legendFilter().requested,
+      ...(select !== undefined && { select }),
+      ...(zoom !== undefined && { zoom }),
+    });
+  };
+  return { inspect, legendFocus, legendFilter, caps };
+}

--- a/packages/svelte/src/lib/interaction/capability-resolution.svelte.ts
+++ b/packages/svelte/src/lib/interaction/capability-resolution.svelte.ts
@@ -48,13 +48,13 @@ export function ssrSafeDerived<T>(compute: () => T): () => T {
 
 export type CapabilityResolution = {
   /** Inspect from prop + `<Inspect>` capability children (last child wins). */
-  inspect(): ResolveInspectCapabilityResult;
+  readonly inspect: () => ResolveInspectCapabilityResult;
   /** Legend focus from GuideLegend layers + deprecated plot prop. */
-  legendFocus(): ResolvedLegendFocusCapability;
+  readonly legendFocus: () => ResolvedLegendFocusCapability;
   /** Legend filter from GuideLegend layers + deprecated plot prop. */
-  legendFilter(): ResolvedLegendFilterCapability;
+  readonly legendFilter: () => ResolvedLegendFilterCapability;
   /** All five capability defaults for wiring advisories. */
-  caps(): ResolvedPlotCapabilities;
+  readonly caps: () => ResolvedPlotCapabilities;
 };
 
 export function createCapabilityResolution(host: {

--- a/packages/svelte/src/lib/legend/resolve-legend-capability.ts
+++ b/packages/svelte/src/lib/legend/resolve-legend-capability.ts
@@ -1,0 +1,104 @@
+/**
+ * Shared core of the legend channel capabilities (GuideLegend `focus` /
+ * `filter`). Owns the skeleton both share: off when nothing enables the kind,
+ * children define the channel set and route through the capability-specific
+ * merge, a plot prop alone means every channel (`"all"`) and passes the RAW
+ * prop through (same reference — no normalization on that path).
+ *
+ * The capability-specific config merges stay with their owners:
+ * focus = any explicit `preview: false` wins; filter = last explicit
+ * `mode`/`multiple` wins (plot first, then children in registry order).
+ */
+
+export type LegendChannelSet = ReadonlySet<string> | "all";
+
+export type ResolvedLegendChannelCapability<TInput> = {
+  /** Opt-in for wiring advisories (truthy even when later checks null it). */
+  readonly requested: TInput | false;
+  /** Value fed to the capability's config consumer. */
+  readonly configInput: TInput | false;
+  /** `"all"` = plot prop only; otherwise the children's channel set. */
+  readonly channels: LegendChannelSet;
+};
+
+/** Registry layer shape (values may be live getters — read via access). */
+type ChannelLayerLike = {
+  readonly kind: string;
+  readonly value?: unknown;
+};
+
+type ChannelChild<TInput> = { channel: string; input: Exclude<TInput, false> };
+
+function isEnabledInput<TInput>(input: TInput | undefined): input is Exclude<TInput, false> {
+  return input !== undefined && (input as unknown) !== false;
+}
+
+function readChildLayers<TInput>(
+  layers: readonly ChannelLayerLike[],
+  layerKind: string,
+): ReadonlyArray<ChannelChild<TInput>> {
+  const out: Array<ChannelChild<TInput>> = [];
+  for (const layer of layers) {
+    if (layer.kind !== layerKind) continue;
+    const value = (layer as { value: { channel: string; input: TInput } | null }).value;
+    if (value === null || value === undefined) continue;
+    if (!isEnabledInput<TInput>(value.input)) continue;
+    out.push({ channel: value.channel, input: value.input });
+  }
+  return out;
+}
+
+/**
+ * Combine plot prop + declaration children into one channel capability.
+ * `mergeChildrenConfig` runs ONLY when children are present — plot-alone
+ * returns the raw prop unchanged.
+ */
+export function resolveLegendChannelCapability<TInput>(args: {
+  readonly plotProp: TInput | undefined;
+  readonly layers: readonly ChannelLayerLike[];
+  readonly layerKind: string;
+  readonly mergeChildrenConfig: (
+    plotProp: TInput | undefined,
+    children: ReadonlyArray<ChannelChild<TInput>>,
+  ) => Exclude<TInput, false>;
+}): ResolvedLegendChannelCapability<TInput> {
+  const children = readChildLayers<TInput>(args.layers, args.layerKind);
+  const plotOn = isEnabledInput(args.plotProp);
+
+  if (children.length === 0 && !plotOn) {
+    return { requested: false, configInput: false, channels: new Set() };
+  }
+
+  if (children.length > 0) {
+    const configInput = args.mergeChildrenConfig(args.plotProp, children);
+    return {
+      requested: configInput,
+      configInput,
+      channels: new Set(children.map((child) => child.channel)),
+    };
+  }
+
+  return {
+    requested: args.plotProp ?? false,
+    configInput: args.plotProp ?? false,
+    channels: "all",
+  };
+}
+
+/**
+ * Keep entries whose scene legend aesthetics intersect the enabled channel
+ * set. Merged legends expose all aesthetics on `legend.aesthetics` (primary
+ * `scale` alone is not enough).
+ */
+export function filterEntriesByChannels<
+  T extends {
+    readonly legend: { readonly scale: string; readonly aesthetics?: readonly string[] };
+  },
+>(entries: readonly T[], channels: LegendChannelSet): T[] {
+  if (channels === "all") return entries.slice();
+  if (channels.size === 0) return [];
+  return entries.filter((entry) => {
+    const aesthetics = entry.legend.aesthetics ?? [entry.legend.scale];
+    return aesthetics.some((aesthetic) => channels.has(aesthetic));
+  });
+}

--- a/packages/svelte/src/lib/legend/resolve-legend-filter.ts
+++ b/packages/svelte/src/lib/legend/resolve-legend-filter.ts
@@ -4,8 +4,18 @@
  *
  * Interactions stay off PortableSpec: `filter` is stripped before guideLegend()
  * and travels as registry layer kind `legendFilter`.
+ *
+ * Skeleton (off / children→channels / plot-alone→"all") lives in
+ * resolve-legend-capability.ts; this module owns only the filter-specific
+ * merge: last explicit `mode`/`multiple` wins (plot first, then children in
+ * registry order).
  */
 import type { LegendFilterInput } from "./filter.js";
+import {
+  filterEntriesByChannels,
+  resolveLegendChannelCapability,
+  type LegendChannelSet,
+} from "./resolve-legend-capability.js";
 
 /** Aesthetic channel a GuideLegend may enable for filter (non-position). */
 type LegendFilterChannel = "color" | "fill" | "size" | "linewidth" | "alpha" | "shape" | "linetype";
@@ -16,7 +26,7 @@ export type LegendFilterLayerValue = {
   readonly input: Exclude<LegendFilterInput, false>;
 } | null;
 
-export type LegendFilterChannelSet = ReadonlySet<string> | "all";
+export type LegendFilterChannelSet = LegendChannelSet;
 
 export type ResolvedLegendFilterCapability = {
   /**
@@ -51,21 +61,6 @@ function isEnabledInput(
   input: LegendFilterInput | undefined,
 ): input is Exclude<LegendFilterInput, false> {
   return input !== undefined && input !== false;
-}
-
-function readChildLayers(
-  layers: readonly LegendFilterLayerLike[],
-): ReadonlyArray<{ channel: string; input: Exclude<LegendFilterInput, false> }> {
-  const out: Array<{ channel: string; input: Exclude<LegendFilterInput, false> }> = [];
-  for (const layer of layers) {
-    if (layer.kind !== "legendFilter") continue;
-    // Layer values may be live getters (registry) — read via property access.
-    const value = (layer as { value: LegendFilterLayerValue }).value;
-    if (value === null || value === undefined) continue;
-    if (!isEnabledInput(value.input)) continue;
-    out.push({ channel: value.channel, input: value.input });
-  }
-  return out;
 }
 
 /**
@@ -103,28 +98,12 @@ export function resolveLegendFilterCapability(input: {
   readonly plotProp: LegendFilterInput | undefined;
   readonly layers: readonly LegendFilterLayerLike[];
 }): ResolvedLegendFilterCapability {
-  const children = readChildLayers(input.layers);
-  const plotOn = isEnabledInput(input.plotProp);
-
-  if (children.length === 0 && !plotOn) {
-    return { requested: false, configInput: false, channels: new Set() };
-  }
-
-  const configInput = resolveConfigInput(input.plotProp, children);
-
-  if (children.length > 0) {
-    return {
-      requested: configInput,
-      configInput,
-      channels: new Set(children.map((child) => child.channel)),
-    };
-  }
-
-  return {
-    requested: input.plotProp ?? false,
-    configInput: input.plotProp ?? false,
-    channels: "all",
-  };
+  return resolveLegendChannelCapability<LegendFilterInput>({
+    plotProp: input.plotProp,
+    layers: input.layers,
+    layerKind: "legendFilter",
+    mergeChildrenConfig: resolveConfigInput,
+  });
 }
 
 /**
@@ -136,12 +115,7 @@ export function filterFilterableLegendEntries<T extends FilterableEntryLike>(
   entries: readonly T[],
   channels: LegendFilterChannelSet,
 ): T[] {
-  if (channels === "all") return entries.slice();
-  if (channels.size === 0) return [];
-  return entries.filter((entry) => {
-    const aesthetics = entry.legend.aesthetics ?? [entry.legend.scale];
-    return aesthetics.some((aesthetic) => channels.has(aesthetic));
-  });
+  return filterEntriesByChannels(entries, channels);
 }
 
 /** True when `filter` is an active opt-in (boolean true or options object). */

--- a/packages/svelte/src/lib/legend/resolve-legend-focus.ts
+++ b/packages/svelte/src/lib/legend/resolve-legend-focus.ts
@@ -4,9 +4,18 @@
  *
  * Interactions stay off PortableSpec: `focus` is stripped before guideLegend()
  * and travels as registry layer kind `legendFocus`.
+ *
+ * Skeleton (off / children→channels / plot-alone→"all") lives in
+ * resolve-legend-capability.ts; this module owns only the focus-specific
+ * merge: any explicit `preview: false` wins across prop and children.
  */
 import type { LegendFocusInput } from "../interaction/interaction.js";
 import type { InteractiveLegendEntry } from "./focus.js";
+import {
+  filterEntriesByChannels,
+  resolveLegendChannelCapability,
+  type LegendChannelSet,
+} from "./resolve-legend-capability.js";
 
 /** Aesthetic channel a GuideLegend may enable for focus (non-position). */
 type LegendFocusChannel = "color" | "fill" | "size" | "linewidth" | "alpha" | "shape" | "linetype";
@@ -17,7 +26,7 @@ export type LegendFocusLayerValue = {
   readonly input: Exclude<LegendFocusInput, false>;
 } | null;
 
-export type LegendFocusChannelSet = ReadonlySet<string> | "all";
+export type LegendFocusChannelSet = LegendChannelSet;
 
 export type ResolvedLegendFocusCapability = {
   /**
@@ -39,27 +48,6 @@ type LegendFocusLayerLike = {
   /** Live getter or plain field — only read when kind is legendFocus. */
   readonly value?: unknown;
 };
-
-function isEnabledInput(
-  input: LegendFocusInput | undefined,
-): input is Exclude<LegendFocusInput, false> {
-  return input !== undefined && input !== false;
-}
-
-function readChildLayers(
-  layers: readonly LegendFocusLayerLike[],
-): ReadonlyArray<{ channel: string; input: Exclude<LegendFocusInput, false> }> {
-  const out: Array<{ channel: string; input: Exclude<LegendFocusInput, false> }> = [];
-  for (const layer of layers) {
-    if (layer.kind !== "legendFocus") continue;
-    // Layer values may be live getters (registry) — read via property access.
-    const value = (layer as { value: LegendFocusLayerValue }).value;
-    if (value === null || value === undefined) continue;
-    if (!isEnabledInput(value.input)) continue;
-    out.push({ channel: value.channel, input: value.input });
-  }
-  return out;
-}
 
 /** Merge preview flags: any explicit `preview: false` disables preview. */
 function resolvePreview(
@@ -85,29 +73,12 @@ export function resolveLegendFocusCapability(input: {
   readonly plotProp: LegendFocusInput | undefined;
   readonly layers: readonly LegendFocusLayerLike[];
 }): ResolvedLegendFocusCapability {
-  const children = readChildLayers(input.layers);
-  const plotOn = isEnabledInput(input.plotProp);
-
-  if (children.length === 0 && !plotOn) {
-    return { requested: false, configInput: false, channels: new Set() };
-  }
-
-  const preview = resolvePreview(input.plotProp, children);
-  const configInput = toConfigInput(preview);
-
-  if (children.length > 0) {
-    return {
-      requested: configInput,
-      configInput,
-      channels: new Set(children.map((child) => child.channel)),
-    };
-  }
-
-  return {
-    requested: input.plotProp ?? false,
-    configInput: input.plotProp ?? false,
-    channels: "all",
-  };
+  return resolveLegendChannelCapability<LegendFocusInput>({
+    plotProp: input.plotProp,
+    layers: input.layers,
+    layerKind: "legendFocus",
+    mergeChildrenConfig: (plotProp, children) => toConfigInput(resolvePreview(plotProp, children)),
+  });
 }
 
 /**
@@ -115,21 +86,14 @@ export function resolveLegendFocusCapability(input: {
  * enabled channel set. Merged legends expose all aesthetics on
  * `legend.aesthetics` (primary `scale` alone is not enough).
  */
-export function filterInteractiveLegendEntries(
+export const filterInteractiveLegendEntries: (
   entries: readonly InteractiveLegendEntry[],
   channels: LegendFocusChannelSet,
-): InteractiveLegendEntry[] {
-  if (channels === "all") return entries.slice();
-  if (channels.size === 0) return [];
-  return entries.filter((entry) => {
-    const aesthetics = entry.legend.aesthetics ?? [entry.legend.scale];
-    return aesthetics.some((aesthetic) => channels.has(aesthetic));
-  });
-}
+) => InteractiveLegendEntry[] = filterEntriesByChannels;
 
 /** True when `focus` is an active opt-in (boolean true or options object). */
 export function isLegendFocusPropEnabled(
   focus: LegendFocusInput | undefined,
 ): focus is Exclude<LegendFocusInput, false> {
-  return isEnabledInput(focus);
+  return focus !== undefined && focus !== false;
 }

--- a/packages/svelte/src/lib/plot-engine.svelte.ts
+++ b/packages/svelte/src/lib/plot-engine.svelte.ts
@@ -73,7 +73,10 @@ import {
   type PlotInteractionScope,
   type ResolvedInteractionConfig,
 } from "./interaction/interaction.js";
-import { createCapabilityResolution } from "./interaction/capability-resolution.svelte.js";
+import {
+  createCapabilityResolution,
+  ssrSafeDerived,
+} from "./interaction/capability-resolution.svelte.js";
 import { duplicateInspectCapabilityDiagnostics } from "./interaction/resolve-inspect-capability.js";
 import { collectWiringDiagnostics } from "./interaction/wiring-advisories.js";
 import { createInspectionState } from "./inspection/inspection-state.svelte.js";
@@ -243,14 +246,8 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
     });
   }
 
-  // Svelte 5.33's one-pass SSR can cache a construction-time empty registry
-  // before declaration children initialize. Recompute from the plain registry
-  // on the server; client reads retain normal rune dependency tracking.
-  // Single SSR guard for the whole engine (#982 — previously duplicated across
-  // orchestrator + assembly).
-  const assembledDerived: PortableSpec | null = $derived.by(assembleCurrentSpec);
-  const assembled = (): PortableSpec | null =>
-    typeof window === "undefined" ? assembleCurrentSpec() : assembledDerived;
+  // SSR one-pass recompute rationale lives on ssrSafeDerived (#982).
+  const assembled: () => PortableSpec | null = ssrSafeDerived(assembleCurrentSpec);
 
   // Facet intent: registry facet plot layer (<FacetWrap/> / <FacetGrid/> / <Facet/>),
   // OR assembled.facet (portable-spec embeds). Grammar props removed in 0.13.0 (#704).
@@ -285,9 +282,7 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
       data: data ?? embedded,
     });
   }
-  const resolvedDatumKeyDerived = $derived.by(resolvedDatumKeyNow);
-  const resolvedDatumKey = () =>
-    typeof window === "undefined" ? resolvedDatumKeyNow() : resolvedDatumKeyDerived;
+  const resolvedDatumKey = ssrSafeDerived(resolvedDatumKeyNow);
 
   const resolvedInteractionScope: PlotInteractionScope = $derived(
     (() => {
@@ -327,9 +322,8 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
       },
     );
   }
-  const interactionConfigDerived = $derived.by(interactionConfigCurrent);
-  const interactionConfig = (): ResolvedInteractionConfig =>
-    typeof window === "undefined" ? interactionConfigCurrent() : interactionConfigDerived;
+  const interactionConfig: () => ResolvedInteractionConfig =
+    ssrSafeDerived(interactionConfigCurrent);
 
   function deliverDiagnostic(diagnostic: PlotDiagnostic): void {
     const ondiagnostic = host.props.ondiagnostic;
@@ -376,93 +370,92 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
       },
     });
   });
-  // Shared once-per-code-per-prop Set for wiring + composition + multi-Inspect
-  // + deprecations. Order: config → wiring → multi-inspect → legendFocus
-  // deprecation → composition.
-  // Grammar-prop deprecation emission removed in 0.13.0 (#704) — props gone.
+  // Shared once-per-dedup-key Set for wiring + multi-Inspect + deprecations +
+  // composition + inspect-geom. Each deliverAdvisoriesOnce call registers ONE
+  // $effect; call order below is the registration (and first-flush delivery)
+  // order. Re-delivering effects (config diagnostics above, chrome area/legend
+  // diagnostics later) stay outside this helper by design.
   const deliveredAdvisories = new Set<string>();
-  $effect(() => {
-    for (const diagnostic of wiringDiagnostics) {
-      const dedupKey = `${diagnostic.code}:${diagnostic.prop}`;
-      if (deliveredAdvisories.has(dedupKey)) continue;
-      deliveredAdvisories.add(dedupKey);
-      deliverDiagnostic(diagnostic);
-    }
-  });
+  function deliverAdvisoriesOnce<T extends PlotDiagnostic>(
+    get: () => readonly T[],
+    dedupKeyOf: (diagnostic: T) => string = (diagnostic) =>
+      `${diagnostic.code}:${(diagnostic as { prop?: string }).prop}`,
+  ): void {
+    $effect(() => {
+      for (const diagnostic of get()) {
+        const dedupKey = dedupKeyOf(diagnostic);
+        if (deliveredAdvisories.has(dedupKey)) continue;
+        deliveredAdvisories.add(dedupKey);
+        deliverDiagnostic(diagnostic);
+      }
+    });
+  }
+
+  deliverAdvisoriesOnce(() => wiringDiagnostics);
 
   // Multiple <Inspect> children: last wins; advisory once per mount.
   const multiInspectDiagnostics = $derived.by((): InteractionDiagnostic[] =>
     duplicateInspectCapabilityDiagnostics(inspectResolved().multiChild),
   );
-  $effect(() => {
-    for (const diagnostic of multiInspectDiagnostics) {
-      const dedupKey = `${diagnostic.code}:${diagnostic.prop}`;
-      if (deliveredAdvisories.has(dedupKey)) continue;
-      deliveredAdvisories.add(dedupKey);
-      deliverDiagnostic(diagnostic);
-    }
-  });
+  deliverAdvisoriesOnce(() => multiInspectDiagnostics);
 
   // Deprecated plot-level key → Inspect / Select / controller identity.
-  $effect(() => {
+  const deprecatedKeyDiagnostics = $derived.by((): PlotDiagnostic[] => {
     const plotProp = readLegacyPlotKey(host.props);
-    if (plotProp === undefined) return;
-    const diagnostic = deprecatedPropDiagnostic({
-      prop: "key",
-      since: "0.21.0",
-      removeIn: "0.22.0",
-      suggestions: [
-        'Use <Inspect identity="year" /> (or inspect={{ identity: "year" }})',
-        'Use select={{ type: "point", identity: "year" }} when selection owns the key',
-        'Use createPlotInteraction({ identity: "year" }) for linked controllers',
-      ],
-      anchor: "row-identity-on-interaction",
-    });
-    const dedupKey = `${diagnostic.code}:${diagnostic.prop}`;
-    if (deliveredAdvisories.has(dedupKey)) return;
-    deliveredAdvisories.add(dedupKey);
-    deliverDiagnostic(diagnostic);
+    if (plotProp === undefined) return [];
+    return [
+      deprecatedPropDiagnostic({
+        prop: "key",
+        since: "0.21.0",
+        removeIn: "0.22.0",
+        suggestions: [
+          'Use <Inspect identity="year" /> (or inspect={{ identity: "year" }})',
+          'Use select={{ type: "point", identity: "year" }} when selection owns the key',
+          'Use createPlotInteraction({ identity: "year" }) for linked controllers',
+        ],
+        anchor: "row-identity-on-interaction",
+      }),
+    ];
   });
+  deliverAdvisoriesOnce(() => deprecatedKeyDiagnostics);
 
   // Deprecated plot-level legendFocus → GuideLegend.focus (one minor window).
-  $effect(() => {
+  const deprecatedLegendFocusDiagnostics = $derived.by((): PlotDiagnostic[] => {
     const plotProp = readLegacyPlotLegendFocus(host.props);
-    if (plotProp === undefined || plotProp === false) return;
-    const diagnostic = deprecatedPropDiagnostic({
-      prop: "legendFocus",
-      since: "0.19.0",
-      removeIn: "0.20.0",
-      suggestions: [
-        'Use <GuideLegend channel="color" focus /> (or the aesthetic that owns the discrete legend)',
-        "focus={{ preview: false }} on GuideLegend replaces legendFocus={{ preview: false }}",
-      ],
-      anchor: "legend-focus-on-guidelegend",
-    });
-    const dedupKey = `${diagnostic.code}:${diagnostic.prop}`;
-    if (deliveredAdvisories.has(dedupKey)) return;
-    deliveredAdvisories.add(dedupKey);
-    deliverDiagnostic(diagnostic);
+    if (plotProp === undefined || plotProp === false) return [];
+    return [
+      deprecatedPropDiagnostic({
+        prop: "legendFocus",
+        since: "0.19.0",
+        removeIn: "0.20.0",
+        suggestions: [
+          'Use <GuideLegend channel="color" focus /> (or the aesthetic that owns the discrete legend)',
+          "focus={{ preview: false }} on GuideLegend replaces legendFocus={{ preview: false }}",
+        ],
+        anchor: "legend-focus-on-guidelegend",
+      }),
+    ];
   });
+  deliverAdvisoriesOnce(() => deprecatedLegendFocusDiagnostics);
 
   // Deprecated plot-level legendFilter → GuideLegend.filter (one minor window).
-  $effect(() => {
+  const deprecatedLegendFilterDiagnostics = $derived.by((): PlotDiagnostic[] => {
     const plotProp = readLegacyPlotLegendFilter(host.props);
-    if (plotProp === undefined || plotProp === false) return;
-    const diagnostic = deprecatedPropDiagnostic({
-      prop: "legendFilter",
-      since: "0.19.0",
-      removeIn: "0.20.0",
-      suggestions: [
-        'Use <GuideLegend channel="color" filter /> (or the aesthetic that owns the discrete legend)',
-        'filter={{ mode: "include", multiple: false }} on GuideLegend replaces legendFilter={{ … }}',
-      ],
-      anchor: "legend-filter-on-guidelegend",
-    });
-    const dedupKey = `${diagnostic.code}:${diagnostic.prop}`;
-    if (deliveredAdvisories.has(dedupKey)) return;
-    deliveredAdvisories.add(dedupKey);
-    deliverDiagnostic(diagnostic);
+    if (plotProp === undefined || plotProp === false) return [];
+    return [
+      deprecatedPropDiagnostic({
+        prop: "legendFilter",
+        since: "0.19.0",
+        removeIn: "0.20.0",
+        suggestions: [
+          'Use <GuideLegend channel="color" filter /> (or the aesthetic that owns the discrete legend)',
+          'filter={{ mode: "include", multiple: false }} on GuideLegend replaces legendFilter={{ … }}',
+        ],
+        anchor: "legend-filter-on-guidelegend",
+      }),
+    ];
   });
+  deliverAdvisoriesOnce(() => deprecatedLegendFilterDiagnostics);
 
   // Composition advisories (#659 slices 3+5+6): pure collect over
   // registry.layers. Last child still wins (shallow merge / last write);
@@ -470,14 +463,7 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
   const compositionDiagnostics = $derived.by((): CompositionDiagnostic[] =>
     collectCompositionDiagnostics(host.registry.layers),
   );
-  $effect(() => {
-    for (const diagnostic of compositionDiagnostics) {
-      const dedupKey = compositionAdvisoryDedupKey(diagnostic);
-      if (deliveredAdvisories.has(dedupKey)) continue;
-      deliveredAdvisories.add(dedupKey);
-      deliverDiagnostic(diagnostic);
-    }
-  });
+  deliverAdvisoriesOnce(() => compositionDiagnostics, compositionAdvisoryDedupKey);
 
   // Inspect axis guides that fight bar/col geometry (or bisect on-bar labels).
   // Needs assembled layers + resolved inspect.mode; once-per-code:prop like wiring.
@@ -486,14 +472,7 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
     if (mode === undefined) return [];
     return inspectAxisOnBarColDiagnostics(mode, layerGeomsFromSpecLayers(assembled()?.layers));
   });
-  $effect(() => {
-    for (const diagnostic of inspectGeomDiagnostics) {
-      const dedupKey = `${diagnostic.code}:${diagnostic.prop}`;
-      if (deliveredAdvisories.has(dedupKey)) continue;
-      deliveredAdvisories.add(dedupKey);
-      deliverDiagnostic(diagnostic);
-    }
-  });
+  deliverAdvisoriesOnce(() => inspectGeomDiagnostics);
 
   // PublicKey → PropertyKey widening lives in widenPlotProps (plot-props.ts).
   // Controllers read host.props handlers directly (already widened).

--- a/packages/svelte/src/lib/plot-engine.svelte.ts
+++ b/packages/svelte/src/lib/plot-engine.svelte.ts
@@ -73,10 +73,8 @@ import {
   type PlotInteractionScope,
   type ResolvedInteractionConfig,
 } from "./interaction/interaction.js";
-import {
-  duplicateInspectCapabilityDiagnostics,
-  resolveInspectCapability,
-} from "./interaction/resolve-inspect-capability.js";
+import { createCapabilityResolution } from "./interaction/capability-resolution.svelte.js";
+import { duplicateInspectCapabilityDiagnostics } from "./interaction/resolve-inspect-capability.js";
 import { collectWiringDiagnostics } from "./interaction/wiring-advisories.js";
 import { createInspectionState } from "./inspection/inspection-state.svelte.js";
 import type { InspectionState } from "./inspection/inspection-state.svelte.js";
@@ -88,16 +86,8 @@ import type { FilterableLegendEntry, LegendFilterState } from "./legend/filter-s
 import type { InteractiveLegendEntry, LegendEntryIdentity } from "./legend/focus.js";
 import { createLegendFocusState } from "./legend/focus-state.svelte.js";
 import type { LegendFocusState } from "./legend/focus-state.svelte.js";
-import {
-  filterFilterableLegendEntries,
-  resolveLegendFilterCapability,
-  type ResolvedLegendFilterCapability,
-} from "./legend/resolve-legend-filter.js";
-import {
-  filterInteractiveLegendEntries,
-  resolveLegendFocusCapability,
-  type ResolvedLegendFocusCapability,
-} from "./legend/resolve-legend-focus.js";
+import { filterFilterableLegendEntries } from "./legend/resolve-legend-filter.js";
+import { filterInteractiveLegendEntries } from "./legend/resolve-legend-focus.js";
 import { createPlotChromeState } from "./chrome/chrome-state.svelte.js";
 import type { PlotChromeState } from "./chrome/chrome-state.svelte.js";
 import { isHostPlotLayer } from "./layers/types.js";
@@ -106,9 +96,7 @@ import {
   readLegacyPlotKey,
   readLegacyPlotLegendFilter,
   readLegacyPlotLegendFocus,
-  resolveCapabilities,
   type EnginePlotProps,
-  type ResolvedPlotCapabilities,
 } from "./plot-props.js";
 import { createPlotAnnouncer } from "./runtime/announcer.svelte.js";
 import type { PlotAnnouncer } from "./runtime/announcer.svelte.js";
@@ -217,19 +205,18 @@ export type PlotEngine = {
 // ---------------------------------------------------------------------------
 
 export function createPlotEngine(host: PlotEngineHost): PlotEngine {
-  // Inspect capability: prop + host capability registry children. Pure resolve
-  // stays props-agnostic of registry; engine is the seam (plot-props stays
-  // props-only). SSR: recompute from the plain registry like assembled (#982)
-  // so one-pass construction does not latch empty children as inspect-off.
-  function resolveInspectCurrent() {
-    return resolveInspectCapability({
-      prop: host.props.inspect,
-      children: host.registry.capabilities("inspect"),
-    });
-  }
-  const inspectResolvedDerived = $derived.by(resolveInspectCurrent);
-  const inspectResolved = () =>
-    typeof window === "undefined" ? resolveInspectCurrent() : inspectResolvedDerived;
+  // Capability resolution seam (inspect / legendFocus / legendFilter / caps):
+  // three independent SSR-safe deriveds behind one factory — see
+  // capability-resolution.svelte.ts for the capabilityVersion-vs-version
+  // isolation contract and the SSR one-pass recompute rationale.
+  const capabilityResolution = createCapabilityResolution({
+    registry: host.registry,
+    props: host.props,
+  });
+  const inspectResolved = capabilityResolution.inspect;
+  const legendFocusResolved = capabilityResolution.legendFocus;
+  const legendFilterResolved = capabilityResolution.legendFilter;
+  const caps = capabilityResolution.caps;
 
   // Reading descriptors through toLayerInput goes through live getters, so
   // geom prop changes flow into this $derived without re-registration.
@@ -318,51 +305,6 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
       });
     })(),
   );
-
-  /**
-   * Legend focus from `<GuideLegend focus>` (and deprecated plot prop).
-   * SSR recompute: same one-pass empty-registry trap as assembleCurrentSpec —
-   * children register after construction-time $derived may snapshot.
-   */
-  function resolveLegendFocusNow(): ResolvedLegendFocusCapability {
-    return resolveLegendFocusCapability({
-      plotProp: readLegacyPlotLegendFocus(host.props),
-      layers: host.registry.layers,
-    });
-  }
-  const legendFocusResolvedDerived = $derived.by(resolveLegendFocusNow);
-  const legendFocusResolved = (): ResolvedLegendFocusCapability =>
-    typeof window === "undefined" ? resolveLegendFocusNow() : legendFocusResolvedDerived;
-
-  /**
-   * Legend filter from `<GuideLegend filter>` (and deprecated plot prop).
-   * Same SSR recompute path as focus — empty registry on first SSR pass.
-   */
-  function resolveLegendFilterNow(): ResolvedLegendFilterCapability {
-    return resolveLegendFilterCapability({
-      plotProp: readLegacyPlotLegendFilter(host.props),
-      layers: host.registry.layers,
-    });
-  }
-  const legendFilterResolvedDerived = $derived.by(resolveLegendFilterNow);
-  const legendFilterResolved = (): ResolvedLegendFilterCapability =>
-    typeof window === "undefined" ? resolveLegendFilterNow() : legendFilterResolvedDerived;
-
-  // Capability defaults for wiring — inspect from prop + <Inspect> children;
-  // legendFocus/legendFilter "requested" from GuideLegend / legacy prop
-  // (not host.props.legendFocus/legendFilter direct — type-aware lint denies
-  // deprecated dual-read outside the isolated readers).
-  const caps = (): ResolvedPlotCapabilities => {
-    const select = host.props.select;
-    const zoom = host.props.zoom;
-    return resolveCapabilities({
-      inspect: inspectResolved().input,
-      legendFocus: legendFocusResolved().requested,
-      legendFilter: legendFilterResolved().requested,
-      ...(select !== undefined && { select }),
-      ...(zoom !== undefined && { zoom }),
-    });
-  };
 
   // interactionConfig: inspect from prop + <Inspect> children; legendFocus from
   // GuideLegend (host registry). SSR hatch matches assembled / inspectResolved.

--- a/packages/svelte/tests/interaction/capability-resolution.ssr.test.ts
+++ b/packages/svelte/tests/interaction/capability-resolution.ssr.test.ts
@@ -1,0 +1,26 @@
+/**
+ * SSR: capability children resolve in the first server pass. Svelte's
+ * one-pass SSR constructs the engine before declaration children register;
+ * the ssrSafeDerived recompute path must not latch the empty registry as
+ * inspect-off (capability-resolution.svelte.ts).
+ */
+import { describe, expect, it } from "vitest";
+
+import InspectChildPlot from "../fixtures/InspectChildPlot.svelte";
+import { renderSsrFixture } from "../helpers/ssr.js";
+
+describe("capability resolution SSR", () => {
+  it("<Inspect> child enables interaction chrome from the very first byte", () => {
+    const fixture = renderSsrFixture(InspectChildPlot, { useInspect: true });
+    // Focusable point targets + the capture surface exist only when the
+    // inspect capability resolved server-side.
+    expect(fixture.body).toContain("tabindex");
+    expect(fixture.body).toContain("gg-capture");
+  });
+
+  it("no capability child, no prop: the same chrome is absent", () => {
+    const fixture = renderSsrFixture(InspectChildPlot, {});
+    expect(fixture.body).not.toContain("tabindex");
+    expect(fixture.body).not.toContain("gg-capture");
+  });
+});

--- a/packages/svelte/tests/interaction/capability-resolution.test.ts
+++ b/packages/svelte/tests/interaction/capability-resolution.test.ts
@@ -1,3 +1,4 @@
+import { fromPartial } from "@total-typescript/shoehorn";
 import { flushSync } from "svelte";
 import { describe, expect, it } from "vitest";
 
@@ -13,7 +14,7 @@ function makeProps(overrides: Record<string, unknown> = {}): EnginePlotProps {
 }
 
 function focusLayer(channel: string): Layer {
-  return { kind: "legendFocus", value: { channel, input: true } } as unknown as Layer;
+  return fromPartial({ kind: "legendFocus", value: { channel, input: true } });
 }
 
 describe("createCapabilityResolution", () => {
@@ -68,10 +69,12 @@ describe("createCapabilityResolution", () => {
     );
     expect(resolution.legendFocus().requested).toBe(false);
     registry.registerPlotLayer(focusLayer("shape"));
-    registry.registerPlotLayer({
-      kind: "legendFilter",
-      value: { channel: "color", input: { mode: "include" as const } },
-    } as unknown as Layer);
+    registry.registerPlotLayer(
+      fromPartial<Layer>({
+        kind: "legendFilter",
+        value: { channel: "color", input: { mode: "include" as const } },
+      }),
+    );
     flushSync();
     expect(resolution.legendFocus().channels).toEqual(new Set(["shape"]));
     expect(resolution.legendFilter().configInput).toEqual({ mode: "include" });

--- a/packages/svelte/tests/interaction/capability-resolution.test.ts
+++ b/packages/svelte/tests/interaction/capability-resolution.test.ts
@@ -1,0 +1,100 @@
+import { flushSync } from "svelte";
+import { describe, expect, it } from "vitest";
+
+import type { Layer } from "../../src/lib/layers/types.js";
+import { LayerRegistry } from "../../src/lib/geoms/registry.svelte.js";
+import { createCapabilityResolution } from "../../src/lib/interaction/capability-resolution.svelte.js";
+import type { EnginePlotProps } from "../../src/lib/plot-props.js";
+import { resolveCapabilities } from "../../src/lib/plot-props.js";
+import { withFlushedEffectRoot } from "../helpers/effect-root.svelte.js";
+
+function makeProps(overrides: Record<string, unknown> = {}): EnginePlotProps {
+  return overrides as unknown as EnginePlotProps;
+}
+
+function focusLayer(channel: string): Layer {
+  return { kind: "legendFocus", value: { channel, input: true } } as unknown as Layer;
+}
+
+describe("createCapabilityResolution", () => {
+  it("inspect: capability children override the prop; last child wins", () => {
+    const registry = new LayerRegistry();
+    const { value: resolution, destroy } = withFlushedEffectRoot(() =>
+      createCapabilityResolution({ registry, props: makeProps({ inspect: false }) }),
+    );
+    expect(resolution.inspect().input).toBe(false);
+    registry.registerCapability("inspect", () => ({}));
+    registry.registerCapability("inspect", () => ({ mode: "x" as const }));
+    flushSync();
+    expect(resolution.inspect().input).toEqual({ mode: "x" });
+    expect(resolution.inspect().multiChild).toBe(true);
+    destroy();
+  });
+
+  it("mark/grammar layer churn does not re-run inspect resolve (registry contract)", () => {
+    const registry = new LayerRegistry();
+    const { value: resolution, destroy } = withFlushedEffectRoot(() =>
+      createCapabilityResolution({ registry, props: makeProps({ inspect: true }) }),
+    );
+    const before = resolution.inspect();
+    const id = registry.registerPlotLayer(focusLayer("color"));
+    flushSync();
+    // Same cached object — the inspect derived depends on capabilityVersion only.
+    expect(resolution.inspect()).toBe(before);
+    registry.unregister(id);
+    flushSync();
+    expect(resolution.inspect()).toBe(before);
+    destroy();
+  });
+
+  it("capability churn does not disturb the legend resolves", () => {
+    const registry = new LayerRegistry();
+    registry.registerPlotLayer(focusLayer("color"));
+    const { value: resolution, destroy } = withFlushedEffectRoot(() =>
+      createCapabilityResolution({ registry, props: makeProps() }),
+    );
+    const before = resolution.legendFocus();
+    expect(before.channels).toEqual(new Set(["color"]));
+    registry.registerCapability("inspect", () => ({}));
+    flushSync();
+    expect(resolution.legendFocus()).toBe(before);
+    destroy();
+  });
+
+  it("legend focus and filter read their registry layer kinds", () => {
+    const registry = new LayerRegistry();
+    const { value: resolution, destroy } = withFlushedEffectRoot(() =>
+      createCapabilityResolution({ registry, props: makeProps() }),
+    );
+    expect(resolution.legendFocus().requested).toBe(false);
+    registry.registerPlotLayer(focusLayer("shape"));
+    registry.registerPlotLayer({
+      kind: "legendFilter",
+      value: { channel: "color", input: { mode: "include" as const } },
+    } as unknown as Layer);
+    flushSync();
+    expect(resolution.legendFocus().channels).toEqual(new Set(["shape"]));
+    expect(resolution.legendFilter().configInput).toEqual({ mode: "include" });
+    destroy();
+  });
+
+  it("caps() folds all five capabilities through resolveCapabilities", () => {
+    const registry = new LayerRegistry();
+    registry.registerCapability("inspect", () => ({}));
+    const { value: resolution, destroy } = withFlushedEffectRoot(() =>
+      createCapabilityResolution({
+        registry,
+        props: makeProps({ select: { type: "point" as const } }),
+      }),
+    );
+    expect(resolution.caps()).toEqual(
+      resolveCapabilities({
+        inspect: true,
+        legendFocus: false,
+        legendFilter: false,
+        select: { type: "point" },
+      }),
+    );
+    destroy();
+  });
+});

--- a/packages/svelte/tests/interaction/capability-resolution.test.ts
+++ b/packages/svelte/tests/interaction/capability-resolution.test.ts
@@ -9,7 +9,7 @@ import { resolveCapabilities } from "../../src/lib/plot-props.js";
 import { withFlushedEffectRoot } from "../helpers/effect-root.svelte.js";
 
 function makeProps(overrides: Record<string, unknown> = {}): EnginePlotProps {
-  return overrides as unknown as EnginePlotProps;
+  return overrides;
 }
 
 function focusLayer(channel: string): Layer {

--- a/packages/svelte/tests/legend/resolve-legend-capability.test.ts
+++ b/packages/svelte/tests/legend/resolve-legend-capability.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  filterEntriesByChannels,
+  resolveLegendChannelCapability,
+} from "../../src/lib/legend/resolve-legend-capability.js";
+
+type FakeInput = true | { flag?: boolean };
+
+/** Children-path merge used by the tests: object-with-count so merges are visible. */
+function mergeCount(
+  plotProp: FakeInput | undefined,
+  children: ReadonlyArray<{ channel: string; input: Exclude<FakeInput, false> }>,
+): Exclude<FakeInput, false> {
+  const explicit = (plotProp !== undefined && plotProp !== true ? 1 : 0) + children.length;
+  return { flag: explicit > 1 };
+}
+
+describe("resolveLegendChannelCapability", () => {
+  it("is off when neither plot prop nor children enable the kind", () => {
+    expect(
+      resolveLegendChannelCapability<FakeInput>({
+        plotProp: undefined,
+        layers: [{ kind: "other", value: { channel: "color", input: true } }],
+        layerKind: "legendFocus",
+        mergeChildrenConfig: mergeCount,
+      }),
+    ).toEqual({ requested: false, configInput: false, channels: new Set() });
+  });
+
+  it("plot prop alone is all-channels and passes the raw reference through", () => {
+    const prop = { flag: true } as const;
+    const resolved = resolveLegendChannelCapability<FakeInput>({
+      plotProp: prop,
+      layers: [],
+      layerKind: "legendFocus",
+      mergeChildrenConfig: () => {
+        throw new Error("mergeChildrenConfig must not run on the plot-alone path");
+      },
+    });
+    expect(resolved.requested).toBe(prop);
+    expect(resolved.configInput).toBe(prop);
+    expect(resolved.channels).toBe("all");
+  });
+
+  it("children define the channel set and route through the capability merge", () => {
+    const resolved = resolveLegendChannelCapability<FakeInput>({
+      plotProp: true,
+      layers: [
+        { kind: "legendFocus", value: { channel: "color", input: true } },
+        { kind: "legendFocus", value: { channel: "shape", input: { flag: false } } },
+        // Skipped: wrong kind, null value, disabled input.
+        { kind: "legendFilter", value: { channel: "alpha", input: true } },
+        { kind: "legendFocus", value: null },
+        { kind: "legendFocus", value: { channel: "size", input: false } },
+      ],
+      layerKind: "legendFocus",
+      mergeChildrenConfig: mergeCount,
+    });
+    expect(resolved.channels).toEqual(new Set(["color", "shape"]));
+    expect(resolved.requested).toEqual({ flag: true });
+    expect(resolved.configInput).toEqual({ flag: true });
+  });
+});
+
+describe("filterEntriesByChannels", () => {
+  const entries = [
+    { legend: { scale: "color" }, name: "plain" },
+    { legend: { scale: "color", aesthetics: ["color", "shape"] }, name: "merged" },
+  ];
+
+  it("keeps all on 'all', drops all on empty, matches merged aesthetics", () => {
+    expect(filterEntriesByChannels(entries, "all")).toHaveLength(2);
+    expect(filterEntriesByChannels(entries, new Set())).toEqual([]);
+    const shape = filterEntriesByChannels(entries, new Set(["shape"]));
+    expect(shape.map((entry) => entry.name)).toEqual(["merged"]);
+  });
+});

--- a/packages/svelte/tests/legend/resolve-legend-focus.test.ts
+++ b/packages/svelte/tests/legend/resolve-legend-focus.test.ts
@@ -68,6 +68,30 @@ describe("resolveLegendFocusCapability", () => {
     });
     expect(resolved.configInput).toEqual({ preview: false });
   });
+
+  it("any explicit preview false wins across prop and children", () => {
+    // plot true + child {preview: false}
+    expect(
+      resolveLegendFocusCapability({
+        plotProp: true,
+        layers: [{ kind: "legendFocus", value: { channel: "color", input: { preview: false } } }],
+      }).configInput,
+    ).toEqual({ preview: false });
+    // plot {preview: false} + child true — the child cannot re-enable preview
+    expect(
+      resolveLegendFocusCapability({
+        plotProp: { preview: false },
+        layers: [{ kind: "legendFocus", value: { channel: "color", input: true } }],
+      }).configInput,
+    ).toEqual({ preview: false });
+  });
+
+  it("plot-prop-alone passes the raw prop reference through", () => {
+    const prop = { preview: false } as const;
+    const resolved = resolveLegendFocusCapability({ plotProp: prop, layers: [] });
+    expect(resolved.requested).toBe(prop);
+    expect(resolved.configInput).toBe(prop);
+  });
 });
 
 describe("filterInteractiveLegendEntries", () => {


### PR DESCRIPTION
## What

Every interaction capability child cloned the same shape: a resolve module, a hand-written SSR-recompute triple in the engine, and a copied once-per-key advisory `$effect`. This PR concentrates each of those idioms in one place. Internal only — no public API or behavior change.

- **`legend/resolve-legend-capability.ts`** — the shared skeleton of the focus/filter twins: off state, children define the channel set and route through the capability-specific merge, a plot prop alone means `"all"` and passes the raw prop through untouched (same reference). The twins keep their public names and their divergent merges — focus: any explicit `preview: false` wins across prop and children; filter: last explicit `mode`/`multiple` wins, plot first then children. New unit tests pin the divergences the twin suites lacked (plot `true` + child `{preview: false}`, cross-source last-wins, raw-reference pass-through).
- **`interaction/capability-resolution.svelte.ts`** — the engine's capability seam: `createCapabilityResolution({registry, props})` with **three independent SSR-safe deriveds**. The inspect resolve reads only `registry.capabilities("inspect")` (`#capabilityVersion`), so geom/mark churn cannot re-run inspect resolve and re-fire config diagnostics — the registry's documented isolation contract, now pinned by unit tests in both directions with a real `LayerRegistry`. The legend resolves read `registry.layers` (`#version`). `interactionConfig` stays in the engine and still never reads `caps()` (the legendFilter-toggle diagnostic-spam contract).
- **`ssrSafeDerived(compute)`** — the "Svelte one-pass SSR can latch an empty registry" recompute idiom, written once instead of six times. `assembled`, `resolvedDatumKey`, and `interactionConfig` migrate to it; zero `typeof window` triples remain in the engine.
- **`deliverAdvisoriesOnce(get, dedupKeyOf?)`** — one `$effect` per diagnostic family, called seven times in the prior registration order (wiring, multi-inspect, key/legendFocus/legendFilter deprecations, composition with its custom dedup key, inspect-geom) over the shared once-per-dedup-key Set. Re-delivering effects (config, chrome) stay outside it by design.
- New SSR test pins that `<Inspect>` capability children resolve in the first server pass (`tabindex` + `gg-capture` chrome present; absent without the child).

## Why

A future capability child stops being a seven-touch engine edit: the resolve, SSR hatch, and caps folding land in the resolution factory, and the copied idioms stop being copyable. `plot-engine.svelte.ts` drops from 966 to ~870 lines with three fewer load-bearing comment copies.

## Tests

- New: `tests/legend/resolve-legend-capability.test.ts` (shared core, red-first), `tests/interaction/capability-resolution.test.ts` (factory + both registry-isolation directions, red-first), `tests/interaction/capability-resolution.ssr.test.ts` (server-pass capability resolution), plus divergence pins added to `resolve-legend-focus.test.ts`.
- Unchanged suites as refactor guards: both twin suites, wiring-diagnostics, plot-engine.lifecycle, inspect-child, legend focus/filter component + integration.
- Full runs green: browser 438 files / 4,749 tests; SSR 15 files / 125 tests; `svelte-check`, oxlint, oxfmt, knip, `bun run check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1290" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->