### PR TITLE
perf(core): window polygon hole rings instead of rescanning the batch

### DIFF
--- a/.changeset/ring-cuts-window.md
+++ b/.changeset/ring-cuts-window.md
@@ -6,11 +6,12 @@
 
 Migration: none — internal, except a narrowed input contract on `pathData`
 
-Every consumer of `PathsBatch.ringStarts` scanned the whole batch-wide array to
-find the ring breaks inside one subpath. A shared `ringCuts` helper binary-
-searches the window instead, so a batch with S filled subpaths and R hole rings
-drops from O(S x R) to O(S log R) per SVG render, per canvas frame, and on the
-brush path through hit-testing.
+SVG serialization, canvas tracing, and the coord hole remap each scanned the
+whole batch-wide `PathsBatch.ringStarts` array to find the ring breaks inside
+one subpath. A shared `ringCuts` helper binary-searches the window instead, so
+a batch with S filled subpaths and R hole rings drops from O(S x R) to
+O(S log R) per SVG render and per canvas frame. Hit testing got the same search
+inline in #1301; it now shares the helper.
 
 This only bites maps whose parts carry holes: with no holes the batch omits
 `ringStarts` and every call site short-circuits ahead of the helper. Where holes

--- a/.changeset/ring-cuts-window.md
+++ b/.changeset/ring-cuts-window.md
@@ -1,0 +1,17 @@
+---
+"@ggsvelte/core": patch
+---
+
+# Window polygon hole rings instead of rescanning the batch
+
+Migration: none — internal
+
+Every consumer of `PathsBatch.ringStarts` scanned the whole batch-wide array to
+find the ring breaks inside one subpath, so a filled polygon batch with S
+subpaths and R hole rings paid O(S x R) per SVG render, per canvas frame, and
+per pointer probe. A shared `ringCuts` helper binary-searches the window
+instead, giving O(log R + k) per subpath.
+
+The `ringStarts` ascending order is now documented on `PathsBatch` and on the
+exported `pathData` — rings come from consecutive cut pairs, so consumers
+already depended on it.

--- a/.changeset/ring-cuts-window.md
+++ b/.changeset/ring-cuts-window.md
@@ -4,14 +4,21 @@
 
 # Window polygon hole rings instead of rescanning the batch
 
-Migration: none — internal
+Migration: none — internal, except a narrowed input contract on `pathData`
 
 Every consumer of `PathsBatch.ringStarts` scanned the whole batch-wide array to
-find the ring breaks inside one subpath, so a filled polygon batch with S
-subpaths and R hole rings paid O(S x R) per SVG render, per canvas frame, and
-per pointer probe. A shared `ringCuts` helper binary-searches the window
-instead, giving O(log R + k) per subpath.
+find the ring breaks inside one subpath. A shared `ringCuts` helper binary-
+searches the window instead, so a batch with S filled subpaths and R hole rings
+drops from O(S x R) to O(S log R) per SVG render, per canvas frame, and on the
+brush path through hit-testing.
 
-The `ringStarts` ascending order is now documented on `PathsBatch` and on the
-exported `pathData` — rings come from consecutive cut pairs, so consumers
-already depended on it.
+This only bites maps whose parts carry holes: with no holes the batch omits
+`ringStarts` and every call site short-circuits ahead of the helper. Where holes
+are common, R grows with S — 3000 counties with a lake each cost 9 million
+compares per frame before.
+
+`ringStarts` ascending order is now documented on `PathsBatch` and on the
+exported `pathData`. Both producers emit it ascending, so every in-tree caller
+is unaffected. A caller hand-building an unsorted array for `pathData` used to
+get its out-of-order breaks anyway (paired into the wrong rings); those breaks
+are now dropped instead.

--- a/packages/core/src/candidate-geometry.ts
+++ b/packages/core/src/candidate-geometry.ts
@@ -2,6 +2,7 @@ import type { ResolvedCandidateInspectMode } from "./candidate-store-types.js";
 import { POINT_SHAPE_NAMES } from "@ggsvelte/spec";
 
 import type { GeometryBatch, PointsBatch } from "./scene.js";
