### PR TITLE
perf(core): gather the y window per grid row in the 2-D KDE

### DIFF
--- a/.changeset/kde2d-y-window.md
+++ b/.changeset/kde2d-y-window.md
@@ -1,0 +1,25 @@
+---
+"@ggsvelte/core": patch
+---
+
+# Gather the y window per grid row in the 2-D KDE
+
+Migration: none — internal
+
+`productKdeGrid`, which builds the density surface behind `geom_density_2d`,
+sorted samples by x and slid an x window across each grid row, but tested y one
+sample at a time in the innermost loop. Every grid row therefore re-walked the
+whole x band and threw away the samples outside `±8σy` individually. It now
+gathers each row's y window once, so neither axis is scanned per cell.
+
+The share of wasted visits grows with the data, because the bandwidth shrinks as
+`n^(-1/5)` while the x band keeps admitting the same fraction: 16% of visited
+pairs cleared no y window at n = 200, 64% at n = 20 000. On a 4 000-point cloud
+over the default 100 × 100 grid the visit count drops from 9.50M to 2.25M, and a
+50 000-point cloud renders 1.29× faster end to end.
+
+The surface is unchanged bit for bit — the gather keeps samples in ascending-x
+order, so the kernel terms are still added in the same sequence, and a
+non-finite `y` is still admitted rather than dropped. When the y window already
+reaches every row there is nothing to prune, so the gather is skipped and the
+sorted arrays are read directly.

--- a/packages/core/src/stats/density-2d.ts
+++ b/packages/core/src/stats/density-2d.ts
@@ -7,8 +7,9 @@
  * Bandwidth: MASS::bandwidth.nrd then kde2d's h/4 scaling (fixture-oriented).
  * Grid: n×n over data range expanded by 5% each side (approx ggplot expand).
  * Contour levels: contourLevels(breaks | bins | binwidth) of the density surface.
