### PR TITLE
perf(core): binary-search ringStarts per subpath in point-in-path tests

### DIFF
--- a/.changeset/inside-path-ring-search.md
+++ b/.changeset/inside-path-ring-search.md
@@ -1,0 +1,7 @@
+---
+"@ggsvelte/core": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+perf(core): binary-search `ringStarts` for a subpath's hole breaks instead of scanning the whole batch array per point-in-path test (O(R) → O(log R + local) per probe; R grows with polygon feature/hole count in choropleths)

--- a/packages/core/src/candidate-geometry.ts
+++ b/packages/core/src/candidate-geometry.ts
@@ -235,10 +235,22 @@ function pathRingRanges(
   if (end <= start) return [];
   const breaks = batch.ringStarts;
   if (breaks === undefined || breaks.length === 0) return [[start, end]];
+  // breaks is non-decreasing (writers append at a monotone vertex cursor), so
+  // the entries inside (start, end) form one contiguous run: binary-search the
+  // first entry > start, then walk while < end — O(log R + local) instead of
+  // scanning all R batch-wide breaks per point-in-path test.
+  let lo = 0;
+  let hi = breaks.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if (breaks[mid]! > start) hi = mid;
+    else lo = mid + 1;
+  }
   const cuts: number[] = [start];
-  for (let i = 0; i < breaks.length; i++) {
+  for (let i = lo; i < breaks.length; i++) {
     const b = breaks[i]!;
-    if (b > start && b < end) cuts.push(b);
+    if (b >= end) break;
+    cuts.push(b);
   }
   cuts.push(end);
   const ranges: (readonly [number, number])[] = [];

--- a/packages/core/src/scene.ts
+++ b/packages/core/src/scene.ts
@@ -84,6 +84,8 @@ export interface PathsBatch {
    * Additional ring-start vertex indices within a closed filled subpath
    * (exterior already starts at pathOffsets[s]). Used for polygon holes:
    * one compound path with multiple M…Z rings (#809 phase 4).
+   * Non-decreasing: writers append at a monotone vertex cursor, and hit
+   * testing binary-searches this array per subpath.
    */
   ringStarts?: Uint32Array;
   /**

--- a/packages/core/tests/candidate/inside-path-ring-ranges.test.ts
+++ b/packages/core/tests/candidate/inside-path-ring-ranges.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "bun:test";
+
+import { insidePath } from "../../src/candidate-geometry.ts";
+import type { GeometryBatch } from "../../src/scene.ts";
+
+type PathsBatch = Extract<GeometryBatch, { kind: "paths" }>;
+
+/**
+ * `donuts` square donut subpaths side by side: outer (o,0)-(o+10,10), hole
+ * (o+3,3)-(o+7,7) with o = 12 × subpath. 8 vertices per subpath; ringStarts
+ * marks each hole start.
+ */
+function donutBatch(donuts: number): PathsBatch {
+  const positions = new Float32Array(donuts * 16);
+  const pathOffsets = new Uint32Array(donuts + 1);
+  const ringStarts = new Uint32Array(donuts);
+  for (let s = 0; s < donuts; s++) {
+    const o = s * 12;
+    const v = s * 8;
+    positions.set([o, 0, o + 10, 0, o + 10, 10, o, 10], v * 2);
+    positions.set([o + 3, 3, o + 7, 3, o + 7, 7, o + 3, 7], (v + 4) * 2);
+    pathOffsets[s] = v;
+    ringStarts[s] = v + 4;
+  }
+  pathOffsets[donuts] = donuts * 8;
+  return {
+    kind: "paths",
+    layerIndex: 0,
+    panelIndex: 0,
+    positions,
+    rowIndex: new Uint32Array(donuts * 8),
+    pathOffsets,
+    ringStarts,
+    fillRule: "evenodd",
+    strokes: Array.from({ length: donuts }, () => null),
+    fills: Array.from({ length: donuts }, () => null),
+    closed: true,
+    linewidth: 0,
+    alpha: 1,
+    curve: "linear",
+  };
+}
+
+describe("insidePath ring decomposition", () => {
+  it("splits a subpath on its own ring breaks (hole excluded, solid included)", () => {
+    const batch = donutBatch(1);
+    expect(insidePath(batch, 0, 8, 5, 5)).toBe(false); // hole center
+    expect(insidePath(batch, 0, 8, 1, 5)).toBe(true); // solid band
+    expect(insidePath(batch, 0, 8, -1, 5)).toBe(false); // outside exterior
+  });
+
+  it("ignores ring breaks that belong to neighboring subpaths", () => {
+    const batch = donutBatch(3);
+    // Middle donut spans vertices [8, 16); breaks 4 and 20 must not cut it.
+    expect(insidePath(batch, 8, 16, 17, 5)).toBe(false); // its own hole
+    expect(insidePath(batch, 8, 16, 13, 5)).toBe(true); // its solid band
+    expect(insidePath(batch, 8, 16, 5, 5)).toBe(false); // first donut's hole is outside
+  });
+
+  it("reads a bounded slice of ringStarts per call, not the whole array", () => {
+    // 512 donuts → 512 ring breaks. One insidePath call on a middle subpath
+    // must locate its breaks by search (O(log R + local)), not scan all R.
+    const batch = donutBatch(512);
+    const ringStarts = batch.ringStarts!;
+    let reads = 0;
+    batch.ringStarts = new Proxy(ringStarts, {
+      get(target, prop) {
+        if (typeof prop === "string" && /^\d+$/.test(prop)) reads += 1;
+        return Reflect.get(target, prop) as unknown;
+      },
+    });
+
+    expect(insidePath(batch, 256 * 8, 257 * 8, 256 * 12 + 1, 5)).toBe(true);
+    expect(reads).toBeGreaterThan(0);
+    // Binary search ≈ log2(512) = 9 probes plus the local walk; the old full
+    // scan read all 512 entries.
+    expect(reads).toBeLessThan(64);
+  });
+});


### PR DESCRIPTION
Fixes #1288.

## Problem

`pathRingRanges` (called from `insidePath`) scanned every entry of the batch-wide `ringStarts` array to pick the hole breaks inside one subpath — O(R) per probe, where R is the total ring count across the batch. R grows with polygon feature/hole count (a choropleth with thousands of multi-ring features), and `insidePath` runs on the pointer-move path via `pathsOps.contains` and per brush rect via `pathsOps.intersects`, so hole-break selection dominated the point-in-polygon work at O(S × R) per event.

## Fix

`ringStarts` is non-decreasing by construction — both writers (`geometry-paths-polygon.ts` pushes a strictly increasing vertex cursor; `coord-path-project.ts` pushes the growing projected-vertex cursor) append monotonically, so the breaks inside `(start, end)` form one contiguous run. Binary-search the first entry past the subpath start, then walk while below its end: O(log R + local). The sortedness contract is now documented on `PathsBatch.ringStarts`.

## Tests

- Characterization first (green on the old code): square-donut fixtures — hole excluded / solid band included, and a middle subpath ignores neighboring subpaths' ring breaks.
- Complexity guard (red on the old code): 512 donut subpaths behind a counting `Proxy` over `ringStarts`; one `insidePath` call read all 512 entries before, bounded at 64 after (~9 binary probes plus the local walk).

## Verification

- `bun test packages/core` — 1,993 pass
- `bun run check` — clean
- `bun run --bun lint:type-aware:run` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1301" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->