+import { ringCuts } from "./ring-cuts.js";
 
 /**
  * Geometry-array topology for candidate indexes / hit refine:
@@ -235,24 +236,7 @@ function pathRingRanges(
   if (end <= start) return [];
   const breaks = batch.ringStarts;
   if (breaks === undefined || breaks.length === 0) return [[start, end]];
-  // breaks is non-decreasing (writers append at a monotone vertex cursor), so
-  // the entries inside (start, end) form one contiguous run: binary-search the
-  // first entry > start, then walk while < end — O(log R + local) instead of
-  // scanning all R batch-wide breaks per point-in-path test.
-  let lo = 0;
-  let hi = breaks.length;
-  while (lo < hi) {
-    const mid = (lo + hi) >> 1;
-    if (breaks[mid]! > start) hi = mid;
-    else lo = mid + 1;
-  }
-  const cuts: number[] = [start];
-  for (let i = lo; i < breaks.length; i++) {
-    const b = breaks[i]!;
-    if (b >= end) break;
-    cuts.push(b);
-  }
-  cuts.push(end);
+  const cuts = ringCuts(breaks, start, end);
   const ranges: (readonly [number, number])[] = [];
   for (let i = 0; i + 1 < cuts.length; i++) {
     const a = cuts[i]!;

--- a/packages/core/src/dom/canvas-marks-paths.ts
+++ b/packages/core/src/dom/canvas-marks-paths.ts
@@ -9,6 +9,7 @@ import type { Linetype } from "../scales/style.js";
 import type { ThemeTokens } from "../theme.js";
 import { themeVar } from "../theme.js";
 import { stepCorners } from "../path-step.js";
+import { ringCuts } from "../ring-cuts.js";
 import type { ColorResolver } from "./canvas-dom.js";
 import { maskIncludes, type PrimitiveFocusMask } from "./canvas-marks-mask.js";
 
@@ -80,12 +81,7 @@ function traceSubpath(
     traceRing(ctx, batch, start, end);
     return;
   }
-  const cuts: number[] = [start];
-  for (let i = 0; i < breaks.length; i++) {
-    const b = breaks[i]!;
-    if (b > start && b < end) cuts.push(b);
-  }
-  cuts.push(end);
+  const cuts = ringCuts(breaks, start, end);
   for (let i = 0; i + 1 < cuts.length; i++) {
     traceRing(ctx, batch, cuts[i]!, cuts[i + 1]!);
   }

--- a/packages/core/src/pipeline/coord-path-project.ts
+++ b/packages/core/src/pipeline/coord-path-project.ts
@@ -1,6 +1,7 @@
 import type { PanelCoordProjector } from "../coord-projector.js";
 import type { PathsBatch } from "../scene.js";
 import { isStepCurve, stepCorners, stepCornersPerSegment } from "../path-step.js";
+import { ringCuts } from "../ring-cuts.js";
 
 import type { PipelineWarning } from "./types.js";
 import {
@@ -232,12 +233,7 @@ export function projectPathBatch(
       sourceRingStarts !== undefined &&
       sourceRingStarts.length > 0;
     if (holeCompound) {
-      const cuts: number[] = [start];
-      for (let i = 0; i < sourceRingStarts.length; i++) {
-        const b = sourceRingStarts[i]!;
-        if (b > start && b < end) cuts.push(b);
-      }
-      cuts.push(end);
+      const cuts = ringCuts(sourceRingStarts, start, end);
       // No interior cuts in this subpath → ordinary single-ring project.
       if (cuts.length === 2) {
         if (!projectRun(start, end)) continue;

--- a/packages/core/src/render-svg-marks.ts
+++ b/packages/core/src/render-svg-marks.ts
@@ -25,6 +25,7 @@ import type { PointShape } from "./scales/style.js";
 import type { ThemeTokens } from "./theme.js";
 import { themeVar } from "./theme.js";
 import { stepCorners } from "./path-step.js";
+import { ringCuts } from "./ring-cuts.js";
 import { escapeXML, px } from "./render-svg-format.js";
 
 /** When true, use solid paint fallbacks and skip glow filters. */
