### PR TITLE
feat: extract ggsvelte-render into @ggsvelte/cli

### DIFF
--- a/.changeset/cli-package-split.md
+++ b/.changeset/cli-package-split.md
@@ -1,0 +1,22 @@
+---
+"@ggsvelte/cli": minor
+"@ggsvelte/svelte": minor
+"@ggsvelte/core": minor
+---
+
+# CLI split: ggsvelte-render moves to @ggsvelte/cli
+
+The `ggsvelte-render` CLI moves to its own package, `@ggsvelte/cli` (ADR 0022).
+
+- `@ggsvelte/cli` (new): owns the `ggsvelte-render` bin; depends only on
+  `@ggsvelte/core`, so agent sandboxes install the spec feedback loop without
+  the Svelte component library. Also re-exports `runCLI`/`CLIIO` for
+  spawn-free embedding.
+- `@ggsvelte/svelte` (breaking, pre-1.0 minor): no longer ships the
+  `ggsvelte-render` bin. Migrate with `npm install -g @ggsvelte/cli` (or add
+  `@ggsvelte/cli` as a dependency) — the command name and behavior are
+  unchanged. `ggsvelte-codemod` still ships with `@ggsvelte/svelte`.
+- `@ggsvelte/core`: the `--version` help text no longer names
+  `@ggsvelte/svelte`; `runCLI` reports the version its caller passes.
+
+Migration: <https://ggsvelte.sh/guide/upgrading#cli-moved-to-ggsvelte-cli>

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@3.1.4/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "fixed": [["@ggsvelte/spec", "@ggsvelte/core", "@ggsvelte/svelte"]],
+  "fixed": [["@ggsvelte/spec", "@ggsvelte/core", "@ggsvelte/svelte", "@ggsvelte/cli"]],
   "linked": [],
   "access": "public",
   "baseBranch": "main",

--- a/.github/actions/ci-download-packages-dist/action.yml
+++ b/.github/actions/ci-download-packages-dist/action.yml
@@ -3,7 +3,7 @@
 name: CI download packages-dist
 description: >
   Download the packages-dist artifact into packages/ and verify that
-  spec/core/svelte dist entrypoints exist.
+  spec/core/svelte/cli dist entrypoints exist.
 
 runs:
   using: composite
@@ -21,7 +21,8 @@ runs:
         for path in \
           packages/spec/dist/index.js \
           packages/core/dist/index.js \
-          packages/svelte/dist/index.js; do
+          packages/svelte/dist/index.js \
+          packages/cli/dist/index.js; do
           if [ ! -f "${path}" ]; then
             echo "::error::packages-dist artifact missing ${path} after download"
             find packages -maxdepth 3 -type d 2>/dev/null | head -40 || true

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,7 @@ updates:
   - package-ecosystem: "bun"
     directories:
       - "/"
+      - "/packages/cli"
       - "/packages/core"
       - "/packages/spec"
       - "/packages/svelte"

--- a/.github/workflows/ci-unit.yml
+++ b/.github/workflows/ci-unit.yml
@@ -18,7 +18,7 @@ permissions: {}
 
 jobs:
   unit:
-    name: unit (bun test spec + core)
+    name: unit (bun test spec + core + cli)
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -49,7 +49,7 @@ jobs:
         run: >
           bun test --coverage --coverage-reporter=lcov
           --coverage-dir=coverage/unit
-          packages/spec packages/core benchmarks scripts tests/evals
+          packages/spec packages/core packages/cli benchmarks scripts tests/evals
       - name: Upload unit coverage to Codecov
         # Custom if overrides default success() — keep the success gate so a
         # failed suite does not upload a partial report or count as green.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          for pkg in spec core svelte; do
+          for pkg in spec core svelte cli; do
             src=".packages-dist-cache/packages/${pkg}/dist"
             if [ ! -d "${src}" ]; then
               echo "incomplete content-hash cache (missing ${src}) — will rebuild"
@@ -140,11 +140,12 @@ jobs:
               exit 0
             fi
           done
-          mkdir -p packages/spec packages/core packages/svelte
-          rm -rf packages/spec/dist packages/core/dist packages/svelte/dist
+          mkdir -p packages/spec packages/core packages/svelte packages/cli
+          rm -rf packages/spec/dist packages/core/dist packages/svelte/dist packages/cli/dist
           cp -a .packages-dist-cache/packages/spec/dist packages/spec/
           cp -a .packages-dist-cache/packages/core/dist packages/core/
           cp -a .packages-dist-cache/packages/svelte/dist packages/svelte/
+          cp -a .packages-dist-cache/packages/cli/dist packages/cli/
           echo "hit=true" >> "$GITHUB_OUTPUT"
           echo "packages-dist: restored from content-hash cache"
       - uses: ./.github/actions/ci-bun-install
@@ -161,13 +162,14 @@ jobs:
           for path in \
             packages/spec/dist/index.js \
             packages/core/dist/index.js \
-            packages/svelte/dist/index.js; do
+            packages/svelte/dist/index.js \
+            packages/cli/dist/index.js; do
             if [ ! -f "${path}" ]; then
               echo "::error::missing required dist output: ${path}"
               exit 1
             fi
           done
-          echo "packages-dist: verified spec/core/svelte dist entrypoints"
+          echo "packages-dist: verified spec/core/svelte/cli dist entrypoints"
       - name: stage packages/*/dist under a single upload root
         # Multi-path upload strips the common prefix, so consumers would see
         # spec/dist instead of packages/spec/dist. Stage once and upload that tree.
@@ -177,10 +179,12 @@ jobs:
           rm -rf .packages-dist-upload
           mkdir -p .packages-dist-upload/packages/spec \
             .packages-dist-upload/packages/core \
-            .packages-dist-upload/packages/svelte
+            .packages-dist-upload/packages/svelte \
+            .packages-dist-upload/packages/cli
           cp -a packages/spec/dist .packages-dist-upload/packages/spec/
           cp -a packages/core/dist .packages-dist-upload/packages/core/
           cp -a packages/svelte/dist .packages-dist-upload/packages/svelte/
+          cp -a packages/cli/dist .packages-dist-upload/packages/cli/
       - name: stage content-hash cache payload for save
         if: steps.restore_dist.outputs.hit != 'true' && steps.content_hash.outputs.bypass != 'true'
         shell: bash
@@ -189,10 +193,12 @@ jobs:
           rm -rf .packages-dist-cache
           mkdir -p .packages-dist-cache/packages/spec \
             .packages-dist-cache/packages/core \
-            .packages-dist-cache/packages/svelte
+            .packages-dist-cache/packages/svelte \
+            .packages-dist-cache/packages/cli
           cp -a packages/spec/dist .packages-dist-cache/packages/spec/
           cp -a packages/core/dist .packages-dist-cache/packages/core/
           cp -a packages/svelte/dist .packages-dist-cache/packages/svelte/
+          cp -a packages/cli/dist .packages-dist-cache/packages/cli/
       - name: upload packages/*/dist for same-run consumers
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -212,7 +218,7 @@ jobs:
       contents: read
 
   unit:
-    name: unit (bun test spec + core)
+    name: unit (bun test spec + core + cli)
     needs: detect-changes
     if: needs.detect-changes.outputs.unit == 'true'
     uses: ./.github/workflows/ci-unit.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@
 #   1. A GitHub remote for this repo — until the repo is pushed to GitHub,
 #      this workflow never runs.
 #   2. npm "trusted publishing" configured on npmjs.com for EACH published
-#      package — @ggsvelte/spec, @ggsvelte/core, and @ggsvelte/svelte — each pointing
+#      package — @ggsvelte/spec, @ggsvelte/core, @ggsvelte/svelte, and @ggsvelte/cli — each pointing
 #      at this repository + this workflow file (release.yml). This requires
 #      the npm org/packages to exist and is maintainer-side setup.
 #
@@ -63,7 +63,7 @@ jobs:
         run: bun run build
       # Publishing is gated behind the NPM_PUBLISH_ENABLED repo variable so
       # this workflow stays green until npm trusted publishing (OIDC) is
-      # configured for all three packages on npmjs.com. Until then the action
+      # configured for all four packages on npmjs.com. Until then the action
       # only maintains the "Version Packages" PR. Flip the gate with:
       #   gh variable set NPM_PUBLISH_ENABLED --body true
       - name: changesets — version PR or publish

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,7 +91,7 @@ upstream, `.md`/`.yaml`/`.svelte` can fold back into oxfmt (`.oxfmtrc.json`
 | publint / @arethetypeswrong/cli              | 0.3.21 / 0.18.5        | package publish shape (skips unbuilt stubs)                                        |
 | actionlint (npm, wasm)                       | 2.0.6                  | workflow lint via `scripts/actionlint.ts` (no shellcheck integration — wasm build) |
 | zizmor                                       | 1.26.1 (uv tool)       | Actions security audit                                                             |
-| @changesets/cli                              | 2.31.0                 | versioning/release (spec+core+svelte fixed lockstep, access public)                |
+| @changesets/cli                              | 2.31.0                 | versioning/release (spec+core+svelte+cli fixed lockstep, access public)            |
 | vitest + @vitest/browser-playwright          | 4.1.10                 | browser-mode component tests (factory `playwright()` provider)                     |
 | playwright / @playwright/test                | 1.61.1 (exact pins)    | must match `ghcr.io/<repo>/ci-runner:v1.61.1-noble` — two-step bump (see below)    |
 | @sveltejs/kit + @sveltejs/adapter-static     | 2.x / 3.x              | apps/docs static docs site (the VR screenshot target)                              |
@@ -202,7 +202,7 @@ a tag main never publishes). The lockstep test encodes that inequality.
 | `bun run bench:budgets`                                       | compare `bench-results.json` against `benchmarks/budgets.json` (provisional budgets, +50%)                                                        |
 | `bun run bench:memory` / `bun run bench:memory:check`         | capture the forced-GC retained-memory sample / enforce `benchmarks/memory-baselines.json`                                                         |
 | `bun run bench` / `bun run bench:smoke`                       | mitata pipeline+renderer benchmarks (full / 1k CI smoke)                                                                                          |
