### PR TITLE
perf(core): derive tile resolution once per axis, not once per row

### DIFF
--- a/.changeset/tile-resolution-hoist.md
+++ b/.changeset/tile-resolution-hoist.md
@@ -1,0 +1,19 @@
+---
+"@ggsvelte/core": patch
+---
+
+# Derive tile resolution once per axis instead of once per row
+
+Migration: none — internal
+
+`emitBandTiles` passed `defaultResolution(frame.xNumeric)` straight into a call
+inside its per-row loop. JavaScript evaluates arguments eagerly, so a continuous
+axis re-derived that value on every row even when a mapped or param width made
+the callee ignore it. `resolution()` scans the whole column into a Set and sorts
+the distinct values, so a `geom_tile` heatmap on continuous axes was O(n²) in
+its cell count: a 200x200 grid scanned 40,000 values 40,000 times, per axis.
+
+Derive it once per axis before the loop. Band axes are unchanged — they pass a
+literal `1` and never reach `resolution()`.
+
+Output is identical for every input; only how often the value is derived changes.

--- a/packages/core/src/pipeline/geometry-edge-rects.ts
+++ b/packages/core/src/pipeline/geometry-edge-rects.ts
@@ -132,10 +132,9 @@ function emitBandTiles(input: {
   const keptRows = new Uint32Array(n);
   let kept = 0;
   let removed = 0;
-  // resolution() scans the whole column into a Set and sorts the distinct
-  // values, and the loop never writes xNumeric/yNumeric, so derive each axis
-  // default once. Band axes keep paying nothing: 1 is the same literal they
-  // pass today, so they never reach resolution().
+  // Safe to hoist because the loop never writes xNumeric/yNumeric. Only the
+  // continuous branches read these; the band arms size from scale.step, so the
+  // guard exists to keep them from paying for a scan they never consult.
   const defaultW = fx.xScale.type === "band" ? 1 : defaultResolution(frame.xNumeric);
   const defaultH = fx.yScale.type === "band" ? 1 : defaultResolution(frame.yNumeric);
   for (let row = 0; row < n; row++) {

--- a/packages/core/src/pipeline/geometry-edge-rects.ts
+++ b/packages/core/src/pipeline/geometry-edge-rects.ts
@@ -132,6 +132,12 @@ function emitBandTiles(input: {
   const keptRows = new Uint32Array(n);
   let kept = 0;
   let removed = 0;
+  // resolution() scans the whole column into a Set and sorts the distinct
+  // values, and the loop never writes xNumeric/yNumeric, so derive each axis
+  // default once. Band axes keep paying nothing: 1 is the same literal they
+  // pass today, so they never reach resolution().
+  const defaultW = fx.xScale.type === "band" ? 1 : defaultResolution(frame.xNumeric);
+  const defaultH = fx.yScale.type === "band" ? 1 : defaultResolution(frame.yNumeric);
   for (let row = 0; row < n; row++) {
     let centerX: number | undefined;
     let centerY: number | undefined;
@@ -152,13 +158,7 @@ function emitBandTiles(input: {
         removed++;
         continue;
       }
-      const w = sizeAt(
-        frame,
-        frame.binding.widthField,
-        widthParam,
-        defaultResolution(frame.xNumeric),
-        row,
-      );
+      const w = sizeAt(frame, frame.binding.widthField, widthParam, defaultW, row);
       if (!(w > 0) || !Number.isFinite(w)) {
         removed++;
         continue;
@@ -188,13 +188,7 @@ function emitBandTiles(input: {
         removed++;
         continue;
       }
-      const h = sizeAt(
-        frame,
-        frame.binding.heightField,
-        heightParam,
-        defaultResolution(frame.yNumeric),
-        row,
-      );
+      const h = sizeAt(frame, frame.binding.heightField, heightParam, defaultH, row);
       if (!(h > 0) || !Number.isFinite(h)) {
         removed++;
         continue;

--- a/packages/core/tests/geometry-tile-resolution.test.ts
+++ b/packages/core/tests/geometry-tile-resolution.test.ts
@@ -1,0 +1,156 @@
+/**
+ * geom_tile default sizing derives resolution() once per continuous axis.
+ * resolution() scans the whole column, so deriving it inside the row loop
+ * made a continuous-axis heatmap quadratic in its cell count.
+ */
+import { fromAny, fromPartial } from "@total-typescript/shoehorn";
+import { describe, expect, it } from "bun:test";
+
+import { tileRectsBatch } from "../src/pipeline/geometry-edge-rects.ts";
+import type { Frame } from "../src/pipeline/geometry-shared.ts";
+import type { LayerFrame } from "../src/pipeline/types.ts";
+
+type ScaleKind = "linear" | "band";
+
+function scaleOf(kind: ScaleKind): unknown {
+  if (kind === "band") {
+    return {
+      type: "band",
+      step: 0.1,
+      normalize: (v: unknown) => (v === null ? undefined : Number(v) / 100),
+      normalizeTransformed: (v: number) => v,
+    };
+  }
+  return {
+    type: "linear",
+    normalize: (v: number) => v,
+    normalizeTransformed: (v: number) => v / 100,
+  };
+}
+
+function fx(x: ScaleKind, y: ScaleKind): Frame {
+  return fromPartial<Frame>({
+    innerWidth: 100,
+    innerHeight: 100,
+    xScale: scaleOf(x),
+    yScale: scaleOf(y),
+  });
+}
+
+/** Counts element reads so a per-row rescan is distinguishable from one pass. */
+function counting(values: Float64Array): { array: Float64Array; reads: () => number } {
+  let reads = 0;
+  const array = new Proxy(values, {
+    get(target, prop) {
+      if (typeof prop === "string" && /^\d+$/.test(prop)) reads += 1;
+      return Reflect.get(target, prop) as unknown;
+    },
+  }) as Float64Array;
+  return { array, reads: () => reads };
+}
+
+function tileFrame(input: {
+  n: number;
+  xNumeric: Float64Array | null;
+  yNumeric: Float64Array | null;
+  xValues?: unknown[] | null;
+  yValues?: unknown[] | null;
+  widthField?: string | null;
+  heightField?: string | null;
+  column?: Record<string, number[]>;
+}): LayerFrame {
+  return fromAny<LayerFrame>({
+    n: input.n,
+    xNumeric: input.xNumeric,
+    yNumeric: input.yNumeric,
+    xValues: input.xValues ?? null,
+    yValues: input.yValues ?? null,
+    fillValues: null,
+    colorValues: null,
+    rowIndex: Uint32Array.from({ length: input.n }, (_, i) => i),
+    table: { column: (name: string) => input.column?.[name] ?? [] },
+    binding: {
+      index: 0,
+      widthField: input.widthField ?? null,
+      heightField: input.heightField ?? null,
+      fill: { constant: "#000", scaledConstant: null },
+      color: { constant: "#000", scaledConstant: null },
+      layer: { params: {} },
+    },
+  });
+}
+
+/** Evenly spaced grid: N cells, gap 1, so resolution() is well defined. */
+function grid(n: number): Float64Array {
+  return Float64Array.from({ length: n }, (_, i) => i + 1);
+}
+
+describe("geom_tile continuous default size", () => {
+  const N = 64;
+
+  it("reads each continuous axis column a bounded number of times", () => {
+    const x = counting(grid(N));
+    const y = counting(grid(N));
+    const frame = tileFrame({ n: N, xNumeric: x.array, yNumeric: y.array });
+    const batch = tileRectsBatch(frame, fx("linear", "linear"), null, null, fromPartial({}), []);
+    expect(batch?.rects.length).toBe(N * 4);
+    // One resolution() scan (N) plus one center read per row (N) is ~2N per
+    // axis. Deriving resolution() per row costs N*N = 4096 instead.
+    expect(x.reads()).toBeGreaterThan(0);
+    expect(x.reads()).toBeLessThan(6 * N);
+    expect(y.reads()).toBeLessThan(6 * N);
+  });
+
+  it("still bounds the reads when width and height are mapped columns", () => {
+    // sizeAt ignores the default here, but the argument was still evaluated
+    // once per row before the hoist.
+    const x = counting(grid(N));
+    const y = counting(grid(N));
+    const frame = tileFrame({
+      n: N,
+      xNumeric: x.array,
+      yNumeric: y.array,
+      widthField: "w",
+      heightField: "h",
+      column: {
+        w: Array.from({ length: N }, () => 1),
+        h: Array.from({ length: N }, () => 1),
+      },
+    });
+    tileRectsBatch(frame, fx("linear", "linear"), null, null, fromPartial({}), []);
+    expect(x.reads()).toBeLessThan(6 * N);
+    expect(y.reads()).toBeLessThan(6 * N);
+  });
+
+  it("never touches the numeric column on a band axis", () => {
+    // Band axes size from scale.step and read xValues, so they must not gain a
+    // resolution() scan they never paid for.
+    const x = counting(grid(N));
+    const frame = tileFrame({
+      n: N,
+      xNumeric: x.array,
+      yNumeric: grid(N),
+      xValues: Array.from({ length: N }, (_, i) => i + 1),
+    });
+    tileRectsBatch(frame, fx("band", "linear"), null, null, fromPartial({}), []);
+    expect(x.reads()).toBe(0);
+  });
+
+  it("sizes continuous tiles from the minimum positive gap", () => {
+    // Gap 2 between distinct x values → each tile spans 2 user units, which is
+    // 2/100 of the axis, so 2px of the 100px panel.
+    const spaced = Float64Array.from([10, 12, 14, 16]);
+    const frame = tileFrame({ n: 4, xNumeric: spaced, yNumeric: Float64Array.from([1, 1, 1, 1]) });
+    const batch = tileRectsBatch(frame, fx("linear", "linear"), null, null, fromPartial({}), []);
+    const widths: number[] = [];
+    for (let i = 0; i < batch!.rects.length; i += 4) widths.push(batch!.rects[i + 2]!);
+    expect(widths.every((w) => Math.abs(w - 2) < 1e-6)).toBe(true);
+  });
+
+  it("falls back to a unit gap when every x is identical", () => {
+    const flat = Float64Array.from([5, 5, 5, 5]);
+    const frame = tileFrame({ n: 4, xNumeric: flat, yNumeric: Float64Array.from([1, 2, 3, 4]) });
+    const batch = tileRectsBatch(frame, fx("linear", "linear"), null, null, fromPartial({}), []);
+    expect(batch!.rects[2]).toBeCloseTo(1, 6);
+  });
+});

--- a/packages/core/tests/geometry-tile-resolution.test.ts
+++ b/packages/core/tests/geometry-tile-resolution.test.ts
@@ -12,7 +12,7 @@ import type { LayerFrame } from "../src/pipeline/types.ts";
 
 type ScaleKind = "linear" | "band";
 
-function scaleOf(kind: ScaleKind): unknown {
+function scaleOf(kind: ScaleKind): Frame["xScale"] {
   if (kind === "band") {
     return {
       type: "band",
@@ -117,14 +117,17 @@ describe("geom_tile continuous default size", () => {
         h: Array.from({ length: N }, () => 1),
       },
     });
-    tileRectsBatch(frame, fx("linear", "linear"), null, null, fromPartial({}), []);
+    const batch = tileRectsBatch(frame, fx("linear", "linear"), null, null, fromPartial({}), []);
+    // Assert the rows survived, so the bounds cannot be met by emitting nothing.
+    expect(batch?.rects.length).toBe(N * 4);
     expect(x.reads()).toBeLessThan(6 * N);
     expect(y.reads()).toBeLessThan(6 * N);
   });
 
   it("never touches the numeric column on a band axis", () => {
     // Band axes size from scale.step and read xValues, so they must not gain a
-    // resolution() scan they never paid for.
+    // resolution() scan they never paid for. This is the only test holding the
+    // band guard, so it also pins that the mixed-axis geometry is still emitted.
     const x = counting(grid(N));
     const frame = tileFrame({
       n: N,
@@ -132,7 +135,12 @@ describe("geom_tile continuous default size", () => {
       yNumeric: grid(N),
       xValues: Array.from({ length: N }, (_, i) => i + 1),
     });
-    tileRectsBatch(frame, fx("band", "linear"), null, null, fromPartial({}), []);
+    const batch = tileRectsBatch(frame, fx("band", "linear"), null, null, fromPartial({}), []);
+    expect(batch?.rects.length).toBe(N * 4);
+    // Band x: one step (0.1) of the 100px panel. Continuous y: gap 1 of the
+    // /100 normalize, so 1px. Mixed axes size from their own rule.
+    expect(batch!.rects[2]!).toBeCloseTo(10, 6);
+    expect(batch!.rects[3]!).toBeCloseTo(1, 6);
     expect(x.reads()).toBe(0);
   });
 

--- a/packages/core/tests/geometry-tile-resolution.test.ts
+++ b/packages/core/tests/geometry-tile-resolution.test.ts
@@ -45,7 +45,7 @@ function counting(values: Float64Array): { array: Float64Array; reads: () => num
       if (typeof prop === "string" && /^\d+$/.test(prop)) reads += 1;
       return Reflect.get(target, prop) as unknown;
     },
-  }) as Float64Array;
+  });
   return { array, reads: () => reads };
 }
 

--- a/packages/core/tests/pipeline-m2/rect-tile-raster.test.ts
+++ b/packages/core/tests/pipeline-m2/rect-tile-raster.test.ts
@@ -121,6 +121,39 @@ describe("geom tile", () => {
     expect(batch.rects.length / 4).toBe(4);
   });
 
+  it("sizes continuous tiles from the minimum positive gap on both axes", () => {
+    // Heatmap shape: continuous x and y, no width/height given, so each axis
+    // falls back to resolution(). Duplicated values must not shrink the gap.
+    const model = runPipeline(
+      gg(
+        { x: [0, 2, 4, 0, 2, 4], y: [0, 0, 0, 5, 5, 5], z: [1, 2, 3, 4, 5, 6] },
+        aes({ x: "x", y: "y", fill: "z" }),
+      )
+        .geomTile()
+        .scales({
+          x: { type: "linear", domain: [-2, 6], expand: { mult: 0, add: 0 }, nice: false },
+          y: { type: "linear", domain: [-5, 10], expand: { mult: 0, add: 0 }, nice: false },
+        })
+        .spec(),
+      size,
+    );
+    const batch = model.scene.batches[0] as RectsBatch;
+    expect(batch.rects.length / 4).toBe(6);
+    // x gap 2 over an 8-unit domain, y gap 5 over a 15-unit domain.
+    const widths: number[] = [];
+    const heights: number[] = [];
+    for (let i = 0; i < batch.rects.length; i += 4) {
+      widths.push(batch.rects[i + 2]!);
+      heights.push(batch.rects[i + 3]!);
+    }
+    expect(widths.every((w) => Math.abs(w - widths[0]!) < 1e-6)).toBe(true);
+    expect(heights.every((h) => Math.abs(h - heights[0]!) < 1e-6)).toBe(true);
+    expect(widths[0]! / heights[0]!).toBeCloseTo(
+      (2 / 8 / (5 / 15)) * (size.width / size.height),
+      1,
+    );
+  });
+
   it("applies width after log transform (params.width is transformed-space span)", () => {
     const model = runPipeline(
       gg({ x: [1, 10, 100], y: [1, 1, 1] }, aes({ x: "x", y: "y" }))

--- a/packages/core/tests/pipeline-m2/rect-tile-raster.test.ts
+++ b/packages/core/tests/pipeline-m2/rect-tile-raster.test.ts
@@ -139,7 +139,6 @@ describe("geom tile", () => {
     );
     const batch = model.scene.batches[0] as RectsBatch;
     expect(batch.rects.length / 4).toBe(6);
-    // x gap 2 over an 8-unit domain, y gap 5 over a 15-unit domain.
     const widths: number[] = [];
     const heights: number[] = [];
     for (let i = 0; i < batch.rects.length; i += 4) {
@@ -148,10 +147,11 @@ describe("geom tile", () => {
     }
     expect(widths.every((w) => Math.abs(w - widths[0]!) < 1e-6)).toBe(true);
     expect(heights.every((h) => Math.abs(h - heights[0]!) < 1e-6)).toBe(true);
-    expect(widths[0]! / heights[0]!).toBeCloseTo(
-      (2 / 8 / (5 / 15)) * (size.width / size.height),
-      1,
-    );
+    // Measure against the panel, not the plot: axis and legend margins are not
+    // ours to predict. x gap 2 of an 8-unit domain, y gap 5 of a 15-unit one.
+    const panel = model.scene.panels[0]!;
+    expect(widths[0]! / panel.width).toBeCloseTo(2 / 8, 6);
+    expect(heights[0]! / panel.height).toBeCloseTo(5 / 15, 6);
   });
 
   it("applies width after log transform (params.width is transformed-space span)", () => {


### PR DESCRIPTION
## What

`emitBandTiles` passed `defaultResolution(frame.xNumeric)` straight into a `sizeAt` call **inside** its per-row loop:

```ts
const w = sizeAt(frame, frame.binding.widthField, widthParam, defaultResolution(frame.xNumeric), row);
```

JavaScript evaluates arguments eagerly, so a continuous axis re-derived that value on every row. `resolution()` scans the whole column into a `Set` and sorts the distinct values, so a `geom_tile` heatmap on continuous axes was **O(n²)** in its cell count — a 200×200 grid scanned 40,000 values 40,000 times, per axis.

Deriving it once per axis above the loop makes it O(n).

## What n is

Frame rows = tile cells in a `geom_tile` layer. The quadratic term is the **scans**, not the sorts: on a regular grid the distinct count per axis is small (~200 for a 200×200 heatmap) while every call still walks all 40,000 values.

Two things worth being precise about:

- It also bit the case where width or height is a **mapped column or a param**. `sizeAt` discards the default there, but the argument was still evaluated per row. One of the tests covers exactly that path.
- Rows with a non-finite center `continue` before the call, so an all-NaN column was already O(n) and now pays one scan it did not before. Output is unchanged; the worst case is still what it was.

## Behavior

Output-identical for every input — only how often the value is derived changes. Band axes are untouched: they size from `scale.step`, pass their own literal `1`, and never reach `resolution()`. The guard exists to keep them from paying for a scan they never consult.

An independent reviewer ran a differential fuzz of the old and new implementations over 4000 randomized frames — all 9 band/linear/log axis combinations, `n` in 0..11, columns including `null`, length-0, NaN, ±Infinity, `-0`, `1e308` and heavy duplicates, with mapped and param sizes in all four combinations — comparing rects, row indices, warnings and thrown errors. Zero mismatches.

## Verification

- `bun test packages/core` — 2018 pass, 0 fail
- `bun run check`, `bun run lint`, `bun run fmt:check` — clean

Tests, each checked against a deliberately broken implementation:

- `tests/geometry-tile-resolution.test.ts` builds the frame directly and counts column reads. 64 cells read **4160** entries per axis before the change and **128** after, bounded at 384. Removing the band guard or swapping the two axes each fail it.
- `tests/pipeline-m2/rect-tile-raster.test.ts` gains a continuous-both-axes heatmap assert, measured against the panel rather than the plot so axis margins can move without breaking it.

## Follow-ups

The audit that found this turned up more than one PR should carry. Each is filed with evidence and the constraints a fix must respect:

- #1306 — every facet panel rescans the whole layer table, O(P×N)
- #1307 — candidate identity index recomputes a whole column per row
- #1308 — candidate datum resolver locates the same source row up to ten times per mark
- #1309 — six geometry emitters call the batch paint vector once per item
- #1310 — guide plans rescanned in full for every scale decision
- #1311 — binned colour and numeric style scales re-derive what the batch parse already computed
- #1312 — hoistable per-iteration recomputation in stats and frame helpers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1313" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->