### PR TITLE
fix: address remaining post-merge review findings from #1278

### DIFF
--- a/.changeset/sweep-1278-tz-lean-date.md
+++ b/.changeset/sweep-1278-tz-lean-date.md
@@ -1,0 +1,10 @@
+---
+"@ggsvelte/core": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+fix(core): reject invalid auto-scale timezones early; lean date axes use timeTicks without Temporal
+
+- `assertTemporalConfiguration` still validates `timezone` when the parser is `"auto"` (no more silent fall-through to generic parse failures).
+- Lean `@ggsvelte/core/render` date-axis charts fall back to `timeTicks` + `formatTime` when the temporal runtime is not installed, instead of throwing from `planTemporalAxis`.

--- a/packages/core/src/layout/layout-derive-ticks.ts
+++ b/packages/core/src/layout/layout-derive-ticks.ts
@@ -373,7 +373,7 @@ export function deriveTicks(
     // `@ggsvelte/core/render` still classifies ISO columns as temporal and
     // trains a time scale — fall through to timeTicks + formatTime instead of
     // throwing from requireTemporalRuntime("planTemporalAxis").
-    const temporalRuntime = domain.temporal !== undefined ? getTemporalRuntime() : null;
+    const temporalRuntime = domain.temporal === undefined ? null : getTemporalRuntime();
     if (domain.temporal !== undefined && temporalRuntime !== null) {
       const plan = temporalRuntime.planAxis({
         aesthetic: domain.temporal.aesthetic,

--- a/packages/core/src/layout/layout-derive-ticks.ts
+++ b/packages/core/src/layout/layout-derive-ticks.ts
@@ -6,7 +6,7 @@ import { encodeKey } from "../scales/state.js";
 import type { CellValue } from "../table.js";
 import type { AxisGuidePlan } from "./temporal-guide.js";
 import { planBandAxis, type BandAxisPlan, type BandGuideConfig } from "./band-guide.js";
-import { requireTemporalRuntime } from "../temporal-runtime.js";
+import { getTemporalRuntime } from "../temporal-runtime.js";
 import type { TextMeasurer } from "./measure.js";
 import { truncateToFit } from "./truncate.js";
 import {
@@ -369,8 +369,13 @@ export function deriveTicks(
   }
 
   if (domain.type === "time") {
-    if (domain.temporal !== undefined) {
-      const plan = requireTemporalRuntime("planTemporalAxis").planAxis({
+    // Full temporal guide planning needs the polyfill runtime. Lean
+    // `@ggsvelte/core/render` still classifies ISO columns as temporal and
+    // trains a time scale — fall through to timeTicks + formatTime instead of
+    // throwing from requireTemporalRuntime("planTemporalAxis").
+    const temporalRuntime = domain.temporal !== undefined ? getTemporalRuntime() : null;
+    if (domain.temporal !== undefined && temporalRuntime !== null) {
+      const plan = temporalRuntime.planAxis({
         aesthetic: domain.temporal.aesthetic,
         panelIndex: domain.temporal.panelIndex,
         domain: [min, max],

--- a/packages/core/src/layout/layout-derive-ticks.ts
+++ b/packages/core/src/layout/layout-derive-ticks.ts
@@ -351,7 +351,13 @@ export function deriveTicks(
   }
 
   // Explicit breaks override derivation (out-of-domain breaks are dropped).
-  if (domain.breaks !== undefined && !(domain.type === "time" && domain.temporal !== undefined)) {
+  // When the full temporal runtime is present, planAxis owns breaks for time
+  // domains (sourceBreaks + measured labels). Without the runtime (lean
+  // render entry), honor converted domain.breaks here so they are not
+  // silently replaced by automatic timeTicks.
+  const planTemporalGuides =
+    domain.type === "time" && domain.temporal !== undefined && getTemporalRuntime() !== null;
+  if (domain.breaks !== undefined && !planTemporalGuides) {
     const values = domain.breaks.filter((v) => Number.isFinite(v) && v >= min && v <= max);
     const step = smallestGap(values);
     const fmt: (v: number) => string = format
@@ -372,7 +378,7 @@ export function deriveTicks(
     // Full temporal guide planning needs the polyfill runtime. Lean
     // `@ggsvelte/core/render` still classifies ISO columns as temporal and
     // trains a time scale — fall through to timeTicks + formatTime instead of
-    // throwing from requireTemporalRuntime("planTemporalAxis").
+    // throwing when planAxis is unavailable.
     const temporalRuntime = domain.temporal === undefined ? null : getTemporalRuntime();
     if (domain.temporal !== undefined && temporalRuntime !== null) {
       const plan = temporalRuntime.planAxis({

--- a/packages/core/src/pipeline/temporal-preflight-shared.ts
+++ b/packages/core/src/pipeline/temporal-preflight-shared.ts
@@ -15,9 +15,10 @@ export function assertTemporalConfiguration(
   conversion: PositionConversionContext,
 ): void {
   if (conversion.forcedDiscrete) return;
-  if (conversion.parser === "auto") return;
-  // Explicit parsers require the full temporal runtime.
-  if (getTemporalRuntime() === null) {
+  // Explicit parsers need the Temporal polyfill; auto + lean ISO does not.
+  // Timezone (and other config) validation still runs for auto — otherwise a
+  // mistyped zone surfaces only as a confusing per-cell parse failure later.
+  if (conversion.parser !== "auto" && getTemporalRuntime() === null) {
     throw new PipelineError(
       "temporal-parse-failed",
       `/scales/${axis}`,

--- a/packages/core/src/temporal-runtime.ts
+++ b/packages/core/src/temporal-runtime.ts
@@ -61,12 +61,3 @@ export function resetTemporalRuntimeForTests(): void {
 export function temporalRuntimeGeneration(): number {
   return runtimeGeneration;
 }
-
-export function requireTemporalRuntime(feature: string): TemporalRuntime {
-  if (runtime === null) {
-    throw new Error(
-      `${feature} requires the temporal runtime. Import @ggsvelte/core (full) or @ggsvelte/core/temporal before rendering time scales.`,
-    );
-  }
-  return runtime;
-}

--- a/packages/core/tests/layout/lean-time-breaks.test.ts
+++ b/packages/core/tests/layout/lean-time-breaks.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Lean date-axis tick path: without the temporal runtime, deriveTicks must
+ * still honor author-configured breaks (Devin on #1291).
+ */
+import { describe, expect, it } from "bun:test";
+
+import { deriveTicks, type DeriveTicksContext } from "../../src/layout/layout-derive-ticks.ts";
+import type { Domain } from "../../src/layout/layout-types.ts";
+import { FONT_METRICS } from "../../src/layout/font-metrics.ts";
+import { MetricsTableMeasurer } from "../../src/layout/measure.ts";
+import { getTemporalRuntime, resetTemporalRuntimeForTests } from "../../src/temporal-runtime.ts";
+import { installTemporal } from "../../src/install-temporal.ts";
+
+const measurer = new MetricsTableMeasurer(FONT_METRICS);
+
+function horizontalCtx(extentPx = 400): DeriveTicksContext {
+  return {
+    orient: "horizontal",
+    extentPx,
+    measurer,
+    fontSize: 11,
+    marginCapPx: 80,
+    orthogonalMarginCapPx: 80,
+    orthogonalChromePx: 10,
+  };
+}
+
+describe("lean deriveTicks time breaks (no temporal runtime)", () => {
+  it("uses converted domain.breaks when domain.temporal is set but runtime is absent", () => {
+    resetTemporalRuntimeForTests();
+    expect(getTemporalRuntime()).toBeNull();
+    try {
+      const domain: Domain = {
+        type: "time",
+        min: Date.UTC(2024, 0, 1),
+        max: Date.UTC(2024, 0, 31),
+        breaks: [Date.UTC(2024, 0, 1), Date.UTC(2024, 0, 15), Date.UTC(2024, 0, 31)],
+        temporal: {
+          aesthetic: "x",
+          panelIndex: 0,
+          kind: "date",
+          config: {},
+          sourceBreaks: ["2024-01-01", "2024-01-15", "2024-01-31"],
+        },
+      };
+      const result = deriveTicks(domain, 5, undefined, horizontalCtx());
+      expect(result.ticks.map((tick) => tick.value)).toEqual([
+        Date.UTC(2024, 0, 1),
+        Date.UTC(2024, 0, 15),
+        Date.UTC(2024, 0, 31),
+      ]);
+      expect(result.guidePlan).toBeUndefined();
+    } finally {
+      installTemporal();
+      expect(getTemporalRuntime()).not.toBeNull();
+    }
+  });
+});

--- a/packages/core/tests/pipeline-temporal/auto-timezone-preflight.test.ts
+++ b/packages/core/tests/pipeline-temporal/auto-timezone-preflight.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Auto temporal scales must still reject invalid timezone names up front
+ * (Devin #1278). The lean/auto early-return must not skip timezone validation.
+ */
+import { describe, expect, it } from "bun:test";
+
+import { aes, gg } from "@ggsvelte/spec";
+
+import { PipelineError, runPipeline } from "../../src/pipeline.ts";
+import { size } from "./fixtures.ts";
+
+const dateRows = [
+  { date: "2024-01-01", value: 1 },
+  { date: "2024-01-02", value: 2 },
+];
+
+const datetimeRows = [
+  { date: "2024-01-01T10:00:00", value: 1 },
+  { date: "2024-01-02T10:00:00", value: 2 },
+];
+
+describe("temporal pipeline: auto parser timezone preflight", () => {
+  it("rejects an invalid timezone with a clear configuration error on auto parse", () => {
+    let caught: unknown;
+    try {
+      runPipeline(
+        gg(dateRows, aes({ x: "date", y: "value" }))
+          .geomLine()
+          .scaleXDate({ timezone: "Not/A_Zone" })
+          .spec(),
+        size,
+      );
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(PipelineError);
+    const message = (caught as PipelineError).message;
+    expect(message).toMatch(/invalid or unsupported timezone/i);
+    expect(message).toMatch(/Not\/A_Zone/);
+    // Must not fall through to the generic "could not be parsed strictly" path.
+    expect(message).not.toMatch(/could not be parsed strictly/i);
+  });
+
+  it("accepts a valid timezone on auto parse", () => {
+    const model = runPipeline(
+      gg(datetimeRows, aes({ x: "date", y: "value" }))
+        .geomLine()
+        .scaleXDatetime({ timezone: "America/New_York", nice: false })
+        .spec(),
+      size,
+    );
+    expect(model.scales.x.type).toBe("time");
+    expect(model.scene.panels.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/core/tests/table-lean-temporal.test.ts
+++ b/packages/core/tests/table-lean-temporal.test.ts
@@ -1,6 +1,9 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 
+import { aes, gg } from "@ggsvelte/spec";
+
 import { installTemporal } from "../src/install-temporal.ts";
+import { runPipeline } from "../src/pipeline.ts";
 import { ColumnTable } from "../src/table.ts";
 import { getTemporalRuntime, resetTemporalRuntimeForTests } from "../src/temporal-runtime.ts";
 
@@ -36,5 +39,39 @@ describe("lean ColumnTable temporal detection (no runtime)", () => {
     });
     expect(table.fieldType("x")).toBe("temporal");
     expect(table.parsed("x").decision.status).toBe("temporal");
+  });
+});
+
+describe("lean pipeline: date-axis charts without temporal runtime", () => {
+  beforeAll(() => {
+    resetTemporalRuntimeForTests();
+    expect(getTemporalRuntime()).toBeNull();
+  });
+
+  afterAll(() => {
+    installTemporal();
+    expect(getTemporalRuntime()).not.toBeNull();
+  });
+
+  it("renders a plain ISO date-axis chart instead of crashing on planTemporalAxis", () => {
+    const model = runPipeline(
+      gg(
+        [
+          { date: "2024-01-01", value: 1 },
+          { date: "2024-01-02", value: 2 },
+          { date: "2024-01-03", value: 3 },
+        ],
+        aes({ x: "date", y: "value" }),
+      )
+        .geomPoint()
+        .spec(),
+      { width: 400, height: 300 },
+    );
+    expect(model.scales.x.type).toBe("time");
+    expect(model.scene.panels).toHaveLength(1);
+    const axisX = model.scene.panels[0]?.axisX ?? [];
+    expect(axisX.length).toBeGreaterThan(0);
+    // Labels come from the lean timeTicks path (formatTime), not a thrown runtime error.
+    expect(axisX.some((tick) => tick.label.length > 0)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Follow-up for unrebutted Devin findings on merged #1278 (lean render path). Prior follow-up #1285 covered mixed ISO+number columns and lifecycle tags; these two stayed open.

### 1. Invalid timezones on auto temporal scales (valid)

`assertTemporalConfiguration` returned immediately when `parser === "auto"`, skipping `temporalParserConfigurationError`. A mistyped `scales.x.timezone` therefore only failed later as a generic “could not be parsed strictly” error (or worse on lean builds).

**Fix:** always run configuration validation (timezone first). Require the Temporal polyfill only for non-auto (explicit) parsers.

**Test:** `packages/core/tests/pipeline-temporal/auto-timezone-preflight.test.ts`

### 2. Lean date-axis charts crash on `planTemporalAxis` (valid)

`liteParseColumn` correctly marks all-ISO columns as temporal; layout then sets `domain.temporal` and `layout-derive-ticks` called `requireTemporalRuntime("planTemporalAxis")`, which throws on `@ggsvelte/core/render` (no polyfill).

**Fix:** when the temporal runtime is absent, fall through to `timeTicks` + `formatTime` instead of throwing.

**Test:** `packages/core/tests/table-lean-temporal.test.ts` (pipeline suite under cleared runtime)

## Parent PR

https://github.com/ljodea/ggsvelte/pull/1278

## Test plan

- [x] `bun test packages/core/tests/pipeline-temporal/auto-timezone-preflight.test.ts packages/core/tests/table-lean-temporal.test.ts packages/core/tests/pipeline-temporal packages/core/tests/layout`
- [ ] CI green
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1291" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->