-| `bun packages/svelte/bin/ggsvelte-render.js`                  | the `ggsvelte-render` CLI (spec JSON -> SVG on stdout; JSON-line diagnostics on stderr)                                                           |
+| `bun packages/cli/bin/ggsvelte-render.js`                     | the `ggsvelte-render` CLI (spec JSON -> SVG on stdout; JSON-line diagnostics on stderr)                                                           |
 | `Rscript packages/core/tests/fixtures/*/generate.R`           | regenerate the ggplot2-parity fixtures (grouping, stats/positions; needs R + ggplot2)                                                             |
 | `bun run knip`                                                | unused files/exports/dependencies                                                                                                                 |
 | `bun run lint:package`                                        | publint + attw (esm-only profile) over built packages — build first                                                                               |
@@ -483,10 +483,10 @@ PR gets one opened rather than a silent skip. The three-way decision
 Add a `.changeset/*.md` **only** when the PR changes an npm-published package
 surface — the same paths `scripts/changeset-check.ts` treats as shipped
 (`package.json`, that package’s npm `files` entries under
-`packages/{core,spec,svelte}`, and — for packages that publish compiled
+`packages/{cli,core,spec,svelte}`, and — for packages that publish compiled
 `dist` without listing `src` — the package’s `src/` tree that builds into
-`dist`, e.g. `packages/svelte/src/**`). Spec, core, and svelte version in
-**fixed lockstep**, so one real (or spurious) changeset advances all three
+`dist`, e.g. `packages/svelte/src/**`). Spec, core, svelte, and cli version
+in **fixed lockstep**, so one real (or spurious) changeset advances all four
 package versions.
 
 **Do not** add a changeset for docs site, examples, scripts, tests, CI, or
@@ -499,8 +499,8 @@ warrant a patch. Missing changesets on package code stay advisory only.
 ### Bump level (SemVer)
 
 Pick the level from the **public surface change**, not from how small the
-diff looks. Spec, core, and svelte share one version, so the highest level
-among pending changesets wins.
+diff looks. Spec, core, svelte, and cli share one version, so the highest
+level among pending changesets wins.
 
 | Level     | Use for                                                                                                                                                                            |
 | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -422,9 +422,10 @@ Plot theme tokens are independent of site light/dark.
 
 | Package                               | Surface                                                             |
 | ------------------------------------- | ------------------------------------------------------------------- |
-| [`@ggsvelte/svelte`](packages/svelte) | Svelte 5 components, re-exports, CLI, agent skill                   |
+| [`@ggsvelte/svelte`](packages/svelte) | Svelte 5 components, re-exports, agent skill                        |
 | [`@ggsvelte/spec`](packages/spec)     | PortableSpec types, JSON Schema, validate/normalize, fluent builder |
 | [`@ggsvelte/core`](packages/core)     | Pipeline, headless SVG, canvas, hit testing                         |
+| [`@ggsvelte/cli`](packages/cli)       | `ggsvelte-render` CLI: validate + render specs in agent sandboxes   |
 
 ## Reference
 

