### PR TITLE
fix(svelte): warn when an <Inspect> child drops the inspect prop's identity

### DIFF
--- a/.changeset/inspect-identity-drop-advisory.md
+++ b/.changeset/inspect-identity-drop-advisory.md
@@ -1,0 +1,18 @@
+---
+"@ggsvelte/svelte": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+fix: warn when an `<Inspect>` child drops the inspect prop's `identity`
+
+`<GGPlot inspect={{ identity: "year" }}><Inspect /></GGPlot>` used to lose the
+`identity` without a word. The child replaces the prop whole (REPLACE, as
+documented), an empty child bag means `inspect={true}`, and row identity then
+fell back to an `id` column or the row index — so pins and selection keys
+silently rebound to the wrong rows.
+
+The capability seam now resolves row identity itself and reports the loss as
+`INTERACTION_INSPECT_IDENTITY_DROPPED`. A child that names its own `identity`
+is a deliberate override and stays quiet. REPLACE semantics are unchanged;
+only the silence is gone.

--- a/apps/docs/src/lib/generated/routes.ts
+++ b/apps/docs/src/lib/generated/routes.ts
@@ -10759,6 +10759,11 @@ export const DOCS_ROUTES = [
         level: 3,
       },
       {
+        id: "interaction-inspect-identity-dropped",
+        title: "INTERACTION_INSPECT_IDENTITY_DROPPED",
+        level: 3,
+      },
+      {
         id: "interaction-duplicate-inspect-capability",
         title: "INTERACTION_DUPLICATE_INSPECT_CAPABILITY",
         level: 3,
@@ -11799,6 +11804,11 @@ export const DOCS_ROUTES = [
       {
         id: "interaction-inspect-x-bisects-bar-labels",
         title: "INTERACTION_INSPECT_X_BISECTS_BAR_LABELS",
+        level: 3,
+      },
+      {
+        id: "interaction-inspect-identity-dropped",
+        title: "INTERACTION_INSPECT_IDENTITY_DROPPED",
         level: 3,
       },
       {

--- a/apps/docs/src/lib/generated/search-index.ts
+++ b/apps/docs/src/lib/generated/search-index.ts
@@ -17426,6 +17426,16 @@ export const DOCS_SEARCH_INDEX = [
     exact: ["INTERACTION_INSPECT_X_BISECTS_BAR_LABELS"],
   },
   {
+    id: "heading:guide-interaction-reference:interaction-inspect-identity-dropped",
+    kind: "heading",
+    title: "INTERACTION_INSPECT_IDENTITY_DROPPED",
+    summary:
+      "INTERACTION_INSPECT_IDENTITY_DROPPED in Interaction reference. Search interaction props, callbacks, event phases, and diagnostic codes.",
+    href: "/guide/interaction-reference#interaction-inspect-identity-dropped",
+    keywords: ["Interaction reference", "documentation"],
+    exact: ["INTERACTION_INSPECT_IDENTITY_DROPPED"],
+  },
+  {
     id: "heading:guide-interaction-reference:interaction-duplicate-inspect-capability",
     kind: "heading",
     title: "INTERACTION_DUPLICATE_INSPECT_CAPABILITY",
@@ -19483,6 +19493,16 @@ export const DOCS_SEARCH_INDEX = [
     href: "/guide/errors#interaction-inspect-x-bisects-bar-labels",
     keywords: ["Errors reference", "Reference"],
     exact: ["INTERACTION_INSPECT_X_BISECTS_BAR_LABELS"],
+  },
+  {
+    id: "heading:guide-errors:interaction-inspect-identity-dropped",
+    kind: "heading",
+    title: "INTERACTION_INSPECT_IDENTITY_DROPPED",
+    summary:
+      "INTERACTION_INSPECT_IDENTITY_DROPPED in Errors reference. Understand validation, render, interaction, and CLI diagnostics and recover safely.",
+    href: "/guide/errors#interaction-inspect-identity-dropped",
+    keywords: ["Errors reference", "Reference"],
+    exact: ["INTERACTION_INSPECT_IDENTITY_DROPPED"],
   },
   {
     id: "heading:guide-errors:interaction-duplicate-inspect-capability",
@@ -42881,6 +42901,23 @@ export const DOCS_SEARCH_INDEX = [
     exact: [
       "INTERACTION_INSPECT_X_BISECTS_BAR_LABELS",
       "interaction:INTERACTION_INSPECT_X_BISECTS_BAR_LABELS",
+    ],
+  },
+  {
+    id: "diagnostic:interaction:INTERACTION_INSPECT_IDENTITY_DROPPED",
+    kind: "diagnostic",
+    title: "INTERACTION_INSPECT_IDENTITY_DROPPED · interaction",
+    summary:
+      "An <Inspect> child replaced the inspect prop whole (REPLACE), so the prop's `identity` no longer applies; rows fall back to an id column or row index.",
+    href: "/guide/errors#interaction-inspect-identity-dropped",
+    keywords: [
+      "interaction",
+      "advisory",
+      "Move identity onto the <Inspect> child; Drop identity from the inspect prop if the default row identity is intended",
+    ],
+    exact: [
+      "INTERACTION_INSPECT_IDENTITY_DROPPED",
+      "interaction:INTERACTION_INSPECT_IDENTITY_DROPPED",
     ],
   },
   {

--- a/packages/svelte/src/lib/interaction/interaction-diagnostics.ts
+++ b/packages/svelte/src/lib/interaction/interaction-diagnostics.ts
@@ -25,6 +25,7 @@ export type InteractionDiagnosticCode =
   | "INTERACTION_INSPECT_X_ON_BAR"
   | "INTERACTION_INSPECT_X_BISECTS_COL_LABELS"
   | "INTERACTION_INSPECT_X_BISECTS_BAR_LABELS"
+  | "INTERACTION_INSPECT_IDENTITY_DROPPED"
   | "INTERACTION_DUPLICATE_INSPECT_CAPABILITY";
 
 export interface InteractionDiagnostic {
@@ -236,6 +237,18 @@ export const INTERACTION_DIAGNOSTIC_CATALOG: Readonly<
     ],
     docUrl:
       "https://ggsvelte.sh/guide/interaction-reference#interaction-inspect-x-bisects-bar-labels",
+  },
+  INTERACTION_INSPECT_IDENTITY_DROPPED: {
+    severity: "advisory",
+    code: "INTERACTION_INSPECT_IDENTITY_DROPPED",
+    message:
+      "An <Inspect> child replaced the inspect prop whole (REPLACE), so the prop's `identity` no longer applies; rows fall back to an id column or row index.",
+    prop: "Inspect",
+    suggestions: [
+      "Move identity onto the <Inspect> child",
+      "Drop identity from the inspect prop if the default row identity is intended",
+    ],
+    docUrl: "https://ggsvelte.sh/guide/interaction-reference#interaction-inspect-identity-dropped",
   },
   INTERACTION_DUPLICATE_INSPECT_CAPABILITY: {
     severity: "advisory",

--- a/packages/svelte/src/lib/interaction/resolve-inspect-capability.ts
+++ b/packages/svelte/src/lib/interaction/resolve-inspect-capability.ts
@@ -6,6 +6,7 @@
  * When any child is registered, the last child's options replace the prop
  * whole (no deep-merge). Multiple children set `multiChild` for diagnostics.
  */
+import type { DatumKey } from "../runtime/resolve-datum-key.js";
 import type { InspectInput, InspectOptions } from "./interaction.js";
 import {
   INTERACTION_DIAGNOSTIC_CATALOG,
@@ -25,14 +26,29 @@ export type ResolveInspectCapabilityResult = {
   readonly input: InspectInput;
   /** True when more than one inspect capability child is registered. */
   readonly multiChild: boolean;
+  /** Row identity the winning source asks for; undefined means "use the default". */
+  readonly identity: DatumKey | undefined;
+  /** True when the prop named an identity that the winning child replaced away. */
+  readonly droppedPropIdentity: boolean;
 };
 
 function childToInput(child: InspectCapabilityChild): InspectInput {
   return Object.keys(child).length === 0 ? true : child;
 }
 
+/** Read `identity` off an inspect input; boolean forms carry none. */
+function identityOf(input: InspectInput | undefined): DatumKey | undefined {
+  if (input === undefined || input === true || input === false) return undefined;
+  return input.identity;
+}
+
 /**
  * Prefer the last capability child over the prop. No children → prop ?? false.
+ *
+ * Resolving `identity` here (rather than leaving callers to re-read it off
+ * `input`) is what makes the REPLACE rule visible: an `<Inspect>` child that
+ * names no identity drops one the prop asked for, and `droppedPropIdentity`
+ * says so instead of the identity vanishing into a row-index default.
  */
 export function resolveInspectCapability(
   input: ResolveInspectCapabilityInput,
@@ -42,12 +58,18 @@ export function resolveInspectCapability(
     return {
       input: input.prop ?? false,
       multiChild: false,
+      identity: identityOf(input.prop),
+      droppedPropIdentity: false,
     };
   }
   const last = children.at(-1)!;
+  const resolved = childToInput(last);
+  const identity = identityOf(resolved);
   return {
-    input: childToInput(last),
+    input: resolved,
     multiChild: children.length > 1,
+    identity,
+    droppedPropIdentity: identity === undefined && identityOf(input.prop) !== undefined,
   };
 }
 
@@ -57,4 +79,12 @@ export function duplicateInspectCapabilityDiagnostics(
 ): InteractionDiagnostic[] {
   if (!multiChild) return [];
   return [{ ...INTERACTION_DIAGNOSTIC_CATALOG.INTERACTION_DUPLICATE_INSPECT_CAPABILITY }];
+}
+
+/** Zero or one advisory for a prop identity a child replaced away. */
+export function droppedInspectIdentityDiagnostics(
+  droppedPropIdentity: boolean,
+): InteractionDiagnostic[] {
+  if (!droppedPropIdentity) return [];
+  return [{ ...INTERACTION_DIAGNOSTIC_CATALOG.INTERACTION_INSPECT_IDENTITY_DROPPED }];
 }

--- a/packages/svelte/src/lib/plot-engine.svelte.ts
+++ b/packages/svelte/src/lib/plot-engine.svelte.ts
@@ -49,7 +49,6 @@ import {
   toLayerInput,
 } from "./assembly/assemble.js";
 import {
-  identityFromInspectInput,
   identityFromSelectInput,
   pickExplicitDatumKey,
   resolveDatumKey,
@@ -77,7 +76,10 @@ import {
   createCapabilityResolution,
   ssrSafeDerived,
 } from "./interaction/capability-resolution.svelte.js";
-import { duplicateInspectCapabilityDiagnostics } from "./interaction/resolve-inspect-capability.js";
+import {
+  droppedInspectIdentityDiagnostics,
+  duplicateInspectCapabilityDiagnostics,
+} from "./interaction/resolve-inspect-capability.js";
 import { collectWiringDiagnostics } from "./interaction/wiring-advisories.js";
 import { createInspectionState } from "./inspection/inspection-state.svelte.js";
 import type { InspectionState } from "./inspection/inspection-state.svelte.js";
@@ -266,7 +268,9 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
   function resolvedDatumKeyNow() {
     const data = host.props.data;
     const embedded = assembled()?.data;
-    const inspectIdentity = identityFromInspectInput(inspectResolved().input);
+    // The capability seam resolves this — do not re-read it off `input`, which
+    // cannot tell a dropped prop identity from one that was never set.
+    const inspectIdentity = inspectResolved().identity;
     const selectIdentity = identityFromSelectInput(host.props.select);
     const controllerIdentity = host.props.interaction?.identity;
     const legacyKey = readLegacyPlotKey(host.props);
@@ -398,6 +402,13 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
     duplicateInspectCapabilityDiagnostics(inspectResolved().multiChild),
   );
   deliverAdvisoriesOnce(() => multiInspectDiagnostics);
+
+  // <Inspect> replaced an inspect prop that named `identity`: rows silently
+  // fell back to id column / row index before #1305's follow-up.
+  const droppedIdentityDiagnostics = $derived.by((): InteractionDiagnostic[] =>
+    droppedInspectIdentityDiagnostics(inspectResolved().droppedPropIdentity),
+  );
+  deliverAdvisoriesOnce(() => droppedIdentityDiagnostics);
 
   // Deprecated plot-level key → Inspect / Select / controller identity.
   const deprecatedKeyDiagnostics = $derived.by((): PlotDiagnostic[] => {

--- a/packages/svelte/src/lib/runtime/resolve-datum-key.ts
+++ b/packages/svelte/src/lib/runtime/resolve-datum-key.ts
@@ -55,14 +55,6 @@ export function pickExplicitDatumKey(sources: ExplicitDatumKeySources): DatumKey
   return undefined;
 }
 
-/** Read `identity` from `inspect` prop / resolved inspect capability input. */
-export function identityFromInspectInput(
-  input: boolean | { readonly identity?: DatumKey } | undefined,
-): DatumKey | undefined {
-  if (input === undefined || input === false || input === true) return undefined;
-  return input.identity;
-}
-
 /** Read `identity` from object-form `select` (string shorthand has none). */
 export function identityFromSelectInput(
   input: false | string | { readonly identity?: DatumKey } | undefined,

--- a/packages/svelte/tests/fixtures/InspectChildPlot.svelte
+++ b/packages/svelte/tests/fixtures/InspectChildPlot.svelte
@@ -18,6 +18,7 @@
     useSecondInspect = false,
     secondInspectMode,
     propInspect,
+    inspectIdentity,
     captureRegistry,
     onrender,
     ondiagnostic,
@@ -27,7 +28,8 @@
     inspectMode?: InspectMode;
     useSecondInspect?: boolean;
     secondInspectMode?: InspectMode;
-    propInspect?: boolean | { mode?: InspectMode };
+    propInspect?: boolean | { mode?: InspectMode; identity?: PropertyKey };
+    inspectIdentity?: PropertyKey;
     captureRegistry?: (registry: LayerRegistry) => void;
     onrender?: (model: unknown, spec: PortableSpec) => void;
     ondiagnostic?: (diagnostic: PlotDiagnostic) => void;
@@ -54,7 +56,7 @@
     <ThemeRegistryCapture capture={captureRegistry} />
   {/if}
   {#if useInspect}
-    <Inspect mode={inspectMode} />
+    <Inspect mode={inspectMode} identity={inspectIdentity} />
   {/if}
   {#if useSecondInspect}
     <Inspect mode={secondInspectMode} />

--- a/packages/svelte/tests/inspection/inspect-child.test.ts
+++ b/packages/svelte/tests/inspection/inspect-child.test.ts
@@ -80,6 +80,39 @@ describe("<Inspect> capability child", () => {
       .toBe(true);
   });
 
+  it("advises when a child replaces an inspect prop that named identity", async () => {
+    const diagnostics: PlotDiagnostic[] = [];
+    render(InspectChildPlot, {
+      useInspect: true,
+      propInspect: { identity: "x" },
+      ondiagnostic: (d: PlotDiagnostic) => {
+        diagnostics.push(d);
+      },
+    });
+    await expect
+      .poll(() => diagnostics.some((d) => d.code === "INTERACTION_INSPECT_IDENTITY_DROPPED"))
+      .toBe(true);
+  });
+
+  it("stays quiet when the child carries its own identity", async () => {
+    const diagnostics: PlotDiagnostic[] = [];
+    render(InspectChildPlot, {
+      useInspect: true,
+      propInspect: { identity: "x" },
+      inspectIdentity: "y",
+      ondiagnostic: (d: PlotDiagnostic) => {
+        diagnostics.push(d);
+      },
+    });
+    flushSync();
+    await new Promise<void>((resolve) => {
+      setTimeout(() => {
+        resolve();
+      }, 50);
+    });
+    expect(diagnostics.some((d) => d.code === "INTERACTION_INSPECT_IDENTITY_DROPPED")).toBe(false);
+  });
+
   it("oninspect with child-only inspect does not emit HANDLER_WITHOUT_CAPABILITY", async () => {
     const diagnostics: PlotDiagnostic[] = [];
     render(InspectChildPlot, {

--- a/packages/svelte/tests/interaction/capability-registry.test.ts
+++ b/packages/svelte/tests/interaction/capability-registry.test.ts
@@ -58,6 +58,11 @@ describe("LayerRegistry capabilities", () => {
       prop: { mode: "xy" },
       children: registry.capabilities("inspect"),
     });
-    expect(resolved).toEqual({ input: { mode: "y" }, multiChild: true });
+    expect(resolved).toEqual({
+      input: { mode: "y" },
+      multiChild: true,
+      identity: undefined,
+      droppedPropIdentity: false,
+    });
   });
 });

--- a/packages/svelte/tests/interaction/resolve-inspect-capability.test.ts
+++ b/packages/svelte/tests/interaction/resolve-inspect-capability.test.ts
@@ -4,6 +4,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  droppedInspectIdentityDiagnostics,
   duplicateInspectCapabilityDiagnostics,
   resolveInspectCapability,
   type InspectCapabilityChild,
@@ -11,10 +12,17 @@ import {
 
 describe("resolveInspectCapability", () => {
   it("is off when prop and children are absent", () => {
-    expect(resolveInspectCapability({})).toEqual({ input: false, multiChild: false });
+    expect(resolveInspectCapability({})).toEqual({
+      input: false,
+      multiChild: false,
+      identity: undefined,
+      droppedPropIdentity: false,
+    });
     expect(resolveInspectCapability({ prop: undefined, children: [] })).toEqual({
       input: false,
       multiChild: false,
+      identity: undefined,
+      droppedPropIdentity: false,
     });
   });
 
@@ -22,11 +30,15 @@ describe("resolveInspectCapability", () => {
     expect(resolveInspectCapability({ prop: true })).toEqual({
       input: true,
       multiChild: false,
+      identity: undefined,
+      droppedPropIdentity: false,
     });
     const options = { mode: "xy" as const, pin: false };
     expect(resolveInspectCapability({ prop: options })).toEqual({
       input: options,
       multiChild: false,
+      identity: undefined,
+      droppedPropIdentity: false,
     });
   });
 
@@ -34,6 +46,8 @@ describe("resolveInspectCapability", () => {
     expect(resolveInspectCapability({ prop: false })).toEqual({
       input: false,
       multiChild: false,
+      identity: undefined,
+      droppedPropIdentity: false,
     });
   });
 
@@ -41,6 +55,8 @@ describe("resolveInspectCapability", () => {
     expect(resolveInspectCapability({ children: [{}] })).toEqual({
       input: true,
       multiChild: false,
+      identity: undefined,
+      droppedPropIdentity: false,
     });
   });
 
@@ -51,13 +67,20 @@ describe("resolveInspectCapability", () => {
         prop: { mode: "x", pin: true, muteSiblings: true },
         children: [child],
       }),
-    ).toEqual({ input: child, multiChild: false });
+    ).toEqual({
+      input: child,
+      multiChild: false,
+      identity: undefined,
+      droppedPropIdentity: false,
+    });
   });
 
   it("child wins over prop false", () => {
     expect(resolveInspectCapability({ prop: false, children: [{ mode: "exact" }] })).toEqual({
       input: { mode: "exact" },
       multiChild: false,
+      identity: undefined,
+      droppedPropIdentity: false,
     });
   });
 
@@ -67,7 +90,62 @@ describe("resolveInspectCapability", () => {
       resolveInspectCapability({
         children: [{ mode: "x" }, last],
       }),
-    ).toEqual({ input: last, multiChild: true });
+    ).toEqual({
+      input: last,
+      multiChild: true,
+      identity: undefined,
+      droppedPropIdentity: false,
+    });
+  });
+});
+
+describe("resolveInspectCapability row identity", () => {
+  it("reports the identity the prop asks for when no child overrides it", () => {
+    expect(resolveInspectCapability({ prop: { identity: "year" } }).identity).toBe("year");
+    expect(resolveInspectCapability({ prop: true }).identity).toBeUndefined();
+    expect(resolveInspectCapability({}).identity).toBeUndefined();
+  });
+
+  it("reports the winning child's identity", () => {
+    expect(
+      resolveInspectCapability({ prop: { identity: "year" }, children: [{ identity: "state" }] })
+        .identity,
+    ).toBe("state");
+    expect(
+      resolveInspectCapability({ children: [{ identity: "a" }, { identity: "b" }] }).identity,
+    ).toBe("b");
+  });
+
+  it("flags a prop identity that a child drops, instead of losing it in silence", () => {
+    // <GGPlot inspect={{ identity: "year" }}><Inspect /></GGPlot> — REPLACE
+    // semantics mean the empty child wins and "year" never reaches the engine.
+    const dropped = resolveInspectCapability({ prop: { identity: "year" }, children: [{}] });
+    expect(dropped.identity).toBeUndefined();
+    expect(dropped.droppedPropIdentity).toBe(true);
+
+    // A child that names its own identity is a deliberate override, not a loss.
+    const overridden = resolveInspectCapability({
+      prop: { identity: "year" },
+      children: [{ identity: "state" }],
+    });
+    expect(overridden.droppedPropIdentity).toBe(false);
+
+    // Nothing to drop when the prop never named an identity.
+    expect(
+      resolveInspectCapability({ prop: { mode: "x" }, children: [{}] }).droppedPropIdentity,
+    ).toBe(false);
+    expect(resolveInspectCapability({ prop: { identity: "year" } }).droppedPropIdentity).toBe(
+      false,
+    );
+  });
+});
+
+describe("droppedInspectIdentityDiagnostics", () => {
+  it("emits only when a prop identity was dropped", () => {
+    expect(droppedInspectIdentityDiagnostics(false)).toEqual([]);
+    const list = droppedInspectIdentityDiagnostics(true);
+    expect(list).toHaveLength(1);
+    expect(list.at(0)?.code).toBe("INTERACTION_INSPECT_IDENTITY_DROPPED");
   });
 });
 

--- a/packages/svelte/tests/runtime/resolve-datum-key.test.ts
+++ b/packages/svelte/tests/runtime/resolve-datum-key.test.ts
@@ -7,7 +7,6 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  identityFromInspectInput,
   identityFromSelectInput,
   pickExplicitDatumKey,
   resolveDatumKey,
@@ -148,18 +147,6 @@ describe("pickExplicitDatumKey", () => {
   it("treats only undefined as absent — allows accessor functions", () => {
     const accessor = (row: { a: number }, index: number) => `${row.a}:${index}`;
     expect(pickExplicitDatumKey({ inspect: accessor })).toBe(accessor);
-  });
-});
-
-describe("identityFromInspectInput", () => {
-  it("returns undefined for absent, false, or true inspect", () => {
-    expect(identityFromInspectInput()).toBeUndefined();
-    expect(identityFromInspectInput(false)).toBeUndefined();
-    expect(identityFromInspectInput(true)).toBeUndefined();
-  });
-
-  it("reads identity from an InspectOptions bag", () => {
-    expect(identityFromInspectInput({ identity: "year", mode: "xy" })).toBe("year");
   });
 });
 


### PR DESCRIPTION
## The bug

```svelte
<GGPlot inspect={{ identity: "year" }}>
  <Inspect />
</GGPlot>
```

`identity: "year"` never reaches the engine, and nothing says so.

The chain: an `<Inspect>` child replaces the prop whole (REPLACE — documented and deliberate), an empty child bag reads as `inspect={true}`, and `identityFromInspectInput(true)` returns `undefined`. Row identity then falls back to an `id` column or the row index, so pins and selection keys rebind to the wrong rows when the data updates. No diagnostic fired, and no test paired the prop with a child.

## The fix

REPLACE semantics are unchanged — that rule is deliberate and documented, so this PR does not re-litigate it. What changes is that the loss is now visible:

- The capability seam resolves row identity itself and returns it as a decision (`identity`), plus `droppedPropIdentity` when a child replaced away an identity the prop named.
- The engine reads `inspectResolved().identity` instead of re-parsing `input`. Re-reading `input` is what made this unreportable: it cannot tell a dropped identity from one that was never set.
- A new advisory, `INTERACTION_INSPECT_IDENTITY_DROPPED`, fires once per mount. A child naming its own `identity` is a deliberate override and stays quiet.
- `identityFromInspectInput` had no production caller left and is removed; the seam's own helper does that job. It was not public API.

The docs table for interaction diagnostics is generated from the catalog, so the new code documents itself; regenerated route and search artifacts are included.

## Tests

- Seam unit tests: identity from prop, from the winning child, last-child-wins, and the drop case — plus the negative cases (child names its own identity; prop never named one).
- Mount tests through a real `<GGPlot>`: the advisory fires for the dropped case and stays silent when the child carries its own identity.
- Full Svelte browser suite passes (chromium, firefox, webkit).
- `bun run check`, `check:svelte` (0 errors, 0 warnings over 1110 files), `lint`, `knip`, `gen-llms` tests, and the docs `--check` scripts are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1314" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->