### PR TITLE
perf(core): O(B²)→O(B) outline mask-source lookup in buildInteractionMasks

### DIFF
--- a/.changeset/interaction-mask-peer-lookup.md
+++ b/.changeset/interaction-mask-peer-lookup.md
@@ -1,0 +1,7 @@
+---
+"@ggsvelte/core": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+perf(core): resolve outline mask sources with one per-layer index instead of rescanning every batch per outline in `buildInteractionMasks` (O(B²) → O(B) over geometry batches; this path recomputes on every hover/legend emphasis change)

--- a/packages/core/src/interaction-mask.ts
+++ b/packages/core/src/interaction-mask.ts
@@ -120,23 +120,34 @@ export function buildInteractionMasks<Key extends PropertyKey>(
 
   // Mirror fill-batch focus onto presentation-only path batches on the same
   // layer (ribbon outline open paths). Null masks stay fully opaque in canvas.
+  // The mask source is the lowest-indexed same-layer batch holding a mask at
+  // that point in the loop — masks mirrored onto earlier outlines included —
+  // so the per-layer index below must track masks this loop adds, not just
+  // the candidate-derived ones.
+  let peerByLayer: Map<number, { batchIndex: number; values: Uint8Array; count: number }> | null =
+    null;
   for (let index = 0; index < batches.length; index++) {
     const batch = batches[index];
     if (batch === undefined || batch.kind !== "paths" || batch.candidates !== false) continue;
     if (focused.has(index)) continue;
-    let source: Uint8Array | undefined;
-    let sourceCount = 0;
-    for (let other = 0; other < batches.length; other++) {
-      if (other === index) continue;
-      const peer = batches[other];
-      if (peer === undefined || peer.layerIndex !== batch.layerIndex) continue;
-      const values = focused.get(other);
-      if (values === undefined) continue;
-      source = values;
-      sourceCount = renderPrimitiveCount(peer);
-      break;
+    if (peerByLayer === null) {
+      peerByLayer = new Map();
+      for (let other = 0; other < batches.length; other++) {
+        const candidate = batches[other];
+        if (candidate === undefined || peerByLayer.has(candidate.layerIndex)) continue;
+        const values = focused.get(other);
+        if (values === undefined) continue;
+        peerByLayer.set(candidate.layerIndex, {
+          batchIndex: other,
+          values,
+          count: renderPrimitiveCount(candidate),
+        });
+      }
     }
-    if (source === undefined) continue;
+    const peer = peerByLayer.get(batch.layerIndex);
+    if (peer === undefined) continue;
+    const source = peer.values;
+    const sourceCount = peer.count;
     const outlineCount = renderPrimitiveCount(batch);
     const mirrored = new Uint8Array(outlineCount);
     if (outlineCount === sourceCount) {
@@ -153,6 +164,12 @@ export function buildInteractionMasks<Key extends PropertyKey>(
       // (zeros = not focused → canvas draws at mutedAlpha)
     }
     focused.set(index, mirrored);
+    if (index < peer.batchIndex)
+      peerByLayer.set(batch.layerIndex, {
+        batchIndex: index,
+        values: mirrored,
+        count: outlineCount,
+      });
   }
 
   return freezeMasks(batches, focused);

--- a/packages/core/tests/interaction-mask.test.ts
+++ b/packages/core/tests/interaction-mask.test.ts
@@ -33,6 +33,24 @@ function rectBatch(count: number): GeometryBatch {
   };
 }
 
+/** Presentation-only open-path batch (`candidates: false`) with `subpaths` strokes. */
+function outlineBatch(subpaths: number, layerIndex: number): GeometryBatch {
+  const vertices = subpaths * 2;
+  return {
+    kind: "paths",
+    layerIndex,
+    panelIndex: 0,
+    positions: new Float32Array(vertices * 2),
+    rowIndex: new Uint32Array(vertices),
+    pathOffsets: Uint32Array.from({ length: subpaths + 1 }, (_, index) => index * 2),
+    strokes: Array.from({ length: subpaths }, () => null),
+    linewidth: 1,
+    alpha: 1,
+    curve: "linear",
+    candidates: false,
+  };
+}
+
 describe("buildInteractionMasks", () => {
   it("projects semantic emphasis onto immutable per-batch primitive masks", () => {
     const candidates: SemanticCandidateKeys<string>[] = [
@@ -147,6 +165,81 @@ describe("buildInteractionMasks", () => {
     expect(masks[1]?.isFocused(1)).toBe(true);
     expect(masks[1]?.isFocused(2)).toBe(false);
     expect(masks[1]?.isFocused(3)).toBe(false);
+  });
+
+  it("leaves an outline null when no same-layer batch has a mask", () => {
+    const candidates: SemanticCandidateKeys<string>[] = [
+      { batchIndex: 0, primitiveIndex: 0, keys: ["a"] },
+    ];
+    const masks = buildInteractionMasks([pointBatch(1), outlineBatch(1, 7)], ["a"], candidates);
+    expect(masks[0]?.focusedCount).toBe(1);
+    expect(masks[1]).toBeNull();
+  });
+
+  it("lets a later outline source an earlier outline's mirrored mask by batch order", () => {
+    // Pins the cascade: the mask source for an outline is the lowest-indexed
+    // same-layer batch that HAS a mask at that point in the loop — including a
+    // mask mirrored earlier onto another outline. Here outline0 (2 subpaths,
+    // index 0) mirrors from the fill (1 path, index 1) via the ×2 branch, and
+    // outline2 (4 subpaths) then sources outline0 (count 2, 4 = 2×2 → ×2
+    // branch → all focused). Sourcing the fill instead would hit the length-
+    // mismatch branch (4 vs 1) and zero everything.
+    const fill: GeometryBatch = {
+      kind: "paths",
+      layerIndex: 0,
+      panelIndex: 0,
+      positions: new Float32Array(8),
+      rowIndex: new Uint32Array([0, 1, 2, 3]),
+      pathOffsets: new Uint32Array([0, 4]),
+      strokes: [null],
+      fills: ["#f00"],
+      closed: true,
+      linewidth: 0,
+      alpha: 1,
+      curve: "linear",
+    };
+    const candidates: SemanticCandidateKeys<string>[] = [
+      { batchIndex: 1, primitiveIndex: 0, keys: ["a"] },
+    ];
+
+    const masks = buildInteractionMasks(
+      [outlineBatch(2, 0), fill, outlineBatch(4, 0)],
+      ["a"],
+      candidates,
+    );
+    expect(masks[0]?.primitiveCount).toBe(2);
+    expect(masks[0]?.focusedCount).toBe(2);
+    expect(masks[2]?.primitiveCount).toBe(4);
+    expect(masks[2]?.focusedCount).toBe(4);
+  });
+
+  it("resolves outline mask sources without rescanning all batches per outline", () => {
+    // 1 focused point batch on layer 0 plus 200 outlines on layers 1..200 —
+    // none finds a peer. Peer resolution must not scan the whole batch list
+    // once per outline (O(B²) batch reads); a per-layer lookup keeps total
+    // batch-element reads linear in B.
+    const outlines = Array.from({ length: 200 }, (_, index) => outlineBatch(1, index + 1));
+    const batches: GeometryBatch[] = [pointBatch(1), ...outlines];
+    const total = batches.length;
+    let reads = 0;
+    const counted = new Proxy(batches, {
+      get(target, prop) {
+        if (typeof prop === "string" && /^\d+$/.test(prop)) reads += 1;
+        return Reflect.get(target, prop) as unknown;
+      },
+    });
+    const candidates: SemanticCandidateKeys<string>[] = [
+      { batchIndex: 0, primitiveIndex: 0, keys: ["a"] },
+    ];
+
+    const masks = buildInteractionMasks(counted, ["a"], candidates);
+    expect(masks[0]?.focusedCount).toBe(1);
+    expect(masks[1]).toBeNull();
+    // Fixed passes (candidate lookup, mirror loop, one peer-index build, final
+    // freeze) each read ≤ B elements; 8×B fails on even a partial per-outline
+    // rescan (the old code read ~B² ≈ 40k).
+    expect(reads).toBeGreaterThan(0);
+    expect(reads).toBeLessThan(8 * total);
   });
 });
 


### PR DESCRIPTION
Fixes #1287.

## Problem

`buildInteractionMasks` mirrors fill-batch focus onto presentation-only outline path batches (`candidates: false`). For each such outline without its own mask, it rescanned the whole batch list to find the first same-layer batch with a mask — O(B²) batch reads where B is the geometry batch count (grows with facet cardinality × layers). The path is warm: it recomputes inside a `$derived` on every hover and legend emphasis change.

## Fix

One lazily built per-layer index mapping `layerIndex` → the lowest-indexed batch holding a mask. Each outline then resolves its source with a Map lookup. The index updates as mirrored masks land, which keeps the existing cascade order: a later outline can still source an earlier outline's mirrored mask when that outline sits at a lower batch index than the fill. O(B²) → O(B).

## Tests

- Characterization first (green on the old code): outline stays `null` with no same-layer mask source, and the cascade case above — outline(2 subpaths) before fill(1 path) before outline(4 subpaths), where sourcing the fill directly would zero the third mask instead of focusing it.
- Complexity guard (red on the old code): 200 outlines on distinct layers behind a counting `Proxy` over the batch array — 40,403 element reads before, bounded at `8 × B` (1,608) after.

## Verification

- `bun test packages/core` — 1,990 pass
- `bun run check` — clean
- `bun run --bun lint:type-aware:run` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1300" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->