--- a/apps/docs/src/lib/generated/routes.ts
+++ b/apps/docs/src/lib/generated/routes.ts
@@ -538,6 +538,11 @@ export const DOCS_ROUTES = [
     },
     headings: [
       {
+        id: "install",
+        title: "Install",
+        level: 2,
+      },
+      {
         id: "input-and-output",
         title: "Input and output",
         level: 2,
@@ -12075,6 +12080,16 @@ export const DOCS_ROUTES = [
         title: "stable-intent (243)",
         level: 3,
       },
+      {
+        id: "ggsvelte-cli",
+        title: "@ggsvelte/cli",
+        level: 2,
+      },
+      {
+        id: "experimental-2",
+        title: "experimental (2)",
+        level: 3,
+      },
     ],
   },
   {
@@ -12096,6 +12111,16 @@ export const DOCS_ROUTES = [
         id: "five-minute-path",
         title: "Five-minute path",
         level: 2,
+      },
+      {
+        id: "0-22-to-0-23",
+        title: "0.22 to 0.23",
+        level: 2,
+      },
+      {
+        id: "cli-moved-to-ggsvelte-cli",
+        title: "CLI moved to @ggsvelte/cli",
+        level: 3,
       },
       {
         id: "0-20-to-0-21",

--- a/apps/docs/src/lib/generated/search-index.ts
+++ b/apps/docs/src/lib/generated/search-index.ts
@@ -668,6 +668,16 @@ export const DOCS_SEARCH_INDEX = [
     exact: ["Command-line reference"],
   },
   {
+    id: "heading:reference-cli:install",
+    kind: "heading",
+    title: "Install",
+    summary:
+      "Install in Command-line reference. Render PortableSpec JSON to SVG with implementation-derived flags, streams, diagnostics, and exit classes.",
+    href: "/reference/cli#install",
+    keywords: ["Command-line reference", "Reference"],
+    exact: ["Install"],
+  },
+  {
     id: "heading:reference-cli:input-and-output",
     kind: "heading",
     title: "Input and output",
@@ -19983,6 +19993,26 @@ export const DOCS_SEARCH_INDEX = [
     exact: ["stable-intent (243)"],
   },
   {
+    id: "heading:guide-lifecycle:ggsvelte-cli",
+    kind: "heading",
+    title: "@ggsvelte/cli",
+    summary:
+      "@ggsvelte/cli in Lifecycle & editions. API stability tags per export, and the defaults-edition mechanism.",
+    href: "/guide/lifecycle#ggsvelte-cli",
+    keywords: ["Lifecycle & editions", "Reference"],
+    exact: ["@ggsvelte/cli"],
+  },
+  {
+    id: "heading:guide-lifecycle:experimental-2",
+    kind: "heading",
+    title: "experimental (2)",
+    summary:
+      "experimental (2) in Lifecycle & editions. API stability tags per export, and the defaults-edition mechanism.",
+    href: "/guide/lifecycle#experimental-2",
+    keywords: ["Lifecycle & editions", "Reference"],
+    exact: ["experimental (2)"],
+  },
+  {
     id: "page:guide-upgrading",
     kind: "page",
     title: "Upgrade guide",
@@ -20000,6 +20030,26 @@ export const DOCS_SEARCH_INDEX = [
     href: "/guide/upgrading#five-minute-path",
     keywords: ["Upgrade guide", "Release"],
     exact: ["Five-minute path"],
+  },
+  {
+    id: "heading:guide-upgrading:0-22-to-0-23",
+    kind: "heading",
+    title: "0.22 to 0.23",
+    summary:
+      "0.22 to 0.23 in Upgrade guide. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
+    href: "/guide/upgrading#0-22-to-0-23",
+    keywords: ["Upgrade guide", "Release"],
+    exact: ["0.22 to 0.23"],
+  },
+  {
+    id: "heading:guide-upgrading:cli-moved-to-ggsvelte-cli",
+    kind: "heading",
+    title: "CLI moved to @ggsvelte/cli",
+    summary:
+      "CLI moved to @ggsvelte/cli in Upgrade guide. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
+    href: "/guide/upgrading#cli-moved-to-ggsvelte-cli",
+    keywords: ["Upgrade guide", "Release"],
+    exact: ["CLI moved to @ggsvelte/cli"],
   },
   {
     id: "heading:guide-upgrading:0-20-to-0-21",
@@ -40202,6 +40252,24 @@ export const DOCS_SEARCH_INDEX = [
     exact: ["yq"],
   },
   {
+    id: "api:ggsvelte-cli:CLIIO",
+    kind: "api",
+    title: "CLIIO",
+    summary: "@ggsvelte/cli · type · experimental.",
+    href: "/guide/lifecycle#ggsvelte-cli",
+    keywords: ["@ggsvelte/cli", ".", "type", "experimental"],
+    exact: ["CLIIO"],
+  },
+  {
+    id: "api:ggsvelte-cli:runCLI",
+    kind: "api",
+    title: "runCLI",
+    summary: "@ggsvelte/cli · value · experimental.",
+    href: "/guide/lifecycle#ggsvelte-cli",
+    keywords: ["@ggsvelte/cli", ".", "value", "experimental"],
+    exact: ["runCLI"],
+  },
+  {
     id: "lifecycle:experimental",
     kind: "lifecycle",
     title: "experimental",
@@ -42942,7 +43010,7 @@ export const DOCS_SEARCH_INDEX = [
     id: "cli:version",
     kind: "cli",
     title: "--version",
-    summary: "Print the installed @ggsvelte/svelte version",
+    summary: "Print the installed ggsvelte CLI version",
     href: "/reference/cli#version",
     keywords: [],
     exact: ["--version"],

--- a/apps/docs/src/routes/reference/cli/+page.svelte
+++ b/apps/docs/src/routes/reference/cli/+page.svelte
@@ -17,6 +17,20 @@
     <code>--help</code>.
   </p>
 
+  <h2 id="install">Install</h2>
+  <p>
+    The CLI ships as its own package, <code>@ggsvelte/cli</code> — it does not
+    arrive with <code>@ggsvelte/svelte</code>. If an agent authors specs in a
+    sandbox, install the CLI in that sandbox: it is how the agent sees
+    validation errors and chart-quality warnings before a chart ships.
+  </p>
+  <CopyCode
+    class="cli-command"
+    language="bash"
+    accessibleLabel="Copy command"
+    code="npm install -g @ggsvelte/cli"
+  />
+
   <h2 id="input-and-output">Input and output</h2>
   <p>
     Pass one JSON file or omit it to read stdin. SVG is the only stdout output.

--- a/bun.lock
+++ b/bun.lock
@@ -133,7 +133,6 @@
       "version": "0.22.0",
       "bin": {
         "ggsvelte-codemod": "bin/ggsvelte-codemod.js",
-        "ggsvelte-render": "bin/ggsvelte-render.js",
       },
       "dependencies": {
         "@ggsvelte/core": "^0.16.0",

--- a/bun.lock
+++ b/bun.lock
@@ -96,11 +96,21 @@
         "typescript": "^6.0.3",
       },
     },
+    "packages/cli": {
+      "name": "@ggsvelte/cli",
+      "version": "0.22.0",
+      "bin": {
+        "ggsvelte-render": "bin/ggsvelte-render.js",
+      },
+      "dependencies": {
+        "@ggsvelte/core": "^0.22.0",
+      },
+    },
     "packages/core": {
       "name": "@ggsvelte/core",
-      "version": "0.21.0",
+      "version": "0.22.0",
       "dependencies": {
-        "@ggsvelte/spec": "^0.21.0",
+        "@ggsvelte/spec": "^0.22.0",
       },
       "devDependencies": {
         "typescript": "^6.0.3",
@@ -108,7 +118,7 @@
     },
     "packages/spec": {
       "name": "@ggsvelte/spec",
-      "version": "0.21.0",
+      "version": "0.22.0",
       "dependencies": {
         "@js-temporal/polyfill": "^0.5.1",
         "typebox": "^1.3.6",
@@ -120,7 +130,7 @@
     },
     "packages/svelte": {
       "name": "@ggsvelte/svelte",
-      "version": "0.21.0",
+      "version": "0.22.0",
       "bin": {
         "ggsvelte-codemod": "bin/ggsvelte-codemod.js",
         "ggsvelte-render": "bin/ggsvelte-render.js",
@@ -319,6 +329,8 @@
     "@ggsvelte-spike/browser": ["@ggsvelte-spike/browser@workspace:spikes/browser"],
 
     "@ggsvelte-spike/pure": ["@ggsvelte-spike/pure@workspace:spikes/pure"],
+
+    "@ggsvelte/cli": ["@ggsvelte/cli@workspace:packages/cli"],
 
     "@ggsvelte/core": ["@ggsvelte/core@workspace:packages/core"],
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -45,6 +45,8 @@ ignore:
   - "**/dist/**"
   - "**/coverage/**"
   - "packages/svelte/bin/**"
+  - "packages/cli/bin/**"
+  - "packages/cli/tests/**"
   - "packages/svelte/skills/**"
   - "packages/core/tests/**"
   - "packages/spec/tests/**"
@@ -58,6 +60,7 @@ flag_management:
       paths:
         - packages/spec/**
         - packages/core/**
+        - packages/cli/**
       carryforward: true
     - name: svelte
       paths:
@@ -78,3 +81,7 @@ component_management:
       name: packages-svelte
       paths:
         - packages/svelte/**
+    - component_id: packages-cli
+      name: packages-cli
+      paths:
+        - packages/cli/**

--- a/docs/decisions/0022-cli-package.md
+++ b/docs/decisions/0022-cli-package.md
@@ -1,0 +1,48 @@
+# 0022 — `ggsvelte-render` becomes its own package (`@ggsvelte/cli`)
+
+Date: 2026-07-31. Status: accepted.
+
+## Problem
+
+The `ggsvelte-render` bin shipped on `@ggsvelte/svelte`. The CLI exists for
+one audience above all: embedded analytics agents that author PortableSpec
+JSON in a sandbox and need the pipeline's validation errors, warnings, and
+advisories before a chart reaches the host webapp. For that audience the old
+packaging failed twice:
+
+1. **The install was wrong-shaped.** Getting a validator meant installing the
+   whole Svelte component library (with a `svelte ^5` peer dep) into an
+   environment that renders nothing. Install agents read that as waste and
+   trimmed it — observed in the field: an agent installing ggsvelte for a
+   webapp edited the packaged skill to delete every CLI mention and shipped a
+   JSON-only workflow. The charts its downstream agents produced carried
+   warnings nobody saw.
+2. **The packaging said "optional".** No release of its own, no install
+   docs, two passing mentions in the skill. Nothing said the CLI is the
+   designed feedback loop.
+
+## Decision
+
+- New published package `@ggsvelte/cli` (packages/cli) owns the
+  `ggsvelte-render` bin. It depends only on `@ggsvelte/core` — no Svelte
+  peer dep — so a sandbox image can install it with one line.
+- `runCLI` stays in `@ggsvelte/core` (tested there); the cli package
+  re-exports `runCLI`/`CLIIO` and ships the thin bin wrapper.
+- `ggsvelte-codemod` stays on `@ggsvelte/svelte`: it rewrites component
+  usage and belongs with the components.
+- Clean break, no alias bin left on `@ggsvelte/svelte` (pre-1.0 breaking
+  rides a minor per ADR 0013). Two install paths would recreate the
+  ambiguity this split removes.
+- `@ggsvelte/cli` joins the changesets **fixed** group: all four packages
+  share one version.
+- Skill and docs now state the CLI is part of the install contract for
+  agent-driven chart generation, with sandbox install instructions.
+
+## Release mechanics
+
+npm trusted publishing (OIDC) cannot first-publish a new package
+(npm/cli#8544): the maintainer publishes `@ggsvelte/cli@0.22.0` once by hand
+(`NPM_CONFIG_PROVENANCE=false npm publish --access public` — provenance
+needs OIDC), configures the trusted publisher for the package, and only then
+merges the next Version Packages PR so `changeset publish` covers all four
+via OIDC. Skipping that order half-publishes the fixed group.

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -41,6 +41,11 @@
       "entry": ["tests/**/*.test.ts"],
       "project": ["src/**", "tests/**"],
     },
+    "packages/cli": {
+      // knip infers bin/ and the exports entry from package.json itself.
+      "entry": ["tests/**/*.test.ts"],
+      "project": ["src/**", "bin/**", "tests/**"],
+    },
     "packages/svelte": {
       // tests/migrations are upgrade-guide fixtures: read by
       // scripts/migration-fixtures.test.ts via the filesystem (not imports)

--- a/lifecycle.json
+++ b/lifecycle.json
@@ -8203,6 +8203,21 @@
           "lifecycle": "experimental"
         }
       }
+    },
+    {
+      "package": "@ggsvelte/cli",
+      "entry": ".",
+      "source": "packages/cli/src/index.ts",
+      "exports": {
+        "CLIIO": {
+          "kind": "type",
+          "lifecycle": "experimental"
+        },
+        "runCLI": {
+          "kind": "value",
+          "lifecycle": "experimental"
+        }
+      }
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "type": "module",
   "scripts": {
-    "check": "tsc -b packages/spec packages/core && bun run check:type-contracts && bun run check:scripts-ci-routing && bun run check:scripts && bun run lifecycle:check",
+    "check": "tsc -b packages/spec packages/core packages/cli && bun run check:type-contracts && bun run check:scripts-ci-routing && bun run check:scripts && bun run lifecycle:check",
     "check:scripts-ci-routing": "bun node_modules/.bin/tsc -p scripts/ci-routing --noEmit",
     "check:scripts": "bun node_modules/.bin/tsc -p scripts --noEmit",
     "check:type-contracts": "tsc -p packages/spec/type-tests/tsconfig.json",
@@ -37,7 +37,7 @@
     "lint:type-aware:run": "oxlint --type-aware --deny-warnings .",
     "fmt": "bun node_modules/.bin/oxfmt && bun node_modules/.bin/prettier --write --log-level warn \"**/*.{svelte,md,yml,yaml}\"",
     "fmt:check": "bun node_modules/.bin/oxfmt --check && bun node_modules/.bin/prettier --check --log-level warn \"**/*.{svelte,md,yml,yaml}\"",
-    "test": "bun test packages/spec packages/core benchmarks scripts tests/evals",
+    "test": "bun test packages/spec packages/core packages/cli benchmarks scripts tests/evals",
     "test:temporal-parser": "bun test packages/spec/tests/temporal-parse.test.ts packages/spec/tests/temporal-parse-format.test.ts packages/spec/tests/temporal-column.test.ts packages/spec/tests/temporal-helpers.test.ts packages/spec/tests/temporal-scale-schema.test.ts packages/spec/tests/temporal-scale-authoring.test.ts packages/spec/tests/temporal-source-gate.test.ts packages/spec/tests/validate-tier2-temporal-reuse.test.ts packages/spec/tests/validate-tier2-temporal-position.test.ts packages/core/tests/table-temporal.test.ts",
     "test:temporal-pipeline": "bun test packages/core/tests/pipeline-temporal packages/core/tests/ticks.test.ts",
     "test:spikes": "cd spikes/browser && bun run --bun test",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,0 +1,8 @@
+# @ggsvelte/cli
+
+## 0.22.0
+
+Initial extraction: the `ggsvelte-render` bin moved here from
+`@ggsvelte/svelte` so agent sandboxes can install the spec feedback loop
+without the Svelte component library. Release history before 0.22.0 lives in
+the `@ggsvelte/svelte` changelog.

--- a/packages/cli/LICENSE
+++ b/packages/cli/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Liam O'Dea
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,74 @@
+# @ggsvelte/cli
+
+[![codecov](https://codecov.io/gh/ljodea/ggsvelte/branch/main/graph/badge.svg?component=packages-cli)](https://app.codecov.io/gh/ljodea/ggsvelte/tree/main/packages%2Fcli)
+
+`ggsvelte-render`: validate and render a ggsvelte plot spec (JSON) to SVG from
+the command line. This is the feedback loop for agents that author specs — it
+surfaces the validation errors, warnings, and advisories a JSON-only workflow
+never sees.
+
+## Why this package exists
+
+An embedded analytics agent writes a spec, the host webapp renders it with
+`@ggsvelte/svelte`. Without this CLI in the agent's sandbox, the agent ships
+the spec blind: a spec can be schema-valid yet draw a misleading chart, and
+the pipeline's warnings (degenerate stacks, single-observation groups, scale
+inference problems) fire in the webapp where nobody reads them. With the CLI,
+the agent renders locally, reads the JSONL diagnostics on stderr, and fixes
+the spec before anyone sees it.
+
+If you embed spec-writing agents, treat this package as part of the install
+contract, not an option.
+
+## Install
+
+```sh
+npm install -g @ggsvelte/cli
+# or: bun add -g @ggsvelte/cli
+# or run without installing: bunx --package @ggsvelte/cli ggsvelte-render spec.json
+```
+
+In an agent sandbox image:
+
+```dockerfile
+FROM node:24-slim
+RUN npm install -g @ggsvelte/cli
+# agents can now run: ggsvelte-render spec.json > out.svg
+```
+
+Pin the same minor version as the `@ggsvelte/svelte` your webapp renders
+with — all `@ggsvelte/*` packages version in lockstep.
+
+## Usage
+
+```sh
+ggsvelte-render spec.json > out.svg          # spec from a file
+ggsvelte-render < spec.json > out.svg        # spec from stdin
+ggsvelte-render spec.json --data data.json   # named datasets from a file
+ggsvelte-render spec.json --width 832 --height 400
+```
+
+- SVG goes to stdout. Nothing else ever does.
+- Diagnostics go to stderr as JSON lines:
+  `{"kind":"error",…}` | `{"kind":"warning",…}` | `{"kind":"advisory",…}`.
+  Scale-inference diagnostics set `source: "scale"` so hosts can filter.
+
+## Exit codes
+
+| Code | Meaning                                                      |
+| ---- | ------------------------------------------------------------ |
+| 0    | rendered                                                     |
+| 1    | render failed (pipeline error — spec was structurally valid) |
+| 2    | usage error (bad flags, unreadable input, invalid JSON)      |
+| 3    | invalid spec (validation errors — see stderr JSON lines)     |
+
+An agent loop: render, and on exit 3 apply the `fix.example` from each stderr
+error at its `path`, re-render; on exit 0 still read stderr — warnings and
+advisories are chart-quality feedback.
+
+## Reference
+
+- [CLI reference](https://ggsvelte.sh/reference/cli) — all options and
+  diagnostics
+- Programmatic use without spawning: `runCLI` from this package (re-exported
+  from `@ggsvelte/core`)

--- a/packages/cli/bin/ggsvelte-render.js
+++ b/packages/cli/bin/ggsvelte-render.js
@@ -34,7 +34,7 @@ if (
   !("version" in packageJson) ||
   typeof packageJson.version !== "string"
 ) {
-  throw new Error("@ggsvelte/svelte package.json has no string version");
+  throw new Error("@ggsvelte/cli package.json has no string version");
 }
 const packageVersion = packageJson.version;
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@ggsvelte/cli",
+  "version": "0.22.0",
+  "description": "ggsvelte-render: validate and render ggsvelte plot specs (JSON) to SVG from the command line — the feedback loop for agents that author specs in sandboxes.",
+  "keywords": [
+    "agents",
+    "charts",
+    "cli",
+    "dataviz",
+    "ggplot2",
+    "grammar-of-graphics",
+    "headless",
+    "plot",
+    "svg",
+    "validation",
+    "visualization"
+  ],
+  "homepage": "https://ggsvelte.sh/",
+  "bugs": "https://github.com/ljodea/ggsvelte/issues",
+  "license": "MIT",
+  "author": "Liam O'Dea",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ljodea/ggsvelte.git",
+    "directory": "packages/cli"
+  },
+  "bin": {
+    "ggsvelte-render": "bin/ggsvelte-render.js"
+  },
+  "files": [
+    "dist",
+    "bin",
+    "src"
+  ],
+  "type": "module",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "dependencies": {
+    "@ggsvelte/core": "^0.22.0"
+  },
+  "engines": {
+    "node": ">=22"
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,0 +1,14 @@
+/**
+ * @ggsvelte/cli — programmatic surface of the `ggsvelte-render` bin.
+ *
+ * The bin (bin/ggsvelte-render.js) wires process streams around
+ * `runCLI`, which lives in @ggsvelte/core so the pipeline and the CLI
+ * share one tested implementation. This entry re-exports that surface so
+ * hosts embedding the CLI (test harnesses, sandbox runners) can call it
+ * without spawning a process.
+ */
+// Every export needs a lifecycle tag; the header default is read
+// into lifecycle.json by scripts/gen-lifecycle.ts.
+// @lifecycle-default experimental
+export { runCLI } from "@ggsvelte/core";
+export type { CLIIO } from "@ggsvelte/core";

--- a/packages/cli/tests/cli-bin.test.ts
+++ b/packages/cli/tests/cli-bin.test.ts
@@ -1,0 +1,67 @@
+/**
+ * ggsvelte-render bin smoke tests: spawn the workspace bin
+ * (packages/cli/bin/ggsvelte-render.js) directly — never network bunx.
+ * Pure runCLI unit tests live in packages/core/tests/cli.test.ts.
+ */
+import { describe, expect, it } from "bun:test";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const SPEC = {
+  data: {
+    values: [
+      { x: 1, y: 2 },
+      { x: 3, y: 4 },
+    ],
+  },
+  aes: { x: { field: "x" }, y: { field: "y" } },
+  layers: [{ geom: "point" }],
+};
+
+describe("workspace bin smoke test", () => {
+  it("reports the version of the CLI package that owns the bin", async () => {
+    const packageDirectory = join(import.meta.dir, "..");
+    const manifest = JSON.parse(readFileSync(join(packageDirectory, "package.json"), "utf8")) as {
+      version: string;
+    };
+    const proc = Bun.spawn(
+      ["bun", join(packageDirectory, "bin", "ggsvelte-render.js"), "--version"],
+      { stdout: "pipe", stderr: "pipe" },
+    );
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toBe(`${manifest.version}\n`);
+    // Bun may emit a host CPU capability warning on stderr before the script runs.
+    const cliStderr = stderr
+      .split(/\r?\n/)
+      .filter(
+        (line) =>
+          !line.startsWith("warn: CPU lacks AVX support") &&
+          !line.includes("bun-darwin-x64-baseline.zip") &&
+          line.trim() !== "",
+      )
+      .join("\n");
+    expect(cliStderr).toBe("");
+  });
+
+  it("bun packages/cli/bin/ggsvelte-render.js spec.json > out.svg", async () => {
+    const binPath = join(import.meta.dir, "..", "bin", "ggsvelte-render.js");
+    const dir = mkdtempSync(join(tmpdir(), "ggsvelte-cli-"));
+    const specPath = join(dir, "spec.json");
+    writeFileSync(specPath, JSON.stringify(SPEC));
+    const proc = Bun.spawn(["bun", binPath, specPath, "--width", "320"], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, exitCode] = await Promise.all([new Response(proc.stdout).text(), proc.exited]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toStartWith("<svg ");
+    expect(stdout.trimEnd()).toEndWith("</svg>");
+    expect(stdout).toContain('width="320"');
+  }, 20_000);
+});

--- a/packages/cli/tests/tsconfig.json
+++ b/packages/cli/tests/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  // Type context for bun:test smoke tests (discovered by oxlint --type-aware;
+  // NOT part of the tsc -b build graph, which only emits from src/).
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "types": ["bun"]
+  },
+  "include": ["./**/*.ts", "../src/**/*.ts"]
+}

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "references": [{ "path": "../core" }],
+  "include": ["src/**/*"]
+}

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -1,6 +1,6 @@
 /**
- * `ggsvelte-render` CLI implementation (plan: the bin lives on the `@ggsvelte/svelte`
- * package — packages/svelte/bin/ggsvelte-render.js is a thin wrapper around
+ * `ggsvelte-render` CLI implementation (the bin lives on the `@ggsvelte/cli`
+ * package — packages/cli/bin/ggsvelte-render.js is a thin wrapper around
  * this pure-entry module, so the logic is testable without spawning).
  *
  * Contract:
@@ -84,7 +84,7 @@ export const CLI_OPTIONS = [
     anchor: "version",
     flag: "--version",
     value: "",
-    description: "Print the installed @ggsvelte/svelte version",
+    description: "Print the installed ggsvelte CLI version",
     kind: "boolean",
     target: "version",
   },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -380,7 +380,7 @@ export type {
 export { paintResourceId } from "./mark-paint.js";
 export type { ResolvedGlow, ResolvedGradientPaint } from "./mark-paint.js";
 
-// CLI implementation (the `ggsvelte-render` bin on the ggsvelte package wraps this)
+// CLI implementation (the `ggsvelte-render` bin on @ggsvelte/cli wraps this)
 export { runCLI } from "./cli.js";
 export type { CLIIO } from "./cli.js";
 

--- a/packages/core/tests/cli.test.ts
+++ b/packages/core/tests/cli.test.ts
@@ -1,13 +1,9 @@
 /**
  * ggsvelte-render CLI: runCLI unit tests (exit codes, stdout purity, JSON-line
- * diagnostics) + a smoke test invoking the workspace bin
- * (packages/svelte/bin/ggsvelte-render.js) directly — never network bunx.
+ * diagnostics). Bin smoke tests spawning the workspace bin live in
+ * packages/cli/tests/cli-bin.test.ts.
  */
 import { describe, expect, it } from "bun:test";
-import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-
 import type { CLIIO } from "../src/cli.ts";
 import { CLI_OPTIONS, runCLI, scaleDiagnosticCliKind } from "../src/cli.ts";
 
@@ -199,51 +195,4 @@ describe("runCLI", () => {
       expect(help).toContain(dataOption.detail);
     }
   });
-});
-
-describe("workspace bin smoke test", () => {
-  it("reports the version of the Svelte package that owns the bin", async () => {
-    const packageDirectory = join(import.meta.dir, "..", "..", "svelte");
-    const manifest = JSON.parse(readFileSync(join(packageDirectory, "package.json"), "utf8")) as {
-      version: string;
-    };
-    const proc = Bun.spawn(
-      ["bun", join(packageDirectory, "bin", "ggsvelte-render.js"), "--version"],
-      { stdout: "pipe", stderr: "pipe" },
-    );
-    const [stdout, stderr, exitCode] = await Promise.all([
-      new Response(proc.stdout).text(),
-      new Response(proc.stderr).text(),
-      proc.exited,
-    ]);
-    expect(exitCode).toBe(0);
-    expect(stdout).toBe(`${manifest.version}\n`);
-    // Bun may emit a host CPU capability warning on stderr before the script runs.
-    const cliStderr = stderr
-      .split(/\r?\n/)
-      .filter(
-        (line) =>
-          !line.startsWith("warn: CPU lacks AVX support") &&
-          !line.includes("bun-darwin-x64-baseline.zip") &&
-          line.trim() !== "",
-      )
-      .join("\n");
-    expect(cliStderr).toBe("");
-  });
-
-  it("bun packages/svelte/bin/ggsvelte-render.js spec.json > out.svg", async () => {
-    const binPath = join(import.meta.dir, "..", "..", "svelte", "bin", "ggsvelte-render.js");
-    const dir = mkdtempSync(join(tmpdir(), "ggsvelte-cli-"));
-    const specPath = join(dir, "spec.json");
-    writeFileSync(specPath, JSON.stringify(SPEC));
-    const proc = Bun.spawn(["bun", binPath, specPath, "--width", "320"], {
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, exitCode] = await Promise.all([new Response(proc.stdout).text(), proc.exited]);
-    expect(exitCode).toBe(0);
-    expect(stdout).toStartWith("<svg ");
-    expect(stdout.trimEnd()).toEndWith("</svg>");
-    expect(stdout).toContain('width="320"');
-  }, 20_000);
 });

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -3,8 +3,10 @@
 [![codecov](https://codecov.io/gh/ljodea/ggsvelte/branch/main/graph/badge.svg?component=packages-svelte)](https://app.codecov.io/gh/ljodea/ggsvelte/tree/main/packages%2Fsvelte)
 
 Svelte 5 components for ggsvelte. Re-exports `@ggsvelte/spec` and
-`@ggsvelte/core`, ships the `ggsvelte-render` CLI, and publishes the agent skill
-at `skills/ggsvelte`.
+`@ggsvelte/core` and publishes the agent skill at `skills/ggsvelte`. The
+`ggsvelte-render` CLI ships separately as
+[`@ggsvelte/cli`](../cli) — install it in any sandbox where an agent
+authors specs.
 
 ```sh
 bun add @ggsvelte/svelte

--- a/packages/svelte/bin/ggsvelte-codemod.js
+++ b/packages/svelte/bin/ggsvelte-codemod.js
@@ -2,7 +2,7 @@
 // ggsvelte-codemod — migrate deprecated <GGPlot> grammar props to child layers.
 //
 // Thin wrapper: all logic lives in runCodemodCLI (pure entry, tested in
-// tests/codemod/), mirroring bin/ggsvelte-render.js. This file only wires the
+// tests/codemod/), mirroring @ggsvelte/cli's bin/ggsvelte-render.js. This file only wires the
 // filesystem, process streams, and the exit code.
 //
 // Dry-run by default (ADR 0013) — writes only with --write.

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ggsvelte/svelte",
   "version": "0.22.0",
-  "description": "ggsvelte: a layered grammar of graphics for Svelte 5 — ggplot2 semantics, JSON-serializable specs, agent-friendly validation, hybrid SVG/canvas rendering, and the ggsvelte-render CLI.",
+  "description": "ggsvelte: a layered grammar of graphics for Svelte 5 — ggplot2 semantics, JSON-serializable specs, agent-friendly validation, and hybrid SVG/canvas rendering. The ggsvelte-render CLI ships separately as @ggsvelte/cli.",
   "keywords": [
     "charts",
     "components",
@@ -24,8 +24,7 @@
     "directory": "packages/svelte"
   },
   "bin": {
-    "ggsvelte-codemod": "bin/ggsvelte-codemod.js",
-    "ggsvelte-render": "bin/ggsvelte-render.js"
+    "ggsvelte-codemod": "bin/ggsvelte-codemod.js"
   },
   "files": [
     "dist",

--- a/packages/svelte/skills/ggsvelte/SKILL.md
+++ b/packages/svelte/skills/ggsvelte/SKILL.md
@@ -14,6 +14,11 @@ same grammar — never build SVG or canvas output yourself:
   `validate(spec)`, render with `renderToSVGString(spec, {width, height})`
   (Node-safe), `ggsvelte-render spec.json > out.svg` (CLI), or `<GGPlot spec>`.
   A third skin, the `gg()` builder, produces the same spec in TypeScript.
+  The CLI is part of the install contract for agent-driven chart generation:
+  install `@ggsvelte/cli` in every sandbox where an agent authors specs
+  (`npm i -g @ggsvelte/cli`). It is the only way the agent sees the
+  pipeline's warnings and advisories before a chart ships; a JSON-only
+  workflow renders blind. Do not drop it to slim an install.
 
 ## Mental model
 
@@ -236,7 +241,9 @@ mixed-sign data); `lintSpec(spec)` is the standalone equivalent. Advisories
 never block; fix them when they match intent. `normalize(input)` canonicalizes
 authoring sugar into a `PortableSpec`; `isPortable`/`toPortable` check and
 strip runtime-only fields. CLIs: `ggsvelte-render spec.json > out.svg`
-(JSON-line diagnostics on stderr) and `ggsvelte-codemod [--write] src`.
+(from `@ggsvelte/cli`; JSON-line diagnostics on stderr — exit 3 means
+validation errors, exit 0 with stderr output means quality warnings worth
+fixing) and `ggsvelte-codemod [--write] src` (ships with `@ggsvelte/svelte`).
 
 ## Recipes (spec JSON — the everyday twelve)
 

--- a/packages/svelte/src/lib/codemod/cli.ts
+++ b/packages/svelte/src/lib/codemod/cli.ts
@@ -4,7 +4,8 @@
  *
  * Pure entry point: all I/O is injected through {@link CodemodIO}, so the whole
  * command is testable without touching a disk. bin/ggsvelte-codemod.js wires
- * process streams and the exit code, exactly as bin/ggsvelte-render.js does.
+ * process streams and the exit code, exactly as @ggsvelte/cli's
+ * bin/ggsvelte-render.js does.
  *
  * ADR 0013: dry-run by default, writes only behind an explicit `--write`, and
  * anything the transform refuses to guess at is reported with the guide anchor

--- a/packages/svelte/src/lib/index.ts
+++ b/packages/svelte/src/lib/index.ts
@@ -1,8 +1,8 @@
 // ggsvelte — Svelte 5 adapter. Props-first API (<GGPlot spec/props>);
 // declaration-only children (<GeomPoint>/<GeomBar>/...) are optional sugar
 // (decision 0001, mechanism A). Re-exports the spec/core surface so
-// `bun add @ggsvelte/svelte` gets everything. Owns the `ggsvelte-render` CLI bin
-// (bin/ggsvelte-render.js, wrapping @ggsvelte/core's runCLI).
+// `bun add @ggsvelte/svelte` gets everything. The `ggsvelte-render` CLI bin
+// lives on @ggsvelte/cli (wrapping @ggsvelte/core's runCLI).
 //
 // Lifecycle (Hadley lesson 13; meanings in CONTRIBUTING.md): tags collected
 // into lifecycle.json by scripts/gen-lifecycle.ts.

--- a/scripts/changeset-check.test.ts
+++ b/scripts/changeset-check.test.ts
@@ -15,6 +15,7 @@ const root = join(import.meta.dir, "..");
 
 /** Fixture mirroring the real published workspace shape (see discovery test). */
 const PACKAGES = [
+  { dir: "packages/cli", name: "@ggsvelte/cli", shipped: ["dist", "bin", "src"] },
   { dir: "packages/core", name: "@ggsvelte/core", shipped: ["dist", "src"] },
   { dir: "packages/spec", name: "@ggsvelte/spec", shipped: ["dist", "schema", "src"] },
   { dir: "packages/svelte", name: "@ggsvelte/svelte", shipped: ["dist", "bin", "skills"] },
@@ -59,13 +60,13 @@ describe("decideChangesetComment", () => {
 
   it("reports missing when shipped package code changes without a changeset", () => {
     const decision = decideChangesetComment(
-      ["packages/core/src/scales.ts", "packages/svelte/bin/ggsvelte-render.js", "README.md"],
+      ["packages/core/src/scales.ts", "packages/cli/bin/ggsvelte-render.js", "README.md"],
       PACKAGES,
     );
     expect(decision.verdict).toBe("missing");
     expect(decision.touched).toEqual([
       "packages/core/src/scales.ts",
-      "packages/svelte/bin/ggsvelte-render.js",
+      "packages/cli/bin/ggsvelte-render.js",
     ]);
   });
 

--- a/scripts/changeset-check.ts
+++ b/scripts/changeset-check.ts
@@ -16,7 +16,7 @@
  * Missing stays non-blocking: internal-only package changes are common and
  * forcing empty changesets is worse than an ignorable comment. Unwarranted
  * blocks: docs/examples/script-only changesets have repeatedly bumped
- * core/spec/svelte with notes that change nothing consumers import.
+ * cli/core/spec/svelte with notes that change nothing consumers import.
  *
  * Pure **edits** of already-queued `.changeset/*.md` files (e.g. promoting
  * patch → minor on a pending entry) do not introduce a new release note and

--- a/scripts/ci-routing.test.ts
+++ b/scripts/ci-routing.test.ts
@@ -1098,10 +1098,10 @@ describe("sharded executions cache independently", () => {
 describe("git ls-tree digests include mode", () => {
   test("mode-only change changes the entry digest", () => {
     const blob = parseGitLsTreeLine(
-      "100644 blob abcdef0123456789\tpackages/svelte/bin/ggsvelte-render.js",
+      "100644 blob abcdef0123456789\tpackages/cli/bin/ggsvelte-render.js",
     );
     const exec = parseGitLsTreeLine(
-      "100755 blob abcdef0123456789\tpackages/svelte/bin/ggsvelte-render.js",
+      "100755 blob abcdef0123456789\tpackages/cli/bin/ggsvelte-render.js",
     );
     expect(blob).not.toBeNull();
     expect(exec).not.toBeNull();
@@ -1111,7 +1111,7 @@ describe("git ls-tree digests include mode", () => {
       formatTreeEntryDigest(exec!.mode, exec!.oid),
     );
 
-    const path = "packages/svelte/bin/ggsvelte-render.js";
+    const path = "packages/cli/bin/ggsvelte-render.js";
     const hash644 = hashJobInputs(
       "packages_dist",
       new Map([[path, formatTreeEntryDigest("100644", "abcdef0123456789")]]),

--- a/scripts/ci-routing/content-hash-inputs.ts
+++ b/scripts/ci-routing/content-hash-inputs.ts
@@ -80,12 +80,14 @@ export const JOB_CONTENT_INPUTS: Record<CacheableExecution, readonly string[]> =
     "packages/spec/**",
     "packages/core/**",
     "packages/svelte/**",
+    "packages/cli/**",
   ],
   unit: [
     ...UNIVERSAL_CONTENT_INPUTS,
     "packages/spec/**",
     "packages/core/**",
     "packages/svelte/**",
+    "packages/cli/**",
     "benchmarks/**",
     "scripts/**",
     "tests/evals/**",
@@ -119,6 +121,7 @@ export const JOB_CONTENT_INPUTS: Record<CacheableExecution, readonly string[]> =
     "packages/spec/**",
     "packages/core/**",
     "packages/svelte/**",
+    "packages/cli/**",
     "apps/docs/**",
     "examples/**",
     // check:scripts-ci-routing tsc covers scripts/ci-routing/** (#734); the
@@ -143,6 +146,7 @@ export const JOB_CONTENT_INPUTS: Record<CacheableExecution, readonly string[]> =
     "packages/spec/**",
     "packages/core/**",
     "packages/svelte/**",
+    "packages/cli/**",
     ...DOCS_SURFACE_CONTENT_INPUTS,
   ],
   // Full vite adapter-static docs site + packed pages-link gate.
@@ -151,6 +155,7 @@ export const JOB_CONTENT_INPUTS: Record<CacheableExecution, readonly string[]> =
     "packages/spec/**",
     "packages/core/**",
     "packages/svelte/**",
+    "packages/cli/**",
     ...DOCS_SURFACE_CONTENT_INPUTS,
   ],
   actions_security: [
@@ -166,6 +171,7 @@ export const JOB_CONTENT_INPUTS: Record<CacheableExecution, readonly string[]> =
     "packages/spec/**",
     "packages/core/**",
     "packages/svelte/**",
+    "packages/cli/**",
   ],
   interaction_perf: [
     ...UNIVERSAL_CONTENT_INPUTS,
@@ -175,6 +181,7 @@ export const JOB_CONTENT_INPUTS: Record<CacheableExecution, readonly string[]> =
     "packages/spec/**",
     "packages/core/**",
     "packages/svelte/**",
+    "packages/cli/**",
     "apps/docs/**",
     "examples/**",
   ],
@@ -183,6 +190,7 @@ export const JOB_CONTENT_INPUTS: Record<CacheableExecution, readonly string[]> =
     "packages/spec/**",
     "packages/core/**",
     "packages/svelte/**",
+    "packages/cli/**",
     "skills/ggsvelte/**",
   ],
   // Same inputs as component_svelte (shared packages/svelte tree); distinct
@@ -192,6 +200,7 @@ export const JOB_CONTENT_INPUTS: Record<CacheableExecution, readonly string[]> =
     "packages/spec/**",
     "packages/core/**",
     "packages/svelte/**",
+    "packages/cli/**",
     "skills/ggsvelte/**",
   ],
   component_spikes: [
@@ -199,6 +208,7 @@ export const JOB_CONTENT_INPUTS: Record<CacheableExecution, readonly string[]> =
     "packages/spec/**",
     "packages/core/**",
     "packages/svelte/**",
+    "packages/cli/**",
     "spikes/**",
   ],
   component_journeys: [
@@ -206,6 +216,7 @@ export const JOB_CONTENT_INPUTS: Record<CacheableExecution, readonly string[]> =
     "packages/spec/**",
     "packages/core/**",
     "packages/svelte/**",
+    "packages/cli/**",
     "apps/docs/**",
     "examples/**",
     "tests/visual/**",
@@ -253,6 +264,7 @@ export const JOB_CONTENT_INPUTS: Record<CacheableExecution, readonly string[]> =
     "packages/spec/**",
     "packages/core/**",
     "packages/svelte/**",
+    "packages/cli/**",
     "scripts/consumer-compat.ts",
     "scripts/consumer-compat-plan.ts",
     "scripts/consumer-compat-fixture.ts",

--- a/scripts/ci-routing/routing.ts
+++ b/scripts/ci-routing/routing.ts
@@ -21,6 +21,7 @@ export type ChangeLane =
   | "spec"
   | "core"
   | "svelte"
+  | "cli"
   | "docs"
   | "docs_render"
   | "examples"
@@ -118,6 +119,7 @@ export const DOCS_CONTENT_SCRIPT_PATTERNS: readonly string[] = [
 export const LANE_PATTERNS: Record<ChangeLane, readonly string[]> = {
   spec: ["packages/spec/**"],
   core: ["packages/core/**"],
+  cli: ["packages/cli/**"],
   svelte: ["packages/svelte/**", "skills/ggsvelte/**"],
   docs: [
     "apps/docs/**",
@@ -447,7 +449,8 @@ export function planJobs(changes: ChangeFlags, options: PlanOptions = {}): JobPl
   // Product-wide force. Intentionally excludes ci.yml / .github/actions so
   // Dependabot action pin bumps stay on the cheap CI-plumbing surface.
   const forceProduct = changes.lockfile || changes.ci_routing;
-  const packageSurface = changes.spec || changes.core || changes.svelte || forceProduct;
+  const packageSurface =
+    changes.spec || changes.core || changes.svelte || changes.cli || forceProduct;
   const docsSurface = changes.docs || changes.examples || forceProduct;
   const browserSurface =
     packageSurface || changes.spikes || changes.visual || changes.performance || forceProduct;
@@ -494,6 +497,7 @@ export function planJobs(changes: ChangeFlags, options: PlanOptions = {}): JobPl
       changes.spec ||
       changes.core ||
       changes.svelte ||
+      changes.cli ||
       changes.scripts ||
       changes.benchmarks ||
       changes.evals ||
@@ -516,7 +520,12 @@ export function planJobs(changes: ChangeFlags, options: PlanOptions = {}): JobPl
     actions_security: changes.workflows || changes.ci_actions || forceProduct,
     // retained-memory imports packages/svelte inspection coordinator.
     bench_smoke:
-      changes.benchmarks || changes.spec || changes.core || changes.svelte || forceProduct,
+      changes.benchmarks ||
+      changes.spec ||
+      changes.core ||
+      changes.svelte ||
+      changes.cli ||
+      forceProduct,
     // Informational only; path-gated and independent of the component job.
     interaction_perf: browserSurface,
     packages_dist: packagesDist,

--- a/scripts/consumer-compat-fixture.ts
+++ b/scripts/consumer-compat-fixture.ts
@@ -33,6 +33,7 @@ export function fixtureManifest(
     "@ggsvelte/spec": file(tarballs[0]!),
     "@ggsvelte/core": file(tarballs[1]!),
     "@ggsvelte/svelte": file(tarballs[2]!),
+    "@ggsvelte/cli": file(tarballs[3]!),
   };
   return {
     name: "ggsvelte-packed-consumer",
@@ -69,7 +70,7 @@ export function writeConsumerFixture(
   if (packageManager === "pnpm") {
     writeFileSync(
       join(directory, "pnpm-workspace.yaml"),
-      `packages: []\noverrides:\n  '@ggsvelte/spec': ${JSON.stringify(manifest.dependencies["@ggsvelte/spec"])}\n  '@ggsvelte/core': ${JSON.stringify(manifest.dependencies["@ggsvelte/core"])}\n  '@ggsvelte/svelte': ${JSON.stringify(manifest.dependencies["@ggsvelte/svelte"])}\n`,
+      `packages: []\noverrides:\n  '@ggsvelte/spec': ${JSON.stringify(manifest.dependencies["@ggsvelte/spec"])}\n  '@ggsvelte/core': ${JSON.stringify(manifest.dependencies["@ggsvelte/core"])}\n  '@ggsvelte/svelte': ${JSON.stringify(manifest.dependencies["@ggsvelte/svelte"])}\n  '@ggsvelte/cli': ${JSON.stringify(manifest.dependencies["@ggsvelte/cli"])}\n`,
     );
   }
   writeFileSync(

--- a/scripts/consumer-compat-plan.ts
+++ b/scripts/consumer-compat-plan.ts
@@ -14,7 +14,7 @@ export interface CommandStep {
   expect?: string;
 }
 
-export const publishablePackageDirectories = ["spec", "core", "svelte"] as const;
+export const publishablePackageDirectories = ["spec", "core", "svelte", "cli"] as const;
 
 export type PublishablePackageVersions = Readonly<
   Record<(typeof publishablePackageDirectories)[number], string>
@@ -97,7 +97,7 @@ function scriptRunner(packageManager: PackageManager, script: string): CommandSt
 
 export function commandPlan(
   packageManager: PackageManager,
-  expectedSveltePackageVersion: string,
+  expectedCliPackageVersion: string,
 ): CommandStep[] {
   const install: CommandStep =
     packageManager === "npm"
@@ -124,7 +124,7 @@ export function commandPlan(
   build.label = "build and prerender SvelteKit consumer";
   const cliVersion = runner(packageManager, "ggsvelte-render", ["--version"]);
   cliVersion.label = "CLI version";
-  cliVersion.expect = expectedSveltePackageVersion;
+  cliVersion.expect = expectedCliPackageVersion;
   const cliFile = runner(packageManager, "ggsvelte-render", ["plot.json"]);
   cliFile.label = "CLI file input";
   cliFile.expect = "<svg";

--- a/scripts/consumer-compat.test.ts
+++ b/scripts/consumer-compat.test.ts
@@ -18,10 +18,13 @@ import { loadSupportMatrix } from "./support-matrix.js";
 
 describe("packed consumer compatibility harness", () => {
   test("installs every publishable tarball rather than workspace source", () => {
-    expect(packageTarballNames({ spec: "0.2.0", core: "0.2.0", svelte: "0.2.1" })).toEqual([
+    expect(
+      packageTarballNames({ spec: "0.2.0", core: "0.2.0", svelte: "0.2.1", cli: "0.2.1" }),
+    ).toEqual([
       "ggsvelte-spec-0.2.0.tgz",
       "ggsvelte-core-0.2.0.tgz",
       "ggsvelte-svelte-0.2.1.tgz",
+      "ggsvelte-cli-0.2.1.tgz",
     ]);
   });
 
@@ -90,7 +93,7 @@ describe("packed consumer compatibility harness", () => {
       writeConsumerFixture(
         directory,
         "5.33.1",
-        ["/tmp/spec.tgz", "/tmp/core.tgz", "/tmp/svelte.tgz"],
+        ["/tmp/spec.tgz", "/tmp/core.tgz", "/tmp/svelte.tgz", "/tmp/cli.tgz"],
         "npm",
       );
       expect(readFileSync(join(directory, "src", "routes", "+page.svelte"), "utf8")).toBe(
@@ -112,6 +115,7 @@ describe("packed consumer compatibility harness", () => {
         join("artifacts", "ggsvelte-spec-0.0.0.tgz"),
         join("artifacts", "ggsvelte-core-0.0.0.tgz"),
         join("artifacts", "ggsvelte-svelte-0.0.0.tgz"),
+        join("artifacts", "ggsvelte-cli-0.0.0.tgz"),
       ],
       "/consumer",
     );
@@ -119,6 +123,7 @@ describe("packed consumer compatibility harness", () => {
     expect(manifest.dependencies["@ggsvelte/spec"]).toContain("ggsvelte-spec-0.0.0.tgz");
     expect(manifest.dependencies["@ggsvelte/core"]).toContain("ggsvelte-core-0.0.0.tgz");
     expect(manifest.dependencies["@ggsvelte/svelte"]).toContain("ggsvelte-svelte-0.0.0.tgz");
+    expect(manifest.dependencies["@ggsvelte/cli"]).toContain("ggsvelte-cli-0.0.0.tgz");
     expect(manifest.devDependencies).toMatchObject({
       "@sveltejs/adapter-static": "3.0.10",
       "@sveltejs/kit": "2.20.8",

--- a/scripts/consumer-compat.ts
+++ b/scripts/consumer-compat.ts
@@ -93,6 +93,7 @@ function pack(root: string, artifacts: string): string[] {
     spec: packageVersion(root, "spec"),
     core: packageVersion(root, "core"),
     svelte: packageVersion(root, "svelte"),
+    cli: packageVersion(root, "cli"),
   };
   for (const packageDirectory of publishablePackageDirectories) {
     const invocation = packagePackInvocation(artifacts);
@@ -128,8 +129,8 @@ function main(): void {
     const tarballs = pack(root, artifacts);
     writeConsumerFixture(fixture, svelteVersion, tarballs, packageManager);
     verifyPackageManagerVersion(packageManager, packageManagerVersion, fixture, root);
-    const expectedSveltePackageVersion = packageVersion(root, "svelte");
-    for (const step of commandPlan(packageManager, expectedSveltePackageVersion)) {
+    const expectedCliPackageVersion = packageVersion(root, "cli");
+    for (const step of commandPlan(packageManager, expectedCliPackageVersion)) {
       run(step, fixture, root);
     }
     console.log(`consumer-compat: PASS (${packageManager}, Svelte ${svelteVersion})`);

--- a/scripts/deprecation-wiring.test.ts
+++ b/scripts/deprecation-wiring.test.ts
@@ -70,7 +70,7 @@ function deprecatedBlocks(source: string): string[] {
 }
 
 describe("deprecated surfaces link migration guidance", () => {
-  const packages = ["spec", "core", "svelte"];
+  const packages = ["spec", "core", "svelte", "cli"];
 
   it("every @deprecated tag carries since-version and a resolving guide link", () => {
     for (const pkg of packages) {

--- a/scripts/docs-route-inventory-pages.ts
+++ b/scripts/docs-route-inventory-pages.ts
@@ -297,6 +297,7 @@ export const TOP_LEVEL_ROUTES: readonly DocsRouteRecord[] = [
     shell: "docs",
     navigation: { section: "Reference", label: "CLI reference", order: 62 },
     headings: [
+      { id: "install", title: "Install", level: 2 },
       { id: "input-and-output", title: "Input and output", level: 2 },
       { id: "options", title: "Options", level: 2 },
       ...CLI_REFERENCE_OPTIONS.map((option) => ({

--- a/scripts/gen-lifecycle.ts
+++ b/scripts/gen-lifecycle.ts
@@ -39,6 +39,7 @@ export const SURFACES: readonly { pkg: string; entry: string; file: string }[] =
   { pkg: "@ggsvelte/core", entry: "./temporal", file: "packages/core/src/temporal-entry.ts" },
   { pkg: "@ggsvelte/core", entry: "./dom", file: "packages/core/src/dom/index.ts" },
   { pkg: "@ggsvelte/svelte", entry: ".", file: "packages/svelte/src/lib/index.ts" },
+  { pkg: "@ggsvelte/cli", entry: ".", file: "packages/cli/src/index.ts" },
 ];
 
 export class LifecycleError extends Error {

--- a/scripts/llms-guide-content.ts
+++ b/scripts/llms-guide-content.ts
@@ -38,9 +38,12 @@ bun add @ggsvelte/svelte
 \`\`\`
 
 \`@ggsvelte/spec\` (schema, validate, builder) and \`@ggsvelte/core\`
-(pipeline, headless render, CLI) are dependencies of the Svelte package.
-Install them directly for spec-only or headless work. Bundled teaching data
-lives at \`@ggsvelte/svelte/data\`.
+(pipeline, headless render) are dependencies of the Svelte package. Install
+them directly for spec-only or headless work. The \`ggsvelte-render\` CLI is
+its own package — install \`@ggsvelte/cli\` in every sandbox where an agent
+authors specs, so validation errors and chart-quality warnings surface
+before a chart ships. Bundled teaching data lives at
+\`@ggsvelte/svelte/data\`.
 
 ## A complete Svelte file
 
@@ -1165,10 +1168,12 @@ const svg = renderToSVGString(spec, { width: 640, height: 400 });
 \`\`\`
 
 \`\`\`sh fragment
+# npm install -g @ggsvelte/cli
 ggsvelte-render spec.json > chart.svg
 \`\`\`
 
-SVG on stdout; JSON Lines diagnostics on stderr. [CLI reference](/reference/cli).
+SVG on stdout; JSON Lines diagnostics on stderr — the agent feedback loop.
+[CLI reference](/reference/cli).
 
 ## Compatibility
 
@@ -1938,6 +1943,24 @@ migration note here.
 The accepted lifecycle and deprecation policy remains in
 [Lifecycle and editions](/guide/lifecycle#lifecycle-tags); this page applies it
 rather than creating a second policy.
+
+## 0.22 to 0.23
+
+### CLI moved to @ggsvelte/cli
+
+The \`ggsvelte-render\` bin no longer ships with \`@ggsvelte/svelte\`. It is
+its own package, \`@ggsvelte/cli\`, with no Svelte dependency — install it
+wherever the command runs (agent sandboxes above all):
+
+\`\`\`sh fragment
+npm install -g @ggsvelte/cli
+# or add @ggsvelte/cli as a dependency of the project that invokes it
+\`\`\`
+
+The command name, flags, exit codes, and JSONL diagnostics are unchanged.
+\`ggsvelte-codemod\` still ships with \`@ggsvelte/svelte\`. If a sandbox image
+or CI step ran \`ggsvelte-render\` via the Svelte package's bin, add
+\`@ggsvelte/cli\` there before upgrading \`@ggsvelte/svelte\`.
 
 ## 0.20 to 0.21
 

--- a/scripts/package-identity.test.ts
+++ b/scripts/package-identity.test.ts
@@ -7,6 +7,7 @@ const packagePaths = [
   "packages/spec/package.json",
   "packages/core/package.json",
   "packages/svelte/package.json",
+  "packages/cli/package.json",
 ] as const;
 
 type PublishedManifest = {

--- a/scripts/package-lint.ts
+++ b/scripts/package-lint.ts
@@ -27,6 +27,7 @@ const targets: Target[] = [
   { dir: "packages/spec", attw: true },
   { dir: "packages/core", attw: true },
   { dir: "packages/svelte", attw: false }, // .svelte d.ts imports (see header)
+  { dir: "packages/cli", attw: true },
 ];
 
 const root = process.cwd();

--- a/scripts/release-wiring.test.ts
+++ b/scripts/release-wiring.test.ts
@@ -64,7 +64,7 @@ describe("R0 release wiring", () => {
     const ci = readCiSurface();
     // CI collects lcov for Codecov. Package tests are CI-only — pre-push was
     // nuked so agents can push without re-running the full unit suite locally.
-    expect(ci).toContain("packages/spec packages/core benchmarks scripts tests/evals");
+    expect(ci).toContain("packages/spec packages/core packages/cli benchmarks scripts tests/evals");
     expect(ci).toContain("--coverage-reporter=lcov");
     expect(ci).toContain("coverage/unit");
     expect(ci).toContain("codecov/codecov-action@");
@@ -259,6 +259,7 @@ describe("R0 release wiring", () => {
     expect(producerJob).toContain("packages/spec/dist");
     expect(producerJob).toContain("packages/core/dist");
     expect(producerJob).toContain("packages/svelte/dist");
+    expect(producerJob).toContain("packages/cli/dist");
     expect(producerJob).toContain("run: bun run build");
     // Consumers download instead of rebuilding packages (via composite).
     const consumerJob = ciJob(ci, "consumer-compat");
@@ -526,6 +527,7 @@ describe("R0 release wiring", () => {
       '"/packages/core"',
       '"/packages/spec"',
       '"/packages/svelte"',
+      '"/packages/cli"',
       '"/apps/docs"',
       '"/examples"',
       '"/benchmarks"',
@@ -559,14 +561,20 @@ describe("R0 release wiring", () => {
       privatePackages?: boolean | { version?: boolean; tag?: boolean };
     };
     expect(config.privatePackages).toBe(false);
-    // fixed (not linked): any release bumps all three so package-identity
+    // fixed (not linked): any release bumps all four so package-identity
     // lockstep versions stay equal even when only one package has a changeset.
-    expect(config.fixed).toEqual([["@ggsvelte/spec", "@ggsvelte/core", "@ggsvelte/svelte"]]);
+    expect(config.fixed).toEqual([
+      ["@ggsvelte/spec", "@ggsvelte/core", "@ggsvelte/svelte", "@ggsvelte/cli"],
+    ]);
     expect(config.linked ?? []).toEqual([]);
   });
 
   it("keeps internal dependencies installable in npm-published manifests", () => {
-    for (const path of ["packages/core/package.json", "packages/svelte/package.json"]) {
+    for (const path of [
+      "packages/core/package.json",
+      "packages/svelte/package.json",
+      "packages/cli/package.json",
+    ]) {
       const manifest = JSON.parse(read(path)) as { dependencies?: Record<string, string> };
       for (const [name, range] of Object.entries(manifest.dependencies ?? {})) {
         if (!name.startsWith("@ggsvelte/")) continue;
@@ -578,11 +586,16 @@ describe("R0 release wiring", () => {
   });
 
   it("ships the CLI bins without npm manifest normalization", () => {
-    const manifest = JSON.parse(read("packages/svelte/package.json")) as {
+    const svelteManifest = JSON.parse(read("packages/svelte/package.json")) as {
       bin?: Record<string, string>;
     };
-    expect(manifest.bin).toEqual({
+    expect(svelteManifest.bin).toEqual({
       "ggsvelte-codemod": "bin/ggsvelte-codemod.js",
+    });
+    const cliManifest = JSON.parse(read("packages/cli/package.json")) as {
+      bin?: Record<string, string>;
+    };
+    expect(cliManifest.bin).toEqual({
       "ggsvelte-render": "bin/ggsvelte-render.js",
     });
   });
@@ -590,9 +603,12 @@ describe("R0 release wiring", () => {
   it("keeps every bin's entry file present and executable-shaped", () => {
     // A bin whose target is missing installs a broken command; npm does not
     // validate the path, so this is the only gate that would catch it.
-    for (const relative of ["bin/ggsvelte-codemod.js", "bin/ggsvelte-render.js"]) {
-      const source = read(`packages/svelte/${relative}`);
-      expect(source.startsWith("#!/usr/bin/env node"), `${relative} needs a shebang`).toBe(true);
+    for (const path of [
+      "packages/svelte/bin/ggsvelte-codemod.js",
+      "packages/cli/bin/ggsvelte-render.js",
+    ]) {
+      const source = read(path);
+      expect(source.startsWith("#!/usr/bin/env node"), `${path} needs a shebang`).toBe(true);
     }
   });
 });

--- a/scripts/support-matrix.test.ts
+++ b/scripts/support-matrix.test.ts
@@ -108,7 +108,7 @@ describe("consumer support matrix", () => {
 
   test("keeps publishable manifests aligned with the declared Node and Svelte support", () => {
     const matrix = loadSupportMatrix(root);
-    for (const dir of ["spec", "core", "svelte"]) {
+    for (const dir of ["spec", "core", "svelte", "cli"]) {
       const manifest = JSON.parse(
         readFileSync(join(root, "packages", dir, "package.json"), "utf8"),
       ) as { engines?: { node?: string }; peerDependencies?: { svelte?: string } };

--- a/skills/ggsvelte/SKILL.md
+++ b/skills/ggsvelte/SKILL.md
@@ -14,6 +14,11 @@ same grammar — never build SVG or canvas output yourself:
   `validate(spec)`, render with `renderToSVGString(spec, {width, height})`
   (Node-safe), `ggsvelte-render spec.json > out.svg` (CLI), or `<GGPlot spec>`.
   A third skin, the `gg()` builder, produces the same spec in TypeScript.
+  The CLI is part of the install contract for agent-driven chart generation:
+  install `@ggsvelte/cli` in every sandbox where an agent authors specs
+  (`npm i -g @ggsvelte/cli`). It is the only way the agent sees the
+  pipeline's warnings and advisories before a chart ships; a JSON-only
+  workflow renders blind. Do not drop it to slim an install.
 
 ## Mental model
 
@@ -236,7 +241,9 @@ mixed-sign data); `lintSpec(spec)` is the standalone equivalent. Advisories
 never block; fix them when they match intent. `normalize(input)` canonicalizes
 authoring sugar into a `PortableSpec`; `isPortable`/`toPortable` check and
 strip runtime-only fields. CLIs: `ggsvelte-render spec.json > out.svg`
-(JSON-line diagnostics on stderr) and `ggsvelte-codemod [--write] src`.
+(from `@ggsvelte/cli`; JSON-line diagnostics on stderr — exit 3 means
+validation errors, exit 0 with stderr output means quality warnings worth
+fixing) and `ggsvelte-codemod [--write] src` (ships with `@ggsvelte/svelte`).
 
 ## Recipes (spec JSON — the everyday twelve)
 


### PR DESCRIPTION
## What

The `ggsvelte-render` CLI moves from a bin on `@ggsvelte/svelte` to its own published package, **`@ggsvelte/cli`** (`packages/cli`). ADR 0022 records the decision.

## Why

The CLI is designed as the feedback loop for embedded analytics agents: render a spec in the sandbox, read the JSONL diagnostics, fix before shipping. But it shipped only inside the Svelte component library, so a sandbox had to install all of `@ggsvelte/svelte` (Svelte 5 peer dep included) to get a validator. Install agents read that as optional and trimmed it — observed in the field, with the packaged skill edited to delete every CLI mention. The result was agents shipping charts whose warnings nobody saw.

`@ggsvelte/cli` depends only on `@ggsvelte/core`, installs with one line in a Docker image, and its README, the skill, and the docs now say plainly: if an agent authors specs in a sandbox, this package is part of the install contract.

## Changes

- **New `packages/cli`**: `ggsvelte-render` bin (moved, logic unchanged — `runCLI` stays in core), `src/index.ts` re-exporting `runCLI`/`CLIIO`, README with the sandbox story, tests spawning the workspace bin (moved from core).
- **`@ggsvelte/svelte`** (breaking, pre-1.0 minor): no longer ships `ggsvelte-render`. `ggsvelte-codemod` stays. Migration is one line; the upgrading guide gained a `0.22 to 0.23` section.
- **`@ggsvelte/core`**: `--version` help text is package-neutral; comment updates.
- **Changesets**: `@ggsvelte/cli` joins the `fixed` group — all four packages share one version. Changeset carries the required `Migration:` marker.
- **CI**: new `cli` routing lane (unit/bench_smoke/packageSurface conditions), `packages/cli/**` added to all 12 content-hash input lists, packages-dist producer/composite verify `packages/cli/dist/index.js`, unit suite and root scripts include `packages/cli`, package-lint (+attw), knip workspace, codecov component, dependabot directory, lifecycle surface (regenerated).
- **Consumer-compat**: packs and installs the fourth tarball; the CLI steps now assert the **cli** package's version.
- **Docs**: install section on the CLI reference page, README packages table row, CONTRIBUTING, skill text (strengthened: the CLI is not optional for agent sandboxes; synced to the shipped copy), llms guide install block, regenerated routes/search indexes.

## Verification

- `bun run check`, full unit suite (`bun test packages/spec packages/core packages/cli benchmarks scripts tests/evals`): green except `docs-spec-chunk-split` which fails on clean main too against a stale local docs build (skips in CI).
- `bun run build`, `lint:package` (publint + attw for cli), `knip`, `fmt:check`, `lint`, `lint:md`, `lint:type-aware`, `lint:actions`, `support:check`, `check:svelte`, `check:docs`: all green.
- `bun run compat:consumer`: **PASS** — packed `@ggsvelte/cli` tarball installs; CLI version/file/stdin steps verified.
- Hand smoke: `ggsvelte-render` renders SVG with JSONL advisories on stderr; `--version` prints the cli manifest version.

## ⚠️ Release sequencing (maintainer step before the next Version Packages merge)

npm trusted publishing (OIDC) cannot first-publish a new package (npm/cli#8544). **Before merging the next "Version Packages" PR**, publish `@ggsvelte/cli@0.22.0` once by hand from merged main and configure the trusted publisher:

```sh
cd packages/cli && NPM_CONFIG_PROVENANCE=false npm publish --access public
# then: npm-side trusted publisher config (npm trust) → this repo + release.yml
```

Skipping this half-publishes the fixed group (spec/core/svelte at 0.23.0, cli missing) and turns the release run red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1292" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->