### PR TITLE
perf(core): drop repeated invariant work in two per-row helpers

### DIFF
--- a/.changeset/hoist-invariant-work.md
+++ b/.changeset/hoist-invariant-work.md
@@ -1,0 +1,7 @@
+---
+"@ggsvelte/core": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+perf(core): run the ISO shape regex once per string cell in `isIsoLikeString` (was twice), and hoist the kind-rank table out of `compareTokens` so the store-build sort comparator allocates nothing per call

--- a/packages/core/src/candidate-axis-token.ts
+++ b/packages/core/src/candidate-axis-token.ts
@@ -26,10 +26,11 @@ export function tokenKey(token: CanonicalAxisToken): string {
   return token.value ? "b:1" : "b:0";
 }
 
+const KIND_RANK = { number: 0, string: 1, boolean: 2 } as const;
+
 /** Total order over canonical axis tokens (package-internal). */
 export function compareTokens(a: CanonicalAxisToken, b: CanonicalAxisToken): number {
-  const rank = { number: 0, string: 1, boolean: 2 } as const;
-  const kind = rank[a.kind] - rank[b.kind];
+  const kind = KIND_RANK[a.kind] - KIND_RANK[b.kind];
   if (kind !== 0) return kind;
   if (a.kind === "number" && b.kind === "number") return a.value - b.value;
   if (a.kind === "string" && b.kind === "string")

--- a/packages/core/src/iso-epoch.ts
+++ b/packages/core/src/iso-epoch.ts
@@ -6,7 +6,9 @@ const ISO_LIKE =
   /^(\d{4})-(\d{2})-(\d{2})(?:[T ](\d{2}):(\d{2})(?::(\d{2})(?:\.(\d{1,9}))?)?(?:Z|([+-])(\d{2}):?(\d{2}))?)?$/;
 
 export function isIsoLikeString(value: string): boolean {
-  return ISO_LIKE.test(value) && isoEpochMs(value) !== undefined;
+  // isoEpochMs already rejects non-matching shapes, so one regex run suffices
+  // (this runs per string cell during column coercion).
+  return isoEpochMs(value) !== undefined;
 }
 
 /** True when the ISO string carries a clock component (time or datetime). */

--- a/packages/core/tests/candidate/canonical-axis-token.test.ts
+++ b/packages/core/tests/candidate/canonical-axis-token.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 
+import { compareTokens } from "../../src/candidate-axis-token.ts";
 import { canonicalAxisToken } from "../../src/candidate-store.ts";
 
 describe("canonicalAxisToken", () => {
@@ -11,5 +12,25 @@ describe("canonicalAxisToken", () => {
     expect(canonicalAxisToken(null)).toBeNull();
     expect(canonicalAxisToken(Number.NaN)).toBeNull();
     expect(canonicalAxisToken(Infinity)).toBeNull();
+  });
+});
+
+describe("compareTokens", () => {
+  const num = (value: number) => ({ kind: "number", value }) as const;
+  const str = (value: string) => ({ kind: "string", value }) as const;
+  const bool = (value: boolean) => ({ kind: "boolean", value }) as const;
+
+  it("orders kinds number < string < boolean, then by value within a kind", () => {
+    expect(compareTokens(num(9), str("a"))).toBeLessThan(0);
+    expect(compareTokens(str("z"), bool(false))).toBeLessThan(0);
+    expect(compareTokens(bool(true), num(0))).toBeGreaterThan(0);
+
+    expect(compareTokens(num(1), num(2))).toBeLessThan(0);
+    expect(compareTokens(str("b"), str("a"))).toBeGreaterThan(0);
+    expect(compareTokens(bool(false), bool(true))).toBeLessThan(0);
+
+    expect(compareTokens(num(3), num(3))).toBe(0);
+    expect(compareTokens(str("a"), str("a"))).toBe(0);
+    expect(compareTokens(bool(true), bool(true))).toBe(0);
   });
 });

--- a/packages/core/tests/iso-epoch.test.ts
+++ b/packages/core/tests/iso-epoch.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "bun:test";
+
+import { isIsoLikeString, isoEpochMs, isoHasClock } from "../src/iso-epoch.ts";
+
+describe("isoEpochMs", () => {
+  it("parses date, datetime, fraction, and offset forms to UTC epoch ms", () => {
+    expect(isoEpochMs("2024-03-05")).toBe(Date.UTC(2024, 2, 5));
+    expect(isoEpochMs("2024-03-05T06:07:08")).toBe(Date.UTC(2024, 2, 5, 6, 7, 8));
+    expect(isoEpochMs("2024-03-05 06:07")).toBe(Date.UTC(2024, 2, 5, 6, 7));
+    // Fractional seconds truncate to milliseconds.
+    expect(isoEpochMs("2024-03-05T06:07:08.123456789")).toBe(Date.UTC(2024, 2, 5, 6, 7, 8, 123));
+    expect(isoEpochMs("2024-03-05T06:07:08Z")).toBe(Date.UTC(2024, 2, 5, 6, 7, 8));
+    expect(isoEpochMs("2024-03-05T06:07:08+02:00")).toBe(
+      Date.UTC(2024, 2, 5, 6, 7, 8) - 2 * 3_600_000,
+    );
+    expect(isoEpochMs("2024-03-05T06:07:08-0230")).toBe(
+      Date.UTC(2024, 2, 5, 6, 7, 8) + 2.5 * 3_600_000,
+    );
+    // Years 0–99 must not map to 1900+.
+    expect(isoEpochMs("0099-01-01")).toBe(new Date(0).setUTCFullYear(99, 0, 1));
+  });
+
+  it("rejects out-of-range fields and non-ISO strings", () => {
+    expect(isoEpochMs("2024-13-01")).toBeUndefined();
+    expect(isoEpochMs("2024-02-30")).toBeUndefined();
+    expect(isoEpochMs("2024-03-05T24:00")).toBeUndefined();
+    expect(isoEpochMs("2024-03-05T06:60")).toBeUndefined();
+    expect(isoEpochMs("2024-03-05T06:07:08+25:00")).toBeUndefined();
+    expect(isoEpochMs("not a date")).toBeUndefined();
+    expect(isoEpochMs("2024/03/05")).toBeUndefined();
+  });
+});
+
+describe("isIsoLikeString", () => {
+  it("accepts exactly the strings isoEpochMs can parse", () => {
+    expect(isIsoLikeString("2024-03-05")).toBe(true);
+    expect(isIsoLikeString("2024-03-05T06:07:08.5Z")).toBe(true);
+    expect(isIsoLikeString("2024-02-30")).toBe(false); // shape matches, calendar rejects
+    expect(isIsoLikeString("not a date")).toBe(false);
+  });
+});
+
+describe("isoHasClock", () => {
+  it("detects a time component with T or space separators", () => {
+    expect(isoHasClock("2024-03-05T06:07")).toBe(true);
+    expect(isoHasClock("2024-03-05 06:07:08")).toBe(true);
+    expect(isoHasClock("2024-03-05")).toBe(false);
+  });
+});


### PR DESCRIPTION
Two small constant-factor cleanups from a complexity audit of `packages/core/src/`. A third audit item (a per-rect `themeVar(\"ink\")` call in `render-svg-marks.ts`) was already fixed on main by the shared style-resolver refactor (#1282), so nothing to do there.

## Changes

- **`iso-epoch.ts`** — `isIsoLikeString` ran `ISO_LIKE.test(value)`, then called `isoEpochMs(value)`, which ran the same regex again via `.exec`. `isoEpochMs` already returns `undefined` for non-matching shapes, so the guard test is redundant: one regex run per string cell instead of two on the accepting path. This runs once per string cell during column coercion.
- **`candidate-axis-token.ts`** — `compareTokens` rebuilt its `{ number: 0, string: 1, boolean: 2 }` rank object on every call. It is the comparator for the candidate-store sort, so that was O(n log n) throwaway allocations per store build. Hoisted to a module constant.

No behavior change intended in either.

## Tests

Neither helper had direct tests, so characterization landed first (green before the refactor, still green after):

- `tests/iso-epoch.test.ts` — parse set (date, datetime, space separator, fractional truncation, Z/±hh:mm/±hhmm offsets, years 0–99) and reject set (month/day/hour/minute/offset out of range, non-ISO shapes), plus `isIsoLikeString` and `isoHasClock`.
- `tests/candidate/canonical-axis-token.test.ts` — `compareTokens` total order: number < string < boolean across kinds, value order within each kind, and equality.

## Verification

- `bun test packages/core` — 1,998 pass
- `bun run check` — clean
- `bun run --bun lint:type-aware:run` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1302" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->