- * KDE surface: sorted-x sliding window (same ±8σ product kernel as a full
- * G²·n scan; fewer examinations when bandwidth is local).
+ * KDE surface: sorted-x sliding window plus a per-row y gather (same ±8σ
+ * product kernel as a full G²·n scan; visits only the pairs inside both
+ * windows, so a local bandwidth cuts the work on both axes).
  *
  * Filled v1 (#802 phase 2): closed isoline rings only (open rings dropped).
  * True isobands between consecutive levels deferred.

--- a/packages/core/src/stats/density-2d.ts
+++ b/packages/core/src/stats/density-2d.ts
@@ -90,7 +90,7 @@ function dnorm(u: number): number {
 export type ProductKdeGridOptions = {
   /**
    * When true, also return how many (grid-cell, sample) pairs the inner loop
-   * examined (post x-window admission). Used by complexity tests only.
+   * examined — those inside both the x and the y window. Complexity tests only.
    */
   countExaminations?: boolean;
 };
@@ -103,9 +103,15 @@ export type ProductKdeGridResult = number[][] & {
  * Product-Gaussian KDE on a regular grid.
  *
  * Samples are sorted once by x; each grid row slides an x-window across
- * ascending `gx` so far-away points are never visited — O(G·n + work) average
- * vs a full O(G²·n) scan of every sample at every cell. Same ±8σ truncation
- * and invN scaling as the historical direct product (MASS::kde2d-shaped).
+ * ascending `gx`, and gathers the samples inside its y-window once up front, so
+ * neither dimension is scanned per cell. Cost is O(G·n) for the gathers plus
+ * one visit per sample-cell pair inside both windows. Scanning y per cell
+ * instead — as this did before — costs O(G²·n·fx) with fx = 16·hx/xspan, and
+ * throws away a share that grows with n (64% at n = 20 000, G = 100).
+ *
+ * `gx` must ascend (the x slide only moves forward). Same ±8σ truncation and
+ * invN scaling as the historical direct product (MASS::kde2d-shaped), and the
+ * same ascending-x addend order, so the surface is unchanged bit for bit.
  */
 export function productKdeGrid(
   xs: Float64Array,
@@ -143,21 +149,59 @@ export function productKdeGrid(
   let examinations = 0;
   const count = options.countExaminations === true;
 
+  // Does any row ever exclude a sample? If the widest sample-to-row gap still
+  // fits inside the window, no gather can remove anything, so read the sorted
+  // arrays directly. That is the wide-bandwidth case, where the gather would be
+  // pure overhead.
+  let yMin = Number.POSITIVE_INFINITY;
+  let yMax = Number.NEGATIVE_INFINITY;
+  for (let k = 0; k < nx; k++) {
+    const v = sortedY[k]!;
+    if (v < yMin) yMin = v;
+    if (v > yMax) yMax = v;
+  }
+  let gyMin = Number.POSITIVE_INFINITY;
+  let gyMax = Number.NEGATIVE_INFINITY;
+  for (let j = 0; j < gridNY; j++) {
+    const v = gy[j]!;
+    if (v < gyMin) gyMin = v;
+    if (v > gyMax) gyMax = v;
+  }
+  const everyRowTakesEverySample = Math.max(gyMax - yMin, yMax - gyMin) <= wy;
+
+  // Samples inside the current row's y window, packed by value in the same
+  // ascending-x order as `sortedX` — so the slide below still works and the
+  // addends keep their order. Packed rather than indexed so the innermost loop
+  // reads one array element per coordinate either way.
+  const rowX = everyRowTakesEverySample ? sortedX : new Float64Array(nx);
+  const rowY = everyRowTakesEverySample ? sortedY : new Float64Array(nx);
+  let rowCount = nx;
+
   for (let j = 0; j < gridNY; j++) {
     const yj = gy[j]!;
+    if (!everyRowTakesEverySample) {
+      rowCount = 0;
+      for (let k = 0; k < nx; k++) {
+        // Negated so a non-finite dy is admitted, as the per-cell test was.
+        if (!(Math.abs(yj - sortedY[k]!) > wy)) {
+          rowX[rowCount] = sortedX[k]!;
+          rowY[rowCount] = sortedY[k]!;
+          rowCount++;
+        }
+      }
+    }
     let lo = 0;
     for (let i = 0; i < gridNX; i++) {
       const xi = gx[i]!;
       const xLo = xi - wx;
       const xHi = xi + wx;
-      while (lo < nx && sortedX[lo]! < xLo) lo++;
+      while (lo < rowCount && rowX[lo]! < xLo) lo++;
       let s = 0;
-      for (let k = lo; k < nx; k++) {
-        const xv = sortedX[k]!;
+      for (let k = lo; k < rowCount; k++) {
+        const xv = rowX[k]!;
         if (xv > xHi) break;
         if (count) examinations++;
-        const dy = yj - sortedY[k]!;
-        if (Math.abs(dy) > wy) continue;
+        const dy = yj - rowY[k]!;
         const dx = xi - xv;
         s += dnorm(dx / hx) * dnorm(dy / hy);
       }

--- a/packages/core/tests/stats-density-2d.test.ts
+++ b/packages/core/tests/stats-density-2d.test.ts
@@ -57,8 +57,8 @@ function naiveProductKdeGrid(
  * `naiveProductKdeGrid` above sums in input order instead, which is why it only
  * agrees to 1e-12.
  *
- * Predicates are written negated (`!(… > w)`) to match production, so a NaN
- * coordinate is admitted rather than dropped.
+ * Both windows reject with `> w` rather than admitting with `<= w`, so a NaN
+ * coordinate is admitted rather than dropped — the contract production keeps.
  */
 function sortedProductKdeGrid(
   xs: Float64Array,
@@ -207,8 +207,9 @@ describe("productKdeGrid", () => {
   });
 
   it("stays exact when the y window covers every row", () => {
-    // Fat bandwidth: no y pruning is possible, so the gather must not change
-    // the surface (nor be re-run per row).
+    // Wide bandwidth: no row can exclude a sample, so production reads the
+    // sorted arrays directly instead of gathering. That choice is invisible
+    // from outside, so this pins the surface, not which branch ran.
     const { xs, ys } = normalCloud(300);
     const gx = evenGrid(-3, 3, 24);
     const gy = evenGrid(-3, 3, 24);

--- a/packages/core/tests/stats-density-2d.test.ts
+++ b/packages/core/tests/stats-density-2d.test.ts
@@ -51,6 +51,77 @@ function naiveProductKdeGrid(
   return z;
 }
 
+/**
+ * Sorted-order reference: same admitted set AND the same addend order as
+ * production (ascending x, ties by original index), so equality can be exact.
+ * `naiveProductKdeGrid` above sums in input order instead, which is why it only
+ * agrees to 1e-12.
+ *
+ * Predicates are written negated (`!(… > w)`) to match production, so a NaN
+ * coordinate is admitted rather than dropped.
+ */
+function sortedProductKdeGrid(
+  xs: Float64Array,
+  ys: Float64Array,
+  gx: Float64Array,
+  gy: Float64Array,
+  hx: number,
+  hy: number,
+): { z: number[][]; pairs: number } {
+  const invSqrt2pi = 1 / Math.sqrt(2 * Math.PI);
+  const dnorm = (u: number) => invSqrt2pi * Math.exp(-0.5 * u * u);
+  const nx = xs.length;
+  const wx = 8 * hx;
+  const wy = 8 * hy;
+  const invN = 1 / (nx * hx * hy);
+  const order = Array.from({ length: nx }, (_, i) => i).toSorted(
+    (a, b) => xs[a]! - xs[b]! || a - b,
+  );
+  const z: number[][] = Array.from({ length: gy.length }, () =>
+    Array.from({ length: gx.length }, () => 0),
+  );
+  let pairs = 0;
+  for (let j = 0; j < gy.length; j++) {
+    const yj = gy[j]!;
+    for (let i = 0; i < gx.length; i++) {
+      const xi = gx[i]!;
+      let s = 0;
+      for (let o = 0; o < nx; o++) {
+        const k = order[o]!;
+        const dx = xi - xs[k]!;
+        if (Math.abs(dx) > wx) continue;
+        const dy = yj - ys[k]!;
+        if (Math.abs(dy) > wy) continue;
+        pairs++;
+        s += dnorm(dx / hx) * dnorm(dy / hy);
+      }
+      z[j]![i] = s * invN;
+    }
+  }
+  return { z, pairs };
+}
+
+/** Deterministic pseudo-normal cloud (Box-Muller-lite), as used downstream. */
+function normalCloud(n: number): { xs: Float64Array; ys: Float64Array } {
+  const x: number[] = [];
+  const y: number[] = [];
+  for (let i = 0; i < n; i++) {
+    const u = ((i * 37 + 11) % 1000) / 1000 + 1e-6;
+    const v = ((i * 91 + 17) % 1000) / 1000 + 1e-6;
+    const r = Math.sqrt(-2 * Math.log(u));
+    const th = 2 * Math.PI * v;
+    x.push(r * Math.cos(th));
+    y.push(r * Math.sin(th));
+  }
+  return { xs: Float64Array.from(x), ys: Float64Array.from(y) };
+}
+
+function evenGrid(from: number, to: number, n: number): Float64Array {
+  const out = new Float64Array(n);
+  for (let i = 0; i < n; i++) out[i] = from + ((to - from) * i) / (n - 1);
+  return out;
+}
+
 describe("productKdeGrid", () => {
   it("matches the direct-product reference surface on a small cloud", () => {
     // Irregular x spacing so sorted-window order differs from input order.
@@ -95,6 +166,68 @@ describe("productKdeGrid", () => {
     // Local bandwidth should examine far fewer than the naive full product.
     expect(examinations).toBeLessThan(full * 0.25);
     expect(examinations).toBeGreaterThan(0);
+  });
+
+  it("sums in ascending-x order, bit for bit", () => {
+    const { xs, ys } = normalCloud(400);
+    const gx = evenGrid(-3, 3, 32);
+    const gy = evenGrid(-3, 3, 32);
+    const got = productKdeGrid(xs, ys, gx, gy, 0.3, 0.25);
+    const { z: want } = sortedProductKdeGrid(xs, ys, gx, gy, 0.3, 0.25);
+    for (let j = 0; j < want.length; j++) {
+      for (let i = 0; i < want[j]!.length; i++) {
+        expect(got[j]![i]!).toBe(want[j]![i]!);
+      }
+    }
+  });
+
+  it("visits only the pairs inside both windows", () => {
+    // The measured regression case: NRD-scale bandwidth, default grid size.
+    const { xs, ys } = normalCloud(4000);
+    const gx = evenGrid(-4, 4, 100);
+    const gy = evenGrid(-4, 4, 100);
+    const hx = 0.12;
+    const hy = 0.12;
+    const { pairs } = sortedProductKdeGrid(xs, ys, gx, gy, hx, hy);
+    const { examinations } = productKdeGrid(xs, ys, gx, gy, hx, hy, {
+      countExaminations: true,
+    });
+    expect(examinations).toBe(pairs);
+  });
+
+  it("zeroes a row whose samples all fall outside the y window", () => {
+    const xs = Float64Array.from([-1, 0, 1]);
+    const ys = Float64Array.from([0, 0, 0]);
+    const gx = evenGrid(-1, 1, 5);
+    const gy = Float64Array.from([-50, 0, 50]);
+    const z = productKdeGrid(xs, ys, gx, gy, 0.5, 0.5);
+    for (const value of z[0]!) expect(value).toBe(0);
+    for (const value of z[2]!) expect(value).toBe(0);
+    expect(z[1]!.some((value) => value > 0)).toBe(true);
+  });
+
+  it("stays exact when the y window covers every row", () => {
+    // Fat bandwidth: no y pruning is possible, so the gather must not change
+    // the surface (nor be re-run per row).
+    const { xs, ys } = normalCloud(300);
+    const gx = evenGrid(-3, 3, 24);
+    const gy = evenGrid(-3, 3, 24);
+    const got = productKdeGrid(xs, ys, gx, gy, 0.4, 40);
+    const { z: want } = sortedProductKdeGrid(xs, ys, gx, gy, 0.4, 40);
+    for (let j = 0; j < want.length; j++) {
+      for (let i = 0; i < want[j]!.length; i++) {
+        expect(got[j]![i]!).toBe(want[j]![i]!);
+      }
+    }
+  });
+
+  it("admits a non-finite y the same way the x window does", () => {
+    // `!(|dy| > wy)` keeps a NaN sample in, matching the pre-existing contract.
+    const xs = Float64Array.from([0, 0.1]);
+    const ys = Float64Array.from([0, Number.NaN]);
+    const gx = Float64Array.from([0]);
+    const gy = Float64Array.from([0]);
+    expect(Number.isNaN(productKdeGrid(xs, ys, gx, gy, 0.5, 0.5)[0]![0]!)).toBe(true);
   });
 });
 


### PR DESCRIPTION
## What

`productKdeGrid` builds the density surface behind `geom_density_2d`. It sorted
samples by x and slid an x window across each grid row, but tested y one sample
at a time in the innermost loop. Every grid row therefore re-walked the whole x
band and discarded the samples outside `±8σy` one by one.

It now gathers each row's y window once, packed by value in ascending-x order,
so neither axis is scanned per cell.

## Why it grows with the data

The bandwidth shrinks as `n^(-1/5)` (`bandwidthNRD`) while the x band keeps
admitting the same share, so the wasted fraction climbs with n. Measured with
the file's own `countExaminations` hook, `G = 100`:

| n | pairs visited | cleared the y window | wasted |
|---|---------------|----------------------|--------|
| 200 | 1.76e6 | 1.47e6 | 16% |
| 1 000 | 5.05e6 | 3.19e6 | 37% |
| 5 000 | 1.85e7 | 8.62e6 | 53% |
| 20 000 | 5.62e7 | 2.00e7 | 64% |

The visit count is `O(G²·n·fx)` with `fx = 16·hx/xspan`, or `O(G²·n^{4/5})`
under NRD bandwidth. Pruning y takes the kernel term to `O(G²·n^{3/5})` and adds
`O(G·n)` for the gathers.

## Numbers

`n = 4000`, `G = 100`: visits fall from 9.50M to 2.25M. Wall clock (min of 7,
same machine) is a smaller win, because the two `Math.exp` calls dominate what
is left:

| case | before | after | |
|------|--------|-------|---|
| NRD bandwidth, n = 1 000 | 49.4 ms | 45.1 ms | 1.10x |
| NRD bandwidth, n = 20 000 | 345.1 ms | 274.3 ms | 1.26x |
| NRD bandwidth, n = 50 000 | 604.6 ms | 468.9 ms | 1.29x |
| wide bandwidth (h = 40) | 3044.6 ms | 3165.3 ms | 0.96x |
| tiny bandwidth (h = 0.002) | 8.5 ms | 8.0 ms | 1.06x |

The gather costs `O(G·n)` whether or not it removes anything, so it is skipped
when the y window already reaches every row from every sample — the wide-
bandwidth row above, where the remaining 4% is the one-time min/max scan.

## Behavior

Unchanged, bit for bit. The gather keeps ascending-x order, so kernel terms are
added in the same sequence, and the y test is written `!(|dy| > wy)` so a
non-finite `dy` is still admitted the way the per-cell test admitted it. Both
are pinned by tests.

`examinations` now counts pairs inside **both** windows rather than pairs past
the x window; its JSDoc says so.

## Tests

- `sortedProductKdeGrid`, a reference that sums in the same sorted-x order as
  production, so equality can be exact. The reference already in the file sums
  in *input* order, which is why it only agrees to 1e-12.
- Surface equality against it, exact (`toBe`), on a 400-point cloud.
- `examinations` equals the reference's both-window pair count. This is the one
  that fails before the change: 9 496 800 against 2 254 708.
- A row whose samples all miss the y window comes out zero.
- Exact surface when the y window covers every row (the skip-the-gather path).
- A non-finite `y` still contaminates its cell rather than being dropped.

```
bun test packages/core/tests/stats-density-2d.test.ts   13 pass
bun test packages/core/tests/pipeline-m2 stats-parity    77 pass
bun run test                                           4038 pass, 1 pre-existing fail
bun run lint && bun run check                          clean
```

The pre-existing failure is `scripts/example-interaction-api.test.ts`, which
walks `examples/node_modules` and trips over a dangling `.bin` symlink from the
local workspace install. It fails identically with this branch stashed.

## Follow-ups

- #1315 — band selection extent spreads the selected keys into `Math.min` /
  `Math.max`, found in the same pass, unrelated to this change.

Reviewed against an independent model before and after implementation; the
plan's original complexity claim understated the gather term and its test oracle
was invalid, both corrected here.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1316" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->