@@ -139,6 +140,10 @@ function pathRingData(
 /**
  * Path data for one subpath. When `ringStarts` lists interior ring starts inside
  * [start, end), emits multiple M…Z rings for even-odd polygon holes.
+ *
+ * `ringStarts` must be ascending in vertex order, as {@link PathsBatch} emits
+ * it — the rings come from consecutive cut pairs, so any other order pairs the
+ * wrong vertices.
  */
 export function pathData(
   positions: Float32Array,
@@ -152,12 +157,7 @@ export function pathData(
   if (ringStarts === undefined || ringStarts.length === 0 || !closed) {
     return pathRingData(positions, start, end, curve, closed);
   }
-  const cuts: number[] = [start];
-  for (let i = 0; i < ringStarts.length; i++) {
-    const b = ringStarts[i]!;
-    if (b > start && b < end) cuts.push(b);
-  }
-  cuts.push(end);
+  const cuts = ringCuts(ringStarts, start, end);
   const parts: string[] = [];
   for (let i = 0; i + 1 < cuts.length; i++) {
     const d = pathRingData(positions, cuts[i]!, cuts[i + 1]!, curve, true);

--- a/packages/core/src/ring-cuts.ts
+++ b/packages/core/src/ring-cuts.ts
@@ -4,11 +4,13 @@
  * SVG serialization, canvas tracing, hit-testing, and coord projection each
  * need the ring boundaries inside one subpath window. Every one of them used
  * to scan the whole batch-wide `ringStarts` array per subpath, so a batch with
- * S subpaths and R ring starts paid O(S x R) per render pass or pointer probe.
+ * S subpaths and R hole rings paid O(S x R) per render pass.
+ *
+ * A cursor carried across an ascending subpath loop would reach O(S + R), but
+ * not every caller qualifies: hit-testing windows one subpath at a time in
+ * probe order, and the canvas focus pass traces an arbitrary subset. A search
+ * that stands alone per call serves all of them.
  */
-// Every export needs a lifecycle tag; the header default is read
-// into lifecycle.json by scripts/gen-lifecycle.ts.
-// @lifecycle-default internal
 
 /**
  * Cut points for the subpath `[start, end)`: `start`, then every `ringStarts`

--- a/packages/core/src/ring-cuts.ts
+++ b/packages/core/src/ring-cuts.ts
@@ -1,0 +1,37 @@
+/**
+ * Ring-cut windowing for closed filled subpaths (polygon holes, #809).
+ *
+ * SVG serialization, canvas tracing, hit-testing, and coord projection each
+ * need the ring boundaries inside one subpath window. Every one of them used
+ * to scan the whole batch-wide `ringStarts` array per subpath, so a batch with
+ * S subpaths and R ring starts paid O(S x R) per render pass or pointer probe.
+ */
+// Every export needs a lifecycle tag; the header default is read
+// into lifecycle.json by scripts/gen-lifecycle.ts.
+// @lifecycle-default internal
+
+/**
+ * Cut points for the subpath `[start, end)`: `start`, then every `ringStarts`
+ * value strictly inside `(start, end)` in ascending order, then `end`.
+ *
+ * `ringStarts` must be ascending — both producers append at a monotonically
+ * increasing vertex cursor, and pairing the cuts into rings already depends on
+ * it. Binary lower bound plus a walk over the window: O(log R + k) per call.
+ */
+export function ringCuts(ringStarts: ArrayLike<number>, start: number, end: number): number[] {
+  const cuts: number[] = [start];
+  let lo = 0;
+  let hi = ringStarts.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    if (ringStarts[mid]! > start) hi = mid;
+    else lo = mid + 1;
+  }
+  for (let i = lo; i < ringStarts.length; i++) {
+    const b = ringStarts[i]!;
+    if (b >= end) break;
+    cuts.push(b);
+  }
+  cuts.push(end);
+  return cuts;
+}

--- a/packages/core/src/scene.ts
+++ b/packages/core/src/scene.ts
@@ -84,8 +84,11 @@ export interface PathsBatch {
    * Additional ring-start vertex indices within a closed filled subpath
    * (exterior already starts at pathOffsets[s]). Used for polygon holes:
    * one compound path with multiple M…Z rings (#809 phase 4).
-   * Non-decreasing: writers append at a monotone vertex cursor, and hit
-   * testing binary-searches this array per subpath.
+   *
+   * Non-decreasing in vertex order across the whole batch: writers append at a
+   * monotone vertex cursor. Consumers window it by binary search (`ringCuts`)
+   * and pair consecutive cuts into rings, so any other order both mis-pairs
+   * vertices and hides breaks.
    */
   ringStarts?: Uint32Array;
   /**

--- a/packages/core/tests/dom/canvas-paths-holes.test.ts
+++ b/packages/core/tests/dom/canvas-paths-holes.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "bun:test";
+
+import { drawStratum } from "../../src/dom/canvas.ts";
+import type { PathsBatch } from "../../src/scene.ts";
+import { recordingContext, resolve, scene } from "./canvas-fixtures.ts";
+
+/**
+ * Canvas hole tracing (#809): each subpath must start a fresh ring at its own
+ * `ringStarts` breaks and ignore the breaks belonging to other subpaths.
+ */
+describe("drawStratum polygon hole tracing", () => {
+  // Two square compounds, each an exterior ring plus a hole ring.
+  // Vertices 0-3 exterior A, 4-7 hole A, 8-11 exterior B, 12-15 hole B.
+  const twoHoles: PathsBatch = {
+    kind: "paths",
+    layerIndex: 0,
+    panelIndex: 0,
+    positions: Float32Array.from([
+      0, 0, 10, 0, 10, 10, 0, 10, 3, 3, 7, 3, 7, 7, 3, 7, 20, 0, 30, 0, 30, 10, 20, 10, 23, 3, 27,
+      3, 27, 7, 23, 7,
+    ]),
+    rowIndex: Uint32Array.from([0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1]),
+    pathOffsets: Uint32Array.from([0, 8, 16]),
+    ringStarts: Uint32Array.from([4, 12]),
+    fillRule: "evenodd",
+    strokes: ["green", "green"],
+    fills: ["red", "red"],
+    closed: true,
+    linewidth: 1,
+    alpha: 1,
+    curve: "linear",
+  };
+
+  it("opens one ring per exterior and hole, at that ring's own start vertex", () => {
+    const { ctx, calls } = recordingContext();
+    drawStratum(ctx, scene([twoHoles]), [twoHoles], resolve);
+    // Panel clipping also begins a path but never moves to a vertex.
+    const moveTos = calls.filter((call) => call.name === "moveTo").map((call) => call.args);
+    expect(moveTos).toEqual([
+      [0, 0], // exterior A
+      [3, 3], // hole A — break 4, inside subpath 0
+      [20, 0], // exterior B
+      [23, 3], // hole B — break 12, inside subpath 1
+    ]);
+    expect(calls.filter((call) => call.name === "closePath")).toHaveLength(4);
+  });
+
+  it("ignores a break that belongs to another subpath", () => {
+    // Same geometry, but only the second compound has a hole. Subpath 0 must
+    // stay a single ring even though the batch-wide break list is non-empty.
+    const holeInSecondOnly: PathsBatch = { ...twoHoles, ringStarts: Uint32Array.from([12]) };
+    const { ctx, calls } = recordingContext();
+    drawStratum(ctx, scene([holeInSecondOnly]), [holeInSecondOnly], resolve);
+    expect(calls.filter((call) => call.name === "moveTo").map((call) => call.args)).toEqual([
+      [0, 0], // exterior A, traced whole — no ring break inside it
+      [20, 0], // exterior B
+      [23, 3], // hole B
+    ]);
+  });
+
+  it("reads the ring-start list per subpath window, not once per subpath in full", () => {
+    // 64 compounds, one hole each: S = R = 64. The old full scan read every
+    // entry for every subpath (S x R = 4096 reads); windowing reads about
+    // log2(R) per subpath.
+    const S = 64;
+    const positions = new Float32Array(S * 8 * 2);
+    const pathOffsets = new Uint32Array(S + 1);
+    const ringStarts = new Uint32Array(S);
+    for (let s = 0; s < S; s++) {
+      const base = s * 8;
+      pathOffsets[s] = base;
+      ringStarts[s] = base + 4;
+      const x = s * 40;
+      // Exterior square then hole square, both in the compound's own column.
+      const ring = [x, 0, x + 10, 0, x + 10, 10, x, 10, x + 3, 3, x + 7, 3, x + 7, 7, x + 3, 7];
+      for (let i = 0; i < ring.length; i++) positions[base * 2 + i] = ring[i]!;
+    }
+    pathOffsets[S] = S * 8;
+
+    let reads = 0;
+    const counted = new Proxy(ringStarts, {
+      get(target, prop) {
+        if (typeof prop === "string" && /^\d+$/.test(prop)) reads += 1;
+        return Reflect.get(target, prop) as unknown;
+      },
+    });
+    const wide: PathsBatch = {
+      ...twoHoles,
+      positions,
+      rowIndex: Uint32Array.from({ length: S * 8 }, () => 0),
+      pathOffsets,
+      ringStarts: counted,
+      strokes: Array.from({ length: S }, () => "green"),
+      fills: Array.from({ length: S }, () => "red"),
+    };
+    const { ctx, calls } = recordingContext();
+    drawStratum(ctx, scene([wide]), [wide], resolve);
+    // Every compound still traced both of its rings.
+    expect(calls.filter((call) => call.name === "moveTo")).toHaveLength(S * 2);
+    expect(reads).toBeGreaterThan(0);
+    // Fails at 4096 if a full scan comes back; holds at the ~8 per subpath a
+    // binary-searched window costs.
+    expect(reads).toBeLessThan(15 * S);
+  });
+
+  it("traces a single ring when the batch carries no ring starts", () => {
+    const solid: PathsBatch = { ...twoHoles };
+    delete solid.ringStarts;
+    delete solid.fillRule;
+    const { ctx, calls } = recordingContext();
+    drawStratum(ctx, scene([solid]), [solid], resolve);
+    expect(calls.filter((call) => call.name === "moveTo").map((call) => call.args)).toEqual([
+      [0, 0],
+      [20, 0],
+    ]);
+  });
+});

--- a/packages/core/tests/pipeline-m2/geom-sf.test.ts
+++ b/packages/core/tests/pipeline-m2/geom-sf.test.ts
@@ -727,6 +727,169 @@ describe("geom_sf", () => {
     expect((d.match(/M/g) ?? []).length).toBe(2);
   });
 
+  it("pathData cuts each subpath only on its own ring starts", () => {
+    // Two compounds, each with a hole: subpath 0 must not cut on subpath 1's
+    // break, and subpath 1 must not cut on subpath 0's.
+    const twoHoles = geo({
+      type: "MultiPolygon",
+      coordinates: [
+        [
+          [
+            [0, 0],
+            [10, 0],
+            [10, 10],
+            [0, 10],
+            [0, 0],
+          ],
+          [
+            [3, 3],
+            [7, 3],
+            [7, 7],
+            [3, 7],
+            [3, 3],
+          ],
+        ],
+        [
+          [
+            [20, 0],
+            [30, 0],
+            [30, 10],
+            [20, 10],
+            [20, 0],
+          ],
+          [
+            [23, 3],
+            [27, 3],
+            [27, 7],
+            [23, 7],
+            [23, 3],
+          ],
+        ],
+      ],
+    });
+    const model = runPipeline(
+      gg({ geometry: [twoHoles] }, aes({}))
+        .geomSf()
+        .spec(),
+      size,
+    );
+    const batch = model.scene.batches[0] as PathsBatch;
+    expect(batch.pathOffsets.length - 1).toBe(2);
+    const breaks = [...batch.ringStarts!];
+    expect(breaks.length).toBe(2);
+    // ringStarts is ascending, and one break lands in each subpath window.
+    expect(breaks[0]!).toBeLessThan(breaks[1]!);
+    expect(breaks[0]!).toBeGreaterThan(batch.pathOffsets[0]!);
+    expect(breaks[0]!).toBeLessThan(batch.pathOffsets[1]!);
+    expect(breaks[1]!).toBeGreaterThan(batch.pathOffsets[1]!);
+    expect(breaks[1]!).toBeLessThan(batch.pathOffsets[2]!);
+
+    for (let s = 0; s < 2; s++) {
+      const d = pathData(
+        batch.positions,
+        batch.pathOffsets[s]!,
+        batch.pathOffsets[s + 1]!,
+        batch.curve,
+        true,
+        batch.ringStarts,
+      );
+      // Exactly two rings — the out-of-window break must not add a third.
+      expect((d.match(/M/g) ?? []).length).toBe(2);
+      expect((d.match(/Z/g) ?? []).length).toBe(2);
+      // Same d the whole-batch break list and a window-local one produce.
+      const own = batch.ringStarts!.filter(
+        (b) => b > batch.pathOffsets[s]! && b < batch.pathOffsets[s + 1]!,
+      );
+      expect(d).toBe(
+        pathData(
+          batch.positions,
+          batch.pathOffsets[s]!,
+          batch.pathOffsets[s + 1]!,
+          batch.curve,
+          true,
+          own,
+        ),
+      );
+    }
+  });
+
+  it("emits ringStarts in ascending vertex order", () => {
+    // Consumers window ringStarts by binary search and pair the cuts into
+    // rings, so both producers must keep it ascending.
+    const nested = geo({
+      type: "MultiPolygon",
+      coordinates: [
+        [
+          [
+            [0, 0],
+            [10, 0],
+            [10, 10],
+            [0, 10],
+            [0, 0],
+          ],
+          [
+            [1, 1],
+            [4, 1],
+            [4, 4],
+            [1, 4],
+            [1, 1],
+          ],
+          [
+            [6, 6],
+            [9, 6],
+            [9, 9],
+            [6, 9],
+            [6, 6],
+          ],
+        ],
+        [
+          [
+            [20, 0],
+            [30, 0],
+            [30, 10],
+            [20, 10],
+            [20, 0],
+          ],
+          [
+            [23, 3],
+            [27, 3],
+            [27, 7],
+            [23, 7],
+            [23, 3],
+          ],
+        ],
+      ],
+    });
+    const spec = gg({ geometry: [nested] }, aes({})).geomSf();
+    const plain = runPipeline(spec.spec(), size);
+    const plainBatch = plain.scene.batches[0] as PathsBatch;
+    const plainBreaks = [...plainBatch.ringStarts!];
+    expect(plainBreaks.length).toBe(3);
+    for (let i = 1; i < plainBreaks.length; i++) {
+      expect(plainBreaks[i]!).toBeGreaterThan(plainBreaks[i - 1]!);
+    }
+
+    // The coord path rewrites ringStarts to post-projection indices; that
+    // remap must stay ascending too.
+    const projected = runPipeline(
+      gg({ geometry: [nested] }, aes({}))
+        .geomSf()
+        .scales({
+          x: { type: "linear", domain: [1, 100], expand: { mult: 0, add: 0 } },
+          y: { type: "linear", domain: [1, 100], expand: { mult: 0, add: 0 } },
+        })
+        .coordTransform({ x: { transform: "log10", expand: false } })
+        .spec(),
+      size,
+    );
+    const projectedBatch = projected.scene.batches[0] as PathsBatch;
+    const projectedBreaks = [...projectedBatch.ringStarts!];
+    expect(projectedBreaks.length).toBeGreaterThan(0);
+    for (let i = 1; i < projectedBreaks.length; i++) {
+      expect(projectedBreaks[i]!).toBeGreaterThan(projectedBreaks[i - 1]!);
+    }
+  });
+
   it("keeps the closing vertex on a closed LineString (open path draw)", () => {
     const closedLine = geo({
       type: "LineString",

--- a/packages/core/tests/ring-cuts.test.ts
+++ b/packages/core/tests/ring-cuts.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Ring-cut windowing — shared by SVG pathData, canvas tracing, hit-testing,
+ * and coord projection. Every caller used to rescan the whole batch-wide
+ * ringStarts array per subpath; these tests pin the window semantics so the
+ * binary-search version stays identical to the linear filter it replaced.
+ */
+import { describe, expect, it } from "bun:test";
+
+import { ringCuts } from "../src/ring-cuts.ts";
+
+/** The linear filter every call site carried before ringCuts existed. */
+function linearCuts(ringStarts: ArrayLike<number>, start: number, end: number): number[] {
+  const cuts: number[] = [start];
+  for (let i = 0; i < ringStarts.length; i++) {
+    const b = ringStarts[i]!;
+    if (b > start && b < end) cuts.push(b);
+  }
+  cuts.push(end);
+  return cuts;
+}
+
+describe("ringCuts", () => {
+  it("returns just the window when no break falls inside it", () => {
+    expect(ringCuts([], 0, 10)).toEqual([0, 10]);
+    expect(ringCuts([20, 30], 0, 10)).toEqual([0, 10]);
+  });
+
+  it("keeps breaks strictly inside the window, in ascending order", () => {
+    expect(ringCuts([3, 6], 0, 10)).toEqual([0, 3, 6, 10]);
+  });
+
+  it("excludes breaks equal to either boundary", () => {
+    expect(ringCuts([0, 5, 10], 0, 10)).toEqual([0, 5, 10]);
+  });
+
+  it("ignores breaks belonging to earlier and later subpaths", () => {
+    const ringStarts = [2, 7, 14, 19, 26];
+    expect(ringCuts(ringStarts, 10, 20)).toEqual([10, 14, 19, 20]);
+  });
+
+  it("handles the first and last subpath windows", () => {
+    const ringStarts = [3, 12, 21];
+    expect(ringCuts(ringStarts, 0, 10)).toEqual([0, 3, 10]);
+    expect(ringCuts(ringStarts, 20, 30)).toEqual([20, 21, 30]);
+  });
+
+  it("accepts a typed array, matching what PathsBatch carries", () => {
+    expect(ringCuts(Uint32Array.from([4, 9]), 0, 12)).toEqual([0, 4, 9, 12]);
+  });
+
+  it("degenerate windows still return a well-formed pair", () => {
+    expect(ringCuts([5], 7, 7)).toEqual([7, 7]);
+  });
+
+  it("matches the linear filter on every window of an ascending array", () => {
+    const ringStarts = [2, 5, 9, 9, 13, 21, 34, 55];
+    for (let start = 0; start <= 60; start++) {
+      for (let end = start; end <= 60; end += 7) {
+        expect(ringCuts(ringStarts, start, end)).toEqual(linearCuts(ringStarts, start, end));
+      }
+    }
+  });
+});

--- a/packages/core/tests/ring-cuts.test.ts
+++ b/packages/core/tests/ring-cuts.test.ts
@@ -50,12 +50,14 @@ describe("ringCuts", () => {
 
   it("degenerate windows still return a well-formed pair", () => {
     expect(ringCuts([5], 7, 7)).toEqual([7, 7]);
+    expect(ringCuts([5], 9, 3)).toEqual([9, 3]);
   });
 
   it("matches the linear filter on every window of an ascending array", () => {
+    // Includes inverted windows (end < start) and bounds outside the array.
     const ringStarts = [2, 5, 9, 9, 13, 21, 34, 55];
-    for (let start = 0; start <= 60; start++) {
-      for (let end = start; end <= 60; end += 7) {
+    for (let start = -3; start <= 60; start++) {
+      for (let end = -3; end <= 60; end += 7) {
         expect(ringCuts(ringStarts, start, end)).toEqual(linearCuts(ringStarts, start, end));
       }
     }


### PR DESCRIPTION
## What

SVG serialization, canvas tracing, and the coord hole remap each scanned the whole batch-wide `PathsBatch.ringStarts` array to find the ring breaks inside one subpath:

| Site | Called from |
|---|---|
| `pathData` (`render-svg-marks.ts`) | SVG serialization, once per subpath per render |
| `traceSubpath` (`dom/canvas-marks-paths.ts`) | canvas redraw, and twice per focus repaint |
| hole remap (`pipeline/coord-path-project.ts`) | once per pipeline run |

A batch with S filled subpaths and R hole rings paid **O(S x R)** per pass. Extracting the window into a shared `ringCuts` helper that binary-searches the lower bound and walks only the breaks in range makes it **O(S log R)**.

#1301 landed the same search inline in the fourth consumer, `pathRingRanges` in hit testing, while this branch was in review. That copy now calls the shared helper.

## What n is, and when it matters

R counts interior hole rings, not rings in general — MultiPolygon islands become their own subpaths. So this is a no-op for hole-free maps: with no holes the batch omits `ringStarts` entirely and every call site short-circuits before the helper. Where holes are common, R grows with S. 3000 counties with a lake each cost 9 million integer compares per frame before this change.

## Behavior

Identical for ascending `ringStarts`, which is what both producers emit and what pairing consecutive cuts into rings already required.

The one narrowing: a caller hand-building an unsorted array for the exported `pathData` used to get its out-of-order breaks (paired into the wrong rings anyway); those are now dropped. No in-tree caller can reach that — both producers append at a monotonically increasing vertex cursor, and the new tests pin it.

A cursor carried across an ascending subpath loop would reach O(S + R), but hit testing windows one subpath at a time in probe order and the canvas focus pass traces an arbitrary subset, so a search that stands alone per call is what serves every caller.

## Verification

- `bun test packages/core` — 2012 pass, 0 fail
- `bun run check`, `bun run lint`, `bun run fmt:check` — clean

New tests, each checked against a deliberately broken implementation:

- `tests/ring-cuts.test.ts` reimplements the linear filter it replaced and sweeps every window of a non-decreasing array against it, including inverted windows and bounds outside the array.
- `tests/pipeline-m2/geom-sf.test.ts` adds two-compound cut isolation through the public `pathData`, and pins that both producers (raw emit and the coord remap) keep `ringStarts` ascending.
- `tests/dom/canvas-paths-holes.test.ts` covers the canvas site, which had none — swapping the window arguments there previously left the whole suite green. It also carries a counting-proxy cost guard: 64 compounds read 4096 entries under the old scan, now bounded under 960.